### PR TITLE
[mlir][EmitC] Add custom assembly format to constant and variable ops

### DIFF
--- a/mlir/include/mlir/Dialect/EmitC/IR/EmitC.td
+++ b/mlir/include/mlir/Dialect/EmitC/IR/EmitC.td
@@ -344,16 +344,17 @@ def EmitC_ConstantOp : EmitC_Op<"constant", [ConstantLike]> {
 
     ```mlir
     // Integer constant
-    %0 = "emitc.constant"(){value = 42 : i32} : () -> i32
+    %0 = emitc.constant(42 : i32) : i32
 
-    // Constant emitted as `char = CHAR_MIN;`
-    %1 = "emitc.constant"() {value = #emitc.opaque<"CHAR_MIN">}
-      : () -> !emitc.opaque<"char">
+    // Constant emitted as `char c = CHAR_MIN;`
+    %1 = emitc.constant(#emitc.opaque<"CHAR_MIN">) : !emitc.opaque<"char">
     ```
   }];
 
   let arguments = (ins EmitC_OpaqueOrTypedAttr:$value);
   let results = (outs AnyType);
+
+  let assemblyFormat = "`(` $value `)` attr-dict `:` type(results)";
 
   let hasFolder = 1;
   let hasVerifier = 1;
@@ -988,19 +989,19 @@ def EmitC_VariableOp : EmitC_Op<"variable", []> {
 
     ```mlir
     // Integer variable
-    %0 = "emitc.variable"(){value = 42 : i32} : () -> i32
+    %0 = emitc.variable(42 : i32) : i32
 
-    // Variable emitted as `int32_t* = NULL;`
-    %1 = "emitc.variable"() {value = #emitc.opaque<"NULL">} 
-      : () -> !emitc.ptr<!emitc.opaque<"int32_t">>
+    // Variable emitted as `int32_t* p = NULL;`
+    %1 = emitc.variable(#emitc.opaque<"NULL">)
+      : !emitc.ptr<!emitc.opaque<"int32_t">>
     ```
 
     Since folding is not supported, it can be used with pointers.
     As an example, it is valid to create pointers to `variable` operations
     by using `apply` operations and pass these to a `call` operation.
     ```mlir
-    %0 = "emitc.variable"() {value = 0 : i32} : () -> i32
-    %1 = "emitc.variable"() {value = 0 : i32} : () -> i32
+    %0 = emitc.variable(0 : i32) : i32
+    %1 = emitc.variable(0 : i32) : i32
     %2 = emitc.apply "&"(%0) : (i32) -> !emitc.ptr<i32>
     %3 = emitc.apply "&"(%1) : (i32) -> !emitc.ptr<i32>
     emitc.call_opaque "write"(%2, %3)
@@ -1011,6 +1012,7 @@ def EmitC_VariableOp : EmitC_Op<"variable", []> {
   let arguments = (ins EmitC_OpaqueOrTypedAttr:$value);
   let results = (outs AnyType);
 
+  let assemblyFormat = "`(` $value `)` attr-dict `:` type(results)";
   let hasVerifier = 1;
 }
 
@@ -1060,7 +1062,7 @@ def EmitC_AssignOp : EmitC_Op<"assign", []> {
 
     ```mlir
     // Integer variable
-    %0 = "emitc.variable"(){value = 42 : i32} : () -> i32
+    %0 = emitc.variable(42 : i32) : i32
     %1 = emitc.call_opaque "foo"() : () -> (i32)
 
     // Assign emitted as `... = ...;`

--- a/mlir/test/Conversion/ArithToEmitC/arith-to-emitc.mlir
+++ b/mlir/test/Conversion/ArithToEmitC/arith-to-emitc.mlir
@@ -2,20 +2,15 @@
 
 // CHECK-LABEL: arith_constants
 func.func @arith_constants() {
-  // CHECK: emitc.constant
-  // CHECK-SAME: value = 0 : index
+  // CHECK: emitc.constant(0 : index)
   %c_index = arith.constant 0 : index
-  // CHECK: emitc.constant
-  // CHECK-SAME: value = 0 : i32
+  // CHECK: emitc.constant(0 : i32)
   %c_signless_int_32 = arith.constant 0 : i32
-  // CHECK: emitc.constant
-  // CHECK-SAME: value = 0.{{0+}}e+00 : f32
+  // CHECK: emitc.constant(0.{{0+}}e+00 : f32)
   %c_float_32 = arith.constant 0.0 : f32
-  // CHECK: emitc.constant
-  // CHECK-SAME: value = dense<0> : tensor<i32>
+  // CHECK: emitc.constant(dense<0> : tensor<i32>)
   %c_tensor_single_value = arith.constant dense<0> : tensor<i32>
-  // CHECK: emitc.constant
-  // CHECK-SAME: value{{.*}}[1, 2], [-3, 9], [0, 0], [2, -1]{{.*}}tensor<4x2xi64>
+  // CHECK: emitc.constant({{.*}}[1, 2], [-3, 9], [0, 0], [2, -1]{{.*}}tensor<4x2xi64>)
   %c_tensor_value = arith.constant dense<[[1, 2], [-3, 9], [0, 0], [2, -1]]> : tensor<4x2xi64>
   return
 }

--- a/mlir/test/Conversion/MemRefToEmitC/memref-to-emitc.mlir
+++ b/mlir/test/Conversion/MemRefToEmitC/memref-to-emitc.mlir
@@ -3,7 +3,7 @@
 // CHECK-LABEL: memref_store
 // CHECK-SAME:  %[[v:.*]]: f32, %[[i:.*]]: index, %[[j:.*]]: index
 func.func @memref_store(%v : f32, %i: index, %j: index) {
-  // CHECK: %[[ALLOCA:.*]] = "emitc.variable"() <{value = #emitc.opaque<"">}> : () -> !emitc.array<4x8xf32>
+  // CHECK: %[[ALLOCA:.*]] = emitc.variable(#emitc.opaque<"">) : !emitc.array<4x8xf32>
   %0 = memref.alloca() : memref<4x8xf32>
 
   // CHECK: %[[SUBSCRIPT:.*]] = emitc.subscript %[[ALLOCA]][%[[i]], %[[j]]] : (!emitc.array<4x8xf32>, index, index) -> f32
@@ -16,11 +16,11 @@ func.func @memref_store(%v : f32, %i: index, %j: index) {
 // CHECK-LABEL: memref_load
 // CHECK-SAME:  %[[i:.*]]: index, %[[j:.*]]: index
 func.func @memref_load(%i: index, %j: index) -> f32 {
-  // CHECK: %[[ALLOCA:.*]] = "emitc.variable"() <{value = #emitc.opaque<"">}> : () -> !emitc.array<4x8xf32>
+  // CHECK: %[[ALLOCA:.*]] = emitc.variable(#emitc.opaque<"">) : !emitc.array<4x8xf32>
   %0 = memref.alloca() : memref<4x8xf32>
 
   // CHECK: %[[LOAD:.*]] = emitc.subscript %[[ALLOCA]][%[[i]], %[[j]]] : (!emitc.array<4x8xf32>, index, index) -> f32
-  // CHECK: %[[VAR:.*]] = "emitc.variable"() <{value = #emitc.opaque<"">}> : () -> f32
+  // CHECK: %[[VAR:.*]] = emitc.variable(#emitc.opaque<"">) : f32
   // CHECK: emitc.assign %[[LOAD]] : f32 to %[[VAR]] : f32
   %1 = memref.load %0[%i, %j] : memref<4x8xf32>
   // CHECK: return %[[VAR]] : f32

--- a/mlir/test/Conversion/SCFToEmitC/for.mlir
+++ b/mlir/test/Conversion/SCFToEmitC/for.mlir
@@ -47,10 +47,10 @@ func.func @for_yield(%arg0 : index, %arg1 : index, %arg2 : index) -> (f32, f32) 
 // CHECK-SAME:      %[[VAL_0:.*]]: index, %[[VAL_1:.*]]: index, %[[VAL_2:.*]]: index) -> (f32, f32) {
 // CHECK-NEXT:    %[[VAL_3:.*]] = arith.constant 0.000000e+00 : f32
 // CHECK-NEXT:    %[[VAL_4:.*]] = arith.constant 1.000000e+00 : f32
-// CHECK-NEXT:    %[[VAL_5:.*]] = "emitc.variable"() <{value = #emitc.opaque<"">}> : () -> f32
-// CHECK-NEXT:    %[[VAL_6:.*]] = "emitc.variable"() <{value = #emitc.opaque<"">}> : () -> f32
-// CHECK-NEXT:    %[[VAL_7:.*]] = "emitc.variable"() <{value = #emitc.opaque<"">}> : () -> f32
-// CHECK-NEXT:    %[[VAL_8:.*]] = "emitc.variable"() <{value = #emitc.opaque<"">}> : () -> f32
+// CHECK-NEXT:    %[[VAL_5:.*]] = emitc.variable(#emitc.opaque<"">) : f32
+// CHECK-NEXT:    %[[VAL_6:.*]] = emitc.variable(#emitc.opaque<"">) : f32
+// CHECK-NEXT:    %[[VAL_7:.*]] = emitc.variable(#emitc.opaque<"">) : f32
+// CHECK-NEXT:    %[[VAL_8:.*]] = emitc.variable(#emitc.opaque<"">) : f32
 // CHECK-NEXT:    emitc.assign %[[VAL_3]] : f32 to %[[VAL_7]] : f32
 // CHECK-NEXT:    emitc.assign %[[VAL_4]] : f32 to %[[VAL_8]] : f32
 // CHECK-NEXT:    emitc.for %[[VAL_9:.*]] = %[[VAL_0]] to %[[VAL_1]] step %[[VAL_2]] {
@@ -77,12 +77,12 @@ func.func @nested_for_yield(%arg0 : index, %arg1 : index, %arg2 : index) -> f32 
 // CHECK-LABEL: func.func @nested_for_yield(
 // CHECK-SAME:      %[[VAL_0:.*]]: index, %[[VAL_1:.*]]: index, %[[VAL_2:.*]]: index) -> f32 {
 // CHECK-NEXT:    %[[VAL_3:.*]] = arith.constant 1.000000e+00 : f32
-// CHECK-NEXT:    %[[VAL_4:.*]] = "emitc.variable"() <{value = #emitc.opaque<"">}> : () -> f32
-// CHECK-NEXT:    %[[VAL_5:.*]] = "emitc.variable"() <{value = #emitc.opaque<"">}> : () -> f32
+// CHECK-NEXT:    %[[VAL_4:.*]] = emitc.variable(#emitc.opaque<"">) : f32
+// CHECK-NEXT:    %[[VAL_5:.*]] = emitc.variable(#emitc.opaque<"">) : f32
 // CHECK-NEXT:    emitc.assign %[[VAL_3]] : f32 to %[[VAL_5]] : f32
 // CHECK-NEXT:    emitc.for %[[VAL_6:.*]] = %[[VAL_0]] to %[[VAL_1]] step %[[VAL_2]] {
-// CHECK-NEXT:      %[[VAL_7:.*]] = "emitc.variable"() <{value = #emitc.opaque<"">}> : () -> f32
-// CHECK-NEXT:      %[[VAL_8:.*]] = "emitc.variable"() <{value = #emitc.opaque<"">}> : () -> f32
+// CHECK-NEXT:      %[[VAL_7:.*]] = emitc.variable(#emitc.opaque<"">) : f32
+// CHECK-NEXT:      %[[VAL_8:.*]] = emitc.variable(#emitc.opaque<"">) : f32
 // CHECK-NEXT:      emitc.assign %[[VAL_5]] : f32 to %[[VAL_8]] : f32
 // CHECK-NEXT:      emitc.for %[[VAL_9:.*]] = %[[VAL_0]] to %[[VAL_1]] step %[[VAL_2]] {
 // CHECK-NEXT:        %[[VAL_10:.*]] = arith.addf %[[VAL_8]], %[[VAL_8]] : f32

--- a/mlir/test/Conversion/SCFToEmitC/if.mlir
+++ b/mlir/test/Conversion/SCFToEmitC/if.mlir
@@ -53,8 +53,8 @@ func.func @test_if_yield(%arg0: i1, %arg1: f32) {
 // CHECK-SAME:                           %[[VAL_0:.*]]: i1,
 // CHECK-SAME:                           %[[VAL_1:.*]]: f32) {
 // CHECK-NEXT:    %[[VAL_2:.*]] = arith.constant 0 : i8
-// CHECK-NEXT:    %[[VAL_3:.*]] = "emitc.variable"() <{value = #emitc.opaque<"">}> : () -> i32
-// CHECK-NEXT:    %[[VAL_4:.*]] = "emitc.variable"() <{value = #emitc.opaque<"">}> : () -> f64
+// CHECK-NEXT:    %[[VAL_3:.*]] = emitc.variable(#emitc.opaque<"">) : i32
+// CHECK-NEXT:    %[[VAL_4:.*]] = emitc.variable(#emitc.opaque<"">) : f64
 // CHECK-NEXT:    emitc.if %[[VAL_0]] {
 // CHECK-NEXT:      %[[VAL_5:.*]] = emitc.call_opaque "func_true_1"(%[[VAL_1]]) : (f32) -> i32
 // CHECK-NEXT:      %[[VAL_6:.*]] = emitc.call_opaque "func_true_2"(%[[VAL_1]]) : (f32) -> f64

--- a/mlir/test/Dialect/EmitC/invalid_ops.mlir
+++ b/mlir/test/Dialect/EmitC/invalid_ops.mlir
@@ -2,7 +2,7 @@
 
 func.func @const_attribute_str() {
     // expected-error @+1 {{'emitc.constant' op string attributes are not supported, use #emitc.opaque instead}}                 
-    %c0 = "emitc.constant"(){value = "NULL"} : () -> !emitc.ptr<i32>
+    %c0 = emitc.constant("NULL") : !emitc.ptr<i32>
     return
 }
 
@@ -10,7 +10,7 @@ func.func @const_attribute_str() {
 
 func.func @const_attribute_return_type_1() {
     // expected-error @+1 {{'emitc.constant' op requires attribute to either be an #emitc.opaque attribute or it's type ('i64') to match the op's result type ('i32')}}
-    %c0 = "emitc.constant"(){value = 42: i64} : () -> i32
+    %c0 = emitc.constant(42: i64) : i32
     return
 }
 
@@ -18,7 +18,7 @@ func.func @const_attribute_return_type_1() {
 
 func.func @const_attribute_return_type_2() {
     // expected-error @+1 {{'emitc.constant' op attribute 'value' failed to satisfy constraint: An opaque attribute or TypedAttr instance}}
-    %c0 = "emitc.constant"(){value = unit} : () -> i32
+    %c0 = emitc.constant(unit) : i32
     return
 }
 
@@ -26,7 +26,7 @@ func.func @const_attribute_return_type_2() {
 
 func.func @empty_constant() {
     // expected-error @+1 {{'emitc.constant' op value must not be empty}}
-    %c0 = "emitc.constant"(){value = #emitc.opaque<"">} : () -> i32
+    %c0 = emitc.constant(#emitc.opaque<"">) : i32
     return
 }
 
@@ -105,7 +105,7 @@ func.func @illegal_operator(%arg : i32) {
 // -----
 
 func.func @illegal_operand() {
-    %1 = "emitc.constant"(){value = 42: i32} : () -> i32
+    %1 = emitc.constant(42: i32) : i32
     // expected-error @+1 {{'emitc.apply' op cannot apply to constant}}
     %2 = emitc.apply "&"(%1) : (i32) -> !emitc.ptr<i32>
     return
@@ -115,7 +115,7 @@ func.func @illegal_operand() {
 
 func.func @var_attribute_return_type_1() {
     // expected-error @+1 {{'emitc.variable' op requires attribute to either be an #emitc.opaque attribute or it's type ('i64') to match the op's result type ('i32')}}
-    %c0 = "emitc.variable"(){value = 42: i64} : () -> i32
+    %c0 = emitc.variable(42: i64) : i32
     return
 }
 
@@ -123,7 +123,7 @@ func.func @var_attribute_return_type_1() {
 
 func.func @var_attribute_return_type_2() {
     // expected-error @+1 {{'emitc.variable' op attribute 'value' failed to satisfy constraint: An opaque attribute or TypedAttr instance}}
-    %c0 = "emitc.variable"(){value = unit} : () -> i32
+    %c0 = emitc.variable(unit) : i32
     return
 }
 
@@ -243,7 +243,7 @@ func.func @test_assign_to_non_variable(%arg1: f32, %arg2: f32) {
 // -----
 
 func.func @test_assign_type_mismatch(%arg1: f32) {
-  %v = "emitc.variable"() <{value = #emitc.opaque<"">}> : () -> i32
+  %v = emitc.variable(#emitc.opaque<"">) : i32
   // expected-error @+1 {{'emitc.assign' op requires value's type ('f32') to match variable's type ('i32')}}
   emitc.assign %arg1 : f32 to %v : i32
   return
@@ -252,7 +252,7 @@ func.func @test_assign_type_mismatch(%arg1: f32) {
 // -----
 
 func.func @test_assign_to_array(%arg1: !emitc.array<4xi32>) {
-  %v = "emitc.variable"() <{value = #emitc.opaque<"">}> : () -> !emitc.array<4xi32>
+  %v = emitc.variable(#emitc.opaque<"">) : !emitc.array<4xi32>
   // expected-error @+1 {{'emitc.assign' op cannot assign to array type}}
   emitc.assign %arg1 : !emitc.array<4xi32> to %v : !emitc.array<4xi32>
   return
@@ -263,7 +263,7 @@ func.func @test_assign_to_array(%arg1: !emitc.array<4xi32>) {
 func.func @test_expression_no_yield() -> i32 {
   // expected-error @+1 {{'emitc.expression' op must yield a value at termination}}
   %r = emitc.expression : i32 {
-    %c7 = "emitc.constant"(){value = 7 : i32} : () -> i32
+    %c7 = emitc.constant(7 : i32) : i32
   }
   return %r : i32
 }
@@ -273,7 +273,7 @@ func.func @test_expression_no_yield() -> i32 {
 func.func @test_expression_illegal_op(%arg0 : i1) -> i32 {
   // expected-error @+1 {{'emitc.expression' op contains an unsupported operation}}
   %r = emitc.expression : i32 {
-    %x = "emitc.variable"() <{value = #emitc.opaque<"">}> : () -> i32
+    %x = emitc.variable(#emitc.opaque<"">) : i32
     emitc.yield %x : i32
   }
   return %r : i32

--- a/mlir/test/Dialect/EmitC/invalid_types.mlir
+++ b/mlir/test/Dialect/EmitC/invalid_types.mlir
@@ -2,14 +2,14 @@
 
 func.func @illegal_opaque_type_1() {
     // expected-error @+1 {{expected non empty string in !emitc.opaque type}}
-    %1 = "emitc.variable"(){value = "42" : !emitc.opaque<"">} : () -> !emitc.opaque<"mytype">
+    %1 = emitc.variable("42" : !emitc.opaque<"">) : !emitc.opaque<"mytype">
 }
 
 // -----
 
 func.func @illegal_opaque_type_2() {
     // expected-error @+1 {{pointer not allowed as outer type with !emitc.opaque, use !emitc.ptr instead}}
-    %1 = "emitc.variable"(){value = "nullptr" : !emitc.opaque<"int32_t*">} : () -> !emitc.opaque<"int32_t*">
+    %1 = emitc.variable("nullptr" : !emitc.opaque<"int32_t*">) : !emitc.opaque<"int32_t*">
 }
 
 // -----

--- a/mlir/test/Dialect/EmitC/ops.mlir
+++ b/mlir/test/Dialect/EmitC/ops.mlir
@@ -40,7 +40,7 @@ func.func @cast(%arg0: i32) {
 }
 
 func.func @c() {
-  %1 = "emitc.constant"(){value = 42 : i32} : () -> i32
+  %1 = emitc.constant(42 : i32) : i32
   return
 }
 
@@ -170,13 +170,13 @@ func.func @test_if_else(%arg0: i1, %arg1: f32) {
 }
 
 func.func @test_assign(%arg1: f32) {
-  %v = "emitc.variable"() <{value = #emitc.opaque<"">}> : () -> f32
+  %v = emitc.variable(#emitc.opaque<"">) : f32
   emitc.assign %arg1 : f32 to %v : f32
   return
 }
 
 func.func @test_expression(%arg0: i32, %arg1: i32, %arg2: i32, %arg3: f32, %arg4: f32) -> i32 {
-  %c7 = "emitc.constant"() {value = 7 : i32} : () -> i32
+  %c7 = emitc.constant(7 : i32) : i32
   %q = emitc.expression : i32 {
     %a = emitc.rem %arg1, %c7 : (i32, i32) -> i32
     emitc.yield %a : i32

--- a/mlir/test/Dialect/EmitC/transforms.mlir
+++ b/mlir/test/Dialect/EmitC/transforms.mlir
@@ -2,7 +2,7 @@
 
 // CHECK-LABEL: func.func @single_expression(
 // CHECK-SAME:                               %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i32, %[[VAL_3:.*]]: i32) -> i1 {
-// CHECK:           %[[VAL_4:.*]] = "emitc.constant"() <{value = 42 : i32}> : () -> i32
+// CHECK:           %[[VAL_4:.*]] = emitc.constant(42 : i32) : i32
 // CHECK:           %[[VAL_5:.*]] = emitc.expression : i1 {
 // CHECK:             %[[VAL_6:.*]] = emitc.mul %[[VAL_0]], %[[VAL_4]] : (i32, i32) -> i32
 // CHECK:             %[[VAL_7:.*]] = emitc.sub %[[VAL_6]], %[[VAL_2]] : (i32, i32) -> i32
@@ -13,7 +13,7 @@
 // CHECK:       }
 
 func.func @single_expression(%arg0: i32, %arg1: i32, %arg2: i32, %arg3: i32) -> i1 {
-  %c42 = "emitc.constant"(){value = 42 : i32} : () -> i32
+  %c42 = emitc.constant (42 : i32) : i32
   %a = emitc.mul %arg0, %c42 : (i32, i32) -> i32
   %b = emitc.sub %a, %arg2 : (i32, i32) -> i32
   %c = emitc.cmp lt, %b, %arg3 :(i32, i32) -> i1

--- a/mlir/test/Target/Cpp/call.mlir
+++ b/mlir/test/Target/Cpp/call.mlir
@@ -18,7 +18,7 @@ func.func @emitc_call_opaque() {
 
 
 func.func @emitc_call_opaque_two_results() {
-  %0 = "emitc.constant"() <{value = 0 : index}> : () -> index
+  %0 = emitc.constant(0 : index) : index
   %1:2 = emitc.call_opaque "two_results" () : () -> (i32, i32)
   return
 }

--- a/mlir/test/Target/Cpp/const.mlir
+++ b/mlir/test/Target/Cpp/const.mlir
@@ -2,18 +2,18 @@
 // RUN: mlir-translate -mlir-to-cpp -declare-variables-at-top %s | FileCheck %s -check-prefix=CPP-DECLTOP
 
 func.func @emitc_constant() {
-  %c0 = "emitc.constant"(){value = #emitc.opaque<"INT_MAX">} : () -> i32
-  %c1 = "emitc.constant"(){value = 42 : i32} : () -> i32
-  %c2 = "emitc.constant"(){value = -1 : i32} : () -> i32
-  %c3 = "emitc.constant"(){value = -1 : si8} : () -> si8
-  %c4 = "emitc.constant"(){value = 255 : ui8} : () -> ui8
-  %c5 = "emitc.constant"(){value = #emitc.opaque<"CHAR_MIN">} : () -> !emitc.opaque<"char">
-  %c6 = "emitc.constant"(){value = 2 : index} : () -> index
-  %c7 = "emitc.constant"(){value = 2.0 : f32} : () -> f32
-  %f64 = "emitc.constant"(){value = 4.0 : f64} : () -> f64
-  %c8 = "emitc.constant"(){value = dense<0> : tensor<i32>} : () -> tensor<i32>
-  %c9 = "emitc.constant"(){value = dense<[0, 1]> : tensor<2xindex>} : () -> tensor<2xindex>
-  %c10 = "emitc.constant"(){value = dense<[[0.0, 1.0], [2.0, 3.0]]> : tensor<2x2xf32>} : () -> tensor<2x2xf32>
+  %c0 = emitc.constant(#emitc.opaque<"INT_MAX">) : i32
+  %c1 = emitc.constant(42 : i32) : i32
+  %c2 = emitc.constant(-1 : i32) : i32
+  %c3 = emitc.constant(-1 : si8) : si8
+  %c4 = emitc.constant(255 : ui8) : ui8
+  %c5 = emitc.constant(#emitc.opaque<"CHAR_MIN">) : !emitc.opaque<"char">
+  %c6 = emitc.constant(2 : index) : index
+  %c7 = emitc.constant(2.0 : f32) : f32
+  %f64 = emitc.constant(4.0 : f64) : f64
+  %c8 = emitc.constant(dense<0> : tensor<i32>) : tensor<i32>
+  %c9 = emitc.constant(dense<[0, 1]> : tensor<2xindex>) : tensor<2xindex>
+  %c10 = emitc.constant(dense<[[0.0, 1.0], [2.0, 3.0]]> : tensor<2x2xf32>) : tensor<2x2xf32>
   return
 }
 // CPP-DEFAULT: void emitc_constant() {

--- a/mlir/test/Target/Cpp/expressions.mlir
+++ b/mlir/test/Target/Cpp/expressions.mlir
@@ -34,7 +34,7 @@ func.func @single_use(%arg0: i32, %arg1: i32, %arg2: i32, %arg3: i32) -> i32 {
     %d = emitc.cmp lt, %c, %arg1 :(i32, i32) -> i1
     emitc.yield %d : i1
   }
-  %v = "emitc.variable"(){value = #emitc.opaque<"">} : () -> i32
+  %v = emitc.variable(#emitc.opaque<"">) : i32
   emitc.if %e {
     emitc.assign %arg0 : i32 to %v : i32
     emitc.yield
@@ -120,7 +120,7 @@ func.func @multiple_uses(%arg0: i32, %arg1: i32, %arg2: i32, %arg3: i32) -> i32 
     %d = emitc.cmp lt, %c, %arg1 :(i32, i32) -> i1
     emitc.yield %d : i1
   }
-  %v = "emitc.variable"(){value = #emitc.opaque<"">} : () -> i32
+  %v = emitc.variable(#emitc.opaque<"">) : i32
   emitc.if %e {
     emitc.assign %arg0 : i32 to %v : i32
     emitc.yield
@@ -128,7 +128,7 @@ func.func @multiple_uses(%arg0: i32, %arg1: i32, %arg2: i32, %arg3: i32) -> i32 
     emitc.assign %arg0 : i32 to %v : i32
     emitc.yield
   }
-  %q = "emitc.variable"(){value = #emitc.opaque<"">} : () -> i1
+  %q = emitc.variable(#emitc.opaque<"">) : i1
   emitc.assign %e : i1 to %q : i1
   return %v : i32
 }
@@ -175,7 +175,7 @@ func.func @different_expressions(%arg0: i32, %arg1: i32, %arg2: i32, %arg3: i32)
     %d = emitc.cmp lt, %c, %arg1 :(i32, i32) -> i1
     emitc.yield %d : i1
   }
-  %v = "emitc.variable"(){value = #emitc.opaque<"">} : () -> i32
+  %v = emitc.variable(#emitc.opaque<"">) : i32
   emitc.if %e3 {
     emitc.assign %arg0 : i32 to %v : i32
     emitc.yield

--- a/mlir/test/Target/Cpp/for.mlir
+++ b/mlir/test/Target/Cpp/for.mlir
@@ -33,17 +33,17 @@ func.func @test_for(%arg0 : index, %arg1 : index, %arg2 : index) {
 // CPP-DECLTOP-NEXT: return;
 
 func.func @test_for_yield() {
-  %start = "emitc.constant"() <{value = 0 : index}> : () -> index
-  %stop = "emitc.constant"() <{value = 10 : index}> : () -> index
-  %step = "emitc.constant"() <{value = 1 : index}> : () -> index
+  %start = emitc.constant(0 : index) : index
+  %stop = emitc.constant(10 : index) : index
+  %step = emitc.constant(1 : index) : index
 
-  %s0 = "emitc.constant"() <{value = 0 : i32}> : () -> i32
-  %p0 = "emitc.constant"() <{value = 1.0 : f32}> : () -> f32
+  %s0 = emitc.constant(0 : i32) : i32
+  %p0 = emitc.constant(1.0 : f32) : f32
 
-  %0 = "emitc.variable"() <{value = #emitc.opaque<"">}> : () -> i32
-  %1 = "emitc.variable"() <{value = #emitc.opaque<"">}> : () -> f32
-  %2 = "emitc.variable"() <{value = #emitc.opaque<"">}> : () -> i32
-  %3 = "emitc.variable"() <{value = #emitc.opaque<"">}> : () -> f32
+  %0 = emitc.variable(#emitc.opaque<"">) : i32
+  %1 = emitc.variable(#emitc.opaque<"">) : f32
+  %2 = emitc.variable(#emitc.opaque<"">) : i32
+  %3 = emitc.variable(#emitc.opaque<"">) : f32
   emitc.assign %s0 : i32 to %2 : i32
   emitc.assign %p0 : f32 to %3 : f32
   emitc.for %iter = %start to %stop step %step {
@@ -121,10 +121,10 @@ func.func @test_for_yield_2() {
   %s0 = emitc.literal "0" : i32
   %p0 = emitc.literal "M_PI" : f32
 
-  %0 = "emitc.variable"() <{value = #emitc.opaque<"">}> : () -> i32
-  %1 = "emitc.variable"() <{value = #emitc.opaque<"">}> : () -> f32
-  %2 = "emitc.variable"() <{value = #emitc.opaque<"">}> : () -> i32
-  %3 = "emitc.variable"() <{value = #emitc.opaque<"">}> : () -> f32
+  %0 = emitc.variable(#emitc.opaque<"">) : i32
+  %1 = emitc.variable(#emitc.opaque<"">) : f32
+  %2 = emitc.variable(#emitc.opaque<"">) : i32
+  %3 = emitc.variable(#emitc.opaque<"">) : f32
   emitc.assign %s0 : i32 to %2 : i32
   emitc.assign %p0 : f32 to %3 : f32
   emitc.for %iter = %start to %stop step %step {

--- a/mlir/test/Target/Cpp/if.mlir
+++ b/mlir/test/Target/Cpp/if.mlir
@@ -49,9 +49,9 @@ func.func @test_if_else(%arg0: i1, %arg1: f32) {
 
 
 func.func @test_if_yield(%arg0: i1, %arg1: f32) {
-  %0 = "emitc.constant"() <{value = 0 : i8}> : () -> i8
-  %x = "emitc.variable"() <{value = #emitc.opaque<"">}> : () -> i32
-  %y = "emitc.variable"() <{value = #emitc.opaque<"">}> : () -> f64
+  %0 = emitc.constant(0 : i8) : i8
+  %x = emitc.variable(#emitc.opaque<"">) : i32
+  %y = emitc.variable(#emitc.opaque<"">) : f64
   emitc.if %arg0 {
     %1 = emitc.call_opaque "func_true_1"(%arg1) : (f32) -> i32
     %2 = emitc.call_opaque "func_true_2"(%arg1) : (f32) -> f64

--- a/mlir/test/Target/Cpp/invalid.mlir
+++ b/mlir/test/Target/Cpp/invalid.mlir
@@ -82,6 +82,6 @@ func.func @array_as_result(%arg: !emitc.array<4xi8>) -> (!emitc.array<4xi8>) {
 // -----
 func.func @ptr_to_array() {
   // expected-error@+1 {{cannot emit pointer to array type '!emitc.ptr<!emitc.array<9xi16>>'}}
-  %v = "emitc.variable"(){value = #emitc.opaque<"NULL">} : () -> !emitc.ptr<!emitc.array<9xi16>>
+  %v = emitc.variable(#emitc.opaque<"NULL">) : !emitc.ptr<!emitc.array<9xi16>>
   return
 }

--- a/mlir/test/Target/Cpp/stdops.mlir
+++ b/mlir/test/Target/Cpp/stdops.mlir
@@ -40,7 +40,7 @@ func.func @std_call_two_results() {
 
 
 func.func @one_result() -> i32 {
-  %0 = "emitc.constant"() <{value = 0 : i32}> : () -> i32
+  %0 = emitc.constant(0 : i32) : i32
   return %0 : i32
 }
 // CPP-DEFAULT: int32_t one_result() {
@@ -54,8 +54,8 @@ func.func @one_result() -> i32 {
 
 
 func.func @two_results() -> (i32, f32) {
-  %0 = "emitc.constant"() <{value = 0 : i32}> : () -> i32
-  %1 = "emitc.constant"() <{value = 1.0 : f32}> : () -> f32
+  %0 = emitc.constant(0 : i32) : i32
+  %1 = emitc.constant(1.0 : f32) : f32
   return %0, %1 : i32, f32
 }
 // CPP-DEFAULT: std::tuple<int32_t, float> two_results() {

--- a/mlir/test/Target/Cpp/variable.mlir
+++ b/mlir/test/Target/Cpp/variable.mlir
@@ -2,15 +2,15 @@
 // RUN: mlir-translate -mlir-to-cpp -declare-variables-at-top %s | FileCheck %s -check-prefix=CPP-DECLTOP
 
 func.func @emitc_variable() {
-  %c0 = "emitc.variable"(){value = #emitc.opaque<"">} : () -> i32
-  %c1 = "emitc.variable"(){value = 42 : i32} : () -> i32
-  %c2 = "emitc.variable"(){value = -1 : i32} : () -> i32
-  %c3 = "emitc.variable"(){value = -1 : si8} : () -> si8
-  %c4 = "emitc.variable"(){value = 255 : ui8} : () -> ui8
-  %c5 = "emitc.variable"(){value = #emitc.opaque<"">} : () -> !emitc.ptr<i32>
-  %c6 = "emitc.variable"(){value = #emitc.opaque<"NULL">} : () -> !emitc.ptr<i32>
-  %c7 = "emitc.variable"(){value = #emitc.opaque<"">} : () -> !emitc.array<3x7xi32>
-  %c8 = "emitc.variable"(){value = #emitc.opaque<"">} : () -> !emitc.array<5x!emitc.ptr<i8>>
+  %c0 = emitc.variable(#emitc.opaque<"">) : i32
+  %c1 = emitc.variable(42 : i32) : i32
+  %c2 = emitc.variable(-1 : i32) : i32
+  %c3 = emitc.variable(-1 : si8) : si8
+  %c4 = emitc.variable(255 : ui8) : ui8
+  %c5 = emitc.variable(#emitc.opaque<"">) : !emitc.ptr<i32>
+  %c6 = emitc.variable(#emitc.opaque<"NULL">) : !emitc.ptr<i32>
+  %c7 = emitc.variable(#emitc.opaque<"">) : !emitc.array<3x7xi32>
+  %c8 = emitc.variable(#emitc.opaque<"">) : !emitc.array<5x!emitc.ptr<i8>>
   return
 }
 // CPP-DEFAULT: void emitc_variable() {


### PR DESCRIPTION
This mirrors the syntax for the `llvm.mlir.constant` operation.