### PR TITLE
[clang] Add tests for some CWG 5xx issues

### DIFF
--- a/clang/test/CXX/drs/dr15xx.cpp
+++ b/clang/test/CXX/drs/dr15xx.cpp
@@ -555,7 +555,7 @@ auto DR1579_lambda_invalid = []() -> GenericMoveOnly<char> {
 #endif
 } // end namespace dr1579
 
-namespace dr1584 {
+namespace dr1584 { // dr1584: 7 drafting 2015-05
 #if __cplusplus >= 201103L
   // Deducing function types from cv-qualified types
   template<typename T> void f(const T *); // #dr1584-f

--- a/clang/test/CXX/drs/dr19xx.cpp
+++ b/clang/test/CXX/drs/dr19xx.cpp
@@ -34,7 +34,7 @@ namespace dr1902 { // dr1902: 3.7
 #endif
 }
 
-namespace dr1903 {
+namespace dr1903 { // dr1903: 2.7
   namespace A {
     struct a {};
     int a;

--- a/clang/test/CXX/drs/dr3xx.cpp
+++ b/clang/test/CXX/drs/dr3xx.cpp
@@ -1568,6 +1568,18 @@ namespace dr391 { // dr391: 2.8 c++11
 }
 
 // dr392 is in dr392.cpp
+
+namespace dr393 { // dr393: 2.7
+
+template <typename T>
+struct S {};
+
+void f1(S<int (*)[]>);
+void f2(S<int (&)[]>);
+void g(int(*S<int>::*)[]);
+
+} // namespace dr393
+
 // dr394: na
 
 namespace dr395 { // dr395: 3.0

--- a/clang/test/CXX/drs/dr3xx.cpp
+++ b/clang/test/CXX/drs/dr3xx.cpp
@@ -1570,7 +1570,6 @@ namespace dr391 { // dr391: 2.8 c++11
 // dr392 is in dr392.cpp
 
 namespace dr393 { // dr393: 2.7
-
 template <typename T>
 struct S {};
 
@@ -1578,6 +1577,14 @@ void f1(S<int (*)[]>);
 void f2(S<int (&)[]>);
 void g(int(*S<int>::*)[]);
 
+template<typename T>
+void sp_assert_convertible( T* ) {}
+
+template<typename T, typename U>
+void h() {
+  T (*p) [] = (U(*)[])0;
+  sp_assert_convertible<T[]>( (U(*)[])0 );
+}
 } // namespace dr393
 
 // dr394: na

--- a/clang/test/CXX/drs/dr4xx.cpp
+++ b/clang/test/CXX/drs/dr4xx.cpp
@@ -2,8 +2,9 @@
 // RUN: env ASAN_OPTIONS=detect_stack_use_after_return=0 %clang_cc1 -std=c++11 %s -verify=expected,cxx98-14,cxx98-17,since-cxx11 -fexceptions -fcxx-exceptions -pedantic-errors
 // RUN: env ASAN_OPTIONS=detect_stack_use_after_return=0 %clang_cc1 -std=c++14 %s -verify=expected,cxx98-14,cxx98-17,since-cxx11 -fexceptions -fcxx-exceptions -pedantic-errors
 // RUN: env ASAN_OPTIONS=detect_stack_use_after_return=0 %clang_cc1 -std=c++17 %s -verify=expected,since-cxx17,cxx98-17,since-cxx11 -fexceptions -fcxx-exceptions -pedantic-errors
-// RUN: env ASAN_OPTIONS=detect_stack_use_after_return=0 %clang_cc1 -std=c++20 %s -verify=expected,since-cxx17,since-cxx11 -fexceptions -fcxx-exceptions -pedantic-errors
-// RUN: env ASAN_OPTIONS=detect_stack_use_after_return=0 %clang_cc1 -std=c++23 %s -verify=expected,since-cxx17,since-cxx11 -fexceptions -fcxx-exceptions -pedantic-errors
+// RUN: env ASAN_OPTIONS=detect_stack_use_after_return=0 %clang_cc1 -std=c++20 %s -verify=expected,since-cxx20,since-cxx17,since-cxx11 -fexceptions -fcxx-exceptions -pedantic-errors
+// RUN: env ASAN_OPTIONS=detect_stack_use_after_return=0 %clang_cc1 -std=c++23 %s -verify=expected,since-cxx20,since-cxx17,since-cxx11 -fexceptions -fcxx-exceptions -pedantic-errors
+// RUN: env ASAN_OPTIONS=detect_stack_use_after_return=0 %clang_cc1 -std=c++2c %s -verify=expected,since-cxx20,since-cxx17,since-cxx11 -fexceptions -fcxx-exceptions -pedantic-errors
 
 // FIXME: __SIZE_TYPE__ expands to 'long long' on some targets.
 __extension__ typedef __SIZE_TYPE__ size_t;
@@ -949,33 +950,34 @@ namespace dr460 { // dr460: yes
 // dr465: na
 
 namespace dr466 { // dr466: 2.8
-  typedef int I;
-  typedef const int CI;
-  typedef volatile int VI;
-  void f(int *a, CI *b, VI *c) {
-    a->~I();
-    a->~CI();
-    a->~VI();
-    a->I::~I();
-    a->CI::~CI();
-    a->VI::~VI();
+typedef int I;
+typedef const int CI;
+typedef volatile int VI;
+void g(int a, CI b, VI c) {
+// since-cxx20-warning@-1 {{volatile-qualified parameter type 'VI' (aka 'volatile int') is deprecated}}
+  a.~I();
+  a.~CI();
+  a.~VI();
+  a.I::~I();
+  a.CI::~CI();
+  a.VI::~VI();
 
-    a->CI::~VI(); // allowed by changes to [expr.id.prim.qual]/2 introduced in P1131R2
+  a.CI::~VI(); // allowed by changes to [expr.id.prim.qual]/2 introduced in P1131R2
 
-    b->~I();
-    b->~CI();
-    b->~VI();
-    b->I::~I();
-    b->CI::~CI();
-    b->VI::~VI();
+  b.~I();
+  b.~CI();
+  b.~VI();
+  b.I::~I();
+  b.CI::~CI();
+  b.VI::~VI();
 
-    c->~I();
-    c->~CI();
-    c->~VI();
-    c->I::~I();
-    c->CI::~CI();
-    c->VI::~VI();
-  }
+  c.~I();
+  c.~CI();
+  c.~VI();
+  c.I::~I();
+  c.CI::~CI();
+  c.VI::~VI();
+}
 }
 
 namespace dr467 { // dr467: yes

--- a/clang/test/CXX/drs/dr5xx.cpp
+++ b/clang/test/CXX/drs/dr5xx.cpp
@@ -18,6 +18,10 @@ namespace std {
 void *operator new(size_t, std::align_val_t); // #dr5xx-global-operator-new-aligned
 #endif
 
+namespace std {
+  struct type_info;
+}
+
 namespace dr500 { // dr500: dup 372
   class D;
   class A {
@@ -264,6 +268,18 @@ namespace dr527 { // dr527: na
 
   int ax = a.x, bx = b.x, cx = c.x, dx = d.x, ex = E::e->x, fx = F::f->x;
 }
+
+namespace dr528 { // dr528: 2.7
+
+struct S; // #dr528-S
+
+void f() {
+  typeid(S);
+  // expected-error@-1 {{'typeid' of incomplete type 'S'}}
+  //   expected-note@#dr528-S {{forward declaration of 'dr528::S'}}
+}
+
+} // namespace dr528
 
 namespace dr530 { // dr530: yes
   template<int*> struct S { enum { N = 1 }; };
@@ -618,6 +634,8 @@ namespace dr548 { // dr548: dup 482
   template void dr548::f<int>();
 }
 
+// dr550: dup 393
+
 namespace dr551 { // dr551: yes c++11
   // FIXME: This obviously should apply in C++98 mode too.
   template<typename T> void f() {}
@@ -641,6 +659,7 @@ namespace dr552 { // dr552: yes
   X<Y, 0> x;
 }
 
+// dr553: 2.7
 struct dr553_class {
   friend void *operator new(size_t, dr553_class);
 };
@@ -661,6 +680,10 @@ namespace dr553 {
 }
 
 // dr554: na
+
+// dr555: na
+// NB: name lookup cases that issue briefly touches are covered in our test for CWG466
+
 // dr556: na
 
 namespace dr557 { // dr557: 3.1
@@ -688,6 +711,20 @@ namespace dr558 { // dr558: 2.9
 }
 
 template<typename> struct dr559 { typedef int T; dr559::T u; }; // dr559: yes
+
+namespace dr560 { // dr560: 16
+
+template <class T>
+struct Outer {
+  struct Inner {
+    Inner* self();
+  };
+};
+template <class T>
+Outer<T>::Inner* Outer<T>::Inner::self() { return this; }
+// cxx98-17-error@-1 {{missing 'typename' prior to dependent type name Outer<T>::Inner; implicit 'typename' is a C++20 extension}}
+
+} // namespace dr560
 
 namespace dr561 { // dr561: yes
   template<typename T> void f(int);

--- a/clang/test/CXX/drs/dr5xx.cpp
+++ b/clang/test/CXX/drs/dr5xx.cpp
@@ -681,8 +681,60 @@ namespace dr553 {
 
 // dr554: na
 
-// dr555: na
-// NB: name lookup cases that issue briefly touches are covered in our test for CWG466
+namespace dr555 { // dr555: 2.8
+typedef int I;
+typedef const int CI;
+typedef volatile int VI;
+void f(int *a, CI *b, VI *c) {
+  a->~I();
+  a->~CI();
+  a->~VI();
+  a->I::~I();
+  a->CI::~CI();
+  a->VI::~VI();
+
+  a->CI::~VI(); // allowed by changes to [expr.id.prim.qual]/2 introduced in P1131R2
+
+  b->~I();
+  b->~CI();
+  b->~VI();
+  b->I::~I();
+  b->CI::~CI();
+  b->VI::~VI();
+
+  c->~I();
+  c->~CI();
+  c->~VI();
+  c->I::~I();
+  c->CI::~CI();
+  c->VI::~VI();
+}
+
+void g(int &a, CI &b, VI &c) {
+  a.~I();
+  a.~CI();
+  a.~VI();
+  a.I::~I();
+  a.CI::~CI();
+  a.VI::~VI();
+
+  a.CI::~VI(); // allowed by changes to [expr.id.prim.qual]/2 introduced in P1131R2
+
+  b.~I();
+  b.~CI();
+  b.~VI();
+  b.I::~I();
+  b.CI::~CI();
+  b.VI::~VI();
+
+  c.~I();
+  c.~CI();
+  c.~VI();
+  c.I::~I();
+  c.CI::~CI();
+  c.VI::~VI();
+}
+} // namespace dr555
 
 // dr556: na
 

--- a/clang/www/cxx_dr_status.html
+++ b/clang/www/cxx_dr_status.html
@@ -2398,7 +2398,7 @@ of class templates</td>
     <td><a href="https://cplusplus.github.io/CWG/issues/393.html">393</a></td>
     <td>CD4</td>
     <td>Pointer to array of unknown bound in template argument list in parameter</td>
-    <td class="unknown" align="center">Unknown</td>
+    <td class="full" align="center">Clang 2.7</td>
   </tr>
   <tr id="394">
     <td><a href="https://cplusplus.github.io/CWG/issues/394.html">394</a></td>
@@ -3208,7 +3208,7 @@ of class templates</td>
     <td><a href="https://cplusplus.github.io/CWG/issues/528.html">528</a></td>
     <td>NAD</td>
     <td>Why are incomplete class types not allowed with <TT>typeid</TT>?</td>
-    <td class="unknown" align="center">Unknown</td>
+    <td class="full" align="center">Clang 2.7</td>
   </tr>
   <tr class="open" id="529">
     <td><a href="https://cplusplus.github.io/CWG/issues/529.html">529</a></td>
@@ -3342,7 +3342,7 @@ and <I>POD class</I></td>
     <td><a href="https://cplusplus.github.io/CWG/issues/550.html">550</a></td>
     <td>dup</td>
     <td>Pointer to array of unknown bound in parameter declarations</td>
-    <td class="unknown" align="center">Unknown</td>
+    <td class="full" align="center">Duplicate of <a href="#393">393</a></td>
   </tr>
   <tr id="551">
     <td><a href="https://cplusplus.github.io/CWG/issues/551.html">551</a></td>
@@ -3360,7 +3360,7 @@ and <I>POD class</I></td>
     <td><a href="https://cplusplus.github.io/CWG/issues/553.html">553</a></td>
     <td>NAD</td>
     <td>Problems with friend allocation and deallocation functions</td>
-    <td class="unknown" align="center">Unknown</td>
+    <td class="full" align="center">Clang 2.7</td>
   </tr>
   <tr id="554">
     <td><a href="https://cplusplus.github.io/CWG/issues/554.html">554</a></td>
@@ -3372,7 +3372,7 @@ and <I>POD class</I></td>
     <td><a href="https://cplusplus.github.io/CWG/issues/555.html">555</a></td>
     <td>CD5</td>
     <td>Pseudo-destructor name lookup</td>
-    <td class="unknown" align="center">Unknown</td>
+    <td class="na" align="center">N/A</td>
   </tr>
   <tr id="556">
     <td><a href="https://cplusplus.github.io/CWG/issues/556.html">556</a></td>
@@ -3402,7 +3402,7 @@ and <I>POD class</I></td>
     <td><a href="https://cplusplus.github.io/CWG/issues/560.html">560</a></td>
     <td>NAD</td>
     <td>Use of the <TT>typename</TT> keyword in return types</td>
-    <td class="unknown" align="center">Unknown</td>
+    <td class="full" align="center">Clang 16</td>
   </tr>
   <tr id="561">
     <td><a href="https://cplusplus.github.io/CWG/issues/561.html">561</a></td>
@@ -9312,7 +9312,7 @@ and <I>POD class</I></td>
     <td><a href="https://cplusplus.github.io/CWG/issues/1584.html">1584</a></td>
     <td>drafting</td>
     <td>Deducing function types from cv-qualified types</td>
-    <td align="center">Not resolved</td>
+    <td title="Clang 7 implements 2015-05 resolution" align="center">Not Resolved*</td>
   </tr>
   <tr id="1585">
     <td><a href="https://cplusplus.github.io/CWG/issues/1585.html">1585</a></td>
@@ -11226,7 +11226,7 @@ and <I>POD class</I></td>
     <td><a href="https://cplusplus.github.io/CWG/issues/1903.html">1903</a></td>
     <td>CD4</td>
     <td>What declarations are introduced by a non-member <I>using-declaration</I>?</td>
-    <td class="unknown" align="center">Unknown</td>
+    <td class="full" align="center">Clang 2.7</td>
   </tr>
   <tr id="1904">
     <td><a href="https://cplusplus.github.io/CWG/issues/1904.html">1904</a></td>

--- a/clang/www/cxx_dr_status.html
+++ b/clang/www/cxx_dr_status.html
@@ -3372,7 +3372,7 @@ and <I>POD class</I></td>
     <td><a href="https://cplusplus.github.io/CWG/issues/555.html">555</a></td>
     <td>CD5</td>
     <td>Pseudo-destructor name lookup</td>
-    <td class="na" align="center">N/A</td>
+    <td class="full" align="center">Clang 2.8</td>
   </tr>
   <tr id="556">
     <td><a href="https://cplusplus.github.io/CWG/issues/556.html">556</a></td>


### PR DESCRIPTION
This patch covers
[CWG393](https://cplusplus.github.io/CWG/issues/393.html) "Pointer to array of unknown bound in template argument list in parameter",
[CWG528](https://cplusplus.github.io/CWG/issues/528.html) "Why are incomplete class types not allowed with `typeid`?",
[CWG550](https://cplusplus.github.io/CWG/issues/550.html) "Pointer to array of unknown bound in parameter declarations",
[CWG553](https://cplusplus.github.io/CWG/issues/553.html) "Problems with friend allocation and deallocation functions",
[CWG555](https://cplusplus.github.io/CWG/issues/555.html) "Pseudo-destructor name lookup",
[CWG560](https://cplusplus.github.io/CWG/issues/560.html) "Use of the `typename` keyword in return types".

CWG393 is on this list, because CWG550 is marked as a duplicate of CWG393.

Test for CWG553 has been already written, but it was missing a status comment. As a drive-by fix, I'm adding missing status comments to CWG1584 and CWG1903 as well.

CWG555 used CWG466 test, and also a variation of that test to test references. CWG466 is now testing non-reference non-pointer case.

CWG560 showcases again that converting warnings to errors in DR tests via `-pedantic-errors` doesn't make things more clear. By default that test is accepted with an extension warning since we implemented [P0634R3](https://wg21.link/p0634r3) "Down with `typename`!" in Clang 16.