### PR TITLE
[scudo] Change isPowerOfTwo macro to return false for zero.

### DIFF
--- a/compiler-rt/lib/scudo/standalone/common.h
+++ b/compiler-rt/lib/scudo/standalone/common.h
@@ -28,7 +28,11 @@ template <class Dest, class Source> inline Dest bit_cast(const Source &S) {
   return D;
 }
 
-inline constexpr bool isPowerOfTwo(uptr X) { return (X & (X - 1)) == 0; }
+inline constexpr bool isPowerOfTwo(uptr X) {
+  if (X == 0)
+    return false;
+  return (X & (X - 1)) == 0;
+}
 
 inline constexpr uptr roundUp(uptr X, uptr Boundary) {
   DCHECK(isPowerOfTwo(Boundary));

--- a/compiler-rt/lib/scudo/standalone/stack_depot.h
+++ b/compiler-rt/lib/scudo/standalone/stack_depot.h
@@ -103,7 +103,7 @@ public:
   // Ensure that RingSize, RingMask and TabMask are set up in a way that
   // all accesses are within range of BufSize.
   bool isValid(uptr BufSize) const {
-    if (RingSize == 0 || !isPowerOfTwo(RingSize))
+    if (!isPowerOfTwo(RingSize))
       return false;
     uptr RingBytes = sizeof(atomic_u64) * RingSize;
     if (RingMask + 1 != RingSize)
@@ -112,7 +112,7 @@ public:
     if (TabMask == 0)
       return false;
     uptr TabSize = TabMask + 1;
-    if (TabSize == 0 || !isPowerOfTwo(TabSize))
+    if (!isPowerOfTwo(TabSize))
       return false;
     uptr TabBytes = sizeof(atomic_u32) * TabSize;
 

--- a/compiler-rt/lib/scudo/standalone/wrappers_c_checks.h
+++ b/compiler-rt/lib/scudo/standalone/wrappers_c_checks.h
@@ -31,15 +31,13 @@ inline void *setErrnoOnNull(void *Ptr) {
 // Checks aligned_alloc() parameters, verifies that the alignment is a power of
 // two and that the size is a multiple of alignment.
 inline bool checkAlignedAllocAlignmentAndSize(uptr Alignment, uptr Size) {
-  return Alignment == 0 || !isPowerOfTwo(Alignment) ||
-         !isAligned(Size, Alignment);
+  return !isPowerOfTwo(Alignment) || !isAligned(Size, Alignment);
 }
 
 // Checks posix_memalign() parameters, verifies that alignment is a power of two
 // and a multiple of sizeof(void *).
 inline bool checkPosixMemalignAlignment(uptr Alignment) {
-  return Alignment == 0 || !isPowerOfTwo(Alignment) ||
-         !isAligned(Alignment, sizeof(void *));
+  return !isPowerOfTwo(Alignment) || !isAligned(Alignment, sizeof(void *));
 }
 
 // Returns true if calloc(Size, N) overflows on Size*N calculation. Use a


### PR DESCRIPTION
Clean-up all of the calls and remove the redundant == 0 checks.

There is only one small visible change. For non-Android, the memalign function will now fail if alignment is zero. Before this would have passed.