### PR TITLE
[mlir][tensor] Fold `tensor.reshape` for dynamic reshape

### DIFF
--- a/mlir/lib/Dialect/Tensor/IR/TensorOps.cpp
+++ b/mlir/lib/Dialect/Tensor/IR/TensorOps.cpp
@@ -1592,9 +1592,8 @@ OpFoldResult ReshapeOp::fold(FoldAdaptor adaptor) {
     auto elements = fromElements.getElements();
     bool dynamicNoop =
         sourceTy.getRank() == static_cast<int64_t>(elements.size());
-    for (auto [id, element] : llvm::enumerate(elements)) {
-      if (!dynamicNoop)
-        break;
+    for (int id = 0, s = elements.size(); id < s && dynamicNoop; ++id) {
+      auto element = elements[id];
 
       APSInt cstElement;
       if (matchPattern(element, m_ConstantInt(&cstElement))) {


### PR DESCRIPTION
If `tensor.reshape` occurs with `d0, d1, d2, ...` for the dimensions we know that the reshape is a no-op. Checking for this case lets us fold away the computation.