### PR TITLE
[libc++] Fix -Wgnu-include-next in stddef.h

### DIFF
--- a/libcxx/include/stddef.h
+++ b/libcxx/include/stddef.h
@@ -26,16 +26,16 @@ Types:
 
 #include <__config>
 
+#if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
+#  pragma GCC system_header
+#endif
+
 // Note: This include is outside of header guards because we sometimes get included multiple times
 //       with different defines and the underlying <stddef.h> will know how to deal with that.
 #include_next <stddef.h>
 
 #ifndef _LIBCPP_STDDEF_H
 #  define _LIBCPP_STDDEF_H
-
-#  if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
-#    pragma GCC system_header
-#  endif
 
 #  ifdef __cplusplus
 typedef decltype(nullptr) nullptr_t;


### PR DESCRIPTION
As reported in #86843, we must have #pragma GCC system_header before we use #include_next, otherwise the compiler may not understand that we're in a system header and may issue a diagnostic for our usage of