### PR TITLE
[clang-format] revert to string << string handling to previous default

### DIFF
--- a/clang/docs/ClangFormatStyleOptions.rst
+++ b/clang/docs/ClangFormatStyleOptions.rst
@@ -3291,7 +3291,7 @@ the configuration (without a prefix: ``Auto``).
          << "\n";
 
   * ``BCOS_Always`` (in configuration: ``Always``)
-    Break between adjacent items
+    Break between adjacent chevrons.
 
     .. code-block:: c++
 

--- a/clang/docs/ClangFormatStyleOptions.rst
+++ b/clang/docs/ClangFormatStyleOptions.rst
@@ -3258,6 +3258,40 @@ the configuration (without a prefix: ``Auto``).
          firstValue :
          SecondValueVeryVeryVeryVeryLong;
 
+.. _BreakChevronOperator:
+
+**BreakChevronOperator** (``BreakChevronOperatorStyle``) :versionbadge:`clang-format 19` :ref:`¶ <BreakChevronOperator>`
+  Break Between Chevron Operators
+
+  Possible values:
+
+  * ``BCOS_Never`` (in configuration: ``Never``)
+    Break using ColumnLimit rules.
+
+    .. code-block:: c++
+
+      os << "aaaaa" << "bbbbb" << "\n";
+
+  * ``BCOS_BetweenStrings`` (in configuration: ``BetweenStrings``)
+    Break between adjacent strings.
+
+    .. code-block:: c++
+
+      os << "aaaaa"
+         << "bbbbb"
+         << "\n";
+
+  * ``BCOS_BetweenNewlineStrings`` (in configuration: ``BetweenNewlineStrings``)
+    Break between adjacent strings that end with \n.
+
+    .. code-block:: c++
+
+      os << "aaaaa\n"
+         << "bbbbb" << "ccccc\n"
+         << "\n";
+
+
+
 .. _BreakConstructorInitializers:
 
 **BreakConstructorInitializers** (``BreakConstructorInitializersStyle``) :versionbadge:`clang-format 5` :ref:`¶ <BreakConstructorInitializers>`

--- a/clang/docs/ClangFormatStyleOptions.rst
+++ b/clang/docs/ClangFormatStyleOptions.rst
@@ -3258,50 +3258,6 @@ the configuration (without a prefix: ``Auto``).
          firstValue :
          SecondValueVeryVeryVeryVeryLong;
 
-.. _BreakChevronOperator:
-
-**BreakChevronOperator** (``BreakChevronOperatorStyle``) :versionbadge:`clang-format 19` :ref:`¶ <BreakChevronOperator>`
-  Break Between Chevron Operators
-
-  Possible values:
-
-  * ``BCOS_Never`` (in configuration: ``Never``)
-    Break using ColumnLimit rules.
-
-    .. code-block:: c++
-
-      os << "aaaaa" << "bbbbb" << "\n";
-
-  * ``BCOS_BetweenStrings`` (in configuration: ``BetweenStrings``)
-    Break between adjacent strings.
-
-    .. code-block:: c++
-
-      os << "aaaaa"
-         << "bbbbb"
-         << "\n";
-
-  * ``BCOS_BetweenNewlineStrings`` (in configuration: ``BetweenNewlineStrings``)
-    Break between adjacent strings that end with \n.
-
-    .. code-block:: c++
-
-      os << "aaaaa\n"
-         << "bbbbb" << "ccccc\n"
-         << "\n";
-
-  * ``BCOS_Always`` (in configuration: ``Always``)
-    Break between adjacent chevrons.
-
-    .. code-block:: c++
-
-      os << "aaaaa\n"
-         << "bbbbb"
-         << "ccccc\n"
-         << "\n";
-
-
-
 .. _BreakConstructorInitializers:
 
 **BreakConstructorInitializers** (``BreakConstructorInitializersStyle``) :versionbadge:`clang-format 5` :ref:`¶ <BreakConstructorInitializers>`
@@ -3400,6 +3356,50 @@ the configuration (without a prefix: ``Auto``).
        class Foo : Base1,
                    Base2
        {};
+
+
+
+.. _BreakStreamOperator:
+
+**BreakStreamOperator** (``BreakStreamOperatorStyle``) :versionbadge:`clang-format 19` :ref:`¶ <BreakStreamOperator>`
+  Break Between Stream Operators.
+
+  Possible values:
+
+  * ``BCOS_Normal`` (in configuration: ``Normal``)
+    Break using ColumnLimit rules.
+
+    .. code-block:: c++
+
+      os << "aaaaa" << "bbbbb" << "\n";
+
+  * ``BCOS_BetweenStrings`` (in configuration: ``BetweenStrings``)
+    Break between adjacent strings.
+
+    .. code-block:: c++
+
+      os << "aaaaa"
+         << "bbbbb"
+         << "\n";
+
+  * ``BCOS_BetweenNewlineStrings`` (in configuration: ``BetweenNewlineStrings``)
+    Break between adjacent strings that end with \n.
+
+    .. code-block:: c++
+
+      os << "aaaaa\n"
+         << "bbbbb" << "ccccc\n"
+         << "\n";
+
+  * ``BCOS_Always`` (in configuration: ``Always``)
+    Break between adjacent stream operations.
+
+    .. code-block:: c++
+
+      os << "aaaaa\n"
+         << "bbbbb"
+         << "ccccc\n"
+         << "\n";
 
 
 

--- a/clang/docs/ClangFormatStyleOptions.rst
+++ b/clang/docs/ClangFormatStyleOptions.rst
@@ -3290,6 +3290,16 @@ the configuration (without a prefix: ``Auto``).
          << "bbbbb" << "ccccc\n"
          << "\n";
 
+  * ``BCOS_Always`` (in configuration: ``Always``)
+    Break between adjacent items
+
+    .. code-block:: c++
+
+      os << "aaaaa\n"
+         << "bbbbb"
+         << "ccccc\n"
+         << "\n";
+
 
 
 .. _BreakConstructorInitializers:

--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -671,6 +671,8 @@ clang-format
   ``BreakTemplateDeclarations``.
 - ``AlwaysBreakAfterReturnType`` is deprecated and renamed to
   ``BreakAfterReturnType``.
+- ``BreakChevronOperator`` Style is added and the previous default
+  of breaking between strings is reverted.
 
 libclang
 --------

--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -671,7 +671,7 @@ clang-format
   ``BreakTemplateDeclarations``.
 - ``AlwaysBreakAfterReturnType`` is deprecated and renamed to
   ``BreakAfterReturnType``.
-- ``BreakChevronOperator`` Style is added and the previous default
+- ``BreakStreamOperator`` Style is added and the previous default
   of breaking between strings is reverted.
 
 libclang

--- a/clang/include/clang/Format/Format.h
+++ b/clang/include/clang/Format/Format.h
@@ -2193,41 +2193,6 @@ struct FormatStyle {
   /// \version 3.7
   bool BreakBeforeTernaryOperators;
 
-  /// Different ways to Break Between Stream Operators.
-  enum BreakStreamOperatorStyle : int8_t {
-    /// Break using ColumnLimit rules.
-    /// \code
-    ///   os << "aaaaa" << "bbbbb" << "\n";
-    /// \endcode
-    BCOS_Normal,
-    /// Break between adjacent strings.
-    /// \code
-    ///   os << "aaaaa"
-    ///      << "bbbbb"
-    ///      << "\n";
-    /// \endcode
-    BCOS_BetweenStrings,
-    /// Break between adjacent strings that end with \n.
-    /// \code
-    ///   os << "aaaaa\n"
-    ///      << "bbbbb" << "ccccc\n"
-    ///      << "\n";
-    /// \endcode
-    BCOS_BetweenNewlineStrings,
-    /// Break between adjacent stream operations.
-    /// \code
-    ///   os << "aaaaa\n"
-    ///      << "bbbbb"
-    ///      << "ccccc\n"
-    ///      << "\n";
-    /// \endcode
-    BCOS_Always
-  };
-
-  /// Break Between Stream Operators.
-  /// \version 19
-  BreakStreamOperatorStyle BreakStreamOperator;
-
   /// Different ways to break initializers.
   enum BreakConstructorInitializersStyle : int8_t {
     /// Break constructor initializers before the colon and after the commas.
@@ -2382,6 +2347,41 @@ struct FormatStyle {
   /// The inheritance list style to use.
   /// \version 7
   BreakInheritanceListStyle BreakInheritanceList;
+
+  /// Different ways to Break Between Stream Operators.
+  enum BreakStreamOperatorStyle : int8_t {
+    /// Break using ColumnLimit rules.
+    /// \code
+    ///   os << "aaaaa" << "bbbbb" << "\n";
+    /// \endcode
+    BCOS_Normal,
+    /// Break between adjacent strings.
+    /// \code
+    ///   os << "aaaaa"
+    ///      << "bbbbb"
+    ///      << "\n";
+    /// \endcode
+    BCOS_BetweenStrings,
+    /// Break between adjacent strings that end with \n.
+    /// \code
+    ///   os << "aaaaa\n"
+    ///      << "bbbbb" << "ccccc\n"
+    ///      << "\n";
+    /// \endcode
+    BCOS_BetweenNewlineStrings,
+    /// Break between adjacent stream operations.
+    /// \code
+    ///   os << "aaaaa\n"
+    ///      << "bbbbb"
+    ///      << "ccccc\n"
+    ///      << "\n";
+    /// \endcode
+    BCOS_Always
+  };
+
+  /// Break Between Stream Operators.
+  /// \version 19
+  BreakStreamOperatorStyle BreakStreamOperator;
 
   /// The template declaration breaking style to use.
   /// \version 19

--- a/clang/include/clang/Format/Format.h
+++ b/clang/include/clang/Format/Format.h
@@ -2193,7 +2193,7 @@ struct FormatStyle {
   /// \version 3.7
   bool BreakBeforeTernaryOperators;
 
-  /// Different ways to Break Between Chevrons
+  /// Different ways to Break Between Chevrons.
   enum BreakChevronOperatorStyle : int8_t {
     /// Break using ColumnLimit rules.
     /// \code
@@ -2214,7 +2214,7 @@ struct FormatStyle {
     ///      << "\n";
     /// \endcode
     BCOS_BetweenNewlineStrings,
-    /// Break between adjacent items
+    /// Break between adjacent chevrons.
     /// \code
     ///   os << "aaaaa\n"
     ///      << "bbbbb"

--- a/clang/include/clang/Format/Format.h
+++ b/clang/include/clang/Format/Format.h
@@ -2193,13 +2193,13 @@ struct FormatStyle {
   /// \version 3.7
   bool BreakBeforeTernaryOperators;
 
-  /// Different ways to Break Between Chevrons.
-  enum BreakChevronOperatorStyle : int8_t {
+  /// Different ways to Break Between Stream Operators.
+  enum BreakStreamOperatorStyle : int8_t {
     /// Break using ColumnLimit rules.
     /// \code
     ///   os << "aaaaa" << "bbbbb" << "\n";
     /// \endcode
-    BCOS_Never,
+    BCOS_Normal,
     /// Break between adjacent strings.
     /// \code
     ///   os << "aaaaa"
@@ -2214,7 +2214,7 @@ struct FormatStyle {
     ///      << "\n";
     /// \endcode
     BCOS_BetweenNewlineStrings,
-    /// Break between adjacent chevrons.
+    /// Break between adjacent stream operations.
     /// \code
     ///   os << "aaaaa\n"
     ///      << "bbbbb"
@@ -2224,9 +2224,9 @@ struct FormatStyle {
     BCOS_Always
   };
 
-  /// Break Between Chevron Operators
+  /// Break Between Stream Operators.
   /// \version 19
-  BreakChevronOperatorStyle BreakChevronOperator;
+  BreakStreamOperatorStyle BreakStreamOperator;
 
   /// Different ways to break initializers.
   enum BreakConstructorInitializersStyle : int8_t {
@@ -4986,7 +4986,7 @@ struct FormatStyle {
            BreakBeforeConceptDeclarations == R.BreakBeforeConceptDeclarations &&
            BreakBeforeInlineASMColon == R.BreakBeforeInlineASMColon &&
            BreakBeforeTernaryOperators == R.BreakBeforeTernaryOperators &&
-           BreakChevronOperator == R.BreakChevronOperator &&
+           BreakStreamOperator == R.BreakStreamOperator &&
            BreakConstructorInitializers == R.BreakConstructorInitializers &&
            BreakFunctionDefinitionParameters ==
                R.BreakFunctionDefinitionParameters &&

--- a/clang/include/clang/Format/Format.h
+++ b/clang/include/clang/Format/Format.h
@@ -2213,7 +2213,15 @@ struct FormatStyle {
     ///      << "bbbbb" << "ccccc\n"
     ///      << "\n";
     /// \endcode
-    BCOS_BetweenNewlineStrings
+    BCOS_BetweenNewlineStrings,
+    /// Break between adjacent items
+    /// \code
+    ///   os << "aaaaa\n"
+    ///      << "bbbbb"
+    ///      << "ccccc\n"
+    ///      << "\n";
+    /// \endcode
+    BCOS_Always
   };
 
   /// Break Between Chevron Operators

--- a/clang/include/clang/Format/Format.h
+++ b/clang/include/clang/Format/Format.h
@@ -2193,6 +2193,33 @@ struct FormatStyle {
   /// \version 3.7
   bool BreakBeforeTernaryOperators;
 
+  /// Different ways to Break Between Chevrons
+  enum BreakChevronOperatorStyle : int8_t {
+    /// Break using ColumnLimit rules.
+    /// \code
+    ///   os << "aaaaa" << "bbbbb" << "\n";
+    /// \endcode
+    BCOS_Never,
+    /// Break between adjacent strings.
+    /// \code
+    ///   os << "aaaaa"
+    ///      << "bbbbb"
+    ///      << "\n";
+    /// \endcode
+    BCOS_BetweenStrings,
+    /// Break between adjacent strings that end with \n.
+    /// \code
+    ///   os << "aaaaa\n"
+    ///      << "bbbbb" << "ccccc\n"
+    ///      << "\n";
+    /// \endcode
+    BCOS_BetweenNewlineStrings
+  };
+
+  /// Break Between Chevron Operators
+  /// \version 19
+  BreakChevronOperatorStyle BreakChevronOperator;
+
   /// Different ways to break initializers.
   enum BreakConstructorInitializersStyle : int8_t {
     /// Break constructor initializers before the colon and after the commas.
@@ -4951,6 +4978,7 @@ struct FormatStyle {
            BreakBeforeConceptDeclarations == R.BreakBeforeConceptDeclarations &&
            BreakBeforeInlineASMColon == R.BreakBeforeInlineASMColon &&
            BreakBeforeTernaryOperators == R.BreakBeforeTernaryOperators &&
+           BreakChevronOperator == R.BreakChevronOperator &&
            BreakConstructorInitializers == R.BreakConstructorInitializers &&
            BreakFunctionDefinitionParameters ==
                R.BreakFunctionDefinitionParameters &&

--- a/clang/lib/Format/Format.cpp
+++ b/clang/lib/Format/Format.cpp
@@ -4147,4 +4147,3 @@ bool isClangFormatOff(StringRef Comment) {
 
 } // namespace format
 } // namespace clang
-                    

--- a/clang/lib/Format/Format.cpp
+++ b/clang/lib/Format/Format.cpp
@@ -244,18 +244,6 @@ struct ScalarEnumerationTraits<FormatStyle::BreakBeforeInlineASMColonStyle> {
 };
 
 template <>
-struct ScalarEnumerationTraits<FormatStyle::BreakStreamOperatorStyle> {
-  static void enumeration(IO &IO,
-                          FormatStyle::BreakStreamOperatorStyle &Value) {
-    IO.enumCase(Value, "Normal", FormatStyle::BCOS_Normal);
-    IO.enumCase(Value, "BetweenStrings", FormatStyle::BCOS_BetweenStrings);
-    IO.enumCase(Value, "BetweenNewlineStrings",
-                FormatStyle::BCOS_BetweenNewlineStrings);
-    IO.enumCase(Value, "Always", FormatStyle::BCOS_Always);
-  }
-};
-
-template <>
 struct ScalarEnumerationTraits<FormatStyle::BreakConstructorInitializersStyle> {
   static void
   enumeration(IO &IO, FormatStyle::BreakConstructorInitializersStyle &Value) {
@@ -273,6 +261,18 @@ struct ScalarEnumerationTraits<FormatStyle::BreakInheritanceListStyle> {
     IO.enumCase(Value, "BeforeComma", FormatStyle::BILS_BeforeComma);
     IO.enumCase(Value, "AfterColon", FormatStyle::BILS_AfterColon);
     IO.enumCase(Value, "AfterComma", FormatStyle::BILS_AfterComma);
+  }
+};
+
+template <>
+struct ScalarEnumerationTraits<FormatStyle::BreakStreamOperatorStyle> {
+  static void enumeration(IO &IO,
+                          FormatStyle::BreakStreamOperatorStyle &Value) {
+    IO.enumCase(Value, "Normal", FormatStyle::BCOS_Normal);
+    IO.enumCase(Value, "BetweenStrings", FormatStyle::BCOS_BetweenStrings);
+    IO.enumCase(Value, "BetweenNewlineStrings",
+                FormatStyle::BCOS_BetweenNewlineStrings);
+    IO.enumCase(Value, "Always", FormatStyle::BCOS_Always);
   }
 };
 
@@ -1479,10 +1479,10 @@ FormatStyle getLLVMStyle(FormatStyle::LanguageKind Language) {
   LLVMStyle.BreakBeforeConceptDeclarations = FormatStyle::BBCDS_Always;
   LLVMStyle.BreakBeforeInlineASMColon = FormatStyle::BBIAS_OnlyMultiline;
   LLVMStyle.BreakBeforeTernaryOperators = true;
-  LLVMStyle.BreakStreamOperator = FormatStyle::BCOS_BetweenStrings;
   LLVMStyle.BreakConstructorInitializers = FormatStyle::BCIS_BeforeColon;
   LLVMStyle.BreakFunctionDefinitionParameters = false;
   LLVMStyle.BreakInheritanceList = FormatStyle::BILS_BeforeColon;
+  LLVMStyle.BreakStreamOperator = FormatStyle::BCOS_BetweenStrings;
   LLVMStyle.BreakStringLiterals = true;
   LLVMStyle.BreakTemplateDeclarations = FormatStyle::BTDS_MultiLine;
   LLVMStyle.ColumnLimit = 80;

--- a/clang/lib/Format/Format.cpp
+++ b/clang/lib/Format/Format.cpp
@@ -244,6 +244,17 @@ struct ScalarEnumerationTraits<FormatStyle::BreakBeforeInlineASMColonStyle> {
 };
 
 template <>
+struct ScalarEnumerationTraits<FormatStyle::BreakChevronOperatorStyle> {
+  static void enumeration(IO &IO,
+                          FormatStyle::BreakChevronOperatorStyle &Value) {
+    IO.enumCase(Value, "Never", FormatStyle::BCOS_Never);
+    IO.enumCase(Value, "BetweenStrings", FormatStyle::BCOS_BetweenStrings);
+    IO.enumCase(Value, "BetweenNewlineStrings",
+                FormatStyle::BCOS_BetweenNewlineStrings);
+  }
+};
+
+template <>
 struct ScalarEnumerationTraits<FormatStyle::BreakConstructorInitializersStyle> {
   static void
   enumeration(IO &IO, FormatStyle::BreakConstructorInitializersStyle &Value) {
@@ -953,6 +964,7 @@ template <> struct MappingTraits<FormatStyle> {
                    Style.BreakBeforeInlineASMColon);
     IO.mapOptional("BreakBeforeTernaryOperators",
                    Style.BreakBeforeTernaryOperators);
+    IO.mapOptional("BreakChevronOperator", Style.BreakChevronOperator);
     IO.mapOptional("BreakConstructorInitializers",
                    Style.BreakConstructorInitializers);
     IO.mapOptional("BreakFunctionDefinitionParameters",
@@ -1466,6 +1478,7 @@ FormatStyle getLLVMStyle(FormatStyle::LanguageKind Language) {
   LLVMStyle.BreakBeforeConceptDeclarations = FormatStyle::BBCDS_Always;
   LLVMStyle.BreakBeforeInlineASMColon = FormatStyle::BBIAS_OnlyMultiline;
   LLVMStyle.BreakBeforeTernaryOperators = true;
+  LLVMStyle.BreakChevronOperator = FormatStyle::BCOS_BetweenStrings;
   LLVMStyle.BreakConstructorInitializers = FormatStyle::BCIS_BeforeColon;
   LLVMStyle.BreakFunctionDefinitionParameters = false;
   LLVMStyle.BreakInheritanceList = FormatStyle::BILS_BeforeColon;

--- a/clang/lib/Format/Format.cpp
+++ b/clang/lib/Format/Format.cpp
@@ -251,6 +251,7 @@ struct ScalarEnumerationTraits<FormatStyle::BreakChevronOperatorStyle> {
     IO.enumCase(Value, "BetweenStrings", FormatStyle::BCOS_BetweenStrings);
     IO.enumCase(Value, "BetweenNewlineStrings",
                 FormatStyle::BCOS_BetweenNewlineStrings);
+    IO.enumCase(Value, "Always", FormatStyle::BCOS_Always);
   }
 };
 
@@ -4146,3 +4147,4 @@ bool isClangFormatOff(StringRef Comment) {
 
 } // namespace format
 } // namespace clang
+                    

--- a/clang/lib/Format/Format.cpp
+++ b/clang/lib/Format/Format.cpp
@@ -244,10 +244,10 @@ struct ScalarEnumerationTraits<FormatStyle::BreakBeforeInlineASMColonStyle> {
 };
 
 template <>
-struct ScalarEnumerationTraits<FormatStyle::BreakChevronOperatorStyle> {
+struct ScalarEnumerationTraits<FormatStyle::BreakStreamOperatorStyle> {
   static void enumeration(IO &IO,
-                          FormatStyle::BreakChevronOperatorStyle &Value) {
-    IO.enumCase(Value, "Never", FormatStyle::BCOS_Never);
+                          FormatStyle::BreakStreamOperatorStyle &Value) {
+    IO.enumCase(Value, "Normal", FormatStyle::BCOS_Normal);
     IO.enumCase(Value, "BetweenStrings", FormatStyle::BCOS_BetweenStrings);
     IO.enumCase(Value, "BetweenNewlineStrings",
                 FormatStyle::BCOS_BetweenNewlineStrings);
@@ -965,7 +965,7 @@ template <> struct MappingTraits<FormatStyle> {
                    Style.BreakBeforeInlineASMColon);
     IO.mapOptional("BreakBeforeTernaryOperators",
                    Style.BreakBeforeTernaryOperators);
-    IO.mapOptional("BreakChevronOperator", Style.BreakChevronOperator);
+    IO.mapOptional("BreakStreamOperator", Style.BreakStreamOperator);
     IO.mapOptional("BreakConstructorInitializers",
                    Style.BreakConstructorInitializers);
     IO.mapOptional("BreakFunctionDefinitionParameters",
@@ -1479,7 +1479,7 @@ FormatStyle getLLVMStyle(FormatStyle::LanguageKind Language) {
   LLVMStyle.BreakBeforeConceptDeclarations = FormatStyle::BBCDS_Always;
   LLVMStyle.BreakBeforeInlineASMColon = FormatStyle::BBIAS_OnlyMultiline;
   LLVMStyle.BreakBeforeTernaryOperators = true;
-  LLVMStyle.BreakChevronOperator = FormatStyle::BCOS_BetweenStrings;
+  LLVMStyle.BreakStreamOperator = FormatStyle::BCOS_BetweenStrings;
   LLVMStyle.BreakConstructorInitializers = FormatStyle::BCIS_BeforeColon;
   LLVMStyle.BreakFunctionDefinitionParameters = false;
   LLVMStyle.BreakInheritanceList = FormatStyle::BILS_BeforeColon;

--- a/clang/lib/Format/TokenAnnotator.cpp
+++ b/clang/lib/Format/TokenAnnotator.cpp
@@ -5611,6 +5611,22 @@ bool TokenAnnotator::mustBreakBefore(const AnnotatedLine &Line,
       return true;
     }
   }
+  if (Style.BreakChevronOperator == FormatStyle::BCOS_Always) {
+    // can be std::os or os
+    auto *FirstChevron = Right.Previous;
+    while (FirstChevron) {
+      if (FirstChevron->isOneOf(tok::lessless, tok::greater))
+        break;
+      FirstChevron = FirstChevron->Previous;
+    }
+
+    if (Right.is(tok::lessless) && FirstChevron)
+      return true;
+    if (Right.is(tok::greater) && Right.Next && Right.Next->is(tok::greater) &&
+        FirstChevron) {
+      return true;
+    }
+  }
   if (Right.is(TT_RequiresClause)) {
     switch (Style.RequiresClausePosition) {
     case FormatStyle::RCPS_OwnLine:

--- a/clang/lib/Format/TokenAnnotator.cpp
+++ b/clang/lib/Format/TokenAnnotator.cpp
@@ -5598,10 +5598,18 @@ bool TokenAnnotator::mustBreakBefore(const AnnotatedLine &Line,
   // FIXME: Breaking after newlines seems useful in general. Turn this into an
   // option and recognize more cases like endl etc, and break independent of
   // what comes after operator lessless.
-  if (Right.is(tok::lessless) && Right.Next &&
-      Right.Next->is(tok::string_literal) && Left.is(tok::string_literal) &&
-      Left.TokenText.ends_with("\\n\"")) {
-    return true;
+  if (Style.BreakChevronOperator == FormatStyle::BCOS_BetweenStrings) {
+    if (Right.is(tok::lessless) && Right.Next && Left.is(tok::string_literal) &&
+        Right.Next->is(tok::string_literal)) {
+      return true;
+    }
+  }
+  if (Style.BreakChevronOperator == FormatStyle::BCOS_BetweenNewlineStrings) {
+    if (Right.is(tok::lessless) && Right.Next &&
+        Right.Next->is(tok::string_literal) && Left.is(tok::string_literal) &&
+        Left.TokenText.ends_with("\\n\"")) {
+      return true;
+    }
   }
   if (Right.is(TT_RequiresClause)) {
     switch (Style.RequiresClausePosition) {

--- a/clang/unittests/Format/ConfigParseTest.cpp
+++ b/clang/unittests/Format/ConfigParseTest.cpp
@@ -396,6 +396,14 @@ TEST(ConfigParseTest, ParsesConfiguration) {
   CHECK_PARSE("BreakBeforeBinaryOperators: true", BreakBeforeBinaryOperators,
               FormatStyle::BOS_All);
 
+  Style.BreakChevronOperator = FormatStyle::BCOS_BetweenStrings;
+  CHECK_PARSE("BreakChevronOperator: BetweenNewlineStrings",
+              BreakChevronOperator, FormatStyle::BCOS_BetweenNewlineStrings);
+  CHECK_PARSE("BreakChevronOperator: Never", BreakChevronOperator,
+              FormatStyle::BCOS_Never);
+  CHECK_PARSE("BreakChevronOperator: BetweenStrings", BreakChevronOperator,
+              FormatStyle::BCOS_BetweenStrings);
+
   Style.BreakConstructorInitializers = FormatStyle::BCIS_BeforeColon;
   CHECK_PARSE("BreakConstructorInitializers: BeforeComma",
               BreakConstructorInitializers, FormatStyle::BCIS_BeforeComma);

--- a/clang/unittests/Format/ConfigParseTest.cpp
+++ b/clang/unittests/Format/ConfigParseTest.cpp
@@ -1461,4 +1461,3 @@ TEST(ConfigParseTest, GetStyleOfSpecificFile) {
 } // namespace
 } // namespace format
 } // namespace clang
-                    

--- a/clang/unittests/Format/ConfigParseTest.cpp
+++ b/clang/unittests/Format/ConfigParseTest.cpp
@@ -396,14 +396,14 @@ TEST(ConfigParseTest, ParsesConfiguration) {
   CHECK_PARSE("BreakBeforeBinaryOperators: true", BreakBeforeBinaryOperators,
               FormatStyle::BOS_All);
 
-  Style.BreakChevronOperator = FormatStyle::BCOS_BetweenStrings;
-  CHECK_PARSE("BreakChevronOperator: BetweenNewlineStrings",
-              BreakChevronOperator, FormatStyle::BCOS_BetweenNewlineStrings);
-  CHECK_PARSE("BreakChevronOperator: Never", BreakChevronOperator,
-              FormatStyle::BCOS_Never);
-  CHECK_PARSE("BreakChevronOperator: BetweenStrings", BreakChevronOperator,
+  Style.BreakStreamOperator = FormatStyle::BCOS_BetweenStrings;
+  CHECK_PARSE("BreakStreamOperator: BetweenNewlineStrings", BreakStreamOperator,
+              FormatStyle::BCOS_BetweenNewlineStrings);
+  CHECK_PARSE("BreakStreamOperator: Normal", BreakStreamOperator,
+              FormatStyle::BCOS_Normal);
+  CHECK_PARSE("BreakStreamOperator: BetweenStrings", BreakStreamOperator,
               FormatStyle::BCOS_BetweenStrings);
-  CHECK_PARSE("BreakChevronOperator: Always", BreakChevronOperator,
+  CHECK_PARSE("BreakStreamOperator: Always", BreakStreamOperator,
               FormatStyle::BCOS_Always);
 
   Style.BreakConstructorInitializers = FormatStyle::BCIS_BeforeColon;

--- a/clang/unittests/Format/ConfigParseTest.cpp
+++ b/clang/unittests/Format/ConfigParseTest.cpp
@@ -396,16 +396,6 @@ TEST(ConfigParseTest, ParsesConfiguration) {
   CHECK_PARSE("BreakBeforeBinaryOperators: true", BreakBeforeBinaryOperators,
               FormatStyle::BOS_All);
 
-  Style.BreakStreamOperator = FormatStyle::BCOS_BetweenStrings;
-  CHECK_PARSE("BreakStreamOperator: BetweenNewlineStrings", BreakStreamOperator,
-              FormatStyle::BCOS_BetweenNewlineStrings);
-  CHECK_PARSE("BreakStreamOperator: Normal", BreakStreamOperator,
-              FormatStyle::BCOS_Normal);
-  CHECK_PARSE("BreakStreamOperator: BetweenStrings", BreakStreamOperator,
-              FormatStyle::BCOS_BetweenStrings);
-  CHECK_PARSE("BreakStreamOperator: Always", BreakStreamOperator,
-              FormatStyle::BCOS_Always);
-
   Style.BreakConstructorInitializers = FormatStyle::BCIS_BeforeColon;
   CHECK_PARSE("BreakConstructorInitializers: BeforeComma",
               BreakConstructorInitializers, FormatStyle::BCIS_BeforeComma);
@@ -429,6 +419,16 @@ TEST(ConfigParseTest, ParsesConfiguration) {
   // For backward compatibility:
   CHECK_PARSE("BreakBeforeInheritanceComma: true", BreakInheritanceList,
               FormatStyle::BILS_BeforeComma);
+
+  Style.BreakStreamOperator = FormatStyle::BCOS_BetweenStrings;
+  CHECK_PARSE("BreakStreamOperator: BetweenNewlineStrings", BreakStreamOperator,
+              FormatStyle::BCOS_BetweenNewlineStrings);
+  CHECK_PARSE("BreakStreamOperator: Normal", BreakStreamOperator,
+              FormatStyle::BCOS_Normal);
+  CHECK_PARSE("BreakStreamOperator: BetweenStrings", BreakStreamOperator,
+              FormatStyle::BCOS_BetweenStrings);
+  CHECK_PARSE("BreakStreamOperator: Always", BreakStreamOperator,
+              FormatStyle::BCOS_Always);
 
   Style.PackConstructorInitializers = FormatStyle::PCIS_BinPack;
   CHECK_PARSE("PackConstructorInitializers: Never", PackConstructorInitializers,

--- a/clang/unittests/Format/ConfigParseTest.cpp
+++ b/clang/unittests/Format/ConfigParseTest.cpp
@@ -403,6 +403,8 @@ TEST(ConfigParseTest, ParsesConfiguration) {
               FormatStyle::BCOS_Never);
   CHECK_PARSE("BreakChevronOperator: BetweenStrings", BreakChevronOperator,
               FormatStyle::BCOS_BetweenStrings);
+  CHECK_PARSE("BreakChevronOperator: Always", BreakChevronOperator,
+              FormatStyle::BCOS_Always);
 
   Style.BreakConstructorInitializers = FormatStyle::BCIS_BeforeColon;
   CHECK_PARSE("BreakConstructorInitializers: BeforeComma",
@@ -1459,3 +1461,4 @@ TEST(ConfigParseTest, GetStyleOfSpecificFile) {
 } // namespace
 } // namespace format
 } // namespace clang
+                    

--- a/clang/unittests/Format/FormatTest.cpp
+++ b/clang/unittests/Format/FormatTest.cpp
@@ -27378,6 +27378,67 @@ TEST_F(FormatTest, StreamOutputOperator) {
   verifyFormat("std::cout << \"ggg\\n\"\n"
                "          << \"dddd\";",
                Style);
+
+  Style.BreakChevronOperator = FormatStyle::BCOS_Always;
+  verifyFormat("std::cout << \"aaaa\"\n"
+               "          << \"bbb\"\n"
+               "          << baz;",
+               Style);
+  verifyFormat("std::cout << \"ggg\\n\"\n"
+               "          << \"dddd\";",
+               Style);
+  verifyFormat("std::cout << \"aaaa\"\n"
+               "          << \"bbbbb\"\n"
+               "          << \"cccc\"\n"
+               "          << \"ddd\";",
+               Style);
+  verifyFormat("std::cout << \"aaaa\"\n"
+               "          << \"bbbbb\"\n"
+               "          << baz\n"
+               "          << \"cccc\"\n"
+               "          << \"ddd\";",
+               Style);
+  verifyFormat("cout << \"aaaa\"\n"
+               "     << \"bbbbb\"\n"
+               "     << baz\n"
+               "     << \"cccc\"\n"
+               "     << \"ddd\";",
+               Style);
+}
+
+TEST_F(FormatTest, StreamInputOperator) {
+  auto Style = getLLVMStyle();
+
+  Style.BreakChevronOperator = FormatStyle::BCOS_Never;
+  verifyFormat("std::in >> aaaa >> bbb >> baz;", Style);
+  verifyFormat("std::in >> ccc >> dddd;", Style);
+
+  Style.BreakChevronOperator = FormatStyle::BCOS_Always;
+  verifyFormat("std::in >> ccc;", Style);
+  verifyFormat("std::in >> aaaa\n"
+               "    >> bbb\n"
+               "    >> baz;",
+               Style);
+  verifyFormat("std::in >> ggg\n"
+               "    >> dddd;",
+               Style);
+  verifyFormat("std::in >> aaaa\n"
+               "    >> bbbbb\n"
+               "    >> cccc\n"
+               "    >> ddd;",
+               Style);
+  verifyFormat("std::in >> aaaa\n"
+               "    >> bbbbb\n"
+               "    >> baz\n"
+               "    >> cccc\n"
+               "    >> ddd;",
+               Style);
+  verifyFormat("in >> aaaa\n"
+               "    >> bbbbb\n"
+               "    >> baz\n"
+               "    >> cccc\n"
+               "    >> ddd;",
+               Style);
 }
 
 TEST_F(FormatTest, BreakAdjacentStringLiterals) {

--- a/clang/unittests/Format/FormatTest.cpp
+++ b/clang/unittests/Format/FormatTest.cpp
@@ -27361,11 +27361,11 @@ TEST_F(FormatTest, StreamOutputOperator) {
                "          << \"ddd\";",
                Style);
 
-  Style.BreakChevronOperator = FormatStyle::BCOS_Never;
+  Style.BreakStreamOperator = FormatStyle::BCOS_Normal;
   verifyFormat("std::cout << \"aaaa\" << \"bbb\" << baz;", Style);
   verifyFormat("std::cout << \"ccc\\n\" << \"dddd\";", Style);
 
-  Style.BreakChevronOperator = FormatStyle::BCOS_BetweenStrings;
+  Style.BreakStreamOperator = FormatStyle::BCOS_BetweenStrings;
   verifyFormat("std::cout << \"eee\"\n"
                "          << \"ffff\";",
                Style);
@@ -27373,13 +27373,13 @@ TEST_F(FormatTest, StreamOutputOperator) {
                "          << \"bbbb\";",
                Style);
 
-  Style.BreakChevronOperator = FormatStyle::BCOS_BetweenNewlineStrings;
+  Style.BreakStreamOperator = FormatStyle::BCOS_BetweenNewlineStrings;
   verifyFormat("std::cout << \"aaaa\" << \"bbb\" << baz;", Style);
   verifyFormat("std::cout << \"ggg\\n\"\n"
                "          << \"dddd\";",
                Style);
 
-  Style.BreakChevronOperator = FormatStyle::BCOS_Always;
+  Style.BreakStreamOperator = FormatStyle::BCOS_Always;
   verifyFormat("std::cout << \"aaaa\"\n"
                "          << \"bbb\"\n"
                "          << baz;",
@@ -27409,11 +27409,11 @@ TEST_F(FormatTest, StreamOutputOperator) {
 TEST_F(FormatTest, StreamInputOperator) {
   auto Style = getLLVMStyle();
 
-  Style.BreakChevronOperator = FormatStyle::BCOS_Never;
+  Style.BreakStreamOperator = FormatStyle::BCOS_Normal;
   verifyFormat("std::in >> aaaa >> bbb >> baz;", Style);
   verifyFormat("std::in >> ccc >> dddd;", Style);
 
-  Style.BreakChevronOperator = FormatStyle::BCOS_Always;
+  Style.BreakStreamOperator = FormatStyle::BCOS_Always;
   verifyFormat("std::in >> ccc;", Style);
   verifyFormat("std::in >> aaaa\n"
                "    >> bbb\n"

--- a/clang/unittests/Format/FormatTest.cpp
+++ b/clang/unittests/Format/FormatTest.cpp
@@ -27340,9 +27340,44 @@ TEST_F(FormatTest, PPDirectivesAndCommentsInBracedInit) {
 }
 
 TEST_F(FormatTest, StreamOutputOperator) {
-  verifyFormat("std::cout << \"foo\" << \"bar\" << baz;");
-  verifyFormat("std::cout << \"foo\\n\"\n"
-               "          << \"bar\";");
+  auto Style = getLLVMStyle();
+
+  // This should be the default as it was the original style, thats
+  // been in place since the beginning.
+  verifyFormat("std::cout << \"aaaa\"\n"
+               "          << \"bbbbb\";",
+               Style);
+  verifyFormat("std::cout << \"aaaa\"\n"
+               "          << \"bbbbb\"\n"
+               "          << \"ccc\";",
+               Style);
+  verifyFormat("std::cout << \"aaaa\"\n"
+               "          << \"bbbbb\"\n"
+               "          << \"cccc\"\n"
+               "          << \"ddd\";",
+               Style);
+  verifyFormat("std::cout << \"aaaa\"\n"
+               "          << \"bbbbb\" << baz << \"cccc\"\n"
+               "          << \"ddd\";",
+               Style);
+
+  Style.BreakChevronOperator = FormatStyle::BCOS_Never;
+  verifyFormat("std::cout << \"aaaa\" << \"bbb\" << baz;", Style);
+  verifyFormat("std::cout << \"ccc\\n\" << \"dddd\";", Style);
+
+  Style.BreakChevronOperator = FormatStyle::BCOS_BetweenStrings;
+  verifyFormat("std::cout << \"eee\"\n"
+               "          << \"ffff\";",
+               Style);
+  verifyFormat("std::cout << \"aa\\n\"\n"
+               "          << \"bbbb\";",
+               Style);
+
+  Style.BreakChevronOperator = FormatStyle::BCOS_BetweenNewlineStrings;
+  verifyFormat("std::cout << \"aaaa\" << \"bbb\" << baz;", Style);
+  verifyFormat("std::cout << \"ggg\\n\"\n"
+               "          << \"dddd\";",
+               Style);
 }
 
 TEST_F(FormatTest, BreakAdjacentStringLiterals) {
@@ -27363,3 +27398,4 @@ TEST_F(FormatTest, BreakAdjacentStringLiterals) {
 } // namespace test
 } // namespace format
 } // namespace clang
+                    

--- a/clang/unittests/Format/FormatTest.cpp
+++ b/clang/unittests/Format/FormatTest.cpp
@@ -27398,4 +27398,3 @@ TEST_F(FormatTest, BreakAdjacentStringLiterals) {
 } // namespace test
 } // namespace format
 } // namespace clang
-                    


### PR DESCRIPTION
Fixes 88433

A change made to the handling of chevron operators causes a large amount of flux in code bases that were previously using clang-format, this fix reverts that change to the default behaviour but adds that new behaviour behind a new option.