### PR TITLE
[cmake] Include GNUInstallDirs before using variables defined by it.

### DIFF
--- a/llvm/cmake/modules/Findzstd.cmake
+++ b/llvm/cmake/modules/Findzstd.cmake
@@ -34,6 +34,7 @@ if(zstd_FOUND)
   elseif (NOT TARGET zstd::libzstd_shared)
     add_library(zstd::libzstd_shared SHARED IMPORTED)
     if(MSVC)
+      include(GNUInstallDirs) # For CMAKE_INSTALL_LIBDIR and friends.
       # IMPORTED_LOCATION is the path to the DLL and IMPORTED_IMPLIB is the "library".
       get_filename_component(zstd_DIRNAME "${zstd_LIBRARY}" DIRECTORY)
       if(NOT "${CMAKE_INSTALL_LIBDIR}" STREQUAL "" AND NOT "${CMAKE_INSTALL_BINDIR}" STREQUAL "")


### PR DESCRIPTION
This fixes an odd problem with the regex when `CMAKE_INSTALL_LIBDIR` is not defined:

`string sub-command REGEX, mode REPLACE: regex "$" matched an empty string.`

Fixes llvm/llvm-project#83802