### PR TITLE
[OpenMP] Enable the affinity tests on FreeBSD, NetBSD and DragonFly

### DIFF
--- a/openmp/runtime/test/lit.cfg
+++ b/openmp/runtime/test/lit.cfg
@@ -129,7 +129,7 @@ if config.operating_system == 'NetBSD':
 if config.operating_system == 'Darwin':
     config.available_features.add("darwin")
 
-if config.operating_system in ['Linux', 'Windows']:
+if config.operating_system in ['Windows', 'Linux', 'FreeBSD', 'NetBSD', 'DragonFly']:
     config.available_features.add('affinity')
 
 if config.operating_system in ['Linux']:


### PR DESCRIPTION
FreeBSD, NetBSD and DragonFly also have affinity support. So enable the tests there as well.