### PR TITLE
[sanitizer_common] Suppress warning of cast from SignalHandlerType to sa_sigaction_t

### DIFF
--- a/compiler-rt/lib/sanitizer_common/sanitizer_posix_libcdep.cpp
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_posix_libcdep.cpp
@@ -216,7 +216,7 @@ static void MaybeInstallSigaction(int signum,
 
   struct sigaction sigact;
   internal_memset(&sigact, 0, sizeof(sigact));
-  sigact.sa_sigaction = (sa_sigaction_t)handler;
+  sigact.sa_sigaction = (sa_sigaction_t)(void (*)(void))handler;
   // Do not block the signal from being received in that signal's handler.
   // Clients are responsible for handling this correctly.
   sigact.sa_flags = SA_SIGINFO | SA_NODEFER;


### PR DESCRIPTION
Some buildbots (e.g., https://lab.llvm.org/buildbot/#/builders/18/builds/16061/steps/10/logs/stdio) have recently started complaining about
```
cast from 'SignalHandlerType' (aka 'void (*)(int, void *, void *)') to 'sa_sigaction_t' (aka 'void (*)(int, siginfo_t *, void *)') converts to incompatible function type [-Werror,-Wcast-function-type-strict]
  219 |   sigact.sa_sigaction = (sa_sigaction_t)handler;
  ```
This patch does an intermediate cast to `'(void (*) (void))'` to suppress the warning.

N.B. SignalHandlerType has `'void*'` instead of `'siginfo_t*'` because it is typedef'ed in sanitizer_common/sanitizer_common.h, which does not have access to the header (signal.h) that defines siginfo_t; we therefore cannot fix SignalHandlerType.
