### PR TITLE
[clang][NFC] Add documentation for `CastExpr::path()`.

### DIFF
--- a/clang/include/clang/AST/Expr.h
+++ b/clang/include/clang/AST/Expr.h
@@ -3552,6 +3552,15 @@ public:
   /// function that it invokes.
   NamedDecl *getConversionFunction() const;
 
+  /// Path through the class hierarchy taken by a `DerivedToBase` or
+  /// `UncheckedDerivedToBase` cast. For each derived-to-base edge in the path,
+  /// the path contains a `CXXBaseSpecifier` for the base class of that edge;
+  /// the entries are ordered from derived class to base class.
+  ///
+  /// For example, given classes `Base`, `Intermediate : public Base` and
+  /// `Derived : public Intermediate`, the path for a cast from `Derived *` to
+  /// `Base *` contains two entries: One for `Intermediate`, and one for `Base`,
+  /// in that order.
   typedef CXXBaseSpecifier **path_iterator;
   typedef const CXXBaseSpecifier *const *path_const_iterator;
   bool path_empty() const { return path_size() == 0; }

--- a/clang/include/clang/AST/Expr.h
+++ b/clang/include/clang/AST/Expr.h
@@ -3552,6 +3552,15 @@ public:
   /// function that it invokes.
   NamedDecl *getConversionFunction() const;
 
+  typedef CXXBaseSpecifier **path_iterator;
+  typedef const CXXBaseSpecifier *const *path_const_iterator;
+  bool path_empty() const { return path_size() == 0; }
+  unsigned path_size() const { return CastExprBits.BasePathSize; }
+  path_iterator path_begin() { return path_buffer(); }
+  path_iterator path_end() { return path_buffer() + path_size(); }
+  path_const_iterator path_begin() const { return path_buffer(); }
+  path_const_iterator path_end() const { return path_buffer() + path_size(); }
+
   /// Path through the class hierarchy taken by casts between base and derived
   /// classes (see implementation of `CastConsistency()` for a full list of
   /// cast kinds that have a path).
@@ -3564,15 +3573,6 @@ public:
   /// `Derived : public Intermediate`, the path for a cast from `Derived *` to
   /// `Base *` contains two entries: One for `Intermediate`, and one for `Base`,
   /// in that order.
-  typedef CXXBaseSpecifier **path_iterator;
-  typedef const CXXBaseSpecifier *const *path_const_iterator;
-  bool path_empty() const { return path_size() == 0; }
-  unsigned path_size() const { return CastExprBits.BasePathSize; }
-  path_iterator path_begin() { return path_buffer(); }
-  path_iterator path_end() { return path_buffer() + path_size(); }
-  path_const_iterator path_begin() const { return path_buffer(); }
-  path_const_iterator path_end() const { return path_buffer() + path_size(); }
-
   llvm::iterator_range<path_iterator> path() {
     return llvm::make_range(path_begin(), path_end());
   }

--- a/clang/include/clang/AST/Expr.h
+++ b/clang/include/clang/AST/Expr.h
@@ -3552,10 +3552,13 @@ public:
   /// function that it invokes.
   NamedDecl *getConversionFunction() const;
 
-  /// Path through the class hierarchy taken by a `DerivedToBase` or
-  /// `UncheckedDerivedToBase` cast. For each derived-to-base edge in the path,
-  /// the path contains a `CXXBaseSpecifier` for the base class of that edge;
-  /// the entries are ordered from derived class to base class.
+  /// Path through the class hierarchy taken by casts between base and derived
+  /// classes (see implementation of `CastConsistency()` for a full list of
+  /// cast kinds that have a path).
+  ///
+  /// For each derived-to-base edge in the path, the path contains a
+  /// `CXXBaseSpecifier` for the base class of that edge; the entries are
+  /// ordered from derived class to base class.
   ///
   /// For example, given classes `Base`, `Intermediate : public Base` and
   /// `Derived : public Intermediate`, the path for a cast from `Derived *` to


### PR DESCRIPTION
This didn't have any documentation, so I had to do some experimenting in godbolt when I used this in https://github.com/llvm/llvm-project/pull/84138, and my reviewer later also had some [questions](https://github.com/llvm/llvm-project/pull/84138#discussion_r1524855434) about this, so I figured it would be worth adding documentation.
