### PR TITLE
[llvm-mca] Remove spurious include_directories()

### DIFF
--- a/llvm/tools/llvm-mca/CMakeLists.txt
+++ b/llvm/tools/llvm-mca/CMakeLists.txt
@@ -1,5 +1,3 @@
-include_directories(include)
-
 set(LLVM_LINK_COMPONENTS
   AllTargetsAsmParsers
   AllTargetsMCAs          # CustomBehaviour and InstrPostProcess


### PR DESCRIPTION
llvm-mca does not have an include directory so this commit removes the
spurious include_directories directive.
