### PR TITLE
[CodeGen] Check entire block if no threshold was given for neighbors

### DIFF
--- a/llvm/include/llvm/CodeGen/MachineBasicBlock.h
+++ b/llvm/include/llvm/CodeGen/MachineBasicBlock.h
@@ -1149,8 +1149,11 @@ public:
   /// \p Reg must be a physical register.
   LivenessQueryResult computeRegisterLiveness(const TargetRegisterInfo *TRI,
                                               MCRegister Reg,
+                                              const_iterator Before) const;
+  LivenessQueryResult computeRegisterLiveness(const TargetRegisterInfo *TRI,
+                                              MCRegister Reg,
                                               const_iterator Before,
-                                              unsigned Neighborhood = 10) const;
+                                              unsigned Neighborhood) const;
 
   // Debugging methods.
   void dump() const;


### PR DESCRIPTION
No way to do this in C++ directly, so let's reserve 0 as a special value.