### PR TITLE
[mlir][arith] mulsi_extended should take fixed-width integers

### DIFF
--- a/mlir/include/mlir/Dialect/Arith/IR/ArithOps.td
+++ b/mlir/include/mlir/Dialect/Arith/IR/ArithOps.td
@@ -413,8 +413,8 @@ def Arith_MulSIExtendedOp : Arith_Op<"mulsi_extended", [Pure, Commutative,
     ```
   }];
 
-  let arguments = (ins SignlessIntegerLike:$lhs, SignlessIntegerLike:$rhs);
-  let results = (outs SignlessIntegerLike:$low, SignlessIntegerLike:$high);
+  let arguments = (ins SignlessFixedWidthIntegerLike:$lhs, SignlessFixedWidthIntegerLike:$rhs);
+  let results = (outs SignlessFixedWidthIntegerLike:$low, SignlessFixedWidthIntegerLike:$high);
 
   let assemblyFormat = "$lhs `,` $rhs attr-dict `:` type($lhs)";
 


### PR DESCRIPTION
According to the spec, `mulsi_extended` takes signless integers (including indices). https://mlir.llvm.org/docs/Dialects/ArithOps/#arithmulsi_extended-arithmulsiextendedop

However, this is not the behaviour implemented: passing `index`-typed args to the operation does not lower canonicalize: 
https://godbolt.org/z/j9xdTc4hn

It seems that, based on this canonicalization pass, https://github.com/llvm/llvm-project/blob/b20360abeb3a80281dc082f1e093abd13cb1ee4c/mlir/lib/Dialect/Arith/IR/ArithCanonicalization.td#L180, `mulsi_extended` is transformed to a pattern involving `extsi`, which expects fixed-width ints. (https://mlir.llvm.org/docs/Dialects/ArithOps/#arithextsi-arithextsiop)

So either the canonicalization pass is incorrect, or it's an issue with the spec. 

This PR changes the spec/op definitions to be in line with canonicalization - but it could be an issue with the canonicalization, and it would be great to clarify this!