### PR TITLE
[cmake][CompilerRT] Propagate CMAKE_INSTALL_CONFIG_NAME to runtime installation

### DIFF
--- a/compiler-rt/cmake/Modules/CompilerRTUtils.cmake
+++ b/compiler-rt/cmake/Modules/CompilerRTUtils.cmake
@@ -528,11 +528,13 @@ function(add_compiler_rt_install_targets name)
                       DEPENDS ${ARG_PARENT_TARGET}
                       COMMAND "${CMAKE_COMMAND}"
                               -DCMAKE_INSTALL_COMPONENT=${ARG_PARENT_TARGET}
+                              -DCMAKE_INSTALL_CONFIG_NAME=$<CONFIG>
                               -P "${CMAKE_BINARY_DIR}/cmake_install.cmake")
     add_custom_target(install-${ARG_PARENT_TARGET}-stripped
                       DEPENDS ${ARG_PARENT_TARGET}
                       COMMAND "${CMAKE_COMMAND}"
                               -DCMAKE_INSTALL_COMPONENT=${ARG_PARENT_TARGET}
+                              -DCMAKE_INSTALL_CONFIG_NAME=$<CONFIG>
                               -DCMAKE_INSTALL_DO_STRIP=1
                               -P "${CMAKE_BINARY_DIR}/cmake_install.cmake")
     set_target_properties(install-${ARG_PARENT_TARGET} PROPERTIES

--- a/llvm/cmake/modules/LLVMExternalProjectUtils.cmake
+++ b/llvm/cmake/modules/LLVMExternalProjectUtils.cmake
@@ -384,7 +384,7 @@ function(llvm_ExternalProject_Add name source_dir)
   endif()
 
   if(NOT ARG_NO_INSTALL)
-    install(CODE "execute_process\(COMMAND \${CMAKE_COMMAND} -DCMAKE_INSTALL_PREFIX=\${CMAKE_INSTALL_PREFIX} -DCMAKE_INSTALL_DO_STRIP=\${CMAKE_INSTALL_DO_STRIP} -P ${BINARY_DIR}/cmake_install.cmake\)"
+    install(CODE "execute_process\(COMMAND \${CMAKE_COMMAND} -DCMAKE_INSTALL_PREFIX=\${CMAKE_INSTALL_PREFIX} -DCMAKE_INSTALL_DO_STRIP=\${CMAKE_INSTALL_DO_STRIP} -DCMAKE_INSTALL_CONFIG_NAME=$<CONFIG> -P ${BINARY_DIR}/cmake_install.cmake\)"
       COMPONENT ${name})
 
     add_llvm_install_targets(install-${name}


### PR DESCRIPTION
LLVM runtimes hit a build failure on Ninja Multi-Config and non-Release configuration (i.e. Debug or RelWithDebInfo), due to missing build configuration.

When the install script runs without the parameter, it uses Release configuration as a fallback, searches the binary to install from Release directory, and fails for the missing binary.
After this PR, the top-level script propagates the build configuration to the sub-project, and should fix the build error.