### PR TITLE
Fix threadprivate variable scope inside BLOCK construct.

### DIFF
--- a/flang/lib/Semantics/check-omp-structure.cpp
+++ b/flang/lib/Semantics/check-omp-structure.cpp
@@ -1048,7 +1048,7 @@ void OmpStructureChecker::CheckThreadprivateOrDeclareTargetVar(
                       name->symbol->GetUltimate().owner();
                   if (!curScope.IsTopLevel()) {
                     const semantics::Scope &declScope =
-                        GetProgramUnitContaining(curScope);
+                        GetProgramUnitOrBlockConstructContaining(curScope);
                     const semantics::Symbol *sym{
                         declScope.parent().FindSymbol(name->symbol->name())};
                     if (sym &&

--- a/flang/test/Lower/OpenMP/threadprivate-hlfir.f90
+++ b/flang/test/Lower/OpenMP/threadprivate-hlfir.f90
@@ -15,6 +15,8 @@
 !CHECK:      %{{.*}} = fir.call @_FortranAioOutputInteger32(%{{.*}}, %[[TP_VAL]]) fastmath<contract> : (!fir.ref<i8>, i32) -> i1
 !CHECK:      omp.terminator
 
+!CHECK:  fir.global internal @_QFsubEa : i32
+
 subroutine sub()
   integer, save:: a
   !$omp threadprivate(a)
@@ -22,22 +24,4 @@ subroutine sub()
     print *, a
   !$omp end parallel
 end subroutine
-
-!CHECK-LABEL: @_QPsub2() {
-!CHECK:   %[[STACK:.*]] = fir.call @llvm.stacksave.p0() fastmath<contract> : () -> !fir.ref<i8>
-!CHECK:   %[[A:.*]] = fir.address_of(@_QFsub2B1Ea) : !fir.ref<i32>
-!CHECK:   %[[A_DECL:.*]]:2 = hlfir.declare %[[A]] {uniq_name = "_QFsub2B1Ea"} : (!fir.ref<i32>) -> (!fir.ref<i32>, !fir.ref<i32>)
-!CHECK:   %[[TP_A:.*]] = omp.threadprivate %[[A_DECL]]#1 : !fir.ref<i32> -> !fir.ref<i32>
-!CHECK:   %[[TP_A_DECL:.*]]:2 = hlfir.declare %[[TP_A]] {uniq_name = "_QFsub2B1Ea"} : (!fir.ref<i32>) -> (!fir.ref<i32>, !fir.ref<i32>)
-!CHECK:   fir.call @llvm.stackrestore.p0(%[[STACK]]) fastmath<contract> : (!fir.ref<i8>) -> ()
-
-subroutine sub2()
-  BLOCK
-    integer, save :: a
-    !$omp threadprivate(a)
-  END BLOCK
-end subroutine
-
-!CHECK:  fir.global internal @_QFsubEa : i32
-!CHECK:  fir.global internal @_QFsub2B1Ea : i32
 

--- a/flang/test/Lower/OpenMP/threadprivate-hlfir.f90
+++ b/flang/test/Lower/OpenMP/threadprivate-hlfir.f90
@@ -15,8 +15,6 @@
 !CHECK:      %{{.*}} = fir.call @_FortranAioOutputInteger32(%{{.*}}, %[[TP_VAL]]) fastmath<contract> : (!fir.ref<i8>, i32) -> i1
 !CHECK:      omp.terminator
 
-!CHECK:  fir.global internal @_QFsubEa : i32
-
 subroutine sub()
   integer, save:: a
   !$omp threadprivate(a)
@@ -24,3 +22,22 @@ subroutine sub()
     print *, a
   !$omp end parallel
 end subroutine
+
+!CHECK-LABEL: @_QPsub2() {
+!CHECK:   %[[STACK:.*]] = fir.call @llvm.stacksave.p0() fastmath<contract> : () -> !fir.ref<i8>
+!CHECK:   %[[A:.*]] = fir.address_of(@_QFsub2B1Ea) : !fir.ref<i32>
+!CHECK:   %[[A_DECL:.*]]:2 = hlfir.declare %[[A]] {uniq_name = "_QFsub2B1Ea"} : (!fir.ref<i32>) -> (!fir.ref<i32>, !fir.ref<i32>)
+!CHECK:   %[[TP_A:.*]] = omp.threadprivate %[[A_DECL]]#1 : !fir.ref<i32> -> !fir.ref<i32>
+!CHECK:   %[[TP_A_DECL:.*]]:2 = hlfir.declare %[[TP_A]] {uniq_name = "_QFsub2B1Ea"} : (!fir.ref<i32>) -> (!fir.ref<i32>, !fir.ref<i32>)
+!CHECK:   fir.call @llvm.stackrestore.p0(%[[STACK]]) fastmath<contract> : (!fir.ref<i8>) -> ()
+
+subroutine sub2()
+  BLOCK
+    integer, save :: a
+    !$omp threadprivate(a)
+  END BLOCK
+end subroutine
+
+!CHECK:  fir.global internal @_QFsubEa : i32
+!CHECK:  fir.global internal @_QFsub2B1Ea : i32
+

--- a/flang/test/Semantics/OpenMP/threadprivate07.f90
+++ b/flang/test/Semantics/OpenMP/threadprivate07.f90
@@ -1,0 +1,15 @@
+! RUN: %python %S/../test_errors.py %s %flang_fc1 -fopenmp
+
+! Check Threadprivate Directive with local variable of a BLOCK construct.
+
+program main
+  call sub1()
+  print *, 'pass'
+end program main
+
+subroutine sub1()
+  BLOCK
+    integer, save :: a
+    !$omp threadprivate(a)
+  END BLOCK
+end subroutine


### PR DESCRIPTION
When a local variable inside a BLOCK construct is used as threadprivate variable, llvm-flang throws below error:

> error: The THREADPRIVATE directive and the common block or variable in it must appear in the same declaration section of a scoping unit