### PR TITLE
Remove remaining uses of Instruction-constructors that insert before another Instruction

### DIFF
--- a/clang/lib/CodeGen/CGCUDANV.cpp
+++ b/clang/lib/CodeGen/CGCUDANV.cpp
@@ -484,9 +484,9 @@ static void replaceManagedVar(llvm::GlobalVariable *Var,
     }
     if (auto *I = dyn_cast<llvm::Instruction>(U)) {
       llvm::Value *OldV = Var;
-      llvm::Instruction *NewV =
-          new llvm::LoadInst(Var->getType(), ManagedVar, "ld.managed", false,
-                             llvm::Align(Var->getAlignment()), I);
+      llvm::Instruction *NewV = new llvm::LoadInst(
+          Var->getType(), ManagedVar, "ld.managed", false,
+          llvm::Align(Var->getAlignment()), I->getIterator());
       WorkItem.pop_back();
       // Replace constant expressions directly or indirectly using the managed
       // variable with instructions.

--- a/clang/lib/CodeGen/CGCall.cpp
+++ b/clang/lib/CodeGen/CGCall.cpp
@@ -5062,8 +5062,8 @@ RValue CodeGenFunction::EmitCall(const CGFunctionInfo &CallInfo,
     llvm::AllocaInst *AI;
     if (IP) {
       IP = IP->getNextNode();
-      AI = new llvm::AllocaInst(ArgStruct, DL.getAllocaAddrSpace(),
-                                "argmem", IP);
+      AI = new llvm::AllocaInst(ArgStruct, DL.getAllocaAddrSpace(), "argmem",
+                                IP->getIterator());
     } else {
       AI = CreateTempAlloca(ArgStruct, "argmem");
     }

--- a/clang/lib/CodeGen/CGCoroutine.cpp
+++ b/clang/lib/CodeGen/CGCoroutine.cpp
@@ -867,8 +867,9 @@ void CodeGenFunction::EmitCoroutineBody(const CoroutineBodyStmt &S) {
     EmitStmt(S.getPromiseDeclStmt());
 
     Address PromiseAddr = GetAddrOfLocalVar(S.getPromiseDecl());
-    auto *PromiseAddrVoidPtr = new llvm::BitCastInst(
-        PromiseAddr.emitRawPointer(*this), VoidPtrTy, "", CoroId);
+    auto *PromiseAddrVoidPtr =
+        new llvm::BitCastInst(PromiseAddr.emitRawPointer(*this), VoidPtrTy, "",
+                              CoroId->getIterator());
     // Update CoroId to refer to the promise. We could not do it earlier because
     // promise local variable was not emitted yet.
     CoroId->setArgOperand(1, PromiseAddrVoidPtr);

--- a/clang/lib/CodeGen/CGExpr.cpp
+++ b/clang/lib/CodeGen/CGExpr.cpp
@@ -112,7 +112,7 @@ llvm::AllocaInst *CodeGenFunction::CreateTempAlloca(llvm::Type *Ty,
   if (ArraySize)
     return Builder.CreateAlloca(Ty, ArraySize, Name);
   return new llvm::AllocaInst(Ty, CGM.getDataLayout().getAllocaAddrSpace(),
-                              ArraySize, Name, AllocaInsertPt);
+                              ArraySize, Name, AllocaInsertPt->getIterator());
 }
 
 /// CreateDefaultAlignTempAlloca - This creates an alloca with the

--- a/clang/lib/CodeGen/CGObjC.cpp
+++ b/clang/lib/CodeGen/CGObjC.cpp
@@ -2394,7 +2394,8 @@ static llvm::Value *emitOptimizedARCReturnCall(llvm::Value *value,
     llvm::OperandBundleDef OB("clang.arc.attachedcall", bundleArgs);
     auto *oldCall = cast<llvm::CallBase>(value);
     llvm::CallBase *newCall = llvm::CallBase::addOperandBundle(
-        oldCall, llvm::LLVMContext::OB_clang_arc_attachedcall, OB, oldCall);
+        oldCall, llvm::LLVMContext::OB_clang_arc_attachedcall, OB,
+        oldCall->getIterator());
     newCall->copyMetadata(*oldCall);
     oldCall->replaceAllUsesWith(newCall);
     oldCall->eraseFromParent();

--- a/clang/lib/CodeGen/CodeGenFunction.h
+++ b/clang/lib/CodeGen/CodeGenFunction.h
@@ -1269,8 +1269,8 @@ public:
                                      CodeGenFunction &CGF) {
     assert(isInConditionalBranch());
     llvm::BasicBlock *block = OutermostConditional->getStartingBlock();
-    auto store =
-        new llvm::StoreInst(value, addr.emitRawPointer(CGF), &block->back());
+    auto store = new llvm::StoreInst(value, addr.emitRawPointer(CGF),
+                                     &block->back().getIterator());
     store->setAlignment(addr.getAlignment().getAsAlign());
   }
 

--- a/clang/lib/CodeGen/CodeGenModule.cpp
+++ b/clang/lib/CodeGen/CodeGenModule.cpp
@@ -5747,13 +5747,13 @@ static void replaceUsesOfNonProtoConstant(llvm::Constant *old,
 
     llvm::CallBase *newCall;
     if (isa<llvm::CallInst>(callSite)) {
-      newCall =
-          llvm::CallInst::Create(newFn, newArgs, newBundles, "", callSite);
+      newCall = llvm::CallInst::Create(newFn, newArgs, newBundles, "",
+                                       callSite->getIterator());
     } else {
       auto *oldInvoke = cast<llvm::InvokeInst>(callSite);
-      newCall = llvm::InvokeInst::Create(newFn, oldInvoke->getNormalDest(),
-                                         oldInvoke->getUnwindDest(), newArgs,
-                                         newBundles, "", callSite);
+      newCall = llvm::InvokeInst::Create(
+          newFn, oldInvoke->getNormalDest(), oldInvoke->getUnwindDest(),
+          newArgs, newBundles, "", callSite->getIterator());
     }
     newArgs.clear(); // for the next iteration
 

--- a/llvm/examples/IRTransforms/SimplifyCFG.cpp
+++ b/llvm/examples/IRTransforms/SimplifyCFG.cpp
@@ -158,7 +158,7 @@ static bool eliminateCondBranches_v1(Function &F) {
     // Replace the conditional branch with an unconditional one, by creating
     // a new unconditional branch to the selected successor and removing the
     // conditional one.
-    BranchInst::Create(BI->getSuccessor(CI->isZero()), BI);
+    BranchInst::Create(BI->getSuccessor(CI->isZero()), BI->getIterator());
     BI->eraseFromParent();
     Changed = true;
   }
@@ -195,7 +195,7 @@ static bool eliminateCondBranches_v2(Function &F, DominatorTree &DT) {
     // a new unconditional branch to the selected successor and removing the
     // conditional one.
     BranchInst *NewBranch =
-        BranchInst::Create(BI->getSuccessor(CI->isZero()), BI);
+        BranchInst::Create(BI->getSuccessor(CI->isZero()), BI->getIterator());
     BI->eraseFromParent();
 
     // Delete the edge between BB and RemovedSucc in the DominatorTree, iff
@@ -242,7 +242,8 @@ static bool eliminateCondBranches_v3(Function &F, DominatorTree &DT) {
     // a new unconditional branch to the selected successor and removing the
     // conditional one.
 
-    BranchInst *NewBranch = BranchInst::Create(TakenSucc, BB.getTerminator());
+    BranchInst *NewBranch =
+        BranchInst::Create(TakenSucc, BB.getTerminator()->getIterator());
     BB.getTerminator()->eraseFromParent();
 
     // Delete the edge between BB and RemovedSucc in the DominatorTree, iff

--- a/llvm/include/llvm/IR/InstrTypes.h
+++ b/llvm/include/llvm/IR/InstrTypes.h
@@ -1542,9 +1542,18 @@ public:
                                     OperandBundleDef OB,
                                     Instruction *InsertPt = nullptr);
 
+  /// Create a clone of \p CB with operand bundle \p OB added.
+  static CallBase *addOperandBundle(CallBase *CB, uint32_t ID,
+                                    OperandBundleDef OB,
+                                    BasicBlock::iterator InsertPt);
+
   /// Create a clone of \p CB with operand bundle \p ID removed.
   static CallBase *removeOperandBundle(CallBase *CB, uint32_t ID,
                                        Instruction *InsertPt = nullptr);
+
+  /// Create a clone of \p CB with operand bundle \p ID removed.
+  static CallBase *removeOperandBundle(CallBase *CB, uint32_t ID,
+                                       BasicBlock::iterator InsertPt);
 
   static bool classof(const Instruction *I) {
     return I->getOpcode() == Instruction::Call ||

--- a/llvm/include/llvm/IR/InstrTypes.h
+++ b/llvm/include/llvm/IR/InstrTypes.h
@@ -1542,18 +1542,9 @@ public:
                                     OperandBundleDef OB,
                                     Instruction *InsertPt = nullptr);
 
-  /// Create a clone of \p CB with operand bundle \p OB added.
-  static CallBase *addOperandBundle(CallBase *CB, uint32_t ID,
-                                    OperandBundleDef OB,
-                                    BasicBlock::iterator InsertPt);
-
   /// Create a clone of \p CB with operand bundle \p ID removed.
   static CallBase *removeOperandBundle(CallBase *CB, uint32_t ID,
                                        Instruction *InsertPt = nullptr);
-
-  /// Create a clone of \p CB with operand bundle \p ID removed.
-  static CallBase *removeOperandBundle(CallBase *CB, uint32_t ID,
-                                       BasicBlock::iterator InsertPt);
 
   static bool classof(const Instruction *I) {
     return I->getOpcode() == Instruction::Call ||

--- a/llvm/lib/FuzzMutate/IRMutator.cpp
+++ b/llvm/lib/FuzzMutate/IRMutator.cpp
@@ -389,7 +389,7 @@ void InsertFunctionStrategy::mutate(BasicBlock &BB, RandomIRBuilder &IB) {
   auto BuilderFunc = [FTy, F, isRetVoid](ArrayRef<Value *> Srcs,
                                          Instruction *Inst) {
     StringRef Name = isRetVoid ? nullptr : "C";
-    CallInst *Call = CallInst::Create(FTy, F, Srcs, Name, Inst);
+    CallInst *Call = CallInst::Create(FTy, F, Srcs, Name, Inst->getIterator());
     // Don't return this call inst if it return void as it can't be sinked.
     return isRetVoid ? nullptr : Call;
   };
@@ -542,7 +542,8 @@ void InsertPHIStrategy::mutate(BasicBlock &BB, RandomIRBuilder &IB) {
   if (&BB == &BB.getParent()->getEntryBlock())
     return;
   Type *Ty = IB.randomType();
-  PHINode *PHI = PHINode::Create(Ty, llvm::pred_size(&BB), "", &BB.front());
+  PHINode *PHI =
+      PHINode::Create(Ty, llvm::pred_size(&BB), "", BB.getFirstInsertionPt());
 
   // Use a map to make sure the same incoming basic block has the same value.
   DenseMap<BasicBlock *, Value *> IncomingValues;

--- a/llvm/lib/FuzzMutate/IRMutator.cpp
+++ b/llvm/lib/FuzzMutate/IRMutator.cpp
@@ -542,8 +542,7 @@ void InsertPHIStrategy::mutate(BasicBlock &BB, RandomIRBuilder &IB) {
   if (&BB == &BB.getParent()->getEntryBlock())
     return;
   Type *Ty = IB.randomType();
-  PHINode *PHI =
-      PHINode::Create(Ty, llvm::pred_size(&BB), "", BB.getFirstInsertionPt());
+  PHINode *PHI = PHINode::Create(Ty, llvm::pred_size(&BB), "", BB.begin());
 
   // Use a map to make sure the same incoming basic block has the same value.
   DenseMap<BasicBlock *, Value *> IncomingValues;

--- a/llvm/lib/FuzzMutate/RandomIRBuilder.cpp
+++ b/llvm/lib/FuzzMutate/RandomIRBuilder.cpp
@@ -69,9 +69,9 @@ AllocaInst *RandomIRBuilder::createStackMemory(Function *F, Type *Ty,
   BasicBlock *EntryBB = &F->getEntryBlock();
   DataLayout DL(F->getParent());
   AllocaInst *Alloca = new AllocaInst(Ty, DL.getAllocaAddrSpace(), "A",
-                                      &*EntryBB->getFirstInsertionPt());
+                                      EntryBB->getFirstInsertionPt());
   if (Init)
-    new StoreInst(Init, Alloca, Alloca->getNextNode());
+    new StoreInst(Init, Alloca, Alloca->getNextNode()->getIterator());
   return Alloca;
 }
 
@@ -165,7 +165,7 @@ Value *RandomIRBuilder::findOrCreateSource(BasicBlock &BB,
       Type *Ty = GV->getValueType();
       LoadInst *LoadGV = nullptr;
       if (BB.getTerminator()) {
-        LoadGV = new LoadInst(Ty, GV, "LGV", &*BB.getFirstInsertionPt());
+        LoadGV = new LoadInst(Ty, GV, "LGV", BB.getFirstInsertionPt());
       } else {
         LoadGV = new LoadInst(Ty, GV, "LGV", &BB);
       }
@@ -213,7 +213,7 @@ Value *RandomIRBuilder::newSource(BasicBlock &BB, ArrayRef<Instruction *> Insts,
     }
     // Pick the type independently.
     Type *AccessTy = RS.getSelection()->getType();
-    auto *NewLoad = new LoadInst(AccessTy, Ptr, "L", &*IP);
+    auto *NewLoad = new LoadInst(AccessTy, Ptr, "L", IP);
 
     // Only sample this load if it really matches the descriptor
     if (Pred.matches(Srcs, NewLoad))
@@ -231,7 +231,8 @@ Value *RandomIRBuilder::newSource(BasicBlock &BB, ArrayRef<Instruction *> Insts,
     Function *F = BB.getParent();
     AllocaInst *Alloca = createStackMemory(F, Ty, newSrc);
     if (BB.getTerminator()) {
-      newSrc = new LoadInst(Ty, Alloca, /*ArrLen,*/ "L", BB.getTerminator());
+      newSrc = new LoadInst(Ty, Alloca, /*ArrLen,*/ "L",
+                            BB.getTerminator()->getIterator());
     } else {
       newSrc = new LoadInst(Ty, Alloca, /*ArrLen,*/ "L", &BB);
     }
@@ -325,7 +326,7 @@ Instruction *RandomIRBuilder::connectToSink(BasicBlock &BB,
       for (BasicBlock *Dom : Dominators) {
         for (Instruction &I : *Dom) {
           if (isa<PointerType>(I.getType()))
-            return new StoreInst(V, &I, Insts.back());
+            return new StoreInst(V, &I, Insts.back()->getIterator());
         }
       }
       break;
@@ -351,7 +352,7 @@ Instruction *RandomIRBuilder::connectToSink(BasicBlock &BB,
       Module *M = BB.getParent()->getParent();
       auto [GV, DidCreate] =
           findOrCreateGlobalVariable(M, {}, fuzzerop::onlyType(V->getType()));
-      return new StoreInst(V, GV, Insts.back());
+      return new StoreInst(V, GV, Insts.back()->getIterator());
     }
     case EndOfValueSink:
     default:
@@ -373,7 +374,7 @@ Instruction *RandomIRBuilder::newSink(BasicBlock &BB,
     }
   }
 
-  return new StoreInst(V, Ptr, Insts.back());
+  return new StoreInst(V, Ptr, Insts.back()->getIterator());
 }
 
 Value *RandomIRBuilder::findPointer(BasicBlock &BB,

--- a/llvm/lib/Transforms/Instrumentation/AddressSanitizer.cpp
+++ b/llvm/lib/Transforms/Instrumentation/AddressSanitizer.cpp
@@ -690,8 +690,8 @@ public:
       if (EHPad && EHPad->isEHPad()) {
         // Replace CI with a clone with an added funclet OperandBundle
         OperandBundleDef OB("funclet", EHPad);
-        auto *NewCall =
-            CallBase::addOperandBundle(CI, LLVMContext::OB_funclet, OB, CI);
+        auto *NewCall = CallBase::addOperandBundle(CI, LLVMContext::OB_funclet,
+                                                   OB, CI->getIterator());
         NewCall->copyMetadata(*CI);
         CI->replaceAllUsesWith(NewCall);
         CI->eraseFromParent();

--- a/llvm/tools/llvm-reduce/deltas/ReduceOperandBundles.cpp
+++ b/llvm/tools/llvm-reduce/deltas/ReduceOperandBundles.cpp
@@ -88,7 +88,8 @@ static void maybeRewriteCallWithDifferentBundles(
             });
 
   // Finally actually replace the bundles on the call.
-  CallBase *NewCall = CallBase::Create(OrigCall, NewBundles, OrigCall);
+  CallBase *NewCall =
+      CallBase::Create(OrigCall, NewBundles, OrigCall->getIterator());
   OrigCall->replaceAllUsesWith(NewCall);
   OrigCall->eraseFromParent();
 }

--- a/llvm/tools/llvm-stress/llvm-stress.cpp
+++ b/llvm/tools/llvm-stress/llvm-stress.cpp
@@ -342,7 +342,7 @@ struct LoadModifier: public Modifier {
     // Try to use predefined pointers. If non-exist, use undef pointer value;
     Value *Ptr = getRandomPointerValue();
     Type *Ty = pickType();
-    Value *V = new LoadInst(Ty, Ptr, "L", BB->getTerminator());
+    Value *V = new LoadInst(Ty, Ptr, "L", BB->getTerminator()->getIterator());
     PT->push_back(V);
   }
 };
@@ -362,7 +362,7 @@ struct StoreModifier: public Modifier {
       return;
 
     Value *Val = getRandomValue(ValTy);
-    new StoreInst(Val, Ptr, BB->getTerminator());
+    new StoreInst(Val, Ptr, BB->getTerminator()->getIterator());
   }
 };
 
@@ -405,7 +405,8 @@ struct BinModifier: public Modifier {
     case 12:{Op = Instruction::Xor;  break; }
     }
 
-    PT->push_back(BinaryOperator::Create(Op, Val0, Val1, "B", Term));
+    PT->push_back(
+        BinaryOperator::Create(Op, Val0, Val1, "B", Term->getIterator()));
   }
 };
 
@@ -468,8 +469,8 @@ struct AllocaModifier: public Modifier {
   void Act() override {
     Type *Tp = pickType();
     const DataLayout &DL = BB->getModule()->getDataLayout();
-    PT->push_back(new AllocaInst(Tp, DL.getAllocaAddrSpace(),
-                                 "A", BB->getFirstNonPHI()));
+    PT->push_back(new AllocaInst(Tp, DL.getAllocaAddrSpace(), "A",
+                                 BB->getFirstNonPHIIt()));
   }
 };
 
@@ -480,9 +481,8 @@ struct ExtractElementModifier: public Modifier {
   void Act() override {
     Value *Val0 = getRandomVectorValue();
     Value *V = ExtractElementInst::Create(
-        Val0,
-        getRandomValue(Type::getInt32Ty(BB->getContext())),
-        "E", BB->getTerminator());
+        Val0, getRandomValue(Type::getInt32Ty(BB->getContext())), "E",
+        BB->getTerminator()->getIterator());
     return PT->push_back(V);
   }
 };
@@ -514,7 +514,7 @@ struct ShuffModifier: public Modifier {
     Constant *Mask = ConstantVector::get(Idxs);
 
     Value *V = new ShuffleVectorInst(Val0, Val1, Mask, "Shuff",
-                                     BB->getTerminator());
+                                     BB->getTerminator()->getIterator());
     PT->push_back(V);
   }
 };
@@ -528,9 +528,8 @@ struct InsertElementModifier: public Modifier {
     Value *Val1 = getRandomValue(Val0->getType()->getScalarType());
 
     Value *V = InsertElementInst::Create(
-        Val0, Val1,
-        getRandomValue(Type::getInt32Ty(BB->getContext())),
-        "I", BB->getTerminator());
+        Val0, Val1, getRandomValue(Type::getInt32Ty(BB->getContext())), "I",
+        BB->getTerminator()->getIterator());
     return PT->push_back(V);
   }
 };
@@ -556,7 +555,7 @@ struct CastModifier: public Modifier {
       if (!DestTy->isPointerTy())
         DestTy = PointerType::get(DestTy, 0);
       return PT->push_back(
-        new BitCastInst(V, DestTy, "PC", BB->getTerminator()));
+          new BitCastInst(V, DestTy, "PC", BB->getTerminator()->getIterator()));
     }
 
     unsigned VSize = VTy->getScalarType()->getPrimitiveSizeInBits();
@@ -565,47 +564,50 @@ struct CastModifier: public Modifier {
     // Generate lots of bitcasts.
     if ((getRandom() & 1) && VSize == DestSize) {
       return PT->push_back(
-        new BitCastInst(V, DestTy, "BC", BB->getTerminator()));
+          new BitCastInst(V, DestTy, "BC", BB->getTerminator()->getIterator()));
     }
 
     // Both types are integers:
     if (VTy->isIntOrIntVectorTy() && DestTy->isIntOrIntVectorTy()) {
       if (VSize > DestSize) {
         return PT->push_back(
-          new TruncInst(V, DestTy, "Tr", BB->getTerminator()));
+            new TruncInst(V, DestTy, "Tr", BB->getTerminator()->getIterator()));
       } else {
         assert(VSize < DestSize && "Different int types with the same size?");
         if (getRandom() & 1)
-          return PT->push_back(
-            new ZExtInst(V, DestTy, "ZE", BB->getTerminator()));
-        return PT->push_back(new SExtInst(V, DestTy, "Se", BB->getTerminator()));
+          return PT->push_back(new ZExtInst(
+              V, DestTy, "ZE", BB->getTerminator()->getIterator()));
+        return PT->push_back(
+            new SExtInst(V, DestTy, "Se", BB->getTerminator()->getIterator()));
       }
     }
 
     // Fp to int.
     if (VTy->isFPOrFPVectorTy() && DestTy->isIntOrIntVectorTy()) {
       if (getRandom() & 1)
-        return PT->push_back(
-          new FPToSIInst(V, DestTy, "FC", BB->getTerminator()));
-      return PT->push_back(new FPToUIInst(V, DestTy, "FC", BB->getTerminator()));
+        return PT->push_back(new FPToSIInst(
+            V, DestTy, "FC", BB->getTerminator()->getIterator()));
+      return PT->push_back(
+          new FPToUIInst(V, DestTy, "FC", BB->getTerminator()->getIterator()));
     }
 
     // Int to fp.
     if (VTy->isIntOrIntVectorTy() && DestTy->isFPOrFPVectorTy()) {
       if (getRandom() & 1)
-        return PT->push_back(
-          new SIToFPInst(V, DestTy, "FC", BB->getTerminator()));
-      return PT->push_back(new UIToFPInst(V, DestTy, "FC", BB->getTerminator()));
+        return PT->push_back(new SIToFPInst(
+            V, DestTy, "FC", BB->getTerminator()->getIterator()));
+      return PT->push_back(
+          new UIToFPInst(V, DestTy, "FC", BB->getTerminator()->getIterator()));
     }
 
     // Both floats.
     if (VTy->isFPOrFPVectorTy() && DestTy->isFPOrFPVectorTy()) {
       if (VSize > DestSize) {
-        return PT->push_back(
-          new FPTruncInst(V, DestTy, "Tr", BB->getTerminator()));
+        return PT->push_back(new FPTruncInst(
+            V, DestTy, "Tr", BB->getTerminator()->getIterator()));
       } else if (VSize < DestSize) {
         return PT->push_back(
-          new FPExtInst(V, DestTy, "ZE", BB->getTerminator()));
+            new FPExtInst(V, DestTy, "ZE", BB->getTerminator()->getIterator()));
       }
       // If VSize == DestSize, then the two types must be fp128 and ppc_fp128,
       // for which there is no defined conversion. So do nothing.
@@ -631,7 +633,8 @@ struct SelectModifier: public Modifier {
         CondTy = VectorType::get(CondTy, VTy->getElementCount());
 
     Value *Cond = getRandomValue(CondTy);
-    Value *V = SelectInst::Create(Cond, Val0, Val1, "Sl", BB->getTerminator());
+    Value *V = SelectInst::Create(Cond, Val0, Val1, "Sl",
+                                  BB->getTerminator()->getIterator());
     return PT->push_back(V);
   }
 };
@@ -660,7 +663,7 @@ struct CmpModifier: public Modifier {
 
     Value *V = CmpInst::Create(fp ? Instruction::FCmp : Instruction::ICmp,
                                (CmpInst::Predicate)op, Val0, Val1, "Cmp",
-                               BB->getTerminator());
+                               BB->getTerminator()->getIterator());
     return PT->push_back(V);
   }
 };
@@ -718,7 +721,8 @@ static void IntroduceControlFlow(Function *F, Random &R) {
     BasicBlock *Next = Curr->splitBasicBlock(Loc, "CF");
     Instr->moveBefore(Curr->getTerminator());
     if (Curr != &F->getEntryBlock()) {
-      BranchInst::Create(Curr, Next, Instr, Curr->getTerminator());
+      BranchInst::Create(Curr, Next, Instr,
+                         Curr->getTerminator()->getIterator());
       Curr->getTerminator()->eraseFromParent();
     }
   }


### PR DESCRIPTION
Related to the work noted in [discourse](https://discourse.llvm.org/t/psa-instruction-constructors-changing-to-iterator-only-insertion/77845) and in [this](https://github.com/llvm/llvm-project/pull/85980) patch.

This removes the remaining set of callsites where instructions are created using constructors that take a `Instruction *InsertBefore` argument, in preparation for those constructors being removed. For an explanation on why we want to do this, see the discussions above; the short summary is that it is useful for ensuring that debug info placement is handled correctly, preventing potential errors from emerging following the RemoveDIs work. In almost all cases this should be NFC, except for a few cases where `getFirstNonPHI()` is replaced by `getFirstNonPHIIt()`, which may prevent a possible error from occurring. 