### PR TITLE
[clang][frontend] Make DumpModuleInfoAction emit the full macro

### DIFF
--- a/clang/lib/Frontend/FrontendActions.cpp
+++ b/clang/lib/Frontend/FrontendActions.cpp
@@ -943,17 +943,62 @@ void DumpModuleInfoAction::ExecuteAction() {
       for (/*<IdentifierInfo *, MacroState> pair*/ const auto &Macro :
            FilteredMacros)
         Out << "     " << Macro.first->getName() << "\n";
-    }
 
-    // Now let's print out any modules we did not see as part of the Primary.
-    for (const auto &SM : SubModMap) {
-      if (!SM.second.Seen && SM.second.Mod) {
-        Out << "  " << ModuleKindName(SM.second.Kind) << " '" << SM.first
-            << "' at index #" << SM.second.Idx
-            << " has no direct reference in the Primary\n";
+      // Emit the macro definition bodies completely.
+      Out << "   Macro Definition Bodies:\n";
+      for (const auto &Macro : FilteredMacros) {
+        Out << "     " << Macro.first->getName();
+        clang::MacroInfo *MI = PP.getMacroInfo(Macro.first);
+        if (MI == nullptr) {
+          Out << '\n';
+          continue;
+        }
+        if (MI->isFunctionLike()) {
+          Out << '(';
+          if (!MI->param_empty()) {
+            MacroInfo::param_iterator AI = MI->param_begin(),
+                                      E = MI->param_end();
+            for (; AI + 1 != E; ++AI) {
+              Out << (*AI)->getName();
+              Out << ',';
+            }
+
+            // Last argument.
+            if ((*AI)->getName() == "__VA_ARGS__")
+              Out << "...";
+            else
+              Out << (*AI)->getName();
+          }
+
+          if (MI->isGNUVarargs())
+            // #define foo(x...)
+            Out << "...";
+
+          Out << ')';
+        }
+
+        SmallString<128> SpellingBuffer;
+        bool First = true;
+        for (const auto &T : MI->tokens()) {
+          if (First || T.hasLeadingSpace())
+            Out << " ";
+          First = false;
+
+          Out << PP.getSpelling(T, SpellingBuffer);
+        }
+        Out << '\n';
       }
+
+      // Now let's print out any modules we did not see as part of the Primary.
+      for (const auto &SM : SubModMap) {
+        if (!SM.second.Seen && SM.second.Mod) {
+          Out << "  " << ModuleKindName(SM.second.Kind) << " '" << SM.first
+              << "' at index #" << SM.second.Idx
+              << " has no direct reference in the Primary\n";
+        }
+      }
+      Out << "  ====== ======\n";
     }
-    Out << "  ====== ======\n";
   }
 
   // The reminder of the output is produced from the listener as the AST

--- a/clang/test/Modules/cxx20-module-file-info-macros.cpp
+++ b/clang/test/Modules/cxx20-module-file-info-macros.cpp
@@ -40,6 +40,11 @@
 // CHECK-DAG: FUNC_Macro
 // CHECK-DAG: CONSTANT
 // CHECK-DAG: FOO
+// CHECK: Macro Definition Bodies:
+// CHECK-DAG: REDEFINE
+// CHECK-DAG: FUNC_Macro(X) (X+1)
+// CHECK-DAG: CONSTANT 43
+// CHECK-DAG: FOO
 // CHECK-NEXT: ===
 
 //--- include_foo.h
@@ -48,6 +53,10 @@
 // CHECK: Macro Definitions:
 // CHECK-DAG: CONSTANT
 // CHECK-DAG: FUNC_Macro
+// CHECK-DAG: FOO
+// CHECK: Macro Definition Bodies:
+// CHECK-DAG: FUNC_Macro(X) (X+1)
+// CHECK-DAG: CONSTANT 43
 // CHECK-DAG: FOO
 // CHECK-NEXT: ===
 
@@ -58,6 +67,10 @@ import "foo.h";
 // CHECK-DAG: CONSTANT
 // CHECK-DAG: FUNC_Macro
 // CHECK-DAG: FOO
+// CHECK: Macro Definition Bodies:
+// CHECK-DAG: FUNC_Macro
+// CHECK-DAG: CONSTANT
+// CHECK-DAG: FOO
 // CHECK-NEXT: ===
 
 //--- named_module.cppm
@@ -66,3 +79,4 @@ module;
 export module M;
 #define M_Module 43
 // CHECK-NOT: Macro Definitions:
+// CHECK-NOT: Macro Definition Bodies:


### PR DESCRIPTION
This PR works on the TODO `Emit the macro definition bodies completely`  in FrontendActions.cpp. Emiting the macro definition bodies completely can help user get more details about macro.

The beginning of macro-body string is get by MacroInfo definition location in SourceManager. Then it compute the macro-body string length by locate the '\n' but not '\\\n'. After that, the string is getted and reformmatted into one line. 
When cannot get the MacroInfo, it will only emit the name of macro definition. 

@rjmccall @kpneal @zahiraam @efriedma-quic @vgvassilev @junaire