### PR TITLE
[AMDGPU] Add calling convention check in call lowering.

### DIFF
--- a/llvm/lib/Target/AMDGPU/SIISelLowering.cpp
+++ b/llvm/lib/Target/AMDGPU/SIISelLowering.cpp
@@ -3684,7 +3684,7 @@ SDValue SITargetLowering::LowerCall(CallLoweringInfo &CLI,
   if (!IsSibCall)
     Chain = DAG.getCALLSEQ_START(Chain, 0, 0, DL);
 
-  if (!IsSibCall || IsChainCallConv) {
+  if (!AMDGPU::isGraphics(CallConv) && (!IsSibCall || IsChainCallConv)) {
     if (!Subtarget->enableFlatScratch()) {
       SmallVector<SDValue, 4> CopyFromChains;
 


### PR DESCRIPTION
In https://github.com/llvm/llvm-project/pull/81394, calls to amdgpu_gfx functions are now allowed to use s0-s3 for inreg arguments. This causes a regression in an offline lit test, where we call an external compute library function from a compute shader. The changes leave registers from the s0-s3 range to not be live-in in the MBB containing the SI_CALL instruction.
This seems to be caused by a missing Gfx CC check in `SITargetLowering::LowerCall`, where we insert a `CopyFromReg` from a call chain to either s48-s51 or s0-s3.
Since by the now missing copy at the beginning of the MBB, SGPR0-SGPR3 are not implicitly live anymore, the lowering of the call still using SGPR0-SGPR3 will also fail, so we should not insert the `CopyFromReg` into the chain as well.

I hope that makes sense somehow.