### PR TITLE
[mlir][vector] Teach `TransferOptimization` to forward masked stores

### DIFF
--- a/mlir/lib/Dialect/Vector/IR/VectorOps.cpp
+++ b/mlir/lib/Dialect/Vector/IR/VectorOps.cpp
@@ -184,7 +184,9 @@ static bool couldBeSameValueWithMasking(vector::TransferWriteOp defWrite,
   }
   // Check for constant splats. These will be the same value if the read is
   // masked (and padded with the splat value), and the write is unmasked or has
-  // the same mask.
+  // the same mask. Note this does not allow the case where the write is masked
+  // and the read is unmasked, as then the read could be of more elements than
+  // the write (which may not be the same value).
   bool couldBeSameSplat = readMask && (!writeMask || writeMask == readMask);
   if (!couldBeSameSplat)
     return false;
@@ -194,6 +196,7 @@ static bool couldBeSameValueWithMasking(vector::TransferWriteOp defWrite,
       !splatAttr.isSplat()) {
     return false;
   }
+  // The padding of the read and the constant splat value must be the same.
   Attribute padAttr;
   if (!matchPattern(read.getPadding(), m_Constant(&padAttr)))
     return false;

--- a/mlir/lib/Dialect/Vector/IR/VectorOps.cpp
+++ b/mlir/lib/Dialect/Vector/IR/VectorOps.cpp
@@ -176,17 +176,17 @@ AffineMap mlir::vector::getTransferMinorIdentityMap(ShapedType shapedType,
 /// `checkSameValueRAW()` -- which calls this function.
 static bool couldBeSameValueWithMasking(vector::TransferWriteOp defWrite,
                                         vector::TransferReadOp read) {
-  if (!defWrite.getMask() && !read.getMask()) {
+  auto readMask = read.getMask();
+  auto writeMask = defWrite.getMask();
+  if (!writeMask && !readMask) {
     // Success: No masks (values could be the same).
     return true;
   }
   // Check for constant splats. These will be the same value if the read is
   // masked (and padded with the splat value), and the write is unmasked or has
   // the same mask.
-  bool couldBeSameSplatValue =
-      read.getMask() &&
-      (!defWrite.getMask() || defWrite.getMask() == read.getMask());
-  if (!couldBeSameSplatValue)
+  bool couldBeSameSplat = readMask && (!writeMask || writeMask == readMask);
+  if (!couldBeSameSplat)
     return false;
   DenseElementsAttr splatAttr;
   if (!matchPattern(defWrite.getVector(),

--- a/mlir/lib/Dialect/Vector/IR/VectorOps.cpp
+++ b/mlir/lib/Dialect/Vector/IR/VectorOps.cpp
@@ -170,10 +170,16 @@ AffineMap mlir::vector::getTransferMinorIdentityMap(ShapedType shapedType,
       shapedType.getContext());
 }
 
+/// Returns true if the value written by `defWrite` could be the same as the
+/// value read by `read`. Note: True is 'could be' not 'definitely' (as this
+/// simply looks at the masks and the value written). For a definite answer use
+/// `checkSameValueRAW()` -- which calls this function.
 static bool couldBeSameValueWithMasking(vector::TransferWriteOp defWrite,
                                         vector::TransferReadOp read) {
-  if (!defWrite.getMask() && !read.getMask())
-    return true; // Success: No masks (values will be the same).
+  if (!defWrite.getMask() && !read.getMask()) {
+    // Success: No masks (values could be the same).
+    return true;
+  }
   // Check for constant splats. These will be the same value if the read is
   // masked (and padded with the splat value), and the write is unmasked or has
   // the same mask.

--- a/mlir/test/Dialect/Vector/vector-transferop-opt.mlir
+++ b/mlir/test/Dialect/Vector/vector-transferop-opt.mlir
@@ -374,7 +374,6 @@ func.func @forward_dead_constant_splat_store_with_masking(%buffer : memref<?x?xf
   %c1 = arith.constant 1 : index
   %c0 = arith.constant 0 : index
   %c512 = arith.constant 512 : index
-  %vscale = vector.vscale
   vector.transfer_write %cst, %buffer[%c0, %c0], %mask {in_bounds = [true, true]} : vector<[8]x[8]xf32>, memref<?x?xf32>
   %0 = vector.transfer_read %buffer[%c0, %c0], %cst_f32, %mask {in_bounds = [true, true]} : memref<?x?xf32>, vector<[8]x[8]xf32>
   %x = scf.for %arg2 = %c0 to %c512 step %c1 iter_args(%acc = %0) -> (vector<[8]x[8]xf32>) {
@@ -400,7 +399,6 @@ func.func @forward_dead_constant_splat_store_with_masking_negative(%buffer : mem
   %c1 = arith.constant 1 : index
   %c0 = arith.constant 0 : index
   %c512 = arith.constant 512 : index
-  %vscale = vector.vscale
   vector.transfer_write %cst, %buffer[%c0, %c0], %mask {in_bounds = [true, true]} : vector<[8]x[8]xf32>, memref<?x?xf32>
   %0 = vector.transfer_read %buffer[%c0, %c0], %cst_f32, %mask {in_bounds = [true, true]} : memref<?x?xf32>, vector<[8]x[8]xf32>
   %x = scf.for %arg2 = %c0 to %c512 step %c1 iter_args(%acc = %0) -> (vector<[8]x[8]xf32>) {


### PR DESCRIPTION
This only handles one case (that's fairly common in practice*), storing a masked constant splat, then reloading again with the same mask and a padding value that matches the splat.

* For SVE/SME (without peeling) this occurs when you have a `linalg.fill` preceding a `linalg.matmul`.