### PR TITLE
[mlir][Interfaces] `ValueBoundsConstraintSet`: Add `dump` helper function

### DIFF
--- a/mlir/include/mlir/Interfaces/ValueBoundsOpInterface.h
+++ b/mlir/include/mlir/Interfaces/ValueBoundsOpInterface.h
@@ -259,6 +259,10 @@ public:
   /// Return an expression that represents a constant.
   AffineExpr getExpr(int64_t constant);
 
+  /// Debugging only: Dump the constraint set and the column-to-value/dim
+  /// mapping to llvm::errs.
+  void dump() const;
+
 protected:
   /// Dimension identifier to indicate a value is index-typed. This is used for
   /// internal data structures/API only.

--- a/mlir/lib/Interfaces/ValueBoundsOpInterface.cpp
+++ b/mlir/lib/Interfaces/ValueBoundsOpInterface.cpp
@@ -715,6 +715,35 @@ ValueBoundsConstraintSet::areEquivalentSlices(MLIRContext *ctx,
   return true;
 }
 
+void ValueBoundsConstraintSet::dump() const {
+  llvm::errs() << "==========\nColumns:\n";
+  llvm::errs() << "(column\tdim\tvalue)\n";
+  for (auto [index, valueDim] : llvm::enumerate(positionToValueDim)) {
+    llvm::errs() << " " << index << "\t";
+    if (valueDim) {
+      if (valueDim->second == kIndexValue) {
+        llvm::errs() << "n/a\t";
+      } else {
+        llvm::errs() << valueDim->second << "\t";
+      }
+      llvm::errs() << getOwnerOfValue(valueDim->first)->getName() << " ";
+      if (OpResult result = dyn_cast<OpResult>(valueDim->first)) {
+        llvm::errs() << "(result " << result.getResultNumber() << ")";
+      } else {
+        llvm::errs() << "(bbarg "
+                     << cast<BlockArgument>(valueDim->first).getArgNumber()
+                     << ")";
+      }
+      llvm::errs() << "\n";
+    } else {
+      llvm::errs() << "n/a\tn/a\n";
+    }
+  }
+  llvm::errs() << "\nConstraint set:\n";
+  cstr.dump();
+  llvm::errs() << "==========\n";
+}
+
 ValueBoundsConstraintSet::BoundBuilder &
 ValueBoundsConstraintSet::BoundBuilder::operator[](int64_t dim) {
   assert(!this->dim.has_value() && "dim was already set");


### PR DESCRIPTION
This commit adds a helper function that dumps the constraint set and the mapping of columns to values/dims. For debugging only.

Example output:
```
==========
Columns:
(column	dim	value)
 0	1	linalg.fill (result 0)
 1	1	tensor.extract_slice (result 0)
 2	n/a	affine.min (result 0)
 3	n/a	scf.for (bbarg 0)
 4	n/a	func.func (bbarg 2)

Constraint set:
Domain: 0, Range: 1, Symbols: 4, Locals: 0
6 constraints
(None	None	None	None	None	const)
 1	-1	0	0	0	0	= 0
 0	1	-1	0	0	0	= 0
 0	0	-1	-1	1	0	>= 0
 0	0	-1	0	0	4	>= 0
 0	0	0	1	0	0	>= 0
 0	0	0	-1	1	-1	>= 0
==========
```