### PR TITLE
[InstCombine] Fold fcmp into select

### DIFF
--- a/llvm/lib/Transforms/InstCombine/InstCombineCompares.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineCompares.cpp
@@ -8052,6 +8052,8 @@ Instruction *InstCombinerImpl::visitFCmpInst(FCmpInst &I) {
                  m_Select(m_Value(), m_Value(X), m_FNeg(m_Deferred(X)))) ||
            match(LHSI, m_Select(m_Value(), m_FNeg(m_Value(X)), m_Deferred(X)))))
         return replaceOperand(I, 0, X);
+      if (Instruction *NV = FoldOpIntoSelect(I, cast<SelectInst>(LHSI)))
+        return NV;
       break;
     case Instruction::PHI:
       if (Instruction *NV = foldOpIntoPhi(I, cast<PHINode>(LHSI)))

--- a/llvm/test/Transforms/InstCombine/fcmp-select.ll
+++ b/llvm/test/Transforms/InstCombine/fcmp-select.ll
@@ -151,9 +151,7 @@ define i1 @fcmp_ogt_select(i1 %cond, float %a, float %b) {
 
 define i1 @test_fcmp_select_const_const(double %x) {
 ; CHECK-LABEL: @test_fcmp_select_const_const(
-; CHECK-NEXT:    [[CMP2:%.*]] = fcmp ord double [[X:%.*]], 0.000000e+00
-; CHECK-NEXT:    [[SEL:%.*]] = select i1 [[CMP2]], double 0xFFFFFFFFFFFFFFFF, double 0.000000e+00
-; CHECK-NEXT:    [[CMP1:%.*]] = fcmp oeq double [[SEL]], 0.000000e+00
+; CHECK-NEXT:    [[CMP1:%.*]] = fcmp uno double [[X:%.*]], 0.000000e+00
 ; CHECK-NEXT:    ret i1 [[CMP1]]
 ;
   %cmp1 = fcmp ord double %x, 0.000000e+00
@@ -164,10 +162,10 @@ define i1 @test_fcmp_select_const_const(double %x) {
 
 define i1 @test_fcmp_select_var_const(double %x, double %y) {
 ; CHECK-LABEL: @test_fcmp_select_var_const(
-; CHECK-NEXT:    [[CMP1:%.*]] = fcmp ogt double [[X:%.*]], 0x3E80000000000000
-; CHECK-NEXT:    [[Y:%.*]] = select i1 [[CMP1]], double [[Y1:%.*]], double 0.000000e+00
-; CHECK-NEXT:    [[TMP1:%.*]] = fcmp olt double [[Y]], 0x3E80000000000000
-; CHECK-NEXT:    ret i1 [[TMP1]]
+; CHECK-NEXT:    [[CMP1:%.*]] = fcmp ule double [[X:%.*]], 0x3E80000000000000
+; CHECK-NEXT:    [[TMP1:%.*]] = fcmp olt double [[Y:%.*]], 0x3E80000000000000
+; CHECK-NEXT:    [[CMP2:%.*]] = select i1 [[CMP1]], i1 true, i1 [[TMP1]]
+; CHECK-NEXT:    ret i1 [[CMP2]]
 ;
   %cmp1 = fcmp ogt double %x, 0x3E80000000000000
   %sel = select i1 %cmp1, double %y, double 0.000000e+00
@@ -177,10 +175,10 @@ define i1 @test_fcmp_select_var_const(double %x, double %y) {
 
 define i1 @test_fcmp_select_var_const_fmf(double %x, double %y) {
 ; CHECK-LABEL: @test_fcmp_select_var_const_fmf(
-; CHECK-NEXT:    [[CMP1:%.*]] = fcmp ogt double [[X:%.*]], 0x3E80000000000000
-; CHECK-NEXT:    [[SEL:%.*]] = select i1 [[CMP1]], double [[Y:%.*]], double 0.000000e+00
-; CHECK-NEXT:    [[CMP2:%.*]] = fcmp nnan olt double [[SEL]], 0x3E80000000000000
-; CHECK-NEXT:    ret i1 [[CMP2]]
+; CHECK-NEXT:    [[CMP1:%.*]] = fcmp ule double [[X:%.*]], 0x3E80000000000000
+; CHECK-NEXT:    [[CMP2:%.*]] = fcmp nnan olt double [[SEL:%.*]], 0x3E80000000000000
+; CHECK-NEXT:    [[CMP3:%.*]] = select i1 [[CMP1]], i1 true, i1 [[CMP2]]
+; CHECK-NEXT:    ret i1 [[CMP3]]
 ;
   %cmp1 = fcmp ogt double %x, 0x3E80000000000000
   %sel = select i1 %cmp1, double %y, double 0.000000e+00
@@ -190,9 +188,7 @@ define i1 @test_fcmp_select_var_const_fmf(double %x, double %y) {
 
 define <2 x i1> @test_fcmp_select_const_const_vec(<2 x double> %x) {
 ; CHECK-LABEL: @test_fcmp_select_const_const_vec(
-; CHECK-NEXT:    [[CMP2:%.*]] = fcmp ord <2 x double> [[X:%.*]], zeroinitializer
-; CHECK-NEXT:    [[SEL:%.*]] = select <2 x i1> [[CMP2]], <2 x double> <double 0xFFFFFFFFFFFFFFFF, double 0xFFFFFFFFFFFFFFFF>, <2 x double> zeroinitializer
-; CHECK-NEXT:    [[CMP1:%.*]] = fcmp oeq <2 x double> [[SEL]], zeroinitializer
+; CHECK-NEXT:    [[CMP1:%.*]] = fcmp uno <2 x double> [[X:%.*]], zeroinitializer
 ; CHECK-NEXT:    ret <2 x i1> [[CMP1]]
 ;
   %cmp1 = fcmp ord <2 x double> %x, zeroinitializer

--- a/llvm/test/Transforms/InstCombine/fcmp-select.ll
+++ b/llvm/test/Transforms/InstCombine/fcmp-select.ll
@@ -244,3 +244,27 @@ define i1 @test_fcmp_select_const_const_multiuse(double %x) {
   %cmp2 = fcmp oeq double %sel, 0.000000e+00
   ret i1 %cmp2
 }
+
+define i1 @test_fcmp_select_const_const_unordered(double %x) {
+; CHECK-LABEL: @test_fcmp_select_const_const_unordered(
+; CHECK-NEXT:    [[CMP1:%.*]] = fcmp ord double [[X:%.*]], 0.000000e+00
+; CHECK-NEXT:    ret i1 [[CMP1]]
+;
+  %cmp1 = fcmp uno double %x, 0.000000e+00
+  %sel = select i1 %cmp1, double 0xFFFFFFFFFFFFFFFF, double 0.000000e+00
+  %cmp2 = fcmp oeq double %sel, 0.000000e+00
+  ret i1 %cmp2
+}
+
+define i1 @test_fcmp_select_var_const_unordered(double %x, double %y) {
+; CHECK-LABEL: @test_fcmp_select_var_const_unordered(
+; CHECK-NEXT:    [[CMP1:%.*]] = fcmp ult double [[X:%.*]], 0x3E80000000000000
+; CHECK-NEXT:    [[TMP1:%.*]] = fcmp ugt double [[Y:%.*]], 0x3E80000000000000
+; CHECK-NEXT:    [[CMP2:%.*]] = select i1 [[CMP1]], i1 [[TMP1]], i1 false
+; CHECK-NEXT:    ret i1 [[CMP2]]
+;
+  %cmp1 = fcmp ult double %x, 0x3E80000000000000
+  %sel = select i1 %cmp1, double %y, double 0.000000e+00
+  %cmp2 = fcmp ugt double %sel, 0x3E80000000000000
+  ret i1 %cmp2
+}

--- a/llvm/test/Transforms/InstCombine/select-select.ll
+++ b/llvm/test/Transforms/InstCombine/select-select.ll
@@ -18,11 +18,10 @@ define float @foo1(float %a) {
 
 define float @foo2(float %a) {
 ; CHECK-LABEL: @foo2(
-; CHECK-NEXT:    [[B:%.*]] = fcmp ogt float [[A:%.*]], 0.000000e+00
-; CHECK-NEXT:    [[C:%.*]] = select i1 [[B]], float [[A]], float 0.000000e+00
+; CHECK-NEXT:    [[B:%.*]] = fcmp ule float [[C:%.*]], 0.000000e+00
 ; CHECK-NEXT:    [[D:%.*]] = fcmp olt float [[C]], 1.000000e+00
-; CHECK-NEXT:    [[E:%.*]] = select i1 [[B]], float [[A]], float 0.000000e+00
-; CHECK-NEXT:    [[F:%.*]] = select i1 [[D]], float [[E]], float 1.000000e+00
+; CHECK-NEXT:    [[E:%.*]] = select i1 [[D]], float [[C]], float 1.000000e+00
+; CHECK-NEXT:    [[F:%.*]] = select i1 [[B]], float 0.000000e+00, float [[E]]
 ; CHECK-NEXT:    ret float [[F]]
 ;
   %b = fcmp ogt float %a, 0.0


### PR DESCRIPTION
This patch simplifies `fcmp (select Cond, C1, C2), C3` patterns in ceres:
Alive2: https://alive2.llvm.org/ce/z/fWh_sD
```
define i1 @src(double %x) {
  %cmp1 = fcmp ord double %x, 0.000000e+00
  %sel = select i1 %cmp1, double 0xFFFFFFFFFFFFFFFF, double 0.000000e+00
  %cmp2 = fcmp oeq double %sel, 0.000000e+00
  ret i1 %cmp2
}

define i1 @tgt(double %x) {
  %cmp1 = fcmp uno double %x, 0.000000e+00
  ret i1 %cmp1
}

```