### PR TITLE
[Offload] Do not pass `-fcf-protection=` for offloading

### DIFF
--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -6867,8 +6867,14 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
     CmdArgs.push_back("-nogpulib");
 
   if (Arg *A = Args.getLastArg(options::OPT_fcf_protection_EQ)) {
-    CmdArgs.push_back(
-        Args.MakeArgString(Twine("-fcf-protection=") + A->getValue()));
+    // Do not pass this argument to the offloading device if the target does not
+    // support it.
+    // TODO: We need a better way to detect incompatible options for offloading.
+    if (JA.getOffloadingDeviceKind() == Action::OFK_None ||
+        (!TC.getTriple().isAMDGPU() && !TC.getTriple().isNVPTX() &&
+         !TC.getTriple().isSPIRV()))
+      CmdArgs.push_back(
+          Args.MakeArgString(Twine("-fcf-protection=") + A->getValue()));
   }
 
   if (Arg *A = Args.getLastArg(options::OPT_mfunction_return_EQ))

--- a/clang/test/Driver/hip-options.hip
+++ b/clang/test/Driver/hip-options.hip
@@ -43,10 +43,10 @@
 // MLLVM-NOT: "-mllvm"{{.*}}"-amdgpu-early-inline-all=true"{{.*}}"-mllvm"{{.*}}"-amdgpu-early-inline-all=true"
 
 // RUN: %clang -### -Xarch_device -g -nogpulib -nogpuinc --cuda-gpu-arch=gfx900 \
-// RUN:   -Xarch_device -fcf-protection=branch -Xarch_device -mllvm=--inline-threshold=100 \
+// RUN:   -Xarch_device -mllvm=--inline-threshold=100 \
 // RUN:   --cuda-gpu-arch=gfx906  %s 2>&1 | FileCheck -check-prefix=DEV %s
-// DEV: "-cc1"{{.*}} "-fcuda-is-device" {{.*}} "-debug-info-kind={{.*}}" {{.*}} "-fcf-protection=branch" {{.*}}"-mllvm" "--inline-threshold=100"
-// DEV: "-cc1"{{.*}} "-fcuda-is-device" {{.*}} "-debug-info-kind={{.*}}" {{.*}} "-fcf-protection=branch" {{.*}}"-mllvm" "--inline-threshold=100"
+// DEV: "-cc1"{{.*}} "-fcuda-is-device" {{.*}} "-debug-info-kind={{.*}}"{{.*}}"-mllvm" "--inline-threshold=100"
+// DEV: "-cc1"{{.*}} "-fcuda-is-device" {{.*}} "-debug-info-kind={{.*}}"{{.*}}"-mllvm" "--inline-threshold=100"
 // DEV-NOT: clang{{.*}} {{.*}} "-debug-info-kind={{.*}}"
 
 // RUN: %clang -### -Xarch_host -g -nogpulib -nogpuinc --cuda-gpu-arch=gfx900 \

--- a/clang/test/Driver/offload-no-fcf-protection.c
+++ b/clang/test/Driver/offload-no-fcf-protection.c
@@ -1,0 +1,39 @@
+// Check that -fcf-protection does not get passed to the device-side
+// compilation.
+
+// RUN: %clang -### -x cuda --target=x86_64-unknown-linux-gnu -nogpulib \
+// RUN:   -nogpuinc --offload-arch=sm_52 -fcf-protection=full -c %s 2>&1 \
+// RUN: | FileCheck %s --check-prefix=CUDA
+
+// CUDA: "-cc1" "-triple" "nvptx64-nvidia-cuda"
+// CUDA-NOT: "-fcf-protection=full"
+// CUDA: "-cc1" "-triple" "x86_64-unknown-linux-gnu"
+// CUDA: "-fcf-protection=full"
+
+// RUN: %clang -### -x hip --target=x86_64-unknown-linux-gnu -nogpulib \
+// RUN:   -nogpuinc --offload-arch=gfx90a -fcf-protection=full -c %s 2>&1 \
+// RUN: | FileCheck %s --check-prefix=HIP
+
+// HIP: "-cc1" "-triple" "amdgcn-amd-amdhsa"
+// HIP-NOT: "-fcf-protection=full"
+// HIP: "-cc1" "-triple" "x86_64-unknown-linux-gnu"
+// HIP: "-fcf-protection=full"
+
+// RUN: %clang -### -x c --target=x86_64-unknown-linux-gnu -nogpulib -fopenmp=libomp \
+// RUN:   -nogpuinc --offload-arch=gfx90a -fcf-protection=full -c %s 2>&1 \
+// RUN: | FileCheck %s --check-prefix=OMP
+
+// OMP: "-cc1" "-triple" "x86_64-unknown-linux-gnu"
+// OMP: "-fcf-protection=full"
+// OMP: "-cc1" "-triple" "amdgcn-amd-amdhsa"
+// OMP-NOT: "-fcf-protection=full"
+// OMP: "-cc1" "-triple" "x86_64-unknown-linux-gnu"
+// OMP: "-fcf-protection=full"
+
+// RUN: %clang -### -x c --target=nvptx64-nvidia-cuda -nogpulib -nogpuinc \
+// RUN:   -march=sm_52 -fcf-protection=full -c %s 2>&1 \
+// RUN: | FileCheck %s --check-prefix=DIRECT
+// RUN: %clang -### -x c --target=amdgcn-amd-amdhsa -nogpulib -nogpuinc \
+// RUN:   -mcpu=gfx90a -fcf-protection=full -c %s 2>&1 \
+// RUN: | FileCheck %s --check-prefix=DIRECT
+// DIRECT: "-fcf-protection=full"


### PR DESCRIPTION
Summary:
This patch prevents the `-fcf-protection=` flag from being passed to the
device compilation during offloading. This is not supported on CUDA and
AMD devices, but if the user is compiling with fcf protection for the
host it will fail to compile.

We have a lot of these cases with various hacked together solutions, it
would be nice to have a single solution to detect from the driver if a
feature like this can be used for offloading, but for now this should
resolve the issue.

Fixes: https://github.com/llvm/llvm-project/issues/86450
