### PR TITLE
[llvm][CMake] Introduce LLVM_RUNTIME_<project>_BUILD in CMake

### DIFF
--- a/llvm/CMakeLists.txt
+++ b/llvm/CMakeLists.txt
@@ -254,7 +254,8 @@ endif()
 unset(SHOULD_ENABLE_PROJECT)
 
 # Set LLVM_RUNTIME_<project>_BUILD variables if a sub-project is enabled to be built as
-# a runtime.
+# a runtime.  As with LLVM_TOOL_<project>_BUILD, the LLVM_RUNTIME_<project>_BUILD variables
+# should be not directly used from the CMake configuration command line.
 foreach(proj ${LLVM_SUPPORTED_RUNTIMES})
   set(SHOULD_ENABLE_PROJECT FALSE)
   string(TOUPPER "${proj}" upper_proj)

--- a/llvm/CMakeLists.txt
+++ b/llvm/CMakeLists.txt
@@ -253,36 +253,6 @@ if (LLVM_ENABLE_PROJECTS_USED OR NOT LLVM_ENABLE_PROJECTS STREQUAL "")
 endif()
 unset(SHOULD_ENABLE_PROJECT)
 
-# Set LLVM_RUNTIME_<project>_BUILD variables if a sub-project is enabled to be built as
-# a runtime.  As with LLVM_TOOL_<project>_BUILD, the LLVM_RUNTIME_<project>_BUILD variables
-# should be not directly used from the CMake configuration command line.
-foreach(proj ${LLVM_SUPPORTED_RUNTIMES})
-  set(SHOULD_ENABLE_PROJECT FALSE)
-  string(TOUPPER "${proj}" upper_proj)
-  string(REGEX REPLACE "-" "_" upper_proj ${upper_proj})
-  if ("${proj}" IN_LIST LLVM_ENABLE_RUNTIMES)
-    message(STATUS "${proj} runtime is enabled")
-    set(SHOULD_ENABLE_PROJECT TRUE)
-    set(PROJ_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../${proj}")
-    if(NOT EXISTS "${PROJ_DIR}" OR NOT IS_DIRECTORY "${PROJ_DIR}")
-      message(FATAL_ERROR "LLVM_ENABLE_RUNTIMES requests ${proj} but directory not found: ${PROJ_DIR}")
-    endif()
-    if(LLVM_EXTERNAL_${upper_proj}_SOURCE_DIR STREQUAL "" )
-      set(LLVM_EXTERNAL_${upper_proj}_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../${proj}" CACHE PATH "" FORCE)
-    else()
-      set(LLVM_EXTERNAL_${upper_proj}_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../${proj}" CACHE PATH "")
-    endif()
-  else()
-    message(STATUS "${proj} runtime is disabled")
-    set(SHOULD_ENABLE_PROJECT FALSE)
-  endif()
-  set(LLVM_RUNTIME_${upper_proj}_BUILD
-      ${SHOULD_ENABLE_PROJECT}
-      CACHE
-      BOOL "Whether to build runtime ${upper_proj} as part of LLVM" FORCE)
-endforeach()
-unset(SHOULD_ENABLE_PROJECT)
-
 # Build llvm with ccache if the package is present
 set(LLVM_CCACHE_BUILD OFF CACHE BOOL "Set to ON for a ccache enabled build")
 if(LLVM_CCACHE_BUILD)

--- a/llvm/CMakeLists.txt
+++ b/llvm/CMakeLists.txt
@@ -253,6 +253,35 @@ if (LLVM_ENABLE_PROJECTS_USED OR NOT LLVM_ENABLE_PROJECTS STREQUAL "")
 endif()
 unset(SHOULD_ENABLE_PROJECT)
 
+# Set LLVM_RUNTIME_<project>_BUILD variables if a sub-project is enabled to be built as
+# a runtime.
+foreach(proj ${LLVM_SUPPORTED_RUNTIMES})
+  set(SHOULD_ENABLE_PROJECT FALSE)
+  string(TOUPPER "${proj}" upper_proj)
+  string(REGEX REPLACE "-" "_" upper_proj ${upper_proj})
+  if ("${proj}" IN_LIST LLVM_ENABLE_RUNTIMES)
+    message(STATUS "${proj} runtime is enabled")
+    set(SHOULD_ENABLE_PROJECT TRUE)
+    set(PROJ_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../${proj}")
+    if(NOT EXISTS "${PROJ_DIR}" OR NOT IS_DIRECTORY "${PROJ_DIR}")
+      message(FATAL_ERROR "LLVM_ENABLE_RUNTIMES requests ${proj} but directory not found: ${PROJ_DIR}")
+    endif()
+    if(LLVM_EXTERNAL_${upper_proj}_SOURCE_DIR STREQUAL "" )
+      set(LLVM_EXTERNAL_${upper_proj}_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../${proj}" CACHE PATH "" FORCE)
+    else()
+      set(LLVM_EXTERNAL_${upper_proj}_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../${proj}" CACHE PATH "")
+    endif()
+  else()
+    message(STATUS "${proj} runtime is disabled")
+    set(SHOULD_ENABLE_PROJECT FALSE)
+  endif()
+  set(LLVM_RUNTIME_${upper_proj}_BUILD
+      ${SHOULD_ENABLE_PROJECT}
+      CACHE
+      BOOL "Whether to build runtime ${upper_proj} as part of LLVM" FORCE)
+endforeach()
+unset(SHOULD_ENABLE_PROJECT)
+
 # Build llvm with ccache if the package is present
 set(LLVM_CCACHE_BUILD OFF CACHE BOOL "Set to ON for a ccache enabled build")
 if(LLVM_CCACHE_BUILD)

--- a/llvm/runtimes/CMakeLists.txt
+++ b/llvm/runtimes/CMakeLists.txt
@@ -208,6 +208,36 @@ foreach(entry ${runtimes})
   list(APPEND RUNTIME_NAMES ${name})
 endforeach()
 
+# Set LLVM_RUNTIME_<project>_BUILD variables if a sub-project is enabled to be built as
+# a runtime.  As with LLVM_TOOL_<project>_BUILD, the LLVM_RUNTIME_<project>_BUILD variables
+# should be not directly used from the CMake configuration command line.
+foreach(proj ${LLVM_SUPPORTED_RUNTIMES})
+  set(SHOULD_ENABLE_RUNTIME FALSE)
+  string(TOUPPER "${proj}" upper_proj)
+  string(REGEX REPLACE "-" "_" upper_proj ${upper_proj})
+  if ("${proj}" IN_LIST LLVM_ENABLE_RUNTIMES)
+    message(STATUS "${proj} runtime is enabled")
+    set(SHOULD_ENABLE_RUNTIME TRUE)
+    set(PROJ_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../../${proj}")
+    if(NOT EXISTS "${PROJ_DIR}" OR NOT IS_DIRECTORY "${PROJ_DIR}")
+      message(FATAL_ERROR "LLVM_ENABLE_RUNTIMES requests ${proj} but directory not found: ${PROJ_DIR}")
+    endif()
+    if(LLVM_EXTERNAL_${upper_proj}_SOURCE_DIR STREQUAL "" )
+      set(LLVM_EXTERNAL_${upper_proj}_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../../${proj}" CACHE PATH "" FORCE)
+    else()
+      set(LLVM_EXTERNAL_${upper_proj}_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../../${proj}" CACHE PATH "")
+    endif()
+  else()
+    message(STATUS "${proj} runtime is disabled")
+    set(SHOULD_ENABLE_RUNTIME FALSE)
+  endif()
+  set(LLVM_RUNTIME_${upper_proj}_BUILD
+      ${SHOULD_ENABLE_RUNTIME}
+      CACHE
+      BOOL "Whether to build runtime ${upper_proj} as part of LLVM" FORCE)
+endforeach()
+unset(SHOULD_ENABLE_RUNTIME)
+
 function(runtime_default_target)
   cmake_parse_arguments(ARG "" "" "DEPENDS;CMAKE_ARGS;PREFIXES" ${ARGN})
 

--- a/llvm/runtimes/CMakeLists.txt
+++ b/llvm/runtimes/CMakeLists.txt
@@ -216,7 +216,7 @@ foreach(proj ${LLVM_SUPPORTED_RUNTIMES})
   string(TOUPPER "${proj}" upper_proj)
   string(REGEX REPLACE "-" "_" upper_proj ${upper_proj})
   if ("${proj}" IN_LIST LLVM_ENABLE_RUNTIMES)
-    message(STATUS "${proj} runtime is enabled")
+    message(STATUS "${proj} runtime is enabled for bootstrap build")
     set(SHOULD_ENABLE_RUNTIME TRUE)
     set(PROJ_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../../${proj}")
     if(NOT EXISTS "${PROJ_DIR}" OR NOT IS_DIRECTORY "${PROJ_DIR}")
@@ -231,7 +231,7 @@ foreach(proj ${LLVM_SUPPORTED_RUNTIMES})
     message(STATUS "${proj} runtime is disabled")
     set(SHOULD_ENABLE_RUNTIME FALSE)
   endif()
-  set(LLVM_RUNTIME_${upper_proj}_BUILD
+  set(LLVM_BOOTSTRAP_RUNTIME_${upper_proj}_BUILD
       ${SHOULD_ENABLE_RUNTIME}
       CACHE
       BOOL "Whether to build runtime ${upper_proj} as part of LLVM" FORCE)

--- a/runtimes/CMakeLists.txt
+++ b/runtimes/CMakeLists.txt
@@ -43,6 +43,27 @@ foreach(proj ${LLVM_ENABLE_RUNTIMES})
   set(LLVM_EXTERNAL_${canon_name}_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../${proj}")
 endforeach()
 
+# Set LLVM_RUNTIME_<project>_BUILD variables if a sub-project is enabled to be built as
+# a runtime.  As with LLVM_TOOL_<project>_BUILD, the LLVM_RUNTIME_<project>_BUILD variables
+# should be not directly used from the CMake configuration command line.
+foreach(proj ${LLVM_SUPPORTED_RUNTIMES})
+  set(SHOULD_ENABLE_RUNTIME FALSE)
+  string(TOUPPER "${proj}" upper_proj)
+  string(REGEX REPLACE "-" "_" upper_proj ${upper_proj})
+  if ("${proj}" IN_LIST LLVM_ENABLE_RUNTIMES)
+    message(STATUS "${proj} runtime is enabled")
+    set(SHOULD_ENABLE_RUNTIME TRUE)
+  else()
+    message(STATUS "${proj} runtime is disabled")
+    set(SHOULD_ENABLE_RUNTIME FALSE)
+  endif()
+  set(LLVM_RUNTIME_${upper_proj}_BUILD
+      ${SHOULD_ENABLE_RUNTIME}
+      CACHE
+      BOOL "Whether to build runtime ${upper_proj} as part of LLVM" FORCE)
+endforeach()
+unset(SHOULD_ENABLE_RUNTIME)
+
 function(runtime_register_component name)
   set_property(GLOBAL APPEND PROPERTY SUB_COMPONENTS ${name})
 endfunction()


### PR DESCRIPTION
This PR adds CMake code to set `LLVM_RUNTIME_<project>_BUILD` similar to `LLVM_TOOL_<project>_BUILD`.  This makes it easier to detect if a particular runtime build has been requested.