### PR TITLE
[MLIR] Add missing MLIRFuncDialect dep to MLIRAffineAnalysis

### DIFF
--- a/mlir/lib/Dialect/Affine/Analysis/CMakeLists.txt
+++ b/mlir/lib/Dialect/Affine/Analysis/CMakeLists.txt
@@ -14,6 +14,7 @@ add_mlir_dialect_library(MLIRAffineAnalysis
   MLIRCallInterfaces
   MLIRControlFlowInterfaces
   MLIRDialectUtils
+  MLIRFuncDialect
   MLIRInferTypeOpInterface
   MLIRSideEffectInterfaces
   MLIRPresburger


### PR DESCRIPTION
This fixes the following failure when doing a clean build (in particular
no .ninja* lying around) of lib/libMLIRAffineAnalysis.a only:
```
In file included from mlir/lib/Dialect/Affine/Analysis/AffineAnalysis.cpp:20:
mlir/include/mlir/Dialect/Func/IR/FuncOps.h:29:10: fatal error: mlir/Dialect/Func/IR/FuncOps.h.inc: No such file or directory
```