### PR TITLE
Revert "[flang] disable memory-allocation-opt.fir test on windows"

### DIFF
--- a/flang/test/Fir/memory-allocation-opt.fir
+++ b/flang/test/Fir/memory-allocation-opt.fir
@@ -1,6 +1,4 @@
 // RUN: fir-opt --memory-allocation-opt="dynamic-array-on-heap=true maximum-array-alloc-size=1024" %s | FileCheck %s
-// FIXME: started crashing on windows https://github.com/llvm/llvm-project/issues/83534
-// UNSUPPORTED: system-windows
 
 // Test for size of array being too big.
 


### PR DESCRIPTION
Reverts llvm/llvm-project#83535
Bug fixed by https://github.com/llvm/llvm-project/pull/83768