### PR TITLE
[mlir][cmake] Enable -Wundef.

### DIFF
--- a/mlir/CMakeLists.txt
+++ b/mlir/CMakeLists.txt
@@ -70,6 +70,12 @@ endif()
 check_c_compiler_flag("-Werror=implicit-function-declaration" C_SUPPORTS_WERROR_IMPLICIT_FUNCTION_DECLARATION)
 append_if(C_SUPPORTS_WERROR_IMPLICIT_FUNCTION_DECLARATION "-Werror=implicit-function-declaration" CMAKE_C_FLAGS)
 
+# Warn on undefined macros. This is often an indication that an include to
+# `mlir-config.h` or similar is missing.
+check_c_compiler_flag("-Wundef" C_SUPPORTS_WUNDEF)
+append_if(C_SUPPORTS_WUNDEF "-Wundef" CMAKE_C_FLAGS)
+append_if(C_SUPPORTS_WUNDEF "-Wundef" CMAKE_CXX_FLAGS)
+
 # Forbid mismatch between declaration and definition for class vs struct. This is
 # harmless on Unix systems, but it'll be a ticking bomb for MSVC/Windows systems
 # where it creeps into the ABI.

--- a/mlir/include/mlir/Config/mlir-config.h.cmake
+++ b/mlir/include/mlir/Config/mlir-config.h.cmake
@@ -8,6 +8,13 @@
 
 /* This file enumerates variables from the MLIR configuration so that they
    can be in exported headers and won't override package specific directives.
+   Defining the variables here is preferable over specifying them in CMake files
+   via `target_compile_definitions` because it is easier to ensure that they are
+   defined consistently across all targets: They are guaranteed to be 0/1
+   variables thanks to #cmakedefine01, so we can test with `#if` and find
+   missing definitions or includes with `-Wundef`. With `#ifdef`, these mistakes
+   can go unnoticed.
+
    This is a C header that can be included in the mlir-c headers. */
 
 #ifndef MLIR_CONFIG_H


### PR DESCRIPTION
This is another follow-up of #83004, which fixed a bug due to some macros not being defined in some situations. By raising warnings on undefined macros, this kind of bug is less likely to be introduced. Similar to #83004, the fix is probably adding an include to `mlir-config.h` (and potentially defining the macro there).