### PR TITLE
[libc++] Don't build against libcxxrt by default on FreeBSD

### DIFF
--- a/libcxx/CMakeLists.txt
+++ b/libcxx/CMakeLists.txt
@@ -229,8 +229,6 @@ option(LIBCXX_USE_COMPILER_RT "Use compiler-rt instead of libgcc" OFF)
 # ABI Library options ---------------------------------------------------------
 if (MSVC)
   set(LIBCXX_DEFAULT_ABI_LIBRARY "vcruntime")
-elseif (${CMAKE_SYSTEM_NAME} MATCHES "FreeBSD")
-  set(LIBCXX_DEFAULT_ABI_LIBRARY "libcxxrt")
 else()
   set(LIBCXX_DEFAULT_ABI_LIBRARY "libcxxabi")
 endif()


### PR DESCRIPTION
The libc++ CMake build aims to provide a general-purpose configuration that matches the canonical LLVM setup (libc++ / libc++abi / libunwind), not the configuration used for compatibility on any given system. For these "compatibility" configurations, we use CMake caches like Apple.cmake and FreeBSD.cmake.

Defaulting to libcxxrt on FreeBSD makes it look as though we're trying to build the system compatible configuration on FreeBSD, which isn't really correct and causes confusion more than anything else.

Fixes #84476