### PR TITLE
[workflows] issue-write: Exit early if there are no comments

### DIFF
--- a/.github/workflows/issue-write.yml
+++ b/.github/workflows/issue-write.yml
@@ -31,7 +31,7 @@ jobs:
           script: |
             var fs = require('fs');
             const comments = JSON.parse(fs.readFileSync('./comments'));
-            if (!comments) {
+            if (!comments || comments.length == 0) {
               return;
             }
 


### PR DESCRIPTION
This will eliminate some unnecessary REST API calls.