### PR TITLE
[mlir][scf] Rewrite vector.transfer_read/write after peeling

### DIFF
--- a/mlir/lib/Dialect/SCF/Transforms/LoopSpecialization.cpp
+++ b/mlir/lib/Dialect/SCF/Transforms/LoopSpecialization.cpp
@@ -175,15 +175,15 @@ static void setInBoundsForVectorReadWrite(RewriterBase &b, Operation *op) {
     read.setInBoundsAttr(b.getBoolArrayAttr({true}));
 }
 
-static bool hasVectorSizeEqualToStep(Operation *Op,
+static bool hasVectorSizeEqualToStep(Operation *op,
                                      std::optional<int64_t> step) {
   if (!step)
     return false;
 
-  if (isa<vector::TransferWriteOp, vector::TransferReadOp>(Op)) {
-    auto vectorType = isa<vector::TransferWriteOp>(Op)
-                          ? cast<vector::TransferWriteOp>(Op).getVectorType()
-                          : cast<vector::TransferReadOp>(Op).getVectorType();
+  if (isa<vector::TransferWriteOp, vector::TransferReadOp>(op)) {
+    auto vectorType = isa<vector::TransferWriteOp>(op)
+                          ? cast<vector::TransferWriteOp>(op).getVectorType()
+                          : cast<vector::TransferReadOp>(op).getVectorType();
 
     if (vectorType.getRank() != 1)
       return false;

--- a/mlir/lib/Dialect/SCF/Transforms/LoopSpecialization.cpp
+++ b/mlir/lib/Dialect/SCF/Transforms/LoopSpecialization.cpp
@@ -200,12 +200,12 @@ static void rewriteVectorizedLoopAfterPeeling(RewriterBase &rewriter,
                                               ForOp forOp) {
   auto stepInt = getConstantIntValue(forOp.getStep());
 
-  forOp.walk([&](Operation *affineOp) {
-    if (!isa<vector::TransferWriteOp, vector::TransferReadOp>(affineOp))
+  forOp.walk([&](Operation *op) {
+    if (!isa<vector::TransferWriteOp, vector::TransferReadOp>(op))
       return WalkResult::advance();
-    if (!hasVectorSizeEqualToStep(affineOp, stepInt))
+    if (!hasVectorSizeEqualToStep(op, stepInt))
       return WalkResult::advance();
-    setInBoundsForVectorReadWrite(rewriter, affineOp);
+    setInBoundsForVectorReadWrite(rewriter, op);
     return WalkResult::advance();
   });
 }

--- a/mlir/lib/Dialect/SCF/Transforms/LoopSpecialization.cpp
+++ b/mlir/lib/Dialect/SCF/Transforms/LoopSpecialization.cpp
@@ -186,8 +186,8 @@ static bool hasVectorSizeEqualToStep(ForOp forOp, Operation *op,
                           ? cast<vector::TransferWriteOp>(op).getVectorType()
                           : cast<vector::TransferReadOp>(op).getVectorType();
     auto indices = isa<vector::TransferWriteOp>(op)
-                          ? cast<vector::TransferWriteOp>(op).getIndices()
-                          : cast<vector::TransferReadOp>(op).getIndices();
+                       ? cast<vector::TransferWriteOp>(op).getIndices()
+                       : cast<vector::TransferReadOp>(op).getIndices();
 
     if (vectorType.getRank() != 1)
       return false;

--- a/mlir/test/Dialect/SCF/for-loop-peeling-vector-load-store.mlir
+++ b/mlir/test/Dialect/SCF/for-loop-peeling-vector-load-store.mlir
@@ -10,10 +10,11 @@ func.func @vector_read_write(%a : memref<100xi32>, %b : memref<100xi32>, %ub: in
 // CHECK-SAME:   %[[A:.*]]: memref<100xi32>, %[[B:.*]]: memref<100xi32>, %[[UB:.*]]: index
 //      CHECK:   %[[LB:.*]] = arith.constant 0 : index
 //      CHECK:   %[[STEP:.*]] = arith.constant 64 : index
+//      CHECK:   %[[PAD:.*]] = arith.constant 0 : i32
 //      CHECK:   %[[NEW_UB:.*]] = affine.apply #[[MAP0]]
 //      CHECK:   scf.for %[[IV:.*]] = %[[LB]] to %[[NEW_UB]] step %[[STEP]] {
-//      CHECK:     %[[VAL:.*]] = vector.load %[[B]][%[[IV]]]
-//      CHECK:     vector.store %[[VAL]], %[[A]][%[[IV]]]
+//      CHECK:     %[[VAL:.*]] = vector.transfer_read %[[B]][%[[IV]]], %[[PAD]] {in_bounds = [true]}
+//      CHECK:     vector.transfer_write %[[VAL]], %[[A]][%[[IV]]] {in_bounds = [true]}
 //      CHECK:   }
 //      CHECK:   scf.for %[[IV:.*]] = %[[NEW_UB]] to %[[UB]] step %[[STEP]] {
 //      CHECK:     %[[VAL:.*]] = vector.transfer_read %[[B]][%[[IV]]]

--- a/mlir/test/Dialect/SCF/for-loop-peeling-vector-load-store.mlir
+++ b/mlir/test/Dialect/SCF/for-loop-peeling-vector-load-store.mlir
@@ -1,0 +1,30 @@
+// RUN: mlir-opt %s -scf-for-loop-peeling -canonicalize -verify-diagnostics | FileCheck %s
+
+func.func @vector_read_write(%a : memref<100xi32>, %b : memref<100xi32>, %ub: index) {
+// %LB to %NEW_UB will be multiple of STEP after peeling.
+// So vector.transfer_write could be transferred to vector.store to avoid
+// generating mask when lowering to LLVM.
+//
+//  CHECK-DAG: #[[MAP0:.*]] = affine_map<()[s0] -> ((s0 floordiv 64) * 64)>
+//      CHECK: func @vector_read_write(
+// CHECK-SAME:   %[[A:.*]]: memref<100xi32>, %[[B:.*]]: memref<100xi32>, %[[UB:.*]]: index
+//      CHECK:   %[[LB:.*]] = arith.constant 0 : index
+//      CHECK:   %[[STEP:.*]] = arith.constant 64 : index
+//      CHECK:   %[[NEW_UB:.*]] = affine.apply #[[MAP0]]
+//      CHECK:   scf.for %[[IV:.*]] = %[[LB]] to %[[NEW_UB]] step %[[STEP]] {
+//      CHECK:     %[[VAL:.*]] = vector.load %[[B]][%[[IV]]]
+//      CHECK:     vector.store %[[VAL]], %[[A]][%[[IV]]]
+//      CHECK:   }
+//      CHECK:   scf.for %[[IV:.*]] = %[[NEW_UB]] to %[[UB]] step %[[STEP]] {
+//      CHECK:     %[[VAL:.*]] = vector.transfer_read %[[B]][%[[IV]]]
+//      CHECK:     vector.transfer_write %[[VAL]], %[[A]][%[[IV]]]
+//      CHECK:   }
+  %c0 = arith.constant 0 : index
+  %c64 = arith.constant 64 : index
+  %pad = arith.constant 0 : i32
+  scf.for %i = %c0 to %ub step %c64 {
+    %val = vector.transfer_read %b[%i], %pad : memref<100xi32>, vector<64xi32>
+    vector.transfer_write %val, %a[%i] : vector<64xi32>, memref<100xi32>
+  }
+  return
+}


### PR DESCRIPTION
After peeling, the loop iteration will be multiple of step. If the vector size of vector.transfer_read/write is equal to step in the peeled loop, there won't be the remaining iteration smaller than the vector size.

In this case, rewriting vector.transfer_read/write to vector.load/store could avoid generating masks when lowering to LLVM Dialect.