### PR TITLE
[flang] Don't allow non-standard data conversions of potentially abse…

### DIFF
--- a/flang/docs/Extensions.md
+++ b/flang/docs/Extensions.md
@@ -344,6 +344,10 @@ end
 * A `NAMELIST` input group may begin with either `&` or `$`.
 * A comma in a fixed-width numeric input field terminates the
   field rather than signaling an invalid character error.
+* Arguments to the intrinsic functions `MAX` and `MIN` are converted
+  when necessary to the type of the result.
+  An `OPTIONAL`, `POINTER`, or `ALLOCATABLE` argument after
+  the first two cannot be converted, as it may not be present.
 
 ### Extensions supported when enabled by options
 

--- a/flang/test/Semantics/intrinsics04.f90
+++ b/flang/test/Semantics/intrinsics04.f90
@@ -1,0 +1,25 @@
+! RUN: %python %S/test_errors.py %s %flang_fc1
+! A potentially absent actual argument cannot require data type conversion.
+subroutine s(o,a,p)
+  integer(2), intent(in), optional :: o
+  integer(2), intent(in), allocatable :: a
+  integer(2), intent(in), pointer :: p
+  !ERROR: An actual argument to MAX/MIN requiring data conversion may not be OPTIONAL, POINTER, or ALLOCATABLE
+  print *, max(1, 2, o)
+  !ERROR: An actual argument to MAX/MIN requiring data conversion may not be OPTIONAL, POINTER, or ALLOCATABLE
+  print *, max(1, 2, a)
+  !ERROR: An actual argument to MAX/MIN requiring data conversion may not be OPTIONAL, POINTER, or ALLOCATABLE
+  print *, max(1, 2, p)
+  !ERROR: An actual argument to MAX/MIN requiring data conversion may not be OPTIONAL, POINTER, or ALLOCATABLE
+  print *, min(1, 2, o)
+  !ERROR: An actual argument to MAX/MIN requiring data conversion may not be OPTIONAL, POINTER, or ALLOCATABLE
+  print *, min(1, 2, a)
+  !ERROR: An actual argument to MAX/MIN requiring data conversion may not be OPTIONAL, POINTER, or ALLOCATABLE
+  print *, min(1, 2, p)
+  print *, max(1_2, 2_2, o) ! ok
+  print *, max(1_2, 2_2, a) ! ok
+  print *, max(1_2, 2_2, p) ! ok
+  print *, min(1_2, 2_2, o) ! ok
+  print *, min(1_2, 2_2, a) ! ok
+  print *, min(1_2, 2_2, p) ! ok
+end


### PR DESCRIPTION
…nt arguments

Arguments to the intrinsic functions MAX and MIN after the first two are optional.  When these actual arguments might not be present at run time, emit a compilation time error if they require data conversion (a non-standard but nearly universal language extension); such a conversion would crash if the argument was absent.

Other compilers either disallow data conversions entirely on MAX/MIN or crash at run time if a converted argument is absent.

Fixes https://github.com/llvm/llvm-project/issues/87046.