### PR TITLE
[lldb][lit] Add MallocNanoZone envvar to Darwin ASan builds

### DIFF
--- a/lldb/test/API/lit.cfg.py
+++ b/lldb/test/API/lit.cfg.py
@@ -121,6 +121,7 @@ if is_configured("llvm_use_sanitizer"):
             config.environment["DYLD_INSERT_LIBRARIES"] = find_sanitizer_runtime(
                 "libclang_rt.asan_osx_dynamic.dylib"
             )
+            config.environment["MallocNanoZone"] = "0"
 
     if "Thread" in config.llvm_use_sanitizer:
         config.environment["TSAN_OPTIONS"] = "halt_on_error=1"

--- a/lldb/test/Shell/lit.cfg.py
+++ b/lldb/test/Shell/lit.cfg.py
@@ -52,6 +52,8 @@ llvm_config.with_system_environment(
 # Enable sanitizer runtime flags.
 config.environment["ASAN_OPTIONS"] = "detect_stack_use_after_return=1"
 config.environment["TSAN_OPTIONS"] = "halt_on_error=1"
+if "Darwin" in config.host_os:
+    config.environment["MallocNanoZone"] = "0"
 
 # Support running the test suite under the lldb-repro wrapper. This makes it
 # possible to capture a test suite run and then rerun all the test from the


### PR DESCRIPTION
When builds on Darwin are configured with ASan, running tests will emit a warning about malloc's nano zone that can interfere with the test output and cause failures. Setting the environment variable `MallocNanoZone` to 0 will remove this warning and allow the tests to run as normal.