### PR TITLE
[clang][ExprConst] Fix second arg of __builtin_{clzg,ctzg} not always being evaluated

### DIFF
--- a/clang/lib/AST/ExprConstant.cpp
+++ b/clang/lib/AST/ExprConstant.cpp
@@ -12361,12 +12361,17 @@ bool IntExprEvaluator::VisitBuiltinCallExpr(const CallExpr *E,
     if (!EvaluateInteger(E->getArg(0), Val, Info))
       return false;
 
+    std::optional<APSInt> Fallback;
+    if (BuiltinOp == Builtin::BI__builtin_clzg && E->getNumArgs() > 1) {
+      APSInt FallbackTemp;
+      if (!EvaluateInteger(E->getArg(1), FallbackTemp, Info))
+        return false;
+      Fallback = FallbackTemp;
+    }
+
     if (!Val) {
-      if (BuiltinOp == Builtin::BI__builtin_clzg && E->getNumArgs() > 1) {
-        if (!EvaluateInteger(E->getArg(1), Val, Info))
-          return false;
-        return Success(Val, E);
-      }
+      if (Fallback)
+        return Success(*Fallback, E);
 
       // When the argument is 0, the result of GCC builtins is undefined,
       // whereas for Microsoft intrinsics, the result is the bit-width of the
@@ -12425,12 +12430,17 @@ bool IntExprEvaluator::VisitBuiltinCallExpr(const CallExpr *E,
     if (!EvaluateInteger(E->getArg(0), Val, Info))
       return false;
 
+    std::optional<APSInt> Fallback;
+    if (BuiltinOp == Builtin::BI__builtin_ctzg && E->getNumArgs() > 1) {
+      APSInt FallbackTemp;
+      if (!EvaluateInteger(E->getArg(1), FallbackTemp, Info))
+        return false;
+      Fallback = FallbackTemp;
+    }
+
     if (!Val) {
-      if (BuiltinOp == Builtin::BI__builtin_ctzg && E->getNumArgs() > 1) {
-        if (!EvaluateInteger(E->getArg(1), Val, Info))
-          return false;
-        return Success(Val, E);
-      }
+      if (Fallback)
+        return Success(*Fallback, E);
 
       return Error(E);
     }

--- a/clang/test/Sema/constant-builtins-all-args-evaluated.cpp
+++ b/clang/test/Sema/constant-builtins-all-args-evaluated.cpp
@@ -8,7 +8,7 @@ constexpr int increment(int& x) {
 
 constexpr int test_clzg_0() {
   int x = 0;
-  [[maybe_unused]] int unused = __builtin_clzg(0U, increment(x));
+  (void)__builtin_clzg(0U, increment(x));
   return x;
 }
 
@@ -16,7 +16,7 @@ static_assert(test_clzg_0() == 1);
 
 constexpr int test_clzg_1() {
   int x = 0;
-  [[maybe_unused]] int unused = __builtin_clzg(1U, increment(x));
+  (void)__builtin_clzg(1U, increment(x));
   return x;
 }
 
@@ -24,7 +24,7 @@ static_assert(test_clzg_1() == 1);
 
 constexpr int test_ctzg_0() {
   int x = 0;
-  [[maybe_unused]] int unused = __builtin_ctzg(0U, increment(x));
+  (void)__builtin_ctzg(0U, increment(x));
   return x;
 }
 
@@ -32,7 +32,7 @@ static_assert(test_ctzg_0() == 1);
 
 constexpr int test_ctzg_1() {
   int x = 0;
-  [[maybe_unused]] int unused = __builtin_ctzg(1U, increment(x));
+  (void)__builtin_ctzg(1U, increment(x));
   return x;
 }
 

--- a/clang/test/Sema/constant-builtins-all-args-evaluated.cpp
+++ b/clang/test/Sema/constant-builtins-all-args-evaluated.cpp
@@ -1,0 +1,39 @@
+// RUN: %clang_cc1 -fsyntax-only -verify %s
+// expected-no-diagnostics
+
+constexpr int increment(int& x) {
+  x++;
+  return x;
+}
+
+constexpr int test_clzg_0() {
+  int x = 0;
+  [[maybe_unused]] int unused = __builtin_clzg(0U, increment(x));
+  return x;
+}
+
+static_assert(test_clzg_0() == 1);
+
+constexpr int test_clzg_1() {
+  int x = 0;
+  [[maybe_unused]] int unused = __builtin_clzg(1U, increment(x));
+  return x;
+}
+
+static_assert(test_clzg_1() == 1);
+
+constexpr int test_ctzg_0() {
+  int x = 0;
+  [[maybe_unused]] int unused = __builtin_ctzg(0U, increment(x));
+  return x;
+}
+
+static_assert(test_ctzg_0() == 1);
+
+constexpr int test_ctzg_1() {
+  int x = 0;
+  [[maybe_unused]] int unused = __builtin_ctzg(1U, increment(x));
+  return x;
+}
+
+static_assert(test_ctzg_1() == 1);

--- a/clang/test/Sema/constant-builtins-all-args-evaluated.cpp
+++ b/clang/test/Sema/constant-builtins-all-args-evaluated.cpp
@@ -1,14 +1,9 @@
 // RUN: %clang_cc1 -fsyntax-only -verify %s
 // expected-no-diagnostics
 
-constexpr int increment(int& x) {
-  x++;
-  return x;
-}
-
 constexpr int test_clzg_0() {
   int x = 0;
-  (void)__builtin_clzg(0U, increment(x));
+  (void)__builtin_clzg(0U, ++x);
   return x;
 }
 
@@ -16,7 +11,7 @@ static_assert(test_clzg_0() == 1);
 
 constexpr int test_clzg_1() {
   int x = 0;
-  (void)__builtin_clzg(1U, increment(x));
+  (void)__builtin_clzg(1U, ++x);
   return x;
 }
 
@@ -24,7 +19,7 @@ static_assert(test_clzg_1() == 1);
 
 constexpr int test_ctzg_0() {
   int x = 0;
-  (void)__builtin_ctzg(0U, increment(x));
+  (void)__builtin_ctzg(0U, ++x);
   return x;
 }
 
@@ -32,7 +27,7 @@ static_assert(test_ctzg_0() == 1);
 
 constexpr int test_ctzg_1() {
   int x = 0;
-  (void)__builtin_ctzg(1U, increment(x));
+  (void)__builtin_ctzg(1U, ++x);
   return x;
 }
 


### PR DESCRIPTION
See https://github.com/llvm/llvm-project/pull/86577#discussion_r1540069558.

cc @efriedma-quic @nickdesaulniers