### PR TITLE
[bazel] Make compiler-rt analyze on macOS

### DIFF
--- a/utils/bazel/llvm-project-overlay/compiler-rt/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/compiler-rt/BUILD.bazel
@@ -19,6 +19,10 @@ cc_library(
         ],
         # Will raise error unless supported platforms.
     }),
+    target_compatible_with = select({
+        "@platforms//os:linux": [],
+        "//conditions:default": ["@platforms//:incompatible"],
+    }),
 )
 
 WIN32_ONLY_FILES = [


### PR DESCRIPTION
Previously the select above would fail for non-linux platforms if you did a `bazel build @llvm-project//...`, now this target specifies that it's only supported on the linux platform through bazel's `target_compatible_with` feature. This makes all targets in the tree be ignored when building on incompatible platforms (and fail if built directly)