### PR TITLE
[LangRef] Add aligned attribute description into masked.compress/expandload sections.

### DIFF
--- a/llvm/docs/LangRef.rst
+++ b/llvm/docs/LangRef.rst
@@ -24277,7 +24277,7 @@ Arguments:
 The first operand is the base pointer for the load. It has the same underlying type as the element of the returned vector. The second operand, mask, is a vector of boolean values with the same number of elements as the return type. The third is a pass-through value that is used to fill the masked-off lanes of the result. The return type and the type of the '``passthru``' operand have the same vector type.
 
 The :ref:`align <attr_align>` parameter attribute can be provided for the first
-operand. The pointer alignment is default to 1.
+operand. The pointer alignment defaults to 1.
 
 Semantics:
 """"""""""
@@ -24337,7 +24337,7 @@ Arguments:
 The first operand is the input vector, from which elements are collected and written to memory. The second operand is the base pointer for the store, it has the same underlying type as the element of the input vector operand. The third operand is the mask, a vector of boolean values. The mask and the input vector must have the same number of vector elements.
 
 The :ref:`align <attr_align>` parameter attribute can be provided for the second
-operand. The pointer alignment is default to 1.
+operand. The pointer alignment defaults to 1.
 
 Semantics:
 """"""""""

--- a/llvm/docs/LangRef.rst
+++ b/llvm/docs/LangRef.rst
@@ -24276,6 +24276,9 @@ Arguments:
 
 The first operand is the base pointer for the load. It has the same underlying type as the element of the returned vector. The second operand, mask, is a vector of boolean values with the same number of elements as the return type. The third is a pass-through value that is used to fill the masked-off lanes of the result. The return type and the type of the '``passthru``' operand have the same vector type.
 
+The :ref:`align <attr_align>` parameter attribute can be provided for the first
+operand.
+
 Semantics:
 """"""""""
 
@@ -24333,6 +24336,8 @@ Arguments:
 
 The first operand is the input vector, from which elements are collected and written to memory. The second operand is the base pointer for the store, it has the same underlying type as the element of the input vector operand. The third operand is the mask, a vector of boolean values. The mask and the input vector must have the same number of vector elements.
 
+The :ref:`align <attr_align>` parameter attribute can be provided for the second
+operand.
 
 Semantics:
 """"""""""

--- a/llvm/docs/LangRef.rst
+++ b/llvm/docs/LangRef.rst
@@ -24277,7 +24277,7 @@ Arguments:
 The first operand is the base pointer for the load. It has the same underlying type as the element of the returned vector. The second operand, mask, is a vector of boolean values with the same number of elements as the return type. The third is a pass-through value that is used to fill the masked-off lanes of the result. The return type and the type of the '``passthru``' operand have the same vector type.
 
 The :ref:`align <attr_align>` parameter attribute can be provided for the first
-operand.
+operand. The pointer alignment is default to 1.
 
 Semantics:
 """"""""""
@@ -24337,7 +24337,7 @@ Arguments:
 The first operand is the input vector, from which elements are collected and written to memory. The second operand is the base pointer for the store, it has the same underlying type as the element of the input vector operand. The third operand is the mask, a vector of boolean values. The mask and the input vector must have the same number of vector elements.
 
 The :ref:`align <attr_align>` parameter attribute can be provided for the second
-operand.
+operand. The pointer alignment is default to 1.
 
 Semantics:
 """"""""""


### PR DESCRIPTION
Align attribute has already been used for masked.compress/expandload in commit #83519, #83763 and #83516.