### PR TITLE
[flang] Avoid forming a reference from null pointer

### DIFF
--- a/flang/lib/Parser/token-sequence.cpp
+++ b/flang/lib/Parser/token-sequence.cpp
@@ -136,7 +136,10 @@ void TokenSequence::Put(
 }
 
 void TokenSequence::Put(const CharBlock &t, Provenance provenance) {
-  Put(&t[0], t.size(), provenance);
+  // Avoid t[0] if t is empty: it would create a reference to nullptr,
+  // which is UB.
+  const char *addr = t.size() ? &t[0] : nullptr;
+  Put(addr, t.size(), provenance);
 }
 
 void TokenSequence::Put(const std::string &s, Provenance provenance) {

--- a/flang/lib/Parser/token-sequence.cpp
+++ b/flang/lib/Parser/token-sequence.cpp
@@ -138,7 +138,7 @@ void TokenSequence::Put(
 void TokenSequence::Put(const CharBlock &t, Provenance provenance) {
   // Avoid t[0] if t is empty: it would create a reference to nullptr,
   // which is UB.
-  const char *addr = t.size() ? &t[0] : nullptr;
+  const char *addr{t.size() ? &t[0] : nullptr};
   Put(addr, t.size(), provenance);
 }
 


### PR DESCRIPTION
Doing so is an undefined behavior.

This was detected by the undefined behavior sanitizer.