### PR TITLE
[libc][NFC] Clean up GPU utilities directory after rework

### DIFF
--- a/libc/src/__support/GPU/CMakeLists.txt
+++ b/libc/src/__support/GPU/CMakeLists.txt
@@ -1,11 +1,9 @@
-if(NOT LIBC_TARGET_OS_IS_GPU)
+if(NOT EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/${LIBC_TARGET_ARCHITECTURE})
   return()
 endif()
 
-foreach(target nvptx amdgpu generic)
-  add_subdirectory(${target})
-  list(APPEND target_gpu_utils libc.src.__support.GPU.${target}.${target}_utils)
-endforeach()
+add_subdirectory(${LIBC_TARGET_ARCHITECTURE})
+set(target_gpu_utils libc.src.__support.GPU.${LIBC_TARGET_ARCHITECTURE}.${LIBC_TARGET_ARCHITECTURE}_utils)
 
 add_header_library(
   utils


### PR DESCRIPTION
Summary:
This CMake can be cleaned up now that the AMDGPU and NVPTX builds do not
share a CMake invocation.
