### PR TITLE
[Clang][ScanDeps] Fix error message typo

### DIFF
--- a/clang/tools/clang-scan-deps/ClangScanDeps.cpp
+++ b/clang/tools/clang-scan-deps/ClangScanDeps.cpp
@@ -190,7 +190,7 @@ static void ParseArgs(int argc, char **argv) {
     CompilationDB = A->getValue();
   } else if (Format != ScanningOutputFormat::P1689) {
     llvm::errs() << ToolName
-                 << ": for the --compiilation-database option: must be "
+                 << ": for the --compilation-database option: must be "
                     "specified at least once!";
     std::exit(1);
   }


### PR DESCRIPTION
fix the error message command suggestion typo when you try to use ``clang-scan-deps`` without any arguments.

![image](https://github.com/llvm/llvm-project/assets/36525792/fddec820-6238-4bdd-bde1-dd2ad40ad4fa)
