### PR TITLE
[libc] Remove LIBC_HAS_ATTRIBUTE macro

### DIFF
--- a/libc/src/__support/macros/config.h
+++ b/libc/src/__support/macros/config.h
@@ -39,12 +39,4 @@
 #define LIBC_HAS_FEATURE(f) 0
 #endif
 
-// Compiler attribute-detection.
-// https://clang.llvm.org/docs/LanguageExtensions.html#has-attribute
-#ifdef __has_attribute
-#define LIBC_HAS_ATTRIBUTE(f) __has_attribute(f)
-#else
-#define LIBC_HAS_ATTRIBUTE(f) 0
-#endif
-
 #endif // LLVM_LIBC_SRC___SUPPORT_MACROS_CONFIG_H

--- a/libc/test/src/__support/arg_list_test.cpp
+++ b/libc/test/src/__support/arg_list_test.cpp
@@ -120,7 +120,7 @@ TEST(LlvmLibcArgListTest, TestStructTypes) {
 }
 
 // Test vector extensions from clang.
-#if LIBC_HAS_ATTRIBUTE(ext_vector_type)
+#if __has_attribute(ext_vector_type)
 
 using int1 = int __attribute__((ext_vector_type(1)));
 using int2 = int __attribute__((ext_vector_type(2)));


### PR DESCRIPTION
Resolves #86547 

Replace occurrences of the macro `LIBC_HAS_ATTRIBUTE` with `__has_attribute`.