### PR TITLE
[polly] Fix cppcheck SA comments reported in #82263

### DIFF
--- a/polly/lib/Support/GICHelper.cpp
+++ b/polly/lib/Support/GICHelper.cpp
@@ -83,10 +83,10 @@ APInt polly::APIntFromVal(__isl_take isl_val *Val) {
 }
 
 template <typename ISLTy, typename ISL_CTX_GETTER, typename ISL_PRINTER>
-static inline std::string stringFromIslObjInternal(__isl_keep ISLTy *isl_obj,
-                                                   ISL_CTX_GETTER ctx_getter_fn,
-                                                   ISL_PRINTER printer_fn,
-                                                   std::string DefaultValue) {
+static inline std::string
+stringFromIslObjInternal(__isl_keep ISLTy *isl_obj,
+                         ISL_CTX_GETTER ctx_getter_fn, ISL_PRINTER printer_fn,
+                         const std::string &DefaultValue) {
   if (!isl_obj)
     return DefaultValue;
   isl_ctx *ctx = ctx_getter_fn(isl_obj);
@@ -134,12 +134,11 @@ ISL_C_OBJECT_TO_STRING(union_map)
 ISL_C_OBJECT_TO_STRING(union_pw_aff)
 ISL_C_OBJECT_TO_STRING(union_pw_multi_aff)
 
-static void replace(std::string &str, const std::string &find,
-                    const std::string &replace) {
+static void replace(std::string &str, StringRef find, StringRef replace) {
   size_t pos = 0;
   while ((pos = str.find(find, pos)) != std::string::npos) {
-    str.replace(pos, find.length(), replace);
-    pos += replace.length();
+    str.replace(pos, find.size(), replace);
+    pos += replace.size();
   }
 }
 

--- a/polly/lib/Transform/MatmulOptimizer.cpp
+++ b/polly/lib/Transform/MatmulOptimizer.cpp
@@ -597,7 +597,7 @@ createMacroKernel(isl::schedule_node Node,
 /// @param MMI Parameters of the matrix multiplication operands.
 /// @return The size of the widest type of the matrix multiplication operands
 ///         in bytes, including alignment padding.
-static uint64_t getMatMulAlignTypeSize(MatMulInfoTy MMI) {
+static uint64_t getMatMulAlignTypeSize(const MatMulInfoTy &MMI) {
   auto *S = MMI.A->getStatement()->getParent();
   auto &DL = S->getFunction().getParent()->getDataLayout();
   auto ElementSizeA = DL.getTypeAllocSize(MMI.A->getElementType());
@@ -612,7 +612,7 @@ static uint64_t getMatMulAlignTypeSize(MatMulInfoTy MMI) {
 /// @param MMI Parameters of the matrix multiplication operands.
 /// @return The size of the widest type of the matrix multiplication operands
 ///         in bits.
-static uint64_t getMatMulTypeSize(MatMulInfoTy MMI) {
+static uint64_t getMatMulTypeSize(const MatMulInfoTy &MMI) {
   auto *S = MMI.A->getStatement()->getParent();
   auto &DL = S->getFunction().getParent()->getDataLayout();
   auto ElementSizeA = DL.getTypeSizeInBits(MMI.A->getElementType());
@@ -634,7 +634,7 @@ static uint64_t getMatMulTypeSize(MatMulInfoTy MMI) {
 /// @return The structure of type MicroKernelParamsTy.
 /// @see MicroKernelParamsTy
 static MicroKernelParamsTy getMicroKernelParams(const TargetTransformInfo *TTI,
-                                                MatMulInfoTy MMI) {
+                                                const MatMulInfoTy &MMI) {
   assert(TTI && "The target transform info should be provided.");
 
   // Nvec - Number of double-precision floating-point numbers that can be hold
@@ -711,7 +711,7 @@ static void getTargetCacheParameters(const llvm::TargetTransformInfo *TTI) {
 static MacroKernelParamsTy
 getMacroKernelParams(const llvm::TargetTransformInfo *TTI,
                      const MicroKernelParamsTy &MicroKernelParams,
-                     MatMulInfoTy MMI) {
+                     const MatMulInfoTy &MMI) {
   getTargetCacheParameters(TTI);
   // According to www.cs.utexas.edu/users/flame/pubs/TOMS-BLIS-Analytical.pdf,
   // it requires information about the first two levels of a cache to determine


### PR DESCRIPTION
This patch addresses the (performance )suggestions by checkcpp static analyzer for couple of files. Here we use const reference for the suggested function arguments.
Fixes #82263.