### PR TITLE
[Orc] Move SymbolStringPool from EPC to ExecutionSession (NFC)

### DIFF
--- a/llvm/examples/Kaleidoscope/include/KaleidoscopeJIT.h
+++ b/llvm/examples/Kaleidoscope/include/KaleidoscopeJIT.h
@@ -71,7 +71,9 @@ public:
     if (!EPC)
       return EPC.takeError();
 
-    auto ES = std::make_unique<ExecutionSession>(std::move(*EPC));
+    auto SSP = std::make_shared<SymbolStringPool>();
+    auto ES =
+        std::make_unique<ExecutionSession>(std::move(*EPC), std::move(SSP));
 
     JITTargetMachineBuilder JTMB(
         ES->getExecutorProcessControl().getTargetTriple());

--- a/llvm/include/llvm/ExecutionEngine/Orc/Core.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/Core.h
@@ -1454,7 +1454,7 @@ public:
   /// Construct an ExecutionSession with the given ExecutorProcessControl
   /// object.
   ExecutionSession(std::unique_ptr<ExecutorProcessControl> EPC,
-                   std::shared_ptr<SymbolStringPool> SSP = nullptr);
+                   std::shared_ptr<SymbolStringPool> SSP);
 
   /// Destroy an ExecutionSession. Verifies that endSession was called prior to
   /// destruction.

--- a/llvm/include/llvm/ExecutionEngine/Orc/Core.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/Core.h
@@ -1453,7 +1453,8 @@ public:
 
   /// Construct an ExecutionSession with the given ExecutorProcessControl
   /// object.
-  ExecutionSession(std::unique_ptr<ExecutorProcessControl> EPC);
+  ExecutionSession(std::unique_ptr<ExecutorProcessControl> EPC,
+                   std::shared_ptr<SymbolStringPool> SSP = nullptr);
 
   /// Destroy an ExecutionSession. Verifies that endSession was called prior to
   /// destruction.
@@ -1474,12 +1475,10 @@ public:
   size_t getPageSize() const { return EPC->getPageSize(); }
 
   /// Get the SymbolStringPool for this instance.
-  std::shared_ptr<SymbolStringPool> getSymbolStringPool() {
-    return EPC->getSymbolStringPool();
-  }
+  std::shared_ptr<SymbolStringPool> getSymbolStringPool() { return SSP; }
 
   /// Add a symbol name to the SymbolStringPool and return a pointer to it.
-  SymbolStringPtr intern(StringRef SymName) { return EPC->intern(SymName); }
+  SymbolStringPtr intern(StringRef SymName) { return SSP->intern(SymName); }
 
   /// Set the Platform for this ExecutionSession.
   void setPlatform(std::unique_ptr<Platform> P) { this->P = std::move(P); }
@@ -1856,6 +1855,7 @@ private:
   mutable std::recursive_mutex SessionMutex;
   bool SessionOpen = true;
   std::unique_ptr<ExecutorProcessControl> EPC;
+  std::shared_ptr<SymbolStringPool> SSP;
   std::unique_ptr<Platform> P;
   ErrorReporter ReportError = logErrorsToStdErr;
   DispatchTaskFunction DispatchTask = runOnCurrentThread;

--- a/llvm/include/llvm/ExecutionEngine/Orc/ExecutorProcessControl.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/ExecutorProcessControl.h
@@ -457,11 +457,11 @@ private:
 class UnsupportedExecutorProcessControl : public ExecutorProcessControl,
                                           private InProcessMemoryAccess {
 public:
-  UnsupportedExecutorProcessControl(
-      std::unique_ptr<TaskDispatcher> D = nullptr, const std::string &TT = "",
-      unsigned PageSize = 0)
-      : ExecutorProcessControl(
-            D ? std::move(D) : std::make_unique<InPlaceTaskDispatcher>()),
+  UnsupportedExecutorProcessControl(std::unique_ptr<TaskDispatcher> D = nullptr,
+                                    const std::string &TT = "",
+                                    unsigned PageSize = 0)
+      : ExecutorProcessControl(D ? std::move(D)
+                                 : std::make_unique<InPlaceTaskDispatcher>()),
         InProcessMemoryAccess(Triple(TT).isArch64Bit()) {
     this->TargetTriple = Triple(TT);
     this->PageSize = PageSize;

--- a/llvm/include/llvm/ExecutionEngine/Orc/ExecutorProcessControl.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/ExecutorProcessControl.h
@@ -413,8 +413,6 @@ public:
   virtual Error disconnect() = 0;
 
 protected:
-
-  std::shared_ptr<SymbolStringPool> SSP;
   std::unique_ptr<TaskDispatcher> D;
   ExecutionSession *ES = nullptr;
   Triple TargetTriple;

--- a/llvm/include/llvm/ExecutionEngine/Orc/SimpleRemoteEPC.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/SimpleRemoteEPC.h
@@ -50,9 +50,7 @@ public:
   static Expected<std::unique_ptr<SimpleRemoteEPC>>
   Create(std::unique_ptr<TaskDispatcher> D, Setup S,
          TransportTCtorArgTs &&...TransportTCtorArgs) {
-    std::unique_ptr<SimpleRemoteEPC> SREPC(
-        new SimpleRemoteEPC(std::make_shared<SymbolStringPool>(),
-                            std::move(D)));
+    std::unique_ptr<SimpleRemoteEPC> SREPC(new SimpleRemoteEPC(std::move(D)));
     auto T = TransportT::Create(
         *SREPC, std::forward<TransportTCtorArgTs>(TransportTCtorArgs)...);
     if (!T)
@@ -94,9 +92,8 @@ public:
   void handleDisconnect(Error Err) override;
 
 private:
-  SimpleRemoteEPC(std::shared_ptr<SymbolStringPool> SSP,
-                  std::unique_ptr<TaskDispatcher> D)
-    : ExecutorProcessControl(std::move(SSP), std::move(D)) {}
+  SimpleRemoteEPC(std::unique_ptr<TaskDispatcher> D)
+      : ExecutorProcessControl(std::move(D)) {}
 
   static Expected<std::unique_ptr<jitlink::JITLinkMemoryManager>>
   createDefaultMemoryManager(SimpleRemoteEPC &SREPC);

--- a/llvm/lib/ExecutionEngine/Orc/EPCDebugObjectRegistrar.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/EPCDebugObjectRegistrar.cpp
@@ -30,8 +30,8 @@ Expected<std::unique_ptr<EPCDebugObjectRegistrar>> createJITLoaderGDBRegistrar(
 
   SymbolStringPtr RegisterFn =
       EPC.getTargetTriple().isOSBinFormatMachO()
-          ? EPC.intern("_llvm_orc_registerJITLoaderGDBWrapper")
-          : EPC.intern("llvm_orc_registerJITLoaderGDBWrapper");
+          ? ES.intern("_llvm_orc_registerJITLoaderGDBWrapper")
+          : ES.intern("llvm_orc_registerJITLoaderGDBWrapper");
 
   SymbolLookupSet RegistrationSymbols;
   RegistrationSymbols.add(RegisterFn);

--- a/llvm/lib/ExecutionEngine/Orc/LLJIT.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/LLJIT.cpp
@@ -936,12 +936,14 @@ LLJIT::LLJIT(LLJITBuilderState &S, Error &Err)
   assert(!(S.EPC && S.ES) && "EPC and ES should not both be set");
 
   if (S.EPC) {
-    ES = std::make_unique<ExecutionSession>(std::move(S.EPC));
-  } else if (S.ES)
+    auto SSP = std::make_shared<SymbolStringPool>();
+    ES = std::make_unique<ExecutionSession>(std::move(S.EPC), std::move(SSP));
+  } else if (S.ES) {
     ES = std::move(S.ES);
-  else {
+  } else {
     if (auto EPC = SelfExecutorProcessControl::Create()) {
-      ES = std::make_unique<ExecutionSession>(std::move(*EPC));
+      auto SSP = std::make_shared<SymbolStringPool>();
+      ES = std::make_unique<ExecutionSession>(std::move(*EPC), std::move(SSP));
     } else {
       Err = EPC.takeError();
       return;

--- a/llvm/tools/lli/lli.cpp
+++ b/llvm/tools/lli/lli.cpp
@@ -964,7 +964,8 @@ int runOrcJIT(const char *ProgName) {
   // unsupported architectures).
   if (UseJITKind != JITKind::OrcLazy) {
     auto ES = std::make_unique<orc::ExecutionSession>(
-        ExitOnErr(orc::SelfExecutorProcessControl::Create()));
+        ExitOnErr(orc::SelfExecutorProcessControl::Create()),
+        std::make_shared<orc::SymbolStringPool>());
     Builder.setLazyCallthroughManager(
         std::make_unique<orc::LazyCallThroughManager>(*ES, orc::ExecutorAddr(),
                                                       nullptr));

--- a/llvm/tools/lli/lli.cpp
+++ b/llvm/tools/lli/lli.cpp
@@ -1024,8 +1024,7 @@ int runOrcJIT(const char *ProgName) {
 
   std::unique_ptr<orc::ExecutorProcessControl> EPC = nullptr;
   if (JITLinker == JITLinkerKind::JITLink) {
-    EPC = ExitOnErr(orc::SelfExecutorProcessControl::Create(
-        std::make_shared<orc::SymbolStringPool>()));
+    EPC = ExitOnErr(orc::SelfExecutorProcessControl::Create());
 
     Builder.getJITTargetMachineBuilder()
         ->setRelocationModel(Reloc::PIC_)

--- a/llvm/tools/llvm-jitlink/llvm-jitlink.cpp
+++ b/llvm/tools/llvm-jitlink/llvm-jitlink.cpp
@@ -954,7 +954,7 @@ Session::~Session() {
 }
 
 Session::Session(std::unique_ptr<ExecutorProcessControl> EPC, Error &Err)
-    : ES(std::move(EPC)),
+    : ES(std::move(EPC), std::make_shared<SymbolStringPool>()),
       ObjLayer(ES, ES.getExecutorProcessControl().getMemMgr()) {
 
   /// Local ObjectLinkingLayer::Plugin class to forward modifyPassConfig to the

--- a/llvm/tools/llvm-jitlink/llvm-jitlink.cpp
+++ b/llvm/tools/llvm-jitlink/llvm-jitlink.cpp
@@ -936,7 +936,6 @@ Expected<std::unique_ptr<Session>> Session::Create(Triple TT,
     if (!PageSize)
       return PageSize.takeError();
     EPC = std::make_unique<SelfExecutorProcessControl>(
-        std::make_shared<SymbolStringPool>(),
         std::make_unique<InPlaceTaskDispatcher>(), std::move(TT), *PageSize,
         createInProcessMemoryManager());
   }

--- a/llvm/unittests/ExecutionEngine/Orc/CoreAPIsTest.cpp
+++ b/llvm/unittests/ExecutionEngine/Orc/CoreAPIsTest.cpp
@@ -1561,7 +1561,9 @@ TEST(JITDylibTest, GetDFSLinkOrderTree) {
   // Test that DFS ordering behaves as expected when the linkage relationships
   // form a tree.
 
-  ExecutionSession ES{std::make_unique<UnsupportedExecutorProcessControl>()};
+  auto SSP = std::make_shared<SymbolStringPool>();
+  ExecutionSession ES{std::make_unique<UnsupportedExecutorProcessControl>(),
+                      SSP};
   auto _ = make_scope_exit([&]() { cantFail(ES.endSession()); });
 
   auto &LibA = ES.createBareJITDylib("A");
@@ -1603,7 +1605,9 @@ TEST(JITDylibTest, GetDFSLinkOrderDiamond) {
   // Test that DFS ordering behaves as expected when the linkage relationships
   // contain a diamond.
 
-  ExecutionSession ES{std::make_unique<UnsupportedExecutorProcessControl>()};
+  auto SSP = std::make_shared<SymbolStringPool>();
+  ExecutionSession ES{std::make_unique<UnsupportedExecutorProcessControl>(),
+                      SSP};
   auto _ = make_scope_exit([&]() { cantFail(ES.endSession()); });
 
   auto &LibA = ES.createBareJITDylib("A");
@@ -1627,7 +1631,9 @@ TEST(JITDylibTest, GetDFSLinkOrderCycle) {
   // Test that DFS ordering behaves as expected when the linkage relationships
   // contain a cycle.
 
-  ExecutionSession ES{std::make_unique<UnsupportedExecutorProcessControl>()};
+  auto SSP = std::make_shared<SymbolStringPool>();
+  ExecutionSession ES{std::make_unique<UnsupportedExecutorProcessControl>(),
+                      SSP};
   auto _ = make_scope_exit([&]() { cantFail(ES.endSession()); });
 
   auto &LibA = ES.createBareJITDylib("A");
@@ -1711,7 +1717,9 @@ TEST_F(CoreAPIsStandardTest, RemoveJITDylibs) {
 TEST(CoreAPIsExtraTest, SessionTeardownByFailedToMaterialize) {
 
   auto RunTestCase = []() -> Error {
-    ExecutionSession ES{std::make_unique<UnsupportedExecutorProcessControl>()};
+    auto SSP = std::make_shared<SymbolStringPool>();
+    ExecutionSession ES{std::make_unique<UnsupportedExecutorProcessControl>(),
+                        SSP};
     auto Foo = ES.intern("foo");
     auto FooFlags = JITSymbolFlags::Exported;
 

--- a/llvm/unittests/ExecutionEngine/Orc/CoreAPIsTest.cpp
+++ b/llvm/unittests/ExecutionEngine/Orc/CoreAPIsTest.cpp
@@ -1711,8 +1711,7 @@ TEST_F(CoreAPIsStandardTest, RemoveJITDylibs) {
 TEST(CoreAPIsExtraTest, SessionTeardownByFailedToMaterialize) {
 
   auto RunTestCase = []() -> Error {
-    ExecutionSession ES{std::make_unique<UnsupportedExecutorProcessControl>(
-        std::make_shared<SymbolStringPool>())};
+    ExecutionSession ES{std::make_unique<UnsupportedExecutorProcessControl>()};
     auto Foo = ES.intern("foo");
     auto FooFlags = JITSymbolFlags::Exported;
 

--- a/llvm/unittests/ExecutionEngine/Orc/ExecutionSessionWrapperFunctionCallsTest.cpp
+++ b/llvm/unittests/ExecutionEngine/Orc/ExecutionSessionWrapperFunctionCallsTest.cpp
@@ -36,7 +36,8 @@ voidWrapper(const char *ArgData, size_t ArgSize) {
 }
 
 TEST(ExecutionSessionWrapperFunctionCalls, RunWrapperTemplate) {
-  ExecutionSession ES(cantFail(SelfExecutorProcessControl::Create()));
+  auto SSP = std::make_shared<SymbolStringPool>();
+  ExecutionSession ES(cantFail(SelfExecutorProcessControl::Create()), SSP);
 
   int32_t Result;
   EXPECT_THAT_ERROR(ES.callSPSWrapper<int32_t(int32_t, int32_t)>(
@@ -47,7 +48,8 @@ TEST(ExecutionSessionWrapperFunctionCalls, RunWrapperTemplate) {
 }
 
 TEST(ExecutionSessionWrapperFunctionCalls, RunVoidWrapperAsyncTemplate) {
-  ExecutionSession ES(cantFail(SelfExecutorProcessControl::Create()));
+  auto SSP = std::make_shared<SymbolStringPool>();
+  ExecutionSession ES(cantFail(SelfExecutorProcessControl::Create()), SSP);
 
   std::promise<MSVCPError> RP;
   ES.callSPSWrapperAsync<void()>(ExecutorAddr::fromPtr(voidWrapper),
@@ -60,7 +62,8 @@ TEST(ExecutionSessionWrapperFunctionCalls, RunVoidWrapperAsyncTemplate) {
 }
 
 TEST(ExecutionSessionWrapperFunctionCalls, RunNonVoidWrapperAsyncTemplate) {
-  ExecutionSession ES(cantFail(SelfExecutorProcessControl::Create()));
+  auto SSP = std::make_shared<SymbolStringPool>();
+  ExecutionSession ES(cantFail(SelfExecutorProcessControl::Create()), SSP);
 
   std::promise<MSVCPExpected<int32_t>> RP;
   ES.callSPSWrapperAsync<int32_t(int32_t, int32_t)>(
@@ -80,7 +83,8 @@ TEST(ExecutionSessionWrapperFunctionCalls, RegisterAsyncHandlerAndRun) {
 
   constexpr ExecutorAddr AddAsyncTagAddr(0x01);
 
-  ExecutionSession ES(cantFail(SelfExecutorProcessControl::Create()));
+  auto SSP = std::make_shared<SymbolStringPool>();
+  ExecutionSession ES(cantFail(SelfExecutorProcessControl::Create()), SSP);
   auto &JD = ES.createBareJITDylib("JD");
 
   auto AddAsyncTag = ES.intern("addAsync_tag");

--- a/llvm/unittests/ExecutionEngine/Orc/ObjectLinkingLayerTest.cpp
+++ b/llvm/unittests/ExecutionEngine/Orc/ObjectLinkingLayerTest.cpp
@@ -37,7 +37,8 @@ public:
   }
 
 protected:
-  ExecutionSession ES{std::make_unique<UnsupportedExecutorProcessControl>()};
+  ExecutionSession ES{std::make_unique<UnsupportedExecutorProcessControl>(),
+                      std::make_shared<SymbolStringPool>()};
   JITDylib &JD = ES.createBareJITDylib("main");
   ObjectLinkingLayer ObjLinkingLayer{
       ES, std::make_unique<InProcessMemoryManager>(4096)};
@@ -208,7 +209,8 @@ TEST(ObjectLinkingLayerSearchGeneratorTest, AbsoluteSymbolsObjectLayer) {
     }
   };
 
-  ExecutionSession ES{std::make_unique<TestEPC>()};
+  auto SSP = std::make_shared<SymbolStringPool>();
+  ExecutionSession ES{std::make_unique<TestEPC>(), SSP};
   JITDylib &JD = ES.createBareJITDylib("main");
   ObjectLinkingLayer ObjLinkingLayer{
       ES, std::make_unique<InProcessMemoryManager>(4096)};

--- a/llvm/unittests/ExecutionEngine/Orc/ObjectLinkingLayerTest.cpp
+++ b/llvm/unittests/ExecutionEngine/Orc/ObjectLinkingLayerTest.cpp
@@ -182,8 +182,7 @@ TEST(ObjectLinkingLayerSearchGeneratorTest, AbsoluteSymbolsObjectLayer) {
   class TestEPC : public UnsupportedExecutorProcessControl {
   public:
     TestEPC()
-        : UnsupportedExecutorProcessControl(nullptr, nullptr,
-                                            "x86_64-apple-darwin") {}
+        : UnsupportedExecutorProcessControl(nullptr, "x86_64-apple-darwin") {}
 
     Expected<tpctypes::DylibHandle> loadDylib(const char *DylibPath) override {
       return ExecutorAddr::fromPtr((void *)nullptr);

--- a/llvm/unittests/ExecutionEngine/Orc/OrcTestCommon.h
+++ b/llvm/unittests/ExecutionEngine/Orc/OrcTestCommon.h
@@ -52,7 +52,9 @@ public:
   }
 
 protected:
-  ExecutionSession ES{std::make_unique<UnsupportedExecutorProcessControl>()};
+  std::shared_ptr<SymbolStringPool> SSP = std::make_shared<SymbolStringPool>();
+  ExecutionSession ES{std::make_unique<UnsupportedExecutorProcessControl>(),
+                      SSP};
   JITDylib &JD = ES.createBareJITDylib("JD");
   SymbolStringPtr Foo = ES.intern("foo");
   SymbolStringPtr Bar = ES.intern("bar");

--- a/llvm/unittests/ExecutionEngine/Orc/OrcTestCommon.h
+++ b/llvm/unittests/ExecutionEngine/Orc/OrcTestCommon.h
@@ -52,8 +52,7 @@ public:
   }
 
 protected:
-  std::shared_ptr<SymbolStringPool> SSP = std::make_shared<SymbolStringPool>();
-  ExecutionSession ES{std::make_unique<UnsupportedExecutorProcessControl>(SSP)};
+  ExecutionSession ES{std::make_unique<UnsupportedExecutorProcessControl>()};
   JITDylib &JD = ES.createBareJITDylib("JD");
   SymbolStringPtr Foo = ES.intern("foo");
   SymbolStringPtr Bar = ES.intern("bar");

--- a/llvm/unittests/ExecutionEngine/Orc/RTDyldObjectLinkingLayerTest.cpp
+++ b/llvm/unittests/ExecutionEngine/Orc/RTDyldObjectLinkingLayerTest.cpp
@@ -46,7 +46,9 @@ static bool testSetProcessAllSections(std::unique_ptr<MemoryBuffer> Obj,
 
   bool NonAllocSectionSeen = false;
 
-  ExecutionSession ES(std::make_unique<UnsupportedExecutorProcessControl>());
+  std::shared_ptr<SymbolStringPool> SSP = std::make_shared<SymbolStringPool>();
+  ExecutionSession ES{std::make_unique<UnsupportedExecutorProcessControl>(),
+                      SSP};
   auto &JD = ES.createBareJITDylib("main");
   auto Foo = ES.intern("foo");
 
@@ -153,7 +155,9 @@ TEST(RTDyldObjectLinkingLayerTest, TestOverrideObjectFlags) {
   }
 
   // Create a simple stack and set the override flags option.
-  ExecutionSession ES{std::make_unique<UnsupportedExecutorProcessControl>()};
+  std::shared_ptr<SymbolStringPool> SSP = std::make_shared<SymbolStringPool>();
+  ExecutionSession ES{std::make_unique<UnsupportedExecutorProcessControl>(),
+                      SSP};
   auto &JD = ES.createBareJITDylib("main");
   auto Foo = ES.intern("foo");
   RTDyldObjectLinkingLayer ObjLayer(
@@ -223,7 +227,9 @@ TEST(RTDyldObjectLinkingLayerTest, TestAutoClaimResponsibilityForSymbols) {
   }
 
   // Create a simple stack and set the override flags option.
-  ExecutionSession ES{std::make_unique<UnsupportedExecutorProcessControl>()};
+  std::shared_ptr<SymbolStringPool> SSP = std::make_shared<SymbolStringPool>();
+  ExecutionSession ES{std::make_unique<UnsupportedExecutorProcessControl>(),
+                      SSP};
   auto &JD = ES.createBareJITDylib("main");
   auto Foo = ES.intern("foo");
   RTDyldObjectLinkingLayer ObjLayer(


### PR DESCRIPTION
`ExecutorProcessControl`'s interface is supposed to be limited, but over time it accumulated some weight. This is a first attempt to sort things out. Moving ownership of the `SymbolStringPool` from `ExecutorProcessControl` to `ExecutionSession` has no functional impact. It only changes the interface.