### PR TITLE
[flang][MLIR][OpenMP] Extend delayed privatization for allocatables

### DIFF
--- a/flang/include/flang/Optimizer/Builder/BoxValue.h
+++ b/flang/include/flang/Optimizer/Builder/BoxValue.h
@@ -13,6 +13,8 @@
 #ifndef FORTRAN_OPTIMIZER_BUILDER_BOXVALUE_H
 #define FORTRAN_OPTIMIZER_BUILDER_BOXVALUE_H
 
+#include "flang/Optimizer/Builder/Todo.h"
+#include "flang/Optimizer/Builder/VariableShadow.h"
 #include "flang/Optimizer/Dialect/FIRType.h"
 #include "flang/Optimizer/Support/FatalError.h"
 #include "flang/Optimizer/Support/Matcher.h"
@@ -479,7 +481,8 @@ class ExtendedValue : public details::matcher<ExtendedValue> {
 public:
   using VT =
       std::variant<UnboxedValue, CharBoxValue, ArrayBoxValue, CharArrayBoxValue,
-                   ProcBoxValue, BoxValue, MutableBoxValue, PolymorphicValue>;
+                   ProcBoxValue, BoxValue, MutableBoxValue, PolymorphicValue,
+                   hlfir::FortranVariableShadow>;
 
   ExtendedValue() : box{UnboxedValue{}} {}
   template <typename A, typename = std::enable_if_t<
@@ -516,6 +519,11 @@ public:
                  [](const fir::CharBoxValue &box) -> unsigned { return 0; },
                  [](const fir::ProcBoxValue &box) -> unsigned { return 0; },
                  [](const fir::PolymorphicValue &box) -> unsigned { return 0; },
+                 [](const hlfir::FortranVariableShadow &box) -> unsigned {
+                   TODO(box.getValue().getLoc(),
+                        "rank(): FortranVariableShadow");
+                   return 0;
+                 },
                  [](const auto &box) -> unsigned { return box.rank(); });
   }
 

--- a/flang/include/flang/Optimizer/Builder/VariableShadow.h
+++ b/flang/include/flang/Optimizer/Builder/VariableShadow.h
@@ -1,0 +1,47 @@
+//===-- VariableShadow.h ----------------------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Coding style: https://mlir.llvm.org/getting_started/DeveloperGuide/
+//
+//===----------------------------------------------------------------------===//
+
+#include "flang/Optimizer/Builder/FIRBuilder.h"
+#include "flang/Optimizer/Dialect/FortranVariableInterface.h"
+#include "mlir/IR/Value.h"
+
+#ifndef FORTRAN_OPTIMIZER_BUILDER_VARIABLESHADOW_H
+#define FORTRAN_OPTIMIZER_BUILDER_VARIABLESHADOW_H
+
+namespace hlfir {
+
+class FortranVariableShadow {
+public:
+  FortranVariableShadow(fir::FirOpBuilder &builder,
+                        mlir::BlockArgument shadowingVal,
+                        fir::FortranVariableOpInterface shadowedVariable);
+
+  mlir::BlockArgument getValue() const { return shadowingVal; }
+
+  mlir::Value getBase() const { return base; }
+
+  mlir::Value getFirBase() const { return firBase; }
+
+  fir::FortranVariableOpInterface getShadowedVariable() const {
+    return shadowedVariable;
+  }
+
+private:
+  mlir::BlockArgument shadowingVal;
+  mlir::Value base;
+  mlir::Value firBase;
+  fir::FortranVariableOpInterface shadowedVariable;
+};
+
+} // namespace hlfir
+
+#endif // FORTRAN_OPTIMIZER_BUILDER_VARIABLESHADOW_H

--- a/flang/include/flang/Optimizer/Dialect/FIRTypes.td
+++ b/flang/include/flang/Optimizer/Dialect/FIRTypes.td
@@ -576,6 +576,65 @@ def fir_VoidType : FIR_Type<"Void", "void"> {
   let genStorageClass = 0;
 }
 
+def fir_VariableShadowType : FIR_Type<"Shadow", "shadow"> {
+  let summary = "Type for Fortran-variables shadow values";
+
+  let description = [{
+    A type to encapulate required data for a Fortran-variable shadow value. A
+    shadow type encapsulates the base type as well as the original base type. It
+    also encapsulates information other information about the shadowed value,
+    such as whether it is allocatable or not.
+
+    For example, if we want to shadow a value produced a `hlfir.declare`
+    instruction similar to the following:
+    ```
+    %1:2 = hlfir.declare %0
+      {fortran_attrs = #fir.var_attrs<allocatable>}
+      : (!fir.ref<!fir.box<!fir.heap<i32>>>)
+        -> (!fir.ref<!fir.box<!fir.heap<i32>>>, !fir.ref<!fir.box<!fir.heap<i32>>>)
+    ```
+
+    We would need to somehow create a value of the type:
+    ```
+    !fir.shadow<!fir.ref<!fir.box<!fir.heap<i32>>>,
+                !fir.ref<!fir.box<!fir.heap<i32>>>,
+                allocatable : true>
+    ```
+
+    The mechanism to create this value can be, for example, through a
+    combincation `fir.undefined`, `fir.insert_value` instructions similar to what
+    would be done for other composite types like `tuple`s:
+    ```
+    %2 = fir.undefined !fir.shadow<!fir.ref<!fir.box<!fir.heap<i32>>>,
+                                   !fir.ref<!fir.box<!fir.heap<i32>>>,
+                                   allocatable : true>
+    %3 = fir.insert_value %2, %1#0, [0 : index] : <... type info omitted ...>
+    %4 = fir.insert_value %3, %3#1, [1 : index] : <... type info omitted ...>
+    ```
+
+    From that point on, you can use `%4` as the shadow of the originally declared
+    variable being shadowed `%1`.
+
+    For more info about the concept of variable shadows, check `VariableShadow.h`.
+  }];
+
+  let parameters = (ins "mlir::Type":$baseTy,
+                        "mlir::Type":$firBaseTy,
+                        "bool":$allocatable);
+
+  let assemblyFormat = [{
+    `<` $baseTy `,` $firBaseTy `,` `allocatable` `:` $allocatable `>`
+  }];
+
+  let extraClassDeclaration = [{
+    mlir::Type getType(unsigned idx) const {
+      if (idx == 0) return getBaseTy();
+      if (idx == 1) return getFirBaseTy();
+      return mlir::Type();
+    }
+  }];
+}
+
 // Whether a type is a BaseBoxType
 def IsBaseBoxTypePred
         : CPred<"$_self.isa<::fir::BaseBoxType>()">;
@@ -590,13 +649,17 @@ def AnyRealLike : TypeConstraint<Or<[FloatLike.predicate,
     fir_RealType.predicate]>, "any real">;
 def AnyIntegerType : Type<AnyIntegerLike.predicate, "any integer">;
 
+def IsShadowTypePred
+        : CPred<"$_self.isa<::fir::ShadowType>()">;
+
 // Composable types
 // Note that we include both fir_ComplexType and AnyComplex, so we can use both
 // the FIR ComplexType and the MLIR ComplexType (the former is used to represent
 // Fortran complex and the latter for C++ std::complex).
 def AnyCompositeLike : TypeConstraint<Or<[fir_RecordType.predicate,
     fir_SequenceType.predicate, fir_ComplexType.predicate, AnyComplex.predicate,
-    fir_VectorType.predicate, IsTupleTypePred, fir_CharacterType.predicate]>,
+    fir_VectorType.predicate, IsTupleTypePred, fir_CharacterType.predicate,
+    IsShadowTypePred]>,
     "any composite">;
 
 // Reference types

--- a/flang/lib/Lower/ConvertExpr.cpp
+++ b/flang/lib/Lower/ConvertExpr.cpp
@@ -981,6 +981,9 @@ public:
           },
           [&](const fir::ProcBoxValue &toBox) {
             TODO(loc, "procedure pointer component in derived type assignment");
+          },
+          [&](const hlfir::FortranVariableShadow &toBox) {
+            TODO(loc, "FortranVariableShadow in derived type assignment");
           });
     }
     return res;

--- a/flang/lib/Lower/SymbolMap.cpp
+++ b/flang/lib/Lower/SymbolMap.cpp
@@ -21,16 +21,18 @@
 void Fortran::lower::SymMap::addSymbol(Fortran::semantics::SymbolRef sym,
                                        const fir::ExtendedValue &exv,
                                        bool force) {
-  exv.match([&](const fir::UnboxedValue &v) { addSymbol(sym, v, force); },
-            [&](const fir::CharBoxValue &v) { makeSym(sym, v, force); },
-            [&](const fir::ArrayBoxValue &v) { makeSym(sym, v, force); },
-            [&](const fir::CharArrayBoxValue &v) { makeSym(sym, v, force); },
-            [&](const fir::BoxValue &v) { makeSym(sym, v, force); },
-            [&](const fir::MutableBoxValue &v) { makeSym(sym, v, force); },
-            [&](const fir::PolymorphicValue &v) { makeSym(sym, v, force); },
-            [](auto) {
-              llvm::report_fatal_error("value not added to symbol table");
-            });
+  exv.match(
+      [&](const fir::UnboxedValue &v) { addSymbol(sym, v, force); },
+      [&](const fir::CharBoxValue &v) { makeSym(sym, v, force); },
+      [&](const fir::ArrayBoxValue &v) { makeSym(sym, v, force); },
+      [&](const fir::CharArrayBoxValue &v) { makeSym(sym, v, force); },
+      [&](const fir::BoxValue &v) { makeSym(sym, v, force); },
+      [&](const fir::MutableBoxValue &v) { makeSym(sym, v, force); },
+      [&](const fir::PolymorphicValue &v) { makeSym(sym, v, force); },
+      [&](const hlfir::FortranVariableShadow &v) { makeSym(sym, v, force); },
+      [](auto) {
+        llvm::report_fatal_error("value not added to symbol table");
+      });
 }
 
 Fortran::lower::SymbolBox

--- a/flang/lib/Optimizer/Builder/MutableBox.cpp
+++ b/flang/lib/Optimizer/Builder/MutableBox.cpp
@@ -562,6 +562,9 @@ void fir::factory::associateMutableBox(fir::FirOpBuilder &builder,
       },
       [&](const fir::ProcBoxValue &) {
         TODO(loc, "procedure pointer assignment");
+      },
+      [&](const hlfir::FortranVariableShadow &) {
+        TODO(loc, "FortranVariableShadow assignment");
       });
 }
 
@@ -663,6 +666,9 @@ void fir::factory::associateMutableBoxWithRemap(
       },
       [&](const fir::ProcBoxValue &) {
         TODO(loc, "procedure pointer assignment");
+      },
+      [&](const hlfir::FortranVariableShadow &) {
+        TODO(loc, "FortranVariableShadow assignment");
       });
 }
 

--- a/flang/lib/Optimizer/Dialect/FIRType.cpp
+++ b/flang/lib/Optimizer/Dialect/FIRType.cpp
@@ -1325,7 +1325,7 @@ void FIROpsDialect::registerTypes() {
            fir::ComplexType, FieldType, HeapType, fir::IntegerType, LenType,
            LogicalType, LLVMPointerType, PointerType, RealType, RecordType,
            ReferenceType, SequenceType, ShapeType, ShapeShiftType, ShiftType,
-           SliceType, TypeDescType, fir::VectorType>();
+           SliceType, TypeDescType, fir::VectorType, fir::ShadowType>();
   fir::ReferenceType::attachInterface<
       OpenMPPointerLikeModel<fir::ReferenceType>>(*getContext());
   fir::ReferenceType::attachInterface<

--- a/flang/test/Lower/OpenMP/delayed-privatization-allocatable.f90
+++ b/flang/test/Lower/OpenMP/delayed-privatization-allocatable.f90
@@ -1,0 +1,69 @@
+! Test delayed privatization for allocatables.
+
+! RUN: bbc -emit-hlfir -fopenmp --openmp-enable-delayed-privatization -o - %s 2>&1 | FileCheck %s
+
+subroutine delayed_privatization_allocatable
+  implicit none
+  integer, allocatable :: var1
+
+!$omp parallel firstprivate(var1)
+  var1 = 10
+!$omp end parallel
+end subroutine
+
+! CHECK-LABEL: omp.private {type = firstprivate}
+! CHECK-SAME: @[[PRIVATIZER_SYM:.*]] : [[TYPE:!fir.shadow<!fir.ref<!fir.box<!fir.heap<i32>>>, !fir.ref<!fir.box<!fir.heap<i32>>>, allocatable : true>]] alloc {
+
+! CHECK-NEXT: ^bb0(%[[PRIV_ARG:.*]]: [[TYPE]]):
+
+! CHECK-NEXT:  %[[BASE:.*]] = fir.extract_value %[[PRIV_ARG]], [0 : index] : ([[TYPE]])
+! CHECK-NEXT:  %[[FIR_BASE:.*]] = fir.extract_value %[[PRIV_ARG]], [1 : index] : ([[TYPE]])
+
+! CHECK-NEXT:   %[[PRIV_ALLOC:.*]] = fir.alloca !fir.box<!fir.heap<i32>> {bindc_name = "var1", pinned, uniq_name = "_QFdelayed_privatization_allocatableEvar1"}
+
+! CHECK-NEXT:   %[[FIR_BASE_VAL:.*]] = fir.load %[[FIR_BASE]] : !fir.ref<!fir.box<!fir.heap<i32>>>
+! CHECK-NEXT:   %[[FIR_BASE_BOX:.*]] = fir.box_addr %[[FIR_BASE_VAL]] : (!fir.box<!fir.heap<i32>>) -> !fir.heap<i32>
+! CHECK-NEXT:   %[[FIR_BASE_ADDR:.*]] = fir.convert %[[FIR_BASE_BOX]] : (!fir.heap<i32>) -> i64
+! CHECK-NEXT:   %[[C0:.*]] = arith.constant 0 : i64
+! CHECK-NEXT:   %[[ALLOC_COND:.*]] = arith.cmpi ne, %[[FIR_BASE_ADDR]], %[[C0]] : i64
+
+! CHECK-NEXT:   fir.if %[[ALLOC_COND]] {
+! CHECK-NEXT:     %[[PRIV_ALLOCMEM:.*]] = fir.allocmem i32 {fir.must_be_heap = true, uniq_name = "_QFdelayed_privatization_allocatableEvar1.alloc"}
+! CHECK-NEXT:     %[[PRIV_ALLOCMEM_BOX:.*]] = fir.embox %[[PRIV_ALLOCMEM]] : (!fir.heap<i32>) -> !fir.box<!fir.heap<i32>>
+! CHECK-NEXT:     fir.store %[[PRIV_ALLOCMEM_BOX]] to %[[PRIV_ALLOC]] : !fir.ref<!fir.box<!fir.heap<i32>>>
+! CHECK-NEXT:   } else {
+! CHECK-NEXT:     %[[ZERO_BITS:.*]] = fir.zero_bits !fir.heap<i32>
+! CHECK-NEXT:     %[[ZERO_BOX:.*]] = fir.embox %[[ZERO_BITS]] : (!fir.heap<i32>) -> !fir.box<!fir.heap<i32>>
+! CHECK-NEXT:     fir.store %[[ZERO_BOX]] to %[[PRIV_ALLOC]] : !fir.ref<!fir.box<!fir.heap<i32>>>
+! CHECK-NEXT:   }
+
+! CHECK-NEXT:   %[[PRIV_DECL:.*]]:2 = hlfir.declare %[[PRIV_ALLOC]]
+
+! CHECK-NEXT:   %[[PRIV_SHADOW:.*]] = fir.undefined [[TYPE]]
+! CHECK-NEXT:   %[[PRIV_SHADOW_2:.*]] = fir.insert_value %[[PRIV_SHADOW]], %[[PRIV_DECL]]#0, [0 : index]
+! CHECK-NEXT:   %[[PRIV_SHADOW_3:.*]] = fir.insert_value %[[PRIV_SHADOW_2]], %[[PRIV_DECL]]#1, [1 : index]
+
+! CHECK-NEXT:   omp.yield(%[[PRIV_SHADOW_3]] : [[TYPE]])
+
+! CHECK-NEXT: } copy {
+! CHECK: ^bb0(%[[PRIV_ORIG_ARG:.*]]: [[TYPE]], %[[PRIV_PRIV_ARG:.*]]: [[TYPE]]):
+! CHECK-NEXT:  %[[ORIG_BASE:.*]] = fir.extract_value %[[PRIV_ORIG_ARG]], [0 : index] : ([[TYPE]])
+! CHECK-NEXT:  %[[ORIG_FIR_BASE:.*]] = fir.extract_value %[[PRIV_ORIG_ARG]], [1 : index] : ([[TYPE]])
+
+! CHECK-NEXT:  %[[PRIV_BASE:.*]] = fir.extract_value %[[PRIV_PRIV_ARG]], [0 : index] : ([[TYPE]])
+! CHECK-NEXT:  %[[PRIV_FIR_BASE:.*]] = fir.extract_value %[[PRIV_PRIV_ARG]], [1 : index] : ([[TYPE]])
+
+! CHECK-NEXT:  %[[PRIV_BASE_VAL:.*]] = fir.load %[[PRIV_BASE]]
+! CHECK-NEXT:  %[[PRIV_BASE_BOX:.*]] = fir.box_addr %[[PRIV_BASE_VAL]]
+! CHECK-NEXT:  %[[PRIV_BASE_ADDR:.*]] = fir.convert %[[PRIV_BASE_BOX]]
+! CHECK-NEXT:  %[[C0:.*]] = arith.constant 0 : i64
+! CHECK-NEXT:  %[[COPY_COND:.*]] = arith.cmpi ne, %[[PRIV_BASE_ADDR]], %[[C0]] : i64
+
+! CHECK-NEXT:  fir.if %[[COPY_COND]] {
+! CHECK-NEXT:    %[[ORIG_BASE_VAL:.*]] = fir.load %[[ORIG_BASE]]
+! CHECK-NEXT:    %[[ORIG_BASE_ADDR:.*]] = fir.box_addr %[[ORIG_BASE_VAL]]
+! CHECK-NEXT:    %[[ORIG_BASE_LD:.*]] = fir.load %[[ORIG_BASE_ADDR]]
+! CHECK-NEXT:    hlfir.assign %[[ORIG_BASE_LD]] to %[[PRIV_BASE_BOX]] temporary_lhs
+! CHECK-NEXT:  }
+
+! CHECK-NEXT:  omp.yield(%[[PRIV_PRIV_ARG]] : [[TYPE]])

--- a/flang/test/Lower/OpenMP/delayed-privatization-firstprivate.f90
+++ b/flang/test/Lower/OpenMP/delayed-privatization-firstprivate.f90
@@ -12,18 +12,34 @@ subroutine delayed_privatization_firstprivate
 end subroutine
 
 ! CHECK-LABEL: omp.private {type = firstprivate}
-! CHECK-SAME: @[[VAR1_PRIVATIZER_SYM:.*]] : !fir.ref<i32> alloc {
-! CHECK-NEXT: ^bb0(%[[PRIV_ARG:.*]]: !fir.ref<i32>):
+! CHECK-SAME: @[[PRIVATIZER_SYM:.*]] : [[TYPE:!fir.shadow<!fir.ref<i32>, !fir.ref<i32>, allocatable : false>]] alloc {
+! CHECK-NEXT: ^bb0(%[[PRIV_ARG:.*]]: [[TYPE]]):
+
+! CHECK-NEXT:  %[[BASE:.*]] = fir.extract_value %[[PRIV_ARG]], [0 : index] : ([[TYPE]]) -> !fir.ref<i32>
+! CHECK-NEXT:  %[[FIR_BASE:.*]] = fir.extract_value %[[PRIV_ARG]], [1 : index] : ([[TYPE]]) -> !fir.ref<i32>
+
 ! CHECK-NEXT:   %[[PRIV_ALLOC:.*]] = fir.alloca i32 {bindc_name = "var1", pinned, uniq_name = "_QFdelayed_privatization_firstprivateEvar1"}
 ! CHECK-NEXT:   %[[PRIV_DECL:.*]]:2 = hlfir.declare %[[PRIV_ALLOC]] {uniq_name = "_QFdelayed_privatization_firstprivateEvar1"} : (!fir.ref<i32>) -> (!fir.ref<i32>, !fir.ref<i32>)
-! CHECK-NEXT:   omp.yield(%[[PRIV_DECL]]#0 : !fir.ref<i32>)
+
+! CHECK-NEXT:  %[[YIELD_VAL:.*]] = fir.undefined [[TYPE]]
+! CHECK-NEXT:  %[[YIELD_VAL_2:.*]] = fir.insert_value %[[YIELD_VAL]], %[[PRIV_DECL]]#0, [0 : index] : ([[TYPE]], !fir.ref<i32>) -> [[TYPE]]
+! CHECK-NEXT:  %[[YIELD_VAL_3:.*]] = fir.insert_value %[[YIELD_VAL_2]], %[[PRIV_DECL]]#1, [1 : index] : ([[TYPE]], !fir.ref<i32>) -> [[TYPE]]
+
+! CHECK-NEXT:   omp.yield(%[[YIELD_VAL_3]] : [[TYPE]])
+
 ! CHECK: } copy {
-! CHECK: ^bb0(%[[PRIV_ORIG_ARG:.*]]: !fir.ref<i32>, %[[PRIV_PRIV_ARG:.*]]: !fir.ref<i32>):
-! CHECK:    %[[ORIG_VAL:.*]] = fir.load %[[PRIV_ORIG_ARG]] : !fir.ref<i32>
-! CHECK:    hlfir.assign %[[ORIG_VAL]] to %[[PRIV_PRIV_ARG]] temporary_lhs : i32, !fir.ref<i32>
-! CHECK:    omp.yield(%[[PRIV_PRIV_ARG]] : !fir.ref<i32>)
-! CHECK: }
+! CHECK: ^bb0(%[[PRIV_ORIG_ARG:.*]]: [[TYPE]], %[[PRIV_PRIV_ARG:.*]]: [[TYPE]]):
+
+! CHECK-NEXT:  %[[ORIG_BASE:.*]] = fir.extract_value %[[PRIV_ORIG_ARG]], [0 : index] : ([[TYPE]]) -> !fir.ref<i32>
+! CHECK-NEXT:  %[[ORIG_FIR_BASE:.*]] = fir.extract_value %[[PRIV_ORIG_ARG]], [1 : index] : ([[TYPE]]) -> !fir.ref<i32>
+
+! CHECK-NEXT:  %[[PRIV_BASE:.*]] = fir.extract_value %[[PRIV_PRIV_ARG]], [0 : index] : ([[TYPE]]) -> !fir.ref<i32>
+! CHECK-NEXT:  %[[PRIV_FIR_BASE:.*]] = fir.extract_value %[[PRIV_PRIV_ARG]], [1 : index] : ([[TYPE]]) -> !fir.ref<i32>
+
+! CHECK-NEXT:  %[[ORIG_VAL:.*]] = fir.load %[[ORIG_BASE]] : !fir.ref<i32>
+! CHECK-NEXT:  hlfir.assign %[[ORIG_VAL]] to %[[PRIV_BASE]] temporary_lhs : i32, !fir.ref<i32>
+! CHECK-NEXT:  omp.yield(%[[PRIV_PRIV_ARG]] : [[TYPE]])
 
 ! CHECK-LABEL: @_QPdelayed_privatization_firstprivate
-! CHECK: omp.parallel private(@[[VAR1_PRIVATIZER_SYM]] %{{.*}} -> %{{.*}} : !fir.ref<i32>) {
+! CHECK: omp.parallel private(@[[PRIVATIZER_SYM]] %{{.*}} -> %{{.*}} : [[TYPE]]) {
 ! CHECK: omp.terminator

--- a/flang/test/Lower/OpenMP/delayed-privatization-private-firstprivate.f90
+++ b/flang/test/Lower/OpenMP/delayed-privatization-private-firstprivate.f90
@@ -14,12 +14,12 @@ subroutine delayed_privatization_private_firstprivate
 end subroutine
 
 ! CHECK-LABEL: omp.private {type = firstprivate}
-! CHECK-SAME: @[[VAR2_PRIVATIZER_SYM:.*]] : !fir.ref<i32> alloc {
+! CHECK-SAME: @[[VAR2_PRIVATIZER_SYM:.*]] : [[TYPE:!fir.shadow<!fir.ref<i32>, !fir.ref<i32>, allocatable : false>]] alloc {
 ! CHECK: } copy {
 ! CHECK: }
 
 ! CHECK-LABEL: omp.private {type = private}
-! CHECK-SAME: @[[VAR1_PRIVATIZER_SYM:.*]] : !fir.ref<i32> alloc {
+! CHECK-SAME: @[[VAR1_PRIVATIZER_SYM:.*]] : [[TYPE]] alloc {
 ! CHECK: }
 
 ! CHECK-LABEL: func.func @_QPdelayed_privatization_private_firstprivate() {
@@ -29,6 +29,14 @@ end subroutine
 ! CHECK:  %[[VAR2_ALLOC:.*]] = fir.alloca i32 {bindc_name = "var2"
 ! CHECK:  %[[VAR2_DECL:.*]]:2 = hlfir.declare %[[VAR2_ALLOC]]
 
+! CHECK:  %[[VAR1_VAL:.*]] = fir.undefined [[TYPE]]
+! CHECK:  %[[VAR1_VAL_2:.*]] = fir.insert_value %[[VAR1_VAL]], %[[VAR1_DECL]]#0, [0 : index]
+! CHECK:  %[[VAR1_VAL_3:.*]] = fir.insert_value %[[VAR1_VAL_2]], %[[VAR1_DECL]]#1, [1 : index]
+
+! CHECK:  %[[VAR2_VAL:.*]] = fir.undefined [[TYPE]]
+! CHECK:  %[[VAR2_VAL_2:.*]] = fir.insert_value %[[VAR2_VAL]], %[[VAR2_DECL]]#0, [0 : index]
+! CHECK:  %[[VAR2_VAL_3:.*]] = fir.insert_value %[[VAR2_VAL_2]], %[[VAR2_DECL]]#1, [1 : index]
+
 ! CHECK:  omp.parallel private(
-! CHECK-SAME: @[[VAR1_PRIVATIZER_SYM]] %[[VAR1_DECL]]#0 -> %{{.*}} : !fir.ref<i32>, 
-! CHECK-SAME: @[[VAR2_PRIVATIZER_SYM]] %[[VAR2_DECL]]#0 -> %{{.*}} : !fir.ref<i32>) {
+! CHECK-SAME: @[[VAR1_PRIVATIZER_SYM]] %[[VAR1_VAL_3]] -> %{{.*}} : [[TYPE]],
+! CHECK-SAME: @[[VAR2_PRIVATIZER_SYM]] %[[VAR2_VAL_3]] -> %{{.*}} : [[TYPE]]) {

--- a/flang/test/Lower/OpenMP/delayed-privatization-private.f90
+++ b/flang/test/Lower/OpenMP/delayed-privatization-private.f90
@@ -12,17 +12,32 @@ subroutine delayed_privatization_private
 end subroutine
 
 ! CHECK-LABEL: omp.private {type = private}
-! CHECK-SAME: @[[PRIVATIZER_SYM:.*]] : !fir.ref<i32> alloc {
-! CHECK-NEXT: ^bb0(%[[PRIV_ARG:.*]]: !fir.ref<i32>):
+! CHECK-SAME: @[[PRIVATIZER_SYM:.*]] : [[TYPE:!fir.shadow<!fir.ref<i32>, !fir.ref<i32>, allocatable : false>]] alloc {
+! CHECK-NEXT: ^bb0(%[[PRIV_ARG:.*]]: [[TYPE]]):
+
+! CHECK-NEXT:  %[[BASE:.*]] = fir.extract_value %[[PRIV_ARG]], [0 : index] : ([[TYPE]]) -> !fir.ref<i32>
+! CHECK-NEXT:  %[[FIR_BASE:.*]] = fir.extract_value %[[PRIV_ARG]], [1 : index] : ([[TYPE]]) -> !fir.ref<i32>
+
 ! CHECK-NEXT:   %[[PRIV_ALLOC:.*]] = fir.alloca i32 {bindc_name = "var1", pinned, uniq_name = "_QFdelayed_privatization_privateEvar1"}
 ! CHECK-NEXT:   %[[PRIV_DECL:.*]]:2 = hlfir.declare %[[PRIV_ALLOC]] {uniq_name = "_QFdelayed_privatization_privateEvar1"} : (!fir.ref<i32>) -> (!fir.ref<i32>, !fir.ref<i32>)
-! CHECK-NEXT:   omp.yield(%[[PRIV_DECL]]#0 : !fir.ref<i32>)
+
+! CHECK-NEXT:  %[[YIELD_VAL:.*]] = fir.undefined [[TYPE]]
+! CHECK-NEXT:  %[[YIELD_VAL_2:.*]] = fir.insert_value %[[YIELD_VAL]], %[[PRIV_DECL]]#0, [0 : index] : ([[TYPE]], !fir.ref<i32>) -> [[TYPE]]
+! CHECK-NEXT:  %[[YIELD_VAL_3:.*]] = fir.insert_value %[[YIELD_VAL_2]], %[[PRIV_DECL]]#1, [1 : index] : ([[TYPE]], !fir.ref<i32>) -> [[TYPE]]
+
+! CHECK-NEXT:   omp.yield(%[[YIELD_VAL_3]] : [[TYPE]])
 ! CHECK-NOT: } copy {
 
 ! CHECK-LABEL: @_QPdelayed_privatization_private
 ! CHECK: %[[ORIG_ALLOC:.*]] = fir.alloca i32 {bindc_name = "var1", uniq_name = "_QFdelayed_privatization_privateEvar1"}
 ! CHECK: %[[ORIG_DECL:.*]]:2 = hlfir.declare %[[ORIG_ALLOC]] {uniq_name = "_QFdelayed_privatization_privateEvar1"} : (!fir.ref<i32>) -> (!fir.ref<i32>, !fir.ref<i32>)
-! CHECK: omp.parallel private(@[[PRIVATIZER_SYM]] %[[ORIG_DECL]]#0 -> %[[PAR_ARG:.*]] : !fir.ref<i32>) {
-! CHECK: %[[PAR_ARG_DECL:.*]]:2 = hlfir.declare %[[PAR_ARG]] {uniq_name = "_QFdelayed_privatization_privateEvar1"} : (!fir.ref<i32>) -> (!fir.ref<i32>, !fir.ref<i32>)
+
+! CHECK-NEXT:  %[[ORIG_VAL:.*]] = fir.undefined [[TYPE]]
+! CHECK-NEXT:  %[[ORIG_VAL_2:.*]] = fir.insert_value %[[ORIG_VAL]], %[[ORIG_DECL]]#0, [0 : index] : ([[TYPE]], !fir.ref<i32>) -> [[TYPE]]
+! CHECK-NEXT:  %[[ORIG_VAL_3:.*]] = fir.insert_value %[[ORIG_VAL_2]], %[[ORIG_DECL]]#1, [1 : index] : ([[TYPE]], !fir.ref<i32>) -> [[TYPE]]
+
+! CHECK: omp.parallel private(@[[PRIVATIZER_SYM]] %[[ORIG_VAL_3]] -> %[[PAR_ARG:.*]] : [[TYPE]]) {
+! CHECK: %[[PAR_ARG_FIR_BASE:.*]] = fir.extract_value %[[PAR_ARG]], [1 : index] : ([[TYPE]]) -> !fir.ref<i32>
+! CHECK: %[[PAR_ARG_DECL:.*]]:2 = hlfir.declare %[[PAR_ARG_FIR_BASE]] {uniq_name = "_QFdelayed_privatization_privateEvar1"} : (!fir.ref<i32>) -> (!fir.ref<i32>, !fir.ref<i32>)
 ! CHECK: hlfir.assign %{{.*}} to %[[PAR_ARG_DECL]]#0 : i32, !fir.ref<i32>
 ! CHECK: omp.terminator

--- a/flang/test/Lower/OpenMP/delayed-privatization-reduction.f90
+++ b/flang/test/Lower/OpenMP/delayed-privatization-reduction.f90
@@ -19,12 +19,12 @@ subroutine red_and_delayed_private
 end subroutine
 
 ! CHECK-LABEL: omp.private {type = private}
-! CHECK-SAME: @[[PRIVATIZER_SYM:.*]] : !fir.ref<i32> alloc {
+! CHECK-SAME: @[[PRIVATIZER_SYM:.*]] : [[TYPE:!fir.shadow<!fir.ref<i32>, !fir.ref<i32>, allocatable : false>]] alloc {
 
 ! CHECK-LABEL: omp.reduction.declare
 ! CHECK-SAME: @[[REDUCTION_SYM:.*]] : i32 init
 
 ! CHECK-LABEL: _QPred_and_delayed_private
 ! CHECK: omp.parallel
-! CHECK-SAME: reduction(@[[REDUCTION_SYM]] %{{.*}} -> %arg0 : !fir.ref<i32>)
-! CHECK-SAME: private(@[[PRIVATIZER_SYM]] %{{.*}} -> %arg1 : !fir.ref<i32>) {
+! CHECK-SAME: reduction(@[[REDUCTION_SYM]] %{{.*}} -> %{{.*}} : !fir.ref<i32>)
+! CHECK-SAME: private(@[[PRIVATIZER_SYM]] %{{.*}} -> %{{.*}} : [[TYPE]]) {


### PR DESCRIPTION
Adds delayed privatization support for allocatables. In order to explain the problem this diff is trying to solve, it would be useful to see an example of `firstprivate` for an alloctable and how it is currently emitted by flang **without** delayed privatization.

Consider the following Fortran code:
```fortran
subroutine delayed_privatization_allocatable
  implicit none
  integer, allocatable :: var1

!$omp parallel firstprivate(var1)
  var1 = 10
!$omp end parallel
end subroutine
```

You would get something like this (again no delayed privatization yet):
```mlir
    ...
    %3:2 = hlfir.declare %0 {fortran_attrs = #fir.var_attrs<allocatable>, ...} : ...
    omp.parallel {
      // Allocation logic
      ...
      %9 = fir.load %3#1 : !fir.ref<!fir.box<!fir.heap<i32>>>
      ...
      fir.if %12 {
        ...
      } else {
        ...
      }
      %13:2 = hlfir.declare %8 {fortran_attrs = #fir.var_attrs<allocatable>, ...} : ...

      // Copy logic
      %14 = fir.load %13#0 : !fir.ref<!fir.box<!fir.heap<i32>>>
      ...
      fir.if %17 {
        %24 = fir.load %3#0 : !fir.ref<!fir.box<!fir.heap<i32>>>
        ...
      }
      ...
      omp.terminator
    }
```

Note that for both the original and the private declaration, the allocation and copy logic use both elements (e.g. `%3#0` and `%3#1`). This poses the following problem for delayed privatization: how can capture both values in order to pass them to the outlined privatizer? The main issue is that `hlfir.declare` returns 2 SSA values that not encapsulated together under a single composite value.

Some possible solutions are:
1. Change the return type of `hlfir.declare`. However, this would be very invasive and therefore does not sound like a good idea.
2. Use the built-in `tuple` type to "pack" both values together. This is reasonable but not very flexible since we won't be able to express other information about the encapsulated values such as whether it is alloctable.
3. Introduce a new concept/type that allows us to do the encapsulation in a more flexible way. This is the "variable shadow" concept introduced by this PR.

A "variable shadow" is a composite value of a special type: `!fir.shadow` that has some special properties:
* It can be constructed only from `BlockArgument`s.
* It always has the type `!fir.shadow`.
* It packs the required information needed by the delayed privatizer that correspond to the result of `hlfir.declare` operation.

We don't introduce any special opertions to deal with shadow values. Rather we treat them similar to other composites. If you want to get a certain component, use `fir.extract_value`. If you want to populate a certain component, use `fir.insert_value`.