### PR TITLE
[libc] Add inf/nan tests for strfrom*() functions

### DIFF
--- a/libc/test/src/stdlib/CMakeLists.txt
+++ b/libc/test/src/stdlib/CMakeLists.txt
@@ -174,6 +174,7 @@ add_header_library(
   StrfromTest.h
   DEPENDS
   libc.src.__support.CPP.type_traits
+  libc.src.__support.FPUtil.fp_bits
 )
 
 add_libc_test(


### PR DESCRIPTION
Adds tests for `inf` and `nan` values to the tests for `strfrom*()` functions.

Also marks some variables as `[[maybe_unused]]` to silence unused variable warnings.