### PR TITLE
Fixed build breaking due to #77178 and #86131

### DIFF
--- a/compiler-rt/lib/asan/tests/asan_noinst_test.cpp
+++ b/compiler-rt/lib/asan/tests/asan_noinst_test.cpp
@@ -45,7 +45,8 @@ TEST(AddressSanitizer, InternalSimpleDeathTest) {
   EXPECT_DEATH(exit(1), "");
 }
 
-static void MallocStress(size_t n) {
+static void *MallocStress(void *NumOfItrPtr) {
+  size_t n = *((size_t *)NumOfItrPtr);
   u32 seed = my_rand();
   BufferedStackTrace stack1;
   stack1.trace_buffer[0] = 0xa123;
@@ -90,20 +91,21 @@ static void MallocStress(size_t n) {
   }
   for (size_t i = 0; i < vec.size(); i++)
     __asan::asan_free(vec[i], &stack3, __asan::FROM_MALLOC);
+  return nullptr;
 }
 
-
 TEST(AddressSanitizer, NoInstMallocTest) {
-  MallocStress(ASAN_LOW_MEMORY ? 300000 : 1000000);
+  const size_t kNumIterations = (ASAN_LOW_MEMORY) ? 300000 : 1000000;
+  MallocStress((void *)&kNumIterations);
 }
 
 TEST(AddressSanitizer, ThreadedMallocStressTest) {
   const int kNumThreads = 4;
-  const int kNumIterations = (ASAN_LOW_MEMORY) ? 10000 : 100000;
+  const size_t kNumIterations = (ASAN_LOW_MEMORY) ? 10000 : 100000;
   pthread_t t[kNumThreads];
   for (int i = 0; i < kNumThreads; i++) {
-    PTHREAD_CREATE(&t[i], 0, (void* (*)(void *x))MallocStress,
-        (void*)kNumIterations);
+    PTHREAD_CREATE(&t[i], 0, (void *(*)(void *x))MallocStress,
+                   (void *)&kNumIterations);
   }
   for (int i = 0; i < kNumThreads; i++) {
     PTHREAD_JOIN(t[i], 0);


### PR DESCRIPTION
Fixed a small issue of matching pthread signature, which was causing the build to break for the compiler-rt project after adding -Wcast-function-type-mismatch to -Wextra dignostic group (https://github.com/llvm/llvm-project/pull/77178 & https://github.com/llvm/llvm-project/pull/86131).