### PR TITLE
[flang][OpenMP] Allow loop iteration variables in DSA clauses

### DIFF
--- a/flang/lib/Semantics/resolve-directives.cpp
+++ b/flang/lib/Semantics/resolve-directives.cpp
@@ -1651,7 +1651,7 @@ void OmpAttributeVisitor::ResolveSeqLoopIndexInParallelOrTaskConstruct(
   }
   // If this symbol already has a data-sharing attribute then there is nothing
   // to do here.
-  if (const Symbol *symbol{iv.symbol}) {
+  if (const Symbol * symbol{iv.symbol}) {
     for (auto symMap : targetIt->objectWithDSA) {
       if (symMap.first->name() == symbol->name()) {
         return;

--- a/flang/lib/Semantics/resolve-directives.cpp
+++ b/flang/lib/Semantics/resolve-directives.cpp
@@ -1651,10 +1651,13 @@ void OmpAttributeVisitor::ResolveSeqLoopIndexInParallelOrTaskConstruct(
   }
   // If this symbol already has a data-sharing attribute then there is nothing
   // to do here.
-  if (const Symbol *symbol = iv.symbol)
-    for (auto symMap : targetIt->objectWithDSA)
-      if (symMap.first->name() == symbol->name())
+  if (const Symbol *symbol{iv.symbol}) {
+    for (auto symMap : targetIt->objectWithDSA) {
+      if (symMap.first->name() == symbol->name()) {
         return;
+      }
+    }
+  }
   // If this symbol is already Private or Firstprivate in the enclosing
   // OpenMP parallel or task then there is nothing to do here.
   if (auto *symbol{targetIt->scope.FindSymbol(iv.source)}) {

--- a/flang/lib/Semantics/resolve-directives.cpp
+++ b/flang/lib/Semantics/resolve-directives.cpp
@@ -1649,6 +1649,12 @@ void OmpAttributeVisitor::ResolveSeqLoopIndexInParallelOrTaskConstruct(
       break;
     }
   }
+  // If this symbol already has a data-sharing attribute then there is nothing
+  // to do here.
+  if (const Symbol *symbol = iv.symbol)
+    for (auto symMap : targetIt->objectWithDSA)
+      if (symMap.first->name() == symbol->name())
+        return;
   // If this symbol is already Private or Firstprivate in the enclosing
   // OpenMP parallel or task then there is nothing to do here.
   if (auto *symbol{targetIt->scope.FindSymbol(iv.source)}) {

--- a/flang/test/Semantics/OpenMP/do20.f90
+++ b/flang/test/Semantics/OpenMP/do20.f90
@@ -1,0 +1,18 @@
+! RUN: %python %S/../test_symbols.py %s %flang_fc1 -fopenmp
+
+! OpenMP 5.2 5.1.1
+! Iteration variables of non-associated loops may be listed in DSA clauses.
+
+!DEF: /shared_iv (Subroutine)Subprogram
+subroutine shared_iv
+  !DEF: /shared_iv/i ObjectEntity INTEGER(4)
+  integer i
+
+  !$omp parallel shared(i)
+    !$omp single
+      !REF: /shared_iv/i
+      do i = 0, 1
+      end do
+    !$omp end single
+  !$omp end parallel
+end subroutine


### PR DESCRIPTION
Iteration variables of non-associated loops may be listed in DSA
clauses.

Fixes https://github.com/llvm/llvm-project/issues/78938
