### PR TITLE
[DebugInfo] DWARF Units without DIEs are okay

### DIFF
--- a/llvm/include/llvm/DebugInfo/DWARF/DWARFDie.h
+++ b/llvm/include/llvm/DebugInfo/DWARF/DWARFDie.h
@@ -48,6 +48,7 @@ public:
   DWARFDie(DWARFUnit *Unit, const DWARFDebugInfoEntry *D) : U(Unit), Die(D) {}
 
   bool isValid() const { return U && Die; }
+  bool isValidUnit() const { return !!U; }
   explicit operator bool() const { return isValid(); }
   const DWARFDebugInfoEntry *getDebugInfoEntry() const { return Die; }
   DWARFUnit *getDwarfUnit() const { return U; }

--- a/llvm/include/llvm/DebugInfo/DWARF/DWARFUnit.h
+++ b/llvm/include/llvm/DebugInfo/DWARF/DWARFUnit.h
@@ -257,6 +257,8 @@ class DWARFUnit {
 
   std::shared_ptr<DWARFUnit> DWO;
 
+  bool DieExtractionSuccess;
+
 protected:
   friend dwarf_linker::parallel::CompileUnit;
 
@@ -442,9 +444,9 @@ public:
 
   DWARFDie getUnitDIE(bool ExtractUnitDIEOnly = true) {
     extractDIEsIfNeeded(ExtractUnitDIEOnly);
-    if (DieArray.empty())
+    if (!DieExtractionSuccess)
       return DWARFDie();
-    return DWARFDie(this, &DieArray[0]);
+    return DWARFDie(this, DieArray.empty() ? nullptr : &DieArray[0]);
   }
 
   DWARFDie getNonSkeletonUnitDIE(bool ExtractUnitDIEOnly = true,

--- a/llvm/lib/DebugInfo/DWARF/DWARFCompileUnit.cpp
+++ b/llvm/lib/DebugInfo/DWARF/DWARFCompileUnit.cpp
@@ -35,12 +35,17 @@ void DWARFCompileUnit::dump(raw_ostream &OS, DIDumpOptions DumpOpts) {
   OS << " (next unit at " << format("0x%08" PRIx64, getNextUnitOffset())
      << ")\n";
 
-  if (DWARFDie CUDie = getUnitDIE(false)) {
-    CUDie.dump(OS, 0, DumpOpts);
-    if (DumpOpts.DumpNonSkeleton) {
-      DWARFDie NonSkeletonCUDie = getNonSkeletonUnitDIE(false);
-      if (NonSkeletonCUDie && CUDie != NonSkeletonCUDie)
-        NonSkeletonCUDie.dump(OS, 0, DumpOpts);
+  DWARFDie CUDie = getUnitDIE(false);
+  if (CUDie.isValidUnit()) {
+    if (CUDie.isValid()) {
+      CUDie.dump(OS, 0, DumpOpts);
+      if (DumpOpts.DumpNonSkeleton) {
+        DWARFDie NonSkeletonCUDie = getNonSkeletonUnitDIE(false);
+        if (NonSkeletonCUDie && CUDie != NonSkeletonCUDie)
+          NonSkeletonCUDie.dump(OS, 0, DumpOpts);
+      }
+    } else {
+      OS << "<compile unit has no DIEs>\n\n";
     }
   } else {
     OS << "<compile unit can't be parsed!>\n\n";

--- a/llvm/lib/DebugInfo/DWARF/DWARFUnit.cpp
+++ b/llvm/lib/DebugInfo/DWARF/DWARFUnit.cpp
@@ -370,6 +370,7 @@ void DWARFUnit::clear() {
   SU = nullptr;
   clearDIEs(false);
   AddrDieMap.clear();
+  DieExtractionSuccess = true;
   if (DWO)
     DWO->clear();
   DWO.reset();
@@ -400,6 +401,10 @@ void DWARFUnit::extractDIEsToVector(
   assert(
       ((AppendCUDie && Dies.empty()) || (!AppendCUDie && Dies.size() == 1)) &&
       "Dies array is not empty");
+
+  if (DIEOffset == NextCUOffset) {
+    return;
+  }
 
   // Fill Parents and Siblings stacks with initial value.
   Parents.push_back(UINT32_MAX);
@@ -468,8 +473,10 @@ void DWARFUnit::extractDIEsToVector(
 }
 
 void DWARFUnit::extractDIEsIfNeeded(bool CUDieOnly) {
-  if (Error e = tryExtractDIEsIfNeeded(CUDieOnly))
+  if (Error e = tryExtractDIEsIfNeeded(CUDieOnly)) {
+    DieExtractionSuccess = false;
     Context.getRecoverableErrorHandler()(std::move(e));
+  }
 }
 
 Error DWARFUnit::tryExtractDIEsIfNeeded(bool CUDieOnly) {


### PR DESCRIPTION
Nothing prevents a DWARF Unit from having no DIEs. However, the API for interacting with DIE-less DWARF Units (through, e.g., getUnitDIE) is a little cumbersome and there are spurious warnings generated. This patch will prevent those warnings and makes it a little easier to work with a DIE-less DWARF Unit.