### PR TITLE
[CI] Run pre-merge build with -k 0 placed after "${BUILD_DIR}"

### DIFF
--- a/.ci/monolithic-linux.sh
+++ b/.ci/monolithic-linux.sh
@@ -54,4 +54,4 @@ cmake -S ${MONOREPO_ROOT}/llvm -B ${BUILD_DIR} \
 
 echo "--- ninja"
 # Targets are not escaped as they are passed as separate arguments.
-ninja -C -k 0 "${BUILD_DIR}" ${targets}
+ninja -C "${BUILD_DIR}" -k 0 ${targets}

--- a/.ci/monolithic-windows.sh
+++ b/.ci/monolithic-windows.sh
@@ -62,4 +62,4 @@ cmake -S ${MONOREPO_ROOT}/llvm -B ${BUILD_DIR} \
 
 echo "--- ninja"
 # Targets are not escaped as they are passed as separate arguments.
-ninja -C -k 0 "${BUILD_DIR}" ${targets}
+ninja -C "${BUILD_DIR}" -k 0 ${targets}


### PR DESCRIPTION
#84828 added `-k 0` to pre-merge CI so that if one job fails the others would continue building. This pull request fixes the location of `-k 0` in the ninja command line.

Resolves #84842 and #83371