### PR TITLE
[libc++][NFC] Remove uses of add_{const,cv,volatile}

### DIFF
--- a/libcxx/include/__iterator/iterator_traits.h
+++ b/libcxx/include/__iterator/iterator_traits.h
@@ -21,7 +21,6 @@
 #include <__fwd/pair.h>
 #include <__iterator/incrementable_traits.h>
 #include <__iterator/readable_traits.h>
-#include <__type_traits/add_const.h>
 #include <__type_traits/common_reference.h>
 #include <__type_traits/conditional.h>
 #include <__type_traits/disjunction.h>
@@ -493,8 +492,8 @@ using __iter_mapped_type = typename iterator_traits<_InputIterator>::value_type:
 
 template <class _InputIterator>
 using __iter_to_alloc_type =
-    pair< typename add_const<typename iterator_traits<_InputIterator>::value_type::first_type>::type,
-          typename iterator_traits<_InputIterator>::value_type::second_type>;
+    pair<const typename iterator_traits<_InputIterator>::value_type::first_type,
+         typename iterator_traits<_InputIterator>::value_type::second_type>;
 
 template <class _Iter>
 using __iterator_category_type = typename iterator_traits<_Iter>::iterator_category;

--- a/libcxx/include/__iterator/ranges_iterator_traits.h
+++ b/libcxx/include/__iterator/ranges_iterator_traits.h
@@ -13,7 +13,6 @@
 #include <__config>
 #include <__fwd/pair.h>
 #include <__ranges/concepts.h>
-#include <__type_traits/add_const.h>
 #include <__type_traits/remove_const.h>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
@@ -32,8 +31,7 @@ using __range_mapped_type = typename ranges::range_value_t<_Range>::second_type;
 
 template <ranges::input_range _Range>
 using __range_to_alloc_type =
-    pair<add_const_t<typename ranges::range_value_t<_Range>::first_type>,
-         typename ranges::range_value_t<_Range>::second_type>;
+    pair<const typename ranges::range_value_t<_Range>::first_type, typename ranges::range_value_t<_Range>::second_type>;
 
 #endif
 

--- a/libcxx/include/__tuple/tuple_element.h
+++ b/libcxx/include/__tuple/tuple_element.h
@@ -12,9 +12,6 @@
 #include <__config>
 #include <__tuple/tuple_indices.h>
 #include <__tuple/tuple_types.h>
-#include <__type_traits/add_const.h>
-#include <__type_traits/add_cv.h>
-#include <__type_traits/add_volatile.h>
 #include <cstddef>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
@@ -28,17 +25,17 @@ struct _LIBCPP_TEMPLATE_VIS tuple_element;
 
 template <size_t _Ip, class _Tp>
 struct _LIBCPP_TEMPLATE_VIS tuple_element<_Ip, const _Tp> {
-  typedef _LIBCPP_NODEBUG typename add_const<typename tuple_element<_Ip, _Tp>::type>::type type;
+  typedef _LIBCPP_NODEBUG const typename tuple_element<_Ip, _Tp>::type type;
 };
 
 template <size_t _Ip, class _Tp>
 struct _LIBCPP_TEMPLATE_VIS tuple_element<_Ip, volatile _Tp> {
-  typedef _LIBCPP_NODEBUG typename add_volatile<typename tuple_element<_Ip, _Tp>::type>::type type;
+  typedef _LIBCPP_NODEBUG volatile typename tuple_element<_Ip, _Tp>::type type;
 };
 
 template <size_t _Ip, class _Tp>
 struct _LIBCPP_TEMPLATE_VIS tuple_element<_Ip, const volatile _Tp> {
-  typedef _LIBCPP_NODEBUG typename add_cv<typename tuple_element<_Ip, _Tp>::type>::type type;
+  typedef _LIBCPP_NODEBUG const volatile typename tuple_element<_Ip, _Tp>::type type;
 };
 
 #ifndef _LIBCPP_CXX03_LANG

--- a/libcxx/include/__type_traits/copy_cv.h
+++ b/libcxx/include/__type_traits/copy_cv.h
@@ -10,9 +10,6 @@
 #define _LIBCPP___TYPE_TRAITS_COPY_CV_H
 
 #include <__config>
-#include <__type_traits/add_const.h>
-#include <__type_traits/add_cv.h>
-#include <__type_traits/add_volatile.h>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
 #  pragma GCC system_header
@@ -29,17 +26,17 @@ struct __copy_cv {
 
 template <class _From, class _To>
 struct __copy_cv<const _From, _To> {
-  using type = typename add_const<_To>::type;
+  using type = const _To;
 };
 
 template <class _From, class _To>
 struct __copy_cv<volatile _From, _To> {
-  using type = typename add_volatile<_To>::type;
+  using type = volatile _To;
 };
 
 template <class _From, class _To>
 struct __copy_cv<const volatile _From, _To> {
-  using type = typename add_cv<_To>::type;
+  using type = const volatile _To;
 };
 
 template <class _From, class _To>

--- a/libcxx/include/__type_traits/is_assignable.h
+++ b/libcxx/include/__type_traits/is_assignable.h
@@ -10,7 +10,6 @@
 #define _LIBCPP___TYPE_TRAITS_IS_ASSIGNABLE_H
 
 #include <__config>
-#include <__type_traits/add_const.h>
 #include <__type_traits/add_lvalue_reference.h>
 #include <__type_traits/add_rvalue_reference.h>
 #include <__type_traits/integral_constant.h>
@@ -31,9 +30,8 @@ inline constexpr bool is_assignable_v = __is_assignable(_Tp, _Arg);
 
 template <class _Tp>
 struct _LIBCPP_TEMPLATE_VIS is_copy_assignable
-    : public integral_constant<
-          bool,
-          __is_assignable(__add_lvalue_reference_t<_Tp>, __add_lvalue_reference_t<typename add_const<_Tp>::type>)> {};
+    : public integral_constant<bool,
+                               __is_assignable(__add_lvalue_reference_t<_Tp>, __add_lvalue_reference_t<const _Tp>)> {};
 
 #if _LIBCPP_STD_VER >= 17
 template <class _Tp>

--- a/libcxx/include/__type_traits/is_constructible.h
+++ b/libcxx/include/__type_traits/is_constructible.h
@@ -10,7 +10,6 @@
 #define _LIBCPP___TYPE_IS_CONSTRUCTIBLE_H
 
 #include <__config>
-#include <__type_traits/add_const.h>
 #include <__type_traits/add_lvalue_reference.h>
 #include <__type_traits/add_rvalue_reference.h>
 #include <__type_traits/integral_constant.h>
@@ -31,8 +30,7 @@ inline constexpr bool is_constructible_v = __is_constructible(_Tp, _Args...);
 
 template <class _Tp>
 struct _LIBCPP_TEMPLATE_VIS is_copy_constructible
-    : public integral_constant<bool, __is_constructible(_Tp, __add_lvalue_reference_t<typename add_const<_Tp>::type>)> {
-};
+    : public integral_constant<bool, __is_constructible(_Tp, __add_lvalue_reference_t<const _Tp>)> {};
 
 #if _LIBCPP_STD_VER >= 17
 template <class _Tp>

--- a/libcxx/include/__type_traits/is_nothrow_assignable.h
+++ b/libcxx/include/__type_traits/is_nothrow_assignable.h
@@ -10,7 +10,6 @@
 #define _LIBCPP___TYPE_TRAITS_IS_NOTHROW_ASSIGNABLE_H
 
 #include <__config>
-#include <__type_traits/add_const.h>
 #include <__type_traits/add_lvalue_reference.h>
 #include <__type_traits/add_rvalue_reference.h>
 #include <__type_traits/integral_constant.h>
@@ -32,9 +31,9 @@ inline constexpr bool is_nothrow_assignable_v = __is_nothrow_assignable(_Tp, _Ar
 
 template <class _Tp>
 struct _LIBCPP_TEMPLATE_VIS is_nothrow_copy_assignable
-    : public integral_constant<bool,
-                               __is_nothrow_assignable(__add_lvalue_reference_t<_Tp>,
-                                                       __add_lvalue_reference_t<typename add_const<_Tp>::type>)> {};
+    : public integral_constant<
+          bool,
+          __is_nothrow_assignable(__add_lvalue_reference_t<_Tp>, __add_lvalue_reference_t<const _Tp>)> {};
 
 #if _LIBCPP_STD_VER >= 17
 template <class _Tp>

--- a/libcxx/include/__type_traits/is_nothrow_constructible.h
+++ b/libcxx/include/__type_traits/is_nothrow_constructible.h
@@ -10,7 +10,6 @@
 #define _LIBCPP___TYPE_TRAITS_IS_NOTHROW_CONSTRUCTIBLE_H
 
 #include <__config>
-#include <__type_traits/add_const.h>
 #include <__type_traits/add_lvalue_reference.h>
 #include <__type_traits/add_rvalue_reference.h>
 #include <__type_traits/integral_constant.h>
@@ -74,15 +73,13 @@ inline constexpr bool is_nothrow_constructible_v = is_nothrow_constructible<_Tp,
 
 template <class _Tp>
 struct _LIBCPP_TEMPLATE_VIS is_nothrow_copy_constructible
-    : public is_nothrow_constructible<_Tp, __add_lvalue_reference_t<typename add_const<_Tp>::type> > {};
+    : public is_nothrow_constructible<_Tp, __add_lvalue_reference_t<const _Tp> > {};
 
 #else // _LIBCPP_COMPILER_GCC
 
 template <class _Tp>
 struct _LIBCPP_TEMPLATE_VIS is_nothrow_copy_constructible
-    : public integral_constant<
-          bool,
-          __is_nothrow_constructible(_Tp, typename add_lvalue_reference<typename add_const<_Tp>::type>::type)> {};
+    : public integral_constant< bool, __is_nothrow_constructible(_Tp, __add_lvalue_reference_t<const _Tp>)> {};
 
 #endif // _LIBCPP_COMPILER_GCC
 

--- a/libcxx/include/__type_traits/is_trivially_assignable.h
+++ b/libcxx/include/__type_traits/is_trivially_assignable.h
@@ -31,9 +31,9 @@ inline constexpr bool is_trivially_assignable_v = __is_trivially_assignable(_Tp,
 
 template <class _Tp>
 struct _LIBCPP_TEMPLATE_VIS is_trivially_copy_assignable
-    : public integral_constant<bool,
-                               __is_trivially_assignable(__add_lvalue_reference_t<_Tp>,
-                                                         __add_lvalue_reference_t<typename add_const<_Tp>::type>)> {};
+    : public integral_constant<
+          bool,
+          __is_trivially_assignable(__add_lvalue_reference_t<_Tp>, __add_lvalue_reference_t<const _Tp>)> {};
 
 #if _LIBCPP_STD_VER >= 17
 template <class _Tp>


### PR DESCRIPTION
These traits can be expressed without having to instantiate any classes, reducing compile times slightly.
