### PR TITLE
github-automation.py: Set maintainer_can_modify=True for backport PRs

### DIFF
--- a/llvm/utils/git/github-automation.py
+++ b/llvm/utils/git/github-automation.py
@@ -586,7 +586,7 @@ class ReleaseWorkflow:
                 body=body,
                 base=release_branch_for_issue,
                 head=head,
-                maintainer_can_modify=False,
+                maintainer_can_modify=True,
             )
 
             pull.as_issue().edit(milestone=self.issue.milestone)


### PR DESCRIPTION
This makes it possible to rebase the branch using the Web UI, which makes it easier to manually merge the PRs.  Manual merge is required when squash merge won't preserve author information of the backport.