### PR TITLE
[clangd][trace] Fix comment to mention that trace spans are measured …

### DIFF
--- a/clang-tools-extra/clangd/support/Trace.h
+++ b/clang-tools-extra/clangd/support/Trace.h
@@ -143,8 +143,8 @@ bool enabled();
 class Span {
 public:
   Span(llvm::Twine Name);
-  /// Records span's duration in seconds to \p LatencyMetric with \p Name as the
-  /// label.
+  /// Records span's duration in milliseconds to \p LatencyMetric with \p Name
+  /// as the label.
   Span(llvm::Twine Name, const Metric &LatencyMetric);
   ~Span();
 


### PR DESCRIPTION
…in milliseconds rather than seconds.