### PR TITLE
[libc++] Remove leftover .fail.cpp matcher in Lit test format

### DIFF
--- a/libcxx/utils/libcxx/test/format.py
+++ b/libcxx/utils/libcxx/test/format.py
@@ -265,7 +265,6 @@ class CxxStandardLibraryTest(lit.formats.FileBasedTest):
             "[.]sh[.][^.]+$",
             "[.]gen[.][^.]+$",
             "[.]verify[.]cpp$",
-            "[.]fail[.]cpp$",
         ]
 
         sourcePath = testSuite.getSourcePath(pathInSuite)


### PR DESCRIPTION
This should have been removed in 8dcb8ea75cef, which removed support for .fail.cpp tests in the libc++ test suite.