### PR TITLE
[IR] Make instr-create fns with Instruction *InsertBefore non-default

### DIFF
--- a/llvm/include/llvm/IR/InstrTypes.h
+++ b/llvm/include/llvm/IR/InstrTypes.h
@@ -60,11 +60,11 @@ protected:
     Op<0>() = V;
   }
   UnaryInstruction(Type *Ty, unsigned iType, Value *V,
-                   Instruction *IB = nullptr)
+                   Instruction *IB)
     : Instruction(Ty, iType, &Op<0>(), 1, IB) {
     Op<0>() = V;
   }
-  UnaryInstruction(Type *Ty, unsigned iType, Value *V, BasicBlock *IAE)
+  UnaryInstruction(Type *Ty, unsigned iType, Value *V, BasicBlock *IAE = nullptr)
     : Instruction(Ty, iType, &Op<0>(), 1, IAE) {
     Op<0>() = V;
   }
@@ -132,16 +132,16 @@ public:
   /// Instruction is allowed to be a dereferenced end iterator.
   ///
   static UnaryOperator *Create(UnaryOps Op, Value *S,
-                               const Twine &Name = Twine(),
-                               Instruction *InsertBefore = nullptr);
+                               const Twine &Name,
+                               Instruction *InsertBefore);
 
   /// Construct a unary instruction, given the opcode and an operand.
   /// Also automatically insert this instruction to the end of the
   /// BasicBlock specified.
   ///
   static UnaryOperator *Create(UnaryOps Op, Value *S,
-                               const Twine &Name,
-                               BasicBlock *InsertAtEnd);
+                               const Twine &Name = Twine(),
+                               BasicBlock *InsertAtEnd = nullptr);
 
   /// These methods just forward to Create, and are useful when you
   /// statically know what type of instruction you're going to create.  These
@@ -180,9 +180,18 @@ public:
 
   static UnaryOperator *
   CreateWithCopiedFlags(UnaryOps Opc, Value *V, Instruction *CopyO,
-                        const Twine &Name = "",
-                        Instruction *InsertBefore = nullptr) {
+                        const Twine &Name,
+                        Instruction *InsertBefore) {
     UnaryOperator *UO = Create(Opc, V, Name, InsertBefore);
+    UO->copyIRFlags(CopyO);
+    return UO;
+  }
+
+  static UnaryOperator *
+  CreateWithCopiedFlags(UnaryOps Opc, Value *V, Instruction *CopyO,
+                        const Twine &Name = "",
+                        BasicBlock *InsertAtEnd = nullptr) {
+    UnaryOperator *UO = Create(Opc, V, Name, InsertAtEnd);
     UO->copyIRFlags(CopyO);
     return UO;
   }
@@ -195,10 +204,17 @@ public:
   }
 
   static UnaryOperator *CreateFNegFMF(Value *Op, Instruction *FMFSource,
-                                      const Twine &Name = "",
-                                      Instruction *InsertBefore = nullptr) {
+                                      const Twine &Name,
+                                      Instruction *InsertBefore) {
     return CreateWithCopiedFlags(Instruction::FNeg, Op, FMFSource, Name,
                                  InsertBefore);
+  }
+
+  static UnaryOperator *CreateFNegFMF(Value *Op, Instruction *FMFSource,
+                                      const Twine &Name = "",
+                                      BasicBlock *InsertAtEnd = nullptr) {
+    return CreateWithCopiedFlags(Instruction::FNeg, Op, FMFSource, Name,
+                                 InsertAtEnd);
   }
 
   UnaryOps getOpcode() const {
@@ -256,15 +272,15 @@ public:
   /// Instruction is allowed to be a dereferenced end iterator.
   ///
   static BinaryOperator *Create(BinaryOps Op, Value *S1, Value *S2,
-                                const Twine &Name = Twine(),
-                                Instruction *InsertBefore = nullptr);
+                                const Twine &Name,
+                                Instruction *InsertBefore);
 
   /// Construct a binary instruction, given the opcode and the two
   /// operands.  Also automatically insert this instruction to the end of the
   /// BasicBlock specified.
   ///
   static BinaryOperator *Create(BinaryOps Op, Value *S1, Value *S2,
-                                const Twine &Name, BasicBlock *InsertAtEnd);
+                                const Twine &Name = Twine(), BasicBlock *InsertAtEnd = nullptr);
 
   /// These methods just forward to Create, and are useful when you
   /// statically know what type of instruction you're going to create.  These
@@ -304,9 +320,18 @@ public:
 
   static BinaryOperator *
   CreateWithCopiedFlags(BinaryOps Opc, Value *V1, Value *V2, Value *CopyO,
-                        const Twine &Name = "",
-                        Instruction *InsertBefore = nullptr) {
+                        const Twine &Name,
+                        Instruction *InsertBefore) {
     BinaryOperator *BO = Create(Opc, V1, V2, Name, InsertBefore);
+    BO->copyIRFlags(CopyO);
+    return BO;
+  }
+
+  static BinaryOperator *
+  CreateWithCopiedFlags(BinaryOps Opc, Value *V1, Value *V2, Value *CopyO,
+                        const Twine &Name = "",
+                        BasicBlock *InsertAtEnd = nullptr) {
+    BinaryOperator *BO = Create(Opc, V1, V2, Name, InsertAtEnd);
     BO->copyIRFlags(CopyO);
     return BO;
   }
@@ -472,22 +497,22 @@ public:
                                    BasicBlock *InsertAtEnd = nullptr);
   static BinaryOperator *CreateNSWNeg(Value *Op, const Twine &Name,
                                       BasicBlock::iterator InsertBefore);
-  static BinaryOperator *CreateNSWNeg(Value *Op, const Twine &Name = "",
-                                      Instruction *InsertBefore = nullptr);
   static BinaryOperator *CreateNSWNeg(Value *Op, const Twine &Name,
-                                      BasicBlock *InsertAtEnd);
+                                      Instruction *InsertBefore);
+  static BinaryOperator *CreateNSWNeg(Value *Op, const Twine &Name = "",
+                                      BasicBlock *InsertAtEnd = nullptr);
   static BinaryOperator *CreateNUWNeg(Value *Op, const Twine &Name,
                                       BasicBlock::iterator InsertBefore);
-  static BinaryOperator *CreateNUWNeg(Value *Op, const Twine &Name = "",
-                                      Instruction *InsertBefore = nullptr);
   static BinaryOperator *CreateNUWNeg(Value *Op, const Twine &Name,
-                                      BasicBlock *InsertAtEnd);
+                                      Instruction *InsertBefore);
+  static BinaryOperator *CreateNUWNeg(Value *Op, const Twine &Name = "",
+                                      BasicBlock *InsertAtEnd = nullptr);
   static BinaryOperator *CreateNot(Value *Op, const Twine &Name,
                                    BasicBlock::iterator InsertBefore);
-  static BinaryOperator *CreateNot(Value *Op, const Twine &Name = "",
-                                   Instruction *InsertBefore = nullptr);
   static BinaryOperator *CreateNot(Value *Op, const Twine &Name,
-                                   BasicBlock *InsertAtEnd);
+                                   Instruction *InsertBefore);
+  static BinaryOperator *CreateNot(Value *Op, const Twine &Name = "",
+                                   BasicBlock *InsertAtEnd = nullptr);
 
   BinaryOps getOpcode() const {
     return static_cast<BinaryOps>(Instruction::getOpcode());
@@ -587,13 +612,13 @@ protected:
   }
   /// Constructor with insert-before-instruction semantics for subclasses
   CastInst(Type *Ty, unsigned iType, Value *S,
-           const Twine &NameStr = "", Instruction *InsertBefore = nullptr)
+           const Twine &NameStr, Instruction *InsertBefore)
     : UnaryInstruction(Ty, iType, S, InsertBefore) {
     setName(NameStr);
   }
   /// Constructor with insert-at-end-of-block semantics for subclasses
   CastInst(Type *Ty, unsigned iType, Value *S,
-           const Twine &NameStr, BasicBlock *InsertAtEnd)
+           const Twine &NameStr = "", BasicBlock *InsertAtEnd = nullptr)
     : UnaryInstruction(Ty, iType, S, InsertAtEnd) {
     setName(NameStr);
   }
@@ -622,8 +647,8 @@ public:
     Instruction::CastOps,    ///< The opcode of the cast instruction
     Value *S,                ///< The value to be casted (operand 0)
     Type *Ty,          ///< The type to which cast should be made
-    const Twine &Name = "", ///< Name for the instruction
-    Instruction *InsertBefore = nullptr ///< Place to insert the instruction
+    const Twine &Name, ///< Name for the instruction
+    Instruction *InsertBefore ///< Place to insert the instruction
   );
   /// Provides a way to construct any of the CastInst subclasses using an
   /// opcode instead of the subclass's constructor. The opcode must be in the
@@ -635,8 +660,8 @@ public:
     Instruction::CastOps,    ///< The opcode for the cast instruction
     Value *S,                ///< The value to be casted (operand 0)
     Type *Ty,          ///< The type to which operand is casted
-    const Twine &Name, ///< The name for the instruction
-    BasicBlock *InsertAtEnd  ///< The block to insert the instruction into
+    const Twine &Name = "", ///< The name for the instruction
+    BasicBlock *InsertAtEnd = nullptr  ///< The block to insert the instruction into
   );
 
   /// Create a ZExt or BitCast cast instruction
@@ -651,16 +676,16 @@ public:
   static CastInst *CreateZExtOrBitCast(
     Value *S,                ///< The value to be casted (operand 0)
     Type *Ty,          ///< The type to which cast should be made
-    const Twine &Name = "", ///< Name for the instruction
-    Instruction *InsertBefore = nullptr ///< Place to insert the instruction
+    const Twine &Name, ///< Name for the instruction
+    Instruction *InsertBefore ///< Place to insert the instruction
   );
 
   /// Create a ZExt or BitCast cast instruction
   static CastInst *CreateZExtOrBitCast(
     Value *S,                ///< The value to be casted (operand 0)
     Type *Ty,          ///< The type to which operand is casted
-    const Twine &Name, ///< The name for the instruction
-    BasicBlock *InsertAtEnd  ///< The block to insert the instruction into
+    const Twine &Name = "", ///< The name for the instruction
+    BasicBlock *InsertAtEnd = nullptr  ///< The block to insert the instruction into
   );
 
   /// Create a SExt or BitCast cast instruction
@@ -675,24 +700,24 @@ public:
   static CastInst *CreateSExtOrBitCast(
     Value *S,                ///< The value to be casted (operand 0)
     Type *Ty,          ///< The type to which cast should be made
-    const Twine &Name = "", ///< Name for the instruction
-    Instruction *InsertBefore = nullptr ///< Place to insert the instruction
+    const Twine &Name, ///< Name for the instruction
+    Instruction *InsertBefore ///< Place to insert the instruction
   );
 
   /// Create a SExt or BitCast cast instruction
   static CastInst *CreateSExtOrBitCast(
     Value *S,                ///< The value to be casted (operand 0)
     Type *Ty,          ///< The type to which operand is casted
-    const Twine &Name, ///< The name for the instruction
-    BasicBlock *InsertAtEnd  ///< The block to insert the instruction into
+    const Twine &Name = "", ///< The name for the instruction
+    BasicBlock *InsertAtEnd = nullptr  ///< The block to insert the instruction into
   );
 
   /// Create a BitCast AddrSpaceCast, or a PtrToInt cast instruction.
   static CastInst *CreatePointerCast(
     Value *S,                ///< The pointer value to be casted (operand 0)
     Type *Ty,          ///< The type to which operand is casted
-    const Twine &Name, ///< The name for the instruction
-    BasicBlock *InsertAtEnd  ///< The block to insert the instruction into
+    const Twine &Name = "", ///< The name for the instruction
+    BasicBlock *InsertAtEnd = nullptr  ///< The block to insert the instruction into
   );
 
   /// Create a BitCast, AddrSpaceCast or a PtrToInt cast instruction.
@@ -707,16 +732,16 @@ public:
   static CastInst *CreatePointerCast(
     Value *S,                ///< The pointer value to be casted (operand 0)
     Type *Ty,          ///< The type to which cast should be made
-    const Twine &Name = "", ///< Name for the instruction
-    Instruction *InsertBefore = nullptr ///< Place to insert the instruction
+    const Twine &Name, ///< Name for the instruction
+    Instruction *InsertBefore ///< Place to insert the instruction
   );
 
   /// Create a BitCast or an AddrSpaceCast cast instruction.
   static CastInst *CreatePointerBitCastOrAddrSpaceCast(
     Value *S,                ///< The pointer value to be casted (operand 0)
     Type *Ty,          ///< The type to which operand is casted
-    const Twine &Name, ///< The name for the instruction
-    BasicBlock *InsertAtEnd  ///< The block to insert the instruction into
+    const Twine &Name = "", ///< The name for the instruction
+    BasicBlock *InsertAtEnd = nullptr  ///< The block to insert the instruction into
   );
 
   /// Create a BitCast or an AddrSpaceCast cast instruction.
@@ -731,8 +756,8 @@ public:
   static CastInst *CreatePointerBitCastOrAddrSpaceCast(
     Value *S,                ///< The pointer value to be casted (operand 0)
     Type *Ty,          ///< The type to which cast should be made
-    const Twine &Name = "", ///< Name for the instruction
-    Instruction *InsertBefore = nullptr ///< Place to insert the instruction
+    const Twine &Name, ///< Name for the instruction
+    Instruction *InsertBefore ///< Place to insert the instruction
   );
 
   /// Create a BitCast, a PtrToInt, or an IntToPTr cast instruction.
@@ -757,8 +782,21 @@ public:
   static CastInst *CreateBitOrPointerCast(
     Value *S,                ///< The pointer value to be casted (operand 0)
     Type *Ty,          ///< The type to which cast should be made
+    const Twine &Name, ///< Name for the instruction
+    Instruction *InsertBefore ///< Place to insert the instruction
+  );
+
+  /// Create a BitCast, a PtrToInt, or an IntToPTr cast instruction.
+  ///
+  /// If the value is a pointer type and the destination an integer type,
+  /// creates a PtrToInt cast. If the value is an integer type and the
+  /// destination a pointer type, creates an IntToPtr cast. Otherwise, creates
+  /// a bitcast.
+  static CastInst *CreateBitOrPointerCast(
+    Value *S,                ///< The pointer value to be casted (operand 0)
+    Type *Ty,          ///< The type to which cast should be made
     const Twine &Name = "", ///< Name for the instruction
-    Instruction *InsertBefore = nullptr ///< Place to insert the instruction
+    BasicBlock *InsertAtEnd = nullptr ///< Place to insert the instruction
   );
 
   /// Create a ZExt, BitCast, or Trunc for int -> int casts.
@@ -775,8 +813,8 @@ public:
     Value *S,                ///< The pointer value to be casted (operand 0)
     Type *Ty,          ///< The type to which cast should be made
     bool isSigned,           ///< Whether to regard S as signed or not
-    const Twine &Name = "", ///< Name for the instruction
-    Instruction *InsertBefore = nullptr ///< Place to insert the instruction
+    const Twine &Name, ///< Name for the instruction
+    Instruction *InsertBefore ///< Place to insert the instruction
   );
 
   /// Create a ZExt, BitCast, or Trunc for int -> int casts.
@@ -784,8 +822,8 @@ public:
     Value *S,                ///< The integer value to be casted (operand 0)
     Type *Ty,          ///< The integer type to which operand is casted
     bool isSigned,           ///< Whether to regard S as signed or not
-    const Twine &Name, ///< The name for the instruction
-    BasicBlock *InsertAtEnd  ///< The block to insert the instruction into
+    const Twine &Name = "", ///< The name for the instruction
+    BasicBlock *InsertAtEnd = nullptr  ///< The block to insert the instruction into
   );
 
   /// Create an FPExt, BitCast, or FPTrunc for fp -> fp casts
@@ -800,16 +838,16 @@ public:
   static CastInst *CreateFPCast(
     Value *S,                ///< The floating point value to be casted
     Type *Ty,          ///< The floating point type to cast to
-    const Twine &Name = "", ///< Name for the instruction
-    Instruction *InsertBefore = nullptr ///< Place to insert the instruction
+    const Twine &Name, ///< Name for the instruction
+    Instruction *InsertBefore ///< Place to insert the instruction
   );
 
   /// Create an FPExt, BitCast, or FPTrunc for fp -> fp casts
   static CastInst *CreateFPCast(
     Value *S,                ///< The floating point value to be casted
     Type *Ty,          ///< The floating point type to cast to
-    const Twine &Name, ///< The name for the instruction
-    BasicBlock *InsertAtEnd  ///< The block to insert the instruction into
+    const Twine &Name = "", ///< The name for the instruction
+    BasicBlock *InsertAtEnd = nullptr  ///< The block to insert the instruction into
   );
 
   /// Create a Trunc or BitCast cast instruction
@@ -824,16 +862,16 @@ public:
   static CastInst *CreateTruncOrBitCast(
     Value *S,                ///< The value to be casted (operand 0)
     Type *Ty,          ///< The type to which cast should be made
-    const Twine &Name = "", ///< Name for the instruction
-    Instruction *InsertBefore = nullptr ///< Place to insert the instruction
+    const Twine &Name, ///< Name for the instruction
+    Instruction *InsertBefore ///< Place to insert the instruction
   );
 
   /// Create a Trunc or BitCast cast instruction
   static CastInst *CreateTruncOrBitCast(
     Value *S,                ///< The value to be casted (operand 0)
     Type *Ty,          ///< The type to which operand is casted
-    const Twine &Name, ///< The name for the instruction
-    BasicBlock *InsertAtEnd  ///< The block to insert the instruction into
+    const Twine &Name = "", ///< The name for the instruction
+    BasicBlock *InsertAtEnd = nullptr  ///< The block to insert the instruction into
   );
 
   /// Check whether a bitcast between these types is valid
@@ -1021,13 +1059,13 @@ protected:
           Instruction *FlagsSource = nullptr);
 
   CmpInst(Type *ty, Instruction::OtherOps op, Predicate pred,
-          Value *LHS, Value *RHS, const Twine &Name = "",
-          Instruction *InsertBefore = nullptr,
+          Value *LHS, Value *RHS, const Twine &Name,
+          Instruction *InsertBefore,
           Instruction *FlagsSource = nullptr);
 
   CmpInst(Type *ty, Instruction::OtherOps op, Predicate pred,
-          Value *LHS, Value *RHS, const Twine &Name,
-          BasicBlock *InsertAtEnd);
+          Value *LHS, Value *RHS, const Twine &Name = "",
+          BasicBlock *InsertAtEnd = nullptr);
 
 public:
   // allocate space for exactly two operands
@@ -1048,15 +1086,15 @@ public:
   /// Create a CmpInst
   static CmpInst *Create(OtherOps Op,
                          Predicate predicate, Value *S1,
-                         Value *S2, const Twine &Name = "",
-                         Instruction *InsertBefore = nullptr);
+                         Value *S2, const Twine &Name,
+                         Instruction *InsertBefore);
 
   /// Construct a compare instruction, given the opcode, the predicate and the
   /// two operands.  Also automatically insert this instruction to the end of
   /// the BasicBlock specified.
   /// Create a CmpInst
   static CmpInst *Create(OtherOps Op, Predicate predicate, Value *S1,
-                         Value *S2, const Twine &Name, BasicBlock *InsertAtEnd);
+                         Value *S2, const Twine &Name = "", BasicBlock *InsertAtEnd = nullptr);
 
   /// Get the opcode casted to the right type
   OtherOps getOpcode() const {
@@ -1513,7 +1551,16 @@ public:
   /// the operand bundles for the new instruction are set to the operand bundles
   /// in \p Bundles.
   static CallBase *Create(CallBase *CB, ArrayRef<OperandBundleDef> Bundles,
-                          Instruction *InsertPt = nullptr);
+                          Instruction *InsertPt);
+
+  /// Create a clone of \p CB with a different set of operand bundles and
+  /// insert it at the end of  \p InsertAtEnd.
+  ///
+  /// The returned call instruction is identical \p CB in every way except that
+  /// the operand bundles for the new instruction are set to the operand bundles
+  /// in \p Bundles.
+  static CallBase *Create(CallBase *CB, ArrayRef<OperandBundleDef> Bundles,
+                          BasicBlock *InsertAtEnd = nullptr);
 
   /// Create a clone of \p CB with the operand bundle with the tag matching
   /// \p Bundle's tag replaced with Bundle, and insert it before \p InsertPt.
@@ -1530,12 +1577,26 @@ public:
   /// the specified operand bundle has been replaced.
   static CallBase *Create(CallBase *CB,
                           OperandBundleDef Bundle,
-                          Instruction *InsertPt = nullptr);
+                          Instruction *InsertPt);
+
+  /// Create a clone of \p CB with the operand bundle with the tag matching
+  /// \p Bundle's tag replaced with Bundle, and insert it at the end of \p InsertAtEnd.
+  ///
+  /// The returned call instruction is identical \p CI in every way except that
+  /// the specified operand bundle has been replaced.
+  static CallBase *Create(CallBase *CB,
+                          OperandBundleDef Bundle,
+                          BasicBlock *InsertAtEnd = nullptr);
 
   /// Create a clone of \p CB with operand bundle \p OB added.
   static CallBase *addOperandBundle(CallBase *CB, uint32_t ID,
                                     OperandBundleDef OB,
-                                    Instruction *InsertPt = nullptr);
+                                    Instruction *InsertPt);
+
+  /// Create a clone of \p CB with operand bundle \p OB added.
+  static CallBase *addOperandBundle(CallBase *CB, uint32_t ID,
+                                    OperandBundleDef OB,
+                                    BasicBlock *InsertAtEnd = nullptr);
 
   /// Create a clone of \p CB with operand bundle \p OB added.
   static CallBase *addOperandBundle(CallBase *CB, uint32_t ID,
@@ -1544,7 +1605,11 @@ public:
 
   /// Create a clone of \p CB with operand bundle \p ID removed.
   static CallBase *removeOperandBundle(CallBase *CB, uint32_t ID,
-                                       Instruction *InsertPt = nullptr);
+                                       Instruction *InsertPt);
+
+  /// Create a clone of \p CB with operand bundle \p ID removed.
+  static CallBase *removeOperandBundle(CallBase *CB, uint32_t ID,
+                                       BasicBlock *InsertAtEnd = nullptr);
 
   /// Create a clone of \p CB with operand bundle \p ID removed.
   static CallBase *removeOperandBundle(CallBase *CB, uint32_t ID,

--- a/llvm/include/llvm/IR/InstrTypes.h
+++ b/llvm/include/llvm/IR/InstrTypes.h
@@ -59,13 +59,13 @@ protected:
       : Instruction(Ty, iType, &Op<0>(), 1, IB) {
     Op<0>() = V;
   }
-  UnaryInstruction(Type *Ty, unsigned iType, Value *V,
-                   Instruction *IB)
-    : Instruction(Ty, iType, &Op<0>(), 1, IB) {
+  UnaryInstruction(Type *Ty, unsigned iType, Value *V, Instruction *IB)
+      : Instruction(Ty, iType, &Op<0>(), 1, IB) {
     Op<0>() = V;
   }
-  UnaryInstruction(Type *Ty, unsigned iType, Value *V, BasicBlock *IAE = nullptr)
-    : Instruction(Ty, iType, &Op<0>(), 1, IAE) {
+  UnaryInstruction(Type *Ty, unsigned iType, Value *V,
+                   BasicBlock *IAE = nullptr)
+      : Instruction(Ty, iType, &Op<0>(), 1, IAE) {
     Op<0>() = V;
   }
 
@@ -131,8 +131,7 @@ public:
   /// into a BasicBlock right before the specified instruction.  The specified
   /// Instruction is allowed to be a dereferenced end iterator.
   ///
-  static UnaryOperator *Create(UnaryOps Op, Value *S,
-                               const Twine &Name,
+  static UnaryOperator *Create(UnaryOps Op, Value *S, const Twine &Name,
                                Instruction *InsertBefore);
 
   /// Construct a unary instruction, given the opcode and an operand.
@@ -178,10 +177,10 @@ public:
     return UO;
   }
 
-  static UnaryOperator *
-  CreateWithCopiedFlags(UnaryOps Opc, Value *V, Instruction *CopyO,
-                        const Twine &Name,
-                        Instruction *InsertBefore) {
+  static UnaryOperator *CreateWithCopiedFlags(UnaryOps Opc, Value *V,
+                                              Instruction *CopyO,
+                                              const Twine &Name,
+                                              Instruction *InsertBefore) {
     UnaryOperator *UO = Create(Opc, V, Name, InsertBefore);
     UO->copyIRFlags(CopyO);
     return UO;
@@ -272,15 +271,15 @@ public:
   /// Instruction is allowed to be a dereferenced end iterator.
   ///
   static BinaryOperator *Create(BinaryOps Op, Value *S1, Value *S2,
-                                const Twine &Name,
-                                Instruction *InsertBefore);
+                                const Twine &Name, Instruction *InsertBefore);
 
   /// Construct a binary instruction, given the opcode and the two
   /// operands.  Also automatically insert this instruction to the end of the
   /// BasicBlock specified.
   ///
   static BinaryOperator *Create(BinaryOps Op, Value *S1, Value *S2,
-                                const Twine &Name = Twine(), BasicBlock *InsertAtEnd = nullptr);
+                                const Twine &Name = Twine(),
+                                BasicBlock *InsertAtEnd = nullptr);
 
   /// These methods just forward to Create, and are useful when you
   /// statically know what type of instruction you're going to create.  These
@@ -318,10 +317,10 @@ public:
     return BO;
   }
 
-  static BinaryOperator *
-  CreateWithCopiedFlags(BinaryOps Opc, Value *V1, Value *V2, Value *CopyO,
-                        const Twine &Name,
-                        Instruction *InsertBefore) {
+  static BinaryOperator *CreateWithCopiedFlags(BinaryOps Opc, Value *V1,
+                                               Value *V2, Value *CopyO,
+                                               const Twine &Name,
+                                               Instruction *InsertBefore) {
     BinaryOperator *BO = Create(Opc, V1, V2, Name, InsertBefore);
     BO->copyIRFlags(CopyO);
     return BO;
@@ -611,15 +610,15 @@ protected:
     setName(NameStr);
   }
   /// Constructor with insert-before-instruction semantics for subclasses
-  CastInst(Type *Ty, unsigned iType, Value *S,
-           const Twine &NameStr, Instruction *InsertBefore)
-    : UnaryInstruction(Ty, iType, S, InsertBefore) {
+  CastInst(Type *Ty, unsigned iType, Value *S, const Twine &NameStr,
+           Instruction *InsertBefore)
+      : UnaryInstruction(Ty, iType, S, InsertBefore) {
     setName(NameStr);
   }
   /// Constructor with insert-at-end-of-block semantics for subclasses
-  CastInst(Type *Ty, unsigned iType, Value *S,
-           const Twine &NameStr = "", BasicBlock *InsertAtEnd = nullptr)
-    : UnaryInstruction(Ty, iType, S, InsertAtEnd) {
+  CastInst(Type *Ty, unsigned iType, Value *S, const Twine &NameStr = "",
+           BasicBlock *InsertAtEnd = nullptr)
+      : UnaryInstruction(Ty, iType, S, InsertAtEnd) {
     setName(NameStr);
   }
 
@@ -643,12 +642,12 @@ public:
   /// constructor has insert-before-instruction semantics to automatically
   /// insert the new CastInst before InsertBefore (if it is non-null).
   /// Construct any of the CastInst subclasses
-  static CastInst *Create(
-    Instruction::CastOps,    ///< The opcode of the cast instruction
-    Value *S,                ///< The value to be casted (operand 0)
-    Type *Ty,          ///< The type to which cast should be made
-    const Twine &Name, ///< Name for the instruction
-    Instruction *InsertBefore ///< Place to insert the instruction
+  static CastInst *
+  Create(Instruction::CastOps,     ///< The opcode of the cast instruction
+         Value *S,                 ///< The value to be casted (operand 0)
+         Type *Ty,                 ///< The type to which cast should be made
+         const Twine &Name,        ///< Name for the instruction
+         Instruction *InsertBefore ///< Place to insert the instruction
   );
   /// Provides a way to construct any of the CastInst subclasses using an
   /// opcode instead of the subclass's constructor. The opcode must be in the
@@ -656,12 +655,13 @@ public:
   /// to automatically insert the new CastInst at the end of InsertAtEnd (if
   /// its non-null).
   /// Construct any of the CastInst subclasses
-  static CastInst *Create(
-    Instruction::CastOps,    ///< The opcode for the cast instruction
-    Value *S,                ///< The value to be casted (operand 0)
-    Type *Ty,          ///< The type to which operand is casted
-    const Twine &Name = "", ///< The name for the instruction
-    BasicBlock *InsertAtEnd = nullptr  ///< The block to insert the instruction into
+  static CastInst *
+  Create(Instruction::CastOps,   ///< The opcode for the cast instruction
+         Value *S,               ///< The value to be casted (operand 0)
+         Type *Ty,               ///< The type to which operand is casted
+         const Twine &Name = "", ///< The name for the instruction
+         BasicBlock *InsertAtEnd =
+             nullptr ///< The block to insert the instruction into
   );
 
   /// Create a ZExt or BitCast cast instruction
@@ -674,18 +674,19 @@ public:
 
   /// Create a ZExt or BitCast cast instruction
   static CastInst *CreateZExtOrBitCast(
-    Value *S,                ///< The value to be casted (operand 0)
-    Type *Ty,          ///< The type to which cast should be made
-    const Twine &Name, ///< Name for the instruction
-    Instruction *InsertBefore ///< Place to insert the instruction
+      Value *S,                 ///< The value to be casted (operand 0)
+      Type *Ty,                 ///< The type to which cast should be made
+      const Twine &Name,        ///< Name for the instruction
+      Instruction *InsertBefore ///< Place to insert the instruction
   );
 
   /// Create a ZExt or BitCast cast instruction
-  static CastInst *CreateZExtOrBitCast(
-    Value *S,                ///< The value to be casted (operand 0)
-    Type *Ty,          ///< The type to which operand is casted
-    const Twine &Name = "", ///< The name for the instruction
-    BasicBlock *InsertAtEnd = nullptr  ///< The block to insert the instruction into
+  static CastInst *
+  CreateZExtOrBitCast(Value *S, ///< The value to be casted (operand 0)
+                      Type *Ty, ///< The type to which operand is casted
+                      const Twine &Name = "", ///< The name for the instruction
+                      BasicBlock *InsertAtEnd =
+                          nullptr ///< The block to insert the instruction into
   );
 
   /// Create a SExt or BitCast cast instruction
@@ -698,26 +699,28 @@ public:
 
   /// Create a SExt or BitCast cast instruction
   static CastInst *CreateSExtOrBitCast(
-    Value *S,                ///< The value to be casted (operand 0)
-    Type *Ty,          ///< The type to which cast should be made
-    const Twine &Name, ///< Name for the instruction
-    Instruction *InsertBefore ///< Place to insert the instruction
+      Value *S,                 ///< The value to be casted (operand 0)
+      Type *Ty,                 ///< The type to which cast should be made
+      const Twine &Name,        ///< Name for the instruction
+      Instruction *InsertBefore ///< Place to insert the instruction
   );
 
   /// Create a SExt or BitCast cast instruction
-  static CastInst *CreateSExtOrBitCast(
-    Value *S,                ///< The value to be casted (operand 0)
-    Type *Ty,          ///< The type to which operand is casted
-    const Twine &Name = "", ///< The name for the instruction
-    BasicBlock *InsertAtEnd = nullptr  ///< The block to insert the instruction into
+  static CastInst *
+  CreateSExtOrBitCast(Value *S, ///< The value to be casted (operand 0)
+                      Type *Ty, ///< The type to which operand is casted
+                      const Twine &Name = "", ///< The name for the instruction
+                      BasicBlock *InsertAtEnd =
+                          nullptr ///< The block to insert the instruction into
   );
 
   /// Create a BitCast AddrSpaceCast, or a PtrToInt cast instruction.
-  static CastInst *CreatePointerCast(
-    Value *S,                ///< The pointer value to be casted (operand 0)
-    Type *Ty,          ///< The type to which operand is casted
-    const Twine &Name = "", ///< The name for the instruction
-    BasicBlock *InsertAtEnd = nullptr  ///< The block to insert the instruction into
+  static CastInst *
+  CreatePointerCast(Value *S, ///< The pointer value to be casted (operand 0)
+                    Type *Ty, ///< The type to which operand is casted
+                    const Twine &Name = "", ///< The name for the instruction
+                    BasicBlock *InsertAtEnd =
+                        nullptr ///< The block to insert the instruction into
   );
 
   /// Create a BitCast, AddrSpaceCast or a PtrToInt cast instruction.
@@ -730,18 +733,19 @@ public:
 
   /// Create a BitCast, AddrSpaceCast or a PtrToInt cast instruction.
   static CastInst *CreatePointerCast(
-    Value *S,                ///< The pointer value to be casted (operand 0)
-    Type *Ty,          ///< The type to which cast should be made
-    const Twine &Name, ///< Name for the instruction
-    Instruction *InsertBefore ///< Place to insert the instruction
+      Value *S,                 ///< The pointer value to be casted (operand 0)
+      Type *Ty,                 ///< The type to which cast should be made
+      const Twine &Name,        ///< Name for the instruction
+      Instruction *InsertBefore ///< Place to insert the instruction
   );
 
   /// Create a BitCast or an AddrSpaceCast cast instruction.
   static CastInst *CreatePointerBitCastOrAddrSpaceCast(
-    Value *S,                ///< The pointer value to be casted (operand 0)
-    Type *Ty,          ///< The type to which operand is casted
-    const Twine &Name = "", ///< The name for the instruction
-    BasicBlock *InsertAtEnd = nullptr  ///< The block to insert the instruction into
+      Value *S,               ///< The pointer value to be casted (operand 0)
+      Type *Ty,               ///< The type to which operand is casted
+      const Twine &Name = "", ///< The name for the instruction
+      BasicBlock *InsertAtEnd =
+          nullptr ///< The block to insert the instruction into
   );
 
   /// Create a BitCast or an AddrSpaceCast cast instruction.
@@ -754,10 +758,10 @@ public:
 
   /// Create a BitCast or an AddrSpaceCast cast instruction.
   static CastInst *CreatePointerBitCastOrAddrSpaceCast(
-    Value *S,                ///< The pointer value to be casted (operand 0)
-    Type *Ty,          ///< The type to which cast should be made
-    const Twine &Name, ///< Name for the instruction
-    Instruction *InsertBefore ///< Place to insert the instruction
+      Value *S,                 ///< The pointer value to be casted (operand 0)
+      Type *Ty,                 ///< The type to which cast should be made
+      const Twine &Name,        ///< Name for the instruction
+      Instruction *InsertBefore ///< Place to insert the instruction
   );
 
   /// Create a BitCast, a PtrToInt, or an IntToPTr cast instruction.
@@ -780,10 +784,10 @@ public:
   /// destination a pointer type, creates an IntToPtr cast. Otherwise, creates
   /// a bitcast.
   static CastInst *CreateBitOrPointerCast(
-    Value *S,                ///< The pointer value to be casted (operand 0)
-    Type *Ty,          ///< The type to which cast should be made
-    const Twine &Name, ///< Name for the instruction
-    Instruction *InsertBefore ///< Place to insert the instruction
+      Value *S,                 ///< The pointer value to be casted (operand 0)
+      Type *Ty,                 ///< The type to which cast should be made
+      const Twine &Name,        ///< Name for the instruction
+      Instruction *InsertBefore ///< Place to insert the instruction
   );
 
   /// Create a BitCast, a PtrToInt, or an IntToPTr cast instruction.
@@ -793,10 +797,10 @@ public:
   /// destination a pointer type, creates an IntToPtr cast. Otherwise, creates
   /// a bitcast.
   static CastInst *CreateBitOrPointerCast(
-    Value *S,                ///< The pointer value to be casted (operand 0)
-    Type *Ty,          ///< The type to which cast should be made
-    const Twine &Name = "", ///< Name for the instruction
-    BasicBlock *InsertAtEnd = nullptr ///< Place to insert the instruction
+      Value *S,               ///< The pointer value to be casted (operand 0)
+      Type *Ty,               ///< The type to which cast should be made
+      const Twine &Name = "", ///< Name for the instruction
+      BasicBlock *InsertAtEnd = nullptr ///< Place to insert the instruction
   );
 
   /// Create a ZExt, BitCast, or Trunc for int -> int casts.
@@ -810,20 +814,21 @@ public:
 
   /// Create a ZExt, BitCast, or Trunc for int -> int casts.
   static CastInst *CreateIntegerCast(
-    Value *S,                ///< The pointer value to be casted (operand 0)
-    Type *Ty,          ///< The type to which cast should be made
-    bool isSigned,           ///< Whether to regard S as signed or not
-    const Twine &Name, ///< Name for the instruction
-    Instruction *InsertBefore ///< Place to insert the instruction
+      Value *S,                 ///< The pointer value to be casted (operand 0)
+      Type *Ty,                 ///< The type to which cast should be made
+      bool isSigned,            ///< Whether to regard S as signed or not
+      const Twine &Name,        ///< Name for the instruction
+      Instruction *InsertBefore ///< Place to insert the instruction
   );
 
   /// Create a ZExt, BitCast, or Trunc for int -> int casts.
-  static CastInst *CreateIntegerCast(
-    Value *S,                ///< The integer value to be casted (operand 0)
-    Type *Ty,          ///< The integer type to which operand is casted
-    bool isSigned,           ///< Whether to regard S as signed or not
-    const Twine &Name = "", ///< The name for the instruction
-    BasicBlock *InsertAtEnd = nullptr  ///< The block to insert the instruction into
+  static CastInst *
+  CreateIntegerCast(Value *S, ///< The integer value to be casted (operand 0)
+                    Type *Ty, ///< The integer type to which operand is casted
+                    bool isSigned, ///< Whether to regard S as signed or not
+                    const Twine &Name = "", ///< The name for the instruction
+                    BasicBlock *InsertAtEnd =
+                        nullptr ///< The block to insert the instruction into
   );
 
   /// Create an FPExt, BitCast, or FPTrunc for fp -> fp casts
@@ -835,19 +840,20 @@ public:
   );
 
   /// Create an FPExt, BitCast, or FPTrunc for fp -> fp casts
-  static CastInst *CreateFPCast(
-    Value *S,                ///< The floating point value to be casted
-    Type *Ty,          ///< The floating point type to cast to
-    const Twine &Name, ///< Name for the instruction
-    Instruction *InsertBefore ///< Place to insert the instruction
+  static CastInst *
+  CreateFPCast(Value *S,          ///< The floating point value to be casted
+               Type *Ty,          ///< The floating point type to cast to
+               const Twine &Name, ///< Name for the instruction
+               Instruction *InsertBefore ///< Place to insert the instruction
   );
 
   /// Create an FPExt, BitCast, or FPTrunc for fp -> fp casts
-  static CastInst *CreateFPCast(
-    Value *S,                ///< The floating point value to be casted
-    Type *Ty,          ///< The floating point type to cast to
-    const Twine &Name = "", ///< The name for the instruction
-    BasicBlock *InsertAtEnd = nullptr  ///< The block to insert the instruction into
+  static CastInst *
+  CreateFPCast(Value *S, ///< The floating point value to be casted
+               Type *Ty, ///< The floating point type to cast to
+               const Twine &Name = "", ///< The name for the instruction
+               BasicBlock *InsertAtEnd =
+                   nullptr ///< The block to insert the instruction into
   );
 
   /// Create a Trunc or BitCast cast instruction
@@ -860,18 +866,19 @@ public:
 
   /// Create a Trunc or BitCast cast instruction
   static CastInst *CreateTruncOrBitCast(
-    Value *S,                ///< The value to be casted (operand 0)
-    Type *Ty,          ///< The type to which cast should be made
-    const Twine &Name, ///< Name for the instruction
-    Instruction *InsertBefore ///< Place to insert the instruction
+      Value *S,                 ///< The value to be casted (operand 0)
+      Type *Ty,                 ///< The type to which cast should be made
+      const Twine &Name,        ///< Name for the instruction
+      Instruction *InsertBefore ///< Place to insert the instruction
   );
 
   /// Create a Trunc or BitCast cast instruction
-  static CastInst *CreateTruncOrBitCast(
-    Value *S,                ///< The value to be casted (operand 0)
-    Type *Ty,          ///< The type to which operand is casted
-    const Twine &Name = "", ///< The name for the instruction
-    BasicBlock *InsertAtEnd = nullptr  ///< The block to insert the instruction into
+  static CastInst *
+  CreateTruncOrBitCast(Value *S, ///< The value to be casted (operand 0)
+                       Type *Ty, ///< The type to which operand is casted
+                       const Twine &Name = "", ///< The name for the instruction
+                       BasicBlock *InsertAtEnd =
+                           nullptr ///< The block to insert the instruction into
   );
 
   /// Check whether a bitcast between these types is valid
@@ -1058,13 +1065,12 @@ protected:
           Value *RHS, const Twine &Name, BasicBlock::iterator InsertBefore,
           Instruction *FlagsSource = nullptr);
 
-  CmpInst(Type *ty, Instruction::OtherOps op, Predicate pred,
-          Value *LHS, Value *RHS, const Twine &Name,
-          Instruction *InsertBefore,
+  CmpInst(Type *ty, Instruction::OtherOps op, Predicate pred, Value *LHS,
+          Value *RHS, const Twine &Name, Instruction *InsertBefore,
           Instruction *FlagsSource = nullptr);
 
-  CmpInst(Type *ty, Instruction::OtherOps op, Predicate pred,
-          Value *LHS, Value *RHS, const Twine &Name = "",
+  CmpInst(Type *ty, Instruction::OtherOps op, Predicate pred, Value *LHS,
+          Value *RHS, const Twine &Name = "",
           BasicBlock *InsertAtEnd = nullptr);
 
 public:
@@ -1084,17 +1090,16 @@ public:
   /// instruction into a BasicBlock right before the specified instruction.
   /// The specified Instruction is allowed to be a dereferenced end iterator.
   /// Create a CmpInst
-  static CmpInst *Create(OtherOps Op,
-                         Predicate predicate, Value *S1,
-                         Value *S2, const Twine &Name,
-                         Instruction *InsertBefore);
+  static CmpInst *Create(OtherOps Op, Predicate predicate, Value *S1, Value *S2,
+                         const Twine &Name, Instruction *InsertBefore);
 
   /// Construct a compare instruction, given the opcode, the predicate and the
   /// two operands.  Also automatically insert this instruction to the end of
   /// the BasicBlock specified.
   /// Create a CmpInst
-  static CmpInst *Create(OtherOps Op, Predicate predicate, Value *S1,
-                         Value *S2, const Twine &Name = "", BasicBlock *InsertAtEnd = nullptr);
+  static CmpInst *Create(OtherOps Op, Predicate predicate, Value *S1, Value *S2,
+                         const Twine &Name = "",
+                         BasicBlock *InsertAtEnd = nullptr);
 
   /// Get the opcode casted to the right type
   OtherOps getOpcode() const {
@@ -1575,23 +1580,21 @@ public:
   ///
   /// The returned call instruction is identical \p CI in every way except that
   /// the specified operand bundle has been replaced.
-  static CallBase *Create(CallBase *CB,
-                          OperandBundleDef Bundle,
+  static CallBase *Create(CallBase *CB, OperandBundleDef Bundle,
                           Instruction *InsertPt);
 
   /// Create a clone of \p CB with the operand bundle with the tag matching
-  /// \p Bundle's tag replaced with Bundle, and insert it at the end of \p InsertAtEnd.
+  /// \p Bundle's tag replaced with Bundle, and insert it at the end of \p
+  /// InsertAtEnd.
   ///
   /// The returned call instruction is identical \p CI in every way except that
   /// the specified operand bundle has been replaced.
-  static CallBase *Create(CallBase *CB,
-                          OperandBundleDef Bundle,
+  static CallBase *Create(CallBase *CB, OperandBundleDef Bundle,
                           BasicBlock *InsertAtEnd = nullptr);
 
   /// Create a clone of \p CB with operand bundle \p OB added.
   static CallBase *addOperandBundle(CallBase *CB, uint32_t ID,
-                                    OperandBundleDef OB,
-                                    Instruction *InsertPt);
+                                    OperandBundleDef OB, Instruction *InsertPt);
 
   /// Create a clone of \p CB with operand bundle \p OB added.
   static CallBase *addOperandBundle(CallBase *CB, uint32_t ID,

--- a/llvm/include/llvm/IR/Instruction.h
+++ b/llvm/include/llvm/IR/Instruction.h
@@ -1012,9 +1012,9 @@ protected:
   Instruction(Type *Ty, unsigned iType, Use *Ops, unsigned NumOps,
               InstListType::iterator InsertBefore);
   Instruction(Type *Ty, unsigned iType, Use *Ops, unsigned NumOps,
-              Instruction *InsertBefore = nullptr);
+              Instruction *InsertBefore);
   Instruction(Type *Ty, unsigned iType, Use *Ops, unsigned NumOps,
-              BasicBlock *InsertAtEnd);
+              BasicBlock *InsertAtEnd = nullptr);
 
 private:
   /// Create a copy of this instruction.

--- a/llvm/include/llvm/IR/Instructions.h
+++ b/llvm/include/llvm/IR/Instructions.h
@@ -90,9 +90,9 @@ public:
   AllocaInst(Type *Ty, unsigned AddrSpace, Value *ArraySize, Align Align,
              const Twine &Name, BasicBlock::iterator);
   AllocaInst(Type *Ty, unsigned AddrSpace, Value *ArraySize, Align Align,
-             const Twine &Name = "", Instruction *InsertBefore = nullptr);
+             const Twine &Name, Instruction *InsertBefore);
   AllocaInst(Type *Ty, unsigned AddrSpace, Value *ArraySize, Align Align,
-             const Twine &Name, BasicBlock *InsertAtEnd);
+             const Twine &Name = "", BasicBlock *InsertAtEnd = nullptr);
 
   /// Return true if there is an allocation size parameter to the allocation
   /// instruction that is not 1.
@@ -212,19 +212,19 @@ public:
   LoadInst(Type *Ty, Value *Ptr, const Twine &NameStr, bool isVolatile,
            Align Align, BasicBlock::iterator InsertBefore);
   LoadInst(Type *Ty, Value *Ptr, const Twine &NameStr, bool isVolatile,
-           Align Align, Instruction *InsertBefore = nullptr);
+           Align Align, Instruction *InsertBefore);
   LoadInst(Type *Ty, Value *Ptr, const Twine &NameStr, bool isVolatile,
-           Align Align, BasicBlock *InsertAtEnd);
+           Align Align, BasicBlock *InsertAtEnd = nullptr);
   LoadInst(Type *Ty, Value *Ptr, const Twine &NameStr, bool isVolatile,
            Align Align, AtomicOrdering Order, SyncScope::ID SSID,
            BasicBlock::iterator InsertBefore);
   LoadInst(Type *Ty, Value *Ptr, const Twine &NameStr, bool isVolatile,
            Align Align, AtomicOrdering Order,
-           SyncScope::ID SSID = SyncScope::System,
-           Instruction *InsertBefore = nullptr);
+           SyncScope::ID SSID,
+           Instruction *InsertBefore);
   LoadInst(Type *Ty, Value *Ptr, const Twine &NameStr, bool isVolatile,
-           Align Align, AtomicOrdering Order, SyncScope::ID SSID,
-           BasicBlock *InsertAtEnd);
+           Align Align, AtomicOrdering Order, SyncScope::ID SSID = SyncScope::System,
+           BasicBlock *InsertAtEnd = nullptr);
 
   /// Return true if this is a load from a volatile memory location.
   bool isVolatile() const { return getSubclassData<VolatileField>(); }
@@ -339,16 +339,16 @@ public:
   StoreInst(Value *Val, Value *Ptr, bool isVolatile,
             BasicBlock::iterator InsertBefore);
   StoreInst(Value *Val, Value *Ptr, bool isVolatile, Align Align,
-            Instruction *InsertBefore = nullptr);
+            Instruction *InsertBefore);
   StoreInst(Value *Val, Value *Ptr, bool isVolatile, Align Align,
-            BasicBlock *InsertAtEnd);
+            BasicBlock *InsertAtEnd = nullptr);
   StoreInst(Value *Val, Value *Ptr, bool isVolatile, Align Align,
             BasicBlock::iterator InsertBefore);
   StoreInst(Value *Val, Value *Ptr, bool isVolatile, Align Align,
-            AtomicOrdering Order, SyncScope::ID SSID = SyncScope::System,
-            Instruction *InsertBefore = nullptr);
+            AtomicOrdering Order, SyncScope::ID SSID,
+            Instruction *InsertBefore);
   StoreInst(Value *Val, Value *Ptr, bool isVolatile, Align Align,
-            AtomicOrdering Order, SyncScope::ID SSID, BasicBlock *InsertAtEnd);
+            AtomicOrdering Order, SyncScope::ID SSID = SyncScope::System, BasicBlock *InsertAtEnd = nullptr);
   StoreInst(Value *Val, Value *Ptr, bool isVolatile, Align Align,
             AtomicOrdering Order, SyncScope::ID SSID,
             BasicBlock::iterator InsertBefore);
@@ -474,10 +474,10 @@ public:
   FenceInst(LLVMContext &C, AtomicOrdering Ordering, SyncScope::ID SSID,
             BasicBlock::iterator InsertBefore);
   FenceInst(LLVMContext &C, AtomicOrdering Ordering,
-            SyncScope::ID SSID = SyncScope::System,
-            Instruction *InsertBefore = nullptr);
-  FenceInst(LLVMContext &C, AtomicOrdering Ordering, SyncScope::ID SSID,
-            BasicBlock *InsertAtEnd);
+            SyncScope::ID SSID,
+            Instruction *InsertBefore);
+  FenceInst(LLVMContext &C, AtomicOrdering Ordering, SyncScope::ID SSID = SyncScope::System,
+            BasicBlock *InsertAtEnd = nullptr);
 
   // allocate space for exactly zero operands
   void *operator new(size_t S) { return User::operator new(S, 0); }
@@ -560,11 +560,11 @@ public:
   AtomicCmpXchgInst(Value *Ptr, Value *Cmp, Value *NewVal, Align Alignment,
                     AtomicOrdering SuccessOrdering,
                     AtomicOrdering FailureOrdering, SyncScope::ID SSID,
-                    Instruction *InsertBefore = nullptr);
+                    Instruction *InsertBefore);
   AtomicCmpXchgInst(Value *Ptr, Value *Cmp, Value *NewVal, Align Alignment,
                     AtomicOrdering SuccessOrdering,
                     AtomicOrdering FailureOrdering, SyncScope::ID SSID,
-                    BasicBlock *InsertAtEnd);
+                    BasicBlock *InsertAtEnd = nullptr);
 
   // allocate space for exactly three operands
   void *operator new(size_t S) { return User::operator new(S, 3); }
@@ -824,10 +824,10 @@ public:
                 BasicBlock::iterator InsertBefore);
   AtomicRMWInst(BinOp Operation, Value *Ptr, Value *Val, Align Alignment,
                 AtomicOrdering Ordering, SyncScope::ID SSID,
-                Instruction *InsertBefore = nullptr);
+                Instruction *InsertBefore);
   AtomicRMWInst(BinOp Operation, Value *Ptr, Value *Val, Align Alignment,
                 AtomicOrdering Ordering, SyncScope::ID SSID,
-                BasicBlock *InsertAtEnd);
+                BasicBlock *InsertAtEnd = nullptr);
 
   // allocate space for exactly two operands
   void *operator new(size_t S) { return User::operator new(S, 2); }
@@ -1012,8 +1012,8 @@ public:
 
   static GetElementPtrInst *Create(Type *PointeeType, Value *Ptr,
                                    ArrayRef<Value *> IdxList,
-                                   const Twine &NameStr = "",
-                                   Instruction *InsertBefore = nullptr) {
+                                   const Twine &NameStr,
+                                   Instruction *InsertBefore) {
     unsigned Values = 1 + unsigned(IdxList.size());
     assert(PointeeType && "Must specify element type");
     return new (Values) GetElementPtrInst(PointeeType, Ptr, IdxList, Values,
@@ -1022,8 +1022,8 @@ public:
 
   static GetElementPtrInst *Create(Type *PointeeType, Value *Ptr,
                                    ArrayRef<Value *> IdxList,
-                                   const Twine &NameStr,
-                                   BasicBlock *InsertAtEnd) {
+                                   const Twine &NameStr = "",
+                                   BasicBlock *InsertAtEnd = nullptr) {
     unsigned Values = 1 + unsigned(IdxList.size());
     assert(PointeeType && "Must specify element type");
     return new (Values) GetElementPtrInst(PointeeType, Ptr, IdxList, Values,
@@ -1044,8 +1044,8 @@ public:
 
   static GetElementPtrInst *
   CreateInBounds(Type *PointeeType, Value *Ptr, ArrayRef<Value *> IdxList,
-                 const Twine &NameStr = "",
-                 Instruction *InsertBefore = nullptr) {
+                 const Twine &NameStr,
+                 Instruction *InsertBefore) {
     GetElementPtrInst *GEP =
         Create(PointeeType, Ptr, IdxList, NameStr, InsertBefore);
     GEP->setIsInBounds(true);
@@ -1054,8 +1054,8 @@ public:
 
   static GetElementPtrInst *CreateInBounds(Type *PointeeType, Value *Ptr,
                                            ArrayRef<Value *> IdxList,
-                                           const Twine &NameStr,
-                                           BasicBlock *InsertAtEnd) {
+                                           const Twine &NameStr = "",
+                                           BasicBlock *InsertAtEnd = nullptr) {
     GetElementPtrInst *GEP =
         Create(PointeeType, Ptr, IdxList, NameStr, InsertAtEnd);
     GEP->setIsInBounds(true);
@@ -1622,8 +1622,8 @@ public:
     return new (ComputeNumOperands(0)) CallInst(Ty, F, NameStr, InsertBefore);
   }
 
-  static CallInst *Create(FunctionType *Ty, Value *F, const Twine &NameStr = "",
-                          Instruction *InsertBefore = nullptr) {
+  static CallInst *Create(FunctionType *Ty, Value *F, const Twine &NameStr,
+                          Instruction *InsertBefore) {
     return new (ComputeNumOperands(0)) CallInst(Ty, F, NameStr, InsertBefore);
   }
 
@@ -1636,7 +1636,7 @@ public:
 
   static CallInst *Create(FunctionType *Ty, Value *Func, ArrayRef<Value *> Args,
                           const Twine &NameStr,
-                          Instruction *InsertBefore = nullptr) {
+                          Instruction *InsertBefore) {
     return new (ComputeNumOperands(Args.size()))
         CallInst(Ty, Func, Args, std::nullopt, NameStr, InsertBefore);
   }
@@ -1654,9 +1654,9 @@ public:
   }
 
   static CallInst *Create(FunctionType *Ty, Value *Func, ArrayRef<Value *> Args,
-                          ArrayRef<OperandBundleDef> Bundles = std::nullopt,
-                          const Twine &NameStr = "",
-                          Instruction *InsertBefore = nullptr) {
+                          ArrayRef<OperandBundleDef> Bundles,
+                          const Twine &NameStr,
+                          Instruction *InsertBefore) {
     const int NumOperands =
         ComputeNumOperands(Args.size(), CountBundleInputs(Bundles));
     const unsigned DescriptorBytes = Bundles.size() * sizeof(BundleOpInfo);
@@ -1665,20 +1665,20 @@ public:
         CallInst(Ty, Func, Args, Bundles, NameStr, InsertBefore);
   }
 
-  static CallInst *Create(FunctionType *Ty, Value *F, const Twine &NameStr,
-                          BasicBlock *InsertAtEnd) {
+  static CallInst *Create(FunctionType *Ty, Value *F, const Twine &NameStr = "",
+                          BasicBlock *InsertAtEnd = nullptr) {
     return new (ComputeNumOperands(0)) CallInst(Ty, F, NameStr, InsertAtEnd);
   }
 
   static CallInst *Create(FunctionType *Ty, Value *Func, ArrayRef<Value *> Args,
-                          const Twine &NameStr, BasicBlock *InsertAtEnd) {
+                          const Twine &NameStr, BasicBlock *InsertAtEnd = nullptr) {
     return new (ComputeNumOperands(Args.size()))
         CallInst(Ty, Func, Args, std::nullopt, NameStr, InsertAtEnd);
   }
 
   static CallInst *Create(FunctionType *Ty, Value *Func, ArrayRef<Value *> Args,
-                          ArrayRef<OperandBundleDef> Bundles,
-                          const Twine &NameStr, BasicBlock *InsertAtEnd) {
+                          ArrayRef<OperandBundleDef> Bundles = std::nullopt,
+                          const Twine &NameStr = "", BasicBlock *InsertAtEnd = nullptr) {
     const int NumOperands =
         ComputeNumOperands(Args.size(), CountBundleInputs(Bundles));
     const unsigned DescriptorBytes = Bundles.size() * sizeof(BundleOpInfo);
@@ -1693,8 +1693,8 @@ public:
                   InsertBefore);
   }
 
-  static CallInst *Create(FunctionCallee Func, const Twine &NameStr = "",
-                          Instruction *InsertBefore = nullptr) {
+  static CallInst *Create(FunctionCallee Func, const Twine &NameStr,
+                          Instruction *InsertBefore) {
     return Create(Func.getFunctionType(), Func.getCallee(), NameStr,
                   InsertBefore);
   }
@@ -1705,45 +1705,45 @@ public:
                           BasicBlock::iterator InsertBefore) {
     return Create(Func.getFunctionType(), Func.getCallee(), Args, Bundles,
                   NameStr, InsertBefore);
+  }
+
+  static CallInst *Create(FunctionCallee Func, ArrayRef<Value *> Args,
+                          ArrayRef<OperandBundleDef> Bundles,
+                          const Twine &NameStr,
+                          Instruction *InsertBefore) {
+    return Create(Func.getFunctionType(), Func.getCallee(), Args, Bundles,
+                  NameStr, InsertBefore);
+  }
+
+  static CallInst *Create(FunctionCallee Func, ArrayRef<Value *> Args,
+                          const Twine &NameStr,
+                          BasicBlock::iterator InsertBefore) {
+    return Create(Func.getFunctionType(), Func.getCallee(), Args, NameStr,
+                  InsertBefore);
+  }
+
+  static CallInst *Create(FunctionCallee Func, ArrayRef<Value *> Args,
+                          const Twine &NameStr,
+                          Instruction *InsertBefore) {
+    return Create(Func.getFunctionType(), Func.getCallee(), Args, NameStr,
+                  InsertBefore);
+  }
+
+  static CallInst *Create(FunctionCallee Func, const Twine &NameStr = "",
+                          BasicBlock *InsertAtEnd = nullptr) {
+    return Create(Func.getFunctionType(), Func.getCallee(), NameStr,
+                  InsertAtEnd);
+  }
+
+  static CallInst *Create(FunctionCallee Func, ArrayRef<Value *> Args,
+                          const Twine &NameStr, BasicBlock *InsertAtEnd = nullptr) {
+    return Create(Func.getFunctionType(), Func.getCallee(), Args, NameStr,
+                  InsertAtEnd);
   }
 
   static CallInst *Create(FunctionCallee Func, ArrayRef<Value *> Args,
                           ArrayRef<OperandBundleDef> Bundles = std::nullopt,
-                          const Twine &NameStr = "",
-                          Instruction *InsertBefore = nullptr) {
-    return Create(Func.getFunctionType(), Func.getCallee(), Args, Bundles,
-                  NameStr, InsertBefore);
-  }
-
-  static CallInst *Create(FunctionCallee Func, ArrayRef<Value *> Args,
-                          const Twine &NameStr,
-                          BasicBlock::iterator InsertBefore) {
-    return Create(Func.getFunctionType(), Func.getCallee(), Args, NameStr,
-                  InsertBefore);
-  }
-
-  static CallInst *Create(FunctionCallee Func, ArrayRef<Value *> Args,
-                          const Twine &NameStr,
-                          Instruction *InsertBefore = nullptr) {
-    return Create(Func.getFunctionType(), Func.getCallee(), Args, NameStr,
-                  InsertBefore);
-  }
-
-  static CallInst *Create(FunctionCallee Func, const Twine &NameStr,
-                          BasicBlock *InsertAtEnd) {
-    return Create(Func.getFunctionType(), Func.getCallee(), NameStr,
-                  InsertAtEnd);
-  }
-
-  static CallInst *Create(FunctionCallee Func, ArrayRef<Value *> Args,
-                          const Twine &NameStr, BasicBlock *InsertAtEnd) {
-    return Create(Func.getFunctionType(), Func.getCallee(), Args, NameStr,
-                  InsertAtEnd);
-  }
-
-  static CallInst *Create(FunctionCallee Func, ArrayRef<Value *> Args,
-                          ArrayRef<OperandBundleDef> Bundles,
-                          const Twine &NameStr, BasicBlock *InsertAtEnd) {
+                          const Twine &NameStr = "", BasicBlock *InsertAtEnd = nullptr) {
     return Create(Func.getFunctionType(), Func.getCallee(), Args, Bundles,
                   NameStr, InsertAtEnd);
   }
@@ -1757,7 +1757,9 @@ public:
   static CallInst *Create(CallInst *CI, ArrayRef<OperandBundleDef> Bundles,
                           BasicBlock::iterator InsertPt);
   static CallInst *Create(CallInst *CI, ArrayRef<OperandBundleDef> Bundles,
-                          Instruction *InsertPt = nullptr);
+                          Instruction *InsertPt);
+  static CallInst *Create(CallInst *CI, ArrayRef<OperandBundleDef> Bundles,
+                          BasicBlock *InsertAtEnd = nullptr);
 
   // Note that 'musttail' implies 'tail'.
   enum TailCallKind : unsigned {
@@ -1907,8 +1909,8 @@ public:
   }
 
   static SelectInst *Create(Value *C, Value *S1, Value *S2,
-                            const Twine &NameStr = "",
-                            Instruction *InsertBefore = nullptr,
+                            const Twine &NameStr,
+                            Instruction *InsertBefore,
                             Instruction *MDFrom = nullptr) {
     SelectInst *Sel = new(3) SelectInst(C, S1, S2, NameStr, InsertBefore);
     if (MDFrom)
@@ -1917,8 +1919,8 @@ public:
   }
 
   static SelectInst *Create(Value *C, Value *S1, Value *S2,
-                            const Twine &NameStr,
-                            BasicBlock *InsertAtEnd) {
+                            const Twine &NameStr = "",
+                            BasicBlock *InsertAtEnd = nullptr) {
     return new(3) SelectInst(C, S1, S2, NameStr, InsertAtEnd);
   }
 
@@ -1984,14 +1986,14 @@ public:
     setName(NameStr);
   }
 
-  VAArgInst(Value *List, Type *Ty, const Twine &NameStr = "",
-             Instruction *InsertBefore = nullptr)
+  VAArgInst(Value *List, Type *Ty, const Twine &NameStr,
+             Instruction *InsertBefore)
     : UnaryInstruction(Ty, VAArg, List, InsertBefore) {
     setName(NameStr);
   }
 
-  VAArgInst(Value *List, Type *Ty, const Twine &NameStr,
-            BasicBlock *InsertAtEnd)
+  VAArgInst(Value *List, Type *Ty, const Twine &NameStr = "",
+            BasicBlock *InsertAtEnd = nullptr)
     : UnaryInstruction(Ty, VAArg, List, InsertAtEnd) {
     setName(NameStr);
   }
@@ -2019,10 +2021,10 @@ public:
 class ExtractElementInst : public Instruction {
   ExtractElementInst(Value *Vec, Value *Idx, const Twine &NameStr,
                      BasicBlock::iterator InsertBefore);
-  ExtractElementInst(Value *Vec, Value *Idx, const Twine &NameStr = "",
-                     Instruction *InsertBefore = nullptr);
   ExtractElementInst(Value *Vec, Value *Idx, const Twine &NameStr,
-                     BasicBlock *InsertAtEnd);
+                     Instruction *InsertBefore);
+  ExtractElementInst(Value *Vec, Value *Idx, const Twine &NameStr = "",
+                     BasicBlock *InsertAtEnd = nullptr);
 
 protected:
   // Note: Instruction needs to be a friend here to call cloneImpl.
@@ -2038,14 +2040,14 @@ public:
   }
 
   static ExtractElementInst *Create(Value *Vec, Value *Idx,
-                                   const Twine &NameStr = "",
-                                   Instruction *InsertBefore = nullptr) {
+                                   const Twine &NameStr,
+                                   Instruction *InsertBefore) {
     return new(2) ExtractElementInst(Vec, Idx, NameStr, InsertBefore);
   }
 
   static ExtractElementInst *Create(Value *Vec, Value *Idx,
-                                   const Twine &NameStr,
-                                   BasicBlock *InsertAtEnd) {
+                                   const Twine &NameStr = "",
+                                   BasicBlock *InsertAtEnd = nullptr) {
     return new(2) ExtractElementInst(Vec, Idx, NameStr, InsertAtEnd);
   }
 
@@ -2092,10 +2094,10 @@ class InsertElementInst : public Instruction {
   InsertElementInst(Value *Vec, Value *NewElt, Value *Idx, const Twine &NameStr,
                     BasicBlock::iterator InsertBefore);
   InsertElementInst(Value *Vec, Value *NewElt, Value *Idx,
-                    const Twine &NameStr = "",
-                    Instruction *InsertBefore = nullptr);
-  InsertElementInst(Value *Vec, Value *NewElt, Value *Idx, const Twine &NameStr,
-                    BasicBlock *InsertAtEnd);
+                    const Twine &NameStr,
+                    Instruction *InsertBefore);
+  InsertElementInst(Value *Vec, Value *NewElt, Value *Idx, const Twine &NameStr = "",
+                    BasicBlock *InsertAtEnd = nullptr);
 
 protected:
   // Note: Instruction needs to be a friend here to call cloneImpl.
@@ -2111,14 +2113,14 @@ public:
   }
 
   static InsertElementInst *Create(Value *Vec, Value *NewElt, Value *Idx,
-                                   const Twine &NameStr = "",
-                                   Instruction *InsertBefore = nullptr) {
+                                   const Twine &NameStr,
+                                   Instruction *InsertBefore) {
     return new(3) InsertElementInst(Vec, NewElt, Idx, NameStr, InsertBefore);
   }
 
   static InsertElementInst *Create(Value *Vec, Value *NewElt, Value *Idx,
-                                   const Twine &NameStr,
-                                   BasicBlock *InsertAtEnd) {
+                                   const Twine &NameStr = "",
+                                   BasicBlock *InsertAtEnd = nullptr) {
     return new(3) InsertElementInst(Vec, NewElt, Idx, NameStr, InsertAtEnd);
   }
 
@@ -2181,30 +2183,30 @@ protected:
 public:
   ShuffleVectorInst(Value *V1, Value *Mask, const Twine &NameStr,
                     BasicBlock::iterator InsertBefore);
-  ShuffleVectorInst(Value *V1, Value *Mask, const Twine &NameStr = "",
-                    Instruction *InsertBefore = nullptr);
   ShuffleVectorInst(Value *V1, Value *Mask, const Twine &NameStr,
-                    BasicBlock *InsertAtEnd);
+                    Instruction *InsertBefore);
+  ShuffleVectorInst(Value *V1, Value *Mask, const Twine &NameStr = "",
+                    BasicBlock *InsertAtEnd = nullptr);
   ShuffleVectorInst(Value *V1, ArrayRef<int> Mask, const Twine &NameStr,
                     BasicBlock::iterator InsertBefore);
-  ShuffleVectorInst(Value *V1, ArrayRef<int> Mask, const Twine &NameStr = "",
-                    Instruction *InsertBefore = nullptr);
   ShuffleVectorInst(Value *V1, ArrayRef<int> Mask, const Twine &NameStr,
-                    BasicBlock *InsertAtEnd);
+                    Instruction *InsertBefore);
+  ShuffleVectorInst(Value *V1, ArrayRef<int> Mask, const Twine &NameStr = "",
+                    BasicBlock *InsertAtEnd = nullptr);
   ShuffleVectorInst(Value *V1, Value *V2, Value *Mask, const Twine &NameStr,
-                    BasicBlock::iterator InsertBefor);
+                    BasicBlock::iterator InsertBefore);
   ShuffleVectorInst(Value *V1, Value *V2, Value *Mask,
-                    const Twine &NameStr = "",
-                    Instruction *InsertBefor = nullptr);
+                    const Twine &NameStr,
+                    Instruction *InsertBefore);
   ShuffleVectorInst(Value *V1, Value *V2, Value *Mask,
-                    const Twine &NameStr, BasicBlock *InsertAtEnd);
+                    const Twine &NameStr = "", BasicBlock *InsertAtEnd = nullptr);
   ShuffleVectorInst(Value *V1, Value *V2, ArrayRef<int> Mask,
-                    const Twine &NameStr, BasicBlock::iterator InsertBefor);
+                    const Twine &NameStr, BasicBlock::iterator InsertBefore);
   ShuffleVectorInst(Value *V1, Value *V2, ArrayRef<int> Mask,
-                    const Twine &NameStr = "",
-                    Instruction *InsertBefor = nullptr);
+                    const Twine &NameStr,
+                    Instruction *InsertBefore);
   ShuffleVectorInst(Value *V1, Value *V2, ArrayRef<int> Mask,
-                    const Twine &NameStr, BasicBlock *InsertAtEnd);
+                    const Twine &NameStr = "", BasicBlock *InsertAtEnd = nullptr);
 
   void *operator new(size_t S) { return User::operator new(S, 2); }
   void operator delete(void *Ptr) { return User::operator delete(Ptr); }
@@ -2706,16 +2708,16 @@ public:
 
   static ExtractValueInst *Create(Value *Agg,
                                   ArrayRef<unsigned> Idxs,
-                                  const Twine &NameStr = "",
-                                  Instruction *InsertBefore = nullptr) {
+                                  const Twine &NameStr,
+                                  Instruction *InsertBefore) {
     return new
       ExtractValueInst(Agg, Idxs, NameStr, InsertBefore);
   }
 
   static ExtractValueInst *Create(Value *Agg,
                                   ArrayRef<unsigned> Idxs,
-                                  const Twine &NameStr,
-                                  BasicBlock *InsertAtEnd) {
+                                  const Twine &NameStr = "",
+                                  BasicBlock *InsertAtEnd = nullptr) {
     return new ExtractValueInst(Agg, Idxs, NameStr, InsertAtEnd);
   }
 
@@ -2822,10 +2824,10 @@ class InsertValueInst : public Instruction {
   InsertValueInst(Value *Agg, Value *Val, unsigned Idx, const Twine &NameStr,
                   BasicBlock::iterator InsertBefore);
   InsertValueInst(Value *Agg, Value *Val, unsigned Idx,
-                  const Twine &NameStr = "",
-                  Instruction *InsertBefore = nullptr);
-  InsertValueInst(Value *Agg, Value *Val, unsigned Idx, const Twine &NameStr,
-                  BasicBlock *InsertAtEnd);
+                  const Twine &NameStr,
+                  Instruction *InsertBefore);
+  InsertValueInst(Value *Agg, Value *Val, unsigned Idx, const Twine &NameStr = "",
+                  BasicBlock *InsertAtEnd = nullptr);
 
   void init(Value *Agg, Value *Val, ArrayRef<unsigned> Idxs,
             const Twine &NameStr);
@@ -2849,15 +2851,15 @@ public:
 
   static InsertValueInst *Create(Value *Agg, Value *Val,
                                  ArrayRef<unsigned> Idxs,
-                                 const Twine &NameStr = "",
-                                 Instruction *InsertBefore = nullptr) {
+                                 const Twine &NameStr,
+                                 Instruction *InsertBefore) {
     return new InsertValueInst(Agg, Val, Idxs, NameStr, InsertBefore);
   }
 
   static InsertValueInst *Create(Value *Agg, Value *Val,
                                  ArrayRef<unsigned> Idxs,
-                                 const Twine &NameStr,
-                                 BasicBlock *InsertAtEnd) {
+                                 const Twine &NameStr = "",
+                                 BasicBlock *InsertAtEnd = nullptr) {
     return new InsertValueInst(Agg, Val, Idxs, NameStr, InsertAtEnd);
   }
 
@@ -2977,8 +2979,8 @@ class PHINode : public Instruction {
   }
 
   explicit PHINode(Type *Ty, unsigned NumReservedValues,
-                   const Twine &NameStr = "",
-                   Instruction *InsertBefore = nullptr)
+                   const Twine &NameStr,
+                   Instruction *InsertBefore)
     : Instruction(Ty, Instruction::PHI, nullptr, 0, InsertBefore),
       ReservedSpace(NumReservedValues) {
     assert(!Ty->isTokenTy() && "PHI nodes cannot have token type!");
@@ -2986,8 +2988,8 @@ class PHINode : public Instruction {
     allocHungoffUses(ReservedSpace);
   }
 
-  PHINode(Type *Ty, unsigned NumReservedValues, const Twine &NameStr,
-          BasicBlock *InsertAtEnd)
+  PHINode(Type *Ty, unsigned NumReservedValues, const Twine &NameStr = "",
+          BasicBlock *InsertAtEnd = nullptr)
     : Instruction(Ty, Instruction::PHI, nullptr, 0, InsertAtEnd),
       ReservedSpace(NumReservedValues) {
     assert(!Ty->isTokenTy() && "PHI nodes cannot have token type!");
@@ -3018,13 +3020,13 @@ public:
   }
 
   static PHINode *Create(Type *Ty, unsigned NumReservedValues,
-                         const Twine &NameStr = "",
-                         Instruction *InsertBefore = nullptr) {
+                         const Twine &NameStr,
+                         Instruction *InsertBefore) {
     return new PHINode(Ty, NumReservedValues, NameStr, InsertBefore);
   }
 
   static PHINode *Create(Type *Ty, unsigned NumReservedValues,
-                         const Twine &NameStr, BasicBlock *InsertAtEnd) {
+                         const Twine &NameStr = "", BasicBlock *InsertAtEnd = nullptr) {
     return new PHINode(Ty, NumReservedValues, NameStr, InsertAtEnd);
   }
 
@@ -3270,10 +3272,10 @@ public:
                                 const Twine &NameStr,
                                 BasicBlock::iterator InsertBefore);
   static LandingPadInst *Create(Type *RetTy, unsigned NumReservedClauses,
-                                const Twine &NameStr = "",
-                                Instruction *InsertBefore = nullptr);
+                                const Twine &NameStr,
+                                Instruction *InsertBefore);
   static LandingPadInst *Create(Type *RetTy, unsigned NumReservedClauses,
-                                const Twine &NameStr, BasicBlock *InsertAtEnd);
+                                const Twine &NameStr = "", BasicBlock *InsertAtEnd = nullptr);
 
   /// Provide fast operand accessors
   DECLARE_TRANSPARENT_OPERAND_ACCESSORS(Value);
@@ -3354,9 +3356,9 @@ private:
   // if it was passed NULL.
   explicit ReturnInst(LLVMContext &C, Value *retVal,
                       BasicBlock::iterator InsertBefore);
-  explicit ReturnInst(LLVMContext &C, Value *retVal = nullptr,
-                      Instruction *InsertBefore = nullptr);
-  ReturnInst(LLVMContext &C, Value *retVal, BasicBlock *InsertAtEnd);
+  explicit ReturnInst(LLVMContext &C, Value *retVal,
+                      Instruction *InsertBefore);
+  ReturnInst(LLVMContext &C, Value *retVal = nullptr, BasicBlock *InsertAtEnd = nullptr);
   explicit ReturnInst(LLVMContext &C, BasicBlock *InsertAtEnd);
 
 protected:
@@ -3371,13 +3373,13 @@ public:
     return new (!!retVal) ReturnInst(C, retVal, InsertBefore);
   }
 
-  static ReturnInst* Create(LLVMContext &C, Value *retVal = nullptr,
-                            Instruction *InsertBefore = nullptr) {
+  static ReturnInst* Create(LLVMContext &C, Value *retVal,
+                            Instruction *InsertBefore) {
     return new(!!retVal) ReturnInst(C, retVal, InsertBefore);
   }
 
-  static ReturnInst* Create(LLVMContext &C, Value *retVal,
-                            BasicBlock *InsertAtEnd) {
+  static ReturnInst* Create(LLVMContext &C, Value *retVal = nullptr,
+                            BasicBlock *InsertAtEnd = nullptr) {
     return new(!!retVal) ReturnInst(C, retVal, InsertAtEnd);
   }
 
@@ -3444,12 +3446,12 @@ class BranchInst : public Instruction {
   explicit BranchInst(BasicBlock *IfTrue, BasicBlock::iterator InsertBefore);
   BranchInst(BasicBlock *IfTrue, BasicBlock *IfFalse, Value *Cond,
              BasicBlock::iterator InsertBefore);
-  explicit BranchInst(BasicBlock *IfTrue, Instruction *InsertBefore = nullptr);
+  explicit BranchInst(BasicBlock *IfTrue, Instruction *InsertBefore);
   BranchInst(BasicBlock *IfTrue, BasicBlock *IfFalse, Value *Cond,
-             Instruction *InsertBefore = nullptr);
-  BranchInst(BasicBlock *IfTrue, BasicBlock *InsertAtEnd);
+             Instruction *InsertBefore);
+  BranchInst(BasicBlock *IfTrue, BasicBlock *InsertAtEnd = nullptr);
   BranchInst(BasicBlock *IfTrue, BasicBlock *IfFalse, Value *Cond,
-             BasicBlock *InsertAtEnd);
+             BasicBlock *InsertAtEnd = nullptr);
 
   void AssertOK();
 
@@ -3493,7 +3495,7 @@ public:
   }
 
   static BranchInst *Create(BasicBlock *IfTrue,
-                            Instruction *InsertBefore = nullptr) {
+                            Instruction *InsertBefore) {
     return new(1) BranchInst(IfTrue, InsertBefore);
   }
 
@@ -3503,16 +3505,16 @@ public:
   }
 
   static BranchInst *Create(BasicBlock *IfTrue, BasicBlock *IfFalse,
-                            Value *Cond, Instruction *InsertBefore = nullptr) {
+                            Value *Cond, Instruction *InsertBefore) {
     return new(3) BranchInst(IfTrue, IfFalse, Cond, InsertBefore);
   }
 
-  static BranchInst *Create(BasicBlock *IfTrue, BasicBlock *InsertAtEnd) {
+  static BranchInst *Create(BasicBlock *IfTrue, BasicBlock *InsertAtEnd = nullptr) {
     return new(1) BranchInst(IfTrue, InsertAtEnd);
   }
 
   static BranchInst *Create(BasicBlock *IfTrue, BasicBlock *IfFalse,
-                            Value *Cond, BasicBlock *InsertAtEnd) {
+                            Value *Cond, BasicBlock *InsertAtEnd = nullptr) {
     return new(3) BranchInst(IfTrue, IfFalse, Cond, InsertAtEnd);
   }
 
@@ -3789,12 +3791,12 @@ public:
 
   static SwitchInst *Create(Value *Value, BasicBlock *Default,
                             unsigned NumCases,
-                            Instruction *InsertBefore = nullptr) {
+                            Instruction *InsertBefore) {
     return new SwitchInst(Value, Default, NumCases, InsertBefore);
   }
 
   static SwitchInst *Create(Value *Value, BasicBlock *Default,
-                            unsigned NumCases, BasicBlock *InsertAtEnd) {
+                            unsigned NumCases, BasicBlock *InsertAtEnd = nullptr) {
     return new SwitchInst(Value, Default, NumCases, InsertAtEnd);
   }
 
@@ -4074,12 +4076,12 @@ public:
   }
 
   static IndirectBrInst *Create(Value *Address, unsigned NumDests,
-                                Instruction *InsertBefore = nullptr) {
+                                Instruction *InsertBefore) {
     return new IndirectBrInst(Address, NumDests, InsertBefore);
   }
 
   static IndirectBrInst *Create(Value *Address, unsigned NumDests,
-                                BasicBlock *InsertAtEnd) {
+                                BasicBlock *InsertAtEnd = nullptr) {
     return new IndirectBrInst(Address, NumDests, InsertAtEnd);
   }
 
@@ -4210,7 +4212,7 @@ public:
   static InvokeInst *Create(FunctionType *Ty, Value *Func, BasicBlock *IfNormal,
                             BasicBlock *IfException, ArrayRef<Value *> Args,
                             const Twine &NameStr,
-                            Instruction *InsertBefore = nullptr) {
+                            Instruction *InsertBefore) {
     int NumOperands = ComputeNumOperands(Args.size());
     return new (NumOperands)
         InvokeInst(Ty, Func, IfNormal, IfException, Args, std::nullopt,
@@ -4233,9 +4235,9 @@ public:
 
   static InvokeInst *Create(FunctionType *Ty, Value *Func, BasicBlock *IfNormal,
                             BasicBlock *IfException, ArrayRef<Value *> Args,
-                            ArrayRef<OperandBundleDef> Bundles = std::nullopt,
-                            const Twine &NameStr = "",
-                            Instruction *InsertBefore = nullptr) {
+                            ArrayRef<OperandBundleDef> Bundles,
+                            const Twine &NameStr,
+                            Instruction *InsertBefore) {
     int NumOperands =
         ComputeNumOperands(Args.size(), CountBundleInputs(Bundles));
     unsigned DescriptorBytes = Bundles.size() * sizeof(BundleOpInfo);
@@ -4247,7 +4249,7 @@ public:
 
   static InvokeInst *Create(FunctionType *Ty, Value *Func, BasicBlock *IfNormal,
                             BasicBlock *IfException, ArrayRef<Value *> Args,
-                            const Twine &NameStr, BasicBlock *InsertAtEnd) {
+                            const Twine &NameStr, BasicBlock *InsertAtEnd = nullptr) {
     int NumOperands = ComputeNumOperands(Args.size());
     return new (NumOperands)
         InvokeInst(Ty, Func, IfNormal, IfException, Args, std::nullopt,
@@ -4256,8 +4258,8 @@ public:
 
   static InvokeInst *Create(FunctionType *Ty, Value *Func, BasicBlock *IfNormal,
                             BasicBlock *IfException, ArrayRef<Value *> Args,
-                            ArrayRef<OperandBundleDef> Bundles,
-                            const Twine &NameStr, BasicBlock *InsertAtEnd) {
+                            ArrayRef<OperandBundleDef> Bundles = std::nullopt,
+                            const Twine &NameStr = "", BasicBlock *InsertAtEnd = nullptr) {
     int NumOperands =
         ComputeNumOperands(Args.size(), CountBundleInputs(Bundles));
     unsigned DescriptorBytes = Bundles.size() * sizeof(BundleOpInfo);
@@ -4278,7 +4280,7 @@ public:
   static InvokeInst *Create(FunctionCallee Func, BasicBlock *IfNormal,
                             BasicBlock *IfException, ArrayRef<Value *> Args,
                             const Twine &NameStr,
-                            Instruction *InsertBefore = nullptr) {
+                            Instruction *InsertBefore) {
     return Create(Func.getFunctionType(), Func.getCallee(), IfNormal,
                   IfException, Args, std::nullopt, NameStr, InsertBefore);
   }
@@ -4294,24 +4296,24 @@ public:
 
   static InvokeInst *Create(FunctionCallee Func, BasicBlock *IfNormal,
                             BasicBlock *IfException, ArrayRef<Value *> Args,
-                            ArrayRef<OperandBundleDef> Bundles = std::nullopt,
-                            const Twine &NameStr = "",
-                            Instruction *InsertBefore = nullptr) {
+                            ArrayRef<OperandBundleDef> Bundles,
+                            const Twine &NameStr,
+                            Instruction *InsertBefore) {
     return Create(Func.getFunctionType(), Func.getCallee(), IfNormal,
                   IfException, Args, Bundles, NameStr, InsertBefore);
   }
 
   static InvokeInst *Create(FunctionCallee Func, BasicBlock *IfNormal,
                             BasicBlock *IfException, ArrayRef<Value *> Args,
-                            const Twine &NameStr, BasicBlock *InsertAtEnd) {
+                            const Twine &NameStr, BasicBlock *InsertAtEnd = nullptr) {
     return Create(Func.getFunctionType(), Func.getCallee(), IfNormal,
                   IfException, Args, NameStr, InsertAtEnd);
   }
 
   static InvokeInst *Create(FunctionCallee Func, BasicBlock *IfNormal,
                             BasicBlock *IfException, ArrayRef<Value *> Args,
-                            ArrayRef<OperandBundleDef> Bundles,
-                            const Twine &NameStr, BasicBlock *InsertAtEnd) {
+                            ArrayRef<OperandBundleDef> Bundles = std::nullopt,
+                            const Twine &NameStr = "", BasicBlock *InsertAtEnd = nullptr) {
     return Create(Func.getFunctionType(), Func.getCallee(), IfNormal,
                   IfException, Args, Bundles, NameStr, InsertAtEnd);
   }
@@ -4325,7 +4327,9 @@ public:
   static InvokeInst *Create(InvokeInst *II, ArrayRef<OperandBundleDef> Bundles,
                             BasicBlock::iterator InsertPt);
   static InvokeInst *Create(InvokeInst *II, ArrayRef<OperandBundleDef> Bundles,
-                            Instruction *InsertPt = nullptr);
+                            Instruction *InsertPt);
+  static InvokeInst *Create(InvokeInst *II, ArrayRef<OperandBundleDef> Bundles,
+                            BasicBlock *InsertAtEnd = nullptr);
 
   // get*Dest - Return the destination basic blocks...
   BasicBlock *getNormalDest() const {
@@ -4477,7 +4481,7 @@ public:
                             BasicBlock *DefaultDest,
                             ArrayRef<BasicBlock *> IndirectDests,
                             ArrayRef<Value *> Args, const Twine &NameStr,
-                            Instruction *InsertBefore = nullptr) {
+                            Instruction *InsertBefore) {
     int NumOperands = ComputeNumOperands(Args.size(), IndirectDests.size());
     return new (NumOperands)
         CallBrInst(Ty, Func, DefaultDest, IndirectDests, Args, std::nullopt,
@@ -4501,8 +4505,8 @@ public:
   static CallBrInst *
   Create(FunctionType *Ty, Value *Func, BasicBlock *DefaultDest,
          ArrayRef<BasicBlock *> IndirectDests, ArrayRef<Value *> Args,
-         ArrayRef<OperandBundleDef> Bundles = std::nullopt,
-         const Twine &NameStr = "", Instruction *InsertBefore = nullptr) {
+         ArrayRef<OperandBundleDef> Bundles,
+         const Twine &NameStr, Instruction *InsertBefore) {
     int NumOperands = ComputeNumOperands(Args.size(), IndirectDests.size(),
                                          CountBundleInputs(Bundles));
     unsigned DescriptorBytes = Bundles.size() * sizeof(BundleOpInfo);
@@ -4516,7 +4520,7 @@ public:
                             BasicBlock *DefaultDest,
                             ArrayRef<BasicBlock *> IndirectDests,
                             ArrayRef<Value *> Args, const Twine &NameStr,
-                            BasicBlock *InsertAtEnd) {
+                            BasicBlock *InsertAtEnd = nullptr) {
     int NumOperands = ComputeNumOperands(Args.size(), IndirectDests.size());
     return new (NumOperands)
         CallBrInst(Ty, Func, DefaultDest, IndirectDests, Args, std::nullopt,
@@ -4527,8 +4531,8 @@ public:
                             BasicBlock *DefaultDest,
                             ArrayRef<BasicBlock *> IndirectDests,
                             ArrayRef<Value *> Args,
-                            ArrayRef<OperandBundleDef> Bundles,
-                            const Twine &NameStr, BasicBlock *InsertAtEnd) {
+                            ArrayRef<OperandBundleDef> Bundles = std::nullopt,
+                            const Twine &NameStr = "", BasicBlock *InsertAtEnd = nullptr) {
     int NumOperands = ComputeNumOperands(Args.size(), IndirectDests.size(),
                                          CountBundleInputs(Bundles));
     unsigned DescriptorBytes = Bundles.size() * sizeof(BundleOpInfo);
@@ -4549,7 +4553,7 @@ public:
   static CallBrInst *Create(FunctionCallee Func, BasicBlock *DefaultDest,
                             ArrayRef<BasicBlock *> IndirectDests,
                             ArrayRef<Value *> Args, const Twine &NameStr,
-                            Instruction *InsertBefore = nullptr) {
+                            Instruction *InsertBefore) {
     return Create(Func.getFunctionType(), Func.getCallee(), DefaultDest,
                   IndirectDests, Args, NameStr, InsertBefore);
   }
@@ -4567,9 +4571,9 @@ public:
   static CallBrInst *Create(FunctionCallee Func, BasicBlock *DefaultDest,
                             ArrayRef<BasicBlock *> IndirectDests,
                             ArrayRef<Value *> Args,
-                            ArrayRef<OperandBundleDef> Bundles = std::nullopt,
-                            const Twine &NameStr = "",
-                            Instruction *InsertBefore = nullptr) {
+                            ArrayRef<OperandBundleDef> Bundles,
+                            const Twine &NameStr,
+                            Instruction *InsertBefore) {
     return Create(Func.getFunctionType(), Func.getCallee(), DefaultDest,
                   IndirectDests, Args, Bundles, NameStr, InsertBefore);
   }
@@ -4577,7 +4581,7 @@ public:
   static CallBrInst *Create(FunctionCallee Func, BasicBlock *DefaultDest,
                             ArrayRef<BasicBlock *> IndirectDests,
                             ArrayRef<Value *> Args, const Twine &NameStr,
-                            BasicBlock *InsertAtEnd) {
+                            BasicBlock *InsertAtEnd = nullptr) {
     return Create(Func.getFunctionType(), Func.getCallee(), DefaultDest,
                   IndirectDests, Args, NameStr, InsertAtEnd);
   }
@@ -4586,8 +4590,8 @@ public:
                             BasicBlock *DefaultDest,
                             ArrayRef<BasicBlock *> IndirectDests,
                             ArrayRef<Value *> Args,
-                            ArrayRef<OperandBundleDef> Bundles,
-                            const Twine &NameStr, BasicBlock *InsertAtEnd) {
+                            ArrayRef<OperandBundleDef> Bundles = std::nullopt,
+                            const Twine &NameStr = "", BasicBlock *InsertAtEnd = nullptr) {
     return Create(Func.getFunctionType(), Func.getCallee(), DefaultDest,
                   IndirectDests, Args, Bundles, NameStr, InsertAtEnd);
   }
@@ -4602,7 +4606,10 @@ public:
                             BasicBlock::iterator InsertPt);
   static CallBrInst *Create(CallBrInst *CBI,
                             ArrayRef<OperandBundleDef> Bundles,
-                            Instruction *InsertPt = nullptr);
+                            Instruction *InsertPt);
+  static CallBrInst *Create(CallBrInst *CBI,
+                            ArrayRef<OperandBundleDef> Bundles,
+                            BasicBlock *InsertAtEnd = nullptr);
 
   /// Return the number of callbr indirect dest labels.
   ///
@@ -4729,11 +4736,11 @@ public:
     return new (1) ResumeInst(Exn, InsertBefore);
   }
 
-  static ResumeInst *Create(Value *Exn, Instruction *InsertBefore = nullptr) {
+  static ResumeInst *Create(Value *Exn, Instruction *InsertBefore) {
     return new(1) ResumeInst(Exn, InsertBefore);
   }
 
-  static ResumeInst *Create(Value *Exn, BasicBlock *InsertAtEnd) {
+  static ResumeInst *Create(Value *Exn, BasicBlock *InsertAtEnd = nullptr) {
     return new(1) ResumeInst(Exn, InsertAtEnd);
   }
 
@@ -4833,15 +4840,15 @@ public:
 
   static CatchSwitchInst *Create(Value *ParentPad, BasicBlock *UnwindDest,
                                  unsigned NumHandlers,
-                                 const Twine &NameStr = "",
-                                 Instruction *InsertBefore = nullptr) {
+                                 const Twine &NameStr,
+                                 Instruction *InsertBefore) {
     return new CatchSwitchInst(ParentPad, UnwindDest, NumHandlers, NameStr,
                                InsertBefore);
   }
 
   static CatchSwitchInst *Create(Value *ParentPad, BasicBlock *UnwindDest,
-                                 unsigned NumHandlers, const Twine &NameStr,
-                                 BasicBlock *InsertAtEnd) {
+                                 unsigned NumHandlers, const Twine &NameStr = "",
+                                 BasicBlock *InsertAtEnd = nullptr) {
     return new CatchSwitchInst(ParentPad, UnwindDest, NumHandlers, NameStr,
                                InsertAtEnd);
   }
@@ -4994,16 +5001,16 @@ public:
   }
 
   static CleanupPadInst *Create(Value *ParentPad,
-                                ArrayRef<Value *> Args = std::nullopt,
-                                const Twine &NameStr = "",
-                                Instruction *InsertBefore = nullptr) {
+                                ArrayRef<Value *> Args,
+                                const Twine &NameStr,
+                                Instruction *InsertBefore) {
     unsigned Values = 1 + Args.size();
     return new (Values)
         CleanupPadInst(ParentPad, Args, Values, NameStr, InsertBefore);
   }
 
-  static CleanupPadInst *Create(Value *ParentPad, ArrayRef<Value *> Args,
-                                const Twine &NameStr, BasicBlock *InsertAtEnd) {
+  static CleanupPadInst *Create(Value *ParentPad, ArrayRef<Value *> Args = std::nullopt,
+                                const Twine &NameStr = "", BasicBlock *InsertAtEnd = nullptr) {
     unsigned Values = 1 + Args.size();
     return new (Values)
         CleanupPadInst(ParentPad, Args, Values, NameStr, InsertAtEnd);
@@ -5049,15 +5056,15 @@ public:
   }
 
   static CatchPadInst *Create(Value *CatchSwitch, ArrayRef<Value *> Args,
-                              const Twine &NameStr = "",
-                              Instruction *InsertBefore = nullptr) {
+                              const Twine &NameStr,
+                              Instruction *InsertBefore) {
     unsigned Values = 1 + Args.size();
     return new (Values)
         CatchPadInst(CatchSwitch, Args, Values, NameStr, InsertBefore);
   }
 
   static CatchPadInst *Create(Value *CatchSwitch, ArrayRef<Value *> Args,
-                              const Twine &NameStr, BasicBlock *InsertAtEnd) {
+                              const Twine &NameStr = "", BasicBlock *InsertAtEnd = nullptr) {
     unsigned Values = 1 + Args.size();
     return new (Values)
         CatchPadInst(CatchSwitch, Args, Values, NameStr, InsertAtEnd);
@@ -5109,14 +5116,14 @@ public:
   }
 
   static CatchReturnInst *Create(Value *CatchPad, BasicBlock *BB,
-                                 Instruction *InsertBefore = nullptr) {
+                                 Instruction *InsertBefore) {
     assert(CatchPad);
     assert(BB);
     return new (2) CatchReturnInst(CatchPad, BB, InsertBefore);
   }
 
   static CatchReturnInst *Create(Value *CatchPad, BasicBlock *BB,
-                                 BasicBlock *InsertAtEnd) {
+                                 BasicBlock *InsertAtEnd = nullptr) {
     assert(CatchPad);
     assert(BB);
     return new (2) CatchReturnInst(CatchPad, BB, InsertAtEnd);
@@ -5183,9 +5190,9 @@ private:
   CleanupReturnInst(Value *CleanupPad, BasicBlock *UnwindBB, unsigned Values,
                     BasicBlock::iterator InsertBefore);
   CleanupReturnInst(Value *CleanupPad, BasicBlock *UnwindBB, unsigned Values,
-                    Instruction *InsertBefore = nullptr);
+                    Instruction *InsertBefore);
   CleanupReturnInst(Value *CleanupPad, BasicBlock *UnwindBB, unsigned Values,
-                    BasicBlock *InsertAtEnd);
+                    BasicBlock *InsertAtEnd = nullptr);
 
   void init(Value *CleanupPad, BasicBlock *UnwindBB);
 
@@ -5207,8 +5214,8 @@ public:
   }
 
   static CleanupReturnInst *Create(Value *CleanupPad,
-                                   BasicBlock *UnwindBB = nullptr,
-                                   Instruction *InsertBefore = nullptr) {
+                                   BasicBlock *UnwindBB,
+                                   Instruction *InsertBefore) {
     assert(CleanupPad);
     unsigned Values = 1;
     if (UnwindBB)
@@ -5217,8 +5224,8 @@ public:
         CleanupReturnInst(CleanupPad, UnwindBB, Values, InsertBefore);
   }
 
-  static CleanupReturnInst *Create(Value *CleanupPad, BasicBlock *UnwindBB,
-                                   BasicBlock *InsertAtEnd) {
+  static CleanupReturnInst *Create(Value *CleanupPad, BasicBlock *UnwindBB = nullptr,
+                                   BasicBlock *InsertAtEnd = nullptr) {
     assert(CleanupPad);
     unsigned Values = 1;
     if (UnwindBB)
@@ -5304,8 +5311,8 @@ protected:
 
 public:
   explicit UnreachableInst(LLVMContext &C, BasicBlock::iterator InsertBefore);
-  explicit UnreachableInst(LLVMContext &C, Instruction *InsertBefore = nullptr);
-  explicit UnreachableInst(LLVMContext &C, BasicBlock *InsertAtEnd);
+  explicit UnreachableInst(LLVMContext &C, Instruction *InsertBefore);
+  explicit UnreachableInst(LLVMContext &C, BasicBlock *InsertAtEnd = nullptr);
 
   // allocate space for exactly zero operands
   void *operator new(size_t S) { return User::operator new(S, 0); }
@@ -5357,16 +5364,16 @@ public:
   TruncInst(
     Value *S,                           ///< The value to be truncated
     Type *Ty,                           ///< The (smaller) type to truncate to
-    const Twine &NameStr = "",          ///< A name for the new instruction
-    Instruction *InsertBefore = nullptr ///< Where to insert the new instruction
+    const Twine &NameStr,               ///< A name for the new instruction
+    Instruction *InsertBefore           ///< Where to insert the new instruction
   );
 
   /// Constructor with insert-at-end-of-block semantics
   TruncInst(
-    Value *S,                     ///< The value to be truncated
-    Type *Ty,                     ///< The (smaller) type to truncate to
-    const Twine &NameStr,         ///< A name for the new instruction
-    BasicBlock *InsertAtEnd       ///< The block to insert the instruction into
+    Value *S,                           ///< The value to be truncated
+    Type *Ty,                           ///< The (smaller) type to truncate to
+    const Twine &NameStr = "",          ///< A name for the new instruction
+    BasicBlock *InsertAtEnd = nullptr   ///< The block to insert at the end of
   );
 
   /// Methods for support type inquiry through isa, cast, and dyn_cast:
@@ -5402,18 +5409,18 @@ public:
 
   /// Constructor with insert-before-instruction semantics
   ZExtInst(
-    Value *S,                           ///< The value to be zero extended
-    Type *Ty,                           ///< The type to zero extend to
-    const Twine &NameStr = "",          ///< A name for the new instruction
-    Instruction *InsertBefore = nullptr ///< Where to insert the new instruction
+    Value *S,                   ///< The value to be zero extended
+    Type *Ty,                   ///< The type to zero extend to
+    const Twine &NameStr,       ///< A name for the new instruction
+    Instruction *InsertBefore   ///< Where to insert the new instruction
   );
 
   /// Constructor with insert-at-end semantics.
   ZExtInst(
-    Value *S,                     ///< The value to be zero extended
-    Type *Ty,                     ///< The type to zero extend to
-    const Twine &NameStr,         ///< A name for the new instruction
-    BasicBlock *InsertAtEnd       ///< The block to insert the instruction into
+    Value *S,                           ///< The value to be zero extended
+    Type *Ty,                           ///< The type to zero extend to
+    const Twine &NameStr = "",          ///< A name for the new instruction
+    BasicBlock *InsertAtEnd = nullptr   ///< The block to insert at the end of
   );
 
   /// Methods for support type inquiry through isa, cast, and dyn_cast:
@@ -5451,16 +5458,16 @@ public:
   SExtInst(
     Value *S,                           ///< The value to be sign extended
     Type *Ty,                           ///< The type to sign extend to
-    const Twine &NameStr = "",          ///< A name for the new instruction
-    Instruction *InsertBefore = nullptr ///< Where to insert the new instruction
+    const Twine &NameStr,          ///< A name for the new instruction
+    Instruction *InsertBefore ///< Where to insert the new instruction
   );
 
   /// Constructor with insert-at-end-of-block semantics
   SExtInst(
-    Value *S,                     ///< The value to be sign extended
-    Type *Ty,                     ///< The type to sign extend to
-    const Twine &NameStr,         ///< A name for the new instruction
-    BasicBlock *InsertAtEnd       ///< The block to insert the instruction into
+    Value *S,                           ///< The value to be sign extended
+    Type *Ty,                           ///< The type to sign extend to
+    const Twine &NameStr = "",          ///< A name for the new instruction
+    BasicBlock *InsertAtEnd = nullptr   ///< The block to insert at the end of
   );
 
   /// Methods for support type inquiry through isa, cast, and dyn_cast:
@@ -5496,18 +5503,18 @@ public:
 
   /// Constructor with insert-before-instruction semantics
   FPTruncInst(
-    Value *S,                           ///< The value to be truncated
-    Type *Ty,                           ///< The type to truncate to
-    const Twine &NameStr = "",          ///< A name for the new instruction
-    Instruction *InsertBefore = nullptr ///< Where to insert the new instruction
+    Value *S,                   ///< The value to be truncated
+    Type *Ty,                   ///< The type to truncate to
+    const Twine &NameStr,       ///< A name for the new instruction
+    Instruction *InsertBefore   ///< Where to insert the new instruction
   );
 
   /// Constructor with insert-before-instruction semantics
   FPTruncInst(
-    Value *S,                     ///< The value to be truncated
-    Type *Ty,                     ///< The type to truncate to
-    const Twine &NameStr,         ///< A name for the new instruction
-    BasicBlock *InsertAtEnd       ///< The block to insert the instruction into
+    Value *S,                           ///< The value to be truncated
+    Type *Ty,                           ///< The type to truncate to
+    const Twine &NameStr = "",          ///< A name for the new instruction
+    BasicBlock *InsertAtEnd = nullptr   ///< The block to insert at the end of
   );
 
   /// Methods for support type inquiry through isa, cast, and dyn_cast:
@@ -5545,16 +5552,16 @@ public:
   FPExtInst(
     Value *S,                           ///< The value to be extended
     Type *Ty,                           ///< The type to extend to
-    const Twine &NameStr = "",          ///< A name for the new instruction
-    Instruction *InsertBefore = nullptr ///< Where to insert the new instruction
+    const Twine &NameStr,          ///< A name for the new instruction
+    Instruction *InsertBefore ///< Where to insert the new instruction
   );
 
   /// Constructor with insert-at-end-of-block semantics
   FPExtInst(
-    Value *S,                     ///< The value to be extended
-    Type *Ty,                     ///< The type to extend to
-    const Twine &NameStr,         ///< A name for the new instruction
-    BasicBlock *InsertAtEnd       ///< The block to insert the instruction into
+    Value *S,                           ///< The value to be extended
+    Type *Ty,                           ///< The type to extend to
+    const Twine &NameStr = "",          ///< A name for the new instruction
+    BasicBlock *InsertAtEnd = nullptr   ///< The block to insert at the end of
   );
 
   /// Methods for support type inquiry through isa, cast, and dyn_cast:
@@ -5592,16 +5599,16 @@ public:
   UIToFPInst(
     Value *S,                           ///< The value to be converted
     Type *Ty,                           ///< The type to convert to
-    const Twine &NameStr = "",          ///< A name for the new instruction
-    Instruction *InsertBefore = nullptr ///< Where to insert the new instruction
+    const Twine &NameStr,          ///< A name for the new instruction
+    Instruction *InsertBefore ///< Where to insert the new instruction
   );
 
   /// Constructor with insert-at-end-of-block semantics
   UIToFPInst(
-    Value *S,                     ///< The value to be converted
-    Type *Ty,                     ///< The type to convert to
-    const Twine &NameStr,         ///< A name for the new instruction
-    BasicBlock *InsertAtEnd       ///< The block to insert the instruction into
+    Value *S,                           ///< The value to be converted
+    Type *Ty,                           ///< The type to convert to
+    const Twine &NameStr = "",          ///< A name for the new instruction
+    BasicBlock *InsertAtEnd = nullptr   ///< The block to insert at the end of
   );
 
   /// Methods for support type inquiry through isa, cast, and dyn_cast:
@@ -5637,18 +5644,18 @@ public:
 
   /// Constructor with insert-before-instruction semantics
   SIToFPInst(
-    Value *S,                           ///< The value to be converted
-    Type *Ty,                           ///< The type to convert to
-    const Twine &NameStr = "",          ///< A name for the new instruction
-    Instruction *InsertBefore = nullptr ///< Where to insert the new instruction
+    Value *S,                   ///< The value to be converted
+    Type *Ty,                   ///< The type to convert to
+    const Twine &NameStr,       ///< A name for the new instruction
+    Instruction *InsertBefore   ///< Where to insert the new instruction
   );
 
   /// Constructor with insert-at-end-of-block semantics
   SIToFPInst(
-    Value *S,                     ///< The value to be converted
-    Type *Ty,                     ///< The type to convert to
-    const Twine &NameStr,         ///< A name for the new instruction
-    BasicBlock *InsertAtEnd       ///< The block to insert the instruction into
+    Value *S,                           ///< The value to be converted
+    Type *Ty,                           ///< The type to convert to
+    const Twine &NameStr = "",          ///< A name for the new instruction
+    BasicBlock *InsertAtEnd = nullptr   ///< The block to insert at the end of
   );
 
   /// Methods for support type inquiry through isa, cast, and dyn_cast:
@@ -5684,18 +5691,18 @@ public:
 
   /// Constructor with insert-before-instruction semantics
   FPToUIInst(
-    Value *S,                           ///< The value to be converted
-    Type *Ty,                           ///< The type to convert to
-    const Twine &NameStr = "",          ///< A name for the new instruction
-    Instruction *InsertBefore = nullptr ///< Where to insert the new instruction
+    Value *S,                   ///< The value to be converted
+    Type *Ty,                   ///< The type to convert to
+    const Twine &NameStr,       ///< A name for the new instruction
+    Instruction *InsertBefore   ///< Where to insert the new instruction
   );
 
   /// Constructor with insert-at-end-of-block semantics
   FPToUIInst(
-    Value *S,                     ///< The value to be converted
-    Type *Ty,                     ///< The type to convert to
-    const Twine &NameStr,         ///< A name for the new instruction
-    BasicBlock *InsertAtEnd       ///< Where to insert the new instruction
+    Value *S,                           ///< The value to be converted
+    Type *Ty,                           ///< The type to convert to
+    const Twine &NameStr = "",          ///< A name for the new instruction
+    BasicBlock *InsertAtEnd = nullptr   ///< The block to insert at the end of
   );
 
   /// Methods for support type inquiry through isa, cast, and dyn_cast:
@@ -5731,18 +5738,18 @@ public:
 
   /// Constructor with insert-before-instruction semantics
   FPToSIInst(
-    Value *S,                           ///< The value to be converted
-    Type *Ty,                           ///< The type to convert to
-    const Twine &NameStr = "",          ///< A name for the new instruction
-    Instruction *InsertBefore = nullptr ///< Where to insert the new instruction
+    Value *S,                   ///< The value to be converted
+    Type *Ty,                   ///< The type to convert to
+    const Twine &NameStr,       ///< A name for the new instruction
+    Instruction *InsertBefore   ///< Where to insert the new instruction
   );
 
   /// Constructor with insert-at-end-of-block semantics
   FPToSIInst(
-    Value *S,                     ///< The value to be converted
-    Type *Ty,                     ///< The type to convert to
-    const Twine &NameStr,         ///< A name for the new instruction
-    BasicBlock *InsertAtEnd       ///< The block to insert the instruction into
+    Value *S,                           ///< The value to be converted
+    Type *Ty,                           ///< The type to convert to
+    const Twine &NameStr = "",          ///< A name for the new instruction
+    BasicBlock *InsertAtEnd = nullptr   ///< The block to insert at the end of
   );
 
   /// Methods for support type inquiry through isa, cast, and dyn_cast:
@@ -5774,18 +5781,18 @@ public:
 
   /// Constructor with insert-before-instruction semantics
   IntToPtrInst(
-    Value *S,                           ///< The value to be converted
-    Type *Ty,                           ///< The type to convert to
-    const Twine &NameStr = "",          ///< A name for the new instruction
-    Instruction *InsertBefore = nullptr ///< Where to insert the new instruction
+    Value *S,                   ///< The value to be converted
+    Type *Ty,                   ///< The type to convert to
+    const Twine &NameStr,       ///< A name for the new instruction
+    Instruction *InsertBefore   ///< Where to insert the new instruction
   );
 
   /// Constructor with insert-at-end-of-block semantics
   IntToPtrInst(
-    Value *S,                     ///< The value to be converted
-    Type *Ty,                     ///< The type to convert to
-    const Twine &NameStr,         ///< A name for the new instruction
-    BasicBlock *InsertAtEnd       ///< The block to insert the instruction into
+    Value *S,                           ///< The value to be converted
+    Type *Ty,                           ///< The type to convert to
+    const Twine &NameStr = "",          ///< A name for the new instruction
+    BasicBlock *InsertAtEnd = nullptr   ///< The block to insert at the end of
   );
 
   /// Clone an identical IntToPtrInst.
@@ -5829,18 +5836,18 @@ public:
 
   /// Constructor with insert-before-instruction semantics
   PtrToIntInst(
-    Value *S,                           ///< The value to be converted
-    Type *Ty,                           ///< The type to convert to
-    const Twine &NameStr = "",          ///< A name for the new instruction
-    Instruction *InsertBefore = nullptr ///< Where to insert the new instruction
+    Value *S,                   ///< The value to be converted
+    Type *Ty,                   ///< The type to convert to
+    const Twine &NameStr,       ///< A name for the new instruction
+    Instruction *InsertBefore   ///< Where to insert the new instruction
   );
 
   /// Constructor with insert-at-end-of-block semantics
   PtrToIntInst(
-    Value *S,                     ///< The value to be converted
-    Type *Ty,                     ///< The type to convert to
-    const Twine &NameStr,         ///< A name for the new instruction
-    BasicBlock *InsertAtEnd       ///< The block to insert the instruction into
+    Value *S,                           ///< The value to be converted
+    Type *Ty,                           ///< The type to convert to
+    const Twine &NameStr = "",          ///< A name for the new instruction
+    BasicBlock *InsertAtEnd = nullptr   ///< The block to insert at the end of
   );
 
   /// Gets the pointer operand.
@@ -5888,18 +5895,18 @@ public:
 
   /// Constructor with insert-before-instruction semantics
   BitCastInst(
-    Value *S,                           ///< The value to be casted
-    Type *Ty,                           ///< The type to casted to
-    const Twine &NameStr = "",          ///< A name for the new instruction
-    Instruction *InsertBefore = nullptr ///< Where to insert the new instruction
+    Value *S,                   ///< The value to be casted
+    Type *Ty,                   ///< The type to casted to
+    const Twine &NameStr,       ///< A name for the new instruction
+    Instruction *InsertBefore   ///< Where to insert the new instruction
   );
 
   /// Constructor with insert-at-end-of-block semantics
   BitCastInst(
-    Value *S,                     ///< The value to be casted
-    Type *Ty,                     ///< The type to casted to
-    const Twine &NameStr,         ///< A name for the new instruction
-    BasicBlock *InsertAtEnd       ///< The block to insert the instruction into
+    Value *S,                           ///< The value to be casted
+    Type *Ty,                           ///< The type to casted to
+    const Twine &NameStr = "",          ///< A name for the new instruction
+    BasicBlock *InsertAtEnd = nullptr   ///< The block to insert at the end of
   );
 
   // Methods for support type inquiry through isa, cast, and dyn_cast:
@@ -5936,18 +5943,18 @@ public:
 
   /// Constructor with insert-before-instruction semantics
   AddrSpaceCastInst(
-    Value *S,                           ///< The value to be casted
-    Type *Ty,                           ///< The type to casted to
-    const Twine &NameStr = "",          ///< A name for the new instruction
-    Instruction *InsertBefore = nullptr ///< Where to insert the new instruction
+    Value *S,                   ///< The value to be casted
+    Type *Ty,                   ///< The type to casted to
+    const Twine &NameStr,       ///< A name for the new instruction
+    Instruction *InsertBefore   ///< Where to insert the new instruction
   );
 
   /// Constructor with insert-at-end-of-block semantics
   AddrSpaceCastInst(
-    Value *S,                     ///< The value to be casted
-    Type *Ty,                     ///< The type to casted to
-    const Twine &NameStr,         ///< A name for the new instruction
-    BasicBlock *InsertAtEnd       ///< The block to insert the instruction into
+    Value *S,                           ///< The value to be casted
+    Type *Ty,                           ///< The type to casted to
+    const Twine &NameStr = "",          ///< A name for the new instruction
+    BasicBlock *InsertAtEnd = nullptr   ///< The block to insert at the end of
   );
 
   // Methods for support type inquiry through isa, cast, and dyn_cast:
@@ -6079,9 +6086,9 @@ public:
   explicit FreezeInst(Value *S, const Twine &NameStr,
                       BasicBlock::iterator InsertBefore);
   explicit FreezeInst(Value *S,
-                      const Twine &NameStr = "",
-                      Instruction *InsertBefore = nullptr);
-  FreezeInst(Value *S, const Twine &NameStr, BasicBlock *InsertAtEnd);
+                      const Twine &NameStr,
+                      Instruction *InsertBefore);
+  FreezeInst(Value *S, const Twine &NameStr = "", BasicBlock *InsertAtEnd = nullptr);
 
   // Methods for support type inquiry through isa, cast, and dyn_cast:
   static inline bool classof(const Instruction *I) {

--- a/llvm/include/llvm/IR/Instructions.h
+++ b/llvm/include/llvm/IR/Instructions.h
@@ -219,11 +219,11 @@ public:
            Align Align, AtomicOrdering Order, SyncScope::ID SSID,
            BasicBlock::iterator InsertBefore);
   LoadInst(Type *Ty, Value *Ptr, const Twine &NameStr, bool isVolatile,
-           Align Align, AtomicOrdering Order,
-           SyncScope::ID SSID,
+           Align Align, AtomicOrdering Order, SyncScope::ID SSID,
            Instruction *InsertBefore);
   LoadInst(Type *Ty, Value *Ptr, const Twine &NameStr, bool isVolatile,
-           Align Align, AtomicOrdering Order, SyncScope::ID SSID = SyncScope::System,
+           Align Align, AtomicOrdering Order,
+           SyncScope::ID SSID = SyncScope::System,
            BasicBlock *InsertAtEnd = nullptr);
 
   /// Return true if this is a load from a volatile memory location.
@@ -348,7 +348,8 @@ public:
             AtomicOrdering Order, SyncScope::ID SSID,
             Instruction *InsertBefore);
   StoreInst(Value *Val, Value *Ptr, bool isVolatile, Align Align,
-            AtomicOrdering Order, SyncScope::ID SSID = SyncScope::System, BasicBlock *InsertAtEnd = nullptr);
+            AtomicOrdering Order, SyncScope::ID SSID = SyncScope::System,
+            BasicBlock *InsertAtEnd = nullptr);
   StoreInst(Value *Val, Value *Ptr, bool isVolatile, Align Align,
             AtomicOrdering Order, SyncScope::ID SSID,
             BasicBlock::iterator InsertBefore);
@@ -473,10 +474,10 @@ public:
   // SequentiallyConsistent.
   FenceInst(LLVMContext &C, AtomicOrdering Ordering, SyncScope::ID SSID,
             BasicBlock::iterator InsertBefore);
-  FenceInst(LLVMContext &C, AtomicOrdering Ordering,
-            SyncScope::ID SSID,
+  FenceInst(LLVMContext &C, AtomicOrdering Ordering, SyncScope::ID SSID,
             Instruction *InsertBefore);
-  FenceInst(LLVMContext &C, AtomicOrdering Ordering, SyncScope::ID SSID = SyncScope::System,
+  FenceInst(LLVMContext &C, AtomicOrdering Ordering,
+            SyncScope::ID SSID = SyncScope::System,
             BasicBlock *InsertAtEnd = nullptr);
 
   // allocate space for exactly zero operands
@@ -1042,10 +1043,10 @@ public:
     return GEP;
   }
 
-  static GetElementPtrInst *
-  CreateInBounds(Type *PointeeType, Value *Ptr, ArrayRef<Value *> IdxList,
-                 const Twine &NameStr,
-                 Instruction *InsertBefore) {
+  static GetElementPtrInst *CreateInBounds(Type *PointeeType, Value *Ptr,
+                                           ArrayRef<Value *> IdxList,
+                                           const Twine &NameStr,
+                                           Instruction *InsertBefore) {
     GetElementPtrInst *GEP =
         Create(PointeeType, Ptr, IdxList, NameStr, InsertBefore);
     GEP->setIsInBounds(true);
@@ -1635,8 +1636,7 @@ public:
   }
 
   static CallInst *Create(FunctionType *Ty, Value *Func, ArrayRef<Value *> Args,
-                          const Twine &NameStr,
-                          Instruction *InsertBefore) {
+                          const Twine &NameStr, Instruction *InsertBefore) {
     return new (ComputeNumOperands(Args.size()))
         CallInst(Ty, Func, Args, std::nullopt, NameStr, InsertBefore);
   }
@@ -1655,8 +1655,7 @@ public:
 
   static CallInst *Create(FunctionType *Ty, Value *Func, ArrayRef<Value *> Args,
                           ArrayRef<OperandBundleDef> Bundles,
-                          const Twine &NameStr,
-                          Instruction *InsertBefore) {
+                          const Twine &NameStr, Instruction *InsertBefore) {
     const int NumOperands =
         ComputeNumOperands(Args.size(), CountBundleInputs(Bundles));
     const unsigned DescriptorBytes = Bundles.size() * sizeof(BundleOpInfo);
@@ -1671,14 +1670,16 @@ public:
   }
 
   static CallInst *Create(FunctionType *Ty, Value *Func, ArrayRef<Value *> Args,
-                          const Twine &NameStr, BasicBlock *InsertAtEnd = nullptr) {
+                          const Twine &NameStr,
+                          BasicBlock *InsertAtEnd = nullptr) {
     return new (ComputeNumOperands(Args.size()))
         CallInst(Ty, Func, Args, std::nullopt, NameStr, InsertAtEnd);
   }
 
   static CallInst *Create(FunctionType *Ty, Value *Func, ArrayRef<Value *> Args,
                           ArrayRef<OperandBundleDef> Bundles = std::nullopt,
-                          const Twine &NameStr = "", BasicBlock *InsertAtEnd = nullptr) {
+                          const Twine &NameStr = "",
+                          BasicBlock *InsertAtEnd = nullptr) {
     const int NumOperands =
         ComputeNumOperands(Args.size(), CountBundleInputs(Bundles));
     const unsigned DescriptorBytes = Bundles.size() * sizeof(BundleOpInfo);
@@ -1709,8 +1710,7 @@ public:
 
   static CallInst *Create(FunctionCallee Func, ArrayRef<Value *> Args,
                           ArrayRef<OperandBundleDef> Bundles,
-                          const Twine &NameStr,
-                          Instruction *InsertBefore) {
+                          const Twine &NameStr, Instruction *InsertBefore) {
     return Create(Func.getFunctionType(), Func.getCallee(), Args, Bundles,
                   NameStr, InsertBefore);
   }
@@ -1723,8 +1723,7 @@ public:
   }
 
   static CallInst *Create(FunctionCallee Func, ArrayRef<Value *> Args,
-                          const Twine &NameStr,
-                          Instruction *InsertBefore) {
+                          const Twine &NameStr, Instruction *InsertBefore) {
     return Create(Func.getFunctionType(), Func.getCallee(), Args, NameStr,
                   InsertBefore);
   }
@@ -1736,14 +1735,16 @@ public:
   }
 
   static CallInst *Create(FunctionCallee Func, ArrayRef<Value *> Args,
-                          const Twine &NameStr, BasicBlock *InsertAtEnd = nullptr) {
+                          const Twine &NameStr,
+                          BasicBlock *InsertAtEnd = nullptr) {
     return Create(Func.getFunctionType(), Func.getCallee(), Args, NameStr,
                   InsertAtEnd);
   }
 
   static CallInst *Create(FunctionCallee Func, ArrayRef<Value *> Args,
                           ArrayRef<OperandBundleDef> Bundles = std::nullopt,
-                          const Twine &NameStr = "", BasicBlock *InsertAtEnd = nullptr) {
+                          const Twine &NameStr = "",
+                          BasicBlock *InsertAtEnd = nullptr) {
     return Create(Func.getFunctionType(), Func.getCallee(), Args, Bundles,
                   NameStr, InsertAtEnd);
   }
@@ -1909,8 +1910,7 @@ public:
   }
 
   static SelectInst *Create(Value *C, Value *S1, Value *S2,
-                            const Twine &NameStr,
-                            Instruction *InsertBefore,
+                            const Twine &NameStr, Instruction *InsertBefore,
                             Instruction *MDFrom = nullptr) {
     SelectInst *Sel = new(3) SelectInst(C, S1, S2, NameStr, InsertBefore);
     if (MDFrom)
@@ -1987,14 +1987,14 @@ public:
   }
 
   VAArgInst(Value *List, Type *Ty, const Twine &NameStr,
-             Instruction *InsertBefore)
-    : UnaryInstruction(Ty, VAArg, List, InsertBefore) {
+            Instruction *InsertBefore)
+      : UnaryInstruction(Ty, VAArg, List, InsertBefore) {
     setName(NameStr);
   }
 
   VAArgInst(Value *List, Type *Ty, const Twine &NameStr = "",
             BasicBlock *InsertAtEnd = nullptr)
-    : UnaryInstruction(Ty, VAArg, List, InsertAtEnd) {
+      : UnaryInstruction(Ty, VAArg, List, InsertAtEnd) {
     setName(NameStr);
   }
 
@@ -2040,14 +2040,14 @@ public:
   }
 
   static ExtractElementInst *Create(Value *Vec, Value *Idx,
-                                   const Twine &NameStr,
-                                   Instruction *InsertBefore) {
+                                    const Twine &NameStr,
+                                    Instruction *InsertBefore) {
     return new(2) ExtractElementInst(Vec, Idx, NameStr, InsertBefore);
   }
 
   static ExtractElementInst *Create(Value *Vec, Value *Idx,
-                                   const Twine &NameStr = "",
-                                   BasicBlock *InsertAtEnd = nullptr) {
+                                    const Twine &NameStr = "",
+                                    BasicBlock *InsertAtEnd = nullptr) {
     return new(2) ExtractElementInst(Vec, Idx, NameStr, InsertAtEnd);
   }
 
@@ -2093,10 +2093,10 @@ DEFINE_TRANSPARENT_OPERAND_ACCESSORS(ExtractElementInst, Value)
 class InsertElementInst : public Instruction {
   InsertElementInst(Value *Vec, Value *NewElt, Value *Idx, const Twine &NameStr,
                     BasicBlock::iterator InsertBefore);
-  InsertElementInst(Value *Vec, Value *NewElt, Value *Idx,
-                    const Twine &NameStr,
+  InsertElementInst(Value *Vec, Value *NewElt, Value *Idx, const Twine &NameStr,
                     Instruction *InsertBefore);
-  InsertElementInst(Value *Vec, Value *NewElt, Value *Idx, const Twine &NameStr = "",
+  InsertElementInst(Value *Vec, Value *NewElt, Value *Idx,
+                    const Twine &NameStr = "",
                     BasicBlock *InsertAtEnd = nullptr);
 
 protected:
@@ -2195,18 +2195,18 @@ public:
                     BasicBlock *InsertAtEnd = nullptr);
   ShuffleVectorInst(Value *V1, Value *V2, Value *Mask, const Twine &NameStr,
                     BasicBlock::iterator InsertBefore);
-  ShuffleVectorInst(Value *V1, Value *V2, Value *Mask,
-                    const Twine &NameStr,
+  ShuffleVectorInst(Value *V1, Value *V2, Value *Mask, const Twine &NameStr,
                     Instruction *InsertBefore);
   ShuffleVectorInst(Value *V1, Value *V2, Value *Mask,
-                    const Twine &NameStr = "", BasicBlock *InsertAtEnd = nullptr);
+                    const Twine &NameStr = "",
+                    BasicBlock *InsertAtEnd = nullptr);
   ShuffleVectorInst(Value *V1, Value *V2, ArrayRef<int> Mask,
                     const Twine &NameStr, BasicBlock::iterator InsertBefore);
   ShuffleVectorInst(Value *V1, Value *V2, ArrayRef<int> Mask,
-                    const Twine &NameStr,
-                    Instruction *InsertBefore);
+                    const Twine &NameStr, Instruction *InsertBefore);
   ShuffleVectorInst(Value *V1, Value *V2, ArrayRef<int> Mask,
-                    const Twine &NameStr = "", BasicBlock *InsertAtEnd = nullptr);
+                    const Twine &NameStr = "",
+                    BasicBlock *InsertAtEnd = nullptr);
 
   void *operator new(size_t S) { return User::operator new(S, 2); }
   void operator delete(void *Ptr) { return User::operator delete(Ptr); }
@@ -2706,16 +2706,14 @@ public:
       ExtractValueInst(Agg, Idxs, NameStr, InsertBefore);
   }
 
-  static ExtractValueInst *Create(Value *Agg,
-                                  ArrayRef<unsigned> Idxs,
+  static ExtractValueInst *Create(Value *Agg, ArrayRef<unsigned> Idxs,
                                   const Twine &NameStr,
                                   Instruction *InsertBefore) {
     return new
       ExtractValueInst(Agg, Idxs, NameStr, InsertBefore);
   }
 
-  static ExtractValueInst *Create(Value *Agg,
-                                  ArrayRef<unsigned> Idxs,
+  static ExtractValueInst *Create(Value *Agg, ArrayRef<unsigned> Idxs,
                                   const Twine &NameStr = "",
                                   BasicBlock *InsertAtEnd = nullptr) {
     return new ExtractValueInst(Agg, Idxs, NameStr, InsertAtEnd);
@@ -2823,11 +2821,10 @@ class InsertValueInst : public Instruction {
   /// one and two index insertvalue instructions are so common.
   InsertValueInst(Value *Agg, Value *Val, unsigned Idx, const Twine &NameStr,
                   BasicBlock::iterator InsertBefore);
-  InsertValueInst(Value *Agg, Value *Val, unsigned Idx,
-                  const Twine &NameStr,
+  InsertValueInst(Value *Agg, Value *Val, unsigned Idx, const Twine &NameStr,
                   Instruction *InsertBefore);
-  InsertValueInst(Value *Agg, Value *Val, unsigned Idx, const Twine &NameStr = "",
-                  BasicBlock *InsertAtEnd = nullptr);
+  InsertValueInst(Value *Agg, Value *Val, unsigned Idx,
+                  const Twine &NameStr = "", BasicBlock *InsertAtEnd = nullptr);
 
   void init(Value *Agg, Value *Val, ArrayRef<unsigned> Idxs,
             const Twine &NameStr);
@@ -2850,8 +2847,7 @@ public:
   }
 
   static InsertValueInst *Create(Value *Agg, Value *Val,
-                                 ArrayRef<unsigned> Idxs,
-                                 const Twine &NameStr,
+                                 ArrayRef<unsigned> Idxs, const Twine &NameStr,
                                  Instruction *InsertBefore) {
     return new InsertValueInst(Agg, Val, Idxs, NameStr, InsertBefore);
   }
@@ -2978,11 +2974,10 @@ class PHINode : public Instruction {
     allocHungoffUses(ReservedSpace);
   }
 
-  explicit PHINode(Type *Ty, unsigned NumReservedValues,
-                   const Twine &NameStr,
+  explicit PHINode(Type *Ty, unsigned NumReservedValues, const Twine &NameStr,
                    Instruction *InsertBefore)
-    : Instruction(Ty, Instruction::PHI, nullptr, 0, InsertBefore),
-      ReservedSpace(NumReservedValues) {
+      : Instruction(Ty, Instruction::PHI, nullptr, 0, InsertBefore),
+        ReservedSpace(NumReservedValues) {
     assert(!Ty->isTokenTy() && "PHI nodes cannot have token type!");
     setName(NameStr);
     allocHungoffUses(ReservedSpace);
@@ -2990,8 +2985,8 @@ class PHINode : public Instruction {
 
   PHINode(Type *Ty, unsigned NumReservedValues, const Twine &NameStr = "",
           BasicBlock *InsertAtEnd = nullptr)
-    : Instruction(Ty, Instruction::PHI, nullptr, 0, InsertAtEnd),
-      ReservedSpace(NumReservedValues) {
+      : Instruction(Ty, Instruction::PHI, nullptr, 0, InsertAtEnd),
+        ReservedSpace(NumReservedValues) {
     assert(!Ty->isTokenTy() && "PHI nodes cannot have token type!");
     setName(NameStr);
     allocHungoffUses(ReservedSpace);
@@ -3020,13 +3015,13 @@ public:
   }
 
   static PHINode *Create(Type *Ty, unsigned NumReservedValues,
-                         const Twine &NameStr,
-                         Instruction *InsertBefore) {
+                         const Twine &NameStr, Instruction *InsertBefore) {
     return new PHINode(Ty, NumReservedValues, NameStr, InsertBefore);
   }
 
   static PHINode *Create(Type *Ty, unsigned NumReservedValues,
-                         const Twine &NameStr = "", BasicBlock *InsertAtEnd = nullptr) {
+                         const Twine &NameStr = "",
+                         BasicBlock *InsertAtEnd = nullptr) {
     return new PHINode(Ty, NumReservedValues, NameStr, InsertAtEnd);
   }
 
@@ -3275,7 +3270,8 @@ public:
                                 const Twine &NameStr,
                                 Instruction *InsertBefore);
   static LandingPadInst *Create(Type *RetTy, unsigned NumReservedClauses,
-                                const Twine &NameStr = "", BasicBlock *InsertAtEnd = nullptr);
+                                const Twine &NameStr = "",
+                                BasicBlock *InsertAtEnd = nullptr);
 
   /// Provide fast operand accessors
   DECLARE_TRANSPARENT_OPERAND_ACCESSORS(Value);
@@ -3356,9 +3352,9 @@ private:
   // if it was passed NULL.
   explicit ReturnInst(LLVMContext &C, Value *retVal,
                       BasicBlock::iterator InsertBefore);
-  explicit ReturnInst(LLVMContext &C, Value *retVal,
-                      Instruction *InsertBefore);
-  ReturnInst(LLVMContext &C, Value *retVal = nullptr, BasicBlock *InsertAtEnd = nullptr);
+  explicit ReturnInst(LLVMContext &C, Value *retVal, Instruction *InsertBefore);
+  ReturnInst(LLVMContext &C, Value *retVal = nullptr,
+             BasicBlock *InsertAtEnd = nullptr);
   explicit ReturnInst(LLVMContext &C, BasicBlock *InsertAtEnd);
 
 protected:
@@ -3373,12 +3369,12 @@ public:
     return new (!!retVal) ReturnInst(C, retVal, InsertBefore);
   }
 
-  static ReturnInst* Create(LLVMContext &C, Value *retVal,
+  static ReturnInst *Create(LLVMContext &C, Value *retVal,
                             Instruction *InsertBefore) {
     return new(!!retVal) ReturnInst(C, retVal, InsertBefore);
   }
 
-  static ReturnInst* Create(LLVMContext &C, Value *retVal = nullptr,
+  static ReturnInst *Create(LLVMContext &C, Value *retVal = nullptr,
                             BasicBlock *InsertAtEnd = nullptr) {
     return new(!!retVal) ReturnInst(C, retVal, InsertAtEnd);
   }
@@ -3494,8 +3490,7 @@ public:
     return new(1) BranchInst(IfTrue, InsertBefore);
   }
 
-  static BranchInst *Create(BasicBlock *IfTrue,
-                            Instruction *InsertBefore) {
+  static BranchInst *Create(BasicBlock *IfTrue, Instruction *InsertBefore) {
     return new(1) BranchInst(IfTrue, InsertBefore);
   }
 
@@ -3509,7 +3504,8 @@ public:
     return new(3) BranchInst(IfTrue, IfFalse, Cond, InsertBefore);
   }
 
-  static BranchInst *Create(BasicBlock *IfTrue, BasicBlock *InsertAtEnd = nullptr) {
+  static BranchInst *Create(BasicBlock *IfTrue,
+                            BasicBlock *InsertAtEnd = nullptr) {
     return new(1) BranchInst(IfTrue, InsertAtEnd);
   }
 
@@ -3790,13 +3786,13 @@ public:
   }
 
   static SwitchInst *Create(Value *Value, BasicBlock *Default,
-                            unsigned NumCases,
-                            Instruction *InsertBefore) {
+                            unsigned NumCases, Instruction *InsertBefore) {
     return new SwitchInst(Value, Default, NumCases, InsertBefore);
   }
 
   static SwitchInst *Create(Value *Value, BasicBlock *Default,
-                            unsigned NumCases, BasicBlock *InsertAtEnd = nullptr) {
+                            unsigned NumCases,
+                            BasicBlock *InsertAtEnd = nullptr) {
     return new SwitchInst(Value, Default, NumCases, InsertAtEnd);
   }
 
@@ -4211,8 +4207,7 @@ public:
 
   static InvokeInst *Create(FunctionType *Ty, Value *Func, BasicBlock *IfNormal,
                             BasicBlock *IfException, ArrayRef<Value *> Args,
-                            const Twine &NameStr,
-                            Instruction *InsertBefore) {
+                            const Twine &NameStr, Instruction *InsertBefore) {
     int NumOperands = ComputeNumOperands(Args.size());
     return new (NumOperands)
         InvokeInst(Ty, Func, IfNormal, IfException, Args, std::nullopt,
@@ -4236,8 +4231,7 @@ public:
   static InvokeInst *Create(FunctionType *Ty, Value *Func, BasicBlock *IfNormal,
                             BasicBlock *IfException, ArrayRef<Value *> Args,
                             ArrayRef<OperandBundleDef> Bundles,
-                            const Twine &NameStr,
-                            Instruction *InsertBefore) {
+                            const Twine &NameStr, Instruction *InsertBefore) {
     int NumOperands =
         ComputeNumOperands(Args.size(), CountBundleInputs(Bundles));
     unsigned DescriptorBytes = Bundles.size() * sizeof(BundleOpInfo);
@@ -4249,7 +4243,8 @@ public:
 
   static InvokeInst *Create(FunctionType *Ty, Value *Func, BasicBlock *IfNormal,
                             BasicBlock *IfException, ArrayRef<Value *> Args,
-                            const Twine &NameStr, BasicBlock *InsertAtEnd = nullptr) {
+                            const Twine &NameStr,
+                            BasicBlock *InsertAtEnd = nullptr) {
     int NumOperands = ComputeNumOperands(Args.size());
     return new (NumOperands)
         InvokeInst(Ty, Func, IfNormal, IfException, Args, std::nullopt,
@@ -4259,7 +4254,8 @@ public:
   static InvokeInst *Create(FunctionType *Ty, Value *Func, BasicBlock *IfNormal,
                             BasicBlock *IfException, ArrayRef<Value *> Args,
                             ArrayRef<OperandBundleDef> Bundles = std::nullopt,
-                            const Twine &NameStr = "", BasicBlock *InsertAtEnd = nullptr) {
+                            const Twine &NameStr = "",
+                            BasicBlock *InsertAtEnd = nullptr) {
     int NumOperands =
         ComputeNumOperands(Args.size(), CountBundleInputs(Bundles));
     unsigned DescriptorBytes = Bundles.size() * sizeof(BundleOpInfo);
@@ -4279,8 +4275,7 @@ public:
 
   static InvokeInst *Create(FunctionCallee Func, BasicBlock *IfNormal,
                             BasicBlock *IfException, ArrayRef<Value *> Args,
-                            const Twine &NameStr,
-                            Instruction *InsertBefore) {
+                            const Twine &NameStr, Instruction *InsertBefore) {
     return Create(Func.getFunctionType(), Func.getCallee(), IfNormal,
                   IfException, Args, std::nullopt, NameStr, InsertBefore);
   }
@@ -4297,15 +4292,15 @@ public:
   static InvokeInst *Create(FunctionCallee Func, BasicBlock *IfNormal,
                             BasicBlock *IfException, ArrayRef<Value *> Args,
                             ArrayRef<OperandBundleDef> Bundles,
-                            const Twine &NameStr,
-                            Instruction *InsertBefore) {
+                            const Twine &NameStr, Instruction *InsertBefore) {
     return Create(Func.getFunctionType(), Func.getCallee(), IfNormal,
                   IfException, Args, Bundles, NameStr, InsertBefore);
   }
 
   static InvokeInst *Create(FunctionCallee Func, BasicBlock *IfNormal,
                             BasicBlock *IfException, ArrayRef<Value *> Args,
-                            const Twine &NameStr, BasicBlock *InsertAtEnd = nullptr) {
+                            const Twine &NameStr,
+                            BasicBlock *InsertAtEnd = nullptr) {
     return Create(Func.getFunctionType(), Func.getCallee(), IfNormal,
                   IfException, Args, NameStr, InsertAtEnd);
   }
@@ -4313,7 +4308,8 @@ public:
   static InvokeInst *Create(FunctionCallee Func, BasicBlock *IfNormal,
                             BasicBlock *IfException, ArrayRef<Value *> Args,
                             ArrayRef<OperandBundleDef> Bundles = std::nullopt,
-                            const Twine &NameStr = "", BasicBlock *InsertAtEnd = nullptr) {
+                            const Twine &NameStr = "",
+                            BasicBlock *InsertAtEnd = nullptr) {
     return Create(Func.getFunctionType(), Func.getCallee(), IfNormal,
                   IfException, Args, Bundles, NameStr, InsertAtEnd);
   }
@@ -4502,11 +4498,12 @@ public:
                    NumOperands, NameStr, InsertBefore);
   }
 
-  static CallBrInst *
-  Create(FunctionType *Ty, Value *Func, BasicBlock *DefaultDest,
-         ArrayRef<BasicBlock *> IndirectDests, ArrayRef<Value *> Args,
-         ArrayRef<OperandBundleDef> Bundles,
-         const Twine &NameStr, Instruction *InsertBefore) {
+  static CallBrInst *Create(FunctionType *Ty, Value *Func,
+                            BasicBlock *DefaultDest,
+                            ArrayRef<BasicBlock *> IndirectDests,
+                            ArrayRef<Value *> Args,
+                            ArrayRef<OperandBundleDef> Bundles,
+                            const Twine &NameStr, Instruction *InsertBefore) {
     int NumOperands = ComputeNumOperands(Args.size(), IndirectDests.size(),
                                          CountBundleInputs(Bundles));
     unsigned DescriptorBytes = Bundles.size() * sizeof(BundleOpInfo);
@@ -4527,12 +4524,11 @@ public:
                    NumOperands, NameStr, InsertAtEnd);
   }
 
-  static CallBrInst *Create(FunctionType *Ty, Value *Func,
-                            BasicBlock *DefaultDest,
-                            ArrayRef<BasicBlock *> IndirectDests,
-                            ArrayRef<Value *> Args,
-                            ArrayRef<OperandBundleDef> Bundles = std::nullopt,
-                            const Twine &NameStr = "", BasicBlock *InsertAtEnd = nullptr) {
+  static CallBrInst *
+  Create(FunctionType *Ty, Value *Func, BasicBlock *DefaultDest,
+         ArrayRef<BasicBlock *> IndirectDests, ArrayRef<Value *> Args,
+         ArrayRef<OperandBundleDef> Bundles = std::nullopt,
+         const Twine &NameStr = "", BasicBlock *InsertAtEnd = nullptr) {
     int NumOperands = ComputeNumOperands(Args.size(), IndirectDests.size(),
                                          CountBundleInputs(Bundles));
     unsigned DescriptorBytes = Bundles.size() * sizeof(BundleOpInfo);
@@ -4572,8 +4568,7 @@ public:
                             ArrayRef<BasicBlock *> IndirectDests,
                             ArrayRef<Value *> Args,
                             ArrayRef<OperandBundleDef> Bundles,
-                            const Twine &NameStr,
-                            Instruction *InsertBefore) {
+                            const Twine &NameStr, Instruction *InsertBefore) {
     return Create(Func.getFunctionType(), Func.getCallee(), DefaultDest,
                   IndirectDests, Args, Bundles, NameStr, InsertBefore);
   }
@@ -4586,12 +4581,12 @@ public:
                   IndirectDests, Args, NameStr, InsertAtEnd);
   }
 
-  static CallBrInst *Create(FunctionCallee Func,
-                            BasicBlock *DefaultDest,
+  static CallBrInst *Create(FunctionCallee Func, BasicBlock *DefaultDest,
                             ArrayRef<BasicBlock *> IndirectDests,
                             ArrayRef<Value *> Args,
                             ArrayRef<OperandBundleDef> Bundles = std::nullopt,
-                            const Twine &NameStr = "", BasicBlock *InsertAtEnd = nullptr) {
+                            const Twine &NameStr = "",
+                            BasicBlock *InsertAtEnd = nullptr) {
     return Create(Func.getFunctionType(), Func.getCallee(), DefaultDest,
                   IndirectDests, Args, Bundles, NameStr, InsertAtEnd);
   }
@@ -4604,11 +4599,9 @@ public:
   /// operand bundles in \p Bundles.
   static CallBrInst *Create(CallBrInst *CBI, ArrayRef<OperandBundleDef> Bundles,
                             BasicBlock::iterator InsertPt);
-  static CallBrInst *Create(CallBrInst *CBI,
-                            ArrayRef<OperandBundleDef> Bundles,
+  static CallBrInst *Create(CallBrInst *CBI, ArrayRef<OperandBundleDef> Bundles,
                             Instruction *InsertPt);
-  static CallBrInst *Create(CallBrInst *CBI,
-                            ArrayRef<OperandBundleDef> Bundles,
+  static CallBrInst *Create(CallBrInst *CBI, ArrayRef<OperandBundleDef> Bundles,
                             BasicBlock *InsertAtEnd = nullptr);
 
   /// Return the number of callbr indirect dest labels.
@@ -4839,15 +4832,15 @@ public:
   }
 
   static CatchSwitchInst *Create(Value *ParentPad, BasicBlock *UnwindDest,
-                                 unsigned NumHandlers,
-                                 const Twine &NameStr,
+                                 unsigned NumHandlers, const Twine &NameStr,
                                  Instruction *InsertBefore) {
     return new CatchSwitchInst(ParentPad, UnwindDest, NumHandlers, NameStr,
                                InsertBefore);
   }
 
   static CatchSwitchInst *Create(Value *ParentPad, BasicBlock *UnwindDest,
-                                 unsigned NumHandlers, const Twine &NameStr = "",
+                                 unsigned NumHandlers,
+                                 const Twine &NameStr = "",
                                  BasicBlock *InsertAtEnd = nullptr) {
     return new CatchSwitchInst(ParentPad, UnwindDest, NumHandlers, NameStr,
                                InsertAtEnd);
@@ -5000,8 +4993,7 @@ public:
         CleanupPadInst(ParentPad, Args, Values, NameStr, InsertBefore);
   }
 
-  static CleanupPadInst *Create(Value *ParentPad,
-                                ArrayRef<Value *> Args,
+  static CleanupPadInst *Create(Value *ParentPad, ArrayRef<Value *> Args,
                                 const Twine &NameStr,
                                 Instruction *InsertBefore) {
     unsigned Values = 1 + Args.size();
@@ -5009,8 +5001,10 @@ public:
         CleanupPadInst(ParentPad, Args, Values, NameStr, InsertBefore);
   }
 
-  static CleanupPadInst *Create(Value *ParentPad, ArrayRef<Value *> Args = std::nullopt,
-                                const Twine &NameStr = "", BasicBlock *InsertAtEnd = nullptr) {
+  static CleanupPadInst *Create(Value *ParentPad,
+                                ArrayRef<Value *> Args = std::nullopt,
+                                const Twine &NameStr = "",
+                                BasicBlock *InsertAtEnd = nullptr) {
     unsigned Values = 1 + Args.size();
     return new (Values)
         CleanupPadInst(ParentPad, Args, Values, NameStr, InsertAtEnd);
@@ -5056,15 +5050,15 @@ public:
   }
 
   static CatchPadInst *Create(Value *CatchSwitch, ArrayRef<Value *> Args,
-                              const Twine &NameStr,
-                              Instruction *InsertBefore) {
+                              const Twine &NameStr, Instruction *InsertBefore) {
     unsigned Values = 1 + Args.size();
     return new (Values)
         CatchPadInst(CatchSwitch, Args, Values, NameStr, InsertBefore);
   }
 
   static CatchPadInst *Create(Value *CatchSwitch, ArrayRef<Value *> Args,
-                              const Twine &NameStr = "", BasicBlock *InsertAtEnd = nullptr) {
+                              const Twine &NameStr = "",
+                              BasicBlock *InsertAtEnd = nullptr) {
     unsigned Values = 1 + Args.size();
     return new (Values)
         CatchPadInst(CatchSwitch, Args, Values, NameStr, InsertAtEnd);
@@ -5213,8 +5207,7 @@ public:
         CleanupReturnInst(CleanupPad, UnwindBB, Values, InsertBefore);
   }
 
-  static CleanupReturnInst *Create(Value *CleanupPad,
-                                   BasicBlock *UnwindBB,
+  static CleanupReturnInst *Create(Value *CleanupPad, BasicBlock *UnwindBB,
                                    Instruction *InsertBefore) {
     assert(CleanupPad);
     unsigned Values = 1;
@@ -5224,7 +5217,8 @@ public:
         CleanupReturnInst(CleanupPad, UnwindBB, Values, InsertBefore);
   }
 
-  static CleanupReturnInst *Create(Value *CleanupPad, BasicBlock *UnwindBB = nullptr,
+  static CleanupReturnInst *Create(Value *CleanupPad,
+                                   BasicBlock *UnwindBB = nullptr,
                                    BasicBlock *InsertAtEnd = nullptr) {
     assert(CleanupPad);
     unsigned Values = 1;
@@ -5361,19 +5355,18 @@ public:
   );
 
   /// Constructor with insert-before-instruction semantics
-  TruncInst(
-    Value *S,                           ///< The value to be truncated
-    Type *Ty,                           ///< The (smaller) type to truncate to
-    const Twine &NameStr,               ///< A name for the new instruction
-    Instruction *InsertBefore           ///< Where to insert the new instruction
+  TruncInst(Value *S,                 ///< The value to be truncated
+            Type *Ty,                 ///< The (smaller) type to truncate to
+            const Twine &NameStr,     ///< A name for the new instruction
+            Instruction *InsertBefore ///< Where to insert the new instruction
   );
 
   /// Constructor with insert-at-end-of-block semantics
   TruncInst(
-    Value *S,                           ///< The value to be truncated
-    Type *Ty,                           ///< The (smaller) type to truncate to
-    const Twine &NameStr = "",          ///< A name for the new instruction
-    BasicBlock *InsertAtEnd = nullptr   ///< The block to insert at the end of
+      Value *S,                         ///< The value to be truncated
+      Type *Ty,                         ///< The (smaller) type to truncate to
+      const Twine &NameStr = "",        ///< A name for the new instruction
+      BasicBlock *InsertAtEnd = nullptr ///< The block to insert at the end of
   );
 
   /// Methods for support type inquiry through isa, cast, and dyn_cast:
@@ -5408,19 +5401,18 @@ public:
   );
 
   /// Constructor with insert-before-instruction semantics
-  ZExtInst(
-    Value *S,                   ///< The value to be zero extended
-    Type *Ty,                   ///< The type to zero extend to
-    const Twine &NameStr,       ///< A name for the new instruction
-    Instruction *InsertBefore   ///< Where to insert the new instruction
+  ZExtInst(Value *S,                 ///< The value to be zero extended
+           Type *Ty,                 ///< The type to zero extend to
+           const Twine &NameStr,     ///< A name for the new instruction
+           Instruction *InsertBefore ///< Where to insert the new instruction
   );
 
   /// Constructor with insert-at-end semantics.
   ZExtInst(
-    Value *S,                           ///< The value to be zero extended
-    Type *Ty,                           ///< The type to zero extend to
-    const Twine &NameStr = "",          ///< A name for the new instruction
-    BasicBlock *InsertAtEnd = nullptr   ///< The block to insert at the end of
+      Value *S,                         ///< The value to be zero extended
+      Type *Ty,                         ///< The type to zero extend to
+      const Twine &NameStr = "",        ///< A name for the new instruction
+      BasicBlock *InsertAtEnd = nullptr ///< The block to insert at the end of
   );
 
   /// Methods for support type inquiry through isa, cast, and dyn_cast:
@@ -5455,19 +5447,18 @@ public:
   );
 
   /// Constructor with insert-before-instruction semantics
-  SExtInst(
-    Value *S,                           ///< The value to be sign extended
-    Type *Ty,                           ///< The type to sign extend to
-    const Twine &NameStr,          ///< A name for the new instruction
-    Instruction *InsertBefore ///< Where to insert the new instruction
+  SExtInst(Value *S,                 ///< The value to be sign extended
+           Type *Ty,                 ///< The type to sign extend to
+           const Twine &NameStr,     ///< A name for the new instruction
+           Instruction *InsertBefore ///< Where to insert the new instruction
   );
 
   /// Constructor with insert-at-end-of-block semantics
   SExtInst(
-    Value *S,                           ///< The value to be sign extended
-    Type *Ty,                           ///< The type to sign extend to
-    const Twine &NameStr = "",          ///< A name for the new instruction
-    BasicBlock *InsertAtEnd = nullptr   ///< The block to insert at the end of
+      Value *S,                         ///< The value to be sign extended
+      Type *Ty,                         ///< The type to sign extend to
+      const Twine &NameStr = "",        ///< A name for the new instruction
+      BasicBlock *InsertAtEnd = nullptr ///< The block to insert at the end of
   );
 
   /// Methods for support type inquiry through isa, cast, and dyn_cast:
@@ -5502,19 +5493,18 @@ public:
   );
 
   /// Constructor with insert-before-instruction semantics
-  FPTruncInst(
-    Value *S,                   ///< The value to be truncated
-    Type *Ty,                   ///< The type to truncate to
-    const Twine &NameStr,       ///< A name for the new instruction
-    Instruction *InsertBefore   ///< Where to insert the new instruction
+  FPTruncInst(Value *S,                 ///< The value to be truncated
+              Type *Ty,                 ///< The type to truncate to
+              const Twine &NameStr,     ///< A name for the new instruction
+              Instruction *InsertBefore ///< Where to insert the new instruction
   );
 
   /// Constructor with insert-before-instruction semantics
   FPTruncInst(
-    Value *S,                           ///< The value to be truncated
-    Type *Ty,                           ///< The type to truncate to
-    const Twine &NameStr = "",          ///< A name for the new instruction
-    BasicBlock *InsertAtEnd = nullptr   ///< The block to insert at the end of
+      Value *S,                         ///< The value to be truncated
+      Type *Ty,                         ///< The type to truncate to
+      const Twine &NameStr = "",        ///< A name for the new instruction
+      BasicBlock *InsertAtEnd = nullptr ///< The block to insert at the end of
   );
 
   /// Methods for support type inquiry through isa, cast, and dyn_cast:
@@ -5549,19 +5539,18 @@ public:
   );
 
   /// Constructor with insert-before-instruction semantics
-  FPExtInst(
-    Value *S,                           ///< The value to be extended
-    Type *Ty,                           ///< The type to extend to
-    const Twine &NameStr,          ///< A name for the new instruction
-    Instruction *InsertBefore ///< Where to insert the new instruction
+  FPExtInst(Value *S,                 ///< The value to be extended
+            Type *Ty,                 ///< The type to extend to
+            const Twine &NameStr,     ///< A name for the new instruction
+            Instruction *InsertBefore ///< Where to insert the new instruction
   );
 
   /// Constructor with insert-at-end-of-block semantics
   FPExtInst(
-    Value *S,                           ///< The value to be extended
-    Type *Ty,                           ///< The type to extend to
-    const Twine &NameStr = "",          ///< A name for the new instruction
-    BasicBlock *InsertAtEnd = nullptr   ///< The block to insert at the end of
+      Value *S,                         ///< The value to be extended
+      Type *Ty,                         ///< The type to extend to
+      const Twine &NameStr = "",        ///< A name for the new instruction
+      BasicBlock *InsertAtEnd = nullptr ///< The block to insert at the end of
   );
 
   /// Methods for support type inquiry through isa, cast, and dyn_cast:
@@ -5596,19 +5585,18 @@ public:
   );
 
   /// Constructor with insert-before-instruction semantics
-  UIToFPInst(
-    Value *S,                           ///< The value to be converted
-    Type *Ty,                           ///< The type to convert to
-    const Twine &NameStr,          ///< A name for the new instruction
-    Instruction *InsertBefore ///< Where to insert the new instruction
+  UIToFPInst(Value *S,                 ///< The value to be converted
+             Type *Ty,                 ///< The type to convert to
+             const Twine &NameStr,     ///< A name for the new instruction
+             Instruction *InsertBefore ///< Where to insert the new instruction
   );
 
   /// Constructor with insert-at-end-of-block semantics
   UIToFPInst(
-    Value *S,                           ///< The value to be converted
-    Type *Ty,                           ///< The type to convert to
-    const Twine &NameStr = "",          ///< A name for the new instruction
-    BasicBlock *InsertAtEnd = nullptr   ///< The block to insert at the end of
+      Value *S,                         ///< The value to be converted
+      Type *Ty,                         ///< The type to convert to
+      const Twine &NameStr = "",        ///< A name for the new instruction
+      BasicBlock *InsertAtEnd = nullptr ///< The block to insert at the end of
   );
 
   /// Methods for support type inquiry through isa, cast, and dyn_cast:
@@ -5643,19 +5631,18 @@ public:
   );
 
   /// Constructor with insert-before-instruction semantics
-  SIToFPInst(
-    Value *S,                   ///< The value to be converted
-    Type *Ty,                   ///< The type to convert to
-    const Twine &NameStr,       ///< A name for the new instruction
-    Instruction *InsertBefore   ///< Where to insert the new instruction
+  SIToFPInst(Value *S,                 ///< The value to be converted
+             Type *Ty,                 ///< The type to convert to
+             const Twine &NameStr,     ///< A name for the new instruction
+             Instruction *InsertBefore ///< Where to insert the new instruction
   );
 
   /// Constructor with insert-at-end-of-block semantics
   SIToFPInst(
-    Value *S,                           ///< The value to be converted
-    Type *Ty,                           ///< The type to convert to
-    const Twine &NameStr = "",          ///< A name for the new instruction
-    BasicBlock *InsertAtEnd = nullptr   ///< The block to insert at the end of
+      Value *S,                         ///< The value to be converted
+      Type *Ty,                         ///< The type to convert to
+      const Twine &NameStr = "",        ///< A name for the new instruction
+      BasicBlock *InsertAtEnd = nullptr ///< The block to insert at the end of
   );
 
   /// Methods for support type inquiry through isa, cast, and dyn_cast:
@@ -5690,19 +5677,18 @@ public:
   );
 
   /// Constructor with insert-before-instruction semantics
-  FPToUIInst(
-    Value *S,                   ///< The value to be converted
-    Type *Ty,                   ///< The type to convert to
-    const Twine &NameStr,       ///< A name for the new instruction
-    Instruction *InsertBefore   ///< Where to insert the new instruction
+  FPToUIInst(Value *S,                 ///< The value to be converted
+             Type *Ty,                 ///< The type to convert to
+             const Twine &NameStr,     ///< A name for the new instruction
+             Instruction *InsertBefore ///< Where to insert the new instruction
   );
 
   /// Constructor with insert-at-end-of-block semantics
   FPToUIInst(
-    Value *S,                           ///< The value to be converted
-    Type *Ty,                           ///< The type to convert to
-    const Twine &NameStr = "",          ///< A name for the new instruction
-    BasicBlock *InsertAtEnd = nullptr   ///< The block to insert at the end of
+      Value *S,                         ///< The value to be converted
+      Type *Ty,                         ///< The type to convert to
+      const Twine &NameStr = "",        ///< A name for the new instruction
+      BasicBlock *InsertAtEnd = nullptr ///< The block to insert at the end of
   );
 
   /// Methods for support type inquiry through isa, cast, and dyn_cast:
@@ -5737,19 +5723,18 @@ public:
   );
 
   /// Constructor with insert-before-instruction semantics
-  FPToSIInst(
-    Value *S,                   ///< The value to be converted
-    Type *Ty,                   ///< The type to convert to
-    const Twine &NameStr,       ///< A name for the new instruction
-    Instruction *InsertBefore   ///< Where to insert the new instruction
+  FPToSIInst(Value *S,                 ///< The value to be converted
+             Type *Ty,                 ///< The type to convert to
+             const Twine &NameStr,     ///< A name for the new instruction
+             Instruction *InsertBefore ///< Where to insert the new instruction
   );
 
   /// Constructor with insert-at-end-of-block semantics
   FPToSIInst(
-    Value *S,                           ///< The value to be converted
-    Type *Ty,                           ///< The type to convert to
-    const Twine &NameStr = "",          ///< A name for the new instruction
-    BasicBlock *InsertAtEnd = nullptr   ///< The block to insert at the end of
+      Value *S,                         ///< The value to be converted
+      Type *Ty,                         ///< The type to convert to
+      const Twine &NameStr = "",        ///< A name for the new instruction
+      BasicBlock *InsertAtEnd = nullptr ///< The block to insert at the end of
   );
 
   /// Methods for support type inquiry through isa, cast, and dyn_cast:
@@ -5781,18 +5766,18 @@ public:
 
   /// Constructor with insert-before-instruction semantics
   IntToPtrInst(
-    Value *S,                   ///< The value to be converted
-    Type *Ty,                   ///< The type to convert to
-    const Twine &NameStr,       ///< A name for the new instruction
-    Instruction *InsertBefore   ///< Where to insert the new instruction
+      Value *S,                 ///< The value to be converted
+      Type *Ty,                 ///< The type to convert to
+      const Twine &NameStr,     ///< A name for the new instruction
+      Instruction *InsertBefore ///< Where to insert the new instruction
   );
 
   /// Constructor with insert-at-end-of-block semantics
   IntToPtrInst(
-    Value *S,                           ///< The value to be converted
-    Type *Ty,                           ///< The type to convert to
-    const Twine &NameStr = "",          ///< A name for the new instruction
-    BasicBlock *InsertAtEnd = nullptr   ///< The block to insert at the end of
+      Value *S,                         ///< The value to be converted
+      Type *Ty,                         ///< The type to convert to
+      const Twine &NameStr = "",        ///< A name for the new instruction
+      BasicBlock *InsertAtEnd = nullptr ///< The block to insert at the end of
   );
 
   /// Clone an identical IntToPtrInst.
@@ -5836,18 +5821,18 @@ public:
 
   /// Constructor with insert-before-instruction semantics
   PtrToIntInst(
-    Value *S,                   ///< The value to be converted
-    Type *Ty,                   ///< The type to convert to
-    const Twine &NameStr,       ///< A name for the new instruction
-    Instruction *InsertBefore   ///< Where to insert the new instruction
+      Value *S,                 ///< The value to be converted
+      Type *Ty,                 ///< The type to convert to
+      const Twine &NameStr,     ///< A name for the new instruction
+      Instruction *InsertBefore ///< Where to insert the new instruction
   );
 
   /// Constructor with insert-at-end-of-block semantics
   PtrToIntInst(
-    Value *S,                           ///< The value to be converted
-    Type *Ty,                           ///< The type to convert to
-    const Twine &NameStr = "",          ///< A name for the new instruction
-    BasicBlock *InsertAtEnd = nullptr   ///< The block to insert at the end of
+      Value *S,                         ///< The value to be converted
+      Type *Ty,                         ///< The type to convert to
+      const Twine &NameStr = "",        ///< A name for the new instruction
+      BasicBlock *InsertAtEnd = nullptr ///< The block to insert at the end of
   );
 
   /// Gets the pointer operand.
@@ -5894,19 +5879,18 @@ public:
   );
 
   /// Constructor with insert-before-instruction semantics
-  BitCastInst(
-    Value *S,                   ///< The value to be casted
-    Type *Ty,                   ///< The type to casted to
-    const Twine &NameStr,       ///< A name for the new instruction
-    Instruction *InsertBefore   ///< Where to insert the new instruction
+  BitCastInst(Value *S,                 ///< The value to be casted
+              Type *Ty,                 ///< The type to casted to
+              const Twine &NameStr,     ///< A name for the new instruction
+              Instruction *InsertBefore ///< Where to insert the new instruction
   );
 
   /// Constructor with insert-at-end-of-block semantics
   BitCastInst(
-    Value *S,                           ///< The value to be casted
-    Type *Ty,                           ///< The type to casted to
-    const Twine &NameStr = "",          ///< A name for the new instruction
-    BasicBlock *InsertAtEnd = nullptr   ///< The block to insert at the end of
+      Value *S,                         ///< The value to be casted
+      Type *Ty,                         ///< The type to casted to
+      const Twine &NameStr = "",        ///< A name for the new instruction
+      BasicBlock *InsertAtEnd = nullptr ///< The block to insert at the end of
   );
 
   // Methods for support type inquiry through isa, cast, and dyn_cast:
@@ -5943,18 +5927,18 @@ public:
 
   /// Constructor with insert-before-instruction semantics
   AddrSpaceCastInst(
-    Value *S,                   ///< The value to be casted
-    Type *Ty,                   ///< The type to casted to
-    const Twine &NameStr,       ///< A name for the new instruction
-    Instruction *InsertBefore   ///< Where to insert the new instruction
+      Value *S,                 ///< The value to be casted
+      Type *Ty,                 ///< The type to casted to
+      const Twine &NameStr,     ///< A name for the new instruction
+      Instruction *InsertBefore ///< Where to insert the new instruction
   );
 
   /// Constructor with insert-at-end-of-block semantics
   AddrSpaceCastInst(
-    Value *S,                           ///< The value to be casted
-    Type *Ty,                           ///< The type to casted to
-    const Twine &NameStr = "",          ///< A name for the new instruction
-    BasicBlock *InsertAtEnd = nullptr   ///< The block to insert at the end of
+      Value *S,                         ///< The value to be casted
+      Type *Ty,                         ///< The type to casted to
+      const Twine &NameStr = "",        ///< A name for the new instruction
+      BasicBlock *InsertAtEnd = nullptr ///< The block to insert at the end of
   );
 
   // Methods for support type inquiry through isa, cast, and dyn_cast:
@@ -6085,10 +6069,10 @@ protected:
 public:
   explicit FreezeInst(Value *S, const Twine &NameStr,
                       BasicBlock::iterator InsertBefore);
-  explicit FreezeInst(Value *S,
-                      const Twine &NameStr,
+  explicit FreezeInst(Value *S, const Twine &NameStr,
                       Instruction *InsertBefore);
-  FreezeInst(Value *S, const Twine &NameStr = "", BasicBlock *InsertAtEnd = nullptr);
+  FreezeInst(Value *S, const Twine &NameStr = "",
+             BasicBlock *InsertAtEnd = nullptr);
 
   // Methods for support type inquiry through isa, cast, and dyn_cast:
   static inline bool classof(const Instruction *I) {

--- a/llvm/lib/IR/Instructions.cpp
+++ b/llvm/lib/IR/Instructions.cpp
@@ -370,7 +370,6 @@ CallBase *CallBase::Create(CallBase *CI, OperandBundleDef OpB,
   return CallBase::Create(CI, OpDefs, InsertAtEnd);
 }
 
-
 Function *CallBase::getCaller() { return getParent()->getParent(); }
 
 unsigned CallBase::getNumSubclassExtraOperandsDynamic() const {

--- a/llvm/lib/IR/Instructions.cpp
+++ b/llvm/lib/IR/Instructions.cpp
@@ -3276,9 +3276,7 @@ UnaryOperator *UnaryOperator::Create(UnaryOps Op, Value *S,
 UnaryOperator *UnaryOperator::Create(UnaryOps Op, Value *S,
                                      const Twine &Name,
                                      BasicBlock *InsertAtEnd) {
-  UnaryOperator *Res = Create(Op, S, Name);
-  Res->insertInto(InsertAtEnd, InsertAtEnd->end());
-  return Res;
+  return new UnaryOperator(Op, S, S->getType(), Name, InsertAtEnd);
 }
 
 void UnaryOperator::AssertOK() {
@@ -3426,9 +3424,9 @@ BinaryOperator *BinaryOperator::Create(BinaryOps Op, Value *S1, Value *S2,
 BinaryOperator *BinaryOperator::Create(BinaryOps Op, Value *S1, Value *S2,
                                        const Twine &Name,
                                        BasicBlock *InsertAtEnd) {
-  BinaryOperator *Res = Create(Op, S1, S2, Name);
-  Res->insertInto(InsertAtEnd, InsertAtEnd->end());
-  return Res;
+  assert(S1->getType() == S2->getType() &&
+         "Cannot create binary operator with two operands of differing type!");
+  return new BinaryOperator(Op, S1, S2, S1->getType(), Name, InsertAtEnd);
 }
 
 BinaryOperator *BinaryOperator::CreateNeg(Value *Op, const Twine &Name,


### PR DESCRIPTION
This patch changes each of the methods that create instructions and may insert it at the same time - generally `InstrType::Create(...)` or constructors - such that the overload called when the insert-position argument is omitted will be the candidate that takes a `BasicBlock *InsertAtEnd` argument, rather than an `Instruction *InsertBefore` argument as is currently default in all cases. This is to move us towards deprecating the insert-before-instruction versions, for the sake of preventing debug-info errors creeping in from the RemoveDIs project; for more details on this motivation, see the relevant [discourse thread](https://discourse.llvm.org/t/psa-instruction-constructors-changing-to-iterator-only-insertion/77845) and the [pull request](https://github.com/llvm/llvm-project/pull/85980) that would delete the insert-before-instruction functions.

Unclear who's best placed to review this, but since this patch should be NFC - even for downstream consumers - it's relatively low-stakes; for the subsequent patch that deprecates the Instruction versions, I'll put out a RFC on discourse.