### PR TITLE
[AArch64] Add AArch64PassRegistry.def

### DIFF
--- a/llvm/include/llvm/Passes/TargetPassRegistry.inc
+++ b/llvm/include/llvm/Passes/TargetPassRegistry.inc
@@ -7,6 +7,9 @@
 //===----------------------------------------------------------------------===//
 //
 // This file is used as the registry of passes in registerPassBuilderCallbacks
+// Just put the following lines in the body of registerPassBuilderCallbacks:
+//  #define GET_PASS_REGISTRY "<Target>PassRegistry.def"
+//  #include "llvm/Passes/TargetPassRegistry.inc"
 //
 //===----------------------------------------------------------------------===//
 
@@ -18,123 +21,8 @@
 #error "must provide <Target>PassRegistry.def"
 #endif
 
-{
-
-  // FIXME: use std::size when MSVC_MIN >= 19.30
-
-  static constexpr bool HAVE_MODULE_ANALYSIS_ =
-      std::array{
-          "",
-#define MODULE_ANALYSIS(NAME, CREATE_PASS) NAME,
-#include GET_PASS_REGISTRY
-#undef MODULE_ANALYSIS
-      }
-          .size() > 1;
-
-  static constexpr bool HAVE_MODULE_PASS_ =
-      std::array{
-          "",
-#define MODULE_PASS(NAME, CREATE_PASS) NAME,
-#include GET_PASS_REGISTRY
-#undef MODULE_PASS
-      }
-          .size() > 1;
-
-  static constexpr bool HAVE_MODULE_PASS_WITH_PARAMS_ =
-      std::array{
-          "",
-#define MODULE_PASS_WITH_PARAMS(NAME, CLASS, CREATE_PASS, PARSER, PARAMS) NAME,
-#include GET_PASS_REGISTRY
-#undef MODULE_PASS_WITH_PARAMS
-      }
-          .size() > 1;
-
-  static constexpr bool HAVE_FUNCTION_ANALYSIS_ =
-      std::array{
-          "",
-#define FUNCTION_ANALYSIS(NAME, CREATE_PASS) NAME,
-#include GET_PASS_REGISTRY
-#undef FUNCTION_ANALYSIS
-      }
-          .size() > 1;
-
-  static constexpr bool HAVE_FUNCTION_ALIAS_ANALYSIS_ =
-      std::array{
-          "",
-#define FUNCTION_ALIAS_ANALYSIS(NAME, CREATE_PASS) NAME,
-#include GET_PASS_REGISTRY
-#undef FUNCTION_ALIAS_ANALYSIS
-      }
-          .size() > 1;
-
-  static constexpr bool HAVE_FUNCTION_PASS_ =
-      std::array{
-          "",
-#define FUNCTION_PASS(NAME, CREATE_PASS) NAME,
-#include GET_PASS_REGISTRY
-#undef FUNCTION_PASS
-      }
-          .size() > 1;
-
-  static constexpr bool HAVE_FUNCTION_PASS_WITH_PARAMS_ =
-      std::array{
-          "",
-#define FUNCTION_PASS_WITH_PARAMS(NAME, CLASS, CREATE_PASS, PARSER, PARAMS)    \
-  NAME,
-#include GET_PASS_REGISTRY
-#undef FUNCTION_PASS_WITH_PARAMS
-      }
-          .size() > 1;
-
-  static constexpr bool HAVE_LOOP_ANALYSIS_ =
-      std::array{
-          "",
-#define LOOP_ANALYSIS(NAME, CREATE_PASS) NAME,
-#include GET_PASS_REGISTRY
-#undef LOOP_ANALYSIS
-      }
-          .size() > 1;
-
-  static constexpr bool HAVE_LOOP_PASS_ =
-      std::array{
-          "",
-#define LOOP_PASS(NAME, CREATE_PASS) NAME,
-#include GET_PASS_REGISTRY
-#undef LOOP_PASS
-      }
-          .size() > 1;
-
-  static constexpr bool HAVE_MACHINE_FUNCTION_ANALYSIS_ =
-      std::array{
-          "",
-#define MACHINE_FUNCTION_ANALYSIS(NAME, CREATE_PASS) NAME,
-#include GET_PASS_REGISTRY
-#undef MACHINE_FUNCTION_ANALYSIS
-      }
-          .size() > 1;
-
-  static constexpr bool HAVE_MACHINE_FUNCTION_PASS_ =
-      std::array{
-          "",
-#define MACHINE_FUNCTION_PASS(NAME, CREATE_PASS) NAME,
-#include GET_PASS_REGISTRY
-#undef MACHINE_FUNCTION_PASS
-      }
-          .size() > 1;
-
-  static constexpr bool HAVE_MACHINE_FUNCTION_PASS_WITH_PARAMS_ =
-      std::array{
-          "",
-#define MACHINE_FUNCTION_PASS_WITH_PARAMS(NAME, CLASS, CREATE_PASS, PARSER,    \
-                                          PARAMS)                              \
-  NAME,
-#include GET_PASS_REGISTRY
-#undef MACHINE_FUNCTION_PASS_WITH_PARAMS
-      }
-          .size() > 1;
-
-  if (PopulateClassToPassNames) {
-    auto *PIC = PB.getPassInstrumentationCallbacks();
+if (PopulateClassToPassNames) {
+  auto *PIC = PB.getPassInstrumentationCallbacks();
 
 #define ADD_CLASS_PASS_TO_PASS_NAME(NAME, CREATE_PASS)                         \
   PIC->addClassToPassName(decltype(CREATE_PASS)::name(), NAME);
@@ -165,12 +53,13 @@
   ADD_CLASS_PASS_TO_PASS_NAME(NAME, CREATE_PASS)
 #define MACHINE_FUNCTION_PASS_WITH_PARAMS(NAME, CLASS, CREATE_PASS, PARSER,    \
                                           PARAMS)                              \
-  ADD_CLASS_PASS_TO_PASS_NAME_WITH_PARAMS(NAME, CREATE_PASS)
+  ADD_CLASS_PASS_TO_PASS_NAME_WITH_PARAMS(NAME, CLASS)
 #include GET_PASS_REGISTRY
 #undef MODULE_ANALYSIS
 #undef MODULE_PASS
 #undef MODULE_PASS_WITH_PARAMS
 #undef FUNCTION_ANALYSIS
+#undef FUNCTION_ALIAS_ANALYSIS
 #undef FUNCTION_PASS
 #undef FUNCTION_PASS_WITH_PARAMS
 #undef LOOP_ANALYSIS
@@ -180,7 +69,7 @@
 #undef MACHINE_FUNCTION_PASS_WITH_PARAMS
 #undef ADD_CLASS_PASS_TO_PASS_NAME
 #undef ADD_CLASS_PASS_TO_PASS_NAME_WITH_PARAMS
-  }
+}
 
 #define ADD_PASS(NAME, CREATE_PASS)                                            \
   if (Name == NAME) {                                                          \
@@ -197,138 +86,107 @@
     return true;                                                               \
   }
 
-  if constexpr (HAVE_MODULE_PASS_) {
-    PB.registerPipelineParsingCallback(
-        [=](StringRef Name, ModulePassManager &PM,
-            ArrayRef<PassBuilder::PipelineElement>) {
+PB.registerPipelineParsingCallback([=](StringRef Name, ModulePassManager &PM,
+                                       ArrayRef<PassBuilder::PipelineElement>) {
 #define MODULE_PASS(NAME, CREATE_PASS) ADD_PASS(NAME, CREATE_PASS)
 #include GET_PASS_REGISTRY
 #undef MODULE_PASS
-          return false;
-        });
-  }
+  return false;
+});
 
-  if constexpr (HAVE_MODULE_PASS_WITH_PARAMS_) {
-    PB.registerPipelineParsingCallback(
-        [=](StringRef Name, ModulePassManager &PM,
-            ArrayRef<PassBuilder::PipelineElement>) {
+PB.registerPipelineParsingCallback([=](StringRef Name, ModulePassManager &PM,
+                                       ArrayRef<PassBuilder::PipelineElement>) {
 #define MODULE_PASS_WITH_PARAMS(NAME, CLASS, CREATE_PASS, PARSER, PARAMS)      \
   ADD_PASS_WITH_PARAMS(NAME, CREATE_PASS, PARSER)
 #include GET_PASS_REGISTRY
 #undef MODULE_PASS_WITH_PARAMS
-          return false;
-        });
-  }
+  return false;
+});
 
-  if constexpr (HAVE_FUNCTION_PASS_) {
-    PB.registerPipelineParsingCallback(
-        [=](StringRef Name, FunctionPassManager &PM,
-            ArrayRef<PassBuilder::PipelineElement>) {
+PB.registerPipelineParsingCallback([=](StringRef Name, FunctionPassManager &PM,
+                                       ArrayRef<PassBuilder::PipelineElement>) {
 #define FUNCTION_PASS(NAME, CREATE_PASS) ADD_PASS(NAME, CREATE_PASS)
 #include GET_PASS_REGISTRY
 #undef FUNCTION_PASS
-          return false;
-        });
-  }
+  return false;
+});
 
-  if constexpr (HAVE_FUNCTION_PASS_WITH_PARAMS_) {
-    PB.registerPipelineParsingCallback(
-        [=](StringRef Name, FunctionPassManager &PM,
-            ArrayRef<PassBuilder::PipelineElement>) {
+PB.registerPipelineParsingCallback([=](StringRef Name, FunctionPassManager &PM,
+                                       ArrayRef<PassBuilder::PipelineElement>) {
 #define FUNCTION_PASS_WITH_PARAMS(NAME, CLASS, CREATE_PASS, PARSER, PARAMS)    \
   ADD_PASS_WITH_PARAMS(NAME, CREATE_PASS, PARSER)
 #include GET_PASS_REGISTRY
 #undef FUNCTION_PASS_WITH_PARAMS
-          return false;
-        });
-  }
+  return false;
+});
 
-  if constexpr (HAVE_LOOP_PASS_) {
-    PB.registerPipelineParsingCallback(
-        [=](StringRef Name, LoopPassManager &PM,
-            ArrayRef<PassBuilder::PipelineElement>) {
+PB.registerPipelineParsingCallback([=](StringRef Name, LoopPassManager &PM,
+                                       ArrayRef<PassBuilder::PipelineElement>) {
 #define LOOP_PASS(NAME, CREATE_PASS) ADD_PASS(NAME, CREATE_PASS)
 #include GET_PASS_REGISTRY
-          return false;
-        });
-  }
+  return false;
+});
 
-  if constexpr (HAVE_MACHINE_FUNCTION_PASS_) {
-    PB.registerPipelineParsingCallback(
-        [=](StringRef Name, MachineFunctionPassManager &PM,
-            ArrayRef<PassBuilder::PipelineElement>) {
+PB.registerPipelineParsingCallback([=](StringRef Name,
+                                       MachineFunctionPassManager &PM,
+                                       ArrayRef<PassBuilder::PipelineElement>) {
 #define MACHINE_FUNCTION_PASS(NAME, CREATE_PASS) ADD_PASS(NAME, CREATE_PASS)
 #include GET_PASS_REGISTRY
-          return false;
-        });
-  }
+  return false;
+});
 
-  if constexpr (HAVE_MACHINE_FUNCTION_PASS_WITH_PARAMS_) {
-    PB.registerPipelineParsingCallback(
-        [=](StringRef Name, FunctionPassManager &PM,
-            ArrayRef<PassBuilder::PipelineElement>) {
+PB.registerPipelineParsingCallback([=](StringRef Name, FunctionPassManager &PM,
+                                       ArrayRef<PassBuilder::PipelineElement>) {
 #define MACHINE_FUNCTION_PASS_WITH_PARAMS(NAME, CLASS, CREATE_PASS, PARSER,    \
                                           PARAMS)                              \
   ADD_PASS_WITH_PARAMS(NAME, CREATE_PASS, PARSER)
 #include GET_PASS_REGISTRY
 #undef MACHINE_FUNCTION_PASS_WITH_PARAMS
-          return false;
-        });
-  }
+  return false;
+});
+
 #undef ADD_PASS
 #undef ADD_PASS_WITH_PARAMS
 
-  if constexpr (HAVE_MODULE_ANALYSIS_) {
-    PB.registerAnalysisRegistrationCallback([](ModuleAnalysisManager &AM) {
+PB.registerAnalysisRegistrationCallback([](ModuleAnalysisManager &AM) {
 #define MODULE_ANALYSIS(NAME, CREATE_PASS)                                     \
   AM.registerPass([&] { return CREATE_PASS; });
 #include GET_PASS_REGISTRY
 #undef MODULE_ANALYSIS
-    });
-  }
+});
 
-  if constexpr (HAVE_FUNCTION_ANALYSIS_) {
-    PB.registerAnalysisRegistrationCallback([](FunctionAnalysisManager &AM) {
+PB.registerAnalysisRegistrationCallback([](FunctionAnalysisManager &AM) {
 #define FUNCTION_ANALYSIS(NAME, CREATE_PASS)                                   \
   AM.registerPass([&] { return CREATE_PASS; });
 #include GET_PASS_REGISTRY
 #undef FUNCTION_ANALYSIS
-    });
-  }
+});
 
-  if constexpr (HAVE_FUNCTION_ALIAS_ANALYSIS_) {
-    PB.registerParseAACallback([](StringRef Name, AAManager &AM) {
-#define FUNCTION_ANALYSIS(NAME, CREATE_PASS)                                   \
+PB.registerParseAACallback([](StringRef Name, AAManager &AM) {
+#define FUNCTION_ALIAS_ANALYSIS(NAME, CREATE_PASS)                             \
   if (Name == NAME) {                                                          \
     AM.registerFunctionAnalysis<                                               \
         std::remove_reference_t<decltype(CREATE_PASS)>>();                     \
     return true;                                                               \
   }
 #include GET_PASS_REGISTRY
-#undef FUNCTION_ANALYSIS
-      return false;
-    });
-  }
+#undef FUNCTION_ALIAS_ANALYSIS
+  return false;
+});
 
-  if constexpr (HAVE_LOOP_ANALYSIS_) {
-    PB.registerAnalysisRegistrationCallback([](LoopAnalysisManager &AM) {
+PB.registerAnalysisRegistrationCallback([](LoopAnalysisManager &AM) {
 #define LOOP_ANALYSIS(NAME, CREATE_PASS)                                       \
   AM.registerPass([&] { return CREATE_PASS; });
 #include GET_PASS_REGISTRY
 #undef LOOP_ANALYSIS
-    });
-  }
+});
 
-  if constexpr (HAVE_MACHINE_FUNCTION_ANALYSIS_) {
-    PB.registerAnalysisRegistrationCallback(
-        [](MachineFunctionAnalysisManager &AM) {
+PB.registerAnalysisRegistrationCallback([](MachineFunctionAnalysisManager &AM) {
 #define MACHINE_FUNCTION_ANALYSIS(NAME, CREATE_PASS)                           \
   AM.registerPass([&] { return CREATE_PASS; });
 #include GET_PASS_REGISTRY
 #undef MACHINE_FUNCTION_ANALYSIS
-        });
-  }
-}
+});
 
 #undef GET_PASS_REGISTRY
 #endif // GET_PASS_REGISTRY

--- a/llvm/include/llvm/Passes/TargetPassRegistry.inc
+++ b/llvm/include/llvm/Passes/TargetPassRegistry.inc
@@ -1,0 +1,334 @@
+//===- TargetPassRegistry.inc - Registry of passes --------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file is used as the registry of passes in registerPassBuilderCallbacks
+//
+//===----------------------------------------------------------------------===//
+
+// NOTE: NO INCLUDE GUARD DESIRED!
+
+#ifdef GET_PASS_REGISTRY
+
+#if !__has_include(GET_PASS_REGISTRY)
+#error "must provide <Target>PassRegistry.def"
+#endif
+
+{
+
+  // FIXME: use std::size when MSVC_MIN >= 19.30
+
+  static constexpr bool HAVE_MODULE_ANALYSIS_ =
+      std::array{
+          "",
+#define MODULE_ANALYSIS(NAME, CREATE_PASS) NAME,
+#include GET_PASS_REGISTRY
+#undef MODULE_ANALYSIS
+      }
+          .size() > 1;
+
+  static constexpr bool HAVE_MODULE_PASS_ =
+      std::array{
+          "",
+#define MODULE_PASS(NAME, CREATE_PASS) NAME,
+#include GET_PASS_REGISTRY
+#undef MODULE_PASS
+      }
+          .size() > 1;
+
+  static constexpr bool HAVE_MODULE_PASS_WITH_PARAMS_ =
+      std::array{
+          "",
+#define MODULE_PASS_WITH_PARAMS(NAME, CLASS, CREATE_PASS, PARSER, PARAMS) NAME,
+#include GET_PASS_REGISTRY
+#undef MODULE_PASS_WITH_PARAMS
+      }
+          .size() > 1;
+
+  static constexpr bool HAVE_FUNCTION_ANALYSIS_ =
+      std::array{
+          "",
+#define FUNCTION_ANALYSIS(NAME, CREATE_PASS) NAME,
+#include GET_PASS_REGISTRY
+#undef FUNCTION_ANALYSIS
+      }
+          .size() > 1;
+
+  static constexpr bool HAVE_FUNCTION_ALIAS_ANALYSIS_ =
+      std::array{
+          "",
+#define FUNCTION_ALIAS_ANALYSIS(NAME, CREATE_PASS) NAME,
+#include GET_PASS_REGISTRY
+#undef FUNCTION_ALIAS_ANALYSIS
+      }
+          .size() > 1;
+
+  static constexpr bool HAVE_FUNCTION_PASS_ =
+      std::array{
+          "",
+#define FUNCTION_PASS(NAME, CREATE_PASS) NAME,
+#include GET_PASS_REGISTRY
+#undef FUNCTION_PASS
+      }
+          .size() > 1;
+
+  static constexpr bool HAVE_FUNCTION_PASS_WITH_PARAMS_ =
+      std::array{
+          "",
+#define FUNCTION_PASS_WITH_PARAMS(NAME, CLASS, CREATE_PASS, PARSER, PARAMS)    \
+  NAME,
+#include GET_PASS_REGISTRY
+#undef FUNCTION_PASS_WITH_PARAMS
+      }
+          .size() > 1;
+
+  static constexpr bool HAVE_LOOP_ANALYSIS_ =
+      std::array{
+          "",
+#define LOOP_ANALYSIS(NAME, CREATE_PASS) NAME,
+#include GET_PASS_REGISTRY
+#undef LOOP_ANALYSIS
+      }
+          .size() > 1;
+
+  static constexpr bool HAVE_LOOP_PASS_ =
+      std::array{
+          "",
+#define LOOP_PASS(NAME, CREATE_PASS) NAME,
+#include GET_PASS_REGISTRY
+#undef LOOP_PASS
+      }
+          .size() > 1;
+
+  static constexpr bool HAVE_MACHINE_FUNCTION_ANALYSIS_ =
+      std::array{
+          "",
+#define MACHINE_FUNCTION_ANALYSIS(NAME, CREATE_PASS) NAME,
+#include GET_PASS_REGISTRY
+#undef MACHINE_FUNCTION_ANALYSIS
+      }
+          .size() > 1;
+
+  static constexpr bool HAVE_MACHINE_FUNCTION_PASS_ =
+      std::array{
+          "",
+#define MACHINE_FUNCTION_PASS(NAME, CREATE_PASS) NAME,
+#include GET_PASS_REGISTRY
+#undef MACHINE_FUNCTION_PASS
+      }
+          .size() > 1;
+
+  static constexpr bool HAVE_MACHINE_FUNCTION_PASS_WITH_PARAMS_ =
+      std::array{
+          "",
+#define MACHINE_FUNCTION_PASS_WITH_PARAMS(NAME, CLASS, CREATE_PASS, PARSER,    \
+                                          PARAMS)                              \
+  NAME,
+#include GET_PASS_REGISTRY
+#undef MACHINE_FUNCTION_PASS_WITH_PARAMS
+      }
+          .size() > 1;
+
+  if (PopulateClassToPassNames) {
+    auto *PIC = PB.getPassInstrumentationCallbacks();
+
+#define ADD_CLASS_PASS_TO_PASS_NAME(NAME, CREATE_PASS)                         \
+  PIC->addClassToPassName(decltype(CREATE_PASS)::name(), NAME);
+#define ADD_CLASS_PASS_TO_PASS_NAME_WITH_PARAMS(NAME, CLASS)                   \
+  PIC->addClassToPassName(CLASS, NAME);
+
+#define MODULE_ANALYSIS(NAME, CREATE_PASS)                                     \
+  ADD_CLASS_PASS_TO_PASS_NAME(NAME, CREATE_PASS)
+#define MODULE_PASS(NAME, CREATE_PASS)                                         \
+  ADD_CLASS_PASS_TO_PASS_NAME(NAME, CREATE_PASS)
+#define MODULE_PASS_WITH_PARAMS(NAME, CLASS, CREATE_PASS, PARSER, PARAMS)      \
+  ADD_CLASS_PASS_TO_PASS_NAME_WITH_PARAMS(NAME, CLASS)
+#define FUNCTION_ANALYSIS(NAME, CREATE_PASS)                                   \
+  ADD_CLASS_PASS_TO_PASS_NAME(NAME, CREATE_PASS)
+#define FUNCTION_ALIAS_ANALYSIS(NAME, CREATE_PASS)                             \
+  ADD_CLASS_PASS_TO_PASS_NAME(NAME, CREATE_PASS)
+#define FUNCTION_PASS(NAME, CREATE_PASS)                                       \
+  ADD_CLASS_PASS_TO_PASS_NAME(NAME, CREATE_PASS)
+#define FUNCTION_PASS_WITH_PARAMS(NAME, CLASS, CREATE_PASS, PARSER, PARAMS)    \
+  ADD_CLASS_PASS_TO_PASS_NAME_WITH_PARAMS(NAME, CLASS)
+#define LOOP_ANALYSIS(NAME, CREATE_PASS)                                       \
+  ADD_CLASS_PASS_TO_PASS_NAME(NAME, CREATE_PASS)
+#define LOOP_PASS(NAME, CREATE_PASS)                                           \
+  ADD_CLASS_PASS_TO_PASS_NAME(NAME, CREATE_PASS)
+#define MACHINE_FUNCTION_ANALYSIS(NAME, CREATE_PASS)                           \
+  ADD_CLASS_PASS_TO_PASS_NAME(NAME, CREATE_PASS)
+#define MACHINE_FUNCTION_PASS(NAME, CREATE_PASS)                               \
+  ADD_CLASS_PASS_TO_PASS_NAME(NAME, CREATE_PASS)
+#define MACHINE_FUNCTION_PASS_WITH_PARAMS(NAME, CLASS, CREATE_PASS, PARSER,    \
+                                          PARAMS)                              \
+  ADD_CLASS_PASS_TO_PASS_NAME_WITH_PARAMS(NAME, CREATE_PASS)
+#include GET_PASS_REGISTRY
+#undef MODULE_ANALYSIS
+#undef MODULE_PASS
+#undef MODULE_PASS_WITH_PARAMS
+#undef FUNCTION_ANALYSIS
+#undef FUNCTION_PASS
+#undef FUNCTION_PASS_WITH_PARAMS
+#undef LOOP_ANALYSIS
+#undef LOOP_PASS
+#undef MACHINE_FUNCTION_ANALYSIS
+#undef MACHINE_FUNCTION_PASS
+#undef MACHINE_FUNCTION_PASS_WITH_PARAMS
+#undef ADD_CLASS_PASS_TO_PASS_NAME
+#undef ADD_CLASS_PASS_TO_PASS_NAME_WITH_PARAMS
+  }
+
+#define ADD_PASS(NAME, CREATE_PASS)                                            \
+  if (Name == NAME) {                                                          \
+    PM.addPass(CREATE_PASS);                                                   \
+    return true;                                                               \
+  }
+
+#define ADD_PASS_WITH_PARAMS(NAME, CREATE_PASS, PARSER)                        \
+  if (PassBuilder::checkParametrizedPassName(Name, NAME)) {                    \
+    auto Params = PassBuilder::parsePassParameters(PARSER, Name, NAME);        \
+    if (!Params)                                                               \
+      return false;                                                            \
+    PM.addPass(CREATE_PASS(Params.get()));                                     \
+    return true;                                                               \
+  }
+
+  if constexpr (HAVE_MODULE_PASS_) {
+    PB.registerPipelineParsingCallback(
+        [=](StringRef Name, ModulePassManager &PM,
+            ArrayRef<PassBuilder::PipelineElement>) {
+#define MODULE_PASS(NAME, CREATE_PASS) ADD_PASS(NAME, CREATE_PASS)
+#include GET_PASS_REGISTRY
+#undef MODULE_PASS
+          return false;
+        });
+  }
+
+  if constexpr (HAVE_MODULE_PASS_WITH_PARAMS_) {
+    PB.registerPipelineParsingCallback(
+        [=](StringRef Name, ModulePassManager &PM,
+            ArrayRef<PassBuilder::PipelineElement>) {
+#define MODULE_PASS_WITH_PARAMS(NAME, CLASS, CREATE_PASS, PARSER, PARAMS)      \
+  ADD_PASS_WITH_PARAMS(NAME, CREATE_PASS, PARSER)
+#include GET_PASS_REGISTRY
+#undef MODULE_PASS_WITH_PARAMS
+          return false;
+        });
+  }
+
+  if constexpr (HAVE_FUNCTION_PASS_) {
+    PB.registerPipelineParsingCallback(
+        [=](StringRef Name, FunctionPassManager &PM,
+            ArrayRef<PassBuilder::PipelineElement>) {
+#define FUNCTION_PASS(NAME, CREATE_PASS) ADD_PASS(NAME, CREATE_PASS)
+#include GET_PASS_REGISTRY
+#undef FUNCTION_PASS
+          return false;
+        });
+  }
+
+  if constexpr (HAVE_FUNCTION_PASS_WITH_PARAMS_) {
+    PB.registerPipelineParsingCallback(
+        [=](StringRef Name, FunctionPassManager &PM,
+            ArrayRef<PassBuilder::PipelineElement>) {
+#define FUNCTION_PASS_WITH_PARAMS(NAME, CLASS, CREATE_PASS, PARSER, PARAMS)    \
+  ADD_PASS_WITH_PARAMS(NAME, CREATE_PASS, PARSER)
+#include GET_PASS_REGISTRY
+#undef FUNCTION_PASS_WITH_PARAMS
+          return false;
+        });
+  }
+
+  if constexpr (HAVE_LOOP_PASS_) {
+    PB.registerPipelineParsingCallback(
+        [=](StringRef Name, LoopPassManager &PM,
+            ArrayRef<PassBuilder::PipelineElement>) {
+#define LOOP_PASS(NAME, CREATE_PASS) ADD_PASS(NAME, CREATE_PASS)
+#include GET_PASS_REGISTRY
+          return false;
+        });
+  }
+
+  if constexpr (HAVE_MACHINE_FUNCTION_PASS_) {
+    PB.registerPipelineParsingCallback(
+        [=](StringRef Name, MachineFunctionPassManager &PM,
+            ArrayRef<PassBuilder::PipelineElement>) {
+#define MACHINE_FUNCTION_PASS(NAME, CREATE_PASS) ADD_PASS(NAME, CREATE_PASS)
+#include GET_PASS_REGISTRY
+          return false;
+        });
+  }
+
+  if constexpr (HAVE_MACHINE_FUNCTION_PASS_WITH_PARAMS_) {
+    PB.registerPipelineParsingCallback(
+        [=](StringRef Name, FunctionPassManager &PM,
+            ArrayRef<PassBuilder::PipelineElement>) {
+#define MACHINE_FUNCTION_PASS_WITH_PARAMS(NAME, CLASS, CREATE_PASS, PARSER,    \
+                                          PARAMS)                              \
+  ADD_PASS_WITH_PARAMS(NAME, CREATE_PASS, PARSER)
+#include GET_PASS_REGISTRY
+#undef MACHINE_FUNCTION_PASS_WITH_PARAMS
+          return false;
+        });
+  }
+#undef ADD_PASS
+#undef ADD_PASS_WITH_PARAMS
+
+  if constexpr (HAVE_MODULE_ANALYSIS_) {
+    PB.registerAnalysisRegistrationCallback([](ModuleAnalysisManager &AM) {
+#define MODULE_ANALYSIS(NAME, CREATE_PASS)                                     \
+  AM.registerPass([&] { return CREATE_PASS; });
+#include GET_PASS_REGISTRY
+#undef MODULE_ANALYSIS
+    });
+  }
+
+  if constexpr (HAVE_FUNCTION_ANALYSIS_) {
+    PB.registerAnalysisRegistrationCallback([](FunctionAnalysisManager &AM) {
+#define FUNCTION_ANALYSIS(NAME, CREATE_PASS)                                   \
+  AM.registerPass([&] { return CREATE_PASS; });
+#include GET_PASS_REGISTRY
+#undef FUNCTION_ANALYSIS
+    });
+  }
+
+  if constexpr (HAVE_FUNCTION_ALIAS_ANALYSIS_) {
+    PB.registerParseAACallback([](StringRef Name, AAManager &AM) {
+#define FUNCTION_ANALYSIS(NAME, CREATE_PASS)                                   \
+  if (Name == NAME) {                                                          \
+    AM.registerFunctionAnalysis<                                               \
+        std::remove_reference_t<decltype(CREATE_PASS)>>();                     \
+    return true;                                                               \
+  }
+#include GET_PASS_REGISTRY
+#undef FUNCTION_ANALYSIS
+      return false;
+    });
+  }
+
+  if constexpr (HAVE_LOOP_ANALYSIS_) {
+    PB.registerAnalysisRegistrationCallback([](LoopAnalysisManager &AM) {
+#define LOOP_ANALYSIS(NAME, CREATE_PASS)                                       \
+  AM.registerPass([&] { return CREATE_PASS; });
+#include GET_PASS_REGISTRY
+#undef LOOP_ANALYSIS
+    });
+  }
+
+  if constexpr (HAVE_MACHINE_FUNCTION_ANALYSIS_) {
+    PB.registerAnalysisRegistrationCallback(
+        [](MachineFunctionAnalysisManager &AM) {
+#define MACHINE_FUNCTION_ANALYSIS(NAME, CREATE_PASS)                           \
+  AM.registerPass([&] { return CREATE_PASS; });
+#include GET_PASS_REGISTRY
+#undef MACHINE_FUNCTION_ANALYSIS
+        });
+  }
+}
+
+#undef GET_PASS_REGISTRY
+#endif // GET_PASS_REGISTRY

--- a/llvm/lib/Target/AArch64/AArch64PassRegistry.def
+++ b/llvm/lib/Target/AArch64/AArch64PassRegistry.def
@@ -1,0 +1,20 @@
+//===- AArch64PassRegistry.def - Registry of AArch64 passes -----*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file is used as the registry of passes that are part of the
+// AArch64 backend.
+//
+//===----------------------------------------------------------------------===//
+
+// NOTE: NO INCLUDE GUARD DESIRED!
+
+#ifndef LOOP_PASS
+#define LOOP_PASS(NAME, CREATE_PASS)
+#endif
+LOOP_PASS("aarch64-lit", AArch64LoopIdiomTransformPass())
+#undef LOOP_PASS

--- a/llvm/lib/Target/AArch64/AArch64TargetMachine.cpp
+++ b/llvm/lib/Target/AArch64/AArch64TargetMachine.cpp
@@ -547,6 +547,10 @@ public:
 
 void AArch64TargetMachine::registerPassBuilderCallbacks(
     PassBuilder &PB, bool PopulateClassToPassNames) {
+
+#define GET_PASS_REGISTRY "AArch64PassRegistry.def"
+#include "llvm/Passes/TargetPassRegistry.inc"
+
   PB.registerLateLoopOptimizationsEPCallback(
       [=](LoopPassManager &LPM, OptimizationLevel Level) {
         LPM.addPass(AArch64LoopIdiomTransformPass());

--- a/llvm/test/Transforms/LoopIdiom/AArch64/byte-compare-index.ll
+++ b/llvm/test/Transforms/LoopIdiom/AArch64/byte-compare-index.ll
@@ -2,6 +2,9 @@
 ; RUN: opt -aarch64-lit -aarch64-lit-verify -verify-dom-info -mtriple aarch64-unknown-linux-gnu -mattr=+sve -S < %s | FileCheck %s
 ; RUN: opt -aarch64-lit -simplifycfg -mtriple aarch64-unknown-linux-gnu -mattr=+sve -S < %s | FileCheck %s --check-prefix=LOOP-DEL
 ; RUN: opt -aarch64-lit -mtriple aarch64-unknown-linux-gnu -S < %s | FileCheck %s --check-prefix=NO-TRANSFORM
+; RUN: opt -p aarch64-lit -aarch64-lit-verify -verify-dom-info -mtriple aarch64-unknown-linux-gnu -mattr=+sve -S < %s | FileCheck %s
+; RUN: opt -passes='function(loop(aarch64-lit)),simplifycfg' -mtriple aarch64-unknown-linux-gnu -mattr=+sve -S < %s | FileCheck %s --check-prefix=LOOP-DEL
+; RUN: opt -p aarch64-lit -mtriple aarch64-unknown-linux-gnu -S < %s | FileCheck %s --check-prefix=NO-TRANSFORM
 
 define i32 @compare_bytes_simple(ptr %a, ptr %b, i32 %len, i32 %extra, i32 %n) {
 ; CHECK-LABEL: define i32 @compare_bytes_simple(


### PR DESCRIPTION
PR #83567 ports `SelectionDAGISel` to the new pass manager, then each backend should provide `<Target>DagToDagISel()` in new pass manager style. Then each target should provide `<Target>PassRegistry.def` to register backend passes in `registerPassBuilderCallbacks` to reduce duplicate code.
This PR adds `AArch64PassRegistry.def` to AArch64 backend and boilerplate code in `registerPassBuilderCallbacks`.