### PR TITLE
[bazel] Improve libc build on macOS

### DIFF
--- a/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
@@ -94,6 +94,10 @@ libc_support_library(
 libc_support_library(
     name = "llvm_libc_types_float128",
     hdrs = ["include/llvm-libc-types/float128.h"],
+    target_compatible_with = select({
+        "@platforms//os:linux": [],
+        "//conditions:default": ["@platforms//:incompatible"],
+    }),
     deps = [":llvm_libc_macros_float_macros"],
 )
 
@@ -972,11 +976,17 @@ libc_support_library(
 libc_support_library(
     name = "__support_osutil_syscall",
     hdrs = ["src/__support/OSUtil/syscall.h"],
-    textual_hdrs = [
-        "src/__support/OSUtil/linux/syscall.h",
-        "src/__support/OSUtil/linux/aarch64/syscall.h",
-        "src/__support/OSUtil/linux/x86_64/syscall.h",
-    ],
+    textual_hdrs = select({
+        "@platforms//os:macos": [
+            "src/__support/OSUtil/darwin/syscall.h",
+            "src/__support/OSUtil/darwin/arm/syscall.h",
+        ],
+        "@platforms//os:linux": [
+            "src/__support/OSUtil/linux/syscall.h",
+            "src/__support/OSUtil/linux/aarch64/syscall.h",
+            "src/__support/OSUtil/linux/x86_64/syscall.h",
+        ],
+    }),
     deps = [
         ":__support_common",
         ":__support_cpp_bit",
@@ -986,9 +996,10 @@ libc_support_library(
 libc_support_library(
     name = "__support_osutil_io",
     hdrs = ["src/__support/OSUtil/io.h"],
-    textual_hdrs = [
-        "src/__support/OSUtil/linux/io.h",
-    ],
+    textual_hdrs = select({
+        "@platforms//os:macos": ["src/__support/OSUtil/darwin/io.h"],
+        "@platforms//os:linux": ["src/__support/OSUtil/linux/io.h"],
+    }),
     deps = [
         ":__support_common",
         ":__support_cpp_string_view",
@@ -1001,6 +1012,10 @@ libc_support_library(
     name = "__support_osutil_quick_exit",
     srcs = ["src/__support/OSUtil/linux/quick_exit.cpp"],
     hdrs = ["src/__support/OSUtil/quick_exit.h"],
+    target_compatible_with = select({
+        "@platforms//os:linux": [],
+        "//conditions:default": ["@platforms//:incompatible"],
+    }),
     deps = [
         ":__support_osutil_syscall",
     ],
@@ -1019,6 +1034,10 @@ libc_support_library(
         "src/__support/StringUtil/error_to_string.h",
         "src/__support/StringUtil/signal_to_string.h",
     ],
+    target_compatible_with = select({
+        "@platforms//os:linux": [],
+        "//conditions:default": ["@platforms//:incompatible"],
+    }),
     deps = [
         ":__support_cpp_array",
         ":__support_cpp_span",
@@ -1036,6 +1055,10 @@ libc_support_library(
         "src/__support/threads/mutex.h",
         "src/__support/threads/mutex_common.h",
     ],
+    target_compatible_with = select({
+        "@platforms//os:linux": [],
+        "//conditions:default": ["@platforms//:incompatible"],
+    }),
     textual_hdrs = [
         "src/__support/threads/linux/mutex.h",
         "src/__support/threads/linux/futex_word.h",
@@ -1695,13 +1718,19 @@ libc_math_function(
 )
 
 libc_math_function(name = "fabs")
+
 libc_math_function(name = "fabsf")
+
 libc_math_function(name = "fabsl")
+
 libc_math_function(name = "fabsf128")
 
 libc_math_function(name = "fdim")
+
 libc_math_function(name = "fdimf")
+
 libc_math_function(name = "fdiml")
+
 libc_math_function(name = "fdimf128")
 
 libc_math_function(
@@ -1729,7 +1758,6 @@ libc_math_function(
 
 libc_math_function(name = "ceilf128")
 
-
 libc_math_function(
     name = "floor",
     specializations = [
@@ -1747,11 +1775,15 @@ libc_math_function(
 )
 
 libc_math_function(name = "floorl")
+
 libc_math_function(name = "floorf128")
 
 libc_math_function(name = "ldexp")
+
 libc_math_function(name = "ldexpf")
+
 libc_math_function(name = "ldexpl")
+
 libc_math_function(name = "ldexpf128")
 
 libc_math_function(
@@ -1771,6 +1803,7 @@ libc_math_function(
 )
 
 libc_math_function(name = "truncl")
+
 libc_math_function(name = "truncf128")
 
 libc_math_function(
@@ -1790,6 +1823,7 @@ libc_math_function(
 )
 
 libc_math_function(name = "roundl")
+
 libc_math_function(name = "roundf128")
 
 libc_math_function(
@@ -1807,8 +1841,11 @@ libc_math_function(
 )
 
 libc_math_function(name = "frexp")
+
 libc_math_function(name = "frexpf")
+
 libc_math_function(name = "frexpl")
+
 libc_math_function(name = "frexpf128")
 
 libc_math_function(name = "hypot")
@@ -1821,31 +1858,47 @@ libc_math_function(
 )
 
 libc_math_function(name = "logb")
+
 libc_math_function(name = "logbf")
+
 libc_math_function(name = "logbl")
+
 libc_math_function(name = "logbf128")
 
 libc_math_function(name = "modf")
+
 libc_math_function(name = "modff")
+
 libc_math_function(name = "modfl")
+
 libc_math_function(name = "modff128")
 
 libc_math_function(name = "remquo")
+
 libc_math_function(name = "remquof")
+
 libc_math_function(name = "remquol")
 
 libc_math_function(name = "remainder")
+
 libc_math_function(name = "remainderf")
+
 libc_math_function(name = "remainderl")
 
 libc_math_function(name = "fmin")
+
 libc_math_function(name = "fminf")
+
 libc_math_function(name = "fminl")
+
 libc_math_function(name = "fminf128")
 
 libc_math_function(name = "fmax")
+
 libc_math_function(name = "fmaxf")
+
 libc_math_function(name = "fmaxl")
+
 libc_math_function(name = "fmaxf128")
 
 libc_math_function(
@@ -1928,38 +1981,64 @@ libc_math_function(
 )
 
 libc_math_function(name = "copysign")
+
 libc_math_function(name = "copysignf")
+
 libc_math_function(name = "copysignl")
-libc_math_function(name = "copysignf128")
+
+libc_math_function(
+    name = "copysignf128",
+    additional_deps = [
+        ":llvm_libc_types_float128",
+    ],
+)
 
 libc_math_function(name = "ilogb")
+
 libc_math_function(name = "ilogbf")
+
 libc_math_function(name = "ilogbl")
+
 libc_math_function(name = "ilogbf128")
 
 libc_math_function(name = "rint")
+
 libc_math_function(name = "rintf")
+
 libc_math_function(name = "rintl")
+
 libc_math_function(name = "rintf128")
 
 libc_math_function(name = "lrint")
+
 libc_math_function(name = "lrintf")
+
 libc_math_function(name = "lrintl")
+
 libc_math_function(name = "lrintf128")
 
 libc_math_function(name = "llrint")
+
 libc_math_function(name = "llrintf")
+
 libc_math_function(name = "llrintl")
+
 libc_math_function(name = "llrintf128")
 
 libc_math_function(name = "lround")
+
 libc_math_function(name = "lroundf")
+
 libc_math_function(name = "lroundl")
+
 libc_math_function(name = "lroundf128")
 
 libc_math_function(name = "llround")
+
 libc_math_function(name = "llroundf")
+
 libc_math_function(name = "llroundl")
+
 libc_math_function(name = "llroundf128")
 
 libc_math_function(
@@ -1995,20 +2074,29 @@ libc_math_function(
 )
 
 libc_math_function(name = "nearbyint")
+
 libc_math_function(name = "nearbyintf")
+
 libc_math_function(name = "nearbyintl")
 
 libc_math_function(name = "nextafter")
+
 libc_math_function(name = "nextafterf")
+
 libc_math_function(name = "nextafterl")
+
 libc_math_function(name = "nextafterf128")
 
 libc_math_function(name = "nexttoward")
+
 libc_math_function(name = "nexttowardf")
+
 libc_math_function(name = "nexttowardl")
 
 libc_math_function(name = "scalbn")
+
 libc_math_function(name = "scalbnf")
+
 libc_math_function(name = "scalbnl")
 
 ############################## inttypes targets ##############################
@@ -2590,6 +2678,10 @@ libc_function(
     name = "open",
     srcs = ["src/fcntl/linux/open.cpp"],
     hdrs = ["src/fcntl/open.h"],
+    target_compatible_with = select({
+        "@platforms//os:linux": [],
+        "//conditions:default": ["@platforms//:incompatible"],
+    }),
     deps = [
         ":__support_common",
         ":__support_osutil_syscall",
@@ -2601,6 +2693,10 @@ libc_function(
     name = "openat",
     srcs = ["src/fcntl/linux/openat.cpp"],
     hdrs = ["src/fcntl/openat.h"],
+    target_compatible_with = select({
+        "@platforms//os:linux": [],
+        "//conditions:default": ["@platforms//:incompatible"],
+    }),
     deps = [
         ":__support_common",
         ":__support_osutil_syscall",
@@ -2680,6 +2776,10 @@ libc_function(
     name = "dup3",
     srcs = ["src/unistd/linux/dup3.cpp"],
     hdrs = ["src/unistd/dup3.h"],
+    target_compatible_with = select({
+        "@platforms//os:linux": [],
+        "//conditions:default": ["@platforms//:incompatible"],
+    }),
     deps = [
         ":__support_common",
         ":__support_osutil_syscall",
@@ -2849,6 +2949,10 @@ libc_function(
     name = "pread",
     srcs = ["src/unistd/linux/pread.cpp"],
     hdrs = ["src/unistd/pread.h"],
+    target_compatible_with = select({
+        "@platforms//os:linux": [],
+        "//conditions:default": ["@platforms//:incompatible"],
+    }),
     deps = [
         ":__support_common",
         ":__support_osutil_syscall",
@@ -2860,6 +2964,10 @@ libc_function(
     name = "pwrite",
     srcs = ["src/unistd/linux/pwrite.cpp"],
     hdrs = ["src/unistd/pwrite.h"],
+    target_compatible_with = select({
+        "@platforms//os:linux": [],
+        "//conditions:default": ["@platforms//:incompatible"],
+    }),
     deps = [
         ":__support_common",
         ":__support_osutil_syscall",
@@ -3263,6 +3371,10 @@ libc_function(
     name = "rename",
     srcs = ["src/stdio/linux/rename.cpp"],
     hdrs = ["src/stdio/rename.h"],
+    target_compatible_with = select({
+        "@platforms//os:linux": [],
+        "//conditions:default": ["@platforms//:incompatible"],
+    }),
     deps = [
         ":__support_common",
         ":__support_osutil_syscall",
@@ -3301,6 +3413,10 @@ libc_function(
     name = "epoll_wait",
     srcs = ["src/sys/epoll/linux/epoll_wait.cpp"],
     hdrs = ["src/sys/epoll/epoll_wait.h"],
+    target_compatible_with = select({
+        "@platforms//os:linux": [],
+        "//conditions:default": ["@platforms//:incompatible"],
+    }),
     weak = True,
     deps = [
         ":__support_osutil_syscall",
@@ -3312,6 +3428,10 @@ libc_function(
     name = "epoll_pwait",
     srcs = ["src/sys/epoll/linux/epoll_pwait.cpp"],
     hdrs = ["src/sys/epoll/epoll_pwait.h"],
+    target_compatible_with = select({
+        "@platforms//os:linux": [],
+        "//conditions:default": ["@platforms//:incompatible"],
+    }),
     weak = True,
     deps = [
         ":__support_osutil_syscall",


### PR DESCRIPTION
With these changes you can now `bazel build @llvm-project//...` on macOS, and the targets in libc that don't yet support macOS (or non-linux) are ignored