### PR TITLE
[libc] raise CMAKE_CXX_STANDARD to C++20

### DIFF
--- a/libc/CMakeLists.txt
+++ b/libc/CMakeLists.txt
@@ -26,8 +26,8 @@ if (CMAKE_BUILD_TYPE STREQUAL "Debug")
   add_definitions("-D_DEBUG")
 endif()
 
-# Default to C++17
-set(CMAKE_CXX_STANDARD 17)
+# Default to C++20
+set(CMAKE_CXX_STANDARD 20)
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules")
 

--- a/libc/config/linux/app.h
+++ b/libc/config/linux/app.h
@@ -108,8 +108,6 @@ struct TLSDescriptor {
   // Note that, dependending the target architecture ABI, it can be the
   // same as |addr| or something else.
   uintptr_t tp = 0;
-
-  constexpr TLSDescriptor() = default;
 };
 
 // Create and initialize the TLS area for the current thread. Should not

--- a/libc/src/__support/threads/fork_callbacks.cpp
+++ b/libc/src/__support/threads/fork_callbacks.cpp
@@ -20,7 +20,6 @@ struct ForkCallbackTriple {
   ForkCallback *prepare = nullptr;
   ForkCallback *parent = nullptr;
   ForkCallback *child = nullptr;
-  constexpr ForkCallbackTriple() = default;
 };
 
 class AtForkCallbackManager {

--- a/libc/src/stdlib/CMakeLists.txt
+++ b/libc/src/stdlib/CMakeLists.txt
@@ -411,8 +411,6 @@ add_entrypoint_object(
     atexit.cpp
   HDRS
     atexit.h
-  CXX_STANDARD
-    20 # For constinit of the atexit callback list.
   DEPENDS
     libc.src.__support.CPP.new
     libc.src.__support.OSUtil.osutil

--- a/libc/test/src/network/CMakeLists.txt
+++ b/libc/test/src/network/CMakeLists.txt
@@ -6,8 +6,6 @@ add_libc_unittest(
     libc_network_unittests
   SRCS
     htonl_test.cpp
-  CXX_STANDARD
-    20
   DEPENDS
     libc.src.network.htonl
     libc.src.network.ntohl
@@ -19,8 +17,6 @@ add_libc_unittest(
     libc_network_unittests
   SRCS
     htons_test.cpp
-  CXX_STANDARD
-    20
   DEPENDS
     libc.src.network.htons
     libc.src.network.ntohs
@@ -32,8 +28,6 @@ add_libc_unittest(
     libc_network_unittests
   SRCS
     ntohl_test.cpp
-  CXX_STANDARD
-    20
   DEPENDS
     libc.src.network.htonl
     libc.src.network.ntohl
@@ -45,8 +39,6 @@ add_libc_unittest(
     libc_network_unittests
   SRCS
     ntohs_test.cpp
-  CXX_STANDARD
-    20
   DEPENDS
     libc.src.network.htons
     libc.src.network.ntohs

--- a/libc/test/src/time/CMakeLists.txt
+++ b/libc/test/src/time/CMakeLists.txt
@@ -9,8 +9,6 @@ add_libc_unittest(
   HDRS
     TmHelper.h
     TmMatcher.h
-  CXX_STANDARD
-    20
   DEPENDS
     libc.src.time.asctime
 )
@@ -24,8 +22,6 @@ add_libc_unittest(
   HDRS
     TmHelper.h
     TmMatcher.h
-  CXX_STANDARD
-    20
   DEPENDS
     libc.src.time.asctime_r
 )
@@ -95,8 +91,6 @@ add_libc_unittest(
   HDRS
     TmHelper.h
     TmMatcher.h
-  CXX_STANDARD
-    20
   DEPENDS
     libc.src.time.mktime
     libc.src.__support.CPP.limits


### PR DESCRIPTION
This is supported by clang-10+ and gcc-10+. Our minimum supported versions are
currently clang-11+, gcc-12+.

We have a few places where we were already using C++20.

libc++ is currently using C++23. We can likely join them, but let's jump to
C++20 first (and ensure our buildbots can support C++23).
