### PR TITLE
[analyzer] Allow egraph rewriter not to open the generated HTML directly

### DIFF
--- a/clang/utils/analyzer/exploded-graph-rewriter.py
+++ b/clang/utils/analyzer/exploded-graph-rewriter.py
@@ -479,12 +479,14 @@ class ExplodedGraph:
 # A visitor that dumps the ExplodedGraph into a DOT file with fancy HTML-based
 # syntax highlighing.
 class DotDumpVisitor:
-    def __init__(self, do_diffs, dark_mode, gray_mode, topo_mode, dump_dot_only):
+    def __init__(self, do_diffs, dark_mode, gray_mode, topo_mode, dump_dot_only,
+            dump_html_only):
         self._do_diffs = do_diffs
         self._dark_mode = dark_mode
         self._gray_mode = gray_mode
         self._topo_mode = topo_mode
         self._dump_dot_only = dump_dot_only
+        self._dump_html_only = dump_html_only
         self._output = []
 
     def _dump_raw(self, s):
@@ -998,6 +1000,8 @@ class DotDumpVisitor:
                 '<html><body bgcolor="%s">%s</body></html>'
                 % ("#1a1a1a" if self._dark_mode else "white", svg),
             )
+            if self._dump_html_only:
+                return
             if sys.platform == "win32":
                 os.startfile(filename)
             elif sys.platform == "darwin":
@@ -1176,7 +1180,8 @@ def main():
         default=False,
         help="black-and-white mode",
     )
-    parser.add_argument(
+    dump_conflict = parser.add_mutually_exclusive_group()
+    dump_conflict.add_argument(
         "--dump-dot-only",
         action="store_const",
         dest="dump_dot_only",
@@ -1185,6 +1190,14 @@ def main():
         help="instead of writing an HTML file and immediately "
         "displaying it, dump the rewritten dot file "
         "to stdout",
+    )
+    dump_conflict.add_argument(
+        "--dump-html-only",
+        action="store_const",
+        dest="dump_html_only",
+        const=True,
+        default=False,
+        help="do not open the generated HTML immediately",
     )
     args = parser.parse_args()
     logging.basicConfig(level=args.loglevel)
@@ -1206,7 +1219,8 @@ def main():
     explorer = BasicExplorer()
 
     visitor = DotDumpVisitor(
-        args.diff, args.dark, args.gray, args.topology, args.dump_dot_only
+        args.diff, args.dark, args.gray, args.topology, args.dump_dot_only,
+        args.dump_html_only
     )
 
     for trimmer in trimmers:

--- a/clang/utils/analyzer/exploded-graph-rewriter.py
+++ b/clang/utils/analyzer/exploded-graph-rewriter.py
@@ -479,8 +479,9 @@ class ExplodedGraph:
 # A visitor that dumps the ExplodedGraph into a DOT file with fancy HTML-based
 # syntax highlighing.
 class DotDumpVisitor:
-    def __init__(self, do_diffs, dark_mode, gray_mode, topo_mode, dump_dot_only,
-            dump_html_only):
+    def __init__(
+        self, do_diffs, dark_mode, gray_mode, topo_mode, dump_dot_only, dump_html_only
+    ):
         self._do_diffs = do_diffs
         self._dark_mode = dark_mode
         self._gray_mode = gray_mode
@@ -1219,8 +1220,12 @@ def main():
     explorer = BasicExplorer()
 
     visitor = DotDumpVisitor(
-        args.diff, args.dark, args.gray, args.topology, args.dump_dot_only,
-        args.dump_html_only
+        args.diff,
+        args.dark,
+        args.gray,
+        args.topology,
+        args.dump_dot_only,
+        args.dump_html_only,
     )
 
     for trimmer in trimmers:

--- a/clang/utils/analyzer/exploded-graph-rewriter.py
+++ b/clang/utils/analyzer/exploded-graph-rewriter.py
@@ -480,14 +480,19 @@ class ExplodedGraph:
 # syntax highlighing.
 class DotDumpVisitor:
     def __init__(
-        self, do_diffs, dark_mode, gray_mode, topo_mode, dump_dot_only, dump_html_only
+        self, do_diffs, dark_mode, gray_mode, topo_mode, dump_html_only, dump_dot_only
     ):
+        assert not (dump_html_only and dump_dot_only), (
+            "Option dump_html_only and dump_dot_only are conflict, "
+            "they cannot be true at the same time."
+        )
+
         self._do_diffs = do_diffs
         self._dark_mode = dark_mode
         self._gray_mode = gray_mode
         self._topo_mode = topo_mode
-        self._dump_dot_only = dump_dot_only
         self._dump_html_only = dump_html_only
+        self._dump_dot_only = dump_dot_only
         self._output = []
 
     def _dump_raw(self, s):
@@ -1183,6 +1188,15 @@ def main():
     )
     dump_conflict = parser.add_mutually_exclusive_group()
     dump_conflict.add_argument(
+        "--dump-html-only",
+        action="store_const",
+        dest="dump_html_only",
+        const=True,
+        default=False,
+        help="dump the rewritten egraph to a temporary HTML file, "
+        "but do not open it immediately as by default",
+    )
+    dump_conflict.add_argument(
         "--dump-dot-only",
         action="store_const",
         dest="dump_dot_only",
@@ -1191,14 +1205,6 @@ def main():
         help="instead of writing an HTML file and immediately "
         "displaying it, dump the rewritten dot file "
         "to stdout",
-    )
-    dump_conflict.add_argument(
-        "--dump-html-only",
-        action="store_const",
-        dest="dump_html_only",
-        const=True,
-        default=False,
-        help="do not open the generated HTML immediately",
     )
     args = parser.parse_args()
     logging.basicConfig(level=args.loglevel)
@@ -1224,8 +1230,8 @@ def main():
         args.dark,
         args.gray,
         args.topology,
-        args.dump_dot_only,
         args.dump_html_only,
+        args.dump_dot_only,
     )
 
     for trimmer in trimmers:


### PR DESCRIPTION
When developing on a headless device through SSH, we do not have a browser or even an X environment. Hence, it would be more convenient if the rewriter could stop before attempting to open the generated HTML file. Then, it can be opened remotely through an HTML server.

This patch adds a new option `--dump-html-only` to make the rewriter stop before opening the generated HTML in a browser. The new option is marked in conflict with the existing `--dump-dot-only` option to prevent unexpected behaviors.