### PR TITLE
[clang][Sema] Fix a CTAD regression after 42239d2e9

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -345,6 +345,9 @@ Bug Fixes in This Version
 - Fixes an assertion failure on invalid code when trying to define member
   functions in lambdas.
 
+- Fixed a regression in CTAD that a friend declaration that befriends itself may cause
+  incorrect constraint substitution. (#GH86769).
+
 Bug Fixes to Compiler Builtins
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/clang/lib/Sema/SemaTemplate.cpp
+++ b/clang/lib/Sema/SemaTemplate.cpp
@@ -1837,7 +1837,7 @@ static TemplateParameterList *GetTemplateParameterList(TemplateDecl *TD) {
   // recent declaration, since that is the only one that is guaranteed to
   // have all the default template argument information.
   Decl *D = TD->getMostRecentDecl();
-  // N3337 [temp.param]p12:
+  // C++11 N3337 [temp.param]p12:
   // A default template argument shall not be specified in a friend class
   // template declaration.
   //

--- a/clang/lib/Sema/SemaTemplate.cpp
+++ b/clang/lib/Sema/SemaTemplate.cpp
@@ -1836,19 +1836,27 @@ static TemplateParameterList *GetTemplateParameterList(TemplateDecl *TD) {
   // Make sure we get the template parameter list from the most
   // recent declaration, since that is the only one that is guaranteed to
   // have all the default template argument information.
-  Decl *ND = TD->getMostRecentDecl();
-  // Skip past friend Decls because they are not supposed to contain default
-  // template arguments. Moreover, these declarations may introduce template
-  // parameters living in different template depths than the corresponding
-  // template parameters in TD, causing unmatched constraint substitution.
-  //
-  // C++23 N4950 [temp.param]p12
+  Decl *D = TD->getMostRecentDecl();
+  // N3337 [temp.param]p12:
   // A default template argument shall not be specified in a friend class
   // template declaration.
-  while (ND->getFriendObjectKind() != Decl::FriendObjectKind::FOK_None &&
-         ND->getPreviousDecl())
-    ND = ND->getPreviousDecl();
-  return cast<TemplateDecl>(ND)->getTemplateParameters();
+  //
+  // Skip past friend *declarations* because they are not supposed to contain
+  // default template arguments. Moreover, these declarations may introduce
+  // template parameters living in different template depths than the
+  // corresponding template parameters in TD, causing unmatched constraint
+  // substitution.
+  //
+  // FIXME: Diagnose such cases within a class template:
+  //  template <class T>
+  //  struct S {
+  //    template <class = void> friend struct C;
+  //  };
+  //  template struct S<int>;
+  while (D->getFriendObjectKind() != Decl::FriendObjectKind::FOK_None &&
+         D->getPreviousDecl())
+    D = D->getPreviousDecl();
+  return cast<TemplateDecl>(D)->getTemplateParameters();
 }
 
 DeclResult Sema::CheckClassTemplate(

--- a/clang/test/SemaTemplate/concepts-friends.cpp
+++ b/clang/test/SemaTemplate/concepts-friends.cpp
@@ -493,7 +493,9 @@ template <X T> struct Y {
 
 template <class T>
 struct Z {
-  // FIXME: This is ill-formed per N4950 [temp.param]p12.
+  // FIXME: This is ill-formed per N3337 [temp.param]p12:
+  // A default template argument shall not be specified in a friend class
+  // template declaration.
   template <X U = void> friend struct Y;
 };
 

--- a/clang/test/SemaTemplate/concepts-friends.cpp
+++ b/clang/test/SemaTemplate/concepts-friends.cpp
@@ -478,3 +478,27 @@ template <Concept> class Foo {
 };
 
 } // namespace FriendOfFriend
+
+namespace GH86769 {
+
+template <typename T>
+concept X = true;
+
+template <X T> struct Y {
+  Y(T) {}
+  template <X U> friend struct Y;
+  template <X U> friend struct Y;
+  template <X U> friend struct Y;
+};
+
+template <class T>
+struct Z {
+  // FIXME: This is ill-formed per N4950 [temp.param]p12.
+  template <X U = void> friend struct Y;
+};
+
+template struct Y<int>;
+template struct Z<int>;
+Y y(1);
+
+}

--- a/clang/test/SemaTemplate/concepts-friends.cpp
+++ b/clang/test/SemaTemplate/concepts-friends.cpp
@@ -493,7 +493,7 @@ template <X T> struct Y {
 
 template <class T>
 struct Z {
-  // FIXME: This is ill-formed per N3337 [temp.param]p12:
+  // FIXME: This is ill-formed per C++11 N3337 [temp.param]p12:
   // A default template argument shall not be specified in a friend class
   // template declaration.
   template <X U = void> friend struct Y;

--- a/clang/test/SemaTemplate/ctad.cpp
+++ b/clang/test/SemaTemplate/ctad.cpp
@@ -53,4 +53,4 @@ X x;
 template<class T, class B> struct Y { Y(T); };
 template<class T, class B=void> struct Y ;
 Y y(1);
-};
+}


### PR DESCRIPTION
The most recent declaration of a template as a friend can introduce a different template parameter depth compared to what we anticipate from a CTAD guide.

Fixes https://github.com/llvm/llvm-project/issues/86769