### PR TITLE
Add 'isPODType' AST matcher

### DIFF
--- a/clang/include/clang/ASTMatchers/ASTMatchers.h
+++ b/clang/include/clang/ASTMatchers/ASTMatchers.h
@@ -4087,6 +4087,23 @@ AST_POLYMORPHIC_MATCHER_P(
   return Inner.matches(source->getTypeLoc(), Finder, Builder);
 }
 
+/// Matches if the matched type is a Plain Old Data (POD) type.
+///
+/// Given
+/// \code
+///   class Y
+///   {
+///   public:
+///       int a;
+///       std::string b;
+///   };
+/// \endcode
+/// fieldDecl(hasType(qualType(isPODType())))
+///   matches Y::a
+AST_MATCHER(QualType, isPODType) {
+  return Node.isPODType(Finder->getASTContext());
+}
+
 /// Matches if the matched type is represented by the given string.
 ///
 /// Given

--- a/clang/lib/ASTMatchers/Dynamic/Registry.cpp
+++ b/clang/lib/ASTMatchers/Dynamic/Registry.cpp
@@ -377,6 +377,7 @@ RegistryMaps::RegistryMaps() {
   REGISTER_MATCHER(hasTypeLoc);
   REGISTER_MATCHER(hasUnaryOperand);
   REGISTER_MATCHER(hasUnarySelector);
+  REGISTER_MATCHER(isPODType);
   REGISTER_MATCHER(hasUnderlyingDecl);
   REGISTER_MATCHER(hasUnderlyingType);
   REGISTER_MATCHER(hasUnqualifiedDesugaredType);


### PR DESCRIPTION
This adds an `isPODType` AST matcher which matches if the matched type is a Plain Old Data (POD) type.

Given:

```cpp
class Y
{ 
public:
    int a;
    std::string b;
};
```

the matcher `fieldDecl(hasType(qualType(isPODType())))` would match `Y::a` but not `Y::b`.