### PR TITLE
[lldb] Invert relationship between Process and AddressableBits

### DIFF
--- a/lldb/include/lldb/Target/Process.h
+++ b/lldb/include/lldb/Target/Process.h
@@ -43,6 +43,7 @@
 #include "lldb/Target/ThreadList.h"
 #include "lldb/Target/ThreadPlanStack.h"
 #include "lldb/Target/Trace.h"
+#include "lldb/Utility/AddressableBits.h"
 #include "lldb/Utility/ArchSpec.h"
 #include "lldb/Utility/Broadcaster.h"
 #include "lldb/Utility/Event.h"
@@ -3218,6 +3219,8 @@ protected:
   virtual Status UpdateAutomaticSignalFiltering();
 
   void LoadOperatingSystemPlugin(bool flush);
+
+  void SetAddressableBitMasks(AddressableBits bit_masks);
 
 private:
   Status DestroyImpl(bool force_kill);

--- a/lldb/include/lldb/Utility/AddressableBits.h
+++ b/lldb/include/lldb/Utility/AddressableBits.h
@@ -32,11 +32,13 @@ public:
 
   void SetLowmemAddressableBits(uint32_t lowmem_addressing_bits);
 
+  uint32_t GetLowmemAddressableBits() const;
+
   void SetHighmemAddressableBits(uint32_t highmem_addressing_bits);
 
-  static lldb::addr_t AddressableBitToMask(uint32_t addressable_bits);
+  uint32_t GetHighmemAddressableBits() const;
 
-  void SetProcessMasks(lldb_private::Process &process);
+  static lldb::addr_t AddressableBitToMask(uint32_t addressable_bits);
 
 private:
   uint32_t m_low_memory_addr_bits;

--- a/lldb/source/Plugins/Process/gdb-remote/ProcessGDBRemote.cpp
+++ b/lldb/source/Plugins/Process/gdb-remote/ProcessGDBRemote.cpp
@@ -900,7 +900,7 @@ void ProcessGDBRemote::DidLaunchOrAttach(ArchSpec &process_arch) {
   }
 
   AddressableBits addressable_bits = m_gdb_comm.GetAddressableBits();
-  addressable_bits.SetProcessMasks(*this);
+  SetAddressableBitMasks(addressable_bits);
 
   if (process_arch.IsValid()) {
     const ArchSpec &target_arch = GetTarget().GetArchitecture();
@@ -2337,7 +2337,7 @@ StateType ProcessGDBRemote::SetThreadStopInfo(StringExtractor &stop_packet) {
       }
     }
 
-    addressable_bits.SetProcessMasks(*this);
+    SetAddressableBitMasks(addressable_bits);
 
     ThreadSP thread_sp = SetThreadStopInfo(
         tid, expedited_register_map, signo, thread_name, reason, description,

--- a/lldb/source/Plugins/Process/mach-core/ProcessMachCore.cpp
+++ b/lldb/source/Plugins/Process/mach-core/ProcessMachCore.cpp
@@ -574,7 +574,7 @@ Status ProcessMachCore::DoLoadCore() {
   CleanupMemoryRegionPermissions();
 
   AddressableBits addressable_bits = core_objfile->GetAddressableBits();
-  addressable_bits.SetProcessMasks(*this);
+  SetAddressableBitMasks(addressable_bits);
 
   return error;
 }

--- a/lldb/source/Target/Process.cpp
+++ b/lldb/source/Target/Process.cpp
@@ -63,6 +63,7 @@
 #include "lldb/Target/ThreadPlanCallFunction.h"
 #include "lldb/Target/ThreadPlanStack.h"
 #include "lldb/Target/UnixSignals.h"
+#include "lldb/Utility/AddressableBits.h"
 #include "lldb/Utility/Event.h"
 #include "lldb/Utility/LLDBLog.h"
 #include "lldb/Utility/Log.h"
@@ -6452,4 +6453,26 @@ Status Process::CalculateCoreFileSaveRanges(lldb::SaveCoreStyle core_style,
     return Status("no valid address ranges found for core style");
 
   return Status(); // Success!
+}
+
+void Process::SetAddressableBitMasks(AddressableBits bit_masks) {
+  uint32_t low_memory_addr_bits = bit_masks.GetLowmemAddressableBits();
+  uint32_t high_memory_addr_bits = bit_masks.GetHighmemAddressableBits();
+
+  if (low_memory_addr_bits == 0 && high_memory_addr_bits == 0)
+    return;
+
+  if (low_memory_addr_bits != 0) {
+    addr_t low_addr_mask =
+        AddressableBits::AddressableBitToMask(low_memory_addr_bits);
+    SetCodeAddressMask(low_addr_mask);
+    SetDataAddressMask(low_addr_mask);
+  }
+
+  if (high_memory_addr_bits != 0) {
+    addr_t high_addr_mask =
+        AddressableBits::AddressableBitToMask(high_memory_addr_bits);
+    SetHighmemCodeAddressMask(high_addr_mask);
+    SetHighmemDataAddressMask(high_addr_mask);
+  }
 }

--- a/lldb/source/Utility/AddressableBits.cpp
+++ b/lldb/source/Utility/AddressableBits.cpp
@@ -7,8 +7,9 @@
 //===----------------------------------------------------------------------===//
 
 #include "lldb/Utility/AddressableBits.h"
-#include "lldb/Target/Process.h"
 #include "lldb/lldb-types.h"
+
+#include <cassert>
 
 using namespace lldb;
 using namespace lldb_private;
@@ -28,9 +29,17 @@ void AddressableBits::SetLowmemAddressableBits(
   m_low_memory_addr_bits = lowmem_addressing_bits;
 }
 
+uint32_t AddressableBits::GetLowmemAddressableBits() const {
+  return m_low_memory_addr_bits;
+}
+
 void AddressableBits::SetHighmemAddressableBits(
     uint32_t highmem_addressing_bits) {
   m_high_memory_addr_bits = highmem_addressing_bits;
+}
+
+uint32_t AddressableBits::GetHighmemAddressableBits() const {
+  return m_high_memory_addr_bits;
 }
 
 addr_t AddressableBits::AddressableBitToMask(uint32_t addressable_bits) {
@@ -39,21 +48,4 @@ addr_t AddressableBits::AddressableBitToMask(uint32_t addressable_bits) {
     return 0; // all bits used for addressing
   else
     return ~((1ULL << addressable_bits) - 1);
-}
-
-void AddressableBits::SetProcessMasks(Process &process) {
-  if (m_low_memory_addr_bits == 0 && m_high_memory_addr_bits == 0)
-    return;
-
-  if (m_low_memory_addr_bits != 0) {
-    addr_t low_addr_mask = AddressableBitToMask(m_low_memory_addr_bits);
-    process.SetCodeAddressMask(low_addr_mask);
-    process.SetDataAddressMask(low_addr_mask);
-  }
-
-  if (m_high_memory_addr_bits != 0) {
-    addr_t hi_addr_mask = AddressableBitToMask(m_high_memory_addr_bits);
-    process.SetHighmemCodeAddressMask(hi_addr_mask);
-    process.SetHighmemDataAddressMask(hi_addr_mask);
-  }
 }


### PR DESCRIPTION
AddressableBits is in the Utility module of LLDB. It currently directly refers to Process, which is from the Target LLDB module. This is a layering violation which concretely means that it is impossible to link anything that uses Utility without it also using Target as well. This is generally not an issue for LLDB (since everything is built together) but it may make it difficult to write unit tests for AddressableBits later on.