### PR TITLE
[compiler-rt][asan] Fix for flaky asan check

### DIFF
--- a/compiler-rt/lib/asan/asan_thread.cpp
+++ b/compiler-rt/lib/asan/asan_thread.cpp
@@ -44,10 +44,15 @@ static ThreadRegistry *asan_thread_registry;
 static ThreadArgRetval *thread_data;
 
 static Mutex mu_for_thread_context;
+// TODO(leonardchan@): It should be possible to make LowLevelAllocator
+// threadsafe and consolidate this one into the GlobalLoweLevelAllocator.
+// We should be able to do something similar to what's in
+// sanitizer_stack_store.cpp.
+static LowLevelAllocator allocator_for_thread_context;
 
 static ThreadContextBase *GetAsanThreadContext(u32 tid) {
   Lock lock(&mu_for_thread_context);
-  return new (GetGlobalLowLevelAllocator()) AsanThreadContext(tid);
+  return new (allocator_for_thread_context) AsanThreadContext(tid);
 }
 
 static void InitThreads() {


### PR DESCRIPTION
This fixes https://github.com/llvm/llvm-project/issues/87324.

We haven't been able to come up with a minimal reproducer but we can reliabely avoid this failure with the following fix. Prior to the GetGlobalLowLevelAllocator change, the old LowLevelAllocator aquired a lock associated with it preventing that specific allocator from being accessed at the same time by many threads. With the GetGlobalLowLevelAllocator change, I had accidentally replaced it but not taken into account the lock, so we can have a data race if the allocator is used at any point while a thread is being created. The global allocator can be used for flag parsing or registering asan globals.