### PR TITLE
[DAGCombiner] ignore loads when finding store in store forwarding optimization

### DIFF
--- a/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp
@@ -18582,6 +18582,10 @@ StoreSDNode *DAGCombiner::getUniqueStoreFeeding(LoadSDNode *LD,
   if (Chain.getOpcode() == ISD::CALLSEQ_START)
     Chain = Chain->getOperand(0);
 
+  // Look through Loads.
+  while (isa<LoadSDNode>(Chain.getNode()))
+    Chain = Chain->getOperand(0);
+
   StoreSDNode *ST = nullptr;
   SmallVector<SDValue, 8> Aliases;
   if (Chain.getOpcode() == ISD::TokenFactor) {

--- a/llvm/test/CodeGen/PowerPC/legalize-vaarg.ll
+++ b/llvm/test/CodeGen/PowerPC/legalize-vaarg.ll
@@ -43,14 +43,13 @@ define <8 x i32> @test_large_vec_vaarg(i32 %n, ...) {
 ; FORWARD-NEXT:    addi 3, 3, 15
 ; FORWARD-NEXT:    rldicr 3, 3, 0, 59
 ; FORWARD-NEXT:    addi 4, 3, 16
+; FORWARD-NEXT:    addi 5, 3, 31
 ; FORWARD-NEXT:    std 4, -8(1)
-; FORWARD-NEXT:    ld 4, -8(1)
+; FORWARD-NEXT:    rldicr 4, 5, 0, 59
 ; FORWARD-NEXT:    lvx 2, 0, 3
-; FORWARD-NEXT:    addi 4, 4, 15
-; FORWARD-NEXT:    rldicr 3, 4, 0, 59
-; FORWARD-NEXT:    addi 4, 3, 16
-; FORWARD-NEXT:    std 4, -8(1)
-; FORWARD-NEXT:    lvx 3, 0, 3
+; FORWARD-NEXT:    addi 3, 4, 16
+; FORWARD-NEXT:    std 3, -8(1)
+; FORWARD-NEXT:    lvx 3, 0, 4
 ; FORWARD-NEXT:    blr
   %args = alloca ptr, align 4
   %x = va_arg ptr %args, <8 x i32>


### PR DESCRIPTION
When find the store for store forwarding optimization, look through the loads.

This should be also good for compile time because we can replace the load with store value early and avoid the time consuming `FindBetterChain()` optimization in `visitLoad()`.