### PR TITLE
Make llvm-nm's --export-symbols option work for ELF

### DIFF
--- a/llvm/docs/CommandGuide/llvm-nm.rst
+++ b/llvm/docs/CommandGuide/llvm-nm.rst
@@ -168,8 +168,10 @@ OPTIONS
 
 .. option:: --export-symbols
 
- Print sorted symbols with their visibility (if applicable), with duplicates
- removed.
+ Print sorted exportable symbols, with duplicates removed. For AIX the
+ symbol visibility is included. Consult your linker documentation o
+ determine which of the exportable symbols will actually be exported.
+ This option is currently only implemented for ELF and XCOFF.
 
 .. option:: --extern-only, -g
 

--- a/llvm/docs/CommandGuide/llvm-nm.rst
+++ b/llvm/docs/CommandGuide/llvm-nm.rst
@@ -168,10 +168,11 @@ OPTIONS
 
 .. option:: --export-symbols
 
- Print sorted exportable symbols, with duplicates removed. For AIX the
- symbol visibility is included. Consult your linker documentation o
- determine which of the exportable symbols will actually be exported.
- This option is currently only implemented for ELF and XCOFF.
+ Print sorted exportable symbols, with duplicates removed. For XCOFF the
+ symbol visibility is additionally displayed. Consult your toolchain
+ documentation to determine which of these symbols will eventually be
+ exported as this depends on linker behaviour. This option is currently
+ only implemented for ELF and XCOFF.
 
 .. option:: --extern-only, -g
 

--- a/llvm/lib/Object/ModuleSymbolTable.cpp
+++ b/llvm/lib/Object/ModuleSymbolTable.cpp
@@ -199,19 +199,6 @@ void ModuleSymbolTable::printSymbolName(raw_ostream &OS, Symbol S) const {
   Mang.getNameWithPrefix(OS, GV, false);
 }
 
-static bool isExportedToOtherDSO(const Triple TT, GlobalValue &GV) {
-  if (TT.isOSBinFormatELF())
-    // A defintition is exported if its non-local, and its visibility
-    // is either DEFAULT or PROTECTED. All other symbols are not exported.
-    return !GV.isDeclarationForLinker() && !GV.hasLocalLinkage() &&
-           (GV.hasDefaultVisibility() || GV.hasProtectedVisibility());
-  else if (TT.isOSBinFormatXCOFF())
-    return true;
-
-  // TODO: Add support for other file formats
-  return false;
-}
-
 uint32_t ModuleSymbolTable::getSymbolFlags(Symbol S) const {
   if (isa<AsmSymbol *>(S))
     return cast<AsmSymbol *>(S)->second;
@@ -227,8 +214,6 @@ uint32_t ModuleSymbolTable::getSymbolFlags(Symbol S) const {
     if (GVar->isConstant())
       Res |= BasicSymbolRef::SF_Const;
   }
-  if (isExportedToOtherDSO(Triple(FirstMod->getTargetTriple()), *GV))
-    Res |= BasicSymbolRef::SF_Exported;
   if (const GlobalObject *GO = GV->getAliaseeObject())
     if (isa<Function>(GO) || isa<GlobalIFunc>(GO))
       Res |= BasicSymbolRef::SF_Executable;

--- a/llvm/test/tools/llvm-nm/export-symbols.test
+++ b/llvm/test/tools/llvm-nm/export-symbols.test
@@ -1,0 +1,108 @@
+## Test the "--export-symbols" option.
+## The option prints out a sorted list of the unique exports from the input files.
+
+# RUN: rm -rf %t
+# RUN: split-file %s %t
+
+# RUN: llvm-as %t/1.ll -o %t/1.bc
+# RUN: llvm-as %t/2.ll -o %t/2.bc
+# RUN: llc -filetype=obj -mtriple=x86_64-pc-linux %t/1.ll -o %t/1.o
+# RUN: llc -filetype=obj -mtriple=x86_64-pc-linux %t/2.ll -o %t/2.o
+
+## Test the following cases:
+## - Show that non-exports are ignored.
+## - Show that only unique exports (with a different name or visibility) are printed.
+## - Show that XCOFF special cases are not handled specially.
+## - Show that the --no-weak option is honoured.
+## - Show that the XCOFF specific --no-rsrc is ignored.
+# RUN: llvm-nm --export-symbols %t/1.bc | FileCheck --check-prefixes=COMMON,WEAK %s --implicit-check-not={{.}}
+# RUN: llvm-nm --export-symbols %t/1.o | FileCheck --check-prefixes=COMMON,WEAK %s --implicit-check-not={{.}}
+# RUN: llvm-nm --export-symbols %t/1.bc %t/2.bc | FileCheck --check-prefixes=COMMON,WEAK,HIDDEN %s --implicit-check-not={{.}}
+# RUN: llvm-nm --export-symbols %t/1.o %t/2.o | FileCheck --check-prefixes=COMMON,WEAK,HIDDEN %s --implicit-check-not={{.}}
+# RUN: llvm-nm --export-symbols --no-weak --no-rsrc  %t/1.bc %t/2.bc %t/1.o %t/2.o | FileCheck --check-prefixes=COMMON,HIDDEN %s --implicit-check-not={{.}}
+
+# COMMON: .
+# COMMON: __1__
+# COMMON: __rsrc
+# COMMON: __sinit
+# COMMON: __sterm
+# COMMON: __tf1
+# COMMON: __tf9
+# COMMON: c
+# COMMON: d
+# HIDDEN: h
+# WEAK:   w
+
+#--- 1.ll
+target triple = "x86_64-unknown-linux-gnu"
+target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
+
+define void @d() {
+  ret void
+}
+
+define hidden void @h() {
+  ret void
+}
+
+declare void @u()
+
+declare i32 @r(...)
+
+declare extern_weak void @wr()
+
+define internal void @l() {
+  ret void
+}
+
+@c = common global i32 0
+
+define weak void @w() {
+  ret void
+}
+
+;; special cases from the AIX implementation.
+
+define void @__sinit() {
+  ret void
+}
+
+define void @__sterm() {
+  ret void
+}
+
+define void @.() {
+  ret void
+}
+
+;define void @(() {
+;  ret void
+;}
+
+define void @__1__() {
+  ret void
+}
+
+define void @__tf1() {
+  ret void
+}
+
+define void @__tf9() {
+  ret void
+}
+
+define void @__rsrc() {
+  ret void
+}
+
+#--- 2.ll
+target triple = "x86_64-unknown-linux-gnu"
+target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
+
+define protected void @d() {
+  ret void
+}
+
+define void @h() {
+  ret void
+}

--- a/llvm/test/tools/llvm-nm/export-symbols.test
+++ b/llvm/test/tools/llvm-nm/export-symbols.test
@@ -1,5 +1,5 @@
 ## Test the "--export-symbols" option.
-## The option prints out a sorted list of the unique exports from the input files.
+## The option prints out a sorted list of the unique exportable symbols from the input files.
 
 # RUN: rm -rf %t
 # RUN: split-file %s %t

--- a/llvm/tools/llvm-nm/Opts.td
+++ b/llvm/tools/llvm-nm/Opts.td
@@ -18,7 +18,7 @@ def debug_syms : FF<"debug-syms", "Show all symbols, even debugger only">;
 def defined_only : FF<"defined-only", "Show only defined symbols">;
 defm demangle : BB<"demangle", "Demangle C++ symbol names", "Don't demangle symbol names">;
 def dynamic : FF<"dynamic", "Display dynamic symbols instead of normal symbols">;
-def export_symbols : FF<"export-symbols", "Print the exportable symbol list for all inputs, currently only implemented for ELF and XCOFF">;
+def export_symbols : FF<"export-symbols", "Print the exportable symbols list for all inputs, currently only implemented for ELF and XCOFF">;
 def extern_only : FF<"extern-only", "Show only external symbols">;
 defm format : Eq<"format", "Specify output format: bsd (default), posix, sysv, darwin, just-symbols">, MetaVarName<"<format>">;
 def help : FF<"help", "Display this help">;

--- a/llvm/tools/llvm-nm/Opts.td
+++ b/llvm/tools/llvm-nm/Opts.td
@@ -18,7 +18,7 @@ def debug_syms : FF<"debug-syms", "Show all symbols, even debugger only">;
 def defined_only : FF<"defined-only", "Show only defined symbols">;
 defm demangle : BB<"demangle", "Demangle C++ symbol names", "Don't demangle symbol names">;
 def dynamic : FF<"dynamic", "Display dynamic symbols instead of normal symbols">;
-def export_symbols : FF<"export-symbols", "Export symbol list for all inputs">;
+def export_symbols : FF<"export-symbols", "Print the exportable symbol list for all inputs, currently only implemented for ELF and XCOFF">;
 def extern_only : FF<"extern-only", "Show only external symbols">;
 defm format : Eq<"format", "Specify output format: bsd (default), posix, sysv, darwin, just-symbols">, MetaVarName<"<format>">;
 def help : FF<"help", "Display this help">;


### PR DESCRIPTION
The --export-symbols option..

> help string: _–export-symbols Export symbol list for all inputs_
> doc:  _Print sorted symbols with their visibility (if applicable), with duplicates removed._

.. was introduced in to llvm-nm for an AIX specific usecase. For non-XCOFF
target it currently simply lists all symbols. This seems incorrect given the option
name and intended functionality.

**ELF behaviour**
For ELF make this option display the set of exportable symbols. This is
particularly useful for bitcode as the binary tools do not offer an
easy way to dump the visibility of bitcode symbols. I have adjusted the
documentation to note that the linker ultimately decides which symbols
are exported and that --export-symbols can only show which symbols are
potential exports for ELF.

**SF_Exported for bitcode:**
I have modified the --export-symbols implementation to print only
symbols with SF_Exported. SF_Exported is currently set for object
file symbols but is not set for bitcode symbols. SF_Exported is checked
by some LLVM code and setting it for bitcode symbols might change
behaviour. So, instead of setting SF_Exported generally for bitcode 
symbols we instead set it for bitcode symbols in llvm-nm specific
code.

**Other file formats**
For non-XCOFF file formats I assume that --export-symbols is not
currently in use as it previously didn't produce sensible output.
Therefore, I do not have to worry about changing the behaviour for
those file formats. This change should improve the output for other
file formats and it should be easy to support them in future if
required. For now they remain unsupported and I have changed the
help text/documentation to note that.