### PR TITLE
Raise an error on namespace aliases with qualified names.

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -419,6 +419,8 @@ Bug Fixes to C++ Support
 - Clang's __builtin_bit_cast will now produce a constant value for records with empty bases. See:
   (#GH82383)
 - Fix a crash when instantiating a lambda that captures ``this`` outside of its context. Fixes (#GH85343).
+- Fix an issue where a namespace alias could be defined using a qualified name (all name components
+  following the first `::` were ignored). (#GH86122)
 
 Bug Fixes to AST Handling
 ^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -420,7 +420,7 @@ Bug Fixes to C++ Support
   (#GH82383)
 - Fix a crash when instantiating a lambda that captures ``this`` outside of its context. Fixes (#GH85343).
 - Fix an issue where a namespace alias could be defined using a qualified name (all name components
-  following the first `::` were ignored). (#GH86122)
+  following the first `::` were ignored).
 
 Bug Fixes to AST Handling
 ^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/clang/include/clang/Basic/DiagnosticParseKinds.td
+++ b/clang/include/clang/Basic/DiagnosticParseKinds.td
@@ -268,6 +268,8 @@ def err_expected_semi_after_namespace_name : Error<
   "expected ';' after namespace name">;
 def err_unexpected_namespace_attributes_alias : Error<
   "attributes cannot be specified on namespace alias">;
+def err_unexpected_qualified_namespace_alias : Error<
+  "unexpected nested name specifier in namespace alias definition">;
 def err_unexpected_nested_namespace_attribute : Error<
   "attributes cannot be specified on a nested namespace definition">;
 def err_inline_namespace_alias : Error<"namespace alias cannot be inline">;

--- a/clang/include/clang/Basic/DiagnosticParseKinds.td
+++ b/clang/include/clang/Basic/DiagnosticParseKinds.td
@@ -269,7 +269,7 @@ def err_expected_semi_after_namespace_name : Error<
 def err_unexpected_namespace_attributes_alias : Error<
   "attributes cannot be specified on namespace alias">;
 def err_unexpected_qualified_namespace_alias : Error<
-  "unexpected nested name specifier in namespace alias definition">;
+  "namespace alias must be a single identifier">;
 def err_unexpected_nested_namespace_attribute : Error<
   "attributes cannot be specified on a nested namespace definition">;
 def err_inline_namespace_alias : Error<"namespace alias cannot be inline">;

--- a/clang/lib/Parse/ParseDeclCXX.cpp
+++ b/clang/lib/Parse/ParseDeclCXX.cpp
@@ -140,6 +140,11 @@ Parser::DeclGroupPtrTy Parser::ParseNamespace(DeclaratorContext Context,
       SkipUntil(tok::semi);
       return nullptr;
     }
+    if (!ExtraNSs.empty()) {
+      Diag(IdentLoc, diag::err_unexpected_qualified_namespace_alias);
+      SkipUntil(tok::semi);
+      return nullptr;
+    }
     if (attrLoc.isValid())
       Diag(attrLoc, diag::err_unexpected_namespace_attributes_alias);
     if (InlineLoc.isValid())

--- a/clang/lib/Parse/ParseDeclCXX.cpp
+++ b/clang/lib/Parse/ParseDeclCXX.cpp
@@ -141,7 +141,10 @@ Parser::DeclGroupPtrTy Parser::ParseNamespace(DeclaratorContext Context,
       return nullptr;
     }
     if (!ExtraNSs.empty()) {
-      Diag(IdentLoc, diag::err_unexpected_qualified_namespace_alias);
+      Diag(ExtraNSs.front().NamespaceLoc,
+           diag::err_unexpected_qualified_namespace_alias)
+          << SourceRange(ExtraNSs.front().NamespaceLoc,
+                         ExtraNSs.back().IdentLoc);
       SkipUntil(tok::semi);
       return nullptr;
     }

--- a/clang/test/SemaCXX/namespace-alias.cpp
+++ b/clang/test/SemaCXX/namespace-alias.cpp
@@ -47,6 +47,8 @@ namespace I {
   namespace A1 { int i; }
   
   namespace A2 = A1;
+
+  namespace A3::extra::specifiers = A2;  // expected-error {{unexpected nested name specifier}}
 }
 
 int f() {

--- a/clang/test/SemaCXX/namespace-alias.cpp
+++ b/clang/test/SemaCXX/namespace-alias.cpp
@@ -48,7 +48,7 @@ namespace I {
   
   namespace A2 = A1;
 
-  namespace A3::extra::specifiers = A2;  // expected-error {{unexpected nested name specifier}}
+  namespace A3::extra::specifiers = A2;  // expected-error {{alias must be a single identifier}}
 }
 
 int f() {


### PR DESCRIPTION
Clang's current behavior is to ignore the trailing qualifiers, but the [grammar](https://eel.is/c++draft/namespace.alias#nt:namespace-alias-definition) for `namespace-alias-definition` requires an `identifier` without qualification.

https://godbolt.org/z/1zvW5q4f8