### PR TITLE
[Orc] Drop call-wrapper shortcuts from core ExecutionSession interface (NFC)

### DIFF
--- a/llvm/include/llvm/ExecutionEngine/Orc/Core.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/Core.h
@@ -1645,52 +1645,6 @@ public:
     DispatchTask(std::move(T));
   }
 
-  /// Run a wrapper function in the executor.
-  ///
-  /// The wrapper function should be callable as:
-  ///
-  /// \code{.cpp}
-  ///   CWrapperFunctionResult fn(uint8_t *Data, uint64_t Size);
-  /// \endcode{.cpp}
-  ///
-  /// The given OnComplete function will be called to return the result.
-  template <typename... ArgTs>
-  void callWrapperAsync(ArgTs &&... Args) {
-    EPC->callWrapperAsync(std::forward<ArgTs>(Args)...);
-  }
-
-  /// Run a wrapper function in the executor. The wrapper function should be
-  /// callable as:
-  ///
-  /// \code{.cpp}
-  ///   CWrapperFunctionResult fn(uint8_t *Data, uint64_t Size);
-  /// \endcode{.cpp}
-  shared::WrapperFunctionResult callWrapper(ExecutorAddr WrapperFnAddr,
-                                            ArrayRef<char> ArgBuffer) {
-    return EPC->callWrapper(WrapperFnAddr, ArgBuffer);
-  }
-
-  /// Run a wrapper function using SPS to serialize the arguments and
-  /// deserialize the results.
-  template <typename SPSSignature, typename SendResultT, typename... ArgTs>
-  void callSPSWrapperAsync(ExecutorAddr WrapperFnAddr, SendResultT &&SendResult,
-                           const ArgTs &...Args) {
-    EPC->callSPSWrapperAsync<SPSSignature, SendResultT, ArgTs...>(
-        WrapperFnAddr, std::forward<SendResultT>(SendResult), Args...);
-  }
-
-  /// Run a wrapper function using SPS to serialize the arguments and
-  /// deserialize the results.
-  ///
-  /// If SPSSignature is a non-void function signature then the second argument
-  /// (the first in the Args list) should be a reference to a return value.
-  template <typename SPSSignature, typename... WrapperCallArgTs>
-  Error callSPSWrapper(ExecutorAddr WrapperFnAddr,
-                       WrapperCallArgTs &&...WrapperCallArgs) {
-    return EPC->callSPSWrapper<SPSSignature, WrapperCallArgTs...>(
-        WrapperFnAddr, std::forward<WrapperCallArgTs>(WrapperCallArgs)...);
-  }
-
   /// Wrap a handler that takes concrete argument types (and a sender for a
   /// concrete return type) to produce an AsyncHandlerWrapperFunction. Uses SPS
   /// to unpack the arguments and pack the result.

--- a/llvm/include/llvm/ExecutionEngine/Orc/EPCEHFrameRegistrar.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/EPCEHFrameRegistrar.h
@@ -20,6 +20,7 @@ namespace llvm {
 namespace orc {
 
 class ExecutionSession;
+class ExecutorProcessControl;
 
 /// Register/Deregisters EH frames in a remote process via a
 /// ExecutorProcessControl instance.
@@ -37,17 +38,17 @@ public:
 
   /// Create a EPCEHFrameRegistrar with the given ExecutorProcessControl
   /// object and registration/deregistration function addresses.
-  EPCEHFrameRegistrar(ExecutionSession &ES,
+  EPCEHFrameRegistrar(ExecutorProcessControl &EPC,
                       ExecutorAddr RegisterEHFrameSectionWrapper,
                       ExecutorAddr DeregisterEHFRameSectionWrapper)
-      : ES(ES), RegisterEHFrameSectionWrapper(RegisterEHFrameSectionWrapper),
+      : EPC(EPC), RegisterEHFrameSectionWrapper(RegisterEHFrameSectionWrapper),
         DeregisterEHFrameSectionWrapper(DeregisterEHFRameSectionWrapper) {}
 
   Error registerEHFrames(ExecutorAddrRange EHFrameSection) override;
   Error deregisterEHFrames(ExecutorAddrRange EHFrameSection) override;
 
 private:
-  ExecutionSession &ES;
+  ExecutorProcessControl &EPC;
   ExecutorAddr RegisterEHFrameSectionWrapper;
   ExecutorAddr DeregisterEHFrameSectionWrapper;
 };

--- a/llvm/lib/ExecutionEngine/Orc/ELFNixPlatform.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/ELFNixPlatform.cpp
@@ -507,7 +507,8 @@ Error ELFNixPlatform::bootstrapELFNixRuntime(JITDylib &PlatformJD) {
   if (!PJDDSOHandle)
     return PJDDSOHandle.takeError();
 
-  if (auto Err = ES.callSPSWrapper<void(uint64_t)>(
+  auto &EPC = ES.getExecutorProcessControl();
+  if (auto Err = EPC.callSPSWrapper<void(uint64_t)>(
           orc_rt_elfnix_platform_bootstrap,
           PJDDSOHandle->getAddress().getValue()))
     return Err;
@@ -574,7 +575,8 @@ Error ELFNixPlatform::registerPerObjectSections(
                                    inconvertibleErrorCode());
 
   Error ErrResult = Error::success();
-  if (auto Err = ES.callSPSWrapper<shared::SPSError(
+  auto &EPC = ES.getExecutorProcessControl();
+  if (auto Err = EPC.callSPSWrapper<shared::SPSError(
                      SPSELFPerObjectSectionsToRegister)>(
           orc_rt_elfnix_register_object_sections, ErrResult, POSR))
     return Err;
@@ -589,7 +591,8 @@ Expected<uint64_t> ELFNixPlatform::createPThreadKey() {
         inconvertibleErrorCode());
 
   Expected<uint64_t> Result(0);
-  if (auto Err = ES.callSPSWrapper<SPSExpected<uint64_t>(void)>(
+  auto &EPC = ES.getExecutorProcessControl();
+  if (auto Err = EPC.callSPSWrapper<SPSExpected<uint64_t>(void)>(
           orc_rt_elfnix_create_pthread_key, Result))
     return std::move(Err);
   return Result;

--- a/llvm/lib/ExecutionEngine/Orc/EPCDebugObjectRegistrar.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/EPCDebugObjectRegistrar.cpp
@@ -51,7 +51,8 @@ Expected<std::unique_ptr<EPCDebugObjectRegistrar>> createJITLoaderGDBRegistrar(
 
 Error EPCDebugObjectRegistrar::registerDebugObject(ExecutorAddrRange TargetMem,
                                                    bool AutoRegisterCode) {
-  return ES.callSPSWrapper<void(shared::SPSExecutorAddrRange, bool)>(
+  auto &EPC = ES.getExecutorProcessControl();
+  return EPC.callSPSWrapper<void(shared::SPSExecutorAddrRange, bool)>(
       RegisterFn, TargetMem, AutoRegisterCode);
 }
 

--- a/llvm/lib/ExecutionEngine/Orc/LLJIT.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/LLJIT.cpp
@@ -614,9 +614,10 @@ Error ORCPlatformSupport::initialize(orc::JITDylib &JD) {
 
   if (auto WrapperAddr = ES.lookup(
           MainSearchOrder, J.mangleAndIntern("__orc_rt_jit_dlopen_wrapper"))) {
-    return ES.callSPSWrapper<SPSDLOpenSig>(WrapperAddr->getAddress(),
-                                           DSOHandles[&JD], JD.getName(),
-                                           int32_t(ORC_RT_RTLD_LAZY));
+    auto &EPC = ES.getExecutorProcessControl();
+    return EPC.callSPSWrapper<SPSDLOpenSig>(WrapperAddr->getAddress(),
+                                            DSOHandles[&JD], JD.getName(),
+                                            int32_t(ORC_RT_RTLD_LAZY));
   } else
     return WrapperAddr.takeError();
 }
@@ -632,8 +633,9 @@ Error ORCPlatformSupport::deinitialize(orc::JITDylib &JD) {
   if (auto WrapperAddr = ES.lookup(
           MainSearchOrder, J.mangleAndIntern("__orc_rt_jit_dlclose_wrapper"))) {
     int32_t result;
-    auto E = J.getExecutionSession().callSPSWrapper<SPSDLCloseSig>(
-        WrapperAddr->getAddress(), result, DSOHandles[&JD]);
+    auto &EPC = ES.getExecutorProcessControl();
+    auto E = EPC.callSPSWrapper<SPSDLCloseSig>(WrapperAddr->getAddress(),
+                                               result, DSOHandles[&JD]);
     if (E)
       return E;
     else if (result)

--- a/llvm/lib/ExecutionEngine/Orc/MachOPlatform.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/MachOPlatform.cpp
@@ -769,7 +769,8 @@ Expected<uint64_t> MachOPlatform::createPThreadKey() {
         inconvertibleErrorCode());
 
   Expected<uint64_t> Result(0);
-  if (auto Err = ES.callSPSWrapper<SPSExpected<uint64_t>(void)>(
+  auto &EPC = ES.getExecutorProcessControl();
+  if (auto Err = EPC.callSPSWrapper<SPSExpected<uint64_t>(void)>(
           CreatePThreadKey.Addr, Result))
     return std::move(Err);
   return Result;


### PR DESCRIPTION
These functions are available through the ExecutorProcessControl interface.