### PR TITLE
[lldb] [ObjC runtime] Don't cast to signed when left shifting

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCRuntimeV2.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCRuntimeV2.cpp
@@ -3154,7 +3154,7 @@ AppleObjCRuntimeV2::TaggedPointerVendorExtended::GetClassDescriptor(
                             << m_objc_debug_taggedpointer_ext_payload_lshift) >>
                            m_objc_debug_taggedpointer_ext_payload_rshift);
   int64_t data_payload_signed =
-      ((int64_t)((int64_t)unobfuscated
+      ((int64_t)((uint64_t)unobfuscated
                  << m_objc_debug_taggedpointer_ext_payload_lshift) >>
        m_objc_debug_taggedpointer_ext_payload_rshift);
 


### PR DESCRIPTION
This is fixing a report from ubsan which I don't think is super high value, but our testsuite hits it on
TestDataFormatterObjCNSContainer.py so I'd like to work around it. We are getting

```
runtime error: left shift of negative value -8827055269646171913

   3159	  int64_t data_payload_signed =
   3160	      ((int64_t)((int64_t)unobfuscated
-> 3161	                 << m_objc_debug_taggedpointer_ext_payload_lshift) >>
   3162	       m_objc_debug_taggedpointer_ext_payload_rshift);
```

At this point `unobfuscated` is 0x85800000000000f7 and `m_objc_debug_taggedpointer_ext_payload_lshift` is 9, so `(int64_t)0x85800000000000f7<<9` shifts off the "sign" bit and then some zeroes etc, and that's how we get this error.

We're only trying to extract some bits in the middle of the doubleword, so the fact that we're "losing" the sign is not a bug.  Change the inner cast to (uint64_t).