### PR TITLE
[clang-format] Remove trailing newlines in TableGen formatting test.

### DIFF
--- a/clang/unittests/Format/FormatTestTableGen.cpp
+++ b/clang/unittests/Format/FormatTestTableGen.cpp
@@ -72,7 +72,7 @@ TEST_F(FormatTestTableGen, LiteralsAndIdentifiers) {
                "  let 0startID = $TokVarName;\n"
                "  let 0xstartInteger = 0x42;\n"
                "  let someIdentifier = $TokVarName;\n"
-               "}\n");
+               "}");
 }
 
 TEST_F(FormatTestTableGen, BangOperators) {
@@ -101,22 +101,22 @@ TEST_F(FormatTestTableGen, BangOperators) {
                "                                  \"zerozero\",\n"
                "                                  true:  // default\n"
                "                                  \"positivepositive\");\n"
-               "}\n");
+               "}");
 }
 
 TEST_F(FormatTestTableGen, Include) {
-  verifyFormat("include \"test/IncludeFile.h\"\n");
+  verifyFormat("include \"test/IncludeFile.h\"");
 }
 
 TEST_F(FormatTestTableGen, Types) {
-  verifyFormat("def Types : list<int>, bits<3>, list<list<string>> {}\n");
+  verifyFormat("def Types : list<int>, bits<3>, list<list<string>> {}");
 }
 
 TEST_F(FormatTestTableGen, SimpleValue1_SingleLiterals) {
   verifyFormat("def SimpleValue {\n"
                "  let Integer = 42;\n"
                "  let String = \"some string\";\n"
-               "}\n");
+               "}");
 }
 
 TEST_F(FormatTestTableGen, SimpleValue1_MultilineString) {
@@ -129,7 +129,7 @@ TEST_F(FormatTestTableGen, SimpleValue1_MultilineString) {
       "delimited by \\[{ and }\\]. It  can break across lines and the line "
       "breaks are retained in the string. \n"
       "(https://llvm.org/docs/TableGen/ProgRef.html#grammar-token-TokCode)}];\n"
-      "}\n";
+      "}";
   StringRef DefWithCodeMessedUp =
       "def SimpleValueCode {  let  \n"
       "Code=       \n"
@@ -139,7 +139,7 @@ TEST_F(FormatTestTableGen, SimpleValue1_MultilineString) {
       "breaks are retained in the string. \n"
       "(https://llvm.org/docs/TableGen/ProgRef.html#grammar-token-TokCode)}] \n"
       " ;  \n"
-      "   }    \n";
+      "   }    ";
   verifyFormat(DefWithCode, DefWithCodeMessedUp);
 }
 
@@ -147,15 +147,15 @@ TEST_F(FormatTestTableGen, SimpleValue2) {
   verifyFormat("def SimpleValue2 {\n"
                "  let True = true;\n"
                "  let False = false;\n"
-               "}\n");
+               "}");
 }
 
 TEST_F(FormatTestTableGen, SimpleValue3) {
-  verifyFormat("class SimpleValue3<int x> { int Question = ?; }\n");
+  verifyFormat("class SimpleValue3<int x> { int Question = ?; }");
 }
 
 TEST_F(FormatTestTableGen, SimpleValue4) {
-  verifyFormat("def SimpleValue4 { let ValueList = {1, 2, 3}; }\n");
+  verifyFormat("def SimpleValue4 { let ValueList = {1, 2, 3}; }");
 }
 
 TEST_F(FormatTestTableGen, SimpleValue5) {
@@ -166,7 +166,7 @@ TEST_F(FormatTestTableGen, SimpleValue5) {
                "      list<int>>;\n"
                "  let SquareBitsListWithType = [ {1, 2},\n"
                "                                 {3, 4} ]<list<bits<8>>>;\n"
-               "}\n");
+               "}");
 }
 
 TEST_F(FormatTestTableGen, SimpleValue6) {
@@ -184,15 +184,15 @@ TEST_F(FormatTestTableGen, SimpleValue6) {
                "  );\n"
                "  let DAGArgBang = (!cast<SomeType>(\"Some\") i32:$src1,\n"
                "      i32:$src2);\n"
-               "}\n");
+               "}");
 }
 
 TEST_F(FormatTestTableGen, SimpleValue7) {
-  verifyFormat("def SimpleValue7 { let Identifier = SimpleValue; }\n");
+  verifyFormat("def SimpleValue7 { let Identifier = SimpleValue; }");
 }
 
 TEST_F(FormatTestTableGen, SimpleValue8) {
-  verifyFormat("def SimpleValue8 { let Class = SimpleValue3<3>; }\n");
+  verifyFormat("def SimpleValue8 { let Class = SimpleValue3<3>; }");
 }
 
 TEST_F(FormatTestTableGen, ValueSuffix) {
@@ -203,19 +203,18 @@ TEST_F(FormatTestTableGen, ValueSuffix) {
                "  let Slice1 = value[1, ];\n"
                "  let Slice2 = value[4...7, 17, 2...3, 4];\n"
                "  let Field = value.field;\n"
-               "}\n");
+               "}");
 }
 
 TEST_F(FormatTestTableGen, PasteOperator) {
-  verifyFormat(
-      "def Paste#\"Operator\" { string Paste = \"Paste\"#operator; }\n");
+  verifyFormat("def Paste#\"Operator\" { string Paste = \"Paste\"#operator; }");
 
   verifyFormat("def [\"Traring\", \"Paste\"]# {\n"
                "  string X = Traring#;\n"
                "  string Y = List<\"Operator\">#;\n"
                "  string Z = [\"Traring\", \"Paste\", \"Traring\", \"Paste\",\n"
                "              \"Traring\", \"Paste\"]#;\n"
-               "}\n");
+               "}");
 }
 
 TEST_F(FormatTestTableGen, ClassDefinition) {
@@ -229,9 +228,9 @@ TEST_F(FormatTestTableGen, ClassDefinition) {
                "  defvar Item6 = 6;\n"
                "  let Item7 = ?;\n"
                "  assert !ge(x, 0), \"Assert7\";\n"
-               "}\n");
+               "}");
 
-  verifyFormat("class FPFormat<bits<3> val> { bits<3> Value = val; }\n");
+  verifyFormat("class FPFormat<bits<3> val> { bits<3> Value = val; }");
 }
 
 TEST_F(FormatTestTableGen, Def) {
@@ -240,18 +239,18 @@ TEST_F(FormatTestTableGen, Def) {
                "  let Item2{1, 3...4} = {1, 2};\n"
                "  defvar Item3 = (ops nodty:$node1, nodty:$node2);\n"
                "  assert !le(Item2, 0), \"Assert4\";\n"
-               "}\n");
+               "}");
 
-  verifyFormat("class FPFormat<bits<3> val> { bits<3> Value = val; }\n");
+  verifyFormat("class FPFormat<bits<3> val> { bits<3> Value = val; }");
 
-  verifyFormat("def NotFP : FPFormat<0>;\n");
+  verifyFormat("def NotFP : FPFormat<0>;");
 }
 
 TEST_F(FormatTestTableGen, Let) {
   verifyFormat("let x = 1, y = value<type>,\n"
                "    z = !and(!gt(!add(1, 2), !sub(3, 4)), !isa<Ty>($x)) in {\n"
                "  class Class1 : Parent<x, y> { let Item1 = z; }\n"
-               "}\n");
+               "}");
 }
 
 TEST_F(FormatTestTableGen, MultiClass) {
@@ -287,7 +286,7 @@ TEST_F(FormatTestTableGen, MultiClass) {
                "      }\n"
                "    }\n"
                "  }\n"
-               "}\n");
+               "}");
 }
 
 TEST_F(FormatTestTableGen, MultiClassesWithPasteOperator) {
@@ -297,25 +296,25 @@ TEST_F(FormatTestTableGen, MultiClassesWithPasteOperator) {
                "  def : Def#x<i>;\n"
                "  def : Def#y<i>;\n"
                "}\n"
-               "multiclass MultiClass2<int i> { def : Def#x<i>; }\n");
+               "multiclass MultiClass2<int i> { def : Def#x<i>; }");
 }
 
 TEST_F(FormatTestTableGen, Defm) {
-  verifyFormat("defm : Multiclass<0>;\n");
+  verifyFormat("defm : Multiclass<0>;");
 
-  verifyFormat("defm Defm1 : Multiclass<1>;\n");
+  verifyFormat("defm Defm1 : Multiclass<1>;");
 }
 
 TEST_F(FormatTestTableGen, Defset) {
   verifyFormat("defset list<Class> DefSet1 = {\n"
                "  def Def1 : Class<1>;\n"
                "  def Def2 : Class<2>;\n"
-               "}\n");
+               "}");
 }
 
 TEST_F(FormatTestTableGen, Defvar) {
   verifyFormat("defvar DefVar1 = !cond(!ge(!size(PaseOperator.Paste), 1): 1,\n"
-               "                       true: 0);\n");
+               "                       true: 0);");
 }
 
 TEST_F(FormatTestTableGen, ForEach) {
@@ -325,21 +324,21 @@ TEST_F(FormatTestTableGen, ForEach) {
       "                  (!if(!lt(x, i),\n"
       "                       !shl(!mul(x, i), !size(\"string\")),\n"
       "                       !size(!strconcat(\"a\", \"b\", \"c\"))))>;\n"
-      "}\n");
+      "}");
 }
 
-TEST_F(FormatTestTableGen, Dump) { verifyFormat("dump \"Dump\";\n"); }
+TEST_F(FormatTestTableGen, Dump) { verifyFormat("dump \"Dump\";"); }
 
 TEST_F(FormatTestTableGen, If) {
   verifyFormat("if !gt(x, 0) then {\n"
                "  def : IfThen<x>;\n"
                "} else {\n"
                "  def : IfElse<x>;\n"
-               "}\n");
+               "}");
 }
 
 TEST_F(FormatTestTableGen, Assert) {
-  verifyFormat("assert !le(DefVar1, 0), \"Assert1\";\n");
+  verifyFormat("assert !le(DefVar1, 0), \"Assert1\";");
 }
 
 TEST_F(FormatTestTableGen, DAGArgBreakElements) {
@@ -349,7 +348,7 @@ TEST_F(FormatTestTableGen, DAGArgBreakElements) {
   ASSERT_EQ(Style.TableGenBreakInsideDAGArg, FormatStyle::DAS_DontBreak);
   verifyFormat("def Def : Parent {\n"
                "  let dagarg = (ins a:$src1, aa:$src2, aaa:$src3)\n"
-               "}\n",
+               "}",
                Style);
   // This option forces to break inside the DAGArg.
   Style.TableGenBreakInsideDAGArg = FormatStyle::DAS_BreakElements;
@@ -357,13 +356,13 @@ TEST_F(FormatTestTableGen, DAGArgBreakElements) {
                "  let dagarg = (ins a:$src1,\n"
                "                    aa:$src2,\n"
                "                    aaa:$src3);\n"
-               "}\n",
+               "}",
                Style);
   verifyFormat("def Def : Parent {\n"
                "  let dagarg = (other a:$src1,\n"
                "                      aa:$src2,\n"
                "                      aaa:$src3);\n"
-               "}\n",
+               "}",
                Style);
   // Then, limit the DAGArg operator only to "ins".
   Style.TableGenBreakingDAGArgOperators = {"ins"};
@@ -371,11 +370,11 @@ TEST_F(FormatTestTableGen, DAGArgBreakElements) {
                "  let dagarg = (ins a:$src1,\n"
                "                    aa:$src2,\n"
                "                    aaa:$src3);\n"
-               "}\n",
+               "}",
                Style);
   verifyFormat("def Def : Parent {\n"
                "  let dagarg = (other a:$src1, aa:$src2, aaa:$src3)\n"
-               "}\n",
+               "}",
                Style);
 }
 
@@ -385,7 +384,7 @@ TEST_F(FormatTestTableGen, DAGArgBreakAll) {
   // By default, the DAGArg does not have a break inside.
   verifyFormat("def Def : Parent {\n"
                "  let dagarg = (ins a:$src1, aa:$src2, aaa:$src3)\n"
-               "}\n",
+               "}",
                Style);
   // This option forces to break inside the DAGArg.
   Style.TableGenBreakInsideDAGArg = FormatStyle::DAS_BreakAll;
@@ -395,7 +394,7 @@ TEST_F(FormatTestTableGen, DAGArgBreakAll) {
                "      aa:$src2,\n"
                "      aaa:$src3\n"
                "  );\n"
-               "}\n",
+               "}",
                Style);
   verifyFormat("def Def : Parent {\n"
                "  let dagarg = (other\n"
@@ -403,7 +402,7 @@ TEST_F(FormatTestTableGen, DAGArgBreakAll) {
                "      aa:$src2,\n"
                "      aaa:$src3\n"
                "  );\n"
-               "}\n",
+               "}",
                Style);
   // Then, limit the DAGArg operator only to "ins".
   Style.TableGenBreakingDAGArgOperators = {"ins"};
@@ -413,11 +412,11 @@ TEST_F(FormatTestTableGen, DAGArgBreakAll) {
                "      aa:$src2,\n"
                "      aaa:$src3\n"
                "  );\n"
-               "}\n",
+               "}",
                Style);
   verifyFormat("def Def : Parent {\n"
                "  let dagarg = (other a:$src1, aa:$src2, aaa:$src3);\n"
-               "}\n",
+               "}",
                Style);
 }
 
@@ -432,11 +431,11 @@ TEST_F(FormatTestTableGen, DAGArgAlignment) {
                "      aa:$src2,\n"
                "      aaa:$src3\n"
                "  )\n"
-               "}\n",
+               "}",
                Style);
   verifyFormat("def Def : Parent {\n"
                "  let dagarg = (not a:$src1, aa:$src2, aaa:$src2)\n"
-               "}\n",
+               "}",
                Style);
   Style.AlignConsecutiveTableGenBreakingDAGArgColons.Enabled = true;
   verifyFormat("def Def : Parent {\n"
@@ -445,11 +444,11 @@ TEST_F(FormatTestTableGen, DAGArgAlignment) {
                "      aa :$src2,\n"
                "      aaa:$src3\n"
                "  )\n"
-               "}\n",
+               "}",
                Style);
   verifyFormat("def Def : Parent {\n"
                "  let dagarg = (not a:$src1, aa:$src2, aaa:$src2)\n"
-               "}\n",
+               "}",
                Style);
 }
 
@@ -458,12 +457,12 @@ TEST_F(FormatTestTableGen, CondOperatorAlignment) {
   Style.ColumnLimit = 60;
   verifyFormat("let CondOpe1 = !cond(!eq(size, 1): 1,\n"
                "                     !eq(size, 16): 1,\n"
-               "                     true: 0);\n",
+               "                     true: 0);",
                Style);
   Style.AlignConsecutiveTableGenCondOperatorColons.Enabled = true;
   verifyFormat("let CondOpe1 = !cond(!eq(size, 1) : 1,\n"
                "                     !eq(size, 16): 1,\n"
-               "                     true         : 0);\n",
+               "                     true         : 0);",
                Style);
 }
 
@@ -472,12 +471,12 @@ TEST_F(FormatTestTableGen, DefAlignment) {
   Style.ColumnLimit = 60;
   verifyFormat("def Def : Parent {}\n"
                "def DefDef : Parent {}\n"
-               "def DefDefDef : Parent {}\n",
+               "def DefDefDef : Parent {}",
                Style);
   Style.AlignConsecutiveTableGenDefinitionColons.Enabled = true;
   verifyFormat("def Def       : Parent {}\n"
                "def DefDef    : Parent {}\n"
-               "def DefDefDef : Parent {}\n",
+               "def DefDefDef : Parent {}",
                Style);
 }
 


### PR DESCRIPTION
Refactoring suggested here https://github.com/llvm/llvm-project/pull/87924 .