### PR TITLE
[PowerPC] don't eliminate the signext if the input is zero extended

### DIFF
--- a/llvm/lib/Target/PowerPC/PPCInstrInfo.cpp
+++ b/llvm/lib/Target/PowerPC/PPCInstrInfo.cpp
@@ -1041,6 +1041,11 @@ bool PPCInstrInfo::isCoalescableExtInstr(const MachineInstr &MI,
   case PPC::EXTSW_32:
   case PPC::EXTSW_32_64:
     SrcReg = MI.getOperand(1).getReg();
+    // On 64-bit targets, extension can not be eliminated if the input is zero
+    // extended. The input before zero extention may be a negative value.
+    if (Subtarget.isPPC64() &&
+        isZeroExtended(SrcReg, &MI.getMF()->getRegInfo()))
+      return false;
     DstReg = MI.getOperand(0).getReg();
     SubIdx = PPC::sub_32;
     return true;

--- a/llvm/test/CodeGen/PowerPC/pr74951.ll
+++ b/llvm/test/CodeGen/PowerPC/pr74951.ll
@@ -11,12 +11,12 @@ define noundef signext i32 @main() {
 ; CHECK-LABEL: main:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    ld r3, L..C0(r2) # @b
-; CHECK-NEXT:    lwz r3, 0(r3)
-; CHECK-NEXT:    andi. r4, r3, 65535
+; CHECK-NEXT:    lwz r4, 0(r3)
+; CHECK-NEXT:    andi. r3, r4, 65535
+; CHECK-NEXT:    extsw r3, r4
 ; CHECK-NEXT:    bne cr0, L..BB0_4
 ; CHECK-NEXT:  # %bb.1: # %lor.rhs.i.i
-; CHECK-NEXT:    extsw r4, r3
-; CHECK-NEXT:    neg r5, r4
+; CHECK-NEXT:    neg r5, r3
 ; CHECK-NEXT:    rldicl r5, r5, 1, 63
 ; CHECK-NEXT:    xori r5, r5, 1
 ; CHECK-NEXT:    cmpw r4, r5


### PR DESCRIPTION

`@b` is -1, so 1 is expected to store to `@g` in block `g.exit`
But with trunk llvm, 0 is stored instead.

At line https://github.com/chenzheng1030/llvm-project/blob/main/llvm/lib/CodeGen/SelectionDAG/InstrEmitter.cpp#L542-L554 
optimizes:
```
    t39: i64 = LDtoc<Mem:(load (s64) from got)> TargetGlobalAddress:i64<ptr @b> 0, Register:i64 $x2
  t4: i32,ch = LWZ<Mem:(dereferenceable load (s32) from @b, !tbaa !3)> TargetConstant:i64<0>, t39, t0
  t48: i64 = EXTSW_32_64 t4

        t7: ch = CopyToReg t0, Register:i64 %0, t48

  t2: i64,ch = CopyFromReg t0, Register:i64 %0
          t5: i32 = EXTRACT_SUBREG t2, TargetConstant:i32<1>
```
to:
```
  %3:gprc = LWZ 0, killed %2:g8rc_and_g8rc_nox0 :: (dereferenceable load (s32) from @b, !tbaa !3)
  %24:gprc = COPY %3:gprc
```

Fixes https://github.com/llvm/llvm-project/issues/74915
