### PR TITLE
[Flang][OpenMP][OpenACC][MLIR] Remove typechecks in atomic write/upda…

### DIFF
--- a/mlir/include/mlir/Dialect/OpenACCMPCommon/Interfaces/AtomicInterfaces.td
+++ b/mlir/include/mlir/Dialect/OpenACCMPCommon/Interfaces/AtomicInterfaces.td
@@ -86,9 +86,6 @@ def AtomicWriteOpInterface : OpInterface<"AtomicWriteOpInterface"> {
       /*args=*/(ins),
       /*methodBody=*/"",
       /*defaultImplementation=*/[{
-        mlir::Type elementType = $_op.getX().getType().getElementType();
-        if (elementType && elementType != $_op.getExpr().getType())
-          return $_op.emitError("address must dereference to value type");
         return mlir::success();
       }]
     >,
@@ -196,12 +193,6 @@ def AtomicUpdateOpInterface : OpInterface<"AtomicUpdateOpInterface"> {
       /*defaultImplementation=*/[{
         if ($_op.getRegion().getNumArguments() != 1)
           return $_op.emitError("the region must accept exactly one argument");
-
-        Type elementType = $_op.getX().getType().getElementType();
-        if (elementType && elementType != $_op.getRegion().getArgument(0).getType()) {
-          return $_op.emitError("the type of the operand must be a pointer type whose "
-                          "element type is the same as that of the region argument");
-        }
 
         return mlir::success();
       }]

--- a/mlir/test/Dialect/OpenACC/invalid.mlir
+++ b/mlir/test/Dialect/OpenACC/invalid.mlir
@@ -521,26 +521,6 @@ acc.set
 
 // -----
 
-func.func @acc_atomic_write(%addr : memref<memref<i32>>, %val : i32) {
-  // expected-error @below {{address must dereference to value type}}
-  acc.atomic.write %addr = %val : memref<memref<i32>>, i32
-  return
-}
-
-// -----
-
-func.func @acc_atomic_update(%x: memref<i32>, %expr: f32) {
-  // expected-error @below {{the type of the operand must be a pointer type whose element type is the same as that of the region argument}}
-  acc.atomic.update %x : memref<i32> {
-  ^bb0(%xval: f32):
-    %newval = llvm.fadd %xval, %expr : f32
-    acc.yield %newval : f32
-  }
-  return
-}
-
-// -----
-
 func.func @acc_atomic_update(%x: memref<i32>, %expr: i32) {
   // expected-error @+2 {{op expects regions to end with 'acc.yield', found 'acc.terminator'}}
   // expected-note @below {{in custom textual format, the absence of terminator implies 'acc.yield'}}

--- a/mlir/test/Dialect/OpenMP/invalid.mlir
+++ b/mlir/test/Dialect/OpenMP/invalid.mlir
@@ -703,26 +703,6 @@ func.func @omp_atomic_write6(%addr : memref<i32>, %val : i32) {
 
 // -----
 
-func.func @omp_atomic_write(%addr : memref<memref<i32>>, %val : i32) {
-  // expected-error @below {{address must dereference to value type}}
-  omp.atomic.write %addr = %val : memref<memref<i32>>, i32
-  return
-}
-
-// -----
-
-func.func @omp_atomic_update1(%x: memref<i32>, %expr: f32) {
-  // expected-error @below {{the type of the operand must be a pointer type whose element type is the same as that of the region argument}}
-  omp.atomic.update %x : memref<i32> {
-  ^bb0(%xval: f32):
-    %newval = llvm.fadd %xval, %expr : f32
-    omp.yield (%newval : f32)
-  }
-  return
-}
-
-// -----
-
 func.func @omp_atomic_update2(%x: memref<i32>, %expr: i32) {
   // expected-error @+2 {{op expects regions to end with 'omp.yield', found 'omp.terminator'}}
   // expected-note @below {{in custom textual format, the absence of terminator implies 'omp.yield'}}


### PR DESCRIPTION
…te Op verifiers

The failures in issues #83144(lhsType : **_fir.logical<4>_**, rhsType : **_i1_**) and #83722(lhsType  : **_fp64_**, rhsType : **_fp32_**) stem from mismatches between types. 

However, since we already emit a fir.convert operation, I propose removing these checks. This simplification leverages the existing conversion operation to handle these cases appropriately.