### PR TITLE
Revert "[ADT] Use `adl_*` wrappers across STLExtras"

### DIFF
--- a/llvm/include/llvm/ADT/STLExtras.h
+++ b/llvm/include/llvm/ADT/STLExtras.h
@@ -320,8 +320,7 @@ public:
 
 /// Returns true if the given container only contains a single element.
 template <typename ContainerTy> bool hasSingleElement(ContainerTy &&C) {
-  auto B = adl_begin(C);
-  auto E = adl_end(C);
+  auto B = std::begin(C), E = std::end(C);
   return B != E && std::next(B) == E;
 }
 
@@ -376,7 +375,8 @@ inline mapped_iterator<ItTy, FuncTy> map_iterator(ItTy I, FuncTy F) {
 
 template <class ContainerTy, class FuncTy>
 auto map_range(ContainerTy &&C, FuncTy F) {
-  return make_range(map_iterator(adl_begin(C), F), map_iterator(adl_end(C), F));
+  return make_range(map_iterator(std::begin(C), F),
+                    map_iterator(std::end(C), F));
 }
 
 /// A base type of mapped iterator, that is useful for building derived
@@ -572,11 +572,11 @@ iterator_range<filter_iterator<detail::IterOfRange<RangeT>, PredicateT>>
 make_filter_range(RangeT &&Range, PredicateT Pred) {
   using FilterIteratorT =
       filter_iterator<detail::IterOfRange<RangeT>, PredicateT>;
-  return make_range(FilterIteratorT(adl_begin(std::forward<RangeT>(Range)),
-                                    adl_end(std::forward<RangeT>(Range)), Pred),
-                    FilterIteratorT(adl_end(std::forward<RangeT>(Range)),
-                                    adl_end(std::forward<RangeT>(Range)),
-                                    Pred));
+  return make_range(
+      FilterIteratorT(std::begin(std::forward<RangeT>(Range)),
+                      std::end(std::forward<RangeT>(Range)), Pred),
+      FilterIteratorT(std::end(std::forward<RangeT>(Range)),
+                      std::end(std::forward<RangeT>(Range)), Pred));
 }
 
 /// A pseudo-iterator adaptor that is designed to implement "early increment"
@@ -656,8 +656,8 @@ iterator_range<early_inc_iterator_impl<detail::IterOfRange<RangeT>>>
 make_early_inc_range(RangeT &&Range) {
   using EarlyIncIteratorT =
       early_inc_iterator_impl<detail::IterOfRange<RangeT>>;
-  return make_range(EarlyIncIteratorT(adl_begin(std::forward<RangeT>(Range))),
-                    EarlyIncIteratorT(adl_end(std::forward<RangeT>(Range))));
+  return make_range(EarlyIncIteratorT(std::begin(std::forward<RangeT>(Range))),
+                    EarlyIncIteratorT(std::end(std::forward<RangeT>(Range))));
 }
 
 // Forward declarations required by zip_shortest/zip_equal/zip_first/zip_longest
@@ -1097,8 +1097,8 @@ public:
   /// We need the full range to know how to switch between each of the
   /// iterators.
   template <typename... RangeTs>
-  explicit concat_iterator(RangeTs &&...Ranges)
-      : Begins(adl_begin(Ranges)...), Ends(adl_end(Ranges)...) {}
+  explicit concat_iterator(RangeTs &&... Ranges)
+      : Begins(std::begin(Ranges)...), Ends(std::end(Ranges)...) {}
 
   using BaseT::operator++;
 
@@ -1127,12 +1127,13 @@ template <typename ValueT, typename... RangeTs> class concat_range {
 public:
   using iterator =
       concat_iterator<ValueT,
-                      decltype(adl_begin(std::declval<RangeTs &>()))...>;
+                      decltype(std::begin(std::declval<RangeTs &>()))...>;
 
 private:
   std::tuple<RangeTs...> Ranges;
 
-  template <size_t... Ns> iterator begin_impl(std::index_sequence<Ns...>) {
+  template <size_t... Ns>
+  iterator begin_impl(std::index_sequence<Ns...>) {
     return iterator(std::get<Ns>(Ranges)...);
   }
   template <size_t... Ns>
@@ -1140,12 +1141,12 @@ private:
     return iterator(std::get<Ns>(Ranges)...);
   }
   template <size_t... Ns> iterator end_impl(std::index_sequence<Ns...>) {
-    return iterator(make_range(adl_end(std::get<Ns>(Ranges)),
-                               adl_end(std::get<Ns>(Ranges)))...);
+    return iterator(make_range(std::end(std::get<Ns>(Ranges)),
+                               std::end(std::get<Ns>(Ranges)))...);
   }
   template <size_t... Ns> iterator end_impl(std::index_sequence<Ns...>) const {
-    return iterator(make_range(adl_end(std::get<Ns>(Ranges)),
-                               adl_end(std::get<Ns>(Ranges)))...);
+    return iterator(make_range(std::end(std::get<Ns>(Ranges)),
+                               std::end(std::get<Ns>(Ranges)))...);
   }
 
 public:
@@ -1419,7 +1420,7 @@ public:
 
 /// Given a container of pairs, return a range over the first elements.
 template <typename ContainerTy> auto make_first_range(ContainerTy &&c) {
-  using EltTy = decltype((*adl_begin(c)));
+  using EltTy = decltype((*std::begin(c)));
   return llvm::map_range(std::forward<ContainerTy>(c),
                          [](EltTy elt) -> typename detail::first_or_second_type<
                                            EltTy, decltype((elt.first))>::type {
@@ -1429,7 +1430,7 @@ template <typename ContainerTy> auto make_first_range(ContainerTy &&c) {
 
 /// Given a container of pairs, return a range over the second elements.
 template <typename ContainerTy> auto make_second_range(ContainerTy &&c) {
-  using EltTy = decltype((*adl_begin(c)));
+  using EltTy = decltype((*std::begin(c)));
   return llvm::map_range(
       std::forward<ContainerTy>(c),
       [](EltTy elt) ->
@@ -2105,7 +2106,7 @@ template<typename Container, typename Range = std::initializer_list<
                                  typename Container::value_type>>
 void replace(Container &Cont, typename Container::iterator ContIt,
              typename Container::iterator ContEnd, Range R) {
-  replace(Cont, ContIt, ContEnd, adl_begin(R), adl_begin(R));
+  replace(Cont, ContIt, ContEnd, R.begin(), R.end());
 }
 
 /// An STL-style algorithm similar to std::for_each that applies a second
@@ -2518,19 +2519,19 @@ bool hasNItemsOrLess(
 
 /// Returns true if the given container has exactly N items
 template <typename ContainerTy> bool hasNItems(ContainerTy &&C, unsigned N) {
-  return hasNItems(adl_begin(C), adl_end(C), N);
+  return hasNItems(std::begin(C), std::end(C), N);
 }
 
 /// Returns true if the given container has N or more items
 template <typename ContainerTy>
 bool hasNItemsOrMore(ContainerTy &&C, unsigned N) {
-  return hasNItemsOrMore(adl_begin(C), adl_end(C), N);
+  return hasNItemsOrMore(std::begin(C), std::end(C), N);
 }
 
 /// Returns true if the given container has N or less items
 template <typename ContainerTy>
 bool hasNItemsOrLess(ContainerTy &&C, unsigned N) {
-  return hasNItemsOrLess(adl_begin(C), adl_end(C), N);
+  return hasNItemsOrLess(std::begin(C), std::end(C), N);
 }
 
 /// Returns a raw pointer that represents the same address as the argument.


### PR DESCRIPTION
Reverts llvm/llvm-project#87936

Seems like this broke some clang designated initializers tests, reverting.