### PR TITLE
[driver] Make --version show if assertions, etc. are enabled

### DIFF
--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -2005,38 +2005,35 @@ void Driver::PrintVersion(const Compilation &C, raw_ostream &OS) const {
   // Print out build configuration options that impact the compiler's runtime
   // behavior. Intended for identifying the source of issues when reproducing
   // changes.
-  std::vector<std::string> BuildOptions = {
-#if !__OPTIMIZE__
-      "+unoptimized",
+  SmallVector<StringRef> BuildOptions = {
+#if __GNUC__ && !__OPTIMIZE__
+    // FIXME: __OPTIMIZE__ is not available on MSVC, this will never show there
+    "+unoptimized",
 #endif
 #ifndef NDEBUG
-      "+assertions",
+    "+assertions",
 #endif
 #ifdef EXPENSIVE_CHECKS
-      "+expensive-checks",
+    "+expensive-checks",
 #endif
 #if __has_feature(address_sanitizer)
-      "+asan",
+    "+asan",
 #endif
 #if __has_feature(undefined_behavior_sanitizer)
-      "+ubsan",
+    "+ubsan",
 #endif
 #if __has_feature(memory_sanitizer)
-      "+msan",
+    "+msan",
 #endif
 #if __has_feature(dataflow_sanitizer)
-      "+dfsan",
+    "+dfsan",
 #endif
   };
   if (!BuildOptions.empty()) {
-    OS << "Build configuration: ";
-    bool FirstOption = true;
-    for (const auto &Option : BuildOptions) {
-      if (!FirstOption)
-        OS << ", ";
-      OS << Option;
-      FirstOption = false;
-    }
+    OS << "Build config: ";
+    llvm::interleaveComma(BuildOptions, OS, [&OS](const StringRef &Option) {
+        OS << Option;
+    });
     OS << '\n';
   }
 

--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -2006,7 +2006,8 @@ void Driver::PrintVersion(const Compilation &C, raw_ostream &OS) const {
   // behavior. Intended for identifying the source of issues when reproducing
   // changes.
   SmallVector<StringRef> BuildOptions = {
-#if !LLVM_IS_DEBUG_BUILD
+#if __GNUC__ && !__OPTIMIZE__
+    // FIXME: __OPTIMIZE__ is not available on MSVC, this will never show there
     "+unoptimized",
 #endif
 #ifndef NDEBUG

--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -2005,7 +2005,7 @@ void Driver::PrintVersion(const Compilation &C, raw_ostream &OS) const {
   // Print the build config if it's non-default.
   // Intended to help LLVM developers understand the configs of compilers
   // they're investigating.
-  if (!llvm::cl::CompilerBuildConfig.empty())
+  if (!llvm::cl::getCompilerBuildConfig().empty())
     llvm::cl::printBuildConfig(OS);
 
   // If configuration files were used, print their paths.

--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -2006,8 +2006,7 @@ void Driver::PrintVersion(const Compilation &C, raw_ostream &OS) const {
   // behavior. Intended for identifying the source of issues when reproducing
   // changes.
   SmallVector<StringRef> BuildOptions = {
-#if __GNUC__ && !__OPTIMIZE__
-    // FIXME: __OPTIMIZE__ is not available on MSVC, this will never show there
+#if !LLVM_IS_DEBUG_BUILD
     "+unoptimized",
 #endif
 #ifndef NDEBUG

--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -2002,40 +2002,11 @@ void Driver::PrintVersion(const Compilation &C, raw_ostream &OS) const {
   // Print out the install directory.
   OS << "InstalledDir: " << Dir << '\n';
 
-  // Print out build configuration options that impact the compiler's runtime
-  // behavior. Intended for identifying the source of issues when reproducing
-  // changes.
-  SmallVector<StringRef> BuildOptions = {
-#if __GNUC__ && !__OPTIMIZE__
-    // FIXME: __OPTIMIZE__ is not available on MSVC, this will never show there
-    "+unoptimized",
-#endif
-#ifndef NDEBUG
-    "+assertions",
-#endif
-#ifdef EXPENSIVE_CHECKS
-    "+expensive-checks",
-#endif
-#if __has_feature(address_sanitizer)
-    "+asan",
-#endif
-#if __has_feature(undefined_behavior_sanitizer)
-    "+ubsan",
-#endif
-#if __has_feature(memory_sanitizer)
-    "+msan",
-#endif
-#if __has_feature(dataflow_sanitizer)
-    "+dfsan",
-#endif
-  };
-  if (!BuildOptions.empty()) {
-    OS << "Build config: ";
-    llvm::interleaveComma(BuildOptions, OS, [&OS](const StringRef &Option) {
-        OS << Option;
-    });
-    OS << '\n';
-  }
+  // Print the build config if it's non-default.
+  // Intended to help LLVM developers understand the configs of compilers
+  // they're investigating.
+  if (!llvm::cl::CompilerBuildConfig.empty())
+    llvm::cl::printBuildConfig(OS);
 
   // If configuration files were used, print their paths.
   for (auto ConfigFile : ConfigFiles)

--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -2002,6 +2002,44 @@ void Driver::PrintVersion(const Compilation &C, raw_ostream &OS) const {
   // Print out the install directory.
   OS << "InstalledDir: " << Dir << '\n';
 
+  // Print out build configuration options that impact the compiler's runtime
+  // behavior. Intended for identifying the source of issues when reproducing
+  // changes.
+  std::vector<std::string> BuildOptions = {
+#if !__OPTIMIZE__
+      "+unoptimized",
+#endif
+#ifndef NDEBUG
+      "+assertions",
+#endif
+#ifdef EXPENSIVE_CHECKS
+      "+expensive-checks",
+#endif
+#if __has_feature(address_sanitizer)
+      "+asan",
+#endif
+#if __has_feature(undefined_behavior_sanitizer)
+      "+ubsan",
+#endif
+#if __has_feature(memory_sanitizer)
+      "+msan",
+#endif
+#if __has_feature(dataflow_sanitizer)
+      "+dfsan",
+#endif
+  };
+  if (!BuildOptions.empty()) {
+    OS << "Build configuration: ";
+    bool FirstOption = true;
+    for (const auto &Option : BuildOptions) {
+      if (!FirstOption)
+        OS << ", ";
+      OS << Option;
+      FirstOption = false;
+    }
+    OS << '\n';
+  }
+
   // If configuration files were used, print their paths.
   for (auto ConfigFile : ConfigFiles)
     OS << "Configuration file: " << ConfigFile << '\n';

--- a/clang/test/Driver/version-build-config.test
+++ b/clang/test/Driver/version-build-config.test
@@ -3,4 +3,4 @@
 
 # CHECK: clang version
 # When assertions are enabled, we should have a build configuration line that reflects that
-# CHECK: Build configuration: {{.*}}+assertions
+# CHECK: Build config: {{.*}}+assertions

--- a/clang/test/Driver/version-build-config.test
+++ b/clang/test/Driver/version-build-config.test
@@ -1,0 +1,6 @@
+# REQUIRES: asserts
+# RUN: %clang --version 2>&1 | FileCheck %s
+
+# CHECK: clang version
+# When assertions are enabled, we should have a build configuration line that reflects that
+# CHECK: Build configuration: {{.*}}+assertions

--- a/llvm/CMakeLists.txt
+++ b/llvm/CMakeLists.txt
@@ -799,6 +799,9 @@ option (LLVM_BUILD_EXTERNAL_COMPILER_RT
 option (LLVM_VERSION_PRINTER_SHOW_HOST_TARGET_INFO
   "Show target and host info when tools are invoked with --version." ON)
 
+option(LLVM_VERSION_PRINTER_SHOW_BUILD_CONFIG
+  "Show the optional build config flags when tools are invoked with --version." ON)
+
 # You can configure which libraries from LLVM you want to include in the
 # shared library by setting LLVM_DYLIB_COMPONENTS to a semi-colon delimited
 # list of LLVM components. All component names handled by llvm-config are valid.

--- a/llvm/include/llvm/Config/config.h.cmake
+++ b/llvm/include/llvm/Config/config.h.cmake
@@ -290,6 +290,9 @@
 /* Whether tools show host and target info when invoked with --version */
 #cmakedefine01 LLVM_VERSION_PRINTER_SHOW_HOST_TARGET_INFO
 
+/* Whether tools show optional build config flags when invoked with --version */
+#cmakedefine01 LLVM_VERSION_PRINTER_SHOW_BUILD_CONFIG
+
 /* Define if libxml2 is supported on this platform. */
 #cmakedefine LLVM_ENABLE_LIBXML2 ${LLVM_ENABLE_LIBXML2}
 

--- a/llvm/include/llvm/Support/CommandLine.h
+++ b/llvm/include/llvm/Support/CommandLine.h
@@ -40,28 +40,6 @@
 #include <type_traits>
 #include <vector>
 
-#if defined(__GNUC__)
-// GCC and GCC-compatible compilers define __OPTIMIZE__ when optimizations are
-// enabled.
-# if defined(__OPTIMIZE__)
-#  define LLVM_IS_DEBUG_BUILD 0
-# else
-#  define LLVM_IS_DEBUG_BUILD 1
-# endif
-#elif defined(_MSC_VER)
-// MSVC doesn't have a predefined macro indicating if optimizations are enabled.
-// Use _DEBUG instead. This macro actually corresponds to the choice between
-// debug and release CRTs, but it is a reasonable proxy.
-# if defined(_DEBUG)
-#  define LLVM_IS_DEBUG_BUILD 1
-# else
-#  define LLVM_IS_DEBUG_BUILD 0
-# endif
-#else
-// Otherwise, for an unknown compiler, assume this is an optimized build.
-# define LLVM_IS_DEBUG_BUILD 0
-#endif
-
 namespace llvm {
 
 namespace vfs {

--- a/llvm/include/llvm/Support/CommandLine.h
+++ b/llvm/include/llvm/Support/CommandLine.h
@@ -2005,7 +2005,7 @@ void PrintHelpMessage(bool Hidden = false, bool Categorized = false);
 /// An array of optional enabled settings in the LLVM build configuration,
 /// which may be of interest to compiler developers. For example, includes
 /// "+assertions" if assertions are enabled. Used by printBuildConfig.
-extern ArrayRef<StringRef> CompilerBuildConfig;
+ArrayRef<StringRef> getCompilerBuildConfig();
 
 /// Prints the compiler build configuration.
 /// Designed for compiler developers, not compiler end-users.

--- a/llvm/include/llvm/Support/CommandLine.h
+++ b/llvm/include/llvm/Support/CommandLine.h
@@ -40,6 +40,28 @@
 #include <type_traits>
 #include <vector>
 
+#if defined(__GNUC__)
+// GCC and GCC-compatible compilers define __OPTIMIZE__ when optimizations are
+// enabled.
+# if defined(__OPTIMIZE__)
+#  define LLVM_IS_DEBUG_BUILD 0
+# else
+#  define LLVM_IS_DEBUG_BUILD 1
+# endif
+#elif defined(_MSC_VER)
+// MSVC doesn't have a predefined macro indicating if optimizations are enabled.
+// Use _DEBUG instead. This macro actually corresponds to the choice between
+// debug and release CRTs, but it is a reasonable proxy.
+# if defined(_DEBUG)
+#  define LLVM_IS_DEBUG_BUILD 1
+# else
+#  define LLVM_IS_DEBUG_BUILD 0
+# endif
+#else
+// Otherwise, for an unknown compiler, assume this is an optimized build.
+# define LLVM_IS_DEBUG_BUILD 0
+#endif
+
 namespace llvm {
 
 namespace vfs {

--- a/llvm/include/llvm/Support/CommandLine.h
+++ b/llvm/include/llvm/Support/CommandLine.h
@@ -2002,6 +2002,16 @@ void PrintVersionMessage();
 /// \param Categorized if true print options in categories
 void PrintHelpMessage(bool Hidden = false, bool Categorized = false);
 
+/// An array of optional enabled settings in the LLVM build configuration,
+/// which may be of interest to compiler developers. For example, includes
+/// "+assertions" if assertions are enabled. Used by printBuildConfig.
+extern ArrayRef<StringRef> CompilerBuildConfig;
+
+/// Prints the compiler build configuration.
+/// Designed for compiler developers, not compiler end-users.
+/// Intended to be used in --version output when enabled.
+void printBuildConfig(raw_ostream &OS);
+
 //===----------------------------------------------------------------------===//
 // Public interface for accessing registered options.
 //

--- a/llvm/lib/Support/CommandLine.cpp
+++ b/llvm/lib/Support/CommandLine.cpp
@@ -2506,28 +2506,6 @@ public:
 
 } // End anonymous namespace
 
-#if defined(__GNUC__)
-// GCC and GCC-compatible compilers define __OPTIMIZE__ when optimizations are
-// enabled.
-# if defined(__OPTIMIZE__)
-#  define LLVM_IS_DEBUG_BUILD 0
-# else
-#  define LLVM_IS_DEBUG_BUILD 1
-# endif
-#elif defined(_MSC_VER)
-// MSVC doesn't have a predefined macro indicating if optimizations are enabled.
-// Use _DEBUG instead. This macro actually corresponds to the choice between
-// debug and release CRTs, but it is a reasonable proxy.
-# if defined(_DEBUG)
-#  define LLVM_IS_DEBUG_BUILD 1
-# else
-#  define LLVM_IS_DEBUG_BUILD 0
-# endif
-#else
-// Otherwise, for an unknown compiler, assume this is an optimized build.
-# define LLVM_IS_DEBUG_BUILD 0
-#endif
-
 namespace {
 class VersionPrinter {
 public:

--- a/llvm/lib/Support/CommandLine.cpp
+++ b/llvm/lib/Support/CommandLine.cpp
@@ -2760,10 +2760,12 @@ ArrayRef<StringRef> cl::CompilerBuildConfig = {
 
 // Utility function for printing the build config.
 void cl::printBuildConfig(raw_ostream &OS) {
+#if LLVM_VERSION_PRINTER_SHOW_BUILD_CONFIG
   OS << "Build config: ";
   llvm::interleaveComma(cl::CompilerBuildConfig, OS,
                         [&OS](const StringRef &Option) { OS << Option; });
   OS << '\n';
+#endif
 }
 
 /// Utility function for printing version number.

--- a/llvm/lib/Support/CommandLine.cpp
+++ b/llvm/lib/Support/CommandLine.cpp
@@ -2734,6 +2734,38 @@ void cl::PrintHelpMessage(bool Hidden, bool Categorized) {
     CommonOptions->CategorizedHiddenPrinter.printHelp();
 }
 
+ArrayRef<StringRef> cl::CompilerBuildConfig = {
+#if LLVM_IS_DEBUG_BUILD
+    "+unoptimized",
+#endif
+#ifndef NDEBUG
+    "+assertions",
+#endif
+#ifdef EXPENSIVE_CHECKS
+    "+expensive-checks",
+#endif
+#if __has_feature(address_sanitizer)
+    "+asan",
+#endif
+#if __has_feature(undefined_behavior_sanitizer)
+    "+ubsan",
+#endif
+#if __has_feature(memory_sanitizer)
+    "+msan",
+#endif
+#if __has_feature(dataflow_sanitizer)
+    "+dfsan",
+#endif
+};
+
+// Utility function for printing the build config.
+void cl::printBuildConfig(raw_ostream &OS) {
+  OS << "Build config: ";
+  llvm::interleaveComma(cl::CompilerBuildConfig, OS,
+                        [&OS](const StringRef &Option) { OS << Option; });
+  OS << '\n';
+}
+
 /// Utility function for printing version number.
 void cl::PrintVersionMessage() {
   CommonOptions->VersionPrinterInstance.print(CommonOptions->ExtraVersionPrinters);

--- a/llvm/lib/Support/CommandLine.cpp
+++ b/llvm/lib/Support/CommandLine.cpp
@@ -2762,8 +2762,7 @@ ArrayRef<StringRef> cl::CompilerBuildConfig = {
 void cl::printBuildConfig(raw_ostream &OS) {
 #if LLVM_VERSION_PRINTER_SHOW_BUILD_CONFIG
   OS << "Build config: ";
-  llvm::interleaveComma(cl::CompilerBuildConfig, OS,
-                        [&OS](const StringRef &Option) { OS << Option; });
+  llvm::interleaveComma(cl::CompilerBuildConfig, OS);
   OS << '\n';
 #endif
 }

--- a/llvm/lib/Support/CommandLine.cpp
+++ b/llvm/lib/Support/CommandLine.cpp
@@ -2739,7 +2739,7 @@ ArrayRef<StringRef> cl::getCompilerBuildConfig() {
       // Placeholder to ensure the array always has elements, since it's an
       // error to have a zero-sized array. Slice this off before returning.
       "",
-      // Actual compiler build config feature list:
+  // Actual compiler build config feature list:
 #if LLVM_IS_DEBUG_BUILD
       "+unoptimized",
 #endif

--- a/llvm/lib/Support/CommandLine.cpp
+++ b/llvm/lib/Support/CommandLine.cpp
@@ -2506,6 +2506,28 @@ public:
 
 } // End anonymous namespace
 
+#if defined(__GNUC__)
+// GCC and GCC-compatible compilers define __OPTIMIZE__ when optimizations are
+// enabled.
+# if defined(__OPTIMIZE__)
+#  define LLVM_IS_DEBUG_BUILD 0
+# else
+#  define LLVM_IS_DEBUG_BUILD 1
+# endif
+#elif defined(_MSC_VER)
+// MSVC doesn't have a predefined macro indicating if optimizations are enabled.
+// Use _DEBUG instead. This macro actually corresponds to the choice between
+// debug and release CRTs, but it is a reasonable proxy.
+# if defined(_DEBUG)
+#  define LLVM_IS_DEBUG_BUILD 1
+# else
+#  define LLVM_IS_DEBUG_BUILD 0
+# endif
+#else
+// Otherwise, for an unknown compiler, assume this is an optimized build.
+# define LLVM_IS_DEBUG_BUILD 0
+#endif
+
 namespace {
 class VersionPrinter {
 public:

--- a/llvm/lib/Support/CommandLine.cpp
+++ b/llvm/lib/Support/CommandLine.cpp
@@ -2736,6 +2736,10 @@ void cl::PrintHelpMessage(bool Hidden, bool Categorized) {
 
 ArrayRef<StringRef> cl::getCompilerBuildConfig() {
   static const StringRef Config[] = {
+      // Placeholder to ensure the array always has elements, since it's an
+      // error to have a zero-sized array. Slice this off before returning.
+      "",
+      // Actual compiler build config feature list:
 #if LLVM_IS_DEBUG_BUILD
       "+unoptimized",
 #endif
@@ -2764,7 +2768,7 @@ ArrayRef<StringRef> cl::getCompilerBuildConfig() {
       "+ubsan",
 #endif
   };
-  return Config;
+  return ArrayRef(Config).drop_front(1);
 }
 
 // Utility function for printing the build config.

--- a/llvm/lib/Support/CommandLine.cpp
+++ b/llvm/lib/Support/CommandLine.cpp
@@ -2734,35 +2734,44 @@ void cl::PrintHelpMessage(bool Hidden, bool Categorized) {
     CommonOptions->CategorizedHiddenPrinter.printHelp();
 }
 
-ArrayRef<StringRef> cl::CompilerBuildConfig = {
+ArrayRef<StringRef> cl::getCompilerBuildConfig() {
+  static const StringRef Config[] = {
 #if LLVM_IS_DEBUG_BUILD
-    "+unoptimized",
+      "+unoptimized",
 #endif
 #ifndef NDEBUG
-    "+assertions",
+      "+assertions",
 #endif
 #ifdef EXPENSIVE_CHECKS
-    "+expensive-checks",
+      "+expensive-checks",
 #endif
 #if __has_feature(address_sanitizer)
-    "+asan",
-#endif
-#if __has_feature(undefined_behavior_sanitizer)
-    "+ubsan",
-#endif
-#if __has_feature(memory_sanitizer)
-    "+msan",
+      "+asan",
 #endif
 #if __has_feature(dataflow_sanitizer)
-    "+dfsan",
+      "+dfsan",
 #endif
-};
+#if __has_feature(hwaddress_sanitizer)
+      "+hwasan",
+#endif
+#if __has_feature(memory_sanitizer)
+      "+msan",
+#endif
+#if __has_feature(thread_sanitizer)
+      "+tsan",
+#endif
+#if __has_feature(undefined_behavior_sanitizer)
+      "+ubsan",
+#endif
+  };
+  return Config;
+}
 
 // Utility function for printing the build config.
 void cl::printBuildConfig(raw_ostream &OS) {
 #if LLVM_VERSION_PRINTER_SHOW_BUILD_CONFIG
   OS << "Build config: ";
-  llvm::interleaveComma(cl::CompilerBuildConfig, OS);
+  llvm::interleaveComma(cl::getCompilerBuildConfig(), OS);
   OS << '\n';
 #endif
 }


### PR DESCRIPTION
It's useful to have some significant build options visible in the version when investigating problems with a specific compiler artifact. This makes it easy to see if assertions, expensive checks, sanitizers, etc. are enabled when checking a compiler version.

Example output:
```
clang version 19.0.0git (git@github.com:apple/llvm-project.git b4db1d4e5ceadcd8c0e0c010b36cdc7ae68ba236)
Target: x86_64-apple-darwin24.0.0
Thread model: posix
InstalledDir: /Users/cassie/Development/apple-llvm-project/build/bin
Build configuration: +assertions, +asan, +ubsan
```

Discussion thread: https://discourse.llvm.org/t/rfc-printing-more-build-config-in-clang-version/78112