### PR TITLE
[NFC][Doc] Fix typo in new pass manager snippet

### DIFF
--- a/llvm/docs/NewPassManager.rst
+++ b/llvm/docs/NewPassManager.rst
@@ -162,10 +162,10 @@ certain parts of the pipeline. For example,
 .. code-block:: c++
 
   PassBuilder PB;
-  PB.registerPipelineStartEPCallback([&](ModulePassManager &MPM,
-                                         PassBuilder::OptimizationLevel Level) {
-      MPM.addPass(FooPass());
-  };
+  PB.registerPipelineStartEPCallback(
+      [&](ModulePassManager &MPM, PassBuilder::OptimizationLevel Level) {
+        MPM.addPass(FooPass());
+      });
 
 will add ``FooPass`` near the very beginning of the pipeline for pass
 managers created by that ``PassBuilder``. See the documentation for


### PR DESCRIPTION
Add missing closing parenthesis and re-flow the snippet to what clang format would generate.