### PR TITLE
[flang] Fix crash in name resolution

### DIFF
--- a/flang/test/Semantics/resolve61.f90
+++ b/flang/test/Semantics/resolve61.f90
@@ -126,3 +126,12 @@ subroutine p13
     pointer(ip, x) ! ok, local declaration
   end
 end
+
+subroutine p14
+  real :: r
+  block
+    asynchronous :: r
+    !ERROR: PARAMETER attribute not allowed on 'r'
+    parameter (r = 1.0)
+  end block
+end


### PR DESCRIPTION
ConvertToObjectEntity() returns true for use- and host-associated object symbols, too.  Ensure in this case that the symbol really is a non-associated object.

Fixes https://github.com/llvm/llvm-project/issues/85776.