### PR TITLE
[Float2Int] Fix pessimization in the MinBW calculation.

### DIFF
--- a/llvm/lib/Transforms/Scalar/Float2Int.cpp
+++ b/llvm/lib/Transforms/Scalar/Float2Int.cpp
@@ -359,9 +359,7 @@ bool Float2IntPass::validateAndTransform() {
 
     // The number of bits required is the maximum of the upper and
     // lower limits, plus one so it can be signed.
-    unsigned MinBW = std::max(R.getSignedMin().getSignificantBits(),
-                              R.getSignedMax().getSignificantBits()) +
-                     1;
+    unsigned MinBW = R.getMinSignedBits() + 1;
     LLVM_DEBUG(dbgs() << "F2I: MinBitwidth=" << MinBW << ", R: " << R << "\n");
 
     // If we've run off the realms of the exactly representable integers,

--- a/llvm/lib/Transforms/Scalar/Float2Int.cpp
+++ b/llvm/lib/Transforms/Scalar/Float2Int.cpp
@@ -359,8 +359,8 @@ bool Float2IntPass::validateAndTransform() {
 
     // The number of bits required is the maximum of the upper and
     // lower limits, plus one so it can be signed.
-    unsigned MinBW = std::max(R.getLower().getSignificantBits(),
-                              R.getUpper().getSignificantBits()) +
+    unsigned MinBW = std::max(R.getSignedMin().getSignificantBits(),
+                              R.getSignedMax().getSignificantBits()) +
                      1;
     LLVM_DEBUG(dbgs() << "F2I: MinBitwidth=" << MinBW << ", R: " << R << "\n");
 


### PR DESCRIPTION
The MinBW was being calculated using the significant bits of the upper and lower bounds. The upper bound is 1 past the last value in the range so I don't think it should be included. Instead get the min and max signed values from the range and use the significant bits of those.

I'm still not sure if the +1 is needed after the std::max.

I haven't investigated if its possible to add a test for this. We only look at whether the MinBW is > 32 right now. So the ranges need to be carefully crafted to see a difference.

CC: @AtariDreams 