### PR TITLE
[X86] Treat returns as SpecialFP values

### DIFF
--- a/llvm/lib/Target/X86/X86FloatingPoint.cpp
+++ b/llvm/lib/Target/X86/X86FloatingPoint.cpp
@@ -432,6 +432,9 @@ bool FPS::processBasicBlock(MachineFunction &MF, MachineBasicBlock &BB) {
     if (MI.isCall())
       FPInstClass = X86II::SpecialFP;
 
+    if (MI.isReturn())
+      FPInstClass = X86II::SpecialFP;
+
     if (FPInstClass == X86II::NotFP)
       continue;  // Efficiently ignore non-fp insts!
 


### PR DESCRIPTION
SpecialFP value handling function has logic for handling returns, but for returns it never gets called because the codepath for it was mistakenly omitted.