### PR TITLE
[libcxx] [modules] Fix relative paths with absolute LIBCXX_INSTALL_MODULES_DIR

### DIFF
--- a/libcxx/modules/CMakeLists.txt
+++ b/libcxx/modules/CMakeLists.txt
@@ -203,12 +203,23 @@ add_custom_target(generate-cxx-modules
     ${_all_modules}
 )
 
+
+function(make_absolute OUT_VAR INPUT BASE)
+  if (IS_ABSOLUTE ${INPUT})
+    set(${OUT_VAR} "${INPUT}" PARENT_SCOPE)
+  else()
+    set(${OUT_VAR} "${BASE}/${INPUT}" PARENT_SCOPE)
+  endif()
+endfunction()
+
 # Configure the modules manifest.
 # Use the relative path between the installation and the module in the json
 # file. This allows moving the entire installation to a different location.
+make_absolute(ABS_LIBRARY_DIR "${LIBCXX_INSTALL_LIBRARY_DIR}" "${CMAKE_INSTALL_PREFIX}")
+make_absolute(ABS_MODULES_DIR "${LIBCXX_INSTALL_MODULES_DIR}" "${CMAKE_INSTALL_PREFIX}")
 file(RELATIVE_PATH LIBCXX_MODULE_RELATIVE_PATH
-  ${CMAKE_INSTALL_PREFIX}/${LIBCXX_INSTALL_LIBRARY_DIR}
-  ${CMAKE_INSTALL_PREFIX}/${LIBCXX_INSTALL_MODULES_DIR})
+  ${ABS_LIBRARY_DIR}
+  ${ABS_MODULES_DIR})
 configure_file(
   "modules.json.in"
   "${LIBCXX_LIBRARY_DIR}/libc++.modules.json"

--- a/libcxx/modules/CMakeLists.txt
+++ b/libcxx/modules/CMakeLists.txt
@@ -203,20 +203,15 @@ add_custom_target(generate-cxx-modules
     ${_all_modules}
 )
 
-
-function(make_absolute OUT_VAR INPUT BASE)
-  if (IS_ABSOLUTE ${INPUT})
-    set(${OUT_VAR} "${INPUT}" PARENT_SCOPE)
-  else()
-    set(${OUT_VAR} "${BASE}/${INPUT}" PARENT_SCOPE)
-  endif()
-endfunction()
-
 # Configure the modules manifest.
 # Use the relative path between the installation and the module in the json
 # file. This allows moving the entire installation to a different location.
-make_absolute(ABS_LIBRARY_DIR "${LIBCXX_INSTALL_LIBRARY_DIR}" "${CMAKE_INSTALL_PREFIX}")
-make_absolute(ABS_MODULES_DIR "${LIBCXX_INSTALL_MODULES_DIR}" "${CMAKE_INSTALL_PREFIX}")
+cmake_path(ABSOLUTE_PATH LIBCXX_INSTALL_LIBRARY_DIR
+  BASE_DIRECTORY ${CMAKE_INSTALL_PREFIX}
+  OUTPUT_VARIABLE ABS_LIBRARY_DIR)
+cmake_path(ABSOLUTE_PATH LIBCXX_INSTALL_MODULES_DIR
+  BASE_DIRECTORY ${CMAKE_INSTALL_PREFIX}
+  OUTPUT_VARIABLE ABS_MODULES_DIR)
 file(RELATIVE_PATH LIBCXX_MODULE_RELATIVE_PATH
   ${ABS_LIBRARY_DIR}
   ${ABS_MODULES_DIR})


### PR DESCRIPTION
In other contexts, install directories such as
LIBCXX_INSTALL_LIBRARY_DIR and LIBCXX_INSTALL_MODULES_DIR can be specified either as a relative path, relative to CMAKE_INSTALL_PREFIX, or as an absolute path.

When calculating the relative path between the two, account for the fact that LIBCXX_INSTALL_MODULES_DIR and LIBCXX_INSTALL_LIBRARY_DIR can be absolute paths too.