### PR TITLE
[BOLT] Skip functions with unsupported Linux kernel features

### DIFF
--- a/bolt/lib/Rewrite/LinuxKernelRewriter.cpp
+++ b/bolt/lib/Rewrite/LinuxKernelRewriter.cpp
@@ -252,11 +252,13 @@ class LinuxKernelRewriter final : public MetadataRewriter {
 
   /// Paravirtual instruction patch sites.
   Error readParaInstructions();
+  Error rewriteParaInstructions();
 
   Error readBugTable();
 
-  /// Read alternative instruction info from .altinstructions.
+  /// Handle alternative instruction info from .altinstructions.
   Error readAltInstructions();
+  Error rewriteAltInstructions();
 
   /// Read .pci_fixup
   Error readPCIFixupTable();
@@ -316,6 +318,12 @@ public:
     // Since rewriteExceptionTable() can mark functions as non-simple, run it
     // before other rewriters that depend on simple/emit status.
     if (Error E = rewriteExceptionTable())
+      return E;
+
+    if (Error E = rewriteAltInstructions())
+      return E;
+
+    if (Error E = rewriteParaInstructions())
       return E;
 
     if (Error E = rewriteORCTables())
@@ -1126,6 +1134,27 @@ Error LinuxKernelRewriter::readParaInstructions() {
   return Error::success();
 }
 
+Error LinuxKernelRewriter::rewriteParaInstructions() {
+  // Disable output of functions with paravirtual instructions before the
+  // rewrite support is complete.
+  for (BinaryFunction &BF : llvm::make_second_range(BC.getBinaryFunctions())) {
+    if (!BC.shouldEmit(BF))
+      continue;
+    for (const BinaryBasicBlock &BB : BF) {
+      if (!BC.shouldEmit(BF))
+        break;
+      for (const MCInst &Inst : BB) {
+        if (BC.MIB->hasAnnotation(Inst, "ParaSite")) {
+          BF.setSimple(false);
+          break;
+        }
+      }
+    }
+  }
+
+  return Error::success();
+}
+
 /// Process __bug_table section.
 /// This section contains information useful for kernel debugging.
 /// Each entry in the section is a struct bug_entry that contains a pointer to
@@ -1301,6 +1330,27 @@ Error LinuxKernelRewriter::readAltInstructions() {
 
   BC.outs() << "BOLT-INFO: parsed " << EntryID
             << " alternative instruction entries\n";
+
+  return Error::success();
+}
+
+Error LinuxKernelRewriter::rewriteAltInstructions() {
+  // Disable output of functions with alt instructions before the rewrite
+  // support is complete.
+  for (BinaryFunction &BF : llvm::make_second_range(BC.getBinaryFunctions())) {
+    if (!BC.shouldEmit(BF))
+      continue;
+    for (const BinaryBasicBlock &BB : BF) {
+      if (!BC.shouldEmit(BF))
+        break;
+      for (const MCInst &Inst : BB) {
+        if (BC.MIB->hasAnnotation(Inst, "AltInst")) {
+          BF.setSimple(false);
+          break;
+        }
+      }
+    }
+  }
 
   return Error::success();
 }


### PR DESCRIPTION
Do not overwrite functions with alternative and paravirtual instructions until a proper update support is implemented.