### PR TITLE
[libclang/python] export libclang version to the bindings

### DIFF
--- a/clang/bindings/python/clang/cindex.py
+++ b/clang/bindings/python/clang/cindex.py
@@ -4339,6 +4339,7 @@ FUNCTION_LIST: list[LibFunc] = [
     ("clang_getCanonicalCursor", [Cursor], Cursor),
     ("clang_getCanonicalType", [Type], Type),
     ("clang_getChildDiagnostics", [Diagnostic], c_object_p),
+    ("clang_getClangVersion", [], _CXString),
     ("clang_getCompletionAvailability", [c_void_p], c_int),
     ("clang_getCompletionBriefComment", [c_void_p], _CXString),
     ("clang_getCompletionChunkCompletionString", [c_void_p, c_int], c_object_p),
@@ -4649,6 +4650,11 @@ class Config:
 
         return library
 
+    def get_version(self):
+        """
+        Returns the libclang version string used by the bindings
+        """
+        return _CXString.from_result(self.lib.clang_getClangVersion())
 
 conf = Config()
 

--- a/clang/bindings/python/tests/cindex/test_version.py
+++ b/clang/bindings/python/tests/cindex/test_version.py
@@ -1,0 +1,11 @@
+import unittest
+import re
+from clang.cindex import Config
+
+
+class TestClangVersion(unittest.TestCase):
+    def test_get_version_format(self):
+        conf = Config()
+        version = conf.get_version()
+
+        self.assertRegex(version, r"^clang version \d+\.\d+\.\d+")

--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -544,6 +544,8 @@ Python Binding Changes
   ``CodeCompletionResults.results`` should be changed to directly use
   ``CodeCompletionResults``: it nows supports ``__len__`` and ``__getitem__``,
   so it can be used the same as ``CodeCompletionResults.results``.
+- Added a new helper method ``get_version`` to the class ``Config`` to read the
+  version string of the libclang in use
 
 OpenMP Support
 --------------

--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -545,7 +545,7 @@ Python Binding Changes
   ``CodeCompletionResults``: it nows supports ``__len__`` and ``__getitem__``,
   so it can be used the same as ``CodeCompletionResults.results``.
 - Added a new helper method ``get_version`` to the class ``Config`` to read the
-  version string of the libclang in use
+  version string of the libclang in use.
 
 OpenMP Support
 --------------


### PR DESCRIPTION
it's useful to know which clang library the python byndings are running