### PR TITLE
[flang][cuda] Update memory effect on fir.cuda_allocate op

### DIFF
--- a/flang/include/flang/Optimizer/Dialect/FIROps.td
+++ b/flang/include/flang/Optimizer/Dialect/FIROps.td
@@ -3200,7 +3200,7 @@ def fir_CUDAAllocateOp : fir_Op<"cuda_allocate", [AttrSizedOperandSegments,
     is initialized before with the standard flang runtime calls.
   }];
 
-  let arguments = (ins Arg<AnyRefOrBoxType, "", [MemWrite]>:$box,
+  let arguments = (ins Arg<fir_ReferenceType, "", [MemRead, MemWrite]>:$box,
                        Arg<Optional<AnyRefOrBoxType>, "", [MemWrite]>:$errmsg,
                        Optional<AnyIntegerType>:$stream,
                        Arg<Optional<AnyRefOrBoxType>, "", [MemWrite]>:$pinned,

--- a/flang/lib/Optimizer/Dialect/FIROps.cpp
+++ b/flang/lib/Optimizer/Dialect/FIROps.cpp
@@ -3998,7 +3998,7 @@ mlir::LogicalResult fir::CUDAAllocateOp::verify() {
     return emitOpError("pinned and stream cannot appears at the same time");
   if (!fir::unwrapRefType(getBox().getType()).isa<fir::BaseBoxType>())
     return emitOpError(
-        "expect box to be a reference to/or a class or box type value");
+        "expect box to be a reference to a class or box type value");
   if (getSource() &&
       !fir::unwrapRefType(getSource().getType()).isa<fir::BaseBoxType>())
     return emitOpError(

--- a/flang/test/Fir/cuf-invalid.fir
+++ b/flang/test/Fir/cuf-invalid.fir
@@ -16,7 +16,7 @@ func.func @_QPsub1() {
 
 func.func @_QPsub1() {
   %1 = fir.alloca i32
-  // expected-error@+1{{'fir.cuda_allocate' op expect box to be a reference to/or a class or box type value}}
+  // expected-error@+1{{'fir.cuda_allocate' op expect box to be a reference to a class or box type value}}
   %2 = fir.cuda_allocate %1 : !fir.ref<i32> {cuda_attr = #fir.cuda<device>} -> i32
   return
 }


### PR DESCRIPTION
Add MemRead effect on the box operand as the descriptor might be read when performing the allocation of the data. 

Also update the expected type of the box operand to be a reference. Check in the verifier that this is a reference to a box or class type. 

This addresses the comment made post commit on #88586 