### PR TITLE
[AMDGPU] Use mangling-agnostic form of IRBuilder::CreateIntrinsic. NFC.

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPUInstCombineIntrinsic.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUInstCombineIntrinsic.cpp
@@ -830,8 +830,8 @@ GCNTTIImpl::instCombineIntrinsic(InstCombiner &IC, IntrinsicInst &II) const {
     // fmed3((fpext X), (fpext Y), (fpext Z)) -> fpext (fmed3(X, Y, Z))
     if (matchFPExtFromF16(Src0, X) && matchFPExtFromF16(Src1, Y) &&
         matchFPExtFromF16(Src2, Z)) {
-      Value *NewCall = IC.Builder.CreateIntrinsic(IID, {X->getType()},
-                                                  {X, Y, Z}, &II, II.getName());
+      Value *NewCall = IC.Builder.CreateIntrinsic(X->getType(), IID, {X, Y, Z},
+                                                  &II, II.getName());
       return new FPExtInst(NewCall, II.getType());
     }
 
@@ -994,8 +994,8 @@ GCNTTIImpl::instCombineIntrinsic(InstCombiner &IC, IntrinsicInst &II) const {
       // %b32 = call i32 ballot.i32(...)
       // %b64 = zext i32 %b32 to i64
       Value *Call = IC.Builder.CreateZExt(
-          IC.Builder.CreateIntrinsic(Intrinsic::amdgcn_ballot,
-                                     {IC.Builder.getInt32Ty()},
+          IC.Builder.CreateIntrinsic(IC.Builder.getInt32Ty(),
+                                     Intrinsic::amdgcn_ballot,
                                      {II.getArgOperand(0)}),
           II.getType());
       Call->takeName(&II);

--- a/llvm/lib/Target/AMDGPU/AMDGPUTargetTransformInfo.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUTargetTransformInfo.cpp
@@ -1098,7 +1098,7 @@ Value *GCNTTIImpl::rewriteIntrinsicWithAddressSpace(IntrinsicInst *II,
       MaskOp = B.CreateTrunc(MaskOp, MaskTy);
     }
 
-    return B.CreateIntrinsic(Intrinsic::ptrmask, {NewV->getType(), MaskTy},
+    return B.CreateIntrinsic(NewV->getType(), Intrinsic::ptrmask,
                              {NewV, MaskOp});
   }
   case Intrinsic::amdgcn_flat_atomic_fadd:

--- a/llvm/lib/Target/AMDGPU/SIISelLowering.cpp
+++ b/llvm/lib/Target/AMDGPU/SIISelLowering.cpp
@@ -16401,8 +16401,9 @@ void SITargetLowering::emitExpandAtomicRMW(AtomicRMWInst *AI) const {
   Builder.CreateBr(CheckSharedBB);
 
   Builder.SetInsertPoint(CheckSharedBB);
-  CallInst *IsShared = Builder.CreateIntrinsic(Intrinsic::amdgcn_is_shared, {},
-                                               {Addr}, nullptr, "is.shared");
+  CallInst *IsShared =
+      Builder.CreateIntrinsic(Builder.getInt1Ty(), Intrinsic::amdgcn_is_shared,
+                              {Addr}, nullptr, "is.shared");
   Builder.CreateCondBr(IsShared, SharedBB, CheckPrivateBB);
 
   Builder.SetInsertPoint(SharedBB);
@@ -16412,8 +16413,9 @@ void SITargetLowering::emitExpandAtomicRMW(AtomicRMWInst *AI) const {
   Builder.CreateBr(PhiBB);
 
   Builder.SetInsertPoint(CheckPrivateBB);
-  CallInst *IsPrivate = Builder.CreateIntrinsic(
-      Intrinsic::amdgcn_is_private, {}, {Addr}, nullptr, "is.private");
+  CallInst *IsPrivate =
+      Builder.CreateIntrinsic(Builder.getInt1Ty(), Intrinsic::amdgcn_is_private,
+                              {Addr}, nullptr, "is.private");
   Builder.CreateCondBr(IsPrivate, PrivateBB, GlobalBB);
 
   Builder.SetInsertPoint(PrivateBB);


### PR DESCRIPTION
Use the form of CreateIntrinsic that takes an explicit return type and
works out the mangling based on that and the types of the arguments. The
advantage is that this still works if intrinsics are changed to have
type mangling, e.g. if readlane/readfirstlane/writelane are changed to
work on any type.

I changed all occurrences of CreateIntrinsic in the AMDGPU backend for
consistency. I think it works out neater in most (but perhaps not all)
cases.
