### PR TITLE
[flang][cuda] Allow list-directed PRINT and WRITE stmt in device code

### DIFF
--- a/flang/lib/Semantics/check-cuda.cpp
+++ b/flang/lib/Semantics/check-cuda.cpp
@@ -282,7 +282,7 @@ private:
         return result;
       }
     }
-    return static_cast<const SEEK *>(nullptr);
+    return nullptr;
   }
   template <typename A> static bool IsInternalIO(const A &stmt) {
     if (stmt.iounit.has_value()) {

--- a/flang/lib/Semantics/check-cuda.cpp
+++ b/flang/lib/Semantics/check-cuda.cpp
@@ -276,9 +276,9 @@ private:
         ec.u);
   }
   template <typename SEEK, typename A>
-  static const auto *GetIOControl(const A &stmt) {
+  static const SEEK *GetIOControl(const A &stmt) {
     for (const auto &spec : stmt.controls) {
-      if (const auto *result = std::get_if<SEEK>(&spec.u)) {
+      if (const auto *result{std::get_if<SEEK>(&spec.u)}) {
         return result;
       }
     }
@@ -288,7 +288,7 @@ private:
     if (stmt.iounit.has_value()) {
       return std::holds_alternative<Fortran::parser::Variable>(stmt.iounit->u);
     }
-    if (auto *unit = GetIOControl<Fortran::parser::IoUnit>(stmt)) {
+    if (auto *unit{GetIOControl<Fortran::parser::IoUnit>(stmt)}) {
       return std::holds_alternative<Fortran::parser::Variable>(unit->u);
     }
     return false;
@@ -317,7 +317,6 @@ private:
                       return;
                     }
                   }
-                  return;
                 }
               }
               WarnIfNotInternal(x.value(), source);

--- a/flang/lib/Semantics/check-cuda.cpp
+++ b/flang/lib/Semantics/check-cuda.cpp
@@ -278,6 +278,22 @@ private:
   void Check(const parser::ActionStmt &stmt, const parser::CharBlock &source) {
     common::visit(
         common::visitors{
+            [&](const common::Indirection<parser::PrintStmt> &x) {
+              if (!std::holds_alternative<Fortran::parser::Star>(
+                      std::get<Fortran::parser::Format>(x.value().t).u)) {
+                context_.Say(source,
+                    "Only list-directed PRINT statement may appear in device code"_err_en_US);
+              }
+            },
+            [&](const common::Indirection<parser::WriteStmt> &x) {
+              if (x.value().format) {
+                if (!std::holds_alternative<Fortran::parser::Star>(
+                        x.value().format->u)) {
+                  context_.Say(source,
+                      "Only list-directed WRITE statement may appear in device code"_err_en_US);
+                }
+              }
+            },
             [&](const auto &x) {
               if (auto msg{ActionStmtChecker<IsCUFKernelDo>::WhyNotOk(x)}) {
                 context_.Say(source, std::move(*msg));

--- a/flang/test/Semantics/cuf09.cuf
+++ b/flang/test/Semantics/cuf09.cuf
@@ -10,12 +10,10 @@ module m
   attributes(device) subroutine devsub2
     real, device :: x(10)
     print*,'from device'
-    !ERROR: Only list-directed PRINT statement may appear in device code
     print '(f10.5)', (x(ivar), ivar = 1, 10)
-
     write(*,*), "Hello world from device!"
-    !ERROR: Only list-directed WRITE statement may appear in device code
-    write(*,'(10F4.1)'), x
+    !WARNING: I/O statement might not be supported on device
+    write(12,'(10F4.1)'), x
   end
 end
 

--- a/flang/test/Semantics/cuf09.cuf
+++ b/flang/test/Semantics/cuf09.cuf
@@ -7,6 +7,16 @@ module m
     do k=1,10
     end do
   end
+  attributes(device) subroutine devsub2
+    real, device :: x(10)
+    print*,'from device'
+    !ERROR: Only list-directed PRINT statement may appear in device code
+    print '(f10.5)', (x(ivar), ivar = 1, 10)
+
+    write(*,*), "Hello world from device!"
+    !ERROR: Only list-directed WRITE statement may appear in device code
+    write(*,'(10F4.1)'), x
+  end
 end
 
 program main


### PR DESCRIPTION
The specification allow list-directed PRINT and WRITE statements to appear in device code. This patch relax the semantic check to allow them.

3.6.11.
List-directed PRINT and WRITE statements to the default unit may be used when compiling for compute capability 2.0 and higher; all other uses of PRINT and WRITE are disallowed.