### PR TITLE
release/18.x: [ARM] Switch to LiveRegUnits to fix r7 register allocation bug

### DIFF
--- a/llvm/lib/Target/ARM/Thumb1FrameLowering.cpp
+++ b/llvm/lib/Target/ARM/Thumb1FrameLowering.cpp
@@ -612,11 +612,11 @@ bool Thumb1FrameLowering::needPopSpecialFixUp(const MachineFunction &MF) const {
 
 static void findTemporariesForLR(const BitVector &GPRsNoLRSP,
                                  const BitVector &PopFriendly,
-                                 const LivePhysRegs &UsedRegs, unsigned &PopReg,
+                                 const LiveRegUnits &UsedRegs, unsigned &PopReg,
                                  unsigned &TmpReg, MachineRegisterInfo &MRI) {
   PopReg = TmpReg = 0;
   for (auto Reg : GPRsNoLRSP.set_bits()) {
-    if (UsedRegs.available(MRI, Reg)) {
+    if (UsedRegs.available(Reg)) {
       // Remember the first pop-friendly register and exit.
       if (PopFriendly.test(Reg)) {
         PopReg = Reg;
@@ -684,7 +684,7 @@ bool Thumb1FrameLowering::emitPopSpecialFixUp(MachineBasicBlock &MBB,
   // Look for a temporary register to use.
   // First, compute the liveness information.
   const TargetRegisterInfo &TRI = *STI.getRegisterInfo();
-  LivePhysRegs UsedRegs(TRI);
+  LiveRegUnits UsedRegs(TRI);
   UsedRegs.addLiveOuts(MBB);
   // The semantic of pristines changed recently and now,
   // the callee-saved registers that are touched in the function

--- a/llvm/test/CodeGen/Thumb/PR35481.ll
+++ b/llvm/test/CodeGen/Thumb/PR35481.ll
@@ -18,11 +18,10 @@ define <4 x i32> @f() local_unnamed_addr #0 {
 ; CHECK-V4T-NEXT:    movs r2, #3
 ; CHECK-V4T-NEXT:    movs r3, #4
 ; CHECK-V4T-NEXT:    bl g
+; CHECK-V4T-NEXT:    ldr r7, [sp, #4]
+; CHECK-V4T-NEXT:    mov lr, r7
 ; CHECK-V4T-NEXT:    pop {r7}
-; CHECK-V4T-NEXT:    mov r12, r0
-; CHECK-V4T-NEXT:    pop {r0}
-; CHECK-V4T-NEXT:    mov lr, r0
-; CHECK-V4T-NEXT:    mov r0, r12
+; CHECK-V4T-NEXT:    add sp, #4
 ; CHECK-V4T-NEXT:    bx lr
 ;
 ; CHECK-V8M-LABEL: f:
@@ -36,11 +35,10 @@ define <4 x i32> @f() local_unnamed_addr #0 {
 ; CHECK-V8M-NEXT:    movs r1, #2
 ; CHECK-V8M-NEXT:    movs r2, #3
 ; CHECK-V8M-NEXT:    movs r3, #4
+; CHECK-V8M-NEXT:    ldr r7, [sp, #4]
+; CHECK-V8M-NEXT:    mov lr, r7
 ; CHECK-V8M-NEXT:    pop {r7}
-; CHECK-V8M-NEXT:    mov r12, r0
-; CHECK-V8M-NEXT:    pop {r0}
-; CHECK-V8M-NEXT:    mov lr, r0
-; CHECK-V8M-NEXT:    mov r0, r12
+; CHECK-V8M-NEXT:    add sp, #4
 ; CHECK-V8M-NEXT:    b g
 entry:
   %call = tail call i32 @h(i32 1)


### PR DESCRIPTION
This fixes a register allocation bug, because while r7 was marked as allowed to be used, LivePhysRegs always reported it as unavailable because it is reserved, despite this being an exception to the rule.