### PR TITLE
[bazel] Remove -lm on macOS

### DIFF
--- a/utils/bazel/llvm-project-overlay/llvm/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/llvm/BUILD.bazel
@@ -292,6 +292,10 @@ cc_library(
             "-ldl",
             "-lm",
         ],
+        "@platforms//os:macos": [
+            "-pthread",
+            "-ldl",
+        ],
         "//conditions:default": [
             "-pthread",
             "-ldl",


### PR DESCRIPTION
Bazel links this library by default which leads to this linker warning on macOS:

```
ld: warning: ignoring duplicate libraries: '-lm'
```