### PR TITLE
Fix error in unrecognized register name handling for "SBFrame.register"

### DIFF
--- a/lldb/bindings/interface/SBFrameExtensions.i
+++ b/lldb/bindings/interface/SBFrameExtensions.i
@@ -44,6 +44,16 @@ STRING_EXTENSION_OUTSIDE(SBFrame)
                 def __init__(self, regs):
                     self.regs = regs
 
+                def __iter__(self):
+                    return self.get_registers()
+
+                def get_registers(self):
+                    for i in range(0,len(self.regs)):
+                        rs = self.regs[i]
+                        for j in range (0,rs.num_children):
+                            reg = rs.GetChildAtIndex(j)
+                            yield reg
+                          
                 def __getitem__(self, key):
                     if type(key) is str:
                         for i in range(0,len(self.regs)):
@@ -52,7 +62,7 @@ STRING_EXTENSION_OUTSIDE(SBFrame)
                                 reg = rs.GetChildAtIndex(j)
                                 if reg.name == key: return reg
                     else:
-                        return lldb.SBValue()
+                        return SBValue()
 
             return registers_access(self.registers)
 

--- a/lldb/test/API/python_api/frame/TestFrames.py
+++ b/lldb/test/API/python_api/frame/TestFrames.py
@@ -73,7 +73,19 @@ class FrameAPITestCase(TestBase):
                 gpr_reg_set = lldbutil.get_GPRs(frame)
                 pc_value = gpr_reg_set.GetChildMemberWithName("pc")
                 self.assertTrue(pc_value, "We should have a valid PC.")
+                # Make sure we can also get this from the "register" property:
+                iterator_pc_value = 0
+                found_pc = False
+                for reg in frame.register:
+                    if reg.name == "pc":
+                        found_pc = True
+                        iterator_pc_value = int(reg.GetValue(), 0)
+                        break
+
                 pc_value_int = int(pc_value.GetValue(), 0)
+                self.assertTrue(found_pc, "Found the PC value in the register list")
+                self.assertEqual(iterator_pc_value, pc_value_int, "The methods of finding pc match")
+    
                 # Make sure on arm targets we dont mismatch PC value on the basis of thumb bit.
                 # Frame PC will not have thumb bit set in case of a thumb
                 # instruction as PC.


### PR DESCRIPTION
The code returned lldb.SBValue() when you passed in an unrecognized register name.  But referring to "lldb" is apparently not legal within the module.

I changed this to just return SBValue(), but then this construct:

(lldb) script
>>> for reg_set in lldb.target.process.thread[0].frames[0].register
...    print(reg)

Runs forever printing "No Value".  The __getitem__(key) gets called with a monotonically increasing by 1 series of integers.  I don't know why Python decided the class we defined should have a generator that returns positive integers in order, but we can add a more useful one here by returning an iterator over the flattened list of registers.

Note, the not very aptly named "SBFrame.registers" is an iterator over register sets, not registers, so the two are not redundant.