### PR TITLE
Rename -macosx_version_min to -macos_version_min

### DIFF
--- a/clang/lib/Driver/ToolChains/Darwin.cpp
+++ b/clang/lib/Driver/ToolChains/Darwin.cpp
@@ -3143,7 +3143,7 @@ void Darwin::addMinVersionArgs(const ArgList &Args,
     CmdArgs.push_back("-maccatalyst_version_min");
   else {
     assert(isTargetMacOS() && "unexpected target");
-    CmdArgs.push_back("-macosx_version_min");
+    CmdArgs.push_back("-macos_version_min");
   }
 
   VersionTuple MinTgtVers = getEffectiveTriple().getMinimumSupportedOSVersion();
@@ -3154,7 +3154,7 @@ void Darwin::addMinVersionArgs(const ArgList &Args,
     assert(isTargetMacOSBased() && "unexpected target");
     VersionTuple VariantTargetVersion;
     if (TargetVariantTriple->isMacOSX()) {
-      CmdArgs.push_back("-macosx_version_min");
+      CmdArgs.push_back("-macos_version_min");
       TargetVariantTriple->getMacOSXVersion(VariantTargetVersion);
     } else {
       assert(TargetVariantTriple->isiOS() &&

--- a/clang/test/Driver/darwin-ld-platform-version-macos.c
+++ b/clang/test/Driver/darwin-ld-platform-version-macos.c
@@ -34,12 +34,12 @@
 // RUN:   -### %t.o 2>&1 \
 // RUN:   | FileCheck --check-prefix=ARM64_NEW_1 %s
 
-// LINKER-OLD: "-macosx_version_min" "10.13.0"
+// LINKER-OLD: "-macos_version_min" "10.13.0"
 // LINKER-NEW: "-platform_version" "macos" "10.13.0" "10.14"
 
 // ARM64_NEW: "-platform_version" "macos" "11.0.0" "10.14"
 // ARM64_NEW_1: "-platform_version" "macos" "11.1.0" "10.14"
-// ARM64_OLD: "-macosx_version_min" "11.0.0"
+// ARM64_OLD: "-macos_version_min" "11.0.0"
 
 // RUN: %clang -target x86_64-apple-macos10.13 -mlinker-version=520 \
 // RUN:   -### %t.o 2>&1 \

--- a/clang/test/Driver/darwin-ld-platform-version-target-version.c
+++ b/clang/test/Driver/darwin-ld-platform-version-target-version.c
@@ -26,5 +26,5 @@
 // ARM64_NEW-INV: "-platform_version" "macos" "11.0.0" "10.15"
 // ARM64_NEW-INV-SAME: "-platform_version" "mac catalyst" "14.0.0" "13.1"
 
-// ARM64_OLD: "-maccatalyst_version_min" "14.0.0" "-macosx_version_min" "11.0.0"
-// ARM64_OLD-INV:  "-macosx_version_min" "11.0.0" "-maccatalyst_version_min" "14.0.0"
+// ARM64_OLD: "-maccatalyst_version_min" "14.0.0" "-macos_version_min" "11.0.0"
+// ARM64_OLD-INV:  "-macos_version_min" "11.0.0" "-maccatalyst_version_min" "14.0.0"

--- a/clang/test/Driver/darwin-ld.c
+++ b/clang/test/Driver/darwin-ld.c
@@ -140,15 +140,15 @@
 // RUN: %clang -target x86_64-apple-macosx10.7 -fuse-ld= -mlinker-version=400 -### %t.o 2>> %t.log
 // RUN: FileCheck -check-prefix=LINK_VERSION_MIN %s < %t.log
 // LINK_VERSION_MIN: {{ld(.exe)?"}}
-// LINK_VERSION_MIN: "-macosx_version_min" "10.6.0"
+// LINK_VERSION_MIN: "-macos_version_min" "10.6.0"
 // LINK_VERSION_MIN: {{ld(.exe)?"}}
-// LINK_VERSION_MIN: "-macosx_version_min" "10.7.0"
+// LINK_VERSION_MIN: "-macos_version_min" "10.7.0"
 
 // RUN: %clang -target x86_64-apple-ios13.1-macabi -fuse-ld= -mlinker-version=400 -### %t.o 2>> %t.log
 // RUN: FileCheck -check-prefix=LINK_VERSION_MIN_MACABI %s < %t.log
 // LINK_VERSION_MIN_MACABI: {{ld(.exe)?"}}
 // LINK_VERSION_MIN_MACABI: "-maccatalyst_version_min" "13.1.0"
-// LINK_VERSION_MIN_MACABI-NOT: macosx_version_min
+// LINK_VERSION_MIN_MACABI-NOT: macos_version_min
 // LINK_VERSION_MIN_MACABI-NOT: macos_version_min
 
 // RUN: %clang -target x86_64-apple-darwin12 -### %t.o 2> %t.log

--- a/clang/test/Driver/darwin-sdkroot.c
+++ b/clang/test/Driver/darwin-sdkroot.c
@@ -73,4 +73,4 @@
 // CHECK-MACOSX: "-cc1"
 // CHECK-MACOSX: "-triple" "x86_64-apple-macosx10.10.0"
 // CHECK-MACOSX: ld
-// CHECK-MACOSX: "-macosx_version_min" "10.10.0"
+// CHECK-MACOSX: "-macos_version_min" "10.10.0"

--- a/clang/test/Driver/darwin-zippered-target-version.c
+++ b/clang/test/Driver/darwin-zippered-target-version.c
@@ -6,11 +6,11 @@
 // RUN:   -darwin-target-variant x86_64-apple-macos10.15 \
 // RUN:   %s -fuse-ld= -mlinker-version=400 -### 2>&1 | FileCheck --check-prefix=INVERTED %s
 
-// CHECK: "-arch" "x86_64" "-macosx_version_min" "10.15.0" "-maccatalyst_version_min" "13.1"
-// CHECK: "-arch" "x86_64h" "-macosx_version_min" "10.15.0" "-maccatalyst_version_min" "13.1"
-// CHECK: "-arch" "i386" "-macosx_version_min" "10.15.0"
+// CHECK: "-arch" "x86_64" "-macos_version_min" "10.15.0" "-maccatalyst_version_min" "13.1"
+// CHECK: "-arch" "x86_64h" "-macos_version_min" "10.15.0" "-maccatalyst_version_min" "13.1"
+// CHECK: "-arch" "i386" "-macos_version_min" "10.15.0"
 // CHECK-NOT: maccatalyst_version_min
 
-// INVERTED: "-arch" "x86_64" "-maccatalyst_version_min" "13.1.0" "-macosx_version_min" "10.15"
+// INVERTED: "-arch" "x86_64" "-maccatalyst_version_min" "13.1.0" "-macos_version_min" "10.15"
 // INVERTED: "-arch" "x86_64h" "-maccatalyst_version_min" "13.1.0"
-// INVERTED-NOT: macosx_version_min
+// INVERTED-NOT: macos_version_min

--- a/clang/test/Driver/target-triple-deployment.c
+++ b/clang/test/Driver/target-triple-deployment.c
@@ -15,13 +15,13 @@
 // RUN: FileCheck %s < %t.log
 
 // CHECK: {{ld(.exe)?"}}
-// CHECK: -macosx_version_min
+// CHECK: -macos_version_min
 // CHECK: 10.4.0
 // CHECK: {{ld(.exe)?"}}
-// CHECK: -macosx_version_min
+// CHECK: -macos_version_min
 // CHECK: 10.5.0
 // CHECK: {{ld(.exe)?"}}
-// CHECK: -macosx_version_min
+// CHECK: -macos_version_min
 // CHECK: 10.7.0
 // CHECK: {{ld(.exe)?"}}
 // CHECK: -iphoneos_version_min

--- a/lld/test/MachO/silent-ignore.s
+++ b/lld/test/MachO/silent-ignore.s
@@ -7,7 +7,7 @@
 # RUN: %lld --version \
 # RUN:   -dynamic \
 # RUN:   -lto_library /lib/foo \
-# RUN:   -macosx_version_min 0 \
+# RUN:   -macos_version_min 0 \
 # RUN:   -no_dtrace_dof \
 # RUN:   -dependency_info /path/to/dependency_info.dat \
 # RUN:   -lto_library ../lib/libLTO.dylib \

--- a/llvm/test/tools/dsymutil/X86/alias.test
+++ b/llvm/test/tools/dsymutil/X86/alias.test
@@ -20,4 +20,4 @@
 # Compile with:
 #   $ clang -g -O0 bar.c -c -o bar.o
 #   $ clang -g -O0 foo.c -c -o foo.o
-#   $ ld -arch x86_64 -macosx_version_min 10.13.0 foo.o bar.o -lSystem -alias _foo _bar -o foobar
+#   $ ld -arch x86_64 -macos_version_min 10.13.0 foo.o bar.o -lSystem -alias _foo _bar -o foobar

--- a/llvm/test/tools/dsymutil/X86/swift-ast-x86_64.test
+++ b/llvm/test/tools/dsymutil/X86/swift-ast-x86_64.test
@@ -14,7 +14,7 @@ let x = 1
 
 Compiled with:
   swiftc /tmp/test.swift -Onone -target x86_64-apple-macosx10.9 -c
-  ld swift-ast.o -add_ast_path Inputs/swift-ast.swiftmodule -arch x86_64 -lSystem -macosx_version_min 10.9.0
+  ld swift-ast.o -add_ast_path Inputs/swift-ast.swiftmodule -arch x86_64 -lSystem -macos_version_min 10.9.0
 
 DSYMUTIL: filename:{{.*}}swift-ast.swiftmodule
 DSYMUTIL-NOT: The file was not recognized as a valid object file

--- a/llvm/test/tools/dsymutil/X86/swift-dwarf-loc.test
+++ b/llvm/test/tools/dsymutil/X86/swift-dwarf-loc.test
@@ -32,7 +32,7 @@ target triple = "x86_64-apple-macosx10.12"
 !12 = !{i32 2, !"Debug Info Version", i32 3}
 
 Compiled with: llc -filetype=obj %p/../Inputs/swift-dwarf-loc.ll -mtriple x86_64-apple-darwin
-Linked with: ld -dylib %T/swift-dwarf-loc.o -arch x86_64 -lSystem -macosx_version_min 10.9.0
+Linked with: ld -dylib %T/swift-dwarf-loc.o -arch x86_64 -lSystem -macos_version_min 10.9.0
 
 CHECK: __var,
 CHECK-NOT: __var,{{.*}}binAddr: 0x0000000000000000

--- a/llvm/test/tools/dsymutil/null-die.test
+++ b/llvm/test/tools/dsymutil/null-die.test
@@ -25,7 +25,7 @@
 #
 # To generate the debug map:
 #
-#   $ ld -arch x86_64 -macosx_version_min 10.13.0 -lSystem null_die.o -o null_die
+#   $ ld -arch x86_64 -macos_version_min 10.13.0 -lSystem null_die.o -o null_die
 #   $ dsymutil -dump-debug-map null_die
 
 ---

--- a/llvm/test/tools/llvm-objdump/MachO/LLVM-bundle.test
+++ b/llvm/test/tools/llvm-objdump/MachO/LLVM-bundle.test
@@ -23,7 +23,7 @@
 # CHECK:   </dylibs>
 # CHECK:   <link-options>
 # CHECK:    <option>-execute</option>
-# CHECK:    <option>-macosx_version_min</option>
+# CHECK:    <option>-macos_version_min</option>
 # CHECK:    <option>10.11.0</option>
 # CHECK:    <option>-e</option>
 # CHECK:    <option>_main</option>

--- a/llvm/test/tools/lto/hide-linkonce-odr.ll
+++ b/llvm/test/tools/lto/hide-linkonce-odr.ll
@@ -1,5 +1,5 @@
 ; RUN: llvm-as %s -o %t.o
-; RUN: %ld64 -lto_library %llvmshlibdir/libLTO.dylib -dylib -arch x86_64 -macosx_version_min 10.10.0 -o %t.dylib %t.o -save-temps  -undefined dynamic_lookup -exported_symbol _c -exported_symbol _b  -exported_symbol _GlobLinkonce -lSystem
+; RUN: %ld64 -lto_library %llvmshlibdir/libLTO.dylib -dylib -arch x86_64 -macos_version_min 10.10.0 -o %t.dylib %t.o -save-temps  -undefined dynamic_lookup -exported_symbol _c -exported_symbol _b  -exported_symbol _GlobLinkonce -lSystem
 
 ; RUN: llvm-dis %t.dylib.lto.opt.bc -o - | FileCheck --check-prefix=IR %s
 ; check that @a is no longer a linkonce_odr definition


### PR DESCRIPTION
`-macosx_version_min` has been renamed to `-macos_version_min`.

