### PR TITLE
[clang][CodeGen] Fix shift-exponent ubsan check for signed _BitInt

### DIFF
--- a/clang/test/CodeGen/ubsan-shift-bitint.c
+++ b/clang/test/CodeGen/ubsan-shift-bitint.c
@@ -6,14 +6,14 @@
 // CHECK-LABEL: define{{.*}} i32 @test_left_variable
 int test_left_variable(unsigned _BitInt(5) b, unsigned _BitInt(2) e) {
   // CHECK: [[E_REG:%.+]] = load [[E_SIZE:i2]]
-  // CHECK: icmp ule [[E_SIZE]] [[E_REG]], -1
+  // CHECK: icmp ule [[E_SIZE]] [[E_REG]], -1,
   return b << e;
 }
 
 // CHECK-LABEL: define{{.*}} i32 @test_right_variable
 int test_right_variable(unsigned _BitInt(2) b, unsigned _BitInt(3) e) {
   // CHECK: [[E_REG:%.+]] = load [[E_SIZE:i3]]
-  // CHECK: icmp ule [[E_SIZE]] [[E_REG]], 1
+  // CHECK: icmp ule [[E_SIZE]] [[E_REG]], 1,
   return b >> e;
 }
 
@@ -34,3 +34,32 @@ int test_right_literal(unsigned _BitInt(2) b) {
   // CHECK: br i1 false, label %cont, label %handler.shift_out_of_bounds
   return b >> 4uwb;
 }
+
+// CHECK-LABEL: define{{.*}} i32 @test_signed_left_variable
+int test_signed_left_variable(unsigned _BitInt(15) b, _BitInt(2) e) {
+  // CHECK: [[E_REG:%.+]] = load [[E_SIZE:i2]]
+  // CHECK: icmp ule [[E_SIZE]] [[E_REG]], 1,
+  return b << e;
+}
+
+// CHECK-LABEL: define{{.*}} i32 @test_signed_right_variable
+int test_signed_right_variable(unsigned _BitInt(32) b, _BitInt(4) e) {
+  // CHECK: [[E_REG:%.+]] = load [[E_SIZE:i4]]
+  // CHECK: icmp ule [[E_SIZE]] [[E_REG]], 7,
+  return b >> e;
+}
+
+// CHECK-LABEL: define{{.*}} i32 @test_signed_left_literal
+int test_signed_left_literal(unsigned _BitInt(16) b) {
+  // CHECK-NOT: br i1 true, label %cont, label %handler.shift_out_of_bounds
+  // CHECK: br i1 false, label %cont, label %handler.shift_out_of_bounds
+  return b << (_BitInt(4))-2wb;
+}
+
+// CHECK-LABEL: define{{.*}} i32 @test_signed_right_literal
+int test_signed_right_literal(unsigned _BitInt(16) b) {
+  // CHECK-NOT: br i1 true, label %cont, label %handler.shift_out_of_bounds
+  // CHECK: br i1 false, label %cont, label %handler.shift_out_of_bounds
+  return b >> (_BitInt(4))-8wb;
+}
+


### PR DESCRIPTION
Commit 5f87957fefb21d454f2f (pull-requst #80515) corrected some codegen problems related to _BitInt types being used as shift exponents. But it did not fix it properly for the special case when the shift count operand is a signed _BitInt.

The basic problem is the same as the one solved for unsigned _BitInt. As we use an unsigned comparison to see if the shift exponent is out-of-bounds, then we need to find an unsigned maximum allowed shift amount to use in the check. Normally the shift amount is limited by bitwidth of the LHS of the shift. However, when the RHS type is small in relation to the LHS then we need to use a value that fits inside the bitwidth of the RHS instead.

The earlier fix simply used the unsigned maximum when deterining the max shift amount based on the RHS type. It did however not take into consideration that the RHS type could have a signed representation. In such situations we need to use the signed maximum instead. Otherwise we do not recognize a negative shift exponent as UB.