### PR TITLE
[OpenMP] Do not emit default thread limits of 128

### DIFF
--- a/clang/test/OpenMP/thread_limit_nvptx.c
+++ b/clang/test/OpenMP/thread_limit_nvptx.c
@@ -7,7 +7,7 @@
 #define HEADER
 
 void foo(int N) {
-// CHECK: l11, !"maxntidx", i32 128}
+// CHECK-NOT: l11, !"maxntidx", i32 128}
 #pragma omp target teams distribute parallel for simd
   for (int i = 0; i < N; ++i)
     ;

--- a/llvm/include/llvm/Frontend/OpenMP/OMPIRBuilder.h
+++ b/llvm/include/llvm/Frontend/OpenMP/OMPIRBuilder.h
@@ -2107,7 +2107,7 @@ public:
   static std::pair<int32_t, int32_t> readTeamBoundsForKernel(const Triple &T,
                                                              Function &Kernel);
   static void writeTeamsForKernel(const Triple &T, Function &Kernel, int32_t LB,
-                                  int32_t UB);
+                                  int32_t UB, int32_t NTid);
   ///}
 
 private:


### PR DESCRIPTION
Summary:
We have logic that currently sets values like `maxntidx` in the PTX to
be 128 if it was not specified by the user because this is what OpenMP
defaults to. This is not strictly correct in the OpenMP case because the
user can increase this with environment variables. Additionally, this
violates the CUDA linking ABI. So if we link code that comes from OpenMP
with a `cubin` from another project the more strict thread limit of
`128` will result in the kernel sometimes failing to link with a
function compiled against a generic target of `1024` due to an inconsistency
in the number of registers required. I.e. a kernel with lower register requirements
cannot link against a function with higher .This was observed when doing 
`cubin` linking against some `libc` functions.
