### PR TITLE
[clang][sema] consolidate diags for incompatible_vector_*

### DIFF
--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -10266,15 +10266,10 @@ def err_block_on_vm : Error<
 def err_sizeless_nonlocal : Error<
   "non-local variable with sizeless type %0">;
 
-def err_vec_builtin_non_vector_all : Error<
- "all arguments to %0 must be vectors">;
-def err_vec_builtin_incompatible_vector_all : Error<
-  "all arguments to %0 must have vectors of the same type">;
-
 def err_vec_builtin_non_vector : Error<
- "first two arguments to %0 must be vectors">;
+ "%select{first two|all}1 arguments to %0 must be vectors">;
 def err_vec_builtin_incompatible_vector : Error<
-  "first two arguments to %0 must have the same type">;
+  "%select{first two|all}1 arguments to %0 must have the same type">;
 def err_vsx_builtin_nonconstant_argument : Error<
   "argument %0 to %1 must be a 2-bit unsigned literal (i.e. 0, 1, 2 or 3)">;
 

--- a/clang/lib/Sema/SemaChecking.cpp
+++ b/clang/lib/Sema/SemaChecking.cpp
@@ -5219,14 +5219,16 @@ bool CheckVectorElementCallArgs(Sema *S, CallExpr *TheCall) {
         //  and not the builtin itself.
         S->Diag(TheCall->getBeginLoc(),
                 diag::err_vec_builtin_incompatible_vector)
-            << TheCall->getDirectCallee() << /*all args*/ true
+            << TheCall->getDirectCallee() << /*useAllTerminology*/ true
             << SourceRange(A.get()->getBeginLoc(), B.get()->getEndLoc());
         retValue = true;
       }
       if (VecTyA->getNumElements() != VecTyB->getNumElements()) {
-        // if we get here a HLSLVectorTruncation is needed.
+        // You should only be hitting this case if you are calling the builtin
+        // directly. HLSL intrinsics should avoid this case via a
+        // HLSLVectorTruncation.
         S->Diag(BuiltinLoc, diag::err_vec_builtin_incompatible_vector)
-            << TheCall->getDirectCallee() << /*all args*/ true
+            << TheCall->getDirectCallee() << /*useAllTerminology*/ true
             << SourceRange(TheCall->getArg(0)->getBeginLoc(),
                            TheCall->getArg(1)->getEndLoc());
         retValue = true;
@@ -5242,7 +5244,7 @@ bool CheckVectorElementCallArgs(Sema *S, CallExpr *TheCall) {
   // Note: if we get here one of the args is a scalar which
   // requires a VectorSplat on Arg0 or Arg1
   S->Diag(BuiltinLoc, diag::err_vec_builtin_non_vector)
-      << TheCall->getDirectCallee() << /*all args*/ true
+      << TheCall->getDirectCallee() << /*useAllTerminology*/ true
       << SourceRange(TheCall->getArg(0)->getBeginLoc(),
                      TheCall->getArg(1)->getEndLoc());
   return true;

--- a/clang/lib/Sema/SemaChecking.cpp
+++ b/clang/lib/Sema/SemaChecking.cpp
@@ -5218,15 +5218,15 @@ bool CheckVectorElementCallArgs(Sema *S, CallExpr *TheCall) {
         // Note: type promotion is intended to be handeled via the intrinsics
         //  and not the builtin itself.
         S->Diag(TheCall->getBeginLoc(),
-                diag::err_vec_builtin_incompatible_vector_all)
-            << TheCall->getDirectCallee()
+                diag::err_vec_builtin_incompatible_vector)
+            << TheCall->getDirectCallee() << /*all args*/ true
             << SourceRange(A.get()->getBeginLoc(), B.get()->getEndLoc());
         retValue = true;
       }
       if (VecTyA->getNumElements() != VecTyB->getNumElements()) {
         // if we get here a HLSLVectorTruncation is needed.
-        S->Diag(BuiltinLoc, diag::err_vec_builtin_incompatible_vector_all)
-            << TheCall->getDirectCallee()
+        S->Diag(BuiltinLoc, diag::err_vec_builtin_incompatible_vector)
+            << TheCall->getDirectCallee() << /*all args*/ true
             << SourceRange(TheCall->getArg(0)->getBeginLoc(),
                            TheCall->getArg(1)->getEndLoc());
         retValue = true;
@@ -5241,8 +5241,8 @@ bool CheckVectorElementCallArgs(Sema *S, CallExpr *TheCall) {
 
   // Note: if we get here one of the args is a scalar which
   // requires a VectorSplat on Arg0 or Arg1
-  S->Diag(BuiltinLoc, diag::err_vec_builtin_non_vector_all)
-      << TheCall->getDirectCallee()
+  S->Diag(BuiltinLoc, diag::err_vec_builtin_non_vector)
+      << TheCall->getDirectCallee() << /*all args*/ true
       << SourceRange(TheCall->getArg(0)->getBeginLoc(),
                      TheCall->getArg(1)->getEndLoc());
   return true;
@@ -9472,7 +9472,7 @@ bool Sema::SemaBuiltinVSX(CallExpr *TheCall) {
   if ((!Arg1Ty->isVectorType() && !Arg1Ty->isDependentType()) ||
       (!Arg2Ty->isVectorType() && !Arg2Ty->isDependentType())) {
     return Diag(BuiltinLoc, diag::err_vec_builtin_non_vector)
-           << TheCall->getDirectCallee()
+           << TheCall->getDirectCallee() << /*isMorethantwoArgs*/ false
            << SourceRange(TheCall->getArg(0)->getBeginLoc(),
                           TheCall->getArg(1)->getEndLoc());
   }
@@ -9480,7 +9480,7 @@ bool Sema::SemaBuiltinVSX(CallExpr *TheCall) {
   // Check the first two arguments are the same type.
   if (!Context.hasSameUnqualifiedType(Arg1Ty, Arg2Ty)) {
     return Diag(BuiltinLoc, diag::err_vec_builtin_incompatible_vector)
-           << TheCall->getDirectCallee()
+           << TheCall->getDirectCallee() << /*isMorethantwoArgs*/ false
            << SourceRange(TheCall->getArg(0)->getBeginLoc(),
                           TheCall->getArg(1)->getEndLoc());
   }
@@ -9516,7 +9516,7 @@ ExprResult Sema::SemaBuiltinShuffleVector(CallExpr *TheCall) {
     if (!LHSType->isVectorType() || !RHSType->isVectorType())
       return ExprError(
           Diag(TheCall->getBeginLoc(), diag::err_vec_builtin_non_vector)
-          << TheCall->getDirectCallee()
+          << TheCall->getDirectCallee() << /*isMorethantwoArgs*/ false
           << SourceRange(TheCall->getArg(0)->getBeginLoc(),
                          TheCall->getArg(1)->getEndLoc()));
 
@@ -9532,12 +9532,14 @@ ExprResult Sema::SemaBuiltinShuffleVector(CallExpr *TheCall) {
         return ExprError(Diag(TheCall->getBeginLoc(),
                               diag::err_vec_builtin_incompatible_vector)
                          << TheCall->getDirectCallee()
+                         << /*isMorethantwoArgs*/ false
                          << SourceRange(TheCall->getArg(1)->getBeginLoc(),
                                         TheCall->getArg(1)->getEndLoc()));
     } else if (!Context.hasSameUnqualifiedType(LHSType, RHSType)) {
       return ExprError(Diag(TheCall->getBeginLoc(),
                             diag::err_vec_builtin_incompatible_vector)
                        << TheCall->getDirectCallee()
+                       << /*isMorethantwoArgs*/ false
                        << SourceRange(TheCall->getArg(0)->getBeginLoc(),
                                       TheCall->getArg(1)->getEndLoc()));
     } else if (numElements != numResElements) {

--- a/clang/test/SemaHLSL/BuiltIns/dot-errors.hlsl
+++ b/clang/test/SemaHLSL/BuiltIns/dot-errors.hlsl
@@ -22,7 +22,7 @@ float test_dot_vector_size_mismatch(float3 p0, float2 p1) {
 
 float test_dot_builtin_vector_size_mismatch(float3 p0, float2 p1) {
   return __builtin_hlsl_dot(p0, p1);
-  // expected-error@-1 {{all arguments to '__builtin_hlsl_dot' must have vectors of the same type}}
+  // expected-error@-1 {{all arguments to '__builtin_hlsl_dot' must have the same type}}
 }
 
 float test_dot_scalar_mismatch(float p0, int p1) {
@@ -38,39 +38,39 @@ float test_dot_element_type_mismatch(int2 p0, float2 p1) {
 //NOTE: for all the *_promotion we are intentionally not handling type promotion in builtins
 float test_builtin_dot_vec_int_to_float_promotion(int2 p0, float2 p1) {
   return __builtin_hlsl_dot(p0, p1);
-  // expected-error@-1 {{all arguments to '__builtin_hlsl_dot' must have vectors of the same type}}
+  // expected-error@-1 {{all arguments to '__builtin_hlsl_dot' must have the same type}}
 }
 
 int64_t test_builtin_dot_vec_int_to_int64_promotion(int64_t2 p0, int2 p1) {
   return __builtin_hlsl_dot(p0, p1);
-  // expected-error@-1 {{all arguments to '__builtin_hlsl_dot' must have vectors of the same type}}
+  // expected-error@-1 {{all arguments to '__builtin_hlsl_dot' must have the same type}}
 }
 
 float test_builtin_dot_vec_half_to_float_promotion(float2 p0, half2 p1) {
   return __builtin_hlsl_dot(p0, p1);
-  // expected-error@-1 {{all arguments to '__builtin_hlsl_dot' must have vectors of the same type}}
+  // expected-error@-1 {{all arguments to '__builtin_hlsl_dot' must have the same type}}
 }
 
 #ifdef __HLSL_ENABLE_16_BIT
 float test_builtin_dot_vec_int16_to_float_promotion(float2 p0, int16_t2 p1) {
   return __builtin_hlsl_dot(p0, p1);
-  // expected-error@-1 {{all arguments to '__builtin_hlsl_dot' must have vectors of the same type}}
+  // expected-error@-1 {{all arguments to '__builtin_hlsl_dot' must have the same type}}
 }
 
 half test_builtin_dot_vec_int16_to_half_promotion(half2 p0, int16_t2 p1) {
   return __builtin_hlsl_dot(p0, p1);
-  // expected-error@-1 {{all arguments to '__builtin_hlsl_dot' must have vectors of the same type}}
+  // expected-error@-1 {{all arguments to '__builtin_hlsl_dot' must have the same type}}
 }
 
 int test_builtin_dot_vec_int16_to_int_promotion(int2 p0, int16_t2 p1) {
   return __builtin_hlsl_dot(p0, p1);
-  // expected-error@-1 {{all arguments to '__builtin_hlsl_dot' must have vectors of the same type}}
+  // expected-error@-1 {{all arguments to '__builtin_hlsl_dot' must have the same type}}
 }
 
 int64_t test_builtin_dot_vec_int16_to_int64_promotion(int64_t2 p0,
                                                       int16_t2 p1) {
   return __builtin_hlsl_dot(p0, p1);
-  // expected-error@-1 {{all arguments to '__builtin_hlsl_dot' must have vectors of the same type}}
+  // expected-error@-1 {{all arguments to '__builtin_hlsl_dot' must have the same type}}
 }
 #endif
 

--- a/clang/test/SemaHLSL/BuiltIns/lerp-errors.hlsl
+++ b/clang/test/SemaHLSL/BuiltIns/lerp-errors.hlsl
@@ -27,7 +27,7 @@ float2 test_lerp_vector_size_mismatch(float3 p0, float2 p1) {
 
 float2 test_lerp_builtin_vector_size_mismatch(float3 p0, float2 p1) {
   return __builtin_hlsl_lerp(p0, p1, p1);
-  // expected-error@-1 {{all arguments to '__builtin_hlsl_lerp' must have vectors of the same type}}
+  // expected-error@-1 {{all arguments to '__builtin_hlsl_lerp' must have the same type}}
 }
 
 float test_lerp_scalar_mismatch(float p0, half p1) {


### PR DESCRIPTION
removing the additions of `err_vec_builtin_non_vector_all` & `err_vec_builtin_incompatible_vector_all`
caused by https://github.com/llvm/llvm-project/pull/83077.

Instead adding a select option to `err_vec_builtin_non_vector` & `err_vec_builtin_incompatible_vector` to account for uses where there are more than two arguments.