### PR TITLE
[BOLT] Fix boltedcollection and no_lbr order in fdata writer and parser

### DIFF
--- a/bolt/lib/Profile/DataReader.cpp
+++ b/bolt/lib/Profile/DataReader.cpp
@@ -1172,15 +1172,15 @@ std::error_code DataReader::parse() {
 
   Col = 0;
   Line = 1;
-  ErrorOr<bool> FlagOrErr = maybeParseNoLBRFlag();
-  if (!FlagOrErr)
-    return FlagOrErr.getError();
-  NoLBRMode = *FlagOrErr;
-
   ErrorOr<bool> BATFlagOrErr = maybeParseBATFlag();
   if (!BATFlagOrErr)
     return BATFlagOrErr.getError();
   BATMode = *BATFlagOrErr;
+
+  ErrorOr<bool> FlagOrErr = maybeParseNoLBRFlag();
+  if (!FlagOrErr)
+    return FlagOrErr.getError();
+  NoLBRMode = *FlagOrErr;
 
   if (!hasBranchData() && !hasMemData()) {
     Diag << "ERROR: no valid profile data found\n";


### PR DESCRIPTION
when BAT and no_lbr are set at the same time, the perf2bolt writes boltedcollection first and then no_lbr

https://github.com/llvm/llvm-project/blob/e6f63a942a45e3545332cd9a43982a69a4d5667b/bolt/lib/Profile/DataAggregator.cpp#L2219-L2225

However, when used, llvm-bolt reads the no_lbr first, and then the boltedcollection

https://github.com/llvm/llvm-project/blob/e6f63a942a45e3545332cd9a43982a69a4d5667b/bolt/lib/Profile/DataReader.cpp#L1175-L1183

This causes an error when reading profile data，because the profile first line is boltedcollection，the maybeParseNoLBRFlag return false despite no_lbr was use
```shell
BOLT-INFO: pre-processing profile using branch profile reader
ERROR: no valid profile data found
BOLT-ERROR: 'cannot pre-process profile': Input/output error.
``` 
So we adjusted the order of the reads