### PR TITLE
[unittests] Fix `TableGenTests` with `LLVM_LINK_LLVM_DYLIB`

### DIFF
--- a/llvm/unittests/TableGen/CMakeLists.txt
+++ b/llvm/unittests/TableGen/CMakeLists.txt
@@ -9,7 +9,7 @@ tablegen(LLVM AutomataTables.inc -gen-searchable-tables)
 tablegen(LLVM AutomataAutomata.inc -gen-automata)
 add_public_tablegen_target(AutomataTestTableGen)
 
-add_llvm_unittest(TableGenTests DISABLE_LLVM_LINK_LLVM_DYLIB
+add_llvm_unittest(TableGenTests
   AutomataTest.cpp
   CodeExpanderTest.cpp
   ParserEntryPointTest.cpp


### PR DESCRIPTION
Since the restructuring in commit fa3d789df1, the option `DISABLE_LLVM_LINK_LLVM_DYLIB` is counter-productive and leads to
```
CommandLine Error: Option 'debug-counter' registered more than once!
```