### PR TITLE
[clang-tidy] Ignore deleted ctor in `bugprone-forwarding-reference-overload`

### DIFF
--- a/clang-tools-extra/clang-tidy/bugprone/ForwardingReferenceOverloadCheck.cpp
+++ b/clang-tools-extra/clang-tidy/bugprone/ForwardingReferenceOverloadCheck.cpp
@@ -72,8 +72,7 @@ void ForwardingReferenceOverloadCheck::registerMatchers(MatchFinder *Finder) {
 
   DeclarationMatcher FindOverload =
       cxxConstructorDecl(
-          hasParameter(0, ForwardingRefParm),
-          unless(isDeleted()),
+          hasParameter(0, ForwardingRefParm), unless(isDeleted()),
           unless(hasAnyParameter(
               // No warning: enable_if as constructor parameter.
               parmVarDecl(hasType(isEnableIf())))),

--- a/clang-tools-extra/clang-tidy/bugprone/ForwardingReferenceOverloadCheck.cpp
+++ b/clang-tools-extra/clang-tidy/bugprone/ForwardingReferenceOverloadCheck.cpp
@@ -73,6 +73,7 @@ void ForwardingReferenceOverloadCheck::registerMatchers(MatchFinder *Finder) {
   DeclarationMatcher FindOverload =
       cxxConstructorDecl(
           hasParameter(0, ForwardingRefParm),
+          unless(isDeleted()),
           unless(hasAnyParameter(
               // No warning: enable_if as constructor parameter.
               parmVarDecl(hasType(isEnableIf())))),

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -147,6 +147,10 @@ Changes in existing checks
   <clang-tidy/checks/bugprone/assert-side-effect>` check by detecting side
   effect from calling a method with non-const reference parameters.
 
+- Improved :doc:`bugprone-forwarding-reference-overload
+  <clang-tidy/checks/bugprone/forwarding-reference-overload>`
+  check to not flag deleted constructors which are unable to hide anything.
+
 - Improved :doc:`bugprone-inc-dec-in-conditions
   <clang-tidy/checks/bugprone/inc-dec-in-conditions>` check to ignore code
   within unevaluated contexts, such as ``decltype``.
@@ -285,10 +289,6 @@ Changes in existing checks
   <clang-tidy/checks/readability/static-definition-in-anonymous-namespace>`
   check by resolving fix-it overlaps in template code by disregarding implicit
   instances.
-
-- Improved :doc:`bugprone-forwarding-reference-overload
-  <clang-tidy/checks/bugprone/forwarding-reference-overload>`
-  check to not flag deleted constructors which are unable to hide anything.
 
 Removed checks
 ^^^^^^^^^^^^^^

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -149,7 +149,7 @@ Changes in existing checks
 
 - Improved :doc:`bugprone-forwarding-reference-overload
   <clang-tidy/checks/bugprone/forwarding-reference-overload>`
-  check to not flag deleted constructors which are unable to hide anything.
+  check to ignore deleted constructors which won't hide other overloads.
 
 - Improved :doc:`bugprone-inc-dec-in-conditions
   <clang-tidy/checks/bugprone/inc-dec-in-conditions>` check to ignore code

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -102,6 +102,7 @@ Improvements to clang-tidy
   similar fashion to what `-header-filter` does for header files.
 - Improved :program:`check_clang_tidy.py` script. Added argument `-export-fixes`
   to aid in clang-tidy and test development.
+- Fixed an issue with `bugprone-forwarding-reference-overload` where it would incorrectly flag deleted constructors
 
 New checks
 ^^^^^^^^^^

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -102,7 +102,6 @@ Improvements to clang-tidy
   similar fashion to what `-header-filter` does for header files.
 - Improved :program:`check_clang_tidy.py` script. Added argument `-export-fixes`
   to aid in clang-tidy and test development.
-- Fixed an issue with `bugprone-forwarding-reference-overload` where it would incorrectly flag deleted constructors
 
 New checks
 ^^^^^^^^^^
@@ -286,6 +285,10 @@ Changes in existing checks
   <clang-tidy/checks/readability/static-definition-in-anonymous-namespace>`
   check by resolving fix-it overlaps in template code by disregarding implicit
   instances.
+
+- Improved :doc:`bugprone-forwarding-reference-overload
+  <clang-tidy/checks/bugprone/forwarding-reference-overload>`
+  check to not flag deleted constructors which are unable to hide anything.
 
 Removed checks
 ^^^^^^^^^^^^^^

--- a/clang-tools-extra/test/clang-tidy/checkers/bugprone/forwarding-reference-overload.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/bugprone/forwarding-reference-overload.cpp
@@ -251,3 +251,13 @@ public:
   Test10(T &&Item, E e)
       : e(e){}
 };
+
+// A deleted ctor cannot hide anything
+class Test11 {
+public:
+  template <typename T>
+  Test11(T&&) = delete;
+
+  Test11(const Test11 &) = default;
+  Test11(Test11 &&) = default;
+};


### PR DESCRIPTION
Fix `bugprone-forwarding-reference-overload` so it doesn't report a constructor that is deleted.