### PR TITLE
[libc++][NFC] Reduce the memory footprint of __copy_cv a bit

### DIFF
--- a/libcxx/include/__type_traits/copy_cv.h
+++ b/libcxx/include/__type_traits/copy_cv.h
@@ -19,28 +19,32 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 
 // Let COPYCV(FROM, TO) be an alias for type TO with the addition of FROM's
 // top-level cv-qualifiers.
-template <class _From, class _To>
+template <class _From>
 struct __copy_cv {
-  using type = _To;
+  template <class _To>
+  using __apply = _To;
+};
+
+template <class _From>
+struct __copy_cv<const _From> {
+  template <class _To>
+  using __apply = const _To;
+};
+
+template <class _From>
+struct __copy_cv<volatile _From> {
+  template <class _To>
+  using __apply = volatile _To;
+};
+
+template <class _From>
+struct __copy_cv<const volatile _From> {
+  template <class _To>
+  using __apply = const volatile _To;
 };
 
 template <class _From, class _To>
-struct __copy_cv<const _From, _To> {
-  using type = const _To;
-};
-
-template <class _From, class _To>
-struct __copy_cv<volatile _From, _To> {
-  using type = volatile _To;
-};
-
-template <class _From, class _To>
-struct __copy_cv<const volatile _From, _To> {
-  using type = const volatile _To;
-};
-
-template <class _From, class _To>
-using __copy_cv_t = typename __copy_cv<_From, _To>::type;
+using __copy_cv_t = typename __copy_cv<_From>::template __apply<_To>;
 
 _LIBCPP_END_NAMESPACE_STD
 


### PR DESCRIPTION
Instead of instantiating `__copy_cv` for every combination of `_From` and `_To` this only instantiates `__copy_cv` for every `_From` type, reducing the number of instantiations.
