### PR TITLE
[Thumb] Resolve FIXME: We can trust live-in information from successor blocks now

### DIFF
--- a/llvm/lib/Target/ARM/ARMLoadStoreOptimizer.cpp
+++ b/llvm/lib/Target/ARM/ARMLoadStoreOptimizer.cpp
@@ -566,18 +566,20 @@ void ARMLoadStoreOpt::UpdateBaseRegUses(MachineBasicBlock &MBB,
   }
 
   // End of block was reached.
-  if (!MBB.succ_empty()) {
-    // FIXME: Because of a bug, live registers are sometimes missing from
-    // the successor blocks' live-in sets. This means we can't trust that
-    // information and *always* have to reset at the end of a block.
-    // See PR21029.
-    if (MBBI != MBB.end()) --MBBI;
-    BuildMI(MBB, MBBI, DL, TII->get(ARM::tSUBi8), Base)
-        .add(t1CondCodeOp(true))
-        .addReg(Base)
-        .addImm(WordOffset * 4)
-        .addImm(Pred)
-        .addReg(PredReg);
+  // Reset if Base is in the successor blocks' live-in sets.
+  for (MachineBasicBlock *Succ : MBB.successors()) {
+    for (const MachineBasicBlock::RegisterMaskPair &LI : Succ->liveins())
+      if (TRI->regsOverlap(LI.PhysReg, Base)) {
+        if (MBBI != MBB.end())
+          --MBBI;
+        BuildMI(MBB, MBBI, DL, TII->get(ARM::tSUBi8), Base)
+            .add(t1CondCodeOp(true))
+            .addReg(Base)
+            .addImm(WordOffset * 4)
+            .addImm(Pred)
+            .addReg(PredReg);
+        break;
+      }
   }
 }
 


### PR DESCRIPTION
As the years have gone by, live-in information has been more and more consistent and reliable, especially with changing how these are calculated.