### PR TITLE
Fix UPCAddressofArraySubscriptGadget::getClaimedVarUseSites()

### DIFF
--- a/clang/lib/Analysis/UnsafeBufferUsage.cpp
+++ b/clang/lib/Analysis/UnsafeBufferUsage.cpp
@@ -1114,7 +1114,7 @@ public:
   virtual DeclUseList getClaimedVarUseSites() const override {
     const auto *ArraySubst = cast<ArraySubscriptExpr>(Node->getSubExpr());
     const auto *DRE =
-        cast<DeclRefExpr>(ArraySubst->getBase()->IgnoreImpCasts());
+        cast<DeclRefExpr>(ArraySubst->getBase()->IgnoreParenImpCasts());
     return {DRE};
   }
 };

--- a/clang/test/SemaCXX/warn-unsafe-buffer-usage-suggestions-crashes.cpp
+++ b/clang/test/SemaCXX/warn-unsafe-buffer-usage-suggestions-crashes.cpp
@@ -1,0 +1,12 @@
+// RUN: %clang_cc1 -std=c++20 -Wunsafe-buffer-usage \
+// RUN:            -fsafe-buffer-usage-suggestions \
+// RUN:            %s -verify %s
+
+char * unsafe_pointer; // expected-warning{{'unsafe_pointer' is an unsafe pointer used for buffer access}}
+
+void test(char * param) {
+}
+
+void dre_parenthesized() {
+  test(&(unsafe_pointer)[1]); // no-crash // expected-note{{used in buffer access here}}
+}


### PR DESCRIPTION
UPCAddressofArraySubscriptGadget::getClaimedVarUseSites should skip parentheses when accessing the DeclRefExpr, otherwise a crash happens with parenthesized references.