### PR TITLE
[clang] Add CodeGen tests for CWG 6xx issues

### DIFF
--- a/clang/test/CXX/drs/dr605.cpp
+++ b/clang/test/CXX/drs/dr605.cpp
@@ -1,0 +1,23 @@
+// RUN: %clang_cc1 -std=c++98 %s -triple x86_64-linux-gnu -emit-llvm -o - -fexceptions -fcxx-exceptions -pedantic-errors | llvm-cxxfilt -n | FileCheck %s --check-prefixes CHECK
+// RUN: %clang_cc1 -std=c++11 %s -triple x86_64-linux-gnu -emit-llvm -o - -fexceptions -fcxx-exceptions -pedantic-errors | llvm-cxxfilt -n | FileCheck %s --check-prefixes CHECK
+// RUN: %clang_cc1 -std=c++14 %s -triple x86_64-linux-gnu -emit-llvm -o - -fexceptions -fcxx-exceptions -pedantic-errors | llvm-cxxfilt -n | FileCheck %s --check-prefixes CHECK
+// RUN: %clang_cc1 -std=c++17 %s -triple x86_64-linux-gnu -emit-llvm -o - -fexceptions -fcxx-exceptions -pedantic-errors | llvm-cxxfilt -n | FileCheck %s --check-prefixes CHECK
+// RUN: %clang_cc1 -std=c++20 %s -triple x86_64-linux-gnu -emit-llvm -o - -fexceptions -fcxx-exceptions -pedantic-errors | llvm-cxxfilt -n | FileCheck %s --check-prefixes CHECK
+// RUN: %clang_cc1 -std=c++23 %s -triple x86_64-linux-gnu -emit-llvm -o - -fexceptions -fcxx-exceptions -pedantic-errors | llvm-cxxfilt -n | FileCheck %s --check-prefixes CHECK
+// RUN: %clang_cc1 -std=c++2c %s -triple x86_64-linux-gnu -emit-llvm -o - -fexceptions -fcxx-exceptions -pedantic-errors | llvm-cxxfilt -n | FileCheck %s --check-prefixes CHECK
+
+namespace dr605 { // dr605: 2.7
+
+template <class T>
+static T f(T t) {}
+
+template <>
+int f(int t) {}
+
+void g(int a) {
+  f(a);
+}
+
+} // namespace dr605
+
+// CHECK: define internal {{.*}} i32 @int dr605::f<int>(int)

--- a/clang/test/CXX/drs/dr650.cpp
+++ b/clang/test/CXX/drs/dr650.cpp
@@ -1,0 +1,40 @@
+// RUN: %clang_cc1 -std=c++98 %s -triple x86_64-linux-gnu -emit-llvm -o - -fexceptions -fcxx-exceptions -pedantic-errors | llvm-cxxfilt -n | FileCheck %s --check-prefixes CHECK
+// RUN: %clang_cc1 -std=c++11 %s -triple x86_64-linux-gnu -emit-llvm -o - -fexceptions -fcxx-exceptions -pedantic-errors | llvm-cxxfilt -n | FileCheck %s --check-prefixes CHECK
+// RUN: %clang_cc1 -std=c++14 %s -triple x86_64-linux-gnu -emit-llvm -o - -fexceptions -fcxx-exceptions -pedantic-errors | llvm-cxxfilt -n | FileCheck %s --check-prefixes CHECK
+// RUN: %clang_cc1 -std=c++17 %s -triple x86_64-linux-gnu -emit-llvm -o - -fexceptions -fcxx-exceptions -pedantic-errors | llvm-cxxfilt -n | FileCheck %s --check-prefixes CHECK
+// RUN: %clang_cc1 -std=c++20 %s -triple x86_64-linux-gnu -emit-llvm -o - -fexceptions -fcxx-exceptions -pedantic-errors | llvm-cxxfilt -n | FileCheck %s --check-prefixes CHECK
+// RUN: %clang_cc1 -std=c++23 %s -triple x86_64-linux-gnu -emit-llvm -o - -fexceptions -fcxx-exceptions -pedantic-errors | llvm-cxxfilt -n | FileCheck %s --check-prefixes CHECK
+// RUN: %clang_cc1 -std=c++2c %s -triple x86_64-linux-gnu -emit-llvm -o - -fexceptions -fcxx-exceptions -pedantic-errors | llvm-cxxfilt -n | FileCheck %s --check-prefixes CHECK
+
+#if __cplusplus == 199711L
+#define NOTHROW throw()
+#else
+#define NOTHROW noexcept(true)
+#endif
+
+namespace dr650 { // dr650: 2.8
+
+struct Q {
+  ~Q() NOTHROW;
+};
+
+struct R {
+  ~R() NOTHROW;
+};
+
+struct S {
+  ~S() NOTHROW;
+};
+
+const S& f() {
+  Q q;
+  return (R(), S());
+}
+
+} // namespace dr650
+
+// CHECK-LABEL: define {{.*}} @dr650::f()()
+// CHECK:         call void @dr650::S::~S()
+// CHECK:         call void @dr650::R::~R()
+// CHECK:         call void @dr650::Q::~Q()
+// CHECK-LABEL: }

--- a/clang/test/CXX/drs/dr653.cpp
+++ b/clang/test/CXX/drs/dr653.cpp
@@ -1,0 +1,25 @@
+// RUN: %clang_cc1 -std=c++98 %s -triple x86_64-linux-gnu -emit-llvm -o - -fexceptions -fcxx-exceptions -pedantic-errors | llvm-cxxfilt -n | FileCheck %s --check-prefixes CHECK
+// RUN: %clang_cc1 -std=c++11 %s -triple x86_64-linux-gnu -emit-llvm -o - -fexceptions -fcxx-exceptions -pedantic-errors | llvm-cxxfilt -n | FileCheck %s --check-prefixes CHECK
+// RUN: %clang_cc1 -std=c++14 %s -triple x86_64-linux-gnu -emit-llvm -o - -fexceptions -fcxx-exceptions -pedantic-errors | llvm-cxxfilt -n | FileCheck %s --check-prefixes CHECK
+// RUN: %clang_cc1 -std=c++17 %s -triple x86_64-linux-gnu -emit-llvm -o - -fexceptions -fcxx-exceptions -pedantic-errors | llvm-cxxfilt -n | FileCheck %s --check-prefixes CHECK
+// RUN: %clang_cc1 -std=c++20 %s -triple x86_64-linux-gnu -emit-llvm -o - -fexceptions -fcxx-exceptions -pedantic-errors | llvm-cxxfilt -n | FileCheck %s --check-prefixes CHECK
+// RUN: %clang_cc1 -std=c++23 %s -triple x86_64-linux-gnu -emit-llvm -o - -fexceptions -fcxx-exceptions -pedantic-errors | llvm-cxxfilt -n | FileCheck %s --check-prefixes CHECK
+// RUN: %clang_cc1 -std=c++2c %s -triple x86_64-linux-gnu -emit-llvm -o - -fexceptions -fcxx-exceptions -pedantic-errors | llvm-cxxfilt -n | FileCheck %s --check-prefixes CHECK
+
+namespace dr653 { // dr653: 2.7
+
+union U {
+  int a;
+  float b;
+};
+
+void f(U u) {
+  U v;
+  v = u;
+}
+
+} // namespace dr653
+
+// CHECK-LABEL: define {{.*}} void @dr653::f(dr653::U)
+// CHECK:         call void @llvm.memcpy.p0.p0.i64(ptr {{.*}} %v, ptr {{.*}} %u, {{.*}})
+// CHECK-LABEL: }

--- a/clang/test/CXX/drs/dr658.cpp
+++ b/clang/test/CXX/drs/dr658.cpp
@@ -1,0 +1,25 @@
+// RUN: %clang_cc1 -std=c++98 %s -triple x86_64-linux-gnu -emit-llvm -o - -fexceptions -fcxx-exceptions -pedantic-errors | llvm-cxxfilt -n | FileCheck %s --check-prefixes CHECK
+// RUN: %clang_cc1 -std=c++11 %s -triple x86_64-linux-gnu -emit-llvm -o - -fexceptions -fcxx-exceptions -pedantic-errors | llvm-cxxfilt -n | FileCheck %s --check-prefixes CHECK
+// RUN: %clang_cc1 -std=c++14 %s -triple x86_64-linux-gnu -emit-llvm -o - -fexceptions -fcxx-exceptions -pedantic-errors | llvm-cxxfilt -n | FileCheck %s --check-prefixes CHECK
+// RUN: %clang_cc1 -std=c++17 %s -triple x86_64-linux-gnu -emit-llvm -o - -fexceptions -fcxx-exceptions -pedantic-errors | llvm-cxxfilt -n | FileCheck %s --check-prefixes CHECK
+// RUN: %clang_cc1 -std=c++20 %s -triple x86_64-linux-gnu -emit-llvm -o - -fexceptions -fcxx-exceptions -pedantic-errors | llvm-cxxfilt -n | FileCheck %s --check-prefixes CHECK
+// RUN: %clang_cc1 -std=c++23 %s -triple x86_64-linux-gnu -emit-llvm -o - -fexceptions -fcxx-exceptions -pedantic-errors | llvm-cxxfilt -n | FileCheck %s --check-prefixes CHECK
+// RUN: %clang_cc1 -std=c++2c %s -triple x86_64-linux-gnu -emit-llvm -o - -fexceptions -fcxx-exceptions -pedantic-errors | llvm-cxxfilt -n | FileCheck %s --check-prefixes CHECK
+
+namespace dr658 { // dr658: 2.7
+
+void f(int* p1) {
+  char* p2 = reinterpret_cast<char*>(p1);
+}
+
+} // namespace dr658
+
+// We're checking that p1 is stored into p2 without changes.
+
+// CHECK-LABEL: define {{.*}} void @dr658::f(int*)(ptr noundef %p1)
+// CHECK:         [[P1_ADDR:%.+]] = alloca ptr, align 8
+// CHECK-NEXT:    [[P2:%.+]] = alloca ptr, align 8
+// CHECK:         store ptr %p1, ptr [[P1_ADDR]]
+// CHECK-NEXT:    [[TEMP:%.+]] = load ptr, ptr [[P1_ADDR]]
+// CHECK-NEXT:    store ptr [[TEMP]], ptr [[P2]]
+// CHECK-LABEL: }

--- a/clang/test/CXX/drs/dr661.cpp
+++ b/clang/test/CXX/drs/dr661.cpp
@@ -1,0 +1,29 @@
+// RUN: %clang_cc1 -std=c++98 %s -triple x86_64-linux-gnu -emit-llvm -o - -fexceptions -fcxx-exceptions -pedantic-errors | llvm-cxxfilt -n | FileCheck %s --check-prefixes CHECK
+// RUN: %clang_cc1 -std=c++11 %s -triple x86_64-linux-gnu -emit-llvm -o - -fexceptions -fcxx-exceptions -pedantic-errors | llvm-cxxfilt -n | FileCheck %s --check-prefixes CHECK
+// RUN: %clang_cc1 -std=c++14 %s -triple x86_64-linux-gnu -emit-llvm -o - -fexceptions -fcxx-exceptions -pedantic-errors | llvm-cxxfilt -n | FileCheck %s --check-prefixes CHECK
+// RUN: %clang_cc1 -std=c++17 %s -triple x86_64-linux-gnu -emit-llvm -o - -fexceptions -fcxx-exceptions -pedantic-errors | llvm-cxxfilt -n | FileCheck %s --check-prefixes CHECK
+// RUN: %clang_cc1 -std=c++20 %s -triple x86_64-linux-gnu -emit-llvm -o - -fexceptions -fcxx-exceptions -pedantic-errors | llvm-cxxfilt -n | FileCheck %s --check-prefixes CHECK
+// RUN: %clang_cc1 -std=c++23 %s -triple x86_64-linux-gnu -emit-llvm -o - -fexceptions -fcxx-exceptions -pedantic-errors | llvm-cxxfilt -n | FileCheck %s --check-prefixes CHECK
+// RUN: %clang_cc1 -std=c++2c %s -triple x86_64-linux-gnu -emit-llvm -o - -fexceptions -fcxx-exceptions -pedantic-errors | llvm-cxxfilt -n | FileCheck %s --check-prefixes CHECK
+
+namespace dr661 {
+
+void f(int a, int b) { // dr661: 2.7
+  a == b;
+  a != b;
+  a < b;
+  a <= b;
+  a > b;
+  a >= b;
+}
+
+} // namespace dr661
+
+// CHECK-LABEL: define {{.*}} void @dr661::f(int, int)
+// CHECK:         icmp eq
+// CHECK:         icmp ne
+// CHECK:         icmp slt
+// CHECK:         icmp sle
+// CHECK:         icmp sgt
+// CHECK:         icmp sge
+// CHECK-LABEL: }

--- a/clang/test/CXX/drs/dr672.cpp
+++ b/clang/test/CXX/drs/dr672.cpp
@@ -1,0 +1,32 @@
+// RUN: %clang_cc1 -std=c++98 %s -triple x86_64-linux-gnu -emit-llvm -o - -fexceptions -fcxx-exceptions -pedantic-errors | llvm-cxxfilt -n | FileCheck %s --check-prefixes CHECK
+// RUN: %clang_cc1 -std=c++11 %s -triple x86_64-linux-gnu -emit-llvm -o - -fexceptions -fcxx-exceptions -pedantic-errors | llvm-cxxfilt -n | FileCheck %s --check-prefixes CHECK
+// RUN: %clang_cc1 -std=c++14 %s -triple x86_64-linux-gnu -emit-llvm -o - -fexceptions -fcxx-exceptions -pedantic-errors | llvm-cxxfilt -n | FileCheck %s --check-prefixes CHECK
+// RUN: %clang_cc1 -std=c++17 %s -triple x86_64-linux-gnu -emit-llvm -o - -fexceptions -fcxx-exceptions -pedantic-errors | llvm-cxxfilt -n | FileCheck %s --check-prefixes CHECK
+// RUN: %clang_cc1 -std=c++20 %s -triple x86_64-linux-gnu -emit-llvm -o - -fexceptions -fcxx-exceptions -pedantic-errors | llvm-cxxfilt -n | FileCheck %s --check-prefixes CHECK
+// RUN: %clang_cc1 -std=c++23 %s -triple x86_64-linux-gnu -emit-llvm -o - -fexceptions -fcxx-exceptions -pedantic-errors | llvm-cxxfilt -n | FileCheck %s --check-prefixes CHECK
+// RUN: %clang_cc1 -std=c++2c %s -triple x86_64-linux-gnu -emit-llvm -o - -fexceptions -fcxx-exceptions -pedantic-errors | llvm-cxxfilt -n | FileCheck %s --check-prefixes CHECK
+
+#if __cplusplus == 199711L
+#define NOTHROW throw()
+#else
+#define NOTHROW noexcept(true)
+#endif
+
+namespace dr672 { // dr672: 2.7
+
+struct A {
+  A() NOTHROW;
+};
+
+void f() {
+  A *a = new A;
+}
+
+} // namespace dr672
+
+// CHECK-LABEL: define {{.*}} void @dr672::f()()
+// CHECK:         [[A:%.+]] = alloca ptr
+// CHECK:         [[CALL:%.+]] = call {{.*}} ptr @operator new(unsigned long)
+// CHECK:         call void @dr672::A::A()
+// CHECK:         store ptr [[CALL]], ptr [[A]]
+// CHECK-LABEL: }

--- a/clang/test/CXX/drs/dr6xx.cpp
+++ b/clang/test/CXX/drs/dr6xx.cpp
@@ -81,7 +81,7 @@ namespace dr603 { // dr603: yes
 }
 
 // dr604: na
-// dr605 needs IRGen test
+// dr605 is in dr605.cpp
 
 namespace dr606 { // dr606: 3.0
 #if __cplusplus >= 201103L
@@ -253,7 +253,7 @@ namespace dr621 { // dr621: yes
 // dr623: na
 // FIXME: Add documentation saying we allow invalid pointer values.
 
-// dr624 needs an IRGen check.
+// dr624 needs a libc++abi test.
 
 namespace dr625 { // dr625: yes
   template<typename T> struct A {};
@@ -650,7 +650,7 @@ struct Y {
 }
 #endif
 
-// dr650 FIXME: add codegen test
+// dr650 is in dr650.cpp
 
 #if __cplusplus >= 201103L
 namespace dr651 { // dr651: yes
@@ -672,7 +672,7 @@ namespace dr652 { // dr652: yes
 }
 #endif
 
-// dr653 FIXME: add codegen test
+// dr653 is in dr653.cpp
 
 #if __cplusplus >= 201103L
 namespace dr654 { // dr654: sup 1423
@@ -798,7 +798,7 @@ namespace dr657 { // dr657: partial
   Cnvt2<Abs>::type err;
 }
 
-// dr658 FIXME: add codegen test
+// dr658 is in dr658.cpp
 
 #if __cplusplus >= 201103L
 namespace dr659 { // dr659: 3.0
@@ -829,7 +829,7 @@ namespace dr660 { // dr660: 3.0
 }
 #endif
 
-// dr661 FIXME: add codegen test
+// dr661 is in dr661.cpp
 
 namespace dr662 { // dr662: yes
   template <typename T> void f(T t) {
@@ -931,7 +931,7 @@ namespace dr667 { // dr667: 8
 }
 #endif
 
-// dr668 FIXME: add codegen test
+// dr668 needs an libc++abi test
 
 #if __cplusplus >= 201103L
 namespace dr669 { // dr669: yes
@@ -971,7 +971,7 @@ namespace dr671 { // dr671: 2.9
   int m = static_cast<int>(e);
 }
 
-// dr672 FIXME: add codegen test
+// dr672 is in dr672.cpp
 
 namespace dr673 { // dr673: yes
   template<typename> struct X { static const int n = 0; };

--- a/clang/www/cxx_dr_status.html
+++ b/clang/www/cxx_dr_status.html
@@ -3672,7 +3672,7 @@ and <I>POD class</I></td>
     <td><a href="https://cplusplus.github.io/CWG/issues/605.html">605</a></td>
     <td>C++11</td>
     <td>Linkage of explicit specializations</td>
-    <td class="unknown" align="center">Unknown</td>
+    <td class="full" align="center">Clang 2.7</td>
   </tr>
   <tr id="606">
     <td><a href="https://cplusplus.github.io/CWG/issues/606.html">606</a></td>
@@ -3942,7 +3942,7 @@ and <I>POD class</I></td>
     <td><a href="https://cplusplus.github.io/CWG/issues/650.html">650</a></td>
     <td>CD2</td>
     <td>Order of destruction for temporaries bound to the returned value of a function</td>
-    <td class="unknown" align="center">Unknown</td>
+    <td class="full" align="center">Clang 2.8</td>
   </tr>
   <tr id="651">
     <td><a href="https://cplusplus.github.io/CWG/issues/651.html">651</a></td>
@@ -3960,7 +3960,7 @@ and <I>POD class</I></td>
     <td><a href="https://cplusplus.github.io/CWG/issues/653.html">653</a></td>
     <td>CD2</td>
     <td>Copy assignment of unions</td>
-    <td class="unknown" align="center">Unknown</td>
+    <td class="full" align="center">Clang 2.7</td>
   </tr>
   <tr id="654">
     <td><a href="https://cplusplus.github.io/CWG/issues/654.html">654</a></td>
@@ -3990,7 +3990,7 @@ and <I>POD class</I></td>
     <td><a href="https://cplusplus.github.io/CWG/issues/658.html">658</a></td>
     <td>CD2</td>
     <td>Defining <TT>reinterpret_cast</TT> for pointer types</td>
-    <td class="unknown" align="center">Unknown</td>
+    <td class="full" align="center">Clang 2.7</td>
   </tr>
   <tr id="659">
     <td><a href="https://cplusplus.github.io/CWG/issues/659.html">659</a></td>
@@ -4008,7 +4008,7 @@ and <I>POD class</I></td>
     <td><a href="https://cplusplus.github.io/CWG/issues/661.html">661</a></td>
     <td>CD1</td>
     <td>Semantics of arithmetic comparisons</td>
-    <td class="unknown" align="center">Unknown</td>
+    <td class="full" align="center">Clang 2.7</td>
   </tr>
   <tr id="662">
     <td><a href="https://cplusplus.github.io/CWG/issues/662.html">662</a></td>
@@ -4074,7 +4074,7 @@ and <I>POD class</I></td>
     <td><a href="https://cplusplus.github.io/CWG/issues/672.html">672</a></td>
     <td>CD2</td>
     <td>Sequencing of initialization in <I>new-expression</I>s</td>
-    <td class="unknown" align="center">Unknown</td>
+    <td class="full" align="center">Clang 2.7</td>
   </tr>
   <tr id="673">
     <td><a href="https://cplusplus.github.io/CWG/issues/673.html">673</a></td>


### PR DESCRIPTION
This patch covers
[CWG605](https://cplusplus.github.io/CWG/issues/605.html) "Linkage of explicit specializations",
[CWG650](https://cplusplus.github.io/CWG/issues/650.html) "Order of destruction for temporaries bound to the returned value of a function",
[CWG653](https://cplusplus.github.io/CWG/issues/653.html) "Copy assignment of unions",
[CWG658](https://cplusplus.github.io/CWG/issues/658.html) "Defining `reinterpret_cast` for pointer types",
[CWG661](https://cplusplus.github.io/CWG/issues/661.html) "Semantics of arithmetic comparisons",
[CWG672](https://cplusplus.github.io/CWG/issues/672.html) "Sequencing of initialization in _new-expression_s".

[CWG624](https://cplusplus.github.io/CWG/issues/624.html) "Overflow in calculating size of allocation" and [CWG668](https://cplusplus.github.io/CWG/issues/668.html) "Throwing an exception from the destructor of a local static object" are marked as requiring libc++abi tests.