### PR TITLE
[mlir][Transform] Mapping update rules for `apply_conversion_patterns`

### DIFF
--- a/mlir/include/mlir/Dialect/Transform/IR/TransformOps.td
+++ b/mlir/include/mlir/Dialect/Transform/IR/TransformOps.td
@@ -203,6 +203,16 @@ def ApplyConversionPatternsOp : TransformDialectOp<"apply_conversion_patterns",
     lower ops to different ops (from a different dialect). More details can be
     found at the documentation site of `TrackingListener`.
 
+    The way op handles are updated can be customized with `find_replacements`.
+    If `find_replacements` is set, replacement ops are *not* deduced from the
+    replacement SSA values. The `find_replacements` dictionary attribute
+    specifies the kind of op that should be considered as a replacement for a
+    replaced tracked op. E.g., "arith.mulf => llvm.fmul" specifies that the
+    replacement op for a tracked "arith.mulf" must be an "llvm.fmul" op that was
+    created in the same pattern that replaced the "arith.mulf" op. If there is
+    no such op or if there are multiple such ops, a tracking listener failure
+    is produced.
+
     This transform produces a silenceable failure if the dialect conversion was
     unsuccessful or the tracking listener failed to find a replacement op.
   }];
@@ -212,6 +222,7 @@ def ApplyConversionPatternsOp : TransformDialectOp<"apply_conversion_patterns",
                        OptionalAttr<StrArrayAttr>:$illegal_ops,
                        OptionalAttr<StrArrayAttr>:$legal_dialects,
                        OptionalAttr<StrArrayAttr>:$illegal_dialects,
+                       OptionalAttr<DictionaryAttr>:$find_replacements,
                        UnitAttr:$partial_conversion,
                        UnitAttr:$preserve_handles);
   let results = (outs);

--- a/mlir/lib/Dialect/Transform/IR/TransformInterfaces.cpp
+++ b/mlir/lib/Dialect/Transform/IR/TransformInterfaces.cpp
@@ -1278,14 +1278,11 @@ void transform::TrackingListener::notifyMatchFailure(
 }
 
 void transform::TrackingListener::notifyOperationErased(Operation *op) {
-  // TODO: Walk can be removed when D144193 has landed.
-  op->walk([&](Operation *op) {
-    // Remove mappings for result values.
-    for (OpResult value : op->getResults())
-      (void)replacePayloadValue(value, nullptr);
-    // Remove mapping for op.
-    (void)replacePayloadOp(op, nullptr);
-  });
+  // Remove mappings for result values.
+  for (OpResult value : op->getResults())
+    (void)replacePayloadValue(value, nullptr);
+  // Remove mapping for op.
+  (void)replacePayloadOp(op, nullptr);
 }
 
 void transform::TrackingListener::notifyOperationReplaced(

--- a/mlir/test/Dialect/Transform/ops-invalid.mlir
+++ b/mlir/test/Dialect/Transform/ops-invalid.mlir
@@ -771,3 +771,25 @@ module attributes { transform.with_named_sequence } {
     transform.yield %arg0 : !transform.any_op
   }
 }
+
+// -----
+
+transform.sequence failures(propagate) {
+^bb0(%arg0: !transform.any_op):
+  // expected-error @below {{expected find_replacements to contain only StringAttr values}}
+  transform.apply_conversion_patterns to %arg0 {
+  } {legal_dialects = ["func", "llvm"], preserve_handles,
+     find_replacements = {"arith.muli" = 3}} : !transform.any_op
+  transform.yield
+}
+
+// -----
+
+transform.sequence failures(propagate) {
+^bb0(%arg0: !transform.any_op):
+  // expected-error @below {{find_replacements requires preserve_handles}}
+  transform.apply_conversion_patterns to %arg0 {
+  } {legal_dialects = ["func", "llvm"],
+     find_replacements = {"arith.muli" = 3}} : !transform.any_op
+  transform.yield
+}


### PR DESCRIPTION
This commit adds a new attribute to `transform.apply_conversion_patterns` that lets users specify how op handles should be updated if a tracked op is replaced during a dialect conversion.

`find_replacements` is a dictionary attribute that specifies what kind of op should be considered for a tracked replaced op of a certain kind. E.g., `"arith.mulsi_extended" => "llvm.mul"` means that a tracked `arith.mulsi_extended` op should be updated to a newly created `llvm.mul` op in the transform state. The op must have been created in the same conversion pattern that replaced the `arith.mulsi_extended`.

The current handle update mechanism is often not good enough because a pattern may create multiple ops and an op may not be directly replaced with the equivalent lower-level op. E.g., the lowering pattern for `arith.mulsi_extended` creates multiple ops and it is unclear which op should be considered as a replacement. Such information can now be injected by the users. (This mechanism will likely evolve over time.)

`find_replacements` is available only for `transform.apply_conversion_patterns` but not for `transform.apply_patterns` at the moment. Conversion patterns are typically written in such a way that each pattern lowers exactly one op. In fact, the dialect conversion asserts that a conversion pattern either replaced or in-place modified the root op. It is unclear if the `find_replacements` mechanism is suitable for regular rewrite patterns.
