### PR TITLE
[llvm][Support] Call clear_error in LockFileManager to avoid report_fatal_error

### DIFF
--- a/llvm/lib/Support/LockFileManager.cpp
+++ b/llvm/lib/Support/LockFileManager.cpp
@@ -205,6 +205,8 @@ LockFileManager::LockFileManager(StringRef FileName)
       S.append(std::string(UniqueLockFileName));
       setError(Out.error(), S);
       sys::fs::remove(UniqueLockFileName);
+      // Don't call report_fatal_error.
+      Out.clear_error();
       return;
     }
   }


### PR DESCRIPTION
As per the comment in `raw_fd_ostream`'s destructor, you must call `clear_error()` to prevent a call to `report_fatal_error()`. There's not really a way to test this, but we did encounter it in the wild.

rdar://117347895