### PR TITLE
[lld-macho][NFC] Preserve original symbol isec, unwindEntry and size

### DIFF
--- a/lld/MachO/ICF.cpp
+++ b/lld/MachO/ICF.cpp
@@ -133,13 +133,13 @@ bool ICF::equalsConstant(const ConcatInputSection *ia,
       assert(isa<Defined>(sa));
       const auto *da = cast<Defined>(sa);
       const auto *db = cast<Defined>(sb);
-      if (!da->isec || !db->isec) {
+      if (!da->isec() || !db->isec()) {
         assert(da->isAbsolute() && db->isAbsolute());
         return da->value + ra.addend == db->value + rb.addend;
       }
-      isecA = da->isec;
+      isecA = da->isec();
       valueA = da->value;
-      isecB = db->isec;
+      isecB = db->isec();
       valueB = db->value;
     } else {
       isecA = ra.referent.get<InputSection *>();
@@ -191,10 +191,10 @@ bool ICF::equalsVariable(const ConcatInputSection *ia,
       const auto *db = cast<Defined>(rb.referent.get<Symbol *>());
       if (da->isAbsolute())
         return true;
-      isecA = dyn_cast<ConcatInputSection>(da->isec);
+      isecA = dyn_cast<ConcatInputSection>(da->isec());
       if (!isecA)
         return true; // literal sections were checked in equalsConstant.
-      isecB = cast<ConcatInputSection>(db->isec);
+      isecB = cast<ConcatInputSection>(db->isec());
     } else {
       const auto *sa = ra.referent.get<InputSection *>();
       const auto *sb = rb.referent.get<InputSection *>();
@@ -212,7 +212,7 @@ bool ICF::equalsVariable(const ConcatInputSection *ia,
   // info matches. For simplicity, we only handle the case where there are only
   // symbols at offset zero within the section (which is typically the case with
   // .subsections_via_symbols.)
-  auto hasUnwind = [](Defined *d) { return d->unwindEntry != nullptr; };
+  auto hasUnwind = [](Defined *d) { return d->unwindEntry() != nullptr; };
   const auto *itA = llvm::find_if(ia->symbols, hasUnwind);
   const auto *itB = llvm::find_if(ib->symbols, hasUnwind);
   if (itA == ia->symbols.end())
@@ -221,8 +221,8 @@ bool ICF::equalsVariable(const ConcatInputSection *ia,
     return false;
   const Defined *da = *itA;
   const Defined *db = *itB;
-  if (da->unwindEntry->icfEqClass[icfPass % 2] !=
-          db->unwindEntry->icfEqClass[icfPass % 2] ||
+  if (da->unwindEntry()->icfEqClass[icfPass % 2] !=
+          db->unwindEntry()->icfEqClass[icfPass % 2] ||
       da->value != 0 || db->value != 0)
     return false;
   auto isZero = [](Defined *d) { return d->value == 0; };
@@ -289,13 +289,13 @@ void ICF::run() {
       for (const Reloc &r : isec->relocs) {
         if (auto *sym = r.referent.dyn_cast<Symbol *>()) {
           if (auto *defined = dyn_cast<Defined>(sym)) {
-            if (defined->isec) {
+            if (defined->isec()) {
               if (auto *referentIsec =
-                      dyn_cast<ConcatInputSection>(defined->isec))
+                      dyn_cast<ConcatInputSection>(defined->isec()))
                 hash += defined->value + referentIsec->icfEqClass[icfPass % 2];
               else
-                hash += defined->isec->kind() +
-                        defined->isec->getOffset(defined->value);
+                hash += defined->isec()->kind() +
+                        defined->isec()->getOffset(defined->value);
             } else {
               hash += defined->value;
             }
@@ -368,8 +368,8 @@ void ICF::segregate(size_t begin, size_t end, EqualsFn equals) {
 
 void macho::markSymAsAddrSig(Symbol *s) {
   if (auto *d = dyn_cast_or_null<Defined>(s))
-    if (d->isec)
-      d->isec->keepUnique = true;
+    if (d->isec())
+      d->isec()->keepUnique = true;
 }
 
 void macho::markAddrSigSymbols() {
@@ -430,8 +430,8 @@ void macho::foldIdenticalSections(bool onlyCfStrings) {
     if (isFoldable) {
       foldable.push_back(isec);
       for (Defined *d : isec->symbols)
-        if (d->unwindEntry)
-          foldable.push_back(d->unwindEntry);
+        if (d->unwindEntry())
+          foldable.push_back(d->unwindEntry());
 
       // Some sections have embedded addends that foil ICF's hashing / equality
       // checks. (We can ignore embedded addends when doing ICF because the same

--- a/lld/MachO/InputSection.cpp
+++ b/lld/MachO/InputSection.cpp
@@ -194,10 +194,8 @@ void ConcatInputSection::foldIdentical(ConcatInputSection *copy) {
   copy->live = false;
   copy->wasCoalesced = true;
   copy->replacement = this;
-  for (auto &copySym : copy->symbols) {
+  for (auto &copySym : copy->symbols)
     copySym->wasIdenticalCodeFolded = true;
-    copySym->size = 0;
-  }
 
   symbols.insert(symbols.end(), copy->symbols.begin(), copy->symbols.end());
   copy->symbols.clear();
@@ -207,7 +205,7 @@ void ConcatInputSection::foldIdentical(ConcatInputSection *copy) {
     return;
   for (auto it = symbols.begin() + 1; it != symbols.end(); ++it) {
     assert((*it)->value == 0);
-    (*it)->unwindEntry = nullptr;
+    (*it)->originalUnwindEntry = nullptr;
   }
 }
 

--- a/lld/MachO/MarkLive.cpp
+++ b/lld/MachO/MarkLive.cpp
@@ -110,10 +110,10 @@ void MarkLiveImpl<RecordWhyLive>::addSym(
     if (!config->whyLive.empty() && config->whyLive.match(s->getName()))
       printWhyLive(s, prev);
   if (auto *d = dyn_cast<Defined>(s)) {
-    if (d->isec)
-      enqueue(d->isec, d->value, prev);
-    if (d->unwindEntry)
-      enqueue(d->unwindEntry, 0, prev);
+    if (d->isec())
+      enqueue(d->isec(), d->value, prev);
+    if (d->unwindEntry())
+      enqueue(d->unwindEntry(), 0, prev);
   }
 }
 
@@ -179,7 +179,7 @@ void MarkLiveImpl<RecordWhyLive>::markTransitively() {
           if (s->isLive()) {
             InputSection *referentIsec = nullptr;
             if (auto *d = dyn_cast<Defined>(s))
-              referentIsec = d->isec;
+              referentIsec = d->isec();
             enqueue(isec, 0, makeEntry(referentIsec, nullptr));
           }
         } else {

--- a/lld/MachO/Relocations.cpp
+++ b/lld/MachO/Relocations.cpp
@@ -24,7 +24,7 @@ static_assert(sizeof(void *) != 8 || sizeof(Reloc) == 24,
 InputSection *Reloc::getReferentInputSection() const {
   if (const auto *sym = referent.dyn_cast<Symbol *>()) {
     if (const auto *d = dyn_cast<Defined>(sym))
-      return d->isec;
+      return d->isec();
     return nullptr;
   } else {
     return referent.get<InputSection *>();

--- a/lld/MachO/SectionPriorities.cpp
+++ b/lld/MachO/SectionPriorities.cpp
@@ -236,7 +236,7 @@ DenseMap<const InputSection *, size_t> CallGraphSort::run() {
         // section.
         for (Symbol *sym : isec->getFile()->symbols) {
           if (auto *d = dyn_cast_or_null<Defined>(sym)) {
-            if (d->isec == isec)
+            if (d->isec() == isec)
               os << sym->getName() << "\n";
           }
         }
@@ -258,7 +258,7 @@ macho::PriorityBuilder::getSymbolPriority(const Defined *sym) {
   if (it == priorities.end())
     return std::nullopt;
   const SymbolPriorityEntry &entry = it->second;
-  const InputFile *f = sym->isec->getFile();
+  const InputFile *f = sym->isec()->getFile();
   if (!f)
     return entry.anyObjectFile;
   // We don't use toString(InputFile *) here because it returns the full path
@@ -287,7 +287,7 @@ void macho::PriorityBuilder::extractCallGraphProfile() {
       if (fromSym && toSym &&
           (!hasOrderFile ||
            (!getSymbolPriority(fromSym) && !getSymbolPriority(toSym))))
-        callGraphProfile[{fromSym->isec, toSym->isec}] += entry.count;
+        callGraphProfile[{fromSym->isec(), toSym->isec()}] += entry.count;
     }
   }
 }
@@ -370,7 +370,7 @@ macho::PriorityBuilder::buildInputSectionPriorities() {
     std::optional<size_t> symbolPriority = getSymbolPriority(sym);
     if (!symbolPriority)
       return;
-    size_t &priority = sectionPriorities[sym->isec];
+    size_t &priority = sectionPriorities[sym->isec()];
     priority = std::max(priority, *symbolPriority);
   };
 

--- a/lld/MachO/SymbolTable.cpp
+++ b/lld/MachO/SymbolTable.cpp
@@ -80,14 +80,14 @@ static void transplantSymbolsAtOffset(InputSection *fromIsec,
       // iterator. However, that is typically the case for files that have
       // .subsections_via_symbols set.
       insertIt = toIsec->symbols.insert(insertIt, d);
-      d->isec = toIsec;
+      d->originalIsec = toIsec;
       d->value = toOff;
       // We don't want to have more than one unwindEntry at a given address, so
       // drop the redundant ones. We We can safely drop the unwindEntries of
       // the symbols in fromIsec since we will be adding another unwindEntry as
       // we finish parsing toIsec's file. (We can assume that toIsec has its
       // own unwindEntry because of the ODR.)
-      d->unwindEntry = nullptr;
+      d->originalUnwindEntry = nullptr;
     }
     return true;
   });
@@ -121,8 +121,8 @@ Defined *SymbolTable::addDefined(StringRef name, InputFile *file,
           // in ObjFile::parseSymbols() such that extern weak symbols appear
           // last, so we don't need to worry about subsequent symbols being
           // added to an already-coalesced section.
-          if (defined->isec)
-            transplantSymbolsAtOffset(concatIsec, defined->isec,
+          if (defined->isec())
+            transplantSymbolsAtOffset(concatIsec, defined->isec(),
                                       /*skip=*/nullptr, value, defined->value);
         }
         return defined;
@@ -130,7 +130,7 @@ Defined *SymbolTable::addDefined(StringRef name, InputFile *file,
 
       if (defined->isWeakDef()) {
         if (auto concatIsec =
-                dyn_cast_or_null<ConcatInputSection>(defined->isec)) {
+                dyn_cast_or_null<ConcatInputSection>(defined->isec())) {
           concatIsec->wasCoalesced = true;
           if (isec)
             transplantSymbolsAtOffset(concatIsec, isec, defined, defined->value,
@@ -212,7 +212,7 @@ Defined *SymbolTable::addDefined(StringRef name, InputFile *file,
 Defined *SymbolTable::aliasDefined(Defined *src, StringRef target,
                                    InputFile *newFile, bool makePrivateExtern) {
   bool isPrivateExtern = makePrivateExtern || src->privateExtern;
-  return addDefined(target, newFile, src->isec, src->value, src->size,
+  return addDefined(target, newFile, src->isec(), src->value, src->size,
                     src->isWeakDef(), isPrivateExtern,
                     src->referencedDynamically, src->noDeadStrip,
                     src->weakDefCanBeHidden);

--- a/lld/MachO/Symbols.h
+++ b/lld/MachO/Symbols.h
@@ -129,7 +129,7 @@ public:
   bool isTlv() const override;
 
   bool isExternal() const { return external; }
-  bool isAbsolute() const { return isec == nullptr; }
+  bool isAbsolute() const { return originalIsec == nullptr; }
 
   uint64_t getVA() const override;
 
@@ -139,9 +139,11 @@ public:
 
   std::string getSourceLocation();
 
-  // Ensure this symbol's pointers to InputSections point to their canonical
-  // copies.
-  void canonicalize();
+  // Get the canonical InputSection of the symbol.
+  InputSection *isec() const;
+
+  // Get the canonical unwind entry of the symbol.
+  ConcatInputSection *unwindEntry() const;
 
   static bool classof(const Symbol *s) { return s->kind() == DefinedKind; }
 
@@ -182,14 +184,17 @@ private:
   const bool external : 1;
 
 public:
-  InputSection *isec;
+  // The native InputSection of the symbol. The symbol may be moved to another
+  // InputSection in which originalIsec->canonical() will point to the new
+  // InputSection
+  InputSection *originalIsec;
   // Contains the offset from the containing subsection. Note that this is
   // different from nlist::n_value, which is the absolute address of the symbol.
   uint64_t value;
   // size is only calculated for regular (non-bitcode) symbols.
   uint64_t size;
   // This can be a subsection of either __compact_unwind or __eh_frame.
-  ConcatInputSection *unwindEntry = nullptr;
+  ConcatInputSection *originalUnwindEntry = nullptr;
 };
 
 // This enum does double-duty: as a symbol property, it indicates whether & how

--- a/lld/MachO/Symbols.h
+++ b/lld/MachO/Symbols.h
@@ -185,7 +185,7 @@ private:
 
 public:
   // The native InputSection of the symbol. The symbol may be moved to another
-  // InputSection in which originalIsec->canonical() will point to the new
+  // InputSection in which case originalIsec->canonical() will point to the new
   // InputSection
   InputSection *originalIsec;
   // Contains the offset from the containing subsection. Note that this is

--- a/lld/MachO/UnwindInfoSection.cpp
+++ b/lld/MachO/UnwindInfoSection.cpp
@@ -185,16 +185,16 @@ UnwindInfoSection::UnwindInfoSection()
 // function symbols for each unique address regardless of whether they have
 // associated unwind info.
 void UnwindInfoSection::addSymbol(const Defined *d) {
-  if (d->unwindEntry)
+  if (d->unwindEntry())
     allEntriesAreOmitted = false;
   // We don't yet know the final output address of this symbol, but we know that
   // they are uniquely determined by a combination of the isec and value, so
   // we use that as the key here.
-  auto p = symbols.insert({{d->isec, d->value}, d});
+  auto p = symbols.insert({{d->isec(), d->value}, d});
   // If we have multiple symbols at the same address, only one of them can have
   // an associated unwind entry.
-  if (!p.second && d->unwindEntry) {
-    assert(p.first->second == d || !p.first->second->unwindEntry);
+  if (!p.second && d->unwindEntry()) {
+    assert(p.first->second == d || !p.first->second->unwindEntry());
     p.first->second = d;
   }
 }
@@ -204,16 +204,16 @@ void UnwindInfoSectionImpl::prepare() {
   // entries to the GOT. Hence the use of a MapVector for
   // UnwindInfoSection::symbols.
   for (const Defined *d : make_second_range(symbols))
-    if (d->unwindEntry) {
-      if (d->unwindEntry->getName() == section_names::compactUnwind) {
-        prepareRelocations(d->unwindEntry);
+    if (d->unwindEntry()) {
+      if (d->unwindEntry()->getName() == section_names::compactUnwind) {
+        prepareRelocations(d->unwindEntry());
       } else {
         // We don't have to add entries to the GOT here because FDEs have
         // explicit GOT relocations, so Writer::scanRelocations() will add those
         // GOT entries. However, we still need to canonicalize the personality
         // pointers (like prepareRelocations() does for CU entries) in order
         // to avoid overflowing the 3-personality limit.
-        FDE &fde = cast<ObjFile>(d->getFile())->fdes[d->unwindEntry];
+        FDE &fde = cast<ObjFile>(d->getFile())->fdes[d->unwindEntry()];
         fde.personality = canonicalizePersonality(fde.personality);
       }
     }
@@ -279,7 +279,7 @@ void UnwindInfoSectionImpl::prepareRelocations(ConcatInputSection *isec) {
       if (auto *defined = dyn_cast<Defined>(s)) {
         // Check if we have created a synthetic symbol at the same address.
         Symbol *&personality =
-            personalityTable[{defined->isec, defined->value}];
+            personalityTable[{defined->isec(), defined->value}];
         if (personality == nullptr) {
           personality = defined;
           in.got->addEntry(defined);
@@ -321,7 +321,7 @@ void UnwindInfoSectionImpl::prepareRelocations(ConcatInputSection *isec) {
 Symbol *UnwindInfoSectionImpl::canonicalizePersonality(Symbol *personality) {
   if (auto *defined = dyn_cast_or_null<Defined>(personality)) {
     // Check if we have created a synthetic symbol at the same address.
-    Symbol *&synth = personalityTable[{defined->isec, defined->value}];
+    Symbol *&synth = personalityTable[{defined->isec(), defined->value}];
     if (synth == nullptr)
       synth = defined;
     else if (synth != defined)
@@ -340,12 +340,12 @@ void UnwindInfoSectionImpl::relocateCompactUnwind(
     CompactUnwindEntry &cu = cuEntries[i];
     const Defined *d = symbolsVec[i].second;
     cu.functionAddress = d->getVA();
-    if (!d->unwindEntry)
+    if (!d->unwindEntry())
       return;
 
     // If we have DWARF unwind info, create a slimmed-down CU entry that points
     // to it.
-    if (d->unwindEntry->getName() == section_names::ehFrame) {
+    if (d->unwindEntry()->getName() == section_names::ehFrame) {
       // The unwinder will look for the DWARF entry starting at the hint,
       // assuming the hint points to a valid CFI record start. If it
       // fails to find the record, it proceeds in a linear search through the
@@ -355,11 +355,11 @@ void UnwindInfoSectionImpl::relocateCompactUnwind(
       // but since we don't keep track of that, just encode zero -- the start of
       // the section is always the start of a CFI record.
       uint64_t dwarfOffsetHint =
-          d->unwindEntry->outSecOff <= DWARF_SECTION_OFFSET
-              ? d->unwindEntry->outSecOff
+          d->unwindEntry()->outSecOff <= DWARF_SECTION_OFFSET
+              ? d->unwindEntry()->outSecOff
               : 0;
       cu.encoding = target->modeDwarfEncoding | dwarfOffsetHint;
-      const FDE &fde = cast<ObjFile>(d->getFile())->fdes[d->unwindEntry];
+      const FDE &fde = cast<ObjFile>(d->getFile())->fdes[d->unwindEntry()];
       cu.functionLength = fde.funcLength;
       // Omit the DWARF personality from compact-unwind entry so that we
       // don't need to encode it.
@@ -368,14 +368,15 @@ void UnwindInfoSectionImpl::relocateCompactUnwind(
       return;
     }
 
-    assert(d->unwindEntry->getName() == section_names::compactUnwind);
+    assert(d->unwindEntry()->getName() == section_names::compactUnwind);
 
-    auto buf = reinterpret_cast<const uint8_t *>(d->unwindEntry->data.data()) -
-               target->wordSize;
+    auto buf =
+        reinterpret_cast<const uint8_t *>(d->unwindEntry()->data.data()) -
+        target->wordSize;
     cu.functionLength =
         support::endian::read32le(buf + cuLayout.functionLengthOffset);
     cu.encoding = support::endian::read32le(buf + cuLayout.encodingOffset);
-    for (const Reloc &r : d->unwindEntry->relocs) {
+    for (const Reloc &r : d->unwindEntry()->relocs) {
       if (r.offset == cuLayout.personalityOffset)
         cu.personality = r.referent.get<Symbol *>();
       else if (r.offset == cuLayout.lsdaOffset)

--- a/lld/MachO/Writer.cpp
+++ b/lld/MachO/Writer.cpp
@@ -725,10 +725,9 @@ void Writer::scanSymbols() {
     if (auto *defined = dyn_cast<Defined>(sym)) {
       if (!defined->isLive())
         continue;
-      defined->canonicalize();
       if (defined->overridesWeakDef)
         addNonWeakDefinition(defined);
-      if (!defined->isAbsolute() && isCodeSection(defined->isec))
+      if (!defined->isAbsolute() && isCodeSection(defined->isec()))
         in.unwindInfo->addSymbol(defined);
     } else if (const auto *dysym = dyn_cast<DylibSymbol>(sym)) {
       // This branch intentionally doesn't check isLive().
@@ -756,9 +755,8 @@ void Writer::scanSymbols() {
         if (auto *defined = dyn_cast_or_null<Defined>(sym)) {
           if (!defined->isLive())
             continue;
-          defined->canonicalize();
           if (!defined->isExternal() && !defined->isAbsolute() &&
-              isCodeSection(defined->isec))
+              isCodeSection(defined->isec()))
             in.unwindInfo->addSymbol(defined);
         }
       }


### PR DESCRIPTION
Currently, when moving symbols from one `InputSection` to another (like in ICF) we directly update the symbol's `isec`, `unwindEntry` and `size`. By doing this we lose the original information. This information will be needed in a future change. Since when moving symbols we always set the symbol's `wasCoalesced`  and `isec-> replacement`, we can just use this info to conditionally get the information we need at access time. 

