### PR TITLE
[libc++] Use clang-tidy version that matches the compiler we use in the CI

### DIFF
--- a/libcxx/test/tools/clang_tidy_checks/CMakeLists.txt
+++ b/libcxx/test/tools/clang_tidy_checks/CMakeLists.txt
@@ -5,7 +5,7 @@
 set(LLVM_DIR_SAVE ${LLVM_DIR})
 set(Clang_DIR_SAVE ${Clang_DIR})
 
-find_package(Clang 18)
+find_package(Clang 18.1)
 if (NOT Clang_FOUND)
   find_package(Clang 17)
 endif()


### PR DESCRIPTION
This works around ODR violations in the clang-tidy plugin we use to perform the modules tests.

Fixes #85242