### PR TITLE
[lld] Error on unsupported split stack

### DIFF
--- a/lld/ELF/Target.cpp
+++ b/lld/ELF/Target.cpp
@@ -141,7 +141,7 @@ bool TargetInfo::needsThunk(RelExpr expr, RelType type, const InputFile *file,
 
 bool TargetInfo::adjustPrologueForCrossSplitStack(uint8_t *loc, uint8_t *end,
                                                   uint8_t stOther) const {
-  llvm_unreachable("Target doesn't support split stacks.");
+  fatal("Target doesn't support split stacks.");
 }
 
 bool TargetInfo::inBranchRange(RelType type, uint64_t src, uint64_t dst) const {

--- a/lld/ELF/Target.cpp
+++ b/lld/ELF/Target.cpp
@@ -141,7 +141,7 @@ bool TargetInfo::needsThunk(RelExpr expr, RelType type, const InputFile *file,
 
 bool TargetInfo::adjustPrologueForCrossSplitStack(uint8_t *loc, uint8_t *end,
                                                   uint8_t stOther) const {
-  fatal("Target doesn't support split stacks.");
+  fatal("target doesn't support split stacks");
 }
 
 bool TargetInfo::inBranchRange(RelType type, uint64_t src, uint64_t dst) const {

--- a/lld/test/ELF/Inputs/riscv-split-stack-callee.s
+++ b/lld/test/ELF/Inputs/riscv-split-stack-callee.s
@@ -1,0 +1,4 @@
+        .globl  test
+        .type   test,@function
+test:
+	ret

--- a/lld/test/ELF/Inputs/riscv-split-stack-callee.s
+++ b/lld/test/ELF/Inputs/riscv-split-stack-callee.s
@@ -1,4 +1,0 @@
-        .globl  test
-        .type   test,@function
-test:
-	ret

--- a/lld/test/ELF/riscv-split-stack.s
+++ b/lld/test/ELF/riscv-split-stack.s
@@ -1,0 +1,15 @@
+# REQUIRES: riscv
+
+# RUN: llvm-mc -filetype=obj -triple=riscv64 %s -o %t.64.o
+# RUN: llvm-mc -filetype=obj -triple=riscv64 %p/Inputs/riscv-split-stack-callee.s -o %t.64.2.o
+# RUN: not ld.lld %t.64.o %t.64.2.o -o %t.64 2>&1 | FileCheck %s
+# CHECK: ld.lld: error: Target doesn't support split stacks.
+
+        .globl  _start
+        .type   _start,@function
+_start:
+        call    test
+	ret
+end:
+        .size   _start, end-_start
+        .section        ".note.GNU-split-stack","",@progbits

--- a/lld/test/ELF/riscv-split-stack.s
+++ b/lld/test/ELF/riscv-split-stack.s
@@ -1,10 +1,12 @@
 # REQUIRES: riscv
 
-# RUN: llvm-mc -filetype=obj -triple=riscv64 %s -o %t.64.o
-# RUN: llvm-mc -filetype=obj -triple=riscv64 %p/Inputs/riscv-split-stack-callee.s -o %t.64.2.o
+# RUN: split-file %s %t
+# RUN: llvm-mc -filetype=obj -triple=riscv64 %t/main.s -o %t.64.o
+# RUN: llvm-mc -filetype=obj -triple=riscv64 %t/callee.s -o %t.64.2.o
 # RUN: not ld.lld %t.64.o %t.64.2.o -o %t.64 2>&1 | FileCheck %s
-# CHECK: ld.lld: error: Target doesn't support split stacks.
+# CHECK: error: target doesn't support split stacks
 
+#--- main.s
         .globl  _start
         .type   _start,@function
 _start:
@@ -13,3 +15,10 @@ _start:
 end:
         .size   _start, end-_start
         .section        ".note.GNU-split-stack","",@progbits
+
+
+#--- callee.s
+        .globl  test
+        .type   test,@function
+test:
+	ret


### PR DESCRIPTION
Targets with no `-fstack-split` support now emit `ld.lld: error: target doesn't support split stacks` instead of `UNREACHABLE executed` with a backtrace asking the user to report a bug.

Resolves #88061