### PR TITLE
[analyzer] Support `PointerType` in `getCXXRecordDecl` for `ContainerModeling`

### DIFF
--- a/clang/lib/StaticAnalyzer/Checkers/ContainerModeling.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/ContainerModeling.cpp
@@ -770,6 +770,10 @@ const CXXRecordDecl *getCXXRecordDecl(ProgramStateRef State,
     Type = RefT->getPointeeType();
   }
 
+  if (const auto *PtrT = Type->getAs<PointerType>()) {
+    Type = PtrT->getPointeeType();
+  }
+
   return Type->getUnqualifiedDesugaredType()->getAsCXXRecordDecl();
 }
 

--- a/clang/test/Analysis/invalidated-iterator.cpp
+++ b/clang/test/Analysis/invalidated-iterator.cpp
@@ -130,6 +130,14 @@ struct cont_with_ptr_iterator {
   T* erase(T*);
 };
 
+void invalidated_access_via_end_iterator_after_push_back() {
+  cont_with_ptr_iterator<int> C;
+  C.push_back(1);
+  auto i = C.end();
+  C.push_back(2);
+  auto j = i[-1]; // expected-warning{{Invalidated iterator accessed}}
+}
+
 void invalidated_dereference_end_ptr_iterator(cont_with_ptr_iterator<int> &C) {
   auto i = C.begin();
   C.erase(i);


### PR DESCRIPTION
## Summary
Static analysis for container models with pointer iterators lacked proper support, failing to detect invalidated iterator access in cases involving `PointerType`s. This change enhanced static analysis by adding support for `PointerType` in container models, ensuring accurate detection of invalidated iterator accesses.

## Changes
Updated `getCXXRecordDecl` to recognize `PointerType`, complementing existing `ReferenceType` handling.
This enables precise modeling across containers using pointer iterators, improving the identification of iterator invalidation.

## Test Case
Added `invalidated_access_via_end_iterator_after_push_back` to illustrate how the update catches previously undetected invalidated iterator accesses, preventing potential bugs.

For this testcase , `auto Type = TI.getType();`  in function `getCXXRecordDecl` would dump like this:

```
PointerType 0x561a9d57e260 'cont_with_ptr_iterator<int> *'
`-ElaboratedType 0x561a9d57c530 'cont_with_ptr_iterator<int>' sugar
  `-TemplateSpecializationType 0x561a9d57c4e0 'cont_with_ptr_iterator<int>' sugar cont_with_ptr_iterator
    |-TemplateArgument type 'int'
    | `-BuiltinType 0x561a9d45a8b0 'int'
    `-RecordType 0x561a9d57c4c0 'struct cont_with_ptr_iterator<int>'
      `-ClassTemplateSpecialization 0x561a9d57c3e8 'cont_with_ptr_iterator'﻿
```

## Impact
This targeted update focuses on refining `getCXXRecordDecl`. Review for any wider implications on static analysis is advisable.

## Request for Feedback
Feedback on this approach, additional test scenarios, or compatibility concerns is highly appreciated to ensure a robust enhancement.

Thanks for considering this contribution aimed at bolstering static analysis capabilities.