### PR TITLE
 [CodeMoverUtils] Enhance CodeMoverUtils to sink an entire BB

### DIFF
--- a/llvm/unittests/Transforms/Utils/CodeMoverUtilsTest.cpp
+++ b/llvm/unittests/Transforms/Utils/CodeMoverUtilsTest.cpp
@@ -673,6 +673,11 @@ TEST(CodeMoverUtils, IsSafeToMoveTest4) {
         // Can move as %add2 and %sub2 are control flow equivalent,
         // although %add2 does not strictly dominate %sub2.
         EXPECT_TRUE(isSafeToMoveBefore(*SubInst2, *AddInst2, DT, &PDT, &DI));
+
+        BasicBlock *BB0 = getBasicBlockByName(F, "if.then.first");
+        BasicBlock *BB1 = getBasicBlockByName(F, "if.then.second");
+        EXPECT_TRUE(
+            isSafeToMoveBefore(*BB0, *BB1->getTerminator(), DT, &PDT, &DI));
       });
 }
 


### PR DESCRIPTION
When moving an entire basic block after `InsertPoint`, currently we check each instruction whether their users are dominated by `InsertPoint`, however, this can be improved such that even a user is not dominated `InsertPoint`, as long as it appears as a subsequent instruction in the same BB, it is safe to move.

This patch is similar to commit 751be2a064f119af74c7b9b1e52bc904d8aa114d that enhanced hoisting an entire BB, and this patch enhances sinking an entire BB. Please refer to the added functionality in test case `llvm/unittests/Transforms/Utils/CodeMoverUtilsTest.cpp`  that was not supported without this patch.