### PR TITLE
[lldb] Remove cmake check for pexpect with LLDB_TEST_USE_VENDOR_PACKAGES

### DIFF
--- a/lldb/test/CMakeLists.txt
+++ b/lldb/test/CMakeLists.txt
@@ -31,23 +31,6 @@ if(LLDB_ENFORCE_STRICT_TEST_REQUIREMENTS)
   endforeach()
 endif()
 
-# The "pexpect" package should come from the system environment, not from the
-# LLDB tree. However, we delay the deletion of it from the tree in case
-# users/buildbots don't have the package yet and need some time to install it.
-# Windows is configured to skip all pexpect tests, and guards all
-# "import pexpect" calls, so we do not need pexpect installed there.
-if (NOT LLDB_TEST_USE_VENDOR_PACKAGES AND NOT WIN32)
-  unset(PY_pexpect_FOUND CACHE)
-  lldb_find_python_module(pexpect)
-  if (NOT PY_pexpect_FOUND)
-    message(FATAL_ERROR
-      "Python module 'pexpect' not found. Please install it via pip or via "
-      "your operating system's package manager. For a temporary workaround, "
-      "use a version from the LLDB tree with "
-      "`LLDB_TEST_USE_VENDOR_PACKAGES=ON`")
-  endif()
-endif()
-
 if(LLDB_BUILT_STANDALONE)
   # In order to run check-lldb-* we need the correct map_config directives in
   # llvm-lit. Because this is a standalone build, LLVM doesn't know about LLDB,


### PR DESCRIPTION
The commit 8bed754c2f965c8cbbb050be6f650b78f7fd78a6 was intended to support the use case where users want to run all the LLDB tests in an environment where pexpect is not installed. Those users can build with `-DLLDB_TEST_USER_ARGS=--skip-category=pexpect` to skip pexpect tests, *but* because we still fail in cmake configuration, they must use `-DLLDB_TEST_USE_VENDOR_PACKAGES=ON` to avoid failing due to pexpect not being available.

I would like to remove `LLDB_TEST_USE_VENDOR_PACKAGES` now, but first I'd like to make sure users w/o pexpect can pass CI with `-DLLDB_TEST_USE_VENDOR_PACKAGES=OFF -DLLDB_TEST_USER_ARGS=--skip-category=pexpect`. Once that is done, I am not aware of any other issues caused by the previous commits, so the third party tree should be safe to remove.