### PR TITLE
CompilerRT: Normalize COMPILER_RT_DEFAULT_TARGET_TRIPLE

### DIFF
--- a/compiler-rt/cmake/Modules/CompilerRTUtils.cmake
+++ b/compiler-rt/cmake/Modules/CompilerRTUtils.cmake
@@ -363,9 +363,19 @@ macro(construct_compiler_rt_default_triple)
     endif()
     message(STATUS "cmake c compiler target: ${CMAKE_C_COMPILER_TARGET}")
     set(COMPILER_RT_DEFAULT_TARGET_TRIPLE ${CMAKE_C_COMPILER_TARGET})
+    if ("${CMAKE_C_COMPILER_ID}" MATCHES "Clang")
+      execute_process(COMMAND ${CMAKE_C_COMPILER} --target=${COMPILER_RT_DEFAULT_TARGET_TRIPLE} -print-effective-triple
+                      OUTPUT_VARIABLE COMPILER_RT_DEFAULT_TARGET_TRIPLE
+                      OUTPUT_STRIP_TRAILING_WHITESPACE)
+    endif()
   else()
     set(COMPILER_RT_DEFAULT_TARGET_TRIPLE ${LLVM_TARGET_TRIPLE} CACHE STRING
           "Default triple for which compiler-rt runtimes will be built.")
+    if ("${CMAKE_C_COMPILER_ID}" MATCHES "Clang")
+      execute_process(COMMAND ${CMAKE_C_COMPILER} --target=${COMPILER_RT_DEFAULT_TARGET_TRIPLE} -print-effective-triple
+                      OUTPUT_VARIABLE COMPILER_RT_DEFAULT_TARGET_TRIPLE
+                      OUTPUT_STRIP_TRAILING_WHITESPACE)
+    endif()
   endif()
 
   string(REPLACE "-" ";" LLVM_TARGET_TRIPLE_LIST ${COMPILER_RT_DEFAULT_TARGET_TRIPLE})

--- a/compiler-rt/cmake/Modules/CompilerRTUtils.cmake
+++ b/compiler-rt/cmake/Modules/CompilerRTUtils.cmake
@@ -363,19 +363,15 @@ macro(construct_compiler_rt_default_triple)
     endif()
     message(STATUS "cmake c compiler target: ${CMAKE_C_COMPILER_TARGET}")
     set(COMPILER_RT_DEFAULT_TARGET_TRIPLE ${CMAKE_C_COMPILER_TARGET})
-    if ("${CMAKE_C_COMPILER_ID}" MATCHES "Clang")
-      execute_process(COMMAND ${CMAKE_C_COMPILER} --target=${COMPILER_RT_DEFAULT_TARGET_TRIPLE} -print-effective-triple
-                      OUTPUT_VARIABLE COMPILER_RT_DEFAULT_TARGET_TRIPLE
-                      OUTPUT_STRIP_TRAILING_WHITESPACE)
-    endif()
   else()
     set(COMPILER_RT_DEFAULT_TARGET_TRIPLE ${LLVM_TARGET_TRIPLE} CACHE STRING
           "Default triple for which compiler-rt runtimes will be built.")
-    if ("${CMAKE_C_COMPILER_ID}" MATCHES "Clang")
-      execute_process(COMMAND ${CMAKE_C_COMPILER} --target=${COMPILER_RT_DEFAULT_TARGET_TRIPLE} -print-effective-triple
-                      OUTPUT_VARIABLE COMPILER_RT_DEFAULT_TARGET_TRIPLE
-                      OUTPUT_STRIP_TRAILING_WHITESPACE)
-    endif()
+  endif()
+
+  if ("${CMAKE_C_COMPILER_ID}" MATCHES "Clang")
+    execute_process(COMMAND ${CMAKE_C_COMPILER} --target=${COMPILER_RT_DEFAULT_TARGET_TRIPLE} -print-effective-triple
+                    OUTPUT_VARIABLE COMPILER_RT_DEFAULT_TARGET_TRIPLE
+                    OUTPUT_STRIP_TRAILING_WHITESPACE)
   endif()
 
   string(REPLACE "-" ";" LLVM_TARGET_TRIPLE_LIST ${COMPILER_RT_DEFAULT_TARGET_TRIPLE})


### PR DESCRIPTION
If LLVM is configured with -DLLVM_DEFAULT_TARGET_TRIPLE, or compiler_rt is configured with -DCOMPILER_RT_DEFAULT_TARGET_TRIPLE, while the argument is not normalized, such as Debian-style vendor-less triple, clang will try to find libclang_rt in lib/<normalized_triple>, while libclang_rt is placed into lib/<triple_arg>.

Let's also place libclang_rt into lib/<normalized_triple>.