### PR TITLE
[mlir][sparse] deallocate temporary transposed tensor

### DIFF
--- a/mlir/lib/Dialect/SparseTensor/Transforms/SparseReinterpretMap.cpp
+++ b/mlir/lib/Dialect/SparseTensor/Transforms/SparseReinterpretMap.cpp
@@ -573,6 +573,12 @@ private:
       rewriter.modifyOpInPlace(linalgOp, [&]() {
         linalgOp->setOperand(t->getOperandNumber(), dst);
       });
+
+      // Release the transposed form afterwards.
+      // TODO: CSE when used in more than one following op?
+      rewriter.setInsertionPointAfter(linalgOp);
+      rewriter.create<bufferization::DeallocTensorOp>(dst.getLoc(), dst);
+
       return success();
     }
     // Cannot be resolved with a single conversion.


### PR DESCRIPTION
Last resort resolution of cycles introduced a sparse conversion without explicit sparse deallocation (which is not inserted by any automatic means). This fixes 2 out of 5 remaining asan detected leaks in sparse integration tests.