### PR TITLE
[libomptarget][nextgen-plugin] Use SCRELEASE/SCACQUIRE in packet headers

### DIFF
--- a/libc/utils/gpu/loader/amdgpu/Loader.cpp
+++ b/libc/utils/gpu/loader/amdgpu/Loader.cpp
@@ -276,7 +276,8 @@ hsa_status_t launch_kernel(hsa_agent_t dev_agent, hsa_executable_t executable,
       (HSA_FENCE_SCOPE_SYSTEM << HSA_PACKET_HEADER_SCACQUIRE_FENCE_SCOPE) |
       (HSA_FENCE_SCOPE_SYSTEM << HSA_PACKET_HEADER_SCRELEASE_FENCE_SCOPE);
   uint32_t header_word = header | (setup << 16u);
-  __atomic_store_n((uint32_t *)&packet->header, header_word, __ATOMIC_RELEASE);
+  __atomic_store_n(reinterpret_cast<uint32_t *>(packet), header_word,
+                   __ATOMIC_RELEASE);
   hsa_signal_store_relaxed(queue->doorbell_signal, packet_id);
 
   // Wait until the kernel has completed execution on the device. Periodically


### PR DESCRIPTION
This patch updates the construction of packet headers to replace the usage of ACQUIRE/RELEASE with SCACQUIRE/SCRELEASE which is now recommended.
The patch also fixes a potential source of problems by ensuring the atomic store operation refers to the header field directly and doesn't rely on it being the first field in the packet struct.

Documentation:
```
HSA_PACKET_HEADER_SCACQUIRE_FENCE_SCOPE
Acquire fence scope. The value of this sub-field determines the scope and type of the memory fence
operation applied before the packet enters the active phase. An acquire fence ensures that any
subsequent global segment or image loads by any unit of execution that belongs to a dispatch that has
not yet entered the active phase on any queue of the same kernel agent, sees any data previously
released at the scopes specified by the acquire fence. The value of this sub-field must be one of hsa_
fence_scope_t.
HSA_PACKET_HEADER_ACQUIRE_FENCE_SCOPE
Deprecated: Renamed as HSA_PACKET_HEADER_SCACQUIRE_FENCE_SCOPE.
HSA_PACKET_HEADER_SCRELEASE_FENCE_SCOPE
Release fence scope. The value of this sub-field determines the scope and type of the memory fence
operation applied after kernel completion but before the packet is completed. A release fence makes any
global segment or image data that was stored by any unit of execution that belonged to a dispatch that
has completed the active phase on any queue of the same kernel agent visible in all the scopes specified
by the release fence. The value of this sub-field must be one of hsa_fence_scope_t.
HSA_PACKET_HEADER_RELEASE_FENCE_SCOPE
Deprecated: Renamed as HSA_PACKET_HEADER_SCRELEASE_FENCE_SCOPE.
```
Source: https://hsafoundation.com/wp-content/uploads/2021/02/HSA-Runtime-1.2.pdf