### PR TITLE
[OpenMP] Allow dynamic `condition` selector in Metadirective

### DIFF
--- a/clang/test/OpenMP/metadirective_ast_print.c
+++ b/clang/test/OpenMP/metadirective_ast_print.c
@@ -77,6 +77,11 @@ void foo(void) {
                                : parallel) default(nothing)
   for (int i = 0; i < 16; i++)
     ;
+
+  int non_const_val = 1;
+#pragma omp metadirective when(user = {condition(non_const_val > 0)} \
+                               : parallel) default(nothing)
+  bar();
 }
 
 // CHECK: void bar(void);
@@ -107,5 +112,8 @@ void foo(void) {
 // CHECK-AMDGCN-NEXT: for (int i = 0; i < 100; i++)
 // CHECK: for (int i = 0; i < 16; i++)
 // CHECK: for (int i = 0; i < 16; i++)
+// CHECK: int non_const_val = 1;
+// CHECK-NEXT: #pragma omp parallel
+// CHECK-NEXT: bar()
 
 #endif


### PR DESCRIPTION
As reported in https://github.com/llvm/llvm-project/issues/82754, Metadirectives uses default for non-const user condition. This is unexpected as the OpenMP specification 5.1 allows dynamic `condition` selector within Metadirectives. In contrast static `condition` selectors work as expected.

### Example (from https://github.com/llvm/llvm-project/issues/82754):
```c++
int non_const_val = 1; // A non const value makes the `condition` selector dynamic; a const value makes it static
#pragma omp metadirective \
    when( user= {condition(non_const_val > 0)} : parallel num_threads( num_threads ) ) \
    default()
    {
        #pragma omp single
        assert( num_threads == omp_get_num_threads() );
    } 
```
where as `user` in `user= {...}` is called _selector set_ and `condition` in `condition(non_const_val > 0)` is called _selector_ (must evaluate to true for the selector to be true). 

## Some context
### As of OpenMP 5.1, dynamic `condition` selectors seem to be allowed
"[...] Any non-constant expression that is evaluated to determine the suitability of a variant is evaluated according to the data state trait in the dynamic trait set of the OpenMP context. The user selector set is dynamic if the _condition selector_ is present and the expression in the condition selector is not a constant expression; otherwise, it is static. [...]"

### Assembled grammar (copied from OpenMP 5.1. specification on [Metadirectives](https://www.openmp.org/spec-html/5.1/openmpsu28.html#x45-440002.3.4) and [Context Selectors](https://www.openmp.org/spec-html/5.1/openmpsu26.html#x43-420002.3.2)):
This helps a lot when browsing through the code and its vocabulary.
```c++
#pragma omp metadirective [clause[ [,] clause] ... ] new-line
// where clause is one of the following:  
when(context-selector-specification: [directive-variant]) 
default([directive-variant])
// where context-selector-specification is
context-selector-specification: 
   trait-set-selector[,trait-set-selector[,...]] 
 // where trait-set-selector is
trait-set-selector: 
   trait-set-selector-name={trait-selector[, trait-selector[, ...]]} 
```
Specification of [Metadirectives](https://www.openmp.org/spec-html/5.1/openmpsu26.html#x43-420002.3.2) in OpenMP 5.1

Closes: https://github.com/llvm/llvm-project/issues/82754