### PR TITLE
[flang][OpenMP] Allow common blocks in nested directives

### DIFF
--- a/flang/lib/Semantics/resolve-directives.cpp
+++ b/flang/lib/Semantics/resolve-directives.cpp
@@ -2096,24 +2096,10 @@ Symbol *OmpAttributeVisitor::ResolveOmpCommonBlockName(
   if (!name) {
     return nullptr;
   }
-  // First check if the Common Block is declared in the current scope
-  if (auto *cur{GetContext().scope.FindCommonBlock(name->source)}) {
-    name->symbol = cur;
-    return cur;
-  }
-  // Then check parent scope, skipping OpenMP scopes and making sure
-  // that the top directive started its own scope.
-  DirContext &topDirContext = dirContext_.front();
-  Scope &topDirScope = topDirContext.scope;
-  assert(!topDirContext.directiveSource.empty());
-  assert(!topDirScope.sourceRange().empty());
-  if (!topDirScope.IsTopLevel() &&
-      topDirContext.directiveSource.begin() ==
-          topDirScope.sourceRange().begin()) {
-    if (auto *prev{topDirScope.parent().FindCommonBlock(name->source)}) {
-      name->symbol = prev;
-      return prev;
-    }
+  if (auto *cb{GetProgramUnitOrBlockConstructContaining(GetContext().scope)
+                   .FindCommonBlock(name->source)}) {
+    name->symbol = cb;
+    return cb;
   }
   return nullptr;
 }

--- a/flang/test/Semantics/OpenMP/resolve03.f90
+++ b/flang/test/Semantics/OpenMP/resolve03.f90
@@ -8,6 +8,9 @@
 
   common /c/ a, b
   integer a(3), b
+  common /tc/ xy
+  integer xz
+  !$omp threadprivate(/tc/)
 
   A = 1
   B = 2
@@ -19,4 +22,17 @@
     !$omp end parallel
   end block
   print *, a, b
+
+  ! Common block names may be used inside nested OpenMP directives.
+  !$omp parallel
+    !$omp parallel copyin(/tc/)
+      xz = xz + 10
+    !$omp end parallel
+  !$omp end parallel
+
+  !$omp parallel
+    !$omp single
+      xz = 18
+    !$omp end single copyprivate(/tc/)
+  !$omp end parallel
 end

--- a/flang/test/Semantics/OpenMP/resolve03.f90
+++ b/flang/test/Semantics/OpenMP/resolve03.f90
@@ -8,8 +8,8 @@
 
   common /c/ a, b
   integer a(3), b
-  common /tc/ xy
-  integer xz
+  common /tc/ x
+  integer x
   !$omp threadprivate(/tc/)
 
   A = 1
@@ -23,16 +23,25 @@
   end block
   print *, a, b
 
+  !$omp parallel
+    block
+      !$omp single
+        x = 18
+      !ERROR: COMMON block must be declared in the same scoping unit in which the OpenMP directive or clause appears
+      !$omp end single copyprivate(/tc/)
+    end block
+  !$omp end parallel
+
   ! Common block names may be used inside nested OpenMP directives.
   !$omp parallel
     !$omp parallel copyin(/tc/)
-      xz = xz + 10
+      x = x + 10
     !$omp end parallel
   !$omp end parallel
 
   !$omp parallel
     !$omp single
-      xz = 18
+      x = 18
     !$omp end single copyprivate(/tc/)
   !$omp end parallel
 end


### PR DESCRIPTION
COMMON block names must be declared in the same scoping unit in
which the OpenMP directive or clause appears, but OpenMP
constructs must not be considered as scoping units. Instead,
consider only program units and block constructs as such.