### PR TITLE
[mlir] Add fast and ftz flags in gpu-lower-to-nvvm-pipeline

### DIFF
--- a/mlir/include/mlir/Dialect/GPU/Pipelines/Passes.h
+++ b/mlir/include/mlir/Dialect/GPU/Pipelines/Passes.h
@@ -53,6 +53,16 @@ struct GPUToNVVMPipelineOptions
           "Whether to use the bareptr calling convention on the host (warning "
           "this should be false until the GPU layering is fixed)"),
       llvm::cl::init(false)};
+  PassOptions::Option<bool> ftz{
+      *this, "ftz",
+      llvm::cl::desc(
+          "Enable flush to zero for denormals"),
+      llvm::cl::init(false)};
+  PassOptions::Option<bool> fast{
+      *this, "fast",
+      llvm::cl::desc(
+          "Enable fast math mode."),
+      llvm::cl::init(false)};
 };
 
 //===----------------------------------------------------------------------===//

--- a/mlir/include/mlir/Dialect/GPU/Pipelines/Passes.h
+++ b/mlir/include/mlir/Dialect/GPU/Pipelines/Passes.h
@@ -54,15 +54,11 @@ struct GPUToNVVMPipelineOptions
           "this should be false until the GPU layering is fixed)"),
       llvm::cl::init(false)};
   PassOptions::Option<bool> ftz{
-      *this, "ftz",
-      llvm::cl::desc(
-          "Enable flush to zero for denormals"),
+      *this, "ftz", llvm::cl::desc("Enable flush to zero for denormals"),
       llvm::cl::init(false)};
-  PassOptions::Option<bool> fast{
-      *this, "fast",
-      llvm::cl::desc(
-          "Enable fast math mode."),
-      llvm::cl::init(false)};
+  PassOptions::Option<bool> fast{*this, "fast",
+                                 llvm::cl::desc("Enable fast math mode."),
+                                 llvm::cl::init(false)};
 };
 
 //===----------------------------------------------------------------------===//

--- a/mlir/lib/Dialect/GPU/Pipelines/GPUToNVVMPipeline.cpp
+++ b/mlir/lib/Dialect/GPU/Pipelines/GPUToNVVMPipeline.cpp
@@ -60,6 +60,8 @@ void buildCommonPassPipeline(
   nvvmTargetOptions.chip = options.cubinChip;
   nvvmTargetOptions.features = options.cubinFeatures;
   nvvmTargetOptions.optLevel = options.optLevel;
+  nvvmTargetOptions.ftzFlag = options.ftz;
+  nvvmTargetOptions.fastFlag = options.fast;
   pm.addPass(createGpuNVVMAttachTarget(nvvmTargetOptions));
   pm.addPass(createLowerAffinePass());
   pm.addPass(createArithToLLVMConversionPass());


### PR DESCRIPTION
This PR adds two flags to the pipeline so we can pass them to the nvvm lowering.