### PR TITLE
[ADT] [NFC] Resolve a potential overload ambiguity in the ADT unit tests

### DIFF
--- a/llvm/unittests/ADT/APIntTest.cpp
+++ b/llvm/unittests/ADT/APIntTest.cpp
@@ -2918,7 +2918,7 @@ TEST(APIntTest, Average) {
   APInt A100(32, 100);
   APInt A101(32, 101);
   APInt A200(32, 200, false);
-  APInt ApUMax(32, UINT_MAX, false);
+  APInt ApUMax(32, static_cast<uint64_t>(UINT_MAX), false);
 
   EXPECT_EQ(APInt(32, 150), APIntOps::avgFloorU(A100, A200));
   EXPECT_EQ(APIntOps::RoundingUDiv(A100 + A200, A2, APInt::Rounding::DOWN),


### PR DESCRIPTION
Some compilers (ex. VS2019 and VS2022) report an overload resolution error with the APInt constructor.
Resolve the ambiguity with a static_cast.