### PR TITLE
[Clang] Resolve FIXME: Use class method when receiver is reference to class

### DIFF
--- a/clang/lib/Analysis/RetainSummaryManager.cpp
+++ b/clang/lib/Analysis/RetainSummaryManager.cpp
@@ -1139,14 +1139,23 @@ const RetainSummary *RetainSummaryManager::getInstanceMethodSummary(
   if (!ReceiverClass)
     ReceiverClass = ME->getReceiverInterface();
 
-  // FIXME: The receiver could be a reference to a class, meaning that
-  //  we should use the class method.
+  // The receiver could be a reference to a class, meaning that
+  // we should use the class method if that happens.
   // id x = [NSObject class];
   // [x performSelector:... withObject:... afterDelay:...];
   Selector S = ME->getSelector();
   const ObjCMethodDecl *Method = ME->getMethodDecl();
-  if (!Method && ReceiverClass)
-    Method = ReceiverClass->getInstanceMethod(S);
+  if (!Method) {
+    if (ReceiverClass) {
+      if (ReceiverType->isSpecificBuiltinType(BuiltinType::ObjCClass)) {
+        // The receiver is a class reference, use the class method.
+        Method = ReceiverClass->getClassMethod(S);
+      } else {
+        // The receiver is an instance reference, use the instance method.
+        Method = ReceiverClass->getInstanceMethod(S);
+      }
+    }
+  }
 
   return getMethodSummary(S, ReceiverClass, Method, ME->getType(),
                           ObjCMethodSummaries);


### PR DESCRIPTION
If the receiver is a class reference, use the class method.