### PR TITLE
[libc] Include time.h in baremetal targets

### DIFF
--- a/libc/config/baremetal/api.td
+++ b/libc/config/baremetal/api.td
@@ -68,6 +68,15 @@ def StringAPI : PublicAPI<"string.h"> {
   let Types = ["size_t"];
 }
 
+def TimeAPI : PublicAPI<"time.h"> {
+  let Types = [
+    "clock_t",
+    "time_t",
+    "struct tm",
+    "struct timespec",
+  ];
+}
+
 def UCharAPI : PublicAPI<"uchar.h"> {
   let Types = ["mbstate_t"];
 }

--- a/libc/config/baremetal/arm/entrypoints.txt
+++ b/libc/config/baremetal/arm/entrypoints.txt
@@ -180,6 +180,9 @@ set(TARGET_LIBC_ENTRYPOINTS
     libc.src.stdlib.strtoll
     libc.src.stdlib.strtoul
     libc.src.stdlib.strtoull
+
+    # time.h entrypoints
+    libc.src.time.difftime
 )
 
 set(TARGET_LIBM_ENTRYPOINTS

--- a/libc/config/baremetal/arm/headers.txt
+++ b/libc/config/baremetal/arm/headers.txt
@@ -13,5 +13,6 @@ set(TARGET_PUBLIC_HEADERS
     libc.include.string
     libc.include.strings
     libc.include.sys_queue
+    libc.include.time
     libc.include.uchar
 )

--- a/libc/config/baremetal/riscv/entrypoints.txt
+++ b/libc/config/baremetal/riscv/entrypoints.txt
@@ -180,6 +180,9 @@ set(TARGET_LIBC_ENTRYPOINTS
     libc.src.stdlib.strtoll
     libc.src.stdlib.strtoul
     libc.src.stdlib.strtoull
+
+    # time.h entrypoints
+    libc.src.time.difftime
 )
 
 set(TARGET_LIBM_ENTRYPOINTS

--- a/libc/config/baremetal/riscv/headers.txt
+++ b/libc/config/baremetal/riscv/headers.txt
@@ -13,5 +13,6 @@ set(TARGET_PUBLIC_HEADERS
     libc.include.string
     libc.include.strings
     libc.include.sys_queue
+    libc.include.time
     libc.include.uchar
 )


### PR DESCRIPTION
These types and conversion functions are used in embedded development.

Note that we cannot yet include other entrypoints such as asctime because `src/time/time_utils.h` unconditionally uses `EOVERFLOW`, which is only defined in POSIX and not in C standard. This issue is tracked by #85556.