### PR TITLE
[lit][ci] Publish lit wheels

### DIFF
--- a/.github/workflows/release-lit.yml
+++ b/.github/workflows/release-lit.yml
@@ -58,7 +58,7 @@ jobs:
           cd llvm/utils/lit
           # Remove 'dev' suffix from lit version.
           sed -i 's/ + "dev"//g' lit/__init__.py
-          python3 setup.py sdist
+          python3 setup.py sdist bdist_wheel
 
       - name: Upload lit to test.pypi.org
         uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
Add wheel publishing in addition to existing source distribution publishing of lit.

Fixes #63369. This also uses the exact fix proposed by @EFord36 in #63369.

I was testing it on my branch (with a further modified version of CI that avoids some of the problematic GitHub Actions steps for a fork and adds debug information about what was built) only to make sure that this produces the expected files. That can be observed here: https://github.com/seldridge/llvm-project/actions/runs/8608056297/job/23589700846#step:7:1 There would now be a `lit-18.1.0-py3-none-any.whl` in addition to a `lit-18.1.0.tar.gz`.

My use case for this is slightly different from #63369. I would like to use `lit` for an internal project. However, the internal project uses a build system which doesn't have support for building source dependencies except when using `--no-use-pep517`. `lit`, however, specifies a `build-backend` in its `pyproject.toml` which [`pip` treats as explicit opt-in to `pep517` even when the command line opt-out is provided](https://github.com/pypa/pip/issues/6230#issuecomment-459805348).