### PR TITLE
[TTI] Add cover functions for costing build and explode vectors [nfc]

### DIFF
--- a/llvm/include/llvm/Analysis/TargetTransformInfo.h
+++ b/llvm/include/llvm/Analysis/TargetTransformInfo.h
@@ -871,6 +871,26 @@ public:
                                            bool Insert, bool Extract,
                                            TTI::TargetCostKind CostKind) const;
 
+  /// Estimate the cost of a build_vector of unknown elements at the indices
+  /// implied by the active lanes in DemandedElts.  The default implementation
+  /// will simply cost a series of insertelements, but some targets can do
+  /// significantly better.
+  InstructionCost getBuildVectorCost(VectorType *Ty,
+                                     const APInt &DemandedElts,
+                                     TTI::TargetCostKind CostKind) const {
+    return getScalarizationOverhead(Ty, DemandedElts, true, false, CostKind);
+  }
+
+  /// Estimate the cost of exploding a vector of unknown elements at the
+  /// indices implied by the active lanes in DemandedElts into individual
+  /// scalar registers.  The default implementation will simply cost a
+  /// series of extractelements, but some targets can do significantly better.
+  InstructionCost getExplodeVectorCost(VectorType *Ty,
+                                       const APInt &DemandedElts,
+                                       TTI::TargetCostKind CostKind) const {
+    return getScalarizationOverhead(Ty, DemandedElts, false, true, CostKind);
+  }
+
   /// Estimate the overhead of scalarizing an instructions unique
   /// non-constant operands. The (potentially vector) types to use for each of
   /// argument are passes via Tys.

--- a/llvm/lib/Transforms/Vectorize/SLPVectorizer.cpp
+++ b/llvm/lib/Transforms/Vectorize/SLPVectorizer.cpp
@@ -8715,9 +8715,7 @@ BoUpSLP::getEntryCost(const TreeEntry *E, ArrayRef<Value *> VectorizedVals,
     assert(Offset < NumElts && "Failed to find vector index offset");
 
     InstructionCost Cost = 0;
-    Cost -= TTI->getScalarizationOverhead(SrcVecTy, DemandedElts,
-                                          /*Insert*/ true, /*Extract*/ false,
-                                          CostKind);
+    Cost -= TTI->getBuildVectorCost(SrcVecTy, DemandedElts, CostKind);
 
     // First cost - resize to actual vector size if not identity shuffle or
     // need to shift the vector.
@@ -9816,9 +9814,9 @@ InstructionCost BoUpSLP::getTreeCost(ArrayRef<Value *> VectorizedVals) {
         MutableArrayRef(Vector.data(), Vector.size()), Base,
         [](const TreeEntry *E) { return E->getVectorFactor(); }, ResizeToVF,
         EstimateShufflesCost);
-    InstructionCost InsertCost = TTI->getScalarizationOverhead(
+    InstructionCost InsertCost = TTI->getBuildVectorCost(
         cast<FixedVectorType>(FirstUsers[I].first->getType()), DemandedElts[I],
-        /*Insert*/ true, /*Extract*/ false, TTI::TCK_RecipThroughput);
+        TTI::TCK_RecipThroughput);
     Cost -= InsertCost;
   }
 
@@ -10531,9 +10529,7 @@ InstructionCost BoUpSLP::getGatherCost(ArrayRef<Value *> VL,
     EstimateInsertCost(I, V);
   }
   if (ForPoisonSrc)
-    Cost =
-        TTI->getScalarizationOverhead(VecTy, ~ShuffledElements, /*Insert*/ true,
-                                      /*Extract*/ false, CostKind);
+    Cost = TTI->getBuildVectorCost(VecTy, ~ShuffledElements, CostKind);
   if (DuplicateNonConst)
     Cost +=
         TTI->getShuffleCost(TargetTransformInfo::SK_PermuteSingleSrc, VecTy);


### PR DESCRIPTION
This is just an API cleanup at the moment.  The newly added routines just proxy to the existing getScalarizationOverhead.  I think the diff speaks for itself in terms of code clarity.