### PR TITLE
[RISCV] Let -data-sections also work on sbss/sdata sections

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVTargetObjectFile.cpp
+++ b/llvm/lib/Target/RISCV/RISCVTargetObjectFile.cpp
@@ -110,9 +110,7 @@ MCSection *RISCVELFTargetObjectFile::SelectSectionForGlobal(
 
     if (Kind.isBSS()) {
       if (EmitUniquedSection) {
-        StringRef Prefix(".sbss");
-        SmallString<128> Name(Prefix);
-        Name.append(".");
+        SmallString<128> Name(".sbss.");
         Name.append(GO->getName());
         return getContext().getELFSection(Name.str(), ELF::SHT_NOBITS,
                                           ELF::SHF_WRITE | ELF::SHF_ALLOC);
@@ -123,9 +121,7 @@ MCSection *RISCVELFTargetObjectFile::SelectSectionForGlobal(
 
     if (Kind.isData()) {
       if (EmitUniquedSection) {
-        StringRef Prefix(".sdata");
-        SmallString<128> Name(Prefix);
-        Name.append(".");
+        SmallString<128> Name(".sdata.");
         Name.append(GO->getName());
         return getContext().getELFSection(Name.str(), ELF::SHT_PROGBITS,
                                           ELF::SHF_WRITE | ELF::SHF_ALLOC);

--- a/llvm/lib/Target/RISCV/RISCVTargetObjectFile.cpp
+++ b/llvm/lib/Target/RISCV/RISCVTargetObjectFile.cpp
@@ -105,8 +105,10 @@ MCSection *RISCVELFTargetObjectFile::SelectSectionForGlobal(
     const GlobalObject *GO, SectionKind Kind, const TargetMachine &TM) const {
   // Handle Small Section classification here.
   if (isGlobalInSmallSection(GO, TM)) {
-    // Emit a unique section for sdata/sbss when -fdata-section.
-    bool EmitUniquedSection = TM.getDataSections();
+    // Emit to an unique sdata/sbss section when -fdata-section is set.
+    // However, if a symbol has an explicit sdata/sbss section, place it in that
+    // section.
+    bool EmitUniquedSection = TM.getDataSections() && !GO->hasSection();
 
     if (Kind.isBSS()) {
       if (EmitUniquedSection) {

--- a/llvm/test/CodeGen/RISCV/sdata-sections.ll
+++ b/llvm/test/CodeGen/RISCV/sdata-sections.ll
@@ -6,9 +6,13 @@
 @v = dso_local global i32 0, align 4
 @r = dso_local global i64 7, align 8
 
-; If a symbol has an explicit sdata/sbss section name, we should honor it.
+; If a symbol has an explicit section name, we should honor it.
 @vv = dso_local global i32 0, section ".sbss", align 4
 @rr = dso_local global i64 7, section ".sdata", align 8
+@bb = dso_local global i32 0, section ".sbss_like", align 4
+@tt = dso_local global i64 7, section ".sdata_like", align 8
+@nn = dso_local global i32 0, section ".custom_a", align 4
+@yy = dso_local global i64 7, section ".custom_b", align 8
 
 ; SmallDataLimit set to 8, so we expect @v will be put in sbss
 ; and @r will be put in sdata.
@@ -19,7 +23,16 @@
 ; RV32:    .section        .sdata.r,"aw"
 ; RV32:    .section        .sbss,"aw"
 ; RV32:    .section        .sdata,"aw"
+; RV32:    .section        .sbss_like,"aw"
+; RV32:    .section        .sdata_like,"aw"
+; RV32:    .section        .custom_a,"aw"
+; RV32:    .section        .custom_b,"aw"
+
 ; RV64:    .section        .sbss.v,"aw"
 ; RV64:    .section        .sdata.r,"aw"
 ; RV64:    .section        .sbss,"aw"
 ; RV64:    .section        .sdata,"aw"
+; RV64:    .section        .sbss_like,"aw"
+; RV64:    .section        .sdata_like,"aw"
+; RV64:    .section        .custom_a,"aw"
+; RV64:    .section        .custom_b,"aw"

--- a/llvm/test/CodeGen/RISCV/sdata-sections.ll
+++ b/llvm/test/CodeGen/RISCV/sdata-sections.ll
@@ -6,6 +6,10 @@
 @v = dso_local global i32 0, align 4
 @r = dso_local global i64 7, align 8
 
+; If a symbol has an explicit sdata/sbss section name, we should honor it.
+@vv = dso_local global i32 0, section ".sbss", align 4
+@rr = dso_local global i64 7, section ".sdata", align 8
+
 ; SmallDataLimit set to 8, so we expect @v will be put in sbss
 ; and @r will be put in sdata.
 !llvm.module.flags = !{!0}
@@ -13,5 +17,9 @@
 
 ; RV32:    .section        .sbss.v,"aw"
 ; RV32:    .section        .sdata.r,"aw"
+; RV32:    .section        .sbss,"aw"
+; RV32:    .section        .sdata,"aw"
 ; RV64:    .section        .sbss.v,"aw"
 ; RV64:    .section        .sdata.r,"aw"
+; RV64:    .section        .sbss,"aw"
+; RV64:    .section        .sdata,"aw"

--- a/llvm/test/CodeGen/RISCV/sdata-sections.ll
+++ b/llvm/test/CodeGen/RISCV/sdata-sections.ll
@@ -1,0 +1,18 @@
+; RUN: llc -mtriple=riscv32 -data-sections < %s | FileCheck -check-prefix=RV32 %s
+; RUN: llc -mtriple=riscv64 -data-sections < %s | FileCheck -check-prefix=RV64 %s
+
+; FIXME: Should append an unique name to each sdata/sbss section if -data-sections,
+; otherwise gc-section cannot remove them. This also matches the behavior on gcc.
+
+@v = dso_local global i32 0, align 4
+@r = dso_local global i64 7, align 8
+
+; SmallDataLimit set to 8, so we expect @v will be put in sbss
+; and @r will be put in sdata.
+!llvm.module.flags = !{!0}
+!0 = !{i32 8, !"SmallDataLimit", i32 8}
+
+; RV32:    .section        .sbss,"aw"
+; RV32:    .section        .sdata,"aw"
+; RV64:    .section        .sbss,"aw"
+; RV64:    .section        .sdata,"aw"

--- a/llvm/test/CodeGen/RISCV/sdata-sections.ll
+++ b/llvm/test/CodeGen/RISCV/sdata-sections.ll
@@ -1,8 +1,7 @@
 ; RUN: llc -mtriple=riscv32 -data-sections < %s | FileCheck -check-prefix=RV32 %s
 ; RUN: llc -mtriple=riscv64 -data-sections < %s | FileCheck -check-prefix=RV64 %s
 
-; FIXME: Should append an unique name to each sdata/sbss section if -data-sections,
-; otherwise gc-section cannot remove them. This also matches the behavior on gcc.
+; Append an unique name to each sdata/sbss section when -data-section.
 
 @v = dso_local global i32 0, align 4
 @r = dso_local global i64 7, align 8
@@ -12,7 +11,7 @@
 !llvm.module.flags = !{!0}
 !0 = !{i32 8, !"SmallDataLimit", i32 8}
 
-; RV32:    .section        .sbss,"aw"
-; RV32:    .section        .sdata,"aw"
-; RV64:    .section        .sbss,"aw"
-; RV64:    .section        .sdata,"aw"
+; RV32:    .section        .sbss.v,"aw"
+; RV32:    .section        .sdata.r,"aw"
+; RV64:    .section        .sbss.v,"aw"
+; RV64:    .section        .sdata.r,"aw"


### PR DESCRIPTION
Add an unique suffix to .sbss/.sdata if -fdata-sections.
Without assigning an unique .sbss/.sdata section to each symbols, a linker may not be able to remove unused part when gc-section since all used and unused symbols are all mixed in the same .sbss/.sdata section.
I believe this also matches the behavior of gcc.