### PR TITLE
[mlir][IR] Improve attribute printing with serial comma

### DIFF
--- a/mlir/include/mlir/IR/OperationSupport.h
+++ b/mlir/include/mlir/IR/OperationSupport.h
@@ -1166,6 +1166,10 @@ public:
   /// Print users of values as comments.
   OpPrintingFlags &printValueUsers();
 
+  /// Use serial comma (a.k.a. Oxford comma) when priting sequences of 3 or more
+  /// elements.
+  OpPrintingFlags &useSerialComma();
+
   /// Return if the given ElementsAttr should be elided.
   bool shouldElideElementsAttr(ElementsAttr attr) const;
 
@@ -1196,6 +1200,10 @@ public:
   /// Return if the printer should print users of values.
   bool shouldPrintValueUsers() const;
 
+  /// Return if the printer should use serial comma when printing sequences of 3
+  /// or more elements.
+  bool shouldUseSerialComma() const;
+
 private:
   /// Elide large elements attributes if the number of elements is larger than
   /// the upper limit.
@@ -1222,6 +1230,9 @@ private:
 
   /// Print users of values.
   bool printValueUsersFlag : 1;
+
+  /// Print sequences of 3 or more elements using serial comma.
+  bool printSerialComma : 1;
 };
 
 //===----------------------------------------------------------------------===//

--- a/mlir/lib/IR/AsmPrinter.cpp
+++ b/mlir/lib/IR/AsmPrinter.cpp
@@ -144,7 +144,7 @@ static bool environmentRequiresSerialComma() {
       currentLanguage.starts_with("en_CA"))
     return true;
   llvm_unreachable(
-      "Unhandle corner case. This is very unlikely to happen in practice.");
+      "Unhandled corner case. This is very unlikely to happen in practice.");
 }
 
 namespace {
@@ -216,6 +216,11 @@ static llvm::ManagedStatic<AsmPrinterOptions> clOptions;
 void mlir::registerAsmPrinterCLOptions() {
   // Make sure that the options struct has been initialized.
   *clOptions;
+
+  static llvm::cl::alias printOxfordComma(
+      "mlir-print-oxford-comma",
+      llvm::cl::desc("Alias for --mlir-print-serial-comma"),
+      llvm::cl::aliasopt(clOptions->printSerialComma));
 }
 
 /// Initialize the printing flags with default supplied by the cl::opts above.

--- a/mlir/test/IR/print-use-serial-comma.mlir
+++ b/mlir/test/IR/print-use-serial-comma.mlir
@@ -1,5 +1,8 @@
 // RUN: mlir-opt %s --mlir-print-serial-comma | FileCheck %s
 
+// Check that the alias flag is also recognized.
+// RUN: mlir-opt %s --mlir-print-oxford-comma | FileCheck %s
+
 // CHECK: foo.dense_attr = dense<[1, 2, and 3]> : tensor<3xi32>
 "test.dense_attr"() {foo.dense_attr = dense<[1, 2, 3]> : tensor<3xi32>} : () -> ()
 

--- a/mlir/test/IR/print-use-serial-comma.mlir
+++ b/mlir/test/IR/print-use-serial-comma.mlir
@@ -1,0 +1,19 @@
+// RUN: mlir-opt %s --mlir-print-serial-comma | FileCheck %s
+
+// CHECK: foo.dense_attr = dense<[1, 2, and 3]> : tensor<3xi32>
+"test.dense_attr"() {foo.dense_attr = dense<[1, 2, 3]> : tensor<3xi32>} : () -> ()
+
+// Nested attributes not supported, we should use 1-d vectors from the LLVM dialect anyway.
+// CHECK{LITERAL}: foo.dense_attr = dense<[[1, 2, 3], [4, 5, 6], [7, 8, and 9]]> : tensor<3x3xi32>
+"test.nested_dense_attr"() {foo.dense_attr = dense<[[1, 2, 3], [4, 5, 6], [7, 8, 9]]> : tensor<3x3xi32>} : () -> ()
+
+// Two elements, serial comma not necessary.
+// CHECK: dense<[1, 2]> : tensor<2xi32>
+"test.non_elided_dense_attr"() {foo.dense_attr = dense<[1, 2]> : tensor<2xi32>} : () -> ()
+
+// CHECK{LITERAL}: sparse<[[0, 0, and 5]], -2.000000e+00> : vector<1x1x10xf16>
+"test.sparse_attr"() {foo.sparse_attr = sparse<[[0, 0, 5]],  -2.0> : vector<1x1x10xf16>} : () -> ()
+
+// One unique element, do not use serial comma.
+// CHECK: dense<1> : tensor<3xi32>
+"test.dense_splat"() {foo.dense_attr = dense<1> : tensor<3xi32>} : () -> ()


### PR DESCRIPTION
Make attributes more readable by using serial comma (a.k.a. Oxford comma). This applies to sequences of length 3 and longer and reduces ambiguity.

The behavior is opt-in and enabled by a new flag `--mlir-print-serial-comma` with a convenience alias `--mlir-print-oxford-comma`.  Parsing support will be added in a follow-up PR.

For more context, see the RFC thread: https://discourse.llvm.org/t/rfc-solving-the-issue-of-long-attributes/78070