### PR TITLE
Disable clang-tidy misc-include-cleaner

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,4 +1,4 @@
-Checks: '-*,clang-diagnostic-*,llvm-*,misc-*,-misc-const-correctness,-misc-unused-parameters,-misc-non-private-member-variables-in-classes,-misc-no-recursion,-misc-use-anonymous-namespace,readability-identifier-naming'
+Checks: '-*,clang-diagnostic-*,llvm-*,misc-*,-misc-const-correctness,-misc-unused-parameters,-misc-non-private-member-variables-in-classes,-misc-no-recursion,-misc-use-anonymous-namespace,readability-identifier-naming,-misc-include-cleaner'
 CheckOptions:
   - key:             readability-identifier-naming.ClassCase
     value:           CamelCase


### PR DESCRIPTION
This does not apply well to LLVM which intentionally rely on forward declarations. Also depending on the config flags passed to CMake the result can be different.