### PR TITLE
[flang][test] Detect OpenMP runtime when built via LLVM_RUNTIMES_TO_B…

### DIFF
--- a/flang/test/lit.site.cfg.py.in
+++ b/flang/test/lit.site.cfg.py.in
@@ -25,7 +25,7 @@ config.cc = "@CMAKE_C_COMPILER@"
 config.osx_sysroot = path(r"@CMAKE_OSX_SYSROOT@")
 config.targets_to_build = "@TARGETS_TO_BUILD@"
 config.default_sysroot = "@DEFAULT_SYSROOT@"
-config.have_openmp_rtl = ("@LLVM_TOOL_OPENMP_BUILD@" == "TRUE")
+config.have_openmp_rtl = ("@LLVM_TOOL_OPENMP_BUILD@" == "TRUE") or ("openmp" in "@LLVM_ENABLE_RUNTIMES@".lower().split(";"))
 config.flang_runtime_f128_math_lib = "@FLANG_RUNTIME_F128_MATH_LIB@"
 
 import lit.llvm


### PR DESCRIPTION
…UILD

The lit config was checking for the presence of the OpenMP runtime by looking at LLVM_TOOL_OPENMP_BUILD. This only works when the runtime is enabled in LLVM_PROJECTS_TO_BUILD. Expand the check to examine LLVM_RUNTIMES_TO_BUILD as well.