### PR TITLE
[clang-format] Fixed the warning in building document for TableGenBreakingDAGArgOperators.

### DIFF
--- a/clang/docs/ClangFormatStyleOptions.rst
+++ b/clang/docs/ClangFormatStyleOptions.rst
@@ -6204,7 +6204,7 @@ the configuration (without a prefix: ``Auto``).
 
   For example the configuration,
 
-  .. code-block:: c++
+  .. code-block:: yaml
 
     TableGenBreakInsideDAGArg: BreakAll
     TableGenBreakingDAGArgOperators: ['ins', 'outs']

--- a/clang/include/clang/Format/Format.h
+++ b/clang/include/clang/Format/Format.h
@@ -4735,7 +4735,7 @@ struct FormatStyle {
   /// the specified identifiers.
   ///
   /// For example the configuration,
-  /// \code
+  /// \code{.yaml}
   ///   TableGenBreakInsideDAGArg: BreakAll
   ///   TableGenBreakingDAGArgOperators: ['ins', 'outs']
   /// \endcode


### PR DESCRIPTION
Intend to fix the `Test documentation build `, degraded here https://github.com/llvm/llvm-project/pull/83149 .