### PR TITLE
XFAIL clang/Driver/test/compress.c on AIX 

### DIFF
--- a/clang/test/Driver/compress.c
+++ b/clang/test/Driver/compress.c
@@ -2,8 +2,6 @@
 
 // REQUIRES: zlib
 
-// XFAIL: target={{.*}}-aix{{.*}}
-
 // RUN: %clang -### -fintegrated-as -Wa,-compress-debug-sections -c %s 2>&1 | FileCheck -check-prefix CHECK-_COMPRESS_DEBUG_SECTIONS %s
 // CHECK-_COMPRESS_DEBUG_SECTIONS: "-compress-debug-sections"
 

--- a/clang/test/Driver/compress.c
+++ b/clang/test/Driver/compress.c
@@ -2,7 +2,7 @@
 
 // REQUIRES: zlib
 
-; XFAIL: target={{.*}}-aix{{.*}}
+// XFAIL: target={{.*}}-aix{{.*}}
 
 // RUN: %clang -### -fintegrated-as -Wa,-compress-debug-sections -c %s 2>&1 | FileCheck -check-prefix CHECK-_COMPRESS_DEBUG_SECTIONS %s
 // CHECK-_COMPRESS_DEBUG_SECTIONS: "-compress-debug-sections"

--- a/clang/test/Driver/compress.c
+++ b/clang/test/Driver/compress.c
@@ -1,4 +1,6 @@
-// REQUIRES: zlib
+// XFAIL: system-aix
+
+// // REQUIRES: zlib
 
 // RUN: %clang -### -fintegrated-as -Wa,-compress-debug-sections -c %s 2>&1 | FileCheck -check-prefix CHECK-_COMPRESS_DEBUG_SECTIONS %s
 // CHECK-_COMPRESS_DEBUG_SECTIONS: "-compress-debug-sections"

--- a/clang/test/Driver/compress.c
+++ b/clang/test/Driver/compress.c
@@ -1,6 +1,8 @@
 // XFAIL: system-aix
 
-// // REQUIRES: zlib
+// REQUIRES: zlib
+
+; XFAIL: target={{.*}}-aix{{.*}}
 
 // RUN: %clang -### -fintegrated-as -Wa,-compress-debug-sections -c %s 2>&1 | FileCheck -check-prefix CHECK-_COMPRESS_DEBUG_SECTIONS %s
 // CHECK-_COMPRESS_DEBUG_SECTIONS: "-compress-debug-sections"


### PR DESCRIPTION
This PR XFAIL's `clang/Driver/compress.c` on AIX since it requires the LLVM integrated assembler / assembly parser support, which is not available on AIX. 

```
/home/jenkinsWorker/jenkins/workspace/LLVM-Release/release-testing-prototype/llvm/clang18.1.2-final/final/llvm-project/clang/test/Driver/compress.c:19:18: error: CHECK-OPT_GZ: expected string not found in input
// CHECK-OPT_GZ: "--compress-debug-sections=zlib"
```