### PR TITLE
[libc] Increase timeout for death tests.

### DIFF
--- a/libc/test/UnitTest/LibcDeathTestExecutors.cpp
+++ b/libc/test/UnitTest/LibcDeathTestExecutors.cpp
@@ -19,7 +19,7 @@ namespace testing {
 bool Test::testProcessKilled(testutils::FunctionCaller *Func, int Signal,
                              const char *LHSStr, const char *RHSStr,
                              internal::Location Loc) {
-  testutils::ProcessStatus Result = testutils::invoke_in_subprocess(Func, 500);
+  testutils::ProcessStatus Result = testutils::invoke_in_subprocess(Func, 1000);
 
   if (const char *error = Result.get_error()) {
     Ctx->markFail();
@@ -31,7 +31,7 @@ bool Test::testProcessKilled(testutils::FunctionCaller *Func, int Signal,
   if (Result.timed_out()) {
     Ctx->markFail();
     tlog << Loc;
-    tlog << "Process timed out after " << 500 << " milliseconds.\n";
+    tlog << "Process timed out after " << 1000 << " milliseconds.\n";
     return false;
   }
 
@@ -62,7 +62,7 @@ bool Test::testProcessKilled(testutils::FunctionCaller *Func, int Signal,
 bool Test::testProcessExits(testutils::FunctionCaller *Func, int ExitCode,
                             const char *LHSStr, const char *RHSStr,
                             internal::Location Loc) {
-  testutils::ProcessStatus Result = testutils::invoke_in_subprocess(Func, 500);
+  testutils::ProcessStatus Result = testutils::invoke_in_subprocess(Func, 1000);
 
   if (const char *error = Result.get_error()) {
     Ctx->markFail();
@@ -74,7 +74,7 @@ bool Test::testProcessExits(testutils::FunctionCaller *Func, int ExitCode,
   if (Result.timed_out()) {
     Ctx->markFail();
     tlog << Loc;
-    tlog << "Process timed out after " << 500 << " milliseconds.\n";
+    tlog << "Process timed out after " << 1000 << " milliseconds.\n";
     return false;
   }
 


### PR DESCRIPTION
Fix test timeout on RISCV bots.
Fixes https://github.com/llvm/llvm-project/issues/87096