### PR TITLE
[bazel] Restrict libpfm to linux

### DIFF
--- a/utils/bazel/llvm-project-overlay/llvm/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/llvm/BUILD.bazel
@@ -3153,8 +3153,10 @@ cc_library(
         ":Support",
         ":Target",
         ":config",
-        ":maybe_pfm",
-    ],
+    ] + select({
+        "@platforms//os:linux": [":maybe_pfm"],
+        "//conditions:default": [],
+    }),
 )
 
 ################################################################################

--- a/utils/bazel/third_party_build/pfm.BUILD
+++ b/utils/bazel/third_party_build/pfm.BUILD
@@ -14,8 +14,12 @@ make_variant(
     copts = ["-w"],
     lib_name = "libpfm",
     lib_source = ":sources",
+    target_compatible_with = select({
+        "@platforms//os:linux": [],
+        "//conditions:default": ["@platforms//:incompatible"],
+    }),
     toolchain = "@rules_foreign_cc//toolchains:preinstalled_autoconf_toolchain",
-    visibility = ["//visibility:public"],
+    visibility = ["//visibility:private"],
 )
 
 alias(
@@ -27,5 +31,9 @@ alias(
 cc_library(
     name = "pfm_system",
     linkopts = ["-lpfm"],
-    visibility = ["//visibility:public"],
+    target_compatible_with = select({
+        "@platforms//os:linux": [],
+        "//conditions:default": ["@platforms//:incompatible"],
+    }),
+    visibility = ["//visibility:private"],
 )


### PR DESCRIPTION
This target doesn't build on macOS (even with the upstream make based build system) so this encodes that in the build without requiring non-linux users to disable it manually with the starlark flag. The flag is still respected for linux users.