### PR TITLE
[NFC][Sanitizer] Refine the restriction on SizeClassAllocator64::kRegionSize

### DIFF
--- a/compiler-rt/lib/sanitizer_common/sanitizer_allocator_primary64.h
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_allocator_primary64.h
@@ -639,7 +639,8 @@ class SizeClassAllocator64 {
   static_assert(kRegionSize >= SizeClassMap::kMaxSize,
                 "Region size exceed largest size");
   // kRegionSize must be <= 2^36, see CompactPtrT.
-  COMPILER_CHECK((kRegionSize) <= (1ULL << (SANITIZER_WORDSIZE / 2 + 4)));
+  COMPILER_CHECK((kRegionSize) <=
+                 (1ULL << (sizeof(CompactPtrT) * 8 + kCompactPtrScale)));
   // Call mmap for user memory with at least this size.
   static const uptr kUserMapSize = 1 << 18;
   // Call mmap for metadata memory with at least this size.


### PR DESCRIPTION
This patch replaces the `SANITIZER_WORDSIZE / 2` with `sizeof(CompactPtrT) * 8`, replaces hardcoded `4` with `kCompactPtrScale` in assertion.