### PR TITLE
[cmake] Place clang behind mlir in the list of external projects

### DIFF
--- a/llvm/tools/CMakeLists.txt
+++ b/llvm/tools/CMakeLists.txt
@@ -37,11 +37,11 @@ add_llvm_tool_subdirectory(llvm-profdata)
 
 # Projects supported via LLVM_EXTERNAL_*_SOURCE_DIR need to be explicitly
 # specified.
-add_llvm_external_project(clang)
 add_llvm_external_project(lld)
 add_llvm_external_project(lldb)
 add_llvm_external_project(mlir)
-# Flang depends on mlir, so place it afterward
+# ClangIR and Flang depends on mlir, so place them afterwards
+add_llvm_external_project(clang)
 add_llvm_external_project(flang)
 add_llvm_external_project(bolt)
 


### PR DESCRIPTION
In preparation for the initial ClangIR upstreaming process, move clang behind MLIR in the list of external projects. Otherwise, cmake will attempt to build clang before MLIR.

This is *technically* the first PR for ClangIR :p