### PR TITLE
[cmake] Place clang behind mlir in the liist of external projects

### DIFF
--- a/llvm/tools/CMakeLists.txt
+++ b/llvm/tools/CMakeLists.txt
@@ -37,12 +37,13 @@ add_llvm_tool_subdirectory(llvm-profdata)
 
 # Projects supported via LLVM_EXTERNAL_*_SOURCE_DIR need to be explicitly
 # specified.
-add_llvm_external_project(clang)
 add_llvm_external_project(lld)
-add_llvm_external_project(lldb)
 add_llvm_external_project(mlir)
-# Flang depends on mlir, so place it afterward
+# ClangIR and Flang depend on mlir, lldb and Flang depend on clang, sort them
+# accordingly so place them afterwards
+add_llvm_external_project(clang)
 add_llvm_external_project(flang)
+add_llvm_external_project(lldb)
 add_llvm_external_project(bolt)
 
 # Automatically add remaining sub-directories containing a 'CMakeLists.txt'


### PR DESCRIPTION
In preparation for the initial ClangIR upstreaming process, move clang
behind MLIR in the list of external projects. Otherwise, cmake will
attempt to build clang before MLIR.

reland of https://github.com/llvm/llvm-project/pull/86050
