### PR TITLE
Disabling DebugInfoD tests for linux aarch64/arm the right way

### DIFF
--- a/lldb/test/API/debuginfod/Normal/TestDebuginfod.py
+++ b/lldb/test/API/debuginfod/Normal/TestDebuginfod.py
@@ -19,11 +19,11 @@ For no-split-dwarf scenarios, there are 2 variations:
 
 
 # It looks like Linux-AArch64 doesn't support build-id's on the LLDB builtbots
-@skipIf(oslist=no_match(["linux"]), archs=no_match(["i386", "x86_64"]))
 class DebugInfodTests(TestBase):
     # No need to try every flavor of debug inf.
     NO_DEBUG_INFO_TESTCASE = True
 
+    @skipIf(oslist=no_match(["linux"]), archs=no_match(["i386", "x86_64"]))
     def test_normal_no_symbols(self):
         """
         Validate behavior with no symbols or symbol locator.
@@ -32,6 +32,7 @@ class DebugInfodTests(TestBase):
         test_root = self.config_test(["a.out"])
         self.try_breakpoint(False)
 
+    @skipIf(oslist=no_match(["linux"]), archs=no_match(["i386", "x86_64"]))
     def test_normal_default(self):
         """
         Validate behavior with symbols, but no symbol locator.
@@ -40,6 +41,7 @@ class DebugInfodTests(TestBase):
         test_root = self.config_test(["a.out", "a.out.debug"])
         self.try_breakpoint(True)
 
+    @skipIf(oslist=no_match(["linux"]), archs=no_match(["i386", "x86_64"]))
     def test_debuginfod_symbols(self):
         """
         Test behavior with the full binary available from Debuginfod as
@@ -48,6 +50,7 @@ class DebugInfodTests(TestBase):
         test_root = self.config_test(["a.out"], "a.out.unstripped")
         self.try_breakpoint(True)
 
+    @skipIf(oslist=no_match(["linux"]), archs=no_match(["i386", "x86_64"]))
     def test_debuginfod_executable(self):
         """
         Test behavior with the full binary available from Debuginfod as
@@ -56,6 +59,7 @@ class DebugInfodTests(TestBase):
         test_root = self.config_test(["a.out"], None, "a.out.unstripped")
         self.try_breakpoint(True)
 
+    @skipIf(oslist=no_match(["linux"]), archs=no_match(["i386", "x86_64"]))
     def test_debuginfod_okd_symbols(self):
         """
         Test behavior with the 'only-keep-debug' symbols available from Debuginfod.

--- a/lldb/test/API/debuginfod/SplitDWARF/TestDebuginfodDWP.py
+++ b/lldb/test/API/debuginfod/SplitDWARF/TestDebuginfodDWP.py
@@ -22,11 +22,11 @@ This file is for split-dwarf (dwp) scenarios.
 
 
 # It looks like Linux-AArch64 doesn't support build-id's on the LLDB builtbots
-@skipIf(oslist=no_match(["linux"]), archs=no_match(["i386", "x86_64"]))
 class DebugInfodDWPTests(TestBase):
     # No need to try every flavor of debug inf.
     NO_DEBUG_INFO_TESTCASE = True
 
+    @skipIf(oslist=no_match(["linux"]), archs=no_match(["i386", "x86_64"]))
     def test_normal_stripped(self):
         """
         Validate behavior with a stripped binary, no symbols or symbol locator.
@@ -34,6 +34,7 @@ class DebugInfodDWPTests(TestBase):
         self.config_test(["a.out"])
         self.try_breakpoint(False)
 
+    @skipIf(oslist=no_match(["linux"]), archs=no_match(["i386", "x86_64"]))
     def test_normal_stripped_split_with_dwp(self):
         """
         Validate behavior with symbols, but no symbol locator.
@@ -41,6 +42,7 @@ class DebugInfodDWPTests(TestBase):
         self.config_test(["a.out", "a.out.debug", "a.out.dwp"])
         self.try_breakpoint(True)
 
+    @skipIf(oslist=no_match(["linux"]), archs=no_match(["i386", "x86_64"]))
     def test_normal_stripped_only_dwp(self):
         """
         Validate behavior *with* dwp symbols only, but missing other symbols,
@@ -50,6 +52,7 @@ class DebugInfodDWPTests(TestBase):
         self.config_test(["a.out", "a.out.dwp"])
         self.try_breakpoint(False)
 
+    @skipIf(oslist=no_match(["linux"]), archs=no_match(["i386", "x86_64"]))
     def test_debuginfod_dwp_from_service(self):
         """
         Test behavior with the unstripped binary, and DWP from the service.
@@ -57,6 +60,7 @@ class DebugInfodDWPTests(TestBase):
         self.config_test(["a.out.debug"], "a.out.dwp")
         self.try_breakpoint(True)
 
+    @skipIf(oslist=no_match(["linux"]), archs=no_match(["i386", "x86_64"]))
     def test_debuginfod_both_symfiles_from_service(self):
         """
         Test behavior with a stripped binary, with the unstripped binary and
@@ -65,6 +69,7 @@ class DebugInfodDWPTests(TestBase):
         self.config_test(["a.out"], "a.out.dwp", "a.out.unstripped")
         self.try_breakpoint(True)
 
+    @skipIf(oslist=no_match(["linux"]), archs=no_match(["i386", "x86_64"]))
     def test_debuginfod_both_okd_symfiles_from_service(self):
         """
         Test behavior with both the only-keep-debug symbols and the dwp symbols


### PR DESCRIPTION
I moved the @skipIf annotation to each test, off of the class itself, as this is what other API tests look like that disable tests for given platforms. Hopefully this will address the Linux AArch64 buildbot issues.