### PR TITLE
[flang][OpenMP] Add test for checking overloaded operator in atomic update

### DIFF
--- a/flang/test/Semantics/OpenMP/atomic-update-overloaded-ops.f90
+++ b/flang/test/Semantics/OpenMP/atomic-update-overloaded-ops.f90
@@ -1,0 +1,31 @@
+! RUN: %python %S/../test_errors.py %s %flang_fc1 -fopenmp
+
+module new_operator
+    implicit none
+
+    interface operator(.MYOPERATOR.)
+       module procedure myprocedure
+    end interface
+contains
+    pure integer function myprocedure(param1, param2)
+        integer, intent(in) :: param1, param2
+        myprocedure = param1 + param2
+    end function
+end module
+
+program sample
+    use new_operator
+    implicit none
+    integer :: x, y 
+
+    !$omp atomic update
+        x = x / y
+     
+    !$omp atomic update
+    !ERROR: Invalid or missing operator in atomic update statement
+        x = x .MYOPERATOR. y
+
+    !$omp atomic
+    !ERROR: Invalid or missing operator in atomic update statement
+        x = x .MYOPERATOR. y
+end program


### PR DESCRIPTION
Atomic update expression does not allow overloaded user-defined operators. This PR adds a test case for the same; the semantic check is already existent.