### PR TITLE
Revert "[clang] Fix crash when declaring invalid lambda member"

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -258,9 +258,6 @@ Bug Fixes in This Version
   operator.
   Fixes (#GH83267).
 
-- Fixes an assertion failure on invalid code when trying to define member
-  functions in lambdas.
-
 Bug Fixes to Compiler Builtins
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -411,7 +408,7 @@ RISC-V Support
 CUDA/HIP Language Changes
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-- PTX is no longer included by default when compiling for CUDA. Using
+- PTX is no longer included by default when compiling for CUDA. Using 
   ``--cuda-include-ptx=all`` will return the old behavior.
 
 CUDA Support

--- a/clang/lib/AST/DeclCXX.cpp
+++ b/clang/lib/AST/DeclCXX.cpp
@@ -1567,9 +1567,10 @@ bool CXXRecordDecl::isGenericLambda() const {
 
 #ifndef NDEBUG
 static bool allLookupResultsAreTheSame(const DeclContext::lookup_result &R) {
-  return llvm::all_of(R, [&](NamedDecl *D) {
-    return D->isInvalidDecl() || declaresSameEntity(D, R.front());
-  });
+  for (auto *D : R)
+    if (!declaresSameEntity(D, R.front()))
+      return false;
+  return true;
 }
 #endif
 


### PR DESCRIPTION
Reverts llvm/llvm-project#74110

Fails on many bots: https://lab.llvm.org/buildbot/#/builders/5/builds/41633