### PR TITLE
[mlir][math] Replace roundeven call by nearbyint call when target does not have C23 features

### DIFF
--- a/flang/lib/Optimizer/CodeGen/CodeGen.cpp
+++ b/flang/lib/Optimizer/CodeGen/CodeGen.cpp
@@ -3589,7 +3589,7 @@ public:
                                                           pattern);
     // Math operations that have not been converted yet must be converted
     // to Libm.
-    mlir::populateMathToLibmConversionPatterns(pattern);
+    mlir::populateMathToLibmConversionPatterns(typeConverter, pattern);
     mlir::populateComplexToLLVMConversionPatterns(typeConverter, pattern);
     mlir::populateVectorToLLVMConversionPatterns(typeConverter, pattern);
 

--- a/flang/lib/Optimizer/CodeGen/CodeGen.cpp
+++ b/flang/lib/Optimizer/CodeGen/CodeGen.cpp
@@ -3589,7 +3589,7 @@ public:
                                                           pattern);
     // Math operations that have not been converted yet must be converted
     // to Libm.
-    mlir::populateMathToLibmConversionPatterns(typeConverter, pattern);
+    mlir::populateMathToLibmConversionPatterns(pattern);
     mlir::populateComplexToLLVMConversionPatterns(typeConverter, pattern);
     mlir::populateVectorToLLVMConversionPatterns(typeConverter, pattern);
 

--- a/mlir/include/mlir/Conversion/MathToLibm/MathToLibm.h
+++ b/mlir/include/mlir/Conversion/MathToLibm/MathToLibm.h
@@ -19,10 +19,13 @@ class OperationPass;
 
 /// Populate the given list with patterns that convert from Math to Libm calls.
 /// If log1pBenefit is present, use it instead of benefit for the Log1p op.
-void populateMathToLibmConversionPatterns(RewritePatternSet &patterns);
+void populateMathToLibmConversionPatterns(
+    RewritePatternSet &patterns, const ConvertMathToLibmOptions &options);
 
 /// Create a pass to convert Math operations to libm calls.
 std::unique_ptr<OperationPass<ModuleOp>> createConvertMathToLibmPass();
+std::unique_ptr<OperationPass<ModuleOp>>
+createConvertMathToLibmPass(const ConvertMathToLibmOptions &options);
 
 } // namespace mlir
 

--- a/mlir/include/mlir/Conversion/MathToLibm/MathToLibm.h
+++ b/mlir/include/mlir/Conversion/MathToLibm/MathToLibm.h
@@ -20,7 +20,7 @@ class OperationPass;
 /// Populate the given list with patterns that convert from Math to Libm calls.
 /// If log1pBenefit is present, use it instead of benefit for the Log1p op.
 void populateMathToLibmConversionPatterns(
-    RewritePatternSet &patterns, const ConvertMathToLibmOptions &options);
+    RewritePatternSet &patterns, const ConvertMathToLibmOptions &options = {});
 
 /// Create a pass to convert Math operations to libm calls.
 std::unique_ptr<OperationPass<ModuleOp>> createConvertMathToLibmPass();

--- a/mlir/include/mlir/Conversion/Passes.td
+++ b/mlir/include/mlir/Conversion/Passes.td
@@ -692,6 +692,12 @@ def ConvertMathToLibm : Pass<"convert-math-to-libm", "ModuleOp"> {
     "func::FuncDialect",
     "vector::VectorDialect",
   ];
+  let options = [
+    Option<"allowC23Features", "allow-c23-features", "bool", "true",
+           "Allow calls to C23-specific functions">,
+    Option<"roundingModeIsDefault", "rounding-mode-is-default", "bool", "false",
+           "Assume default rounding mode">
+  ];
 }
 
 //===----------------------------------------------------------------------===//

--- a/mlir/test/Conversion/MathToLibm/nearbyint.mlir
+++ b/mlir/test/Conversion/MathToLibm/nearbyint.mlir
@@ -1,0 +1,41 @@
+// RUN: mlir-opt %s --pass-pipeline='builtin.module(convert-math-to-libm{allow-c23-features=0 rounding-mode-is-default}, canonicalize)' | FileCheck %s
+
+// CHECK-DAG: @nearbyint(f64) -> f64 attributes {libm, llvm.readnone}
+// CHECK-DAG: @nearbyintf(f32) -> f32 attributes {libm, llvm.readnone}
+
+// CHECK-LABEL: func @nearbyint_caller
+// CHECK-SAME: %[[FLOAT:.*]]: f32
+// CHECK-SAME: %[[DOUBLE:.*]]: f64
+func.func @nearbyint_caller(%float: f32, %double: f64) -> (f32, f64)  {
+  // CHECK-DAG: %[[FLOAT_RESULT:.*]] = call @nearbyintf(%[[FLOAT]]) : (f32) -> f32
+  %float_result = math.roundeven %float : f32
+  // CHECK-DAG: %[[DOUBLE_RESULT:.*]] = call @nearbyint(%[[DOUBLE]]) : (f64) -> f64
+  %double_result = math.roundeven %double : f64
+  // CHECK: return %[[FLOAT_RESULT]], %[[DOUBLE_RESULT]]
+  return %float_result, %double_result : f32, f64
+}
+
+// CHECK-LABEL:   func @nearbyint_vec_caller(
+// CHECK-SAME:                           %[[VAL_0:.*]]: vector<2xf32>,
+// CHECK-SAME:                           %[[VAL_1:.*]]: vector<2xf64>) -> (vector<2xf32>, vector<2xf64>) {
+// CHECK-DAG:       %[[CVF:.*]] = arith.constant dense<0.000000e+00> : vector<2xf32>
+// CHECK-DAG:       %[[CVD:.*]] = arith.constant dense<0.000000e+00> : vector<2xf64>
+// CHECK:           %[[IN0_F32:.*]] = vector.extract %[[VAL_0]][0] : f32 from vector<2xf32>
+// CHECK:           %[[OUT0_F32:.*]] = call @nearbyintf(%[[IN0_F32]]) : (f32) -> f32
+// CHECK:           %[[VAL_8:.*]] = vector.insert %[[OUT0_F32]], %[[CVF]] [0] : f32 into vector<2xf32>
+// CHECK:           %[[IN1_F32:.*]] = vector.extract %[[VAL_0]][1] : f32 from vector<2xf32>
+// CHECK:           %[[OUT1_F32:.*]] = call @nearbyintf(%[[IN1_F32]]) : (f32) -> f32
+// CHECK:           %[[VAL_11:.*]] = vector.insert %[[OUT1_F32]], %[[VAL_8]] [1] : f32 into vector<2xf32>
+// CHECK:           %[[IN0_F64:.*]] = vector.extract %[[VAL_1]][0] : f64 from vector<2xf64>
+// CHECK:           %[[OUT0_F64:.*]] = call @nearbyint(%[[IN0_F64]]) : (f64) -> f64
+// CHECK:           %[[VAL_14:.*]] = vector.insert %[[OUT0_F64]], %[[CVD]] [0] : f64 into vector<2xf64>
+// CHECK:           %[[IN1_F64:.*]] = vector.extract %[[VAL_1]][1] : f64 from vector<2xf64>
+// CHECK:           %[[OUT1_F64:.*]] = call @nearbyint(%[[IN1_F64]]) : (f64) -> f64
+// CHECK:           %[[VAL_17:.*]] = vector.insert %[[OUT1_F64]], %[[VAL_14]] [1] : f64 into vector<2xf64>
+// CHECK:           return %[[VAL_11]], %[[VAL_17]] : vector<2xf32>, vector<2xf64>
+// CHECK:         }
+func.func @nearbyint_vec_caller(%float: vector<2xf32>, %double: vector<2xf64>) -> (vector<2xf32>, vector<2xf64>) {
+  %float_result = math.roundeven %float : vector<2xf32>
+  %double_result = math.roundeven %double : vector<2xf64>
+  return %float_result, %double_result : vector<2xf32>, vector<2xf64>
+}

--- a/mlir/test/Conversion/MathToLibm/nearbyint.mlir
+++ b/mlir/test/Conversion/MathToLibm/nearbyint.mlir
@@ -1,7 +1,7 @@
 // RUN: mlir-opt %s --pass-pipeline='builtin.module(convert-math-to-libm{allow-c23-features=0 rounding-mode-is-default}, canonicalize)' | FileCheck %s
 
-// CHECK-DAG: @nearbyint(f64) -> f64 attributes {libm, llvm.readnone}
-// CHECK-DAG: @nearbyintf(f32) -> f32 attributes {libm, llvm.readnone}
+// CHECK-DAG: @nearbyint(f64) -> f64 attributes {llvm.readnone}
+// CHECK-DAG: @nearbyintf(f32) -> f32 attributes {llvm.readnone}
 
 // CHECK-LABEL: func @nearbyint_caller
 // CHECK-SAME: %[[FLOAT:.*]]: f32

--- a/mlir/test/Conversion/MathToLibm/roundeven-failed.mlir
+++ b/mlir/test/Conversion/MathToLibm/roundeven-failed.mlir
@@ -1,0 +1,8 @@
+// RUN: mlir-opt %s --pass-pipeline='builtin.module(convert-math-to-libm{allow-c23-features=0 rounding-mode-is-default=0})' -verify-diagnostics
+
+func.func @nearbyint_caller(%float: f32, %double: f64) -> (f32, f64)  {
+  // expected-error@+1 {{failed to legalize operation 'math.roundeven'}}
+  %float_result = math.roundeven %float : f32
+  %double_result = math.roundeven %double : f64
+  return %float_result, %double_result : f32, f64
+}


### PR DESCRIPTION
This commit:

- adds a flag to the MathToLibm pass on whether to allow emission of code using C23 features (default: yes),
- lowers `math.roundeven` to calls to `roundeven` only if C23 features are allowed,
- adds a flag for the user to state that the rounding mode is the default (`FE_TONEAREST`) (default: no),
- if C23 is not allowed and rounding mode is default, lowers `math.roundeven` to calls to `nearbyint`.

A bit more details: This commit introduces a flag to "allow a certain standard", which I'm not a fan of because that could lead to a multiplication of flags specific to each pass and each standard. Ideally it would piggyback on some flag that states which language/standard is the target. What are your thoughts on this?
