### PR TITLE
[APINotes] Add test for C++ class templates

### DIFF
--- a/clang/test/APINotes/Inputs/Headers/Templates.apinotes
+++ b/clang/test/APINotes/Inputs/Headers/Templates.apinotes
@@ -1,0 +1,5 @@
+---
+Name: Templates
+Tags:
+- Name: Box
+  SwiftImportAs: owned

--- a/clang/test/APINotes/Inputs/Headers/Templates.h
+++ b/clang/test/APINotes/Inputs/Headers/Templates.h
@@ -1,0 +1,9 @@
+template <typename T>
+struct Box {
+  T value;
+
+  const T& get_value() const { return value; }
+  const T* get_ptr() const { return &value; }
+};
+
+using IntBox = Box<int>;

--- a/clang/test/APINotes/Inputs/Headers/module.modulemap
+++ b/clang/test/APINotes/Inputs/Headers/module.modulemap
@@ -36,6 +36,10 @@ module Namespaces {
   header "Namespaces.h"
 }
 
+module Templates {
+  header "Templates.h"
+}
+
 module SwiftImportAs {
   header "SwiftImportAs.h"
 }

--- a/clang/test/APINotes/templates.cpp
+++ b/clang/test/APINotes/templates.cpp
@@ -1,0 +1,9 @@
+// RUN: rm -rf %t && mkdir -p %t
+// RUN: %clang_cc1 -fmodules -fblocks -fimplicit-module-maps -fmodules-cache-path=%t/ModulesCache/Tmpl -fdisable-module-hash -fapinotes-modules -fsyntax-only -I %S/Inputs/Headers -F %S/Inputs/Frameworks %s -x c++
+// RUN: %clang_cc1 -fmodules -fblocks -fimplicit-module-maps -fmodules-cache-path=%t/ModulesCache/Tmpl -fdisable-module-hash -fapinotes-modules -fsyntax-only -I %S/Inputs/Headers -F %S/Inputs/Frameworks %s -ast-dump -ast-dump-filter Box -x c++ | FileCheck -check-prefix=CHECK-BOX %s
+
+#include "Templates.h"
+
+// CHECK-BOX: Dumping Box:
+// CHECK-BOX-NEXT: ClassTemplateDecl {{.+}} imported in Templates Box
+// CHECK-BOX: SwiftAttrAttr {{.+}} <<invalid sloc>> "import_owned"


### PR DESCRIPTION
This upstreams https://github.com/apple/llvm-project/pull/7930.

This adds a test to verify that we can apply attributes to C++ class templates using API Notes. Doing the same for function templates is not currently possible and requires more work.