### PR TITLE
[AMDGPU] Add getRegPressureLimit(TargetOccupancy)

### DIFF
--- a/llvm/lib/Target/AMDGPU/GCNSchedStrategy.cpp
+++ b/llvm/lib/Target/AMDGPU/GCNSchedStrategy.cpp
@@ -88,8 +88,11 @@ void GCNSchedStrategy::initialize(ScheduleDAGMI *DAG) {
       std::min(ST.getMaxNumSGPRs(TargetOccupancy, true), SGPRExcessLimit);
 
   if (!KnownExcessRP) {
+    const SIRegisterInfo *SRI = static_cast<const SIRegisterInfo *>(TRI);
     VGPRCriticalLimit =
-        std::min(ST.getMaxNumVGPRs(TargetOccupancy), VGPRExcessLimit);
+        std::min(SRI->getRegPressureLimit(&AMDGPU::VGPR_32RegClass, *MF,
+                                          TargetOccupancy),
+                 VGPRExcessLimit);
   } else {
     // This is similar to ST.getMaxNumVGPRs(TargetOccupancy) result except
     // returns a reasonably small number for targets with lots of VGPRs, such

--- a/llvm/lib/Target/AMDGPU/SIRegisterInfo.h
+++ b/llvm/lib/Target/AMDGPU/SIRegisterInfo.h
@@ -323,6 +323,11 @@ public:
   unsigned getRegPressureLimit(const TargetRegisterClass *RC,
                                MachineFunction &MF) const override;
 
+  // Compute the register pressure limit for a given \p TargetOccupancy.
+  unsigned getRegPressureLimit(const TargetRegisterClass *RC,
+                               MachineFunction &MF,
+                               unsigned TargetOccupancy) const;
+
   unsigned getRegPressureSetLimit(const MachineFunction &MF,
                                   unsigned Idx) const override;
 


### PR DESCRIPTION
Add a new overload* for `getRegPressureLimit` that computes the limit using a given target occupancy, rather than the one based on the LDS size. Use it to set the critical VGPR limit in `GCNSchedStrategy` (because I'm touching `GCNSchedStrategy` downstream and it seems like a better idea to use the concept of the register pressure limit than to invent a new confusingly named helper that's trying to do mostly the same thing).

This is NFC in our existing tests, but there might be examples in the wild where this could change the scheduling. In particular it might set a more aggressive `VGPRCriticalLimit` if
```
getMaxNumVGPRs(MFI.getWavesPerEU() < getMaxNumVGPRs(TargetOccupancy)
```
I'm not sure how often we'd hit that case, and even if we do hit it, using fewer VGPRs might be a good thing anyway.

(*) I'm adding an overload rather than a simple optional parameter because the original getRegPressureLimit is virtual.