### PR TITLE
[clang-tidy]avoid bugprone-unused-return-value false positive for assignment operator overloading

### DIFF
--- a/clang-tools-extra/clang-tidy/bugprone/UnusedReturnValueCheck.cpp
+++ b/clang-tools-extra/clang-tidy/bugprone/UnusedReturnValueCheck.cpp
@@ -32,8 +32,8 @@ AST_MATCHER_P(FunctionDecl, isInstantiatedFrom, Matcher<FunctionDecl>,
 }
 
 AST_MATCHER_P(CXXMethodDecl, isOperatorOverloading,
-              llvm::SmallVector<OverloadedOperatorKind>, kinds) {
-  return llvm::is_contained(kinds, Node.getOverloadedOperator());
+              llvm::SmallVector<OverloadedOperatorKind>, Kinds) {
+  return llvm::is_contained(Kinds, Node.getOverloadedOperator());
 }
 } // namespace
 

--- a/clang-tools-extra/clang-tidy/bugprone/UnusedReturnValueCheck.cpp
+++ b/clang-tools-extra/clang-tidy/bugprone/UnusedReturnValueCheck.cpp
@@ -12,6 +12,7 @@
 #include "clang/AST/ASTContext.h"
 #include "clang/ASTMatchers/ASTMatchFinder.h"
 #include "clang/ASTMatchers/ASTMatchers.h"
+#include "clang/Basic/OperatorKinds.h"
 
 using namespace clang::ast_matchers;
 using namespace clang::ast_matchers::internal;
@@ -28,6 +29,11 @@ AST_MATCHER_P(FunctionDecl, isInstantiatedFrom, Matcher<FunctionDecl>,
   FunctionDecl *InstantiatedFrom = Node.getInstantiatedFromMemberFunction();
   return InnerMatcher.matches(InstantiatedFrom ? *InstantiatedFrom : Node,
                               Finder, Builder);
+}
+
+AST_MATCHER_P(CXXMethodDecl, isOperatorOverloading,
+              llvm::SmallVector<OverloadedOperatorKind>, kinds) {
+  return llvm::is_contained(kinds, Node.getOverloadedOperator());
 }
 } // namespace
 
@@ -159,17 +165,20 @@ void UnusedReturnValueCheck::storeOptions(ClangTidyOptions::OptionMap &Opts) {
 
 void UnusedReturnValueCheck::registerMatchers(MatchFinder *Finder) {
   auto MatchedDirectCallExpr = expr(
-      callExpr(callee(functionDecl(
-                   // Don't match void overloads of checked functions.
-                   unless(returns(voidType())),
-                   // Don't match copy or move assignment operator.
-                   unless(cxxMethodDecl(anyOf(isCopyAssignmentOperator(),
-                                              isMoveAssignmentOperator()))),
-                   anyOf(isInstantiatedFrom(
-                             matchers::matchesAnyListedName(CheckedFunctions)),
-                         returns(hasCanonicalType(hasDeclaration(
-                             namedDecl(matchers::matchesAnyListedName(
-                                 CheckedReturnTypes)))))))))
+      callExpr(
+          callee(functionDecl(
+              // Don't match void overloads of checked functions.
+              unless(returns(voidType())),
+              // Don't match copy or move assignment operator.
+              unless(cxxMethodDecl(isOperatorOverloading(
+                  {OO_Equal, OO_PlusEqual, OO_MinusEqual, OO_StarEqual,
+                   OO_SlashEqual, OO_PercentEqual, OO_CaretEqual, OO_AmpEqual,
+                   OO_PipeEqual, OO_LessLessEqual, OO_GreaterGreaterEqual}))),
+              anyOf(
+                  isInstantiatedFrom(
+                      matchers::matchesAnyListedName(CheckedFunctions)),
+                  returns(hasCanonicalType(hasDeclaration(namedDecl(
+                      matchers::matchesAnyListedName(CheckedReturnTypes)))))))))
           .bind("match"));
 
   auto CheckCastToVoid =

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -152,9 +152,9 @@ Changes in existing checks
 
 - Improved :doc:`bugprone-unused-return-value
   <clang-tidy/checks/bugprone/unused-return-value>` check by updating the
-  parameter `CheckedFunctions` to support regexp and avoiding false postive for
+  parameter `CheckedFunctions` to support regexp, avoiding false positive for
   function with the same prefix as the default argument, e.g. ``std::unique_ptr``
-  and ``std::unique``.
+  and ``std::unique``, avoiding false positive for assignment operator overloading.
 
 - Improved :doc:`bugprone-use-after-move
   <clang-tidy/checks/bugprone/use-after-move>` check to also handle

--- a/clang-tools-extra/docs/clang-tidy/checks/bugprone/unused-return-value.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/bugprone/unused-return-value.rst
@@ -5,7 +5,7 @@ bugprone-unused-return-value
 
 Warns on unused function return values. The checked functions can be configured.
 
-Operator overloading with assignment semantics are ignored。
+Operator overloading with assignment semantics are ignored.
 
 Options
 -------

--- a/clang-tools-extra/docs/clang-tidy/checks/bugprone/unused-return-value.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/bugprone/unused-return-value.rst
@@ -5,6 +5,8 @@ bugprone-unused-return-value
 
 Warns on unused function return values. The checked functions can be configured.
 
+Operator overloading with assignment semantics are ignored。
+
 Options
 -------
 

--- a/clang-tools-extra/test/clang-tidy/checkers/bugprone/unused-return-value-avoid-assignment.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/bugprone/unused-return-value-avoid-assignment.cpp
@@ -1,0 +1,31 @@
+// RUN: %check_clang_tidy %s bugprone-unused-return-value %t \
+// RUN: -config='{CheckOptions: \
+// RUN:  {bugprone-unused-return-value.CheckedFunctions: "::*"}}' \
+// RUN: --
+
+struct S {
+  S(){};
+  S(S const &);
+  S(S &&);
+  S &operator=(S const &);
+  S &operator=(S &&);
+};
+
+S returnValue();
+S const &returnRef();
+
+void bar() {
+  returnValue();
+  // CHECK-MESSAGES: [[@LINE-1]]:3: warning: the value returned by this function should not be disregarded; neglecting it may lead to errors
+
+  S a{};
+  a = returnValue();
+  // CHECK-NOT: [[@LINE-1]]:3: warning
+  a.operator=(returnValue());
+  // CHECK-NOT: [[@LINE-1]]:3: warning
+
+  a = returnRef();
+  // CHECK-NOT: [[@LINE-1]]:3: warning
+  a.operator=(returnRef());
+  // CHECK-NOT: [[@LINE-1]]:3: warning
+}

--- a/clang-tools-extra/test/clang-tidy/checkers/bugprone/unused-return-value-avoid-assignment.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/bugprone/unused-return-value-avoid-assignment.cpp
@@ -9,6 +9,7 @@ struct S {
   S(S &&);
   S &operator=(S const &);
   S &operator=(S &&);
+  S &operator+=(S);
 };
 
 S returnValue();
@@ -20,12 +21,10 @@ void bar() {
 
   S a{};
   a = returnValue();
-  // CHECK-NOT: [[@LINE-1]]:3: warning
   a.operator=(returnValue());
-  // CHECK-NOT: [[@LINE-1]]:3: warning
 
   a = returnRef();
-  // CHECK-NOT: [[@LINE-1]]:3: warning
   a.operator=(returnRef());
-  // CHECK-NOT: [[@LINE-1]]:3: warning
+
+  a += returnRef();
 }


### PR DESCRIPTION
Fixes: #84480
We assuem assignemnt at most of time, operator overloading means the value is assigned to the other variable, then clang-tidy should suppress warning even if this operator overloading match the regex.
