### PR TITLE
[LLD][COFF] Check machine types in ICF::equalsConstant.

### DIFF
--- a/lld/COFF/ICF.cpp
+++ b/lld/COFF/ICF.cpp
@@ -178,7 +178,7 @@ bool ICF::equalsConstant(const SectionChunk *a, const SectionChunk *b) {
          a->getSectionName() == b->getSectionName() &&
          a->header->SizeOfRawData == b->header->SizeOfRawData &&
          a->checksum == b->checksum && a->getContents() == b->getContents() &&
-         assocEquals(a, b);
+         a->getMachine() == b->getMachine() && assocEquals(a, b);
 }
 
 // Compare "moving" part of two sections, namely relocation targets.

--- a/lld/test/COFF/arm64x-icf.s
+++ b/lld/test/COFF/arm64x-icf.s
@@ -1,0 +1,37 @@
+// REQUIRES: aarch64
+// RUN: split-file %s %t.dir && cd %t.dir
+
+// RUN: llvm-mc -filetype=obj -triple=arm64ec-windows func-arm64ec.s -o func-arm64ec.obj
+// RUN: llvm-mc -filetype=obj -triple=aarch64-windows func-arm64.s -o func-arm64.obj
+// RUN: lld-link -machine:arm64x -dll -noentry -out:out.dll func-arm64ec.obj func-arm64.obj
+// RUN: llvm-objdump -d out.dll | FileCheck %s
+
+// CHECK:      0000000180001000 <.text>:
+// CHECK-NEXT: 180001000: 52800020     mov     w0, #0x1                // =1
+// CHECK-NEXT: 180001004: d65f03c0     ret
+// CHECK-NEXT:                 ...
+// CHECK-NEXT: 180002000: 52800020     mov     w0, #0x1                // =1
+// CHECK-NEXT: 180002004: d65f03c0     ret
+
+
+#--- func-arm64.s
+        .section .text,"xr",discard,func
+        .globl func
+        .p2align 2
+func:
+        mov w0, #1
+        ret
+
+        .data
+        .rva func
+
+#--- func-arm64ec.s
+        .section .text,"xr",discard,"#func"
+        .globl "#func"
+        .p2align 2
+"#func":
+        mov w0, #1
+        ret
+
+        .data
+        .rva "#func"


### PR DESCRIPTION
Avoid replacing replacing a chunk with one from a different type. It's mostly a concern for ARM64X, where we don't want to merge aarch64 and arm64ec chunks, but it may also in theory happen on pure ARM64EC between arm64ec and x86_64 chunks.