### PR TITLE
[FuzzMutate] Fix optional cast after musttail call

### DIFF
--- a/llvm/lib/FuzzMutate/IRMutator.cpp
+++ b/llvm/lib/FuzzMutate/IRMutator.cpp
@@ -116,7 +116,10 @@ InjectorIRStrategy::chooseOperation(Value *Src, RandomIRBuilder &IB) {
 
 static inline iterator_range<BasicBlock::iterator>
 getInsertionRange(BasicBlock &BB) {
-  auto End = BB.getTerminatingMustTailCall() ? std::prev(BB.end()) : BB.end();
+  auto End = BB.end();
+  if (auto MTC = BB.getTerminatingMustTailCall()) {
+    End = MTC->getIterator();
+  }
   return make_range(BB.getFirstInsertionPt(), End);
 }
 

--- a/llvm/unittests/FuzzMutate/StrategiesTest.cpp
+++ b/llvm/unittests/FuzzMutate/StrategiesTest.cpp
@@ -141,6 +141,19 @@ TEST(InjectorIRStrategyTest, InsertWMustTailCall) {
   mutateAndVerifyModule(Source, Mutator, 100);
 }
 
+TEST(InjectorIRStrategyTest, InsertWMustTailCallCast) {
+  StringRef Source = "\n\
+        define i1 @recursive() {    \n\
+        Entry:     \n\
+            %Ret = musttail call i1 @recursive() \n\
+            %Cast = bitcast i1 %Ret to i1 \n\
+            ret i1 %Cast \n\
+        }";
+  auto Mutator = createInjectorMutator();
+  ASSERT_TRUE(Mutator);
+  mutateAndVerifyModule(Source, Mutator, 100);
+}
+
 TEST(InjectorIRStrategyTest, InsertWTailCall) {
   StringRef Source = "\n\
         define i1 @recursive() {    \n\


### PR DESCRIPTION
In the case of a musttail call, an optional cast instruction can be placed between the call instruction and the return. Therefore `getInsertionRange` should take that into account.
