### PR TITLE
[Clang][Sema] Fix crash when using name of UnresolvedUsingValueDecl with template arguments

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -305,6 +305,8 @@ Bug Fixes to C++ Support
   our attention by an attempt to fix in (#GH77703). Fixes (#GH83385).
 - Fix evaluation of some immediate calls in default arguments.
   Fixes (#GH80630)
+- Fix a crash when an explicit template argument list is used with a name for which lookup
+  finds a non-template function and a dependent using declarator.
 
 Bug Fixes to AST Handling
 ^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/clang/lib/AST/ASTContext.cpp
+++ b/clang/lib/AST/ASTContext.cpp
@@ -9200,8 +9200,7 @@ TemplateName
 ASTContext::getOverloadedTemplateName(UnresolvedSetIterator Begin,
                                       UnresolvedSetIterator End) const {
   unsigned size = End - Begin;
-  assert((size == 1 && isa<UnresolvedUsingValueDecl>(*Begin)) ||
-         size > 1 && "set is not overloaded!");
+  assert(size > 1 && "set is not overloaded!");
 
   void *memory = Allocate(sizeof(OverloadedTemplateStorage) +
                           size * sizeof(FunctionTemplateDecl*));

--- a/clang/lib/AST/ASTContext.cpp
+++ b/clang/lib/AST/ASTContext.cpp
@@ -9200,7 +9200,8 @@ TemplateName
 ASTContext::getOverloadedTemplateName(UnresolvedSetIterator Begin,
                                       UnresolvedSetIterator End) const {
   unsigned size = End - Begin;
-  assert(size > 1 && "set is not overloaded!");
+  assert((size == 1 && isa<UnresolvedUsingValueDecl>(*Begin)) ||
+         size > 1 && "set is not overloaded!");
 
   void *memory = Allocate(sizeof(OverloadedTemplateStorage) +
                           size * sizeof(FunctionTemplateDecl*));

--- a/clang/lib/Sema/SemaDecl.cpp
+++ b/clang/lib/Sema/SemaDecl.cpp
@@ -1115,7 +1115,8 @@ Corrected:
     bool IsFunctionTemplate;
     bool IsVarTemplate;
     TemplateName Template;
-    if (Result.end() - Result.begin() > 1) {
+
+    if ((Result.end() - Result.begin() > 1) || Result.isUnresolvableResult()) {
       IsFunctionTemplate = true;
       Template = Context.getOverloadedTemplateName(Result.begin(),
                                                    Result.end());

--- a/clang/lib/Sema/SemaDecl.cpp
+++ b/clang/lib/Sema/SemaDecl.cpp
@@ -1117,7 +1117,6 @@ Corrected:
     bool IsFunctionTemplate;
     bool IsVarTemplate;
     TemplateName Template;
-
     if (Result.end() - Result.begin() > 1) {
       IsFunctionTemplate = true;
       Template = Context.getOverloadedTemplateName(Result.begin(),

--- a/clang/lib/Sema/SemaDecl.cpp
+++ b/clang/lib/Sema/SemaDecl.cpp
@@ -1110,17 +1110,20 @@ Corrected:
     //   unqualified-id followed by a < and name lookup finds either one
     //   or more functions or finds nothing.
     if (!IsFilteredTemplateName)
-      FilterAcceptableTemplateNames(Result);
+      FilterAcceptableTemplateNames(Result,
+                                    /*AllowFunctionTemplates=*/true,
+                                    /*AllowDependent=*/true);
 
     bool IsFunctionTemplate;
     bool IsVarTemplate;
     TemplateName Template;
 
-    if ((Result.end() - Result.begin() > 1) || Result.isUnresolvableResult()) {
+    if (Result.end() - Result.begin() > 1) {
       IsFunctionTemplate = true;
       Template = Context.getOverloadedTemplateName(Result.begin(),
                                                    Result.end());
     } else if (!Result.empty()) {
+      assert(!Result.isUnresolvableResult());
       auto *TD = cast<TemplateDecl>(getAsTemplateNameDecl(
           *Result.begin(), /*AllowFunctionTemplates=*/true,
           /*AllowDependent=*/false));

--- a/clang/test/SemaTemplate/unqual-unresolved-using-value.cpp
+++ b/clang/test/SemaTemplate/unqual-unresolved-using-value.cpp
@@ -1,0 +1,24 @@
+// RUN: %clang_cc1 -std=c++20 -fsyntax-only -verify %s
+
+template<typename T>
+struct A : T {
+  using T::f;
+  using T::g;
+
+  void f();
+  void g();
+
+  void h() {
+    f<int>();
+    g<int>(); // expected-error{{no member named 'g' in 'A<B>'}}
+  }
+};
+
+struct B {
+  template<typename T>
+  void f();
+
+  void g();
+};
+
+template struct A<B>; // expected-note{{in instantiation of member function 'A<B>::h' requested here}}

--- a/clang/test/SemaTemplate/unqual-unresolved-using-value.cpp
+++ b/clang/test/SemaTemplate/unqual-unresolved-using-value.cpp
@@ -4,13 +4,16 @@ template<typename T>
 struct A : T {
   using T::f;
   using T::g;
+  using T::h;
 
   void f();
   void g();
 
-  void h() {
+  void i() {
     f<int>();
     g<int>(); // expected-error{{no member named 'g' in 'A<B>'}}
+    h<int>(); // expected-error{{expected '(' for function-style cast or type construction}}
+              // expected-error@-1{{expected expression}}
   }
 };
 
@@ -19,6 +22,9 @@ struct B {
   void f();
 
   void g();
+
+  template<typename T>
+  void h();
 };
 
-template struct A<B>; // expected-note{{in instantiation of member function 'A<B>::h' requested here}}
+template struct A<B>; // expected-note{{in instantiation of member function 'A<B>::i' requested here}}


### PR DESCRIPTION
The following snippet causes a crash ([godbolt link](https://godbolt.org/z/E17sYfYrY)):
```cpp
template<typename T>
struct A : T {
  using T::f;
  void f();

  void g() {
    f<int>(); // crash here
  }
};
```
This happens because we cast the result of `getAsTemplateNameDecl` as a `TemplateDecl` in `Sema::ClassifyName`, which we cannot do for an `UnresolvedUsingValueDecl`. ~I believe the correct thing to do here is create an `OverloadedTemplateName`, since it may instantiate to a using declaration naming any number of declarations.~ This patch fixes the crash by considering a name to be that of a template if _any_ function declaration is found per [[temp.names] p3.3](http://eel.is/c++draft/temp.names#3.3).