### PR TITLE
[libcxx] makes `pair` conditionally trivially copyable for C++20

### DIFF
--- a/libcxx/include/__config
+++ b/libcxx/include/__config
@@ -180,6 +180,9 @@
 // requires code not to make these assumptions.
 #    define _LIBCPP_ABI_USE_WRAP_ITER_IN_STD_ARRAY
 #    define _LIBCPP_ABI_USE_WRAP_ITER_IN_STD_STRING_VIEW
+// Allows std::pair's copy assignment and move assignment operators to be trivial
+// when both its element types' respective assignment operators are trivial.
+#    define _LIBCPP_ABI_PAIR_TRIVIALLY_COPYABLE
 #  elif _LIBCPP_ABI_VERSION == 1
 #    if !(defined(_LIBCPP_OBJECT_FORMAT_COFF) || defined(_LIBCPP_OBJECT_FORMAT_XCOFF))
 // Enable compiling copies of now inline methods into the dylib to support

--- a/libcxx/test/std/utilities/utility/pairs/pairs.pair/assign_pair.pass.cpp
+++ b/libcxx/test/std/utilities/utility/pairs/pairs.pair/assign_pair.pass.cpp
@@ -88,6 +88,16 @@ TEST_CONSTEXPR_CXX20 bool test() {
     assert(&p.second == &inc_obj);
   }
 
+#if TEST_STD_VER >= 20 && defined(_LIBCPP_ABI_PAIR_TRIVIALLY_COPYABLE)
+  static_assert(std::is_trivially_copy_assignable<std::pair<int, int>>::value, "");
+#else
+  static_assert(!std::is_trivially_copy_assignable<std::pair<int, int>>::value, "");
+#endif
+
+  static_assert(!std::is_trivially_copy_assignable<std::pair<CountAssign, int>>::value, "");
+  static_assert(!std::is_trivially_copy_assignable<std::pair<int, CountAssign>>::value, "");
+  static_assert(!std::is_trivially_copy_assignable<std::pair<CountAssign, CountAssign>>::value, "");
+
   return true;
 }
 

--- a/libcxx/test/std/utilities/utility/pairs/pairs.pair/assign_pair_cxx03.pass.cpp
+++ b/libcxx/test/std/utilities/utility/pairs/pairs.pair/assign_pair_cxx03.pass.cpp
@@ -62,7 +62,9 @@ int main(int, char**)
       assert(p.second == 'x');
     }
 
-  return 0;
+    static_assert(!std::is_trivially_copy_assignable<std::pair<int, int> >::value, "");
+
+    return 0;
 }
 
 struct Incomplete {};

--- a/libcxx/test/std/utilities/utility/pairs/pairs.pair/assign_rv_pair.pass.cpp
+++ b/libcxx/test/std/utilities/utility/pairs/pairs.pair/assign_rv_pair.pass.cpp
@@ -130,6 +130,17 @@ TEST_CONSTEXPR_CXX20 bool test() {
     static_assert(!std::is_move_assignable<P5>::value, "");
     static_assert(!std::is_move_assignable<P6>::value, "");
   }
+
+#if TEST_STD_VER >= 20 && defined(_LIBCPP_ABI_PAIR_TRIVIALLY_COPYABLE)
+  static_assert(std::is_trivially_move_assignable<std::pair<int, int>>::value, "");
+#else
+  static_assert(!std::is_trivially_move_assignable<std::pair<int, int>>::value, "");
+#endif
+
+  static_assert(!std::is_trivially_move_assignable<std::pair<CountAssign, int>>::value, "");
+  static_assert(!std::is_trivially_move_assignable<std::pair<int, CountAssign>>::value, "");
+  static_assert(!std::is_trivially_move_assignable<std::pair<CountAssign, CountAssign>>::value, "");
+
   return true;
 }
 

--- a/libcxx/test/std/utilities/utility/pairs/pairs.pair/trivially_copyable.compile.pass.cpp
+++ b/libcxx/test/std/utilities/utility/pairs/pairs.pair/trivially_copyable.compile.pass.cpp
@@ -1,0 +1,45 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: c++03, c++11, c++14, c++17
+
+// <utility>
+
+// template <class T1, class T2> struct pair
+
+// Checks that `std::pair` is actually trivially copyable.
+
+#include <type_traits>
+#include <utility>
+
+#if defined(_LIBCPP_ABI_PAIR_TRIVIALLY_COPYABLE)
+static_assert(std::is_trivially_copyable_v<std::pair<int, int>>);
+static_assert(std::is_trivially_copyable_v<std::pair<int, int const>>);
+static_assert(std::is_trivially_copyable_v<std::pair<int const, int>>);
+static_assert(std::is_trivially_copyable_v<std::pair<int const, int const>>);
+
+static_assert(!std::is_trivially_copyable_v<std::pair<int, int&>>);
+static_assert(!std::is_trivially_copyable_v<std::pair<int&, int>>);
+static_assert(!std::is_trivially_copyable_v<std::pair<int&, int&>>);
+
+enum E {};
+static_assert(std::is_trivially_copyable_v<std::pair<E, E>>);
+static_assert(std::is_trivially_copyable_v<std::pair<E, E const>>);
+static_assert(std::is_trivially_copyable_v<std::pair<E const, E>>);
+static_assert(std::is_trivially_copyable_v<std::pair<E const, E const>>);
+
+static_assert(std::is_trivially_copyable_v<std::pair<E, int>>);
+static_assert(std::is_trivially_copyable_v<std::pair<E, int const>>);
+static_assert(std::is_trivially_copyable_v<std::pair<E const, int>>);
+static_assert(std::is_trivially_copyable_v<std::pair<E const, int const>>);
+
+struct S {};
+static_assert(std::is_trivially_copyable_v<std::pair<S, S>>);
+static_assert(std::is_trivially_copyable_v<std::pair<S, int>>);
+static_assert(std::is_trivially_copyable_v<std::pair<S, E>>);
+#endif


### PR DESCRIPTION
`pair` can have trivial copy and move assignment operators when both its members have trivial copy and move operators, which opens `pair` up to being trivially copyable. This is the first of three possible commits to bring users a more robust implementation of `std::pair`.

It's currently unclear how to implement this without using a _requires-clause_, so the feature is restricted to C++20 for now, but backporting this to C++11 would be ideal. There has also been some interest in moving this out of the unstable ABI mode. Both of these changes are intended to arrive in future pull requests, should their feasibility pan out.