### PR TITLE
[MLIR] Don't check for key before inserting in map in GreedyPatternRewriteDriver worklist (NFC)

### DIFF
--- a/mlir/lib/Transforms/Utils/GreedyPatternRewriteDriver.cpp
+++ b/mlir/lib/Transforms/Utils/GreedyPatternRewriteDriver.cpp
@@ -243,9 +243,8 @@ bool Worklist::empty() const {
 void Worklist::push(Operation *op) {
   assert(op && "cannot push nullptr to worklist");
   // Check to see if the worklist already contains this op.
-  if (map.count(op))
+  if (!map.insert({op, list.size()}).second)
     return;
-  map[op] = list.size();
   list.push_back(op);
 }
 


### PR DESCRIPTION
This is a common anti-pattern (any volunteer for a clang-tidy check?).

This does not show real word significant impact though.