### PR TITLE
[libc][stdlib] initial support for __cxa_finalize

### DIFF
--- a/libc/src/stdlib/exit.cpp
+++ b/libc/src/stdlib/exit.cpp
@@ -10,14 +10,12 @@
 #include "src/__support/OSUtil/quick_exit.h"
 #include "src/__support/common.h"
 
+extern "C" void __cxa_finalize(void *);
+
 namespace LIBC_NAMESPACE {
 
-namespace internal {
-void call_exit_callbacks();
-}
-
 LLVM_LIBC_FUNCTION(void, exit, (int status)) {
-  internal::call_exit_callbacks();
+  __cxa_finalize(nullptr);
   quick_exit(status);
   __builtin_unreachable();
 }


### PR DESCRIPTION
I'm trying to break up the pieces of supporting __cxa_finalize into smaller
commits. Provide this symbol first, and make use of it from exit.

Next will be to store __dso_handle, then finally to only run callbacks that
were registered from a specific dso.

Link: #85651
Link: https://itanium-cxx-abi.github.io/cxx-abi/abi.html#dso-dtor
