### PR TITLE
[RemoveDIs] Load into new debug info format by default in llvm-dis

### DIFF
--- a/llvm/tools/llvm-dis/llvm-dis.cpp
+++ b/llvm/tools/llvm-dis/llvm-dis.cpp
@@ -81,6 +81,7 @@ static cl::opt<bool> PrintThinLTOIndexOnly(
     cl::init(false), cl::Hidden, cl::cat(DisCategory));
 
 extern cl::opt<bool> WriteNewDbgInfoFormat;
+
 extern cl::opt<cl::boolOrDefault> LoadBitcodeIntoNewDbgInfoFormat;
 
 namespace {
@@ -169,6 +170,7 @@ int main(int argc, char **argv) {
 
   cl::HideUnrelatedOptions({&DisCategory, &getColorCategory()});
   cl::ParseCommandLineOptions(argc, argv, "llvm .bc -> .ll disassembler\n");
+
   // Load bitcode into the new debug info format by default.
   if (LoadBitcodeIntoNewDbgInfoFormat == cl::boolOrDefault::BOU_UNSET)
     LoadBitcodeIntoNewDbgInfoFormat = cl::boolOrDefault::BOU_TRUE;

--- a/llvm/tools/llvm-dis/llvm-dis.cpp
+++ b/llvm/tools/llvm-dis/llvm-dis.cpp
@@ -81,8 +81,6 @@ static cl::opt<bool> PrintThinLTOIndexOnly(
     cl::init(false), cl::Hidden, cl::cat(DisCategory));
 
 extern cl::opt<bool> WriteNewDbgInfoFormat;
-
-extern cl::opt<bool> WriteNewDbgInfoFormat;
 extern cl::opt<cl::boolOrDefault> LoadBitcodeIntoNewDbgInfoFormat;
 
 namespace {

--- a/llvm/tools/llvm-dis/llvm-dis.cpp
+++ b/llvm/tools/llvm-dis/llvm-dis.cpp
@@ -82,6 +82,9 @@ static cl::opt<bool> PrintThinLTOIndexOnly(
 
 extern cl::opt<bool> WriteNewDbgInfoFormat;
 
+extern cl::opt<bool> WriteNewDbgInfoFormat;
+extern cl::opt<cl::boolOrDefault> LoadBitcodeIntoNewDbgInfoFormat;
+
 namespace {
 
 static void printDebugLoc(const DebugLoc &DL, formatted_raw_ostream &OS) {
@@ -168,6 +171,9 @@ int main(int argc, char **argv) {
 
   cl::HideUnrelatedOptions({&DisCategory, &getColorCategory()});
   cl::ParseCommandLineOptions(argc, argv, "llvm .bc -> .ll disassembler\n");
+  // Load bitcode into the new debug info format by default.
+  if (LoadBitcodeIntoNewDbgInfoFormat == cl::boolOrDefault::BOU_UNSET)
+    LoadBitcodeIntoNewDbgInfoFormat = cl::boolOrDefault::BOU_TRUE;
 
   LLVMContext Context;
   Context.setDiagnosticHandler(


### PR DESCRIPTION
Directly load all bitcode into the new debug info format in llvm-dis. This means that new-mode bitcode no longer round-trips back to old-mode after parsing, and that old-mode bitcode gets auto-upgraded to new-mode debug info (which is the current in-memory default in LLVM).