### PR TITLE
[clang] Fix assertion failure when printing atomic apvalues

### DIFF
--- a/clang/lib/AST/APValue.cpp
+++ b/clang/lib/AST/APValue.cpp
@@ -704,6 +704,9 @@ void APValue::printPretty(raw_ostream &Out, const PrintingPolicy &Policy,
     return;
   }
 
+  if (const auto *AT = Ty->getAs<AtomicType>())
+    Ty = AT->getValueType();
+
   switch (getKind()) {
   case APValue::None:
     Out << "<out of lifetime>";


### PR DESCRIPTION
When printing an `_Atomic(some struct type)`, we would later run into an assertion because we do a `Ty->castAs<RecordType>()`, which doesn't work with an `AtomicType`.

Not sure how to best write a test for, this, but OTOH, `printPretty` is currently only  used for debugging as far as I know(?).