### PR TITLE
[flang][NFC] Use LLVM's endianness enum

### DIFF
--- a/flang/include/flang/Common/uint128.h
+++ b/flang/include/flang/Common/uint128.h
@@ -20,6 +20,7 @@
 #endif
 
 #include "leading-zero-bit-count.h"
+#include "llvm/ADT/bit.h"
 #include <cstdint>
 #include <type_traits>
 
@@ -261,12 +262,10 @@ private:
     }
   }
   static constexpr std::uint64_t topBit{std::uint64_t{1} << 63};
-#if FLANG_LITTLE_ENDIAN
-  std::uint64_t low_{0}, high_{0};
-#elif FLANG_BIG_ENDIAN
+#if defined(BYTE_ORDER) && defined(BIG_ENDIAN) && BYTE_ORDER == BIG_ENDIAN
   std::uint64_t high_{0}, low_{0};
 #else
-#error host endianness is not known
+  std::uint64_t low_{0}, high_{0};
 #endif
 };
 

--- a/flang/include/flang/Evaluate/common.h
+++ b/flang/include/flang/Evaluate/common.h
@@ -18,6 +18,7 @@
 #include "flang/Common/restorer.h"
 #include "flang/Parser/char-block.h"
 #include "flang/Parser/message.h"
+#include "llvm/ADT/bit.h"
 #include <cinttypes>
 #include <map>
 #include <set>
@@ -142,13 +143,8 @@ template <typename A> struct ValueWithRealFlags {
   RealFlags flags{};
 };
 
-#if FLANG_BIG_ENDIAN
-constexpr bool isHostLittleEndian{false};
-#elif FLANG_LITTLE_ENDIAN
-constexpr bool isHostLittleEndian{true};
-#else
-#error host endianness is not known
-#endif
+constexpr bool isHostLittleEndian =
+    (llvm::endianness::native == llvm::endianness::little);
 
 // HostUnsignedInt<BITS> finds the smallest native unsigned integer type
 // whose size is >= BITS.

--- a/flang/runtime/environment.h
+++ b/flang/runtime/environment.h
@@ -12,19 +12,16 @@
 #include "flang/Common/optional.h"
 #include "flang/Decimal/decimal.h"
 
+#include "llvm/ADT/bit.h"
+
 struct EnvironmentDefaultList;
 
 namespace Fortran::runtime {
 
 class Terminator;
 
-#if FLANG_BIG_ENDIAN
-constexpr bool isHostLittleEndian{false};
-#elif FLANG_LITTLE_ENDIAN
-constexpr bool isHostLittleEndian{true};
-#else
-#error host endianness is not known
-#endif
+constexpr bool isHostLittleEndian =
+    (llvm::endianness::native == llvm::endianness::little);
 
 // External unformatted I/O data conversions
 enum class Convert { Unknown, Native, LittleEndian, BigEndian, Swap };


### PR DESCRIPTION
Replace the FLANG_LITTLE_ENDIAN and FLANG_BIG_ENDIAN preprocessor defines with equivalents from LLVM. This ensures that tools that use flang's headers are not required to provide these preorocessor defines themselves.