### PR TITLE
[lldb] Handle clang::Language::CIR

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp
+++ b/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp
@@ -477,6 +477,7 @@ static void ParseLangArgs(LangOptions &Opts, InputKind IK, const char *triple) {
     // Based on the base language, pick one.
     switch (IK.getLanguage()) {
     case clang::Language::Unknown:
+    case clang::Language::CIR:
     case clang::Language::LLVM_IR:
     case clang::Language::RenderScript:
       llvm_unreachable("Invalid input kind!");


### PR DESCRIPTION
  commit e66b670f3bf9312f696e66c31152ae535207d6bb
  Author: Nathan Lanza <nathanlanza@gmail.com>
  Date:   Thu Mar 21 19:53:48 2024 -0400

triggers:

  lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp:478:16:
  error: enumeration value 'CIR' not handled in switch
  [-Werror,-Wswitch]

This patch teaches lldb to handle clang::Language::CIR the same way as
clang::Language::LLVM_IR.
