### PR TITLE
[test][AArch64][CodeGen] Delete redundant check lines

### DIFF
--- a/llvm/test/CodeGen/AArch64/elf-globals-static.ll
+++ b/llvm/test/CodeGen/AArch64/elf-globals-static.ll
@@ -15,11 +15,6 @@ define i8 @test_i8(i8 %new) {
 ; CHECK: ldrb {{w[0-9]+}}, [x[[HIREG]], :lo12:var8]
 ; CHECK: strb {{w[0-9]+}}, [x[[HIREG]], :lo12:var8]
 
-; CHECK-PIC-LABEL: test_i8:
-; CHECK-PIC: adrp x[[HIREG:[0-9]+]], :got:var8
-; CHECK-PIC: ldr x[[VAR_ADDR:[0-9]+]], [x[[HIREG]], :got_lo12:var8]
-; CHECK-PIC: ldrb {{w[0-9]+}}, [x[[VAR_ADDR]]]
-
 ; CHECK-FAST-LABEL: test_i8:
 ; CHECK-FAST: adrp x[[HIREG:[0-9]+]], var8
 ; CHECK-FAST: ldrb {{w[0-9]+}}, [x[[HIREG]], :lo12:var8]

--- a/llvm/test/CodeGen/AArch64/tagged-globals-pic.ll
+++ b/llvm/test/CodeGen/AArch64/tagged-globals-pic.ll
@@ -31,18 +31,6 @@ define ptr @global_addr() #0 {
 }
 
 define i32 @global_load() #0 {
-  ; CHECK-SELECTIONDAGISEL: global_load:
-  ; CHECK-SELECTIONDAGISEL: adrp [[REG:x[0-9]+]], :pg_hi21_nc:global
-  ; CHECK-SELECTIONDAGISEL: ldr w0, [[[REG]], :lo12:global]
-  ; CHECK-SELECTIONDAGISEL: ret
-
-  ; CHECK-GLOBALISEL: global_load:
-  ; CHECK-GLOBALISEL: adrp [[REG:x[0-9]+]], :pg_hi21_nc:global
-  ; CHECK-GLOBALISEL: movk [[REG]], #:prel_g3:global+4294967296
-  ; CHECK-GLOBALISEL: add [[REG]], [[REG]], :lo12:global
-  ; CHECK-GLOBALISEL: ldr w0, [[[REG]]]
-  ; CHECK-GLOBALISEL: ret
-
   ; CHECK-PIC: global_load:
   ; CHECK-PIC: adrp [[REG:x[0-9]+]], :got:global
   ; CHECK-PIC: ldr  [[REG]], [[[REG]], :got_lo12:global]
@@ -54,18 +42,6 @@ define i32 @global_load() #0 {
 }
 
 define void @global_store() #0 {
-  ; CHECK-SELECTIONDAGISEL: global_store:
-  ; CHECK-SELECTIONDAGISEL: adrp [[REG:x[0-9]+]], :pg_hi21_nc:global
-  ; CHECK-SELECTIONDAGISEL: str wzr, [[[REG]], :lo12:global]
-  ; CHECK-SELECTIONDAGISEL: ret
-
-  ; CHECK-GLOBALISEL: global_store:
-  ; CHECK-GLOBALISEL: adrp [[REG:x[0-9]+]], :pg_hi21_nc:global
-  ; CHECK-GLOBALISEL: movk [[REG]], #:prel_g3:global+4294967296
-  ; CHECK-GLOBALISEL: add [[REG]], [[REG]], :lo12:global
-  ; CHECK-GLOBALISEL: str wzr, [[[REG]]]
-  ; CHECK-GLOBALISEL: ret
-
   ; CHECK-PIC: global_store:
   ; CHECK-PIC: adrp [[REG:x[0-9]+]], :got:global
   ; CHECK-PIC: ldr  [[REG]], [[[REG]], :got_lo12:global]


### PR DESCRIPTION
llvm/test/CodeGen/AArch64/elf-globals-pic.ll:

Since https://reviews.llvm.org/D91734, elf-globals-static.ll test contains several `CHECK-PIC` lines. They do not seem to bring any value since there are no FileCheck run lines checking against this prefix. The right place for such tests should be elf-globals-pic.ll, which already contains check lines being deleted in this commit. Both elf-globals-pic.ll and elf-globals-static.ll were created after splitting arm64-elf-globals.ll in 6dbd0ea, and having `CHECK-PIC` lines in elf-globals-static.ll seems like an issue occurred because of git thinking that elf-globals-pic.ll is a new file and elf-global-static.ll is a rename of arm64-elf-globals.ll.

llvm/test/CodeGen/AArch64/tagged-globals-pic.ll:

Similar to elf-globals-pic.ll, contains unneeded `CHECK-SELECTIONDAGISEL` and `CHECK-GLOBALISEL` directives not checked by any FileCheck invocation. These directives are present in tagged-globals-static.ll. Both tests are present in the code tree since fd32639 when tagged-globals.ll was splitted into tagged-globals-{pic|static}.ll.