### PR TITLE
[libc] rename cpp::count_ones to cpp::popcount to better mirror std::

### DIFF
--- a/libc/src/__support/CPP/bit.h
+++ b/libc/src/__support/CPP/bit.h
@@ -283,7 +283,7 @@ popcount(T value) {
 }
 #define ADD_SPECIALIZATION(TYPE, BUILTIN)                                      \
   template <>                                                                  \
-  [[nodiscard]] LIBC_INLINE constexpr int popcount<TYPE>(TYPE value) {       \
+  [[nodiscard]] LIBC_INLINE constexpr int popcount<TYPE>(TYPE value) {         \
     return BUILTIN(value);                                                     \
   }
 ADD_SPECIALIZATION(unsigned char, __builtin_popcount)

--- a/libc/src/__support/CPP/bit.h
+++ b/libc/src/__support/CPP/bit.h
@@ -269,14 +269,12 @@ first_trailing_one(T value) {
   return value == cpp::numeric_limits<T>::max() ? 0 : countr_zero(value) + 1;
 }
 
-/// Count number of 1's aka population count or hamming weight.
+/// Count number of 1's aka population count or Hamming weight.
 ///
 /// Only unsigned integral types are allowed.
-// TODO: rename as 'popcount' to follow the standard
-// https://en.cppreference.com/w/cpp/numeric/popcount
 template <typename T>
 [[nodiscard]] LIBC_INLINE constexpr cpp::enable_if_t<cpp::is_unsigned_v<T>, int>
-count_ones(T value) {
+popcount(T value) {
   int count = 0;
   for (int i = 0; i != cpp::numeric_limits<T>::digits; ++i)
     if ((value >> i) & 0x1)
@@ -285,7 +283,7 @@ count_ones(T value) {
 }
 #define ADD_SPECIALIZATION(TYPE, BUILTIN)                                      \
   template <>                                                                  \
-  [[nodiscard]] LIBC_INLINE constexpr int count_ones<TYPE>(TYPE value) {       \
+  [[nodiscard]] LIBC_INLINE constexpr int popcount<TYPE>(TYPE value) {       \
     return BUILTIN(value);                                                     \
   }
 ADD_SPECIALIZATION(unsigned char, __builtin_popcount)
@@ -300,7 +298,7 @@ ADD_SPECIALIZATION(unsigned long long, __builtin_popcountll)
 template <typename T>
 [[nodiscard]] LIBC_INLINE constexpr cpp::enable_if_t<cpp::is_unsigned_v<T>, int>
 count_zeros(T value) {
-  return count_ones<T>(static_cast<T>(~value));
+  return popcount<T>(static_cast<T>(~value));
 }
 
 } // namespace LIBC_NAMESPACE::cpp

--- a/libc/src/__support/UInt.h
+++ b/libc/src/__support/UInt.h
@@ -979,7 +979,7 @@ has_single_bit(T value) {
   for (auto word : value.val) {
     if (word == 0)
       continue;
-    bits += count_ones(word);
+    bits += popcount(word);
     if (bits > 1)
       return false;
   }

--- a/libc/src/stdbit/stdc_count_ones_uc.cpp
+++ b/libc/src/stdbit/stdc_count_ones_uc.cpp
@@ -14,7 +14,7 @@
 namespace LIBC_NAMESPACE {
 
 LLVM_LIBC_FUNCTION(unsigned, stdc_count_ones_uc, (unsigned char value)) {
-  return static_cast<unsigned>(cpp::count_ones(value));
+  return static_cast<unsigned>(cpp::popcount(value));
 }
 
 } // namespace LIBC_NAMESPACE

--- a/libc/src/stdbit/stdc_count_ones_ui.cpp
+++ b/libc/src/stdbit/stdc_count_ones_ui.cpp
@@ -14,7 +14,7 @@
 namespace LIBC_NAMESPACE {
 
 LLVM_LIBC_FUNCTION(unsigned, stdc_count_ones_ui, (unsigned value)) {
-  return static_cast<unsigned>(cpp::count_ones(value));
+  return static_cast<unsigned>(cpp::popcount(value));
 }
 
 } // namespace LIBC_NAMESPACE

--- a/libc/src/stdbit/stdc_count_ones_ul.cpp
+++ b/libc/src/stdbit/stdc_count_ones_ul.cpp
@@ -14,7 +14,7 @@
 namespace LIBC_NAMESPACE {
 
 LLVM_LIBC_FUNCTION(unsigned, stdc_count_ones_ul, (unsigned long value)) {
-  return static_cast<unsigned>(cpp::count_ones(value));
+  return static_cast<unsigned>(cpp::popcount(value));
 }
 
 } // namespace LIBC_NAMESPACE

--- a/libc/src/stdbit/stdc_count_ones_ull.cpp
+++ b/libc/src/stdbit/stdc_count_ones_ull.cpp
@@ -14,7 +14,7 @@
 namespace LIBC_NAMESPACE {
 
 LLVM_LIBC_FUNCTION(unsigned, stdc_count_ones_ull, (unsigned long long value)) {
-  return static_cast<unsigned>(cpp::count_ones(value));
+  return static_cast<unsigned>(cpp::popcount(value));
 }
 
 } // namespace LIBC_NAMESPACE

--- a/libc/src/stdbit/stdc_count_ones_us.cpp
+++ b/libc/src/stdbit/stdc_count_ones_us.cpp
@@ -14,7 +14,7 @@
 namespace LIBC_NAMESPACE {
 
 LLVM_LIBC_FUNCTION(unsigned, stdc_count_ones_us, (unsigned short value)) {
-  return static_cast<unsigned>(cpp::count_ones(value));
+  return static_cast<unsigned>(cpp::popcount(value));
 }
 
 } // namespace LIBC_NAMESPACE

--- a/libc/test/src/__support/CPP/bit_test.cpp
+++ b/libc/test/src/__support/CPP/bit_test.cpp
@@ -260,9 +260,9 @@ TYPED_TEST(LlvmLibcBitTest, CountZeros, UnsignedTypesNoBigInt) {
 }
 
 TYPED_TEST(LlvmLibcBitTest, CountOnes, UnsignedTypesNoBigInt) {
-  EXPECT_EQ(count_ones(T(0)), 0);
+  EXPECT_EQ(popcount(T(0)), 0);
   for (int i = 0; i != cpp::numeric_limits<T>::digits; ++i)
-    EXPECT_EQ(count_ones<T>(cpp::numeric_limits<T>::max() >> i),
+    EXPECT_EQ(popcount<T>(cpp::numeric_limits<T>::max() >> i),
               cpp::numeric_limits<T>::digits - i);
 }
 


### PR DESCRIPTION
libc/src/__support/CPP/bit.h and cpp:: is meant to mirror std::. Fix the TODO.
