### PR TITLE
[libcxx] Handle changing of fr_FR locale thousand sep in Windows libcxx tests

### DIFF
--- a/libcxx/test/std/localization/locale.categories/category.monetary/locale.money.get/locale.money.get.members/get_long_double_fr_FR.pass.cpp
+++ b/libcxx/test/std/localization/locale.categories/category.monetary/locale.money.get/locale.money.get.members/get_long_double_fr_FR.pass.cpp
@@ -54,7 +54,7 @@ public:
 };
 
 static std::wstring convert_thousands_sep(std::wstring const& in) {
-  return LocaleHelpers::convert_thousands_sep_fr_FR(in);
+  return LocaleHelpers::convert_mon_thousands_sep_fr_FR(in);
 }
 #endif // TEST_HAS_NO_WIDE_CHARACTERS
 

--- a/libcxx/test/std/localization/locale.categories/category.monetary/locale.money.put/locale.money.put.members/put_long_double_fr_FR.pass.cpp
+++ b/libcxx/test/std/localization/locale.categories/category.monetary/locale.money.put/locale.money.put.members/put_long_double_fr_FR.pass.cpp
@@ -54,7 +54,7 @@ public:
 };
 
 static std::wstring convert_thousands_sep(std::wstring const& in) {
-  return LocaleHelpers::convert_thousands_sep_fr_FR(in);
+  return LocaleHelpers::convert_mon_thousands_sep_fr_FR(in);
 }
 #endif // TEST_HAS_NO_WIDE_CHARACTERS
 

--- a/libcxx/test/std/localization/locale.categories/category.monetary/locale.moneypunct.byname/thousands_sep.pass.cpp
+++ b/libcxx/test/std/localization/locale.categories/category.monetary/locale.moneypunct.byname/thousands_sep.pass.cpp
@@ -29,6 +29,10 @@
 #include "test_macros.h"
 #include "platform_support.h" // locale name macros
 
+#if defined(_WIN32) && !defined(TEST_HAS_NO_WIDE_CHARACTERS)
+#include "locale_helpers.h"
+#endif
+
 class Fnf
     : public std::moneypunct_byname<char, false>
 {
@@ -115,7 +119,11 @@ int main(int, char**)
 #if defined(_CS_GNU_LIBC_VERSION)
     const wchar_t fr_sep = glibc_version_less_than("2.27") ? L' ' : L'\u202F';
 #elif defined(_WIN32)
-    const wchar_t fr_sep = L'\u00A0';
+    // Windows has changed it's fr thousands sep between releases.
+    // Fetch the host's separator in order to know what to expect from the test results.
+    const std::wstring fr_sep_s = LocaleHelpers::get_locale_mon_thousands_sep(LOCALE_fr_FR_UTF_8);
+    assert(fr_sep_s.size() == 1);
+    const wchar_t fr_sep = fr_sep_s[0];
 #elif defined(_AIX)
     const wchar_t fr_sep = L'\u202F';
 #else

--- a/libcxx/test/std/localization/locale.categories/category.monetary/locale.moneypunct.byname/thousands_sep.pass.cpp
+++ b/libcxx/test/std/localization/locale.categories/category.monetary/locale.moneypunct.byname/thousands_sep.pass.cpp
@@ -30,7 +30,7 @@
 #include "platform_support.h" // locale name macros
 
 #if defined(_WIN32) && !defined(TEST_HAS_NO_WIDE_CHARACTERS)
-#include "locale_helpers.h"
+#  include "locale_helpers.h"
 #endif
 
 class Fnf

--- a/libcxx/test/std/localization/locale.categories/facet.numpunct/locale.numpunct.byname/thousands_sep.pass.cpp
+++ b/libcxx/test/std/localization/locale.categories/facet.numpunct/locale.numpunct.byname/thousands_sep.pass.cpp
@@ -28,6 +28,10 @@
 #include "test_macros.h"
 #include "platform_support.h" // locale name macros
 
+#if defined(_WIN32) && !defined(TEST_HAS_NO_WIDE_CHARACTERS)
+#include "locale_helpers.h"
+#endif
+
 int main(int, char**)
 {
     {
@@ -78,7 +82,11 @@ int main(int, char**)
 #if defined(_CS_GNU_LIBC_VERSION)
             const wchar_t wsep = glibc_version_less_than("2.27") ? L' ' : L'\u202f';
 #elif defined(_WIN32)
-            const wchar_t wsep = L'\u00A0';
+            // Windows has changed it's fr thousands sep between releases.
+            // Fetch the host's separator in order to know what to expect from the test results.
+            const std::wstring wsep_s = LocaleHelpers::get_locale_mon_thousands_sep(LOCALE_fr_FR_UTF_8);
+            assert(wsep_s.size() == 1);
+            const wchar_t wsep = wsep_s[0];
 #else
             const wchar_t wsep = L',';
 #endif

--- a/libcxx/test/std/localization/locale.categories/facet.numpunct/locale.numpunct.byname/thousands_sep.pass.cpp
+++ b/libcxx/test/std/localization/locale.categories/facet.numpunct/locale.numpunct.byname/thousands_sep.pass.cpp
@@ -29,7 +29,7 @@
 #include "platform_support.h" // locale name macros
 
 #if defined(_WIN32) && !defined(TEST_HAS_NO_WIDE_CHARACTERS)
-#include "locale_helpers.h"
+#  include "locale_helpers.h"
 #endif
 
 int main(int, char**)
@@ -82,11 +82,11 @@ int main(int, char**)
 #if defined(_CS_GNU_LIBC_VERSION)
             const wchar_t wsep = glibc_version_less_than("2.27") ? L' ' : L'\u202f';
 #elif defined(_WIN32)
-            // Windows has changed it's fr thousands sep between releases.
-            // Fetch the host's separator in order to know what to expect from the test results.
-            const std::wstring wsep_s = LocaleHelpers::get_locale_mon_thousands_sep(LOCALE_fr_FR_UTF_8);
-            assert(wsep_s.size() == 1);
-            const wchar_t wsep = wsep_s[0];
+          // Windows has changed it's fr thousands sep between releases.
+          // Fetch the host's separator in order to know what to expect from the test results.
+          const std::wstring wsep_s = LocaleHelpers::get_locale_mon_thousands_sep(LOCALE_fr_FR_UTF_8);
+          assert(wsep_s.size() == 1);
+          const wchar_t wsep = wsep_s[0];
 #else
             const wchar_t wsep = L',';
 #endif

--- a/libcxx/test/std/time/time.duration/time.duration.nonmember/ostream.pass.cpp
+++ b/libcxx/test/std/time/time.duration/time.duration.nonmember/ostream.pass.cpp
@@ -37,7 +37,7 @@
 #include "test_macros.h"
 
 #if defined(_WIN32) && !defined(TEST_HAS_NO_WIDE_CHARACTERS)
-#include "locale_helpers.h"
+#  include "locale_helpers.h"
 #endif
 
 #define SV(S) MAKE_STRING_VIEW(CharT, S)
@@ -95,10 +95,14 @@ static void test_values() {
 #ifdef _WIN32
     std::wstring expected_sep = LocaleHelpers::get_locale_thousands_sep(LOCALE_fr_FR_UTF_8);
     assert(expected_sep.size() == 1);
-    assert(stream_fr_FR_locale<CharT>(-1'000'000s) == LocaleHelpers::convert_thousands_sep(L"-1 000 000s", expected_sep[0]));
-    assert(stream_fr_FR_locale<CharT>(1'000'000s) == LocaleHelpers::convert_thousands_sep(L"1 000 000s", expected_sep[0]));
-    assert(stream_fr_FR_locale<CharT>(-1'000.123456s) == LocaleHelpers::convert_thousands_sep(L"-1 000,1235s", expected_sep[0]));
-    assert(stream_fr_FR_locale<CharT>(1'000.123456s) == LocaleHelpers::convert_thousands_sep(L"1 000,1235s", expected_sep[0]));
+    assert(stream_fr_FR_locale<CharT>(-1'000'000s) ==
+           LocaleHelpers::convert_thousands_sep(L"-1 000 000s", expected_sep[0]));
+    assert(stream_fr_FR_locale<CharT>(1'000'000s) ==
+           LocaleHelpers::convert_thousands_sep(L"1 000 000s", expected_sep[0]));
+    assert(stream_fr_FR_locale<CharT>(-1'000.123456s) ==
+           LocaleHelpers::convert_thousands_sep(L"-1 000,1235s", expected_sep[0]));
+    assert(stream_fr_FR_locale<CharT>(1'000.123456s) ==
+           LocaleHelpers::convert_thousands_sep(L"1 000,1235s", expected_sep[0]));
 #elif defined(__APPLE__)
     assert(stream_fr_FR_locale<CharT>(-1'000'000s) == SV("-1000000s"));
     assert(stream_fr_FR_locale<CharT>(1'000'000s) == SV("1000000s"));

--- a/libcxx/test/std/time/time.duration/time.duration.nonmember/ostream.pass.cpp
+++ b/libcxx/test/std/time/time.duration/time.duration.nonmember/ostream.pass.cpp
@@ -36,6 +36,10 @@
 #include "platform_support.h" // locale name macros
 #include "test_macros.h"
 
+#if defined(_WIN32) && !defined(TEST_HAS_NO_WIDE_CHARACTERS)
+#include "locale_helpers.h"
+#endif
+
 #define SV(S) MAKE_STRING_VIEW(CharT, S)
 
 template <class CharT, class Rep, class Period>
@@ -89,10 +93,12 @@ static void test_values() {
 #endif
   } else {
 #ifdef _WIN32
-    assert(stream_fr_FR_locale<CharT>(-1'000'000s) == SV("-1\u00A0000\u00A0000s"));
-    assert(stream_fr_FR_locale<CharT>(1'000'000s) == SV("1\u00A0000\u00A0000s"));
-    assert(stream_fr_FR_locale<CharT>(-1'000.123456s) == SV("-1\u00A0000,1235s"));
-    assert(stream_fr_FR_locale<CharT>(1'000.123456s) == SV("1\u00A0000,1235s"));
+    std::wstring expected_sep = LocaleHelpers::get_locale_thousands_sep(LOCALE_fr_FR_UTF_8);
+    assert(expected_sep.size() == 1);
+    assert(stream_fr_FR_locale<CharT>(-1'000'000s) == LocaleHelpers::convert_thousands_sep(L"-1 000 000s", expected_sep[0]));
+    assert(stream_fr_FR_locale<CharT>(1'000'000s) == LocaleHelpers::convert_thousands_sep(L"1 000 000s", expected_sep[0]));
+    assert(stream_fr_FR_locale<CharT>(-1'000.123456s) == LocaleHelpers::convert_thousands_sep(L"-1 000,1235s", expected_sep[0]));
+    assert(stream_fr_FR_locale<CharT>(1'000.123456s) == LocaleHelpers::convert_thousands_sep(L"1 000,1235s", expected_sep[0]));
 #elif defined(__APPLE__)
     assert(stream_fr_FR_locale<CharT>(-1'000'000s) == SV("-1000000s"));
     assert(stream_fr_FR_locale<CharT>(1'000'000s) == SV("1000000s"));

--- a/libcxx/test/support/locale_helpers.h
+++ b/libcxx/test/support/locale_helpers.h
@@ -41,7 +41,7 @@ std::wstring convert_thousands_sep(std::wstring const& in, wchar_t sep) {
   return out;
 }
 
-#if defined(_WIN32)
+#  if defined(_WIN32)
 // This implementation is similar to the locale_guard in the private libcxx implementation headers
 // but exists here for usability from the libcxx/test/std conformance test suites.
 class LocaleGuard {
@@ -118,14 +118,14 @@ std::wstring get_locale_mon_thousands_sep(const char* locale) {
 std::wstring get_locale_thousands_sep(const char* locale) {
   return get_locale_lconv_cstr_member(locale, &lconv::thousands_sep);
 }
-#endif // _WIN32
+#  endif // _WIN32
 
 // GLIBC 2.27 and newer use U+202F NARROW NO-BREAK SPACE as a thousands separator.
 // This function converts the spaces in string inputs to U+202F if need
 // be. FreeBSD's locale data also uses U+202F, since 2018.
 // Windows may use U+00A0 NO-BREAK SPACE or U+0202F NARROW NO-BREAK SPACE.
 std::wstring convert_mon_thousands_sep_fr_FR(std::wstring const& in) {
-#if defined(_CS_GNU_LIBC_VERSION)
+#  if defined(_CS_GNU_LIBC_VERSION)
   if (glibc_version_less_than("2.27"))
     return in;
   else


### PR DESCRIPTION
libcxx tests which assume the thousands separator for fr_FR locale is x00A0 on Windows currently fail when run on newer versions of Windows (It seems to have been updated to the new correct value of 0x202F around windows 11. The exact windows version where it changed doesn't seem to be documented anywhere). 

This PR updates the tests to not hard-code the separator but instead find the host's fr_FR separator to set the right expectation in the tests that assume this. It uses 2 new functions in test/support/locale_helpers.h to do this: `get_locale_thousands_sep` and `get_locale_mon_thousands_sep`.

This fixes 5 tests under windows.

-----

Testing notes:

Tested with toolsets:
- windows llvm-mingw-20231128-ucrt-x86_64  (note, msvcrt has dozens of pre-existing locale failures). 
- msvc 2022

For both toolsets above I see the 5 tests passing now, whereas they were failing previously (and no new failures in overall check-cxx).

- Also ran check-cxx tests with C++03 on the above windows toolsets.


Individual test commands:
```
python ./bin/llvm-lit.py --filter std/localization/locale.categories/category.monetary/locale.moneypunct.byname/thousands_sep.pass.cpp libcxx/test -v -a

python ./bin/llvm-lit.py --filter std/localization/locale.categories/facet.numpunct/locale.numpunct.byname/thousands_sep.pass.cpp libcxx/test -v -a

python ./bin/llvm-lit.py --filter std/time/time.duration/time.duration.nonmember/ostream.pass.cpp libcxx/test -v -a

python ./bin/llvm-lit.py --filter std/localization/locale.categories/category.monetary/locale.money.get/locale.money.get.members/get_long_double_fr_FR.pass.cpp libcxx/test -v -a

python ./bin/llvm-lit.py --filter std/localization/locale.categories/category.monetary/locale.money.put/locale.money.put.members/put_long_double_fr_FR.pass.cpp libcxx/test -v -a
```