### PR TITLE
 [workflow] Don't add a comment when the first run of the formatter passes

### DIFF
--- a/.github/workflows/pr-code-format.yml
+++ b/.github/workflows/pr-code-format.yml
@@ -73,7 +73,9 @@ jobs:
         # to take advantage of the new --diff_from_common_commit option
         # explicitly in code-format-helper.py and not have to diff starting at
         # the merge base.
+        # Create an empty comments file so the pr-write job doesn't fail.
         run: |
+          touch comments &&
           python ./code-format-tools/llvm/utils/git/code-format-helper.py \
             --write-comment-to-file \
             --token ${{ secrets.GITHUB_TOKEN }} \

--- a/.github/workflows/pr-code-format.yml
+++ b/.github/workflows/pr-code-format.yml
@@ -75,7 +75,7 @@ jobs:
         # the merge base.
         # Create an empty comments file so the pr-write job doesn't fail.
         run: |
-          touch comments &&
+          echo "[]" > comments &&
           python ./code-format-tools/llvm/utils/git/code-format-helper.py \
             --write-comment-to-file \
             --token ${{ secrets.GITHUB_TOKEN }} \

--- a/llvm/utils/git/code-format-helper.py
+++ b/llvm/utils/git/code-format-helper.py
@@ -124,7 +124,8 @@ View the diff from {self.name} here.
         existing_comment = self.find_comment(pr)
 
         if args.write_comment_to_file:
-            self.comment = {"body": comment_text}
+            if create_new or existing_comment:
+                self.comment = {"body": comment_text}
             if existing_comment:
                 self.comment["id"] = existing_comment.id
             return


### PR DESCRIPTION
This was inadvertently changed in
2120f574103c487787390263b3692c4b167f6bdf.