### PR TITLE
Revert "[llvm] Include LLVM_REPOSITORY and LLVM_REVISION in tool version"

### DIFF
--- a/llvm/lib/Support/CMakeLists.txt
+++ b/llvm/lib/Support/CMakeLists.txt
@@ -288,9 +288,6 @@ add_llvm_component_library(LLVMSupport
   ${LLVM_MAIN_INCLUDE_DIR}/llvm/Support
   ${Backtrace_INCLUDE_DIRS}
 
-  DEPENDS
-  llvm_vcsrevision_h
-
   LINK_LIBS
   ${system_libs} ${imported_libs} ${delayload_flags}
 

--- a/llvm/lib/Support/CommandLine.cpp
+++ b/llvm/lib/Support/CommandLine.cpp
@@ -39,7 +39,6 @@
 #include "llvm/Support/Path.h"
 #include "llvm/Support/Process.h"
 #include "llvm/Support/StringSaver.h"
-#include "llvm/Support/VCSRevision.h"
 #include "llvm/Support/VirtualFileSystem.h"
 #include "llvm/Support/raw_ostream.h"
 #include <cstdlib>
@@ -2539,15 +2538,7 @@ public:
 #else
     OS << "LLVM (http://llvm.org/):\n  ";
 #endif
-    OS << PACKAGE_NAME << " version " << PACKAGE_VERSION;
-#ifdef LLVM_REPOSITORY
-    OS << " (" << LLVM_REPOSITORY;
-#ifdef LLVM_REVISION
-    OS << ' ' << LLVM_REVISION;
-#endif
-    OS << ')';
-#endif
-    OS << "\n  ";
+    OS << PACKAGE_NAME << " version " << PACKAGE_VERSION << "\n  ";
 #if LLVM_IS_DEBUG_BUILD
     OS << "DEBUG build";
 #else


### PR DESCRIPTION
Reverts llvm/llvm-project#84990 because this causes a full rebuild after the commit hash changes. 