### PR TITLE
[libcxx] adds opt out mechanism for using __wrap_iter for array and s…

### DIFF
--- a/libcxx/docs/ReleaseNotes/19.rst
+++ b/libcxx/docs/ReleaseNotes/19.rst
@@ -49,6 +49,9 @@ Improvements and New Features
 -----------------------------
 
 - The performance of growing ``std::vector`` has been improved for trivially relocatable types.
+- ``std::array`` and ``std::string_view`` are no longer pointers in the unstable ABI by default, and
+  can be reverted to raw pointers by defining the macros ``_LIBCPP_ABI_NO_USE_WRAP_ITER_IN_STD_ARRAY``
+  and ``_LIBCPP_ABI_NO_USE_WRAP_ITER_IN_STD_STRING_VIEW``.
 
 Deprecations and Removals
 -------------------------

--- a/libcxx/include/__config
+++ b/libcxx/include/__config
@@ -178,8 +178,14 @@
 // pointers, which prevents people from relying on a non-portable implementation
 // detail. This is especially useful because enabling bounded iterators hardening
 // requires code not to make these assumptions.
-#    define _LIBCPP_ABI_USE_WRAP_ITER_IN_STD_ARRAY
-#    define _LIBCPP_ABI_USE_WRAP_ITER_IN_STD_STRING_VIEW
+
+#    if !defined(_LIBCPP_ABI_NO_USE_WRAP_ITER_IN_STD_ARRAY)
+#        define _LIBCPP_ABI_USE_WRAP_ITER_IN_STD_ARRAY
+#    endif
+
+#    if !defined(_LIBCPP_ABI_NO_USE_WRAP_ITER_IN_STD_STRING_VIEW)
+#        define _LIBCPP_ABI_USE_WRAP_ITER_IN_STD_STRING_VIEW
+#    endif
 #  elif _LIBCPP_ABI_VERSION == 1
 #    if !(defined(_LIBCPP_OBJECT_FORMAT_COFF) || defined(_LIBCPP_OBJECT_FORMAT_XCOFF))
 // Enable compiling copies of now inline methods into the dylib to support


### PR DESCRIPTION
…tring_view

`__config` was unconditionally opting users into this change, and to opt out required either a manual edit of the header, or getting users to manually define each unstable ABI macro they want to support. This patch strikes a middle-ground by adding an opt-out mechanism.