### PR TITLE
[NFC] Eliminate trailing white space causing CI build failure

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -409,7 +409,7 @@ RISC-V Support
 CUDA/HIP Language Changes
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-- PTX is no longer included by default when compiling for CUDA. Using 
+- PTX is no longer included by default when compiling for CUDA. Using
   ``--cuda-include-ptx=all`` will return the old behavior.
 
 CUDA Support


### PR DESCRIPTION
To resolve the following issue in the CI build:
```
*** Checking for trailing whitespace left in Clang source files ***
+ grep -rnI '[[:blank:]]$' clang/lib clang/include clang/docs
clang/docs/ReleaseNotes.rst:412:- PTX is no longer included by default when compiling for CUDA. Using
+ echo '*** Trailing whitespace has been found in Clang source files as described above ***'
*** Trailing whitespace has been found in Clang source files as described above ***
+ exit 1
```