### PR TITLE
[X86] Fix typo: QWORD alignment is greater than or equal to 8, not greater than 8

### DIFF
--- a/llvm/lib/Target/X86/X86SelectionDAGInfo.cpp
+++ b/llvm/lib/Target/X86/X86SelectionDAGInfo.cpp
@@ -80,13 +80,13 @@ SDValue X86SelectionDAGInfo::EmitTargetCodeForMemset(
     uint64_t Val = ValC->getZExtValue() & 255;
 
     // If the value is a constant, then we can potentially use larger sets.
-    if (Alignment > Align(2)) {
+    if (Alignment >= Align(4)) {
       // DWORD aligned
       AVT = MVT::i32;
       ValReg = X86::EAX;
       Val = (Val << 8)  | Val;
       Val = (Val << 16) | Val;
-      if (Subtarget.is64Bit() && Alignment > Align(8)) { // QWORD aligned
+      if (Subtarget.is64Bit() && Alignment >= Align(8)) { // QWORD aligned
         AVT = MVT::i64;
         ValReg = X86::RAX;
         Val = (Val << 32) | Val;

--- a/llvm/test/CodeGen/X86/memset-minsize.ll
+++ b/llvm/test/CodeGen/X86/memset-minsize.ll
@@ -139,10 +139,10 @@ entry:
 define void @small_memset_to_rep_stos_64(ptr %ptr) minsize nounwind {
 ; CHECK-LABEL: small_memset_to_rep_stos_64:
 ; CHECK:       # %bb.0: # %entry
-; CHECK-NEXT:    pushq $32
+; CHECK-NEXT:    pushq $16
 ; CHECK-NEXT:    popq %rcx
 ; CHECK-NEXT:    xorl %eax, %eax
-; CHECK-NEXT:    rep;stosl %eax, %es:(%rdi)
+; CHECK-NEXT:    rep;stosq %rax, %es:(%rdi)
 ; CHECK-NEXT:    retq
 entry:
   call void @llvm.memset.p0.i64(ptr align 8 %ptr, i8 0, i64 128, i1 false)

--- a/llvm/test/CodeGen/X86/memset-minsize.ll
+++ b/llvm/test/CodeGen/X86/memset-minsize.ll
@@ -136,4 +136,17 @@ entry:
   ret void
 }
 
+define void @small_memset_to_rep_stos_64(ptr %ptr) minsize nounwind {
+; CHECK-LABEL: small_memset_to_rep_stos_64:
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    pushq $32
+; CHECK-NEXT:    popq %rcx
+; CHECK-NEXT:    xorl %eax, %eax
+; CHECK-NEXT:    rep;stosl %eax, %es:(%rdi)
+; CHECK-NEXT:    retq
+entry:
+  call void @llvm.memset.p0.i64(ptr align 8 %ptr, i8 0, i64 128, i1 false)
+  ret void
+}
+
 declare void @llvm.memset.p0.i32(ptr nocapture writeonly, i8, i32, i1)


### PR DESCRIPTION
Align(8) is QWORD aligned, but this was checking to see if alignment was greater than that, when it should have been checking for being greater than OR EQUAL to Align(8).

This bug was introduced in https://github.com/llvm/llvm-project/commit/6a6af30d433d7 during the transition to the Align type.