### PR TITLE
[mlir] Add `requiresReplacedValues` and `visitReplacedValues` to `PromotableOpInterface`

### DIFF
--- a/mlir/include/mlir/Dialect/LLVMIR/LLVMIntrinsicOps.td
+++ b/mlir/include/mlir/Dialect/LLVMIR/LLVMIntrinsicOps.td
@@ -564,7 +564,7 @@ class LLVM_DbgIntrOp<string name, string argName, list<Trait> traits = []>
 
 def LLVM_DbgDeclareOp : LLVM_DbgIntrOp<"dbg.declare", "addr", [
     DeclareOpInterfaceMethods<PromotableOpInterface, [
-      "requiresAmendingMutatedDefs", "amendMutatedDefs"
+      "requiresReplacedValues", "visitReplacedValues"
     ]>]> {
   let summary = "Describes how the address relates to a source language variable.";
   let arguments = (ins

--- a/mlir/include/mlir/Dialect/LLVMIR/LLVMIntrinsicOps.td
+++ b/mlir/include/mlir/Dialect/LLVMIR/LLVMIntrinsicOps.td
@@ -562,8 +562,10 @@ class LLVM_DbgIntrOp<string name, string argName, list<Trait> traits = []>
   }];
 }
 
-def LLVM_DbgDeclareOp : LLVM_DbgIntrOp<"dbg.declare", "addr",
-    [DeclareOpInterfaceMethods<PromotableOpInterface>]> {
+def LLVM_DbgDeclareOp : LLVM_DbgIntrOp<"dbg.declare", "addr", [
+    DeclareOpInterfaceMethods<PromotableOpInterface, [
+      "requiresVisitingMutatedDefs", "visitMutatedDefs"
+    ]>]> {
   let summary = "Describes how the address relates to a source language variable.";
   let arguments = (ins
     LLVM_AnyPointer:$addr,

--- a/mlir/include/mlir/Dialect/LLVMIR/LLVMIntrinsicOps.td
+++ b/mlir/include/mlir/Dialect/LLVMIR/LLVMIntrinsicOps.td
@@ -564,7 +564,7 @@ class LLVM_DbgIntrOp<string name, string argName, list<Trait> traits = []>
 
 def LLVM_DbgDeclareOp : LLVM_DbgIntrOp<"dbg.declare", "addr", [
     DeclareOpInterfaceMethods<PromotableOpInterface, [
-      "requiresVisitingMutatedDefs", "visitMutatedDefs"
+      "requiresAmendingMutatedDefs", "amendMutatedDefs"
     ]>]> {
   let summary = "Describes how the address relates to a source language variable.";
   let arguments = (ins

--- a/mlir/include/mlir/Interfaces/MemorySlotInterfaces.td
+++ b/mlir/include/mlir/Interfaces/MemorySlotInterfaces.td
@@ -229,6 +229,27 @@ def PromotableOpInterface : OpInterface<"PromotableOpInterface"> {
       (ins "const ::llvm::SmallPtrSetImpl<mlir::OpOperand *> &":$blockingUses,
            "::mlir::RewriterBase &":$rewriter)
     >,
+    InterfaceMethod<[{
+        Checks whether the operation requires visiting the mutated
+        definitions by a store operation.
+      }], "bool", "requiresVisitingMutatedDefs", (ins), [{}],
+      [{ return false; }]
+    >,
+    InterfaceMethod<[{
+        Visits all the mutated definitions by a store operation.
+
+        This method will only be called after all blocking issues haven been
+        scheduled for removal and if `requiresVisitingMutatedDefs` returned
+        true.
+
+        The rewriter is located after the promotable operation on call. All IR
+        mutations must happen through the rewriter. During the transformation,
+        *no operation should be deleted*.
+      }],
+      "void", "visitMutatedDefs",
+      (ins "::llvm::ArrayRef<std::pair<::mlir::Operation*, ::mlir::Value>>":$mutatedDefs,
+           "::mlir::RewriterBase &":$rewriter), [{}], [{ return; }]
+    >,
   ];
 }
 

--- a/mlir/include/mlir/Interfaces/MemorySlotInterfaces.td
+++ b/mlir/include/mlir/Interfaces/MemorySlotInterfaces.td
@@ -230,32 +230,32 @@ def PromotableOpInterface : OpInterface<"PromotableOpInterface"> {
            "::mlir::RewriterBase &":$rewriter)
     >,
     InterfaceMethod<[{
-        This method returns whether the promoted operation requires amending the
-        mutated definitions by a store operation.
+        This method allows the promoted operation to visit the SSA values used
+        in place of the memory slot once the promotion process of the memory
+        slot is complete.
 
-        If this method returns true, the operation will be visited using the
-        `amendMutatedDefs` method after the main mutation stage finishes
+        If this method returns true, the `visitReplacedValues` method on this
+        operation will be called after the main mutation stage finishes
         (i.e., after all ops have been processed with `removeBlockingUses`).
 
-        Operations should only request amending the mutated definitions if the
-        intended transformation applies to all mutated values. Furthermore,
-        mutated values must not be deleted.
-      }], "bool", "requiresAmendingMutatedDefs", (ins), [{}],
+        Operations should only the replaced values if the intended
+        transformation applies to all the replaced values. Furthermore, replaced
+        values must not be deleted.
+      }], "bool", "requiresReplacedValues", (ins), [{}],
       [{ return false; }]
     >,
     InterfaceMethod<[{
-        Transforms the IR to amend all the mutated definitions to the slot by a
-        store operation.
+        Transforms the IR using the SSA values that replaced the memory slot.
 
         This method will only be called after all blocking uses have been
-        scheduled for removal and if `requiresAmendingMutatedDefs` returned
+        scheduled for removal and if `requiresReplacedValues` returned
         true.
 
         The rewriter is located after the promotable operation on call. All IR
         mutations must happen through the rewriter. During the transformation,
         *no operation should be deleted*.
       }],
-      "void", "amendMutatedDefs",
+      "void", "visitReplacedValues",
       (ins "::llvm::ArrayRef<std::pair<::mlir::Operation*, ::mlir::Value>>":$mutatedDefs,
            "::mlir::RewriterBase &":$rewriter), [{}], [{ return; }]
     >,

--- a/mlir/include/mlir/Interfaces/MemorySlotInterfaces.td
+++ b/mlir/include/mlir/Interfaces/MemorySlotInterfaces.td
@@ -232,6 +232,9 @@ def PromotableOpInterface : OpInterface<"PromotableOpInterface"> {
     InterfaceMethod<[{
         Checks whether the operation requires visiting the mutated
         definitions by a store operation.
+        If this method returns true, the operation will be visited using the
+        `visitMutatedDefs` method after the main mutation stage finishes
+        (i.e., after all ops have been processed with `removeBlockingUses`).
       }], "bool", "requiresVisitingMutatedDefs", (ins), [{}],
       [{ return false; }]
     >,

--- a/mlir/include/mlir/Interfaces/MemorySlotInterfaces.td
+++ b/mlir/include/mlir/Interfaces/MemorySlotInterfaces.td
@@ -230,26 +230,32 @@ def PromotableOpInterface : OpInterface<"PromotableOpInterface"> {
            "::mlir::RewriterBase &":$rewriter)
     >,
     InterfaceMethod<[{
-        Checks whether the operation requires visiting the mutated
-        definitions by a store operation.
+        This method returns whether the promoted operation requires amending the
+        mutated definitions by a store operation.
+
         If this method returns true, the operation will be visited using the
-        `visitMutatedDefs` method after the main mutation stage finishes
+        `amendMutatedDefs` method after the main mutation stage finishes
         (i.e., after all ops have been processed with `removeBlockingUses`).
-      }], "bool", "requiresVisitingMutatedDefs", (ins), [{}],
+
+        Operations should only request amending the mutated definitions if the
+        intended transformation applies to all mutated values. Furthermore,
+        mutated values must not be deleted.
+      }], "bool", "requiresAmendingMutatedDefs", (ins), [{}],
       [{ return false; }]
     >,
     InterfaceMethod<[{
-        Visits all the mutated definitions by a store operation.
+        Transforms the IR to amend all the mutated definitions to the slot by a
+        store operation.
 
         This method will only be called after all blocking uses have been
-        scheduled for removal and if `requiresVisitingMutatedDefs` returned
+        scheduled for removal and if `requiresAmendingMutatedDefs` returned
         true.
 
         The rewriter is located after the promotable operation on call. All IR
         mutations must happen through the rewriter. During the transformation,
         *no operation should be deleted*.
       }],
-      "void", "visitMutatedDefs",
+      "void", "amendMutatedDefs",
       (ins "::llvm::ArrayRef<std::pair<::mlir::Operation*, ::mlir::Value>>":$mutatedDefs,
            "::mlir::RewriterBase &":$rewriter), [{}], [{ return; }]
     >,

--- a/mlir/include/mlir/Interfaces/MemorySlotInterfaces.td
+++ b/mlir/include/mlir/Interfaces/MemorySlotInterfaces.td
@@ -238,7 +238,7 @@ def PromotableOpInterface : OpInterface<"PromotableOpInterface"> {
     InterfaceMethod<[{
         Visits all the mutated definitions by a store operation.
 
-        This method will only be called after all blocking issues haven been
+        This method will only be called after all blocking uses have been
         scheduled for removal and if `requiresVisitingMutatedDefs` returned
         true.
 

--- a/mlir/lib/Dialect/LLVMIR/IR/LLVMMemorySlot.cpp
+++ b/mlir/lib/Dialect/LLVMIR/IR/LLVMMemorySlot.cpp
@@ -398,9 +398,9 @@ DeletionKind LLVM::DbgValueOp::removeBlockingUses(
   return DeletionKind::Keep;
 }
 
-bool LLVM::DbgDeclareOp::requiresAmendingMutatedDefs() { return true; }
+bool LLVM::DbgDeclareOp::requiresReplacedValues() { return true; }
 
-void LLVM::DbgDeclareOp::amendMutatedDefs(
+void LLVM::DbgDeclareOp::visitReplacedValues(
     ArrayRef<std::pair<Operation *, Value>> definitions,
     RewriterBase &rewriter) {
   for (auto [op, value] : definitions) {

--- a/mlir/lib/Dialect/LLVMIR/IR/LLVMMemorySlot.cpp
+++ b/mlir/lib/Dialect/LLVMIR/IR/LLVMMemorySlot.cpp
@@ -398,9 +398,9 @@ DeletionKind LLVM::DbgValueOp::removeBlockingUses(
   return DeletionKind::Keep;
 }
 
-bool LLVM::DbgDeclareOp::requiresVisitingMutatedDefs() { return true; }
+bool LLVM::DbgDeclareOp::requiresAmendingMutatedDefs() { return true; }
 
-void LLVM::DbgDeclareOp::visitMutatedDefs(
+void LLVM::DbgDeclareOp::amendMutatedDefs(
     ArrayRef<std::pair<Operation *, Value>> definitions,
     RewriterBase &rewriter) {
   for (auto [op, value] : definitions) {

--- a/mlir/test/Dialect/LLVMIR/mem2reg-dbginfo.mlir
+++ b/mlir/test/Dialect/LLVMIR/mem2reg-dbginfo.mlir
@@ -29,6 +29,27 @@ llvm.func @basic_store_load(%arg0: i64) -> i64 {
   llvm.return %2 : i64
 }
 
+// CHECK-LABEL: llvm.func @multiple_store_load
+llvm.func @multiple_store_load(%arg0: i64) -> i64 {
+  %0 = llvm.mlir.constant(1 : i32) : i32
+  // CHECK-NOT: = llvm.alloca
+  %1 = llvm.alloca %0 x i64 {alignment = 8 : i64} : (i32) -> !llvm.ptr
+  // CHECK-NOT: llvm.intr.dbg.declare
+  llvm.intr.dbg.declare #di_local_variable = %1 : !llvm.ptr
+  // CHECK-NOT: llvm.store
+  llvm.store %arg0, %1 {alignment = 4 : i64} : i64, !llvm.ptr
+  // CHECK-NOT: llvm.intr.dbg.declare
+  llvm.intr.dbg.declare #di_local_variable = %1 : !llvm.ptr
+  // CHECK: llvm.intr.dbg.value #[[$VAR]] = %[[LOADED:.*]] : i64
+  // CHECK: llvm.intr.dbg.value #[[$VAR]] = %[[LOADED]] : i64
+  // CHECK-NOT: llvm.intr.dbg.value
+  // CHECK-NOT: llvm.intr.dbg.declare
+  // CHECK-NOT: llvm.store
+  %2 = llvm.load %1 {alignment = 4 : i64} : !llvm.ptr -> i64
+  // CHECK: llvm.return %[[LOADED]] : i64
+  llvm.return %2 : i64
+}
+
 // CHECK-LABEL: llvm.func @block_argument_value
 // CHECK-SAME: (%[[ARG0:.*]]: i64, {{.*}})
 llvm.func @block_argument_value(%arg0: i64, %arg1: i1) -> i64 {


### PR DESCRIPTION
Add `requiresReplacedValues` and `visitReplacedValues` methods to `PromotableOpInterface`. These methods allow `PromotableOpInterface` ops to transforms definitions mutated by a `store`.

This change is necessary to correctly handle the promotion of `LLVM_DbgDeclareOp`. It is also necessary for enabling https://github.com/llvm/llvm-project/pull/73057/