### PR TITLE
[OpenMP] Use a memory fence before incrementing the dispatch buffer index

### DIFF
--- a/openmp/runtime/src/kmp_dispatch.cpp
+++ b/openmp/runtime/src/kmp_dispatch.cpp
@@ -2397,6 +2397,8 @@ static int __kmp_dispatch_next(ident_t *loc, int gtid, kmp_int32 *p_last,
           sh->u.s.ordered_iteration = 0;
         }
 
+        KMP_MB(); /* Flush all pending memory write invalidates.  */
+
         sh->buffer_index += __kmp_dispatch_num_buffers;
         KD_TRACE(100, ("__kmp_dispatch_next: T#%d change buffer_index:%d\n",
                        gtid, sh->buffer_index));


### PR DESCRIPTION
This patch uses a memory fence in function `__kmp_dispatch_next()` to flush pending memory write invalidates before incrementing the `volatile` variable `buffer_index` to fix intermittent time-outs of OpenMP runtime LIT test cases `env/kmp_set_dispatch_buf.c` and `worksharing/for/kmp_set_dispatch_buf.c`, noting that the same is needed for incrementing `buffer_index` in function `__kmpc_next_section()` (line 2600 of `kmp_dispatch.cpp`).