### PR TITLE
[clang][CodeComplete] Handle deref operator in getApproximateType

### DIFF
--- a/clang/lib/Sema/SemaCodeComplete.cpp
+++ b/clang/lib/Sema/SemaCodeComplete.cpp
@@ -20,6 +20,7 @@
 #include "clang/AST/ExprConcepts.h"
 #include "clang/AST/ExprObjC.h"
 #include "clang/AST/NestedNameSpecifier.h"
+#include "clang/AST/OperationKinds.h"
 #include "clang/AST/QualTypeNames.h"
 #include "clang/AST/RecursiveASTVisitor.h"
 #include "clang/AST/Type.h"
@@ -5673,6 +5674,10 @@ QualType getApproximateType(const Expr *E) {
       if (VD->hasInit())
         return getApproximateType(VD->getInit());
     }
+  }
+  if (const auto *UO = llvm::dyn_cast<UnaryOperator>(E)) {
+    if (UO->getOpcode() == UnaryOperatorKind::UO_Deref)
+      return UO->getSubExpr()->getType()->getPointeeType();
   }
   return Unresolved;
 }

--- a/clang/test/CodeCompletion/member-access.cpp
+++ b/clang/test/CodeCompletion/member-access.cpp
@@ -348,7 +348,23 @@ namespace function_can_be_call {
     T foo(U, V);
   };
 
-  &S::f
-  // RUN: %clang_cc1 -fsyntax-only -code-completion-at=%s:351:7 %s -o - | FileCheck -check-prefix=CHECK_FUNCTION_CAN_BE_CALL %s
+  void test() {
+    &S::f
+  }
+  // RUN: %clang_cc1 -fsyntax-only -code-completion-at=%s:352:9 %s -o - | FileCheck -check-prefix=CHECK_FUNCTION_CAN_BE_CALL %s
   // CHECK_FUNCTION_CAN_BE_CALL: COMPLETION: foo : [#T#]foo<<#typename T#>, <#typename U#>>(<#U#>, <#V#>)
+}
+
+namespace deref_dependent_this {
+template <typename T>
+class A {
+  int field;
+
+  void function() {
+    (*this).field;
+// RUN: %clang_cc1 -fsyntax-only -code-completion-at=%s:364:13 %s -o - | FileCheck -check-prefix=CHECK-DEREF-THIS %s
+// CHECK-DEREF-THIS: field : [#int#]field
+// CHECK-DEREF-THIS: [#void#]function()
+  }
+};
 }


### PR DESCRIPTION
This allows completing after `(*this).` in a dependent context.

Fixes https://github.com/clangd/clangd/issues/1952