### PR TITLE
[llvm-exegesis] Add support for alder lake

### DIFF
--- a/llvm/lib/Target/X86/X86PfmCounters.td
+++ b/llvm/lib/Target/X86/X86PfmCounters.td
@@ -210,15 +210,11 @@ def AlderLakePfmCounters : ProcPfmCounters {
   let IssueCounters = [
     PfmIssueCounter<"ADLPPort00", "uops_dispatched_port:port_0">,
     PfmIssueCounter<"ADLPPort01", "uops_dispatched_port:port_1">,
-    PfmIssueCounter<"ADLPPort02", "uops_dispatched_port:port_2_3_10">,
-    PfmIssueCounter<"ADLPPort03", "uops_dispatched_port:port_2_3_10">,
-    PfmIssueCounter<"ADLPPort04", "uops_dispatched_port:port_4_9">,
+    PfmIssueCounter<"ADLPPort02_03_10", "uops_dispatched_port:port_2_3_10">,
+    PfmIssueCounter<"ADLPPort04_09", "uops_dispatched_port:port_4_9">,
     PfmIssueCounter<"ADLPPort05", "uops_dispatched_port:port_5_11">,
     PfmIssueCounter<"ADLPPort06", "uops_dispatched_port:port_6">,
-    PfmIssueCounter<"ADLPPort07", "uops_dispatched_port:port_7_8">,
-    PfmIssueCounter<"ADLPPort08", "uops_dispatched_port:port_7_8">,
-    PfmIssueCounter<"ADLPPort09", "uops_dispatched_port:port_4_9">,
-    PfmIssueCounter<"ADLPPort10", "uops_dispatched_port:port_2_3_10">,
+    PfmIssueCounter<"ADLPPort07_08", "uops_dispatched_port:port_7_8">,
     PfmIssueCounter<"ADLPPort11", "uops_dispatched_port:port_5_11">,
   ];
   let ValidationCounters = DefaultIntelPfmValidationCounters;

--- a/llvm/lib/Target/X86/X86PfmCounters.td
+++ b/llvm/lib/Target/X86/X86PfmCounters.td
@@ -212,10 +212,9 @@ def AlderLakePfmCounters : ProcPfmCounters {
     PfmIssueCounter<"ADLPPort01", "uops_dispatched_port:port_1">,
     PfmIssueCounter<"ADLPPort02_03_10", "uops_dispatched_port:port_2_3_10">,
     PfmIssueCounter<"ADLPPort04_09", "uops_dispatched_port:port_4_9">,
-    PfmIssueCounter<"ADLPPort05", "uops_dispatched_port:port_5_11">,
+    PfmIssueCounter<"ADLPPort05_11", "uops_dispatched_port:port_5_11">,
     PfmIssueCounter<"ADLPPort06", "uops_dispatched_port:port_6">,
-    PfmIssueCounter<"ADLPPort07_08", "uops_dispatched_port:port_7_8">,
-    PfmIssueCounter<"ADLPPort11", "uops_dispatched_port:port_5_11">,
+    PfmIssueCounter<"ADLPPort07_08", "uops_dispatched_port:port_7_8">
   ];
   let ValidationCounters = DefaultIntelPfmValidationCounters;
 }

--- a/llvm/lib/Target/X86/X86PfmCounters.td
+++ b/llvm/lib/Target/X86/X86PfmCounters.td
@@ -204,6 +204,27 @@ def : PfmCountersBinding<"icelake-server", IceLakePfmCounters>;
 def : PfmCountersBinding<"rocketlake", IceLakePfmCounters>;
 def : PfmCountersBinding<"tigerlake", IceLakePfmCounters>;
 
+def AlderLakePfmCounters : ProcPfmCounters {
+  let CycleCounter = UnhaltedCoreCyclesPfmCounter;
+  let UopsCounter = UopsIssuedPfmCounter;
+  let IssueCounters = [
+    PfmIssueCounter<"ADLPPort00", "uops_dispatched_port:port_0">,
+    PfmIssueCounter<"ADLPPort01", "uops_dispatched_port:port_1">,
+    PfmIssueCounter<"ADLPPort02", "uops_dispatched_port:port_2_3_10">,
+    PfmIssueCounter<"ADLPPort03", "uops_dispatched_port:port_2_3_10">,
+    PfmIssueCounter<"ADLPPort04", "uops_dispatched_port:port_4_9">,
+    PfmIssueCounter<"ADLPPort05", "uops_dispatched_port:port_5_11">,
+    PfmIssueCounter<"ADLPPort06", "uops_dispatched_port:port_6">,
+    PfmIssueCounter<"ADLPPort07", "uops_dispatched_port:port_7_8">,
+    PfmIssueCounter<"ADLPPort08", "uops_dispatched_port:port_7_8">,
+    PfmIssueCounter<"ADLPPort09", "uops_dispatched_port:port_4_9">,
+    PfmIssueCounter<"ADLPPort10", "uops_dispatched_port:port_2_3_10">,
+    PfmIssueCounter<"ADLPPort11", "uops_dispatched_port:port_5_11">,
+  ];
+  let ValidationCounters = DefaultIntelPfmValidationCounters;
+}
+def : PfmCountersBinding<"alderlake", AlderLakePfmCounters>;
+
 // AMD X86 Counters.
 defvar DefaultAMDPfmValidationCounters = [
   PfmValidationCounter<InstructionRetired, "RETIRED_INSTRUCTIONS">,

--- a/llvm/lib/Target/X86/X86SchedAlderlakeP.td
+++ b/llvm/lib/Target/X86/X86SchedAlderlakeP.td
@@ -60,6 +60,8 @@ def ADLPPort01_05_10       : ProcResGroup<[ADLPPort01, ADLPPort05, ADLPPort10]>;
 def ADLPPort02_03          : ProcResGroup<[ADLPPort02, ADLPPort03]>;
 def ADLPPort02_03_07       : ProcResGroup<[ADLPPort02, ADLPPort03, ADLPPort07]>;
 def ADLPPort02_03_11       : ProcResGroup<[ADLPPort02, ADLPPort03, ADLPPort11]>;
+def ADLPPort02_03_10       : ProcResGroup<[ADLPPort02, ADLPPort03, ADLPPort10]>;
+def ADLPPort05_11          : ProcResGroup<[ADLPPort05, ADLPPort11]>;
 def ADLPPort07_08          : ProcResGroup<[ADLPPort07, ADLPPort08]>;
 
 // EU has 112 reservation stations.
@@ -78,6 +80,10 @@ def ADLPPort02_03_07_08_11 : ProcResGroup<[ADLPPort02, ADLPPort03, ADLPPort07,
                                            ADLPPort08, ADLPPort11]> {
   let BufferSize = 72;
 }
+
+def ADLPPortAny : ProcResGroup<[ADLPPort00, ADLPPort01, ADLPPort02, ADLPPort03,
+                                ADLPPort04, ADLPPort05, ADLPPort06, ADLPPort07,
+                                ADLPPort08, ADLPPort09, ADLPPort10, ADLPPort11]>;
 
 // Integer loads are 5 cycles, so ReadAfterLd registers needn't be available
 // until 5 cycles after the memory operand.


### PR DESCRIPTION
This patch adds the PFM counter definitions for Intel alder lake CPUs.