### PR TITLE
[mlir] Adjust split marker flag logic to fix MSVC build.

### DIFF
--- a/mlir/include/mlir/Tools/mlir-opt/MlirOptMain.h
+++ b/mlir/include/mlir/Tools/mlir-opt/MlirOptMain.h
@@ -142,10 +142,17 @@ public:
   MlirOptMainConfig &
   splitInputFile(std::string splitMarker = kDefaultSplitMarker) {
     splitInputFileFlag = std::move(splitMarker);
+    splitInputFileSpecified = true;
     return *this;
   }
-  bool shouldSplitInputFile() const { return splitInputFileFlag.empty(); }
-  StringRef inputSplitMarker() const { return splitInputFileFlag; }
+  bool shouldSplitInputFile() const {
+    return splitInputFileSpecified || !splitInputFileFlag.empty();
+  }
+  std::string inputSplitMarker() const {
+    return splitInputFileSpecified && splitInputFileFlag.empty()
+               ? kDefaultSplitMarker
+               : splitInputFileFlag;
+  }
 
   /// Set whether to merge the output chunks into one file using the given
   /// marker.
@@ -226,6 +233,9 @@ protected:
 
   /// Show the registered dialects before trying to load the input file.
   bool showDialectsFlag = false;
+
+  /// Whether the split-input-file flag was specified.
+  bool splitInputFileSpecified = false;
 
   /// Split the input file based on the given marker into chunks and process
   /// each chunk independently. Input is not split if empty.

--- a/mlir/lib/Tools/mlir-opt/MlirOptMain.cpp
+++ b/mlir/lib/Tools/mlir-opt/MlirOptMain.cpp
@@ -128,16 +128,13 @@ struct MlirOptMainConfigCLOptions : public MlirOptMainConfig {
         cl::desc("Print the list of registered dialects and exit"),
         cl::location(showDialectsFlag), cl::init(false));
 
-    static cl::opt<std::string, /*ExternalStorage=*/true> splitInputFile{
+    static cl::opt<std::string, /*ExternalStorage=*/true> splitInputFile(
         "split-input-file", llvm::cl::ValueOptional,
-        cl::callback([&](const std::string &str) {
-          // Implicit value: use default marker if flag was used without value.
-          if (str.empty())
-            splitInputFile.setValue(kDefaultSplitMarker);
-        }),
+        cl::callback(
+            [&](const std::string &str) { splitInputFileSpecified = true; }),
         cl::desc("Split the input file into chunks using the given or "
                  "default marker and process each chunk independently"),
-        cl::location(splitInputFileFlag), cl::init("")};
+        cl::location(splitInputFileFlag), cl::init(""));
 
     static cl::opt<std::string, /*ExternalStorage=*/true> outputSplitMarker(
         "output-split-marker",

--- a/mlir/lib/Tools/mlir-translate/MlirTranslateMain.cpp
+++ b/mlir/lib/Tools/mlir-translate/MlirTranslateMain.cpp
@@ -62,16 +62,14 @@ LogicalResult mlir::mlirTranslateMain(int argc, char **argv,
       llvm::cl::desc("Allow operation with no registered dialects (discouraged: testing only!)"),
       llvm::cl::init(false));
 
-  static llvm::cl::opt<std::string> inputSplitMarker{
+  static bool inputSplitMarkerSpecified = false;
+  static llvm::cl::opt<std::string> inputSplitMarker(
       "split-input-file", llvm::cl::ValueOptional,
-      llvm::cl::callback([&](const std::string &str) {
-        // Implicit value: use default marker if flag was used without value.
-        if (str.empty())
-          inputSplitMarker.setValue(kDefaultSplitMarker);
-      }),
+      llvm::cl::callback(
+          [&](const std::string &str) { inputSplitMarkerSpecified = true; }),
       llvm::cl::desc("Split the input file into chunks using the given or "
                      "default marker and process each chunk independently"),
-      llvm::cl::init("")};
+      llvm::cl::init(""));
 
   static llvm::cl::opt<bool> verifyDiagnostics(
       "verify-diagnostics",
@@ -185,9 +183,12 @@ LogicalResult mlir::mlirTranslateMain(int argc, char **argv,
     return result;
   };
 
-  if (failed(splitAndProcessBuffer(std::move(input), processBuffer,
-                                   output->os(), inputSplitMarker,
-                                   outputSplitMarker)))
+  if (failed(splitAndProcessBuffer(
+          std::move(input), processBuffer, output->os(),
+          inputSplitMarkerSpecified && inputSplitMarker.getValue().empty()
+              ? kDefaultSplitMarker
+              : inputSplitMarker.getValue(),
+          outputSplitMarker)))
     return failure();
 
   output->keep();


### PR DESCRIPTION
We should not try to capture the flag variable inside the callback passed when creating the flag variable. As a fix, we use a separate boolean variable to track whether the command line flag was specified.