### PR TITLE
After pr75525 i was not able to build receiving error: decimal-to-bin…

### DIFF
--- a/flang/lib/Decimal/decimal-to-binary.cpp
+++ b/flang/lib/Decimal/decimal-to-binary.cpp
@@ -11,6 +11,7 @@
 #include "flang/Common/leading-zero-bit-count.h"
 #include "flang/Decimal/binary-floating-point.h"
 #include "flang/Decimal/decimal.h"
+#include "flang/Evaluate/real.h"
 #include <cinttypes>
 #include <cstring>
 #include <ctype.h>


### PR DESCRIPTION
After pr75525 i was not able to build receiving error: `decimal-to-binary.cpp:381:24: error: called object type 'float' is not a function or function pointer`

this include solves it though.

https://github.com/llvm/llvm-project/blob/ea697dcc2ad9e6a1cc313d792b485d9218a943a1/flang/lib/Decimal/decimal-to-binary.cpp#L381

(i do use the [netbsd](https://pkgsrc.smartos.org) llvm on macos, shouldnt matter though)