### PR TITLE
Return `errc::no_such_file_or_directory` in `fs::access` if `GetFileAttributesW` fails

### DIFF
--- a/llvm/lib/Support/Windows/Path.inc
+++ b/llvm/lib/Support/Windows/Path.inc
@@ -623,6 +623,10 @@ std::error_code access(const Twine &Path, AccessMode Mode) {
   DWORD Attributes = ::GetFileAttributesW(PathUtf16.begin());
 
   if (Attributes == INVALID_FILE_ATTRIBUTES) {
+    // Avoid returning unexpected error codes when querying for existence.
+    if (Mode == AccessMode::Exist)
+      return errc::no_such_file_or_directory;
+
     // See if the file didn't actually exist.
     DWORD LastError = ::GetLastError();
     if (LastError != ERROR_FILE_NOT_FOUND && LastError != ERROR_PATH_NOT_FOUND)


### PR DESCRIPTION
Fixes https://github.com/llvm/llvm-project/issues/83046

There is a race condition when calling `GetFileAttributesW` that can cause it to return `ERROR_ACCESS_DENIED` on a path which exists, which is unexpected for callers using this function to check for file existence by passing `AccessMode::Exist`. This was manifesting as a compiler crash on Windows downstream in the Swift compiler when using the `-index-store-path` flag (more information in https://github.com/apple/llvm-project/issues/8224).

I looked for alternate APIs to avoid bringing in `shlwapi.h`, but didn't see any good candidates. I'm not tied at all to this solution, any feedback and alternative approaches are more than welcome.