### PR TITLE
[memprof] Move allocator base to avoid conflict with high-entropy ASLR

### DIFF
--- a/compiler-rt/lib/memprof/memprof_allocator.h
+++ b/compiler-rt/lib/memprof/memprof_allocator.h
@@ -46,7 +46,7 @@ struct MemprofMapUnmapCallback {
   void OnUnmap(uptr p, uptr size) const;
 };
 
-constexpr uptr kAllocatorSpace = 0x600000000000ULL;
+constexpr uptr kAllocatorSpace = 0x500000000000ULL;
 constexpr uptr kAllocatorSize = 0x40000000000ULL; // 4T.
 typedef DefaultSizeClassMap SizeClassMap;
 template <typename AddressSpaceViewTy>

--- a/compiler-rt/lib/memprof/memprof_allocator.h
+++ b/compiler-rt/lib/memprof/memprof_allocator.h
@@ -46,7 +46,11 @@ struct MemprofMapUnmapCallback {
   void OnUnmap(uptr p, uptr size) const;
 };
 
+#if SANITIZER_APPLE
+constexpr uptr kAllocatorSpace = 0x600000000000ULL;
+#else
 constexpr uptr kAllocatorSpace = 0x500000000000ULL;
+#endif
 constexpr uptr kAllocatorSize = 0x40000000000ULL; // 4T.
 typedef DefaultSizeClassMap SizeClassMap;
 template <typename AddressSpaceViewTy>


### PR DESCRIPTION
memprof often fails when ASLR entropy is too high ('sudo sysctl vm.mmap_rnd_bits=32; ninja check-memprof'), which is the default setting for newer versions of Ubuntu (https://git.launchpad.net/~ubuntu-kernel/ubuntu/+source/linux/+git/jammy/commit/?h=hwe-6.5-next--2024.03.04-1--auto&id=6b522637c6a7dabd8530026ae933fb5ff17e877f). This patch fixes the issue by moving the allocator base, analogously to ASan (https://reviews.llvm.org/D148280).

Explanation from the ASan patch: when CONFIG_ARCH_MMAP_RND_BITS == 32, it will frequently conflict with memprof's allocator, because the PIE program segment base address of 0x555555555554 plus an ASLR shift of up to ((2**32) * 4K == 0x100000000000) will sometimes exceed memprof's hardcoded base address of 0x600000000000. We fix this by simply moving the allocator base to 0x500000000000, which is below the PIE program segment base address. This is cleaner than trying to move it to another location that is sandwiched between the PIE program and library segments, because if either of those grow too large, it will collide with the allocator region.

Note that we will never need to change this base address again (unless we want to increase the size of the allocator), because ASLR cannot be set above 32-bits for x86-64 Linux (the PIE program segment and library segments would collide with each other; see also ARCH_MMAP_RND_BITS_MAX in https://github.com/torvalds/linux/blob/master/arch/x86/Kconfig).