### PR TITLE
[AMDGPU] Use BUF multiclasses to reduce repetition. NFC.

### DIFF
--- a/llvm/lib/Target/AMDGPU/BUFInstructions.td
+++ b/llvm/lib/Target/AMDGPU/BUFInstructions.td
@@ -2323,19 +2323,41 @@ class Base_MUBUF_Real_gfx6_gfx7_gfx10<bits<7> op, MUBUF_Pseudo ps, int ef> :
   let Inst{55}    = ps.tfe;
 }
 
-class MUBUF_Real_gfx10<bits<8> op, MUBUF_Pseudo ps> :
-    Base_MUBUF_Real_gfx6_gfx7_gfx10<op{6-0}, ps, SIEncodingFamily.GFX10> {
-  let Inst{15} = !if(ps.has_dlc, cpol{CPolBit.DLC}, ps.dlc_value);
-  let Inst{25} = op{7};
-  let AssemblerPredicate = isGFX10Only;
-  let DecoderNamespace = "GFX10";
+multiclass MUBUF_Real_gfx10<bits<8> op> {
+  defvar ps = !cast<MUBUF_Pseudo>(NAME);
+  def _gfx10 : Base_MUBUF_Real_gfx6_gfx7_gfx10<op{6-0}, ps, SIEncodingFamily.GFX10> {
+    let Inst{15} = !if(ps.has_dlc, cpol{CPolBit.DLC}, ps.dlc_value);
+    let Inst{25} = op{7};
+    let AssemblerPredicate = isGFX10Only;
+    let DecoderNamespace = "GFX10";
+  }
 }
 
-class MUBUF_Real_gfx6_gfx7<bits<8> op, MUBUF_Pseudo ps> :
-    Base_MUBUF_Real_gfx6_gfx7_gfx10<op{6-0}, ps, SIEncodingFamily.SI> {
-  let Inst{15} = ps.addr64;
-  let AssemblerPredicate = isGFX6GFX7;
-  let DecoderNamespace = "GFX6GFX7";
+multiclass MUBUF_Real_gfx6_gfx7<bits<8> op> {
+  defvar ps = !cast<MUBUF_Pseudo>(NAME);
+  def _gfx6_gfx7 : Base_MUBUF_Real_gfx6_gfx7_gfx10<op{6-0}, ps, SIEncodingFamily.SI> {
+    let Inst{15} = ps.addr64;
+    let AssemblerPredicate = isGFX6GFX7;
+    let DecoderNamespace = "GFX6GFX7";
+  }
+}
+
+multiclass MUBUF_Real_gfx6<bits<8> op> {
+  defvar ps = !cast<MUBUF_Pseudo>(NAME);
+  def _gfx6 : Base_MUBUF_Real_gfx6_gfx7_gfx10<op{6-0}, ps, SIEncodingFamily.SI> {
+    let Inst{15} = ps.addr64;
+    let AssemblerPredicate = isGFX6;
+    let DecoderNamespace = "GFX6";
+  }
+}
+
+multiclass MUBUF_Real_gfx7<bits<8> op> {
+  defvar ps = !cast<MUBUF_Pseudo>(NAME);
+  def _gfx7 : Base_MUBUF_Real_gfx6_gfx7_gfx10<op{6-0}, ps, SIEncodingFamily.SI> {
+    let Inst{15} = ps.addr64;
+    let AssemblerPredicate = isGFX7Only;
+    let DecoderNamespace = "GFX7";
+  }
 }
 
 //===----------------------------------------------------------------------===//
@@ -2407,19 +2429,19 @@ class VBUFFER_MUBUF_Real_gfx12<bits<8> op, MUBUF_Pseudo ps,
   let DecoderNamespace = "GFX12";
 }
 
-class VBUFFER_MTBUF_Real_gfx12<bits<4> op, MTBUF_Pseudo ps,
-                               string real_name = ps.Mnemonic> :
-  VBUFFER_Real<ps, real_name>, SIMCInstr<ps.PseudoInstr, SIEncodingFamily.GFX12> {
+multiclass VBUFFER_MTBUF_Real_gfx12<bits<4> op, string real_name> {
+  defvar ps = !cast<MTBUF_Pseudo>(NAME);
+  def _gfx12 : VBUFFER_Real<ps, real_name>, SIMCInstr<ps.PseudoInstr, SIEncodingFamily.GFX12> {
+    let MTBUF = 1;
 
-  let MTBUF = 1;
+    bits<7>  format;
 
-  bits<7>  format;
-
-  let Inst{17-14} = op;
-  let Inst{21-18} = 0b1000;
-  let Inst{61-55} = format;
-  let AssemblerPredicate = isGFX12Only;
-  let DecoderNamespace = "GFX12";
+    let Inst{17-14} = op;
+    let Inst{21-18} = 0b1000;
+    let Inst{61-55} = format;
+    let AssemblerPredicate = isGFX12Only;
+    let DecoderNamespace = "GFX12";
+  }
 }
 
 //===----------------------------------------------------------------------===//
@@ -2442,24 +2464,26 @@ class Mnem_gfx11 <string mnemonic, string real_name> :
 class Mnem_gfx12 <string mnemonic, string real_name> :
   MnemonicAlias<mnemonic, real_name>, Requires<[isGFX12Plus]>;
 
-class MUBUF_Real_gfx11_impl<bits<8> op, string ps_name, string real_name> :
-  MUBUF_Real_gfx11<op, !cast<MUBUF_Pseudo>(ps_name), real_name>;
+multiclass MUBUF_Real_gfx11_impl<bits<8> op, string real_name> {
+  def _gfx11 : MUBUF_Real_gfx11<op, !cast<MUBUF_Pseudo>(NAME), real_name>;
+}
 
-class VBUFFER_MUBUF_Real_gfx12_impl<bits<8> op, string ps_name, string real_name> :
-  VBUFFER_MUBUF_Real_gfx12<op, !cast<MUBUF_Pseudo>(ps_name), real_name>;
+multiclass VBUFFER_MUBUF_Real_gfx12_impl<bits<8> op, string real_name> {
+  def _gfx12 : VBUFFER_MUBUF_Real_gfx12<op, !cast<MUBUF_Pseudo>(NAME), real_name>;
+}
 
 multiclass MUBUF_Real_AllAddr_gfx11_Renamed_Impl2<bits<8> op, string real_name> {
-  def _BOTHEN_gfx11 : MUBUF_Real_gfx11_impl<op, NAME # "_BOTHEN", real_name>;
-  def _IDXEN_gfx11 : MUBUF_Real_gfx11_impl<op, NAME # "_IDXEN", real_name>;
-  def _OFFEN_gfx11 : MUBUF_Real_gfx11_impl<op, NAME # "_OFFEN", real_name>;
-  def _OFFSET_gfx11 : MUBUF_Real_gfx11_impl<op, NAME # "_OFFSET", real_name>;
+  defm _BOTHEN : MUBUF_Real_gfx11_impl<op, real_name>;
+  defm _IDXEN  : MUBUF_Real_gfx11_impl<op, real_name>;
+  defm _OFFEN  : MUBUF_Real_gfx11_impl<op, real_name>;
+  defm _OFFSET : MUBUF_Real_gfx11_impl<op, real_name>;
 }
 
 multiclass MUBUF_Real_AllAddr_gfx12_Renamed_Impl2<bits<8> op, string real_name> {
-  def _BOTHEN_gfx12 : VBUFFER_MUBUF_Real_gfx12_impl<op, NAME # "_VBUFFER_BOTHEN", real_name>;
-  def _IDXEN_gfx12 : VBUFFER_MUBUF_Real_gfx12_impl<op, NAME # "_VBUFFER_IDXEN", real_name>;
-  def _OFFEN_gfx12 : VBUFFER_MUBUF_Real_gfx12_impl<op, NAME # "_VBUFFER_OFFEN", real_name>;
-  def _OFFSET_gfx12 : VBUFFER_MUBUF_Real_gfx12_impl<op, NAME # "_VBUFFER_OFFSET", real_name>;
+  defm _VBUFFER_BOTHEN : VBUFFER_MUBUF_Real_gfx12_impl<op, real_name>;
+  defm _VBUFFER_IDXEN  : VBUFFER_MUBUF_Real_gfx12_impl<op, real_name>;
+  defm _VBUFFER_OFFEN  : VBUFFER_MUBUF_Real_gfx12_impl<op, real_name>;
+  defm _VBUFFER_OFFSET : VBUFFER_MUBUF_Real_gfx12_impl<op, real_name>;
 }
 
 multiclass MUBUF_Real_AllAddr_gfx11_gfx12_Renamed_Impl2<bits<8> op, string real_name> :
@@ -2492,38 +2516,30 @@ multiclass MUBUF_Real_AllAddr_gfx11_gfx12_Renamed<bits<8> op, string real_name> 
   def : Mnem_gfx11_gfx12<get_BUF_ps<NAME>.Mnemonic, real_name>;
 }
 
-class MUBUF_Real_Atomic_gfx11_impl<bits<8> op, string ps_name,
-                                   string real_name> :
-  MUBUF_Real_gfx11<op, !cast<MUBUF_Pseudo>(ps_name), real_name>;
+multiclass MUBUF_Real_Atomic_gfx11_impl<bits<8> op, string real_name> {
+  def _gfx11 : MUBUF_Real_gfx11<op, !cast<MUBUF_Pseudo>(NAME), real_name>;
+}
 
-class MUBUF_Real_Atomic_gfx12_impl<bits<8> op, string ps_name,
-                                   string real_name> :
-  VBUFFER_MUBUF_Real_gfx12<op, !cast<MUBUF_Pseudo>(ps_name), real_name>;
+multiclass MUBUF_Real_Atomic_gfx12_impl<bits<8> op, string real_name> {
+  def _gfx12 : VBUFFER_MUBUF_Real_gfx12<op, !cast<MUBUF_Pseudo>(NAME), real_name>;
+}
 
 multiclass MUBUF_Real_Atomic_gfx11_Renamed_impl<bits<8> op, bit is_return,
                                                 string real_name> {
   defvar Rtn = !if(is_return, "_RTN", "");
-  def _BOTHEN#Rtn#_gfx11 :
-    MUBUF_Real_Atomic_gfx11_impl<op, NAME # "_BOTHEN" # Rtn, real_name>;
-  def _IDXEN#Rtn#_gfx11 :
-    MUBUF_Real_Atomic_gfx11_impl<op, NAME # "_IDXEN" # Rtn, real_name>;
-  def _OFFEN#Rtn#_gfx11 :
-    MUBUF_Real_Atomic_gfx11_impl<op, NAME # "_OFFEN" # Rtn, real_name>;
-  def _OFFSET#Rtn#_gfx11 :
-    MUBUF_Real_Atomic_gfx11_impl<op, NAME # "_OFFSET" # Rtn, real_name>;
+  defm _BOTHEN#Rtn : MUBUF_Real_Atomic_gfx11_impl<op, real_name>;
+  defm _IDXEN#Rtn  : MUBUF_Real_Atomic_gfx11_impl<op, real_name>;
+  defm _OFFEN#Rtn  : MUBUF_Real_Atomic_gfx11_impl<op, real_name>;
+  defm _OFFSET#Rtn : MUBUF_Real_Atomic_gfx11_impl<op, real_name>;
 }
 
 multiclass MUBUF_Real_Atomic_gfx12_Renamed_impl<bits<8> op, bit is_return,
                                                 string real_name> {
   defvar Rtn = !if(is_return, "_RTN", "");
-  def _BOTHEN#Rtn#_gfx12 :
-    MUBUF_Real_Atomic_gfx12_impl<op, NAME # "_VBUFFER_BOTHEN" # Rtn, real_name>;
-  def _IDXEN#Rtn#_gfx12 :
-    MUBUF_Real_Atomic_gfx12_impl<op, NAME # "_VBUFFER_IDXEN" # Rtn, real_name>;
-  def _OFFEN#Rtn#_gfx12 :
-    MUBUF_Real_Atomic_gfx12_impl<op, NAME # "_VBUFFER_OFFEN" # Rtn, real_name>;
-  def _OFFSET#Rtn#_gfx12 :
-    MUBUF_Real_Atomic_gfx12_impl<op, NAME # "_VBUFFER_OFFSET" # Rtn, real_name>;
+  defm _VBUFFER_BOTHEN#Rtn : MUBUF_Real_Atomic_gfx12_impl<op, real_name>;
+  defm _VBUFFER_IDXEN#Rtn  : MUBUF_Real_Atomic_gfx12_impl<op, real_name>;
+  defm _VBUFFER_OFFEN#Rtn  : MUBUF_Real_Atomic_gfx12_impl<op, real_name>;
+  defm _VBUFFER_OFFSET#Rtn : MUBUF_Real_Atomic_gfx12_impl<op, real_name>;
 }
 
 multiclass MUBUF_Real_Atomic_gfx11_gfx12_Renamed_impl<bits<8> op, bit is_return,
@@ -2652,52 +2668,40 @@ defm BUFFER_ATOMIC_PK_ADD_BF16    : MUBUF_Real_Atomic_gfx12<0x05a>;
 //===----------------------------------------------------------------------===//
 
 multiclass MUBUF_Real_AllAddr_Helper_gfx10<bits<8> op> {
-  def _BOTHEN_gfx10 :
-    MUBUF_Real_gfx10<op, !cast<MUBUF_Pseudo>(NAME#"_BOTHEN")>;
-  def _IDXEN_gfx10 :
-    MUBUF_Real_gfx10<op, !cast<MUBUF_Pseudo>(NAME#"_IDXEN")>;
-  def _OFFEN_gfx10 :
-    MUBUF_Real_gfx10<op, !cast<MUBUF_Pseudo>(NAME#"_OFFEN")>;
-  def _OFFSET_gfx10 :
-    MUBUF_Real_gfx10<op, !cast<MUBUF_Pseudo>(NAME#"_OFFSET")>;
+  defm _BOTHEN : MUBUF_Real_gfx10<op>;
+  defm _IDXEN  : MUBUF_Real_gfx10<op>;
+  defm _OFFEN  : MUBUF_Real_gfx10<op>;
+  defm _OFFSET : MUBUF_Real_gfx10<op>;
 }
 multiclass MUBUF_Real_AllAddr_gfx10<bits<8> op> {
   defm NAME : MUBUF_Real_AllAddr_Helper_gfx10<op>;
   defm _TFE : MUBUF_Real_AllAddr_Helper_gfx10<op>;
 }
 multiclass MUBUF_Real_AllAddr_Lds_gfx10<bits<8> op, bit isTFE = 0> {
-  def _OFFSET_gfx10 : MUBUF_Real_gfx10<op, !cast<MUBUF_Pseudo>(NAME#"_OFFSET")>;
-  def _OFFEN_gfx10  : MUBUF_Real_gfx10<op, !cast<MUBUF_Pseudo>(NAME#"_OFFEN")>;
-  def _IDXEN_gfx10  : MUBUF_Real_gfx10<op, !cast<MUBUF_Pseudo>(NAME#"_IDXEN")>;
-  def _BOTHEN_gfx10 : MUBUF_Real_gfx10<op, !cast<MUBUF_Pseudo>(NAME#"_BOTHEN")>;
+  defm _OFFSET : MUBUF_Real_gfx10<op>;
+  defm _OFFEN  : MUBUF_Real_gfx10<op>;
+  defm _IDXEN  : MUBUF_Real_gfx10<op>;
+  defm _BOTHEN : MUBUF_Real_gfx10<op>;
 
   if !not(isTFE) then {
-    def _LDS_OFFSET_gfx10 : MUBUF_Real_gfx10<op, !cast<MUBUF_Pseudo>(NAME#"_LDS_OFFSET")>;
-    def _LDS_OFFEN_gfx10  : MUBUF_Real_gfx10<op, !cast<MUBUF_Pseudo>(NAME#"_LDS_OFFEN")>;
-    def _LDS_IDXEN_gfx10  : MUBUF_Real_gfx10<op, !cast<MUBUF_Pseudo>(NAME#"_LDS_IDXEN")>;
-    def _LDS_BOTHEN_gfx10 : MUBUF_Real_gfx10<op, !cast<MUBUF_Pseudo>(NAME#"_LDS_BOTHEN")>;
+    defm _LDS_OFFSET : MUBUF_Real_gfx10<op>;
+    defm _LDS_OFFEN  : MUBUF_Real_gfx10<op>;
+    defm _LDS_IDXEN  : MUBUF_Real_gfx10<op>;
+    defm _LDS_BOTHEN : MUBUF_Real_gfx10<op>;
   }
 }
 multiclass MUBUF_Real_Atomics_RTN_gfx10<bits<8> op> {
-  def _BOTHEN_RTN_gfx10 :
-    MUBUF_Real_gfx10<op, !cast<MUBUF_Pseudo>(NAME#"_BOTHEN_RTN")>;
-  def _IDXEN_RTN_gfx10 :
-    MUBUF_Real_gfx10<op, !cast<MUBUF_Pseudo>(NAME#"_IDXEN_RTN")>;
-  def _OFFEN_RTN_gfx10 :
-    MUBUF_Real_gfx10<op, !cast<MUBUF_Pseudo>(NAME#"_OFFEN_RTN")>;
-  def _OFFSET_RTN_gfx10 :
-    MUBUF_Real_gfx10<op, !cast<MUBUF_Pseudo>(NAME#"_OFFSET_RTN")>;
+  defm _BOTHEN_RTN : MUBUF_Real_gfx10<op>;
+  defm _IDXEN_RTN  : MUBUF_Real_gfx10<op>;
+  defm _OFFEN_RTN  : MUBUF_Real_gfx10<op>;
+  defm _OFFSET_RTN : MUBUF_Real_gfx10<op>;
 }
 multiclass MUBUF_Real_Atomics_gfx10<bits<8> op> :
     MUBUF_Real_Atomics_RTN_gfx10<op> {
-  def _BOTHEN_gfx10 :
-    MUBUF_Real_gfx10<op, !cast<MUBUF_Pseudo>(NAME#"_BOTHEN")>;
-  def _IDXEN_gfx10 :
-    MUBUF_Real_gfx10<op, !cast<MUBUF_Pseudo>(NAME#"_IDXEN")>;
-  def _OFFEN_gfx10 :
-    MUBUF_Real_gfx10<op, !cast<MUBUF_Pseudo>(NAME#"_OFFEN")>;
-  def _OFFSET_gfx10 :
-    MUBUF_Real_gfx10<op, !cast<MUBUF_Pseudo>(NAME#"_OFFSET")>;
+  defm _BOTHEN : MUBUF_Real_gfx10<op>;
+  defm _IDXEN  : MUBUF_Real_gfx10<op>;
+  defm _OFFEN  : MUBUF_Real_gfx10<op>;
+  defm _OFFSET : MUBUF_Real_gfx10<op>;
 }
 
 defm BUFFER_STORE_BYTE_D16_HI     : MUBUF_Real_AllAddr_gfx10<0x019>;
@@ -2720,78 +2724,51 @@ defm BUFFER_STORE_FORMAT_D16_XY   : MUBUF_Real_AllAddr_gfx10<0x085>;
 defm BUFFER_STORE_FORMAT_D16_XYZ  : MUBUF_Real_AllAddr_gfx10<0x086>;
 defm BUFFER_STORE_FORMAT_D16_XYZW : MUBUF_Real_AllAddr_gfx10<0x087>;
 
-def BUFFER_GL0_INV_gfx10 :
-  MUBUF_Real_gfx10<0x071, BUFFER_GL0_INV>;
-def BUFFER_GL1_INV_gfx10 :
-  MUBUF_Real_gfx10<0x072, BUFFER_GL1_INV>;
+defm BUFFER_GL0_INV : MUBUF_Real_gfx10<0x071>;
+defm BUFFER_GL1_INV : MUBUF_Real_gfx10<0x072>;
 
 //===----------------------------------------------------------------------===//
 // MUBUF - GFX6, GFX7, GFX10.
 //===----------------------------------------------------------------------===//
 
-multiclass MUBUF_Real_gfx6<bits<8> op> {
-  let AssemblerPredicate = isGFX6, DecoderNamespace = "GFX6" in
-  def _gfx6 : MUBUF_Real_gfx6_gfx7<op, !cast<MUBUF_Pseudo>(NAME)>;
-}
-
-multiclass MUBUF_Real_gfx7<bits<8> op> {
-  let AssemblerPredicate = isGFX7Only, DecoderNamespace = "GFX7" in
-  def _gfx7 : MUBUF_Real_gfx6_gfx7<op, !cast<MUBUF_Pseudo>(NAME)>;
-}
-
 multiclass MUBUF_Real_AllAddr_Helper_gfx6_gfx7<bits<8> op> {
-  def _ADDR64_gfx6_gfx7 :
-    MUBUF_Real_gfx6_gfx7<op, !cast<MUBUF_Pseudo>(NAME#"_ADDR64")>;
-  def _BOTHEN_gfx6_gfx7 :
-    MUBUF_Real_gfx6_gfx7<op, !cast<MUBUF_Pseudo>(NAME#"_BOTHEN")>;
-  def _IDXEN_gfx6_gfx7 :
-    MUBUF_Real_gfx6_gfx7<op, !cast<MUBUF_Pseudo>(NAME#"_IDXEN")>;
-  def _OFFEN_gfx6_gfx7 :
-    MUBUF_Real_gfx6_gfx7<op, !cast<MUBUF_Pseudo>(NAME#"_OFFEN")>;
-  def _OFFSET_gfx6_gfx7 :
-    MUBUF_Real_gfx6_gfx7<op, !cast<MUBUF_Pseudo>(NAME#"_OFFSET")>;
+  defm _ADDR64 : MUBUF_Real_gfx6_gfx7<op>;
+  defm _BOTHEN : MUBUF_Real_gfx6_gfx7<op>;
+  defm _IDXEN  : MUBUF_Real_gfx6_gfx7<op>;
+  defm _OFFEN  : MUBUF_Real_gfx6_gfx7<op>;
+  defm _OFFSET : MUBUF_Real_gfx6_gfx7<op>;
 }
 multiclass MUBUF_Real_AllAddr_gfx6_gfx7<bits<8> op> {
   defm NAME : MUBUF_Real_AllAddr_Helper_gfx6_gfx7<op>;
   defm _TFE : MUBUF_Real_AllAddr_Helper_gfx6_gfx7<op>;
 }
 multiclass MUBUF_Real_AllAddr_Lds_gfx6_gfx7<bits<8> op, bit isTFE = 0> {
-  def _OFFSET_gfx6_gfx7 : MUBUF_Real_gfx6_gfx7<op, !cast<MUBUF_Pseudo>(NAME#"_OFFSET")>;
-  def _ADDR64_gfx6_gfx7 : MUBUF_Real_gfx6_gfx7<op, !cast<MUBUF_Pseudo>(NAME#"_ADDR64")>;
-  def _OFFEN_gfx6_gfx7  : MUBUF_Real_gfx6_gfx7<op, !cast<MUBUF_Pseudo>(NAME#"_OFFEN")>;
-  def _IDXEN_gfx6_gfx7  : MUBUF_Real_gfx6_gfx7<op, !cast<MUBUF_Pseudo>(NAME#"_IDXEN")>;
-  def _BOTHEN_gfx6_gfx7 : MUBUF_Real_gfx6_gfx7<op, !cast<MUBUF_Pseudo>(NAME#"_BOTHEN")>;
+  defm _OFFSET : MUBUF_Real_gfx6_gfx7<op>;
+  defm _ADDR64 : MUBUF_Real_gfx6_gfx7<op>;
+  defm _OFFEN  : MUBUF_Real_gfx6_gfx7<op>;
+  defm _IDXEN  : MUBUF_Real_gfx6_gfx7<op>;
+  defm _BOTHEN : MUBUF_Real_gfx6_gfx7<op>;
 
   if !not(isTFE) then {
-    def _LDS_OFFSET_gfx6_gfx7 : MUBUF_Real_gfx6_gfx7<op, !cast<MUBUF_Pseudo>(NAME#"_LDS_OFFSET")>;
-    def _LDS_ADDR64_gfx6_gfx7 : MUBUF_Real_gfx6_gfx7<op, !cast<MUBUF_Pseudo>(NAME#"_LDS_ADDR64")>;
-    def _LDS_OFFEN_gfx6_gfx7  : MUBUF_Real_gfx6_gfx7<op, !cast<MUBUF_Pseudo>(NAME#"_LDS_OFFEN")>;
-    def _LDS_IDXEN_gfx6_gfx7  : MUBUF_Real_gfx6_gfx7<op, !cast<MUBUF_Pseudo>(NAME#"_LDS_IDXEN")>;
-    def _LDS_BOTHEN_gfx6_gfx7 : MUBUF_Real_gfx6_gfx7<op, !cast<MUBUF_Pseudo>(NAME#"_LDS_BOTHEN")>;
+    defm _LDS_OFFSET : MUBUF_Real_gfx6_gfx7<op>;
+    defm _LDS_ADDR64 : MUBUF_Real_gfx6_gfx7<op>;
+    defm _LDS_OFFEN  : MUBUF_Real_gfx6_gfx7<op>;
+    defm _LDS_IDXEN  : MUBUF_Real_gfx6_gfx7<op>;
+    defm _LDS_BOTHEN : MUBUF_Real_gfx6_gfx7<op>;
   }
 }
 multiclass MUBUF_Real_Atomics_gfx6_gfx7<bits<8> op> {
-  def _ADDR64_gfx6_gfx7 :
-    MUBUF_Real_gfx6_gfx7<op, !cast<MUBUF_Pseudo>(NAME#"_ADDR64")>;
-  def _BOTHEN_gfx6_gfx7 :
-    MUBUF_Real_gfx6_gfx7<op, !cast<MUBUF_Pseudo>(NAME#"_BOTHEN")>;
-  def _IDXEN_gfx6_gfx7 :
-    MUBUF_Real_gfx6_gfx7<op, !cast<MUBUF_Pseudo>(NAME#"_IDXEN")>;
-  def _OFFEN_gfx6_gfx7 :
-    MUBUF_Real_gfx6_gfx7<op, !cast<MUBUF_Pseudo>(NAME#"_OFFEN")>;
-  def _OFFSET_gfx6_gfx7 :
-    MUBUF_Real_gfx6_gfx7<op, !cast<MUBUF_Pseudo>(NAME#"_OFFSET")>;
+  defm _ADDR64 : MUBUF_Real_gfx6_gfx7<op>;
+  defm _BOTHEN : MUBUF_Real_gfx6_gfx7<op>;
+  defm _IDXEN  : MUBUF_Real_gfx6_gfx7<op>;
+  defm _OFFEN  : MUBUF_Real_gfx6_gfx7<op>;
+  defm _OFFSET : MUBUF_Real_gfx6_gfx7<op>;
 
-  def _ADDR64_RTN_gfx6_gfx7 :
-    MUBUF_Real_gfx6_gfx7<op, !cast<MUBUF_Pseudo>(NAME#"_ADDR64_RTN")>;
-  def _BOTHEN_RTN_gfx6_gfx7 :
-    MUBUF_Real_gfx6_gfx7<op, !cast<MUBUF_Pseudo>(NAME#"_BOTHEN_RTN")>;
-  def _IDXEN_RTN_gfx6_gfx7 :
-    MUBUF_Real_gfx6_gfx7<op, !cast<MUBUF_Pseudo>(NAME#"_IDXEN_RTN")>;
-  def _OFFEN_RTN_gfx6_gfx7 :
-    MUBUF_Real_gfx6_gfx7<op, !cast<MUBUF_Pseudo>(NAME#"_OFFEN_RTN")>;
-  def _OFFSET_RTN_gfx6_gfx7 :
-    MUBUF_Real_gfx6_gfx7<op, !cast<MUBUF_Pseudo>(NAME#"_OFFSET_RTN")>;
+  defm _ADDR64_RTN : MUBUF_Real_gfx6_gfx7<op>;
+  defm _BOTHEN_RTN : MUBUF_Real_gfx6_gfx7<op>;
+  defm _IDXEN_RTN  : MUBUF_Real_gfx6_gfx7<op>;
+  defm _OFFEN_RTN  : MUBUF_Real_gfx6_gfx7<op>;
+  defm _OFFSET_RTN : MUBUF_Real_gfx6_gfx7<op>;
 }
 
 multiclass MUBUF_Real_AllAddr_gfx6_gfx7_gfx10<bits<8> op> :
@@ -2874,7 +2851,7 @@ defm BUFFER_ATOMIC_CSUB       : MUBUF_Real_Atomics_gfx10<0x034>;
 
 defm BUFFER_WBINVL1_SC        : MUBUF_Real_gfx6<0x070>;
 defm BUFFER_WBINVL1_VOL       : MUBUF_Real_gfx7<0x070>;
-def  BUFFER_WBINVL1_gfx6_gfx7 : MUBUF_Real_gfx6_gfx7<0x071, BUFFER_WBINVL1>;
+defm BUFFER_WBINVL1           : MUBUF_Real_gfx6_gfx7<0x071>;
 
 //===----------------------------------------------------------------------===//
 // Base ENC_MTBUF for GFX6, GFX7, GFX10, GFX11.
@@ -2892,18 +2869,19 @@ class Base_MTBUF_Real_gfx6_gfx7_gfx10_gfx11<MTBUF_Pseudo ps, int ef,
   let Inst{63-56} = !if(ps.has_soffset, soffset, ?);
 }
 
-class MTBUF_Real_gfx11<bits<4> op, MTBUF_Pseudo ps,
-                       string real_name = ps.Mnemonic> :
-  Base_MTBUF_Real_gfx6_gfx7_gfx10_gfx11<ps, SIEncodingFamily.GFX11, real_name> {
-  let Inst{12}    = !if(ps.has_slc, cpol{CPolBit.SLC}, ?);
-  let Inst{13}    = !if(ps.has_dlc, cpol{CPolBit.DLC}, ps.dlc_value);
-  let Inst{18-15} = op;
-  let Inst{25-19} = format;
-  let Inst{53}    = ps.tfe;
-  let Inst{54}    = ps.offen;
-  let Inst{55}    = ps.idxen;
-  let AssemblerPredicate = isGFX11Only;
-  let DecoderNamespace = "GFX11";
+multiclass MTBUF_Real_gfx11<bits<4> op, string real_name> {
+  defvar ps = !cast<MTBUF_Pseudo>(NAME);
+  def _gfx11 : Base_MTBUF_Real_gfx6_gfx7_gfx10_gfx11<ps, SIEncodingFamily.GFX11, real_name> {
+    let Inst{12}    = !if(ps.has_slc, cpol{CPolBit.SLC}, ?);
+    let Inst{13}    = !if(ps.has_dlc, cpol{CPolBit.DLC}, ps.dlc_value);
+    let Inst{18-15} = op;
+    let Inst{25-19} = format;
+    let Inst{53}    = ps.tfe;
+    let Inst{54}    = ps.offen;
+    let Inst{55}    = ps.idxen;
+    let AssemblerPredicate = isGFX11Only;
+    let DecoderNamespace = "GFX11";
+  }
 }
 
 class Base_MTBUF_Real_gfx6_gfx7_gfx10<bits<3> op, MTBUF_Pseudo ps, int ef> :
@@ -2920,23 +2898,15 @@ class Base_MTBUF_Real_gfx6_gfx7_gfx10<bits<3> op, MTBUF_Pseudo ps, int ef> :
 //===----------------------------------------------------------------------===//
 
 multiclass MTBUF_Real_AllAddr_gfx11_gfx12_Renamed_Impl<bits<4> op, string real_name> {
-  def _BOTHEN_gfx11 :
-    MTBUF_Real_gfx11<op, !cast<MTBUF_Pseudo>(NAME#"_BOTHEN"), real_name>;
-  def _IDXEN_gfx11 :
-    MTBUF_Real_gfx11<op, !cast<MTBUF_Pseudo>(NAME#"_IDXEN"), real_name>;
-  def _OFFEN_gfx11 :
-    MTBUF_Real_gfx11<op, !cast<MTBUF_Pseudo>(NAME#"_OFFEN"), real_name>;
-  def _OFFSET_gfx11 :
-    MTBUF_Real_gfx11<op, !cast<MTBUF_Pseudo>(NAME#"_OFFSET"), real_name>;
+  defm _BOTHEN : MTBUF_Real_gfx11<op, real_name>;
+  defm _IDXEN  : MTBUF_Real_gfx11<op, real_name>;
+  defm _OFFEN  : MTBUF_Real_gfx11<op, real_name>;
+  defm _OFFSET : MTBUF_Real_gfx11<op, real_name>;
 
-  def _BOTHEN_gfx12 :
-    VBUFFER_MTBUF_Real_gfx12<op, !cast<MTBUF_Pseudo>(NAME#"_VBUFFER_BOTHEN"), real_name>;
-  def _IDXEN_gfx12 :
-    VBUFFER_MTBUF_Real_gfx12<op, !cast<MTBUF_Pseudo>(NAME#"_VBUFFER_IDXEN"), real_name>;
-  def _OFFEN_gfx12 :
-    VBUFFER_MTBUF_Real_gfx12<op, !cast<MTBUF_Pseudo>(NAME#"_VBUFFER_OFFEN"), real_name>;
-  def _OFFSET_gfx12 :
-    VBUFFER_MTBUF_Real_gfx12<op, !cast<MTBUF_Pseudo>(NAME#"_VBUFFER_OFFSET"), real_name>;
+  defm _VBUFFER_BOTHEN : VBUFFER_MTBUF_Real_gfx12<op, real_name>;
+  defm _VBUFFER_IDXEN  : VBUFFER_MTBUF_Real_gfx12<op, real_name>;
+  defm _VBUFFER_OFFEN  : VBUFFER_MTBUF_Real_gfx12<op, real_name>;
+  defm _VBUFFER_OFFSET : VBUFFER_MTBUF_Real_gfx12<op, real_name>;
 }
 
 multiclass MTBUF_Real_AllAddr_gfx11_gfx12<bits<4> op>
@@ -2970,24 +2940,22 @@ defm TBUFFER_STORE_FORMAT_XYZW     : MTBUF_Real_AllAddr_gfx11_gfx12<0x007>;
 // MTBUF - GFX10.
 //===----------------------------------------------------------------------===//
 
-class MTBUF_Real_gfx10<bits<4> op, MTBUF_Pseudo ps> :
-    Base_MTBUF_Real_gfx6_gfx7_gfx10<op{2-0}, ps, SIEncodingFamily.GFX10> {
-  let Inst{15} = !if(ps.has_dlc, cpol{CPolBit.DLC}, ps.dlc_value);
-  let Inst{25-19} = format;
-  let Inst{53} = op{3};
-  let AssemblerPredicate = isGFX10Only;
-  let DecoderNamespace = "GFX10";
+multiclass MTBUF_Real_gfx10<bits<4> op> {
+  defvar ps = !cast<MTBUF_Pseudo>(NAME);
+  def _gfx10 : Base_MTBUF_Real_gfx6_gfx7_gfx10<op{2-0}, ps, SIEncodingFamily.GFX10> {
+    let Inst{15} = !if(ps.has_dlc, cpol{CPolBit.DLC}, ps.dlc_value);
+    let Inst{25-19} = format;
+    let Inst{53} = op{3};
+    let AssemblerPredicate = isGFX10Only;
+    let DecoderNamespace = "GFX10";
+  }
 }
 
 multiclass MTBUF_Real_AllAddr_gfx10<bits<4> op> {
-  def _BOTHEN_gfx10 :
-    MTBUF_Real_gfx10<op, !cast<MTBUF_Pseudo>(NAME#"_BOTHEN")>;
-  def _IDXEN_gfx10 :
-    MTBUF_Real_gfx10<op, !cast<MTBUF_Pseudo>(NAME#"_IDXEN")>;
-  def _OFFEN_gfx10 :
-    MTBUF_Real_gfx10<op, !cast<MTBUF_Pseudo>(NAME#"_OFFEN")>;
-  def _OFFSET_gfx10 :
-    MTBUF_Real_gfx10<op, !cast<MTBUF_Pseudo>(NAME#"_OFFSET")>;
+  defm _BOTHEN : MTBUF_Real_gfx10<op>;
+  defm _IDXEN  : MTBUF_Real_gfx10<op>;
+  defm _OFFEN  : MTBUF_Real_gfx10<op>;
+  defm _OFFSET : MTBUF_Real_gfx10<op>;
 }
 
 defm TBUFFER_LOAD_FORMAT_D16_X     : MTBUF_Real_AllAddr_gfx10<0x008>;
@@ -3003,26 +2971,23 @@ defm TBUFFER_STORE_FORMAT_D16_XYZW : MTBUF_Real_AllAddr_gfx10<0x00f>;
 // MTBUF - GFX6, GFX7, GFX10.
 //===----------------------------------------------------------------------===//
 
-class MTBUF_Real_gfx6_gfx7<bits<4> op, MTBUF_Pseudo ps> :
-    Base_MTBUF_Real_gfx6_gfx7_gfx10<op{2-0}, ps, SIEncodingFamily.SI> {
-  let Inst{15} = ps.addr64;
-  let Inst{22-19} = dfmt;
-  let Inst{25-23} = nfmt;
-  let AssemblerPredicate = isGFX6GFX7;
-  let DecoderNamespace = "GFX6GFX7";
+multiclass MTBUF_Real_gfx6_gfx7<bits<4> op> {
+  defvar ps = !cast<MTBUF_Pseudo>(NAME);
+  def _gfx6_gfx7 : Base_MTBUF_Real_gfx6_gfx7_gfx10<op{2-0}, ps, SIEncodingFamily.SI> {
+    let Inst{15} = ps.addr64;
+    let Inst{22-19} = dfmt;
+    let Inst{25-23} = nfmt;
+    let AssemblerPredicate = isGFX6GFX7;
+    let DecoderNamespace = "GFX6GFX7";
+  }
 }
 
 multiclass MTBUF_Real_AllAddr_gfx6_gfx7<bits<4> op> {
-  def _ADDR64_gfx6_gfx7 :
-    MTBUF_Real_gfx6_gfx7<op, !cast<MTBUF_Pseudo>(NAME#"_ADDR64")>;
-  def _BOTHEN_gfx6_gfx7 :
-    MTBUF_Real_gfx6_gfx7<op, !cast<MTBUF_Pseudo>(NAME#"_BOTHEN")>;
-  def _IDXEN_gfx6_gfx7 :
-    MTBUF_Real_gfx6_gfx7<op, !cast<MTBUF_Pseudo>(NAME#"_IDXEN")>;
-  def _OFFEN_gfx6_gfx7 :
-    MTBUF_Real_gfx6_gfx7<op, !cast<MTBUF_Pseudo>(NAME#"_OFFEN")>;
-  def _OFFSET_gfx6_gfx7 :
-    MTBUF_Real_gfx6_gfx7<op, !cast<MTBUF_Pseudo>(NAME#"_OFFSET")>;
+  defm _ADDR64 : MTBUF_Real_gfx6_gfx7<op>;
+  defm _BOTHEN : MTBUF_Real_gfx6_gfx7<op>;
+  defm _IDXEN  : MTBUF_Real_gfx6_gfx7<op>;
+  defm _OFFEN  : MTBUF_Real_gfx6_gfx7<op>;
+  defm _OFFSET : MTBUF_Real_gfx6_gfx7<op>;
 }
 
 multiclass MTBUF_Real_AllAddr_gfx6_gfx7_gfx10<bits<4> op> :
@@ -3062,23 +3027,28 @@ class MUBUF_Real_Base_vi <bits<7> op, MUBUF_Pseudo ps, int Enc,
   let Inst{63-56} = !if(ps.has_soffset, soffset, ?);
 }
 
-class MUBUF_Real_vi <bits<7> op, MUBUF_Pseudo ps, bit has_sccb = ps.has_sccb> :
-  MUBUF_Real_Base_vi<op, ps, SIEncodingFamily.VI, has_sccb> {
-  let AssemblerPredicate = isGFX8GFX9NotGFX90A;
-  let DecoderNamespace = "GFX8";
+multiclass MUBUF_Real_vi <bits<7> op,
+                          bit has_sccb = !cast<MUBUF_Pseudo>(NAME).has_sccb> {
+  defvar ps = !cast<MUBUF_Pseudo>(NAME);
+  def _vi : MUBUF_Real_Base_vi<op, ps, SIEncodingFamily.VI, has_sccb> {
+    let AssemblerPredicate = isGFX8GFX9NotGFX90A;
+    let DecoderNamespace = "GFX8";
 
-  let Inst{55}    = ps.tfe;
+    let Inst{55}    = ps.tfe;
+  }
 }
 
-class MUBUF_Real_gfx90a <bits<7> op, MUBUF_Pseudo ps,
-                         bit has_sccb = ps.has_sccb> :
-  MUBUF_Real_Base_vi<op, ps, SIEncodingFamily.GFX90A, has_sccb> {
-  let AssemblerPredicate = isGFX90APlus;
-  let DecoderNamespace = "GFX90A";
-  let AsmString = ps.Mnemonic # !subst("$sccb", !if(has_sccb, "$sccb",""),
-                                ps.AsmOperands);
+multiclass MUBUF_Real_gfx90a <bits<7> op,
+                              bit has_sccb = !cast<MUBUF_Pseudo>(NAME).has_sccb> {
+  defvar ps = !cast<MUBUF_Pseudo>(NAME);
+  def _gfx90a : MUBUF_Real_Base_vi<op, ps, SIEncodingFamily.GFX90A, has_sccb> {
+    let AssemblerPredicate = isGFX90APlus;
+    let DecoderNamespace = "GFX90A";
+    let AsmString = ps.Mnemonic # !subst("$sccb", !if(has_sccb, "$sccb",""),
+                                  ps.AsmOperands);
 
-  let Inst{55}    = acc;
+    let Inst{55}    = acc;
+  }
 }
 
 class MUBUF_Real_gfx940 <bits<7> op, MUBUF_Pseudo ps> :
@@ -3090,28 +3060,27 @@ class MUBUF_Real_gfx940 <bits<7> op, MUBUF_Pseudo ps> :
   let Inst{55} = acc;
 }
 
-multiclass MUBUF_Real_vi_gfx90a<bits<7> op, MUBUF_Pseudo ps, bit isTFE = 0> {
-  def _vi :     MUBUF_Real_vi<op, ps>;
+multiclass MUBUF_Real_vi_gfx90a<bits<7> op, bit isTFE = 0> : MUBUF_Real_vi<op> {
+  defvar ps = !cast<MUBUF_Pseudo>(NAME);
 
   if !not(isTFE) then {
     if !not(ps.FPAtomic) then
-      def _gfx90a : MUBUF_Real_gfx90a<op, ps>;
+      defm NAME : MUBUF_Real_gfx90a<op>;
   }
 
   if ps.FPAtomic then {
-    def _gfx90a : MUBUF_Real_gfx90a<op, ps, 0> {
-      let SubtargetPredicate = isGFX90AOnly;
-      let AssemblerPredicate = isGFX90AOnly;
-    }
+    let SubtargetPredicate = isGFX90AOnly,
+        AssemblerPredicate = isGFX90AOnly in
+    defm NAME : MUBUF_Real_gfx90a<op, 0>;
     def _gfx940 : MUBUF_Real_gfx940<op, ps>;
   }
 }
 
 multiclass MUBUF_Real_AllAddr_Helper_vi<bits<7> op, bit isTFE = 0> {
-  defm _OFFSET : MUBUF_Real_vi_gfx90a <op, !cast<MUBUF_Pseudo>(NAME#"_OFFSET"), isTFE>;
-  defm _OFFEN  : MUBUF_Real_vi_gfx90a <op, !cast<MUBUF_Pseudo>(NAME#"_OFFEN"), isTFE>;
-  defm _IDXEN  : MUBUF_Real_vi_gfx90a <op, !cast<MUBUF_Pseudo>(NAME#"_IDXEN"), isTFE>;
-  defm _BOTHEN : MUBUF_Real_vi_gfx90a <op, !cast<MUBUF_Pseudo>(NAME#"_BOTHEN"), isTFE>;
+  defm _OFFSET : MUBUF_Real_vi_gfx90a <op, isTFE>;
+  defm _OFFEN  : MUBUF_Real_vi_gfx90a <op, isTFE>;
+  defm _IDXEN  : MUBUF_Real_vi_gfx90a <op, isTFE>;
+  defm _BOTHEN : MUBUF_Real_vi_gfx90a <op, isTFE>;
 }
 
 multiclass MUBUF_Real_AllAddr_vi<bits<7> op, bit hasTFE = 1> {
@@ -3121,26 +3090,26 @@ multiclass MUBUF_Real_AllAddr_vi<bits<7> op, bit hasTFE = 1> {
 }
 
 multiclass MUBUF_Real_AllAddr_Lds_Helper_vi<bits<7> op, bit isTFE = 0> {
-  def _OFFSET_vi : MUBUF_Real_vi <op, !cast<MUBUF_Pseudo>(NAME#"_OFFSET")>;
-  def _OFFEN_vi  : MUBUF_Real_vi <op, !cast<MUBUF_Pseudo>(NAME#"_OFFEN")>;
-  def _IDXEN_vi  : MUBUF_Real_vi <op, !cast<MUBUF_Pseudo>(NAME#"_IDXEN")>;
-  def _BOTHEN_vi : MUBUF_Real_vi <op, !cast<MUBUF_Pseudo>(NAME#"_BOTHEN")>;
+  defm _OFFSET : MUBUF_Real_vi <op>;
+  defm _OFFEN  : MUBUF_Real_vi <op>;
+  defm _IDXEN  : MUBUF_Real_vi <op>;
+  defm _BOTHEN : MUBUF_Real_vi <op>;
 
   if !not(isTFE) then {
-    def _LDS_OFFSET_vi : MUBUF_Real_vi <op, !cast<MUBUF_Pseudo>(NAME#"_LDS_OFFSET")>;
-    def _LDS_OFFEN_vi  : MUBUF_Real_vi <op, !cast<MUBUF_Pseudo>(NAME#"_LDS_OFFEN")>;
-    def _LDS_IDXEN_vi  : MUBUF_Real_vi <op, !cast<MUBUF_Pseudo>(NAME#"_LDS_IDXEN")>;
-    def _LDS_BOTHEN_vi : MUBUF_Real_vi <op, !cast<MUBUF_Pseudo>(NAME#"_LDS_BOTHEN")>;
+    defm _LDS_OFFSET : MUBUF_Real_vi <op>;
+    defm _LDS_OFFEN  : MUBUF_Real_vi <op>;
+    defm _LDS_IDXEN  : MUBUF_Real_vi <op>;
+    defm _LDS_BOTHEN : MUBUF_Real_vi <op>;
 
-    def _OFFSET_gfx90a : MUBUF_Real_gfx90a <op, !cast<MUBUF_Pseudo>(NAME#"_OFFSET")>;
-    def _OFFEN_gfx90a  : MUBUF_Real_gfx90a <op, !cast<MUBUF_Pseudo>(NAME#"_OFFEN")>;
-    def _IDXEN_gfx90a  : MUBUF_Real_gfx90a <op, !cast<MUBUF_Pseudo>(NAME#"_IDXEN")>;
-    def _BOTHEN_gfx90a : MUBUF_Real_gfx90a <op, !cast<MUBUF_Pseudo>(NAME#"_BOTHEN")>;
+    defm _OFFSET : MUBUF_Real_gfx90a <op>;
+    defm _OFFEN  : MUBUF_Real_gfx90a <op>;
+    defm _IDXEN  : MUBUF_Real_gfx90a <op>;
+    defm _BOTHEN : MUBUF_Real_gfx90a <op>;
 
-    def _LDS_OFFSET_gfx90a : MUBUF_Real_gfx90a <op, !cast<MUBUF_Pseudo>(NAME#"_LDS_OFFSET")>;
-    def _LDS_OFFEN_gfx90a  : MUBUF_Real_gfx90a <op, !cast<MUBUF_Pseudo>(NAME#"_LDS_OFFEN")>;
-    def _LDS_IDXEN_gfx90a  : MUBUF_Real_gfx90a <op, !cast<MUBUF_Pseudo>(NAME#"_LDS_IDXEN")>;
-    def _LDS_BOTHEN_gfx90a : MUBUF_Real_gfx90a <op, !cast<MUBUF_Pseudo>(NAME#"_LDS_BOTHEN")>;
+    defm _LDS_OFFSET : MUBUF_Real_gfx90a <op>;
+    defm _LDS_OFFEN  : MUBUF_Real_gfx90a <op>;
+    defm _LDS_IDXEN  : MUBUF_Real_gfx90a <op>;
+    defm _LDS_BOTHEN : MUBUF_Real_gfx90a <op>;
   }
 }
 
@@ -3149,33 +3118,35 @@ multiclass MUBUF_Real_AllAddr_Lds_vi<bits<7> op> {
   defm _TFE : MUBUF_Real_AllAddr_Lds_Helper_vi<op, 1>;
 }
 
-class MUBUF_Real_gfx80 <bits<7> op, MUBUF_Pseudo ps> :
-  MUBUF_Real<ps>,
-  Enc64,
-  SIMCInstr<ps.PseudoInstr, SIEncodingFamily.GFX80> {
-  let AssemblerPredicate=HasUnpackedD16VMem;
-  let DecoderNamespace="GFX80_UNPACKED";
+multiclass MUBUF_Real_gfx80 <bits<7> op> {
+  defvar ps = !cast<MUBUF_Pseudo>(NAME);
+  def _gfx80 : MUBUF_Real<ps>,
+               Enc64,
+               SIMCInstr<ps.PseudoInstr, SIEncodingFamily.GFX80> {
+    let AssemblerPredicate=HasUnpackedD16VMem;
+    let DecoderNamespace="GFX80_UNPACKED";
 
-  let Inst{11-0}  = !if(ps.has_offset, offset, ?);
-  let Inst{12}    = ps.offen;
-  let Inst{13}    = ps.idxen;
-  let Inst{14}    = !if(ps.has_glc, cpol{CPolBit.GLC}, ps.glc_value);
-  let Inst{16}    = ps.lds;
-  let Inst{17}    = !if(ps.has_slc, cpol{CPolBit.SLC}, ?);
-  let Inst{24-18} = op;
-  let Inst{31-26} = 0x38; //encoding
-  let Inst{39-32} = !if(ps.has_vaddr, vaddr, ?);
-  let Inst{47-40} = !if(ps.has_vdata, vdata{7-0}, ?);
-  let Inst{52-48} = !if(ps.has_srsrc, srsrc{6-2}, ?);
-  let Inst{55}    = ps.tfe;
-  let Inst{63-56} = !if(ps.has_soffset, soffset, ?);
+    let Inst{11-0}  = !if(ps.has_offset, offset, ?);
+    let Inst{12}    = ps.offen;
+    let Inst{13}    = ps.idxen;
+    let Inst{14}    = !if(ps.has_glc, cpol{CPolBit.GLC}, ps.glc_value);
+    let Inst{16}    = ps.lds;
+    let Inst{17}    = !if(ps.has_slc, cpol{CPolBit.SLC}, ?);
+    let Inst{24-18} = op;
+    let Inst{31-26} = 0x38; //encoding
+    let Inst{39-32} = !if(ps.has_vaddr, vaddr, ?);
+    let Inst{47-40} = !if(ps.has_vdata, vdata{7-0}, ?);
+    let Inst{52-48} = !if(ps.has_srsrc, srsrc{6-2}, ?);
+    let Inst{55}    = ps.tfe;
+    let Inst{63-56} = !if(ps.has_soffset, soffset, ?);
+  }
 }
 
 multiclass MUBUF_Real_AllAddr_Helper_gfx80<bits<7> op> {
-  def _OFFSET_gfx80 : MUBUF_Real_gfx80 <op, !cast<MUBUF_Pseudo>(NAME#"_OFFSET")>;
-  def _OFFEN_gfx80  : MUBUF_Real_gfx80 <op, !cast<MUBUF_Pseudo>(NAME#"_OFFEN")>;
-  def _IDXEN_gfx80  : MUBUF_Real_gfx80 <op, !cast<MUBUF_Pseudo>(NAME#"_IDXEN")>;
-  def _BOTHEN_gfx80 : MUBUF_Real_gfx80 <op, !cast<MUBUF_Pseudo>(NAME#"_BOTHEN")>;
+  defm _OFFSET : MUBUF_Real_gfx80 <op>;
+  defm _OFFEN  : MUBUF_Real_gfx80 <op>;
+  defm _IDXEN  : MUBUF_Real_gfx80 <op>;
+  defm _BOTHEN : MUBUF_Real_gfx80 <op>;
 }
 
 multiclass MUBUF_Real_AllAddr_gfx80<bits<7> op> {
@@ -3185,10 +3156,10 @@ multiclass MUBUF_Real_AllAddr_gfx80<bits<7> op> {
 
 multiclass MUBUF_Real_Atomic_vi<bits<7> op> :
   MUBUF_Real_AllAddr_vi<op, 0> {
-  defm _OFFSET_RTN : MUBUF_Real_vi_gfx90a <op, !cast<MUBUF_Pseudo>(NAME#"_OFFSET_RTN")>;
-  defm _OFFEN_RTN  : MUBUF_Real_vi_gfx90a <op, !cast<MUBUF_Pseudo>(NAME#"_OFFEN_RTN")>;
-  defm _IDXEN_RTN  : MUBUF_Real_vi_gfx90a <op, !cast<MUBUF_Pseudo>(NAME#"_IDXEN_RTN")>;
-  defm _BOTHEN_RTN : MUBUF_Real_vi_gfx90a <op, !cast<MUBUF_Pseudo>(NAME#"_BOTHEN_RTN")>;
+  defm _OFFSET_RTN : MUBUF_Real_vi_gfx90a <op>;
+  defm _OFFEN_RTN  : MUBUF_Real_vi_gfx90a <op>;
+  defm _IDXEN_RTN  : MUBUF_Real_vi_gfx90a <op>;
+  defm _BOTHEN_RTN : MUBUF_Real_vi_gfx90a <op>;
 }
 
 defm BUFFER_LOAD_FORMAT_X       : MUBUF_Real_AllAddr_Lds_vi <0x00>;
@@ -3274,11 +3245,11 @@ defm BUFFER_ATOMIC_XOR_X2       : MUBUF_Real_Atomic_vi <0x6a>;
 defm BUFFER_ATOMIC_INC_X2       : MUBUF_Real_Atomic_vi <0x6b>;
 defm BUFFER_ATOMIC_DEC_X2       : MUBUF_Real_Atomic_vi <0x6c>;
 
-defm BUFFER_STORE_LDS_DWORD     : MUBUF_Real_vi_gfx90a <0x3d, BUFFER_STORE_LDS_DWORD>;
+defm BUFFER_STORE_LDS_DWORD     : MUBUF_Real_vi_gfx90a <0x3d>;
 
 let AssemblerPredicate = isGFX8GFX9 in {
-def BUFFER_WBINVL1_vi           : MUBUF_Real_vi <0x3e, BUFFER_WBINVL1>;
-def BUFFER_WBINVL1_VOL_vi       : MUBUF_Real_vi <0x3f, BUFFER_WBINVL1_VOL>;
+defm BUFFER_WBINVL1             : MUBUF_Real_vi <0x3e>;
+defm BUFFER_WBINVL1_VOL         : MUBUF_Real_vi <0x3f>;
 } // End AssemblerPredicate = isGFX8GFX9
 
 
@@ -3294,12 +3265,11 @@ let SubtargetPredicate = isGFX90APlus in {
   defm BUFFER_ATOMIC_MAX_F64 : MUBUF_Real_Atomic_vi<0x51>;
 } // End SubtargetPredicate = isGFX90APlus
 
-def BUFFER_WBL2_gfx90a  : MUBUF_Real_gfx90a<0x28, BUFFER_WBL2> {
-  let AsmString = BUFFER_WBL2.Mnemonic; // drop flags
-  let AssemblerPredicate = isGFX90AOnly;
-  let SubtargetPredicate = isGFX90AOnly;
-}
-def BUFFER_INVL2_gfx90a : MUBUF_Real_gfx90a<0x29, BUFFER_INVL2>;
+let AsmString = BUFFER_WBL2.Mnemonic, // drop flags
+    AssemblerPredicate = isGFX90AOnly,
+    SubtargetPredicate = isGFX90AOnly in
+defm BUFFER_WBL2  : MUBUF_Real_gfx90a<0x28>;
+defm BUFFER_INVL2 : MUBUF_Real_gfx90a<0x29>;
 
 let SubtargetPredicate = isGFX940Plus in {
 def BUFFER_WBL2_gfx940  : MUBUF_Real_gfx940<0x28, BUFFER_WBL2>;
@@ -3345,46 +3315,49 @@ class MTBUF_Real_gfx90a <bits<4> op, MTBUF_Pseudo ps> :
   let Inst{55}    = acc;
 }
 
-multiclass MTBUF_Real_vi_gfx90a<bits<4> op, MTBUF_Pseudo ps> {
+multiclass MTBUF_Real_vi_gfx90a<bits<4> op> {
+  defvar ps = !cast<MTBUF_Pseudo>(NAME);
   def _vi :     MTBUF_Real_vi<op, ps>;
   def _gfx90a : MTBUF_Real_gfx90a<op, ps>;
 }
 
 multiclass MTBUF_Real_AllAddr_vi<bits<4> op> {
-  defm _OFFSET : MTBUF_Real_vi_gfx90a <op, !cast<MTBUF_Pseudo>(NAME#"_OFFSET")>;
-  defm _OFFEN  : MTBUF_Real_vi_gfx90a <op, !cast<MTBUF_Pseudo>(NAME#"_OFFEN")>;
-  defm _IDXEN  : MTBUF_Real_vi_gfx90a <op, !cast<MTBUF_Pseudo>(NAME#"_IDXEN")>;
-  defm _BOTHEN : MTBUF_Real_vi_gfx90a <op, !cast<MTBUF_Pseudo>(NAME#"_BOTHEN")>;
+  defm _OFFSET : MTBUF_Real_vi_gfx90a <op>;
+  defm _OFFEN  : MTBUF_Real_vi_gfx90a <op>;
+  defm _IDXEN  : MTBUF_Real_vi_gfx90a <op>;
+  defm _BOTHEN : MTBUF_Real_vi_gfx90a <op>;
 }
 
-class MTBUF_Real_gfx80 <bits<4> op, MTBUF_Pseudo ps> :
-  MTBUF_Real<ps>,
-  Enc64,
-  SIMCInstr<ps.PseudoInstr, SIEncodingFamily.GFX80> {
-  let AssemblerPredicate=HasUnpackedD16VMem;
-  let DecoderNamespace="GFX80_UNPACKED";
+multiclass MTBUF_Real_gfx80 <bits<4> op> {
+  defvar ps = !cast<MTBUF_Pseudo>(NAME);
+  def _gfx80 : MTBUF_Real<ps>,
+               Enc64,
+               SIMCInstr<ps.PseudoInstr, SIEncodingFamily.GFX80> {
+    let AssemblerPredicate=HasUnpackedD16VMem;
+    let DecoderNamespace="GFX80_UNPACKED";
 
-  let Inst{11-0}  = !if(ps.has_offset, offset, ?);
-  let Inst{12}    = ps.offen;
-  let Inst{13}    = ps.idxen;
-  let Inst{14}    = !if(ps.has_glc, cpol{CPolBit.GLC}, ps.glc_value);
-  let Inst{18-15} = op;
-  let Inst{22-19} = dfmt;
-  let Inst{25-23} = nfmt;
-  let Inst{31-26} = 0x3a; //encoding
-  let Inst{39-32} = !if(ps.has_vaddr, vaddr, ?);
-  let Inst{47-40} = !if(ps.has_vdata, vdata{7-0}, ?);
-  let Inst{52-48} = !if(ps.has_srsrc, srsrc{6-2}, ?);
-  let Inst{54}    = !if(ps.has_slc, cpol{CPolBit.SLC}, ?);
-  let Inst{55}    = ps.tfe;
-  let Inst{63-56} = !if(ps.has_soffset, soffset, ?);
+    let Inst{11-0}  = !if(ps.has_offset, offset, ?);
+    let Inst{12}    = ps.offen;
+    let Inst{13}    = ps.idxen;
+    let Inst{14}    = !if(ps.has_glc, cpol{CPolBit.GLC}, ps.glc_value);
+    let Inst{18-15} = op;
+    let Inst{22-19} = dfmt;
+    let Inst{25-23} = nfmt;
+    let Inst{31-26} = 0x3a; //encoding
+    let Inst{39-32} = !if(ps.has_vaddr, vaddr, ?);
+    let Inst{47-40} = !if(ps.has_vdata, vdata{7-0}, ?);
+    let Inst{52-48} = !if(ps.has_srsrc, srsrc{6-2}, ?);
+    let Inst{54}    = !if(ps.has_slc, cpol{CPolBit.SLC}, ?);
+    let Inst{55}    = ps.tfe;
+    let Inst{63-56} = !if(ps.has_soffset, soffset, ?);
+  }
 }
 
 multiclass MTBUF_Real_AllAddr_gfx80<bits<4> op> {
-  def _OFFSET_gfx80 : MTBUF_Real_gfx80 <op, !cast<MTBUF_Pseudo>(NAME#"_OFFSET")>;
-  def _OFFEN_gfx80  : MTBUF_Real_gfx80 <op, !cast<MTBUF_Pseudo>(NAME#"_OFFEN")>;
-  def _IDXEN_gfx80  : MTBUF_Real_gfx80 <op, !cast<MTBUF_Pseudo>(NAME#"_IDXEN")>;
-  def _BOTHEN_gfx80 : MTBUF_Real_gfx80 <op, !cast<MTBUF_Pseudo>(NAME#"_BOTHEN")>;
+  defm _OFFSET : MTBUF_Real_gfx80 <op>;
+  defm _OFFEN  : MTBUF_Real_gfx80 <op>;
+  defm _IDXEN  : MTBUF_Real_gfx80 <op>;
+  defm _BOTHEN : MTBUF_Real_gfx80 <op>;
 }
 
 defm TBUFFER_LOAD_FORMAT_X     : MTBUF_Real_AllAddr_vi <0x00>;


### PR DESCRIPTION
Define BUF Real instructions with this general pattern for all
architectures (not just GFX11):

  multiclass Something_Real_gfx11<...> {
    defvar ps = !cast<Pseudo>(NAME);
    def _gfx11 : ...;
  }

This allows removing a huge amount of repetition in the definitions of
individual Real instructions, where they would have to !cast their own
name to a Pseudo and pass that in as a class argument.