### PR TITLE
[LLDB][Test] Fix the test case of listing verbose break info on Windows

### DIFF
--- a/lldb/test/API/functionalities/breakpoint/breakpoint_options/TestBreakpointOptions.py
+++ b/lldb/test/API/functionalities/breakpoint/breakpoint_options/TestBreakpointOptions.py
@@ -95,8 +95,10 @@ class BreakpointOptionsTestCase(TestBase):
         self.expect(
             "breakpoint list -v",
             "Verbose breakpoint list contains mangled names",
+            # The demangled function name is system-dependent, e.g.
+            # 'int ns::func(void)' on Windows and 'ns::func()' on Linux.
             substrs=[
-                "function = ns::func",
+                f"function = {function.GetName()}",
                 f"mangled function = {function.GetMangledName()}",
             ],
         )


### PR DESCRIPTION
I noticed a failure of [running LLDB test suites on Windows AArch64](https://lab.llvm.org/buildbot/#/builders/219/builds/9849). The failed test case is about
checking output of command `breakpoint list -v -L c++`, and an mismatch on the demangled
name of a function occurred. The test case expects `ns::func(void)`, but on Windows it is `int ns::func(void)`.
It results from the different mangling scheme used by MSVC, and the comparison is as follows:

| Scheme | Mangled | Demangled (fully) | Note |
| --- | --- | --- | --- |
| MSVC | `?func@ns@@YAHXZ` | `int __cdecl ns::func(void)` | [Godbolt](https://godbolt.org/z/5ns8c7xW3) (I have no available Windows device) |
| Itanium | `_ZN2ns4funcEv` | `ns::func()` | |

According to the current use of MSVC demangling,

https://github.com/llvm/llvm-project/blob/8f68022f8e6e54d1aeae4ed301f5a015963089b7/lldb/source/Core/Mangled.cpp#L128-L143

the `__cdecl` specifier is not part of the name. However, the function's parameter types should be present
as ` llvm::MSDF_NoVariableType` [does not affect a symbol for functions](https://github.com/llvm/llvm-project/blob/8f68022f8e6e54d1aeae4ed301f5a015963089b7/llvm/lib/Demangle/MicrosoftDemangleNodes.cpp#L417-L453).

Therefore, it is inappropriate to assume the demangled name are the same on all platforms. Instead of tweaking the
existing code of demangling to get the same (demangled) name, I think it is more reasonable to modify the test case.