### PR TITLE
[CompilerRT] Apply CMake INTDIR substitution for Ninja Multi-Config build

### DIFF
--- a/compiler-rt/cmake/Modules/AddCompilerRT.cmake
+++ b/compiler-rt/cmake/Modules/AddCompilerRT.cmake
@@ -16,11 +16,12 @@ function(set_target_output_directories target output_dir)
   # RUNTIME_OUTPUT_DIRECTORY_DEBUG, RUNTIME_OUTPUT_DIRECTORY_RELEASE, ...
   if(CMAKE_CONFIGURATION_TYPES)
     foreach(build_mode ${CMAKE_CONFIGURATION_TYPES})
+      string(REPLACE ${CMAKE_CFG_INTDIR} ${build_mode} out ${output_dir})
       string(TOUPPER "${build_mode}" CONFIG_SUFFIX)
       set_target_properties("${target}" PROPERTIES
-          "ARCHIVE_OUTPUT_DIRECTORY_${CONFIG_SUFFIX}" ${output_dir}
-          "LIBRARY_OUTPUT_DIRECTORY_${CONFIG_SUFFIX}" ${output_dir}
-          "RUNTIME_OUTPUT_DIRECTORY_${CONFIG_SUFFIX}" ${output_dir})
+          "ARCHIVE_OUTPUT_DIRECTORY_${CONFIG_SUFFIX}" ${out}
+          "LIBRARY_OUTPUT_DIRECTORY_${CONFIG_SUFFIX}" ${out}
+          "RUNTIME_OUTPUT_DIRECTORY_${CONFIG_SUFFIX}" ${out})
     endforeach()
   else()
     set_target_properties("${target}" PROPERTIES


### PR DESCRIPTION
On Ninja Multi-Config mode configuration, CompilerRT generates its output to a weird directory, such as
`${CONFIGURATION}/lib/clang/19/lib/x86_64-pc-linux-gnu/libclang_rt.builtins.a`
which contains unexpanded `${CONFIGURATION}` as a directory name.
That causes a build error around syms-stamp on my environment.

After this patch applied, `${CONFIGURATION}` will be expanded to corresponding build configs such as Debug, Release, and RelWithDebInfo.
We can see similar expansion in [AddLLVM.cmake](https://github.com/llvm/llvm-project/blob/7a4e89761a13bfad27a2614ecea5e8698f50336c/llvm/cmake/modules/AddLLVM.cmake#L359).