### PR TITLE
[LLVM][NFC] Ignore including the GNUInstallDirs on the GPU

### DIFF
--- a/llvm/cmake/modules/AddLLVM.cmake
+++ b/llvm/cmake/modules/AddLLVM.cmake
@@ -1,4 +1,8 @@
-include(GNUInstallDirs)
+if(NOT ("${LLVM_RUNTIMES_TARGET}" MATCHES "^amdgcn" OR
+        "${LLVM_RUNTIMES_TARGET}" MATCHES "^nvptx64"))
+  include(GNUInstallDirs)
+endif()
+
 include(LLVMDistributionSupport)
 include(LLVMProcessSources)
 include(LLVM-Config)

--- a/llvm/cmake/modules/AddLLVM.cmake
+++ b/llvm/cmake/modules/AddLLVM.cmake
@@ -1,5 +1,4 @@
-if(NOT ("${LLVM_RUNTIMES_TARGET}" MATCHES "^amdgcn" OR
-        "${LLVM_RUNTIMES_TARGET}" MATCHES "^nvptx64"))
+if(NOT LLVM_RUNTIMES_GPU_BUILD)
   include(GNUInstallDirs)
 endif()
 

--- a/llvm/cmake/modules/HandleLLVMOptions.cmake
+++ b/llvm/cmake/modules/HandleLLVMOptions.cmake
@@ -122,8 +122,7 @@ endif()
 
 # If we are targeting a GPU architecture in a runtimes build we want to ignore
 # all the standard flag handling.
-if("${LLVM_RUNTIMES_TARGET}" MATCHES "^amdgcn" OR
-   "${LLVM_RUNTIMES_TARGET}" MATCHES "^nvptx64")
+if(LLVM_RUNTIMES_GPU_BUILD)
   return()
 endif()
 

--- a/runtimes/CMakeLists.txt
+++ b/runtimes/CMakeLists.txt
@@ -151,6 +151,12 @@ endif()
 # Avoid checking whether the compiler is working.
 set(LLVM_COMPILER_CHECKED ON)
 
+# This can be used to detect whether we're targeting a GPU architecture.
+if("${LLVM_RUNTIMES_TARGET}" MATCHES "^amdgcn" OR
+   "${LLVM_RUNTIMES_TARGET}" MATCHES "^nvptx64")
+  set(LLVM_RUNTIMES_GPU_BUILD ON)
+endif()
+
 # Handle common options used by all runtimes.
 include(AddLLVM)
 include(HandleLLVMOptions)


### PR DESCRIPTION
Summary:
I've begun treating GPU runtimes builds as cross-compiling with the LLVM
infrastructure. However, we include a lot of random stuff that the GPU
build isn't prepared to handle. This currently emits a warning, and
while it's not striclty necessary, is annoying. This patch suppresses it
by not including the standard GNU install directory resources when used
from the GPU.
