### PR TITLE
[workflows] Use issue-write workflow for warning about private emails

### DIFF
--- a/.github/workflows/email-check.yaml
+++ b/.github/workflows/email-check.yaml
@@ -1,7 +1,7 @@
 name: "Check for private emails used in PRs"
 
 on:
-  pull_request_target:
+  pull_request:
     types:
       - opened
 
@@ -10,8 +10,6 @@ permissions:
 
 jobs:
   validate_email:
-    permissions:
-      pull-requests: write
     runs-on: ubuntu-latest
     if: github.repository == 'llvm/llvm-project'
     steps:
@@ -25,20 +23,24 @@ jobs:
         run: |
           git log -1
           echo "EMAIL=$(git show -s --format='%ae' HEAD~0)" >> $GITHUB_OUTPUT
+          # Create empty comment file
+          echo "[]" > comments
 
       - name: Validate author email
         if: ${{ endsWith(steps.author.outputs.EMAIL, 'noreply.github.com')  }}
-        uses: actions/github-script@v6
         env:
-          EMAIL: ${{ steps.author.outputs.EMAIL }}
+          COMMENT: >-
+            ⚠️ We detected that you are using a GitHub private e-mail address to contribute to the repo.<br/>
+            Please turn off [Keep my email addresses private](https://github.com/settings/emails) setting in your account.<br/>
+            See [LLVM Discourse](https://discourse.llvm.org/t/hidden-emails-on-github-should-we-do-something-about-it) for more information.
+        run: |
+          cat << EOF > comments
+          [{"body" : "$COMMENT"}]
+          EOF
+
+      - uses: actions/upload-artifact@26f96dfa697d77e81fd5907df203aa23a56210a8 #v4.3.0
+        if: always()
         with:
-          script: |
-            const { EMAIL } = process.env
-            await github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: `⚠️ We detected that you are using a GitHub private e-mail address to contribute to the repo.
-              Please turn off [Keep my email addresses private](https://github.com/settings/emails) setting in your account.
-              See [LLVM Discourse](https://discourse.llvm.org/t/hidden-emails-on-github-should-we-do-something-about-it) for more information.
-            `})
+          name: workflow-args
+          path: |
+            comments

--- a/.github/workflows/issue-write.yml
+++ b/.github/workflows/issue-write.yml
@@ -2,7 +2,9 @@ name: Comment on an issue
 
 on:
   workflow_run:
-    workflows: ["Check code formatting"]
+    workflows:
+      - "Check code formatting"
+      - "Check for private emails used in PRs"
     types:
       - completed
 


### PR DESCRIPTION
This allows us to use the less privileged pull_request event for the validate_email job, since this workflow no longer writes a comment directly.