### PR TITLE
AMDGPU: Use list-table for metadata table

### DIFF
--- a/llvm/docs/AMDGPUUsage.rst
+++ b/llvm/docs/AMDGPUUsage.rst
@@ -1317,15 +1317,16 @@ LLVM IR Metadata
 
 The AMDGPU backend implements the following LLVM IR metadata.
 
-.. table:: AMDGPU LLVM IR Metadata
+.. list-table:: AMDGPU LLVM IR Metatdata
   :name: amdgpu-llvm-ir-metadata-table
+  * - Metadata Name
+    - Description
+    - Values
 
-  ==============================================   ==========================================================
-  LLVM IR Metadata                                   Description
-  ==============================================   ==========================================================
-  !amdgpu.last.use                                 Sets TH_LOAD_LU temporal hint on load instructions that support it.
-                                                   Takes priority over nontemporal hint (TH_LOAD_NT).
-  ==============================================   ==========================================================
+  * - !amdgpu.last.use
+    - Sets TH_LOAD_LU temporal hint on load instructions that support it.
+      Takes priority over nontemporal hint (TH_LOAD_NT).
+    - {}
 
 LLVM IR Attributes
 ------------------

--- a/llvm/docs/AMDGPUUsage.rst
+++ b/llvm/docs/AMDGPUUsage.rst
@@ -1319,10 +1319,10 @@ The AMDGPU backend implements the following LLVM IR metadata.
 
 .. list-table:: AMDGPU LLVM IR Metatdata
   :name: amdgpu-llvm-ir-metadata-table
+
   * - Metadata Name
     - Description
     - Values
-
   * - !amdgpu.last.use
     - Sets TH_LOAD_LU temporal hint on load instructions that support it.
       Takes priority over nontemporal hint (TH_LOAD_NT).


### PR DESCRIPTION
The table syntax for sphinx is really insufferably whitespace dependent. I've been meaning to convert the existing attribute and intrinsic tables to use list-table, which is less painful to merge.