### PR TITLE
[Libomptarget] Fix linking to LLVM dylib

### DIFF
--- a/openmp/libomptarget/plugins-nextgen/CMakeLists.txt
+++ b/openmp/libomptarget/plugins-nextgen/CMakeLists.txt
@@ -14,41 +14,40 @@
 set(common_dir ${CMAKE_CURRENT_SOURCE_DIR}/common)
 add_subdirectory(common)
 function(add_target_library target_name lib_name)
-  llvm_map_components_to_libnames(llvm_libs
-    ${LLVM_TARGETS_TO_BUILD}
-    AggressiveInstCombine
-    Analysis
-    BinaryFormat
-    BitReader
-    BitWriter
-    CodeGen
-    Core
-    Extensions
-    InstCombine
-    Instrumentation
-    IPO
-    IRReader
-    Linker
-    MC
-    Object
-    Passes
-    Remarks
-    ScalarOpts
-    Support
-    Target
-    TargetParser
-    TransformUtils
-    Vectorize
-  )
-
   add_llvm_library(${target_name} SHARED
+    LINK_COMPONENTS
+      ${LLVM_TARGETS_TO_BUILD}
+      AggressiveInstCombine
+      Analysis
+      BinaryFormat
+      BitReader
+      BitWriter
+      CodeGen
+      Core
+      Extensions
+      InstCombine
+      Instrumentation
+      IPO
+      IRReader
+      Linker
+      MC
+      Object
+      Passes
+      Remarks
+      ScalarOpts
+      Support
+      Target
+      TargetParser
+      TransformUtils
+      Vectorize
+
     NO_INSTALL_RPATH
     BUILDTREE_ONLY
   )
 
   llvm_update_compile_flags(${target_name})
   target_link_libraries(${target_name} PRIVATE
-                        PluginCommon ${llvm_libs} ${OPENMP_PTHREAD_LIB})
+                        PluginCommon ${OPENMP_PTHREAD_LIB})
 
   target_compile_definitions(${target_name} PRIVATE TARGET_NAME=${lib_name})
   target_compile_definitions(${target_name} PRIVATE 


### PR DESCRIPTION
Use `LINK_COMPONENTS` parameter of `add_llvm_library` rather than passing LLVM components directly to `target_link_libraries`, in order to ensure that LLVM dylib is linked correctly when used.  Otherwise, CMake insists on linking to static libraries that aren't present on distributions doing pure dylib installs, such as Gentoo.

This fixes a regression introduced
in dcbddc25250158469c5635ad2ae4095faef53dfd.