### PR TITLE
[flang] Fix cuda-option test on Darwin

### DIFF
--- a/flang/test/Driver/cuda-option.f90
+++ b/flang/test/Driver/cuda-option.f90
@@ -1,6 +1,6 @@
 ! Test -fcuda option
-! RUN: %flang -fc1 -cpp -x cuda -fdebug-unparse %s -o - | FileCheck %s
-! RUN: not %flang -fc1 -cpp %s -o - 2>&1 | FileCheck %s --check-prefix=ERROR
+! RUN: %flang_fc1 -cpp -x cuda -fdebug-unparse %s -o - | FileCheck %s
+! RUN: not %flang_fc1 -cpp %s -o - 2>&1 | FileCheck %s --check-prefix=ERROR
 program main
 #if _CUDA
   integer :: var = _CUDA


### PR DESCRIPTION
On Darwin, -isysroot is needed and is automatically appended to
%flang and %flang_fc1, so use %flang_fc1 instead to have both -fc1
and -isysroot in the expected positions and avoid errors.
