### PR TITLE
[clang] CTAD: Track template template type parameters that referenced in

### DIFF
--- a/clang/lib/Sema/SemaTemplate.cpp
+++ b/clang/lib/Sema/SemaTemplate.cpp
@@ -2719,6 +2719,12 @@ SmallVector<unsigned> TemplateParamsReferencedInTemplateArgumentList(
       return true;
     }
 
+    bool TraverseTemplateName(TemplateName Template) {
+      if (auto *TD = Template.getAsTemplateDecl())
+        MarkAppeared(TD);
+      return RecursiveASTVisitor::TraverseTemplateName(Template);
+    }
+
     void MarkAppeared(NamedDecl *ND) {
       if (TemplateParams.contains(ND))
         ReferencedTemplateParams.insert(ND);

--- a/clang/test/SemaCXX/cxx20-ctad-type-alias.cpp
+++ b/clang/test/SemaCXX/cxx20-ctad-type-alias.cpp
@@ -259,3 +259,19 @@ using Bar2 = Foo<K>; // expected-error {{extraneous template parameter list in a
 
 Bar2 b = 1; // expected-error {{no viable constructor or deduction guide for deduction of template arguments}}
 } // namespace test19
+
+// GH85385
+namespace test20 {
+template <template <typename> typename T>
+struct K {};
+
+template <typename U>
+class Foo {};
+
+// Verify that template template type parameter TTP is referenced/used in the
+// template arguments of the RHS.
+template <template<typename> typename TTP>
+using Bar = Foo<K<TTP>>; // expected-note {{candidate template ignored: could not match 'Foo<K<>>' against 'int'}}
+
+Bar s = 1; // expected-error {{no viable constructor or deduction guide for deduction of template arguments of}}
+}

--- a/clang/test/SemaCXX/cxx20-ctad-type-alias.cpp
+++ b/clang/test/SemaCXX/cxx20-ctad-type-alias.cpp
@@ -273,5 +273,9 @@ class Foo {};
 template <template<typename> typename TTP>
 using Bar = Foo<K<TTP>>; // expected-note {{candidate template ignored: could not match 'Foo<K<>>' against 'int'}}
 
+template <class T>
+class Container {};
+Bar t = Foo<K<Container>>();
+
 Bar s = 1; // expected-error {{no viable constructor or deduction guide for deduction of template arguments of}}
-}
+} // namespace test20


### PR DESCRIPTION
the template arguments of the RHS.

Fixes https://github.com/llvm/llvm-project/issues/85385.

The Finder was missing for this case, for the crash test, the template parameter TTP was incorrectly considered as not referenced/appeared in the template arguments of the right hand side of the alias template decl, thus the synthesized deduction decl doesn't contain this TTP in the template parameter list, but we have references in the declaration, thus it caused crashes.