### PR TITLE
[clang] Add test for CWG392

### DIFF
--- a/clang/test/CXX/drs/dr392.cpp
+++ b/clang/test/CXX/drs/dr392.cpp
@@ -12,7 +12,7 @@
 #define NOTHROW noexcept(true)
 #endif
 
-namespace dr392 {
+namespace dr392 { // dr392: 2.8
 
 struct A {
   operator bool() NOTHROW;

--- a/clang/test/CXX/drs/dr392.cpp
+++ b/clang/test/CXX/drs/dr392.cpp
@@ -1,0 +1,40 @@
+// RUN: %clang_cc1 -std=c++98 %s -triple x86_64-linux-gnu -emit-llvm -disable-llvm-passes -o - -fexceptions -fcxx-exceptions -pedantic-errors | llvm-cxxfilt -n | FileCheck %s --check-prefixes CHECK
+// RUN: %clang_cc1 -std=c++11 %s -triple x86_64-linux-gnu -emit-llvm -disable-llvm-passes -o - -fexceptions -fcxx-exceptions -pedantic-errors | llvm-cxxfilt -n | FileCheck %s --check-prefixes CHECK
+// RUN: %clang_cc1 -std=c++14 %s -triple x86_64-linux-gnu -emit-llvm -disable-llvm-passes -o - -fexceptions -fcxx-exceptions -pedantic-errors | llvm-cxxfilt -n | FileCheck %s --check-prefixes CHECK
+// RUN: %clang_cc1 -std=c++17 %s -triple x86_64-linux-gnu -emit-llvm -disable-llvm-passes -o - -fexceptions -fcxx-exceptions -pedantic-errors | llvm-cxxfilt -n | FileCheck %s --check-prefixes CHECK
+// RUN: %clang_cc1 -std=c++20 %s -triple x86_64-linux-gnu -emit-llvm -disable-llvm-passes -o - -fexceptions -fcxx-exceptions -pedantic-errors | llvm-cxxfilt -n | FileCheck %s --check-prefixes CHECK
+// RUN: %clang_cc1 -std=c++23 %s -triple x86_64-linux-gnu -emit-llvm -disable-llvm-passes -o - -fexceptions -fcxx-exceptions -pedantic-errors | llvm-cxxfilt -n | FileCheck %s --check-prefixes CHECK
+// RUN: %clang_cc1 -std=c++2c %s -triple x86_64-linux-gnu -emit-llvm -disable-llvm-passes -o - -fexceptions -fcxx-exceptions -pedantic-errors | llvm-cxxfilt -n | FileCheck %s --check-prefixes CHECK
+
+#if __cplusplus == 199711L
+#define NOTHROW throw()
+#else
+#define NOTHROW noexcept(true)
+#endif
+
+namespace dr392 {
+
+struct A {
+  operator bool() NOTHROW;
+};
+
+class C {
+public:
+  C() NOTHROW;
+  ~C() NOTHROW;
+  A& get() NOTHROW { return p; }
+private:
+  A p;
+};
+
+void f()
+{
+  if (C().get()) {}
+}
+
+} // namespace dr392
+
+// CHECK-LABEL: define {{.*}} void @dr392::f()()
+// CHECK:         call {{.*}} i1 @dr392::A::operator bool()
+// CHECK:         call void @dr392::C::~C()
+// CHECK-LABEL: }

--- a/clang/test/CXX/drs/dr3xx.cpp
+++ b/clang/test/CXX/drs/dr3xx.cpp
@@ -1401,7 +1401,7 @@ namespace dr387 { // dr387: 2.8
   }
 }
 
-// FIXME: dr388 needs codegen test
+// FIXME: dr388 needs libc++abi test
 
 namespace dr389 { // dr389: no
   struct S {
@@ -1567,7 +1567,7 @@ namespace dr391 { // dr391: 2.8 c++11
   const C<int> &c = fc();
 }
 
-// dr392 FIXME write codegen test
+// dr392 is in dr392.cpp
 // dr394: na
 
 namespace dr395 { // dr395: 3.0

--- a/clang/www/cxx_dr_status.html
+++ b/clang/www/cxx_dr_status.html
@@ -2392,7 +2392,7 @@ of class templates</td>
     <td><a href="https://cplusplus.github.io/CWG/issues/392.html">392</a></td>
     <td>CD1</td>
     <td>Use of full expression lvalue before temporary destruction</td>
-    <td class="unknown" align="center">Unknown</td>
+    <td class="full" align="center">Clang 2.8</td>
   </tr>
   <tr id="393">
     <td><a href="https://cplusplus.github.io/CWG/issues/393.html">393</a></td>


### PR DESCRIPTION
[CWG392](https://cplusplus.github.io/CWG/issues/392.html) "Use of full expression lvalue before temporary destruction". We're testing that `operator bool()` is called before destructor of `C`.

I'm also marking CWG388 as requiring libc++abi test instead of codegen test, as we need to test matching between exception object and exception handlers.