### PR TITLE
[clang][UBSan] Remove rigid metadata checks for `ubsan-bitfield-conversion`

### DIFF
--- a/clang/test/CodeGen/ubsan-bitfield-conversion.c
+++ b/clang/test/CodeGen/ubsan-bitfield-conversion.c
@@ -17,7 +17,7 @@ void foo1(int x) {
   // CHECK-NEXT: [[BFRESULTASHR:%.*]] = ashr i8 [[BFRESULTSHL]], 5
   // CHECK-NEXT: [[BFRESULTCAST:%.*]] = sext i8 [[BFRESULTASHR]] to i32
   // CHECK-BITFIELD-CONVERSION: call void @__ubsan_handle_implicit_conversion
-  // CHECK-BITFIELD-CONVERSION-NEXT: br label %[[CONT:.*]], !nosanitize !6
+  // CHECK-BITFIELD-CONVERSION-NEXT: br label %[[CONT:.*]], !nosanitize
   // CHECK-BITFIELD-CONVERSION: [[CONT]]:
   // CHECK-NEXT: ret void
 }
@@ -29,7 +29,7 @@ void foo2(int x) {
   // CHECK-NEXT: [[BFRESULTSHL:%.*]] = shl i8 {{.*}}, 6
   // CHECK-NEXT: [[BFRESULTASHR:%.*]] = ashr i8 [[BFRESULTSHL]], 6
   // CHECK-BITFIELD-CONVERSION: call void @__ubsan_handle_implicit_conversion
-  // CHECK-BITFIELD-CONVERSION-NEXT: br label %[[CONT:.*]], !nosanitize !6
+  // CHECK-BITFIELD-CONVERSION-NEXT: br label %[[CONT:.*]], !nosanitize
   // CHECK-BITFIELD-CONVERSION: [[CONT]]:
   // CHECK-NEXT: ret void
 }
@@ -42,7 +42,7 @@ void foo3() {
   // CHECK-NEXT: [[BFRESULTASHR:%.*]] = ashr i8 [[BFRESULTSHL]], 5
   // CHECK-NEXT: [[BFRESULTCAST:%.*]] = sext i8 [[BFRESULTASHR]] to i32
   // CHECK-BITFIELD-CONVERSION: call void @__ubsan_handle_implicit_conversion
-  // CHECK-BITFIELD-CONVERSION-NEXT: br label %[[CONT:.*]], !nosanitize !6
+  // CHECK-BITFIELD-CONVERSION-NEXT: br label %[[CONT:.*]], !nosanitize
   // CHECK-BITFIELD-CONVERSION: [[CONT]]:
   // CHECK-NEXT: ret void
 }
@@ -55,7 +55,7 @@ void foo4(int x) {
   // CHECK-NEXT: [[BFRESULTASHR:%.*]] = ashr i8 [[BFRESULTSHL]], 5
   // CHECK-NEXT: [[BFRESULTCAST:%.*]] = sext i8 [[BFRESULTASHR]] to i32
   // CHECK-BITFIELD-CONVERSION: call void @__ubsan_handle_implicit_conversion
-  // CHECK-BITFIELD-CONVERSION-NEXT: br label %[[CONT:.*]], !nosanitize !6
+  // CHECK-BITFIELD-CONVERSION-NEXT: br label %[[CONT:.*]], !nosanitize
   // CHECK-BITFIELD-CONVERSION: [[CONT]]:
   // CHECK-NEXT: ret void
 }

--- a/clang/test/CodeGenCXX/ubsan-bitfield-conversion.cpp
+++ b/clang/test/CodeGenCXX/ubsan-bitfield-conversion.cpp
@@ -23,14 +23,14 @@ void foo1(int x) {
   // CHECK-BITFIELD-CONVERSION-NEXT: [[BFRESULTASHR:%.*]] = ashr i8 [[BFRESULTSHL]], 5
   // CHECK-BITFIELD-CONVERSION-NEXT: [[BFRESULTCAST:%.*]] = sext i8 [[BFRESULTASHR]] to i32
   // CHECK-BITFIELD-CONVERSION: call void @__ubsan_handle_implicit_conversion
-  // CHECK-BITFIELD-CONVERSION-NEXT: br label %[[CONT:.*]], !nosanitize !6
+  // CHECK-BITFIELD-CONVERSION-NEXT: br label %[[CONT:.*]], !nosanitize
   c.a = x;
   // CHECK: store i8 %{{.*}}
   // CHECK-BITFIELD-CONVERSION: [[BFRESULTSHL:%.*]] = shl i8 {{.*}}, 5
   // CHECK-BITFIELD-CONVERSION-NEXT: [[BFRESULTASHR:%.*]] = ashr i8 [[BFRESULTSHL]], 5
   // CHECK-BITFIELD-CONVERSION-NEXT: [[BFRESULTCAST:%.*]] = sext i8 [[BFRESULTASHR]] to i32
   // CHECK-BITFIELD-CONVERSION: call void @__ubsan_handle_implicit_conversion
-  // CHECK-BITFIELD-CONVERSION-NEXT: br label %[[CONT:.*]], !nosanitize !6
+  // CHECK-BITFIELD-CONVERSION-NEXT: br label %[[CONT:.*]], !nosanitize
   // CHECK-BITFIELD-CONVERSION: [[CONT]]:
   // CHECK-NEXT: ret void
 }
@@ -42,13 +42,13 @@ void foo2(int x) {
   // CHECK-BITFIELD-CONVERSION: [[BFRESULTSHL:%.*]] = shl i8 {{.*}}, 6
   // CHECK-BITFIELD-CONVERSION-NEXT: [[BFRESULTASHR:%.*]] = ashr i8 [[BFRESULTSHL]], 6
   // CHECK-BITFIELD-CONVERSION: call void @__ubsan_handle_implicit_conversion
-  // CHECK-BITFIELD-CONVERSION-NEXT: br label %[[CONT:.*]], !nosanitize !6
+  // CHECK-BITFIELD-CONVERSION-NEXT: br label %[[CONT:.*]], !nosanitize
   c.b = x;
   // CHECK: store i8 %{{.*}}
   // CHECK-BITFIELD-CONVERSION: [[BFRESULTSHL:%.*]] = shl i8 {{.*}}, 6
   // CHECK-BITFIELD-CONVERSION-NEXT: [[BFRESULTASHR:%.*]] = ashr i8 [[BFRESULTSHL]], 6
   // CHECK-BITFIELD-CONVERSION: call void @__ubsan_handle_implicit_conversion
-  // CHECK-BITFIELD-CONVERSION-NEXT: br label %[[CONT:.*]], !nosanitize !6
+  // CHECK-BITFIELD-CONVERSION-NEXT: br label %[[CONT:.*]], !nosanitize
   // CHECK-BITFIELD-CONVERSION: [[CONT]]:
   // CHECK-NEXT: ret void
 }
@@ -61,14 +61,14 @@ void foo3() {
   // CHECK-NEXT: [[BFRESULTASHR:%.*]] = ashr i8 [[BFRESULTSHL]], 5
   // CHECK-NEXT: [[BFRESULTCAST:%.*]] = sext i8 [[BFRESULTASHR]] to i32
   // CHECK-BITFIELD-CONVERSION: call void @__ubsan_handle_implicit_conversion
-  // CHECK-BITFIELD-CONVERSION-NEXT: br label %[[CONT:.*]], !nosanitize !6
+  // CHECK-BITFIELD-CONVERSION-NEXT: br label %[[CONT:.*]], !nosanitize
   c.a++;
   // CHECK: store i8 %{{.*}}
   // CHECK-NEXT: [[BFRESULTSHL:%.*]] = shl i8 {{.*}}, 5
   // CHECK-NEXT: [[BFRESULTASHR:%.*]] = ashr i8 [[BFRESULTSHL]], 5
   // CHECK-NEXT: [[BFRESULTCAST:%.*]] = sext i8 [[BFRESULTASHR]] to i32
   // CHECK-BITFIELD-CONVERSION: call void @__ubsan_handle_implicit_conversion
-  // CHECK-BITFIELD-CONVERSION-NEXT: br label %[[CONT:.*]], !nosanitize !6
+  // CHECK-BITFIELD-CONVERSION-NEXT: br label %[[CONT:.*]], !nosanitize
   // CHECK-BITFIELD-CONVERSION: [[CONT]]:
   // CHECK-NEXT: ret void
 }
@@ -81,14 +81,14 @@ void foo4(int x) {
   // CHECK-NEXT: [[BFRESULTASHR:%.*]] = ashr i8 [[BFRESULTSHL]], 5
   // CHECK-NEXT: [[BFRESULTCAST:%.*]] = sext i8 [[BFRESULTASHR]] to i32
   // CHECK-BITFIELD-CONVERSION: call void @__ubsan_handle_implicit_conversion
-  // CHECK-BITFIELD-CONVERSION-NEXT: br label %[[CONT:.*]], !nosanitize !6
+  // CHECK-BITFIELD-CONVERSION-NEXT: br label %[[CONT:.*]], !nosanitize
   c.a += x;
   // CHECK: store i8 %{{.*}}
   // CHECK-NEXT: [[BFRESULTSHL:%.*]] = shl i8 {{.*}}, 5
   // CHECK-NEXT: [[BFRESULTASHR:%.*]] = ashr i8 [[BFRESULTSHL]], 5
   // CHECK-NEXT: [[BFRESULTCAST:%.*]] = sext i8 [[BFRESULTASHR]] to i32
   // CHECK-BITFIELD-CONVERSION: call void @__ubsan_handle_implicit_conversion
-  // CHECK-BITFIELD-CONVERSION-NEXT: br label %[[CONT:.*]], !nosanitize !6
+  // CHECK-BITFIELD-CONVERSION-NEXT: br label %[[CONT:.*]], !nosanitize
   // CHECK-BITFIELD-CONVERSION: [[CONT]]:
   // CHECK-NEXT: ret void
 }


### PR DESCRIPTION
Follow-up to discussion: https://github.com/llvm/llvm-project/pull/87761

As discussed after landing the original PR:
Since fails could happen w.r.t. checking `!6`, these checks should be removed.