### PR TITLE
[mlir][emitc] Arith to EmitC: Handle addi, subi and muli

### DIFF
--- a/mlir/lib/Conversion/ArithToEmitC/ArithToEmitC.cpp
+++ b/mlir/lib/Conversion/ArithToEmitC/ArithToEmitC.cpp
@@ -96,6 +96,9 @@ void mlir::populateArithToEmitCPatterns(TypeConverter &typeConverter,
     ArithOpConversion<arith::DivFOp, emitc::DivOp>,
     ArithOpConversion<arith::MulFOp, emitc::MulOp>,
     ArithOpConversion<arith::SubFOp, emitc::SubOp>,
+    ArithOpConversion<arith::AddIOp, emitc::AddOp>,
+    ArithOpConversion<arith::MulIOp, emitc::MulOp>,
+    ArithOpConversion<arith::SubIOp, emitc::SubOp>,
     SelectOpConversion
   >(typeConverter, ctx);
   // clang-format on

--- a/mlir/lib/Conversion/ArithToEmitC/ArithToEmitC.cpp
+++ b/mlir/lib/Conversion/ArithToEmitC/ArithToEmitC.cpp
@@ -69,6 +69,11 @@ public:
       return rewriter.notifyMatchFailure(op, "expected integer type");
     }
 
+    if (type.isInteger(1)) {
+      // arith expects wrap-around arithmethic, which doesn't happen on `bool`.
+      return rewriter.notifyMatchFailure(op, "i1 type is not implemented");
+    }
+
     Value lhs = adaptor.getLhs();
     Value rhs = adaptor.getRhs();
     Type arithmeticType = type;

--- a/mlir/lib/Conversion/ArithToEmitC/ArithToEmitC.cpp
+++ b/mlir/lib/Conversion/ArithToEmitC/ArithToEmitC.cpp
@@ -55,6 +55,50 @@ public:
   }
 };
 
+template <typename ArithOp, typename EmitCOp>
+class IntegerOpConversion final : public OpConversionPattern<ArithOp> {
+public:
+  using OpConversionPattern<ArithOp>::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(ArithOp op, typename ArithOp::Adaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+
+    Type type = this->getTypeConverter()->convertType(op.getType());
+    if (!isa_and_nonnull<IntegerType, IndexType>(type)) {
+      return rewriter.notifyMatchFailure(op, "expected integer type");
+    }
+
+    Value lhs = adaptor.getLhs();
+    Value rhs = adaptor.getRhs();
+    Type arithmeticType = type;
+    if ((type.isSignlessInteger() || type.isSignedInteger()) &&
+        !bitEnumContainsAll(op.getOverflowFlags(),
+                            arith::IntegerOverflowFlags::nsw)) {
+      // If the C type is signed and the op doesn't guarantee "No Signed Wrap",
+      // we compute in unsigned integers to avoid UB.
+      arithmeticType = rewriter.getIntegerType(type.getIntOrFloatBitWidth(),
+                                               /*isSigned=*/false);
+    }
+    if (arithmeticType != type) {
+      lhs = rewriter.template create<emitc::CastOp>(op.getLoc(), arithmeticType,
+                                                    lhs);
+      rhs = rewriter.template create<emitc::CastOp>(op.getLoc(), arithmeticType,
+                                                    rhs);
+    }
+
+    Value result = rewriter.template create<EmitCOp>(op.getLoc(),
+                                                     arithmeticType, lhs, rhs);
+
+    if (arithmeticType != type) {
+      result =
+          rewriter.template create<emitc::CastOp>(op.getLoc(), type, result);
+    }
+    rewriter.replaceOp(op, result);
+    return success();
+  }
+};
+
 class SelectOpConversion : public OpConversionPattern<arith::SelectOp> {
 public:
   using OpConversionPattern<arith::SelectOp>::OpConversionPattern;
@@ -96,9 +140,9 @@ void mlir::populateArithToEmitCPatterns(TypeConverter &typeConverter,
     ArithOpConversion<arith::DivFOp, emitc::DivOp>,
     ArithOpConversion<arith::MulFOp, emitc::MulOp>,
     ArithOpConversion<arith::SubFOp, emitc::SubOp>,
-    ArithOpConversion<arith::AddIOp, emitc::AddOp>,
-    ArithOpConversion<arith::MulIOp, emitc::MulOp>,
-    ArithOpConversion<arith::SubIOp, emitc::SubOp>,
+    IntegerOpConversion<arith::AddIOp, emitc::AddOp>,
+    IntegerOpConversion<arith::MulIOp, emitc::MulOp>,
+    IntegerOpConversion<arith::SubIOp, emitc::SubOp>,
     SelectOpConversion
   >(typeConverter, ctx);
   // clang-format on

--- a/mlir/test/Conversion/ArithToEmitC/arith-to-emitc-failed.mlir
+++ b/mlir/test/Conversion/ArithToEmitC/arith-to-emitc-failed.mlir
@@ -1,0 +1,15 @@
+// RUN: mlir-opt -convert-arith-to-emitc %s -split-input-file -verify-diagnostics
+
+func.func @bool(%arg0: i1, %arg1: i1) {
+  // expected-error@+1 {{failed to legalize operation 'arith.addi'}}
+  %0 = arith.addi %arg0, %arg1 : i1
+  return
+}
+
+// -----
+
+func.func @vector(%arg0: vector<4xi32>, %arg1: vector<4xi32>) {
+  // expected-error@+1 {{failed to legalize operation 'arith.addi'}}
+  %0 = arith.addi %arg0, %arg1 : vector<4xi32>
+  return
+}

--- a/mlir/test/Conversion/ArithToEmitC/arith-to-emitc.mlir
+++ b/mlir/test/Conversion/ArithToEmitC/arith-to-emitc.mlir
@@ -37,6 +37,19 @@ func.func @arith_ops(%arg0: f32, %arg1: f32) {
 
 // -----
 
+func.func @arith_integer_ops(%arg0: i32, %arg1: i32) {
+  // CHECK: emitc.add %arg0, %arg1 : (i32, i32) -> i32
+  %0 = arith.addi %arg0, %arg1 : i32
+  // CHECK: emitc.sub %arg0, %arg1 : (i32, i32) -> i32
+  %1 = arith.subi %arg0, %arg1 : i32
+  // CHECK: emitc.mul %arg0, %arg1 : (i32, i32) -> i32
+  %2 = arith.muli %arg0, %arg1 : i32
+
+  return
+}
+
+// -----
+
 func.func @arith_select(%arg0: i1, %arg1: tensor<8xi32>, %arg2: tensor<8xi32>) -> () {
   // CHECK: [[V0:[^ ]*]] = emitc.conditional %arg0, %arg1, %arg2 : tensor<8xi32>
   %0 = arith.select %arg0, %arg1, %arg2 : i1, tensor<8xi32>

--- a/mlir/test/Conversion/ArithToEmitC/arith-to-emitc.mlir
+++ b/mlir/test/Conversion/ArithToEmitC/arith-to-emitc.mlir
@@ -39,20 +39,20 @@ func.func @arith_ops(%arg0: f32, %arg1: f32) {
 
 // CHECK-LABEL: arith_integer_ops
 func.func @arith_integer_ops(%arg0: i32, %arg1: i32) {
-  // CHECK: %[[C1:[^ ]*]] = emitc.cast %arg0 : i32 to ui3
-  // CHECK: %[[C2:[^ ]*]] = emitc.cast %arg1 : i32 to ui3
+  // CHECK: %[[C1:[^ ]*]] = emitc.cast %arg0 : i32 to ui32
+  // CHECK: %[[C2:[^ ]*]] = emitc.cast %arg1 : i32 to ui32
   // CHECK: %[[ADD:[^ ]*]] = emitc.add %[[C1]], %[[C2]] : (ui32, ui32) -> ui32
-  // CHECK: %[[C3:[^ ]*]] = emitc.cast %[[ADD]] : ui32 to i3
+  // CHECK: %[[C3:[^ ]*]] = emitc.cast %[[ADD]] : ui32 to i32
   %0 = arith.addi %arg0, %arg1 : i32
-  // CHECK: %[[C1:[^ ]*]] = emitc.cast %arg0 : i32 to ui3
-  // CHECK: %[[C2:[^ ]*]] = emitc.cast %arg1 : i32 to ui3
+  // CHECK: %[[C1:[^ ]*]] = emitc.cast %arg0 : i32 to ui32
+  // CHECK: %[[C2:[^ ]*]] = emitc.cast %arg1 : i32 to ui32
   // CHECK: %[[SUB:[^ ]*]] = emitc.sub %[[C1]], %[[C2]] : (ui32, ui32) -> ui32
-  // CHECK: %[[C3:[^ ]*]] = emitc.cast %[[SUB]] : ui32 to i3
+  // CHECK: %[[C3:[^ ]*]] = emitc.cast %[[SUB]] : ui32 to i32
   %1 = arith.subi %arg0, %arg1 : i32
-  // CHECK: %[[C1:[^ ]*]] = emitc.cast %arg0 : i32 to ui3
-  // CHECK: %[[C2:[^ ]*]] = emitc.cast %arg1 : i32 to ui3
+  // CHECK: %[[C1:[^ ]*]] = emitc.cast %arg0 : i32 to ui32
+  // CHECK: %[[C2:[^ ]*]] = emitc.cast %arg1 : i32 to ui32
   // CHECK: %[[MUL:[^ ]*]] = emitc.mul %[[C1]], %[[C2]] : (ui32, ui32) -> ui32
-  // CHECK: %[[C3:[^ ]*]] = emitc.cast %[[MUL]] : ui32 to i3
+  // CHECK: %[[C3:[^ ]*]] = emitc.cast %[[MUL]] : ui32 to i32
   %2 = arith.muli %arg0, %arg1 : i32
 
   return

--- a/mlir/test/Conversion/ArithToEmitC/arith-to-emitc.mlir
+++ b/mlir/test/Conversion/ArithToEmitC/arith-to-emitc.mlir
@@ -37,13 +37,51 @@ func.func @arith_ops(%arg0: f32, %arg1: f32) {
 
 // -----
 
+// CHECK-LABEL: arith_integer_ops
 func.func @arith_integer_ops(%arg0: i32, %arg1: i32) {
-  // CHECK: emitc.add %arg0, %arg1 : (i32, i32) -> i32
+  // CHECK: %[[C1:[^ ]*]] = emitc.cast %arg0 : i32 to ui3
+  // CHECK: %[[C2:[^ ]*]] = emitc.cast %arg1 : i32 to ui3
+  // CHECK: %[[ADD:[^ ]*]] = emitc.add %[[C1]], %[[C2]] : (ui32, ui32) -> ui32
+  // CHECK: %[[C3:[^ ]*]] = emitc.cast %[[ADD]] : ui32 to i3
   %0 = arith.addi %arg0, %arg1 : i32
-  // CHECK: emitc.sub %arg0, %arg1 : (i32, i32) -> i32
+  // CHECK: %[[C1:[^ ]*]] = emitc.cast %arg0 : i32 to ui3
+  // CHECK: %[[C2:[^ ]*]] = emitc.cast %arg1 : i32 to ui3
+  // CHECK: %[[SUB:[^ ]*]] = emitc.sub %[[C1]], %[[C2]] : (ui32, ui32) -> ui32
+  // CHECK: %[[C3:[^ ]*]] = emitc.cast %[[SUB]] : ui32 to i3
   %1 = arith.subi %arg0, %arg1 : i32
-  // CHECK: emitc.mul %arg0, %arg1 : (i32, i32) -> i32
+  // CHECK: %[[C1:[^ ]*]] = emitc.cast %arg0 : i32 to ui3
+  // CHECK: %[[C2:[^ ]*]] = emitc.cast %arg1 : i32 to ui3
+  // CHECK: %[[MUL:[^ ]*]] = emitc.mul %[[C1]], %[[C2]] : (ui32, ui32) -> ui32
+  // CHECK: %[[C3:[^ ]*]] = emitc.cast %[[MUL]] : ui32 to i3
   %2 = arith.muli %arg0, %arg1 : i32
+
+  return
+}
+
+// -----
+
+// CHECK-LABEL: arith_integer_ops_signed_nsw
+func.func @arith_integer_ops_signed_nsw(%arg0: i32, %arg1: i32) {
+  // CHECK: emitc.add %arg0, %arg1 : (i32, i32) -> i32
+  %0 = arith.addi %arg0, %arg1 overflow<nsw> : i32
+  // CHECK: emitc.sub %arg0, %arg1 : (i32, i32) -> i32
+  %1 = arith.subi %arg0, %arg1 overflow<nsw>  : i32
+  // CHECK: emitc.mul %arg0, %arg1 : (i32, i32) -> i32
+  %2 = arith.muli %arg0, %arg1 overflow<nsw> : i32
+
+  return
+}
+
+// -----
+
+// CHECK-LABEL: arith_index
+func.func @arith_index(%arg0: index, %arg1: index) {
+  // CHECK: emitc.add %arg0, %arg1 : (index, index) -> index
+  %0 = arith.addi %arg0, %arg1 : index
+  // CHECK: emitc.sub %arg0, %arg1 : (index, index) -> index
+  %1 = arith.subi %arg0, %arg1 : index
+  // CHECK: emitc.mul %arg0, %arg1 : (index, index) -> index
+  %2 = arith.muli %arg0, %arg1 : index
 
   return
 }


### PR DESCRIPTION
Important to consider that `arith` has wrap around semantics, and in C++ signed overflow is UB.
Unless the operation guarantees that no signed overflow happens, we will perform the arithmetic in an equivalent unsigned type.