### PR TITLE
[mlir][pass] Add composite pass utility

### DIFF
--- a/mlir/include/mlir/Transforms/Passes.h
+++ b/mlir/include/mlir/Transforms/Passes.h
@@ -43,7 +43,7 @@ class GreedyRewriteConfig;
 #define GEN_PASS_DECL_SYMBOLDCE
 #define GEN_PASS_DECL_SYMBOLPRIVATIZE
 #define GEN_PASS_DECL_TOPOLOGICALSORT
-#define GEN_PASS_DECL_COMPOSITEPASS
+#define GEN_PASS_DECL_COMPOSITEFIXEDPOINTPASS
 #include "mlir/Transforms/Passes.h.inc"
 
 /// Creates an instance of the Canonicalizer pass, configured with default
@@ -133,10 +133,9 @@ std::unique_ptr<Pass> createTopologicalSortPass();
 
 /// Create composite pass, which runs selected set of passes until fixed point
 /// or maximum number of iterations reached.
-std::unique_ptr<Pass>
-createCompositePass(std::string name,
-                    llvm::function_ref<void(OpPassManager &)> populateFunc,
-                    unsigned maxIterations = 10);
+std::unique_ptr<Pass> createCompositeFixedPointPass(
+    std::string name, llvm::function_ref<void(OpPassManager &)> populateFunc,
+    unsigned maxIterations = 10);
 
 //===----------------------------------------------------------------------===//
 // Registration

--- a/mlir/include/mlir/Transforms/Passes.h
+++ b/mlir/include/mlir/Transforms/Passes.h
@@ -131,7 +131,7 @@ createSymbolPrivatizePass(ArrayRef<std::string> excludeSymbols = {});
 /// their producers.
 std::unique_ptr<Pass> createTopologicalSortPass();
 
-/// Create composite pass, which runs selected set of passes until fixed point
+/// Create composite pass, which runs provided set of passes until fixed point
 /// or maximum number of iterations reached.
 std::unique_ptr<Pass> createCompositeFixedPointPass(
     std::string name, llvm::function_ref<void(OpPassManager &)> populateFunc,

--- a/mlir/include/mlir/Transforms/Passes.h
+++ b/mlir/include/mlir/Transforms/Passes.h
@@ -43,6 +43,7 @@ class GreedyRewriteConfig;
 #define GEN_PASS_DECL_SYMBOLDCE
 #define GEN_PASS_DECL_SYMBOLPRIVATIZE
 #define GEN_PASS_DECL_TOPOLOGICALSORT
+#define GEN_PASS_DECL_COMPOSITEPASS
 #include "mlir/Transforms/Passes.h.inc"
 
 /// Creates an instance of the Canonicalizer pass, configured with default
@@ -133,7 +134,7 @@ std::unique_ptr<Pass> createTopologicalSortPass();
 /// Create composite pass, which runs selected set of passes until fixed point
 /// or maximum number of iterations reached.
 std::unique_ptr<Pass>
-createCompositePass(std::string name, std::string argument,
+createCompositePass(std::string name,
                     llvm::function_ref<void(OpPassManager &)> populateFunc,
                     unsigned maxIterations = 10);
 

--- a/mlir/include/mlir/Transforms/Passes.h
+++ b/mlir/include/mlir/Transforms/Passes.h
@@ -135,7 +135,7 @@ std::unique_ptr<Pass> createTopologicalSortPass();
 /// or maximum number of iterations reached.
 std::unique_ptr<Pass> createCompositeFixedPointPass(
     std::string name, llvm::function_ref<void(OpPassManager &)> populateFunc,
-    unsigned maxIterations = 10);
+    int maxIterations = 10);
 
 //===----------------------------------------------------------------------===//
 // Registration

--- a/mlir/include/mlir/Transforms/Passes.h
+++ b/mlir/include/mlir/Transforms/Passes.h
@@ -130,6 +130,13 @@ createSymbolPrivatizePass(ArrayRef<std::string> excludeSymbols = {});
 /// their producers.
 std::unique_ptr<Pass> createTopologicalSortPass();
 
+/// Create composite pass, which runs selected set of passes until fixed point
+/// or maximum number of iterations reached.
+std::unique_ptr<Pass>
+createCompositePass(std::string name, std::string argument,
+                    llvm::function_ref<void(OpPassManager &)> populateFunc,
+                    unsigned maxIterations = 10);
+
 //===----------------------------------------------------------------------===//
 // Registration
 //===----------------------------------------------------------------------===//

--- a/mlir/include/mlir/Transforms/Passes.td
+++ b/mlir/include/mlir/Transforms/Passes.td
@@ -552,4 +552,20 @@ def TopologicalSort : Pass<"topological-sort"> {
   let constructor = "mlir::createTopologicalSortPass()";
 }
 
+def CompositePass : Pass<"composite-pass"> {
+  let summary = "TBD";
+  let description = [{
+    TBD
+  }];
+
+  let options = [
+    Option<"name", "name", "std::string", /*default=*/"\"CompositePass\"",
+      "Composite pass display name">,
+    Option<"pipelineStr", "pipeline", "std::string", /*default=*/"",
+      "Composite pass inner pipeline">,
+    Option<"maxIter", "max-iterations", "unsigned", /*default=*/"10",
+      "Maximum number of iterations if inner pipeline">,
+  ];
+}
+
 #endif // MLIR_TRANSFORMS_PASSES

--- a/mlir/include/mlir/Transforms/Passes.td
+++ b/mlir/include/mlir/Transforms/Passes.td
@@ -552,7 +552,7 @@ def TopologicalSort : Pass<"topological-sort"> {
   let constructor = "mlir::createTopologicalSortPass()";
 }
 
-def CompositePass : Pass<"composite-pass"> {
+def CompositeFixedPointPass : Pass<"composite-fixed-point-pass"> {
   let summary = "TBD";
   let description = [{
     TBD

--- a/mlir/include/mlir/Transforms/Passes.td
+++ b/mlir/include/mlir/Transforms/Passes.td
@@ -553,13 +553,14 @@ def TopologicalSort : Pass<"topological-sort"> {
 }
 
 def CompositeFixedPointPass : Pass<"composite-fixed-point-pass"> {
-  let summary = "TBD";
+  let summary = "Composite fixed point pass";
   let description = [{
-    TBD
+    Composite pass runs provided set of passes until fixed point or maximum
+    number of iterations reached.
   }];
 
   let options = [
-    Option<"name", "name", "std::string", /*default=*/"\"CompositePass\"",
+    Option<"name", "name", "std::string", /*default=*/"\"CompositeFixedPointPass\"",
       "Composite pass display name">,
     Option<"pipelineStr", "pipeline", "std::string", /*default=*/"",
       "Composite pass inner pipeline">,

--- a/mlir/include/mlir/Transforms/Passes.td
+++ b/mlir/include/mlir/Transforms/Passes.td
@@ -564,7 +564,7 @@ def CompositeFixedPointPass : Pass<"composite-fixed-point-pass"> {
       "Composite pass display name">,
     Option<"pipelineStr", "pipeline", "std::string", /*default=*/"",
       "Composite pass inner pipeline">,
-    Option<"maxIter", "max-iterations", "unsigned", /*default=*/"10",
+    Option<"maxIter", "max-iterations", "int", /*default=*/"10",
       "Maximum number of iterations if inner pipeline">,
   ];
 }

--- a/mlir/lib/Transforms/CMakeLists.txt
+++ b/mlir/lib/Transforms/CMakeLists.txt
@@ -2,6 +2,7 @@ add_subdirectory(Utils)
 
 add_mlir_library(MLIRTransforms
   Canonicalizer.cpp
+  CompositePass.cpp
   ControlFlowSink.cpp
   CSE.cpp
   GenerateRuntimeVerification.cpp

--- a/mlir/lib/Transforms/CompositePass.cpp
+++ b/mlir/lib/Transforms/CompositePass.cpp
@@ -1,0 +1,81 @@
+//===- CompositePass.cpp - Composite pass code ----------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// CompositePass allows to run set of passes until fixed point is reached.
+//
+//===----------------------------------------------------------------------===//
+
+#include "mlir/Transforms/Passes.h"
+
+#include "mlir/Pass/Pass.h"
+#include "mlir/Pass/PassManager.h"
+
+using namespace mlir;
+
+namespace {
+struct CompositePass final
+    : public PassWrapper<CompositePass, OperationPass<void>> {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(CompositePass)
+
+  CompositePass(std::string name_, std::string argument_,
+                llvm::function_ref<void(OpPassManager &)> populateFunc,
+                unsigned maxIterations)
+      : name(std::move(name_)), argument(std::move(argument_)),
+        dynamicPM(std::make_shared<OpPassManager>()), maxIters(maxIterations) {
+    populateFunc(*dynamicPM);
+  }
+
+  void getDependentDialects(DialectRegistry &registry) const override {
+    dynamicPM->getDependentDialects(registry);
+  }
+
+  void runOnOperation() override {
+    auto op = getOperation();
+    OperationFingerPrint fp(op);
+
+    unsigned currentIter = 0;
+    while (true) {
+      if (failed(runPipeline(*dynamicPM, op)))
+        return signalPassFailure();
+
+      if (currentIter++ >= maxIters) {
+        op->emitWarning("Composite pass \"" + llvm::Twine(name) +
+                        "\"+ didn't converge in " + llvm::Twine(maxIters) +
+                        " iterations");
+        break;
+      }
+
+      OperationFingerPrint newFp(op);
+      if (newFp == fp)
+        break;
+
+      fp = newFp;
+    }
+  }
+
+protected:
+  llvm::StringRef getName() const override { return name; }
+
+  llvm::StringRef getArgument() const override { return argument; }
+
+private:
+  std::string name;
+  std::string argument;
+  std::shared_ptr<OpPassManager> dynamicPM;
+  unsigned maxIters;
+};
+} // namespace
+
+std::unique_ptr<Pass> mlir::createCompositePass(
+    std::string name, std::string argument,
+    llvm::function_ref<void(OpPassManager &)> populateFunc,
+    unsigned maxIterations) {
+
+  return std::make_unique<CompositePass>(std::move(name), std::move(argument),
+                                         populateFunc, maxIterations);
+}

--- a/mlir/lib/Transforms/CompositePass.cpp
+++ b/mlir/lib/Transforms/CompositePass.cpp
@@ -51,6 +51,15 @@ struct CompositeFixedPointPass final
     return success();
   }
 
+  LogicalResult initialize(MLIRContext * /*context*/) override {
+    if (maxIter <= 0) {
+      llvm::errs() << "Invalid maxIterations value: " << maxIter << "\n";
+      return failure();
+    }
+
+    return success();
+  }
+
   void getDependentDialects(DialectRegistry &registry) const override {
     dynamicPM.getDependentDialects(registry);
   }
@@ -90,7 +99,7 @@ private:
 
 std::unique_ptr<Pass> mlir::createCompositeFixedPointPass(
     std::string name, llvm::function_ref<void(OpPassManager &)> populateFunc,
-    unsigned maxIterations) {
+    int maxIterations) {
 
   return std::make_unique<CompositeFixedPointPass>(std::move(name),
                                                    populateFunc, maxIterations);

--- a/mlir/lib/Transforms/CompositePass.cpp
+++ b/mlir/lib/Transforms/CompositePass.cpp
@@ -50,11 +50,10 @@ struct CompositeFixedPointPass final
     return success();
   }
 
-  LogicalResult initialize(MLIRContext * /*context*/) override {
-    if (maxIter <= 0) {
-      llvm::errs() << "Invalid maxIterations value: " << maxIter << "\n";
-      return failure();
-    }
+  LogicalResult initialize(MLIRContext *context) override {
+    if (maxIter <= 0)
+      return emitError(UnknownLoc::get(context))
+             << "Invalid maxIterations value: " << maxIter << "\n";
 
     return success();
   }

--- a/mlir/lib/Transforms/CompositePass.cpp
+++ b/mlir/lib/Transforms/CompositePass.cpp
@@ -33,11 +33,10 @@ struct CompositeFixedPointPass final
     name = std::move(name_);
     maxIter = maxIterations;
     populateFunc(dynamicPM);
-    std::string pipeline;
-    llvm::raw_string_ostream os(pipeline);
+
+    llvm::raw_string_ostream os(pipelineStr);
     dynamicPM.printAsTextualPipeline(os);
     os.flush();
-    pipelineStr = pipeline;
   }
 
   LogicalResult initializeOptions(StringRef options) override {

--- a/mlir/lib/Transforms/CompositePass.cpp
+++ b/mlir/lib/Transforms/CompositePass.cpp
@@ -16,19 +16,20 @@
 #include "mlir/Pass/PassManager.h"
 
 namespace mlir {
-#define GEN_PASS_DEF_COMPOSITEPASS
+#define GEN_PASS_DEF_COMPOSITEFIXEDPOINTPASS
 #include "mlir/Transforms/Passes.h.inc"
 } // namespace mlir
 
 using namespace mlir;
 
 namespace {
-struct CompositePass final : public impl::CompositePassBase<CompositePass> {
-  using CompositePassBase::CompositePassBase;
+struct CompositeFixedPointPass final
+    : public impl::CompositeFixedPointPassBase<CompositeFixedPointPass> {
+  using CompositeFixedPointPassBase::CompositeFixedPointPassBase;
 
-  CompositePass(std::string name_,
-                llvm::function_ref<void(OpPassManager &)> populateFunc,
-                unsigned maxIterations)
+  CompositeFixedPointPass(
+      std::string name_, llvm::function_ref<void(OpPassManager &)> populateFunc,
+      unsigned maxIterations)
       : dynamicPM(std::make_shared<OpPassManager>()) {
     name = std::move(name_);
     maxIter = maxIterations;
@@ -41,7 +42,7 @@ struct CompositePass final : public impl::CompositePassBase<CompositePass> {
   }
 
   LogicalResult initializeOptions(StringRef options) override {
-    if (failed(CompositePassBase::initializeOptions(options)))
+    if (failed(CompositeFixedPointPassBase::initializeOptions(options)))
       return failure();
 
     dynamicPM = std::make_shared<OpPassManager>();
@@ -90,10 +91,10 @@ private:
 };
 } // namespace
 
-std::unique_ptr<Pass> mlir::createCompositePass(
+std::unique_ptr<Pass> mlir::createCompositeFixedPointPass(
     std::string name, llvm::function_ref<void(OpPassManager &)> populateFunc,
     unsigned maxIterations) {
 
-  return std::make_unique<CompositePass>(std::move(name), populateFunc,
-                                         maxIterations);
+  return std::make_unique<CompositeFixedPointPass>(std::move(name),
+                                                   populateFunc, maxIterations);
 }

--- a/mlir/lib/Transforms/CompositePass.cpp
+++ b/mlir/lib/Transforms/CompositePass.cpp
@@ -36,7 +36,6 @@ struct CompositeFixedPointPass final
 
     llvm::raw_string_ostream os(pipelineStr);
     dynamicPM.printAsTextualPipeline(os);
-    os.flush();
   }
 
   LogicalResult initializeOptions(StringRef options) override {

--- a/mlir/lib/Transforms/CompositePass.cpp
+++ b/mlir/lib/Transforms/CompositePass.cpp
@@ -38,14 +38,15 @@ struct CompositeFixedPointPass final
     dynamicPM.printAsTextualPipeline(os);
   }
 
-  LogicalResult initializeOptions(StringRef options) override {
-    if (failed(CompositeFixedPointPassBase::initializeOptions(options)))
+  LogicalResult initializeOptions(
+      StringRef options,
+      function_ref<LogicalResult(const Twine &)> errorHandler) override {
+    if (failed(CompositeFixedPointPassBase::initializeOptions(options,
+                                                              errorHandler)))
       return failure();
 
-    if (failed(parsePassPipeline(pipelineStr, dynamicPM))) {
-      llvm::errs() << "Failed to parse composite pass pipeline\n";
-      return failure();
-    }
+    if (failed(parsePassPipeline(pipelineStr, dynamicPM)))
+      return errorHandler("Failed to parse composite pass pipeline");
 
     return success();
   }

--- a/mlir/lib/Transforms/CompositePass.cpp
+++ b/mlir/lib/Transforms/CompositePass.cpp
@@ -29,7 +29,7 @@ struct CompositeFixedPointPass final
 
   CompositeFixedPointPass(
       std::string name_, llvm::function_ref<void(OpPassManager &)> populateFunc,
-      unsigned maxIterations) {
+      int maxIterations) {
     name = std::move(name_);
     maxIter = maxIterations;
     populateFunc(dynamicPM);
@@ -66,8 +66,8 @@ struct CompositeFixedPointPass final
     auto op = getOperation();
     OperationFingerPrint fp(op);
 
-    unsigned currentIter = 0;
-    unsigned maxIterVal = maxIter;
+    int currentIter = 0;
+    int maxIterVal = maxIter;
     while (true) {
       if (failed(runPipeline(dynamicPM, op)))
         return signalPassFailure();

--- a/mlir/test/Transforms/composite-pass.mlir
+++ b/mlir/test/Transforms/composite-pass.mlir
@@ -1,5 +1,5 @@
-// RUN: mlir-opt %s --log-actions-to=- --test-composite-pass -split-input-file | FileCheck %s
-// RUN: mlir-opt %s --log-actions-to=- --composite-pass='name=TestCompositePass pipeline=any(canonicalize,cse)' -split-input-file | FileCheck %s
+// RUN: mlir-opt %s --log-actions-to=- --test-composite-fixed-point-pass -split-input-file | FileCheck %s
+// RUN: mlir-opt %s --log-actions-to=- --composite-fixed-point-pass='name=TestCompositePass pipeline=any(canonicalize,cse)' -split-input-file | FileCheck %s
 
 // CHECK-LABEL: running `TestCompositePass`
 //       CHECK: running `Canonicalizer`

--- a/mlir/test/Transforms/composite-pass.mlir
+++ b/mlir/test/Transforms/composite-pass.mlir
@@ -1,0 +1,25 @@
+// RUN: mlir-opt %s --log-actions-to=- --test-composite-pass -split-input-file | FileCheck %s
+
+// CHECK-LABEL: running `TestCompositePass`
+//       CHECK: running `Canonicalizer`
+//       CHECK: running `CSE`
+//   CHECK-NOT: running `Canonicalizer`
+//   CHECK-NOT: running `CSE`
+func.func @test() {
+  return
+}
+
+// -----
+
+// CHECK-LABEL: running `TestCompositePass`
+//       CHECK: running `Canonicalizer`
+//       CHECK: running `CSE`
+//       CHECK: running `Canonicalizer`
+//       CHECK: running `CSE`
+//   CHECK-NOT: running `Canonicalizer`
+//   CHECK-NOT: running `CSE`
+func.func @test() {
+// this constant will be canonicalized away, causing another pass iteration
+  %0 = arith.constant 1.5 : f32
+  return
+}

--- a/mlir/test/Transforms/composite-pass.mlir
+++ b/mlir/test/Transforms/composite-pass.mlir
@@ -1,4 +1,5 @@
 // RUN: mlir-opt %s --log-actions-to=- --test-composite-pass -split-input-file | FileCheck %s
+// RUN: mlir-opt %s --log-actions-to=- --composite-pass='name=TestCompositePass pipeline=any(canonicalize,cse)' -split-input-file | FileCheck %s
 
 // CHECK-LABEL: running `TestCompositePass`
 //       CHECK: running `Canonicalizer`

--- a/mlir/test/lib/Transforms/CMakeLists.txt
+++ b/mlir/test/lib/Transforms/CMakeLists.txt
@@ -20,6 +20,7 @@ endif()
 # Exclude tests from libMLIR.so
 add_mlir_library(MLIRTestTransforms
   TestCommutativityUtils.cpp
+  TestCompositePass.cpp
   TestConstantFold.cpp
   TestControlFlowSink.cpp
   TestInlining.cpp

--- a/mlir/test/lib/Transforms/TestCompositePass.cpp
+++ b/mlir/test/lib/Transforms/TestCompositePass.cpp
@@ -1,0 +1,30 @@
+//===------ TestCompositePass.cpp --- composite test pass -----------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements a pass to test the composite pass utility.
+//
+//===----------------------------------------------------------------------===//
+
+#include "mlir/Pass/Pass.h"
+#include "mlir/Pass/PassManager.h"
+#include "mlir/Pass/PassRegistry.h"
+#include "mlir/Transforms/Passes.h"
+
+namespace mlir {
+namespace test {
+void registerTestCompositePass() {
+  registerPass([]() -> std::unique_ptr<Pass> {
+    return createCompositePass("TestCompositePass", "test-composite-pass",
+                               [](OpPassManager &p) {
+                                 p.addPass(createCanonicalizerPass());
+                                 p.addPass(createCSEPass());
+                               });
+  });
+}
+} // namespace test
+} // namespace mlir

--- a/mlir/test/lib/Transforms/TestCompositePass.cpp
+++ b/mlir/test/lib/Transforms/TestCompositePass.cpp
@@ -18,13 +18,21 @@
 namespace mlir {
 namespace test {
 void registerTestCompositePass() {
-  registerPass([]() -> std::unique_ptr<Pass> {
-    return createCompositePass("TestCompositePass", "test-composite-pass",
-                               [](OpPassManager &p) {
-                                 p.addPass(createCanonicalizerPass());
-                                 p.addPass(createCSEPass());
-                               });
-  });
+  registerPassPipeline(
+      "test-composite-pass", "Test composite pass",
+      [](OpPassManager &pm, StringRef optionsStr,
+         function_ref<LogicalResult(const Twine &)> errorHandler) {
+        if (!optionsStr.empty())
+          return failure();
+
+        pm.addPass(
+            createCompositePass("TestCompositePass", [](OpPassManager &p) {
+              p.addPass(createCanonicalizerPass());
+              p.addPass(createCSEPass());
+            }));
+        return success();
+      },
+      [](function_ref<void(const detail::PassOptions &)>) {});
 }
 } // namespace test
 } // namespace mlir

--- a/mlir/test/lib/Transforms/TestCompositePass.cpp
+++ b/mlir/test/lib/Transforms/TestCompositePass.cpp
@@ -19,14 +19,14 @@ namespace mlir {
 namespace test {
 void registerTestCompositePass() {
   registerPassPipeline(
-      "test-composite-pass", "Test composite pass",
+      "test-composite-fixed-point-pass", "Test composite pass",
       [](OpPassManager &pm, StringRef optionsStr,
          function_ref<LogicalResult(const Twine &)> errorHandler) {
         if (!optionsStr.empty())
           return failure();
 
-        pm.addPass(
-            createCompositePass("TestCompositePass", [](OpPassManager &p) {
+        pm.addPass(createCompositeFixedPointPass(
+            "TestCompositePass", [](OpPassManager &p) {
               p.addPass(createCanonicalizerPass());
               p.addPass(createCSEPass());
             }));

--- a/mlir/tools/mlir-opt/mlir-opt.cpp
+++ b/mlir/tools/mlir-opt/mlir-opt.cpp
@@ -68,6 +68,7 @@ void registerTosaTestQuantUtilAPIPass();
 void registerVectorizerTestPass();
 
 namespace test {
+void registerTestCompositePass();
 void registerCommutativityUtils();
 void registerConvertCallOpPass();
 void registerInliner();
@@ -195,6 +196,7 @@ void registerTestPasses() {
   registerVectorizerTestPass();
   registerTosaTestQuantUtilAPIPass();
 
+  mlir::test::registerTestCompositePass();
   mlir::test::registerCommutativityUtils();
   mlir::test::registerConvertCallOpPass();
   mlir::test::registerInliner();


### PR DESCRIPTION
Composite pass allows to run sequence of passes in the loop until fixed point or maximum number of iterations is reached. The usual candidates are canonicalize+CSE as canonicalize can open more opportunities for CSE and vice-versa.