### PR TITLE
[flang] Diagnose the impure procedure reference in finalization according to the rank of the entity

### DIFF
--- a/flang/include/flang/Semantics/tools.h
+++ b/flang/include/flang/Semantics/tools.h
@@ -180,7 +180,8 @@ const Symbol *IsFinalizable(const Symbol &,
 const Symbol *IsFinalizable(const DerivedTypeSpec &,
     std::set<const DerivedTypeSpec *> * = nullptr,
     bool withImpureFinalizer = false, std::optional<int> rank = std::nullopt);
-const Symbol *HasImpureFinal(const Symbol &, std::optional<int> rank = std::nullopt);
+const Symbol *HasImpureFinal(
+    const Symbol &, std::optional<int> rank = std::nullopt);
 // Is this type finalizable or does it contain any polymorphic allocatable
 // ultimate components?
 bool MayRequireFinalization(const DerivedTypeSpec &derived);

--- a/flang/include/flang/Semantics/tools.h
+++ b/flang/include/flang/Semantics/tools.h
@@ -180,7 +180,7 @@ const Symbol *IsFinalizable(const Symbol &,
 const Symbol *IsFinalizable(const DerivedTypeSpec &,
     std::set<const DerivedTypeSpec *> * = nullptr,
     bool withImpureFinalizer = false, std::optional<int> rank = std::nullopt);
-const Symbol *HasImpureFinal(const Symbol &);
+const Symbol *HasImpureFinal(const Symbol &, std::optional<int> rank = std::nullopt);
 // Is this type finalizable or does it contain any polymorphic allocatable
 // ultimate components?
 bool MayRequireFinalization(const DerivedTypeSpec &derived);

--- a/flang/lib/Semantics/check-do-forall.cpp
+++ b/flang/lib/Semantics/check-do-forall.cpp
@@ -220,8 +220,11 @@ public:
       if (MightDeallocatePolymorphic(*entity, DeallocateNonCoarray)) {
         SayDeallocateOfPolymorph(variable.GetSource(), *entity, reason);
       }
-      if (const Symbol * impure{HasImpureFinal(*entity)}) {
-        SayDeallocateWithImpureFinal(*entity, reason, *impure);
+      if (const auto *assignment{GetAssignment(stmt)}) {
+        const auto lhs{assignment->lhs};
+        if (const Symbol * impure{HasImpureFinal(*entity, lhs.Rank())}) {
+          SayDeallocateWithImpureFinal(*entity, reason, *impure);
+        }
       }
     }
     if (const auto *assignment{GetAssignment(stmt)}) {

--- a/flang/lib/Semantics/check-do-forall.cpp
+++ b/flang/lib/Semantics/check-do-forall.cpp
@@ -221,7 +221,7 @@ public:
         SayDeallocateOfPolymorph(variable.GetSource(), *entity, reason);
       }
       if (const auto *assignment{GetAssignment(stmt)}) {
-        const auto lhs{assignment->lhs};
+        const auto &lhs{assignment->lhs};
         if (const Symbol * impure{HasImpureFinal(*entity, lhs.Rank())}) {
           SayDeallocateWithImpureFinal(*entity, reason, *impure);
         }

--- a/flang/lib/Semantics/tools.cpp
+++ b/flang/lib/Semantics/tools.cpp
@@ -836,10 +836,7 @@ const Symbol *HasImpureFinal(const Symbol &original, std::optional<int> rank) {
           // finalizable assumed-rank not allowed (C839)
           return nullptr;
         } else {
-          int actualRank{symbol.Rank()};
-          if (rank) {
-            actualRank = rank.value();
-          }
+          int actualRank{rank.value_or(symbol.Rank())};
           return HasImpureFinal(*derived, actualRank);
         }
       }

--- a/flang/lib/Semantics/tools.cpp
+++ b/flang/lib/Semantics/tools.cpp
@@ -836,7 +836,7 @@ const Symbol *HasImpureFinal(const Symbol &original, std::optional<int> rank) {
           // finalizable assumed-rank not allowed (C839)
           return nullptr;
         } else {
-          int actualRank = symbol.Rank();
+          int actualRank{symbol.Rank()};
           if (rank) {
             actualRank = rank.value();
           }


### PR DESCRIPTION
Use the rank of the array section to determine which final procedure would be called in diagnosing whether that procedure is impure or not.