### PR TITLE
[LoongArch] Return true from shouldConsiderGEPOffsetSplit

### DIFF
--- a/llvm/lib/Target/LoongArch/LoongArchISelLowering.h
+++ b/llvm/lib/Target/LoongArch/LoongArchISelLowering.h
@@ -238,6 +238,7 @@ public:
   bool isShuffleMaskLegal(ArrayRef<int> Mask, EVT VT) const override {
     return false;
   }
+  bool shouldConsiderGEPOffsetSplit() const override { return true; }
 
 private:
   /// Target-specific function used to lower LoongArch calling conventions.

--- a/llvm/test/Transforms/CodeGenPrepare/LoongArch/splitgep.ll
+++ b/llvm/test/Transforms/CodeGenPrepare/LoongArch/splitgep.ll
@@ -4,9 +4,9 @@
 define void @test(ptr %sp, ptr %t, i32 %n) {
 ; CHECK-LABEL: @test(
 ; CHECK-NEXT:  entry:
-; CHECK-NEXT:    %s = load ptr, ptr %sp, align 8
-; CHECK-NEXT:    br label %while_cond
-
+; CHECK-NEXT:    %splitgep1 = getelementptr i8, ptr %t, i64 80000
+; CHECK-NEXT:    %s = load ptr, ptr %sp
+; CHECK-NEXT:    %splitgep = getelementptr i8, ptr %s, i64 80000
 entry:
   %s = load ptr, ptr %sp
   br label %while_cond


### PR DESCRIPTION
If not performing gep splits can prevent important 
optimizations, such as preventing the element indices / member offsets from 
being (partially) folded into load/store instruction immediates.