### PR TITLE
[DXIL] Add lowering for `reversebits` and `trunc`

### DIFF
--- a/llvm/lib/Target/DirectX/DXIL.td
+++ b/llvm/lib/Target/DirectX/DXIL.td
@@ -285,9 +285,6 @@ def RSqrt : DXILOpMapping<25, unary, int_dx_rsqrt,
                          "Returns the reciprocal of the square root of the specified value."
                          "rsqrt(x) = 1 / sqrt(x).",
                          [llvm_halforfloat_ty, LLVMMatchType<0>]>;
-def Rbits : DXILOpMapping<30, unary, int_bitreverse,
-                         "Returns the specified value with its bits reversed.",
-                         [llvm_anyint_ty, LLVMMatchType<0>]>;
 def Round : DXILOpMapping<26, unary, int_round,
                          "Returns the input rounded to the nearest integer"
                          "within a floating-point type.",
@@ -298,6 +295,9 @@ def Floor : DXILOpMapping<27, unary, int_floor,
 def Trunc : DXILOpMapping<29, unary, int_trunc,
                          "Returns the specified value truncated to the integer component.",
                          [llvm_halforfloat_ty, LLVMMatchType<0>]>;
+def Rbits : DXILOpMapping<30, unary, int_bitreverse,
+                         "Returns the specified value with its bits reversed.",
+                         [llvm_anyint_ty, LLVMMatchType<0>]>;
 def FMax : DXILOpMapping<35, binary, int_maxnum,
                          "Float maximum. FMax(a,b) = a > b ? a : b">;
 def FMin : DXILOpMapping<36, binary, int_minnum,

--- a/llvm/lib/Target/DirectX/DXIL.td
+++ b/llvm/lib/Target/DirectX/DXIL.td
@@ -295,6 +295,9 @@ def Round : DXILOpMapping<26, unary, int_round,
 def Floor : DXILOpMapping<27, unary, int_floor,
                          "Returns the largest integer that is less than or equal to the input.",
                          [llvm_halforfloat_ty, LLVMMatchType<0>]>;
+def Trunc : DXILOpMapping<29, unary, int_trunc,
+                         "Returns the specified value truncated to the integer component.",
+                         [llvm_halforfloat_ty, LLVMMatchType<0>]>;
 def FMax : DXILOpMapping<35, binary, int_maxnum,
                          "Float maximum. FMax(a,b) = a > b ? a : b">;
 def FMin : DXILOpMapping<36, binary, int_minnum,

--- a/llvm/lib/Target/DirectX/DXIL.td
+++ b/llvm/lib/Target/DirectX/DXIL.td
@@ -285,6 +285,9 @@ def RSqrt : DXILOpMapping<25, unary, int_dx_rsqrt,
                          "Returns the reciprocal of the square root of the specified value."
                          "rsqrt(x) = 1 / sqrt(x).",
                          [llvm_halforfloat_ty, LLVMMatchType<0>]>;
+def Rbits : DXILOpMapping<30, unary, int_bitreverse,
+                         "Returns the specified value with its bits reversed.",
+                         [llvm_anyint_ty, LLVMMatchType<0>]>;
 def Round : DXILOpMapping<26, unary, int_round,
                          "Returns the input rounded to the nearest integer"
                          "within a floating-point type.",

--- a/llvm/test/CodeGen/DirectX/reversebits.ll
+++ b/llvm/test/CodeGen/DirectX/reversebits.ll
@@ -25,3 +25,7 @@ entry:
   %elt.bitreverse = call i64 @llvm.bitreverse.i64(i64 %a)
   ret i64 %elt.bitreverse
 }
+
+declare i16 @llvm.bitreverse.i16(i16)
+declare i32 @llvm.bitreverse.i32(i32)
+declare i64 @llvm.bitreverse.i64(i64)

--- a/llvm/test/CodeGen/DirectX/reversebits.ll
+++ b/llvm/test/CodeGen/DirectX/reversebits.ll
@@ -1,0 +1,27 @@
+; RUN: opt -S -dxil-op-lower < %s | FileCheck %s
+
+; Make sure dxil operation function calls for reversebits are generated for all integer types.
+
+; Function Attrs: nounwind
+define noundef i16 @test_bitreverse_short(i16 noundef %a) #0 {
+entry:
+; CHECK:call i16 @dx.op.unary.i16(i32 30, i16 %{{.*}})
+  %elt.bitreverse = call i16 @llvm.bitreverse.i16(i16 %a)
+  ret i16 %elt.bitreverse
+}
+
+; Function Attrs: nounwind
+define noundef i32 @test_bitreverse_int(i32 noundef %a) #0 {
+entry:
+; CHECK:call i32 @dx.op.unary.i32(i32 30, i32 %{{.*}})
+  %elt.bitreverse = call i32 @llvm.bitreverse.i32(i32 %a)
+  ret i32 %elt.bitreverse
+}
+
+; Function Attrs: nounwind
+define noundef i64 @test_bitreverse_long(i64 noundef %a) #0 {
+entry:
+; CHECK:call i64 @dx.op.unary.i64(i32 30, i64 %{{.*}})
+  %elt.bitreverse = call i64 @llvm.bitreverse.i64(i64 %a)
+  ret i64 %elt.bitreverse
+}

--- a/llvm/test/CodeGen/DirectX/reversebits.ll
+++ b/llvm/test/CodeGen/DirectX/reversebits.ll
@@ -3,7 +3,7 @@
 ; Make sure dxil operation function calls for reversebits are generated for all integer types.
 
 ; Function Attrs: nounwind
-define noundef i16 @test_bitreverse_short(i16 noundef %a) #0 {
+define noundef i16 @test_bitreverse_short(i16 noundef %a) {
 entry:
 ; CHECK:call i16 @dx.op.unary.i16(i32 30, i16 %{{.*}})
   %elt.bitreverse = call i16 @llvm.bitreverse.i16(i16 %a)
@@ -11,7 +11,7 @@ entry:
 }
 
 ; Function Attrs: nounwind
-define noundef i32 @test_bitreverse_int(i32 noundef %a) #0 {
+define noundef i32 @test_bitreverse_int(i32 noundef %a) {
 entry:
 ; CHECK:call i32 @dx.op.unary.i32(i32 30, i32 %{{.*}})
   %elt.bitreverse = call i32 @llvm.bitreverse.i32(i32 %a)
@@ -19,7 +19,7 @@ entry:
 }
 
 ; Function Attrs: nounwind
-define noundef i64 @test_bitreverse_long(i64 noundef %a) #0 {
+define noundef i64 @test_bitreverse_long(i64 noundef %a) {
 entry:
 ; CHECK:call i64 @dx.op.unary.i64(i32 30, i64 %{{.*}})
   %elt.bitreverse = call i64 @llvm.bitreverse.i64(i64 %a)

--- a/llvm/test/CodeGen/DirectX/trunc.ll
+++ b/llvm/test/CodeGen/DirectX/trunc.ll
@@ -15,3 +15,6 @@ entry:
   %elt.trunc = call half @llvm.trunc.f16(half %a)
   ret half %elt.trunc
 }
+
+declare half @llvm.trunc.f16(half)
+declare float @llvm.trunc.f32(float)

--- a/llvm/test/CodeGen/DirectX/trunc.ll
+++ b/llvm/test/CodeGen/DirectX/trunc.ll
@@ -1,0 +1,17 @@
+; RUN: opt -S -dxil-op-lower < %s | FileCheck %s
+
+; Make sure dxil operation function calls for trunc are generated for float and half.
+
+define noundef float @trunc_float(float noundef %a) #0 {
+entry:
+; CHECK:call float @dx.op.unary.f32(i32 29, float %{{.*}})
+  %elt.trunc = call float @llvm.trunc.f32(float %a)
+  ret float %elt.trunc
+}
+
+define noundef half @trunc_half(half noundef %a) #0 {
+entry:
+; CHECK:call half @dx.op.unary.f16(i32 29, half %{{.*}})
+  %elt.trunc = call half @llvm.trunc.f16(half %a)
+  ret half %elt.trunc
+}

--- a/llvm/test/CodeGen/DirectX/trunc.ll
+++ b/llvm/test/CodeGen/DirectX/trunc.ll
@@ -2,14 +2,14 @@
 
 ; Make sure dxil operation function calls for trunc are generated for float and half.
 
-define noundef float @trunc_float(float noundef %a) #0 {
+define noundef float @trunc_float(float noundef %a) {
 entry:
 ; CHECK:call float @dx.op.unary.f32(i32 29, float %{{.*}})
   %elt.trunc = call float @llvm.trunc.f32(float %a)
   ret float %elt.trunc
 }
 
-define noundef half @trunc_half(half noundef %a) #0 {
+define noundef half @trunc_half(half noundef %a) {
 entry:
 ; CHECK:call half @dx.op.unary.f16(i32 29, half %{{.*}})
   %elt.trunc = call half @llvm.trunc.f16(half %a)

--- a/llvm/test/CodeGen/DirectX/trunc_error.ll
+++ b/llvm/test/CodeGen/DirectX/trunc_error.ll
@@ -1,0 +1,10 @@
+; RUN: not opt -S -dxil-op-lower %s 2>&1 | FileCheck %s
+
+; DXIL operation trunc does not support double overload type
+; CHECK: LLVM ERROR: Invalid Overload Type
+
+define noundef double @trunc_double(double noundef %a) {
+entry:
+  %elt.trunc = call double @llvm.trunc.f64(double %a)
+  ret double %elt.trunc
+}


### PR DESCRIPTION
Add lowering of `llvm.bitreverse` and `llvm.trunc` intrinsics to DXIL ops.

Fixes #86582
Fixes #86581