### PR TITLE
Revert "[libc] Match stdlib.h baremetal entrypoints with types"

### DIFF
--- a/libc/config/baremetal/api.td
+++ b/libc/config/baremetal/api.td
@@ -68,7 +68,7 @@ def StdlibAPI : PublicAPI<"stdlib.h"> {
     "size_t",
     "__bsearchcompare_t",
     "__qsortcompare_t",
-    "__qsortrcompare_t",
+    "__atexithandler_t",
   ];
 }
 


### PR DESCRIPTION
Reverts llvm/llvm-project#85030

This patch causes build failures when building runtimes for armv6m
```
FAILED: /b/s/w/ir/x/w/llvm_build/include/armv6m-unknown-eabi/stdlib.h 
cd /b/s/w/ir/x/w/llvm-llvm-project/libc/include && /b/s/w/ir/x/w/llvm_build/bin/libc-hdrgen -o /b/s/w/ir/x/w/llvm_build/include/armv6m-unknown-eabi/stdlib.h --header stdlib.h --def /b/s/w/ir/x/w/llvm-llvm-project/libc/include/stdlib.h.def -I /b/s/w/ir/x/w/llvm-llvm-project/libc --e=__assert_fail --e=isalnum --e=isalpha --e=isascii --e=isblank --e=iscntrl --e=isdigit --e=isgraph --e=islower --e=isprint --e=ispunct --e=isspace --e=isupper --e=isxdigit --e=toascii --e=tolower --e=toupper --e=__stack_chk_fail --e=errno --e=bcmp --e=bcopy --e=bzero --e=index --e=memccpy --e=memchr --e=memcmp --e=memcpy --e=memmem --e=memmove --e=mempcpy --e=memrchr --e=memset --e=memset_explicit --e=rindex --e=stpcpy --e=stpncpy --e=strcasecmp --e=strcasestr --e=strcat --e=strchr --e=strchrnul --e=strcmp --e=strcoll --e=strcpy --e=strcspn --e=strerror --e=strerror_r --e=strlcat --e=strlcpy --e=strlen --e=strncasecmp --e=strncat --e=strncmp --e=strncpy --e=strnlen --e=strpbrk --e=strrchr --e=strsep --e=strspn --e=strstr --e=strtok --e=strtok_r --e=strxfrm --e=imaxabs --e=imaxdiv --e=strtoimax --e=strtoumax --e=sprintf --e=snprintf --e=vsprintf --e=vsnprintf --e=stdc_leading_zeros_uc --e=stdc_leading_zeros_us --e=stdc_leading_zeros_ui --e=stdc_leading_zeros_ul --e=stdc_leading_zeros_ull --e=stdc_leading_ones_uc --e=stdc_leading_ones_us --e=stdc_leading_ones_ui --e=stdc_leading_ones_ul --e=stdc_leading_ones_ull --e=stdc_trailing_zeros_uc --e=stdc_trailing_zeros_us --e=stdc_trailing_zeros_ui --e=stdc_trailing_zeros_ul --e=stdc_trailing_zeros_ull --e=stdc_trailing_ones_uc --e=stdc_trailing_ones_us --e=stdc_trailing_ones_ui --e=stdc_trailing_ones_ul --e=stdc_trailing_ones_ull --e=stdc_first_leading_zero_uc --e=stdc_first_leading_zero_us --e=stdc_first_leading_zero_ui --e=stdc_first_leading_zero_ul --e=stdc_first_leading_zero_ull --e=stdc_first_leading_one_uc --e=stdc_first_leading_one_us --e=stdc_first_leading_one_ui --e=stdc_first_leading_one_ul --e=stdc_first_leading_one_ull --e=stdc_first_trailing_zero_uc --e=stdc_first_trailing_zero_us --e=stdc_first_trailing_zero_ui --e=stdc_first_trailing_zero_ul --e=stdc_first_trailing_zero_ull --e=stdc_first_trailing_one_uc --e=stdc_first_trailing_one_us --e=stdc_first_trailing_one_ui --e=stdc_first_trailing_one_ul --e=stdc_first_trailing_one_ull --e=stdc_count_zeros_uc --e=stdc_count_zeros_us --e=stdc_count_zeros_ui --e=stdc_count_zeros_ul --e=stdc_count_zeros_ull --e=stdc_count_ones_uc --e=stdc_count_ones_us --e=stdc_count_ones_ui --e=stdc_count_ones_ul --e=stdc_count_ones_ull --e=stdc_has_single_bit_uc --e=stdc_has_single_bit_us --e=stdc_has_single_bit_ui --e=stdc_has_single_bit_ul --e=stdc_has_single_bit_ull --e=stdc_bit_width_uc --e=stdc_bit_width_us --e=stdc_bit_width_ui --e=stdc_bit_width_ul --e=stdc_bit_width_ull --e=stdc_bit_floor_uc --e=stdc_bit_floor_us --e=stdc_bit_floor_ui --e=stdc_bit_floor_ul --e=stdc_bit_floor_ull --e=stdc_bit_ceil_uc --e=stdc_bit_ceil_us --e=stdc_bit_ceil_ui --e=stdc_bit_ceil_ul --e=stdc_bit_ceil_ull --e=abort --e=abs --e=atoi --e=atof --e=atol --e=atoll --e=bsearch --e=div --e=labs --e=ldiv --e=llabs --e=lldiv --e=qsort --e=qsort_r --e=rand --e=srand --e=strtod --e=strtof --e=strtol --e=strtold --e=strtoll --e=strtoul --e=strtoull --e=feclearexcept --e=fedisableexcept --e=feenableexcept --e=fegetenv --e=fegetexcept --e=fegetexceptflag --e=fegetround --e=feholdexcept --e=fesetenv --e=fesetexceptflag --e=fesetround --e=feraiseexcept --e=fetestexcept --e=feupdateenv --e=acosf --e=acoshf --e=asinf --e=asinhf --e=atanf --e=atanhf --e=ceil --e=ceilf --e=ceill --e=copysign --e=copysignf --e=copysignl --e=cosf --e=coshf --e=erff --e=exp --e=exp10 --e=exp10f --e=exp2 --e=exp2f --e=expf --e=expm1 --e=expm1f --e=fabs --e=fabsf --e=fabsl --e=fdim --e=fdimf --e=fdiml --e=floor --e=floorf --e=floorl --e=fma --e=fmaf --e=fmax --e=fmaxf --e=fmaxl --e=fmin --e=fminf --e=fminl --e=fmod --e=fmodf --e=fmodl --e=frexp --e=frexpf --e=frexpl --e=hypot --e=hypotf --e=ilogb --e=ilogbf --e=ilogbl --e=ldexp --e=ldexpf --e=ldexpl --e=llogb --e=llogbf --e=llogbl --e=llrint --e=llrintf --e=llrintl --e=llround --e=llroundf --e=llroundl --e=log --e=log10 --e=log10f --e=log1p --e=log1pf --e=log2 --e=log2f --e=logb --e=logbf --e=logbl --e=logf --e=lrint --e=lrintf --e=lrintl --e=lround --e=lroundf --e=lroundl --e=modf --e=modff --e=modfl --e=nan --e=nanf --e=nanl --e=nearbyint --e=nearbyintf --e=nearbyintl --e=nextafter --e=nextafterf --e=nextafterl --e=nexttoward --e=nexttowardf --e=nexttowardl --e=powf --e=remainder --e=remainderf --e=remainderl --e=remquo --e=remquof --e=remquol --e=rint --e=rintf --e=rintl --e=round --e=roundf --e=roundl --e=scalbn --e=scalbnf --e=scalbnl --e=sincosf --e=sinf --e=sinhf --e=sqrt --e=sqrtf --e=sqrtl --e=tanf --e=tanhf --e=trunc --e=truncf --e=truncl --e=abshk --e=abshr --e=absk --e=absr --e=abslk --e=abslr --e=exphk --e=expk --e=roundhk --e=roundhr --e=roundk --e=roundr --e=roundlk --e=roundlr --e=rounduhk --e=rounduhr --e=rounduk --e=roundur --e=roundulk --e=roundulr --e=sqrtuhk --e=sqrtuhr --e=sqrtuk --e=sqrtur --e=sqrtulr --e=uhksqrtus --e=uksqrtui /b/s/w/ir/x/w/llvm-llvm-project/libc/config/baremetal/api.td
error: __qsortrcompare_t not found in any standard spec.
```
Original failure:  https://ci.chromium.org/ui/p/fuchsia/builders/toolchain.ci/clang-linux-x64/b8753376051397217137/overview
I've tested that reverting this commit would make the build green again.
https://ci.chromium.org/raw/build/logs.chromium.org/fuchsia/led/paulkirth_google.com/29c31064b1fb757cb90a304e79086d644406406dff130569c2e77b066021eee6/+/build.proto?server=chromium-swarm.appspot.com