### PR TITLE
[CMake][HLSL] Add SPIRV to target list for build

### DIFF
--- a/clang/cmake/caches/HLSL.cmake
+++ b/clang/cmake/caches/HLSL.cmake
@@ -4,7 +4,7 @@ set(LLVM_TARGETS_TO_BUILD Native CACHE STRING "")
 
 # Include the DirectX target for DXIL code generation, eventually we'll include
 # SPIR-V here too.
-set(LLVM_EXPERIMENTAL_TARGETS_TO_BUILD DirectX CACHE STRING "")
+set(LLVM_EXPERIMENTAL_TARGETS_TO_BUILD "DirectX;SPIRV" CACHE STRING "")
 
 # HLSL support is currently limted to clang, eventually it will expand to
 # clang-tools-extra too.


### PR DESCRIPTION
This change just enables the SPIR-V target by default in the HLSL build configurations. Since SPIR-V support is something we expect from the full HLSL compiler releases for pairity with DXC we should enable it in the default developer workflow.