### PR TITLE
[TableGen][SchedMachineModel] Improve way to create WriteLatencyTable.

### DIFF
--- a/llvm/utils/TableGen/Common/CodeGenSchedule.cpp
+++ b/llvm/utils/TableGen/Common/CodeGenSchedule.cpp
@@ -746,14 +746,13 @@ unsigned CodeGenSchedModels::getSchedRWIdx(const Record *Def,
   return I == RWVec.end() ? 0 : std::distance(RWVec.begin(), I);
 }
 
-bool CodeGenSchedModels::hasReadOfWrite(Record *WriteDef) const {
-  for (auto &ProcModel : ProcModels) {
-    const RecVec &RADefs = ProcModel.ReadAdvanceDefs;
-    for (auto &RADef : RADefs) {
-      RecVec ValidWrites = RADef->getValueAsListOfDefs("ValidWrites");
-      if (is_contained(ValidWrites, WriteDef))
-        return true;
-    }
+bool CodeGenSchedModels::hasReadOfWrite(
+    const Record *WriteDef, const CodeGenProcModel &ProcModel) const {
+  const RecVec &RADefs = ProcModel.ReadAdvanceDefs;
+  for (auto &RADef : RADefs) {
+    RecVec ValidWrites = RADef->getValueAsListOfDefs("ValidWrites");
+    if (is_contained(ValidWrites, WriteDef))
+      return true;
   }
   return false;
 }

--- a/llvm/utils/TableGen/Common/CodeGenSchedule.h
+++ b/llvm/utils/TableGen/Common/CodeGenSchedule.h
@@ -537,7 +537,8 @@ public:
   unsigned getSchedRWIdx(const Record *Def, bool IsRead) const;
 
   // Return true if the given write record is referenced by a ReadAdvance.
-  bool hasReadOfWrite(Record *WriteDef) const;
+  bool hasReadOfWrite(const Record *WriteDef,
+                      const CodeGenProcModel &ProcModel) const;
 
   // Get a SchedClass from its index.
   CodeGenSchedClass &getSchedClass(unsigned Idx) {

--- a/llvm/utils/TableGen/SubtargetEmitter.cpp
+++ b/llvm/utils/TableGen/SubtargetEmitter.cpp
@@ -1122,8 +1122,8 @@ void SubtargetEmitter::GenSchedClassTables(const CodeGenProcModel &ProcModel,
       WriterNames.push_back(SchedModels.getSchedWrite(WriteID).Name);
       // If this Write is not referenced by a ReadAdvance, don't distinguish it
       // from other WriteLatency entries.
-      if (!SchedModels.hasReadOfWrite(
-              SchedModels.getSchedWrite(WriteID).TheDef)) {
+      if (!SchedModels.hasReadOfWrite(SchedModels.getSchedWrite(WriteID).TheDef,
+                                      ProcModel)) {
         WriteID = 0;
       }
       WLEntry.WriteResourceID = WriteID;


### PR DESCRIPTION
Tablegen will generate xxxWriteLatencyTable to record the
latency information for schedule class in xxxGenSubtargetInfo.inc,
and element in latency table is {Cycles, WriteResourceID}, each
target may have multiple processors using different SchedModels,
and WriteResourceId will not zero if any of SchedModel define
ReadAdvance that its ValidWrites includes SchedWrite
(as the old hasReadOfWrite function does).

Use the new method(Only use currect ProcModel) to check if we
hasReadWrite doesn't affect the usage of LatencyTable, and it
has two good points:
1. It doesn't need traverse all the ProcModels
2. It may generate simpler latency table with less elements.
