### PR TITLE
[LiveIns] Improve recomputeLiveIns()

### DIFF
--- a/llvm/include/llvm/CodeGen/LivePhysRegs.h
+++ b/llvm/include/llvm/CodeGen/LivePhysRegs.h
@@ -197,7 +197,7 @@ void computeAndAddLiveIns(LivePhysRegs &LiveRegs,
 
 /// Convenience function for recomputing live-in's for a MBB. Returns true if
 /// any changes were made.
-inline bool recomputeLiveIns(MachineBasicBlock &MBB) {
+static inline bool recomputeLiveIns(MachineBasicBlock &MBB) {
   LivePhysRegs LPR;
   std::vector<MachineBasicBlock::RegisterMaskPair> OldLiveIns;
 
@@ -205,7 +205,8 @@ inline bool recomputeLiveIns(MachineBasicBlock &MBB) {
   computeAndAddLiveIns(LPR, MBB);
   MBB.sortUniqueLiveIns();
 
-  auto NewLiveIns = MBB.getLiveIns();
+  const std::vector<MachineBasicBlock::RegisterMaskPair> &NewLiveIns =
+      MBB.getLiveIns();
   return OldLiveIns != NewLiveIns;
 }
 

--- a/llvm/include/llvm/CodeGen/LivePhysRegs.h
+++ b/llvm/include/llvm/CodeGen/LivePhysRegs.h
@@ -197,16 +197,16 @@ void computeAndAddLiveIns(LivePhysRegs &LiveRegs,
 
 /// Convenience function for recomputing live-in's for a MBB. Returns true if
 /// any changes were made.
-static inline bool recomputeLiveIns(MachineBasicBlock &MBB) {
+inline bool recomputeLiveIns(MachineBasicBlock &MBB) {
   LivePhysRegs LPR;
-  auto oldLiveIns = MBB.getLiveIns();
+  std::vector<MachineBasicBlock::RegisterMaskPair> OldLiveIns;
 
-  MBB.clearLiveIns();
+  MBB.clearLiveIns(OldLiveIns);
   computeAndAddLiveIns(LPR, MBB);
   MBB.sortUniqueLiveIns();
 
-  auto newLiveIns = MBB.getLiveIns();
-  return oldLiveIns != newLiveIns;
+  auto NewLiveIns = MBB.getLiveIns();
+  return OldLiveIns != NewLiveIns;
 }
 
 /// Convenience function for recomputing live-in's for a set of MBBs until the

--- a/llvm/include/llvm/CodeGen/MachineBasicBlock.h
+++ b/llvm/include/llvm/CodeGen/MachineBasicBlock.h
@@ -481,7 +481,7 @@ public:
   /// Remove entry from the livein set and return iterator to the next.
   livein_iterator removeLiveIn(livein_iterator I);
 
-  const std::vector<RegisterMaskPair> getLiveIns() const { return LiveIns; }
+  const std::vector<RegisterMaskPair> &getLiveIns() const { return LiveIns; }
 
   class liveout_iterator {
   public:

--- a/llvm/include/llvm/CodeGen/MachineBasicBlock.h
+++ b/llvm/include/llvm/CodeGen/MachineBasicBlock.h
@@ -441,6 +441,10 @@ public:
   /// Clear live in list.
   void clearLiveIns();
 
+  /// Clear the live in list, and return the removed live in's in \p OldLiveIns.
+  /// Requires that the vector \p OldLiveIns is empty.
+  void clearLiveIns(std::vector<RegisterMaskPair> &OldLiveIns);
+
   /// Add PhysReg as live in to this block, and ensure that there is a copy of
   /// PhysReg to a virtual register of class RC. Return the virtual register
   /// that is a copy of the live in PhysReg.
@@ -477,7 +481,7 @@ public:
   /// Remove entry from the livein set and return iterator to the next.
   livein_iterator removeLiveIn(livein_iterator I);
 
-  std::vector<RegisterMaskPair> getLiveIns() const { return LiveIns; }
+  const std::vector<RegisterMaskPair> getLiveIns() const { return LiveIns; }
 
   class liveout_iterator {
   public:

--- a/llvm/lib/CodeGen/MachineBasicBlock.cpp
+++ b/llvm/lib/CodeGen/MachineBasicBlock.cpp
@@ -1728,7 +1728,8 @@ void MachineBasicBlock::clearLiveIns() {
   LiveIns.clear();
 }
 
-void MachineBasicBlock::clearLiveIns(std::vector<RegisterMaskPair> &OldLiveIns) {
+void MachineBasicBlock::clearLiveIns(
+    std::vector<RegisterMaskPair> &OldLiveIns) {
   assert(OldLiveIns.empty() && "Vector must be empty");
   std::swap(LiveIns, OldLiveIns);
 }

--- a/llvm/lib/CodeGen/MachineBasicBlock.cpp
+++ b/llvm/lib/CodeGen/MachineBasicBlock.cpp
@@ -1728,6 +1728,11 @@ void MachineBasicBlock::clearLiveIns() {
   LiveIns.clear();
 }
 
+void MachineBasicBlock::clearLiveIns(std::vector<RegisterMaskPair> &OldLiveIns) {
+  assert(OldLiveIns.empty() && "Vector must be empty");
+  std::swap(LiveIns, OldLiveIns);
+}
+
 MachineBasicBlock::livein_iterator MachineBasicBlock::livein_begin() const {
   assert(getParent()->getProperties().hasProperty(
       MachineFunctionProperties::Property::TracksLiveness) &&


### PR DESCRIPTION
Some small changes to recomputeLiveIns() to improve performance:

- Instead of copying the list of old live-ins, and then clearing
  them, a new method swaps the list for an empty one.
- getLiveIns() now returns a constant reference to the list

As result, the list-data is never copied. Depending on the implementation
details of the vector container, it can also save calls to allocate
and deallocate memory.
I see a small improvement on CTMark with these changes.
