### PR TITLE
[flang][unittests] Use malloc when memory will be deallcated with free

### DIFF
--- a/flang/unittests/Runtime/Ragged.cpp
+++ b/flang/unittests/Runtime/Ragged.cpp
@@ -14,7 +14,7 @@ using namespace Fortran::runtime;
 TEST(Ragged, RaggedArrayAllocateDeallocateTest) {
   struct RaggedArrayHeader header;
   unsigned rank = 2;
-  int64_t *extents = new int64_t[2];
+  int64_t *extents = reinterpret_cast<int64_t *>(malloc(2 * sizeof(int64_t)));
   extents[0] = 10;
   extents[1] = 100;
   RaggedArrayHeader *ret = (RaggedArrayHeader *)_FortranARaggedArrayAllocate(


### PR DESCRIPTION
Runtime unit tests used `new[]` to allocate memory, which then was released using `free`.

This was detected by address sanitizer.