### PR TITLE
[cmake] Move LLVM_ENABLE_PIC cmake option to HandleLLVMOptions.cmake

### DIFF
--- a/llvm/CMakeLists.txt
+++ b/llvm/CMakeLists.txt
@@ -599,9 +599,6 @@ set(LLVM_TARGETS_TO_BUILD
    ${LLVM_EXPERIMENTAL_TARGETS_TO_BUILD})
 list(REMOVE_DUPLICATES LLVM_TARGETS_TO_BUILD)
 
-if (NOT CMAKE_SYSTEM_NAME MATCHES "OS390")
-  option(LLVM_ENABLE_PIC "Build Position-Independent Code" ON)
-endif()
 option(LLVM_ENABLE_MODULES "Compile with C++ modules enabled." OFF)
 if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
   option(LLVM_ENABLE_MODULE_DEBUGGING "Compile with -gmodules." ON)
@@ -929,17 +926,6 @@ set(LLVM_DEFAULT_TARGET_TRIPLE "${LLVM_DEFAULT_TARGET_TRIPLE_DEFAULT}" CACHE STR
 message(STATUS "LLVM default target triple: ${LLVM_DEFAULT_TARGET_TRIPLE}")
 
 set(LLVM_TARGET_TRIPLE "${LLVM_DEFAULT_TARGET_TRIPLE}")
-
-if(WIN32 OR CYGWIN)
-  if(BUILD_SHARED_LIBS OR LLVM_BUILD_LLVM_DYLIB)
-    set(LLVM_ENABLE_PLUGINS_default ON)
-  else()
-    set(LLVM_ENABLE_PLUGINS_default OFF)
-  endif()
-else()
-  set(LLVM_ENABLE_PLUGINS_default ${LLVM_ENABLE_PIC})
-endif()
-option(LLVM_ENABLE_PLUGINS "Enable plugin support" ${LLVM_ENABLE_PLUGINS_default})
 
 set(LLVM_ENABLE_NEW_PASS_MANAGER TRUE CACHE BOOL
   "Enable the new pass manager by default.")

--- a/llvm/cmake/modules/HandleLLVMOptions.cmake
+++ b/llvm/cmake/modules/HandleLLVMOptions.cmake
@@ -376,6 +376,9 @@ if( LLVM_USE_LINKER )
   endif()
 endif()
 
+if (NOT CMAKE_SYSTEM_NAME MATCHES "OS390")
+  option(LLVM_ENABLE_PIC "Build Position-Independent Code" ON)
+endif()
 if( LLVM_ENABLE_PIC )
   if( XCODE )
     # Xcode has -mdynamic-no-pic on by default, which overrides -fPIC. I don't
@@ -413,6 +416,17 @@ if( LLVM_ENABLE_PIC )
     llvm_replace_compiler_option(CMAKE_CXX_FLAGS_RELWITHDEBINFO "-O[23]" "-O")
   endif()
 endif()
+
+if(WIN32 OR CYGWIN)
+  if(BUILD_SHARED_LIBS OR LLVM_BUILD_LLVM_DYLIB)
+    set(LLVM_ENABLE_PLUGINS_default ON)
+  else()
+    set(LLVM_ENABLE_PLUGINS_default OFF)
+  endif()
+else()
+  set(LLVM_ENABLE_PLUGINS_default ${LLVM_ENABLE_PIC})
+endif()
+option(LLVM_ENABLE_PLUGINS "Enable plugin support" ${LLVM_ENABLE_PLUGINS_default})
 
 if((NOT (${CMAKE_SYSTEM_NAME} MATCHES "AIX")) AND
    (NOT (WIN32 OR CYGWIN) OR (MINGW AND CMAKE_CXX_COMPILER_ID MATCHES "Clang")))


### PR DESCRIPTION
LLVM_ENABLE_PIC is used by various LLVM projects which can be built standalone (runtimes, for example), but the only place this option defined is CMakeLists.txt in `llvm/` directory. This hides LLVM_ENABLE_PIC for standalone project builds and makes different defaults for them (as of LLVM_ENABLE_PIC is ON by default, but only for builds where `llvm/` directory is root).

This patch proposes moving the option to HandleLLVMOptions.cmake so that making it defined for all projects that can be built standalone and avoid inconsistency in defaults. The patch also moves LLVM_ENABLE_PLUGINS cmake option since its default value may depend on LLVM_ENABLE_PIC.