### PR TITLE
[AIX] Add git revision to .file string

### DIFF
--- a/llvm/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
@@ -114,6 +114,7 @@
 #include "llvm/Support/MathExtras.h"
 #include "llvm/Support/Path.h"
 #include "llvm/Support/Timer.h"
+#include "llvm/Support/VCSRevision.h"
 #include "llvm/Support/raw_ostream.h"
 #include "llvm/Target/TargetLoweringObjectFile.h"
 #include "llvm/Target/TargetMachine.h"
@@ -497,12 +498,15 @@ bool AsmPrinter::doInitialization(Module &M) {
     else
       FileName = M.getSourceFileName();
     if (MAI->hasFourStringsDotFile()) {
-#ifdef PACKAGE_VENDOR
       const char VerStr[] =
-          PACKAGE_VENDOR " " PACKAGE_NAME " version " PACKAGE_VERSION;
-#else
-      const char VerStr[] = PACKAGE_NAME " version " PACKAGE_VERSION;
+#ifdef PACKAGE_VENDOR
+      PACKAGE_VENDOR " "
 #endif
+      PACKAGE_NAME " version " PACKAGE_VERSION
+#ifdef LLVM_REVISION
+      " (" LLVM_REVISION ")"
+#endif
+      ;
       // TODO: Add timestamp and description.
       OutStreamer->emitFileDirective(FileName, VerStr, "", "");
     } else {

--- a/llvm/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
@@ -500,13 +500,13 @@ bool AsmPrinter::doInitialization(Module &M) {
     if (MAI->hasFourStringsDotFile()) {
       const char VerStr[] =
 #ifdef PACKAGE_VENDOR
-      PACKAGE_VENDOR " "
+          PACKAGE_VENDOR " "
 #endif
-      PACKAGE_NAME " version " PACKAGE_VERSION
+          PACKAGE_NAME " version " PACKAGE_VERSION
 #ifdef LLVM_REVISION
-      " (" LLVM_REVISION ")"
+                         " (" LLVM_REVISION ")"
 #endif
-      ;
+          ;
       // TODO: Add timestamp and description.
       OutStreamer->emitFileDirective(FileName, VerStr, "", "");
     } else {

--- a/llvm/test/CMakeLists.txt
+++ b/llvm/test/CMakeLists.txt
@@ -25,6 +25,7 @@ llvm_canonicalize_cmake_booleans(
   LLVM_INCLUDE_DXIL_TESTS
   LLVM_TOOL_LLVM_DRIVER_BUILD
   LLVM_INCLUDE_SPIRV_TOOLS_TESTS
+  LLVM_APPEND_VC_REV
   )
 
 configure_lit_site_cfg(

--- a/llvm/test/CodeGen/PowerPC/git_revision.ll
+++ b/llvm/test/CodeGen/PowerPC/git_revision.ll
@@ -1,0 +1,13 @@
+; Check that the git revision is contained in the assembly/object files
+
+; RUN: cd %S && git rev-parse HEAD > %t
+
+; RUN: llc < %s > %t.a.o
+; RUN: sed -n -e "/$(cat %t)/p" %t.a.o
+
+; RUN: llc -filetype=obj < %s > %t.b.o
+; RUN: sed -n -e "/$(cat %t)/p" %t.b.o
+
+source_filename = "git_revision.cpp"
+target datalayout = "E-m:a-Fi64-i64:64-n32:64-S128-v256:256:256-v512:512:512"
+target triple = "powerpc64-ibm-aix7.2.0.0"

--- a/llvm/test/CodeGen/PowerPC/git_revision.ll
+++ b/llvm/test/CodeGen/PowerPC/git_revision.ll
@@ -1,12 +1,11 @@
 ; Check that the git revision is contained in the assembly/object files
 
-; RUN: cd %S && git rev-parse HEAD > %t
+; REQUIRES: vc-rev-enabled 
 
-; RUN: llc < %s > %t.a.o
-; RUN: sed -n -e "/$(cat %t)/p" %t.a.o
+; RUN: llc < %s | FileCheck %s -DREVISION=git-revision
+; RUN: llc -filetype=obj < %s | FileCheck %s -DREVISION=git-revision
 
-; RUN: llc -filetype=obj < %s > %t.b.o
-; RUN: sed -n -e "/$(cat %t)/p" %t.b.o
+; CHECK: ([[REVISION]])
 
 source_filename = "git_revision.cpp"
 target datalayout = "E-m:a-Fi64-i64:64-n32:64-S128-v256:256:256-v512:512:512"

--- a/llvm/test/CodeGen/PowerPC/lit.local.cfg
+++ b/llvm/test/CodeGen/PowerPC/lit.local.cfg
@@ -8,15 +8,16 @@ config.suffixes.add(".py")
 def get_revision(repo_path):
     cmd = ['git', '-C', repo_path, 'rev-parse', 'HEAD']
     try:
-        return subprocess.run(cmd, stdout=subprocess.PIPE, check=True).stdout.decode('ascii')
+        return subprocess.run(cmd, stdout=subprocess.PIPE, check=True).stdout.decode()
     except subprocess.CalledProcessError:
-        print("An error occured retrieving the git revision")
-        raise
+        print("An error occurred retrieving the git revision.")
+        return None
 
 if config.have_vc_rev:
     if config.force_vc_rev:
         git_revision = config.force_vc_rev
     else:
         git_revision = get_revision(config.llvm_src_root)
-    config.substitutions.append(("git-revision", git_revision))
-    config.available_features.add("vc-rev-enabled")
+    if git_revision:
+        config.substitutions.append(("git-revision", git_revision))
+        config.available_features.add("vc-rev-enabled")

--- a/llvm/test/CodeGen/PowerPC/lit.local.cfg
+++ b/llvm/test/CodeGen/PowerPC/lit.local.cfg
@@ -1,4 +1,18 @@
 if not "PowerPC" in config.root.targets:
     config.unsupported = True
 
+import subprocess
+
 config.suffixes.add(".py")
+
+def get_revision(repo_path):
+  cmd = ['git', '-C', repo_path, 'rev-parse', 'HEAD']
+  return subprocess.run(cmd, stdout=subprocess.PIPE).stdout.decode('ascii')
+
+if config.have_vc_rev:
+  config.available_features.add("vc-rev-enabled")
+  if config.force_vc_rev:
+    git_revision = config.force_vc_rev
+  else:
+    git_revision = get_revision(config.llvm_src_root)
+  config.substitutions.append(("git-revision", git_revision))

--- a/llvm/test/CodeGen/PowerPC/lit.local.cfg
+++ b/llvm/test/CodeGen/PowerPC/lit.local.cfg
@@ -6,13 +6,17 @@ import subprocess
 config.suffixes.add(".py")
 
 def get_revision(repo_path):
-  cmd = ['git', '-C', repo_path, 'rev-parse', 'HEAD']
-  return subprocess.run(cmd, stdout=subprocess.PIPE).stdout.decode('ascii')
+    cmd = ['git', '-C', repo_path, 'rev-parse', 'HEAD']
+    try:
+        return subprocess.run(cmd, stdout=subprocess.PIPE, check=True).stdout.decode('ascii')
+    except subprocess.CalledProcessError:
+        print("An error occured retrieving the git revision")
+        raise
 
 if config.have_vc_rev:
-  config.available_features.add("vc-rev-enabled")
-  if config.force_vc_rev:
-    git_revision = config.force_vc_rev
-  else:
-    git_revision = get_revision(config.llvm_src_root)
-  config.substitutions.append(("git-revision", git_revision))
+    if config.force_vc_rev:
+        git_revision = config.force_vc_rev
+    else:
+        git_revision = get_revision(config.llvm_src_root)
+    config.substitutions.append(("git-revision", git_revision))
+    config.available_features.add("vc-rev-enabled")

--- a/llvm/test/lit.site.cfg.py.in
+++ b/llvm/test/lit.site.cfg.py.in
@@ -61,6 +61,8 @@ config.reverse_iteration = @LLVM_ENABLE_REVERSE_ITERATION@
 config.dxil_tests = @LLVM_INCLUDE_DXIL_TESTS@
 config.have_llvm_driver = @LLVM_TOOL_LLVM_DRIVER_BUILD@
 config.spirv_tools_tests = @LLVM_INCLUDE_SPIRV_TOOLS_TESTS@
+config.have_vc_rev = @LLVM_APPEND_VC_REV@
+config.force_vc_rev = "@LLVM_FORCE_VC_REVISION@"
 
 import lit.llvm
 lit.llvm.initialize(lit_config, config)


### PR DESCRIPTION
If `LLVM_APPEND_VC_REV` is on, add the git revision to the `.file` string. The revision can be set with `LLVM_FORCE_VC_REVISION`. 

Before:
`.file	"git_revision.cpp",,"LLVM version 19.0.0git"`

After:
`.file	"git_revision.cpp",,"LLVM version 19.0.0git (LLVM_REVISION)"`