### PR TITLE
[lld][ELF] Add /PASSTHRU/. #65087

### DIFF
--- a/lld/ELF/InputSection.cpp
+++ b/lld/ELF/InputSection.cpp
@@ -310,6 +310,7 @@ std::string InputSectionBase::getObjMsg(uint64_t off) const {
 }
 
 InputSection InputSection::discarded(nullptr, 0, 0, 0, ArrayRef<uint8_t>(), "");
+InputSection InputSection::passthru(nullptr, 0, 0, 0, ArrayRef<uint8_t>(), "");
 
 InputSection::InputSection(InputFile *f, uint64_t flags, uint32_t type,
                            uint32_t addralign, ArrayRef<uint8_t> data,

--- a/lld/ELF/InputSection.h
+++ b/lld/ELF/InputSection.h
@@ -415,6 +415,7 @@ public:
   void replace(InputSection *other);
 
   static InputSection discarded;
+  static InputSection passthru;
 
 private:
   template <class ELFT, class RelTy> void copyRelocations(uint8_t *buf);

--- a/lld/test/ELF/linkerscript/Inputs/passthru2.s
+++ b/lld/test/ELF/linkerscript/Inputs/passthru2.s
@@ -1,0 +1,6 @@
+
+.section .x.b, "a"
+  .quad 0
+
+.section .y.b, "a"
+  .quad 0

--- a/lld/test/ELF/linkerscript/passthru.s
+++ b/lld/test/ELF/linkerscript/passthru.s
@@ -1,0 +1,27 @@
+# REQUIRES: x86
+# RUN: llvm-mc -filetype=obj -triple=x86_64-unknown-linux %s -o %t1
+# RUN: llvm-mc -filetype=obj -triple=x86_64-unknown-linux %S/Inputs/passthru2.s -o %t2
+# RUN: echo "SECTIONS { " \
+# RUN:      "  /PASSTHRU/ : { *(.x*); *(.y*) }" \
+# RUN:      "  .y.foo : { *(.x*); }" \
+# RUN:      "  .x.foo : { *(.y*); }" \
+# RUN:      "}" > %t.script
+# RUN: ld.lld -o %t.out --script %t.script %t1 %t2
+# RUN: llvm-objdump --section-headers %t.out | FileCheck %s
+
+# The order should not be affected by the order of matches in the /PASSTHRU/
+# section, and we should not have any .x.foo or .y.foo sections.
+
+# CHECK: 1 .x.a
+# CHECK: 2 .y.a
+# CHECK: 3 .x.b
+# CHECK: 4 .y.b
+
+# CHECK-NOT: .x.foo
+# CHECK-NOT: .y.foo
+
+.section .x.a, "a"
+  .quad 0
+
+.section .y.a, "a"
+  .quad 0


### PR DESCRIPTION
This adds a special output section name to linker
scripts similar to /DISCARD/, but where any input
section mentioned in the description will not be
considered for any further matching, and will not
result in any orphan handling diagnostics if they
are enabled.
