### PR TITLE
[NFC] [C++20] [Modules] [P1689] [Scanner] Don't use thread pool in P1689 per file mode

### DIFF
--- a/clang/tools/clang-scan-deps/ClangScanDeps.cpp
+++ b/clang/tools/clang-scan-deps/ClangScanDeps.cpp
@@ -910,8 +910,7 @@ int clang_scan_deps_main(int argc, char **argv, const llvm::ToolContext &) {
 
       // Run the tool on it.
       if (Format == ScanningOutputFormat::Make) {
-        auto MaybeFile =
-            WorkerTool.getDependencyFile(Input->CommandLine, CWD);
+        auto MaybeFile = WorkerTool.getDependencyFile(Input->CommandLine, CWD);
         if (handleMakeDependencyToolResult(Filename, MaybeFile, DependencyOS,
                                            Errs))
           HadErrors = true;
@@ -996,9 +995,8 @@ int clang_scan_deps_main(int argc, char **argv, const llvm::ToolContext &) {
     }
 
     for (unsigned I = 0; I < Pool.getMaxConcurrency(); ++I) {
-      Pool.async([ScanningTask, &WorkerTools, I]() {
-        ScanningTask(WorkerTools[I]);
-      });
+      Pool.async(
+          [ScanningTask, &WorkerTools, I]() { ScanningTask(WorkerTools[I]); });
     }
     Pool.wait();
   }

--- a/clang/tools/clang-scan-deps/ClangScanDeps.cpp
+++ b/clang/tools/clang-scan-deps/ClangScanDeps.cpp
@@ -744,9 +744,6 @@ getCompilationDataBase(int argc, char **argv, std::string &ErrorMessage) {
     return nullptr;
   }
 
-  // Only 1 threads is required if P1689 per file mode.
-  NumThreads = 1;
-
   // There might be multiple jobs for a compilation. Extract the specified
   // output filename from the last job.
   auto LastCmd = C->getJobs().end();


### PR DESCRIPTION

I suddenly found that the clang scan deps may use all concurrent threads to scan the files. It makes sense in the batch mode. But in P1689 per file mode, it simply wastes times and resources.

This patch itself should be a NFC patch. It simply moves codes.