### PR TITLE
[OpenMP][AIX] Fix test config for AIX

### DIFF
--- a/openmp/runtime/test/lit.cfg
+++ b/openmp/runtime/test/lit.cfg
@@ -112,13 +112,15 @@ if config.operating_system == 'AIX':
     config.available_features.add("aix")
     object_mode = os.environ.get('OBJECT_MODE', '32')
     if object_mode == '64':
-      config.test_flags += " -m64"
+      # Set OBJECT_MODE to 64 for LIT test if it is explicitly set.
+      config.environment['OBJECT_MODE'] = os.environ['OBJECT_MODE']
     elif object_mode == '32':
       # Set user data area to 2GB since the default size 256MB in 32-bit mode
       # is not sufficient to run LIT tests on systems that have a lot of
       # CPUs when creating one worker thread for each CPU and each worker
       # thread uses 4MB stack size.
       config.test_flags += " -Wl,-bmaxdata:0x80000000"
+      config.test_openmp_flags += " -Wl,-bmaxdata:0x80000000"
 
 if 'Linux' in config.operating_system:
     config.available_features.add("linux")


### PR DESCRIPTION
This patch fixes the test config so that it works for `tasking/omp50_taskdep_depobj.c` which uses different flags to test with compiler's `omp.h`.
* set test environment variable `OBJECT_MODE` to `64` if it is set explicitly to `64` in the AIX environment. `OBJECT_MODE` is default to `32` and is recognized by AIX compilers and toolchain. In this way, we don't need to set `-m64` for all compiler flags for 64-bit mode
* add option `-Wl,-bmaxdata` to 32-bit `test_openmp_flags` used by `tasking/omp50_taskdep_depobj.c`