### PR TITLE
[lldb][test] Enforce `pexpect` system availability by default

### DIFF
--- a/lldb/cmake/modules/LLDBConfig.cmake
+++ b/lldb/cmake/modules/LLDBConfig.cmake
@@ -68,7 +68,7 @@ option(LLDB_SKIP_DSYM "Whether to skip generating a dSYM when installing lldb." 
 option(LLDB_ENFORCE_STRICT_TEST_REQUIREMENTS
   "Fail to configure if certain requirements are not met for testing." OFF)
 option(LLDB_TEST_USE_VENDOR_PACKAGES
-  "Use packages from lldb/third_party/Python/module instead of system deps." ON)
+  "Use packages from lldb/third_party/Python/module instead of system deps." OFF)
 
 set(LLDB_GLOBAL_INIT_DIRECTORY "" CACHE STRING
   "Path to the global lldbinit directory. Relative paths are resolved relative to the

--- a/lldb/test/CMakeLists.txt
+++ b/lldb/test/CMakeLists.txt
@@ -34,7 +34,9 @@ endif()
 # The "pexpect" package should come from the system environment, not from the
 # LLDB tree. However, we delay the deletion of it from the tree in case
 # users/buildbots don't have the package yet and need some time to install it.
-if (NOT LLDB_TEST_USE_VENDOR_PACKAGES)
+# Windows is configured to skip all pexpect tests, and guards all
+# "import pexpect" calls, so we do not need pexpect installed there.
+if (NOT LLDB_TEST_USE_VENDOR_PACKAGES AND NOT WIN32)
   unset(PY_pexpect_FOUND CACHE)
   lldb_find_python_module(pexpect)
   if (NOT PY_pexpect_FOUND)


### PR DESCRIPTION
This switches the default of `LLDB_TEST_USE_VENDOR_PACKAGES` from `ON` to `OFF` in preparation for eventually deleting it. All known LLDB buildbots have this package installed, so flipping the default will uncover any other users.

If this breaks anything, the preferred fix is to install `pexpect` on the host system. The second fix is to build with cmake option `-DLLDB_TEST_USE_VENDOR_PACKAGES=ON` as a temporary measure until `pexpect` can be installed. If neither of those work, reverting this patch is OK.