### PR TITLE
[MLIR] Add C-API for parsing bytecode

### DIFF
--- a/mlir/include/mlir-c/IR.h
+++ b/mlir/include/mlir-c/IR.h
@@ -50,6 +50,7 @@ extern "C" {
 
 DEFINE_C_API_STRUCT(MlirAsmState, void);
 DEFINE_C_API_STRUCT(MlirBytecodeWriterConfig, void);
+DEFINE_C_API_STRUCT(MlirBytecodeReaderConfig, void);
 DEFINE_C_API_STRUCT(MlirContext, void);
 DEFINE_C_API_STRUCT(MlirDialect, void);
 DEFINE_C_API_STRUCT(MlirDialectRegistry, void);
@@ -469,6 +470,16 @@ mlirBytecodeWriterConfigDesiredEmitVersion(MlirBytecodeWriterConfig flags,
                                            int64_t version);
 
 //===----------------------------------------------------------------------===//
+// Bytecode parsing flags API.
+//===----------------------------------------------------------------------===//
+
+MLIR_CAPI_EXPORTED MlirBytecodeReaderConfig
+mlirBytecodeReaderConfigCreate(void);
+
+MLIR_CAPI_EXPORTED void
+mlirBytecodeReaderConfigDestroy(MlirBytecodeReaderConfig config);
+
+//===----------------------------------------------------------------------===//
 // Operation API.
 //===----------------------------------------------------------------------===//
 
@@ -819,6 +830,16 @@ MLIR_CAPI_EXPORTED MlirOperation mlirBlockGetTerminator(MlirBlock block);
 /// Takes an operation owned by the caller and appends it to the block.
 MLIR_CAPI_EXPORTED void mlirBlockAppendOwnedOperation(MlirBlock block,
                                                       MlirOperation operation);
+
+/// Read the operations defined within the given buffer, containing MLIR
+/// bytecode, into the provided block.
+MLIR_CAPI_EXPORTED MlirLogicalResult mlirBlockAppendParseBytecode(
+    MlirContext context, MlirBlock block, MlirStringRef buffer);
+
+/// Same as mlirBlockAppendParseBytecode but with reader config.
+MLIR_CAPI_EXPORTED MlirLogicalResult mlirBlockAppendParseBytecodeWithConfig(
+    MlirContext context, MlirBlock block, MlirStringRef buffer,
+    MlirBytecodeReaderConfig config);
 
 /// Takes an operation owned by the caller and inserts it as `pos` to the block.
 /// This is an expensive operation that scans the block linearly, prefer

--- a/mlir/include/mlir/CAPI/IR.h
+++ b/mlir/include/mlir/CAPI/IR.h
@@ -15,6 +15,7 @@
 #ifndef MLIR_CAPI_IR_H
 #define MLIR_CAPI_IR_H
 
+#include "mlir/Bytecode/BytecodeReader.h"
 #include "mlir/Bytecode/BytecodeWriter.h"
 #include "mlir/CAPI/Wrap.h"
 #include "mlir/IR/BuiltinOps.h"
@@ -23,6 +24,7 @@
 
 DEFINE_C_API_PTR_METHODS(MlirAsmState, mlir::AsmState)
 DEFINE_C_API_PTR_METHODS(MlirBytecodeWriterConfig, mlir::BytecodeWriterConfig)
+DEFINE_C_API_PTR_METHODS(MlirBytecodeReaderConfig, mlir::BytecodeReaderConfig)
 DEFINE_C_API_PTR_METHODS(MlirContext, mlir::MLIRContext)
 DEFINE_C_API_PTR_METHODS(MlirDialect, mlir::Dialect)
 DEFINE_C_API_PTR_METHODS(MlirDialectRegistry, mlir::DialectRegistry)

--- a/mlir/include/mlir/IR/AsmState.h
+++ b/mlir/include/mlir/IR/AsmState.h
@@ -464,9 +464,11 @@ public:
   /// `fallbackResourceMap` is an optional fallback handler that can be used to
   /// parse external resources not explicitly handled by another parser.
   ParserConfig(MLIRContext *context, bool verifyAfterParse = true,
-               FallbackAsmResourceMap *fallbackResourceMap = nullptr)
+               FallbackAsmResourceMap *fallbackResourceMap = nullptr,
+               BytecodeReaderConfig *bytecodeReaderConfig = nullptr)
       : context(context), verifyAfterParse(verifyAfterParse),
-        fallbackResourceMap(fallbackResourceMap) {
+        fallbackResourceMap(fallbackResourceMap),
+        bytecodeReaderConfig(bytecodeReaderConfig) {
     assert(context && "expected valid MLIR context");
   }
 
@@ -476,9 +478,10 @@ public:
   /// Returns if the parser should verify the IR after parsing.
   bool shouldVerifyAfterParse() const { return verifyAfterParse; }
 
-  /// Returns the parsing configurations associated to the bytecode read.
-  BytecodeReaderConfig &getBytecodeReaderConfig() const {
-    return const_cast<BytecodeReaderConfig &>(bytecodeReaderConfig);
+  /// Returns the parsing configurations associated to the bytecode read,
+  /// returns nullptr if no config was set.
+  BytecodeReaderConfig *getBytecodeReaderConfig() const {
+    return const_cast<BytecodeReaderConfig *>(bytecodeReaderConfig);
   }
 
   /// Return the resource parser registered to the given name, or nullptr if no
@@ -515,7 +518,7 @@ private:
   bool verifyAfterParse;
   DenseMap<StringRef, std::unique_ptr<AsmResourceParser>> resourceParsers;
   FallbackAsmResourceMap *fallbackResourceMap;
-  BytecodeReaderConfig bytecodeReaderConfig;
+  BytecodeReaderConfig *bytecodeReaderConfig;
 };
 
 //===----------------------------------------------------------------------===//

--- a/mlir/lib/Bytecode/Reader/BytecodeReader.cpp
+++ b/mlir/lib/Bytecode/Reader/BytecodeReader.cpp
@@ -1257,35 +1257,35 @@ LogicalResult AttrTypeReader::parseCustomEntry(Entry<T> &entry,
   if (failed(entry.dialect->load(dialectReader, fileLoc.getContext())))
     return failure();
 
-  if constexpr (std::is_same_v<T, Type>) {
-    // Try parsing with callbacks first if available.
-    for (const auto &callback :
-         parserConfig.getBytecodeReaderConfig().getTypeCallbacks()) {
-      if (failed(
-              callback->read(dialectReader, entry.dialect->name, entry.entry)))
-        return failure();
-      // Early return if parsing was successful.
-      if (!!entry.entry)
-        return success();
+  if (auto *config = parserConfig.getBytecodeReaderConfig()) {
+    if constexpr (std::is_same_v<T, Type>) {
+      // Try parsing with callbacks first if available.
+      for (const auto &callback : config->getTypeCallbacks()) {
+        if (failed(callback->read(dialectReader, entry.dialect->name,
+                                  entry.entry)))
+          return failure();
+        // Early return if parsing was successful.
+        if (!!entry.entry)
+          return success();
 
-      // Reset the reader if we failed to parse, so we can fall through the
-      // other parsing functions.
-      reader = EncodingReader(entry.data, reader.getLoc());
-    }
-  } else {
-    // Try parsing with callbacks first if available.
-    for (const auto &callback :
-         parserConfig.getBytecodeReaderConfig().getAttributeCallbacks()) {
-      if (failed(
-              callback->read(dialectReader, entry.dialect->name, entry.entry)))
-        return failure();
-      // Early return if parsing was successful.
-      if (!!entry.entry)
-        return success();
+        // Reset the reader if we failed to parse, so we can fall through the
+        // other parsing functions.
+        reader = EncodingReader(entry.data, reader.getLoc());
+      }
+    } else {
+      // Try parsing with callbacks first if available.
+      for (const auto &callback : config->getAttributeCallbacks()) {
+        if (failed(callback->read(dialectReader, entry.dialect->name,
+                                  entry.entry)))
+          return failure();
+        // Early return if parsing was successful.
+        if (!!entry.entry)
+          return success();
 
-      // Reset the reader if we failed to parse, so we can fall through the
-      // other parsing functions.
-      reader = EncodingReader(entry.data, reader.getLoc());
+        // Reset the reader if we failed to parse, so we can fall through the
+        // other parsing functions.
+        reader = EncodingReader(entry.data, reader.getLoc());
+      }
     }
   }
 


### PR DESCRIPTION
Currently, we already have C-API `mlirOperationWriteBytecode` and `mlirOperationWriteBytecodeWithConfig` for exporting MLIR data to MLIR bytecode, however there is still a lack of C-API for importing MLIR bytecode.

This PR proposes adding these new C-API functions to improve the lack of the import capability.

```c
//===----------------------------------------------------------------------===//
// Bytecode parsing flags API.
//===----------------------------------------------------------------------===//

MLIR_CAPI_EXPORTED MlirBytecodeReaderConfig
mlirBytecodeReaderConfigCreate(void);

MLIR_CAPI_EXPORTED void
mlirBytecodeReaderConfigDestroy(MlirBytecodeReaderConfig config);

//===----------------------------------------------------------------------===//
// Block API.
//===----------------------------------------------------------------------===//

/// Read the operations defined within the given buffer, containing MLIR
/// bytecode, into the provided block.
MLIR_CAPI_EXPORTED MlirLogicalResult mlirBlockAppendParseBytecode(
    MlirContext context, MlirBlock block, MlirStringRef buffer);

/// Same as mlirBlockAppendParseBytecode but with reader config.
MLIR_CAPI_EXPORTED MlirLogicalResult mlirBlockAppendParseBytecodeWithConfig(
    MlirContext context, MlirBlock block, MlirStringRef buffer,
    MlirBytecodeReaderConfig config);
```