### PR TITLE
[mlir][tosa] Add support for 0 dim in ReshapeOp

### DIFF
--- a/mlir/lib/Dialect/Tosa/IR/TosaOps.cpp
+++ b/mlir/lib/Dialect/Tosa/IR/TosaOps.cpp
@@ -928,10 +928,16 @@ LogicalResult tosa::ReshapeOp::inferReturnTypeComponents(
   // dimension.
   int64_t numElements = inputShape.getNumElements();
   int64_t staticMul = 1;
-  for (auto val : newShapeValue) {
+  int i = 0;
+  for (auto &val : newShapeValue) {
+    if (val == 0) {
+      // Swap 0 dim with corresponding input dim
+      val = inputShape.getDimSize(i);
+    }
     if (!ShapedType::isDynamic(val)) {
       staticMul *= val;
     }
+    i++;
   }
 
   // Determine the length of the dynamic dimension.


### PR DESCRIPTION
This change adds support for onnx models with 0 values in reshape op
shape input.

By default, when any value in the ‘shape’ input is equal to zero the
corresponding dimension value is copied from the input tensor dynamically.
Source: https://onnx.ai/onnx/operators/onnx__Reshape.html