### PR TITLE
[flang][runtime] Use cuda::std::variant in the CUDA build.

### DIFF
--- a/flang/include/flang/Common/idioms.h
+++ b/flang/include/flang/Common/idioms.h
@@ -24,6 +24,7 @@
 #endif
 
 #include "enum-class.h"
+#include "variant.h"
 #include "visit.h"
 #include <array>
 #include <functional>
@@ -33,7 +34,6 @@
 #include <string>
 #include <tuple>
 #include <type_traits>
-#include <variant>
 
 #if __GNUC__ == 7
 // Avoid a deduction bug in GNU 7.x headers by forcing the answer.

--- a/flang/include/flang/Common/template.h
+++ b/flang/include/flang/Common/template.h
@@ -9,12 +9,12 @@
 #ifndef FORTRAN_COMMON_TEMPLATE_H_
 #define FORTRAN_COMMON_TEMPLATE_H_
 
+#include "variant.h"
 #include "flang/Common/idioms.h"
 #include <functional>
 #include <optional>
 #include <tuple>
 #include <type_traits>
-#include <variant>
 #include <vector>
 
 // Utility templates for metaprogramming and for composing the

--- a/flang/include/flang/Common/unwrap.h
+++ b/flang/include/flang/Common/unwrap.h
@@ -12,11 +12,11 @@
 #include "indirection.h"
 #include "reference-counted.h"
 #include "reference.h"
+#include "variant.h"
 #include "visit.h"
 #include <memory>
 #include <optional>
 #include <type_traits>
-#include <variant>
 
 // Given a nest of variants, optionals, &/or pointers, Unwrap<>() isolates
 // a packaged value of a specific type if it is present and returns a pointer

--- a/flang/include/flang/Common/variant.h
+++ b/flang/include/flang/Common/variant.h
@@ -1,0 +1,30 @@
+//===-- include/flang/Common/variant.h --------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// A single way to expose C++ variant class in files that can be used
+// in F18 runtime build. With inclusion of this file std::variant
+// and the related names become available, though, they may correspond
+// to alternative definitions (e.g. from cuda::std namespace).
+
+#ifndef FORTRAN_COMMON_VARIANT_H
+#define FORTRAN_COMMON_VARIANT_H
+
+#if RT_USE_LIBCUDACXX
+#include <cuda/std/variant>
+namespace std {
+using cuda::std::get;
+using cuda::std::monostate;
+using cuda::std::variant;
+using cuda::std::variant_size_v;
+using cuda::std::visit;
+} // namespace std
+#else // !RT_USE_LIBCUDACXX
+#include <variant>
+#endif // !RT_USE_LIBCUDACXX
+
+#endif // FORTRAN_COMMON_VARIANT_H

--- a/flang/include/flang/Common/visit.h
+++ b/flang/include/flang/Common/visit.h
@@ -21,9 +21,9 @@
 #ifndef FORTRAN_COMMON_VISIT_H_
 #define FORTRAN_COMMON_VISIT_H_
 
+#include "variant.h"
 #include "flang/Common/api-attrs.h"
 #include <type_traits>
-#include <variant>
 
 namespace Fortran::common {
 namespace log2visit {

--- a/flang/runtime/CMakeLists.txt
+++ b/flang/runtime/CMakeLists.txt
@@ -173,6 +173,7 @@ set(sources
 option(FLANG_EXPERIMENTAL_CUDA_RUNTIME
   "Compile Fortran runtime as CUDA sources (experimental)" OFF
   )
+set(FLANG_LIBCUDACXX_PATH "" CACHE PATH "Path to libcu++ package installation")
 
 # List of files that are buildable for all devices.
 set(supported_files
@@ -259,6 +260,13 @@ if (FLANG_EXPERIMENTAL_CUDA_RUNTIME)
   set_source_files_properties(${supported_files} PROPERTIES COMPILE_OPTIONS
     "${CUDA_COMPILE_OPTIONS}"
     )
+
+  if (EXISTS "${FLANG_LIBCUDACXX_PATH}/include")
+    # When using libcudacxx headers files, we have to use them
+    # for all files of F18 runtime.
+    include_directories(AFTER ${FLANG_LIBCUDACXX_PATH}/include)
+    add_compile_definitions(RT_USE_LIBCUDACXX=1)
+  endif()
 endif()
 
 set(FLANG_EXPERIMENTAL_OMP_OFFLOAD_BUILD "off" CACHE STRING

--- a/flang/runtime/io-stmt.h
+++ b/flang/runtime/io-stmt.h
@@ -21,9 +21,9 @@
 #include "flang/Common/visit.h"
 #include "flang/Runtime/descriptor.h"
 #include "flang/Runtime/io-api.h"
+#include <flang/Common/variant.h>
 #include <functional>
 #include <type_traits>
-#include <variant>
 
 namespace Fortran::runtime::io {
 

--- a/flang/runtime/unit.cpp
+++ b/flang/runtime/unit.cpp
@@ -482,10 +482,7 @@ bool ExternalFileUnit::SetDirectRec(
 
 void ExternalFileUnit::EndIoStatement() {
   io_.reset();
-  RT_DIAG_PUSH
-  RT_DIAG_DISABLE_CALL_HOST_FROM_DEVICE_WARN
   u_.emplace<std::monostate>();
-  RT_DIAG_POP
   lock_.Drop();
 }
 
@@ -752,10 +749,7 @@ std::int32_t ExternalFileUnit::ReadHeaderOrFooter(std::int64_t frameOffset) {
 
 void ChildIo::EndIoStatement() {
   io_.reset();
-  RT_DIAG_PUSH
-  RT_DIAG_DISABLE_CALL_HOST_FROM_DEVICE_WARN
   u_.emplace<std::monostate>();
-  RT_DIAG_POP
 }
 
 Iostat ChildIo::CheckFormattingAndDirection(

--- a/flang/runtime/unit.h
+++ b/flang/runtime/unit.h
@@ -25,7 +25,7 @@
 #include "flang/Runtime/memory.h"
 #include <cstdlib>
 #include <cstring>
-#include <variant>
+#include <flang/Common/variant.h>
 
 namespace Fortran::runtime::io {
 
@@ -152,10 +152,7 @@ public:
 #else
     lock_.Take();
 #endif
-    RT_DIAG_PUSH
-    RT_DIAG_DISABLE_CALL_HOST_FROM_DEVICE_WARN
     A &state{u_.emplace<A>(std::forward<X>(xs)...)};
-    RT_DIAG_POP
     if constexpr (!std::is_same_v<A, OpenStatementState>) {
       state.mutableModes() = ConnectionState::modes;
     }
@@ -265,10 +262,7 @@ public:
 
   template <typename A, typename... X>
   RT_API_ATTRS IoStatementState &BeginIoStatement(X &&...xs) {
-    RT_DIAG_PUSH
-    RT_DIAG_DISABLE_CALL_HOST_FROM_DEVICE_WARN
     A &state{u_.emplace<A>(std::forward<X>(xs)...)};
-    RT_DIAG_POP
     io_.emplace(state);
     return *io_;
   }


### PR DESCRIPTION
Added `FLANG_LIBCUDACXX_PATH` CMake variable to specify
installation of header-only libcudacxx library.
If it is specified, the `<cuda/std/variant>` is used to provide
implementation of `std::variant`.
