### PR TITLE
[lld-macho] Ignore -no_warn_duplicate_libraries flag

### DIFF
--- a/lld/MachO/Options.td
+++ b/lld/MachO/Options.td
@@ -1407,3 +1407,9 @@ def debug_variant : Flag<["-"], "debug_variant">,
     HelpText<"Do not warn about issues that are only problems for binaries shipping to customers.">,
     Flags<[HelpHidden]>,
     Group<grp_ignored_silently>;
+
+// NOTE: This flag should be respected if -warn_duplicate_libraries is ever implemented.
+def no_warn_duplicate_libraries : Flag<["-"], "no_warn_duplicate_libraries">,
+    HelpText<"Do not warn if the input contains duplicate library options.">,
+    Flags<[HelpHidden]>,
+    Group<grp_ignored_silently>;

--- a/lld/test/MachO/silent-ignore.s
+++ b/lld/test/MachO/silent-ignore.s
@@ -20,7 +20,7 @@
 
 ## Check that we don't emit any warnings nor errors for these unimplemented flags.
 # RUN: llvm-mc -filetype=obj -triple=x86_64-apple-darwin %s -o %t.o
-# RUN: %lld %t.o -o /dev/null -objc_abi_version 2 -debug_variant
+# RUN: %lld %t.o -o /dev/null -objc_abi_version 2 -debug_variant -no_warn_duplicate_libraries
 
 .globl _main
 _main:


### PR DESCRIPTION
This is a new ld64 flag (along with `-warn_duplicate_libraries`), where the warning is enabled by default, and it can be useful to ignore since it can be hard to dedup library flags across large builds. This doesn't ignore the enabling version since if someone manually passed that and lld didn't respect it, we probably want the user to know that.