### PR TITLE
[MLIR] Add missing MLIRGPUDialect dep to MLIRSPIRVDialect

### DIFF
--- a/mlir/lib/Dialect/SPIRV/IR/CMakeLists.txt
+++ b/mlir/lib/Dialect/SPIRV/IR/CMakeLists.txt
@@ -27,6 +27,7 @@ add_mlir_dialect_library(MLIRSPIRVDialect
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Dialect/SPIRV
 
   DEPENDS
+  MLIRGPUDialect
   MLIRSPIRVAttributeIncGen
   MLIRSPIRVAttrUtilsGen
   MLIRSPIRVAvailabilityIncGen


### PR DESCRIPTION
This fixes the following failure when doing a clean build (in particular
no .ninja* lying around) of lib/libMLIRSPIRVDialect.a only:
```
mlir/lib/Dialect/SPIRV/IR/SPIRVDialect.cpp:17:
mlir/include/mlir/Dialect/GPU/IR/CompilationInterfaces.h:120:10: fatal error: mlir/Dialect/GPU/IR/CompilationAttrInterfaces.h.inc: No such file or directory
```