### PR TITLE
[CI] Hotfix: CI runs failing due to target escaping

### DIFF
--- a/.ci/monolithic-linux.sh
+++ b/.ci/monolithic-linux.sh
@@ -54,4 +54,4 @@ cmake -S "${MONOREPO_ROOT}"/llvm -B "${BUILD_DIR}" \
 
 echo "--- ninja"
 # Targets are not escaped as they are passed as separate arguments.
-ninja -C "${BUILD_DIR}" -k 0 "${targets}"
+ninja -C "${BUILD_DIR}" -k 0 ${targets}

--- a/.ci/monolithic-windows.sh
+++ b/.ci/monolithic-windows.sh
@@ -62,4 +62,4 @@ cmake -S "${MONOREPO_ROOT}"/llvm -B "${BUILD_DIR}" \
 
 echo "--- ninja"
 # Targets are not escaped as they are passed as separate arguments.
-ninja -C "${BUILD_DIR}" -k 0 "${targets}"
+ninja -C "${BUILD_DIR}" -k 0 ${targets}


### PR DESCRIPTION
My patch #86877 contains a mistake.
Should have read the comment.
Recent buildkite runs fail because of this, so it is a bit urgent.