### PR TITLE
[C++20][Coroutines] lambda-coroutine with promise_type ctor.

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -95,6 +95,10 @@ C++20 Feature Support
   templates (`P1814R0 <https://wg21.link/p1814r0>`_).
   (#GH54051).
 
+- Clang now treats a lambda-coroutine with a `promise_type` with a constructor
+  or a user-defined `operator new` correctly, passing the lambdas
+  `this`-pointer as the first argument of the parameter list.
+
 C++23 Feature Support
 ^^^^^^^^^^^^^^^^^^^^^
 

--- a/clang/lib/Sema/SemaCoroutine.cpp
+++ b/clang/lib/Sema/SemaCoroutine.cpp
@@ -1402,7 +1402,8 @@ static bool collectPlacementArgs(Sema &S, FunctionDecl &FD, SourceLocation Loc,
         Sema::CXXThisScopeRAII ThisScope(S, Record, ThisQuals,
                                          /*Enabled=*/Record != nullptr);
 
-        ThisExpr = S.ActOnCXXThis(Loc, /*ThisRefersToClosureObject=*/true);
+        ThisExpr = S.BuildCXXThisExpr(
+            Loc, MD->getThisType().getNonReferenceType(), true, true);
       } else {
         ThisExpr = S.ActOnCXXThis(Loc);
       }
@@ -1671,6 +1672,7 @@ bool CoroutineStmtBuilder::makeNewAndDeleteExpr() {
   NewExpr = S.ActOnFinishFullExpr(NewExpr.get(), /*DiscardedValue*/ false);
   if (NewExpr.isInvalid())
     return false;
+
 
   // Make delete call.
 

--- a/clang/test/SemaCXX/coroutine-promise-ctor-lambda.cpp
+++ b/clang/test/SemaCXX/coroutine-promise-ctor-lambda.cpp
@@ -1,0 +1,71 @@
+// RUN: %clang_cc1 -fsyntax-only -verify -I%S/Inputs -std=c++20 %s
+
+// expected-no-diagnostics
+
+#include "std-coroutine.h"
+
+using size_t = decltype(sizeof(0));
+
+struct Generator {
+  struct promise_type {
+    int _val{};
+
+    Generator get_return_object() noexcept
+    {
+      return {};
+    }
+
+    std::suspend_never initial_suspend() noexcept
+    {
+      return {};
+    }
+
+    std::suspend_always final_suspend() noexcept
+    {
+      return {};
+    }
+
+    void return_void() noexcept {}
+    void unhandled_exception() noexcept {}
+
+    template<typename This, typename... TheRest>
+    promise_type(This&,
+                 TheRest&&...)
+    {
+    }
+  };
+};
+
+struct CapturingThisTest
+{
+    int x{};
+
+    void AsPointer()
+    {
+      auto lamb = [=,this]() -> Generator {
+        int y = x;
+        co_return;
+      };
+
+      static_assert(sizeof(decltype(lamb)) == sizeof(void*));
+    }
+
+    void AsStarThis()
+    {
+      auto lamb = [*this]() -> Generator {
+        int y = x;
+        co_return;
+      };
+
+      static_assert(sizeof(decltype(lamb)) == sizeof(int));
+    }
+};
+
+int main()
+{
+  auto lamb = []() -> Generator {
+    co_return;
+  };
+
+  static_assert(sizeof(decltype(lamb)) == 1);
+}

--- a/clang/test/SemaCXX/cxx23-coroutine-promise-ctor-static-callop-lambda.cpp
+++ b/clang/test/SemaCXX/cxx23-coroutine-promise-ctor-static-callop-lambda.cpp
@@ -1,0 +1,47 @@
+// RUN: %clang_cc1 -fsyntax-only -verify -I%S/Inputs -std=c++23 %s
+
+// expected-no-diagnostics
+
+#include "std-coroutine.h"
+
+using size_t = decltype(sizeof(0));
+
+struct Generator {
+  struct promise_type {
+    int _val{};
+
+    Generator get_return_object() noexcept
+    {
+      return {};
+    }
+
+    std::suspend_never initial_suspend() noexcept
+    {
+      return {};
+    }
+
+    std::suspend_always final_suspend() noexcept
+    {
+      return {};
+    }
+
+    void return_void() noexcept {}
+    void unhandled_exception() noexcept {}
+
+    template<typename... TheRest>
+    promise_type(TheRest&&...)
+    {
+    }
+  };
+};
+
+
+int main()
+{
+  auto lamb = []() static -> Generator {
+    co_return;
+  };
+
+  static_assert(sizeof(decltype(lamb)) == 1);
+}
+

--- a/clang/test/SemaCXX/gh84064-1.cpp
+++ b/clang/test/SemaCXX/gh84064-1.cpp
@@ -66,6 +66,15 @@ struct CapturingThisTest
 
       static_assert(sizeof(decltype(lamb)) == sizeof(int));
     }
+
+    void NoCapture()
+    {
+      auto lamb = []() -> Generator {
+        co_return;
+      };
+
+      static_assert(sizeof(decltype(lamb)) == 1);
+    }
 };
 
 int main()


### PR DESCRIPTION
This is a follow-up of #84064. It turned out that a coroutine-lambda with a `promise_type` and a user-defined constructor ignores the `this` pointer. Per http://eel.is/c++draft/dcl.fct.def.coroutine#4, in such a case, the first parameter to the constructor is an lvalue of `*this`.