### PR TITLE
[SystemZ][z/OS] Add missing include header to AutoConvert.cpp to fix build

### DIFF
--- a/llvm/lib/Support/AutoConvert.cpp
+++ b/llvm/lib/Support/AutoConvert.cpp
@@ -14,6 +14,7 @@
 #ifdef __MVS__
 
 #include "llvm/Support/AutoConvert.h"
+#include "llvm/Support/Error.h"
 #include <cassert>
 #include <fcntl.h>
 #include <sys/stat.h>


### PR DESCRIPTION
https://github.com/llvm/llvm-project/commit/ba13fa2a5d57581bff1a7e9322234af30f4882f6 added usages of `errnoAsErrorCode()` to AutoConvert.cpp, need to include Error.h header to fix build failure.