### PR TITLE
Revert "[libc] Remove UB specializations of type traits for `BigInt`"

### DIFF
--- a/libc/src/__support/CMakeLists.txt
+++ b/libc/src/__support/CMakeLists.txt
@@ -95,7 +95,6 @@ add_header_library(
   HDRS
     integer_to_string.h
   DEPENDS
-    .uint
     libc.src.__support.common
     libc.src.__support.CPP.algorithm
     libc.src.__support.CPP.limits

--- a/libc/src/__support/float_to_string.h
+++ b/libc/src/__support/float_to_string.h
@@ -713,7 +713,7 @@ template <> class FloatToString<long double> {
       float_as_fixed.shift_left(SHIFT_AMOUNT);
 
       // If there are still digits above the decimal point, handle those.
-      if (float_as_fixed.clz() < static_cast<int>(EXTRA_INT_WIDTH)) {
+      if (float_as_fixed.clz() < EXTRA_INT_WIDTH) {
         cpp::UInt<EXTRA_INT_WIDTH> above_decimal_point =
             float_as_fixed >> FLOAT_AS_INT_WIDTH;
 

--- a/libc/src/__support/integer_to_string.h
+++ b/libc/src/__support/integer_to_string.h
@@ -67,7 +67,6 @@
 #include "src/__support/CPP/span.h"
 #include "src/__support/CPP/string_view.h"
 #include "src/__support/CPP/type_traits.h"
-#include "src/__support/UInt.h" // is_big_int
 #include "src/__support/common.h"
 
 namespace LIBC_NAMESPACE {
@@ -150,18 +149,6 @@ public:
 using StringBufferWriter = StringBufferWriterImpl<true>;
 using BackwardStringBufferWriter = StringBufferWriterImpl<false>;
 
-template <typename T, class = void> struct IntegerWriterUnsigned {};
-
-template <typename T>
-struct IntegerWriterUnsigned<T, cpp::enable_if_t<cpp::is_integral_v<T>>> {
-  using type = cpp::make_unsigned_t<T>;
-};
-
-template <typename T>
-struct IntegerWriterUnsigned<T, cpp::enable_if_t<cpp::is_big_int_v<T>>> {
-  using type = typename T::unsigned_type;
-};
-
 } // namespace details
 
 namespace radix {
@@ -176,7 +163,7 @@ template <size_t radix> using Custom = details::Fmt<radix>;
 
 // See file header for documentation.
 template <typename T, typename Fmt = radix::Dec> class IntegerToString {
-  static_assert(cpp::is_integral_v<T> || cpp::is_big_int_v<T>);
+  static_assert(cpp::is_integral_v<T>);
 
   LIBC_INLINE static constexpr size_t compute_buffer_size() {
     constexpr auto MAX_DIGITS = []() -> size_t {
@@ -221,8 +208,8 @@ template <typename T, typename Fmt = radix::Dec> class IntegerToString {
 
   // An internal stateless structure that handles the number formatting logic.
   struct IntegerWriter {
-    static_assert(cpp::is_integral_v<T> || cpp::is_big_int_v<T>);
-    using UNSIGNED_T = typename details::IntegerWriterUnsigned<T>::type;
+    static_assert(cpp::is_integral_v<T>);
+    using UNSIGNED_T = cpp::make_unsigned_t<T>;
 
     LIBC_INLINE static char digit_char(uint8_t digit) {
       if (digit < 10)

--- a/libc/test/UnitTest/CMakeLists.txt
+++ b/libc/test/UnitTest/CMakeLists.txt
@@ -74,7 +74,6 @@ add_unittest_framework_library(
     libc.src.__support.CPP.type_traits
     libc.src.__support.fixed_point.fx_rep
     libc.src.__support.OSUtil.osutil
-    libc.src.__support.uint
     libc.src.__support.uint128
 )
 

--- a/libc/test/UnitTest/LibcTest.cpp
+++ b/libc/test/UnitTest/LibcTest.cpp
@@ -38,8 +38,7 @@ TestLogger &operator<<(TestLogger &logger, Location Loc) {
 // When the value is UInt128, __uint128_t or wider, show its hexadecimal
 // digits.
 template <typename T>
-cpp::enable_if_t<(cpp::is_integral_v<T> && (sizeof(T) > sizeof(uint64_t))) ||
-                     cpp::is_big_int_v<T>,
+cpp::enable_if_t<cpp::is_integral_v<T> && (sizeof(T) > sizeof(uint64_t)),
                  cpp::string>
 describeValue(T Value) {
   static_assert(sizeof(T) % 8 == 0, "Unsupported size of UInt");
@@ -48,10 +47,11 @@ describeValue(T Value) {
 }
 
 // When the value is of a standard integral type, just display it as normal.
-template <typename T>
-cpp::enable_if_t<cpp::is_integral_v<T> && (sizeof(T) <= sizeof(uint64_t)),
+template <typename ValType>
+cpp::enable_if_t<cpp::is_integral_v<ValType> &&
+                     sizeof(ValType) <= sizeof(uint64_t),
                  cpp::string>
-describeValue(T Value) {
+describeValue(ValType Value) {
   return cpp::to_string(Value);
 }
 

--- a/libc/test/UnitTest/LibcTest.h
+++ b/libc/test/UnitTest/LibcTest.h
@@ -127,7 +127,6 @@ protected:
   // of type promotion.
   template <typename ValType,
             cpp::enable_if_t<cpp::is_integral_v<ValType> ||
-                                 cpp::is_big_int_v<ValType> ||
                                  cpp::is_fixed_point_v<ValType>,
                              int> = 0>
   bool test(TestCond Cond, ValType LHS, ValType RHS, const char *LHSStr,

--- a/libc/test/UnitTest/TestLogger.cpp
+++ b/libc/test/UnitTest/TestLogger.cpp
@@ -2,7 +2,6 @@
 #include "src/__support/CPP/string.h"
 #include "src/__support/CPP/string_view.h"
 #include "src/__support/OSUtil/io.h" // write_to_stderr
-#include "src/__support/UInt.h"      // is_big_int
 #include "src/__support/UInt128.h"
 
 #include <stdint.h>
@@ -48,9 +47,8 @@ template <> TestLogger &TestLogger::operator<<(void *addr) {
 }
 
 template <typename T> TestLogger &TestLogger::operator<<(T t) {
-  if constexpr (cpp::is_big_int_v<T> ||
-                (cpp::is_integral_v<T> && cpp::is_unsigned_v<T> &&
-                 (sizeof(T) > sizeof(uint64_t)))) {
+  if constexpr (cpp::is_integral_v<T> && cpp::is_unsigned_v<T> &&
+                sizeof(T) > sizeof(uint64_t)) {
     static_assert(sizeof(T) % 8 == 0, "Unsupported size of UInt");
     const IntegerToString<T, radix::Hex::WithPrefix> buffer(t);
     return *this << buffer.view();
@@ -70,7 +68,7 @@ template TestLogger &TestLogger::operator<< <unsigned short>(unsigned short);
 template TestLogger &TestLogger::operator<< <unsigned int>(unsigned int);
 template TestLogger &TestLogger::operator<< <unsigned long>(unsigned long);
 template TestLogger &
-    TestLogger::operator<< <unsigned long long>(unsigned long long);
+TestLogger::operator<< <unsigned long long>(unsigned long long);
 
 #ifdef __SIZEOF_INT128__
 template TestLogger &TestLogger::operator<< <__uint128_t>(__uint128_t);

--- a/libc/test/src/__support/CPP/bit_test.cpp
+++ b/libc/test/src/__support/CPP/bit_test.cpp
@@ -12,44 +12,21 @@
 
 #include <stdint.h>
 
-#include <iostream>
-
 namespace LIBC_NAMESPACE::cpp {
 
-using UnsignedTypesNoBigInt = testing::TypeList<
+using UnsignedTypes =
+    testing::TypeList<unsigned char, unsigned short, unsigned int,
+                      unsigned long, unsigned long long,
 #if defined(__SIZEOF_INT128__)
-    __uint128_t,
+                      __uint128_t,
 #endif
-    unsigned char, unsigned short, unsigned int, unsigned long,
-    unsigned long long>;
-
-using UnsignedTypes = testing::TypeList<
-#if defined(__SIZEOF_INT128__)
-    __uint128_t,
-#endif
-    unsigned char, unsigned short, unsigned int, unsigned long,
-    unsigned long long, cpp::UInt<128>>;
+                      cpp::UInt<128>>;
 
 TYPED_TEST(LlvmLibcBitTest, HasSingleBit, UnsignedTypes) {
-  constexpr auto ZERO = T(0);
-  constexpr auto ALL_ONES = T(~ZERO);
-  EXPECT_FALSE(has_single_bit<T>(ZERO));
-  EXPECT_FALSE(has_single_bit<T>(ALL_ONES));
-
+  EXPECT_FALSE(has_single_bit<T>(T(0)));
+  EXPECT_FALSE(has_single_bit<T>(~T(0)));
   for (T value = 1; value; value <<= 1)
     EXPECT_TRUE(has_single_bit<T>(value));
-
-  // We test that if two bits are set has_single_bit returns false.
-  // We do this by setting the highest or lowest bit depending or where the
-  // current bit is. This is a bit convoluted but it helps catch a bug on BigInt
-  // where we have to work on an element-by-element basis.
-  constexpr auto MIDPOINT = T(ALL_ONES / 2);
-  constexpr auto LSB = T(1);
-  constexpr auto MSB = T(~(ALL_ONES >> 1));
-  for (T value = 1; value; value <<= 1) {
-    auto two_bits_value = value | ((value <= MIDPOINT) ? MSB : LSB);
-    EXPECT_FALSE(has_single_bit<T>(two_bits_value));
-  }
 }
 
 TYPED_TEST(LlvmLibcBitTest, CountLZero, UnsignedTypes) {
@@ -229,39 +206,39 @@ TEST(LlvmLibcBitTest, Rotr) {
             rotr<uint64_t>(0x12345678deadbeefULL, -19));
 }
 
-TYPED_TEST(LlvmLibcBitTest, FirstLeadingZero, UnsignedTypesNoBigInt) {
+TYPED_TEST(LlvmLibcBitTest, FirstLeadingZero, UnsignedTypes) {
   EXPECT_EQ(first_leading_zero<T>(cpp::numeric_limits<T>::max()), 0);
   for (int i = 0U; i != cpp::numeric_limits<T>::digits; ++i)
     EXPECT_EQ(first_leading_zero<T>(~(T(1) << i)),
               cpp::numeric_limits<T>::digits - i);
 }
 
-TYPED_TEST(LlvmLibcBitTest, FirstLeadingOne, UnsignedTypesNoBigInt) {
+TYPED_TEST(LlvmLibcBitTest, FirstLeadingOne, UnsignedTypes) {
   EXPECT_EQ(first_leading_one<T>(static_cast<T>(0)), 0);
   for (int i = 0U; i != cpp::numeric_limits<T>::digits; ++i)
     EXPECT_EQ(first_leading_one<T>(T(1) << i),
               cpp::numeric_limits<T>::digits - i);
 }
 
-TYPED_TEST(LlvmLibcBitTest, FirstTrailingZero, UnsignedTypesNoBigInt) {
+TYPED_TEST(LlvmLibcBitTest, FirstTrailingZero, UnsignedTypes) {
   EXPECT_EQ(first_trailing_zero<T>(cpp::numeric_limits<T>::max()), 0);
   for (int i = 0U; i != cpp::numeric_limits<T>::digits; ++i)
     EXPECT_EQ(first_trailing_zero<T>(~(T(1) << i)), i + 1);
 }
 
-TYPED_TEST(LlvmLibcBitTest, FirstTrailingOne, UnsignedTypesNoBigInt) {
+TYPED_TEST(LlvmLibcBitTest, FirstTrailingOne, UnsignedTypes) {
   EXPECT_EQ(first_trailing_one<T>(cpp::numeric_limits<T>::max()), 0);
   for (int i = 0U; i != cpp::numeric_limits<T>::digits; ++i)
     EXPECT_EQ(first_trailing_one<T>(T(1) << i), i + 1);
 }
 
-TYPED_TEST(LlvmLibcBitTest, CountZeros, UnsignedTypesNoBigInt) {
+TYPED_TEST(LlvmLibcBitTest, CountZeros, UnsignedTypes) {
   EXPECT_EQ(count_zeros(T(0)), cpp::numeric_limits<T>::digits);
   for (int i = 0; i != cpp::numeric_limits<T>::digits; ++i)
     EXPECT_EQ(count_zeros<T>(cpp::numeric_limits<T>::max() >> i), i);
 }
 
-TYPED_TEST(LlvmLibcBitTest, CountOnes, UnsignedTypesNoBigInt) {
+TYPED_TEST(LlvmLibcBitTest, CountOnes, UnsignedTypes) {
   EXPECT_EQ(count_ones(T(0)), 0);
   for (int i = 0; i != cpp::numeric_limits<T>::digits; ++i)
     EXPECT_EQ(count_ones<T>(cpp::numeric_limits<T>::max() >> i),

--- a/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
@@ -507,7 +507,6 @@ libc_support_library(
         ":__support_cpp_span",
         ":__support_cpp_string_view",
         ":__support_cpp_type_traits",
-        ":__support_uint",
     ],
 )
 

--- a/utils/bazel/llvm-project-overlay/libc/test/UnitTest/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/test/UnitTest/BUILD.bazel
@@ -18,7 +18,6 @@ libc_support_library(
         "//libc:__support_cpp_string",
         "//libc:__support_cpp_string_view",
         "//libc:__support_osutil_io",
-        "//libc:__support_uint",
         "//libc:__support_uint128",
     ],
 )


### PR DESCRIPTION
Reverts llvm/llvm-project#84035

Several bots are failing:
 - https://lab.llvm.org/buildbot/#/builders/223/builds/37522
 - https://lab.llvm.org/buildbot/#/builders/162/builds/51978
 - https://lab.llvm.org/buildbot/#/builders/163/builds/52560
 - https://lab.llvm.org/buildbot/#/builders/250/builds/19619