### PR TITLE
[NFC][AMDGPU] Fix redundant assignment from #77952

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPULowerBufferFatPointers.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPULowerBufferFatPointers.cpp
@@ -1671,7 +1671,7 @@ PtrParts SplitPtrStructs::visitSelectInst(SelectInst &SI) {
   auto [TrueRsrc, TrueOff] = getPtrParts(True);
   auto [FalseRsrc, FalseOff] = getPtrParts(False);
 
-  Value *RsrcRes = RsrcRes =
+  Value *RsrcRes =
       IRB.CreateSelect(Cond, TrueRsrc, FalseRsrc, SI.getName() + ".rsrc", &SI);
   copyMetadata(RsrcRes, &SI);
   Conditionals.push_back(&SI);


### PR DESCRIPTION
Someone pointed out a typo (Value* RsrcRes = RsrcRes = ...) in PR the address space 7 lowering, this commit fixes it.