### PR TITLE
[InstCombine] Handle vec values when constant fold comparisons with constant values with range info.

### DIFF
--- a/llvm/lib/Analysis/InstructionSimplify.cpp
+++ b/llvm/lib/Analysis/InstructionSimplify.cpp
@@ -3788,10 +3788,10 @@ static Value *simplifyICmpInst(unsigned Predicate, Value *LHS, Value *RHS,
           *LHS_Instr->getMetadata(LLVMContext::MD_range));
 
       if (LHS_CR.icmp(Pred, RHS_CR))
-        return ConstantInt::getTrue(RHS->getContext());
+        return ConstantInt::getTrue(ITy);
 
       if (LHS_CR.icmp(CmpInst::getInversePredicate(Pred), RHS_CR))
-        return ConstantInt::getFalse(RHS->getContext());
+        return ConstantInt::getFalse(ITy);
     }
   }
 


### PR DESCRIPTION
found that this failed with an assertion when vec was used in this optimization while working on https://github.com/llvm/llvm-project/pull/84627

failed with backtrace 
```
opt: /home/andjo403/llvm-project/llvm/lib/IR/Value.cpp:507: void llvm::Value::doRAUW(llvm::Value*, llvm::Value::ReplaceMetadataUses): Assertion `New->getType() == getType() && "replaceAllUses of value with new value of different type!"' failed.
PLEASE submit a bug report to https://github.com/llvm/llvm-project/issues/ and include the crash backtrace.
Stack dump:
0.      Program arguments: buildReleaseDebug/bin/opt --debug -S -passes=instcombine /home/andjo403/llvm-project/llvm/test/Transforms/InstCombine/icmp-range.ll
 #0 0x000056272247001c llvm::sys::PrintStackTrace(llvm::raw_ostream&, int) /home/andjo403/llvm-project/llvm/lib/Support/Unix/Signals.inc:727:3
 #1 0x000056272246d784 llvm::sys::RunSignalHandlers() /home/andjo403/llvm-project/llvm/lib/Support/Signals.cpp:105:20
 #2 0x000056272246e715 SignalHandler(int) /home/andjo403/llvm-project/llvm/lib/Support/Unix/Signals.inc:403:31
 #3 0x00007fe17a42e420 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x14420)
 #4 0x00007fe179ecb00b raise /build/glibc-wuryBv/glibc-2.31/signal/../sysdeps/unix/sysv/linux/raise.c:51:1
 #5 0x00007fe179eaa859 abort /build/glibc-wuryBv/glibc-2.31/stdlib/abort.c:81:7
 #6 0x00007fe179eaa729 get_sysdep_segment_value /build/glibc-wuryBv/glibc-2.31/intl/loadmsgcat.c:509:8
 #7 0x00007fe179eaa729 _nl_load_domain /build/glibc-wuryBv/glibc-2.31/intl/loadmsgcat.c:970:34
 #8 0x00007fe179ebbfd6 (/lib/x86_64-linux-gnu/libc.so.6+0x33fd6)
 #9 0x000056272257c994 decltype(auto) llvm::cast<llvm::BasicBlock, llvm::Value>(llvm::Value*) /home/andjo403/llvm-project/llvm/include/llvm/Support/Casting.h:578:3
#10 0x000056272257c994 llvm::Value::doRAUW(llvm::Value*, llvm::Value::ReplaceMetadataUses) /home/andjo403/llvm-project/llvm/lib/IR/Value.cpp:531:37
#11 0x00005627235fb0ec llvm::InstCombiner::replaceInstUsesWith(llvm::Instruction&, llvm::Value*) /home/andjo403/llvm-project/llvm/include/llvm/Transforms/InstCombine/InstCombiner.h:405:13
#12 0x00005627236b0a85 llvm::InstCombinerImpl::visitICmpInst(llvm::ICmpInst&) /home/andjo403/llvm-project/llvm/lib/Transforms/InstCombine/InstCombineCompares.cpp:7214:35
#13 0x00005627236175e9 llvm::InstCombinerImpl::run() /home/andjo403/llvm-project/llvm/lib/Transforms/InstCombine/InstructionCombining.cpp:4899:36
#14 0x0000562723618eaa combineInstructionsOverFunction(llvm::Function&, llvm::InstructionWorklist&, llvm::AAResults*, llvm::AssumptionCache&, llvm::TargetLibraryInfo&, llvm::TargetTransformInfo&, llvm::DominatorTree&, llvm::OptimizationRemarkEmitter&, llvm::BlockFrequencyInfo*, llvm::ProfileSummaryInfo*, llvm::LoopInfo*, llvm::InstCombineOptions const&) (.isra.0) /home/andjo403/llvm-project/llvm/lib/Transforms/InstCombine/InstructionCombining.cpp:5198:5
#15 0x000056272361a252 llvm::InstCombinePass::run(llvm::Function&, llvm::AnalysisManager<llvm::Function>&) /home/andjo403/llvm-project/llvm/lib/Transforms/InstCombine/InstructionCombining.cpp:5255:3
#16 0x0000562723bfff26 llvm::detail::PassModel<llvm::Function, llvm::InstCombinePass, llvm::AnalysisManager<llvm::Function>>::run(llvm::Function&, llvm::AnalysisManager<llvm::Function>&) /home/andjo403/llvm-project/llvm/include/llvm/IR/PassManagerInternal.h:91:3
#17 0x000056272270ee09 llvm::PassManager<llvm::Function, llvm::AnalysisManager<llvm::Function>>::run(llvm::Function&, llvm::AnalysisManager<llvm::Function>&) /home/andjo403/llvm-project/llvm/include/llvm/IR/PassManager.h:247:7
#18 0x0000562723a31a26 llvm::detail::PassModel<llvm::Function, llvm::PassManager<llvm::Function, llvm::AnalysisManager<llvm::Function>>, llvm::AnalysisManager<llvm::Function>>::run(llvm::Function&, llvm::AnalysisManager<llvm::Function>&) /home/andjo403/llvm-project/llvm/include/llvm/IR/PassManagerInternal.h:91:3
#19 0x000056272270d718 llvm::ModuleToFunctionPassAdaptor::run(llvm::Module&, llvm::AnalysisManager<llvm::Module>&) /home/andjo403/llvm-project/llvm/lib/IR/PassManager.cpp:128:41
#20 0x0000562723a32fa6 llvm::detail::PassModel<llvm::Module, llvm::ModuleToFunctionPassAdaptor, llvm::AnalysisManager<llvm::Module>>::run(llvm::Module&, llvm::AnalysisManager<llvm::Module>&) /home/andjo403/llvm-project/llvm/include/llvm/IR/PassManagerInternal.h:91:3
#21 0x000056272270b719 llvm::PassManager<llvm::Module, llvm::AnalysisManager<llvm::Module>>::run(llvm::Module&, llvm::AnalysisManager<llvm::Module>&) /home/andjo403/llvm-project/llvm/include/llvm/IR/PassManager.h:247:7
#22 0x0000562723b279c2 llvm::SmallPtrSetImplBase::~SmallPtrSetImplBase() /home/andjo403/llvm-project/llvm/include/llvm/ADT/SmallPtrSet.h:84:17
#23 0x0000562723b279c2 llvm::SmallPtrSetImpl<llvm::AnalysisKey*>::~SmallPtrSetImpl() /home/andjo403/llvm-project/llvm/include/llvm/ADT/SmallPtrSet.h:321:7
#24 0x0000562723b279c2 llvm::SmallPtrSet<llvm::AnalysisKey*, 2u>::~SmallPtrSet() /home/andjo403/llvm-project/llvm/include/llvm/ADT/SmallPtrSet.h:427:7
#25 0x0000562723b279c2 llvm::PreservedAnalyses::~PreservedAnalyses() /home/andjo403/llvm-project/llvm/include/llvm/IR/Analysis.h:109:7
#26 0x0000562723b279c2 llvm::runPassPipeline(llvm::StringRef, llvm::Module&, llvm::TargetMachine*, llvm::TargetLibraryInfoImpl*, llvm::ToolOutputFile*, llvm::ToolOutputFile*, llvm::ToolOutputFile*, llvm::StringRef, llvm::ArrayRef<llvm::PassPlugin>, llvm::ArrayRef<std::function<void (llvm::PassBuilder&)>>, llvm::opt_tool::OutputKind, llvm::opt_tool::VerifierKind, bool, bool, bool, bool, bool, bool, bool) /home/andjo403/llvm-project/llvm/tools/opt/NewPMDriver.cpp:547:10
#27 0x000056272244ca85 std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>::_M_is_local() const /usr/include/c++/9/bits/basic_string.h:226:26
#28 0x000056272244ca85 std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>::_M_dispose() /usr/include/c++/9/bits/basic_string.h:235:6
#29 0x000056272244ca85 std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>::~basic_string() /usr/include/c++/9/bits/basic_string.h:662:9
#30 0x000056272244ca85 optMain /home/andjo403/llvm-project/llvm/tools/opt/optdriver.cpp:708:28
#31 0x00007fe179eac083 __libc_start_main /build/glibc-wuryBv/glibc-2.31/csu/../csu/libc-start.c:342:3
#32 0x000056272243ed2e _start (buildReleaseDebug/bin/opt+0x1752d2e)
Aborted
```