### PR TITLE
[hwasan] Don't instrument when PGO profile is collected

### DIFF
--- a/clang/lib/CodeGen/BackendUtil.cpp
+++ b/clang/lib/CodeGen/BackendUtil.cpp
@@ -717,8 +717,11 @@ static void addSanitizers(const Triple &TargetTriple,
                                          DestructorKind));
       }
     };
-    ASanPass(SanitizerKind::Address, false);
-    ASanPass(SanitizerKind::KernelAddress, true);
+    // Don't slow down already slow `ProfileIRInstr` binary.
+    if (!CodeGenOpts.hasProfileIRInstr()) {
+      ASanPass(SanitizerKind::Address, false);
+      ASanPass(SanitizerKind::KernelAddress, true);
+    }
 
     auto HWASanPass = [&](SanitizerMask Mask, bool CompileKernel) {
       if (LangOpts.Sanitize.has(Mask)) {
@@ -728,8 +731,11 @@ static void addSanitizers(const Triple &TargetTriple,
              /*DisableOptimization=*/CodeGenOpts.OptimizationLevel == 0}));
       }
     };
-    HWASanPass(SanitizerKind::HWAddress, false);
-    HWASanPass(SanitizerKind::KernelHWAddress, true);
+    // Don't slow down already slow `ProfileIRInstr` binary.
+    if (!CodeGenOpts.hasProfileIRInstr()) {
+      HWASanPass(SanitizerKind::HWAddress, false);
+      HWASanPass(SanitizerKind::KernelHWAddress, true);
+    }
 
     if (LangOpts.Sanitize.has(SanitizerKind::DataFlow)) {
       MPM.addPass(DataFlowSanitizerPass(LangOpts.NoSanitizeFiles));

--- a/clang/test/CodeGen/asan-new-pm.ll
+++ b/clang/test/CodeGen/asan-new-pm.ll
@@ -1,6 +1,12 @@
 ; Test that ASan runs with the new pass manager
 ; RUN: %clang_cc1 -triple x86_64-unknown-unknown -S -emit-llvm -o - -fsanitize=address %s | FileCheck %s
-; RUN: %clang_cc1 -triple x86_64-unknown-unknown -S -emit-llvm -o - -O1 -fsanitize=address %s | FileCheck %s
+; RUN: %clang_cc1 -triple x86_64-unknown-unknown -S -emit-llvm -o - -fsanitize=address -O1 %s | FileCheck %s
+
+; RUN: %clang_cc1 -triple x86_64-unknown-unknown -S -emit-llvm -o - -fsanitize=address -fprofile-instrument=llvm %s | FileCheck %s -check-prefixes=NOASAN
+; RUN: %clang_cc1 -triple x86_64-unknown-unknown -S -emit-llvm -o - -fsanitize=address -fprofile-instrument=llvm -O1 %s | FileCheck %s -check-prefixes=NOASAN
+
+; RUN: %clang_cc1 -triple x86_64-unknown-unknown -S -emit-llvm -o - -fsanitize=address -fprofile-instrument=clang %s | FileCheck %s
+; RUN: %clang_cc1 -triple x86_64-unknown-unknown -S -emit-llvm -o - -fsanitize=address -fprofile-instrument=clang -O1 %s | FileCheck %s
 
 ; CHECK-DAG: @llvm.global_ctors = {{.*}}@asan.module_ctor
 
@@ -20,3 +26,4 @@ entry:
 
 ; CHECK-DAG: __asan_version_mismatch_check_v8
 
+; NOASAN-NOT: __asan

--- a/clang/test/CodeGen/hwasan-new-pm.c
+++ b/clang/test/CodeGen/hwasan-new-pm.c
@@ -3,12 +3,30 @@
 // being instrumented properly.
 
 // RUN: %clang_cc1 -triple x86_64-linux-gnu -S -emit-llvm -o - -fsanitize=hwaddress %s | FileCheck %s
-// RUN: %clang_cc1 -triple x86_64-linux-gnu -S -emit-llvm -o - -O1 -fsanitize=hwaddress %s | FileCheck %s
+// RUN: %clang_cc1 -triple x86_64-linux-gnu -S -emit-llvm -o - -fsanitize=hwaddress -O1 %s | FileCheck %s
+
+// Don't instrument when collecting profiles, to avoid additional slowdown of slow `profile-instrument` binary.
+// RUN: %clang_cc1 -triple x86_64-linux-gnu -S -emit-llvm -o - -fsanitize=hwaddress -fprofile-instrument=llvm %s | FileCheck %s -check-prefixes=NOHWASAN
+// RUN: %clang_cc1 -triple x86_64-linux-gnu -S -emit-llvm -o - -fsanitize=hwaddress -fprofile-instrument=llvm -O1 %s | FileCheck %s -check-prefixes=NOHWASAN
+
+// Nothing special is done for clang PGO.
+// RUN: %clang_cc1 -triple x86_64-linux-gnu -S -emit-llvm -o - -fsanitize=hwaddress -fprofile-instrument=clang %s | FileCheck %s
+// RUN: %clang_cc1 -triple x86_64-linux-gnu -S -emit-llvm -o - -fsanitize=hwaddress -fprofile-instrument=clang -O1 %s | FileCheck %s
 
 // RUN: %clang_cc1 -triple x86_64-linux-gnu -S -emit-llvm -o - -fsanitize=kernel-hwaddress %s | FileCheck %s
-// RUN: %clang_cc1 -triple x86_64-linux-gnu -S -emit-llvm -o - -O1 -fsanitize=kernel-hwaddress %s | FileCheck %s
+// RUN: %clang_cc1 -triple x86_64-linux-gnu -S -emit-llvm -o - -fsanitize=kernel-hwaddress -O1 %s | FileCheck %s
+
+// Don't instrument when collecting profiles, to avoid additional slowdown of slow `profile-instrument` binary.
+// RUN: %clang_cc1 -triple x86_64-linux-gnu -S -emit-llvm -o - -fsanitize=kernel-hwaddress -fprofile-instrument=llvm %s | FileCheck %s -check-prefixes=NOHWASAN
+// RUN: %clang_cc1 -triple x86_64-linux-gnu -S -emit-llvm -o - -fsanitize=kernel-hwaddress -fprofile-instrument=llvm -O1 %s | FileCheck %s -check-prefixes=NOHWASAN
+
+// Nothing special is done for clang PGO.
+// RUN: %clang_cc1 -triple x86_64-linux-gnu -S -emit-llvm -o - -fsanitize=kernel-hwaddress -fprofile-instrument=clang %s | FileCheck %s
+// RUN: %clang_cc1 -triple x86_64-linux-gnu -S -emit-llvm -o - -fsanitize=kernel-hwaddress -fprofile-instrument=clang -O1 %s | FileCheck %s
 
 int foo(int *a) { return *a; }
 
 // All the cases above mark the function with sanitize_hwaddress.
 // CHECK: sanitize_hwaddress
+// CHECK: declare void @__hwasan_
+// NOHWASAN-NOT: __hwasan


### PR DESCRIPTION
We can't do that for msan, dfsan, and probably tsan as they may
be linked with pre-instrumented binary.

Probably we can disable SanitizerCoveragePass and SanitizerBinaryMetadataPass,
but they are not expensive enough to justify diverging pipeline.