### PR TITLE
[libc++] Cherry-pick the disabling of modules tests onto release/18.x

### DIFF
--- a/libcxx/test/libcxx/module_std.gen.py
+++ b/libcxx/test/libcxx/module_std.gen.py
@@ -16,7 +16,11 @@
 # to be one monolitic test. Since the test doesn't take very long it's
 # not a huge issue.
 
+# WARNING: Disabled at the bottom. Fix this test and remove the UNSUPPORTED line
+# TODO: Re-enable this test once we understand why it keeps timing out.
+
 # RUN: %{python} %s %{libcxx}/utils
+# END.
 
 import sys
 
@@ -35,4 +39,5 @@ generator = module_test_generator(
 
 
 print("//--- module_std.sh.cpp")
+print('// UNSUPPORTED: clang')
 generator.write_test("std")

--- a/libcxx/test/libcxx/module_std_compat.gen.py
+++ b/libcxx/test/libcxx/module_std_compat.gen.py
@@ -16,7 +16,11 @@
 # to be one monolitic test. Since the test doesn't take very long it's
 # not a huge issue.
 
+# WARNING: Disabled at the bottom. Fix this test and remove the UNSUPPORTED line
+# TODO: Re-enable this test once we understand why it keeps timing out.
+
 # RUN: %{python} %s %{libcxx}/utils
+# END.
 
 import sys
 
@@ -36,6 +40,7 @@ generator = module_test_generator(
 
 
 print("//--- module_std_compat.sh.cpp")
+print("// UNSUPPORTED: clang")
 generator.write_test(
     "std.compat",
     module_c_headers,


### PR DESCRIPTION
LIT was never really meant to generate tests during discovery, and we probably shouldn't be doing this.

This hack is even worse than the initial attempt because it buries the "UNSUPPORTED" at the bottom of the test.

Fixes #85242