### PR TITLE
[clang-format] Exit clang-format-diff only after all diffs are printed

### DIFF
--- a/clang/tools/clang-format/clang-format-diff.py
+++ b/clang/tools/clang-format/clang-format-diff.py
@@ -138,6 +138,7 @@ def main():
             )
 
     # Reformat files containing changes in place.
+    has_diff = False
     for filename, lines in lines_by_file.items():
         if args.i and args.verbose:
             print("Formatting {}".format(filename))
@@ -169,7 +170,7 @@ def main():
 
         stdout, stderr = p.communicate()
         if p.returncode != 0:
-            sys.exit(p.returncode)
+            return p.returncode
 
         if not args.i:
             with open(filename) as f:
@@ -185,9 +186,12 @@ def main():
             )
             diff_string = "".join(diff)
             if len(diff_string) > 0:
+                has_diff = True
                 sys.stdout.write(diff_string)
-                sys.exit(1)
+
+    if has_diff:
+        return 1
 
 
 if __name__ == "__main__":
-    main()
+    sys.exit(main())


### PR DESCRIPTION
See https://github.com/llvm/llvm-project/pull/70883#issuecomment-2020811077.