### PR TITLE
Get rid of noisy debug log in verifyOpAndAdjustFlags.

### DIFF
--- a/mlir/lib/IR/AsmPrinter.cpp
+++ b/mlir/lib/IR/AsmPrinter.cpp
@@ -1895,9 +1895,6 @@ static OpPrintingFlags verifyOpAndAdjustFlags(Operation *op,
       printerFlags.shouldAssumeVerified())
     return printerFlags;
 
-  LLVM_DEBUG(llvm::dbgs() << DEBUG_TYPE << ": Verifying operation: "
-                          << op->getName() << "\n");
-
   // Ignore errors emitted by the verifier. We check the thread id to avoid
   // consuming other threads' errors.
   auto parentThreadId = llvm::get_threadid();


### PR DESCRIPTION
This debug log adds noise to a large fraction of *other* debug logs when you
run with -debug, because it prints "Verifying operation: blah blah\n" whenever
those other debug logs dump an op.

You can use -debug-only to get around this, but sometimes -debug really is
what's called for!
