### PR TITLE
[clangd] Don't ignore external HFI in `SymbolCollector`

### DIFF
--- a/clang-tools-extra/clangd/index/SymbolCollector.cpp
+++ b/clang-tools-extra/clangd/index/SymbolCollector.cpp
@@ -409,7 +409,7 @@ private:
     // Framework headers are spelled as <FrameworkName/Foo.h>, not
     // "path/FrameworkName.framework/Headers/Foo.h".
     auto &HS = PP->getHeaderSearchInfo();
-    if (const auto *HFI = HS.getExistingLocalFileInfo(*FE))
+    if (const auto *HFI = HS.getExistingFileInfo(*FE))
       if (!HFI->Framework.empty())
         if (auto Spelling =
                 getFrameworkHeaderIncludeSpelling(*FE, HFI->Framework, HS))


### PR DESCRIPTION
The `FileEntry` corresponds to a `FileID` containing the `SourceLocation` of a `NamedDecl` which (I think) might've been deserialized from a PCM file. Considering external `HeaderFileInfo` here is most likely the right thing to do here in order to get the correct spelling in case the current compiler instance has not register this file as a header yet.