### PR TITLE
[lldb][test] Add test for chained PCH debugging

### DIFF
--- a/lldb/test/API/lang/cpp/gmodules/pch-chain/Makefile
+++ b/lldb/test/API/lang/cpp/gmodules/pch-chain/Makefile
@@ -1,0 +1,10 @@
+include Makefile.rules
+
+OBJECTS += main.o
+
+$(EXE): $(BUILDDIR)/main.o
+
+$(BUILDDIR)/main.o: main.cpp
+	$(CC) -cc1 -emit-pch -x c++-header -fmodule-format=obj -fmodules -O0 -dwarf-ext-refs -debug-info-kind=standalone $(SRCDIR)/base-pch.h -o base-pch.h.gch
+	$(CC) -cc1 -emit-pch -x c++-header -fmodule-format=obj -fmodules -O0 -dwarf-ext-refs -debug-info-kind=standalone -include-pch base-pch.h.gch $(SRCDIR)/pch.h -o pch.h.gch
+	$(CC) -cc1 -emit-obj -x c++ -fmodules -O0 -dwarf-ext-refs -debug-info-kind=standalone -include-pch pch.h.gch $(SRCDIR)/main.cpp -o $(BUILDDIR)/main.o

--- a/lldb/test/API/lang/cpp/gmodules/pch-chain/TestPchChain.py
+++ b/lldb/test/API/lang/cpp/gmodules/pch-chain/TestPchChain.py
@@ -1,0 +1,73 @@
+"""
+Tests that we correctly track AST layout info
+(specifically alignment) when moving AST nodes
+between several ClangASTImporter instances
+(in this case, from a pch chain to executable
+to expression AST).
+"""
+
+import lldb
+import os
+from lldbsuite.test.decorators import *
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test import lldbutil
+
+
+class TestPchChain(TestBase):
+    @add_test_categories(["gmodules"])
+    @expectedFailureAll("Chained pch debugging currently not fully supported")
+    def test_expr(self):
+        self.build()
+        exe = self.getBuildArtifact("a.out")
+        self.target = self.dbg.CreateTarget(exe)
+        self.assertTrue(self.target, VALID_TARGET)
+        lldbutil.run_break_set_by_file_and_line(
+            self, "main.cpp", 9, num_expected_locations=1
+        )
+
+        self.runCmd("run", RUN_SUCCEEDED)
+
+        self.expect(
+            "frame variable data",
+            substrs=["row = 1", "col = 2", "row = 3", "col = 4", "stride = 5"],
+        )
+
+    @add_test_categories(["gmodules"])
+    @expectedFailureAll("Chained pch debugging currently not fully supported")
+    def test_frame_var(self):
+        self.build()
+        exe = self.getBuildArtifact("a.out")
+        self.target = self.dbg.CreateTarget(exe)
+        self.assertTrue(self.target, VALID_TARGET)
+        lldbutil.run_break_set_by_file_and_line(
+            self, "main.cpp", 9, num_expected_locations=1
+        )
+
+        self.runCmd("run", RUN_SUCCEEDED)
+
+        self.expect_expr(
+            "data",
+            result_type="MatrixData",
+            result_children=[
+                ValueCheck(
+                    name="section",
+                    children=[
+                        ValueCheck(
+                            name="origin",
+                            children=[
+                                ValueCheck(name="row", value="1"),
+                                ValueCheck(name="col", value="2"),
+                            ],
+                        ),
+                        ValueCheck(
+                            name="size",
+                            children=[
+                                ValueCheck(name="row", value="3"),
+                                ValueCheck(name="col", value="4"),
+                            ],
+                        ),
+                    ],
+                ),
+                ValueCheck(name="stride", value="5"),
+            ],
+        )

--- a/lldb/test/API/lang/cpp/gmodules/pch-chain/base-pch.h
+++ b/lldb/test/API/lang/cpp/gmodules/pch-chain/base-pch.h
@@ -1,0 +1,9 @@
+#ifndef BASE_PCH_H_IN
+#define BASE_PCH_H_IN
+
+struct [[gnu::aligned(128)]] RowCol {
+  unsigned row;
+  unsigned col;
+};
+
+#endif // _H_IN

--- a/lldb/test/API/lang/cpp/gmodules/pch-chain/main.cpp
+++ b/lldb/test/API/lang/cpp/gmodules/pch-chain/main.cpp
@@ -1,0 +1,10 @@
+int main(int argc, const char *argv[]) {
+  struct MatrixData data = {0};
+  data.section.origin.row = 1;
+  data.section.origin.col = 2;
+  data.section.size.row = 3;
+  data.section.size.col = 4;
+  data.stride = 5;
+
+  return data.section.size.row;
+}

--- a/lldb/test/API/lang/cpp/gmodules/pch-chain/pch.h
+++ b/lldb/test/API/lang/cpp/gmodules/pch-chain/pch.h
@@ -1,0 +1,16 @@
+#ifndef PCH_H_IN
+#define PCH_H_IN
+
+static const int kAlignment = 64;
+
+struct [[gnu::aligned(kAlignment)]] Submatrix {
+  struct RowCol origin;
+  struct RowCol size;
+};
+
+struct [[gnu::aligned(kAlignment)]] MatrixData {
+  struct Submatrix section;
+  unsigned stride;
+};
+
+#endif // _H_IN


### PR DESCRIPTION
Adds a test-case for debugging a program with a
pch chain, that is, the main executable depends
on a pch that itself included another pch.

Currently clang doesn't emit the sekeleton CUs
required for LLDB to track all types on the pch chain. Thus this test is XFAILed for now.