### PR TITLE
[RISCV] Use 'riscv-isa' module flag to set ELF flags and attributes.

### DIFF
--- a/llvm/test/CodeGen/RISCV/attributes-module-flag.ll
+++ b/llvm/test/CodeGen/RISCV/attributes-module-flag.ll
@@ -1,0 +1,17 @@
+; RUN: llc -mtriple=riscv32 %s -o - | FileCheck %s --check-prefix=RV32
+; RUN: llc -mtriple=riscv64 %s -o - | FileCheck %s --check-prefix=RV64
+
+; Test generation of ELF attribute from module metadata
+
+; RV32: .attribute 5, "rv32i2p1_m2p0_zba1p0"
+; RV64: .attribute 5, "rv64i2p1_m2p0_zba1p0"
+
+define i32 @addi(i32 %a) {
+  %1 = add i32 %a, 1
+  ret i32 %1
+}
+
+!llvm.module.flags = !{!0}
+
+!0 = !{i32 6, !"riscv-isa", !1}
+!1 = !{!"rv64i2p1_m2p0", !"rv64i2p1_zba1p0"}

--- a/llvm/test/CodeGen/RISCV/module-elf-flags.ll
+++ b/llvm/test/CodeGen/RISCV/module-elf-flags.ll
@@ -1,0 +1,13 @@
+; RUN: llc -mtriple=riscv32 -filetype=obj < %s | llvm-readelf -h - | FileCheck -check-prefixes=FLAGS %s
+
+; FLAGS: Flags: 0x11, RVC, TSO
+
+define i32 @addi(i32 %a) {
+  %1 = add i32 %a, 1
+  ret i32 %1
+}
+
+!llvm.module.flags = !{!0}
+
+!0 = !{i32 6, !"riscv-isa", !1}
+!1 = !{!"rv64i2p1_c2p0_ztso0p1"}


### PR DESCRIPTION
Walk all the ISA strings and set the subtarget bits for any extension we find in any string.

This allows LTO output to have a ELF attributes from the union of all of the files used to compile it.