### PR TITLE
[libc][setjmp] fix setjmp test via naked fn attr

### DIFF
--- a/libc/src/setjmp/x86_64/CMakeLists.txt
+++ b/libc/src/setjmp/x86_64/CMakeLists.txt
@@ -8,12 +8,8 @@ add_entrypoint_object(
     libc.hdr.types.jmp_buf
   COMPILE_OPTIONS
     -O3
-    -fno-omit-frame-pointer
-    # TODO: Remove once one of these lands:
-    # https://github.com/llvm/llvm-project/pull/87837
-    # https://github.com/llvm/llvm-project/pull/88054
-    # https://github.com/llvm/llvm-project/pull/88157
-    -ftrivial-auto-var-init=uninitialized
+    -fomit-frame-pointer
+    -momit-leaf-frame-pointer
 )
 
 add_entrypoint_object(

--- a/libc/src/setjmp/x86_64/CMakeLists.txt
+++ b/libc/src/setjmp/x86_64/CMakeLists.txt
@@ -8,8 +8,6 @@ add_entrypoint_object(
     libc.hdr.types.jmp_buf
   COMPILE_OPTIONS
     -O3
-    -fomit-frame-pointer
-    -momit-leaf-frame-pointer
 )
 
 add_entrypoint_object(

--- a/libc/src/setjmp/x86_64/setjmp.cpp
+++ b/libc/src/setjmp/x86_64/setjmp.cpp
@@ -16,23 +16,14 @@
 
 namespace LIBC_NAMESPACE_DECL {
 
-LLVM_LIBC_FUNCTION(int, setjmp, (jmp_buf buf)) {
-  register __UINT64_TYPE__ rbx __asm__("rbx");
-  register __UINT64_TYPE__ r12 __asm__("r12");
-  register __UINT64_TYPE__ r13 __asm__("r13");
-  register __UINT64_TYPE__ r14 __asm__("r14");
-  register __UINT64_TYPE__ r15 __asm__("r15");
-
-  // We want to store the register values as is. So, we will suppress the
-  // compiler warnings about the uninitialized variables declared above.
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wuninitialized"
-  LIBC_INLINE_ASM("mov %1, %0\n\t" : "=m"(buf->rbx) : "r"(rbx) :);
-  LIBC_INLINE_ASM("mov %1, %0\n\t" : "=m"(buf->r12) : "r"(r12) :);
-  LIBC_INLINE_ASM("mov %1, %0\n\t" : "=m"(buf->r13) : "r"(r13) :);
-  LIBC_INLINE_ASM("mov %1, %0\n\t" : "=m"(buf->r14) : "r"(r14) :);
-  LIBC_INLINE_ASM("mov %1, %0\n\t" : "=m"(buf->r15) : "r"(r15) :);
-#pragma GCC diagnostic pop
+LLVM_LIBC_FUNCTION(int, setjmp, (__jmp_buf * buf)) {
+  asm("mov %%rbx, %[rbx]\n\t"
+      "mov %%r12, %[r12]\n\t"
+      "mov %%r13, %[r13]\n\t"
+      "mov %%r14, %[r14]\n\t"
+      "mov %%r15, %[r15]"
+      : [rbx] "=m"(buf->rbx), [r12] "=m"(buf->r12), [r13] "=m"(buf->r13),
+        [r14] "=m"(buf->r14), [r15] "=m"(buf->r15));
 
   // We want the rbp of the caller, which is what __builtin_frame_address(1)
   // should return. But, compilers generate a warning that calling

--- a/libc/src/setjmp/x86_64/setjmp.cpp
+++ b/libc/src/setjmp/x86_64/setjmp.cpp
@@ -17,8 +17,7 @@
 
 namespace LIBC_NAMESPACE_DECL {
 
-__attribute__((naked))
-LLVM_LIBC_FUNCTION(int, setjmp, (__jmp_buf * buf)) {
+__attribute__((naked)) LLVM_LIBC_FUNCTION(int, setjmp, (__jmp_buf * buf)) {
   asm("mov %%rbx, %c[rbx](%%rdi)\n\t"
       "mov %%rbp, %c[rbp](%%rdi)\n\t"
       "mov %%r12, %c[r12](%%rdi)\n\t"

--- a/libc/src/setjmp/x86_64/setjmp.cpp
+++ b/libc/src/setjmp/x86_64/setjmp.cpp
@@ -29,16 +29,15 @@ LLVM_LIBC_FUNCTION(int, setjmp, (__jmp_buf * buf)) {
       "lea 8(%%rsp), %%rax\n\t"
       "mov %%rax, %c[rsp](%%rdi)\n\t"
 
-      "mov %[read_rip], %c[rip](%%rdi)\n\t"
+      "mov (%%rsp), %%rax\n\t"
+      "mov %%rax, %c[rip](%%rdi)\n\t"
 
       "xorl %%eax, %%eax\n\t"
-      "retq"
-      ::
-      [rbx] "i"(offsetof(__jmp_buf, rbx)), [r12] "i"(offsetof(__jmp_buf, r12)),
+      "retq" ::[rbx] "i"(offsetof(__jmp_buf, rbx)),
+      [rbp] "i"(offsetof(__jmp_buf, rbp)), [r12] "i"(offsetof(__jmp_buf, r12)),
       [r13] "i"(offsetof(__jmp_buf, r13)), [r14] "i"(offsetof(__jmp_buf, r14)),
-      [r15] "i"(offsetof(__jmp_buf, r15)), [rbp] "i"(offsetof(__jmp_buf, rbp)),
-      [rsp] "i"(offsetof(__jmp_buf, rsp)), [rip] "i"(offsetof(__jmp_buf, rip)),
-      [read_rip] "r" (reinterpret_cast<__UINTPTR_TYPE__>(__builtin_return_address(0)))
+      [r15] "i"(offsetof(__jmp_buf, r15)), [rsp] "i"(offsetof(__jmp_buf, rsp)),
+      [rip] "i"(offsetof(__jmp_buf, rip))
       : "rax");
 }
 

--- a/libc/src/setjmp/x86_64/setjmp.cpp
+++ b/libc/src/setjmp/x86_64/setjmp.cpp
@@ -19,21 +19,22 @@ namespace LIBC_NAMESPACE_DECL {
 
 [[gnu::naked]]
 LLVM_LIBC_FUNCTION(int, setjmp, (__jmp_buf * buf)) {
-  asm("mov %%rbx, %c[rbx](%%rdi)\n\t"
-      "mov %%rbp, %c[rbp](%%rdi)\n\t"
-      "mov %%r12, %c[r12](%%rdi)\n\t"
-      "mov %%r13, %c[r13](%%rdi)\n\t"
-      "mov %%r14, %c[r14](%%rdi)\n\t"
-      "mov %%r15, %c[r15](%%rdi)\n\t"
+  asm(R"(
+      mov %%rbx, %c[rbx](%%rdi)
+      mov %%rbp, %c[rbp](%%rdi)
+      mov %%r12, %c[r12](%%rdi)
+      mov %%r13, %c[r13](%%rdi)
+      mov %%r14, %c[r14](%%rdi)
+      mov %%r15, %c[r15](%%rdi)
 
-      "lea 8(%%rsp), %%rax\n\t"
-      "mov %%rax, %c[rsp](%%rdi)\n\t"
+      lea 8(%%rsp), %%rax
+      mov %%rax, %c[rsp](%%rdi)
 
-      "mov (%%rsp), %%rax\n\t"
-      "mov %%rax, %c[rip](%%rdi)\n\t"
+      mov (%%rsp), %%rax
+      mov %%rax, %c[rip](%%rdi)
 
-      "xorl %%eax, %%eax\n\t"
-      "retq" ::[rbx] "i"(offsetof(__jmp_buf, rbx)),
+      xorl %%eax, %%eax
+      retq)" ::[rbx] "i"(offsetof(__jmp_buf, rbx)),
       [rbp] "i"(offsetof(__jmp_buf, rbp)), [r12] "i"(offsetof(__jmp_buf, r12)),
       [r13] "i"(offsetof(__jmp_buf, r13)), [r14] "i"(offsetof(__jmp_buf, r14)),
       [r15] "i"(offsetof(__jmp_buf, r15)), [rsp] "i"(offsetof(__jmp_buf, rsp)),

--- a/libc/src/setjmp/x86_64/setjmp.cpp
+++ b/libc/src/setjmp/x86_64/setjmp.cpp
@@ -17,7 +17,8 @@
 
 namespace LIBC_NAMESPACE_DECL {
 
-__attribute__((naked)) LLVM_LIBC_FUNCTION(int, setjmp, (__jmp_buf * buf)) {
+[[gnu::naked]]
+LLVM_LIBC_FUNCTION(int, setjmp, (__jmp_buf * buf)) {
   asm("mov %%rbx, %c[rbx](%%rdi)\n\t"
       "mov %%rbp, %c[rbp](%%rdi)\n\t"
       "mov %%r12, %c[r12](%%rdi)\n\t"


### PR DESCRIPTION
This would consistently fail for me locally, to the point where I could not run
ninja libc-unit-tests without ninja libc_setjmp_unittests failing.

Turns out that since I enabled -ftrivial-auto-var-init=pattern in
commit 1d5c16d ("[libc] default enable -ftrivial-auto-var-init=pattern (#78776)")
this has been a problem. Our x86_64 setjmp definition disabled -Wuninitialized,
so we wound up clobbering these registers and instead backing up
0xAAAAAAAAAAAAAAAA rather than the actual register value.

Use `naked` function attribute to avoid function prolog/epilog.
