### PR TITLE
[libc] Provide empty weak implementation of baremetal OSUtil

### DIFF
--- a/libc/src/__support/OSUtil/baremetal/io.cpp
+++ b/libc/src/__support/OSUtil/baremetal/io.cpp
@@ -11,7 +11,7 @@
 #include "src/__support/CPP/string_view.h"
 
 // This is intended to be provided by the vendor.
-extern "C" void __llvm_libc_log_write(const char *msg, size_t len);
+extern "C" [[gnu::weak]] void __llvm_libc_log_write(const char *, size_t) {}
 
 namespace LIBC_NAMESPACE {
 

--- a/libc/src/__support/OSUtil/baremetal/quick_exit.cpp
+++ b/libc/src/__support/OSUtil/baremetal/quick_exit.cpp
@@ -9,7 +9,9 @@
 #include "src/__support/OSUtil/quick_exit.h"
 
 // This is intended to be provided by the vendor.
-extern "C" [[noreturn]] void __llvm_libc_quick_exit(int status);
+extern "C" [[gnu::weak]] [[noreturn]] void __llvm_libc_quick_exit(int) {
+  __builtin_trap();
+}
 
 namespace LIBC_NAMESPACE {
 


### PR DESCRIPTION
This avoids vendor having to provide one in order to link the libc.