### PR TITLE
[AArch64] set MaxInterleaveFactor to 4 for NeoverseV2

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64Subtarget.cpp
+++ b/llvm/lib/Target/AArch64/AArch64Subtarget.cpp
@@ -240,6 +240,7 @@ void AArch64Subtarget::initializeProperties(bool HasMinSize) {
     PrefLoopAlignment = Align(32);
     MaxBytesForLoopAlignment = 16;
     VScaleForTuning = 1;
+    MaxInterleaveFactor = 4;
     break;
   case NeoverseV1:
     PrefFunctionAlignment = Align(16);


### PR DESCRIPTION
Set MaxInterleaveFactor to 4 for NeoverseV2 which has 4 SIMD pipelines.