### PR TITLE
[clang-tidy] Fix readability-duplicate-include for includes with macro

### DIFF
--- a/clang-tools-extra/clang-tidy/readability/DuplicateIncludeCheck.cpp
+++ b/clang-tools-extra/clang-tidy/readability/DuplicateIncludeCheck.cpp
@@ -18,6 +18,9 @@ namespace clang::tidy::readability {
 static SourceLocation advanceBeyondCurrentLine(const SourceManager &SM,
                                                SourceLocation Start,
                                                int Offset) {
+  // Keep macro location as it is
+  if (Start.isMacroID())
+    return Start;
   const FileID Id = SM.getFileID(Start);
   const unsigned LineNumber = SM.getSpellingLineNumber(Start);
   while (SM.getFileID(Start) == Id &&

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -251,6 +251,10 @@ Changes in existing checks
   analyzed, se the check now handles the common patterns
   `const auto e = (*vector_ptr)[i]` and `const auto e = vector_ptr->at(i);`.
 
+- Improved :doc:`readability-duplicate-include
+  <clang-tidy/checks/readability/duplicate-include>` check by resolving crash
+  at include directives that form the filename using macro.
+
 - Improved :doc:`readability-identifier-naming
   <clang-tidy/checks/readability/identifier-naming>` check in `GetConfigPerFile`
   mode by resolving symbolic links to header files. Fixed handling of Hungarian
@@ -269,10 +273,6 @@ Changes in existing checks
   <clang-tidy/checks/readability/static-definition-in-anonymous-namespace>`
   check by resolving fix-it overlaps in template code by disregarding implicit
   instances.
-
-- Improved :doc:`readability-duplicate-include
-  <clang-tidy/checks/readability/duplicate-include>` check by resolving crash
-  at include directives that form the filename using macro.
 
 Removed checks
 ^^^^^^^^^^^^^^

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -270,6 +270,10 @@ Changes in existing checks
   check by resolving fix-it overlaps in template code by disregarding implicit
   instances.
 
+- Improved :doc:`readability-duplicate-include
+  <clang-tidy/checks/readability/duplicate-include>` check by resolving crash
+  at include directives that form the filename using macro.
+
 Removed checks
 ^^^^^^^^^^^^^^
 

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -252,8 +252,8 @@ Changes in existing checks
   `const auto e = (*vector_ptr)[i]` and `const auto e = vector_ptr->at(i);`.
 
 - Improved :doc:`readability-duplicate-include
-  <clang-tidy/checks/readability/duplicate-include>` check by resolving crash
-  at include directives that form the filename using macro.
+  <clang-tidy/checks/readability/duplicate-include>` check by excluding include
+  directives that form the filename using macro.
 
 - Improved :doc:`readability-identifier-naming
   <clang-tidy/checks/readability/identifier-naming>` check in `GetConfigPerFile`

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/duplicate-include.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/duplicate-include.cpp
@@ -72,31 +72,16 @@ int r;
 // CHECK-FIXES-NEXT: {{^int r;$}}
 
 namespace Issue_87303 {
-// Include name from macro
+#define RESET_INCLUDE_CACHE
+// Expect no warnings
+
 #define MACRO_FILENAME "duplicate-include.h"
-int a;
 #include MACRO_FILENAME
-int b;
 #include "duplicate-include.h"
-int c;
-// CHECK-MESSAGES: :[[@LINE-2]]:1: warning: duplicate include
-// CHECK-FIXES:      {{^int a;$}}
-// CHECK-FIXES-NEXT: {{^#include MACRO_FILENAME$}}
-// CHECK-FIXES-NEXT: {{^int b;$}}
-// CHECK-FIXES-NEXT: {{^int c;$}}
 
-// Keep macro
 #define MACRO_FILENAME_2 <duplicate-include2.h>
-int d;
 #include <duplicate-include2.h>
-int e;
 #include MACRO_FILENAME_2
-int f;
-// CHECK-MESSAGES: :[[@LINE-2]]:1: warning: duplicate include
-// CHECK-FIXES:      {{^int d;$}}
-// CHECK-FIXES-NEXT: {{^#include <duplicate-include2.h>$}}
-// CHECK-FIXES-NEXT: {{^int e;$}}
-// CHECK-FIXES-NEXT: {{^#include MACRO_FILENAME_2$}}
-// CHECK-FIXES-NEXT: {{^int f;$}}
 
+#undef RESET_INCLUDE_CACHE
 } // Issue_87303

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/duplicate-include.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/duplicate-include.cpp
@@ -70,3 +70,33 @@ int r;
 // CHECK-FIXES:      {{^int q;$}}
 // CHECK-FIXES-NEXT: {{^#include <sys/types.h>$}}
 // CHECK-FIXES-NEXT: {{^int r;$}}
+
+namespace Issue_87303 {
+// Include name from macro
+#define MACRO_FILENAME "duplicate-include.h"
+int a;
+#include MACRO_FILENAME
+int b;
+#include "duplicate-include.h"
+int c;
+// CHECK-MESSAGES: :[[@LINE-2]]:1: warning: duplicate include
+// CHECK-FIXES:      {{^int a;$}}
+// CHECK-FIXES-NEXT: {{^#include MACRO_FILENAME$}}
+// CHECK-FIXES-NEXT: {{^int b;$}}
+// CHECK-FIXES-NEXT: {{^int c;$}}
+
+// Keep macro
+#define MACRO_FILENAME_2 <duplicate-include2.h>
+int d;
+#include <duplicate-include2.h>
+int e;
+#include MACRO_FILENAME_2
+int f;
+// CHECK-MESSAGES: :[[@LINE-2]]:1: warning: duplicate include
+// CHECK-FIXES:      {{^int d;$}}
+// CHECK-FIXES-NEXT: {{^#include <duplicate-include2.h>$}}
+// CHECK-FIXES-NEXT: {{^int e;$}}
+// CHECK-FIXES-NEXT: {{^#include MACRO_FILENAME_2$}}
+// CHECK-FIXES-NEXT: {{^int f;$}}
+
+} // Issue_87303


### PR DESCRIPTION
Completely skip include directives that form the filename using macros.

fixes #87303 