### PR TITLE
[Clang][OpenMP] throw compilation error instead of crash in Stmt::OMPScopeDirectiveClass case (#77535)

### DIFF
--- a/clang/lib/CodeGen/CGStmt.cpp
+++ b/clang/lib/CodeGen/CGStmt.cpp
@@ -414,7 +414,8 @@ void CodeGenFunction::EmitStmt(const Stmt *S, ArrayRef<const Attr *> Attrs) {
     CGM.ErrorUnsupported(S, "OpenMP dispatch directive");
     break;
   case Stmt::OMPScopeDirectiveClass:
-    llvm_unreachable("scope not supported with FE outlining");
+    CGM.ErrorUnsupported(S, "scope with FE outlining");
+    break;
   case Stmt::OMPMaskedDirectiveClass:
     EmitOMPMaskedDirective(cast<OMPMaskedDirective>(*S));
     break;

--- a/clang/test/OpenMP/error_unsupport_feature.c
+++ b/clang/test/OpenMP/error_unsupport_feature.c
@@ -1,0 +1,8 @@
+// RUN: %clang_cc1 -emit-obj -verify -fopenmp %s
+
+int main () {
+  int r = 0;
+#pragma omp scope reduction(+:r) // expected-error {{cannot compile this scope with FE outlining yet}}
+  r++;
+  return r;
+}

--- a/clang/test/OpenMP/error_unsupport_feature.c
+++ b/clang/test/OpenMP/error_unsupport_feature.c
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -emit-obj -verify -fopenmp %s
+// RUN: %clang_cc1 -emit-llvm -verify -fopenmp %s
 
 int main () {
   int r = 0;


### PR DESCRIPTION
Fix #77535, Change unstable assertion into compilation error, and add a test for it.