### PR TITLE
[memprof] Add a version field to MemProf

### DIFF
--- a/llvm/include/llvm/ProfileData/InstrProf.h
+++ b/llvm/include/llvm/ProfileData/InstrProf.h
@@ -1165,6 +1165,9 @@ inline std::unique_ptr<Summary> allocSummary(uint32_t TotalSize) {
                                       Summary(TotalSize));
 }
 
+// Version 1: First version
+constexpr uint64_t MemProfVersion = 1;
+
 } // end namespace IndexedInstrProf
 
 namespace RawInstrProf {

--- a/llvm/lib/ProfileData/InstrProfReader.cpp
+++ b/llvm/lib/ProfileData/InstrProfReader.cpp
@@ -1230,6 +1230,15 @@ Error IndexedInstrProfReader::readHeader() {
             Header->MemProfOffset);
 
     const unsigned char *Ptr = Start + MemProfOffset;
+
+    const uint64_t MemProfVersion =
+        support::endian::readNext<uint64_t, llvm::endianness::little,
+                                  unaligned>(Ptr);
+    if (MemProfVersion != IndexedInstrProf::MemProfVersion) {
+      return make_error<InstrProfError>(instrprof_error::unsupported_version,
+                                        "unsupported MemProf version");
+    }
+
     // The value returned from RecordTableGenerator.Emit.
     const uint64_t RecordTableOffset =
         support::endian::readNext<uint64_t, llvm::endianness::little,

--- a/llvm/lib/ProfileData/InstrProfWriter.cpp
+++ b/llvm/lib/ProfileData/InstrProfWriter.cpp
@@ -529,6 +529,9 @@ Error InstrProfWriter::writeImpl(ProfOStream &OS) {
   uint64_t MemProfSectionStart = 0;
   if (static_cast<bool>(ProfileKind & InstrProfKind::MemProf)) {
     MemProfSectionStart = OS.tell();
+
+    OS.write(IndexedInstrProf::MemProfVersion);
+
     OS.write(0ULL); // Reserve space for the memprof record table offset.
     OS.write(0ULL); // Reserve space for the memprof frame payload offset.
     OS.write(0ULL); // Reserve space for the memprof frame table offset.
@@ -571,9 +574,9 @@ Error InstrProfWriter::writeImpl(ProfOStream &OS) {
     uint64_t FrameTableOffset = FrameTableGenerator.Emit(OS.OS, *FrameWriter);
 
     PatchItem PatchItems[] = {
-        {MemProfSectionStart, &RecordTableOffset, 1},
-        {MemProfSectionStart + sizeof(uint64_t), &FramePayloadOffset, 1},
-        {MemProfSectionStart + 2 * sizeof(uint64_t), &FrameTableOffset, 1},
+        {MemProfSectionStart + sizeof(uint64_t), &RecordTableOffset, 1},
+        {MemProfSectionStart + 2 * sizeof(uint64_t), &FramePayloadOffset, 1},
+        {MemProfSectionStart + 3 * sizeof(uint64_t), &FrameTableOffset, 1},
     };
     OS.patch(PatchItems);
   }


### PR DESCRIPTION
This patch adds a version field to the MemProf section of the indexed
profile format.  It adds no backward compatibility for now because
MemProf and PGHO are under active development.
