### PR TITLE
Fix override keyword being print to the left side

### DIFF
--- a/clang/include/clang/Basic/Attr.td
+++ b/clang/include/clang/Basic/Attr.td
@@ -1590,6 +1590,7 @@ def RegCall : DeclOrTypeAttr {
 }
 
 def Final : InheritableAttr {
+  let CanPrintOnLeft = 0;
   let Spellings = [CustomKeyword<"final">, CustomKeyword<"sealed">];
   let Accessors = [Accessor<"isSpelledAsSealed", [CustomKeyword<"sealed">]>];
   let SemaHandler = 0;
@@ -2472,6 +2473,7 @@ def Overloadable : Attr {
 }
 
 def Override : InheritableAttr {
+  let CanPrintOnLeft = 0;
   let Spellings = [CustomKeyword<"override">];
   let SemaHandler = 0;
   // Omitted from docs, since this is language syntax, not an attribute, as far

--- a/clang/test/AST/ast-dump-override-final.cpp
+++ b/clang/test/AST/ast-dump-override-final.cpp
@@ -1,0 +1,20 @@
+// This file contain tests to check if override and final are dumped in the
+// correct positions.
+
+// RUN: %clang_cc1 -ast-print -x c++ %s -o - | FileCheck %s
+
+// CHECK: class A {
+class A {
+  // CHECK-NEXT: virtual void f();
+  virtual void f();
+
+  // CHECK-NEXT: virtual void g() final;
+  virtual void g() final;
+} AA;
+
+// CHECK: class B : public A {
+class B : public A {
+  // CHECK-NEXT: virtual void f() override {
+  virtual void f() override {
+  };
+} B;


### PR DESCRIPTION
Previously, the `override` keyword in C++ was being print in the left side of a method decl, which is unsupported by C++ standard. This commit fixes that by setting the `CanPrintOnLeft` field to 0, forcing it to be print on the right side of the decl.

This comes from the fact that #87281 won't be backported into clang-18. However since classes with `override` keyword is broken in LLVM-18, I think this is still worth fixing.

@vgvassilev Please check if it works in your test cases.

Notice that this PR targets release/18.x, and not the main branch.