### PR TITLE
[flang] Fix use-after-free in `MemoryAllocation.cpp`

### DIFF
--- a/flang/lib/Optimizer/Transforms/MemoryAllocation.cpp
+++ b/flang/lib/Optimizer/Transforms/MemoryAllocation.cpp
@@ -200,7 +200,8 @@ public:
       return keepStackAllocation(alloca, &func.front(), options);
     });
 
-    patterns.insert<AllocaOpConversion>(context, analysis.getReturns(func));
+    llvm::SmallVector<mlir::Operation *> returnOps = analysis.getReturns(func);
+    patterns.insert<AllocaOpConversion>(context, returnOps);
     if (mlir::failed(
             mlir::applyPartialConversion(func, target, std::move(patterns)))) {
       mlir::emitError(func.getLoc(),


### PR DESCRIPTION
`AllocaOpConversion` takes an `ArrayRef<Operation *>`, but the underlying `SmallVector<Operation *>` was dead by the time the pattern ran.