### PR TITLE
[libc] fix up the use of angle includes in include/

### DIFF
--- a/libc/include/arpa/inet.h.def
+++ b/libc/include/arpa/inet.h.def
@@ -9,7 +9,7 @@
 #ifndef LLVM_LIBC_ARPA_INET_H
 #define LLVM_LIBC_ARPA_INET_H
 
-#include <__llvm-libc-common.h>
+#include "__llvm-libc-common.h"
 
 #include <inttypes.h>
 

--- a/libc/include/assert.h.def
+++ b/libc/include/assert.h.def
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <__llvm-libc-common.h>
+#include "__llvm-libc-common.h"
 
 // This file may be usefully included multiple times to change assert()'s
 // definition based on NDEBUG.

--- a/libc/include/ctype.h.def
+++ b/libc/include/ctype.h.def
@@ -9,7 +9,7 @@
 #ifndef LLVM_LIBC_CTYPE_H
 #define LLVM_LIBC_CTYPE_H
 
-#include <__llvm-libc-common.h>
+#include "__llvm-libc-common.h"
 
 %%public_api()
 

--- a/libc/include/dirent.h.def
+++ b/libc/include/dirent.h.def
@@ -9,7 +9,7 @@
 #ifndef LLVM_LIBC_DIRENT_H
 #define LLVM_LIBC_DIRENT_H
 
-#include <__llvm-libc-common.h>
+#include "__llvm-libc-common.h"
 
 %%public_api()
 

--- a/libc/include/errno.h.def
+++ b/libc/include/errno.h.def
@@ -9,7 +9,7 @@
 #ifndef LLVM_LIBC_ERRNO_H
 #define LLVM_LIBC_ERRNO_H
 
-#include <__llvm-libc-common.h>
+#include "__llvm-libc-common.h"
 
 #ifdef __linux__
 
@@ -40,7 +40,7 @@
 #endif // ENOTRECOVERABLE
 
 #else // __linux__
-#include <llvm-libc-macros/generic-error-number-macros.h>
+#include "llvm-libc-macros/generic-error-number-macros.h"
 #endif
 
 #if !defined(__AMDGPU__) && !defined(__NVPTX__)

--- a/libc/include/fcntl.h.def
+++ b/libc/include/fcntl.h.def
@@ -9,8 +9,8 @@
 #ifndef LLVM_LIBC_FCNTL_H
 #define LLVM_LIBC_FCNTL_H
 
-#include <__llvm-libc-common.h>
-#include <llvm-libc-macros/fcntl-macros.h>
+#include "__llvm-libc-common.h"
+#include "llvm-libc-macros/fcntl-macros.h"
 
 %%public_api()
 

--- a/libc/include/features.h.def
+++ b/libc/include/features.h.def
@@ -9,8 +9,8 @@
 #ifndef LLVM_LIBC_FEATURES_H
 #define LLVM_LIBC_FEATURES_H
 
-#include <__llvm-libc-common.h>
-#include <llvm-libc-macros/features-macros.h>
+#include "__llvm-libc-common.h"
+#include "llvm-libc-macros/features-macros.h"
 
 %%public_api()
 

--- a/libc/include/fenv.h.def
+++ b/libc/include/fenv.h.def
@@ -9,8 +9,8 @@
 #ifndef LLVM_LIBC_FENV_H
 #define LLVM_LIBC_FENV_H
 
-#include <__llvm-libc-common.h>
-#include <llvm-libc-macros/fenv-macros.h>
+#include "__llvm-libc-common.h"
+#include "llvm-libc-macros/fenv-macros.h"
 
 %%public_api()
 

--- a/libc/include/float.h.def
+++ b/libc/include/float.h.def
@@ -9,6 +9,6 @@
 #ifndef LLVM_LIBC_FLOAT_H
 #define LLVM_LIBC_FLOAT_H
 
-#include <llvm-libc-macros/float-macros.h>
+#include "llvm-libc-macros/float-macros.h"
 
 #endif // LLVM_LIBC_FLOAT_H

--- a/libc/include/gpu/rpc.h.def
+++ b/libc/include/gpu/rpc.h.def
@@ -9,9 +9,9 @@
 #ifndef LLVM_LIBC_GPU_RPC_H
 #define LLVM_LIBC_GPU_RPC_H
 
-#include <__llvm-libc-common.h>
+#include "__llvm-libc-common.h"
 
-#include <llvm-libc-types/rpc_opcodes_t.h>
+#include "llvm-libc-types/rpc_opcodes_t.h"
 
 %%public_api()
 

--- a/libc/include/inttypes.h.def
+++ b/libc/include/inttypes.h.def
@@ -9,8 +9,8 @@
 #ifndef LLVM_LIBC_INTTYPES_H
 #define LLVM_LIBC_INTTYPES_H
 
-#include <__llvm-libc-common.h>
-#include <llvm-libc-macros/inttypes-macros.h>
+#include "__llvm-libc-common.h"
+#include "llvm-libc-macros/inttypes-macros.h"
 #include <stdint.h>
 
 %%public_api()

--- a/libc/include/limits.h.def
+++ b/libc/include/limits.h.def
@@ -9,6 +9,6 @@
 #ifndef LLVM_LIBC_LIMITS_H
 #define LLVM_LIBC_LIMITS_H
 
-#include <llvm-libc-macros/limits-macros.h>
+#include "llvm-libc-macros/limits-macros.h"
 
 #endif // LLVM_LIBC_LIMITS_H

--- a/libc/include/llvm-libc-macros/containerof-macro.h
+++ b/libc/include/llvm-libc-macros/containerof-macro.h
@@ -9,7 +9,7 @@
 #ifndef LLVM_LIBC_MACROS_CONTAINEROF_MACRO_H
 #define LLVM_LIBC_MACROS_CONTAINEROF_MACRO_H
 
-#include <llvm-libc-macros/offsetof-macro.h>
+#include "llvm-libc-macros/offsetof-macro.h"
 
 #define __containerof(ptr, type, member)                                       \
   ({                                                                           \

--- a/libc/include/llvm-libc-macros/sys-queue-macros.h
+++ b/libc/include/llvm-libc-macros/sys-queue-macros.h
@@ -9,8 +9,8 @@
 #ifndef LLVM_LIBC_MACROS_SYS_QUEUE_MACROS_H
 #define LLVM_LIBC_MACROS_SYS_QUEUE_MACROS_H
 
-#include <llvm-libc-macros/containerof-macro.h>
-#include <llvm-libc-macros/null-macro.h>
+#include "llvm-libc-macros/containerof-macro.h"
+#include "llvm-libc-macros/null-macro.h"
 
 #ifdef __cplusplus
 #define QUEUE_TYPEOF(type) type

--- a/libc/include/llvm-libc-types/__mutex_type.h
+++ b/libc/include/llvm-libc-types/__mutex_type.h
@@ -9,7 +9,7 @@
 #ifndef LLVM_LIBC_TYPES___MUTEX_TYPE_H
 #define LLVM_LIBC_TYPES___MUTEX_TYPE_H
 
-#include <llvm-libc-types/__futex_word.h>
+#include "llvm-libc-types/__futex_word.h"
 
 typedef struct {
   unsigned char __timed;

--- a/libc/include/llvm-libc-types/cookie_io_functions_t.h
+++ b/libc/include/llvm-libc-types/cookie_io_functions_t.h
@@ -9,9 +9,9 @@
 #ifndef LLVM_LIBC_TYPES_COOKIE_IO_FUNCTIONS_T_H
 #define LLVM_LIBC_TYPES_COOKIE_IO_FUNCTIONS_T_H
 
-#include <llvm-libc-types/off64_t.h>
-#include <llvm-libc-types/size_t.h>
-#include <llvm-libc-types/ssize_t.h>
+#include "llvm-libc-types/off64_t.h"
+#include "llvm-libc-types/size_t.h"
+#include "llvm-libc-types/ssize_t.h"
 
 typedef ssize_t cookie_read_function_t(void *, char *, size_t);
 typedef ssize_t cookie_write_function_t(void *, const char *, size_t);

--- a/libc/include/llvm-libc-types/fd_set.h
+++ b/libc/include/llvm-libc-types/fd_set.h
@@ -9,7 +9,7 @@
 #ifndef LLVM_LIBC_TYPES_FD_SET_H
 #define LLVM_LIBC_TYPES_FD_SET_H
 
-#include <llvm-libc-macros/sys-select-macros.h> // FD_SETSIZE
+#include "llvm-libc-macros/sys-select-macros.h" // FD_SETSIZE
 
 typedef struct {
   __FD_SET_WORD_TYPE __set[__FD_SET_ARRAYSIZE];

--- a/libc/include/llvm-libc-types/mtx_t.h
+++ b/libc/include/llvm-libc-types/mtx_t.h
@@ -9,7 +9,7 @@
 #ifndef LLVM_LIBC_TYPES_MTX_T_H
 #define LLVM_LIBC_TYPES_MTX_T_H
 
-#include <llvm-libc-types/__mutex_type.h>
+#include "llvm-libc-types/__mutex_type.h"
 
 typedef __mutex_type mtx_t;
 

--- a/libc/include/llvm-libc-types/once_flag.h
+++ b/libc/include/llvm-libc-types/once_flag.h
@@ -9,7 +9,7 @@
 #ifndef LLVM_LIBC_TYPES_ONCE_FLAG_H
 #define LLVM_LIBC_TYPES_ONCE_FLAG_H
 
-#include <llvm-libc-types/__futex_word.h>
+#include "llvm-libc-types/__futex_word.h"
 
 #ifdef __linux__
 typedef __futex_word once_flag;

--- a/libc/include/llvm-libc-types/pthread_attr_t.h
+++ b/libc/include/llvm-libc-types/pthread_attr_t.h
@@ -9,7 +9,7 @@
 #ifndef LLVM_LIBC_TYPES_PTHREAD_ATTR_T_H
 #define LLVM_LIBC_TYPES_PTHREAD_ATTR_T_H
 
-#include <llvm-libc-types/size_t.h>
+#include "llvm-libc-types/size_t.h"
 
 typedef struct {
   int __detachstate;

--- a/libc/include/llvm-libc-types/pthread_mutex_t.h
+++ b/libc/include/llvm-libc-types/pthread_mutex_t.h
@@ -9,7 +9,7 @@
 #ifndef LLVM_LIBC_TYPES_PTHREAD_MUTEX_T_H
 #define LLVM_LIBC_TYPES_PTHREAD_MUTEX_T_H
 
-#include <llvm-libc-types/__mutex_type.h>
+#include "llvm-libc-types/__mutex_type.h"
 
 typedef __mutex_type pthread_mutex_t;
 

--- a/libc/include/llvm-libc-types/pthread_once_t.h
+++ b/libc/include/llvm-libc-types/pthread_once_t.h
@@ -9,7 +9,7 @@
 #ifndef LLVM_LIBC_TYPES_PTHREAD_ONCE_T_H
 #define LLVM_LIBC_TYPES_PTHREAD_ONCE_T_H
 
-#include <llvm-libc-types/__futex_word.h>
+#include "llvm-libc-types/__futex_word.h"
 
 #ifdef __linux__
 typedef __futex_word pthread_once_t;

--- a/libc/include/llvm-libc-types/pthread_t.h
+++ b/libc/include/llvm-libc-types/pthread_t.h
@@ -9,7 +9,7 @@
 #ifndef LLVM_LIBC_TYPES_PTHREAD_T_H
 #define LLVM_LIBC_TYPES_PTHREAD_T_H
 
-#include <llvm-libc-types/__thread_type.h>
+#include "llvm-libc-types/__thread_type.h"
 
 typedef __thread_type pthread_t;
 

--- a/libc/include/llvm-libc-types/siginfo_t.h
+++ b/libc/include/llvm-libc-types/siginfo_t.h
@@ -9,10 +9,10 @@
 #ifndef LLVM_LIBC_TYPES_SIGINFO_T_H
 #define LLVM_LIBC_TYPES_SIGINFO_T_H
 
-#include <llvm-libc-types/clock_t.h>
-#include <llvm-libc-types/pid_t.h>
-#include <llvm-libc-types/uid_t.h>
-#include <llvm-libc-types/union_sigval.h>
+#include "llvm-libc-types/clock_t.h"
+#include "llvm-libc-types/pid_t.h"
+#include "llvm-libc-types/uid_t.h"
+#include "llvm-libc-types/union_sigval.h"
 
 #define SI_MAX_SIZE 128
 

--- a/libc/include/llvm-libc-types/sigset_t.h
+++ b/libc/include/llvm-libc-types/sigset_t.h
@@ -9,7 +9,7 @@
 #ifndef LLVM_LIBC_TYPES_SIGSET_T_H
 #define LLVM_LIBC_TYPES_SIGSET_T_H
 
-#include <llvm-libc-macros/signal-macros.h>
+#include "llvm-libc-macros/signal-macros.h"
 
 // This definition can be adjusted/specialized for different targets and
 // platforms as necessary. This definition works for Linux on most targets.

--- a/libc/include/llvm-libc-types/stack_t.h
+++ b/libc/include/llvm-libc-types/stack_t.h
@@ -9,7 +9,7 @@
 #ifndef LLVM_LIBC_TYPES_STACK_T_H
 #define LLVM_LIBC_TYPES_STACK_T_H
 
-#include <llvm-libc-types/size_t.h>
+#include "llvm-libc-types/size_t.h"
 
 typedef struct {
   // The order of the fields declared here should match the kernel definition

--- a/libc/include/llvm-libc-types/struct_dirent.h
+++ b/libc/include/llvm-libc-types/struct_dirent.h
@@ -9,8 +9,8 @@
 #ifndef LLVM_LIBC_TYPES_STRUCT_DIRENT_H
 #define LLVM_LIBC_TYPES_STRUCT_DIRENT_H
 
-#include <llvm-libc-types/ino_t.h>
-#include <llvm-libc-types/off_t.h>
+#include "llvm-libc-types/ino_t.h"
+#include "llvm-libc-types/off_t.h"
 
 struct dirent {
   ino_t d_ino;

--- a/libc/include/llvm-libc-types/struct_epoll_event.h
+++ b/libc/include/llvm-libc-types/struct_epoll_event.h
@@ -9,7 +9,7 @@
 #ifndef LLVM_LIBC_TYPES_STRUCT_EPOLL_EVENT_H
 #define LLVM_LIBC_TYPES_STRUCT_EPOLL_EVENT_H
 
-#include <llvm-libc-types/struct_epoll_data.h>
+#include "llvm-libc-types/struct_epoll_data.h"
 
 typedef struct epoll_event {
   __UINT32_TYPE__ events;

--- a/libc/include/llvm-libc-types/struct_rlimit.h
+++ b/libc/include/llvm-libc-types/struct_rlimit.h
@@ -9,7 +9,7 @@
 #ifndef LLVM_LIBC_TYPES_STRUCT_RLIMIT_H
 #define LLVM_LIBC_TYPES_STRUCT_RLIMIT_H
 
-#include <llvm-libc-types/rlim_t.h>
+#include "llvm-libc-types/rlim_t.h"
 
 struct rlimit {
   rlim_t rlim_cur;

--- a/libc/include/llvm-libc-types/struct_rusage.h
+++ b/libc/include/llvm-libc-types/struct_rusage.h
@@ -9,7 +9,7 @@
 #ifndef LLVM_LIBC_TYPES_STRUCT_RUSAGE_H
 #define LLVM_LIBC_TYPES_STRUCT_RUSAGE_H
 
-#include <llvm-libc-types/struct_timeval.h>
+#include "llvm-libc-types/struct_timeval.h"
 
 struct rusage {
   struct timeval ru_utime;

--- a/libc/include/llvm-libc-types/struct_sched_param.h
+++ b/libc/include/llvm-libc-types/struct_sched_param.h
@@ -9,9 +9,9 @@
 #ifndef LLVM_LIBC_TYPES_STRUCT_SCHED_PARAM_H
 #define LLVM_LIBC_TYPES_STRUCT_SCHED_PARAM_H
 
-#include <llvm-libc-types/pid_t.h>
-#include <llvm-libc-types/struct_timespec.h>
-#include <llvm-libc-types/time_t.h>
+#include "llvm-libc-types/pid_t.h"
+#include "llvm-libc-types/struct_timespec.h"
+#include "llvm-libc-types/time_t.h"
 
 struct sched_param {
   // Process or thread execution scheduling priority.

--- a/libc/include/llvm-libc-types/struct_sigaction.h
+++ b/libc/include/llvm-libc-types/struct_sigaction.h
@@ -9,8 +9,8 @@
 #ifndef LLVM_LIBC_TYPES_STRUCT_SIGACTION_H
 #define LLVM_LIBC_TYPES_STRUCT_SIGACTION_H
 
-#include <llvm-libc-types/siginfo_t.h>
-#include <llvm-libc-types/sigset_t.h>
+#include "llvm-libc-types/siginfo_t.h"
+#include "llvm-libc-types/sigset_t.h"
 
 struct sigaction {
   union {

--- a/libc/include/llvm-libc-types/struct_sockaddr.h
+++ b/libc/include/llvm-libc-types/struct_sockaddr.h
@@ -9,7 +9,7 @@
 #ifndef LLVM_LIBC_TYPES_STRUCT_SOCKADDR_H
 #define LLVM_LIBC_TYPES_STRUCT_SOCKADDR_H
 
-#include <llvm-libc-types/sa_family_t.h>
+#include "llvm-libc-types/sa_family_t.h"
 
 struct sockaddr {
   sa_family_t sa_family;

--- a/libc/include/llvm-libc-types/struct_sockaddr_un.h
+++ b/libc/include/llvm-libc-types/struct_sockaddr_un.h
@@ -9,7 +9,7 @@
 #ifndef LLVM_LIBC_TYPES_STRUCT_SOCKADDR_UN_H
 #define LLVM_LIBC_TYPES_STRUCT_SOCKADDR_UN_H
 
-#include <llvm-libc-types/sa_family_t.h>
+#include "llvm-libc-types/sa_family_t.h"
 
 // This is the sockaddr specialization for AF_UNIX or AF_LOCAL sockets, as
 // defined by posix.

--- a/libc/include/llvm-libc-types/struct_stat.h
+++ b/libc/include/llvm-libc-types/struct_stat.h
@@ -9,16 +9,16 @@
 #ifndef LLVM_LIBC_TYPES_STRUCT_STAT_H
 #define LLVM_LIBC_TYPES_STRUCT_STAT_H
 
-#include <llvm-libc-types/blkcnt_t.h>
-#include <llvm-libc-types/blksize_t.h>
-#include <llvm-libc-types/dev_t.h>
-#include <llvm-libc-types/gid_t.h>
-#include <llvm-libc-types/ino_t.h>
-#include <llvm-libc-types/mode_t.h>
-#include <llvm-libc-types/nlink_t.h>
-#include <llvm-libc-types/off_t.h>
-#include <llvm-libc-types/struct_timespec.h>
-#include <llvm-libc-types/uid_t.h>
+#include "llvm-libc-types/blkcnt_t.h"
+#include "llvm-libc-types/blksize_t.h"
+#include "llvm-libc-types/dev_t.h"
+#include "llvm-libc-types/gid_t.h"
+#include "llvm-libc-types/ino_t.h"
+#include "llvm-libc-types/mode_t.h"
+#include "llvm-libc-types/nlink_t.h"
+#include "llvm-libc-types/off_t.h"
+#include "llvm-libc-types/struct_timespec.h"
+#include "llvm-libc-types/uid_t.h"
 
 struct stat {
   dev_t st_dev;

--- a/libc/include/llvm-libc-types/struct_termios.h
+++ b/libc/include/llvm-libc-types/struct_termios.h
@@ -9,9 +9,9 @@
 #ifndef __LLVM_LIBC_TYPES_STRUCT_TERMIOS_H__
 #define __LLVM_LIBC_TYPES_STRUCT_TERMIOS_H__
 
-#include <llvm-libc-types/cc_t.h>
-#include <llvm-libc-types/speed_t.h>
-#include <llvm-libc-types/tcflag_t.h>
+#include "llvm-libc-types/cc_t.h"
+#include "llvm-libc-types/speed_t.h"
+#include "llvm-libc-types/tcflag_t.h"
 
 struct termios {
   tcflag_t c_iflag; // Input mode flags

--- a/libc/include/llvm-libc-types/struct_timespec.h
+++ b/libc/include/llvm-libc-types/struct_timespec.h
@@ -9,7 +9,7 @@
 #ifndef LLVM_LIBC_TYPES_STRUCT_TIMESPEC_H
 #define LLVM_LIBC_TYPES_STRUCT_TIMESPEC_H
 
-#include <llvm-libc-types/time_t.h>
+#include "llvm-libc-types/time_t.h"
 
 struct timespec {
   time_t tv_sec; /* Seconds.  */

--- a/libc/include/llvm-libc-types/struct_timeval.h
+++ b/libc/include/llvm-libc-types/struct_timeval.h
@@ -9,8 +9,8 @@
 #ifndef LLVM_LIBC_TYPES_STRUCT_TIMEVAL_H
 #define LLVM_LIBC_TYPES_STRUCT_TIMEVAL_H
 
-#include <llvm-libc-types/suseconds_t.h>
-#include <llvm-libc-types/time_t.h>
+#include "llvm-libc-types/suseconds_t.h"
+#include "llvm-libc-types/time_t.h"
 
 struct timeval {
   time_t tv_sec;       // Seconds

--- a/libc/include/llvm-libc-types/thrd_t.h
+++ b/libc/include/llvm-libc-types/thrd_t.h
@@ -9,7 +9,7 @@
 #ifndef LLVM_LIBC_TYPES_THRD_T_H
 #define LLVM_LIBC_TYPES_THRD_T_H
 
-#include <llvm-libc-types/__thread_type.h>
+#include "llvm-libc-types/__thread_type.h"
 
 typedef __thread_type thrd_t;
 

--- a/libc/include/math.h.def
+++ b/libc/include/math.h.def
@@ -9,9 +9,9 @@
 #ifndef LLVM_LIBC_MATH_H
 #define LLVM_LIBC_MATH_H
 
-#include <__llvm-libc-common.h>
-#include <llvm-libc-macros/math-macros.h>
-#include <llvm-libc-types/float128.h>
+#include "__llvm-libc-common.h"
+#include "llvm-libc-macros/math-macros.h"
+#include "llvm-libc-types/float128.h"
 
 
 %%public_api()

--- a/libc/include/pthread.h.def
+++ b/libc/include/pthread.h.def
@@ -9,7 +9,7 @@
 #ifndef LLVM_LIBC_PTHREAD_H
 #define LLVM_LIBC_PTHREAD_H
 
-#include <__llvm-libc-common.h>
+#include "__llvm-libc-common.h"
 
 #define PTHREAD_STACK_MIN (1 << 14) // 16KB
 

--- a/libc/include/sched.h.def
+++ b/libc/include/sched.h.def
@@ -9,8 +9,8 @@
 #ifndef LLVM_LIBC_SCHED_H
 #define LLVM_LIBC_SCHED_H
 
-#include <__llvm-libc-common.h>
-#include <llvm-libc-macros/sched-macros.h>
+#include "__llvm-libc-common.h"
+#include "llvm-libc-macros/sched-macros.h"
 
 %%public_api()
 

--- a/libc/include/search.h.def
+++ b/libc/include/search.h.def
@@ -9,7 +9,7 @@
 #ifndef LLVM_LIBC_SEARCH_H
 #define LLVM_LIBC_SEARCH_H
 
-#include <__llvm-libc-common.h>
+#include "__llvm-libc-common.h"
 #define __need_size_t
 #include <stddef.h>
 

--- a/libc/include/setjmp.h.def
+++ b/libc/include/setjmp.h.def
@@ -9,7 +9,7 @@
 #ifndef LLVM_LIBC_SETJMP_H
 #define LLVM_LIBC_SETJMP_H
 
-#include <__llvm-libc-common.h>
+#include "__llvm-libc-common.h"
 
 %%public_api()
 

--- a/libc/include/signal.h.def
+++ b/libc/include/signal.h.def
@@ -9,12 +9,12 @@
 #ifndef LLVM_LIBC_SIGNAL_H
 #define LLVM_LIBC_SIGNAL_H
 
-#include <__llvm-libc-common.h>
+#include "__llvm-libc-common.h"
 
 #define __need_size_t
 #include <stddef.h>
 
-#include <llvm-libc-macros/signal-macros.h>
+#include "llvm-libc-macros/signal-macros.h"
 
 %%public_api()
 

--- a/libc/include/spawn.h.def
+++ b/libc/include/spawn.h.def
@@ -9,7 +9,7 @@
 #ifndef LLVM_LIBC_SPAWN_H
 #define LLVM_LIBC_SPAWN_H
 
-#include <__llvm-libc-common.h>
+#include "__llvm-libc-common.h"
 
 %%public_api()
 

--- a/libc/include/stdbit.h.def
+++ b/libc/include/stdbit.h.def
@@ -9,10 +9,10 @@
 #ifndef LLVM_LIBC_STDBIT_H
 #define LLVM_LIBC_STDBIT_H
 
-#include <__llvm-libc-common.h>
+#include "__llvm-libc-common.h"
 
 %%public_api()
 
-#include <llvm-libc-macros/stdbit-macros.h>
+#include "llvm-libc-macros/stdbit-macros.h"
 
 #endif // LLVM_LIBC_STDBIT_H

--- a/libc/include/stdckdint.h.def
+++ b/libc/include/stdckdint.h.def
@@ -9,10 +9,10 @@
 #ifndef LLVM_LIBC_STDCKDINT_H
 #define LLVM_LIBC_STDCKDINT_H
 
-#include <__llvm-libc-common.h>
+#include "__llvm-libc-common.h"
 
 %%public_api()
 
-#include <llvm-libc-macros/stdckdint-macros.h>
+#include "llvm-libc-macros/stdckdint-macros.h"
 
 #endif // LLVM_LIBC_STDCKDINT_H

--- a/libc/include/stdfix.h.def
+++ b/libc/include/stdfix.h.def
@@ -9,8 +9,8 @@
 #ifndef LLVM_LIBC_STDFIX_H
 #define LLVM_LIBC_STDFIX_H
 
-#include <__llvm-libc-common.h>
-#include <llvm-libc-macros/stdfix-macros.h>
+#include "__llvm-libc-common.h"
+#include "llvm-libc-macros/stdfix-macros.h"
 
 // From ISO/IEC TR 18037:2008 standard:
 // https://www.iso.org/standard/51126.html

--- a/libc/include/stdint.h.def
+++ b/libc/include/stdint.h.def
@@ -9,6 +9,6 @@
 #ifndef LLVM_LIBC_STDINT_H
 #define LLVM_LIBC_STDINT_H
 
-#include <llvm-libc-macros/stdint-macros.h>
+#include "llvm-libc-macros/stdint-macros.h"
 
 #endif // LLVM_LIBC_STDINT_H

--- a/libc/include/stdio.h.def
+++ b/libc/include/stdio.h.def
@@ -9,9 +9,9 @@
 #ifndef LLVM_LIBC_STDIO_H
 #define LLVM_LIBC_STDIO_H
 
-#include <__llvm-libc-common.h>
-#include <llvm-libc-macros/file-seek-macros.h>
-#include <llvm-libc-macros/stdio-macros.h>
+#include "__llvm-libc-common.h"
+#include "llvm-libc-macros/file-seek-macros.h"
+#include "llvm-libc-macros/stdio-macros.h"
 
 #include <stdarg.h>
 

--- a/libc/include/stdlib.h.def
+++ b/libc/include/stdlib.h.def
@@ -9,8 +9,8 @@
 #ifndef LLVM_LIBC_STDLIB_H
 #define LLVM_LIBC_STDLIB_H
 
-#include <__llvm-libc-common.h>
-#include <llvm-libc-macros/stdlib-macros.h>
+#include "__llvm-libc-common.h"
+#include "llvm-libc-macros/stdlib-macros.h"
 
 %%public_api()
 

--- a/libc/include/string.h.def
+++ b/libc/include/string.h.def
@@ -9,9 +9,9 @@
 #ifndef LLVM_LIBC_STRING_H
 #define LLVM_LIBC_STRING_H
 
-#include <__llvm-libc-common.h>
+#include "__llvm-libc-common.h"
 
-#include <llvm-libc-macros/null-macro.h>
+#include "llvm-libc-macros/null-macro.h"
 
 %%public_api()
 

--- a/libc/include/strings.h.def
+++ b/libc/include/strings.h.def
@@ -9,7 +9,7 @@
 #ifndef LLVM_LIBC_STRINGS_H
 #define LLVM_LIBC_STRINGS_H
 
-#include <__llvm-libc-common.h>
+#include "__llvm-libc-common.h"
 
 %%public_api()
 

--- a/libc/include/sys/auxv.h.def
+++ b/libc/include/sys/auxv.h.def
@@ -9,9 +9,9 @@
 #ifndef LLVM_LIBC_SYS_AUXV_H
 #define LLVM_LIBC_SYS_AUXV_H
 
-#include <__llvm-libc-common.h>
+#include "__llvm-libc-common.h"
 
-#include <llvm-libc-macros/sys-auxv-macros.h>
+#include "llvm-libc-macros/sys-auxv-macros.h"
 
 %%public_api()
 

--- a/libc/include/sys/epoll.h.def
+++ b/libc/include/sys/epoll.h.def
@@ -9,7 +9,7 @@
 #ifndef LLVM_LIBC_SYS_EPOLL_H
 #define LLVM_LIBC_SYS_EPOLL_H
 
-#include <__llvm-libc-common.h>
+#include "__llvm-libc-common.h"
 
 %%public_api()
 

--- a/libc/include/sys/ioctl.h.def
+++ b/libc/include/sys/ioctl.h.def
@@ -9,9 +9,9 @@
 #ifndef LLVM_LIBC_SYS_IOCTL_H
 #define LLVM_LIBC_SYS_IOCTL_H
 
-#include <__llvm-libc-common.h>
+#include "__llvm-libc-common.h"
 
-#include <llvm-libc-macros/sys-ioctl-macros.h>
+#include "llvm-libc-macros/sys-ioctl-macros.h"
 
 %%public_api()
 

--- a/libc/include/sys/mman.h.def
+++ b/libc/include/sys/mman.h.def
@@ -9,9 +9,9 @@
 #ifndef LLVM_LIBC_SYS_MMAN_H
 #define LLVM_LIBC_SYS_MMAN_H
 
-#include <__llvm-libc-common.h>
+#include "__llvm-libc-common.h"
 
-#include <llvm-libc-macros/sys-mman-macros.h>
+#include "llvm-libc-macros/sys-mman-macros.h"
 
 %%public_api()
 

--- a/libc/include/sys/prctl.h.def
+++ b/libc/include/sys/prctl.h.def
@@ -9,7 +9,7 @@
 #ifndef LLVM_LIBC_SYS_PRCTL_H
 #define LLVM_LIBC_SYS_PRCTL_H
 
-#include <__llvm-libc-common.h>
+#include "__llvm-libc-common.h"
 
 // Process control is highly platform specific, so the platform usually defines
 // the macros itself.

--- a/libc/include/sys/queue.h
+++ b/libc/include/sys/queue.h
@@ -9,6 +9,6 @@
 #ifndef SYS_QUEUE_H
 #define SYS_QUEUE_H
 
-#include <llvm-libc-macros/sys-queue-macros.h>
+#include "llvm-libc-macros/sys-queue-macros.h"
 
 #endif // SYS_QUEUE_H

--- a/libc/include/sys/random.h.def
+++ b/libc/include/sys/random.h.def
@@ -9,9 +9,9 @@
 #ifndef LLVM_LIBC_SYS_RANDOM_H
 #define LLVM_LIBC_SYS_RANDOM_H
 
-#include <__llvm-libc-common.h>
+#include "__llvm-libc-common.h"
 
-#include <llvm-libc-macros/sys-random-macros.h>
+#include "llvm-libc-macros/sys-random-macros.h"
 
 %%public_api()
 

--- a/libc/include/sys/resource.h.def
+++ b/libc/include/sys/resource.h.def
@@ -9,9 +9,9 @@
 #ifndef LLVM_LIBC_SYS_RESOURCE_H
 #define LLVM_LIBC_SYS_RESOURCE_H
 
-#include <__llvm-libc-common.h>
+#include "__llvm-libc-common.h"
 
-#include <llvm-libc-macros/sys-resource-macros.h>
+#include "llvm-libc-macros/sys-resource-macros.h"
 
 %%public_api()
 

--- a/libc/include/sys/select.h.def
+++ b/libc/include/sys/select.h.def
@@ -9,9 +9,9 @@
 #ifndef LLVM_LIBC_SYS_SELECT_H
 #define LLVM_LIBC_SYS_SELECT_H
 
-#include <__llvm-libc-common.h>
+#include "__llvm-libc-common.h"
 
-#include <llvm-libc-macros/sys-select-macros.h>
+#include "llvm-libc-macros/sys-select-macros.h"
 
 %%public_api()
 

--- a/libc/include/sys/sendfile.h.def
+++ b/libc/include/sys/sendfile.h.def
@@ -9,7 +9,7 @@
 #ifndef LLVM_LIBC_SYS_SENDFILE_H
 #define LLVM_LIBC_SYS_SENDFILE_H
 
-#include <__llvm-libc-common.h>
+#include "__llvm-libc-common.h"
 
 %%public_api()
 

--- a/libc/include/sys/socket.h.def
+++ b/libc/include/sys/socket.h.def
@@ -9,9 +9,9 @@
 #ifndef LLVM_LIBC_SYS_SOCKET_H
 #define LLVM_LIBC_SYS_SOCKET_H
 
-#include <__llvm-libc-common.h>
+#include "__llvm-libc-common.h"
 
-#include <llvm-libc-macros/sys-socket-macros.h>
+#include "llvm-libc-macros/sys-socket-macros.h"
 
 %%public_api()
 

--- a/libc/include/sys/stat.h.def
+++ b/libc/include/sys/stat.h.def
@@ -9,9 +9,9 @@
 #ifndef LLVM_LIBC_SYS_STAT_H
 #define LLVM_LIBC_SYS_STAT_H
 
-#include <__llvm-libc-common.h>
+#include "__llvm-libc-common.h"
 
-#include <llvm-libc-macros/sys-stat-macros.h>
+#include "llvm-libc-macros/sys-stat-macros.h"
 
 %%public_api()
 

--- a/libc/include/sys/time.h.def
+++ b/libc/include/sys/time.h.def
@@ -9,11 +9,11 @@
 #ifndef LLVM_LIBC_SYS_TIME_H
 #define LLVM_LIBC_SYS_TIME_H
 
-#include <__llvm-libc-common.h>
+#include "__llvm-libc-common.h"
 
-#include <llvm-libc-types/struct_timeval.h>
+#include "llvm-libc-types/struct_timeval.h"
 
-#include <llvm-libc-macros/sys-time-macros.h>
+#include "llvm-libc-macros/sys-time-macros.h"
 
 %%public_api()
 

--- a/libc/include/sys/types.h.def
+++ b/libc/include/sys/types.h.def
@@ -9,7 +9,7 @@
 #ifndef LLVM_LIBC_SYS_TYPES_H
 #define LLVM_LIBC_SYS_TYPES_H
 
-#include <__llvm-libc-common.h>
+#include "__llvm-libc-common.h"
 
 %%public_api()
 

--- a/libc/include/sys/utsname.h.def
+++ b/libc/include/sys/utsname.h.def
@@ -9,7 +9,7 @@
 #ifndef LLVM_LIBC_SYS_UTSNAME_H
 #define LLVM_LIBC_SYS_UTSNAME_H
 
-#include <__llvm-libc-common.h>
+#include "__llvm-libc-common.h"
 
 %%public_api()
 

--- a/libc/include/sys/wait.h.def
+++ b/libc/include/sys/wait.h.def
@@ -9,9 +9,9 @@
 #ifndef LLVM_LIBC_SYS_WAIT_H
 #define LLVM_LIBC_SYS_WAIT_H
 
-#include <__llvm-libc-common.h>
+#include "__llvm-libc-common.h"
 
-#include <llvm-libc-macros/sys-wait-macros.h>
+#include "llvm-libc-macros/sys-wait-macros.h"
 
 %%public_api()
 

--- a/libc/include/termios.h.def
+++ b/libc/include/termios.h.def
@@ -9,8 +9,8 @@
 #ifndef LLVM_LIBC_TERMIOS_H
 #define LLVM_LIBC_TERMIOS_H
 
-#include <__llvm-libc-common.h>
-#include <llvm-libc-macros/termios-macros.h>
+#include "__llvm-libc-common.h"
+#include "llvm-libc-macros/termios-macros.h"
 
 %%public_api()
 

--- a/libc/include/threads.h.def
+++ b/libc/include/threads.h.def
@@ -9,7 +9,7 @@
 #ifndef LLVM_LIBC_THREADS_H
 #define LLVM_LIBC_THREADS_H
 
-#include <__llvm-libc-common.h>
+#include "__llvm-libc-common.h"
 
 %%public_api()
 

--- a/libc/include/time.h.def
+++ b/libc/include/time.h.def
@@ -9,8 +9,8 @@
 #ifndef LLVM_LIBC_TIME_H
 #define LLVM_LIBC_TIME_H
 
-#include <__llvm-libc-common.h>
-#include <llvm-libc-macros/time-macros.h>
+#include "__llvm-libc-common.h"
+#include "llvm-libc-macros/time-macros.h"
 
 %%public_api()
 

--- a/libc/include/uchar.h.def
+++ b/libc/include/uchar.h.def
@@ -9,7 +9,7 @@
 #ifndef LLVM_LIBC_UCHAR_H
 #define LLVM_LIBC_UCHAR_H
 
-#include <__llvm-libc-common.h>
+#include "__llvm-libc-common.h"
 
 %%public_api()
 

--- a/libc/include/unistd.h.def
+++ b/libc/include/unistd.h.def
@@ -9,9 +9,9 @@
 #ifndef LLVM_LIBC_UNISTD_H
 #define LLVM_LIBC_UNISTD_H
 
-#include <__llvm-libc-common.h>
-#include <llvm-libc-macros/file-seek-macros.h>
-#include <llvm-libc-macros/unistd-macros.h>
+#include "__llvm-libc-common.h"
+#include "llvm-libc-macros/file-seek-macros.h"
+#include "llvm-libc-macros/unistd-macros.h"
 
 %%public_api()
 

--- a/libc/include/wchar.h.def
+++ b/libc/include/wchar.h.def
@@ -9,8 +9,8 @@
 #ifndef LLVM_LIBC_WCHAR_H
 #define LLVM_LIBC_WCHAR_H
 
-#include <__llvm-libc-common.h>
-#include <llvm-libc-macros/wchar-macros.h>
+#include "__llvm-libc-common.h"
+#include "llvm-libc-macros/wchar-macros.h"
 
 %%public_api()
 


### PR DESCRIPTION
Performed en-masse via:

    $ grep -rn "#include <ll" libc/include -l | \
      xargs perl -pi -e 's/#include <ll(.*)>/#include "ll$1"/'
    $ grep -rn "#include <__" libc/include -l | \
      xargs perl -pi -e 's/#include <__(.*)>/#include "__$1"/'

Link: #83463
Link: #83210
