### PR TITLE
[Clang][Sema] Skip checking anonymous enum in using enum declaration

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -494,6 +494,7 @@ Bug Fixes to C++ Support
 
 - Fix crash when inheriting from a cv-qualified type. Fixes:
   (`#35603 <https://github.com/llvm/llvm-project/issues/35603>`_)
+- Fix a crash when the using enum declaration uses an anonymous enumeration. Fixes (#GH86790).
 
 Bug Fixes to AST Handling
 ^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/clang/lib/Sema/SemaDecl.cpp
+++ b/clang/lib/Sema/SemaDecl.cpp
@@ -1537,6 +1537,10 @@ void Sema::PushOnScopeChains(NamedDecl *D, Scope *S, bool AddToContext) {
       cast<FunctionDecl>(D)->isFunctionTemplateSpecialization())
     return;
 
+  if (isa<UsingEnumDecl>(D) && D->getDeclName().isEmpty()) {
+    S->AddDecl(D);
+    return;
+  }
   // If this replaces anything in the current scope,
   IdentifierResolver::iterator I = IdResolver.begin(D->getDeclName()),
                                IEnd = IdResolver.end();

--- a/clang/test/SemaCXX/PR86790.cpp
+++ b/clang/test/SemaCXX/PR86790.cpp
@@ -1,0 +1,32 @@
+// RUN: %clang_cc1 -verify -std=c++20 -fsyntax-only %s
+
+enum {A, S, D, F};
+int main() {
+    using asdf = decltype(A);
+    using enum asdf; // this line causes the crash
+    return 0;
+}
+
+namespace N1 {
+    enum {A, S, D, F};
+    constexpr struct T {
+    using asdf = decltype(A);
+    using enum asdf;
+    } t;
+
+    static_assert(t.D == D);
+    static_assert(T::S == S);
+}
+
+namespace N2 {
+    enum {A, S, D, F};
+    constexpr struct T {
+    struct {
+        using asdf = decltype(A);
+        using enum asdf;
+    } inner;
+    } t;
+
+    static_assert(t.inner.D == D);
+    static_assert(t.D == D); // expected-error {{no member named 'D' in 'N2::T'}}
+}


### PR DESCRIPTION
Try to fix https://github.com/llvm/llvm-project/issues/86790
`getFETokenInfo` requires `DeclarationName` shouldn't be empty and this will produce crash when checking name conflict of an anonymous `NamedDecl` in `Sema::PushOnScopeChains` and whether it's a reserved identifier or not. These wouldn't happen when it's a anonymous enum and we can skip the checking and just add the declaration to current scope.