### PR TITLE
[flang] Fixed build issues after f20ea05.

### DIFF
--- a/flang/runtime/complex-reduction.c
+++ b/flang/runtime/complex-reduction.c
@@ -82,7 +82,8 @@ static long_double_Complex_t CMPLXL(long double r, long double i) {
  * supports __builtin_complex. For Clang, require >=12.0.
  * Otherwise, rely on the memory layout compatibility.
  */
-#if (defined(__clang_major__) && (__clang_major__ >= 12)) || defined(__GNUC__)
+#if (defined(__clang_major__) && (__clang_major__ >= 12)) || \
+    (defined(__GNUC__) && !defined(__clang__))
 #define CMPLXF128 __builtin_complex
 #else
 static CFloat128ComplexType CMPLXF128(CFloat128Type r, CFloat128Type i) {


### PR DESCRIPTION
Older versions of clang do not have __builtin_complex, but they
may define `__GNUC__`.
