### PR TITLE
Fix bug in documentation regarding dependencies.

### DIFF
--- a/libcxx/docs/Modules.rst
+++ b/libcxx/docs/Modules.rst
@@ -207,7 +207,7 @@ This is a small sample program that uses the module ``std``. It consists of a
 
   add_executable(main)
   add_dependencies(main std)
-  target_link_libraries(std)
+  target_link_libraries(main std)
   target_sources(main
     PRIVATE
       main.cpp

--- a/libcxx/docs/Modules.rst
+++ b/libcxx/docs/Modules.rst
@@ -206,6 +206,8 @@ This is a small sample program that uses the module ``std``. It consists of a
   #
 
   add_executable(main)
+  add_dependencies(main std)
+  target_link_libraries(std)
   target_sources(main
     PRIVATE
       main.cpp
@@ -218,12 +220,8 @@ Building this project is done with the following steps, assuming the files
 
   $ mkdir build
   $ cmake -G Ninja -S . -B build -DCMAKE_CXX_COMPILER=<path-to-compiler> -DLIBCXX_BUILD=<build>
-  $ ninja -j1 std -C build
   $ ninja -C build
   $ build/main
-
-.. note:: The ``std`` dependencies of ``std.compat`` is not always resolved when
-          building the ``std`` target using multiple jobs.
 
 .. warning:: ``<path-to-compiler>`` should point point to the real binary and
              not to a symlink.


### PR DESCRIPTION
The docs for building modules suggest you have to build with -j1 and
build the std modules first. Fortunetly, that's just a bug in the
documentation. By correctly listing the libraries as dependencies,
the build system will order the builds correctly.
