### PR TITLE
[APINotes] Fix failing tests after a PCM logic change

### DIFF
--- a/clang/lib/APINotes/APINotesManager.cpp
+++ b/clang/lib/APINotes/APINotesManager.cpp
@@ -224,7 +224,7 @@ APINotesManager::getCurrentModuleAPINotes(Module *M, bool LookInModule,
   llvm::SmallVector<FileEntryRef, 2> APINotes;
 
   // First, look relative to the module itself.
-  if (LookInModule) {
+  if (LookInModule && M->Directory) {
     // Local function to try loading an API notes file in the given directory.
     auto tryAPINotes = [&](DirectoryEntryRef Dir, bool WantPublic) {
       if (auto File = findAPINotesFile(Dir, ModuleName, WantPublic)) {


### PR DESCRIPTION
This fixes tests that are going to be upstreamed in the near future. Currently they are failing downstream in the Apple open source fork.

Failing tests
  Clang :: APINotes/retain-count-convention.m
  Clang :: APINotes/types.m
  Clang :: APINotes/versioned-multi.c
  Clang :: APINotes/versioned.m

Since 2e5af56 got merged, Clang now enables `LangOpts.APINotesModules` when reading a precompiled module that was built with API Notes enabled. This is correct. The logic in APINotesManager needs to be adjusted to handle this.

rdar://123526142