### PR TITLE
[NFC][OpenMP] Split nesting_of_regions test

### DIFF
--- a/clang/test/OpenMP/Inputs/nesting_of_regions.cpp
+++ b/clang/test/OpenMP/Inputs/nesting_of_regions.cpp
@@ -1,15 +1,3 @@
-// RUN: %clang_cc1 -fsyntax-only -fopenmp -fopenmp-version=45 -fno-openmp-extensions -verify=expected,omp45,omp45warn,omp %s
-// RUN: %clang_cc1 -fsyntax-only -fopenmp -fno-openmp-extensions -verify=expected,omp50,omp %s
-// RUN: %clang_cc1 -fsyntax-only -fopenmp -fopenmp-extensions -verify=expected,omp50 %s
-// RUN: %clang_cc1 -fsyntax-only -fopenmp -fopenmp-version=45 -verify=expected,omp45,omp -fno-openmp-extensions -Wno-openmp %s
-// RUN: %clang_cc1 -fsyntax-only -fopenmp -fopenmp-version=45 -verify=expected,omp45,omp -fno-openmp-extensions -Wno-source-uses-openmp %s
-// RUN: %clang_cc1 -fsyntax-only -fopenmp -fopenmp-version=51 -verify=expected,omp51,omp -fno-openmp-extensions -Wno-source-uses-openmp %s
-
-// RUN: %clang_cc1 -fsyntax-only -fopenmp-simd -fopenmp-version=45 -fno-openmp-extensions -verify=expected,omp45,omp45warn,omp %s
-// RUN: %clang_cc1 -fsyntax-only -fopenmp-simd -verify=expected,omp50,omp -fno-openmp-extensions %s
-// RUN: %clang_cc1 -fsyntax-only -fopenmp-simd -fopenmp-version=51 -verify=expected,omp51,omp -fno-openmp-extensions %s
-// SIMD-ONLY0-NOT: {{__kmpc|__tgt}}
-
 void bar();
 
 template <class T>
@@ -19577,4 +19565,3 @@ void foo() {
 
   return foo<int>();
 }
-

--- a/clang/test/OpenMP/nesting_of_regions_45.cpp
+++ b/clang/test/OpenMP/nesting_of_regions_45.cpp
@@ -1,0 +1,4 @@
+// RUN: %clang_cc1 -fsyntax-only -fopenmp -fopenmp-version=45 -fno-openmp-extensions -verify=expected,omp45,omp45warn,omp %s
+// RUN: %clang_cc1 -fsyntax-only -fopenmp -fopenmp-version=45 -verify=expected,omp45,omp -fno-openmp-extensions -Wno-openmp %s
+
+#include "Inputs/nesting_of_regions.cpp"

--- a/clang/test/OpenMP/nesting_of_regions_50.cpp
+++ b/clang/test/OpenMP/nesting_of_regions_50.cpp
@@ -1,0 +1,4 @@
+// RUN: %clang_cc1 -fsyntax-only -fopenmp -fno-openmp-extensions -verify=expected,omp50,omp %s
+// RUN: %clang_cc1 -fsyntax-only -fopenmp -fopenmp-extensions -verify=expected,omp50 %s
+
+#include "Inputs/nesting_of_regions.cpp"

--- a/clang/test/OpenMP/nesting_of_regions_51.cpp
+++ b/clang/test/OpenMP/nesting_of_regions_51.cpp
@@ -1,0 +1,4 @@
+// RUN: %clang_cc1 -fsyntax-only -fopenmp-simd -fopenmp-version=51 -verify=expected,omp51,omp -fno-openmp-extensions %s
+// RUN: %clang_cc1 -fsyntax-only -fopenmp -fopenmp-version=51 -verify=expected,omp51,omp -fno-openmp-extensions -Wno-source-uses-openmp %s
+
+#include "Inputs/nesting_of_regions.cpp"

--- a/clang/test/OpenMP/nesting_of_regions_simd_45.cpp
+++ b/clang/test/OpenMP/nesting_of_regions_simd_45.cpp
@@ -1,0 +1,3 @@
+// RUN: %clang_cc1 -fsyntax-only -fopenmp-simd -fopenmp-version=45 -fno-openmp-extensions -verify=expected,omp45,omp45warn,omp %s
+
+#include "Inputs/nesting_of_regions.cpp"

--- a/clang/test/OpenMP/nesting_of_regions_simd_50.cpp
+++ b/clang/test/OpenMP/nesting_of_regions_simd_50.cpp
@@ -1,0 +1,3 @@
+// RUN: %clang_cc1 -fsyntax-only -fopenmp-simd -verify=expected,omp50,omp -fno-openmp-extensions %s
+
+#include "Inputs/nesting_of_regions.cpp"


### PR DESCRIPTION
This test is the bottleneck for OpenMP lit tests, running about twice as long as the others. Break it into five tests based on run lines with the same version.