### PR TITLE
[InstCombine] Fold `sext(trunc nsw)` and `zext(trunc nuw)`

### DIFF
--- a/llvm/lib/Transforms/InstCombine/InstCombineCasts.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineCasts.cpp
@@ -1471,12 +1471,6 @@ Instruction *InstCombinerImpl::visitSExt(SExtInst &Sext) {
 
   Value *X;
   if (match(Src, m_Trunc(m_Value(X)))) {
-    // If the input has more sign bits than bits truncated, then convert
-    // directly to final type.
-    unsigned XBitSize = X->getType()->getScalarSizeInBits();
-    if (ComputeNumSignBits(X, 0, &Sext) > XBitSize - SrcBitSize)
-      return CastInst::CreateIntegerCast(X, DestTy, /* isSigned */ true);
-
     // If trunc has nsw flag, then convert directly to final type.
     auto *CSrc = cast<TruncInst>(Src);
     if (CSrc->hasNoSignedWrap()) {
@@ -1497,6 +1491,7 @@ Instruction *InstCombinerImpl::visitSExt(SExtInst &Sext) {
     // the logic shift to arithmetic shift and eliminate the cast to
     // intermediate type:
     // sext (trunc (lshr Y, C)) --> sext/trunc (ashr Y, C)
+    unsigned XBitSize = X->getType()->getScalarSizeInBits();
     Value *Y;
     if (Src->hasOneUse() &&
         match(X, m_LShr(m_Value(Y),

--- a/llvm/lib/Transforms/InstCombine/InstCombineCasts.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineCasts.cpp
@@ -1189,10 +1189,9 @@ Instruction *InstCombinerImpl::visitZExt(ZExtInst &Zext) {
     // TODO: Subsume this into EvaluateInDifferentType.
 
     Value *A = CSrc->getOperand(0);
-    // If TRUNC has nuw flag, then convert directly to final type.
+    // If trunc has nuw flag, then convert directly to final type.
     if (CSrc->hasNoUnsignedWrap()) {
-      CastInst *I =
-          CastInst::CreateIntegerCast(A, DestTy, /* isSigned */ false);
+      CastInst *I = CastInst::CreateIntegerCast(A, DestTy, /*isSigned=*/false);
       if (auto *ZExt = dyn_cast<ZExtInst>(I))
         ZExt->setNonNeg();
       if (auto *Trunc = dyn_cast<TruncInst>(I))
@@ -1479,9 +1478,9 @@ Instruction *InstCombinerImpl::visitSExt(SExtInst &Sext) {
       return CastInst::CreateIntegerCast(X, DestTy, /* isSigned */ true);
 
     // If trunc has nsw flag, then convert directly to final type.
-    auto *CSrc = static_cast<TruncInst *>(Src);
+    auto *CSrc = cast<TruncInst>(Src);
     if (CSrc->hasNoSignedWrap()) {
-      CastInst *I = CastInst::CreateIntegerCast(X, DestTy, /* isSigned */ true);
+      CastInst *I = CastInst::CreateIntegerCast(X, DestTy, /*isSigned=*/true);
       if (auto *Trunc = dyn_cast<TruncInst>(I))
         Trunc->setHasNoSignedWrap(true);
       return I;

--- a/llvm/test/Transforms/InstCombine/sext.ll
+++ b/llvm/test/Transforms/InstCombine/sext.ll
@@ -423,3 +423,47 @@ define i64 @smear_set_bit_different_dest_type_wider_dst(i32 %x) {
   %s = sext i8 %a to i64
   ret i64 %s
 }
+
+define i32 @sext_trunc_nsw(i16 %x) {
+; CHECK-LABEL: @sext_trunc_nsw(
+; CHECK-NEXT:    [[C:%.*]] = trunc nsw i16 [[X:%.*]] to i8
+; CHECK-NEXT:    [[E:%.*]] = sext i8 [[C]] to i32
+; CHECK-NEXT:    ret i32 [[E]]
+;
+  %c = trunc nsw i16 %x to i8
+  %e = sext i8 %c to i32
+  ret i32 %e
+}
+
+define i16 @sext_trunc_nsw_2(i32 %x) {
+; CHECK-LABEL: @sext_trunc_nsw_2(
+; CHECK-NEXT:    [[C:%.*]] = trunc nsw i32 [[X:%.*]] to i8
+; CHECK-NEXT:    [[E:%.*]] = sext i8 [[C]] to i16
+; CHECK-NEXT:    ret i16 [[E]]
+;
+  %c = trunc nsw i32 %x to i8
+  %e = sext i8 %c to i16
+  ret i16 %e
+}
+
+define <2 x i32> @sext_trunc_nsw_vec(<2 x i16> %x) {
+; CHECK-LABEL: @sext_trunc_nsw_vec(
+; CHECK-NEXT:    [[C:%.*]] = trunc nsw <2 x i16> [[X:%.*]] to <2 x i8>
+; CHECK-NEXT:    [[E:%.*]] = sext <2 x i8> [[C]] to <2 x i32>
+; CHECK-NEXT:    ret <2 x i32> [[E]]
+;
+  %c = trunc nsw <2 x i16> %x to <2 x i8>
+  %e = sext <2 x i8> %c to <2 x i32>
+  ret <2 x i32> %e
+}
+
+define i32 @sext_trunc(i16 %x) {
+; CHECK-LABEL: @sext_trunc(
+; CHECK-NEXT:    [[C:%.*]] = trunc i16 [[X:%.*]] to i8
+; CHECK-NEXT:    [[E:%.*]] = sext i8 [[C]] to i32
+; CHECK-NEXT:    ret i32 [[E]]
+;
+  %c = trunc i16 %x to i8
+  %e = sext i8 %c to i32
+  ret i32 %e
+}

--- a/llvm/test/Transforms/InstCombine/sext.ll
+++ b/llvm/test/Transforms/InstCombine/sext.ll
@@ -444,6 +444,15 @@ define i16 @sext_trunc_nsw_2(i32 %x) {
   ret i16 %e
 }
 
+define i16 @sext_trunc_nsw_3(i16 %x) {
+; CHECK-LABEL: @sext_trunc_nsw_3(
+; CHECK-NEXT:    ret i16 [[E:%.*]]
+;
+  %c = trunc nsw i16 %x to i8
+  %e = sext i8 %c to i16
+  ret i16 %e
+}
+
 define <2 x i32> @sext_trunc_nsw_vec(<2 x i16> %x) {
 ; CHECK-LABEL: @sext_trunc_nsw_vec(
 ; CHECK-NEXT:    [[E:%.*]] = sext <2 x i16> [[X:%.*]] to <2 x i32>

--- a/llvm/test/Transforms/InstCombine/sext.ll
+++ b/llvm/test/Transforms/InstCombine/sext.ll
@@ -426,8 +426,7 @@ define i64 @smear_set_bit_different_dest_type_wider_dst(i32 %x) {
 
 define i32 @sext_trunc_nsw(i16 %x) {
 ; CHECK-LABEL: @sext_trunc_nsw(
-; CHECK-NEXT:    [[C:%.*]] = trunc nsw i16 [[X:%.*]] to i8
-; CHECK-NEXT:    [[E:%.*]] = sext i8 [[C]] to i32
+; CHECK-NEXT:    [[E:%.*]] = sext i16 [[X:%.*]] to i32
 ; CHECK-NEXT:    ret i32 [[E]]
 ;
   %c = trunc nsw i16 %x to i8
@@ -437,8 +436,7 @@ define i32 @sext_trunc_nsw(i16 %x) {
 
 define i16 @sext_trunc_nsw_2(i32 %x) {
 ; CHECK-LABEL: @sext_trunc_nsw_2(
-; CHECK-NEXT:    [[C:%.*]] = trunc nsw i32 [[X:%.*]] to i8
-; CHECK-NEXT:    [[E:%.*]] = sext i8 [[C]] to i16
+; CHECK-NEXT:    [[E:%.*]] = trunc nsw i32 [[X:%.*]] to i16
 ; CHECK-NEXT:    ret i16 [[E]]
 ;
   %c = trunc nsw i32 %x to i8
@@ -448,8 +446,7 @@ define i16 @sext_trunc_nsw_2(i32 %x) {
 
 define <2 x i32> @sext_trunc_nsw_vec(<2 x i16> %x) {
 ; CHECK-LABEL: @sext_trunc_nsw_vec(
-; CHECK-NEXT:    [[C:%.*]] = trunc nsw <2 x i16> [[X:%.*]] to <2 x i8>
-; CHECK-NEXT:    [[E:%.*]] = sext <2 x i8> [[C]] to <2 x i32>
+; CHECK-NEXT:    [[E:%.*]] = sext <2 x i16> [[X:%.*]] to <2 x i32>
 ; CHECK-NEXT:    ret <2 x i32> [[E]]
 ;
   %c = trunc nsw <2 x i16> %x to <2 x i8>

--- a/llvm/test/Transforms/InstCombine/zext.ll
+++ b/llvm/test/Transforms/InstCombine/zext.ll
@@ -888,6 +888,15 @@ define i16 @zext_trunc_nuw_2(i32 %x) {
   ret i16 %e
 }
 
+define i16 @zext_trunc_nuw_3(i16 %x) {
+; CHECK-LABEL: @zext_trunc_nuw_3(
+; CHECK-NEXT:    ret i16 [[E:%.*]]
+;
+  %c = trunc nuw i16 %x to i8
+  %e = zext i8 %c to i16
+  ret i16 %e
+}
+
 define <2 x i32> @zext_trunc_nuw_vec(<2 x i16> %x) {
 ; CHECK-LABEL: @zext_trunc_nuw_vec(
 ; CHECK-NEXT:    [[E1:%.*]] = zext nneg <2 x i16> [[X:%.*]] to <2 x i32>

--- a/llvm/test/Transforms/InstCombine/zext.ll
+++ b/llvm/test/Transforms/InstCombine/zext.ll
@@ -870,8 +870,7 @@ entry:
 
 define i32 @zext_trunc_nuw(i16 %x) {
 ; CHECK-LABEL: @zext_trunc_nuw(
-; CHECK-NEXT:    [[X:%.*]] = and i16 [[X1:%.*]], 255
-; CHECK-NEXT:    [[E1:%.*]] = zext nneg i16 [[X]] to i32
+; CHECK-NEXT:    [[E1:%.*]] = zext nneg i16 [[X:%.*]] to i32
 ; CHECK-NEXT:    ret i32 [[E1]]
 ;
   %c = trunc nuw i16 %x to i8
@@ -881,8 +880,7 @@ define i32 @zext_trunc_nuw(i16 %x) {
 
 define i16 @zext_trunc_nuw_2(i32 %x) {
 ; CHECK-LABEL: @zext_trunc_nuw_2(
-; CHECK-NEXT:    [[TMP1:%.*]] = trunc i32 [[X:%.*]] to i16
-; CHECK-NEXT:    [[E:%.*]] = and i16 [[TMP1]], 255
+; CHECK-NEXT:    [[E:%.*]] = trunc nuw i32 [[X:%.*]] to i16
 ; CHECK-NEXT:    ret i16 [[E]]
 ;
   %c = trunc nuw i32 %x to i8
@@ -892,8 +890,7 @@ define i16 @zext_trunc_nuw_2(i32 %x) {
 
 define <2 x i32> @zext_trunc_nuw_vec(<2 x i16> %x) {
 ; CHECK-LABEL: @zext_trunc_nuw_vec(
-; CHECK-NEXT:    [[X:%.*]] = and <2 x i16> [[X1:%.*]], <i16 255, i16 255>
-; CHECK-NEXT:    [[E1:%.*]] = zext nneg <2 x i16> [[X]] to <2 x i32>
+; CHECK-NEXT:    [[E1:%.*]] = zext nneg <2 x i16> [[X:%.*]] to <2 x i32>
 ; CHECK-NEXT:    ret <2 x i32> [[E1]]
 ;
   %c = trunc nuw <2 x i16> %x to <2 x i8>

--- a/llvm/test/Transforms/InstCombine/zext.ll
+++ b/llvm/test/Transforms/InstCombine/zext.ll
@@ -867,3 +867,47 @@ entry:
   %res = zext nneg i2 %x to i32
   ret i32 %res
 }
+
+define i32 @zext_trunc_nuw(i16 %x) {
+; CHECK-LABEL: @zext_trunc_nuw(
+; CHECK-NEXT:    [[X:%.*]] = and i16 [[X1:%.*]], 255
+; CHECK-NEXT:    [[E1:%.*]] = zext nneg i16 [[X]] to i32
+; CHECK-NEXT:    ret i32 [[E1]]
+;
+  %c = trunc nuw i16 %x to i8
+  %e = zext i8 %c to i32
+  ret i32 %e
+}
+
+define i16 @zext_trunc_nuw_2(i32 %x) {
+; CHECK-LABEL: @zext_trunc_nuw_2(
+; CHECK-NEXT:    [[TMP1:%.*]] = trunc i32 [[X:%.*]] to i16
+; CHECK-NEXT:    [[E:%.*]] = and i16 [[TMP1]], 255
+; CHECK-NEXT:    ret i16 [[E]]
+;
+  %c = trunc nuw i32 %x to i8
+  %e = zext i8 %c to i16
+  ret i16 %e
+}
+
+define <2 x i32> @zext_trunc_nuw_vec(<2 x i16> %x) {
+; CHECK-LABEL: @zext_trunc_nuw_vec(
+; CHECK-NEXT:    [[X:%.*]] = and <2 x i16> [[X1:%.*]], <i16 255, i16 255>
+; CHECK-NEXT:    [[E1:%.*]] = zext nneg <2 x i16> [[X]] to <2 x i32>
+; CHECK-NEXT:    ret <2 x i32> [[E1]]
+;
+  %c = trunc nuw <2 x i16> %x to <2 x i8>
+  %e = zext <2 x i8> %c to <2 x i32>
+  ret <2 x i32> %e
+}
+
+define i32 @zext_trunc(i16 %x) {
+; CHECK-LABEL: @zext_trunc(
+; CHECK-NEXT:    [[E:%.*]] = and i16 [[X:%.*]], 255
+; CHECK-NEXT:    [[E1:%.*]] = zext nneg i16 [[E]] to i32
+; CHECK-NEXT:    ret i32 [[E1]]
+;
+  %c = trunc i16 %x to i8
+  %e = zext i8 %c to i32
+  ret i32 %e
+}


### PR DESCRIPTION
Fold
- `sext (trunc nsw X to Y) to Z` to `cast (nsw) X to Z`, and
- `zext (trunc nuw X to Y) to Z` to `cast (nuw) X to Z`

Alive2 proofs:
- `sext`: https://alive2.llvm.org/ce/z/cqsk5t
- `zext`: https://alive2.llvm.org/ce/z/kdtEWb

Closes https://github.com/llvm/llvm-project/issues/98017.
