### PR TITLE
[flang][runtime] Partial revert of #83383.

### DIFF
--- a/flang/runtime/Float128Math/exponent.cpp
+++ b/flang/runtime/Float128Math/exponent.cpp
@@ -12,7 +12,7 @@
 namespace Fortran::runtime {
 extern "C" {
 
-#if LDBL_MANT_DIG == 113 || HAS_FLOAT128
+#if LDBL_MANT_DIG != 113 && HAS_FLOAT128
 // EXPONENT (16.9.75)
 CppTypeFor<TypeCategory::Integer, 4> RTDEF(Exponent16_4)(F128Type x) {
   return Exponent<CppTypeFor<TypeCategory::Integer, 4>>(x);

--- a/flang/runtime/Float128Math/fraction.cpp
+++ b/flang/runtime/Float128Math/fraction.cpp
@@ -12,7 +12,7 @@
 namespace Fortran::runtime {
 extern "C" {
 
-#if LDBL_MANT_DIG == 113 || HAS_FLOAT128
+#if LDBL_MANT_DIG != 113 && HAS_FLOAT128
 // FRACTION (16.9.80)
 F128Type RTDEF(Fraction16)(F128Type x) { return Fraction(x); }
 #endif

--- a/flang/runtime/Float128Math/mod-real.cpp
+++ b/flang/runtime/Float128Math/mod-real.cpp
@@ -12,7 +12,7 @@
 namespace Fortran::runtime {
 extern "C" {
 
-#if LDBL_MANT_DIG == 113 || HAS_FLOAT128
+#if LDBL_MANT_DIG != 113 && HAS_FLOAT128
 // MOD (16.9.135)
 F128Type RTDEF(ModReal16)(
     F128Type x, F128Type p, const char *sourceFile, int sourceLine) {

--- a/flang/runtime/Float128Math/modulo-real.cpp
+++ b/flang/runtime/Float128Math/modulo-real.cpp
@@ -12,7 +12,7 @@
 namespace Fortran::runtime {
 extern "C" {
 
-#if LDBL_MANT_DIG == 113 || HAS_FLOAT128
+#if LDBL_MANT_DIG != 113 && HAS_FLOAT128
 // MODULO (16.9.136)
 F128Type RTDEF(ModuloReal16)(
     F128Type x, F128Type p, const char *sourceFile, int sourceLine) {

--- a/flang/runtime/Float128Math/nearest.cpp
+++ b/flang/runtime/Float128Math/nearest.cpp
@@ -11,7 +11,7 @@
 namespace Fortran::runtime {
 extern "C" {
 
-#if LDBL_MANT_DIG == 113 || HAS_FLOAT128
+#if LDBL_MANT_DIG != 113 && HAS_FLOAT128
 CppTypeFor<TypeCategory::Real, 16> RTDEF(Nearest16)(
     CppTypeFor<TypeCategory::Real, 16> x, bool positive) {
   return Nextafter<true>::invoke(

--- a/flang/runtime/Float128Math/rrspacing.cpp
+++ b/flang/runtime/Float128Math/rrspacing.cpp
@@ -12,7 +12,7 @@
 namespace Fortran::runtime {
 extern "C" {
 
-#if LDBL_MANT_DIG == 113 || HAS_FLOAT128
+#if LDBL_MANT_DIG != 113 && HAS_FLOAT128
 // FRACTION (16.9.80)
 F128Type RTDEF(RRSpacing16)(F128Type x) { return RRSpacing<113>(x); }
 #endif

--- a/flang/runtime/Float128Math/scale.cpp
+++ b/flang/runtime/Float128Math/scale.cpp
@@ -13,7 +13,7 @@
 namespace Fortran::runtime {
 extern "C" {
 
-#if LDBL_MANT_DIG == 113 || HAS_FLOAT128
+#if LDBL_MANT_DIG != 113 && HAS_FLOAT128
 F128Type RTDEF(Scale16)(F128Type x, std::int64_t p) {
   auto ip{static_cast<int>(p)};
   if (ip != p) {

--- a/flang/runtime/Float128Math/set-exponent.cpp
+++ b/flang/runtime/Float128Math/set-exponent.cpp
@@ -12,7 +12,7 @@
 namespace Fortran::runtime {
 extern "C" {
 
-#if LDBL_MANT_DIG == 113 || HAS_FLOAT128
+#if LDBL_MANT_DIG != 113 && HAS_FLOAT128
 // SET_EXPONENT (16.9.171)
 F128Type RTDEF(SetExponent16)(F128Type x, std::int64_t p) {
   return SetExponent(x, p);

--- a/flang/runtime/Float128Math/spacing.cpp
+++ b/flang/runtime/Float128Math/spacing.cpp
@@ -12,7 +12,7 @@
 namespace Fortran::runtime {
 extern "C" {
 
-#if LDBL_MANT_DIG == 113 || HAS_FLOAT128
+#if LDBL_MANT_DIG != 113 && HAS_FLOAT128
 // SPACING (16.9.180)
 F128Type RTDEF(Spacing16)(F128Type x) { return Spacing<113>(x); }
 #endif

--- a/flang/runtime/numeric-templates.h
+++ b/flang/runtime/numeric-templates.h
@@ -21,6 +21,7 @@
 #include "terminator.h"
 #include "tools.h"
 #include "flang/Common/float128.h"
+#include "flang/Runtime/api-attrs.h"
 #include <cstdint>
 #include <limits>
 

--- a/flang/runtime/numeric.cpp
+++ b/flang/runtime/numeric.cpp
@@ -324,7 +324,18 @@ CppTypeFor<TypeCategory::Integer, 8> RTDEF(Exponent10_8)(
     CppTypeFor<TypeCategory::Real, 10> x) {
   return Exponent<CppTypeFor<TypeCategory::Integer, 8>>(x);
 }
+#elif LDBL_MANT_DIG == 113
+// The __float128 implementation resides in FortranFloat128Math library.
+CppTypeFor<TypeCategory::Integer, 4> RTDEF(Exponent16_4)(
+    CppTypeFor<TypeCategory::Real, 16> x) {
+  return Exponent<CppTypeFor<TypeCategory::Integer, 4>>(x);
+}
+CppTypeFor<TypeCategory::Integer, 8> RTDEF(Exponent16_8)(
+    CppTypeFor<TypeCategory::Real, 16> x) {
+  return Exponent<CppTypeFor<TypeCategory::Integer, 8>>(x);
+}
 #endif
+
 
 CppTypeFor<TypeCategory::Integer, 1> RTDEF(Floor4_1)(
     CppTypeFor<TypeCategory::Real, 4> x) {
@@ -431,6 +442,12 @@ CppTypeFor<TypeCategory::Real, 10> RTDEF(Fraction10)(
     CppTypeFor<TypeCategory::Real, 10> x) {
   return Fraction(x);
 }
+#elif LDBL_MANT_DIG == 113
+// The __float128 implementation resides in FortranFloat128Math library.
+CppTypeFor<TypeCategory::Real, 16> RTDEF(Fraction16)(
+    CppTypeFor<TypeCategory::Real, 16> x) {
+  return Fraction(x);
+}
 #endif
 
 bool RTDEF(IsFinite4)(CppTypeFor<TypeCategory::Real, 4> x) {
@@ -513,6 +530,13 @@ CppTypeFor<TypeCategory::Real, 10> RTDEF(ModReal10)(
     const char *sourceFile, int sourceLine) {
   return RealMod<false>(x, p, sourceFile, sourceLine);
 }
+#elif LDBL_MANT_DIG == 113
+// The __float128 implementation resides in FortranFloat128Math library.
+CppTypeFor<TypeCategory::Real, 16> RTDEF(ModReal16)(
+    CppTypeFor<TypeCategory::Real, 16> x, CppTypeFor<TypeCategory::Real, 16> p,
+    const char *sourceFile, int sourceLine) {
+  return RealMod<false>(x, p, sourceFile, sourceLine);
+}
 #endif
 
 CppTypeFor<TypeCategory::Integer, 1> RTDEF(ModuloInteger1)(
@@ -563,6 +587,13 @@ CppTypeFor<TypeCategory::Real, 10> RTDEF(ModuloReal10)(
     const char *sourceFile, int sourceLine) {
   return RealMod<true>(x, p, sourceFile, sourceLine);
 }
+#elif LDBL_MANT_DIG == 113
+// The __float128 implementation resides in FortranFloat128Math library.
+CppTypeFor<TypeCategory::Real, 16> RTDEF(ModuloReal16)(
+    CppTypeFor<TypeCategory::Real, 16> x, CppTypeFor<TypeCategory::Real, 16> p,
+    const char *sourceFile, int sourceLine) {
+  return RealMod<true>(x, p, sourceFile, sourceLine);
+}
 #endif
 
 CppTypeFor<TypeCategory::Real, 4> RTDEF(Nearest4)(
@@ -577,6 +608,12 @@ CppTypeFor<TypeCategory::Real, 8> RTDEF(Nearest8)(
 CppTypeFor<TypeCategory::Real, 10> RTDEF(Nearest10)(
     CppTypeFor<TypeCategory::Real, 10> x, bool positive) {
   return Nearest<64>(x, positive);
+}
+#elif LDBL_MANT_DIG == 113
+// The __float128 implementation resides in FortranFloat128Math library.
+CppTypeFor<TypeCategory::Real, 16> RTDEF(Nearest16)(
+    CppTypeFor<TypeCategory::Real, 16> x, bool positive) {
+  return Nearest<113>(x, positive);
 }
 #endif
 
@@ -685,6 +722,12 @@ CppTypeFor<TypeCategory::Real, 10> RTDEF(RRSpacing10)(
     CppTypeFor<TypeCategory::Real, 10> x) {
   return RRSpacing<64>(x);
 }
+#elif LDBL_MANT_DIG == 113
+// The __float128 implementation resides in FortranFloat128Math library.
+CppTypeFor<TypeCategory::Real, 16> RTDEF(RRSpacing16)(
+    CppTypeFor<TypeCategory::Real, 16> x) {
+  return RRSpacing<113>(x);
+}
 #endif
 
 CppTypeFor<TypeCategory::Real, 4> RTDEF(SetExponent4)(
@@ -700,6 +743,12 @@ CppTypeFor<TypeCategory::Real, 10> RTDEF(SetExponent10)(
     CppTypeFor<TypeCategory::Real, 10> x, std::int64_t p) {
   return SetExponent(x, p);
 }
+#elif LDBL_MANT_DIG == 113
+// The __float128 implementation resides in FortranFloat128Math library.
+CppTypeFor<TypeCategory::Real, 16> RTDEF(SetExponent16)(
+    CppTypeFor<TypeCategory::Real, 16> x, std::int64_t p) {
+  return SetExponent(x, p);
+}
 #endif
 
 CppTypeFor<TypeCategory::Real, 4> RTDEF(Scale4)(
@@ -713,6 +762,12 @@ CppTypeFor<TypeCategory::Real, 8> RTDEF(Scale8)(
 #if LDBL_MANT_DIG == 64
 CppTypeFor<TypeCategory::Real, 10> RTDEF(Scale10)(
     CppTypeFor<TypeCategory::Real, 10> x, std::int64_t p) {
+  return Scale(x, p);
+}
+#elif LDBL_MANT_DIG == 113
+// The __float128 implementation resides in FortranFloat128Math library.
+CppTypeFor<TypeCategory::Real, 16> RTDEF(Scale16)(
+    CppTypeFor<TypeCategory::Real, 16> x, std::int64_t p) {
   return Scale(x, p);
 }
 #endif
@@ -768,6 +823,12 @@ CppTypeFor<TypeCategory::Real, 8> RTDEF(Spacing8)(
 CppTypeFor<TypeCategory::Real, 10> RTDEF(Spacing10)(
     CppTypeFor<TypeCategory::Real, 10> x) {
   return Spacing<64>(x);
+}
+#elif LDBL_MANT_DIG == 113
+// The __float128 implementation resides in FortranFloat128Math library.
+CppTypeFor<TypeCategory::Real, 16> RTDEF(Spacing16)(
+    CppTypeFor<TypeCategory::Real, 16> x) {
+  return Spacing<113>(x);
 }
 #endif
 

--- a/flang/runtime/numeric.cpp
+++ b/flang/runtime/numeric.cpp
@@ -336,7 +336,6 @@ CppTypeFor<TypeCategory::Integer, 8> RTDEF(Exponent16_8)(
 }
 #endif
 
-
 CppTypeFor<TypeCategory::Integer, 1> RTDEF(Floor4_1)(
     CppTypeFor<TypeCategory::Real, 4> x) {
   return Floor<CppTypeFor<TypeCategory::Integer, 1>>(x);


### PR DESCRIPTION
For `LDBL_MANT_DIG == 113` targets the REAL(16) versions of F18
runtime APIs can stay and should better stay in FortranRuntime.
This way, no additional linking actions are required, because
glibc provides all that is needed.
I thought I would isolate all REAL(16) implementations (both
via `__float128` and `long double`) into Float128Math library,
but that was a bad idea.

This should fix aarch64 buildbots failing gfortran tests.
