### PR TITLE
[RISCV][WIP] Fold (sh3add Z, (add X, (slli Y, 6))) -> (sh3add (sh3add Y, Z), X).

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVISelDAGToDAG.h
+++ b/llvm/lib/Target/RISCV/RISCVISelDAGToDAG.h
@@ -189,6 +189,7 @@ public:
 
 private:
   bool doPeepholeSExtW(SDNode *Node);
+  bool doPeepholeSHXADD(SDNode *Node);
   bool doPeepholeMaskedRVV(MachineSDNode *Node);
   bool doPeepholeMergeVVMFold();
   bool doPeepholeNoRegPassThru();


### PR DESCRIPTION
This gives a 0.5% reduction in dynamic instruction count for 531.deepsjeng_r from spec2017. Using 2 sh3add matches what gcc generates.

This pattern appears when indexing arrays like `uint64_t fillUpAttacks[64][8]`. The first index needs to multiplied by 64 bytes and the second index needs to be multiplied by 8 bytes. Then both multiplied indices need to be added to the start of the array to calculate the full address. Alternatively, you can multiply the first index by 8 add it to the second index, then multiply the sum by 8 before adding the base pointer.

What we currently generate is a direct result of how GEPs are expanded in SelectionDAGBuilder.

This patch is a proof of concept I hacked together to do measurements and not necessarily how I think it should be implemented. There other variations of this pattern with different shift amounts that I did not handle and did not look for.

We do a lot of work during isel to find shXadd and slli instructions that are obscured. In the motivating example, Y in `(slli Y, 6)` is `(srli W, 58)`. What becomes `(slli (srli W, 58), 6)` is `(and (srl W, 52), -64)` when we start isel. We convert to a shift pair during selection of the `and`. Unless we repeat all of that cleverness to find all the variations of this pattern, we need to do this optimization sometime after isel.

There could be deeper versions of this pattern with more indices too.

X86 misses the opportunity to use 2 LEAs on the same code.

Posting this patch for discussion.