### PR TITLE
[InstCombine] Use the select condition to try to constant fold binops into select

### DIFF
--- a/llvm/lib/Transforms/InstCombine/InstCombineInternal.h
+++ b/llvm/lib/Transforms/InstCombine/InstCombineInternal.h
@@ -615,8 +615,14 @@ public:
   Instruction *FoldOpIntoSelect(Instruction &Op, SelectInst *SI,
                                 bool FoldWithMultiUse = false);
 
-  /// This is a convenience wrapper function for the above two functions.
-  Instruction *foldBinOpIntoSelectOrPhi(BinaryOperator &I);
+  /// This is a convenience wrapper function for `FoldOpIntoSelect`.
+  Instruction *foldBinOpIntoSelect(BinaryOperator &I,
+                                   bool AllowMultiUse = false);
+
+  /// This is a convenience wrapper function for `foldBinOpIntoSelect` and
+  /// `foldBinopIntoPhi`.
+  Instruction *foldBinOpIntoSelectOrPhi(BinaryOperator &I,
+                                        bool AllowMultiUseSelect = false);
 
   Instruction *foldAddWithConstant(BinaryOperator &Add);
 

--- a/llvm/lib/Transforms/InstCombine/InstCombineMulDivRem.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineMulDivRem.cpp
@@ -1182,12 +1182,9 @@ Instruction *InstCombinerImpl::commonIDivTransforms(BinaryOperator &I) {
   // If the divisor is a select-of-constants, try to constant fold all div ops:
   // C / (select Cond, TrueC, FalseC) --> select Cond, (C / TrueC), (C / FalseC)
   // TODO: Adapt simplifyDivRemOfSelectWithZeroOp to allow this and other folds.
-  if (match(Op0, m_ImmConstant()) &&
-      match(Op1, m_Select(m_Value(), m_ImmConstant(), m_ImmConstant()))) {
-    if (Instruction *R = FoldOpIntoSelect(I, cast<SelectInst>(Op1),
-                                          /*FoldWithMultiUse*/ true))
-      return R;
-  }
+  if (Instruction *R = foldBinOpIntoSelect(I,
+                                           /*AllowMultiUseSelect=*/true))
+    return R;
 
   const APInt *C2;
   if (match(Op1, m_APInt(C2))) {
@@ -1270,7 +1267,8 @@ Instruction *InstCombinerImpl::commonIDivTransforms(BinaryOperator &I) {
     }
 
     if (!C2->isZero()) // avoid X udiv 0
-      if (Instruction *FoldedDiv = foldBinOpIntoSelectOrPhi(I))
+      if (Instruction *FoldedDiv =
+              foldBinOpIntoSelectOrPhi(I, /*AllowMultiUseSelect=*/true))
         return FoldedDiv;
   }
 
@@ -2124,12 +2122,9 @@ Instruction *InstCombinerImpl::commonIRemTransforms(BinaryOperator &I) {
   // If the divisor is a select-of-constants, try to constant fold all rem ops:
   // C % (select Cond, TrueC, FalseC) --> select Cond, (C % TrueC), (C % FalseC)
   // TODO: Adapt simplifyDivRemOfSelectWithZeroOp to allow this and other folds.
-  if (match(Op0, m_ImmConstant()) &&
-      match(Op1, m_Select(m_Value(), m_ImmConstant(), m_ImmConstant()))) {
-    if (Instruction *R = FoldOpIntoSelect(I, cast<SelectInst>(Op1),
-                                          /*FoldWithMultiUse*/ true))
-      return R;
-  }
+  if (Instruction *R = foldBinOpIntoSelect(I,
+                                           /*AllowMultiUse=*/true))
+    return R;
 
   if (isa<Constant>(Op1)) {
     if (Instruction *Op0I = dyn_cast<Instruction>(Op0)) {

--- a/llvm/lib/Transforms/InstCombine/InstructionCombining.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstructionCombining.cpp
@@ -2007,16 +2007,12 @@ Instruction *InstCombinerImpl::foldBinopWithPhiOperands(BinaryOperator &BO) {
 static std::optional<bool> shouldFoldOpIntoSelect(BinaryOperator &I, Value *Op,
                                                   Value *OpOther,
                                                   bool AllowMultiUse) {
-  if (!AllowMultiUse && !Op->hasOneUse())
+  if (!isa<SelectInst>(Op) || (!AllowMultiUse && !Op->hasOneUse()))
     return std::nullopt;
-  if (isa<SelectInst>(Op)) {
-    // If we will be able to constant fold the incorporated binop, then
-    // multi-use. Otherwise single-use.
-    return match(OpOther, m_ImmConstant()) &&
-           match(Op, m_Select(m_Value(), m_ImmConstant(), m_ImmConstant()));
-  }
-
-  return std::nullopt;
+  // If we will be able to constant fold the incorporated binop, then
+  // multi-use. Otherwise single-use.
+  return match(OpOther, m_ImmConstant()) &&
+         match(Op, m_Select(m_Value(), m_ImmConstant(), m_ImmConstant()));
 }
 
 Instruction *InstCombinerImpl::foldBinOpIntoSelect(BinaryOperator &I,

--- a/llvm/lib/Transforms/InstCombine/InstructionCombining.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstructionCombining.cpp
@@ -2002,14 +2002,61 @@ Instruction *InstCombinerImpl::foldBinopWithPhiOperands(BinaryOperator &BO) {
   return NewPhi;
 }
 
-Instruction *InstCombinerImpl::foldBinOpIntoSelectOrPhi(BinaryOperator &I) {
+// Return std::nullopt if we should not fold. Return true if we should fold
+// multi-use select and false for single-use select.
+static std::optional<bool> shouldFoldOpIntoSelect(BinaryOperator &I, Value *Op,
+                                                  Value *OpOther,
+                                                  bool AllowMultiUse) {
+  if (!AllowMultiUse && !Op->hasOneUse())
+    return std::nullopt;
+  if (isa<SelectInst>(Op)) {
+    // If we will be able to constant fold the incorporated binop, then
+    // multi-use. Otherwise single-use.
+    return match(OpOther, m_ImmConstant()) &&
+           match(Op, m_Select(m_Value(), m_ImmConstant(), m_ImmConstant()));
+  }
+
+  return std::nullopt;
+}
+
+Instruction *InstCombinerImpl::foldBinOpIntoSelect(BinaryOperator &I,
+                                                   bool AllowMultiUse) {
+  std::optional<bool> CanSpeculativelyExecuteRes;
+  for (unsigned OpIdx = 0; OpIdx < 2; ++OpIdx) {
+    // Slightly more involved logic for select. For select we use the condition
+    // to to infer information about the arm. This allows us to constant-fold
+    // even when the select arm(s) are not constant. For example if we have: `(X
+    // == 10 ? 19 : Y) * X`, we can entirely contant fold the true arm as `X ==
+    // 10` dominates it. So we end up with `X == 10 ? 190 : (X * Y))`.
+    if (auto MultiUse = shouldFoldOpIntoSelect(
+            I, I.getOperand(OpIdx), I.getOperand(1 - OpIdx), AllowMultiUse)) {
+      if (!*MultiUse) {
+        if (!CanSpeculativelyExecuteRes) {
+          const SimplifyQuery Q = SQ.getWithInstruction(&I);
+          CanSpeculativelyExecuteRes =
+              isSafeToSpeculativelyExecute(&I, Q.CxtI, Q.AC, Q.DT, &TLI);
+        }
+        if (!*CanSpeculativelyExecuteRes)
+          return nullptr;
+      }
+      if (Instruction *NewSel = FoldOpIntoSelect(
+              I, cast<SelectInst>(I.getOperand(OpIdx)), *MultiUse))
+        return NewSel;
+    }
+  }
+  return nullptr;
+}
+
+Instruction *
+InstCombinerImpl::foldBinOpIntoSelectOrPhi(BinaryOperator &I,
+                                           bool AllowMultiUseSelect) {
+  if (auto *SI = foldBinOpIntoSelect(I, AllowMultiUseSelect))
+    return SI;
+
   if (!isa<Constant>(I.getOperand(1)))
     return nullptr;
 
-  if (auto *Sel = dyn_cast<SelectInst>(I.getOperand(0))) {
-    if (Instruction *NewSel = FoldOpIntoSelect(I, Sel))
-      return NewSel;
-  } else if (auto *PN = dyn_cast<PHINode>(I.getOperand(0))) {
+  if (auto *PN = dyn_cast<PHINode>(I.getOperand(0))) {
     if (Instruction *NewPhi = foldOpIntoPhi(I, PN))
       return NewPhi;
   }

--- a/llvm/test/Transforms/InstCombine/binop-select.ll
+++ b/llvm/test/Transforms/InstCombine/binop-select.ll
@@ -356,7 +356,7 @@ define <2 x half> @fmul_sel_op1(i1 %b, <2 x half> %p) {
 ; CHECK-LABEL: @fmul_sel_op1(
 ; CHECK-NEXT:    ret <2 x half> zeroinitializer
 ;
-  %x = fadd <2 x half> %p, <half 1.0, half 2.0>  ; thwart complexity-based canonicalization
+  %x = fadd <2 x half> %p, <half 1.0, half 2.0> ; thwart complexity-based canonicalization
   %s = select i1 %b, <2 x half> zeroinitializer, <2 x half> <half 0xHffff, half 0xHffff>
   %r = fmul nnan nsz <2 x half> %x, %s
   ret <2 x half> %r
@@ -370,7 +370,7 @@ define <2 x half> @fmul_sel_op1_use(i1 %b, <2 x half> %p) {
 ; CHECK-NEXT:    [[R:%.*]] = fmul nnan nsz <2 x half> [[X]], [[S]]
 ; CHECK-NEXT:    ret <2 x half> [[R]]
 ;
-  %x = fadd <2 x half> %p, <half 1.0, half 2.0>  ; thwart complexity-based canonicalization
+  %x = fadd <2 x half> %p, <half 1.0, half 2.0> ; thwart complexity-based canonicalization
   %s = select i1 %b, <2 x half> zeroinitializer, <2 x half> <half 0xHffff, half 0xHffff>
   call void @use_v2f16(<2 x half> %s)
   %r = fmul nnan nsz <2 x half> %x, %s

--- a/llvm/test/Transforms/InstCombine/binop-select.ll
+++ b/llvm/test/Transforms/InstCombine/binop-select.ll
@@ -403,8 +403,8 @@ define i32 @ashr_sel_op1_use(i1 %b) {
 define i32 @test_mul_to_const_Cmul(i32 %x) {
 ; CHECK-LABEL: @test_mul_to_const_Cmul(
 ; CHECK-NEXT:    [[C:%.*]] = icmp eq i32 [[X:%.*]], 61
-; CHECK-NEXT:    [[COND:%.*]] = select i1 [[C]], i32 9, i32 14
-; CHECK-NEXT:    [[R:%.*]] = mul i32 [[X]], [[COND]]
+; CHECK-NEXT:    [[TMP1:%.*]] = mul i32 [[X]], 14
+; CHECK-NEXT:    [[R:%.*]] = select i1 [[C]], i32 549, i32 [[TMP1]]
 ; CHECK-NEXT:    ret i32 [[R]]
 ;
   %c = icmp eq i32 %x, 61
@@ -429,8 +429,8 @@ define float @test_fmul_to_const_Cmul_fail(float %x) {
 define i32 @test_mul_to_const_mul(i32 %x, i32 %y) {
 ; CHECK-LABEL: @test_mul_to_const_mul(
 ; CHECK-NEXT:    [[C:%.*]] = icmp eq i32 [[X:%.*]], 61
-; CHECK-NEXT:    [[COND:%.*]] = select i1 [[C]], i32 9, i32 [[Y:%.*]]
-; CHECK-NEXT:    [[R:%.*]] = mul i32 [[X]], [[COND]]
+; CHECK-NEXT:    [[TMP1:%.*]] = mul i32 [[X]], [[Y:%.*]]
+; CHECK-NEXT:    [[R:%.*]] = select i1 [[C]], i32 549, i32 [[TMP1]]
 ; CHECK-NEXT:    ret i32 [[R]]
 ;
   %c = icmp eq i32 %x, 61
@@ -442,8 +442,8 @@ define i32 @test_mul_to_const_mul(i32 %x, i32 %y) {
 define <2 x i32> @test_mul_to_const_mul_vec(<2 x i32> %x, <2 x i32> %y) {
 ; CHECK-LABEL: @test_mul_to_const_mul_vec(
 ; CHECK-NEXT:    [[C:%.*]] = icmp eq <2 x i32> [[X:%.*]], <i32 61, i32 9>
-; CHECK-NEXT:    [[COND:%.*]] = select <2 x i1> [[C]], <2 x i32> <i32 9, i32 12>, <2 x i32> [[Y:%.*]]
-; CHECK-NEXT:    [[R:%.*]] = mul <2 x i32> [[X]], [[COND]]
+; CHECK-NEXT:    [[TMP1:%.*]] = mul <2 x i32> [[X]], [[Y:%.*]]
+; CHECK-NEXT:    [[R:%.*]] = select <2 x i1> [[C]], <2 x i32> <i32 549, i32 108>, <2 x i32> [[TMP1]]
 ; CHECK-NEXT:    ret <2 x i32> [[R]]
 ;
   %c = icmp eq <2 x i32> %x, <i32 61, i32 9>
@@ -523,7 +523,7 @@ define i32 @test_div_with_multiuse(i1 %cond) {
 ; CHECK-LABEL: @test_div_with_multiuse(
 ; CHECK-NEXT:    [[SEL:%.*]] = select i1 [[COND:%.*]], i32 132, i32 66
 ; CHECK-NEXT:    call void @use(i32 [[SEL]])
-; CHECK-NEXT:    [[RET:%.*]] = udiv i32 [[SEL]], 22
+; CHECK-NEXT:    [[RET:%.*]] = select i1 [[COND]], i32 6, i32 3
 ; CHECK-NEXT:    ret i32 [[RET]]
 ;
   %sel = select i1 %cond, i32 132, i32 66
@@ -563,7 +563,7 @@ define <2 x i32> @test_rem_with_multiuse(<2 x i1> %cond) {
 ; CHECK-LABEL: @test_rem_with_multiuse(
 ; CHECK-NEXT:    [[SEL:%.*]] = select <2 x i1> [[COND:%.*]], <2 x i32> <i32 132, i32 132>, <2 x i32> <i32 66, i32 66>
 ; CHECK-NEXT:    call void @use(<2 x i32> [[SEL]])
-; CHECK-NEXT:    [[RET:%.*]] = urem <2 x i32> [[SEL]], <i32 21, i32 21>
+; CHECK-NEXT:    [[RET:%.*]] = select <2 x i1> [[COND]], <2 x i32> <i32 6, i32 6>, <2 x i32> <i32 3, i32 3>
 ; CHECK-NEXT:    ret <2 x i32> [[RET]]
 ;
   %sel = select <2 x i1> %cond, <2 x i32> <i32 132, i32 132>, <2 x i32> <i32 66, i32 66>

--- a/llvm/test/Transforms/InstCombine/binop-select.ll
+++ b/llvm/test/Transforms/InstCombine/binop-select.ll
@@ -136,7 +136,6 @@ define <2 x i8> @test_sub_dont_deduce_with_poison_cond_vec(<2 x i8> %x, <2 x i8>
   ret <2 x i8> %sub
 }
 
-
 define <2 x i8> @test_sub_deduce_with_undef_val_vec(<2 x i8> %x, <2 x i8> %y) {
 ; CHECK-LABEL: @test_sub_deduce_with_undef_val_vec(
 ; CHECK-NEXT:    [[C_NOT:%.*]] = icmp eq <2 x i8> [[X:%.*]], <i8 1, i8 2>
@@ -149,7 +148,6 @@ define <2 x i8> @test_sub_deduce_with_undef_val_vec(<2 x i8> %x, <2 x i8> %y) {
   %sub = call <2 x i8> @llvm.sadd.sat.v2i8(<2 x i8> %x, <2 x i8> %cond)
   ret <2 x i8> %sub
 }
-
 
 define i32 @test6(i1 %c, i32 %x, i32 %y) {
 ; CHECK-LABEL: @test6(
@@ -174,7 +172,6 @@ define i32 @test7(i1 %c, i32 %x) {
   %div = sdiv i32 %x, %cond
   ret i32 %div
 }
-
 
 define i32 @test8(i1 %c, i32 %x, i32 %y) {
 ; CHECK-LABEL: @test8(
@@ -243,7 +240,6 @@ define i32 @extra_use(i1 %c, i32 %x, i32 %y) {
   %sub = sub nsw i32 0, %cond
   ret i32 %sub
 }
-
 
 define i32 @extra_use2(i1 %c, i32 %x) {
 ; CHECK-LABEL: @extra_use2(
@@ -360,7 +356,7 @@ define <2 x half> @fmul_sel_op1(i1 %b, <2 x half> %p) {
 ; CHECK-LABEL: @fmul_sel_op1(
 ; CHECK-NEXT:    ret <2 x half> zeroinitializer
 ;
-  %x = fadd <2 x half> %p, <half 1.0, half 2.0> ; thwart complexity-based canonicalization
+  %x = fadd <2 x half> %p, <half 1.0, half 2.0>  ; thwart complexity-based canonicalization
   %s = select i1 %b, <2 x half> zeroinitializer, <2 x half> <half 0xHffff, half 0xHffff>
   %r = fmul nnan nsz <2 x half> %x, %s
   ret <2 x half> %r
@@ -374,7 +370,7 @@ define <2 x half> @fmul_sel_op1_use(i1 %b, <2 x half> %p) {
 ; CHECK-NEXT:    [[R:%.*]] = fmul nnan nsz <2 x half> [[X]], [[S]]
 ; CHECK-NEXT:    ret <2 x half> [[R]]
 ;
-  %x = fadd <2 x half> %p, <half 1.0, half 2.0> ; thwart complexity-based canonicalization
+  %x = fadd <2 x half> %p, <half 1.0, half 2.0>  ; thwart complexity-based canonicalization
   %s = select i1 %b, <2 x half> zeroinitializer, <2 x half> <half 0xHffff, half 0xHffff>
   call void @use_v2f16(<2 x half> %s)
   %r = fmul nnan nsz <2 x half> %x, %s
@@ -402,4 +398,189 @@ define i32 @ashr_sel_op1_use(i1 %b) {
   call void @use(i32 %s)
   %r = ashr i32 -2, %s
   ret i32 %r
+}
+
+define i32 @test_mul_to_const_Cmul(i32 %x) {
+; CHECK-LABEL: @test_mul_to_const_Cmul(
+; CHECK-NEXT:    [[C:%.*]] = icmp eq i32 [[X:%.*]], 61
+; CHECK-NEXT:    [[COND:%.*]] = select i1 [[C]], i32 9, i32 14
+; CHECK-NEXT:    [[R:%.*]] = mul i32 [[X]], [[COND]]
+; CHECK-NEXT:    ret i32 [[R]]
+;
+  %c = icmp eq i32 %x, 61
+  %cond = select i1 %c, i32 9, i32 14
+  %r = mul i32 %x, %cond
+  ret i32 %r
+}
+
+define float @test_fmul_to_const_Cmul_fail(float %x) {
+; CHECK-LABEL: @test_fmul_to_const_Cmul_fail(
+; CHECK-NEXT:    [[C:%.*]] = fcmp oeq float [[X:%.*]], 6.100000e+01
+; CHECK-NEXT:    [[COND:%.*]] = select i1 [[C]], float 9.000000e+00, float 1.400000e+01
+; CHECK-NEXT:    [[R:%.*]] = fmul float [[X]], [[COND]]
+; CHECK-NEXT:    ret float [[R]]
+;
+  %c = fcmp oeq float %x, 61.0
+  %cond = select i1 %c, float 9.0, float 14.0
+  %r = fmul float %x, %cond
+  ret float %r
+}
+
+define i32 @test_mul_to_const_mul(i32 %x, i32 %y) {
+; CHECK-LABEL: @test_mul_to_const_mul(
+; CHECK-NEXT:    [[C:%.*]] = icmp eq i32 [[X:%.*]], 61
+; CHECK-NEXT:    [[COND:%.*]] = select i1 [[C]], i32 9, i32 [[Y:%.*]]
+; CHECK-NEXT:    [[R:%.*]] = mul i32 [[X]], [[COND]]
+; CHECK-NEXT:    ret i32 [[R]]
+;
+  %c = icmp eq i32 %x, 61
+  %cond = select i1 %c, i32 9, i32 %y
+  %r = mul i32 %x, %cond
+  ret i32 %r
+}
+
+define <2 x i32> @test_mul_to_const_mul_vec(<2 x i32> %x, <2 x i32> %y) {
+; CHECK-LABEL: @test_mul_to_const_mul_vec(
+; CHECK-NEXT:    [[C:%.*]] = icmp eq <2 x i32> [[X:%.*]], <i32 61, i32 9>
+; CHECK-NEXT:    [[COND:%.*]] = select <2 x i1> [[C]], <2 x i32> <i32 9, i32 12>, <2 x i32> [[Y:%.*]]
+; CHECK-NEXT:    [[R:%.*]] = mul <2 x i32> [[X]], [[COND]]
+; CHECK-NEXT:    ret <2 x i32> [[R]]
+;
+  %c = icmp eq <2 x i32> %x, <i32 61, i32 9>
+  %cond = select <2 x i1> %c, <2 x i32> <i32 9, i32 12>, <2 x i32> %y
+  %r = mul <2 x i32> %x, %cond
+  ret <2 x i32> %r
+}
+
+define i32 @test_mul_to_const_Cmul_fail_multiuse(i32 %x, i32 %y) {
+; CHECK-LABEL: @test_mul_to_const_Cmul_fail_multiuse(
+; CHECK-NEXT:    [[C:%.*]] = icmp eq i32 [[X:%.*]], 61
+; CHECK-NEXT:    [[COND:%.*]] = select i1 [[C]], i32 9, i32 14
+; CHECK-NEXT:    [[R:%.*]] = mul i32 [[X]], [[COND]]
+; CHECK-NEXT:    call void @use(i32 [[COND]])
+; CHECK-NEXT:    ret i32 [[R]]
+;
+  %c = icmp eq i32 %x, 61
+  %cond = select i1 %c, i32 9, i32 14
+  %r = mul i32 %x, %cond
+  call void @use(i32 %cond)
+  ret i32 %r
+}
+
+define i32 @test_div_to_const_div_fail_non_speculatable(i32 %x, i32 %y) {
+; CHECK-LABEL: @test_div_to_const_div_fail_non_speculatable(
+; CHECK-NEXT:    [[C:%.*]] = icmp eq i32 [[X:%.*]], 61
+; CHECK-NEXT:    [[COND:%.*]] = select i1 [[C]], i32 9, i32 [[Y:%.*]]
+; CHECK-NEXT:    [[R:%.*]] = udiv i32 [[X]], [[COND]]
+; CHECK-NEXT:    ret i32 [[R]]
+;
+  %c = icmp eq i32 %x, 61
+  %cond = select i1 %c, i32 9, i32 %y
+  %r = udiv i32 %x, %cond
+  ret i32 %r
+}
+
+define i32 @test_div_to_const_Cdiv_todo(i32 %x, i32 %y) {
+; CHECK-LABEL: @test_div_to_const_Cdiv_todo(
+; CHECK-NEXT:    [[C:%.*]] = icmp eq i32 [[X:%.*]], 61
+; CHECK-NEXT:    [[COND:%.*]] = select i1 [[C]], i32 9, i32 14
+; CHECK-NEXT:    [[R:%.*]] = udiv i32 [[X]], [[COND]]
+; CHECK-NEXT:    ret i32 [[R]]
+;
+  %c = icmp eq i32 %x, 61
+  %cond = select i1 %c, i32 9, i32 14
+  %r = udiv i32 %x, %cond
+  ret i32 %r
+}
+
+define <2 x i32> @test_rem_to_const_Cdiv_todo(<2 x i32> %x, <2 x i32> %y) {
+; CHECK-LABEL: @test_rem_to_const_Cdiv_todo(
+; CHECK-NEXT:    [[C:%.*]] = icmp eq <2 x i32> [[X:%.*]], <i32 3, i32 3>
+; CHECK-NEXT:    [[COND:%.*]] = select <2 x i1> [[C]], <2 x i32> <i32 9, i32 9>, <2 x i32> <i32 14, i32 14>
+; CHECK-NEXT:    [[R:%.*]] = srem <2 x i32> [[X]], [[COND]]
+; CHECK-NEXT:    ret <2 x i32> [[R]]
+;
+  %c = icmp eq <2 x i32> %x, <i32 3, i32 3>
+  %cond = select <2 x i1> %c, <2 x i32> <i32 9, i32 9>, <2 x i32> <i32 14, i32 14>
+  %r = srem <2 x i32> %x, %cond
+  ret <2 x i32> %r
+}
+
+define i32 @test_or_with_multiuse_fail(i1 %cond) {
+; CHECK-LABEL: @test_or_with_multiuse_fail(
+; CHECK-NEXT:    [[SEL:%.*]] = select i1 [[COND:%.*]], i32 32, i32 0
+; CHECK-NEXT:    call void @use(i32 [[SEL]])
+; CHECK-NEXT:    [[RET:%.*]] = or disjoint i32 [[SEL]], 22
+; CHECK-NEXT:    ret i32 [[RET]]
+;
+  %sel = select i1 %cond, i32 32, i32 0
+  call void @use(i32 %sel)
+  %ret = or disjoint i32 %sel, 22
+  ret i32 %ret
+}
+
+define i32 @test_div_with_multiuse(i1 %cond) {
+; CHECK-LABEL: @test_div_with_multiuse(
+; CHECK-NEXT:    [[SEL:%.*]] = select i1 [[COND:%.*]], i32 132, i32 66
+; CHECK-NEXT:    call void @use(i32 [[SEL]])
+; CHECK-NEXT:    [[RET:%.*]] = udiv i32 [[SEL]], 22
+; CHECK-NEXT:    ret i32 [[RET]]
+;
+  %sel = select i1 %cond, i32 132, i32 66
+  call void @use(i32 %sel)
+  %ret = sdiv i32 %sel, 22
+  ret i32 %ret
+}
+
+define float @test_fdiv_with_multiuse(i1 %cond) {
+; CHECK-LABEL: @test_fdiv_with_multiuse(
+; CHECK-NEXT:    [[SEL:%.*]] = select i1 [[COND:%.*]], float 1.320000e+02, float 6.600000e+01
+; CHECK-NEXT:    call void @use(float [[SEL]])
+; CHECK-NEXT:    [[RET:%.*]] = fdiv float [[SEL]], 2.200000e+01
+; CHECK-NEXT:    ret float [[RET]]
+;
+  %sel = select i1 %cond, float 132.0, float 66.0
+  call void @use(float %sel)
+  %ret = fdiv float %sel, 22.0
+  ret float %ret
+}
+
+define float @test_fmul_with_multiuse(i1 %cond) {
+; CHECK-LABEL: @test_fmul_with_multiuse(
+; CHECK-NEXT:    [[SEL:%.*]] = select i1 [[COND:%.*]], float 1.320000e+02, float 6.600000e+01
+; CHECK-NEXT:    call void @use(float [[SEL]])
+; CHECK-NEXT:    [[RET:%.*]] = fmul float [[SEL]], 2.200000e+01
+; CHECK-NEXT:    ret float [[RET]]
+;
+  %sel = select i1 %cond, float 132.0, float 66.0
+  call void @use(float %sel)
+  %ret = fmul float %sel, 22.0
+  ret float %ret
+}
+
+
+define <2 x i32> @test_rem_with_multiuse(<2 x i1> %cond) {
+; CHECK-LABEL: @test_rem_with_multiuse(
+; CHECK-NEXT:    [[SEL:%.*]] = select <2 x i1> [[COND:%.*]], <2 x i32> <i32 132, i32 132>, <2 x i32> <i32 66, i32 66>
+; CHECK-NEXT:    call void @use(<2 x i32> [[SEL]])
+; CHECK-NEXT:    [[RET:%.*]] = urem <2 x i32> [[SEL]], <i32 21, i32 21>
+; CHECK-NEXT:    ret <2 x i32> [[RET]]
+;
+  %sel = select <2 x i1> %cond, <2 x i32> <i32 132, i32 132>, <2 x i32> <i32 66, i32 66>
+  call void @use(<2 x i32> %sel)
+  %ret = urem <2 x i32> %sel, <i32 21, i32 21>
+  ret <2 x i32> %ret
+}
+
+define i32 @test_mul_with_multiuse(i1 %cond) {
+; CHECK-LABEL: @test_mul_with_multiuse(
+; CHECK-NEXT:    [[SEL:%.*]] = select i1 [[COND:%.*]], i32 14, i32 12
+; CHECK-NEXT:    call void @use(i32 [[SEL]])
+; CHECK-NEXT:    [[RET:%.*]] = mul nuw nsw i32 [[SEL]], 9
+; CHECK-NEXT:    ret i32 [[RET]]
+;
+  %sel = select i1 %cond, i32 14, i32 12
+  call void @use(i32 %sel)
+  %ret = mul i32 %sel, 9
+  ret i32 %ret
 }

--- a/llvm/test/Transforms/InstCombine/pr72433.ll
+++ b/llvm/test/Transforms/InstCombine/pr72433.ll
@@ -6,10 +6,10 @@ define i32 @widget(i32 %arg, i32 %arg1) {
 ; CHECK-SAME: i32 [[ARG:%.*]], i32 [[ARG1:%.*]]) {
 ; CHECK-NEXT:  bb:
 ; CHECK-NEXT:    [[ICMP:%.*]] = icmp ne i32 [[ARG]], 0
-; CHECK-NEXT:    [[TMP0:%.*]] = zext i1 [[ICMP]] to i32
-; CHECK-NEXT:    [[MUL:%.*]] = shl nuw nsw i32 20, [[TMP0]]
 ; CHECK-NEXT:    [[XOR:%.*]] = zext i1 [[ICMP]] to i32
-; CHECK-NEXT:    [[ADD9:%.*]] = or disjoint i32 [[MUL]], [[XOR]]
+; CHECK-NEXT:    [[MUL:%.*]] = shl nuw nsw i32 20, [[XOR]]
+; CHECK-NEXT:    [[XOR1:%.*]] = zext i1 [[ICMP]] to i32
+; CHECK-NEXT:    [[ADD9:%.*]] = or disjoint i32 [[MUL]], [[XOR1]]
 ; CHECK-NEXT:    [[TMP1:%.*]] = zext i1 [[ICMP]] to i32
 ; CHECK-NEXT:    [[MUL2:%.*]] = shl nuw nsw i32 [[ADD9]], [[TMP1]]
 ; CHECK-NEXT:    ret i32 [[MUL2]]


### PR DESCRIPTION
The select condition may allow us to constant fold binops on
non-constant arms if the condition implies one of the binop operand is constant
For example if we have:
```
%c = icmp eq i8 %y, 10
%s = select i1 %c, i8 123, i8 %x
%r = mul i8 %s, %y
```

We can replace substitute `10` in for `%y` on the true arm and do:
```
%c = icmp eq i8 %y, 10
%mul = mul i8 %x, %y
%r = select i1 %c, i8 1230, i8 %mul
```

