### PR TITLE
[Support] add move operations to raw_ostream

### DIFF
--- a/llvm/include/llvm/Support/raw_ostream.h
+++ b/llvm/include/llvm/Support/raw_ostream.h
@@ -143,6 +143,8 @@ public:
 
   raw_ostream(const raw_ostream &) = delete;
   void operator=(const raw_ostream &) = delete;
+  raw_ostream(raw_ostream &&) = default;
+  raw_ostream &operator=(raw_ostream &&) = default;
 
   virtual ~raw_ostream();
 


### PR DESCRIPTION
Copy constructor/operator= were explicitly deleted. Hence, move constructor/operator= were left implicitly deleted. This patch declares them by default and allows the following code to be compiled.

raw_fd_ostream openStream(StringRef Path) {
    std::error_code EC;
    raw_fd_ostream OS(Path, EC);
    // handle errors here
    return std::move(OS);
}