### PR TITLE
[emacs] Handle vector types, arbitary integer types and function names

### DIFF
--- a/llvm/utils/emacs/llvm-mode.el
+++ b/llvm/utils/emacs/llvm-mode.el
@@ -18,6 +18,14 @@
     table)
   "Syntax table used while in LLVM mode.")
 
+(defconst llvm-mode-primitive-type-regexp
+  (concat
+   "\\(i[0-9]+\\|"
+   (regexp-opt
+    '("void" "half" "bfloat" "float" "double" "fp128" "x86_fp80" "ppc_fp128"
+      "x86_mmx" "x86_amx" "ptr" "type" "label" "opaque" "token") t)
+   "\\)"))
+
 (defvar llvm-font-lock-keywords
   (list
    ;; Attributes
@@ -34,10 +42,23 @@
    '("[-a-zA-Z$._0-9]+:" . font-lock-variable-name-face)
    ;; Unnamed variable slots
    '("%[-]?[0-9]+" . font-lock-variable-name-face)
-   ;; Types
-   `(,(regexp-opt
-       '("void" "i1" "i8" "i16" "i32" "i64" "i128" "half" "bfloat" "float" "double" "fp128" "x86_fp80" "ppc_fp128" "x86_mmx" "x86_amx" "ptr"
-         "type" "label" "opaque" "token") 'symbols) . font-lock-type-face)
+   ;; Function names
+   '("@[-a-zA-Z$._][-a-zA-Z$._0-9]*" . font-lock-function-name-face)
+   ;; Fixed vector types
+   `(,(concat "<[ \t]*\\([0-9]+\\)[ \t]*x[ \t]+"
+	      llvm-mode-primitive-type-regexp
+	      "[ \t]*>")
+     (1 'font-lock-type-face)
+     (2 'font-lock-type-face))
+   ;; Scalable vector types
+   `(,(concat "<[ \t]*\\(vscale[ \t]\\)+x[ \t]+\\([0-9]+\\)[ \t]*x[ \t]+"
+	      llvm-mode-primitive-type-regexp
+	      "[ \t]*>")
+     (1 'font-lock-keyword-face)
+     (2 'font-lock-type-face)
+     (3 'font-lock-type-face))
+   ;; Primitive types
+   `(,(concat "\\<" llvm-mode-primitive-type-regexp "\\>") . font-lock-type-face)
    ;; Integer literals
    '("\\b[-]?[0-9]+\\b" . font-lock-preprocessor-face)
    ;; Floating point constants


### PR DESCRIPTION
Resurrecting this patch from https://reviews.llvm.org/D158321

This adds a few more regexp patterns for llvm-mode-syntax-table. The primitive type regexp was split out so it could be reused when handling vectors. Also worth noting is that the vector regexp needs to come before the primitive types, otherwise they will match first.

@goldsteinn I was able to address your review comments, turns out you can set a font-face for a specific match group. And < 2x i64> should be accepted now.

<img width="274" alt="screenshot of new font faces matched" src="https://github.com/llvm/llvm-project/assets/2488460/681cf07c-7118-40ec-b3f7-23fc44a1eada">

