### PR TITLE
Revert "XFAIL TestLocalVariables.py on Windows"

### DIFF
--- a/lldb/test/API/lang/c/local_variables/TestLocalVariables.py
+++ b/lldb/test/API/lang/c/local_variables/TestLocalVariables.py
@@ -19,7 +19,6 @@ class LocalVariablesTestCase(TestBase):
         self.source = "main.c"
         self.line = line_number(self.source, "// Set break point at this line.")
 
-    @skipIfWindows
     def test_c_local_variables(self):
         """Test local variable value."""
         self.build()


### PR DESCRIPTION
This reverts commit 3434472ed74141848634b5eb3cd625d651e22562.

Closes #43097.