### PR TITLE
[orc] Reduce memory usage from empty materialization info DenseMaps

### DIFF
--- a/llvm/include/llvm/ExecutionEngine/Orc/Core.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/Core.h
@@ -1333,6 +1333,10 @@ private:
 
   void unlinkMaterializationResponsibility(MaterializationResponsibility &MR);
 
+  /// Attempt to reduce memory usage from empty \c UnmaterializedInfos and
+  /// \c MaterializingInfos tables.
+  void shrinkMaterializationInfoMemory();
+
   ExecutionSession &ES;
   enum { Open, Closing, Closed } State = Open;
   std::mutex GeneratorsMutex;

--- a/llvm/lib/ExecutionEngine/Orc/Core.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/Core.cpp
@@ -1002,6 +1002,17 @@ void JITDylib::unlinkMaterializationResponsibility(
   });
 }
 
+void JITDylib::shrinkMaterializationInfoMemory() {
+  // DenseMap::erase never shrinks its storage; use clear to heuristically free
+  // memory since we may have long-lived JDs after linking is done.
+
+  if (UnmaterializedInfos.empty())
+    UnmaterializedInfos.clear();
+
+  if (MaterializingInfos.empty())
+    MaterializingInfos.clear();
+}
+
 void JITDylib::setLinkOrder(JITDylibSearchOrder NewLinkOrder,
                             bool LinkAgainstThisJITDylibFirst) {
   ES.runSessionLocked([&]() {
@@ -1111,6 +1122,8 @@ Error JITDylib::remove(const SymbolNameSet &Names) {
       auto SymI = SymbolMaterializerItrPair.first;
       Symbols.erase(SymI);
     }
+
+    shrinkMaterializationInfoMemory();
 
     return Error::success();
   });
@@ -1312,6 +1325,8 @@ JITDylib::removeTracker(ResourceTracker &RT) {
 
     Symbols.erase(I);
   }
+
+  shrinkMaterializationInfoMemory();
 
   return Result;
 }
@@ -2675,6 +2690,8 @@ void ExecutionSession::OL_completeLookup(
             return true;
           });
 
+      JD.shrinkMaterializationInfoMemory();
+
       // Handle failure.
       if (Err) {
 
@@ -3118,6 +3135,8 @@ void ExecutionSession::IL_makeEDUReady(
 
     JD.MaterializingInfos.erase(MII);
   }
+
+  JD.shrinkMaterializationInfoMemory();
 }
 
 void ExecutionSession::IL_makeEDUEmitted(
@@ -3632,6 +3651,8 @@ ExecutionSession::IL_failSymbols(JITDylib &JD,
           ExtractFailedQueries(DepMI);
           DepJD.MaterializingInfos.erase(SymbolStringPtr(DepName));
         }
+
+        DepJD.shrinkMaterializationInfoMemory();
       }
 
       MI.DependantEDUs.clear();
@@ -3644,6 +3665,8 @@ ExecutionSession::IL_failSymbols(JITDylib &JD,
            "Can not delete MaterializingInfo with queries pending");
     JD.MaterializingInfos.erase(Name);
   }
+
+  JD.shrinkMaterializationInfoMemory();
 
 #ifdef EXPENSIVE_CHECKS
   verifySessionState("exiting ExecutionSession::IL_failSymbols");


### PR DESCRIPTION
Saves several MB of memory in larger applications after linking finishes by clearing DenseMap storage that is empty. This does not attempt to shrink partially full materialization infos. The assumption is that adding more after linking finishes is rare.

rdar://126145336