### PR TITLE
[bzl] Remove obsolete `output_to_genfiles = True`

### DIFF
--- a/utils/bazel/llvm-project-overlay/llvm/enum_targets_gen.bzl
+++ b/utils/bazel/llvm-project-overlay/llvm/enum_targets_gen.bzl
@@ -64,7 +64,5 @@ enum_targets_gen = rule(
                   " `@LLVM_ENUM_{macro_name}S@`",
         ),
     },
-    # output_to_genfiles is required for header files.
-    output_to_genfiles = True,
     implementation = enum_targets_gen_impl,
 )

--- a/utils/bazel/llvm-project-overlay/mlir/tblgen.bzl
+++ b/utils/bazel/llvm-project-overlay/mlir/tblgen.bzl
@@ -181,8 +181,6 @@ def _gentbl_rule_impl(ctx):
 gentbl_rule = rule(
     _gentbl_rule_impl,
     doc = "Generates tabular code from a table definition file.",
-    # Match genrule behavior
-    output_to_genfiles = True,
     attrs = {
         "tblgen": attr.label(
             doc = "The TableGen executable with which to generate `out`.",


### PR DESCRIPTION
The [bazel docs](https://bazel.build/rules/lib/globals/bzl#rule) discourage setting this. The comments about being necessary for headers or genrules seem to be obsolete, at least for the LLVM tree itself.

The effect of this is that generated files will go to `bazel-bin` instead of `bazel-genfiles`.

One external use was fixed here: https://github.com/google/jax/commit/32bb3b06132b4256cd8674fb98bce057dc968610.