### PR TITLE
[DWARF] Add support for DW_TAG_template_alias for template aliases

### DIFF
--- a/llvm/include/llvm/IR/DIBuilder.h
+++ b/llvm/include/llvm/IR/DIBuilder.h
@@ -310,6 +310,24 @@ namespace llvm {
                                  DINode::DIFlags Flags = DINode::FlagZero,
                                  DINodeArray Annotations = nullptr);
 
+    /// Create debugging information entry for a template alias.
+    /// \param Ty          Original type.
+    /// \param Name        Alias name.
+    /// \param File        File where this type is defined.
+    /// \param LineNo      Line number.
+    /// \param Context     The surrounding context for the alias.
+    /// \param TParams     The template arguments.
+    /// \param AlignInBits Alignment. (optional)
+    /// \param Flags       Flags to describe inheritance attribute (optional),
+    ///                    e.g. private.
+    /// \param Annotations Annotations. (optional)
+    DIDerivedType *createTemplateAlias(DIType *Ty, StringRef Name, DIFile *File,
+                                       unsigned LineNo, DIScope *Context,
+                                       DINodeArray TParams,
+                                       uint32_t AlignInBits = 0,
+                                       DINode::DIFlags Flags = DINode::FlagZero,
+                                       DINodeArray Annotations = nullptr);
+
     /// Create debugging information entry for a 'friend'.
     DIDerivedType *createFriend(DIType *Ty, DIType *FriendTy);
 

--- a/llvm/include/llvm/IR/DebugInfoMetadata.h
+++ b/llvm/include/llvm/IR/DebugInfoMetadata.h
@@ -1093,13 +1093,18 @@ public:
   /// Get extra data associated with this derived type.
   ///
   /// Class type for pointer-to-members, objective-c property node for ivars,
-  /// global constant wrapper for static members, or virtual base pointer offset
-  /// for inheritance.
+  /// global constant wrapper for static members, virtual base pointer offset
+  /// for inheritance, or a tuple of template parameters for template aliases.
   ///
   /// TODO: Separate out types that need this extra operand: pointer-to-member
   /// types and member fields (static members and ivars).
   Metadata *getExtraData() const { return getRawExtraData(); }
   Metadata *getRawExtraData() const { return getOperand(4); }
+
+  /// Get the template parameters from a template alias.
+  DITemplateParameterArray getTemplateParams() const {
+    return cast_or_null<MDTuple>(getExtraData());
+  }
 
   /// Get annotations associated with this derived type.
   DINodeArray getAnnotations() const {

--- a/llvm/lib/CodeGen/AsmPrinter/DebugHandlerBase.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/DebugHandlerBase.cpp
@@ -154,7 +154,8 @@ uint64_t DebugHandlerBase::getBaseTypeSize(const DIType *Ty) {
   if (Tag != dwarf::DW_TAG_member && Tag != dwarf::DW_TAG_typedef &&
       Tag != dwarf::DW_TAG_const_type && Tag != dwarf::DW_TAG_volatile_type &&
       Tag != dwarf::DW_TAG_restrict_type && Tag != dwarf::DW_TAG_atomic_type &&
-      Tag != dwarf::DW_TAG_immutable_type)
+      Tag != dwarf::DW_TAG_immutable_type &&
+      Tag != dwarf::DW_TAG_template_alias)
     return DDTy->getSizeInBits();
 
   DIType *BaseType = DDTy->getBaseType();
@@ -210,7 +211,8 @@ bool DebugHandlerBase::isUnsignedDIType(const DIType *Ty) {
     assert(T == dwarf::DW_TAG_typedef || T == dwarf::DW_TAG_const_type ||
            T == dwarf::DW_TAG_volatile_type ||
            T == dwarf::DW_TAG_restrict_type || T == dwarf::DW_TAG_atomic_type ||
-           T == dwarf::DW_TAG_immutable_type);
+           T == dwarf::DW_TAG_immutable_type ||
+           T == dwarf::DW_TAG_template_alias);
     assert(DTy->getBaseType() && "Expected valid base type");
     return isUnsignedDIType(DTy->getBaseType());
   }

--- a/llvm/lib/CodeGen/AsmPrinter/DwarfDebug.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/DwarfDebug.cpp
@@ -2483,6 +2483,7 @@ static dwarf::PubIndexEntryDescriptor computeIndexValue(DwarfUnit *CU,
   case dwarf::DW_TAG_typedef:
   case dwarf::DW_TAG_base_type:
   case dwarf::DW_TAG_subrange_type:
+  case dwarf::DW_TAG_template_alias:
     return dwarf::PubIndexEntryDescriptor(dwarf::GIEK_TYPE, dwarf::GIEL_STATIC);
   case dwarf::DW_TAG_namespace:
     return dwarf::GIEK_TYPE;

--- a/llvm/lib/CodeGen/AsmPrinter/DwarfUnit.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/DwarfUnit.cpp
@@ -803,6 +803,11 @@ void DwarfUnit::constructTypeDIE(DIE &Buffer, const DIDerivedType *DTy) {
   if (DTy->getDWARFAddressSpace())
     addUInt(Buffer, dwarf::DW_AT_address_class, dwarf::DW_FORM_data4,
             *DTy->getDWARFAddressSpace());
+
+  // Add template alias template parameters.
+  if (Tag == dwarf::DW_TAG_template_alias)
+    addTemplateParams(Buffer, DTy->getTemplateParams());
+
   if (auto PtrAuthData = DTy->getPtrAuthData()) {
     addUInt(Buffer, dwarf::DW_AT_LLVM_ptrauth_key, dwarf::DW_FORM_data1,
             PtrAuthData->key());

--- a/llvm/lib/DWARFLinker/Classic/DWARFLinker.cpp
+++ b/llvm/lib/DWARFLinker/Classic/DWARFLinker.cpp
@@ -116,6 +116,7 @@ static bool isTypeTag(uint16_t Tag) {
   case dwarf::DW_TAG_string_type:
   case dwarf::DW_TAG_structure_type:
   case dwarf::DW_TAG_subroutine_type:
+  case dwarf::DW_TAG_template_alias:
   case dwarf::DW_TAG_typedef:
   case dwarf::DW_TAG_union_type:
   case dwarf::DW_TAG_ptr_to_member_type:

--- a/llvm/lib/DebugInfo/DWARF/DWARFDie.cpp
+++ b/llvm/lib/DebugInfo/DWARF/DWARFDie.cpp
@@ -515,6 +515,7 @@ getTypeSizeImpl(DWARFDie Die, uint64_t PointerSize,
   case DW_TAG_immutable_type:
   case DW_TAG_volatile_type:
   case DW_TAG_restrict_type:
+  case DW_TAG_template_alias:
   case DW_TAG_typedef: {
     if (DWARFDie BaseType = Die.getAttributeValueAsReferencedDie(DW_AT_type))
       return getTypeSizeImpl(BaseType, PointerSize, Visited);

--- a/llvm/lib/IR/DIBuilder.cpp
+++ b/llvm/lib/IR/DIBuilder.cpp
@@ -356,6 +356,17 @@ DIDerivedType *DIBuilder::createTypedef(DIType *Ty, StringRef Name,
                             nullptr, Annotations);
 }
 
+DIDerivedType *
+DIBuilder::createTemplateAlias(DIType *Ty, StringRef Name, DIFile *File,
+                               unsigned LineNo, DIScope *Context,
+                               DINodeArray TParams, uint32_t AlignInBits,
+                               DINode::DIFlags Flags, DINodeArray Annotations) {
+  return DIDerivedType::get(VMContext, dwarf::DW_TAG_template_alias, Name, File,
+                            LineNo, getNonCompileUnitScope(Context), Ty, 0,
+                            AlignInBits, 0, std::nullopt, std::nullopt, Flags,
+                            TParams.get(), Annotations);
+}
+
 DIDerivedType *DIBuilder::createFriend(DIType *Ty, DIType *FriendTy) {
   assert(Ty && "Invalid type!");
   assert(FriendTy && "Invalid friend type!");

--- a/llvm/lib/IR/Verifier.cpp
+++ b/llvm/lib/IR/Verifier.cpp
@@ -1240,7 +1240,8 @@ void Verifier::visitDIDerivedType(const DIDerivedType &N) {
               (N.getTag() == dwarf::DW_TAG_variable && N.isStaticMember()) ||
               N.getTag() == dwarf::DW_TAG_inheritance ||
               N.getTag() == dwarf::DW_TAG_friend ||
-              N.getTag() == dwarf::DW_TAG_set_type,
+              N.getTag() == dwarf::DW_TAG_set_type ||
+              N.getTag() == dwarf::DW_TAG_template_alias,
           "invalid tag", &N);
   if (N.getTag() == dwarf::DW_TAG_ptr_to_member_type) {
     CheckDI(isType(N.getRawExtraData()), "invalid pointer to member type", &N,

--- a/llvm/test/DebugInfo/X86/template-alias.ll
+++ b/llvm/test/DebugInfo/X86/template-alias.ll
@@ -1,0 +1,71 @@
+; RUN: llc %s -o - --filetype=obj | llvm-dwarfdump - --name A --show-children | FileCheck %s --check-prefix=TREE
+
+;; -ggnu-pubnames (nameTableKind: GNU).
+; RUN: llc %s -o - --filetype=obj \
+; RUN: | llvm-dwarfdump - --debug-gnu-pubtypes \
+; RUN: | FileCheck %s --check-prefix=GNU-TYPES
+
+;; -gpubnames (remove nameTableKind field from DICompileUnit).
+; RUN: sed 's/, nameTableKind: GNU//g' < %s \
+; RUN: | llc - -o - --filetype=obj \
+; RUN: | llvm-dwarfdump - --debug-pubtypes \
+; RUN: | FileCheck %s --check-prefix=PUB-TYPES
+
+;; C++ source from clang/test/CodeGenCXX/template-alias.cpp, compiled with -gsce:
+;; template<typename Y, int Z>
+;; struct X {
+;;   Y m1 = Z;
+;; };
+;;
+;; template<typename B, int C>
+;; using A = X<B, C>;
+;;
+;; A<int, 5> a;
+
+;; Test emission of DIDerivedType with tag: DW_TAG_template_alias.
+
+; TREE: DW_TAG_template_alias
+; TREE: DW_AT_type (0x{{[0-9a-f]+}} "X<int, 5>")
+; TREE: DW_AT_name ("A")
+; TREE:   DW_TAG_template_type_parameter
+; TREE:     DW_AT_type        (0x{{[0-9a-f]+}} "int")
+; TREE:     DW_AT_name        ("B")
+; TREE:   DW_TAG_template_value_parameter
+; TREE:     DW_AT_type        (0x{{[0-9a-f]+}} "int")
+; TREE:     DW_AT_name        ("C")
+; TREE:     DW_AT_const_value (5)
+; TREE:   NULL
+
+; GNU-TYPES: STATIC   TYPE     "A"
+; PUB-TYPES: "A"
+
+target triple = "x86_64-unknown-unkown"
+
+%struct.X = type { i32 }
+
+@a = global %struct.X { i32 5 }, align 4, !dbg !0
+
+!llvm.dbg.cu = !{!2}
+!llvm.module.flags = !{!17, !18}
+!llvm.ident = !{!19}
+
+!0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
+!1 = distinct !DIGlobalVariable(name: "a", scope: !2, file: !5, line: 14, type: !6, isLocal: false, isDefinition: true)
+!2 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus_14, file: !3, producer: "clang version 19.0.0git", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, globals: !4, splitDebugInlining: false, nameTableKind: GNU)
+!3 = !DIFile(filename: "<stdin>", directory: "/")
+!4 = !{!0}
+!5 = !DIFile(filename: "clang/test/CodeGenCXX/template-alias.cpp", directory: "/")
+!6 = !DIDerivedType(tag: DW_TAG_template_alias, name: "A", file: !5, line: 12, baseType: !7, extraData: !14)
+!7 = distinct !DICompositeType(tag: DW_TAG_structure_type, name: "X<int, 5>", file: !5, line: 7, size: 32, flags: DIFlagTypePassByValue | DIFlagNonTrivial, elements: !8, templateParams: !11, identifier: "_ZTS1XIiLi5EE")
+!8 = !{!9}
+!9 = !DIDerivedType(tag: DW_TAG_member, name: "m1", scope: !7, file: !5, line: 8, baseType: !10, size: 32)
+!10 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+!11 = !{!12, !13}
+!12 = !DITemplateTypeParameter(name: "Y", type: !10)
+!13 = !DITemplateValueParameter(name: "Z", type: !10, value: i32 5)
+!14 = !{!15, !16}
+!15 = !DITemplateTypeParameter(name: "B", type: !10)
+!16 = !DITemplateValueParameter(name: "C", type: !10, value: i32 5)
+!17 = !{i32 2, !"Debug Info Version", i32 3}
+!18 = !{i32 1, !"wchar_size", i32 4}
+!19 = !{!"clang version 19.0.0git"}

--- a/llvm/test/tools/llvm-symbolizer/frame-types.s
+++ b/llvm/test/tools/llvm-symbolizer/frame-types.s
@@ -5,52 +5,56 @@
 
 // CHECK: f
 // CHECK-NEXT: a
-// CHECK-NEXT: /tmp{{/|\\}}frame-types.cpp:4
-// CHECK-NEXT: -1 1 ??
+// CHECK-NEXT: /tmp{{/|\\}}frame-types.cpp:11
+// CHECK-NEXT: -5 1 ??
 // CHECK-NEXT: f
 // CHECK-NEXT: b
-// CHECK-NEXT: /tmp{{/|\\}}frame-types.cpp:5
-// CHECK-NEXT: -8 4 ??
-// CHECK-NEXT: f
-// CHECK-NEXT: c
-// CHECK-NEXT: /tmp{{/|\\}}frame-types.cpp:6
+// CHECK-NEXT: /tmp{{/|\\}}frame-types.cpp:12
 // CHECK-NEXT: -12 4 ??
 // CHECK-NEXT: f
-// CHECK-NEXT: d
-// CHECK-NEXT: /tmp{{/|\\}}frame-types.cpp:7
+// CHECK-NEXT: c
+// CHECK-NEXT: /tmp{{/|\\}}frame-types.cpp:13
 // CHECK-NEXT: -16 4 ??
 // CHECK-NEXT: f
+// CHECK-NEXT: d
+// CHECK-NEXT: /tmp{{/|\\}}frame-types.cpp:14
+// CHECK-NEXT: -20 4 ??
+// CHECK-NEXT: f
 // CHECK-NEXT: e
-// CHECK-NEXT: /tmp{{/|\\}}frame-types.cpp:8
+// CHECK-NEXT: /tmp{{/|\\}}frame-types.cpp:15
 // CHECK-NEXT: -32 8 ??
 // CHECK-NEXT: f
 // CHECK-NEXT: f
-// CHECK-NEXT: /tmp{{/|\\}}frame-types.cpp:9
+// CHECK-NEXT: /tmp{{/|\\}}frame-types.cpp:16
 // CHECK-NEXT: -36 4 ??
 // CHECK-NEXT: f
 // CHECK-NEXT: g
-// CHECK-NEXT: /tmp{{/|\\}}frame-types.cpp:10
+// CHECK-NEXT: /tmp{{/|\\}}frame-types.cpp:17
 // CHECK-NEXT: -37 1 ??
 // CHECK-NEXT: f
 // CHECK-NEXT: h
-// CHECK-NEXT: /tmp{{/|\\}}frame-types.cpp:11
+// CHECK-NEXT: /tmp{{/|\\}}frame-types.cpp:18
 // CHECK-NEXT: -38 1 ??
 // CHECK-NEXT: f
 // CHECK-NEXT: i
-// CHECK-NEXT: /tmp{{/|\\}}frame-types.cpp:12
+// CHECK-NEXT: /tmp{{/|\\}}frame-types.cpp:19
 // CHECK-NEXT: -44 4 ??
 // CHECK-NEXT: f
 // CHECK-NEXT: j
-// CHECK-NEXT: /tmp{{/|\\}}frame-types.cpp:14
+// CHECK-NEXT: /tmp{{/|\\}}frame-types.cpp:21
 // CHECK-NEXT: -45 1 ??
 // CHECK-NEXT: f
 // CHECK-NEXT: k
-// CHECK-NEXT: /tmp{{/|\\}}frame-types.cpp:15
+// CHECK-NEXT: /tmp{{/|\\}}frame-types.cpp:22
 // CHECK-NEXT: -57 12 ??
 // CHECK-NEXT: f
 // CHECK-NEXT: l
-// CHECK-NEXT: /tmp{{/|\\}}frame-types.cpp:16
+// CHECK-NEXT: /tmp{{/|\\}}frame-types.cpp:23
 // CHECK-NEXT: -345 288 ??
+// CHECK-NEXT: f
+// CHECK-NEXT: m
+// CHECK-NEXT: /tmp{{/|\\}}frame-types.cpp:24
+// CHECK-NEXT: -352 4 ??
 
 // Generated from:
 //
@@ -76,14 +80,13 @@
 
 	.text
 	.file	"frame-types.cpp"
-	.globl	_Z1fv                   # -- Begin function _Z1fv
+	.globl	_Z1fv                           # -- Begin function _Z1fv
 	.p2align	4, 0x90
 	.type	_Z1fv,@function
 _Z1fv:                                  # @_Z1fv
 .Lfunc_begin0:
-	.file	1 "/tmp" "frame-types.cpp"
-	.loc	1 3 0                   # frame-types.cpp:3:0
-	.cfi_sections .debug_frame
+	.file	0 "/tmp" "frame-types.cpp"
+	.loc	0 10 0                          # frame-types.cpp:10:0
 	.cfi_startproc
 # %bb.0:                                # %entry
 	pushl	%ebp
@@ -91,441 +94,579 @@ _Z1fv:                                  # @_Z1fv
 	.cfi_offset %ebp, -8
 	movl	%esp, %ebp
 	.cfi_def_cfa_register %ebp
-	subl	$352, %esp              # imm = 0x160
 .Ltmp0:
-	.loc	1 6 9 prologue_end      # frame-types.cpp:6:9
-	leal	-1(%ebp), %eax
+	pushl	%ebx
+	subl	$372, %esp                      # imm = 0x174
+	.cfi_offset %ebx, -12
+	.loc	0 13 9 prologue_end             # frame-types.cpp:13:9
+	calll	.L0$pb
+.L0$pb:
+	popl	%ebx
 .Ltmp1:
-	#DEBUG_VALUE: f:a <- [$eax+0]
-	movl	%eax, -12(%ebp)
-	.loc	1 7 14                  # frame-types.cpp:7:14
-	movb	$1, -17(%ebp)
-	.loc	1 7 10 is_stmt 0        # frame-types.cpp:7:10
-	leal	-17(%ebp), %eax
-.Ltmp2:
+	addl	$_GLOBAL_OFFSET_TABLE_+(.Ltmp1-.L0$pb), %ebx
+	leal	-5(%ebp), %eax
 	movl	%eax, -16(%ebp)
-	.loc	1 10 14 is_stmt 1       # frame-types.cpp:10:14
+	.loc	0 14 14                         # frame-types.cpp:14:14
+	movb	$1, -21(%ebp)
+	.loc	0 14 10 is_stmt 0               # frame-types.cpp:14:10
+	leal	-21(%ebp), %eax
+	movl	%eax, -20(%ebp)
+	.loc	0 17 14 is_stmt 1               # frame-types.cpp:17:14
 	movb	$2, -37(%ebp)
-	.loc	1 17 1                  # frame-types.cpp:17:1
-	addl	$352, %esp              # imm = 0x160
+	.loc	0 24 14                         # frame-types.cpp:24:14
+	leal	-352(%ebp), %eax
+	xorl	%ecx, %ecx
+	movl	%eax, (%esp)
+	movl	$0, 4(%esp)
+	movl	$4, 8(%esp)
+	calll	memset@PLT
+	.loc	0 25 1 epilogue_begin           # frame-types.cpp:25:1
+	addl	$372, %esp                      # imm = 0x174
+	popl	%ebx
 	popl	%ebp
 	.cfi_def_cfa %esp, 4
 	retl
-.Ltmp3:
+.Ltmp2:
 .Lfunc_end0:
 	.size	_Z1fv, .Lfunc_end0-_Z1fv
 	.cfi_endproc
                                         # -- End function
-	.section	.debug_str,"MS",@progbits,1
-.Linfo_string0:
-	.asciz	"clang version 9.0.0 "  # string offset=0
-.Linfo_string1:
-	.asciz	"frame-types.cpp"       # string offset=21
-.Linfo_string2:
-	.asciz	"/tmp"                  # string offset=37
-.Linfo_string3:
-	.asciz	"_Z1fv"                 # string offset=42
-.Linfo_string4:
-	.asciz	"f"                     # string offset=48
-.Linfo_string5:
-	.asciz	"a"                     # string offset=50
-.Linfo_string6:
-	.asciz	"char"                  # string offset=52
-.Linfo_string7:
-	.asciz	"b"                     # string offset=57
-.Linfo_string8:
-	.asciz	"c"                     # string offset=59
-.Linfo_string9:
-	.asciz	"d"                     # string offset=61
-.Linfo_string10:
-	.asciz	"e"                     # string offset=63
-.Linfo_string11:
-	.asciz	"S"                     # string offset=65
-.Linfo_string12:
-	.asciz	"g"                     # string offset=67
-.Linfo_string13:
-	.asciz	"h"                     # string offset=69
-.Linfo_string14:
-	.asciz	"i"                     # string offset=71
-.Linfo_string15:
-	.asciz	"j"                     # string offset=73
-.Linfo_string16:
-	.asciz	"char_typedef"          # string offset=75
-.Linfo_string17:
-	.asciz	"k"                     # string offset=88
-.Linfo_string18:
-	.asciz	"__ARRAY_SIZE_TYPE__"   # string offset=90
-.Linfo_string19:
-	.asciz	"l"                     # string offset=110
 	.section	.debug_abbrev,"",@progbits
-	.byte	1                       # Abbreviation Code
-	.byte	17                      # DW_TAG_compile_unit
-	.byte	1                       # DW_CHILDREN_yes
-	.byte	37                      # DW_AT_producer
-	.byte	14                      # DW_FORM_strp
-	.byte	19                      # DW_AT_language
-	.byte	5                       # DW_FORM_data2
-	.byte	3                       # DW_AT_name
-	.byte	14                      # DW_FORM_strp
-	.byte	16                      # DW_AT_stmt_list
-	.byte	23                      # DW_FORM_sec_offset
-	.byte	27                      # DW_AT_comp_dir
-	.byte	14                      # DW_FORM_strp
-	.byte	17                      # DW_AT_low_pc
-	.byte	1                       # DW_FORM_addr
-	.byte	18                      # DW_AT_high_pc
-	.byte	6                       # DW_FORM_data4
-	.byte	0                       # EOM(1)
-	.byte	0                       # EOM(2)
-	.byte	2                       # Abbreviation Code
-	.byte	46                      # DW_TAG_subprogram
-	.byte	1                       # DW_CHILDREN_yes
-	.byte	17                      # DW_AT_low_pc
-	.byte	1                       # DW_FORM_addr
-	.byte	18                      # DW_AT_high_pc
-	.byte	6                       # DW_FORM_data4
-	.byte	64                      # DW_AT_frame_base
-	.byte	24                      # DW_FORM_exprloc
-	.byte	110                     # DW_AT_linkage_name
-	.byte	14                      # DW_FORM_strp
-	.byte	3                       # DW_AT_name
-	.byte	14                      # DW_FORM_strp
-	.byte	58                      # DW_AT_decl_file
-	.byte	11                      # DW_FORM_data1
-	.byte	59                      # DW_AT_decl_line
-	.byte	11                      # DW_FORM_data1
-	.byte	63                      # DW_AT_external
-	.byte	25                      # DW_FORM_flag_present
-	.byte	0                       # EOM(1)
-	.byte	0                       # EOM(2)
-	.byte	3                       # Abbreviation Code
-	.byte	52                      # DW_TAG_variable
-	.byte	0                       # DW_CHILDREN_no
-	.byte	2                       # DW_AT_location
-	.byte	24                      # DW_FORM_exprloc
-	.byte	3                       # DW_AT_name
-	.byte	14                      # DW_FORM_strp
-	.byte	58                      # DW_AT_decl_file
-	.byte	11                      # DW_FORM_data1
-	.byte	59                      # DW_AT_decl_line
-	.byte	11                      # DW_FORM_data1
-	.byte	73                      # DW_AT_type
-	.byte	19                      # DW_FORM_ref4
-	.byte	0                       # EOM(1)
-	.byte	0                       # EOM(2)
-	.byte	4                       # Abbreviation Code
-	.byte	22                      # DW_TAG_typedef
-	.byte	0                       # DW_CHILDREN_no
-	.byte	73                      # DW_AT_type
-	.byte	19                      # DW_FORM_ref4
-	.byte	3                       # DW_AT_name
-	.byte	14                      # DW_FORM_strp
-	.byte	58                      # DW_AT_decl_file
-	.byte	11                      # DW_FORM_data1
-	.byte	59                      # DW_AT_decl_line
-	.byte	11                      # DW_FORM_data1
-	.byte	0                       # EOM(1)
-	.byte	0                       # EOM(2)
-	.byte	5                       # Abbreviation Code
-	.byte	36                      # DW_TAG_base_type
-	.byte	0                       # DW_CHILDREN_no
-	.byte	3                       # DW_AT_name
-	.byte	14                      # DW_FORM_strp
-	.byte	62                      # DW_AT_encoding
-	.byte	11                      # DW_FORM_data1
-	.byte	11                      # DW_AT_byte_size
-	.byte	11                      # DW_FORM_data1
-	.byte	0                       # EOM(1)
-	.byte	0                       # EOM(2)
-	.byte	6                       # Abbreviation Code
-	.byte	15                      # DW_TAG_pointer_type
-	.byte	0                       # DW_CHILDREN_no
-	.byte	73                      # DW_AT_type
-	.byte	19                      # DW_FORM_ref4
-	.byte	0                       # EOM(1)
-	.byte	0                       # EOM(2)
-	.byte	7                       # Abbreviation Code
-	.byte	16                      # DW_TAG_reference_type
-	.byte	0                       # DW_CHILDREN_no
-	.byte	73                      # DW_AT_type
-	.byte	19                      # DW_FORM_ref4
-	.byte	0                       # EOM(1)
-	.byte	0                       # EOM(2)
-	.byte	8                       # Abbreviation Code
-	.byte	66                      # DW_TAG_rvalue_reference_type
-	.byte	0                       # DW_CHILDREN_no
-	.byte	73                      # DW_AT_type
-	.byte	19                      # DW_FORM_ref4
-	.byte	0                       # EOM(1)
-	.byte	0                       # EOM(2)
-	.byte	9                       # Abbreviation Code
-	.byte	31                      # DW_TAG_ptr_to_member_type
-	.byte	0                       # DW_CHILDREN_no
-	.byte	73                      # DW_AT_type
-	.byte	19                      # DW_FORM_ref4
-	.byte	29                      # DW_AT_containing_type
-	.byte	19                      # DW_FORM_ref4
-	.byte	0                       # EOM(1)
-	.byte	0                       # EOM(2)
-	.byte	10                      # Abbreviation Code
-	.byte	21                      # DW_TAG_subroutine_type
-	.byte	1                       # DW_CHILDREN_yes
-	.byte	73                      # DW_AT_type
-	.byte	19                      # DW_FORM_ref4
-	.byte	0                       # EOM(1)
-	.byte	0                       # EOM(2)
-	.byte	11                      # Abbreviation Code
-	.byte	5                       # DW_TAG_formal_parameter
-	.byte	0                       # DW_CHILDREN_no
-	.byte	73                      # DW_AT_type
-	.byte	19                      # DW_FORM_ref4
-	.byte	52                      # DW_AT_artificial
-	.byte	25                      # DW_FORM_flag_present
-	.byte	0                       # EOM(1)
-	.byte	0                       # EOM(2)
-	.byte	12                      # Abbreviation Code
-	.byte	19                      # DW_TAG_structure_type
-	.byte	0                       # DW_CHILDREN_no
-	.byte	3                       # DW_AT_name
-	.byte	14                      # DW_FORM_strp
-	.byte	60                      # DW_AT_declaration
-	.byte	25                      # DW_FORM_flag_present
-	.byte	0                       # EOM(1)
-	.byte	0                       # EOM(2)
-	.byte	13                      # Abbreviation Code
-	.byte	38                      # DW_TAG_const_type
-	.byte	0                       # DW_CHILDREN_no
-	.byte	73                      # DW_AT_type
-	.byte	19                      # DW_FORM_ref4
-	.byte	0                       # EOM(1)
-	.byte	0                       # EOM(2)
-	.byte	14                      # Abbreviation Code
-	.byte	53                      # DW_TAG_volatile_type
-	.byte	0                       # DW_CHILDREN_no
-	.byte	73                      # DW_AT_type
-	.byte	19                      # DW_FORM_ref4
-	.byte	0                       # EOM(1)
-	.byte	0                       # EOM(2)
-	.byte	15                      # Abbreviation Code
-	.byte	55                      # DW_TAG_restrict_type
-	.byte	0                       # DW_CHILDREN_no
-	.byte	73                      # DW_AT_type
-	.byte	19                      # DW_FORM_ref4
-	.byte	0                       # EOM(1)
-	.byte	0                       # EOM(2)
-	.byte	16                      # Abbreviation Code
-	.byte	1                       # DW_TAG_array_type
-	.byte	1                       # DW_CHILDREN_yes
-	.byte	73                      # DW_AT_type
-	.byte	19                      # DW_FORM_ref4
-	.byte	0                       # EOM(1)
-	.byte	0                       # EOM(2)
-	.byte	17                      # Abbreviation Code
-	.byte	33                      # DW_TAG_subrange_type
-	.byte	0                       # DW_CHILDREN_no
-	.byte	73                      # DW_AT_type
-	.byte	19                      # DW_FORM_ref4
-	.byte	55                      # DW_AT_count
-	.byte	11                      # DW_FORM_data1
-	.byte	0                       # EOM(1)
-	.byte	0                       # EOM(2)
-	.byte	18                      # Abbreviation Code
-	.byte	36                      # DW_TAG_base_type
-	.byte	0                       # DW_CHILDREN_no
-	.byte	3                       # DW_AT_name
-	.byte	14                      # DW_FORM_strp
-	.byte	11                      # DW_AT_byte_size
-	.byte	11                      # DW_FORM_data1
-	.byte	62                      # DW_AT_encoding
-	.byte	11                      # DW_FORM_data1
-	.byte	0                       # EOM(1)
-	.byte	0                       # EOM(2)
-	.byte	0                       # EOM(3)
+	.byte	1                               # Abbreviation Code
+	.byte	17                              # DW_TAG_compile_unit
+	.byte	1                               # DW_CHILDREN_yes
+	.byte	37                              # DW_AT_producer
+	.byte	37                              # DW_FORM_strx1
+	.byte	19                              # DW_AT_language
+	.byte	5                               # DW_FORM_data2
+	.byte	3                               # DW_AT_name
+	.byte	37                              # DW_FORM_strx1
+	.byte	114                             # DW_AT_str_offsets_base
+	.byte	23                              # DW_FORM_sec_offset
+	.byte	16                              # DW_AT_stmt_list
+	.byte	23                              # DW_FORM_sec_offset
+	.byte	27                              # DW_AT_comp_dir
+	.byte	37                              # DW_FORM_strx1
+	.byte	17                              # DW_AT_low_pc
+	.byte	27                              # DW_FORM_addrx
+	.byte	18                              # DW_AT_high_pc
+	.byte	6                               # DW_FORM_data4
+	.byte	115                             # DW_AT_addr_base
+	.byte	23                              # DW_FORM_sec_offset
+	.byte	0                               # EOM(1)
+	.byte	0                               # EOM(2)
+	.byte	2                               # Abbreviation Code
+	.byte	46                              # DW_TAG_subprogram
+	.byte	1                               # DW_CHILDREN_yes
+	.byte	17                              # DW_AT_low_pc
+	.byte	27                              # DW_FORM_addrx
+	.byte	18                              # DW_AT_high_pc
+	.byte	6                               # DW_FORM_data4
+	.byte	64                              # DW_AT_frame_base
+	.byte	24                              # DW_FORM_exprloc
+	.byte	110                             # DW_AT_linkage_name
+	.byte	37                              # DW_FORM_strx1
+	.byte	3                               # DW_AT_name
+	.byte	37                              # DW_FORM_strx1
+	.byte	58                              # DW_AT_decl_file
+	.byte	11                              # DW_FORM_data1
+	.byte	59                              # DW_AT_decl_line
+	.byte	11                              # DW_FORM_data1
+	.byte	63                              # DW_AT_external
+	.byte	25                              # DW_FORM_flag_present
+	.byte	0                               # EOM(1)
+	.byte	0                               # EOM(2)
+	.byte	3                               # Abbreviation Code
+	.byte	52                              # DW_TAG_variable
+	.byte	0                               # DW_CHILDREN_no
+	.byte	2                               # DW_AT_location
+	.byte	24                              # DW_FORM_exprloc
+	.byte	3                               # DW_AT_name
+	.byte	37                              # DW_FORM_strx1
+	.byte	58                              # DW_AT_decl_file
+	.byte	11                              # DW_FORM_data1
+	.byte	59                              # DW_AT_decl_line
+	.byte	11                              # DW_FORM_data1
+	.byte	73                              # DW_AT_type
+	.byte	19                              # DW_FORM_ref4
+	.byte	0                               # EOM(1)
+	.byte	0                               # EOM(2)
+	.byte	4                               # Abbreviation Code
+	.byte	22                              # DW_TAG_typedef
+	.byte	0                               # DW_CHILDREN_no
+	.byte	73                              # DW_AT_type
+	.byte	19                              # DW_FORM_ref4
+	.byte	3                               # DW_AT_name
+	.byte	37                              # DW_FORM_strx1
+	.byte	58                              # DW_AT_decl_file
+	.byte	11                              # DW_FORM_data1
+	.byte	59                              # DW_AT_decl_line
+	.byte	11                              # DW_FORM_data1
+	.byte	0                               # EOM(1)
+	.byte	0                               # EOM(2)
+	.byte	5                               # Abbreviation Code
+	.byte	36                              # DW_TAG_base_type
+	.byte	0                               # DW_CHILDREN_no
+	.byte	3                               # DW_AT_name
+	.byte	37                              # DW_FORM_strx1
+	.byte	62                              # DW_AT_encoding
+	.byte	11                              # DW_FORM_data1
+	.byte	11                              # DW_AT_byte_size
+	.byte	11                              # DW_FORM_data1
+	.byte	0                               # EOM(1)
+	.byte	0                               # EOM(2)
+	.byte	6                               # Abbreviation Code
+	.byte	15                              # DW_TAG_pointer_type
+	.byte	0                               # DW_CHILDREN_no
+	.byte	73                              # DW_AT_type
+	.byte	19                              # DW_FORM_ref4
+	.byte	0                               # EOM(1)
+	.byte	0                               # EOM(2)
+	.byte	7                               # Abbreviation Code
+	.byte	16                              # DW_TAG_reference_type
+	.byte	0                               # DW_CHILDREN_no
+	.byte	73                              # DW_AT_type
+	.byte	19                              # DW_FORM_ref4
+	.byte	0                               # EOM(1)
+	.byte	0                               # EOM(2)
+	.byte	8                               # Abbreviation Code
+	.byte	66                              # DW_TAG_rvalue_reference_type
+	.byte	0                               # DW_CHILDREN_no
+	.byte	73                              # DW_AT_type
+	.byte	19                              # DW_FORM_ref4
+	.byte	0                               # EOM(1)
+	.byte	0                               # EOM(2)
+	.byte	9                               # Abbreviation Code
+	.byte	31                              # DW_TAG_ptr_to_member_type
+	.byte	0                               # DW_CHILDREN_no
+	.byte	73                              # DW_AT_type
+	.byte	19                              # DW_FORM_ref4
+	.byte	29                              # DW_AT_containing_type
+	.byte	19                              # DW_FORM_ref4
+	.byte	0                               # EOM(1)
+	.byte	0                               # EOM(2)
+	.byte	10                              # Abbreviation Code
+	.byte	21                              # DW_TAG_subroutine_type
+	.byte	1                               # DW_CHILDREN_yes
+	.byte	73                              # DW_AT_type
+	.byte	19                              # DW_FORM_ref4
+	.byte	0                               # EOM(1)
+	.byte	0                               # EOM(2)
+	.byte	11                              # Abbreviation Code
+	.byte	5                               # DW_TAG_formal_parameter
+	.byte	0                               # DW_CHILDREN_no
+	.byte	73                              # DW_AT_type
+	.byte	19                              # DW_FORM_ref4
+	.byte	52                              # DW_AT_artificial
+	.byte	25                              # DW_FORM_flag_present
+	.byte	0                               # EOM(1)
+	.byte	0                               # EOM(2)
+	.byte	12                              # Abbreviation Code
+	.byte	19                              # DW_TAG_structure_type
+	.byte	0                               # DW_CHILDREN_no
+	.byte	3                               # DW_AT_name
+	.byte	37                              # DW_FORM_strx1
+	.byte	60                              # DW_AT_declaration
+	.byte	25                              # DW_FORM_flag_present
+	.byte	0                               # EOM(1)
+	.byte	0                               # EOM(2)
+	.byte	13                              # Abbreviation Code
+	.byte	38                              # DW_TAG_const_type
+	.byte	0                               # DW_CHILDREN_no
+	.byte	73                              # DW_AT_type
+	.byte	19                              # DW_FORM_ref4
+	.byte	0                               # EOM(1)
+	.byte	0                               # EOM(2)
+	.byte	14                              # Abbreviation Code
+	.byte	53                              # DW_TAG_volatile_type
+	.byte	0                               # DW_CHILDREN_no
+	.byte	73                              # DW_AT_type
+	.byte	19                              # DW_FORM_ref4
+	.byte	0                               # EOM(1)
+	.byte	0                               # EOM(2)
+	.byte	15                              # Abbreviation Code
+	.byte	55                              # DW_TAG_restrict_type
+	.byte	0                               # DW_CHILDREN_no
+	.byte	73                              # DW_AT_type
+	.byte	19                              # DW_FORM_ref4
+	.byte	0                               # EOM(1)
+	.byte	0                               # EOM(2)
+	.byte	16                              # Abbreviation Code
+	.byte	1                               # DW_TAG_array_type
+	.byte	1                               # DW_CHILDREN_yes
+	.byte	73                              # DW_AT_type
+	.byte	19                              # DW_FORM_ref4
+	.byte	0                               # EOM(1)
+	.byte	0                               # EOM(2)
+	.byte	17                              # Abbreviation Code
+	.byte	33                              # DW_TAG_subrange_type
+	.byte	0                               # DW_CHILDREN_no
+	.byte	73                              # DW_AT_type
+	.byte	19                              # DW_FORM_ref4
+	.byte	55                              # DW_AT_count
+	.byte	11                              # DW_FORM_data1
+	.byte	0                               # EOM(1)
+	.byte	0                               # EOM(2)
+	.byte	18                              # Abbreviation Code
+	.byte	36                              # DW_TAG_base_type
+	.byte	0                               # DW_CHILDREN_no
+	.byte	3                               # DW_AT_name
+	.byte	37                              # DW_FORM_strx1
+	.byte	11                              # DW_AT_byte_size
+	.byte	11                              # DW_FORM_data1
+	.byte	62                              # DW_AT_encoding
+	.byte	11                              # DW_FORM_data1
+	.byte	0                               # EOM(1)
+	.byte	0                               # EOM(2)
+	.byte	19                              # Abbreviation Code
+	.byte	19                              # DW_TAG_structure_type
+	.byte	1                               # DW_CHILDREN_yes
+	.byte	54                              # DW_AT_calling_convention
+	.byte	11                              # DW_FORM_data1
+	.byte	3                               # DW_AT_name
+	.byte	37                              # DW_FORM_strx1
+	.byte	11                              # DW_AT_byte_size
+	.byte	11                              # DW_FORM_data1
+	.byte	58                              # DW_AT_decl_file
+	.byte	11                              # DW_FORM_data1
+	.byte	59                              # DW_AT_decl_line
+	.byte	11                              # DW_FORM_data1
+	.byte	0                               # EOM(1)
+	.byte	0                               # EOM(2)
+	.byte	20                              # Abbreviation Code
+	.byte	47                              # DW_TAG_template_type_parameter
+	.byte	0                               # DW_CHILDREN_no
+	.byte	73                              # DW_AT_type
+	.byte	19                              # DW_FORM_ref4
+	.byte	3                               # DW_AT_name
+	.byte	37                              # DW_FORM_strx1
+	.byte	0                               # EOM(1)
+	.byte	0                               # EOM(2)
+	.byte	21                              # Abbreviation Code
+	.byte	13                              # DW_TAG_member
+	.byte	0                               # DW_CHILDREN_no
+	.byte	3                               # DW_AT_name
+	.byte	37                              # DW_FORM_strx1
+	.byte	73                              # DW_AT_type
+	.byte	19                              # DW_FORM_ref4
+	.byte	58                              # DW_AT_decl_file
+	.byte	11                              # DW_FORM_data1
+	.byte	59                              # DW_AT_decl_line
+	.byte	11                              # DW_FORM_data1
+	.byte	56                              # DW_AT_data_member_location
+	.byte	11                              # DW_FORM_data1
+	.byte	0                               # EOM(1)
+	.byte	0                               # EOM(2)
+	.byte	0                               # EOM(3)
 	.section	.debug_info,"",@progbits
 .Lcu_begin0:
 	.long	.Ldebug_info_end0-.Ldebug_info_start0 # Length of Unit
 .Ldebug_info_start0:
-	.short	4                       # DWARF version number
-	.long	.debug_abbrev           # Offset Into Abbrev. Section
-	.byte	4                       # Address Size (in bytes)
-	.byte	1                       # Abbrev [1] 0xb:0x157 DW_TAG_compile_unit
-	.long	.Linfo_string0          # DW_AT_producer
-	.short	4                       # DW_AT_language
-	.long	.Linfo_string1          # DW_AT_name
-	.long	.Lline_table_start0     # DW_AT_stmt_list
-	.long	.Linfo_string2          # DW_AT_comp_dir
-	.long	.Lfunc_begin0           # DW_AT_low_pc
-	.long	.Lfunc_end0-.Lfunc_begin0 # DW_AT_high_pc
-	.byte	2                       # Abbrev [2] 0x26:0xca DW_TAG_subprogram
-	.long	.Lfunc_begin0           # DW_AT_low_pc
-	.long	.Lfunc_end0-.Lfunc_begin0 # DW_AT_high_pc
-	.byte	1                       # DW_AT_frame_base
+	.short	5                               # DWARF version number
+	.byte	1                               # DWARF Unit Type
+	.byte	4                               # Address Size (in bytes)
+	.long	.debug_abbrev                   # Offset Into Abbrev. Section
+	.byte	1                               # Abbrev [1] 0xc:0x148 DW_TAG_compile_unit
+	.byte	0                               # DW_AT_producer
+	.short	26                              # DW_AT_language
+	.byte	1                               # DW_AT_name
+	.long	.Lstr_offsets_base0             # DW_AT_str_offsets_base
+	.long	.Lline_table_start0             # DW_AT_stmt_list
+	.byte	2                               # DW_AT_comp_dir
+	.byte	0                               # DW_AT_low_pc
+	.long	.Lfunc_end0-.Lfunc_begin0       # DW_AT_high_pc
+	.long	.Laddr_table_base0              # DW_AT_addr_base
+	.byte	2                               # Abbrev [2] 0x23:0xa6 DW_TAG_subprogram
+	.byte	0                               # DW_AT_low_pc
+	.long	.Lfunc_end0-.Lfunc_begin0       # DW_AT_high_pc
+	.byte	1                               # DW_AT_frame_base
 	.byte	85
-	.long	.Linfo_string3          # DW_AT_linkage_name
-	.long	.Linfo_string4          # DW_AT_name
-	.byte	1                       # DW_AT_decl_file
-	.byte	3                       # DW_AT_decl_line
+	.byte	3                               # DW_AT_linkage_name
+	.byte	4                               # DW_AT_name
+	.byte	0                               # DW_AT_decl_file
+	.byte	10                              # DW_AT_decl_line
                                         # DW_AT_external
-	.byte	3                       # Abbrev [3] 0x3b:0xe DW_TAG_variable
-	.byte	2                       # DW_AT_location
+	.byte	3                               # Abbrev [3] 0x2f:0xb DW_TAG_variable
+	.byte	2                               # DW_AT_location
 	.byte	145
-	.byte	127
-	.long	.Linfo_string5          # DW_AT_name
-	.byte	1                       # DW_AT_decl_file
-	.byte	4                       # DW_AT_decl_line
-	.long	240                     # DW_AT_type
-	.byte	3                       # Abbrev [3] 0x49:0xe DW_TAG_variable
-	.byte	2                       # DW_AT_location
-	.byte	145
-	.byte	120
-	.long	.Linfo_string7          # DW_AT_name
-	.byte	1                       # DW_AT_decl_file
-	.byte	5                       # DW_AT_decl_line
-	.long	247                     # DW_AT_type
-	.byte	3                       # Abbrev [3] 0x57:0xe DW_TAG_variable
-	.byte	2                       # DW_AT_location
+	.byte	123
+	.byte	5                               # DW_AT_name
+	.byte	0                               # DW_AT_decl_file
+	.byte	11                              # DW_AT_decl_line
+	.long	201                             # DW_AT_type
+	.byte	3                               # Abbrev [3] 0x3a:0xb DW_TAG_variable
+	.byte	2                               # DW_AT_location
 	.byte	145
 	.byte	116
-	.long	.Linfo_string8          # DW_AT_name
-	.byte	1                       # DW_AT_decl_file
-	.byte	6                       # DW_AT_decl_line
-	.long	252                     # DW_AT_type
-	.byte	3                       # Abbrev [3] 0x65:0xe DW_TAG_variable
-	.byte	2                       # DW_AT_location
+	.byte	7                               # DW_AT_name
+	.byte	0                               # DW_AT_decl_file
+	.byte	12                              # DW_AT_decl_line
+	.long	205                             # DW_AT_type
+	.byte	3                               # Abbrev [3] 0x45:0xb DW_TAG_variable
+	.byte	2                               # DW_AT_location
 	.byte	145
 	.byte	112
-	.long	.Linfo_string9          # DW_AT_name
-	.byte	1                       # DW_AT_decl_file
-	.byte	7                       # DW_AT_decl_line
-	.long	257                     # DW_AT_type
-	.byte	3                       # Abbrev [3] 0x73:0xe DW_TAG_variable
-	.byte	2                       # DW_AT_location
+	.byte	8                               # DW_AT_name
+	.byte	0                               # DW_AT_decl_file
+	.byte	13                              # DW_AT_decl_line
+	.long	210                             # DW_AT_type
+	.byte	3                               # Abbrev [3] 0x50:0xb DW_TAG_variable
+	.byte	2                               # DW_AT_location
+	.byte	145
+	.byte	108
+	.byte	9                               # DW_AT_name
+	.byte	0                               # DW_AT_decl_file
+	.byte	14                              # DW_AT_decl_line
+	.long	215                             # DW_AT_type
+	.byte	3                               # Abbrev [3] 0x5b:0xb DW_TAG_variable
+	.byte	2                               # DW_AT_location
 	.byte	145
 	.byte	96
-	.long	.Linfo_string10         # DW_AT_name
-	.byte	1                       # DW_AT_decl_file
-	.byte	8                       # DW_AT_decl_line
-	.long	262                     # DW_AT_type
-	.byte	3                       # Abbrev [3] 0x81:0xe DW_TAG_variable
-	.byte	2                       # DW_AT_location
+	.byte	10                              # DW_AT_name
+	.byte	0                               # DW_AT_decl_file
+	.byte	15                              # DW_AT_decl_line
+	.long	220                             # DW_AT_type
+	.byte	3                               # Abbrev [3] 0x66:0xb DW_TAG_variable
+	.byte	2                               # DW_AT_location
 	.byte	145
 	.byte	92
-	.long	.Linfo_string4          # DW_AT_name
-	.byte	1                       # DW_AT_decl_file
-	.byte	9                       # DW_AT_decl_line
-	.long	292                     # DW_AT_type
-	.byte	3                       # Abbrev [3] 0x8f:0xe DW_TAG_variable
-	.byte	2                       # DW_AT_location
+	.byte	4                               # DW_AT_name
+	.byte	0                               # DW_AT_decl_file
+	.byte	16                              # DW_AT_decl_line
+	.long	247                             # DW_AT_type
+	.byte	3                               # Abbrev [3] 0x71:0xb DW_TAG_variable
+	.byte	2                               # DW_AT_location
 	.byte	145
 	.byte	91
-	.long	.Linfo_string12         # DW_AT_name
-	.byte	1                       # DW_AT_decl_file
-	.byte	10                      # DW_AT_decl_line
-	.long	301                     # DW_AT_type
-	.byte	3                       # Abbrev [3] 0x9d:0xe DW_TAG_variable
-	.byte	2                       # DW_AT_location
+	.byte	12                              # DW_AT_name
+	.byte	0                               # DW_AT_decl_file
+	.byte	17                              # DW_AT_decl_line
+	.long	256                             # DW_AT_type
+	.byte	3                               # Abbrev [3] 0x7c:0xb DW_TAG_variable
+	.byte	2                               # DW_AT_location
 	.byte	145
 	.byte	90
-	.long	.Linfo_string13         # DW_AT_name
-	.byte	1                       # DW_AT_decl_file
-	.byte	11                      # DW_AT_decl_line
-	.long	306                     # DW_AT_type
-	.byte	3                       # Abbrev [3] 0xab:0xe DW_TAG_variable
-	.byte	2                       # DW_AT_location
+	.byte	13                              # DW_AT_name
+	.byte	0                               # DW_AT_decl_file
+	.byte	18                              # DW_AT_decl_line
+	.long	261                             # DW_AT_type
+	.byte	3                               # Abbrev [3] 0x87:0xb DW_TAG_variable
+	.byte	2                               # DW_AT_location
 	.byte	145
 	.byte	84
-	.long	.Linfo_string14         # DW_AT_name
-	.byte	1                       # DW_AT_decl_file
-	.byte	12                      # DW_AT_decl_line
-	.long	311                     # DW_AT_type
-	.byte	3                       # Abbrev [3] 0xb9:0xe DW_TAG_variable
-	.byte	2                       # DW_AT_location
+	.byte	14                              # DW_AT_name
+	.byte	0                               # DW_AT_decl_file
+	.byte	19                              # DW_AT_decl_line
+	.long	266                             # DW_AT_type
+	.byte	3                               # Abbrev [3] 0x92:0xb DW_TAG_variable
+	.byte	2                               # DW_AT_location
 	.byte	145
 	.byte	83
-	.long	.Linfo_string15         # DW_AT_name
-	.byte	1                       # DW_AT_decl_file
-	.byte	14                      # DW_AT_decl_line
-	.long	228                     # DW_AT_type
-	.byte	3                       # Abbrev [3] 0xc7:0xe DW_TAG_variable
-	.byte	2                       # DW_AT_location
+	.byte	15                              # DW_AT_name
+	.byte	0                               # DW_AT_decl_file
+	.byte	21                              # DW_AT_decl_line
+	.long	192                             # DW_AT_type
+	.byte	3                               # Abbrev [3] 0x9d:0xb DW_TAG_variable
+	.byte	2                               # DW_AT_location
 	.byte	145
 	.byte	71
-	.long	.Linfo_string17         # DW_AT_name
-	.byte	1                       # DW_AT_decl_file
-	.byte	15                      # DW_AT_decl_line
-	.long	316                     # DW_AT_type
-	.byte	3                       # Abbrev [3] 0xd5:0xf DW_TAG_variable
-	.byte	3                       # DW_AT_location
+	.byte	17                              # DW_AT_name
+	.byte	0                               # DW_AT_decl_file
+	.byte	22                              # DW_AT_decl_line
+	.long	271                             # DW_AT_type
+	.byte	3                               # Abbrev [3] 0xa8:0xc DW_TAG_variable
+	.byte	3                               # DW_AT_location
 	.byte	145
 	.ascii	"\247}"
-	.long	.Linfo_string19         # DW_AT_name
-	.byte	1                       # DW_AT_decl_file
-	.byte	16                      # DW_AT_decl_line
-	.long	335                     # DW_AT_type
-	.byte	4                       # Abbrev [4] 0xe4:0xb DW_TAG_typedef
-	.long	240                     # DW_AT_type
-	.long	.Linfo_string16         # DW_AT_name
-	.byte	1                       # DW_AT_decl_file
-	.byte	13                      # DW_AT_decl_line
-	.byte	0                       # End Of Children Mark
-	.byte	5                       # Abbrev [5] 0xf0:0x7 DW_TAG_base_type
-	.long	.Linfo_string6          # DW_AT_name
-	.byte	6                       # DW_AT_encoding
-	.byte	1                       # DW_AT_byte_size
-	.byte	6                       # Abbrev [6] 0xf7:0x5 DW_TAG_pointer_type
-	.long	240                     # DW_AT_type
-	.byte	7                       # Abbrev [7] 0xfc:0x5 DW_TAG_reference_type
-	.long	240                     # DW_AT_type
-	.byte	8                       # Abbrev [8] 0x101:0x5 DW_TAG_rvalue_reference_type
-	.long	240                     # DW_AT_type
-	.byte	9                       # Abbrev [9] 0x106:0x9 DW_TAG_ptr_to_member_type
-	.long	271                     # DW_AT_type
-	.long	287                     # DW_AT_containing_type
-	.byte	10                      # Abbrev [10] 0x10f:0xb DW_TAG_subroutine_type
-	.long	240                     # DW_AT_type
-	.byte	11                      # Abbrev [11] 0x114:0x5 DW_TAG_formal_parameter
-	.long	282                     # DW_AT_type
+	.byte	19                              # DW_AT_name
+	.byte	0                               # DW_AT_decl_file
+	.byte	23                              # DW_AT_decl_line
+	.long	287                             # DW_AT_type
+	.byte	3                               # Abbrev [3] 0xb4:0xc DW_TAG_variable
+	.byte	3                               # DW_AT_location
+	.byte	145
+	.ascii	"\240}"
+	.byte	20                              # DW_AT_name
+	.byte	0                               # DW_AT_decl_file
+	.byte	24                              # DW_AT_decl_line
+	.long	305                             # DW_AT_type
+	.byte	4                               # Abbrev [4] 0xc0:0x8 DW_TAG_typedef
+	.long	201                             # DW_AT_type
+	.byte	16                              # DW_AT_name
+	.byte	0                               # DW_AT_decl_file
+	.byte	20                              # DW_AT_decl_line
+	.byte	0                               # End Of Children Mark
+	.byte	5                               # Abbrev [5] 0xc9:0x4 DW_TAG_base_type
+	.byte	6                               # DW_AT_name
+	.byte	6                               # DW_AT_encoding
+	.byte	1                               # DW_AT_byte_size
+	.byte	6                               # Abbrev [6] 0xcd:0x5 DW_TAG_pointer_type
+	.long	201                             # DW_AT_type
+	.byte	7                               # Abbrev [7] 0xd2:0x5 DW_TAG_reference_type
+	.long	201                             # DW_AT_type
+	.byte	8                               # Abbrev [8] 0xd7:0x5 DW_TAG_rvalue_reference_type
+	.long	201                             # DW_AT_type
+	.byte	9                               # Abbrev [9] 0xdc:0x9 DW_TAG_ptr_to_member_type
+	.long	229                             # DW_AT_type
+	.long	245                             # DW_AT_containing_type
+	.byte	10                              # Abbrev [10] 0xe5:0xb DW_TAG_subroutine_type
+	.long	201                             # DW_AT_type
+	.byte	11                              # Abbrev [11] 0xea:0x5 DW_TAG_formal_parameter
+	.long	240                             # DW_AT_type
                                         # DW_AT_artificial
-	.byte	0                       # End Of Children Mark
-	.byte	6                       # Abbrev [6] 0x11a:0x5 DW_TAG_pointer_type
-	.long	287                     # DW_AT_type
-	.byte	12                      # Abbrev [12] 0x11f:0x5 DW_TAG_structure_type
-	.long	.Linfo_string11         # DW_AT_name
+	.byte	0                               # End Of Children Mark
+	.byte	6                               # Abbrev [6] 0xf0:0x5 DW_TAG_pointer_type
+	.long	245                             # DW_AT_type
+	.byte	12                              # Abbrev [12] 0xf5:0x2 DW_TAG_structure_type
+	.byte	11                              # DW_AT_name
                                         # DW_AT_declaration
-	.byte	9                       # Abbrev [9] 0x124:0x9 DW_TAG_ptr_to_member_type
-	.long	240                     # DW_AT_type
-	.long	287                     # DW_AT_containing_type
-	.byte	13                      # Abbrev [13] 0x12d:0x5 DW_TAG_const_type
-	.long	240                     # DW_AT_type
-	.byte	14                      # Abbrev [14] 0x132:0x5 DW_TAG_volatile_type
-	.long	240                     # DW_AT_type
-	.byte	15                      # Abbrev [15] 0x137:0x5 DW_TAG_restrict_type
-	.long	247                     # DW_AT_type
-	.byte	16                      # Abbrev [16] 0x13c:0xc DW_TAG_array_type
-	.long	240                     # DW_AT_type
-	.byte	17                      # Abbrev [17] 0x141:0x6 DW_TAG_subrange_type
-	.long	328                     # DW_AT_type
-	.byte	12                      # DW_AT_count
-	.byte	0                       # End Of Children Mark
-	.byte	18                      # Abbrev [18] 0x148:0x7 DW_TAG_base_type
-	.long	.Linfo_string18         # DW_AT_name
-	.byte	8                       # DW_AT_byte_size
-	.byte	7                       # DW_AT_encoding
-	.byte	16                      # Abbrev [16] 0x14f:0x12 DW_TAG_array_type
-	.long	240                     # DW_AT_type
-	.byte	17                      # Abbrev [17] 0x154:0x6 DW_TAG_subrange_type
-	.long	328                     # DW_AT_type
-	.byte	12                      # DW_AT_count
-	.byte	17                      # Abbrev [17] 0x15a:0x6 DW_TAG_subrange_type
-	.long	328                     # DW_AT_type
-	.byte	24                      # DW_AT_count
-	.byte	0                       # End Of Children Mark
-	.byte	0                       # End Of Children Mark
+	.byte	9                               # Abbrev [9] 0xf7:0x9 DW_TAG_ptr_to_member_type
+	.long	201                             # DW_AT_type
+	.long	245                             # DW_AT_containing_type
+	.byte	13                              # Abbrev [13] 0x100:0x5 DW_TAG_const_type
+	.long	201                             # DW_AT_type
+	.byte	14                              # Abbrev [14] 0x105:0x5 DW_TAG_volatile_type
+	.long	201                             # DW_AT_type
+	.byte	15                              # Abbrev [15] 0x10a:0x5 DW_TAG_restrict_type
+	.long	205                             # DW_AT_type
+	.byte	16                              # Abbrev [16] 0x10f:0xc DW_TAG_array_type
+	.long	201                             # DW_AT_type
+	.byte	17                              # Abbrev [17] 0x114:0x6 DW_TAG_subrange_type
+	.long	283                             # DW_AT_type
+	.byte	12                              # DW_AT_count
+	.byte	0                               # End Of Children Mark
+	.byte	18                              # Abbrev [18] 0x11b:0x4 DW_TAG_base_type
+	.byte	18                              # DW_AT_name
+	.byte	8                               # DW_AT_byte_size
+	.byte	7                               # DW_AT_encoding
+	.byte	16                              # Abbrev [16] 0x11f:0x12 DW_TAG_array_type
+	.long	201                             # DW_AT_type
+	.byte	17                              # Abbrev [17] 0x124:0x6 DW_TAG_subrange_type
+	.long	283                             # DW_AT_type
+	.byte	12                              # DW_AT_count
+	.byte	17                              # Abbrev [17] 0x12a:0x6 DW_TAG_subrange_type
+	.long	283                             # DW_AT_type
+	.byte	24                              # DW_AT_count
+	.byte	0                               # End Of Children Mark
+	.byte	4                               # Abbrev [4] 0x131:0x8 DW_TAG_typedef
+	.long	313                             # DW_AT_type
+	.byte	24                              # DW_AT_name
+	.byte	0                               # DW_AT_decl_file
+	.byte	8                               # DW_AT_decl_line
+	.byte	19                              # Abbrev [19] 0x139:0x16 DW_TAG_structure_type
+	.byte	5                               # DW_AT_calling_convention
+	.byte	23                              # DW_AT_name
+	.byte	4                               # DW_AT_byte_size
+	.byte	0                               # DW_AT_decl_file
+	.byte	4                               # DW_AT_decl_line
+	.byte	20                              # Abbrev [20] 0x13f:0x6 DW_TAG_template_type_parameter
+	.long	335                             # DW_AT_type
+	.byte	22                              # DW_AT_name
+	.byte	21                              # Abbrev [21] 0x145:0x9 DW_TAG_member
+	.byte	20                              # DW_AT_name
+	.long	335                             # DW_AT_type
+	.byte	0                               # DW_AT_decl_file
+	.byte	5                               # DW_AT_decl_line
+	.byte	0                               # DW_AT_data_member_location
+	.byte	0                               # End Of Children Mark
+	.byte	5                               # Abbrev [5] 0x14f:0x4 DW_TAG_base_type
+	.byte	21                              # DW_AT_name
+	.byte	5                               # DW_AT_encoding
+	.byte	4                               # DW_AT_byte_size
+	.byte	0                               # End Of Children Mark
 .Ldebug_info_end0:
-	.section	.debug_macinfo,"",@progbits
-	.byte	0                       # End Of Macro List Mark
-
-	.ident	"clang version 9.0.0 "
+	.section	.debug_str_offsets,"",@progbits
+	.long	104                             # Length of String Offsets Set
+	.short	5
+	.short	0
+.Lstr_offsets_base0:
+	.section	.debug_str,"MS",@progbits,1
+.Linfo_string0:
+	.asciz	"clang version 19.0.0git" # string offset=0
+.Linfo_string1:
+	.asciz	"frame-types.cpp"               # string offset=107
+.Linfo_string2:
+	.asciz	"/tmp"                          # string offset=123
+.Linfo_string3:
+	.asciz	"_Z1fv"                         # string offset=128
+.Linfo_string4:
+	.asciz	"f"                             # string offset=134
+.Linfo_string5:
+	.asciz	"a"                             # string offset=136
+.Linfo_string6:
+	.asciz	"char"                          # string offset=138
+.Linfo_string7:
+	.asciz	"b"                             # string offset=143
+.Linfo_string8:
+	.asciz	"c"                             # string offset=145
+.Linfo_string9:
+	.asciz	"d"                             # string offset=147
+.Linfo_string10:
+	.asciz	"e"                             # string offset=149
+.Linfo_string11:
+	.asciz	"S"                             # string offset=151
+.Linfo_string12:
+	.asciz	"g"                             # string offset=153
+.Linfo_string13:
+	.asciz	"h"                             # string offset=155
+.Linfo_string14:
+	.asciz	"i"                             # string offset=157
+.Linfo_string15:
+	.asciz	"j"                             # string offset=159
+.Linfo_string16:
+	.asciz	"char_typedef"                  # string offset=161
+.Linfo_string17:
+	.asciz	"k"                             # string offset=174
+.Linfo_string18:
+	.asciz	"__ARRAY_SIZE_TYPE__"           # string offset=176
+.Linfo_string19:
+	.asciz	"l"                             # string offset=196
+.Linfo_string20:
+	.asciz	"m"                             # string offset=198
+.Linfo_string21:
+	.asciz	"int"                           # string offset=200
+.Linfo_string22:
+	.asciz	"Y"                             # string offset=204
+.Linfo_string23:
+	.asciz	"Base<int>"                     # string offset=206
+.Linfo_string24:
+	.asciz	"Alias<int>"                    # string offset=216
+	.section	.debug_str_offsets,"",@progbits
+	.long	.Linfo_string0
+	.long	.Linfo_string1
+	.long	.Linfo_string2
+	.long	.Linfo_string3
+	.long	.Linfo_string4
+	.long	.Linfo_string5
+	.long	.Linfo_string6
+	.long	.Linfo_string7
+	.long	.Linfo_string8
+	.long	.Linfo_string9
+	.long	.Linfo_string10
+	.long	.Linfo_string11
+	.long	.Linfo_string12
+	.long	.Linfo_string13
+	.long	.Linfo_string14
+	.long	.Linfo_string15
+	.long	.Linfo_string16
+	.long	.Linfo_string17
+	.long	.Linfo_string18
+	.long	.Linfo_string19
+	.long	.Linfo_string20
+	.long	.Linfo_string21
+	.long	.Linfo_string22
+	.long	.Linfo_string23
+	.long	.Linfo_string24
+	.section	.debug_addr,"",@progbits
+	.long	.Ldebug_addr_end0-.Ldebug_addr_start0 # Length of contribution
+.Ldebug_addr_start0:
+	.short	5                               # DWARF version number
+	.byte	4                               # Address size
+	.byte	0                               # Segment selector size
+.Laddr_table_base0:
+	.long	.Lfunc_begin0
+.Ldebug_addr_end0:
+	.ident	"clang version 19.0.0git"
 	.section	".note.GNU-stack","",@progbits
 	.addrsig
 	.section	.debug_line,"",@progbits


### PR DESCRIPTION
Part 1 of fix for issue https://github.com/llvm/llvm-project/issues/54624

Split from PR #87623. Clang front end changes to follow.

Use DICompositeType to represent the template alias, using its extraData field as a tuple of DITemplateParameter to describe the template parameters.

Added template-alias.ll  - Check DWARF emission.
Modified  frame-types.s  - Check llvm-symbolizer understands the DIE.

---

@adrian-prantl this is all the LLVM-IR-side code from  #87623, which I believe you are happy with?