### PR TITLE
[Flang] Relaxing an error when contiguous pointer is assigned to a non-contig…

### DIFF
--- a/flang/lib/Semantics/pointer-assignment.cpp
+++ b/flang/lib/Semantics/pointer-assignment.cpp
@@ -266,7 +266,7 @@ bool PointerAssignmentChecker::Check(const evaluate::FunctionRef<T> &f) {
   } else if (isContiguous_ &&
       !funcResult->attrs.test(FunctionResult::Attr::Contiguous)) {
     msg = "CONTIGUOUS %s is associated with the result of reference to"
-          " function '%s' that is not contiguous"_err_en_US;
+          " function '%s' that is not known to be contiguous"_warn_en_US;
   } else if (lhsType_) {
     const auto *frTypeAndShape{funcResult->GetTypeAndShape()};
     CHECK(frTypeAndShape);


### PR DESCRIPTION
…uous function.

Fix from [thtsikas](https://github.com/thtsikas) based on a discussion in [slack](https://flang-compiler.slack.com/archives/C5C58TT32/p1711124374836079).

Example:
```
Program test
  Integer, Pointer, Contiguous :: cont(:)
  Interface
     Function f()
       Integer, Pointer :: f(:)
     End Function
  End Interface
  cont => f()
  Print *, cont(3)
End Program

Function f()
  Integer, Pointer :: f(:)
  Allocate (f(4),Source=[1,1,42,1])
  ! f => f(4:1:-1)        !! not contiguous, runtime error
End Function f
```

Understanding is that the standard intended to allow this pattern. The restriction 10.2.2.3 p6 Data pointer assignment  "If the pointer object has the CONTIGUOUS attribute, the pointer target shall be contiguous." is not associated with a numbered constraint. If there is a mechanism for injecting runtime checks, this would be a place to do it. Absent that, a warning is the best we can do.

No other compiler treats contigPtr => func() as an error when func() is not CONTIGUOUS, so a warning would probably be better for consistency.
https://godbolt.org/z/5cM6roeEE