### PR TITLE
Mark test as XFAIL that started failing after 418f0066eb.

### DIFF
--- a/cross-project-tests/debuginfo-tests/llgdb-tests/forward-declare-class.cpp
+++ b/cross-project-tests/debuginfo-tests/llgdb-tests/forward-declare-class.cpp
@@ -1,6 +1,7 @@
 // RUN: %clangxx %target_itanium_abi_host_triple -O0 -g %s -c -o %t.o
 // RUN: %test_debuginfo %s %t.o
 // Radar 9168773
+// XFAIL: !system-darwin && gdb-clang-incompatibility
 
 // DEBUGGER: ptype A
 // Work around a gdb bug where it believes that a class is a


### PR DESCRIPTION
Similar failures were previously seen and XFAILed in https://reviews.llvm.org/D118468.

See the phabricator review for a description of the problem, and the linked discourse thread for what the failing output looks like.

This change should fix the issue on two buildbots that are running older versions of GDB:
- https://lab.llvm.org/buildbot/#/builders/217/builds/37559
- https://lab.llvm.org/buildbot/#/builders/247/builds/15173