### PR TITLE
[StandardInstrumentations] Support -print-after-pass-number option

### DIFF
--- a/llvm/include/llvm/Passes/StandardInstrumentations.h
+++ b/llvm/include/llvm/Passes/StandardInstrumentations.h
@@ -66,6 +66,7 @@ private:
   bool shouldPrintAfterPass(StringRef PassID);
   bool shouldPrintPassNumbers();
   bool shouldPrintBeforePassNumber();
+  bool shouldPrintAfterPassNumber();
 
   void pushPassRunDescriptor(StringRef PassID, Any IR,
                              std::string &DumpIRFilename);

--- a/llvm/include/llvm/Passes/StandardInstrumentations.h
+++ b/llvm/include/llvm/Passes/StandardInstrumentations.h
@@ -64,6 +64,7 @@ private:
 
   bool shouldPrintBeforePass(StringRef PassID);
   bool shouldPrintAfterPass(StringRef PassID);
+  bool shouldPrintAfterPassNumberCheck();
   bool shouldPrintPassNumbers();
   bool shouldPrintBeforePassNumber();
   bool shouldPrintAfterPassNumber();

--- a/llvm/include/llvm/Passes/StandardInstrumentations.h
+++ b/llvm/include/llvm/Passes/StandardInstrumentations.h
@@ -64,10 +64,11 @@ private:
 
   bool shouldPrintBeforePass(StringRef PassID);
   bool shouldPrintAfterPass(StringRef PassID);
-  bool shouldPrintAfterPassNumberCheck();
+  bool shouldPrintBeforeCurrentPassNumber();
+  bool shouldPrintAfterCurrentPassNumber();
   bool shouldPrintPassNumbers();
-  bool shouldPrintBeforePassNumber();
-  bool shouldPrintAfterPassNumber();
+  bool shouldPrintBeforeSomePassNumber();
+  bool shouldPrintAfterSomePassNumber();
 
   void pushPassRunDescriptor(StringRef PassID, Any IR,
                              std::string &DumpIRFilename);

--- a/llvm/lib/Passes/StandardInstrumentations.cpp
+++ b/llvm/lib/Passes/StandardInstrumentations.cpp
@@ -807,8 +807,6 @@ void PrintIRInstrumentation::printBeforePass(StringRef PassID, Any IR) {
       (shouldPrintBeforePass(PassID) || shouldPrintAfterPass(PassID)))
     DumpIRFilename = fetchDumpFilename(PassID, IR);
 
-  ++CurrentPassNumber;
-
   // Saving Module for AfterPassInvalidated operations.
   // Note: here we rely on a fact that we do not change modules while
   // traversing the pipeline, so the latest captured module is good
@@ -819,9 +817,14 @@ void PrintIRInstrumentation::printBeforePass(StringRef PassID, Any IR) {
   if (!shouldPrintIR(IR))
     return;
 
+  ++CurrentPassNumber;
+
   if (shouldPrintPassNumbers())
     dbgs() << " Running pass " << CurrentPassNumber << " " << PassID
            << " on " << getIRName(IR) << "\n";
+
+  if (shouldPrintAfterPass(PassID))
+    pushPassRunDescriptor(PassID, IR, DumpIRFilename);
 
   if (!shouldPrintBeforePass(PassID))
     return;

--- a/llvm/lib/Passes/StandardInstrumentations.cpp
+++ b/llvm/lib/Passes/StandardInstrumentations.cpp
@@ -123,10 +123,10 @@ static cl::opt<unsigned> PrintBeforePassNumber(
     cl::desc("Print IR before the pass with this number as "
              "reported by print-pass-numbers"));
 
-static cl::opt<unsigned> PrintAfterPassNumber(
-    "print-after-pass-number", cl::init(0), cl::Hidden,
-    cl::desc("Print IR after the pass with this number as "
-             "reported by print-pass-numbers"));
+static cl::opt<unsigned>
+    PrintAfterPassNumber("print-after-pass-number", cl::init(0), cl::Hidden,
+                         cl::desc("Print IR after the pass with this number as "
+                                  "reported by print-pass-numbers"));
 
 static cl::opt<std::string> IRDumpDirectory(
     "ir-dump-directory",
@@ -932,8 +932,7 @@ bool PrintIRInstrumentation::shouldPrintAfterPass(StringRef PassID) {
   if (shouldPrintAfterAll())
     return true;
 
-  if (shouldPrintAfterPassNumber() &&
-      CurrentPassNumber == PrintAfterPassNumber)
+  if (shouldPrintAfterPassNumber() && CurrentPassNumber == PrintAfterPassNumber)
     return true;
 
   StringRef PassName = PIC->getPassNameForClassName(PassID);
@@ -957,7 +956,8 @@ void PrintIRInstrumentation::registerCallbacks(
   this->PIC = &PIC;
 
   // BeforePass callback is not just for printing, it also saves a Module
-  // for later use in AfterPassInvalidated and keeps tracks of the CurrentPassNumber.
+  // for later use in AfterPassInvalidated and keeps tracks of the
+  // CurrentPassNumber.
   if (shouldPrintPassNumbers() || shouldPrintBeforePassNumber() ||
       shouldPrintAfterPassNumber() || shouldPrintBeforeSomePass() ||
       shouldPrintAfterSomePass())

--- a/llvm/lib/Passes/StandardInstrumentations.cpp
+++ b/llvm/lib/Passes/StandardInstrumentations.cpp
@@ -805,7 +805,8 @@ void PrintIRInstrumentation::printBeforePass(StringRef PassID, Any IR) {
   std::string DumpIRFilename;
   if (!IRDumpDirectory.empty() &&
       (shouldPrintBeforePass(PassID) || shouldPrintAfterPass(PassID) ||
-       shouldPrintBeforeCurrentPassNumber() || shouldPrintAfterCurrentPassNumber()))
+       shouldPrintBeforeCurrentPassNumber() ||
+       shouldPrintAfterCurrentPassNumber()))
     DumpIRFilename = fetchDumpFilename(PassID, IR);
 
   // Saving Module for AfterPassInvalidated operations.

--- a/llvm/test/Other/print-at-pass-number.ll
+++ b/llvm/test/Other/print-at-pass-number.ll
@@ -1,4 +1,5 @@
 ; RUN: opt -passes="loop(indvars,loop-deletion,loop-unroll-full)" -print-pass-numbers -S -o /dev/null %s 2>&1 | FileCheck %s --check-prefix=NUMBER
+; RUN: opt -passes="loop(indvars,loop-deletion,loop-unroll-full)" -print-pass-numbers -filter-print-funcs=baz -S -o /dev/null %s 2>&1 | FileCheck %s --check-prefix=NUMBER-FILTERED
 ; RUN: opt -passes="loop(indvars,loop-deletion,loop-unroll-full)" -print-module-scope -print-before-pass-number=3 -S -o /dev/null %s 2>&1 | FileCheck %s --check-prefix=BEFORE
 ; RUN: opt -passes="loop(indvars,loop-deletion,loop-unroll-full)" -print-module-scope -print-after-pass-number=2 -S -o /dev/null %s 2>&1 | FileCheck %s --check-prefix=AFTER
 
@@ -23,8 +24,18 @@ bb4:                                              ; preds = %bb1
   ret i32 %add3
 }
 
+define i32 @baz(i32 %arg) {
+  ret i32 0;
+}
+
 ; NUMBER:  Running pass 1 LoopSimplifyPass on bar
 ; NUMBER-NEXT: Running pass 2 LCSSAPass on bar
 ; NUMBER-NEXT: Running pass 3 IndVarSimplifyPass on bb1
 ; NUMBER-NEXT: Running pass 4 LoopDeletionPass on bb1
+; NUMBER-NEXT: Running pass 5 LoopSimplifyPass on baz
+; NUMBER-NEXT: Running pass 6 LCSSAPass on baz
 ; NUMBER-NOT: Running pass
+
+; NUMBER-FILTERED: Running pass 1 LoopSimplifyPass on baz
+; NUMBER-FILTERED-NEXT: Running pass 2 LCSSAPass on baz
+

--- a/llvm/test/Other/print-at-pass-number.ll
+++ b/llvm/test/Other/print-at-pass-number.ll
@@ -1,9 +1,12 @@
 ; RUN: opt -passes="loop(indvars,loop-deletion,loop-unroll-full)" -print-pass-numbers -S -o /dev/null %s 2>&1 | FileCheck %s --check-prefix=NUMBER
 ; RUN: opt -passes="loop(indvars,loop-deletion,loop-unroll-full)" -print-module-scope -print-before-pass-number=3 -S -o /dev/null %s 2>&1 | FileCheck %s --check-prefix=BEFORE
+; RUN: opt -passes="loop(indvars,loop-deletion,loop-unroll-full)" -print-module-scope -print-after-pass-number=2 -S -o /dev/null %s 2>&1 | FileCheck %s --check-prefix=AFTER
 
 define i32 @bar(i32 %arg) {
 ; BEFORE: *** IR Dump Before 3-IndVarSimplifyPass on bb1 ***
 ; BEFORE: define i32 @bar(i32 %arg) {
+; AFTER:  *** IR Dump After 2-LCSSAPass on bar ***
+; AFTER:  define i32 @bar(i32 %arg) {
 
 bb:
   br label %bb1


### PR DESCRIPTION
There's already support for `-print-before-pass-number`, so it makes sense that we also have a `-print-after-pass-number`. This is especially useful if you want to print the IR after the very last pass without resorting to `-print-after-all` and combing through stderr or the IR file directory.