### PR TITLE
[llvm] Fix symbol name offset in parsing chained-fixup entry function

### DIFF
--- a/llvm/lib/Object/MachOObjectFile.cpp
+++ b/llvm/lib/Object/MachOObjectFile.cpp
@@ -5231,8 +5231,8 @@ MachOObjectFile::getDyldChainedFixupTargets() const {
       auto RawValue = getArray<uint64_t, 2>(*this, ImportPtr);
 
       LibOrdinal = getEncodedOrdinal<uint16_t>(RawValue[0] & 0xFFFF);
-      NameOffset = (RawValue[0] >> 16) & 1;
-      WeakImport = RawValue[0] >> 17;
+      WeakImport = (RawValue[0] >> 16) & 1;
+      NameOffset = RawValue[0] >> 32;
       Addend = RawValue[1];
     } else {
       llvm_unreachable("Import format should have been checked");


### PR DESCRIPTION
I could not find any symbol name when using objdump to parse chained-fixup entries. Then I found this bug that NameOffset had a wrong value because NameOffset and WeakImport varibles were exchanged and calculation for NameOffset was also wrong.

The definition of dyld_chained_import_addend64 is in MachO.h. 
```
struct dyld_chained_import_addend64 {
  uint64_t lib_ordinal : 16;
  uint64_t weak_import : 1;
  uint64_t reserved : 15;
  uint64_t name_offset : 32;
  uint64_t addend;
};
```
https://github.com/llvm/llvm-project/blame/main/llvm/include/llvm/BinaryFormat/MachO.h#L1109-L1115