### PR TITLE
[clang] Claim conformance for CWG466

### DIFF
--- a/clang/test/CXX/drs/dr4xx.cpp
+++ b/clang/test/CXX/drs/dr4xx.cpp
@@ -948,7 +948,7 @@ namespace dr460 { // dr460: yes
 // dr464: na
 // dr465: na
 
-namespace dr466 { // dr466: no
+namespace dr466 { // dr466: 2.8
   typedef int I;
   typedef const int CI;
   typedef volatile int VI;
@@ -960,7 +960,7 @@ namespace dr466 { // dr466: no
     a->CI::~CI();
     a->VI::~VI();
 
-    a->CI::~VI(); // FIXME: This is invalid; CI and VI are not the same scalar type.
+    a->CI::~VI(); // allowed by changes to [expr.id.prim.qual]/2 introduced in P1131R2
 
     b->~I();
     b->~CI();

--- a/clang/www/cxx_dr_status.html
+++ b/clang/www/cxx_dr_status.html
@@ -2836,7 +2836,7 @@ of class templates</td>
     <td><a href="https://cplusplus.github.io/CWG/issues/466.html">466</a></td>
     <td>CD1</td>
     <td>cv-qualifiers on pseudo-destructor type</td>
-    <td class="none" align="center">No</td>
+    <td class="full" align="center">Clang 2.8</td>
   </tr>
   <tr id="467">
     <td><a href="https://cplusplus.github.io/CWG/issues/467.html">467</a></td>


### PR DESCRIPTION
[CWG466](https://cplusplus.github.io/CWG/issues/466.html) "cv-qualifiers on pseudo-destructor type".
Richard claimed that we don't implement this DR because of one ill-formed example being accepted: `a->CI::~VI();`. This example is testing the behavior of calling a pseudo-destructor via a qualified name, where components of qualified name denote the same `int` type, but with different cv-qualifications.

Initially, the following wording from [expr.pseudo] quoted in CWG466 was left intact:
> Furthermore, the two type-names in a pseudo-destructor-name of the form
>
>    `:: (opt) nested-name-specifier (opt) type-name ::~ type-name`
>
>shall designate the same scalar type.

According to this wording, the example is indeed ill-formed.

[P1131R2](https://wg21.link/p1131r2) merged wording for pseudo-destructors into regular destructor wording. Among other things, [expr.pseudo] was removed, and [expr.prim.id.qual]/2 was changed to read:

> Where `type-name ::~ type-name` is used, the two type-names shall refer to the same type (ignoring cv-qualifications);

I believe P1131R2 made the example well-formed.

However, this wording didn't survive [P1787R6](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2020/p1787r6.html) "Declarations and where to find them". In that paper I don't see the intent to make the example ill-formed again, so I assume it confirmed status-quo via other wording. My _guess_ the new wording is http://eel.is/c++draft/basic.lookup#qual.general-4.6:
> If a qualified name Q follows a ~: 
> - <...>
> - The [type-name](http://eel.is/c++draft/dcl.type.simple#nt:type-name) that is or contains Q shall refer to its (original) lookup context (ignoring cv-qualification) under the interpretation established by at least one (successful) lookup performed[.](http://eel.is/c++draft/basic.lookup#qual.general-4.6.sentence-1)