### PR TITLE
Add ALLOW_RETRIES to flaky test dbg-record-roundtrip.ll

### DIFF
--- a/llvm/test/Bitcode/dbg-record-roundtrip.ll
+++ b/llvm/test/Bitcode/dbg-record-roundtrip.ll
@@ -20,7 +20,7 @@
 ;; NOTE2: Unfortunately, the above only stopped it occuring on my machine.
 ;; It failed again intermittently here:
 ;; https://lab.llvm.org/buildbot/#/builders/245/builds/21930
-;; Allow this test to run fail-over twice, until this strangeness is understood.
+;; Allow this test to fail-over twice, until this strangeness is understood.
 ; ALLOW_RETRIES: 2
 ; RUN: llvm-as %s --experimental-debuginfo-iterators=true --write-experimental-debuginfo-iterators-to-bitcode=true -o %t
 ; RUN: llvm-link %t %s --experimental-debuginfo-iterators=false -o /dev/null

--- a/llvm/test/Bitcode/dbg-record-roundtrip.ll
+++ b/llvm/test/Bitcode/dbg-record-roundtrip.ll
@@ -17,6 +17,11 @@
 ;; NOTE: This test fails intermittently on linux if the llvm-as output is piped
 ;; into llvm-link in the RUN lines below, unless the verify-uselistorder RUN
 ;; lines above are removed. Write to a temporary file to avoid that weirdness.
+;; NOTE2: Unfortunately, the above only stopped it occuring on my machine.
+;; It failed again intermittently here:
+;; https://lab.llvm.org/buildbot/#/builders/245/builds/21930
+;; Allow this test to run fail-over twice, until this strangeness is understood.
+; ALLOW_RETRIES: 2
 ; RUN: llvm-as %s --experimental-debuginfo-iterators=true --write-experimental-debuginfo-iterators-to-bitcode=true -o %t
 ; RUN: llvm-link %t %s --experimental-debuginfo-iterators=false -o /dev/null
 ; RUN: llvm-as %s --experimental-debuginfo-iterators=false -o %t


### PR DESCRIPTION
Something strange is happening in this test.

If the llvm-as output is piped into llvm-link in the final RUN lines then this test fails on my machine (1 in 200) using WSL2. If the verify-uselistorder RUN lines are removed then it doesn't fail on my machine (in 10,000+). If the llvm-as and llvm-link RUN lines mentioned at the start are removed then it doesn't fail on my machine (in 10,000+).

Writing the llvm-as output to a temporary file for llvm-link to read on those final RUN lines, the test doesn't fail on my machine (in 10,000+). But it _does_ fail on a bot: https://lab.llvm.org/buildbot/#/builders/245/builds/21930. So clearly my workaround doesn't solve the underlying problem (and I have no idea what that is).

Lit says the test fails with one of the tools (verify-uselistorder, by the looks of it, looking at the bot failure output ending with RUN line 5) exiting with code 74.

I added an `on_exit` hook into verify-uselistorder and changed main's `return 0` for `exit(0)`. I print the exit status in the `on_exit`, and it's always `0`, even when I catch the test failing.