### PR TITLE
[openmp] using h/w clock tick to measure time instead of gettimeofday…

### DIFF
--- a/openmp/runtime/src/kmp_lock.cpp
+++ b/openmp/runtime/src/kmp_lock.cpp
@@ -2644,11 +2644,14 @@ static void __kmp_set_drdpa_lock_flags(kmp_drdpa_lock_t *lck,
 #define __kmp_tsc() __kmp_hardware_timestamp()
 // Runtime's default backoff parameters
 kmp_backoff_t __kmp_spin_backoff_params = {1, 4096, 100};
+#elif KMP_ARCH_AARCH64 && KMP_OS_LINUX
+#define __kmp_tsc() __kmp_hardware_timestamp()
+kmp_backoff_t __kmp_spin_backoff_params = {1, 256, 100};
 #else
 // Use nanoseconds for other platforms
 extern kmp_uint64 __kmp_now_nsec();
-kmp_backoff_t __kmp_spin_backoff_params = {1, 256, 100};
 #define __kmp_tsc() __kmp_now_nsec()
+kmp_backoff_t __kmp_spin_backoff_params = {1, 256, 100};
 #endif
 
 // A useful predicate for dealing with timestamps that may wrap.

--- a/openmp/runtime/src/z_Linux_asm.S
+++ b/openmp/runtime/src/z_Linux_asm.S
@@ -1360,6 +1360,22 @@ KMP_LABEL(kmp_1):
 	DEBUG_INFO __kmp_invoke_microtask
 // -- End  __kmp_invoke_microtask
 
+#if KMP_OS_LINUX
+// kmp_uint64
+// __kmp_hardware_timestamp(void)
+// we load the current frequency of the system counter
+// then the system counter. frequency * counter gives
+// current time
+   PROC __kmp_hardware_timestamp
+   mrs x0, cntfrq_el0
+   mrs x1, cntvct_el0
+   mul x2, x1, x0
+   mov x30, x2
+   ret
+   DEBUG_INFO __kmp_hardware_timestamp
+// -- End  __kmp_hardware_timestamp
+#endif
+
 #endif /* (KMP_OS_LINUX || KMP_OS_DARWIN || KMP_OS_WINDOWS) && KMP_ARCH_AARCH64 */
 
 #if (KMP_OS_LINUX || KMP_OS_DARWIN || KMP_OS_WINDOWS) && KMP_ARCH_ARM


### PR DESCRIPTION
… on Linux/arm64.

using counter timer frequency register for that purpose, available in user mode.