### PR TITLE
[mlir] Extend split marker tests of `mlir-opt` and `mlir-pdll`.

### DIFF
--- a/mlir/test/mlir-opt/split-markers.mlir
+++ b/mlir/test/mlir-opt/split-markers.mlir
@@ -1,12 +1,17 @@
 // Check near-miss mechanics:
 // RUN: mlir-opt --split-input-file --verify-diagnostics %s 2> %t \
-// RUN: &&  FileCheck --input-file %t %s
+// RUN: && FileCheck --input-file %t --check-prefix=CHECK-DEFAULT %s
 // RUN: cat %t
 
 // Check that (1) custom input splitter and (2) custom output splitters work.
-// RUN: mlir-opt %s -split-input-file="// CHECK: ""----" \
+// RUN: mlir-opt %s -split-input-file="// CHECK-DEFAULT: ""----" \
 // RUN:   -output-split-marker="// ---- next split ----" \
-// RUN: | FileCheck --check-prefix=CHECK-SPLITTERS %s
+// RUN: | FileCheck --check-prefix=CHECK-CUSTOM %s
+
+// Check that (3) the input is not split if `-split-input-file` is not given.
+// RUN: mlir-opt %s 2> %t \
+// RUN: || FileCheck --input-file %t --check-prefix=CHECK-NOSPLIT %s
+// RUN: cat %t
 
 func.func @main() {return}
 
@@ -14,22 +19,25 @@ func.func @main() {return}
 
 // expected-note @+1 {{see existing symbol definition here}}
 func.func @foo() { return }
-// CHECK: warning: near miss with file split marker
-// CHECK: ----
+// CHECK-DEFAULT: warning: near miss with file split marker
+// CHECK-DEFAULT: ----
 // ----
+
+// CHECK-NOSPLIT: error: redefinition of symbol named 'main'
+func.func @main() {return}
 
 // expected-error @+1 {{redefinition of symbol named 'foo'}}
 func.func @foo() { return }
-// CHECK: warning: near miss with file split marker
-// CHECK: ----
+// CHECK-DEFAULT: warning: near miss with file split marker
+// CHECK-DEFAULT: ----
 // ----
 func.func @bar2() {return }
 
 // No error flagged at the end for a near miss.
 // ----
 
-// CHECK-SPLITTERS: module
-// CHECK-SPLITTERS: ---- next split ----
-// CHECK-SPLITTERS: module
-// CHECK-SPLITTERS: ---- next split ----
-// CHECK-SPLITTERS: module
+// CHECK-CUSTOM: module
+// CHECK-CUSTOM: ---- next split ----
+// CHECK-CUSTOM: module
+// CHECK-CUSTOM: ---- next split ----
+// CHECK-CUSTOM: module

--- a/mlir/test/mlir-pdll/split-markers.pdll
+++ b/mlir/test/mlir-pdll/split-markers.pdll
@@ -9,6 +9,10 @@
 // RUN:   -split-input-file="// ""=====" -output-split-marker "// #####" \
 // RUN: | FileCheck -check-prefix=CHECK-CUSTOM %s
 
+// Check that (5) the input is not split if `-split-input-file` is not given.
+// RUN: mlir-pdll %s \
+// RUN: | FileCheck -check-prefix=CHECK-NOSPLIT %s
+
 // CHECK-DEFAULT:      Module
 // CHECK-DEFAULT-NEXT: PatternDecl
 // CHECK-DEFAULT-NOT:  PatternDecl
@@ -24,6 +28,14 @@
 // CHECK-CUSTOM-NEXT: Module
 // CHECK-CUSTOM-NEXT: PatternDecl
 // CHECK-CUSTOM-NOT:  PatternDecl
+
+// CHECK-NOSPLIT:      Module
+// CHECK-NOSPLIT-NEXT: PatternDecl
+// CHECK-NOSPLIT-NOT:  Module
+// CHECK-NOSPLIT:      PatternDecl
+// CHECK-NOSPLIT-NOT:  Module
+// CHECK-NOSPLIT:      PatternDecl
+// CHECK-NOSPLIT-NOT:  Module
 
 Pattern => erase op<test.op>;
 


### PR DESCRIPTION
Recently #84765 made the split markers of various tools configurable but did not test *not* using the split markers for two of them. This PR adds those tests.