### PR TITLE
[HLSL] Add validation for the -enable-16bit-types option

### DIFF
--- a/clang/include/clang/Basic/DiagnosticDriverKinds.td
+++ b/clang/include/clang/Basic/DiagnosticDriverKinds.td
@@ -753,7 +753,8 @@ def err_drv_hlsl_unsupported_target : Error<
   "HLSL code generation is unsupported for target '%0'">;
 def err_drv_hlsl_bad_shader_required_in_target : Error<
   "%select{shader model|Vulkan environment|shader stage}0 is required as %select{OS|environment}1 in target '%2' for HLSL code generation">;
-
+def err_drv_hlsl_enable_16bit_types_option_invalid: Error<
+  "enable_16bit_types option only valid when target shader model [-T] is >= 6.2 and Hlsl Version [-HV] is >= 2021">;
 def err_drv_hlsl_bad_shader_unsupported : Error<
   "%select{shader model|Vulkan environment|shader stage}0 '%1' in target '%2' is invalid for HLSL code generation">;
 def warn_drv_dxc_missing_dxv : Warning<"dxv not found. "

--- a/clang/include/clang/Basic/DiagnosticDriverKinds.td
+++ b/clang/include/clang/Basic/DiagnosticDriverKinds.td
@@ -753,7 +753,7 @@ def err_drv_hlsl_unsupported_target : Error<
   "HLSL code generation is unsupported for target '%0'">;
 def err_drv_hlsl_bad_shader_required_in_target : Error<
   "%select{shader model|Vulkan environment|shader stage}0 is required as %select{OS|environment}1 in target '%2' for HLSL code generation">;
-def err_drv_hlsl_16bit_types_unsupported: Error<  
+def err_drv_hlsl_16bit_types_unsupported: Error<
   "'%0' option requires target HLSL Version >= 2018%select{| and shader model >= 6.2}1, but HLSL Version is '%2'%select{| and shader model is '%3'}1">;
 def err_drv_hlsl_bad_shader_unsupported : Error<
   "%select{shader model|Vulkan environment|shader stage}0 '%1' in target '%2' is invalid for HLSL code generation">;

--- a/clang/include/clang/Basic/DiagnosticDriverKinds.td
+++ b/clang/include/clang/Basic/DiagnosticDriverKinds.td
@@ -753,8 +753,10 @@ def err_drv_hlsl_unsupported_target : Error<
   "HLSL code generation is unsupported for target '%0'">;
 def err_drv_hlsl_bad_shader_required_in_target : Error<
   "%select{shader model|Vulkan environment|shader stage}0 is required as %select{OS|environment}1 in target '%2' for HLSL code generation">;
-def err_drv_hlsl_enable_16bit_types_option_invalid: Error<
-  "enable_16bit_types option only valid when target shader model [-T] is >= 6.2 and HLSL Version [-HV] is >= 2021">;
+def err_drv_dxc_enable_16bit_types_option_invalid: Error<
+  "enable-16bit-types option only valid when target shader model [-T] is >= 6.2 and HLSL Version [-HV] is >= 2021">;
+def err_drv_cc1_hlsl_spirv_fnative_half_type_option_invalid: Error<
+  "fnative-half-type option only valid when hlsl language standard version is >= 2021">;
 def err_drv_hlsl_bad_shader_unsupported : Error<
   "%select{shader model|Vulkan environment|shader stage}0 '%1' in target '%2' is invalid for HLSL code generation">;
 def warn_drv_dxc_missing_dxv : Warning<"dxv not found. "

--- a/clang/include/clang/Basic/DiagnosticDriverKinds.td
+++ b/clang/include/clang/Basic/DiagnosticDriverKinds.td
@@ -754,9 +754,9 @@ def err_drv_hlsl_unsupported_target : Error<
 def err_drv_hlsl_bad_shader_required_in_target : Error<
   "%select{shader model|Vulkan environment|shader stage}0 is required as %select{OS|environment}1 in target '%2' for HLSL code generation">;
 def err_drv_dxc_enable_16bit_types_option_invalid: Error<
-  "enable-16bit-types option only valid when target shader model [-T] is >= 6.2 and HLSL Version [-HV] is >= 2021">;
+  "'-enable-16bit-types' option only valid when target shader model [-T] is >= 6.2 and HLSL Version [-HV] is >= hlsl2018, but shader model is '%0' and HLSL Version is '%1'">;
 def err_drv_cc1_hlsl_spirv_fnative_half_type_option_invalid: Error<
-  "fnative-half-type option only valid when hlsl language standard version is >= 2021">;
+  "'-fnative-half-type' option only valid when HLSL language standard version is >= 2018, but language standard version is '%0'">;
 def err_drv_hlsl_bad_shader_unsupported : Error<
   "%select{shader model|Vulkan environment|shader stage}0 '%1' in target '%2' is invalid for HLSL code generation">;
 def warn_drv_dxc_missing_dxv : Warning<"dxv not found. "

--- a/clang/include/clang/Basic/DiagnosticDriverKinds.td
+++ b/clang/include/clang/Basic/DiagnosticDriverKinds.td
@@ -753,10 +753,8 @@ def err_drv_hlsl_unsupported_target : Error<
   "HLSL code generation is unsupported for target '%0'">;
 def err_drv_hlsl_bad_shader_required_in_target : Error<
   "%select{shader model|Vulkan environment|shader stage}0 is required as %select{OS|environment}1 in target '%2' for HLSL code generation">;
-def err_drv_dxc_enable_16bit_types_option_invalid: Error<
-  "'-enable-16bit-types' option only valid when target shader model [-T] is >= 6.2 and HLSL Version [-HV] is >= hlsl2018, but shader model is '%0' and HLSL Version is '%1'">;
-def err_drv_cc1_hlsl_spirv_fnative_half_type_option_invalid: Error<
-  "'-fnative-half-type' option only valid when HLSL language standard version is >= 2018, but language standard version is '%0'">;
+def err_drv_hlsl_16bit_types_unsupported: Error<
+  "'%0' option requires target HLSL Version >= 2018 and %select{|shader model >= 6.2}1, but HLSL Version is '%2'" %select{|and shader model is '%3'}1>;
 def err_drv_hlsl_bad_shader_unsupported : Error<
   "%select{shader model|Vulkan environment|shader stage}0 '%1' in target '%2' is invalid for HLSL code generation">;
 def warn_drv_dxc_missing_dxv : Warning<"dxv not found. "

--- a/clang/include/clang/Basic/DiagnosticDriverKinds.td
+++ b/clang/include/clang/Basic/DiagnosticDriverKinds.td
@@ -753,8 +753,8 @@ def err_drv_hlsl_unsupported_target : Error<
   "HLSL code generation is unsupported for target '%0'">;
 def err_drv_hlsl_bad_shader_required_in_target : Error<
   "%select{shader model|Vulkan environment|shader stage}0 is required as %select{OS|environment}1 in target '%2' for HLSL code generation">;
-def err_drv_hlsl_16bit_types_unsupported: Error<
-  "'%0' option requires target HLSL Version >= 2018 and %select{|shader model >= 6.2}1, but HLSL Version is '%2'" %select{|and shader model is '%3'}1>;
+def err_drv_hlsl_16bit_types_unsupported: Error<  
+  "'%0' option requires target HLSL Version >= 2018%select{| and shader model >= 6.2}1, but HLSL Version is '%2'%select{| and shader model is '%3'}1">;
 def err_drv_hlsl_bad_shader_unsupported : Error<
   "%select{shader model|Vulkan environment|shader stage}0 '%1' in target '%2' is invalid for HLSL code generation">;
 def warn_drv_dxc_missing_dxv : Warning<"dxv not found. "

--- a/clang/include/clang/Basic/DiagnosticDriverKinds.td
+++ b/clang/include/clang/Basic/DiagnosticDriverKinds.td
@@ -754,7 +754,7 @@ def err_drv_hlsl_unsupported_target : Error<
 def err_drv_hlsl_bad_shader_required_in_target : Error<
   "%select{shader model|Vulkan environment|shader stage}0 is required as %select{OS|environment}1 in target '%2' for HLSL code generation">;
 def err_drv_hlsl_enable_16bit_types_option_invalid: Error<
-  "enable_16bit_types option only valid when target shader model [-T] is >= 6.2 and Hlsl Version [-HV] is >= 2021">;
+  "enable_16bit_types option only valid when target shader model [-T] is >= 6.2 and HLSL Version [-HV] is >= 2021">;
 def err_drv_hlsl_bad_shader_unsupported : Error<
   "%select{shader model|Vulkan environment|shader stage}0 '%1' in target '%2' is invalid for HLSL code generation">;
 def warn_drv_dxc_missing_dxv : Warning<"dxv not found. "

--- a/clang/lib/Driver/ToolChains/HLSL.cpp
+++ b/clang/lib/Driver/ToolChains/HLSL.cpp
@@ -303,6 +303,8 @@ HLSLToolChain::TranslateArgs(const DerivedArgList &Args, StringRef BoundArch,
     }
 
     if (!parsedTargetProfile.has_value())
+      // This should be unreachable, target profile validation happens
+      // before this point.
       return DAL;
     else {
       if (parsedTargetProfile.value().Major < 6 ||

--- a/clang/lib/Driver/ToolChains/HLSL.cpp
+++ b/clang/lib/Driver/ToolChains/HLSL.cpp
@@ -66,48 +66,15 @@ bool isLegalShaderModel(Triple &T) {
   return false;
 }
 
-struct ShaderModel {
-  StringRef TargetKind;
-  unsigned Major;
-  unsigned Minor;
-  bool OfflineLibMinor = false;
-};
-
-std::optional<ShaderModel> GetShaderModelFromString(StringRef Profile) {
+std::optional<std::string> tryParseProfile(StringRef Profile) {
+  // [ps|vs|gs|hs|ds|cs|ms|as]_[major]_[minor]
   SmallVector<StringRef, 3> Parts;
   Profile.split(Parts, "_");
   if (Parts.size() != 3)
     return std::nullopt;
 
-  unsigned long long Major = 0;
-  if (llvm::getAsUnsignedInteger(Parts[1], 0, Major))
-    return std::nullopt;
-
-  unsigned long long Minor = 0;
-  bool isOfflineLibMinor = false;
-  if (Parts[0] == "lib" && Parts[2] == "x")
-    isOfflineLibMinor = true;
-  else if (llvm::getAsUnsignedInteger(Parts[2], 0, Minor))
-    return std::nullopt;
-
-  ShaderModel ret;
-  ret.TargetKind = Parts[0];
-  ret.Major = Major;
-  ret.Minor = Minor;
-  ret.OfflineLibMinor = isOfflineLibMinor;
-
-  return ret;
-}
-
-std::optional<std::string> tryParseProfile(StringRef Profile) {
-  std::optional<ShaderModel> SM = GetShaderModelFromString(Profile);
-  if (!SM.has_value()) {
-    return std::nullopt;
-  }
-  // [ps|vs|gs|hs|ds|cs|ms|as]_[major]_[minor]
-
   Triple::EnvironmentType Kind =
-      StringSwitch<Triple::EnvironmentType>(SM.value().TargetKind)
+      StringSwitch<Triple::EnvironmentType>(Parts[0])
           .Case("ps", Triple::EnvironmentType::Pixel)
           .Case("vs", Triple::EnvironmentType::Vertex)
           .Case("gs", Triple::EnvironmentType::Geometry)
@@ -121,11 +88,21 @@ std::optional<std::string> tryParseProfile(StringRef Profile) {
   if (Kind == Triple::EnvironmentType::UnknownEnvironment)
     return std::nullopt;
 
+  unsigned long long Major = 0;
+  if (llvm::getAsUnsignedInteger(Parts[1], 0, Major))
+    return std::nullopt;
+
+  unsigned long long Minor = 0;
+  if (Parts[2] == "x" && Kind == Triple::EnvironmentType::Library)
+    Minor = OfflineLibMinor;
+  else if (llvm::getAsUnsignedInteger(Parts[2], 0, Minor))
+    return std::nullopt;
+
   // dxil-unknown-shadermodel-hull
   llvm::Triple T;
   T.setArch(Triple::ArchType::dxil);
   T.setOSName(Triple::getOSTypeName(Triple::OSType::ShaderModel).str() +
-              VersionTuple(SM.value().Major, SM.value().Minor).getAsString());
+              VersionTuple(Major, Minor).getAsString());
   T.setEnvironment(Kind);
   if (isLegalShaderModel(T))
     return T.getTriple();
@@ -279,43 +256,6 @@ HLSLToolChain::TranslateArgs(const DerivedArgList &Args, StringRef BoundArch,
     DAL->AddJoinedArg(nullptr, Opts.getOption(options::OPT_O), "3");
   }
 
-  if (DAL->hasArg(options::OPT_fnative_half_type)) {
-
-    bool HVArgIsValid = true;
-    bool TPArgIsValid = true;
-
-    const StringRef HVArg =
-        DAL->getLastArgValue(options::OPT_std_EQ, "hlsl2021");
-
-    const StringRef TPArg =
-        DAL->getLastArgValue(options::OPT_target_profile, "");
-    std::optional<ShaderModel> parsedTargetProfile =
-        GetShaderModelFromString(TPArg);
-
-    unsigned long long HV_year;
-    StringRef HV_year_str = HVArg.drop_front(4);
-    if (HV_year_str != "202x") {
-      llvm::getAsUnsignedInteger(HV_year_str, 0, HV_year);
-      if (HV_year < 2021)
-        HVArgIsValid = false;
-    }
-
-    if (!parsedTargetProfile.has_value())
-      // This should be unreachable, target profile validation happens
-      // before this point.
-      return DAL;
-    else {
-      if (parsedTargetProfile.value().Major < 6 ||
-          (parsedTargetProfile.value().Major == 6 &&
-           parsedTargetProfile.value().Minor < 2))
-        TPArgIsValid = false;
-    }
-
-    // if the HLSL Version is not at least 2021, or the shader model is not at
-    // least 6.2, then enable-16bit-types is an invalid flag.
-    if (!(HVArgIsValid && TPArgIsValid))
-      getDriver().Diag(diag::err_drv_hlsl_enable_16bit_types_option_invalid);
-  }
   return DAL;
 }
 

--- a/clang/lib/Driver/ToolChains/HLSL.cpp
+++ b/clang/lib/Driver/ToolChains/HLSL.cpp
@@ -304,6 +304,8 @@ HLSLToolChain::TranslateArgs(const DerivedArgList &Args, StringRef BoundArch,
     }
 
     if (!parsedTargetProfile.has_value())
+      // This should be unreachable, target profile validation happens
+      // before this point.
       return DAL;
     else {
       if (parsedTargetProfile.value().Major < 6 ||

--- a/clang/lib/Driver/ToolChains/HLSL.cpp
+++ b/clang/lib/Driver/ToolChains/HLSL.cpp
@@ -279,9 +279,6 @@ HLSLToolChain::TranslateArgs(const DerivedArgList &Args, StringRef BoundArch,
     DAL->AddJoinedArg(nullptr, Opts.getOption(options::OPT_O), "3");
   }
 
-  // FIXME: add validation for enable_16bit_types should be after HLSL 2018 and
-  // shader model 6.2.
-  // See: https://github.com/llvm/llvm-project/issues/57876
   if (DAL->hasArg(options::OPT_fnative_half_type)) {
 
     bool HVArgIsValid = true;

--- a/clang/lib/Driver/ToolChains/HLSL.cpp
+++ b/clang/lib/Driver/ToolChains/HLSL.cpp
@@ -278,9 +278,7 @@ HLSLToolChain::TranslateArgs(const DerivedArgList &Args, StringRef BoundArch,
   if (!DAL->hasArg(options::OPT_O_Group)) {
     DAL->AddJoinedArg(nullptr, Opts.getOption(options::OPT_O), "3");
   }
-  // FIXME: add validation for enable_16bit_types should be after HLSL 2018 and
-  // shader model 6.2.
-  // See: https://github.com/llvm/llvm-project/issues/57876
+
   if (DAL->hasArg(options::OPT_fnative_half_type)) {
 
     bool HVArgIsValid = true;

--- a/clang/lib/Driver/ToolChains/HLSL.cpp
+++ b/clang/lib/Driver/ToolChains/HLSL.cpp
@@ -66,15 +66,48 @@ bool isLegalShaderModel(Triple &T) {
   return false;
 }
 
-std::optional<std::string> tryParseProfile(StringRef Profile) {
-  // [ps|vs|gs|hs|ds|cs|ms|as]_[major]_[minor]
+struct ShaderModel {
+  StringRef TargetKind;
+  unsigned Major;
+  unsigned Minor;
+  bool OfflineLibMinor = false;
+};
+
+std::optional<ShaderModel> GetShaderModelFromString(StringRef Profile) {
   SmallVector<StringRef, 3> Parts;
   Profile.split(Parts, "_");
   if (Parts.size() != 3)
     return std::nullopt;
 
+  unsigned long long Major = 0;
+  if (llvm::getAsUnsignedInteger(Parts[1], 0, Major))
+    return std::nullopt;
+
+  unsigned long long Minor = 0;
+  bool isOfflineLibMinor = false;
+  if (Parts[0] == "lib" && Parts[2] == "x")
+    isOfflineLibMinor = true;
+  else if (llvm::getAsUnsignedInteger(Parts[2], 0, Minor))
+    return std::nullopt;
+
+  ShaderModel ret;
+  ret.TargetKind = Parts[0];
+  ret.Major = Major;
+  ret.Minor = Minor;
+  ret.OfflineLibMinor = isOfflineLibMinor;
+
+  return ret;
+}
+
+std::optional<std::string> tryParseProfile(StringRef Profile) {
+  std::optional<ShaderModel> SM = GetShaderModelFromString(Profile);
+  if (!SM.has_value()) {
+    return std::nullopt;
+  }
+  // [ps|vs|gs|hs|ds|cs|ms|as]_[major]_[minor]
+
   Triple::EnvironmentType Kind =
-      StringSwitch<Triple::EnvironmentType>(Parts[0])
+      StringSwitch<Triple::EnvironmentType>(SM.value().TargetKind)
           .Case("ps", Triple::EnvironmentType::Pixel)
           .Case("vs", Triple::EnvironmentType::Vertex)
           .Case("gs", Triple::EnvironmentType::Geometry)
@@ -88,21 +121,11 @@ std::optional<std::string> tryParseProfile(StringRef Profile) {
   if (Kind == Triple::EnvironmentType::UnknownEnvironment)
     return std::nullopt;
 
-  unsigned long long Major = 0;
-  if (llvm::getAsUnsignedInteger(Parts[1], 0, Major))
-    return std::nullopt;
-
-  unsigned long long Minor = 0;
-  if (Parts[2] == "x" && Kind == Triple::EnvironmentType::Library)
-    Minor = OfflineLibMinor;
-  else if (llvm::getAsUnsignedInteger(Parts[2], 0, Minor))
-    return std::nullopt;
-
   // dxil-unknown-shadermodel-hull
   llvm::Triple T;
   T.setArch(Triple::ArchType::dxil);
   T.setOSName(Triple::getOSTypeName(Triple::OSType::ShaderModel).str() +
-              VersionTuple(Major, Minor).getAsString());
+              VersionTuple(SM.value().Major, SM.value().Minor).getAsString());
   T.setEnvironment(Kind);
   if (isLegalShaderModel(T))
     return T.getTriple();
@@ -256,6 +279,44 @@ HLSLToolChain::TranslateArgs(const DerivedArgList &Args, StringRef BoundArch,
     DAL->AddJoinedArg(nullptr, Opts.getOption(options::OPT_O), "3");
   }
 
+  // FIXME: add validation for enable_16bit_types should be after HLSL 2018 and
+  // shader model 6.2.
+  // See: https://github.com/llvm/llvm-project/issues/57876
+  if (DAL->hasArg(options::OPT_fnative_half_type)) {
+
+    bool HVArgIsValid = true;
+    bool TPArgIsValid = true;
+
+    const StringRef HVArg =
+        DAL->getLastArgValue(options::OPT_std_EQ, "hlsl2021");
+
+    const StringRef TPArg =
+        DAL->getLastArgValue(options::OPT_target_profile, "");
+    std::optional<ShaderModel> parsedTargetProfile =
+        GetShaderModelFromString(TPArg);
+
+    unsigned long long HV_year;
+    StringRef HV_year_str = HVArg.drop_front(4);
+    if (HV_year_str != "202x") {
+      llvm::getAsUnsignedInteger(HV_year_str, 0, HV_year);
+      if (HV_year < 2021)
+        HVArgIsValid = false;
+    }
+
+    if (!parsedTargetProfile.has_value())
+      return DAL;
+    else {
+      if (parsedTargetProfile.value().Major < 6 ||
+          (parsedTargetProfile.value().Major == 6 &&
+           parsedTargetProfile.value().Minor < 2))
+        TPArgIsValid = false;
+    }
+
+    // if the HLSL Version is not at least 2021, or the shader model is not at
+    // least 6.2, then enable-16bit-types is an invalid flag.
+    if (!(HVArgIsValid && TPArgIsValid))
+      getDriver().Diag(diag::err_drv_hlsl_enable_16bit_types_option_invalid);
+  }
   return DAL;
 }
 

--- a/clang/lib/Frontend/CompilerInvocation.cpp
+++ b/clang/lib/Frontend/CompilerInvocation.cpp
@@ -4292,6 +4292,18 @@ bool CompilerInvocation::ParseLangArgs(LangOptions &Opts, ArgList &Args,
       } else {
         llvm_unreachable("expected DXIL or SPIR-V target");
       }
+      // validate that if fnative-half-type is given, that
+      // the language standard is at least hlsl2021, and that
+      // the target shader model is at least 6.2
+      if (Args.getLastArg(OPT_fnative_half_type)) {
+        bool LangStdArgIsValid = Opts.LangStd >= LangStandard::lang_hlsl2021;
+        bool TPArgIsValid = T.getOSVersion() >= VersionTuple(6, 2);
+
+        // if the HLSL Version is not at least 2021, or the shader model is not
+        // at least 6.2, then enable-16bit-types is an invalid flag.
+        if (!(LangStdArgIsValid && TPArgIsValid))
+          Diags.Report(diag::err_drv_hlsl_enable_16bit_types_option_invalid);
+      }
     } else
       Diags.Report(diag::err_drv_hlsl_unsupported_target) << T.str();
   }

--- a/clang/lib/Frontend/CompilerInvocation.cpp
+++ b/clang/lib/Frontend/CompilerInvocation.cpp
@@ -4305,18 +4305,6 @@ bool CompilerInvocation::ParseLangArgs(LangOptions &Opts, ArgList &Args,
       } else {
         llvm_unreachable("expected DXIL or SPIR-V target");
       }
-      // validate that if fnative-half-type is given, that
-      // the language standard is at least hlsl2021, and that
-      // the target shader model is at least 6.2
-      if (Args.getLastArg(OPT_fnative_half_type)) {
-        bool LangStdArgIsValid = Opts.LangStd >= LangStandard::lang_hlsl2021;
-        bool TPArgIsValid = T.getOSVersion() >= VersionTuple(6, 2);
-
-        // if the HLSL Version is not at least 2021, or the shader model is not
-        // at least 6.2, then enable-16bit-types is an invalid flag.
-        if (!(LangStdArgIsValid && TPArgIsValid))
-          Diags.Report(diag::err_drv_hlsl_enable_16bit_types_option_invalid);
-      }
     } else
       Diags.Report(diag::err_drv_hlsl_unsupported_target) << T.str();
   }

--- a/clang/lib/Frontend/CompilerInvocation.cpp
+++ b/clang/lib/Frontend/CompilerInvocation.cpp
@@ -4297,6 +4297,11 @@ bool CompilerInvocation::ParseLangArgs(LangOptions &Opts, ArgList &Args,
           Diags.Report(diag::err_drv_hlsl_bad_shader_unsupported)
               << VulkanEnv << T.getOSName() << T.str();
         }
+        if (Args.getLastArg(OPT_fnative_half_type)) {
+          if (!(Opts.LangStd >= LangStandard::lang_hlsl2021))
+            Diags.Report(diag::err_drv_hlsl_bad_shader_unsupported)
+                << VulkanEnv << T.getOSName() << T.str();
+        }
       } else {
         llvm_unreachable("expected DXIL or SPIR-V target");
       }

--- a/clang/lib/Frontend/CompilerInvocation.cpp
+++ b/clang/lib/Frontend/CompilerInvocation.cpp
@@ -4290,11 +4290,11 @@ bool CompilerInvocation::ParseLangArgs(LangOptions &Opts, ArgList &Args,
         if (Args.getLastArg(OPT_fnative_half_type)) {
           const LangStandard &Std =
               LangStandard::getLangStandardForKind(Opts.LangStd);
-
           if (!(Opts.LangStd >= LangStandard::lang_hlsl2018 &&
                 T.getOSVersion() >= VersionTuple(6, 2)))
-            Diags.Report(diag::err_drv_dxc_enable_16bit_types_option_invalid)
-                << T.getOSVersion().getAsString() << Std.getName();
+            Diags.Report(diag::err_drv_hlsl_16bit_types_unsupported)
+                << "-enable-16bit-types" << true << Std.getName()
+                << T.getOSVersion().getAsString();
         }
       } else if (T.isSPIRVLogical()) {
         if (!T.isVulkanOS() || T.getVulkanVersion() == VersionTuple(0)) {
@@ -4305,9 +4305,9 @@ bool CompilerInvocation::ParseLangArgs(LangOptions &Opts, ArgList &Args,
           const LangStandard &Std =
               LangStandard::getLangStandardForKind(Opts.LangStd);
           if (!(Opts.LangStd >= LangStandard::lang_hlsl2018))
-            Diags.Report(
-                diag::err_drv_cc1_hlsl_spirv_fnative_half_type_option_invalid)
-                << Std.getName();
+            Diags.Report(diag::err_drv_hlsl_16bit_types_unsupported)
+                << "-fnative-half-type" << false << Std.getName()
+                << T.getOSVersion().getAsString();
         }
       } else {
         llvm_unreachable("expected DXIL or SPIR-V target");

--- a/clang/lib/Frontend/CompilerInvocation.cpp
+++ b/clang/lib/Frontend/CompilerInvocation.cpp
@@ -4305,6 +4305,18 @@ bool CompilerInvocation::ParseLangArgs(LangOptions &Opts, ArgList &Args,
       } else {
         llvm_unreachable("expected DXIL or SPIR-V target");
       }
+      // validate that if fnative-half-type is given, that
+      // the language standard is at least hlsl2021, and that
+      // the target shader model is at least 6.2
+      if (Args.getLastArg(OPT_fnative_half_type)) {
+        bool LangStdArgIsValid = Opts.LangStd >= LangStandard::lang_hlsl2021;
+        bool TPArgIsValid = T.getOSVersion() >= VersionTuple(6, 2);
+
+        // if the HLSL Version is not at least 2021, or the shader model is not
+        // at least 6.2, then enable-16bit-types is an invalid flag.
+        if (!(LangStdArgIsValid && TPArgIsValid))
+          Diags.Report(diag::err_drv_hlsl_enable_16bit_types_option_invalid);
+      }
     } else
       Diags.Report(diag::err_drv_hlsl_unsupported_target) << T.str();
   }

--- a/clang/lib/Frontend/CompilerInvocation.cpp
+++ b/clang/lib/Frontend/CompilerInvocation.cpp
@@ -4284,13 +4284,17 @@ bool CompilerInvocation::ParseLangArgs(LangOptions &Opts, ArgList &Args,
           Diags.Report(diag::err_drv_hlsl_bad_shader_unsupported)
               << ShaderModel << T.getOSName() << T.str();
         }
-        // validate that if fnative-half-type is given, that
-        // the language standard is at least hlsl2021, and that
-        // the target shader model is at least 6.2
+        // Validate that if fnative-half-type is given, that
+        // the language standard is at least hlsl2018, and that
+        // the target shader model is at least 6.2.
         if (Args.getLastArg(OPT_fnative_half_type)) {
-          if (!(Opts.LangStd >= LangStandard::lang_hlsl2021 &&
+          const LangStandard &Std =
+              LangStandard::getLangStandardForKind(Opts.LangStd);
+
+          if (!(Opts.LangStd >= LangStandard::lang_hlsl2018 &&
                 T.getOSVersion() >= VersionTuple(6, 2)))
-            Diags.Report(diag::err_drv_dxc_enable_16bit_types_option_invalid);
+            Diags.Report(diag::err_drv_dxc_enable_16bit_types_option_invalid)
+                << T.getOSVersion().getAsString() << Std.getName();
         }
       } else if (T.isSPIRVLogical()) {
         if (!T.isVulkanOS() || T.getVulkanVersion() == VersionTuple(0)) {
@@ -4298,10 +4302,12 @@ bool CompilerInvocation::ParseLangArgs(LangOptions &Opts, ArgList &Args,
               << VulkanEnv << T.getOSName() << T.str();
         }
         if (Args.getLastArg(OPT_fnative_half_type)) {
-          if (!(Opts.LangStd >= LangStandard::lang_hlsl2021))
+          const LangStandard &Std =
+              LangStandard::getLangStandardForKind(Opts.LangStd);
+          if (!(Opts.LangStd >= LangStandard::lang_hlsl2018))
             Diags.Report(
                 diag::err_drv_cc1_hlsl_spirv_fnative_half_type_option_invalid)
-                << VulkanEnv << T.getOSName() << T.str();
+                << Std.getName();
         }
       } else {
         llvm_unreachable("expected DXIL or SPIR-V target");

--- a/clang/lib/Frontend/CompilerInvocation.cpp
+++ b/clang/lib/Frontend/CompilerInvocation.cpp
@@ -4290,7 +4290,7 @@ bool CompilerInvocation::ParseLangArgs(LangOptions &Opts, ArgList &Args,
         if (Args.getLastArg(OPT_fnative_half_type)) {
           if (!(Opts.LangStd >= LangStandard::lang_hlsl2021 &&
                 T.getOSVersion() >= VersionTuple(6, 2)))
-            Diags.Report(diag::err_drv_hlsl_enable_16bit_types_option_invalid);
+            Diags.Report(diag::err_drv_dxc_enable_16bit_types_option_invalid);
         }
       } else if (T.isSPIRVLogical()) {
         if (!T.isVulkanOS() || T.getVulkanVersion() == VersionTuple(0)) {
@@ -4299,7 +4299,8 @@ bool CompilerInvocation::ParseLangArgs(LangOptions &Opts, ArgList &Args,
         }
         if (Args.getLastArg(OPT_fnative_half_type)) {
           if (!(Opts.LangStd >= LangStandard::lang_hlsl2021))
-            Diags.Report(diag::err_drv_hlsl_bad_shader_unsupported)
+            Diags.Report(
+                diag::err_drv_cc1_hlsl_spirv_fnative_half_type_option_invalid)
                 << VulkanEnv << T.getOSName() << T.str();
         }
       } else {

--- a/clang/lib/Frontend/CompilerInvocation.cpp
+++ b/clang/lib/Frontend/CompilerInvocation.cpp
@@ -4306,8 +4306,7 @@ bool CompilerInvocation::ParseLangArgs(LangOptions &Opts, ArgList &Args,
               LangStandard::getLangStandardForKind(Opts.LangStd);
           if (!(Opts.LangStd >= LangStandard::lang_hlsl2018))
             Diags.Report(diag::err_drv_hlsl_16bit_types_unsupported)
-                << "-fnative-half-type" << false << Std.getName()
-                << T.getOSVersion().getAsString();
+                << "-fnative-half-type" << false << Std.getName();
         }
       } else {
         llvm_unreachable("expected DXIL or SPIR-V target");

--- a/clang/test/CodeGenHLSL/builtins/RWBuffer-elementtype.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/RWBuffer-elementtype.hlsl
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -triple dxil-pc-shadermodel6.0-compute -finclude-default-header -fnative-half-type -emit-llvm -o - %s | FileCheck %s
+// RUN: %clang_cc1 -triple dxil-pc-shadermodel6.2-compute -finclude-default-header -fnative-half-type -emit-llvm -o - %s | FileCheck %s
 
 RWBuffer<int16_t> BufI16;
 RWBuffer<uint16_t> BufU16;

--- a/clang/test/Options/enable_16bit_types_validation.hlsl
+++ b/clang/test/Options/enable_16bit_types_validation.hlsl
@@ -1,7 +1,7 @@
 // RUN: not %clang_dxc -enable-16bit-types -T cs_6_0 -HV 2016 %s 2>&1 -###   | FileCheck -check-prefix=both_invalid %s
 // RUN: not %clang_dxc -enable-16bit-types -T lib_6_4 -HV 2017 %s 2>&1 -###   | FileCheck -check-prefix=HV_invalid %s
 // RUN: not %clang_dxc -enable-16bit-types -T cs_6_0 /HV 2021 %s 2>&1 -###   | FileCheck -check-prefix=TP_invalid %s
-// RUN: %clang_dxc -enable-16bit-types -T lib_6_4 /HV 2021 %s 2>&1 -###   | FileCheck -check-prefix=valid %ss
+// RUN: %clang_dxc -enable-16bit-types -T lib_6_4 /HV 2021 %s 2>&1 -###   | FileCheck -check-prefix=valid %s
 
 
 // both_invalid: error: enable_16bit_types option only valid when target shader model [-T] is >= 6.2 and Hlsl Version [-HV] is >= 2021

--- a/clang/test/Options/enable_16bit_types_validation.hlsl
+++ b/clang/test/Options/enable_16bit_types_validation.hlsl
@@ -4,9 +4,9 @@
 // RUN: %clang_dxc -enable-16bit-types -T lib_6_4 /HV 2021 %s 2>&1 -###   | FileCheck -check-prefix=valid %s
 
 
-// both_invalid: error: enable_16bit_types option only valid when target shader model [-T] is >= 6.2 and HLSL Version [-HV] is >= 2021
-// HV_invalid: error: enable_16bit_types option only valid when target shader model [-T] is >= 6.2 and HLSL Version [-HV] is >= 2021
-// TP_invalid: error: enable_16bit_types option only valid when target shader model [-T] is >= 6.2 and HLSL Version [-HV] is >= 2021
+// both_invalid: error: enable-16bit-types option only valid when target shader model [-T] is >= 6.2 and HLSL Version [-HV] is >= 2021
+// HV_invalid: error: enable-16bit-types option only valid when target shader model [-T] is >= 6.2 and HLSL Version [-HV] is >= 2021
+// TP_invalid: error: enable-16bit-types option only valid when target shader model [-T] is >= 6.2 and HLSL Version [-HV] is >= 2021
 
 // valid: "dxil-unknown-shadermodel6.4-library"
 // valid-SAME: "-std=hlsl2021"

--- a/clang/test/Options/enable_16bit_types_validation.hlsl
+++ b/clang/test/Options/enable_16bit_types_validation.hlsl
@@ -4,9 +4,9 @@
 // RUN: %clang_dxc -enable-16bit-types -T lib_6_4 /HV 2021 %s 2>&1 -###   | FileCheck -check-prefix=valid %s
 
 
-// both_invalid: error: enable_16bit_types option only valid when target shader model [-T] is >= 6.2 and Hlsl Version [-HV] is >= 2021
-// HV_invalid: error: enable_16bit_types option only valid when target shader model [-T] is >= 6.2 and Hlsl Version [-HV] is >= 2021
-// TP_invalid: error: enable_16bit_types option only valid when target shader model [-T] is >= 6.2 and Hlsl Version [-HV] is >= 2021
+// both_invalid: error: enable_16bit_types option only valid when target shader model [-T] is >= 6.2 and HLSL Version [-HV] is >= 2021
+// HV_invalid: error: enable_16bit_types option only valid when target shader model [-T] is >= 6.2 and HLSL Version [-HV] is >= 2021
+// TP_invalid: error: enable_16bit_types option only valid when target shader model [-T] is >= 6.2 and HLSL Version [-HV] is >= 2021
 // valid: "dxil-unknown-shadermodel6.4-library"
 // valid-SAME: "-std=hlsl2021"
 // valid-SAME: "-fnative-half-type"

--- a/clang/test/Options/enable_16bit_types_validation.hlsl
+++ b/clang/test/Options/enable_16bit_types_validation.hlsl
@@ -3,10 +3,9 @@
 // RUN: not %clang_dxc -enable-16bit-types -T cs_6_0 /HV 2021 %s 2>&1  | FileCheck -check-prefix=TP_invalid %s
 // RUN: %clang_dxc -enable-16bit-types -T lib_6_4 /HV 2021 %s 2>&1 -###   | FileCheck -check-prefix=valid %s
 
-
-// both_invalid: error: '-enable-16bit-types' option only valid when target shader model [-T] is >= 6.2 and HLSL Version [-HV] is >= hlsl2018, but shader model is '6.0' and HLSL Version is 'hlsl2016'
-// HV_invalid: error: '-enable-16bit-types' option only valid when target shader model [-T] is >= 6.2 and HLSL Version [-HV] is >= hlsl2018, but shader model is '6.4' and HLSL Version is 'hlsl2017'
-// TP_invalid: error: '-enable-16bit-types' option only valid when target shader model [-T] is >= 6.2 and HLSL Version [-HV] is >= hlsl2018, but shader model is '6.0' and HLSL Version is 'hlsl2021'
+// both_invalid: error: '-enable-16bit-types' option requires target HLSL Version >= 2018 and shader model >= 6.2, but HLSL Version is 'hlsl2016' and shader model is '6.0'
+// HV_invalid: error: '-enable-16bit-types' option requires target HLSL Version >= 2018 and shader model >= 6.2, but HLSL Version is 'hlsl2017' and shader model is '6.4'
+// TP_invalid: error: '-enable-16bit-types' option requires target HLSL Version >= 2018 and shader model >= 6.2, but HLSL Version is 'hlsl2021' and shader model is '6.0'
 
 // valid: "dxil-unknown-shadermodel6.4-library"
 // valid-SAME: "-std=hlsl2021"

--- a/clang/test/Options/enable_16bit_types_validation.hlsl
+++ b/clang/test/Options/enable_16bit_types_validation.hlsl
@@ -1,0 +1,19 @@
+// RUN: not %clang_dxc -enable-16bit-types -T cs_6_0 -HV 2016 %s 2>&1 -###   | FileCheck -check-prefix=both_invalid %s
+// RUN: not %clang_dxc -enable-16bit-types -T lib_6_4 -HV 2017 %s 2>&1 -###   | FileCheck -check-prefix=HV_invalid %s
+// RUN: not %clang_dxc -enable-16bit-types -T cs_6_0 /HV 2021 %s 2>&1 -###   | FileCheck -check-prefix=TP_invalid %s
+// RUN: %clang_dxc -enable-16bit-types -T lib_6_4 /HV 2021 %s 2>&1 -###   | FileCheck -check-prefix=valid %ss
+
+
+// both_invalid: error: enable_16bit_types option only valid when target shader model [-T] is >= 6.2 and Hlsl Version [-HV] is >= 2021
+// HV_invalid: error: enable_16bit_types option only valid when target shader model [-T] is >= 6.2 and Hlsl Version [-HV] is >= 2021
+// TP_invalid: error: enable_16bit_types option only valid when target shader model [-T] is >= 6.2 and Hlsl Version [-HV] is >= 2021
+// valid: "dxil-unknown-shadermodel6.4-library"
+// valid-SAME: "-std=hlsl2021"
+// valid-SAME: "-fnative-half-type"
+
+[numthreads(1,1,1)]
+void main()
+{
+  return;
+}
+

--- a/clang/test/Options/enable_16bit_types_validation.hlsl
+++ b/clang/test/Options/enable_16bit_types_validation.hlsl
@@ -4,9 +4,9 @@
 // RUN: %clang_dxc -enable-16bit-types -T lib_6_4 /HV 2021 %s 2>&1 -###   | FileCheck -check-prefix=valid %s
 
 
-// both_invalid: error: enable-16bit-types option only valid when target shader model [-T] is >= 6.2 and HLSL Version [-HV] is >= 2021
-// HV_invalid: error: enable-16bit-types option only valid when target shader model [-T] is >= 6.2 and HLSL Version [-HV] is >= 2021
-// TP_invalid: error: enable-16bit-types option only valid when target shader model [-T] is >= 6.2 and HLSL Version [-HV] is >= 2021
+// both_invalid: error: '-enable-16bit-types' option only valid when target shader model [-T] is >= 6.2 and HLSL Version [-HV] is >= hlsl2018, but shader model is '6.0' and HLSL Version is 'hlsl2016'
+// HV_invalid: error: '-enable-16bit-types' option only valid when target shader model [-T] is >= 6.2 and HLSL Version [-HV] is >= hlsl2018, but shader model is '6.4' and HLSL Version is 'hlsl2017'
+// TP_invalid: error: '-enable-16bit-types' option only valid when target shader model [-T] is >= 6.2 and HLSL Version [-HV] is >= hlsl2018, but shader model is '6.0' and HLSL Version is 'hlsl2021'
 
 // valid: "dxil-unknown-shadermodel6.4-library"
 // valid-SAME: "-std=hlsl2021"

--- a/clang/test/Options/enable_16bit_types_validation.hlsl
+++ b/clang/test/Options/enable_16bit_types_validation.hlsl
@@ -1,6 +1,6 @@
-// RUN: not %clang_dxc -enable-16bit-types -T cs_6_0 -HV 2016 %s 2>&1 -###   | FileCheck -check-prefix=both_invalid %s
-// RUN: not %clang_dxc -enable-16bit-types -T lib_6_4 -HV 2017 %s 2>&1 -###   | FileCheck -check-prefix=HV_invalid %s
-// RUN: not %clang_dxc -enable-16bit-types -T cs_6_0 /HV 2021 %s 2>&1 -###   | FileCheck -check-prefix=TP_invalid %s
+// RUN: not %clang_dxc -enable-16bit-types -T cs_6_0 -HV 2016 %s 2>&1  | FileCheck -check-prefix=both_invalid %s
+// RUN: not %clang_dxc -enable-16bit-types -T lib_6_4 -HV 2017 %s 2>&1 | FileCheck -check-prefix=HV_invalid %s
+// RUN: not %clang_dxc -enable-16bit-types -T cs_6_0 /HV 2021 %s 2>&1  | FileCheck -check-prefix=TP_invalid %s
 // RUN: %clang_dxc -enable-16bit-types -T lib_6_4 /HV 2021 %s 2>&1 -###   | FileCheck -check-prefix=valid %s
 
 

--- a/clang/test/Options/enable_16bit_types_validation.hlsl
+++ b/clang/test/Options/enable_16bit_types_validation.hlsl
@@ -1,15 +1,21 @@
 // RUN: not %clang_dxc -enable-16bit-types -T cs_6_0 -HV 2016 %s 2>&1  | FileCheck -check-prefix=both_invalid %s
-// RUN: not %clang_dxc -enable-16bit-types -T lib_6_4 -HV 2017 %s 2>&1 | FileCheck -check-prefix=HV_invalid %s
+// RUN: not %clang_dxc -enable-16bit-types -T lib_6_4 -HV 2017 %s 2>&1 | FileCheck -check-prefix=HV_invalid_2017 %s
 // RUN: not %clang_dxc -enable-16bit-types -T cs_6_0 /HV 2021 %s 2>&1  | FileCheck -check-prefix=TP_invalid %s
-// RUN: %clang_dxc -enable-16bit-types -T lib_6_4 /HV 2021 %s 2>&1 -###   | FileCheck -check-prefix=valid %s
+// RUN: %clang_dxc -enable-16bit-types -T lib_6_4 /HV 2018 %s 2>&1 -###   | FileCheck -check-prefix=valid_2018 %s
+// RUN: %clang_dxc -enable-16bit-types -T lib_6_4 /HV 2021 %s 2>&1 -###   | FileCheck -check-prefix=valid_2021 %s
+
 
 // both_invalid: error: '-enable-16bit-types' option requires target HLSL Version >= 2018 and shader model >= 6.2, but HLSL Version is 'hlsl2016' and shader model is '6.0'
-// HV_invalid: error: '-enable-16bit-types' option requires target HLSL Version >= 2018 and shader model >= 6.2, but HLSL Version is 'hlsl2017' and shader model is '6.4'
+// HV_invalid_2017: error: '-enable-16bit-types' option requires target HLSL Version >= 2018 and shader model >= 6.2, but HLSL Version is 'hlsl2017' and shader model is '6.4'
 // TP_invalid: error: '-enable-16bit-types' option requires target HLSL Version >= 2018 and shader model >= 6.2, but HLSL Version is 'hlsl2021' and shader model is '6.0'
 
-// valid: "dxil-unknown-shadermodel6.4-library"
-// valid-SAME: "-std=hlsl2021"
-// valid-SAME: "-fnative-half-type"
+// valid_2021: "dxil-unknown-shadermodel6.4-library"
+// valid_2021-SAME: "-std=hlsl2021"
+// valid_2021-SAME: "-fnative-half-type"
+
+// valid_2018: "dxil-unknown-shadermodel6.4-library"
+// valid_2018-SAME: "-std=hlsl2018"
+// valid_2018-SAME: "-fnative-half-type"
 
 [numthreads(1,1,1)]
 void main()

--- a/clang/test/Options/enable_16bit_types_validation.hlsl
+++ b/clang/test/Options/enable_16bit_types_validation.hlsl
@@ -7,6 +7,7 @@
 // both_invalid: error: enable_16bit_types option only valid when target shader model [-T] is >= 6.2 and HLSL Version [-HV] is >= 2021
 // HV_invalid: error: enable_16bit_types option only valid when target shader model [-T] is >= 6.2 and HLSL Version [-HV] is >= 2021
 // TP_invalid: error: enable_16bit_types option only valid when target shader model [-T] is >= 6.2 and HLSL Version [-HV] is >= 2021
+
 // valid: "dxil-unknown-shadermodel6.4-library"
 // valid-SAME: "-std=hlsl2021"
 // valid-SAME: "-fnative-half-type"

--- a/clang/test/Options/enable_16bit_types_validation_spirv.hlsl
+++ b/clang/test/Options/enable_16bit_types_validation_spirv.hlsl
@@ -1,0 +1,10 @@
+// RUN: %clang_cc1 -internal-isystem D:\llvm-project\build\x64-Release\lib\clang\19\include -nostdsysteminc -triple spirv-vulkan-library -x hlsl -std=hlsl2016 -emit-llvm -disable-llvm-passes  -o - %s | FileCheck %s --check-prefix=SPIRV
+// kRUN: %clang_dxc -T lib_6_4 -HV 2016 -enable-16bit-types %s | FileCheck %s --check-prefix=SPIRV
+// SPIRV: error: enable_16bit_types option only valid when target shader model [-T] is >= 6.2 and HLSL Version [-HV] is >= 2021
+
+[numthreads(1,1,1)]
+void main()
+{
+  return;
+}
+

--- a/clang/test/Options/enable_16bit_types_validation_spirv.hlsl
+++ b/clang/test/Options/enable_16bit_types_validation_spirv.hlsl
@@ -1,7 +1,7 @@
 // RUN: not %clang_cc1 -internal-isystem D:\llvm-project\build\x64-Release\lib\clang\19\include -nostdsysteminc -triple spirv-vulkan-library -x hlsl -std=hlsl2016 -fnative-half-type -emit-llvm -disable-llvm-passes  -o - %s 2>&1 | FileCheck %s --check-prefix=SPIRV
 // RUN: %clang_cc1 -internal-isystem D:\llvm-project\build\x64-Release\lib\clang\19\include -nostdsysteminc -triple spirv-vulkan-library -x hlsl -std=hlsl2021 -fnative-half-type -emit-llvm -disable-llvm-passes  -o - %s 2>&1 | FileCheck %s --check-prefix=valid
 
-// SPIRV: error: fnative-half-type option only valid when hlsl language standard version is >= 2021
+// SPIRV: error: '-fnative-half-type' option only valid when HLSL language standard version is >= 2018, but language standard version is 'hlsl2016'
 
 // valid: "spirv-unknown-vulkan-library"
 // valid: define spir_func void @main() #0 {

--- a/clang/test/Options/enable_16bit_types_validation_spirv.hlsl
+++ b/clang/test/Options/enable_16bit_types_validation_spirv.hlsl
@@ -1,6 +1,10 @@
 // RUN: not %clang_cc1 -internal-isystem D:\llvm-project\build\x64-Release\lib\clang\19\include -nostdsysteminc -triple spirv-vulkan-library -x hlsl -std=hlsl2016 -fnative-half-type -emit-llvm -disable-llvm-passes  -o - %s 2>&1 | FileCheck %s --check-prefix=SPIRV
+// RUN: %clang_cc1 -internal-isystem D:\llvm-project\build\x64-Release\lib\clang\19\include -nostdsysteminc -triple spirv-vulkan-library -x hlsl -std=hlsl2021 -fnative-half-type -emit-llvm -disable-llvm-passes  -o - %s 2>&1 | FileCheck %s --check-prefix=valid
 
 // SPIRV: error: fnative-half-type option only valid when hlsl language standard version is >= 2021
+
+// valid: "spirv-unknown-vulkan-library"
+// valid: define spir_func void @main() #0 {
 
 [numthreads(1,1,1)]
 void main()

--- a/clang/test/Options/enable_16bit_types_validation_spirv.hlsl
+++ b/clang/test/Options/enable_16bit_types_validation_spirv.hlsl
@@ -1,7 +1,7 @@
 // RUN: not %clang_cc1 -internal-isystem D:\llvm-project\build\x64-Release\lib\clang\19\include -nostdsysteminc -triple spirv-vulkan-library -x hlsl -std=hlsl2016 -fnative-half-type -emit-llvm -disable-llvm-passes  -o - %s 2>&1 | FileCheck %s --check-prefix=SPIRV
 // RUN: %clang_cc1 -internal-isystem D:\llvm-project\build\x64-Release\lib\clang\19\include -nostdsysteminc -triple spirv-vulkan-library -x hlsl -std=hlsl2021 -fnative-half-type -emit-llvm -disable-llvm-passes  -o - %s 2>&1 | FileCheck %s --check-prefix=valid
 
-// SPIRV: error: '-fnative-half-type' option only valid when HLSL language standard version is >= 2018, but language standard version is 'hlsl2016'
+// SPIRV: error: '-fnative-half-type' option requires target HLSL Version >= 2018, but HLSL Version is 'hlsl2016'
 
 // valid: "spirv-unknown-vulkan-library"
 // valid: define spir_func void @main() #0 {

--- a/clang/test/Options/enable_16bit_types_validation_spirv.hlsl
+++ b/clang/test/Options/enable_16bit_types_validation_spirv.hlsl
@@ -1,6 +1,6 @@
-// RUN: %clang_cc1 -internal-isystem D:\llvm-project\build\x64-Release\lib\clang\19\include -nostdsysteminc -triple spirv-vulkan-library -x hlsl -std=hlsl2016 -emit-llvm -disable-llvm-passes  -o - %s | FileCheck %s --check-prefix=SPIRV
-// kRUN: %clang_dxc -T lib_6_4 -HV 2016 -enable-16bit-types %s | FileCheck %s --check-prefix=SPIRV
-// SPIRV: error: enable_16bit_types option only valid when target shader model [-T] is >= 6.2 and HLSL Version [-HV] is >= 2021
+// RUN: not %clang_cc1 -internal-isystem D:\llvm-project\build\x64-Release\lib\clang\19\include -nostdsysteminc -triple spirv-vulkan-library -x hlsl -std=hlsl2016 -fnative-half-type -emit-llvm -disable-llvm-passes  -o - %s 2>&1 | FileCheck %s --check-prefix=SPIRV
+
+// SPIRV: error: fnative-half-type option only valid when hlsl language standard version is >= 2021
 
 [numthreads(1,1,1)]
 void main()


### PR DESCRIPTION
Previously, the clang compiler with the dxc driver would accept the -enable-16bit-types flag without checking to see if the required conditions are met for proper processing of the flag. 
Specifically, -enable-16bit-types requires a shader model of at least 6.2 and an HLSL version of at least 2021.
This PR adds a validation check for these other options having the required values, and emits an error if these constraints are not met. 
Fixes #57876