### PR TITLE
Add 'forNone' and 'forNoDescendant' AST matchers

### DIFF
--- a/clang/include/clang/ASTMatchers/ASTMatchers.h
+++ b/clang/include/clang/ASTMatchers/ASTMatchers.h
@@ -3547,6 +3547,21 @@ extern const internal::ArgumentAdaptingMatcherFunc<
     internal::ForEachDescendantMatcher>
     forEachDescendant;
 
+/// Matches AST nodes that have no child AST nodes that match the
+/// provided matcher.
+///
+/// Usable as: Any Matcher
+extern const internal::ArgumentAdaptingMatcherFunc<internal::ForNoneMatcher>
+    forNone;
+
+/// Matches AST nodes that have no descendant AST nodes that match the
+/// provided matcher.
+///
+/// Usable as: Any Matcher
+extern const internal::ArgumentAdaptingMatcherFunc<
+    internal::ForNoDescendantMatcher>
+    forNoDescendant;
+
 /// Matches if the node or any descendant matches.
 ///
 /// Generates results for each match.

--- a/clang/lib/ASTMatchers/ASTMatchersInternal.cpp
+++ b/clang/lib/ASTMatchers/ASTMatchersInternal.cpp
@@ -106,6 +106,15 @@ void BoundNodesTreeBuilder::visitMatches(Visitor *ResultVisitor) {
   }
 }
 
+bool BoundNodesTreeBuilder::contains(const internal::BoundNodesMap &Subset) {
+  for (BoundNodesMap &Binding : Bindings) {
+    if (Binding.contains(Subset)) {
+      return true;
+    }
+  }
+  return false;
+}
+
 namespace {
 
 using VariadicOperatorFunction = bool (*)(
@@ -1022,8 +1031,12 @@ const internal::ArgumentAdaptingMatcherFunc<internal::HasDescendantMatcher>
     hasDescendant = {};
 const internal::ArgumentAdaptingMatcherFunc<internal::ForEachMatcher> forEach =
     {};
+const internal::ArgumentAdaptingMatcherFunc<internal::ForNoneMatcher> forNone =
+    {};
 const internal::ArgumentAdaptingMatcherFunc<internal::ForEachDescendantMatcher>
     forEachDescendant = {};
+const internal::ArgumentAdaptingMatcherFunc<internal::ForNoDescendantMatcher>
+    forNoDescendant = {};
 const internal::ArgumentAdaptingMatcherFunc<
     internal::HasParentMatcher,
     internal::TypeList<Decl, NestedNameSpecifierLoc, Stmt, TypeLoc, Attr>,

--- a/clang/lib/ASTMatchers/Dynamic/Registry.cpp
+++ b/clang/lib/ASTMatchers/Dynamic/Registry.cpp
@@ -259,6 +259,8 @@ RegistryMaps::RegistryMaps() {
   REGISTER_MATCHER(forEachOverridden);
   REGISTER_MATCHER(forEachSwitchCase);
   REGISTER_MATCHER(forEachTemplateArgument);
+  REGISTER_MATCHER(forNone);
+  REGISTER_MATCHER(forNoDescendant);
   REGISTER_MATCHER(forField);
   REGISTER_MATCHER(forFunction);
   REGISTER_MATCHER(forStmt);


### PR DESCRIPTION
This adds `forNone` and `forNoDescendant` AST matchers. `forNoDescendant` is simply the recursive version of `forNone`. 

`forNone` matches only if there are no immediate children of the current node that match the inner matcher. For example, given:

```cpp
class F
{
public:
  int A;

  F() {};
};
```

the matcher:

```
cxxConstructorDecl(
    unless(isImplicit()),
    unless(isDelegatingConstructor()),
    unless(isDeleted()),
    unless(isDefaulted()),
    hasBody(stmt()),
    ofClass(cxxRecordDecl(forEach(fieldDecl().bind("declared_field")))),
    forNone(cxxCtorInitializer(forField(fieldDecl(equalsBoundNode("declared_field")).bind("referenced_field"))))
).bind("bad_constructor")
```

would match `F()`, because it does not have an initializer for `A`. We use this in our modified version of Clang to detect constructors that do not fully initialize all fields.

*Note:* The `forNoDescendant` AST matcher is included in this pull request, as both matchers depend on the new `BoundNodesTreeBuilder::contains` function.
