### PR TITLE
[libc] stop including unistd.h in src/

### DIFF
--- a/libc/src/__support/File/linux/lseekImpl.h
+++ b/libc/src/__support/File/linux/lseekImpl.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_LIBC_SRC___SUPPORT_FILE_LINUX_LSEEKIMPL_H
 #define LLVM_LIBC_SRC___SUPPORT_FILE_LINUX_LSEEKIMPL_H
 
+#include "include/llvm-libc-types/off_t.h"
 #include "src/__support/OSUtil/syscall.h" // For internal syscall function.
 #include "src/__support/common.h"
 #include "src/__support/error_or.h"
@@ -16,7 +17,6 @@
 
 #include <stdint.h>      // For uint64_t.
 #include <sys/syscall.h> // For syscall numbers.
-#include <unistd.h>      // For off_t.
 
 namespace LIBC_NAMESPACE {
 namespace internal {

--- a/libc/src/unistd/dup.h
+++ b/libc/src/unistd/dup.h
@@ -9,8 +9,6 @@
 #ifndef LLVM_LIBC_SRC_UNISTD_DUP_H
 #define LLVM_LIBC_SRC_UNISTD_DUP_H
 
-#include <unistd.h>
-
 namespace LIBC_NAMESPACE {
 
 int dup(int fd);

--- a/libc/src/unistd/dup2.h
+++ b/libc/src/unistd/dup2.h
@@ -9,8 +9,6 @@
 #ifndef LLVM_LIBC_SRC_UNISTD_DUP2_H
 #define LLVM_LIBC_SRC_UNISTD_DUP2_H
 
-#include <unistd.h>
-
 namespace LIBC_NAMESPACE {
 
 int dup2(int oldfd, int newfd);

--- a/libc/src/unistd/dup3.h
+++ b/libc/src/unistd/dup3.h
@@ -9,8 +9,6 @@
 #ifndef LLVM_LIBC_SRC_UNISTD_DUP3_H
 #define LLVM_LIBC_SRC_UNISTD_DUP3_H
 
-#include <unistd.h>
-
 namespace LIBC_NAMESPACE {
 
 int dup3(int oldfd, int newfd, int flags);

--- a/libc/src/unistd/fork.h
+++ b/libc/src/unistd/fork.h
@@ -9,7 +9,7 @@
 #ifndef LLVM_LIBC_SRC_UNISTD_FORK_H
 #define LLVM_LIBC_SRC_UNISTD_FORK_H
 
-#include <unistd.h>
+#include "include/llvm-libc-types/pid_t.h"
 
 namespace LIBC_NAMESPACE {
 

--- a/libc/src/unistd/ftruncate.h
+++ b/libc/src/unistd/ftruncate.h
@@ -9,7 +9,7 @@
 #ifndef LLVM_LIBC_SRC_UNISTD_FTRUNCATE_H
 #define LLVM_LIBC_SRC_UNISTD_FTRUNCATE_H
 
-#include <unistd.h>
+#include "include/llvm-libc-types/off_t.h"
 
 namespace LIBC_NAMESPACE {
 

--- a/libc/src/unistd/getcwd.h
+++ b/libc/src/unistd/getcwd.h
@@ -9,7 +9,7 @@
 #ifndef LLVM_LIBC_SRC_UNISTD_GETCWD_H
 #define LLVM_LIBC_SRC_UNISTD_GETCWD_H
 
-#include <unistd.h>
+#include "include/llvm-libc-types/size_t.h"
 
 namespace LIBC_NAMESPACE {
 

--- a/libc/src/unistd/geteuid.h
+++ b/libc/src/unistd/geteuid.h
@@ -9,7 +9,7 @@
 #ifndef LLVM_LIBC_SRC_UNISTD_GETEUID_H
 #define LLVM_LIBC_SRC_UNISTD_GETEUID_H
 
-#include <unistd.h>
+#include "include/llvm-libc-types/uid_t.h"
 
 namespace LIBC_NAMESPACE {
 

--- a/libc/src/unistd/getopt.h
+++ b/libc/src/unistd/getopt.h
@@ -9,8 +9,8 @@
 #ifndef LLVM_LIBC_SRC_UNISTD_GETOPT_H
 #define LLVM_LIBC_SRC_UNISTD_GETOPT_H
 
-#include <stdio.h>
-#include <unistd.h>
+#include "include/llvm-libc-types/FILE.h"
+#include "src/__support/common.h"
 
 namespace LIBC_NAMESPACE {
 

--- a/libc/src/unistd/getopt.h
+++ b/libc/src/unistd/getopt.h
@@ -10,7 +10,6 @@
 #define LLVM_LIBC_SRC_UNISTD_GETOPT_H
 
 #include "include/llvm-libc-types/FILE.h"
-#include "src/__support/common.h"
 
 namespace LIBC_NAMESPACE {
 

--- a/libc/src/unistd/getpid.h
+++ b/libc/src/unistd/getpid.h
@@ -9,7 +9,7 @@
 #ifndef LLVM_LIBC_SRC_UNISTD_GETPID_H
 #define LLVM_LIBC_SRC_UNISTD_GETPID_H
 
-#include <unistd.h>
+#include "include/llvm-libc-types/pid_t.h"
 
 namespace LIBC_NAMESPACE {
 

--- a/libc/src/unistd/getppid.h
+++ b/libc/src/unistd/getppid.h
@@ -9,7 +9,7 @@
 #ifndef LLVM_LIBC_SRC_UNISTD_GETPPID_H
 #define LLVM_LIBC_SRC_UNISTD_GETPPID_H
 
-#include <unistd.h>
+#include "include/llvm-libc-types/pid_t.h"
 
 namespace LIBC_NAMESPACE {
 

--- a/libc/src/unistd/getuid.h
+++ b/libc/src/unistd/getuid.h
@@ -9,7 +9,7 @@
 #ifndef LLVM_LIBC_SRC_UNISTD_GETUID_H
 #define LLVM_LIBC_SRC_UNISTD_GETUID_H
 
-#include <unistd.h>
+#include "include/llvm-libc-types/uid_t.h"
 
 namespace LIBC_NAMESPACE {
 

--- a/libc/src/unistd/isatty.h
+++ b/libc/src/unistd/isatty.h
@@ -9,8 +9,6 @@
 #ifndef LLVM_LIBC_SRC_UNISTD_ISATTY_H
 #define LLVM_LIBC_SRC_UNISTD_ISATTY_H
 
-#include <unistd.h>
-
 namespace LIBC_NAMESPACE {
 
 int isatty(int fd);

--- a/libc/src/unistd/link.h
+++ b/libc/src/unistd/link.h
@@ -9,8 +9,6 @@
 #ifndef LLVM_LIBC_SRC_UNISTD_LINK_H
 #define LLVM_LIBC_SRC_UNISTD_LINK_H
 
-#include <unistd.h>
-
 namespace LIBC_NAMESPACE {
 
 int link(const char *, const char *);

--- a/libc/src/unistd/linux/ftruncate.cpp
+++ b/libc/src/unistd/linux/ftruncate.cpp
@@ -8,13 +8,13 @@
 
 #include "src/unistd/ftruncate.h"
 
+#include "include/llvm-libc-types/off_t.h"
 #include "src/__support/OSUtil/syscall.h" // For internal syscall function.
 #include "src/__support/common.h"
-
 #include "src/errno/libc_errno.h"
+
 #include <stdint.h>      // For uint64_t.
 #include <sys/syscall.h> // For syscall numbers.
-#include <unistd.h>
 
 namespace LIBC_NAMESPACE {
 

--- a/libc/src/unistd/linux/lseek.cpp
+++ b/libc/src/unistd/linux/lseek.cpp
@@ -7,14 +7,14 @@
 //===----------------------------------------------------------------------===//
 
 #include "src/unistd/lseek.h"
-#include "src/errno/libc_errno.h"
 
+#include "include/llvm-libc-types/off_t.h"
 #include "src/__support/File/linux/lseekImpl.h"
 #include "src/__support/OSUtil/syscall.h" // For internal syscall function.
 #include "src/__support/common.h"
+#include "src/errno/libc_errno.h"
 
 #include <sys/syscall.h> // For syscall numbers.
-#include <unistd.h>      // For off_t.
 
 namespace LIBC_NAMESPACE {
 

--- a/libc/src/unistd/linux/readlink.cpp
+++ b/libc/src/unistd/linux/readlink.cpp
@@ -8,10 +8,12 @@
 
 #include "src/unistd/readlink.h"
 
+#include "include/llvm-libc-types/size_t.h"
+#include "include/llvm-libc-types/ssize_t.h"
 #include "src/__support/OSUtil/syscall.h" // For internal syscall function.
 #include "src/__support/common.h"
-
 #include "src/errno/libc_errno.h"
+
 #include <fcntl.h>
 #include <sys/syscall.h> // For syscall numbers.
 

--- a/libc/src/unistd/linux/readlinkat.cpp
+++ b/libc/src/unistd/linux/readlinkat.cpp
@@ -8,10 +8,12 @@
 
 #include "src/unistd/readlinkat.h"
 
+#include "include/llvm-libc-types/size_t.h"
+#include "include/llvm-libc-types/ssize_t.h"
 #include "src/__support/OSUtil/syscall.h" // For internal syscall function.
 #include "src/__support/common.h"
-
 #include "src/errno/libc_errno.h"
+
 #include <fcntl.h>
 #include <sys/syscall.h> // For syscall numbers.
 

--- a/libc/src/unistd/linux/sysconf.cpp
+++ b/libc/src/unistd/linux/sysconf.cpp
@@ -8,12 +8,11 @@
 
 #include "src/unistd/sysconf.h"
 
+#include "include/llvm-libc-macros/linux/unistd-macros.h"
 #include "src/__support/common.h"
-
 #include "src/errno/libc_errno.h"
 #include "src/sys/auxv/getauxval.h"
 #include <sys/auxv.h>
-#include <unistd.h>
 
 namespace LIBC_NAMESPACE {
 

--- a/libc/src/unistd/linux/truncate.cpp
+++ b/libc/src/unistd/linux/truncate.cpp
@@ -8,13 +8,13 @@
 
 #include "src/unistd/truncate.h"
 
+#include "include/llvm-libc-types/off_t.h"
 #include "src/__support/OSUtil/syscall.h" // For internal syscall function.
 #include "src/__support/common.h"
 #include "src/errno/libc_errno.h"
 
 #include <stdint.h>      // For uint64_t.
 #include <sys/syscall.h> // For syscall numbers.
-#include <unistd.h>
 
 namespace LIBC_NAMESPACE {
 

--- a/libc/src/unistd/lseek.h
+++ b/libc/src/unistd/lseek.h
@@ -9,7 +9,7 @@
 #ifndef LLVM_LIBC_SRC_UNISTD_LSEEK_H
 #define LLVM_LIBC_SRC_UNISTD_LSEEK_H
 
-#include <unistd.h>
+#include "include/llvm-libc-types/off_t.h"
 
 namespace LIBC_NAMESPACE {
 

--- a/libc/src/unistd/pread.h
+++ b/libc/src/unistd/pread.h
@@ -9,7 +9,9 @@
 #ifndef LLVM_LIBC_SRC_UNISTD_PREAD_H
 #define LLVM_LIBC_SRC_UNISTD_PREAD_H
 
-#include <unistd.h>
+#include "include/llvm-libc-types/off_t.h"
+#include "include/llvm-libc-types/size_t.h"
+#include "include/llvm-libc-types/ssize_t.h"
 
 namespace LIBC_NAMESPACE {
 

--- a/libc/src/unistd/pwrite.h
+++ b/libc/src/unistd/pwrite.h
@@ -9,7 +9,9 @@
 #ifndef LLVM_LIBC_SRC_UNISTD_PWRITE_H
 #define LLVM_LIBC_SRC_UNISTD_PWRITE_H
 
-#include <unistd.h>
+#include "include/llvm-libc-types/off_t.h"
+#include "include/llvm-libc-types/size_t.h"
+#include "include/llvm-libc-types/ssize_t.h"
 
 namespace LIBC_NAMESPACE {
 

--- a/libc/src/unistd/read.h
+++ b/libc/src/unistd/read.h
@@ -9,7 +9,8 @@
 #ifndef LLVM_LIBC_SRC_UNISTD_READ_H
 #define LLVM_LIBC_SRC_UNISTD_READ_H
 
-#include <unistd.h>
+#include "include/llvm-libc-types/size_t.h"
+#include "include/llvm-libc-types/ssize_t.h"
 
 namespace LIBC_NAMESPACE {
 

--- a/libc/src/unistd/readlink.h
+++ b/libc/src/unistd/readlink.h
@@ -9,7 +9,8 @@
 #ifndef LLVM_LIBC_SRC_UNISTD_READLINK_H
 #define LLVM_LIBC_SRC_UNISTD_READLINK_H
 
-#include <unistd.h>
+#include "include/llvm-libc-types/size_t.h"
+#include "include/llvm-libc-types/ssize_t.h"
 
 namespace LIBC_NAMESPACE {
 

--- a/libc/src/unistd/readlinkat.h
+++ b/libc/src/unistd/readlinkat.h
@@ -9,7 +9,8 @@
 #ifndef LLVM_LIBC_SRC_UNISTD_READLINKAT_H
 #define LLVM_LIBC_SRC_UNISTD_READLINKAT_H
 
-#include <unistd.h>
+#include "include/llvm-libc-types/size_t.h"
+#include "include/llvm-libc-types/ssize_t.h"
 
 namespace LIBC_NAMESPACE {
 

--- a/libc/src/unistd/swab.h
+++ b/libc/src/unistd/swab.h
@@ -9,7 +9,7 @@
 #ifndef LLVM_LIBC_SRC_UNISTD_SWAB_H
 #define LLVM_LIBC_SRC_UNISTD_SWAB_H
 
-#include <unistd.h> // For ssize_t
+#include "include/llvm-libc-types/ssize_t.h"
 
 namespace LIBC_NAMESPACE {
 

--- a/libc/src/unistd/symlink.h
+++ b/libc/src/unistd/symlink.h
@@ -9,8 +9,6 @@
 #ifndef LLVM_LIBC_SRC_UNISTD_SYMLINK_H
 #define LLVM_LIBC_SRC_UNISTD_SYMLINK_H
 
-#include <unistd.h>
-
 namespace LIBC_NAMESPACE {
 
 int symlink(const char *, const char *);

--- a/libc/src/unistd/symlinkat.h
+++ b/libc/src/unistd/symlinkat.h
@@ -9,8 +9,6 @@
 #ifndef LLVM_LIBC_SRC_UNISTD_SYMLINKAT_H
 #define LLVM_LIBC_SRC_UNISTD_SYMLINKAT_H
 
-#include <unistd.h>
-
 namespace LIBC_NAMESPACE {
 
 int symlinkat(const char *, int, const char *);

--- a/libc/src/unistd/syscall.h
+++ b/libc/src/unistd/syscall.h
@@ -9,9 +9,6 @@
 #ifndef LLVM_LIBC_SRC_UNISTD_SYSCALL_H
 #define LLVM_LIBC_SRC_UNISTD_SYSCALL_H
 
-#include <stdarg.h>
-#include <unistd.h>
-
 namespace LIBC_NAMESPACE {
 
 long __llvm_libc_syscall(long number, long arg1, long arg2, long arg3,

--- a/libc/src/unistd/sysconf.h
+++ b/libc/src/unistd/sysconf.h
@@ -9,8 +9,6 @@
 #ifndef LLVM_LIBC_SRC_UNISTD_SYSCONF_H
 #define LLVM_LIBC_SRC_UNISTD_SYSCONF_H
 
-#include <unistd.h>
-
 namespace LIBC_NAMESPACE {
 
 long sysconf(int name);

--- a/libc/src/unistd/truncate.h
+++ b/libc/src/unistd/truncate.h
@@ -9,7 +9,7 @@
 #ifndef LLVM_LIBC_SRC_UNISTD_TRUNCATE_H
 #define LLVM_LIBC_SRC_UNISTD_TRUNCATE_H
 
-#include <unistd.h>
+#include "include/llvm-libc-types/off_t.h"
 
 namespace LIBC_NAMESPACE {
 

--- a/libc/src/unistd/write.h
+++ b/libc/src/unistd/write.h
@@ -9,7 +9,8 @@
 #ifndef LLVM_LIBC_SRC_UNISTD_WRITE_H
 #define LLVM_LIBC_SRC_UNISTD_WRITE_H
 
-#include <unistd.h>
+#include "include/llvm-libc-types/size_t.h"
+#include "include/llvm-libc-types/ssize_t.h"
 
 namespace LIBC_NAMESPACE {
 

--- a/libc/test/src/sys/mman/linux/mincore_test.cpp
+++ b/libc/test/src/sys/mman/linux/mincore_test.cpp
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "include/llvm-libc-macros/linux/unistd-macros.h"
 #include "src/__support/OSUtil/syscall.h" // For internal syscall function.
 #include "src/errno/libc_errno.h"
 #include "src/sys/mman/madvise.h"
@@ -21,7 +22,6 @@
 
 #include <sys/mman.h>
 #include <sys/syscall.h>
-#include <unistd.h>
 
 using LIBC_NAMESPACE::testing::ErrnoSetterMatcher::Fails;
 using LIBC_NAMESPACE::testing::ErrnoSetterMatcher::Succeeds;

--- a/libc/test/src/sys/mman/linux/mlock_test.cpp
+++ b/libc/test/src/sys/mman/linux/mlock_test.cpp
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "include/llvm-libc-macros/linux/unistd-macros.h"
 #include "src/__support/OSUtil/syscall.h" // For internal syscall function.
 #include "src/errno/libc_errno.h"
 #include "src/sys/mman/madvise.h"
@@ -29,7 +30,6 @@
 #include <sys/mman.h>
 #include <sys/resource.h>
 #include <sys/syscall.h>
-#include <unistd.h>
 
 using namespace LIBC_NAMESPACE::testing::ErrnoSetterMatcher;
 

--- a/libc/test/src/sys/mman/linux/msync_test.cpp
+++ b/libc/test/src/sys/mman/linux/msync_test.cpp
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "include/llvm-libc-macros/linux/unistd-macros.h"
 #include "src/errno/libc_errno.h"
 #include "src/sys/mman/mlock.h"
 #include "src/sys/mman/mmap.h"

--- a/libc/test/src/unistd/sysconf_test.cpp
+++ b/libc/test/src/unistd/sysconf_test.cpp
@@ -9,7 +9,7 @@
 #include "src/unistd/sysconf.h"
 #include "test/UnitTest/Test.h"
 
-#include <unistd.h>
+#include "include/llvm-libc-macros/linux/unistd-macros.h"
 
 TEST(LlvmLibcSysconfTest, PagesizeTest) {
   long pagesize = LIBC_NAMESPACE::sysconf(_SC_PAGESIZE);

--- a/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
@@ -97,6 +97,11 @@ libc_support_library(
     deps = [":llvm_libc_macros_float_macros"],
 )
 
+libc_support_library(
+  name = "llvm_libc_types",
+  hdrs = glob(["include/llvm-libc-types/*.h"]),
+)
+
 ############################### Support libraries ##############################
 
 libc_support_library(
@@ -2732,6 +2737,7 @@ libc_function(
         ":__support_common",
         ":__support_osutil_syscall",
         ":errno",
+        ":llvm_libc_types",
     ],
 )
 
@@ -2754,6 +2760,7 @@ libc_function(
         ":__support_common",
         ":__support_osutil_syscall",
         ":errno",
+        ":llvm_libc_types",
     ],
 )
 
@@ -2765,6 +2772,7 @@ libc_function(
         ":__support_common",
         ":__support_osutil_syscall",
         ":errno",
+        ":llvm_libc_types",
     ],
 )
 
@@ -2776,6 +2784,7 @@ libc_function(
         ":__support_common",
         ":__support_osutil_syscall",
         ":errno",
+        ":llvm_libc_types",
     ],
 )
 
@@ -2787,6 +2796,7 @@ libc_function(
         ":__support_common",
         ":__support_osutil_syscall",
         ":errno",
+        ":llvm_libc_types",
     ],
 )
 
@@ -2846,6 +2856,7 @@ libc_function(
         ":__support_file_linux_lseekimpl",
         ":__support_osutil_syscall",
         ":errno",
+        ":llvm_libc_types",
     ],
 )
 
@@ -2857,6 +2868,7 @@ libc_function(
         ":__support_common",
         ":__support_osutil_syscall",
         ":errno",
+        ":llvm_libc_types",
     ],
 )
 
@@ -2868,6 +2880,7 @@ libc_function(
         ":__support_common",
         ":__support_osutil_syscall",
         ":errno",
+        ":llvm_libc_types",
     ],
 )
 
@@ -2881,6 +2894,7 @@ libc_function(
         ":__support_macros_sanitizer",
         ":__support_osutil_syscall",
         ":errno",
+        ":llvm_libc_types",
     ],
 )
 
@@ -2892,6 +2906,7 @@ libc_function(
         ":__support_common",
         ":__support_osutil_syscall",
         ":errno",
+        ":llvm_libc_types",
     ],
 )
 
@@ -2903,6 +2918,7 @@ libc_function(
         ":__support_common",
         ":__support_osutil_syscall",
         ":errno",
+        ":llvm_libc_types",
     ],
 )
 
@@ -2961,6 +2977,7 @@ libc_function(
         ":__support_common",
         ":__support_osutil_syscall",
         ":errno",
+        ":llvm_libc_types",
     ],
 )
 
@@ -2972,6 +2989,7 @@ libc_function(
         ":__support_common",
         ":__support_osutil_syscall",
         ":errno",
+        ":llvm_libc_types",
     ],
 )
 
@@ -3006,6 +3024,7 @@ libc_function(
         ":__support_common",
         ":__support_osutil_syscall",
         ":errno",
+        ":llvm_libc_types",
     ],
 )
 


### PR DESCRIPTION
It's not hermetic to include the system libc's headers and is one of the
reasons why our linter bot has been very red for a long time.

This is starting to be an issue for new contributors as well, since we're now
getting conflicts between the parts of our codebase that are hermetic, vs parts
that aren't.

I need to think about a rule of thumb or policy that can be publicly documented
so that we don't backslide.

I should probably clean up test/ as well, but let's clean up just src/ to
unblock fellow contributors.

Link: https://github.com/llvm/llvm-project/pull/85514#discussion_r1532078163
