### PR TITLE
[clang][dataflow] Fix crash when analyzing a coroutine

### DIFF
--- a/clang/lib/Analysis/FlowSensitive/AdornedCFG.cpp
+++ b/clang/lib/Analysis/FlowSensitive/AdornedCFG.cpp
@@ -103,7 +103,7 @@ buildContainsExprConsumedInDifferentBlock(
   auto CheckChildExprs = [&Result, &StmtToBlock](const Stmt *S,
                                                  const CFGBlock *Block) {
     for (const Stmt *Child : S->children()) {
-      if (!isa<Expr>(Child))
+      if (!isa_and_nonnull<Expr>(Child))
         continue;
       const CFGBlock *ChildBlock = StmtToBlock.lookup(Child);
       if (ChildBlock != Block)

--- a/clang/unittests/Analysis/FlowSensitive/TransferTest.cpp
+++ b/clang/unittests/Analysis/FlowSensitive/TransferTest.cpp
@@ -4664,7 +4664,7 @@ TEST(TransferTest, DoesNotCrashOnUnionThisExpr) {
 
 TEST(TransferTest, DoesNotCrashOnNullChildren) {
   std::string Code = (CoroutineLibrary + R"cc(
-    task foo() noexcept {
+    task target() noexcept {
       co_return;
     }
   )cc")
@@ -4675,7 +4675,7 @@ TEST(TransferTest, DoesNotCrashOnNullChildren) {
       Code,
       [](const llvm::StringMap<DataflowAnalysisState<NoopLattice>> &,
          ASTContext &) {},
-      LangStandard::lang_cxx20, /*ApplyBuiltinTransfer=*/true, "foo");
+      LangStandard::lang_cxx20, /*ApplyBuiltinTransfer=*/true);
 }
 
 TEST(TransferTest, StructuredBindingAssignFromStructIntMembersToRefs) {

--- a/clang/unittests/Analysis/FlowSensitive/TransferTest.cpp
+++ b/clang/unittests/Analysis/FlowSensitive/TransferTest.cpp
@@ -37,6 +37,40 @@ using ::testing::Ne;
 using ::testing::NotNull;
 using ::testing::UnorderedElementsAre;
 
+// Declares a minimal coroutine library.
+constexpr llvm::StringRef CoroutineLibrary = R"cc(
+struct promise;
+struct task;
+
+namespace std {
+template <class, class...>
+struct coroutine_traits {};
+template <>
+struct coroutine_traits<task> {
+    using promise_type = promise;
+};
+
+template <class Promise = void>
+struct coroutine_handle {
+    static constexpr coroutine_handle from_address(void *addr) { return {}; }
+};
+}  // namespace std
+
+struct awaitable {
+    bool await_ready() const noexcept;
+    void await_suspend(std::coroutine_handle<promise>) const noexcept;
+    void await_resume() const noexcept;
+};
+struct task {};
+struct promise {
+    task get_return_object();
+    awaitable initial_suspend();
+    awaitable final_suspend() noexcept;
+    void unhandled_exception();
+    void return_void();
+};
+)cc";
+
 void runDataflow(
     llvm::StringRef Code,
     std::function<
@@ -4607,7 +4641,7 @@ TEST(TransferTest, LoopCanProveInvariantForBoolean) {
 }
 
 TEST(TransferTest, DoesNotCrashOnUnionThisExpr) {
-  std::string Code = R"(
+  std::string Code = R"cc(
     union Union {
       int A;
       float B;
@@ -4618,7 +4652,7 @@ TEST(TransferTest, DoesNotCrashOnUnionThisExpr) {
       Union B;
       A = B;
     }
-  )";
+  )cc";
   // This is a crash regression test when calling the transfer function on a
   // `CXXThisExpr` that refers to a union.
   runDataflow(
@@ -4626,6 +4660,21 @@ TEST(TransferTest, DoesNotCrashOnUnionThisExpr) {
       [](const llvm::StringMap<DataflowAnalysisState<NoopLattice>> &,
          ASTContext &) {},
       LangStandard::lang_cxx17, /*ApplyBuiltinTransfer=*/true, "operator=");
+}
+
+TEST(TransferTest, DoesNotCrashOnNullChildren) {
+  std::string Code = (CoroutineLibrary + R"cc(
+    task foo() noexcept {
+      co_return;
+    }
+  )cc").str();
+  // This is a crash regression test when calling `AdornedCFG::build` on a
+  // statement (in this case, the `CoroutineBodyStmt`) with null children.
+  runDataflow(
+      Code,
+      [](const llvm::StringMap<DataflowAnalysisState<NoopLattice>> &,
+         ASTContext &) {},
+      LangStandard::lang_cxx20, /*ApplyBuiltinTransfer=*/true, "foo");
 }
 
 TEST(TransferTest, StructuredBindingAssignFromStructIntMembersToRefs) {

--- a/clang/unittests/Analysis/FlowSensitive/TransferTest.cpp
+++ b/clang/unittests/Analysis/FlowSensitive/TransferTest.cpp
@@ -4667,7 +4667,8 @@ TEST(TransferTest, DoesNotCrashOnNullChildren) {
     task foo() noexcept {
       co_return;
     }
-  )cc").str();
+  )cc")
+                         .str();
   // This is a crash regression test when calling `AdornedCFG::build` on a
   // statement (in this case, the `CoroutineBodyStmt`) with null children.
   runDataflow(


### PR DESCRIPTION
A coroutine function body (`CoroutineBodyStmt`) may have null children, which causes `isa` to segfault.