### PR TITLE
[clangd] Remove calls to getFileLoc() in declToSym()

### DIFF
--- a/clang-tools-extra/clangd/FindSymbols.cpp
+++ b/clang-tools-extra/clangd/FindSymbols.cpp
@@ -223,8 +223,8 @@ std::string getSymbolDetail(ASTContext &Ctx, const NamedDecl &ND) {
 std::optional<DocumentSymbol> declToSym(ASTContext &Ctx, const NamedDecl &ND) {
   auto &SM = Ctx.getSourceManager();
 
-  SourceLocation BeginLoc = SM.getFileLoc(ND.getBeginLoc());
-  SourceLocation EndLoc = SM.getFileLoc(ND.getEndLoc());
+  SourceLocation BeginLoc = ND.getBeginLoc();
+  SourceLocation EndLoc = ND.getEndLoc();
   const auto SymbolRange =
       toHalfOpenFileRange(SM, Ctx.getLangOpts(), {BeginLoc, EndLoc});
   if (!SymbolRange)

--- a/clang-tools-extra/clangd/unittests/FindSymbolsTests.cpp
+++ b/clang-tools-extra/clangd/unittests/FindSymbolsTests.cpp
@@ -750,6 +750,9 @@ TEST(DocumentSymbols, RangeFromMacro) {
     $fullDef[[FF3() {
       int var = 42;
     }]]
+
+    #define FF4(name) int name = 0
+    $FooRange[[FF4($FooSelectionRange[[foo]])]];
   )");
   TU.Code = Main.code().str();
   EXPECT_THAT(
@@ -766,7 +769,11 @@ TEST(DocumentSymbols, RangeFromMacro) {
           AllOf(withName("FF3"), withDetail("()"),
                 symRange(Main.range("fullDef")),
                 children(AllOf(withName("waldo"), withDetail("void ()"),
-                               symRange(Main.range("fullDef")))))));
+                               symRange(Main.range("fullDef"))))),
+          AllOf(
+              withName("FF4"), withDetail("(foo)"),
+              children(AllOf(withName("foo"), symRange(Main.range("FooRange")),
+                             symNameRange(Main.range("FooSelectionRange")))))));
 }
 
 TEST(DocumentSymbols, FuncTemplates) {


### PR DESCRIPTION
toHalfOpenFileRange() already handles translating macro locations to file locations, and it can provide a better result by knowing about both ends of the range.

Fixes https://github.com/clangd/clangd/issues/1941