### PR TITLE
[libc] Match stdlib.h baremetal entrypoints with types

### DIFF
--- a/libc/config/baremetal/api.td
+++ b/libc/config/baremetal/api.td
@@ -60,7 +60,7 @@ def StdlibAPI : PublicAPI<"stdlib.h"> {
     "size_t",
     "__bsearchcompare_t",
     "__qsortcompare_t",
-    "__atexithandler_t",
+    "__qsortrcompare_t",
   ];
 }
 


### PR DESCRIPTION
To match the entrypoints and types for baremetal, we need to include __qsortrcompare_t and omit __atexithandler_t.