### PR TITLE
[analyzer][NFC] Make CheckerDocumentation checker in-sync with actual checker callbacks

### DIFF
--- a/clang/include/clang/StaticAnalyzer/Checkers/Checkers.td
+++ b/clang/include/clang/StaticAnalyzer/Checkers/Checkers.td
@@ -1654,6 +1654,10 @@ def StdCLibraryFunctionsTesterChecker : Checker<"StdCLibraryFunctionsTester">,
   WeakDependencies<[StdCLibraryFunctionsChecker]>,
   Documentation<NotDocumented>;
 
+def CheckerDocumentationChecker : Checker<"CheckerDocumentation">,
+  HelpText<"Defines an empty checker callback for all possible handlers.">,
+  Documentation<NotDocumented>;
+
 } // end "debug"
 
 

--- a/clang/lib/StaticAnalyzer/Checkers/CheckerDocumentation.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/CheckerDocumentation.cpp
@@ -137,10 +137,7 @@ public:
   /// (2) and (3). Post-call for the allocator is called after step (1).
   /// Pre-statement for the new-expression is called on step (4) when the value
   /// of the expression is evaluated.
-  /// \param NE     The C++ new-expression that triggered the allocation.
-  /// \param Target The allocated region, casted to the class type.
-  void checkNewAllocator(const CXXNewExpr *NE, SVal Target,
-                         CheckerContext &) const {}
+  void checkNewAllocator(const CXXAllocatorCall &, CheckerContext &) const {}
 
   /// Called on a load from and a store to a location.
   ///
@@ -328,6 +325,14 @@ public:
 
 void CheckerDocumentation::checkPostStmt(const DeclStmt *DS,
                                          CheckerContext &C) const {
+}
+
+void registerCheckerDocumentationChecker(CheckerManager &Mgr) {
+  Mgr.registerChecker<CheckerDocumentation>();
+}
+
+bool shouldRegisterCheckerDocumentationChecker(const CheckerManager &) {
+  return false;
 }
 
 } // end namespace ento


### PR DESCRIPTION
In PR #83677 I was surprised to see that outdated checker callback signatures are a problem. It turns out, we need the `registerChecker...` function to invoke the `Mgr.registerChecker<>()` which would instantiate the `_register` calls, that would take the address of the defined checker callbacks. Consequently, if the expected signatures mismatch, it won't compile from now on, so we have static guarantee that this issue never pops up again.

Given we need the `register` call, at this point we could just hook this checker into the `debug` package and make it never registered. It shouldn't hurt anyone :)