### PR TITLE
[libc][stdbit][c23] fixes typos in bit_width, bit_floor C type-generic macros

### DIFF
--- a/libc/include/llvm-libc-macros/stdbit-macros.h
+++ b/libc/include/llvm-libc-macros/stdbit-macros.h
@@ -274,14 +274,14 @@ inline unsigned long long stdc_bit_floor(unsigned long long x) {
       unsigned long long: stdc_has_single_bit_ull)(x)
 #define stdc_bit_width(x)                                                      \
   _Generic((x),                                                                \
-      unsigned char: stdc_bit_width_ui,                                        \
+      unsigned char: stdc_bit_width_uc,                                        \
       unsigned short: stdc_bit_width_us,                                       \
       unsigned: stdc_bit_width_ui,                                             \
       unsigned long: stdc_bit_width_ul,                                        \
       unsigned long long: stdc_bit_width_ull)(x)
 #define stdc_bit_floor(x)                                                      \
   _Generic((x),                                                                \
-      unsigned char: stdc_bit_floor_ui,                                        \
+      unsigned char: stdc_bit_floor_uc,                                        \
       unsigned short: stdc_bit_floor_us,                                       \
       unsigned: stdc_bit_floor_ui,                                             \
       unsigned long: stdc_bit_floor_ul,                                        \


### PR DESCRIPTION
Fixes #84658.

Assuming these were typos in the first place.

I am unsure of the best way to ensure that both sides of the preprocessor condition in `libc/include/llvm-libc-macros/stdbit-macros.h` are tested. Could someone point me in the right direction for adding test coverage to the non `__cplusplus` branch? Or maybe it is being tested and I've missed it.