### PR TITLE
[clang][test] Avoid writing to a potentially write-protected dir

### DIFF
--- a/clang/test/Driver/lld-repro.c
+++ b/clang/test/Driver/lld-repro.c
@@ -4,12 +4,12 @@
 // RUN: echo "-nostartfiles -nostdlib -fuse-ld=lld -gen-reproducer=error -fcrash-diagnostics-dir=%t" \
 // RUN:   | sed -e 's/\\/\\\\/g' > %t.rsp
 
-// RUN: not %clang %s @%t.rsp -fcrash-diagnostics=all 2>&1 \
+// RUN: not %clang %s @%t.rsp -fcrash-diagnostics=all -o /dev/null 2>&1 \
 // RUN:   | FileCheck %s
 
 // Test that the reproducer can still be created even when the input source cannot be preprocessed
 // again, like when reading from stdin.
-// RUN: not %clang -x c - @%t.rsp -fcrash-diagnostics=all 2>&1 < %s \
+// RUN: not %clang -x c - @%t.rsp -fcrash-diagnostics=all -o /dev/null 2>&1 < %s \
 // RUN:   | FileCheck %s
 
 // check that we still get lld's output
@@ -20,9 +20,9 @@
 // CHECK-NEXT: note: diagnostic msg:
 // CHECK: ********************
 
-// RUN: not %clang %s @%t.rsp -fcrash-diagnostics=compiler 2>&1 \
+// RUN: not %clang %s @%t.rsp -fcrash-diagnostics=compiler -o /dev/null 2>&1 \
 // RUN:   | FileCheck %s --check-prefix=NO-LINKER
-// RUN: not %clang %s @%t.rsp 2>&1 \
+// RUN: not %clang %s @%t.rsp -o /dev/null 2>&1 \
 // RUN:   | FileCheck %s --check-prefix=NO-LINKER
 
 // NO-LINKER-NOT: Preprocessed source(s) and associated run script(s) are located at:


### PR DESCRIPTION
This test just checks for the stdout/stderr of clang, but it incidentally tries to write to `a.out` in the current directory, which may be write protected. Typically one would write `clang -o %t.o` for a writeable dir, but since we only care about stdout/stderr, throw away the object file and just write to /dev/null instead.