### PR TITLE
[scudo] Change tests that use setrlimit to cause mmap to fail.

### DIFF
--- a/compiler-rt/lib/scudo/standalone/tests/strings_test.cpp
+++ b/compiler-rt/lib/scudo/standalone/tests/strings_test.cpp
@@ -143,7 +143,8 @@ TEST(ScudoStringsTest, CapacityIncreaseFails) {
 
   // qemu does not honor the setrlimit, so verify before proceeding.
   scudo::MemMapT MemMap;
-  if (MemMap.map(/*Addr=*/0U, scudo::getPageSizeCached(), "scudo:test", MAP_ALLOWNOMEM)) {
+  if (MemMap.map(/*Addr=*/0U, scudo::getPageSizeCached(), "scudo:test",
+                 MAP_ALLOWNOMEM)) {
     MemMap.unmap(MemMap.getBase(), MemMap.getCapacity());
     setrlimit(RLIMIT_AS, &Limit);
     GTEST_SKIP() << "Limiting address space does not prevent mmap.";

--- a/compiler-rt/lib/scudo/standalone/tests/strings_test.cpp
+++ b/compiler-rt/lib/scudo/standalone/tests/strings_test.cpp
@@ -142,7 +142,6 @@ TEST(ScudoStringsTest, CapacityIncreaseFails) {
   rlimit EmptyLimit = {.rlim_cur = 0, .rlim_max = Limit.rlim_max};
   EXPECT_EQ(0, setrlimit(RLIMIT_AS, &EmptyLimit));
 
-#if !SCUDO_ANDROID
   // qemu does not honor the setrlimit, so verify before proceeding.
   void *ptr = mmap(nullptr, 100, PROT_READ | PROT_WRITE,
                    MAP_ANONYMOUS | MAP_PRIVATE, -1, 0);
@@ -151,7 +150,6 @@ TEST(ScudoStringsTest, CapacityIncreaseFails) {
     setrlimit(RLIMIT_AS, &Limit);
     GTEST_SKIP() << "Limiting address space does not prevent mmap.";
   }
-#endif
 
   // Test requires that the default length is at least 6 characters.
   scudo::uptr MaxSize = Str.capacity();

--- a/compiler-rt/lib/scudo/standalone/tests/strings_test.cpp
+++ b/compiler-rt/lib/scudo/standalone/tests/strings_test.cpp
@@ -144,7 +144,8 @@ TEST(ScudoStringsTest, CapacityIncreaseFails) {
 
 #if !SCUDO_ANDROID
   // qemu does not honor the setrlimit, so verify before proceeding.
-  void *ptr = mmap(nullptr, 100, PROT_READ | PROT_WRITE, MAP_ANONYMOUS | MAP_PRIVATE, -1, 0);
+  void *ptr = mmap(nullptr, 100, PROT_READ | PROT_WRITE,
+                   MAP_ANONYMOUS | MAP_PRIVATE, -1, 0);
   if (ptr != MAP_FAILED) {
     munmap(ptr, 100);
     setrlimit(RLIMIT_AS, &Limit);

--- a/compiler-rt/lib/scudo/standalone/tests/strings_test.cpp
+++ b/compiler-rt/lib/scudo/standalone/tests/strings_test.cpp
@@ -130,7 +130,6 @@ TEST(ScudoStringsTest, Padding) {
 
 #if defined(__linux__)
 
-#include <sys/mman.h>
 #include <sys/resource.h>
 
 TEST(ScudoStringsTest, CapacityIncreaseFails) {
@@ -143,10 +142,9 @@ TEST(ScudoStringsTest, CapacityIncreaseFails) {
   EXPECT_EQ(0, setrlimit(RLIMIT_AS, &EmptyLimit));
 
   // qemu does not honor the setrlimit, so verify before proceeding.
-  void *ptr = mmap(nullptr, 100, PROT_READ | PROT_WRITE,
-                   MAP_ANONYMOUS | MAP_PRIVATE, -1, 0);
-  if (ptr != MAP_FAILED) {
-    munmap(ptr, 100);
+  scudo::MemMapT MemMap;
+  if (MemMap.map(/*Addr=*/0U, scudo::getPageSizeCached(), "scudo:test", MAP_ALLOWNOMEM)) {
+    MemMap.unmap(MemMap.getBase(), MemMap.getCapacity());
     setrlimit(RLIMIT_AS, &Limit);
     GTEST_SKIP() << "Limiting address space does not prevent mmap.";
   }

--- a/compiler-rt/lib/scudo/standalone/tests/vector_test.cpp
+++ b/compiler-rt/lib/scudo/standalone/tests/vector_test.cpp
@@ -59,7 +59,6 @@ TEST(ScudoVectorTest, ReallocateFails) {
   rlimit EmptyLimit = {.rlim_cur = 0, .rlim_max = Limit.rlim_max};
   EXPECT_EQ(0, setrlimit(RLIMIT_AS, &EmptyLimit));
 
-#if !SCUDO_ANDROID
   // qemu does not honor the setrlimit, so verify before proceeding.
   void *ptr = mmap(nullptr, 100, PROT_READ | PROT_WRITE,
                    MAP_ANONYMOUS | MAP_PRIVATE, -1, 0);
@@ -68,7 +67,6 @@ TEST(ScudoVectorTest, ReallocateFails) {
     setrlimit(RLIMIT_AS, &Limit);
     GTEST_SKIP() << "Limiting address space does not prevent mmap.";
   }
-#endif
 
   V.resize(capacity);
   // Set the last element so we can check it later.

--- a/compiler-rt/lib/scudo/standalone/tests/vector_test.cpp
+++ b/compiler-rt/lib/scudo/standalone/tests/vector_test.cpp
@@ -44,6 +44,7 @@ TEST(ScudoVectorTest, ResizeReduction) {
 
 #if defined(__linux__)
 
+#include <sys/mman.h>
 #include <sys/resource.h>
 
 // Verify that if the reallocate fails, nothing new is added.
@@ -57,6 +58,16 @@ TEST(ScudoVectorTest, ReallocateFails) {
 
   rlimit EmptyLimit = {.rlim_cur = 0, .rlim_max = Limit.rlim_max};
   EXPECT_EQ(0, setrlimit(RLIMIT_AS, &EmptyLimit));
+
+#if !SCUDO_ANDROID
+  // qemu does not honor the setrlimit, so verify before proceeding.
+  void *ptr = mmap(nullptr, 100, PROT_READ | PROT_WRITE, MAP_ANONYMOUS | MAP_PRIVATE, -1, 0);
+  if (ptr != MAP_FAILED) {
+    munmap(ptr, 100);
+    setrlimit(RLIMIT_AS, &Limit);
+    GTEST_SKIP() << "Limiting address space does not prevent mmap.";
+  }
+#endif
 
   V.resize(capacity);
   // Set the last element so we can check it later.

--- a/compiler-rt/lib/scudo/standalone/tests/vector_test.cpp
+++ b/compiler-rt/lib/scudo/standalone/tests/vector_test.cpp
@@ -60,7 +60,8 @@ TEST(ScudoVectorTest, ReallocateFails) {
 
   // qemu does not honor the setrlimit, so verify before proceeding.
   scudo::MemMapT MemMap;
-  if (MemMap.map(/*Addr=*/0U, scudo::getPageSizeCached(), "scudo:test", MAP_ALLOWNOMEM)) {
+  if (MemMap.map(/*Addr=*/0U, scudo::getPageSizeCached(), "scudo:test",
+                 MAP_ALLOWNOMEM)) {
     MemMap.unmap(MemMap.getBase(), MemMap.getCapacity());
     setrlimit(RLIMIT_AS, &Limit);
     GTEST_SKIP() << "Limiting address space does not prevent mmap.";

--- a/compiler-rt/lib/scudo/standalone/tests/vector_test.cpp
+++ b/compiler-rt/lib/scudo/standalone/tests/vector_test.cpp
@@ -44,7 +44,6 @@ TEST(ScudoVectorTest, ResizeReduction) {
 
 #if defined(__linux__)
 
-#include <sys/mman.h>
 #include <sys/resource.h>
 
 // Verify that if the reallocate fails, nothing new is added.
@@ -60,10 +59,9 @@ TEST(ScudoVectorTest, ReallocateFails) {
   EXPECT_EQ(0, setrlimit(RLIMIT_AS, &EmptyLimit));
 
   // qemu does not honor the setrlimit, so verify before proceeding.
-  void *ptr = mmap(nullptr, 100, PROT_READ | PROT_WRITE,
-                   MAP_ANONYMOUS | MAP_PRIVATE, -1, 0);
-  if (ptr != MAP_FAILED) {
-    munmap(ptr, 100);
+  scudo::MemMapT MemMap;
+  if (MemMap.map(/*Addr=*/0U, scudo::getPageSizeCached(), "scudo:test", MAP_ALLOWNOMEM)) {
+    MemMap.unmap(MemMap.getBase(), MemMap.getCapacity());
     setrlimit(RLIMIT_AS, &Limit);
     GTEST_SKIP() << "Limiting address space does not prevent mmap.";
   }

--- a/compiler-rt/lib/scudo/standalone/tests/vector_test.cpp
+++ b/compiler-rt/lib/scudo/standalone/tests/vector_test.cpp
@@ -61,7 +61,8 @@ TEST(ScudoVectorTest, ReallocateFails) {
 
 #if !SCUDO_ANDROID
   // qemu does not honor the setrlimit, so verify before proceeding.
-  void *ptr = mmap(nullptr, 100, PROT_READ | PROT_WRITE, MAP_ANONYMOUS | MAP_PRIVATE, -1, 0);
+  void *ptr = mmap(nullptr, 100, PROT_READ | PROT_WRITE,
+                   MAP_ANONYMOUS | MAP_PRIVATE, -1, 0);
   if (ptr != MAP_FAILED) {
     munmap(ptr, 100);
     setrlimit(RLIMIT_AS, &Limit);


### PR DESCRIPTION
It appears that qemu does not actually cause mmap to fail when calling setrlimit to limit the address space size. In the two tests that use setrlimit, detect if mmap still works and skip the tests in that case.

Since all Android targets should support setrlimit, compile out the mmap check code for them.