### PR TITLE
Reapply [libcxx] [modules] Fix relative paths with absolute LIBCXX_INSTALL_MODULES_DIR

### DIFF
--- a/libcxx/modules/CMakeLists.txt
+++ b/libcxx/modules/CMakeLists.txt
@@ -206,14 +206,16 @@ add_custom_target(generate-cxx-modules
 # Configure the modules manifest.
 # Use the relative path between the installation and the module in the json
 # file. This allows moving the entire installation to a different location.
-#
-# Using a trailing slash in BASE_DIRECTORY, to produce a seemingly valid
-# absolute path, even if CMAKE_INSTALL_PREFIX is empty.
+if("${CMAKE_INSTALL_PREFIX}" STREQUAL "")
+  set(BASE_DIRECTORY "/")
+else()
+  set(BASE_DIRECTORY ${CMAKE_INSTALL_PREFIX})
+endif()
 cmake_path(ABSOLUTE_PATH LIBCXX_INSTALL_LIBRARY_DIR
-  BASE_DIRECTORY "${CMAKE_INSTALL_PREFIX}/"
+  BASE_DIRECTORY ${BASE_DIRECTORY}
   OUTPUT_VARIABLE ABS_LIBRARY_DIR)
 cmake_path(ABSOLUTE_PATH LIBCXX_INSTALL_MODULES_DIR
-  BASE_DIRECTORY "${CMAKE_INSTALL_PREFIX}/"
+  BASE_DIRECTORY ${BASE_DIRECTORY}
   OUTPUT_VARIABLE ABS_MODULES_DIR)
 file(RELATIVE_PATH LIBCXX_MODULE_RELATIVE_PATH
   ${ABS_LIBRARY_DIR}

--- a/libcxx/modules/CMakeLists.txt
+++ b/libcxx/modules/CMakeLists.txt
@@ -206,9 +206,18 @@ add_custom_target(generate-cxx-modules
 # Configure the modules manifest.
 # Use the relative path between the installation and the module in the json
 # file. This allows moving the entire installation to a different location.
+#
+# Using a trailing slash in BASE_DIRECTORY, to produce a seemingly valid
+# absolute path, even if CMAKE_INSTALL_PREFIX is empty.
+cmake_path(ABSOLUTE_PATH LIBCXX_INSTALL_LIBRARY_DIR
+  BASE_DIRECTORY "${CMAKE_INSTALL_PREFIX}/"
+  OUTPUT_VARIABLE ABS_LIBRARY_DIR)
+cmake_path(ABSOLUTE_PATH LIBCXX_INSTALL_MODULES_DIR
+  BASE_DIRECTORY "${CMAKE_INSTALL_PREFIX}/"
+  OUTPUT_VARIABLE ABS_MODULES_DIR)
 file(RELATIVE_PATH LIBCXX_MODULE_RELATIVE_PATH
-  ${CMAKE_INSTALL_PREFIX}/${LIBCXX_INSTALL_LIBRARY_DIR}
-  ${CMAKE_INSTALL_PREFIX}/${LIBCXX_INSTALL_MODULES_DIR})
+  ${ABS_LIBRARY_DIR}
+  ${ABS_MODULES_DIR})
 configure_file(
   "modules.json.in"
   "${LIBCXX_LIBRARY_DIR}/libc++.modules.json"


### PR DESCRIPTION
This reapplies 272d1b44efdedb68c194970a610f0ca1b7b769c5 (from #85756), which was reverted in
407937036fa7640f61f225474b1ea6623a40dbdd.

In the previous attempt, empty CMAKE_INSTALL_PREFIX was handled by quoting them, in d209d1340b99d4fbd325dffb5e13b757ab8264ea. That made the calls to cmake_path(ABSOLUTE_PATH) succeed, but the output paths of that weren't actually absolute, which was required by file(RELATIVE_PATH).

Avoid this issue by appending a slash to CMAKE_INSTALL_PREFIX, so we always get an absolute path, even if CMAKE_INSTALL_PREFIX was empty.