### PR TITLE
[RISC-V] Only emit multiples of 16 as immediate for cm.push

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVFrameLowering.cpp
+++ b/llvm/lib/Target/RISCV/RISCVFrameLowering.cpp
@@ -555,7 +555,7 @@ void RISCVFrameLowering::emitPrologue(MachineFunction &MF,
       FirstFrameSetup->getOpcode() == RISCV::CM_PUSH) {
     // Use available stack adjustment in push instruction to allocate additional
     // stack space.
-    uint64_t Spimm = std::min(StackSize, (uint64_t)48);
+    uint64_t Spimm = alignTo(std::min(StackSize, (uint64_t)48), 16);
     FirstFrameSetup->getOperand(1).setImm(Spimm);
     StackSize -= Spimm;
   }

--- a/llvm/lib/Target/RISCV/RISCVFrameLowering.cpp
+++ b/llvm/lib/Target/RISCV/RISCVFrameLowering.cpp
@@ -557,7 +557,7 @@ void RISCVFrameLowering::emitPrologue(MachineFunction &MF,
     // stack space.
     uint64_t Spimm = alignTo(std::min(StackSize, (uint64_t)48), 16);
     FirstFrameSetup->getOperand(1).setImm(Spimm);
-    StackSize -= Spimm;
+    StackSize -= std::min(StackSize, Spimm);
   }
 
   if (StackSize != 0) {

--- a/llvm/lib/Target/RISCV/RISCVFrameLowering.cpp
+++ b/llvm/lib/Target/RISCV/RISCVFrameLowering.cpp
@@ -777,9 +777,9 @@ void RISCVFrameLowering::emitEpilogue(MachineFunction &MF,
       MBBI->getOpcode() == RISCV::CM_POP) {
     // Use available stack adjustment in pop instruction to deallocate stack
     // space.
-    uint64_t Spimm = std::min(StackSize, (uint64_t)48);
+    uint64_t Spimm = alignTo(std::min(StackSize, (uint64_t)48), 16);
     MBBI->getOperand(1).setImm(Spimm);
-    StackSize -= Spimm;
+    StackSize -= std::min(StackSize, Spimm);
   }
 
   // Deallocate stack

--- a/llvm/test/CodeGen/RISCV/zcmp-additional-stack.ll
+++ b/llvm/test/CodeGen/RISCV/zcmp-additional-stack.ll
@@ -31,7 +31,7 @@ define ptr @func(ptr %s, i32 %_c, ptr %incdec.ptr, i1 %0, i8 %conv14) #0 {
 ; RV32-NEXT:    lw a0, 4(sp) # 4-byte Folded Reload
 ; RV32-NEXT:    sb a0, 0(s0)
 ; RV32-NEXT:    mv a0, s1
-; RV32-NEXT:    cm.popret {ra, s0-s1}, 24
+; RV32-NEXT:    cm.popret {ra, s0-s1}, 32
 entry:
   br label %while.body
 

--- a/llvm/test/CodeGen/RISCV/zcmp-additional-stack.ll
+++ b/llvm/test/CodeGen/RISCV/zcmp-additional-stack.ll
@@ -3,7 +3,8 @@
 define ptr @func(ptr %s, i32 %_c, ptr %incdec.ptr, i1 %0, i8 %conv14) #0 {
 ; RV32-LABEL: func:
 ; RV32:       # %bb.0: # %entry
-; RV32-NEXT:    cm.push {ra, s0-s1}, -24
+; RV32-NEXT:    cm.push {ra, s0-s1}, -32
+; RV32-NEXT:    addi sp, sp, 8
 ; RV32-NEXT:    .cfi_def_cfa_offset 24
 ; RV32-NEXT:    .cfi_offset ra, -12
 ; RV32-NEXT:    .cfi_offset s0, -8

--- a/llvm/test/CodeGen/RISCV/zcmp-additional-stack.ll
+++ b/llvm/test/CodeGen/RISCV/zcmp-additional-stack.ll
@@ -4,7 +4,6 @@ define ptr @func(ptr %s, i32 %_c, ptr %incdec.ptr, i1 %0, i8 %conv14) #0 {
 ; RV32-LABEL: func:
 ; RV32:       # %bb.0: # %entry
 ; RV32-NEXT:    cm.push {ra, s0-s1}, -32
-; RV32-NEXT:    addi sp, sp, 8
 ; RV32-NEXT:    .cfi_def_cfa_offset 24
 ; RV32-NEXT:    .cfi_offset ra, -12
 ; RV32-NEXT:    .cfi_offset s0, -8


### PR DESCRIPTION
An immediate that isn't a multiple of 16 is meaningless and we should always emit the next higher multiple. Otherwise the value is simply truncated of course which leads to clobbering CSR's on the stack.