### PR TITLE
[flang][NFC] Address reported "possible missing return"

### DIFF
--- a/flang/lib/Semantics/tools.cpp
+++ b/flang/lib/Semantics/tools.cpp
@@ -1275,6 +1275,8 @@ static bool StopAtComponentPre(const Symbol &component) {
     return !IsPointer(component);
   } else if constexpr (componentKind == ComponentKind::PotentialAndPointer) {
     return true;
+  } else {
+    DIE("unexpected ComponentKind");
   }
 }
 


### PR DESCRIPTION
A function uses "if constexpr" to consider all possible types in a variant, but looks as if it can fall out without returning an expression.  Add a final "else" with a crash to make things more clear and to protect against unlikely future extensions of the type.

Fixes https://github.com/llvm/llvm-project/issues/86391.