### PR TITLE
[llvm][x86] Add TLSDESC support for X86 code generation

### DIFF
--- a/llvm/lib/Target/X86/MCTargetDesc/X86BaseInfo.h
+++ b/llvm/lib/Target/X86/MCTargetDesc/X86BaseInfo.h
@@ -431,6 +431,18 @@ enum TOF {
   /// See 'ELF Handling for Thread-Local Storage' for more details.
   ///    SYMBOL_LABEL @TLSLDM
   MO_TLSLDM,
+  /// MO_TLSDESC - On a symbol operand this indicates that the immediate is
+  /// the offset of the GOT entry with the TLS index for the module that
+  /// contains the symbol. When this index is passed to a call to
+  /// the resolver function, it will return the offset from the thread pointer.
+  /// See 'ELF Handling for Thread-Local Storage' for more details.
+  ///    SYMBOL_LABEL @TLSDESC
+  MO_TLSDESC,
+  /// MO_TLSCALL - On a symbol operand this indicates this  call to
+  /// the resolver function, it will return the offset from the thread pointer.
+  /// See 'ELF Handling for Thread-Local Storage' for more details.
+  ///    SYMBOL_LABEL @TLSCALL
+  MO_TLSCALL,
   /// MO_GOTTPOFF - On a symbol operand this indicates that the immediate is
   /// the offset of the GOT entry with the thread-pointer offset for the
   /// symbol. Used in the x86-64 initial exec TLS access model.

--- a/llvm/lib/Target/X86/X86AsmPrinter.cpp
+++ b/llvm/lib/Target/X86/X86AsmPrinter.cpp
@@ -271,6 +271,12 @@ void X86AsmPrinter::PrintSymbolOperand(const MachineOperand &MO,
   case X86II::MO_TLSGD:     O << "@TLSGD";     break;
   case X86II::MO_TLSLD:     O << "@TLSLD";     break;
   case X86II::MO_TLSLDM:    O << "@TLSLDM";    break;
+  case X86II::MO_TLSDESC:
+    O << "@TLSDESC";
+    break;
+  case X86II::MO_TLSCALL:
+    O << "@TLSCALL";
+    break;
   case X86II::MO_GOTTPOFF:  O << "@GOTTPOFF";  break;
   case X86II::MO_INDNTPOFF: O << "@INDNTPOFF"; break;
   case X86II::MO_TPOFF:     O << "@TPOFF";     break;

--- a/llvm/lib/Target/X86/X86InstrInfo.cpp
+++ b/llvm/lib/Target/X86/X86InstrInfo.cpp
@@ -10088,6 +10088,8 @@ X86InstrInfo::getSerializableDirectMachineOperandTargetFlags() const {
       {MO_TLSGD, "x86-tlsgd"},
       {MO_TLSLD, "x86-tlsld"},
       {MO_TLSLDM, "x86-tlsldm"},
+      {MO_TLSDESC, "x86-tlsdesc"},
+      {MO_TLSCALL, "x86-tlscall"},
       {MO_GOTTPOFF, "x86-gottpoff"},
       {MO_INDNTPOFF, "x86-indntpoff"},
       {MO_TPOFF, "x86-tpoff"},
@@ -10241,6 +10243,8 @@ struct LDTLSCleanup : public MachineFunctionPass {
       switch (I->getOpcode()) {
       case X86::TLS_base_addr32:
       case X86::TLS_base_addr64:
+      case X86::TLSCall_32:
+      case X86::TLSCall_64:
         if (TLSBaseAddrReg)
           I = ReplaceTLSBaseAddrCall(*I, TLSBaseAddrReg);
         else

--- a/llvm/lib/Target/X86/X86MCInstLower.cpp
+++ b/llvm/lib/Target/X86/X86MCInstLower.cpp
@@ -257,6 +257,12 @@ MCOperand X86MCInstLower::LowerSymbolOperand(const MachineOperand &MO,
   case X86II::MO_TLSLDM:
     RefKind = MCSymbolRefExpr::VK_TLSLDM;
     break;
+  case X86II::MO_TLSDESC:
+    RefKind = MCSymbolRefExpr::VK_TLSDESC;
+    break;
+  case X86II::MO_TLSCALL:
+    RefKind = MCSymbolRefExpr::VK_TLSCALL;
+    break;
   case X86II::MO_GOTTPOFF:
     RefKind = MCSymbolRefExpr::VK_GOTTPOFF;
     break;

--- a/llvm/test/CodeGen/X86/tlsdesc-dynamic.ll
+++ b/llvm/test/CodeGen/X86/tlsdesc-dynamic.ll
@@ -1,0 +1,74 @@
+; RUN: llc -mtriple=x86_64-linux-gnu -relocation-model=pic -enable-tlsdesc %s -o - | FileCheck %s --check-prefixes=GD
+; RUN: llc -mtriple=x86_64-linux-gnu -relocation-model=pic -enable-tlsdesc -filetype=obj < %s | llvm-objdump -r - | FileCheck --check-prefixes=GD-RELOC %s
+
+@general_dynamic_var = external thread_local global i32
+
+define i32 @test_generaldynamic() {
+  %val = load i32, ptr @general_dynamic_var
+  ret i32 %val
+;      GD: test_generaldynamic:
+;      GD: leaq general_dynamic_var@tlsdesc(%rip), [[REG:%.*]]
+; GD-NEXT: callq *general_dynamic_var@tlscall([[REG]])
+; GD-NEXT: movl %fs:([[REG]]),
+
+; GD-RELOC: R_X86_64_GOTPC32_TLSDESC general_dynamic_var
+; GD-RELOC: R_X86_64_TLSDESC_CALL general_dynamic_var
+}
+
+define ptr @test_generaldynamic_addr() {
+  ret ptr @general_dynamic_var
+;      GD: test_generaldynamic_addr:
+;      GD: leaq general_dynamic_var@tlsdesc(%rip), [[REG:%.*]]
+; GD-NEXT: callq *general_dynamic_var@tlscall([[REG]])
+; GD-NEXT: addq %fs:0, %rax
+
+; GD-RELOC: R_X86_64_GOTPC32_TLSDESC general_dynamic_var
+; GD-RELOC: R_X86_64_TLSDESC_CALL general_dynamic_var
+}
+
+@local_dynamic_var = external thread_local(localdynamic) global i32
+
+define i32 @test_localdynamic() {
+  %val = load i32, ptr @local_dynamic_var
+  ret i32 %val
+;      GD: test_localdynamic:
+;      GD: leaq _TLS_MODULE_BASE_@tlsdesc(%rip), [[REG:%.*]]
+; GD-NEXT: callq *_TLS_MODULE_BASE_@tlscall([[REG]])
+; GD-NEXT: movl  %fs:local_dynamic_var@DTPOFF(%rax), %eax
+
+; GD-RELOC: R_X86_64_GOTPC32_TLSDESC _TLS_MODULE_BASE_
+; GD-RELOC: R_X86_64_TLSDESC_CALL _TLS_MODULE_BASE_
+; GD-RELOC: R_X86_64_DTPOFF32 local_dynamic_var
+}
+
+define ptr @test_localdynamic_addr() {
+  ret ptr @local_dynamic_var
+;      GD: test_localdynamic_addr:
+;      GD: leaq _TLS_MODULE_BASE_@tlsdesc(%rip), [[REG:%.*]]
+; GD-NEXT: callq *_TLS_MODULE_BASE_@tlscall([[REG]])
+; GD-NEXT: movq %fs:0, %rcx
+; GD-NEXT: leaq local_dynamic_var@DTPOFF(%rcx,[[REG]])
+
+; GD-RELOC: R_X86_64_GOTPC32_TLSDESC _TLS_MODULE_BASE_
+; GD-RELOC: R_X86_64_TLSDESC_CALL _TLS_MODULE_BASE_
+; GD-RELOC: R_X86_64_DTPOFF32 local_dynamic_var
+}
+
+@local_dynamic_var2 = external thread_local(localdynamic) global i32
+
+define i32 @test_localdynamic_deduplicate() {
+  %val = load i32, ptr @local_dynamic_var
+  %val2 = load i32, ptr @local_dynamic_var2
+  %sum = add i32 %val, %val2
+  ret i32 %sum
+;      GD: test_localdynamic_deduplicate:
+;      GD: leaq _TLS_MODULE_BASE_@tlsdesc(%rip), [[REG:%.*]]
+; GD-NEXT: callq *_TLS_MODULE_BASE_@tlscall([[REG]])
+; GD-NEXT: movl  %fs:local_dynamic_var@DTPOFF(%rax)
+; GD-NEXT: addl  %fs:local_dynamic_var2@DTPOFF(%rax)
+
+; GD-RELOC: R_X86_64_GOTPC32_TLSDESC _TLS_MODULE_BASE_
+; GD-RELOC: R_X86_64_TLSDESC_CALL _TLS_MODULE_BASE_
+; GD-RELOC: R_X86_64_DTPOFF32 local_dynamic_var2
+}
+

--- a/llvm/test/CodeGen/X86/tlsdesc.ll
+++ b/llvm/test/CodeGen/X86/tlsdesc.ll
@@ -1,0 +1,18 @@
+; RUN: llc -mtriple=x86_64-linux-gnu -relocation-model=pic -enable-tlsdesc %s -o - | FileCheck %s --check-prefixes=INST
+; RUN: llc -mtriple=x86_64-linux-gnu -relocation-model=pic -filetype=obj -enable-tlsdesc < %s | llvm-objdump -r - | FileCheck --check-prefixes=RELOC %s
+
+@var = thread_local global i32 zeroinitializer
+
+define i32 @test_thread_local() nounwind {
+
+  %val = load i32, ptr @var
+  ret i32 %val
+
+;      INST: test_thread_local:
+;      INST: leaq var@tlsdesc(%rip), [[REG:%.*]]
+; INST-NEXT: callq *var@tlscall([[REG]])
+; INST-NEXT: movl %fs:([[REG]]),
+
+; RELOC: R_X86_64_GOTPC32_TLSDESC var
+; RELOC: R_X86_64_TLSDESC_CALL var
+}


### PR DESCRIPTION
Changes code generation for Global Dynamic TLS access to use TLS
Descriptors instead of traditional TLS access, when the correct
code generation option is set.

Results in TLS access of the form:

```
lea a@tlsdesc(%rip), %rax
call *a@tlscall(%rax)
```

This ABI is important for the linker to be able to optimize TLS
accesses, from GD->LE and LD->IE, which can be more efficient.
