### PR TITLE
[sanitizer][windows] report symbols in clang_rt. or \compiler-rt\lib\ as internal.

### DIFF
--- a/compiler-rt/lib/sanitizer_common/sanitizer_symbolizer_report.cpp
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_symbolizer_report.cpp
@@ -39,7 +39,11 @@ static bool FrameIsInternal(const SymbolizedStack *frame) {
                internal_strstr(file, "/include/c++/") ||
                internal_strstr(file, "/include/g++")))
     return true;
+  if (file && internal_strstr(file, "\\compiler-rt\\lib\\"))
+    return true;
   if (module && (internal_strstr(module, "libclang_rt.")))
+    return true;
+  if (module && (internal_strstr(module, "clang_rt.")))
     return true;
   return false;
 }


### PR DESCRIPTION
This is the windows equivalent to the existing filters.

Work from https://github.com/llvm/llvm-project/pull/81677 that can be applied separately (and is actually not critical for that PR)