### PR TITLE
[LLD][COFF] Make unresolved symbol search behavior compliant with MSVC link.exe

### DIFF
--- a/lld/COFF/Driver.cpp
+++ b/lld/COFF/Driver.cpp
@@ -369,7 +369,7 @@ void LinkerDriver::enqueueArchiveMember(const Archive::Child &c,
 
 void LinkerDriver::enqueueLazyFile(InputFile *file) {
   enqueueSecondaryTask([=]() {
-    // Once it has been enqued, it cannot be lazy anymore.
+    // Once it has been enqueued, it cannot be lazy anymore.
     file->lazy = false;
     ctx.symtab.addFile(file);
   });

--- a/lld/COFF/Driver.cpp
+++ b/lld/COFF/Driver.cpp
@@ -511,7 +511,7 @@ void LinkerDriver::parseDirectives(InputFile *file) {
 
   // If we are running off the low-priority task list, execute and drain the
   // high priority task list before going any further. This is to ensure symbols
-  // provided by /DEFAULTLIB archives are linked property in the symbol table.
+  // provided by /DEFAULTLIB archives are linked properly in the symbol table.
   executeFirstQueue(firstTaskQueue);
 }
 

--- a/lld/COFF/InputFiles.h
+++ b/lld/COFF/InputFiles.h
@@ -112,7 +112,7 @@ class ArchiveFile : public InputFile {
 public:
   explicit ArchiveFile(COFFLinkerContext &ctx, MemoryBufferRef m);
   static bool classof(const InputFile *f) { return f->kind() == ArchiveKind; }
-  void parse() override{};
+  void parse() override {};
   void parseLazy();
 
   // Enqueues an archive member load for the given symbol. If we've already

--- a/lld/COFF/SymbolTable.cpp
+++ b/lld/COFF/SymbolTable.cpp
@@ -677,15 +677,15 @@ void SymbolTable::addLazyArchive(ArchiveFile *f, const Archive::Symbol &sym) {
   f->addMember(sym);
 }
 
-void SymbolTable::addLazyObject(InputFile *f, StringRef name) {
+void SymbolTable::addLazyObject(InputFile *f, StringRef n) {
   assert(f->lazy);
-  auto [s, wasInserted] = insert(name, f);
+  auto [s, wasInserted] = insert(n, f);
   if (wasInserted) {
-    replaceSymbol<LazyObject>(s, f, name);
+    replaceSymbol<LazyObject>(s, f, n);
     return;
   }
-  if (auto *n = lazyNode(s)) {
-    chainLazy<LazyObject>(n, f, name);
+  if (auto *node = lazyNode(s)) {
+    chainLazy<LazyObject>(node, f, n);
     return;
   }
   auto *u = dyn_cast<Undefined>(s);

--- a/lld/COFF/SymbolTable.cpp
+++ b/lld/COFF/SymbolTable.cpp
@@ -648,9 +648,9 @@ void SymbolTable::addLazyArchive(ArchiveFile *f, const Archive::Symbol &sym) {
     replaceSymbol<LazyArchive>(s, f, sym);
     return;
   }
-  if (auto *n = lazyNode(s)) {
-    assert(!s->pendingArchiveLoad);
-    chainLazy<LazyArchive>(n, f, sym);
+  if (auto *node = lazyNode(s)) {
+    if (!s->pendingArchiveLoad)
+      chainLazy<LazyArchive>(node, f, sym);
     return;
   }
   auto *u = dyn_cast<Undefined>(s);
@@ -668,8 +668,8 @@ void SymbolTable::addLazyObject(InputFile *f, StringRef n) {
     return;
   }
   if (auto *node = lazyNode(s)) {
-    assert(!s->pendingArchiveLoad);
-    chainLazy<LazyObject>(node, f, n);
+    if (!s->pendingArchiveLoad)
+      chainLazy<LazyObject>(node, f, n);
     return;
   }
   auto *u = dyn_cast<Undefined>(s);

--- a/lld/COFF/SymbolTable.cpp
+++ b/lld/COFF/SymbolTable.cpp
@@ -694,6 +694,7 @@ void SymbolTable::addLazyObject(InputFile *f, StringRef n) {
     return;
   }
   if (auto *node = lazyNode(s)) {
+    assert(!s->pendingArchiveLoad);
     chainLazy<LazyObject>(node, f, n);
     return;
   }

--- a/lld/COFF/SymbolTable.cpp
+++ b/lld/COFF/SymbolTable.cpp
@@ -538,25 +538,25 @@ std::pair<Symbol *, bool> SymbolTable::insert(StringRef name, InputFile *file) {
 }
 
 static LazyIntrusiveNode *getLazyNode(Symbol *s) {
-  if (auto *sym = dyn_cast<LazyArchive>(s))
+  if (auto *sym = dyn_cast_if_present<LazyArchive>(s))
     return &sym->node;
-  if (auto *sym = dyn_cast<LazyObject>(s))
+  if (auto *sym = dyn_cast_if_present<LazyObject>(s))
     return &sym->node;
   return nullptr;
 }
 
 static ArchiveFile *getLazyParent(InputFile *f) {
-  if (auto *obj = dyn_cast<ObjFile>(f))
+  if (auto *obj = dyn_cast_if_present<ObjFile>(f))
     return obj->parent;
-  if (auto *obj = dyn_cast<BitcodeFile>(f))
+  if (auto *obj = dyn_cast_if_present<BitcodeFile>(f))
     return obj->parent;
   return nullptr;
 }
 
 static ArchiveFile *getLazyArchive(Symbol *s) {
-  if (auto *sym = dyn_cast<LazyArchive>(s))
+  if (auto *sym = dyn_cast_if_present<LazyArchive>(s))
     return sym->file;
-  if (auto *sym = dyn_cast<LazyObject>(s))
+  if (auto *sym = dyn_cast_if_present<LazyObject>(s))
     return getLazyParent(sym->file);
   return nullptr;
 }

--- a/lld/COFF/Symbols.h
+++ b/lld/COFF/Symbols.h
@@ -286,6 +286,15 @@ private:
   uint32_t offset;
 };
 
+// Keep track of symbols with the same name exposed by archives. This is
+// required to later resolve unresolved symbols in the same order as required
+// by the MSVC spec. These are indexes in the specific bump allocator for
+// SymbolUnion.
+struct LazyIntrusiveNode {
+  uint32_t next = 0;
+  uint32_t last = 0;
+};
+
 // This class represents a symbol defined in an archive file. It is
 // created from an archive file header, and it knows how to load an
 // object file from an archive to replace itself with a defined
@@ -302,6 +311,7 @@ public:
 
   ArchiveFile *file;
   const Archive::Symbol sym;
+  LazyIntrusiveNode node;
 };
 
 class LazyObject : public Symbol {
@@ -309,6 +319,7 @@ public:
   LazyObject(InputFile *f, StringRef n) : Symbol(LazyObjectKind, n), file(f) {}
   static bool classof(const Symbol *s) { return s->kind() == LazyObjectKind; }
   InputFile *file;
+  LazyIntrusiveNode node;
 };
 
 // MinGW only.

--- a/lld/docs/ReleaseNotes.rst
+++ b/lld/docs/ReleaseNotes.rst
@@ -36,6 +36,10 @@ Breaking changes
 COFF Improvements
 -----------------
 
+* Symbols pulled from archives/LIBs are now resolved in the same way (archive
+  order) as MSVC link.exe. For more information see:
+  https://learn.microsoft.com/en-us/cpp/build/reference/link-input-files?view=msvc-170
+
 MinGW Improvements
 ------------------
 

--- a/lld/test/COFF/duplicate-imp-func.s
+++ b/lld/test/COFF/duplicate-imp-func.s
@@ -28,8 +28,10 @@
 # Once the import library member from %t.lib.dll.a gets loaded, libfunc
 # and __imp_libfunc already are defined.
 
-# Just check that this fails cleanly (doesn't crash).
-# RUN: not lld-link -lldmingw -out:%t.main.exe -entry:main %t.main.o %t.lib.dll.a %t.helper.a
+# This test should now succeed since we're following the MSVC symbol searching behvior described in:
+# https://learn.microsoft.com/en-us/cpp/build/reference/link-input-files?view=msvc-170
+# In this case, the linker will select the libfunc symbol in %t.helper.a
+# RUN: lld-link -lldmingw -out:%t.main.exe -entry:main %t.main.o %t.lib.dll.a %t.helper.a
 
 # Test with %t.helper.a on the command line; in this case we won't try to
 # include libfunc from %t.lib.dll.a and everything works fine.

--- a/lld/test/COFF/duplicate-imp-func.s
+++ b/lld/test/COFF/duplicate-imp-func.s
@@ -28,7 +28,7 @@
 # Once the import library member from %t.lib.dll.a gets loaded, libfunc
 # and __imp_libfunc already are defined.
 
-# This test should now succeed since we're following the MSVC symbol searching behvior described in:
+# This test should now succeed since we're following the MSVC symbol searching behavior described in:
 # https://learn.microsoft.com/en-us/cpp/build/reference/link-input-files?view=msvc-170
 # In this case, the linker will select the libfunc symbol in %t.helper.a
 # RUN: lld-link -lldmingw -out:%t.main.exe -entry:main %t.main.o %t.lib.dll.a %t.helper.a

--- a/lld/test/COFF/lib-searching-behavior.s
+++ b/lld/test/COFF/lib-searching-behavior.s
@@ -53,12 +53,16 @@
 # LIB: 140001008: e8 03 00 00 00                   callq   0x140001010 <.text+0x10>
 # LIB: 140001010: 31 c0                            xorl    %eax, %eax
 
-# In this last test, we should pick up the import symbol from %t.lib.dll.a since it isn't defined anywhere else.
+# Here, we should pick up the import symbol from %t.lib.dll.a since it isn't defined anywhere else.
 # RUN: lld-link -out:%t.main.exe -entry:main %t.main.o %t.lib.dll.a %t.helper1.a
 # RUN: llvm-objdump --no-print-imm-hex -d %t.main.exe | FileCheck --check-prefix=LIB-IMP %s
 
 # LIB-IMP: 140001000 <.text>:
 # LIB-IMP: 140001010: ff 25 22 10 00 00            jmpq    *4130(%rip)
+
+# Test cmd-line archives
+# RUN: lld-link -out:%t.main.exe -entry:main %t.main.o %t.lib.dll.a -start-lib %t.helper1.o %t.helper2.o -end-lib
+# RUN: llvm-objdump --no-print-imm-hex -d %t.main.exe | FileCheck --check-prefix=LIB %s
 
     .globl main
     .text

--- a/lld/test/COFF/lib-searching-behavior.s
+++ b/lld/test/COFF/lib-searching-behavior.s
@@ -1,0 +1,67 @@
+# REQUIRES: x86
+
+# This test ensures that we're following the MSVC symbol searching behvior described in:
+# https://learn.microsoft.com/en-us/cpp/build/reference/link-input-files?view=msvc-170
+# "Object files on the command line are processed in the order they appear on the command line.
+# Libraries are searched in command line order as well, with the following caveat: Symbols that
+# are unresolved when bringing in an object file from a library are searched for in that library
+# first, and then the following libraries from the command line and /DEFAULTLIB (Specify default
+# library) directives, and then to any libraries at the beginning of the command line."
+
+# RUN: echo -e ".intel_syntax noprefix\n.globl libfunc\n.text\nlibfunc:\nmov eax, 1\nret\n.section .drectve\n.ascii \"/EXPORT:libfunc\"" > %t.lib.s
+# RUN: llvm-mc -triple=x86_64-pc-windows-msvc %t.lib.s -filetype=obj -o %t.lib.o
+# RUN: lld-link -dll -out:%t.lib.dll -entry:libfunc %t.lib.o -implib:%t.lib.dll.a
+
+# RUN: echo -e ".globl helper\n.text\nhelper:\ncall libfunc\nret" > %t.helper1.s
+# RUN: echo -e ".intel_syntax noprefix\n.globl libfunc\n.text\nlibfunc:\nxor eax, eax\nret" > %t.helper2.s
+# RUN: llvm-mc -triple=x86_64-pc-windows-msvc %t.helper1.s -filetype=obj -o %t.helper1.o
+# RUN: llvm-mc -triple=x86_64-pc-windows-msvc %t.helper2.s -filetype=obj -o %t.helper2.o
+
+# RUN: llvm-ar rcs %t.helper.a %t.helper1.o %t.helper2.o
+
+# RUN: llvm-mc -triple=x86_64-pc-windows-msvc %s -filetype=obj -o %t.main.o
+
+# Simulate a setup, where two libraries provide the same function;
+# %t.lib.dll.a is a pure import library which provides a import symbol "libfunc".
+# %t.helper.a is a static library which contains "helper1" and "helper2".
+#
+# helper1 contains an undefined reference to libfunc. helper2 contains an
+# implementation of libfunc.
+#
+# First %t.main.o is processed and pushes a undefined symbol 'helper'.
+# Then %t.lib.dll.a is processed a pushes the lazy archive symbol 'libfunc' in the symbol table.
+# Then comes %t.helper.a and it pushes 'helper' and 'libfunc' as lazy symbols. Then 'helper' is
+# resolved and that pushes 'libfunc' as a undefined symbol. That pulls on %t.helper.a(%t.helper2.o)
+# which contains the 'libfunc' symbol, resolving it. This is illustrative of the MSVC library searching
+# behavior which starts with the current library object which requested the unresolved symbol.
+# RUN: lld-link -out:%t.main.exe -entry:main %t.main.o %t.lib.dll.a %t.helper.a
+# RUN: llvm-objdump --no-print-imm-hex -d %t.main.exe | FileCheck --check-prefix=LIB %s
+
+# In this case, the symbol in %t.helper.a(%t.helper2.o) is still considered first.
+# RUN: lld-link -out:%t.main.exe -entry:main %t.main.o %t.helper.a %t.lib.dll.a
+# RUN: llvm-objdump --no-print-imm-hex -d %t.main.exe | FileCheck --check-prefix=LIB %s
+
+# In this test we're defining libfunc in a third library that comes after all the others. The symbol should be pulled
+# now from that third library.
+# RUN: llvm-ar rcs %t.helper1.a %t.helper1.o
+# RUN: llvm-ar rcs %t.helper2.a %t.helper2.o
+# RUN: lld-link -out:%t.main.exe -entry:main %t.main.o %t.lib.dll.a %t.helper1.a %t.helper2.a
+# RUN: llvm-objdump --no-print-imm-hex -d %t.main.exe | FileCheck --check-prefix=LIB %s
+
+# LIB: 140001000 <.text>:
+# LIB: 140001000: e8 03 00 00 00                   callq   0x140001008 <.text+0x8>
+# LIB: 140001008: e8 03 00 00 00                   callq   0x140001010 <.text+0x10>
+# LIB: 140001010: 31 c0                            xorl    %eax, %eax
+
+# In this last test, we should pick up the import symbol from %t.lib.dll.a since it isn't defined anywhere else.
+# RUN: lld-link -out:%t.main.exe -entry:main %t.main.o %t.lib.dll.a %t.helper1.a
+# RUN: llvm-objdump --no-print-imm-hex -d %t.main.exe | FileCheck --check-prefix=LIB-IMP %s
+
+# LIB-IMP: 140001000 <.text>:
+# LIB-IMP: 140001010: ff 25 22 10 00 00            jmpq    *4130(%rip)
+
+    .globl main
+    .text
+main:
+    call helper
+    ret


### PR DESCRIPTION
Before this PR, unresolved symbols were always resolved depending on the order of inputs on the command line. The first input (.LIB or .OBJ) to provide a symbol would win. Subsequent inputs to provide the same symbol would either error out, or in case of archives (LIBs) would be ignored.

The MSVC documentation however suggests a subtle difference for resolving unresolved symbols, once an archive OBJ is brought in by another symbol. As per: https://learn.microsoft.com/en-us/cpp/build/reference/link-input-files?view=msvc-170

> _Object files on the command line are processed in the order they appear on the command line. Libraries are searched in command line order as well, with the following caveat: **Symbols that are unresolved when bringing in an object file from a library are searched for in that library first, and then the following libraries from the command line and [/DEFAULTLIB (Specify default library)](https://learn.microsoft.com/en-us/cpp/build/reference/defaultlib-specify-default-library?view=msvc-170) directives, and then to any libraries at the beginning of the command line.**_

(Thanks to Grant Richins from the MSVC linker team who pointed me to that paragraph)

This PR aligns the LLD behavior with MSVC. The approach I've taken is to keep (in the symbol table) all the _duplicated_ lazy symbols exposed by input archives. More specifically, the first symbol for a given symbol name is pushed in the symbol table as usual, and any subsequent (lazy) symbols with the same name will be linked to that first symbol in a (intrusive) linked list. When an archive OBJ is pulled in through another symbol, any unresolved symbols for that OBJ are resolved by searching through the linked list, starting at the OBJ's specific archive position. For example:
```
> lld-link /nodefaultlib main.obj a.lib b.lib c.lib /entry:main
```
In this case, `main.obj` pulls on a symbol inside `b.lib`, which pulls on `b1.obj` in that archive. `b1.obj` then requires another unresolved symbol `f`, and starts searching at `b.lib`, then `c.lib`, then `a.lib`. Previously, we always pulled the symbol from the first archive exposing it, `a.lib` in this case.

In practical terms, the unresolved symbol searching remains O(1) time, unless N archives are exposing the same symbol name, which makes the worst case O(N) time for that given symbol.

This fixes a long-standing bug we were seeing from both Rust and C++, see: https://github.com/llvm/llvm-project/issues/82050

**Additional note:** I also had to fix the behavior of command-line archives introduced in https://github.com/llvm/llvm-project/commit/7dc5e7a0a4f4d27f3fa09e18907fe6f34767bfe2, to be symmetric with regular LIB files. Therefore OBJs enclosed in `-start-lib`/`-end-lib` are now lazily read, to postpone resolving of their symbols to after the entire command-line was processed.