### PR TITLE
Add lldb-dap to Swift distributions

### DIFF
--- a/lldb/cmake/caches/Apple-lldb-Linux.cmake
+++ b/lldb/cmake/caches/Apple-lldb-Linux.cmake
@@ -5,6 +5,7 @@ set(LLVM_DISTRIBUTION_COMPONENTS
   lldb
   liblldb
   lldb-argdumper
+  lldb-dap
   lldb-server
   lldb-python-scripts
   CACHE STRING "")

--- a/lldb/cmake/caches/Apple-lldb-macOS.cmake
+++ b/lldb/cmake/caches/Apple-lldb-macOS.cmake
@@ -22,6 +22,7 @@ set(LLVM_DISTRIBUTION_COMPONENTS
   lldb
   liblldb
   lldb-argdumper
+  lldb-dap
   darwin-debug
   debugserver
   CACHE STRING "")


### PR DESCRIPTION
This includes the lldb-dap executable in the MacOS and Linux distributions of Swift. Currently there is a commit in the Apple repo to do this for just MacOS https://github.com/apple/llvm-project/pull/8176. This PR extends this to both Linux and MacOS and brings the change upstream.

@JDevlieghere @adrian-prantl 