### PR TITLE
[Sanitizers][Darwin] Bump up DEFAULT_SANITIZER_MIN_OSX_VERSION

### DIFF
--- a/compiler-rt/cmake/config-ix.cmake
+++ b/compiler-rt/cmake/config-ix.cmake
@@ -461,7 +461,7 @@ if(APPLE)
     set(ORC_SUPPORTED_OS osx)
   endif()
 
-  set(DEFAULT_SANITIZER_MIN_OSX_VERSION 10.10)
+  set(DEFAULT_SANITIZER_MIN_OSX_VERSION 10.13)
   set(DARWIN_osx_MIN_VER_FLAG "-mmacosx-version-min")
   if(NOT SANITIZER_MIN_OSX_VERSION)
     string(REGEX MATCH "${DARWIN_osx_MIN_VER_FLAG}=([.0-9]+)"


### PR DESCRIPTION
The greendragon was recently moved and now it runs on somewhat newer macOS
version - which breaks some sanitizers tests

rdar://125052915
