### PR TITLE
[DiagnosticInfo] Set correct DiagnosticKind for DiagnosticInfoIgnoringInvalidDebugMetadata class

### DIFF
--- a/llvm/include/llvm/IR/DiagnosticInfo.h
+++ b/llvm/include/llvm/IR/DiagnosticInfo.h
@@ -219,7 +219,7 @@ public:
   /// \p The module that is concerned by this debug metadata version diagnostic.
   DiagnosticInfoIgnoringInvalidDebugMetadata(
       const Module &M, DiagnosticSeverity Severity = DS_Warning)
-      : DiagnosticInfo(DK_DebugMetadataVersion, Severity), M(M) {}
+      : DiagnosticInfo(DK_DebugMetadataInvalid, Severity), M(M) {}
 
   const Module &getModule() const { return M; }
 


### PR DESCRIPTION
LLVM currently sets the diagnostic kind for `DiagnosticInfoIgnoringInvalidDebugMetadata` as `DK_DebugMetadataVersion` instead of `DK_DebugMetadataInvalid` meaning that the output of classof is incorrect.