### PR TITLE
[mlir][Vector] Fix an assertion on failing cast in vector-transfer-flatten-patterns

### DIFF
--- a/mlir/lib/Dialect/Vector/Transforms/VectorLinearize.cpp
+++ b/mlir/lib/Dialect/Vector/Transforms/VectorLinearize.cpp
@@ -22,9 +22,9 @@ using namespace mlir;
 static bool isLessThanTargetBitWidth(Operation *op, unsigned targetBitWidth) {
   auto resultTypes = op->getResultTypes();
   for (auto resType : resultTypes) {
-    VectorType vecType = cast<VectorType>(resType);
+    VectorType vecType = dyn_cast<VectorType>(resType);
     // Reject index since getElementTypeBitWidth will abort for Index types.
-    if (vecType.getElementType().isIndex())
+    if (!vecType || vecType.getElementType().isIndex())
       return false;
     unsigned trailingVecDimBitWidth =
         vecType.getShape().back() * vecType.getElementTypeBitWidth();

--- a/mlir/test/Dialect/Vector/linearize.mlir
+++ b/mlir/test/Dialect/Vector/linearize.mlir
@@ -93,6 +93,8 @@ func.func @test_index_no_linearize(%arg0: vector<2x2xindex>, %arg1: vector<2x2xi
 
 // -----
 
+// vectorizable operation (arith.mulf) with tensor result types.
+
 // CHECK-LABEL: func.func @nonvec_result
 // CHECK128-LABEL: func.func @nonvec_result
 // CHECK0-LABEL: func.func @nonvec_result

--- a/mlir/test/Dialect/Vector/linearize.mlir
+++ b/mlir/test/Dialect/Vector/linearize.mlir
@@ -93,13 +93,16 @@ func.func @test_index_no_linearize(%arg0: vector<2x2xindex>, %arg1: vector<2x2xi
 
 // -----
 
-// This test exists to make sure it doesn't hit an assert and compiles through.
-func.func @simple_mul(%arg0: tensor<4xf32>, %arg1: tensor<4xf32>) -> (tensor<4xf32>, tensor<4xf32>) {
+// CHECK-LABEL: func.func @nonvec_result
+// CHECK128-LABEL: func.func @nonvec_result
+// CHECK0-LABEL: func.func @nonvec_result
+// CHECK-SAME: (%[[ARG0:.*]]: tensor<4xf32>, %[[ARG1:.*]]: tensor<4xf32>)
+// CHECK128-SAME: (%[[ARG0:.*]]: tensor<4xf32>, %[[ARG1:.*]]: tensor<4xf32>)
+// CHECK0-SAME: (%[[ARG0:.*]]: tensor<4xf32>, %[[ARG1:.*]]: tensor<4xf32>)
+func.func @nonvec_result(%arg0: tensor<4xf32>, %arg1: tensor<4xf32>) -> (tensor<4xf32>, tensor<4xf32>) {
+    // CHECK: %[[MULF:.*]] = arith.mulf %[[ARG0]], %[[ARG1]]
+    // CHECK128: %[[MULF:.*]] = arith.mulf %[[ARG0]], %[[ARG1]]
+    // CHECK0: %[[MULF:.*]] = arith.mulf %[[ARG0]], %[[ARG1]]
     %0 = arith.mulf %arg0, %arg1 : tensor<4xf32>
     return %0, %arg0 : tensor<4xf32>, tensor<4xf32>
 }
-
-// CHECK-LABEL: func.func @simple_mul
-// CHECK128-LABEL: func.func @simple_mul
-// CHECK0-LABEL: func.func @simple_mul
-

--- a/mlir/test/Dialect/Vector/linearize.mlir
+++ b/mlir/test/Dialect/Vector/linearize.mlir
@@ -95,16 +95,11 @@ func.func @test_index_no_linearize(%arg0: vector<2x2xindex>, %arg1: vector<2x2xi
 
 // vectorizable operation (arith.mulf) with tensor result types.
 
-// CHECK-LABEL: func.func @nonvec_result
-// CHECK128-LABEL: func.func @nonvec_result
-// CHECK0-LABEL: func.func @nonvec_result
-// CHECK-SAME: (%[[ARG0:.*]]: tensor<4xf32>, %[[ARG1:.*]]: tensor<4xf32>)
-// CHECK128-SAME: (%[[ARG0:.*]]: tensor<4xf32>, %[[ARG1:.*]]: tensor<4xf32>)
-// CHECK0-SAME: (%[[ARG0:.*]]: tensor<4xf32>, %[[ARG1:.*]]: tensor<4xf32>)
-func.func @nonvec_result(%arg0: tensor<4xf32>, %arg1: tensor<4xf32>) -> (tensor<4xf32>, tensor<4xf32>) {
-    // CHECK: %[[MULF:.*]] = arith.mulf %[[ARG0]], %[[ARG1]]
-    // CHECK128: %[[MULF:.*]] = arith.mulf %[[ARG0]], %[[ARG1]]
-    // CHECK0: %[[MULF:.*]] = arith.mulf %[[ARG0]], %[[ARG1]]
-    %0 = arith.mulf %arg0, %arg1 : tensor<4xf32>
-    return %0, %arg0 : tensor<4xf32>, tensor<4xf32>
+func.func @nonvec_result(%arg0: tensor<2x2xf32>, %arg1: tensor<2x2xf32>) -> (tensor<2x2xf32>, tensor<2x2xf32>) {
+    // CHECK: %[[MULF:.*]] = arith.mulf %arg0, %arg1 : tensor<2x2xf32>
+    // CHECK128: %[[MULF:.*]] = arith.mulf %arg0, %arg1 : tensor<2x2xf32>
+    // CHECK0: %[[MULF:.*]] = arith.mulf %arg0, %arg1 : tensor<2x2xf32>
+    %0 = arith.mulf %arg0, %arg1 : tensor<2x2xf32>
+
+    return %0, %arg0 : tensor<2x2xf32>, tensor<2x2xf32>
 }

--- a/mlir/test/Dialect/Vector/linearize.mlir
+++ b/mlir/test/Dialect/Vector/linearize.mlir
@@ -90,3 +90,16 @@ func.func @test_index_no_linearize(%arg0: vector<2x2xindex>, %arg1: vector<2x2xi
     %0 = arith.addi %arg0, %arg1 : vector<2x2xindex>
     return %0 : vector<2x2xindex>
 }
+
+// -----
+
+// This test exists to make sure it doesn't hit an assert and compiles through.
+func.func @simple_mul(%arg0: tensor<4xf32>, %arg1: tensor<4xf32>) -> (tensor<4xf32>, tensor<4xf32>) {
+    %0 = arith.mulf %arg0, %arg1 : tensor<4xf32>
+    return %0, %arg0 : tensor<4xf32>, tensor<4xf32>
+}
+
+// CHECK-LABEL: func.func @simple_mul
+// CHECK128-LABEL: func.func @simple_mul
+// CHECK0-LABEL: func.func @simple_mul
+

--- a/mlir/test/Dialect/Vector/vector-transfer-flatten.mlir
+++ b/mlir/test/Dialect/Vector/vector-transfer-flatten.mlir
@@ -493,4 +493,3 @@ func.func @unsupported_non_contiguous_dim_write(%value : vector<2x2xf32>,
 
 // CHECK-128B-LABEL: func @unsupported_non_contiguous_dim_write(
 //   CHECK-128B-NOT:   memref.collapse_shape
-

--- a/mlir/test/Dialect/Vector/vector-transfer-flatten.mlir
+++ b/mlir/test/Dialect/Vector/vector-transfer-flatten.mlir
@@ -494,13 +494,3 @@ func.func @unsupported_non_contiguous_dim_write(%value : vector<2x2xf32>,
 // CHECK-128B-LABEL: func @unsupported_non_contiguous_dim_write(
 //   CHECK-128B-NOT:   memref.collapse_shape
 
-// -----
-
-// This test exists to make sure it doesn't hit an assert and compiles through.
-func.func @simple_mul(%arg0: tensor<4xf32>, %arg1: tensor<4xf32>) -> (tensor<4xf32>, tensor<4xf32>) {
-    %0 = arith.mulf %arg0, %arg1 : tensor<4xf32>
-    return %0, %arg0 : tensor<4xf32>, tensor<4xf32>
-}
-
-// CHECK-LABEL: func.func @simple_mul
-// CHECK-128B-LABEL: func.func @simple_mul

--- a/mlir/test/Dialect/Vector/vector-transfer-flatten.mlir
+++ b/mlir/test/Dialect/Vector/vector-transfer-flatten.mlir
@@ -493,3 +493,14 @@ func.func @unsupported_non_contiguous_dim_write(%value : vector<2x2xf32>,
 
 // CHECK-128B-LABEL: func @unsupported_non_contiguous_dim_write(
 //   CHECK-128B-NOT:   memref.collapse_shape
+
+// -----
+
+// This test exists to make sure it doesn't hit an assert and compiles through.
+func.func @simple_mul(%arg0: tensor<4xf32>, %arg1: tensor<4xf32>) -> (tensor<4xf32>, tensor<4xf32>) {
+    %0 = arith.mulf %arg0, %arg1 : tensor<4xf32>
+    return %0, %arg0 : tensor<4xf32>, tensor<4xf32>
+}
+
+// CHECK-LABEL: func.func @simple_mul
+// CHECK-128B-LABEL: func.func @simple_mul


### PR DESCRIPTION
When the result is not a vectorType, there is an assert. This patch will do the check 
and bail when the result is not a VectorType.