### PR TITLE
[lldb] Enable a test that was never enabled

### DIFF
--- a/lldb/test/API/functionalities/breakpoint/breakpoint_options/TestBreakpointOptions.py
+++ b/lldb/test/API/functionalities/breakpoint/breakpoint_options/TestBreakpointOptions.py
@@ -13,6 +13,7 @@ class BreakpointOptionsTestCase(TestBase):
         """Test breakpoint command for different options."""
         self.build()
         self.breakpoint_options_test()
+        self.breakpoint_options_language_test()
 
     def setUp(self):
         # Call super's setUp().


### PR DESCRIPTION
According to the git log (d9442afba1bd6), this test has never been enabled/disabled, it was checked in without being called anywhere. But it passes and it is useful, so this commit enables it.