### PR TITLE
[libc][NFC] Move `BigInt` out of the `cpp` namespace

### DIFF
--- a/libc/src/__support/FPUtil/dyadic_float.h
+++ b/libc/src/__support/FPUtil/dyadic_float.h
@@ -31,7 +31,7 @@ namespace LIBC_NAMESPACE::fputil {
 // To simplify and improve the efficiency, many functions will assume that the
 // inputs are normal.
 template <size_t Bits> struct DyadicFloat {
-  using MantissaType = LIBC_NAMESPACE::cpp::UInt<Bits>;
+  using MantissaType = LIBC_NAMESPACE::UInt<Bits>;
 
   Sign sign = Sign::POS;
   int exponent = 0;

--- a/libc/src/__support/UInt128.h
+++ b/libc/src/__support/UInt128.h
@@ -15,8 +15,8 @@
 using UInt128 = __uint128_t;
 using Int128 = __int128_t;
 #else
-using UInt128 = LIBC_NAMESPACE::cpp::UInt<128>;
-using Int128 = LIBC_NAMESPACE::cpp::Int<128>;
+using UInt128 = LIBC_NAMESPACE::UInt<128>;
+using Int128 = LIBC_NAMESPACE::Int<128>;
 #endif
 
 #endif // LLVM_LIBC_SRC___SUPPORT_UINT128_H

--- a/libc/src/__support/float_to_string.h
+++ b/libc/src/__support/float_to_string.h
@@ -179,7 +179,7 @@ LIBC_INLINE constexpr uint32_t length_for_num(uint32_t idx,
 // TODO: Fix long doubles (needs bigger table or alternate algorithm.)
 // Currently the table values are generated, which is very slow.
 template <size_t INT_SIZE>
-LIBC_INLINE constexpr cpp::UInt<MID_INT_SIZE> get_table_positive(int exponent,
+LIBC_INLINE constexpr UInt<MID_INT_SIZE> get_table_positive(int exponent,
                                                                  size_t i) {
   // INT_SIZE is the size of int that is used for the internal calculations of
   // this function. It should be large enough to hold 2^(exponent+constant), so
@@ -191,17 +191,17 @@ LIBC_INLINE constexpr cpp::UInt<MID_INT_SIZE> get_table_positive(int exponent,
   if (shift_amount < 0) {
     return 1;
   }
-  cpp::UInt<INT_SIZE> num(0);
+  UInt<INT_SIZE> num(0);
   // MOD_SIZE is one of the limiting factors for how big the constant argument
   // can get, since it needs to be small enough to fit in the result UInt,
   // otherwise we'll get truncation on return.
-  constexpr cpp::UInt<INT_SIZE> MOD_SIZE =
-      (cpp::UInt<INT_SIZE>(EXP10_9)
+  constexpr UInt<INT_SIZE> MOD_SIZE =
+      (UInt<INT_SIZE>(EXP10_9)
        << (CALC_SHIFT_CONST + (IDX_SIZE > 1 ? IDX_SIZE : 0)));
 
-  num = cpp::UInt<INT_SIZE>(1) << (shift_amount);
+  num = UInt<INT_SIZE>(1) << (shift_amount);
   if (i > 0) {
-    cpp::UInt<INT_SIZE> fives(EXP5_9);
+    UInt<INT_SIZE> fives(EXP5_9);
     fives.pow_n(i);
     num = num / fives;
   }
@@ -217,7 +217,7 @@ LIBC_INLINE constexpr cpp::UInt<MID_INT_SIZE> get_table_positive(int exponent,
 }
 
 template <size_t INT_SIZE>
-LIBC_INLINE cpp::UInt<MID_INT_SIZE> get_table_positive_df(int exponent,
+LIBC_INLINE UInt<MID_INT_SIZE> get_table_positive_df(int exponent,
                                                           size_t i) {
   static_assert(INT_SIZE == 256,
                 "Only 256 is supported as an int size right now.");
@@ -233,11 +233,11 @@ LIBC_INLINE cpp::UInt<MID_INT_SIZE> get_table_positive_df(int exponent,
     return 1;
   }
   fputil::DyadicFloat<INT_SIZE> num(false, 0, 1);
-  constexpr cpp::UInt<INT_SIZE> MOD_SIZE =
-      (cpp::UInt<INT_SIZE>(EXP10_9)
+  constexpr UInt<INT_SIZE> MOD_SIZE =
+      (UInt<INT_SIZE>(EXP10_9)
        << (CALC_SHIFT_CONST + (IDX_SIZE > 1 ? IDX_SIZE : 0)));
 
-  constexpr cpp::UInt<INT_SIZE> FIVE_EXP_MINUS_NINE_MANT{
+  constexpr UInt<INT_SIZE> FIVE_EXP_MINUS_NINE_MANT{
       {0xf387295d242602a7, 0xfdd7645e011abac9, 0x31680a88f8953030,
        0x89705f4136b4a597}};
 
@@ -251,7 +251,7 @@ LIBC_INLINE cpp::UInt<MID_INT_SIZE> get_table_positive_df(int exponent,
   num = mul_pow_2(num, shift_amount);
 
   // Adding one is part of the formula.
-  cpp::UInt<INT_SIZE> int_num = static_cast<cpp::UInt<INT_SIZE>>(num) + 1;
+  UInt<INT_SIZE> int_num = static_cast<UInt<INT_SIZE>>(num) + 1;
   if (int_num > MOD_SIZE) {
     auto rem =
         int_num
@@ -261,7 +261,7 @@ LIBC_INLINE cpp::UInt<MID_INT_SIZE> get_table_positive_df(int exponent,
     int_num = rem;
   }
 
-  cpp::UInt<MID_INT_SIZE> result = int_num;
+  UInt<MID_INT_SIZE> result = int_num;
 
   return result;
 }
@@ -275,11 +275,11 @@ LIBC_INLINE cpp::UInt<MID_INT_SIZE> get_table_positive_df(int exponent,
 // The formula being used looks more like this:
 // floor(10^(9*(-i)) * 2^(c_0 + (-e))) % (10^9 * 2^c_0)
 template <size_t INT_SIZE>
-LIBC_INLINE cpp::UInt<MID_INT_SIZE> get_table_negative(int exponent, size_t i) {
+LIBC_INLINE UInt<MID_INT_SIZE> get_table_negative(int exponent, size_t i) {
   int shift_amount = CALC_SHIFT_CONST - exponent;
-  cpp::UInt<INT_SIZE> num(1);
-  constexpr cpp::UInt<INT_SIZE> MOD_SIZE =
-      (cpp::UInt<INT_SIZE>(EXP10_9)
+  UInt<INT_SIZE> num(1);
+  constexpr UInt<INT_SIZE> MOD_SIZE =
+      (UInt<INT_SIZE>(EXP10_9)
        << (CALC_SHIFT_CONST + (IDX_SIZE > 1 ? IDX_SIZE : 0)));
 
   size_t ten_blocks = i;
@@ -298,12 +298,12 @@ LIBC_INLINE cpp::UInt<MID_INT_SIZE> get_table_negative(int exponent, size_t i) {
   }
 
   if (five_blocks > 0) {
-    cpp::UInt<INT_SIZE> fives(EXP5_9);
+    UInt<INT_SIZE> fives(EXP5_9);
     fives.pow_n(five_blocks);
     num = fives;
   }
   if (ten_blocks > 0) {
-    cpp::UInt<INT_SIZE> tens(EXP10_9);
+    UInt<INT_SIZE> tens(EXP10_9);
     tens.pow_n(ten_blocks);
     if (five_blocks <= 0) {
       num = tens;
@@ -327,7 +327,7 @@ LIBC_INLINE cpp::UInt<MID_INT_SIZE> get_table_negative(int exponent, size_t i) {
 }
 
 template <size_t INT_SIZE>
-LIBC_INLINE cpp::UInt<MID_INT_SIZE> get_table_negative_df(int exponent,
+LIBC_INLINE UInt<MID_INT_SIZE> get_table_negative_df(int exponent,
                                                           size_t i) {
   static_assert(INT_SIZE == 256,
                 "Only 256 is supported as an int size right now.");
@@ -341,11 +341,11 @@ LIBC_INLINE cpp::UInt<MID_INT_SIZE> get_table_negative_df(int exponent,
   int shift_amount = CALC_SHIFT_CONST - exponent;
 
   fputil::DyadicFloat<INT_SIZE> num(false, 0, 1);
-  constexpr cpp::UInt<INT_SIZE> MOD_SIZE =
-      (cpp::UInt<INT_SIZE>(EXP10_9)
+  constexpr UInt<INT_SIZE> MOD_SIZE =
+      (UInt<INT_SIZE>(EXP10_9)
        << (CALC_SHIFT_CONST + (IDX_SIZE > 1 ? IDX_SIZE : 0)));
 
-  constexpr cpp::UInt<INT_SIZE> TEN_EXP_NINE_MANT(EXP10_9);
+  constexpr UInt<INT_SIZE> TEN_EXP_NINE_MANT(EXP10_9);
 
   static const fputil::DyadicFloat<INT_SIZE> TEN_EXP_NINE(false, 0,
                                                           TEN_EXP_NINE_MANT);
@@ -356,7 +356,7 @@ LIBC_INLINE cpp::UInt<MID_INT_SIZE> get_table_negative_df(int exponent,
   }
   num = mul_pow_2(num, shift_amount);
 
-  cpp::UInt<INT_SIZE> int_num = static_cast<cpp::UInt<INT_SIZE>>(num);
+  UInt<INT_SIZE> int_num = static_cast<UInt<INT_SIZE>>(num);
   if (int_num > MOD_SIZE) {
     auto rem =
         int_num
@@ -366,16 +366,16 @@ LIBC_INLINE cpp::UInt<MID_INT_SIZE> get_table_negative_df(int exponent,
     int_num = rem;
   }
 
-  cpp::UInt<MID_INT_SIZE> result = int_num;
+  UInt<MID_INT_SIZE> result = int_num;
 
   return result;
 }
 
-LIBC_INLINE uint32_t fast_uint_mod_1e9(const cpp::UInt<MID_INT_SIZE> &val) {
+LIBC_INLINE uint32_t fast_uint_mod_1e9(const UInt<MID_INT_SIZE> &val) {
   // The formula for mult_const is:
   //  1 + floor((2^(bits in target integer size + log_2(divider))) / divider)
   // Where divider is 10^9 and target integer size is 128.
-  const cpp::UInt<MID_INT_SIZE> mult_const(
+  const UInt<MID_INT_SIZE> mult_const(
       {0x31680A88F8953031u, 0x89705F4136B4A597u, 0});
   const auto middle = (mult_const * val);
   const uint64_t result = static_cast<uint64_t>(middle[2]);
@@ -385,9 +385,9 @@ LIBC_INLINE uint32_t fast_uint_mod_1e9(const cpp::UInt<MID_INT_SIZE> &val) {
 }
 
 LIBC_INLINE uint32_t mul_shift_mod_1e9(const FPBits::StorageType mantissa,
-                                       const cpp::UInt<MID_INT_SIZE> &large,
+                                       const UInt<MID_INT_SIZE> &large,
                                        const int32_t shift_amount) {
-  cpp::UInt<MID_INT_SIZE + FPBits::STORAGE_LEN> val(large);
+  UInt<MID_INT_SIZE + FPBits::STORAGE_LEN> val(large);
   val = (val * mantissa) >> shift_amount;
   return static_cast<uint32_t>(
       val.div_uint_half_times_pow_2(static_cast<uint32_t>(EXP10_9), 0).value());
@@ -452,7 +452,7 @@ public:
 
       const uint32_t pos_exp = idx * IDX_SIZE;
 
-      cpp::UInt<MID_INT_SIZE> val;
+      UInt<MID_INT_SIZE> val;
 
 #if defined(LIBC_COPT_FLOAT_TO_STR_USE_DYADIC_FLOAT)
       // ----------------------- DYADIC FLOAT CALC MODE ------------------------
@@ -502,7 +502,7 @@ public:
     if (exponent < 0) {
       const int32_t idx = -exponent / IDX_SIZE;
 
-      cpp::UInt<MID_INT_SIZE> val;
+      UInt<MID_INT_SIZE> val;
 
       const uint32_t pos_exp = static_cast<uint32_t>(idx * IDX_SIZE);
 
@@ -643,7 +643,7 @@ template <> class FloatToString<long double> {
       internal::div_ceil(sizeof(long double) * CHAR_BIT, UINT_WORD_SIZE) *
       UINT_WORD_SIZE;
 
-  using wide_int = cpp::UInt<FLOAT_AS_INT_WIDTH + EXTRA_INT_WIDTH>;
+  using wide_int = UInt<FLOAT_AS_INT_WIDTH + EXTRA_INT_WIDTH>;
 
   // float_as_fixed represents the floating point number as a fixed point number
   // with the point EXTRA_INT_WIDTH bits from the left of the number. This can
@@ -658,7 +658,7 @@ template <> class FloatToString<long double> {
   size_t block_buffer_valid = 0;
 
   template <size_t Bits>
-  LIBC_INLINE static constexpr BlockInt grab_digits(cpp::UInt<Bits> &int_num) {
+  LIBC_INLINE static constexpr BlockInt grab_digits(UInt<Bits> &int_num) {
     auto wide_result = int_num.div_uint_half_times_pow_2(EXP5_9, 9);
     // the optional only comes into effect when dividing by 0, which will
     // never happen here. Thus, we just assert that it has value.
@@ -714,7 +714,7 @@ template <> class FloatToString<long double> {
 
       // If there are still digits above the decimal point, handle those.
       if (float_as_fixed.clz() < static_cast<int>(EXTRA_INT_WIDTH)) {
-        cpp::UInt<EXTRA_INT_WIDTH> above_decimal_point =
+        UInt<EXTRA_INT_WIDTH> above_decimal_point =
             float_as_fixed >> FLOAT_AS_INT_WIDTH;
 
         size_t positive_int_block_index = 0;

--- a/libc/src/__support/float_to_string.h
+++ b/libc/src/__support/float_to_string.h
@@ -180,7 +180,7 @@ LIBC_INLINE constexpr uint32_t length_for_num(uint32_t idx,
 // Currently the table values are generated, which is very slow.
 template <size_t INT_SIZE>
 LIBC_INLINE constexpr UInt<MID_INT_SIZE> get_table_positive(int exponent,
-                                                                 size_t i) {
+                                                            size_t i) {
   // INT_SIZE is the size of int that is used for the internal calculations of
   // this function. It should be large enough to hold 2^(exponent+constant), so
   // ~1000 for double and ~16000 for long double. Be warned that the time
@@ -217,8 +217,7 @@ LIBC_INLINE constexpr UInt<MID_INT_SIZE> get_table_positive(int exponent,
 }
 
 template <size_t INT_SIZE>
-LIBC_INLINE UInt<MID_INT_SIZE> get_table_positive_df(int exponent,
-                                                          size_t i) {
+LIBC_INLINE UInt<MID_INT_SIZE> get_table_positive_df(int exponent, size_t i) {
   static_assert(INT_SIZE == 256,
                 "Only 256 is supported as an int size right now.");
   // This version uses dyadic floats with 256 bit mantissas to perform the same
@@ -327,8 +326,7 @@ LIBC_INLINE UInt<MID_INT_SIZE> get_table_negative(int exponent, size_t i) {
 }
 
 template <size_t INT_SIZE>
-LIBC_INLINE UInt<MID_INT_SIZE> get_table_negative_df(int exponent,
-                                                          size_t i) {
+LIBC_INLINE UInt<MID_INT_SIZE> get_table_negative_df(int exponent, size_t i) {
   static_assert(INT_SIZE == 256,
                 "Only 256 is supported as an int size right now.");
   // This version uses dyadic floats with 256 bit mantissas to perform the same

--- a/libc/src/__support/integer_literals.h
+++ b/libc/src/__support/integer_literals.h
@@ -115,13 +115,13 @@ template <typename T> struct Parser {
   }
 };
 
-// Specialization for cpp::UInt<N>.
+// Specialization for UInt<N>.
 // Because this code runs at compile time we try to make it efficient. For
 // binary and hexadecimal formats we read digits by chunks of 64 bits and
 // produce the BigInt internal representation direcly. For decimal numbers we
 // go the slow path and use slower BigInt arithmetic.
-template <size_t N> struct Parser<LIBC_NAMESPACE::cpp::UInt<N>> {
-  using UIntT = cpp::UInt<N>;
+template <size_t N> struct Parser<LIBC_NAMESPACE::UInt<N>> {
+  using UIntT = UInt<N>;
   template <int base> static constexpr UIntT parse(const char *str) {
     const DigitBuffer<UIntT, base> buffer(str);
     if constexpr (base == 10) {
@@ -166,7 +166,7 @@ LIBC_INLINE constexpr UInt128 operator""_u128(const char *x) {
 }
 
 LIBC_INLINE constexpr auto operator""_u256(const char *x) {
-  return internal::parse_with_prefix<cpp::UInt<256>>(x);
+  return internal::parse_with_prefix<UInt<256>>(x);
 }
 
 } // namespace LIBC_NAMESPACE

--- a/libc/src/__support/integer_to_string.h
+++ b/libc/src/__support/integer_to_string.h
@@ -158,7 +158,7 @@ struct IntegerWriterUnsigned<T, cpp::enable_if_t<cpp::is_integral_v<T>>> {
 };
 
 template <typename T>
-struct IntegerWriterUnsigned<T, cpp::enable_if_t<cpp::is_big_int_v<T>>> {
+struct IntegerWriterUnsigned<T, cpp::enable_if_t<is_big_int_v<T>>> {
   using type = typename T::unsigned_type;
 };
 
@@ -176,7 +176,7 @@ template <size_t radix> using Custom = details::Fmt<radix>;
 
 // See file header for documentation.
 template <typename T, typename Fmt = radix::Dec> class IntegerToString {
-  static_assert(cpp::is_integral_v<T> || cpp::is_big_int_v<T>);
+  static_assert(cpp::is_integral_v<T> || is_big_int_v<T>);
 
   LIBC_INLINE static constexpr size_t compute_buffer_size() {
     constexpr auto MAX_DIGITS = []() -> size_t {
@@ -221,7 +221,7 @@ template <typename T, typename Fmt = radix::Dec> class IntegerToString {
 
   // An internal stateless structure that handles the number formatting logic.
   struct IntegerWriter {
-    static_assert(cpp::is_integral_v<T> || cpp::is_big_int_v<T>);
+    static_assert(cpp::is_integral_v<T> || is_big_int_v<T>);
     using UNSIGNED_T = typename details::IntegerWriterUnsigned<T>::type;
 
     LIBC_INLINE static char digit_char(uint8_t digit) {

--- a/libc/src/__support/str_to_float.h
+++ b/libc/src/__support/str_to_float.h
@@ -524,7 +524,7 @@ clinger_fast_path(ExpandedFloat<T> init_num,
 
   FPBits result;
   T float_mantissa;
-  if constexpr (cpp::is_same_v<StorageType, cpp::UInt<128>>) {
+  if constexpr (cpp::is_same_v<StorageType, UInt<128>>) {
     float_mantissa = static_cast<T>(fputil::DyadicFloat<128>(
         Sign::POS, 0,
         fputil::DyadicFloat<128>::MantissaType(

--- a/libc/src/stdio/printf_core/float_dec_converter.h
+++ b/libc/src/stdio/printf_core/float_dec_converter.h
@@ -34,8 +34,8 @@ using ExponentString =
 
 // Returns true if value is divisible by 2^p.
 template <typename T>
-LIBC_INLINE constexpr cpp::enable_if_t<
-    cpp::is_integral_v<T> || is_big_int_v<T>, bool>
+LIBC_INLINE constexpr cpp::enable_if_t<cpp::is_integral_v<T> || is_big_int_v<T>,
+                                       bool>
 multiple_of_power_of_2(T value, uint32_t p) {
   return (value & ((T(1) << p) - 1)) == 0;
 }
@@ -78,8 +78,8 @@ LIBC_INLINE RoundDirection get_round_direction(int last_digit, bool truncated,
 }
 
 template <typename T>
-LIBC_INLINE constexpr cpp::enable_if_t<
-    cpp::is_integral_v<T> || is_big_int_v<T>, bool>
+LIBC_INLINE constexpr cpp::enable_if_t<cpp::is_integral_v<T> || is_big_int_v<T>,
+                                       bool>
 zero_after_digits(int32_t base_2_exp, int32_t digits_after_point, T mantissa,
                   const int32_t mant_width) {
   const int32_t required_twos = -base_2_exp - digits_after_point - 1;

--- a/libc/src/stdio/printf_core/float_dec_converter.h
+++ b/libc/src/stdio/printf_core/float_dec_converter.h
@@ -12,7 +12,7 @@
 #include "src/__support/CPP/string_view.h"
 #include "src/__support/FPUtil/FPBits.h"
 #include "src/__support/FPUtil/rounding_mode.h"
-#include "src/__support/UInt.h" // cpp::is_big_int_v
+#include "src/__support/UInt.h" // is_big_int_v
 #include "src/__support/float_to_string.h"
 #include "src/__support/integer_to_string.h"
 #include "src/__support/libc_assert.h"
@@ -35,7 +35,7 @@ using ExponentString =
 // Returns true if value is divisible by 2^p.
 template <typename T>
 LIBC_INLINE constexpr cpp::enable_if_t<
-    cpp::is_integral_v<T> || cpp::is_big_int_v<T>, bool>
+    cpp::is_integral_v<T> || is_big_int_v<T>, bool>
 multiple_of_power_of_2(T value, uint32_t p) {
   return (value & ((T(1) << p) - 1)) == 0;
 }
@@ -79,7 +79,7 @@ LIBC_INLINE RoundDirection get_round_direction(int last_digit, bool truncated,
 
 template <typename T>
 LIBC_INLINE constexpr cpp::enable_if_t<
-    cpp::is_integral_v<T> || cpp::is_big_int_v<T>, bool>
+    cpp::is_integral_v<T> || is_big_int_v<T>, bool>
 zero_after_digits(int32_t base_2_exp, int32_t digits_after_point, T mantissa,
                   const int32_t mant_width) {
   const int32_t required_twos = -base_2_exp - digits_after_point - 1;

--- a/libc/test/UnitTest/LibcTest.cpp
+++ b/libc/test/UnitTest/LibcTest.cpp
@@ -39,7 +39,7 @@ TestLogger &operator<<(TestLogger &logger, Location Loc) {
 // digits.
 template <typename T>
 cpp::enable_if_t<(cpp::is_integral_v<T> && (sizeof(T) > sizeof(uint64_t))) ||
-                     cpp::is_big_int_v<T>,
+                     is_big_int_v<T>,
                  cpp::string>
 describeValue(T Value) {
   static_assert(sizeof(T) % 8 == 0, "Unsupported size of UInt");
@@ -221,12 +221,12 @@ TEST_SPECIALIZATION(bool);
 TEST_SPECIALIZATION(__uint128_t);
 #endif
 
-TEST_SPECIALIZATION(LIBC_NAMESPACE::cpp::Int<128>);
+TEST_SPECIALIZATION(LIBC_NAMESPACE::Int<128>);
 
-TEST_SPECIALIZATION(LIBC_NAMESPACE::cpp::UInt<128>);
-TEST_SPECIALIZATION(LIBC_NAMESPACE::cpp::UInt<192>);
-TEST_SPECIALIZATION(LIBC_NAMESPACE::cpp::UInt<256>);
-TEST_SPECIALIZATION(LIBC_NAMESPACE::cpp::UInt<320>);
+TEST_SPECIALIZATION(LIBC_NAMESPACE::UInt<128>);
+TEST_SPECIALIZATION(LIBC_NAMESPACE::UInt<192>);
+TEST_SPECIALIZATION(LIBC_NAMESPACE::UInt<256>);
+TEST_SPECIALIZATION(LIBC_NAMESPACE::UInt<320>);
 
 TEST_SPECIALIZATION(LIBC_NAMESPACE::cpp::string_view);
 TEST_SPECIALIZATION(LIBC_NAMESPACE::cpp::string);

--- a/libc/test/UnitTest/LibcTest.h
+++ b/libc/test/UnitTest/LibcTest.h
@@ -125,11 +125,11 @@ protected:
   // is the result of the |Cond| operation on |LHS| and |RHS|. Though not bad,
   // |Cond| on mismatched |LHS| and |RHS| types can potentially succeed because
   // of type promotion.
-  template <typename ValType,
-            cpp::enable_if_t<cpp::is_integral_v<ValType> ||
-                                 is_big_int_v<ValType> ||
-                                 cpp::is_fixed_point_v<ValType>,
-                             int> = 0>
+  template <
+      typename ValType,
+      cpp::enable_if_t<cpp::is_integral_v<ValType> || is_big_int_v<ValType> ||
+                           cpp::is_fixed_point_v<ValType>,
+                       int> = 0>
   bool test(TestCond Cond, ValType LHS, ValType RHS, const char *LHSStr,
             const char *RHSStr, internal::Location Loc) {
     return internal::test(Ctx, Cond, LHS, RHS, LHSStr, RHSStr, Loc);

--- a/libc/test/UnitTest/LibcTest.h
+++ b/libc/test/UnitTest/LibcTest.h
@@ -127,7 +127,7 @@ protected:
   // of type promotion.
   template <typename ValType,
             cpp::enable_if_t<cpp::is_integral_v<ValType> ||
-                                 cpp::is_big_int_v<ValType> ||
+                                 is_big_int_v<ValType> ||
                                  cpp::is_fixed_point_v<ValType>,
                              int> = 0>
   bool test(TestCond Cond, ValType LHS, ValType RHS, const char *LHSStr,

--- a/libc/test/UnitTest/StringUtils.h
+++ b/libc/test/UnitTest/StringUtils.h
@@ -17,7 +17,7 @@ namespace LIBC_NAMESPACE {
 
 // Return the first N hex digits of an integer as a string in upper case.
 template <typename T>
-cpp::enable_if_t<cpp::is_integral_v<T> || cpp::is_big_int_v<T>, cpp::string>
+cpp::enable_if_t<cpp::is_integral_v<T> || is_big_int_v<T>, cpp::string>
 int_to_hex(T value, size_t length = sizeof(T) * 2) {
   cpp::string s(length, '0');
 

--- a/libc/test/UnitTest/TestLogger.cpp
+++ b/libc/test/UnitTest/TestLogger.cpp
@@ -48,7 +48,7 @@ template <> TestLogger &TestLogger::operator<<(void *addr) {
 }
 
 template <typename T> TestLogger &TestLogger::operator<<(T t) {
-  if constexpr (cpp::is_big_int_v<T> ||
+  if constexpr (is_big_int_v<T> ||
                 (cpp::is_integral_v<T> && cpp::is_unsigned_v<T> &&
                  (sizeof(T) > sizeof(uint64_t)))) {
     static_assert(sizeof(T) % 8 == 0, "Unsupported size of UInt");
@@ -75,10 +75,10 @@ template TestLogger &
 #ifdef __SIZEOF_INT128__
 template TestLogger &TestLogger::operator<< <__uint128_t>(__uint128_t);
 #endif
-template TestLogger &TestLogger::operator<< <cpp::UInt<128>>(cpp::UInt<128>);
-template TestLogger &TestLogger::operator<< <cpp::UInt<192>>(cpp::UInt<192>);
-template TestLogger &TestLogger::operator<< <cpp::UInt<256>>(cpp::UInt<256>);
-template TestLogger &TestLogger::operator<< <cpp::UInt<320>>(cpp::UInt<320>);
+template TestLogger &TestLogger::operator<< <UInt<128>>(UInt<128>);
+template TestLogger &TestLogger::operator<< <UInt<192>>(UInt<192>);
+template TestLogger &TestLogger::operator<< <UInt<256>>(UInt<256>);
+template TestLogger &TestLogger::operator<< <UInt<320>>(UInt<320>);
 
 // TODO: Add floating point formatting once it's supported by StringStream.
 

--- a/libc/test/src/__support/CPP/bit_test.cpp
+++ b/libc/test/src/__support/CPP/bit_test.cpp
@@ -26,7 +26,7 @@ using UnsignedTypes = testing::TypeList<
     __uint128_t,
 #endif
     unsigned char, unsigned short, unsigned int, unsigned long,
-    unsigned long long, cpp::UInt<128>>;
+    unsigned long long, UInt<128>>;
 
 TYPED_TEST(LlvmLibcBitTest, HasSingleBit, UnsignedTypes) {
   constexpr auto ZERO = T(0);

--- a/libc/test/src/__support/CPP/limits_test.cpp
+++ b/libc/test/src/__support/CPP/limits_test.cpp
@@ -33,8 +33,7 @@ TEST(LlvmLibcLimitsTest, LimitsFollowSpec) {
 
 TEST(LlvmLibcLimitsTest, UInt128Limits) {
   auto umax128 = cpp::numeric_limits<LIBC_NAMESPACE::UInt<128>>::max();
-  auto umax64 =
-      LIBC_NAMESPACE::UInt<128>(cpp::numeric_limits<uint64_t>::max());
+  auto umax64 = LIBC_NAMESPACE::UInt<128>(cpp::numeric_limits<uint64_t>::max());
   EXPECT_GT(umax128, umax64);
   ASSERT_EQ(~LIBC_NAMESPACE::UInt<128>(0), umax128);
 #ifdef __SIZEOF_INT128__

--- a/libc/test/src/__support/CPP/limits_test.cpp
+++ b/libc/test/src/__support/CPP/limits_test.cpp
@@ -32,11 +32,11 @@ TEST(LlvmLibcLimitsTest, LimitsFollowSpec) {
 }
 
 TEST(LlvmLibcLimitsTest, UInt128Limits) {
-  auto umax128 = cpp::numeric_limits<LIBC_NAMESPACE::cpp::UInt<128>>::max();
+  auto umax128 = cpp::numeric_limits<LIBC_NAMESPACE::UInt<128>>::max();
   auto umax64 =
-      LIBC_NAMESPACE::cpp::UInt<128>(cpp::numeric_limits<uint64_t>::max());
+      LIBC_NAMESPACE::UInt<128>(cpp::numeric_limits<uint64_t>::max());
   EXPECT_GT(umax128, umax64);
-  ASSERT_EQ(~LIBC_NAMESPACE::cpp::UInt<128>(0), umax128);
+  ASSERT_EQ(~LIBC_NAMESPACE::UInt<128>(0), umax128);
 #ifdef __SIZEOF_INT128__
   ASSERT_EQ(~__uint128_t(0), cpp::numeric_limits<__uint128_t>::max());
 #endif

--- a/libc/test/src/__support/integer_literals_test.cpp
+++ b/libc/test/src/__support/integer_literals_test.cpp
@@ -104,7 +104,7 @@ TEST(LlvmLibcIntegerLiteralTest, u128) {
 }
 
 TEST(LlvmLibcIntegerLiteralTest, u256) {
-  using UInt256 = LIBC_NAMESPACE::cpp::UInt<256>;
+  using UInt256 = LIBC_NAMESPACE::UInt<256>;
   const UInt256 ZERO = 0;
   const UInt256 U8_MAX = UINT8_MAX;
   const UInt256 U16_MAX = UINT16_MAX;

--- a/libc/test/src/__support/integer_to_string_test.cpp
+++ b/libc/test/src/__support/integer_to_string_test.cpp
@@ -228,7 +228,7 @@ TEST(LlvmLibcIntegerToStringTest, UINT64_Base_36) {
 }
 
 TEST(LlvmLibcIntegerToStringTest, UINT256_Base_16) {
-  using UInt256 = LIBC_NAMESPACE::cpp::UInt<256>;
+  using UInt256 = LIBC_NAMESPACE::UInt<256>;
   using type = IntegerToString<UInt256, Hex::WithWidth<64>>;
   EXPECT(
       type,

--- a/libc/test/src/__support/uint_test.cpp
+++ b/libc/test/src/__support/uint_test.cpp
@@ -14,19 +14,19 @@
 
 namespace LIBC_NAMESPACE {
 
-using LL_UInt64 = cpp::UInt<64>;
-// We want to test cpp::UInt<128> explicitly. So, for
+using LL_UInt64 = UInt<64>;
+// We want to test UInt<128> explicitly. So, for
 // convenience, we use a sugar which does not conflict with the UInt128 type
 // which can resolve to __uint128_t if the platform has it.
-using LL_UInt128 = cpp::UInt<128>;
-using LL_UInt192 = cpp::UInt<192>;
-using LL_UInt256 = cpp::UInt<256>;
-using LL_UInt320 = cpp::UInt<320>;
-using LL_UInt512 = cpp::UInt<512>;
-using LL_UInt1024 = cpp::UInt<1024>;
+using LL_UInt128 = UInt<128>;
+using LL_UInt192 = UInt<192>;
+using LL_UInt256 = UInt<256>;
+using LL_UInt320 = UInt<320>;
+using LL_UInt512 = UInt<512>;
+using LL_UInt1024 = UInt<1024>;
 
-using LL_Int128 = cpp::Int<128>;
-using LL_Int192 = cpp::Int<192>;
+using LL_Int128 = Int<128>;
+using LL_Int192 = Int<192>;
 
 TEST(LlvmLibcUIntClassTest, BitCastToFromDouble) {
   static_assert(cpp::is_trivially_copyable<LL_UInt64>::value);
@@ -677,8 +677,8 @@ TEST(LlvmLibcUIntClassTest, ConstructorFromUInt128Tests) {
 }
 
 TEST(LlvmLibcUIntClassTest, WordTypeUInt128Tests) {
-  using LL_UInt256_128 = cpp::BigInt<256, false, __uint128_t>;
-  using LL_UInt128_128 = cpp::BigInt<128, false, __uint128_t>;
+  using LL_UInt256_128 = BigInt<256, false, __uint128_t>;
+  using LL_UInt128_128 = BigInt<128, false, __uint128_t>;
 
   LL_UInt256_128 a(1);
 
@@ -710,7 +710,7 @@ TEST(LlvmLibcUIntClassTest, WordTypeUInt128Tests) {
 #endif // __SIZEOF_INT128__
 
 TEST(LlvmLibcUIntClassTest, OtherWordTypeTests) {
-  using LL_UInt96 = cpp::BigInt<96, false, uint32_t>;
+  using LL_UInt96 = BigInt<96, false, uint32_t>;
 
   LL_UInt96 a(1);
 


### PR DESCRIPTION
As noted in https://github.com/llvm/llvm-project/pull/84035#discussion_r1516817755 only files under the CPP folder should be in the `cpp` namespace.
