### PR TITLE
[clang][dataflow] Bail out if input is Objective-C++.

### DIFF
--- a/clang/lib/Analysis/FlowSensitive/AdornedCFG.cpp
+++ b/clang/lib/Analysis/FlowSensitive/AdornedCFG.cpp
@@ -144,7 +144,7 @@ llvm::Expected<AdornedCFG> AdornedCFG::build(const Decl &D, Stmt &S,
 
   // The shape of certain elements of the AST can vary depending on the
   // language. We currently only support C++.
-  if (!C.getLangOpts().CPlusPlus)
+  if (!C.getLangOpts().CPlusPlus || C.getLangOpts().ObjC)
     return llvm::createStringError(
         std::make_error_code(std::errc::invalid_argument),
         "Can only analyze C++");

--- a/clang/unittests/Analysis/FlowSensitive/DeterminismTest.cpp
+++ b/clang/unittests/Analysis/FlowSensitive/DeterminismTest.cpp
@@ -30,7 +30,9 @@ namespace clang::dataflow {
 // flow-condition at function exit.
 std::string analyzeAndPrintExitCondition(llvm::StringRef Code) {
   DataflowAnalysisContext DACtx(std::make_unique<WatchedLiteralsSolver>());
-  clang::TestAST AST(Code);
+  TestInputs Inputs(Code);
+  Inputs.Language = TestLanguage::Lang_CXX17;
+  clang::TestAST AST(Inputs);
   const auto *Target =
       cast<FunctionDecl>(test::findValueDecl(AST.context(), "target"));
   Environment InitEnv(DACtx, *Target);


### PR DESCRIPTION
We only ever intended to support C++, but the condition we were testing allowed
Objective-C++ code by mistake.
