### PR TITLE
[libunwind] Compile the asm as well as the C++ source

### DIFF
--- a/libunwind/CMakeLists.txt
+++ b/libunwind/CMakeLists.txt
@@ -3,6 +3,7 @@
 #===============================================================================
 
 cmake_minimum_required(VERSION 3.20.0)
+project(Unwind LANGUAGES C CXX ASM)
 
 set(LLVM_COMMON_CMAKE_UTILS "${CMAKE_CURRENT_SOURCE_DIR}/../cmake")
 


### PR DESCRIPTION
When a CMakeLists.txt is missing a 'project' statement you get the default supported languages of C and CXX. https://cmake.org/cmake/help/latest/command/project.html. The help says ASM should be listed last.

CMake doesn't raise an error about the .S files it has been told about when project is missing. It silently ignores them. In this case, the symptom is an undefined symbol *jumpto in the library.

Working theory for why this isn't more obviously broken everywhere is the 'runtimes' CMakeLists.txt does contain a 'project' statement which lists ASM and/or by default linking shared libraries with undefined symbols succeeds.

The string immediately after project appears to be arbitrary, chosen 'Unwind' to match the capitalization of 'Runtimes'. 

For completeness, this also removes the following warning when building libunwind by itself:

>CMake Warning (dev) in CMakeLists.txt:
>  No project() command is present.  The top-level CMakeLists.txt file must
>  contain a literal, direct call to the project() command.  Add a line of
>  code such as
>
>    project(ProjectName)
>
>  near the top of the file, but after cmake_minimum_required().
>
>  CMake is pretending there is a "project(Project)" command on the first
>  line.
> This warning is for project developers.  Use -Wno-dev to suppress it.

This gives no hint that the consequence of ignoring this warning is cmake will ignore your assembly.