### PR TITLE
[OpenMP] Disable flaky barrier fence test

### DIFF
--- a/openmp/libomptarget/test/offloading/barrier_fence.c
+++ b/openmp/libomptarget/test/offloading/barrier_fence.c
@@ -3,6 +3,10 @@
 // RUN: %libomptarget-compileopt-generic -fopenmp-offload-mandatory -O3
 // RUN: %libomptarget-run-generic
 
+// FIXME: This test is flaky on all targets
+// UNSUPPORTED: amdgcn-amd-amdhsa
+// UNSUPPORTED: nvptx64-nvidia-cuda
+// UNSUPPORTED: nvptx64-nvidia-cuda-LTO
 // UNSUPPORTED: aarch64-unknown-linux-gnu
 // UNSUPPORTED: aarch64-unknown-linux-gnu-LTO
 // UNSUPPORTED: x86_64-pc-linux-gnu


### PR DESCRIPTION
Summary:
This test is flaky on all targets I know of. We should disable it for
now so running the test suite doesn't randomly fail 50% of the time.
