### PR TITLE
[FuzzMutate] Only use undef when explictly asked to

### DIFF
--- a/llvm/lib/FuzzMutate/OpDescriptor.cpp
+++ b/llvm/lib/FuzzMutate/OpDescriptor.cpp
@@ -8,9 +8,14 @@
 
 #include "llvm/FuzzMutate/OpDescriptor.h"
 #include "llvm/IR/Constants.h"
+#include "llvm/Support/CommandLine.h"
 
 using namespace llvm;
 using namespace fuzzerop;
+
+static cl::opt<bool> UseUndef("use-undef",
+                              cl::desc("Use undef when generating programs."),
+                              cl::init(false));
 
 void fuzzerop::makeConstantsWithType(Type *T, std::vector<Constant *> &Cs) {
   if (auto *IntTy = dyn_cast<IntegerType>(T)) {
@@ -42,7 +47,8 @@ void fuzzerop::makeConstantsWithType(Type *T, std::vector<Constant *> &Cs) {
       Cs.push_back(ConstantVector::getSplat(EC, Elt));
     }
   } else {
-    Cs.push_back(UndefValue::get(T));
+    if (UseUndef)
+      Cs.push_back(UndefValue::get(T));
     Cs.push_back(PoisonValue::get(T));
   }
 }


### PR DESCRIPTION
Per discussion in https://github.com/SecurityLab-UCD/IRFuzzer/issues/49, generating undef during fuzzing seems to be less fruitful. Let's eliminate undef in favor of poison unless the user explicitly asked for it.