### PR TITLE
[libc] move non <bit> functions to math_extras

### DIFF
--- a/libc/src/__support/CMakeLists.txt
+++ b/libc/src/__support/CMakeLists.txt
@@ -34,6 +34,7 @@ add_header_library(
   HDRS
     math_extras.h
   DEPENDS
+    libc.src.__support.CPP.bit
     libc.src.__support.CPP.limits
     libc.src.__support.CPP.type_traits
     libc.src.__support.macros.attributes

--- a/libc/src/__support/CPP/bit.h
+++ b/libc/src/__support/CPP/bit.h
@@ -239,36 +239,6 @@ LIBC_INLINE constexpr To bit_or_static_cast(const From &from) {
   }
 }
 
-// TODO: remove from 'bit.h' as it is not a standard function.
-template <typename T>
-[[nodiscard]] LIBC_INLINE constexpr cpp::enable_if_t<cpp::is_unsigned_v<T>, int>
-first_leading_zero(T value) {
-  return value == cpp::numeric_limits<T>::max() ? 0 : countl_one(value) + 1;
-}
-
-// TODO: remove from 'bit.h' as it is not a standard function.
-template <typename T>
-[[nodiscard]] LIBC_INLINE constexpr cpp::enable_if_t<cpp::is_unsigned_v<T>, int>
-first_leading_one(T value) {
-  return first_leading_zero(static_cast<T>(~value));
-}
-
-// TODO: remove from 'bit.h' as it is not a standard function.
-template <typename T>
-[[nodiscard]] LIBC_INLINE constexpr cpp::enable_if_t<cpp::is_unsigned_v<T>, int>
-first_trailing_zero(T value) {
-  return value == cpp::numeric_limits<T>::max()
-             ? 0
-             : countr_zero(static_cast<T>(~value)) + 1;
-}
-
-// TODO: remove from 'bit.h' as it is not a standard function.
-template <typename T>
-[[nodiscard]] LIBC_INLINE constexpr cpp::enable_if_t<cpp::is_unsigned_v<T>, int>
-first_trailing_one(T value) {
-  return value == cpp::numeric_limits<T>::max() ? 0 : countr_zero(value) + 1;
-}
-
 /// Count number of 1's aka population count or Hamming weight.
 ///
 /// Only unsigned integral types are allowed.
@@ -293,13 +263,6 @@ ADD_SPECIALIZATION(unsigned long, __builtin_popcountl)
 ADD_SPECIALIZATION(unsigned long long, __builtin_popcountll)
 // TODO: 128b specializations?
 #undef ADD_SPECIALIZATION
-
-// TODO: remove from 'bit.h' as it is not a standard function.
-template <typename T>
-[[nodiscard]] LIBC_INLINE constexpr cpp::enable_if_t<cpp::is_unsigned_v<T>, int>
-count_zeros(T value) {
-  return popcount<T>(static_cast<T>(~value));
-}
 
 } // namespace LIBC_NAMESPACE::cpp
 

--- a/libc/src/__support/math_extras.h
+++ b/libc/src/__support/math_extras.h
@@ -10,7 +10,8 @@
 #ifndef LLVM_LIBC_SRC___SUPPORT_MATH_EXTRAS_H
 #define LLVM_LIBC_SRC___SUPPORT_MATH_EXTRAS_H
 
-#include "src/__support/CPP/limits.h"        // CHAR_BIT
+#include "src/__support/CPP/bit.h"           // countl_one, countr_zero
+#include "src/__support/CPP/limits.h"        // CHAR_BIT, numeric_limits
 #include "src/__support/CPP/type_traits.h"   // is_unsigned_v
 #include "src/__support/macros/attributes.h" // LIBC_INLINE
 #include "src/__support/macros/config.h"     // LIBC_HAS_BUILTIN
@@ -225,6 +226,40 @@ sub_with_borrow<unsigned long long>(unsigned long long a, unsigned long long b,
 }
 
 #endif // LIBC_HAS_BUILTIN(__builtin_subc)
+
+template <typename T>
+[[nodiscard]] LIBC_INLINE constexpr cpp::enable_if_t<cpp::is_unsigned_v<T>, int>
+first_leading_zero(T value) {
+  return value == cpp::numeric_limits<T>::max() ? 0
+                                                : cpp::countl_one(value) + 1;
+}
+
+template <typename T>
+[[nodiscard]] LIBC_INLINE constexpr cpp::enable_if_t<cpp::is_unsigned_v<T>, int>
+first_leading_one(T value) {
+  return first_leading_zero(static_cast<T>(~value));
+}
+
+template <typename T>
+[[nodiscard]] LIBC_INLINE constexpr cpp::enable_if_t<cpp::is_unsigned_v<T>, int>
+first_trailing_zero(T value) {
+  return value == cpp::numeric_limits<T>::max()
+             ? 0
+             : cpp::countr_zero(static_cast<T>(~value)) + 1;
+}
+
+template <typename T>
+[[nodiscard]] LIBC_INLINE constexpr cpp::enable_if_t<cpp::is_unsigned_v<T>, int>
+first_trailing_one(T value) {
+  return value == cpp::numeric_limits<T>::max() ? 0
+                                                : cpp::countr_zero(value) + 1;
+}
+
+template <typename T>
+[[nodiscard]] LIBC_INLINE constexpr cpp::enable_if_t<cpp::is_unsigned_v<T>, int>
+count_zeros(T value) {
+  return cpp::popcount<T>(static_cast<T>(~value));
+}
 
 } // namespace LIBC_NAMESPACE
 

--- a/libc/src/stdbit/CMakeLists.txt
+++ b/libc/src/stdbit/CMakeLists.txt
@@ -1,30 +1,38 @@
+function(declare_dependencies prefixes dependencies)
+  set(suffixes c s i l ll)
+  foreach(prefix ${prefixes})
+    foreach(suffix IN LISTS suffixes)
+      add_entrypoint_object(
+        stdc_${prefix}_u${suffix}
+        SRCS
+          stdc_${prefix}_u${suffix}.cpp
+        HDRS
+          stdc_${prefix}_u${suffix}.h
+        DEPENDS
+          ${dependencies}
+      )
+    endforeach()
+  endforeach()
+endfunction()
+
+
 set(prefixes
   leading_zeros
   leading_ones
   trailing_zeros
   trailing_ones
-  first_leading_zero
-  first_leading_one
-  first_trailing_zero
-  first_trailing_one
-  count_zeros
   count_ones
   has_single_bit
   bit_width
   bit_floor
   bit_ceil
 )
-set(suffixes c s i l ll)
-foreach(prefix IN LISTS prefixes)
-  foreach(suffix IN LISTS suffixes)
-    add_entrypoint_object(
-      stdc_${prefix}_u${suffix}
-      SRCS
-        stdc_${prefix}_u${suffix}.cpp
-      HDRS
-        stdc_${prefix}_u${suffix}.h
-      DEPENDS
-        libc.src.__support.CPP.bit
-    )
-  endforeach()
-endforeach()
+declare_dependencies("${prefixes}" libc.src.__support.CPP.bit)
+set(prefixes
+  first_leading_zero
+  first_leading_one
+  first_trailing_zero
+  first_trailing_one
+  count_zeros
+)
+declare_dependencies("${prefixes}" libc.src.__support.math_extras)

--- a/libc/src/stdbit/stdc_count_zeros_uc.cpp
+++ b/libc/src/stdbit/stdc_count_zeros_uc.cpp
@@ -8,13 +8,13 @@
 
 #include "src/stdbit/stdc_count_zeros_uc.h"
 
-#include "src/__support/CPP/bit.h"
 #include "src/__support/common.h"
+#include "src/__support/math_extras.h"
 
 namespace LIBC_NAMESPACE {
 
 LLVM_LIBC_FUNCTION(unsigned, stdc_count_zeros_uc, (unsigned char value)) {
-  return static_cast<unsigned>(cpp::count_zeros(value));
+  return static_cast<unsigned>(count_zeros(value));
 }
 
 } // namespace LIBC_NAMESPACE

--- a/libc/src/stdbit/stdc_count_zeros_ui.cpp
+++ b/libc/src/stdbit/stdc_count_zeros_ui.cpp
@@ -8,13 +8,13 @@
 
 #include "src/stdbit/stdc_count_zeros_ui.h"
 
-#include "src/__support/CPP/bit.h"
 #include "src/__support/common.h"
+#include "src/__support/math_extras.h"
 
 namespace LIBC_NAMESPACE {
 
 LLVM_LIBC_FUNCTION(unsigned, stdc_count_zeros_ui, (unsigned value)) {
-  return static_cast<unsigned>(cpp::count_zeros(value));
+  return static_cast<unsigned>(count_zeros(value));
 }
 
 } // namespace LIBC_NAMESPACE

--- a/libc/src/stdbit/stdc_count_zeros_ul.cpp
+++ b/libc/src/stdbit/stdc_count_zeros_ul.cpp
@@ -8,13 +8,13 @@
 
 #include "src/stdbit/stdc_count_zeros_ul.h"
 
-#include "src/__support/CPP/bit.h"
 #include "src/__support/common.h"
+#include "src/__support/math_extras.h"
 
 namespace LIBC_NAMESPACE {
 
 LLVM_LIBC_FUNCTION(unsigned, stdc_count_zeros_ul, (unsigned long value)) {
-  return static_cast<unsigned>(cpp::count_zeros(value));
+  return static_cast<unsigned>(count_zeros(value));
 }
 
 } // namespace LIBC_NAMESPACE

--- a/libc/src/stdbit/stdc_count_zeros_ull.cpp
+++ b/libc/src/stdbit/stdc_count_zeros_ull.cpp
@@ -8,13 +8,13 @@
 
 #include "src/stdbit/stdc_count_zeros_ull.h"
 
-#include "src/__support/CPP/bit.h"
 #include "src/__support/common.h"
+#include "src/__support/math_extras.h"
 
 namespace LIBC_NAMESPACE {
 
 LLVM_LIBC_FUNCTION(unsigned, stdc_count_zeros_ull, (unsigned long long value)) {
-  return static_cast<unsigned>(cpp::count_zeros(value));
+  return static_cast<unsigned>(count_zeros(value));
 }
 
 } // namespace LIBC_NAMESPACE

--- a/libc/src/stdbit/stdc_count_zeros_us.cpp
+++ b/libc/src/stdbit/stdc_count_zeros_us.cpp
@@ -8,13 +8,13 @@
 
 #include "src/stdbit/stdc_count_zeros_us.h"
 
-#include "src/__support/CPP/bit.h"
 #include "src/__support/common.h"
+#include "src/__support/math_extras.h"
 
 namespace LIBC_NAMESPACE {
 
 LLVM_LIBC_FUNCTION(unsigned, stdc_count_zeros_us, (unsigned short value)) {
-  return static_cast<unsigned>(cpp::count_zeros(value));
+  return static_cast<unsigned>(count_zeros(value));
 }
 
 } // namespace LIBC_NAMESPACE

--- a/libc/src/stdbit/stdc_first_leading_one_uc.cpp
+++ b/libc/src/stdbit/stdc_first_leading_one_uc.cpp
@@ -8,13 +8,13 @@
 
 #include "src/stdbit/stdc_first_leading_one_uc.h"
 
-#include "src/__support/CPP/bit.h"
 #include "src/__support/common.h"
+#include "src/__support/math_extras.h"
 
 namespace LIBC_NAMESPACE {
 
 LLVM_LIBC_FUNCTION(unsigned, stdc_first_leading_one_uc, (unsigned char value)) {
-  return static_cast<unsigned>(cpp::first_leading_one(value));
+  return static_cast<unsigned>(first_leading_one(value));
 }
 
 } // namespace LIBC_NAMESPACE

--- a/libc/src/stdbit/stdc_first_leading_one_ui.cpp
+++ b/libc/src/stdbit/stdc_first_leading_one_ui.cpp
@@ -8,13 +8,13 @@
 
 #include "src/stdbit/stdc_first_leading_one_ui.h"
 
-#include "src/__support/CPP/bit.h"
 #include "src/__support/common.h"
+#include "src/__support/math_extras.h"
 
 namespace LIBC_NAMESPACE {
 
 LLVM_LIBC_FUNCTION(unsigned, stdc_first_leading_one_ui, (unsigned value)) {
-  return static_cast<unsigned>(cpp::first_leading_one(value));
+  return static_cast<unsigned>(first_leading_one(value));
 }
 
 } // namespace LIBC_NAMESPACE

--- a/libc/src/stdbit/stdc_first_leading_one_ul.cpp
+++ b/libc/src/stdbit/stdc_first_leading_one_ul.cpp
@@ -8,13 +8,13 @@
 
 #include "src/stdbit/stdc_first_leading_one_ul.h"
 
-#include "src/__support/CPP/bit.h"
 #include "src/__support/common.h"
+#include "src/__support/math_extras.h"
 
 namespace LIBC_NAMESPACE {
 
 LLVM_LIBC_FUNCTION(unsigned, stdc_first_leading_one_ul, (unsigned long value)) {
-  return static_cast<unsigned>(cpp::first_leading_one(value));
+  return static_cast<unsigned>(first_leading_one(value));
 }
 
 } // namespace LIBC_NAMESPACE

--- a/libc/src/stdbit/stdc_first_leading_one_ull.cpp
+++ b/libc/src/stdbit/stdc_first_leading_one_ull.cpp
@@ -8,14 +8,14 @@
 
 #include "src/stdbit/stdc_first_leading_one_ull.h"
 
-#include "src/__support/CPP/bit.h"
 #include "src/__support/common.h"
+#include "src/__support/math_extras.h"
 
 namespace LIBC_NAMESPACE {
 
 LLVM_LIBC_FUNCTION(unsigned, stdc_first_leading_one_ull,
                    (unsigned long long value)) {
-  return static_cast<unsigned>(cpp::first_leading_one(value));
+  return static_cast<unsigned>(first_leading_one(value));
 }
 
 } // namespace LIBC_NAMESPACE

--- a/libc/src/stdbit/stdc_first_leading_one_us.cpp
+++ b/libc/src/stdbit/stdc_first_leading_one_us.cpp
@@ -8,14 +8,14 @@
 
 #include "src/stdbit/stdc_first_leading_one_us.h"
 
-#include "src/__support/CPP/bit.h"
 #include "src/__support/common.h"
+#include "src/__support/math_extras.h"
 
 namespace LIBC_NAMESPACE {
 
 LLVM_LIBC_FUNCTION(unsigned, stdc_first_leading_one_us,
                    (unsigned short value)) {
-  return static_cast<unsigned>(cpp::first_leading_one(value));
+  return static_cast<unsigned>(first_leading_one(value));
 }
 
 } // namespace LIBC_NAMESPACE

--- a/libc/src/stdbit/stdc_first_leading_zero_uc.cpp
+++ b/libc/src/stdbit/stdc_first_leading_zero_uc.cpp
@@ -8,14 +8,14 @@
 
 #include "src/stdbit/stdc_first_leading_zero_uc.h"
 
-#include "src/__support/CPP/bit.h"
 #include "src/__support/common.h"
+#include "src/__support/math_extras.h"
 
 namespace LIBC_NAMESPACE {
 
 LLVM_LIBC_FUNCTION(unsigned, stdc_first_leading_zero_uc,
                    (unsigned char value)) {
-  return static_cast<unsigned>(cpp::first_leading_zero(value));
+  return static_cast<unsigned>(first_leading_zero(value));
 }
 
 } // namespace LIBC_NAMESPACE

--- a/libc/src/stdbit/stdc_first_leading_zero_ui.cpp
+++ b/libc/src/stdbit/stdc_first_leading_zero_ui.cpp
@@ -8,13 +8,13 @@
 
 #include "src/stdbit/stdc_first_leading_zero_ui.h"
 
-#include "src/__support/CPP/bit.h"
 #include "src/__support/common.h"
+#include "src/__support/math_extras.h"
 
 namespace LIBC_NAMESPACE {
 
 LLVM_LIBC_FUNCTION(unsigned, stdc_first_leading_zero_ui, (unsigned value)) {
-  return static_cast<unsigned>(cpp::first_leading_zero(value));
+  return static_cast<unsigned>(first_leading_zero(value));
 }
 
 } // namespace LIBC_NAMESPACE

--- a/libc/src/stdbit/stdc_first_leading_zero_ul.cpp
+++ b/libc/src/stdbit/stdc_first_leading_zero_ul.cpp
@@ -8,14 +8,14 @@
 
 #include "src/stdbit/stdc_first_leading_zero_ul.h"
 
-#include "src/__support/CPP/bit.h"
 #include "src/__support/common.h"
+#include "src/__support/math_extras.h"
 
 namespace LIBC_NAMESPACE {
 
 LLVM_LIBC_FUNCTION(unsigned, stdc_first_leading_zero_ul,
                    (unsigned long value)) {
-  return static_cast<unsigned>(cpp::first_leading_zero(value));
+  return static_cast<unsigned>(first_leading_zero(value));
 }
 
 } // namespace LIBC_NAMESPACE

--- a/libc/src/stdbit/stdc_first_leading_zero_ull.cpp
+++ b/libc/src/stdbit/stdc_first_leading_zero_ull.cpp
@@ -8,14 +8,14 @@
 
 #include "src/stdbit/stdc_first_leading_zero_ull.h"
 
-#include "src/__support/CPP/bit.h"
 #include "src/__support/common.h"
+#include "src/__support/math_extras.h"
 
 namespace LIBC_NAMESPACE {
 
 LLVM_LIBC_FUNCTION(unsigned, stdc_first_leading_zero_ull,
                    (unsigned long long value)) {
-  return static_cast<unsigned>(cpp::first_leading_zero(value));
+  return static_cast<unsigned>(first_leading_zero(value));
 }
 
 } // namespace LIBC_NAMESPACE

--- a/libc/src/stdbit/stdc_first_leading_zero_us.cpp
+++ b/libc/src/stdbit/stdc_first_leading_zero_us.cpp
@@ -8,14 +8,14 @@
 
 #include "src/stdbit/stdc_first_leading_zero_us.h"
 
-#include "src/__support/CPP/bit.h"
 #include "src/__support/common.h"
+#include "src/__support/math_extras.h"
 
 namespace LIBC_NAMESPACE {
 
 LLVM_LIBC_FUNCTION(unsigned, stdc_first_leading_zero_us,
                    (unsigned short value)) {
-  return static_cast<unsigned>(cpp::first_leading_zero(value));
+  return static_cast<unsigned>(first_leading_zero(value));
 }
 
 } // namespace LIBC_NAMESPACE

--- a/libc/src/stdbit/stdc_first_trailing_one_uc.cpp
+++ b/libc/src/stdbit/stdc_first_trailing_one_uc.cpp
@@ -8,14 +8,14 @@
 
 #include "src/stdbit/stdc_first_trailing_one_uc.h"
 
-#include "src/__support/CPP/bit.h"
 #include "src/__support/common.h"
+#include "src/__support/math_extras.h"
 
 namespace LIBC_NAMESPACE {
 
 LLVM_LIBC_FUNCTION(unsigned, stdc_first_trailing_one_uc,
                    (unsigned char value)) {
-  return static_cast<unsigned>(cpp::first_trailing_one(value));
+  return static_cast<unsigned>(first_trailing_one(value));
 }
 
 } // namespace LIBC_NAMESPACE

--- a/libc/src/stdbit/stdc_first_trailing_one_ui.cpp
+++ b/libc/src/stdbit/stdc_first_trailing_one_ui.cpp
@@ -8,13 +8,13 @@
 
 #include "src/stdbit/stdc_first_trailing_one_ui.h"
 
-#include "src/__support/CPP/bit.h"
 #include "src/__support/common.h"
+#include "src/__support/math_extras.h"
 
 namespace LIBC_NAMESPACE {
 
 LLVM_LIBC_FUNCTION(unsigned, stdc_first_trailing_one_ui, (unsigned value)) {
-  return static_cast<unsigned>(cpp::first_trailing_one(value));
+  return static_cast<unsigned>(first_trailing_one(value));
 }
 
 } // namespace LIBC_NAMESPACE

--- a/libc/src/stdbit/stdc_first_trailing_one_ul.cpp
+++ b/libc/src/stdbit/stdc_first_trailing_one_ul.cpp
@@ -8,14 +8,14 @@
 
 #include "src/stdbit/stdc_first_trailing_one_ul.h"
 
-#include "src/__support/CPP/bit.h"
 #include "src/__support/common.h"
+#include "src/__support/math_extras.h"
 
 namespace LIBC_NAMESPACE {
 
 LLVM_LIBC_FUNCTION(unsigned, stdc_first_trailing_one_ul,
                    (unsigned long value)) {
-  return static_cast<unsigned>(cpp::first_trailing_one(value));
+  return static_cast<unsigned>(first_trailing_one(value));
 }
 
 } // namespace LIBC_NAMESPACE

--- a/libc/src/stdbit/stdc_first_trailing_one_ull.cpp
+++ b/libc/src/stdbit/stdc_first_trailing_one_ull.cpp
@@ -8,14 +8,14 @@
 
 #include "src/stdbit/stdc_first_trailing_one_ull.h"
 
-#include "src/__support/CPP/bit.h"
 #include "src/__support/common.h"
+#include "src/__support/math_extras.h"
 
 namespace LIBC_NAMESPACE {
 
 LLVM_LIBC_FUNCTION(unsigned, stdc_first_trailing_one_ull,
                    (unsigned long long value)) {
-  return static_cast<unsigned>(cpp::first_trailing_one(value));
+  return static_cast<unsigned>(first_trailing_one(value));
 }
 
 } // namespace LIBC_NAMESPACE

--- a/libc/src/stdbit/stdc_first_trailing_one_us.cpp
+++ b/libc/src/stdbit/stdc_first_trailing_one_us.cpp
@@ -8,14 +8,14 @@
 
 #include "src/stdbit/stdc_first_trailing_one_us.h"
 
-#include "src/__support/CPP/bit.h"
 #include "src/__support/common.h"
+#include "src/__support/math_extras.h"
 
 namespace LIBC_NAMESPACE {
 
 LLVM_LIBC_FUNCTION(unsigned, stdc_first_trailing_one_us,
                    (unsigned short value)) {
-  return static_cast<unsigned>(cpp::first_trailing_one(value));
+  return static_cast<unsigned>(first_trailing_one(value));
 }
 
 } // namespace LIBC_NAMESPACE

--- a/libc/src/stdbit/stdc_first_trailing_zero_uc.cpp
+++ b/libc/src/stdbit/stdc_first_trailing_zero_uc.cpp
@@ -8,14 +8,14 @@
 
 #include "src/stdbit/stdc_first_trailing_zero_uc.h"
 
-#include "src/__support/CPP/bit.h"
 #include "src/__support/common.h"
+#include "src/__support/math_extras.h"
 
 namespace LIBC_NAMESPACE {
 
 LLVM_LIBC_FUNCTION(unsigned, stdc_first_trailing_zero_uc,
                    (unsigned char value)) {
-  return static_cast<unsigned>(cpp::first_trailing_zero(value));
+  return static_cast<unsigned>(first_trailing_zero(value));
 }
 
 } // namespace LIBC_NAMESPACE

--- a/libc/src/stdbit/stdc_first_trailing_zero_ui.cpp
+++ b/libc/src/stdbit/stdc_first_trailing_zero_ui.cpp
@@ -8,13 +8,13 @@
 
 #include "src/stdbit/stdc_first_trailing_zero_ui.h"
 
-#include "src/__support/CPP/bit.h"
 #include "src/__support/common.h"
+#include "src/__support/math_extras.h"
 
 namespace LIBC_NAMESPACE {
 
 LLVM_LIBC_FUNCTION(unsigned, stdc_first_trailing_zero_ui, (unsigned value)) {
-  return static_cast<unsigned>(cpp::first_trailing_zero(value));
+  return static_cast<unsigned>(first_trailing_zero(value));
 }
 
 } // namespace LIBC_NAMESPACE

--- a/libc/src/stdbit/stdc_first_trailing_zero_ul.cpp
+++ b/libc/src/stdbit/stdc_first_trailing_zero_ul.cpp
@@ -8,14 +8,14 @@
 
 #include "src/stdbit/stdc_first_trailing_zero_ul.h"
 
-#include "src/__support/CPP/bit.h"
 #include "src/__support/common.h"
+#include "src/__support/math_extras.h"
 
 namespace LIBC_NAMESPACE {
 
 LLVM_LIBC_FUNCTION(unsigned, stdc_first_trailing_zero_ul,
                    (unsigned long value)) {
-  return static_cast<unsigned>(cpp::first_trailing_zero(value));
+  return static_cast<unsigned>(first_trailing_zero(value));
 }
 
 } // namespace LIBC_NAMESPACE

--- a/libc/src/stdbit/stdc_first_trailing_zero_ull.cpp
+++ b/libc/src/stdbit/stdc_first_trailing_zero_ull.cpp
@@ -8,14 +8,14 @@
 
 #include "src/stdbit/stdc_first_trailing_zero_ull.h"
 
-#include "src/__support/CPP/bit.h"
 #include "src/__support/common.h"
+#include "src/__support/math_extras.h"
 
 namespace LIBC_NAMESPACE {
 
 LLVM_LIBC_FUNCTION(unsigned, stdc_first_trailing_zero_ull,
                    (unsigned long long value)) {
-  return static_cast<unsigned>(cpp::first_trailing_zero(value));
+  return static_cast<unsigned>(first_trailing_zero(value));
 }
 
 } // namespace LIBC_NAMESPACE

--- a/libc/src/stdbit/stdc_first_trailing_zero_us.cpp
+++ b/libc/src/stdbit/stdc_first_trailing_zero_us.cpp
@@ -8,14 +8,14 @@
 
 #include "src/stdbit/stdc_first_trailing_zero_us.h"
 
-#include "src/__support/CPP/bit.h"
 #include "src/__support/common.h"
+#include "src/__support/math_extras.h"
 
 namespace LIBC_NAMESPACE {
 
 LLVM_LIBC_FUNCTION(unsigned, stdc_first_trailing_zero_us,
                    (unsigned short value)) {
-  return static_cast<unsigned>(cpp::first_trailing_zero(value));
+  return static_cast<unsigned>(first_trailing_zero(value));
 }
 
 } // namespace LIBC_NAMESPACE

--- a/libc/test/src/__support/CPP/bit_test.cpp
+++ b/libc/test/src/__support/CPP/bit_test.cpp
@@ -228,38 +228,6 @@ TEST(LlvmLibcBitTest, Rotr) {
             rotr<uint64_t>(0x12345678deadbeefULL, -19));
 }
 
-TYPED_TEST(LlvmLibcBitTest, FirstLeadingZero, UnsignedTypesNoBigInt) {
-  EXPECT_EQ(first_leading_zero<T>(cpp::numeric_limits<T>::max()), 0);
-  for (int i = 0U; i != cpp::numeric_limits<T>::digits; ++i)
-    EXPECT_EQ(first_leading_zero<T>(~(T(1) << i)),
-              cpp::numeric_limits<T>::digits - i);
-}
-
-TYPED_TEST(LlvmLibcBitTest, FirstLeadingOne, UnsignedTypesNoBigInt) {
-  EXPECT_EQ(first_leading_one<T>(static_cast<T>(0)), 0);
-  for (int i = 0U; i != cpp::numeric_limits<T>::digits; ++i)
-    EXPECT_EQ(first_leading_one<T>(T(1) << i),
-              cpp::numeric_limits<T>::digits - i);
-}
-
-TYPED_TEST(LlvmLibcBitTest, FirstTrailingZero, UnsignedTypesNoBigInt) {
-  EXPECT_EQ(first_trailing_zero<T>(cpp::numeric_limits<T>::max()), 0);
-  for (int i = 0U; i != cpp::numeric_limits<T>::digits; ++i)
-    EXPECT_EQ(first_trailing_zero<T>(~(T(1) << i)), i + 1);
-}
-
-TYPED_TEST(LlvmLibcBitTest, FirstTrailingOne, UnsignedTypesNoBigInt) {
-  EXPECT_EQ(first_trailing_one<T>(cpp::numeric_limits<T>::max()), 0);
-  for (int i = 0U; i != cpp::numeric_limits<T>::digits; ++i)
-    EXPECT_EQ(first_trailing_one<T>(T(1) << i), i + 1);
-}
-
-TYPED_TEST(LlvmLibcBitTest, CountZeros, UnsignedTypesNoBigInt) {
-  EXPECT_EQ(count_zeros(T(0)), cpp::numeric_limits<T>::digits);
-  for (int i = 0; i != cpp::numeric_limits<T>::digits; ++i)
-    EXPECT_EQ(count_zeros<T>(cpp::numeric_limits<T>::max() >> i), i);
-}
-
 TYPED_TEST(LlvmLibcBitTest, CountOnes, UnsignedTypesNoBigInt) {
   EXPECT_EQ(popcount(T(0)), 0);
   for (int i = 0; i != cpp::numeric_limits<T>::digits; ++i)

--- a/libc/test/src/__support/math_extras_test.cpp
+++ b/libc/test/src/__support/math_extras_test.cpp
@@ -13,6 +13,14 @@
 
 namespace LIBC_NAMESPACE {
 
+// TODO: add UInt<128> support.
+using UnsignedTypesNoBigInt = testing::TypeList<
+#if defined(LIBC_TYPES_HAS_INT128)
+    __uint128_t,
+#endif // LIBC_TYPES_HAS_INT128
+    unsigned char, unsigned short, unsigned int, unsigned long,
+    unsigned long long>;
+
 TEST(LlvmLibcBlockMathExtrasTest, mask_trailing_ones) {
   EXPECT_EQ(0_u8, (mask_leading_ones<uint8_t, 0>()));
   EXPECT_EQ(0_u8, (mask_trailing_ones<uint8_t, 0>()));
@@ -59,6 +67,38 @@ TEST(LlvmLibcBlockMathExtrasTest, mask_trailing_ones) {
             (mask_trailing_ones<UInt128, 128>()));
   EXPECT_EQ(0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF_u128,
             (mask_leading_ones<UInt128, 128>()));
+}
+
+TYPED_TEST(LlvmLibcBitTest, FirstLeadingZero, UnsignedTypesNoBigInt) {
+  EXPECT_EQ(first_leading_zero<T>(cpp::numeric_limits<T>::max()), 0);
+  for (int i = 0U; i != cpp::numeric_limits<T>::digits; ++i)
+    EXPECT_EQ(first_leading_zero<T>(~(T(1) << i)),
+              cpp::numeric_limits<T>::digits - i);
+}
+
+TYPED_TEST(LlvmLibcBitTest, FirstLeadingOne, UnsignedTypesNoBigInt) {
+  EXPECT_EQ(first_leading_one<T>(static_cast<T>(0)), 0);
+  for (int i = 0U; i != cpp::numeric_limits<T>::digits; ++i)
+    EXPECT_EQ(first_leading_one<T>(T(1) << i),
+              cpp::numeric_limits<T>::digits - i);
+}
+
+TYPED_TEST(LlvmLibcBitTest, FirstTrailingZero, UnsignedTypesNoBigInt) {
+  EXPECT_EQ(first_trailing_zero<T>(cpp::numeric_limits<T>::max()), 0);
+  for (int i = 0U; i != cpp::numeric_limits<T>::digits; ++i)
+    EXPECT_EQ(first_trailing_zero<T>(~(T(1) << i)), i + 1);
+}
+
+TYPED_TEST(LlvmLibcBitTest, FirstTrailingOne, UnsignedTypesNoBigInt) {
+  EXPECT_EQ(first_trailing_one<T>(cpp::numeric_limits<T>::max()), 0);
+  for (int i = 0U; i != cpp::numeric_limits<T>::digits; ++i)
+    EXPECT_EQ(first_trailing_one<T>(T(1) << i), i + 1);
+}
+
+TYPED_TEST(LlvmLibcBitTest, CountZeros, UnsignedTypesNoBigInt) {
+  EXPECT_EQ(count_zeros(T(0)), cpp::numeric_limits<T>::digits);
+  for (int i = 0; i != cpp::numeric_limits<T>::digits; ++i)
+    EXPECT_EQ(count_zeros<T>(cpp::numeric_limits<T>::max() >> i), i);
 }
 
 } // namespace LIBC_NAMESPACE


### PR DESCRIPTION
As per TODOs added in
https://github.com/llvm/llvm-project/pull/84035/commits/48b0bc837085a38ff1de33010d9222363f70238f.
