### PR TITLE
[libc] Remove definition of LIBC_NAMESPACE in test

### DIFF
--- a/libc/test/src/math/smoke/CanonicalizeTest.h
+++ b/libc/test/src/math/smoke/CanonicalizeTest.h
@@ -22,8 +22,6 @@
 
 #define TEST_REGULAR(x, y, expected) TEST_SPECIAL(x, y, expected, 0)
 
-#define LIBC_NAMESPACE __llvm_libc_19_0_0_git
-
 template <typename T>
 class CanonicalizeTest : public LIBC_NAMESPACE::testing::Test {
 


### PR DESCRIPTION
The canonicalize test added in #85940 defined the LIBC_NAMESPACE macro.
this macro is intended to be set only by the build system and never in
the code.
