### PR TITLE
[MLIR][ROCDL] Fix BallotOp LLVM translation and add doc

### DIFF
--- a/mlir/include/mlir/Dialect/LLVMIR/ROCDLOps.td
+++ b/mlir/include/mlir/Dialect/LLVMIR/ROCDLOps.td
@@ -162,10 +162,20 @@ def ROCDL_BallotOp :
   ROCDL_Op<"ballot">,
   Results<(outs LLVM_Type:$res)>,
   Arguments<(ins I1:$pred)> {
+  let summary = "Vote across thread group";
+
+  let description = [{
+      This operation applies a reduction to the source predicate across all the active threads within a warp, 
+      resulting in a destination predicate value that is uniform for every thread in the warp.
+
+      i1 -> i32
+  }];
+
   string llvmBuilder = [{
       $res = createIntrinsicCall(builder,
             llvm::Intrinsic::amdgcn_ballot, {$pred}, {llvm::Type::getInt32Ty(moduleTranslation.getLLVMContext())});
   }];
+
   let assemblyFormat = "$pred attr-dict `:` type($res)";
 }
 

--- a/mlir/include/mlir/Dialect/LLVMIR/ROCDLOps.td
+++ b/mlir/include/mlir/Dialect/LLVMIR/ROCDLOps.td
@@ -171,7 +171,7 @@ def ROCDL_BallotOp :
 
   string llvmBuilder = [{
       $res = createIntrinsicCall(builder,
-            llvm::Intrinsic::amdgcn_ballot, {$pred}, {$res.getType()});
+            llvm::Intrinsic::amdgcn_ballot, {$pred}, {$res->getType()});
   }];
 
   let assemblyFormat = "$pred attr-dict `:` type($res)";

--- a/mlir/include/mlir/Dialect/LLVMIR/ROCDLOps.td
+++ b/mlir/include/mlir/Dialect/LLVMIR/ROCDLOps.td
@@ -171,7 +171,7 @@ def ROCDL_BallotOp :
 
   string llvmBuilder = [{
       $res = createIntrinsicCall(builder,
-            llvm::Intrinsic::amdgcn_ballot, {$pred}, {$res->getType()});
+            llvm::Intrinsic::amdgcn_ballot, {$pred}, {$_resultType});
   }];
 
   let assemblyFormat = "$pred attr-dict `:` type($res)";

--- a/mlir/include/mlir/Dialect/LLVMIR/ROCDLOps.td
+++ b/mlir/include/mlir/Dialect/LLVMIR/ROCDLOps.td
@@ -166,9 +166,7 @@ def ROCDL_BallotOp :
 
   let description = [{
       Ballot provides a bit mask containing the 1-bit predicate value from each lane. 
-      The nth bit of the result contains the 1 bit contributed by the nth warp lane
-
-      i1 -> anyint
+      The nth bit of the result contains the 1 bit contributed by the nth warp lane.
   }];
 
   string llvmBuilder = [{

--- a/mlir/include/mlir/Dialect/LLVMIR/ROCDLOps.td
+++ b/mlir/include/mlir/Dialect/LLVMIR/ROCDLOps.td
@@ -165,15 +165,15 @@ def ROCDL_BallotOp :
   let summary = "Vote across thread group";
 
   let description = [{
-      This operation applies a reduction to the source predicate across all the active threads within a warp, 
-      resulting in a destination predicate value that is uniform for every thread in the warp.
+      Ballot provides a bit mask containing the 1-bit predicate value from each lane. 
+      The nth bit of the result contains the 1 bit contributed by the nth warp lane
 
-      i1 -> i32
+      i1 -> anyint
   }];
 
   string llvmBuilder = [{
       $res = createIntrinsicCall(builder,
-            llvm::Intrinsic::amdgcn_ballot, {$pred}, {llvm::Type::getInt32Ty(moduleTranslation.getLLVMContext())});
+            llvm::Intrinsic::amdgcn_ballot, {$pred}, {$res.getType()});
   }];
 
   let assemblyFormat = "$pred attr-dict `:` type($res)";

--- a/mlir/test/Target/LLVMIR/rocdl.mlir
+++ b/mlir/test/Target/LLVMIR/rocdl.mlir
@@ -88,15 +88,15 @@ llvm.func @rocdl.bpermute(%src : i32) -> i32 {
   llvm.return %0 : i32
 }
 
-llvm.func @rocdl.ballot(%pred : i1) -> i32 {
-  // CHECK-LABEL: rocdl.ballot
+llvm.func @rocdl.ballot32(%pred : i1) -> i32 {
+  // CHECK-LABEL: rocdl.ballot32
   // CHECK: call i32 @llvm.amdgcn.ballot
   %0 = rocdl.ballot %pred : i32
   llvm.return %0 : i32
 }
 
-llvm.func @rocdl.ballot(%pred : i1) -> i64 {
-  // CHECK-LABEL: rocdl.ballot
+llvm.func @rocdl.ballot64(%pred : i1) -> i64 {
+  // CHECK-LABEL: rocdl.ballot64
   // CHECK: call i64 @llvm.amdgcn.ballot
   %0 = rocdl.ballot %pred : i64
   llvm.return %0 : i64

--- a/mlir/test/Target/LLVMIR/rocdl.mlir
+++ b/mlir/test/Target/LLVMIR/rocdl.mlir
@@ -95,6 +95,13 @@ llvm.func @rocdl.ballot(%pred : i1) -> i32 {
   llvm.return %0 : i32
 }
 
+llvm.func @rocdl.ballot(%pred : i1) -> i64 {
+  // CHECK-LABEL: rocdl.ballot
+  // CHECK: call i64 @llvm.amdgcn.ballot
+  %0 = rocdl.ballot %pred : i64
+  llvm.return %0 : i64
+}
+
 llvm.func @rocdl.waitcnt() {
   // CHECK-LABEL: rocdl.waitcnt
   // CHECK-NEXT: call void @llvm.amdgcn.s.waitcnt(i32 0)


### PR DESCRIPTION

This modifies the return type of the intrinsic call to handle 32 and 64 bits
properly and document the MLIR operation.