### PR TITLE
[libc] Initialize rand for fma tests

### DIFF
--- a/libc/test/src/math/CMakeLists.txt
+++ b/libc/test/src/math/CMakeLists.txt
@@ -1271,6 +1271,7 @@ add_fp_unittest(
   DEPENDS
     libc.src.math.fmaf
     libc.src.stdlib.rand
+    libc.src.stdlib.srand
     libc.src.__support.FPUtil.fp_bits
   FLAGS
     FMA_OPT__ONLY
@@ -1286,6 +1287,7 @@ add_fp_unittest(
   DEPENDS
     libc.src.math.fma
     libc.src.stdlib.rand
+    libc.src.stdlib.srand
     libc.src.__support.FPUtil.fp_bits
 )
 

--- a/libc/test/src/math/FmaTest.h
+++ b/libc/test/src/math/FmaTest.h
@@ -11,6 +11,7 @@
 
 #include "src/__support/FPUtil/FPBits.h"
 #include "src/stdlib/rand.h"
+#include "src/stdlib/srand.h"
 #include "test/UnitTest/FPMatcher.h"
 #include "test/UnitTest/Test.h"
 #include "utils/MPFRWrapper/MPFRUtils.h"
@@ -76,6 +77,7 @@ public:
   void test_subnormal_range(Func func) {
     constexpr StorageType COUNT = 100'001;
     constexpr StorageType STEP = (MAX_SUBNORMAL - MIN_SUBNORMAL) / COUNT;
+    LIBC_NAMESPACE::srand(1);
     for (StorageType v = MIN_SUBNORMAL, w = MAX_SUBNORMAL;
          v <= MAX_SUBNORMAL && w >= MIN_SUBNORMAL; v += STEP, w -= STEP) {
       T x = FPBits(get_random_bit_pattern()).get_val(), y = FPBits(v).get_val(),
@@ -89,6 +91,7 @@ public:
   void test_normal_range(Func func) {
     constexpr StorageType COUNT = 100'001;
     constexpr StorageType STEP = (MAX_NORMAL - MIN_NORMAL) / COUNT;
+    LIBC_NAMESPACE::srand(1);
     for (StorageType v = MIN_NORMAL, w = MAX_NORMAL;
          v <= MAX_NORMAL && w >= MIN_NORMAL; v += STEP, w -= STEP) {
       T x = FPBits(v).get_val(), y = FPBits(w).get_val(),


### PR DESCRIPTION
Summary:
The GPU build will have some random garbage here since we do not support
initializers for the underlying implementation. Manually set the seed to
1.
