### PR TITLE
[RISCV] Fix canFoldToVWWithSameExtension allowing different FP extensions

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
+++ b/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
@@ -14090,7 +14090,7 @@ canFoldToVWWithSameExtensionImpl(SDNode *Root, const NodeExtensionHelper &LHS,
     return CombineResult(NodeExtensionHelper::getSExtOpcode(Root->getOpcode()),
                          Root, LHS, /*LHSExt=*/{ExtKind::SExt}, RHS,
                          /*RHSExt=*/{ExtKind::SExt});
-  if ((AllowExtMask & ExtKind::FPExt) && RHS.SupportsFPExt)
+  if ((AllowExtMask & ExtKind::FPExt) && LHS.SupportsFPExt && RHS.SupportsFPExt)
     return CombineResult(NodeExtensionHelper::getFPExtOpcode(Root->getOpcode()),
                          Root, LHS, /*LHSExt=*/{ExtKind::FPExt}, RHS,
                          /*RHSExt=*/{ExtKind::FPExt});


### PR DESCRIPTION
We previously weren't checking that the LHS was also FPExt, which means we might try to combine fadd x, (fpext y) to vfwadd.vv incorrectly during materialization.

However this never ends up happening because coincidentally, the VL and mask are always incompatible, since any non-extending operand doesn't set the VL or Mask. (I noticed this whilst working on a patch to relax the VL and Mask requirements)

So unfortunately I don't think there's a way to create test case for this currently since it's only a latent bug.
