### PR TITLE
[lld-macho][NFC] Refactor ObjCSelRefsSection out of ObjCStubsSection

### DIFF
--- a/lld/MachO/SyntheticSections.cpp
+++ b/lld/MachO/SyntheticSections.cpp
@@ -807,10 +807,7 @@ void StubHelperSection::setUp() {
 }
 
 ObjCSelRefsSection::ObjCSelRefsSection()
-    : SyntheticSection(segment_names::data, section_names::objcSelrefs) {
-  flags = S_ATTR_NO_DEAD_STRIP;
-  align = target->wordSize;
-}
+    : SyntheticSection(segment_names::data, section_names::objcSelrefs) {}
 
 void ObjCSelRefsSection::initialize() {
   // Do not fold selrefs without ICF.
@@ -864,8 +861,7 @@ ConcatInputSection *ObjCSelRefsSection::makeSelRef(StringRef methName) {
   return objcSelref;
 }
 
-ConcatInputSection *
-ObjCSelRefsSection::getSelRefForMethName(StringRef methName) {
+ConcatInputSection *ObjCSelRefsSection::getSelRef(StringRef methName) {
   auto it = methnameToSelref.find(CachedHashStringRef(methName));
   if (it == methnameToSelref.end())
     return nullptr;
@@ -894,9 +890,8 @@ StringRef ObjCStubsSection::getMethname(Symbol *sym) {
 void ObjCStubsSection::addEntry(Symbol *sym) {
   StringRef methname = getMethname(sym);
   // We create a selref entry for each unique methname.
-  if (!in.objcSelRefs->getSelRefForMethName(methname)) {
+  if (!in.objcSelRefs->getSelRef(methname))
     in.objcSelRefs->makeSelRef(methname);
-  }
 
   auto stubSize = config->objcStubsMode == ObjCStubsMode::fast
                       ? target->objcStubsFastSize
@@ -945,7 +940,7 @@ void ObjCStubsSection::writeTo(uint8_t *buf) const {
     Defined *sym = symbols[i];
 
     auto methname = getMethname(sym);
-    InputSection *selRef = in.objcSelRefs->getSelRefForMethName(methname);
+    InputSection *selRef = in.objcSelRefs->getSelRef(methname);
     assert(selRef != nullptr && "no selref for methname");
     auto selrefAddr = selRef->getVA(0);
     target->writeObjCMsgSendStub(buf + stubOffset, sym, in.objcStubs->addr,

--- a/lld/MachO/SyntheticSections.cpp
+++ b/lld/MachO/SyntheticSections.cpp
@@ -836,9 +836,9 @@ void ObjCSelRefsSection::initialize() {
   }
 }
 
-ConcatInputSection *ObjCSelRefsSection::makeSelRef(StringRef methName) {
+ConcatInputSection *ObjCSelRefsSection::makeSelRef(StringRef methname) {
   auto methnameOffset =
-      in.objcMethnameSection->getStringOffset(methName).outSecOff;
+      in.objcMethnameSection->getStringOffset(methname).outSecOff;
 
   size_t wordSize = target->wordSize;
   uint8_t *selrefData = bAlloc().Allocate<uint8_t>(wordSize);
@@ -857,12 +857,12 @@ ConcatInputSection *ObjCSelRefsSection::makeSelRef(StringRef methName) {
   objcSelref->parent = ConcatOutputSection::getOrCreateForInput(objcSelref);
   inputSections.push_back(objcSelref);
   objcSelref->isFinal = true;
-  methnameToSelref[CachedHashStringRef(methName)] = objcSelref;
+  methnameToSelref[CachedHashStringRef(methname)] = objcSelref;
   return objcSelref;
 }
 
-ConcatInputSection *ObjCSelRefsSection::getSelRef(StringRef methName) {
-  auto it = methnameToSelref.find(CachedHashStringRef(methName));
+ConcatInputSection *ObjCSelRefsSection::getSelRef(StringRef methname) {
+  auto it = methnameToSelref.find(CachedHashStringRef(methname));
   if (it == methnameToSelref.end())
     return nullptr;
   return it->second;

--- a/lld/MachO/SyntheticSections.h
+++ b/lld/MachO/SyntheticSections.h
@@ -326,7 +326,7 @@ public:
   bool isNeeded() const override { return false; }
   void writeTo(uint8_t *buf) const override {}
 
-  ConcatInputSection *getSelRefForMethName(StringRef methName);
+  ConcatInputSection *getSelRef(StringRef methName);
   ConcatInputSection *makeSelRef(StringRef methName);
 
 private:

--- a/lld/MachO/SyntheticSections.h
+++ b/lld/MachO/SyntheticSections.h
@@ -320,14 +320,16 @@ public:
   ObjCSelRefsSection();
   void initialize();
 
-  // This SyntheticSection does not do its own writing, but instead uses the
-  // creates SyntheticInputSection's and inserts them into inputSections
+  // This SyntheticSection does not do directly write data to the output, it is
+  // just a placeholder for easily creating SyntheticInputSection's which will
+  // be inserted into inputSections and handeled by the default writing
+  // mechanism.
   uint64_t getSize() const override { return 0; }
   bool isNeeded() const override { return false; }
   void writeTo(uint8_t *buf) const override {}
 
-  ConcatInputSection *getSelRef(StringRef methName);
-  ConcatInputSection *makeSelRef(StringRef methName);
+  ConcatInputSection *getSelRef(StringRef methname);
+  ConcatInputSection *makeSelRef(StringRef methname);
 
 private:
   llvm::DenseMap<llvm::CachedHashStringRef, ConcatInputSection *>

--- a/lld/MachO/Writer.cpp
+++ b/lld/MachO/Writer.cpp
@@ -720,7 +720,7 @@ static void addNonWeakDefinition(const Defined *defined) {
 
 void Writer::scanSymbols() {
   TimeTraceScope timeScope("Scan symbols");
-  in.objcStubs->initialize();
+  in.objcSelRefs->initialize();
   for (Symbol *sym : symtab->getSymbols()) {
     if (auto *defined = dyn_cast<Defined>(sym)) {
       if (!defined->isLive())
@@ -1359,6 +1359,7 @@ void macho::createSyntheticSections() {
   in.got = make<GotSection>();
   in.tlvPointers = make<TlvPointerSection>();
   in.stubs = make<StubsSection>();
+  in.objcSelRefs = make<ObjCSelRefsSection>();
   in.objcStubs = make<ObjCStubsSection>();
   in.unwindInfo = makeUnwindInfoSection();
   in.objCImageInfo = make<ObjCImageInfoSection>();


### PR DESCRIPTION
Currently ObjCStubsSection is handling both the logic for the "__objc_stubs" section, as well as the logic for the "__objc_selrefs" section. 
While this is OK for now, it will be an issue for other features that want to interact with the "__objc_selrefs" section, such as upcoming relative method lists feature - which will also want to create / reference entries in the "__objc_selrefs" section. 
In this PR we split the logic relating to handling the "__objc_selrefs" section into a new SyntheticSection (ObjCSelRefsSection). Non-functional change - neither the behavior nor implementation changes, the interface is just made more friendly to not have "__objc_selrefs" so bound to "__objc_stubs".