### PR TITLE
[RemoveDIs][NFC] Rename DPLabel->DbgLabelRecord

### DIFF
--- a/llvm/docs/RemoveDIsDebugInfo.md
+++ b/llvm/docs/RemoveDIsDebugInfo.md
@@ -65,9 +65,9 @@ We're using a dedicated C++ class called `DbgRecord` to store debug info, with a
 
   https://llvm.org/docs/doxygen/classllvm_1_1DbgRecord.html
   https://llvm.org/docs/doxygen/classllvm_1_1DbgVariableRecord.html
-  https://llvm.org/docs/doxygen/classllvm_1_1DPLabel.html
+  https://llvm.org/docs/doxygen/classllvm_1_1DbgLabelRecord.html
 
-This allows you to treat a `DbgVariableRecord` as if it's a `dbg.value`/`dbg.declare`/`dbg.assign` intrinsic most of the time, for example in generic (auto-param) lambdas, and the same for `DPLabel` and `dbg.label`s.
+This allows you to treat a `DbgVariableRecord` as if it's a `dbg.value`/`dbg.declare`/`dbg.assign` intrinsic most of the time, for example in generic (auto-param) lambdas, and the same for `DbgLabelRecord` and `dbg.label`s.
 
 ## How do these `DbgRecords` fit into the instruction stream?
 
@@ -97,7 +97,7 @@ Each instruction has a pointer to a `DPMarker` (which will become optional), tha
 
 Not shown are the links from DbgRecord to other parts of the `Value`/`Metadata` hierachy: `DbgRecord` subclasses have tracking pointers to the DIMetadata that they use, and `DbgVariableRecord` has references to `Value`s that are stored in a `DebugValueUser` base class. This refers to a `ValueAsMetadata` object referring to `Value`s, via the `TrackingMetadata` facility.
 
-The various kinds of debug intrinsic (value, declare, assign, label) are all stored in `DbgRecord` subclasses, with a "RecordKind" field distinguishing `DPLabel`s from `DbgVariableRecord`s, and a `LocationType` field in the `DbgVariableRecord` class further disambiguating the various debug variable intrinsics it can represent.
+The various kinds of debug intrinsic (value, declare, assign, label) are all stored in `DbgRecord` subclasses, with a "RecordKind" field distinguishing `DbgLabelRecord`s from `DbgVariableRecord`s, and a `LocationType` field in the `DbgVariableRecord` class further disambiguating the various debug variable intrinsics it can represent.
 
 ## Finding debug info records
 

--- a/llvm/include/llvm/IR/DebugProgramInstruction.h
+++ b/llvm/include/llvm/IR/DebugProgramInstruction.h
@@ -222,23 +222,23 @@ inline raw_ostream &operator<<(raw_ostream &OS, const DbgRecord &R) {
 /// llvm.dbg.label intrinsic.
 /// FIXME: Rename DbgLabelRecord when DbgVariableRecord is renamed to
 /// DbgVariableRecord.
-class DPLabel : public DbgRecord {
+class DbgLabelRecord : public DbgRecord {
   DbgRecordParamRef<DILabel> Label;
 
   /// This constructor intentionally left private, so that it is only called via
-  /// "createUnresolvedDPLabel", which clearly expresses that it is for parsing
+  /// "createUnresolvedDbgLabelRecord", which clearly expresses that it is for parsing
   /// only.
-  DPLabel(MDNode *Label, MDNode *DL);
+  DbgLabelRecord(MDNode *Label, MDNode *DL);
 
 public:
-  DPLabel(DILabel *Label, DebugLoc DL);
+  DbgLabelRecord(DILabel *Label, DebugLoc DL);
 
-  /// For use during parsing; creates a DPLabel from as-of-yet unresolved
-  /// MDNodes. Trying to access the resulting DPLabel's fields before they are
+  /// For use during parsing; creates a DbgLabelRecord from as-of-yet unresolved
+  /// MDNodes. Trying to access the resulting DbgLabelRecord's fields before they are
   /// resolved, or if they resolve to the wrong type, will result in a crash.
-  static DPLabel *createUnresolvedDPLabel(MDNode *Label, MDNode *DL);
+  static DbgLabelRecord *createUnresolvedDbgLabelRecord(MDNode *Label, MDNode *DL);
 
-  DPLabel *clone() const;
+  DbgLabelRecord *clone() const;
   void print(raw_ostream &O, bool IsForDebug = false) const;
   void print(raw_ostream &ROS, ModuleSlotTracker &MST, bool IsForDebug) const;
   DbgLabelInst *createDebugIntrinsic(Module *M,

--- a/llvm/include/llvm/IR/DebugProgramInstruction.h
+++ b/llvm/include/llvm/IR/DebugProgramInstruction.h
@@ -226,17 +226,19 @@ class DbgLabelRecord : public DbgRecord {
   DbgRecordParamRef<DILabel> Label;
 
   /// This constructor intentionally left private, so that it is only called via
-  /// "createUnresolvedDbgLabelRecord", which clearly expresses that it is for parsing
-  /// only.
+  /// "createUnresolvedDbgLabelRecord", which clearly expresses that it is for
+  /// parsing only.
   DbgLabelRecord(MDNode *Label, MDNode *DL);
 
 public:
   DbgLabelRecord(DILabel *Label, DebugLoc DL);
 
   /// For use during parsing; creates a DbgLabelRecord from as-of-yet unresolved
-  /// MDNodes. Trying to access the resulting DbgLabelRecord's fields before they are
-  /// resolved, or if they resolve to the wrong type, will result in a crash.
-  static DbgLabelRecord *createUnresolvedDbgLabelRecord(MDNode *Label, MDNode *DL);
+  /// MDNodes. Trying to access the resulting DbgLabelRecord's fields before
+  /// they are resolved, or if they resolve to the wrong type, will result in a
+  /// crash.
+  static DbgLabelRecord *createUnresolvedDbgLabelRecord(MDNode *Label,
+                                                        MDNode *DL);
 
   DbgLabelRecord *clone() const;
   void print(raw_ostream &O, bool IsForDebug = false) const;

--- a/llvm/lib/AsmParser/LLParser.cpp
+++ b/llvm/lib/AsmParser/LLParser.cpp
@@ -6607,7 +6607,7 @@ bool LLParser::parseDebugRecord(DbgRecord *&DR, PerFunctionState &PFS) {
       return true;
     if (parseToken(lltok::rparen, "Expected ')' here"))
       return true;
-    DR = DPLabel::createUnresolvedDPLabel(Label, DbgLoc);
+    DR = DbgLabelRecord::createUnresolvedDbgLabelRecord(Label, DbgLoc);
     return false;
   }
 

--- a/llvm/lib/Bitcode/Reader/BitcodeReader.cpp
+++ b/llvm/lib/Bitcode/Reader/BitcodeReader.cpp
@@ -6426,14 +6426,14 @@ Error BitcodeReader::parseFunctionBody(Function *F) {
       break;
     }
     case bitc::FUNC_CODE_DEBUG_RECORD_LABEL: {
-      // DPLabels are placed after the Instructions that they are attached to.
+      // DbgLabelRecords are placed after the Instructions that they are attached to.
       Instruction *Inst = getLastInstruction();
       if (!Inst)
         return error("Invalid dbg record: missing instruction");
       DILocation *DIL = cast<DILocation>(getFnMetadataByID(Record[0]));
       DILabel *Label = cast<DILabel>(getFnMetadataByID(Record[1]));
       Inst->getParent()->insertDbgRecordBefore(
-          new DPLabel(Label, DebugLoc(DIL)), Inst->getIterator());
+          new DbgLabelRecord(Label, DebugLoc(DIL)), Inst->getIterator());
       continue; // This isn't an instruction.
     }
     case bitc::FUNC_CODE_DEBUG_RECORD_VALUE_SIMPLE:

--- a/llvm/lib/Bitcode/Reader/BitcodeReader.cpp
+++ b/llvm/lib/Bitcode/Reader/BitcodeReader.cpp
@@ -6426,7 +6426,8 @@ Error BitcodeReader::parseFunctionBody(Function *F) {
       break;
     }
     case bitc::FUNC_CODE_DEBUG_RECORD_LABEL: {
-      // DbgLabelRecords are placed after the Instructions that they are attached to.
+      // DbgLabelRecords are placed after the Instructions that they are
+      // attached to.
       Instruction *Inst = getLastInstruction();
       if (!Inst)
         return error("Invalid dbg record: missing instruction");

--- a/llvm/lib/Bitcode/Writer/BitcodeWriter.cpp
+++ b/llvm/lib/Bitcode/Writer/BitcodeWriter.cpp
@@ -3570,9 +3570,9 @@ void ModuleBitcodeWriter::writeFunction(
         // instruction. Write it after the instruction so that it's easy to
         // re-attach to the instruction reading the records in.
         for (DbgRecord &DR : I.DbgMarker->getDbgRecordRange()) {
-          if (DPLabel *DPL = dyn_cast<DPLabel>(&DR)) {
-            Vals.push_back(VE.getMetadataID(&*DPL->getDebugLoc()));
-            Vals.push_back(VE.getMetadataID(DPL->getLabel()));
+          if (DbgLabelRecord *DLR = dyn_cast<DbgLabelRecord>(&DR)) {
+            Vals.push_back(VE.getMetadataID(&*DLR->getDebugLoc()));
+            Vals.push_back(VE.getMetadataID(DLR->getLabel()));
             Stream.EmitRecord(bitc::FUNC_CODE_DEBUG_RECORD_LABEL, Vals);
             Vals.clear();
             continue;

--- a/llvm/lib/Bitcode/Writer/ValueEnumerator.cpp
+++ b/llvm/lib/Bitcode/Writer/ValueEnumerator.cpp
@@ -441,9 +441,9 @@ ValueEnumerator::ValueEnumerator(const Module &M,
         };
 
         for (DbgRecord &DR : I.getDbgRecordRange()) {
-          if (DPLabel *DPL = dyn_cast<DPLabel>(&DR)) {
-            EnumerateMetadata(&F, DPL->getLabel());
-            EnumerateMetadata(&F, &*DPL->getDebugLoc());
+          if (DbgLabelRecord *DLR = dyn_cast<DbgLabelRecord>(&DR)) {
+            EnumerateMetadata(&F, DLR->getLabel());
+            EnumerateMetadata(&F, &*DLR->getDebugLoc());
             continue;
           }
           // Enumerate non-local location metadata.

--- a/llvm/lib/CodeGen/GlobalISel/IRTranslator.cpp
+++ b/llvm/lib/CodeGen/GlobalISel/IRTranslator.cpp
@@ -3376,13 +3376,13 @@ void IRTranslator::translateDbgDeclareRecord(Value *Address, bool HasArgList,
 void IRTranslator::translateDbgInfo(const Instruction &Inst,
                                       MachineIRBuilder &MIRBuilder) {
   for (DbgRecord &DR : Inst.getDbgRecordRange()) {
-    if (DPLabel *DPL = dyn_cast<DPLabel>(&DR)) {
-      MIRBuilder.setDebugLoc(DPL->getDebugLoc());
-      assert(DPL->getLabel() && "Missing label");
-      assert(DPL->getLabel()->isValidLocationForIntrinsic(
+    if (DbgLabelRecord *DLR = dyn_cast<DbgLabelRecord>(&DR)) {
+      MIRBuilder.setDebugLoc(DLR->getDebugLoc());
+      assert(DLR->getLabel() && "Missing label");
+      assert(DLR->getLabel()->isValidLocationForIntrinsic(
                  MIRBuilder.getDebugLoc()) &&
              "Expected inlined-at fields to agree");
-      MIRBuilder.buildDbgLabel(DPL->getLabel());
+      MIRBuilder.buildDbgLabel(DLR->getLabel());
       continue;
     }
     DbgVariableRecord &DVR = cast<DbgVariableRecord>(DR);

--- a/llvm/lib/CodeGen/SelectionDAG/FastISel.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/FastISel.cpp
@@ -1192,16 +1192,16 @@ void FastISel::handleDbgInfo(const Instruction *II) {
     flushLocalValueMap();
     recomputeInsertPt();
 
-    if (DPLabel *DPL = dyn_cast<DPLabel>(&DR)) {
-      assert(DPL->getLabel() && "Missing label");
+    if (DbgLabelRecord *DLR = dyn_cast<DbgLabelRecord>(&DR)) {
+      assert(DLR->getLabel() && "Missing label");
       if (!FuncInfo.MF->getMMI().hasDebugInfo()) {
-        LLVM_DEBUG(dbgs() << "Dropping debug info for " << *DPL << "\n");
+        LLVM_DEBUG(dbgs() << "Dropping debug info for " << *DLR << "\n");
         continue;
       }
 
-      BuildMI(*FuncInfo.MBB, FuncInfo.InsertPt, DPL->getDebugLoc(),
+      BuildMI(*FuncInfo.MBB, FuncInfo.InsertPt, DLR->getDebugLoc(),
               TII.get(TargetOpcode::DBG_LABEL))
-          .addMetadata(DPL->getLabel());
+          .addMetadata(DLR->getLabel());
       continue;
     }
 

--- a/llvm/lib/CodeGen/SelectionDAG/SelectionDAGBuilder.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/SelectionDAGBuilder.cpp
@@ -1248,18 +1248,18 @@ void SelectionDAGBuilder::visitDbgInfo(const Instruction &I) {
   // We must skip DbgVariableRecords if they've already been processed above as
   // we have just emitted the debug values resulting from assignment tracking
   // analysis, making any existing DbgVariableRecords redundant (and probably
-  // less correct). We still need to process DPLabels. This does sink DPLabels
+  // less correct). We still need to process DbgLabelRecords. This does sink DbgLabelRecords
   // to the bottom of the group of debug records. That sholdn't be important
-  // as it does so deterministcally and ordering between DPLabels and
+  // as it does so deterministcally and ordering between DbgLabelRecords and
   // DbgVariableRecords is immaterial (other than for MIR/IR printing).
   bool SkipDbgVariableRecords = DAG.getFunctionVarLocs();
   // Is there is any debug-info attached to this instruction, in the form of
   // DbgRecord non-instruction debug-info records.
   for (DbgRecord &DR : I.getDbgRecordRange()) {
-    if (DPLabel *DPL = dyn_cast<DPLabel>(&DR)) {
-      assert(DPL->getLabel() && "Missing label");
+    if (DbgLabelRecord *DLR = dyn_cast<DbgLabelRecord>(&DR)) {
+      assert(DLR->getLabel() && "Missing label");
       SDDbgLabel *SDV =
-          DAG.getDbgLabel(DPL->getLabel(), DPL->getDebugLoc(), SDNodeOrder);
+          DAG.getDbgLabel(DLR->getLabel(), DLR->getDebugLoc(), SDNodeOrder);
       DAG.AddDbgLabel(SDV);
       continue;
     }

--- a/llvm/lib/CodeGen/SelectionDAG/SelectionDAGBuilder.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/SelectionDAGBuilder.cpp
@@ -1248,10 +1248,11 @@ void SelectionDAGBuilder::visitDbgInfo(const Instruction &I) {
   // We must skip DbgVariableRecords if they've already been processed above as
   // we have just emitted the debug values resulting from assignment tracking
   // analysis, making any existing DbgVariableRecords redundant (and probably
-  // less correct). We still need to process DbgLabelRecords. This does sink DbgLabelRecords
-  // to the bottom of the group of debug records. That sholdn't be important
-  // as it does so deterministcally and ordering between DbgLabelRecords and
-  // DbgVariableRecords is immaterial (other than for MIR/IR printing).
+  // less correct). We still need to process DbgLabelRecords. This does sink
+  // DbgLabelRecords to the bottom of the group of debug records. That sholdn't
+  // be important as it does so deterministcally and ordering between
+  // DbgLabelRecords and DbgVariableRecords is immaterial (other than for MIR/IR
+  // printing).
   bool SkipDbgVariableRecords = DAG.getFunctionVarLocs();
   // Is there is any debug-info attached to this instruction, in the form of
   // DbgRecord non-instruction debug-info records.

--- a/llvm/lib/IR/AsmWriter.cpp
+++ b/llvm/lib/IR/AsmWriter.cpp
@@ -1152,8 +1152,8 @@ void SlotTracker::processDbgRecordMetadata(const DbgRecord &DR) {
       if (auto *Empty = dyn_cast<MDNode>(DVR->getRawAddress()))
         CreateMetadataSlot(Empty);
     }
-  } else if (const DPLabel *DPL = dyn_cast<const DPLabel>(&DR)) {
-    CreateMetadataSlot(DPL->getRawLabel());
+  } else if (const DbgLabelRecord *DLR = dyn_cast<const DbgLabelRecord>(&DR)) {
+    CreateMetadataSlot(DLR->getRawLabel());
   } else {
     llvm_unreachable("unsupported DbgRecord kind");
   }
@@ -2719,7 +2719,7 @@ public:
   void printInstruction(const Instruction &I);
   void printDPMarker(const DPMarker &DPI);
   void printDbgVariableRecord(const DbgVariableRecord &DVR);
-  void printDPLabel(const DPLabel &DPL);
+  void printDbgLabelRecord(const DbgLabelRecord &DLR);
   void printDbgRecord(const DbgRecord &DR);
   void printDbgRecordLine(const DbgRecord &DR);
 
@@ -4621,8 +4621,8 @@ void AssemblyWriter::printDPMarker(const DPMarker &Marker) {
 void AssemblyWriter::printDbgRecord(const DbgRecord &DR) {
   if (auto *DVR = dyn_cast<DbgVariableRecord>(&DR))
     printDbgVariableRecord(*DVR);
-  else if (auto *DPL = dyn_cast<DPLabel>(&DR))
-    printDPLabel(*DPL);
+  else if (auto *DLR = dyn_cast<DbgLabelRecord>(&DR))
+    printDbgLabelRecord(*DLR);
   else
     llvm_unreachable("Unexpected DbgRecord kind");
 }
@@ -4672,7 +4672,7 @@ void AssemblyWriter::printDbgRecordLine(const DbgRecord &DR) {
   Out << '\n';
 }
 
-void AssemblyWriter::printDPLabel(const DPLabel &Label) {
+void AssemblyWriter::printDbgLabelRecord(const DbgLabelRecord &Label) {
   auto WriterCtx = getContext();
   Out << "#dbg_label(";
   WriteAsOperandInternal(Out, Label.getRawLabel(), WriterCtx, true);
@@ -4934,7 +4934,7 @@ void DPMarker::print(raw_ostream &ROS, ModuleSlotTracker &MST,
   W.printDPMarker(*this);
 }
 
-void DPLabel::print(raw_ostream &ROS, bool IsForDebug) const {
+void DbgLabelRecord::print(raw_ostream &ROS, bool IsForDebug) const {
 
   ModuleSlotTracker MST(getModuleFromDPI(this), true);
   print(ROS, MST, IsForDebug);
@@ -4957,7 +4957,7 @@ void DbgVariableRecord::print(raw_ostream &ROS, ModuleSlotTracker &MST,
   W.printDbgVariableRecord(*this);
 }
 
-void DPLabel::print(raw_ostream &ROS, ModuleSlotTracker &MST,
+void DbgLabelRecord::print(raw_ostream &ROS, ModuleSlotTracker &MST,
                     bool IsForDebug) const {
   formatted_raw_ostream OS(ROS);
   SlotTracker EmptySlotTable(static_cast<const Module *>(nullptr));
@@ -4970,7 +4970,7 @@ void DPLabel::print(raw_ostream &ROS, ModuleSlotTracker &MST,
   incorporateFunction(Marker->getParent() ? Marker->getParent()->getParent()
                                           : nullptr);
   AssemblyWriter W(OS, SlotTable, getModuleFromDPI(this), nullptr, IsForDebug);
-  W.printDPLabel(*this);
+  W.printDbgLabelRecord(*this);
 }
 
 void Value::print(raw_ostream &ROS, bool IsForDebug) const {

--- a/llvm/lib/IR/AsmWriter.cpp
+++ b/llvm/lib/IR/AsmWriter.cpp
@@ -4958,7 +4958,7 @@ void DbgVariableRecord::print(raw_ostream &ROS, ModuleSlotTracker &MST,
 }
 
 void DbgLabelRecord::print(raw_ostream &ROS, ModuleSlotTracker &MST,
-                    bool IsForDebug) const {
+                           bool IsForDebug) const {
   formatted_raw_ostream OS(ROS);
   SlotTracker EmptySlotTable(static_cast<const Module *>(nullptr));
   SlotTracker &SlotTable =

--- a/llvm/lib/IR/AutoUpgrade.cpp
+++ b/llvm/lib/IR/AutoUpgrade.cpp
@@ -2358,7 +2358,7 @@ static MDType *unwrapMAVOp(CallBase *CI, unsigned Op) {
 static void upgradeDbgIntrinsicToDbgRecord(StringRef Name, CallBase *CI) {
   DbgRecord *DR = nullptr;
   if (Name == "label") {
-    DR = new DPLabel(unwrapMAVOp<DILabel>(CI, 0), CI->getDebugLoc());
+    DR = new DbgLabelRecord(unwrapMAVOp<DILabel>(CI, 0), CI->getDebugLoc());
   } else if (Name == "assign") {
     DR = new DbgVariableRecord(
         unwrapMAVOp<Metadata>(CI, 0), unwrapMAVOp<DILocalVariable>(CI, 1),

--- a/llvm/lib/IR/BasicBlock.cpp
+++ b/llvm/lib/IR/BasicBlock.cpp
@@ -83,7 +83,8 @@ void BasicBlock::convertToNewDbgValues() {
     }
 
     if (DbgLabelInst *DLI = dyn_cast<DbgLabelInst>(&I)) {
-      DbgVarRecs.push_back(new DbgLabelRecord(DLI->getLabel(), DLI->getDebugLoc()));
+      DbgVarRecs.push_back(
+          new DbgLabelRecord(DLI->getLabel(), DLI->getDebugLoc()));
       DLI->eraseFromParent();
       continue;
     }

--- a/llvm/lib/IR/BasicBlock.cpp
+++ b/llvm/lib/IR/BasicBlock.cpp
@@ -83,7 +83,7 @@ void BasicBlock::convertToNewDbgValues() {
     }
 
     if (DbgLabelInst *DLI = dyn_cast<DbgLabelInst>(&I)) {
-      DbgVarRecs.push_back(new DPLabel(DLI->getLabel(), DLI->getDebugLoc()));
+      DbgVarRecs.push_back(new DbgLabelRecord(DLI->getLabel(), DLI->getDebugLoc()));
       DLI->eraseFromParent();
       continue;
     }

--- a/llvm/lib/IR/DIBuilder.cpp
+++ b/llvm/lib/IR/DIBuilder.cpp
@@ -1155,12 +1155,12 @@ DbgInstPtr DIBuilder::insertLabel(DILabel *LabelInfo, const DILocation *DL,
 
   trackIfUnresolved(LabelInfo);
   if (M.IsNewDbgInfoFormat) {
-    DPLabel *DPL = new DPLabel(LabelInfo, DL);
+    DbgLabelRecord *DLR = new DbgLabelRecord(LabelInfo, DL);
     if (InsertBB && InsertBefore)
-      InsertBB->insertDbgRecordBefore(DPL, InsertBefore->getIterator());
+      InsertBB->insertDbgRecordBefore(DLR, InsertBefore->getIterator());
     else if (InsertBB)
-      InsertBB->insertDbgRecordBefore(DPL, InsertBB->end());
-    return DPL;
+      InsertBB->insertDbgRecordBefore(DLR, InsertBB->end());
+    return DLR;
   }
 
   if (!LabelFn)

--- a/llvm/lib/IR/DebugProgramInstruction.cpp
+++ b/llvm/lib/IR/DebugProgramInstruction.cpp
@@ -82,7 +82,7 @@ void DbgRecord::deleteRecord() {
     delete cast<DbgVariableRecord>(this);
     return;
   case LabelKind:
-    delete cast<DPLabel>(this);
+    delete cast<DbgLabelRecord>(this);
     return;
   }
   llvm_unreachable("unsupported DbgRecord kind");
@@ -94,7 +94,7 @@ void DbgRecord::print(raw_ostream &O, bool IsForDebug) const {
     cast<DbgVariableRecord>(this)->print(O, IsForDebug);
     return;
   case LabelKind:
-    cast<DPLabel>(this)->print(O, IsForDebug);
+    cast<DbgLabelRecord>(this)->print(O, IsForDebug);
     return;
   };
   llvm_unreachable("unsupported DbgRecord kind");
@@ -107,7 +107,7 @@ void DbgRecord::print(raw_ostream &O, ModuleSlotTracker &MST,
     cast<DbgVariableRecord>(this)->print(O, MST, IsForDebug);
     return;
   case LabelKind:
-    cast<DPLabel>(this)->print(O, MST, IsForDebug);
+    cast<DbgLabelRecord>(this)->print(O, MST, IsForDebug);
     return;
   };
   llvm_unreachable("unsupported DbgRecord kind");
@@ -121,7 +121,7 @@ bool DbgRecord::isIdenticalToWhenDefined(const DbgRecord &R) const {
     return cast<DbgVariableRecord>(this)->isIdenticalToWhenDefined(
         *cast<DbgVariableRecord>(&R));
   case LabelKind:
-    return cast<DPLabel>(this)->getLabel() == cast<DPLabel>(R).getLabel();
+    return cast<DbgLabelRecord>(this)->getLabel() == cast<DbgLabelRecord>(R).getLabel();
   };
   llvm_unreachable("unsupported DbgRecord kind");
 }
@@ -136,24 +136,24 @@ DbgRecord::createDebugIntrinsic(Module *M, Instruction *InsertBefore) const {
   case ValueKind:
     return cast<DbgVariableRecord>(this)->createDebugIntrinsic(M, InsertBefore);
   case LabelKind:
-    return cast<DPLabel>(this)->createDebugIntrinsic(M, InsertBefore);
+    return cast<DbgLabelRecord>(this)->createDebugIntrinsic(M, InsertBefore);
   };
   llvm_unreachable("unsupported DbgRecord kind");
 }
 
-DPLabel::DPLabel(MDNode *Label, MDNode *DL)
+DbgLabelRecord::DbgLabelRecord(MDNode *Label, MDNode *DL)
     : DbgRecord(LabelKind, DebugLoc(DL)), Label(Label) {
   assert(Label && "Unexpected nullptr");
   assert((isa<DILabel>(Label) || Label->isTemporary()) &&
          "Label type must be or resolve to a DILabel");
 }
-DPLabel::DPLabel(DILabel *Label, DebugLoc DL)
+DbgLabelRecord::DbgLabelRecord(DILabel *Label, DebugLoc DL)
     : DbgRecord(LabelKind, DL), Label(Label) {
   assert(Label && "Unexpected nullptr");
 }
 
-DPLabel *DPLabel::createUnresolvedDPLabel(MDNode *Label, MDNode *DL) {
-  return new DPLabel(Label, DL);
+DbgLabelRecord *DbgLabelRecord::createUnresolvedDbgLabelRecord(MDNode *Label, MDNode *DL) {
+  return new DbgLabelRecord(Label, DL);
 }
 
 DbgVariableRecord::DbgVariableRecord(DbgVariableRecord::LocationType Type,
@@ -380,7 +380,7 @@ DbgRecord *DbgRecord::clone() const {
   case ValueKind:
     return cast<DbgVariableRecord>(this)->clone();
   case LabelKind:
-    return cast<DPLabel>(this)->clone();
+    return cast<DbgLabelRecord>(this)->clone();
   };
   llvm_unreachable("unsupported DbgRecord kind");
 }
@@ -389,8 +389,8 @@ DbgVariableRecord *DbgVariableRecord::clone() const {
   return new DbgVariableRecord(*this);
 }
 
-DPLabel *DPLabel::clone() const {
-  return new DPLabel(getLabel(), getDebugLoc());
+DbgLabelRecord *DbgLabelRecord::clone() const {
+  return new DbgLabelRecord(getLabel(), getDebugLoc());
 }
 
 DbgVariableIntrinsic *
@@ -450,7 +450,7 @@ DbgVariableRecord::createDebugIntrinsic(Module *M,
   return DVI;
 }
 
-DbgLabelInst *DPLabel::createDebugIntrinsic(Module *M,
+DbgLabelInst *DbgLabelRecord::createDebugIntrinsic(Module *M,
                                             Instruction *InsertBefore) const {
   auto *LabelFn = Intrinsic::getDeclaration(M, Intrinsic::dbg_label);
   Value *Args[] = {

--- a/llvm/lib/IR/DebugProgramInstruction.cpp
+++ b/llvm/lib/IR/DebugProgramInstruction.cpp
@@ -121,7 +121,8 @@ bool DbgRecord::isIdenticalToWhenDefined(const DbgRecord &R) const {
     return cast<DbgVariableRecord>(this)->isIdenticalToWhenDefined(
         *cast<DbgVariableRecord>(&R));
   case LabelKind:
-    return cast<DbgLabelRecord>(this)->getLabel() == cast<DbgLabelRecord>(R).getLabel();
+    return cast<DbgLabelRecord>(this)->getLabel() ==
+           cast<DbgLabelRecord>(R).getLabel();
   };
   llvm_unreachable("unsupported DbgRecord kind");
 }
@@ -152,7 +153,8 @@ DbgLabelRecord::DbgLabelRecord(DILabel *Label, DebugLoc DL)
   assert(Label && "Unexpected nullptr");
 }
 
-DbgLabelRecord *DbgLabelRecord::createUnresolvedDbgLabelRecord(MDNode *Label, MDNode *DL) {
+DbgLabelRecord *DbgLabelRecord::createUnresolvedDbgLabelRecord(MDNode *Label,
+                                                               MDNode *DL) {
   return new DbgLabelRecord(Label, DL);
 }
 
@@ -450,8 +452,9 @@ DbgVariableRecord::createDebugIntrinsic(Module *M,
   return DVI;
 }
 
-DbgLabelInst *DbgLabelRecord::createDebugIntrinsic(Module *M,
-                                            Instruction *InsertBefore) const {
+DbgLabelInst *
+DbgLabelRecord::createDebugIntrinsic(Module *M,
+                                     Instruction *InsertBefore) const {
   auto *LabelFn = Intrinsic::getDeclaration(M, Intrinsic::dbg_label);
   Value *Args[] = {
       MetadataAsValue::get(getDebugLoc()->getContext(), getLabel())};

--- a/llvm/lib/Transforms/Scalar/SpeculativeExecution.cpp
+++ b/llvm/lib/Transforms/Scalar/SpeculativeExecution.cpp
@@ -292,7 +292,7 @@ bool SpeculativeExecutionPass::considerHoistingFromTo(
   InstructionCost TotalSpeculationCost = 0;
   unsigned NotHoistedInstCount = 0;
   for (const auto &I : FromBlock) {
-    // Make note of any DbgVariableRecords that need hoisting. DPLabels
+    // Make note of any DbgVariableRecords that need hoisting. DbgLabelRecords
     // get left behind just like llvm.dbg.labels.
     for (DbgVariableRecord &DVR : filterDbgVars(I.getDbgRecordRange())) {
       if (HasNoUnhoistedInstr(DVR.location_ops()))

--- a/llvm/lib/Transforms/Utils/BasicBlockUtils.cpp
+++ b/llvm/lib/Transforms/Utils/BasicBlockUtils.cpp
@@ -388,7 +388,7 @@ DbgVariableRecordsRemoveRedundantDbgInstrsUsingBackwardScan(BasicBlock *BB) {
   SmallDenseSet<DebugVariable> VariableSet;
   for (auto &I : reverse(*BB)) {
     for (DbgRecord &DR : reverse(I.getDbgRecordRange())) {
-      if (isa<DPLabel>(DR)) {
+      if (isa<DbgLabelRecord>(DR)) {
         // Emulate existing behaviour (see comment below for dbg.declares).
         // FIXME: Don't do this.
         VariableSet.clear();

--- a/llvm/lib/Transforms/Utils/CodeExtractor.cpp
+++ b/llvm/lib/Transforms/Utils/CodeExtractor.cpp
@@ -1619,8 +1619,8 @@ static void fixupDebugInfoPostExtraction(Function &OldFunc, Function &NewFunc,
 
   auto UpdateDbgRecordsOnInst = [&](Instruction &I) -> void {
     for (DbgRecord &DR : I.getDbgRecordRange()) {
-      if (DPLabel *DPL = dyn_cast<DPLabel>(&DR)) {
-        UpdateDbgLabel(DPL);
+      if (DbgLabelRecord *DLR = dyn_cast<DbgLabelRecord>(&DR)) {
+        UpdateDbgLabel(DLR);
         continue;
       }
 

--- a/llvm/lib/Transforms/Utils/ValueMapper.cpp
+++ b/llvm/lib/Transforms/Utils/ValueMapper.cpp
@@ -538,8 +538,8 @@ Value *Mapper::mapValue(const Value *V) {
 }
 
 void Mapper::remapDbgRecord(DbgRecord &DR) {
-  if (DPLabel *DPL = dyn_cast<DPLabel>(&DR)) {
-    DPL->setLabel(cast<DILabel>(mapMetadata(DPL->getLabel())));
+  if (DbgLabelRecord *DLR = dyn_cast<DbgLabelRecord>(&DR)) {
+    DLR->setLabel(cast<DILabel>(mapMetadata(DLR->getLabel())));
     return;
   }
 

--- a/llvm/unittests/IR/IRBuilderTest.cpp
+++ b/llvm/unittests/IR/IRBuilderTest.cpp
@@ -922,7 +922,7 @@ TEST_F(IRBuilderTest, DIBuilder) {
     DILabel *Label =
         DIB.createLabel(BarScope, "badger", File, 1, /*AlwaysPreserve*/ false);
 
-    { /* dbg.label | DPLabel */
+    { /* dbg.label | DbgLabelRecord */
       // Insert before I and check order.
       ExpectOrder(DIB.insertLabel(Label, LabelLoc, I), I->getIterator());
 
@@ -931,7 +931,7 @@ TEST_F(IRBuilderTest, DIBuilder) {
       // inserted into the block untill another instruction is added.
       DbgInstPtr LabelRecord = DIB.insertLabel(Label, LabelLoc, BB);
       // Specifically do not insert a terminator, to check this works. `I`
-      // should have absorbed the DPLabel in the new debug info mode.
+      // should have absorbed the DbgLabelRecord in the new debug info mode.
       I = Builder.CreateAlloca(Builder.getInt32Ty());
       ExpectOrder(LabelRecord, I->getIterator());
     }


### PR DESCRIPTION
This patch renames DPLabel to DbgLabelRecord, in accordance with the ongoing DbgRecord rename. This rename was fairly trivial, since DPLabel isn't as widely used as DPValue and has no real conflicts in either its full or abbreviated name. As usual, the entire replacement was done automatically, with `s/DPLabel/DbgLabelRecord/` and `s/DPL/DLR/`.