### PR TITLE
[libc] Replace mentions of `LIBC_FULLBUILD` with `LLVM_LIBC_FULL_BUILD` in 'examples/'

### DIFF
--- a/libc/examples/README.md
+++ b/libc/examples/README.md
@@ -59,7 +59,7 @@ have installed them, you have to inform CMake that we are linking against the
 full libc as follows:
 
 ```bash
-cmake ../ -G <GEN> -DLIBC_FULLBUILD=ON    \
+cmake ../ -G <GEN> -DLLVM_LIBC_FULL_BUILD=ON    \
   -DCMAKE_SYSROOT=<SYSROOT>               \
   -DCMAKE_C_COMPILER=<SYSROOT>/bin/clang  \
   -DCMAKE_TRY_COMPILE_TARGET_TYPE=STATIC_LIBRARY

--- a/libc/examples/examples.cmake
+++ b/libc/examples/examples.cmake
@@ -4,13 +4,13 @@ function(add_example name)
     ${ARGN}
   )
 
-  if(LIBC_FULLBUILD)
+  if(LLVM_LIBC_FULL_BUILD)
     target_link_options(${name} PRIVATE -static -rtlib=compiler-rt -fuse-ld=lld)
   elseif(LIBC_OVERLAY_ARCHIVE_DIR)
     target_link_directories(${name} PRIVATE ${LIBC_OVERLAY_ARCHIVE_DIR})
     target_link_options(${name} PRIVATE -l:libllvmlibc.a)
   else()
-    message(FATAL_ERROR "Either LIBC_FULLBUILD should be on or "
+    message(FATAL_ERROR "Either LLVM_LIBC_FULL_BUILD should be on or "
                         "LIBC_OVERLAY_ARCHIVE_DIR should be set.")
   endif()
 endfunction()


### PR DESCRIPTION
Resolves #88328