### PR TITLE
[Clang][Sema] placement new initializes typedef array with correct size

### DIFF
--- a/clang/test/SemaCXX/PR41441.cpp
+++ b/clang/test/SemaCXX/PR41441.cpp
@@ -1,5 +1,5 @@
 // RUN: %clang -S -fno-discard-value-names -emit-llvm -o - %s | FileCheck %s
-// Issue no: 41441
+
 #include <new>
 
 // CHECK: call void @llvm.memset.p0.i64(ptr align 1 %x, i8 0, i64 8, i1 false)

--- a/clang/test/SemaCXX/PR41441.cpp
+++ b/clang/test/SemaCXX/PR41441.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang -S -fno-discard-value-names -emit-llvm -o - %s | FileCheck %s
+// RUN: %clang --target=x86_64-pc-linux -S -fno-discard-value-names -emit-llvm -o - %s | FileCheck %s
 
 #include <new>
 


### PR DESCRIPTION
Build Failure Fix
Fixes build failures due to #83124 