### PR TITLE
[clangd] Include Json Rpc Request ID in trace events

### DIFF
--- a/clang-tools-extra/clangd/support/Trace.cpp
+++ b/clang-tools-extra/clangd/support/Trace.cpp
@@ -24,6 +24,8 @@ namespace clang {
 namespace clangd {
 namespace trace {
 
+Key<std::string> EventTracer::kRequestId;
+
 namespace {
 // The current implementation is naive: each thread writes to Out guarded by Mu.
 // Perhaps we should replace this by something that disturbs performance less.
@@ -159,6 +161,10 @@ private:
     Out.object([&] {
       Out.attribute("pid", 0);
       Out.attribute("ph", Phase);
+      const auto *id = Context::current().get(kRequestId);
+      if (id) {
+        Out.attribute("rid", *id);
+      }
       for (const auto &KV : Event)
         Out.attribute(KV.first, KV.second);
     });

--- a/clang-tools-extra/clangd/support/Trace.h
+++ b/clang-tools-extra/clangd/support/Trace.h
@@ -99,6 +99,8 @@ public:
   /// Called whenever a metrics records a measurement.
   virtual void record(const Metric &Metric, double Value,
                       llvm::StringRef Label) {}
+  /// A key to store json request id in the context used in tracers
+  static Key<std::string> kRequestId;
 };
 
 /// Sets up a global EventTracer that consumes events produced by Span and


### PR DESCRIPTION
Included in a new field, `rid,` this allows us to associate each trace log with the incoming request that sent them. Helpful for associating insights from clangd logs with logging on an lsp client side - such as a vscode extension.