### PR TITLE
[PowerPC][RFC] Make power9-vector indicate isa-3.0 and power9-altivec

### DIFF
--- a/clang/lib/Basic/Targets/PPC.cpp
+++ b/clang/lib/Basic/Targets/PPC.cpp
@@ -597,6 +597,7 @@ bool PPCTargetInfo::initFeatureMap(
                                           .Default(false);
 
   Features["isa-v30-instructions"] =
+      llvm::is_contained(FeaturesVec, "+power9-vector") or
       llvm::StringSwitch<bool>(CPU).Case("pwr9", true).Default(false);
 
   Features["quadword-atomics"] =
@@ -604,6 +605,8 @@ bool PPCTargetInfo::initFeatureMap(
                                        .Case("pwr9", true)
                                        .Case("pwr8", true)
                                        .Default(false);
+
+  Features["power9-altivec"] = llvm::is_contained(FeaturesVec, "+power9-vector");
 
   // Power10 includes all the same features as Power9 plus any features specific
   // to the Power10 core.


### PR DESCRIPTION
This is to address https://github.com/llvm/llvm-project/issues/84703. However this might not be a long-term solution in my view.