### PR TITLE
[zOS] Turn CLANG_INTERPRETER_PLATFORM_CANNOT_CREATE_LLJIT on for zOS

### DIFF
--- a/clang/unittests/Interpreter/InterpreterExtensionsTest.cpp
+++ b/clang/unittests/Interpreter/InterpreterExtensionsTest.cpp
@@ -30,7 +30,7 @@
 
 #include <system_error>
 
-#if defined(_AIX)
+#if defined(_AIX) || defined(__MVS__)
 #define CLANG_INTERPRETER_PLATFORM_CANNOT_CREATE_LLJIT
 #endif
 


### PR DESCRIPTION
PR [https://github.com/llvm/llvm-project/pull/84461](https://github.com/llvm/llvm-project/pull/84461) disabled `clang/unittests/Interpreter/InterpreterExtensionsTest.cpp` for AIX by turning on `CLANG_INTERPRETER_PLATFORM_CANNOT_CREATE_LLJIT`.
This PR turns `CLANG_INTERPRETER_PLATFORM_CANNOT_CREATE_LLJIT` on for zOS as well, since LLJIT cannot be created on zOS either. 