### PR TITLE
[MLIR] Add missing MLIRDialectUtils dep to TilingInterface

### DIFF
--- a/mlir/lib/Interfaces/CMakeLists.txt
+++ b/mlir/lib/Interfaces/CMakeLists.txt
@@ -101,7 +101,20 @@ add_mlir_library(MLIRSubsetOpInterface
   MLIRValueBoundsOpInterface
   )
 
-add_mlir_interface_library(TilingInterface)
+add_mlir_library(MLIRTilingInterface
+  TilingInterface.cpp
+
+  ADDITIONAL_HEADER_DIRS
+  ${MLIR_MAIN_INCLUDE_DIR}/mlir/Interfaces
+
+  DEPENDS
+  MLIRTilingInterfaceIncGen
+  MLIRDialectUtils
+
+  LINK_LIBS PUBLIC
+  MLIRIR
+)
+
 add_mlir_interface_library(VectorInterfaces)
 add_mlir_interface_library(ViewLikeInterface)
 


### PR DESCRIPTION
This fixes the following failure when doing a clean build (in particular
no .ninja* lying around) of lib/libMLIRTilingInterface.a only:
```
In file included from mlir/include/mlir/Interfaces/TilingInterface.h:17,                                                                     
                 from mlir/lib/Interfaces/TilingInterface.cpp:13:                                                                            
mlir/include/mlir/Dialect/Utils/StructuredOpsUtils.h:27:10: fatal error: mlir/Dialect/Utils/DialectUtilsEnums.h.inc: No such file or directory
```