### PR TITLE
[libc] Temporary math macros fix

### DIFF
--- a/libc/cmake/modules/LLVMLibCCompileOptionRules.cmake
+++ b/libc/cmake/modules/LLVMLibCCompileOptionRules.cmake
@@ -43,6 +43,7 @@ function(_get_common_compile_options output_var flags)
     list(APPEND compile_options "-fpie")
 
     if(LLVM_LIBC_FULL_BUILD)
+      list(APPEND compile_options "-DLIBC_FULL_BUILD")
       # Only add -ffreestanding flag in full build mode.
       list(APPEND compile_options "-ffreestanding")
     endif()
@@ -126,6 +127,7 @@ function(_get_common_test_compile_options output_var c_test flags)
     list(APPEND compile_options "-fpie")
 
     if(LLVM_LIBC_FULL_BUILD)
+      list(APPEND compile_options "-DLIBC_FULL_BUILD")
       # Only add -ffreestanding flag in full build mode.
       list(APPEND compile_options "-ffreestanding")
       list(APPEND compile_options "-fno-exceptions")
@@ -178,5 +180,10 @@ function(_get_hermetic_test_compile_options output_var flags)
          -Wno-multi-gpu --cuda-path=${LIBC_CUDA_ROOT}
          -nogpulib -march=${LIBC_GPU_TARGET_ARCHITECTURE} -fno-use-cxa-atexit)
   endif()
+
+  if(LLVM_LIBC_FULL_BUILD)
+    list(APPEND compile_options "-DLIBC_FULL_BUILD")
+  endif()
+  
   set(${output_var} ${compile_options} PARENT_SCOPE)
 endfunction()

--- a/libc/include/llvm-libc-macros/math-macros.h
+++ b/libc/include/llvm-libc-macros/math-macros.h
@@ -10,7 +10,9 @@
 #define LLVM_LIBC_MACROS_MATH_MACROS_H
 
 // TODO: Remove this. This is a temporary fix for a downstream problem.
-#ifdef LLVM_LIBC_FULLBUILD
+// This cannot be left permanently since it would require downstream users to
+// define this macro.
+#ifdef LIBC_FULL_BUILD
 
 #include "limits-macros.h"
 
@@ -82,10 +84,10 @@ template <typename T> inline constexpr bool isnan(T x) {
 
 #endif
 
-#else
+#else // LIBC_FULL_BUILD
 
 #include <math.h>
 
-#endif // LLVM_LIBC_FULLBUILD
+#endif // LIBC_FULL_BUILD
 
 #endif // LLVM_LIBC_MACROS_MATH_MACROS_H

--- a/libc/include/llvm-libc-macros/math-macros.h
+++ b/libc/include/llvm-libc-macros/math-macros.h
@@ -9,6 +9,9 @@
 #ifndef LLVM_LIBC_MACROS_MATH_MACROS_H
 #define LLVM_LIBC_MACROS_MATH_MACROS_H
 
+// TODO: Remove this. This is a temporary fix for a downstream problem.
+#ifdef LLVM_LIBC_FULLBUILD
+
 #include "limits-macros.h"
 
 #define FP_NAN 0
@@ -78,5 +81,11 @@ template <typename T> inline constexpr bool isnan(T x) {
 #define isnan(x) __builtin_isnan(x)
 
 #endif
+
+#else
+
+#include <math.h>
+
+#endif // LLVM_LIBC_FULLBUILD
 
 #endif // LLVM_LIBC_MACROS_MATH_MACROS_H

--- a/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
@@ -68,7 +68,6 @@ libc_support_library(
     name = "llvm_libc_macros_math_macros",
     hdrs = ["include/llvm-libc-macros/math-macros.h"],
     deps = [":llvm_libc_macros_limits_macros"],
-    defines = ["__FP_LOGBNAN_MIN"],
 )
 
 libc_support_library(
@@ -1000,8 +999,8 @@ libc_support_library(
 
 libc_support_library(
     name = "__support_osutil_quick_exit",
-    hdrs = ["src/__support/OSUtil/quick_exit.h"],
     srcs = ["src/__support/OSUtil/linux/quick_exit.cpp"],
+    hdrs = ["src/__support/OSUtil/quick_exit.h"],
     deps = [
         ":__support_osutil_syscall",
     ],


### PR DESCRIPTION
Downstream's having some issues due to math-macros.h issues. These will
be fixed properly soon.

See https://github.com/llvm/llvm-project/issues/87683 for tracking this tech debt.