### PR TITLE
[lldb] Remove process restart prompt from TestSourceManager

### DIFF
--- a/lldb/test/API/source-manager/TestSourceManager.py
+++ b/lldb/test/API/source-manager/TestSourceManager.py
@@ -323,11 +323,10 @@ class SourceManagerTestCase(TestBase):
         )
 
         self.expect(
-            "thread info", substrs=[f"{src_file}:0", "stop reason = breakpoint"]
-        )
-        self.expect(
-            "frame select 0",
+            "process status",
             substrs=[
+                "stop reason = breakpoint",
+                f"{src_file}:0",
                 "Note: this address is compiler-generated code in function",
                 "that has no source code associated with it.",
             ],

--- a/lldb/test/API/source-manager/TestSourceManager.py
+++ b/lldb/test/API/source-manager/TestSourceManager.py
@@ -323,13 +323,13 @@ class SourceManagerTestCase(TestBase):
         )
 
         self.expect(
-            "run",
-            RUN_SUCCEEDED,
+            "thread info", substrs=[f"{src_file}:0", "stop reason = breakpoint"]
+        )
+        self.expect(
+            "frame select 0",
             substrs=[
-                "stop reason = breakpoint",
-                "%s:%d" % (src_file, 0),
-                "Note: this address is compiler-generated code in " "function",
-                "that has no source code associated " "with it.",
+                "Note: this address is compiler-generated code in function",
+                "that has no source code associated with it.",
             ],
         )
 


### PR DESCRIPTION
In TestSourceManager, test_artificial_source_location will give the process restart prompt if you run the test individually. The reason is that we run the process twice: first using a convenience function to run to a specific breakpoint and then again to check for a specific message emitted when you hit the breakpoint. Instead of running twice and making the test difficult to run individually, we can just check for the specific messages using other commands.