### PR TITLE
[libc++] Only forward-declare ABI-functions in exception_ptr.h if they are meant to be used

### DIFF
--- a/libcxx/include/__exception/exception_ptr.h
+++ b/libcxx/include/__exception/exception_ptr.h
@@ -26,6 +26,8 @@
 
 #ifndef _LIBCPP_ABI_MICROSOFT
 
+#  if _LIBCPP_AVAILABILITY_HAS_INIT_PRIMARY_EXCEPTION
+
 namespace __cxxabiv1 {
 
 extern "C" {
@@ -37,13 +39,15 @@ _LIBCPP_OVERRIDABLE_FUNC_VIS __cxa_exception* __cxa_init_primary_exception(
     void*,
     std::type_info*,
     void(
-#  if defined(_WIN32)
+#    if defined(_WIN32)
         __thiscall
-#  endif
+#    endif
             *)(void*)) throw();
 }
 
 } // namespace __cxxabiv1
+
+#  endif
 
 #endif
 


### PR DESCRIPTION
This patch fixes the unconditional forward-declarations of ABI-functions in exception_ptr.h, and makes it dependent on the availability macro, as it should've been from the beginning.
The declarations being unconditional break the build with libcxxrt before [045c52ce821388f4ae4d119fe4fb75f1eb547b85](https://github.com/libcxxrt/libcxxrt/commit/045c52ce821388f4ae4d119fe4fb75f1eb547b85), now they are opt-out.

* libcxx/include/__exception/exception_ptr.h 
  Only forward-declare ABI-functions if they are meant to be used.