### PR TITLE
[libc][NFC] fix typo in fenv type proxy headers

### DIFF
--- a/libc/hdr/types/CMakeLists.txt
+++ b/libc/hdr/types/CMakeLists.txt
@@ -28,7 +28,7 @@ add_proxy_header_library(
     fenv_t.h
   FULL_BUILD_DEPENDS
     libc.include.llvm-libc-types.fenv_t
-    libc.incude.fenv
+    libc.include.fenv
 )
 
 add_proxy_header_library(
@@ -37,5 +37,5 @@ add_proxy_header_library(
     fexcept_t.h
   FULL_BUILD_DEPENDS
     libc.include.llvm-libc-types.fexcept_t
-    libc.incude.fenv
+    libc.include.fenv
 )


### PR DESCRIPTION
libc.incude.fenv ->
libc.include.fenv
