### PR TITLE
[SystemZ][zOS] Override emitGlobalAlias for ADA 

### DIFF
--- a/llvm/include/llvm/CodeGen/AsmPrinter.h
+++ b/llvm/include/llvm/CodeGen/AsmPrinter.h
@@ -897,12 +897,14 @@ private:
   virtual void emitModuleCommandLines(Module &M);
 
   GCMetadataPrinter *getOrCreateGCPrinter(GCStrategy &S);
+
+protected:
   virtual void emitGlobalAlias(const Module &M, const GlobalAlias &GA);
-  void emitGlobalIFunc(Module &M, const GlobalIFunc &GI);
 
 private:
   /// This method decides whether the specified basic block requires a label.
   bool shouldEmitLabelForBasicBlock(const MachineBasicBlock &MBB) const;
+  void emitGlobalIFunc(Module &M, const GlobalIFunc &GI);
 
 protected:
   virtual bool shouldEmitWeakSwiftAsyncExtendedFramePointerFlags() const {

--- a/llvm/include/llvm/MC/MCSymbolGOFF.h
+++ b/llvm/include/llvm/MC/MCSymbolGOFF.h
@@ -18,10 +18,26 @@
 namespace llvm {
 
 class MCSymbolGOFF : public MCSymbol {
+  mutable StringRef AliasName; // ADA indirect
+
+  enum SymbolFlags : uint16_t {
+    SF_Alias = 0x02,     // Symbol is alias.
+    SF_Indirect = 0x200, // Symbol referenced indirectly.
+  };
+
 public:
   MCSymbolGOFF(const StringMapEntry<bool> *Name, bool IsTemporary)
-      : MCSymbol(SymbolKindGOFF, Name, IsTemporary) {}
+      : MCSymbol(SymbolKindGOFF, Name, IsTemporary), AliasName() {}
   static bool classof(const MCSymbol *S) { return S->isGOFF(); }
+
+  bool hasAliasName() const { return !AliasName.empty(); }
+  void setAliasName(StringRef Name) { AliasName = Name; }
+  StringRef getAliasName() const { return AliasName; }
+
+  void setIndirect(bool Value = true) {
+    modifyFlags(Value ? SF_Indirect : 0, SF_Indirect);
+  }
+  bool isIndirect() const { return getFlags() & SF_Indirect; }
 };
 } // end namespace llvm
 

--- a/llvm/include/llvm/MC/MCSymbolGOFF.h
+++ b/llvm/include/llvm/MC/MCSymbolGOFF.h
@@ -18,7 +18,7 @@
 namespace llvm {
 
 class MCSymbolGOFF : public MCSymbol {
-  mutable StringRef AliasName; // ADA indirect
+  mutable StringRef ExternalName; // Alternate external name.
 
   enum SymbolFlags : uint16_t {
     SF_Alias = 0x02,     // Symbol is alias.
@@ -27,12 +27,14 @@ class MCSymbolGOFF : public MCSymbol {
 
 public:
   MCSymbolGOFF(const StringMapEntry<bool> *Name, bool IsTemporary)
-      : MCSymbol(SymbolKindGOFF, Name, IsTemporary), AliasName() {}
+      : MCSymbol(SymbolKindGOFF, Name, IsTemporary), ExternalName() {}
   static bool classof(const MCSymbol *S) { return S->isGOFF(); }
 
-  bool hasAliasName() const { return !AliasName.empty(); }
-  void setAliasName(StringRef Name) { AliasName = Name; }
-  StringRef getAliasName() const { return AliasName; }
+  bool hasExternalName() const { return !ExternalName.empty(); }
+  void setExternalName(StringRef Name) {
+    ExternalName = Name;
+  }
+  StringRef getExternalName() const { return ExternalName; }
 
   void setIndirect(bool Value = true) {
     modifyFlags(Value ? SF_Indirect : 0, SF_Indirect);

--- a/llvm/lib/Target/SystemZ/SystemZAsmPrinter.cpp
+++ b/llvm/lib/Target/SystemZ/SystemZAsmPrinter.cpp
@@ -1031,7 +1031,7 @@ void SystemZAsmPrinter::emitADASection() {
           static_cast<MCSymbolGOFF *>(OutContext.getOrCreateSymbol(
               Twine(Sym->getName()).concat("@indirect")));
       IndirectSym->setExternal(Sym->isExternal());
-      IndirectSym->setAliasName(Sym->getName());
+      IndirectSym->setExternalName(Sym->getName());
       IndirectSym->setIndirect(true);
 
       EMIT_COMMENT("pointer to function descriptor");

--- a/llvm/lib/Target/SystemZ/SystemZAsmPrinter.cpp
+++ b/llvm/lib/Target/SystemZ/SystemZAsmPrinter.cpp
@@ -1030,6 +1030,9 @@ void SystemZAsmPrinter::emitADASection() {
       MCSymbolGOFF *IndirectSym =
           static_cast<MCSymbolGOFF *>(OutContext.getOrCreateSymbol(
               Twine(Sym->getName()).concat("@indirect")));
+      IndirectSym->setExternal(Sym->isExternal());
+      IndirectSym->setAliasName(Sym->getName());
+      IndirectSym->setIndirect(true);
 
       EMIT_COMMENT("pointer to function descriptor");
       OutStreamer->emitValue(

--- a/llvm/lib/Target/SystemZ/SystemZAsmPrinter.h
+++ b/llvm/lib/Target/SystemZ/SystemZAsmPrinter.h
@@ -118,6 +118,7 @@ public:
   void emitFunctionEntryLabel() override;
   void emitFunctionBodyEnd() override;
   void emitStartOfAsmFile(Module &M) override;
+  void emitGlobalAlias(const Module &M, const GlobalAlias &GA) override;
 
 private:
   void emitCallInformation(CallType CT);

--- a/llvm/test/CodeGen/SystemZ/zos-ada-globalalias.ll
+++ b/llvm/test/CodeGen/SystemZ/zos-ada-globalalias.ll
@@ -1,0 +1,35 @@
+; RUN: llc -mtriple s390x-ibm-zos < %s | FileCheck %s
+
+; C test case:
+; typedef void (*voidfunc)();
+; void func(){}
+; voidfunc ptr = &func;
+
+; CHECK: ptr:
+; CHECK:        .quad   func
+
+@ptr = hidden global void (...)* bitcast (void ()* @func to void (...)*), align 8
+  
+define hidden void @func() {
+entry:
+  ret void
+}
+
+; C test case for global alias
+; void __f() {}
+; void f() __attribute__ ((alias ("__f")));
+; void (*fp)() = &f;
+
+; CHECK:        .quad   f
+
+; CHECK:        .globl  f
+; CHECK:        .hidden f
+; CHECK: .set f, V(__f)
+
+@fp = hidden global void (...)* @f, align 8
+@f = hidden alias void (...), bitcast (void ()* @__f to void (...)*)
+
+define hidden void @__f() #0 {
+entry:
+  ret void
+}

--- a/llvm/test/CodeGen/SystemZ/zos-ada-relocations.ll
+++ b/llvm/test/CodeGen/SystemZ/zos-ada-relocations.ll
@@ -56,9 +56,7 @@ entry:
 declare signext i32 @callout(i32 signext)
 
 ; CHECK:     .section    ".ada"
-; CHECK:  .set @@DoFunc@indirect0, DoFunc
-; CHECK:      .indirect_symbol   @@DoFunc@indirect0
-; CHECK:  .quad V(@@DoFunc@indirect0)          * Offset 0 pointer to function descriptor DoFunc
+; CHECK:  .quad V(DoFunc@indirect)             * Offset 0 pointer to function descriptor DoFunc
 ; CHECK:  .quad R(Caller)                      * Offset 8 function descriptor of Caller
 ; CHECK:  .quad V(Caller)
 ; CHECK:  .quad A(i2)                           * Offset 24 pointer to data symbol i2


### PR DESCRIPTION
This PR overrides emitGlobalAlias to properly handle the indirect symbol case in the ADA for GlobalAlias.