### PR TITLE
[lldb][test][FreeBSD] Narrow vectorcall xfail to x86 platforms

### DIFF
--- a/lldb/test/API/lang/c/calling-conventions/TestCCallingConventions.py
+++ b/lldb/test/API/lang/c/calling-conventions/TestCCallingConventions.py
@@ -62,7 +62,10 @@ class TestCase(TestBase):
             return
         self.expect_expr("func(1, 2, 3, 4)", result_type="int", result_value="10")
 
+    # Fails on x86, passes elsewhere because clang doesn't support vectorcall on
+    # any other architectures.
     @expectedFailureAll(
+        triple=re.compile("^(x86|i386)"),
         oslist=["freebsd"], bugnumber="github.com/llvm/llvm-project/issues/56084"
     )
     def test_vectorcall(self):


### PR DESCRIPTION
This relates to #56084.

vectorcall only works on x86 https://clang.llvm.org/docs/AttributeReference.html#vectorcall so elsewhere it fails to compile. Which is expected on AArch64 for example so is treated as a pass.