### PR TITLE
[flang] Improve error message with declaration

### DIFF
--- a/flang/include/flang/Parser/char-block.h
+++ b/flang/include/flang/Parser/char-block.h
@@ -132,17 +132,20 @@ private:
     // "memcmp" in glibc has "nonnull" attributes on the input pointers.
     // Avoid passing null pointers, since it would result in an undefined
     // behavior.
-    if (size() == 0)
+    if (size() == 0) {
       return that.size() == 0 ? 0 : -1;
-    if (that.size() == 0)
+    } else if (that.size() == 0) {
       return 1;
-    std::size_t bytes{std::min(size(), that.size())};
-    int cmp{std::memcmp(static_cast<const void *>(begin()),
-        static_cast<const void *>(that.begin()), bytes)};
-    if (cmp != 0) {
-      return cmp;
+    } else {
+      std::size_t bytes{std::min(size(), that.size())};
+      int cmp{std::memcmp(static_cast<const void *>(begin()),
+          static_cast<const void *>(that.begin()), bytes)};
+      if (cmp != 0) {
+        return cmp;
+      } else {
+        return size() < that.size() ? -1 : size() > that.size();
+      }
     }
-    return size() < that.size() ? -1 : size() > that.size();
   }
 
   int Compare(const char *that) const {

--- a/flang/lib/Semantics/resolve-names.cpp
+++ b/flang/lib/Semantics/resolve-names.cpp
@@ -2250,7 +2250,7 @@ void ScopeHandler::SayWithDecl(
     const parser::Name &name, Symbol &symbol, MessageFixedText &&msg) {
   bool isFatal{msg.IsFatal()};
   Say(name, std::move(msg), symbol.name())
-      .Attach(Message{name.source,
+      .Attach(Message{symbol.name(),
           symbol.test(Symbol::Flag::Implicit)
               ? "Implicit declaration of '%s'"_en_US
               : "Declaration of '%s'"_en_US,
@@ -7840,7 +7840,7 @@ const parser::Name *DeclarationVisitor::FindComponent(
   auto &symbol{base->symbol->GetUltimate()};
   if (!symbol.has<AssocEntityDetails>() && !ConvertToObjectEntity(symbol)) {
     SayWithDecl(*base, symbol,
-        "'%s' is an invalid base for a component reference"_err_en_US);
+        "'%s' is not an object and may not be used as the base of a component reference or type parameter inquiry"_err_en_US);
     return nullptr;
   }
   auto *type{symbol.GetType()};

--- a/flang/test/Semantics/resolve21.f90
+++ b/flang/test/Semantics/resolve21.f90
@@ -16,15 +16,15 @@ subroutine s1
   external :: w
   !ERROR: 'z' is not an object of derived type; it is implicitly typed
   i = z%i
-  !ERROR: 's1' is an invalid base for a component reference
+  !ERROR: 's1' is not an object and may not be used as the base of a component reference or type parameter inquiry
   i = s1%i
   !ERROR: 'j' is not an object of derived type
   i = j%i
   !ERROR: Component 'j' not found in derived type 't'
   i = x%j
-  !ERROR: 'v' is an invalid base for a component reference
+  !ERROR: 'v' is not an object and may not be used as the base of a component reference or type parameter inquiry
   i = v%i
-  !ERROR: 'w' is an invalid base for a component reference
+  !ERROR: 'w' is not an object and may not be used as the base of a component reference or type parameter inquiry
   i = w%i
   i = x%i  !OK
 end subroutine


### PR DESCRIPTION
When a program attempts to use a non-object entity as the base of a component reference or type parameter inquiry, the message is somewhat uninformative and the position of the entity's declaration will not reflect any updates made to the symbol during name resolution.

Includes some NFC C++17 style clean-up on some code noticed while debugging (missing mandatory braces).