### PR TITLE
[libc] Fix lane-id utility function not using built-in

### DIFF
--- a/libc/src/__support/GPU/nvptx/utils.h
+++ b/libc/src/__support/GPU/nvptx/utils.h
@@ -97,7 +97,7 @@ LIBC_INLINE uint32_t get_lane_size() { return 32; }
 
 /// Returns the id of the thread inside of a CUDA warp executing together.
 [[clang::convergent]] LIBC_INLINE uint32_t get_lane_id() {
-  return get_thread_id() & (get_lane_size() - 1);
+  return __nvvm_read_ptx_sreg_laneid();
 }
 
 /// Returns the bit-mask of active threads in the current warp.


### PR DESCRIPTION
Summary:
Previously we got the lane-id from taking the global thread ID and
taking off the bottom 5 bits. This works but is inefficient compared to
the NVPTX intrinsic simply dedicated to get this value.
