### PR TITLE
[llvm-diff] Also diff alloca's allocated type and alignment

### DIFF
--- a/llvm/test/tools/llvm-diff/special-state.ll
+++ b/llvm/test/tools/llvm-diff/special-state.ll
@@ -1,0 +1,42 @@
+; Diff file with itself, assert no difference by return code
+; RUN: llvm-diff %s %s
+
+; Replace %newvar1 with %newvar2 in the phi node. This can only
+; be detected to be different once BB1 has been processed.
+; RUN: rm -f %t.ll
+; RUN: cat %s | sed -e 's/i16/i8/' > %t.ll
+; RUN: not llvm-diff %s %t.ll 2>&1 | FileCheck %s
+
+; CHECK:      in function alloca:
+; CHECK-NEXT:   in block %0 / %0:
+; CHECK-NEXT:     >   %1 = alloca i8, align 1
+; CHECK-NEXT:     >   ret ptr %1
+; CHECK-NEXT:     <   %1 = alloca i16, align 1
+; CHECK-NEXT:     <   ret ptr %1
+
+define ptr @alloca() {
+  %1 = alloca i16, align 1
+  ret ptr %1
+}
+
+; CHECK:      in function load:
+; CHECK-NEXT:   in block %0 / %0:
+; CHECK-NEXT:     >   %1 = load i8, ptr %addr, align 4
+; CHECK-NEXT:     <   %1 = load i16, ptr %addr, align 4
+
+define void @load(ptr %addr) {
+  %1 = load i16, ptr %addr, align 4
+  ret void
+}
+
+; CHECK:      in function gep:
+; CHECK-NEXT:   in block %0 / %0:
+; CHECK-NEXT:     >   %1 = getelementptr %struct.ty1.0, ptr %addr, i32 0
+; CHECK-NEXT:     <   %1 = getelementptr %struct.ty1, ptr %addr, i32 0
+
+%struct.ty1 = type { i16 }
+
+define void @gep(ptr %addr) {
+  %1 = getelementptr %struct.ty1, ptr %addr, i32 0
+  ret void
+}

--- a/llvm/tools/llvm-diff/lib/DifferenceEngine.cpp
+++ b/llvm/tools/llvm-diff/lib/DifferenceEngine.cpp
@@ -377,6 +377,9 @@ class FunctionDifferenceEngine {
       return true;
     }
 
+    if (!L->hasSameSpecialState(R))
+      return true;
+
     if (isa<CmpInst>(L)) {
       if (cast<CmpInst>(L)->getPredicate()
             != cast<CmpInst>(R)->getPredicate()) {
@@ -527,20 +530,6 @@ class FunctionDifferenceEngine {
           Difference = true;
         }
       return Difference;
-    } else if (isa<AllocaInst>(L)) {
-      const AllocaInst *LI = cast<AllocaInst>(L);
-      const AllocaInst *RI = cast<AllocaInst>(R);
-
-      if (LI->getAllocatedType() != RI->getAllocatedType()) {
-        if (Complain)
-          Engine.log("alloca allocated type differ");
-        return true;
-      }
-      if (LI->getAlign() != RI->getAlign()) {
-        if (Complain)
-          Engine.log("alloca alignment differ");
-        return true;
-      }
     } else if (isa<UnreachableInst>(L)) {
       return false;
     }

--- a/llvm/tools/llvm-diff/lib/DifferenceEngine.cpp
+++ b/llvm/tools/llvm-diff/lib/DifferenceEngine.cpp
@@ -389,6 +389,12 @@ class FunctionDifferenceEngine {
         if (Complain) Engine.log("different predicates");
         return true;
       }
+    } else if (isa<LoadInst>(L)) {
+      if (cast<LoadInst>(L)->getType() != cast<LoadInst>(R)->getType()) {
+        if (Complain)
+          Engine.log("load types differ");
+        return true;
+      }
     } else if (isa<CallInst>(L)) {
       return diffCallSites(cast<CallInst>(*L), cast<CallInst>(*R), Complain);
     } else if (isa<PHINode>(L)) {

--- a/llvm/tools/llvm-diff/lib/DifferenceEngine.cpp
+++ b/llvm/tools/llvm-diff/lib/DifferenceEngine.cpp
@@ -377,8 +377,11 @@ class FunctionDifferenceEngine {
       return true;
     }
 
-    if (!L->hasSameSpecialState(R))
+    if (!L->hasSameSpecialState(R)) {
+      if (Complain)
+        Engine.log("special states differ");
       return true;
+    }
 
     if (isa<CmpInst>(L)) {
       if (cast<CmpInst>(L)->getPredicate()

--- a/llvm/tools/llvm-diff/lib/DifferenceEngine.cpp
+++ b/llvm/tools/llvm-diff/lib/DifferenceEngine.cpp
@@ -527,6 +527,20 @@ class FunctionDifferenceEngine {
           Difference = true;
         }
       return Difference;
+    } else if (isa<AllocaInst>(L)) {
+      const AllocaInst *LI = cast<AllocaInst>(L);
+      const AllocaInst *RI = cast<AllocaInst>(R);
+
+      if (LI->getAllocatedType() != RI->getAllocatedType()) {
+        if (Complain)
+          Engine.log("alloca allocated type differ");
+        return true;
+      }
+      if (LI->getAlign() != RI->getAlign()) {
+        if (Complain)
+          Engine.log("alloca alignment differ");
+        return true;
+      }
     } else if (isa<UnreachableInst>(L)) {
       return false;
     }


### PR DESCRIPTION
Currently, the function
https://github.com/llvm/llvm-project/blob/8c3304453c22ad1b5a914e64a7f6435f58f4099c/llvm/tools/llvm-diff/lib/DifferenceEngine.cpp#L364-L369
doesn't handle the non-operand data of `AllocaInst`. For example,
``` llvm
alloca i64, align 1
alloca i32, align 1
```
would be considered the same instruction.

---

Under some special circumstances, that would make llvm-diff crash:
``` llvm
define ptr @func() {
  %1 = alloca i64, align 1
  %2 = alloca i32, align 1
  %3 = alloca i8, align 1
  ret ptr %2
}
```

``` llvm
define ptr @func() {
  %1 = alloca i64, align 1
  %2 = alloca i32, align 1
  ret ptr %2
}
```

```
$ ./build/bin/llvm-diff lhs.ll rhs.ll
in function func:
  in block %0 / %0:
    in instruction   ret ptr %2 /   ret ptr %2:
      operands %2 and %2 differ
llvm-diff: path/llvm/tools/llvm-diff/lib/DifferenceEngine.cpp:268: void (anonymous namespace)::FunctionDifferenceEngine::unify(const Instruction *, const Instruction *): Assertion `!Result && "structural differences second time around?"' failed.
fish: Job 1, './build/bin/llvm-diff lhs.ll r…' terminated by signal SIGABRT (Abort)
```