### PR TITLE
[Headers][X86] Add rounding and exception notes to conversions

### DIFF
--- a/clang/lib/Headers/avxintrin.h
+++ b/clang/lib/Headers/avxintrin.h
@@ -2246,8 +2246,8 @@ _mm256_cvtps_pd(__m128 __a)
   return (__m256d)__builtin_convertvector((__v4sf)__a, __v4df);
 }
 
-/// Converts a 256-bit vector of [4 x double] into a 128-bit vector of [4
-///    x i32], truncating inexact results.
+/// Converts a 256-bit vector of [4 x double] into signed truncated (rounded
+///    toward zero) 32-bit integers returned in a 128-bit vector of [4 x i32].
 ///
 ///    If a converted value does not fit in a 32-bit integer, raises a
 ///    floating-point invalid exception. If the exception is masked, returns
@@ -2286,8 +2286,8 @@ _mm256_cvtpd_epi32(__m256d __a)
   return (__m128i)__builtin_ia32_cvtpd2dq256((__v4df) __a);
 }
 
-/// Converts a vector of [8 x float] into a vector of [8 x i32],
-///    truncating inexact results.
+/// Converts a vector of [8 x float] into signed truncated (rounded toward
+///    zero) 32-bit integers returned in a vector of [8 x i32].
 ///
 ///    If a converted value does not fit in a 32-bit integer, raises a
 ///    floating-point invalid exception. If the exception is masked, returns

--- a/clang/lib/Headers/avxintrin.h
+++ b/clang/lib/Headers/avxintrin.h
@@ -2246,8 +2246,9 @@ _mm256_cvtps_pd(__m128 __a)
   return (__m256d)__builtin_convertvector((__v4sf)__a, __v4df);
 }
 
-/// Converts a 256-bit vector of [4 x double] into signed truncated (rounded
-///    toward zero) 32-bit integers returned in a 128-bit vector of [4 x i32].
+/// Converts a 256-bit vector of [4 x double] into four signed truncated
+///    (rounded toward zero) 32-bit integers returned in a 128-bit vector of
+///    [4 x i32].
 ///
 ///    If a converted value does not fit in a 32-bit integer, raises a
 ///    floating-point invalid exception. If the exception is masked, returns
@@ -2286,8 +2287,8 @@ _mm256_cvtpd_epi32(__m256d __a)
   return (__m128i)__builtin_ia32_cvtpd2dq256((__v4df) __a);
 }
 
-/// Converts a vector of [8 x float] into signed truncated (rounded toward
-///    zero) 32-bit integers returned in a vector of [8 x i32].
+/// Converts a vector of [8 x float] into eight signed truncated (rounded
+///    toward zero) 32-bit integers returned in a vector of [8 x i32].
 ///
 ///    If a converted value does not fit in a 32-bit integer, raises a
 ///    floating-point invalid exception. If the exception is masked, returns

--- a/clang/lib/Headers/avxintrin.h
+++ b/clang/lib/Headers/avxintrin.h
@@ -2180,8 +2180,7 @@ _mm256_cvtepi32_pd(__m128i __a)
   return (__m256d)__builtin_convertvector((__v4si)__a, __v4df);
 }
 
-/// Converts a vector of [8 x i32] into a vector of [8 x float]. Rounds inexact
-///    results according to the rounding control bits in the MXCSR register.
+/// Converts a vector of [8 x i32] into a vector of [8 x float].
 ///
 /// \headerfile <x86intrin.h>
 ///
@@ -2197,8 +2196,7 @@ _mm256_cvtepi32_ps(__m256i __a)
 }
 
 /// Converts a 256-bit vector of [4 x double] into a 128-bit vector of
-///    [4 x float]. Rounds inexact results according to the rounding control
-///    bits in the MXCSR register.
+///    [4 x float].
 ///
 /// \headerfile <x86intrin.h>
 ///
@@ -2213,12 +2211,11 @@ _mm256_cvtpd_ps(__m256d __a)
   return (__m128)__builtin_ia32_cvtpd2ps256((__v4df) __a);
 }
 
-/// Converts a vector of [8 x float] into a vector of [8 x i32]. Rounds inexact
-///    results according to the rounding control bits in the MXCSR register.
+/// Converts a vector of [8 x float] into a vector of [8 x i32].
 ///
-///    If a converted value is larger than the maximum possible result,
-///    raises a floating-point invalid exception. If the exception is
-///    masked, returns the most negative integer.
+///    If a converted value does not fit in a 32-bit integer, raises a
+///    floating-point invalid exception. If the exception is masked, returns
+///    the most negative integer.
 ///
 /// \headerfile <x86intrin.h>
 ///
@@ -2252,9 +2249,9 @@ _mm256_cvtps_pd(__m128 __a)
 /// Converts a 256-bit vector of [4 x double] into a 128-bit vector of [4
 ///    x i32], truncating inexact results.
 ///
-///    If a converted value is larger than the maximum possible result,
-///    raises a floating-point invalid exception. If the exception is
-///    masked, returns the most negative integer.
+///    If a converted value does not fit in a 32-bit integer, raises a
+///    floating-point invalid exception. If the exception is masked, returns
+///    the most negative integer.
 ///
 /// \headerfile <x86intrin.h>
 ///
@@ -2270,12 +2267,11 @@ _mm256_cvttpd_epi32(__m256d __a)
 }
 
 /// Converts a 256-bit vector of [4 x double] into a 128-bit vector of
-///    [4 x i32]. Rounds inexact results according to the rounding control bits
-///    in the MXCSR register.
+///    [4 x i32].
 ///
-///    If a converted value is larger than the maximum possible result,
-///    raises a floating-point invalid exception. If the exception is
-///    masked, returns the most negative integer.
+///    If a converted value does not fit in a 32-bit integer, raises a
+///    floating-point invalid exception. If the exception is masked, returns
+///    the most negative integer.
 ///
 /// \headerfile <x86intrin.h>
 ///
@@ -2293,9 +2289,9 @@ _mm256_cvtpd_epi32(__m256d __a)
 /// Converts a vector of [8 x float] into a vector of [8 x i32],
 ///    truncating inexact results.
 ///
-///    If a converted value is larger than the maximum possible result,
-///    raises a floating-point invalid exception. If the exception is
-///    masked, returns the most negative integer.
+///    If a converted value does not fit in a 32-bit integer, raises a
+///    floating-point invalid exception. If the exception is masked, returns
+///    the most negative integer.
 ///
 /// \headerfile <x86intrin.h>
 ///

--- a/clang/lib/Headers/avxintrin.h
+++ b/clang/lib/Headers/avxintrin.h
@@ -2180,7 +2180,8 @@ _mm256_cvtepi32_pd(__m128i __a)
   return (__m256d)__builtin_convertvector((__v4si)__a, __v4df);
 }
 
-/// Converts a vector of [8 x i32] into a vector of [8 x float].
+/// Converts a vector of [8 x i32] into a vector of [8 x float]. Rounds inexact
+///    results according to the rounding control bits in the MXCSR register.
 ///
 /// \headerfile <x86intrin.h>
 ///
@@ -2196,7 +2197,8 @@ _mm256_cvtepi32_ps(__m256i __a)
 }
 
 /// Converts a 256-bit vector of [4 x double] into a 128-bit vector of
-///    [4 x float].
+///    [4 x float]. Rounds inexact results according to the rounding control
+///    bits in the MXCSR register.
 ///
 /// \headerfile <x86intrin.h>
 ///
@@ -2211,7 +2213,12 @@ _mm256_cvtpd_ps(__m256d __a)
   return (__m128)__builtin_ia32_cvtpd2ps256((__v4df) __a);
 }
 
-/// Converts a vector of [8 x float] into a vector of [8 x i32].
+/// Converts a vector of [8 x float] into a vector of [8 x i32]. Rounds inexact
+///    results according to the rounding control bits in the MXCSR register.
+///
+///    If a converted value is larger than the maximum possible result,
+///    raises a floating-point invalid exception. If the exception is
+///    masked, returns the most negative integer.
 ///
 /// \headerfile <x86intrin.h>
 ///
@@ -2243,8 +2250,11 @@ _mm256_cvtps_pd(__m128 __a)
 }
 
 /// Converts a 256-bit vector of [4 x double] into a 128-bit vector of [4
-///    x i32], truncating the result by rounding towards zero when it is
-///    inexact.
+///    x i32], truncating inexact results.
+///
+///    If a converted value is larger than the maximum possible result,
+///    raises a floating-point invalid exception. If the exception is
+///    masked, returns the most negative integer.
 ///
 /// \headerfile <x86intrin.h>
 ///
@@ -2259,9 +2269,13 @@ _mm256_cvttpd_epi32(__m256d __a)
   return (__m128i)__builtin_ia32_cvttpd2dq256((__v4df) __a);
 }
 
-/// Converts a 256-bit vector of [4 x double] into a 128-bit vector of [4
-///    x i32]. When a conversion is inexact, the value returned is rounded
-///    according to the rounding control bits in the MXCSR register.
+/// Converts a 256-bit vector of [4 x double] into a 128-bit vector of
+///    [4 x i32]. Rounds inexact results according to the rounding control bits
+///    in the MXCSR register.
+///
+///    If a converted value is larger than the maximum possible result,
+///    raises a floating-point invalid exception. If the exception is
+///    masked, returns the most negative integer.
 ///
 /// \headerfile <x86intrin.h>
 ///
@@ -2277,7 +2291,11 @@ _mm256_cvtpd_epi32(__m256d __a)
 }
 
 /// Converts a vector of [8 x float] into a vector of [8 x i32],
-///    truncating the result by rounding towards zero when it is inexact.
+///    truncating inexact results.
+///
+///    If a converted value is larger than the maximum possible result,
+///    raises a floating-point invalid exception. If the exception is
+///    masked, returns the most negative integer.
 ///
 /// \headerfile <x86intrin.h>
 ///

--- a/clang/lib/Headers/emmintrin.h
+++ b/clang/lib/Headers/emmintrin.h
@@ -1245,8 +1245,7 @@ static __inline__ int __DEFAULT_FN_ATTRS _mm_ucomineq_sd(__m128d __a,
 /// Converts the two double-precision floating-point elements of a
 ///    128-bit vector of [2 x double] into two single-precision floating-point
 ///    values, returned in the lower 64 bits of a 128-bit vector of [4 x float].
-///    Rounds inexact results according to the rounding control bits in the
-///    MXCSR register. The upper 64 bits of the result vector are set to zero.
+///    The upper 64 bits of the result vector are set to zero.
 ///
 /// \headerfile <x86intrin.h>
 ///
@@ -1301,13 +1300,13 @@ static __inline__ __m128d __DEFAULT_FN_ATTRS _mm_cvtepi32_pd(__m128i __a) {
 }
 
 /// Converts the two double-precision floating-point elements of a
-///    128-bit vector of [2 x double] into two signed 32-bit integer values.
-///    Rounds inexact results according to the rounding control bits in the
-///    MXCSR register.
+///    128-bit vector of [2 x double] into two signed 32-bit integer values,
+///    returned in the lower 64 bits of a 128-bit vector of [4 x i32]. The upper
+///    64 bits of the result vector are set to zero.
 ///
-///    If a converted value is larger than the maximum possible result,
-///    raises a floating-point invalid exception. If the exception is
-///    masked, returns the most negative integer.
+///    If a converted value does not fit in a 32-bit integer, raises a
+///    floating-point invalid exception. If the exception is masked, returns
+///    the most negative integer.
 ///
 /// \headerfile <x86intrin.h>
 ///
@@ -1322,12 +1321,11 @@ static __inline__ __m128i __DEFAULT_FN_ATTRS _mm_cvtpd_epi32(__m128d __a) {
 }
 
 /// Converts the low-order element of a 128-bit vector of [2 x double]
-///    into a 32-bit signed integer value. Rounds inexact results according to
-///    the rounding control bits in the MXCSR register.
+///    into a 32-bit signed integer value.
 ///
-///    If a converted value is larger than the maximum possible result,
-///    raises a floating-point invalid exception. If the exception is
-///    masked, returns the most negative integer.
+///    If the converted value does not fit in a 32-bit integer, raises a
+///    floating-point invalid exception. If the exception is masked, returns
+///    the most negative integer.
 ///
 /// \headerfile <x86intrin.h>
 ///
@@ -1343,10 +1341,9 @@ static __inline__ int __DEFAULT_FN_ATTRS _mm_cvtsd_si32(__m128d __a) {
 
 /// Converts the lower double-precision floating-point element of a
 ///    128-bit vector of [2 x double], in the second parameter, into a
-///    single-precision floating-point value, returned in the lower 32 bits of
-///    a 128-bit vector of [4 x float]. Rounds inexact results according to the
-///    rounding control bits in the MXCSR register. The upper 96 bits of the
-///    result vector are copied from the upper 96 bits of the first parameter.
+///    single-precision floating-point value, returned in the lower 32 bits of a
+///    128-bit vector of [4 x float]. The upper 96 bits of the result vector are
+///    copied from the upper 96 bits of the first parameter.
 ///
 /// \headerfile <x86intrin.h>
 ///
@@ -1416,11 +1413,12 @@ static __inline__ __m128d __DEFAULT_FN_ATTRS _mm_cvtss_sd(__m128d __a,
 
 /// Converts the two double-precision floating-point elements of a
 ///    128-bit vector of [2 x double] into two signed 32-bit integer values,
+///    returned in the lower 64 bits of a 128-bit vector of [4 x i32],
 ///    truncating inexact results.
 ///
-///    If a converted value is larger than the maximum possible result,
-///    raises a floating-point invalid exception. If the exception is
-///    masked, returns the most negative integer.
+///    If a converted value does not fit in a 32-bit integer, raises a
+///    floating-point invalid exception. If the exception is masked, returns
+///    the most negative integer.
 ///
 /// \headerfile <x86intrin.h>
 ///
@@ -1438,9 +1436,9 @@ static __inline__ __m128i __DEFAULT_FN_ATTRS _mm_cvttpd_epi32(__m128d __a) {
 /// Converts the low-order element of a [2 x double] vector into a 32-bit
 ///    signed integer value, truncating inexact results.
 ///
-///    If a converted value is larger than the maximum possible result,
-///    raises a floating-point invalid exception. If the exception is
-///    masked, returns the most negative integer.
+///    If the converted value does not fit in a 32-bit integer, raises a
+///    floating-point invalid exception. If the exception is masked, returns
+///    the most negative integer.
 ///
 /// \headerfile <x86intrin.h>
 ///
@@ -1456,13 +1454,12 @@ static __inline__ int __DEFAULT_FN_ATTRS _mm_cvttsd_si32(__m128d __a) {
 }
 
 /// Converts the two double-precision floating-point elements of a
-///    128-bit vector of [2 x double] into two signed 32-bit integer values.
-///    Rounds inexact results according to the rounding control bits in the
-///    MXCSR register.
+///    128-bit vector of [2 x double] into two signed 32-bit integer values,
+///    returned in a 64-bit vector of [2 x i32].
 ///
-///    If a converted value is larger than the maximum possible result,
-///    raises a floating-point invalid exception. If the exception is
-///    masked, returns the most negative integer.
+///    If a converted value does not fit in a 32-bit integer, raises a
+///    floating-point invalid exception. If the exception is masked, returns
+///    the most negative integer.
 ///
 /// \headerfile <x86intrin.h>
 ///
@@ -1477,11 +1474,11 @@ static __inline__ __m64 __DEFAULT_FN_ATTRS_MMX _mm_cvtpd_pi32(__m128d __a) {
 
 /// Converts the two double-precision floating-point elements of a
 ///    128-bit vector of [2 x double] into two signed 32-bit integer values,
-///    truncating inexact results.
+///    returned in a 64-bit vector of [2 x i32], truncating inexact results.
 ///
-///    If a converted value is larger than the maximum possible result,
-///    raises a floating-point invalid exception. If the exception is
-///    masked, returns the most negative integer.
+///    If a converted value does not fit in a 32-bit integer, raises a
+///    floating-point invalid exception. If the exception is masked, returns
+///    the most negative integer.
 ///
 /// \headerfile <x86intrin.h>
 ///
@@ -3206,9 +3203,8 @@ static __inline__ __m128i __DEFAULT_FN_ATTRS _mm_cmplt_epi32(__m128i __a,
 #ifdef __x86_64__
 /// Converts a 64-bit signed integer value from the second operand into a
 ///    double-precision value and returns it in the lower element of a [2 x
-///    double] vector. Rounds inexact results according to the rounding control
-///    bits in the MXCSR register. The upper element of the returned vector is
-///    copied from the upper element of the first operand.
+///    double] vector; the upper element of the returned vector is copied from
+///    the upper element of the first operand.
 ///
 /// \headerfile <x86intrin.h>
 ///
@@ -3229,12 +3225,11 @@ static __inline__ __m128d __DEFAULT_FN_ATTRS _mm_cvtsi64_sd(__m128d __a,
 }
 
 /// Converts the first (lower) element of a vector of [2 x double] into a
-///    64-bit signed integer value. Rounds inexact results according to the
-///    rounding control bits in the MXCSR register.
+///    64-bit signed integer value.
 ///
-///    If a converted value is larger than the maximum possible result,
-///    raises a floating-point invalid exception. If the exception is
-///    masked, returns the most negative integer.
+///    If the converted value does not fit in a 64-bit integer, raises a
+///    floating-point invalid exception. If the exception is masked, returns
+///    the most negative integer.
 ///
 /// \headerfile <x86intrin.h>
 ///
@@ -3251,9 +3246,9 @@ static __inline__ long long __DEFAULT_FN_ATTRS _mm_cvtsd_si64(__m128d __a) {
 /// Converts the first (lower) element of a vector of [2 x double] into a
 ///    64-bit signed integer value, truncating inexact results.
 ///
-///    If a converted value is larger than the maximum possible result,
-///    raises a floating-point invalid exception. If the exception is
-///    masked, returns the most negative integer.
+///    If a converted value does not fit in a 64-bit integer, raises a
+///    floating-point invalid exception. If the exception is masked, returns
+///    the most negative integer.
 ///
 /// \headerfile <x86intrin.h>
 ///
@@ -3269,8 +3264,7 @@ static __inline__ long long __DEFAULT_FN_ATTRS _mm_cvttsd_si64(__m128d __a) {
 }
 #endif
 
-/// Converts a vector of [4 x i32] into a vector of [4 x float]. Rounds inexact
-///    results according to the rounding control bits in the MXCSR register.
+/// Converts a vector of [4 x i32] into a vector of [4 x float].
 ///
 /// \headerfile <x86intrin.h>
 ///
@@ -3283,12 +3277,11 @@ static __inline__ __m128 __DEFAULT_FN_ATTRS _mm_cvtepi32_ps(__m128i __a) {
   return (__m128) __builtin_convertvector((__v4si)__a, __v4sf);
 }
 
-/// Converts a vector of [4 x float] into a vector of [4 x i32]. Rounds inexact
-///    results according to the rounding control bits in the MXCSR register.
+/// Converts a vector of [4 x float] into a vector of [4 x i32].
 ///
-///    If a converted value is larger than the maximum possible result,
-///    raises a floating-point invalid exception. If the exception is
-///    masked, returns the most negative integer.
+///    If a converted value does not fit in a 32-bit integer, raises a
+///    floating-point invalid exception. If the exception is masked, returns
+///    the most negative integer.
 ///
 /// \headerfile <x86intrin.h>
 ///
@@ -3305,9 +3298,9 @@ static __inline__ __m128i __DEFAULT_FN_ATTRS _mm_cvtps_epi32(__m128 __a) {
 /// Converts a vector of [4 x float] into a vector of [4 x i32],
 ///    truncating inexact results.
 ///
-///    If a converted value is larger than the maximum possible result,
-///    raises a floating-point invalid exception. If the exception is
-///    masked, returns the most negative integer.
+///    If a converted value does not fit in a 32-bit integer, raises a
+///    floating-point invalid exception. If the exception is masked, returns
+///    the most negative integer.
 ///
 /// \headerfile <x86intrin.h>
 ///

--- a/clang/lib/Headers/emmintrin.h
+++ b/clang/lib/Headers/emmintrin.h
@@ -1412,9 +1412,9 @@ static __inline__ __m128d __DEFAULT_FN_ATTRS _mm_cvtss_sd(__m128d __a,
 }
 
 /// Converts the two double-precision floating-point elements of a
-///    128-bit vector of [2 x double] into two signed 32-bit integer values,
-///    returned in the lower 64 bits of a 128-bit vector of [4 x i32],
-///    truncating inexact results.
+///    128-bit vector of [2 x double] into two signed truncated (rounded
+///    toward zero) 32-bit integer values, returned in the lower 64 bits
+///    of a 128-bit vector of [4 x i32].
 ///
 ///    If a converted value does not fit in a 32-bit integer, raises a
 ///    floating-point invalid exception. If the exception is masked, returns
@@ -1434,7 +1434,7 @@ static __inline__ __m128i __DEFAULT_FN_ATTRS _mm_cvttpd_epi32(__m128d __a) {
 }
 
 /// Converts the low-order element of a [2 x double] vector into a 32-bit
-///    signed integer value, truncating inexact results.
+///    signed truncated (rounded toward zero) integer value.
 ///
 ///    If the converted value does not fit in a 32-bit integer, raises a
 ///    floating-point invalid exception. If the exception is masked, returns
@@ -1473,8 +1473,8 @@ static __inline__ __m64 __DEFAULT_FN_ATTRS_MMX _mm_cvtpd_pi32(__m128d __a) {
 }
 
 /// Converts the two double-precision floating-point elements of a
-///    128-bit vector of [2 x double] into two signed 32-bit integer values,
-///    returned in a 64-bit vector of [2 x i32], truncating inexact results.
+///    128-bit vector of [2 x double] into two signed truncated (rounded toward
+///    zero) 32-bit integer values, returned in a 64-bit vector of [2 x i32].
 ///
 ///    If a converted value does not fit in a 32-bit integer, raises a
 ///    floating-point invalid exception. If the exception is masked, returns
@@ -3244,7 +3244,7 @@ static __inline__ long long __DEFAULT_FN_ATTRS _mm_cvtsd_si64(__m128d __a) {
 }
 
 /// Converts the first (lower) element of a vector of [2 x double] into a
-///    64-bit signed integer value, truncating inexact results.
+///    64-bit signed truncated (rounded toward zero) integer value.
 ///
 ///    If a converted value does not fit in a 64-bit integer, raises a
 ///    floating-point invalid exception. If the exception is masked, returns
@@ -3295,8 +3295,8 @@ static __inline__ __m128i __DEFAULT_FN_ATTRS _mm_cvtps_epi32(__m128 __a) {
   return (__m128i)__builtin_ia32_cvtps2dq((__v4sf)__a);
 }
 
-/// Converts a vector of [4 x float] into a vector of [4 x i32],
-///    truncating inexact results.
+/// Converts a vector of [4 x float] into four signed truncated (rounded toward
+///    zero) 32-bit integers, returned in a vector of [4 x i32].
 ///
 ///    If a converted value does not fit in a 32-bit integer, raises a
 ///    floating-point invalid exception. If the exception is masked, returns

--- a/clang/lib/Headers/emmintrin.h
+++ b/clang/lib/Headers/emmintrin.h
@@ -1245,7 +1245,8 @@ static __inline__ int __DEFAULT_FN_ATTRS _mm_ucomineq_sd(__m128d __a,
 /// Converts the two double-precision floating-point elements of a
 ///    128-bit vector of [2 x double] into two single-precision floating-point
 ///    values, returned in the lower 64 bits of a 128-bit vector of [4 x float].
-///    The upper 64 bits of the result vector are set to zero.
+///    Rounds inexact results according to the rounding control bits in the
+///    MXCSR register. The upper 64 bits of the result vector are set to zero.
 ///
 /// \headerfile <x86intrin.h>
 ///
@@ -1300,9 +1301,13 @@ static __inline__ __m128d __DEFAULT_FN_ATTRS _mm_cvtepi32_pd(__m128i __a) {
 }
 
 /// Converts the two double-precision floating-point elements of a
-///    128-bit vector of [2 x double] into two signed 32-bit integer values,
-///    returned in the lower 64 bits of a 128-bit vector of [4 x i32]. The upper
-///    64 bits of the result vector are set to zero.
+///    128-bit vector of [2 x double] into two signed 32-bit integer values.
+///    Rounds inexact results according to the rounding control bits in the
+///    MXCSR register.
+///
+///    If a converted value is larger than the maximum possible result,
+///    raises a floating-point invalid exception. If the exception is
+///    masked, returns the most negative integer.
 ///
 /// \headerfile <x86intrin.h>
 ///
@@ -1317,7 +1322,12 @@ static __inline__ __m128i __DEFAULT_FN_ATTRS _mm_cvtpd_epi32(__m128d __a) {
 }
 
 /// Converts the low-order element of a 128-bit vector of [2 x double]
-///    into a 32-bit signed integer value.
+///    into a 32-bit signed integer value. Rounds inexact results according to
+///    the rounding control bits in the MXCSR register.
+///
+///    If a converted value is larger than the maximum possible result,
+///    raises a floating-point invalid exception. If the exception is
+///    masked, returns the most negative integer.
 ///
 /// \headerfile <x86intrin.h>
 ///
@@ -1333,9 +1343,10 @@ static __inline__ int __DEFAULT_FN_ATTRS _mm_cvtsd_si32(__m128d __a) {
 
 /// Converts the lower double-precision floating-point element of a
 ///    128-bit vector of [2 x double], in the second parameter, into a
-///    single-precision floating-point value, returned in the lower 32 bits of a
-///    128-bit vector of [4 x float]. The upper 96 bits of the result vector are
-///    copied from the upper 96 bits of the first parameter.
+///    single-precision floating-point value, returned in the lower 32 bits of
+///    a 128-bit vector of [4 x float]. Rounds inexact results according to the
+///    rounding control bits in the MXCSR register. The upper 96 bits of the
+///    result vector are copied from the upper 96 bits of the first parameter.
 ///
 /// \headerfile <x86intrin.h>
 ///
@@ -1405,11 +1416,11 @@ static __inline__ __m128d __DEFAULT_FN_ATTRS _mm_cvtss_sd(__m128d __a,
 
 /// Converts the two double-precision floating-point elements of a
 ///    128-bit vector of [2 x double] into two signed 32-bit integer values,
-///    returned in the lower 64 bits of a 128-bit vector of [4 x i32].
+///    truncating inexact results.
 ///
-///    If the result of either conversion is inexact, the result is truncated
-///    (rounded towards zero) regardless of the current MXCSR setting. The upper
-///    64 bits of the result vector are set to zero.
+///    If a converted value is larger than the maximum possible result,
+///    raises a floating-point invalid exception. If the exception is
+///    masked, returns the most negative integer.
 ///
 /// \headerfile <x86intrin.h>
 ///
@@ -1425,7 +1436,11 @@ static __inline__ __m128i __DEFAULT_FN_ATTRS _mm_cvttpd_epi32(__m128d __a) {
 }
 
 /// Converts the low-order element of a [2 x double] vector into a 32-bit
-///    signed integer value, truncating the result when it is inexact.
+///    signed integer value, truncating inexact results.
+///
+///    If a converted value is larger than the maximum possible result,
+///    raises a floating-point invalid exception. If the exception is
+///    masked, returns the most negative integer.
 ///
 /// \headerfile <x86intrin.h>
 ///
@@ -1441,8 +1456,13 @@ static __inline__ int __DEFAULT_FN_ATTRS _mm_cvttsd_si32(__m128d __a) {
 }
 
 /// Converts the two double-precision floating-point elements of a
-///    128-bit vector of [2 x double] into two signed 32-bit integer values,
-///    returned in a 64-bit vector of [2 x i32].
+///    128-bit vector of [2 x double] into two signed 32-bit integer values.
+///    Rounds inexact results according to the rounding control bits in the
+///    MXCSR register.
+///
+///    If a converted value is larger than the maximum possible result,
+///    raises a floating-point invalid exception. If the exception is
+///    masked, returns the most negative integer.
 ///
 /// \headerfile <x86intrin.h>
 ///
@@ -1457,10 +1477,11 @@ static __inline__ __m64 __DEFAULT_FN_ATTRS_MMX _mm_cvtpd_pi32(__m128d __a) {
 
 /// Converts the two double-precision floating-point elements of a
 ///    128-bit vector of [2 x double] into two signed 32-bit integer values,
-///    returned in a 64-bit vector of [2 x i32].
+///    truncating inexact results.
 ///
-///    If the result of either conversion is inexact, the result is truncated
-///    (rounded towards zero) regardless of the current MXCSR setting.
+///    If a converted value is larger than the maximum possible result,
+///    raises a floating-point invalid exception. If the exception is
+///    masked, returns the most negative integer.
 ///
 /// \headerfile <x86intrin.h>
 ///
@@ -3185,8 +3206,9 @@ static __inline__ __m128i __DEFAULT_FN_ATTRS _mm_cmplt_epi32(__m128i __a,
 #ifdef __x86_64__
 /// Converts a 64-bit signed integer value from the second operand into a
 ///    double-precision value and returns it in the lower element of a [2 x
-///    double] vector; the upper element of the returned vector is copied from
-///    the upper element of the first operand.
+///    double] vector. Rounds inexact results according to the rounding control
+///    bits in the MXCSR register. The upper element of the returned vector is
+///    copied from the upper element of the first operand.
 ///
 /// \headerfile <x86intrin.h>
 ///
@@ -3207,7 +3229,12 @@ static __inline__ __m128d __DEFAULT_FN_ATTRS _mm_cvtsi64_sd(__m128d __a,
 }
 
 /// Converts the first (lower) element of a vector of [2 x double] into a
-///    64-bit signed integer value, according to the current rounding mode.
+///    64-bit signed integer value. Rounds inexact results according to the
+///    rounding control bits in the MXCSR register.
+///
+///    If a converted value is larger than the maximum possible result,
+///    raises a floating-point invalid exception. If the exception is
+///    masked, returns the most negative integer.
 ///
 /// \headerfile <x86intrin.h>
 ///
@@ -3222,7 +3249,11 @@ static __inline__ long long __DEFAULT_FN_ATTRS _mm_cvtsd_si64(__m128d __a) {
 }
 
 /// Converts the first (lower) element of a vector of [2 x double] into a
-///    64-bit signed integer value, truncating the result when it is inexact.
+///    64-bit signed integer value, truncating inexact results.
+///
+///    If a converted value is larger than the maximum possible result,
+///    raises a floating-point invalid exception. If the exception is
+///    masked, returns the most negative integer.
 ///
 /// \headerfile <x86intrin.h>
 ///
@@ -3238,7 +3269,8 @@ static __inline__ long long __DEFAULT_FN_ATTRS _mm_cvttsd_si64(__m128d __a) {
 }
 #endif
 
-/// Converts a vector of [4 x i32] into a vector of [4 x float].
+/// Converts a vector of [4 x i32] into a vector of [4 x float]. Rounds inexact
+///    results according to the rounding control bits in the MXCSR register.
 ///
 /// \headerfile <x86intrin.h>
 ///
@@ -3251,7 +3283,12 @@ static __inline__ __m128 __DEFAULT_FN_ATTRS _mm_cvtepi32_ps(__m128i __a) {
   return (__m128) __builtin_convertvector((__v4si)__a, __v4sf);
 }
 
-/// Converts a vector of [4 x float] into a vector of [4 x i32].
+/// Converts a vector of [4 x float] into a vector of [4 x i32]. Rounds inexact
+///    results according to the rounding control bits in the MXCSR register.
+///
+///    If a converted value is larger than the maximum possible result,
+///    raises a floating-point invalid exception. If the exception is
+///    masked, returns the most negative integer.
 ///
 /// \headerfile <x86intrin.h>
 ///
@@ -3266,7 +3303,11 @@ static __inline__ __m128i __DEFAULT_FN_ATTRS _mm_cvtps_epi32(__m128 __a) {
 }
 
 /// Converts a vector of [4 x float] into a vector of [4 x i32],
-///    truncating the result when it is inexact.
+///    truncating inexact results.
+///
+///    If a converted value is larger than the maximum possible result,
+///    raises a floating-point invalid exception. If the exception is
+///    masked, returns the most negative integer.
 ///
 /// \headerfile <x86intrin.h>
 ///

--- a/clang/lib/Headers/xmmintrin.h
+++ b/clang/lib/Headers/xmmintrin.h
@@ -1295,12 +1295,11 @@ _mm_ucomineq_ss(__m128 __a, __m128 __b)
 }
 
 /// Converts a float value contained in the lower 32 bits of a vector of
-///    [4 x float] into a 32-bit integer. Rounds an inexact result according to
-///    the rounding control bits in the MXCSR register.
+///    [4 x float] into a 32-bit integer.
 ///
-///    If a converted value is larger than the maximum possible result,
-///    raises a floating-point invalid exception. If the exception is
-///    masked, returns the most negative integer.
+///    If the converted value does not fit in a 32-bit integer, raises a
+///    floating-point invalid exception. If the exception is masked, returns
+///    the most negative integer.
 ///
 /// \headerfile <x86intrin.h>
 ///
@@ -1318,12 +1317,11 @@ _mm_cvtss_si32(__m128 __a)
 }
 
 /// Converts a float value contained in the lower 32 bits of a vector of
-///    [4 x float] into a 32-bit integer. Rounds an inexact result according to
-///    the rounding control bits in the MXCSR register.
+///    [4 x float] into a 32-bit integer.
 ///
-///    If a converted value is larger than the maximum possible result,
-///    raises a floating-point invalid exception. If the exception is
-///    masked, returns the most negative integer.
+///    If the converted value does not fit in a 32-bit integer, raises a
+///    floating-point invalid exception. If the exception is masked, returns
+///    the most negative integer.
 ///
 /// \headerfile <x86intrin.h>
 ///
@@ -1343,12 +1341,11 @@ _mm_cvt_ss2si(__m128 __a)
 #ifdef __x86_64__
 
 /// Converts a float value contained in the lower 32 bits of a vector of
-///    [4 x float] into a 64-bit integer. Rounds an inexact result according to
-///    the rounding control bits in the MXCSR register.
+///    [4 x float] into a 64-bit integer.
 ///
-///    If a converted value is larger than the maximum possible result,
-///    raises a floating-point invalid exception. If the exception is
-///    masked, returns the most negative integer.
+///    If the converted value does not fit in a 32-bit integer, raises a
+///    floating-point invalid exception. If the exception is masked, returns
+///    the most negative integer.
 ///
 /// \headerfile <x86intrin.h>
 ///
@@ -1367,13 +1364,12 @@ _mm_cvtss_si64(__m128 __a)
 
 #endif
 
-/// Converts two low-order float values in a 128-bit vector of [4 x float] into
-///    a 64-bit vector of [2 x i32]. Rounds inexact results according to the
-///    rounding control bits in the MXCSR register.
+/// Converts two low-order float values in a 128-bit vector of
+///    [4 x float] into a 64-bit vector of [2 x i32].
 ///
-///    If a converted value is larger than the maximum possible result,
-///    raises a floating-point invalid exception. If the exception is
-///    masked, returns the most negative integer.
+///    If a converted value does not fit in a 32-bit integer, raises a
+///    floating-point invalid exception. If the exception is masked, returns
+///    the most negative integer.
 ///
 /// \headerfile <x86intrin.h>
 ///
@@ -1388,13 +1384,12 @@ _mm_cvtps_pi32(__m128 __a)
   return (__m64)__builtin_ia32_cvtps2pi((__v4sf)__a);
 }
 
-/// Converts two low-order float values in a 128-bit vector of [4 x float] into
-///    a 64-bit vector of [2 x i32]. Rounds inexact results according to the
-///    rounding control bits in the MXCSR register.
+/// Converts two low-order float values in a 128-bit vector of
+///    [4 x float] into a 64-bit vector of [2 x i32].
 ///
-///    If a converted value is larger than the maximum possible result,
-///    raises a floating-point invalid exception. If the exception is
-///    masked, returns the most negative integer.
+///    If a converted value does not fit in a 32-bit integer, raises a
+///    floating-point invalid exception. If the exception is masked, returns
+///    the most negative integer.
 ///
 /// \headerfile <x86intrin.h>
 ///
@@ -1412,9 +1407,9 @@ _mm_cvt_ps2pi(__m128 __a)
 /// Converts a float value contained in the lower 32 bits of a vector of
 ///    [4 x float] into a 32-bit integer, truncating an inexact result.
 ///
-///    If a converted value is larger than the maximum possible result,
-///    raises a floating-point invalid exception. If the exception is
-///    masked, returns the most negative integer.
+///    If the converted value does not fit in a 32-bit integer, raises a
+///    floating-point invalid exception. If the exception is masked, returns
+///    the most negative integer.
 ///
 /// \headerfile <x86intrin.h>
 ///
@@ -1434,9 +1429,9 @@ _mm_cvttss_si32(__m128 __a)
 /// Converts a float value contained in the lower 32 bits of a vector of
 ///    [4 x float] into a 32-bit integer, truncating an inexact result.
 ///
-///    If a converted value is larger than the maximum possible result,
-///    raises a floating-point invalid exception. If the exception is
-///    masked, returns the most negative integer.
+///    If the converted value does not fit in a 32-bit integer, raises a
+///    floating-point invalid exception. If the exception is masked, returns
+///    the most negative integer.
 ///
 /// \headerfile <x86intrin.h>
 ///
@@ -1457,9 +1452,9 @@ _mm_cvtt_ss2si(__m128 __a)
 /// Converts a float value contained in the lower 32 bits of a vector of
 ///    [4 x float] into a 64-bit integer, truncating an inexact result.
 ///
-///    If a converted value is larger than the maximum possible result,
-///    raises a floating-point invalid exception. If the exception is
-///    masked, returns the most negative integer.
+///    If the converted value does not fit in a 64-bit integer, raises a
+///    floating-point invalid exception. If the exception is masked, returns
+///    the most negative integer.
 ///
 /// \headerfile <x86intrin.h>
 ///
@@ -1481,9 +1476,9 @@ _mm_cvttss_si64(__m128 __a)
 ///    [4 x float] into a 64-bit vector of [2 x i32], truncating inexact
 ///    results.
 ///
-///    If a converted value is larger than the maximum possible result,
-///    raises a floating-point invalid exception. If the exception is
-///    masked, returns the most negative integer.
+///    If a converted value does not fit in a 32-bit integer, raises a
+///    floating-point invalid exception. If the exception is masked, returns
+///    the most negative integer.
 ///
 /// \headerfile <x86intrin.h>
 ///
@@ -1502,9 +1497,9 @@ _mm_cvttps_pi32(__m128 __a)
 /// Converts two low-order float values in a 128-bit vector of [4 x
 ///    float] into a 64-bit vector of [2 x i32], truncating inexact results.
 ///
-///    If a converted value is larger than the maximum possible result,
-///    raises a floating-point invalid exception. If the exception is
-///    masked, returns the most negative integer.
+///    If a converted value does not fit in a 32-bit integer, raises a
+///    floating-point invalid exception. If the exception is masked, returns
+///    the most negative integer.
 ///
 /// \headerfile <x86intrin.h>
 ///
@@ -1519,11 +1514,10 @@ _mm_cvtt_ps2pi(__m128 __a)
   return _mm_cvttps_pi32(__a);
 }
 
-/// Converts a 32-bit signed integer value into a floating point value and
-///    writes it to the lower 32 bits of the destination. Rounds an inexact
-///    result according to the rounding control bits in the MXCSR register.
-///    The remaining higher order elements of the destination vector are copied
-///    from the corresponding elements in the first operand.
+/// Converts a 32-bit signed integer value into a floating point value
+///    and writes it to the lower 32 bits of the destination. The remaining
+///    higher order elements of the destination vector are copied from the
+///    corresponding elements in the first operand.
 ///
 /// \headerfile <x86intrin.h>
 ///
@@ -1543,11 +1537,10 @@ _mm_cvtsi32_ss(__m128 __a, int __b)
   return __a;
 }
 
-/// Converts a 32-bit signed integer value into a floating point value and
-///    writes it to the lower 32 bits of the destination. Rounds an inexact
-///    result according to the rounding control bits in the MXCSR register.
-///    The remaining higher order elements of the destination are copied from
-///    the corresponding elements in the first operand.
+/// Converts a 32-bit signed integer value into a floating point value
+///    and writes it to the lower 32 bits of the destination. The remaining
+///    higher order elements of the destination are copied from the
+///    corresponding elements in the first operand.
 ///
 /// \headerfile <x86intrin.h>
 ///
@@ -1568,11 +1561,10 @@ _mm_cvt_si2ss(__m128 __a, int __b)
 
 #ifdef __x86_64__
 
-/// Converts a 64-bit signed integer value into a floating point value and
-///    writes it to the lower 32 bits of the destination. Rounds an inexact
-///    result according to the rounding control bits in the MXCSR register.
-///    The remaining higher order elements of the destination are copied from
-///    the corresponding elements in the first operand.
+/// Converts a 64-bit signed integer value into a floating point value
+///    and writes it to the lower 32 bits of the destination. The remaining
+///    higher order elements of the destination are copied from the
+///    corresponding elements in the first operand.
 ///
 /// \headerfile <x86intrin.h>
 ///
@@ -1596,10 +1588,8 @@ _mm_cvtsi64_ss(__m128 __a, long long __b)
 
 /// Converts two elements of a 64-bit vector of [2 x i32] into two
 ///    floating point values and writes them to the lower 64-bits of the
-///    destination. Rounds inexact results according to the rounding control
-///    bits in the MXCSR register. The remaining higher order elements of the
-///    destination are copied from the corresponding elements in the first
-///    operand.
+///    destination. The remaining higher order elements of the destination are
+///    copied from the corresponding elements in the first operand.
 ///
 /// \headerfile <x86intrin.h>
 ///
@@ -1621,10 +1611,8 @@ _mm_cvtpi32_ps(__m128 __a, __m64 __b)
 
 /// Converts two elements of a 64-bit vector of [2 x i32] into two
 ///    floating point values and writes them to the lower 64-bits of the
-///    destination. Rounds inexact results according to the rounding control
-///    bits in the MXCSR register. The remaining higher order elements of the
-///    destination are copied from the corresponding elements in the first
-///    operand.
+///    destination. The remaining higher order elements of the destination are
+///    copied from the corresponding elements in the first operand.
 ///
 /// \headerfile <x86intrin.h>
 ///
@@ -2883,9 +2871,7 @@ _mm_cvtpu8_ps(__m64 __a)
 }
 
 /// Converts the two 32-bit signed integer values from each 64-bit vector
-///    operand of [2 x i32] into a 128-bit vector of [4 x float]. Rounds
-///    inexact results according to the rounding control bits in the MXCSR
-///    register.
+///    operand of [2 x i32] into a 128-bit vector of [4 x float].
 ///
 /// \headerfile <x86intrin.h>
 ///
@@ -2914,9 +2900,7 @@ _mm_cvtpi32x2_ps(__m64 __a, __m64 __b)
 
 /// Converts each single-precision floating-point element of a 128-bit
 ///    floating-point vector of [4 x float] into a 16-bit signed integer, and
-///    packs the results into a 64-bit integer vector of [4 x i16]. Rounds
-///    inexact results according to the rounding control bits in the MXCSR
-///    register.
+///    packs the results into a 64-bit integer vector of [4 x i16].
 ///
 ///    If the floating-point element is NaN or infinity, or if the
 ///    floating-point element is greater than 0x7FFFFFFF or less than -0x8000,
@@ -2946,8 +2930,7 @@ _mm_cvtps_pi16(__m128 __a)
 /// Converts each single-precision floating-point element of a 128-bit
 ///    floating-point vector of [4 x float] into an 8-bit signed integer, and
 ///    packs the results into the lower 32 bits of a 64-bit integer vector of
-///    [8 x i8]. The upper 32 bits of the vector are set to 0. Rounds inexact
-///    results according to the rounding control bits in the MXCSR register.
+///    [8 x i8]. The upper 32 bits of the vector are set to 0.
 ///
 ///    If the floating-point element is NaN or infinity, or if the
 ///    floating-point element is greater than 0x7FFFFFFF or less than -0x80, it

--- a/clang/lib/Headers/xmmintrin.h
+++ b/clang/lib/Headers/xmmintrin.h
@@ -1404,8 +1404,8 @@ _mm_cvt_ps2pi(__m128 __a)
   return _mm_cvtps_pi32(__a);
 }
 
-/// Converts a float value contained in the lower 32 bits of a vector of
-///    [4 x float] into a 32-bit integer, truncating an inexact result.
+/// Converts the lower (first) element of a vector of [4 x float] into a signed
+///    truncated (rounded toward zero) 32-bit integer.
 ///
 ///    If the converted value does not fit in a 32-bit integer, raises a
 ///    floating-point invalid exception. If the exception is masked, returns
@@ -1426,8 +1426,8 @@ _mm_cvttss_si32(__m128 __a)
   return __builtin_ia32_cvttss2si((__v4sf)__a);
 }
 
-/// Converts a float value contained in the lower 32 bits of a vector of
-///    [4 x float] into a 32-bit integer, truncating an inexact result.
+/// Converts the lower (first) element of a vector of [4 x float] into a signed
+///    truncated (rounded toward zero) 32-bit integer.
 ///
 ///    If the converted value does not fit in a 32-bit integer, raises a
 ///    floating-point invalid exception. If the exception is masked, returns
@@ -1449,8 +1449,8 @@ _mm_cvtt_ss2si(__m128 __a)
 }
 
 #ifdef __x86_64__
-/// Converts a float value contained in the lower 32 bits of a vector of
-///    [4 x float] into a 64-bit integer, truncating an inexact result.
+/// Converts the lower (first) element of a vector of [4 x float] into a signed
+///    truncated (rounded toward zero) 64-bit integer.
 ///
 ///    If the converted value does not fit in a 64-bit integer, raises a
 ///    floating-point invalid exception. If the exception is masked, returns
@@ -1472,9 +1472,9 @@ _mm_cvttss_si64(__m128 __a)
 }
 #endif
 
-/// Converts two low-order float values in a 128-bit vector of
-///    [4 x float] into a 64-bit vector of [2 x i32], truncating inexact
-///    results.
+/// Converts the lower (first) two elements of a 128-bit vector of [4 x float]
+///    into two signed truncated (rounded toward zero) 32-bit integers,
+///    returned in a 64-bit vector of [2 x i32].
 ///
 ///    If a converted value does not fit in a 32-bit integer, raises a
 ///    floating-point invalid exception. If the exception is masked, returns
@@ -1494,8 +1494,9 @@ _mm_cvttps_pi32(__m128 __a)
   return (__m64)__builtin_ia32_cvttps2pi((__v4sf)__a);
 }
 
-/// Converts two low-order float values in a 128-bit vector of [4 x
-///    float] into a 64-bit vector of [2 x i32], truncating inexact results.
+/// Converts the lower (first) two elements of a 128-bit vector of [4 x float]
+///    into two signed truncated (rounded toward zero) 64-bit integers,
+///    returned in a 64-bit vector of [2 x i32].
 ///
 ///    If a converted value does not fit in a 32-bit integer, raises a
 ///    floating-point invalid exception. If the exception is masked, returns

--- a/clang/lib/Headers/xmmintrin.h
+++ b/clang/lib/Headers/xmmintrin.h
@@ -1295,7 +1295,12 @@ _mm_ucomineq_ss(__m128 __a, __m128 __b)
 }
 
 /// Converts a float value contained in the lower 32 bits of a vector of
-///    [4 x float] into a 32-bit integer.
+///    [4 x float] into a 32-bit integer. Rounds an inexact result according to
+///    the rounding control bits in the MXCSR register.
+///
+///    If a converted value is larger than the maximum possible result,
+///    raises a floating-point invalid exception. If the exception is
+///    masked, returns the most negative integer.
 ///
 /// \headerfile <x86intrin.h>
 ///
@@ -1313,7 +1318,12 @@ _mm_cvtss_si32(__m128 __a)
 }
 
 /// Converts a float value contained in the lower 32 bits of a vector of
-///    [4 x float] into a 32-bit integer.
+///    [4 x float] into a 32-bit integer. Rounds an inexact result according to
+///    the rounding control bits in the MXCSR register.
+///
+///    If a converted value is larger than the maximum possible result,
+///    raises a floating-point invalid exception. If the exception is
+///    masked, returns the most negative integer.
 ///
 /// \headerfile <x86intrin.h>
 ///
@@ -1333,7 +1343,12 @@ _mm_cvt_ss2si(__m128 __a)
 #ifdef __x86_64__
 
 /// Converts a float value contained in the lower 32 bits of a vector of
-///    [4 x float] into a 64-bit integer.
+///    [4 x float] into a 64-bit integer. Rounds an inexact result according to
+///    the rounding control bits in the MXCSR register.
+///
+///    If a converted value is larger than the maximum possible result,
+///    raises a floating-point invalid exception. If the exception is
+///    masked, returns the most negative integer.
 ///
 /// \headerfile <x86intrin.h>
 ///
@@ -1352,8 +1367,13 @@ _mm_cvtss_si64(__m128 __a)
 
 #endif
 
-/// Converts two low-order float values in a 128-bit vector of
-///    [4 x float] into a 64-bit vector of [2 x i32].
+/// Converts two low-order float values in a 128-bit vector of [4 x float] into
+///    a 64-bit vector of [2 x i32]. Rounds inexact results according to the
+///    rounding control bits in the MXCSR register.
+///
+///    If a converted value is larger than the maximum possible result,
+///    raises a floating-point invalid exception. If the exception is
+///    masked, returns the most negative integer.
 ///
 /// \headerfile <x86intrin.h>
 ///
@@ -1368,8 +1388,13 @@ _mm_cvtps_pi32(__m128 __a)
   return (__m64)__builtin_ia32_cvtps2pi((__v4sf)__a);
 }
 
-/// Converts two low-order float values in a 128-bit vector of
-///    [4 x float] into a 64-bit vector of [2 x i32].
+/// Converts two low-order float values in a 128-bit vector of [4 x float] into
+///    a 64-bit vector of [2 x i32]. Rounds inexact results according to the
+///    rounding control bits in the MXCSR register.
+///
+///    If a converted value is larger than the maximum possible result,
+///    raises a floating-point invalid exception. If the exception is
+///    masked, returns the most negative integer.
 ///
 /// \headerfile <x86intrin.h>
 ///
@@ -1385,8 +1410,11 @@ _mm_cvt_ps2pi(__m128 __a)
 }
 
 /// Converts a float value contained in the lower 32 bits of a vector of
-///    [4 x float] into a 32-bit integer, truncating the result when it is
-///    inexact.
+///    [4 x float] into a 32-bit integer, truncating an inexact result.
+///
+///    If a converted value is larger than the maximum possible result,
+///    raises a floating-point invalid exception. If the exception is
+///    masked, returns the most negative integer.
 ///
 /// \headerfile <x86intrin.h>
 ///
@@ -1404,8 +1432,11 @@ _mm_cvttss_si32(__m128 __a)
 }
 
 /// Converts a float value contained in the lower 32 bits of a vector of
-///    [4 x float] into a 32-bit integer, truncating the result when it is
-///    inexact.
+///    [4 x float] into a 32-bit integer, truncating an inexact result.
+///
+///    If a converted value is larger than the maximum possible result,
+///    raises a floating-point invalid exception. If the exception is
+///    masked, returns the most negative integer.
 ///
 /// \headerfile <x86intrin.h>
 ///
@@ -1424,8 +1455,11 @@ _mm_cvtt_ss2si(__m128 __a)
 
 #ifdef __x86_64__
 /// Converts a float value contained in the lower 32 bits of a vector of
-///    [4 x float] into a 64-bit integer, truncating the result when it is
-///    inexact.
+///    [4 x float] into a 64-bit integer, truncating an inexact result.
+///
+///    If a converted value is larger than the maximum possible result,
+///    raises a floating-point invalid exception. If the exception is
+///    masked, returns the most negative integer.
 ///
 /// \headerfile <x86intrin.h>
 ///
@@ -1444,8 +1478,12 @@ _mm_cvttss_si64(__m128 __a)
 #endif
 
 /// Converts two low-order float values in a 128-bit vector of
-///    [4 x float] into a 64-bit vector of [2 x i32], truncating the result
-///    when it is inexact.
+///    [4 x float] into a 64-bit vector of [2 x i32], truncating inexact
+///    results.
+///
+///    If a converted value is larger than the maximum possible result,
+///    raises a floating-point invalid exception. If the exception is
+///    masked, returns the most negative integer.
 ///
 /// \headerfile <x86intrin.h>
 ///
@@ -1462,8 +1500,11 @@ _mm_cvttps_pi32(__m128 __a)
 }
 
 /// Converts two low-order float values in a 128-bit vector of [4 x
-///    float] into a 64-bit vector of [2 x i32], truncating the result when it
-///    is inexact.
+///    float] into a 64-bit vector of [2 x i32], truncating inexact results.
+///
+///    If a converted value is larger than the maximum possible result,
+///    raises a floating-point invalid exception. If the exception is
+///    masked, returns the most negative integer.
 ///
 /// \headerfile <x86intrin.h>
 ///
@@ -1478,10 +1519,11 @@ _mm_cvtt_ps2pi(__m128 __a)
   return _mm_cvttps_pi32(__a);
 }
 
-/// Converts a 32-bit signed integer value into a floating point value
-///    and writes it to the lower 32 bits of the destination. The remaining
-///    higher order elements of the destination vector are copied from the
-///    corresponding elements in the first operand.
+/// Converts a 32-bit signed integer value into a floating point value and
+///    writes it to the lower 32 bits of the destination. Rounds an inexact
+///    result according to the rounding control bits in the MXCSR register.
+///    The remaining higher order elements of the destination vector are copied
+///    from the corresponding elements in the first operand.
 ///
 /// \headerfile <x86intrin.h>
 ///
@@ -1501,10 +1543,11 @@ _mm_cvtsi32_ss(__m128 __a, int __b)
   return __a;
 }
 
-/// Converts a 32-bit signed integer value into a floating point value
-///    and writes it to the lower 32 bits of the destination. The remaining
-///    higher order elements of the destination are copied from the
-///    corresponding elements in the first operand.
+/// Converts a 32-bit signed integer value into a floating point value and
+///    writes it to the lower 32 bits of the destination. Rounds an inexact
+///    result according to the rounding control bits in the MXCSR register.
+///    The remaining higher order elements of the destination are copied from
+///    the corresponding elements in the first operand.
 ///
 /// \headerfile <x86intrin.h>
 ///
@@ -1525,10 +1568,11 @@ _mm_cvt_si2ss(__m128 __a, int __b)
 
 #ifdef __x86_64__
 
-/// Converts a 64-bit signed integer value into a floating point value
-///    and writes it to the lower 32 bits of the destination. The remaining
-///    higher order elements of the destination are copied from the
-///    corresponding elements in the first operand.
+/// Converts a 64-bit signed integer value into a floating point value and
+///    writes it to the lower 32 bits of the destination. Rounds an inexact
+///    result according to the rounding control bits in the MXCSR register.
+///    The remaining higher order elements of the destination are copied from
+///    the corresponding elements in the first operand.
 ///
 /// \headerfile <x86intrin.h>
 ///
@@ -1552,8 +1596,10 @@ _mm_cvtsi64_ss(__m128 __a, long long __b)
 
 /// Converts two elements of a 64-bit vector of [2 x i32] into two
 ///    floating point values and writes them to the lower 64-bits of the
-///    destination. The remaining higher order elements of the destination are
-///    copied from the corresponding elements in the first operand.
+///    destination. Rounds inexact results according to the rounding control
+///    bits in the MXCSR register. The remaining higher order elements of the
+///    destination are copied from the corresponding elements in the first
+///    operand.
 ///
 /// \headerfile <x86intrin.h>
 ///
@@ -1575,8 +1621,10 @@ _mm_cvtpi32_ps(__m128 __a, __m64 __b)
 
 /// Converts two elements of a 64-bit vector of [2 x i32] into two
 ///    floating point values and writes them to the lower 64-bits of the
-///    destination. The remaining higher order elements of the destination are
-///    copied from the corresponding elements in the first operand.
+///    destination. Rounds inexact results according to the rounding control
+///    bits in the MXCSR register. The remaining higher order elements of the
+///    destination are copied from the corresponding elements in the first
+///    operand.
 ///
 /// \headerfile <x86intrin.h>
 ///
@@ -2835,7 +2883,9 @@ _mm_cvtpu8_ps(__m64 __a)
 }
 
 /// Converts the two 32-bit signed integer values from each 64-bit vector
-///    operand of [2 x i32] into a 128-bit vector of [4 x float].
+///    operand of [2 x i32] into a 128-bit vector of [4 x float]. Rounds
+///    inexact results according to the rounding control bits in the MXCSR
+///    register.
 ///
 /// \headerfile <x86intrin.h>
 ///
@@ -2864,7 +2914,9 @@ _mm_cvtpi32x2_ps(__m64 __a, __m64 __b)
 
 /// Converts each single-precision floating-point element of a 128-bit
 ///    floating-point vector of [4 x float] into a 16-bit signed integer, and
-///    packs the results into a 64-bit integer vector of [4 x i16].
+///    packs the results into a 64-bit integer vector of [4 x i16]. Rounds
+///    inexact results according to the rounding control bits in the MXCSR
+///    register.
 ///
 ///    If the floating-point element is NaN or infinity, or if the
 ///    floating-point element is greater than 0x7FFFFFFF or less than -0x8000,
@@ -2894,7 +2946,8 @@ _mm_cvtps_pi16(__m128 __a)
 /// Converts each single-precision floating-point element of a 128-bit
 ///    floating-point vector of [4 x float] into an 8-bit signed integer, and
 ///    packs the results into the lower 32 bits of a 64-bit integer vector of
-///    [8 x i8]. The upper 32 bits of the vector are set to 0.
+///    [8 x i8]. The upper 32 bits of the vector are set to 0. Rounds inexact
+///    results according to the rounding control bits in the MXCSR register.
 ///
 ///    If the floating-point element is NaN or infinity, or if the
 ///    floating-point element is greater than 0x7FFFFFFF or less than -0x80, it


### PR DESCRIPTION
Consistently describe rounding/truncating on convert intrinsics. Add notes where an out-of-range result can raise an exception.