### PR TITLE
add ucmp and scmp support to SelectionDAG

### DIFF
--- a/llvm/include/llvm/CodeGen/ISDOpcodes.h
+++ b/llvm/include/llvm/CodeGen/ISDOpcodes.h
@@ -676,6 +676,11 @@ enum NodeType {
   UMIN,
   UMAX,
 
+  /// [US]CMP - Three way integer comparison - returns -1, 0, or 1 if
+  /// Op1 < Op2, Op1 == Op2, Op1 > Op2, respectively.
+  SCMP,
+  UCMP,
+
   /// Bitwise operators - logical and, logical or, logical xor.
   AND,
   OR,

--- a/llvm/include/llvm/CodeGen/TargetLowering.h
+++ b/llvm/include/llvm/CodeGen/TargetLowering.h
@@ -5314,6 +5314,10 @@ public:
   /// method accepts integers as its arguments.
   SDValue expandIntMINMAX(SDNode *Node, SelectionDAG &DAG) const;
 
+  /// Method for building the DAG expansion of ISD::[US]CMP. This
+  /// method accepts integers as its arguments.
+  SDValue expandCMP(SDNode *Node, SelectionDAG &DAG) const;
+
   /// Method for building the DAG expansion of ISD::[US][ADD|SUB]SAT. This
   /// method accepts integers as its arguments.
   SDValue expandAddSubSat(SDNode *Node, SelectionDAG &DAG) const;

--- a/llvm/lib/CodeGen/SelectionDAG/LegalizeDAG.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/LegalizeDAG.cpp
@@ -3582,6 +3582,10 @@ bool SelectionDAGLegalize::ExpandNode(SDNode *Node) {
     Results.push_back(Tmp1);
     break;
   }
+  case ISD::UCMP:
+  case ISD::SCMP:
+  // FIX: add logic here
+    break;
   case ISD::FMINNUM:
   case ISD::FMAXNUM: {
     if (SDValue Expanded = TLI.expandFMINNUM_FMAXNUM(Node, DAG))
@@ -5134,6 +5138,10 @@ void SelectionDAGLegalize::PromoteNode(SDNode *Node) {
     Results.push_back(DAG.getNode(TruncOp, dl, OVT, Tmp1));
     break;
   }
+  case ISD::UCMP:
+  case ISD::SCMP:
+    // FIX: add logic here
+    break;
   case ISD::UMUL_LOHI:
   case ISD::SMUL_LOHI: {
     // Promote to a multiply in a wider integer type.

--- a/llvm/lib/CodeGen/SelectionDAG/SelectionDAG.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/SelectionDAG.cpp
@@ -6706,9 +6706,22 @@ SDValue SelectionDAG::getNode(unsigned Opcode, const SDLoc &DL, EVT VT,
     break;
   case ISD::UCMP:
   case ISD::SCMP:
+    // FIX: This cast is clearly wrong
+    assert(cast<SignedInt>(N1.getValueType) && "This operator should have signed types");
     assert(VT.isInteger() && "This operator does not apply to FP types!");
     assert(N1.getValueType() == N2.getValueType() && N1.getValueType() == VT &&
 	       "Binary operator types must match");
+    // FIX: This logic should probably go in a separate function to deduplicate it from ucmp. Suggestions?
+    if (N1C > N2C) {
+      // FIX: All of these casts are horrible, I couldn't find the proper way to fold the constants in
+      return cast<ConstantInt>(1);
+    }
+    if (N1C == N2C) {
+      return cast<ConstantInt>(0);
+    }
+    if (N1C < N2C) {
+      return cast<ConstantInt>(-1);
+    }
       break;
   case ISD::MUL:
     assert(VT.isInteger() && "This operator does not apply to FP types!");

--- a/llvm/lib/CodeGen/SelectionDAG/SelectionDAG.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/SelectionDAG.cpp
@@ -6707,8 +6707,8 @@ SDValue SelectionDAG::getNode(unsigned Opcode, const SDLoc &DL, EVT VT,
   case ISD::UCMP:
   case ISD::SCMP:
     assert(VT.isInteger() && "This operator does not apply to FP types!");
-    assert(N1.getValueType() == N2.getValueType() && 
-           N1.getValueType() == VT && "Binary operator types must match");
+    assert(N1.getValueType() == N2.getValueType() && N1.getValueType() == VT &&
+	       "Binary operator types must match");
       break;
   case ISD::MUL:
     assert(VT.isInteger() && "This operator does not apply to FP types!");

--- a/llvm/lib/CodeGen/SelectionDAG/SelectionDAG.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/SelectionDAG.cpp
@@ -6704,6 +6704,12 @@ SDValue SelectionDAG::getNode(unsigned Opcode, const SDLoc &DL, EVT VT,
         VT.getVectorElementType() == MVT::i1)
       return getNode(ISD::XOR, DL, VT, N1, N2);
     break;
+  case ISD::UCMP:
+  case ISD::SCMP:
+    assert(VT.isInteger() && "This operator does not apply to FP types!");
+    assert(N1.getValueType() == N2.getValueType() && 
+           N1.getValueType() == VT && "Binary operator types must match");
+      break;
   case ISD::MUL:
     assert(VT.isInteger() && "This operator does not apply to FP types!");
     assert(N1.getValueType() == N2.getValueType() &&

--- a/llvm/unittests/Analysis/ValueTrackingTest.cpp
+++ b/llvm/unittests/Analysis/ValueTrackingTest.cpp
@@ -891,6 +891,8 @@ TEST(ValueTracking, propagatesPoison) {
       {true, "call i32 @llvm.smin.i32(i32 %x, i32 %y)", 0},
       {true, "call i32 @llvm.umax.i32(i32 %x, i32 %y)", 0},
       {true, "call i32 @llvm.umin.i32(i32 %x, i32 %y)", 0},
+      {true, "call i32 @llvm.scmp.i32.i32(i32 %x, i32 %y)", 0},
+      {true, "call i32 @llvm.ucmp.i32.i32(i32 %x, i32 %y)", 0},
       {true, "call i32 @llvm.bitreverse.i32(i32 %x)", 0},
       {true, "call i32 @llvm.bswap.i32(i32 %x)", 0},
       {false, "call i32 @llvm.fshl.i32(i32 %x, i32 %y, i32 %shamt)", 0},


### PR DESCRIPTION
This PR is the next step after https://github.com/llvm/llvm-project/pull/83227 in a possible GSoC project to add 3 way comparison intrinsics to LLVM IR.

Steps as outlined in the [documentation](https://llvm.org/docs/ExtendingLLVM.html#adding-a-new-selectiondag-node)

1. [X] Add an enum value for the SelectionDAG node in `.../ISDOpcodes.h`
2. [x]  `CodeGen/SelectionDAG/SelectionDAG.cpp` - add code to print the node to `getOperationName`
3. [ ] `.../SelectionDAG/LegalizeDAG.cpp` - add legalize, promote, expand directives as necessary
4. [ ] ibid - size promotion of only applicable to same sizes
5. [ ] ibid - add a case for node in `ExpandOp` to teach legalizer for 64bits in 32bit targets
6. [ ] `SDAG/DAGCombiner.cpp` - add a visit function (see `visitFABS` and `visitSRL` as starting places
7. [ ] `llvm/Target/PowerPC/PPCISelLowering.cpp` - add native support if not default
8. [ ] `Target/TargetSelectionDAG.td` - add a `def` to that node with appropriate type constrains (see `add/bswap/fadd`)
9. [ ] `lib/Target/PowerPC/PPCInstrInfo.td` - add a pattern for new node that uses one or more target nodes (see `rotl` in `PPCInstrInfo.td`)
10. [ ] add complex patterns?
11. [ ] `test/CodeGen/*` add unit tests as you go

cc @nikic and @dc03-work 