### PR TITLE
[BOLT] Fix enumeration of secondary entry points

### DIFF
--- a/bolt/lib/Core/BinaryFunction.cpp
+++ b/bolt/lib/Core/BinaryFunction.cpp
@@ -3547,7 +3547,7 @@ MCSymbol *BinaryFunction::getSymbolForEntryID(uint64_t EntryID) {
   if (!isMultiEntry())
     return nullptr;
 
-  uint64_t NumEntries = 0;
+  uint64_t NumEntries = 1;
   if (hasCFG()) {
     for (BinaryBasicBlock *BB : BasicBlocks) {
       MCSymbol *EntrySymbol = getSecondaryEntryPointSymbol(*BB);
@@ -3580,7 +3580,7 @@ uint64_t BinaryFunction::getEntryIDForSymbol(const MCSymbol *Symbol) const {
       return 0;
 
   // Check all secondary entries available as either basic blocks or lables.
-  uint64_t NumEntries = 0;
+  uint64_t NumEntries = 1;
   for (const BinaryBasicBlock *BB : BasicBlocks) {
     MCSymbol *EntrySymbol = getSecondaryEntryPointSymbol(*BB);
     if (!EntrySymbol)
@@ -3589,7 +3589,7 @@ uint64_t BinaryFunction::getEntryIDForSymbol(const MCSymbol *Symbol) const {
       return NumEntries;
     ++NumEntries;
   }
-  NumEntries = 0;
+  NumEntries = 1;
   for (const std::pair<const uint32_t, MCSymbol *> &KV : Labels) {
     MCSymbol *EntrySymbol = getSecondaryEntryPointSymbol(KV.second);
     if (!EntrySymbol)

--- a/bolt/test/X86/yaml-secondary-entry-discriminator.s
+++ b/bolt/test/X86/yaml-secondary-entry-discriminator.s
@@ -1,0 +1,71 @@
+# This reproduces a bug with BOLT setting incorrect discriminator for
+# secondary entry points in YAML profile.
+
+# REQUIRES: system-linux
+# RUN: llvm-mc -filetype=obj -triple x86_64-unknown-unknown %s -o %t.o
+# RUN: link_fdata %s %t.o %t.fdata
+# RUN: llvm-strip --strip-unneeded %t.o
+# RUN: %clang %cflags %t.o -o %t.exe -Wl,-q -nostdlib
+# RUN: llvm-bolt %t.exe -o %t.out --data %t.fdata -w %t.yaml --print-profile \
+# RUN:   --print-only=main | FileCheck %s --check-prefix=CHECK-CFG
+# RUN: FileCheck %s -input-file %t.yaml
+# CHECK:      - name:    main
+# CHECK-NEXT:   fid:     2
+# CHECK-NEXT:   hash:    0xADF270D550151185
+# CHECK-NEXT:   exec:    0
+# CHECK-NEXT:   nblocks: 4
+# CHECK-NEXT:   blocks:
+# CHECK:          - bid:   1
+# CHECK-NEXT:       insns: 1
+# CHECK-NEXT:       hash:  0x36A303CBA4360014
+# CHECK-NEXT:       calls: [ { off: 0x0, fid: 1, disc: 1, cnt: 1 } ]
+
+# Make sure that the profile is attached correctly
+# RUN: llvm-bolt %t.exe -o %t.out --data %t.yaml --print-profile \
+# RUN:   --print-only=main | FileCheck %s --check-prefix=CHECK-CFG
+
+# CHECK-CFG: Binary Function "main" after attaching profile {
+# CHECK-CFG:      callq secondary_entry # Offset: [[#]] # Count: 1
+# CHECK-CFG:      callq *%rax # Offset: [[#]] # CallProfile: 1 (1 misses) :
+# XXX: uncomment after discriminator is set correctly for indirect calls
+# COM: CHECK-CFG-NEXT:     { secondary_entry: 1 (1 misses) }
+# CHECK-CFG: }
+
+.globl func
+.type	func, @function
+func:
+  .cfi_startproc
+  pushq   %rbp
+  movq    %rsp, %rbp
+.globl secondary_entry
+secondary_entry:
+  popq    %rbp
+  retq
+  nopl    (%rax)
+  .cfi_endproc
+  .size	func, .-func
+
+.globl main
+.type	main, @function
+main:
+  .cfi_startproc
+  pushq   %rbp
+  movq    %rsp, %rbp
+  subq    $16, %rsp
+  movl    $0, -4(%rbp)
+  testq   %rax, %rax
+  jne     Lindcall
+Lcall:
+  call    secondary_entry
+# FDATA: 1 main #Lcall# 1 secondary_entry 0 1 1
+Lindcall:
+  callq   *%rax
+# FDATA: 1 main #Lindcall# 1 secondary_entry 0 1 1
+  xorl    %eax, %eax
+  addq    $16, %rsp
+  popq    %rbp
+  retq
+# For relocations against .text
+  call exit
+  .cfi_endproc
+  .size	main, .-main


### PR DESCRIPTION
Make them start with 1 instead of 0 (reserved for primary entry point).

Test Plan:
```
bin/llvm-lit -a tools/bolt/test/X86/yaml-secondary-entry-discriminator.s
```