### PR TITLE
[clang-tidy] fix false negative in cppcoreguidelines-missing-std-forward

### DIFF
--- a/clang-tools-extra/clang-tidy/cppcoreguidelines/MissingStdForwardCheck.cpp
+++ b/clang-tools-extra/clang-tidy/cppcoreguidelines/MissingStdForwardCheck.cpp
@@ -112,10 +112,12 @@ void MissingStdForwardCheck::registerMatchers(MatchFinder *Finder) {
 
   auto ForwardCallMatcher = callExpr(
       callExpr().bind("call"), argumentCountIs(1),
-      hasArgument(
-          0, declRefExpr(to(
-                 varDecl(optionally(equalsBoundNode("param"))).bind("var")))),
-      forCallable(anyOf(equalsBoundNode("func"), CapturedInLambda)),
+      hasArgument(0, declRefExpr(to(varDecl().bind("var")))),
+      forCallable(
+          anyOf(allOf(equalsBoundNode("func"),
+                      functionDecl(hasAnyParameter(parmVarDecl(allOf(
+                          equalsBoundNode("param"), equalsBoundNode("var")))))),
+                CapturedInLambda)),
       callee(unresolvedLookupExpr(hasAnyDeclaration(
           namedDecl(hasUnderlyingDecl(hasName("::std::forward")))))),
 

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -156,7 +156,8 @@ Changes in existing checks
 
 - Improved :doc:`cppcoreguidelines-missing-std-forward
   <clang-tidy/checks/cppcoreguidelines/missing-std-forward>` check by no longer
-  giving false positives for deleted functions.
+  giving false positives for deleted functions and fix false negative when some
+  parameters are forwarded, but other aren't.
 
 - Cleaned up :doc:`cppcoreguidelines-prefer-member-initializer
   <clang-tidy/checks/cppcoreguidelines/prefer-member-initializer>`

--- a/clang-tools-extra/test/clang-tidy/checkers/cppcoreguidelines/missing-std-forward.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/cppcoreguidelines/missing-std-forward.cpp
@@ -95,6 +95,16 @@ void lambda_value_capture_copy(T&& t) {
   [&,t]() { T other = std::forward<T>(t); };
 }
 
+template <typename X>
+void use(const X &x) {}
+
+template <typename X, typename Y>
+void foo(X &&x, Y &&y) {
+  // CHECK-MESSAGES: :[[@LINE-1]]:21: warning: forwarding reference parameter 'y' is never forwarded inside the function body [cppcoreguidelines-missing-std-forward]
+    use(std::forward<X>(x));
+    use(y);
+}
+
 } // namespace positive_cases
 
 namespace negative_cases {


### PR DESCRIPTION
Try to fix https://github.com/llvm/llvm-project/issues/83845
When `std::forward` is invoked in a function, make sure it uses correct parameter by checking if the bounded `var` equals the parameter.