### PR TITLE
[lldb/API] Add missing `eBroadcastBitSymbolsChanged` to SBTarget (NFC)

### DIFF
--- a/lldb/include/lldb/API/SBTarget.h
+++ b/lldb/include/lldb/API/SBTarget.h
@@ -42,7 +42,8 @@ public:
     eBroadcastBitModulesLoaded = (1 << 1),
     eBroadcastBitModulesUnloaded = (1 << 2),
     eBroadcastBitWatchpointChanged = (1 << 3),
-    eBroadcastBitSymbolsLoaded = (1 << 4)
+    eBroadcastBitSymbolsLoaded = (1 << 4),
+    eBroadcastBitSymbolsChanged = (1 << 5),
   };
 
   // Constructors


### PR DESCRIPTION
This patch exposes the missing `eBroadcastBitSymbolsChanged` event bit in `SBTarget`.