### PR TITLE
MIPS/Clang: Set HasUnalignedAccess false if +strict-align

### DIFF
--- a/clang/lib/Basic/Targets/Mips.h
+++ b/clang/lib/Basic/Targets/Mips.h
@@ -318,6 +318,7 @@ public:
     FPMode = isFP64Default() ? FP64 : FPXX;
     NoOddSpreg = false;
     bool OddSpregGiven = false;
+    bool StrictAlign = false;
 
     for (const auto &Feature : Features) {
       if (Feature == "+single-float")
@@ -330,6 +331,10 @@ public:
         IsMicromips = true;
       else if (Feature == "+mips32r6" || Feature == "+mips64r6")
         HasUnalignedAccess = true;
+      // We cannot be sure that the order of strict-align vs mips32r6.
+      // Thus we need an extra variable here.
+      else if (Feature == "+strict-align")
+        StrictAlign = true;
       else if (Feature == "+dsp")
         DspRev = std::max(DspRev, DSP1);
       else if (Feature == "+dspr2")
@@ -367,6 +372,9 @@ public:
 
     if (FPMode == FPXX && !OddSpregGiven)
       NoOddSpreg = true;
+
+    if (StrictAlign)
+      HasUnalignedAccess = false;
 
     setDataLayout();
 


### PR DESCRIPTION
TargetInfo has HasUnalignedAccess support now. For MIPSr6, we should set it according strict-align.

For pre-R6, we always set strict-align and HasUnalignedAccess to false.