### PR TITLE
Allow MCInstrAnalysis to change MCInst

### DIFF
--- a/llvm/include/llvm/MC/MCInstrAnalysis.h
+++ b/llvm/include/llvm/MC/MCInstrAnalysis.h
@@ -24,6 +24,7 @@
 
 namespace llvm {
 
+class MCContext;
 class MCRegisterInfo;
 class Triple;
 
@@ -51,6 +52,10 @@ public:
   /// Whenever state becomes irrelevant (e.g., when starting to disassemble a
   /// new function), clients should call resetState to clear it.
   virtual void updateState(const MCInst &Inst, uint64_t Addr) {}
+
+  /// Let the analysis update disassembled instruction from a recorded internal
+  /// state.
+  virtual void updateInst(MCInst &Inst, const MCContext &Ctx) const {}
 
   virtual bool isBranch(const MCInst &Inst) const {
     return Info->get(Inst.getOpcode()).isBranch();

--- a/llvm/tools/llvm-objdump/llvm-objdump.cpp
+++ b/llvm/tools/llvm-objdump/llvm-objdump.cpp
@@ -2252,6 +2252,9 @@ disassembleObject(ObjectFile &Obj, const ObjectFile &DbgObj,
           LVP.update({Index, Section.getIndex()},
                      {Index + Size, Section.getIndex()}, Index + Size != End);
 
+          if (Disassembled && DT->InstrAnalysis)
+            DT->InstrAnalysis->updateInst(Inst, *DT->Context);
+
           DT->InstPrinter->setCommentStream(CommentStream);
 
           DT->Printer->printInst(


### PR DESCRIPTION
I have a compelling case downstream to let it modify an instruction from a recorded state. Currently NFC. Just an interface.