### PR TITLE
[libc++] Attempts to fix OSS-Fuzz builds.

### DIFF
--- a/libcxx/include/__config
+++ b/libcxx/include/__config
@@ -44,7 +44,9 @@
 // Warn if a compiler version is used that is not supported anymore
 // LLVM RELEASE Update the minimum compiler versions
 #  if defined(_LIBCPP_CLANG_VER)
-#    if _LIBCPP_CLANG_VER < 1600
+// The OSS-Fuzz builds uses an unsupported Clang version (Clang 15).
+// TODO Find a permanent solution for OSS-Fuzz.
+#    if _LIBCPP_CLANG_VER < 1500
 #      warning "Libc++ only supports Clang 16 and later"
 #    endif
 #  elif defined(_LIBCPP_APPLE_CLANG_VER)


### PR DESCRIPTION
OSS-Fuzz still uses Clang-15 which causes OSS-Fuzz to fail. It has not been tested that after this change there are other issues with the build.