### PR TITLE
[memprof] Call SmallVector::reserve

### DIFF
--- a/llvm/lib/ProfileData/RawMemProfReader.cpp
+++ b/llvm/lib/ProfileData/RawMemProfReader.cpp
@@ -127,6 +127,7 @@ CallStackMap readStackInfo(const char *Ptr) {
         endian::readNext<uint64_t, llvm::endianness::little, unaligned>(Ptr);
 
     SmallVector<uint64_t> CallStack;
+    CallStack.reserve(NumPCs);
     for (uint64_t J = 0; J < NumPCs; J++) {
       CallStack.push_back(
           endian::readNext<uint64_t, llvm::endianness::little, unaligned>(Ptr));


### PR DESCRIPTION
With one raw memprof file I have, NumPCs averages about 41.  Given the
default number of inline elements being 8 for SmallVector<uint64_t>,
we should reserve the storage in advance.
