### PR TITLE
[lldb][test][FreeBSD] Fix some concurrent event tests

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/lldbutil.py
+++ b/lldb/packages/Python/lldbsuite/test/lldbutil.py
@@ -809,7 +809,7 @@ def is_thread_crashed(test, thread):
             thread.GetStopReason() == lldb.eStopReasonException
             and "EXC_BAD_ACCESS" in thread.GetStopDescription(100)
         )
-    elif test.getPlatform() == "linux":
+    elif test.getPlatform() in ["linux", "freebsd"]:
         return (
             thread.GetStopReason() == lldb.eStopReasonSignal
             and thread.GetStopReasonDataAtIndex(0)

--- a/lldb/test/API/functionalities/thread/concurrent_events/TestConcurrentTwoBreakpointsOneSignal.py
+++ b/lldb/test/API/functionalities/thread/concurrent_events/TestConcurrentTwoBreakpointsOneSignal.py
@@ -8,9 +8,6 @@ class ConcurrentTwoBreakpointsOneSignal(ConcurrentEventsBase):
     # Atomic sequences are not supported yet for MIPS in LLDB.
     @skipIf(triple="^mips")
     @expectedFlakeyNetBSD
-    @expectedFailureAll(
-        archs=["aarch64"], oslist=["freebsd"], bugnumber="llvm.org/pr49433"
-    )
     def test(self):
         """Test two threads that trigger a breakpoint and one signal thread."""
         self.build()


### PR DESCRIPTION
A lot of `TestConcurrent*.py` expect one of the threads to crash, but we weren't checking for it properly.

Possibly because signal reporting got better on FreeBSD at some point, and it now shows the same info as Linux does.

```
  lldb-api :: functionalities/inferior-changed/TestInferiorChanged.py
  lldb-api :: functionalities/inferior-crashing/TestInferiorCrashing.py
  lldb-api :: functionalities/inferior-crashing/TestInferiorCrashingStep.py
  lldb-api :: functionalities/inferior-crashing/recursive-inferior/TestRecursiveInferior.py
  lldb-api :: functionalities/inferior-crashing/recursive-inferior/TestRecursiveInferiorStep.py
  lldb-api :: functionalities/thread/concurrent_events/TestConcurrentCrashWithBreak.py
  lldb-api :: functionalities/thread/concurrent_events/TestConcurrentCrashWithSignal.py
  lldb-api :: functionalities/thread/concurrent_events/TestConcurrentCrashWithWatchpoint.py
  lldb-api :: functionalities/thread/concurrent_events/TestConcurrentCrashWithWatchpointBreakpointSignal.py
```

Fixes #48777

`TestConcurrentTwoBreakpointsOneSignal.py` no longer fails, at least on an AWS instance, so I've removed the xfail there.