### PR TITLE
[GISEL] G_SPLAT_VECTOR can take a splat that is larger than the vector element

### DIFF
--- a/llvm/docs/GlobalISel/GenericOpcode.rst
+++ b/llvm/docs/GlobalISel/GenericOpcode.rst
@@ -690,8 +690,8 @@ G_SPLAT_VECTOR
 
 Create a vector where all elements are the scalar from the source operand.
 
-The type of the operand must be equal to or smaller than the vector element
-type. If the operand is smaller than the vector element type, the scalar is
+The type of the operand must be equal to or larger than the vector element
+type. If the operand is larger than the vector element type, the scalar is
 implicitly truncated to the vector element type.
 
 Vector Reduction Operations

--- a/llvm/docs/GlobalISel/GenericOpcode.rst
+++ b/llvm/docs/GlobalISel/GenericOpcode.rst
@@ -690,6 +690,10 @@ G_SPLAT_VECTOR
 
 Create a vector where all elements are the scalar from the source operand.
 
+The type of the operand must be equal to or smaller than the vector element
+type. If the operand is smaller than the vector element type, the scalar is
+implicitly truncated to the vector element type.
+
 Vector Reduction Operations
 ---------------------------
 

--- a/llvm/lib/CodeGen/MachineVerifier.cpp
+++ b/llvm/lib/CodeGen/MachineVerifier.cpp
@@ -1778,7 +1778,7 @@ void MachineVerifier::verifyPreISelGenericInstruction(const MachineInstr *MI) {
       break;
     }
 
-    if (TypeSize::isKnownGT(DstTy.getScalarType().getSizeInBits(),
+    if (TypeSize::isKnownGT(DstTy.getElementType().getSizeInBits(),
                             SrcTy.getSizeInBits())) {
       report("Element type of the destination must be the same size or smaller "
              "than the source type",

--- a/llvm/lib/CodeGen/MachineVerifier.cpp
+++ b/llvm/lib/CodeGen/MachineVerifier.cpp
@@ -1774,9 +1774,10 @@ void MachineVerifier::verifyPreISelGenericInstruction(const MachineInstr *MI) {
     if (!SrcTy.isScalar())
       report("Source type must be a scalar", MI);
 
-    if (DstTy.getScalarType() != SrcTy)
-      report("Element type of the destination must be the same type as the "
-             "source type",
+    if (TypeSize::isKnownGT(DstTy.getScalarType().getSizeInBits(),
+                            SrcTy.getSizeInBits()))
+      report("Element type of the destination must be the same size or smaller "
+             "than the source type",
              MI);
 
     break;

--- a/llvm/lib/CodeGen/MachineVerifier.cpp
+++ b/llvm/lib/CodeGen/MachineVerifier.cpp
@@ -1768,17 +1768,23 @@ void MachineVerifier::verifyPreISelGenericInstruction(const MachineInstr *MI) {
     LLT DstTy = MRI->getType(MI->getOperand(0).getReg());
     LLT SrcTy = MRI->getType(MI->getOperand(1).getReg());
 
-    if (!DstTy.isScalableVector())
+    if (!DstTy.isScalableVector()) {
       report("Destination type must be a scalable vector", MI);
+      break;
+    }
 
-    if (!SrcTy.isScalar())
+    if (!SrcTy.isScalar()) {
       report("Source type must be a scalar", MI);
+      break;
+    }
 
     if (TypeSize::isKnownGT(DstTy.getScalarType().getSizeInBits(),
-                            SrcTy.getSizeInBits()))
+                            SrcTy.getSizeInBits())) {
       report("Element type of the destination must be the same size or smaller "
              "than the source type",
              MI);
+      break;
+    }
 
     break;
   }

--- a/llvm/test/MachineVerifier/test_g_splat_vector.mir
+++ b/llvm/test/MachineVerifier/test_g_splat_vector.mir
@@ -22,6 +22,6 @@ body:             |
     ; CHECK: Source type must be a scalar
     %6:_(<vscale x 2 x s32>) = G_SPLAT_VECTOR %2
 
-    ; CHECK: Element type of the destination must be the same type as the source type
-    %7:_(<vscale x 2 x s64>) = G_SPLAT_VECTOR %0
+    ; CHECK: Element type of the destination must be the same size or smaller than the source type
+    %7:_(<vscale x 2 x s128>) = G_SPLAT_VECTOR %0
 ...


### PR DESCRIPTION
This is what SelectionDAG does. We'd like to reuse SelectionDAG patterns.