### PR TITLE
[clang-pseudo] clang-format files

### DIFF
--- a/clang-tools-extra/pseudo/gen/Main.cpp
+++ b/clang-tools-extra/pseudo/gen/Main.cpp
@@ -74,7 +74,7 @@ std::string mangleSymbol(SymbolID SID, const Grammar &G) {
 #define TOK(X) llvm::StringRef(#X).upper(),
 #define KEYWORD(Keyword, Condition) llvm::StringRef(#Keyword).upper(),
 #include "clang/Basic/TokenKinds.def"
-      };
+  };
   if (isToken(SID))
     return TokNames[symbolToToken(SID)];
   std::string Name = G.symbolName(SID).str();
@@ -84,7 +84,7 @@ std::string mangleSymbol(SymbolID SID, const Grammar &G) {
 }
 
 // Mangles the RHS of a rule definition into a valid identifier.
-// 
+//
 // These are unique only for a fixed LHS.
 // e.g. for the grammar rule `ptr-declarator := ptr-operator ptr-declarator`,
 // it is `ptr_operator__ptr_declarator`.

--- a/clang-tools-extra/pseudo/include/clang-pseudo/GLR.h
+++ b/clang-tools-extra/pseudo/include/clang-pseudo/GLR.h
@@ -120,8 +120,8 @@ struct ParseParams {
   const TokenStream &Code;
 
   // Arena for data structure used by the GLR algorithm.
-  ForestArena &Forest;  // Storage for the output forest.
-  GSS &GSStack;         // Storage for parsing stacks.
+  ForestArena &Forest; // Storage for the output forest.
+  GSS &GSStack;        // Storage for parsing stacks.
 };
 
 // Parses the given token stream as the start symbol with the GLR algorithm,

--- a/clang-tools-extra/pseudo/include/clang-pseudo/cxx/CXX.h
+++ b/clang-tools-extra/pseudo/include/clang-pseudo/cxx/CXX.h
@@ -65,7 +65,7 @@ enum Rule : RuleID {
 #define RULE(LHS, RHS, ID) RHS = ID,
 #include "CXXSymbols.inc"
 };
-}
+} // namespace dummy
 } // namespace rules
 } // namespace detail
 

--- a/clang-tools-extra/pseudo/include/clang-pseudo/grammar/LRGraph.h
+++ b/clang-tools-extra/pseudo/include/clang-pseudo/grammar/LRGraph.h
@@ -143,9 +143,9 @@ public:
   //   stmt := { . stmt-seq [recover=braces] }
   // has a Recovery { Src = S, Strategy=braces, Result=stmt-seq }.
   struct Recovery {
-    StateID Src; // The state we are in when encountering the error.
-    ExtensionID Strategy;      // Heuristic choosing the tokens to match.
-    SymbolID Result;           // The symbol that is produced.
+    StateID Src;          // The state we are in when encountering the error.
+    ExtensionID Strategy; // Heuristic choosing the tokens to match.
+    SymbolID Result;      // The symbol that is produced.
   };
 
   llvm::ArrayRef<State> states() const { return States; }

--- a/clang-tools-extra/pseudo/include/clang-pseudo/grammar/LRTable.h
+++ b/clang-tools-extra/pseudo/include/clang-pseudo/grammar/LRTable.h
@@ -76,14 +76,13 @@ public:
   // Expected to be called by LR parsers.
   // If the nonterminal is invalid here, returns std::nullopt.
   std::optional<StateID> getGoToState(StateID State,
-                                       SymbolID Nonterminal) const {
+                                      SymbolID Nonterminal) const {
     return Gotos.get(gotoIndex(State, Nonterminal, numStates()));
   }
   // Returns the state after we shift a terminal.
   // Expected to be called by LR parsers.
   // If the terminal is invalid here, returns std::nullopt.
-  std::optional<StateID> getShiftState(StateID State,
-                                        SymbolID Terminal) const {
+  std::optional<StateID> getShiftState(StateID State, SymbolID Terminal) const {
     return Shifts.get(shiftIndex(State, Terminal, numStates()));
   }
 

--- a/clang-tools-extra/pseudo/lib/DirectiveTree.cpp
+++ b/clang-tools-extra/pseudo/lib/DirectiveTree.cpp
@@ -148,9 +148,9 @@ struct Dumper {
   llvm::raw_ostream &OS;
   unsigned Indent = 0;
 
-  Dumper(llvm::raw_ostream& OS) : OS(OS) {}
-  void operator()(const DirectiveTree& Tree) {
-    for (const auto& Chunk : Tree.Chunks)
+  Dumper(llvm::raw_ostream &OS) : OS(OS) {}
+  void operator()(const DirectiveTree &Tree) {
+    for (const auto &Chunk : Tree.Chunks)
       std::visit(*this, Chunk);
   }
   void operator()(const DirectiveTree::Conditional &Conditional) {
@@ -185,7 +185,7 @@ DirectiveTree DirectiveTree::parse(const TokenStream &Code) {
 // Define operator<< in terms of dump() functions above.
 #define OSTREAM_DUMP(Type)                                                     \
   llvm::raw_ostream &operator<<(llvm::raw_ostream &OS, const Type &T) {        \
-    Dumper{OS}(T);                                                         \
+    Dumper{OS}(T);                                                             \
     return OS;                                                                 \
   }
 OSTREAM_DUMP(DirectiveTree)

--- a/clang-tools-extra/pseudo/lib/GLR.cpp
+++ b/clang-tools-extra/pseudo/lib/GLR.cpp
@@ -317,7 +317,7 @@ template <typename T> void sortAndUnique(std::vector<T> &Vec) {
 // storage across calls).
 class GLRReduce {
   const ParseParams &Params;
-  const Language& Lang;
+  const Language &Lang;
   // There are two interacting complications:
   // 1.  Performing one reduce can unlock new reduces on the newly-created head.
   // 2a. The ambiguous ForestNodes must be complete (have all sequence nodes).
@@ -390,7 +390,7 @@ class GLRReduce {
   struct PushSpec {
     // The last node popped before pushing. Its parent is the reduction base(s).
     // (Base is more fundamental, but this is cheaper to store).
-    const GSS::Node* LastPop = nullptr;
+    const GSS::Node *LastPop = nullptr;
     Sequence *Seq = nullptr;
   };
   KeyedQueue<Family, PushSpec> Sequences; // FIXME: rename => PendingPushes?
@@ -402,6 +402,7 @@ class GLRReduce {
   SymbolID Lookahead;
 
   Sequence TempSequence;
+
 public:
   GLRReduce(const ParseParams &Params, const Language &Lang)
       : Params(Params), Lang(Lang) {}
@@ -603,7 +604,8 @@ ForestNode &glrParse(const ParseParams &Params, SymbolID StartSymbol,
                      const Language &Lang) {
   GLRReduce Reduce(Params, Lang);
   assert(isNonterminal(StartSymbol) && "Start symbol must be a nonterminal");
-  llvm::ArrayRef<ForestNode> Terminals = Params.Forest.createTerminals(Params.Code);
+  llvm::ArrayRef<ForestNode> Terminals =
+      Params.Forest.createTerminals(Params.Code);
   auto &GSS = Params.GSStack;
 
   StateID StartState = Lang.Table.getStartState(StartSymbol);
@@ -628,9 +630,10 @@ ForestNode &glrParse(const ParseParams &Params, SymbolID StartSymbol,
   };
   // Each iteration fully processes a single token.
   for (unsigned I = 0; I < Terminals.size();) {
-    LLVM_DEBUG(llvm::dbgs() << llvm::formatv(
-                   "Next token {0} (id={1})\n",
-                  Lang.G.symbolName(Terminals[I].symbol()), Terminals[I].symbol()));
+    LLVM_DEBUG(llvm::dbgs()
+               << llvm::formatv("Next token {0} (id={1})\n",
+                                Lang.G.symbolName(Terminals[I].symbol()),
+                                Terminals[I].symbol()));
     // Consume the token.
     glrShift(Heads, Terminals[I], Params, Lang, NextHeads);
 
@@ -749,8 +752,8 @@ unsigned GSS::gc(std::vector<const Node *> &&Queue) {
   while (!Queue.empty()) {
     Node *N = const_cast<Node *>(Queue.back()); // Safe: we created these nodes.
     Queue.pop_back();
-    if (N->GCParity != GCParity) { // Not seen yet
-      N->GCParity = GCParity;      // Mark as seen
+    if (N->GCParity != GCParity) {       // Not seen yet
+      N->GCParity = GCParity;            // Mark as seen
       for (const Node *P : N->parents()) // And walk parents
         Queue.push_back(P);
     }

--- a/clang-tools-extra/pseudo/lib/cxx/CXX.cpp
+++ b/clang-tools-extra/pseudo/lib/cxx/CXX.cpp
@@ -207,72 +207,74 @@ bool hasExclusiveType(const ForestNode *N) {
     // All supported symbols are nonterminals.
     assert(N->kind() == ForestNode::Sequence);
     switch (N->rule()) {
-      // seq := element seq: check element then continue into seq
-      case rule::decl_specifier_seq::decl_specifier__decl_specifier_seq:
-      case rule::defining_type_specifier_seq::defining_type_specifier__defining_type_specifier_seq:
-      case rule::type_specifier_seq::type_specifier__type_specifier_seq:
-        if (hasExclusiveType(N->children()[0]))
-          return true;
-        N = N->children()[1];
-        continue;
-      // seq := element: continue into element
-      case rule::decl_specifier_seq::decl_specifier:
-      case rule::type_specifier_seq::type_specifier:
-      case rule::defining_type_specifier_seq::defining_type_specifier:
-        N = N->children()[0];
-        continue;
-
-      // defining-type-specifier
-      case rule::defining_type_specifier::type_specifier:
-        N = N->children()[0];
-        continue;
-      case rule::defining_type_specifier::class_specifier:
-      case rule::defining_type_specifier::enum_specifier:
+    // seq := element seq: check element then continue into seq
+    case rule::decl_specifier_seq::decl_specifier__decl_specifier_seq:
+    case rule::defining_type_specifier_seq::
+        defining_type_specifier__defining_type_specifier_seq:
+    case rule::type_specifier_seq::type_specifier__type_specifier_seq:
+      if (hasExclusiveType(N->children()[0]))
         return true;
+      N = N->children()[1];
+      continue;
+    // seq := element: continue into element
+    case rule::decl_specifier_seq::decl_specifier:
+    case rule::type_specifier_seq::type_specifier:
+    case rule::defining_type_specifier_seq::defining_type_specifier:
+      N = N->children()[0];
+      continue;
 
-      // decl-specifier
-      case rule::decl_specifier::defining_type_specifier:
-        N = N->children()[0];
-        continue;
-      case rule::decl_specifier::CONSTEVAL:
-      case rule::decl_specifier::CONSTEXPR:
-      case rule::decl_specifier::CONSTINIT:
-      case rule::decl_specifier::INLINE:
-      case rule::decl_specifier::FRIEND:
-      case rule::decl_specifier::storage_class_specifier:
-      case rule::decl_specifier::TYPEDEF:
-      case rule::decl_specifier::function_specifier:
-        return false;
+    // defining-type-specifier
+    case rule::defining_type_specifier::type_specifier:
+      N = N->children()[0];
+      continue;
+    case rule::defining_type_specifier::class_specifier:
+    case rule::defining_type_specifier::enum_specifier:
+      return true;
 
-      // type-specifier
-      case rule::type_specifier::elaborated_type_specifier:
-      case rule::type_specifier::typename_specifier:
-        return true;
-      case rule::type_specifier::simple_type_specifier:
-        N = N->children()[0];
-        continue;
-      case rule::type_specifier::cv_qualifier:
-        return false;
+    // decl-specifier
+    case rule::decl_specifier::defining_type_specifier:
+      N = N->children()[0];
+      continue;
+    case rule::decl_specifier::CONSTEVAL:
+    case rule::decl_specifier::CONSTEXPR:
+    case rule::decl_specifier::CONSTINIT:
+    case rule::decl_specifier::INLINE:
+    case rule::decl_specifier::FRIEND:
+    case rule::decl_specifier::storage_class_specifier:
+    case rule::decl_specifier::TYPEDEF:
+    case rule::decl_specifier::function_specifier:
+      return false;
 
-      // simple-type-specifier
-      case rule::simple_type_specifier::type_name:
-      case rule::simple_type_specifier::template_name:
-      case rule::simple_type_specifier::builtin_type:
-      case rule::simple_type_specifier::nested_name_specifier__TEMPLATE__simple_template_id:
-      case rule::simple_type_specifier::nested_name_specifier__template_name:
-      case rule::simple_type_specifier::nested_name_specifier__type_name:
-      case rule::simple_type_specifier::decltype_specifier:
-      case rule::simple_type_specifier::placeholder_type_specifier:
-        return true;
-      case rule::simple_type_specifier::LONG:
-      case rule::simple_type_specifier::SHORT:
-      case rule::simple_type_specifier::SIGNED:
-      case rule::simple_type_specifier::UNSIGNED:
-        return false;
+    // type-specifier
+    case rule::type_specifier::elaborated_type_specifier:
+    case rule::type_specifier::typename_specifier:
+      return true;
+    case rule::type_specifier::simple_type_specifier:
+      N = N->children()[0];
+      continue;
+    case rule::type_specifier::cv_qualifier:
+      return false;
 
-      default:
-        LLVM_DEBUG(llvm::errs() << "Unhandled rule " << N->rule() << "\n");
-        llvm_unreachable("hasExclusiveType be exhaustive!");
+    // simple-type-specifier
+    case rule::simple_type_specifier::type_name:
+    case rule::simple_type_specifier::template_name:
+    case rule::simple_type_specifier::builtin_type:
+    case rule::simple_type_specifier::
+        nested_name_specifier__TEMPLATE__simple_template_id:
+    case rule::simple_type_specifier::nested_name_specifier__template_name:
+    case rule::simple_type_specifier::nested_name_specifier__type_name:
+    case rule::simple_type_specifier::decltype_specifier:
+    case rule::simple_type_specifier::placeholder_type_specifier:
+      return true;
+    case rule::simple_type_specifier::LONG:
+    case rule::simple_type_specifier::SHORT:
+    case rule::simple_type_specifier::SIGNED:
+    case rule::simple_type_specifier::UNSIGNED:
+      return false;
+
+    default:
+      LLVM_DEBUG(llvm::errs() << "Unhandled rule " << N->rule() << "\n");
+      llvm_unreachable("hasExclusiveType be exhaustive!");
     }
   }
 }
@@ -283,13 +285,13 @@ llvm::DenseMap<ExtensionID, RuleGuard> buildGuards() {
     [](const GuardParams &P) { return cond; }                                  \
   }
 #define TOKEN_GUARD(kind, cond)                                                \
-  [](const GuardParams& P) {                                                   \
+  [](const GuardParams &P) {                                                   \
     const Token &Tok = onlyToken(tok::kind, P.RHS, P.Tokens);                  \
     return cond;                                                               \
   }
 #define SYMBOL_GUARD(kind, cond)                                               \
-  [](const GuardParams& P) {                                                   \
-    const ForestNode &N = onlySymbol(Symbol::kind, P.RHS, P.Tokens); \
+  [](const GuardParams &P) {                                                   \
+    const ForestNode &N = onlySymbol(Symbol::kind, P.RHS, P.Tokens);           \
     return cond;                                                               \
   }
   return {

--- a/clang-tools-extra/pseudo/lib/cxx/CXX.cpp
+++ b/clang-tools-extra/pseudo/lib/cxx/CXX.cpp
@@ -280,10 +280,7 @@ bool hasExclusiveType(const ForestNode *N) {
 }
 
 llvm::DenseMap<ExtensionID, RuleGuard> buildGuards() {
-#define GUARD(cond)                                                            \
-  {                                                                            \
-    [](const GuardParams &P) { return cond; }                                  \
-  }
+#define GUARD(cond) {[](const GuardParams &P) { return cond; }}
 #define TOKEN_GUARD(kind, cond)                                                \
   [](const GuardParams &P) {                                                   \
     const Token &Tok = onlyToken(tok::kind, P.RHS, P.Tokens);                  \

--- a/clang-tools-extra/pseudo/lib/grammar/GrammarBNF.cpp
+++ b/clang-tools-extra/pseudo/lib/grammar/GrammarBNF.cpp
@@ -60,8 +60,8 @@ public:
       Consider(Spec.Target);
       for (const RuleSpec::Element &Elt : Spec.Sequence) {
         Consider(Elt.Symbol);
-        for (const auto& KV : Elt.Attributes)
-           UniqueAttributeValues.insert(KV.second);
+        for (const auto &KV : Elt.Attributes)
+          UniqueAttributeValues.insert(KV.second);
       }
     }
     for (llvm::StringRef Name : UniqueNonterminals) {
@@ -183,7 +183,7 @@ private:
     struct Element {
       llvm::StringRef Symbol; // Name of the symbol
       // Attributes that are associated to the sequence symbol or rule.
-      std::vector<std::pair<llvm::StringRef/*Key*/, llvm::StringRef/*Value*/>>
+      std::vector<std::pair<llvm::StringRef /*Key*/, llvm::StringRef /*Value*/>>
           Attributes;
     };
     std::vector<Element> Sequence;
@@ -248,7 +248,7 @@ private:
     return true;
   }
   // Apply the parsed extensions (stored in RuleSpec) to the grammar Rule.
-  void applyAttributes(const RuleSpec& Spec, const GrammarTable& T, Rule& R) {
+  void applyAttributes(const RuleSpec &Spec, const GrammarTable &T, Rule &R) {
     auto LookupExtensionID = [&T](llvm::StringRef Name) {
       const auto It = llvm::partition_point(
           T.AttributeValues, [&](llvm::StringRef X) { return X < Name; });

--- a/clang-tools-extra/pseudo/tool/ClangPseudo.cpp
+++ b/clang-tools-extra/pseudo/tool/ClangPseudo.cpp
@@ -43,13 +43,14 @@ static opt<bool> PrintSource("print-source", desc("Print token stream"));
 static opt<bool> PrintTokens("print-tokens", desc("Print detailed token info"));
 static opt<bool>
     PrintDirectiveTree("print-directive-tree",
-                      desc("Print directive structure of source code"));
+                       desc("Print directive structure of source code"));
 static opt<bool>
     StripDirectives("strip-directives",
                     desc("Strip directives and select conditional sections"));
 static opt<bool> Disambiguate("disambiguate",
                               desc("Choose best tree from parse forest"));
-static opt<bool> PrintStatistics("print-statistics", desc("Print GLR parser statistics"));
+static opt<bool> PrintStatistics("print-statistics",
+                                 desc("Print GLR parser statistics"));
 static opt<bool> PrintForest("print-forest", desc("Print parse forest"));
 static opt<bool> ForestAbbrev("forest-abbrev", desc("Abbreviate parse forest"),
                               init(true));
@@ -63,8 +64,8 @@ static std::string readOrDie(llvm::StringRef Path) {
   llvm::ErrorOr<std::unique_ptr<llvm::MemoryBuffer>> Text =
       llvm::MemoryBuffer::getFile(Path);
   if (std::error_code EC = Text.getError()) {
-    llvm::errs() << "Error: can't read file '" << Path
-                 << "': " << EC.message() << "\n";
+    llvm::errs() << "Error: can't read file '" << Path << "': " << EC.message()
+                 << "\n";
     ::exit(1);
   }
   return Text.get()->getBuffer().str();

--- a/clang-tools-extra/pseudo/unittests/GLRTest.cpp
+++ b/clang-tools-extra/pseudo/unittests/GLRTest.cpp
@@ -52,7 +52,7 @@ Token::Index recoverBraces(Token::Index Begin, const TokenStream &Code) {
   EXPECT_GT(Begin, 0u);
   const Token &Left = Code.tokens()[Begin - 1];
   EXPECT_EQ(Left.Kind, tok::l_brace);
-  if (const auto* Right = Left.pair()) {
+  if (const auto *Right = Left.pair()) {
     EXPECT_EQ(Right->Kind, tok::r_brace);
     return Code.index(*Right);
   }
@@ -71,7 +71,7 @@ public:
     Empty.finalize();
     return Empty;
   }
- 
+
   void buildGrammar(std::vector<std::string> Nonterminals,
                     std::vector<std::string> Rules) {
     Nonterminals.push_back("_");
@@ -185,8 +185,8 @@ TEST_F(GLRTest, ReduceConflictsSplitting) {
       GSStack.addNode(1, &Arena.createTerminal(tok::identifier, 0), {GSSNode0});
 
   std::vector<const GSS::Node *> Heads = {GSSNode1};
-  glrReduce(Heads, tokenSymbol(tok::eof),
-            {emptyTokenStream(), Arena, GSStack}, TestLang);
+  glrReduce(Heads, tokenSymbol(tok::eof), {emptyTokenStream(), Arena, GSStack},
+            TestLang);
   EXPECT_THAT(Heads, UnorderedElementsAre(
                          GSSNode1,
                          AllOf(state(2), parsedSymbolID(id("class-name")),
@@ -209,8 +209,8 @@ TEST_F(GLRTest, ReduceSplittingDueToMultipleBases) {
   auto *ClassNameNode = &Arena.createOpaque(id("class-name"), /*TokenIndex=*/0);
   auto *EnumNameNode = &Arena.createOpaque(id("enum-name"), /*TokenIndex=*/0);
 
-  const auto *GSSNode2 =
-      GSStack.addNode(/*State=*/2, /*ForestNode=*/ClassNameNode, /*Parents=*/{});
+  const auto *GSSNode2 = GSStack.addNode(
+      /*State=*/2, /*ForestNode=*/ClassNameNode, /*Parents=*/{});
   const auto *GSSNode3 =
       GSStack.addNode(/*State=*/3, /*ForestNode=*/EnumNameNode, /*Parents=*/{});
   const auto *GSSNode4 = GSStack.addNode(
@@ -332,8 +332,8 @@ TEST_F(GLRTest, ReduceJoiningWithSameBase) {
   TestLang.Table = std::move(B).build();
 
   std::vector<const GSS::Node *> Heads = {GSSNode3, GSSNode4};
-  glrReduce(Heads, tokenSymbol(tok::eof),
-            {emptyTokenStream(), Arena, GSStack}, TestLang);
+  glrReduce(Heads, tokenSymbol(tok::eof), {emptyTokenStream(), Arena, GSStack},
+            TestLang);
 
   EXPECT_THAT(
       Heads, UnorderedElementsAre(GSSNode3, GSSNode4,
@@ -660,21 +660,18 @@ TEST_F(GLRTest, RecoveryFromStartOfInput) {
   )bnf");
   TestLang.Table = LRTable::buildSLR(TestLang.G);
   bool fallback_recovered = false;
-  auto fallback = [&](Token::Index Start, const TokenStream & Code) {
+  auto fallback = [&](Token::Index Start, const TokenStream &Code) {
     fallback_recovered = true;
     return Code.tokens().size();
   };
-  TestLang.RecoveryStrategies.try_emplace(
-      extensionID("Fallback"),
-      fallback);
+  TestLang.RecoveryStrategies.try_emplace(extensionID("Fallback"), fallback);
   clang::LangOptions LOptions;
   TokenStream Tokens = cook(lex("?", LOptions), LOptions);
 
   const ForestNode &Parsed =
       glrParse({Tokens, Arena, GSStack}, id("start"), TestLang);
   EXPECT_TRUE(fallback_recovered);
-  EXPECT_EQ(Parsed.dumpRecursive(TestLang.G),
-            "[  0, end) start := <opaque>\n");
+  EXPECT_EQ(Parsed.dumpRecursive(TestLang.G), "[  0, end) start := <opaque>\n");
 }
 
 TEST_F(GLRTest, RepeatedRecovery) {
@@ -737,14 +734,11 @@ TEST_F(GLRTest, GuardExtension) {
 
     start := IDENTIFIER [guard]
   )bnf");
-  TestLang.Guards.try_emplace(
-      ruleFor("start"), [&](const GuardParams &P) {
-        assert(P.RHS.size() == 1 &&
-               P.RHS.front()->symbol() ==
-                   tokenSymbol(clang::tok::identifier));
-        return P.Tokens.tokens()[P.RHS.front()->startTokenIndex()]
-                   .text() == "test";
-      });
+  TestLang.Guards.try_emplace(ruleFor("start"), [&](const GuardParams &P) {
+    assert(P.RHS.size() == 1 &&
+           P.RHS.front()->symbol() == tokenSymbol(clang::tok::identifier));
+    return P.Tokens.tokens()[P.RHS.front()->startTokenIndex()].text() == "test";
+  });
   clang::LangOptions LOptions;
   TestLang.Table = LRTable::buildSLR(TestLang.G);
 


### PR DESCRIPTION
This PR just clang-formats the `clang-tools-extra/pseudo` directory to make contribution easier.

One issue I ran into is clang-format kept changing this region, despite the `clang-format off` directives, which I manually reverted:
```
//clang-format off
#define NONTERMINAL(NAME, ID) \
};                            \
}                             \
namespace NAME {              \
enum Rule : RuleID {
//clang-format on
```