### PR TITLE
github-upload-release.py: Fix bug preventing release creation

### DIFF
--- a/llvm/utils/release/github-upload-release.py
+++ b/llvm/utils/release/github-upload-release.py
@@ -107,6 +107,6 @@ elif args.command == "check-permissions":
     sys.exit(1)
 
 if args.command == "create":
-    create_release(llvm_repo, args.release, args.user)
+    create_release(llvm_repo, args.release)
 if args.command == "upload":
     upload_files(llvm_repo, args.release, args.files)


### PR DESCRIPTION
After aa02002491333c42060373bc84f1ff5d2c76b4ce we started passing the user name to the create_release function and this was being interpreted as the git tag.