### PR TITLE
[LLDB] Add lldb-python-scripts to the things installed on Linux.

### DIFF
--- a/lldb/cmake/caches/Apple-lldb-Linux.cmake
+++ b/lldb/cmake/caches/Apple-lldb-Linux.cmake
@@ -5,4 +5,5 @@ set(LLVM_DISTRIBUTION_COMPONENTS
   liblldb
   lldb-argdumper
   lldb-server
+  lldb-python-scripts
   CACHE STRING "")


### PR DESCRIPTION
We should be installing the python scripts here.

rdar://123436512