### PR TITLE
Add handling of the `-nostdlibinc` option to ccc-analyzer

### DIFF
--- a/clang/tools/scan-build/libexec/ccc-analyzer
+++ b/clang/tools/scan-build/libexec/ccc-analyzer
@@ -361,6 +361,7 @@ sub Analyze {
 
 my %CompileOptionMap = (
   '-nostdinc' => 0,
+  '-nostdlibinc' => 0,
   '-include' => 1,
   '-idirafter' => 1,
   '-imacros' => 1,


### PR DESCRIPTION
Compiler options recognizable to ccc-analyzer are stored in maps.  An option missing in the map will be dropped by ccc-analyzer.  This causes a build error in one of our projects that only happens in scan-build but not regular build, because ccc-analyzer do not recognize `-nostdlibinc`.

This commit adds the option to the map.