### PR TITLE
gn build: Define SANITIZER_COMMON_NO_REDEFINE_BUILTINS for ubsan_minimal.

### DIFF
--- a/llvm/utils/gn/secondary/compiler-rt/lib/ubsan_minimal/BUILD.gn
+++ b/llvm/utils/gn/secondary/compiler-rt/lib/ubsan_minimal/BUILD.gn
@@ -15,4 +15,5 @@ static_library("ubsan_minimal") {
   ]
   configs += [ "//llvm/utils/gn/build:crt_code" ]
   sources = [ "ubsan_minimal_handlers.cpp" ]
+  defines = [ "SANITIZER_COMMON_NO_REDEFINE_BUILTINS" ]
 }


### PR DESCRIPTION
Matches the cmake build.
