### PR TITLE
[TableGen][NFC] Add maybe_unused to MRI

### DIFF
--- a/llvm/utils/TableGen/MacroFusionPredicatorEmitter.cpp
+++ b/llvm/utils/TableGen/MacroFusionPredicatorEmitter.cpp
@@ -108,7 +108,8 @@ void MacroFusionPredicatorEmitter::emitMacroFusionImpl(
     OS.indent(4) << "const TargetSubtargetInfo &STI,\n";
     OS.indent(4) << "const MachineInstr *FirstMI,\n";
     OS.indent(4) << "const MachineInstr &SecondMI) {\n";
-    OS.indent(2) << "auto &MRI = SecondMI.getMF()->getRegInfo();\n";
+    OS.indent(2)
+        << "[[maybe_unused]] auto &MRI = SecondMI.getMF()->getRegInfo();\n";
 
     emitPredicates(Predicates, IsCommutable, PE, OS);
 


### PR DESCRIPTION
This suppresses warning `unused variable 'MRI' [-Wunused-variable]`
for those fusions that don't need `MRI`.
