### PR TITLE
[libc] Move baremetal write_to_stderr implementation to io.cpp

### DIFF
--- a/libc/src/__support/OSUtil/baremetal/CMakeLists.txt
+++ b/libc/src/__support/OSUtil/baremetal/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_object_library(
   baremetal_util
   SRCS
+    io.cpp
     quick_exit.cpp
   HDRS
     io.h

--- a/libc/src/__support/OSUtil/baremetal/io.cpp
+++ b/libc/src/__support/OSUtil/baremetal/io.cpp
@@ -6,15 +6,17 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef LLVM_LIBC_SRC___SUPPORT_OSUTIL_BAREMETAL_IO_H
-#define LLVM_LIBC_SRC___SUPPORT_OSUTIL_BAREMETAL_IO_H
+#include "io.h"
 
 #include "src/__support/CPP/string_view.h"
 
+// This is intended to be provided by the vendor.
+extern "C" void __llvm_libc_log_write(const char *msg, size_t len);
+
 namespace LIBC_NAMESPACE {
 
-void write_to_stderr(cpp::string_view msg);
+void write_to_stderr(cpp::string_view msg) {
+  __llvm_libc_log_write(msg.data(), msg.size());
+}
 
 } // namespace LIBC_NAMESPACE
-
-#endif // LLVM_LIBC_SRC___SUPPORT_OSUTIL_BAREMETAL_IO_H

--- a/libc/src/__support/OSUtil/baremetal/io.h
+++ b/libc/src/__support/OSUtil/baremetal/io.h
@@ -16,7 +16,7 @@ namespace LIBC_NAMESPACE {
 // This is intended to be provided by the vendor.
 extern "C" void __llvm_libc_log_write(const char *msg, size_t len);
 
-void write_to_stderr(cpp::string_view msg) {
+inline void write_to_stderr(cpp::string_view msg) {
   __llvm_libc_log_write(msg.data(), msg.size());
 }
 

--- a/libc/src/__support/OSUtil/baremetal/io.h
+++ b/libc/src/__support/OSUtil/baremetal/io.h
@@ -16,7 +16,7 @@ namespace LIBC_NAMESPACE {
 // This is intended to be provided by the vendor.
 extern "C" void __llvm_libc_log_write(const char *msg, size_t len);
 
-inline void write_to_stderr(cpp::string_view msg) {
+LIBC_INLINE void write_to_stderr(cpp::string_view msg) {
   __llvm_libc_log_write(msg.data(), msg.size());
 }
 


### PR DESCRIPTION
This is required to avoid multiple definitions error.