### PR TITLE
[SLP] Compute a shuffle mask for SK_InsertSubvector

### DIFF
--- a/llvm/lib/Transforms/Vectorize/SLPVectorizer.cpp
+++ b/llvm/lib/Transforms/Vectorize/SLPVectorizer.cpp
@@ -4330,7 +4330,7 @@ BoUpSLP::LoadsState BoUpSLP::canVectorizeLoads(
             }
             SmallVector<int> ShuffleMask(VL.size());
             for (int Idx : seq<int>(0, VL.size()))
-              ShuffleMask[i] = i / VF == I ? VL.size() + i % VF : i;
+              ShuffleMask[Idx] = Idx / VF == I ? VL.size() + Idx % VF : Idx;
             VecLdCost +=
                 TTI.getShuffleCost(TTI ::SK_InsertSubvector, VecTy,
                                    ShuffleMask, CostKind, I * VF, SubVecTy);
@@ -7733,7 +7733,7 @@ class BoUpSLP::ShuffleCostEstimator : public BaseShuffleAnalysis {
           SmallVector<int> ShuffleMask(VL.size());
           for (int I = VF, E = VL.size(); I < E; I += VF) {
             for (int Idx : seq<int>(0, E))
-              ShuffleMask[i] = i / VF == I ? E + i % VF : i;
+              ShuffleMask[Idx] = Idx / VF == I ? E + Idx % VF : Idx;
             GatherCost += TTI.getShuffleCost(TTI::SK_InsertSubvector, VecTy,
                                              ShuffleMask, CostKind, I, LoadTy);
           }

--- a/llvm/lib/Transforms/Vectorize/SLPVectorizer.cpp
+++ b/llvm/lib/Transforms/Vectorize/SLPVectorizer.cpp
@@ -7732,7 +7732,7 @@ class BoUpSLP::ShuffleCostEstimator : public BaseShuffleAnalysis {
           // Add the cost for the subvectors insert.
           SmallVector<int> ShuffleMask(VL.size());
           for (int I = VF, E = VL.size(); I < E; I += VF) {
-            for (int i = 0; i < E; i++)
+            for (int Idx : seq<int>(0, E))
               ShuffleMask[i] = i / VF == I ? E + i % VF : i;
             GatherCost += TTI.getShuffleCost(TTI::SK_InsertSubvector, VecTy,
                                              ShuffleMask, CostKind, I, LoadTy);

--- a/llvm/lib/Transforms/Vectorize/SLPVectorizer.cpp
+++ b/llvm/lib/Transforms/Vectorize/SLPVectorizer.cpp
@@ -4329,7 +4329,7 @@ BoUpSLP::LoadsState BoUpSLP::canVectorizeLoads(
                   "Expected only consecutive, strided or masked gather loads.");
             }
             SmallVector<int> ShuffleMask(VL.size());
-            for (int i = 0; i < VL.size(); i++)
+            for (int Idx : seq<int>(0, VL.size()))
               ShuffleMask[i] = i / VF == I ? VL.size() + i % VF : i;
             VecLdCost +=
                 TTI.getShuffleCost(TTI ::SK_InsertSubvector, VecTy,

--- a/llvm/lib/Transforms/Vectorize/SLPVectorizer.cpp
+++ b/llvm/lib/Transforms/Vectorize/SLPVectorizer.cpp
@@ -4328,9 +4328,12 @@ BoUpSLP::LoadsState BoUpSLP::canVectorizeLoads(
               llvm_unreachable(
                   "Expected only consecutive, strided or masked gather loads.");
             }
+            SmallVector<int> ShuffleMask(VL.size());
+            for (int i = 0; i < VL.size(); i++)
+              ShuffleMask[i] = i / VF == I ? VL.size() + i % VF : i;
             VecLdCost +=
                 TTI.getShuffleCost(TTI ::SK_InsertSubvector, VecTy,
-                                   std::nullopt, CostKind, I * VF, SubVecTy);
+                                   ShuffleMask, CostKind, I * VF, SubVecTy);
           }
           // If masked gather cost is higher - better to vectorize, so
           // consider it as a gather node. It will be better estimated
@@ -7454,7 +7457,7 @@ getShuffleCost(const TargetTransformInfo &TTI, TTI::ShuffleKind Kind,
         Index + NumSrcElts <= static_cast<int>(Mask.size()))
       return TTI.getShuffleCost(
           TTI::SK_InsertSubvector,
-          FixedVectorType::get(Tp->getElementType(), Mask.size()), std::nullopt,
+          FixedVectorType::get(Tp->getElementType(), Mask.size()), Mask,
           TTI::TCK_RecipThroughput, Index, Tp);
   }
   return TTI.getShuffleCost(Kind, Tp, Mask, CostKind, Index, SubTp, Args);
@@ -7727,9 +7730,13 @@ class BoUpSLP::ShuffleCostEstimator : public BaseShuffleAnalysis {
         }
         if (NeedInsertSubvectorAnalysis) {
           // Add the cost for the subvectors insert.
-          for (int I = VF, E = VL.size(); I < E; I += VF)
+          SmallVector<int> ShuffleMask(VL.size());
+          for (int I = VF, E = VL.size(); I < E; I += VF) {
+            for (int i = 0; i < E; i++)
+              ShuffleMask[i] = i / VF == I ? E + i % VF : i;
             GatherCost += TTI.getShuffleCost(TTI::SK_InsertSubvector, VecTy,
-                                             std::nullopt, CostKind, I, LoadTy);
+                                             ShuffleMask, CostKind, I, LoadTy);
+          }
         }
         GatherCost -= ScalarsCost;
       }


### PR DESCRIPTION
This is the third of a series of small patches to compute shuffle masks for the couple of cases where we call getShuffleCost without one. My goal is to add an invariant that all calls to getShuffleCost for fixed length vectors have a mask.

After this change, there is one SK_InsertSubvector case left.  I excluded it from this patch just because I thought it worthy of individual attention and review.