### PR TITLE
[RISCV] ReadStoreData is read later in the pipeline for SiFive7

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVSchedSiFive7.td
+++ b/llvm/lib/Target/RISCV/RISCVSchedSiFive7.td
@@ -950,7 +950,7 @@ def : InstRW<[WriteIALU], (instrs COPY)>;
 def : SiFive7AnyToGPRBypass<ReadJmp>;
 def : SiFive7AnyToGPRBypass<ReadJalr>;
 def : ReadAdvance<ReadCSR, 0>;
-def : ReadAdvance<ReadStoreData, 0>;
+def : SiFive7AnyToGPRBypass<ReadStoreData>;
 def : ReadAdvance<ReadMemBase, 0>;
 def : SiFive7AnyToGPRBypass<ReadIALU>;
 def : SiFive7AnyToGPRBypass<ReadIALU32>;


### PR DESCRIPTION
Store data is read later in the pipeline, so we use SiFive7AnyToGPRBypass to model that a store instruction can begin some cycles before that data is ready.