### PR TITLE
[libc++] Switch FreeBSD to C++26

### DIFF
--- a/libcxx/utils/ci/buildkite-pipeline.yml
+++ b/libcxx/utils/ci/buildkite-pipeline.yml
@@ -207,7 +207,7 @@ steps:
 - group: ':freebsd: FreeBSD'
   steps:
   - label: FreeBSD 13 amd64
-    command: libcxx/utils/ci/run-buildbot generic-cxx23
+    command: libcxx/utils/ci/run-buildbot generic-cxx26
     env:
       CC: clang17
       CXX: clang++17


### PR DESCRIPTION
As discussed in #86320; opening this PR for CI.

It looks like (prior to this change) there are no C++26 jobs right now.