### PR TITLE
[scudo] Fix stack depot validation.

### DIFF
--- a/compiler-rt/lib/scudo/standalone/stack_depot.h
+++ b/compiler-rt/lib/scudo/standalone/stack_depot.h
@@ -112,7 +112,7 @@ public:
     if (TabMask == 0)
       return false;
     uptr TabSize = TabMask + 1;
-    if (!isPowerOfTwo(TabSize))
+    if (TabSize == 0 || !isPowerOfTwo(TabSize))
       return false;
     uptr TabBytes = sizeof(atomic_u32) * TabSize;
 


### PR DESCRIPTION
In the StackDepot::isValid function, there is work to validate the TabMask variable. Unfortunately, if TabMask is set to the maximum allowed value, TabSize = TabMask + 1 becomes zero and validation passes.

Disallow that case to prevent invalid reads into the Tab structure.