### PR TITLE
[workflows] Update the version of the scorecard-action

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -36,7 +36,7 @@ jobs:
           persist-credentials: false
 
       - name: "Run analysis"
-        uses: ossf/scorecard-action@e38b1902ae4f44df626f11ba0734b14fb91f8f86 # v2.1.2
+        uses: ossf/scorecard-action@0864cf19026789058feabb7e87baa5f140aac736 # v2.3.1
         with:
           results_file: results.sarif
           results_format: sarif


### PR DESCRIPTION
I'm hoping this will fix the errors we've been seeing the last few days:

2024-03-19T20:44:07.4841482Z 2024/03/19 20:44:07 error signing scorecard json results: error signing payload: getting key from Fulcio: verifying SCT: updating local metadata and targets: error updating to TUF remote mirror: invalid key