### PR TITLE
[libc++] Avoids using ENODATA.

### DIFF
--- a/libcxx/docs/ReleaseNotes/19.rst
+++ b/libcxx/docs/ReleaseNotes/19.rst
@@ -101,7 +101,7 @@ TODO
 ABI Affecting Changes
 ---------------------
 
-- The optional POSIX macro ``ENODATA`` has been deprecated in C++. The
+- The optional POSIX macro ``ENODATA`` has been deprecated in C++ and POSIX 2017. The
   ``random_device`` could throw a ``system_error`` with this value. It now
   throws ``ENOMSG``.
 

--- a/libcxx/docs/ReleaseNotes/19.rst
+++ b/libcxx/docs/ReleaseNotes/19.rst
@@ -100,7 +100,10 @@ TODO
 
 ABI Affecting Changes
 ---------------------
-TODO
+
+- The optional POSIX macro ``ENODATA`` has been deprecated in C++. The
+  ``random_device`` could throw a ``system_error`` with this value. It now
+  throws ``ENOMSG``.
 
 
 Build System Changes

--- a/libcxx/src/random.cpp
+++ b/libcxx/src/random.cpp
@@ -79,10 +79,8 @@ unsigned random_device::operator()() {
   char* p  = reinterpret_cast<char*>(&r);
   while (n > 0) {
     ssize_t s = read(__f_, p, n);
-    _LIBCPP_SUPPRESS_DEPRECATED_PUSH
     if (s == 0)
-      __throw_system_error(ENODATA, "random_device got EOF"); // TODO ENODATA -> ENOMSG
-    _LIBCPP_SUPPRESS_DEPRECATED_POP
+      __throw_system_error(ENOMSG, "random_device got EOF");
     if (s == -1) {
       if (errno != EINTR)
         __throw_system_error(errno, "random_device got an unexpected error");


### PR DESCRIPTION
This macro is deprecated in C++26.

Fixes https://github.com/llvm/llvm-project/issues/81360