### PR TITLE
Look for compiler-rt from subdir given by --target

### DIFF
--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -516,6 +516,7 @@ static llvm::Triple computeTargetTriple(const Driver &D,
     TargetTriple = A->getValue();
 
   llvm::Triple Target(llvm::Triple::normalize(TargetTriple));
+  Target.setOrigin(TargetTriple);
 
   // GNU/Hurd's triples should have been -hurd-gnu*, but were historically made
   // -gnu* only, and we can not change this, so we have to detect that case as

--- a/clang/lib/Driver/ToolChain.cpp
+++ b/clang/lib/Driver/ToolChain.cpp
@@ -755,6 +755,12 @@ std::optional<std::string>
 ToolChain::getTargetSubDirPath(StringRef BaseDir) const {
   auto getPathForTriple =
       [&](const llvm::Triple &Triple) -> std::optional<std::string> {
+    if (!Triple.getOrigin().empty()) {
+      SmallString<128> Po(BaseDir);
+      llvm::sys::path::append(Po, Triple.getOrigin());
+      if (getVFS().exists(Po))
+        return std::string(Po);
+    }
     SmallString<128> P(BaseDir);
     llvm::sys::path::append(P, Triple.str());
     if (getVFS().exists(P))

--- a/llvm/include/llvm/TargetParser/Triple.h
+++ b/llvm/include/llvm/TargetParser/Triple.h
@@ -298,6 +298,8 @@ public:
 private:
   std::string Data;
 
+  StringRef Origin = StringRef();
+
   /// The parsed arch type.
   ArchType Arch{};
 
@@ -424,6 +426,8 @@ public:
   const std::string &str() const { return Data; }
 
   const std::string &getTriple() const { return Data; }
+
+  const StringRef getOrigin() const { return Origin; }
 
   /// Get the architecture (first) component of the triple.
   StringRef getArchName() const;
@@ -1057,6 +1061,8 @@ public:
   /// @}
   /// @name Mutators
   /// @{
+
+  void setOrigin(StringRef Orig) { Origin = Orig; };
 
   /// Set the architecture (first) component of the triple to a known type.
   void setArch(ArchType Kind, SubArchType SubArch = NoSubArch);

--- a/llvm/lib/TargetParser/Triple.cpp
+++ b/llvm/lib/TargetParser/Triple.cpp
@@ -928,9 +928,9 @@ static Triple::ObjectFormatType getDefaultFormat(const Triple &T) {
 /// This stores the string representation and parses the various pieces into
 /// enum members.
 Triple::Triple(const Twine &Str)
-    : Data(Str.str()), Arch(UnknownArch), SubArch(NoSubArch),
-      Vendor(UnknownVendor), OS(UnknownOS), Environment(UnknownEnvironment),
-      ObjectFormat(UnknownObjectFormat) {
+    : Data(Str.str()), Origin(Str.getSingleStringRef()), Arch(UnknownArch),
+      SubArch(NoSubArch), Vendor(UnknownVendor), OS(UnknownOS),
+      Environment(UnknownEnvironment), ObjectFormat(UnknownObjectFormat) {
   // Do minimal parsing by hand here.
   SmallVector<StringRef, 4> Components;
   StringRef(Data).split(Components, '-', /*MaxSplit*/ 3);


### PR DESCRIPTION
Currently, clang looks for compiler-rt only from the normalized triple subdir. While if we are configured with a non-normalized triple with -DLLVM_DEFAULT_TARGET_TRIPLE, such as triples without vendor section, clang will fail to find compiler_rt.

Let's look for compiler_rt from the subdir with name from --target option, too.

To archive this, we add a new member called Origin to class Triple.

Fixes: #87150.