### PR TITLE
[compiler-rt] Call __sys_mmap in internal_mmap on FreeBSD

### DIFF
--- a/compiler-rt/lib/sanitizer_common/sanitizer_linux.cpp
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_linux.cpp
@@ -197,12 +197,17 @@ ScopedBlockSignals::~ScopedBlockSignals() { SetSigProcMask(&saved_, nullptr); }
 #    include "sanitizer_syscall_generic.inc"
 #  endif
 
+extern "C" void *__sys_mmap(void *addr, size_t len, int prot, int flags, int fd,
+                            off_t offset);
+
 // --------------- sanitizer_libc.h
 #  if !SANITIZER_SOLARIS && !SANITIZER_NETBSD
 #    if !SANITIZER_S390
 uptr internal_mmap(void *addr, uptr length, int prot, int flags, int fd,
                    u64 offset) {
-#      if SANITIZER_FREEBSD || SANITIZER_LINUX_USES_64BIT_SYSCALLS
+#      if SANITIZER_FREEBSD
+  return (uptr)__sys_mmap(addr, length, prot, flags, fd, offset);
+#      elif SANITIZER_LINUX_USES_64BIT_SYSCALLS
   return internal_syscall(SYSCALL(mmap), (uptr)addr, length, prot, flags, fd,
                           offset);
 #      else

--- a/compiler-rt/lib/sanitizer_common/sanitizer_linux.cpp
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_linux.cpp
@@ -147,6 +147,8 @@ const int FUTEX_WAKE_PRIVATE = FUTEX_WAKE | FUTEX_PRIVATE_FLAG;
 
 #  if SANITIZER_FREEBSD
 #    define SANITIZER_USE_GETENTROPY 1
+extern "C" void *__sys_mmap(void *addr, size_t len, int prot, int flags, int fd,
+                            off_t offset);
 #  endif
 
 namespace __sanitizer {
@@ -196,9 +198,6 @@ ScopedBlockSignals::~ScopedBlockSignals() { SetSigProcMask(&saved_, nullptr); }
 #  else
 #    include "sanitizer_syscall_generic.inc"
 #  endif
-
-extern "C" void *__sys_mmap(void *addr, size_t len, int prot, int flags, int fd,
-                            off_t offset);
 
 // --------------- sanitizer_libc.h
 #  if !SANITIZER_SOLARIS && !SANITIZER_NETBSD


### PR DESCRIPTION
Due to the slightly non-standard interface that returns a pointer
rather than just an integer, the __syscall() utility cannot be used
on all architectures. This change is required for example to use the
sanitizers on Arm Morello.
