### PR TITLE
[analyzer][docs] Document the `optin.performance.Padding` checker

### DIFF
--- a/clang/docs/analyzer/checkers.rst
+++ b/clang/docs/analyzer/checkers.rst
@@ -820,8 +820,9 @@ ordering the fields by ``sizeof`` would usually also lead to the same optimal
 layout.
 
 In rare cases, one can use the ``#pragma pack(1)`` directive to enforce a packed
-layout too, but it is discouraged and the reordering of fields should be
-preferred.
+layout too, but it can significantly increase the access times, so reordering the
+fields is usually a better solution.
+
 
 .. code-block:: cpp
 

--- a/clang/docs/analyzer/checkers.rst
+++ b/clang/docs/analyzer/checkers.rst
@@ -804,27 +804,37 @@ Check for performance anti-patterns when using Grand Central Dispatch.
 
 .. _optin-performance-Padding:
 
-optin.performance.Padding (PaddingChecker)
-"""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
+optin.performance.Padding (C, C++, objC)
+""""""""""""""""""""""""""""""""""""""""
 Check for excessively padded structs.
 
-.. code-block:: objc
+This checker detects structs with excessive padding, which can lead to wasted memory and decreased performance. Padding bytes are added by compilers to align data within the struct for performance optimization or memory alignment purposes. However, excessive padding can significantly increase the size of the struct without adding useful data, leading to inefficient memory usage, cache misses, and decreased performance.
 
- struct TestStruct {
-      int data1;   // 4 bytes
-      char data2;  // 1 byte
-      char padding[27];  // 27 bytes of padding
-    };  // Total size: 32 bytes 
-  
-  void TestFunction() {
-      struct TestStruct struct1;  // Warning is generated due to excessive padding.
-    }
+.. code-block:: C
 
-   // Reports are only generated if the excessive padding exceeds 'AllowedPad' in bytes.
+   #include <stdio.h>
+   // #pragma pack(1) // Uncomment it to disable structure padding
+   struct TestStruct {
+       char data1;  // 1 byte
+       char data2;  // 1 byte
+       int data3;   // 4 bytes
+   };             // Total size: 6 bytes
+   
+   int main () {
+       struct TestStruct struct1;
+       print("Structure size: %d",sizeof(struct1)); // Structure size: 8
+       return 0;
+   }
+   
+Total memory used is 8 bytes due to structure padding. In this case, padding is of 2 bytes. Padding is done to decrease the number of CPU cycles needed to access data members of the structure; it increases the performance of the processor but at the penalty of memory.
+Padding can be disabled by using the pragma directive.
+Padding can also be decreased by putting data members of the structure in descending order of their size.
 
-  // AllowedPad: Default Value: 24 bytes
+Reports are only generated if the excessive padding exceeds 'AllowedPad' in bytes. AllowedPad is the threshold value of padding.
 
-   Usage: `AllowedPad=<value>`
+AllowedPad Option:
+- Default Value: 24 bytes
+- Usage: ``AllowedPad=<value>``
 
 .. _optin-portability-UnixAPI:
 

--- a/clang/docs/analyzer/checkers.rst
+++ b/clang/docs/analyzer/checkers.rst
@@ -804,7 +804,7 @@ Check for performance anti-patterns when using Grand Central Dispatch.
 
 .. _optin-performance-Padding:
 
-optin.performance.Padding (C, C++, objC)
+optin.performance.Padding (C, C++, ObjC)
 """"""""""""""""""""""""""""""""""""""""
 Check for excessively padded structs.
 
@@ -826,11 +826,11 @@ This checker detects structs with excessive padding, which can lead to wasted me
        return 0;
    }
    
-Total memory used is 8 bytes due to structure padding. In this case, padding is of 2 bytes. Padding is done to decrease the number of CPU cycles needed to access data members of the structure; it increases the performance of the processor but at the penalty of memory.
+Total memory used is 8 bytes due to structure padding. In this case, padding is of 2 bytes. Padding is done to decrease the number of CPU cycles needed to access data members of the structure, it increases the performance of the processor but at the penalty of memory.
 Padding can be disabled by using the pragma directive.
 Padding can also be decreased by putting data members of the structure in descending order of their size.
 
-Reports are only generated if the excessive padding exceeds 'AllowedPad' in bytes. AllowedPad is the threshold value of padding.
+Reports are only generated if the excessive padding exceeds ``AllowedPad`` in bytes. AllowedPad is the threshold value of padding.
 
 AllowedPad Option:
 - Default Value: 24 bytes

--- a/clang/docs/analyzer/checkers.rst
+++ b/clang/docs/analyzer/checkers.rst
@@ -804,9 +804,27 @@ Check for performance anti-patterns when using Grand Central Dispatch.
 
 .. _optin-performance-Padding:
 
-optin.performance.Padding
-"""""""""""""""""""""""""
+optin.performance.Padding (PaddingChecker)
+"""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
 Check for excessively padded structs.
+
+.. code-block:: objc
+
+ struct TestStruct {
+      int data1;   // 4 bytes
+      char data2;  // 1 byte
+      char padding[27];  // 27 bytes of padding
+    };  // Total size: 32 bytes 
+  
+  void TestFunction() {
+      struct TestStruct struct1;  // Warning is generated due to excessive padding.
+    }
+
+   // Reports are only generated if the excessive padding exceeds 'AllowedPad' in bytes.
+
+  // AllowedPad: Default Value: 24 bytes
+
+   Usage: `AllowedPad=<value>`
 
 .. _optin-portability-UnixAPI:
 

--- a/clang/docs/analyzer/checkers.rst
+++ b/clang/docs/analyzer/checkers.rst
@@ -810,7 +810,7 @@ Check for excessively padded structs.
 
 This checker detects structs with excessive padding, which can lead to wasted memory and decreased performance. Padding bytes are added by compilers to align data within the struct for performance optimization or memory alignment purposes. However, excessive padding can significantly increase the size of the struct without adding useful data, leading to inefficient memory usage, cache misses, and decreased performance.
 
-.. code-block:: C
+.. code-block:: c
 
    #include <stdio.h>
    // #pragma pack(1) // Uncomment it to disable structure padding
@@ -822,7 +822,7 @@ This checker detects structs with excessive padding, which can lead to wasted me
    
    int main () {
        struct TestStruct struct1;
-       print("Structure size: %d",sizeof(struct1)); // Structure size: 8
+       printf("Structure size: %d",sizeof(struct1)); // Structure size: 8
        return 0;
    }
    

--- a/clang/docs/analyzer/checkers.rst
+++ b/clang/docs/analyzer/checkers.rst
@@ -860,8 +860,8 @@ fields is usually a better solution.
  };
  static_assert(sizeof(Optimal) == 4*8+5+3);
 
- // no-warning: Enforcing bitpacked representation.
- // Access times will have signifficant overhead. Prefer reordering the fields instead.
+ // no-warning: Bit packing representation is also accepted by this checker, but
+ // it can significantly increase access times, so prefer reordering the fields.
  #pragma pack(1)
  struct BitPacked {
    char c1;

--- a/clang/include/clang/StaticAnalyzer/Checkers/Checkers.td
+++ b/clang/include/clang/StaticAnalyzer/Checkers/Checkers.td
@@ -908,7 +908,7 @@ def PaddingChecker : Checker<"Padding">,
                   "24",
                   Released>
   ]>,
-  Documentation<NotDocumented>;
+  Documentation<HasDocumentation>;
 
 } // end: "padding"
 


### PR DESCRIPTION
# Added documentation for optin.performance.Padding.
- Performance package has `PaddingChecker` checker.
- It checks for excessively padded structs.
   - It has one option that is `AllowedPad`, an integer option.
   - It's default value is 24 bytes.
      - Reports are generated when padding exceeds `AllowedPad`.
 ## Purpose
The purpose of this pull request is to improve the clarity and completeness of the documentation for PaddingChecker in the optin.performance.Padding checker.

Closes #73675