### PR TITLE
[llvm-objdump][macho] Fix relative method list dumping for little endian hosts

### DIFF
--- a/llvm/test/tools/llvm-objdump/MachO/AArch64/macho-relative-method-lists.test
+++ b/llvm/test/tools/llvm-objdump/MachO/AArch64/macho-relative-method-lists.test
@@ -1,4 +1,3 @@
-XFAIL: system-aix
 RUN: llvm-objdump --macho --objc-meta-data    %p/Inputs/rel-method-lists-arm64_32.dylib | FileCheck %s --check-prefix=CHK32
 RUN: llvm-otool -ov                           %p/Inputs/rel-method-lists-arm64_32.dylib | FileCheck %s --check-prefix=CHK32
 

--- a/llvm/tools/llvm-objdump/MachODump.cpp
+++ b/llvm/tools/llvm-objdump/MachODump.cpp
@@ -4499,11 +4499,15 @@ static void print_relative_method_list(uint32_t structSizeAndFlags,
         outs() << indent << " (nameRefPtr extends past the end of the section)";
       else {
         if (pointerSize == 64) {
-          name = get_pointer_64(*reinterpret_cast<const uint64_t *>(nameRefPtr),
-                                xoffset, left, xS, info);
+          uint64_t nameOff_64 = *reinterpret_cast<const uint64_t *>(nameRefPtr);
+          if (info->O->isLittleEndian() != sys::IsLittleEndianHost)
+            sys::swapByteOrder(nameOff_64);
+          name = get_pointer_64(nameOff_64, xoffset, left, xS, info);
         } else {
-          name = get_pointer_32(*reinterpret_cast<const uint32_t *>(nameRefPtr),
-                                xoffset, left, xS, info);
+          uint32_t nameOff_32 = *reinterpret_cast<const uint32_t *>(nameRefPtr);
+          if (info->O->isLittleEndian() != sys::IsLittleEndianHost)
+            sys::swapByteOrder(nameOff_32);
+          name = get_pointer_32(nameOff_32, xoffset, left, xS, info);
         }
         if (name != nullptr)
           outs() << format(" %.*s", left, name);


### PR DESCRIPTION
`macho-relative-method-lists.test` is failing on little endian platforms, when matching 'name'. 

```
CHK32-NEXT: name 0x144 (0x{{[0-9a-f]*}}) instance_method_00

next:10'0             X error: no match found
          18:  name 0x144 (0x7ac)      
```
This seems like the obvious fix.