### PR TITLE
[clang] Avoid superfluous 'const' qualifiers in composite pointer type

### DIFF
--- a/clang/lib/Sema/SemaExprCXX.cpp
+++ b/clang/lib/Sema/SemaExprCXX.cpp
@@ -7260,8 +7260,8 @@ QualType Sema::FindCompositePointerType(SourceLocation Loc,
         Composite1 = Arr1->getElementType();
         Composite2 = Arr2->getElementType();
         Steps.emplace_back(Step::Array);
-        if (CAT1 || CAT2)
-          NeedConstBefore = Steps.size();
+        if ((CAT1 || CAT2) && Steps.size() > 2)
+          NeedConstBefore = Steps.size() - 2;
         continue;
       }
     }

--- a/clang/test/SemaCXX/cxx20-p0388-unbound-ary.cpp
+++ b/clang/test/SemaCXX/cxx20-p0388-unbound-ary.cpp
@@ -170,4 +170,28 @@ void g3() {
 
 } // namespace Eight
 
-#endif
+namespace Nine {
+
+template<auto, class>
+constexpr bool is_of_type = false;
+
+template<class T, T expr>
+constexpr bool is_of_type<expr, T> = true;
+
+using T1 = int (*)[1];
+using T2 = int (*)[];
+static_assert(is_of_type<0 ? T1() : T2(), T2>);
+
+using U1 = int* (**)[1];
+using U2 = int* (**)[];
+using U3 = int* (* const*)[];
+static_assert(is_of_type<0 ? U1() : U2(), U3>);
+
+using V1 = int* (*(**)[])[1];
+using V2 = int* (*(**)[1])[];
+using V3 = int* (* const(* const*)[])[];
+static_assert(is_of_type<0 ? V1() : V2(), V3>);
+
+} // namespace Nine
+
+#endif // __cplusplus >= 202002


### PR DESCRIPTION
Avoid adding `const` on too many levels to the qualification-combined type when going from "array of `N`" to "array of unknown bound of".

Fixes #66599