### PR TITLE
 [AMDGPU] Add disassembler diagnostics for invalid kernel descriptors 

### DIFF
--- a/llvm/docs/AMDGPUUsage.rst
+++ b/llvm/docs/AMDGPUUsage.rst
@@ -4652,7 +4652,7 @@ The fields used by CP for code objects before V3 also match those specified in
                                                      entry point instruction
                                                      which must be 256 byte
                                                      aligned.
-     351:272 20                                      Reserved, must be 0.
+     351:192 20                                      Reserved, must be 0.
              bytes
      383:352 4 bytes COMPUTE_PGM_RSRC3               GFX6-GFX9
                                                        Reserved, must be 0.
@@ -5248,14 +5248,14 @@ The fields used by CP for code objects before V3 also match those specified in
      5:0     6 bits  ACCUM_OFFSET                    Offset of a first AccVGPR in the unified register file. Granularity 4.
                                                      Value 0-63. 0 - accum-offset = 4, 1 - accum-offset = 8, ...,
                                                      63 - accum-offset = 256.
-     6:15    10                                      Reserved, must be 0.
+     15:6    10                                      Reserved, must be 0.
              bits
      16      1 bit   TG_SPLIT                        - If 0 the waves of a work-group are
                                                        launched in the same CU.
                                                      - If 1 the waves of a work-group can be
                                                        launched in different CUs. The waves
                                                        cannot use S_BARRIER or LDS.
-     17:31   15                                      Reserved, must be 0.
+     31:17   15                                      Reserved, must be 0.
              bits
      32      **Total size 4 bytes.**
      ======= ===================================================================================================================

--- a/llvm/include/llvm/MC/MCDisassembler/MCDisassembler.h
+++ b/llvm/include/llvm/MC/MCDisassembler/MCDisassembler.h
@@ -12,6 +12,7 @@
 #include "llvm/ADT/StringRef.h"
 #include "llvm/BinaryFormat/XCOFF.h"
 #include "llvm/MC/MCDisassembler/MCSymbolizer.h"
+#include "llvm/Support/Error.h"
 #include <cstdint>
 #include <memory>
 #include <vector>
@@ -139,29 +140,26 @@ public:
   /// start of a symbol, or the entire symbol.
   /// This is used for example by WebAssembly to decode preludes.
   ///
-  /// Base implementation returns std::nullopt. So all targets by default ignore
-  /// to treat symbols separately.
+  /// Base implementation returns false. So all targets by default decline to
+  /// treat symbols separately.
   ///
   /// \param Symbol   - The symbol.
   /// \param Size     - The number of bytes consumed.
   /// \param Address  - The address, in the memory space of region, of the first
   ///                   byte of the symbol.
   /// \param Bytes    - A reference to the actual bytes at the symbol location.
-  /// \param ErrS     - A stream to print newline separated error comments that
-  ///                   will be emitted if Fail is returned.
-  /// \return         - MCDisassembler::Success if bytes are decoded
-  ///                   successfully. Size must hold the number of bytes that
-  ///                   were decoded.
-  ///                 - MCDisassembler::Fail if the bytes are invalid. Size
-  ///                   must hold the number of bytes that were decoded before
-  ///                   failing. The target must print nothing. This can be
-  ///                   done by buffering the output if needed.
-  ///                 - std::nullopt if the target doesn't want to handle the
-  ///                   symbol separately. Value of Size is ignored in this
-  ///                   case.
-  virtual std::optional<DecodeStatus>
-  onSymbolStart(SymbolInfoTy &Symbol, uint64_t &Size, ArrayRef<uint8_t> Bytes,
-                uint64_t Address, raw_ostream &ErrS) const;
+  /// \param Err      - An out parameter that indicates whether an error was
+  ///                   found.
+  /// \return         - True if this symbol triggered some target specific
+  ///                   disassembly for this symbol. Size must be set with the
+  ///                   number of bytes consumed regardless of whether an error
+  ///                   was found.
+  ///                 - False if the target doesn't want to handle the symbol
+  ///                   separately. The value of Size is ignored in this case,
+  ///                   and Err must not be set.
+  virtual bool onSymbolStart(SymbolInfoTy &Symbol, uint64_t &Size,
+                             ArrayRef<uint8_t> Bytes, uint64_t Address,
+                             Error &Err) const;
   // TODO:
   // Implement similar hooks that can be used at other points during
   // disassembly. Something along the following lines:

--- a/llvm/include/llvm/MC/MCDisassembler/MCDisassembler.h
+++ b/llvm/include/llvm/MC/MCDisassembler/MCDisassembler.h
@@ -147,7 +147,8 @@ public:
   /// \param Address  - The address, in the memory space of region, of the first
   ///                   byte of the symbol.
   /// \param Bytes    - A reference to the actual bytes at the symbol location.
-  /// \param CStream  - The stream to print comments and annotations on.
+  /// \param ErrS     - A stream to print newline seperated error comments that
+  ///                   will be emitted if Fail is returned.
   /// \return         - MCDisassembler::Success if bytes are decoded
   ///                   successfully. Size must hold the number of bytes that
   ///                   were decoded.
@@ -160,7 +161,7 @@ public:
   ///                   case.
   virtual std::optional<DecodeStatus>
   onSymbolStart(SymbolInfoTy &Symbol, uint64_t &Size, ArrayRef<uint8_t> Bytes,
-                uint64_t Address, raw_ostream &CStream) const;
+                uint64_t Address, raw_ostream &ErrS) const;
   // TODO:
   // Implement similar hooks that can be used at other points during
   // disassembly. Something along the following lines:

--- a/llvm/include/llvm/MC/MCDisassembler/MCDisassembler.h
+++ b/llvm/include/llvm/MC/MCDisassembler/MCDisassembler.h
@@ -147,7 +147,7 @@ public:
   /// \param Address  - The address, in the memory space of region, of the first
   ///                   byte of the symbol.
   /// \param Bytes    - A reference to the actual bytes at the symbol location.
-  /// \param ErrS     - A stream to print newline seperated error comments that
+  /// \param ErrS     - A stream to print newline separated error comments that
   ///                   will be emitted if Fail is returned.
   /// \return         - MCDisassembler::Success if bytes are decoded
   ///                   successfully. Size must hold the number of bytes that

--- a/llvm/include/llvm/MC/MCDisassembler/MCDisassembler.h
+++ b/llvm/include/llvm/MC/MCDisassembler/MCDisassembler.h
@@ -148,18 +148,18 @@ public:
   /// \param Address  - The address, in the memory space of region, of the first
   ///                   byte of the symbol.
   /// \param Bytes    - A reference to the actual bytes at the symbol location.
-  /// \param Err      - An out parameter that indicates whether an error was
-  ///                   found.
   /// \return         - True if this symbol triggered some target specific
   ///                   disassembly for this symbol. Size must be set with the
-  ///                   number of bytes consumed regardless of whether an error
-  ///                   was found.
+  ///                   number of bytes consumed.
+  ///                 - Error if this symbol triggered some target specific
+  ///                   disassembly for this symbol, but an error was found with
+  ///                   it. Size must be set with the number of bytes consumed.
   ///                 - False if the target doesn't want to handle the symbol
   ///                   separately. The value of Size is ignored in this case,
   ///                   and Err must not be set.
-  virtual bool onSymbolStart(SymbolInfoTy &Symbol, uint64_t &Size,
-                             ArrayRef<uint8_t> Bytes, uint64_t Address,
-                             Error &Err) const;
+  virtual Expected<bool> onSymbolStart(SymbolInfoTy &Symbol, uint64_t &Size,
+                                       ArrayRef<uint8_t> Bytes,
+                                       uint64_t Address) const;
   // TODO:
   // Implement similar hooks that can be used at other points during
   // disassembly. Something along the following lines:

--- a/llvm/lib/MC/MCDisassembler/MCDisassembler.cpp
+++ b/llvm/lib/MC/MCDisassembler/MCDisassembler.cpp
@@ -13,11 +13,10 @@ using namespace llvm;
 
 MCDisassembler::~MCDisassembler() = default;
 
-std::optional<MCDisassembler::DecodeStatus>
-MCDisassembler::onSymbolStart(SymbolInfoTy &Symbol, uint64_t &Size,
-                              ArrayRef<uint8_t> Bytes, uint64_t Address,
-                              raw_ostream &CStream) const {
-  return std::nullopt;
+bool MCDisassembler::onSymbolStart(SymbolInfoTy &Symbol, uint64_t &Size,
+                                   ArrayRef<uint8_t> Bytes, uint64_t Address,
+                                   Error &Err) const {
+  return false;
 }
 
 uint64_t MCDisassembler::suggestBytesToSkip(ArrayRef<uint8_t> Bytes,

--- a/llvm/lib/MC/MCDisassembler/MCDisassembler.cpp
+++ b/llvm/lib/MC/MCDisassembler/MCDisassembler.cpp
@@ -13,9 +13,10 @@ using namespace llvm;
 
 MCDisassembler::~MCDisassembler() = default;
 
-bool MCDisassembler::onSymbolStart(SymbolInfoTy &Symbol, uint64_t &Size,
-                                   ArrayRef<uint8_t> Bytes, uint64_t Address,
-                                   Error &Err) const {
+Expected<bool> MCDisassembler::onSymbolStart(SymbolInfoTy &Symbol,
+                                             uint64_t &Size,
+                                             ArrayRef<uint8_t> Bytes,
+                                             uint64_t Address) const {
   return false;
 }
 

--- a/llvm/lib/Target/AMDGPU/Disassembler/AMDGPUDisassembler.h
+++ b/llvm/lib/Target/AMDGPU/Disassembler/AMDGPUDisassembler.h
@@ -161,38 +161,37 @@ public:
     return MCDisassembler::Fail;
   }
 
-  std::optional<DecodeStatus>
-  onSymbolStart(SymbolInfoTy &Symbol, uint64_t &Size, ArrayRef<uint8_t> Bytes,
-                uint64_t Address, raw_ostream &CStream) const override;
+  bool onSymbolStart(SymbolInfoTy &Symbol, uint64_t &Size,
+                     ArrayRef<uint8_t> Bytes, uint64_t Address,
+                     Error &Err) const override;
 
-  DecodeStatus decodeKernelDescriptor(StringRef KdName, ArrayRef<uint8_t> Bytes,
-                                      uint64_t KdAddress) const;
+  Error decodeKernelDescriptor(StringRef KdName, ArrayRef<uint8_t> Bytes,
+                               uint64_t KdAddress) const;
 
-  DecodeStatus
-  decodeKernelDescriptorDirective(DataExtractor::Cursor &Cursor,
-                                  ArrayRef<uint8_t> Bytes,
-                                  raw_string_ostream &KdStream) const;
+  Error decodeKernelDescriptorDirective(DataExtractor::Cursor &Cursor,
+                                        ArrayRef<uint8_t> Bytes,
+                                        raw_string_ostream &KdStream) const;
 
   /// Decode as directives that handle COMPUTE_PGM_RSRC1.
   /// \param FourByteBuffer - Bytes holding contents of COMPUTE_PGM_RSRC1.
   /// \param KdStream       - Stream to write the disassembled directives to.
   // NOLINTNEXTLINE(readability-identifier-naming)
-  DecodeStatus decodeCOMPUTE_PGM_RSRC1(uint32_t FourByteBuffer,
-                                       raw_string_ostream &KdStream) const;
+  Error decodeCOMPUTE_PGM_RSRC1(uint32_t FourByteBuffer,
+                                raw_string_ostream &KdStream) const;
 
   /// Decode as directives that handle COMPUTE_PGM_RSRC2.
   /// \param FourByteBuffer - Bytes holding contents of COMPUTE_PGM_RSRC2.
   /// \param KdStream       - Stream to write the disassembled directives to.
   // NOLINTNEXTLINE(readability-identifier-naming)
-  DecodeStatus decodeCOMPUTE_PGM_RSRC2(uint32_t FourByteBuffer,
-                                       raw_string_ostream &KdStream) const;
+  Error decodeCOMPUTE_PGM_RSRC2(uint32_t FourByteBuffer,
+                                raw_string_ostream &KdStream) const;
 
   /// Decode as directives that handle COMPUTE_PGM_RSRC3.
   /// \param FourByteBuffer - Bytes holding contents of COMPUTE_PGM_RSRC3.
   /// \param KdStream       - Stream to write the disassembled directives to.
   // NOLINTNEXTLINE(readability-identifier-naming)
-  DecodeStatus decodeCOMPUTE_PGM_RSRC3(uint32_t FourByteBuffer,
-                                       raw_string_ostream &KdStream) const;
+  Error decodeCOMPUTE_PGM_RSRC3(uint32_t FourByteBuffer,
+                                raw_string_ostream &KdStream) const;
 
   void convertEXPInst(MCInst &MI) const;
   void convertVINTERPInst(MCInst &MI) const;

--- a/llvm/lib/Target/AMDGPU/Disassembler/AMDGPUDisassembler.h
+++ b/llvm/lib/Target/AMDGPU/Disassembler/AMDGPUDisassembler.h
@@ -161,37 +161,39 @@ public:
     return MCDisassembler::Fail;
   }
 
-  bool onSymbolStart(SymbolInfoTy &Symbol, uint64_t &Size,
-                     ArrayRef<uint8_t> Bytes, uint64_t Address,
-                     Error &Err) const override;
+  Expected<bool> onSymbolStart(SymbolInfoTy &Symbol, uint64_t &Size,
+                               ArrayRef<uint8_t> Bytes,
+                               uint64_t Address) const override;
 
-  Error decodeKernelDescriptor(StringRef KdName, ArrayRef<uint8_t> Bytes,
-                               uint64_t KdAddress) const;
-
-  Error decodeKernelDescriptorDirective(DataExtractor::Cursor &Cursor,
+  Expected<bool> decodeKernelDescriptor(StringRef KdName,
                                         ArrayRef<uint8_t> Bytes,
-                                        raw_string_ostream &KdStream) const;
+                                        uint64_t KdAddress) const;
+
+  Expected<bool>
+  decodeKernelDescriptorDirective(DataExtractor::Cursor &Cursor,
+                                  ArrayRef<uint8_t> Bytes,
+                                  raw_string_ostream &KdStream) const;
 
   /// Decode as directives that handle COMPUTE_PGM_RSRC1.
   /// \param FourByteBuffer - Bytes holding contents of COMPUTE_PGM_RSRC1.
   /// \param KdStream       - Stream to write the disassembled directives to.
   // NOLINTNEXTLINE(readability-identifier-naming)
-  Error decodeCOMPUTE_PGM_RSRC1(uint32_t FourByteBuffer,
-                                raw_string_ostream &KdStream) const;
+  Expected<bool> decodeCOMPUTE_PGM_RSRC1(uint32_t FourByteBuffer,
+                                         raw_string_ostream &KdStream) const;
 
   /// Decode as directives that handle COMPUTE_PGM_RSRC2.
   /// \param FourByteBuffer - Bytes holding contents of COMPUTE_PGM_RSRC2.
   /// \param KdStream       - Stream to write the disassembled directives to.
   // NOLINTNEXTLINE(readability-identifier-naming)
-  Error decodeCOMPUTE_PGM_RSRC2(uint32_t FourByteBuffer,
-                                raw_string_ostream &KdStream) const;
+  Expected<bool> decodeCOMPUTE_PGM_RSRC2(uint32_t FourByteBuffer,
+                                         raw_string_ostream &KdStream) const;
 
   /// Decode as directives that handle COMPUTE_PGM_RSRC3.
   /// \param FourByteBuffer - Bytes holding contents of COMPUTE_PGM_RSRC3.
   /// \param KdStream       - Stream to write the disassembled directives to.
   // NOLINTNEXTLINE(readability-identifier-naming)
-  Error decodeCOMPUTE_PGM_RSRC3(uint32_t FourByteBuffer,
-                                raw_string_ostream &KdStream) const;
+  Expected<bool> decodeCOMPUTE_PGM_RSRC3(uint32_t FourByteBuffer,
+                                         raw_string_ostream &KdStream) const;
 
   void convertEXPInst(MCInst &MI) const;
   void convertVINTERPInst(MCInst &MI) const;

--- a/llvm/lib/Target/WebAssembly/Disassembler/WebAssemblyDisassembler.cpp
+++ b/llvm/lib/Target/WebAssembly/Disassembler/WebAssemblyDisassembler.cpp
@@ -47,9 +47,10 @@ class WebAssemblyDisassembler final : public MCDisassembler {
   DecodeStatus getInstruction(MCInst &Instr, uint64_t &Size,
                               ArrayRef<uint8_t> Bytes, uint64_t Address,
                               raw_ostream &CStream) const override;
-  std::optional<DecodeStatus>
-  onSymbolStart(SymbolInfoTy &Symbol, uint64_t &Size, ArrayRef<uint8_t> Bytes,
-                uint64_t Address, raw_ostream &CStream) const override;
+
+  bool onSymbolStart(SymbolInfoTy &Symbol, uint64_t &Size,
+                     ArrayRef<uint8_t> Bytes, uint64_t Address,
+                     Error &Err) const override;
 
 public:
   WebAssemblyDisassembler(const MCSubtargetInfo &STI, MCContext &Ctx,
@@ -122,31 +123,32 @@ bool parseImmediate(MCInst &MI, uint64_t &Size, ArrayRef<uint8_t> Bytes) {
   return true;
 }
 
-std::optional<MCDisassembler::DecodeStatus>
-WebAssemblyDisassembler::onSymbolStart(SymbolInfoTy &Symbol, uint64_t &Size,
-                                       ArrayRef<uint8_t> Bytes,
-                                       uint64_t Address,
-                                       raw_ostream &CStream) const {
+bool WebAssemblyDisassembler::onSymbolStart(SymbolInfoTy &Symbol,
+                                            uint64_t &Size,
+                                            ArrayRef<uint8_t> Bytes,
+                                            uint64_t Address,
+                                            Error &Err) const {
+  ErrorAsOutParameter ErrOutParam(&Err);
   Size = 0;
   if (Symbol.Type == wasm::WASM_SYMBOL_TYPE_SECTION) {
     // Start of a code section: we're parsing only the function count.
     int64_t FunctionCount;
     if (!nextLEB(FunctionCount, Bytes, Size, false))
-      return std::nullopt;
+      return false;
     outs() << "        # " << FunctionCount << " functions in section.";
   } else {
     // Parse the start of a single function.
     int64_t BodySize, LocalEntryCount;
     if (!nextLEB(BodySize, Bytes, Size, false) ||
         !nextLEB(LocalEntryCount, Bytes, Size, false))
-      return std::nullopt;
+      return false;
     if (LocalEntryCount) {
       outs() << "        .local ";
       for (int64_t I = 0; I < LocalEntryCount; I++) {
         int64_t Count, Type;
         if (!nextLEB(Count, Bytes, Size, false) ||
             !nextLEB(Type, Bytes, Size, false))
-          return std::nullopt;
+          return false;
         for (int64_t J = 0; J < Count; J++) {
           if (I || J)
             outs() << ", ";
@@ -156,7 +158,7 @@ WebAssemblyDisassembler::onSymbolStart(SymbolInfoTy &Symbol, uint64_t &Size,
     }
   }
   outs() << "\n";
-  return MCDisassembler::Success;
+  return true;
 }
 
 MCDisassembler::DecodeStatus WebAssemblyDisassembler::getInstruction(

--- a/llvm/lib/Target/WebAssembly/Disassembler/WebAssemblyDisassembler.cpp
+++ b/llvm/lib/Target/WebAssembly/Disassembler/WebAssemblyDisassembler.cpp
@@ -48,9 +48,9 @@ class WebAssemblyDisassembler final : public MCDisassembler {
                               ArrayRef<uint8_t> Bytes, uint64_t Address,
                               raw_ostream &CStream) const override;
 
-  bool onSymbolStart(SymbolInfoTy &Symbol, uint64_t &Size,
-                     ArrayRef<uint8_t> Bytes, uint64_t Address,
-                     Error &Err) const override;
+  Expected<bool> onSymbolStart(SymbolInfoTy &Symbol, uint64_t &Size,
+                               ArrayRef<uint8_t> Bytes,
+                               uint64_t Address) const override;
 
 public:
   WebAssemblyDisassembler(const MCSubtargetInfo &STI, MCContext &Ctx,
@@ -123,12 +123,10 @@ bool parseImmediate(MCInst &MI, uint64_t &Size, ArrayRef<uint8_t> Bytes) {
   return true;
 }
 
-bool WebAssemblyDisassembler::onSymbolStart(SymbolInfoTy &Symbol,
-                                            uint64_t &Size,
-                                            ArrayRef<uint8_t> Bytes,
-                                            uint64_t Address,
-                                            Error &Err) const {
-  ErrorAsOutParameter ErrOutParam(&Err);
+Expected<bool> WebAssemblyDisassembler::onSymbolStart(SymbolInfoTy &Symbol,
+                                                      uint64_t &Size,
+                                                      ArrayRef<uint8_t> Bytes,
+                                                      uint64_t Address) const {
   Size = 0;
   if (Symbol.Type == wasm::WASM_SYMBOL_TYPE_SECTION) {
     // Start of a code section: we're parsing only the function count.

--- a/llvm/test/MC/Disassembler/AMDGPU/kernel-descriptor-errors.test
+++ b/llvm/test/MC/Disassembler/AMDGPU/kernel-descriptor-errors.test
@@ -1,0 +1,73 @@
+# RUN: yaml2obj %s -DGPU=GFX1100 -DKD=0000000000000000000000001000000000000000000000001000000000000000000000000000000000000000000000000300AC60800000000004000000000000 \
+# RUN:   | llvm-objdump --disassemble-symbols=test.kd - | FileCheck %s --check-prefix=RES_4
+# RES_4: ; error decoding test.kd: kernel descriptor reserved bits set in range 127:96
+# RES_4-NEXT: ; decoding failed region as bytes
+
+# RUN: yaml2obj %s -DGPU=GFX1100 -DKD=0000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000300AC60800000000004000000000000 \
+# RUN:   | llvm-objdump --disassemble-symbols=test.kd - | FileCheck %s --check-prefix=RES_20
+# RES_20: ; error decoding test.kd: kernel descriptor reserved bits set in range 351:192
+# RES_20-NEXT: ; decoding failed region as bytes
+
+# RUN: yaml2obj %s -DGPU=GFX1100 -DKD=0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000300AC60800000000004000000000001 \
+# RUN:   | llvm-objdump --disassemble-symbols=test.kd - | FileCheck %s --check-prefix=RES_4_2
+# RES_4_2: ; error decoding test.kd: kernel descriptor reserved bits set in range 511:480
+# RES_4_2-NEXT: ; decoding failed region as bytes
+
+# RUN: yaml2obj %s -DGPU=GFX90A -DKD=00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000006000000000000 \
+# RUN:   | llvm-objdump --disassemble-symbols=test.kd - | FileCheck %s --check-prefix=RES_457
+# RES_457: ; error decoding test.kd: kernel descriptor reserved bits in range (457:455) set
+# RES_457-NEXT: ; decoding failed region as bytes
+
+# RUN: yaml2obj %s -DGPU=GFX90A -DKD=0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000c000000000000 \
+# RUN:   | llvm-objdump --disassemble-symbols=test.kd - | FileCheck %s --check-prefix=WF32
+# WF32: ; error decoding test.kd: kernel descriptor reserved bit (458) set, must be zero on gfx9
+# WF32-NEXT: ; decoding failed region as bytes
+
+# RUN: yaml2obj %s -DGPU=GFX1100 -DKD=0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000300AC60800000000024000000000000 \
+# RUN:   | llvm-objdump --disassemble-symbols=test.kd - | FileCheck %s --check-prefix=RES_463
+# RES_463: ; error decoding test.kd: kernel descriptor reserved bits in range (463:460) set
+# RES_463-NEXT: ; decoding failed region as bytes
+
+--- !ELF
+FileHeader:
+  Class:           ELFCLASS64
+  Data:            ELFDATA2LSB
+  OSABI:           ELFOSABI_AMDGPU_HSA
+  ABIVersion:      0x3
+  Type:            ET_REL
+  Machine:         EM_AMDGPU
+  Flags:           [ EF_AMDGPU_MACH_AMDGCN_[[GPU]], EF_AMDGPU_FEATURE_XNACK_UNSUPPORTED_V4, EF_AMDGPU_FEATURE_SRAMECC_UNSUPPORTED_V4 ]
+  SectionHeaderStringTable: .strtab
+Sections:
+  - Name:            .text
+    Type:            SHT_PROGBITS
+    Flags:           [ SHF_ALLOC, SHF_EXECINSTR ]
+    AddressAlign:    0x4
+    Content:         [[KD]]
+  - Name:            .rela.text
+    Type:            SHT_RELA
+    Flags:           [ SHF_INFO_LINK ]
+    Link:            .symtab
+    AddressAlign:    0x8
+    Info:            .text
+    Relocations:
+      - Offset:          0x10
+        Symbol:          test
+        Type:            R_AMDGPU_REL64
+        Addend:          16
+  - Type:            SectionHeaderTable
+    Sections:
+      - Name:            .strtab
+      - Name:            .text
+      - Name:            .rela.text
+      - Name:            .symtab
+Symbols:
+  - Name:            test.kd
+    Type:            STT_OBJECT
+    Section:         .text
+    Binding:         STB_GLOBAL
+    Size:            0x40
+  - Name:            test
+    Binding:         STB_GLOBAL
+    Other:           [ STV_PROTECTED ]
+...

--- a/llvm/test/MC/Disassembler/AMDGPU/kernel-descriptor-errors.test
+++ b/llvm/test/MC/Disassembler/AMDGPU/kernel-descriptor-errors.test
@@ -1,16 +1,16 @@
 # RUN: yaml2obj %s -DGPU=GFX1100 -DKD=0000000000000000000000001000000000000000000000001000000000000000000000000000000000000000000000000300AC60800000000004000000000000 \
 # RUN:   | llvm-objdump --disassemble-symbols=test.kd - | FileCheck %s --check-prefix=RES_4
-# RES_4: ; error decoding test.kd: kernel descriptor reserved bits set in range 127:96
+# RES_4: ; error decoding test.kd: kernel descriptor reserved bits in range (127:96) set
 # RES_4-NEXT: ; decoding failed region as bytes
 
 # RUN: yaml2obj %s -DGPU=GFX1100 -DKD=0000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000300AC60800000000004000000000000 \
 # RUN:   | llvm-objdump --disassemble-symbols=test.kd - | FileCheck %s --check-prefix=RES_20
-# RES_20: ; error decoding test.kd: kernel descriptor reserved bits set in range 351:192
+# RES_20: ; error decoding test.kd: kernel descriptor reserved bits in range (351:192) set
 # RES_20-NEXT: ; decoding failed region as bytes
 
 # RUN: yaml2obj %s -DGPU=GFX1100 -DKD=0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000300AC60800000000004000000000001 \
 # RUN:   | llvm-objdump --disassemble-symbols=test.kd - | FileCheck %s --check-prefix=RES_4_2
-# RES_4_2: ; error decoding test.kd: kernel descriptor reserved bits set in range 511:480
+# RES_4_2: ; error decoding test.kd: kernel descriptor reserved bits in range (511:480) set
 # RES_4_2-NEXT: ; decoding failed region as bytes
 
 # RUN: yaml2obj %s -DGPU=GFX90A -DKD=00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000006000000000000 \

--- a/llvm/test/MC/Disassembler/AMDGPU/kernel-descriptor-rsrc-errors.test
+++ b/llvm/test/MC/Disassembler/AMDGPU/kernel-descriptor-rsrc-errors.test
@@ -1,0 +1,92 @@
+# RUN: yaml2obj %s -DGPU=GFX1200 -DSRC1=0300AC60 -DSRC2=80000000 -DSRC3=00000000 \
+# RUN:   | llvm-objdump --disassemble-symbols=test.kd - | FileCheck %s --check-prefix=VALID
+# VALID: .amdhsa_kernel test
+
+# RUN: yaml2obj %s -DGPU=GFX1200 -DSRC1=4300AC60 -DSRC2=80000000 -DSRC3=00000000 \
+# RUN:   | llvm-objdump --disassemble-symbols=test.kd - | FileCheck %s --check-prefix=SRC1_9_6
+# SRC1_9_6: ; error decoding test.kd: kernel descriptor COMPUTE_PGM_RSRC1_GRANULATED_WAVEFRONT_SGPR_COUNT reserved bits in range (9:6) set, must be zero on gfx10+
+# SRC1_9_6-NEXT: ; decoding failed region as bytes
+
+# RUN: yaml2obj %s -DGPU=GFX1200 -DSRC1=0308AC60 -DSRC2=80000000 -DSRC3=00000000 \
+# RUN:   | llvm-objdump --disassemble-symbols=test.kd - | FileCheck %s --check-prefix=SRC1_PRIORITY
+# SRC1_PRIORITY: ; error decoding test.kd: kernel descriptor COMPUTE_PGM_RSRC1_PRIORITY reserved bits in range (11:10) set
+# SRC1_PRIORITY-NEXT: ; decoding failed region as bytes
+
+# RUN: yaml2obj %s -DGPU=GFX1200 -DSRC1=0300BC60 -DSRC2=80000000 -DSRC3=00000000 \
+# RUN:   | llvm-objdump --disassemble-symbols=test.kd - | FileCheck %s --check-prefix=SRC1_PRIV
+# SRC1_PRIV: ; error decoding test.kd: kernel descriptor COMPUTE_PGM_RSRC1_PRIV reserved bit (20) set
+# SRC1_PRIV-NEXT: ; decoding failed region as bytes
+
+# RUN: yaml2obj %s -DGPU=GFX801 -DSRC1=0300AC64 -DSRC2=80000000 -DSRC3=00000000 \
+# RUN:   | llvm-objdump --disassemble-symbols=test.kd - | FileCheck %s --check-prefix=SRC1_6_8
+# SRC1_6_8: ; error decoding test.kd: kernel descriptor COMPUTE_PGM_RSRC1 reserved bit (26) set, must be zero pre-gfx9
+# SRC1_6_8-NEXT: ; decoding failed region as bytes
+
+# RUN: yaml2obj %s -DGPU=GFX1200 -DSRC1=0300AC60 -DSRC2=80200000 -DSRC3=00000000 \
+# RUN:   | llvm-objdump --disassemble-symbols=test.kd - | FileCheck %s --check-prefix=RSRC2
+# RSRC2: ; error decoding test.kd: kernel descriptor COMPUTE_PGM_RSRC2_ENABLE_EXCEPTION_ADDRESS_WATCH reserved bit (13) set
+# RSRC2-NEXT: ; decoding failed region as bytes
+
+# RUN: yaml2obj %s -DGPU=GFX90A -DSRC1=0300AC60 -DSRC2=80000000 -DSRC3=40000000 \
+# RUN:   | llvm-objdump --disassemble-symbols=test.kd - | FileCheck %s --check-prefix=RSRC3_90A
+# RSRC3_90A: ; error decoding test.kd: kernel descriptor COMPUTE_PGM_RSRC3 reserved bits in range (15:6) set, must be zero on gfx90a
+# RSRC3_90A-NEXT: ; decoding failed region as bytes
+
+# RUN: yaml2obj %s -DGPU=GFX1200 -DSRC1=0300AC60 -DSRC2=80000000 -DSRC3=01000000 \
+# RUN:   | llvm-objdump --disassemble-symbols=test.kd - | FileCheck %s --check-prefix=RSRC3_RES
+# RSRC3_RES: ; error decoding test.kd: kernel descriptor COMPUTE_PGM_RSRC3 reserved bits in range (3:0) set, must be zero on gfx12+
+# RSRC3_RES-NEXT: ; decoding failed region as bytes
+
+# RUN: yaml2obj %s -DGPU=GFX1100 -DSRC1=0300AC60 -DSRC2=80000000 -DSRC3=00000100 \
+# RUN:   | llvm-objdump --disassemble-symbols=test.kd - | FileCheck %s --check-prefix=RSRC3_10
+# RSRC3_10: ; error decoding test.kd: kernel descriptor COMPUTE_PGM_RSRC3 reserved bits in range (30:14) set, must be zero on gfx10+
+# RSRC3_10-NEXT: ; decoding failed region as bytes
+
+# RUN: yaml2obj %s -DGPU=GFX801 -DSRC1=0300AC60 -DSRC2=80000000 -DSRC3=00000001 \
+# RUN:   | llvm-objdump --disassemble-symbols=test.kd - | FileCheck %s --check-prefix=RSRC3_PRE_9
+# RSRC3_PRE_9: ; error decoding test.kd: kernel descriptor COMPUTE_PGM_RSRC3 must be all zero before gfx9
+# RSRC3_PRE_9-NEXT: ; decoding failed region as bytes
+
+--- !ELF
+FileHeader:
+  Class:           ELFCLASS64
+  Data:            ELFDATA2LSB
+  OSABI:           ELFOSABI_AMDGPU_HSA
+  ABIVersion:      0x3
+  Type:            ET_REL
+  Machine:         EM_AMDGPU
+  Flags:           [ EF_AMDGPU_MACH_AMDGCN_[[GPU]], EF_AMDGPU_FEATURE_XNACK_UNSUPPORTED_V4, EF_AMDGPU_FEATURE_SRAMECC_UNSUPPORTED_V4 ]
+  SectionHeaderStringTable: .strtab
+Sections:
+  - Name:            .text
+    Type:            SHT_PROGBITS
+    Flags:           [ SHF_ALLOC, SHF_EXECINSTR ]
+    AddressAlign:    0x4
+    Content:         0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000[[SRC3]][[SRC1]][[SRC2]]0004000000000000
+  - Name:            .rela.text
+    Type:            SHT_RELA
+    Flags:           [ SHF_INFO_LINK ]
+    Link:            .symtab
+    AddressAlign:    0x8
+    Info:            .text
+    Relocations:
+      - Offset:          0x10
+        Symbol:          test
+        Type:            R_AMDGPU_REL64
+        Addend:          16
+  - Type:            SectionHeaderTable
+    Sections:
+      - Name:            .strtab
+      - Name:            .text
+      - Name:            .rela.text
+      - Name:            .symtab
+Symbols:
+  - Name:            test.kd
+    Type:            STT_OBJECT
+    Section:         .text
+    Binding:         STB_GLOBAL
+    Size:            0x40
+  - Name:            test
+    Binding:         STB_GLOBAL
+    Other:           [ STV_PROTECTED ]
+...

--- a/llvm/tools/llvm-objdump/llvm-objdump.cpp
+++ b/llvm/tools/llvm-objdump/llvm-objdump.cpp
@@ -2051,58 +2051,51 @@ disassembleObject(ObjectFile &Obj, const ObjectFile &DbgObj,
       for (size_t SHI = 0; SHI < SymbolsHere.size(); ++SHI) {
         SymbolInfoTy Symbol = SymbolsHere[SHI];
 
-        SmallString<40> ErrorComments;
-        raw_svector_ostream ErrorCommentsStream(ErrorComments);
-
-        auto Status = DT->DisAsm->onSymbolStart(
+        Error Err = Error::success();
+        bool Responded = DT->DisAsm->onSymbolStart(
             Symbol, Size, Bytes.slice(Start, End - Start), SectionAddr + Start,
-            ErrorCommentsStream);
+            Err);
 
-        if (!Status) {
-          // If onSymbolStart returns std::nullopt, that means it didn't trigger
-          // any interesting handling for this symbol. Try the other symbols
-          // defined at this address.
+        if (!Responded) {
+          // This symbol didn't trigger any interesting handling. Try the other
+          // symbols defined at this address. Errors can only be returned if the
+          // disassembler responds.
+          cantFail(std::move(Err));
           continue;
         }
 
-        if (*Status == MCDisassembler::Fail) {
-          // If onSymbolStart returns Fail, that means it identified some kind
-          // of special data at this address, but wasn't able to disassemble it
-          // meaningfully. So we fall back to disassembling the failed region
-          // as bytes, assuming that the target detected the failure before
-          // printing anything.
-          //
-          // Return values Success or SoftFail (i.e no 'real' failure) are
-          // expected to mean that the target has emitted its own output.
-          //
-          // Either way, 'Size' will have been set to the amount of data
-          // covered by whatever prologue the target identified. So we advance
-          // our own position to beyond that. Sometimes that will be the entire
-          // distance to the next symbol, and sometimes it will be just a
-          // prologue and we should start disassembling instructions from where
-          // it left off.
+        // If onSymbolStart responded and set Err, that means it identified some
+        // kind of special data at this address, but wasn't able to disassemble
+        // it meaningfully. So we fall back to printing the error out and
+        // disassembling the failed region as bytes, assuming that the target
+        // detected the failure before printing anything.
+        //
+        // Either way, 'Size' will have been set to the amount of data covered
+        // by whatever prologue the target identified. So we advance our own
+        // position to beyond that. Sometimes that will be the entire distance
+        // to the next symbol, and sometimes it will be just a prologue and we
+        // should start disassembling instructions from where it left off.
 
-          // Print any error comments onSymbolStart emitted, or a generic error.
-          StringRef CommentStr = DT->Context->getAsmInfo()->getCommentString();
-          if (!ErrorComments.empty()) {
-            StringRef Comments = ErrorComments;
-            do {
-              StringRef Line;
-              std::tie(Line, Comments) = Comments.split('\n');
-              outs() << CommentStr << " error decoding " << SymNamesHere[SHI]
-                     << ": " << Line << '\n';
-            } while (!Comments.empty());
-            outs() << CommentStr << " decoding failed region as bytes.\n";
-          } else {
-            outs() << CommentStr << " error in decoding " << SymNamesHere[SHI]
-                   << " : decoding failed region as bytes.\n";
-          }
+        if (Err) {
+          std::string ErrMsgStr = toString(std::move(Err));
+          StringRef ErrMsg = ErrMsgStr;
+          do {
+            StringRef Line;
+            std::tie(Line, ErrMsg) = ErrMsg.split('\n');
+            outs() << DT->Context->getAsmInfo()->getCommentString()
+                   << " error decoding " << SymNamesHere[SHI] << ": " << Line
+                   << '\n';
+          } while (!ErrMsg.empty());
 
-          for (uint64_t I = 0; I < Size; ++I) {
-            outs() << "\t.byte\t " << format_hex(Bytes[I], 1, /*Upper=*/true)
-                   << "\n";
+          if (Size) {
+            outs() << DT->Context->getAsmInfo()->getCommentString()
+                   << " decoding failed region as bytes.\n";
+            for (uint64_t I = 0; I < Size; ++I)
+              outs() << "\t.byte\t " << format_hex(Bytes[I], 1, /*Upper=*/true)
+                     << '\n';
           }
         }
+
         Start += Size;
         break;
       }

--- a/llvm/tools/llvm-objdump/llvm-objdump.cpp
+++ b/llvm/tools/llvm-objdump/llvm-objdump.cpp
@@ -2066,12 +2066,15 @@ disassembleObject(ObjectFile &Obj, const ObjectFile &DbgObj,
         // disassembling the failed region as bytes, assuming that the target
         // detected the failure before printing anything.
         if (!RespondedOrErr) {
-          outs() << DT->Context->getAsmInfo()->getCommentString()
-                 << " error decoding " << SymNamesHere[SHI] << ": "
-                 << StringRef(toString(RespondedOrErr.takeError()))
-                        .split('\n')
-                        .first
-                 << '\n';
+          std::string ErrMsgStr = toString(RespondedOrErr.takeError());
+          StringRef ErrMsg = ErrMsgStr;
+          do {
+            StringRef Line;
+            std::tie(Line, ErrMsg) = ErrMsg.split('\n');
+            outs() << DT->Context->getAsmInfo()->getCommentString()
+                   << " error decoding " << SymNamesHere[SHI] << ": " << Line
+                   << '\n';
+          } while (!ErrMsg.empty());
 
           if (Size) {
             outs() << DT->Context->getAsmInfo()->getCommentString()

--- a/llvm/tools/llvm-objdump/llvm-objdump.cpp
+++ b/llvm/tools/llvm-objdump/llvm-objdump.cpp
@@ -2051,33 +2051,30 @@ disassembleObject(ObjectFile &Obj, const ObjectFile &DbgObj,
       for (size_t SHI = 0; SHI < SymbolsHere.size(); ++SHI) {
         SymbolInfoTy Symbol = SymbolsHere[SHI];
 
-        Error Err = Error::success();
-        bool Responded = DT->DisAsm->onSymbolStart(
-            Symbol, Size, Bytes.slice(Start, End - Start), SectionAddr + Start,
-            Err);
+        Expected<bool> RespondedOrErr = DT->DisAsm->onSymbolStart(
+            Symbol, Size, Bytes.slice(Start, End - Start), SectionAddr + Start);
 
-        if (!Responded) {
+        if (RespondedOrErr && !*RespondedOrErr) {
           // This symbol didn't trigger any interesting handling. Try the other
-          // symbols defined at this address. Errors can only be returned if the
-          // disassembler responds.
-          cantFail(std::move(Err));
+          // symbols defined at this address.
           continue;
         }
 
-        // If onSymbolStart responded and set Err, that means it identified some
+        // If onSymbolStart returned an Error, that means it identified some
         // kind of special data at this address, but wasn't able to disassemble
         // it meaningfully. So we fall back to printing the error out and
         // disassembling the failed region as bytes, assuming that the target
         // detected the failure before printing anything.
         //
-        // Either way, 'Size' will have been set to the amount of data covered
-        // by whatever prologue the target identified. So we advance our own
-        // position to beyond that. Sometimes that will be the entire distance
-        // to the next symbol, and sometimes it will be just a prologue and we
-        // should start disassembling instructions from where it left off.
+        // Regardless of whether onSymbolStart returned an Error or true, 'Size'
+        // will have been set to the amount of data covered by whatever prologue
+        // the target identified. So we advance our own position to beyond that.
+        // Sometimes that will be the entire distance to the next symbol, and
+        // sometimes it will be just a prologue and we should start
+        // disassembling instructions from where it left off.
 
-        if (Err) {
-          std::string ErrMsgStr = toString(std::move(Err));
+        if (!RespondedOrErr) {
+          std::string ErrMsgStr = toString(RespondedOrErr.takeError());
           StringRef ErrMsg = ErrMsgStr;
           do {
             StringRef Line;
@@ -2089,7 +2086,7 @@ disassembleObject(ObjectFile &Obj, const ObjectFile &DbgObj,
 
           if (Size) {
             outs() << DT->Context->getAsmInfo()->getCommentString()
-                   << " decoding failed region as bytes.\n";
+                   << " decoding failed region as bytes\n";
             for (uint64_t I = 0; I < Size; ++I)
               outs() << "\t.byte\t " << format_hex(Bytes[I], 1, /*Upper=*/true)
                      << '\n';


### PR DESCRIPTION
These mostly are checking for various reserved bits being set. The diagnostics for gpu-dependent reserved bits have a bit more context since they seem like the most likely ones to be observed in practice.