### PR TITLE
[SPIR-V] Map llvm.{min,max}num to GL::N{Min,Max}

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVInstructionSelector.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVInstructionSelector.cpp
@@ -432,10 +432,10 @@ bool SPIRVInstructionSelector::spvSelect(Register ResVReg,
 
   case TargetOpcode::G_FMINNUM:
   case TargetOpcode::G_FMINIMUM:
-    return selectExtInst(ResVReg, ResType, I, CL::fmin, GL::FMin);
+    return selectExtInst(ResVReg, ResType, I, CL::fmin, GL::NMin);
   case TargetOpcode::G_FMAXNUM:
   case TargetOpcode::G_FMAXIMUM:
-    return selectExtInst(ResVReg, ResType, I, CL::fmax, GL::FMax);
+    return selectExtInst(ResVReg, ResType, I, CL::fmax, GL::NMax);
 
   case TargetOpcode::G_FCOPYSIGN:
     return selectExtInst(ResVReg, ResType, I, CL::copysign);

--- a/llvm/test/CodeGen/SPIRV/hlsl-intrinsics/fmax.ll
+++ b/llvm/test/CodeGen/SPIRV/hlsl-intrinsics/fmax.ll
@@ -5,21 +5,21 @@
 
 define noundef half @test_fmax_half(half noundef %a, half noundef %b) {
 entry:
-; CHECK: %[[#]] = OpExtInst %[[#]] %[[#]] FMax %[[#]] %[[#]]
+; CHECK: %[[#]] = OpExtInst %[[#]] %[[#]] NMax %[[#]] %[[#]]
   %0 = call half @llvm.maxnum.f16(half %a, half %b)
   ret half %0
 }
 
 define noundef float @test_fmax_float(float noundef %a, float noundef %b) {
 entry:
-; CHECK: %[[#]] = OpExtInst %[[#]] %[[#]] FMax %[[#]] %[[#]]
+; CHECK: %[[#]] = OpExtInst %[[#]] %[[#]] NMax %[[#]] %[[#]]
   %0 = call float @llvm.maxnum.f32(float %a, float %b)
   ret float %0
 }
 
 define noundef double @test_fmax_double(double noundef %a, double noundef %b) {
 entry:
-; CHECK: %[[#]] = OpExtInst %[[#]] %[[#]] FMax %[[#]] %[[#]]
+; CHECK: %[[#]] = OpExtInst %[[#]] %[[#]] NMax %[[#]] %[[#]]
   %0 = call double @llvm.maxnum.f64(double %a, double %b)
   ret double %0
 }

--- a/llvm/test/CodeGen/SPIRV/hlsl-intrinsics/fmax.ll
+++ b/llvm/test/CodeGen/SPIRV/hlsl-intrinsics/fmax.ll
@@ -1,6 +1,5 @@
 ; RUN: llc -O0 -mtriple=spirv-unknown-unknown %s -o - | FileCheck %s
 ; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv-unknown-unknown %s -o - -filetype=obj | spirv-val %}
-; TODO: This need to be NMax: See https://github.com/llvm/llvm-project/issues/87072
 ; CHECK: OpExtInstImport "GLSL.std.450"
 
 define noundef half @test_fmax_half(half noundef %a, half noundef %b) {

--- a/llvm/test/CodeGen/SPIRV/hlsl-intrinsics/fmin.ll
+++ b/llvm/test/CodeGen/SPIRV/hlsl-intrinsics/fmin.ll
@@ -1,6 +1,5 @@
 ; RUN: llc -O0 -mtriple=spirv-unknown-unknown %s -o - | FileCheck %s
 ; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv-unknown-unknown %s -o - -filetype=obj | spirv-val %}
-; TODO: This need to be NMin: See https://github.com/llvm/llvm-project/issues/87072
 
 ; CHECK: OpExtInstImport "GLSL.std.450"
 ; CHECK: OpMemoryModel Logical GLSL450

--- a/llvm/test/CodeGen/SPIRV/hlsl-intrinsics/fmin.ll
+++ b/llvm/test/CodeGen/SPIRV/hlsl-intrinsics/fmin.ll
@@ -7,21 +7,21 @@
 
 define noundef half @test_fmax_half(half noundef %a, half noundef %b) {
 entry:
-; CHECK: %[[#]] = OpExtInst %[[#]] %[[#]] FMin %[[#]] %[[#]]
+; CHECK: %[[#]] = OpExtInst %[[#]] %[[#]] NMin %[[#]] %[[#]]
   %0 = call half @llvm.minnum.f16(half %a, half %b)
   ret half %0
 }
 
 define noundef float @test_fmax_float(float noundef %a, float noundef %b) {
 entry:
-; CHECK: %[[#]] = OpExtInst %[[#]] %[[#]] FMin %[[#]] %[[#]]
+; CHECK: %[[#]] = OpExtInst %[[#]] %[[#]] NMin %[[#]] %[[#]]
   %0 = call float @llvm.minnum.f32(float %a, float %b)
   ret float %0
 }
 
 define noundef double @test_fmax_double(double noundef %a, double noundef %b) {
 entry:
-; CHECK: %[[#]] = OpExtInst %[[#]] %[[#]] FMin %[[#]] %[[#]]
+; CHECK: %[[#]] = OpExtInst %[[#]] %[[#]] NMin %[[#]] %[[#]]
   %0 = call double @llvm.minnum.f64(double %a, double %b)
   ret double %0
 }


### PR DESCRIPTION
SPIR-V intsruction selection was mapping the LLVM float min/max intrinsics to FMin and FMax respectively for GL/Vulkan environments, which does not match the intrinsics' documented treatment of NaN operands. This patch switches the mapping to the correctly matched NMin and NMax operations.

Fixes #87072