### PR TITLE
[RemoveDIs] Fix nullptr dereference in getFirstNonPHIIt()

### DIFF
--- a/llvm/lib/IR/BasicBlock.cpp
+++ b/llvm/lib/IR/BasicBlock.cpp
@@ -348,6 +348,8 @@ const Instruction* BasicBlock::getFirstNonPHI() const {
 
 BasicBlock::const_iterator BasicBlock::getFirstNonPHIIt() const {
   const Instruction *I = getFirstNonPHI();
+  if (!I)
+    return end();
   BasicBlock::const_iterator It = I->getIterator();
   // Set the head-inclusive bit to indicate that this iterator includes
   // any debug-info at the start of the block. This is a no-op unless the


### PR DESCRIPTION
getFirstNonPHI() returns nullptr for blocks that lack a non-phi (including a terminator) but getFirstNonPHIIt() may dereference its result unconditionally. Return end() instead.

This came up for us downstream while correcting our getFirstNonPHI() calls that intended to return the position after the phi's but before the debug info to getFirstNonPHIIt(). The pass in question is populating new BB's and hasn't added terminators yet.