### PR TITLE
[APInt] Use a std::move() to avoid a copy in the loop in multiplicativeInverse.

### DIFF
--- a/llvm/lib/Support/APInt.cpp
+++ b/llvm/lib/Support/APInt.cpp
@@ -1249,7 +1249,7 @@ APInt APInt::multiplicativeInverse() const {
   APInt Factor = *this;
   APInt T;
   while (!(T = *this * Factor).isOne())
-    Factor *= 2 - T;
+    Factor *= 2 - std::move(T);
   return Factor;
 }
 


### PR DESCRIPTION
This allows the subtract to reuse the storage of T. T will be assigned over by the condition on the next iteration. I think assigning over a moved from value should be ok.