### PR TITLE
[Hexagon] Reduce redundancy in Hexagon features

### DIFF
--- a/llvm/lib/Target/Hexagon/Hexagon.td
+++ b/llvm/lib/Target/Hexagon/Hexagon.td
@@ -34,38 +34,7 @@ def ExtensionHVXQFloat: SubtargetFeature<"hvx-qfloat", "UseHVXQFloatOps",
 
 def ExtensionHVX: SubtargetFeature<"hvx", "HexagonHVXVersion",
       "Hexagon::ArchEnum::V60", "Hexagon HVX instructions">;
-def ExtensionHVXV60: SubtargetFeature<"hvxv60", "HexagonHVXVersion",
-      "Hexagon::ArchEnum::V60", "Hexagon HVX instructions",
-      [ExtensionHVX]>;
-def ExtensionHVXV62: SubtargetFeature<"hvxv62", "HexagonHVXVersion",
-      "Hexagon::ArchEnum::V62", "Hexagon HVX instructions",
-      [ExtensionHVX, ExtensionHVXV60]>;
-def ExtensionHVXV65: SubtargetFeature<"hvxv65", "HexagonHVXVersion",
-      "Hexagon::ArchEnum::V65", "Hexagon HVX instructions",
-      [ExtensionHVX, ExtensionHVXV60, ExtensionHVXV62]>;
-def ExtensionHVXV66: SubtargetFeature<"hvxv66", "HexagonHVXVersion",
-      "Hexagon::ArchEnum::V66", "Hexagon HVX instructions",
-      [ExtensionHVX, ExtensionHVXV60, ExtensionHVXV62, ExtensionHVXV65,
-       ExtensionZReg]>;
-def ExtensionHVXV67: SubtargetFeature<"hvxv67", "HexagonHVXVersion",
-      "Hexagon::ArchEnum::V67", "Hexagon HVX instructions",
-      [ExtensionHVXV60, ExtensionHVXV62, ExtensionHVXV65, ExtensionHVXV66]>;
-def ExtensionHVXV68: SubtargetFeature<"hvxv68", "HexagonHVXVersion",
-      "Hexagon::ArchEnum::V68", "Hexagon HVX instructions",
-      [ExtensionHVXV60, ExtensionHVXV62, ExtensionHVXV65, ExtensionHVXV66,
-       ExtensionHVXV67]>;
-def ExtensionHVXV69: SubtargetFeature<"hvxv69", "HexagonHVXVersion",
-      "Hexagon::ArchEnum::V69", "Hexagon HVX instructions",
-      [ExtensionHVXV60, ExtensionHVXV62, ExtensionHVXV65, ExtensionHVXV66,
-       ExtensionHVXV67, ExtensionHVXV68]>;
-def ExtensionHVXV71: SubtargetFeature<"hvxv71", "HexagonHVXVersion",
-      "Hexagon::ArchEnum::V71", "Hexagon HVX instructions",
-      [ExtensionHVXV60, ExtensionHVXV62, ExtensionHVXV65, ExtensionHVXV66,
-       ExtensionHVXV67, ExtensionHVXV68, ExtensionHVXV69]>;
-def ExtensionHVXV73: SubtargetFeature<"hvxv73", "HexagonHVXVersion",
-      "Hexagon::ArchEnum::V73", "Hexagon HVX instructions",
-      [ExtensionHVXV60, ExtensionHVXV62, ExtensionHVXV65, ExtensionHVXV66,
-       ExtensionHVXV67, ExtensionHVXV68, ExtensionHVXV69, ExtensionHVXV71]>;
+include "HexagonDepHVXExtensions.td"
 
 def ExtensionHVX64B: SubtargetFeature<"hvx-length64b", "UseHVX64BOps",
       "true", "Hexagon HVX 64B instructions", [ExtensionHVX]>;
@@ -119,24 +88,6 @@ def UseHVX128B         : Predicate<"HST->useHVX128BOps()">,
                          AssemblerPredicate<(all_of ExtensionHVX128B)>;
 def UseHVX             : Predicate<"HST->useHVXOps()">,
                          AssemblerPredicate<(all_of ExtensionHVXV60)>;
-def UseHVXV60          : Predicate<"HST->useHVXV60Ops()">,
-                         AssemblerPredicate<(all_of ExtensionHVXV60)>;
-def UseHVXV62          : Predicate<"HST->useHVXV62Ops()">,
-                         AssemblerPredicate<(all_of ExtensionHVXV62)>;
-def UseHVXV65          : Predicate<"HST->useHVXV65Ops()">,
-                         AssemblerPredicate<(all_of ExtensionHVXV65)>;
-def UseHVXV66          : Predicate<"HST->useHVXV66Ops()">,
-                         AssemblerPredicate<(all_of ExtensionHVXV66)>;
-def UseHVXV67          : Predicate<"HST->useHVXV67Ops()">,
-                         AssemblerPredicate<(all_of ExtensionHVXV67)>;
-def UseHVXV68          : Predicate<"HST->useHVXV68Ops()">,
-                         AssemblerPredicate<(all_of ExtensionHVXV68)>;
-def UseHVXV69          : Predicate<"HST->useHVXV69Ops()">,
-                         AssemblerPredicate<(all_of ExtensionHVXV69)>;
-def UseHVXV71          : Predicate<"HST->useHVXV71Ops()">,
-                         AssemblerPredicate<(all_of ExtensionHVXV71)>;
-def UseHVXV73          : Predicate<"HST->useHVXV73Ops()">,
-                         AssemblerPredicate<(all_of ExtensionHVXV73)>;
 def UseAudio           : Predicate<"HST->useAudioOps()">,
                          AssemblerPredicate<(all_of ExtensionAudio)>;
 def UseZReg            : Predicate<"HST->useZRegOps()">,
@@ -400,7 +351,7 @@ class Proc<string Name, SchedMachineModel Model,
  : ProcessorModel<Name, Model, Features>;
 
 def : Proc<"generic", HexagonModelV60,
-           [ArchV5, ArchV55, ArchV60,
+           [ArchV60,
             FeatureCompound, FeatureDuplex, FeaturePreV65, FeatureMemops,
             FeatureNVJ, FeatureNVS, FeaturePackets, FeatureSmallData,
             FeatureCabac]>;
@@ -410,70 +361,65 @@ def : Proc<"hexagonv5",  HexagonModelV5,
             FeatureNVJ, FeatureNVS, FeaturePackets, FeatureSmallData,
             FeatureCabac]>;
 def : Proc<"hexagonv55", HexagonModelV55,
-           [ArchV5, ArchV55,
+           [ArchV55,
             FeatureCompound, FeatureDuplex, FeaturePreV65, FeatureMemops,
             FeatureNVJ, FeatureNVS, FeaturePackets, FeatureSmallData,
             FeatureCabac]>;
 def : Proc<"hexagonv60", HexagonModelV60,
-           [ArchV5, ArchV55, ArchV60,
+           [ArchV60,
             FeatureCompound, FeatureDuplex, FeaturePreV65, FeatureMemops,
             FeatureNVJ, FeatureNVS, FeaturePackets, FeatureSmallData,
             FeatureCabac]>;
 def : Proc<"hexagonv62", HexagonModelV62,
-           [ArchV5, ArchV55, ArchV60, ArchV62,
+           [ArchV62,
             FeatureCompound, FeatureDuplex, FeaturePreV65, FeatureMemops,
             FeatureNVJ, FeatureNVS, FeaturePackets, FeatureSmallData,
             FeatureCabac]>;
 def : Proc<"hexagonv65", HexagonModelV65,
-           [ArchV5, ArchV55, ArchV60, ArchV62, ArchV65,
+           [ArchV65,
             FeatureCompound, FeatureDuplex, FeatureMemNoShuf, FeatureMemops,
             FeatureNVJ, FeatureNVS, FeaturePackets, FeatureSmallData,
             FeatureCabac]>;
 def : Proc<"hexagonv66", HexagonModelV66,
-           [ArchV5, ArchV55, ArchV60, ArchV62, ArchV65, ArchV66,
+           [ArchV66,
             FeatureCompound, FeatureDuplex, FeatureMemNoShuf, FeatureMemops,
             FeatureNVJ, FeatureNVS, FeaturePackets, FeatureSmallData,
             FeatureCabac]>;
 def : Proc<"hexagonv67", HexagonModelV67,
-           [ArchV5, ArchV55, ArchV60, ArchV62, ArchV65, ArchV66, ArchV67,
+           [ArchV67,
             FeatureCompound, FeatureDuplex, FeatureMemNoShuf, FeatureMemops,
             FeatureNVJ, FeatureNVS, FeaturePackets, FeatureSmallData,
             FeatureCabac]>;
 def : Proc<"hexagonv68", HexagonModelV68,
-           [ArchV5, ArchV55, ArchV60, ArchV62, ArchV65, ArchV66, ArchV67,
-            ArchV68,
+           [ArchV68,
             FeatureCompound, FeatureDuplex, FeatureMemNoShuf, FeatureMemops,
             FeatureNVJ, FeatureNVS, FeaturePackets, FeatureSmallData,
             FeatureCabac]>;
 def : Proc<"hexagonv69", HexagonModelV69,
-           [ArchV5, ArchV55, ArchV60, ArchV62, ArchV65, ArchV66, ArchV67,
-            ArchV68, ArchV69,
+           [ArchV69,
             FeatureCompound, FeatureDuplex, FeatureMemNoShuf, FeatureMemops,
             FeatureNVJ, FeatureNVS, FeaturePackets, FeatureSmallData,
             FeatureCabac]>;
 def : Proc<"hexagonv71", HexagonModelV71,
-           [ArchV5, ArchV55, ArchV60, ArchV62, ArchV65, ArchV66, ArchV67,
-            ArchV68, ArchV69, ArchV71,
+           [ArchV71,
             FeatureCompound, FeatureDuplex, FeatureMemNoShuf, FeatureMemops,
             FeatureNVJ, FeatureNVS, FeaturePackets, FeatureSmallData,
             FeatureCabac]>;
 def : Proc<"hexagonv73", HexagonModelV73,
-           [ArchV5, ArchV55, ArchV60, ArchV62, ArchV65, ArchV66, ArchV67,
-            ArchV68, ArchV69, ArchV71, ArchV73,
+           [ArchV73,
             FeatureCompound, FeatureDuplex, FeatureMemNoShuf, FeatureMemops,
             FeatureNVJ, FeatureNVS, FeaturePackets, FeatureSmallData]>;
 // Need to update the correct features for tiny core.
 // Disable NewValueJumps since the packetizer is unable to handle a packet with
 // a new value jump and another SLOT0 instruction.
 def : Proc<"hexagonv67t", HexagonModelV67T,
-           [ArchV5, ArchV55, ArchV60, ArchV62, ArchV65, ArchV66, ArchV67,
+           [ArchV67,
             ProcTinyCore, ExtensionAudio,
             FeatureCompound, FeatureMemNoShuf, FeatureMemops,
             FeatureNVS, FeaturePackets, FeatureSmallData]>;
 
 def : Proc<"hexagonv71t", HexagonModelV71T,
-           [ArchV5, ArchV55, ArchV60, ArchV62, ArchV65, ArchV66, ArchV67,
-            ArchV68, ArchV69, ArchV71,
+           [ArchV71,
             ProcTinyCore, ExtensionAudio,
             FeatureCompound, FeatureMemNoShuf, FeatureMemops,
             FeatureNVS, FeaturePackets, FeatureSmallData]>;

--- a/llvm/lib/Target/Hexagon/HexagonDepArch.td
+++ b/llvm/lib/Target/Hexagon/HexagonDepArch.td
@@ -8,25 +8,25 @@
 // Automatically generated file, do not edit!
 //===----------------------------------------------------------------------===//
 
-def ArchV5: SubtargetFeature<"v5", "HexagonArchVersion", "Hexagon::ArchEnum::V5", "Enable Hexagon V5 architecture">;
-def HasV5 : Predicate<"HST->hasV5Ops()">, AssemblerPredicate<(all_of ArchV5)>;
-def ArchV55: SubtargetFeature<"v55", "HexagonArchVersion", "Hexagon::ArchEnum::V55", "Enable Hexagon V55 architecture">;
-def HasV55 : Predicate<"HST->hasV55Ops()">, AssemblerPredicate<(all_of ArchV55)>;
-def ArchV60: SubtargetFeature<"v60", "HexagonArchVersion", "Hexagon::ArchEnum::V60", "Enable Hexagon V60 architecture">;
-def HasV60 : Predicate<"HST->hasV60Ops()">, AssemblerPredicate<(all_of ArchV60)>;
-def ArchV62: SubtargetFeature<"v62", "HexagonArchVersion", "Hexagon::ArchEnum::V62", "Enable Hexagon V62 architecture">;
-def HasV62 : Predicate<"HST->hasV62Ops()">, AssemblerPredicate<(all_of ArchV62)>;
-def ArchV65: SubtargetFeature<"v65", "HexagonArchVersion", "Hexagon::ArchEnum::V65", "Enable Hexagon V65 architecture">;
-def HasV65 : Predicate<"HST->hasV65Ops()">, AssemblerPredicate<(all_of ArchV65)>;
-def ArchV66: SubtargetFeature<"v66", "HexagonArchVersion", "Hexagon::ArchEnum::V66", "Enable Hexagon V66 architecture">;
-def HasV66 : Predicate<"HST->hasV66Ops()">, AssemblerPredicate<(all_of ArchV66)>;
-def ArchV67: SubtargetFeature<"v67", "HexagonArchVersion", "Hexagon::ArchEnum::V67", "Enable Hexagon V67 architecture">;
-def HasV67 : Predicate<"HST->hasV67Ops()">, AssemblerPredicate<(all_of ArchV67)>;
-def ArchV68: SubtargetFeature<"v68", "HexagonArchVersion", "Hexagon::ArchEnum::V68", "Enable Hexagon V68 architecture">;
-def HasV68 : Predicate<"HST->hasV68Ops()">, AssemblerPredicate<(all_of ArchV68)>;
-def ArchV69: SubtargetFeature<"v69", "HexagonArchVersion", "Hexagon::ArchEnum::V69", "Enable Hexagon V69 architecture">;
-def HasV69 : Predicate<"HST->hasV69Ops()">, AssemblerPredicate<(all_of ArchV69)>;
-def ArchV71: SubtargetFeature<"v71", "HexagonArchVersion", "Hexagon::ArchEnum::V71", "Enable Hexagon V71 architecture">;
-def HasV71 : Predicate<"HST->hasV71Ops()">, AssemblerPredicate<(all_of ArchV71)>;
-def ArchV73: SubtargetFeature<"v73", "HexagonArchVersion", "Hexagon::ArchEnum::V73", "Enable Hexagon V73 architecture">;
-def HasV73 : Predicate<"HST->hasV73Ops()">, AssemblerPredicate<(all_of ArchV73)>;
+def ArchV5 : SubtargetFeature<"v5", "HexagonArchVersion", "Hexagon::ArchEnum::V5", "Enable Hexagon V5 architecture">;
+def HasV5  : Predicate<"HST->hasFeature(llvm::Hexagon::ArchV5)">, AssemblerPredicate<(all_of ArchV5)>;
+def ArchV55: SubtargetFeature<"v55", "HexagonArchVersion", "Hexagon::ArchEnum::V55", "Enable Hexagon V55 architecture", [ArchV5]>;
+def HasV55 : Predicate<"HST->hasFeature(llvm::Hexagon::ArchV55)">, AssemblerPredicate<(all_of ArchV55)>;
+def ArchV60: SubtargetFeature<"v60", "HexagonArchVersion", "Hexagon::ArchEnum::V60", "Enable Hexagon V60 architecture", [ArchV55]>;
+def HasV60 : Predicate<"HST->hasFeature(llvm::Hexagon::ArchV60)">, AssemblerPredicate<(all_of ArchV60)>;
+def ArchV62: SubtargetFeature<"v62", "HexagonArchVersion", "Hexagon::ArchEnum::V62", "Enable Hexagon V62 architecture", [ArchV60]>;
+def HasV62 : Predicate<"HST->hasFeature(llvm::Hexagon::ArchV62)">, AssemblerPredicate<(all_of ArchV62)>;
+def ArchV65: SubtargetFeature<"v65", "HexagonArchVersion", "Hexagon::ArchEnum::V65", "Enable Hexagon V65 architecture", [ArchV62]>;
+def HasV65 : Predicate<"HST->hasFeature(llvm::Hexagon::ArchV65)">, AssemblerPredicate<(all_of ArchV65)>;
+def ArchV66: SubtargetFeature<"v66", "HexagonArchVersion", "Hexagon::ArchEnum::V66", "Enable Hexagon V66 architecture", [ArchV65]>;
+def HasV66 : Predicate<"HST->hasFeature(llvm::Hexagon::ArchV66)">, AssemblerPredicate<(all_of ArchV66)>;
+def ArchV67: SubtargetFeature<"v67", "HexagonArchVersion", "Hexagon::ArchEnum::V67", "Enable Hexagon V67 architecture", [ArchV66]>;
+def HasV67 : Predicate<"HST->hasFeature(llvm::Hexagon::ArchV67)">, AssemblerPredicate<(all_of ArchV67)>;
+def ArchV68: SubtargetFeature<"v68", "HexagonArchVersion", "Hexagon::ArchEnum::V68", "Enable Hexagon V68 architecture", [ArchV67]>;
+def HasV68 : Predicate<"HST->hasFeature(llvm::Hexagon::ArchV68)">, AssemblerPredicate<(all_of ArchV68)>;
+def ArchV69: SubtargetFeature<"v69", "HexagonArchVersion", "Hexagon::ArchEnum::V69", "Enable Hexagon V69 architecture", [ArchV68]>;
+def HasV69 : Predicate<"HST->hasFeature(llvm::Hexagon::ArchV69)">, AssemblerPredicate<(all_of ArchV69)>;
+def ArchV71: SubtargetFeature<"v71", "HexagonArchVersion", "Hexagon::ArchEnum::V71", "Enable Hexagon V71 architecture", [ArchV69]>;
+def HasV71 : Predicate<"HST->hasFeature(llvm::Hexagon::ArchV71)">, AssemblerPredicate<(all_of ArchV71)>;
+def ArchV73: SubtargetFeature<"v73", "HexagonArchVersion", "Hexagon::ArchEnum::V73", "Enable Hexagon V73 architecture", [ArchV71]>;
+def HasV73 : Predicate<"HST->hasFeature(llvm::Hexagon::ArchV73)">, AssemblerPredicate<(all_of ArchV73)>;

--- a/llvm/lib/Target/Hexagon/HexagonDepHVXExtensions.td
+++ b/llvm/lib/Target/Hexagon/HexagonDepHVXExtensions.td
@@ -1,0 +1,28 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+// Automatically generated file, do not edit!
+//===----------------------------------------------------------------------===//
+
+def ExtensionHVXV60 : SubtargetFeature<"hvxv60", "HexagonHVXVersion", "Hexagon::ArchEnum::V60", "Hexagon HVX V60 instructions", [ExtensionHVX]>;
+def UseHVXV60       : Predicate<"HST->hasFeature(llvm::Hexagon::ExtensionHVXV60)">, AssemblerPredicate<(all_of ExtensionHVXV60)>;
+def ExtensionHVXV62 : SubtargetFeature<"hvxv62", "HexagonHVXVersion", "Hexagon::ArchEnum::V62", "Hexagon HVX V62 instructions", [ExtensionHVXV60]>;
+def UseHVXV62       : Predicate<"HST->hasFeature(llvm::Hexagon::ExtensionHVXV62)">, AssemblerPredicate<(all_of ExtensionHVXV62)>;
+def ExtensionHVXV65 : SubtargetFeature<"hvxv65", "HexagonHVXVersion", "Hexagon::ArchEnum::V65", "Hexagon HVX V65 instructions", [ExtensionHVXV62]>;
+def UseHVXV65       : Predicate<"HST->hasFeature(llvm::Hexagon::ExtensionHVXV65)">, AssemblerPredicate<(all_of ExtensionHVXV65)>;
+def ExtensionHVXV66 : SubtargetFeature<"hvxv66", "HexagonHVXVersion", "Hexagon::ArchEnum::V66", "Hexagon HVX V66 instructions", [ExtensionHVXV65, ExtensionZReg]>;
+def UseHVXV66       : Predicate<"HST->hasFeature(llvm::Hexagon::ExtensionHVXV66)">, AssemblerPredicate<(all_of ExtensionHVXV66)>;
+def ExtensionHVXV67 : SubtargetFeature<"hvxv67", "HexagonHVXVersion", "Hexagon::ArchEnum::V67", "Hexagon HVX V67 instructions", [ExtensionHVXV66]>;
+def UseHVXV67       : Predicate<"HST->hasFeature(llvm::Hexagon::Arch67)">, AssemblerPredicate<(all_of ExtensionHVXV67)>;
+def ExtensionHVXV68 : SubtargetFeature<"hvxv68", "HexagonHVXVersion", "Hexagon::ArchEnum::V68", "Hexagon HVX V68 instructions", [ExtensionHVXV67]>;
+def UseHVXV68       : Predicate<"HST->hasFeature(llvm::Hexagon::ExtensionHVXV68)">, AssemblerPredicate<(all_of ExtensionHVXV68)>;
+def ExtensionHVXV69 : SubtargetFeature<"hvxv69", "HexagonHVXVersion", "Hexagon::ArchEnum::V69", "Hexagon HVX V69 instructions", [ExtensionHVXV68]>;
+def UseHVXV69       : Predicate<"HST->hasFeature(llvm::Hexagon::ExtensionHVXV69)">, AssemblerPredicate<(all_of ExtensionHVXV69)>;
+def ExtensionHVXV71 : SubtargetFeature<"hvxv71", "HexagonHVXVersion", "Hexagon::ArchEnum::V71", "Hexagon HVX V71 instructions", [ExtensionHVXV69]>;
+def UseHVXV71       : Predicate<"HST->hasFeature(llvm::Hexagon::ExtensionHVXV71)">, AssemblerPredicate<(all_of ExtensionHVXV71)>;
+def ExtensionHVXV73 : SubtargetFeature<"hvxv73", "HexagonHVXVersion", "Hexagon::ArchEnum::V73", "Hexagon HVX V73 instructions", [ExtensionHVXV71]>;
+def UseHVXV73       : Predicate<"HST->hasFeature(llvm::Hexagon::ExtensionHVXV73)">, AssemblerPredicate<(all_of ExtensionHVXV73)>;

--- a/llvm/lib/Target/Hexagon/HexagonISelLowering.cpp
+++ b/llvm/lib/Target/Hexagon/HexagonISelLowering.cpp
@@ -521,7 +521,7 @@ HexagonTargetLowering::LowerCall(TargetLowering::CallLoweringInfo &CLI,
       RegsToPass.push_back(std::make_pair(VA.getLocReg(), Arg));
   }
 
-  if (NeedsArgAlign && Subtarget.hasV60Ops()) {
+  if (NeedsArgAlign && Subtarget.hasFeature(llvm::Hexagon::ArchV60)) {
     LLVM_DEBUG(dbgs() << "Function needs byte stack align due to call args\n");
     Align VecAlign = HRI.getSpillAlign(Hexagon::HvxVRRegClass);
     LargestAlignSeen = std::max(LargestAlignSeen, VecAlign);
@@ -1812,17 +1812,17 @@ HexagonTargetLowering::HexagonTargetLowering(const TargetMachine &TM,
 
   // Subtarget-specific operation actions.
   //
-  if (Subtarget.hasV60Ops()) {
+  if (Subtarget.hasFeature(llvm::Hexagon::ArchV60)) {
     setOperationAction(ISD::ROTL, MVT::i32, Legal);
     setOperationAction(ISD::ROTL, MVT::i64, Legal);
     setOperationAction(ISD::ROTR, MVT::i32, Legal);
     setOperationAction(ISD::ROTR, MVT::i64, Legal);
   }
-  if (Subtarget.hasV66Ops()) {
+  if (Subtarget.hasFeature(llvm::Hexagon::ArchV66)) {
     setOperationAction(ISD::FADD, MVT::f64, Legal);
     setOperationAction(ISD::FSUB, MVT::f64, Legal);
   }
-  if (Subtarget.hasV67Ops()) {
+  if (Subtarget.hasFeature(llvm::Hexagon::ArchV67)) {
     setOperationAction(ISD::FMINNUM, MVT::f64, Legal);
     setOperationAction(ISD::FMAXNUM, MVT::f64, Legal);
     setOperationAction(ISD::FMUL,    MVT::f64, Legal);
@@ -3631,7 +3631,8 @@ HexagonTargetLowering::getRegForInlineAsmConstraint(
       case 512:
         return {0u, &Hexagon::HvxVRRegClass};
       case 1024:
-        if (Subtarget.hasV60Ops() && Subtarget.useHVX128BOps())
+        if (Subtarget.hasFeature(llvm::Hexagon::ArchV60) &&
+            Subtarget.useHVX128BOps())
           return {0u, &Hexagon::HvxVRRegClass};
         return {0u, &Hexagon::HvxWRRegClass};
       case 2048:

--- a/llvm/lib/Target/Hexagon/HexagonISelLoweringHVX.cpp
+++ b/llvm/lib/Target/Hexagon/HexagonISelLoweringHVX.cpp
@@ -82,7 +82,8 @@ HexagonTargetLowering::initializeHVXLowering() {
     addRegisterClass(MVT::v32i1, &Hexagon::HvxQRRegClass);
     addRegisterClass(MVT::v64i1, &Hexagon::HvxQRRegClass);
     addRegisterClass(MVT::v128i1, &Hexagon::HvxQRRegClass);
-    if (Subtarget.useHVXV68Ops() && Subtarget.useHVXFloatingPoint()) {
+    if (Subtarget.hasFeature(llvm::Hexagon::ExtensionHVXV68) &&
+        Subtarget.useHVXFloatingPoint()) {
       addRegisterClass(MVT::v32f32, &Hexagon::HvxVRRegClass);
       addRegisterClass(MVT::v64f16, &Hexagon::HvxVRRegClass);
       addRegisterClass(MVT::v64f32, &Hexagon::HvxWRRegClass);
@@ -117,7 +118,8 @@ HexagonTargetLowering::initializeHVXLowering() {
   setOperationAction(ISD::VECTOR_SHUFFLE,          ByteW, Legal);
   setOperationAction(ISD::INTRINSIC_WO_CHAIN, MVT::Other, Custom);
 
-  if (Subtarget.useHVX128BOps() && Subtarget.useHVXV68Ops() &&
+  if (Subtarget.useHVX128BOps() &&
+      Subtarget.hasFeature(llvm::Hexagon::ExtensionHVXV68) &&
       Subtarget.useHVXFloatingPoint()) {
 
     static const MVT FloatV[] = { MVT::v64f16, MVT::v32f32 };
@@ -615,7 +617,7 @@ void HexagonTargetLowering::AdjustHvxInstrPostInstrSelection(
 
   switch (Opc) {
   case Hexagon::PS_vsplatib:
-    if (Subtarget.useHVXV62Ops()) {
+    if (Subtarget.hasFeature(llvm::Hexagon::ExtensionHVXV62)) {
       // SplatV = A2_tfrsi #imm
       // OutV = V6_lvsplatb SplatV
       Register SplatV = MRI.createVirtualRegister(&Hexagon::IntRegsRegClass);
@@ -639,7 +641,7 @@ void HexagonTargetLowering::AdjustHvxInstrPostInstrSelection(
     MB.erase(At);
     break;
   case Hexagon::PS_vsplatrb:
-    if (Subtarget.useHVXV62Ops()) {
+    if (Subtarget.hasFeature(llvm::Hexagon::ExtensionHVXV62)) {
       // OutV = V6_lvsplatb Inp
       Register OutV = MI.getOperand(0).getReg();
       BuildMI(MB, At, DL, TII.get(Hexagon::V6_lvsplatb), OutV)
@@ -656,7 +658,7 @@ void HexagonTargetLowering::AdjustHvxInstrPostInstrSelection(
     MB.erase(At);
     break;
   case Hexagon::PS_vsplatih:
-    if (Subtarget.useHVXV62Ops()) {
+    if (Subtarget.hasFeature(llvm::Hexagon::ExtensionHVXV62)) {
       // SplatV = A2_tfrsi #imm
       // OutV = V6_lvsplath SplatV
       Register SplatV = MRI.createVirtualRegister(&Hexagon::IntRegsRegClass);
@@ -680,7 +682,7 @@ void HexagonTargetLowering::AdjustHvxInstrPostInstrSelection(
     MB.erase(At);
     break;
   case Hexagon::PS_vsplatrh:
-    if (Subtarget.useHVXV62Ops()) {
+    if (Subtarget.hasFeature(llvm::Hexagon::ExtensionHVXV62)) {
       // OutV = V6_lvsplath Inp
       Register OutV = MI.getOperand(0).getReg();
       BuildMI(MB, At, DL, TII.get(Hexagon::V6_lvsplath), OutV)
@@ -1938,7 +1940,7 @@ HexagonTargetLowering::LowerHvxMulLoHi(SDValue Op, SelectionDAG &DAG) const {
 
   // Legal on HVX v62+, but lower it here because patterns can't handle multi-
   // valued nodes.
-  if (Subtarget.useHVXV62Ops())
+  if (Subtarget.hasFeature(llvm::Hexagon::ExtensionHVXV62))
     return emitHvxMulLoHiV62(Vu, SignedVu, Vv, SignedVv, dl, DAG);
 
   if (Opc == HexagonISD::SMUL_LOHI) {
@@ -2090,7 +2092,8 @@ HexagonTargetLowering::LowerHvxFunnelShift(SDValue Op,
   // The expansion into regular shifts produces worse code for i8 and for
   // right shift of i32 on v65+.
   bool UseShifts = ElemTy != MVT::i8;
-  if (Subtarget.useHVXV65Ops() && ElemTy == MVT::i32)
+  if (Subtarget.hasFeature(llvm::Hexagon::ExtensionHVXV65) &&
+      ElemTy == MVT::i32)
     UseShifts = false;
 
   if (SDValue SplatV = getSplatValue(S, DAG); SplatV && UseShifts) {

--- a/llvm/lib/Target/Hexagon/HexagonInstrInfo.cpp
+++ b/llvm/lib/Target/Hexagon/HexagonInstrInfo.cpp
@@ -1763,7 +1763,7 @@ bool HexagonInstrInfo::isPredicable(const MachineInstr &MI) const {
   }
 
   // HVX loads are not predicable on v60, but are on v62.
-  if (!Subtarget.hasV62Ops()) {
+  if (!Subtarget.hasFeature(llvm::Hexagon::ArchV62)) {
     switch (MI.getOpcode()) {
       case Hexagon::V6_vL32b_ai:
       case Hexagon::V6_vL32b_pi:
@@ -3175,7 +3175,7 @@ bool HexagonInstrInfo::hasUncondBranch(const MachineBasicBlock *B)
 bool HexagonInstrInfo::mayBeCurLoad(const MachineInstr &MI) const {
   const uint64_t F = MI.getDesc().TSFlags;
   return ((F >> HexagonII::mayCVLoadPos) & HexagonII::mayCVLoadMask) &&
-         Subtarget.hasV60Ops();
+         Subtarget.hasFeature(llvm::Hexagon::ArchV60);
 }
 
 // Returns true, if a ST insn can be promoted to a new-value store.
@@ -3900,7 +3900,7 @@ int HexagonInstrInfo::getDotOldOp(const MachineInstr &MI) const {
     assert(NewOp >= 0 && "Couldn't change new-value store to its old form.");
   }
 
-  if (Subtarget.hasV60Ops())
+  if (Subtarget.hasFeature(llvm::Hexagon::ArchV60))
     return NewOp;
 
   // Subtargets prior to V60 didn't support 'taken' forms of predicated jumps.

--- a/llvm/lib/Target/Hexagon/HexagonRegisterInfo.cpp
+++ b/llvm/lib/Target/Hexagon/HexagonRegisterInfo.cpp
@@ -187,7 +187,7 @@ BitVector HexagonRegisterInfo::getReservedRegs(const MachineFunction &MF)
   // Leveraging these registers will require more work to recognize
   // the new semantics posed, Hi/LoVec patterns, etc.
   // Note well: if enabled, they should be restricted to only
-  // where `HST.useHVXOps() && HST.hasV67Ops()` is true.
+  // where `HST.useHVXOps() && HST.hasFeature(llvm::Hexagon::ArchV67)` is true.
   for (auto Reg : Hexagon_MC::GetVectRegRev())
     Reserved.set(Reg);
 

--- a/llvm/lib/Target/Hexagon/HexagonSubtarget.cpp
+++ b/llvm/lib/Target/Hexagon/HexagonSubtarget.cpp
@@ -135,7 +135,7 @@ HexagonSubtarget::initializeSubtargetDependencies(StringRef CPU, StringRef FS) {
       if (!HvxVer.drop_front(5).consumeInteger(10, Ver) && Ver >= 68)
         AddQFloat = true;
     } else if (HvxVer == "+hvx") {
-      if (hasV68Ops())
+      if (hasFeature(llvm::Hexagon::ArchV68))
         AddQFloat = true;
     }
 
@@ -146,7 +146,7 @@ HexagonSubtarget::initializeSubtargetDependencies(StringRef CPU, StringRef FS) {
   std::string FeatureString = Features.getString();
   ParseSubtargetFeatures(CPUString, /*TuneCPU*/ CPUString, FeatureString);
 
-  if (useHVXV68Ops())
+  if (hasFeature(llvm::Hexagon::ExtensionHVXV68))
     UseHVXFloatingPoint = UseHVXIEEEFPOps || UseHVXQFloatOps;
 
   if (UseHVXQFloatOps && UseHVXIEEEFPOps && UseHVXFloatingPoint)
@@ -156,7 +156,7 @@ HexagonSubtarget::initializeSubtargetDependencies(StringRef CPU, StringRef FS) {
   if (OverrideLongCalls.getPosition())
     UseLongCalls = OverrideLongCalls;
 
-  UseBSBScheduling = hasV60Ops() && EnableBSBSched;
+  UseBSBScheduling = hasFeature(llvm::Hexagon::ArchV60) && EnableBSBSched;
 
   if (isTinyCore()) {
     // Tiny core has a single thread, so back-to-back scheduling is enabled by
@@ -545,7 +545,7 @@ int HexagonSubtarget::updateLatency(MachineInstr &SrcInst,
                                     int Latency) const {
   if (IsArtificial)
     return 1;
-  if (!hasV60Ops())
+  if (!hasFeature(llvm::Hexagon::ArchV60))
     return Latency;
 
   auto &QII = static_cast<const HexagonInstrInfo &>(*getInstrInfo());
@@ -679,13 +679,13 @@ bool HexagonSubtarget::isBestZeroLatency(SUnit *Src, SUnit *Dst,
   // Reassign the latency for the previous bests, which requires setting
   // the dependence edge in both directions.
   if (SrcBest != nullptr) {
-    if (!hasV60Ops())
+    if (!hasFeature(llvm::Hexagon::ArchV60))
       changeLatency(SrcBest, Dst, 1);
     else
       restoreLatency(SrcBest, Dst);
   }
   if (DstBest != nullptr) {
-    if (!hasV60Ops())
+    if (!hasFeature(llvm::Hexagon::ArchV60))
       changeLatency(Src, DstBest, 1);
     else
       restoreLatency(Src, DstBest);

--- a/llvm/lib/Target/Hexagon/HexagonSubtarget.h
+++ b/llvm/lib/Target/Hexagon/HexagonSubtarget.h
@@ -144,73 +144,6 @@ public:
 
   bool isXRaySupported() const override { return true; }
 
-  bool hasV5Ops() const {
-    return getHexagonArchVersion() >= Hexagon::ArchEnum::V5;
-  }
-  bool hasV5OpsOnly() const {
-    return getHexagonArchVersion() == Hexagon::ArchEnum::V5;
-  }
-  bool hasV55Ops() const {
-    return getHexagonArchVersion() >= Hexagon::ArchEnum::V55;
-  }
-  bool hasV55OpsOnly() const {
-    return getHexagonArchVersion() == Hexagon::ArchEnum::V55;
-  }
-  bool hasV60Ops() const {
-    return getHexagonArchVersion() >= Hexagon::ArchEnum::V60;
-  }
-  bool hasV60OpsOnly() const {
-    return getHexagonArchVersion() == Hexagon::ArchEnum::V60;
-  }
-  bool hasV62Ops() const {
-    return getHexagonArchVersion() >= Hexagon::ArchEnum::V62;
-  }
-  bool hasV62OpsOnly() const {
-    return getHexagonArchVersion() == Hexagon::ArchEnum::V62;
-  }
-  bool hasV65Ops() const {
-    return getHexagonArchVersion() >= Hexagon::ArchEnum::V65;
-  }
-  bool hasV65OpsOnly() const {
-    return getHexagonArchVersion() == Hexagon::ArchEnum::V65;
-  }
-  bool hasV66Ops() const {
-    return getHexagonArchVersion() >= Hexagon::ArchEnum::V66;
-  }
-  bool hasV66OpsOnly() const {
-    return getHexagonArchVersion() == Hexagon::ArchEnum::V66;
-  }
-  bool hasV67Ops() const {
-    return getHexagonArchVersion() >= Hexagon::ArchEnum::V67;
-  }
-  bool hasV67OpsOnly() const {
-    return getHexagonArchVersion() == Hexagon::ArchEnum::V67;
-  }
-  bool hasV68Ops() const {
-    return getHexagonArchVersion() >= Hexagon::ArchEnum::V68;
-  }
-  bool hasV68OpsOnly() const {
-    return getHexagonArchVersion() == Hexagon::ArchEnum::V68;
-  }
-  bool hasV69Ops() const {
-    return getHexagonArchVersion() >= Hexagon::ArchEnum::V69;
-  }
-  bool hasV69OpsOnly() const {
-    return getHexagonArchVersion() == Hexagon::ArchEnum::V69;
-  }
-  bool hasV71Ops() const {
-    return getHexagonArchVersion() >= Hexagon::ArchEnum::V71;
-  }
-  bool hasV71OpsOnly() const {
-    return getHexagonArchVersion() == Hexagon::ArchEnum::V71;
-  }
-  bool hasV73Ops() const {
-    return getHexagonArchVersion() >= Hexagon::ArchEnum::V73;
-  }
-  bool hasV73OpsOnly() const {
-    return getHexagonArchVersion() == Hexagon::ArchEnum::V73;
-  }
-
   bool useAudioOps() const { return UseAudioOps; }
   bool useCompound() const { return UseCompound; }
   bool useLongCalls() const { return UseLongCalls; }
@@ -232,34 +165,7 @@ public:
   }
   bool useHVXFloatingPoint() const { return UseHVXFloatingPoint; }
   bool useHVXOps() const {
-    return HexagonHVXVersion > Hexagon::ArchEnum::NoArch;
-  }
-  bool useHVXV60Ops() const {
-    return HexagonHVXVersion >= Hexagon::ArchEnum::V60;
-  }
-  bool useHVXV62Ops() const {
-    return HexagonHVXVersion >= Hexagon::ArchEnum::V62;
-  }
-  bool useHVXV65Ops() const {
-    return HexagonHVXVersion >= Hexagon::ArchEnum::V65;
-  }
-  bool useHVXV66Ops() const {
-    return HexagonHVXVersion >= Hexagon::ArchEnum::V66;
-  }
-  bool useHVXV67Ops() const {
-    return HexagonHVXVersion >= Hexagon::ArchEnum::V67;
-  }
-  bool useHVXV68Ops() const {
-    return HexagonHVXVersion >= Hexagon::ArchEnum::V68;
-  }
-  bool useHVXV69Ops() const {
-    return HexagonHVXVersion >= Hexagon::ArchEnum::V69;
-  }
-  bool useHVXV71Ops() const {
-    return HexagonHVXVersion >= Hexagon::ArchEnum::V71;
-  }
-  bool useHVXV73Ops() const {
-    return HexagonHVXVersion >= Hexagon::ArchEnum::V73;
+    return hasFeature(llvm::Hexagon::ExtensionHVX);
   }
   bool useHVX128BOps() const { return useHVXOps() && UseHVX128BOps; }
   bool useHVX64BOps() const { return useHVXOps() && UseHVX64BOps; }
@@ -323,7 +229,7 @@ public:
     static MVT Types[] = {MVT::i8, MVT::i16, MVT::i32};
     static MVT TypesV68[] = {MVT::i8, MVT::i16, MVT::i32, MVT::f16, MVT::f32};
 
-    if (useHVXV68Ops() && useHVXFloatingPoint())
+    if (hasFeature(llvm::Hexagon::ExtensionHVXV68) && useHVXFloatingPoint())
       return ArrayRef(TypesV68);
     return ArrayRef(Types);
   }

--- a/llvm/lib/Target/Hexagon/HexagonTargetTransformInfo.cpp
+++ b/llvm/lib/Target/Hexagon/HexagonTargetTransformInfo.cpp
@@ -57,9 +57,10 @@ bool HexagonTTIImpl::isHVXVectorType(Type *Ty) const {
     return false;
   if (!ST.isTypeForHVX(VecTy))
     return false;
-  if (ST.useHVXV69Ops() || !VecTy->getElementType()->isFloatingPointTy())
+  if (ST.hasFeature(Hexagon::ExtensionHVXV69) ||
+      !VecTy->getElementType()->isFloatingPointTy())
     return true;
-  return ST.useHVXV68Ops() && EnableV68FloatAutoHVX;
+  return ST.hasFeature(llvm::Hexagon::ExtensionHVXV68) && EnableV68FloatAutoHVX;
 }
 
 unsigned HexagonTTIImpl::getTypeNumElements(Type *Ty) const {

--- a/llvm/lib/Target/Hexagon/HexagonVLIWPacketizer.cpp
+++ b/llvm/lib/Target/Hexagon/HexagonVLIWPacketizer.cpp
@@ -1105,7 +1105,8 @@ bool HexagonPacketizerList::isSoloInstruction(const MachineInstr &MI) {
 static bool cannotCoexistAsymm(const MachineInstr &MI, const MachineInstr &MJ,
       const HexagonInstrInfo &HII) {
   const MachineFunction *MF = MI.getParent()->getParent();
-  if (MF->getSubtarget<HexagonSubtarget>().hasV60OpsOnly() &&
+  if (MF->getSubtarget<HexagonSubtarget>().getHexagonArchVersion() ==
+          Hexagon::ArchEnum::V60 &&
       HII.isHVXMemWithAIndirect(MI, MJ))
     return true;
 
@@ -1540,9 +1541,10 @@ bool HexagonPacketizerList::isLegalToPacketizeTogether(SUnit *SUI, SUnit *SUJ) {
         break;
       }
 
-      if (Slot1Store && MF.getSubtarget<HexagonSubtarget>().hasV65Ops() &&
-          ((LoadJ && StoreI && !NVStoreI) ||
-           (StoreJ && LoadI && !NVStoreJ)) &&
+      if (Slot1Store &&
+          MF.getSubtarget<HexagonSubtarget>().hasFeature(
+              llvm::Hexagon::ArchV65) &&
+          ((LoadJ && StoreI && !NVStoreI) || (StoreJ && LoadI && !NVStoreJ)) &&
           (J.getOpcode() != Hexagon::S2_allocframe &&
            I.getOpcode() != Hexagon::S2_allocframe) &&
           (J.getOpcode() != Hexagon::L2_deallocframe &&

--- a/llvm/lib/Target/Hexagon/MCTargetDesc/HexagonMCTargetDesc.cpp
+++ b/llvm/lib/Target/Hexagon/MCTargetDesc/HexagonMCTargetDesc.cpp
@@ -400,12 +400,8 @@ static MCTargetStreamer *createHexagonNullTargetStreamer(MCStreamer &S) {
   return new HexagonTargetStreamer(S);
 }
 
-static void LLVM_ATTRIBUTE_UNUSED clearFeature(MCSubtargetInfo* STI, uint64_t F) {
-  if (STI->hasFeature(F))
-    STI->ToggleFeature(F);
-}
-
-static bool LLVM_ATTRIBUTE_UNUSED checkFeature(MCSubtargetInfo* STI, uint64_t F) {
+static bool LLVM_ATTRIBUTE_UNUSED checkFeature(MCSubtargetInfo *STI,
+                                               uint64_t F) {
   return STI->hasFeature(F);
 }
 


### PR DESCRIPTION
This is one of the series of changes intended to reduce redundancy in Hexagon backend-related architecture versions and features. 

- Architecture versions transitively imply older versions.
- HVX versions and predicates are moved to a separate td file, allowing for automatic generation.
- hasXXXOps() helpers are removed from HexagonSubtarget, replaced by direct calls hasFeature(). 