### PR TITLE
[compiler-rt] Allow building builtins.a without a libc

### DIFF
--- a/compiler-rt/cmake/config-ix.cmake
+++ b/compiler-rt/cmake/config-ix.cmake
@@ -235,9 +235,9 @@ set(COMPILER_RT_SUPPORTED_ARCH)
 # Try to compile a very simple source file to ensure we can target the given
 # platform. We use the results of these tests to build only the various target
 # runtime libraries supported by our current compilers cross-compiling
-# abilities.
+# abilities. Avoids using libc as that may not be available yet.
 set(SIMPLE_SOURCE ${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/simple.cc)
-file(WRITE ${SIMPLE_SOURCE} "#include <stdlib.h>\n#include <stdio.h>\nint main(void) { printf(\"hello, world\"); }\n")
+file(WRITE ${SIMPLE_SOURCE} "int main(void) { return 0; }\n")
 
 # Detect whether the current target platform is 32-bit or 64-bit, and setup
 # the correct commandline flags needed to attempt to target 32-bit and 64-bit.


### PR DESCRIPTION
compiler-rt may depend on libc (memset etc). Likewise a libc built by clang may depend on compiler-rt builtins.

This circular dependency doesn't matter much once they're both compiled. The easy compilation order to build both from source is:

1. install libc headers somewhere
2. build compiler-rt builtins against those headers
3. build libc against compiler-rt builtins

This patch relaxes the cmake sanity check to pass without requiring a libc library. That allows the above sequence to work. Otherwise one needs to build a static libc, then use that to pass the compiler-rt cmake check, then build a normal libc. 


