### PR TITLE
lit_test : check if there is already a deps key in kwargs

### DIFF
--- a/utils/bazel/llvm-project-overlay/llvm/lit_test.bzl
+++ b/utils/bazel/llvm-project-overlay/llvm/lit_test.bzl
@@ -35,7 +35,7 @@ def lit_test(
         args = args + ["-v"] + ["$(execpath %s)" % src for src in srcs],
         data = data + srcs,
         legacy_create_init = False,
-        deps = [Label("//llvm:lit")],
+        deps = [Label("//llvm:lit")] + kwargs.pop("deps", []),
         **kwargs
     )
 

--- a/utils/bazel/llvm-project-overlay/llvm/lit_test.bzl
+++ b/utils/bazel/llvm-project-overlay/llvm/lit_test.bzl
@@ -10,6 +10,7 @@ def lit_test(
         srcs,
         args = None,
         data = None,
+        deps = None,
         **kwargs):
     """Runs a single test file with LLVM's lit tool.
 
@@ -27,6 +28,7 @@ def lit_test(
 
     args = args or []
     data = data or []
+    deps = deps or []
 
     native.py_test(
         name = name,
@@ -35,7 +37,7 @@ def lit_test(
         args = args + ["-v"] + ["$(execpath %s)" % src for src in srcs],
         data = data + srcs,
         legacy_create_init = False,
-        deps = [Label("//llvm:lit")] + kwargs.pop("deps", []),
+        deps = deps + [Label("//llvm:lit")],
         **kwargs
     )
 


### PR DESCRIPTION
This change checks if there is already a `deps` key in `kwargs` and concatenate it to avoid multiple values for  `deps` key argument.

background:
https://github.com/llvm/llvm-project/pull/87022 recently added explicit `deps` to the lit_test. This is causing StableHLO bazel build failures  at https://github.com/openxla/stablehlo/actions/runs/8511888283/job/23312383380?pr=2147

Tested: local build run is successful