### PR TITLE
[libc++][hardening] Use `__builtin_verbose_trap` if it's available.

### DIFF
--- a/libcxx/vendor/llvm/default_assertion_handler.in
+++ b/libcxx/vendor/llvm/default_assertion_handler.in
@@ -23,8 +23,11 @@
 
 #else
 
-// TODO(hardening): use `__builtin_verbose_trap(message)` once that becomes available.
-#  define _LIBCPP_ASSERTION_HANDLER(message) ((void)message, __builtin_trap())
+#  if __has_builtin(__builtin_verbose_trap)
+#    define _LIBCPP_ASSERTION_HANDLER(message) (__builtin_verbose_trap(message))
+#  else
+#    define _LIBCPP_ASSERTION_HANDLER(message) ((void)message, __builtin_trap())
+#  endif
 
 #endif // _LIBCPP_HARDENING_MODE == _LIBCPP_HARDENING_MODE_DEBUG
 

--- a/libcxx/vendor/llvm/default_assertion_handler.in
+++ b/libcxx/vendor/llvm/default_assertion_handler.in
@@ -24,7 +24,7 @@
 #else
 
 #  if __has_builtin(__builtin_verbose_trap)
-#    define _LIBCPP_ASSERTION_HANDLER(message) (__builtin_verbose_trap(message))
+#    define _LIBCPP_ASSERTION_HANDLER(message) __builtin_verbose_trap("libc++", message)
 #  else
 #    define _LIBCPP_ASSERTION_HANDLER(message) ((void)message, __builtin_trap())
 #  endif


### PR DESCRIPTION
Keep falling back to `__builtin_trap` on older versions of Clang.
