### PR TITLE
[clang-format] Add --fail-on-incomplete-format.

### DIFF
--- a/clang/docs/ClangFormat.rst
+++ b/clang/docs/ClangFormat.rst
@@ -61,6 +61,7 @@ to format C/C++/Java/JavaScript/JSON/Objective-C/Protobuf/C# code.
     --dry-run                      - If set, do not actually make the formatting changes
     --dump-config                  - Dump configuration options to stdout and exit.
                                      Can be used with -style option.
+    --fail-on-incomplete-format    - If set, fail with exit code 1 on incomplete format.
     --fallback-style=<string>      - The name of the predefined style used as a
                                      fallback in case clang-format is invoked with
                                      -style=file, but can not find the .clang-format

--- a/clang/test/Format/fail-on-incomplete.cpp
+++ b/clang/test/Format/fail-on-incomplete.cpp
@@ -1,4 +1,4 @@
-// RUN: not clang-format %s -style=LLVM -fail-on-incomplete-format
-// RUN: clang-format %s -style=LLVM
-int a(
+// RUN: not clang-format -style=LLVM -fail-on-incomplete-format %s
+// RUN: clang-format -style=LLVM %s
 
+int a(

--- a/clang/test/Format/fail-on-incomplete.cpp
+++ b/clang/test/Format/fail-on-incomplete.cpp
@@ -1,0 +1,4 @@
+// RUN: not clang-format %s -style=LLVM -fail-on-incomplete-format
+// RUN: clang-format %s -style=LLVM
+int a(
+

--- a/clang/tools/clang-format/ClangFormat.cpp
+++ b/clang/tools/clang-format/ClangFormat.cpp
@@ -540,10 +540,7 @@ static bool format(StringRef FileName, bool ErrorOnIncompleteFormat = false) {
       Rewrite.getEditBuffer(ID).write(outs());
     }
   }
-  if (ErrorOnIncompleteFormat && !Status.FormatComplete)
-    return true;
-
-  return false;
+  return ErrorOnIncompleteFormat && !Status.FormatComplete;
 }
 
 } // namespace format


### PR DESCRIPTION
At the moment clang-format will return exit code 0 on incomplete results. In scripts it would sometimes be useful if clang-format would instead fail in those cases, signalling that there was something wrong with the code being formatted.