### PR TITLE
CompilerRT: Normalize COMPILER_RT_DEFAULT_TARGET_TRIPLE

### DIFF
--- a/compiler-rt/cmake/Modules/CompilerRTUtils.cmake
+++ b/compiler-rt/cmake/Modules/CompilerRTUtils.cmake
@@ -363,7 +363,7 @@ macro(construct_compiler_rt_default_triple)
     endif()
     message(STATUS "cmake c compiler target: ${CMAKE_C_COMPILER_TARGET}")
     if ("${CMAKE_C_COMPILER_ID}" MATCHES "Clang")
-      execute_process(COMMAND ${CMAKE_C_COMPILER} -target ${CMAKE_C_COMPILER_TARGET} -print-effective-triple
+      execute_process(COMMAND ${CMAKE_C_COMPILER} --target=${CMAKE_C_COMPILER_TARGET} -print-effective-triple
                       OUTPUT_VARIABLE COMPILER_RT_DEFAULT_TARGET_TRIPLE
                       OUTPUT_STRIP_TRAILING_WHITESPACE)
     else()
@@ -371,7 +371,7 @@ macro(construct_compiler_rt_default_triple)
     endif()
   else()
     if ("${CMAKE_C_COMPILER_ID}" MATCHES "Clang")
-      execute_process(COMMAND ${CMAKE_C_COMPILER} -target ${LLVM_TARGET_TRIPLE} -print-effective-triple
+      execute_process(COMMAND ${CMAKE_C_COMPILER} --target=${LLVM_TARGET_TRIPLE} -print-effective-triple
                       OUTPUT_VARIABLE COMPILER_RT_DEFAULT_TARGET_TRIPLE
                       OUTPUT_STRIP_TRAILING_WHITESPACE)
     else()

--- a/compiler-rt/cmake/Modules/CompilerRTUtils.cmake
+++ b/compiler-rt/cmake/Modules/CompilerRTUtils.cmake
@@ -362,10 +362,22 @@ macro(construct_compiler_rt_default_triple)
       message(FATAL_ERROR "CMAKE_C_COMPILER_TARGET must also be set when COMPILER_RT_DEFAULT_TARGET_ONLY is ON")
     endif()
     message(STATUS "cmake c compiler target: ${CMAKE_C_COMPILER_TARGET}")
-    set(COMPILER_RT_DEFAULT_TARGET_TRIPLE ${CMAKE_C_COMPILER_TARGET})
+    if ("${CMAKE_C_COMPILER_ID}" MATCHES "Clang")
+      execute_process(COMMAND ${CMAKE_C_COMPILER} -target ${CMAKE_C_COMPILER_TARGET} -print-effective-triple
+                      OUTPUT_VARIABLE COMPILER_RT_DEFAULT_TARGET_TRIPLE
+                      OUTPUT_STRIP_TRAILING_WHITESPACE)
+    else()
+      set(COMPILER_RT_DEFAULT_TARGET_TRIPLE ${CMAKE_C_COMPILER_TARGET})
+    endif()
   else()
-    set(COMPILER_RT_DEFAULT_TARGET_TRIPLE ${LLVM_TARGET_TRIPLE} CACHE STRING
-          "Default triple for which compiler-rt runtimes will be built.")
+    if ("${CMAKE_C_COMPILER_ID}" MATCHES "Clang")
+      execute_process(COMMAND ${CMAKE_C_COMPILER} -target ${LLVM_TARGET_TRIPLE} -print-effective-triple
+                      OUTPUT_VARIABLE COMPILER_RT_DEFAULT_TARGET_TRIPLE
+                      OUTPUT_STRIP_TRAILING_WHITESPACE)
+    else()
+      set(COMPILER_RT_DEFAULT_TARGET_TRIPLE ${LLVM_TARGET_TRIPLE} CACHE STRING
+            "Default triple for which compiler-rt runtimes will be built.")
+    endif()
   endif()
 
   string(REPLACE "-" ";" LLVM_TARGET_TRIPLE_LIST ${COMPILER_RT_DEFAULT_TARGET_TRIPLE})


### PR DESCRIPTION
If LLVM is configured with -DLLVM_DEFAULT_TARGET_TRIPLE, and the argument is not normalized, such as Debian-style vendor-less triple, clang will try to find libclang_rt in lib/<normalized_triple>, while libclang_rt is placed into lib/<triple_arg>.

Let's also place libclang_rt into lib/<normalized_triple>.