### PR TITLE
[clang][c++20] Fix code coverage mapping crash with generalized NTTPs

### DIFF
--- a/clang/lib/CodeGen/CoverageMappingGen.cpp
+++ b/clang/lib/CodeGen/CoverageMappingGen.cpp
@@ -2187,8 +2187,8 @@ struct CounterCoverageMappingBuilder
   }
 
   void VisitOpaqueValueExpr(const OpaqueValueExpr* OVE) {
-    if (const Expr *SE = OVE->getSourceExpr())
-      Visit(SE);
+    if (OVE->isUnique())
+      Visit(OVE->getSourceExpr());
   }
 };
 

--- a/clang/lib/CodeGen/CoverageMappingGen.cpp
+++ b/clang/lib/CodeGen/CoverageMappingGen.cpp
@@ -2187,7 +2187,8 @@ struct CounterCoverageMappingBuilder
   }
 
   void VisitOpaqueValueExpr(const OpaqueValueExpr* OVE) {
-    Visit(OVE->getSourceExpr());
+    if (const Expr *SE = OVE->getSourceExpr())
+      Visit(SE);
   }
 };
 

--- a/clang/test/CoverageMapping/templates.cpp
+++ b/clang/test/CoverageMapping/templates.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -mllvm -emptyline-comment-coverage=false -fprofile-instrument=clang -fcoverage-mapping -dump-coverage-mapping -emit-llvm-only -main-file-name templates.cpp %s | FileCheck %s
+// RUN: %clang_cc1 -std=c++20 -mllvm -emptyline-comment-coverage=false -fprofile-instrument=clang -fcoverage-mapping -dump-coverage-mapping -emit-llvm-only -main-file-name templates.cpp %s | FileCheck %s
 
 template<typename T>
 void unused(T x) {
@@ -30,5 +30,6 @@ namespace structural_value_crash {
 
   void test() {
     tpl_fn<arr>();
+    tpl_fn<&arr[1]>();
   }
 }


### PR DESCRIPTION
Introduced in #78041, originally reported as #79957 and fixed partially in #80050.

`OpaqueValueExpr` used with `TemplateArgument::StructuralValue` has no corresponding source expression.

A test case with subobject-referring NTTP added.

@erichkeane, @cor3ntin, @Endilll