### PR TITLE
[Clang][Sema] Allow access to a public template alias declaration that refers to friend's private nested type

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -351,6 +351,8 @@ Bug Fixes to C++ Support
   when one of the function had more specialized templates.
   Fixes (`#82509 <https://github.com/llvm/llvm-project/issues/82509>`_)
   and (`#74494 <https://github.com/llvm/llvm-project/issues/74494>`_)
+- Allow access to a public template alias declaration that refers to friend's
+  private nested type. (#GH25708).
 
 Bug Fixes to AST Handling
 ^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/clang/lib/Sema/SemaTemplate.cpp
+++ b/clang/lib/Sema/SemaTemplate.cpp
@@ -4343,9 +4343,13 @@ QualType Sema::CheckTemplateIdType(TemplateName Name,
     if (Inst.isInvalid())
       return QualType();
 
-    CanonType = SubstType(Pattern->getUnderlyingType(),
-                          TemplateArgLists, AliasTemplate->getLocation(),
-                          AliasTemplate->getDeclName());
+    std::optional<ContextRAII> SavedContext;
+    if (!AliasTemplate->getDeclContext()->isFileContext())
+      SavedContext.emplace(*this, AliasTemplate->getDeclContext());
+
+    CanonType =
+        SubstType(Pattern->getUnderlyingType(), TemplateArgLists,
+                  AliasTemplate->getLocation(), AliasTemplate->getDeclName());
     if (CanonType.isNull()) {
       // If this was enable_if and we failed to find the nested type
       // within enable_if in a SFINAE context, dig out the specific

--- a/clang/test/SemaTemplate/PR25708.cpp
+++ b/clang/test/SemaTemplate/PR25708.cpp
@@ -1,0 +1,20 @@
+// RUN: %clang_cc1 -std=c++11 -verify %s
+// expected-no-diagnostics
+
+struct FooAccessor
+{
+    template <typename T>
+    using Foo = typename T::Foo;
+};
+
+class Type
+{
+    friend struct FooAccessor;
+
+    using Foo = int;
+};
+
+int main()
+{
+    FooAccessor::Foo<Type> t;
+}


### PR DESCRIPTION
This patch attempts to fix https://github.com/llvm/llvm-project/issues/25708
Current access check missed qualifier(`NestedNameSpecifier`) in friend class checking. Add it to `Records` of `EffectiveContext` by changing the `DeclContext` makes `MatchesFriend` work.