### PR TITLE
[clang-tidy] `isOnlyUsedAsConst`: Handle static method calls.

### DIFF
--- a/clang-tools-extra/clang-tidy/utils/DeclRefExprUtils.cpp
+++ b/clang-tools-extra/clang-tidy/utils/DeclRefExprUtils.cpp
@@ -155,15 +155,16 @@ AST_MATCHER_P(DeclRefExpr, doesNotMutateObject, int, Indirections) {
       if (const auto *const Member = dyn_cast<MemberExpr>(P)) {
         if (const auto *const Method =
                 dyn_cast<CXXMethodDecl>(Member->getMemberDecl())) {
-          if (!Method->isConst()) {
-            // The method can mutate our variable.
-            return false;
+          if (Method->isConst() || Method->isStatic()) {
+            // The method call cannot mutate our variable.
+            continue;
           }
-          continue;
+          return false;
         }
         Stack.emplace_back(Member, 0);
         continue;
       }
+
       if (const auto *const Op = dyn_cast<UnaryOperator>(P)) {
         switch (Op->getOpcode()) {
         case UO_AddrOf:

--- a/clang-tools-extra/unittests/clang-tidy/DeclRefExprUtilsTest.cpp
+++ b/clang-tools-extra/unittests/clang-tidy/DeclRefExprUtilsTest.cpp
@@ -51,6 +51,8 @@ template <int Indirections> void RunTest(StringRef Snippet) {
       void constMethod() const;
       void nonConstMethod();
 
+      static void staticMethod();
+
       void operator()(ConstTag) const;
       void operator()(NonConstTag);
 
@@ -109,10 +111,12 @@ TEST(ConstReferenceDeclRefExprsTest, ConstValueVar) {
       useConstPtr(&/*const*/target);
       useConstPtrConstRef(&/*const*/target);
       /*const*/target.constMethod();
+      /*const*/target.staticMethod();
       /*const*/target(ConstTag{});
       /*const*/target[42];
       useConstRef((/*const*/target));
       (/*const*/target).constMethod();
+      /*const*/target.staticMethod();
       (void)(/*const*/target == /*const*/target);
       (void)/*const*/target;
       (void)&/*const*/target;
@@ -140,6 +144,7 @@ TEST(ConstReferenceDeclRefExprsTest, ConstRefVar) {
       useConstPtr(&/*const*/target);
       useConstPtrConstRef(&/*const*/target);
       /*const*/target.constMethod();
+      /*const*/target.staticMethod();
       /*const*/target(ConstTag{});
       /*const*/target[42];
       useConstRef((/*const*/target));
@@ -179,6 +184,7 @@ TEST(ConstReferenceDeclRefExprsTest, ValueVar) {
       useConstPtr(&/*const*/target);
       useConstPtrConstRef(&/*const*/target);
       /*const*/target.constMethod();
+      /*const*/target.staticMethod();
       target.nonConstMethod();
       /*const*/target(ConstTag{});
       target[42];
@@ -218,6 +224,7 @@ TEST(ConstReferenceDeclRefExprsTest, RefVar) {
       useConstPtr(&/*const*/target);
       useConstPtrConstRef(&/*const*/target);
       /*const*/target.constMethod();
+      /*const*/target.staticMethod();
       target.nonConstMethod();
       /*const*/target(ConstTag{});
       target[42];
@@ -256,6 +263,7 @@ TEST(ConstReferenceDeclRefExprsTest, PtrVar) {
       useConstPtrConstRef(/*const*/target);
       usePtrConstPtr(&target);
       /*const*/target->constMethod();
+      /*const*/target->staticMethod();
       target->nonConstMethod();
       (*/*const*/target)(ConstTag{});
       (*target)[42];
@@ -292,6 +300,7 @@ TEST(ConstReferenceDeclRefExprsTest, ConstPtrVar) {
       useConstPtrConstPtr(&/*const*/target);
       useConstPtrConstRef(/*const*/target);
       /*const*/target->constMethod();
+      /*const*/target->staticMethod();
       (*/*const*/target)(ConstTag{});
       (*/*const*/target)[42];
       /*const*/target->operator[](42);


### PR DESCRIPTION
... using method syntax:

```
struct S {
  static void f()
};

void DoIt(S& s) {
  s.f();  // Does not mutate `s` through the `this` parameter.
}
```