### PR TITLE
[NFC][BP] Remove unused parameter from function

### DIFF
--- a/llvm/include/llvm/Support/BalancedPartitioning.h
+++ b/llvm/include/llvm/Support/BalancedPartitioning.h
@@ -142,9 +142,8 @@ private:
               std::optional<BPThreadPool> &TP) const;
 
   /// Run bisection iterations
-  void runIterations(const FunctionNodeRange Nodes, unsigned RecDepth,
-                     unsigned LeftBucket, unsigned RightBucket,
-                     std::mt19937 &RNG) const;
+  void runIterations(const FunctionNodeRange Nodes, unsigned LeftBucket,
+                     unsigned RightBucket, std::mt19937 &RNG) const;
 
   /// Run a bisection iteration to improve the optimization goal
   /// \returns the total number of moved FunctionNodes

--- a/llvm/lib/Support/BalancedPartitioning.cpp
+++ b/llvm/lib/Support/BalancedPartitioning.cpp
@@ -136,7 +136,7 @@ void BalancedPartitioning::bisect(const FunctionNodeRange Nodes,
   // Split into two and assign to the left and right buckets
   split(Nodes, LeftBucket);
 
-  runIterations(Nodes, RecDepth, LeftBucket, RightBucket, RNG);
+  runIterations(Nodes, LeftBucket, RightBucket, RNG);
 
   // Split nodes wrt the resulting buckets
   auto NodesMid =
@@ -163,7 +163,7 @@ void BalancedPartitioning::bisect(const FunctionNodeRange Nodes,
 }
 
 void BalancedPartitioning::runIterations(const FunctionNodeRange Nodes,
-                                         unsigned RecDepth, unsigned LeftBucket,
+                                         unsigned LeftBucket,
                                          unsigned RightBucket,
                                          std::mt19937 &RNG) const {
   unsigned NumNodes = std::distance(Nodes.begin(), Nodes.end());


### PR DESCRIPTION
Remove the unused parameter `RecDepth` from `runIterations()`.