### PR TITLE
[MLIR] Fix typo bug in AffineExprVisitor for WalkResult return case

### DIFF
--- a/mlir/include/mlir/IR/AffineExprVisitor.h
+++ b/mlir/include/mlir/IR/AffineExprVisitor.h
@@ -222,7 +222,7 @@ private:
       walkPostOrder(expr.getLHS());
     }
     if constexpr (std::is_same<RetTy, WalkResult>::value) {
-      if (walkPostOrder(expr.getLHS()).wasInterrupted())
+      if (walkPostOrder(expr.getRHS()).wasInterrupted())
         return WalkResult::interrupt();
       return WalkResult::advance();
     } else {

--- a/mlir/test/IR/affine-walk.mlir
+++ b/mlir/test/IR/affine-walk.mlir
@@ -7,3 +7,8 @@
 
 "test.check_first_mod"() {"map" = #map} : () -> ()
 // expected-remark@-1 {{mod expression}}
+
+#map_rhs_mod = affine_map<(i, j) -> (i + i mod 2, j)>
+
+"test.check_first_mod"() {"map" = #map_rhs_mod} : () -> ()
+// expected-remark@-1 {{mod expression}}


### PR DESCRIPTION
Fix typo bug in AffineExprVisitor for the WalkResult return case. This
didn't show up immmediately because most walks in the tree didn't
use walk result.
