### PR TITLE
[lld][WebAssembly] Always search *.so for -Bdynamic

### DIFF
--- a/lld/wasm/Config.h
+++ b/lld/wasm/Config.h
@@ -72,7 +72,7 @@ struct Configuration {
   bool stripAll;
   bool stripDebug;
   bool stackFirst;
-  bool isStatic = false;
+  bool isStatic = true;
   bool trace;
   uint64_t globalBase;
   uint64_t initialHeap;

--- a/lld/wasm/Config.h
+++ b/lld/wasm/Config.h
@@ -72,6 +72,8 @@ struct Configuration {
   bool stripAll;
   bool stripDebug;
   bool stackFirst;
+  // Because dyamanic linking under Wasm is still experimental we default to
+  // static linking
   bool isStatic = true;
   bool trace;
   uint64_t globalBase;

--- a/lld/wasm/Driver.cpp
+++ b/lld/wasm/Driver.cpp
@@ -554,6 +554,11 @@ static void readConfigs(opt::InputArgList &args) {
   config->zStackSize =
       args::getZOptionValue(args, OPT_z, "stack-size", WasmPageSize);
 
+  // -Bdynamic by default if -pie or -shared is specified.
+  if (config->pie || config->shared) {
+    config->isStatic = false;
+  }
+
   if (config->maxMemory != 0 && config->noGrowableMemory) {
     // Erroring out here is simpler than defining precedence rules.
     error("--max-memory is incompatible with --no-growable-memory");

--- a/lld/wasm/Driver.cpp
+++ b/lld/wasm/Driver.cpp
@@ -555,9 +555,8 @@ static void readConfigs(opt::InputArgList &args) {
       args::getZOptionValue(args, OPT_z, "stack-size", WasmPageSize);
 
   // -Bdynamic by default if -pie or -shared is specified.
-  if (config->pie || config->shared) {
+  if (config->pie || config->shared)
     config->isStatic = false;
-  }
 
   if (config->maxMemory != 0 && config->noGrowableMemory) {
     // Erroring out here is simpler than defining precedence rules.

--- a/lld/wasm/Driver.cpp
+++ b/lld/wasm/Driver.cpp
@@ -341,9 +341,7 @@ static std::optional<std::string> findFromSearchPaths(StringRef path) {
 // search paths.
 static std::optional<std::string> searchLibraryBaseName(StringRef name) {
   for (StringRef dir : config->searchPaths) {
-    // Currently we don't enable dynamic linking at all unless -shared or -pie
-    // are used, so don't even look for .so files in that case..
-    if (ctx.isPic && !config->isStatic)
+    if (!config->isStatic)
       if (std::optional<std::string> s = findFile(dir, "lib" + name + ".so"))
         return s;
     if (std::optional<std::string> s = findFile(dir, "lib" + name + ".a"))

--- a/lld/wasm/Options.td
+++ b/lld/wasm/Options.td
@@ -38,9 +38,9 @@ multiclass B<string name, string help1, string help2> {
 // The following flags are shared with the ELF linker
 def Bsymbolic: F<"Bsymbolic">, HelpText<"Bind defined symbols locally">;
 
-def Bdynamic: F<"Bdynamic">, HelpText<"Link against shared libraries (default)">;
+def Bdynamic: F<"Bdynamic">, HelpText<"Link against shared libraries">;
 
-def Bstatic: F<"Bstatic">, HelpText<"Do not link against shared libraries">;
+def Bstatic: F<"Bstatic">, HelpText<"Do not link against shared libraries (default)">;
 
 def build_id: F<"build-id">, HelpText<"Alias for --build-id=fast">;
 


### PR DESCRIPTION
Search *.so libraries regardless of -pie to make it a bit more straightforward to build non-pie dynamic-linked executables.

Flip the default to -Bstatic (unless -pie or -shared is specified) as I think it's what most users expect for the default as of today.
The assumption here is that, because dynamic-linking is not widely used for WebAssembly, the most users do not specify -Bdynamic or -Bstatic, expecting static link.
Although the recent wasi-sdk ships *.so files, there are not many wasm runtimes providing the support of dynamic-linking. (only emscripten and toywasm as far as i know.)
