### PR TITLE
[Inliner] Check number of operands in AddReturnAttributes

### DIFF
--- a/llvm/lib/Transforms/Utils/InlineFunction.cpp
+++ b/llvm/lib/Transforms/Utils/InlineFunction.cpp
@@ -1384,7 +1384,7 @@ static void AddReturnAttributes(CallBase &CB, ValueToValueMapTy &VMap) {
 
   for (auto &BB : *CalledFunction) {
     auto *RI = dyn_cast<ReturnInst>(BB.getTerminator());
-    if (!RI || !isa<CallBase>(RI->getOperand(0)))
+    if (!RI || RI->getNumOperands() == 0 || !isa<CallBase>(RI->getOperand(0)))
       continue;
     auto *RetVal = cast<CallBase>(RI->getOperand(0));
     // Check that the cloned RetVal exists and is a call, otherwise we cannot


### PR DESCRIPTION
The commit [2da4960](https://github.com/llvm/llvm-project/commit/2da4960f20f7e5d88a68ce25636a895284dc66d8) enabled `noundef` attributes propagation. It looks like ret void is considered to be `noundef`, thus `ValidUB.hasAttributes` now returns true for this type of instructions and everything proceed further to work with operands. The issue is that such instruction doesn't have operands, which means when accessing `RI->getOperand(0)` inliner pass crashes with an assert:

    llvm/include/llvm/IR/Instructions.h:3420: llvm::Value* llvm::ReturnInst::getOperand(unsigned int) const:
    Assertion `i_nocapture < OperandTraits<ReturnInst>::operands(this) && "getOperand() out of range!"' failed.

Fix that by verifying if the `ReturnInst` in fact has some operands to process.

/cc @goldsteinn as an author of the commit referenced in [[3](https://github.com/llvm/llvm-project/commit/2da4960f20f7e5d88a68ce25636a895284dc66d8)], and @chandlerc as mentioned in code_owners regarding inlining pass.

Fixes #86162 