### PR TITLE
[clangd] Add config option to allow detection of unused system headers

### DIFF
--- a/clang-tools-extra/clangd/Config.h
+++ b/clang-tools-extra/clangd/Config.h
@@ -110,9 +110,9 @@ struct Config {
     IncludesPolicy UnusedIncludes = IncludesPolicy::Strict;
     IncludesPolicy MissingIncludes = IncludesPolicy::None;
 
-    /// IncludeCleaner will not diagnose usages of these headers matched by
-    /// these regexes.
     struct {
+      /// IncludeCleaner will not diagnose usages of these headers matched by
+      /// these regexes.
       std::vector<std::function<bool(llvm::StringRef)>> IgnoreHeader;
       bool AnalyzeSystemHeaders = false;
     } Includes;

--- a/clang-tools-extra/clangd/Config.h
+++ b/clang-tools-extra/clangd/Config.h
@@ -114,7 +114,7 @@ struct Config {
       /// IncludeCleaner will not diagnose usages of these headers matched by
       /// these regexes.
       std::vector<std::function<bool(llvm::StringRef)>> IgnoreHeader;
-      bool AnalyzeSystemHeaders = false;
+      bool AnalyzeAngledIncludes = false;
     } Includes;
   } Diagnostics;
 

--- a/clang-tools-extra/clangd/Config.h
+++ b/clang-tools-extra/clangd/Config.h
@@ -114,6 +114,7 @@ struct Config {
     /// these regexes.
     struct {
       std::vector<std::function<bool(llvm::StringRef)>> IgnoreHeader;
+      bool AnalyzeSystemHeaders = false;
     } Includes;
   } Diagnostics;
 

--- a/clang-tools-extra/clangd/ConfigCompile.cpp
+++ b/clang-tools-extra/clangd/ConfigCompile.cpp
@@ -591,6 +591,9 @@ struct FragmentCompiler {
         Filters->push_back(std::move(CompiledRegex));
       }
     }
+    // Optional to override the resulting AnalyzeAngledIncludes
+    // only if it's explicitly set in the current fragment.
+    // Otherwise it's inherited from parent fragment.
     std::optional<bool> AnalyzeAngledIncludes;
     if (F.AnalyzeAngledIncludes.has_value())
       AnalyzeAngledIncludes = **F.AnalyzeAngledIncludes;

--- a/clang-tools-extra/clangd/ConfigCompile.cpp
+++ b/clang-tools-extra/clangd/ConfigCompile.cpp
@@ -591,13 +591,13 @@ struct FragmentCompiler {
         Filters->push_back(std::move(CompiledRegex));
       }
     }
-    std::optional<bool> AnalyzeSystemHeaders;
-    if (F.AnalyzeSystemHeaders.has_value())
-      AnalyzeSystemHeaders = **F.AnalyzeSystemHeaders;
-    if (!Filters && !AnalyzeSystemHeaders.has_value())
+    std::optional<bool> AnalyzeAngledIncludes;
+    if (F.AnalyzeAngledIncludes.has_value())
+      AnalyzeAngledIncludes = **F.AnalyzeAngledIncludes;
+    if (!Filters && !AnalyzeAngledIncludes.has_value())
       return;
     Out.Apply.push_back([Filters = std::move(Filters),
-                         AnalyzeSystemHeaders](const Params &, Config &C) {
+                         AnalyzeAngledIncludes](const Params &, Config &C) {
       if (Filters) {
         auto Filter = [Filters](llvm::StringRef Path) {
           for (auto &Regex : *Filters)
@@ -607,8 +607,8 @@ struct FragmentCompiler {
         };
         C.Diagnostics.Includes.IgnoreHeader.emplace_back(std::move(Filter));
       }
-      if (AnalyzeSystemHeaders.has_value())
-        C.Diagnostics.Includes.AnalyzeSystemHeaders = *AnalyzeSystemHeaders;
+      if (AnalyzeAngledIncludes.has_value())
+        C.Diagnostics.Includes.AnalyzeAngledIncludes = *AnalyzeAngledIncludes;
     });
   }
 

--- a/clang-tools-extra/clangd/ConfigFragment.h
+++ b/clang-tools-extra/clangd/ConfigFragment.h
@@ -257,7 +257,7 @@ struct Fragment {
 
       /// If false (default), unused system headers will be ignored.
       /// Standard library headers are analyzed regardless of this option.
-      std::optional<Located<bool>> AnalyzeSystemHeaders;
+      std::optional<Located<bool>> AnalyzeAngledIncludes;
     };
     IncludesBlock Includes;
 

--- a/clang-tools-extra/clangd/ConfigFragment.h
+++ b/clang-tools-extra/clangd/ConfigFragment.h
@@ -254,6 +254,10 @@ struct Fragment {
       /// unused or missing. These can match any suffix of the header file in
       /// question.
       std::vector<Located<std::string>> IgnoreHeader;
+
+      /// If false (default), unused system headers will be ignored.
+      /// Standard library headers are analyzed regardless of this option.
+      std::optional<Located<bool>> AnalyzeSystemHeaders;
     };
     IncludesBlock Includes;
 

--- a/clang-tools-extra/clangd/ConfigYAML.cpp
+++ b/clang-tools-extra/clangd/ConfigYAML.cpp
@@ -169,9 +169,9 @@ private:
       if (auto Values = scalarValues(N))
         F.IgnoreHeader = std::move(*Values);
     });
-    Dict.handle("AnalyzeSystemHeaders", [&](Node &N) {
-      if (auto Value = boolValue(N, "AnalyzeSystemHeaders"))
-        F.AnalyzeSystemHeaders = *Value;
+    Dict.handle("AnalyzeAngledIncludes", [&](Node &N) {
+      if (auto Value = boolValue(N, "AnalyzeAngledIncludes"))
+        F.AnalyzeAngledIncludes = *Value;
     });
     Dict.parse(N);
   }

--- a/clang-tools-extra/clangd/ConfigYAML.cpp
+++ b/clang-tools-extra/clangd/ConfigYAML.cpp
@@ -169,6 +169,10 @@ private:
       if (auto Values = scalarValues(N))
         F.IgnoreHeader = std::move(*Values);
     });
+    Dict.handle("AnalyzeSystemHeaders", [&](Node &N) {
+      if (auto Value = boolValue(N, "AnalyzeSystemHeaders"))
+        F.AnalyzeSystemHeaders = *Value;
+    });
     Dict.parse(N);
   }
 

--- a/clang-tools-extra/clangd/IncludeCleaner.cpp
+++ b/clang-tools-extra/clangd/IncludeCleaner.cpp
@@ -87,12 +87,10 @@ bool mayConsiderUnused(const Inclusion &Inc, ParsedAST &AST,
   // Until we have good support for umbrella headers, don't warn about them
   // (unless analysis is explicitly enabled).
   if (Inc.Written.front() == '<') {
-    if (tooling::stdlib::Header::named(Inc.Written)) {
+    if (tooling::stdlib::Header::named(Inc.Written))
       return true;
-    }
-    if (!AnalyzeAngledIncludes) {
+    if (!AnalyzeAngledIncludes)
       return false;
-    }
   }
   if (PI) {
     // Check if main file is the public interface for a private header. If so we

--- a/clang-tools-extra/clangd/IncludeCleaner.h
+++ b/clang-tools-extra/clangd/IncludeCleaner.h
@@ -55,7 +55,7 @@ struct IncludeCleanerFindings {
 
 IncludeCleanerFindings
 computeIncludeCleanerFindings(ParsedAST &AST,
-                              bool AnalyzeSystemHeaders = false);
+                              bool AnalyzeAngledIncludes = false);
 
 using HeaderFilter = llvm::ArrayRef<std::function<bool(llvm::StringRef)>>;
 std::vector<Diag>

--- a/clang-tools-extra/clangd/IncludeCleaner.h
+++ b/clang-tools-extra/clangd/IncludeCleaner.h
@@ -53,7 +53,9 @@ struct IncludeCleanerFindings {
   std::vector<MissingIncludeDiagInfo> MissingIncludes;
 };
 
-IncludeCleanerFindings computeIncludeCleanerFindings(ParsedAST &AST);
+IncludeCleanerFindings
+computeIncludeCleanerFindings(ParsedAST &AST,
+                              bool AnalyzeSystemHeaders = false);
 
 using HeaderFilter = llvm::ArrayRef<std::function<bool(llvm::StringRef)>>;
 std::vector<Diag>
@@ -61,15 +63,6 @@ issueIncludeCleanerDiagnostics(ParsedAST &AST, llvm::StringRef Code,
                                const IncludeCleanerFindings &Findings,
                                const ThreadsafeFS &TFS,
                                HeaderFilter IgnoreHeader = {});
-
-/// Affects whether standard library includes should be considered for
-/// removal. This is off by default for now due to implementation limitations:
-/// - macros are not tracked
-/// - symbol names without a unique associated header are not tracked
-/// - references to std-namespaced C types are not properly tracked:
-///   instead of std::size_t -> <cstddef> we see ::size_t -> <stddef.h>
-/// FIXME: remove this hack once the implementation is good enough.
-void setIncludeCleanerAnalyzesStdlib(bool B);
 
 /// Converts the clangd include representation to include-cleaner
 /// include representation.

--- a/clang-tools-extra/clangd/ParsedAST.cpp
+++ b/clang-tools-extra/clangd/ParsedAST.cpp
@@ -374,7 +374,7 @@ std::vector<Diag> getIncludeCleanerDiags(ParsedAST &AST, llvm::StringRef Code,
   if (SuppressMissing && SuppressUnused)
     return {};
   auto Findings = computeIncludeCleanerFindings(
-      AST, Cfg.Diagnostics.Includes.AnalyzeSystemHeaders);
+      AST, Cfg.Diagnostics.Includes.AnalyzeAngledIncludes);
   if (SuppressMissing)
     Findings.MissingIncludes.clear();
   if (SuppressUnused)

--- a/clang-tools-extra/clangd/ParsedAST.cpp
+++ b/clang-tools-extra/clangd/ParsedAST.cpp
@@ -373,7 +373,8 @@ std::vector<Diag> getIncludeCleanerDiags(ParsedAST &AST, llvm::StringRef Code,
       Cfg.Diagnostics.UnusedIncludes == Config::IncludesPolicy::None;
   if (SuppressMissing && SuppressUnused)
     return {};
-  auto Findings = computeIncludeCleanerFindings(AST);
+  auto Findings = computeIncludeCleanerFindings(
+      AST, Cfg.Diagnostics.Includes.AnalyzeSystemHeaders);
   if (SuppressMissing)
     Findings.MissingIncludes.clear();
   if (SuppressUnused)

--- a/clang-tools-extra/clangd/unittests/ConfigCompileTests.cpp
+++ b/clang-tools-extra/clangd/unittests/ConfigCompileTests.cpp
@@ -279,10 +279,10 @@ TEST_F(ConfigCompileTests, DiagnosticsIncludeCleaner) {
   EXPECT_FALSE(HeaderFilter("bar.h"));
 
   Frag = {};
-  EXPECT_FALSE(Conf.Diagnostics.Includes.AnalyzeSystemHeaders);
-  Frag.Diagnostics.Includes.AnalyzeSystemHeaders = true;
+  EXPECT_FALSE(Conf.Diagnostics.Includes.AnalyzeAngledIncludes);
+  Frag.Diagnostics.Includes.AnalyzeAngledIncludes = true;
   EXPECT_TRUE(compileAndApply());
-  EXPECT_TRUE(Conf.Diagnostics.Includes.AnalyzeSystemHeaders);
+  EXPECT_TRUE(Conf.Diagnostics.Includes.AnalyzeAngledIncludes);
 }
 
 TEST_F(ConfigCompileTests, DiagnosticSuppression) {

--- a/clang-tools-extra/clangd/unittests/ConfigCompileTests.cpp
+++ b/clang-tools-extra/clangd/unittests/ConfigCompileTests.cpp
@@ -277,6 +277,12 @@ TEST_F(ConfigCompileTests, DiagnosticsIncludeCleaner) {
   };
   EXPECT_TRUE(HeaderFilter("foo.h"));
   EXPECT_FALSE(HeaderFilter("bar.h"));
+
+  Frag = {};
+  EXPECT_FALSE(Conf.Diagnostics.Includes.AnalyzeSystemHeaders);
+  Frag.Diagnostics.Includes.AnalyzeSystemHeaders = true;
+  EXPECT_TRUE(compileAndApply());
+  EXPECT_TRUE(Conf.Diagnostics.Includes.AnalyzeSystemHeaders);
 }
 
 TEST_F(ConfigCompileTests, DiagnosticSuppression) {

--- a/clang-tools-extra/clangd/unittests/ConfigYAMLTests.cpp
+++ b/clang-tools-extra/clangd/unittests/ConfigYAMLTests.cpp
@@ -278,18 +278,18 @@ Diagnostics:
               ElementsAre(val("foo"), val("bar")));
 }
 
-TEST(ParseYAML, IncludesAnalyzeSystemHeaders) {
+TEST(ParseYAML, IncludesAnalyzeAngledIncludes) {
   CapturedDiags Diags;
   Annotations YAML(R"yaml(
 Diagnostics:
   Includes:
-    AnalyzeSystemHeaders: true
+    AnalyzeAngledIncludes: true
   )yaml");
   auto Results =
       Fragment::parseYAML(YAML.code(), "config.yaml", Diags.callback());
   ASSERT_THAT(Diags.Diagnostics, IsEmpty());
   ASSERT_EQ(Results.size(), 1u);
-  EXPECT_THAT(Results[0].Diagnostics.Includes.AnalyzeSystemHeaders,
+  EXPECT_THAT(Results[0].Diagnostics.Includes.AnalyzeAngledIncludes,
               llvm::ValueIs(val(true)));
 }
 

--- a/clang-tools-extra/clangd/unittests/ConfigYAMLTests.cpp
+++ b/clang-tools-extra/clangd/unittests/ConfigYAMLTests.cpp
@@ -278,6 +278,21 @@ Diagnostics:
               ElementsAre(val("foo"), val("bar")));
 }
 
+TEST(ParseYAML, IncludesAnalyzeSystemHeaders) {
+  CapturedDiags Diags;
+  Annotations YAML(R"yaml(
+Diagnostics:
+  Includes:
+    AnalyzeSystemHeaders: true
+  )yaml");
+  auto Results =
+      Fragment::parseYAML(YAML.code(), "config.yaml", Diags.callback());
+  ASSERT_THAT(Diags.Diagnostics, IsEmpty());
+  ASSERT_EQ(Results.size(), 1u);
+  EXPECT_THAT(Results[0].Diagnostics.Includes.AnalyzeSystemHeaders,
+              llvm::ValueIs(val(true)));
+}
+
 TEST(ParseYAML, Style) {
   CapturedDiags Diags;
   Annotations YAML(R"yaml(

--- a/clang-tools-extra/clangd/unittests/IncludeCleanerTests.cpp
+++ b/clang-tools-extra/clangd/unittests/IncludeCleanerTests.cpp
@@ -108,6 +108,7 @@ TEST(IncludeCleaner, GetUnusedHeaders) {
     #include "unguarded.h"
     #include "unused.h"
     #include <system_header.h>
+    #include <non_system_angled_header.h>
     void foo() {
       a();
       b();
@@ -122,6 +123,7 @@ TEST(IncludeCleaner, GetUnusedHeaders) {
   TU.AdditionalFiles["dir/c.h"] = guard("void c();");
   TU.AdditionalFiles["unused.h"] = guard("void unused();");
   TU.AdditionalFiles["dir/unused.h"] = guard("void dirUnused();");
+  TU.AdditionalFiles["dir/non_system_angled_header.h"] = guard("");
   TU.AdditionalFiles["system/system_header.h"] = guard("");
   TU.AdditionalFiles["unguarded.h"] = "";
   TU.ExtraArgs.push_back("-I" + testPath("dir"));
@@ -135,19 +137,26 @@ TEST(IncludeCleaner, GetUnusedHeaders) {
                            Pointee(writtenInclusion("\"dir/unused.h\""))));
 }
 
-TEST(IncludeCleaner, SystemUnusedHeaders) {
+TEST(IncludeCleaner, UnusedAngledHeaders) {
   auto TU = TestTU::withCode(R"cpp(
     #include <system_header.h>
     #include <system_unused.h>
+    #include <non_system_angled_unused.h>
     SystemClass x;
   )cpp");
   TU.AdditionalFiles["system/system_header.h"] = guard("class SystemClass {};");
   TU.AdditionalFiles["system/system_unused.h"] = guard("");
-  TU.ExtraArgs = {"-isystem", testPath("system")};
+  TU.AdditionalFiles["dir/non_system_angled_unused.h"] = guard("");
+  TU.ExtraArgs = {
+      "-isystem" + testPath("system"),
+      "-I" + testPath("dir"),
+  };
   auto AST = TU.build();
   IncludeCleanerFindings Findings = computeIncludeCleanerFindings(AST, true);
   EXPECT_THAT(Findings.UnusedIncludes,
-              ElementsAre(Pointee(writtenInclusion("<system_unused.h>"))));
+              UnorderedElementsAre(
+                  Pointee(writtenInclusion("<system_unused.h>")),
+                  Pointee(writtenInclusion("<non_system_angled_unused.h>"))));
 }
 
 TEST(IncludeCleaner, ComputeMissingHeaders) {

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -81,8 +81,8 @@ Objective-C
 Miscellaneous
 ^^^^^^^^^^^^^
 
-- Added a boolean option `AnalyzeSystemHeaders` to `Includes` config section,
-  which allows to enable unused includes detection for all system headers.
+- Added a boolean option `AnalyzeAngledIncludes` to `Includes` config section,
+  which allows to enable unused includes detection for all angled ("system") headers.
   At this moment umbrella headers are not supported, so enabling this option
   may result in false-positives.
 

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -81,6 +81,11 @@ Objective-C
 Miscellaneous
 ^^^^^^^^^^^^^
 
+- Added a boolean option `AnalyzeSystemHeaders` to `Includes` config section,
+  which allows to enable unused includes detection for all system headers.
+  At this moment umbrella headers are not supported, so enabling this option
+  may result in false-positives.
+
 Improvements to clang-doc
 -------------------------
 


### PR DESCRIPTION
This PR adds a new `AnalyzeSystemHeaders` option to `Includes` section of clangd config. This option will allow to mark all system headers, not just the ones from standard library, as unused.

Why this change is useful?
In our codebase all includes from outside of local directory are written with angle brackets. For example,
```cpp
// foo.cpp
#include "foo.h"  // main header
#include "foo_utils.h"  // From the same directory
#include <util/generic/string.h>  // Other directory, path is relative to repository root
#include <algorithm>  // Header from standard library
```

I'd like to use the builtin include-cleaner of clangd to detect unused includes, but currently it ignores non-standard system headers (which make up around 75% of includes in our codebase)

I understand that enabling unused include detection for system headers will probably produce some false positives due to lack of support for umbrella headers, but they can be filtered out by `IgnoreHeader`. This is not ideal, but still better than not having unused include detection for system headers at all.