### PR TITLE
[flang] Dodge bogus GCC 13.2.0 error message in new code

### DIFF
--- a/flang/include/flang/Parser/parse-tree.h
+++ b/flang/include/flang/Parser/parse-tree.h
@@ -3317,7 +3317,7 @@ struct CompilerDirective {
     TUPLE_CLASS_BOILERPLATE(NameValue);
     std::tuple<Name, std::optional<std::uint64_t>> t;
   };
-  struct Unrecognized {};
+  EMPTY_CLASS(Unrecognized);
   CharBlock source;
   std::variant<std::list<IgnoreTKR>, LoopCount, std::list<AssumeAligned>,
       std::list<NameValue>, Unrecognized>

--- a/flang/lib/Parser/Fortran-parsers.cpp
+++ b/flang/lib/Parser/Fortran-parsers.cpp
@@ -1280,9 +1280,8 @@ TYPE_PARSER(beginDirective >> "DIR$ "_tok >>
                     many(construct<CompilerDirective::NameValue>(
                         name, maybe(("="_tok || ":"_tok) >> digitString64))))) /
             endOfStmt ||
-        construct<CompilerDirective>(
-            SkipTo<'\n'>{} >> pure<CompilerDirective::Unrecognized>()) /
-            endOfStmt))
+        construct<CompilerDirective>(pure<CompilerDirective::Unrecognized>()) /
+            SkipTo<'\n'>{}))
 
 TYPE_PARSER(extension<LanguageFeature::CrayPointer>(
     "nonstandard usage: based POINTER"_port_en_US,


### PR DESCRIPTION
Rearrange some new code a little bit to avoid a bogus error message coming out from GCC 13.2.0 about an uninitialized data member in a parser.