### PR TITLE
[cmake] Don't install static extensions when linked into libLLVM

### DIFF
--- a/llvm/cmake/modules/AddLLVM.cmake
+++ b/llvm/cmake/modules/AddLLVM.cmake
@@ -1180,9 +1180,17 @@ function(process_llvm_pass_plugins)
       # LLVM_INSTALL_PACKAGE_DIR might be absolute, so don't reuse below.
       string(REPLACE "${CMAKE_CFG_INTDIR}" "." llvm_cmake_builddir "${LLVM_LIBRARY_DIR}")
       set(llvm_cmake_builddir "${llvm_cmake_builddir}/cmake/llvm")
-      file(WRITE
-          "${llvm_cmake_builddir}/LLVMConfigExtensions.cmake"
-          "set(LLVM_STATIC_EXTENSIONS ${LLVM_STATIC_EXTENSIONS})")
+      if(LLVM_LINK_LLVM_DYLIB)
+          # Install a dummy file. When the extensions are part of libLLVM other
+          # tools should link it instead of the static library.
+          file(WRITE
+              "${llvm_cmake_builddir}/LLVMConfigExtensions.cmake"
+              "set(LLVM_STATIC_EXTENSIONS )")
+      else()
+          file(WRITE
+              "${llvm_cmake_builddir}/LLVMConfigExtensions.cmake"
+              "set(LLVM_STATIC_EXTENSIONS ${LLVM_STATIC_EXTENSIONS})")
+      endif()
       install(FILES
           ${llvm_cmake_builddir}/LLVMConfigExtensions.cmake
           DESTINATION ${LLVM_INSTALL_PACKAGE_DIR}

--- a/polly/cmake/polly_macros.cmake
+++ b/polly/cmake/polly_macros.cmake
@@ -41,7 +41,8 @@ macro(add_polly_library name)
   if( LLVM_LINK_COMPONENTS )
     llvm_config(${name} ${LLVM_LINK_COMPONENTS})
   endif( LLVM_LINK_COMPONENTS )
-  if (NOT LLVM_INSTALL_TOOLCHAIN_ONLY OR ${name} STREQUAL "LLVMPolly")
+  if ((NOT LLVM_INSTALL_TOOLCHAIN_ONLY OR ${name} STREQUAL "LLVMPolly")
+    AND NOT LLVM_LINK_LLVM_DYLIB)
     install(TARGETS ${name}
       COMPONENT ${name}
       EXPORT LLVMExports


### PR DESCRIPTION
When extensions like polly are linked as part of `libLLVM` these don't need to be and likely shouldn't be installed.

Reason being that e.g. out-of-tree clang builds against `libLLVM` will try to statically link these extensions
when calling `process_llvm_pass_plugins`.

1. This is undesirable because the whole point is to have a shared library to link to
2.  It actually causes issues because `LLVMExports.cmake` will include e.g. `libPollyISL`, `LLVMPolly`, etc. as installed targets depending on on non-installed `LLVM*.a` targets which are available via `libLLVM.so` 

This is mainly intended to allow distributions to ship polly enabled `libLLVM` while still keeping e.g. clang independent and linked dynamically.