### PR TITLE
[libomptarget] Support BE ELF files in plugins-nextgen

### DIFF
--- a/openmp/libomptarget/plugins-nextgen/common/include/GlobalHandler.h
+++ b/openmp/libomptarget/plugins-nextgen/common/include/GlobalHandler.h
@@ -103,9 +103,6 @@ class GenericGlobalHandlerTy {
 public:
   virtual ~GenericGlobalHandlerTy() {}
 
-  /// Helper function for getting an ELF from a device image.
-  Expected<ELF64LEObjectFile> getELFObjectFile(DeviceImageTy &Image);
-
   /// Returns whether the symbol named \p SymName is present in the given \p
   /// Image.
   bool isSymbolInImage(GenericDeviceTy &Device, DeviceImageTy &Image,

--- a/openmp/libomptarget/plugins-nextgen/common/include/Utils/ELF.h
+++ b/openmp/libomptarget/plugins-nextgen/common/include/Utils/ELF.h
@@ -27,18 +27,14 @@ bool isELF(llvm::StringRef Buffer);
 /// Checks if the given \p Object is a valid ELF matching the e_machine value.
 llvm::Expected<bool> checkMachine(llvm::StringRef Object, uint16_t EMachine);
 
-/// Returns a pointer to the given \p Symbol inside of an ELF object.
-llvm::Expected<const void *> getSymbolAddress(
-    const llvm::object::ELFObjectFile<llvm::object::ELF64LE> &ELFObj,
-    const llvm::object::ELF64LE::Sym &Symbol);
-
-/// Returns the symbol associated with the \p Name in the \p ELFObj. It will
+/// Returns the symbol associated with the \p Name in the \p Obj. It will
 /// first search for the hash sections to identify symbols from the hash table.
 /// If that fails it will fall back to a linear search in the case of an
-/// executable file without a hash table.
-llvm::Expected<const typename llvm::object::ELF64LE::Sym *>
-getSymbol(const llvm::object::ELFObjectFile<llvm::object::ELF64LE> &ELFObj,
-          llvm::StringRef Name);
+/// executable file without a hash table.  If the symbol is found, it returns
+/// a StringRef covering the symbol's data in the Obj buffer, based on its
+/// address and size; otherwise, it returns std::nullopt.
+llvm::Expected<std::optional<llvm::StringRef>>
+findSymbolInImage(const llvm::StringRef Obj, llvm::StringRef Name);
 
 } // namespace elf
 } // namespace utils

--- a/openmp/libomptarget/plugins-nextgen/common/src/GlobalHandler.cpp
+++ b/openmp/libomptarget/plugins-nextgen/common/src/GlobalHandler.cpp
@@ -25,16 +25,6 @@ using namespace omp;
 using namespace target;
 using namespace plugin;
 
-Expected<ELF64LEObjectFile>
-GenericGlobalHandlerTy::getELFObjectFile(DeviceImageTy &Image) {
-  assert(utils::elf::isELF(Image.getMemoryBuffer().getBuffer()) &&
-         "Input is not an ELF file");
-
-  Expected<ELF64LEObjectFile> ElfOrErr =
-      ELF64LEObjectFile::create(Image.getMemoryBuffer());
-  return ElfOrErr;
-}
-
 Error GenericGlobalHandlerTy::moveGlobalBetweenDeviceAndHost(
     GenericDeviceTy &Device, DeviceImageTy &Image, const GlobalTy &HostGlobal,
     bool Device2Host) {
@@ -81,55 +71,37 @@ Error GenericGlobalHandlerTy::moveGlobalBetweenDeviceAndHost(
 bool GenericGlobalHandlerTy::isSymbolInImage(GenericDeviceTy &Device,
                                              DeviceImageTy &Image,
                                              StringRef SymName) {
-  // Get the ELF object file for the image. Notice the ELF object may already
-  // be created in previous calls, so we can reuse it. If this is unsuccessful
-  // just return false as we couldn't find it.
-  auto ELFObjOrErr = getELFObjectFile(Image);
-  if (!ELFObjOrErr) {
-    consumeError(ELFObjOrErr.takeError());
-    return false;
-  }
 
   // Search the ELF symbol using the symbol name.
-  auto SymOrErr = utils::elf::getSymbol(*ELFObjOrErr, SymName);
+  auto SymOrErr = utils::elf::findSymbolInImage(
+      Image.getMemoryBuffer().getBuffer(), SymName);
   if (!SymOrErr) {
     consumeError(SymOrErr.takeError());
     return false;
   }
 
-  return *SymOrErr;
+  return SymOrErr->has_value();
 }
 
 Error GenericGlobalHandlerTy::getGlobalMetadataFromImage(
     GenericDeviceTy &Device, DeviceImageTy &Image, GlobalTy &ImageGlobal) {
 
-  // Get the ELF object file for the image. Notice the ELF object may already
-  // be created in previous calls, so we can reuse it.
-  auto ELFObj = getELFObjectFile(Image);
-  if (!ELFObj)
-    return ELFObj.takeError();
-
   // Search the ELF symbol using the symbol name.
-  auto SymOrErr = utils::elf::getSymbol(*ELFObj, ImageGlobal.getName());
+  auto SymOrErr = utils::elf::findSymbolInImage(
+      Image.getMemoryBuffer().getBuffer(), ImageGlobal.getName());
   if (!SymOrErr)
     return Plugin::error("Failed ELF lookup of global '%s': %s",
                          ImageGlobal.getName().data(),
                          toString(SymOrErr.takeError()).data());
 
-  if (!*SymOrErr)
+  if (!SymOrErr->has_value())
     return Plugin::error("Failed to find global symbol '%s' in the ELF image",
                          ImageGlobal.getName().data());
 
-  auto AddrOrErr = utils::elf::getSymbolAddress(*ELFObj, **SymOrErr);
-  // Get the section to which the symbol belongs.
-  if (!AddrOrErr)
-    return Plugin::error("Failed to get ELF symbol from global '%s': %s",
-                         ImageGlobal.getName().data(),
-                         toString(AddrOrErr.takeError()).data());
-
   // Setup the global symbol's address and size.
-  ImageGlobal.setPtr(const_cast<void *>(*AddrOrErr));
-  ImageGlobal.setSize((*SymOrErr)->st_size);
+  auto Symbol = **SymOrErr;
+  ImageGlobal.setPtr(static_cast<void *>(const_cast<char *>(Symbol.data())));
+  ImageGlobal.setSize(Symbol.size());
 
   return Plugin::success();
 }


### PR DESCRIPTION
Code in plugins-nextgen reading ELF files is currently hard-coded to assume a 64-bit little-endian ELF format.  Unfortunately, this assumption is even embedded in the interface between GlobalHandler and Utils/ELF routines, which use ELF64LE types.

To fix this, I've refactored the interface to push all ELF specific types into Utils/ELF.  Specifically, this patch removes both the getSymbol and getSymbolAddress routines and replaces them with a single findSymbolInImage, which gets a MemoryBufferRef identifying the raw object file image as input, and returns a StringRef covering the data addressed by the symbol (address and size) if found, or an empty StringRef otherwise.

This allows properly templating over multiple ELF format variants inside Utils/ELF; specifically, this patch adds support for 64-bit big-endian ELF files in addition to 64-bit little-endian files.