### PR TITLE
[clang-tidy] Fix result check after overwriteChangedFiles()

### DIFF
--- a/clang-tools-extra/clang-tidy/ClangTidy.cpp
+++ b/clang-tools-extra/clang-tidy/ClangTidy.cpp
@@ -233,7 +233,7 @@ public:
         if (!tooling::applyAllReplacements(Replacements.get(), Rewrite)) {
           llvm::errs() << "Can't apply replacements for file " << File << "\n";
         }
-        AnyNotWritten &= Rewrite.overwriteChangedFiles();
+        AnyNotWritten |= Rewrite.overwriteChangedFiles();
       }
 
       if (AnyNotWritten) {


### PR DESCRIPTION
If any return from overwriteChangedFiles is true some fixes were not applied.