### PR TITLE
[ArithToSPIRV] Fix a warning

### DIFF
--- a/mlir/lib/Conversion/ArithToSPIRV/ArithToSPIRV.cpp
+++ b/mlir/lib/Conversion/ArithToSPIRV/ArithToSPIRV.cpp
@@ -992,7 +992,6 @@ public:
       return failure();
 
     Location loc = op.getLoc();
-    auto *converter = getTypeConverter<SPIRVTypeConverter>();
 
     Value replace;
     if (bitEnumContainsAll(op.getFastmath(), arith::FastMathFlags::nnan)) {


### PR DESCRIPTION
  mlir/lib/Conversion/ArithToSPIRV/ArithToSPIRV.cpp:995:11: error:
  unused variable 'converter' [-Werror,-Wunused-variable]
