### PR TITLE
[Clang][Parse] Diagnose requires expressions with explicit object parameters

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -364,6 +364,8 @@ Improvements to Clang's diagnostics
 - Clang now uses the correct type-parameter-key (``class`` or ``typename``) when printing
   template template parameter declarations.
 
+- Clang now diagnoses requires expressions with explicit object parameters.
+
 Improvements to Clang's time-trace
 ----------------------------------
 

--- a/clang/include/clang/Basic/DiagnosticParseKinds.td
+++ b/clang/include/clang/Basic/DiagnosticParseKinds.td
@@ -373,8 +373,6 @@ def err_requires_clause_must_appear_after_trailing_return : Error<
   "trailing return type must appear before trailing requires clause">;
 def err_requires_clause_on_declarator_not_declaring_a_function : Error<
   "trailing requires clause can only be used when declaring a function">;
-def err_requires_clause_explicit_object_parameter: Error<
-  "a requires clause cannot have an explicit object parameter">;
 def err_requires_clause_inside_parens : Error<
   "trailing requires clause should be placed outside parentheses">;
 def ext_auto_storage_class : ExtWarn<
@@ -865,6 +863,8 @@ def err_empty_requires_expr : Error<
   "a requires expression must contain at least one requirement">;
 def err_requires_expr_parameter_list_ellipsis : Error<
   "varargs not allowed in requires expression">;
+def err_requires_expr_explicit_object_parameter: Error<
+  "a requires expression cannot have an explicit object parameter">;
 def err_expected_semi_requirement : Error<
   "expected ';' at end of requirement">;
 def err_requires_expr_missing_arrow : Error<

--- a/clang/include/clang/Basic/DiagnosticParseKinds.td
+++ b/clang/include/clang/Basic/DiagnosticParseKinds.td
@@ -373,6 +373,8 @@ def err_requires_clause_must_appear_after_trailing_return : Error<
   "trailing return type must appear before trailing requires clause">;
 def err_requires_clause_on_declarator_not_declaring_a_function : Error<
   "trailing requires clause can only be used when declaring a function">;
+def err_requires_clause_explicit_object_parameter: Error<
+  "a requires clause cannot have an explicit object parameter">;
 def err_requires_clause_inside_parens : Error<
   "trailing requires clause should be placed outside parentheses">;
 def ext_auto_storage_class : ExtWarn<

--- a/clang/lib/Parse/ParseDecl.cpp
+++ b/clang/lib/Parse/ParseDecl.cpp
@@ -7660,8 +7660,21 @@ void Parser::ParseParameterDeclarationClause(
     // Parse a C++23 Explicit Object Parameter
     // We do that in all language modes to produce a better diagnostic.
     SourceLocation ThisLoc;
-    if (getLangOpts().CPlusPlus && Tok.is(tok::kw_this))
+    if (getLangOpts().CPlusPlus && Tok.is(tok::kw_this)) {
       ThisLoc = ConsumeToken();
+      // C++23 [dcl.fct]p6:
+      //   An explicit-object-parameter-declaration is a parameter-declaration
+      //   with a this specifier. An explicit-object-parameter-declaration
+      //   shall appear only as the first parameter-declaration of a
+      //   parameter-declaration-list of either:
+      //   - a member-declarator that declares a member function, or
+      //   - a lambda-declarator.
+      //
+      // The parameter-declaration-list of a requires-expression is not such
+      // a context.
+      if (DeclaratorCtx == DeclaratorContext::RequiresExpr)
+        Diag(ThisLoc, diag::err_requires_clause_explicit_object_parameter);
+    }
 
     ParseDeclarationSpecifiers(DS, /*TemplateInfo=*/ParsedTemplateInfo(),
                                AS_none, DeclSpecContext::DSC_normal,

--- a/clang/lib/Parse/ParseDecl.cpp
+++ b/clang/lib/Parse/ParseDecl.cpp
@@ -7673,7 +7673,7 @@ void Parser::ParseParameterDeclarationClause(
       // The parameter-declaration-list of a requires-expression is not such
       // a context.
       if (DeclaratorCtx == DeclaratorContext::RequiresExpr)
-        Diag(ThisLoc, diag::err_requires_clause_explicit_object_parameter);
+        Diag(ThisLoc, diag::err_requires_expr_explicit_object_parameter);
     }
 
     ParseDeclarationSpecifiers(DS, /*TemplateInfo=*/ParsedTemplateInfo(),

--- a/clang/test/CXX/dcl.decl/dcl.meaning/dcl.fct/p6-cxx23.cpp
+++ b/clang/test/CXX/dcl.decl/dcl.meaning/dcl.fct/p6-cxx23.cpp
@@ -3,6 +3,5 @@
 auto x0 = requires (this int) { true; }; // expected-error {{a requires expression cannot have an explicit object parameter}}
 auto x1 = requires (int, this int) { true; }; // expected-error {{a requires expression cannot have an explicit object parameter}}
 
-template<this auto>
-void f(); // expected-error {{expected template parameter}}
-          // expected-error@-1 {{no function template matches function template specialization 'f'}}
+template<this auto> // expected-error {{expected template parameter}}
+void f(); // expected-error {{no function template matches function template specialization 'f'}}

--- a/clang/test/CXX/dcl.decl/dcl.meaning/dcl.fct/p6-cxx23.cpp
+++ b/clang/test/CXX/dcl.decl/dcl.meaning/dcl.fct/p6-cxx23.cpp
@@ -1,4 +1,8 @@
 // RUN: %clang_cc1 -std=c++23 -fsyntax-only -verify %s
 
-auto x0 = requires (this int) { true; }; // expected-error {{a requires clause cannot have an explicit object parameter}}
-auto x1 = requires (int, this int) { true; }; // expected-error {{a requires clause cannot have an explicit object parameter}}
+auto x0 = requires (this int) { true; }; // expected-error {{a requires expression cannot have an explicit object parameter}}
+auto x1 = requires (int, this int) { true; }; // expected-error {{a requires expression cannot have an explicit object parameter}}
+
+template<this auto>
+void f(); // expected-error {{expected template parameter}}
+          // expected-error@-1 {{no function template matches function template specialization 'f'}}

--- a/clang/test/CXX/dcl.decl/dcl.meaning/dcl.fct/p6-cxx23.cpp
+++ b/clang/test/CXX/dcl.decl/dcl.meaning/dcl.fct/p6-cxx23.cpp
@@ -1,0 +1,4 @@
+// RUN: %clang_cc1 -std=c++23 -fsyntax-only -verify %s
+
+auto x0 = requires (this int) { true; }; // expected-error {{a requires clause cannot have an explicit object parameter}}
+auto x1 = requires (int, this int) { true; }; // expected-error {{a requires clause cannot have an explicit object parameter}}


### PR DESCRIPTION
Clang currently allows the following:
```cpp
auto x = requires (this int) { true; };
```
This patch addresses that.
