### PR TITLE
[lldb][sbdebugger] Move SBDebugger Broadcast bit enum into lldb-enumerations.h

### DIFF
--- a/lldb/include/lldb/API/SBDebugger.h
+++ b/lldb/include/lldb/API/SBDebugger.h
@@ -42,11 +42,13 @@ public:
 
 class LLDB_API SBDebugger {
 public:
+  // The enum values here need to match their corresponding values in
+  // Debugger.h.
   FLAGS_ANONYMOUS_ENUM(){
       eBroadcastBitProgress = (1 << 0),
       eBroadcastBitWarning = (1 << 1),
       eBroadcastBitError = (1 << 2),
-      eBroadcastBitProgressCategory = (1 << 3),
+      eBroadcastBitProgressCategory = (1 << 4),
   };
 
   SBDebugger();

--- a/lldb/include/lldb/API/SBDebugger.h
+++ b/lldb/include/lldb/API/SBDebugger.h
@@ -42,15 +42,6 @@ public:
 
 class LLDB_API SBDebugger {
 public:
-  // The enum values here need to match their corresponding values in
-  // Debugger.h.
-  FLAGS_ANONYMOUS_ENUM(){
-      eBroadcastBitProgress = (1 << 0),
-      eBroadcastBitWarning = (1 << 1),
-      eBroadcastBitError = (1 << 2),
-      eBroadcastBitProgressCategory = (1 << 4),
-  };
-
   SBDebugger();
 
   SBDebugger(const lldb::SBDebugger &rhs);

--- a/lldb/include/lldb/lldb-enumerations.h
+++ b/lldb/include/lldb/lldb-enumerations.h
@@ -1339,6 +1339,14 @@ enum AddressMaskRange {
   eAddressMaskRangeAll = eAddressMaskRangeAny,
 };
 
+/// Used by the debugger to indicate which events are being broadcasted.
+enum DebuggerBroadcast {
+  eBroadcastBitProgress = (1 << 0),
+  eBroadcastBitWarning = (1 << 1),
+  eBroadcastBitError = (1 << 2),
+  eBroadcastBitProgressCategory = (1 << 4),
+};
+
 } // namespace lldb
 
 #endif // LLDB_LLDB_ENUMERATIONS_H

--- a/lldb/include/lldb/lldb-enumerations.h
+++ b/lldb/include/lldb/lldb-enumerations.h
@@ -1340,11 +1340,11 @@ enum AddressMaskRange {
 };
 
 /// Used by the debugger to indicate which events are being broadcasted.
-enum DebuggerBroadcast {
+enum DebuggerBroadcastBit {
   eBroadcastBitProgress = (1 << 0),
   eBroadcastBitWarning = (1 << 1),
   eBroadcastBitError = (1 << 2),
-  eBroadcastBitProgressCategory = (1 << 4),
+  eBroadcastBitProgressCategory = (1 << 3),
 };
 
 } // namespace lldb

--- a/lldb/test/API/functionalities/diagnostic_reporting/TestDiagnosticReporting.py
+++ b/lldb/test/API/functionalities/diagnostic_reporting/TestDiagnosticReporting.py
@@ -15,7 +15,7 @@ class TestDiagnosticReporting(TestBase):
         self.broadcaster = self.dbg.GetBroadcaster()
         self.listener = lldbutil.start_listening_from(
             self.broadcaster,
-            lldb.SBDebugger.eBroadcastBitWarning | lldb.SBDebugger.eBroadcastBitError,
+            lldb.eBroadcastBitWarning | lldb.eBroadcastBitError,
         )
 
     def test_dwarf_symbol_loading_diagnostic_report(self):

--- a/lldb/test/API/functionalities/progress_reporting/TestProgressReporting.py
+++ b/lldb/test/API/functionalities/progress_reporting/TestProgressReporting.py
@@ -13,7 +13,7 @@ class TestProgressReporting(TestBase):
         TestBase.setUp(self)
         self.broadcaster = self.dbg.GetBroadcaster()
         self.listener = lldbutil.start_listening_from(
-            self.broadcaster, lldb.SBDebugger.eBroadcastBitProgress
+            self.broadcaster, lldb.eBroadcastBitProgress
         )
 
     def test_dwarf_symbol_loading_progress_report(self):

--- a/lldb/test/API/functionalities/progress_reporting/clang_modules/TestClangModuleBuildProgress.py
+++ b/lldb/test/API/functionalities/progress_reporting/clang_modules/TestClangModuleBuildProgress.py
@@ -34,7 +34,7 @@ class TestCase(TestBase):
         # other unrelated progress events.
         broadcaster = self.dbg.GetBroadcaster()
         listener = lldbutil.start_listening_from(
-            broadcaster, lldb.SBDebugger.eBroadcastBitProgress
+            broadcaster, lldb.eBroadcastBitProgress
         )
 
         # Trigger module builds.

--- a/lldb/test/API/macosx/rosetta/TestRosetta.py
+++ b/lldb/test/API/macosx/rosetta/TestRosetta.py
@@ -49,7 +49,7 @@ class TestRosetta(TestBase):
         if rosetta_debugserver_installed():
             broadcaster = self.dbg.GetBroadcaster()
             listener = lldbutil.start_listening_from(
-                broadcaster, lldb.SBDebugger.eBroadcastBitWarning
+                broadcaster, lldb.eBroadcastBitWarning
             )
 
             target, process, thread, bkpt = lldbutil.run_to_source_breakpoint(


### PR DESCRIPTION
When the `eBroadcastBitProgressCategory` bit was originally added to Debugger.h and SBDebugger.h, each corresponding bit was added in order of the other bits that were previously there. Since `Debugger.h` has an enum bit that `SBDebugger.h` does not, this meant that their offsets did not match. 

Instead of trying to keep the bit offsets in sync between the two, it's preferable to just move SBDebugger's enum into the main enumerations header and use the bits from there.