### PR TITLE
[lldb] Use sort-ordering for indexes when sorting by size

### DIFF
--- a/lldb/source/Symbol/Symtab.cpp
+++ b/lldb/source/Symbol/Symtab.cpp
@@ -142,10 +142,11 @@ void Symtab::Dump(Stream *s, Target *target, SortOrder sort_order,
       for (const Symbol &symbol : m_symbols)
         size_map.emplace(symbol.GetByteSize(), &symbol);
 
+      size_t idx = 0;
       for (const auto &size_to_symbol : size_map) {
         const Symbol *symbol = size_to_symbol.second;
         s->Indent();
-        symbol->Dump(s, target, symbol - &m_symbols[0], name_preference);
+        symbol->Dump(s, target, idx++, name_preference);
       }
     } break;
 

--- a/lldb/test/Shell/SymbolFile/Breakpad/symtab-sorted-by-size.test
+++ b/lldb/test/Shell/SymbolFile/Breakpad/symtab-sorted-by-size.test
@@ -4,8 +4,8 @@
 
 # CHECK: num_symbols = 4 (sorted by size):
 # CHECK: [    0]      0  SX Code            0x0000000000400000                    0x00000000000000b0 0x00000000 ___lldb_unnamed_symbol0
-# CHECK: [    3]      0   X Code            0x00000000004000d0                    0x0000000000000022 0x00000000 _start
-# CHECK: [    1]      0   X Code            0x00000000004000b0                    0x0000000000000010 0x00000000 f1
-# CHECK: [    2]      0   X Code            0x00000000004000c0                    0x0000000000000010 0x00000000 f2
+# CHECK: [    1]      0   X Code            0x00000000004000d0                    0x0000000000000022 0x00000000 _start
+# CHECK: [    2]      0   X Code            0x00000000004000b0                    0x0000000000000010 0x00000000 f1
+# CHECK: [    3]      0   X Code            0x00000000004000c0                    0x0000000000000010 0x00000000 f2
 
 image dump symtab -s size symtab.out


### PR DESCRIPTION
Use sort-ordering for indexes when sorting by size. This addresses Jason's post commit review feedback.