### PR TITLE
[mlir][tosa] Prevent div by 0 in ReshapeOp::inferReturnTypeComponents

### DIFF
--- a/mlir/lib/Dialect/Tosa/IR/TosaOps.cpp
+++ b/mlir/lib/Dialect/Tosa/IR/TosaOps.cpp
@@ -936,8 +936,12 @@ LogicalResult tosa::ReshapeOp::inferReturnTypeComponents(
 
   // Determine the length of the dynamic dimension.
   for (auto &val : newShapeValue) {
-    if (ShapedType::isDynamic(val))
+    if (ShapedType::isDynamic(val)) {
+      if (staticMul == 0) {
+        return failure();
+      }
       val = numElements / staticMul;
+    }
   }
 
   inferredReturnShapes.push_back(


### PR DESCRIPTION
Check if staticMul is 0 before division and return failure()
instead of undefined behavior.