### PR TITLE
[mlir] Remove unused and untested `shouldSplitInputFile`.

### DIFF
--- a/mlir/include/mlir/Tools/mlir-opt/MlirOptMain.h
+++ b/mlir/include/mlir/Tools/mlir-opt/MlirOptMain.h
@@ -144,7 +144,6 @@ public:
     splitInputFileFlag = std::move(splitMarker);
     return *this;
   }
-  bool shouldSplitInputFile() const { return splitInputFileFlag.empty(); }
   StringRef inputSplitMarker() const { return splitInputFileFlag; }
 
   /// Set whether to merge the output chunks into one file using the given


### PR DESCRIPTION
This was changed by #84765 but turned out to be buggy. Since it isn't used and isn't tested, it is probably best to remove it.