### PR TITLE
[TBAA] Add bail-out to skip tbaa generation to getTBAAStructInfo.

### DIFF
--- a/clang/lib/CodeGen/CodeGenTBAA.cpp
+++ b/clang/lib/CodeGen/CodeGenTBAA.cpp
@@ -343,6 +343,9 @@ CodeGenTBAA::CollectFields(uint64_t BaseOffset,
 
 llvm::MDNode *
 CodeGenTBAA::getTBAAStructInfo(QualType QTy) {
+  if (CodeGenOpts.OptimizationLevel == 0 || CodeGenOpts.RelaxedAliasing)
+    return nullptr;
+
   const Type *Ty = Context.getCanonicalType(QTy).getTypePtr();
 
   if (llvm::MDNode *N = StructMetadataCache[Ty])

--- a/clang/test/CodeGen/tbaa-struct-relaxed-aliasing-with-tsan.cpp
+++ b/clang/test/CodeGen/tbaa-struct-relaxed-aliasing-with-tsan.cpp
@@ -5,9 +5,7 @@
 // RUN:     FileCheck %s
 //
 // Check that we do not create tbaa for instructions generated for copies.
-// FIXME: !tbaa.struct is generated with null node as tag.
 
-// CHECK: !tbaa.struct
 // CHECK-NOT: !tbaa
 
 struct A {


### PR DESCRIPTION
Without this bail out, we may generate fields with null nodes as tags are generated by using getTypeInfo which has the same bail out.