### PR TITLE
[libc] Prevent constant propagation for atanf(+-Inf) in gcc.

### DIFF
--- a/libc/src/math/generic/atanf.cpp
+++ b/libc/src/math/generic/atanf.cpp
@@ -37,8 +37,10 @@ LLVM_LIBC_FUNCTION(float, atanf, (float x)) {
     double const_term = 0.0;
     if (LIBC_UNLIKELY(x_abs >= 0x4180'0000)) {
       // atan(+-Inf) = +-pi/2.
-      if (x_bits.is_inf())
-        return static_cast<float>(SIGNED_PI_OVER_2[sign.is_neg()]);
+      if (x_bits.is_inf()) {
+        volatile double sign_pi_over_2 = SIGNED_PI_OVER_2[sign.is_neg()];
+        return static_cast<float>(sign_pi_over_2);
+      }
       if (x_bits.is_nan())
         return x;
       // x >= 16


### PR DESCRIPTION
gcc bot failures with `atanf(+-Inf)`: https://lab.llvm.org/buildbot/#/builders/250/builds/20331/steps/8/logs/stdio