### PR TITLE
[mlir][gpu] remove async requirement for conversion to LLVM

### DIFF
--- a/mlir/lib/Conversion/GPUCommon/GPUToLLVMConversion.cpp
+++ b/mlir/lib/Conversion/GPUCommon/GPUToLLVMConversion.cpp
@@ -757,12 +757,9 @@ static LogicalResult areAllLLVMTypes(Operation *op, ValueRange operands,
 static LogicalResult
 isAsyncWithOneDependency(ConversionPatternRewriter &rewriter,
                          gpu::AsyncOpInterface op) {
-  if (op.getAsyncDependencies().size() != 1)
+  if (op.getAsyncToken() && op.getAsyncDependencies().size() != 1)
     return rewriter.notifyMatchFailure(
         op, "Can only convert with exactly one async dependency.");
-
-  if (!op.getAsyncToken())
-    return rewriter.notifyMatchFailure(op, "Can convert only async version.");
 
   return success();
 }


### PR DESCRIPTION
This check makes sense (as a current analysis limitation) if the op is in fact async but I don't really understand why all of these conversions require async? E.g., if I'm doing everything synchronously, I believe all of runtime APIs calls are still correct/legal?