### PR TITLE
[compiler-rt] Only query llvm-config in the orc tests

### DIFF
--- a/compiler-rt/test/lit.common.cfg.py
+++ b/compiler-rt/test/lit.common.cfg.py
@@ -738,22 +738,6 @@ if config.lto_supported:
 if config.have_rpc_xdr_h:
     config.available_features.add("sunrpc")
 
-# Ask llvm-config about assertion mode.
-try:
-    llvm_config_cmd = subprocess.Popen(
-        [os.path.join(config.llvm_tools_dir, "llvm-config"), "--assertion-mode"],
-        stdout=subprocess.PIPE,
-        env=config.environment,
-    )
-except OSError as e:
-    print("Could not launch llvm-config in " + config.llvm_tools_dir)
-    print("    Failed with error #{0}: {1}".format(e.errno, e.strerror))
-    exit(42)
-
-if re.search(r"ON", llvm_config_cmd.stdout.read().decode("ascii")):
-    config.available_features.add("asserts")
-llvm_config_cmd.wait()
-
 # Sanitizer tests tend to be flaky on Windows due to PR24554, so add some
 # retries. We don't do this on otther platforms because it's slower.
 if platform.system() == "Windows":

--- a/compiler-rt/test/orc/lit.cfg.py
+++ b/compiler-rt/test/orc/lit.cfg.py
@@ -1,6 +1,7 @@
 # -*- Python -*-
 
 import os
+import subprocess
 
 # Setup config name.
 config.name = "ORC" + config.name_suffix
@@ -79,3 +80,14 @@ config.excludes = ["Inputs"]
 
 if config.host_os not in ["Darwin", "FreeBSD", "Linux", "Windows"]:
     config.unsupported = True
+
+# Ask llvm-config about assertion mode.
+try:
+    llvm_config_result = subprocess.check_output(
+        [os.path.join(config.llvm_tools_dir, "llvm-config"), "--assertion-mode"],
+        env=config.environment,
+    )
+    if llvm_config_result.startswith(b"ON"):
+        config.available_features.add("asserts")
+except OSError as e:
+    lit_config.warning(f"Could not determine if LLVM was built with assertions: {e}")


### PR DESCRIPTION
This check for assertions is only used inside the test/orc directory, but
doing it in the top level lit config means all testsuites depend on
llvm-config being present. This is not necessarily needed e.g. when
testing just the builtins. While touching this code, simplify it a bit
by using subprocess.check_output() instead of Popen() and use a string
comparison instead of a regex match.
