### PR TITLE
[lldb/Test] Fix oversight in ProcessEventDataTest::SetUp (NFC)

### DIFF
--- a/lldb/unittests/Process/ProcessEventDataTest.cpp
+++ b/lldb/unittests/Process/ProcessEventDataTest.cpp
@@ -8,6 +8,7 @@
 
 #include "Plugins/Platform/MacOSX/PlatformMacOSX.h"
 #include "Plugins/Platform/MacOSX/PlatformRemoteMacOSX.h"
+#include "TestingSupport/TestUtilities.h"
 #include "lldb/Core/Debugger.h"
 #include "lldb/Host/FileSystem.h"
 #include "lldb/Host/HostInfo.h"
@@ -29,6 +30,8 @@ public:
     FileSystem::Initialize();
     HostInfo::Initialize();
     PlatformMacOSX::Initialize();
+    std::call_once(TestUtilities::g_debugger_initialize_flag,
+                   []() { Debugger::Initialize(nullptr); });
   }
   void TearDown() override {
     PlatformMacOSX::Terminate();


### PR DESCRIPTION
This patch addresses an oversight in `ProcessEventDataTest::SetUp` unittest to ensure the Debugger is initialized properly.