### PR TITLE
[Github] Make CI container build more reliable

### DIFF
--- a/.github/workflows/build-ci-container.yml
+++ b/.github/workflows/build-ci-container.yml
@@ -77,14 +77,18 @@ jobs:
           cp ./.github/workflows/containers/github-action-ci/storage.conf ~/.config/containers/storage.conf
           podman info
 
+        # Download the container image into /mnt/podman rather than
+        # $GITHUB_WORKSPACE to avoid space limitations on the default drive
+        # and use the permissions setup for /mnt/podman.
       - name: Download stage1-toolchain
         uses: actions/download-artifact@v4
         with:
           name: stage1-toolchain
+          path: /mnt/podman
 
       - name: Load stage1-toolchain
         run: |
-          podman load -i stage1-toolchain.tar
+          podman load -i /mnt/podman/stage1-toolchain.tar
 
       - name: Build Container
         working-directory: ./.github/workflows/containers/github-action-ci/


### PR DESCRIPTION
This patch increases the reliability of the CI container build (that was failing consistently before this patch) by fixing some transient space issues. During the stage2 build setup, the tar archive was pulled in from the artifact and placed into $GITHUB_WORKSPACE, almost filling it. Podman while running podman load uses additional space on the same drive as $GITHUB_WORKSPACE, eventually running out of space. This patch moves the downloaded tar archive to /mnt/podman, which has significantly more space, and avoids this problem.

Fixes #83142.