### PR TITLE
Add a NeverSpeculatable trait

### DIFF
--- a/mlir/include/mlir/Interfaces/SideEffectInterfaces.h
+++ b/mlir/include/mlir/Interfaces/SideEffectInterfaces.h
@@ -304,6 +304,17 @@ struct AlwaysSpeculatableImplTrait
     return Speculation::Speculatable;
   }
 };
+
+/// This trait marks an op (which must be tagged as implementing the
+/// ConditionallySpeculatable interface) as never being speculatable.
+template <typename ConcreteType>
+struct NeverSpeculatableImplTrait
+    : public TraitBase<ConcreteType, NeverSpeculatableImplTrait> {
+
+  Speculation::Speculatability getSpeculatability() {
+    return Speculation::NotSpeculatable;
+  }
+};
 } // namespace OpTrait
 
 //===----------------------------------------------------------------------===//

--- a/mlir/include/mlir/Interfaces/SideEffectInterfaces.td
+++ b/mlir/include/mlir/Interfaces/SideEffectInterfaces.td
@@ -110,6 +110,11 @@ def RecursivelySpeculatableImplTrait
 def AlwaysSpeculatableImplTrait
   : NativeOpTrait<"AlwaysSpeculatableImplTrait">;
 
+// Used to inject an implementation of getSpeculatability.  Users should not use
+// this directly.
+def NeverSpeculatableImplTrait
+  : NativeOpTrait<"NeverSpeculatableImplTrait">;
+
 // This op interface enables Op authors to inject custom logic to determine
 // whether an Operation can be speculatively executed.  Ops that implement this
 // interface need to implement the custom logic in the `getSpeculatability` method.
@@ -135,6 +140,10 @@ def ConditionallySpeculatable : OpInterface<"ConditionallySpeculatable"> {
 // Marks an Operation as always speculatable.
 def AlwaysSpeculatable : TraitList<[
     ConditionallySpeculatable, AlwaysSpeculatableImplTrait]>;
+
+// Marks an Operation as never speculatable.
+def NeverSpeculatable : TraitList<[
+    ConditionallySpeculatable, NeverSpeculatableImplTrait]>;
 
 // Marks an Operation as speculatable only if all the operations in all attached
 // regions are also speculatable.

--- a/mlir/test/lib/Dialect/Test/TestOps.td
+++ b/mlir/test/lib/Dialect/Test/TestOps.td
@@ -2749,18 +2749,12 @@ def PureOp : TEST_Op<"always_speculatable_op", [Pure]> {
   let results = (outs I32:$result);
 }
 
-def NeverSpeculatableOp : TEST_Op<"never_speculatable_op", [ConditionallySpeculatable]> {
+def NeverSpeculatableOp : TEST_Op<"never_speculatable_op", [NeverSpeculatable]> {
   let description = [{
     Op used to test conditional speculation.  This op can never be
     speculatively executed.
   }];
   let results = (outs I32:$result);
-
-  let extraClassDeclaration = [{
-    ::mlir::Speculation::Speculatability getSpeculatability() {
-      return ::mlir::Speculation::NotSpeculatable;
-    }
-  }];
 }
 
 def RecursivelySpeculatableOp : TEST_Op<"recursively_speculatable_op", [


### PR DESCRIPTION
I am implementing speculatability for all ops in the stablehlo dialect and some ops are never speculatable. I think it makes sense to have this trait here since there is already an AlwaysSpeculatable trait, even though use of NeverSpeculatable is likely to be much rarer.