### PR TITLE
[InstCombine] Restrict multiuse in foldBinOpOfSelectAndCastOfSelectCondition

### DIFF
--- a/llvm/lib/Transforms/InstCombine/InstructionCombining.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstructionCombining.cpp
@@ -1004,6 +1004,7 @@ InstCombinerImpl::foldBinOpOfSelectAndCastOfSelectCondition(BinaryOperator &I) {
   Value *LHS = I.getOperand(0), *RHS = I.getOperand(1);
   Value *A, *CondVal, *TrueVal, *FalseVal;
   Value *CastOp;
+  SelectInst *SI;
 
   auto MatchSelectAndCast = [&](Value *CastOp, Value *SelectOp) {
     return match(CastOp, m_ZExtOrSExt(m_Value(A))) &&
@@ -1011,14 +1012,15 @@ InstCombinerImpl::foldBinOpOfSelectAndCastOfSelectCondition(BinaryOperator &I) {
            match(SelectOp, m_Select(m_Value(CondVal), m_Value(TrueVal),
                                     m_Value(FalseVal)));
   };
-
   // Make sure one side of the binop is a select instruction, and the other is a
   // zero/sign extension operating on a i1.
-  if (MatchSelectAndCast(LHS, RHS))
+  if (MatchSelectAndCast(LHS, RHS)) {
     CastOp = LHS;
-  else if (MatchSelectAndCast(RHS, LHS))
+    SI = cast<SelectInst>(RHS);
+  } else if (MatchSelectAndCast(RHS, LHS)) {
     CastOp = RHS;
-  else
+    SI = cast<SelectInst>(LHS);
+  } else
     return nullptr;
 
   auto NewFoldedConst = [&](bool IsTrueArm, Value *V) {
@@ -1038,6 +1040,10 @@ InstCombinerImpl::foldBinOpOfSelectAndCastOfSelectCondition(BinaryOperator &I) {
     return IsCastOpRHS ? Builder.CreateBinOp(Opc, V, C)
                        : Builder.CreateBinOp(Opc, C, V);
   };
+
+  if (!SI->hasOneUse() && !(isa<Constant>(SI->getTrueValue()) && isa<Constant>(SI->getFalseValue()))) {
+    return nullptr;
+  }
 
   // If the value used in the zext/sext is the select condition, or the negated
   // of the select condition, the binop can be simplified.


### PR DESCRIPTION
This fold currently allows multiuse selects which is not profitable in the general case (see https://godbolt.org/z/TacMbKa3j).

I couldn't figure out a cheap and easy way to avoid the regressions when only one select arm is constant,
but this case probably never comes up in real code anyway.

I tried to handle this fold in FoldOpIntoSelect instead, but that function and its callers currently assume
that the Op must have a constant operand (e.g. for ADDs the function gets called via foldAddWithConstant 
and foldBinOpIntoSelectOrPhi). And changing this pre-condition would probably lead to (compile time)
regressions, so I abandoned the attempt for now and went for a simpler fix. 

Related to #86176
