### PR TITLE
[TableGen] Fix operand constraint checking problem.

### DIFF
--- a/llvm/test/TableGen/ConstraintChecking3.td
+++ b/llvm/test/TableGen/ConstraintChecking3.td
@@ -4,5 +4,5 @@ include "ConstraintChecking.inc"
 
 // (This is illegal because the '=' has to be surrounded by whitespace)
 
-// CHECK: [[FILE]]:[[@LINE+1]]:5: error: Illegal format for tied-to constraint in 'Foo'
+// CHECK: [[FILE]]:[[@LINE+1]]:5: error: Unrecognized constraint '$dest1=$dest2' in 'Foo'
 def Foo : TestInstructionWithConstraints<"$dest1=$dest2">;

--- a/llvm/test/TableGen/ConstraintChecking8.td
+++ b/llvm/test/TableGen/ConstraintChecking8.td
@@ -19,7 +19,7 @@ def Foo : TestInstructionWithConstraints<"$dest1 == $src2">;
 #endif
 
 #ifdef T2
-// CHECK2: [[FILE]]:[[@LINE+1]]:5: error: Illegal format for tied-to constraint in 'Foo': '= $rhs'
+// CHECK2: [[FILE]]:[[@LINE+1]]:5: error: Unrecognized constraint '= $rhs' in 'Foo'
 def Foo : TestInstructionWithConstraints<"= $rhs">;
 #endif
 

--- a/llvm/test/TableGen/ConstraintChecking8.td
+++ b/llvm/test/TableGen/ConstraintChecking8.td
@@ -1,8 +1,34 @@
-// RUN: not llvm-tblgen -gen-asm-writer -I %p -I %p/../../include %s 2>&1 | FileCheck %s -DFILE=%s
+// RUN: not llvm-tblgen -gen-asm-writer -DT0 -I %p -I %p/../../include %s 2>&1 | FileCheck %s -DFILE=%s
+// RUN: not llvm-tblgen -gen-asm-writer -DT1 -I %p -I %p/../../include %s 2>&1 | FileCheck %s -DFILE=%s --check-prefix=CHECK1
+// RUN: not llvm-tblgen -gen-asm-writer -DT2 -I %p -I %p/../../include %s 2>&1 | FileCheck %s -DFILE=%s --check-prefix=CHECK2
+// RUN: not llvm-tblgen -gen-asm-writer -DT3 -I %p -I %p/../../include %s 2>&1 | FileCheck %s -DFILE=%s --check-prefix=CHECK3
+// RUN: not llvm-tblgen -gen-asm-writer -DT4 -I %p -I %p/../../include %s 2>&1 | FileCheck %s -DFILE=%s --check-prefix=CHECK4
 
 include "ConstraintChecking.inc"
 
 // Make sure exactly the token "=" appears.
 
+#ifdef T0
 // CHECK: [[FILE]]:[[@LINE+1]]:5: error: Unrecognized constraint '$dest1 != $src2' in 'Foo'
 def Foo : TestInstructionWithConstraints<"$dest1 != $src2">;
+#endif
+
+#ifdef T1
+// CHECK1: [[FILE]]:[[@LINE+1]]:5: error: Unrecognized constraint '$dest1 == $src2' in 'Foo'
+def Foo : TestInstructionWithConstraints<"$dest1 == $src2">;
+#endif
+
+#ifdef T2
+// CHECK2: [[FILE]]:[[@LINE+1]]:5: error: Illegal format for tied-to constraint in 'Foo': '= $rhs'
+def Foo : TestInstructionWithConstraints<"= $rhs">;
+#endif
+
+#ifdef T3
+// CHECK3: [[FILE]]:[[@LINE+1]]:5: error: Unrecognized constraint '$lhs =' in 'Foo'
+def Foo : TestInstructionWithConstraints<"$lhs =">;
+#endif
+
+#ifdef T4
+// CHECK4: [[FILE]]:[[@LINE+1]]:5: error: Unrecognized constraint '=' in 'Foo'
+def Foo : TestInstructionWithConstraints<"=">;
+#endif

--- a/llvm/test/TableGen/ConstraintChecking8.td
+++ b/llvm/test/TableGen/ConstraintChecking8.td
@@ -1,0 +1,8 @@
+// RUN: not llvm-tblgen -gen-asm-writer -I %p -I %p/../../include %s 2>&1 | FileCheck %s -DFILE=%s
+
+include "ConstraintChecking.inc"
+
+// Make sure exactly the token "=" appears.
+
+// CHECK: [[FILE]]:[[@LINE+1]]:5: error: Unrecognized constraint '$dest1 != $src2' in 'Foo'
+def Foo : TestInstructionWithConstraints<"$dest1 != $src2">;

--- a/llvm/test/TableGen/ConstraintChecking9.td
+++ b/llvm/test/TableGen/ConstraintChecking9.td
@@ -1,8 +1,0 @@
-// RUN: not llvm-tblgen -gen-asm-writer -I %p -I %p/../../include %s 2>&1 | FileCheck %s -DFILE=%s
-
-include "ConstraintChecking.inc"
-
-// Make sure exactly the token "=" appears.
-
-// CHECK: [[FILE]]:[[@LINE+1]]:5: error: Unrecognized constraint '$dest1 == $src2' in 'Foo'
-def Foo : TestInstructionWithConstraints<"$dest1 == $src2">;

--- a/llvm/test/TableGen/ConstraintChecking9.td
+++ b/llvm/test/TableGen/ConstraintChecking9.td
@@ -1,0 +1,8 @@
+// RUN: not llvm-tblgen -gen-asm-writer -I %p -I %p/../../include %s 2>&1 | FileCheck %s -DFILE=%s
+
+include "ConstraintChecking.inc"
+
+// Make sure exactly the token "=" appears.
+
+// CHECK: [[FILE]]:[[@LINE+1]]:5: error: Unrecognized constraint '$dest1 == $src2' in 'Foo'
+def Foo : TestInstructionWithConstraints<"$dest1 == $src2">;

--- a/llvm/utils/TableGen/CodeGenInstruction.cpp
+++ b/llvm/utils/TableGen/CodeGenInstruction.cpp
@@ -325,7 +325,8 @@ static void ParseConstraint(StringRef CStr, CGIOperandList &Ops, Record *Rec) {
 
   // Only other constraint is "TIED_TO" for now.
   StringRef::size_type pos = CStr.find_first_of('=');
-  if (pos == StringRef::npos)
+  if (pos == StringRef::npos || CStr.find_first_of(" \t", pos) != (pos + 1) ||
+      CStr.find_last_of(" \t", pos) != (pos - 1))
     PrintFatalError(Rec->getLoc(), "Unrecognized constraint '" + CStr +
                                        "' in '" + Rec->getName() + "'");
   start = CStr.find_first_not_of(" \t");

--- a/llvm/utils/TableGen/CodeGenInstruction.cpp
+++ b/llvm/utils/TableGen/CodeGenInstruction.cpp
@@ -325,7 +325,8 @@ static void ParseConstraint(StringRef CStr, CGIOperandList &Ops, Record *Rec) {
 
   // Only other constraint is "TIED_TO" for now.
   StringRef::size_type pos = CStr.find_first_of('=');
-  if (pos == StringRef::npos || CStr.find_first_of(" \t", pos) != (pos + 1) ||
+  if (pos == StringRef::npos || pos == 0 ||
+      CStr.find_first_of(" \t", pos) != (pos + 1) ||
       CStr.find_last_of(" \t", pos) != (pos - 1))
     PrintFatalError(Rec->getLoc(), "Unrecognized constraint '" + CStr +
                                        "' in '" + Rec->getName() + "'");


### PR DESCRIPTION
Currently operand constraint checks on "$dest = $src" are inadvertently accepting any token that contains "=". This has surprising results, e.g, "$dest != $src" is accepted as a constraint but then treated as "=".

This patch ensures that only exactly the token "=" is accepted.