### PR TITLE
[libc][c23][fenv] Implement fetestexceptflag

### DIFF
--- a/libc/config/baremetal/arm/entrypoints.txt
+++ b/libc/config/baremetal/arm/entrypoints.txt
@@ -201,6 +201,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.fenv.fesetround
     libc.src.fenv.feraiseexcept
     libc.src.fenv.fetestexcept
+    libc.src.fenv.fetestexceptflag
     libc.src.fenv.feupdateenv
 
     # math.h entrypoints

--- a/libc/config/baremetal/riscv/entrypoints.txt
+++ b/libc/config/baremetal/riscv/entrypoints.txt
@@ -201,6 +201,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.fenv.fesetround
     libc.src.fenv.feraiseexcept
     libc.src.fenv.fetestexcept
+    libc.src.fenv.fetestexceptflag
     libc.src.fenv.feupdateenv
 
     # math.h entrypoints

--- a/libc/config/darwin/arm/entrypoints.txt
+++ b/libc/config/darwin/arm/entrypoints.txt
@@ -112,6 +112,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.fenv.fesetround
     libc.src.fenv.feraiseexcept
     libc.src.fenv.fetestexcept
+    libc.src.fenv.fetestexceptflag
     libc.src.fenv.feupdateenv
 
     # math.h entrypoints

--- a/libc/config/darwin/x86_64/entrypoints.txt
+++ b/libc/config/darwin/x86_64/entrypoints.txt
@@ -106,6 +106,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     # libc.src.fenv.fesetround
     # libc.src.fenv.feraiseexcept
     # libc.src.fenv.fetestexcept
+    # libc.src.fenv.fetestexceptflag
     # libc.src.fenv.feupdateenv
 
     ## Currently disabled for failing tests.

--- a/libc/config/linux/aarch64/entrypoints.txt
+++ b/libc/config/linux/aarch64/entrypoints.txt
@@ -324,6 +324,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.fenv.fesetround
     libc.src.fenv.feraiseexcept
     libc.src.fenv.fetestexcept
+    libc.src.fenv.fetestexceptflag
     libc.src.fenv.feupdateenv
 
     # math.h entrypoints

--- a/libc/config/linux/arm/entrypoints.txt
+++ b/libc/config/linux/arm/entrypoints.txt
@@ -192,6 +192,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.fenv.fesetround
     libc.src.fenv.feraiseexcept
     libc.src.fenv.fetestexcept
+    libc.src.fenv.fetestexceptflag
     libc.src.fenv.feupdateenv
 
     # math.h entrypoints

--- a/libc/config/linux/riscv/entrypoints.txt
+++ b/libc/config/linux/riscv/entrypoints.txt
@@ -332,6 +332,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.fenv.fesetround
     libc.src.fenv.feraiseexcept
     libc.src.fenv.fetestexcept
+    libc.src.fenv.fetestexceptflag
     libc.src.fenv.feupdateenv
 
     # math.h entrypoints

--- a/libc/config/linux/x86_64/entrypoints.txt
+++ b/libc/config/linux/x86_64/entrypoints.txt
@@ -346,6 +346,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.fenv.fesetround
     libc.src.fenv.feraiseexcept
     libc.src.fenv.fetestexcept
+    libc.src.fenv.fetestexceptflag
     libc.src.fenv.feupdateenv
 
     # math.h entrypoints

--- a/libc/config/windows/entrypoints.txt
+++ b/libc/config/windows/entrypoints.txt
@@ -110,6 +110,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.fenv.fesetround
     libc.src.fenv.feraiseexcept
     libc.src.fenv.fetestexcept
+    libc.src.fenv.fetestexceptflag
     libc.src.fenv.feupdateenv
 
     # math.h entrypoints

--- a/libc/docs/c23.rst
+++ b/libc/docs/c23.rst
@@ -21,7 +21,7 @@ Additions:
 * fenv.h
 
   * fesetexcept |check|
-  * fetestexceptflag
+  * fetestexceptflag |check|
   * fegetmode
   * fesetmode
 * math.h

--- a/libc/docs/fenv.rst
+++ b/libc/docs/fenv.rst
@@ -42,7 +42,7 @@ fenv.h Functions
     - |check|
     - 7.6.6.3
   * - fesetexcept
-    -
+    - |check|
     - 7.6.4.4
   * - fesetexceptflag
     - |check|
@@ -57,7 +57,7 @@ fenv.h Functions
     - |check|
     - 7.6.4.7
   * - fetestexceptflag
-    -
+    - |check|
     - 7.6.4.6
   * - feupdateenv
     - |check|

--- a/libc/spec/stdc.td
+++ b/libc/spec/stdc.td
@@ -150,6 +150,11 @@ def StdC : StandardSpec<"stdc"> {
               [ArgSpec<IntType>]
           >,
           FunctionSpec<
+              "fetestexceptflag",
+              RetValSpec<IntType>,
+              [ArgSpec<ConstFExceptTPtr>, ArgSpec<IntType>]
+          >,
+          FunctionSpec<
               "feraiseexcept",
               RetValSpec<IntType>,
               [ArgSpec<IntType>]

--- a/libc/src/fenv/CMakeLists.txt
+++ b/libc/src/fenv/CMakeLists.txt
@@ -63,6 +63,19 @@ add_entrypoint_object(
 )
 
 add_entrypoint_object(
+  fetestexceptflag
+  SRCS
+    fetestexceptflag.cpp
+  HDRS
+    fetestexceptflag.h
+  DEPENDS
+    libc.include.fenv
+    libc.src.__support.FPUtil.fenv_impl
+  COMPILE_OPTIONS
+    -O2
+)
+
+add_entrypoint_object(
   fegetenv
   SRCS
     fegetenv.cpp

--- a/libc/src/fenv/CMakeLists.txt
+++ b/libc/src/fenv/CMakeLists.txt
@@ -69,7 +69,7 @@ add_entrypoint_object(
   HDRS
     fetestexceptflag.h
   DEPENDS
-    libc.include.fenv
+    libc.hdr.types.fexcept_t
     libc.src.__support.FPUtil.fenv_impl
   COMPILE_OPTIONS
     -O2

--- a/libc/src/fenv/fetestexceptflag.cpp
+++ b/libc/src/fenv/fetestexceptflag.cpp
@@ -1,0 +1,24 @@
+//===-- Implementation of fetestexceptflag function -----------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "src/fenv/fetestexceptflag.h"
+#include "src/__support/FPUtil/FEnvImpl.h"
+#include "src/__support/common.h"
+
+#include <fenv.h>
+
+namespace LIBC_NAMESPACE {
+
+LLVM_LIBC_FUNCTION(int, fetestexceptflag,
+                   (const fexcept_t *flagp, int excepts)) {
+  static_assert(sizeof(int) >= sizeof(fexcept_t),
+                "fexcept_t value cannot fit in an int value.");
+  return *flagp | fputil::test_except(excepts);
+}
+
+} // namespace LIBC_NAMESPACE

--- a/libc/src/fenv/fetestexceptflag.cpp
+++ b/libc/src/fenv/fetestexceptflag.cpp
@@ -7,10 +7,9 @@
 //===----------------------------------------------------------------------===//
 
 #include "src/fenv/fetestexceptflag.h"
+#include "hdr/types/fexcept_t.h"
 #include "src/__support/FPUtil/FEnvImpl.h"
 #include "src/__support/common.h"
-
-#include <fenv.h>
 
 namespace LIBC_NAMESPACE {
 

--- a/libc/src/fenv/fetestexceptflag.h
+++ b/libc/src/fenv/fetestexceptflag.h
@@ -1,0 +1,20 @@
+//===-- Implementation header for fetestexceptflag --------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC_FENV_FETESTEXCEPTFLAG_H
+#define LLVM_LIBC_SRC_FENV_FETESTEXCEPTFLAG_H
+
+#include <fenv.h>
+
+namespace LIBC_NAMESPACE {
+
+int fetestexceptflag(const fexcept_t *, int excepts);
+
+} // namespace LIBC_NAMESPACE
+
+#endif // LLVM_LIBC_SRC_FENV_FETESTEXCEPTFLAG_H

--- a/libc/src/fenv/fetestexceptflag.h
+++ b/libc/src/fenv/fetestexceptflag.h
@@ -9,7 +9,7 @@
 #ifndef LLVM_LIBC_SRC_FENV_FETESTEXCEPTFLAG_H
 #define LLVM_LIBC_SRC_FENV_FETESTEXCEPTFLAG_H
 
-#include <fenv.h>
+#include "hdr/types/fexcept_t.h"
 
 namespace LIBC_NAMESPACE {
 

--- a/libc/test/src/fenv/CMakeLists.txt
+++ b/libc/test/src/fenv/CMakeLists.txt
@@ -48,6 +48,7 @@ add_libc_unittest(
   DEPENDS
     libc.src.fenv.fegetexceptflag
     libc.src.fenv.fesetexceptflag
+    libc.src.fenv.fetestexceptflag
     libc.src.__support.FPUtil.fenv_impl
 )
 

--- a/libc/test/src/fenv/exception_flags_test.cpp
+++ b/libc/test/src/fenv/exception_flags_test.cpp
@@ -1,4 +1,5 @@
-//===-- Unittests for fegetexceptflag and fesetexceptflag -----------------===//
+//===-- Unittests for fegetexceptflag, fesetexceptflag and ----------------===//
+//===-- fetestexceptflag --------------------------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -9,11 +10,12 @@
 #include "hdr/types/fexcept_t.h"
 #include "src/fenv/fegetexceptflag.h"
 #include "src/fenv/fesetexceptflag.h"
+#include "src/fenv/fetestexceptflag.h"
 
 #include "src/__support/FPUtil/FEnvImpl.h"
 #include "test/UnitTest/Test.h"
 
-TEST(LlvmLibcFenvTest, GetExceptFlagAndSetExceptFlag) {
+TEST(LlvmLibcFenvTest, GetExceptFlagAndSetExceptFlagAndTestExceptFlag) {
   // We will disable all exceptions to prevent invocation of the exception
   // handler.
   LIBC_NAMESPACE::fputil::disable_except(FE_ALL_EXCEPT);
@@ -39,6 +41,11 @@ TEST(LlvmLibcFenvTest, GetExceptFlagAndSetExceptFlag) {
     ASSERT_EQ(LIBC_NAMESPACE::fesetexceptflag(&eflags, FE_ALL_EXCEPT), 0);
     ASSERT_NE(LIBC_NAMESPACE::fputil::test_except(FE_ALL_EXCEPT) & e, 0);
 
+    // Exception flags are exactly the flags corresponding to the previously
+    // raised exception.
+    ASSERT_EQ(LIBC_NAMESPACE::fetestexceptflag(&eflags, FE_ALL_EXCEPT),
+              LIBC_NAMESPACE::fputil::test_except(FE_ALL_EXCEPT));
+
     // Cleanup. We clear all excepts as raising excepts like FE_OVERFLOW
     // can also raise FE_INEXACT.
     LIBC_NAMESPACE::fputil::clear_except(FE_ALL_EXCEPT);
@@ -48,6 +55,8 @@ TEST(LlvmLibcFenvTest, GetExceptFlagAndSetExceptFlag) {
   LIBC_NAMESPACE::fputil::raise_except(FE_INVALID);
   fexcept_t eflags;
   LIBC_NAMESPACE::fegetexceptflag(&eflags, FE_ALL_EXCEPT);
+  ASSERT_EQ(LIBC_NAMESPACE::fetestexceptflag(&eflags, FE_ALL_EXCEPT),
+            FE_INVALID);
   // Clear all exceptions and raise two other exceptions.
   LIBC_NAMESPACE::fputil::clear_except(FE_ALL_EXCEPT);
   LIBC_NAMESPACE::fputil::raise_except(FE_OVERFLOW | FE_INEXACT);

--- a/libc/test/src/fenv/exception_flags_test.cpp
+++ b/libc/test/src/fenv/exception_flags_test.cpp
@@ -1,5 +1,4 @@
-//===-- Unittests for fegetexceptflag, fesetexceptflag and ----------------===//
-//===-- fetestexceptflag --------------------------------------------------===//
+//===-- Unittests for fe{get|set|test}exceptflag --------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -15,7 +14,7 @@
 #include "src/__support/FPUtil/FEnvImpl.h"
 #include "test/UnitTest/Test.h"
 
-TEST(LlvmLibcFenvTest, GetExceptFlagAndSetExceptFlagAndTestExceptFlag) {
+TEST(LlvmLibcFenvTest, GetSetTestExceptFlag) {
   // We will disable all exceptions to prevent invocation of the exception
   // handler.
   LIBC_NAMESPACE::fputil::disable_except(FE_ALL_EXCEPT);

--- a/libc/test/src/fenv/exception_flags_test.cpp
+++ b/libc/test/src/fenv/exception_flags_test.cpp
@@ -50,16 +50,26 @@ TEST(LlvmLibcFenvTest, GetSetTestExceptFlag) {
     LIBC_NAMESPACE::fputil::clear_except(FE_ALL_EXCEPT);
   }
 
-  // Next, we will raise one exception and save the flags.
+  // Next, we will raise one exception, save the flag and clear all exceptions.
   LIBC_NAMESPACE::fputil::raise_except(FE_INVALID);
-  fexcept_t eflags;
-  LIBC_NAMESPACE::fegetexceptflag(&eflags, FE_ALL_EXCEPT);
-  ASSERT_EQ(LIBC_NAMESPACE::fetestexceptflag(&eflags, FE_ALL_EXCEPT),
+  fexcept_t invalid_flag;
+  LIBC_NAMESPACE::fegetexceptflag(&invalid_flag, FE_ALL_EXCEPT);
+  ASSERT_EQ(LIBC_NAMESPACE::fetestexceptflag(&invalid_flag, FE_ALL_EXCEPT),
             FE_INVALID);
-  // Clear all exceptions and raise two other exceptions.
   LIBC_NAMESPACE::fputil::clear_except(FE_ALL_EXCEPT);
+
+  // Raise two other exceptions and verify that they are set.
   LIBC_NAMESPACE::fputil::raise_except(FE_OVERFLOW | FE_INEXACT);
+  fexcept_t overflow_and_inexact_flag;
+  LIBC_NAMESPACE::fegetexceptflag(&overflow_and_inexact_flag, FE_ALL_EXCEPT);
+  ASSERT_EQ(LIBC_NAMESPACE::fetestexceptflag(&overflow_and_inexact_flag,
+                                             FE_ALL_EXCEPT),
+            FE_OVERFLOW | FE_INEXACT);
+  ASSERT_EQ(LIBC_NAMESPACE::fetestexceptflag(&overflow_and_inexact_flag,
+                                             FE_OVERFLOW | FE_INEXACT),
+            FE_OVERFLOW | FE_INEXACT);
+
   // When we set the flags and test, we should only see FE_INVALID.
-  LIBC_NAMESPACE::fesetexceptflag(&eflags, FE_ALL_EXCEPT);
+  LIBC_NAMESPACE::fesetexceptflag(&invalid_flag, FE_ALL_EXCEPT);
   EXPECT_EQ(LIBC_NAMESPACE::fputil::test_except(FE_ALL_EXCEPT), FE_INVALID);
 }

--- a/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
@@ -1146,6 +1146,16 @@ libc_function(
 )
 
 libc_function(
+    name = "fetestexceptflag",
+    srcs = ["src/fenv/fetestexceptflag.cpp"],
+    hdrs = ["src/fenv/fetestexceptflag.h"],
+    deps = [
+        ":__support_common",
+        ":__support_fputil_fenv_impl",
+    ],
+)
+
+libc_function(
     name = "feclearexcept",
     srcs = ["src/fenv/feclearexcept.cpp"],
     hdrs = ["src/fenv/feclearexcept.h"],

--- a/utils/bazel/llvm-project-overlay/libc/test/src/fenv/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/test/src/fenv/BUILD.bazel
@@ -75,6 +75,7 @@ libc_test(
     libc_function_deps = [
         "//libc:fegetexceptflag",
         "//libc:fesetexceptflag",
+        "//libc:fetestexceptflag",
     ],
     deps = [
         "//libc:__support_fputil_fenv_impl",


### PR DESCRIPTION
Provide C23 `fetestexceptflag` function according to 7.6.4.6 in the latest [revision of the C standard](https://www.open-std.org/jtc1/sc22/wg14/www/docs/n3096.pdf) from 2023-04-02.

Closes https://github.com/llvm/llvm-project/issues/87565.