### PR TITLE
[AArch64] Adjust ROBsize for Ampere1B (NFC)

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64SchedAmpere1B.td
+++ b/llvm/lib/Target/AArch64/AArch64SchedAmpere1B.td
@@ -18,7 +18,7 @@
 
 def Ampere1BModel : SchedMachineModel {
   let IssueWidth            =  12;  // Maximum micro-ops dispatch rate.
-  let MicroOpBufferSize     = 192;  // micro-op re-order buffer size
+  let MicroOpBufferSize     = 208;  // micro-op re-order buffer size
   let LoadLatency           =   3;  // Optimistic load latency
   let MispredictPenalty     =  10;  // Branch mispredict penalty
   let LoopMicroOpBufferSize =  32;  // Instruction queue size


### PR DESCRIPTION
To align more closely with common usage, we now use the size of the reorder-buffer for MicroOpBufferSize instead of the entries of the global micro-op scheduler.