### PR TITLE
[clang-repl] Refactor locking of runtime PTU stack (NFC)

### DIFF
--- a/clang/include/clang/Interpreter/Interpreter.h
+++ b/clang/include/clang/Interpreter/Interpreter.h
@@ -142,6 +142,7 @@ public:
 
 private:
   size_t getEffectivePTUSize() const;
+  void markUserCodeStart();
 
   bool FindRuntimeInterface();
 


### PR DESCRIPTION
The previous implementation seemed hacky, because it required the reader to be familiar with the internal workings of the PTU stack. The concept itself is a pragmatic solution and not very surprising. Keeping it behind a finalization call seems reasonable.