### PR TITLE
[Driver,AArch64] Remove AArch32-specific -m[no-]unaligned-access

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -191,7 +191,7 @@ Removed Compiler Flags
 -------------------------
 
 - The ``-freroll-loops`` flag has been removed. It had no effect since Clang 13.
-- ``-m[no-]unaligned-access`` is removed for RISC-V and LoongArch.
+- ``-m[no-]unaligned-access`` is removed for AArch64, RISC-V, and LoongArch.
   ``-m[no-]strict-align``, also supported by GCC, should be used instead.
   (`#85350 <https://github.com/llvm/llvm-project/pull/85350>`_.)
 

--- a/clang/lib/Driver/ToolChains/Arch/AArch64.cpp
+++ b/clang/lib/Driver/ToolChains/Arch/AArch64.cpp
@@ -321,13 +321,8 @@ void aarch64::getAArch64TargetFeatures(const Driver &D,
     }
   }
 
-  if (Arg *A = Args.getLastArg(
-          options::OPT_mstrict_align, options::OPT_mno_strict_align,
-          options::OPT_mno_unaligned_access, options::OPT_munaligned_access)) {
-    if (A->getOption().matches(options::OPT_mstrict_align) ||
-        A->getOption().matches(options::OPT_mno_unaligned_access))
-      Features.push_back("+strict-align");
-  } else if (Triple.isOSOpenBSD())
+  if (Args.hasFlag(options::OPT_mstrict_align, options::OPT_mno_strict_align,
+                   Triple.isOSOpenBSD()))
     Features.push_back("+strict-align");
 
   if (Args.hasArg(options::OPT_ffixed_x1))

--- a/clang/test/Driver/arm-alignment.c
+++ b/clang/test/Driver/arm-alignment.c
@@ -37,18 +37,12 @@
 // RUN: %clang -target thumbv8m.base-none-gnueabi -### %s 2> %t
 // RUN: FileCheck --check-prefix CHECK-ALIGNED-ARM <%t %s
 
-// RUN: %clang --target=aarch64 -munaligned-access -### %s 2> %t
-// RUN: FileCheck --check-prefix=CHECK-UNALIGNED-AARCH64 < %t %s
-
-// RUN: %clang --target=aarch64 -mstrict-align -munaligned-access -### %s 2> %t
-// RUN: FileCheck --check-prefix=CHECK-UNALIGNED-AARCH64 < %t %s
-
-// RUN: %clang --target=aarch64 -mno-unaligned-access -munaligned-access -### %s 2> %t
-// RUN: FileCheck --check-prefix=CHECK-UNALIGNED-AARCH64 < %t %s
+// RUN: not %clang --target=aarch64 -munaligned-access -mno-unaligned-access -### %s 2>&1 | FileCheck %s --check-prefix=ERR
+// ERR: error: unsupported option '-munaligned-access' for target 'aarch64'
+// ERR: error: unsupported option '-mno-unaligned-access' for target 'aarch64'
 
 // CHECK-UNALIGNED-ARM-NOT: "-target-feature" "+strict-align"
 // CHECK-UNALIGNED-AARCH64-NOT: "-target-feature" "+strict-align"
-
 
 // RUN: %clang -target arm-none-gnueabi -mno-unaligned-access -### %s 2> %t
 // RUN: FileCheck --check-prefix=CHECK-ALIGNED-ARM < %t %s
@@ -83,19 +77,7 @@
 // RUN: %clang -target armv6m-netbsd-eabi -### %s 2> %t
 // RUN: FileCheck --check-prefix=CHECK-ALIGNED-ARM < %t %s
 
-// RUN: %clang --target=aarch64 -mno-unaligned-access -### %s 2> %t
-// RUN: FileCheck --check-prefix=CHECK-ALIGNED-AARCH64 < %t %s
-
 // RUN: %clang --target=aarch64 -mstrict-align -### %s 2> %t
-// RUN: FileCheck --check-prefix=CHECK-ALIGNED-AARCH64 < %t %s
-
-// RUN: %clang --target=aarch64 -munaligned-access -mno-unaligned-access -### %s 2> %t
-// RUN: FileCheck --check-prefix=CHECK-ALIGNED-AARCH64 < %t %s
-
-// RUN: %clang --target=aarch64 -munaligned-access -mstrict-align -### %s 2> %t
-// RUN: FileCheck --check-prefix=CHECK-ALIGNED-AARCH64 < %t %s
-
-// RUN: %clang --target=aarch64 -mkernel -mno-unaligned-access -### %s 2> %t
 // RUN: FileCheck --check-prefix=CHECK-ALIGNED-AARCH64 < %t %s
 
 // RUN: %clang -target aarch64-unknown-openbsd -### %s 2> %t


### PR DESCRIPTION
Follow-up to #85350: GCC only supports -m[no-]strict-align for AArch64
and rejects adding -m[no-]unaligned-access aliases. We inapropriated
supported -m[no-]unaligned-access as aliases for non-AArch64 due to an
early design issue (a146a48349c965932dcf304ffb8155b25307f245).

Since the behavior has been longtime for ARM, keep ARM unchanged but
tighten up the behavior for AArch64.
