### PR TITLE
[LinkerWrapper] Do not include config files for device linking

### DIFF
--- a/clang/tools/clang-linker-wrapper/ClangLinkerWrapper.cpp
+++ b/clang/tools/clang-linker-wrapper/ClangLinkerWrapper.cpp
@@ -458,6 +458,7 @@ Expected<StringRef> clang(ArrayRef<StringRef> InputFiles, const ArgList &Args) {
   StringRef OptLevel = Args.getLastArgValue(OPT_opt_level, "O2");
   SmallVector<StringRef, 16> CmdArgs{
       *ClangPath,
+      "--no-default-config",
       "-o",
       *TempFileOrErr,
       Args.MakeArgString("--target=" + Triple.getTriple()),


### PR DESCRIPTION
Summary:
The device linking phase only wants to create the necessary commands to
emit the device binary. There were issues where the user's default
config file was being used and passing incompatible arguments to the
device compilation step. Simply disable this since we do not want any
additional arguments to these clang invocations.
