### PR TITLE
[tsan][test] Remove some unneded debug comments in a tsan test

### DIFF
--- a/compiler-rt/test/tsan/Linux/signal_in_futex_wait.cpp
+++ b/compiler-rt/test/tsan/Linux/signal_in_futex_wait.cpp
@@ -57,16 +57,13 @@ private:
 Mutex mutex;
 
 void *Thread(void *x) {
-  // fprintf(stderr, "canova here thread 0\n");
   // Waiting for the futex.
   mutex.lock();
-  // fprintf(stderr, "canova here thread 1\n");
   // Finished waiting.
   return nullptr;
 }
 
 static void SigprofHandler(int signal, siginfo_t *info, void *context) {
-  // fprintf(stderr, "canova here sigprof handler\n");
   // Unlock the futex.
   mutex.unlock();
 }


### PR DESCRIPTION
I introduced this test in #86537, let's remove some unneeded debugging comments.
This PR was initially also moving the test to linux directory but looks like it's already done by 17ab9e64464f989b3fe4a304a450581a618097a0 .