### PR TITLE
[SjLjEHPrepare] Use inverse_depth_first() instead of _ext variant (NFC).

### DIFF
--- a/llvm/lib/CodeGen/SjLjEHPrepare.cpp
+++ b/llvm/lib/CodeGen/SjLjEHPrepare.cpp
@@ -150,9 +150,7 @@ static void MarkBlocksLiveIn(BasicBlock *BB,
   if (!LiveBBs.insert(BB).second)
     return; // already been here.
 
-  df_iterator_default_set<BasicBlock*> Visited;
-
-  for (BasicBlock *B : inverse_depth_first_ext(BB, Visited))
+  for (BasicBlock *B : inverse_depth_first(BB))
     LiveBBs.insert(B);
 }
 


### PR DESCRIPTION
inverse_depth_first df_iterator_default_set as default set, so there's no need to explicitly use inverse_depth_first_ext.