### PR TITLE
[Clang] Fix test broken due to unsupported calling convention

### DIFF
--- a/clang/test/SemaCXX/gh84473.cpp
+++ b/clang/test/SemaCXX/gh84473.cpp
@@ -1,0 +1,11 @@
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -std=c++23 -fsyntax-only -verify %s
+// expected-no-diagnostics
+
+namespace GH84473_bug {
+void f1() {
+  int b;
+  (void) [=] [[gnu::regcall]] () {
+    (void) b;
+  };
+}
+}

--- a/clang/test/SemaCXX/lambda-expressions.cpp
+++ b/clang/test/SemaCXX/lambda-expressions.cpp
@@ -762,12 +762,3 @@ template auto t::operator()<int>(int a) const; // expected-note {{in instantiati
 
 }
 #endif
-
-namespace GH84473_bug {
-void f1() {
-  int b;
-  (void) [=] [[gnu::regcall]] () { // expected-warning {{an attribute specifier sequence in this position is a C++23 extension}}
-    (void) b;
-  };
-}
-}


### PR DESCRIPTION
#88428 ended up breaking CI because it included a test that uses the `regcall` calling convention, which isn’t supported on all targets; I’ve moved it into a separate file that sets the triple.