### PR TITLE
[MLIR][Types] add isFloat() to Type class

### DIFF
--- a/mlir/include/mlir/IR/Types.h
+++ b/mlir/include/mlir/IR/Types.h
@@ -133,6 +133,9 @@ public:
   bool isF80() const;
   bool isF128() const;
 
+  /// Return true if this is a floating point type.
+  bool isFloat() const;
+
   /// Return true if this is an integer type (with the specified width).
   bool isInteger() const;
   bool isInteger(unsigned width) const;

--- a/mlir/lib/IR/Types.cpp
+++ b/mlir/lib/IR/Types.cpp
@@ -53,6 +53,8 @@ bool Type::isF64() const { return llvm::isa<Float64Type>(*this); }
 bool Type::isF80() const { return llvm::isa<Float80Type>(*this); }
 bool Type::isF128() const { return llvm::isa<Float128Type>(*this); }
 
+bool Type::isFloat() const { return llvm::isa<FloatType>(*this); }
+
 bool Type::isIndex() const { return llvm::isa<IndexType>(*this); }
 
 bool Type::isInteger() const { return llvm::isa<IntegerType>(*this); }
@@ -101,24 +103,20 @@ bool Type::isUnsignedInteger(unsigned width) const {
 }
 
 bool Type::isSignlessIntOrIndex() const {
-  return isSignlessInteger() || llvm::isa<IndexType>(*this);
+  return isSignlessInteger() || isIndex();
 }
 
 bool Type::isSignlessIntOrIndexOrFloat() const {
-  return isSignlessInteger() || llvm::isa<IndexType, FloatType>(*this);
+  return isSignlessInteger() || isIndex() || isFloat();
 }
 
 bool Type::isSignlessIntOrFloat() const {
-  return isSignlessInteger() || llvm::isa<FloatType>(*this);
+  return isSignlessInteger() || isFloat();
 }
 
-bool Type::isIntOrIndex() const {
-  return llvm::isa<IntegerType>(*this) || isIndex();
-}
+bool Type::isIntOrIndex() const { return isInteger() || isIndex(); }
 
-bool Type::isIntOrFloat() const {
-  return llvm::isa<IntegerType, FloatType>(*this);
-}
+bool Type::isIntOrFloat() const { return isInteger() || isFloat(); }
 
 bool Type::isIntOrIndexOrFloat() const { return isIntOrFloat() || isIndex(); }
 


### PR DESCRIPTION
Add isFloat() as a member function to the Type class and canonicalize the compound queries to use the base queries.