### PR TITLE
[InstCombine] Simplify `zext nneg i1 X` to zero

### DIFF
--- a/llvm/lib/Transforms/InstCombine/InstCombineCasts.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineCasts.cpp
@@ -1121,6 +1121,10 @@ Instruction *InstCombinerImpl::visitZExt(ZExtInst &Zext) {
   Value *Src = Zext.getOperand(0);
   Type *SrcTy = Src->getType(), *DestTy = Zext.getType();
 
+  // zext nneg bool x -> 0
+  if (SrcTy->isIntOrIntVectorTy(1) && Zext.hasNonNeg())
+    return replaceInstUsesWith(Zext, Constant::getNullValue(Zext.getType()));
+
   // Try to extend the entire expression tree to the wide destination type.
   unsigned BitsToClear;
   if (shouldChangeType(SrcTy, DestTy) &&

--- a/llvm/test/Transforms/InstCombine/zext.ll
+++ b/llvm/test/Transforms/InstCombine/zext.ll
@@ -836,3 +836,36 @@ define i64 @zext_nneg_demanded_constant(i8 %a) nounwind {
   %c = and i64 %b, 254
   ret i64 %c
 }
+
+define i32 @zext_nneg_i1(i1 %x) {
+; CHECK-LABEL: @zext_nneg_i1(
+; CHECK-NEXT:  entry:
+; CHECK-NEXT:    [[RES:%.*]] = zext nneg i1 [[X:%.*]] to i32
+; CHECK-NEXT:    ret i32 [[RES]]
+;
+entry:
+  %res = zext nneg i1 %x to i32
+  ret i32 %res
+}
+
+define <2 x i32> @zext_nneg_i1_vec(<2 x i1> %x) {
+; CHECK-LABEL: @zext_nneg_i1_vec(
+; CHECK-NEXT:  entry:
+; CHECK-NEXT:    [[RES:%.*]] = zext nneg <2 x i1> [[X:%.*]] to <2 x i32>
+; CHECK-NEXT:    ret <2 x i32> [[RES]]
+;
+entry:
+  %res = zext nneg <2 x i1> %x to <2 x i32>
+  ret <2 x i32> %res
+}
+
+define i32 @zext_nneg_i2(i2 %x) {
+; CHECK-LABEL: @zext_nneg_i2(
+; CHECK-NEXT:  entry:
+; CHECK-NEXT:    [[RES:%.*]] = zext nneg i2 [[X:%.*]] to i32
+; CHECK-NEXT:    ret i32 [[RES]]
+;
+entry:
+  %res = zext nneg i2 %x to i32
+  ret i32 %res
+}

--- a/llvm/test/Transforms/InstCombine/zext.ll
+++ b/llvm/test/Transforms/InstCombine/zext.ll
@@ -840,8 +840,7 @@ define i64 @zext_nneg_demanded_constant(i8 %a) nounwind {
 define i32 @zext_nneg_i1(i1 %x) {
 ; CHECK-LABEL: @zext_nneg_i1(
 ; CHECK-NEXT:  entry:
-; CHECK-NEXT:    [[RES:%.*]] = zext nneg i1 [[X:%.*]] to i32
-; CHECK-NEXT:    ret i32 [[RES]]
+; CHECK-NEXT:    ret i32 0
 ;
 entry:
   %res = zext nneg i1 %x to i32
@@ -851,8 +850,7 @@ entry:
 define <2 x i32> @zext_nneg_i1_vec(<2 x i1> %x) {
 ; CHECK-LABEL: @zext_nneg_i1_vec(
 ; CHECK-NEXT:  entry:
-; CHECK-NEXT:    [[RES:%.*]] = zext nneg <2 x i1> [[X:%.*]] to <2 x i32>
-; CHECK-NEXT:    ret <2 x i32> [[RES]]
+; CHECK-NEXT:    ret <2 x i32> zeroinitializer
 ;
 entry:
   %res = zext nneg <2 x i1> %x to <2 x i32>


### PR DESCRIPTION
Alive2: https://alive2.llvm.org/ce/z/Wm6kCk

It is not suitable to implement this in InstSimplify because nneg flag is dropped :(
https://github.com/llvm/llvm-project/blob/0be9592b0077dc63596ce46379cf7b3bd4a405c8/llvm/lib/Analysis/InstructionSimplify.cpp#L7116-L7120
