### PR TITLE
[StandardInstrumentation] Add YieldCallback to NewPM

### DIFF
--- a/llvm/include/llvm/Passes/StandardInstrumentations.h
+++ b/llvm/include/llvm/Passes/StandardInstrumentations.h
@@ -451,6 +451,15 @@ public:
   void registerCallbacks(PassInstrumentationCallbacks &PIC);
 };
 
+
+class YieldInstrumentation {
+  LLVMContext &Context;
+
+public:
+  YieldInstrumentation(LLVMContext &Context) : Context(Context) {}
+  void registerCallbacks(PassInstrumentationCallbacks &PIC);
+};
+
 /// This class implements --time-trace functionality for new pass manager.
 /// It provides the pass-instrumentation callbacks that measure the pass
 /// execution time. They collect time tracing info by TimeProfiler.
@@ -580,6 +589,7 @@ class StandardInstrumentations {
   PrintCrashIRInstrumentation PrintCrashIR;
   IRChangedTester ChangeTester;
   VerifyInstrumentation Verify;
+  YieldInstrumentation YieldAfterPass;
 
   bool VerifyEach;
 


### PR DESCRIPTION
Currently, this is done in Legacy Pass Manager which is used only in code gen (and previously when we were using legacy PM in opt). When we switched to new PM, we lost this functionality.

Tested this with our downstream yield callback implementation to interrupt compilation when compile takes more than X seconds.