### PR TITLE
[docs][CMake] Add CMakePreset, improve VS documentation

### DIFF
--- a/.vs/CMakeWorkspaceSettings.json
+++ b/.vs/CMakeWorkspaceSettings.json
@@ -1,0 +1,4 @@
+{
+  "enableCMake": true,
+  "sourceDirectory": "llvm"
+}

--- a/.vs/CMakeWorkspaceSettings.json
+++ b/.vs/CMakeWorkspaceSettings.json
@@ -1,4 +1,4 @@
 {
-  "enableCMake": true,
-  "sourceDirectory": "llvm"
+  "sourceDirectory": "llvm",
+  "enableCMake": false
 }

--- a/llvm/CMakePresets.json
+++ b/llvm/CMakePresets.json
@@ -1,0 +1,91 @@
+
+/*
+   This is the default presets for LLVM, if you want to add your own
+   custom one, create a CMakeUserPreset.json instead.
+*/
+
+{
+  "version": 2,
+  "cmakeMinimumRequired": {
+    "major": 3,
+    "minor": 20,
+    "patch": 0
+  },
+  "configurePresets": [
+    {
+      "name": "default_win",
+      "hidden": true,
+      "generator": "Ninja",
+      "binaryDir": "${sourceParentDir}/out/${presetName}",
+      "cacheVariables": {
+        /* Most of the users would like to have these projects enabled */
+        "LLVM_ENABLE_PROJECTS": "clang;lld;clang-tools-extra"
+      }
+    },
+    {
+      "name": "Debug_Win_x64_msvc",
+      "inherits": "default_win",
+      "displayName": "Debug Win x64 (MSVC)",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug",
+        "LLVM_OPTIMIZED_TABLEGEN": "ON"
+      }
+    },
+    {
+      "name": "Release_Win_x64_msvc",
+      "inherits": "default_win",
+      "displayName": "Release Win x64 (MSVC)",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Release",
+        "LLVM_ENABLE_PDB": "ON",
+        "LLVM_ENABLE_ASSERTIONS": "ON"
+      }
+    },
+    {
+      "name": "Debug_Win_x64_clang",
+      "inherits": "default_win",
+      "displayName": "Debug Win x64 (Clang)",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug",
+        "CMAKE_CXX_COMPILER": "clang-cl",
+        "CMAKE_C_COMPILER": "clang-cl",
+        "LLVM_OPTIMIZED_TABLEGEN": "ON"
+      }
+    },
+    {
+      "name": "Release_Win_x64_clang",
+      "inherits": "default_win",
+      "displayName": "Release Win x64 (Clang)",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Release",
+        "CMAKE_CXX_COMPILER": "clang-cl",
+        "CMAKE_C_COMPILER": "clang-cl",
+        "LLVM_ENABLE_PDB": "ON",
+        "LLVM_ENABLE_ASSERTIONS": "ON"
+      }
+    }
+  ],
+  "buildPresets": [
+    {
+      "name": "Debug_Win_x64_msvc",
+      "configurePreset": "Debug_Win_x64_msvc",
+      "inheritConfigureEnvironment": true
+    },
+    {
+      "name": "Release_Win_x64_msvc",
+      "configurePreset": "Release_Win_x64_msvc",
+      "inheritConfigureEnvironment": true
+    },
+    {
+      "name": "Debug_Win_x64_clang",
+      "configurePreset": "Debug_Win_x64_clang",
+      "inheritConfigureEnvironment": true
+    },
+    {
+      "name": "Release_Win_x64_clang",
+      "configurePreset": "Release_Win_x64_clang",
+      "inheritConfigureEnvironment": true
+    }
+
+  ]
+}

--- a/llvm/CMakePresets.json
+++ b/llvm/CMakePresets.json
@@ -18,7 +18,6 @@
       "generator": "Ninja",
       "binaryDir": "${sourceParentDir}/out/${presetName}",
       "cacheVariables": {
-        /* Most of the users would like to have these projects enabled */
         "LLVM_ENABLE_PROJECTS": "clang;lld;clang-tools-extra"
       }
     },
@@ -60,8 +59,7 @@
         "CMAKE_BUILD_TYPE": "Release",
         "CMAKE_CXX_COMPILER": "clang-cl",
         "CMAKE_C_COMPILER": "clang-cl",
-        "LLVM_ENABLE_PDB": "ON",
-        "LLVM_ENABLE_ASSERTIONS": "ON"
+        "LLVM_ENABLE_PDB": "ON"
       }
     }
   ],

--- a/llvm/CMakePresets.json
+++ b/llvm/CMakePresets.json
@@ -1,7 +1,7 @@
 
 /*
    This is the default presets for LLVM, if you want to add your own
-   custom one, create a CMakeUserPreset.json instead.
+   custom one, create a CMakeUserPresets.json instead.
 */
 
 {

--- a/llvm/docs/GettingStartedVS.rst
+++ b/llvm/docs/GettingStartedVS.rst
@@ -36,7 +36,7 @@ and software you will need.
 
 Hardware
 --------
-Any system that can adequately run Visual Studio 2019 is fine. The LLVM
+Any system that can adequately run Visual Studio 2019 or 2022 is fine. The LLVM
 source tree including the git index consumes approximately 3GB.
 Object files, libraries and executables consume approximately 5GB in
 Release mode and much more in Debug mode. SSD drive and >16GB RAM are
@@ -47,7 +47,7 @@ Software
 --------
 You will need `Visual Studio <https://visualstudio.microsoft.com/>`_ 2019 or
 later, with the latest Update installed. Visual Studio Community Edition
-suffices.
+suffices. We recommend using Visual Studio 2022.
 
 You will also need the `CMake <http://www.cmake.org/>`_ build system since it
 generates the project files you will use to build with. CMake is bundled with
@@ -72,7 +72,8 @@ These instruction were tested with Visual Studio 2019 and Python 3.9.6:
 1. Download and install `Visual Studio <https://visualstudio.microsoft.com/>`_.
 2. In the Visual Studio installer, Workloads tab, select the
    **Desktop development with C++** workload. Under Individual components tab,
-   select **Git for Windows**.
+   select **Git for Windows**. You might want to install **C++ Clang compiler for Windows**
+   as well, since this will allow you to build LLVM with Clang. 
 3. Complete the Visual Studio installation.
 4. Download and install the latest `Python 3 release <http://www.python.org/>`_.
 5. In the first install screen, select both **Install launcher for all users**
@@ -119,7 +120,43 @@ These instruction were tested with Visual Studio 2019 and Python 3.9.6:
  Select the last link: ``Source code (zip)`` and unpack the downloaded file using
  Windows Explorer built-in zip support or any other unzip tool.
 
-12. Finally, configure LLVM using CMake:
+12. Open the LLVM folder in Visual Studio or configure LLVM with CMake.
+
+    Recently Visual Studio has added native support for CMake which will run and
+    manage the CMake settings for you instead of you manually having to generate
+    a Visual Studio Soluion. This is the recommended way to build and debug LLVM
+    in Visual Studio 2022.
+
+    If you want to generate a Visual Studio Solution for older versions of Visual
+    Studio or becasue that is a workflow that suites you better please refer to the
+    chapter below on :ref:`generating Visual Studio Solution<gen_vs_cmake>`.
+
+    To use the native CMake support, launch `Visual Studio 2022` and select the
+    option `Open a Local Folder` and open the root `llvm-project` folder. This
+    will automatically launch CMake (have some patience, it can be a bit slow)
+    and populate the interface.
+
+    LLVM ships with a default `CMakePresets.json` that is supposed to make it easy
+    to get started, but usually you need to modify the setings used, the best way
+    to do this is to create a `CMakeUserPresets.json` in the `llvm` subfolder and
+    add your own configuration there. For more information about the Preset system
+    see `Microsoft's documentation <https://learn.microsoft.com/en-us/cpp/build/cmake-presets-json-reference>`_.
+
+    The default CMakePreset comes with MSVC and Clang targets. In order to use the
+    Clang target you need to have the **C++ Clang compiler for Windows** component
+    of Visual Studio installed.
+
+    In order to debug Clang and other binaries within Visual Studio, see `Microsoft's
+    documentation. <https://learn.microsoft.com/en-us/cpp/build/configure-cmake-debugging-sessions>`_.
+
+
+.. _gen_vs_cmake:
+
+Generate Visual Studio Solution with CMake
+==========================================
+
+1.  After following the steps above you can generate a Visual Studio Solution by
+    running the following CMake command:
 
     .. code-block:: bat
 
@@ -154,7 +191,7 @@ These instruction were tested with Visual Studio 2019 and Python 3.9.6:
      want to use the 64-bit toolset, pass the ``-Thost=x64`` flag when
      generating the Visual Studio solution. This requires CMake 3.8.0 or later.
 
-13. Start Visual Studio and select configuration:
+2. Start Visual Studio and select configuration:
 
    In the directory you created the project files will have an ``llvm.sln``
    file, just double-click on that to open Visual Studio. The default Visual
@@ -166,7 +203,7 @@ These instruction were tested with Visual Studio 2019 and Python 3.9.6:
    compiler flags, disabling optimization and enabling debug information, only
    for specific libraries or source files you actually need to debug.
 
-14. Test LLVM in Visual Studio:
+3. Test LLVM in Visual Studio:
 
    You can run LLVM tests by merely building the project "check-all". The test
    results will be shown in the VS output window. Once the build succeeds, you

--- a/llvm/docs/GettingStartedVS.rst
+++ b/llvm/docs/GettingStartedVS.rst
@@ -153,17 +153,14 @@ LLVM ships with a default CMakePresets.json that is supposed to make it easy to
 get started, but usually you need to modify the settings used. The best way to
 do this is to create a CMakeUserPresets.json in the llvm subfolder and add your
 configuration there. For more information about the Preset system, see
-Microsoft's documentation
-<https://learn.microsoft.com/en-us/cpp/build/cmake-presets-json-reference>_.
+`Microsoft's documentation <https://learn.microsoft.com/en-us/cpp/build/cmake-presets-json-reference>`_.
 
 The default CMakePreset comes with MSVC and Clang targets. To use the Clang
 target, you need to have the C++ Clang compiler for Windows component of Visual
 Studio installed.
 
-To debug Clang and other binaries within Visual Studio, see Microsoft's
-documentation
-<https://learn.microsoft.com/en-us/cpp/build/configure-cmake-debugging-sessions>_.
-
+To debug Clang and other binaries within Visual Studio, see 
+`Visual Studio documentation <https://learn.microsoft.com/en-us/cpp/build/configure-cmake-debugging-sessions>`_.
 
 .. _gen_vs_cmake:
 

--- a/llvm/docs/GettingStartedVS.rst
+++ b/llvm/docs/GettingStartedVS.rst
@@ -63,6 +63,7 @@ allows you to adjust installation options.
 You will need `Git for Windows <https://git-scm.com/>`_ with bash tools, too.
 Git for Windows is also bundled with Visual Studio 2019.
 
+.. _getting_started:
 
 Getting Started
 ===============
@@ -132,13 +133,15 @@ These instruction were tested with Visual Studio 2019 and Python 3.9.6:
 Visual Studio native CMake support
 ==================================
 
+Before you can build LLVM with Visual Studio you need to follow the step
+outlined in :ref:`Getting Started<getting_started>`.
+
 Support for native CMake integration was added in Visual Studio 2019, but it has
 been made more robust in 2022. If you are using Visual Studio before 2022, it's
 recommended to generate a Visual Studio solution from CMake instead of using the
 native CMake integration.
 
-If you want to generate a Visual Studio Solution for older versions of Visual
-Studio or because that is a workflow that suits you better, please refer to the
+If you want to generate a Visual Studio Solution, please refer to the
 chapter below on :ref:generating Visual Studio Solution<gen_vs_cmake>.
 
 To use the native CMake support, launch Visual Studio 2022 and select the option
@@ -167,8 +170,10 @@ documentation
 Generate Visual Studio Solution with CMake
 ==========================================
 
-1.  After following the steps above you can generate a Visual Studio Solution by
-    running the following CMake command:
+Before you can generate the Visual Studio solution you need to follow the step
+outlined in :ref:`Getting Started<getting_started>`.
+
+1.  You can generate a Visual Studio Solution by running the following CMake command:
 
     .. code-block:: bat
 

--- a/llvm/docs/GettingStartedVS.rst
+++ b/llvm/docs/GettingStartedVS.rst
@@ -120,34 +120,46 @@ These instruction were tested with Visual Studio 2019 and Python 3.9.6:
  Select the last link: ``Source code (zip)`` and unpack the downloaded file using
  Windows Explorer built-in zip support or any other unzip tool.
 
-12. Open the LLVM folder in Visual Studio or configure LLVM with CMake.
+12. Open the LLVM folder in Visual Studio or generate a solution via CMake.
 
-    Recently Visual Studio has added native support for CMake which will run and
-    manage the CMake settings for you instead of you manually having to generate
-    a Visual Studio Soluion. This is the recommended way to build and debug LLVM
-    in Visual Studio 2022.
+  At this point you can select if you want to use the
+  :ref:`native support for CMake<vs_native_cmake>` in Visual Studio or
+  :ref:`generate Visual Studio<gen_vs_cmake>` solution file from CMake.
+  Both integrations are supported in the LLVM project.
 
-    If you want to generate a Visual Studio Solution for older versions of Visual
-    Studio or becasue that is a workflow that suites you better please refer to the
-    chapter below on :ref:`generating Visual Studio Solution<gen_vs_cmake>`.
+.. _vs_native_cmake:
 
-    To use the native CMake support, launch `Visual Studio 2022` and select the
-    option `Open a Local Folder` and open the root `llvm-project` folder. This
-    will automatically launch CMake (have some patience, it can be a bit slow)
-    and populate the interface.
+Visual Studio native CMake support
+==================================
 
-    LLVM ships with a default `CMakePresets.json` that is supposed to make it easy
-    to get started, but usually you need to modify the setings used, the best way
-    to do this is to create a `CMakeUserPresets.json` in the `llvm` subfolder and
-    add your own configuration there. For more information about the Preset system
-    see `Microsoft's documentation <https://learn.microsoft.com/en-us/cpp/build/cmake-presets-json-reference>`_.
+Support for native CMake integration was added in Visual Studio 2019, but it has
+been made more robust in 2022. If you are using Visual Studio before 2022, it's
+recommended to generate a Visual Studio solution from CMake instead of using the
+native CMake integration.
 
-    The default CMakePreset comes with MSVC and Clang targets. In order to use the
-    Clang target you need to have the **C++ Clang compiler for Windows** component
-    of Visual Studio installed.
+If you want to generate a Visual Studio Solution for older versions of Visual
+Studio or because that is a workflow that suits you better, please refer to the
+chapter below on :ref:generating Visual Studio Solution<gen_vs_cmake>.
 
-    In order to debug Clang and other binaries within Visual Studio, see `Microsoft's
-    documentation. <https://learn.microsoft.com/en-us/cpp/build/configure-cmake-debugging-sessions>`_.
+To use the native CMake support, launch Visual Studio 2022 and select the option
+Open a Local Folder and open the root llvm-project folder. This will
+automatically launch CMake (have some patience, it can be a bit slow) and
+populate the interface.
+
+LLVM ships with a default CMakePresets.json that is supposed to make it easy to
+get started, but usually you need to modify the settings used. The best way to
+do this is to create a CMakeUserPresets.json in the llvm subfolder and add your
+configuration there. For more information about the Preset system, see
+Microsoft's documentation
+<https://learn.microsoft.com/en-us/cpp/build/cmake-presets-json-reference>_.
+
+The default CMakePreset comes with MSVC and Clang targets. To use the Clang
+target, you need to have the C++ Clang compiler for Windows component of Visual
+Studio installed.
+
+To debug Clang and other binaries within Visual Studio, see Microsoft's
+documentation
+<https://learn.microsoft.com/en-us/cpp/build/configure-cmake-debugging-sessions>_.
 
 
 .. _gen_vs_cmake:


### PR DESCRIPTION
This commit adds the following:

* .vs/CMakeWorkspaceSettings.json - This file make Visual Studio find the llvm source directory out of the box with no configuration. And enables CMake for this project.
* Adds llvm/CMakePresets.json - Some sane defaults to make VS be able to configure and build LLVM/Clang without any changes. At this time it only adds Windows targets, but can be expanded for other platforms.
* Update the documentation for Getting started on Windows. This points out that the Visual Studio native CMake configuration is a better choice for most people.

This works great when installing Visual Studio 2022 community edition and just opening the llvm-project folder, but I would love to hear what other people think about the defaults in the preset and the documentation changes. If you have access to a visual studio install, please try this patch and following the docs.

