### PR TITLE
[MLIR][LLVM] Recursion importer handle repeated self-references

### DIFF
--- a/mlir/lib/Target/LLVMIR/DebugImporter.cpp
+++ b/mlir/lib/Target/LLVMIR/DebugImporter.cpp
@@ -468,7 +468,7 @@ DebugImporter::RecursionPruner::lookup(llvm::DINode *node) {
           // A replacement may contain additional unbound self-refs.
           return std::make_pair(replacement, mlir::WalkResult::advance());
         }
-        return std::make_pair(attr, mlir::WalkResult::skip());
+        return std::make_pair(attr, mlir::WalkResult::advance());
       });
 
   Attribute replacedAttr = replacer.replace(entry.attr);

--- a/mlir/lib/Target/LLVMIR/DebugImporter.cpp
+++ b/mlir/lib/Target/LLVMIR/DebugImporter.cpp
@@ -25,264 +25,8 @@ using namespace mlir;
 using namespace mlir::LLVM;
 using namespace mlir::LLVM::detail;
 
-/// Get the `getRecSelf` constructor for the translated type of `node` if its
-/// translated DITypeAttr supports recursion. Otherwise, returns nullptr.
-static function_ref<DIRecursiveTypeAttrInterface(DistinctAttr)>
-getRecSelfConstructor(llvm::DINode *node) {
-  using CtorType = function_ref<DIRecursiveTypeAttrInterface(DistinctAttr)>;
-  return TypeSwitch<llvm::DINode *, CtorType>(node)
-      .Case([&](llvm::DICompositeType *) {
-        return CtorType(DICompositeTypeAttr::getRecSelf);
-      })
-      .Default(CtorType());
-}
-
-/// Translation helper for recursive DINodes.
-/// Works alongside a stack-based DINode translator (the "main translator") for
-/// gracefully handling DINodes that are recursive.
-///
-/// Usage:
-/// - Before translating a node, call `tryPrune` to see if the pruner can
-///   preempt this translation. If this is a node that the pruner already knows
-///   how to handle, it will return the translated DINodeAttr.
-/// - After a node is successfully translated by the main translator, call
-///   `finalizeTranslation` to save the translated result with the pruner, and
-///   give it a chance to further modify the result.
-/// - Regardless of success or failure by the main translator, always call
-///   `finally` at the end of translating a node. This is necessary to keep the
-///   internal book-keeping in sync.
-///
-/// This helper maintains an internal cache so that no recursive type will
-/// be translated more than once by the main translator.
-/// This internal cache is different from the cache maintained by the main
-/// translator because it may store nodes that are not self-contained (i.e.
-/// contain unbounded recursive self-references).
-class mlir::LLVM::detail::RecursionPruner {
-public:
-  RecursionPruner(MLIRContext *context) : context(context) {}
-
-  /// If this node was previously cached, returns the cached result.
-  /// If this node is a recursive instance that was previously seen, returns a
-  /// self-reference.
-  /// Otherwise, returns null attr.
-  DINodeAttr tryPrune(llvm::DINode *node) {
-    // Lookup the cache first.
-    auto [result, unboundSelfRefs] = lookup(node);
-    if (result) {
-      // Need to inject unbound self-refs into the previous layer.
-      if (!unboundSelfRefs.empty())
-        translationStack.back().second.unboundSelfRefs.insert(
-            unboundSelfRefs.begin(), unboundSelfRefs.end());
-      return result;
-    }
-
-    // If the node type is capable of being recursive, check if it's seen
-    // before.
-    auto recSelfCtor = getRecSelfConstructor(node);
-    if (recSelfCtor) {
-      // If a cyclic dependency is detected since the same node is being
-      // traversed twice, emit a recursive self type, and mark the duplicate
-      // node on the translationStack so it can emit a recursive decl type.
-      auto [iter, inserted] = translationStack.try_emplace(node);
-      if (!inserted) {
-        // The original node may have already been assigned a recursive ID from
-        // a different self-reference. Use that if possible.
-        DIRecursiveTypeAttrInterface recSelf = iter->second.recSelf;
-        if (!recSelf) {
-          DistinctAttr recId = DistinctAttr::create(UnitAttr::get(context));
-          recSelf = recSelfCtor(recId);
-          iter->second.recSelf = recSelf;
-        }
-        // Inject the self-ref into the previous layer.
-        translationStack.back().second.unboundSelfRefs.insert(recSelf);
-        return cast<DINodeAttr>(recSelf);
-      }
-    }
-    return nullptr;
-  }
-
-  /// Register the translated result of `node`. Returns the finalized result
-  /// (with recId if recursive) and whether the result is self-contained
-  /// (i.e. contains no unbound self-refs).
-  std::pair<DINodeAttr, bool> finalizeTranslation(llvm::DINode *node,
-                                                  DINodeAttr result) {
-    // If `node` is not a potentially recursive type, it will not be on the
-    // translation stack. Nothing to set in this case.
-    if (translationStack.empty())
-      return {result, true};
-    if (translationStack.back().first != node)
-      return {result, translationStack.back().second.unboundSelfRefs.empty()};
-
-    TranslationState &state = translationStack.back().second;
-
-    // If this node is actually recursive, set the recId onto `result`.
-    if (DIRecursiveTypeAttrInterface recSelf = state.recSelf) {
-      auto recType = cast<DIRecursiveTypeAttrInterface>(result);
-      result = cast<DINodeAttr>(recType.withRecId(recSelf.getRecId()));
-
-      // Remove this recSelf from the set of unbound selfRefs.
-      state.unboundSelfRefs.erase(recSelf);
-
-      // Insert the newly resolved recursive type into the cache entries that
-      // rely on it.
-      // Only need to look at the caches at this level.
-      uint64_t numRemaining = state.cacheSize;
-      for (CachedTranslation &cacheEntry :
-           llvm::make_second_range(llvm::reverse(cache))) {
-        if (numRemaining == 0)
-          break;
-        --numRemaining;
-
-        if (auto refIter = cacheEntry.pendingReplacements.find(recSelf);
-            refIter != cacheEntry.pendingReplacements.end())
-          refIter->second = result;
-      }
-    }
-
-    // Insert the current result into the cache.
-    state.cacheSize++;
-    auto [iter, inserted] = cache.try_emplace(node);
-    assert(inserted && "invalid state: caching the same DINode twice");
-    iter->second.attr = result;
-
-    // If this node had any unbound self-refs free when it is registered into
-    // the cache, set up replacement placeholders: This result will need these
-    // unbound self-refs to be replaced before being used.
-    for (DIRecursiveTypeAttrInterface selfRef : state.unboundSelfRefs)
-      iter->second.pendingReplacements.try_emplace(selfRef, nullptr);
-
-    return {result, state.unboundSelfRefs.empty()};
-  }
-
-  /// Pop off a frame from the translation stack after a node is done being
-  /// translated.
-  void popTranslationStack(llvm::DINode *node) {
-    // If `node` is not a potentially recursive type, it will not be on the
-    // translation stack. Nothing to handle in this case.
-    if (translationStack.empty() || translationStack.back().first != node)
-      return;
-
-    // At the end of the stack, all unbound self-refs must be resolved already,
-    // and the entire cache should be accounted for.
-    TranslationState &currLayerState = translationStack.back().second;
-    if (translationStack.size() == 1) {
-      assert(currLayerState.unboundSelfRefs.empty() &&
-             "internal error: unbound recursive self reference at top level.");
-      assert(currLayerState.cacheSize == cache.size() &&
-             "internal error: inconsistent cache size");
-      translationStack.pop_back();
-      cache.clear();
-      return;
-    }
-
-    // Copy unboundSelfRefs down to the previous level.
-    TranslationState &nextLayerState = (++translationStack.rbegin())->second;
-    nextLayerState.unboundSelfRefs.insert(
-        currLayerState.unboundSelfRefs.begin(),
-        currLayerState.unboundSelfRefs.end());
-
-    // The current layer cache is now considered part of the lower layer cache.
-    nextLayerState.cacheSize += currLayerState.cacheSize;
-
-    // Finally pop off this layer when all bookkeeping is done.
-    translationStack.pop_back();
-  }
-
-private:
-  /// Returns the cached result (if exists) with all known replacements applied.
-  /// Also returns the set of unbound self-refs that are unresolved in this
-  /// cached result.
-  /// The cache entry will also be updated with the replaced result and with the
-  /// applied replacements removed from the pendingReplacements map.
-  std::pair<DINodeAttr, DenseSet<DIRecursiveTypeAttrInterface>>
-  lookup(llvm::DINode *node) {
-    auto cacheIter = cache.find(node);
-    if (cacheIter == cache.end())
-      return {};
-
-    CachedTranslation &entry = cacheIter->second;
-
-    if (entry.pendingReplacements.empty())
-      return std::make_pair(entry.attr,
-                            DenseSet<DIRecursiveTypeAttrInterface>{});
-
-    AttrTypeReplacer replacer;
-    replacer.addReplacement(
-        [&entry](DIRecursiveTypeAttrInterface attr)
-            -> std::optional<std::pair<Attribute, WalkResult>> {
-          if (auto replacement = entry.pendingReplacements.lookup(attr)) {
-            // A replacement may contain additional unbound self-refs.
-            return std::make_pair(replacement, mlir::WalkResult::advance());
-          }
-          return std::make_pair(attr, mlir::WalkResult::skip());
-        });
-
-    Attribute replacedAttr = replacer.replace(entry.attr);
-    DINodeAttr result = cast<DINodeAttr>(replacedAttr);
-
-    // Update cache entry to save replaced version and remove already-applied
-    // replacements.
-    entry.attr = result;
-    DenseSet<DIRecursiveTypeAttrInterface> unboundRefs;
-    DenseSet<DIRecursiveTypeAttrInterface> boundRefs;
-    for (auto [refSelf, replacement] : entry.pendingReplacements) {
-      if (replacement)
-        boundRefs.insert(refSelf);
-      else
-        unboundRefs.insert(refSelf);
-    }
-
-    for (DIRecursiveTypeAttrInterface ref : boundRefs)
-      entry.pendingReplacements.erase(ref);
-
-    return std::make_pair(result, unboundRefs);
-  }
-
-  MLIRContext *context;
-
-  /// A lazy cached translation that contains the translated attribute as well
-  /// as any unbound self-references that need to be replaced at lookup.
-  struct CachedTranslation {
-    /// The translated attr. May contain unbound self-references for other
-    /// recursive attrs.
-    DINodeAttr attr;
-    /// The pending replacements that need to be run on this `attr` before it
-    /// can be used.
-    /// Each key is a recursive self-ref, and each value is a recursive decl
-    /// that may contain additional unbound self-refs that need to be replaced.
-    /// Each replacement will be applied at most once. Once a replacement is
-    /// applied, the cached `attr` will be updated, and the replacement will be
-    /// removed from this map.
-    DenseMap<DIRecursiveTypeAttrInterface, DINodeAttr> pendingReplacements;
-  };
-  /// A mapping between LLVM debug metadata and the corresponding attribute.
-  llvm::MapVector<llvm::DINode *, CachedTranslation> cache;
-
-  /// Each potentially recursive node will have a TranslationState pushed onto
-  /// the `translationStack` to keep track of whether this node is actually
-  /// recursive (i.e. has self-references inside), and other book-keeping.
-  struct TranslationState {
-    /// The rec-self if this node is indeed a recursive node (i.e. another
-    /// instance of itself is seen while translating it). Null if this node
-    /// has not been seen again deeper in the translation stack.
-    DIRecursiveTypeAttrInterface recSelf;
-    /// The number of cache entries belonging to this layer of the translation
-    /// stack. This corresponds to the last `cacheSize` entries of `cache`.
-    uint64_t cacheSize = 0;
-    /// All the unbound recursive self references in this layer of the
-    /// translation stack.
-    DenseSet<DIRecursiveTypeAttrInterface> unboundSelfRefs;
-  };
-  /// A stack that stores the metadata nodes that are being traversed. The stack
-  /// is used to handle cyclic dependencies during metadata translation.
-  /// Each node is pushed with an empty TranslationState. If it is ever seen
-  /// later when the stack is deeper, the node is recursive, and its
-  /// TranslationState is assigned a recSelf.
-  llvm::MapVector<llvm::DINode *, TranslationState> translationStack;
-};
-
 DebugImporter::DebugImporter(ModuleOp mlirModule)
-    : recursionPruner(new RecursionPruner(mlirModule.getContext())),
+    : recursionPruner(mlirModule.getContext()),
       context(mlirModule.getContext()), mlirModule(mlirModule) {}
 
 DebugImporter::~DebugImporter() {}
@@ -510,11 +254,11 @@ DINodeAttr DebugImporter::translate(llvm::DINode *node) {
 
   // Register with the recursive translator. If it is seen before, return the
   // result immediately.
-  if (DINodeAttr attr = recursionPruner->tryPrune(node))
+  if (DINodeAttr attr = recursionPruner.tryPrune(node))
     return attr;
 
   auto guard = llvm::make_scope_exit(
-      [&]() { recursionPruner->popTranslationStack(node); });
+      [&]() { recursionPruner.popTranslationStack(node); });
 
   // Convert the debug metadata if possible.
   auto translateNode = [this](llvm::DINode *node) -> DINodeAttr {
@@ -552,13 +296,199 @@ DINodeAttr DebugImporter::translate(llvm::DINode *node) {
   };
   if (DINodeAttr attr = translateNode(node)) {
     auto [result, isSelfContained] =
-        recursionPruner->finalizeTranslation(node, attr);
+        recursionPruner.finalizeTranslation(node, attr);
     // Only cache fully self-contained nodes.
     if (isSelfContained)
       nodeToAttr.try_emplace(node, result);
     return result;
   }
   return nullptr;
+}
+
+//===----------------------------------------------------------------------===//
+// RecursionPruner
+//===----------------------------------------------------------------------===//
+/// Get the `getRecSelf` constructor for the translated type of `node` if its
+/// translated DITypeAttr supports recursion. Otherwise, returns nullptr.
+static function_ref<DIRecursiveTypeAttrInterface(DistinctAttr)>
+getRecSelfConstructor(llvm::DINode *node) {
+  using CtorType = function_ref<DIRecursiveTypeAttrInterface(DistinctAttr)>;
+  return TypeSwitch<llvm::DINode *, CtorType>(node)
+      .Case([&](llvm::DICompositeType *) {
+        return CtorType(DICompositeTypeAttr::getRecSelf);
+      })
+      .Default(CtorType());
+}
+
+DINodeAttr DebugImporter::RecursionPruner::tryPrune(llvm::DINode *node) {
+  // Lookup the cache first.
+  auto [result, unboundSelfRefs] = lookup(node);
+  if (result) {
+    // Need to inject unbound self-refs into the previous layer.
+    if (!unboundSelfRefs.empty())
+      translationStack.back().second.unboundSelfRefs.insert(
+          unboundSelfRefs.begin(), unboundSelfRefs.end());
+    return result;
+  }
+
+  // If the node type is capable of being recursive, check if it's seen
+  // before.
+  auto recSelfCtor = getRecSelfConstructor(node);
+  if (recSelfCtor) {
+    // If a cyclic dependency is detected since the same node is being
+    // traversed twice, emit a recursive self type, and mark the duplicate
+    // node on the translationStack so it can emit a recursive decl type.
+    auto [iter, inserted] = translationStack.try_emplace(node);
+    if (!inserted) {
+      // The original node may have already been assigned a recursive ID from
+      // a different self-reference. Use that if possible.
+      DIRecursiveTypeAttrInterface recSelf = iter->second.recSelf;
+      if (!recSelf) {
+        DistinctAttr recId = DistinctAttr::create(UnitAttr::get(context));
+        recSelf = recSelfCtor(recId);
+        iter->second.recSelf = recSelf;
+      }
+      // Inject the self-ref into the previous layer.
+      translationStack.back().second.unboundSelfRefs.insert(recSelf);
+      return cast<DINodeAttr>(recSelf);
+    }
+  }
+  return nullptr;
+}
+
+/// Register the translated result of `node`. Returns the finalized result
+/// (with recId if recursive) and whether the result is self-contained
+/// (i.e. contains no unbound self-refs).
+std::pair<DINodeAttr, bool>
+DebugImporter::RecursionPruner::finalizeTranslation(llvm::DINode *node,
+                                                    DINodeAttr result) {
+  // If `node` is not a potentially recursive type, it will not be on the
+  // translation stack. Nothing to set in this case.
+  if (translationStack.empty())
+    return {result, true};
+  if (translationStack.back().first != node)
+    return {result, translationStack.back().second.unboundSelfRefs.empty()};
+
+  TranslationState &state = translationStack.back().second;
+
+  // If this node is actually recursive, set the recId onto `result`.
+  if (DIRecursiveTypeAttrInterface recSelf = state.recSelf) {
+    auto recType = cast<DIRecursiveTypeAttrInterface>(result);
+    result = cast<DINodeAttr>(recType.withRecId(recSelf.getRecId()));
+
+    // Remove this recSelf from the set of unbound selfRefs.
+    state.unboundSelfRefs.erase(recSelf);
+
+    // Insert the newly resolved recursive type into the cache entries that
+    // rely on it.
+    // Only need to look at the caches at this level.
+    uint64_t numRemaining = state.cacheSize;
+    for (CachedTranslation &cacheEntry :
+         llvm::make_second_range(llvm::reverse(cache))) {
+      if (numRemaining == 0)
+        break;
+      --numRemaining;
+
+      if (auto refIter = cacheEntry.pendingReplacements.find(recSelf);
+          refIter != cacheEntry.pendingReplacements.end())
+        refIter->second = result;
+    }
+  }
+
+  // Insert the current result into the cache.
+  state.cacheSize++;
+  auto [iter, inserted] = cache.try_emplace(node);
+  assert(inserted && "invalid state: caching the same DINode twice");
+  iter->second.attr = result;
+
+  // If this node had any unbound self-refs free when it is registered into
+  // the cache, set up replacement placeholders: This result will need these
+  // unbound self-refs to be replaced before being used.
+  for (DIRecursiveTypeAttrInterface selfRef : state.unboundSelfRefs)
+    iter->second.pendingReplacements.try_emplace(selfRef, nullptr);
+
+  return {result, state.unboundSelfRefs.empty()};
+}
+
+/// Pop off a frame from the translation stack after a node is done being
+/// translated.
+void DebugImporter::RecursionPruner::popTranslationStack(llvm::DINode *node) {
+  // If `node` is not a potentially recursive type, it will not be on the
+  // translation stack. Nothing to handle in this case.
+  if (translationStack.empty() || translationStack.back().first != node)
+    return;
+
+  // At the end of the stack, all unbound self-refs must be resolved already,
+  // and the entire cache should be accounted for.
+  TranslationState &currLayerState = translationStack.back().second;
+  if (translationStack.size() == 1) {
+    assert(currLayerState.unboundSelfRefs.empty() &&
+           "internal error: unbound recursive self reference at top level.");
+    assert(currLayerState.cacheSize == cache.size() &&
+           "internal error: inconsistent cache size");
+    translationStack.pop_back();
+    cache.clear();
+    return;
+  }
+
+  // Copy unboundSelfRefs down to the previous level.
+  TranslationState &nextLayerState = (++translationStack.rbegin())->second;
+  nextLayerState.unboundSelfRefs.insert(currLayerState.unboundSelfRefs.begin(),
+                                        currLayerState.unboundSelfRefs.end());
+
+  // The current layer cache is now considered part of the lower layer cache.
+  nextLayerState.cacheSize += currLayerState.cacheSize;
+
+  // Finally pop off this layer when all bookkeeping is done.
+  translationStack.pop_back();
+}
+
+/// Returns the cached result (if exists) with all known replacements applied.
+/// Also returns the set of unbound self-refs that are unresolved in this
+/// cached result.
+/// The cache entry will also be updated with the replaced result and with the
+/// applied replacements removed from the pendingReplacements map.
+std::pair<DINodeAttr, DenseSet<DIRecursiveTypeAttrInterface>>
+DebugImporter::RecursionPruner::lookup(llvm::DINode *node) {
+  auto cacheIter = cache.find(node);
+  if (cacheIter == cache.end())
+    return {};
+
+  CachedTranslation &entry = cacheIter->second;
+
+  if (entry.pendingReplacements.empty())
+    return std::make_pair(entry.attr, DenseSet<DIRecursiveTypeAttrInterface>{});
+
+  AttrTypeReplacer replacer;
+  replacer.addReplacement(
+      [&entry](DIRecursiveTypeAttrInterface attr)
+          -> std::optional<std::pair<Attribute, WalkResult>> {
+        if (auto replacement = entry.pendingReplacements.lookup(attr)) {
+          // A replacement may contain additional unbound self-refs.
+          return std::make_pair(replacement, mlir::WalkResult::advance());
+        }
+        return std::make_pair(attr, mlir::WalkResult::skip());
+      });
+
+  Attribute replacedAttr = replacer.replace(entry.attr);
+  DINodeAttr result = cast<DINodeAttr>(replacedAttr);
+
+  // Update cache entry to save replaced version and remove already-applied
+  // replacements.
+  entry.attr = result;
+  DenseSet<DIRecursiveTypeAttrInterface> unboundRefs;
+  DenseSet<DIRecursiveTypeAttrInterface> boundRefs;
+  for (auto [refSelf, replacement] : entry.pendingReplacements) {
+    if (replacement)
+      boundRefs.insert(refSelf);
+    else
+      unboundRefs.insert(refSelf);
+  }
+
+  for (DIRecursiveTypeAttrInterface ref : boundRefs)
+    entry.pendingReplacements.erase(ref);
+
+  return std::make_pair(result, unboundRefs);
 }
 
 //===----------------------------------------------------------------------===//

--- a/mlir/lib/Target/LLVMIR/DebugImporter.cpp
+++ b/mlir/lib/Target/LLVMIR/DebugImporter.cpp
@@ -29,8 +29,6 @@ DebugImporter::DebugImporter(ModuleOp mlirModule)
     : recursionPruner(mlirModule.getContext()),
       context(mlirModule.getContext()), mlirModule(mlirModule) {}
 
-DebugImporter::~DebugImporter() {}
-
 Location DebugImporter::translateFuncLocation(llvm::Function *func) {
   llvm::DISubprogram *subprogram = func->getSubprogram();
   if (!subprogram)
@@ -357,9 +355,6 @@ DINodeAttr DebugImporter::RecursionPruner::pruneOrPushTranslationStack(
   return nullptr;
 }
 
-/// Register the translated result of `node`. Returns the finalized result
-/// (with recId if recursive) and whether the result is self-contained
-/// (i.e. contains no unbound self-refs).
 std::pair<DINodeAttr, bool>
 DebugImporter::RecursionPruner::finalizeTranslation(llvm::DINode *node,
                                                     DINodeAttr result) {
@@ -411,8 +406,6 @@ DebugImporter::RecursionPruner::finalizeTranslation(llvm::DINode *node,
   return {result, state.unboundSelfRefs.empty()};
 }
 
-/// Pop off a frame from the translation stack after a node is done being
-/// translated.
 void DebugImporter::RecursionPruner::popTranslationStack(llvm::DINode *node) {
   // If `node` is not a potentially recursive type, it will not be on the
   // translation stack. Nothing to handle in this case.
@@ -444,11 +437,6 @@ void DebugImporter::RecursionPruner::popTranslationStack(llvm::DINode *node) {
   translationStack.pop_back();
 }
 
-/// Returns the cached result (if exists) with all known replacements applied.
-/// Also returns the set of unbound self-refs that are unresolved in this
-/// cached result.
-/// The cache entry will also be updated with the replaced result and with the
-/// applied replacements removed from the pendingReplacements map.
 std::pair<DINodeAttr, DenseSet<DIRecursiveTypeAttrInterface>>
 DebugImporter::RecursionPruner::lookup(llvm::DINode *node) {
   auto cacheIter = cache.find(node);

--- a/mlir/lib/Target/LLVMIR/DebugImporter.cpp
+++ b/mlir/lib/Target/LLVMIR/DebugImporter.cpp
@@ -307,6 +307,7 @@ DINodeAttr DebugImporter::translate(llvm::DINode *node) {
 //===----------------------------------------------------------------------===//
 // RecursionPruner
 //===----------------------------------------------------------------------===//
+
 /// Get the `getRecSelf` constructor for the translated type of `node` if its
 /// translated DITypeAttr supports recursion. Otherwise, returns nullptr.
 static function_ref<DIRecursiveTypeAttrInterface(DistinctAttr)>

--- a/mlir/lib/Target/LLVMIR/DebugImporter.h
+++ b/mlir/lib/Target/LLVMIR/DebugImporter.h
@@ -94,7 +94,7 @@ private:
   /// distinct id attribute.
   DenseMap<llvm::DINode *, DistinctAttr> nodeToDistinctAttr;
 
-  // Translation copilot for recursive types.
+  /// A translation helper for recursive types.
   std::unique_ptr<RecursionPruner> recursionPruner;
 
   MLIRContext *context;

--- a/mlir/lib/Target/LLVMIR/DebugImporter.h
+++ b/mlir/lib/Target/LLVMIR/DebugImporter.h
@@ -30,7 +30,6 @@ namespace detail {
 class DebugImporter {
 public:
   DebugImporter(ModuleOp mlirModule);
-  ~DebugImporter();
 
   /// Translates the given LLVM debug location to an MLIR location.
   Location translateLoc(llvm::DILocation *loc);

--- a/mlir/lib/Target/LLVMIR/DebugImporter.h
+++ b/mlir/lib/Target/LLVMIR/DebugImporter.h
@@ -97,15 +97,16 @@ private:
   /// for gracefully handling DINodes that are recursive.
   ///
   /// Usage:
-  /// - Before translating a node, call `tryPrune` to see if the pruner can
-  ///   preempt this translation. If this is a node that the pruner already
-  ///   knows how to handle, it will return the translated DINodeAttr.
+  /// - Before translating a node, call `pruneOrPushTranslationStack` to see if
+  ///   the pruner can preempt this translation. If this is a node that the
+  ///   pruner already knows how to handle, it will return the translated
+  ///   DINodeAttr.
   /// - After a node is successfully translated by the main translator, call
   ///   `finalizeTranslation` to save the translated result with the pruner, and
   ///   give it a chance to further modify the result.
   /// - Regardless of success or failure by the main translator, always call
-  ///   `finally` at the end of translating a node. This is necessary to keep
-  ///   the internal book-keeping in sync.
+  ///   `popTranslationStack` at the end of translating a node. This is
+  ///   necessary to keep the internal book-keeping in sync.
   ///
   /// This helper maintains an internal cache so that no recursive type will
   /// be translated more than once by the main translator.
@@ -119,8 +120,10 @@ private:
     /// If this node was previously cached, returns the cached result.
     /// If this node is a recursive instance that was previously seen, returns a
     /// self-reference.
-    /// Otherwise, returns null attr.
-    DINodeAttr tryPrune(llvm::DINode *node);
+    /// Otherwise, returns null attr, and a translation stack frame is created
+    /// for this node. Expects `finalizeTranslation` & `popTranslationStack`
+    /// to be called on this node later.
+    DINodeAttr pruneOrPushTranslationStack(llvm::DINode *node);
 
     /// Register the translated result of `node`. Returns the finalized result
     /// (with recId if recursive) and whether the result is self-contained

--- a/mlir/lib/Target/LLVMIR/DebugTranslation.cpp
+++ b/mlir/lib/Target/LLVMIR/DebugTranslation.cpp
@@ -216,18 +216,15 @@ DebugTranslation::translateImpl(DIGlobalVariableAttr attr) {
 llvm::DIType *
 DebugTranslation::translateRecursive(DIRecursiveTypeAttrInterface attr) {
   DistinctAttr recursiveId = attr.getRecId();
-  if (attr.isRecSelf()) {
-    auto *iter = recursiveTypeMap.find(recursiveId);
-    assert(iter != recursiveTypeMap.end() && "unbound DI recursive self type");
+  if (auto *iter = recursiveTypeMap.find(recursiveId);
+      iter != recursiveTypeMap.end()) {
     return iter->second;
+  } else {
+    assert(!attr.isRecSelf() && "unbound DI recursive self type");
   }
 
   auto setRecursivePlaceholder = [&](llvm::DIType *placeholder) {
-    [[maybe_unused]] auto [iter, inserted] =
-        recursiveTypeMap.try_emplace(recursiveId, placeholder);
-    (void)iter;
-    (void)inserted;
-    assert(inserted && "illegal reuse of recursive id");
+    recursiveTypeMap.try_emplace(recursiveId, placeholder);
   };
 
   llvm::DIType *result =

--- a/mlir/test/Target/LLVMIR/Import/debug-info.ll
+++ b/mlir/test/Target/LLVMIR/Import/debug-info.ll
@@ -625,7 +625,6 @@ declare !dbg !1 void @declaration()
 
 ; CHECK: #llvm.di_subprogram<{{.*}}scope = #[[A_OUTER]]
 
-
 define void @class_field(ptr %arg1) !dbg !18 {
   ret void
 }
@@ -637,7 +636,6 @@ declare void @llvm.dbg.value(metadata, metadata, metadata)
 !0 = !{i32 2, !"Debug Info Version", i32 3}
 !1 = distinct !DICompileUnit(language: DW_LANG_C, file: !2)
 !2 = !DIFile(filename: "debug-info.ll", directory: "/")
-
 
 !3 = !DICompositeType(tag: DW_TAG_class_type, name: "A", file: !2, line: 42, flags: DIFlagTypePassByReference | DIFlagNonTrivial, elements: !4)
 !4 = !{!7, !8}

--- a/mlir/test/Target/LLVMIR/Import/debug-info.ll
+++ b/mlir/test/Target/LLVMIR/Import/debug-info.ll
@@ -663,19 +663,18 @@ define void @class_field(ptr %arg1) !dbg !18 {
 ; This should result in a cached instance of B --> C --> B_SELF to be reused
 ; when visiting B from C (after visiting B from A).
 
-; CHECK-DAG: #[[C_INNER:.+]] = #llvm.di_composite_type<{{.*}}name = "C", {{.*}}scope = #[[A_SELF:[^ ]+]], {{.*}}elements = #[[C_INNER_TO_B_SELF:.+]]
-; CHECK-DAG: #[[C_INNER_TO_B_SELF:.+]] = #llvm.di_derived_type<{{.*}}name = "->B", {{.*}}baseType = #[[B_SELF:[^ ]+]]>
-; CHECK-DAG: #[[B_TO_C_INNER:.+]] = #llvm.di_derived_type<{{.*}}name = "->C", {{.*}}baseType = #[[C_INNER]]
-; CHECK-DAG: #[[B:.+]] = #llvm.di_composite_type<{{.*}}recId = [[B_RECID:.+]], {{.*}}name = "B", {{.*}}scope = #[[A_SELF]], {{.*}}elements = #[[B_TO_C_INNER]]
-; CHECK-DAG: #[[A_SELF]] = #llvm.di_composite_type<{{.*}}recId = [[A_RECID:.+]]>
+; CHECK-DAG: #[[A:.+]] = #llvm.di_composite_type<{{.*}}name = "A", {{.*}}elements = #[[TO_B_OUTER:.+]], #[[TO_C_OUTER:.+]]>
+; CHECK-DAG: #llvm.di_subprogram<{{.*}}scope = #[[A]],
+
+; CHECK-DAG: #[[TO_B_OUTER]] = #llvm.di_derived_type<{{.*}}name = "->B", {{.*}}baseType = #[[B_OUTER:.+]]>
+; CHECK-DAG: #[[B_OUTER]] = #llvm.di_composite_type<{{.*}}recId = [[B_RECID:.+]], {{.*}}name = "B", {{.*}}elements = #[[TO_C_INNER:.+]]>
+; CHECK-DAG: #[[TO_C_INNER]] = #llvm.di_derived_type<{{.*}}name = "->C", {{.*}}baseType = #[[C_INNER:.+]]>
+; CHECK-DAG: #[[C_INNER]] = #llvm.di_composite_type<{{.*}}name = "C", {{.*}}elements = #[[TO_B_SELF:.+]]>
+; CHECK-DAG: #[[TO_B_SELF]] = #llvm.di_derived_type<{{.*}}name = "->B", {{.*}}baseType = #[[B_SELF:.+]]>
 ; CHECK-DAG: #[[B_SELF]] = #llvm.di_composite_type<{{.*}}recId = [[B_RECID]]>
 
-; CHECK-DAG: #[[TO_B:.+]] = #llvm.di_derived_type<{{.*}}name = "->B", {{.*}}baseType = #[[B]]
-; CHECK-DAG: #[[C_OUTER:.+]] = #llvm.di_composite_type<{{.*}}name = "C", {{.*}}scope = #[[A_SELF]], {{.*}}elements = #[[TO_B]]
-; CHECK-DAG: #[[TO_C:.+]] = #llvm.di_derived_type<{{.*}}name = "->C", {{.*}}baseType = #[[C_OUTER]]
-; CHECK-DAG: #[[A:.+]] = #llvm.di_composite_type<{{.*}}recId = [[A_RECID]], {{.*}}name = "A", {{.*}}elements = #[[TO_B]], #[[TO_C]]
-
-; CHECK-DAG: #llvm.di_subprogram<{{.*}}scope = #[[A]],
+; CHECK-DAG: #[[TO_C_OUTER]] = #llvm.di_derived_type<{{.*}}name = "->C", {{.*}}baseType = #[[C_OUTER:.+]]>
+; CHECK-DAG: #[[C_OUTER]] = #llvm.di_composite_type<{{.*}}name = "C", {{.*}}elements = #[[TO_B_OUTER]]>
 
 define void @class_field(ptr %arg1) !dbg !18 {
   ret void
@@ -688,8 +687,8 @@ define void @class_field(ptr %arg1) !dbg !18 {
 !2 = !DIFile(filename: "debug-info.ll", directory: "/")
 
 !3 = !DICompositeType(tag: DW_TAG_class_type, name: "A", file: !2, line: 42, flags: DIFlagTypePassByReference | DIFlagNonTrivial, elements: !4)
-!5 = !DICompositeType(tag: DW_TAG_class_type, name: "B", scope: !3, file: !2, line: 42, flags: DIFlagTypePassByReference | DIFlagNonTrivial, elements: !10)
-!6 = !DICompositeType(tag: DW_TAG_class_type, name: "C", scope: !3, file: !2, line: 42, flags: DIFlagTypePassByReference | DIFlagNonTrivial, elements: !9)
+!5 = !DICompositeType(tag: DW_TAG_class_type, name: "B", file: !2, line: 42, flags: DIFlagTypePassByReference | DIFlagNonTrivial, elements: !10)
+!6 = !DICompositeType(tag: DW_TAG_class_type, name: "C", file: !2, line: 42, flags: DIFlagTypePassByReference | DIFlagNonTrivial, elements: !9)
 
 !7 = !DIDerivedType(tag: DW_TAG_member, name: "->B", file: !2, baseType: !5)
 !8 = !DIDerivedType(tag: DW_TAG_member, name: "->C", file: !2, baseType: !6)


### PR DESCRIPTION
Followup to this discussion: https://github.com/llvm/llvm-project/pull/80251#discussion_r1535599920.

The previous debug importer was correct but inefficient. For cases with mutual recursion that contain more than one back-edge, each back-edge would result in a new translated instance. This is because the previous implementation never caches any translated result with unbounded self-references. This means all translation inside a recursive context is performed from scratch, which will incur repeated run-time cost as well as repeated attribute sub-trees in the translated IR (differing only in their `recId`s).

This PR refactors the importer to handle caching inside a recursive context.
- In the presence of unbound self-refs, the translation result is cached in a separate cache that keeps track of the set of dependent unbound self-refs.
- A dependent cache entry is valid only when all the unbound self-refs are in scope. Whenever a cached entry goes out of scope, it will be removed the next time it is looked up.