### PR TITLE
[libc++][format] Fixed `println.blank_line.sh.cpp` test on llvm-clang-win-x-* configurations

### DIFF
--- a/libcxx/test/std/input.output/iostream.format/print.fun/println.blank_line.sh.cpp
+++ b/libcxx/test/std/input.output/iostream.format/print.fun/println.blank_line.sh.cpp
@@ -35,13 +35,15 @@
 
 // FILE_DEPENDENCIES: echo.sh
 // RUN: %{build}
-// RUN: %{exec} bash echo.sh -ne "\n" > %t.expected
+// RUN: %{exec} bash echo.sh -ne "println blank line test: \n" > %t.expected
 // RUN: %{exec} "%t.exe" > %t.actual
 // RUN: diff -u %t.actual %t.expected
 
 #include <print>
 
 int main(int, char**) {
+  // On some configurations the `diff -u` test fails if we print a single blank line character `\n`, so we print some text first.
+  std::print("println blank line test: ");
   std::println();
 
   return 0;


### PR DESCRIPTION
Fix for issue: https://github.com/llvm/llvm-project/pull/87277#issuecomment-2041864530

The test fails on the windows to linux cross builders. The proposed resolution is to print some text. The issue is possibly due to the original test outputting a single `\n` character.