### PR TITLE
[NFC][CLANG] Fix null pointer dereferences

### DIFF
--- a/clang/lib/Sema/SemaTemplateDeduction.cpp
+++ b/clang/lib/Sema/SemaTemplateDeduction.cpp
@@ -5514,9 +5514,9 @@ FunctionTemplateDecl *Sema::getMoreSpecializedTemplate(
   QualType Obj2Ty;
   if (TPOC == TPOC_Call) {
     const FunctionProtoType *Proto1 =
-        FD1->getType()->getAs<FunctionProtoType>();
+        FD1->getType()->castAs<FunctionProtoType>();
     const FunctionProtoType *Proto2 =
-        FD2->getType()->getAs<FunctionProtoType>();
+        FD2->getType()->castAs<FunctionProtoType>();
 
     //   - In the context of a function call, the function parameter types are
     //     used.


### PR DESCRIPTION
This patch replaces getAs<> with castAs<> to resolve potential static analyzer bugs for

1. Dereferencing Proto1->param_type_begin(), which is known to be nullptr
2. Dereferencing Proto2->param_type_begin(), which is known to be nullptr
3. Dereferencing a pointer issue with nullptr Proto1 when calling param_type_end()
4. Dereferencing a pointer issue with nullptr Proto2 when calling param_type_end()

in clang::Sema::getMoreSpecializedTemplate().