### PR TITLE
RFC: [AMDGPU] Select CONVERGENCECTRL_GLUE generically

### DIFF
--- a/llvm/include/llvm/CodeGen/SelectionDAGISel.h
+++ b/llvm/include/llvm/CodeGen/SelectionDAGISel.h
@@ -462,6 +462,7 @@ private:
   void Select_CONVERGENCECTRL_ANCHOR(SDNode *N);
   void Select_CONVERGENCECTRL_ENTRY(SDNode *N);
   void Select_CONVERGENCECTRL_LOOP(SDNode *N);
+  void Select_CONVERGENCECTRL_GLUE(SDNode *N);
 
   void pushStackMapLiveVariable(SmallVectorImpl<SDValue> &Ops, SDValue Operand,
                                 SDLoc DL);

--- a/llvm/include/llvm/IR/IntrinsicsAMDGPU.td
+++ b/llvm/include/llvm/IR/IntrinsicsAMDGPU.td
@@ -2175,7 +2175,7 @@ def int_amdgcn_wave_reduce_umax : AMDGPUWaveReduce;
 def int_amdgcn_readfirstlane :
   ClangBuiltin<"__builtin_amdgcn_readfirstlane">,
   Intrinsic<[llvm_i32_ty], [llvm_i32_ty],
-            [IntrNoMem, IntrConvergent, IntrWillReturn, IntrNoCallback, IntrNoFree]>;
+            [IntrNoMem, IntrConvergent, IntrWillReturn, IntrNoCallback, IntrNoFree], "", [SDNPOptInGlue]>;
 
 // The lane argument must be uniform across the currently active threads of the
 // current wave. Otherwise, the result is undefined.

--- a/llvm/lib/CodeGen/SelectionDAG/SelectionDAGISel.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/SelectionDAGISel.cpp
@@ -2385,6 +2385,11 @@ void SelectionDAGISel::Select_CONVERGENCECTRL_LOOP(SDNode *N) {
                        N->getValueType(0), N->getOperand(0));
 }
 
+void SelectionDAGISel::Select_CONVERGENCECTRL_GLUE(SDNode *N) {
+  CurDAG->SelectNodeTo(N, TargetOpcode::CONVERGENCECTRL_GLUE,
+                       N->getValueType(0), N->getOperand(0));
+}
+
 void SelectionDAGISel::pushStackMapLiveVariable(SmallVectorImpl<SDValue> &Ops,
                                                 SDValue OpVal, SDLoc DL) {
   SDNode *OpNode = OpVal.getNode();
@@ -3140,6 +3145,9 @@ void SelectionDAGISel::SelectCodeCommon(SDNode *NodeToMatch,
     return;
   case ISD::CONVERGENCECTRL_LOOP:
     Select_CONVERGENCECTRL_LOOP(NodeToMatch);
+    return;
+  case ISD::CONVERGENCECTRL_GLUE:
+    Select_CONVERGENCECTRL_GLUE(NodeToMatch);
     return;
   }
 

--- a/llvm/lib/Target/AMDGPU/AMDGPUISelDAGToDAG.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUISelDAGToDAG.cpp
@@ -2688,18 +2688,7 @@ void AMDGPUDAGToDAGISel::SelectINTRINSIC_W_CHAIN(SDNode *N) {
 
 void AMDGPUDAGToDAGISel::SelectINTRINSIC_WO_CHAIN(SDNode *N) {
   unsigned IntrID = N->getConstantOperandVal(0);
-  unsigned Opcode = AMDGPU::INSTRUCTION_LIST_END;
-  SDNode *ConvGlueNode = N->getGluedNode();
-  if (ConvGlueNode) {
-    // FIXME: Possibly iterate over multiple glue nodes?
-    assert(ConvGlueNode->getOpcode() == ISD::CONVERGENCECTRL_GLUE);
-    ConvGlueNode = ConvGlueNode->getOperand(0).getNode();
-    ConvGlueNode =
-        CurDAG->getMachineNode(TargetOpcode::CONVERGENCECTRL_GLUE, {},
-                               MVT::Glue, SDValue(ConvGlueNode, 0));
-  } else {
-    ConvGlueNode = nullptr;
-  }
+  unsigned Opcode;
   switch (IntrID) {
   case Intrinsic::amdgcn_wqm:
     Opcode = AMDGPU::WQM;
@@ -2731,19 +2720,11 @@ void AMDGPUDAGToDAGISel::SelectINTRINSIC_WO_CHAIN(SDNode *N) {
     break;
   default:
     SelectCode(N);
-    break;
+    return;
   }
 
-  if (Opcode != AMDGPU::INSTRUCTION_LIST_END) {
-    SDValue Src = N->getOperand(1);
-    CurDAG->SelectNodeTo(N, Opcode, N->getVTList(), {Src});
-  }
-
-  if (ConvGlueNode) {
-    SmallVector<SDValue, 4> NewOps(N->op_begin(), N->op_end());
-    NewOps.push_back(SDValue(ConvGlueNode, 0));
-    CurDAG->MorphNodeTo(N, N->getOpcode(), N->getVTList(), NewOps);
-  }
+  SDValue Src = N->getOperand(1);
+  CurDAG->SelectNodeTo(N, Opcode, N->getVTList(), {Src});
 }
 
 void AMDGPUDAGToDAGISel::SelectINTRINSIC_VOID(SDNode *N) {


### PR DESCRIPTION
Teach SelectionDAGISel::SelectCodeCommonn how to select
CONVERGENCECTRL_GLUE instead of doing it in the AMDGPU backend.
