### PR TITLE
[SLP] Compute a shuffle mask for getGatherCost

### DIFF
--- a/llvm/lib/Transforms/Vectorize/SLPVectorizer.cpp
+++ b/llvm/lib/Transforms/Vectorize/SLPVectorizer.cpp
@@ -10516,7 +10516,7 @@ InstructionCost BoUpSLP::getGatherCost(ArrayRef<Value *> VL,
           TTI->getVectorInstrCost(Instruction::InsertElement, VecTy, CostKind,
                                   I, Constant::getNullValue(VecTy), V);
   };
-  SmallVector<int> ShuffleMask(VL.size(), -1);
+  SmallVector<int> ShuffleMask(VL.size(), PoisonMaskElem);
   for (unsigned I = 0, E = VL.size(); I < E; ++I) {
     Value *V = VL[I];
     // No need to shuffle duplicates for constants.

--- a/llvm/lib/Transforms/Vectorize/SLPVectorizer.cpp
+++ b/llvm/lib/Transforms/Vectorize/SLPVectorizer.cpp
@@ -10522,7 +10522,7 @@ InstructionCost BoUpSLP::getGatherCost(ArrayRef<Value *> VL,
     // No need to shuffle duplicates for constants.
     if ((ForPoisonSrc && isConstant(V)) || isa<UndefValue>(V)) {
       ShuffledElements.setBit(I);
-      ShuffleMask[I] = I;
+      ShuffleMask[I] = isa<PoisonValue>(V) ? PoisonMaskElem : I;
       continue;
     }
 

--- a/llvm/lib/Transforms/Vectorize/SLPVectorizer.cpp
+++ b/llvm/lib/Transforms/Vectorize/SLPVectorizer.cpp
@@ -10535,7 +10535,7 @@ InstructionCost BoUpSLP::getGatherCost(ArrayRef<Value *> VL,
 
     DuplicateNonConst = true;
     ShuffledElements.setBit(I);
-    ShuffleMask[I] = UniqueElements[V];
+    ShuffleMask[I] = Res.first->second;
   }
   if (ForPoisonSrc)
     Cost =

--- a/llvm/lib/Transforms/Vectorize/SLPVectorizer.cpp
+++ b/llvm/lib/Transforms/Vectorize/SLPVectorizer.cpp
@@ -10526,9 +10526,9 @@ InstructionCost BoUpSLP::getGatherCost(ArrayRef<Value *> VL,
       continue;
     }
 
-    if (!UniqueElements.count(V)) {
+    auto Res = UniqueElements.try_emplace(V, I);
+    if (Res.second) {
       EstimateInsertCost(I, V);
-      UniqueElements[V] = I;
       ShuffleMask[I] = I;
       continue;
     }


### PR DESCRIPTION
This is the second of a series of small patches to compute shuffle masks for the couple of cases where we call getShuffleCost without one. My goal is to add an invariant that all calls to getShuffleCost for fixed length vectors have a mask.