### PR TITLE
[libc++] Switch FreeBSD CI job to Clang 17

### DIFF
--- a/libcxx/utils/ci/buildkite-pipeline.yml
+++ b/libcxx/utils/ci/buildkite-pipeline.yml
@@ -209,8 +209,8 @@ steps:
   - label: FreeBSD 13 amd64
     command: libcxx/utils/ci/run-buildbot generic-cxx23
     env:
-      CC: clang16
-      CXX: clang++16
+      CC: clang17
+      CXX: clang++17
     agents:
       queue: libcxx-builders
       os: freebsd

--- a/libcxx/utils/libcxx/test/features.py
+++ b/libcxx/utils/libcxx/test/features.py
@@ -280,6 +280,7 @@ DEFAULT_FEATURES = [
         # This is not allowed per C11 7.1.2 Standard headers/6
         #  Any declaration of a library function shall have external linkage.
         when=lambda cfg: "__ANDROID__" in compilerMacros(cfg)
+        or "__FreeBSD__" in compilerMacros(cfg)
         or "_WIN32" in compilerMacros(cfg)
         or platform.system().lower().startswith("aix")
         # Avoid building on platforms that don't support modules properly.


### PR DESCRIPTION
libc++ will drop support for Clang 16 before long.