### PR TITLE
Revert "Fix error in unrecognized register name handling for "SBFrame.register""

### DIFF
--- a/lldb/bindings/interface/SBFrameExtensions.i
+++ b/lldb/bindings/interface/SBFrameExtensions.i
@@ -44,16 +44,6 @@ STRING_EXTENSION_OUTSIDE(SBFrame)
                 def __init__(self, regs):
                     self.regs = regs
 
-                def __iter__(self):
-                    return self.get_registers()
-
-                def get_registers(self):
-                    for i in range(0,len(self.regs)):
-                        rs = self.regs[i]
-                        for j in range (0,rs.num_children):
-                            reg = rs.GetChildAtIndex(j)
-                            yield reg
-                          
                 def __getitem__(self, key):
                     if type(key) is str:
                         for i in range(0,len(self.regs)):
@@ -62,7 +52,7 @@ STRING_EXTENSION_OUTSIDE(SBFrame)
                                 reg = rs.GetChildAtIndex(j)
                                 if reg.name == key: return reg
                     else:
-                        return SBValue()
+                        return lldb.SBValue()
 
             return registers_access(self.registers)
 

--- a/lldb/test/API/python_api/frame/TestFrames.py
+++ b/lldb/test/API/python_api/frame/TestFrames.py
@@ -73,19 +73,7 @@ class FrameAPITestCase(TestBase):
                 gpr_reg_set = lldbutil.get_GPRs(frame)
                 pc_value = gpr_reg_set.GetChildMemberWithName("pc")
                 self.assertTrue(pc_value, "We should have a valid PC.")
-                # Make sure we can also get this from the "register" property:
-                iterator_pc_value = 0
-                found_pc = False
-                for reg in frame.register:
-                    if reg.name == "pc":
-                        found_pc = True
-                        iterator_pc_value = int(reg.GetValue(), 0)
-                        break
-
                 pc_value_int = int(pc_value.GetValue(), 0)
-                self.assertTrue(found_pc, "Found the PC value in the register list")
-                self.assertEqual(iterator_pc_value, pc_value_int, "The methods of finding pc match")
-    
                 # Make sure on arm targets we dont mismatch PC value on the basis of thumb bit.
                 # Frame PC will not have thumb bit set in case of a thumb
                 # instruction as PC.


### PR DESCRIPTION
Reverts llvm/llvm-project#88047. TestFrames.py is failing on x86_64 GreenDragon: https://green.lab.llvm.org/job/llvm.org/view/LLDB/job/lldb-cmake/983/