### PR TITLE
[libc] fix another build failure from using limits.h

### DIFF
--- a/libc/test/src/__support/CMakeLists.txt
+++ b/libc/test/src/__support/CMakeLists.txt
@@ -78,6 +78,7 @@ add_libc_test(
   SRCS
     integer_to_string_test.cpp
   DEPENDS
+    libc.src.__support.CPP.limits
     libc.src.__support.CPP.string_view
     libc.src.__support.integer_literals
     libc.src.__support.integer_to_string

--- a/libc/test/src/__support/integer_to_string_test.cpp
+++ b/libc/test/src/__support/integer_to_string_test.cpp
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "src/__support/CPP/limits.h"
 #include "src/__support/CPP/span.h"
 #include "src/__support/CPP/string_view.h"
 #include "src/__support/UInt.h"
@@ -14,8 +15,6 @@
 #include "src/__support/integer_to_string.h"
 
 #include "test/UnitTest/Test.h"
-
-#include "limits.h"
 
 using LIBC_NAMESPACE::IntegerToString;
 using LIBC_NAMESPACE::cpp::span;


### PR DESCRIPTION
My GCC build is failing with issues similar why we added our own.  Looks like
we missed one spot. See also:

commit 72ce62941579 ("[libc] Add C23 limits.h header. (#78887)")
