### PR TITLE
[Flang] Update Extensions.md for supported BIND(C) LOGICAL kind.

### DIFF
--- a/flang/docs/Extensions.md
+++ b/flang/docs/Extensions.md
@@ -308,9 +308,10 @@ end
   enforce it and the constraint is not necessary for a correct
   implementation.
 * A label may follow a semicolon in fixed form source.
-* A scalar logical dummy argument to a `BIND(C)` procedure does
-  not have to have `KIND=C_BOOL` since it can be converted to/from
-  `_Bool` without loss of information.
+* A logical dummy argument to a `BIND(C)` procedure, or a logical
+  component to a `BIND(C)` derived type does not have to have
+  `KIND=C_BOOL` since it can be converted to/from `_Bool` without
+  loss of information.
 * The character length of the `SOURCE=` or `MOLD=` in `ALLOCATE`
   may be distinct from the constant character length, if any,
   of an allocated object.


### PR DESCRIPTION
Flang also supports non-scalar logical dummy argument with a different KIND from C_BOOL to a bind(c) routine as well as a component in a bind(c) derived type. Update the document.

```
subroutine sub(arg)
logical(4) :: arg(4)
end
```

```
type dt
logical(4) :: comp
end type
end
```