### PR TITLE
[RISCV] Preserve MMO when expanding PseudoRV32ZdinxSD/PseudoRV32ZdinxLD.

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVExpandPseudoInsts.cpp
+++ b/llvm/lib/Target/RISCV/RISCVExpandPseudoInsts.cpp
@@ -312,26 +312,40 @@ bool RISCVExpandPseudo::expandRV32ZdinxStore(MachineBasicBlock &MBB,
       TRI->getSubReg(MBBI->getOperand(0).getReg(), RISCV::sub_gpr_even);
   Register Hi =
       TRI->getSubReg(MBBI->getOperand(0).getReg(), RISCV::sub_gpr_odd);
-  BuildMI(MBB, MBBI, DL, TII->get(RISCV::SW))
-      .addReg(Lo, getKillRegState(MBBI->getOperand(0).isKill()))
-      .addReg(MBBI->getOperand(1).getReg())
-      .add(MBBI->getOperand(2));
+  auto MIBLo = BuildMI(MBB, MBBI, DL, TII->get(RISCV::SW))
+                   .addReg(Lo, getKillRegState(MBBI->getOperand(0).isKill()))
+                   .addReg(MBBI->getOperand(1).getReg())
+                   .add(MBBI->getOperand(2));
+
+  MachineMemOperand *MMOHi = nullptr;
+  if (MBBI->hasOneMemOperand()) {
+    MachineMemOperand *OldMMO = MBBI->memoperands().front();
+    MachineFunction *MF = MBB.getParent();
+    MachineMemOperand *MMOLo = MF->getMachineMemOperand(OldMMO, 0, 4);
+    MMOHi = MF->getMachineMemOperand(OldMMO, 4, 4);
+    MIBLo.setMemRefs(MMOLo);
+  }
+
   if (MBBI->getOperand(2).isGlobal() || MBBI->getOperand(2).isCPI()) {
     // FIXME: Zdinx RV32 can not work on unaligned memory.
     assert(!STI->hasFastUnalignedAccess());
 
     assert(MBBI->getOperand(2).getOffset() % 8 == 0);
     MBBI->getOperand(2).setOffset(MBBI->getOperand(2).getOffset() + 4);
-    BuildMI(MBB, MBBI, DL, TII->get(RISCV::SW))
-        .addReg(Hi, getKillRegState(MBBI->getOperand(0).isKill()))
-        .add(MBBI->getOperand(1))
-        .add(MBBI->getOperand(2));
+    auto MIBHi = BuildMI(MBB, MBBI, DL, TII->get(RISCV::SW))
+                     .addReg(Hi, getKillRegState(MBBI->getOperand(0).isKill()))
+                     .add(MBBI->getOperand(1))
+                     .add(MBBI->getOperand(2));
+    if (MMOHi)
+      MIBHi.setMemRefs(MMOHi);
   } else {
     assert(isInt<12>(MBBI->getOperand(2).getImm() + 4));
-    BuildMI(MBB, MBBI, DL, TII->get(RISCV::SW))
-        .addReg(Hi, getKillRegState(MBBI->getOperand(0).isKill()))
-        .add(MBBI->getOperand(1))
-        .addImm(MBBI->getOperand(2).getImm() + 4);
+    auto MIBHi = BuildMI(MBB, MBBI, DL, TII->get(RISCV::SW))
+                     .addReg(Hi, getKillRegState(MBBI->getOperand(0).isKill()))
+                     .add(MBBI->getOperand(1))
+                     .addImm(MBBI->getOperand(2).getImm() + 4);
+    if (MMOHi)
+      MIBHi.setMemRefs(MMOHi);
   }
   MBBI->eraseFromParent();
   return true;
@@ -349,36 +363,53 @@ bool RISCVExpandPseudo::expandRV32ZdinxLoad(MachineBasicBlock &MBB,
   Register Hi =
       TRI->getSubReg(MBBI->getOperand(0).getReg(), RISCV::sub_gpr_odd);
 
+  MachineMemOperand *MMOLo = nullptr;
+  MachineMemOperand *MMOHi = nullptr;
+  if (MBBI->hasOneMemOperand()) {
+    MachineMemOperand *OldMMO = MBBI->memoperands().front();
+    MachineFunction *MF = MBB.getParent();
+    MMOLo = MF->getMachineMemOperand(OldMMO, 0, 4);
+    MMOHi = MF->getMachineMemOperand(OldMMO, 4, 4);
+  }
+
   // If the register of operand 1 is equal to the Lo register, then swap the
   // order of loading the Lo and Hi statements.
   bool IsOp1EqualToLo = Lo == MBBI->getOperand(1).getReg();
   // Order: Lo, Hi
   if (!IsOp1EqualToLo) {
-    BuildMI(MBB, MBBI, DL, TII->get(RISCV::LW), Lo)
-        .addReg(MBBI->getOperand(1).getReg())
-        .add(MBBI->getOperand(2));
+    auto MIBLo = BuildMI(MBB, MBBI, DL, TII->get(RISCV::LW), Lo)
+                     .addReg(MBBI->getOperand(1).getReg())
+                     .add(MBBI->getOperand(2));
+    if (MMOLo)
+      MIBLo.setMemRefs(MMOLo);
   }
 
   if (MBBI->getOperand(2).isGlobal() || MBBI->getOperand(2).isCPI()) {
     auto Offset = MBBI->getOperand(2).getOffset();
     assert(MBBI->getOperand(2).getOffset() % 8 == 0);
     MBBI->getOperand(2).setOffset(Offset + 4);
-    BuildMI(MBB, MBBI, DL, TII->get(RISCV::LW), Hi)
-        .addReg(MBBI->getOperand(1).getReg())
-        .add(MBBI->getOperand(2));
+    auto MIBHi = BuildMI(MBB, MBBI, DL, TII->get(RISCV::LW), Hi)
+                     .addReg(MBBI->getOperand(1).getReg())
+                     .add(MBBI->getOperand(2));
     MBBI->getOperand(2).setOffset(Offset);
+    if (MMOHi)
+      MIBHi.setMemRefs(MMOHi);
   } else {
     assert(isInt<12>(MBBI->getOperand(2).getImm() + 4));
-    BuildMI(MBB, MBBI, DL, TII->get(RISCV::LW), Hi)
-        .addReg(MBBI->getOperand(1).getReg())
-        .addImm(MBBI->getOperand(2).getImm() + 4);
+    auto MIBHi = BuildMI(MBB, MBBI, DL, TII->get(RISCV::LW), Hi)
+                     .addReg(MBBI->getOperand(1).getReg())
+                     .addImm(MBBI->getOperand(2).getImm() + 4);
+    if (MMOHi)
+      MIBHi.setMemRefs(MMOHi);
   }
 
   // Order: Hi, Lo
   if (IsOp1EqualToLo) {
-    BuildMI(MBB, MBBI, DL, TII->get(RISCV::LW), Lo)
-        .addReg(MBBI->getOperand(1).getReg())
-        .add(MBBI->getOperand(2));
+    auto MIBLo = BuildMI(MBB, MBBI, DL, TII->get(RISCV::LW), Lo)
+                     .addReg(MBBI->getOperand(1).getReg())
+                     .add(MBBI->getOperand(2));
+    if (MMOLo)
+      MIBLo.setMemRefs(MMOLo);
   }
 
   MBBI->eraseFromParent();

--- a/llvm/lib/Target/RISCV/RISCVExpandPseudoInsts.cpp
+++ b/llvm/lib/Target/RISCV/RISCVExpandPseudoInsts.cpp
@@ -312,17 +312,18 @@ bool RISCVExpandPseudo::expandRV32ZdinxStore(MachineBasicBlock &MBB,
       TRI->getSubReg(MBBI->getOperand(0).getReg(), RISCV::sub_gpr_even);
   Register Hi =
       TRI->getSubReg(MBBI->getOperand(0).getReg(), RISCV::sub_gpr_odd);
-  auto MIBLo = BuildMI(MBB, MBBI, DL, TII->get(RISCV::SW))
-                   .addReg(Lo, getKillRegState(MBBI->getOperand(0).isKill()))
-                   .addReg(MBBI->getOperand(1).getReg())
-                   .add(MBBI->getOperand(2));
 
   assert(MBBI->hasOneMemOperand() && "Expected mem operand");
   MachineMemOperand *OldMMO = MBBI->memoperands().front();
   MachineFunction *MF = MBB.getParent();
   MachineMemOperand *MMOLo = MF->getMachineMemOperand(OldMMO, 0, 4);
   MachineMemOperand *MMOHi = MF->getMachineMemOperand(OldMMO, 4, 4);
-  MIBLo.setMemRefs(MMOLo);
+
+  BuildMI(MBB, MBBI, DL, TII->get(RISCV::SW))
+      .addReg(Lo, getKillRegState(MBBI->getOperand(0).isKill()))
+      .addReg(MBBI->getOperand(1).getReg())
+      .add(MBBI->getOperand(2))
+      .setMemRefs(MMOLo);
 
   if (MBBI->getOperand(2).isGlobal() || MBBI->getOperand(2).isCPI()) {
     // FIXME: Zdinx RV32 can not work on unaligned memory.
@@ -330,18 +331,18 @@ bool RISCVExpandPseudo::expandRV32ZdinxStore(MachineBasicBlock &MBB,
 
     assert(MBBI->getOperand(2).getOffset() % 8 == 0);
     MBBI->getOperand(2).setOffset(MBBI->getOperand(2).getOffset() + 4);
-    auto MIBHi = BuildMI(MBB, MBBI, DL, TII->get(RISCV::SW))
-                     .addReg(Hi, getKillRegState(MBBI->getOperand(0).isKill()))
-                     .add(MBBI->getOperand(1))
-                     .add(MBBI->getOperand(2));
-    MIBHi.setMemRefs(MMOHi);
+    BuildMI(MBB, MBBI, DL, TII->get(RISCV::SW))
+        .addReg(Hi, getKillRegState(MBBI->getOperand(0).isKill()))
+        .add(MBBI->getOperand(1))
+        .add(MBBI->getOperand(2))
+        .setMemRefs(MMOHi);
   } else {
     assert(isInt<12>(MBBI->getOperand(2).getImm() + 4));
-    auto MIBHi = BuildMI(MBB, MBBI, DL, TII->get(RISCV::SW))
-                     .addReg(Hi, getKillRegState(MBBI->getOperand(0).isKill()))
-                     .add(MBBI->getOperand(1))
-                     .addImm(MBBI->getOperand(2).getImm() + 4);
-    MIBHi.setMemRefs(MMOHi);
+    BuildMI(MBB, MBBI, DL, TII->get(RISCV::SW))
+        .addReg(Hi, getKillRegState(MBBI->getOperand(0).isKill()))
+        .add(MBBI->getOperand(1))
+        .addImm(MBBI->getOperand(2).getImm() + 4)
+        .setMemRefs(MMOHi);
   }
   MBBI->eraseFromParent();
   return true;
@@ -370,35 +371,35 @@ bool RISCVExpandPseudo::expandRV32ZdinxLoad(MachineBasicBlock &MBB,
   bool IsOp1EqualToLo = Lo == MBBI->getOperand(1).getReg();
   // Order: Lo, Hi
   if (!IsOp1EqualToLo) {
-    auto MIBLo = BuildMI(MBB, MBBI, DL, TII->get(RISCV::LW), Lo)
-                     .addReg(MBBI->getOperand(1).getReg())
-                     .add(MBBI->getOperand(2));
-    MIBLo.setMemRefs(MMOLo);
+    BuildMI(MBB, MBBI, DL, TII->get(RISCV::LW), Lo)
+        .addReg(MBBI->getOperand(1).getReg())
+        .add(MBBI->getOperand(2))
+        .setMemRefs(MMOLo);
   }
 
   if (MBBI->getOperand(2).isGlobal() || MBBI->getOperand(2).isCPI()) {
     auto Offset = MBBI->getOperand(2).getOffset();
     assert(MBBI->getOperand(2).getOffset() % 8 == 0);
     MBBI->getOperand(2).setOffset(Offset + 4);
-    auto MIBHi = BuildMI(MBB, MBBI, DL, TII->get(RISCV::LW), Hi)
-                     .addReg(MBBI->getOperand(1).getReg())
-                     .add(MBBI->getOperand(2));
+    BuildMI(MBB, MBBI, DL, TII->get(RISCV::LW), Hi)
+        .addReg(MBBI->getOperand(1).getReg())
+        .add(MBBI->getOperand(2))
+        .setMemRefs(MMOHi);
     MBBI->getOperand(2).setOffset(Offset);
-    MIBHi.setMemRefs(MMOHi);
   } else {
     assert(isInt<12>(MBBI->getOperand(2).getImm() + 4));
-    auto MIBHi = BuildMI(MBB, MBBI, DL, TII->get(RISCV::LW), Hi)
-                     .addReg(MBBI->getOperand(1).getReg())
-                     .addImm(MBBI->getOperand(2).getImm() + 4);
-    MIBHi.setMemRefs(MMOHi);
+    BuildMI(MBB, MBBI, DL, TII->get(RISCV::LW), Hi)
+        .addReg(MBBI->getOperand(1).getReg())
+        .addImm(MBBI->getOperand(2).getImm() + 4)
+        .setMemRefs(MMOHi);
   }
 
   // Order: Hi, Lo
   if (IsOp1EqualToLo) {
-    auto MIBLo = BuildMI(MBB, MBBI, DL, TII->get(RISCV::LW), Lo)
-                     .addReg(MBBI->getOperand(1).getReg())
-                     .add(MBBI->getOperand(2));
-    MIBLo.setMemRefs(MMOLo);
+    BuildMI(MBB, MBBI, DL, TII->get(RISCV::LW), Lo)
+        .addReg(MBBI->getOperand(1).getReg())
+        .add(MBBI->getOperand(2))
+        .setMemRefs(MMOLo);
   }
 
   MBBI->eraseFromParent();

--- a/llvm/test/CodeGen/RISCV/zdinx-large-spill.mir
+++ b/llvm/test/CodeGen/RISCV/zdinx-large-spill.mir
@@ -14,28 +14,28 @@
   ; CHECK-NEXT:    .cfi_def_cfa_offset 2064
   ; CHECK-NEXT:    lui t0, 1
   ; CHECK-NEXT:    add t0, sp, t0
-  ; CHECK-NEXT:    sw a0, -2040(t0)
-  ; CHECK-NEXT:    sw a1, -2036(t0)
+  ; CHECK-NEXT:    sw a0, -2040(t0) # 4-byte Folded Spill
+  ; CHECK-NEXT:    sw a1, -2036(t0) # 4-byte Folded Spill
   ; CHECK-NEXT:    lui a0, 1
   ; CHECK-NEXT:    add a0, sp, a0
-  ; CHECK-NEXT:    sw a2, -2048(a0)
-  ; CHECK-NEXT:    sw a3, -2044(a0)
-  ; CHECK-NEXT:    sw a4, 2040(sp)
-  ; CHECK-NEXT:    sw a5, 2044(sp)
-  ; CHECK-NEXT:    sw a6, 2032(sp)
-  ; CHECK-NEXT:    sw a7, 2036(sp)
+  ; CHECK-NEXT:    sw a2, -2048(a0) # 4-byte Folded Spill
+  ; CHECK-NEXT:    sw a3, -2044(a0) # 4-byte Folded Spill
+  ; CHECK-NEXT:    sw a4, 2040(sp) # 4-byte Folded Spill
+  ; CHECK-NEXT:    sw a5, 2044(sp) # 4-byte Folded Spill
+  ; CHECK-NEXT:    sw a6, 2032(sp) # 4-byte Folded Spill
+  ; CHECK-NEXT:    sw a7, 2036(sp) # 4-byte Folded Spill
   ; CHECK-NEXT:    lui a0, 1
   ; CHECK-NEXT:    add a0, sp, a0
-  ; CHECK-NEXT:    lw a1, -2036(a0)
-  ; CHECK-NEXT:    lw a0, -2040(a0)
+  ; CHECK-NEXT:    lw a1, -2036(a0) # 4-byte Folded Reload
+  ; CHECK-NEXT:    lw a0, -2040(a0) # 4-byte Folded Reload
   ; CHECK-NEXT:    lui a0, 1
   ; CHECK-NEXT:    add a0, sp, a0
-  ; CHECK-NEXT:    lw a2, -2048(a0)
-  ; CHECK-NEXT:    lw a3, -2044(a0)
-  ; CHECK-NEXT:    lw a4, 2040(sp)
-  ; CHECK-NEXT:    lw a5, 2044(sp)
-  ; CHECK-NEXT:    lw a6, 2032(sp)
-  ; CHECK-NEXT:    lw a7, 2036(sp)
+  ; CHECK-NEXT:    lw a2, -2048(a0) # 4-byte Folded Reload
+  ; CHECK-NEXT:    lw a3, -2044(a0) # 4-byte Folded Reload
+  ; CHECK-NEXT:    lw a4, 2040(sp) # 4-byte Folded Reload
+  ; CHECK-NEXT:    lw a5, 2044(sp) # 4-byte Folded Reload
+  ; CHECK-NEXT:    lw a6, 2032(sp) # 4-byte Folded Reload
+  ; CHECK-NEXT:    lw a7, 2036(sp) # 4-byte Folded Reload
   ; CHECK-NEXT:    addi sp, sp, 2032
   ; CHECK-NEXT:    addi sp, sp, 32
   ; CHECK-NEXT:    ret


### PR DESCRIPTION
This allows the asm printer to print the stack spill/reload messages.

Stacked on #85871