### PR TITLE
Add new flag -Wpointer-integer-ordered-compare

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -249,7 +249,8 @@ Modified Compiler Flags
   grouped under ``-Wpointer-integer-compare`` and moved previously
   ungrouped diagnostics ``ext_typecheck_ordered_comparison_of_pointer_integer``,
   ``ext_typecheck_ordered_comparison_of_pointer_and_zero`` under
-  ``-Wpointer-integer-ordered-compare``. Fixes #GH88090
+  ``-Wpointer-integer-ordered-compare``.This also resolves false negative
+  for comparison between pointers and literal zero.  Fixes #GH88090
 
 
 Removed Compiler Flags

--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -245,6 +245,12 @@ Modified Compiler Flags
        f3 *c = (f3 *)x;
      }
 
+- Added a new diagnostic flag ``-Wpointer-integer-ordered-compare`` which is
+  grouped under ``-Wpointer-integer-compare`` and moved previously
+  ungrouped diagnostics ``ext_typecheck_ordered_comparison_of_pointer_integer``,
+  ``ext_typecheck_ordered_comparison_of_pointer_and_zero`` under
+  ``-Wpointer-integer-ordered-compare``. Fixes #GH88090
+
 
 Removed Compiler Flags
 -------------------------

--- a/clang/include/clang/Basic/DiagnosticGroups.td
+++ b/clang/include/clang/Basic/DiagnosticGroups.td
@@ -719,6 +719,7 @@ def PointerIntegerCompare : DiagGroup<"pointer-integer-compare",[PointerIntegerO
 def GNUVariableSizedTypeNotAtEnd : DiagGroup<"gnu-variable-sized-type-not-at-end">;
 def Varargs : DiagGroup<"varargs">;
 def XorUsedAsPow : DiagGroup<"xor-used-as-pow">;
+
 def Unsequenced : DiagGroup<"unsequenced">;
 // GCC name for -Wunsequenced
 def : DiagGroup<"sequence-point", [Unsequenced]>;

--- a/clang/include/clang/Basic/DiagnosticGroups.td
+++ b/clang/include/clang/Basic/DiagnosticGroups.td
@@ -714,10 +714,11 @@ def HeaderHygiene : DiagGroup<"header-hygiene">;
 def DuplicateDeclSpecifier : DiagGroup<"duplicate-decl-specifier">;
 def CompareDistinctPointerType : DiagGroup<"compare-distinct-pointer-types">;
 def GNUUnionCast : DiagGroup<"gnu-union-cast">;
+def PointerIntegerOrderedCompare : DiagGroup<"pointer-integer-ordered-compare">;
+def PointerIntegerCompare : DiagGroup<"pointer-integer-compare",[PointerIntegerOrderedCompare]>;
 def GNUVariableSizedTypeNotAtEnd : DiagGroup<"gnu-variable-sized-type-not-at-end">;
 def Varargs : DiagGroup<"varargs">;
 def XorUsedAsPow : DiagGroup<"xor-used-as-pow">;
-
 def Unsequenced : DiagGroup<"unsequenced">;
 // GCC name for -Wunsequenced
 def : DiagGroup<"sequence-point", [Unsequenced]>;

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -7272,9 +7272,11 @@ def err_typecheck_sub_ptr_compatible : Error<
   "%diff{$ and $ are not pointers to compatible types|"
   "pointers to incompatible types}0,1">;
 def ext_typecheck_ordered_comparison_of_pointer_integer : ExtWarn<
-  "ordered comparison between pointer and integer (%0 and %1)">;
+  "ordered comparison between pointer and integer (%0 and %1)">,
+  InGroup<PointerIntegerOrderedCompare>;
 def ext_typecheck_ordered_comparison_of_pointer_and_zero : Extension<
-  "ordered comparison between pointer and zero (%0 and %1) is an extension">;
+  "ordered comparison between pointer and zero (%0 and %1) is an extension">,
+  InGroup<PointerIntegerOrderedCompare>;
 def err_typecheck_ordered_comparison_of_pointer_and_zero : Error<
   "ordered comparison between pointer and zero (%0 and %1)">;
 def err_typecheck_three_way_comparison_of_pointer_and_zero : Error<
@@ -7299,7 +7301,7 @@ def err_typecheck_comparison_of_fptr_to_void : Error<
   "equality comparison between function pointer and void pointer (%0 and %1)">;
 def ext_typecheck_comparison_of_pointer_integer : ExtWarn<
   "comparison between pointer and integer (%0 and %1)">,
-  InGroup<DiagGroup<"pointer-integer-compare">>;
+  InGroup<PointerIntegerCompare>;
 def err_typecheck_comparison_of_pointer_integer : Error<
   "comparison between pointer and integer (%0 and %1)">;
 def ext_typecheck_comparison_of_distinct_pointers : ExtWarn<

--- a/clang/test/Misc/warning-flags.c
+++ b/clang/test/Misc/warning-flags.c
@@ -18,7 +18,7 @@ This test serves two purposes:
 
 The list of warnings below should NEVER grow.  It should gradually shrink to 0.
 
-CHECK: Warnings without flags (66):
+CHECK: Warnings without flags (65):
 
 CHECK-NEXT:   ext_expected_semi_decl_list
 CHECK-NEXT:   ext_explicit_specialization_storage_class
@@ -28,7 +28,6 @@ CHECK-NEXT:   ext_plain_complex
 CHECK-NEXT:   ext_template_arg_extra_parens
 CHECK-NEXT:   ext_template_spec_extra_headers
 CHECK-NEXT:   ext_typecheck_cond_incompatible_operands
-CHECK-NEXT:   ext_typecheck_ordered_comparison_of_pointer_integer
 CHECK-NEXT:   ext_using_undefined_std
 CHECK-NEXT:   pp_invalid_string_literal
 CHECK-NEXT:   pp_out_of_date_dependency
@@ -89,4 +88,4 @@ CHECK-NEXT:   warn_weak_import
 
 The list of warnings in -Wpedantic should NEVER grow.
 
-CHECK: Number in -Wpedantic (not covered by other -W flags): 26
+CHECK: Number in -Wpedantic (not covered by other -W flags): 25

--- a/clang/test/Sema/compare_pointers.c
+++ b/clang/test/Sema/compare_pointers.c
@@ -20,6 +20,7 @@ int test3(int *a){
 int test4(int *a){
     return a>1; // pointer-integer-ordered-warning{{ordered comparison between pointer and integer ('int *' and 'int')}}
 }
+
 int test5(int *a){
     int zero = 0;
     return a>=zero; // pointer-integer-ordered-warning{{ordered comparison between pointer and integer ('int *' and 'int')}}

--- a/clang/test/Sema/compare_pointers.c
+++ b/clang/test/Sema/compare_pointers.c
@@ -24,7 +24,3 @@ int test5(int *a){
     int zero = 0;
     return a>=zero; // pointer-integer-ordered-warning{{ordered comparison between pointer and integer ('int *' and 'int')}}
 }
-
-
-
-

--- a/clang/test/Sema/compare_pointers.c
+++ b/clang/test/Sema/compare_pointers.c
@@ -1,0 +1,30 @@
+// RUN: %clang_cc1 -Wno-pointer-integer-compare -Wpointer-integer-ordered-compare -fsyntax-only -verify=pointer-integer-ordered %s
+// RUN: %clang_cc1 -Wpointer-integer-compare -Wno-pointer-integer-ordered-compare -fsyntax-only -verify=pointer-integer %s
+
+void test1(int *a){
+    int b = 1;
+    short c = 1;
+    if(c<a) {}; // pointer-integer-ordered-warning{{ordered comparison between pointer and integer ('short' and 'int *')}}
+    if(a!=b) {}; // pointer-integer-warning{{comparison between pointer and integer ('int *' and 'int')}}
+    if(a == b) {}; // pointer-integer-warning{{comparison between pointer and integer ('int *' and 'int')}}
+}
+
+int test2(int *a){
+    return a>=0; // pointer-integer-ordered-warning{{ordered comparison between pointer and zero ('int *' and 'int') is an extension}}
+}
+
+int test3(int *a){
+    return a>=1; // pointer-integer-ordered-warning{{ordered comparison between pointer and integer ('int *' and 'int')}}
+}
+
+int test4(int *a){
+    return a>1; // pointer-integer-ordered-warning{{ordered comparison between pointer and integer ('int *' and 'int')}}
+}
+int test5(int *a){
+    int zero = 0;
+    return a>=zero; // pointer-integer-ordered-warning{{ordered comparison between pointer and integer ('int *' and 'int')}}
+}
+
+
+
+


### PR DESCRIPTION
**Overview:**
This pull request fixes #88090 where a false negative issue related to `-Wpointer-integer-compare` failing on comparison between a pointer and zero.

**Testing:**
- Tested the updated code.
- Verified that other functionalities remain unaffected.

**Dependencies:**
- No dependencies on other pull requests.

**CC:**
- @AaronBallman , @shafik 

