### PR TITLE
[clangd] Support go-to-definition on type hints. The protocol part

### DIFF
--- a/clang-tools-extra/clangd/ClangdLSPServer.cpp
+++ b/clang-tools-extra/clangd/ClangdLSPServer.cpp
@@ -1390,7 +1390,7 @@ void ClangdLSPServer::onClangdInlayHints(const InlayHintsParams &Params,
           // Extension doesn't have paddingLeft/Right so adjust the label
           // accordingly.
           {"label",
-           ((Hint.paddingLeft ? " " : "") + llvm::StringRef(Hint.label) +
+           ((Hint.paddingLeft ? " " : "") + llvm::StringRef(Hint.joinLabels()) +
             (Hint.paddingRight ? " " : ""))
                .str()},
       });

--- a/clang-tools-extra/clangd/InlayHints.cpp
+++ b/clang-tools-extra/clangd/InlayHints.cpp
@@ -977,8 +977,12 @@ private:
       return;
     bool PadLeft = Prefix.consume_front(" ");
     bool PadRight = Suffix.consume_back(" ");
-    Results.push_back(InlayHint{LSPPos, (Prefix + Label + Suffix).str(), Kind,
-                                PadLeft, PadRight, LSPRange});
+    Results.push_back(InlayHint{LSPPos,
+                                /*label=*/{(Prefix + Label + Suffix).str()},
+                                Kind,
+                                PadLeft,
+                                PadRight,
+                                LSPRange});
   }
 
   // Get the range of the main file that *exactly* corresponds to R.

--- a/clang-tools-extra/clangd/InlayHints.cpp
+++ b/clang-tools-extra/clangd/InlayHints.cpp
@@ -979,10 +979,7 @@ private:
     bool PadRight = Suffix.consume_back(" ");
     Results.push_back(InlayHint{LSPPos,
                                 /*label=*/{(Prefix + Label + Suffix).str()},
-                                Kind,
-                                PadLeft,
-                                PadRight,
-                                LSPRange});
+                                Kind, PadLeft, PadRight, LSPRange});
   }
 
   // Get the range of the main file that *exactly* corresponds to R.

--- a/clang-tools-extra/clangd/Protocol.cpp
+++ b/clang-tools-extra/clangd/Protocol.cpp
@@ -1483,18 +1483,9 @@ llvm::json::Value toJSON(const InlayHintKind &Kind) {
   llvm_unreachable("Unknown clang.clangd.InlayHintKind");
 }
 
-namespace {
-
-llvm::json::Array toJSON(const std::vector<InlayHintLabelPart> &Labels) {
-  return llvm::json::Array{
-      llvm::map_range(Labels, [](auto &Label) { return toJSON(Label); })};
-}
-
-} // namespace
-
 llvm::json::Value toJSON(const InlayHint &H) {
   llvm::json::Object Result{{"position", H.position},
-                            {"label", toJSON(H.label)},
+                            {"label", H.label},
                             {"paddingLeft", H.paddingLeft},
                             {"paddingRight", H.paddingRight}};
   auto K = toJSON(H.kind);

--- a/clang-tools-extra/clangd/Protocol.cpp
+++ b/clang-tools-extra/clangd/Protocol.cpp
@@ -1538,6 +1538,8 @@ llvm::json::Value toJSON(const InlayHintLabelPart &L) {
     Result["tooltip"] = *L.tooltip;
   if (L.location)
     Result["location"] = *L.location;
+  if (L.command)
+    Result["command"] = *L.command;
   return Result;
 }
 

--- a/clang-tools-extra/clangd/Protocol.h
+++ b/clang-tools-extra/clangd/Protocol.h
@@ -1689,6 +1689,42 @@ enum class InlayHintKind {
 };
 llvm::json::Value toJSON(const InlayHintKind &);
 
+/// An inlay hint label part allows for interactive and composite labels
+/// of inlay hints.
+struct InlayHintLabelPart {
+
+  InlayHintLabelPart(std::string value,
+                     std::optional<Location> location = std::nullopt)
+      : value(std::move(value)), location(std::move(location)) {}
+
+  /// The value of this label part.
+  std::string value;
+
+  /// The tooltip text when you hover over this label part. Depending on
+	/// the client capability `inlayHint.resolveSupport`, clients might resolve
+	/// this property late using the resolve request.
+  std::optional<MarkupContent> tooltip;
+
+	/// An optional source code location that represents this
+	/// label part.
+	///
+	/// The editor will use this location for the hover and for code navigation
+	/// features: This part will become a clickable link that resolves to the
+	/// definition of the symbol at the given location (not necessarily the
+	/// location itself), it shows the hover that shows at the given location,
+	/// and it shows a context menu with further code navigation commands.
+	///
+	/// Depending on the client capability `inlayHint.resolveSupport` clients
+	/// might resolve this property late using the resolve request.
+  std::optional<Location> location;
+
+  /// The command field is not used for now, hence omitted.
+};
+llvm::json::Value toJSON(const InlayHintLabelPart &);
+bool operator==(const InlayHintLabelPart &, const InlayHintLabelPart &);
+bool operator<(const InlayHintLabelPart &, const InlayHintLabelPart &);
+llvm::raw_ostream &operator<<(llvm::raw_ostream &, const InlayHintLabelPart &);
+
 /// Inlay hint information.
 struct InlayHint {
   /// The position of this hint.
@@ -1698,7 +1734,7 @@ struct InlayHint {
   /// InlayHintLabelPart label parts.
   ///
   /// *Note* that neither the string nor the label part can be empty.
-  std::string label;
+  std::vector<InlayHintLabelPart> label;
 
   /// The kind of this hint. Can be omitted in which case the client should fall
   /// back to a reasonable default.
@@ -1724,6 +1760,9 @@ struct InlayHint {
   /// The range allows clients more flexibility of when/how to display the hint.
   /// This is an (unserialized) clangd extension.
   Range range;
+
+  /// Join the label[].value together.
+  std::string joinLabels() const;
 };
 llvm::json::Value toJSON(const InlayHint &);
 bool operator==(const InlayHint &, const InlayHint &);

--- a/clang-tools-extra/clangd/Protocol.h
+++ b/clang-tools-extra/clangd/Protocol.h
@@ -1720,10 +1720,10 @@ struct InlayHintLabelPart {
   /// might resolve this property late using the resolve request.
   std::optional<Location> location;
 
-	/// An optional command for this label part.
+  /// An optional command for this label part.
   ///
-	/// Depending on the client capability `inlayHint.resolveSupport` clients
-	/// might resolve this property late using the resolve request.
+  /// Depending on the client capability `inlayHint.resolveSupport` clients
+  /// might resolve this property late using the resolve request.
   std::optional<Command> command;
 };
 llvm::json::Value toJSON(const InlayHintLabelPart &);

--- a/clang-tools-extra/clangd/Protocol.h
+++ b/clang-tools-extra/clangd/Protocol.h
@@ -1693,6 +1693,8 @@ llvm::json::Value toJSON(const InlayHintKind &);
 /// of inlay hints.
 struct InlayHintLabelPart {
 
+  InlayHintLabelPart() = default;
+
   InlayHintLabelPart(std::string value,
                      std::optional<Location> location = std::nullopt)
       : value(std::move(value)), location(std::move(location)) {}
@@ -1718,7 +1720,11 @@ struct InlayHintLabelPart {
   /// might resolve this property late using the resolve request.
   std::optional<Location> location;
 
-  /// The command field is not used for now, hence omitted.
+	/// An optional command for this label part.
+  ///
+	/// Depending on the client capability `inlayHint.resolveSupport` clients
+	/// might resolve this property late using the resolve request.
+  std::optional<Command> command;
 };
 llvm::json::Value toJSON(const InlayHintLabelPart &);
 bool operator==(const InlayHintLabelPart &, const InlayHintLabelPart &);

--- a/clang-tools-extra/clangd/Protocol.h
+++ b/clang-tools-extra/clangd/Protocol.h
@@ -1701,21 +1701,21 @@ struct InlayHintLabelPart {
   std::string value;
 
   /// The tooltip text when you hover over this label part. Depending on
-	/// the client capability `inlayHint.resolveSupport`, clients might resolve
-	/// this property late using the resolve request.
+  /// the client capability `inlayHint.resolveSupport`, clients might resolve
+  /// this property late using the resolve request.
   std::optional<MarkupContent> tooltip;
 
-	/// An optional source code location that represents this
-	/// label part.
-	///
-	/// The editor will use this location for the hover and for code navigation
-	/// features: This part will become a clickable link that resolves to the
-	/// definition of the symbol at the given location (not necessarily the
-	/// location itself), it shows the hover that shows at the given location,
-	/// and it shows a context menu with further code navigation commands.
-	///
-	/// Depending on the client capability `inlayHint.resolveSupport` clients
-	/// might resolve this property late using the resolve request.
+  /// An optional source code location that represents this
+  /// label part.
+  ///
+  /// The editor will use this location for the hover and for code navigation
+  /// features: This part will become a clickable link that resolves to the
+  /// definition of the symbol at the given location (not necessarily the
+  /// location itself), it shows the hover that shows at the given location,
+  /// and it shows a context menu with further code navigation commands.
+  ///
+  /// Depending on the client capability `inlayHint.resolveSupport` clients
+  /// might resolve this property late using the resolve request.
   std::optional<Location> location;
 
   /// The command field is not used for now, hence omitted.

--- a/clang-tools-extra/clangd/test/inlayHints.test
+++ b/clang-tools-extra/clangd/test/inlayHints.test
@@ -51,7 +51,11 @@
 # CHECK-NEXT:  "result": [
 # CHECK-NEXT:    {
 # CHECK-NEXT:      "kind": 2,
-# CHECK-NEXT:      "label": "bar:",
+# CHECK-NEXT:      "label": [
+# CHECK-NEXT:        {
+# CHECK-NEXT:          "value": "bar:"
+# CHECK-NEXT:        }
+# CHECK-NEXT:      ],
 # CHECK-NEXT:      "paddingLeft": false,
 # CHECK-NEXT:      "paddingRight": true,
 # CHECK-NEXT:      "position": {

--- a/clang-tools-extra/clangd/tool/Check.cpp
+++ b/clang-tools-extra/clangd/tool/Check.cpp
@@ -367,7 +367,13 @@ public:
     auto Hints = inlayHints(*AST, LineRange);
 
     for (const auto &Hint : Hints) {
-      vlog("  {0} {1} {2}", Hint.kind, Hint.position, Hint.label);
+      vlog("  {0} {1} [{2}]", Hint.kind, Hint.position, [&] {
+        return llvm::join(llvm::map_range(Hint.label,
+                                          [&](auto &L) {
+                                            return llvm::formatv("{{{0}}", L);
+                                          }),
+                          ", ");
+      }());
     }
   }
 

--- a/clang-tools-extra/clangd/unittests/InlayHintTests.cpp
+++ b/clang-tools-extra/clangd/unittests/InlayHintTests.cpp
@@ -25,7 +25,7 @@ namespace clangd {
 
 llvm::raw_ostream &operator<<(llvm::raw_ostream &Stream,
                               const InlayHint &Hint) {
-  return Stream << Hint.label << "@" << Hint.range;
+  return Stream << Hint.joinLabels() << "@" << Hint.range;
 }
 
 namespace {
@@ -57,10 +57,11 @@ struct ExpectedHint {
 
 MATCHER_P2(HintMatcher, Expected, Code, llvm::to_string(Expected)) {
   llvm::StringRef ExpectedView(Expected.Label);
-  if (arg.label != ExpectedView.trim(" ") ||
+  std::string ResultLabel = arg.joinLabels();
+  if (ResultLabel != ExpectedView.trim(" ") ||
       arg.paddingLeft != ExpectedView.starts_with(" ") ||
       arg.paddingRight != ExpectedView.ends_with(" ")) {
-    *result_listener << "label is '" << arg.label << "'";
+    *result_listener << "label is '" << ResultLabel << "'";
     return false;
   }
   if (arg.range != Code.range(Expected.RangeName)) {
@@ -72,7 +73,7 @@ MATCHER_P2(HintMatcher, Expected, Code, llvm::to_string(Expected)) {
   return true;
 }
 
-MATCHER_P(labelIs, Label, "") { return arg.label == Label; }
+MATCHER_P(labelIs, Label, "") { return arg.joinLabels() == Label; }
 
 Config noHintsConfig() {
   Config C;


### PR DESCRIPTION
This is in preparation for implementing go-to-definition support on type inlay hints, switching the label field within the InlayHint protocol to an array of InlayHintLabelPart.