### PR TITLE
[flang] Handle forward reference to shadowing derived type from IMPLICIT

### DIFF
--- a/flang/test/Semantics/resolve29.f90
+++ b/flang/test/Semantics/resolve29.f90
@@ -3,6 +3,7 @@ module m1
   type t1
   end type
   type t3
+    integer t3c
   end type
   interface
     subroutine s1(x)
@@ -63,6 +64,17 @@ contains
       integer n(2)
     end type
     type(t2) x
+  end
+  subroutine s10()
+    !Forward shadowing derived type in IMPLICIT
+    !(supported by all other compilers)
+    implicit type(t1) (c) ! forward shadow
+    implicit type(t3) (d) ! host associated
+    type t1
+      integer a
+    end type
+    c%a = 1
+    d%t3c = 2
   end
 end module
 module m2


### PR DESCRIPTION
A derived type name in an IMPLICIT statement might be a host association or it might be a forward reference to a local derived type, which may be shadowing a host-associated name.  Add a scan over the specification part in search of derived type definitions to determine the right interpretation.

Fixes https://github.com/llvm/llvm-project/issues/87215.