### PR TITLE
[mlir][OpenMP][NFC] - Minor fix in OpenMP ops documentation

### DIFF
--- a/mlir/include/mlir/Dialect/OpenMP/OpenMPOps.td
+++ b/mlir/include/mlir/Dialect/OpenMP/OpenMPOps.td
@@ -162,7 +162,7 @@ def PrivateClauseOp : OpenMP_Op<"private", [IsolatedFromAbove]> {
     and how to initialize the copy from the original item in the copy region.
 
     Examples:
-    ---------
+
     * `private(x)` would be emitted as:
     ```mlir
     omp.private {type = private} @x.privatizer : !fir.ref<i32> alloc {


### PR DESCRIPTION
This patch is a minor formatting fix in the OpenMP ops documentation wherein the examples section in ``omp.private`` was breaking out into a top level list item.