### PR TITLE
[mlir] Rectify mishandling in `InsertOpConstantFolder` causing crash with assertion when using `mlir-opt --canonicalize`

### DIFF
--- a/mlir/test/Dialect/LLVMIR/constant-folding.mlir
+++ b/mlir/test/Dialect/LLVMIR/constant-folding.mlir
@@ -169,3 +169,16 @@ llvm.func @null_pointer_select(%cond: i1) -> !llvm.ptr {
   // CHECK-NEXT: llvm.return %[[NULLPTR]]
   llvm.return %result : !llvm.ptr
 }
+
+// -----
+
+llvm.func @malloc(i64) -> !llvm.ptr
+
+// CHECK-LABEL: func.func @insert_op
+func.func @insert_op(%arg0: index, %arg1: memref<13x13xi64>, %arg2: index) {
+  %cst_7 = arith.constant dense<1526248407> : vector<1xi64>
+  %1 = llvm.mlir.constant(1 : index) : i64
+  %101 = vector.insert %1, %cst_7 [0] : i64 into vector<1xi64>
+  vector.print %101 : vector<1xi64>
+  return
+}


### PR DESCRIPTION
Resolves #74236