### PR TITLE
[RISCV] Support rv{32, 64}e in the compiler builtins

### DIFF
--- a/compiler-rt/lib/builtins/riscv/restore.S
+++ b/compiler-rt/lib/builtins/riscv/restore.S
@@ -22,6 +22,8 @@
 
 #if __riscv_xlen == 32
 
+#ifndef __riscv_32e
+
   .globl  __riscv_restore_12
   .type   __riscv_restore_12,@function
 __riscv_restore_12:
@@ -86,7 +88,28 @@ __riscv_restore_0:
   addi    sp, sp, 16
   ret
 
+#else
+
+  .globl  __riscv_restore_2
+  .type   __riscv_restore_2,@function
+  .globl  __riscv_restore_1
+  .type   __riscv_restore_1,@function
+  .globl  __riscv_restore_0
+  .type   __riscv_restore_0,@function
+__riscv_restore_2:
+__riscv_restore_1:
+__riscv_restore_0:
+  lw      s1,  0(sp)
+  lw      s0,  4(sp)
+  lw      ra,  8(sp)
+  addi    sp, sp, 12
+  ret
+
+#endif
+
 #elif __riscv_xlen == 64
+
+#ifndef __riscv_64e
 
   .globl  __riscv_restore_12
   .type   __riscv_restore_12,@function
@@ -160,6 +183,25 @@ __riscv_restore_0:
   ld      ra,  8(sp)
   addi    sp, sp, 16
   ret
+
+#else
+
+  .globl  __riscv_restore_2
+  .type   __riscv_restore_2,@function
+  .globl  __riscv_restore_1
+  .type   __riscv_restore_1,@function
+  .globl  __riscv_restore_0
+  .type   __riscv_restore_0,@function
+__riscv_restore_2:
+__riscv_restore_1:
+__riscv_restore_0:
+  ld      s1,  0(sp)
+  ld      s0,  8(sp)
+  ld      ra,  16(sp)
+  addi    sp, sp, 24
+  ret
+
+#endif
 
 #else
 # error "xlen must be 32 or 64 for save-restore implementation

--- a/compiler-rt/lib/builtins/riscv/save.S
+++ b/compiler-rt/lib/builtins/riscv/save.S
@@ -216,8 +216,8 @@ __riscv_save_2:
 __riscv_save_1:
 __riscv_save_0:
   addi   sp, sp, -24
-  sd     s0, 0(sp)
-  sd     s1, 8(sp)
+  sd     s1, 0(sp)
+  sd     s0, 8(sp)
   sd     ra, 16(sp)
   jr     t0
 

--- a/compiler-rt/lib/builtins/riscv/save.S
+++ b/compiler-rt/lib/builtins/riscv/save.S
@@ -18,6 +18,8 @@
 
 #if __riscv_xlen == 32
 
+#ifndef __riscv_32e
+
   .globl  __riscv_save_12
   .type   __riscv_save_12,@function
 __riscv_save_12:
@@ -92,7 +94,28 @@ __riscv_save_0:
   sw      ra,  12(sp)
   jr      t0
 
+#else
+
+  .globl  __riscv_save_2
+  .type   __riscv_save_2,@function
+  .globl  __riscv_save_1
+  .type   __riscv_save_1,@function
+  .globl  __riscv_save_0
+  .type   __riscv_save_0,@function
+__riscv_save_2:
+__riscv_save_1:
+__riscv_save_0:
+  addi    sp, sp, -12
+  sw      s1,  0(sp)
+  sw      s0,  4(sp)
+  sw      ra,  8(sp)
+  jr      t0
+
+#endif
+
 #elif __riscv_xlen == 64
+
+#ifndef __riscv_64e
 
   .globl  __riscv_save_12
   .type   __riscv_save_12,@function
@@ -180,6 +203,25 @@ __riscv_save_0:
   sd     s0, 0(sp)
   sd     ra, 8(sp)
   jr     t0
+
+#else
+
+  .globl  __riscv_save_2
+  .type   __riscv_save_2,@function
+  .globl  __riscv_save_1
+  .type   __riscv_save_1,@function
+  .globl  __riscv_save_0
+  .type   __riscv_save_0,@function
+__riscv_save_2:
+__riscv_save_1:
+__riscv_save_0:
+  addi   sp, sp, -24
+  sd     s0, 0(sp)
+  sd     s1, 8(sp)
+  sd     ra, 16(sp)
+  jr     t0
+
+#endif
 
 #else
 # error "xlen must be 32 or 64 for save-restore implementation


### PR DESCRIPTION
Register spills (save/restore) in RISC-V embedded work differently because there are less registers and different stack alignment.

[GCC equivalent ](https://github.com/gcc-mirror/gcc/blob/master/libgcc/config/riscv/save-restore.S#L298C16-L336)

Follow up from #76777.

CC @koute @wangpc-pp 