### PR TITLE
[NFC][NewGVN] Remove the initialization of the PredicateInfo from the constructor.

### DIFF
--- a/llvm/lib/Transforms/Scalar/NewGVN.cpp
+++ b/llvm/lib/Transforms/Scalar/NewGVN.cpp
@@ -658,7 +658,6 @@ public:
          TargetLibraryInfo *TLI, AliasAnalysis *AA, MemorySSA *MSSA,
          const DataLayout &DL)
       : F(F), DT(DT), TLI(TLI), AA(AA), MSSA(MSSA), AC(AC), DL(DL),
-        PredInfo(std::make_unique<PredicateInfo>(F, *DT, *AC)),
         SQ(DL, TLI, DT, AC, /*CtxI=*/nullptr, /*UseInstrInfo=*/false,
            /*CanUseUndef=*/false) {}
 
@@ -3426,6 +3425,7 @@ bool NewGVN::runGVN() {
     StartingVNCounter = DebugCounter::getCounterValue(VNCounter);
   bool Changed = false;
   NumFuncArgs = F.arg_size();
+  PredInfo = std::make_unique<PredicateInfo>(F, *DT, *AC);
   MSSAWalker = MSSA->getWalker();
   SingletonDeadExpression = new (ExpressionAllocator) DeadExpression();
 


### PR DESCRIPTION
The initialization of the PredicateInfo in the constructor might create problems during testing. For example, we might need to disable some functions by adding early returns in runGVN(). In this case, we will see a crash. This is due to the fact that the predicated code has already been emitted and it is not removed.