### PR TITLE
[Clang] [Sema] Do not attempt to dump the layout of dependent types when `-fdump-record-layouts-complete` is passed

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -308,8 +308,8 @@ Miscellaneous Bug Fixes
 Miscellaneous Clang Crashes Fixed
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-- Do not attempt to dump the layout of dependent types when ``-fdump-record-layouts-complete``
-  is passed.
+- Do not attempt to dump the layout of dependent types or invalid declarations
+  when ``-fdump-record-layouts-complete`` is passed.
   Fixes (`#83684 <https://github.com/llvm/llvm-project/issues/83684>`_).
 
 OpenACC Specific Changes

--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -308,6 +308,10 @@ Miscellaneous Bug Fixes
 Miscellaneous Clang Crashes Fixed
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+- Do not attempt to dump the layout of dependent types when ``-fdump-record-layouts-complete``
+  is passed.
+  Fixes (`#83684 <https://github.com/llvm/llvm-project/issues/83684>`_).
+
 OpenACC Specific Changes
 ------------------------
 

--- a/clang/lib/AST/Decl.cpp
+++ b/clang/lib/AST/Decl.cpp
@@ -5042,7 +5042,7 @@ void RecordDecl::completeDefinition() {
 
   // Layouts are dumped when computed, so if we are dumping for all complete
   // types, we need to force usage to get types that wouldn't be used elsewhere.
-  if (Ctx.getLangOpts().DumpRecordLayoutsComplete)
+  if (Ctx.getLangOpts().DumpRecordLayoutsComplete && !isDependentType())
     (void)Ctx.getASTRecordLayout(this);
 }
 

--- a/clang/lib/AST/Decl.cpp
+++ b/clang/lib/AST/Decl.cpp
@@ -5042,6 +5042,9 @@ void RecordDecl::completeDefinition() {
 
   // Layouts are dumped when computed, so if we are dumping for all complete
   // types, we need to force usage to get types that wouldn't be used elsewhere.
+  //
+  // If the type is dependent, then we can't compute its layout because there
+  // is no way for us to know the size or alignment of a dependent type.
   if (Ctx.getLangOpts().DumpRecordLayoutsComplete && !isDependentType())
     (void)Ctx.getASTRecordLayout(this);
 }

--- a/clang/lib/AST/Decl.cpp
+++ b/clang/lib/AST/Decl.cpp
@@ -5044,8 +5044,11 @@ void RecordDecl::completeDefinition() {
   // types, we need to force usage to get types that wouldn't be used elsewhere.
   //
   // If the type is dependent, then we can't compute its layout because there
-  // is no way for us to know the size or alignment of a dependent type.
-  if (Ctx.getLangOpts().DumpRecordLayoutsComplete && !isDependentType())
+  // is no way for us to know the size or alignment of a dependent type. Also
+  // ignore declarations marked as invalid since 'getASTRecordLayout()' asserts
+  // on that.
+  if (Ctx.getLangOpts().DumpRecordLayoutsComplete && !isDependentType() &&
+      !isInvalidDecl())
     (void)Ctx.getASTRecordLayout(this);
 }
 

--- a/clang/test/Layout/dump-complete-invalid.cpp
+++ b/clang/test/Layout/dump-complete-invalid.cpp
@@ -1,0 +1,6 @@
+// RUN: %clang_cc1 -verify -fsyntax-only -fdump-record-layouts-complete %s
+
+struct Incomplete; // expected-note {{forward declaration}}
+
+// Check we don't crash on trying to print out an invalid declaration.
+struct Invalid : Incomplete {}; // expected-error {{base class has incomplete type}}

--- a/clang/test/Layout/dump-complete.cpp
+++ b/clang/test/Layout/dump-complete.cpp
@@ -22,9 +22,15 @@ struct ts {
   T x;
 };
 
+template <>
+struct ts<void> {
+  float f;
+};
+
 void f() {
   ts<int> a;
   ts<double> b;
+  ts<void> c;
 }
 
 namespace gh83684 {
@@ -38,6 +44,8 @@ struct AllocationResult {
 // CHECK:          0 | struct a
 // CHECK:          0 | struct b
 // CHECK:          0 | class c
+// CHECK:          0 | struct ts<void>
+// CHECK-NEXT:     0 |   float
 // CHECK:          0 | struct ts<int>
 // CHECK:          0 | struct ts<double>
 // CHECK-NOT:      0 | class d

--- a/clang/test/Layout/dump-complete.cpp
+++ b/clang/test/Layout/dump-complete.cpp
@@ -33,6 +33,26 @@ void f() {
   ts<void> c;
 }
 
+namespace gh83671 {
+template <class _Tp, _Tp __v>
+struct integral_constant {
+  static constexpr const _Tp value = __v;
+  typedef integral_constant type;
+};
+
+template <bool _Val>
+using _BoolConstant = integral_constant<bool, _Val>;
+
+template <class _Tp, class _Up>
+struct is_same : _BoolConstant<__is_same(_Tp, _Up)> {};
+
+template < class _Tp >
+class numeric_limits {};
+
+template < class _Tp >
+class numeric_limits< const _Tp > : public numeric_limits< _Tp > {};
+}
+
 namespace gh83684 {
 template <class Pointer>
 struct AllocationResult {

--- a/clang/test/Layout/dump-complete.cpp
+++ b/clang/test/Layout/dump-complete.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -emit-llvm-only -fdump-record-layouts-complete %s | FileCheck %s
+// RUN: %clang_cc1 -fsyntax-only -fdump-record-layouts-complete %s | FileCheck %s
 
 struct a {
   int x;
@@ -12,7 +12,34 @@ class c {};
 
 class d;
 
+template <typename>
+struct s {
+  int x;
+};
+
+template <typename T>
+struct ts {
+  T x;
+};
+
+void f() {
+  ts<int> a;
+  ts<double> b;
+}
+
+namespace gh83684 {
+template <class Pointer>
+struct AllocationResult {
+  Pointer ptr = nullptr;
+  int count = 0;
+};
+}
+
 // CHECK:          0 | struct a
 // CHECK:          0 | struct b
 // CHECK:          0 | class c
+// CHECK:          0 | struct ts<int>
+// CHECK:          0 | struct ts<double>
 // CHECK-NOT:      0 | class d
+// CHECK-NOT:      0 | struct s
+// CHECK-NOT:      0 | struct AllocationResult


### PR DESCRIPTION
We were crashing on trying to print the layout of an uninstantiated template, which obviously doesn’t make sense.

This fixes #83684.