### PR TITLE
[driver] Do not warn about unused plugin flags.

### DIFF
--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -3645,14 +3645,14 @@ defm rwpi : BoolFOption<"rwpi",
           "Generate read-write position independent code (ARM only)">,
   NegFlag<SetFalse, [], [ClangOption, FlangOption, CC1Option]>>;
 def fplugin_EQ : Joined<["-"], "fplugin=">, Group<f_Group>,
-  Flags<[NoXarchOption]>, MetaVarName<"<dsopath>">,
+  Flags<[NoXarchOption, NoArgumentUnused]>, MetaVarName<"<dsopath>">,
   HelpText<"Load the named plugin (dynamic shared object)">;
 def fplugin_arg : Joined<["-"], "fplugin-arg-">,
-  MetaVarName<"<name>-<arg>">,
+  MetaVarName<"<name>-<arg>">, Flags<[NoArgumentUnused]>,
   HelpText<"Pass <arg> to plugin <name>">;
 def fpass_plugin_EQ : Joined<["-"], "fpass-plugin=">,
   Group<f_Group>, Visibility<[ClangOption, CC1Option, FlangOption, FC1Option]>,
-  MetaVarName<"<dsopath>">,
+  MetaVarName<"<dsopath>">, Flags<[NoArgumentUnused]>,
   HelpText<"Load pass plugin from a dynamic shared object file (only with new pass manager).">,
   MarshallingInfoStringVector<CodeGenOpts<"PassPlugins">>;
 defm tocdata : BoolOption<"m","tocdata",

--- a/clang/test/Driver/clang-s-plugin.s
+++ b/clang/test/Driver/clang-s-plugin.s
@@ -1,0 +1,5 @@
+// RUN: %clang -### -c -fpass-plugin=bar.so -fplugin=bar.so -fplugin-arg-bar-option -Werror %s 2>&1 | FileCheck %s
+
+// Plugins are only relevant for the -cc1 phase. No warning should be raised
+// when applied to assembly files. See GH #88173.
+// CHECK-NOT: argument unused during compilation

--- a/clang/test/Driver/clang-s-plugin.s
+++ b/clang/test/Driver/clang-s-plugin.s
@@ -1,5 +1,0 @@
-// RUN: %clang -### -c -fpass-plugin=bar.so -fplugin=bar.so -fplugin-arg-bar-option -Werror %s 2>&1 | FileCheck %s
-
-// Plugins are only relevant for the -cc1 phase. No warning should be raised
-// when applied to assembly files. See GH #88173.
-// CHECK-NOT: argument unused during compilation

--- a/clang/test/Driver/plugin-driver-args.cpp
+++ b/clang/test/Driver/plugin-driver-args.cpp
@@ -20,3 +20,8 @@
 
 // RUN: %clang -fplugin=%llvmshlibdir/CallSuperAttr%pluginext -fplugin-arg-testname- -fsyntax-only %s -### 2>&1 | FileCheck %s --check-prefix=CHECK-NO-PLUGIN-ARG2
 // CHECK-NO-PLUGIN-ARG2: missing plugin argument for plugin testname in -fplugin-arg-testname-
+
+// Plugins are only relevant for the -cc1 phase. No warning should be raised
+// when only using the assembler. See GH #88173.
+// RUN: %clang -c -fpass-plugin=bar.so -fplugin=bar.so -fplugin-arg-bar-option -Werror -x assembler %s -### 2>&1 | FileCheck %s --check-prefix=CHECK-PLUGIN-ASM
+// CHECK-PLUGIN-ASM-NOT: argument unused during compilation


### PR DESCRIPTION
Plugins are not loaded without the -cc1 phase. Do not report them when running on an assembly file or when linking. Many build tools add these options to all driver invocations, including LLVM's build system.

Fixes #88173