### PR TITLE
[NFC][CLANG] Fix static analyzer bugs about unnecessary object copies with auto keyword

### DIFF
--- a/clang/lib/Analysis/FlowSensitive/DataflowEnvironment.cpp
+++ b/clang/lib/Analysis/FlowSensitive/DataflowEnvironment.cpp
@@ -416,7 +416,7 @@ void Environment::initialize() {
     assert(Parent != nullptr);
 
     if (Parent->isLambda()) {
-      for (auto Capture : Parent->captures()) {
+      for (const auto &Capture : Parent->captures()) {
         if (Capture.capturesVariable()) {
           const auto *VarDecl = Capture.getCapturedVar();
           assert(VarDecl != nullptr);


### PR DESCRIPTION
Reported by Static Analyzer Tool:
In clang::dataflow::Environment::initialize(): Using the auto keyword without an & causes the copy of an object of type LambdaCapture