### PR TITLE
[ValueTracking] Use `ConstantRange::toKnownBits` when computing from Range Metadata; NFC

### DIFF
--- a/llvm/lib/Analysis/ValueTracking.cpp
+++ b/llvm/lib/Analysis/ValueTracking.cpp
@@ -423,8 +423,7 @@ void llvm::computeKnownBitsFromRangeMetadata(const MDNode &Ranges,
   unsigned NumRanges = Ranges.getNumOperands() / 2;
   assert(NumRanges >= 1);
 
-  Known.Zero.setAllBits();
-  Known.One.setAllBits();
+  ConstantRange CR = ConstantRange::getEmpty(BitWidth);
 
   for (unsigned i = 0; i < NumRanges; ++i) {
     ConstantInt *Lower =
@@ -432,15 +431,9 @@ void llvm::computeKnownBitsFromRangeMetadata(const MDNode &Ranges,
     ConstantInt *Upper =
         mdconst::extract<ConstantInt>(Ranges.getOperand(2 * i + 1));
     ConstantRange Range(Lower->getValue(), Upper->getValue());
-
-    // The first CommonPrefixBits of all values in Range are equal.
-    unsigned CommonPrefixBits =
-        (Range.getUnsignedMax() ^ Range.getUnsignedMin()).countl_zero();
-    APInt Mask = APInt::getHighBitsSet(BitWidth, CommonPrefixBits);
-    APInt UnsignedMax = Range.getUnsignedMax().zextOrTrunc(BitWidth);
-    Known.One &= UnsignedMax & Mask;
-    Known.Zero &= ~UnsignedMax & Mask;
+    CR = CR.unionWith(Range.zextOrTrunc(BitWidth));
   }
+  Known = Known.unionWith(CR.toKnownBits());
 }
 
 static bool isEphemeralValueOf(const Instruction *I, const Value *E) {


### PR DESCRIPTION
Just replaces some bespoke logic with a better tested API.
