### PR TITLE
[clang-format] Added unittest of TableGen formatting w.r.t. block type calculation.

### DIFF
--- a/clang/unittests/Format/FormatTestTableGen.cpp
+++ b/clang/unittests/Format/FormatTestTableGen.cpp
@@ -290,6 +290,16 @@ TEST_F(FormatTestTableGen, MultiClass) {
                "}\n");
 }
 
+TEST_F(FormatTestTableGen, MultiClassesWithPasteOperator) {
+  // This is a sensitive example for the handling of the paste operators in
+  // brace type calculation.
+  verifyFormat("multiclass MultiClass1<int i> {\n"
+               "  def : Def#x<i>;\n"
+               "  def : Def#y<i>;\n"
+               "}\n"
+               "multiclass MultiClass2<int i> { def : Def#x<i>; }\n");
+}
+
 TEST_F(FormatTestTableGen, Defm) {
   verifyFormat("defm : Multiclass<0>;\n");
 


### PR DESCRIPTION
The test I mentioned here https://github.com/llvm/llvm-project/pull/87450 .
This is a regression test to detect the case block type is not calculated due to the paste `#` operator misunderstood as preprocessor. 