### PR TITLE
[Dexter] Extend XFAIL of Dexter tests to all MacOS architectures.

### DIFF
--- a/cross-project-tests/debuginfo-tests/llgdb-tests/static-member-2.cpp
+++ b/cross-project-tests/debuginfo-tests/llgdb-tests/static-member-2.cpp
@@ -2,7 +2,7 @@
 // RUN: %clangxx %target_itanium_abi_host_triple %t -o %t.out
 // RUN: %test_debuginfo %s %t.out
 // XFAIL: gdb-clang-incompatibility
-// XFAIL: system-darwin && target-aarch64
+// XFAIL: system-darwin
 
 // DEBUGGER: delete breakpoints
 // DEBUGGER: break static-member.cpp:33

--- a/cross-project-tests/debuginfo-tests/llgdb-tests/static-member.cpp
+++ b/cross-project-tests/debuginfo-tests/llgdb-tests/static-member.cpp
@@ -2,7 +2,7 @@
 // RUN: %clangxx %target_itanium_abi_host_triple %t -o %t.out
 // RUN: %test_debuginfo %s %t.out
 // XFAIL: !system-darwin && gdb-clang-incompatibility
-// XFAIL: system-darwin && target-aarch64
+// XFAIL: system-darwin
 // DEBUGGER: delete breakpoints
 // DEBUGGER: break static-member.cpp:33
 // DEBUGGER: r


### PR DESCRIPTION
I am trying to bring up a MacOS buildbot targeting x86 and noticed that two Dexter tests were failing, `cross-project-tests/debuginfo-tests/llgdb-tests/static-member.cpp` and `cross-project-tests/debuginfo-tests/llgdb-tests/static-member-2.cpp`. Looking in the history for these tests, they were XFAILed for Apple Silicon in 9c46606. To test, I locally removed the XFAIL on my local Apple Silicon machine, and the errors produced match those my buildbot on x86 is producing.

For example:
```
FAIL: cross-project-tests :: debuginfo-tests/llgdb-tests/static-member.cpp (132 of 137)
******************** TEST 'cross-project-tests :: debuginfo-tests/llgdb-tests/static-member.cpp' FAILED ********************
Exit Code: 1

Command Output (stdout):
--
Debugger output was:
error: 'delete' is not a valid command.
imported lldb from: "/Applications/Xcode.app/Contents/SharedFrameworks/LLDB.framework/Resources/Python"
>  delete breakpoints
None
>  break static-member.cpp:33
SBBreakpoint: id = 1, file = 'static-member.cpp', line = 33, exact_match = 0, locations = 1
>  r
success
>  ptype MyClass
class MyClass {
    static const int a = 4;
    static int b;
    static int c;
public:
    int d;
}
>  p MyClass::a
(const int) $0 = 4
>  p MyClass::c
(int) $1 = 15
> quit

--
Command Output (stderr):
--
RUN: at line 1: /Users/dyung/src/git/llvm/build/bin/clang --driver-mode=g++ --target=arm64-apple-darwin23.3.0 -O0 -g /Users/dyung/src/git/llvm/cross-project-tests/debuginfo-tests/llgdb-tests/static-member.cpp -o /Users/dyung/src/git/llvm/build/projects/cross-project-tests/debuginfo-tests/llgdb-tests/Output/static-member.cpp.tmp -c
+ /Users/dyung/src/git/llvm/build/bin/clang --driver-mode=g++ --target=arm64-apple-darwin23.3.0 -O0 -g /Users/dyung/src/git/llvm/cross-project-tests/debuginfo-tests/llgdb-tests/static-member.cpp -o /Users/dyung/src/git/llvm/build/projects/cross-project-tests/debuginfo-tests/llgdb-tests/Output/static-member.cpp.tmp -c
RUN: at line 2: /Users/dyung/src/git/llvm/build/bin/clang --driver-mode=g++ --target=arm64-apple-darwin23.3.0 /Users/dyung/src/git/llvm/build/projects/cross-project-tests/debuginfo-tests/llgdb-tests/Output/static-member.cpp.tmp -o /Users/dyung/src/git/llvm/build/projects/cross-project-tests/debuginfo-tests/llgdb-tests/Output/static-member.cpp.tmp.out
+ /Users/dyung/src/git/llvm/build/bin/clang --driver-mode=g++ --target=arm64-apple-darwin23.3.0 /Users/dyung/src/git/llvm/build/projects/cross-project-tests/debuginfo-tests/llgdb-tests/Output/static-member.cpp.tmp -o /Users/dyung/src/git/llvm/build/projects/cross-project-tests/debuginfo-tests/llgdb-tests/Output/static-member.cpp.tmp.out
RUN: at line 3: /Users/dyung/src/git/llvm/cross-project-tests/debuginfo-tests/llgdb-tests/test_debuginfo.pl /Users/dyung/src/git/llvm/cross-project-tests/debuginfo-tests/llgdb-tests/static-member.cpp /Users/dyung/src/git/llvm/build/projects/cross-project-tests/debuginfo-tests/llgdb-tests/Output/static-member.cpp.tmp.out
+ /Users/dyung/src/git/llvm/cross-project-tests/debuginfo-tests/llgdb-tests/test_debuginfo.pl /Users/dyung/src/git/llvm/cross-project-tests/debuginfo-tests/llgdb-tests/static-member.cpp /Users/dyung/src/git/llvm/build/projects/cross-project-tests/debuginfo-tests/llgdb-tests/Output/static-member.cpp.tmp.out
/Users/dyung/src/git/llvm/cross-project-tests/debuginfo-tests/llgdb-tests/static-member.cpp:11:11: error: CHECK: expected string not found in input
// CHECK: static const int a;
          ^
/Users/dyung/src/git/llvm/build/projects/cross-project-tests/debuginfo-tests/llgdb-tests/Output/static-member.cpp.gdb.output:10:16: note: scanning from here
class MyClass {
               ^
/Users/dyung/src/git/llvm/build/projects/cross-project-tests/debuginfo-tests/llgdb-tests/Output/static-member.cpp.gdb.output:11:2: note: possible intended match here
 static const int a = 4;
 ^

Input file: /Users/dyung/src/git/llvm/build/projects/cross-project-tests/debuginfo-tests/llgdb-tests/Output/static-member.cpp.gdb.output
Check file: /Users/dyung/src/git/llvm/cross-project-tests/debuginfo-tests/llgdb-tests/static-member.cpp

-dump-input=help explains the following input dump.

Input was:
<<<<<<
            .
            .
            .
            5: > break static-member.cpp:33 
            6: SBBreakpoint: id = 1, file = 'static-member.cpp', line = 33, exact_match = 0, locations = 1 
            7: > r 
            8: success 
            9: > ptype MyClass 
           10: class MyClass { 
check:11'0                    X error: no match found
           11:  static const int a = 4; 
check:11'0     ~~~~~~~~~~~~~~~~~~~~~~~~~
check:11'1      ?                        possible intended match
           12:  static int b; 
check:11'0     ~~~~~~~~~~~~~~~
           13:  static int c; 
check:11'0     ~~~~~~~~~~~~~~~
           14: public: 
check:11'0     ~~~~~~~~
           15:  int d; 
check:11'0     ~~~~~~~~
           16: } 
check:11'0     ~~
            .
            .
            .
>>>>>>
```
This matches what my x86 MacOS buildbot seems to be hitting for this test https://lab.llvm.org/staging/#/builders/188/builds/307/steps/6/logs/FAIL__cross-project-tests__static-member_cpp.

The failing output for static-member-2.cpp also seems to match between my Apple Silicon and x86 machines, so I think it makes sense to extend the XFAIL to all `system-darwin` targets, and not just aarch64.