### PR TITLE
[clang-fuzzer] Set the link language for dictionary

### DIFF
--- a/clang/tools/clang-fuzzer/dictionary/CMakeLists.txt
+++ b/clang/tools/clang-fuzzer/dictionary/CMakeLists.txt
@@ -2,3 +2,7 @@ add_clang_executable(clang-fuzzer-dictionary
   dictionary.c
   )
 
+set_target_properties(clang-fuzzer-dictionary
+  PROPERTIES
+  LINKER_LANGUAGE CXX
+  )


### PR DESCRIPTION
clang-fuzzer-dictionary is a C-source tool so by default doesn't link with CMake's specified C++ libraries, which are needed for libclang.

(This fixes issues building with C++ libraries other than the system default)