### PR TITLE
[clang][docs] Modernize attribute docs for darwin specifics

### DIFF
--- a/clang/include/clang/Basic/AttrDocs.td
+++ b/clang/include/clang/Basic/AttrDocs.td
@@ -1604,23 +1604,31 @@ specifies availability for the current target platform, the availability
 attributes are ignored. Supported platforms are:
 
 ``ios``
-  Apple's iOS operating system. The minimum deployment target is specified by
-  the ``-mios-version-min=*version*`` or ``-miphoneos-version-min=*version*``
-  command-line arguments.
+  Apple's iOS operating system. The minimum deployment target is specified 
+  as part of the triple. Alternatively, it can be specified by the 
+  ``-mtargetos=ios*version*`` command-line argument.
 
 ``macos``
-  Apple's macOS operating system. The minimum deployment target is
-  specified by the ``-mmacosx-version-min=*version*`` command-line argument.
-  ``macosx`` is supported for backward-compatibility reasons, but it is
-  deprecated.
+  Apple's macOS operating system. The minimum deployment target is specified 
+  as part of the triple. Alternatively, it can be specified by the 
+  ``-mtargetos=macos*version*`` or ``-mtargetos=macosx*version*``
+  command-line arguments. ``macosx`` is supported for backward-compatibility 
+  reasons, but it is deprecated.
 
 ``tvos``
-  Apple's tvOS operating system. The minimum deployment target is specified by
-  the ``-mtvos-version-min=*version*`` command-line argument.
+  Apple's tvOS operating system. The minimum deployment target is specified 
+  as part of the triple. Alternatively, it can be specified by the 
+  the ``-mtargetos=tvos*version*`` command-line argument.
 
 ``watchos``
-  Apple's watchOS operating system. The minimum deployment target is specified by
-  the ``-mwatchos-version-min=*version*`` command-line argument.
+  Apple's watchOS operating system. The minimum deployment target is specified
+  as part of the triple. Alternatively, it can be specified by the 
+  the ``-mtargetos=watchos*version*`` command-line argument.
+
+``visionos``
+  Apple's visionOS operating system. The minimum deployment target is specified
+  as part of the triple. Alternatively, it can be specified by the 
+  the ``-mtargetos=visionos*version*`` command-line argument.
 
 ``driverkit``
   Apple's DriverKit userspace kernel extensions. The minimum deployment target

--- a/clang/include/clang/Basic/AttrDocs.td
+++ b/clang/include/clang/Basic/AttrDocs.td
@@ -1605,34 +1605,39 @@ attributes are ignored. Supported platforms are:
 
 ``ios``
   Apple's iOS operating system. The minimum deployment target is specified 
-  as part of the triple. Alternatively, it can be specified by the 
-  ``-mtargetos=ios*version*`` command-line argument.
+  as part of the ``-target *arch*-apple-ios*version*`` command line argument. 
+  Alternatively, it can be specified by the ``-mtargetos=ios*version*`` 
+  command-line argument.
 
 ``macos``
   Apple's macOS operating system. The minimum deployment target is specified 
-  as part of the triple. Alternatively, it can be specified by the 
-  ``-mtargetos=macos*version*`` or ``-mtargetos=macosx*version*``
-  command-line arguments. ``macosx`` is supported for backward-compatibility 
-  reasons, but it is deprecated.
+  as part of the ``-target *arch*-apple-macos*version*`` command line argument. 
+  Alternatively, it can be specified by the ``-mtargetos=macos*version*`` 
+  command-line argument. ``macosx`` is supported for 
+  backward-compatibility reasons, but it is deprecated.
 
 ``tvos``
   Apple's tvOS operating system. The minimum deployment target is specified 
-  as part of the triple. Alternatively, it can be specified by the 
-  the ``-mtargetos=tvos*version*`` command-line argument.
+  as part of the ``-target *arch*-apple-tvos*version*`` command line argument. 
+  Alternatively, it can be specified by the ``-mtargetos=tvos*version*`` 
+  command-line argument.
 
 ``watchos``
   Apple's watchOS operating system. The minimum deployment target is specified
-  as part of the triple. Alternatively, it can be specified by the 
-  the ``-mtargetos=watchos*version*`` command-line argument.
+  as part of the ``-target *arch*-apple-watchos*version*`` command line argument. 
+  Alternatively, it can be specified by the ``-mtargetos=watchos*version*`` 
+  command-line argument.
 
 ``visionos``
   Apple's visionOS operating system. The minimum deployment target is specified
-  as part of the triple. Alternatively, it can be specified by the 
-  the ``-mtargetos=visionos*version*`` command-line argument.
+  as part of the ``-target *arch*-apple-visionos*version*`` command line argument. 
+  Alternatively, it can be specified by the ``-mtargetos=visionos*version*`` 
+  command-line argument.
 
 ``driverkit``
   Apple's DriverKit userspace kernel extensions. The minimum deployment target
-  is specified as part of the triple.
+  is specified as part of the ``-target *arch*-apple-driverkit*version*`` 
+  command line argument.
 
 A declaration can typically be used even when deploying back to a platform
 version prior to when the declaration was introduced. When this happens, the

--- a/clang/test/Driver/mtargetos-darwin.c
+++ b/clang/test/Driver/mtargetos-darwin.c
@@ -4,6 +4,7 @@
 // RUN: %clang -mtargetos=ios14-macabi -arch arm64 -c %s -o %t.o -### 2>&1 | FileCheck --check-prefix=MACCATALYST %s
 // RUN: %clang -mtargetos=tvos14 -arch arm64 -c %s -o %t.o -### 2>&1 | FileCheck --check-prefix=TVOS %s
 // RUN: %clang -mtargetos=watchos7.1 -arch arm64 -c %s -o %t.o -### 2>&1 | FileCheck --check-prefix=WATCHOS %s
+// RUN: %clang -mtargetos=visionos1 -arch arm64 -c %s -o %t.o -### 2>&1 | FileCheck --check-prefix=VISIONOS %s
 
 // RUN: not %clang -target arm64-apple-ios14 -mtargetos=ios14 -arch arm64 -c %s -o %t.o -### 2>&1 | FileCheck --check-prefix=NOMIX1 %s
 // RUN: not %clang -mtargetos=ios14 -arch arm64 -miphoneos-version-min=14 -c %s -o %t.o -### 2>&1 | FileCheck --check-prefix=NOMIX2 %s
@@ -19,6 +20,7 @@
 // MACCATALYST: "-cc1" "-triple" "arm64-apple-ios14.0.0-macabi"
 // TVOS: "-cc1" "-triple" "arm64-apple-tvos14.0.0"
 // WATCHOS: "-cc1" "-triple" "arm64-apple-watchos7.1.0"
+// VISIONOS: "-cc1" "-triple" "arm64-apple-xros1.0.0"
 
 // NOMIX1: error: cannot specify '-mtargetos=ios14' along with '-target arm64-apple-ios14'
 // NOMIX2: error: cannot specify '-miphoneos-version-min=14' along with '-mtargetos=ios14'


### PR DESCRIPTION
* Generally recommend target triples. But replace `m*version-min` with `mtargetos`.
* Also include test coverage for -mtargetos=visionos