### PR TITLE
[CVP]: Fold `icmp eq X, C` to `trunc X to i1` if C=2k+1 and X in [2k, 2k+1]

### DIFF
--- a/llvm/lib/Transforms/Scalar/CorrelatedValuePropagation.cpp
+++ b/llvm/lib/Transforms/Scalar/CorrelatedValuePropagation.cpp
@@ -374,7 +374,7 @@ static bool processCmp(CmpInst *Cmp, LazyValueInfo *LVI) {
       return true;
 
   if (processEqualityICmp(Cmp, LVI))
-      return true;
+    return true;
 
   return false;
 }

--- a/llvm/test/Transforms/CorrelatedValuePropagation/icmp.ll
+++ b/llvm/test/Transforms/CorrelatedValuePropagation/icmp.ll
@@ -1535,3 +1535,37 @@ bb3:
   %4 = phi i1 [ %3, %bb1 ], [ %2, %bb2 ]
   ret i1 %4
 }
+
+define i1 @test_icmp_ne_on_wrapped_set(i8 %x) {
+; CHECK-LABEL: @test_icmp_ne_on_wrapped_set(
+; CHECK-NEXT:    [[TMP1:%.*]] = icmp sle i8 [[X:%.*]], -128
+; CHECK-NEXT:    [[TMP2:%.*]] = icmp sge i8 [[X]], 127
+; CHECK-NEXT:    [[TMP3:%.*]] = or i1 [[TMP1]], [[TMP2]]
+; CHECK-NEXT:    br i1 [[TMP3]], label [[BB1:%.*]], label [[BB2:%.*]]
+; CHECK:       bb2:
+; CHECK-NEXT:    [[TMP4:%.*]] = tail call i1 @get_bool()
+; CHECK-NEXT:    br label [[BB3:%.*]]
+; CHECK:       bb1:
+; CHECK-NEXT:    [[TMP5:%.*]] = trunc i8 [[X]] to i1
+; CHECK-NEXT:    br label [[BB3]]
+; CHECK:       bb3:
+; CHECK-NEXT:    [[TMP6:%.*]] = phi i1 [ [[TMP5]], [[BB1]] ], [ [[TMP4]], [[BB2]] ]
+; CHECK-NEXT:    ret i1 [[TMP6]]
+;
+  %1 = icmp sle i8 %x, -128
+  %2 = icmp sge i8 %x, 127
+  %3 = or i1 %1, %2
+  br i1 %3, label %bb1, label %bb2
+
+bb2:
+  %4 = tail call i1 @get_bool()
+  br label %bb3
+
+bb1:
+  %5 = icmp eq i8 %x, 127
+  br label %bb3
+
+bb3:
+  %6 = phi i1 [ %5, %bb1 ], [ %4, %bb2 ]
+  ret i1 %6
+}

--- a/llvm/test/Transforms/CorrelatedValuePropagation/icmp.ll
+++ b/llvm/test/Transforms/CorrelatedValuePropagation/icmp.ll
@@ -1569,3 +1569,37 @@ bb3:
   %6 = phi i1 [ %5, %bb1 ], [ %4, %bb2 ]
   ret i1 %6
 }
+
+define i1 @test_icmp_ne_on_nsw(i8 %x) {
+; CHECK-LABEL: @test_icmp_ne_on_nsw(
+; CHECK-NEXT:    [[TMP1:%.*]] = icmp sle i8 [[X:%.*]], 0
+; CHECK-NEXT:    [[TMP2:%.*]] = icmp sge i8 [[X]], -1
+; CHECK-NEXT:    [[TMP3:%.*]] = and i1 [[TMP1]], [[TMP2]]
+; CHECK-NEXT:    br i1 [[TMP3]], label [[BB1:%.*]], label [[BB2:%.*]]
+; CHECK:       bb2:
+; CHECK-NEXT:    [[TMP4:%.*]] = tail call i1 @get_bool()
+; CHECK-NEXT:    br label [[BB3:%.*]]
+; CHECK:       bb1:
+; CHECK-NEXT:    [[TMP5:%.*]] = trunc i8 [[X]] to i1
+; CHECK-NEXT:    br label [[BB3]]
+; CHECK:       bb3:
+; CHECK-NEXT:    [[TMP6:%.*]] = phi i1 [ [[TMP5]], [[BB1]] ], [ [[TMP4]], [[BB2]] ]
+; CHECK-NEXT:    ret i1 [[TMP6]]
+;
+  %1 = icmp sle i8 %x, 0
+  %2 = icmp sge i8 %x, -1
+  %3 = and i1 %1, %2
+  br i1 %3, label %bb1, label %bb2
+
+bb2:
+  %4 = tail call i1 @get_bool()
+  br label %bb3
+
+bb1:
+  %5 = icmp eq i8 %x, -1
+  br label %bb3
+
+bb3:
+  %6 = phi i1 [ %5, %bb1 ], [ %4, %bb2 ]
+  ret i1 %6
+}

--- a/llvm/test/Transforms/CorrelatedValuePropagation/icmp.ll
+++ b/llvm/test/Transforms/CorrelatedValuePropagation/icmp.ll
@@ -1475,3 +1475,63 @@ entry:
   %select = select i1 %cmp1, i1 %cmp2, i1 false
   ret i1 %select
 }
+
+define i1 @test_icmp_eq_on_valid_bool_range(i8 %x) {
+; CHECK-LABEL: @test_icmp_eq_on_valid_bool_range(
+; CHECK-NEXT:    [[TMP1:%.*]] = icmp ult i8 [[X:%.*]], 2
+; CHECK-NEXT:    br i1 [[TMP1]], label [[BB1:%.*]], label [[BB2:%.*]]
+; CHECK:       bb2:
+; CHECK-NEXT:    [[TMP2:%.*]] = tail call i1 @get_bool()
+; CHECK-NEXT:    br label [[BB3:%.*]]
+; CHECK:       bb1:
+; CHECK-NEXT:    [[TMP3:%.*]] = icmp eq i8 [[X]], 1
+; CHECK-NEXT:    br label [[BB3]]
+; CHECK:       bb3:
+; CHECK-NEXT:    [[TMP4:%.*]] = phi i1 [ [[TMP3]], [[BB1]] ], [ [[TMP2]], [[BB2]] ]
+; CHECK-NEXT:    ret i1 [[TMP4]]
+;
+  %1 = icmp ult i8 %x, 2
+  br i1 %1, label %bb1, label %bb2
+
+bb2:
+  %2 = tail call i1 @get_bool()
+  br label %bb3
+
+bb1:
+  %3 = icmp eq i8 %x, 1
+  br label %bb3
+
+bb3:
+  %4 = phi i1 [ %3, %bb1 ], [ %2, %bb2 ]
+  ret i1 %4
+}
+
+define i1 @test_icmp_ne_on_valid_bool_range(i8 %x) {
+; CHECK-LABEL: @test_icmp_ne_on_valid_bool_range(
+; CHECK-NEXT:    [[TMP1:%.*]] = icmp ult i8 [[X:%.*]], 2
+; CHECK-NEXT:    br i1 [[TMP1]], label [[BB1:%.*]], label [[BB2:%.*]]
+; CHECK:       bb2:
+; CHECK-NEXT:    [[TMP2:%.*]] = tail call i1 @get_bool()
+; CHECK-NEXT:    br label [[BB3:%.*]]
+; CHECK:       bb1:
+; CHECK-NEXT:    [[TMP3:%.*]] = icmp ne i8 [[X]], 0
+; CHECK-NEXT:    br label [[BB3]]
+; CHECK:       bb3:
+; CHECK-NEXT:    [[TMP4:%.*]] = phi i1 [ [[TMP3]], [[BB1]] ], [ [[TMP2]], [[BB2]] ]
+; CHECK-NEXT:    ret i1 [[TMP4]]
+;
+  %1 = icmp ult i8 %x, 2
+  br i1 %1, label %bb1, label %bb2
+
+bb2:
+  %2 = tail call i1 @get_bool()
+  br label %bb3
+
+bb1:
+  %3 = icmp ne i8 %x, 0
+  br label %bb3
+
+bb3:
+  %4 = phi i1 [ %3, %bb1 ], [ %2, %bb2 ]
+  ret i1 %4
+}

--- a/llvm/test/Transforms/CorrelatedValuePropagation/icmp.ll
+++ b/llvm/test/Transforms/CorrelatedValuePropagation/icmp.ll
@@ -614,10 +614,10 @@ define void @test_cmp_phi(i8 %a) {
 ; CHECK-NEXT:    br i1 [[C0]], label [[LOOP:%.*]], label [[EXIT:%.*]]
 ; CHECK:       loop:
 ; CHECK-NEXT:    [[P:%.*]] = phi i8 [ [[A]], [[ENTRY:%.*]] ], [ [[B:%.*]], [[LOOP]] ]
-; CHECK-NEXT:    [[C1:%.*]] = icmp ne i8 [[P]], 0
+; CHECK-NEXT:    [[TMP0:%.*]] = trunc i8 [[P]] to i1
 ; CHECK-NEXT:    [[C4:%.*]] = call i1 @get_bool()
 ; CHECK-NEXT:    [[B]] = zext i1 [[C4]] to i8
-; CHECK-NEXT:    br i1 [[C1]], label [[LOOP]], label [[EXIT]]
+; CHECK-NEXT:    br i1 [[TMP0]], label [[LOOP]], label [[EXIT]]
 ; CHECK:       exit:
 ; CHECK-NEXT:    ret void
 ;
@@ -1484,7 +1484,7 @@ define i1 @test_icmp_eq_on_valid_bool_range(i8 %x) {
 ; CHECK-NEXT:    [[TMP2:%.*]] = tail call i1 @get_bool()
 ; CHECK-NEXT:    br label [[BB3:%.*]]
 ; CHECK:       bb1:
-; CHECK-NEXT:    [[TMP3:%.*]] = icmp eq i8 [[X]], 1
+; CHECK-NEXT:    [[TMP3:%.*]] = trunc i8 [[X]] to i1
 ; CHECK-NEXT:    br label [[BB3]]
 ; CHECK:       bb3:
 ; CHECK-NEXT:    [[TMP4:%.*]] = phi i1 [ [[TMP3]], [[BB1]] ], [ [[TMP2]], [[BB2]] ]
@@ -1514,7 +1514,7 @@ define i1 @test_icmp_ne_on_valid_bool_range(i8 %x) {
 ; CHECK-NEXT:    [[TMP2:%.*]] = tail call i1 @get_bool()
 ; CHECK-NEXT:    br label [[BB3:%.*]]
 ; CHECK:       bb1:
-; CHECK-NEXT:    [[TMP3:%.*]] = icmp ne i8 [[X]], 0
+; CHECK-NEXT:    [[TMP3:%.*]] = trunc i8 [[X]] to i1
 ; CHECK-NEXT:    br label [[BB3]]
 ; CHECK:       bb3:
 ; CHECK-NEXT:    [[TMP4:%.*]] = phi i1 [ [[TMP3]], [[BB1]] ], [ [[TMP2]], [[BB2]] ]

--- a/llvm/test/Transforms/CorrelatedValuePropagation/icmp.ll
+++ b/llvm/test/Transforms/CorrelatedValuePropagation/icmp.ll
@@ -614,7 +614,7 @@ define void @test_cmp_phi(i8 %a) {
 ; CHECK-NEXT:    br i1 [[C0]], label [[LOOP:%.*]], label [[EXIT:%.*]]
 ; CHECK:       loop:
 ; CHECK-NEXT:    [[P:%.*]] = phi i8 [ [[A]], [[ENTRY:%.*]] ], [ [[B:%.*]], [[LOOP]] ]
-; CHECK-NEXT:    [[TMP0:%.*]] = trunc i8 [[P]] to i1
+; CHECK-NEXT:    [[TMP0:%.*]] = trunc nuw i8 [[P]] to i1
 ; CHECK-NEXT:    [[C4:%.*]] = call i1 @get_bool()
 ; CHECK-NEXT:    [[B]] = zext i1 [[C4]] to i8
 ; CHECK-NEXT:    br i1 [[TMP0]], label [[LOOP]], label [[EXIT]]
@@ -1484,7 +1484,7 @@ define i1 @test_icmp_eq_on_valid_bool_range(i8 %x) {
 ; CHECK-NEXT:    [[TMP2:%.*]] = tail call i1 @get_bool()
 ; CHECK-NEXT:    br label [[BB3:%.*]]
 ; CHECK:       bb1:
-; CHECK-NEXT:    [[TMP3:%.*]] = trunc i8 [[X]] to i1
+; CHECK-NEXT:    [[TMP3:%.*]] = trunc nuw i8 [[X]] to i1
 ; CHECK-NEXT:    br label [[BB3]]
 ; CHECK:       bb3:
 ; CHECK-NEXT:    [[TMP4:%.*]] = phi i1 [ [[TMP3]], [[BB1]] ], [ [[TMP2]], [[BB2]] ]
@@ -1514,7 +1514,7 @@ define i1 @test_icmp_ne_on_valid_bool_range(i8 %x) {
 ; CHECK-NEXT:    [[TMP2:%.*]] = tail call i1 @get_bool()
 ; CHECK-NEXT:    br label [[BB3:%.*]]
 ; CHECK:       bb1:
-; CHECK-NEXT:    [[TMP3:%.*]] = trunc i8 [[X]] to i1
+; CHECK-NEXT:    [[TMP3:%.*]] = trunc nuw i8 [[X]] to i1
 ; CHECK-NEXT:    br label [[BB3]]
 ; CHECK:       bb3:
 ; CHECK-NEXT:    [[TMP4:%.*]] = phi i1 [ [[TMP3]], [[BB1]] ], [ [[TMP2]], [[BB2]] ]
@@ -1580,7 +1580,7 @@ define i1 @test_icmp_ne_on_nsw(i8 %x) {
 ; CHECK-NEXT:    [[TMP4:%.*]] = tail call i1 @get_bool()
 ; CHECK-NEXT:    br label [[BB3:%.*]]
 ; CHECK:       bb1:
-; CHECK-NEXT:    [[TMP5:%.*]] = trunc i8 [[X]] to i1
+; CHECK-NEXT:    [[TMP5:%.*]] = trunc nsw i8 [[X]] to i1
 ; CHECK-NEXT:    br label [[BB3]]
 ; CHECK:       bb3:
 ; CHECK-NEXT:    [[TMP6:%.*]] = phi i1 [ [[TMP5]], [[BB1]] ], [ [[TMP4]], [[BB2]] ]

--- a/llvm/test/Transforms/JumpThreading/pr33917.ll
+++ b/llvm/test/Transforms/JumpThreading/pr33917.ll
@@ -15,16 +15,16 @@ define void @patatino() personality ptr @rust_eh_personality {
 ; CHECK-LABEL: @patatino(
 ; CHECK-NEXT:  bb9:
 ; CHECK-NEXT:    [[T9:%.*]] = invoke ptr @foo()
-; CHECK-NEXT:    to label [[GOOD:%.*]] unwind label [[BAD:%.*]]
+; CHECK-NEXT:            to label [[GOOD:%.*]] unwind label [[BAD:%.*]]
 ; CHECK:       bad:
 ; CHECK-NEXT:    [[T10:%.*]] = landingpad { ptr, i32 }
-; CHECK-NEXT:    cleanup
+; CHECK-NEXT:            cleanup
 ; CHECK-NEXT:    resume { ptr, i32 } [[T10]]
 ; CHECK:       good:
 ; CHECK-NEXT:    [[T11:%.*]] = icmp ne ptr [[T9]], null
 ; CHECK-NEXT:    [[T12:%.*]] = zext i1 [[T11]] to i64
-; CHECK-NEXT:    [[COND:%.*]] = icmp eq i64 [[T12]], 1
-; CHECK-NEXT:    br i1 [[COND]], label [[IF_TRUE:%.*]], label [[DONE:%.*]]
+; CHECK-NEXT:    [[TMP0:%.*]] = trunc i64 [[T12]] to i1
+; CHECK-NEXT:    br i1 [[TMP0]], label [[IF_TRUE:%.*]], label [[DONE:%.*]]
 ; CHECK:       if_true:
 ; CHECK-NEXT:    call void @llvm.assume(i1 [[T11]])
 ; CHECK-NEXT:    br label [[DONE]]

--- a/llvm/test/Transforms/JumpThreading/pr33917.ll
+++ b/llvm/test/Transforms/JumpThreading/pr33917.ll
@@ -23,7 +23,7 @@ define void @patatino() personality ptr @rust_eh_personality {
 ; CHECK:       good:
 ; CHECK-NEXT:    [[T11:%.*]] = icmp ne ptr [[T9]], null
 ; CHECK-NEXT:    [[T12:%.*]] = zext i1 [[T11]] to i64
-; CHECK-NEXT:    [[TMP0:%.*]] = trunc i64 [[T12]] to i1
+; CHECK-NEXT:    [[TMP0:%.*]] = trunc nuw i64 [[T12]] to i1
 ; CHECK-NEXT:    br i1 [[TMP0]], label [[IF_TRUE:%.*]], label [[DONE:%.*]]
 ; CHECK:       if_true:
 ; CHECK-NEXT:    call void @llvm.assume(i1 [[T11]])


### PR DESCRIPTION
For
``` llvm
define i1 @src(i8 %x) {
  %1 = icmp ult i8 %x, 2
  br i1 %1, label %bb1, label %bb2

bb2:
  %2 = tail call i1 @dynamic()
  br label %bb3

bb1:
  %3 = icmp eq i8 %x, 1 ; <===
  br label %bb3

bb3:
  %4 = phi i1 [ %3, %bb1 ], [ %2, %bb2 ]
  ret i1 %4
}

declare i1 @dynamic()
```
we can fold `icmp eq i8 %x, 1` to `trunc i8 %x to i1` since x is in [0, 1].
The alive2 proof is [https://alive2.llvm.org/ce/z/sGig3-](https://alive2.llvm.org/ce/z/sGig3-).

Generally, for
- `icmp eq X, C` if C = 2k+1 and X is in [2k, 2k+1]
- or `icmp ne X, C` if C = 2k and X is in [2k, 2k+1]

we can fold it to `trunc X to i1`.

With this fold, RISC-V can eliminate two instructions, while ARM can eliminate one instruction on the hot path. Link: [https://godbolt.org/z/xMTbP94Yn](https://godbolt.org/z/xMTbP94Yn).
The real-world case: https://github.com/rust-lang/rust/issues/121673