### PR TITLE
Add 'refersToPack' AST matcher

### DIFF
--- a/clang/lib/ASTMatchers/Dynamic/Registry.cpp
+++ b/clang/lib/ASTMatchers/Dynamic/Registry.cpp
@@ -551,6 +551,7 @@ RegistryMaps::RegistryMaps() {
   REGISTER_MATCHER(referenceType);
   REGISTER_MATCHER(referenceTypeLoc);
   REGISTER_MATCHER(refersToDeclaration);
+  REGISTER_MATCHER(refersToPack);
   REGISTER_MATCHER(refersToIntegralType);
   REGISTER_MATCHER(refersToTemplate);
   REGISTER_MATCHER(refersToType);


### PR DESCRIPTION
This adds a 'refersToPack' AST matcher, which can be used to match against template arguments that are inside parameter packs. The inner matcher is evaluated against each argument in the parameter pack, such that given:

```cpp
template<typename T, typename... Params> class A {};
A<int, double> a;
A<double, int> b;
A<double, int, long> c;
```

The matcher `classTemplateSpecializationDecl(hasAnyTemplateArgument(refersToPack(refersToType(...))))` would evaluate the `refersToType` against:

- For `a`, the `double` template argument. 
- For `b`, the `int` template argument.
- For `c`, the `int` template argument, then the `long` template argument.

If the inner matcher matches against any argument of the parameter pack, then `refersToPack` matches.