### PR TITLE
[Clang][Sema] Warn when 'exclude_from_explicit_instantiation' attribute is used on local classes and members thereof

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -287,6 +287,9 @@ Attribute Changes in Clang
   This allows the ``_Nullable`` and ``_Nonnull`` family of type attributes to
   apply to this class.
 
+- Clang now warns that the ``exclude_from_explicit_instantiation`` attribute
+  is ignored when applied to a local class or a member thereof.
+
 Improvements to Clang's diagnostics
 -----------------------------------
 - Clang now applies syntax highlighting to the code snippets it

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -3669,6 +3669,9 @@ def warn_attribute_dllexport_explicit_instantiation_decl : Warning<
 def warn_attribute_dllexport_explicit_instantiation_def : Warning<
   "'dllexport' attribute ignored on explicit instantiation definition">,
   InGroup<IgnoredAttributes>;
+def warn_attribute_exclude_from_explicit_instantiation_local_class : Warning<
+  "%0 attribute ignored on local class%select{| member}1">,
+  InGroup<IgnoredAttributes>;
 def warn_invalid_initializer_from_system_header : Warning<
   "invalid constructor from class in system header, should not be explicit">,
   InGroup<DiagGroup<"invalid-initializer-from-system-header">>;

--- a/clang/lib/Sema/SemaTemplateInstantiate.cpp
+++ b/clang/lib/Sema/SemaTemplateInstantiate.cpp
@@ -4124,7 +4124,8 @@ Sema::InstantiateClassMembers(SourceLocation PointOfInstantiation,
           }
         }
 
-        if (Function->hasAttr<ExcludeFromExplicitInstantiationAttr>())
+        if (Function->hasAttr<ExcludeFromExplicitInstantiationAttr>() &&
+            !Instantiation->isLocalClass())
           continue;
 
         MemberSpecializationInfo *MSInfo =
@@ -4169,7 +4170,8 @@ Sema::InstantiateClassMembers(SourceLocation PointOfInstantiation,
         continue;
 
       if (Var->isStaticDataMember()) {
-        if (Var->hasAttr<ExcludeFromExplicitInstantiationAttr>())
+        if (Var->hasAttr<ExcludeFromExplicitInstantiationAttr>() &&
+            !Instantiation->isLocalClass())
           continue;
 
         MemberSpecializationInfo *MSInfo = Var->getMemberSpecializationInfo();
@@ -4203,7 +4205,8 @@ Sema::InstantiateClassMembers(SourceLocation PointOfInstantiation,
         }
       }
     } else if (auto *Record = dyn_cast<CXXRecordDecl>(D)) {
-      if (Record->hasAttr<ExcludeFromExplicitInstantiationAttr>())
+      if (Record->hasAttr<ExcludeFromExplicitInstantiationAttr>() &&
+          !Instantiation->isLocalClass())
         continue;
 
       // Always skip the injected-class-name, along with any

--- a/clang/lib/Sema/SemaTemplateInstantiate.cpp
+++ b/clang/lib/Sema/SemaTemplateInstantiate.cpp
@@ -4124,8 +4124,7 @@ Sema::InstantiateClassMembers(SourceLocation PointOfInstantiation,
           }
         }
 
-        if (Function->hasAttr<ExcludeFromExplicitInstantiationAttr>() &&
-            !Instantiation->isLocalClass())
+        if (Function->hasAttr<ExcludeFromExplicitInstantiationAttr>())
           continue;
 
         MemberSpecializationInfo *MSInfo =
@@ -4170,8 +4169,7 @@ Sema::InstantiateClassMembers(SourceLocation PointOfInstantiation,
         continue;
 
       if (Var->isStaticDataMember()) {
-        if (Var->hasAttr<ExcludeFromExplicitInstantiationAttr>() &&
-            !Instantiation->isLocalClass())
+        if (Var->hasAttr<ExcludeFromExplicitInstantiationAttr>())
           continue;
 
         MemberSpecializationInfo *MSInfo = Var->getMemberSpecializationInfo();
@@ -4205,8 +4203,7 @@ Sema::InstantiateClassMembers(SourceLocation PointOfInstantiation,
         }
       }
     } else if (auto *Record = dyn_cast<CXXRecordDecl>(D)) {
-      if (Record->hasAttr<ExcludeFromExplicitInstantiationAttr>() &&
-          !Instantiation->isLocalClass())
+      if (Record->hasAttr<ExcludeFromExplicitInstantiationAttr>())
         continue;
 
       // Always skip the injected-class-name, along with any

--- a/clang/test/SemaCXX/attr-exclude_from_explicit_instantiation.local-class.cpp
+++ b/clang/test/SemaCXX/attr-exclude_from_explicit_instantiation.local-class.cpp
@@ -1,0 +1,64 @@
+// RUN: %clang_cc1 -std=c++20 -fsyntax-only -verify %s
+
+// Test that the exclude_from_explicit_instantiation attribute is ignored
+// for local classes and members thereof.
+
+#define EXCLUDE_FROM_EXPLICIT_INSTANTIATION __attribute__((exclude_from_explicit_instantiation)) // expected-note 0+{{expanded from macro}}
+
+namespace N0 {
+
+  template<typename T>
+  void f() {
+    struct EXCLUDE_FROM_EXPLICIT_INSTANTIATION A { // expected-warning {{attribute ignored on local class}}
+                                                   // expected-note@-1 2{{in instantiation of}}
+      EXCLUDE_FROM_EXPLICIT_INSTANTIATION void g(T t) { // expected-warning {{attribute ignored on local class member}}
+        *t; // expected-error {{indirection requires pointer operand ('int' invalid)}}
+      }
+
+      struct EXCLUDE_FROM_EXPLICIT_INSTANTIATION B { // expected-warning {{attribute ignored on local class}}
+        void h(T t) {
+          *t; // expected-error {{indirection requires pointer operand ('int' invalid)}}
+        }
+      };
+    };
+  }
+
+  template void f<int>(); // expected-note 2{{in instantiation of}}
+
+}
+
+// This is a reduced example from libc++ which required that 'value'
+// be prefixed with 'this->' because the definition of 'Local::operator A'
+// was not instantiated when the definition of 'g' was.
+namespace N1 {
+
+  struct A { };
+
+  struct B {
+    operator A() {
+      return A();
+    }
+  };
+
+  template<typename T>
+  auto f(T t) {
+    return A(t);
+  }
+
+  template<typename T>
+  auto g(T t) {
+    struct Local {
+      T value;
+
+      EXCLUDE_FROM_EXPLICIT_INSTANTIATION // expected-warning {{attribute ignored on local class member}}
+      operator A() {
+        return A(value);
+      }
+    };
+
+    return f(Local(t));
+  }
+
+  auto x = g(B());
+
+}


### PR DESCRIPTION
A local class and its members declared in a function template are instantiated alongside the definition of that template. It therefore does not make sense to apply the `exclude_from_explicit_instantiation` attribute to such declarations, and this patch adds a warning to diagnose these cases (in addition to ignoring the attribute). 

(The motivation for this patch is to fix a failing test in libc++ for #84050. In particular, [this line](https://github.com/llvm/llvm-project/blob/main/libcxx/include/__memory/uses_allocator_construction.h#L199) in libc++ contains the expression `this->__value_`  (reduced repro [here](https://godbolt.org/z/KqEerKWPd)) which will be looked up prior to instantiation (the lookup context is the current instantiation) once #84050 lands. `_LIBCPP_HIDE_FROM_ABI` includes `__attribute__((exclude_from_explicit_instantiation))`, which TLDR in the reduced repro results in `Local` being instantiated with `Local::operator A` as its `DeclContext`)
