### PR TITLE
Add non-null check before accessing pointer

### DIFF
--- a/llvm/lib/Target/AMDGPU/SIFoldOperands.cpp
+++ b/llvm/lib/Target/AMDGPU/SIFoldOperands.cpp
@@ -1054,7 +1054,8 @@ void SIFoldOperands::foldOperand(
       // Don't fold if OpToFold doesn't hold an aligned register.
       const TargetRegisterClass *RC =
           TRI->getRegClassForReg(*MRI, OpToFold.getReg());
-      if (RC && TRI->hasVectorRegisters(RC) && OpToFold.getSubReg()) {
+      assert(RC);
+      if (TRI->hasVectorRegisters(RC) && OpToFold.getSubReg()) {
         unsigned SubReg = OpToFold.getSubReg();
         if (const TargetRegisterClass *SubRC =
                 TRI->getSubRegisterClass(RC, SubReg))

--- a/llvm/lib/Target/AMDGPU/SIFoldOperands.cpp
+++ b/llvm/lib/Target/AMDGPU/SIFoldOperands.cpp
@@ -1054,7 +1054,7 @@ void SIFoldOperands::foldOperand(
       // Don't fold if OpToFold doesn't hold an aligned register.
       const TargetRegisterClass *RC =
           TRI->getRegClassForReg(*MRI, OpToFold.getReg());
-      if (TRI->hasVectorRegisters(RC) && OpToFold.getSubReg()) {
+      if (RC && TRI->hasVectorRegisters(RC) && OpToFold.getSubReg()) {
         unsigned SubReg = OpToFold.getSubReg();
         if (const TargetRegisterClass *SubRC =
                 TRI->getSubRegisterClass(RC, SubReg))


### PR DESCRIPTION
Add a check if RC is not null to ensure that a consecutive access is safe.

A static analyzer flagged this issue since hasVectorRegisters potentially dereferences RC.