### PR TITLE
[Clang] Fix __is_trivially_equaltiy_comparable documentation

### DIFF
--- a/clang/docs/LanguageExtensions.rst
+++ b/clang/docs/LanguageExtensions.rst
@@ -1640,7 +1640,8 @@ The following type trait primitives are supported by Clang. Those traits marked
   were made trivially relocatable via the ``clang::trivial_abi`` attribute.
 * ``__is_trivially_equality_comparable`` (Clang): Returns true if comparing two
   objects of the provided type is known to be equivalent to comparing their
-  value representations.
+  object representations. Note that types containing padding bytes are never
+  trivially equality comparable.
 * ``__is_unbounded_array`` (C++, GNU, Microsoft, Embarcadero)
 * ``__is_union`` (C++, GNU, Microsoft, Embarcadero)
 * ``__is_unsigned`` (C++, Embarcadero):


### PR DESCRIPTION
Currently `__is_trivially_equality_comparable` is documented to return true if comparing the value representation is equivalent to calling the comparison operator, which is not quite what the trait actually checks. The traits actually checks that comparing the object representation is equivalent, which means that there cannot be padding bytes in the type.

