### PR TITLE
[clang][test] Fix constant __builtin_popcountg test requiring __int128

### DIFF
--- a/clang/test/Sema/constant-builtins-2.c
+++ b/clang/test/Sema/constant-builtins-2.c
@@ -242,7 +242,9 @@ char popcount12[__builtin_popcountg(0xF0F0U) == 8 ? 1 : -1];
 char popcount13[__builtin_popcountg(~0U) == BITSIZE(int) ? 1 : -1];
 char popcount14[__builtin_popcountg(~0UL) == BITSIZE(long) ? 1 : -1];
 char popcount15[__builtin_popcountg(~0ULL) == BITSIZE(long long) ? 1 : -1];
+#ifdef __SIZEOF_INT128__
 char popcount16[__builtin_popcountg(~(unsigned __int128)0) == BITSIZE(__int128) ? 1 : -1];
+#endif
 char popcount17[__builtin_popcountg(~(unsigned _BitInt(128))0) == BITSIZE(_BitInt(128)) ? 1 : -1];
 
 char parity1[__builtin_parity(0) == 0 ? 1 : -1];


### PR DESCRIPTION
See https://lab.llvm.org/buildbot/#/builders/245/builds/21611/steps/5/logs/FAIL__Clang__constant-builtins-2_c.
