### PR TITLE
[BOLT][DWARF] Add support for DW_IDX_parent

### DIFF
--- a/bolt/include/bolt/Core/DIEBuilder.h
+++ b/bolt/include/bolt/Core/DIEBuilder.h
@@ -209,6 +209,9 @@ private:
   void updateReferences();
 
   /// Update the Offset and Size of DIE, populate DebugNames table.
+  /// Along with current CU, and DIE being processed and the new DIE offset to
+  /// be updated, it takes in Parents vector that can be empty if this DIE has
+  /// no parents.
   uint32_t
   finalizeDIEs(DWARFUnit &CU, DIE &Die,
                std::vector<std::optional<BOLTDWARF5AccelTableData *>> &Parents,

--- a/bolt/include/bolt/Core/DIEBuilder.h
+++ b/bolt/include/bolt/Core/DIEBuilder.h
@@ -209,7 +209,10 @@ private:
   void updateReferences();
 
   /// Update the Offset and Size of DIE, populate DebugNames table.
-  uint32_t finalizeDIEs(DWARFUnit &CU, DIE &Die, uint32_t &CurOffset);
+  uint32_t
+  finalizeDIEs(DWARFUnit &CU, DIE &Die,
+               std::vector<std::optional<BOLTDWARF5AccelTableData *>> &Parents,
+               uint32_t &CurOffset);
 
   void registerUnit(DWARFUnit &DU, bool NeedSort);
 

--- a/bolt/include/bolt/Core/DebugNames.h
+++ b/bolt/include/bolt/Core/DebugNames.h
@@ -52,8 +52,8 @@ public:
       Abbrev->~DebugNamesAbbrev();
   }
   /// Add DWARF5 Accelerator table entry.
-  /// Input is DWARFUnit being processed, DIE that belongs to it, and potential
-  /// SkeletonCU if the Unit comes from a DWO section.
+  /// Input is DWARFUnit being processed, DIE that belongs to it, potential
+  /// DWOID if the Unit comes from a DWO section, and potential parent entry.
   std::optional<BOLTDWARF5AccelTableData *>
   addAccelTableEntry(DWARFUnit &Unit, const DIE &Die,
                      const std::optional<uint64_t> &DWOID,

--- a/bolt/include/bolt/Core/DebugNames.h
+++ b/bolt/include/bolt/Core/DebugNames.h
@@ -36,6 +36,9 @@ public:
   bool isTU() const { return DWARF5AccelTableData::isTU(); }
   std::optional<unsigned> getSecondUnitID() const { return SecondUnitID; }
 
+  void setPatchOffset(uint64_t PatchOffset) { OffsetVal = PatchOffset; }
+  uint64_t getPatchOffset() const { return std::get<uint64_t>(OffsetVal); }
+
 private:
   std::optional<unsigned> SecondUnitID;
 };
@@ -51,8 +54,10 @@ public:
   /// Add DWARF5 Accelerator table entry.
   /// Input is DWARFUnit being processed, DIE that belongs to it, and potential
   /// SkeletonCU if the Unit comes from a DWO section.
-  void addAccelTableEntry(DWARFUnit &Unit, const DIE &Die,
-                          const std::optional<uint64_t> &DWOID);
+  std::optional<BOLTDWARF5AccelTableData *>
+  addAccelTableEntry(DWARFUnit &Unit, const DIE &Die,
+                     const std::optional<uint64_t> &DWOID,
+                     std::optional<BOLTDWARF5AccelTableData *> &Parent);
   /// Set current unit being processed.
   void setCurrentUnit(DWARFUnit &Unit, const uint64_t UnitStartOffset);
   /// Emit Accelerator table.
@@ -121,6 +126,8 @@ private:
   llvm::DenseMap<llvm::hash_code, uint64_t> StrCacheToOffsetMap;
   // Contains DWO ID to CUList Index.
   llvm::DenseMap<uint64_t, uint32_t> CUOffsetsToPatch;
+  // Contains a map of Entry ID to Entry relative offset.
+  llvm::DenseMap<uint64_t, uint32_t> EntryRelativeOffsets;
   /// Adds Unit to either CUList, LocalTUList or ForeignTUList.
   /// Input Unit being processed, and DWO ID if Unit is being processed comes
   /// from a DWO section.
@@ -143,7 +150,7 @@ private:
   /// Write Entries.
   void writeEntries();
   /// Write an Entry.
-  void writeEntry(const BOLTDWARF5AccelTableData &Entry);
+  void writeEntry(BOLTDWARF5AccelTableData &Entry);
   /// Write augmentation_string for BOLT.
   void writeAugmentationString();
   /// Emit out Header for DWARF5 Accelerator table.

--- a/bolt/lib/Core/DebugNames.cpp
+++ b/bolt/lib/Core/DebugNames.cpp
@@ -523,8 +523,9 @@ void DWARF5AcceleratorTable::writeEntries() {
               &EntriesBuffer.get()->data()[PatchOffset]);
           *Ptr = Iter->second;
         } else {
-          BC.errs() << "Could not find entry with offset " << *ParentOffset
-                    << "\n";
+          BC.errs() << "BOLT-WARNING: [internal-dwarf-warning]: Could not find "
+                       "entry with offset "
+                    << *ParentOffset << "\n";
         }
       }
     }

--- a/bolt/lib/Core/DebugNames.cpp
+++ b/bolt/lib/Core/DebugNames.cpp
@@ -13,6 +13,7 @@
 #include "llvm/Support/EndianStream.h"
 #include "llvm/Support/LEB128.h"
 #include <cstdint>
+#include <optional>
 
 namespace llvm {
 namespace bolt {
@@ -163,10 +164,16 @@ static uint64_t getNameOffset(BinaryContext &BC, DWARFUnit &Unit,
                                    Index * DwarfOffsetByteSize);
 }
 
-void DWARF5AcceleratorTable::addAccelTableEntry(
-    DWARFUnit &Unit, const DIE &Die, const std::optional<uint64_t> &DWOID) {
+static uint64_t getEntryID(const BOLTDWARF5AccelTableData &Entry) {
+  return reinterpret_cast<uint64_t>(&Entry);
+}
+
+std::optional<BOLTDWARF5AccelTableData *>
+DWARF5AcceleratorTable::addAccelTableEntry(
+    DWARFUnit &Unit, const DIE &Die, const std::optional<uint64_t> &DWOID,
+    std::optional<BOLTDWARF5AccelTableData *> &Parent) {
   if (Unit.getVersion() < 5 || !NeedToCreate)
-    return;
+    return std::nullopt;
   std::string NameToUse = "";
   auto canProcess = [&](const DIE &Die) -> bool {
     switch (Die.getTag()) {
@@ -217,7 +224,7 @@ void DWARF5AcceleratorTable::addAccelTableEntry(
   };
 
   if (!canProcess(Die))
-    return;
+    return std::nullopt;
 
   // Addes a Unit to either CU, LocalTU or ForeignTU list the first time we
   // encounter it.
@@ -227,10 +234,11 @@ void DWARF5AcceleratorTable::addAccelTableEntry(
     addUnit(Unit, DWOID);
   }
 
-  auto addEntry = [&](DIEValue ValName) -> void {
+  auto addEntry =
+      [&](DIEValue ValName) -> std::optional<BOLTDWARF5AccelTableData *> {
     if ((!ValName || ValName.getForm() == dwarf::DW_FORM_string) &&
         NameToUse.empty())
-      return;
+      return std::nullopt;
     std::string Name = "";
     uint64_t NameIndexOffset = 0;
     if (NameToUse.empty()) {
@@ -275,13 +283,23 @@ void DWARF5AcceleratorTable::addAccelTableEntry(
                   << ".\n";
       SecondIndex = Iter->second;
     }
+    std::optional<uint64_t> ParentOffset =
+        (Parent ? std::optional<uint64_t>(getEntryID(**Parent)) : std::nullopt);
+    // This will be populated later in writeEntry.
+    // This way only parent entries get tracked.
+    // Keeping memory footprint down.
+    if (ParentOffset)
+      EntryRelativeOffsets.insert({*ParentOffset, 0});
     It.Values.push_back(new (Allocator) BOLTDWARF5AccelTableData(
-        Die.getOffset(), std::nullopt, DieTag, UnitID, IsTU, SecondIndex));
+        Die.getOffset(), ParentOffset, DieTag, UnitID, IsTU, SecondIndex));
+    return It.Values.back();
   };
 
-  addEntry(Die.findAttribute(dwarf::Attribute::DW_AT_name));
-  addEntry(Die.findAttribute(dwarf::Attribute::DW_AT_linkage_name));
-  return;
+  std::optional<BOLTDWARF5AccelTableData *> NameEntry =
+      addEntry(Die.findAttribute(dwarf::Attribute::DW_AT_name));
+  std::optional<BOLTDWARF5AccelTableData *> LinkageNameEntry =
+      addEntry(Die.findAttribute(dwarf::Attribute::DW_AT_linkage_name));
+  return NameEntry ? NameEntry : LinkageNameEntry;
 }
 
 /// Algorithm from llvm implementation.
@@ -382,6 +400,11 @@ void DWARF5AcceleratorTable::populateAbbrevsMap() {
         if (SecondEntryRet)
           Abbrev.addAttribute(SecondEntryRet->Encoding);
         Abbrev.addAttribute({dwarf::DW_IDX_die_offset, dwarf::DW_FORM_ref4});
+        if (std::optional<uint64_t> Offset = Value->getParentDieOffset())
+          Abbrev.addAttribute({dwarf::DW_IDX_parent, dwarf::DW_FORM_ref4});
+        else
+          Abbrev.addAttribute(
+              {dwarf::DW_IDX_parent, dwarf::DW_FORM_flag_present});
         FoldingSetNodeID ID;
         Abbrev.Profile(ID);
         void *InsertPos;
@@ -401,7 +424,11 @@ void DWARF5AcceleratorTable::populateAbbrevsMap() {
   }
 }
 
-void DWARF5AcceleratorTable::writeEntry(const BOLTDWARF5AccelTableData &Entry) {
+void DWARF5AcceleratorTable::writeEntry(BOLTDWARF5AccelTableData &Entry) {
+  const uint64_t EntryID = getEntryID(Entry);
+  if (EntryRelativeOffsets.find(EntryID) != EntryRelativeOffsets.end())
+    EntryRelativeOffsets[EntryID] = EntriesBuffer->size();
+
   const std::optional<DWARF5AccelTable::UnitIndexAndEncoding> EntryRet =
       getIndexForEntry(Entry);
   // For forgeign type (FTU) units that need to refer to the FTU and to the CU.
@@ -456,6 +483,17 @@ void DWARF5AcceleratorTable::writeEntry(const BOLTDWARF5AccelTableData &Entry) {
                              llvm::endianness::little);
       break;
     }
+    case dwarf::DW_IDX_parent: {
+      assert(
+          (AttrEnc.Form == dwarf::DW_FORM_ref4 && Entry.getParentDieOffset()) ||
+          AttrEnc.Form == dwarf::DW_FORM_flag_present);
+      if (std::optional<uint64_t> ParentOffset = Entry.getParentDieOffset()) {
+        Entry.setPatchOffset(EntriesBuffer->size());
+        support::endian::write(*Entriestream, static_cast<uint32_t>(0xBADF00D),
+                               llvm::endianness::little);
+      }
+      break;
+    }
     }
   }
 }
@@ -464,11 +502,31 @@ void DWARF5AcceleratorTable::writeEntries() {
   for (auto &Bucket : getBuckets()) {
     for (DWARF5AcceleratorTable::HashData *Hash : Bucket) {
       Hash->EntryOffset = EntriesBuffer->size();
-      for (const BOLTDWARF5AccelTableData *Value : Hash->Values) {
+      for (BOLTDWARF5AccelTableData *Value : Hash->Values) {
         writeEntry(*Value);
       }
       support::endian::write(*Entriestream, static_cast<uint8_t>(0),
                              llvm::endianness::little);
+    }
+  }
+  // Patching parent offsets.
+  for (auto &Bucket : getBuckets()) {
+    for (DWARF5AcceleratorTable::HashData *Hash : Bucket) {
+      for (BOLTDWARF5AccelTableData *Entry : Hash->Values) {
+        std::optional<uint64_t> ParentOffset = Entry->getParentDieOffset();
+        if (!ParentOffset)
+          continue;
+        if (const auto Iter = EntryRelativeOffsets.find(*ParentOffset);
+            Iter != EntryRelativeOffsets.end()) {
+          const uint64_t PatchOffset = Entry->getPatchOffset();
+          uint32_t *Ptr = reinterpret_cast<uint32_t *>(
+              &EntriesBuffer.get()->data()[PatchOffset]);
+          *Ptr = Iter->second;
+        } else {
+          BC.errs() << "Could not find entry with offset " << *ParentOffset
+                    << "\n";
+        }
+      }
     }
   }
 }

--- a/bolt/lib/Core/DebugNames.cpp
+++ b/bolt/lib/Core/DebugNames.cpp
@@ -489,7 +489,7 @@ void DWARF5AcceleratorTable::writeEntry(BOLTDWARF5AccelTableData &Entry) {
           AttrEnc.Form == dwarf::DW_FORM_flag_present);
       if (std::optional<uint64_t> ParentOffset = Entry.getParentDieOffset()) {
         Entry.setPatchOffset(EntriesBuffer->size());
-        support::endian::write(*Entriestream, static_cast<uint32_t>(0xBADF00D),
+        support::endian::write(*Entriestream, static_cast<uint32_t>(UINT32_MAX),
                                llvm::endianness::little);
       }
       break;

--- a/bolt/test/X86/dwarf5-debug-names-generate-debug-names.test
+++ b/bolt/test/X86/dwarf5-debug-names-generate-debug-names.test
@@ -14,7 +14,7 @@
 ; BOLT: [[OFFSET2:0x[0-9a-f]*]]: Compile Unit
 ; BOLT:       Name Index @ 0x0 {
 ; BOLT-NEXT:   Header {
-; BOLT-NEXT:     Length: 0x103
+; BOLT-NEXT:     Length: 0x109
 ; BOLT-NEXT:     Format: DWARF32
 ; BOLT-NEXT:     Version: 5
 ; BOLT-NEXT:     CU count: 2
@@ -22,7 +22,7 @@
 ; BOLT-NEXT:     Foreign TU count: 0
 ; BOLT-NEXT:     Bucket count: 8
 ; BOLT-NEXT:     Name count: 8
-; BOLT-NEXT:     Abbreviations table size: 0x19
+; BOLT-NEXT:     Abbreviations table size: 0x1F
 ; BOLT-NEXT:     Augmentation: 'BOLT'
 ; BOLT-NEXT:   }
 ; BOLT-NEXT:   Compilation Unit offsets [
@@ -34,16 +34,19 @@
 ; BOLT-NEXT:       Tag: DW_TAG_base_type
 ; BOLT-NEXT:       DW_IDX_compile_unit: DW_FORM_data1
 ; BOLT-NEXT:       DW_IDX_die_offset: DW_FORM_ref4
+; BOLT-NEXT:       DW_IDX_parent: DW_FORM_flag_present
 ; BOLT-NEXT:     }
 ; BOLT-NEXT:     Abbreviation [[ABBREV2:0x[0-9a-f]*]] {
 ; BOLT-NEXT:       Tag: DW_TAG_subprogram
 ; BOLT-NEXT:       DW_IDX_compile_unit: DW_FORM_data1
 ; BOLT-NEXT:       DW_IDX_die_offset: DW_FORM_ref4
+; BOLT-NEXT:       DW_IDX_parent: DW_FORM_flag_present
 ; BOLT-NEXT:     }
 ; BOLT-NEXT:     Abbreviation [[ABBREV3:0x[0-9a-f]*]] {
 ; BOLT-NEXT:       Tag: DW_TAG_variable
 ; BOLT-NEXT:       DW_IDX_compile_unit: DW_FORM_data1
 ; BOLT-NEXT:       DW_IDX_die_offset: DW_FORM_ref4
+; BOLT-NEXT:       DW_IDX_parent: DW_FORM_flag_present
 ; BOLT-NEXT:     }
 ; BOLT-NEXT:   ]
 ; BOLT-NEXT:   Bucket 0 [
@@ -55,12 +58,14 @@
 ; BOLT-NEXT:         Tag: DW_TAG_base_type
 ; BOLT-NEXT:         DW_IDX_compile_unit: 0x01
 ; BOLT-NEXT:         DW_IDX_die_offset: 0x00000033
+; BOLT-NEXT:         DW_IDX_parent: <parent not indexed>
 ; BOLT-NEXT:       }
 ; BOLT-NEXT:       Entry @ {{.+}} {
 ; BOLT-NEXT:         Abbrev: [[ABBREV1]]
 ; BOLT-NEXT:         Tag: DW_TAG_base_type
 ; BOLT-NEXT:         DW_IDX_compile_unit: 0x00
 ; BOLT-NEXT:         DW_IDX_die_offset: 0x0000007f
+; BOLT-NEXT:         DW_IDX_parent: <parent not indexed>
 ; BOLT-NEXT:       }
 ; BOLT-NEXT:     }
 ; BOLT-NEXT:   ]
@@ -73,6 +78,7 @@
 ; BOLT-NEXT:         Tag: DW_TAG_subprogram
 ; BOLT-NEXT:         DW_IDX_compile_unit: 0x01
 ; BOLT-NEXT:         DW_IDX_die_offset: 0x0000005e
+; BOLT-NEXT:         DW_IDX_parent: <parent not indexed>
 ; BOLT-NEXT:       }
 ; BOLT-NEXT:     }
 ; BOLT-NEXT:     Name 3 {
@@ -83,6 +89,7 @@
 ; BOLT-NEXT:         Tag: DW_TAG_subprogram
 ; BOLT-NEXT:         DW_IDX_compile_unit: 0x00
 ; BOLT-NEXT:         DW_IDX_die_offset: 0x00000028
+; BOLT-NEXT:         DW_IDX_parent: <parent not indexed>
 ; BOLT-NEXT:       }
 ; BOLT-NEXT:     }
 ; BOLT-NEXT:   ]
@@ -95,6 +102,7 @@
 ; BOLT-NEXT:         Tag: DW_TAG_subprogram
 ; BOLT-NEXT:         DW_IDX_compile_unit: 0x00
 ; BOLT-NEXT:         DW_IDX_die_offset: 0x00000028
+; BOLT-NEXT:         DW_IDX_parent: <parent not indexed>
 ; BOLT-NEXT:       }
 ; BOLT-NEXT:     }
 ; BOLT-NEXT:     Name 5 {
@@ -105,6 +113,7 @@
 ; BOLT-NEXT:         Tag: DW_TAG_subprogram
 ; BOLT-NEXT:         DW_IDX_compile_unit: 0x00
 ; BOLT-NEXT:         DW_IDX_die_offset: 0x00000049
+; BOLT-NEXT:         DW_IDX_parent: <parent not indexed>
 ; BOLT-NEXT:       }
 ; BOLT-NEXT:     }
 ; BOLT-NEXT:     Name 6 {
@@ -115,6 +124,7 @@
 ; BOLT-NEXT:         Tag: DW_TAG_variable
 ; BOLT-NEXT:         DW_IDX_compile_unit: 0x01
 ; BOLT-NEXT:         DW_IDX_die_offset: 0x00000028
+; BOLT-NEXT:         DW_IDX_parent: <parent not indexed>
 ; BOLT-NEXT:       }
 ; BOLT-NEXT:     }
 ; BOLT-NEXT:   ]
@@ -127,6 +137,7 @@
 ; BOLT-NEXT:         Tag: DW_TAG_base_type
 ; BOLT-NEXT:         DW_IDX_compile_unit: 0x00
 ; BOLT-NEXT:         DW_IDX_die_offset: 0x00000092
+; BOLT-NEXT:         DW_IDX_parent: <parent not indexed>
 ; BOLT-NEXT:       }
 ; BOLT-NEXT:     }
 ; BOLT-NEXT:   ]
@@ -145,6 +156,7 @@
 ; BOLT-NEXT:         Tag: DW_TAG_subprogram
 ; BOLT-NEXT:         DW_IDX_compile_unit: 0x01
 ; BOLT-NEXT:         DW_IDX_die_offset: 0x0000005e
+; BOLT-NEXT:         DW_IDX_parent: <parent not indexed>
 ; BOLT-NEXT:       }
 ; BOLT-NEXT:     }
 ; BOLT-NEXT:   ]

--- a/bolt/test/X86/dwarf5-debug-names.test
+++ b/bolt/test/X86/dwarf5-debug-names.test
@@ -11,7 +11,7 @@
 ; BOLT: [[OFFSET2:0x[0-9a-f]*]]: Compile Unit
 ; BOLT:       Name Index @ 0x0 {
 ; BOLT-NEXT:   Header {
-; BOLT-NEXT:     Length: 0x1C2
+; BOLT-NEXT:     Length: 0x1DA
 ; BOLT-NEXT:     Format: DWARF32
 ; BOLT-NEXT:     Version: 5
 ; BOLT-NEXT:     CU count: 2
@@ -19,7 +19,7 @@
 ; BOLT-NEXT:     Foreign TU count: 0
 ; BOLT-NEXT:     Bucket count: 14
 ; BOLT-NEXT:     Name count: 15
-; BOLT-NEXT:     Abbreviations table size: 0x29
+; BOLT-NEXT:     Abbreviations table size: 0x3D
 ; BOLT-NEXT:     Augmentation: 'BOLT'
 ; BOLT-NEXT:   }
 ; BOLT-NEXT:   Compilation Unit offsets [
@@ -31,27 +31,38 @@
 ; BOLT-NEXT:       Tag: DW_TAG_structure_type
 ; BOLT-NEXT:       DW_IDX_compile_unit: DW_FORM_data1
 ; BOLT-NEXT:       DW_IDX_die_offset: DW_FORM_ref4
+; BOLT-NEXT:       DW_IDX_parent: DW_FORM_flag_present
 ; BOLT-NEXT:     }
 ; BOLT-NEXT:     Abbreviation [[ABBREV2:0x[0-9a-f]*]] {
 ; BOLT-NEXT:       Tag: DW_TAG_namespace
 ; BOLT-NEXT:       DW_IDX_compile_unit: DW_FORM_data1
 ; BOLT-NEXT:       DW_IDX_die_offset: DW_FORM_ref4
+; BOLT-NEXT:       DW_IDX_parent: DW_FORM_flag_present
 ; BOLT-NEXT:     }
 ; BOLT-NEXT:     Abbreviation [[ABBREV3:0x[0-9a-f]*]] {
 ; BOLT-NEXT:       Tag: DW_TAG_subprogram
 ; BOLT-NEXT:       DW_IDX_compile_unit: DW_FORM_data1
 ; BOLT-NEXT:       DW_IDX_die_offset: DW_FORM_ref4
+; BOLT-NEXT:       DW_IDX_parent: DW_FORM_flag_present
 ; BOLT-NEXT:     }
 ; BOLT-NEXT:     Abbreviation [[ABBREV4:0x[0-9a-f]*]] {
 ; BOLT-NEXT:       Tag: DW_TAG_base_type
 ; BOLT-NEXT:       DW_IDX_compile_unit: DW_FORM_data1
 ; BOLT-NEXT:       DW_IDX_die_offset: DW_FORM_ref4
+; BOLT-NEXT:       DW_IDX_parent: DW_FORM_flag_present
 ; BOLT-NEXT:     }
 ; BOLT-NEXT:     Abbreviation [[ABBREV5:0x[0-9a-f]*]] {
 ; BOLT-NEXT:       Tag: DW_TAG_variable
 ; BOLT-NEXT:       DW_IDX_compile_unit: DW_FORM_data1
 ; BOLT-NEXT:       DW_IDX_die_offset: DW_FORM_ref4
+; BOLT-NEXT:       DW_IDX_parent: DW_FORM_flag_present
 ; BOLT-NEXT:     }
+; BOLT-NEXT:       Abbreviation [[ABBREV6:0x[0-9a-f]*]] {
+; BOLT-NEXT:         Tag: DW_TAG_structure_type
+; BOLT-NEXT:         DW_IDX_compile_unit: DW_FORM_data1
+; BOLT-NEXT:         DW_IDX_die_offset: DW_FORM_ref4
+; BOLT-NEXT:         DW_IDX_parent: DW_FORM_ref4
+; BOLT-NEXT:       }
 ; BOLT-NEXT:   ]
 ; BOLT-NEXT:   Bucket 0 [
 ; BOLT-NEXT:     Name 1 {
@@ -62,6 +73,7 @@
 ; BOLT-NEXT:         Tag: DW_TAG_structure_type
 ; BOLT-NEXT:         DW_IDX_compile_unit: 0x00
 ; BOLT-NEXT:         DW_IDX_die_offset: 0x0000002f
+; BOLT-NEXT:         DW_IDX_parent: <parent not indexed>
 ; BOLT-NEXT:       }
 ; BOLT-NEXT:     }
 ; BOLT-NEXT:   ]
@@ -74,6 +86,7 @@
 ; BOLT-NEXT:         Tag: DW_TAG_structure_type
 ; BOLT-NEXT:         DW_IDX_compile_unit: 0x00
 ; BOLT-NEXT:         DW_IDX_die_offset: 0x000000eb
+; BOLT-NEXT:         DW_IDX_parent: <parent not indexed>
 ; BOLT-NEXT:       }
 ; BOLT-NEXT:     }
 ; BOLT-NEXT:   ]
@@ -81,17 +94,19 @@
 ; BOLT-NEXT:     Name 3 {
 ; BOLT-NEXT:       Hash: 0x8CFC710C
 ; BOLT-NEXT:       String: {{.+}} "(anonymous namespace)"
-; BOLT-NEXT:       Entry @ {{.+}} {
+; BOLT-NEXT:       Entry @ [[ENTRY:0x[0-9a-f]*]] {
 ; BOLT-NEXT:         Abbrev: [[ABBREV2]]
 ; BOLT-NEXT:         Tag: DW_TAG_namespace
 ; BOLT-NEXT:         DW_IDX_compile_unit: 0x00
 ; BOLT-NEXT:         DW_IDX_die_offset: 0x00000061
+; BOLT-NEXT:         DW_IDX_parent: <parent not indexed>
 ; BOLT-NEXT:       }
 ; BOLT-NEXT:       Entry @ {{.+}} {
 ; BOLT-NEXT:         Abbrev: [[ABBREV2]]
 ; BOLT-NEXT:         Tag: DW_TAG_namespace
 ; BOLT-NEXT:         DW_IDX_compile_unit: 0x00
 ; BOLT-NEXT:         DW_IDX_die_offset: 0x00000061
+; BOLT-NEXT:         DW_IDX_parent: <parent not indexed>
 ; BOLT-NEXT:       }
 ; BOLT-NEXT:     }
 ; BOLT-NEXT:     Name 4 {
@@ -102,6 +117,7 @@
 ; BOLT-NEXT:         Tag: DW_TAG_structure_type
 ; BOLT-NEXT:         DW_IDX_compile_unit: 0x01
 ; BOLT-NEXT:         DW_IDX_die_offset: 0x0000005a
+; BOLT-NEXT:         DW_IDX_parent: <parent not indexed>
 ; BOLT-NEXT:       }
 ; BOLT-NEXT:     }
 ; BOLT-NEXT:   ]
@@ -120,6 +136,7 @@
 ; BOLT-NEXT:         Tag: DW_TAG_structure_type
 ; BOLT-NEXT:         DW_IDX_compile_unit: 0x00
 ; BOLT-NEXT:         DW_IDX_die_offset: 0x000000c9
+; BOLT-NEXT:         DW_IDX_parent: <parent not indexed>
 ; BOLT-NEXT:       }
 ; BOLT-NEXT:     }
 ; BOLT-NEXT:     Name 6 {
@@ -130,6 +147,7 @@
 ; BOLT-NEXT:         Tag: DW_TAG_subprogram
 ; BOLT-NEXT:         DW_IDX_compile_unit: 0x01
 ; BOLT-NEXT:         DW_IDX_die_offset: 0x00000033
+; BOLT-NEXT:         DW_IDX_parent: <parent not indexed>
 ; BOLT-NEXT:       }
 ; BOLT-NEXT:     }
 ; BOLT-NEXT:     Name 7 {
@@ -140,12 +158,14 @@
 ; BOLT-NEXT:         Tag: DW_TAG_base_type
 ; BOLT-NEXT:         DW_IDX_compile_unit: 0x01
 ; BOLT-NEXT:         DW_IDX_die_offset: 0x0000009f
+; BOLT-NEXT:         DW_IDX_parent: <parent not indexed>
 ; BOLT-NEXT:       }
 ; BOLT-NEXT:       Entry @ {{.+}} {
 ; BOLT-NEXT:         Abbrev: [[ABBREV4]]
 ; BOLT-NEXT:         Tag: DW_TAG_base_type
 ; BOLT-NEXT:         DW_IDX_compile_unit: 0x00
 ; BOLT-NEXT:         DW_IDX_die_offset: 0x000000c5
+; BOLT-NEXT:         DW_IDX_parent: <parent not indexed>
 ; BOLT-NEXT:       }
 ; BOLT-NEXT:     }
 ; BOLT-NEXT:   ]
@@ -158,6 +178,7 @@
 ; BOLT-NEXT:         Tag: DW_TAG_structure_type
 ; BOLT-NEXT:         DW_IDX_compile_unit: 0x00
 ; BOLT-NEXT:         DW_IDX_die_offset: 0x0000003f
+; BOLT-NEXT:         DW_IDX_parent: <parent not indexed>
 ; BOLT-NEXT:       }
 ; BOLT-NEXT:     }
 ; BOLT-NEXT:     Name 9 {
@@ -168,6 +189,7 @@
 ; BOLT-NEXT:         Tag: DW_TAG_variable
 ; BOLT-NEXT:         DW_IDX_compile_unit: 0x01
 ; BOLT-NEXT:         DW_IDX_die_offset: 0x00000024
+; BOLT-NEXT:         DW_IDX_parent: <parent not indexed>
 ; BOLT-NEXT:       }
 ; BOLT-NEXT:     }
 ; BOLT-NEXT:   ]
@@ -180,6 +202,7 @@
 ; BOLT-NEXT:         Tag: DW_TAG_subprogram
 ; BOLT-NEXT:         DW_IDX_compile_unit: 0x01
 ; BOLT-NEXT:         DW_IDX_die_offset: 0x00000033
+; BOLT-NEXT:         DW_IDX_parent: <parent not indexed>
 ; BOLT-NEXT:       }
 ; BOLT-NEXT:     }
 ; BOLT-NEXT:   ]
@@ -192,6 +215,7 @@
 ; BOLT-NEXT:         Tag: DW_TAG_variable
 ; BOLT-NEXT:         DW_IDX_compile_unit: 0x00
 ; BOLT-NEXT:         DW_IDX_die_offset: 0x00000024
+; BOLT-NEXT:         DW_IDX_parent: <parent not indexed>
 ; BOLT-NEXT:       }
 ; BOLT-NEXT:     }
 ; BOLT-NEXT:   ]
@@ -207,12 +231,14 @@
 ; BOLT-NEXT:         Tag: DW_TAG_base_type
 ; BOLT-NEXT:         DW_IDX_compile_unit: 0x01
 ; BOLT-NEXT:         DW_IDX_die_offset: 0x0000002f
+; BOLT-NEXT:         DW_IDX_parent: <parent not indexed>
 ; BOLT-NEXT:       }
 ; BOLT-NEXT:       Entry @ {{.+}} {
 ; BOLT-NEXT:         Abbrev: [[ABBREV4]]
 ; BOLT-NEXT:         Tag: DW_TAG_base_type
 ; BOLT-NEXT:         DW_IDX_compile_unit: 0x00
 ; BOLT-NEXT:         DW_IDX_die_offset: 0x0000005d
+; BOLT-NEXT:         DW_IDX_parent: <parent not indexed>
 ; BOLT-NEXT:       }
 ; BOLT-NEXT:     }
 ; BOLT-NEXT:     Name 13 {
@@ -223,12 +249,14 @@
 ; BOLT-NEXT:         Tag: DW_TAG_structure_type
 ; BOLT-NEXT:         DW_IDX_compile_unit: 0x01
 ; BOLT-NEXT:         DW_IDX_die_offset: 0x00000078
+; BOLT-NEXT:         DW_IDX_parent: <parent not indexed>
 ; BOLT-NEXT:       }
 ; BOLT-NEXT:       Entry @ {{.+}} {
 ; BOLT-NEXT:         Abbrev: [[ABBREV1]]
 ; BOLT-NEXT:         Tag: DW_TAG_structure_type
 ; BOLT-NEXT:         DW_IDX_compile_unit: 0x00
 ; BOLT-NEXT:         DW_IDX_die_offset: 0x00000104
+; BOLT-NEXT:         DW_IDX_parent: <parent not indexed>
 ; BOLT-NEXT:       }
 ; BOLT-NEXT:     }
 ; BOLT-NEXT:     Name 14 {
@@ -239,6 +267,7 @@
 ; BOLT-NEXT:         Tag: DW_TAG_subprogram
 ; BOLT-NEXT:         DW_IDX_compile_unit: 0x00
 ; BOLT-NEXT:         DW_IDX_die_offset: 0x00000073
+; BOLT-NEXT:         DW_IDX_parent: <parent not indexed>
 ; BOLT-NEXT:       }
 ; BOLT-NEXT:     }
 ; BOLT-NEXT:   ]
@@ -250,10 +279,11 @@
 ; BOLT-NEXT:       Hash: 0x59796A
 ; BOLT-NEXT:       String: {{.+}} "t1"
 ; BOLT-NEXT:       Entry @ {{.+}} {
-; BOLT-NEXT:         Abbrev: [[ABBREV1]]
+; BOLT-NEXT:         Abbrev: [[ABBREV6]]
 ; BOLT-NEXT:         Tag: DW_TAG_structure_type
 ; BOLT-NEXT:         DW_IDX_compile_unit: 0x00
 ; BOLT-NEXT:         DW_IDX_die_offset: 0x00000062
+; BOLT-NEXT:         DW_IDX_parent: Entry @ [[ENTRY]]
 ; BOLT-NEXT:       }
 ; BOLT-NEXT:     }
 ; BOLT-NEXT:   ]

--- a/bolt/test/X86/dwarf5-df-debug-names-generate-debug-names.test
+++ b/bolt/test/X86/dwarf5-df-debug-names-generate-debug-names.test
@@ -17,7 +17,7 @@
 ; BOLT: [[OFFSET2:0x[0-9a-f]*]]: Compile Unit
 ; BOLT:       Name Index @ 0x0 {
 ; BOLT-NEXT:   Header {
-; BOLT-NEXT:     Length: 0x148
+; BOLT-NEXT:     Length: 0x14E
 ; BOLT-NEXT:     Format: DWARF32
 ; BOLT-NEXT:     Version: 5
 ; BOLT-NEXT:     CU count: 2
@@ -25,7 +25,7 @@
 ; BOLT-NEXT:     Foreign TU count: 0
 ; BOLT-NEXT:     Bucket count: 11
 ; BOLT-NEXT:     Name count: 11
-; BOLT-NEXT:     Abbreviations table size: 0x19
+; BOLT-NEXT:     Abbreviations table size: 0x1F
 ; BOLT-NEXT:     Augmentation: 'BOLT'
 ; BOLT-NEXT:   }
 ; BOLT-NEXT:   Compilation Unit offsets [
@@ -37,16 +37,19 @@
 ; BOLT-NEXT:       Tag: DW_TAG_variable
 ; BOLT-NEXT:       DW_IDX_compile_unit: DW_FORM_data1
 ; BOLT-NEXT:       DW_IDX_die_offset: DW_FORM_ref4
+; BOLT-NEXT:       DW_IDX_parent: DW_FORM_flag_present
 ; BOLT-NEXT:     }
 ; BOLT-NEXT:     Abbreviation [[ABBREV2:0x[0-9a-f]*]] {
 ; BOLT-NEXT:       Tag: DW_TAG_base_type
 ; BOLT-NEXT:       DW_IDX_compile_unit: DW_FORM_data1
 ; BOLT-NEXT:       DW_IDX_die_offset: DW_FORM_ref4
+; BOLT-NEXT:       DW_IDX_parent: DW_FORM_flag_present
 ; BOLT-NEXT:     }
 ; BOLT-NEXT:     Abbreviation [[ABBREV3:0x[0-9a-f]*]] {
 ; BOLT-NEXT:       Tag: DW_TAG_subprogram
 ; BOLT-NEXT:       DW_IDX_compile_unit: DW_FORM_data1
 ; BOLT-NEXT:       DW_IDX_die_offset: DW_FORM_ref4
+; BOLT-NEXT:       DW_IDX_parent: DW_FORM_flag_present
 ; BOLT-NEXT:     }
 ; BOLT-NEXT:   ]
 ; BOLT-NEXT:   Bucket 0 [
@@ -58,6 +61,7 @@
 ; BOLT-NEXT:         Tag: DW_TAG_variable
 ; BOLT-NEXT:         DW_IDX_compile_unit: 0x00
 ; BOLT-NEXT:         DW_IDX_die_offset: 0x00000029
+; BOLT-NEXT:         DW_IDX_parent: <parent not indexed>
 ; BOLT-NEXT:       }
 ; BOLT-NEXT:     }
 ; BOLT-NEXT:     Name 2 {
@@ -68,6 +72,7 @@
 ; BOLT-NEXT:         Tag: DW_TAG_base_type
 ; BOLT-NEXT:         DW_IDX_compile_unit: 0x00
 ; BOLT-NEXT:         DW_IDX_die_offset: 0x0000008c
+; BOLT-NEXT:         DW_IDX_parent: <parent not indexed>
 ; BOLT-NEXT:       }
 ; BOLT-NEXT:     }
 ; BOLT-NEXT:   ]
@@ -80,6 +85,7 @@
 ; BOLT-NEXT:         Tag: DW_TAG_variable
 ; BOLT-NEXT:         DW_IDX_compile_unit: 0x01
 ; BOLT-NEXT:         DW_IDX_die_offset: 0x00000029
+; BOLT-NEXT:         DW_IDX_parent: <parent not indexed>
 ; BOLT-NEXT:       }
 ; BOLT-NEXT:     }
 ; BOLT-NEXT:     Name 4 {
@@ -90,6 +96,7 @@
 ; BOLT-NEXT:         Tag: DW_TAG_variable
 ; BOLT-NEXT:         DW_IDX_compile_unit: 0x01
 ; BOLT-NEXT:         DW_IDX_die_offset: 0x0000001a
+; BOLT-NEXT:         DW_IDX_parent: <parent not indexed>
 ; BOLT-NEXT:       }
 ; BOLT-NEXT:     }
 ; BOLT-NEXT:   ]
@@ -102,6 +109,7 @@
 ; BOLT-NEXT:         Tag: DW_TAG_subprogram
 ; BOLT-NEXT:         DW_IDX_compile_unit: 0x00
 ; BOLT-NEXT:         DW_IDX_die_offset: 0x00000034
+; BOLT-NEXT:         DW_IDX_parent: <parent not indexed>
 ; BOLT-NEXT:       }
 ; BOLT-NEXT:     }
 ; BOLT-NEXT:   ]
@@ -114,6 +122,7 @@
 ; BOLT-NEXT:         Tag: DW_TAG_subprogram
 ; BOLT-NEXT:         DW_IDX_compile_unit: 0x01
 ; BOLT-NEXT:         DW_IDX_die_offset: 0x00000034
+; BOLT-NEXT:         DW_IDX_parent: <parent not indexed>
 ; BOLT-NEXT:       }
 ; BOLT-NEXT:     }
 ; BOLT-NEXT:   ]
@@ -129,6 +138,7 @@
 ; BOLT-NEXT:         Tag: DW_TAG_subprogram
 ; BOLT-NEXT:         DW_IDX_compile_unit: 0x00
 ; BOLT-NEXT:         DW_IDX_die_offset: 0x00000034
+; BOLT-NEXT:         DW_IDX_parent: <parent not indexed>
 ; BOLT-NEXT:       }
 ; BOLT-NEXT:     }
 ; BOLT-NEXT:   ]
@@ -141,12 +151,14 @@
 ; BOLT-NEXT:         Tag: DW_TAG_base_type
 ; BOLT-NEXT:         DW_IDX_compile_unit: 0x00
 ; BOLT-NEXT:         DW_IDX_die_offset: 0x00000025
+; BOLT-NEXT:         DW_IDX_parent: <parent not indexed>
 ; BOLT-NEXT:       }
 ; BOLT-NEXT:       Entry @ {{.+}} {
 ; BOLT-NEXT:         Abbrev: [[ABBREV2]]
 ; BOLT-NEXT:         Tag: DW_TAG_base_type
 ; BOLT-NEXT:         DW_IDX_compile_unit: 0x01
 ; BOLT-NEXT:         DW_IDX_die_offset: 0x00000025
+; BOLT-NEXT:         DW_IDX_parent: <parent not indexed>
 ; BOLT-NEXT:       }
 ; BOLT-NEXT:     }
 ; BOLT-NEXT:   ]
@@ -159,6 +171,7 @@
 ; BOLT-NEXT:         Tag: DW_TAG_subprogram
 ; BOLT-NEXT:         DW_IDX_compile_unit: 0x01
 ; BOLT-NEXT:         DW_IDX_die_offset: 0x00000034
+; BOLT-NEXT:         DW_IDX_parent: <parent not indexed>
 ; BOLT-NEXT:       }
 ; BOLT-NEXT:     }
 ; BOLT-NEXT:     Name 10 {
@@ -169,6 +182,7 @@
 ; BOLT-NEXT:         Tag: DW_TAG_subprogram
 ; BOLT-NEXT:         DW_IDX_compile_unit: 0x00
 ; BOLT-NEXT:         DW_IDX_die_offset: 0x00000057
+; BOLT-NEXT:         DW_IDX_parent: <parent not indexed>
 ; BOLT-NEXT:       }
 ; BOLT-NEXT:     }
 ; BOLT-NEXT:   ]
@@ -187,6 +201,7 @@
 ; BOLT-NEXT:         Tag: DW_TAG_variable
 ; BOLT-NEXT:         DW_IDX_compile_unit: 0x00
 ; BOLT-NEXT:         DW_IDX_die_offset: 0x0000001a
+; BOLT-NEXT:         DW_IDX_parent: <parent not indexed>
 ; BOLT-NEXT:       }
 ; BOLT-NEXT:     }
 ; BOLT-NEXT:   ]

--- a/bolt/test/X86/dwarf5-df-debug-names.test
+++ b/bolt/test/X86/dwarf5-df-debug-names.test
@@ -14,136 +14,148 @@
 
 ; BOLT: [[OFFSET:0x[0-9a-f]*]]: Compile Unit
 ; BOLT: [[OFFSET1:0x[0-9a-f]*]]: Compile Unit
-: BOLT:       Name Index @ 0x0 {
-: BOLT-NEXT:   Header {
-: BOLT-NEXT:     Length: 0xF4
-: BOLT-NEXT:     Format: DWARF32
-: BOLT-NEXT:     Version: 5
-: BOLT-NEXT:     CU count: 2
-: BOLT-NEXT:     Local TU count: 0
-: BOLT-NEXT:     Foreign TU count: 0
-: BOLT-NEXT:     Bucket count: 7
-: BOLT-NEXT:     Name count: 7
-: BOLT-NEXT:     Abbreviations table size: 0x21
-: BOLT-NEXT:     Augmentation: 'BOLT'
-: BOLT-NEXT:   }
-: BOLT-NEXT:   Compilation Unit offsets [
-: BOLT-NEXT:     CU[0]: [[OFFSET]]
-: BOLT-NEXT:     CU[1]: [[OFFSET1]]
-: BOLT-NEXT:   ]
-: BOLT-NEXT:   Abbreviations [
-: BOLT-NEXT:     Abbreviation [[ABBREV1:0x[0-9a-f]*]] {
-: BOLT-NEXT:       Tag: DW_TAG_structure_type
-: BOLT-NEXT:       DW_IDX_compile_unit: DW_FORM_data1
-: BOLT-NEXT:       DW_IDX_die_offset: DW_FORM_ref4
-: BOLT-NEXT:     }
-: BOLT-NEXT:     Abbreviation [[ABBREV2:0x[0-9a-f]*]] {
-: BOLT-NEXT:       Tag: DW_TAG_base_type
-: BOLT-NEXT:       DW_IDX_compile_unit: DW_FORM_data1
-: BOLT-NEXT:       DW_IDX_die_offset: DW_FORM_ref4
-: BOLT-NEXT:     }
-: BOLT-NEXT:     Abbreviation [[ABBREV3:0x[0-9a-f]*]] {
-: BOLT-NEXT:       Tag: DW_TAG_variable
-: BOLT-NEXT:       DW_IDX_compile_unit: DW_FORM_data1
-: BOLT-NEXT:       DW_IDX_die_offset: DW_FORM_ref4
-: BOLT-NEXT:     }
-: BOLT-NEXT:     Abbreviation [[ABBREV4:0x[0-9a-f]*]] {
-: BOLT-NEXT:       Tag: DW_TAG_subprogram
-: BOLT-NEXT:       DW_IDX_compile_unit: DW_FORM_data1
-: BOLT-NEXT:       DW_IDX_die_offset: DW_FORM_ref4
-: BOLT-NEXT:     }
-: BOLT-NEXT:   ]
-: BOLT-NEXT:   Bucket 0 [
-: BOLT-NEXT:     EMPTY
-: BOLT-NEXT:   ]
-: BOLT-NEXT:   Bucket 1 [
-: BOLT-NEXT:     Name 1 {
-: BOLT-NEXT:       Hash: 0x7C96E4DB
-: BOLT-NEXT:       String: {{.+}} "Foo2"
-: BOLT-NEXT:       Entry @ {{.+}} {
-: BOLT-NEXT:         Abbrev: [[ABBREV1]]
-: BOLT-NEXT:         Tag: DW_TAG_structure_type
-: BOLT-NEXT:         DW_IDX_compile_unit: 0x00
-: BOLT-NEXT:         DW_IDX_die_offset: 0x00000068
-: BOLT-NEXT:       }
-: BOLT-NEXT:     }
-: BOLT-NEXT:   ]
-: BOLT-NEXT:   Bucket 2 [
-: BOLT-NEXT:     Name 2 {
-: BOLT-NEXT:       Hash: 0xBA564846
-: BOLT-NEXT:       String: {{.+}} "Foo2Int"
-: BOLT-NEXT:       Entry @ {{.+}} {
-: BOLT-NEXT:         Abbrev: [[ABBREV1]]
-: BOLT-NEXT:         Tag: DW_TAG_structure_type
-: BOLT-NEXT:         DW_IDX_compile_unit: 0x01
-: BOLT-NEXT:         DW_IDX_die_offset: 0x00000025
-: BOLT-NEXT:       }
-: BOLT-NEXT:     }
-: BOLT-NEXT:   ]
-: BOLT-NEXT:   Bucket 3 [
-: BOLT-NEXT:     Name 3 {
-: BOLT-NEXT:       Hash: 0xB888030
-: BOLT-NEXT:       String: {{.+}} "int"
-: BOLT-NEXT:       Entry @ {{.+}} {
-: BOLT-NEXT:         Abbrev: [[ABBREV2]]
-: BOLT-NEXT:         Tag: DW_TAG_base_type
-: BOLT-NEXT:         DW_IDX_compile_unit: 0x01
-: BOLT-NEXT:         DW_IDX_die_offset: 0x00000043
-: BOLT-NEXT:       }
-: BOLT-NEXT:       Entry @ {{.+}} {
-: BOLT-NEXT:         Abbrev: [[ABBREV2]]
-: BOLT-NEXT:         Tag: DW_TAG_base_type
-: BOLT-NEXT:         DW_IDX_compile_unit: 0x00
-: BOLT-NEXT:         DW_IDX_die_offset: 0x00000056
-: BOLT-NEXT:       }
-: BOLT-NEXT:     }
-: BOLT-NEXT:     Name 4 {
-: BOLT-NEXT:       Hash: 0xF73809C
-: BOLT-NEXT:       String: {{.+}} "Foo2a"
-: BOLT-NEXT:       Entry @ {{.+}} {
-: BOLT-NEXT:         Abbrev: [[ABBREV1]]
-: BOLT-NEXT:         Tag: DW_TAG_structure_type
-: BOLT-NEXT:         DW_IDX_compile_unit: 0x00
-: BOLT-NEXT:         DW_IDX_die_offset: 0x00000078
-: BOLT-NEXT:       }
-: BOLT-NEXT:     }
-: BOLT-NEXT:     Name 5 {
-: BOLT-NEXT:       Hash: 0x7C96CB76
-: BOLT-NEXT:       String: {{.+}} "fint"
-: BOLT-NEXT:       Entry @ {{.+}} {
-: BOLT-NEXT:         Abbrev: [[ABBREV3]]
-: BOLT-NEXT:         Tag: DW_TAG_variable
-: BOLT-NEXT:         DW_IDX_compile_unit: 0x01
-: BOLT-NEXT:         DW_IDX_die_offset: 0x0000001a
-: BOLT-NEXT:       }
-: BOLT-NEXT:     }
-: BOLT-NEXT:     Name 6 {
-: BOLT-NEXT:       Hash: 0x7C9A7F6A
-: BOLT-NEXT:       String: {{.+}} "main"
-: BOLT-NEXT:       Entry @ {{.+}} {
-: BOLT-NEXT:         Abbrev: [[ABBREV4]]
-: BOLT-NEXT:         Tag: DW_TAG_subprogram
-: BOLT-NEXT:         DW_IDX_compile_unit: 0x00
-: BOLT-NEXT:         DW_IDX_die_offset: 0x0000001a
-: BOLT-NEXT:       }
-: BOLT-NEXT:     }
-: BOLT-NEXT:   ]
-: BOLT-NEXT:   Bucket 4 [
-: BOLT-NEXT:     EMPTY
-: BOLT-NEXT:   ]
-: BOLT-NEXT:   Bucket 5 [
-: BOLT-NEXT:     Name 7 {
-: BOLT-NEXT:       Hash: 0x7C952063
-: BOLT-NEXT:       String: {{.+}} "char"
-: BOLT-NEXT:       Entry @ {{.+}} {
-: BOLT-NEXT:         Abbrev: [[ABBREV2]]
-: BOLT-NEXT:         Tag: DW_TAG_base_type
-: BOLT-NEXT:         DW_IDX_compile_unit: 0x00
-: BOLT-NEXT:         DW_IDX_die_offset: 0x00000064
-: BOLT-NEXT:       }
-: BOLT-NEXT:     }
-: BOLT-NEXT:   ]
-: BOLT-NEXT:   Bucket 6 [
-: BOLT-NEXT:     EMPTY
-: BOLT-NEXT:   ]
-: BOLT-NEXT: }
+; BOLT:       Name Index @ 0x0 {
+; BOLT-NEXT:   Header {
+; BOLT-NEXT:     Length: 0xFC
+; BOLT-NEXT:     Format: DWARF32
+; BOLT-NEXT:     Version: 5
+; BOLT-NEXT:     CU count: 2
+; BOLT-NEXT:     Local TU count: 0
+; BOLT-NEXT:     Foreign TU count: 0
+; BOLT-NEXT:     Bucket count: 7
+; BOLT-NEXT:     Name count: 7
+; BOLT-NEXT:     Abbreviations table size: 0x29
+; BOLT-NEXT:     Augmentation: 'BOLT'
+; BOLT-NEXT:   }
+; BOLT-NEXT:   Compilation Unit offsets [
+; BOLT-NEXT:     CU[0]: [[OFFSET]]
+; BOLT-NEXT:     CU[1]: [[OFFSET1]]
+; BOLT-NEXT:   ]
+; BOLT-NEXT:   Abbreviations [
+; BOLT-NEXT:     Abbreviation [[ABBREV1:0x[0-9a-f]*]] {
+; BOLT-NEXT:       Tag: DW_TAG_structure_type
+; BOLT-NEXT:       DW_IDX_compile_unit: DW_FORM_data1
+; BOLT-NEXT:       DW_IDX_die_offset: DW_FORM_ref4
+; BOLT-NEXT:       DW_IDX_parent: DW_FORM_flag_present
+; BOLT-NEXT:     }
+; BOLT-NEXT:     Abbreviation [[ABBREV2:0x[0-9a-f]*]] {
+; BOLT-NEXT:       Tag: DW_TAG_base_type
+; BOLT-NEXT:       DW_IDX_compile_unit: DW_FORM_data1
+; BOLT-NEXT:       DW_IDX_die_offset: DW_FORM_ref4
+; BOLT-NEXT:       DW_IDX_parent: DW_FORM_flag_present
+; BOLT-NEXT:     }
+; BOLT-NEXT:     Abbreviation [[ABBREV3:0x[0-9a-f]*]] {
+; BOLT-NEXT:       Tag: DW_TAG_variable
+; BOLT-NEXT:       DW_IDX_compile_unit: DW_FORM_data1
+; BOLT-NEXT:       DW_IDX_die_offset: DW_FORM_ref4
+; BOLT-NEXT:       DW_IDX_parent: DW_FORM_flag_present
+; BOLT-NEXT:     }
+; BOLT-NEXT:     Abbreviation [[ABBREV4:0x[0-9a-f]*]] {
+; BOLT-NEXT:       Tag: DW_TAG_subprogram
+; BOLT-NEXT:       DW_IDX_compile_unit: DW_FORM_data1
+; BOLT-NEXT:       DW_IDX_die_offset: DW_FORM_ref4
+; BOLT-NEXT:       DW_IDX_parent: DW_FORM_flag_present
+; BOLT-NEXT:     }
+; BOLT-NEXT:   ]
+; BOLT-NEXT:   Bucket 0 [
+; BOLT-NEXT:     EMPTY
+; BOLT-NEXT:   ]
+; BOLT-NEXT:   Bucket 1 [
+; BOLT-NEXT:     Name 1 {
+; BOLT-NEXT:       Hash: 0x7C96E4DB
+; BOLT-NEXT:       String: {{.+}} "Foo2"
+; BOLT-NEXT:       Entry @ {{.+}} {
+; BOLT-NEXT:         Abbrev: [[ABBREV1]]
+; BOLT-NEXT:         Tag: DW_TAG_structure_type
+; BOLT-NEXT:         DW_IDX_compile_unit: 0x00
+; BOLT-NEXT:         DW_IDX_die_offset: 0x00000068
+; BOLT-NEXT:         DW_IDX_parent: <parent not indexed>
+; BOLT-NEXT:       }
+; BOLT-NEXT:     }
+; BOLT-NEXT:   ]
+; BOLT-NEXT:   Bucket 2 [
+; BOLT-NEXT:     Name 2 {
+; BOLT-NEXT:       Hash: 0xBA564846
+; BOLT-NEXT:       String: {{.+}} "Foo2Int"
+; BOLT-NEXT:       Entry @ {{.+}} {
+; BOLT-NEXT:         Abbrev: [[ABBREV1]]
+; BOLT-NEXT:         Tag: DW_TAG_structure_type
+; BOLT-NEXT:         DW_IDX_compile_unit: 0x01
+; BOLT-NEXT:         DW_IDX_die_offset: 0x00000025
+; BOLT-NEXT:         DW_IDX_parent: <parent not indexed>
+; BOLT-NEXT:       }
+; BOLT-NEXT:     }
+; BOLT-NEXT:   ]
+; BOLT-NEXT:   Bucket 3 [
+; BOLT-NEXT:     Name 3 {
+; BOLT-NEXT:       Hash: 0xB888030
+; BOLT-NEXT:       String: {{.+}} "int"
+; BOLT-NEXT:       Entry @ {{.+}} {
+; BOLT-NEXT:         Abbrev: [[ABBREV2]]
+; BOLT-NEXT:         Tag: DW_TAG_base_type
+; BOLT-NEXT:         DW_IDX_compile_unit: 0x01
+; BOLT-NEXT:         DW_IDX_die_offset: 0x00000043
+; BOLT-NEXT:         DW_IDX_parent: <parent not indexed>
+; BOLT-NEXT:       }
+; BOLT-NEXT:       Entry @ {{.+}} {
+; BOLT-NEXT:         Abbrev: [[ABBREV2]]
+; BOLT-NEXT:         Tag: DW_TAG_base_type
+; BOLT-NEXT:         DW_IDX_compile_unit: 0x00
+; BOLT-NEXT:         DW_IDX_die_offset: 0x00000056
+; BOLT-NEXT:         DW_IDX_parent: <parent not indexed>
+; BOLT-NEXT:       }
+; BOLT-NEXT:     }
+; BOLT-NEXT:     Name 4 {
+; BOLT-NEXT:       Hash: 0xF73809C
+; BOLT-NEXT:       String: {{.+}} "Foo2a"
+; BOLT-NEXT:       Entry @ {{.+}} {
+; BOLT-NEXT:         Abbrev: [[ABBREV1]]
+; BOLT-NEXT:         Tag: DW_TAG_structure_type
+; BOLT-NEXT:         DW_IDX_compile_unit: 0x00
+; BOLT-NEXT:         DW_IDX_die_offset: 0x00000078
+; BOLT-NEXT:         DW_IDX_parent: <parent not indexed>
+; BOLT-NEXT:       }
+; BOLT-NEXT:     }
+; BOLT-NEXT:     Name 5 {
+; BOLT-NEXT:       Hash: 0x7C96CB76
+; BOLT-NEXT:       String: {{.+}} "fint"
+; BOLT-NEXT:       Entry @ {{.+}} {
+; BOLT-NEXT:         Abbrev: [[ABBREV3]]
+; BOLT-NEXT:         Tag: DW_TAG_variable
+; BOLT-NEXT:         DW_IDX_compile_unit: 0x01
+; BOLT-NEXT:         DW_IDX_die_offset: 0x0000001a
+; BOLT-NEXT:         DW_IDX_parent: <parent not indexed>
+; BOLT-NEXT:       }
+; BOLT-NEXT:     }
+; BOLT-NEXT:     Name 6 {
+; BOLT-NEXT:       Hash: 0x7C9A7F6A
+; BOLT-NEXT:       String: {{.+}} "main"
+; BOLT-NEXT:       Entry @ {{.+}} {
+; BOLT-NEXT:         Abbrev: [[ABBREV4]]
+; BOLT-NEXT:         Tag: DW_TAG_subprogram
+; BOLT-NEXT:         DW_IDX_compile_unit: 0x00
+; BOLT-NEXT:         DW_IDX_die_offset: 0x0000001a
+; BOLT-NEXT:         DW_IDX_parent: <parent not indexed>
+; BOLT-NEXT:       }
+; BOLT-NEXT:     }
+; BOLT-NEXT:   ]
+; BOLT-NEXT:   Bucket 4 [
+; BOLT-NEXT:     EMPTY
+; BOLT-NEXT:   ]
+; BOLT-NEXT:   Bucket 5 [
+; BOLT-NEXT:     Name 7 {
+; BOLT-NEXT:       Hash: 0x7C952063
+; BOLT-NEXT:       String: {{.+}} "char"
+; BOLT-NEXT:       Entry @ {{.+}} {
+; BOLT-NEXT:         Abbrev: [[ABBREV2]]
+; BOLT-NEXT:         Tag: DW_TAG_base_type
+; BOLT-NEXT:         DW_IDX_compile_unit: 0x00
+; BOLT-NEXT:         DW_IDX_die_offset: 0x00000064
+; BOLT-NEXT:         DW_IDX_parent: <parent not indexed>
+; BOLT-NEXT:       }
+; BOLT-NEXT:     }
+; BOLT-NEXT:   ]
+; BOLT-NEXT:   Bucket 6 [
+; BOLT-NEXT:     EMPTY
+; BOLT-NEXT:   ]
+; BOLT-NEXT: }

--- a/bolt/test/X86/dwarf5-df-main-debug-names-ftu-ltu-mix.test
+++ b/bolt/test/X86/dwarf5-df-main-debug-names-ftu-ltu-mix.test
@@ -31,6 +31,7 @@
 ; BOLT-NEXT:       Tag: DW_TAG_variable
 ; BOLT-NEXT:       DW_IDX_compile_unit: 0x02
 ; BOLT-NEXT:       DW_IDX_die_offset: 0x0000001e
+; BOLT-NEXT:       DW_IDX_parent: <parent not indexed>
 ; BOLT-NEXT:     }
 ; BOLT-NEXT:   }
 ; BOLT:        Name 6 {
@@ -42,6 +43,7 @@
 ; BOLT-NEXT:       DW_IDX_type_unit: 0x02
 ; BOLT-NEXT:       DW_IDX_compile_unit: 0x00
 ; BOLT-NEXT:       DW_IDX_die_offset: 0x00000021
+; BOLT-NEXT:       DW_IDX_parent: <parent not indexed>
 ; BOLT-NEXT:     }
 ; BOLT-NEXT:   }
 ; BOLT:        Name 7 {
@@ -52,5 +54,6 @@
 ; BOLT-NEXT:       Tag: DW_TAG_structure_type
 ; BOLT-NEXT:       DW_IDX_type_unit: 0x00
 ; BOLT-NEXT:       DW_IDX_die_offset: 0x00000023
+; BOLT-NEXT:       DW_IDX_parent: <parent not indexed>
 ; BOLT-NEXT:     }
 ; BOLT-NEXT:   }

--- a/bolt/test/X86/dwarf5-df-one-cu-debug-names.test
+++ b/bolt/test/X86/dwarf5-df-one-cu-debug-names.test
@@ -13,7 +13,7 @@
 ; BOLT: [[OFFSET:0x[0-9a-f]*]]: Compile Unit
 ; BOLT:       Name Index @ 0x0 {
 ; BOLT-NEXT:   Header {
-; BOLT-NEXT:     Length: 0xA9
+; BOLT-NEXT:     Length: 0xAF
 ; BOLT-NEXT:     Format: DWARF32
 ; BOLT-NEXT:     Version: 5
 ; BOLT-NEXT:     CU count: 1
@@ -21,7 +21,7 @@
 ; BOLT-NEXT:     Foreign TU count: 0
 ; BOLT-NEXT:     Bucket count: 5
 ; BOLT-NEXT:     Name count: 5
-; BOLT-NEXT:     Abbreviations table size: 0x13
+; BOLT-NEXT:     Abbreviations table size: 0x19
 ; BOLT-NEXT:     Augmentation: 'BOLT'
 ; BOLT-NEXT:   }
 ; BOLT-NEXT:   Compilation Unit offsets [
@@ -31,14 +31,17 @@
 ; BOLT-NEXT:     Abbreviation [[ABBREV1:0x[0-9a-f]*]] {
 ; BOLT-NEXT:       Tag: DW_TAG_structure_type
 ; BOLT-NEXT:       DW_IDX_die_offset: DW_FORM_ref4
+; BOLT-NEXT:       DW_IDX_parent: DW_FORM_flag_present
 ; BOLT-NEXT:     }
 ; BOLT-NEXT:     Abbreviation [[ABBREV2:0x[0-9a-f]*]] {
 ; BOLT-NEXT:       Tag: DW_TAG_subprogram
 ; BOLT-NEXT:       DW_IDX_die_offset: DW_FORM_ref4
+; BOLT-NEXT:       DW_IDX_parent: DW_FORM_flag_present
 ; BOLT-NEXT:     }
 ; BOLT-NEXT:     Abbreviation [[ABBREV3:0x[0-9a-f]*]] {
 ; BOLT-NEXT:       Tag: DW_TAG_base_type
 ; BOLT-NEXT:       DW_IDX_die_offset: DW_FORM_ref4
+; BOLT-NEXT:       DW_IDX_parent: DW_FORM_flag_present
 ; BOLT-NEXT:     }
 ; BOLT-NEXT:   ]
 ; BOLT-NEXT:   Bucket 0 [
@@ -52,6 +55,7 @@
 ; BOLT-NEXT:         Abbrev: [[ABBREV1]]
 ; BOLT-NEXT:         Tag: DW_TAG_structure_type
 ; BOLT-NEXT:         DW_IDX_die_offset: 0x00000068
+; BOLT-NEXT:         DW_IDX_parent: <parent not indexed>
 ; BOLT-NEXT:       }
 ; BOLT-NEXT:     }
 ; BOLT-NEXT:     Name 2 {
@@ -61,6 +65,7 @@
 ; BOLT-NEXT:         Abbrev: [[ABBREV2]]
 ; BOLT-NEXT:         Tag: DW_TAG_subprogram
 ; BOLT-NEXT:         DW_IDX_die_offset: 0x0000001a
+; BOLT-NEXT:         DW_IDX_parent: <parent not indexed>
 ; BOLT-NEXT:       }
 ; BOLT-NEXT:     }
 ; BOLT-NEXT:   ]
@@ -75,6 +80,7 @@
 ; BOLT-NEXT:         Abbrev: [[ABBREV3]]
 ; BOLT-NEXT:         Tag: DW_TAG_base_type
 ; BOLT-NEXT:         DW_IDX_die_offset: 0x00000056
+; BOLT-NEXT:         DW_IDX_parent: <parent not indexed>
 ; BOLT-NEXT:       }
 ; BOLT-NEXT:     }
 ; BOLT-NEXT:   ]
@@ -86,6 +92,7 @@
 ; BOLT-NEXT:         Abbrev: [[ABBREV1]]
 ; BOLT-NEXT:         Tag: DW_TAG_structure_type
 ; BOLT-NEXT:         DW_IDX_die_offset: 0x00000078
+; BOLT-NEXT:         DW_IDX_parent: <parent not indexed>
 ; BOLT-NEXT:       }
 ; BOLT-NEXT:     }
 ; BOLT-NEXT:     Name 5 {
@@ -95,6 +102,7 @@
 ; BOLT-NEXT:         Abbrev: [[ABBREV3]]
 ; BOLT-NEXT:         Tag: DW_TAG_base_type
 ; BOLT-NEXT:         DW_IDX_die_offset: 0x00000064
+; BOLT-NEXT:         DW_IDX_parent: <parent not indexed>
 ; BOLT-NEXT:       }
 ; BOLT-NEXT:     }
 ; BOLT-NEXT:   ]

--- a/bolt/test/X86/dwarf5-df-types-debug-names.test
+++ b/bolt/test/X86/dwarf5-df-types-debug-names.test
@@ -25,7 +25,7 @@
 
 ; BOLT:       Name Index @ 0x0 {
 ; BOLT-NEXT:   Header {
-; BOLT-NEXT:     Length: 0x174
+; BOLT-NEXT:     Length: 0x17E
 ; BOLT-NEXT:     Format: DWARF32
 ; BOLT-NEXT:     Version: 5
 ; BOLT-NEXT:     CU count: 2
@@ -33,7 +33,7 @@
 ; BOLT-NEXT:     Foreign TU count: 4
 ; BOLT-NEXT:     Bucket count: 9
 ; BOLT-NEXT:     Name count: 9
-; BOLT-NEXT:     Abbreviations table size: 0x2D
+; BOLT-NEXT:     Abbreviations table size: 0x37
 ; BOLT-NEXT:     Augmentation: 'BOLT'
 ; BOLT-NEXT:   }
 ; BOLT-NEXT:   Compilation Unit offsets [
@@ -52,27 +52,32 @@
 ; BOLT-NEXT:       DW_IDX_type_unit: DW_FORM_data1
 ; BOLT-NEXT:       DW_IDX_compile_unit: DW_FORM_data1
 ; BOLT-NEXT:       DW_IDX_die_offset: DW_FORM_ref4
+; BOLT-NEXT:       DW_IDX_parent: DW_FORM_flag_present
 ; BOLT-NEXT:     }
 ; BOLT-NEXT:     Abbreviation [[ABBREV1:0x[0-9a-f]*]] {
 ; BOLT-NEXT:       Tag: DW_TAG_subprogram
 ; BOLT-NEXT:       DW_IDX_compile_unit: DW_FORM_data1
 ; BOLT-NEXT:       DW_IDX_die_offset: DW_FORM_ref4
+; BOLT-NEXT:       DW_IDX_parent: DW_FORM_flag_present
 ; BOLT-NEXT:     }
 ; BOLT-NEXT:     Abbreviation [[ABBREV2:0x[0-9a-f]*]] {
 ; BOLT-NEXT:       Tag: DW_TAG_variable
 ; BOLT-NEXT:       DW_IDX_compile_unit: DW_FORM_data1
 ; BOLT-NEXT:       DW_IDX_die_offset: DW_FORM_ref4
+; BOLT-NEXT:         DW_IDX_parent: DW_FORM_flag_present
 ; BOLT-NEXT:     }
 ; BOLT-NEXT:     Abbreviation [[ABBREV3:0x[0-9a-f]*]] {
 ; BOLT-NEXT:       Tag: DW_TAG_base_type
 ; BOLT-NEXT:       DW_IDX_compile_unit: DW_FORM_data1
 ; BOLT-NEXT:       DW_IDX_die_offset: DW_FORM_ref4
+; BOLT-NEXT:       DW_IDX_parent: DW_FORM_flag_present
 ; BOLT-NEXT:     }
 ; BOLT-NEXT:     Abbreviation [[ABBREV4:0x[0-9a-f]*]] {
 ; BOLT-NEXT:       Tag: DW_TAG_base_type
 ; BOLT-NEXT:       DW_IDX_type_unit: DW_FORM_data1
 ; BOLT-NEXT:       DW_IDX_compile_unit: DW_FORM_data1
 ; BOLT-NEXT:       DW_IDX_die_offset: DW_FORM_ref4
+; BOLT-NEXT:       DW_IDX_parent: DW_FORM_flag_present
 ; BOLT-NEXT:     }
 ; BOLT-NEXT:   ]
 ; BOLT-NEXT:   Bucket 0 [
@@ -88,6 +93,7 @@
 ; BOLT-NEXT:         DW_IDX_type_unit: 0x00
 ; BOLT-NEXT:         DW_IDX_compile_unit: 0x00
 ; BOLT-NEXT:         DW_IDX_die_offset: 0x00000021
+; BOLT-NEXT:         DW_IDX_parent: <parent not indexed>
 ; BOLT-NEXT:       }
 ; BOLT-NEXT:     }
 ; BOLT-NEXT:     Name 2 {
@@ -98,6 +104,7 @@
 ; BOLT-NEXT:         Tag: DW_TAG_subprogram
 ; BOLT-NEXT:         DW_IDX_compile_unit: 0x01
 ; BOLT-NEXT:         DW_IDX_die_offset: 0x00000029
+; BOLT-NEXT:         DW_IDX_parent: <parent not indexed>
 ; BOLT-NEXT:       }
 ; BOLT-NEXT:     }
 ; BOLT-NEXT:     Name 3 {
@@ -108,6 +115,7 @@
 ; BOLT-NEXT:         Tag: DW_TAG_variable
 ; BOLT-NEXT:         DW_IDX_compile_unit: 0x01
 ; BOLT-NEXT:         DW_IDX_die_offset: 0x0000001a
+; BOLT-NEXT:         DW_IDX_parent: <parent not indexed>
 ; BOLT-NEXT:       }
 ; BOLT-NEXT:     }
 ; BOLT-NEXT:   ]
@@ -120,6 +128,7 @@
 ; BOLT-NEXT:         Tag: DW_TAG_base_type
 ; BOLT-NEXT:         DW_IDX_compile_unit: 0x01
 ; BOLT-NEXT:         DW_IDX_die_offset: 0x00000025
+; BOLT-NEXT:         DW_IDX_parent: <parent not indexed>
 ; BOLT-NEXT:       }
 ; BOLT-NEXT:       Entry @ {{.+}} {
 ; BOLT-NEXT:         Abbrev: 0x5
@@ -127,12 +136,14 @@
 ; BOLT-NEXT:         DW_IDX_type_unit: 0x02
 ; BOLT-NEXT:         DW_IDX_compile_unit: 0x01
 ; BOLT-NEXT:         DW_IDX_die_offset: 0x0000003f
+; BOLT-NEXT:         DW_IDX_parent: <parent not indexed>
 ; BOLT-NEXT:       }
 ; BOLT-NEXT:       Entry @ {{.+}} {
 ; BOLT-NEXT:         Abbrev: [[ABBREV3]]
 ; BOLT-NEXT:         Tag: DW_TAG_base_type
 ; BOLT-NEXT:         DW_IDX_compile_unit: 0x00
 ; BOLT-NEXT:         DW_IDX_die_offset: 0x00000056
+; BOLT-NEXT:         DW_IDX_parent: <parent not indexed>
 ; BOLT-NEXT:       }
 ; BOLT-NEXT:     }
 ; BOLT-NEXT:   ]
@@ -145,6 +156,7 @@
 ; BOLT-NEXT:         Tag: DW_TAG_subprogram
 ; BOLT-NEXT:         DW_IDX_compile_unit: 0x01
 ; BOLT-NEXT:         DW_IDX_die_offset: 0x00000029
+; BOLT-NEXT:         DW_IDX_parent: <parent not indexed>
 ; BOLT-NEXT:       }
 ; BOLT-NEXT:     }
 ; BOLT-NEXT:     Name 6 {
@@ -156,6 +168,7 @@
 ; BOLT-NEXT:         DW_IDX_type_unit: 0x01
 ; BOLT-NEXT:         DW_IDX_compile_unit: 0x00
 ; BOLT-NEXT:         DW_IDX_die_offset: 0x00000021
+; BOLT-NEXT:         DW_IDX_parent: <parent not indexed>
 ; BOLT-NEXT:       }
 ; BOLT-NEXT:       Entry @ {{.+}} {
 ; BOLT-NEXT:         Abbrev: [[ABBREV]]
@@ -163,6 +176,7 @@
 ; BOLT-NEXT:         DW_IDX_type_unit: 0x03
 ; BOLT-NEXT:         DW_IDX_compile_unit: 0x01
 ; BOLT-NEXT:         DW_IDX_die_offset: 0x00000021
+; BOLT-NEXT:         DW_IDX_parent: <parent not indexed>
 ; BOLT-NEXT:       }
 ; BOLT-NEXT:     }
 ; BOLT-NEXT:     Name 7 {
@@ -174,6 +188,7 @@
 ; BOLT-NEXT:         DW_IDX_type_unit: 0x02
 ; BOLT-NEXT:         DW_IDX_compile_unit: 0x01
 ; BOLT-NEXT:         DW_IDX_die_offset: 0x00000021
+; BOLT-NEXT:         DW_IDX_parent: <parent not indexed>
 ; BOLT-NEXT:       }
 ; BOLT-NEXT:     }
 ; BOLT-NEXT:   ]
@@ -195,6 +210,7 @@
 ; BOLT-NEXT:         Tag: DW_TAG_subprogram
 ; BOLT-NEXT:         DW_IDX_compile_unit: 0x00
 ; BOLT-NEXT:         DW_IDX_die_offset: 0x0000001a
+; BOLT-NEXT:         DW_IDX_parent: <parent not indexed>
 ; BOLT-NEXT:       }
 ; BOLT-NEXT:     }
 ; BOLT-NEXT:   ]
@@ -208,6 +224,7 @@
 ; BOLT-NEXT:         DW_IDX_type_unit: 0x00
 ; BOLT-NEXT:         DW_IDX_compile_unit: 0x00
 ; BOLT-NEXT:         DW_IDX_die_offset: 0x00000036
+; BOLT-NEXT:         DW_IDX_parent: <parent not indexed>
 ; BOLT-NEXT:       }
 ; BOLT-NEXT:       Entry @ {{.+}} {
 ; BOLT-NEXT:         Abbrev: 0x5
@@ -215,6 +232,7 @@
 ; BOLT-NEXT:         DW_IDX_type_unit: 0x01
 ; BOLT-NEXT:         DW_IDX_compile_unit: 0x00
 ; BOLT-NEXT:         DW_IDX_die_offset: 0x00000048
+; BOLT-NEXT:         DW_IDX_parent: <parent not indexed>
 ; BOLT-NEXT:       }
 ; BOLT-NEXT:       Entry @ {{.+}} {
 ; BOLT-NEXT:         Abbrev: 0x5
@@ -222,12 +240,14 @@
 ; BOLT-NEXT:         DW_IDX_type_unit: 0x03
 ; BOLT-NEXT:         DW_IDX_compile_unit: 0x01
 ; BOLT-NEXT:         DW_IDX_die_offset: 0x00000048
+; BOLT-NEXT:         DW_IDX_parent: <parent not indexed>
 ; BOLT-NEXT:       }
 ; BOLT-NEXT:       Entry @ {{.+}} {
 ; BOLT-NEXT:         Abbrev: [[ABBREV3]]
 ; BOLT-NEXT:         Tag: DW_TAG_base_type
 ; BOLT-NEXT:         DW_IDX_compile_unit: 0x00
 ; BOLT-NEXT:         DW_IDX_die_offset: 0x00000064
+; BOLT-NEXT:         DW_IDX_parent: <parent not indexed>
 ; BOLT-NEXT:       }
 ; BOLT-NEXT:     }
 ; BOLT-NEXT:   ]

--- a/bolt/test/X86/dwarf5-df-types-one-cu-debug-names.test
+++ b/bolt/test/X86/dwarf5-df-types-one-cu-debug-names.test
@@ -17,7 +17,7 @@
 ; BOLT: [[OFFSET:0x[0-9a-f]*]]: Compile Unit
 ; BOLT:       Name Index @ 0x0 {
 ; BOLT-NEXT:   Header {
-; BOLT-NEXT:     Length: 0xD1
+; BOLT-NEXT:     Length: 0xD9
 ; BOLT-NEXT:     Format: DWARF32
 ; BOLT-NEXT:     Version: 5
 ; BOLT-NEXT:     CU count: 1
@@ -25,7 +25,7 @@
 ; BOLT-NEXT:     Foreign TU count: 2
 ; BOLT-NEXT:     Bucket count: 5
 ; BOLT-NEXT:     Name count: 5
-; BOLT-NEXT:     Abbreviations table size: 0x1D
+; BOLT-NEXT:     Abbreviations table size: 0x25
 ; BOLT-NEXT:     Augmentation: 'BOLT'
 ; BOLT-NEXT:   }
 ; BOLT-NEXT:   Compilation Unit offsets [
@@ -40,19 +40,23 @@
 ; BOLT-NEXT:       Tag: DW_TAG_structure_type
 ; BOLT-NEXT:       DW_IDX_type_unit: DW_FORM_data1
 ; BOLT-NEXT:       DW_IDX_die_offset: DW_FORM_ref4
+; BOLT-NEXT:       DW_IDX_parent: DW_FORM_flag_present
 ; BOLT-NEXT:     }
 ; BOLT-NEXT:     Abbreviation [[ABBREV2:0x[0-9a-f]*]] {
 ; BOLT-NEXT:       Tag: DW_TAG_subprogram
 ; BOLT-NEXT:       DW_IDX_die_offset: DW_FORM_ref4
+; BOLT-NEXT:       DW_IDX_parent: DW_FORM_flag_present
 ; BOLT-NEXT:     }
 ; BOLT-NEXT:     Abbreviation [[ABBREV3:0x[0-9a-f]*]] {
 ; BOLT-NEXT:       Tag: DW_TAG_base_type
 ; BOLT-NEXT:       DW_IDX_die_offset: DW_FORM_ref4
+; BOLT-NEXT:       DW_IDX_parent: DW_FORM_flag_present
 ; BOLT-NEXT:     }
 ; BOLT-NEXT:     Abbreviation [[ABBREV4:0x[0-9a-f]*]] {
 ; BOLT-NEXT:       Tag: DW_TAG_base_type
 ; BOLT-NEXT:       DW_IDX_type_unit: DW_FORM_data1
 ; BOLT-NEXT:       DW_IDX_die_offset: DW_FORM_ref4
+; BOLT-NEXT:       DW_IDX_parent: DW_FORM_flag_present
 ; BOLT-NEXT:     }
 ; BOLT-NEXT:   ]
 ; BOLT-NEXT:   Bucket 0 [
@@ -67,6 +71,7 @@
 ; BOLT-NEXT:         Tag: DW_TAG_structure_type
 ; BOLT-NEXT:         DW_IDX_type_unit: 0x00
 ; BOLT-NEXT:         DW_IDX_die_offset: 0x00000021
+; BOLT-NEXT:         DW_IDX_parent: <parent not indexed>
 ; BOLT-NEXT:       }
 ; BOLT-NEXT:     }
 ; BOLT-NEXT:     Name 2 {
@@ -76,6 +81,7 @@
 ; BOLT-NEXT:         Abbrev: [[ABBREV2]]
 ; BOLT-NEXT:         Tag: DW_TAG_subprogram
 ; BOLT-NEXT:         DW_IDX_die_offset: 0x0000001a
+; BOLT-NEXT:         DW_IDX_parent: <parent not indexed>
 ; BOLT-NEXT:       }
 ; BOLT-NEXT:     }
 ; BOLT-NEXT:   ]
@@ -90,6 +96,7 @@
 ; BOLT-NEXT:         Abbrev: [[ABBREV3]]
 ; BOLT-NEXT:         Tag: DW_TAG_base_type
 ; BOLT-NEXT:         DW_IDX_die_offset: 0x00000056
+; BOLT-NEXT:         DW_IDX_parent: <parent not indexed>
 ; BOLT-NEXT:       }
 ; BOLT-NEXT:     }
 ; BOLT-NEXT:   ]
@@ -102,6 +109,7 @@
 ; BOLT-NEXT:         Tag: DW_TAG_structure_type
 ; BOLT-NEXT:         DW_IDX_type_unit: 0x01
 ; BOLT-NEXT:         DW_IDX_die_offset: 0x00000021
+; BOLT-NEXT:         DW_IDX_parent: <parent not indexed>
 ; BOLT-NEXT:       }
 ; BOLT-NEXT:     }
 ; BOLT-NEXT:     Name 5 {
@@ -112,17 +120,20 @@
 ; BOLT-NEXT:         Tag: DW_TAG_base_type
 ; BOLT-NEXT:         DW_IDX_type_unit: 0x00
 ; BOLT-NEXT:         DW_IDX_die_offset: 0x00000036
+; BOLT-NEXT:         DW_IDX_parent: <parent not indexed>
 ; BOLT-NEXT:       }
 ; BOLT-NEXT:       Entry @ {{.+}} {
 ; BOLT-NEXT:         Abbrev: [[ABBREV4]]
 ; BOLT-NEXT:         Tag: DW_TAG_base_type
 ; BOLT-NEXT:         DW_IDX_type_unit: 0x01
 ; BOLT-NEXT:         DW_IDX_die_offset: 0x00000048
+; BOLT-NEXT:         DW_IDX_parent: <parent not indexed>
 ; BOLT-NEXT:       }
 ; BOLT-NEXT:       Entry @ {{.+}} {
 ; BOLT-NEXT:         Abbrev: [[ABBREV3]]
 ; BOLT-NEXT:         Tag: DW_TAG_base_type
 ; BOLT-NEXT:         DW_IDX_die_offset: 0x00000064
+; BOLT-NEXT:         DW_IDX_parent: <parent not indexed>
 ; BOLT-NEXT:       }
 ; BOLT-NEXT:     }
 ; BOLT-NEXT:   ]

--- a/bolt/test/X86/dwarf5-one-cu-debug-names.test
+++ b/bolt/test/X86/dwarf5-one-cu-debug-names.test
@@ -9,7 +9,7 @@
 ; BOLT: [[OFFSET1:0x[0-9a-f]*]]: Compile Unit
 ; BOLT:       Name Index @ 0x0 {
 ; BOLT-NEXT:   Header {
-; BOLT-NEXT:     Length: 0x13E
+; BOLT-NEXT:     Length: 0x154
 ; BOLT-NEXT:     Format: DWARF32
 ; BOLT-NEXT:     Version: 5
 ; BOLT-NEXT:     CU count: 1
@@ -17,7 +17,7 @@
 ; BOLT-NEXT:     Foreign TU count: 0
 ; BOLT-NEXT:     Bucket count: 11
 ; BOLT-NEXT:     Name count: 11
-; BOLT-NEXT:     Abbreviations table size: 0x1F
+; BOLT-NEXT:     Abbreviations table size: 0x31
 ; BOLT-NEXT:     Augmentation: 'BOLT'
 ; BOLT-NEXT:   }
 ; BOLT-NEXT:   Compilation Unit offsets [
@@ -27,22 +27,32 @@
 ; BOLT-NEXT:     Abbreviation [[ABBREV1:0x[0-9a-f]*]] {
 ; BOLT-NEXT:       Tag: DW_TAG_structure_type
 ; BOLT-NEXT:       DW_IDX_die_offset: DW_FORM_ref4
+; BOLT-NEXT:       DW_IDX_parent: DW_FORM_flag_present
 ; BOLT-NEXT:     }
 ; BOLT-NEXT:     Abbreviation [[ABBREV2:0x[0-9a-f]*]] {
 ; BOLT-NEXT:       Tag: DW_TAG_base_type
 ; BOLT-NEXT:       DW_IDX_die_offset: DW_FORM_ref4
+; BOLT-NEXT:       DW_IDX_parent: DW_FORM_flag_present
 ; BOLT-NEXT:     }
 ; BOLT-NEXT:     Abbreviation [[ABBREV3:0x[0-9a-f]*]] {
-; BOLT-NEXT:       Tag: DW_TAG_variable
-; BOLT-NEXT:       DW_IDX_die_offset: DW_FORM_ref4
+; BOLT-NEXT:        Tag: DW_TAG_structure_type
+; BOLT-NEXT:        DW_IDX_die_offset: DW_FORM_ref4
+; BOLT-NEXT:        DW_IDX_parent: DW_FORM_ref4
 ; BOLT-NEXT:     }
 ; BOLT-NEXT:     Abbreviation [[ABBREV4:0x[0-9a-f]*]] {
-; BOLT-NEXT:       Tag: DW_TAG_subprogram
+; BOLT-NEXT:       Tag: DW_TAG_variable
 ; BOLT-NEXT:       DW_IDX_die_offset: DW_FORM_ref4
+; BOLT-NEXT:       DW_IDX_parent: DW_FORM_flag_present
 ; BOLT-NEXT:     }
 ; BOLT-NEXT:     Abbreviation [[ABBREV5:0x[0-9a-f]*]] {
+; BOLT-NEXT:       Tag: DW_TAG_subprogram
+; BOLT-NEXT:       DW_IDX_die_offset: DW_FORM_ref4
+; BOLT-NEXT:       DW_IDX_parent: DW_FORM_flag_present
+; BOLT-NEXT:     }
+; BOLT-NEXT:     Abbreviation [[ABBREV6:0x[0-9a-f]*]] {
 ; BOLT-NEXT:       Tag: DW_TAG_namespace
 ; BOLT-NEXT:       DW_IDX_die_offset: DW_FORM_ref4
+; BOLT-NEXT:       DW_IDX_parent: DW_FORM_flag_present
 ; BOLT-NEXT:     }
 ; BOLT-NEXT:   ]
 ; BOLT-NEXT:   Bucket 0 [
@@ -53,6 +63,7 @@
 ; BOLT-NEXT:         Abbrev: [[ABBREV1]]
 ; BOLT-NEXT:         Tag: DW_TAG_structure_type
 ; BOLT-NEXT:         DW_IDX_die_offset: 0x00000104
+; BOLT-NEXT:         DW_IDX_parent: <parent not indexed>
 ; BOLT-NEXT:       }
 ; BOLT-NEXT:     }
 ; BOLT-NEXT:     Name 2 {
@@ -62,6 +73,7 @@
 ; BOLT-NEXT:         Abbrev: [[ABBREV2]]
 ; BOLT-NEXT:         Tag: DW_TAG_base_type
 ; BOLT-NEXT:         DW_IDX_die_offset: 0x000000c5
+; BOLT-NEXT:         DW_IDX_parent: <parent not indexed>
 ; BOLT-NEXT:       }
 ; BOLT-NEXT:     }
 ; BOLT-NEXT:   ]
@@ -73,6 +85,7 @@
 ; BOLT-NEXT:         Abbrev: [[ABBREV1]]
 ; BOLT-NEXT:         Tag: DW_TAG_structure_type
 ; BOLT-NEXT:         DW_IDX_die_offset: 0x000000c9
+; BOLT-NEXT:         DW_IDX_parent: <parent not indexed>
 ; BOLT-NEXT:       }
 ; BOLT-NEXT:     }
 ; BOLT-NEXT:     Name 4 {
@@ -82,6 +95,7 @@
 ; BOLT-NEXT:         Abbrev: [[ABBREV1]]
 ; BOLT-NEXT:         Tag: DW_TAG_structure_type
 ; BOLT-NEXT:         DW_IDX_die_offset: 0x0000003f
+; BOLT-NEXT:         DW_IDX_parent: <parent not indexed>
 ; BOLT-NEXT:       }
 ; BOLT-NEXT:     }
 ; BOLT-NEXT:   ]
@@ -93,6 +107,7 @@
 ; BOLT-NEXT:         Abbrev: [[ABBREV1]]
 ; BOLT-NEXT:         Tag: DW_TAG_structure_type
 ; BOLT-NEXT:         DW_IDX_die_offset: 0x000000eb
+; BOLT-NEXT:         DW_IDX_parent: <parent not indexed>
 ; BOLT-NEXT:       }
 ; BOLT-NEXT:     }
 ; BOLT-NEXT:   ]
@@ -107,18 +122,20 @@
 ; BOLT-NEXT:       Hash: 0x59796A
 ; BOLT-NEXT:       String: {{.+}} "t1"
 ; BOLT-NEXT:       Entry @ {{.+}} {
-; BOLT-NEXT:         Abbrev: [[ABBREV1]]
+; BOLT-NEXT:         Abbrev: [[ABBREV3]]
 ; BOLT-NEXT:         Tag: DW_TAG_structure_type
 ; BOLT-NEXT:         DW_IDX_die_offset: 0x00000062
+; BOLT-NEXT:         DW_IDX_parent: Entry @ 0x14d
 ; BOLT-NEXT:       }
 ; BOLT-NEXT:     }
 ; BOLT-NEXT:     Name 7 {
 ; BOLT-NEXT:       Hash: 0x5979AC
 ; BOLT-NEXT:       String: {{.+}} "v1"
 ; BOLT-NEXT:       Entry @ {{.+}} {
-; BOLT-NEXT:         Abbrev: [[ABBREV3]]
+; BOLT-NEXT:         Abbrev: [[ABBREV4]]
 ; BOLT-NEXT:         Tag: DW_TAG_variable
 ; BOLT-NEXT:         DW_IDX_die_offset: 0x00000024
+; BOLT-NEXT:         DW_IDX_parent: <parent not indexed>
 ; BOLT-NEXT:       }
 ; BOLT-NEXT:     }
 ; BOLT-NEXT:   ]
@@ -130,6 +147,7 @@
 ; BOLT-NEXT:         Abbrev: [[ABBREV2]]
 ; BOLT-NEXT:         Tag: DW_TAG_base_type
 ; BOLT-NEXT:         DW_IDX_die_offset: 0x0000005d
+; BOLT-NEXT:         DW_IDX_parent: <parent not indexed>
 ; BOLT-NEXT:       }
 ; BOLT-NEXT:     }
 ; BOLT-NEXT:   ]
@@ -141,15 +159,17 @@
 ; BOLT-NEXT:         Abbrev: [[ABBREV1]]
 ; BOLT-NEXT:         Tag: DW_TAG_structure_type
 ; BOLT-NEXT:         DW_IDX_die_offset: 0x0000002f
+; BOLT-NEXT:         DW_IDX_parent: <parent not indexed>
 ; BOLT-NEXT:       }
 ; BOLT-NEXT:     }
 ; BOLT-NEXT:     Name 10 {
 ; BOLT-NEXT:       Hash: 0x7C9A7F6A
 ; BOLT-NEXT:       String: {{.+}} "main"
 ; BOLT-NEXT:       Entry @ {{.+}} {
-; BOLT-NEXT:         Abbrev: [[ABBREV4]]
+; BOLT-NEXT:         Abbrev: [[ABBREV5]]
 ; BOLT-NEXT:         Tag: DW_TAG_subprogram
 ; BOLT-NEXT:         DW_IDX_die_offset: 0x00000073
+; BOLT-NEXT:         DW_IDX_parent: <parent not indexed>
 ; BOLT-NEXT:       }
 ; BOLT-NEXT:     }
 ; BOLT-NEXT:   ]
@@ -157,15 +177,17 @@
 ; BOLT-NEXT:     Name 11 {
 ; BOLT-NEXT:       Hash: 0x8CFC710C
 ; BOLT-NEXT:       String: {{.+}} "(anonymous namespace)"
-; BOLT-NEXT:       Entry @ {{.+}} {
-; BOLT-NEXT:         Abbrev: [[ABBREV5]]
+; BOLT-NEXT:       Entry @ 0x14d {
+; BOLT-NEXT:         Abbrev: [[ABBREV6]]
 ; BOLT-NEXT:         Tag: DW_TAG_namespace
 ; BOLT-NEXT:         DW_IDX_die_offset: 0x00000061
+; BOLT-NEXT:         DW_IDX_parent: <parent not indexed>
 ; BOLT-NEXT:       }
 ; BOLT-NEXT:       Entry @ {{.+}} {
-; BOLT-NEXT:         Abbrev: [[ABBREV5]]
+; BOLT-NEXT:         Abbrev: [[ABBREV6]]
 ; BOLT-NEXT:         Tag: DW_TAG_namespace
 ; BOLT-NEXT:         DW_IDX_die_offset: 0x00000061
+; BOLT-NEXT:         DW_IDX_parent: <parent not indexed>
 ; BOLT-NEXT:       }
 ; BOLT-NEXT:     }
 ; BOLT-NEXT:   ]

--- a/bolt/test/X86/dwarf5-types-debug-names.test
+++ b/bolt/test/X86/dwarf5-types-debug-names.test
@@ -14,7 +14,7 @@
 
 ; BOLT: Name Index @ 0x0 {
 ; BOLT:   Header {
-; BOLT:     Length: 0xE1
+; BOLT:     Length: 0xE9
 ; BOLT:     Format: DWARF32
 ; BOLT:     Version: 5
 ; BOLT:     CU count: 2
@@ -22,7 +22,7 @@
 ; BOLT:     Foreign TU count: 0
 ; BOLT:     Bucket count: 6
 ; BOLT:     Name count: 6
-; BOLT:     Abbreviations table size: 0x21
+; BOLT:     Abbreviations table size: 0x29
 ; BOLT:     Augmentation: 'BOLT'
 ; BOLT:   }
 ; BOLT:   Compilation Unit offsets [
@@ -37,21 +37,25 @@
 ; BOLT:       Tag: DW_TAG_structure_type
 ; BOLT:       DW_IDX_type_unit: DW_FORM_data1
 ; BOLT:       DW_IDX_die_offset: DW_FORM_ref4
+; BOLT:       DW_IDX_parent: DW_FORM_flag_present
 ; BOLT:     }
 ; BOLT:     Abbreviation [[ABBREV1:0x[0-9a-f]*]] {
 ; BOLT:       Tag: DW_TAG_subprogram
 ; BOLT:       DW_IDX_compile_unit: DW_FORM_data1
 ; BOLT:       DW_IDX_die_offset: DW_FORM_ref4
+; BOLT:       DW_IDX_parent: DW_FORM_flag_present
 ; BOLT:     }
 ; BOLT:     Abbreviation [[ABBREV2:0x[0-9a-f]*]] {
 ; BOLT:       Tag: DW_TAG_base_type
 ; BOLT:       DW_IDX_compile_unit: DW_FORM_data1
 ; BOLT:       DW_IDX_die_offset: DW_FORM_ref4
+; BOLT:       DW_IDX_parent: DW_FORM_flag_present
 ; BOLT:     }
 ; BOLT:     Abbreviation [[ABBREV3:0x[0-9a-f]*]] {
 ; BOLT:       Tag: DW_TAG_base_type
 ; BOLT:       DW_IDX_type_unit: DW_FORM_data1
 ; BOLT:       DW_IDX_die_offset: DW_FORM_ref4
+; BOLT:       DW_IDX_parent: DW_FORM_flag_present
 ; BOLT:     }
 ; BOLT:   ]
 ; BOLT:   Bucket 0 [
@@ -63,6 +67,7 @@
 ; BOLT:         Tag: DW_TAG_structure_type
 ; BOLT:         DW_IDX_type_unit: 0x00
 ; BOLT:         DW_IDX_die_offset: 0x00000023
+; BOLT:         DW_IDX_parent: <parent not indexed>
 ; BOLT:       }
 ; BOLT:     }
 ; BOLT:   ]
@@ -75,6 +80,7 @@
 ; BOLT:         Tag: DW_TAG_subprogram
 ; BOLT:         DW_IDX_compile_unit: 0x01
 ; BOLT:         DW_IDX_die_offset: 0x00000024
+; BOLT:         DW_IDX_parent: <parent not indexed>
 ; BOLT:       }
 ; BOLT:     }
 ; BOLT:   ]
@@ -87,6 +93,7 @@
 ; BOLT:         Tag: DW_TAG_base_type
 ; BOLT:         DW_IDX_compile_unit: 0x01
 ; BOLT:         DW_IDX_die_offset: 0x00000040
+; BOLT:         DW_IDX_parent: <parent not indexed>
 ; BOLT:       }
 ; BOLT:     }
 ; BOLT:   ]
@@ -99,6 +106,7 @@
 ; BOLT:         Tag: DW_TAG_subprogram
 ; BOLT:         DW_IDX_compile_unit: 0x01
 ; BOLT:         DW_IDX_die_offset: 0x00000024
+; BOLT:         DW_IDX_parent: <parent not indexed>
 ; BOLT:       }
 ; BOLT:     }
 ; BOLT:   ]
@@ -111,6 +119,7 @@
 ; BOLT:         Tag: DW_TAG_subprogram
 ; BOLT:         DW_IDX_compile_unit: 0x00
 ; BOLT:         DW_IDX_die_offset: 0x00000024
+; BOLT:         DW_IDX_parent: <parent not indexed>
 ; BOLT:       }
 ; BOLT:     }
 ; BOLT:   ]
@@ -123,6 +132,7 @@
 ; BOLT:         Tag: DW_TAG_base_type
 ; BOLT:         DW_IDX_type_unit: 0x00
 ; BOLT:         DW_IDX_die_offset: 0x00000038
+; BOLT:         DW_IDX_parent: <parent not indexed>
 ; BOLT:       }
 ; BOLT:     }
 ; BOLT:   ]

--- a/bolt/test/X86/dwarf5-types-one-cu-debug-names.test
+++ b/bolt/test/X86/dwarf5-types-one-cu-debug-names.test
@@ -11,7 +11,7 @@
 
 ; BOLT:Name Index @ 0x0 {
 ; BOLT-NEXT:  Header {
-; BOLT-NEXT:    Length: 0xA3
+; BOLT-NEXT:    Length: 0xAB
 ; BOLT-NEXT:    Format: DWARF32
 ; BOLT-NEXT:    Version: 5
 ; BOLT-NEXT:    CU count: 1
@@ -19,7 +19,7 @@
 ; BOLT-NEXT:    Foreign TU count: 0
 ; BOLT-NEXT:    Bucket count: 4
 ; BOLT-NEXT:    Name count: 4
-; BOLT-NEXT:    Abbreviations table size: 0x1D
+; BOLT-NEXT:    Abbreviations table size: 0x25
 ; BOLT-NEXT:    Augmentation: 'BOLT'
 ; BOLT-NEXT:  }
 ; BOLT-NEXT:  Compilation Unit offsets [
@@ -32,20 +32,24 @@
 ; BOLT-NEXT:    Abbreviation [[ABBREV:0x[0-9a-f]*]] {
 ; BOLT-NEXT:      Tag: DW_TAG_base_type
 ; BOLT-NEXT:      DW_IDX_die_offset: DW_FORM_ref4
+; BOLT-NEXT:      DW_IDX_parent: DW_FORM_flag_present
 ; BOLT-NEXT:    }
 ; BOLT-NEXT:    Abbreviation [[ABBREV1:0x[0-9a-f]*]] {
 ; BOLT-NEXT:      Tag: DW_TAG_structure_type
 ; BOLT-NEXT:      DW_IDX_type_unit: DW_FORM_data1
 ; BOLT-NEXT:      DW_IDX_die_offset: DW_FORM_ref4
+; BOLT-NEXT:      DW_IDX_parent: DW_FORM_flag_present
 ; BOLT-NEXT:    }
 ; BOLT-NEXT:    Abbreviation [[ABBREV2:0x[0-9a-f]*]] {
 ; BOLT-NEXT:      Tag: DW_TAG_subprogram
 ; BOLT-NEXT:      DW_IDX_die_offset: DW_FORM_ref4
+; BOLT-NEXT:      DW_IDX_parent: DW_FORM_flag_present
 ; BOLT-NEXT:    }
 ; BOLT-NEXT:    Abbreviation [[ABBREV3:0x[0-9a-f]*]] {
 ; BOLT-NEXT:      Tag: DW_TAG_base_type
 ; BOLT-NEXT:      DW_IDX_type_unit: DW_FORM_data1
 ; BOLT-NEXT:      DW_IDX_die_offset: DW_FORM_ref4
+; BOLT-NEXT:      DW_IDX_parent: DW_FORM_flag_present
 ; BOLT-NEXT:    }
 ; BOLT-NEXT:  ]
 ; BOLT-NEXT:  Bucket 0 [
@@ -56,6 +60,7 @@
 ; BOLT-NEXT:        Abbrev: [[ABBREV]]
 ; BOLT-NEXT:        Tag: DW_TAG_base_type
 ; BOLT-NEXT:        DW_IDX_die_offset: 0x0000003f
+; BOLT-NEXT:        DW_IDX_parent: <parent not indexed>
 ; BOLT-NEXT:      }
 ; BOLT-NEXT:    }
 ; BOLT-NEXT:    Name 2 {
@@ -66,6 +71,7 @@
 ; BOLT-NEXT:        Tag: DW_TAG_structure_type
 ; BOLT-NEXT:        DW_IDX_type_unit: 0x00
 ; BOLT-NEXT:        DW_IDX_die_offset: 0x00000023
+; BOLT-NEXT:        DW_IDX_parent: <parent not indexed>
 ; BOLT-NEXT:      }
 ; BOLT-NEXT:    }
 ; BOLT-NEXT:  ]
@@ -80,6 +86,7 @@
 ; BOLT-NEXT:        Abbrev: [[ABBREV2]]
 ; BOLT-NEXT:        Tag: DW_TAG_subprogram
 ; BOLT-NEXT:        DW_IDX_die_offset: 0x00000024
+; BOLT-NEXT:        DW_IDX_parent: <parent not indexed>
 ; BOLT-NEXT:      }
 ; BOLT-NEXT:    }
 ; BOLT-NEXT:  ]
@@ -92,6 +99,7 @@
 ; BOLT-NEXT:        Tag: DW_TAG_base_type
 ; BOLT-NEXT:        DW_IDX_type_unit: 0x00
 ; BOLT-NEXT:        DW_IDX_die_offset: 0x00000038
+; BOLT-NEXT:        DW_IDX_parent: <parent not indexed>
 ; BOLT-NEXT:      }
 ; BOLT-NEXT:    }
 ; BOLT-NEXT:  ]


### PR DESCRIPTION
This adds support for DW_IDX_parent. If DIE has a parent then DW_IDX_parent in Entry will point to Entry for that parent DIE. Otherwise it will have DW_FORM_flag_present in abbrev. Which takes zero space in Entry.

This came from
https://discourse.llvm.org/t/rfc-improve-dwarf-5-debug-names-type-lookup-parsing-speed/74151