### PR TITLE
[lldb][NFC] Turn ChildCacheState into an unscoped enum

### DIFF
--- a/lldb/include/lldb/lldb-enumerations.h
+++ b/lldb/include/lldb/lldb-enumerations.h
@@ -1310,7 +1310,7 @@ enum CompletionType {
 
 /// Specifies if children need to be re-computed
 /// after a call to \ref SyntheticChildrenFrontEnd::Update.
-enum class ChildCacheState {
+enum ChildCacheState {
   eRefetch = 0, ///< Children need to be recomputed dynamically.
 
   eReuse = 1, ///< Children did not change and don't need to be recomputed;


### PR DESCRIPTION
Done for consistency with the rest of the enums in `lldb-enumerations.h`. See
https://github.com/llvm/llvm-project/pull/80167#issuecomment-2043721298