### PR TITLE
[tsan] Add callbacks for futex syscalls and mark them as blocking on tsan

### DIFF
--- a/compiler-rt/include/sanitizer/linux_syscall_hooks.h
+++ b/compiler-rt/include/sanitizer/linux_syscall_hooks.h
@@ -1856,6 +1856,15 @@
   __sanitizer_syscall_pre_impl_sigaltstack((long)ss, (long)oss)
 #define __sanitizer_syscall_post_sigaltstack(res, ss, oss)                     \
   __sanitizer_syscall_post_impl_sigaltstack(res, (long)ss, (long)oss)
+#define __sanitizer_syscall_pre_futex(uaddr, futex_op, val, timeout, uaddr2,   \
+                                      val3)                                    \
+  __sanitizer_syscall_pre_impl_futex((long)uaddr, (long)futex_op, (long)val,   \
+                                     (long)timeout, (long)uaddr2, (long)val3)
+#define __sanitizer_syscall_post_futex(res, uaddr, futex_op, val, timeout,     \
+                                       uaddr2, val3)                           \
+  __sanitizer_syscall_post_impl_futex(res, (long)uaddr, (long)futex_op,        \
+                                      (long)val, (long)timeout, (long)uaddr2,  \
+                                      (long)val3)
 
 // And now a few syscalls we don't handle yet.
 #define __sanitizer_syscall_pre_afs_syscall(...)
@@ -1875,7 +1884,6 @@
 #define __sanitizer_syscall_pre_fchown32(...)
 #define __sanitizer_syscall_pre_ftime(...)
 #define __sanitizer_syscall_pre_ftruncate64(...)
-#define __sanitizer_syscall_pre_futex(...)
 #define __sanitizer_syscall_pre_getegid32(...)
 #define __sanitizer_syscall_pre_geteuid32(...)
 #define __sanitizer_syscall_pre_getgid32(...)
@@ -1954,7 +1962,6 @@
 #define __sanitizer_syscall_post_fchown32(res, ...)
 #define __sanitizer_syscall_post_ftime(res, ...)
 #define __sanitizer_syscall_post_ftruncate64(res, ...)
-#define __sanitizer_syscall_post_futex(res, ...)
 #define __sanitizer_syscall_post_getegid32(res, ...)
 #define __sanitizer_syscall_post_geteuid32(res, ...)
 #define __sanitizer_syscall_post_getgid32(res, ...)
@@ -3093,6 +3100,11 @@ void __sanitizer_syscall_post_impl_rt_sigaction(long res, long signum, long act,
                                                 long oldact, long sz);
 void __sanitizer_syscall_pre_impl_sigaltstack(long ss, long oss);
 void __sanitizer_syscall_post_impl_sigaltstack(long res, long ss, long oss);
+void __sanitizer_syscall_pre_impl_futex(long uaddr, long futex_op, long val,
+                                        long timeout, long uaddr2, long val3);
+void __sanitizer_syscall_post_impl_futex(long res, long uaddr, long futex_op,
+                                         long val, long timeout, long uaddr2,
+                                         long val3);
 #ifdef __cplusplus
 } // extern "C"
 #endif

--- a/compiler-rt/lib/sanitizer_common/sanitizer_common_syscalls.inc
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_common_syscalls.inc
@@ -38,6 +38,10 @@
 //          Called before fork syscall.
 //   COMMON_SYSCALL_POST_FORK(long res)
 //          Called after fork syscall.
+//   COMMON_SYSCALL_BLOCKING_START()
+//         Called before blocking syscall.
+//   COMMON_SYSCALL_BLOCKING_END()
+//         Called after blocking syscall.
 //===----------------------------------------------------------------------===//
 
 #include "sanitizer_platform.h"
@@ -82,6 +86,16 @@
 
 #  ifndef COMMON_SYSCALL_POST_FORK
 #    define COMMON_SYSCALL_POST_FORK(res) \
+      {}
+#  endif
+
+#  ifndef COMMON_SYSCALL_BLOCKING_START
+#    define COMMON_SYSCALL_BLOCKING_START() \
+      {}
+#  endif
+
+#  ifndef COMMON_SYSCALL_BLOCKING_END
+#    define COMMON_SYSCALL_BLOCKING_END() \
       {}
 #  endif
 
@@ -3176,6 +3190,18 @@ POST_SYSCALL(sigaltstack)(long res, void *ss, void *oss) {
     }
   }
 }
+
+PRE_SYSCALL(futex)
+(void *uaddr, long futex_op, long val, void *timeout, void *uaddr2, long val3) {
+  COMMON_SYSCALL_BLOCKING_START();
+}
+
+POST_SYSCALL(futex)
+(long res, void *uaddr, long futex_op, long val, void *timeout, void *uaddr2,
+ long val3) {
+  COMMON_SYSCALL_BLOCKING_END();
+}
+
 }  // extern "C"
 
 #  undef PRE_SYSCALL

--- a/compiler-rt/test/tsan/signal_in_futex_wait.cpp
+++ b/compiler-rt/test/tsan/signal_in_futex_wait.cpp
@@ -1,0 +1,116 @@
+// RUN: %clang_tsan %s -lstdc++ -o %t && %run %t 2>&1 | FileCheck %s
+
+#include "test.h"
+#include <errno.h>
+#include <linux/futex.h>
+#include <pthread.h>
+#include <signal.h>
+#include <stdio.h>
+#include <sys/syscall.h>
+
+#include <cassert>
+#include <stdexcept>
+#include <thread>
+
+#include <sanitizer/linux_syscall_hooks.h>
+
+int futex(int *uaddr, int futex_op, int val, const struct timespec *timeout,
+          int *uaddr2, int val3) {
+  __sanitizer_syscall_pre_futex(uaddr, futex_op, val, timeout, uaddr2, val3);
+  int result = syscall(SYS_futex, uaddr, futex_op, val, timeout, uaddr2, val3);
+  __sanitizer_syscall_post_futex(result, uaddr, futex_op, val, timeout, uaddr2,
+                                 val3);
+  return result;
+}
+
+// Simple mutex implementation using futex.
+class Mutex {
+public:
+  Mutex() : value(0) {}
+
+  void lock() {
+    int c;
+    while ((c = __sync_val_compare_and_swap(&value, 0, 1)) != 0) {
+      if (c != 1)
+        continue;
+      int r = futex(&value, FUTEX_WAIT_PRIVATE, 1, nullptr, nullptr, 0);
+      if (r == -1 && errno != EAGAIN) {
+        fprintf(stderr, "futex wait error\n");
+        abort();
+      }
+    }
+  }
+
+  void unlock() {
+    value = 0;
+    int r = futex(&value, FUTEX_WAKE_PRIVATE, 1, nullptr, nullptr, 0);
+    if (r == -1) {
+      fprintf(stderr, "futex wake error\n");
+      abort();
+    }
+  }
+
+private:
+  int value;
+};
+
+Mutex mutex;
+
+void *Thread(void *x) {
+  // fprintf(stderr, "canova here thread 0\n");
+  // Waiting for the futex.
+  mutex.lock();
+  // fprintf(stderr, "canova here thread 1\n");
+  // Finished waiting.
+  return nullptr;
+}
+
+static void SigprofHandler(int signal, siginfo_t *info, void *context) {
+  // fprintf(stderr, "canova here sigprof handler\n");
+  // Unlock the futex.
+  mutex.unlock();
+}
+
+void InstallSignalHandler() {
+  struct sigaction sa;
+  sa.sa_sigaction = SigprofHandler;
+  sigemptyset(&sa.sa_mask);
+  sa.sa_flags = SA_RESTART | SA_SIGINFO;
+  if (sigaction(SIGPROF, &sa, 0) != 0) {
+    fprintf(stderr, "failed to install signal handler\n");
+    abort();
+  }
+}
+
+int main() {
+  alarm(60); // Kill the test if it hangs.
+
+  // Install the signal handler
+  InstallSignalHandler();
+
+  // Lock the futex at first so the other thread will wait for it.
+  mutex.lock();
+
+  // Create the thread to wait for the futex.
+  pthread_t thread;
+  pthread_create(&thread, NULL, Thread, NULL);
+
+  // Just waiting a bit to make sure the thead is at the FUTEX_WAIT_PRIVATE
+  // syscall.
+  std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
+  // Send the signal to the other thread, which will send the futex wake
+  // syscall.
+  int r = pthread_kill(thread, SIGPROF);
+  assert(r == 0);
+
+  // Futex should be notified and the thread should be able to continue.
+  pthread_join(thread, NULL);
+
+  // Exiting successfully.
+  fprintf(stderr, "PASS\n");
+  return 0;
+}
+
+// CHECK-NOT: WARNING: ThreadSanitizer:
+// CHECK: PASS


### PR DESCRIPTION
Fixes #83844.

This PR adds callbacks to mark futex syscalls as blocking. Unfortunately we didn't have a mechanism before to mark syscalls as a blocking call, so I had to implement it, but it mostly reuses the `BlockingCall` implementation [here](https://github.com/llvm/llvm-project/blob/96819daa3d095cf9f662e0229dc82eaaa25480e8/compiler-rt/lib/tsan/rtl/tsan_interceptors_posix.cpp#L362-L380).

The issue includes some information but this issue was discovered because Rust uses futexes directly. So most likely we need to update Rust as well to use these callbacks.

Also see the latest comments in #85188 for some context.
I also sent another PR #84162 to mark `pthread_*_lock` calls as blocking.