### PR TITLE
[Orc] Move TaskDispatcher ownership from EPC to derived classes

### DIFF
--- a/llvm/include/llvm/ExecutionEngine/Orc/ExecutorProcessControl.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/ExecutorProcessControl.h
@@ -187,9 +187,8 @@ public:
     ExecutorAddr JITDispatchContext;
   };
 
-  ExecutorProcessControl(std::shared_ptr<SymbolStringPool> SSP,
-                         std::unique_ptr<TaskDispatcher> D)
-    : SSP(std::move(SSP)), D(std::move(D)) {}
+  ExecutorProcessControl(std::shared_ptr<SymbolStringPool> SSP)
+    : SSP(std::move(SSP)) {}
 
   virtual ~ExecutorProcessControl();
 
@@ -421,11 +420,11 @@ public:
 protected:
 
   std::shared_ptr<SymbolStringPool> SSP;
-  std::unique_ptr<TaskDispatcher> D;
   ExecutionSession *ES = nullptr;
   Triple TargetTriple;
   unsigned PageSize = 0;
   JITDispatchInfo JDI;
+  TaskDispatcher *D;
   MemoryAccess *MemAccess = nullptr;
   jitlink::JITLinkMemoryManager *MemMgr = nullptr;
   StringMap<std::vector<char>> BootstrapMap;
@@ -465,11 +464,10 @@ class UnsupportedExecutorProcessControl : public ExecutorProcessControl,
 public:
   UnsupportedExecutorProcessControl(
       std::shared_ptr<SymbolStringPool> SSP = nullptr,
-      std::unique_ptr<TaskDispatcher> D = nullptr, const std::string &TT = "",
+      const std::string &TT = "",
       unsigned PageSize = 0)
       : ExecutorProcessControl(
-            SSP ? std::move(SSP) : std::make_shared<SymbolStringPool>(),
-            D ? std::move(D) : std::make_unique<InPlaceTaskDispatcher>()),
+            SSP ? std::move(SSP) : std::make_shared<SymbolStringPool>()),
         InProcessMemoryAccess(Triple(TT).isArch64Bit()) {
     this->TargetTriple = Triple(TT);
     this->PageSize = PageSize;
@@ -549,6 +547,7 @@ private:
   jitDispatchViaWrapperFunctionManager(void *Ctx, const void *FnTag,
                                        const char *Data, size_t Size);
 
+  std::unique_ptr<TaskDispatcher> OwnedTaskDispatcher;
   std::unique_ptr<jitlink::JITLinkMemoryManager> OwnedMemMgr;
   char GlobalManglingPrefix = 0;
 };

--- a/llvm/include/llvm/ExecutionEngine/Orc/ExecutorProcessControl.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/ExecutorProcessControl.h
@@ -188,7 +188,7 @@ public:
   };
 
   ExecutorProcessControl(std::shared_ptr<SymbolStringPool> SSP)
-    : SSP(std::move(SSP)) {}
+      : SSP(std::move(SSP)) {}
 
   virtual ~ExecutorProcessControl();
 
@@ -418,7 +418,6 @@ public:
   virtual Error disconnect() = 0;
 
 protected:
-
   std::shared_ptr<SymbolStringPool> SSP;
   ExecutionSession *ES = nullptr;
   Triple TargetTriple;
@@ -464,10 +463,9 @@ class UnsupportedExecutorProcessControl : public ExecutorProcessControl,
 public:
   UnsupportedExecutorProcessControl(
       std::shared_ptr<SymbolStringPool> SSP = nullptr,
-      const std::string &TT = "",
-      unsigned PageSize = 0)
-      : ExecutorProcessControl(
-            SSP ? std::move(SSP) : std::make_shared<SymbolStringPool>()),
+      const std::string &TT = "", unsigned PageSize = 0)
+      : ExecutorProcessControl(SSP ? std::move(SSP)
+                                   : std::make_shared<SymbolStringPool>()),
         InProcessMemoryAccess(Triple(TT).isArch64Bit()) {
     this->TargetTriple = Triple(TT);
     this->PageSize = PageSize;

--- a/llvm/include/llvm/ExecutionEngine/Orc/SimpleRemoteEPC.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/SimpleRemoteEPC.h
@@ -96,7 +96,8 @@ public:
 private:
   SimpleRemoteEPC(std::shared_ptr<SymbolStringPool> SSP,
                   std::unique_ptr<TaskDispatcher> D)
-      : ExecutorProcessControl(std::move(SSP)), OwnedTaskDispatcher(std::move(D)) {
+      : ExecutorProcessControl(std::move(SSP)),
+        OwnedTaskDispatcher(std::move(D)) {
     this->D = OwnedTaskDispatcher.get();
   }
 

--- a/llvm/include/llvm/ExecutionEngine/Orc/SimpleRemoteEPC.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/SimpleRemoteEPC.h
@@ -96,7 +96,9 @@ public:
 private:
   SimpleRemoteEPC(std::shared_ptr<SymbolStringPool> SSP,
                   std::unique_ptr<TaskDispatcher> D)
-    : ExecutorProcessControl(std::move(SSP), std::move(D)) {}
+      : ExecutorProcessControl(std::move(SSP)), OwnedTaskDispatcher(std::move(D)) {
+    this->D = OwnedTaskDispatcher.get();
+  }
 
   static Expected<std::unique_ptr<jitlink::JITLinkMemoryManager>>
   createDefaultMemoryManager(SimpleRemoteEPC &SREPC);
@@ -130,6 +132,7 @@ private:
   std::unique_ptr<SimpleRemoteEPCTransport> T;
   std::unique_ptr<jitlink::JITLinkMemoryManager> OwnedMemMgr;
   std::unique_ptr<MemoryAccess> OwnedMemAccess;
+  std::unique_ptr<TaskDispatcher> OwnedTaskDispatcher;
 
   std::unique_ptr<EPCGenericDylibManager> DylibMgr;
   ExecutorAddr RunAsMainAddr;

--- a/llvm/unittests/ExecutionEngine/Orc/ObjectLinkingLayerTest.cpp
+++ b/llvm/unittests/ExecutionEngine/Orc/ObjectLinkingLayerTest.cpp
@@ -182,7 +182,7 @@ TEST(ObjectLinkingLayerSearchGeneratorTest, AbsoluteSymbolsObjectLayer) {
   class TestEPC : public UnsupportedExecutorProcessControl {
   public:
     TestEPC()
-        : UnsupportedExecutorProcessControl(nullptr, nullptr,
+        : UnsupportedExecutorProcessControl(nullptr,
                                             "x86_64-apple-darwin") {}
 
     Expected<tpctypes::DylibHandle> loadDylib(const char *DylibPath) override {

--- a/llvm/unittests/ExecutionEngine/Orc/ObjectLinkingLayerTest.cpp
+++ b/llvm/unittests/ExecutionEngine/Orc/ObjectLinkingLayerTest.cpp
@@ -182,8 +182,7 @@ TEST(ObjectLinkingLayerSearchGeneratorTest, AbsoluteSymbolsObjectLayer) {
   class TestEPC : public UnsupportedExecutorProcessControl {
   public:
     TestEPC()
-        : UnsupportedExecutorProcessControl(nullptr,
-                                            "x86_64-apple-darwin") {}
+        : UnsupportedExecutorProcessControl(nullptr, "x86_64-apple-darwin") {}
 
     Expected<tpctypes::DylibHandle> loadDylib(const char *DylibPath) override {
       return ExecutorAddr::fromPtr((void *)nullptr);


### PR DESCRIPTION
We use this approach for MemoryManager and MemoryAccess already. This patch applies it for TaskDispatcher too.