### PR TITLE
[Support][Windows] Use the original path if GetFinalPathNameByHandleW() failed

### DIFF
--- a/llvm/lib/Support/Windows/Path.inc
+++ b/llvm/lib/Support/Windows/Path.inc
@@ -157,7 +157,9 @@ std::string getMainExecutable(const char *argv0, void *MainExecAddr) {
 
   SmallString<256> RealPath;
   sys::fs::real_path(PathNameUTF8, RealPath);
-  return std::string(RealPath);
+  if (RealPath.size())
+    return std::string(RealPath);
+  return std::string(PathNameUTF8.data());
 }
 
 UniqueID file_status::getUniqueID() const {


### PR DESCRIPTION
The commit f11b056c (#76304) breaks `clang` and other tools if they are used from a RAMDrive. `GetFinalPathNameByHandleW()` may return 0 and GetLastError 0x28. This patch fixes that issue. Note `real_path()` uses `openFileForRead()` but it reports the error only if failed to open a file. Getting `RealPath` is optional functionality.

BTW, `sys::fs::real_path()` resolves not only symlinks, but also network drives and virtual drives created by the `subst` tool. It may break an automation. It is better to detect symlinks and resolve only symlinks.