### PR TITLE
[libc] Add an option to always build GPU loader utilities

### DIFF
--- a/libc/CMakeLists.txt
+++ b/libc/CMakeLists.txt
@@ -61,7 +61,8 @@ if(LLVM_LIBC_FULL_BUILD OR LLVM_LIBC_GPU_BUILD)
   endif()
 endif()
 # We will build the GPU utilities if we are not doing a runtimes build.
-if(LLVM_LIBC_GPU_BUILD AND NOT LLVM_RUNTIMES_BUILD)
+option(LIBC_BUILD_GPU_LOADER "Always build the GPU loader utilities" OFF)
+if(LIBC_BUILD_GPU_LOADER OR (LLVM_LIBC_GPU_BUILD AND NOT LLVM_RUNTIMES_BUILD))
   add_subdirectory(utils/gpu)
 endif()
 


### PR DESCRIPTION
Summary:
Right now it's difficult to build these utilities standalone becayse
they're keyed off of the other GPU handling. if someone wants to *just*
build these utilities it's not possible without setting up the runtimes
build. Since we can't just build these by default add an option to
enable it.

We can't just use the handling like LIBC_HDRGEN does because this is
only for the GPU build, which isn't fully set up until way later. So
this is probably the easiest way to just allow people to build these
tools even without a GPU build setup.
