### PR TITLE
Don't require a UUID in a .dwp file.

### DIFF
--- a/lldb/source/Plugins/SymbolFile/DWARF/SymbolFileDWARF.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/SymbolFileDWARF.cpp
@@ -4377,7 +4377,6 @@ const std::shared_ptr<SymbolFileDWARFDwo> &SymbolFileDWARF::GetDwpSymbolFile() {
     FileSpecList search_paths = Target::GetDefaultDebugFileSearchPaths();
     ModuleSpec module_spec;
     module_spec.GetFileSpec() = m_objfile_sp->GetFileSpec();
-    module_spec.GetUUID() = m_objfile_sp->GetUUID();
     for (const auto &symfile : symfiles.files()) {
       module_spec.GetSymbolFileSpec() =
           FileSpec(symfile.GetPath() + ".dwp", symfile.GetPathStyle());

--- a/lldb/test/Shell/SymbolFile/DWARF/x86/dwp-separate-debug-file.cpp
+++ b/lldb/test/Shell/SymbolFile/DWARF/x86/dwp-separate-debug-file.cpp
@@ -139,6 +139,20 @@
 // RUN:   -o "target variable a" \
 // RUN:   -b %t | FileCheck %s
 
+// Now move the .debug and .dwp file into another directory so that we can use
+// the target.debug-file-search-paths setting to search for the files.
+// RUN: mkdir -p %t-debug-info-dir
+// RUN: mv %t.dwp %t-debug-info-dir
+// RUN: mv %t.debug %t-debug-info-dir
+// RUN: %lldb \
+// RUN:   -O "log enable dwarf split" \
+// RUN:   -O "setting set target.debug-file-search-paths '%t-debug-info-dir'" \
+// RUN:   -o "target variable a" \
+// RUN:   -b %t | FileCheck %s
+// RUN:
+
+// Now move the .debug and .dwp file into another directory so that we can use
+// the target.debug-file-search-paths setting to search for the files.
 // CHECK: Searching for DWP using:
 // CHECK: Found DWP file:
 // CHECK: (A) a = (x = 47)


### PR DESCRIPTION
DWP files don't usually have a GNU build ID built into them. When searching for a .dwp file, don't require a UUID to be in the .dwp file. The debug info search information was checking for a UUID in the .dwp file when debug info search paths were being used. This is now fixed by not specifying the UUID in the ModuleSpec being used for the .dwp file search.