### PR TITLE
[Clang] NFC Silence compiler warning spam

### DIFF
--- a/clang/include/clang/Basic/SyncScope.h
+++ b/clang/include/clang/Basic/SyncScope.h
@@ -252,8 +252,7 @@ public:
   }
 
   bool isValid(unsigned S) const override {
-    return S >= static_cast<unsigned>(System) &&
-           S <= static_cast<unsigned>(Last);
+    return S <= static_cast<unsigned>(Last);
   }
 
   ArrayRef<unsigned> getRuntimeValues() const override {


### PR DESCRIPTION
This non-functional change eliminates the compiler warning
```
/repo/llvm-project/clang/include/clang/Basic/SyncScope.h: In member function ‘virtual bool clang::AtomicScopeGenericModel::isValid(unsigned int) const’:
/repo/llvm-project/clang/include/clang/Basic/SyncScope.h:255:14: warning: comparison of unsigned expression >= 0 is always true [-Wtype-limits]
     return S >= static_cast<unsigned>(System) &&
            ~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```
which was appearing repeatedly, as this header is included into very many source files (through various chains of 6-7 header files).