### PR TITLE
[documentation] [mlir] DataLayout.md: fix broken link to DLTI dialect

### DIFF
--- a/mlir/docs/DataLayout.md
+++ b/mlir/docs/DataLayout.md
@@ -289,7 +289,7 @@ The default data layout assumes 8-bit bytes.
 
 ### DLTI Dialect
 
-The [DLTI](Dialects/DLTI.md) dialect provides the attributes implementing
+The [DLTI](https://mlir.llvm.org/docs/Dialects/DLTIDialect/) dialect provides the attributes implementing
 `DataLayoutSpecInterface` and `DataLayoutEntryInterface`, as well as a dialect
 attribute that can be used to attach the specification to a given operation. The
 verifier of this attribute triggers those of the specification and checks the

--- a/mlir/docs/DataLayout.md
+++ b/mlir/docs/DataLayout.md
@@ -289,7 +289,7 @@ The default data layout assumes 8-bit bytes.
 
 ### DLTI Dialect
 
-The [DLTI](https://mlir.llvm.org/docs/Dialects/DLTIDialect/) dialect provides the attributes implementing
+The [DLTI](../Dialects/DLTIDialect/) dialect provides the attributes implementing
 `DataLayoutSpecInterface` and `DataLayoutEntryInterface`, as well as a dialect
 attribute that can be used to attach the specification to a given operation. The
 verifier of this attribute triggers those of the specification and checks the


### PR DESCRIPTION
The link to DLTI dialect was broken. @joker-eph 