### PR TITLE
[AsmPrinter,X86] Hard code AT&T syntax input for module-level inline assembly for MSVC triples

### DIFF
--- a/clang/test/CodeGen/X86/inline-asm-cl.c
+++ b/clang/test/CodeGen/X86/inline-asm-cl.c
@@ -1,0 +1,19 @@
+// REQUIRES: x86-registered-target
+/// Some clang-cl users expect AT&T syntax input even if -x86-asm-syntax=intel is set.
+// RUN: %clang_cc1 -triple x86_64-windows-msvc -S -fms-extensions -mllvm -x86-asm-syntax=intel %s -o - | FileCheck %s
+
+// CHECK:         .intel_syntax noprefix
+// CHECK:         mov     rax, rax
+// CHECK-LABEL: foo:
+// CHECK:         mov     rdx, rdx
+// CHECK:         mov     rdx, rdx
+
+asm("movq %rax, %rax");
+
+void foo() {
+  asm("movq %rdx, %rdx");
+
+  __asm {
+    mov rdx, rdx
+  }
+}

--- a/llvm/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
@@ -541,7 +541,9 @@ bool AsmPrinter::doInitialization(Module &M) {
     emitInlineAsm(
         M.getModuleInlineAsm() + "\n", *TM.getMCSubtargetInfo(),
         TM.Options.MCOptions, nullptr,
-        InlineAsm::AsmDialect(TM.getMCAsmInfo()->getAssemblerDialect()));
+        TM.getTargetTriple().isWindowsMSVCEnvironment()
+            ? InlineAsm::AD_ATT
+            : InlineAsm::AsmDialect(TM.getMCAsmInfo()->getAssemblerDialect()));
     OutStreamer->AddComment("End of file scope inline assembly");
     OutStreamer->addBlankLine();
   }


### PR DESCRIPTION
clang-cl is conflating input assembly syntax with output assembly
syntax. It expects AT&T syntax input but Intel syntax output. This
conflicts with clang -c -masm=intel users that do expect -masm=intel to
control both input and output.

After #85367, we use AT&T dialect for module-level inline assembly
parsing, breaking assumptions by Chromium. Hard code MSVC to use
AT&T for now.

```
% cat a.c
asm("movq %rax, %rax");
int main() { asm("movq %rax, %rax"); }
% clang-cl -c a.c   # succeeded
```
