### PR TITLE
Reland "[Win32][ELF] Make CodeView a DebugInfoFormat only for COFF format"

### DIFF
--- a/clang/lib/Driver/ToolChains/MSVC.h
+++ b/clang/lib/Driver/ToolChains/MSVC.h
@@ -61,9 +61,8 @@ public:
   /// formats, and to DWARF otherwise. Users can use -gcodeview and -gdwarf to
   /// override the default.
   llvm::codegenoptions::DebugInfoFormat getDefaultDebugFormat() const override {
-    return getTriple().isOSBinFormatMachO()
-               ? llvm::codegenoptions::DIF_DWARF
-               : llvm::codegenoptions::DIF_CodeView;
+    return getTriple().isOSBinFormatCOFF() ? llvm::codegenoptions::DIF_CodeView
+                                           : llvm::codegenoptions::DIF_DWARF;
   }
 
   /// Set the debugger tuning to "default", since we're definitely not tuning

--- a/clang/test/Driver/gcodeview-command-line.c
+++ b/clang/test/Driver/gcodeview-command-line.c
@@ -1,5 +1,6 @@
 // Note: %s must be preceded by --, otherwise it may be interpreted as a
 // command-line option, e.g. on Mac where %s is commonly under /Users.
+// REQUIRES: aarch64-registered-target,arm-registered-target,x86-registered-target
 
 // ON-NOT: "-gno-codview-commandline"
 // OFF: "-gno-codeview-command-line"

--- a/clang/test/Misc/win32-elf.c
+++ b/clang/test/Misc/win32-elf.c
@@ -1,0 +1,5 @@
+// Check that basic use of win32-elf targets works.
+// RUN: %clang -fsyntax-only -target x86_64-pc-win32-elf %s
+
+// RUN: %clang -fsyntax-only -target x86_64-pc-win32-elf -g %s -### 2>&1 | FileCheck %s -check-prefix=DEBUG-INFO
+// DEBUG-INFO: -dwarf-version={{.*}}


### PR DESCRIPTION
This relands #87149.

The previous commit exposed failures on some targets. The reason is only a few targets support COFF ObjectFormatType on Windows: https://github.com/llvm/llvm-project/blob/main/llvm/lib/TargetParser/Triple.cpp#L835-L842

With #87149, the targets don't support COFF will report "warning: argument unused during compilation: '-gcodeview-command-line' [-Wunused-command-line-argument]" in the test gcodeview-command-line.c

This patch limits gcodeview-command-line.c only run on targets support COFF.