### PR TITLE
[clang] Bailout when the substitution of template parameter mapping is invalid.

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -455,6 +455,7 @@ Bug Fixes to C++ Support
 - Fix an issue where a namespace alias could be defined using a qualified name (all name components
   following the first `::` were ignored).
 - Fix an out-of-bounds crash when checking the validity of template partial specializations. (part of #GH86757).
+- Fix an issue caused by not handling invalid cases when substituting into the parameter mapping of a constraint. Fixes (#GH86757).
 
 Bug Fixes to AST Handling
 ^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/clang/lib/Sema/SemaConcept.cpp
+++ b/clang/lib/Sema/SemaConcept.cpp
@@ -1281,6 +1281,8 @@ substituteParameterMappings(Sema &S, NormalizedConstraint &N,
       S, InstLocBegin,
       Sema::InstantiatingTemplate::ParameterMappingSubstitution{}, Concept,
       {InstLocBegin, InstLocEnd});
+  if (Inst.isInvalid())
+    return true;
   if (S.SubstTemplateArguments(*Atomic.ParameterMapping, MLTAL, SubstArgs))
     return true;
 

--- a/clang/test/SemaTemplate/concepts-GH86757.cpp
+++ b/clang/test/SemaTemplate/concepts-GH86757.cpp
@@ -1,0 +1,13 @@
+// RUN: %clang_cc1 -std=c++20 -Wfatal-errors -verify %s
+
+template <typename> int a;
+template <typename... b> concept c = a<b...>;
+template <typename> concept e = c<>;
+
+// must be a fatal error to trigger the crash
+undefined; // expected-error {{a type specifier is required for all declarations}}
+
+template <typename d> concept g = e<d>;
+template <g> struct h
+template <g d>
+struct h<d>;


### PR DESCRIPTION
Fixes #86757

We missed to handle the invalid case when substituting into the parameter mapping of an constraint during normalization.
The constructor of `InstantiatingTemplate` will bail out (no `CodeSynthesisContext` will be added to the instantiation stack) if there was a fatal error, consequently we should stop doing any further template instantiations.