### PR TITLE
[SPIR-V] Re-implement switch and improve validation of forward calls

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVAsmPrinter.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVAsmPrinter.cpp
@@ -111,9 +111,8 @@ void SPIRVAsmPrinter::emitEndOfAsmFile(Module &M) {
   uint32_t DecSPIRVVersion = ST->getSPIRVVersion();
   uint32_t Major = DecSPIRVVersion / 10;
   uint32_t Minor = DecSPIRVVersion - Major * 10;
-  // TODO: calculate Bound more carefully from maximum used register number,
-  // accounting for generated OpLabels and other related instructions if
-  // needed.
+  // Bound is an approximation that accounts for the maximum used register
+  // number and number of generated OpLabels
   unsigned Bound = 2 * (ST->getBound() + 1) + NLabels;
   bool FlagToRestore = OutStreamer->getUseAssemblerInfoForParsing();
   OutStreamer->setUseAssemblerInfoForParsing(true);

--- a/llvm/lib/Target/SPIRV/SPIRVAsmPrinter.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVAsmPrinter.cpp
@@ -43,6 +43,8 @@ using namespace llvm;
 
 namespace {
 class SPIRVAsmPrinter : public AsmPrinter {
+  unsigned NLabels = 0;
+
 public:
   explicit SPIRVAsmPrinter(TargetMachine &TM,
                            std::unique_ptr<MCStreamer> Streamer)
@@ -112,7 +114,7 @@ void SPIRVAsmPrinter::emitEndOfAsmFile(Module &M) {
   // TODO: calculate Bound more carefully from maximum used register number,
   // accounting for generated OpLabels and other related instructions if
   // needed.
-  unsigned Bound = 2 * (ST->getBound() + 1);
+  unsigned Bound = 2 * (ST->getBound() + 1) + NLabels;
   bool FlagToRestore = OutStreamer->getUseAssemblerInfoForParsing();
   OutStreamer->setUseAssemblerInfoForParsing(true);
   if (MCAssembler *Asm = OutStreamer->getAssemblerPtr())
@@ -158,6 +160,7 @@ void SPIRVAsmPrinter::emitOpLabel(const MachineBasicBlock &MBB) {
   LabelInst.setOpcode(SPIRV::OpLabel);
   LabelInst.addOperand(MCOperand::createReg(MAI->getOrCreateMBBRegister(MBB)));
   outputMCInst(LabelInst);
+  ++NLabels;
 }
 
 void SPIRVAsmPrinter::emitBasicBlockStart(const MachineBasicBlock &MBB) {

--- a/llvm/lib/Target/SPIRV/SPIRVGlobalRegistry.h
+++ b/llvm/lib/Target/SPIRV/SPIRVGlobalRegistry.h
@@ -284,7 +284,12 @@ public:
   // Return the VReg holding the result of the given OpTypeXXX instruction.
   Register getSPIRVTypeID(const SPIRVType *SpirvType) const;
 
-  void setCurrentFunc(MachineFunction &MF) { CurMF = &MF; }
+  // Return previous value of the current machine function
+  MachineFunction *setCurrentFunc(MachineFunction &MF) {
+    MachineFunction *Ret = CurMF;
+    CurMF = &MF;
+    return Ret;
+  }
 
   // Whether the given VReg has an OpTypeXXX instruction mapped to it with the
   // given opcode (e.g. OpTypeFloat).

--- a/llvm/lib/Target/SPIRV/SPIRVISelLowering.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVISelLowering.cpp
@@ -160,12 +160,15 @@ void validateFunCallMachineDef(const SPIRVSubtarget &STI,
             : nullptr;
     if (DefElemType) {
       const Type *DefElemTy = GR.getTypeForSPIRVType(DefElemType);
-      // Switch GR context to the call site instead of the (default) definition
-      // side
-      GR.setCurrentFunc(*FunCall.getParent()->getParent());
+      // validatePtrTypes() works in the context if the call site
+      // When we process historical records about forward calls
+      // we need to switch context to the (forward) call site and
+      // then restore it back to the current machine function.
+      MachineFunction *CurMF =
+          GR.setCurrentFunc(*FunCall.getParent()->getParent());
       validatePtrTypes(STI, CallMRI, GR, FunCall, OpIdx, DefElemType,
                        DefElemTy);
-      GR.setCurrentFunc(*FunDef->getParent()->getParent());
+      GR.setCurrentFunc(*CurMF);
     }
   }
 }
@@ -215,6 +218,11 @@ void validateAccessChain(const SPIRVSubtarget &STI, MachineRegisterInfo *MRI,
 // TODO: the logic of inserting additional bitcast's is to be moved
 // to pre-IRTranslation passes eventually
 void SPIRVTargetLowering::finalizeLowering(MachineFunction &MF) const {
+  // finalizeLowering() is called twice (see GlobalISel/InstructionSelect.cpp)
+  // We'd like to avoid the needless second processing pass.
+  if (ProcessedMF.find(&MF) != ProcessedMF.end())
+    return;
+
   MachineRegisterInfo *MRI = &MF.getRegInfo();
   SPIRVGlobalRegistry &GR = *STI.getSPIRVGlobalRegistry();
   GR.setCurrentFunc(MF);
@@ -302,5 +310,6 @@ void SPIRVTargetLowering::finalizeLowering(MachineFunction &MF) const {
       }
     }
   }
+  ProcessedMF.insert(&MF);
   TargetLowering::finalizeLowering(MF);
 }

--- a/llvm/lib/Target/SPIRV/SPIRVISelLowering.h
+++ b/llvm/lib/Target/SPIRV/SPIRVISelLowering.h
@@ -16,12 +16,16 @@
 
 #include "SPIRVGlobalRegistry.h"
 #include "llvm/CodeGen/TargetLowering.h"
+#include <set>
 
 namespace llvm {
 class SPIRVSubtarget;
 
 class SPIRVTargetLowering : public TargetLowering {
   const SPIRVSubtarget &STI;
+
+  // Record of already processed machine functions
+  mutable std::set<const MachineFunction *> ProcessedMF;
 
 public:
   explicit SPIRVTargetLowering(const TargetMachine &TM,

--- a/llvm/test/CodeGen/SPIRV/branching/OpSwitchUnreachable.ll
+++ b/llvm/test/CodeGen/SPIRV/branching/OpSwitchUnreachable.ll
@@ -1,8 +1,9 @@
 ; RUN: llc -O0 -mtriple=spirv32-unknown-unknown %s -o - | FileCheck %s --check-prefix=CHECK-SPIRV
+; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv32-unknown-unknown %s -o - -filetype=obj | spirv-val %}
 
 define void @test_switch_with_unreachable_block(i1 %a) {
   %value = zext i1 %a to i32
-; CHECK-SPIRV:      OpSwitch %[[#]] %[[#REACHABLE:]]
+; CHECK-SPIRV:      OpSwitch %[[#]] %[[#UNREACHABLE:]] 0 %[[#REACHABLE:]] 1 %[[#REACHABLE:]]
   switch i32 %value, label %unreachable [
     i32 0, label %reachable
     i32 1, label %reachable
@@ -13,7 +14,7 @@ reachable:
 ; CHECK-SPIRV-NEXT: OpReturn
   ret void
 
-; CHECK-SPIRV:      %[[#]] = OpLabel
+; CHECK-SPIRV:      %[[#UNREACHABLE]] = OpLabel
 ; CHECK-SPIRV-NEXT: OpUnreachable
 unreachable:
   unreachable

--- a/llvm/test/CodeGen/SPIRV/branching/switch-range-check.ll
+++ b/llvm/test/CodeGen/SPIRV/branching/switch-range-check.ll
@@ -8,19 +8,19 @@
 
 define spir_func void @foo(i64 noundef %addr, i64 noundef %as) {
 entry:
-  %0 = inttoptr i64 %as to ptr addrspace(4)
-  %1 = load i8, ptr addrspace(4) %0
-  %cmp = icmp sgt i8 %1, 0
+  %src = inttoptr i64 %as to ptr addrspace(4)
+  %val = load i8, ptr addrspace(4) %src
+  %cmp = icmp sgt i8 %val, 0
   br i1 %cmp, label %if.then, label %if.end
 
-if.then:                                          ; preds = %entry
-  %add.ptr = getelementptr inbounds i8, ptr addrspace(4) %0, i64 1
-  %2 = load i8, ptr addrspace(4) %add.ptr
+if.then:
+  %add.ptr = getelementptr inbounds i8, ptr addrspace(4) %src, i64 1
+  %cond = load i8, ptr addrspace(4) %add.ptr
   br label %if.end
 
-if.end:                                           ; preds = %if.then, %entry
-  %shadow_value.0.in = phi i8 [ %2, %if.then ], [ %1, %entry ]
-  switch i8 %shadow_value.0.in, label %sw.default [
+if.end:
+  %swval = phi i8 [ %cond, %if.then ], [ %val, %entry ]
+  switch i8 %swval, label %sw.default [
     i8 -127, label %sw.epilog
     i8 -126, label %sw.bb3
     i8 -125, label %sw.bb4
@@ -35,83 +35,38 @@ if.end:                                           ; preds = %if.then, %entry
     i8 -123, label %sw.bb11
   ]
 
-sw.bb3:                                           ; preds = %if.end
+sw.bb3:
   br label %sw.epilog
 
-sw.bb4:                                           ; preds = %if.end
+sw.bb4:
   br label %sw.epilog
 
-sw.bb5:                                           ; preds = %if.end
+sw.bb5:
   br label %sw.epilog
 
-sw.bb6:                                           ; preds = %if.end
+sw.bb6:
   br label %sw.epilog
 
-sw.bb7:                                           ; preds = %if.end
+sw.bb7:
   br label %sw.epilog
 
-sw.bb8:                                           ; preds = %if.end, %if.end, %if.end
+sw.bb8:
   br label %sw.epilog
 
-sw.bb9:                                           ; preds = %if.end
+sw.bb9:
   br label %sw.epilog
 
-sw.bb10:                                          ; preds = %if.end
+sw.bb10:
   br label %sw.epilog
 
-sw.bb11:                                          ; preds = %if.end
+sw.bb11:
   br label %sw.epilog
 
-sw.default:                                       ; preds = %if.end
+sw.default:
   br label %sw.epilog
 
-sw.epilog:                                        ; preds = %sw.default, %sw.bb11, %sw.bb10, %sw.bb9, %sw.bb8, %sw.bb7, %sw.bb6, %sw.bb5, %sw.bb4, %sw.bb3, %if.end
+sw.epilog:
   br label %exit
-
-if.then.i:                                        ; preds = %sw.epilog
-  br label %exit
-
-for.cond.i:                                       ; preds = %for.inc.i, %if.then.i
-  br label %exit
-
-for.inc.i:                                        ; preds = %for.cond.i
-  br label %exit
-
-if.end.i:                                         ; preds = %for.cond.i, %if.then.i
-  br label %exit
-
-if.end18.thread.i:                                ; preds = %if.end.i
-  br label %5
-
-for.cond8.i:                                      ; preds = %for.inc14.i, %if.end.i
-  br label %exit
-
-for.inc14.i:                                      ; preds = %for.cond8.i
-  br label %exit
-
-if.end18.i:                                       ; preds = %for.cond8.i
-  br label %5
-
-5:                                                ; preds = %if.end18.i, %if.end18.thread.i
-  br label %for.cond25.i
-
-for.cond25.i:                                     ; preds = %for.body29.i, %5
-  br label %exit
-
-for.cond.cleanup27.i:                             ; preds = %for.cond25.i
-  br label %for.cond41.i
-
-for.body29.i:                                     ; preds = %for.cond25.i
-  br label %for.cond25.i
-
-for.cond41.i:                                     ; preds = %for.body45.i, %for.cond.cleanup27.i
-  br label %exit
-
-for.cond.cleanup43.i:                             ; preds = %for.cond41.i
-  br label %exit
-
-for.body45.i:                                     ; preds = %for.cond41.i
-  br label %for.cond41.i
 
 exit:
   ret void

--- a/llvm/test/CodeGen/SPIRV/branching/switch-range-check.ll
+++ b/llvm/test/CodeGen/SPIRV/branching/switch-range-check.ll
@@ -1,0 +1,118 @@
+; RUN: llc -O0 -mtriple=spirv32-unknown-unknown %s -o - | FileCheck %s
+; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv32-unknown-unknown %s -o - -filetype=obj | spirv-val %}
+
+; CHECK: %[[#Var:]] = OpPhi
+; CHECK: OpSwitch %[[#Var]] %[[#]] [[#]] %[[#]] [[#]] %[[#]] [[#]] %[[#]] [[#]] %[[#]] [[#]] %[[#]] [[#]] %[[#]] [[#]] %[[#]] [[#]] %[[#]] [[#]] %[[#]] [[#]] %[[#]] [[#]] %[[#]] [[#]] %[[#]]
+; CHECK-COUNT-11: OpBranch
+; CHECK-NOT: OpBranch
+
+define spir_func void @foo(i64 noundef %addr, i64 noundef %as) {
+entry:
+  %0 = inttoptr i64 %as to ptr addrspace(4)
+  %1 = load i8, ptr addrspace(4) %0
+  %cmp = icmp sgt i8 %1, 0
+  br i1 %cmp, label %if.then, label %if.end
+
+if.then:                                          ; preds = %entry
+  %add.ptr = getelementptr inbounds i8, ptr addrspace(4) %0, i64 1
+  %2 = load i8, ptr addrspace(4) %add.ptr
+  br label %if.end
+
+if.end:                                           ; preds = %if.then, %entry
+  %shadow_value.0.in = phi i8 [ %2, %if.then ], [ %1, %entry ]
+  switch i8 %shadow_value.0.in, label %sw.default [
+    i8 -127, label %sw.epilog
+    i8 -126, label %sw.bb3
+    i8 -125, label %sw.bb4
+    i8 -111, label %sw.bb5
+    i8 -110, label %sw.bb6
+    i8 -109, label %sw.bb7
+    i8 -15, label %sw.bb8
+    i8 -14, label %sw.bb8
+    i8 -13, label %sw.bb8
+    i8 -124, label %sw.bb9
+    i8 -95, label %sw.bb10
+    i8 -123, label %sw.bb11
+  ]
+
+sw.bb3:                                           ; preds = %if.end
+  br label %sw.epilog
+
+sw.bb4:                                           ; preds = %if.end
+  br label %sw.epilog
+
+sw.bb5:                                           ; preds = %if.end
+  br label %sw.epilog
+
+sw.bb6:                                           ; preds = %if.end
+  br label %sw.epilog
+
+sw.bb7:                                           ; preds = %if.end
+  br label %sw.epilog
+
+sw.bb8:                                           ; preds = %if.end, %if.end, %if.end
+  br label %sw.epilog
+
+sw.bb9:                                           ; preds = %if.end
+  br label %sw.epilog
+
+sw.bb10:                                          ; preds = %if.end
+  br label %sw.epilog
+
+sw.bb11:                                          ; preds = %if.end
+  br label %sw.epilog
+
+sw.default:                                       ; preds = %if.end
+  br label %sw.epilog
+
+sw.epilog:                                        ; preds = %sw.default, %sw.bb11, %sw.bb10, %sw.bb9, %sw.bb8, %sw.bb7, %sw.bb6, %sw.bb5, %sw.bb4, %sw.bb3, %if.end
+  br label %exit
+
+if.then.i:                                        ; preds = %sw.epilog
+  br label %exit
+
+for.cond.i:                                       ; preds = %for.inc.i, %if.then.i
+  br label %exit
+
+for.inc.i:                                        ; preds = %for.cond.i
+  br label %exit
+
+if.end.i:                                         ; preds = %for.cond.i, %if.then.i
+  br label %exit
+
+if.end18.thread.i:                                ; preds = %if.end.i
+  br label %5
+
+for.cond8.i:                                      ; preds = %for.inc14.i, %if.end.i
+  br label %exit
+
+for.inc14.i:                                      ; preds = %for.cond8.i
+  br label %exit
+
+if.end18.i:                                       ; preds = %for.cond8.i
+  br label %5
+
+5:                                                ; preds = %if.end18.i, %if.end18.thread.i
+  br label %for.cond25.i
+
+for.cond25.i:                                     ; preds = %for.body29.i, %5
+  br label %exit
+
+for.cond.cleanup27.i:                             ; preds = %for.cond25.i
+  br label %for.cond41.i
+
+for.body29.i:                                     ; preds = %for.cond25.i
+  br label %for.cond25.i
+
+for.cond41.i:                                     ; preds = %for.body45.i, %for.cond.cleanup27.i
+  br label %exit
+
+for.cond.cleanup43.i:                             ; preds = %for.cond41.i
+  br label %exit
+
+for.body45.i:                                     ; preds = %for.cond41.i
+  br label %for.cond41.i
+
+exit:
+  ret void
+}


### PR DESCRIPTION
This PR fixes issue https://github.com/llvm/llvm-project/issues/87763 and preserves valid CFG in cases when previous scheme failed to generate valid code for a switch statement. The PR hardens one existing test case and adds one more test case as a validation of a new switch generation. Tests are passing spirv-val now.

This PR also improves validation of forward calls.

