### PR TITLE
[libc] Fix missing UINTMAX_WIDTH

### DIFF
--- a/libc/test/src/stdio/sprintf_test.cpp
+++ b/libc/test/src/stdio/sprintf_test.cpp
@@ -203,9 +203,10 @@ TEST(LlvmLibcSPrintfTest, IntConv) {
 
   char format[64];
   char uintmax[128];
-  LIBC_NAMESPACE::sprintf(format, "%%w%du", UINTMAX_WIDTH);
-  const int uintmax_len = LIBC_NAMESPACE::sprintf(uintmax, "%ju", UINTMAX_MAX);
-  written = LIBC_NAMESPACE::sprintf(buff, format, UINTMAX_MAX);
+  LIBC_NAMESPACE::sprintf(format, "%%w%du", sizeof(uintmax_t) * CHAR_BIT);
+  const int uintmax_len =
+      LIBC_NAMESPACE::sprintf(uintmax, "%ju", sizeof(uintmax_t) * CHAR_BIT);
+  written = LIBC_NAMESPACE::sprintf(buff, format, sizeof(uintmax_t) * CHAR_BIT);
   EXPECT_EQ(written, uintmax_len);
   ASSERT_STREQ(buff, uintmax);
 


### PR DESCRIPTION
In patch #82461 the sprintf tests were made to use UINTMAX_WIDTH which
isn't defined on all systems. This patch changes it to
sizeof(uintmax_t)*CHAR_BIT which is more portable.
