### PR TITLE
[llvm] Include LLVM_REPOSITORY and LLVM_REVISION in tool version

### DIFF
--- a/llvm/lib/Support/CMakeLists.txt
+++ b/llvm/lib/Support/CMakeLists.txt
@@ -286,6 +286,9 @@ add_llvm_component_library(LLVMSupport
   ${LLVM_MAIN_INCLUDE_DIR}/llvm/Support
   ${Backtrace_INCLUDE_DIRS}
 
+  DEPENDS
+  llvm_vcsrevision_h
+
   LINK_LIBS
   ${system_libs} ${imported_libs} ${delayload_flags}
 

--- a/llvm/lib/Support/CommandLine.cpp
+++ b/llvm/lib/Support/CommandLine.cpp
@@ -39,6 +39,7 @@
 #include "llvm/Support/Path.h"
 #include "llvm/Support/Process.h"
 #include "llvm/Support/StringSaver.h"
+#include "llvm/Support/VCSRevision.h"
 #include "llvm/Support/VirtualFileSystem.h"
 #include "llvm/Support/raw_ostream.h"
 #include <cstdlib>
@@ -2538,7 +2539,15 @@ public:
 #else
     OS << "LLVM (http://llvm.org/):\n  ";
 #endif
-    OS << PACKAGE_NAME << " version " << PACKAGE_VERSION << "\n  ";
+    OS << PACKAGE_NAME << " version " << PACKAGE_VERSION;
+#ifdef LLVM_REPOSITORY
+    OS << " (" << LLVM_REPOSITORY;
+#ifdef LLVM_REVISION
+    OS << ' ' << LLVM_REVISION;
+#endif
+    OS << ')';
+#endif
+    OS << "\n  ";
 #if LLVM_IS_DEBUG_BUILD
     OS << "DEBUG build";
 #else


### PR DESCRIPTION
Include the `LLVM_REPOSITORY` and `LLVM_REVISION` in the version output of tools using `cl::PrintVersionMessage()` such as dwarfdump and dsymutil.

Before:

```
$ llvm-dwarfdump --version
LLVM (http://llvm.org/):
  LLVM version 19.0.0git
  Optimized build with assertions.
```

After:

```
$ llvm-dwarfdump --version
LLVM (http://llvm.org/):
  LLVM version 19.0.0git (git@github.com:llvm/llvm-project.git 8467457afc61d70e881c9817ace26356ef757733)
  Optimized build with assertions.
```

rdar://121526866