### PR TITLE
Revert "[scudo] Use getMonotonicTimeFast for tryLock."

### DIFF
--- a/compiler-rt/lib/scudo/standalone/tsd.h
+++ b/compiler-rt/lib/scudo/standalone/tsd.h
@@ -41,9 +41,9 @@ template <class Allocator> struct alignas(SCUDO_CACHE_LINE_SIZE) TSD {
       return true;
     }
     if (atomic_load_relaxed(&Precedence) == 0)
-      atomic_store_relaxed(&Precedence,
-                           static_cast<uptr>(getMonotonicTimeFast() >>
-                                             FIRST_32_SECOND_64(16, 0)));
+      atomic_store_relaxed(
+          &Precedence,
+          static_cast<uptr>(getMonotonicTime() >> FIRST_32_SECOND_64(16, 0)));
     return false;
   }
   inline void lock() NO_THREAD_SAFETY_ANALYSIS {


### PR DESCRIPTION
This reverts commit 36ca9a29025a2f678096e9545fa2ec44e8432592.

We were using the `time` as the seed while choosing a new TSD. To make the access of TSDs evenly distributed, we require a higher precision in `time`. Otherwise, many threads may result in having the same random access pattern on TSDs because they share the same `time` in certain period. On Linux, CLOCK_MONOTONIC_COARSE usually adopts 4 ms precision. This is way higher than the average accessing time of TSD (which is usually less than 1 us). As a result, when multiple threads try to select a new TSD in a 4 ms interval, they share the same `time` seed and end up choosing and congesting on the same TSD.