### PR TITLE
[Flang] Add new CHECK_MSG() function

### DIFF
--- a/flang/include/flang/Common/idioms.h
+++ b/flang/include/flang/Common/idioms.h
@@ -87,6 +87,8 @@ template <typename... LAMBDAS> visitors(LAMBDAS... x) -> visitors<LAMBDAS...>;
 // To disable, compile with '-DCHECK=(void)'
 #ifndef CHECK
 #define CHECK(x) ((x) || (DIE("CHECK(" #x ") failed"), false))
+// Same as above, but with a custom error message.
+#define CHECK_MSG(x, y) ((x) || (DIE("CHECK(" #x ") failed: " #y), false))
 #endif
 
 // User-defined type traits that default to false:

--- a/flang/lib/Evaluate/constant.cpp
+++ b/flang/lib/Evaluate/constant.cpp
@@ -160,7 +160,7 @@ template <typename RESULT, typename ELEMENT>
 auto ConstantBase<RESULT, ELEMENT>::Reshape(
     const ConstantSubscripts &dims) const -> std::vector<Element> {
   std::optional<uint64_t> optN{TotalElementCount(dims)};
-  CHECK(optN);
+  CHECK_MSG(optN, "Overflow in TotalElementCount");
   uint64_t n{*optN};
   CHECK(!empty() || n == 0);
   std::vector<Element> elements;


### PR DESCRIPTION
Added a new variant of the CHECK() function that takes a custom message as a parameter. This is useful for more meaninful error messages when the compiler is expected to crash.

Fixes #78931