### PR TITLE
[MLIR] Add llvm (debug) attributes to CAPI

### DIFF
--- a/mlir/include/mlir-c/BuiltinAttributes.h
+++ b/mlir/include/mlir-c/BuiltinAttributes.h
@@ -266,6 +266,10 @@ mlirSymbolRefAttrGetNestedReference(MlirAttribute attr, intptr_t pos);
 /// Returns the typeID of an SymbolRef attribute.
 MLIR_CAPI_EXPORTED MlirTypeID mlirSymbolRefAttrGetTypeID(void);
 
+/// Creates a DisctinctAttr with the referenced attribute.
+MLIR_CAPI_EXPORTED MlirAttribute
+mlirDisctinctAttrCreate(MlirAttribute referencedAttr);
+
 //===----------------------------------------------------------------------===//
 // Flat SymbolRef attribute.
 //===----------------------------------------------------------------------===//

--- a/mlir/include/mlir-c/Dialect/LLVM.h
+++ b/mlir/include/mlir-c/Dialect/LLVM.h
@@ -11,6 +11,7 @@
 #define MLIR_C_DIALECT_LLVM_H
 
 #include "mlir-c/IR.h"
+#include "mlir-c/Support.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -97,6 +98,236 @@ MLIR_CAPI_EXPORTED MlirType mlirLLVMStructTypeOpaqueGet(MlirContext ctx,
 MLIR_CAPI_EXPORTED MlirLogicalResult
 mlirLLVMStructTypeSetBody(MlirType structType, intptr_t nFieldTypes,
                           MlirType const *fieldTypes, bool isPacked);
+
+enum MlirLLVMCConv {
+  MlirLLVMCConvC = 0,
+  MlirLLVMCConvFast = 8,
+  MlirLLVMCConvCold = 9,
+  MlirLLVMCConvGHC = 10,
+  MlirLLVMCConvHiPE = 11,
+  MlirLLVMCConvAnyReg = 13,
+  MlirLLVMCConvPreserveMost = 14,
+  MlirLLVMCConvPreserveAll = 15,
+  MlirLLVMCConvSwift = 16,
+  MlirLLVMCConvCXX_FAST_TLS = 17,
+  MlirLLVMCConvTail = 18,
+  MlirLLVMCConvCFGuard_Check = 19,
+  MlirLLVMCConvSwiftTail = 20,
+  MlirLLVMCConvX86_StdCall = 64,
+  MlirLLVMCConvX86_FastCall = 65,
+  MlirLLVMCConvARM_APCS = 66,
+  MlirLLVMCConvARM_AAPCS = 67,
+  MlirLLVMCConvARM_AAPCS_VFP = 68,
+  MlirLLVMCConvMSP430_INTR = 69,
+  MlirLLVMCConvX86_ThisCall = 70,
+  MlirLLVMCConvPTX_Kernel = 71,
+  MlirLLVMCConvPTX_Device = 72,
+  MlirLLVMCConvSPIR_FUNC = 75,
+  MlirLLVMCConvSPIR_KERNEL = 76,
+  MlirLLVMCConvIntel_OCL_BI = 77,
+  MlirLLVMCConvX86_64_SysV = 78,
+  MlirLLVMCConvWin64 = 79,
+  MlirLLVMCConvX86_VectorCall = 80,
+  MlirLLVMCConvDUMMY_HHVM = 81,
+  MlirLLVMCConvDUMMY_HHVM_C = 82,
+  MlirLLVMCConvX86_INTR = 83,
+  MlirLLVMCConvAVR_INTR = 84,
+  MlirLLVMCConvAVR_BUILTIN = 86,
+  MlirLLVMCConvAMDGPU_VS = 87,
+  MlirLLVMCConvAMDGPU_GS = 88,
+  MlirLLVMCConvAMDGPU_CS = 90,
+  MlirLLVMCConvAMDGPU_KERNEL = 91,
+  MlirLLVMCConvX86_RegCall = 92,
+  MlirLLVMCConvAMDGPU_HS = 93,
+  MlirLLVMCConvMSP430_BUILTIN = 94,
+  MlirLLVMCConvAMDGPU_LS = 95,
+  MlirLLVMCConvAMDGPU_ES = 96,
+  MlirLLVMCConvAArch64_VectorCall = 97,
+  MlirLLVMCConvAArch64_SVE_VectorCall = 98,
+  MlirLLVMCConvWASM_EmscriptenInvoke = 99,
+  MlirLLVMCConvAMDGPU_Gfx = 100,
+  MlirLLVMCConvM68k_INTR = 101,
+};
+typedef enum MlirLLVMCConv MlirLLVMCConv;
+
+/// Creates a LLVM CConv attribute.
+MLIR_CAPI_EXPORTED MlirAttribute mlirLLVMCConvAttrGet(MlirContext ctx,
+                                                      MlirLLVMCConv cconv);
+
+enum MlirLLVMComdat {
+  MlirLLVMComdatAny = 0,
+  MlirLLVMComdatExactMatch = 1,
+  MlirLLVMComdatLargest = 2,
+  MlirLLVMComdatNoDeduplicate = 3,
+  MlirLLVMComdatSameSize = 4,
+};
+typedef enum MlirLLVMComdat MlirLLVMComdat;
+
+/// Creates a LLVM Comdat attribute.
+MLIR_CAPI_EXPORTED MlirAttribute mlirLLVMComdatAttrGet(MlirContext ctx,
+                                                       MlirLLVMComdat comdat);
+
+enum MlirLLVMLinkage {
+  MlirLLVMLinkagePrivate = 0,
+  MlirLLVMLinkageInternal = 1,
+  MlirLLVMLinkageAvailableExternally = 2,
+  MlirLLVMLinkageLinkonce = 3,
+  MlirLLVMLinkageWeak = 4,
+  MlirLLVMLinkageCommon = 5,
+  MlirLLVMLinkageAppending = 6,
+  MlirLLVMLinkageExternWeak = 7,
+  MlirLLVMLinkageLinkonceODR = 8,
+  MlirLLVMLinkageWeakODR = 9,
+  MlirLLVMLinkageExternal = 10,
+};
+typedef enum MlirLLVMLinkage MlirLLVMLinkage;
+
+/// Creates a LLVM Linkage attribute.
+MLIR_CAPI_EXPORTED MlirAttribute
+mlirLLVMLinkageAttrGet(MlirContext ctx, MlirLLVMLinkage linkage);
+
+/// Creates a LLVM DINullType attribute.
+MLIR_CAPI_EXPORTED MlirAttribute mlirLLVMDINullTypeAttrGet(MlirContext ctx);
+
+/// Creates a LLVM DIExpressionElem attribute.
+MLIR_CAPI_EXPORTED MlirAttribute
+mlirLLVMDIExpressionElemAttrGet(MlirContext ctx, unsigned int opcode,
+                                intptr_t nArguments, uint64_t const *arguments);
+
+/// Creates a LLVM DIExpression attribute.
+MLIR_CAPI_EXPORTED MlirAttribute mlirLLVMDIExpressionAttrGet(
+    MlirContext ctx, intptr_t nOperations, MlirAttribute const *operations);
+
+enum MlirLLVMTypeEncoding {
+  MlirLLVMTypeEncodingAddress = 0x1,
+  MlirLLVMTypeEncodingBoolean = 0x2,
+  MlirLLVMTypeEncodingComplexFloat = 0x31,
+  MlirLLVMTypeEncodingFloatT = 0x4,
+  MlirLLVMTypeEncodingSigned = 0x5,
+  MlirLLVMTypeEncodingSignedChar = 0x6,
+  MlirLLVMTypeEncodingUnsigned = 0x7,
+  MlirLLVMTypeEncodingUnsignedChar = 0x08,
+  MlirLLVMTypeEncodingImaginaryFloat = 0x09,
+  MlirLLVMTypeEncodingPackedDecimal = 0x0a,
+  MlirLLVMTypeEncodingNumericString = 0x0b,
+  MlirLLVMTypeEncodingEdited = 0x0c,
+  MlirLLVMTypeEncodingSignedFixed = 0x0d,
+  MlirLLVMTypeEncodingUnsignedFixed = 0x0e,
+  MlirLLVMTypeEncodingDecimalFloat = 0x0f,
+  MlirLLVMTypeEncodingUTF = 0x10,
+  MlirLLVMTypeEncodingUCS = 0x11,
+  MlirLLVMTypeEncodingASCII = 0x12,
+  MlirLLVMTypeEncodingLoUser = 0x80,
+  MlirLLVMTypeEncodingHiUser = 0xff,
+};
+typedef enum MlirLLVMTypeEncoding MlirLLVMTypeEncoding;
+
+/// Creates a LLVM DIBasicType attribute.
+MLIR_CAPI_EXPORTED MlirAttribute mlirLLVMDIBasicTypeAttrGet(
+    MlirContext ctx, unsigned int tag, MlirAttribute name, uint64_t sizeInBits,
+    MlirLLVMTypeEncoding encoding);
+
+/// Creates a LLVM DICompositeType attribute.
+MLIR_CAPI_EXPORTED MlirAttribute mlirLLVMDICompositeTypeAttrGet(
+    MlirContext ctx, unsigned int tag, MlirAttribute name, MlirAttribute file,
+    uint32_t line, MlirAttribute scope, MlirAttribute baseType, int64_t flags,
+    uint64_t sizeInBits, uint64_t alignInBits, intptr_t nElements,
+    MlirAttribute const *elements);
+
+/// Creates a LLVM DIDerivedType attribute.
+MLIR_CAPI_EXPORTED MlirAttribute mlirLLVMDIDerivedTypeAttrGet(
+    MlirContext ctx, unsigned int tag, MlirAttribute name,
+    MlirAttribute baseType, uint64_t sizeInBits, uint32_t alignInBits,
+    uint64_t offsetInBits);
+
+/// Gets the base type from a LLVM DIDerivedType attribute.
+MLIR_CAPI_EXPORTED MlirAttribute
+mlirLLVMDIDerivedTypeAttrGetBaseType(MlirAttribute diDerivedType);
+
+/// Creates a LLVM DIFileAttr attribute.
+MLIR_CAPI_EXPORTED MlirAttribute mlirLLVMDIFileAttrGet(MlirContext ctx,
+                                                       MlirAttribute name,
+                                                       MlirAttribute directory);
+
+enum MlirLLVMDIEmissionKind {
+  MlirLLVMDIEmissionKindNone = 0,
+  MlirLLVMDIEmissionKindFull = 1,
+  MlirLLVMDIEmissionKindLineTablesOnly = 2,
+  MlirLLVMDIEmissionKindDebugDirectivesOnly = 3,
+};
+typedef enum MlirLLVMDIEmissionKind MlirLLVMDIEmissionKind;
+
+/// Creates a LLVM DICompileUnit attribute.
+MLIR_CAPI_EXPORTED MlirAttribute mlirLLVMDICompileUnitAttrGet(
+    MlirContext ctx, MlirAttribute id, unsigned int sourceLanguage,
+    MlirAttribute file, MlirAttribute producer, bool isOptimized,
+    MlirLLVMDIEmissionKind emissionKind);
+
+/// Creates a LLVM DIFlags attribute.
+MLIR_CAPI_EXPORTED MlirAttribute mlirLLVMDIFlagsAttrGet(MlirContext ctx,
+                                                        uint64_t value);
+
+/// Creates a LLVM DILexicalBlock attribute.
+MLIR_CAPI_EXPORTED MlirAttribute mlirLLVMDILexicalBlockAttrGet(
+    MlirContext ctx, MlirAttribute scope, MlirAttribute file, unsigned int line,
+    unsigned int column);
+
+/// Creates a LLVM DILexicalBlockFile attribute.
+MLIR_CAPI_EXPORTED MlirAttribute mlirLLVMDILexicalBlockFileAttrGet(
+    MlirContext ctx, MlirAttribute scope, MlirAttribute file,
+    unsigned int discriminator);
+
+/// Creates a LLVM DILocalVariableAttr attribute.
+MLIR_CAPI_EXPORTED MlirAttribute mlirLLVMDILocalVariableAttrGet(
+    MlirContext ctx, MlirAttribute scope, MlirAttribute name,
+    MlirAttribute diFile, unsigned int line, unsigned int arg,
+    unsigned int alignInBits, MlirAttribute diType);
+
+/// Creates a LLVM DISubprogramAttr attribute.
+MLIR_CAPI_EXPORTED MlirAttribute mlirLLVMDISubprogramAttrGet(
+    MlirContext ctx, MlirAttribute id, MlirAttribute compileUnit,
+    MlirAttribute scope, MlirAttribute name, MlirAttribute linkageName,
+    MlirAttribute file, unsigned int line, unsigned int scopeLine,
+    uint64_t subprogramFlags, MlirAttribute type);
+
+/// Gets the scope from this DISubprogramAttr.
+MLIR_CAPI_EXPORTED MlirAttribute
+mlirLLVMDISubprogramAttrGetScope(MlirAttribute diSubprogram);
+
+/// Gets the line from this DISubprogramAttr.
+MLIR_CAPI_EXPORTED unsigned int
+mlirLLVMDISubprogramAttrGetLine(MlirAttribute diSubprogram);
+
+/// Gets the scope line from this DISubprogram.
+MLIR_CAPI_EXPORTED unsigned int
+mlirLLVMDISubprogramAttrGetScopeLine(MlirAttribute diSubprogram);
+
+/// Gets the compile unit from this DISubprogram.
+MLIR_CAPI_EXPORTED MlirAttribute
+mlirLLVMDISubprogramAttrGetCompileUnit(MlirAttribute diSubprogram);
+
+/// Gets the file from this DISubprogramAttr.
+MLIR_CAPI_EXPORTED MlirAttribute
+mlirLLVMDISubprogramAttrGetFile(MlirAttribute diSubprogram);
+
+/// Gets the type from this DISubprogramAttr.
+MLIR_CAPI_EXPORTED MlirAttribute
+mlirLLVMDISubprogramAttrGetType(MlirAttribute diSubprogram);
+
+/// Creates a LLVM DISubroutineTypeAttr attribute.
+MLIR_CAPI_EXPORTED MlirAttribute
+mlirLLVMDISubroutineTypeAttrGet(MlirContext ctx, unsigned int callingConvention,
+                                intptr_t nTypes, MlirAttribute const *types);
+
+/// Creates a LLVM DIModuleAttr attribute.
+MLIR_CAPI_EXPORTED MlirAttribute mlirLLVMDIModuleAttrGet(
+    MlirContext ctx, MlirAttribute file, MlirAttribute scope,
+    MlirAttribute name, MlirAttribute configMacros, MlirAttribute includePath,
+    MlirAttribute apinotes, unsigned int line, bool isDecl);
+
+/// Gets the scope of this DIModuleAttr.
+MLIR_CAPI_EXPORTED MlirAttribute
+mlirLLVMDIModuleAttrGetScope(MlirAttribute diModule);
 
 #ifdef __cplusplus
 }

--- a/mlir/lib/CAPI/Dialect/LLVM.cpp
+++ b/mlir/lib/CAPI/Dialect/LLVM.cpp
@@ -7,9 +7,16 @@
 //===----------------------------------------------------------------------===//
 
 #include "mlir-c/Dialect/LLVM.h"
+#include "mlir-c/IR.h"
+#include "mlir-c/Support.h"
 #include "mlir/CAPI/Registration.h"
+#include "mlir/CAPI/Wrap.h"
+#include "mlir/Dialect/LLVMIR/LLVMAttrs.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/Dialect/LLVMIR/LLVMTypes.h"
+#include "llvm-c/Core.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/SmallVectorExtras.h"
 
 using namespace mlir;
 using namespace mlir::LLVM;
@@ -109,4 +116,204 @@ MlirLogicalResult mlirLLVMStructTypeSetBody(MlirType structType,
   return wrap(
       cast<LLVM::LLVMStructType>(unwrap(structType))
           .setBody(unwrapList(nFieldTypes, fieldTypes, fields), isPacked));
+}
+
+MlirAttribute mlirLLVMDIExpressionElemAttrGet(MlirContext ctx,
+                                              unsigned int opcode,
+                                              intptr_t nArguments,
+                                              uint64_t const *arguments) {
+  auto list = ArrayRef<uint64_t>(arguments, nArguments);
+  return wrap(DIExpressionElemAttr::get(unwrap(ctx), opcode, list));
+}
+
+MlirAttribute mlirLLVMDIExpressionAttrGet(MlirContext ctx, intptr_t nOperations,
+                                          MlirAttribute const *operations) {
+  SmallVector<Attribute> attrStorage;
+  attrStorage.reserve(nOperations);
+
+  return wrap(DIExpressionAttr::get(
+      unwrap(ctx),
+      llvm::map_to_vector(
+          unwrapList(nOperations, operations, attrStorage),
+          [](Attribute a) { return a.cast<DIExpressionElemAttr>(); })));
+}
+
+MlirAttribute mlirLLVMDINullTypeAttrGet(MlirContext ctx) {
+  return wrap(DINullTypeAttr::get(unwrap(ctx)));
+}
+
+MlirAttribute mlirLLVMDIBasicTypeAttrGet(MlirContext ctx, unsigned int tag,
+                                         MlirAttribute name,
+                                         uint64_t sizeInBits,
+                                         MlirLLVMTypeEncoding encoding) {
+
+  return wrap(DIBasicTypeAttr::get(
+      unwrap(ctx), tag, cast<StringAttr>(unwrap(name)), sizeInBits, encoding));
+}
+
+MlirAttribute mlirLLVMDICompositeTypeAttrGet(
+    MlirContext ctx, unsigned int tag, MlirAttribute name, MlirAttribute file,
+    uint32_t line, MlirAttribute scope, MlirAttribute baseType, int64_t flags,
+    uint64_t sizeInBits, uint64_t alignInBits, intptr_t nElements,
+    MlirAttribute const *elements) {
+  SmallVector<Attribute> elementsStorage;
+  elementsStorage.reserve(nElements);
+
+  return wrap(DICompositeTypeAttr::get(
+      unwrap(ctx), tag, cast<StringAttr>(unwrap(name)),
+      cast<DIFileAttr>(unwrap(file)), line, cast<DIScopeAttr>(unwrap(scope)),
+      cast<DITypeAttr>(unwrap(baseType)), DIFlags(flags), sizeInBits,
+      alignInBits,
+      llvm::map_to_vector(unwrapList(nElements, elements, elementsStorage),
+                          [](Attribute a) { return a.cast<DINodeAttr>(); })));
+}
+
+MlirAttribute mlirLLVMDIDerivedTypeAttrGet(MlirContext ctx, unsigned int tag,
+                                           MlirAttribute name,
+                                           MlirAttribute baseType,
+                                           uint64_t sizeInBits,
+                                           uint32_t alignInBits,
+                                           uint64_t offsetInBits) {
+  return wrap(DIDerivedTypeAttr::get(unwrap(ctx), tag,
+                                     cast<StringAttr>(unwrap(name)),
+                                     cast<DITypeAttr>(unwrap(baseType)),
+                                     sizeInBits, alignInBits, offsetInBits));
+}
+
+MlirAttribute
+mlirLLVMDIDerivedTypeAttrGetBaseType(MlirAttribute diDerivedType) {
+  return wrap(cast<DIDerivedTypeAttr>(unwrap(diDerivedType)).getBaseType());
+}
+
+MlirAttribute mlirLLVMCConvAttrGet(MlirContext ctx, MlirLLVMCConv cconv) {
+  return wrap(CConvAttr::get(unwrap(ctx), CConv(cconv)));
+}
+
+MlirAttribute mlirLLVMComdatAttrGet(MlirContext ctx, MlirLLVMComdat comdat) {
+  return wrap(ComdatAttr::get(unwrap(ctx), comdat::Comdat(comdat)));
+}
+
+MlirAttribute mlirLLVMLinkageAttrGet(MlirContext ctx, MlirLLVMLinkage linkage) {
+  return wrap(LinkageAttr::get(unwrap(ctx), linkage::Linkage(linkage)));
+}
+
+MlirAttribute mlirLLVMDIFileAttrGet(MlirContext ctx, MlirAttribute name,
+                                    MlirAttribute directory) {
+  return wrap(DIFileAttr::get(unwrap(ctx), cast<StringAttr>(unwrap(name)),
+                              cast<StringAttr>(unwrap(directory))));
+}
+
+MlirAttribute
+mlirLLVMDICompileUnitAttrGet(MlirContext ctx, MlirAttribute id,
+                             unsigned int sourceLanguage, MlirAttribute file,
+                             MlirAttribute producer, bool isOptimized,
+                             MlirLLVMDIEmissionKind emissionKind) {
+  return wrap(DICompileUnitAttr::get(
+      unwrap(ctx), cast<DistinctAttr>(unwrap(id)), sourceLanguage,
+      cast<DIFileAttr>(unwrap(file)), cast<StringAttr>(unwrap(producer)),
+      isOptimized, DIEmissionKind(emissionKind)));
+}
+
+MlirAttribute mlirLLVMDIFlagsAttrGet(MlirContext ctx, uint64_t value) {
+  return wrap(DIFlagsAttr::get(unwrap(ctx), DIFlags(value)));
+}
+
+MlirAttribute mlirLLVMDILexicalBlockAttrGet(MlirContext ctx,
+                                            MlirAttribute scope,
+                                            MlirAttribute file,
+                                            unsigned int line,
+                                            unsigned int column) {
+  return wrap(
+      DILexicalBlockAttr::get(unwrap(ctx), cast<DIScopeAttr>(unwrap(scope)),
+                              cast<DIFileAttr>(unwrap(file)), line, column));
+}
+
+MlirAttribute mlirLLVMDILexicalBlockFileAttrGet(MlirContext ctx,
+                                                MlirAttribute scope,
+                                                MlirAttribute file,
+                                                unsigned int discriminator) {
+  return wrap(DILexicalBlockFileAttr::get(
+      unwrap(ctx), cast<DIScopeAttr>(unwrap(scope)),
+      cast<DIFileAttr>(unwrap(file)), discriminator));
+}
+
+MlirAttribute
+mlirLLVMDILocalVariableAttrGet(MlirContext ctx, MlirAttribute scope,
+                               MlirAttribute name, MlirAttribute diFile,
+                               unsigned int line, unsigned int arg,
+                               unsigned int alignInBits, MlirAttribute diType) {
+  return wrap(DILocalVariableAttr::get(
+      unwrap(ctx), cast<DIScopeAttr>(unwrap(scope)),
+      cast<StringAttr>(unwrap(name)), cast<DIFileAttr>(unwrap(diFile)), line,
+      arg, alignInBits, cast<DITypeAttr>(unwrap(diType))));
+}
+
+MlirAttribute mlirLLVMDISubroutineTypeAttrGet(MlirContext ctx,
+                                              unsigned int callingConvention,
+                                              intptr_t nTypes,
+                                              MlirAttribute const *types) {
+  SmallVector<Attribute> attrStorage;
+  attrStorage.reserve(nTypes);
+
+  return wrap(DISubroutineTypeAttr::get(
+      unwrap(ctx), callingConvention,
+      llvm::map_to_vector(unwrapList(nTypes, types, attrStorage),
+                          [](Attribute a) { return a.cast<DITypeAttr>(); })));
+}
+
+MlirAttribute mlirLLVMDISubprogramAttrGet(
+    MlirContext ctx, MlirAttribute id, MlirAttribute compileUnit,
+    MlirAttribute scope, MlirAttribute name, MlirAttribute linkageName,
+    MlirAttribute file, unsigned int line, unsigned int scopeLine,
+    uint64_t subprogramFlags, MlirAttribute type) {
+  return wrap(DISubprogramAttr::get(
+      unwrap(ctx), cast<DistinctAttr>(unwrap(id)),
+      cast<DICompileUnitAttr>(unwrap(compileUnit)),
+      cast<DIScopeAttr>(unwrap(scope)), cast<StringAttr>(unwrap(name)),
+      cast<StringAttr>(unwrap(linkageName)), cast<DIFileAttr>(unwrap(file)),
+      line, scopeLine, DISubprogramFlags(subprogramFlags),
+      cast<DISubroutineTypeAttr>(unwrap(type))));
+}
+
+MlirAttribute mlirLLVMDISubprogramAttrGetScope(MlirAttribute diSubprogram) {
+  return wrap(cast<DISubprogramAttr>(unwrap(diSubprogram)).getScope());
+}
+
+unsigned int mlirLLVMDISubprogramAttrGetLine(MlirAttribute diSubprogram) {
+  return cast<DISubprogramAttr>(unwrap(diSubprogram)).getLine();
+}
+
+unsigned int mlirLLVMDISubprogramAttrGetScopeLine(MlirAttribute diSubprogram) {
+  return cast<DISubprogramAttr>(unwrap(diSubprogram)).getScopeLine();
+}
+
+MlirAttribute
+mlirLLVMDISubprogramAttrGetCompileUnit(MlirAttribute diSubprogram) {
+  return wrap(cast<DISubprogramAttr>(unwrap(diSubprogram)).getCompileUnit());
+}
+
+MlirAttribute mlirLLVMDISubprogramAttrGetFile(MlirAttribute diSubprogram) {
+  return wrap(cast<DISubprogramAttr>(unwrap(diSubprogram)).getFile());
+}
+
+MlirAttribute mlirLLVMDISubprogramAttrGetType(MlirAttribute diSubprogram) {
+  return wrap(cast<DISubprogramAttr>(unwrap(diSubprogram)).getType());
+}
+
+MlirAttribute mlirLLVMDIModuleAttrGet(MlirContext ctx, MlirAttribute file,
+                                      MlirAttribute scope, MlirAttribute name,
+                                      MlirAttribute configMacros,
+                                      MlirAttribute includePath,
+                                      MlirAttribute apinotes, unsigned int line,
+                                      bool isDecl) {
+  return wrap(DIModuleAttr::get(
+      unwrap(ctx), cast<DIFileAttr>(unwrap(file)),
+      cast<DIScopeAttr>(unwrap(scope)), cast<StringAttr>(unwrap(name)),
+      cast<StringAttr>(unwrap(configMacros)),
+      cast<StringAttr>(unwrap(includePath)), cast<StringAttr>(unwrap(apinotes)),
+      line, isDecl));
+}
+
+MlirAttribute mlirLLVMDIModuleAttrGetScope(MlirAttribute diModule) {
+  return wrap(cast<DIModuleAttr>(unwrap(diModule)).getScope());
 }

--- a/mlir/lib/CAPI/IR/BuiltinAttributes.cpp
+++ b/mlir/lib/CAPI/IR/BuiltinAttributes.cpp
@@ -289,6 +289,10 @@ MlirTypeID mlirSymbolRefAttrGetTypeID(void) {
   return wrap(SymbolRefAttr::getTypeID());
 }
 
+MlirAttribute mlirDisctinctAttrCreate(MlirAttribute referencedAttr) {
+  return wrap(mlir::DistinctAttr::create(unwrap(referencedAttr)));
+}
+
 //===----------------------------------------------------------------------===//
 // Flat SymbolRef attribute.
 //===----------------------------------------------------------------------===//

--- a/mlir/test/CAPI/ir.c
+++ b/mlir/test/CAPI/ir.c
@@ -1482,6 +1482,10 @@ int printAffineMap(MlirContext ctx) {
   // CHECK: (d0, d1, d2) -> (d0)
   // CHECK: (d0, d1, d2) -> (d2)
 
+  // CHECK: distinct[0]<"foo">
+  mlirAttributeDump(mlirDisctinctAttrCreate(
+      mlirStringAttrGet(ctx, mlirStringRefCreateFromCString("foo"))));
+
   return 0;
 }
 

--- a/mlir/test/CAPI/llvm.c
+++ b/mlir/test/CAPI/llvm.c
@@ -10,9 +10,12 @@
 // RUN: mlir-capi-llvm-test 2>&1 | FileCheck %s
 
 #include "mlir-c/Dialect/LLVM.h"
+#include "mlir-c/BuiltinAttributes.h"
 #include "mlir-c/BuiltinTypes.h"
 #include "mlir-c/IR.h"
 #include "mlir-c/Support.h"
+#include "llvm-c/Core.h"
+#include "llvm-c/DebugInfo.h"
 
 #include <assert.h>
 #include <inttypes.h>
@@ -77,7 +80,7 @@ static void testTypeCreation(MlirContext ctx) {
 
 // CHECK-LABEL: testStructTypeCreation
 static int testStructTypeCreation(MlirContext ctx) {
-  fprintf(stderr, "testStructTypeCreation");
+  fprintf(stderr, "testStructTypeCreation\n");
 
   // CHECK: !llvm.struct<()>
   mlirTypeDump(mlirLLVMStructTypeLiteralGet(ctx, /*nFieldTypes=*/0,
@@ -225,12 +228,120 @@ static int testStructTypeCreation(MlirContext ctx) {
   return 0;
 }
 
+// CHECK-LABEL: testLLVMAttributes
+static void testLLVMAttributes(MlirContext ctx) {
+  fprintf(stderr, "testLLVMAttributes\n");
+
+  // CHECK: #llvm.linkage<internal>
+  mlirAttributeDump(mlirLLVMLinkageAttrGet(ctx, MlirLLVMLinkageInternal));
+  // CHECK: #llvm.cconv<ccc>
+  mlirAttributeDump(mlirLLVMCConvAttrGet(ctx, MlirLLVMCConvC));
+  // CHECK: #llvm<comdat any>
+  mlirAttributeDump(mlirLLVMComdatAttrGet(ctx, MlirLLVMComdatAny));
+}
+
+// CHECK-LABEL: testDebugInfoAttributes
+static void testDebugInfoAttributes(MlirContext ctx) {
+  fprintf(stderr, "testDebugInfoAttributes\n");
+
+  MlirAttribute foo =
+      mlirStringAttrGet(ctx, mlirStringRefCreateFromCString("foo"));
+  MlirAttribute bar =
+      mlirStringAttrGet(ctx, mlirStringRefCreateFromCString("bar"));
+  MlirAttribute id = mlirDisctinctAttrCreate(foo);
+
+  // CHECK: #llvm.di_null_type
+  mlirAttributeDump(mlirLLVMDINullTypeAttrGet(ctx));
+
+  // CHECK: #llvm.di_basic_type<tag = DW_TAG_null, name = "foo", sizeInBits =
+  // CHECK-SAME: 64, encoding = DW_ATE_signed>
+  MlirAttribute di_type =
+      mlirLLVMDIBasicTypeAttrGet(ctx, 0, foo, 64, MlirLLVMTypeEncodingSigned);
+  mlirAttributeDump(di_type);
+
+  MlirAttribute file = mlirLLVMDIFileAttrGet(ctx, foo, bar);
+
+  // CHECK: #llvm.di_file<"foo" in "bar">
+  mlirAttributeDump(file);
+
+  MlirAttribute compile_unit =
+      mlirLLVMDICompileUnitAttrGet(ctx, id, LLVMDWARFSourceLanguageC99, file,
+                                   foo, false, MlirLLVMDIEmissionKindFull);
+
+  // CHECK: #llvm.di_compile_unit<{{.*}}>
+  mlirAttributeDump(compile_unit);
+
+  MlirAttribute di_module = mlirLLVMDIModuleAttrGet(
+      ctx, file, compile_unit, foo,
+      mlirStringAttrGet(ctx, mlirStringRefCreateFromCString("")), bar, foo, 1,
+      0);
+  // CHECK: #llvm.di_module<{{.*}}>
+  mlirAttributeDump(di_module);
+
+  // CHECK: #llvm.di_compile_unit<{{.*}}>
+  mlirAttributeDump(mlirLLVMDIModuleAttrGetScope(di_module));
+
+  // CHECK: 1 : i32
+  mlirAttributeDump(mlirLLVMDIFlagsAttrGet(ctx, 0x1));
+
+  // CHECK: #llvm.di_lexical_block<{{.*}}>
+  mlirAttributeDump(
+      mlirLLVMDILexicalBlockAttrGet(ctx, compile_unit, file, 1, 2));
+
+  // CHECK: #llvm.di_lexical_block_file<{{.*}}>
+  mlirAttributeDump(
+      mlirLLVMDILexicalBlockFileAttrGet(ctx, compile_unit, file, 3));
+
+  // CHECK: #llvm.di_local_variable<{{.*}}>
+  mlirAttributeDump(mlirLLVMDILocalVariableAttrGet(ctx, compile_unit, foo, file,
+                                                   1, 0, 8, di_type));
+  // CHECK: #llvm.di_derived_type<{{.*}}>
+  mlirAttributeDump(
+      mlirLLVMDIDerivedTypeAttrGet(ctx, 0, bar, di_type, 64, 8, 0));
+
+  // CHECK: #llvm.di_composite_type<{{.*}}>
+  mlirAttributeDump(mlirLLVMDICompositeTypeAttrGet(
+      ctx, 0, foo, file, 1, compile_unit, di_type, 0, 64, 8, 1, &di_type));
+
+  MlirAttribute subroutine_type =
+      mlirLLVMDISubroutineTypeAttrGet(ctx, 0x0, 1, &di_type);
+
+  // CHECK: #llvm.di_subroutine_type<{{.*}}>
+  mlirAttributeDump(subroutine_type);
+
+  MlirAttribute di_subprogram =
+      mlirLLVMDISubprogramAttrGet(ctx, id, compile_unit, compile_unit, foo, bar,
+                                  file, 1, 2, 0, subroutine_type);
+  // CHECK: #llvm.di_subprogram<{{.*}}>
+  mlirAttributeDump(di_subprogram);
+
+  // CHECK: #llvm.di_compile_unit<{{.*}}>
+  mlirAttributeDump(mlirLLVMDISubprogramAttrGetScope(di_subprogram));
+
+  // CHECK: #llvm.di_file<{{.*}}>
+  mlirAttributeDump(mlirLLVMDISubprogramAttrGetFile(di_subprogram));
+
+  // CHECK: #llvm.di_subroutine_type<{{.*}}>
+  mlirAttributeDump(mlirLLVMDISubprogramAttrGetType(di_subprogram));
+
+  MlirAttribute expression_elem =
+      mlirLLVMDIExpressionElemAttrGet(ctx, 1, 1, &(uint64_t){1});
+
+  // CHECK: #llvm<di_expression_elem(1)>
+  mlirAttributeDump(expression_elem);
+
+  // CHECK: #llvm.di_expression<[(1)]>
+  mlirAttributeDump(mlirLLVMDIExpressionAttrGet(ctx, 1, &expression_elem));
+}
+
 int main(void) {
   MlirContext ctx = mlirContextCreate();
   mlirDialectHandleRegisterDialect(mlirGetDialectHandle__llvm__(), ctx);
   mlirContextGetOrLoadDialect(ctx, mlirStringRefCreateFromCString("llvm"));
   testTypeCreation(ctx);
   int result = testStructTypeCreation(ctx);
+  testLLVMAttributes(ctx);
+  testDebugInfoAttributes(ctx);
   mlirContextDestroy(ctx);
   if (result)
     fprintf(stderr, "FAILED: code %d", result);


### PR DESCRIPTION
This PR adds the following to the mlir c api:

- The disctinct mlir builtin attribute.
- LLVM attributes (mostly debug related ones)

