### PR TITLE
[vscode] Use which to default path

### DIFF
--- a/mlir/utils/vscode/package.json
+++ b/mlir/utils/vscode/package.json
@@ -48,7 +48,8 @@
     "@vscode/vsce": "^2.19.0",
     "clang-format": "^1.8.0",
     "typescript": "^4.6.4",
-    "vscode-test": "^1.3.0"
+    "vscode-test": "^1.3.0",
+    "which": "^4.0.0"
   },
   "repository": {
     "type": "git",

--- a/mlir/utils/vscode/src/mlirContext.ts
+++ b/mlir/utils/vscode/src/mlirContext.ts
@@ -2,6 +2,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as vscode from 'vscode';
 import * as vscodelc from 'vscode-languageclient/node';
+import * as which from 'which';
 
 import * as config from './config';
 import * as configWatcher from './configWatcher';
@@ -334,7 +335,7 @@ export class MLIRContext implements vscode.Disposable {
       if (defaultPath === '') {
         return filePath;
       }
-      filePath = defaultPath;
+      return await which(defaultPath);
 
       // Fallthrough to try resolving the default path.
     }


### PR DESCRIPTION
Currently, https://github.com/llvm/llvm-project/pull/83681/files#diff-b8e9974ee74a344420a4884b67816686649d96126f8104be2010b8dba53aeb35L343 use `**/mlir-lsp-server` to search the path of `mlir-lsp-server`. However, after installation, the mlir-lsp-server should be in `PATH` (e.g., `/bin:/usr/bin`), we should search `PATH` firstly, if we cannot found, we search `**/mlir-lsp-server` again.