### PR TITLE
[PDLL]: Fix crash when negation doesn't apply to native constraint

### DIFF
--- a/mlir/lib/Tools/PDLL/Parser/Parser.cpp
+++ b/mlir/lib/Tools/PDLL/Parser/Parser.cpp
@@ -1968,6 +1968,8 @@ FailureOr<ast::Expr *> Parser::parseNegatedExpr() {
   FailureOr<ast::Expr *> identifierExpr = parseIdentifierExpr();
   if (failed(identifierExpr))
     return failure();
+  if (!curToken.is(Token::l_paren))
+    return emitError("expected `(` after function name");
   return parseCallExpr(*identifierExpr, /*isNegated = */ true);
 }
 

--- a/mlir/test/mlir-pdll/Parser/expr-failure.pdll
+++ b/mlir/test/mlir-pdll/Parser/expr-failure.pdll
@@ -206,6 +206,23 @@ Pattern {
 // -----
 
 Pattern {
+  // CHECK: expected native constraint
+  not attr<"0 : i1">
+  erase _;
+}
+
+// -----
+
+Pattern {
+  let tuple = (attr<"3 : i34">);
+  // CHECK: expected `(` after function name
+  not tuple.0;
+  erase _;
+}
+
+// -----
+
+Pattern {
   // CHECK: expected expression
   let tuple = (10 = _: Value);
   erase op<>;


### PR DESCRIPTION
Fixes that
```
Pattern {
  let tuple = (attr<"3 : i34">);
  not tuple.0;
  erase _;
}
```
would crash the PDLL parser because it expected a native constraint after `not`.