### PR TITLE
[libc++][CI] Reenables the module tests.

### DIFF
--- a/libcxx/test/libcxx/module_std.gen.py
+++ b/libcxx/test/libcxx/module_std.gen.py
@@ -16,11 +16,7 @@
 # to be one monolitic test. Since the test doesn't take very long it's
 # not a huge issue.
 
-# WARNING: Disabled at the bottom. Fix this test and remove the UNSUPPORTED line
-# TODO: Re-enable this test once we understand why it keeps timing out.
-
 # RUN: %{python} %s %{libcxx-dir}/utils
-# END.
 
 import sys
 
@@ -39,5 +35,4 @@ generator = module_test_generator(
 
 
 print("//--- module_std.sh.cpp")
-print('// UNSUPPORTED: clang')
 generator.write_test("std")

--- a/libcxx/test/libcxx/module_std_compat.gen.py
+++ b/libcxx/test/libcxx/module_std_compat.gen.py
@@ -16,11 +16,7 @@
 # to be one monolitic test. Since the test doesn't take very long it's
 # not a huge issue.
 
-# WARNING: Disabled at the bottom. Fix this test and remove the UNSUPPORTED line
-# TODO: Re-enable this test once we understand why it keeps timing out.
-
 # RUN: %{python} %s %{libcxx-dir}/utils
-# END.
 
 import sys
 
@@ -40,7 +36,6 @@ generator = module_test_generator(
 
 
 print("//--- module_std_compat.sh.cpp")
-print("// UNSUPPORTED: clang")
 generator.write_test(
     "std.compat",
     module_c_headers,


### PR DESCRIPTION
These were disabled due to ODR violations with mixed versions of clang-tidy and the clang libraries. This issue was fixed in e19e8600cf743690e1a23fb8a2b0dfbe2dafe559.

This reverts commit 0bbada93a559b604797fe57978f3eca5e41edaeb.