### PR TITLE
[libc++] `std::ranges::advance`: avoid unneeded bounds checks when advancing iterator

### DIFF
--- a/libcxx/include/__iterator/advance.h
+++ b/libcxx/include/__iterator/advance.h
@@ -170,14 +170,14 @@ public:
     } else {
       // Otherwise, if `n` is non-negative, while `bool(i != bound_sentinel)` is true, increments `i` but at
       // most `n` times.
-      while (__i != __bound_sentinel && __n > 0) {
+      while (__n > 0 && __i != __bound_sentinel) {
         ++__i;
         --__n;
       }
 
       // Otherwise, while `bool(i != bound_sentinel)` is true, decrements `i` but at most `-n` times.
       if constexpr (bidirectional_iterator<_Ip> && same_as<_Ip, _Sp>) {
-        while (__i != __bound_sentinel && __n < 0) {
+        while (__n < 0 && __i != __bound_sentinel) {
           --__i;
           ++__n;
         }

--- a/libcxx/test/std/iterators/iterator.primitives/range.iter.ops/range.iter.ops.advance/iterator_count_sentinel.pass.cpp
+++ b/libcxx/test/std/iterators/iterator.primitives/range.iter.ops/range.iter.ops.advance/iterator_count_sentinel.pass.cpp
@@ -88,8 +88,8 @@ template <bool Count, typename It>
 constexpr void
 check_backward(int* first, int* last, std::iter_difference_t<It> n, int* expected, Expected expected_counts) {
   // Check preconditions for `advance` when called with negative `n`
-  // (see [range.iter.op.advance]).
-  assert(n < 0);
+  // (see [range.iter.op.advance]). In addition, allow `n == 0`.
+  assert(n <= 0);
   static_assert(std::bidirectional_iterator<It>);
 
   using Difference = std::iter_difference_t<It>;
@@ -212,11 +212,9 @@ constexpr bool test() {
         check_forward_sized_sentinel<int*>(                        range, range+size, n, expected);
       }
 
-      // Exclude the `n == 0` case for the backwards checks (this is tested by
-      // the forward tests above).
       // Input and forward iterators are not tested as the backwards case does
       // not apply for them.
-      if (n > 0) {
+      {
         int* expected = n > size ? range : range + size - n;
         {
           Expected expected_counts = {

--- a/libcxx/test/std/iterators/iterator.primitives/range.iter.ops/range.iter.ops.advance/iterator_count_sentinel.pass.cpp
+++ b/libcxx/test/std/iterators/iterator.primitives/range.iter.ops/range.iter.ops.advance/iterator_count_sentinel.pass.cpp
@@ -45,7 +45,6 @@ constexpr void check_forward(int* first, int* last, std::iter_difference_t<It> n
     if (n == 0) {
       assert(it.equals_count() == 0);
     } else {
-      assert(it.equals_count() > 0);
       assert(it.equals_count() == M || it.equals_count() == M + 1);
       assert(it.equals_count() <= n);
     }

--- a/libcxx/test/std/iterators/iterator.primitives/range.iter.ops/range.iter.ops.advance/iterator_count_sentinel.pass.cpp
+++ b/libcxx/test/std/iterators/iterator.primitives/range.iter.ops/range.iter.ops.advance/iterator_count_sentinel.pass.cpp
@@ -234,7 +234,7 @@ constexpr bool test() {
       // not apply for them.
       if (n > 0) {
         int* expected = n > size ? range : range + size - n;
-        check_backward<bidirectional_iterator<int*>>(range, range+size, -n, expected);
+        check_backward<bidirectional_iterator<int*>>(range, range + size, -n, expected);
         check_backward<random_access_iterator<int*>>(range, range+size, -n, expected);
         check_backward<contiguous_iterator<int*>>(   range, range+size, -n, expected);
         check_backward<int*>(                        range, range+size, -n, expected);

--- a/libcxx/test/std/iterators/iterator.primitives/range.iter.ops/range.iter.ops.advance/iterator_count_sentinel.pass.cpp
+++ b/libcxx/test/std/iterators/iterator.primitives/range.iter.ops/range.iter.ops.advance/iterator_count_sentinel.pass.cpp
@@ -45,7 +45,13 @@ constexpr void check_forward(int* first, int* last, std::iter_difference_t<It> n
     if (n == 0) {
       assert(it.equals_count() == 0);
     } else {
-      assert(it.equals_count() == M || it.equals_count() == M + 1);
+      if (n > M) {
+        // We "hit" the bound, so there is one extra equality check.
+        assert(it.equals_count() == M + 1);
+      } else {
+        assert(it.equals_count() == M);
+      }
+      // In any case, there must not be more than `n` bounds checks.
       assert(it.equals_count() <= n);
     }
   }

--- a/libcxx/test/std/iterators/iterator.primitives/range.iter.ops/range.iter.ops.advance/iterator_count_sentinel.pass.cpp
+++ b/libcxx/test/std/iterators/iterator.primitives/range.iter.ops/range.iter.ops.advance/iterator_count_sentinel.pass.cpp
@@ -225,10 +225,10 @@ constexpr bool test() {
   // `bidirectional_iterator` that doesn't model `sized_sentinel_for`.
   {
     static_assert(std::bidirectional_iterator<bidirectional_iterator<iota_iterator>>);
-    static_assert(!std::sized_sentinel_for<bidirectional_iterator<iota_iterator>,
-                                           bidirectional_iterator<iota_iterator>>);
+    static_assert(
+        !std::sized_sentinel_for<bidirectional_iterator<iota_iterator>, bidirectional_iterator<iota_iterator>>);
 
-    auto it = stride_counting_iterator(bidirectional_iterator(iota_iterator{+1}));
+    auto it   = stride_counting_iterator(bidirectional_iterator(iota_iterator{+1}));
     auto sent = stride_counting_iterator(bidirectional_iterator(iota_iterator{-2}));
     assert(std::ranges::advance(it, -3, sent) == 0);
     assert(base(base(it)) == iota_iterator{-2});

--- a/libcxx/test/support/test_iterators.h
+++ b/libcxx/test/support/test_iterators.h
@@ -725,11 +725,14 @@ struct common_input_iterator {
 #  endif // TEST_STD_VER >= 20
 
 // Iterator adaptor that counts the number of times the iterator has had a successor/predecessor
-// operation called. Has two recorders:
+// operation or an equality comparison operation called. Has three recorders:
 // * `stride_count`, which records the total number of calls to an op++, op--, op+=, or op-=.
 // * `stride_displacement`, which records the displacement of the calls. This means that both
 //   op++/op+= will increase the displacement counter by 1, and op--/op-= will decrease the
 //   displacement counter by 1.
+// * `equals_count`, which records the total number of calls to an op== or op!=. If compared
+//   against a sentinel object, that sentinel object must call the `record_equality_comparison`
+//   function so that the comparison is counted correctly.
 template <class It>
 class stride_counting_iterator {
 public:
@@ -753,6 +756,8 @@ public:
     constexpr difference_type stride_count() const { return stride_count_; }
 
     constexpr difference_type stride_displacement() const { return stride_displacement_; }
+
+    constexpr difference_type equals_count() const { return equals_count_; }
 
     constexpr decltype(auto) operator*() const { return *It(base_); }
 
@@ -838,9 +843,15 @@ public:
         return base(x) - base(y);
     }
 
+    constexpr void record_equality_comparison() const
+    {
+        ++equals_count_;
+    }
+
     constexpr bool operator==(stride_counting_iterator const& other) const
         requires std::sentinel_for<It, It>
     {
+        record_equality_comparison();
         return It(base_) == It(other.base_);
     }
 
@@ -875,6 +886,7 @@ private:
     decltype(base(std::declval<It>())) base_;
     difference_type stride_count_ = 0;
     difference_type stride_displacement_ = 0;
+    mutable difference_type equals_count_ = 0;
 };
 template <class It>
 stride_counting_iterator(It) -> stride_counting_iterator<It>;
@@ -887,7 +899,14 @@ class sentinel_wrapper {
 public:
     explicit sentinel_wrapper() = default;
     constexpr explicit sentinel_wrapper(const It& it) : base_(base(it)) {}
-    constexpr bool operator==(const It& other) const { return base_ == base(other); }
+    constexpr bool operator==(const It& other) const {
+      // If supported, record statistics about the equality operator call
+      // inside `other`.
+      if constexpr (requires { other.record_equality_comparison(); }) {
+        other.record_equality_comparison();
+      }
+      return base_ == base(other);
+    }
     friend constexpr It base(const sentinel_wrapper& s) { return It(s.base_); }
 private:
     decltype(base(std::declval<It>())) base_;

--- a/libcxx/test/support/test_iterators.h
+++ b/libcxx/test/support/test_iterators.h
@@ -843,16 +843,13 @@ public:
         return base(x) - base(y);
     }
 
-    constexpr void record_equality_comparison() const
-    {
-        ++equals_count_;
-    }
+    constexpr void record_equality_comparison() const { ++equals_count_; }
 
     constexpr bool operator==(stride_counting_iterator const& other) const
         requires std::sentinel_for<It, It>
     {
-        record_equality_comparison();
-        return It(base_) == It(other.base_);
+      record_equality_comparison();
+      return It(base_) == It(other.base_);
     }
 
     friend constexpr bool operator<(stride_counting_iterator const& x, stride_counting_iterator const& y)


### PR DESCRIPTION
Currently, the bounds check in `std::ranges::advance(it, n, s)` is done _before_ `n` is checked. This results in one extra, unneeded bounds check.

Thus, `std::ranges::advance(it, 1, s)` currently is _not_ simply equivalent to:

```c++
if (it != s) {
    ++it;
}
```

This difference in behavior matters when the check involves some "expensive" logic. For example, the `==` operator of `std::istreambuf_iterator` may actually have to read the underlying `streambuf`.

Swapping around the checks in the `while` results in the expected behavior.