### PR TITLE
[hwasan] Fix DCHECK with COMPILER_RT_DEBUG=ON

### DIFF
--- a/compiler-rt/lib/hwasan/hwasan_checks.h
+++ b/compiler-rt/lib/hwasan/hwasan_checks.h
@@ -140,7 +140,7 @@ __attribute__((always_inline, nodebug)) static inline uptr ShortTagSize(
 
 __attribute__((always_inline, nodebug)) static inline bool
 PossiblyShortTagMatches(tag_t mem_tag, uptr ptr, uptr sz) {
-  DCHECK(IsAligned(ptr, kShadowAlignment));
+  DCHECK(IsAligned(ptr, sz));
   tag_t ptr_tag = GetTagFromPointer(ptr);
   if (ptr_tag == mem_tag)
     return true;


### PR DESCRIPTION
It appears this assertion should actually be checking that the pointer
is aligned to `sz` bytes rather than the shadow alignment, since
otherwise the `(ptr & (kShadowAlignment - 1))` mask would always be 0.
