### PR TITLE
[libc++] Include missing <__assert> after #80091

### DIFF
--- a/libcxx/src/new.cpp
+++ b/libcxx/src/new.cpp
@@ -7,6 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "include/overridable_function.h"
+#include <__assert>
 #include <__memory/aligned_alloc.h>
 #include <cstddef>
 #include <cstdlib>


### PR DESCRIPTION
`_LIBCPP_ASSERT_SHIM` used by the -fno-exceptions
LIBCXX_ENABLE_NEW_DELETE_DEFINITIONS=on configuration needs
`_LIBCPP_ASSERT` from `<__assert>`.
