### PR TITLE
[X86] Resolve FIXME: WinCOFFObjectWriter::RecordRelocation can emit PC-relative calls

### DIFF
--- a/llvm/lib/Target/X86/X86Subtarget.cpp
+++ b/llvm/lib/Target/X86/X86Subtarget.cpp
@@ -238,10 +238,7 @@ X86Subtarget::classifyGlobalFunctionReference(const GlobalValue *GV,
 
 /// Return true if the subtarget allows calls to immediate address.
 bool X86Subtarget::isLegalToCallImmediateAddr() const {
-  // FIXME: I386 PE/COFF supports PC relative calls using IMAGE_REL_I386_REL32
-  // but WinCOFFObjectWriter::RecordRelocation cannot emit them.  Once it does,
-  // the following check for Win32 should be removed.
-  if (Is64Bit || isTargetWin32())
+  if (Is64Bit)
     return false;
   return isTargetELF() || TM.getRelocationModel() == Reloc::Static;
 }

--- a/llvm/test/CodeGen/X86/call-imm.ll
+++ b/llvm/test/CodeGen/X86/call-imm.ll
@@ -2,6 +2,7 @@
 ; RUN: llc < %s -mtriple=i386-apple-darwin -relocation-model=pic | FileCheck -check-prefix X86PIC %s
 ; RUN: llc < %s -mtriple=i386-pc-linux -relocation-model=dynamic-no-pic | FileCheck -check-prefix X86DYN %s
 ; RUN: llc < %s -mtriple=i386-pc-win32 -relocation-model=static | FileCheck -check-prefix X86WINSTA %s
+; RUN: llc < %s -mtriple=i386-pc-win32 -relocation-model=pic | FileCheck -check-prefix X86WINPIC %s
 
 ; Call to immediate is not safe on x86-64 unless we *know* that the
 ; call will be within 32-bits pcrel from the dest immediate.
@@ -21,5 +22,6 @@ entry:
 ; X86STA: {{call.*12345678}}
 ; X86PIC-NOT: {{call.*12345678}}
 ; X86DYN: {{call.*12345678}}
-; X86WINSTA: {{call.*[*]%eax}}
+; X86WINSTA: {{call.*12345678}}
+; X86WINPIC-NOT: {{call.*12345678}}
 ; X64: {{call.*[*]%rax}}


### PR DESCRIPTION
This has been true for a while now, but this check has not been removed.