### PR TITLE
[libc++] Fix UB in filesystem::__copy for non-existent destination.

### DIFF
--- a/libcxx/src/filesystem/operations.cpp
+++ b/libcxx/src/filesystem/operations.cpp
@@ -109,20 +109,20 @@ void __copy(const path& from, const path& to, copy_options options, error_code* 
   const bool sym_status2 = bool(options & copy_options::copy_symlinks);
 
   error_code m_ec1;
-  StatT f_st = {};
+  StatT f_st;
   const file_status f =
       sym_status || sym_status2 ? detail::posix_lstat(from, f_st, &m_ec1) : detail::posix_stat(from, f_st, &m_ec1);
   if (m_ec1)
     return err.report(m_ec1);
 
-  StatT t_st          = {};
+  StatT t_st;
   const file_status t = sym_status ? detail::posix_lstat(to, t_st, &m_ec1) : detail::posix_stat(to, t_st, &m_ec1);
 
   if (not status_known(t))
     return err.report(m_ec1);
 
   if (!exists(f) || is_other(f) || is_other(t) || (is_directory(f) && is_regular_file(t)) ||
-      detail::stat_equivalent(f_st, t_st)) {
+      (exists(t) && detail::stat_equivalent(f_st, t_st))) {
     return err.report(errc::function_not_supported);
   }
 


### PR DESCRIPTION
lstat/stat/fstat has no guarantee whether `struct stat` buffer is changed or not on failure. `filesystem::__copy` function assumes, that `struct stat` buffer is not updated on lstat/stat/fstat failure, which is not true.

It appears that for non-existing destination `detail::posix_lstat(to, t_st, &m_ec1)` returns failure indicator and overwrites `struct stat` buffer with garbage values, which accidentally equal to the `f_st` from stack internals from the previous `detail::posix_lstat(from, f_st, &m_ec1)` call.

`file_type::not_found` is a known status, so check against `if (not status_known(t))` is passed and execution continues further. Then `__copy` function returns `errc::function_not_supported`, because stats are accidentally equivalent, which is a mistake.

Before checking for `detail::stat_equivalent`, need to make sure, that lstat/stat/fstat functions returned success.

As soon as `f_st` and `t_st` access without checking for the lstat/stat/fstat success indicator is an UB, it is not needed to zero-initialize them.