### PR TITLE
[memprof] Create a call stack table

### DIFF
--- a/llvm/include/llvm/ProfileData/RawMemProfReader.h
+++ b/llvm/include/llvm/ProfileData/RawMemProfReader.h
@@ -97,6 +97,8 @@ protected:
   }
   // A mapping from FrameId (a hash of the contents) to the frame.
   llvm::DenseMap<FrameId, Frame> IdToFrame;
+  // A mapping from CallStackId (a hash of the contents) to the call stack.
+  llvm::DenseMap<CallStackId, SmallVector<FrameId>> CallStackIdToCallStack;
   // A mapping from function GUID, hash of the canonical function symbol to the
   // memprof profile data for that function, i.e allocation and callsite info.
   llvm::MapVector<GlobalValue::GUID, IndexedMemProfRecord> FunctionProfileData;

--- a/llvm/lib/ProfileData/RawMemProfReader.cpp
+++ b/llvm/lib/ProfileData/RawMemProfReader.cpp
@@ -447,6 +447,7 @@ Error RawMemProfReader::mapRawProfileToRecords() {
     }
 
     CallStackId CSId = hashCallStack(Callstack);
+    CallStackIdToCallStack.insert({CSId, Callstack});
 
     // We attach the memprof record to each function bottom-up including the
     // first non-inline frame.


### PR DESCRIPTION
We are in the process of reducing the size of the indexed memprof file
by creating a hash table of call stacks so that IndexedAllocationInfo
can refer to a call stack with the hash of the call stack.  The idea
is analogus to IdToFrame, a hash table to map a FrameId to its
corresponding Frame.

This patch prepares for that future by keeping call stacks in a hash
table so that we can drop CallStack from IndexedAllocationInfo.

We will eventually serialize the hash table into an indexed profile
file just as we serialize MemProfFrameData, a hash table of Frames
indexed by FrameId.

This patch does not add a use of the hash table yet.
