### PR TITLE
[bazel] Fix lit tests with python 3.11+

### DIFF
--- a/utils/bazel/llvm-project-overlay/llvm/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/llvm/BUILD.bazel
@@ -4927,6 +4927,7 @@ py_binary(
     name = "lit",
     testonly = True,
     srcs = ["utils/lit/lit.py"] + glob(["utils/lit/lit/**/*.py"]),
+    imports = ["utils/lit"],
 )
 
 py_binary(

--- a/utils/bazel/llvm-project-overlay/llvm/lit_test.bzl
+++ b/utils/bazel/llvm-project-overlay/llvm/lit_test.bzl
@@ -35,6 +35,7 @@ def lit_test(
         args = args + ["-v"] + ["$(execpath %s)" % src for src in srcs],
         data = data + srcs,
         legacy_create_init = False,
+        deps = [Label("//llvm:lit")],
         **kwargs
     )
 


### PR DESCRIPTION
In python3.11 there is a new environment variable PYTHONSAFEPATH which
stops python from setting the current directory as the first entry in
sys.path. Bazel started setting this to ensure that python targets
don't accidentally access things that aren't in their dependency tree.
This resulted in lit tests breaking because sys.path didn't include the
directory to the lit source files. This is fixed by adding the lit
binary to the dependency tree and propagating the import path from it.

Fixes https://github.com/llvm/llvm-project/issues/75963
