### PR TITLE
[lldb][DataFormatter] Fix format specifiers in LibCxxSliceArray summary provider

### DIFF
--- a/lldb/source/Plugins/Language/CPlusPlus/LibCxxSliceArray.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibCxxSliceArray.cpp
@@ -35,7 +35,7 @@ bool LibcxxStdSliceArraySummaryProvider(ValueObject &valobj, Stream &stream,
     return false;
   const size_t stride = ptr_sp->GetValueAsUnsigned(0);
 
-  stream.Printf("stride=%" PRIu64 " size=%" PRIu64, stride, size);
+  stream.Printf("stride=%zu size=%zu", stride, size);
 
   return true;
 }


### PR DESCRIPTION
This caused following warnings in an LLDB build:
```
[237/1072] Building CXX object tools/l...lusLanguage.dir/LibCxxSliceArray.cpp.o
/Volumes/Data/llvm-project/lldb/source/Plugins/Language/CPlusPlus/LibCxxSliceArray.cpp:38:53: warning: format specifies type 'unsigned long long' but the argument has type 'size_t' (aka 'unsigned long') [-Wformat]
   38 |   stream.Printf("stride=%" PRIu64 " size=%" PRIu64, stride, size);
      |                         ~~~~~~~~~                   ^~~~~~
/Volumes/Data/llvm-project/lldb/source/Plugins/Language/CPlusPlus/LibCxxSliceArray.cpp:38:61: warning: format specifies type 'unsigned long long' but the argument has type 'size_t' (aka 'unsigned long') [-Wformat]
   38 |   stream.Printf("stride=%" PRIu64 " size=%" PRIu64, stride, size);
      |                                          ~~~~~~~~~          ^~~~
2 warnings generated.
```

This patch simply changes the format specifiers to use the `%zu` for `size_t`s.