### PR TITLE
[AMDGPU] Fix crash when a MachineFunction is not generated

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPUAsmPrinter.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUAsmPrinter.cpp
@@ -471,6 +471,11 @@ AMDGPUAsmPrinter::getAmdhsaKernelDescriptor(const MachineFunction &MF,
 }
 
 bool AMDGPUAsmPrinter::runOnMachineFunction(MachineFunction &MF) {
+  // It is possible that an unreachable function is not emitted so we don't need
+  // to print it anyway.
+  if (MF.empty())
+    return false;
+
   // Init target streamer lazily on the first function so that previous passes
   // can set metadata.
   if (!IsTargetStreamerInitialized)

--- a/llvm/lib/Target/AMDGPU/AMDGPUResourceUsageAnalysis.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUResourceUsageAnalysis.cpp
@@ -155,7 +155,10 @@ bool AMDGPUResourceUsageAnalysis::runOnModule(Module &M) {
 
     SIFunctionResourceInfo &Info = CI.first->second;
     MachineFunction *MF = MMI.getMachineFunction(*F);
-    assert(MF && "function must have been generated already");
+    // It's possible that the unreachable function is not generated at all. We
+    // don't need to count resource usage in that case anyway.
+    if (!MF)
+      continue;
     Info = analyzeResourceUsage(*MF, TM, AssumedStackSizeForDynamicSizeObjects,
                                 AssumedStackSizeForExternalCall);
     HasIndirectCall |= Info.HasIndirectCall;

--- a/llvm/test/CodeGen/AMDGPU/machine-function-not-generated.ll
+++ b/llvm/test/CodeGen/AMDGPU/machine-function-not-generated.ll
@@ -1,0 +1,5 @@
+; RUN: llc --mtriple=amdgcn-amd-amdhsa %s -o -
+
+define internal void @_omp_reduction_list_to_global_reduce_func() {
+  ret void
+}


### PR DESCRIPTION
The `AMDGPUResourceUsageAnalysis` pass assumes the compiler generates
MachineFunction for each function in a module, which is not always true. The
CodeGen pass skips an internal unreachable function. In this patch we simply
skip the function that is not generated because we don't need to count its
resource usage anyway.

Fix #65188.
