### PR TITLE
[AArch64] Adjust ROBsize for Ampere1/Ampere1A (NFC)

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64SchedAmpere1.td
+++ b/llvm/lib/Target/AArch64/AArch64SchedAmpere1.td
@@ -18,7 +18,7 @@
 
 def Ampere1Model : SchedMachineModel {
   let IssueWidth            =   4;  // 4-way decode and dispatch
-  let MicroOpBufferSize     = 174;  // micro-op re-order buffer size
+  let MicroOpBufferSize     = 192;  // re-order buffer size
   let LoadLatency           =   4;  // Optimistic load latency
   let MispredictPenalty     =  10;  // Branch mispredict penalty
   let LoopMicroOpBufferSize =  32;  // Instruction queue size


### PR DESCRIPTION
To align more closely with common usage, we now use the size of the reorder-buffer for MicroOpBufferSize instead of the entries of the global micro-op scheduler.