### PR TITLE
Build actions-builder image with clang binaries pinned to 18.0

### DIFF
--- a/libcxx/utils/ci/Dockerfile
+++ b/libcxx/utils/ci/Dockerfile
@@ -130,7 +130,11 @@ RUN <<EOF
   sudo /tmp/llvm.sh $(($LLVM_HEAD_VERSION - 3)) all  # for CI transitions
   sudo /tmp/llvm.sh $(($LLVM_HEAD_VERSION - 2)) all  # previous release
   sudo /tmp/llvm.sh $(($LLVM_HEAD_VERSION - 1)) all  # latest release
-  sudo /tmp/llvm.sh $LLVM_HEAD_VERSION          all  # current ToT
+
+
+  # FIXME(EricWF): Remove the ".0" from the version number. We're doing this temporarily to allow clang-tidy to be
+  # built against binary packages, and we need to pin those packages for stability.
+  sudo /tmp/llvm.sh ${LLVM_HEAD_VERSION}.0      all  # current ToT
   sudo apt-get install -y libomp5-$LLVM_HEAD_VERSION
   sudo rm -rf /var/lib/apt/lists/*
 EOF

--- a/libcxx/utils/ci/docker-compose.yml
+++ b/libcxx/utils/ci/docker-compose.yml
@@ -15,7 +15,7 @@ services:
         BASE_IMAGE: ubuntu:jammy
         <<: *compiler_versions
   actions-builder:
-    image: ghcr.io/libcxx/actions-builder:${TAG:-latest}
+    image: ghcr.io/libcxx/actions-builder:${TAG:-clang-18.0}
     build:
       context: .
       dockerfile: Dockerfile


### PR DESCRIPTION
This is a temp workaround to allow the modules tests flake less for the
moment
