### PR TITLE
[bazel] Add td_library target for OptParser.td

### DIFF
--- a/utils/bazel/llvm-project-overlay/llvm/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/llvm/BUILD.bazel
@@ -4,6 +4,7 @@
 
 load("@bazel_skylib//rules:common_settings.bzl", "string_flag")
 load("@bazel_skylib//rules:expand_template.bzl", "expand_template")
+load("//mlir:tblgen.bzl", "td_library")
 load(":binary_alias.bzl", "binary_alias")
 load(":config.bzl", "llvm_config_defines")
 load(":enum_targets_gen.bzl", "enum_targets_gen")
@@ -154,6 +155,12 @@ exports_files([
     "include/llvm/Config/llvm-config.h.cmake",
     "include/llvm/Config/abi-breaking.h.cmake",
 ])
+
+td_library(
+    name = "OptParserTdFiles",
+    srcs = ["include/llvm/Option/OptParser.td"],
+    includes = ["include"],
+)
 
 cc_library(
     name = "config",


### PR DESCRIPTION
This allows downstream consumers to depend on this file. Without this target the include paths to this are mangled by bazel.