### PR TITLE
[X86] Fix determining if globals with size <8 bits are large

### DIFF
--- a/llvm/lib/Target/TargetMachine.cpp
+++ b/llvm/lib/Target/TargetMachine.cpp
@@ -92,7 +92,7 @@ bool TargetMachine::isLargeGlobalValue(const GlobalValue *GVal) const {
                                 GV->getName().starts_with("__stop_")))
       return true;
     const DataLayout &DL = GV->getParent()->getDataLayout();
-    uint64_t Size = DL.getTypeSizeInBits(GV->getValueType()) / 8;
+    uint64_t Size = DL.getTypeAllocSize(GV->getValueType());
     return Size == 0 || Size > LargeDataThreshold;
   }
 

--- a/llvm/test/CodeGen/X86/code-model-elf.ll
+++ b/llvm/test/CodeGen/X86/code-model-elf.ll
@@ -772,9 +772,7 @@ define dso_local i1 @load_bool() #0 {
 ;
 ; MEDIUM-SMALL-DATA-PIC-LABEL: load_bool:
 ; MEDIUM-SMALL-DATA-PIC:       # %bb.0:
-; MEDIUM-SMALL-DATA-PIC-NEXT:    leaq _GLOBAL_OFFSET_TABLE_(%rip), %rax
-; MEDIUM-SMALL-DATA-PIC-NEXT:    movabsq $bool@GOTOFF, %rcx
-; MEDIUM-SMALL-DATA-PIC-NEXT:    movzbl (%rax,%rcx), %eax
+; MEDIUM-SMALL-DATA-PIC-NEXT:    movzbl bool(%rip), %eax
 ; MEDIUM-SMALL-DATA-PIC-NEXT:    retq
 ;
 ; MEDIUM-PIC-LABEL: load_bool:


### PR DESCRIPTION
Previously any global under 8 bits would accidentally be considered 0 sized, which is considered a large global.