### PR TITLE
[libc] Added tablegen definition for fileno

### DIFF
--- a/libc/spec/posix.td
+++ b/libc/spec/posix.td
@@ -1169,6 +1169,11 @@ def POSIX : StandardSpec<"POSIX"> {
               RetValSpec<IntType>,
               [ArgSpec<VoidType>]
           >,
+          FunctionSpec<
+            "fileno",
+            RetValSpec<IntType>,
+            [ArgSpec<FILEPtr>]
+          >,
       ]
   >;
 


### PR DESCRIPTION
This was missed in the previous PR. Updating tablegen definition with this PR. 

cc: @nickdesaulniers 