### PR TITLE
[analyzer] Use explicit call description mode (easy cases)

### DIFF
--- a/clang/lib/StaticAnalyzer/Checkers/CastValueChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/CastValueChecker.cpp
@@ -56,23 +56,23 @@ public:
 
 private:
   // These are known in the LLVM project. The pairs are in the following form:
-  // {{{namespace, call}, argument-count}, {callback, kind}}
+  // {{match-mode, {namespace, call}, argument-count}, {callback, kind}}
   const CallDescriptionMap<std::pair<CastCheck, CallKind>> CDM = {
-      {{{"llvm", "cast"}, 1},
+      {{CDM::SimpleFunc, {"llvm", "cast"}, 1},
        {&CastValueChecker::evalCast, CallKind::Function}},
-      {{{"llvm", "dyn_cast"}, 1},
+      {{CDM::SimpleFunc, {"llvm", "dyn_cast"}, 1},
        {&CastValueChecker::evalDynCast, CallKind::Function}},
-      {{{"llvm", "cast_or_null"}, 1},
+      {{CDM::SimpleFunc, {"llvm", "cast_or_null"}, 1},
        {&CastValueChecker::evalCastOrNull, CallKind::Function}},
-      {{{"llvm", "dyn_cast_or_null"}, 1},
+      {{CDM::SimpleFunc, {"llvm", "dyn_cast_or_null"}, 1},
        {&CastValueChecker::evalDynCastOrNull, CallKind::Function}},
-      {{{"clang", "castAs"}, 0},
+      {{CDM::CXXMethod, {"clang", "castAs"}, 0},
        {&CastValueChecker::evalCastAs, CallKind::Method}},
-      {{{"clang", "getAs"}, 0},
+      {{CDM::CXXMethod, {"clang", "getAs"}, 0},
        {&CastValueChecker::evalGetAs, CallKind::Method}},
-      {{{"llvm", "isa"}, 1},
+      {{CDM::SimpleFunc, {"llvm", "isa"}, 1},
        {&CastValueChecker::evalIsa, CallKind::InstanceOf}},
-      {{{"llvm", "isa_and_nonnull"}, 1},
+      {{CDM::SimpleFunc, {"llvm", "isa_and_nonnull"}, 1},
        {&CastValueChecker::evalIsaAndNonNull, CallKind::InstanceOf}}};
 
   void evalCast(const CallEvent &Call, DefinedOrUnknownSVal DV,

--- a/clang/lib/StaticAnalyzer/Checkers/ChrootChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/ChrootChecker.cpp
@@ -43,7 +43,8 @@ class ChrootChecker : public Checker<eval::Call, check::PreCall> {
   // This bug refers to possibly break out of a chroot() jail.
   const BugType BT_BreakJail{this, "Break out of jail"};
 
-  const CallDescription Chroot{{"chroot"}, 1}, Chdir{{"chdir"}, 1};
+  const CallDescription Chroot{CDM::CLibrary, {"chroot"}, 1},
+      Chdir{CDM::CLibrary, {"chdir"}, 1};
 
 public:
   ChrootChecker() {}

--- a/clang/lib/StaticAnalyzer/Checkers/ErrnoTesterChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/ErrnoTesterChecker.cpp
@@ -70,13 +70,15 @@ private:
 
   using EvalFn = std::function<void(CheckerContext &, const CallEvent &)>;
   const CallDescriptionMap<EvalFn> TestCalls{
-      {{{"ErrnoTesterChecker_setErrno"}, 1}, &ErrnoTesterChecker::evalSetErrno},
-      {{{"ErrnoTesterChecker_getErrno"}, 0}, &ErrnoTesterChecker::evalGetErrno},
-      {{{"ErrnoTesterChecker_setErrnoIfError"}, 0},
+      {{CDM::SimpleFunc, {"ErrnoTesterChecker_setErrno"}, 1},
+       &ErrnoTesterChecker::evalSetErrno},
+      {{CDM::SimpleFunc, {"ErrnoTesterChecker_getErrno"}, 0},
+       &ErrnoTesterChecker::evalGetErrno},
+      {{CDM::SimpleFunc, {"ErrnoTesterChecker_setErrnoIfError"}, 0},
        &ErrnoTesterChecker::evalSetErrnoIfError},
-      {{{"ErrnoTesterChecker_setErrnoIfErrorRange"}, 0},
+      {{CDM::SimpleFunc, {"ErrnoTesterChecker_setErrnoIfErrorRange"}, 0},
        &ErrnoTesterChecker::evalSetErrnoIfErrorRange},
-      {{{"ErrnoTesterChecker_setErrnoCheckState"}, 0},
+      {{CDM::SimpleFunc, {"ErrnoTesterChecker_setErrnoCheckState"}, 0},
        &ErrnoTesterChecker::evalSetErrnoCheckState}};
 };
 

--- a/clang/lib/StaticAnalyzer/Checkers/MmapWriteExecChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/MmapWriteExecChecker.cpp
@@ -27,8 +27,8 @@ using namespace ento;
 
 namespace {
 class MmapWriteExecChecker : public Checker<check::PreCall> {
-  CallDescription MmapFn;
-  CallDescription MprotectFn;
+  CallDescription MmapFn{CDM::CLibrary, {"mmap"}, 6};
+  CallDescription MprotectFn{CDM::CLibrary, {"mprotect"}, 3};
   static int ProtWrite;
   static int ProtExec;
   static int ProtRead;
@@ -36,7 +36,6 @@ class MmapWriteExecChecker : public Checker<check::PreCall> {
                    "Security"};
 
 public:
-  MmapWriteExecChecker() : MmapFn({"mmap"}, 6), MprotectFn({"mprotect"}, 3) {}
   void checkPreCall(const CallEvent &Call, CheckerContext &C) const;
   int ProtExecOv;
   int ProtReadOv;

--- a/clang/lib/StaticAnalyzer/Checkers/StdVariantChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/StdVariantChecker.cpp
@@ -129,9 +129,11 @@ static llvm::StringRef indefiniteArticleBasedOnVowel(char a) {
 
 class StdVariantChecker : public Checker<eval::Call, check::RegionChanges> {
   // Call descriptors to find relevant calls
-  CallDescription VariantConstructor{{"std", "variant", "variant"}};
-  CallDescription VariantAssignmentOperator{{"std", "variant", "operator="}};
-  CallDescription StdGet{{"std", "get"}, 1, 1};
+  CallDescription VariantConstructor{CDM::CXXMethod,
+                                     {"std", "variant", "variant"}};
+  CallDescription VariantAssignmentOperator{CDM::CXXMethod,
+                                            {"std", "variant", "operator="}};
+  CallDescription StdGet{CDM::SimpleFunc, {"std", "get"}, 1, 1};
 
   BugType BadVariantType{this, "BadVariantType", "BadVariantType"};
 

--- a/clang/lib/StaticAnalyzer/Checkers/StringChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/StringChecker.cpp
@@ -27,7 +27,7 @@ class StringChecker : public Checker<check::PreCall> {
   mutable const FunctionDecl *StringConstCharPtrCtor = nullptr;
   mutable CanQualType SizeTypeTy;
   const CallDescription TwoParamStdStringCtor = {
-      {"std", "basic_string", "basic_string"}, 2, 2};
+      CDM::CXXMethod, {"std", "basic_string", "basic_string"}, 2, 2};
 
   bool isCharToStringCtor(const CallEvent &Call, const ASTContext &ACtx) const;
 

--- a/clang/lib/StaticAnalyzer/Checkers/cert/PutenvWithAutoChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/cert/PutenvWithAutoChecker.cpp
@@ -30,7 +30,7 @@ class PutenvWithAutoChecker : public Checker<check::PostCall> {
 private:
   BugType BT{this, "'putenv' function should not be called with auto variables",
              categories::SecurityError};
-  const CallDescription Putenv{{"putenv"}, 1};
+  const CallDescription Putenv{CDM::CLibrary, {"putenv"}, 1};
 
 public:
   void checkPostCall(const CallEvent &Call, CheckerContext &C) const;


### PR DESCRIPTION
This commit explicitly specifies the matching mode (C library function, any non-method function, or C++ method) for the `CallDescription`s constructed in various checkers where this transition was easy and straightforward.

This change won't cause major functional changes, but isn't NFC because it ensures that e.g. call descriptions for a non-method function won't accidentally match a method that has the same name.

Separate commits will perform (or have already performed) this change in other checkers. My goal is to ensure that the call description mode is always explicitly specified and eliminate (or strongly restrict) the vague "may be either a method or a simple function" mode that's the current default.