### PR TITLE
[libc][fenv] Add compile time check

### DIFF
--- a/libc/src/fenv/fegetexceptflag.cpp
+++ b/libc/src/fenv/fegetexceptflag.cpp
@@ -15,7 +15,8 @@
 namespace LIBC_NAMESPACE {
 
 LLVM_LIBC_FUNCTION(int, fegetexceptflag, (fexcept_t * flagp, int excepts)) {
-  // TODO: Add a compile time check to see if the excepts actually fit in flagp.
+  static_assert(sizeof(int) >= sizeof(fexcept_t),
+                "fexcept_t value cannot fit in an int value.");
   *flagp = static_cast<fexcept_t>(fputil::test_except(FE_ALL_EXCEPT) & excepts);
   return 0;
 }


### PR DESCRIPTION
Take care of a TODO. This
check makes sure that the fexcept_t
value fits in an int value.

TODO introduced in: https://github.com/llvm/llvm-project/commit/9550f8ba9a3a697f28a7920c8aeb5cba1e8003a6