### PR TITLE
[docs] Add "QoI", "QoL" to LLVM lexicon

### DIFF
--- a/llvm/docs/Lexicon.rst
+++ b/llvm/docs/Lexicon.rst
@@ -242,6 +242,38 @@ P
 **PRE**
     Partial Redundancy Elimination
 
+Q
+-
+
+.. _qoi:
+
+**QoI**
+    Quality of Implementation.
+
+    In contexts where software implements some standard, such as the C++
+    standard, QoI is used to refer to bits that add additional value beyond just
+    what is mandated by that standard.
+
+    In the context of the LLVM project, for example, the Clang compiler is
+    mandated to successfully translate C programs that strictly conform to the C
+    standard. However, when given invalid programs as input, it prints detailed
+    error messages, as well as "fix-it" hints that correct issues when applied.
+    All of these are "QoI" -- that is, not strictly necessary to conform to the
+    standard, but very nice to have.
+
+    Although the terms may be used interchangeably in many contexts, this is
+    technically distinct from `QoL`_.
+
+.. _qol:
+
+**QoL**
+    Quality of Life.
+
+    Outside of the LLVM project,
+    `quality of life (QoL) <https://en.wikipedia.org/wiki/Quality_of_life>`_ is,
+    by far, used much more commonly than `QoI`_. However, within LLVM, it is
+    most likely a typo, used where an author meant to write `QoI`_.
+
 R
 -
 


### PR DESCRIPTION
Add the terms "QoI" (quality of implementation) and "QoL" (quality of life) to the lexicon.

One might ask: why classify "QoL" as a typo? Couldn't it be considered an alternative, technically distinct term to "QoI?"

I thought so as well at first, but then I checked the rate of occurrence of both terms within the project. Outside of the lexicon, "QoI" appears 7 times in the LLVM source code, and in 28 commit messages:

```
$ git grep -I QoI -- ":!llvm/docs/Lexicon.rst" | wc -l
      7
$ git grep --grep=QoI --format=oneline -- ":!llvm/docs/Lexicon.rst" | wc -l
      28
```

"QoL" does not appear at all in source code, and in only 3 commit messages:

```
$ git grep -I QoL -- ":!llvm/docs/Lexicon.rst" | wc -l
      0
$ git log --grep=QoL --format=oneline -- ":!llvm/docs/Lexicon.rst" | wc -l
      3
```

So, "QoI" appears around 9 times as frequently in commit messages, and "QoL" never appears in source code. Further, in one of the three commit messages in which it appears, "QoL" seems to be used where "QoI" would be more appropriate.

Based on its lack of prevalence within the project, this patch treats "QoL" as either a typo for "QoI," or an obscure acronym for "quality of life."