### PR TITLE
[DWARF] Add accessor for NameIndex Offsets field.

### DIFF
--- a/llvm/include/llvm/DebugInfo/DWARF/DWARFAcceleratorTable.h
+++ b/llvm/include/llvm/DebugInfo/DWARF/DWARFAcceleratorTable.h
@@ -608,6 +608,9 @@ public:
     /// Returns Hdr field
     Header getHeader() const { return Hdr; }
 
+    /// Returns Offsets field
+    DWARFDebugNamesOffsets getOffsets() const { return Offsets; }
+
     /// Reads offset of compilation unit CU. CU is 0-based.
     uint64_t getCUOffset(uint32_t CU) const;
     uint32_t getCUCount() const { return Hdr.CompUnitCount; }


### PR DESCRIPTION
Add an accessor function to DWARFDebugNames::NameIndex to allow other classes to access the Offsets field within NameIndex.  This will be used by LLD to create a merged .debug_names index (https://github.com/llvm/llvm-project/pull/86508)