### PR TITLE
[bazel] Add support for --incompatible_disallow_empty_glob

### DIFF
--- a/utils/bazel/.bazelrc
+++ b/utils/bazel/.bazelrc
@@ -35,6 +35,10 @@ build --features=layering_check
 # See: https://bazel.build/reference/be/functions#exports_files
 build --incompatible_no_implicit_file_export
 
+# Enable so downstream users can flip this flag globally, this should
+# eventually become the default
+common --incompatible_disallow_empty_glob
+
 ###############################################################################
 # Options to select different strategies for linking potential dependent
 # libraries. The default leaves it disabled.

--- a/utils/bazel/llvm-project-overlay/bolt/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/bolt/BUILD.bazel
@@ -221,8 +221,6 @@ cc_library(
     srcs = glob([
         "lib/Target/AArch64/*.cpp",
     ]),
-    hdrs = glob([
-    ]),
     includes = ["include"],
     deps = [
         ":Core",

--- a/utils/bazel/llvm-project-overlay/clang-tools-extra/clang-tidy/defs.bzl
+++ b/utils/bazel/llvm-project-overlay/clang-tools-extra/clang-tidy/defs.bzl
@@ -16,8 +16,8 @@ _common_library_deps = [
 ]
 
 def clang_tidy_library(name, **kwargs):
-    kwargs["srcs"] = kwargs.get("srcs", native.glob([paths.join(name, "*.cpp")]))
-    kwargs["hdrs"] = kwargs.get("hdrs", native.glob([paths.join(name, "*.h")]))
+    kwargs["srcs"] = kwargs.get("srcs", native.glob([paths.join(name, "*.cpp")], allow_empty = True))
+    kwargs["hdrs"] = kwargs.get("hdrs", native.glob([paths.join(name, "*.h")], allow_empty=True))
     kwargs["deps"] = kwargs.get("deps", []) + _common_library_deps
     cc_library(
         name = name,

--- a/utils/bazel/llvm-project-overlay/clang/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/clang/BUILD.bazel
@@ -614,7 +614,6 @@ cc_library(
         "include/clang/Basic/Version.inc",
     ] + glob([
         "lib/Basic/*.cpp",
-        "lib/Basic/*.c",
         "lib/Basic/*.h",
         "lib/Basic/Targets/*.cpp",
         "lib/Basic/Targets/*.h",
@@ -1042,7 +1041,6 @@ cc_library(
         "lib/Analysis/FlowSensitive/Models/*.cpp",
         "lib/Analysis/FlowSensitive/*.cpp",
         "lib/Analysis/*.cpp",
-        "lib/Analysis/*.h",
     ]) + [
         ":analysis_htmllogger_gen",
     ],
@@ -1180,10 +1178,8 @@ gentbl(
 
 cc_library(
     name = "parse",
-    srcs = [
-    ] + glob([
+    srcs = glob([
         "lib/Parse/*.cpp",
-        "lib/Parse/*.h",
     ]),
     hdrs = [
         "include/clang/Parse/AttrParserStringSwitches.inc",
@@ -1207,7 +1203,6 @@ cc_library(
     name = "ast_matchers",
     srcs = glob([
         "lib/ASTMatchers/*.cpp",
-        "lib/ASTMatchers/*.h",
     ]),
     hdrs = glob(["include/clang/ASTMatchers/*.h"]),
     includes = ["include"],
@@ -1241,7 +1236,6 @@ cc_library(
     name = "rewrite",
     srcs = glob([
         "lib/Rewrite/*.cpp",
-        "lib/Rewrite/*.h",
     ]),
     hdrs = glob(["include/clang/Rewrite/Core/*.h"]),
     includes = ["include"],
@@ -1275,7 +1269,6 @@ cc_library(
     name = "tooling_core",
     srcs = glob([
         "lib/Tooling/Core/*.cpp",
-        "lib/Tooling/Core/*.h",
     ]),
     hdrs = glob(["include/clang/Tooling/Core/*.h"]),
     includes = ["include"],
@@ -1340,11 +1333,9 @@ cc_library(
     name = "tooling_refactoring",
     srcs = glob([
         "lib/Tooling/Refactoring/**/*.cpp",
-        "lib/Tooling/Refactoring/**/*.h",
     ]),
     hdrs = glob([
         "include/clang/Tooling/Refactoring/**/*.h",
-        "include/clang/Tooling/Refactoring/**/*.def",
     ]),
     deps = [
         ":ast",
@@ -1593,9 +1584,6 @@ cc_library(
     srcs = glob(
         [
             "lib/Driver/*.cpp",
-            "lib/Driver/*.h",
-            "lib/Driver/Arch/*.cpp",
-            "lib/Driver/Arch/*.h",
             "lib/Driver/ToolChains/*.cpp",
             "lib/Driver/ToolChains/*.h",
             "lib/Driver/ToolChains/Arch/*.cpp",
@@ -1833,9 +1821,6 @@ cc_library(
     copts = ["$(STACK_FRAME_UNLIMITED)"],
     data = [":builtin_headers_gen"],
     includes = ["include"],
-    textual_hdrs = glob([
-        "include/clang/Frontend/*.def",
-    ]),
     deps = [
         ":apinotes",
         ":ast",
@@ -1872,7 +1857,6 @@ cc_library(
     name = "frontend_rewrite",
     srcs = glob([
         "lib/Frontend/Rewrite/*.cpp",
-        "lib/Frontend/Rewrite/*.h",
     ]),
     hdrs = glob(["include/clang/Rewrite/Frontend/*.h"]),
     includes = ["include"],
@@ -2116,7 +2100,6 @@ cc_library(
     name = "frontend_tool",
     srcs = glob([
         "lib/FrontendTool/*.cpp",
-        "lib/FrontendTool/*.h",
     ]),
     hdrs = glob(["include/clang/FrontendTool/*.h"]),
     includes = ["include"],
@@ -2320,7 +2303,6 @@ cc_binary(
     testonly = 1,
     srcs = glob([
         "tools/clang-import-test/*.cpp",
-        "tools/clang-import-test/*.h",
     ]),
     stamp = 0,
     deps = [
@@ -2350,7 +2332,6 @@ cc_library(
     name = "clang-driver",
     srcs = glob([
         "tools/driver/*.cpp",
-        "tools/driver/*.h",
     ]) + ["clang-driver.cpp"],
     copts = [
         # Disable stack frame size checks in the driver because
@@ -2668,7 +2649,6 @@ cc_library(
     name = "extract_api",
     srcs = glob([
         "lib/ExtractAPI/**/*.cpp",
-        "lib/ExtractAPI/**/*.h",
     ]),
     hdrs = glob(["include/clang/ExtractAPI/**/*.h"]),
     includes = ["include"],

--- a/utils/bazel/llvm-project-overlay/lld/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/lld/BUILD.bazel
@@ -187,7 +187,6 @@ cc_library(
     name = "MinGW",
     srcs = glob([
         "MinGW/*.cpp",
-        "MinGW/*.h",
     ]),
     includes = ["MinGW"],
     deps = [
@@ -296,7 +295,6 @@ cc_binary(
     name = "lld",
     srcs = glob([
         "tools/lld/*.cpp",
-        "tools/lld/*.h",
     ]) + ["lld-driver.cpp"],
     deps = [
         ":COFF",

--- a/utils/bazel/llvm-project-overlay/llvm/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/llvm/BUILD.bazel
@@ -66,7 +66,10 @@ enum_targets_gen(
 llvm_target_asm_parsers = [
     t
     for t in llvm_targets
-    if glob(["lib/Target/{}/AsmParser/CMakeLists.txt".format(t)])
+    if glob(
+        ["lib/Target/{}/AsmParser/CMakeLists.txt".format(t)],
+        allow_empty = True,
+    )
 ]
 
 enum_targets_gen(
@@ -81,7 +84,10 @@ enum_targets_gen(
 llvm_target_disassemblers = [
     t
     for t in llvm_targets
-    if glob(["lib/Target/{}/Disassembler/CMakeLists.txt".format(t)])
+    if glob(
+        ["lib/Target/{}/Disassembler/CMakeLists.txt".format(t)],
+        allow_empty = True,
+    )
 ]
 
 enum_targets_gen(
@@ -96,7 +102,10 @@ enum_targets_gen(
 llvm_target_mcas = [
     t
     for t in llvm_targets
-    if glob(["lib/Target/{}/MCA/CMakeLists.txt".format(t)])
+    if glob(
+        ["lib/Target/{}/MCA/CMakeLists.txt".format(t)],
+        allow_empty = True,
+    )
 ]
 
 enum_targets_gen(
@@ -111,7 +120,10 @@ enum_targets_gen(
 llvm_target_exegesis = [
     t
     for t in llvm_targets
-    if glob(["tools/llvm-exegesis/lib/{}/CMakeLists.txt".format(t)])
+    if glob(
+        ["tools/llvm-exegesis/lib/{}/CMakeLists.txt".format(t)],
+        allow_empty = True,
+    )
 ]
 
 enum_targets_gen(
@@ -168,7 +180,6 @@ cc_library(
     name = "Demangle",
     srcs = glob([
         "lib/Demangle/*.cpp",
-        "lib/Demangle/*.h",
     ]),
     hdrs = glob([
         "include/llvm/Demangle/*.h",
@@ -203,7 +214,6 @@ cc_library(
         "include/llvm/Option/*.h",
     ]) + select({
         "@platforms//os:windows": glob([
-            "lib/Support/Windows/*.h",
             "lib/Support/Windows/*.inc",
         ]),
         "//conditions:default": glob([
@@ -315,7 +325,6 @@ cc_library(
     name = "LineEditor",
     srcs = glob([
         "lib/LineEditor/*.cpp",
-        "lib/LineEditor/*.h",
     ]),
     hdrs = glob(["include/llvm/LineEditor/*.h"]),
     copts = llvm_copts,
@@ -329,7 +338,6 @@ cc_library(
     name = "Option",
     srcs = glob([
         "lib/Option/*.cpp",
-        "lib/Option/*.h",
     ]),
     hdrs = glob(["include/llvm/Option/*.h"]),
     copts = llvm_copts,
@@ -376,8 +384,6 @@ cc_library(
     name = "BinaryFormat",
     srcs = glob([
         "lib/BinaryFormat/*.cpp",
-        "lib/BinaryFormat/*.def",
-        "lib/BinaryFormat/*.h",
     ]),
     hdrs = glob([
         "include/llvm/BinaryFormat/*.h",
@@ -409,7 +415,6 @@ cc_library(
     name = "DebugInfoMSF",
     srcs = glob([
         "lib/DebugInfo/MSF/*.cpp",
-        "lib/DebugInfo/MSF/*.h",
     ]),
     hdrs = glob(["include/llvm/DebugInfo/MSF/*.h"]),
     copts = llvm_copts,
@@ -420,7 +425,6 @@ cc_library(
     name = "DebugInfoBTF",
     srcs = glob([
         "lib/DebugInfo/BTF/*.cpp",
-        "lib/DebugInfo/BTF/*.h",
     ]),
     hdrs = glob(["include/llvm/DebugInfo/BTF/*.h"]) + [
         "include/llvm/DebugInfo/BTF/BTF.def",
@@ -437,7 +441,6 @@ cc_library(
     name = "DebugInfoCodeView",
     srcs = glob([
         "lib/DebugInfo/CodeView/*.cpp",
-        "lib/DebugInfo/CodeView/*.h",
     ]),
     hdrs = glob([
         "include/llvm/DebugInfo/CodeView/*.h",
@@ -480,9 +483,7 @@ cc_library(
     name = "DebugInfoPDB",
     srcs = glob([
         "lib/DebugInfo/PDB/*.cpp",
-        "lib/DebugInfo/PDB/*.h",
         "lib/DebugInfo/PDB/Native/*.cpp",
-        "lib/DebugInfo/PDB/Native/*.h",
     ]),
     hdrs = glob([
         "include/llvm/DebugInfo/PDB/*.h",
@@ -523,12 +524,9 @@ cc_library(
     name = "MC",
     srcs = glob([
         "lib/MC/*.cpp",
-        "lib/MC/*.h",
     ]),
     hdrs = glob([
         "include/llvm/MC/*.h",
-        "include/llvm/MC/*.def",
-        "include/llvm/MC/*.inc",
     ]),
     copts = llvm_copts,
     deps = [
@@ -545,7 +543,6 @@ cc_library(
     name = "DebugInfoDWARF",
     srcs = glob([
         "lib/DebugInfo/DWARF/*.cpp",
-        "lib/DebugInfo/DWARF/*.h",
     ]),
     hdrs = glob(["include/llvm/DebugInfo/DWARF/*.h"]),
     copts = llvm_copts,
@@ -563,7 +560,6 @@ cc_library(
     name = "DebugInfoGSYM",
     srcs = glob([
         "lib/DebugInfo/GSYM/*.cpp",
-        "lib/DebugInfo/GSYM/*.h",
     ]),
     hdrs = glob(["include/llvm/DebugInfo/GSYM/*.h"]),
     copts = llvm_copts,
@@ -580,7 +576,6 @@ cc_library(
     name = "Symbolize",
     srcs = glob([
         "lib/DebugInfo/Symbolize/*.cpp",
-        "lib/DebugInfo/Symbolize/*.h",
     ]),
     hdrs = glob([
         "include/llvm/DebugInfo/Symbolize/*.h",
@@ -658,7 +653,6 @@ cc_binary(
     srcs = glob(
         [
             "utils/TableGen/*.cpp",
-            "utils/TableGen/*.inc",
             "utils/TableGen/*.h",
             "utils/TableGen/GlobalISel/*.cpp",
             "utils/TableGen/GlobalISel/*.h",
@@ -821,7 +815,6 @@ cc_library(
     name = "BitstreamReader",
     srcs = glob([
         "lib/Bitstream/Reader/*.cpp",
-        "lib/Bitstream/Reader/*.h",
     ]),
     hdrs = [
         "include/llvm/Bitstream/BitCodeEnums.h",
@@ -836,9 +829,6 @@ cc_library(
 
 cc_library(
     name = "BitstreamWriter",
-    srcs = glob([
-        "lib/Bitstream/Writer/*.h",
-    ]),
     hdrs = [
         "include/llvm/Bitstream/BitCodeEnums.h",
         "include/llvm/Bitstream/BitCodes.h",
@@ -956,7 +946,6 @@ cc_library(
     name = "MCParser",
     srcs = glob([
         "lib/MC/MCParser/*.cpp",
-        "lib/MC/MCParser/*.h",
     ]),
     hdrs = glob(["include/llvm/MC/MCParser/*.h"]),
     copts = llvm_copts,
@@ -1002,9 +991,7 @@ cc_library(
     srcs = glob([
         "lib/TextAPI/BinaryReader/**/*.cpp",
     ]),
-    hdrs = ["include/llvm/TextAPI/DylibReader.h"] + glob(
-        ["lib/TextAPI/BinaryReader/**/*.h"],
-    ),
+    hdrs = ["include/llvm/TextAPI/DylibReader.h"],
     copts = llvm_copts,
     deps = [
         ":Object",
@@ -1067,7 +1054,6 @@ cc_library(
     name = "ObjectYAML",
     srcs = glob([
         "lib/ObjectYAML/*.cpp",
-        "lib/ObjectYAML/*.h",
     ]),
     hdrs = glob(["include/llvm/ObjectYAML/*.h"]),
     copts = llvm_copts,
@@ -1085,7 +1071,6 @@ cc_library(
     name = "ProfileData",
     srcs = glob([
         "lib/ProfileData/*.cpp",
-        "lib/ProfileData/*.h",
     ]),
     hdrs = glob([
         "include/llvm/ProfileData/*.h",
@@ -1109,7 +1094,6 @@ cc_library(
     name = "Coverage",
     srcs = glob([
         "lib/ProfileData/Coverage/*.cpp",
-        "lib/ProfileData/Coverage/*.h",
     ]),
     hdrs = glob(["include/llvm/ProfileData/Coverage/*.h"]),
     copts = llvm_copts,
@@ -1126,8 +1110,6 @@ cc_library(
     srcs = glob(
         [
             "lib/Analysis/*.cpp",
-            "lib/Analysis/*.h",
-            "lib/Analysis/*.def",
         ],
     ),
     hdrs = glob(
@@ -1185,7 +1167,6 @@ cc_library(
     name = "Target",
     srcs = glob([
         "lib/Target/*.cpp",
-        "lib/Target/*.h",
     ]),
     hdrs = glob([
         "include/llvm/Target/*.h",
@@ -1221,14 +1202,11 @@ cc_library(
     name = "TargetParser",
     srcs = glob([
         "lib/TargetParser/*.cpp",
-        "lib/TargetParser/*.h",
     ]) + select({
         "@platforms//os:windows": glob([
-            "lib/TargetParser/Windows/*.h",
             "lib/TargetParser/Windows/*.inc",
         ]),
         "//conditions:default": glob([
-            "lib/TargetParser/Unix/*.h",
             "lib/TargetParser/Unix/*.inc",
         ]),
     }),
@@ -1252,7 +1230,6 @@ cc_library(
     name = "DWP",
     srcs = glob([
         "lib/DWP/*.cpp",
-        "lib/DWP/*.h",
     ]),
     hdrs = glob(["include/llvm/DWP/*.h"]),
     copts = llvm_copts,
@@ -1269,7 +1246,6 @@ cc_library(
     name = "TransformUtils",
     srcs = glob([
         "lib/Transforms/Utils/*.cpp",
-        "lib/Transforms/Utils/*.h",
     ]),
     hdrs = glob(["include/llvm/Transforms/Utils/*.h"]) + [
         "include/llvm/Transforms/Utils.h",
@@ -1390,7 +1366,6 @@ cc_library(
     name = "Scalar",
     srcs = glob([
         "lib/Transforms/Scalar/*.cpp",
-        "lib/Transforms/Scalar/*.h",
     ]),
     hdrs = glob(["include/llvm/Transforms/Scalar/*.h"]) + [
         "include/llvm/Transforms/Scalar.h",
@@ -1432,9 +1407,6 @@ cc_library(
 
 cc_library(
     name = "FrontendDebug",
-    srcs = glob([
-        "lib/Frontend/Debug/*.cpp",
-    ]),
     hdrs = glob([
         "include/llvm/Frontend/Debug/*.h",
     ]),
@@ -1530,8 +1502,6 @@ cc_library(
     ]),
     hdrs = glob([
         "include/llvm/Frontend/OpenMP/*.h",
-        "include/llvm/Frontend/OpenMP/OMP/*.h",
-        "include/llvm/Frontend/*.h",
     ]) + [
         "include/llvm/Frontend/OpenMP/OMP.h.inc",
         "include/llvm/Frontend/OpenMP/OMP.inc",
@@ -1591,9 +1561,7 @@ cc_library(
     ]) + [
         "include/llvm/Frontend/OpenACC/ACC.inc",
     ],
-    hdrs = glob([
-        "include/llvm/Frontend/OpenACC/*.h",
-    ]) + ["include/llvm/Frontend/OpenACC/ACC.h.inc"],
+    hdrs = ["include/llvm/Frontend/OpenACC/ACC.h.inc"],
     copts = llvm_copts,
     deps = [
         ":Analysis",
@@ -1607,7 +1575,6 @@ cc_library(
     name = "AsmParser",
     srcs = glob([
         "lib/AsmParser/*.cpp",
-        "lib/AsmParser/*.h",
     ]),
     hdrs = glob(["include/llvm/AsmParser/*.h"]),
     copts = llvm_copts,
@@ -1623,7 +1590,6 @@ cc_library(
     name = "IRPrinter",
     srcs = glob([
         "lib/IRPrinter/*.cpp",
-        "lib/IRPrinter/*.h",
     ]),
     hdrs = glob([
         "include/llvm/IRPrinter/*.h",
@@ -1640,7 +1606,6 @@ cc_library(
     name = "IRReader",
     srcs = glob([
         "lib/IRReader/*.cpp",
-        "lib/IRReader/*.h",
     ]),
     hdrs = glob([
         "include/llvm/IRReader/*.h",
@@ -1683,7 +1648,6 @@ cc_library(
     name = "IPO",
     srcs = glob([
         "lib/Transforms/IPO/*.cpp",
-        "lib/Transforms/IPO/*.h",
     ]),
     hdrs = glob([
         "include/llvm/Transforms/IPO/*.h",
@@ -1721,7 +1685,6 @@ cc_library(
     name = "CFGuard",
     srcs = glob([
         "lib/Transforms/CFGuard/*.cpp",
-        "lib/Transforms/CFGuard/*.h",
     ]),
     hdrs = ["include/llvm/Transforms/CFGuard.h"],
     copts = llvm_copts,
@@ -1736,7 +1699,6 @@ cc_library(
     name = "HipStdPar",
     srcs = glob([
         "lib/Transforms/HipStdPar/*.cpp",
-        "lib/Transforms/HipStdPar/*.h",
     ]),
     hdrs = ["include/llvm/Transforms/HipStdPar/HipStdPar.h"],
     copts = llvm_copts,
@@ -1826,7 +1788,6 @@ cc_library(
     copts = llvm_copts,
     textual_hdrs = glob([
         "include/llvm/CodeGen/**/*.def",
-        "include/llvm/CodeGen/**/*.inc",
     ]),
     deps = [
         ":AggressiveInstCombine",
@@ -2305,10 +2266,13 @@ gentbl(
         td_file = "lib/Target/" + target["name"] + "/" + target["short_name"] + ".td",
         td_srcs = [
             ":common_target_td_sources",
-        ] + glob([
-            "lib/Target/" + target["name"] + "/*.td",
-            "lib/Target/" + target["name"] + "/GISel/*.td",
-        ]),
+        ] + glob(
+            [
+                "lib/Target/" + target["name"] + "/*.td",
+                "lib/Target/" + target["name"] + "/GISel/*.td",
+            ],
+            allow_empty = True,
+        ),
         deps = target.get("tbl_deps", []),
     )],
     [cc_library(
@@ -2332,43 +2296,49 @@ gentbl(
     # a number of targets due to crisscrossing inclusion of headers.
     [cc_library(
         name = target["name"] + "UtilsAndDesc",
-        srcs = glob([
-            "lib/Target/" + target["name"] + "/MCTargetDesc/*.cpp",
-            "lib/Target/" + target["name"] + "/Utils/*.cpp",
+        srcs = glob(
+            [
+                "lib/Target/" + target["name"] + "/MCTargetDesc/*.cpp",
+                "lib/Target/" + target["name"] + "/Utils/*.cpp",
 
-            # We have to include these headers here as well as in the `hdrs`
-            # below to allow the `.cpp` files to use file-relative-inclusion to
-            # find them, even though consumers of this library use inclusion
-            # relative to the target with the `strip_includes_prefix` of this
-            # library. This mixture is likely incompatible with header modules.
-            "lib/Target/" + target["name"] + "/MCTargetDesc/*.h",
-            "lib/Target/" + target["name"] + "/Utils/*.h",
-        ]),
-        hdrs = glob([
-            "lib/Target/" + target["name"] + "/MCTargetDesc/*.h",
-            "lib/Target/" + target["name"] + "/Utils/*.h",
+                # We have to include these headers here as well as in the `hdrs`
+                # below to allow the `.cpp` files to use file-relative-inclusion to
+                # find them, even though consumers of this library use inclusion
+                # relative to the target with the `strip_includes_prefix` of this
+                # library. This mixture is likely incompatible with header modules.
+                "lib/Target/" + target["name"] + "/MCTargetDesc/*.h",
+                "lib/Target/" + target["name"] + "/Utils/*.h",
+            ],
+            allow_empty = True,
+        ),
+        hdrs = glob(
+            [
+                "lib/Target/" + target["name"] + "/MCTargetDesc/*.h",
+                "lib/Target/" + target["name"] + "/Utils/*.h",
 
-            # This a bit of a hack to allow us to expose common, internal
-            # target header files to other libraries within the target via
-            # target-relative includes. This usage of headers is inherently
-            # non-modular as there is a mixture of target-relative inclusion
-            # using this rule and file-relative inclusion using the repeated
-            # listing of these headers in the `srcs` of subsequent rules.
-            "lib/Target/" + target["name"] + "/*.h",
+                # This a bit of a hack to allow us to expose common, internal
+                # target header files to other libraries within the target via
+                # target-relative includes. This usage of headers is inherently
+                # non-modular as there is a mixture of target-relative inclusion
+                # using this rule and file-relative inclusion using the repeated
+                # listing of these headers in the `srcs` of subsequent rules.
+                "lib/Target/" + target["name"] + "/*.h",
 
-            # FIXME: The entries below should be `textual_hdrs` instead of
-            # `hdrs`, but unfortunately that doesn't work with
-            # `strip_include_prefix`:
-            # https://github.com/bazelbuild/bazel/issues/12424
-            #
-            # Once that issue is fixed and released, we can switch this to
-            # `textual_hdrs` and remove the feature disabling the various Bazel
-            # features (both current and under-development) that motivated the
-            # distinction between these two.
-            "lib/Target/" + target["name"] + "/*.def",
-            "lib/Target/" + target["name"] + "/*.inc",
-            "lib/Target/" + target["name"] + "/MCTargetDesc/*.def",
-        ]),
+                # FIXME: The entries below should be `textual_hdrs` instead of
+                # `hdrs`, but unfortunately that doesn't work with
+                # `strip_include_prefix`:
+                # https://github.com/bazelbuild/bazel/issues/12424
+                #
+                # Once that issue is fixed and released, we can switch this to
+                # `textual_hdrs` and remove the feature disabling the various Bazel
+                # features (both current and under-development) that motivated the
+                # distinction between these two.
+                "lib/Target/" + target["name"] + "/*.def",
+                "lib/Target/" + target["name"] + "/*.inc",
+                "lib/Target/" + target["name"] + "/MCTargetDesc/*.def",
+            ],
+            allow_empty = True,
+        ),
         copts = llvm_copts,
         features = [
             "-parse_headers",
@@ -2392,20 +2362,26 @@ gentbl(
     )],
     [cc_library(
         name = target["name"] + "CodeGen",
-        srcs = glob([
-            "lib/Target/" + target["name"] + "/GISel/*.cpp",
-            "lib/Target/" + target["name"] + "/GISel/*.h",
-            "lib/Target/" + target["name"] + "/*.cpp",
-            "lib/Target/" + target["name"] + "/*.h",
-        ]),
+        srcs = glob(
+            [
+                "lib/Target/" + target["name"] + "/GISel/*.cpp",
+                "lib/Target/" + target["name"] + "/GISel/*.h",
+                "lib/Target/" + target["name"] + "/*.cpp",
+                "lib/Target/" + target["name"] + "/*.h",
+            ],
+            allow_empty = True,
+        ),
         hdrs = ["lib/Target/" + target["name"] + "/" + target["short_name"] + ".h"],
         copts = llvm_copts,
         features = ["-layering_check"],
         strip_include_prefix = "lib/Target/" + target["name"],
-        textual_hdrs = glob([
-            "lib/Target/" + target["name"] + "/*.def",
-            "lib/Target/" + target["name"] + "/*.inc",
-        ]),
+        textual_hdrs = glob(
+            [
+                "lib/Target/" + target["name"] + "/*.def",
+                "lib/Target/" + target["name"] + "/*.inc",
+            ],
+            allow_empty = True,
+        ),
         deps = [
             ":Analysis",
             ":BinaryFormat",
@@ -2430,10 +2406,13 @@ gentbl(
     )],
     [cc_library(
         name = target["name"] + "AsmParser",
-        srcs = glob([
-            "lib/Target/" + target["name"] + "/AsmParser/*.cpp",
-            "lib/Target/" + target["name"] + "/AsmParser/*.h",
-        ]),
+        srcs = glob(
+            [
+                "lib/Target/" + target["name"] + "/AsmParser/*.cpp",
+                "lib/Target/" + target["name"] + "/AsmParser/*.h",
+            ],
+            allow_empty = True,
+        ),
         copts = llvm_copts,
         deps = [
             ":BinaryFormat",
@@ -2464,9 +2443,12 @@ gentbl(
         # `textual_hdrs` and remove the feature disabling the various Bazel
         # features (both current and under-development) that motivated the
         # distinction between these two.
-        hdrs = glob([
-            "lib/Target/" + target["name"] + "/Disassembler/*.h",
-        ]),
+        hdrs = glob(
+            [
+                "lib/Target/" + target["name"] + "/Disassembler/*.h",
+            ],
+            allow_empty = True,
+        ),
         features = [
             "-parse_headers",
             "-header_modules",
@@ -2475,11 +2457,14 @@ gentbl(
     )],
     [cc_library(
         name = target["name"] + "Disassembler",
-        srcs = glob([
-            "lib/Target/" + target["name"] + "/Disassembler/*.cpp",
-            "lib/Target/" + target["name"] + "/Disassembler/*.c",
-            "lib/Target/" + target["name"] + "/Disassembler/*.h",
-        ]),
+        srcs = glob(
+            [
+                "lib/Target/" + target["name"] + "/Disassembler/*.cpp",
+                "lib/Target/" + target["name"] + "/Disassembler/*.c",
+                "lib/Target/" + target["name"] + "/Disassembler/*.h",
+            ],
+            allow_empty = True,
+        ),
         copts = llvm_copts,
         features = ["-layering_check"],
         deps = [
@@ -2497,11 +2482,14 @@ gentbl(
     )],
     [cc_library(
         name = target["name"] + "TargetMCA",
-        srcs = glob([
-            "lib/Target/" + target["name"] + "/MCA/*.cpp",
-            "lib/Target/" + target["name"] + "/MCA/*.c",
-            "lib/Target/" + target["name"] + "/MCA/*.h",
-        ]),
+        srcs = glob(
+            [
+                "lib/Target/" + target["name"] + "/MCA/*.cpp",
+                "lib/Target/" + target["name"] + "/MCA/*.c",
+                "lib/Target/" + target["name"] + "/MCA/*.h",
+            ],
+            allow_empty = True,
+        ),
         copts = llvm_copts,
         features = ["-layering_check"],
         deps = [
@@ -2560,27 +2548,9 @@ cc_library(
 )
 
 cc_library(
-    name = "MLPolicies",
-    srcs = glob([
-        "lib/Analysis/ML/*.cpp",
-        "lib/Analysis/ML/*.h",
-    ]),
-    hdrs = glob([
-        "include/llvm/Analysis/ML/*.h",
-    ]),
-    copts = llvm_copts,
-    deps = [
-        ":Analysis",
-        ":Core",
-        ":Support",
-    ],
-)
-
-cc_library(
     name = "Passes",
     srcs = glob([
         "lib/Passes/*.cpp",
-        "lib/Passes/*.h",
     ]),
     hdrs = glob([
         "include/llvm/Passes/*.h",
@@ -2601,7 +2571,6 @@ cc_library(
         ":InstCombine",
         ":Instrumentation",
         ":MC",
-        ":MLPolicies",
         ":ObjCARC",
         ":Scalar",
         ":Support",
@@ -2618,7 +2587,6 @@ cc_library(
     name = "LTO",
     srcs = glob([
         "lib/LTO/*.cpp",
-        "lib/LTO/*.h",
     ]),
     hdrs = glob([
         "include/llvm/LTO/*.h",
@@ -2658,7 +2626,6 @@ cc_library(
     name = "ExecutionEngine",
     srcs = glob([
         "lib/ExecutionEngine/*.cpp",
-        "lib/ExecutionEngine/*.h",
         "lib/ExecutionEngine/RuntimeDyld/*.cpp",
         "lib/ExecutionEngine/RuntimeDyld/*.h",
         "lib/ExecutionEngine/RuntimeDyld/Targets/*.cpp",
@@ -2772,11 +2739,9 @@ cc_library(
     name = "OrcJIT",
     srcs = glob([
         "lib/ExecutionEngine/Orc/*.cpp",
-        "lib/ExecutionEngine/Orc/*.h",
     ]),
     hdrs = glob([
         "include/llvm/ExecutionEngine/Orc/*.h",
-        "include/llvm/ExecutionEngine/Orc/RPC/*.h",
     ]) + [
         "include/llvm-c/LLJIT.h",
         "include/llvm-c/Orc.h",
@@ -2900,7 +2865,6 @@ cc_library(
     name = "DWARFLinker",
     srcs = glob([
         "lib/DWARFLinker/Classic/*.cpp",
-        "lib/DWARFLinker/Classic/*.h",
     ]),
     hdrs = glob(["include/llvm/DWARFLinker/Classic/*.h"]),
     copts = llvm_copts,
@@ -2921,7 +2885,6 @@ cc_library(
     name = "DWARFLinkerBase",
     srcs = glob([
         "lib/DWARFLinker/*.cpp",
-        "lib/DWARFLinker/*.h",
     ]),
     hdrs = glob(["include/llvm/DWARFLinker/*.h"]),
     copts = llvm_copts,
@@ -3012,7 +2975,6 @@ cc_library(
     name = "InterfaceStub",
     srcs = glob([
         "lib/InterfaceStub/*.cpp",
-        "lib/InterfaceStub/*.h",
     ]),
     hdrs = glob([
         "include/llvm/InterfaceStub/*.h",
@@ -3063,7 +3025,6 @@ cc_library(
     name = "MCA",
     srcs = glob([
         "lib/MCA/**/*.cpp",
-        "lib/MCA/**/*.h",
     ]),
     hdrs = glob([
         "include/llvm/MCA/**/*.h",
@@ -3090,7 +3051,6 @@ cc_library(
     name = "XRay",
     srcs = glob([
         "lib/XRay/*.cpp",
-        "lib/XRay/*.h",
     ]),
     hdrs = glob(["include/llvm/XRay/*.h"]),
     copts = llvm_copts,
@@ -3147,21 +3107,24 @@ cc_library(
 
 cc_library(
     name = "Exegesis",
-    srcs = glob([
-        "tools/llvm-exegesis/lib/*.cpp",
-        # We have to include these headers here as well as in the `hdrs` below
-        # to allow the `.cpp` files to use file-relative-inclusion to find
-        # them, even though consumers of this library use inclusion relative to
-        # `tools/llvm-exegesis/lib` with the `strip_includes_prefix` of this
-        # library. This mixture appears to be incompatible with header modules.
-        "tools/llvm-exegesis/lib/*.h",
-    ] + [
-        "tools/llvm-exegesis/lib/{}/*.cpp".format(t)
-        for t in llvm_target_exegesis
-    ] + [
-        "tools/llvm-exegesis/lib/{}/*.h".format(t)
-        for t in llvm_target_exegesis
-    ]),
+    srcs = glob(
+        [
+            "tools/llvm-exegesis/lib/*.cpp",
+            # We have to include these headers here as well as in the `hdrs` below
+            # to allow the `.cpp` files to use file-relative-inclusion to find
+            # them, even though consumers of this library use inclusion relative to
+            # `tools/llvm-exegesis/lib` with the `strip_includes_prefix` of this
+            # library. This mixture appears to be incompatible with header modules.
+            "tools/llvm-exegesis/lib/*.h",
+        ] + [
+            "tools/llvm-exegesis/lib/{}/*.cpp".format(t)
+            for t in llvm_target_exegesis
+        ] + [
+            "tools/llvm-exegesis/lib/{}/*.h".format(t)
+            for t in llvm_target_exegesis
+        ],
+        allow_empty = True,
+    ),
     hdrs = glob(["tools/llvm-exegesis/lib/*.h"]),
     copts = llvm_copts,
     features = [
@@ -3335,7 +3298,6 @@ cc_binary(
     name = "llvm-ar",
     srcs = glob([
         "tools/llvm-ar/*.cpp",
-        "tools/llvm-ar/*.h",
     ]) + ["llvm-ar-driver.cpp"],
     copts = llvm_copts,
     stamp = 0,
@@ -3373,7 +3335,6 @@ cc_binary(
     name = "llvm-as",
     srcs = glob([
         "tools/llvm-as/*.cpp",
-        "tools/llvm-as/*.h",
     ]),
     copts = llvm_copts,
     stamp = 0,
@@ -3390,7 +3351,6 @@ cc_binary(
     name = "llvm-bcanalyzer",
     srcs = glob([
         "tools/llvm-bcanalyzer/*.cpp",
-        "tools/llvm-bcanalyzer/*.h",
     ]),
     copts = llvm_copts,
     stamp = 0,
@@ -3477,7 +3437,6 @@ cc_binary(
     name = "llvm-cvtres",
     srcs = glob([
         "tools/llvm-cvtres/*.cpp",
-        "tools/llvm-cvtres/*.h",
     ]),
     copts = llvm_copts,
     stamp = 0,
@@ -3511,7 +3470,6 @@ cc_binary(
     name = "llvm-cxxmap",
     srcs = glob([
         "tools/llvm-cxxmap/*.cpp",
-        "tools/llvm-cxxmap/*.h",
     ]),
     copts = llvm_copts,
     stamp = 0,
@@ -3546,7 +3504,6 @@ cc_binary(
     name = "llvm-cxxfilt",
     srcs = glob([
         "tools/llvm-cxxfilt/*.cpp",
-        "tools/llvm-cxxfilt/*.h",
     ]) + ["llvm-cxxfilt-driver.cpp"],
     copts = llvm_copts,
     stamp = 0,
@@ -3579,7 +3536,6 @@ cc_binary(
     name = "llvm-debuginfod-find",
     srcs = glob([
         "tools/llvm-debuginfod-find/*.cpp",
-        "tools/llvm-debuginfod-find/*.h",
     ]),
     copts = llvm_copts,
     stamp = 0,
@@ -3596,7 +3552,6 @@ cc_binary(
     name = "llvm-dis",
     srcs = glob([
         "tools/llvm-dis/*.cpp",
-        "tools/llvm-dis/*.h",
     ]),
     copts = llvm_copts,
     stamp = 0,
@@ -3691,7 +3646,6 @@ cc_binary(
     name = "llvm-dwp",
     srcs = glob([
         "tools/llvm-dwp/*.cpp",
-        "tools/llvm-dwp/*.h",
     ]) + ["llvm-dwp-driver.cpp"],
     copts = llvm_copts,
     stamp = 0,
@@ -3731,7 +3685,6 @@ cc_binary(
     name = "llvm-extract",
     srcs = glob([
         "tools/llvm-extract/*.cpp",
-        "tools/llvm-extract/*.h",
     ]),
     copts = llvm_copts,
     stamp = 0,
@@ -3773,7 +3726,6 @@ cc_binary(
     name = "llvm-gsymutil",
     srcs = glob([
         "tools/llvm-gsymutil/*.cpp",
-        "tools/llvm-gsymutil/*.h",
     ]) + ["llvm-gsymutil-driver.cpp"],
     copts = llvm_copts,
     stamp = 0,
@@ -3925,7 +3877,6 @@ cc_binary(
     name = "llvm-link",
     srcs = glob([
         "tools/llvm-link/*.cpp",
-        "tools/llvm-link/*.h",
     ]),
     copts = llvm_copts,
     stamp = 0,
@@ -3990,7 +3941,6 @@ cc_binary(
     name = "llvm-lto",
     srcs = glob([
         "tools/llvm-lto/*.cpp",
-        "tools/llvm-lto/*.h",
     ]),
     copts = llvm_copts,
     stamp = 0,
@@ -4013,7 +3963,6 @@ cc_binary(
     name = "llvm-lto2",
     srcs = glob([
         "tools/llvm-lto2/*.cpp",
-        "tools/llvm-lto2/*.h",
     ]),
     copts = llvm_copts,
     stamp = 0,
@@ -4159,7 +4108,6 @@ cc_binary(
     name = "llvm-mt",
     srcs = glob([
         "tools/llvm-mt/*.cpp",
-        "tools/llvm-mt/*.h",
     ]) + ["llvm-mt-driver.cpp"],
     copts = llvm_copts,
     stamp = 0,
@@ -4196,7 +4144,6 @@ cc_binary(
     name = "llvm-nm",
     srcs = glob([
         "tools/llvm-nm/*.cpp",
-        "tools/llvm-nm/*.h",
     ]) + ["llvm-nm-driver.cpp"],
     copts = llvm_copts,
     stamp = 0,
@@ -4280,7 +4227,6 @@ cc_binary(
     name = "llvm-stress",
     srcs = glob([
         "tools/llvm-stress/*.cpp",
-        "tools/llvm-stress/*.h",
     ]),
     copts = llvm_copts,
     stamp = 0,
@@ -4457,7 +4403,6 @@ cc_binary(
     name = "llvm-profdata",
     srcs = glob([
         "tools/llvm-profdata/*.cpp",
-        "tools/llvm-profdata/*.h",
     ]) + ["llvm-profdata-driver.cpp"],
     copts = llvm_copts,
     stamp = 0,
@@ -4641,7 +4586,6 @@ cc_binary(
     name = "llvm-rtdyld",
     srcs = glob([
         "tools/llvm-rtdyld/*.cpp",
-        "tools/llvm-rtdyld/*.h",
     ]),
     copts = llvm_copts,
     stamp = 0,
@@ -4683,7 +4627,6 @@ cc_binary(
     name = "llvm-size",
     srcs = glob([
         "tools/llvm-size/*.cpp",
-        "tools/llvm-size/*.h",
     ]) + ["llvm-size-driver.cpp"],
     copts = llvm_copts,
     stamp = 0,
@@ -4699,7 +4642,6 @@ cc_binary(
     name = "llvm-split",
     srcs = glob([
         "tools/llvm-split/*.cpp",
-        "tools/llvm-split/*.h",
     ]),
     copts = llvm_copts,
     stamp = 0,
@@ -4729,7 +4671,6 @@ cc_binary(
     name = "llvm-strings",
     srcs = glob([
         "tools/llvm-strings/*.cpp",
-        "tools/llvm-strings/*.h",
     ]),
     copts = llvm_copts,
     stamp = 0,
@@ -4766,7 +4707,6 @@ cc_binary(
     name = "llvm-symbolizer",
     srcs = glob([
         "tools/llvm-symbolizer/*.cpp",
-        "tools/llvm-symbolizer/*.h",
     ]) + ["llvm-symbolizer-driver.cpp"],
     copts = llvm_copts,
     stamp = 0,
@@ -4792,7 +4732,6 @@ cc_binary(
     name = "llvm-undname",
     srcs = glob([
         "tools/llvm-undname/*.cpp",
-        "tools/llvm-undname/*.h",
     ]),
     copts = llvm_copts,
     stamp = 0,
@@ -4806,7 +4745,6 @@ cc_binary(
     name = "llvm-xray",
     srcs = glob([
         "tools/llvm-xray/*.cpp",
-        "tools/llvm-xray/*.cc",
         "tools/llvm-xray/*.h",
     ]),
     copts = llvm_copts,
@@ -4889,7 +4827,6 @@ cc_binary(
     name = "sancov",
     srcs = glob([
         "tools/sancov/*.cpp",
-        "tools/sancov/*.h",
     ]) + ["sancov-driver.cpp"],
     copts = llvm_copts,
     stamp = 0,
@@ -4912,7 +4849,6 @@ cc_binary(
     name = "sanstats",
     srcs = glob([
         "tools/sanstats/*.cpp",
-        "tools/sanstats/*.h",
     ]),
     copts = llvm_copts,
     stamp = 0,
@@ -4927,7 +4863,6 @@ cc_binary(
     name = "split-file",
     srcs = glob([
         "utils/split-file/*.cpp",
-        "utils/split-file/*.h",
     ]),
     copts = llvm_copts,
     stamp = 0,
@@ -5023,7 +4958,6 @@ cc_library(
     testonly = True,
     srcs = glob([
         "lib/Testing/Support/*.cpp",
-        "lib/Testing/Support/*.h",
     ]),
     hdrs = glob(["include/llvm/Testing/Support/*.h"]),
     copts = llvm_copts,
@@ -5052,7 +4986,6 @@ cc_binary(
     testonly = True,
     srcs = glob([
         "utils/FileCheck/*.cpp",
-        "utils/FileCheck/*.h",
     ]),
     copts = llvm_copts,
     stamp = 0,
@@ -5098,7 +5031,6 @@ cc_binary(
     testonly = True,
     srcs = glob([
         "utils/count/*.c",
-        "utils/count/*.h",
     ]),
     stamp = 0,
     deps = [":Support"],
@@ -5109,7 +5041,6 @@ cc_binary(
     testonly = True,
     srcs = glob([
         "tools/lli/ChildTarget/*.cpp",
-        "tools/lli/ChildTarget/*.h",
     ]),
     copts = llvm_copts,
     # The tests load code into this binary that expect to see symbols
@@ -5176,7 +5107,6 @@ cc_binary(
     testonly = True,
     srcs = glob([
         "tools/llvm-diff/*.cpp",
-        "tools/llvm-diff/*.h",
     ]),
     copts = llvm_copts,
     stamp = 0,
@@ -5194,7 +5124,6 @@ cc_binary(
     testonly = True,
     srcs = glob([
         "tools/llvm-isel-fuzzer/*.cpp",
-        "tools/llvm-isel-fuzzer/*.h",
     ]),
     copts = llvm_copts,
     stamp = 0,
@@ -5240,7 +5169,6 @@ cc_binary(
     testonly = True,
     srcs = glob([
         "utils/not/*.cpp",
-        "utils/not/*.h",
     ]),
     copts = llvm_copts,
     stamp = 0,
@@ -5320,7 +5248,6 @@ cc_binary(
     testonly = True,
     srcs = glob([
         "tools/llvm-tli-checker/*.cpp",
-        "tools/llvm-tli-checker/*.h",
     ]),
     copts = llvm_copts,
     stamp = 0,
@@ -5367,7 +5294,6 @@ cc_binary(
     name = "verify-uselistorder",
     srcs = glob([
         "tools/verify-uselistorder/*.cpp",
-        "tools/verify-uselistorder/*.h",
     ]),
     copts = llvm_copts,
     stamp = 0,
@@ -5387,7 +5313,6 @@ cc_binary(
     testonly = True,
     srcs = glob([
         "tools/yaml2obj/*.cpp",
-        "tools/yaml2obj/*.h",
     ]),
     copts = llvm_copts,
     stamp = 0,

--- a/utils/bazel/llvm-project-overlay/mlir/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/mlir/BUILD.bazel
@@ -325,9 +325,7 @@ cc_library(
         "lib/IR/*.cpp",
         "lib/IR/*.h",
         "lib/IR/PDL/*.cpp",
-        "lib/Bytecode/Reader/*.h",
         "lib/Bytecode/Writer/*.h",
-        "lib/Bytecode/*.h",
     ]) + [
         "include/mlir/IR/PDLPatternMatch.h.inc",
         "include/mlir/Interfaces/CallInterfaces.h",
@@ -1630,7 +1628,6 @@ cc_library(
     srcs = glob(
         [
             "lib/Dialect/AMDGPU/Transforms/*.cpp",
-            "lib/Dialect/AMDGPU/Transforms/*.h",
         ],
     ),
     hdrs = glob(["include/mlir/Dialect/AMDGPU/Transforms/*.h"]),
@@ -1769,7 +1766,6 @@ cc_library(
     name = "TargetCpp",
     srcs = glob([
         "lib/Target/Cpp/*.cpp",
-        "lib/Target/Cpp/*.h",
     ]),
     hdrs = glob(["include/mlir/Target/Cpp/*.h"]),
     deps = [
@@ -1968,7 +1964,6 @@ cc_library(
     name = "ArmNeon2dToIntr",
     srcs = glob([
         "lib/Conversion/ArmNeon2dToIntr/*.cpp",
-        "lib/Conversion/ArmNeon2dToIntr/*.h",
     ]),
     hdrs = glob([
         "include/mlir/Conversion/ArmNeon2dToIntr/*.h",
@@ -2840,7 +2835,6 @@ cc_library(
     name = "SCFTransforms",
     srcs = glob([
         "lib/Dialect/SCF/Transforms/*.cpp",
-        "lib/Dialect/SCF/Transforms/*.h",
     ]),
     hdrs = glob([
         "include/mlir/Dialect/SCF/Transforms/*.h",
@@ -3189,7 +3183,6 @@ cc_library(
     name = "SparseTensorTransforms",
     srcs = glob([
         "lib/Dialect/SparseTensor/Transforms/*.cpp",
-        "lib/Dialect/SparseTensor/Transforms/*.h",
         "lib/Dialect/SparseTensor/Transforms/Utils/*.cpp",
         "lib/Dialect/SparseTensor/Transforms/Utils/*.h",
     ]),
@@ -3829,7 +3822,6 @@ cc_library(
     name = "Dialect",
     srcs = glob([
         "lib/Dialect/*.cpp",
-        "lib/Dialect/*.h",
     ]),
     hdrs = glob([
         "include/mlir/Dialect/*.h",
@@ -3871,7 +3863,6 @@ cc_library(
     name = "DialectUtils",
     srcs = glob([
         "lib/Dialect/Utils/*.cpp",
-        "lib/Dialect/Utils/*.h",
     ]),
     hdrs = glob([
         "include/mlir/Dialect/Utils/*.h",
@@ -3890,7 +3881,6 @@ cc_library(
     name = "AffineDialect",
     srcs = glob([
         "lib/Dialect/Affine/IR/*.cpp",
-        "lib/Dialect/Affine/IR/*.h",
     ]),
     hdrs = glob([
         "include/mlir/Dialect/Affine/IR/*.h",
@@ -4012,7 +4002,6 @@ cc_library(
     name = "AffineAnalysis",
     srcs = glob([
         "lib/Dialect/Affine/Analysis/*.cpp",
-        "lib/Dialect/Affine/Analysis/*.h",
     ]),
     hdrs = glob(["include/mlir/Dialect/Affine/Analysis/*.h"]),
     includes = ["include"],
@@ -4036,7 +4025,6 @@ cc_library(
     srcs = glob(
         [
             "lib/Dialect/Affine/Utils/*.cpp",
-            "lib/Dialect/Affine/Utils/*.h",
         ],
     ),
     hdrs = [
@@ -4083,7 +4071,6 @@ cc_library(
     name = "AffineTransforms",
     srcs = glob([
         "lib/Dialect/Affine/Transforms/*.cpp",
-        "lib/Dialect/Affine/Transforms/*.h",
     ]),
     hdrs = [
         "include/mlir/Dialect/Affine/Passes.h",
@@ -4191,7 +4178,6 @@ cc_library(
         ":MemRefToSPIRV",
         ":NVGPUToNVVM",
         ":NVVMToLLVM",
-        ":OpenACCToLLVM",
         ":OpenACCToSCF",
         ":OpenMPToLLVM",
         ":PDLToPDLInterp",
@@ -4224,7 +4210,6 @@ cc_library(
     name = "AsyncToLLVM",
     srcs = glob([
         "lib/Conversion/AsyncToLLVM/*.cpp",
-        "lib/Conversion/AsyncToLLVM/*.h",
     ]),
     hdrs = glob(["include/mlir/Conversion/AsyncToLLVM/*.h"]),
     includes = ["include"],
@@ -4250,7 +4235,6 @@ cc_library(
     name = "AffineToStandard",
     srcs = glob([
         "lib/Conversion/AffineToStandard/*.cpp",
-        "lib/Conversion/AffineToStandard/*.h",
     ]),
     hdrs = glob(["include/mlir/Conversion/AffineToStandard/*.h"]),
     includes = ["include"],
@@ -4271,32 +4255,11 @@ cc_library(
     ],
 )
 
-# SDBM dialect only contains attribute components that can be constructed given
-# a dialect object, so whenever it is used it must also be registered. Therefore
-# we don't split out the registration library for it.
-cc_library(
-    name = "SDBM",
-    srcs = glob([
-        "lib/Dialect/SDBM/*.cpp",
-        "lib/Dialect/SDBM/*.h",
-    ]),
-    hdrs = glob([
-        "include/mlir/Dialect/SDBM/*.h",
-    ]),
-    includes = ["include"],
-    deps = [
-        ":IR",
-        ":Support",
-        "//llvm:Support",
-    ],
-)
-
 cc_library(
     name = "SCFDialect",
     srcs = glob(
         [
             "lib/Dialect/SCF/IR/*.cpp",
-            "lib/Dialect/SCF/IR/*.h",
         ],
     ),
     hdrs = glob(
@@ -4605,7 +4568,6 @@ cc_library(
     name = "ShapeToStandard",
     srcs = glob([
         "lib/Conversion/ShapeToStandard/*.cpp",
-        "lib/Conversion/ShapeToStandard/*.h",
     ]),
     hdrs = ["include/mlir/Conversion/ShapeToStandard/ShapeToStandard.h"],
     includes = ["include"],
@@ -4645,7 +4607,6 @@ cc_library(
     name = "ShapeTransforms",
     srcs = glob([
         "lib/Dialect/Shape/Transforms/*.cpp",
-        "lib/Dialect/Shape/Transforms/*.h",
     ]),
     hdrs = [
         "include/mlir/Dialect/Shape/Analysis/ShapeMappingAnalysis.h",
@@ -4728,7 +4689,6 @@ cc_library(
     srcs = glob(
         [
             "lib/Dialect/ControlFlow/IR/*.cpp",
-            "lib/Dialect/ControlFlow/IR/*.h",
         ],
     ),
     hdrs = glob([
@@ -4774,13 +4734,10 @@ cc_library(
     srcs = glob(
         [
             "lib/Dialect/Func/IR/*.cpp",
-            "lib/Dialect/Func/IR/*.h",
-            "lib/Dialect/Func/Utils/*.cpp",
         ],
     ),
     hdrs = glob([
         "include/mlir/Dialect/Func/IR/*.h",
-        "include/mlir/Dialect/Func/Utils/*.h",
     ]),
     includes = ["include"],
     deps = [
@@ -4931,7 +4888,6 @@ cc_library(
     name = "FuncTransforms",
     srcs = glob([
         "lib/Dialect/Func/Transforms/*.cpp",
-        "lib/Dialect/Func/Transforms/*.h",
     ]),
     hdrs = glob(["include/mlir/Dialect/Func/Transforms/*.h"]),
     includes = ["include"],
@@ -5068,7 +5024,6 @@ cc_library(
     srcs = glob(
         [
             "lib/Dialect/Vector/Transforms/*.cpp",
-            "lib/Dialect/Vector/Transforms/*.h",
         ],
     ),
     hdrs = glob([
@@ -5135,7 +5090,6 @@ cc_library(
     name = "Support",
     srcs = glob([
         "lib/Support/*.cpp",
-        "lib/Support/*.h",
     ]),
     hdrs = glob(["include/mlir/Support/*.h"]),
     includes = ["include"],
@@ -5149,11 +5103,8 @@ cc_library(
     name = "Debug",
     srcs = glob([
         "lib/Debug/*.cpp",
-        "lib/Debug/*.h",
         "lib/Debug/BreakpointManagers/*.cpp",
-        "lib/Debug/BreakpointManagers/*.h",
         "lib/Debug/Observers/*.cpp",
-        "lib/Debug/Observers/*.h",
     ]),
     hdrs = glob([
         "include/mlir/Debug/*.h",
@@ -5195,8 +5146,6 @@ cc_library(
         [
             "lib/Tools/mlir-lsp-server/*.cpp",
             "lib/Tools/mlir-lsp-server/*.h",
-            "lib/Tools/mlir-lsp-server/lsp/*.cpp",
-            "lib/Tools/mlir-lsp-server/lsp/*.h",
         ],
     ),
     hdrs = glob(
@@ -5270,8 +5219,6 @@ cc_library(
     name = "BytecodeReader",
     srcs = glob([
         "lib/Bytecode/Reader/*.cpp",
-        "lib/Bytecode/Reader/*.h",
-        "lib/Bytecode/*.h",
     ]),
     hdrs = glob([
         "include/mlir/Bytecode/*.h",
@@ -5291,7 +5238,6 @@ cc_library(
     srcs = glob([
         "lib/Bytecode/Writer/*.cpp",
         "lib/Bytecode/Writer/*.h",
-        "lib/Bytecode/*.h",
     ]),
     hdrs = glob([
         "include/mlir/Bytecode/*.h",
@@ -5309,7 +5255,6 @@ cc_library(
     name = "Parser",
     srcs = glob([
         "lib/Parser/*.cpp",
-        "lib/Parser/*.h",
     ]),
     hdrs = glob([
         "include/mlir/Parser/*.h",
@@ -5440,7 +5385,6 @@ cc_library(
     name = "LLVMIRTransforms",
     srcs = glob([
         "lib/Dialect/LLVMIR/Transforms/*.cpp",
-        "lib/Dialect/LLVMIR/Transforms/*.h",
     ]),
     hdrs = glob(["include/mlir/Dialect/LLVMIR/Transforms/*.h"]),
     includes = ["include"],
@@ -5593,7 +5537,6 @@ cc_library(
     srcs = glob(
         [
             "lib/Dialect/GPU/IR/*.cpp",
-            "lib/Dialect/GPU/IR/*.h",
         ],
     ),
     hdrs = glob(["include/mlir/Dialect/GPU/IR/*.h"]),
@@ -5687,7 +5630,6 @@ cc_library(
     srcs = glob(
         [
             "lib/Dialect/GPU/Transforms/*.cpp",
-            "lib/Dialect/GPU/Transforms/*.h",
         ],
     ),
     hdrs = glob(["include/mlir/Dialect/GPU/Transforms/*.h"]),
@@ -5877,7 +5819,6 @@ cc_library(
     name = "GPUToNVVMTransforms",
     srcs = glob([
         "lib/Conversion/GPUToNVVM/*.cpp",
-        "lib/Conversion/GPUToNVVM/*.h",
     ]),
     hdrs = glob([
         "include/mlir/Conversion/GPUToNVVM/*.h",
@@ -5913,7 +5854,6 @@ cc_library(
     name = "AMDGPUToROCDL",
     srcs = glob([
         "lib/Conversion/AMDGPUToROCDL/*.cpp",
-        "lib/Conversion/AMDGPUToROCDL/*.h",
     ]) + ["include/mlir/Conversion/GPUToROCDL/Runtimes.h"],
     hdrs = glob([
         "include/mlir/Conversion/AMDGPUToROCDL/*.h",
@@ -5938,7 +5878,6 @@ cc_library(
     name = "NVGPUToNVVM",
     srcs = glob([
         "lib/Conversion/NVGPUToNVVM/*.cpp",
-        "lib/Conversion/NVGPUToNVVM/*.h",
     ]),
     hdrs = glob([
         "include/mlir/Conversion/NVGPUToNVVM/*.h",
@@ -5966,7 +5905,6 @@ cc_library(
     name = "VectorToSPIRV",
     srcs = glob([
         "lib/Conversion/VectorToSPIRV/*.cpp",
-        "lib/Conversion/VectorToSPIRV/*.h",
     ]),
     hdrs = glob([
         "include/mlir/Conversion/VectorToSPIRV/*.h",
@@ -6095,7 +6033,6 @@ cc_library(
     name = "GPUToSPIRV",
     srcs = glob([
         "lib/Conversion/GPUToSPIRV/*.cpp",
-        "lib/Conversion/GPUToSPIRV/*.h",
     ]),
     hdrs = glob([
         "include/mlir/Conversion/GPUToSPIRV/*.h",
@@ -6665,7 +6602,6 @@ cc_library(
     name = "PDLDialect",
     srcs = glob([
         "lib/Dialect/PDL/IR/*.cpp",
-        "lib/Dialect/PDL/IR/*.h",
     ]),
     hdrs = glob([
         "include/mlir/Dialect/PDL/IR/*.h",
@@ -6740,7 +6676,6 @@ cc_library(
     name = "PDLInterpDialect",
     srcs = glob([
         "lib/Dialect/PDLInterp/IR/*.cpp",
-        "lib/Dialect/PDLInterp/IR/*.h",
     ]),
     hdrs = glob([
         "include/mlir/Dialect/PDLInterp/IR/*.h",
@@ -7038,7 +6973,6 @@ cc_library(
     srcs = glob(
         [
             "lib/Dialect/SPIRV/Transforms/*.cpp",
-            "lib/Dialect/SPIRV/Transforms/*.h",
         ],
         exclude = ["lib/Dialect/SPIRV/Transforms/SPIRVConversion.cpp"],
     ),
@@ -7077,7 +7011,6 @@ cc_library(
     name = "MathToSPIRV",
     srcs = glob([
         "lib/Conversion/MathToSPIRV/*.cpp",
-        "lib/Conversion/MathToSPIRV/*.h",
     ]),
     hdrs = glob([
         "include/mlir/Conversion/MathToSPIRV/*.h",
@@ -7104,7 +7037,6 @@ cc_library(
     name = "FuncToEmitC",
     srcs = glob([
         "lib/Conversion/FuncToEmitC/*.cpp",
-        "lib/Conversion/FuncToEmitC/*.h",
     ]),
     hdrs = glob([
         "include/mlir/Conversion/FuncToEmitC/*.h",
@@ -7130,7 +7062,6 @@ cc_library(
     name = "FuncToSPIRV",
     srcs = glob([
         "lib/Conversion/FuncToSPIRV/*.cpp",
-        "lib/Conversion/FuncToSPIRV/*.h",
     ]),
     hdrs = glob([
         "include/mlir/Conversion/FuncToSPIRV/*.h",
@@ -7162,7 +7093,6 @@ cc_library(
     name = "TensorToLinalg",
     srcs = glob([
         "lib/Conversion/TensorToLinalg/*.cpp",
-        "lib/Conversion/TensorToLinalg/*.h",
     ]),
     hdrs = glob([
         "include/mlir/Conversion/TensorToLinalg/*.h",
@@ -7191,7 +7121,6 @@ cc_library(
     name = "TensorToSPIRV",
     srcs = glob([
         "lib/Conversion/TensorToSPIRV/*.cpp",
-        "lib/Conversion/TensorToSPIRV/*.h",
     ]),
     hdrs = glob([
         "include/mlir/Conversion/TensorToSPIRV/*.h",
@@ -7477,7 +7406,6 @@ cc_library(
     srcs = glob(
         [
             "lib/Dialect/Tensor/Transforms/*.cpp",
-            "lib/Dialect/Tensor/Transforms/*.h",
         ],
     ),
     hdrs = glob(["include/mlir/Dialect/Tensor/Transforms/*.h"]),
@@ -7584,7 +7512,6 @@ cc_library(
     srcs = glob(
         include = [
             "lib/Transforms/Utils/*.cpp",
-            "lib/Transforms/Utils/*.h",
         ],
         exclude = ["lib/Transforms/Utils/InliningUtils.cpp"],
     ),
@@ -7923,7 +7850,6 @@ cc_library(
     name = "Transforms",
     srcs = glob([
         "lib/Transforms/*.cpp",
-        "lib/Transforms/*.h",
     ]),
     hdrs = glob(["include/mlir/Transforms/*.h"]),
     includes = ["include"],
@@ -8011,7 +7937,6 @@ cc_library(
     name = "SCFToSPIRV",
     srcs = glob([
         "lib/Conversion/SCFToSPIRV/*.cpp",
-        "lib/Conversion/SCFToSPIRV/*.h",
     ]),
     hdrs = glob([
         "include/mlir/Conversion/SCFToSPIRV/*.h",
@@ -8261,7 +8186,6 @@ cc_library(
     name = "MemRefToEmitC",
     srcs = glob([
         "lib/Conversion/MemRefToEmitC/*.cpp",
-        "lib/Conversion/MemRefToEmitC/*.h",
     ]),
     hdrs = glob([
         "include/mlir/Conversion/MemRefToEmitC/*.h",
@@ -8311,7 +8235,6 @@ cc_library(
     name = "MemRefToSPIRV",
     srcs = glob([
         "lib/Conversion/MemRefToSPIRV/*.cpp",
-        "lib/Conversion/MemRefToSPIRV/*.h",
     ]),
     hdrs = glob([
         "include/mlir/Conversion/MemRefToSPIRV/*.h",
@@ -8371,7 +8294,6 @@ cc_library(
     name = "ArithToArmSME",
     srcs = glob([
         "lib/Conversion/ArithToArmSME/*.cpp",
-        "lib/Conversion/ArithToArmSME/*.h",
     ]),
     hdrs = glob([
         "include/mlir/Conversion/ArithToArmSME/*.h",
@@ -8392,7 +8314,6 @@ cc_library(
     name = "ArithToEmitC",
     srcs = glob([
         "lib/Conversion/ArithToEmitC/*.cpp",
-        "lib/Conversion/ArithToEmitC/*.h",
     ]),
     hdrs = glob([
         "include/mlir/Conversion/ArithToEmitC/*.h",
@@ -8683,9 +8604,7 @@ cc_library(
     srcs = glob(
         [
             "lib/Analysis/*.cpp",
-            "lib/Analysis/*.h",
             "lib/Analysis/*/*.cpp",
-            "lib/Analysis/*/*.h",
         ],
     ),
     hdrs = glob(
@@ -8991,7 +8910,6 @@ cc_library(
         ":IR",
         ":LLVMDialect",
         ":OpenACCDialect",
-        ":OpenACCToLLVM",
         ":OpenMPCommon",
         ":Support",
         ":ToLLVMIRTranslation",
@@ -9357,7 +9275,6 @@ cc_library(
         ":SCFToGPU",
         ":SCFTransformOps",
         ":SCFTransforms",
-        ":SDBM",
         ":SPIRVDialect",
         ":SPIRVPassIncGen",
         ":SPIRVTarget",
@@ -9468,7 +9385,6 @@ cc_binary(
         "//mlir/test:TestTosaDialect",
         "//mlir/test:TestTransformDialect",
         "//mlir/test:TestTransforms",
-        "//mlir/test:TestTypeDialect",
         "//mlir/test:TestVector",
         "//mlir/test:TestVectorToSPIRV",
     ],
@@ -10086,7 +10002,6 @@ cc_library(
     srcs = glob(
         [
             "lib/Dialect/OpenACC/IR/*.cpp",
-            "lib/Dialect/OpenACC/IR/*.h",
         ],
     ),
     hdrs = glob(
@@ -10140,7 +10055,6 @@ cc_library(
     srcs = glob(
         [
             "lib/Dialect/OpenACC/Transforms/*.cpp",
-            "lib/Dialect/OpenACC/Transforms/*.h",
         ],
     ),
     hdrs = glob(["include/mlir/Dialect/OpenACC/Transforms/*.h"]),
@@ -10304,7 +10218,6 @@ cc_library(
     srcs = glob(
         [
             "lib/Dialect/OpenMP/IR/*.cpp",
-            "lib/Dialect/OpenMP/IR/*.h",
         ],
     ),
     hdrs = glob(
@@ -10340,7 +10253,6 @@ cc_library(
     name = "OpenACCToSCF",
     srcs = glob([
         "lib/Conversion/OpenACCToSCF/*.cpp",
-        "lib/Conversion/OpenACCToSCF/*.h",
     ]),
     hdrs = glob([
         "include/mlir/Conversion/OpenACCToSCF/*.h",
@@ -10361,34 +10273,9 @@ cc_library(
 )
 
 cc_library(
-    name = "OpenACCToLLVM",
-    srcs = glob([
-        "lib/Conversion/OpenACCToLLVM/*.cpp",
-        "lib/Conversion/OpenACCToLLVM/*.h",
-    ]),
-    hdrs = glob([
-        "include/mlir/Conversion/OpenACCToLLVM/*.h",
-    ]),
-    includes = ["include"],
-    deps = [
-        ":ConversionPassIncGen",
-        ":FuncDialect",
-        ":IR",
-        ":LLVMCommonConversion",
-        ":LLVMDialect",
-        ":OpenACCDialect",
-        ":Pass",
-        ":Transforms",
-        "//llvm:Core",
-        "//llvm:Support",
-    ],
-)
-
-cc_library(
     name = "OpenMPToLLVM",
     srcs = glob([
         "lib/Conversion/OpenMPToLLVM/*.cpp",
-        "lib/Conversion/OpenMPToLLVM/*.h",
     ]),
     hdrs = glob([
         "include/mlir/Conversion/OpenMPToLLVM/*.h",
@@ -10598,7 +10485,6 @@ cc_library(
     name = "IndexToLLVM",
     srcs = glob([
         "lib/Conversion/IndexToLLVM/*.cpp",
-        "lib/Conversion/IndexToLLVM/*.h",
     ]),
     hdrs = glob([
         "include/mlir/Conversion/IndexToLLVM/*.h",
@@ -10624,7 +10510,6 @@ cc_library(
     name = "IndexToSPIRV",
     srcs = glob([
         "lib/Conversion/IndexToSPIRV/*.cpp",
-        "lib/Conversion/IndexToSPIRV/*.h",
     ]),
     hdrs = glob([
         "include/mlir/Conversion/IndexToSPIRV/*.h",
@@ -11015,7 +10900,6 @@ cc_library(
     name = "LinalgToStandard",
     srcs = glob([
         "lib/Conversion/LinalgToStandard/*.cpp",
-        "lib/Conversion/LinalgToStandard/*.h",
     ]),
     hdrs = glob([
         "include/mlir/Conversion/LinalgToStandard/*.h",
@@ -11161,7 +11045,6 @@ cc_library(
     name = "LinalgUtils",
     srcs = glob([
         "lib/Dialect/Linalg/Utils/*.cpp",
-        "lib/Dialect/Linalg/Utils/*.h",
     ]),
     hdrs = glob([
         "include/mlir/Dialect/Linalg/Utils/*.h",
@@ -11190,7 +11073,6 @@ cc_library(
     name = "LinalgTransforms",
     srcs = glob([
         "lib/Dialect/Linalg/Transforms/*.cpp",
-        "lib/Dialect/Linalg/Transforms/*.h",
     ]),
     hdrs = [
         "include/mlir/Dialect/Linalg/Passes.h",
@@ -11542,7 +11424,6 @@ cc_library(
     name = "VectorToLLVM",
     srcs = glob([
         "lib/Conversion/VectorToLLVM/*.cpp",
-        "lib/Conversion/VectorToLLVM/*.h",
     ]),
     hdrs = glob([
         "include/mlir/Conversion/VectorToLLVM/*.h",
@@ -11584,7 +11465,6 @@ cc_library(
     name = "VectorToArmSME",
     srcs = glob([
         "lib/Conversion/VectorToArmSME/*.cpp",
-        "lib/Conversion/VectorToArmSME/*.h",
     ]),
     hdrs = glob([
         "include/mlir/Conversion/VectorToArmSME/*.h",
@@ -11605,7 +11485,6 @@ cc_library(
     name = "VectorToGPU",
     srcs = glob([
         "lib/Conversion/VectorToGPU/*.cpp",
-        "lib/Conversion/VectorToGPU/*.h",
     ]),
     hdrs = glob([
         "include/mlir/Conversion/VectorToGPU/*.h",
@@ -11642,7 +11521,6 @@ cc_library(
     name = "VectorToSCF",
     srcs = glob([
         "lib/Conversion/VectorToSCF/*.cpp",
-        "lib/Conversion/VectorToSCF/*.h",
     ]),
     hdrs = glob([
         "include/mlir/Conversion/VectorToSCF/*.h",
@@ -11792,7 +11670,6 @@ cc_library(
     name = "TosaDialect",
     srcs = glob([
         "lib/Dialect/Tosa/IR/*.cpp",
-        "lib/Dialect/Tosa/IR/*.h",
         "lib/Dialect/Tosa/Utils/*.cpp",
         "lib/Dialect/Tosa/Transforms/*.cpp",
     ]),
@@ -11832,7 +11709,6 @@ cc_library(
     name = "TosaToArith",
     srcs = glob([
         "lib/Conversion/TosaToArith/*.cpp",
-        "lib/Conversion/TosaToArith/*.h",
     ]),
     hdrs = glob([
         "include/mlir/Conversion/TosaToArith/*.h",
@@ -11856,7 +11732,6 @@ cc_library(
     name = "TosaToLinalg",
     srcs = glob([
         "lib/Conversion/TosaToLinalg/*.cpp",
-        "lib/Conversion/TosaToLinalg/*.h",
     ]),
     hdrs = glob([
         "include/mlir/Conversion/TosaToLinalg/*.h",
@@ -11889,7 +11764,6 @@ cc_library(
     name = "TosaToMLProgram",
     srcs = glob([
         "lib/Conversion/TosaToMLProgram/*.cpp",
-        "lib/Conversion/TosaToMLProgram/*.h",
     ]),
     hdrs = glob([
         "include/mlir/Conversion/TosaToMLProgram/*.h",
@@ -11913,7 +11787,6 @@ cc_library(
     name = "TosaToSCF",
     srcs = glob([
         "lib/Conversion/TosaToSCF/*.cpp",
-        "lib/Conversion/TosaToSCF/*.h",
     ]),
     hdrs = glob([
         "include/mlir/Conversion/TosaToSCF/*.h",
@@ -11938,7 +11811,6 @@ cc_library(
     name = "TosaToTensor",
     srcs = glob([
         "lib/Conversion/TosaToTensor/*.cpp",
-        "lib/Conversion/TosaToTensor/*.h",
     ]),
     hdrs = glob([
         "include/mlir/Conversion/TosaToTensor/*.h",
@@ -12443,7 +12315,6 @@ cc_library(
     srcs = glob(
         [
             "lib/Dialect/Complex/IR/*.cpp",
-            "lib/Dialect/Complex/IR/*.h",
         ],
     ),
     hdrs = ["include/mlir/Dialect/Complex/IR/Complex.h"],
@@ -12466,7 +12337,6 @@ cc_library(
     name = "ComplexToLLVM",
     srcs = glob([
         "lib/Conversion/ComplexToLLVM/*.cpp",
-        "lib/Conversion/ComplexToLLVM/*.h",
     ]),
     hdrs = glob([
         "include/mlir/Conversion/ComplexToLLVM/*.h",
@@ -12494,7 +12364,6 @@ cc_library(
     name = "ComplexToLibm",
     srcs = glob([
         "lib/Conversion/ComplexToLibm/*.cpp",
-        "lib/Conversion/ComplexToLibm/*.h",
     ]),
     hdrs = glob([
         "include/mlir/Conversion/ComplexToLibm/*.h",
@@ -12518,7 +12387,6 @@ cc_library(
     name = "ComplexToSPIRV",
     srcs = glob([
         "lib/Conversion/ComplexToSPIRV/*.cpp",
-        "lib/Conversion/ComplexToSPIRV/*.h",
     ]),
     hdrs = glob([
         "include/mlir/Conversion/ComplexToSPIRV/*.h",
@@ -12543,7 +12411,6 @@ cc_library(
     name = "ComplexToStandard",
     srcs = glob([
         "lib/Conversion/ComplexToStandard/*.cpp",
-        "lib/Conversion/ComplexToStandard/*.h",
     ]),
     hdrs = glob([
         "include/mlir/Conversion/ComplexToStandard/*.h",
@@ -12760,7 +12627,6 @@ cc_library(
     name = "ArithTransforms",
     srcs = glob([
         "lib/Dialect/Arith/Transforms/*.cpp",
-        "lib/Dialect/Arith/Transforms/*.h",
     ]),
     hdrs = glob([
         "include/mlir/Dialect/Arith/Transforms/*.h",
@@ -12882,7 +12748,6 @@ cc_library(
     srcs = glob(
         [
             "lib/Dialect/Math/IR/*.cpp",
-            "lib/Dialect/Math/IR/*.h",
         ],
     ),
     hdrs = [
@@ -12909,7 +12774,6 @@ cc_library(
     name = "MathTransforms",
     srcs = glob([
         "lib/Dialect/Math/Transforms/*.cpp",
-        "lib/Dialect/Math/Transforms/*.h",
     ]),
     hdrs = glob(["include/mlir/Dialect/Math/Transforms/*.h"]),
     includes = ["include"],
@@ -12933,7 +12797,6 @@ cc_library(
     name = "MathToLibm",
     srcs = glob([
         "lib/Conversion/MathToLibm/*.cpp",
-        "lib/Conversion/MathToLibm/*.h",
     ]),
     hdrs = glob([
         "include/mlir/Conversion/MathToLibm/*.h",
@@ -13024,7 +12887,6 @@ cc_library(
     srcs = glob(
         [
             "lib/Dialect/MemRef/IR/*.cpp",
-            "lib/Dialect/MemRef/IR/*.h",
         ],
     ),
     hdrs = [
@@ -13102,7 +12964,6 @@ cc_library(
     srcs = glob(
         [
             "lib/Dialect/MemRef/Transforms/*.cpp",
-            "lib/Dialect/MemRef/Transforms/*.h",
         ],
     ),
     hdrs = glob(["include/mlir/Dialect/MemRef/Transforms/*.h"]),
@@ -13730,7 +13591,6 @@ cc_library(
     srcs = glob(
         [
             "lib/Dialect/Bufferization/Transforms/*.cpp",
-            "lib/Dialect/Bufferization/Transforms/*.h",
         ],
     ),
     hdrs = glob(["include/mlir/Dialect/Bufferization/Transforms/*.h"]),
@@ -13922,7 +13782,6 @@ cc_library(
     srcs = glob(
         [
             "lib/Tools/PDLL/ODS/*.cpp",
-            "lib/Tools/PDLL/ODS/*.h",
         ],
     ),
     hdrs = glob(["include/mlir/Tools/PDLL/ODS/*.h"]),
@@ -13956,7 +13815,6 @@ cc_library(
     srcs = glob(
         [
             "lib/Tools/PDLL/CodeGen/*.cpp",
-            "lib/Tools/PDLL/CodeGen/*.h",
         ],
     ),
     hdrs = glob(["include/mlir/Tools/PDLL/CodeGen/*.h"]),
@@ -14117,7 +13975,6 @@ cc_library(
     name = "UBToLLVM",
     srcs = glob([
         "lib/Conversion/UBToLLVM/*.cpp",
-        "lib/Conversion/UBToLLVM/*.h",
     ]),
     hdrs = glob([
         "include/mlir/Conversion/UBToLLVM/*.h",
@@ -14138,7 +13995,6 @@ cc_library(
     name = "UBToSPIRV",
     srcs = glob([
         "lib/Conversion/UBToSPIRV/*.cpp",
-        "lib/Conversion/UBToSPIRV/*.h",
     ]),
     hdrs = glob([
         "include/mlir/Conversion/UBToSPIRV/*.h",

--- a/utils/bazel/llvm-project-overlay/mlir/test/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/mlir/test/BUILD.bazel
@@ -818,7 +818,6 @@ cc_library(
 cc_library(
     name = "TestMesh",
     srcs = glob(["lib/Dialect/Mesh/**/*.cpp"]),
-    hdrs = glob(["lib/Dialect/Mesh/**/*.h"]),
     includes = ["lib/Dialect/Test"],
     deps = [
         ":TestDialect",
@@ -1043,18 +1042,6 @@ cc_library(
         "//mlir:VectorToSCF",
         "//mlir:VectorTransforms",
         "//mlir:X86VectorDialect",
-    ],
-)
-
-cc_library(
-    name = "TestTypeDialect",
-    srcs = glob([
-        "lib/Dialect/LLVMIR/*.cpp",
-    ]),
-    deps = [
-        ":TestDialect",
-        "//mlir:IR",
-        "//mlir:LLVMDialect",
     ],
 )
 

--- a/utils/bazel/llvm-project-overlay/mlir/unittests/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/mlir/unittests/BUILD.bazel
@@ -16,7 +16,6 @@ cc_test(
     size = "small",
     srcs = glob([
         "Debug/*.cpp",
-        "Debug/*.h",
     ]),
     deps = [
         "//llvm:Support",
@@ -35,7 +34,6 @@ cc_test(
     size = "small",
     srcs = glob([
         "IR/*.cpp",
-        "IR/*.h",
     ]),
     deps = [
         "//llvm:Support",
@@ -57,7 +55,6 @@ cc_test(
     size = "small",
     srcs = glob([
         "Interfaces/*.cpp",
-        "Interfaces/*.h",
     ]),
     deps = [
         "//llvm:Support",
@@ -82,7 +79,6 @@ cc_test(
     size = "small",
     srcs = glob([
         "Support/*.cpp",
-        "Support/*.h",
     ]),
     deps = [
         "//llvm:Support",
@@ -98,7 +94,6 @@ cc_test(
     size = "small",
     srcs = glob([
         "Pass/*.cpp",
-        "Pass/*.h",
     ]),
     deps = [
         "//llvm:Support",
@@ -118,7 +113,6 @@ cc_test(
     size = "small",
     srcs = glob([
         "Rewrite/*.cpp",
-        "Rewrite/*.h",
     ]),
     deps = [
         "//mlir:IR",
@@ -134,7 +128,6 @@ cc_test(
     size = "small",
     srcs = glob([
         "Dialect/*.cpp",
-        "Dialect/*.h",
     ]),
     deps = [
         "//llvm:Support",
@@ -149,7 +142,6 @@ cc_test(
     size = "small",
     srcs = glob([
         "Dialect/MemRef/*.cpp",
-        "Dialect/MemRef/*.h",
     ]),
     deps = [
         "//llvm:TestingSupport",
@@ -162,26 +154,10 @@ cc_test(
 )
 
 cc_test(
-    name = "quantops_tests",
-    size = "small",
-    srcs = glob([
-        "Dialect/Quant/*.cpp",
-        "Dialect/Quant/*.h",
-    ]),
-    deps = [
-        "//llvm:TestingSupport",
-        "//mlir:QuantOps",
-        "//mlir:Transforms",
-        "//third-party/unittest:gtest_main",
-    ],
-)
-
-cc_test(
     name = "scf_tests",
     size = "small",
     srcs = glob([
         "Dialect/SCF/*.cpp",
-        "Dialect/SCF/*.h",
     ]),
     deps = [
         "//mlir:ArithDialect",
@@ -200,7 +176,6 @@ cc_test(
     size = "small",
     srcs = glob([
         "Dialect/SparseTensor/*.cpp",
-        "Dialect/SparseTensor/*.h",
     ]),
     deps = [
         "//llvm:Support",
@@ -218,7 +193,6 @@ cc_test(
     size = "small",
     srcs = glob([
         "Dialect/SPIRV/*.cpp",
-        "Dialect/SPIRV/*.h",
     ]),
     deps = [
         "//llvm:Support",
@@ -238,7 +212,6 @@ cc_test(
     size = "small",
     srcs = glob([
         "Dialect/Transform/*.cpp",
-        "Dialect/Transform/*.h",
     ]),
     deps = [
         "//llvm:Support",
@@ -264,7 +237,6 @@ cc_test(
     size = "small",
     srcs = glob([
         "Dialect/Utils/*.cpp",
-        "Dialect/Utils/*.h",
     ]),
     deps = [
         "//llvm:Support",
@@ -317,7 +289,6 @@ cc_test(
     size = "small",
     srcs = glob([
         "TableGen/*.cpp",
-        "TableGen/*.h",
     ]) + [
         "TableGen/EnumsGenTest.cpp.inc",
         "TableGen/EnumsGenTest.h.inc",
@@ -343,7 +314,6 @@ cc_test(
     size = "small",
     srcs = glob([
         "Transforms/*.cpp",
-        "Transforms/*.h",
     ]),
     deps = [
         "//mlir:AffineAnalysis",
@@ -363,8 +333,6 @@ cc_test(
     name = "analysis_tests",
     size = "small",
     srcs = glob([
-        "Analysis/*.cpp",
-        "Analysis/*.h",
         "Analysis/*/*.cpp",
         "Analysis/*/*.h",
     ]),
@@ -387,9 +355,6 @@ cc_test(
     size = "small",
     srcs = glob([
         "Bytecode/*.cpp",
-        "Bytecode/*.h",
-        "Bytecode/*/*.cpp",
-        "Bytecode/*/*.h",
     ]),
     deps = [
         "//llvm:Support",
@@ -408,10 +373,7 @@ cc_test(
     name = "conversion_tests",
     size = "small",
     srcs = glob([
-        "Conversion/*.cpp",
-        "Conversion/*.h",
         "Conversion/*/*.cpp",
-        "Conversion/*/*.h",
     ]),
     deps = [
         "//mlir:ArithDialect",


### PR DESCRIPTION
This bazel flag, that should be flipped in an upcoming release https://github.com/bazelbuild/bazel/pull/15327, fails if globs have no matches. This helps find libraries where you are accidentally not including files because of typos. This change removes the various globs that were not matching anything, and uncovered some targets that were doing nothing because their source files were deleted. There are a few cases where globs were intentionally optional in the case of loops that expanded to different potential options, so those now use `allow_empty = True`. This allows downstream consumers to also flip this flags for their own builds, where previously this would fail in LLVM instead.

The downside to this change is that if files are added in these relatively standard locations, manual work will have to be done to add this patterns back. If folks prefer we could instead add `allow_empty = True` to every glob.