### PR TITLE
[analyzer] Variant checker bindings

### DIFF
--- a/clang/include/clang/StaticAnalyzer/Core/PathSensitive/ExprEngine.h
+++ b/clang/include/clang/StaticAnalyzer/Core/PathSensitive/ExprEngine.h
@@ -440,6 +440,12 @@ public:
 
   const CoreEngine &getCoreEngine() const { return Engine; }
 
+  ProgramStateRef handleCastingBeforeEvalCall(ExplodedNode *Pred,
+                                              const Expr *Ex,
+                                              SVal ValueToBind,
+                                              ProgramStateRef State,
+                                              StmtNodeBuilder* Bldr = nullptr) const;
+
 public:
   /// Visit - Transfer function logic for all statements.  Dispatches to
   ///  other functions that handle specific kinds of statements.

--- a/clang/lib/StaticAnalyzer/Checkers/StdVariantChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/StdVariantChecker.cpp
@@ -270,10 +270,14 @@ private:
       return false;
 
     QualType RefStoredType = StoredSVal->getType(C.getASTContext());
+    llvm::errs() << "Just dump the stored SVal\n";
+    StoredSVal->dump();
+    llvm::errs() <<"\n The type:\n";
 
     if (RefStoredType->getPointeeType().isNull())
       return false;
     QualType StoredType = RefStoredType->getPointeeType();
+    StoredType->dump();
 
     const CallExpr *CE = cast<CallExpr>(Call.getOriginExpr());
     const FunctionDecl *FD = CE->getDirectCallee();
@@ -310,6 +314,9 @@ private:
       return false;
 
     if (RetrievedCanonicalType == StoredCanonicalType) {
+      llvm::errs() << "Variant Checker stroed sval bind dump:\n";
+      StoredSVal->dump();
+      llvm::errs() << "\n";
       State = State->BindExpr(CE, C.getLocationContext(), *StoredSVal);
       C.addTransition(State);
       return true;

--- a/clang/lib/StaticAnalyzer/Checkers/TaggedUnionModeling.h
+++ b/clang/lib/StaticAnalyzer/Checkers/TaggedUnionModeling.h
@@ -55,6 +55,15 @@ bool handleConstructorAndAssignment(const CallEvent &Call, CheckerContext &C,
     return false;
 
   auto ArgSVal = Call.getArgSVal(0);
+  llvm::errs() << "Bind this for std::get\n";
+  ArgSVal.dump();
+  llvm::errs() << "\n";
+  auto *CE0 = Call.getArgExpr(0);
+  if (!CE0)
+    return false;
+  llvm::errs() << "The second one\n";
+  C.getState()->getSVal(CE0, C.getLocationContext()).dump();
+
   const auto *ThisRegion = ThisSVal.getAsRegion();
   const auto *ArgMemRegion = ArgSVal.getAsRegion();
   if (!ArgMemRegion)

--- a/clang/lib/StaticAnalyzer/Checkers/TaggedUnionModeling.h
+++ b/clang/lib/StaticAnalyzer/Checkers/TaggedUnionModeling.h
@@ -9,15 +9,11 @@
 #ifndef LLVM_CLANG_LIB_STATICANALYZER_CHECKERS_TAGGEDUNIONMODELING_H
 #define LLVM_CLANG_LIB_STATICANALYZER_CHECKERS_TAGGEDUNIONMODELING_H
 
-#include "clang/StaticAnalyzer/Checkers/BuiltinCheckerRegistration.h"
-#include "clang/StaticAnalyzer/Core/BugReporter/BugType.h"
-#include "clang/StaticAnalyzer/Core/Checker.h"
 #include "clang/StaticAnalyzer/Core/CheckerManager.h"
-#include "clang/StaticAnalyzer/Core/PathSensitive/CallDescription.h"
 #include "clang/StaticAnalyzer/Core/PathSensitive/CallEvent.h"
 #include "clang/StaticAnalyzer/Core/PathSensitive/CheckerContext.h"
-#include "llvm/ADT/FoldingSet.h"
-#include <numeric>
+#include "clang/StaticAnalyzer/Core/PathSensitive/SVals.h"
+#include <vector>
 
 namespace clang::ento::tagged_union_modeling {
 
@@ -30,6 +26,7 @@ bool isMoveAssignmentCall(const CallEvent &Call);
 bool isMoveConstructorCall(const CallEvent &Call);
 bool isStdType(const Type *Type, const std::string &TypeName);
 bool isStdVariant(const Type *Type);
+void printSVals(std::vector<SVal> v);
 
 // When invalidating regions, we also have to follow that by invalidating the
 // corresponding custom data in the program state.
@@ -51,27 +48,29 @@ removeInformationStoredForDeadInstances(const CallEvent &Call,
 }
 
 template <class TypeMap>
-void handleConstructorAndAssignment(const CallEvent &Call, CheckerContext &C,
+bool handleConstructorAndAssignment(const CallEvent &Call, CheckerContext &C,
                                     SVal ThisSVal) {
   ProgramStateRef State = Call.getState();
 
   if (!State)
-    return;
+    return false;
 
   auto ArgSVal = Call.getArgSVal(0);
   const auto *ThisRegion = ThisSVal.getAsRegion();
   const auto *ArgMemRegion = ArgSVal.getAsRegion();
+  if (!ArgMemRegion)
+    return false;
 
   // Make changes to the state according to type of constructor/assignment
   bool IsCopy = isCopyConstructorCall(Call) || isCopyAssignmentCall(Call);
   bool IsMove = isMoveConstructorCall(Call) || isMoveAssignmentCall(Call);
   // First we handle copy and move operations
   if (IsCopy || IsMove) {
-    const QualType *OtherQType = State->get<TypeMap>(ArgMemRegion);
-
+    // const QualType *OtherQType = State->get<TypeMap>(ArgMemRegion);
+    const SVal *OtherSVal = State->get<TypeMap>(ArgMemRegion);
     // If the argument of a copy constructor or assignment is unknown then
     // we will not know the argument of the copied to object.
-    if (!OtherQType) {
+    if (!OtherSVal) {
       State = State->remove<TypeMap>(ThisRegion);
     } else {
       // When move semantics is used we can only know that the moved from
@@ -80,18 +79,65 @@ void handleConstructorAndAssignment(const CallEvent &Call, CheckerContext &C,
       if (IsMove)
         State = State->remove<TypeMap>(ArgMemRegion);
 
-      State = State->set<TypeMap>(ThisRegion, *OtherQType);
+      State = State->set<TypeMap>(ThisRegion, *OtherSVal);
     }
   } else {
-    // Value constructor
-    auto ArgQType = ArgSVal.getType(C.getASTContext());
-    const Type *ArgTypePtr = ArgQType.getTypePtr();
+    // Value constructor.
+    // Here we create a MemRegion and an SVal for the value held by
+    // std::variant, since std::variant owns the held value.
+    //
+    // If we don't do this here later on UndefinedAssignmentChecker will warn
+    // for garbage value assignment.
+    const auto *Mreg = ArgSVal.getAsRegion();
+    SVal PointedToSVal = C.getState()->getSVal(Mreg);
 
-    QualType WoPointer = ArgTypePtr->getPointeeType();
-    State = State->set<TypeMap>(ThisRegion, WoPointer);
+    auto SymForStdVariantHeldValue = C.getSValBuilder().conjureSymbolVal(
+        "std::variant held value", Call.getArgExpr(0), C.getLocationContext(),
+        C.blockCount());
+    auto *SymRegForStdVariantHeldValue =
+        C.getSValBuilder().getRegionManager().getSymbolicRegion(
+            SymForStdVariantHeldValue.getAsSymbol());
+    auto LocForVariantHeldValue =
+        C.getSValBuilder().makeLoc(SymRegForStdVariantHeldValue);
+    State = State->bindLoc(LocForVariantHeldValue, PointedToSVal,
+                           C.getLocationContext());
+    State = State->set<TypeMap>(ThisRegion, LocForVariantHeldValue);
   }
 
   C.addTransition(State);
+  return true;
+}
+
+template <class HeldValueMap>
+bool handleStdSwapCall(const CallEvent &Call, CheckerContext &C) {
+  assert(Call.getNumArgs() == 2 &&
+         "This function only handles std::swap with two arguments.");
+
+  for (unsigned i = 0; i < Call.getNumArgs(); i++) {
+    if (!isStdVariant(Call.getArgExpr(i)->getType().getTypePtr()))
+      return false;
+  }
+
+  ProgramStateRef State = C.getState();
+
+  const MemRegion *LeftRegion = Call.getArgSVal(0).getAsRegion();
+  const MemRegion *RightRegion = Call.getArgSVal(1).getAsRegion();
+  if (!LeftRegion || !RightRegion)
+    return false;
+
+  const SVal *LeftSVal = State->get<HeldValueMap>(LeftRegion);
+  const SVal *RightSVal = State->get<HeldValueMap>(RightRegion);
+  if (!LeftSVal || !RightSVal) {
+    State = State->remove<HeldValueMap>(LeftRegion);
+    State = State->remove<HeldValueMap>(RightRegion);
+    C.addTransition(State);
+    return false;
+  }
+
+  State = State->set<HeldValueMap>(LeftRegion, *RightSVal);
+  State = State->set<HeldValueMap>(RightRegion, *LeftSVal);
+  C.addTransition(State);
+  return true;
 }
 
 } // namespace clang::ento::tagged_union_modeling

--- a/clang/lib/StaticAnalyzer/Checkers/UndefinedAssignmentChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/UndefinedAssignmentChecker.cpp
@@ -108,12 +108,6 @@ void UndefinedAssignmentChecker::checkBind(SVal location, SVal val,
     bugreporter::trackExpressionValue(N, ex, *R);
   }
   C.emitReport(std::move(R));
-  // llvm::errs() << "Undef checker reports to loc: \n";
-  // location.dump();
-  // llvm::errs() << "\nand Val:\n";
-  // val.dump();
-  // //C.getState()->dump();
-  // llvm::errs() << "\n";
 }
 
 void ento::registerUndefinedAssignmentChecker(CheckerManager &mgr) {

--- a/clang/lib/StaticAnalyzer/Checkers/UndefinedAssignmentChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/UndefinedAssignmentChecker.cpp
@@ -16,6 +16,7 @@
 #include "clang/StaticAnalyzer/Core/Checker.h"
 #include "clang/StaticAnalyzer/Core/CheckerManager.h"
 #include "clang/StaticAnalyzer/Core/PathSensitive/CheckerContext.h"
+#include "llvm/Support/raw_ostream.h"
 
 using namespace clang;
 using namespace ento;
@@ -101,13 +102,18 @@ void UndefinedAssignmentChecker::checkBind(SVal location, SVal val,
 
   if (OS.str().empty())
     OS << BT.getDescription();
-
   auto R = std::make_unique<PathSensitiveBugReport>(BT, OS.str(), N);
   if (ex) {
     R->addRange(ex->getSourceRange());
     bugreporter::trackExpressionValue(N, ex, *R);
   }
   C.emitReport(std::move(R));
+  // llvm::errs() << "Undef checker reports to loc: \n";
+  // location.dump();
+  // llvm::errs() << "\nand Val:\n";
+  // val.dump();
+  // //C.getState()->dump();
+  // llvm::errs() << "\n";
 }
 
 void ento::registerUndefinedAssignmentChecker(CheckerManager &mgr) {

--- a/clang/lib/StaticAnalyzer/Core/ExprEngine.cpp
+++ b/clang/lib/StaticAnalyzer/Core/ExprEngine.cpp
@@ -2261,6 +2261,8 @@ void ExprEngine::Visit(const Stmt *S, ExplodedNode *Pred,
       Bldr.takeNodes(Pred);
       const auto *C = cast<CastExpr>(S);
       ExplodedNodeSet dstExpr;
+      // Point of interes: maybe my cast somehow will not get visited or will
+      // be visited before I bind to it.
       VisitCast(C, C->getSubExpr(), Pred, dstExpr);
 
       // Handle the postvisit checks.

--- a/clang/lib/StaticAnalyzer/Core/ExprEngineC.cpp
+++ b/clang/lib/StaticAnalyzer/Core/ExprEngineC.cpp
@@ -300,6 +300,7 @@ ProgramStateRef ExprEngine::handleLValueBitCast(
 
 void ExprEngine::VisitCast(const CastExpr *CastE, const Expr *Ex,
                            ExplodedNode *Pred, ExplodedNodeSet &Dst) {
+  
 
   ExplodedNodeSet dstPreStmt;
   getCheckerManager().runCheckersForPreStmt(dstPreStmt, Pred, CastE, *this);
@@ -350,6 +351,12 @@ void ExprEngine::VisitCast(const CastExpr *CastE, const Expr *Ex,
       case CK_UserDefinedConversion:
       case CK_FunctionToPointerDecay:
       case CK_BuiltinFnToFnPtr: {
+        llvm::errs() << "-- VisitCast BEGIN --\n";
+        llvm::errs() << "   The cast expr:\n";
+        CastE->dump();
+        llvm::errs() << "   The Expr behind it:\n";
+        Ex->dump();
+        llvm::errs() << "-- VisitCast END --\n";
         // Copy the SVal of Ex to CastE.
         // Point of interest
         state = updateStateAfterSimpleCast(Bldr, Pred, CastE, Ex);

--- a/clang/lib/StaticAnalyzer/Core/ExprEngineC.cpp
+++ b/clang/lib/StaticAnalyzer/Core/ExprEngineC.cpp
@@ -641,14 +641,9 @@ void ExprEngine::VisitDeclStmt(const DeclStmt *DS, ExplodedNode *Pred,
       // the handling of the casting is the responsible to bind the
       // sub expressions (in our case std::get call expressions) value
       // to the cast expression.
-      if (auto *AsImplCast = dyn_cast_or_null<CastExpr>(InitEx);
-          AsImplCast && InitVal.isUndef()) {
-        // InitVal = state->getSVal(AsImplCast->getSubExpr(), LC);
-        state = updateStateAfterSimpleCast(B, Pred, AsImplCast,
-                                           AsImplCast->getSubExpr());
-        B.generateNode(InitEx, Pred, state);
-        InitVal = state->getSVal(InitEx, LC);
-      }
+
+      state = handleCastingBeforeEvalCall(Pred, InitEx, InitVal, state, &B);
+      InitVal = state->getSVal(InitEx, LC);
 
       assert(DS->isSingleDecl());
       if (getObjectUnderConstruction(state, DS, LC)) {

--- a/clang/lib/StaticAnalyzer/Core/ExprEngineCallAndReturn.cpp
+++ b/clang/lib/StaticAnalyzer/Core/ExprEngineCallAndReturn.cpp
@@ -686,6 +686,9 @@ void ExprEngine::evalCall(ExplodedNodeSet &Dst, ExplodedNode *Pred,
   // Actually evaluate the function call.  We try each of the checkers
   // to see if the can evaluate the function call, and get a callback at
   // defaultEvalCall if all of them fail.
+  llvm::errs() << "Evaluating call\n";
+  Call.dump();
+  llvm::errs() << "\nEvaluating call END\n";
   ExplodedNodeSet dstCallEvaluated;
   getCheckerManager().runCheckersForEvalCall(dstCallEvaluated, dstPreVisit,
                                              Call, *this, EvalCallOptions());

--- a/clang/test/Analysis/Inputs/system-header-simulator-cxx.h
+++ b/clang/test/Analysis/Inputs/system-header-simulator-cxx.h
@@ -1354,6 +1354,7 @@ template <typename Ret, typename... Args> class packaged_task<Ret(Args...)> {
   constexpr add_pointer_t<T> get_if(variant<Types...>*) noexcept;
   template <class T, class... Types>
   constexpr add_pointer_t<const T> get_if(const variant<Types...>*) noexcept;
+  
 
   template <class... Types>
   class variant {
@@ -1371,6 +1372,8 @@ template <typename Ret, typename... Args> class packaged_task<Ret(Args...)> {
     template<typename T,
             typename = std::enable_if_t<!is_same_v<std::variant<Types...>, decay_t<T>>>>
     variant& operator=(T&&);
+    template<class T, class... Args>
+      constexpr T& emplace(Args&&...);
   };
   #endif
 

--- a/clang/test/Analysis/std-variant-checker.cpp
+++ b/clang/test/Analysis/std-variant-checker.cpp
@@ -384,3 +384,10 @@ void stdEmplace() {
   (void)a;
   (void)c;
 }
+
+void followHeldValue() {
+  std::variant<int, char> v = 0;
+  int a = std::get<int> (v);
+  int b = 5/a;
+  (void)b;
+}

--- a/clang/test/Analysis/std-variant-checker.cpp
+++ b/clang/test/Analysis/std-variant-checker.cpp
@@ -388,6 +388,6 @@ void stdEmplace() {
 void followHeldValue() {
   std::variant<int, char> v = 0;
   int a = std::get<int> (v);
-  int b = 5/a;
+  int b = 5/a; // expected-warning {{The right operand of '/' is a garbage value}}
   (void)b;
 }

--- a/clang/test/Analysis/std-variant-checker.cpp
+++ b/clang/test/Analysis/std-variant-checker.cpp
@@ -81,6 +81,7 @@ void stdGetObject() {
   Foo f = std::get<Foo>(v);
   int i = std::get<int>(v); // expected-warning {{std::variant 'v' held a 'Foo', not an 'int'}}
   (void)i;
+  (void)f;
 }
 
 void stdGetPointerAndPointee() {
@@ -351,6 +352,33 @@ void nonInlineFunctionCall() {
 void nonInlineFunctionCallPtr() {
   std::variant<int, char> v = 'c';
   changesToInt(&v);
+  int a = std::get<int> (v); // no-warning
+  char c = std::get<char> (v); // no-warning
+  (void)a;
+  (void)c;
+}
+
+//----------------------------------------------------------------------------//
+// std::swap for std::variant
+//----------------------------------------------------------------------------//
+
+void swapForVariants() {
+  std::variant<int, char> a = 5;
+  std::variant<int, char> b = 'C';
+  std::swap(a, b);
+  int a1 = std::get<int>(b);
+  char c = std::get<int>(a); // expected-warning {{std::variant 'a' held a 'char', not an 'int'}}
+  (void)a1;
+  (void)c;
+}
+
+//----------------------------------------------------------------------------//
+// std::swap for std::variant
+//----------------------------------------------------------------------------//
+
+void stdEmplace() {
+  std::variant<int, char> v = 'c';
+  v.emplace<int> (5);
   int a = std::get<int> (v); // no-warning
   char c = std::get<char> (v); // no-warning
   (void)a;


### PR DESCRIPTION
An eval call should bind an SVal to the evaluated call expression. The goal of this PR is to do that. It mostly works after fixing a minor bug.

There are still some failing tests of which you can see more information in the commit description.
The reason why these tests are failing is that this "post processing of casts after call evaluation" does not happen before every `evalBind` callback. I am still thinking of an elegant way how to implement this post processing elegantly for each eval call. I can not put this logic into eval call because in that call we do not have enough information about the expression to do the post processing.