### PR TITLE
[lldb] Omit --show-globals in `help target var`

### DIFF
--- a/lldb/test/API/functionalities/target_var/TestTargetVar.py
+++ b/lldb/test/API/functionalities/target_var/TestTargetVar.py
@@ -15,6 +15,16 @@ class targetCommandTestCase(TestBase):
     def testTargetVarExpr(self):
         self.build()
         lldbutil.run_to_name_breakpoint(self, "main")
+        self.expect(
+            "help target variable",
+            substrs=[
+                "--no-args",
+                "--no-recognized-args",
+                "--no-locals",
+                "--show-globals",
+            ],
+            matching=False,
+        )
         self.expect("target variable i", substrs=["i", "42"])
         self.expect(
             "target variable var", patterns=["\(incomplete \*\) var = 0[xX](0)*dead"]


### PR DESCRIPTION
This option doesn't exist. It is currently displayed by `help target var` due to a bug introduced by 41ae8e7445 in 2018.

Some code for `target var` and `frame var` is shared, and some hard-code constants are used in order to filter out options that belong only to `frame var`. However, the aforementioned commit failed to update these constants properly. This patch addresses the issue by having a _single_ place where the filtering of options needs to be done.