### PR TITLE
[clang] Reject incomplete types in `__is_layout_compatible()`

### DIFF
--- a/clang/lib/Sema/SemaExprCXX.cpp
+++ b/clang/lib/Sema/SemaExprCXX.cpp
@@ -6026,6 +6026,11 @@ static bool EvaluateBinaryTypeTrait(Sema &Self, TypeTrait BTT, QualType LhsT,
     return false;
   }
   case BTT_IsLayoutCompatible: {
+    if (!LhsT->isVoidType() && !LhsT->isIncompleteArrayType())
+      Self.RequireCompleteType(KeyLoc, LhsT, diag::err_incomplete_type);
+    if (!RhsT->isVoidType() && !RhsT->isIncompleteArrayType())
+      Self.RequireCompleteType(KeyLoc, RhsT, diag::err_incomplete_type);
+
     if (LhsT->isVariableArrayType() || RhsT->isVariableArrayType())
       Self.Diag(KeyLoc, diag::err_vla_unsupported)
           << 1 << tok::kw___is_layout_compatible;


### PR DESCRIPTION
This is a follow-up to #81506. As discussed in #87737, we're rejecting incomplete types, save for exceptions listed in the C++ standard (`void` and arrays of unknown bound). Note that arrays of unknown bound of incomplete types are accepted.

Since we're happy with the current behavior of this intrinsic for flexible array members (https://github.com/llvm/llvm-project/pull/87737#discussion_r1553652570), I added a couple of tests for that as well.