### PR TITLE
Unwrap CountAttributed for debug info

### DIFF
--- a/clang/lib/CodeGen/CGDebugInfo.cpp
+++ b/clang/lib/CodeGen/CGDebugInfo.cpp
@@ -3463,6 +3463,9 @@ static QualType UnwrapTypeForDebugInfo(QualType T, const ASTContext &C) {
     case Type::BTFTagAttributed:
       T = cast<BTFTagAttributedType>(T)->getWrappedType();
       break;
+    case Type::CountAttributed:
+      T = cast<CountAttributedType>(T)->desugar();
+      break;
     case Type::Elaborated:
       T = cast<ElaboratedType>(T)->getNamedType();
       break;

--- a/clang/test/CodeGen/attr-counted-by-debug-info.c
+++ b/clang/test/CodeGen/attr-counted-by-debug-info.c
@@ -13,6 +13,6 @@ struct {
 } agent_send_response_port_num;
 
 // CHECK: !DICompositeType(tag: DW_TAG_array_type, baseType: ![[BT:.*]], elements: ![[ELEMENTS:.*]])
-// CHECK: ![[BT]] = !DIBasicType(name: "long", size: 64, encoding: DW_ATE_signed)
+// CHECK: ![[BT]] = !DIBasicType(name: "long", size: {{.*}}, encoding: DW_ATE_signed)
 // CHECK: ![[ELEMENTS]] = !{![[COUNT:.*]]}
 // CHECK: ![[COUNT]] = !DISubrange(count: -1)

--- a/clang/test/CodeGen/attr-counted-by-debug-info.c
+++ b/clang/test/CodeGen/attr-counted-by-debug-info.c
@@ -13,6 +13,6 @@ struct {
 } agent_send_response_port_num;
 
 // CHECK: !DICompositeType(tag: DW_TAG_array_type, baseType: ![[BT:.*]], elements: ![[ELEMENTS:.*]])
-// ![[BT]] = !DIBasicType(name: "long", size: 64, encoding: DW_ATE_signed)
-// ![[ELEMENTS]] = !{![[COUNT]]}
-// ![[COUNT]] = !DISubrange(count: -1)
+// CHECK: ![[BT]] = !DIBasicType(name: "long", size: 64, encoding: DW_ATE_signed)
+// CHECK: ![[ELEMENTS]] = !{![[COUNT:.*]]}
+// CHECK: ![[COUNT]] = !DISubrange(count: -1)

--- a/clang/test/CodeGen/attr-counted-by-debug-info.c
+++ b/clang/test/CodeGen/attr-counted-by-debug-info.c
@@ -1,0 +1,18 @@
+// RUN: %clang -emit-llvm -DCOUNTED_BY -S -g %s -o - | FileCheck %s
+// RUN: %clang -emit-llvm -S -g %s -o - | FileCheck %s
+
+#ifdef COUNTED_BY
+#define __counted_by(member)    __attribute__((__counted_by__(member)))
+#else
+#define __counted_by(member)
+#endif
+
+struct {
+  int num_counters;
+  long value[] __counted_by(num_counters);
+} agent_send_response_port_num;
+
+// CHECK: !DICompositeType(tag: DW_TAG_array_type, baseType: ![[BT:.*]], elements: ![[ELEMENTS:.*]])
+// ![[BT]] = !DIBasicType(name: "long", size: 64, encoding: DW_ATE_signed)
+// ![[ELEMENTS]] = !{![[COUNT]]}
+// ![[COUNT]] = !DISubrange(count: -1)


### PR DESCRIPTION
Fix crash caused by 3eb9ff30959a670559bcba03d149d4c51bf7c9c9