### PR TITLE
[AMDGPU] Use get_BUF_ps to default real_name of BUF instructions. NFC.

### DIFF
--- a/llvm/lib/Target/AMDGPU/BUFInstructions.td
+++ b/llvm/lib/Target/AMDGPU/BUFInstructions.td
@@ -2502,7 +2502,8 @@ multiclass MUBUF_Real_AllAddr_gfx11_gfx12_Impl<bits<8> op, string real_name,
 multiclass MUBUF_Real_AllAddr_gfx11<bits<8> op, bit hasTFE = 1> :
   MUBUF_Real_AllAddr_gfx11_Impl<op, get_BUF_ps<NAME>.Mnemonic, hasTFE>;
 
-multiclass MUBUF_Real_AllAddr_gfx11_gfx12<bits<8> op, string real_name = !tolower(NAME)> :
+multiclass MUBUF_Real_AllAddr_gfx11_gfx12<bits<8> op,
+                                 string real_name = get_BUF_ps<NAME>.Mnemonic> :
   MUBUF_Real_AllAddr_gfx11_gfx12_Impl<op, real_name> {
   defvar ps = get_BUF_ps<NAME>;
   if !ne(ps.Mnemonic, real_name) then
@@ -2542,7 +2543,9 @@ multiclass MUBUF_Real_Atomic_gfx11<bits<8> op, string real_name> :
   def : Mnem_gfx11_gfx12<get_BUF_ps<NAME>.Mnemonic, real_name>;
 }
 
-multiclass MUBUF_Real_Atomic_gfx11_gfx12<bits<8> op, string gfx12_name = !tolower(NAME), string gfx11_name = gfx12_name> :
+multiclass MUBUF_Real_Atomic_gfx11_gfx12<bits<8> op,
+                                  string gfx12_name = get_BUF_ps<NAME>.Mnemonic,
+                                  string gfx11_name = gfx12_name> :
   MUBUF_Real_Atomic_gfx11_impl<op, 0, gfx11_name>,
   MUBUF_Real_Atomic_gfx11_impl<op, 1, gfx11_name>,
   MUBUF_Real_Atomic_gfx12_impl<op, 0, gfx12_name>,
@@ -2887,7 +2890,8 @@ multiclass MTBUF_Real_AllAddr_gfx11_gfx12_Impl<bits<4> op, string real_name> {
   defm _VBUFFER_OFFSET : VBUFFER_MTBUF_Real_gfx12<op, real_name>;
 }
 
-multiclass MTBUF_Real_AllAddr_gfx11_gfx12<bits<4> op, string real_name = !tolower(NAME)>
+multiclass MTBUF_Real_AllAddr_gfx11_gfx12<bits<4> op,
+                                   string real_name = get_BUF_ps<NAME>.Mnemonic>
   : MTBUF_Real_AllAddr_gfx11_gfx12_Impl<op, real_name> {
   defvar ps = get_BUF_ps<NAME>;
   if !ne(ps.Mnemonic, real_name) then

--- a/llvm/lib/Target/AMDGPU/BUFInstructions.td
+++ b/llvm/lib/Target/AMDGPU/BUFInstructions.td
@@ -2485,7 +2485,7 @@ multiclass MUBUF_Real_AllAddr_gfx11_gfx12_Impl2<bits<8> op, string real_name> :
   MUBUF_Real_AllAddr_gfx12_Impl2<op, real_name>;
 
 multiclass MUBUF_Real_AllAddr_gfx11_Impl<bits<8> op, bit hasTFE,
-                                         string real_name> {
+                                 string real_name = get_BUF_ps<NAME>.Mnemonic> {
   defm NAME : MUBUF_Real_AllAddr_gfx11_Impl2<op, real_name>;
   if hasTFE then
     defm _TFE : MUBUF_Real_AllAddr_gfx11_Impl2<op, real_name>;
@@ -2500,7 +2500,7 @@ multiclass MUBUF_Real_AllAddr_gfx11_gfx12_Impl<bits<8> op, bit hasTFE,
 
 // Non-renamed, non-atomic gfx11/gfx12 mubuf instructions.
 multiclass MUBUF_Real_AllAddr_gfx11<bits<8> op, bit hasTFE = 1> :
-  MUBUF_Real_AllAddr_gfx11_Impl<op, hasTFE, get_BUF_ps<NAME>.Mnemonic>;
+  MUBUF_Real_AllAddr_gfx11_Impl<op, hasTFE>;
 
 multiclass MUBUF_Real_AllAddr_gfx11_gfx12<bits<8> op,
                                  string real_name = get_BUF_ps<NAME>.Mnemonic> :
@@ -2520,7 +2520,7 @@ multiclass MUBUF_Real_Atomic_gfx11_impl<bits<8> op, bit is_return,
 }
 
 multiclass MUBUF_Real_Atomic_gfx12_impl<bits<8> op, bit is_return,
-                                                string real_name> {
+                                 string real_name = get_BUF_ps<NAME>.Mnemonic> {
   defvar Rtn = !if(is_return, "_RTN", "");
   defm _VBUFFER_BOTHEN#Rtn : VBUFFER_MUBUF_Real_gfx12<op, real_name>;
   defm _VBUFFER_IDXEN#Rtn  : VBUFFER_MUBUF_Real_gfx12<op, real_name>;
@@ -2534,13 +2534,14 @@ multiclass MUBUF_Real_Atomic_gfx11_gfx12_impl<bits<8> op, bit is_return,
   MUBUF_Real_Atomic_gfx12_impl<op, is_return, real_name>;
 
 multiclass MUBUF_Real_Atomic_gfx12<bits<8> op> :
-  MUBUF_Real_Atomic_gfx12_impl<op, 0, get_BUF_ps<NAME>.Mnemonic>,
-  MUBUF_Real_Atomic_gfx12_impl<op, 1, get_BUF_ps<NAME>.Mnemonic>;
+  MUBUF_Real_Atomic_gfx12_impl<op, 0>,
+  MUBUF_Real_Atomic_gfx12_impl<op, 1>;
 
 multiclass MUBUF_Real_Atomic_gfx11<bits<8> op, string real_name> :
   MUBUF_Real_Atomic_gfx11_impl<op, 0, real_name>,
   MUBUF_Real_Atomic_gfx11_impl<op, 1, real_name> {
-  def : Mnem_gfx11_gfx12<get_BUF_ps<NAME>.Mnemonic, real_name>;
+  defvar ps = get_BUF_ps<NAME>;
+  def : Mnem_gfx11_gfx12<ps.Mnemonic, real_name>;
 }
 
 multiclass MUBUF_Real_Atomic_gfx11_gfx12<bits<8> op,

--- a/llvm/lib/Target/AMDGPU/BUFInstructions.td
+++ b/llvm/lib/Target/AMDGPU/BUFInstructions.td
@@ -2484,15 +2484,15 @@ multiclass MUBUF_Real_AllAddr_gfx11_gfx12_Impl2<bits<8> op, string real_name> :
   MUBUF_Real_AllAddr_gfx11_Impl2<op, real_name>,
   MUBUF_Real_AllAddr_gfx12_Impl2<op, real_name>;
 
-multiclass MUBUF_Real_AllAddr_gfx11_Impl<bits<8> op, string real_name,
-                                                 bit hasTFE = 1> {
+multiclass MUBUF_Real_AllAddr_gfx11_Impl<bits<8> op, bit hasTFE,
+                                         string real_name> {
   defm NAME : MUBUF_Real_AllAddr_gfx11_Impl2<op, real_name>;
   if hasTFE then
     defm _TFE : MUBUF_Real_AllAddr_gfx11_Impl2<op, real_name>;
 }
 
-multiclass MUBUF_Real_AllAddr_gfx11_gfx12_Impl<bits<8> op, string real_name,
-                                                 bit hasTFE = 1> {
+multiclass MUBUF_Real_AllAddr_gfx11_gfx12_Impl<bits<8> op, bit hasTFE,
+                                               string real_name> {
   defm NAME : MUBUF_Real_AllAddr_gfx11_gfx12_Impl2<op, real_name>;
   if hasTFE then
     defm _TFE : MUBUF_Real_AllAddr_gfx11_gfx12_Impl2<op, real_name>;
@@ -2500,11 +2500,11 @@ multiclass MUBUF_Real_AllAddr_gfx11_gfx12_Impl<bits<8> op, string real_name,
 
 // Non-renamed, non-atomic gfx11/gfx12 mubuf instructions.
 multiclass MUBUF_Real_AllAddr_gfx11<bits<8> op, bit hasTFE = 1> :
-  MUBUF_Real_AllAddr_gfx11_Impl<op, get_BUF_ps<NAME>.Mnemonic, hasTFE>;
+  MUBUF_Real_AllAddr_gfx11_Impl<op, hasTFE, get_BUF_ps<NAME>.Mnemonic>;
 
 multiclass MUBUF_Real_AllAddr_gfx11_gfx12<bits<8> op,
                                  string real_name = get_BUF_ps<NAME>.Mnemonic> :
-  MUBUF_Real_AllAddr_gfx11_gfx12_Impl<op, real_name> {
+  MUBUF_Real_AllAddr_gfx11_gfx12_Impl<op, /*hasTFE=*/1, real_name> {
   defvar ps = get_BUF_ps<NAME>;
   if !ne(ps.Mnemonic, real_name) then
     def : Mnem_gfx11_gfx12<ps.Mnemonic, real_name>;


### PR DESCRIPTION
- **Use get_BUF_ps<NAME>.Mnemonic instead of !tolower(NAME)**
- **Swap hasTFE and real_name arguments**
- **Use optional arguments defaulted to get_BUF_ps<NAME>.Mnemonic**
