### PR TITLE
[clang-tidy]bugprone-unused-return-value ignore `++` and `--` operator overloading

### DIFF
--- a/clang-tools-extra/clang-tidy/bugprone/UnusedReturnValueCheck.cpp
+++ b/clang-tools-extra/clang-tidy/bugprone/UnusedReturnValueCheck.cpp
@@ -38,11 +38,7 @@ constexpr std::initializer_list<OverloadedOperatorKind>
         OO_PipeEqual,  OO_LessLessEqual, OO_GreaterGreaterEqual, OO_PlusPlus,
         OO_MinusMinus};
 
-AST_MATCHER(CXXOperatorCallExpr, isAssignmentOverloadedOperatorCall) {
-  return llvm::is_contained(AssignmentOverloadedOperatorKinds,
-                            Node.getOperator());
-}
-AST_MATCHER(CXXMethodDecl, isAssignmentOverloadedOperatorMethod) {
+AST_MATCHER(FunctionDecl, isAssignmentOverloadedOperatorMethod) {
   return llvm::is_contained(AssignmentOverloadedOperatorKinds,
                             Node.getOverloadedOperator());
 }
@@ -186,8 +182,7 @@ void UnusedReturnValueCheck::registerMatchers(MatchFinder *Finder) {
                   returns(hasCanonicalType(hasDeclaration(namedDecl(
                       matchers::matchesAnyListedName(CheckedReturnTypes)))))))),
           // Don't match copy or move assignment operator.
-          unless(cxxOperatorCallExpr(isAssignmentOverloadedOperatorCall())),
-          unless(callee(cxxMethodDecl(isAssignmentOverloadedOperatorMethod()))))
+          unless(callee(functionDecl(isAssignmentOverloadedOperatorMethod()))))
           .bind("match"));
 
   auto CheckCastToVoid =

--- a/clang-tools-extra/clang-tidy/bugprone/UnusedReturnValueCheck.cpp
+++ b/clang-tools-extra/clang-tidy/bugprone/UnusedReturnValueCheck.cpp
@@ -165,20 +165,20 @@ void UnusedReturnValueCheck::storeOptions(ClangTidyOptions::OptionMap &Opts) {
 
 void UnusedReturnValueCheck::registerMatchers(MatchFinder *Finder) {
   auto MatchedDirectCallExpr = expr(
-      callExpr(
-          callee(functionDecl(
-              // Don't match void overloads of checked functions.
-              unless(returns(voidType())),
-              // Don't match copy or move assignment operator.
-              unless(cxxMethodDecl(isOperatorOverloading(
-                  {OO_Equal, OO_PlusEqual, OO_MinusEqual, OO_StarEqual,
-                   OO_SlashEqual, OO_PercentEqual, OO_CaretEqual, OO_AmpEqual,
-                   OO_PipeEqual, OO_LessLessEqual, OO_GreaterGreaterEqual}))),
-              anyOf(
-                  isInstantiatedFrom(
-                      matchers::matchesAnyListedName(CheckedFunctions)),
-                  returns(hasCanonicalType(hasDeclaration(namedDecl(
-                      matchers::matchesAnyListedName(CheckedReturnTypes)))))))))
+      callExpr(callee(functionDecl(
+                   // Don't match void overloads of checked functions.
+                   unless(returns(voidType())),
+                   // Don't match copy or move assignment operator.
+                   unless(cxxMethodDecl(isOperatorOverloading(
+                       {OO_Equal, OO_PlusEqual, OO_MinusEqual, OO_StarEqual,
+                        OO_SlashEqual, OO_PercentEqual, OO_CaretEqual,
+                        OO_AmpEqual, OO_PipeEqual, OO_LessLessEqual,
+                        OO_GreaterGreaterEqual, OO_PlusPlus, OO_MinusMinus}))),
+                   anyOf(isInstantiatedFrom(
+                             matchers::matchesAnyListedName(CheckedFunctions)),
+                         returns(hasCanonicalType(hasDeclaration(
+                             namedDecl(matchers::matchesAnyListedName(
+                                 CheckedReturnTypes)))))))))
           .bind("match"));
 
   auto CheckCastToVoid =

--- a/clang-tools-extra/test/clang-tidy/checkers/bugprone/unused-return-value-avoid-assignment.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/bugprone/unused-return-value-avoid-assignment.cpp
@@ -16,6 +16,8 @@ struct S {
   S &operator--(int);
 };
 
+S &operator-=(S&, S);
+
 S returnValue();
 S const &returnRef();
 
@@ -31,6 +33,8 @@ void bar() {
   a.operator=(returnRef());
 
   a += returnRef();
+  a -= returnRef();
+
   a++;
   ++a;
   a--;

--- a/clang-tools-extra/test/clang-tidy/checkers/bugprone/unused-return-value-avoid-assignment.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/bugprone/unused-return-value-avoid-assignment.cpp
@@ -10,6 +10,10 @@ struct S {
   S &operator=(S const &);
   S &operator=(S &&);
   S &operator+=(S);
+  S &operator++();
+  S &operator++(int);
+  S &operator--();
+  S &operator--(int);
 };
 
 S returnValue();
@@ -27,4 +31,8 @@ void bar() {
   a.operator=(returnRef());
 
   a += returnRef();
+  a++;
+  ++a;
+  a--;
+  --a;
 }

--- a/clang-tools-extra/test/clang-tidy/checkers/bugprone/unused-return-value-avoid-assignment.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/bugprone/unused-return-value-avoid-assignment.cpp
@@ -3,29 +3,37 @@
 // RUN:  {bugprone-unused-return-value.CheckedFunctions: "::*"}}' \
 // RUN: --
 
-struct S {
-  S(){};
-  S(S const &);
-  S(S &&);
-  S &operator=(S const &);
-  S &operator=(S &&);
-  S &operator+=(S);
-  S &operator++();
-  S &operator++(int);
-  S &operator--();
-  S &operator--(int);
+struct S1 {
+  S1(){};
+  S1(S1 const &);
+  S1(S1 &&);
+  S1 &operator=(S1 const &);
+  S1 &operator=(S1 &&);
+  S1 &operator+=(S1);
+  S1 &operator++();
+  S1 &operator++(int);
+  S1 &operator--();
+  S1 &operator--(int);
 };
 
-S &operator-=(S&, S);
+struct S2 {
+  S2(){};
+  S2(S2 const &);
+  S2(S2 &&);
+};
 
-S returnValue();
-S const &returnRef();
+S2 &operator-=(S2&, int);
+S2 &operator++(S2 &);
+S2 &operator++(S2 &, int);
+
+S1 returnValue();
+S1 const &returnRef();
 
 void bar() {
   returnValue();
   // CHECK-MESSAGES: [[@LINE-1]]:3: warning: the value returned by this function should not be disregarded; neglecting it may lead to errors
 
-  S a{};
+  S1 a{};
   a = returnValue();
   a.operator=(returnValue());
 
@@ -33,10 +41,15 @@ void bar() {
   a.operator=(returnRef());
 
   a += returnRef();
-  a -= returnRef();
 
   a++;
   ++a;
   a--;
   --a;
+
+  S2 b{};
+
+  b -= 1;
+  b++;
+  ++b;
 }


### PR DESCRIPTION
Fixes: #84705
Further fix for #84489