### PR TITLE
[clangd] Add metric for rename decl kind

### DIFF
--- a/clang-tools-extra/clangd/refactor/Rename.cpp
+++ b/clang-tools-extra/clangd/refactor/Rename.cpp
@@ -1072,6 +1072,10 @@ llvm::Expected<RenameResult> rename(const RenameInputs &RInputs) {
   if (Reject)
     return makeError(*Reject);
 
+  static constexpr trace::Metric RenameTriggerCounter(
+      "rename_trigger_count", trace::Metric::Counter, "decl_kind");
+  RenameTriggerCounter.record(1, RenameDecl.getDeclKindName());
+
   // We have two implementations of the rename:
   //   - AST-based rename: used for renaming local symbols, e.g. variables
   //     defined in a function body;

--- a/clang-tools-extra/clangd/refactor/Rename.cpp
+++ b/clang-tools-extra/clangd/refactor/Rename.cpp
@@ -1062,6 +1062,10 @@ llvm::Expected<RenameResult> rename(const RenameInputs &RInputs) {
     return makeError(ReasonToReject::AmbiguousSymbol);
 
   const auto &RenameDecl = **DeclsUnderCursor.begin();
+  static constexpr trace::Metric RenameTriggerCounter(
+      "rename_trigger_count", trace::Metric::Counter, "decl_kind");
+  RenameTriggerCounter.record(1, RenameDecl.getDeclKindName());
+
   std::string Placeholder = getName(RenameDecl);
   auto Invalid = checkName(RenameDecl, RInputs.NewName, Placeholder);
   if (Invalid)
@@ -1071,10 +1075,6 @@ llvm::Expected<RenameResult> rename(const RenameInputs &RInputs) {
       renameable(RenameDecl, RInputs.MainFilePath, RInputs.Index, Opts);
   if (Reject)
     return makeError(*Reject);
-
-  static constexpr trace::Metric RenameTriggerCounter(
-      "rename_trigger_count", trace::Metric::Counter, "decl_kind");
-  RenameTriggerCounter.record(1, RenameDecl.getDeclKindName());
 
   // We have two implementations of the rename:
   //   - AST-based rename: used for renaming local symbols, e.g. variables


### PR DESCRIPTION
This will give us insight into what users are renaming in practice - for instance, try to gauge the impact of the ObjC rename support.