### PR TITLE
[HLSL] Add HLSLRootSignatureAttr.

### DIFF
--- a/clang/include/clang/Basic/Attr.td
+++ b/clang/include/clang/Basic/Attr.td
@@ -4403,6 +4403,14 @@ def HLSLParamModifier : TypeAttr {
   let Args = [DefaultBoolArgument<"MergedSpelling", /*default*/0, /*fake*/1>];
 }
 
+def HLSLRootSignature : InheritableAttr {
+  let Spellings = [Microsoft<"RootSignature">];
+  let Subjects = SubjectList<[HLSLEntry]>;
+  let LangOpts = [HLSL];
+  let Documentation = [HLSLParamQualifierDocs];
+  let Args = [StringArgument<"InputString"> , DeclArgument<Var, "RootSignatureObject", 0, /*fake*/ 1>];
+}
+
 def RandomizeLayout : InheritableAttr {
   let Spellings = [GCC<"randomize_layout">];
   let Subjects = SubjectList<[Record]>;

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -3862,6 +3862,9 @@ public:
   HLSLNumThreadsAttr *mergeHLSLNumThreadsAttr(Decl *D,
                                               const AttributeCommonInfo &AL,
                                               int X, int Y, int Z);
+  HLSLRootSignatureAttr *
+  mergeHLSLRootSignatureAttr(Decl *D, const AttributeCommonInfo &AL,
+                             StringRef OrigStr);
   HLSLShaderAttr *mergeHLSLShaderAttr(Decl *D, const AttributeCommonInfo &AL,
                                       HLSLShaderAttr::ShaderType ShaderType);
   HLSLParamModifierAttr *

--- a/clang/lib/Sema/SemaDecl.cpp
+++ b/clang/lib/Sema/SemaDecl.cpp
@@ -2958,6 +2958,8 @@ static bool mergeDeclAttribute(Sema &S, NamedDecl *D,
   else if (const auto *NT = dyn_cast<HLSLNumThreadsAttr>(Attr))
     NewAttr =
         S.mergeHLSLNumThreadsAttr(D, *NT, NT->getX(), NT->getY(), NT->getZ());
+  else if (const auto *RS = dyn_cast<HLSLRootSignatureAttr>(Attr))
+    NewAttr = S.mergeHLSLRootSignatureAttr(D, *RS, RS->getInputString());
   else if (const auto *SA = dyn_cast<HLSLShaderAttr>(Attr))
     NewAttr = S.mergeHLSLShaderAttr(D, *SA, SA->getType());
   else if (isa<SuppressAttr>(Attr))

--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -7184,16 +7184,15 @@ Sema::mergeHLSLRootSignatureAttr(Decl *D, const AttributeCommonInfo &AL,
 
   // Create a record decl for the root signature.
   IdentifierInfo *II = &Context.Idents.get(FD->getName().str() + ".RS");
-  RecordDecl *RD =
-      RecordDecl::Create(Context, TagDecl::TagKind::Struct, DC,
-                         SourceLocation(), SourceLocation(), II);
+  RecordDecl *RD = RecordDecl::Create(Context, TagDecl::TagKind::Struct, DC,
+                                      SourceLocation(), SourceLocation(), II);
   // TODO: Add fields to the record decl.
 
   // Create a type for the root signature.
   QualType T = Context.getRecordType(RD);
   // Create a variable decl for the root signature.
-  VarDecl *VD = VarDecl::Create(Context, DC, SourceLocation(),
-                                SourceLocation(), II, T, nullptr, SC_None);
+  VarDecl *VD = VarDecl::Create(Context, DC, SourceLocation(), SourceLocation(),
+                                II, T, nullptr, SC_None);
 
   // TODO: Add initializers to the variable decl.
 

--- a/clang/test/AST/HLSL/root_sigature.hlsl
+++ b/clang/test/AST/HLSL/root_sigature.hlsl
@@ -1,0 +1,14 @@
+// RUN: %clang_cc1 -triple dxil-pc-shadermodel6.0-compute -x hlsl -ast-dump -o - %s | FileCheck %s
+
+// Make sure HLSLRootSignatureAttr is created with Var 'main.RS'
+
+// CHECK: FunctionDecl 0x{{.*}} main 'void ()'
+// CHECK-NEXT:   |-CompoundStmt
+// CHECK-NEXT:   |-HLSLShaderAttr 0x{{.*}} Compute
+// CHECK-NEXT:   |-HLSLRootSignatureAttr 0x{{.*}} "" Var 0x{{.*}} 'main.RS' 'main.RS'
+// CHECK-NEXT:   `-HLSLNumThreadsAttr 0x{{.*}} 1 1 1
+
+[shader("compute")]
+[RootSignature("")]
+[numthreads(1,1,1)]
+void main() {}

--- a/clang/test/SemaHLSL/ilegal_root_sigatures.hlsl
+++ b/clang/test/SemaHLSL/ilegal_root_sigatures.hlsl
@@ -1,0 +1,7 @@
+// RUN: %clang_cc1 -triple dxil-pc-shadermodel6.3-library -verify %s
+
+// expected-error@+1 {{expected string literal as argument of 'RootSignature' attribute}}
+[RootSignature(1)]
+[shader("compute")]
+[numthreads(1,1,1)]
+void main() {}


### PR DESCRIPTION
First PR for RootSignature support.
HLSLRootSignatureAttr is added.
It will save the original input string for rewrite and a fake variable for the parsed result.

Parsing will be in the following PR.

For #55116