### PR TITLE
[clang][Darwin] Handle reexported library arguments in driver

### DIFF
--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -3635,6 +3635,9 @@ defm preserve_as_comments : BoolFOption<"preserve-as-comments",
           "Do not preserve comments in inline assembly">,
   PosFlag<SetTrue>>;
 def framework : Separate<["-"], "framework">, Flags<[LinkerInput]>;
+def reexport_framework : Separate<["-"], "reexport_framework">, Flags<[LinkerInput]>;
+def reexport_l : Joined<["-"], "reexport-l">, Flags<[LinkerInput]>;
+def reexport_library : JoinedOrSeparate<["-"], "reexport_library">, Flags<[LinkerInput]>;
 def frandom_seed_EQ : Joined<["-"], "frandom-seed=">, Group<clang_ignored_f_Group>;
 def freg_struct_return : Flag<["-"], "freg-struct-return">, Group<f_Group>,
   Visibility<[ClangOption, CC1Option]>,

--- a/clang/test/Driver/darwin-ld-reexports.c
+++ b/clang/test/Driver/darwin-ld-reexports.c
@@ -1,0 +1,21 @@
+// RUN: touch %t.o
+// RUN: %clang -target arm64-apple-darwin13 -### \
+// RUN: -reexport_framework Foo -reexport-lBar -reexport_library Baz %t.o 2> %t.log
+
+// Check older spellings also work.
+// RUN: %clang -target arm64-apple-darwin13 -### \
+// RUN: -Xlinker -reexport_framework -Xlinker Forest \
+// RUN: -Xlinker -reexport-lBranch \
+// RUN: -Xlinker -reexport_library -Xlinker Flower %t.o 2>> %t.log
+// RUN: FileCheck -check-prefix=LINK_REEXPORT %s < %t.log
+
+// LINK_REEXPORT: {{ld(.exe)?"}}
+// LINK_REEXPORT: "-reexport_framework" "Foo"
+// LINK_REEXPORT: "-reexport-lBar"
+// LINK_REEXPORT: "-reexport_library" "Baz"
+// LINK_REEXPORT: "-reexport_framework" "Forest"
+// LINK_REEXPORT: "-reexport-lBranch"
+// LINK_REEXPORT: "-reexport_library" "Flower"
+
+// Make sure arguments are not repeated.
+// LINK_REEXPORT-NOT: "-reexport


### PR DESCRIPTION
`-reexport*` is the newer spelling for `-sub-library` which is already supported by the clang driver when invoking ld.
Support the new spellings when passed by the user. This also helps simplify `clang-installapi` driver logic.