### PR TITLE
[flang] Catch inappropriate attributes for PARAMETERs

### DIFF
--- a/flang/lib/Semantics/check-declarations.cpp
+++ b/flang/lib/Semantics/check-declarations.cpp
@@ -632,6 +632,11 @@ void CheckHelper::CheckObjectEntity(
     const Symbol &symbol, const ObjectEntityDetails &details) {
   CheckSymbolType(symbol);
   CheckArraySpec(symbol, details.shape());
+  CheckConflicting(symbol, Attr::ALLOCATABLE, Attr::PARAMETER);
+  CheckConflicting(symbol, Attr::ASYNCHRONOUS, Attr::PARAMETER);
+  CheckConflicting(symbol, Attr::SAVE, Attr::PARAMETER);
+  CheckConflicting(symbol, Attr::TARGET, Attr::PARAMETER);
+  CheckConflicting(symbol, Attr::VOLATILE, Attr::PARAMETER);
   Check(details.shape());
   Check(details.coshape());
   if (details.shape().Rank() > common::maxRank) {

--- a/flang/test/Semantics/declarations02.f90
+++ b/flang/test/Semantics/declarations02.f90
@@ -10,6 +10,20 @@ module m
   integer, parameter :: x3 = 1
   bind(c) :: x3
 
+  !ERROR: 'x4' may not have both the ALLOCATABLE and PARAMETER attributes
+  !ERROR: 'x4' may not have both the ASYNCHRONOUS and PARAMETER attributes
+  !ERROR: 'x4' may not have both the SAVE and PARAMETER attributes
+  !ERROR: 'x4' may not have both the TARGET and PARAMETER attributes
+  !ERROR: 'x4' may not have both the VOLATILE and PARAMETER attributes
+  !ERROR: The entity 'x4' with an explicit SAVE attribute must be a variable, procedure pointer, or COMMON block
+  !ERROR: An entity may not have the ASYNCHRONOUS attribute unless it is a variable
+  integer, parameter :: x4 = 1
+  allocatable x4
+  asynchronous x4
+  save x4
+  target x4
+  volatile x4
+
   type :: my_type1
     integer :: x4
   end type


### PR DESCRIPTION
There's several symbol attributes that cannot be applied to named constants, but that weren't being checked.