### PR TITLE
[flang] Fix spurious overflow warning folding exponentiation by integ…

### DIFF
--- a/flang/lib/Evaluate/int-power.h
+++ b/flang/lib/Evaluate/int-power.h
@@ -33,6 +33,10 @@ ValueWithRealFlags<REAL> TimesIntPowerOf(const REAL &factor, const REAL &base,
     REAL squares{base};
     int nbits{INT::bits - absPower.LEADZ()};
     for (int j{0}; j < nbits; ++j) {
+      if (j > 0) { // avoid spurious overflow on last iteration
+        squares =
+            squares.Multiply(squares, rounding).AccumulateFlags(result.flags);
+      }
       if (absPower.BTEST(j)) {
         if (negativePower) {
           result.value = result.value.Divide(squares, rounding)
@@ -42,8 +46,6 @@ ValueWithRealFlags<REAL> TimesIntPowerOf(const REAL &factor, const REAL &base,
                              .AccumulateFlags(result.flags);
         }
       }
-      squares =
-          squares.Multiply(squares, rounding).AccumulateFlags(result.flags);
     }
   }
   return result;


### PR DESCRIPTION
…er powers

The code that folds exponentiation by an integer power can report a spurious overflow warning because it calculates one last unnecessary square of the base value.  10.**(+/-32) exposes the problem -- the value of 10.**64 is calculated but not needed.  Rearrange the implementation to only calculate squares that are necessary.

Fixes https://github.com/llvm/llvm-project/issues/88151.