### PR TITLE
[libc][msan] Fix "non-constexpr function '__msan_unpoison' cannot be used in a constant expression"

### DIFF
--- a/libc/src/__support/macros/sanitizer.h
+++ b/libc/src/__support/macros/sanitizer.h
@@ -48,20 +48,12 @@
 //-----------------------------------------------------------------------------
 
 #if defined(LIBC_HAVE_MEMORY_SANITIZER)
-// Only perform MSAN unpoison in non-constexpr context and silence
-// '-Wconstant-evaluated' when MSAN_UNPOISON is called from manifestly constant
-// contexts.
+// Only perform MSAN unpoison in non-constexpr context.
 #include <sanitizer/msan_interface.h>
 #define MSAN_UNPOISON(addr, size)                                              \
   do {                                                                         \
-    _Pragma("GCC diagnostic push \"-Wconstant-evaluated\"");                   \
-    _Pragma("GCC diagnostic ignored \"-Wconstant-evaluated\"");                \
-    _Pragma("clang diagnostic push \"-Wconstant-evaluated\"");                 \
-    _Pragma("clang diagnostic ignored \"-Wconstant-evaluated\"");              \
-    if constexpr (!__builtin_is_constant_evaluated())                          \
+    if (!__builtin_is_constant_evaluated())                                    \
       __msan_unpoison(addr, size);                                             \
-    _Pragma("clang diagnostic pop");                                           \
-    _Pragma("GCC diagnostic pop");                                             \
   } while (0)
 #else
 #define MSAN_UNPOISON(ptr, size)


### PR DESCRIPTION
Prior to this patch, calling `cpp::bit_cast<T>` in `constexpr` expressions under `-fsanitize=memory` would fail with the following message "non-constexpr function '__msan_unpoison' cannot be used in a constant expression".

This patch makes sure that the `__msan_unpoison` expression is guarded by `!__builtin_is_constant_evaluated()`.