### PR TITLE
[libc][docs] codify Policy on Assembler Sources

### DIFF
--- a/libc/docs/dev/code_style.rst
+++ b/libc/docs/dev/code_style.rst
@@ -238,8 +238,9 @@ level languages like Assembly, such as:
 While it's not impossible to have Assembly code that correctly provides all of
 the above, we do not wish to maintain such Assembly sources in llvm-libc.
 
-That said, there a few functions provided by llvm-libc that are more difficult
-to implement or maintain in C++ than Assembly.
+That said, there a few functions provided by llvm-libc that are impossible
+to reliably implement in C++ for all compilers supported for building
+llvm-libc.
 
 We do use inline or out-of-line Assembly in an intentionally minimal set of
 places; typically places where the stack or individual register state must be

--- a/libc/docs/dev/code_style.rst
+++ b/libc/docs/dev/code_style.rst
@@ -234,7 +234,7 @@ level languages like Assembly, such as:
 * Sanitization
 * Debug info
 
-While its not impossible to have Assembly code that correctly provides all of
+While it's not impossible to have Assembly code that correctly provides all of
 the above, we do not wish to maintain such Assembly sources in llvm-libc.
 
 That said, there a few functions provided by llvm-libc that are more difficult

--- a/libc/docs/dev/code_style.rst
+++ b/libc/docs/dev/code_style.rst
@@ -220,11 +220,11 @@ defines. Code under ``libc/src/`` should ``#include`` a proxy header from
 our header from ``libc/include/`` (fullbuild) or the corresponding underlying
 system header (overlay).
 
-Policy on Assembler sources
-===========================
+Policy on Assembly sources
+==========================
 
 Coding in high level languages such as C++ provides benefits relative to low
-level languages like Assembler, such as:
+level languages like Assembly, such as:
 
 * Improved safety
 * Instrumentation
@@ -234,17 +234,17 @@ level languages like Assembler, such as:
 * Sanitization
 * Debug info
 
-While its not impossible to have Assembler code that correctly provides all of
-the above, we do not wish to maintain such Assembler sources in llvm-libc.
+While its not impossible to have Assembly code that correctly provides all of
+the above, we do not wish to maintain such Assembly sources in llvm-libc.
 
 That said, there a few functions provided by llvm-libc that are more difficult
-to implement or maintain in C++ than Assembler. We do use inline or out-of-line
-Assembler in an intentionally minimal set of places; typically places where the
+to implement or maintain in C++ than Assembly. We do use inline or out-of-line
+Assembly in an intentionally minimal set of places; typically places where the
 stack or individual register state must be manipulated very carefully for
 correctness.
 
-Contributions adding Assembler for performance are not welcome. Contributors
+Contributions adding Assembly for performance are not welcome. Contributors
 should strive to stick with C++ for as long as it remains reasonable to do so.
-llvm-libc maintainers reserve the right to reject Assembler contributions that
+llvm-libc maintainers reserve the right to reject Assembly contributions that
 they feel could be better maintained if rewritten in C++, and to revisit this
 policy in the future.

--- a/libc/docs/dev/code_style.rst
+++ b/libc/docs/dev/code_style.rst
@@ -219,3 +219,32 @@ defines. Code under ``libc/src/`` should ``#include`` a proxy header from
 ``hdr/``, which contains a guard on ``LLVM_LIBC_FULL_BUILD`` to either include
 our header from ``libc/include/`` (fullbuild) or the corresponding underlying
 system header (overlay).
+
+Policy on Assembler sources
+===========================
+
+Coding in high level languages such as C++ provides benefits relative to low
+level languages like Assembler, such as:
+
+* Improved safety
+* Instrumentation
+
+  * Code coverage
+  * Profile collection
+* Sanitization
+* Debug info
+
+While its not impossible to have Assembler code that correctly provides all of
+the above, we do not wish to maintain such Assembler sources in llvm-libc.
+
+That said, there a few functions provided by llvm-libc that are more difficult
+to implement or maintain in C++ than Assembler. We do use inline or out-of-line
+Assembler in an intentionally minimal set of places; typically places where the
+stack or individual register state must be manipulated very carefully for
+correctness.
+
+Contributions adding Assembler for performance are not welcome. Contributors
+should strive to stick with C++ for as long as it remains reasonable to do so.
+llvm-libc maintainers reserve the right to reject Assembler contributions that
+could they feel could be better maintained if rewritten in C++, and to revisit
+this policy in the future.

--- a/libc/docs/dev/code_style.rst
+++ b/libc/docs/dev/code_style.rst
@@ -246,5 +246,5 @@ correctness.
 Contributions adding Assembler for performance are not welcome. Contributors
 should strive to stick with C++ for as long as it remains reasonable to do so.
 llvm-libc maintainers reserve the right to reject Assembler contributions that
-could they feel could be better maintained if rewritten in C++, and to revisit
-this policy in the future.
+they feel could be better maintained if rewritten in C++, and to revisit this
+policy in the future.

--- a/libc/docs/dev/code_style.rst
+++ b/libc/docs/dev/code_style.rst
@@ -238,7 +238,7 @@ level languages like Assembly, such as:
 While it's not impossible to have Assembly code that correctly provides all of
 the above, we do not wish to maintain such Assembly sources in llvm-libc.
 
-That said, there a few functions provided by llvm-libc that are impossible
+That said, there are a few functions provided by llvm-libc that are impossible
 to reliably implement in C++ for all compilers supported for building
 llvm-libc.
 

--- a/libc/docs/dev/code_style.rst
+++ b/libc/docs/dev/code_style.rst
@@ -227,24 +227,35 @@ Coding in high level languages such as C++ provides benefits relative to low
 level languages like Assembly, such as:
 
 * Improved safety
+* Compile time diagnostics
 * Instrumentation
 
   * Code coverage
   * Profile collection
 * Sanitization
-* Debug info
+* Automatic generation of debug info
 
 While it's not impossible to have Assembly code that correctly provides all of
 the above, we do not wish to maintain such Assembly sources in llvm-libc.
 
 That said, there a few functions provided by llvm-libc that are more difficult
-to implement or maintain in C++ than Assembly. We do use inline or out-of-line
-Assembly in an intentionally minimal set of places; typically places where the
-stack or individual register state must be manipulated very carefully for
-correctness.
+to implement or maintain in C++ than Assembly.
 
-Contributions adding Assembly for performance are not welcome. Contributors
-should strive to stick with C++ for as long as it remains reasonable to do so.
-llvm-libc maintainers reserve the right to reject Assembly contributions that
-they feel could be better maintained if rewritten in C++, and to revisit this
-policy in the future.
+We do use inline or out-of-line Assembly in an intentionally minimal set of
+places; typically places where the stack or individual register state must be
+manipulated very carefully for correctness, or instances where a specific
+instruction sequence does not have a corresponding compiler builtin function
+today.
+
+Contributions adding functions implemented purely in Assembly for performance
+are not welcome.
+
+Contributors should strive to stick with C++ for as long as it remains
+reasonable to do so. Ideally, bugs should be filed against compiler vendors,
+and links to those bug reports should appear in commit messages or comments
+that seek to add Assembly to llvm-libc.
+
+Patches containing any amount of Assembly ideally should be approved by 2
+maintainers. llvm-libc maintainers reserve the right to reject Assembly
+contributions that they feel could be better maintained if rewritten in C++,
+and to revisit this policy in the future.


### PR DESCRIPTION
It would be helpful in future code reviews to document a policy with regards to
where and when Assembler sources are appropriate. That way when reviewers point
out infractions, they can point to this written policy, which may help
contributors understand that it's not solely the personal preferences of
individual reviewers but instead rather a previously agreed upon rule by maintainers.

Link: https://github.com/llvm/llvm-project/pull/87837
Link: https://github.com/llvm/llvm-project/pull/88157
Link: https://discourse.llvm.org/t/hand-written-in-assembly-in-libc-setjmp-longjmp/73249/12
