### PR TITLE
[libc++] Add <locale> include in <chrono>

### DIFF
--- a/libcxx/include/chrono
+++ b/libcxx/include/chrono
@@ -883,6 +883,7 @@ constexpr chrono::year                                  operator ""y(unsigned lo
 
 #if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER == 20
 #  include <charconv>
+#  include <locale>
 #endif
 
 #endif // _LIBCPP_CHRONO

--- a/libcxx/test/libcxx/transitive_includes/cxx20.csv
+++ b/libcxx/test/libcxx/transitive_includes/cxx20.csv
@@ -128,6 +128,7 @@ chrono ctime
 chrono cwchar
 chrono forward_list
 chrono limits
+chrono locale
 chrono optional
 chrono ostream
 chrono ratio


### PR DESCRIPTION
I accidentally removed this transitive include in #85478.
