### PR TITLE
[MIPS][CallSiteInfo][NFC] Fill CallSiteInfo only when needed

### DIFF
--- a/llvm/lib/Target/Mips/MipsISelLowering.cpp
+++ b/llvm/lib/Target/Mips/MipsISelLowering.cpp
@@ -3381,7 +3381,7 @@ MipsTargetLowering::LowerCall(TargetLowering::CallLoweringInfo &CLI,
 
       // Collect CSInfo about which register passes which parameter.
       const TargetOptions &Options = DAG.getTarget().Options;
-      if (Options.SupportsDebugEntryValues)
+      if (Options.EmitCallSiteInfo)
         CSInfo.emplace_back(VA.getLocReg(), i);
 
       continue;


### PR DESCRIPTION
Argument-register pairs in CallSiteInfo is only needed when EmitCallSiteInfo
is on. Currently, the pairs are always pushed to the vector but only used
when EmitCallSiteInfo is on.

Don't fill the CallSiteInfo vector unless used.

Differential Revision: https://reviews.llvm.org/D107108?id=362887
