### PR TITLE
[RFC][libc] Codify header inclusion policy

### DIFF
--- a/libc/docs/usage_modes.rst
+++ b/libc/docs/usage_modes.rst
@@ -6,6 +6,10 @@ The libc can used in two different modes:
 
 #. The **overlay** mode: In this mode, the link order semantics are exploited
    to overlay implementations from LLVM's libc over the system libc. See
-   :ref:`overlay_mode` for more information about this mode.
+   :ref:`overlay_mode` for more information about this mode. In this mode, libc
+   uses the ABI of the system it's being overlayed onto. Headers are NOT
+   generated. libllvmlibc.a is the only build artifact.
 #. The **fullbuild** mode: In this mode, LLVM's libc is used as the only libc
    for the binary. See :ref:`fullbuild_mode` for information about this mode.
+   In this mode, libc uses its own ABI. Headers are generated along with a
+   libc.a.

--- a/libc/hdr/CMakeLists.txt
+++ b/libc/hdr/CMakeLists.txt
@@ -40,3 +40,5 @@ add_proxy_header_library(
     libc.include.llvm-libc-macros.fenv_macros
     libc.include.fenv
 )
+
+add_subdirectory(types)

--- a/libc/hdr/types/CMakeLists.txt
+++ b/libc/hdr/types/CMakeLists.txt
@@ -1,0 +1,23 @@
+add_proxy_header_library(
+  sigset_t
+  HDRS
+    sigset_t.h
+  FULL_BUILD_DEPENDS
+    libc.include.llvm-libc-types.sigset_t
+)
+
+add_proxy_header_library(
+  struct_epoll_event
+  HDRS
+    struct_epoll_event.h
+  FULL_BUILD_DEPENDS
+    libc.include.llvm-libc-types.struct_epoll_event
+)
+
+add_proxy_header_library(
+  struct_timespec
+  HDRS
+    struct_timespec.h
+  FULL_BUILD_DEPENDS
+    libc.include.llvm-libc-types.struct_timespec
+)

--- a/libc/hdr/types/sigset_t.h
+++ b/libc/hdr/types/sigset_t.h
@@ -1,0 +1,21 @@
+//===-- Proxy for sigset_t ------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+#ifndef LLVM_LIBC_HDR_TYPES_SIGSET_T_H
+#define LLVM_LIBC_HDR_TYPES_SIGSET_T_H
+
+#ifdef LIBC_FULL_BUILD
+
+#include "include/llvm-libc-types/sigset_t.h"
+
+#else
+
+#include <signal.h>
+
+#endif // LIBC_FULL_BUILD
+
+#endif // LLVM_LIBC_HDR_TYPES_SIGSET_T_H

--- a/libc/hdr/types/struct_epoll_event.h
+++ b/libc/hdr/types/struct_epoll_event.h
@@ -1,0 +1,21 @@
+//===-- Proxy for struct epoll_event --------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+#ifndef LLVM_LIBC_HDR_TYPES_STRUCT_EPOLL_EVENT_H
+#define LLVM_LIBC_HDR_TYPES_STRUCT_EPOLL_EVENT_H
+
+#ifdef LIBC_FULL_BUILD
+
+#include "include/llvm-libc-types/struct_epoll_event.h"
+
+#else
+
+#include <sys/epoll.h>
+
+#endif // LIBC_FULL_BUILD
+
+#endif // LLVM_LIBC_HDR_TYPES_STRUCT_EPOLL_EVENT_H

--- a/libc/hdr/types/struct_timespec.h
+++ b/libc/hdr/types/struct_timespec.h
@@ -1,0 +1,21 @@
+//===-- Proxy for struct timespec  ----------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+#ifndef LLVM_LIBC_HDR_TYPES_STRUCT_TIMESPEC_H
+#define LLVM_LIBC_HDR_TYPES_STRUCT_TIMESPEC_H
+
+#ifdef LIBC_FULL_BUILD
+
+#include "include/llvm-libc-types/struct_timespec.h"
+
+#else
+
+#include <time.h>
+
+#endif // LIBC_FULL_BUILD
+
+#endif // LLVM_LIBC_HDR_TYPES_STRUCT_TIMESPEC_H

--- a/libc/src/signal/linux/CMakeLists.txt
+++ b/libc/src/signal/linux/CMakeLists.txt
@@ -3,6 +3,8 @@ add_header_library(
   HDRS
     signal_utils.h
   DEPENDS
+    libc.hdr.types.sigset_t
+    libc.include.signal
     libc.include.sys_syscall
     libc.src.__support.OSUtil.osutil
 )
@@ -28,7 +30,7 @@ add_entrypoint_object(
     ../raise.h
   DEPENDS
     .signal_utils
-    libc.include.signal
+    libc.hdr.types.sigset_t
     libc.include.sys_syscall
     libc.src.__support.OSUtil.osutil
 )
@@ -57,7 +59,7 @@ add_entrypoint_object(
     ../sigaction.h
   DEPENDS
     .__restore
-    libc.include.signal
+    libc.hdr.types.sigset_t
     libc.include.sys_syscall
     libc.src.__support.OSUtil.osutil
     libc.src.errno.errno
@@ -84,7 +86,7 @@ add_entrypoint_object(
     ../sigprocmask.h
   DEPENDS
     .signal_utils
-    libc.include.signal
+    libc.hdr.types.sigset_t
     libc.include.sys_syscall
     libc.src.__support.OSUtil.osutil
     libc.src.errno.errno
@@ -98,7 +100,7 @@ add_entrypoint_object(
     ../sigemptyset.h
   DEPENDS
     .signal_utils
-    libc.include.signal
+    libc.hdr.types.sigset_t
     libc.src.errno.errno
 )
 
@@ -110,7 +112,7 @@ add_entrypoint_object(
     ../sigaddset.h
   DEPENDS
     .signal_utils
-    libc.include.signal
+    libc.hdr.types.sigset_t
     libc.src.errno.errno
 )
 
@@ -133,7 +135,7 @@ add_entrypoint_object(
     ../sigfillset.h
   DEPENDS
     .signal_utils
-    libc.include.signal
+    libc.hdr.types.sigset_t
     libc.src.errno.errno
 )
 
@@ -145,6 +147,6 @@ add_entrypoint_object(
     ../sigdelset.h
   DEPENDS
     .signal_utils
-    libc.include.signal
+    libc.hdr.types.sigset_t
     libc.src.errno.errno
 )

--- a/libc/src/signal/linux/raise.cpp
+++ b/libc/src/signal/linux/raise.cpp
@@ -7,14 +7,15 @@
 //===----------------------------------------------------------------------===//
 
 #include "src/signal/raise.h"
-#include "src/signal/linux/signal_utils.h"
 
+#include "hdr/types/sigset_t.h"
 #include "src/__support/common.h"
+#include "src/signal/linux/signal_utils.h"
 
 namespace LIBC_NAMESPACE {
 
 LLVM_LIBC_FUNCTION(int, raise, (int sig)) {
-  ::sigset_t sigset;
+  sigset_t sigset;
   block_all_signals(sigset);
   long pid = LIBC_NAMESPACE::syscall_impl<long>(SYS_getpid);
   long tid = LIBC_NAMESPACE::syscall_impl<long>(SYS_gettid);

--- a/libc/src/signal/linux/sigaction.cpp
+++ b/libc/src/signal/linux/sigaction.cpp
@@ -7,12 +7,11 @@
 //===----------------------------------------------------------------------===//
 
 #include "src/signal/sigaction.h"
+
+#include "hdr/types/sigset_t.h"
+#include "src/__support/common.h"
 #include "src/errno/libc_errno.h"
 #include "src/signal/linux/signal_utils.h"
-
-#include "src/__support/common.h"
-
-#include <signal.h>
 
 namespace LIBC_NAMESPACE {
 

--- a/libc/src/signal/linux/sigaddset.cpp
+++ b/libc/src/signal/linux/sigaddset.cpp
@@ -7,11 +7,11 @@
 //===----------------------------------------------------------------------===//
 
 #include "src/signal/sigaddset.h"
+
+#include "hdr/types/sigset_t.h"
 #include "src/__support/common.h"
 #include "src/errno/libc_errno.h"
 #include "src/signal/linux/signal_utils.h"
-
-#include <signal.h>
 
 namespace LIBC_NAMESPACE {
 

--- a/libc/src/signal/linux/sigdelset.cpp
+++ b/libc/src/signal/linux/sigdelset.cpp
@@ -7,11 +7,11 @@
 //===----------------------------------------------------------------------===//
 
 #include "src/signal/sigdelset.h"
+
+#include "hdr/types/sigset_t.h"
 #include "src/__support/common.h"
 #include "src/errno/libc_errno.h"
 #include "src/signal/linux/signal_utils.h"
-
-#include <signal.h>
 
 namespace LIBC_NAMESPACE {
 

--- a/libc/src/signal/linux/sigfillset.cpp
+++ b/libc/src/signal/linux/sigfillset.cpp
@@ -7,11 +7,11 @@
 //===----------------------------------------------------------------------===//
 
 #include "src/signal/sigfillset.h"
+
+#include "hdr/types/sigset_t.h"
 #include "src/__support/common.h"
 #include "src/errno/libc_errno.h"
 #include "src/signal/linux/signal_utils.h"
-
-#include <signal.h>
 
 namespace LIBC_NAMESPACE {
 

--- a/libc/src/signal/linux/signal_utils.h
+++ b/libc/src/signal/linux/signal_utils.h
@@ -9,10 +9,11 @@
 #ifndef LLVM_LIBC_SRC_SIGNAL_LINUX_SIGNAL_UTILS_H
 #define LLVM_LIBC_SRC_SIGNAL_LINUX_SIGNAL_UTILS_H
 
+#include "hdr/types/sigset_t.h"
 #include "src/__support/OSUtil/syscall.h" // For internal syscall function.
 #include "src/__support/common.h"
 
-#include <signal.h>
+#include <signal.h> // sigaction
 #include <stddef.h>
 #include <sys/syscall.h>          // For syscall numbers.
 

--- a/libc/src/signal/linux/sigprocmask.cpp
+++ b/libc/src/signal/linux/sigprocmask.cpp
@@ -7,13 +7,13 @@
 //===----------------------------------------------------------------------===//
 
 #include "src/signal/sigprocmask.h"
+
+#include "hdr/types/sigset_t.h"
 #include "src/__support/OSUtil/syscall.h" // For internal syscall function.
+#include "src/__support/common.h"
 #include "src/errno/libc_errno.h"
 #include "src/signal/linux/signal_utils.h"
 
-#include "src/__support/common.h"
-
-#include <signal.h>
 #include <sys/syscall.h> // For syscall numbers.
 
 namespace LIBC_NAMESPACE {

--- a/libc/src/signal/sigaddset.h
+++ b/libc/src/signal/sigaddset.h
@@ -9,7 +9,7 @@
 #ifndef LLVM_LIBC_SRC_SIGNAL_SIGADDSET_H
 #define LLVM_LIBC_SRC_SIGNAL_SIGADDSET_H
 
-#include <signal.h>
+#include "hdr/types/sigset_t.h"
 
 namespace LIBC_NAMESPACE {
 

--- a/libc/src/signal/sigdelset.h
+++ b/libc/src/signal/sigdelset.h
@@ -9,7 +9,7 @@
 #ifndef LLVM_LIBC_SRC_SIGNAL_SIGDELSET_H
 #define LLVM_LIBC_SRC_SIGNAL_SIGDELSET_H
 
-#include <signal.h>
+#include "hdr/types/sigset_t.h"
 
 namespace LIBC_NAMESPACE {
 

--- a/libc/src/signal/sigemptyset.h
+++ b/libc/src/signal/sigemptyset.h
@@ -9,7 +9,7 @@
 #ifndef LLVM_LIBC_SRC_SIGNAL_SIGEMPTYSET_H
 #define LLVM_LIBC_SRC_SIGNAL_SIGEMPTYSET_H
 
-#include <signal.h>
+#include "hdr/types/sigset_t.h"
 
 namespace LIBC_NAMESPACE {
 

--- a/libc/src/signal/sigfillset.h
+++ b/libc/src/signal/sigfillset.h
@@ -9,7 +9,7 @@
 #ifndef LLVM_LIBC_SRC_SIGNAL_SIGFILLSET_H
 #define LLVM_LIBC_SRC_SIGNAL_SIGFILLSET_H
 
-#include <signal.h>
+#include "hdr/types/sigset_t.h"
 
 namespace LIBC_NAMESPACE {
 

--- a/libc/src/signal/sigprocmask.h
+++ b/libc/src/signal/sigprocmask.h
@@ -9,7 +9,7 @@
 #ifndef LLVM_LIBC_SRC_SIGNAL_SIGPROCMASK_H
 #define LLVM_LIBC_SRC_SIGNAL_SIGPROCMASK_H
 
-#include <signal.h>
+#include "hdr/types/sigset_t.h"
 
 namespace LIBC_NAMESPACE {
 

--- a/libc/src/sys/epoll/epoll_pwait.h
+++ b/libc/src/sys/epoll/epoll_pwait.h
@@ -9,11 +9,8 @@
 #ifndef LLVM_LIBC_SRC_SYS_EPOLL_EPOLL_PWAIT_H
 #define LLVM_LIBC_SRC_SYS_EPOLL_EPOLL_PWAIT_H
 
-// TODO: Use this include once the include headers are also using quotes.
-// #include "include/llvm-libc-types/sigset_t.h"
-// #include "include/llvm-libc-types/struct_epoll_event.h"
-
-#include <sys/epoll.h>
+#include "hdr/types/sigset_t.h"
+#include "hdr/types/struct_epoll_event.h"
 
 namespace LIBC_NAMESPACE {
 

--- a/libc/src/sys/epoll/epoll_pwait2.h
+++ b/libc/src/sys/epoll/epoll_pwait2.h
@@ -16,8 +16,8 @@
 namespace LIBC_NAMESPACE {
 
 // TODO: sigmask and timeout should be nullable
-int epoll_pwait2(int epfd, struct epoll_event *events, int maxevents,
-                 const struct timespec *timeout, const sigset_t *sigmask);
+int epoll_pwait2(int epfd, epoll_event *events, int maxevents,
+                 const timespec *timeout, const sigset_t *sigmask);
 
 } // namespace LIBC_NAMESPACE
 

--- a/libc/src/sys/epoll/epoll_pwait2.h
+++ b/libc/src/sys/epoll/epoll_pwait2.h
@@ -9,18 +9,15 @@
 #ifndef LLVM_LIBC_SRC_SYS_EPOLL_EPOLL_PWAIT2_H
 #define LLVM_LIBC_SRC_SYS_EPOLL_EPOLL_PWAIT2_H
 
-// TODO: Use this include once the include headers are also using quotes.
-// #include "include/llvm-libc-types/sigset_t.h"
-// #include "include/llvm-libc-types/struct_epoll_event.h"
-// #include "include/llvm-libc-types/struct_timespec.h"
-
-#include <sys/epoll.h>
+#include "hdr/types/sigset_t.h"
+#include "hdr/types/struct_epoll_event.h"
+#include "hdr/types/struct_timespec.h"
 
 namespace LIBC_NAMESPACE {
 
 // TODO: sigmask and timeout should be nullable
-int epoll_pwait2(int epfd, epoll_event *events, int maxevents,
-                 const timespec *timeout, const sigset_t *sigmask);
+int epoll_pwait2(int epfd, struct epoll_event *events, int maxevents,
+                 const struct timespec *timeout, const sigset_t *sigmask);
 
 } // namespace LIBC_NAMESPACE
 

--- a/libc/src/sys/epoll/epoll_wait.h
+++ b/libc/src/sys/epoll/epoll_wait.h
@@ -9,14 +9,12 @@
 #ifndef LLVM_LIBC_SRC_SYS_EPOLL_EPOLL_WAIT_H
 #define LLVM_LIBC_SRC_SYS_EPOLL_EPOLL_WAIT_H
 
-// TODO: Use this include once the include headers are also using quotes.
-// #include "include/llvm-libc-types/struct_epoll_event.h"
-
-#include <sys/epoll.h>
+#include "hdr/types/struct_epoll_event.h"
 
 namespace LIBC_NAMESPACE {
 
-int epoll_wait(int epfd, epoll_event *events, int maxevents, int timeout);
+int epoll_wait(int epfd, struct epoll_event *events, int maxevents,
+               int timeout);
 
 } // namespace LIBC_NAMESPACE
 

--- a/libc/src/sys/epoll/epoll_wait.h
+++ b/libc/src/sys/epoll/epoll_wait.h
@@ -13,8 +13,7 @@
 
 namespace LIBC_NAMESPACE {
 
-int epoll_wait(int epfd, struct epoll_event *events, int maxevents,
-               int timeout);
+int epoll_wait(int epfd, epoll_event *events, int maxevents, int timeout);
 
 } // namespace LIBC_NAMESPACE
 

--- a/libc/src/sys/epoll/linux/CMakeLists.txt
+++ b/libc/src/sys/epoll/linux/CMakeLists.txt
@@ -5,7 +5,9 @@ add_entrypoint_object(
   HDRS
     ../epoll_wait.h
   DEPENDS
-    libc.include.sys_epoll
+    libc.hdr.types.sigset_t
+    libc.hdr.types.struct_epoll_event
+    libc.hdr.types.struct_timespec
     libc.include.sys_syscall
     libc.src.__support.OSUtil.osutil
     libc.src.errno.errno
@@ -18,7 +20,9 @@ add_entrypoint_object(
   HDRS
     ../epoll_pwait.h
   DEPENDS
-    libc.include.sys_epoll
+    libc.hdr.types.sigset_t
+    libc.hdr.types.struct_epoll_event
+    libc.hdr.types.struct_timespec
     libc.include.signal
     libc.include.sys_syscall
     libc.src.__support.OSUtil.osutil
@@ -32,10 +36,12 @@ add_entrypoint_object(
   HDRS
     ../epoll_pwait2.h
   DEPENDS
-    libc.include.sys_epoll
+    libc.hdr.types.sigset_t
+    libc.hdr.types.struct_epoll_event
+    libc.hdr.types.struct_timespec
     libc.include.signal
-    libc.include.time
     libc.include.sys_syscall
+    libc.include.time
     libc.src.__support.OSUtil.osutil
     libc.src.errno.errno
 )

--- a/libc/src/sys/epoll/linux/epoll_pwait.cpp
+++ b/libc/src/sys/epoll/linux/epoll_pwait.cpp
@@ -8,17 +8,13 @@
 
 #include "src/sys/epoll/epoll_pwait.h"
 
+#include "hdr/types/sigset_t.h"
+#include "hdr/types/struct_epoll_event.h"
 #include "src/__support/OSUtil/syscall.h" // For internal syscall function.
 #include "src/__support/common.h"
-
 #include "src/errno/libc_errno.h"
+
 #include <sys/syscall.h> // For syscall numbers.
-
-// TODO: Use this include once the include headers are also using quotes.
-// #include "include/llvm-libc-types/sigset_t.h"
-// #include "include/llvm-libc-types/struct_epoll_event.h"
-
-#include <sys/epoll.h>
 
 namespace LIBC_NAMESPACE {
 

--- a/libc/src/sys/epoll/linux/epoll_pwait2.cpp
+++ b/libc/src/sys/epoll/linux/epoll_pwait2.cpp
@@ -8,18 +8,14 @@
 
 #include "src/sys/epoll/epoll_pwait2.h"
 
+#include "hdr/types/sigset_t.h"
+#include "hdr/types/struct_epoll_event.h"
+#include "hdr/types/struct_timespec.h"
 #include "src/__support/OSUtil/syscall.h" // For internal syscall function.
 #include "src/__support/common.h"
-
 #include "src/errno/libc_errno.h"
+
 #include <sys/syscall.h> // For syscall numbers.
-
-// TODO: Use this include once the include headers are also using quotes.
-// #include "include/llvm-libc-types/sigset_t.h"
-// #include "include/llvm-libc-types/struct_epoll_event.h"
-// #include "include/llvm-libc-types/struct_timespec.h"
-
-#include <sys/epoll.h>
 
 namespace LIBC_NAMESPACE {
 

--- a/libc/src/sys/epoll/linux/epoll_wait.cpp
+++ b/libc/src/sys/epoll/linux/epoll_wait.cpp
@@ -8,16 +8,13 @@
 
 #include "src/sys/epoll/epoll_wait.h"
 
+#include "hdr/types/sigset_t.h"
+#include "hdr/types/struct_epoll_event.h"
 #include "src/__support/OSUtil/syscall.h" // For internal syscall function.
 #include "src/__support/common.h"
 #include "src/errno/libc_errno.h"
+
 #include <sys/syscall.h> // For syscall numbers.
-
-// TODO: Use this include once the include headers are also using quotes.
-// #include "include/llvm-libc-types/sigset_t.h"
-// #include "include/llvm-libc-types/struct_epoll_event.h"
-
-#include <sys/epoll.h>
 
 namespace LIBC_NAMESPACE {
 

--- a/libc/src/sys/select/linux/select.cpp
+++ b/libc/src/sys/select/linux/select.cpp
@@ -8,14 +8,14 @@
 
 #include "src/sys/select/select.h"
 
+#include "hdr/types/sigset_t.h"
+#include "hdr/types/struct_timespec.h"
 #include "src/__support/CPP/limits.h"
 #include "src/__support/OSUtil/syscall.h" // For internal syscall function.
 #include "src/__support/common.h"
-
 #include "src/errno/libc_errno.h"
-#include <signal.h>
-#include <stddef.h> // For size_t
-#include <sys/select.h>
+
+#include <stddef.h>      // For size_t
 #include <sys/syscall.h> // For syscall numbers.
 
 namespace LIBC_NAMESPACE {

--- a/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
@@ -3417,6 +3417,15 @@ libc_function(
 
 ############################## sys/epoll targets ###############################
 
+libc_support_library(
+  name = "types_sigset_t",
+  hdrs = ["hdr/types/sigset_t.h"],
+)
+libc_support_library(
+  name = "types_struct_epoll_event",
+  hdrs = ["hdr/types/struct_epoll_event.h"],
+)
+
 libc_function(
     name = "epoll_wait",
     srcs = ["src/sys/epoll/linux/epoll_wait.cpp"],
@@ -3429,6 +3438,8 @@ libc_function(
     deps = [
         ":__support_osutil_syscall",
         ":errno",
+        ":types_sigset_t",
+        ":types_struct_epoll_event",
     ],
 )
 
@@ -3444,6 +3455,8 @@ libc_function(
     deps = [
         ":__support_osutil_syscall",
         ":errno",
+        ":types_sigset_t",
+        ":types_struct_epoll_event",
     ],
 )
 


### PR DESCRIPTION
This RFC is meant to spur discussion; it's not yet clear if this policy is best (or even makes sense).

When supporting "overlay" vs "fullbuild" modes, "what ABI are you using?" becomes a fundamental question to have concrete answers for. Overlay mode MUST match the ABI of the system being overlayed onto; fullbuild more flexible (the only system ABI relevant is the OS kernel).

When implementing llvm-libc we generally prefer the include-what-you use style of avoiding transitive dependencies (since that makes refactoring headers more painful, and slows down build times). So what header do you include for any given type or function declaration? For any given userspace program, the answer is straightforward. But for llvm-libc which is trying to support multiple ABIs (at least one per configuration), the answer is perhaps less clear.

This proposal seeks to add one layer of indirection relative to what's being done today.

It then converts users of sigset_t and struct epoll_event and the epoll implemenations over to this convention as an example.