### PR TITLE
[Flang] Define c_int_fast16_t and c_int_fast32_t for PowerPC.

### DIFF
--- a/flang/lib/Frontend/CompilerInvocation.cpp
+++ b/flang/lib/Frontend/CompilerInvocation.cpp
@@ -1332,20 +1332,21 @@ void CompilerInvocation::setDefaultPredefinitions() {
   }
 
   llvm::Triple targetTriple{llvm::Triple(this->targetOpts.triple)};
+  if (targetTriple.isPPC()) {
+    // '__powerpc__' is a generic macro for any PowerPC cases. e.g. Max integer
+    // size.
+    fortranOptions.predefinitions.emplace_back("__powerpc__", "1");
+  }
+  if (targetTriple.isOSLinux()) {
+    fortranOptions.predefinitions.emplace_back("__linux__", "1");
+  }
+
   switch (targetTriple.getArch()) {
   default:
     break;
   case llvm::Triple::ArchType::x86_64:
     fortranOptions.predefinitions.emplace_back("__x86_64__", "1");
     fortranOptions.predefinitions.emplace_back("__x86_64", "1");
-    break;
-  case llvm::Triple::ArchType::ppc:
-  case llvm::Triple::ArchType::ppcle:
-  case llvm::Triple::ArchType::ppc64:
-  case llvm::Triple::ArchType::ppc64le:
-    // '__powerpc__' is a generic macro for any PowerPC cases. e.g. Max integer
-    // size.
-    fortranOptions.predefinitions.emplace_back("__powerpc__", "1");
     break;
   }
 }

--- a/flang/module/iso_c_binding.f90
+++ b/flang/module/iso_c_binding.f90
@@ -58,9 +58,17 @@ module iso_c_binding
     c_int_least8_t = c_int8_t, &
     c_int_fast8_t = c_int8_t, &
     c_int_least16_t = c_int16_t, &
+#if defined(__linux__) && defined(__powerpc__)
+    c_int_fast16_t = c_long, &
+#else
     c_int_fast16_t = c_int16_t, &
+#endif
     c_int_least32_t = c_int32_t, &
+#if defined(__linux__) && defined(__powerpc__)
+    c_int_fast32_t = c_long, &
+#else
     c_int_fast32_t = c_int32_t, &
+#endif
     c_int_least64_t = c_int64_t, &
     c_int_fast64_t = c_int64_t, &
     c_int_least128_t = c_int128_t, &

--- a/flang/test/Driver/predefined-macros-powerpc2.f90
+++ b/flang/test/Driver/predefined-macros-powerpc2.f90
@@ -1,0 +1,13 @@
+! Test predefined macro for PowerPC architecture
+
+! RUN: %flang_fc1 -triple ppc64le-unknown-linux -cpp -E %s | FileCheck %s
+! REQUIRES: target=powerpc{{.*}}
+
+! CHECK: integer :: var1 = 1
+! CHECK: integer :: var2 = 1
+
+#if defined(__linux__) && defined(__powerpc__)
+  integer :: var1 = __powerpc__
+  integer :: var2 = __linux__
+#endif
+end program


### PR DESCRIPTION
On Linux, PowerPC defines `int_fast16_t` and `int_fast32_t` as `long`. Need to update the corresponding type, `c_int_fast16_t` and `c_int_fast32_t` in `iso_c_binding` module so they are interoparable. 