### PR TITLE
[scudo] Add errno description to mmap failure.

### DIFF
--- a/compiler-rt/lib/scudo/standalone/report_linux.cpp
+++ b/compiler-rt/lib/scudo/standalone/report_linux.cpp
@@ -27,9 +27,8 @@ void NORETURN reportMapError(uptr SizeIfOOM) {
   ScopedString Error;
   Error.append("Scudo ERROR: internal map failure (error desc=%s)",
                strerror(errno));
-  if (SizeIfOOM) {
+  if (SizeIfOOM)
     Error.append(" requesting %zuKB", SizeIfOOM >> 10);
-  }
   Error.append("\n");
   reportRawError(Error.data());
 }

--- a/compiler-rt/lib/scudo/standalone/report_linux.cpp
+++ b/compiler-rt/lib/scudo/standalone/report_linux.cpp
@@ -25,9 +25,10 @@ namespace scudo {
 // Fatal internal map() error (potentially OOM related).
 void NORETURN reportMapError(uptr SizeIfOOM) {
   ScopedString Error;
-  Error.append("Scudo ERROR: internal map failure");
+  Error.append("Scudo ERROR: internal map failure (error desc=%s)",
+               strerror(errno));
   if (SizeIfOOM) {
-    Error.append(" (NO MEMORY) requesting %zuKB", SizeIfOOM >> 10);
+    Error.append(" requesting %zuKB", SizeIfOOM >> 10);
   }
   Error.append("\n");
   reportRawError(Error.data());

--- a/compiler-rt/lib/scudo/standalone/tests/report_test.cpp
+++ b/compiler-rt/lib/scudo/standalone/tests/report_test.cpp
@@ -53,3 +53,28 @@ TEST(ScudoReportDeathTest, CSpecific) {
   EXPECT_DEATH(scudo::reportInvalidAlignedAllocAlignment(123, 456),
                "Scudo ERROR.*123.*456");
 }
+
+#if SCUDO_LINUX || SCUDO_TRUSTY || SCUDO_ANDROID
+#include "report_linux.h"
+
+#include <errno.h>
+#include <sys/mman.h>
+
+TEST(ScudoReportDeathTest, Linux) {
+  errno = ENOMEM;
+  EXPECT_DEATH(scudo::reportMapError(),
+               "Scudo ERROR:.*internal map failure \\(error desc=.*\\)\\s*$");
+  errno = ENOMEM;
+  EXPECT_DEATH(scudo::reportMapError(1024U),
+               "Scudo ERROR:.*internal map failure \\(error desc=.*\\) "
+               "requesting 1KB\\s*$");
+  errno = ENOMEM;
+  EXPECT_DEATH(scudo::reportUnmapError(0x1000U, 100U),
+               "Scudo ERROR:.*internal unmap failure \\(error desc=.*\\) Addr "
+               "0x1000 Size 100\\s*$");
+  errno = ENOMEM;
+  EXPECT_DEATH(scudo::reportProtectError(0x1000U, 100U, PROT_READ),
+               "Scudo ERROR:.*internal protect failure \\(error desc=.*\\) "
+               "Addr 0x1000 Size 100 Prot 1\\s*$");
+}
+#endif


### PR DESCRIPTION
Added unit tests for all of the linux report error functions.