### PR TITLE
[ObjC] Set visibility of IvarOffsetGV when it is created in ObjCIvarOffsetVariable

### DIFF
--- a/clang/lib/CodeGen/CGObjCMac.cpp
+++ b/clang/lib/CodeGen/CGObjCMac.cpp
@@ -6826,24 +6826,26 @@ CGObjCNonFragileABIMac::ObjCIvarOffsetVariable(const ObjCInterfaceDecl *ID,
   Name += Ivar->getName();
   llvm::GlobalVariable *IvarOffsetGV = CGM.getModule().getGlobalVariable(Name);
   if (!IvarOffsetGV) {
-    IvarOffsetGV =
-        new llvm::GlobalVariable(CGM.getModule(), ObjCTypes.IvarOffsetVarTy,
-                                 false, llvm::GlobalValue::ExternalLinkage,
-                                 nullptr, Name.str());
+    IvarOffsetGV = new llvm::GlobalVariable(
+        CGM.getModule(), ObjCTypes.IvarOffsetVarTy, false,
+        llvm::GlobalValue::ExternalLinkage, nullptr, Name.str());
+    bool IsPrivateOrPackage =
+        Ivar->getAccessControl() == ObjCIvarDecl::Private ||
+        Ivar->getAccessControl() == ObjCIvarDecl::Package;
     if (CGM.getTriple().isOSBinFormatCOFF()) {
-      bool IsPrivateOrPackage =
-          Ivar->getAccessControl() == ObjCIvarDecl::Private ||
-          Ivar->getAccessControl() == ObjCIvarDecl::Package;
-
       const ObjCInterfaceDecl *ContainingID = Ivar->getContainingInterface();
-
       if (ContainingID->hasAttr<DLLImportAttr>())
-        IvarOffsetGV
-            ->setDLLStorageClass(llvm::GlobalValue::DLLImportStorageClass);
+        IvarOffsetGV->setDLLStorageClass(
+            llvm::GlobalValue::DLLImportStorageClass);
       else if (ContainingID->hasAttr<DLLExportAttr>() && !IsPrivateOrPackage)
-        IvarOffsetGV
-            ->setDLLStorageClass(llvm::GlobalValue::DLLExportStorageClass);
+        IvarOffsetGV->setDLLStorageClass(
+            llvm::GlobalValue::DLLExportStorageClass);
     }
+
+    if (IsPrivateOrPackage || ID->getVisibility() == HiddenVisibility)
+      IvarOffsetGV->setVisibility(llvm::GlobalValue::HiddenVisibility);
+    else
+      IvarOffsetGV->setVisibility(llvm::GlobalValue::DefaultVisibility);
   }
   return IvarOffsetGV;
 }
@@ -6859,8 +6861,6 @@ CGObjCNonFragileABIMac::EmitIvarOffsetVar(const ObjCInterfaceDecl *ID,
       CGM.getDataLayout().getABITypeAlign(ObjCTypes.IvarOffsetVarTy));
 
   if (!CGM.getTriple().isOSBinFormatCOFF()) {
-    // FIXME: This matches gcc, but shouldn't the visibility be set on the use
-    // as well (i.e., in ObjCIvarOffsetVariable).
     if (Ivar->getAccessControl() == ObjCIvarDecl::Private ||
         Ivar->getAccessControl() == ObjCIvarDecl::Package ||
         ID->getVisibility() == HiddenVisibility)

--- a/clang/test/CodeGenObjC/dllstorage.m
+++ b/clang/test/CodeGenObjC/dllstorage.m
@@ -33,7 +33,7 @@ __declspec(dllexport)
 }
 @end
 
-// CHECK-IR-DAG: @"OBJC_IVAR_$_J._ivar" = global i32
+// CHECK-IR-DAG: @"OBJC_IVAR_$_J._ivar" = hidden global i32 0, align 4 
 
 // CHECK-NF-DAG: @"__objc_ivar_offset_J._ivar.@" = hidden global i32
 
@@ -54,7 +54,7 @@ __declspec(dllexport)
 }
 @end
 
-// CHECK-IR-DAG: @"OBJC_IVAR_$_K._ivar" = global i32
+// CHECK-IR-DAG: @"OBJC_IVAR_$_K._ivar" = hidden global i32
 
 // CHECK-NF-DAG: @"__objc_ivar_offset_K._ivar.@" = hidden global i32
 
@@ -88,11 +88,11 @@ __declspec(dllexport)
 }
 @end
 
-// CHECK-IR-DAG: @"OBJC_IVAR_$_L._none" = global i32
+// CHECK-IR-DAG: @"OBJC_IVAR_$_L._none" = hidden global i32
 // CHECK-IR-DAG: @"OBJC_IVAR_$_L._public" = dllexport global i32
 // CHECK-IR-DAG: @"OBJC_IVAR_$_L._protected" = dllexport global i32
-// CHECK-IR-DAG: @"OBJC_IVAR_$_L._package" = global i32
-// CHECK-IR-DAG: @"OBJC_IVAR_$_L._private" = global i32
+// CHECK-IR-DAG: @"OBJC_IVAR_$_L._package" = hidden global i32
+// CHECK-IR-DAG: @"OBJC_IVAR_$_L._private" = hidden global i32
 
 // CHECK-NF-DAG: @"__objc_ivar_offset_L._none.@" = hidden global i32
 // CHECK-NF-DAG: @"__objc_ivar_offset_L._public.@" = dso_local dllexport global i32


### PR DESCRIPTION
It makes sense to set the visibility of the IvarOffsetGV when a new value for it is made in the heap.