### PR TITLE
[bazel] Add workflows to label and assign bazel PRs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -108,3 +108,6 @@ clang/test/AST/Interp/ @tbaederr
 
 # BOLT
 /bolt/ @aaupov @maksfb @rafaelauler @ayermolo @dcci
+
+# Bazel build system.
+/utils/bazel/ @rupprecht

--- a/.github/new-prs-labeler.yml
+++ b/.github/new-prs-labeler.yml
@@ -933,3 +933,6 @@ openmp:libomp:
 
 openmp:libomptarget:
   - any: ['openmp/**', '!openmp/runtime/**']
+
+bazel:
+  - utils/bazel/**


### PR DESCRIPTION
Bazel PRs aren't being tagged or auto assigned, so they're easily missed, especially for those created by contributors w/o triage or commit access.

I'm putting myself as the default auto reviewer, but only for the purposes of making sure PRs don't get lost.