### PR TITLE
Reland [AMDGPU] Add AMDGPU specific variadic operation MCExprs

### DIFF
--- a/llvm/docs/AMDGPUUsage.rst
+++ b/llvm/docs/AMDGPUUsage.rst
@@ -1543,15 +1543,16 @@ As part of the AMDGPU MC layer, AMDGPU provides the following target specific
   .. table:: AMDGPU MCExpr types:
      :name: amdgpu-mcexpr-table
 
-     =================== ======================================================================
-     AMDGPU MCExpr       Description
-     =================== ======================================================================
-     ``max(arg, ...)``   Variadic operation that returns maximum value of all its arguments.
+     =================== ================= ========================================================
+     MCExpr              Operands          Return value
+     =================== ================= ========================================================
+     ``max(arg, ...)``   1 or more         Variadic signed operation that returns the maximum
+                                           value of all its arguments.
 
-     ``or(arg, ...)``    Variadic operation that returns the bitwise-or result of all its
-                         arguments.
+     ``or(arg, ...)``    1 or more         Variadic signed operation that returns the bitwise-or
+                                           result of all its arguments.
 
-     =================== ======================================================================
+     =================== ================= ========================================================
 
 .. _amdgpu-elf-code-object:
 

--- a/llvm/docs/AMDGPUUsage.rst
+++ b/llvm/docs/AMDGPUUsage.rst
@@ -1534,6 +1534,24 @@ The AMDGPU backend supports the following calling conventions:
 
      =============================== ==========================================================
 
+AMDGPU MCExpr
+-------------
+
+As part of the AMDGPU MC layer, AMDGPU provides the following target specific
+``MCExpr``\s.
+
+  .. table:: AMDGPU MCExpr types:
+     :name: amdgpu-mcexpr-table
+
+     =================== ======================================================================
+     AMDGPU MCExpr       Description
+     =================== ======================================================================
+     ``max(arg, ...)``   Variadic operation that returns maximum value of all its arguments.
+
+     ``or(arg, ...)``    Variadic operation that returns the bitwise-or result of all its
+                         arguments.
+
+     =================== ======================================================================
 
 .. _amdgpu-elf-code-object:
 

--- a/llvm/lib/Target/AMDGPU/AsmParser/AMDGPUAsmParser.cpp
+++ b/llvm/lib/Target/AMDGPU/AsmParser/AMDGPUAsmParser.cpp
@@ -8287,16 +8287,16 @@ void AMDGPUAsmParser::onBeginOfFile() {
 bool AMDGPUAsmParser::parsePrimaryExpr(const MCExpr *&Res, SMLoc &EndLoc) {
   using AGVK = AMDGPUVariadicMCExpr::AMDGPUVariadicKind;
 
-  auto parseVariadicExpr = [&](AGVK Kind, const MCExpr *&res, SMLoc &EndLoc) {
-    std::vector<const MCExpr *> Exprs;
+  auto ParseVariadicExpr = [&](AGVK Kind, const MCExpr *&Result,
+                               SMLoc &EndLoc) {
+    SmallVector<const MCExpr *, 4> Exprs;
     while (true) {
-      if (isToken(AsmToken::RParen)) {
+      if (trySkipToken(AsmToken::RParen)) {
         if (Exprs.empty()) {
           Error(getToken().getLoc(), "empty max/or expression");
           return true;
         }
-        lex();
-        res = AMDGPUVariadicMCExpr::create(Kind, Exprs, getContext());
+        Result = AMDGPUVariadicMCExpr::create(Kind, Exprs, getContext());
         return false;
       }
       const MCExpr *Expr;
@@ -8320,7 +8320,7 @@ bool AMDGPUAsmParser::parsePrimaryExpr(const MCExpr *&Res, SMLoc &EndLoc) {
     if (VK != AGVK::AGVK_None && peekToken().is(AsmToken::LParen)) {
       lex(); // Eat 'max'/'or'
       lex(); // Eat '('
-      return parseVariadicExpr(VK, Res, EndLoc);
+      return ParseVariadicExpr(VK, Res, EndLoc);
     }
   }
   return getParser().parsePrimaryExpr(Res, EndLoc, nullptr);

--- a/llvm/lib/Target/AMDGPU/AsmParser/AMDGPUAsmParser.cpp
+++ b/llvm/lib/Target/AMDGPU/AsmParser/AMDGPUAsmParser.cpp
@@ -8285,7 +8285,7 @@ void AMDGPUAsmParser::onBeginOfFile() {
 ///           max(expr, ...)
 ///
 bool AMDGPUAsmParser::parsePrimaryExpr(const MCExpr *&Res, SMLoc &EndLoc) {
-  using AGVK = AMDGPUVariadicMCExpr::AMDGPUVariadicKind;
+  using AGVK = AMDGPUVariadicMCExpr::VariadicKind;
 
   if (isToken(AsmToken::Identifier)) {
     StringRef TokenId = getTokenStr();

--- a/llvm/lib/Target/AMDGPU/MCTargetDesc/AMDGPUMCExpr.cpp
+++ b/llvm/lib/Target/AMDGPU/MCTargetDesc/AMDGPUMCExpr.cpp
@@ -20,10 +20,13 @@ using namespace llvm;
 const AMDGPUVariadicMCExpr *
 AMDGPUVariadicMCExpr::create(VariadicKind Kind, ArrayRef<const MCExpr *> Args,
                              MCContext &Ctx) {
-  // Storage for the argument's 'const MCExpr*' allocated through MCContext new placement which means that AMDGPUVariadicMCExpr objects and all of its contents will now be allocated through MCContext new placement.
+  // Storage for the argument's 'const MCExpr*' allocated through MCContext new
+  // placement which means that AMDGPUVariadicMCExpr objects and all of its
+  // contents will now be allocated through MCContext new placement.
   //
-  // Will result in an asan failure if allocated on the heap (e.g., through SmallVector's grow).
-  const MCExpr **CtxArgs = new (Ctx) const MCExpr*[Args.size()];
+  // Will result in an asan failure if allocated on the heap (e.g., through
+  // SmallVector's grow).
+  const MCExpr **CtxArgs = new (Ctx) const MCExpr *[Args.size()];
   for (size_t i = 0; i < Args.size(); ++i)
     CtxArgs[i] = Args[i];
   return new (Ctx) AMDGPUVariadicMCExpr(Kind, ArrayRef(CtxArgs, Args.size()));

--- a/llvm/lib/Target/AMDGPU/MCTargetDesc/AMDGPUMCExpr.cpp
+++ b/llvm/lib/Target/AMDGPU/MCTargetDesc/AMDGPUMCExpr.cpp
@@ -26,8 +26,9 @@ AMDGPUVariadicMCExpr::create(VariadicKind Kind, ArrayRef<const MCExpr *> Args,
   //
   // Will result in an asan failure if allocated on the heap (e.g., through
   // SmallVector's grow).
-  const MCExpr **CtxArgs = new (Ctx) const MCExpr *[Args.size()];
-  std::copy(Args.begin(), Args.end(), CtxArgs);
+  const MCExpr **CtxArgs = static_cast<const MCExpr **>(
+      Ctx.allocate(sizeof(const MCExpr *) * Args.size()));
+  std::uninitialized_copy(Args.begin(), Args.end(), CtxArgs);
   return new (Ctx) AMDGPUVariadicMCExpr(Kind, ArrayRef(CtxArgs, Args.size()));
 }
 

--- a/llvm/lib/Target/AMDGPU/MCTargetDesc/AMDGPUMCExpr.cpp
+++ b/llvm/lib/Target/AMDGPU/MCTargetDesc/AMDGPUMCExpr.cpp
@@ -27,8 +27,7 @@ AMDGPUVariadicMCExpr::create(VariadicKind Kind, ArrayRef<const MCExpr *> Args,
   // Will result in an asan failure if allocated on the heap (e.g., through
   // SmallVector's grow).
   const MCExpr **CtxArgs = new (Ctx) const MCExpr *[Args.size()];
-  for (size_t i = 0; i < Args.size(); ++i)
-    CtxArgs[i] = Args[i];
+  std::copy(Args.begin(), Args.end(), CtxArgs);
   return new (Ctx) AMDGPUVariadicMCExpr(Kind, ArrayRef(CtxArgs, Args.size()));
 }
 

--- a/llvm/lib/Target/AMDGPU/MCTargetDesc/AMDGPUMCExpr.cpp
+++ b/llvm/lib/Target/AMDGPU/MCTargetDesc/AMDGPUMCExpr.cpp
@@ -20,7 +20,13 @@ using namespace llvm;
 const AMDGPUVariadicMCExpr *
 AMDGPUVariadicMCExpr::create(VariadicKind Kind, ArrayRef<const MCExpr *> Args,
                              MCContext &Ctx) {
-  return new (Ctx) AMDGPUVariadicMCExpr(Kind, Args);
+  // Storage for the argument's 'const MCExpr*' allocated through MCContext new placement which means that AMDGPUVariadicMCExpr objects and all of its contents will now be allocated through MCContext new placement.
+  //
+  // Will result in an asan failure if allocated on the heap (e.g., through SmallVector's grow).
+  const MCExpr **CtxArgs = new (Ctx) const MCExpr*[Args.size()];
+  for (size_t i = 0; i < Args.size(); ++i)
+    CtxArgs[i] = Args[i];
+  return new (Ctx) AMDGPUVariadicMCExpr(Kind, ArrayRef(CtxArgs, Args.size()));
 }
 
 const MCExpr *AMDGPUVariadicMCExpr::getSubExpr(size_t Index) const {

--- a/llvm/lib/Target/AMDGPU/MCTargetDesc/AMDGPUMCExpr.cpp
+++ b/llvm/lib/Target/AMDGPU/MCTargetDesc/AMDGPUMCExpr.cpp
@@ -46,7 +46,7 @@ void AMDGPUVariadicMCExpr::printImpl(raw_ostream &OS,
     if ((It + 1) != Args.end())
       OS << ", ";
   }
-  OS << ")";
+  OS << ')';
 }
 
 bool AMDGPUVariadicMCExpr::evaluateAsRelocatableImpl(

--- a/llvm/lib/Target/AMDGPU/MCTargetDesc/AMDGPUMCExpr.cpp
+++ b/llvm/lib/Target/AMDGPU/MCTargetDesc/AMDGPUMCExpr.cpp
@@ -1,0 +1,92 @@
+//===- AMDGPUMCExpr.cpp - AMDGPU specific MC expression classes -----------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "AMDGPUMCExpr.h"
+#include "llvm/MC/MCContext.h"
+#include "llvm/MC/MCStreamer.h"
+#include "llvm/MC/MCSymbol.h"
+#include "llvm/MC/MCValue.h"
+#include "llvm/Support/Allocator.h"
+#include "llvm/Support/raw_ostream.h"
+
+using namespace llvm;
+
+const AMDGPUVariadicMCExpr *
+AMDGPUVariadicMCExpr::create(AMDGPUVariadicKind Kind,
+                             const std::vector<const MCExpr *> &Args,
+                             MCContext &Ctx) {
+  return new (Ctx) AMDGPUVariadicMCExpr(Kind, Args);
+}
+
+const MCExpr *AMDGPUVariadicMCExpr::getSubExpr(size_t index) const {
+  assert(index < Args.size() &&
+         "Indexing out of bounds AMDGPUVariadicMCExpr sub-expr");
+  return Args[index];
+}
+
+void AMDGPUVariadicMCExpr::printImpl(raw_ostream &OS,
+                                     const MCAsmInfo *MAI) const {
+  switch (Kind) {
+  default:
+    llvm_unreachable("Unknown AMDGPUVariadicMCExpr kind.");
+  case AGVK_Or:
+    OS << "or(";
+    break;
+  case AGVK_Max:
+    OS << "max(";
+    break;
+  }
+  for (auto it = Args.begin(); it != Args.end(); ++it) {
+    (*it)->print(OS, MAI, /*InParens=*/false);
+    if ((it + 1) != Args.end())
+      OS << ", ";
+  }
+  OS << ")";
+}
+
+bool AMDGPUVariadicMCExpr::evaluateAsRelocatableImpl(
+    MCValue &Res, const MCAsmLayout *Layout, const MCFixup *Fixup) const {
+  int64_t total = 0;
+
+  auto Op = [this](int64_t Arg1, int64_t Arg2) -> int64_t {
+    switch (Kind) {
+    default:
+      llvm_unreachable("Unknown AMDGPUVariadicMCExpr kind.");
+    case AGVK_Max:
+      return Arg1 > Arg2 ? Arg1 : Arg2;
+    case AGVK_Or:
+      return (!!Arg1) || (!!Arg2);
+    }
+  };
+
+  for (const MCExpr *Arg : Args) {
+    MCValue ArgRes;
+    if (!Arg->evaluateAsRelocatable(ArgRes, Layout, Fixup))
+      return false;
+    if (!ArgRes.isAbsolute())
+      return false;
+    total = Op(total, ArgRes.getConstant());
+  }
+
+  Res = MCValue::get(total);
+  return true;
+}
+
+void AMDGPUVariadicMCExpr::visitUsedExpr(MCStreamer &Streamer) const {
+  for (const MCExpr *Arg : Args) {
+    Streamer.visitUsedExpr(*Arg);
+  }
+}
+
+MCFragment *AMDGPUVariadicMCExpr::findAssociatedFragment() const {
+  for (const MCExpr *Arg : Args) {
+    if (Arg->findAssociatedFragment())
+      return Arg->findAssociatedFragment();
+  }
+  return nullptr;
+}

--- a/llvm/lib/Target/AMDGPU/MCTargetDesc/AMDGPUMCExpr.cpp
+++ b/llvm/lib/Target/AMDGPU/MCTargetDesc/AMDGPUMCExpr.cpp
@@ -18,15 +18,15 @@
 using namespace llvm;
 
 const AMDGPUVariadicMCExpr *
-AMDGPUVariadicMCExpr::create(AMDGPUVariadicKind Kind,
-                             ArrayRef<const MCExpr *> Args, MCContext &Ctx) {
+AMDGPUVariadicMCExpr::create(VariadicKind Kind, ArrayRef<const MCExpr *> Args,
+                             MCContext &Ctx) {
   return new (Ctx) AMDGPUVariadicMCExpr(Kind, Args);
 }
 
-const MCExpr *AMDGPUVariadicMCExpr::GetSubExpr(size_t index) const {
-  assert(index < Args.size() &&
+const MCExpr *AMDGPUVariadicMCExpr::getSubExpr(size_t Index) const {
+  assert(Index < Args.size() &&
          "Indexing out of bounds AMDGPUVariadicMCExpr sub-expr");
-  return Args[index];
+  return Args[Index];
 }
 
 void AMDGPUVariadicMCExpr::printImpl(raw_ostream &OS,
@@ -49,14 +49,14 @@ void AMDGPUVariadicMCExpr::printImpl(raw_ostream &OS,
   OS << ')';
 }
 
-static int64_t Op(AMDGPUVariadicMCExpr::AMDGPUVariadicKind Kind, int64_t Arg1,
+static int64_t op(AMDGPUVariadicMCExpr::VariadicKind Kind, int64_t Arg1,
                   int64_t Arg2) {
   switch (Kind) {
   default:
     llvm_unreachable("Unknown AMDGPUVariadicMCExpr kind.");
-  case AMDGPUVariadicMCExpr::AMDGPUVariadicKind::AGVK_Max:
+  case AMDGPUVariadicMCExpr::AGVK_Max:
     return std::max(Arg1, Arg2);
-  case AMDGPUVariadicMCExpr::AMDGPUVariadicKind::AGVK_Or:
+  case AMDGPUVariadicMCExpr::AGVK_Or:
     return Arg1 || Arg2;
   }
 }
@@ -73,7 +73,7 @@ bool AMDGPUVariadicMCExpr::evaluateAsRelocatableImpl(
 
     if (!Total.has_value())
       Total = ArgRes.getConstant();
-    Total = Op(Kind, *Total, ArgRes.getConstant());
+    Total = op(Kind, *Total, ArgRes.getConstant());
   }
 
   Res = MCValue::get(*Total);

--- a/llvm/lib/Target/AMDGPU/MCTargetDesc/AMDGPUMCExpr.cpp
+++ b/llvm/lib/Target/AMDGPU/MCTargetDesc/AMDGPUMCExpr.cpp
@@ -57,7 +57,7 @@ static int64_t op(AMDGPUVariadicMCExpr::VariadicKind Kind, int64_t Arg1,
   case AMDGPUVariadicMCExpr::AGVK_Max:
     return std::max(Arg1, Arg2);
   case AMDGPUVariadicMCExpr::AGVK_Or:
-    return Arg1 || Arg2;
+    return Arg1 | Arg2;
   }
 }
 

--- a/llvm/lib/Target/AMDGPU/MCTargetDesc/AMDGPUMCExpr.h
+++ b/llvm/lib/Target/AMDGPU/MCTargetDesc/AMDGPUMCExpr.h
@@ -10,7 +10,6 @@
 #define LLVM_LIB_TARGET_AMDGPU_MCTARGETDESC_AMDGPUMCEXPR_H
 
 #include "llvm/ADT/ArrayRef.h"
-#include "llvm/ADT/SmallVector.h"
 #include "llvm/MC/MCExpr.h"
 
 namespace llvm {
@@ -31,7 +30,7 @@ public:
 
 private:
   VariadicKind Kind;
-  SmallVector<const MCExpr *, 2> Args;
+  ArrayRef<const MCExpr *> Args;
 
   AMDGPUVariadicMCExpr(VariadicKind Kind, ArrayRef<const MCExpr *> Args)
       : Kind(Kind), Args(Args) {

--- a/llvm/lib/Target/AMDGPU/MCTargetDesc/AMDGPUMCExpr.h
+++ b/llvm/lib/Target/AMDGPU/MCTargetDesc/AMDGPUMCExpr.h
@@ -30,14 +30,13 @@ public:
 
 private:
   VariadicKind Kind;
+  MCContext &Ctx;
+  const MCExpr **RawArgs;
   ArrayRef<const MCExpr *> Args;
 
-  AMDGPUVariadicMCExpr(VariadicKind Kind, ArrayRef<const MCExpr *> Args)
-      : Kind(Kind), Args(Args) {
-    assert(Args.size() >= 1 && "Needs a minimum of one expression.");
-    assert(Kind != AGVK_None &&
-           "Cannot construct AMDGPUVariadicMCExpr of kind none.");
-  }
+  AMDGPUVariadicMCExpr(VariadicKind Kind, ArrayRef<const MCExpr *> Args,
+                       MCContext &Ctx);
+  ~AMDGPUVariadicMCExpr();
 
 public:
   static const AMDGPUVariadicMCExpr *

--- a/llvm/lib/Target/AMDGPU/MCTargetDesc/AMDGPUMCExpr.h
+++ b/llvm/lib/Target/AMDGPU/MCTargetDesc/AMDGPUMCExpr.h
@@ -1,0 +1,64 @@
+//===- AMDGPUMCExpr.h - AMDGPU specific MC expression classes ---*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIB_TARGET_AMDGPU_MCTARGETDESC_AMDGPUMCEXPR_H
+#define LLVM_LIB_TARGET_AMDGPU_MCTARGETDESC_AMDGPUMCEXPR_H
+
+#include "llvm/MC/MCExpr.h"
+
+namespace llvm {
+
+class AMDGPUMCExpr : public MCTargetExpr {
+  static bool classof(const MCExpr *E) {
+    return E->getKind() == MCExpr::Target;
+  }
+  void fixELFSymbolsInTLSFixups(MCAssembler &) const override{};
+};
+
+class AMDGPUVariadicMCExpr : public AMDGPUMCExpr {
+public:
+  enum AMDGPUVariadicKind { AGVK_None, AGVK_Or, AGVK_Max };
+
+private:
+  AMDGPUVariadicKind Kind;
+  std::vector<const MCExpr *> Args;
+
+  AMDGPUVariadicMCExpr(AMDGPUVariadicKind Kind,
+                       const std::vector<const MCExpr *> &Args)
+      : Kind(Kind), Args(Args) {
+    assert(Args.size() >= 1 && "Can't take the maximum of 0 expressions.");
+  }
+
+public:
+  static const AMDGPUVariadicMCExpr *
+  create(AMDGPUVariadicKind Kind, const std::vector<const MCExpr *> &Args,
+         MCContext &Ctx);
+
+  static const AMDGPUVariadicMCExpr *
+  createOr(const std::vector<const MCExpr *> &Args, MCContext &Ctx) {
+    return create(AMDGPUVariadicKind::AGVK_Or, Args, Ctx);
+  }
+
+  static const AMDGPUVariadicMCExpr *
+  createMax(const std::vector<const MCExpr *> &Args, MCContext &Ctx) {
+    return create(AMDGPUVariadicKind::AGVK_Max, Args, Ctx);
+  }
+
+  AMDGPUVariadicKind getKind() const { return Kind; }
+  const MCExpr *getSubExpr(size_t index) const;
+
+  void printImpl(raw_ostream &OS, const MCAsmInfo *MAI) const override;
+  bool evaluateAsRelocatableImpl(MCValue &Res, const MCAsmLayout *Layout,
+                                 const MCFixup *Fixup) const override;
+  void visitUsedExpr(MCStreamer &Streamer) const override;
+  MCFragment *findAssociatedFragment() const override;
+};
+
+} // end namespace llvm
+
+#endif // LLVM_LIB_TARGET_AMDGPU_MCTARGETDESC_AMDGPUMCEXPR_H

--- a/llvm/lib/Target/AMDGPU/MCTargetDesc/AMDGPUMCExpr.h
+++ b/llvm/lib/Target/AMDGPU/MCTargetDesc/AMDGPUMCExpr.h
@@ -19,7 +19,7 @@ namespace llvm {
 ///
 /// Takes in a minimum of 1 argument to be used with an operation. The supported
 /// operations are:
-///   - (logic) or
+///   - (bitwise) or
 ///   - max
 ///
 /// \note If the 'or'/'max' operations are provided only a single argument, the

--- a/llvm/lib/Target/AMDGPU/MCTargetDesc/AMDGPUMCExpr.h
+++ b/llvm/lib/Target/AMDGPU/MCTargetDesc/AMDGPUMCExpr.h
@@ -22,6 +22,9 @@ namespace llvm {
 ///   - (logic) or
 ///   - max
 ///
+/// \note If the 'or'/'max' operations are provided only a single argument, the
+/// operation will act as a no-op and simply resolve as the provided argument.
+///
 class AMDGPUVariadicMCExpr : public MCTargetExpr {
 public:
   enum AMDGPUVariadicKind { AGVK_None, AGVK_Or, AGVK_Max };
@@ -51,17 +54,18 @@ public:
   }
 
   AMDGPUVariadicKind getKind() const { return Kind; }
-  const MCExpr *getSubExpr(size_t index) const;
+  const MCExpr *GetSubExpr(size_t index) const;
 
   void printImpl(raw_ostream &OS, const MCAsmInfo *MAI) const override;
   bool evaluateAsRelocatableImpl(MCValue &Res, const MCAsmLayout *Layout,
                                  const MCFixup *Fixup) const override;
   void visitUsedExpr(MCStreamer &Streamer) const override;
   MCFragment *findAssociatedFragment() const override;
+  void fixELFSymbolsInTLSFixups(MCAssembler &) const override{};
+
   static bool classof(const MCExpr *E) {
     return E->getKind() == MCExpr::Target;
   }
-  void fixELFSymbolsInTLSFixups(MCAssembler &) const override{};
 };
 
 } // end namespace llvm

--- a/llvm/lib/Target/AMDGPU/MCTargetDesc/AMDGPUMCExpr.h
+++ b/llvm/lib/Target/AMDGPU/MCTargetDesc/AMDGPUMCExpr.h
@@ -27,34 +27,35 @@ namespace llvm {
 ///
 class AMDGPUVariadicMCExpr : public MCTargetExpr {
 public:
-  enum AMDGPUVariadicKind { AGVK_None, AGVK_Or, AGVK_Max };
+  enum VariadicKind { AGVK_None, AGVK_Or, AGVK_Max };
 
 private:
-  AMDGPUVariadicKind Kind;
+  VariadicKind Kind;
   SmallVector<const MCExpr *, 2> Args;
 
-  AMDGPUVariadicMCExpr(AMDGPUVariadicKind Kind, ArrayRef<const MCExpr *> Args)
+  AMDGPUVariadicMCExpr(VariadicKind Kind, ArrayRef<const MCExpr *> Args)
       : Kind(Kind), Args(Args) {
     assert(Args.size() >= 1 && "Needs a minimum of one expression.");
+    assert(Kind != AGVK_None &&
+           "Cannot construct AMDGPUVariadicMCExpr of kind none.");
   }
 
 public:
-  static const AMDGPUVariadicMCExpr *create(AMDGPUVariadicKind Kind,
-                                            ArrayRef<const MCExpr *> Args,
-                                            MCContext &Ctx);
+  static const AMDGPUVariadicMCExpr *
+  create(VariadicKind Kind, ArrayRef<const MCExpr *> Args, MCContext &Ctx);
 
   static const AMDGPUVariadicMCExpr *createOr(ArrayRef<const MCExpr *> Args,
                                               MCContext &Ctx) {
-    return create(AMDGPUVariadicKind::AGVK_Or, Args, Ctx);
+    return create(VariadicKind::AGVK_Or, Args, Ctx);
   }
 
   static const AMDGPUVariadicMCExpr *createMax(ArrayRef<const MCExpr *> Args,
                                                MCContext &Ctx) {
-    return create(AMDGPUVariadicKind::AGVK_Max, Args, Ctx);
+    return create(VariadicKind::AGVK_Max, Args, Ctx);
   }
 
-  AMDGPUVariadicKind getKind() const { return Kind; }
-  const MCExpr *GetSubExpr(size_t index) const;
+  VariadicKind getKind() const { return Kind; }
+  const MCExpr *getSubExpr(size_t Index) const;
 
   void printImpl(raw_ostream &OS, const MCAsmInfo *MAI) const override;
   bool evaluateAsRelocatableImpl(MCValue &Res, const MCAsmLayout *Layout,

--- a/llvm/lib/Target/AMDGPU/MCTargetDesc/CMakeLists.txt
+++ b/llvm/lib/Target/AMDGPU/MCTargetDesc/CMakeLists.txt
@@ -5,6 +5,7 @@ add_llvm_component_library(LLVMAMDGPUDesc
   AMDGPUInstPrinter.cpp
   AMDGPUMCAsmInfo.cpp
   AMDGPUMCCodeEmitter.cpp
+  AMDGPUMCExpr.cpp
   AMDGPUMCTargetDesc.cpp
   AMDGPUTargetStreamer.cpp
   R600InstPrinter.cpp

--- a/llvm/test/MC/AMDGPU/mcexpr_amd.s
+++ b/llvm/test/MC/AMDGPU/mcexpr_amd.s
@@ -29,16 +29,16 @@
 // OBJDUMP-NEXT: 8000000000000000 l       *ABS*  0000000000000000 max_expr_one_min
 // OBJDUMP-NEXT: 0000000000000003 l       *ABS*  0000000000000000 max_expr_two_min
 // OBJDUMP-NEXT: 0000000000989680 l       *ABS*  0000000000000000 max_expr_three_min
-// OBJDUMP-NEXT: 0000000000000001 l       *ABS*  0000000000000000 or_expression_all
-// OBJDUMP-NEXT: 0000000000000001 l       *ABS*  0000000000000000 or_expression_two
+// OBJDUMP-NEXT: 0000000000000007 l       *ABS*  0000000000000000 or_expression_all
+// OBJDUMP-NEXT: 0000000000000003 l       *ABS*  0000000000000000 or_expression_two
 // OBJDUMP-NEXT: 0000000000000001 l       *ABS*  0000000000000000 or_expression_one
-// OBJDUMP-NEXT: 0000000000000001 l       *ABS*  0000000000000000 or_literals
+// OBJDUMP-NEXT: 000000000000000f l       *ABS*  0000000000000000 or_literals
 // OBJDUMP-NEXT: 0000000000000000 l       *ABS*  0000000000000000 or_false
-// OBJDUMP-NEXT: 0000000000000001 l       *ABS*  0000000000000000 or_with_or_sym
+// OBJDUMP-NEXT: 00000000000000ff l       *ABS*  0000000000000000 or_with_or_sym
 // OBJDUMP-NEXT: 00000000000000ff l       *ABS*  0000000000000000 or
-// OBJDUMP-NEXT: 0000000000000001 l       *ABS*  0000000000000000 or_with_subexpr
-// OBJDUMP-NEXT: 0000000000000002 l       *ABS*  0000000000000000 or_as_subexpr
-// OBJDUMP-NEXT: 0000000000000001 l       *ABS*  0000000000000000 or_recursive_subexpr
+// OBJDUMP-NEXT: 0000000000000003 l       *ABS*  0000000000000000 or_with_subexpr
+// OBJDUMP-NEXT: 0000000000000008 l       *ABS*  0000000000000000 or_as_subexpr
+// OBJDUMP-NEXT: 0000000000000007 l       *ABS*  0000000000000000 or_recursive_subexpr
 
 // ASM: .set zero, 0
 // ASM: .set one, 1
@@ -98,9 +98,9 @@
 .set max_expr_three_min, max(i64_min, three, 10000000)
 
 // ASM: .set or_expression_all, or(1, 2, five, 3, four)
-// ASM: .set or_expression_two, 1
+// ASM: .set or_expression_two, 3
 // ASM: .set or_expression_one, 1
-// ASM: .set or_literals, 1
+// ASM: .set or_literals, 15
 // ASM: .set or_false, 0
 // ASM: .set or_with_or_sym, or(or, 4, 3, 1, 2)
 
@@ -111,7 +111,7 @@
 .set or_false, or(zero, 0, (2-2), 5 > 6)
 .set or_with_or_sym, or(or, 4, 3, one, two)
 
-// ASM: .set or_with_subexpr, 1
+// ASM: .set or_with_subexpr, 3
 // ASM: .set or_as_subexpr, 1+(or(4, 3, five))
 // ASM: .set or_recursive_subexpr, or(or(1, four), 3, or_expression_all)
 

--- a/llvm/test/MC/AMDGPU/mcexpr_amd.s
+++ b/llvm/test/MC/AMDGPU/mcexpr_amd.s
@@ -7,6 +7,8 @@
 // OBJDUMP-NEXT: 0000000000000001 l       *ABS*  0000000000000000 one
 // OBJDUMP-NEXT: 0000000000000002 l       *ABS*  0000000000000000 two
 // OBJDUMP-NEXT: 0000000000000003 l       *ABS*  0000000000000000 three
+// OBJDUMP-NEXT: 7fffffffffffffff l       *ABS*  0000000000000000 i64_max
+// OBJDUMP-NEXT: 8000000000000000 l       *ABS*  0000000000000000 i64_min
 // OBJDUMP-NEXT: 0000000000000005 l       *ABS*  0000000000000000 max_expression_all
 // OBJDUMP-NEXT: 0000000000000005 l       *ABS*  0000000000000000 five
 // OBJDUMP-NEXT: 0000000000000004 l       *ABS*  0000000000000000 four
@@ -21,6 +23,12 @@
 // OBJDUMP-NEXT: 0000000000000003 l       *ABS*  0000000000000000 max_with_subexpr
 // OBJDUMP-NEXT: 0000000000000006 l       *ABS*  0000000000000000 max_as_subexpr
 // OBJDUMP-NEXT: 0000000000000005 l       *ABS*  0000000000000000 max_recursive_subexpr
+// OBJDUMP-NEXT: 7fffffffffffffff l       *ABS*  0000000000000000 max_expr_one_max
+// OBJDUMP-NEXT: 7fffffffffffffff l       *ABS*  0000000000000000 max_expr_two_max
+// OBJDUMP-NEXT: 7fffffffffffffff l       *ABS*  0000000000000000 max_expr_three_max
+// OBJDUMP-NEXT: 8000000000000000 l       *ABS*  0000000000000000 max_expr_one_min
+// OBJDUMP-NEXT: 0000000000000003 l       *ABS*  0000000000000000 max_expr_two_min
+// OBJDUMP-NEXT: 0000000000989680 l       *ABS*  0000000000000000 max_expr_three_min
 // OBJDUMP-NEXT: 0000000000000001 l       *ABS*  0000000000000000 or_expression_all
 // OBJDUMP-NEXT: 0000000000000001 l       *ABS*  0000000000000000 or_expression_two
 // OBJDUMP-NEXT: 0000000000000001 l       *ABS*  0000000000000000 or_expression_one
@@ -36,11 +44,15 @@
 // ASM: .set one, 1
 // ASM: .set two, 2
 // ASM: .set three, 3
+// ASM: .set i64_max, 9223372036854775807
+// ASM: .set i64_min, -9223372036854775808
 
 .set zero, 0
 .set one, 1
 .set two, 2
 .set three, 3
+.set i64_max, 0x7FFFFFFFFFFFFFFF
+.set i64_min, 0x8000000000000000
 
 // ASM: .set max_expression_all, max(1, 2, five, 3, four)
 // ASM: .set max_expression_two, 2
@@ -68,6 +80,22 @@
 .set max_with_subexpr, max(((one | 3) << 3) / 8)
 .set max_as_subexpr, 1 + max(4, 3, five)
 .set max_recursive_subexpr, max(max(one, four), three, max_expression_all)
+
+// ASM: .set max_expr_one_max, 9223372036854775807
+// ASM: .set max_expr_two_max, max(9223372036854775807, five)
+// ASM: .set max_expr_three_max, max(9223372036854775807, five, 10000000)
+
+.set max_expr_one_max, max(i64_max)
+.set max_expr_two_max, max(i64_max, five)
+.set max_expr_three_max, max(i64_max, five, 10000000)
+
+// ASM: .set max_expr_one_min, -9223372036854775808
+// ASM: .set max_expr_two_min, 3
+// ASM: .set max_expr_three_min, 10000000
+
+.set max_expr_one_min, max(i64_min)
+.set max_expr_two_min, max(i64_min, three)
+.set max_expr_three_min, max(i64_min, three, 10000000)
 
 // ASM: .set or_expression_all, or(1, 2, five, 3, four)
 // ASM: .set or_expression_two, 1

--- a/llvm/test/MC/AMDGPU/mcexpr_amd.s
+++ b/llvm/test/MC/AMDGPU/mcexpr_amd.s
@@ -15,6 +15,9 @@
 // OBJDUMP-NEXT: 000000000000000a l       *ABS*  0000000000000000 max_literals
 // OBJDUMP-NEXT: 000000000000000f l       *ABS*  0000000000000000 max_with_max_sym
 // OBJDUMP-NEXT: 000000000000000f l       *ABS*  0000000000000000 max
+// OBJDUMP-NEXT: ffffffffffffffff l       *ABS*  0000000000000000 neg_one
+// OBJDUMP-NEXT: ffffffffffffffff l       *ABS*  0000000000000000 max_neg_numbers
+// OBJDUMP-NEXT: ffffffffffffffff l       *ABS*  0000000000000000 max_neg_number
 // OBJDUMP-NEXT: 0000000000000003 l       *ABS*  0000000000000000 max_with_subexpr
 // OBJDUMP-NEXT: 0000000000000006 l       *ABS*  0000000000000000 max_as_subexpr
 // OBJDUMP-NEXT: 0000000000000005 l       *ABS*  0000000000000000 max_recursive_subexpr
@@ -50,6 +53,13 @@
 .set max_expression_one, max(one)
 .set max_literals, max(1,2,3,4,5,6,7,8,9,10)
 .set max_with_max_sym, max(max, 4, 3, one, two)
+
+// ASM: .set max_neg_numbers, -1
+// ASM: .set max_neg_number, -1
+
+.set neg_one, -1
+.set max_neg_numbers, max(-5, -4, -3, -2, neg_one)
+.set max_neg_number, max(neg_one)
 
 // ASM: .set max_with_subexpr, 3
 // ASM: .set max_as_subexpr, 1+(max(4, 3, five))

--- a/llvm/test/MC/AMDGPU/mcexpr_amd.s
+++ b/llvm/test/MC/AMDGPU/mcexpr_amd.s
@@ -1,0 +1,92 @@
+// RUN: llvm-mc -triple amdgcn-amd-amdhsa < %s | FileCheck --check-prefix=ASM %s
+// RUN: llvm-mc -triple amdgcn-amd-amdhsa -filetype=obj < %s > %t
+// RUN: llvm-objdump --syms %t | FileCheck --check-prefix=OBJDUMP %s
+
+// OBJDUMP: SYMBOL TABLE:
+// OBJDUMP-NEXT: 0000000000000000 l       *ABS*  0000000000000000 zero
+// OBJDUMP-NEXT: 0000000000000001 l       *ABS*  0000000000000000 one
+// OBJDUMP-NEXT: 0000000000000002 l       *ABS*  0000000000000000 two
+// OBJDUMP-NEXT: 0000000000000003 l       *ABS*  0000000000000000 three
+// OBJDUMP-NEXT: 0000000000000005 l       *ABS*  0000000000000000 max_expression_all
+// OBJDUMP-NEXT: 0000000000000005 l       *ABS*  0000000000000000 five
+// OBJDUMP-NEXT: 0000000000000004 l       *ABS*  0000000000000000 four
+// OBJDUMP-NEXT: 0000000000000002 l       *ABS*  0000000000000000 max_expression_two
+// OBJDUMP-NEXT: 0000000000000001 l       *ABS*  0000000000000000 max_expression_one
+// OBJDUMP-NEXT: 000000000000000a l       *ABS*  0000000000000000 max_literals
+// OBJDUMP-NEXT: 000000000000000f l       *ABS*  0000000000000000 max_with_max_sym
+// OBJDUMP-NEXT: 000000000000000f l       *ABS*  0000000000000000 max
+// OBJDUMP-NEXT: 0000000000000003 l       *ABS*  0000000000000000 max_with_subexpr
+// OBJDUMP-NEXT: 0000000000000006 l       *ABS*  0000000000000000 max_as_subexpr
+// OBJDUMP-NEXT: 0000000000000005 l       *ABS*  0000000000000000 max_recursive_subexpr
+// OBJDUMP-NEXT: 0000000000000001 l       *ABS*  0000000000000000 or_expression_all
+// OBJDUMP-NEXT: 0000000000000001 l       *ABS*  0000000000000000 or_expression_two
+// OBJDUMP-NEXT: 0000000000000001 l       *ABS*  0000000000000000 or_expression_one
+// OBJDUMP-NEXT: 0000000000000001 l       *ABS*  0000000000000000 or_literals
+// OBJDUMP-NEXT: 0000000000000000 l       *ABS*  0000000000000000 or_false
+// OBJDUMP-NEXT: 0000000000000001 l       *ABS*  0000000000000000 or_with_or_sym
+// OBJDUMP-NEXT: 00000000000000ff l       *ABS*  0000000000000000 or
+// OBJDUMP-NEXT: 0000000000000001 l       *ABS*  0000000000000000 or_with_subexpr
+// OBJDUMP-NEXT: 0000000000000002 l       *ABS*  0000000000000000 or_as_subexpr
+// OBJDUMP-NEXT: 0000000000000001 l       *ABS*  0000000000000000 or_recursive_subexpr
+
+// ASM: .set zero, 0
+// ASM: .set one, 1
+// ASM: .set two, 2
+// ASM: .set three, 3
+
+.set zero, 0
+.set one, 1
+.set two, 2
+.set three, 3
+
+// ASM: .set max_expression_all, max(1, 2, five, 3, four)
+// ASM: .set max_expression_two, 2
+// ASM: .set max_expression_one, 1
+// ASM: .set max_literals, 10
+// ASM: .set max_with_max_sym, max(max, 4, 3, 1, 2)
+
+.set max_expression_all, max(one, two, five, three, four)
+.set max_expression_two, max(one, two)
+.set max_expression_one, max(one)
+.set max_literals, max(1,2,3,4,5,6,7,8,9,10)
+.set max_with_max_sym, max(max, 4, 3, one, two)
+
+// ASM: .set max_with_subexpr, 3
+// ASM: .set max_as_subexpr, 1+(max(4, 3, five))
+// ASM: .set max_recursive_subexpr, max(max(1, four), 3, max_expression_all)
+
+.set max_with_subexpr, max(((one | 3) << 3) / 8)
+.set max_as_subexpr, 1 + max(4, 3, five)
+.set max_recursive_subexpr, max(max(one, four), three, max_expression_all)
+
+// ASM: .set or_expression_all, or(1, 2, five, 3, four)
+// ASM: .set or_expression_two, 1
+// ASM: .set or_expression_one, 1
+// ASM: .set or_literals, 1
+// ASM: .set or_false, 0
+// ASM: .set or_with_or_sym, or(or, 4, 3, 1, 2)
+
+.set or_expression_all, or(one, two, five, three, four)
+.set or_expression_two, or(one, two)
+.set or_expression_one, or(one)
+.set or_literals, or(1,2,3,4,5,6,7,8,9,10)
+.set or_false, or(zero, 0, (2-2), 5 > 6)
+.set or_with_or_sym, or(or, 4, 3, one, two)
+
+// ASM: .set or_with_subexpr, 1
+// ASM: .set or_as_subexpr, 1+(or(4, 3, five))
+// ASM: .set or_recursive_subexpr, or(or(1, four), 3, or_expression_all)
+
+.set or_with_subexpr, or(((one | 3) << 3) / 8)
+.set or_as_subexpr, 1 + or(4, 3, five)
+.set or_recursive_subexpr, or(or(one, four), three, or_expression_all)
+
+// ASM: .set four, 4
+// ASM: .set five, 5
+// ASM: .set max, 15
+// ASM: .set or, 255
+
+.set four, 4
+.set five, 5
+.set max, 0xF
+.set or, 0xFF

--- a/llvm/test/MC/AMDGPU/mcexpr_amd_err.s
+++ b/llvm/test/MC/AMDGPU/mcexpr_amd_err.s
@@ -1,29 +1,44 @@
 // RUN: not llvm-mc -triple amdgcn-amd-amdhsa %s 2>&1 | FileCheck --check-prefix=ASM %s
 
-// ASM: 20:22: error: empty max expression
-// ASM: 20:22: error: missing expression
-// ASM: 21:20: error: empty or expression
-// ASM: 21:20: error: missing expression
-// ASM: 23:29: error: unknown token in expression
-// ASM: 23:29: error: missing expression
-// ASM: 24:32: error: unexpected token in max expression
-// ASM: 24:32: error: missing expression
-// ASM: 25:42: error: unknown token in expression
-// ASM: 25:42: error: missing expression
-// ASM: 26:38: error: unexpected token in or expression
-// ASM: 26:38: error: missing expression
-
 .set one, 1
 .set two, 2
 .set three, 3
 
 .set max_empty, max()
+// ASM: :[[@LINE-1]]:{{[0-9]+}}: error: empty max expression
+// ASM: :[[@LINE-2]]:{{[0-9]+}}: error: missing expression
+
 .set or_empty, or()
+// ASM: :[[@LINE-1]]:{{[0-9]+}}: error: empty or expression
+// ASM: :[[@LINE-2]]:{{[0-9]+}}: error: missing expression
+
 .set max_post_aux_comma, max(one,)
+// ASM: :[[@LINE-1]]:{{[0-9]+}}: error: mismatch of commas in max expression
+// ASM: :[[@LINE-2]]:{{[0-9]+}}: error: missing expression
+
 .set max_pre_aux_comma, max(,one)
+// asm: :[[@line-1]]:{{[0-9]+}}: error: unknown token in expression
+// ASM: :[[@LINE-2]]:{{[0-9]+}}: error: missing expression
+
+.set max_double_comma, max(one,, two)
+// ASM: :[[@LINE-1]]:{{[0-9]+}}: error: unknown token in expression
+// ASM: :[[@LINE-2]]:{{[0-9]+}}: error: missing expression
+
+.set max_no_comma, max(one two)
+// ASM: :[[@LINE-1]]:{{[0-9]+}}: error: unexpected token in max expression
+// ASM: :[[@LINE-2]]:{{[0-9]+}}: error: missing expression
+
 .set max_missing_paren, max(two
+// ASM: :[[@LINE-1]]:{{[0-9]+}}: error: unexpected token in max expression
+// ASM: :[[@LINE-2]]:{{[0-9]+}}: error: missing expression
+
 .set max_expression_one, max(three, four,
+// ASM: :[[@LINE-1]]:{{[0-9]+}}: error: unknown token in expression
+// ASM: :[[@LINE-2]]:{{[0-9]+}}: error: missing expression
+
 .set or_expression_one, or(four, five
+// ASM: :[[@LINE-1]]:{{[0-9]+}}: error: unexpected token in or expression
+// ASM: :[[@LINE-2]]:{{[0-9]+}}: error: missing expression
 
 .set four, 4
 .set five, 5

--- a/llvm/test/MC/AMDGPU/mcexpr_amd_err.s
+++ b/llvm/test/MC/AMDGPU/mcexpr_amd_err.s
@@ -1,0 +1,26 @@
+// RUN: not llvm-mc -triple amdgcn-amd-amdhsa %s 2>&1 | FileCheck --check-prefix=ASM %s
+
+// ASM: error: empty max/or expression
+// ASM: error: missing expression
+// ASM: error: unknown token in expression
+// ASM: error: missing expression
+// ASM: error: unexpected token in max/or expression
+// ASM: error: missing expression
+// ASM: error: unknown token in expression
+// ASM: error: missing expression
+// ASM: error: unexpected token in max/or expression
+// ASM: error: missing expression
+
+.set one, 1
+.set two, 2
+.set three, 3
+
+.set max_empty, max()
+.set max_post_aux_comma, max(one,)
+.set max_pre_aux_comma, max(,one)
+.set max_missing_paren, max(two
+.set max_expression_one, max(three, four,
+.set max_expression_one, max(four, five
+
+.set four, 4
+.set five, 5

--- a/llvm/test/MC/AMDGPU/mcexpr_amd_err.s
+++ b/llvm/test/MC/AMDGPU/mcexpr_amd_err.s
@@ -1,14 +1,16 @@
 // RUN: not llvm-mc -triple amdgcn-amd-amdhsa %s 2>&1 | FileCheck --check-prefix=ASM %s
 
-// ASM: error: empty max/or expression
+// ASM: error: empty max expression
+// ASM: error: missing expression
+// ASM: error: empty or expression
 // ASM: error: missing expression
 // ASM: error: unknown token in expression
 // ASM: error: missing expression
-// ASM: error: unexpected token in max/or expression
+// ASM: error: unexpected token in max expression
 // ASM: error: missing expression
 // ASM: error: unknown token in expression
 // ASM: error: missing expression
-// ASM: error: unexpected token in max/or expression
+// ASM: error: unexpected token in or expression
 // ASM: error: missing expression
 
 .set one, 1
@@ -16,11 +18,12 @@
 .set three, 3
 
 .set max_empty, max()
+.set or_empty, or()
 .set max_post_aux_comma, max(one,)
 .set max_pre_aux_comma, max(,one)
 .set max_missing_paren, max(two
 .set max_expression_one, max(three, four,
-.set max_expression_one, max(four, five
+.set or_expression_one, or(four, five
 
 .set four, 4
 .set five, 5

--- a/llvm/test/MC/AMDGPU/mcexpr_amd_err.s
+++ b/llvm/test/MC/AMDGPU/mcexpr_amd_err.s
@@ -40,5 +40,14 @@
 // ASM: :[[@LINE-1]]:{{[0-9]+}}: error: unexpected token in or expression
 // ASM: :[[@LINE-2]]:{{[0-9]+}}: error: missing expression
 
+.set max_no_lparen, max four, five)
+// ASM: :[[@LINE-1]]:{{[0-9]+}}: error: expected newline
+
+.set max_no_paren, max one, two, three
+// ASM: :[[@LINE-1]]:{{[0-9]+}}: error: expected newline
+
+.set max_rparen_only, max)
+// ASM: :[[@LINE-1]]:{{[0-9]+}}: error: expected newline
+
 .set four, 4
 .set five, 5

--- a/llvm/test/MC/AMDGPU/mcexpr_amd_err.s
+++ b/llvm/test/MC/AMDGPU/mcexpr_amd_err.s
@@ -1,17 +1,17 @@
 // RUN: not llvm-mc -triple amdgcn-amd-amdhsa %s 2>&1 | FileCheck --check-prefix=ASM %s
 
-// ASM: error: empty max expression
-// ASM: error: missing expression
-// ASM: error: empty or expression
-// ASM: error: missing expression
-// ASM: error: unknown token in expression
-// ASM: error: missing expression
-// ASM: error: unexpected token in max expression
-// ASM: error: missing expression
-// ASM: error: unknown token in expression
-// ASM: error: missing expression
-// ASM: error: unexpected token in or expression
-// ASM: error: missing expression
+// ASM: 20:22: error: empty max expression
+// ASM: 20:22: error: missing expression
+// ASM: 21:20: error: empty or expression
+// ASM: 21:20: error: missing expression
+// ASM: 23:29: error: unknown token in expression
+// ASM: 23:29: error: missing expression
+// ASM: 24:32: error: unexpected token in max expression
+// ASM: 24:32: error: missing expression
+// ASM: 25:42: error: unknown token in expression
+// ASM: 25:42: error: missing expression
+// ASM: 26:38: error: unexpected token in or expression
+// ASM: 26:38: error: missing expression
 
 .set one, 1
 .set two, 2


### PR DESCRIPTION
Adds AMDGPU specific variadic MCExpr operations 'max' and 'or'. Required for moving function/program resource usage information propagation to MC layer as propagation of the maximum and logic OR values will go through MCExprs. Propagation of said resource usage info through these MCExpr operations compared to current handling in AMDGPUResourceUsageAnalysis will ease the constraint on the order for a function's resource usage analysis as the symbolic definition of a resource can occur after its use.

Previous merge with main triggered asan memory leaks as shown in https://github.com/llvm/llvm-project/pull/82022#issuecomment-1982288737 by @fmayer. The leak was caused by SmallVector's grow functionality that got invoked as the variadic argument count exceeds the local storage limit (and results in heap allocation). However, MCTargetExpr and all its derived classes do not deallocate meaning any normal heap allocation within AMDGPUVariadicMCExpr does not have a paired deallocation. As a solution, the storage used by AMDGPUVariadicMCExpr for its variadic MCExpr container is now bump-allocated as well through the MCContext allocation.

Relands #82022 with fixes