### PR TITLE
IRVerifier: Allow GlobalValue as llvm.threadlocal.address operand

### DIFF
--- a/llvm/docs/LangRef.rst
+++ b/llvm/docs/LangRef.rst
@@ -28130,7 +28130,8 @@ Syntax:
 Arguments:
 """"""""""
 
-The first argument is a thread local :ref:`global variable <globalvars>`.
+The `llvm.threadlocal.address` intrinsic requires a global value argument (a
+:ref:`global variable <globalvars>` or alias) that is thread local.
 
 Semantics:
 """"""""""

--- a/llvm/lib/IR/Verifier.cpp
+++ b/llvm/lib/IR/Verifier.cpp
@@ -6226,10 +6226,10 @@ void Verifier::visitIntrinsicCall(Intrinsic::ID ID, CallBase &Call) {
   }
   case Intrinsic::threadlocal_address: {
     const Value &Arg0 = *Call.getArgOperand(0);
-    Check(isa<GlobalVariable>(Arg0),
-          "llvm.threadlocal.address first argument must be a GlobalVariable");
-    Check(cast<GlobalVariable>(Arg0).isThreadLocal(),
-          "llvm.threadlocal.address operand isThreadLocal() must no be false");
+    Check(isa<GlobalValue>(Arg0),
+          "llvm.threadlocal.address first argument must be a GlobalValue");
+    Check(cast<GlobalValue>(Arg0).isThreadLocal(),
+          "llvm.threadlocal.address operand isThreadLocal() must be true");
     break;
   }
   };

--- a/llvm/test/Verifier/threadlocal-pass.ll
+++ b/llvm/test/Verifier/threadlocal-pass.ll
@@ -1,0 +1,13 @@
+; RUN: opt -passes=verify -S < %s | FileCheck %s
+
+@var = thread_local global i32 0
+@alias = thread_local alias i32, ptr @var
+
+; CHECK-LABEL: @should_pass
+define void @should_pass() {
+  %p0 = call ptr @llvm.threadlocal.address(ptr @var)
+  store i32 42, ptr %p0, align 4
+  %p1 = call ptr @llvm.threadlocal.address(ptr @alias)
+  store i32 13, ptr %p1, align 4
+  ret void
+}

--- a/llvm/test/Verifier/threadlocal.ll
+++ b/llvm/test/Verifier/threadlocal.ll
@@ -1,0 +1,34 @@
+; RUN: not llvm-as %s -o /dev/null 2>&1 | FileCheck %s
+
+@var = global i32 0
+@tlsvar = thread_local addrspace(1) global i32 0
+
+define void @fail0(ptr %arg) {
+; CHECK: llvm.threadlocal.address first argument must be a GlobalValue
+  %p0 = call ptr @llvm.threadlocal.address(ptr %arg)
+  store i32 42, ptr %p0, align 4
+  ret void
+}
+
+define void @fail1() {
+; CHECK: llvm.threadlocal.address first argument must be a GlobalValue
+  %p0 = call ptr @llvm.threadlocal.address.p0(ptr addrspacecast (ptr addrspace(1) @tlsvar to ptr addrspace(0)))
+  store i32 42, ptr %p0, align 4
+  ret void
+}
+
+
+
+define void @fail2() {
+; CHECK: llvm.threadlocal.address operand isThreadLocal() must be true
+  %p0 = call ptr @llvm.threadlocal.address(ptr @var)
+  store i32 42, ptr %p0, align 4
+  ret void
+}
+
+define void @fail3() {
+; CHECK: llvm.threadlocal.address operand isThreadLocal() must be true
+  %p0 = call ptr @llvm.threadlocal.address(ptr @fail2)
+  store i32 42, ptr %p0, align 4
+  ret void
+}


### PR DESCRIPTION
Loosen `llvm.threadlocal.address` verifier checks to allow any `GlobalValue` with `isThreadLocal()` set to true.