### PR TITLE
[ORC] Add default visibility to required JIT functions

### DIFF
--- a/llvm/lib/ExecutionEngine/Orc/TargetProcess/JITLoaderGDB.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/TargetProcess/JITLoaderGDB.cpp
@@ -26,11 +26,13 @@ extern "C" {
 // We put information about the JITed function in this global, which the
 // debugger reads.  Make sure to specify the version statically, because the
 // debugger checks the version before we can set it during runtime.
+LLVM_ATTRIBUTE_VISIBILITY_DEFAULT
 struct jit_descriptor __jit_debug_descriptor = {JitDescriptorVersion, 0,
                                                 nullptr, nullptr};
 
 // Debuggers that implement the GDB JIT interface put a special breakpoint in
 // this function.
+LLVM_ATTRIBUTE_VISIBILITY_DEFAULT
 LLVM_ATTRIBUTE_NOINLINE void __jit_debug_register_code() {
   // The noinline and the asm prevent calls to this function from being
   // optimized out.


### PR DESCRIPTION
If you build LLVM with `-DCMAKE_CXX_VISIBILITY_PRESET=hidden` to help reduce binary size, these symbols end up becoming local, and getting stripped. This forces default visibility to override the global setting in that case.

Relevant: https://github.com/llvm/llvm-project/issues/62815#issuecomment-1560078260