### PR TITLE
[coroutine] Fix type of an ImplicitParamDecl used in generateAwaitSuspendWrapper

### DIFF
--- a/clang/lib/CodeGen/CGCoroutine.cpp
+++ b/clang/lib/CodeGen/CGCoroutine.cpp
@@ -422,7 +422,9 @@ CodeGenFunction::generateAwaitSuspendWrapper(Twine const &CoroName,
 
   FunctionArgList args;
 
-  ImplicitParamDecl AwaiterDecl(C, C.VoidPtrTy, ImplicitParamKind::Other);
+  QualType AwaiterType = S.getOpaqueValue()->getType();
+  ImplicitParamDecl AwaiterDecl(C, C.getPointerType(AwaiterType),
+                                ImplicitParamKind::Other);
   ImplicitParamDecl FrameDecl(C, C.VoidPtrTy, ImplicitParamKind::Other);
   QualType ReturnTy = S.getSuspendExpr()->getType();
 
@@ -449,8 +451,7 @@ CodeGenFunction::generateAwaitSuspendWrapper(Twine const &CoroName,
 
   // FIXME: add TBAA metadata to the loads
   llvm::Value *AwaiterPtr = Builder.CreateLoad(GetAddrOfLocalVar(&AwaiterDecl));
-  auto AwaiterLValue =
-      MakeNaturalAlignAddrLValue(AwaiterPtr, AwaiterDecl.getType());
+  auto AwaiterLValue = MakeNaturalAlignAddrLValue(AwaiterPtr, AwaiterType);
 
   CurAwaitSuspendWrapper.FramePtr =
       Builder.CreateLoad(GetAddrOfLocalVar(&FrameDecl));


### PR DESCRIPTION
Use the correct type for AwaiterDecl instead of using `void *`.

See the discussion here:
https://github.com/llvm/llvm-project/pull/79712#discussion_r1544153100