### PR TITLE
AMDGPU: Discussion: Do we actually need these TSFlags bits in Real?

### DIFF
--- a/llvm/lib/Target/AMDGPU/BUFInstructions.td
+++ b/llvm/lib/Target/AMDGPU/BUFInstructions.td
@@ -331,9 +331,12 @@ class MUBUF_Real <MUBUF_Pseudo ps, string real_name = ps.Mnemonic> :
   let isPseudo = 0;
   let isCodeGenOnly = 0;
 
-  let VM_CNT = 1;
-  let EXP_CNT = 1;
-  let MUBUF = 1;
+  // I see no reason to hard-code these bits in Real. We are copying
+  // TSFlags from Pseudo, so these values won't go into Real's TSFlags.
+  // If we don't use these bits in Real, we should not set them here.
+  //let VM_CNT = 1;
+  //let EXP_CNT = 1;
+  //let MUBUF = 1;
 
   // copy relevant pseudo op flags
   let SubtargetPredicate   = ps.SubtargetPredicate;
@@ -341,15 +344,15 @@ class MUBUF_Real <MUBUF_Pseudo ps, string real_name = ps.Mnemonic> :
   let OtherPredicates      = ps.OtherPredicates;
   let Constraints          = ps.Constraints;
   let DisableEncoding      = ps.DisableEncoding;
-  let TSFlags              = ps.TSFlags;
+  let TSFlags              = ps.TSFlags; // TSFlags from pseudo carry everything.
   let UseNamedOperandTable = ps.UseNamedOperandTable;
   let SchedRW              = ps.SchedRW;
   let mayLoad              = ps.mayLoad;
   let mayStore             = ps.mayStore;
   let IsAtomicRet          = ps.IsAtomicRet;
   let IsAtomicNoRet        = ps.IsAtomicNoRet;
-  let VALU                 = ps.VALU;
-  let LGKM_CNT             = ps.LGKM_CNT;
+  //let VALU                 = ps.VALU;      // Have we ever used  VALU in real?
+  //let LGKM_CNT             = ps.LGKM_CNT;  // Have we ever used  LGKM in real?
 
   bits<12> offset;
   bits<5>  cpol;


### PR DESCRIPTION
  I am thinking it is unnecessay to assign to any TSFlags bits (LGKM_CNT, for example) in Real. I haven't seen any use of these bits directly. And we usually copy TSFlags from Pseudo. As a result, the values of these bits won't go into the TSFlags of Real. Is there any other use of them (besides possible setting the TSFlags)

  I want to propose to clean up these assignment, as shown in the example of MUBUF_Real. But I want to hear from you for opinions first.  Thanks.