### PR TITLE
Copy missing metadata to new inst created from existing inst

### DIFF
--- a/llvm/lib/Transforms/Utils/SCCPSolver.cpp
+++ b/llvm/lib/Transforms/Utils/SCCPSolver.cpp
@@ -210,6 +210,7 @@ static bool replaceSignedInst(SCCPSolver &Solver,
 
   // Wire up the new instruction and update state.
   assert(NewInst && "Expected replacement instruction");
+  NewInst->copyMetadata(Inst);
   NewInst->takeName(&Inst);
   InsertedValues.insert(NewInst);
   Inst.replaceAllUsesWith(NewInst);


### PR DESCRIPTION
Previously in replaceSignedInst of SCCPSolver.cpp, the new usigned instructions created from the signed instructions are missing debug messages as the metadata are not being propagated over.
Added a line to copy the metadata of the old inst to the new one.