### PR TITLE
[mlir][arith] Refine the verifier for arith.constant

### DIFF
--- a/mlir/lib/Dialect/Arith/IR/ArithOps.cpp
+++ b/mlir/lib/Dialect/Arith/IR/ArithOps.cpp
@@ -191,13 +191,11 @@ LogicalResult arith::ConstantOp::verify() {
         "value must be an integer, float, or elements attribute");
   }
 
-  // Intializing scalable vectors with elements attribute is not supported
-  // unless it's a vector splot.
   auto vecType = dyn_cast<VectorType>(type);
-  auto val = dyn_cast<DenseElementsAttr>(getValue());
-  if ((vecType && val) && vecType.isScalable() && !val.isSplat())
+  if (vecType && vecType.isScalable() && !isa<SplatElementsAttr>(getValue()))
     return emitOpError(
-        "using elements attribute to initialize a scalable vector");
+        "intializing scalable vectors with elements attribute is not supported"
+        " unless it's a vector splat");
   return success();
 }
 

--- a/mlir/lib/Dialect/Arith/IR/ArithOps.cpp
+++ b/mlir/lib/Dialect/Arith/IR/ArithOps.cpp
@@ -190,6 +190,14 @@ LogicalResult arith::ConstantOp::verify() {
     return emitOpError(
         "value must be an integer, float, or elements attribute");
   }
+
+  // Intializing scalable vectors with elements attribute is not supported
+  // unless it's a vector splot.
+  auto vecType = dyn_cast<VectorType>(type);
+  auto val = dyn_cast<DenseElementsAttr>(getValue());
+  if ((vecType && val) && vecType.isScalable() && !val.isSplat())
+    return emitOpError(
+        "using elements attribute to initialize a scalable vector");
   return success();
 }
 

--- a/mlir/test/Dialect/Arith/invalid.mlir
+++ b/mlir/test/Dialect/Arith/invalid.mlir
@@ -215,6 +215,14 @@ func.func @func_with_ops() {
 
 // -----
 
+func.func @func_with_ops() {
+^bb0:
+  // expected-error@+1 {{op failed to verify that result type has i1 element type and same shape as operands}}
+  %c = arith.constant dense<[0, 1]> : vector<[2] x i32>
+}
+
+// -----
+
 func.func @invalid_cmp_shape(%idx : () -> ()) {
   // expected-error@+1 {{'lhs' must be signless-integer-like, but got '() -> ()'}}
   %cmp = arith.cmpi eq, %idx, %idx : () -> ()

--- a/mlir/test/Dialect/Arith/invalid.mlir
+++ b/mlir/test/Dialect/Arith/invalid.mlir
@@ -64,6 +64,15 @@ func.func @constant_out_of_range() {
 
 // -----
 
+func.func @constant_invalid_scalable_vec_initialization() {
+^bb0:
+  // expected-error@+1 {{'arith.constant' op intializing scalable vectors with elements attribute is not supported unless it's a vector splat}}
+  %c = arith.constant dense<[0, 1]> : vector<[2] x i32>
+  return
+}
+
+// -----
+
 func.func @constant_wrong_type() {
 ^bb:
   %x = "arith.constant"(){value = 10.} : () -> f32 // expected-error {{'arith.constant' op failed to verify that all of {value, result} have same type}}
@@ -211,14 +220,6 @@ func.func @func_with_ops() {
   %c = arith.constant dense<0> : tensor<42 x i32, "foo">
   // expected-error@+1 {{op failed to verify that result type has i1 element type and same shape as operands}}
   %r = "arith.cmpi"(%c, %c) {predicate = 0} : (tensor<42 x i32, "foo">, tensor<42 x i32, "foo">) -> tensor<42 x i1, "bar">
-}
-
-// -----
-
-func.func @func_with_ops() {
-^bb0:
-  // expected-error@+1 {{op failed to verify that result type has i1 element type and same shape as operands}}
-  %c = arith.constant dense<[0, 1]> : vector<[2] x i32>
 }
 
 // -----


### PR DESCRIPTION
Disallows initialization of scalable vectors with an attribute of
arbitrary values, e.g.:
```mlir
  %c = arith.constant dense<[0, 1]> : vector<[2] x i32>
```

Initialization using vector splats remains allowed (i.e. when all the
init values are identical):
```mlir
  %c = arith.constant dense<[1, 1]> : vector<[2] x i32>
```