### PR TITLE
[lldb] Print mangled names with verbose break list

### DIFF
--- a/lldb/source/Breakpoint/BreakpointLocation.cpp
+++ b/lldb/source/Breakpoint/BreakpointLocation.cpp
@@ -524,7 +524,8 @@ void BreakpointLocation::GetDescription(Stream *s,
           s->EOL();
           s->Indent("function = ");
           s->PutCString(sc.function->GetName().AsCString("<unknown>"));
-          if (ConstString mangled_name = sc.function->GetMangled().GetMangledName()) {
+          if (ConstString mangled_name =
+                  sc.function->GetMangled().GetMangledName()) {
             s->EOL();
             s->Indent("mangled function = ");
             s->PutCString(mangled_name.AsCString());

--- a/lldb/source/Breakpoint/BreakpointLocation.cpp
+++ b/lldb/source/Breakpoint/BreakpointLocation.cpp
@@ -524,6 +524,9 @@ void BreakpointLocation::GetDescription(Stream *s,
           s->EOL();
           s->Indent("function = ");
           s->PutCString(sc.function->GetName().AsCString("<unknown>"));
+          s->EOL();
+          s->Indent("mangled function = ");
+          s->PutCString(sc.function->GetMangled().GetMangledName().AsCString("<unknown>"));
         }
 
         if (sc.line_entry.line > 0) {

--- a/lldb/source/Breakpoint/BreakpointLocation.cpp
+++ b/lldb/source/Breakpoint/BreakpointLocation.cpp
@@ -524,9 +524,11 @@ void BreakpointLocation::GetDescription(Stream *s,
           s->EOL();
           s->Indent("function = ");
           s->PutCString(sc.function->GetName().AsCString("<unknown>"));
-          s->EOL();
-          s->Indent("mangled function = ");
-          s->PutCString(sc.function->GetMangled().GetMangledName().AsCString("<unknown>"));
+          if (ConstString mangled_name = sc.function->GetMangled().GetMangledName()) {
+            s->EOL();
+            s->Indent("mangled function = ");
+            s->PutCString(mangled_name.AsCString());
+          }
         }
 
         if (sc.line_entry.line > 0) {

--- a/lldb/test/API/functionalities/breakpoint/breakpoint_options/TestBreakpointOptions.py
+++ b/lldb/test/API/functionalities/breakpoint/breakpoint_options/TestBreakpointOptions.py
@@ -82,7 +82,7 @@ class BreakpointOptionsTestCase(TestBase):
         self.runCmd("file " + exe, CURRENT_EXECUTABLE_SET)
 
         # This should create a breakpoint with 1 locations.
-        lldbutil.run_break_set_by_symbol(
+        bp_id = lldbutil.run_break_set_by_symbol(
             self,
             "ns::func",
             sym_exact=False,
@@ -90,12 +90,14 @@ class BreakpointOptionsTestCase(TestBase):
             num_expected_locations=1,
         )
 
+        location = self.target().FindBreakpointByID(bp_id).GetLocationAtIndex(0)
+        function = location.GetAddress().GetFunction()
         self.expect(
             "breakpoint list -v",
             "Verbose breakpoint list contains mangled names",
             substrs=[
-                "function = ns::func"
-                "mangled function ="
+                "function = ns::func",
+                f"mangled function = {function.GetMangledName()}",
             ],
         )
 

--- a/lldb/test/API/functionalities/breakpoint/breakpoint_options/TestBreakpointOptions.py
+++ b/lldb/test/API/functionalities/breakpoint/breakpoint_options/TestBreakpointOptions.py
@@ -90,6 +90,15 @@ class BreakpointOptionsTestCase(TestBase):
             num_expected_locations=1,
         )
 
+        self.expect(
+            "breakpoint list -v",
+            "Verbose breakpoint list contains mangled names",
+            substrs=[
+                "function = ns::func"
+                "mangled function ="
+            ],
+        )
+
         # This should create a breakpoint with 0 locations.
         lldbutil.run_break_set_by_symbol(
             self,


### PR DESCRIPTION
When debugging LLDB itself, it can often be useful to know the mangled name of the function where a breakpoint is set. Since the `--verbose` setting of `break --list` is aimed at debugging LLDB, this patch makes it so that the mangled name is also printed in that mode.

Note about testing: since mangling is not the same on Windows and Linux, the test refrains from hardcoding mangled names.