### PR TITLE
[Clang] Only check for error in C++20 mode

### DIFF
--- a/clang/test/SemaCXX/cxx23-assume.cpp
+++ b/clang/test/SemaCXX/cxx23-assume.cpp
@@ -65,8 +65,8 @@ static_assert(h(4) == sizeof(int));
 static_assert(__has_cpp_attribute(assume) == 202207L);
 static_assert(__has_attribute(assume));
 
-constexpr bool i() { // expected-error {{never produces a constant expression}}
-  [[assume(false)]]; // expected-note {{assumption evaluated to false}} expected-note {{assumption evaluated to false}} ext-warning {{C++23 extension}}
+constexpr bool i() { // ext-error {{never produces a constant expression}}
+  [[assume(false)]]; // ext-note {{assumption evaluated to false}} expected-note {{assumption evaluated to false}} ext-warning {{C++23 extension}}
   return true;
 }
 


### PR DESCRIPTION
Fix a test that was added in #81014 and which caused buildbots to fail. Only check for the ‘never produces a constant expression error’ in C++20 mode.

This fixes #84623.