### PR TITLE
[libc][support][FixedVector] add reverse iterator

### DIFF
--- a/libc/src/__support/fixedvector.h
+++ b/libc/src/__support/fixedvector.h
@@ -59,7 +59,9 @@ public:
   static void destroy(FixedVector<T, CAPACITY> *store) { store->reset(); }
 
   using reverse_iterator = typename cpp::array<T, CAPACITY>::reverse_iterator;
-  LIBC_INLINE constexpr reverse_iterator rbegin() { return reverse_iterator{&store[item_count]}; }
+  LIBC_INLINE constexpr reverse_iterator rbegin() {
+    return reverse_iterator{&store[item_count]};
+  }
   LIBC_INLINE constexpr reverse_iterator rend() { return store.rend(); }
 };
 

--- a/libc/src/__support/fixedvector.h
+++ b/libc/src/__support/fixedvector.h
@@ -11,6 +11,8 @@
 
 #include "src/__support/CPP/array.h"
 
+#include "src/__support/CPP/iterator.h"
+
 namespace LIBC_NAMESPACE {
 
 // A fixed size data store backed by an underlying cpp::array data structure. It
@@ -55,6 +57,10 @@ public:
   // matches the `destroy` API of those other data structures so that users
   // can easily swap one data structure for the other.
   static void destroy(FixedVector<T, CAPACITY> *store) { store->reset(); }
+
+  using reverse_iterator = typename cpp::array<T, CAPACITY>::reverse_iterator;
+  LIBC_INLINE constexpr reverse_iterator rbegin() { return reverse_iterator{&store[item_count]}; }
+  LIBC_INLINE constexpr reverse_iterator rend() { return store.rend(); }
 };
 
 } // namespace LIBC_NAMESPACE

--- a/libc/test/src/__support/fixedvector_test.cpp
+++ b/libc/test/src/__support/fixedvector_test.cpp
@@ -43,3 +43,19 @@ TEST(LlvmLibcFixedVectorTest, Destroy) {
   LIBC_NAMESPACE::FixedVector<int, 20>::destroy(&fixed_vector);
   ASSERT_TRUE(fixed_vector.empty());
 }
+
+TEST(LlvmLibcFixedVectorTest, Iteration) {
+  LIBC_NAMESPACE::FixedVector<int, 20> v;
+  for (int i = 0; i < 3; i++)
+    v.push_back(i);
+  auto it = v.rbegin();
+  ASSERT_EQ(*it, 2);
+  ASSERT_EQ(*++it, 1);
+  ASSERT_EQ(*++it, 0);
+  // TODO: need an overload of Test::test for iterators?
+  // ASSERT_EQ(++it, v.rend());
+  // ASSERT_EQ(v.rbegin(), v.rbegin());
+  ASSERT_TRUE(++it == v.rend());
+  for (auto it = v.rbegin(), e = v.rend(); it != e; ++it)
+    ASSERT_GT(*it, -1);
+}

--- a/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
@@ -445,6 +445,7 @@ libc_support_library(
     hdrs = ["src/__support/fixedvector.h"],
     deps = [
         ":__support_cpp_array",
+        ":__support_cpp_iterator",
     ],
 )
 


### PR DESCRIPTION
Critically, we don't want to return an iterator to the end of the underlying
cpp::array "store." Add a test to catch this issue.

This will be used by __cxa_finalize to iterate backwards through a FixedVector.

Link: #85651
