### PR TITLE
Fix vfork test strcmp buildbot failure

### DIFF
--- a/lldb/test/API/functionalities/fork/concurrent_vfork/main.cpp
+++ b/lldb/test/API/functionalities/fork/concurrent_vfork/main.cpp
@@ -1,6 +1,7 @@
 #include <assert.h>
 #include <iostream>
 #include <mutex>
+#include <string.h>
 #include <sys/wait.h>
 #include <thread>
 #include <unistd.h>


### PR DESCRIPTION
The buildbot seems to complain about `strcmp` function not available in the vfork patch (https://github.com/llvm/llvm-project/pull/81564):
https://lab.llvm.org/buildbot/#/builders/68/builds/70093/steps/6/logs/stdio 

Unfortunately, I can't reproduce the failure on my linux machine so this is a guessing fix. If anyone has a way to reproduce and very this fix, please feel free to merge this change. 