### PR TITLE
[Driver,CrossWindows] Remove -isystem-after

### DIFF
--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -4335,9 +4335,6 @@ def isysroot : JoinedOrSeparate<["-"], "isysroot">, Group<clang_i_Group>,
 def isystem : JoinedOrSeparate<["-"], "isystem">, Group<clang_i_Group>,
   Visibility<[ClangOption, CC1Option]>,
   HelpText<"Add directory to SYSTEM include search path">, MetaVarName<"<directory>">;
-def isystem_after : JoinedOrSeparate<["-"], "isystem-after">,
-  Group<clang_i_Group>, Flags<[NoXarchOption]>, MetaVarName<"<directory>">,
-  HelpText<"Add directory to end of the SYSTEM include search path">;
 def iwithprefixbefore : JoinedOrSeparate<["-"], "iwithprefixbefore">, Group<clang_i_Group>,
   HelpText<"Set directory to include search path with prefix">, MetaVarName<"<dir>">,
   Visibility<[ClangOption, CC1Option]>;

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -1219,13 +1219,6 @@ void Clang::AddPreprocessingOptions(Compilation &C, const JobAction &JA,
                                                        << A->getAsString(Args);
         }
       }
-    } else if (A->getOption().matches(options::OPT_isystem_after)) {
-      // Handling of paths which must come late.  These entries are handled by
-      // the toolchain itself after the resource dir is inserted in the right
-      // search order.
-      // Do not claim the argument so that the use of the argument does not
-      // silently go unnoticed on toolchains which do not honour the option.
-      continue;
     } else if (A->getOption().matches(options::OPT_stdlibxx_isystem)) {
       // Translated to -internal-isystem by the driver, no need to pass to cc1.
       continue;

--- a/clang/lib/Driver/ToolChains/CrossWindows.cpp
+++ b/clang/lib/Driver/ToolChains/CrossWindows.cpp
@@ -239,15 +239,8 @@ AddClangSystemIncludeArgs(const llvm::opt::ArgList &DriverArgs,
   const Driver &D = getDriver();
   const std::string &SysRoot = D.SysRoot;
 
-  auto AddSystemAfterIncludes = [&]() {
-    for (const auto &P : DriverArgs.getAllArgValues(options::OPT_isystem_after))
-      addSystemInclude(DriverArgs, CC1Args, P);
-  };
-
-  if (DriverArgs.hasArg(options::OPT_nostdinc)) {
-    AddSystemAfterIncludes();
+  if (DriverArgs.hasArg(options::OPT_nostdinc))
     return;
-  }
 
   addSystemInclude(DriverArgs, CC1Args, SysRoot + "/usr/local/include");
   if (!DriverArgs.hasArg(options::OPT_nobuiltininc)) {
@@ -255,7 +248,6 @@ AddClangSystemIncludeArgs(const llvm::opt::ArgList &DriverArgs,
     llvm::sys::path::append(ResourceDir, "include");
     addSystemInclude(DriverArgs, CC1Args, ResourceDir);
   }
-  AddSystemAfterIncludes();
   addExternCSystemInclude(DriverArgs, CC1Args, SysRoot + "/usr/include");
 }
 

--- a/clang/test/Driver/windows-cross.c
+++ b/clang/test/Driver/windows-cross.c
@@ -72,16 +72,16 @@
 // CHECK-SANITIZE-TSAN: error: unsupported argument 'tsan' to option '-fsanitize='
 // CHECK-SANITIZE-TSAN-NOT: "-fsanitize={{.*}}"
 
-// RUN: %clang -### -target armv7-windows-itanium -isystem-after "Windows Kits/10/Include/10.0.10586.0/ucrt" -isystem-after "Windows Kits/10/Include/10.0.10586.0/um" -isystem-after "Windows Kits/10/Include/10.0.10586.0/shared" -c %s -o /dev/null 2>&1 \
+// RUN: %clang -### --target=armv7-windows-itanium -idirafter "Windows Kits/10/Include/10.0.10586.0/ucrt" -idirafter "Windows Kits/10/Include/10.0.10586.0/um" -idirafter "Windows Kits/10/Include/10.0.10586.0/shared" -c %s -o /dev/null 2>&1 \
 // RUN:     | FileCheck %s --check-prefix CHECK-ISYSTEM-AFTER
 // CHECK-ISYSTEM-AFTER: "-resource-dir" "[[RESOURCE_DIR:[^"]+]]"
+// CHECK-ISYSTEM-AFTER: "-idirafter" "Windows Kits{{[/\\]}}10{{[/\\]}}Include{{[/\\]}}10.0.10586.0{{[/\\]}}ucrt"
+// CHECK-ISYSTEM-AFTER: "-idirafter" "Windows Kits{{[/\\]}}10{{[/\\]}}Include{{[/\\]}}10.0.10586.0{{[/\\]}}um"
+// CHECK-ISYSTEM-AFTER: "-idirafter" "Windows Kits{{[/\\]}}10{{[/\\]}}Include{{[/\\]}}10.0.10586.0{{[/\\]}}shared"
 // CHECK-ISYSTEM-AFTER: "-internal-isystem" "[[RESOURCE_DIR]]{{(/|\\\\)}}include"
-// CHECK-ISYSTEM-AFTER: "-internal-isystem" "Windows Kits{{[/\\]}}10{{[/\\]}}Include{{[/\\]}}10.0.10586.0{{[/\\]}}ucrt"
-// CHECK-ISYSTEM-AFTER: "-internal-isystem" "Windows Kits{{[/\\]}}10{{[/\\]}}Include{{[/\\]}}10.0.10586.0{{[/\\]}}um"
-// CHECK-ISYSTEM-AFTER: "-internal-isystem" "Windows Kits{{[/\\]}}10{{[/\\]}}Include{{[/\\]}}10.0.10586.0{{[/\\]}}shared"
 
-// RUN: %clang -### -target armv7-windows-itanium -nostdinc -isystem-after "Windows Kits/10/Include/10.0.10586.0/ucrt" -c %s -o /dev/null 2>&1 \
+// RUN: %clang -### -target armv7-windows-itanium -nostdinc -idirafter "Windows Kits/10/Include/10.0.10586.0/ucrt" -c %s -o /dev/null 2>&1 \
 // RUN:     | FileCheck %s --check-prefix CHECK-NOSTDINC-ISYSTEM-AFTER
 // CHECK-NOSTDINC-ISYSTEM-AFTER: "-resource-dir" "[[RESOURCE_DIR:[^"]+]]"
+// CHECK-NOSTDINC-ISYSTEM-AFTER: "-idirafter" "Windows Kits{{[/\\]}}10{{[/\\]}}Include{{[/\\]}}10.0.10586.0{{[/\\]}}ucrt"
 // CHECK-NOSTDINC-ISYSTEM-AFTER-NOT: "-internal-isystem" "[[RESOURCE_DIR]]{{(/|\\\\)}}include"
-// CHECK-NOSTDINC-ISYSTEM-AFTER: "-internal-isystem" "Windows Kits{{[/\\]}}10{{[/\\]}}Include{{[/\\]}}10.0.10586.0{{[/\\]}}ucrt"


### PR DESCRIPTION
Commit 88879e6559a3ae8593e32568900707b1dbf3f060 added -isystem-after
(not in GCC) for CrossWindows (see
543a78b55ee993c2977fc2984f278f7ec0125765; *-windows-itanium).
I have heard two reports that the documented option
(https://clang.llvm.org/docs/ClangCommandLineReference.html#cmdoption-clang-isystem-after-directory)
is causing confusion as other ToolChains accept and ignore
`-isystem-after`, not leading to an error.

I think -isystem-after can just be deleted. The use cases can be
approximated with -idirafter.
