### PR TITLE
[DRAFT][RISCV] Emit arch string macro to facilitate ASM programming

### DIFF
--- a/clang/lib/Basic/Targets/RISCV.cpp
+++ b/clang/lib/Basic/Targets/RISCV.cpp
@@ -139,6 +139,7 @@ void RISCVTargetInfo::getTargetDefines(const LangOptions &Opts,
   unsigned MinVLen = ISAInfo->getMinVLen();
   unsigned MaxELen = ISAInfo->getMaxELen();
   unsigned MaxELenFp = ISAInfo->getMaxELenFp();
+  std::string ArchString = "\"" + ISAInfo->toString() + "\"";
   if (CodeModel == "default")
     CodeModel = "small";
 
@@ -222,6 +223,7 @@ void RISCVTargetInfo::getTargetDefines(const LangOptions &Opts,
     else
       Builder.defineMacro("__riscv_32e");
   }
+  Builder.defineMacro("__riscv_cmdline_arch_string", ArchString);
 }
 
 static constexpr Builtin::Info BuiltinInfo[] = {

--- a/clang/test/Preprocessor/riscv-target-features.c
+++ b/clang/test/Preprocessor/riscv-target-features.c
@@ -185,8 +185,10 @@
 // RUN: %clang --target=riscv64-unknown-linux-gnu \
 // RUN:   -march=rv64ia -E -dM %s \
 // RUN:   -o - | FileCheck --check-prefix=CHECK-A-EXT %s
+// CHECK-A-EXT: __INTPTR_WIDTH__ [[WIDTH:[1-9]+]]
 // CHECK-A-EXT: __riscv_a 2001000{{$}}
 // CHECK-A-EXT: __riscv_atomic 1
+// CHECK-A-EXT: __riscv_cmdline_arch_string "rv[[WIDTH]]i2p1_a2p1"
 
 // RUN: %clang --target=riscv32-unknown-linux-gnu \
 // RUN:   -march=rv32ic -E -dM %s \
@@ -203,6 +205,8 @@
 // RUN: %clang --target=riscv64-unknown-linux-gnu \
 // RUN:   -march=rv64ifd -E -dM %s \
 // RUN:   -o - | FileCheck --check-prefix=CHECK-D-EXT %s
+// CHECK-D-EXT: __INTPTR_WIDTH__ [[WIDTH:[1-9]+]]
+// CHECK-D-EXT: __riscv_cmdline_arch_string "rv[[WIDTH]]i2p1_f2p2_d2p2_zicsr2p0"
 // CHECK-D-EXT: __riscv_d 2002000{{$}}
 // CHECK-D-EXT: __riscv_fdiv 1
 // CHECK-D-EXT: __riscv_flen 64
@@ -217,6 +221,8 @@
 // CHECK-RV32E: __riscv_32e 1
 // CHECK-RV64E: __riscv_64e 1
 // CHECK-E-EXT: __riscv_abi_rve 1
+// CHECK-RV32E: __riscv_cmdline_arch_string "rv32e2p0"
+// CHECK-RV64E: __riscv_cmdline_arch_string "rv64e2p0"
 // CHECK-E-EXT: __riscv_e 2000000{{$}}
 
 // RUN: %clang --target=riscv32-unknown-linux-gnu \
@@ -225,6 +231,8 @@
 // RUN: %clang --target=riscv64-unknown-linux-gnu \
 // RUN:   -march=rv64if -E -dM %s \
 // RUN:   -o - | FileCheck --check-prefix=CHECK-F-EXT %s
+// CHECK-F-EXT: __INTPTR_WIDTH__ [[WIDTH:[1-9]+]]
+// CHECK-F-EXT: __riscv_cmdline_arch_string "rv[[WIDTH]]i2p1_f2p2_zicsr2p0"
 // CHECK-F-EXT: __riscv_f 2002000{{$}}
 // CHECK-F-EXT: __riscv_fdiv 1
 // CHECK-F-EXT: __riscv_flen 32


### PR DESCRIPTION
In order to make assembly programming more convenient, emit macro __riscv_cmdline_arch_string that will be defined to the arch string based on the command line arguments. This string may differ from the actual string that is added to the object or assembly file. This provides a convenient mechanism for the programmer to add the .attribute directive into pre-processed asm files.

Example file.S:
.attribute 5, __riscv_cmdline_arch_string