### PR TITLE
[mlir][arith] Add result pretty printing for constant vscale values

### DIFF
--- a/mlir/include/mlir/Dialect/Arith/IR/ArithOps.td
+++ b/mlir/include/mlir/Dialect/Arith/IR/ArithOps.td
@@ -343,7 +343,9 @@ def Arith_SubIOp : Arith_IntBinaryOpWithOverflowFlags<"subi"> {
 // MulIOp
 //===----------------------------------------------------------------------===//
 
-def Arith_MulIOp : Arith_IntBinaryOpWithOverflowFlags<"muli", [Commutative]> {
+def Arith_MulIOp : Arith_IntBinaryOpWithOverflowFlags<"muli",
+  [Commutative, DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>]
+> {
   let summary = [{
     Integer multiplication operation.
   }];

--- a/mlir/test/Dialect/Arith/vscale_constants.mlir
+++ b/mlir/test/Dialect/Arith/vscale_constants.mlir
@@ -3,12 +3,12 @@
 // Note: This test is checking value names (so deliberately is not using a regex match).
 
 func.func @test_vscale_constant_names() {
-  %0 = vector.vscale
-  %1 = arith.constant 8 : index
-  %2 = arith.constant 10 : index
-  // CHECK: %c8_vscale = arith.muli %c8, %vscale : index
-  %3 = arith.muli %1, %0 : index
-  // CHECK: %c10_vscale = arith.muli %vscale, %c10 : index
-  %4 = arith.muli %0, %2 : index
+  %vscale = vector.vscale
+  %c8 = arith.constant 8 : index
+  // CHECK: %c8_vscale = arith.muli
+  %0 = arith.muli %vscale, %c8 : index
+  %c10 = arith.constant 10 : index
+  // CHECK: %c10_vscale = arith.muli
+  %1 = arith.muli %c10, %vscale : index
   return
 }

--- a/mlir/test/Dialect/Arith/vscale_constants.mlir
+++ b/mlir/test/Dialect/Arith/vscale_constants.mlir
@@ -1,0 +1,14 @@
+// RUN: mlir-opt %s | FileCheck %s
+
+// Note: This test is checking value names (so deliberately is not using a regex match).
+
+func.func @test_vscale_constant_names() {
+  %0 = vector.vscale
+  %1 = arith.constant 8 : index
+  %2 = arith.constant 10 : index
+  // CHECK: %c8_vscale = arith.muli %c8, %vscale : index
+  %3 = arith.muli %1, %0 : index
+  // CHECK: %c10_vscale = arith.muli %vscale, %c10 : index
+  %4 = arith.muli %0, %2 : index
+  return
+}


### PR DESCRIPTION
In scalable code it is very common to have constant multiples of vscale, e.g. `4 * vscale`. This updates `arith.muli` to pretty print the result name in cases like this, so `4 * vscale` would be `%c4_vscale`.

This makes reading IR dumps of scalable code a little nicer.