### PR TITLE
Hack together a building module test suite example.

### DIFF
--- a/libcxx/include/CMakeLists.txt
+++ b/libcxx/include/CMakeLists.txt
@@ -1023,6 +1023,26 @@ set(files
   wctype.h
   )
 
+
+# Create a set of wrapper includes for use with C++ modules. Most headers are replaced
+# with one containing "import std.compat" and a few are textually copied because
+# they're non-modular or they have macros.
+#
+# Wrapped headers must be
+#  (A) Public headers
+#  (B) not C headers ending in .h (those provide macros sometimes)
+#  (C) not a textual
+set(TOP_LEVEL_HEADERS ${files})
+list(FILTER TOP_LEVEL_HEADERS EXCLUDE REGEX "^.*/.*$")
+set(TEXTUAL_HEADERS ${TOP_LEVEL_HEADERS})
+list(FILTER TEXTUAL_HEADERS INCLUDE REGEX "^(version|cassert|cerrno|climits|cstdarg|cstdio|.*\.h|__.*)$")
+set(WRAPPED_HEADERS)
+foreach (header ${TOP_LEVEL_HEADERS})
+  if (NOT ${header} IN_LIST TEXTUAL_HEADERS)
+    list(APPEND WRAPPED_HEADERS ${header})
+  endif()
+endforeach()
+
 configure_file("__config_site.in" "${LIBCXX_GENERATED_INCLUDE_TARGET_DIR}/__config_site" @ONLY)
 configure_file("${LIBCXX_ASSERTION_HANDLER_FILE}" "${LIBCXX_GENERATED_INCLUDE_DIR}/__assertion_handler" COPYONLY)
 
@@ -1038,7 +1058,29 @@ foreach(f ${files})
   list(APPEND _all_includes "${dst}")
 endforeach()
 
-add_custom_target(generate-cxx-headers ALL DEPENDS ${_all_includes})
+set(_wrapper_headers)
+foreach(f ${TEXTUAL_HEADERS})
+    set(src "${LIBCXX_GENERATED_INCLUDE_DIR}/${f}")
+    set(dst "${LIBCXX_GENERATED_MODULE_DIR}/../vm/${f}")
+    add_custom_command(OUTPUT ${dst}
+        DEPENDS ${src} ${_all_includes}
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different ${src} ${dst}
+        COMMENT "Copying CXX header ${f}")
+    list(APPEND _wrapper_headers "${dst}")
+endforeach()
+
+foreach(f ${WRAPPED_HEADERS})
+    set(src "${CMAKE_CURRENT_SOURCE_DIR}/../modules/std_compat_wrapper.h")
+    set(dst "${LIBCXX_GENERATED_MODULE_DIR}/../vm/${f}")
+    add_custom_command(OUTPUT ${dst}
+        DEPENDS ${src}
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different ${src} ${dst}
+        COMMENT "Copying CXX header ${f}")
+    list(APPEND _wrapper_headers "${dst}")
+endforeach()
+
+
+add_custom_target(generate-cxx-headers ALL DEPENDS ${_all_includes} ${_wrapper_headers})
 
 add_library(cxx-headers INTERFACE)
 target_link_libraries(cxx-headers INTERFACE libcxx-abi-headers)

--- a/libcxx/modules/std_compat_wrapper.h
+++ b/libcxx/modules/std_compat_wrapper.h
@@ -1,0 +1,17 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _LIBCPP__STD_COMPAT_WRAPPER_H
+#define _LIBCPP__STD_COMPAT_WRAPPER_H
+
+#include <__config>
+#include <version>
+
+import std.compat;
+
+#endif

--- a/libcxx/utils/compile-std-module.sh
+++ b/libcxx/utils/compile-std-module.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+set -x
+set -e
+MODULE_DIR='/usr/local/include/c++/v1/__modules'
+
+FLAGS='-std=c++26 -pthread'
+LIBCXX_FLAGS='-nostdinc++ -isystem /usr/local/include/c++/v1 -isystem /usr/local/include/x86_64-unknown-linux-gnu/c++/v1'
+function compile_module {
+  MODULE_NAME=$1
+  shift
+  clang++ $LIBCXX_FLAGS $FLAGS -fmodule-output=./$MODULE_NAME.pcm -c $MODULE_DIR/$MODULE_NAME.cppm -o $MODULE_NAME.o  "$@"
+
+}
+compile_module std $@
+compile_module std.compat -fmodule-file=std=./std.pcm $@
+
+ar rcs libc++modules.a std.o std.compat.o


### PR DESCRIPTION
You would first build + configure, that should produce wrapper
headers next to the other generated headers at c++/vm rather than v1.

Then, use the compile-std-module.sh script to produce the PCM's
somewhere.

Then modify your generated lit.site.cfg in the build directory
to look something like (note this example does'n use the in-tree
generated headers set because I didn't want to rewrite it)

config.substitutions.append(('%{flags}',
    '-pthread' + (' -isysroot {}'.format('') if '' else '')
    + ' -fmodule-file=std.compat=/tmp/test/std.compat.pcm'
    + ' -fmodule-file=std=/tmp/test/std.pcm'
))
config.substitutions.append(('%{compile_flags}',
    '-nostdinc++ -isystem /usr/local/include/c++/vm -isystem /usr/local/include/x86_64-unknown-linux-gnu/c++/v1 -I %{libcxx-dir}/test/support'
))
config.substitutions.append(('%{link_flags}',
    '-stdlib=libc++ /tmp/test/std.o /tmp/test/std.compat.o'
))
