### PR TITLE
[libc++] Refactor<__type_traits/is_swappable.h>

### DIFF
--- a/libcxx/include/__hash_table
+++ b/libcxx/include/__hash_table
@@ -928,13 +928,12 @@ public:
 
   _LIBCPP_HIDE_FROM_ABI void swap(__hash_table& __u)
 #if _LIBCPP_STD_VER <= 11
-      _NOEXCEPT_(__is_nothrow_swappable<hasher>::value&& __is_nothrow_swappable<key_equal>::value &&
+      _NOEXCEPT_(__is_nothrow_swappable_v<hasher>&& __is_nothrow_swappable_v<key_equal> &&
                  (!allocator_traits<__pointer_allocator>::propagate_on_container_swap::value ||
-                  __is_nothrow_swappable<__pointer_allocator>::value) &&
-                 (!__node_traits::propagate_on_container_swap::value ||
-                  __is_nothrow_swappable<__node_allocator>::value));
+                  __is_nothrow_swappable_v<__pointer_allocator>) &&
+                 (!__node_traits::propagate_on_container_swap::value || __is_nothrow_swappable_v<__node_allocator>));
 #else
-      _NOEXCEPT_(__is_nothrow_swappable<hasher>::value&& __is_nothrow_swappable<key_equal>::value);
+      _NOEXCEPT_(__is_nothrow_swappable_v<hasher>&& __is_nothrow_swappable_v<key_equal>);
 #endif
 
   _LIBCPP_HIDE_FROM_ABI size_type max_bucket_count() const _NOEXCEPT { return max_size(); }
@@ -1985,12 +1984,12 @@ __hash_table<_Tp, _Hash, _Equal, _Alloc>::__equal_range_multi(const _Key& __k) c
 template <class _Tp, class _Hash, class _Equal, class _Alloc>
 void __hash_table<_Tp, _Hash, _Equal, _Alloc>::swap(__hash_table& __u)
 #if _LIBCPP_STD_VER <= 11
-    _NOEXCEPT_(__is_nothrow_swappable<hasher>::value&& __is_nothrow_swappable<key_equal>::value &&
+    _NOEXCEPT_(__is_nothrow_swappable_v<hasher>&& __is_nothrow_swappable_v<key_equal> &&
                (!allocator_traits<__pointer_allocator>::propagate_on_container_swap::value ||
-                __is_nothrow_swappable<__pointer_allocator>::value) &&
-               (!__node_traits::propagate_on_container_swap::value || __is_nothrow_swappable<__node_allocator>::value))
+                __is_nothrow_swappable_v<__pointer_allocator>) &&
+               (!__node_traits::propagate_on_container_swap::value || __is_nothrow_swappable_v<__node_allocator>))
 #else
-    _NOEXCEPT_(__is_nothrow_swappable<hasher>::value&& __is_nothrow_swappable<key_equal>::value)
+    _NOEXCEPT_(__is_nothrow_swappable_v<hasher>&& __is_nothrow_swappable_v<key_equal>)
 #endif
 {
   _LIBCPP_ASSERT_COMPATIBLE_ALLOCATOR(

--- a/libcxx/include/__memory/compressed_pair.h
+++ b/libcxx/include/__memory/compressed_pair.h
@@ -150,7 +150,7 @@ public:
   }
 
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 void swap(__compressed_pair& __x)
-      _NOEXCEPT_(__is_nothrow_swappable<_T1>::value&& __is_nothrow_swappable<_T2>::value) {
+      _NOEXCEPT_(__is_nothrow_swappable_v<_T1>&& __is_nothrow_swappable_v<_T2>) {
     using std::swap;
     swap(first(), __x.first());
     swap(second(), __x.second());
@@ -160,7 +160,7 @@ public:
 template <class _T1, class _T2>
 inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 void
 swap(__compressed_pair<_T1, _T2>& __x, __compressed_pair<_T1, _T2>& __y)
-    _NOEXCEPT_(__is_nothrow_swappable<_T1>::value&& __is_nothrow_swappable<_T2>::value) {
+    _NOEXCEPT_(__is_nothrow_swappable_v<_T1>&& __is_nothrow_swappable_v<_T2>) {
   __x.swap(__y);
 }
 

--- a/libcxx/include/__memory/swap_allocator.h
+++ b/libcxx/include/__memory/swap_allocator.h
@@ -26,7 +26,7 @@ _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 void __swap_allocator(_Alloc
 #if _LIBCPP_STD_VER >= 14
     _NOEXCEPT
 #else
-    _NOEXCEPT_(__is_nothrow_swappable<_Alloc>::value)
+    _NOEXCEPT_(__is_nothrow_swappable_v<_Alloc>)
 #endif
 {
   using std::swap;
@@ -42,7 +42,7 @@ inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 void __swap_allocator
 #if _LIBCPP_STD_VER >= 14
     _NOEXCEPT
 #else
-    _NOEXCEPT_(__is_nothrow_swappable<_Alloc>::value)
+    _NOEXCEPT_(__is_nothrow_swappable_v<_Alloc>)
 #endif
 {
   std::__swap_allocator(

--- a/libcxx/include/__memory/unique_ptr.h
+++ b/libcxx/include/__memory/unique_ptr.h
@@ -471,7 +471,7 @@ public:
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX23 void swap(unique_ptr& __u) _NOEXCEPT { __ptr_.swap(__u.__ptr_); }
 };
 
-template <class _Tp, class _Dp, __enable_if_t<__is_swappable<_Dp>::value, int> = 0>
+template <class _Tp, class _Dp, __enable_if_t<__is_swappable_v<_Dp>, int> = 0>
 inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX23 void
 swap(unique_ptr<_Tp, _Dp>& __x, unique_ptr<_Tp, _Dp>& __y) _NOEXCEPT {
   __x.swap(__y);

--- a/libcxx/include/__split_buffer
+++ b/libcxx/include/__split_buffer
@@ -187,7 +187,7 @@ public:
   _LIBCPP_CONSTEXPR_SINCE_CXX20 _LIBCPP_HIDE_FROM_ABI void __destruct_at_end(pointer __new_last, true_type) _NOEXCEPT;
 
   _LIBCPP_CONSTEXPR_SINCE_CXX20 _LIBCPP_HIDE_FROM_ABI void swap(__split_buffer& __x)
-      _NOEXCEPT_(!__alloc_traits::propagate_on_container_swap::value || __is_nothrow_swappable<__alloc_rr>::value);
+      _NOEXCEPT_(!__alloc_traits::propagate_on_container_swap::value || __is_nothrow_swappable_v<__alloc_rr>);
 
   _LIBCPP_CONSTEXPR_SINCE_CXX20 _LIBCPP_HIDE_FROM_ABI bool __invariants() const;
 
@@ -409,7 +409,7 @@ __split_buffer<_Tp, _Allocator>::operator=(__split_buffer&& __c)
 
 template <class _Tp, class _Allocator>
 _LIBCPP_CONSTEXPR_SINCE_CXX20 void __split_buffer<_Tp, _Allocator>::swap(__split_buffer& __x)
-    _NOEXCEPT_(!__alloc_traits::propagate_on_container_swap::value || __is_nothrow_swappable<__alloc_rr>::value) {
+    _NOEXCEPT_(!__alloc_traits::propagate_on_container_swap::value || __is_nothrow_swappable_v<__alloc_rr>) {
   std::swap(__first_, __x.__first_);
   std::swap(__begin_, __x.__begin_);
   std::swap(__end_, __x.__end_);

--- a/libcxx/include/__tree
+++ b/libcxx/include/__tree
@@ -1006,11 +1006,10 @@ public:
 
   _LIBCPP_HIDE_FROM_ABI void swap(__tree& __t)
 #if _LIBCPP_STD_VER <= 11
-      _NOEXCEPT_(__is_nothrow_swappable<value_compare>::value &&
-                 (!__node_traits::propagate_on_container_swap::value ||
-                  __is_nothrow_swappable<__node_allocator>::value));
+      _NOEXCEPT_(__is_nothrow_swappable_v<value_compare> &&
+                 (!__node_traits::propagate_on_container_swap::value || __is_nothrow_swappable_v<__node_allocator>));
 #else
-      _NOEXCEPT_(__is_nothrow_swappable<value_compare>::value);
+      _NOEXCEPT_(__is_nothrow_swappable_v<value_compare>);
 #endif
 
   template <class _Key, class... _Args>
@@ -1549,10 +1548,10 @@ void __tree<_Tp, _Compare, _Allocator>::destroy(__node_pointer __nd) _NOEXCEPT {
 template <class _Tp, class _Compare, class _Allocator>
 void __tree<_Tp, _Compare, _Allocator>::swap(__tree& __t)
 #if _LIBCPP_STD_VER <= 11
-    _NOEXCEPT_(__is_nothrow_swappable<value_compare>::value &&
-               (!__node_traits::propagate_on_container_swap::value || __is_nothrow_swappable<__node_allocator>::value))
+    _NOEXCEPT_(__is_nothrow_swappable_v<value_compare> &&
+               (!__node_traits::propagate_on_container_swap::value || __is_nothrow_swappable_v<__node_allocator>))
 #else
-    _NOEXCEPT_(__is_nothrow_swappable<value_compare>::value)
+    _NOEXCEPT_(__is_nothrow_swappable_v<value_compare>)
 #endif
 {
   using std::swap;

--- a/libcxx/include/__type_traits/is_swappable.h
+++ b/libcxx/include/__type_traits/is_swappable.h
@@ -11,16 +11,12 @@
 
 #include <__config>
 #include <__type_traits/add_lvalue_reference.h>
-#include <__type_traits/conditional.h>
 #include <__type_traits/enable_if.h>
 #include <__type_traits/is_assignable.h>
 #include <__type_traits/is_constructible.h>
 #include <__type_traits/is_nothrow_assignable.h>
 #include <__type_traits/is_nothrow_constructible.h>
-#include <__type_traits/is_referenceable.h>
-#include <__type_traits/is_same.h>
-#include <__type_traits/is_void.h>
-#include <__type_traits/nat.h>
+#include <__type_traits/void_t.h>
 #include <__utility/declval.h>
 #include <cstddef>
 
@@ -30,10 +26,17 @@
 
 _LIBCPP_BEGIN_NAMESPACE_STD
 
+template <class _Tp, class _Up, class = void>
+inline const bool __is_swappable_with_v = false;
+
 template <class _Tp>
-struct __is_swappable;
+inline const bool __is_swappable_v = __is_swappable_with_v<_Tp&, _Tp&>;
+
+template <class _Tp, class _Up, bool = __is_swappable_with_v<_Tp, _Up> >
+inline const bool __is_nothrow_swappable_with_v = false;
+
 template <class _Tp>
-struct __is_nothrow_swappable;
+inline const bool __is_nothrow_swappable_v = __is_nothrow_swappable_with_v<_Tp&, _Tp&>;
 
 #ifndef _LIBCPP_CXX03_LANG
 template <class _Tp>
@@ -47,85 +50,52 @@ template <class _Tp>
 inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 __swap_result_t<_Tp> swap(_Tp& __x, _Tp& __y)
     _NOEXCEPT_(is_nothrow_move_constructible<_Tp>::value&& is_nothrow_move_assignable<_Tp>::value);
 
-template <class _Tp, size_t _Np, __enable_if_t<__is_swappable<_Tp>::value, int> = 0>
-inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 void swap(_Tp (&__a)[_Np], _Tp (&__b)[_Np])
-    _NOEXCEPT_(__is_nothrow_swappable<_Tp>::value);
+template <class _Tp, size_t _Np, __enable_if_t<__is_swappable_v<_Tp>, int> = 0>
+inline _LIBCPP_HIDE_FROM_ABI
+_LIBCPP_CONSTEXPR_SINCE_CXX20 void swap(_Tp (&__a)[_Np], _Tp (&__b)[_Np]) _NOEXCEPT_(__is_nothrow_swappable_v<_Tp>);
 
-namespace __detail {
 // ALL generic swap overloads MUST already have a declaration available at this point.
 
-template <class _Tp, class _Up = _Tp, bool _NotVoid = !is_void<_Tp>::value && !is_void<_Up>::value>
-struct __swappable_with {
-  template <class _LHS, class _RHS>
-  static decltype(swap(std::declval<_LHS>(), std::declval<_RHS>())) __test_swap(int);
-  template <class, class>
-  static __nat __test_swap(long);
-
-  // Extra parens are needed for the C++03 definition of decltype.
-  typedef decltype((__test_swap<_Tp, _Up>(0))) __swap1;
-  typedef decltype((__test_swap<_Up, _Tp>(0))) __swap2;
-
-  static const bool value = _IsNotSame<__swap1, __nat>::value && _IsNotSame<__swap2, __nat>::value;
-};
-
 template <class _Tp, class _Up>
-struct __swappable_with<_Tp, _Up, false> : false_type {};
+inline const bool __is_swappable_with_v<_Tp,
+                                        _Up,
+                                        __void_t<decltype(swap(std::declval<_Tp>(), std::declval<_Up>())),
+                                                 decltype(swap(std::declval<_Up>(), std::declval<_Tp>()))> > = true;
 
-template <class _Tp, class _Up = _Tp, bool _Swappable = __swappable_with<_Tp, _Up>::value>
-struct __nothrow_swappable_with {
-  static const bool value =
-#ifndef _LIBCPP_HAS_NO_NOEXCEPT
-      noexcept(swap(std::declval<_Tp>(), std::declval<_Up>()))&& noexcept(
-          swap(std::declval<_Up>(), std::declval<_Tp>()));
-#else
-      false;
+#ifndef _LIBCPP_CXX03_LANG // C++03 doesn't have noexcept, so things are never nothrow swappable
+template <class _Tp, class _Up>
+inline const bool __is_nothrow_swappable_with_v<_Tp, _Up, true> =
+    noexcept(swap(std::declval<_Tp>(), std::declval<_Up>())) &&
+    noexcept(swap(std::declval<_Up>(), std::declval<_Tp>()));
 #endif
-};
-
-template <class _Tp, class _Up>
-struct __nothrow_swappable_with<_Tp, _Up, false> : false_type {};
-
-} // namespace __detail
-
-template <class _Tp>
-struct __is_swappable : public integral_constant<bool, __detail::__swappable_with<_Tp&>::value> {};
-
-template <class _Tp>
-struct __is_nothrow_swappable : public integral_constant<bool, __detail::__nothrow_swappable_with<_Tp&>::value> {};
 
 #if _LIBCPP_STD_VER >= 17
 
 template <class _Tp, class _Up>
-struct _LIBCPP_TEMPLATE_VIS is_swappable_with
-    : public integral_constant<bool, __detail::__swappable_with<_Tp, _Up>::value> {};
-
-template <class _Tp>
-struct _LIBCPP_TEMPLATE_VIS is_swappable
-    : public __conditional_t<__libcpp_is_referenceable<_Tp>::value,
-                             is_swappable_with<__add_lvalue_reference_t<_Tp>, __add_lvalue_reference_t<_Tp> >,
-                             false_type> {};
+inline constexpr bool is_swappable_with_v = __is_swappable_with_v<_Tp, _Up>;
 
 template <class _Tp, class _Up>
-struct _LIBCPP_TEMPLATE_VIS is_nothrow_swappable_with
-    : public integral_constant<bool, __detail::__nothrow_swappable_with<_Tp, _Up>::value> {};
+struct _LIBCPP_TEMPLATE_VIS is_swappable_with : bool_constant<is_swappable_with_v<_Tp, _Up>> {};
 
 template <class _Tp>
-struct _LIBCPP_TEMPLATE_VIS is_nothrow_swappable
-    : public __conditional_t<__libcpp_is_referenceable<_Tp>::value,
-                             is_nothrow_swappable_with<__add_lvalue_reference_t<_Tp>, __add_lvalue_reference_t<_Tp> >,
-                             false_type> {};
+inline constexpr bool is_swappable_v =
+    is_swappable_with_v<__add_lvalue_reference_t<_Tp>, __add_lvalue_reference_t<_Tp>>;
+
+template <class _Tp>
+struct _LIBCPP_TEMPLATE_VIS is_swappable : bool_constant<is_swappable_v<_Tp>> {};
 
 template <class _Tp, class _Up>
-inline constexpr bool is_swappable_with_v = is_swappable_with<_Tp, _Up>::value;
-
-template <class _Tp>
-inline constexpr bool is_swappable_v = is_swappable<_Tp>::value;
+inline constexpr bool is_nothrow_swappable_with_v = __is_nothrow_swappable_with_v<_Tp, _Up>;
 
 template <class _Tp, class _Up>
-inline constexpr bool is_nothrow_swappable_with_v = is_nothrow_swappable_with<_Tp, _Up>::value;
+struct _LIBCPP_TEMPLATE_VIS is_nothrow_swappable_with : bool_constant<is_nothrow_swappable_with_v<_Tp, _Up>> {};
 
 template <class _Tp>
-inline constexpr bool is_nothrow_swappable_v = is_nothrow_swappable<_Tp>::value;
+inline constexpr bool is_nothrow_swappable_v =
+    is_nothrow_swappable_with_v<__add_lvalue_reference_t<_Tp>, __add_lvalue_reference_t<_Tp>>;
+
+template <class _Tp>
+struct _LIBCPP_TEMPLATE_VIS is_nothrow_swappable : bool_constant<is_nothrow_swappable_v<_Tp>> {};
 
 #endif // _LIBCPP_STD_VER >= 17
 

--- a/libcxx/include/__utility/pair.h
+++ b/libcxx/include/__utility/pair.h
@@ -409,7 +409,7 @@ struct _LIBCPP_TEMPLATE_VIS pair
 #endif   // _LIBCPP_CXX03_LANG
 
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 void swap(pair& __p)
-      _NOEXCEPT_(__is_nothrow_swappable<first_type>::value&& __is_nothrow_swappable<second_type>::value) {
+      _NOEXCEPT_(__is_nothrow_swappable_v<first_type>&& __is_nothrow_swappable_v<second_type>) {
     using std::swap;
     swap(first, __p.first);
     swap(second, __p.second);
@@ -417,7 +417,7 @@ struct _LIBCPP_TEMPLATE_VIS pair
 
 #if _LIBCPP_STD_VER >= 23
   _LIBCPP_HIDE_FROM_ABI constexpr void swap(const pair& __p) const
-      noexcept(__is_nothrow_swappable<const first_type>::value && __is_nothrow_swappable<const second_type>::value) {
+      noexcept(__is_nothrow_swappable_v<const first_type> && __is_nothrow_swappable_v<const second_type>) {
     using std::swap;
     swap(first, __p.first);
     swap(second, __p.second);
@@ -513,15 +513,15 @@ struct common_type<pair<_T1, _T2>, pair<_U1, _U2>> {
 };
 #endif // _LIBCPP_STD_VER >= 23
 
-template <class _T1, class _T2, __enable_if_t<__is_swappable<_T1>::value && __is_swappable<_T2>::value, int> = 0>
+template <class _T1, class _T2, __enable_if_t<__is_swappable_v<_T1> && __is_swappable_v<_T2>, int> = 0>
 inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 void swap(pair<_T1, _T2>& __x, pair<_T1, _T2>& __y)
-    _NOEXCEPT_(__is_nothrow_swappable<_T1>::value&& __is_nothrow_swappable<_T2>::value) {
+    _NOEXCEPT_(__is_nothrow_swappable_v<_T1>&& __is_nothrow_swappable_v<_T2>) {
   __x.swap(__y);
 }
 
 #if _LIBCPP_STD_VER >= 23
 template <class _T1, class _T2>
-  requires(__is_swappable<const _T1>::value && __is_swappable<const _T2>::value)
+  requires(__is_swappable_v<const _T1> && __is_swappable_v<const _T2>)
 _LIBCPP_HIDE_FROM_ABI constexpr void
 swap(const pair<_T1, _T2>& __x, const pair<_T1, _T2>& __y) noexcept(noexcept(__x.swap(__y))) {
   __x.swap(__y);

--- a/libcxx/include/__utility/swap.h
+++ b/libcxx/include/__utility/swap.h
@@ -44,9 +44,9 @@ inline _LIBCPP_HIDE_FROM_ABI __swap_result_t<_Tp> _LIBCPP_CONSTEXPR_SINCE_CXX20 
   __y = std::move(__t);
 }
 
-template <class _Tp, size_t _Np, __enable_if_t<__is_swappable<_Tp>::value, int> >
+template <class _Tp, size_t _Np, __enable_if_t<__is_swappable_v<_Tp>, int> >
 inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 void swap(_Tp (&__a)[_Np], _Tp (&__b)[_Np])
-    _NOEXCEPT_(__is_nothrow_swappable<_Tp>::value) {
+    _NOEXCEPT_(__is_nothrow_swappable_v<_Tp>) {
   for (size_t __i = 0; __i != _Np; ++__i) {
     swap(__a[__i], __b[__i]);
   }

--- a/libcxx/include/array
+++ b/libcxx/include/array
@@ -192,8 +192,7 @@ struct _LIBCPP_TEMPLATE_VIS array {
     std::fill_n(data(), _Size, __u);
   }
 
-  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 void swap(array& __a)
-      _NOEXCEPT_(__is_nothrow_swappable<_Tp>::value) {
+  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 void swap(array& __a) _NOEXCEPT_(__is_nothrow_swappable_v<_Tp>) {
     std::swap_ranges(data(), data() + _Size, __a.data());
   }
 
@@ -428,7 +427,7 @@ operator<=>(const array<_Tp, _Size>& __x, const array<_Tp, _Size>& __y) {
 
 #endif // _LIBCPP_STD_VER <= 17
 
-template <class _Tp, size_t _Size, __enable_if_t<_Size == 0 || __is_swappable<_Tp>::value, int> = 0>
+template <class _Tp, size_t _Size, __enable_if_t<_Size == 0 || __is_swappable_v<_Tp>, int> = 0>
 inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 void swap(array<_Tp, _Size>& __x, array<_Tp, _Size>& __y)
     _NOEXCEPT_(noexcept(__x.swap(__y))) {
   __x.swap(__y);

--- a/libcxx/include/deque
+++ b/libcxx/include/deque
@@ -214,6 +214,7 @@ template <class T, class Allocator, class Predicate>
 #include <__type_traits/is_allocator.h>
 #include <__type_traits/is_convertible.h>
 #include <__type_traits/is_same.h>
+#include <__type_traits/is_swappable.h>
 #include <__type_traits/type_identity.h>
 #include <__utility/forward.h>
 #include <__utility/move.h>
@@ -794,7 +795,7 @@ public:
 #if _LIBCPP_STD_VER >= 14
       _NOEXCEPT;
 #else
-      _NOEXCEPT_(!__alloc_traits::propagate_on_container_swap::value || __is_nothrow_swappable<allocator_type>::value);
+      _NOEXCEPT_(!__alloc_traits::propagate_on_container_swap::value || __is_nothrow_swappable_v<allocator_type>);
 #endif
   _LIBCPP_HIDE_FROM_ABI void clear() _NOEXCEPT;
 
@@ -2452,7 +2453,7 @@ inline void deque<_Tp, _Allocator>::swap(deque& __c)
 #if _LIBCPP_STD_VER >= 14
     _NOEXCEPT
 #else
-    _NOEXCEPT_(!__alloc_traits::propagate_on_container_swap::value || __is_nothrow_swappable<allocator_type>::value)
+    _NOEXCEPT_(!__alloc_traits::propagate_on_container_swap::value || __is_nothrow_swappable_v<allocator_type>)
 #endif
 {
   __map_.swap(__c.__map_);

--- a/libcxx/include/experimental/propagate_const
+++ b/libcxx/include/experimental/propagate_const
@@ -266,8 +266,7 @@ public:
 
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR element_type& operator*() { return *get(); }
 
-  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR void swap(propagate_const& __pt)
-      _NOEXCEPT_(__is_nothrow_swappable<_Tp>::value) {
+  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR void swap(propagate_const& __pt) _NOEXCEPT_(__is_nothrow_swappable_v<_Tp>) {
     using std::swap;
     swap(__t_, __pt.__t_);
   }
@@ -391,7 +390,7 @@ _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR bool operator>=(const _Tp& __t, const pr
 
 template <class _Tp>
 _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR void swap(propagate_const<_Tp>& __pc1, propagate_const<_Tp>& __pc2)
-    _NOEXCEPT_(__is_nothrow_swappable<_Tp>::value) {
+    _NOEXCEPT_(__is_nothrow_swappable_v<_Tp>) {
   __pc1.swap(__pc2);
 }
 

--- a/libcxx/include/forward_list
+++ b/libcxx/include/forward_list
@@ -567,7 +567,7 @@ public:
 #if _LIBCPP_STD_VER >= 14
       _NOEXCEPT;
 #else
-      _NOEXCEPT_(!__node_traits::propagate_on_container_swap::value || __is_nothrow_swappable<__node_allocator>::value);
+      _NOEXCEPT_(!__node_traits::propagate_on_container_swap::value || __is_nothrow_swappable_v<__node_allocator>);
 #endif
 
 protected:
@@ -618,7 +618,7 @@ inline void __forward_list_base<_Tp, _Alloc>::swap(__forward_list_base& __x)
 #if _LIBCPP_STD_VER >= 14
     _NOEXCEPT
 #else
-    _NOEXCEPT_(!__node_traits::propagate_on_container_swap::value || __is_nothrow_swappable<__node_allocator>::value)
+    _NOEXCEPT_(!__node_traits::propagate_on_container_swap::value || __is_nothrow_swappable_v<__node_allocator>)
 #endif
 {
   std::__swap_allocator(
@@ -821,7 +821,7 @@ public:
 #if _LIBCPP_STD_VER >= 14
       _NOEXCEPT
 #else
-      _NOEXCEPT_(!__node_traits::propagate_on_container_swap::value || __is_nothrow_swappable<__node_allocator>::value)
+      _NOEXCEPT_(!__node_traits::propagate_on_container_swap::value || __is_nothrow_swappable_v<__node_allocator>)
 #endif
   {
     base::swap(__x);

--- a/libcxx/include/list
+++ b/libcxx/include/list
@@ -533,7 +533,7 @@ protected:
 #if _LIBCPP_STD_VER >= 14
       _NOEXCEPT;
 #else
-      _NOEXCEPT_(!__alloc_traits::propagate_on_container_swap::value || __is_nothrow_swappable<allocator_type>::value);
+      _NOEXCEPT_(!__alloc_traits::propagate_on_container_swap::value || __is_nothrow_swappable_v<allocator_type>);
 #endif
 
   _LIBCPP_HIDE_FROM_ABI void __copy_assign_alloc(const __list_imp& __c) {
@@ -639,7 +639,7 @@ void __list_imp<_Tp, _Alloc>::swap(__list_imp& __c)
 #if _LIBCPP_STD_VER >= 14
     _NOEXCEPT
 #else
-    _NOEXCEPT_(!__alloc_traits::propagate_on_container_swap::value || __is_nothrow_swappable<allocator_type>::value)
+    _NOEXCEPT_(!__alloc_traits::propagate_on_container_swap::value || __is_nothrow_swappable_v<allocator_type>)
 #endif
 {
   _LIBCPP_ASSERT_COMPATIBLE_ALLOCATOR(
@@ -861,8 +861,7 @@ public:
 #if _LIBCPP_STD_VER >= 14
       _NOEXCEPT
 #else
-      _NOEXCEPT_(!__node_alloc_traits::propagate_on_container_swap::value ||
-                 __is_nothrow_swappable<__node_allocator>::value)
+      _NOEXCEPT_(!__node_alloc_traits::propagate_on_container_swap::value || __is_nothrow_swappable_v<__node_allocator>)
 #endif
   {
     base::swap(__c);

--- a/libcxx/include/map
+++ b/libcxx/include/map
@@ -641,7 +641,7 @@ public:
   _LIBCPP_HIDE_FROM_ABI bool operator()(const _Key& __x, const _CP& __y) const {
     return static_cast<const _Compare&>(*this)(__x, __y.__get_value().first);
   }
-  _LIBCPP_HIDE_FROM_ABI void swap(__map_value_compare& __y) _NOEXCEPT_(__is_nothrow_swappable<_Compare>::value) {
+  _LIBCPP_HIDE_FROM_ABI void swap(__map_value_compare& __y) _NOEXCEPT_(__is_nothrow_swappable_v<_Compare>) {
     using std::swap;
     swap(static_cast<_Compare&>(*this), static_cast<_Compare&>(__y));
   }
@@ -679,7 +679,7 @@ public:
   _LIBCPP_HIDE_FROM_ABI bool operator()(const _Key& __x, const _CP& __y) const {
     return __comp_(__x, __y.__get_value().first);
   }
-  void swap(__map_value_compare& __y) _NOEXCEPT_(__is_nothrow_swappable<_Compare>::value) {
+  void swap(__map_value_compare& __y) _NOEXCEPT_(__is_nothrow_swappable_v<_Compare>) {
     using std::swap;
     swap(__comp_, __y.__comp_);
   }
@@ -1359,7 +1359,7 @@ public:
   }
 #endif
 
-  _LIBCPP_HIDE_FROM_ABI void swap(map& __m) _NOEXCEPT_(__is_nothrow_swappable<__base>::value) {
+  _LIBCPP_HIDE_FROM_ABI void swap(map& __m) _NOEXCEPT_(__is_nothrow_swappable_v<__base>) {
     __tree_.swap(__m.__tree_);
   }
 
@@ -1951,7 +1951,7 @@ public:
 
   _LIBCPP_HIDE_FROM_ABI void clear() _NOEXCEPT { __tree_.clear(); }
 
-  _LIBCPP_HIDE_FROM_ABI void swap(multimap& __m) _NOEXCEPT_(__is_nothrow_swappable<__base>::value) {
+  _LIBCPP_HIDE_FROM_ABI void swap(multimap& __m) _NOEXCEPT_(__is_nothrow_swappable_v<__base>) {
     __tree_.swap(__m.__tree_);
   }
 

--- a/libcxx/include/queue
+++ b/libcxx/include/queue
@@ -411,7 +411,7 @@ public:
 #endif // _LIBCPP_CXX03_LANG
   _LIBCPP_HIDE_FROM_ABI void pop() { c.pop_front(); }
 
-  _LIBCPP_HIDE_FROM_ABI void swap(queue& __q) _NOEXCEPT_(__is_nothrow_swappable<container_type>::value) {
+  _LIBCPP_HIDE_FROM_ABI void swap(queue& __q) _NOEXCEPT_(__is_nothrow_swappable_v<container_type>) {
     using std::swap;
     swap(c, __q.c);
   }
@@ -500,7 +500,7 @@ operator<=>(const queue<_Tp, _Container>& __x, const queue<_Tp, _Container>& __y
 
 #endif
 
-template <class _Tp, class _Container, __enable_if_t<__is_swappable<_Container>::value, int> = 0>
+template <class _Tp, class _Container, __enable_if_t<__is_swappable_v<_Container>, int> = 0>
 inline _LIBCPP_HIDE_FROM_ABI void swap(queue<_Tp, _Container>& __x, queue<_Tp, _Container>& __y)
     _NOEXCEPT_(_NOEXCEPT_(__x.swap(__y))) {
   __x.swap(__y);
@@ -676,7 +676,7 @@ public:
   _LIBCPP_HIDE_FROM_ABI void pop();
 
   _LIBCPP_HIDE_FROM_ABI void swap(priority_queue& __q)
-      _NOEXCEPT_(__is_nothrow_swappable<container_type>::value&& __is_nothrow_swappable<value_compare>::value);
+      _NOEXCEPT_(__is_nothrow_swappable_v<container_type>&& __is_nothrow_swappable_v<value_compare>);
 
   _LIBCPP_NODISCARD _LIBCPP_HIDE_FROM_ABI const _Container& __get_container() const { return c; }
 };
@@ -922,7 +922,7 @@ inline void priority_queue<_Tp, _Container, _Compare>::pop() {
 
 template <class _Tp, class _Container, class _Compare>
 inline void priority_queue<_Tp, _Container, _Compare>::swap(priority_queue& __q)
-    _NOEXCEPT_(__is_nothrow_swappable<container_type>::value&& __is_nothrow_swappable<value_compare>::value) {
+    _NOEXCEPT_(__is_nothrow_swappable_v<container_type>&& __is_nothrow_swappable_v<value_compare>) {
   using std::swap;
   swap(c, __q.c);
   swap(comp, __q.comp);
@@ -931,7 +931,7 @@ inline void priority_queue<_Tp, _Container, _Compare>::swap(priority_queue& __q)
 template <class _Tp,
           class _Container,
           class _Compare,
-          __enable_if_t<__is_swappable<_Container>::value && __is_swappable<_Compare>::value, int> = 0>
+          __enable_if_t<__is_swappable_v<_Container> && __is_swappable_v<_Compare>, int> = 0>
 inline _LIBCPP_HIDE_FROM_ABI void
 swap(priority_queue<_Tp, _Container, _Compare>& __x, priority_queue<_Tp, _Container, _Compare>& __y)
     _NOEXCEPT_(_NOEXCEPT_(__x.swap(__y))) {

--- a/libcxx/include/regex
+++ b/libcxx/include/regex
@@ -4214,11 +4214,7 @@ public:
   _LIBCPP_HIDE_FROM_ABI int compare(const string_type& __s) const { return str().compare(__s); }
   _LIBCPP_HIDE_FROM_ABI int compare(const value_type* __s) const { return str().compare(__s); }
 
-  _LIBCPP_HIDE_FROM_ABI void swap(sub_match& __s)
-#ifndef _LIBCPP_CXX03_LANG
-      _NOEXCEPT(__is_nothrow_swappable<_BidirectionalIterator>::value)
-#endif // _LIBCPP_CXX03_LANG
-  {
+  _LIBCPP_HIDE_FROM_ABI void swap(sub_match& __s) _NOEXCEPT_(__is_nothrow_swappable_v<_BidirectionalIterator>) {
     this->pair<_BidirectionalIterator, _BidirectionalIterator>::swap(__s);
     std::swap(matched, __s.matched);
   }

--- a/libcxx/include/set
+++ b/libcxx/include/set
@@ -812,9 +812,7 @@ public:
   }
 #endif
 
-  _LIBCPP_HIDE_FROM_ABI void swap(set& __s) _NOEXCEPT_(__is_nothrow_swappable<__base>::value) {
-    __tree_.swap(__s.__tree_);
-  }
+  _LIBCPP_HIDE_FROM_ABI void swap(set& __s) _NOEXCEPT_(__is_nothrow_swappable_v<__base>) { __tree_.swap(__s.__tree_); }
 
   _LIBCPP_HIDE_FROM_ABI allocator_type get_allocator() const _NOEXCEPT { return __tree_.__alloc(); }
   _LIBCPP_HIDE_FROM_ABI key_compare key_comp() const { return __tree_.value_comp(); }
@@ -1270,7 +1268,7 @@ public:
   }
 #endif
 
-  _LIBCPP_HIDE_FROM_ABI void swap(multiset& __s) _NOEXCEPT_(__is_nothrow_swappable<__base>::value) {
+  _LIBCPP_HIDE_FROM_ABI void swap(multiset& __s) _NOEXCEPT_(__is_nothrow_swappable_v<__base>) {
     __tree_.swap(__s.__tree_);
   }
 

--- a/libcxx/include/stack
+++ b/libcxx/include/stack
@@ -268,7 +268,7 @@ public:
 
   _LIBCPP_HIDE_FROM_ABI void pop() { c.pop_back(); }
 
-  _LIBCPP_HIDE_FROM_ABI void swap(stack& __s) _NOEXCEPT_(__is_nothrow_swappable<container_type>::value) {
+  _LIBCPP_HIDE_FROM_ABI void swap(stack& __s) _NOEXCEPT_(__is_nothrow_swappable_v<container_type>) {
     using std::swap;
     swap(c, __s.c);
   }
@@ -354,7 +354,7 @@ operator<=>(const stack<_Tp, _Container>& __x, const stack<_Tp, _Container>& __y
 
 #endif
 
-template <class _Tp, class _Container, __enable_if_t<__is_swappable<_Container>::value, int> = 0>
+template <class _Tp, class _Container, __enable_if_t<__is_swappable_v<_Container>, int> = 0>
 inline _LIBCPP_HIDE_FROM_ABI void swap(stack<_Tp, _Container>& __x, stack<_Tp, _Container>& __y)
     _NOEXCEPT_(_NOEXCEPT_(__x.swap(__y))) {
   __x.swap(__y);

--- a/libcxx/include/string
+++ b/libcxx/include/string
@@ -1643,7 +1643,7 @@ public:
 #if _LIBCPP_STD_VER >= 14
       _NOEXCEPT;
 #else
-      _NOEXCEPT_(!__alloc_traits::propagate_on_container_swap::value || __is_nothrow_swappable<allocator_type>::value);
+      _NOEXCEPT_(!__alloc_traits::propagate_on_container_swap::value || __is_nothrow_swappable_v<allocator_type>);
 #endif
 
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 const value_type* c_str() const _NOEXCEPT { return data(); }
@@ -3350,7 +3350,7 @@ inline _LIBCPP_CONSTEXPR_SINCE_CXX20 void basic_string<_CharT, _Traits, _Allocat
 #if _LIBCPP_STD_VER >= 14
     _NOEXCEPT
 #else
-    _NOEXCEPT_(!__alloc_traits::propagate_on_container_swap::value || __is_nothrow_swappable<allocator_type>::value)
+    _NOEXCEPT_(!__alloc_traits::propagate_on_container_swap::value || __is_nothrow_swappable_v<allocator_type>)
 #endif
 {
   _LIBCPP_ASSERT_COMPATIBLE_ALLOCATOR(

--- a/libcxx/include/tuple
+++ b/libcxx/include/tuple
@@ -279,14 +279,14 @@ class __tuple_leaf;
 template <size_t _Ip, class _Hp, bool _Ep>
 inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 void
 swap(__tuple_leaf<_Ip, _Hp, _Ep>& __x, __tuple_leaf<_Ip, _Hp, _Ep>& __y)
-    _NOEXCEPT_(__is_nothrow_swappable<_Hp>::value) {
+    _NOEXCEPT_(__is_nothrow_swappable_v<_Hp>) {
   swap(__x.get(), __y.get());
 }
 
 template <size_t _Ip, class _Hp, bool _Ep>
 _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 void
 swap(const __tuple_leaf<_Ip, _Hp, _Ep>& __x, const __tuple_leaf<_Ip, _Hp, _Ep>& __y)
-    _NOEXCEPT_(__is_nothrow_swappable<const _Hp>::value) {
+    _NOEXCEPT_(__is_nothrow_swappable_v<const _Hp>) {
   swap(__x.get(), __y.get());
 }
 
@@ -362,13 +362,13 @@ public:
   _LIBCPP_HIDE_FROM_ABI __tuple_leaf(__tuple_leaf&& __t)      = default;
 
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 int swap(__tuple_leaf& __t)
-      _NOEXCEPT_(__is_nothrow_swappable<__tuple_leaf>::value) {
+      _NOEXCEPT_(__is_nothrow_swappable_v<__tuple_leaf>) {
     std::swap(*this, __t);
     return 0;
   }
 
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 int swap(const __tuple_leaf& __t) const
-      _NOEXCEPT_(__is_nothrow_swappable<const __tuple_leaf>::value) {
+      _NOEXCEPT_(__is_nothrow_swappable_v<const __tuple_leaf>) {
     std::swap(*this, __t);
     return 0;
   }
@@ -417,13 +417,13 @@ public:
   __tuple_leaf(__tuple_leaf&&)      = default;
 
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 int swap(__tuple_leaf& __t)
-      _NOEXCEPT_(__is_nothrow_swappable<__tuple_leaf>::value) {
+      _NOEXCEPT_(__is_nothrow_swappable_v<__tuple_leaf>) {
     std::swap(*this, __t);
     return 0;
   }
 
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 int swap(const __tuple_leaf& __rhs) const
-      _NOEXCEPT_(__is_nothrow_swappable<const __tuple_leaf>::value) {
+      _NOEXCEPT_(__is_nothrow_swappable_v<const __tuple_leaf>) {
     std::swap(*this, __rhs);
     return 0;
   }
@@ -496,12 +496,12 @@ struct _LIBCPP_DECLSPEC_EMPTY_BASES __tuple_impl<__tuple_indices<_Indx...>, _Tp.
   __tuple_impl(__tuple_impl&&)      = default;
 
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 void swap(__tuple_impl& __t)
-      _NOEXCEPT_(__all<__is_nothrow_swappable<_Tp>::value...>::value) {
+      _NOEXCEPT_(__all<__is_nothrow_swappable_v<_Tp>...>::value) {
     std::__swallow(__tuple_leaf<_Indx, _Tp>::swap(static_cast<__tuple_leaf<_Indx, _Tp>&>(__t))...);
   }
 
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 void swap(const __tuple_impl& __t) const
-      _NOEXCEPT_(__all<__is_nothrow_swappable<const _Tp>::value...>::value) {
+      _NOEXCEPT_(__all<__is_nothrow_swappable_v<const _Tp>...>::value) {
     std::__swallow(__tuple_leaf<_Indx, _Tp>::swap(static_cast<const __tuple_leaf<_Indx, _Tp>&>(__t))...);
   }
 };
@@ -974,7 +974,7 @@ public:
 
   // [tuple.swap]
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 void swap(tuple& __t)
-      _NOEXCEPT_(__all<__is_nothrow_swappable<_Tp>::value...>::value) {
+      _NOEXCEPT_(__all<__is_nothrow_swappable_v<_Tp>...>::value) {
     __base_.swap(__t.__base_);
   }
 
@@ -1031,9 +1031,9 @@ template <class _Alloc, class... _Tp>
 tuple(allocator_arg_t, _Alloc, tuple<_Tp...>) -> tuple<_Tp...>;
 #  endif
 
-template <class... _Tp, __enable_if_t<__all<__is_swappable<_Tp>::value...>::value, int> = 0>
+template <class... _Tp, __enable_if_t<__all<__is_swappable_v<_Tp>...>::value, int> = 0>
 inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 void swap(tuple<_Tp...>& __t, tuple<_Tp...>& __u)
-    _NOEXCEPT_(__all<__is_nothrow_swappable<_Tp>::value...>::value) {
+    _NOEXCEPT_(__all<__is_nothrow_swappable_v<_Tp>...>::value) {
   __t.swap(__u);
 }
 

--- a/libcxx/include/unordered_map
+++ b/libcxx/include/unordered_map
@@ -650,7 +650,7 @@ public:
     return static_cast<const _Hash&>(*this)(__x);
   }
 #endif
-  _LIBCPP_HIDE_FROM_ABI void swap(__unordered_map_hasher& __y) _NOEXCEPT_(__is_nothrow_swappable<_Hash>::value) {
+  _LIBCPP_HIDE_FROM_ABI void swap(__unordered_map_hasher& __y) _NOEXCEPT_(__is_nothrow_swappable_v<_Hash>) {
     using std::swap;
     swap(static_cast<_Hash&>(*this), static_cast<_Hash&>(__y));
   }
@@ -674,7 +674,7 @@ public:
     return __hash_(__x);
   }
 #endif
-  _LIBCPP_HIDE_FROM_ABI void swap(__unordered_map_hasher& __y) _NOEXCEPT_(__is_nothrow_swappable<_Hash>::value) {
+  _LIBCPP_HIDE_FROM_ABI void swap(__unordered_map_hasher& __y) _NOEXCEPT_(__is_nothrow_swappable_v<_Hash>) {
     using std::swap;
     swap(__hash_, __y.__hash_);
   }
@@ -725,7 +725,7 @@ public:
     return static_cast<const _Pred&>(*this)(__x, __y);
   }
 #endif
-  _LIBCPP_HIDE_FROM_ABI void swap(__unordered_map_equal& __y) _NOEXCEPT_(__is_nothrow_swappable<_Pred>::value) {
+  _LIBCPP_HIDE_FROM_ABI void swap(__unordered_map_equal& __y) _NOEXCEPT_(__is_nothrow_swappable_v<_Pred>) {
     using std::swap;
     swap(static_cast<_Pred&>(*this), static_cast<_Pred&>(__y));
   }
@@ -768,7 +768,7 @@ public:
     return __pred_(__x, __y);
   }
 #endif
-  _LIBCPP_HIDE_FROM_ABI void swap(__unordered_map_equal& __y) _NOEXCEPT_(__is_nothrow_swappable<_Pred>::value) {
+  _LIBCPP_HIDE_FROM_ABI void swap(__unordered_map_equal& __y) _NOEXCEPT_(__is_nothrow_swappable_v<_Pred>) {
     using std::swap;
     swap(__pred_, __y.__pred_);
   }
@@ -1373,7 +1373,7 @@ public:
   }
 #endif
 
-  _LIBCPP_HIDE_FROM_ABI void swap(unordered_map& __u) _NOEXCEPT_(__is_nothrow_swappable<__table>::value) {
+  _LIBCPP_HIDE_FROM_ABI void swap(unordered_map& __u) _NOEXCEPT_(__is_nothrow_swappable_v<__table>) {
     __table_.swap(__u.__table_);
   }
 
@@ -2120,7 +2120,7 @@ public:
   }
 #endif
 
-  _LIBCPP_HIDE_FROM_ABI void swap(unordered_multimap& __u) _NOEXCEPT_(__is_nothrow_swappable<__table>::value) {
+  _LIBCPP_HIDE_FROM_ABI void swap(unordered_multimap& __u) _NOEXCEPT_(__is_nothrow_swappable_v<__table>) {
     __table_.swap(__u.__table_);
   }
 

--- a/libcxx/include/unordered_set
+++ b/libcxx/include/unordered_set
@@ -828,7 +828,7 @@ public:
   }
 #endif
 
-  _LIBCPP_HIDE_FROM_ABI void swap(unordered_set& __u) _NOEXCEPT_(__is_nothrow_swappable<__table>::value) {
+  _LIBCPP_HIDE_FROM_ABI void swap(unordered_set& __u) _NOEXCEPT_(__is_nothrow_swappable_v<__table>) {
     __table_.swap(__u.__table_);
   }
 
@@ -1425,7 +1425,7 @@ public:
   }
   _LIBCPP_HIDE_FROM_ABI void clear() _NOEXCEPT { __table_.clear(); }
 
-  _LIBCPP_HIDE_FROM_ABI void swap(unordered_multiset& __u) _NOEXCEPT_(__is_nothrow_swappable<__table>::value) {
+  _LIBCPP_HIDE_FROM_ABI void swap(unordered_multiset& __u) _NOEXCEPT_(__is_nothrow_swappable_v<__table>) {
     __table_.swap(__u.__table_);
   }
 

--- a/libcxx/include/vector
+++ b/libcxx/include/vector
@@ -743,7 +743,7 @@ public:
 #if _LIBCPP_STD_VER >= 14
       _NOEXCEPT;
 #else
-      _NOEXCEPT_(!__alloc_traits::propagate_on_container_swap::value || __is_nothrow_swappable<allocator_type>::value);
+      _NOEXCEPT_(!__alloc_traits::propagate_on_container_swap::value || __is_nothrow_swappable_v<allocator_type>);
 #endif
 
   _LIBCPP_CONSTEXPR_SINCE_CXX20 _LIBCPP_HIDE_FROM_ABI bool __invariants() const;
@@ -1767,7 +1767,7 @@ _LIBCPP_CONSTEXPR_SINCE_CXX20 void vector<_Tp, _Allocator>::swap(vector& __x)
 #if _LIBCPP_STD_VER >= 14
     _NOEXCEPT
 #else
-    _NOEXCEPT_(!__alloc_traits::propagate_on_container_swap::value || __is_nothrow_swappable<allocator_type>::value)
+    _NOEXCEPT_(!__alloc_traits::propagate_on_container_swap::value || __is_nothrow_swappable_v<allocator_type>)
 #endif
 {
   _LIBCPP_ASSERT_COMPATIBLE_ALLOCATOR(
@@ -2108,7 +2108,7 @@ public:
 #if _LIBCPP_STD_VER >= 14
       _NOEXCEPT;
 #else
-      _NOEXCEPT_(!__alloc_traits::propagate_on_container_swap::value || __is_nothrow_swappable<allocator_type>::value);
+      _NOEXCEPT_(!__alloc_traits::propagate_on_container_swap::value || __is_nothrow_swappable_v<allocator_type>);
 #endif
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 static void swap(reference __x, reference __y) _NOEXCEPT {
     std::swap(__x, __y);
@@ -2770,7 +2770,7 @@ _LIBCPP_CONSTEXPR_SINCE_CXX20 void vector<bool, _Allocator>::swap(vector& __x)
 #if _LIBCPP_STD_VER >= 14
     _NOEXCEPT
 #else
-    _NOEXCEPT_(!__alloc_traits::propagate_on_container_swap::value || __is_nothrow_swappable<allocator_type>::value)
+    _NOEXCEPT_(!__alloc_traits::propagate_on_container_swap::value || __is_nothrow_swappable_v<allocator_type>)
 #endif
 {
   std::swap(this->__begin_, __x.__begin_);

--- a/libcxx/test/std/utilities/meta/meta.unary/meta.unary.prop/is_swappable_include_order.pass.cpp
+++ b/libcxx/test/std/utilities/meta/meta.unary/meta.unary.prop/is_swappable_include_order.pass.cpp
@@ -23,22 +23,21 @@
 
 #include "test_macros.h"
 
-int main(int, char**)
-{
-    // Use a builtin type so we don't get ADL lookup.
-    typedef double T[17][29];
-    {
-        LIBCPP_STATIC_ASSERT(std::__is_swappable<T>::value, "");
+int main(int, char**) {
+  // Use a builtin type so we don't get ADL lookup.
+  typedef double T[17][29];
+  {
+    LIBCPP_STATIC_ASSERT(std::__is_swappable_v<T>, "");
 #if TEST_STD_VER > 14
-        static_assert(std::is_swappable_v<T>, "");
+    static_assert(std::is_swappable_v<T>, "");
 #endif
-    }
-    {
-        T t1 = {};
-        T t2 = {};
-       std::iter_swap(t1, t2);
-       std::swap_ranges(t1, t1 + 17, t2);
-    }
+  }
+  {
+    T t1 = {};
+    T t2 = {};
+    std::iter_swap(t1, t2);
+    std::swap_ranges(t1, t1 + 17, t2);
+  }
 
   return 0;
 }

--- a/libcxx/test/support/nasty_containers.h
+++ b/libcxx/test/support/nasty_containers.h
@@ -123,13 +123,15 @@ public:
     void resize(size_type sz)                      { v_.resize(sz); }
     void resize(size_type sz, const value_type& c) { v_.resize(sz, c); }
 
-    void swap(nasty_vector &nv)
+    void swap(nasty_vector& nv)
 #if TEST_STD_VER > 14
-    noexcept(std::is_nothrow_swappable<nested_container>::value)
+        noexcept(std::is_nothrow_swappable<nested_container>::value)
 #elif defined(_LIBCPP_VERSION)
-    TEST_NOEXCEPT_COND(std::__is_nothrow_swappable<nested_container>::value)
+        TEST_NOEXCEPT_COND(std::__is_nothrow_swappable_v<nested_container>)
 #endif
-    { v_.swap(nv.v_); }
+    {
+      v_.swap(nv.v_);
+    }
 
     nasty_vector *operator &()             { assert(false); return nullptr; }  // nasty
     const nasty_vector *operator &() const { assert(false); return nullptr; }  // nasty
@@ -252,13 +254,15 @@ public:
     void resize(size_type n)                      { l_.resize(n); }
     void resize(size_type n, const value_type& c) { l_.resize(n, c); }
 
-    void swap(nasty_list &nl)
+    void swap(nasty_list& nl)
 #if TEST_STD_VER > 14
-    noexcept(std::is_nothrow_swappable<nested_container>::value)
+        noexcept(std::is_nothrow_swappable<nested_container>::value)
 #elif defined(_LIBCPP_VERSION)
-    TEST_NOEXCEPT_COND(std::__is_nothrow_swappable<nested_container>::value)
+        TEST_NOEXCEPT_COND(std::__is_nothrow_swappable_v<nested_container>)
 #endif
-    { l_.swap(nl.l_); }
+    {
+      l_.swap(nl.l_);
+    }
 
     void clear() TEST_NOEXCEPT { l_.clear(); }
 

--- a/libcxx/test/support/poisoned_hash_helper.h
+++ b/libcxx/test/support/poisoned_hash_helper.h
@@ -145,7 +145,7 @@ TEST_CONSTEXPR_CXX20 void test_hash_enabled(InputKey const& key) {
 #if TEST_STD_VER > 14
   static_assert(std::is_swappable<Hash>::value, "");
 #elif defined(_LIBCPP_VERSION)
-  static_assert(std::__is_swappable<Hash>::value, "");
+  static_assert(std::__is_swappable_v<Hash>, "");
 #endif
 
   // Hashable requirements


### PR DESCRIPTION
This changes the `is_swappable` implementation to use variable templates first and basing the class templates on that. This avoids instantiating them when the `_v` versions are used, which are generally less resource intensive.
