### PR TITLE
[lldb] Add ability to detect darwin host linker version to xfail tests

### DIFF
--- a/lldb/test/API/lang/c/tls_globals/TestTlsGlobals.py
+++ b/lldb/test/API/lang/c/tls_globals/TestTlsGlobals.py
@@ -40,6 +40,7 @@ class TlsGlobalTestCase(TestBase):
     @skipIfWindows
     @skipIf(oslist=["linux"], archs=["arm", "aarch64"])
     @skipIf(oslist=no_match([lldbplatformutil.getDarwinOSTriples(), "linux"]))
+    @expectedFailureIf(lldbplatformutil.xcode15LinkerBug())
     def test(self):
         """Test thread-local storage."""
         self.build()


### PR DESCRIPTION
When Apple released its new linker, it had a subtle bug that caused LLDB's TLS tests to fail. Unfortunately this means that TLS tests are not going to work on machines that have affected versions of the linker, so we should annotate the tests so that they only work when we are confident the linker has the required fix.

I'm not completely satisfied with this implementation. That being said, I believe that adding suport for linker versions in general is a non-trivial change that would require far more thought. There are a few challenges involved:
- LLDB's testing infra takes an argument to change the compiler, but there's no way to switch out the linker.
- There's no standard way to ask a compiler what linker it will use.
- There's no standard way to ask a linker what its version is. Many platforms have the same name for their linker (ld).
- Some platforms automatically switch out the linker underneath you. We do this for Windows tests (where we use LLD no matter what).

Given that this is affecting the tests on our CI, I think this is an acceptable solution in the interim.