### PR TITLE
[libc] Include empty remove in baremetal stdio.h

### DIFF
--- a/libc/config/baremetal/arm/entrypoints.txt
+++ b/libc/config/baremetal/arm/entrypoints.txt
@@ -79,6 +79,7 @@ set(TARGET_LIBC_ENTRYPOINTS
     libc.src.inttypes.strtoumax
 
     # stdio.h entrypoints
+    libc.src.stdio.remove
     libc.src.stdio.sprintf
     libc.src.stdio.snprintf
     libc.src.stdio.vsprintf

--- a/libc/config/baremetal/riscv/entrypoints.txt
+++ b/libc/config/baremetal/riscv/entrypoints.txt
@@ -79,6 +79,7 @@ set(TARGET_LIBC_ENTRYPOINTS
     libc.src.inttypes.strtoumax
 
     # stdio.h entrypoints
+    libc.src.stdio.remove
     libc.src.stdio.sprintf
     libc.src.stdio.snprintf
     libc.src.stdio.vsprintf

--- a/libc/src/stdio/baremetal/CMakeLists.txt
+++ b/libc/src/stdio/baremetal/CMakeLists.txt
@@ -1,0 +1,7 @@
+add_entrypoint_object(
+  remove
+  SRCS
+    remove.cpp
+  HDRS
+    ../remove.h
+)

--- a/libc/src/stdio/baremetal/remove.cpp
+++ b/libc/src/stdio/baremetal/remove.cpp
@@ -1,0 +1,22 @@
+//===-- Linux implementation of remove ------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "src/stdio/remove.h"
+
+#include "src/__support/common.h"
+
+namespace LIBC_NAMESPACE {
+
+// TODO: See https://github.com/llvm/llvm-project/issues/85335 for more details
+// on why this is needed.
+
+LLVM_LIBC_FUNCTION(int, remove, (const char *)) {
+  return -1;
+}
+
+} // namespace LIBC_NAMESPACE

--- a/libc/src/stdio/baremetal/remove.cpp
+++ b/libc/src/stdio/baremetal/remove.cpp
@@ -12,11 +12,8 @@
 
 namespace LIBC_NAMESPACE {
 
-// TODO: See https://github.com/llvm/llvm-project/issues/85335 for more details
-// on why this is needed.
+// TODO: This is a temporary workaround for issue #85335.
 
-LLVM_LIBC_FUNCTION(int, remove, (const char *)) {
-  return -1;
-}
+LLVM_LIBC_FUNCTION(int, remove, (const char *)) { return -1; }
 
 } // namespace LIBC_NAMESPACE


### PR DESCRIPTION
This is required to avoid compilation error in libc++.

See #85335 for more details.