### PR TITLE
[Sema] Don't drop weak_import from a declaration that follows a declaration directly contained in a linkage-specification

### DIFF
--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -6018,7 +6018,7 @@ def note_extern_c_global_conflict : Note<
 def note_extern_c_begins_here : Note<
   "extern \"C\" language linkage specification begins here">;
 def warn_weak_import : Warning <
-  "an already-declared variable is made a weak_import declaration %0">;
+  "an already-defined variable is made a weak_import declaration %0">;
 def ext_static_non_static : Extension<
   "redeclaring non-static %0 as static is a Microsoft extension">,
   InGroup<MicrosoftRedeclareStatic>;

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -6018,7 +6018,7 @@ def note_extern_c_global_conflict : Note<
 def note_extern_c_begins_here : Note<
   "extern \"C\" language linkage specification begins here">;
 def warn_weak_import : Warning <
-  "an already-defined variable is made a weak_import declaration %0">;
+  "%0 cannot be declared 'weak_import' because its definition has been provided">;
 def ext_static_non_static : Extension<
   "redeclaring non-static %0 as static is a Microsoft extension">,
   InGroup<MicrosoftRedeclareStatic>;

--- a/clang/lib/Sema/SemaDecl.cpp
+++ b/clang/lib/Sema/SemaDecl.cpp
@@ -4613,8 +4613,7 @@ void Sema::MergeVarDecl(VarDecl *New, LookupResult &Previous) {
   mergeDeclAttributes(New, Old);
   // Warn if an already-declared variable is made a weak_import in a subsequent
   // declaration
-  if (New->hasAttr<WeakImportAttr>() &&
-      Old->getStorageClass() == SC_None &&
+  if (New->hasAttr<WeakImportAttr>() && Old->isThisDeclarationADefinition() &&
       !Old->hasAttr<WeakImportAttr>()) {
     Diag(New->getLocation(), diag::warn_weak_import) << New->getDeclName();
     Diag(Old->getLocation(), diag::note_previous_declaration);

--- a/clang/lib/Sema/SemaDecl.cpp
+++ b/clang/lib/Sema/SemaDecl.cpp
@@ -4617,7 +4617,7 @@ void Sema::MergeVarDecl(VarDecl *New, LookupResult &Previous) {
     for (auto *D = Old; D; D = D->getPreviousDecl()) {
       if (D->isThisDeclarationADefinition() != VarDecl::DeclarationOnly) {
         Diag(New->getLocation(), diag::warn_weak_import) << New->getDeclName();
-        Diag(D->getLocation(), diag::note_previous_declaration);
+        Diag(D->getLocation(), diag::note_previous_definition);
         // Remove weak_import attribute on new declaration.
         New->dropAttr<WeakImportAttr>();
         break;

--- a/clang/lib/Sema/SemaDecl.cpp
+++ b/clang/lib/Sema/SemaDecl.cpp
@@ -4613,12 +4613,23 @@ void Sema::MergeVarDecl(VarDecl *New, LookupResult &Previous) {
   mergeDeclAttributes(New, Old);
   // Warn if an already-declared variable is made a weak_import in a subsequent
   // declaration
-  if (New->hasAttr<WeakImportAttr>() && Old->isThisDeclarationADefinition() &&
-      !Old->hasAttr<WeakImportAttr>()) {
-    Diag(New->getLocation(), diag::warn_weak_import) << New->getDeclName();
-    Diag(Old->getLocation(), diag::note_previous_declaration);
-    // Remove weak_import attribute on new declaration.
-    New->dropAttr<WeakImportAttr>();
+  if (New->hasAttr<WeakImportAttr>()) {
+    // We know there's no full definition as the attribute on New would have
+    // been removed otherwise. Just look for the most recent tentative
+    // definition.
+    VarDecl *TentativeDef = nullptr;
+    for (auto *D = Old; D; D = D->getPreviousDecl())
+      if (D->isThisDeclarationADefinition() == VarDecl::TentativeDefinition) {
+        TentativeDef = D;
+        break;
+      }
+
+    if (TentativeDef) {
+      Diag(New->getLocation(), diag::warn_weak_import) << New->getDeclName();
+      Diag(TentativeDef->getLocation(), diag::note_previous_declaration);
+      // Remove weak_import attribute on new declaration.
+      New->dropAttr<WeakImportAttr>();
+    }
   }
 
   if (const auto *ILA = New->getAttr<InternalLinkageAttr>())

--- a/clang/test/Sema/attr-weak.c
+++ b/clang/test/Sema/attr-weak.c
@@ -16,10 +16,10 @@ struct __attribute__((weak_import)) s1 {}; // expected-warning {{'weak_import' a
 static int f(void) __attribute__((weak)); // expected-error {{weak declaration cannot have internal linkage}}
 static int x __attribute__((weak)); // expected-error {{weak declaration cannot have internal linkage}}
 
-int C; // expected-note {{previous declaration is here}}
+int C; // expected-note {{previous definition is here}}
 extern int C __attribute__((weak_import)); // expected-warning {{an already-defined variable is made a weak_import declaration}}
 
-int C2; // expected-note {{previous declaration is here}}
+int C2; // expected-note {{previous definition is here}}
 extern int C2;
 extern int C2 __attribute__((weak_import)); // expected-warning {{an already-defined variable is made a weak_import declaration}}
 

--- a/clang/test/Sema/attr-weak.c
+++ b/clang/test/Sema/attr-weak.c
@@ -17,11 +17,11 @@ static int f(void) __attribute__((weak)); // expected-error {{weak declaration c
 static int x __attribute__((weak)); // expected-error {{weak declaration cannot have internal linkage}}
 
 int C; // expected-note {{previous declaration is here}}
-extern int C __attribute__((weak_import)); // expected-warning {{an already-declared variable is made a weak_import declaration}}
+extern int C __attribute__((weak_import)); // expected-warning {{an already-defined variable is made a weak_import declaration}}
 
 int C2; // expected-note {{previous declaration is here}}
 extern int C2;
-extern int C2 __attribute__((weak_import)); // expected-warning {{an already-declared variable is made a weak_import declaration}}
+extern int C2 __attribute__((weak_import)); // expected-warning {{an already-defined variable is made a weak_import declaration}}
 
 static int pr14946_x;
 extern int pr14946_x  __attribute__((weak)); // expected-error {{weak declaration cannot have internal linkage}}

--- a/clang/test/Sema/attr-weak.c
+++ b/clang/test/Sema/attr-weak.c
@@ -17,11 +17,11 @@ static int f(void) __attribute__((weak)); // expected-error {{weak declaration c
 static int x __attribute__((weak)); // expected-error {{weak declaration cannot have internal linkage}}
 
 int C; // expected-note {{previous definition is here}}
-extern int C __attribute__((weak_import)); // expected-warning {{an already-defined variable is made a weak_import declaration}}
+extern int C __attribute__((weak_import)); // expected-warning {{'C' cannot be declared 'weak_import'}}
 
 int C2; // expected-note {{previous definition is here}}
 extern int C2;
-extern int C2 __attribute__((weak_import)); // expected-warning {{an already-defined variable is made a weak_import declaration}}
+extern int C2 __attribute__((weak_import)); // expected-warning {{'C2' cannot be declared 'weak_import'}}
 
 static int pr14946_x;
 extern int pr14946_x  __attribute__((weak)); // expected-error {{weak declaration cannot have internal linkage}}

--- a/clang/test/Sema/attr-weak.c
+++ b/clang/test/Sema/attr-weak.c
@@ -19,6 +19,10 @@ static int x __attribute__((weak)); // expected-error {{weak declaration cannot 
 int C; // expected-note {{previous declaration is here}}
 extern int C __attribute__((weak_import)); // expected-warning {{an already-declared variable is made a weak_import declaration}}
 
+int C2; // expected-note {{previous declaration is here}}
+extern int C2;
+extern int C2 __attribute__((weak_import)); // expected-warning {{an already-declared variable is made a weak_import declaration}}
+
 static int pr14946_x;
 extern int pr14946_x  __attribute__((weak)); // expected-error {{weak declaration cannot have internal linkage}}
 

--- a/clang/test/SemaCXX/attr-weak.cpp
+++ b/clang/test/SemaCXX/attr-weak.cpp
@@ -55,3 +55,10 @@ constexpr bool weak_method_is_non_null = &WithWeakMember::weak_method != nullptr
 // virtual member function is present.
 constexpr bool virtual_weak_method_is_non_null = &WithWeakMember::virtual_weak_method != nullptr; // expected-error {{must be initialized by a constant expression}}
 // expected-note@-1 {{comparison against pointer to weak member 'WithWeakMember::virtual_weak_method' can only be performed at runtime}}
+
+// Check that no warnings are emitted.
+extern "C" int g0;
+extern int g0 __attribute__((weak_import));
+
+extern "C" int g1 = 0; // expected-note {{previous definition is here}}
+extern int g1 __attribute__((weak_import)); // expected-warning {{attribute declaration must precede definition}}


### PR DESCRIPTION
Only drop it if the declaration follows a definition. I believe this is what 33e022650adee965c65f9aea086ee74f3fd1bad5 was trying to do.

rdar://61865848