### PR TITLE
[libc] Move EOF macro to stdio-macros.h

### DIFF
--- a/libc/config/baremetal/api.td
+++ b/libc/config/baremetal/api.td
@@ -53,12 +53,7 @@ def IntTypesAPI : PublicAPI<"inttypes.h"> {
 }
 
 def StdIOAPI : PublicAPI<"stdio.h"> {
-  let Macros = [
-    SimpleMacroDef<"EOF", "-1">,
-  ];
-  let Types = [
-    "size_t"
-  ];
+  let Types = ["size_t"];
 }
 
 def StdlibAPI : PublicAPI<"stdlib.h"> {

--- a/libc/config/baremetal/api.td
+++ b/libc/config/baremetal/api.td
@@ -52,6 +52,15 @@ def IntTypesAPI : PublicAPI<"inttypes.h"> {
   let Types = ["imaxdiv_t"];
 }
 
+def StdIOAPI : PublicAPI<"stdio.h"> {
+  let Macros = [
+    SimpleMacroDef<"EOF", "-1">,
+  ];
+  let Types = [
+    "size_t"
+  ];
+}
+
 def StdlibAPI : PublicAPI<"stdlib.h"> {
   let Types = [
     "div_t",

--- a/libc/config/gpu/api.td
+++ b/libc/config/gpu/api.td
@@ -63,7 +63,6 @@ def StdIOAPI : PublicAPI<"stdio.h"> {
     SimpleMacroDef<"_IOFBF", "0">,
     SimpleMacroDef<"_IOLBF", "1">,
     SimpleMacroDef<"_IONBF", "2">,
-    SimpleMacroDef<"EOF", "-1">,
   ];
   let Types = ["size_t", "FILE"];
 }

--- a/libc/config/linux/api.td
+++ b/libc/config/linux/api.td
@@ -76,7 +76,6 @@ def StdIOAPI : PublicAPI<"stdio.h"> {
     SimpleMacroDef<"_IOFBF", "0">,
     SimpleMacroDef<"_IOLBF", "1">,
     SimpleMacroDef<"_IONBF", "2">,
-    SimpleMacroDef<"EOF", "-1">,
   ];
   let Types = ["size_t", "FILE", "cookie_io_functions_t"];
 }

--- a/libc/include/llvm-libc-macros/stdio-macros.h
+++ b/libc/include/llvm-libc-macros/stdio-macros.h
@@ -9,6 +9,10 @@
 #ifndef LLVM_LIBC_MACROS_STDIO_MACROS_H
 #define LLVM_LIBC_MACROS_STDIO_MACROS_H
 
+#ifndef EOF
+#define EOF -1
+#endif
+
 #define BUFSIZ 1024
 
 #endif // LLVM_LIBC_MACROS_STDIO_MACROS_H

--- a/libc/include/llvm-libc-macros/stdio-macros.h
+++ b/libc/include/llvm-libc-macros/stdio-macros.h
@@ -10,7 +10,7 @@
 #define LLVM_LIBC_MACROS_STDIO_MACROS_H
 
 #ifndef EOF
-#define EOF -1
+#define EOF (-1)
 #endif
 
 #define BUFSIZ 1024


### PR DESCRIPTION
libc++ char_traits.h assumes EOF is always available

See #85158 for more details.