### PR TITLE
RFC: Argpromotion of externally visible functions

### DIFF
--- a/llvm/include/llvm/Transforms/IPO/ArgumentPromotion.h
+++ b/llvm/include/llvm/Transforms/IPO/ArgumentPromotion.h
@@ -15,6 +15,8 @@
 
 namespace llvm {
 
+static constexpr unsigned ArgPromotionDefaultMaxElements = 2;
+
 /// Argument promotion pass.
 ///
 /// This pass walks the functions in each SCC and for each one tries to
@@ -22,9 +24,12 @@ namespace llvm {
 /// direct (by-value) arguments.
 class ArgumentPromotionPass : public PassInfoMixin<ArgumentPromotionPass> {
   unsigned MaxElements;
+  bool IsThinLTOPreLink;
 
 public:
-  ArgumentPromotionPass(unsigned MaxElements = 2u) : MaxElements(MaxElements) {}
+  ArgumentPromotionPass(unsigned MaxElements = ArgPromotionDefaultMaxElements,
+                        bool IsThinLTOPreLink = false)
+      : MaxElements(MaxElements), IsThinLTOPreLink(IsThinLTOPreLink) {}
 
   PreservedAnalyses run(LazyCallGraph::SCC &C, CGSCCAnalysisManager &AM,
                         LazyCallGraph &CG, CGSCCUpdateResult &UR);

--- a/llvm/lib/Passes/PassBuilderPipelines.cpp
+++ b/llvm/lib/Passes/PassBuilderPipelines.cpp
@@ -931,7 +931,9 @@ PassBuilder::buildInlinerPipeline(OptimizationLevel Level,
   // When at O3 add argument promotion to the pass pipeline.
   // FIXME: It isn't at all clear why this should be limited to O3.
   if (Level == OptimizationLevel::O3)
-    MainCGPipeline.addPass(ArgumentPromotionPass());
+    MainCGPipeline.addPass(
+        ArgumentPromotionPass(ArgPromotionDefaultMaxElements,
+                              Phase == ThinOrFullLTOPhase::ThinLTOPreLink));
 
   // Try to perform OpenMP specific optimizations. This is a (quick!) no-op if
   // there are no OpenMP runtime calls present in the module.
@@ -1864,7 +1866,8 @@ PassBuilder::buildLTODefaultPipeline(OptimizationLevel Level,
 
   // If we didn't decide to inline a function, check to see if we can
   // transform it to pass arguments by value instead of by reference.
-  MPM.addPass(createModuleToPostOrderCGSCCPassAdaptor(ArgumentPromotionPass()));
+  MPM.addPass(createModuleToPostOrderCGSCCPassAdaptor(
+      ArgumentPromotionPass(ArgPromotionDefaultMaxElements)));
 
   FunctionPassManager FPM;
   // The IPO Passes may leave cruft around. Clean up after them.


### PR DESCRIPTION
Promotion of extern functions is still safe so long as the external interface remains the same. This commit adds the ability to split an otherwise argpromotable function into a wrapper function that maintains the external interface, and a wrappee that gets argpromoted.

In most compilation modes, this doesn't make sense; many extern functions are called mostly from outside the module, so the split would just add a pointless layer of indirection. Therefore, we enable this splitting only for ThinLTO, where the wrapper is actually inlinable.

I'm still working to measure the impact on some big server workloads (which are noisier), but building clang with ThinLTO and measuring compilation time on some [single compilation-unit programs](https://people.csail.mit.edu/smcc/projects/single-file-programs/) shows something like a 0.3%-0.6% end to end wall time improvement on my machine.

Changes on the llvm test suite are fairly minor; my experience is that this has more of a difference on big template-y C++ programs, which aren't terribly well represented there. One thing that changes is, since argpromotion has the effect of moving loads earlier than they might otherwise occur, some strict aliasing violations that previously went undetected now cause errors.

This shouldn't be merged as-is (no tests, less than thorough performance testing); but I'd rather make sure the approach seems reasonable here before building up too much that will have to change. Once there's some vague alignment on the strategy, I thought I'd pursue related optimizations around other ABI fixes as well (e.g. returning sret parameters in registers instead of via the stack, like what can happen with std::unique_ptr-returning functions).