### PR TITLE
Refine the examples in the debug info document

### DIFF
--- a/llvm/docs/HowToUpdateDebugInfo.rst
+++ b/llvm/docs/HowToUpdateDebugInfo.rst
@@ -91,9 +91,9 @@ misattributed to a block containing one of the instructions-to-be-merged.
 
 Examples of transformations that should follow this rule include:
 
-* Hoisting identical instructions from successors of a conditional branch or
-  sinking those from different predecessors. For example, merging identical
-  loads/stores which occur on both sides of a CFG diamond (see the
+* Hoisting identical instructions from all successors of a conditional branch
+  or sinking those from all different predecessors. For example, merging
+  identical loads/stores which occur on both sides of a CFG diamond (see the
   ``MergedLoadStoreMotion`` pass). For each group of identical instructions
   being hoisted/sunk, the merge of all their locations should be applied to
   the merged instruction.

--- a/llvm/docs/HowToUpdateDebugInfo.rst
+++ b/llvm/docs/HowToUpdateDebugInfo.rst
@@ -91,8 +91,11 @@ misattributed to a block containing one of the instructions-to-be-merged.
 
 Examples of transformations that should follow this rule include:
 
-* Merging identical loads/stores which occur on both sides of a CFG diamond
-  (see the ``MergedLoadStoreMotion`` pass).
+* Hoisting identical instructions from successors of a conditional branch. For
+  example, merging identical loads/stores which occur on both sides of a CFG
+  diamond (see the ``MergedLoadStoreMotion`` pass). If there are more than one
+  group of identical instructions hoisted, apply merging instruction locations
+  for each single merged instruction.
 
 * Merging identical loop-invariant stores (see the LICM utility
   ``llvm::promoteLoopAccessesToScalars``).
@@ -114,11 +117,6 @@ Examples of transformations for which this rule *does not* apply include:
   is true when it's not (or vice versa), which leads to a confusing
   single-stepping experience. The rule for
   :ref:`dropping locations<WhenToDropLocation>` should apply here.
-
-* Hoisting identical instructions which appear in several successor blocks into
-  a predecessor block (see ``BranchFolder::HoistCommonCodeInSuccs``). In this
-  case there is no single merged instruction. The rule for
-  :ref:`dropping locations<WhenToDropLocation>` applies.
 
 .. _WhenToDropLocation:
 

--- a/llvm/docs/HowToUpdateDebugInfo.rst
+++ b/llvm/docs/HowToUpdateDebugInfo.rst
@@ -91,11 +91,12 @@ misattributed to a block containing one of the instructions-to-be-merged.
 
 Examples of transformations that should follow this rule include:
 
-* Hoisting identical instructions from successors of a conditional branch. For
-  example, merging identical loads/stores which occur on both sides of a CFG
-  diamond (see the ``MergedLoadStoreMotion`` pass). If there are more than one
-  group of identical instructions hoisted, apply merging instruction locations
-  for each single merged instruction.
+* Hoisting identical instructions from successors of a conditional branch or
+  sinking those from different predecessors. For example, merging identical
+  loads/stores which occur on both sides of a CFG diamond (see the
+  ``MergedLoadStoreMotion`` pass). For each group of identical instructions
+  being hoisted/sunk, the merge of all their locations should be applied to
+  the merged instruction.
 
 * Merging identical loop-invariant stores (see the LICM utility
   ``llvm::promoteLoopAccessesToScalars``).

--- a/llvm/docs/HowToUpdateDebugInfo.rst
+++ b/llvm/docs/HowToUpdateDebugInfo.rst
@@ -92,11 +92,11 @@ misattributed to a block containing one of the instructions-to-be-merged.
 Examples of transformations that should follow this rule include:
 
 * Hoisting identical instructions from all successors of a conditional branch
-  or sinking those from all paths to a postdominating block. For example, merging
-  identical loads/stores which occur on both sides of a CFG diamond (see the
-  ``MergedLoadStoreMotion`` pass). For each group of identical instructions
-  being hoisted/sunk, the merge of all their locations should be applied to
-  the merged instruction.
+  or sinking those from all paths to a postdominating block. For example,
+  merging identical loads/stores which occur on both sides of a CFG diamond
+  (see the ``MergedLoadStoreMotion`` pass). For each group of identical
+  instructions being hoisted/sunk, the merge of all their locations should be
+  applied to the merged instruction.
 
 * Merging identical loop-invariant stores (see the LICM utility
   ``llvm::promoteLoopAccessesToScalars``).

--- a/llvm/docs/HowToUpdateDebugInfo.rst
+++ b/llvm/docs/HowToUpdateDebugInfo.rst
@@ -119,6 +119,13 @@ Examples of transformations for which this rule *does not* apply include:
   single-stepping experience. The rule for
   :ref:`dropping locations<WhenToDropLocation>` should apply here.
 
+* Hoisting/sinking a part of the identical instructions with the same location.
+  Consider hoisting two identical instructions with the same location from
+  first two cases of a switch that has three cases. Merging their locations
+  would make the location from the first two cases reachable when the third
+  case is taken. The rule for :ref:`dropping locations<WhenToDropLocation>`
+  applies.
+
 .. _WhenToDropLocation:
 
 When to drop an instruction location

--- a/llvm/docs/HowToUpdateDebugInfo.rst
+++ b/llvm/docs/HowToUpdateDebugInfo.rst
@@ -119,12 +119,12 @@ Examples of transformations for which this rule *does not* apply include:
   single-stepping experience. The rule for
   :ref:`dropping locations<WhenToDropLocation>` should apply here.
 
-* Hoisting/sinking a part of the identical instructions with the same location.
-  Consider hoisting two identical instructions with the same location from
-  first two cases of a switch that has three cases. Merging their locations
-  would make the location from the first two cases reachable when the third
-  case is taken. The rule for :ref:`dropping locations<WhenToDropLocation>`
-  applies.
+* Hoisting/sinking that would make a location reachable when it previously
+  wasn't. Consider hoisting two identical instructions with the same location
+  from first two cases of a switch that has three cases. Merging their
+  locations would make the location from the first two cases reachable when the
+  third case is taken. The rule for
+  :ref:`dropping locations<WhenToDropLocation>` applies.
 
 .. _WhenToDropLocation:
 

--- a/llvm/docs/HowToUpdateDebugInfo.rst
+++ b/llvm/docs/HowToUpdateDebugInfo.rst
@@ -92,7 +92,7 @@ misattributed to a block containing one of the instructions-to-be-merged.
 Examples of transformations that should follow this rule include:
 
 * Hoisting identical instructions from all successors of a conditional branch
-  or sinking those from all different predecessors. For example, merging
+  or sinking those from all paths to a postdominating block. For example, merging
   identical loads/stores which occur on both sides of a CFG diamond (see the
   ``MergedLoadStoreMotion`` pass). For each group of identical instructions
   being hoisted/sunk, the merge of all their locations should be applied to


### PR DESCRIPTION
This PR modifies the examples of section "When to merge instruction locations" in [HowToUpdateDebugInfo](https://llvm.org/docs/HowToUpdateDebugInfo.html) according to [the discussion](https://discourse.llvm.org/t/debuginfo-merging-instruction-locations-of-hoisted-instructions/77357), removing one misleading counterexample and refining the description of hoisting identical instructions.