### PR TITLE
[libc++] Remove <array> include from <span>

### DIFF
--- a/libcxx/include/__fwd/array.h
+++ b/libcxx/include/__fwd/array.h
@@ -35,6 +35,12 @@ template <size_t _Ip, class _Tp, size_t _Size>
 _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 const _Tp&& get(const array<_Tp, _Size>&&) _NOEXCEPT;
 #endif
 
+template <class>
+struct __is_std_array : false_type {};
+
+template <class _Tp, size_t _Size>
+struct __is_std_array<array<_Tp, _Size> > : true_type {};
+
 _LIBCPP_END_NAMESPACE_STD
 
 #endif // _LIBCPP___FWD_ARRAY_H

--- a/libcxx/include/span
+++ b/libcxx/include/span
@@ -130,10 +130,12 @@ template<class R>
 
 #include <__assert>
 #include <__config>
+#include <__fwd/array.h>
 #include <__fwd/span.h>
 #include <__iterator/bounded_iter.h>
 #include <__iterator/concepts.h>
 #include <__iterator/iterator_traits.h>
+#include <__iterator/reverse_iterator.h>
 #include <__iterator/wrap_iter.h>
 #include <__memory/pointer_traits.h>
 #include <__ranges/concepts.h>
@@ -141,13 +143,16 @@ template<class R>
 #include <__ranges/enable_borrowed_range.h>
 #include <__ranges/enable_view.h>
 #include <__ranges/size.h>
+#include <__type_traits/is_array.h>
+#include <__type_traits/is_const.h>
 #include <__type_traits/is_convertible.h>
+#include <__type_traits/remove_cv.h>
 #include <__type_traits/remove_cvref.h>
 #include <__type_traits/remove_reference.h>
 #include <__type_traits/type_identity.h>
 #include <__utility/forward.h>
-#include <array>   // for array
-#include <cstddef> // for byte
+#include <cstddef>      // for byte
+#include <initializer_list>
 #include <stdexcept>
 #include <version>
 
@@ -170,12 +175,6 @@ _LIBCPP_PUSH_MACROS
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 #if _LIBCPP_STD_VER >= 20
-
-template <class _Tp>
-struct __is_std_array : false_type {};
-
-template <class _Tp, size_t _Sz>
-struct __is_std_array<array<_Tp, _Sz>> : true_type {};
 
 template <class _Tp>
 struct __is_std_span : false_type {};
@@ -586,6 +585,7 @@ _LIBCPP_END_NAMESPACE_STD
 _LIBCPP_POP_MACROS
 
 #if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
+#  include <array>
 #  include <concepts>
 #  include <functional>
 #  include <iterator>

--- a/libcxx/test/libcxx/transitive_includes/cxx23.csv
+++ b/libcxx/test/libcxx/transitive_includes/cxx23.csv
@@ -509,7 +509,6 @@ shared_mutex string
 shared_mutex version
 source_location cstdint
 source_location version
-span array
 span cstddef
 span initializer_list
 span limits

--- a/libcxx/test/libcxx/transitive_includes/cxx26.csv
+++ b/libcxx/test/libcxx/transitive_includes/cxx26.csv
@@ -509,7 +509,6 @@ shared_mutex string
 shared_mutex version
 source_location cstdint
 source_location version
-span array
 span cstddef
 span initializer_list
 span limits

--- a/libcxx/test/std/ranges/range.utility/range.subrange/operator.pair_like.pass.cpp
+++ b/libcxx/test/std/ranges/range.utility/range.subrange/operator.pair_like.pass.cpp
@@ -13,6 +13,7 @@
 //   requires pair-like-convertible-from<PairLike, const I&, const S&>
 // constexpr operator PairLike() const;
 
+#include <array>
 #include <cassert>
 #include <concepts>
 #include <ranges>


### PR DESCRIPTION
This reduces the include time of `<span>` from 122ms to 78ms.
