### PR TITLE
[Clang] Add wraps attribute (for granular integer overflow handling)

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -249,6 +249,16 @@ Attribute Changes in Clang
 - Introduced a new attribute ``[[clang::coro_await_elidable]]`` on coroutine return types
   to express elideability at call sites where the coroutine is co_awaited as a prvalue.
 
+- Introduced ``__attribute((wraps))__`` which can be added to type or variable
+  declarations. Using an attributed type or variable in an arithmetic
+  expression will define the overflow behavior for that expression as having
+  two's complement wrap-around. These expressions cannot trigger integer
+  overflow warnings or sanitizer warnings. They also cannot be optimized away
+  by some eager UB optimizations.
+
+  This attribute is only valid for C, as there are built-in language
+  alternatives for other languages.
+
 Improvements to Clang's diagnostics
 -----------------------------------
 

--- a/clang/include/clang/AST/Expr.h
+++ b/clang/include/clang/AST/Expr.h
@@ -4098,6 +4098,9 @@ public:
     return getFPFeaturesInEffect(LO).getAllowFEnvAccess();
   }
 
+  /// Does one of the subexpressions have the wraps attribute?
+  bool hasWrappingOperand(const ASTContext &Ctx) const;
+
 protected:
   BinaryOperator(const ASTContext &Ctx, Expr *lhs, Expr *rhs, Opcode opc,
                  QualType ResTy, ExprValueKind VK, ExprObjectKind OK,

--- a/clang/include/clang/AST/Type.h
+++ b/clang/include/clang/AST/Type.h
@@ -1454,6 +1454,8 @@ public:
     return getQualifiers().hasStrongOrWeakObjCLifetime();
   }
 
+  bool hasWrapsAttr() const;
+
   // true when Type is objc's weak and weak is enabled but ARC isn't.
   bool isNonWeakInMRRWithObjCWeak(const ASTContext &Context) const;
 

--- a/clang/include/clang/Basic/Attr.td
+++ b/clang/include/clang/Basic/Attr.td
@@ -4796,3 +4796,10 @@ def ClspvLibclcBuiltin: InheritableAttr {
   let Documentation = [ClspvLibclcBuiltinDoc];
   let SimpleHandler = 1;
 }
+
+def Wraps : DeclOrTypeAttr {
+  let Spellings = [Clang<"wraps">];
+  let Subjects = SubjectList<[Var, TypedefName, Field]>;
+  let Documentation = [WrapsDocs];
+  let LangOpts = [COnly];
+}

--- a/clang/include/clang/Basic/AttrDocs.td
+++ b/clang/include/clang/Basic/AttrDocs.td
@@ -8446,3 +8446,72 @@ Declares that a function potentially allocates heap memory, and prevents any pot
 of ``nonallocating`` by the compiler.
   }];
 }
+
+def WrapsDocs : Documentation {
+  let Category = DocCatField;
+  let Content = [{
+This attribute can be used with type or variable declarations to denote that
+arithmetic containing these marked components have defined overflow behavior.
+Specifically, the behavior is defined as being consistent with two's complement
+wrap-around. For the purposes of sanitizers or warnings that concern themselves
+with the definedness of integer arithmetic, they will cease to instrument or
+warn about arithmetic that directly involves a "wrapping" component.
+
+For example, ``-fsanitize=signed-integer-overflow`` or ``-Winteger-overflow``
+will not warn about suspicious overflowing arithmetic -- assuming correct usage
+of the wraps attribute.
+
+This example shows some basic usage of ``__attribute__((wraps))`` on a type
+definition when building with ``-fsanitize=signed-integer-overflow``
+
+.. code-block:: c
+
+  typedef int __attribute__((wraps)) wrapping_int;
+
+  void foo() {
+    wrapping_int a = INT_MAX;
+    ++a; // no sanitizer warning
+  }
+
+  int main() { foo(); }
+
+In the following example, we use ``__attribute__((wraps))`` on a variable to
+disable overflow instrumentation for arithmetic expressions it appears in. We
+do so with a popular overflow-checking pattern which we might not want to trip
+sanitizers (like ``-fsanitize=unsigned-integer-overflow``).
+
+.. code-block:: c
+
+  void foo(int offset) {
+    unsigned int A __attribute__((wraps)) = UINT_MAX;
+
+    // check for overflow using a common pattern, however we may accidentally
+    // perform a real overflow thus triggering sanitizers to step in. Since "A"
+    // is "wrapping", we can avoid sanitizer warnings.
+    if (A + offset < A) {
+      // handle overflow manually
+      // ...
+      return;
+    }
+
+    // now, handle non-overflow case ...
+  }
+
+The above example demonstrates some of the power and elegance this attribute
+provides. We can use code patterns we are already familiar with (like ``if (x +
+y < x)``) while gaining control over the overflow behavior on a case-by-case
+basis.
+
+When combined with ``-fwrapv``, this attribute can still be applied as normal
+but has no function apart from annotating types and variables for readers. This
+is because ``-fwrapv`` defines all arithmetic as being "wrapping", rendering
+this attribute's efforts redundant.
+
+When using this attribute without ``-fwrapv`` and without any sanitizers, it
+still has an impact on the definedness of arithmetic expressions containing
+wrapping components. Since the behavior of said expressions is now technically
+defined, the compiler will forgo some eager optimizations that are used on
+expressions containing UB.
+}];
+}
+

--- a/clang/include/clang/Basic/DiagnosticGroups.td
+++ b/clang/include/clang/Basic/DiagnosticGroups.td
@@ -1577,3 +1577,9 @@ def ExtractAPIMisuse : DiagGroup<"extractapi-misuse">;
 // Warnings about using the non-standard extension having an explicit specialization
 // with a storage class specifier.
 def ExplicitSpecializationStorageClass : DiagGroup<"explicit-specialization-storage-class">;
+
+// Warnings regarding the usage of __attribute__((wraps)) on non-integer types.
+def UselessWrapsAttr : DiagGroup<"useless-wraps-attribute">;
+
+// Warnings about the wraps attribute getting implicitly discarded
+def ImpDiscardedWrapsAttr : DiagGroup<"implicitly-discarded-wraps-attribute">;

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -6633,6 +6633,13 @@ def warn_counted_by_attr_elt_type_unknown_size :
   Warning<err_counted_by_attr_pointee_unknown_size.Summary>,
   InGroup<BoundsSafetyCountedByEltTyUnknownSize>;
 
+def warn_wraps_attr_var_decl_type_not_integer : Warning<
+  "using attribute 'wraps' with non-integer type '%0' has no function">,
+  InGroup<UselessWrapsAttr>;
+def warn_wraps_attr_maybe_lost : Warning<
+  "'wraps' attribute may be implicitly discarded when converted to %0">,
+  InGroup<ImpDiscardedWrapsAttr>;
+
 let CategoryName = "ARC Semantic Issue" in {
 
 // ARC-mode diagnostics.

--- a/clang/lib/AST/Expr.cpp
+++ b/clang/lib/AST/Expr.cpp
@@ -2240,6 +2240,11 @@ bool BinaryOperator::isNullPointerArithmeticExtension(ASTContext &Ctx,
   return true;
 }
 
+bool BinaryOperator::hasWrappingOperand(const ASTContext &Ctx) const {
+  return getLHS()->getType().hasWrapsAttr() ||
+         getRHS()->getType().hasWrapsAttr();
+}
+
 SourceLocExpr::SourceLocExpr(const ASTContext &Ctx, SourceLocIdentKind Kind,
                              QualType ResultTy, SourceLocation BLoc,
                              SourceLocation RParenLoc,
@@ -4856,6 +4861,8 @@ BinaryOperator::BinaryOperator(const ASTContext &Ctx, Expr *lhs, Expr *rhs,
   if (hasStoredFPFeatures())
     setStoredFPFeatures(FPFeatures);
   setDependence(computeDependence(this));
+  if (hasWrappingOperand(Ctx))
+    setType(Ctx.getAttributedType(attr::Wraps, getType(), getType()));
 }
 
 BinaryOperator::BinaryOperator(const ASTContext &Ctx, Expr *lhs, Expr *rhs,
@@ -4874,6 +4881,8 @@ BinaryOperator::BinaryOperator(const ASTContext &Ctx, Expr *lhs, Expr *rhs,
   if (hasStoredFPFeatures())
     setStoredFPFeatures(FPFeatures);
   setDependence(computeDependence(this));
+  if (hasWrappingOperand(Ctx))
+    setType(Ctx.getAttributedType(attr::Wraps, getType(), getType()));
 }
 
 BinaryOperator *BinaryOperator::CreateEmpty(const ASTContext &C,

--- a/clang/lib/AST/ExprConstant.cpp
+++ b/clang/lib/AST/ExprConstant.cpp
@@ -2809,7 +2809,7 @@ static bool CheckedIntArithmetic(EvalInfo &Info, const Expr *E,
   APSInt Value(Op(LHS.extend(BitWidth), RHS.extend(BitWidth)), false);
   Result = Value.trunc(LHS.getBitWidth());
   if (Result.extend(BitWidth) != Value) {
-    if (Info.checkingForUndefinedBehavior())
+    if (Info.checkingForUndefinedBehavior() && !E->getType().hasWrapsAttr())
       Info.Ctx.getDiagnostics().Report(E->getExprLoc(),
                                        diag::warn_integer_constant_overflow)
           << toString(Result, 10, Result.isSigned(), /*formatAsCLiteral=*/false,
@@ -14412,7 +14412,7 @@ bool IntExprEvaluator::VisitUnaryOperator(const UnaryOperator *E) {
     if (!Result.isInt()) return Error(E);
     const APSInt &Value = Result.getInt();
     if (Value.isSigned() && Value.isMinSignedValue() && E->canOverflow()) {
-      if (Info.checkingForUndefinedBehavior())
+      if (Info.checkingForUndefinedBehavior() && !E->getType().hasWrapsAttr())
         Info.Ctx.getDiagnostics().Report(E->getExprLoc(),
                                          diag::warn_integer_constant_overflow)
             << toString(Value, 10, Value.isSigned(), /*formatAsCLiteral=*/false,

--- a/clang/lib/AST/Type.cpp
+++ b/clang/lib/AST/Type.cpp
@@ -2850,6 +2850,10 @@ bool QualType::isWebAssemblyFuncrefType() const {
          getAddressSpace() == LangAS::wasm_funcref;
 }
 
+bool QualType::hasWrapsAttr() const {
+  return !isNull() && getTypePtr()->hasAttr(attr::Wraps);
+}
+
 QualType::PrimitiveDefaultInitializeKind
 QualType::isNonTrivialToPrimitiveDefaultInitialize() const {
   if (const auto *RT =

--- a/clang/lib/AST/TypePrinter.cpp
+++ b/clang/lib/AST/TypePrinter.cpp
@@ -2024,6 +2024,9 @@ void TypePrinter::printAttributedAfter(const AttributedType *T,
   case attr::AArch64SVEPcs: OS << "aarch64_sve_pcs"; break;
   case attr::AMDGPUKernelCall: OS << "amdgpu_kernel"; break;
   case attr::IntelOclBicc: OS << "inteloclbicc"; break;
+  case attr::Wraps:
+    OS << "wraps";
+    break;
   case attr::PreserveMost:
     OS << "preserve_most";
     break;

--- a/clang/lib/Sema/Sema.cpp
+++ b/clang/lib/Sema/Sema.cpp
@@ -735,6 +735,9 @@ ExprResult Sema::ImpCastExprToType(Expr *E, QualType Ty,
   QualType ExprTy = Context.getCanonicalType(E->getType());
   QualType TypeTy = Context.getCanonicalType(Ty);
 
+  if (E->getType().getTypePtr()->isIntegerType() && E->getType().hasWrapsAttr())
+    Ty = Context.getAttributedType(attr::Wraps, Ty, Ty);
+
   if (ExprTy == TypeTy)
     return E;
 

--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -3930,6 +3930,10 @@ void Sema::AddAlignValueAttr(Decl *D, const AttributeCommonInfo &CI, Expr *E) {
   D->addAttr(::new (Context) AlignValueAttr(Context, CI, E));
 }
 
+static void handleWrapsAttr(Sema &S, Decl *D, const ParsedAttr &AL) {
+  D->addAttr(::new (S.Context) WrapsAttr(S.Context, AL));
+}
+
 static void handleAlignedAttr(Sema &S, Decl *D, const ParsedAttr &AL) {
   if (AL.hasParsedType()) {
     const ParsedType &TypeArg = AL.getTypeArg();
@@ -6861,12 +6865,14 @@ ProcessDeclAttribute(Sema &S, Scope *scope, Decl *D, const ParsedAttr &AL,
   case ParsedAttr::AT_AvailableOnlyInDefaultEvalMethod:
     handleAvailableOnlyInDefaultEvalMethod(S, D, AL);
     break;
-
   case ParsedAttr::AT_CountedBy:
   case ParsedAttr::AT_CountedByOrNull:
   case ParsedAttr::AT_SizedBy:
   case ParsedAttr::AT_SizedByOrNull:
     handleCountedByAttrField(S, D, AL);
+    break;
+  case ParsedAttr::AT_Wraps:
+    handleWrapsAttr(S, D, AL);
     break;
 
   // Microsoft attributes:

--- a/clang/lib/Sema/SemaType.cpp
+++ b/clang/lib/Sema/SemaType.cpp
@@ -6522,6 +6522,18 @@ static void HandleBTFTypeTagAttribute(QualType &Type, const ParsedAttr &Attr,
       ::new (Ctx) BTFTypeTagAttr(Ctx, Attr, BTFTypeTag), Type);
 }
 
+static void handleWrapsAttr(QualType &Type, const ParsedAttr &Attr,
+                            TypeProcessingState &State) {
+  Sema &S = State.getSema();
+  ASTContext &Ctx = S.Context;
+
+  if (!Type->isIntegerType())
+    S.Diag(Attr.getLoc(), diag::warn_wraps_attr_var_decl_type_not_integer)
+        << Type.getAsString();
+
+  Type = State.getAttributedType(::new (Ctx) WrapsAttr(Ctx, Attr), Type, Type);
+}
+
 /// HandleAddressSpaceTypeAttribute - Process an address_space attribute on the
 /// specified type.  The attribute contains 1 argument, the id of the address
 /// space for the type.
@@ -8637,6 +8649,9 @@ static void processTypeAttrs(TypeProcessingState &state, QualType &type,
     case ParsedAttr::AT_BTFTypeTag:
       HandleBTFTypeTagAttribute(type, attr, state);
       attr.setUsedAsTypeAttr();
+      break;
+    case ParsedAttr::AT_Wraps:
+      handleWrapsAttr(type, attr, state);
       break;
 
     case ParsedAttr::AT_MayAlias:

--- a/clang/test/CodeGen/integer-overflow.c
+++ b/clang/test/CodeGen/integer-overflow.c
@@ -105,3 +105,69 @@ void test1(void) {
   // TRAPV:    call ptr @llvm.frameaddress.p0(i32 0)
   // CATCH_UB: call ptr @llvm.frameaddress.p0(i32 0)
 }
+
+// Tests for integer overflow using __attribute__((wraps))
+typedef int __attribute__((wraps)) wrapping_int;
+
+void test2(void) {
+  // DEFAULT-LABEL: define{{.*}} void @test2
+  // WRAPV-LABEL: define{{.*}} void @test2
+  // TRAPV-LABEL: define{{.*}} void @test2
+  extern volatile wrapping_int a, b, c;
+
+  // Basically, all cases should match the WRAPV case since this attribute
+  // effectively enables wrapv for expressions containing wrapping types.
+
+  // DEFAULT,WRAPV,TRAPV,CATCH_UB,TRAPV_HANDLER: add i32
+  a = b + c;
+
+  // DEFAULT,WRAPV,TRAPV,CATCH_UB,TRAPV_HANDLER: sub i32
+  a = b - c;
+
+  // DEFAULT,WRAPV,TRAPV,CATCH_UB,TRAPV_HANDLER: mul i32
+  a = b * c;
+
+  // DEFAULT,WRAPV,TRAPV,CATCH_UB,TRAPV_HANDLER: sub i32 0,
+  a = -b;
+
+  // DEFAULT,WRAPV,TRAPV,CATCH_UB,TRAPV_HANDLER: add i32 {{.*}}, 1
+  ++b;
+
+  // DEFAULT,WRAPV,TRAPV,CATCH_UB,TRAPV_HANDLER: add i32 {{.*}}, -1
+  --b;
+
+  // Less trivial cases
+  extern volatile wrapping_int u, v;
+  extern volatile int w;
+
+  // DEFAULT,WRAPV,TRAPV,CATCH_UB,TRAPV_HANDLER: add i32
+  if (u + v < u) {}
+
+  // DEFAULT,WRAPV,TRAPV,CATCH_UB,TRAPV_HANDLER: add i32
+  for (;u + v < u;) {}
+
+  // this (w+1) should have instrumentation
+  // DEFAULT,WRAPV,TRAPV,CATCH_UB,TRAPV_HANDLER: call {{.*}} @llvm.sadd.with.overflow.i32
+  u = (w+1) + v;
+
+  // no parts of this expression should have instrumentation
+  // DEFAULT,WRAPV,TRAPV,CATCH_UB,TRAPV_HANDLER: add i32 {{.*}}, 1
+  u = (v+1) + w;
+
+  // downcast off the wraps attribute
+  // DEFAULT,WRAPV,TRAPV,CATCH_UB,TRAPV_HANDLER: call { i32, i1 } @llvm.sadd.with.overflow.i32
+  u = (int) u + (int) v;
+
+  // DEFAULT,WRAPV,TRAPV,CATCH_UB,TRAPV_HANDLER: call { i32, i1 } @llvm.sadd.with.overflow.i32
+  u = (int) u + w;
+
+  // persist wraps attribute through implicit integer promotion
+  // DEFAULT,WRAPV,TRAPV,CATCH_UB,TRAPV_HANDLER: store i8 127, ptr [[D1:%.*]]
+  // DEFAULT,WRAPV,TRAPV,CATCH_UB,TRAPV_HANDLER: mul{{.*}} = mul i32
+  // would look like mul{{.*}} = mul nsw i32
+  // if overflow behavior was not defined.
+  char __attribute__((wraps)) d;
+  d = 127;
+  w = d*d*d*d*d; // d is promoted to int, then calculation is made.
+                 // wraps prevents instrumentation even through promotion
+}

--- a/clang/test/CodeGen/unsigned-overflow.c
+++ b/clang/test/CodeGen/unsigned-overflow.c
@@ -5,6 +5,11 @@
 unsigned long li, lj, lk;
 unsigned int ii, ij, ik;
 
+// The wraps attribute disables sanitizer instrumentation for arithmetic
+// expressions containing these types.
+unsigned long __attribute__((wraps)) li_w, lj_w, lk_w;
+unsigned int __attribute__((wraps)) ii_w, ij_w, ik_w;
+
 extern void opaquelong(unsigned long);
 extern void opaqueint(unsigned int);
 
@@ -18,6 +23,11 @@ void testlongadd(void) {
   // CHECK-NEXT: [[T5:%.*]] = extractvalue { i64, i1 } [[T3]], 1
   // CHECK: call void @__ubsan_handle_add_overflow
   li = lj + lk;
+
+  // CHECK: [[T6:%.*]] = load i64, ptr @lj_w
+  // CHECK-NEXT: [[T7:%.*]] = load i64, ptr @lk_w
+  // CHECK-NEXT: add i64 [[T6]], [[T7]]
+  li_w = lj_w + lk_w;
 }
 
 // CHECK-LABEL: define{{.*}} void @testlongsub()
@@ -30,6 +40,11 @@ void testlongsub(void) {
   // CHECK-NEXT: [[T5:%.*]] = extractvalue { i64, i1 } [[T3]], 1
   // CHECK: call void @__ubsan_handle_sub_overflow
   li = lj - lk;
+
+  // CHECK: [[T6:%.*]] = load i64, ptr @lj_w
+  // CHECK-NEXT: [[T7:%.*]] = load i64, ptr @lk_w
+  // CHECK-NEXT: sub i64 [[T6]], [[T7]]
+  li_w = lj_w - lk_w;
 }
 
 // CHECK-LABEL: define{{.*}} void @testlongmul()
@@ -42,28 +57,39 @@ void testlongmul(void) {
   // CHECK-NEXT: [[T5:%.*]] = extractvalue { i64, i1 } [[T3]], 1
   // CHECK: call void @__ubsan_handle_mul_overflow
   li = lj * lk;
+
+  // CHECK: [[T6:%.*]] = load i64, ptr @lj_w
+  // CHECK-NEXT: [[T7:%.*]] = load i64, ptr @lk_w
+  // CHECK-NEXT: mul i64 [[T6]], [[T7]]
+  li_w = lj_w * lk_w;
 }
 
 // CHECK-LABEL: define{{.*}} void @testlongpostinc()
 void testlongpostinc(void) {
-  opaquelong(li++);
-
   // CHECK:      [[T1:%.*]] = load i64, ptr @li
   // CHECK-NEXT: [[T2:%.*]] = call { i64, i1 } @llvm.uadd.with.overflow.i64(i64 [[T1]], i64 1)
   // CHECK-NEXT: [[T3:%.*]] = extractvalue { i64, i1 } [[T2]], 0
   // CHECK-NEXT: [[T4:%.*]] = extractvalue { i64, i1 } [[T2]], 1
   // CHECK:      call void @__ubsan_handle_add_overflow
+  opaquelong(li++);
+
+  // CHECK: [[T5:%.*]] = load i64, ptr @li_w
+  // CHECK-NEXT: add i64 [[T5]], 1
+  opaquelong(li_w++);
 }
 
 // CHECK-LABEL: define{{.*}} void @testlongpreinc()
 void testlongpreinc(void) {
-  opaquelong(++li);
-
   // CHECK:      [[T1:%.*]] = load i64, ptr @li
   // CHECK-NEXT: [[T2:%.*]] = call { i64, i1 } @llvm.uadd.with.overflow.i64(i64 [[T1]], i64 1)
   // CHECK-NEXT: [[T3:%.*]] = extractvalue { i64, i1 } [[T2]], 0
   // CHECK-NEXT: [[T4:%.*]] = extractvalue { i64, i1 } [[T2]], 1
   // CHECK:      call void @__ubsan_handle_add_overflow
+  opaquelong(++li);
+
+  // CHECK: [[T5:%.*]] = load i64, ptr @li_w
+  // CHECK-NEXT: add i64 [[T5]], 1
+  opaquelong(++li_w);
 }
 
 // CHECK-LABEL: define{{.*}} void @testintadd()
@@ -76,6 +102,11 @@ void testintadd(void) {
   // CHECK-NEXT: [[T5:%.*]] = extractvalue { i32, i1 } [[T3]], 1
   // CHECK:      call void @__ubsan_handle_add_overflow
   ii = ij + ik;
+
+  // CHECK: [[T6:%.*]] = load i32, ptr @ij_w
+  // CHECK-NEXT: [[T7:%.*]] = load i32, ptr @ik_w
+  // CHECK-NEXT: add i32 [[T6]], [[T7]]
+  ii_w = ij_w + ik_w;
 }
 
 // CHECK-LABEL: define{{.*}} void @testintsub()
@@ -88,6 +119,11 @@ void testintsub(void) {
   // CHECK-NEXT: [[T5:%.*]] = extractvalue { i32, i1 } [[T3]], 1
   // CHECK:      call void @__ubsan_handle_sub_overflow
   ii = ij - ik;
+
+  // CHECK: [[T6:%.*]] = load i32, ptr @ij_w
+  // CHECK-NEXT: [[T7:%.*]] = load i32, ptr @ik_w
+  // CHECK-NEXT: sub i32 [[T6]], [[T7]]
+  ii_w = ij_w - ik_w;
 }
 
 // CHECK-LABEL: define{{.*}} void @testintmul()
@@ -100,26 +136,37 @@ void testintmul(void) {
   // CHECK-NEXT: [[T5:%.*]] = extractvalue { i32, i1 } [[T3]], 1
   // CHECK:      call void @__ubsan_handle_mul_overflow
   ii = ij * ik;
+
+  // CHECK: [[T6:%.*]] = load i32, ptr @ij_w
+  // CHECK-NEXT: [[T7:%.*]] = load i32, ptr @ik_w
+  // CHECK-NEXT: mul i32 [[T6]], [[T7]]
+  ii_w = ij_w * ik_w;
 }
 
 // CHECK-LABEL: define{{.*}} void @testintpostinc()
 void testintpostinc(void) {
-  opaqueint(ii++);
-
   // CHECK:      [[T1:%.*]] = load i32, ptr @ii
   // CHECK-NEXT: [[T2:%.*]] = call { i32, i1 } @llvm.uadd.with.overflow.i32(i32 [[T1]], i32 1)
   // CHECK-NEXT: [[T3:%.*]] = extractvalue { i32, i1 } [[T2]], 0
   // CHECK-NEXT: [[T4:%.*]] = extractvalue { i32, i1 } [[T2]], 1
   // CHECK:      call void @__ubsan_handle_add_overflow
+  opaqueint(ii++);
+
+  // CHECK: [[T5:%.*]] = load i32, ptr @ii_w
+  // CHECK-NEXT: add i32 [[T5]], 1
+  opaqueint(ii_w++);
 }
 
 // CHECK-LABEL: define{{.*}} void @testintpreinc()
 void testintpreinc(void) {
-  opaqueint(++ii);
-
   // CHECK:      [[T1:%.*]] = load i32, ptr @ii
   // CHECK-NEXT: [[T2:%.*]] = call { i32, i1 } @llvm.uadd.with.overflow.i32(i32 [[T1]], i32 1)
   // CHECK-NEXT: [[T3:%.*]] = extractvalue { i32, i1 } [[T2]], 0
   // CHECK-NEXT: [[T4:%.*]] = extractvalue { i32, i1 } [[T2]], 1
   // CHECK:      call void @__ubsan_handle_add_overflow
+  opaqueint(++ii);
+
+  // CHECK: [[T5:%.*]] = load i32, ptr @ii_w
+  // CHECK-NEXT: add i32 [[T5]], 1
+  opaqueint(++ii_w);
 }

--- a/clang/test/Misc/pragma-attribute-supported-attributes-list.test
+++ b/clang/test/Misc/pragma-attribute-supported-attributes-list.test
@@ -216,6 +216,7 @@
 // CHECK-NEXT: WebAssemblyImportModule (SubjectMatchRule_function)
 // CHECK-NEXT: WebAssemblyImportName (SubjectMatchRule_function)
 // CHECK-NEXT: WorkGroupSizeHint (SubjectMatchRule_function)
+// CHECK-NEXT: Wraps (SubjectMatchRule_variable, SubjectMatchRule_type_alias, SubjectMatchRule_field)
 // CHECK-NEXT: XRayInstrument (SubjectMatchRule_function, SubjectMatchRule_objc_method)
 // CHECK-NEXT: XRayLogArgs (SubjectMatchRule_function, SubjectMatchRule_objc_method)
 // CHECK-NEXT: ZeroCallUsedRegs (SubjectMatchRule_function)

--- a/clang/test/Sema/attr-wraps.c
+++ b/clang/test/Sema/attr-wraps.c
@@ -1,0 +1,43 @@
+// RUN: %clang_cc1 %s -verify -fsyntax-only -triple x86_64-pc-linux-gnu
+typedef int __attribute__((wraps)) wrapping_int;
+typedef unsigned __attribute__((wraps)) wrapping_u32;
+
+int implicit_truncation(void) {
+  const wrapping_int A = 1;
+  return 2147483647 + A; // no warning
+}
+
+struct R {
+  wrapping_int a: 2; // test bitfield sign change -- no warning
+  wrapping_u32 b: 1; // test bitfield overflow/truncation -- no warning
+  int baseline: 2; // baseline, should warn
+};
+
+void bitfields_truncation(void) {
+  struct R r;
+  r.a = 2; // this value changes from 2 to -2
+  ++r.a;
+
+  r.b = 2; // changes from 2 to 0
+  ++r.b;
+
+  // expected-warning@+1 {{to bit-field changes value from}}
+  r.baseline = 2;
+}
+
+extern void implicitly_discards_wraps_attribute(int discards);
+
+int discard_test(void) {
+  wrapping_int A = 1;
+  // expected-warning@+1 {{'wraps' attribute may be implicitly discarded}}
+  implicitly_discards_wraps_attribute(A);
+
+  int B = A; // assignments don't warn right now -- probably too noisy
+  return A; // neither do non-wrapping return types
+}
+
+float useless_wraps_attribute(void) {
+  // expected-warning@+1 {{using attribute 'wraps' with non-integer type}}
+  float __attribute__((wraps)) A = 3.14;
+  return A;
+}


### PR DESCRIPTION
## Intro

This attribute would allow for more granular control over what expressions can emit integer overflow warnings or integer overflow sanitizer errors.

#### Here are some examples:

_copy-pasted from my [RFC.](https://discourse.llvm.org/t/rfc-add-wraps-attribute-for-granular-integer-overflow-handling/77670)_


When compiling with `-fsanitize=signed-integer-overflow,unsigned-integer-overflow`:

```c
typedef int __attribute__((wraps)) wrapping_int;

wrapping_int A = INT_MAX;
++A; /* This will not trigger a runtime sanitizer error */
```

```c
unsigned long addr __attribute__((wraps)); /* wraps can be added to variables */
unsigned long size; /* both operands don't need wraps, just one */
...
if (addr + size < addr) {
  // handle overflow gracefully, because the overflow sanitizer won't trip
}
...
```

```c
typedef int __attribute__((wraps)) wrapping_int;

int a = (wrapping_int) INT_MAX + 1; // no sanitizer trip (or -Winteger-overflow)
```

The next few examples will show some cases where sanitizers will still trip (by design):

```c
wrapping_int A = INT_MAX;
int B = 1;

A = INT_MAX + 1; // overflow sanitizer trips! (INT_MAX + 1) is computed and trips the sanitizer before assignment to A

B = (INT_MAX+B) * A; // overflow sanitizer trips!

B =  INT_MAX + B * A; // overflow sanitizer does NOT trip!
// This is because B * A is computed first, the result type carries the wraps attribute
// with it from A, then that result is used in summation with INT_MAX.
```

## Reasoning
The root cause of many security vulnerabilities in the Linux kernel is [arithmetic overflow](https://cwe.mitre.org/data/definitions/190.html). 

The currently available choices to control arithmetic overflow behavior are very limited. The instrumentation is "all or nothing" which lacks the granularity required for many cases.

Enabling or disabling a sanitizer like ``-fsanitize=unsigned-integer-overflow`` completely opts you in or out of instrumentation for __all__ unsigned arithmetic. For functions where intentional wrap-around is performed you could use ``__attribute__((no_sanitize("unsigned-integer-overflow")))`` to completely disable sanitizer instrumentation. This, however, is not ideal if your function is large and multi-purposed -- perhaps even containing loads of arithmetic that you don't want to disable instrumentation for. Getting more granular, we have compiler built-ins like ``__builtin_add_overflow()`` or similar. However, in some codebases, refactoring existing arithmetic to utilize these overflow builtins may only serve to complicate code. For example, the Linux Kernel has, like lots of other projects, some agreed upon idioms which are understood by its developers and changing these patterns is [frowned upon](https://lore.kernel.org/all/CAHk-=whS7FSbBoo1gxe+83twO2JeGNsUKMhAcfWymw9auqBvjg@mail.gmail.com):


"if there's some unsigned wrap-around checker that doesn't
understand this traditional way of doing overflow checking, that piece
of crap needs fixing." - Linus 


This was in response to a patch that was trying to change the commonly accepted idiom: `base + offset < base` to utilize a builtin (via a macro) to silence sanitizer errors.

Recently, there's been some effort by Kees, myself and others to reintroduce the signed and unsigned integer overflow sanitizers in the Linux Kernel. Upon turning these sanitizers back on (or for the case of signed-integer-overflow, [making it work at all](https://github.com/llvm/llvm-project/pull/82432)) we encountered plently of existing instances of integer overflow in the Kernel. However, there's some pushback when trying to alter the "traditional" way of doing things.

With this new wrapping attribute we can specifically craft types that disable overflow instrumentation, without modifying traditional and widely understood code patterns -- resulting in easier to read code.

### To summarize the behavior:

Using ``__attribute__((wraps))`` on a typedef or variable declaration makes it a "wrapping" type or variable thereby disabling overflow instrumentation for either 1) arithmetic performed directly on wrapping variables or types or 2) arithmetic performed on the result of calculations containing a wrapping variable or type. Instrumentation is not disabled for calculations containing subexpressions wherein no wrapping variables are present.

... and also, implicit-(un)signed-integer-truncation sanitizers and warnings are turned off for wrapping types/declarations (since [6794e45](https://github.com/llvm/llvm-project/pull/86618/commits/6794e45c63a396c18707e10f20a12d36a775457a))

```c
typedef int __attribute__((wraps)) wrapping_int;

int main() {
  wrapping_int A = 2147483648; // no truncation warning!
}
```


## Other Notes

* ~``[[wraps]]`` and ``[[clang::wraps]]`` are supported for C++11~ - not since [0f7e8c9](https://github.com/llvm/llvm-project/pull/86618/commits/0f7e8c96cd197dc273c19b071f98e41fd9185b26)

* The wraps attribute cannot be applied to functions

* The wraps attribute _can_ be applied to member variables

* Constant expressions containing a wrapping type or variable should not result in `-Winteger-overflow` warnings either.

### CCs
@kees @nickdesaulniers @bwendling @erichkeane @haoNoQ @apple-fcloutier @FlashSheridan 


