### PR TITLE
[RISCV] Always use signed APSInt in getExactInteger.

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
+++ b/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
@@ -3233,7 +3233,9 @@ struct VIDSequence {
 
 static std::optional<uint64_t> getExactInteger(const APFloat &APF,
                                                uint32_t BitWidth) {
-  APSInt ValInt(BitWidth, !APF.isNegative());
+  // We will use a SINT_TO_FP to materialize this constant so we should use a
+  // signed APSInt here.
+  APSInt ValInt(BitWidth, /*IsUnsigned*/ false);
   // We use an arbitrary rounding mode here. If a floating-point is an exact
   // integer (e.g., 1.0), the rounding mode does not affect the output value. If
   // the rounding mode changes the output value, then it is not an exact

--- a/llvm/test/CodeGen/RISCV/rvv/vle_vid-vfcvt.ll
+++ b/llvm/test/CodeGen/RISCV/rvv/vle_vid-vfcvt.ll
@@ -113,16 +113,15 @@ entry:
   ret void
 }
 
-; FIXME: This is miscompiled. This will create -2147483648.0 instead of
-; 2147483648.0 for the 4th element.
+; Make sure we don't try to use vid+vsll+vfcvt. We previously flipped the sign
+; of 2147483648.0.
 define void @foo_9(ptr nocapture noundef writeonly %t) {
 ; CHECK-LABEL: foo_9:
 ; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    lui a1, %hi(.LCPI8_0)
+; CHECK-NEXT:    addi a1, a1, %lo(.LCPI8_0)
 ; CHECK-NEXT:    vsetivli zero, 4, e32, m1, ta, ma
-; CHECK-NEXT:    vid.v v8
-; CHECK-NEXT:    vsll.vi v8, v8, 31
-; CHECK-NEXT:    vrsub.vi v8, v8, 0
-; CHECK-NEXT:    vfcvt.f.x.v v8, v8
+; CHECK-NEXT:    vle32.v v8, (a1)
 ; CHECK-NEXT:    vse32.v v8, (a0)
 ; CHECK-NEXT:    ret
 entry:


### PR DESCRIPTION
We were setting based on whether the FP value is positive/negative, but we really want to know whether the resulting integer will be treated as a signed or unsigned value. Since we use SINT_TO_FP to convert the integer to FP, we should always used signed here.

Without this we convert +2147483648.0 to an integer 0x80000000 and convert it using sint_to_fp which produces -2147483648.0.