### PR TITLE
[SelectionDAG][Statepoint] Fix truncation of `gc.statepoint` ID argument

### DIFF
--- a/llvm/lib/CodeGen/SelectionDAG/SelectionDAGBuilder.h
+++ b/llvm/lib/CodeGen/SelectionDAG/SelectionDAGBuilder.h
@@ -449,7 +449,7 @@ public:
     ArrayRef<const Use> GCTransitionArgs;
 
     /// The ID that the resulting STATEPOINT instruction has to report.
-    unsigned ID = -1;
+    uint64_t ID = -1;
 
     /// Information regarding the underlying call instruction.
     TargetLowering::CallLoweringInfo CLI;


### PR DESCRIPTION
The ID argument of `gc.statepoint` gets incorrectly truncated to 32 bits during code generation.
This is fixed by using `uint64_t` instead of `unsigned` for the `ID` member in `SelectionDAGBuilder::StatepointLoweringInfo`, and a `patchpoint` test case is extended to check for 64 bit ID generation in stackmaps.