### PR TITLE
Run pre-merge build with -k 0 to ensure all tests runs

### DIFF
--- a/.ci/monolithic-linux.sh
+++ b/.ci/monolithic-linux.sh
@@ -54,4 +54,4 @@ cmake -S ${MONOREPO_ROOT}/llvm -B ${BUILD_DIR} \
 
 echo "--- ninja"
 # Targets are not escaped as they are passed as separate arguments.
-ninja -C "${BUILD_DIR}" ${targets}
+ninja -C -k 0 "${BUILD_DIR}" ${targets}

--- a/.ci/monolithic-windows.sh
+++ b/.ci/monolithic-windows.sh
@@ -62,4 +62,4 @@ cmake -S ${MONOREPO_ROOT}/llvm -B ${BUILD_DIR} \
 
 echo "--- ninja"
 # Targets are not escaped as they are passed as separate arguments.
-ninja -C "${BUILD_DIR}" ${targets}
+ninja -C -k 0 "${BUILD_DIR}" ${targets}


### PR DESCRIPTION
The -k option allows to continue the build after failures as much as possible. This is useful here because when we run

> ninja check-llvm check-clang

we would like the clang tests to run even if there is a failure in a llvm tests.

Fixes #83371