### PR TITLE
Fix failing tests after #86242

### DIFF
--- a/llvm/lib/Target/DirectX/DirectXPassRegistry.def
+++ b/llvm/lib/Target/DirectX/DirectXPassRegistry.def
@@ -24,6 +24,6 @@ MODULE_ANALYSIS("dxil-resource", DXILResourceAnalysis())
 #define MODULE_PASS(NAME, CREATE_PASS)
 #endif
 // TODO: rename to print<foo> after NPM switch
-MODULE_PASS("print-dx-shader-flags", DXILResourcePrinterPass(dbgs()))
+MODULE_PASS("print-dx-shader-flags", dxil::ShaderFlagsAnalysisPrinter(dbgs()))
 MODULE_PASS("print-dxil-resource", DXILResourcePrinterPass(dbgs()))
 #undef MODULE_PASS


### PR DESCRIPTION
PR #86242 introduced a copy-paste error that caused some tests to fail by mapping the wrong pass name to a pass. This resolves the issue and fixes the failing tests.