### PR TITLE
[SelectionDAG] Verify SPLAT_VECTOR nodes when they are created.

### DIFF
--- a/llvm/lib/CodeGen/SelectionDAG/SelectionDAG.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/SelectionDAG.cpp
@@ -6025,7 +6025,7 @@ SDValue SelectionDAG::getNode(unsigned Opcode, const SDLoc &DL, EVT VT,
     // FIXME: Hexagon uses i32 scalar for a floating point zero vector so allow
     // that for now.
     assert((VT.getVectorElementType() == N1.getValueType() ||
-            (!VT.isInteger() && N1.getValueType() == MVT::i32) ||
+            (VT.isFloatingPoint() && N1.getValueType() == MVT::i32) ||
             (VT.getVectorElementType().isInteger() &&
              N1.getValueType().isInteger() &&
              VT.getVectorElementType().bitsLE(N1.getValueType()))) &&

--- a/llvm/lib/CodeGen/SelectionDAG/SelectionDAG.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/SelectionDAG.cpp
@@ -6020,6 +6020,17 @@ SDValue SelectionDAG::getNode(unsigned Opcode, const SDLoc &DL, EVT VT,
     if (N1.getValueType().getScalarType() == MVT::i1)
       return getNode(ISD::VECREDUCE_AND, DL, VT, N1);
     break;
+  case ISD::SPLAT_VECTOR:
+    assert(VT.isVector() && "Wrong return type!");
+    // FIXME: Hexagon uses i32 scalar for a floating point zero vector so allow
+    // that for now.
+    assert((VT.getVectorElementType() == N1.getValueType() ||
+            (!VT.isInteger() && N1.getValueType() == MVT::i32) ||
+            (VT.getVectorElementType().isInteger() &&
+             N1.getValueType().isInteger() &&
+             VT.getVectorElementType().bitsLE(N1.getValueType()))) &&
+           "Wrong operand type!");
+    break;
   }
 
   SDNode *N;


### PR DESCRIPTION
This applies the same rules we have for the scalar operands of a BUILD_VECTOR where the scalar type must match the element type or for integer vectors we allow the scalar type to be larger than the element type. Hexagon uses i32 for an FP zero vector so we allow that as an exception.