### PR TITLE
[libc] fixup ftello test

### DIFF
--- a/libc/test/src/stdio/ftell_test.cpp
+++ b/libc/test/src/stdio/ftell_test.cpp
@@ -39,7 +39,7 @@ protected:
     // still return the correct effective offset.
     ASSERT_EQ(size_t(LIBC_NAMESPACE::ftell(file)), WRITE_SIZE);
 
-    off_t offseto = 42;
+    off_t offseto = 5;
     ASSERT_EQ(0, LIBC_NAMESPACE::fseeko(file, offseto, SEEK_SET));
     ASSERT_EQ(LIBC_NAMESPACE::ftello(file), offseto);
     ASSERT_EQ(0, LIBC_NAMESPACE::fseeko(file, -offseto, SEEK_END));


### PR DESCRIPTION
Use a seek offset that fits within the file size.

This was missed in presubmit because the FILE based stdio tests aren't run in
overlay mode; fullbuild is not tested in presubmit.

WRITE_SIZE == 11, so using a value of 42 for offseto would cause the expression
`WRITE_SIZE - offseto` to evaluate to -31 as an unsigned 64b integer
(18446744073709551585ULL).

Fixes #86928
