### PR TITLE
[lldb][FreeBSD] Add FreeBSD specific AT_HWCAP value

### DIFF
--- a/lldb/source/Plugins/Process/Utility/AuxVector.h
+++ b/lldb/source/Plugins/Process/Utility/AuxVector.h
@@ -23,10 +23,6 @@ public:
   /// On Linux and FreeBSD, running "LD_SHOW_AUXV=1 ./executable" will spew AUX
   /// information. Added AUXV prefix to avoid potential conflicts with system-
   /// defined macros. For FreeBSD, the numbers can be found in sys/elf_common.h.
-  ///
-  /// Linux and FreeBSD values diverge, so the FreeBSD classes will convert
-  /// some entries to the Linux AT_ value so that LLDB only has to use
-  /// the constants listed here when asking the AuxVector for a value.
   enum EntryType {
     AUXV_AT_NULL = 0,      ///< End of auxv.
     AUXV_AT_IGNORE = 1,    ///< Ignore entry.

--- a/lldb/source/Plugins/Process/Utility/AuxVector.h
+++ b/lldb/source/Plugins/Process/Utility/AuxVector.h
@@ -20,9 +20,13 @@ public:
   AuxVector(const lldb_private::DataExtractor &data);
 
   /// Constants describing the type of entry.
-  /// On Linux, running "LD_SHOW_AUXV=1 ./executable" will spew AUX
+  /// On Linux and FreeBSD, running "LD_SHOW_AUXV=1 ./executable" will spew AUX
   /// information. Added AUXV prefix to avoid potential conflicts with system-
-  /// defined macros
+  /// defined macros. For FreeBSD, the numbers can be found in sys/elf_common.h.
+  ///
+  /// Linux and FreeBSD values diverge, so the FreeBSD classes will convert
+  /// some entries to the Linux AT_ value so that LLDB only has to use
+  /// the constants listed here when asking the AuxVector for a value.
   enum EntryType {
     AUXV_AT_NULL = 0,      ///< End of auxv.
     AUXV_AT_IGNORE = 1,    ///< Ignore entry.
@@ -39,6 +43,11 @@ public:
     AUXV_AT_EUID = 12,     ///< Effective UID.
     AUXV_AT_GID = 13,      ///< GID.
     AUXV_AT_EGID = 14,     ///< Effective GID.
+
+    // At this point Linux and FreeBSD diverge and many of the following values
+    // are Linux specific. If you use them make sure you are in Linux specific
+    // code or they have the same value on other platforms.
+
     AUXV_AT_CLKTCK = 17,   ///< Clock frequency (e.g. times(2)).
     AUXV_AT_PLATFORM = 15, ///< String identifying platform.
     AUXV_AT_HWCAP =
@@ -60,6 +69,10 @@ public:
     AUXV_AT_L1D_CACHESHAPE = 35,
     AUXV_AT_L2_CACHESHAPE = 36,
     AUXV_AT_L3_CACHESHAPE = 37,
+
+    // Platform specific values which may overlap the Linux values.
+
+    AUXV_FREEBSD_AT_HWCAP = 25, ///< FreeBSD specific AT_HWCAP value.
   };
 
   std::optional<uint64_t> GetAuxValue(enum EntryType entry_type) const;


### PR DESCRIPTION
While adding register fields I realised that the AUXV values for Linux and FreeBSD disagree here.

So I've added a FreeBSD specific HWCAP value that I can use from FreeBSD specific code.

The alternative is translating GetAuxValue calls depending on platform, which requires that we know what we are at all times.

Another way would be to convert the entries' values when we construct the AuxVector but the platform specific call that reads the data just returns a raw array. So adding another layer here is more disruption.