### PR TITLE
[flang] Do not create .f18.mod files for each compiled module

### DIFF
--- a/flang/docs/ModFiles.md
+++ b/flang/docs/ModFiles.md
@@ -27,7 +27,9 @@ often use `rm *.mod` to clean up.
 The disadvantage of using the same name as other compilers is that it is not
 clear which compiler created a `.mod` file and files from multiple compilers
 cannot be in the same directory. This could be solved by adding something
-between the module name and extension, e.g. `<modulename>-f18.mod`.
+between the module name and extension, e.g. `<modulename>-f18.mod`.  If this
+needed, Flang's fc1 accepts the option `-module-suffix` to alter the suffix
+used for the module file on disk.
 
 ## Format
 

--- a/flang/docs/ModFiles.md
+++ b/flang/docs/ModFiles.md
@@ -28,7 +28,7 @@ The disadvantage of using the same name as other compilers is that it is not
 clear which compiler created a `.mod` file and files from multiple compilers
 cannot be in the same directory. This could be solved by adding something
 between the module name and extension, e.g. `<modulename>-f18.mod`.  If this
-needed, Flang's fc1 accepts the option `-module-suffix` to alter the suffix
+is needed, Flang's fc1 accepts the option `-module-suffix` to alter the suffix
 used for the module file.
 
 ## Format

--- a/flang/docs/ModFiles.md
+++ b/flang/docs/ModFiles.md
@@ -29,7 +29,7 @@ clear which compiler created a `.mod` file and files from multiple compilers
 cannot be in the same directory. This could be solved by adding something
 between the module name and extension, e.g. `<modulename>-f18.mod`.  If this
 needed, Flang's fc1 accepts the option `-module-suffix` to alter the suffix
-used for the module file on disk.
+used for the module file.
 
 ## Format
 

--- a/flang/tools/f18/CMakeLists.txt
+++ b/flang/tools/f18/CMakeLists.txt
@@ -47,7 +47,7 @@ if (NOT CMAKE_CROSSCOMPILING)
       endif()
     endif()
 
-    # The module contains PPC vector types that needs the PPC target.
+    # The module contains PPC vector types that needs th1e PPC target.
     set(opts "")
       if(${filename} STREQUAL "__ppc_intrinsics" OR
          ${filename} STREQUAL "mma")
@@ -65,11 +65,8 @@ if (NOT CMAKE_CROSSCOMPILING)
         ${FLANG_SOURCE_DIR}/module/${filename}.f90
       DEPENDS flang-new ${FLANG_SOURCE_DIR}/module/${filename}.f90 ${depends}
     )
-    add_custom_command(OUTPUT ${base}.f18.mod
-      DEPENDS ${base}.mod
-      COMMAND ${CMAKE_COMMAND} -E copy ${base}.mod ${base}.f18.mod)
-    list(APPEND MODULE_FILES ${base}.mod ${base}.f18.mod)
-    install(FILES ${base}.mod ${base}.f18.mod DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/flang")
+    list(APPEND MODULE_FILES ${base}.mod)
+    install(FILES ${base}.mod DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/flang")
   endforeach()
 endif()
 

--- a/flang/tools/f18/CMakeLists.txt
+++ b/flang/tools/f18/CMakeLists.txt
@@ -47,7 +47,7 @@ if (NOT CMAKE_CROSSCOMPILING)
       endif()
     endif()
 
-    # The module contains PPC vector types that needs th1e PPC target.
+    # The module contains PPC vector types that needs the PPC target.
     set(opts "")
       if(${filename} STREQUAL "__ppc_intrinsics" OR
          ${filename} STREQUAL "mma")


### PR DESCRIPTION
The default CMake scripts had a copy operation to copy a compiled `.mod` file to also be available with suffix `.f18.mod`.  This seems no longer needed.  Also updated ModFiles.md to point to `-module-suffix`.