### PR TITLE
[LLVM] Extend setModuleFlag interface.

### DIFF
--- a/llvm/include/llvm/IR/Module.h
+++ b/llvm/include/llvm/IR/Module.h
@@ -548,6 +548,8 @@ public:
   void addModuleFlag(MDNode *Node);
   /// Like addModuleFlag but replaces the old module flag if it already exists.
   void setModuleFlag(ModFlagBehavior Behavior, StringRef Key, Metadata *Val);
+  void setModuleFlag(ModFlagBehavior Behavior, StringRef Key, Constant *Val);
+  void setModuleFlag(ModFlagBehavior Behavior, StringRef Key, uint32_t Val);
 
   /// @}
   /// @name Materialization

--- a/llvm/lib/IR/Module.cpp
+++ b/llvm/lib/IR/Module.cpp
@@ -397,6 +397,15 @@ void Module::setModuleFlag(ModFlagBehavior Behavior, StringRef Key,
   }
   addModuleFlag(Behavior, Key, Val);
 }
+void Module::setModuleFlag(ModFlagBehavior Behavior, StringRef Key,
+                           Constant *Val) {
+  setModuleFlag(Behavior, Key, ConstantAsMetadata::get(Val));
+}
+void Module::setModuleFlag(ModFlagBehavior Behavior, StringRef Key,
+                           uint32_t Val) {
+  Type *Int32Ty = Type::getInt32Ty(Context);
+  setModuleFlag(Behavior, Key, ConstantInt::get(Int32Ty, Val));
+}
 
 void Module::setDataLayout(StringRef Desc) {
   DL.reset(Desc);

--- a/llvm/unittests/IR/ModuleTest.cpp
+++ b/llvm/unittests/IR/ModuleTest.cpp
@@ -8,6 +8,7 @@
 
 #include "llvm/IR/Module.h"
 #include "llvm/AsmParser/Parser.h"
+#include "llvm/IR/Constants.h"
 #include "llvm/IR/GlobalVariable.h"
 #include "llvm/IR/ModuleSummaryIndex.h"
 #include "llvm/Pass.h"
@@ -84,6 +85,21 @@ TEST(ModuleTest, setModuleFlag) {
   EXPECT_EQ(Val1, M.getModuleFlag(Key));
   M.setModuleFlag(Module::ModFlagBehavior::Error, Key, Val2);
   EXPECT_EQ(Val2, M.getModuleFlag(Key));
+}
+
+TEST(ModuleTest, setModuleFlagInt) {
+  LLVMContext Context;
+  Module M("M", Context);
+  StringRef Key = "Key";
+  uint32_t Val1 = 1;
+  uint32_t Val2 = 2;
+  EXPECT_EQ(nullptr, M.getModuleFlag(Key));
+  M.setModuleFlag(Module::ModFlagBehavior::Error, Key, Val1);
+  auto A1 = mdconst::extract_or_null<ConstantInt>(M.getModuleFlag(Key));
+  EXPECT_EQ(Val1, A1->getZExtValue());
+  M.setModuleFlag(Module::ModFlagBehavior::Error, Key, Val2);
+  auto A2 = mdconst::extract_or_null<ConstantInt>(M.getModuleFlag(Key));
+  EXPECT_EQ(Val2, A2->getZExtValue());
 }
 
 const char *IRString = R"IR(


### PR DESCRIPTION
Add same interfaces variants to the `Module::setModuleFlag` as the `Module::addModuleFlag` has.