### PR TITLE
[[clang::always_destroy]] attribute silences warn-exit-time-destructor

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -289,6 +289,10 @@ Improvements to Clang's diagnostics
 - Clang now correctly diagnoses no arguments to a variadic macro parameter as a C23/C++20 extension.
   Fixes #GH84495.
 
+- Clang no longer emits the ``exit-time destructor`` warning on static variables explicitly 
+  annotated with the ``clang::always_destroy`` attribute. 
+  Fixes #GH68686, #GH86486
+
 Improvements to Clang's time-trace
 ----------------------------------
 

--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -289,7 +289,7 @@ Improvements to Clang's diagnostics
 - Clang now correctly diagnoses no arguments to a variadic macro parameter as a C23/C++20 extension.
   Fixes #GH84495.
 
-- Clang no longer emits a ``-Wexit-time destructor`` warning on static variables explicitly
+- Clang no longer emits a ``-Wexit-time destructors`` warning on static variables explicitly
   annotated with the ``clang::always_destroy`` attribute.
   Fixes #GH68686, #GH86486
 

--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -289,8 +289,8 @@ Improvements to Clang's diagnostics
 - Clang now correctly diagnoses no arguments to a variadic macro parameter as a C23/C++20 extension.
   Fixes #GH84495.
 
-- Clang no longer emits the ``exit-time destructor`` warning on static variables explicitly 
-  annotated with the ``clang::always_destroy`` attribute. 
+- Clang no longer emits the ``exit-time destructor`` warning on static variables explicitly
+  annotated with the ``clang::always_destroy`` attribute.
   Fixes #GH68686, #GH86486
 
 Improvements to Clang's time-trace

--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -289,7 +289,7 @@ Improvements to Clang's diagnostics
 - Clang now correctly diagnoses no arguments to a variadic macro parameter as a C23/C++20 extension.
   Fixes #GH84495.
 
-- Clang no longer emits the ``exit-time destructor`` warning on static variables explicitly
+- Clang no longer emits a ``-Wexit-time destructor`` warning on static variables explicitly
   annotated with the ``clang::always_destroy`` attribute.
   Fixes #GH68686, #GH86486
 

--- a/clang/include/clang/Basic/AttrDocs.td
+++ b/clang/include/clang/Basic/AttrDocs.td
@@ -6070,8 +6070,8 @@ The ``always_destroy`` attribute specifies that a variable with static or thread
 storage duration should have its exit-time destructor run. This attribute is the
 default unless clang was invoked with -fno-c++-static-destructors.
 
-If a variable is explicitly declared with this attribute clang will silence the
-exit-time destructor warning.
+If a variable is explicitly declared with this attribute, Clang will silence
+otherwise applicable ``-Wexit-time-destructor`` warnings.
   }];
 }
 

--- a/clang/include/clang/Basic/AttrDocs.td
+++ b/clang/include/clang/Basic/AttrDocs.td
@@ -6071,7 +6071,7 @@ storage duration should have its exit-time destructor run. This attribute is the
 default unless clang was invoked with -fno-c++-static-destructors.
 
 If a variable is explicitly declared with this attribute, Clang will silence
-otherwise applicable ``-Wexit-time-destructor`` warnings.
+otherwise applicable ``-Wexit-time-destructors`` warnings.
   }];
 }
 

--- a/clang/include/clang/Basic/AttrDocs.td
+++ b/clang/include/clang/Basic/AttrDocs.td
@@ -6070,7 +6070,7 @@ The ``always_destroy`` attribute specifies that a variable with static or thread
 storage duration should have its exit-time destructor run. This attribute is the
 default unless clang was invoked with -fno-c++-static-destructors.
 
-If a variable is explicity declared with this attribute clang will silence the
+If a variable is explicitly declared with this attribute clang will silence the
 exit-time destructor warning.
   }];
 }

--- a/clang/include/clang/Basic/AttrDocs.td
+++ b/clang/include/clang/Basic/AttrDocs.td
@@ -6069,6 +6069,9 @@ def AlwaysDestroyDocs : Documentation {
 The ``always_destroy`` attribute specifies that a variable with static or thread
 storage duration should have its exit-time destructor run. This attribute is the
 default unless clang was invoked with -fno-c++-static-destructors.
+
+If a variable is explicity declared with this attribute clang will silence the
+exit-time destructor warning.
   }];
 }
 

--- a/clang/lib/Sema/SemaDeclCXX.cpp
+++ b/clang/lib/Sema/SemaDeclCXX.cpp
@@ -16202,7 +16202,8 @@ void Sema::FinalizeVarWithDestructor(VarDecl *VD, const RecordType *Record) {
 
   // Emit warning for non-trivial dtor in global scope (a real global,
   // class-static, function-static).
-  Diag(VD->getLocation(), diag::warn_exit_time_destructor);
+  if (!VD->hasAttr<AlwaysDestroyAttr>())
+    Diag(VD->getLocation(), diag::warn_exit_time_destructor);
 
   // TODO: this should be re-enabled for static locals by !CXAAtExit
   if (!VD->isStaticLocal())

--- a/clang/test/SemaCXX/warn-exit-time-destructors.cpp
+++ b/clang/test/SemaCXX/warn-exit-time-destructors.cpp
@@ -51,6 +51,11 @@ struct A { ~A(); };
 }
 
 namespace test5 {
+struct A { ~A(); };
+[[clang::always_destroy]] A a; // no warning
+}
+
+namespace test6 {
 #if __cplusplus >= 202002L
 #define CPP20_CONSTEXPR constexpr
 #else
@@ -68,3 +73,4 @@ namespace test5 {
   T t; // expected-warning {{exit-time destructor}}
 #undef CPP20_CONSTEXPR
 }
+

--- a/clang/test/SemaCXX/warn-exit-time-destructors.cpp
+++ b/clang/test/SemaCXX/warn-exit-time-destructors.cpp
@@ -51,8 +51,12 @@ struct A { ~A(); };
 }
 
 namespace test5 {
-struct A { ~A(); };
-[[clang::always_destroy]] A a; // no warning
+  struct A { ~A(); };
+  [[clang::always_destroy]] A a; // no warning
+
+  void func() {
+    [[clang::always_destroy]] static A a; // no warning
+  }
 }
 
 namespace test6 {


### PR DESCRIPTION
user wants the warning silenced by the attribute so no warning should be issued.

Fixes https://github.com/llvm/llvm-project/issues/68686