### PR TITLE
[RemoveDIs] Do not load into new debug info format from bitcode by default

### DIFF
--- a/llvm/tools/verify-uselistorder/verify-uselistorder.cpp
+++ b/llvm/tools/verify-uselistorder/verify-uselistorder.cpp
@@ -69,6 +69,7 @@ static cl::opt<unsigned>
                 cl::init(1), cl::cat(Cat));
 
 extern cl::opt<cl::boolOrDefault> LoadBitcodeIntoNewDbgInforFormat;
+
 namespace {
 
 struct TempFile {

--- a/llvm/tools/verify-uselistorder/verify-uselistorder.cpp
+++ b/llvm/tools/verify-uselistorder/verify-uselistorder.cpp
@@ -543,6 +543,7 @@ int main(int argc, char **argv) {
   cl::HideUnrelatedOptions(Cat);
   cl::ParseCommandLineOptions(argc, argv,
                               "llvm tool to verify use-list order\n");
+
   // Do not load bitcode into the new debug info format by default.
   if (LoadBitcodeIntoNewDbgInforFormat == cl::boolOrDefault::BOU_UNSET)
     LoadBitcodeIntoNewDbgInforFormat = cl::boolOrDefault::BOU_FALSE;

--- a/llvm/tools/verify-uselistorder/verify-uselistorder.cpp
+++ b/llvm/tools/verify-uselistorder/verify-uselistorder.cpp
@@ -68,6 +68,7 @@ static cl::opt<unsigned>
                 cl::desc("Number of times to shuffle and verify use-lists"),
                 cl::init(1), cl::cat(Cat));
 
+extern cl::opt<cl::boolOrDefault> LoadBitcodeIntoNewDbgInforFormat;
 namespace {
 
 struct TempFile {
@@ -169,8 +170,7 @@ std::unique_ptr<Module> TempFile::readBitcode(LLVMContext &Context) const {
 
   // verify-uselistoder currently only supports old-style debug info mode.
   // FIXME: Update mapping code for RemoveDIs.
-  assert(!ModuleOr.get()->IsNewDbgInfoFormat &&
-         "Unexpectedly in new debug info mode");
+  ModuleOr.get()->setIsNewDbgInfoFormat(false);
   return std::move(ModuleOr.get());
 }
 
@@ -182,7 +182,7 @@ std::unique_ptr<Module> TempFile::readAssembly(LLVMContext &Context) const {
     Err.print("verify-uselistorder", errs());
   // verify-uselistoder currently only supports old-style debug info mode.
   // FIXME: Update mapping code for RemoveDIs.
-  assert(!M->IsNewDbgInfoFormat && "Unexpectedly in new debug info mode");
+  M->setIsNewDbgInfoFormat(false);
   return M;
 }
 
@@ -543,6 +543,9 @@ int main(int argc, char **argv) {
   cl::HideUnrelatedOptions(Cat);
   cl::ParseCommandLineOptions(argc, argv,
                               "llvm tool to verify use-list order\n");
+  // Do not load bitcode into the new debug info format by default.
+  if (LoadBitcodeIntoNewDbgInforFormat == cl::boolOrDefault::BOU_UNSET)
+    LoadBitcodeIntoNewDbgInforFormat = cl::boolOrDefault::BOU_FALSE;
 
   LLVMContext Context;
   SMDiagnostic Err;
@@ -551,7 +554,7 @@ int main(int argc, char **argv) {
   std::unique_ptr<Module> M = parseIRFile(InputFilename, Err, Context);
   // verify-uselistoder currently only supports old-style debug info mode.
   // FIXME: Update mapping code for RemoveDIs.
-  assert(!M->IsNewDbgInfoFormat && "Unexpectedly in new debug info mode");
+  M->setIsNewDbgInfoFormat(false);
 
   if (!M.get()) {
     Err.print(argv[0], errs());


### PR DESCRIPTION
This is NFC right now, as the global default behaviour is also "do not load into the new debug info format by default", but we want to change that soon.

Additionally unconditionally convert from the new debug info format into if we've loaded into it (e.g., if the bitcode file loaded was already in the new format).

The latter change is needed because verify-uselistorder doesn't yet understand DbgRecords (it doesn't know how to map them).

The former change is needed because if we load from an old debug format bitcode file but load directly into the new format _and then convert back to the old mode after_, the use-lists of the debug intrinsic functions (the functions' global value uses) change.