### PR TITLE
[libcxx] modules: compile library interface object files of `std` and `std.compat` modules into `libc++experimental.a`

### DIFF
--- a/libcxx/modules/CMakeLists.txt
+++ b/libcxx/modules/CMakeLists.txt
@@ -211,7 +211,7 @@ file(RELATIVE_PATH LIBCXX_MODULE_RELATIVE_PATH
   ${CMAKE_INSTALL_PREFIX}/${LIBCXX_INSTALL_MODULES_DIR})
 configure_file(
   "modules.json.in"
-  "${LIBCXX_LIBRARY_DIR}/libc++.modules.json"
+  "${LIBCXX_LIBRARY_DIR}/libc++experimental.modules.json"
   @ONLY
 )
 
@@ -229,6 +229,23 @@ if (LIBCXX_INSTALL_MODULES)
     )
   endforeach()
 
+  # Build the "library interface object files" as part of the library artifact.
+  # For now, this adds just the module initializer symbols for modules "std"
+  # and "std.compat".
+  target_sources(cxx_experimental PUBLIC FILE_SET CXX_MODULES
+    BASE_DIRS
+      "${LIBCXX_GENERATED_MODULE_DIR}"
+    FILES
+      "${LIBCXX_GENERATED_MODULE_DIR}/std.cppm"
+      "${LIBCXX_GENERATED_MODULE_DIR}/std.compat.cppm"
+  )
+  set_source_files_properties(
+      "${LIBCXX_GENERATED_MODULE_DIR}/std.cppm"
+      "${LIBCXX_GENERATED_MODULE_DIR}/std.compat.cppm"
+    TARGET_DIRECTORY cxx_experimental
+    PROPERTIES COMPILE_OPTIONS "-U_LIBCPP_BUILDING_LIBRARY;-Wno-reserved-module-identifier")
+  add_dependencies(cxx_experimental generate-cxx-modules)
+
   # Install the generated module files.
   install(FILES
       "${LIBCXX_GENERATED_MODULE_DIR}/std.cppm"
@@ -240,7 +257,7 @@ if (LIBCXX_INSTALL_MODULES)
 
   # Install the module manifest.
   install(FILES
-      "${LIBCXX_LIBRARY_DIR}/libc++.modules.json"
+      "${LIBCXX_LIBRARY_DIR}/libc++experimental.modules.json"
     DESTINATION "${LIBCXX_INSTALL_LIBRARY_DIR}"
     COMPONENT cxx-modules
     PERMISSIONS OWNER_READ OWNER_WRITE GROUP_READ WORLD_READ

--- a/libcxx/modules/CMakeLists.txt
+++ b/libcxx/modules/CMakeLists.txt
@@ -229,22 +229,26 @@ if (LIBCXX_INSTALL_MODULES)
     )
   endforeach()
 
-  # Build the "library interface object files" as part of the library artifact.
-  # For now, this adds just the module initializer symbols for modules "std"
-  # and "std.compat".
-  target_sources(cxx_experimental PUBLIC FILE_SET CXX_MODULES
-    BASE_DIRS
-      "${LIBCXX_GENERATED_MODULE_DIR}"
-    FILES
-      "${LIBCXX_GENERATED_MODULE_DIR}/std.cppm"
-      "${LIBCXX_GENERATED_MODULE_DIR}/std.compat.cppm"
-  )
-  set_source_files_properties(
-      "${LIBCXX_GENERATED_MODULE_DIR}/std.cppm"
-      "${LIBCXX_GENERATED_MODULE_DIR}/std.compat.cppm"
-    TARGET_DIRECTORY cxx_experimental
-    PROPERTIES COMPILE_OPTIONS "-U_LIBCPP_BUILDING_LIBRARY;-Wno-reserved-module-identifier")
-  add_dependencies(cxx_experimental generate-cxx-modules)
+  if (CMAKE_VERSION VERSION_GREATER_EQUAL "3.28.0")
+    # Build the "library interface object files" as part of the library artifact.
+    # For now, this adds just the module initializer symbols for modules "std"
+    # and "std.compat".
+    target_sources(cxx_experimental PUBLIC FILE_SET CXX_MODULES
+      BASE_DIRS
+        "${LIBCXX_GENERATED_MODULE_DIR}"
+      FILES
+        "${LIBCXX_GENERATED_MODULE_DIR}/std.cppm"
+        "${LIBCXX_GENERATED_MODULE_DIR}/std.compat.cppm"
+    )
+    set_source_files_properties(
+        "${LIBCXX_GENERATED_MODULE_DIR}/std.cppm"
+        "${LIBCXX_GENERATED_MODULE_DIR}/std.compat.cppm"
+      TARGET_DIRECTORY cxx_experimental
+      PROPERTIES COMPILE_OPTIONS "-U_LIBCPP_BUILDING_LIBRARY;-Wno-reserved-module-identifier")
+    add_dependencies(cxx_experimental generate-cxx-modules)
+  else()
+    message(WARNING "CMake 3.28.0 needed for module symbol support in libc++experimental")
+  endif()
 
   # Install the generated module files.
   install(FILES


### PR DESCRIPTION
The current design of C++ modules and the current state of the build system tooling (mostly CMake I guess) make it hard to ship module interface files (`.cppm`) to users without still providing the object files of the `.cppm` files in some library artifact.

There are good discussions about the problems here:

 - <https://lists.isocpp.org/sg15/2024/02/2353.php>
 - <https://github.com/llvm/llvm-project/issues/80639>

This patch adds the `.cppm` files to the build of `libc++experimental.a`. This results in exactly two new symbols, namely the module initializer symbols of the `std` and `std.compat` modules. Furthermore, `libc++.modules.json` is renamed to `libc++experimental.modules.json` to express that the module symbols are owned by `libc++experimental.a`, not `libc++.{a,so}`.

CMake >= 3.28 is needed for this to work if `LIBCXX_INSTALL_MODULES` is `ON`.