### PR TITLE
[libc] allow libc-hdrgen to work on windows files

### DIFF
--- a/libc/utils/HdrGen/Generator.cpp
+++ b/libc/utils/HdrGen/Generator.cpp
@@ -84,11 +84,19 @@ void Generator::generate(llvm::raw_ostream &OS, llvm::RecordKeeper &Records) {
       Line = Line.drop_front(CommandPrefixSize);
 
       P = Line.split("(");
+      // It's possible that we have windows line endings, so strip off the extra CR.
+      P.second = P.second.trim();
       if (P.second.empty() || P.second[P.second.size() - 1] != ')') {
         SrcMgr.PrintMessage(llvm::SMLoc::getFromPointer(P.second.data()),
                             llvm::SourceMgr::DK_Error,
                             "Command argument list should begin with '(' "
                             "and end with ')'.");
+        SrcMgr.PrintMessage(llvm::SMLoc::getFromPointer(P.second.data()),
+                            llvm::SourceMgr::DK_Error,
+                            P.second.data());
+        SrcMgr.PrintMessage(llvm::SMLoc::getFromPointer(P.second.data()),
+                            llvm::SourceMgr::DK_Error,
+                            std::to_string(P.second.size()));
         std::exit(1);
       }
       llvm::StringRef CommandName = P.first;

--- a/libc/utils/HdrGen/Generator.cpp
+++ b/libc/utils/HdrGen/Generator.cpp
@@ -84,7 +84,8 @@ void Generator::generate(llvm::raw_ostream &OS, llvm::RecordKeeper &Records) {
       Line = Line.drop_front(CommandPrefixSize);
 
       P = Line.split("(");
-      // It's possible that we have windows line endings, so strip off the extra CR.
+      // It's possible that we have windows line endings, so strip off the extra
+      // CR.
       P.second = P.second.trim();
       if (P.second.empty() || P.second[P.second.size() - 1] != ')') {
         SrcMgr.PrintMessage(llvm::SMLoc::getFromPointer(P.second.data()),
@@ -92,8 +93,7 @@ void Generator::generate(llvm::raw_ostream &OS, llvm::RecordKeeper &Records) {
                             "Command argument list should begin with '(' "
                             "and end with ')'.");
         SrcMgr.PrintMessage(llvm::SMLoc::getFromPointer(P.second.data()),
-                            llvm::SourceMgr::DK_Error,
-                            P.second.data());
+                            llvm::SourceMgr::DK_Error, P.second.data());
         SrcMgr.PrintMessage(llvm::SMLoc::getFromPointer(P.second.data()),
                             llvm::SourceMgr::DK_Error,
                             std::to_string(P.second.size()));


### PR DESCRIPTION
The code does some (overly simple?) checks on file syntax. These checks assume unix line endings and fail on windows. This commit updates the code to strip extra whitespace, making the checks more robust, particularly in the presence of windows line endings.

Fixes #86023