### PR TITLE
[SystemZ] [z/OS] Emit offset to PPA2 in separate MCSection

### DIFF
--- a/llvm/include/llvm/MC/MCObjectFileInfo.h
+++ b/llvm/include/llvm/MC/MCObjectFileInfo.h
@@ -228,6 +228,7 @@ protected:
   // GOFF specific sections.
   MCSection *PPA1Section = nullptr;
   MCSection *PPA2Section = nullptr;
+  MCSection *PPA2ListSection = nullptr;
   MCSection *ADASection = nullptr;
   MCSection *IDRLSection = nullptr;
 
@@ -434,6 +435,7 @@ public:
   // GOFF specific sections.
   MCSection *getPPA1Section() const { return PPA1Section; }
   MCSection *getPPA2Section() const { return PPA2Section; }
+  MCSection *getPPA2ListSection() const { return PPA2ListSection; }
   MCSection *getADASection() const { return ADASection; }
   MCSection *getIDRLSection() const { return IDRLSection; }
 

--- a/llvm/lib/MC/MCObjectFileInfo.cpp
+++ b/llvm/lib/MC/MCObjectFileInfo.cpp
@@ -554,6 +554,11 @@ void MCObjectFileInfo::initGOFFMCObjectFileInfo(const Triple &T) {
   PPA2Section =
       Ctx->getGOFFSection(".ppa2", SectionKind::getMetadata(), TextSection,
                           MCConstantExpr::create(GOFF::SK_PPA2, *Ctx));
+
+  PPA2ListSection =
+      Ctx->getGOFFSection(".ppa2list", SectionKind::getData(),
+                          nullptr, nullptr);
+
   ADASection =
       Ctx->getGOFFSection(".ada", SectionKind::getData(), nullptr, nullptr);
   IDRLSection =

--- a/llvm/lib/Target/SystemZ/SystemZAsmPrinter.cpp
+++ b/llvm/lib/Target/SystemZ/SystemZAsmPrinter.cpp
@@ -1531,6 +1531,9 @@ void SystemZAsmPrinter::emitPPA2(Module &M) {
 
   OutStreamer->emitInt16(0x0000); // Service level string length.
 
+  // The binder requires that the offset to the PPA2 be emitted in a different,
+  // specially-named section.
+  OutStreamer->switchSection(getObjFileLowering().getPPA2ListSection());
   // Emit 8 byte alignment.
   // Emit pointer to PPA2 label.
   OutStreamer->AddComment("A(PPA2-CELQSTRT)");


### PR DESCRIPTION
The ppa2list section isn't really part of the ppa2 section. The ppa2list section contains the offset to the ppa2, and must be created with a special section name (specifically, C_@@QPPA2). The binder searches for a section with this name, then uses this value to locate the ppa2.

In GOFF terms, these are entirely separate sections; the PPA2 section isn't even really a section but rather belongs to the code section. On the other hand, the ppa2list section is a section in its own right and resides in a separate TXT record.