### PR TITLE
[NFC][Clang] Fix potential dereferencing of nullptr

### DIFF
--- a/clang/lib/CodeGen/CGExprComplex.cpp
+++ b/clang/lib/CodeGen/CGExprComplex.cpp
@@ -289,7 +289,7 @@ public:
                                         const BinOpInfo &Op);
 
   QualType GetHigherPrecisionFPType(QualType ElementType) {
-    const auto *CurrentBT = dyn_cast<BuiltinType>(ElementType);
+    const auto *CurrentBT = cast<BuiltinType>(ElementType);
     switch (CurrentBT->getKind()) {
     case BuiltinType::Kind::Float16:
       return CGF.getContext().FloatTy;

--- a/clang/lib/CodeGen/Targets/PPC.cpp
+++ b/clang/lib/CodeGen/Targets/PPC.cpp
@@ -274,7 +274,7 @@ void AIXTargetCodeGenInfo::setTargetAttributes(
   if (!isa<llvm::GlobalVariable>(GV))
     return;
 
-  auto *GVar = dyn_cast<llvm::GlobalVariable>(GV);
+  auto *GVar = cast<llvm::GlobalVariable>(GV);
   auto GVId = GV->getName();
 
   // Is this a global variable specified by the user as toc-data?

--- a/clang/lib/Sema/SemaTemplate.cpp
+++ b/clang/lib/Sema/SemaTemplate.cpp
@@ -2974,7 +2974,7 @@ void DeclareImplicitDeductionGuidesForTypeAlias(
     if (auto *FPrime = SemaRef.InstantiateFunctionDeclaration(
             F, TemplateArgListForBuildingFPrime, AliasTemplate->getLocation(),
             Sema::CodeSynthesisContext::BuildingDeductionGuides)) {
-      auto *GG = dyn_cast<CXXDeductionGuideDecl>(FPrime);
+      auto *GG = cast<CXXDeductionGuideDecl>(FPrime);
       buildDeductionGuide(SemaRef, AliasTemplate, FPrimeTemplateParamList,
                           GG->getCorrespondingConstructor(),
                           GG->getExplicitSpecifier(), GG->getTypeSourceInfo(),


### PR DESCRIPTION
This patch replaces dyn_cast<> with cast<> to resolve potential static analyzer bugs for

1. Dereferencing a pointer issue with nullptr GVar when calling addAttribute() in AIXTargetCodeGenInfo::setTargetAttributes(clang::Decl const *, llvm::GlobalValue *, clang::CodeGen::CodeGenModule &).

2. Dereferencing a pointer issue with nullptr GG when calling getCorrespondingConstructor() in DeclareImplicitDeductionGuidesForTypeAlias(clang::Sema &, clang::TypeAliasTemplateDecl *, clang::SourceLocation).

3. Dereferencing a pointer issue with nullptr CurrentBT when calling getKind() in ComplexExprEmitter::GetHigherPrecisionFPType(clang::QualType).