### PR TITLE
[MachineOutliner] Efficient Implementation of MachineOutliner::findCandidates()

### DIFF
--- a/llvm/lib/CodeGen/MachineOutliner.cpp
+++ b/llvm/lib/CodeGen/MachineOutliner.cpp
@@ -616,17 +616,14 @@ void MachineOutliner::findCandidates(
       // * End before the other starts
       // * Start after the other ends
       unsigned EndIdx = StartIdx + StringLen - 1;
-      auto FirstOverlap = find_if(
-          CandidatesForRepeatedSeq, [StartIdx, EndIdx](const Candidate &C) {
-            return EndIdx >= C.getStartIdx() && StartIdx <= C.getEndIdx();
-          });
-      if (FirstOverlap != CandidatesForRepeatedSeq.end()) {
+      if (CandidatesForRepeatedSeq.size() > 0 &&
+          StartIdx <= CandidatesForRepeatedSeq.back().getEndIdx()) {
 #ifndef NDEBUG
         ++NumDiscarded;
         LLVM_DEBUG(dbgs() << "    .. DISCARD candidate @ [" << StartIdx
                           << ", " << EndIdx << "]; overlaps with candidate @ ["
-                          << FirstOverlap->getStartIdx() << ", "
-                          << FirstOverlap->getEndIdx() << "]\n");
+                          << CandidatesForRepeatedSeq.back().getStartIdx() << ", "
+                          << CandidatesForRepeatedSeq.back().getEndIdx() << "]\n");
 #endif
         continue;
       }

--- a/llvm/lib/Support/SuffixTree.cpp
+++ b/llvm/lib/Support/SuffixTree.cpp
@@ -274,6 +274,11 @@ void SuffixTree::RepeatedSubstringIterator::advance() {
     RS.Length = Length;
     for (unsigned StartIdx : RepeatedSubstringStarts)
       RS.StartIndices.push_back(StartIdx);
+
+    // Sort the start indices so that we can efficiently check if candidates
+    // overlap with each other in MachineOutliner::findCandidates().
+    llvm::sort(RS.StartIndices);
+
     break;
   }
   // At this point, either NewRS is an empty RepeatedSubstring, or it was

--- a/llvm/test/Analysis/IRSimilarityIdentifier/basic.ll
+++ b/llvm/test/Analysis/IRSimilarityIdentifier/basic.ll
@@ -4,7 +4,7 @@
 ; This is a simple test to make sure the IRSimilarityIdentifier and
 ; IRSimilarityPrinterPass is working.
 
-; CHECK: 4 candidates of length 6.  Found in: 
+; CHECK: 4 candidates of length 6.  Found in:
 ; CHECK-NEXT:  Function: turtle, Basic Block: (unnamed)
 ; CHECK-NEXT:    Start Instruction:   store i32 1, ptr %1, align 4
 ; CHECK-NEXT:      End Instruction:   store i32 6, ptr %6, align 4
@@ -17,7 +17,7 @@
 ; CHECK-NEXT:  Function: dog, Basic Block: entry
 ; CHECK-NEXT:    Start Instruction:   store i32 6, ptr %0, align 4
 ; CHECK-NEXT:      End Instruction:   store i32 5, ptr %5, align 4
-; CHECK-NEXT:4 candidates of length 5.  Found in: 
+; CHECK-NEXT:4 candidates of length 5.  Found in:
 ; CHECK-NEXT:  Function: turtle, Basic Block: (unnamed)
 ; CHECK-NEXT:    Start Instruction:   store i32 2, ptr %2, align 4
 ; CHECK-NEXT:      End Instruction:   store i32 6, ptr %6, align 4
@@ -30,7 +30,7 @@
 ; CHECK-NEXT:  Function: dog, Basic Block: entry
 ; CHECK-NEXT:    Start Instruction:   store i32 1, ptr %1, align 4
 ; CHECK-NEXT:      End Instruction:   store i32 5, ptr %5, align 4
-; CHECK-NEXT:4 candidates of length 4.  Found in: 
+; CHECK-NEXT:4 candidates of length 4.  Found in:
 ; CHECK-NEXT:  Function: turtle, Basic Block: (unnamed)
 ; CHECK-NEXT:    Start Instruction:   store i32 3, ptr %3, align 4
 ; CHECK-NEXT:      End Instruction:   store i32 6, ptr %6, align 4
@@ -43,7 +43,7 @@
 ; CHECK-NEXT:  Function: dog, Basic Block: entry
 ; CHECK-NEXT:    Start Instruction:   store i32 2, ptr %2, align 4
 ; CHECK-NEXT:      End Instruction:   store i32 5, ptr %5, align 4
-; CHECK-NEXT:4 candidates of length 3.  Found in: 
+; CHECK-NEXT:4 candidates of length 3.  Found in:
 ; CHECK-NEXT:  Function: turtle, Basic Block: (unnamed)
 ; CHECK-NEXT:    Start Instruction:   store i32 4, ptr %4, align 4
 ; CHECK-NEXT:      End Instruction:   store i32 6, ptr %6, align 4
@@ -56,7 +56,7 @@
 ; CHECK-NEXT:  Function: dog, Basic Block: entry
 ; CHECK-NEXT:    Start Instruction:   store i32 3, ptr %3, align 4
 ; CHECK-NEXT:      End Instruction:   store i32 5, ptr %5, align 4
-; CHECK-NEXT:4 candidates of length 2.  Found in: 
+; CHECK-NEXT:4 candidates of length 2.  Found in:
 ; CHECK-NEXT:  Function: turtle, Basic Block: (unnamed)
 ; CHECK-NEXT:    Start Instruction:   store i32 5, ptr %5, align 4
 ; CHECK-NEXT:      End Instruction:   store i32 6, ptr %6, align 4
@@ -69,23 +69,6 @@
 ; CHECK-NEXT:  Function: dog, Basic Block: entry
 ; CHECK-NEXT:    Start Instruction:   store i32 4, ptr %4, align 4
 ; CHECK-NEXT:      End Instruction:   store i32 5, ptr %5, align 4
-
-define linkonce_odr void @fish() {
-entry:
-  %0 = alloca i32, align 4
-  %1 = alloca i32, align 4
-  %2 = alloca i32, align 4
-  %3 = alloca i32, align 4
-  %4 = alloca i32, align 4
-  %5 = alloca i32, align 4
-  store i32 6, ptr %0, align 4
-  store i32 1, ptr %1, align 4
-  store i32 2, ptr %2, align 4
-  store i32 3, ptr %3, align 4
-  store i32 4, ptr %4, align 4
-  store i32 5, ptr %5, align 4
-  ret void
-}
 
 define void @turtle() {
   %1 = alloca i32, align 4
@@ -104,6 +87,23 @@ define void @turtle() {
 }
 
 define void @cat() {
+entry:
+  %0 = alloca i32, align 4
+  %1 = alloca i32, align 4
+  %2 = alloca i32, align 4
+  %3 = alloca i32, align 4
+  %4 = alloca i32, align 4
+  %5 = alloca i32, align 4
+  store i32 6, ptr %0, align 4
+  store i32 1, ptr %1, align 4
+  store i32 2, ptr %2, align 4
+  store i32 3, ptr %3, align 4
+  store i32 4, ptr %4, align 4
+  store i32 5, ptr %5, align 4
+  ret void
+}
+
+define linkonce_odr void @fish() {
 entry:
   %0 = alloca i32, align 4
   %1 = alloca i32, align 4

--- a/llvm/test/Analysis/IRSimilarityIdentifier/different.ll
+++ b/llvm/test/Analysis/IRSimilarityIdentifier/different.ll
@@ -14,11 +14,11 @@
 ; CHECK-NEXT:       End Instruction:   store i32 5, ptr %5, align 4
 ; CHECK-NEXT: 2 candidates of length 3.  Found in:
 ; CHECK-NEXT:   Function: turtle, Basic Block: (unnamed)
-; CHECK-NEXT:     Start Instruction:   %b = load i32, ptr %1, align 4
-; CHECK-NEXT:       End Instruction:   %d = load i32, ptr %3, align 4
-; CHECK-NEXT:   Function: turtle, Basic Block: (unnamed)
 ; CHECK-NEXT:     Start Instruction:   %a = load i32, ptr %0, align 4
 ; CHECK-NEXT:       End Instruction:   %c = load i32, ptr %2, align 4
+; CHECK-NEXT:   Function: turtle, Basic Block: (unnamed)
+; CHECK-NEXT:     Start Instruction:   %b = load i32, ptr %1, align 4
+; CHECK-NEXT:       End Instruction:   %d = load i32, ptr %3, align 4
 
 define linkonce_odr void @fish() {
 entry:

--- a/llvm/test/CodeGen/AArch64/machine-outliner-overlap.mir
+++ b/llvm/test/CodeGen/AArch64/machine-outliner-overlap.mir
@@ -8,27 +8,27 @@
 # CHECK-NEXT:    Candidates discarded: 0
 # CHECK-NEXT:    Candidates kept: 2
 # CHECK-DAG:  Sequence length: 8
-# CHECK-NEXT:    .. DISCARD candidate @ [5, 12]; overlaps with candidate @ [12, 19]
+# CHECK-NEXT:    .. DISCARD candidate @ [12, 19]; overlaps with candidate @ [5, 12]
 # CHECK-NEXT:    Candidates discarded: 1
 # CHECK-NEXT:    Candidates kept: 1
 # CHECK-DAG:   Sequence length: 9
-# CHECK-NEXT:    .. DISCARD candidate @ [4, 12]; overlaps with candidate @ [11, 19]
+# CHECK-NEXT:    .. DISCARD candidate @ [11, 19]; overlaps with candidate @ [4, 12]
 # CHECK-NEXT:    Candidates discarded: 1
 # CHECK-NEXT:    Candidates kept: 1
 # CHECK-DAG:   Sequence length: 10
-# CHECK-NEXT:    .. DISCARD candidate @ [3, 12]; overlaps with candidate @ [10, 19]
+# CHECK-NEXT:    .. DISCARD candidate @ [10, 19]; overlaps with candidate @ [3, 12]
 # CHECK-NEXT:    Candidates discarded: 1
 # CHECK-NEXT:    Candidates kept: 1
 # CHECK-DAG:   Sequence length: 11
-# CHECK-NEXT:    .. DISCARD candidate @ [2, 12]; overlaps with candidate @ [9, 19]
+# CHECK-NEXT:    .. DISCARD candidate @ [9, 19]; overlaps with candidate @ [2, 12]
 # CHECK-NEXT:    Candidates discarded: 1
 # CHECK-NEXT:    Candidates kept: 1
 # CHECK-DAG:   Sequence length: 12
-# CHECK-NEXT:    .. DISCARD candidate @ [1, 12]; overlaps with candidate @ [8, 19]
+# CHECK-NEXT:    .. DISCARD candidate @ [8, 19]; overlaps with candidate @ [1, 12]
 # CHECK-NEXT:    Candidates discarded: 1
 # CHECK-NEXT:    Candidates kept: 1
 # CHECK-DAG:   Sequence length: 13
-# CHECK-NEXT:    .. DISCARD candidate @ [0, 12]; overlaps with candidate @ [7, 19]
+# CHECK-NEXT:    .. DISCARD candidate @ [7, 19]; overlaps with candidate @ [0, 12]
 # CHECK-NEXT:    Candidates discarded: 1
 # CHECK-NEXT:    Candidates kept: 1
 

--- a/llvm/test/Transforms/IROutliner/outlining-commutative.ll
+++ b/llvm/test/Transforms/IROutliner/outlining-commutative.ll
@@ -123,7 +123,7 @@ define void @outline_from_sub1() {
 ; CHECK-NEXT:    [[A:%.*]] = alloca i32, align 4
 ; CHECK-NEXT:    [[B:%.*]] = alloca i32, align 4
 ; CHECK-NEXT:    [[C:%.*]] = alloca i32, align 4
-; CHECK-NEXT:    call void @outlined_ir_func_2(ptr [[A]], ptr [[B]], ptr [[C]])
+; CHECK-NEXT:    call void @outlined_ir_func_1(ptr [[A]], ptr [[B]], ptr [[C]])
 ; CHECK-NEXT:    ret void
 ;
 entry:
@@ -148,7 +148,7 @@ define void @outline_from_sub2() {
 ; CHECK-NEXT:    [[A:%.*]] = alloca i32, align 4
 ; CHECK-NEXT:    [[B:%.*]] = alloca i32, align 4
 ; CHECK-NEXT:    [[C:%.*]] = alloca i32, align 4
-; CHECK-NEXT:    call void @outlined_ir_func_2(ptr [[A]], ptr [[B]], ptr [[C]])
+; CHECK-NEXT:    call void @outlined_ir_func_1(ptr [[A]], ptr [[B]], ptr [[C]])
 ; CHECK-NEXT:    ret void
 ;
 entry:
@@ -173,7 +173,7 @@ define void @dontoutline_from_flipped_sub3() {
 ; CHECK-NEXT:    [[A:%.*]] = alloca i32, align 4
 ; CHECK-NEXT:    [[B:%.*]] = alloca i32, align 4
 ; CHECK-NEXT:    [[C:%.*]] = alloca i32, align 4
-; CHECK-NEXT:    call void @outlined_ir_func_1(ptr [[A]], ptr [[B]], ptr [[C]])
+; CHECK-NEXT:    call void @outlined_ir_func_2(ptr [[A]], ptr [[B]], ptr [[C]])
 ; CHECK-NEXT:    ret void
 ;
 entry:
@@ -198,7 +198,7 @@ define void @dontoutline_from_flipped_sub4() {
 ; CHECK-NEXT:    [[A:%.*]] = alloca i32, align 4
 ; CHECK-NEXT:    [[B:%.*]] = alloca i32, align 4
 ; CHECK-NEXT:    [[C:%.*]] = alloca i32, align 4
-; CHECK-NEXT:    call void @outlined_ir_func_1(ptr [[A]], ptr [[B]], ptr [[C]])
+; CHECK-NEXT:    call void @outlined_ir_func_2(ptr [[A]], ptr [[B]], ptr [[C]])
 ; CHECK-NEXT:    ret void
 ;
 entry:
@@ -237,9 +237,9 @@ entry:
 ; CHECK-NEXT:    [[AL:%.*]] = load i32, ptr [[ARG0]], align 4
 ; CHECK-NEXT:    [[BL:%.*]] = load i32, ptr [[ARG1]], align 4
 ; CHECK-NEXT:    [[CL:%.*]] = load i32, ptr [[ARG2]], align 4
-; CHECK-NEXT:    [[TMP0:%.*]] = sub i32 [[BL]], [[AL]]
-; CHECK-NEXT:    [[TMP1:%.*]] = sub i32 [[CL]], [[AL]]
-; CHECK-NEXT:    [[TMP2:%.*]] = sub i32 [[CL]], [[BL]]
+; CHECK-NEXT:    [[TMP0:%.*]] = sub i32 [[AL]], [[BL]]
+; CHECK-NEXT:    [[TMP1:%.*]] = sub i32 [[AL]], [[CL]]
+; CHECK-NEXT:    [[TMP2:%.*]] = sub i32 [[BL]], [[CL]]
 
 ; CHECK: define internal void @outlined_ir_func_2(ptr [[ARG0:%.*]], ptr [[ARG1:%.*]], ptr [[ARG2:%.*]]) #0 {
 ; CHECK: entry_to_outline:
@@ -249,6 +249,6 @@ entry:
 ; CHECK-NEXT:    [[AL:%.*]] = load i32, ptr [[ARG0]], align 4
 ; CHECK-NEXT:    [[BL:%.*]] = load i32, ptr [[ARG1]], align 4
 ; CHECK-NEXT:    [[CL:%.*]] = load i32, ptr [[ARG2]], align 4
-; CHECK-NEXT:    [[TMP0:%.*]] = sub i32 [[AL]], [[BL]]
-; CHECK-NEXT:    [[TMP1:%.*]] = sub i32 [[AL]], [[CL]]
-; CHECK-NEXT:    [[TMP2:%.*]] = sub i32 [[BL]], [[CL]]
+; CHECK-NEXT:    [[TMP0:%.*]] = sub i32 [[BL]], [[AL]]
+; CHECK-NEXT:    [[TMP1:%.*]] = sub i32 [[CL]], [[AL]]
+; CHECK-NEXT:    [[TMP2:%.*]] = sub i32 [[CL]], [[BL]]

--- a/llvm/test/tools/llvm-sim/single-sim-file.test
+++ b/llvm/test/tools/llvm-sim/single-sim-file.test
@@ -6,52 +6,52 @@
 # CHECK: {
 # CHECK-NEXT: "1": [
 # CHECK-NEXT:  {
-# CHECK-NEXT:   "start": 14,
-# CHECK-NEXT:   "end": 19
-# CHECK-NEXT:  },
-# CHECK-NEXT:  {
 # CHECK-NEXT:   "start": 4,
 # CHECK-NEXT:   "end": 9
+# CHECK-NEXT:  },
+# CHECK-NEXT:  {
+# CHECK-NEXT:   "start": 14,
+# CHECK-NEXT:   "end": 19
 # CHECK-NEXT:  }
 # CHECK-NEXT: ],
 # CHECK-NEXT: "2": [
 # CHECK-NEXT:  {
-# CHECK-NEXT:   "start": 15,
-# CHECK-NEXT:   "end": 19
-# CHECK-NEXT:  },
-# CHECK-NEXT:  {
 # CHECK-NEXT:   "start": 5,
 # CHECK-NEXT:   "end": 9
+# CHECK-NEXT:  },
+# CHECK-NEXT:  {
+# CHECK-NEXT:   "start": 15,
+# CHECK-NEXT:   "end": 19
 # CHECK-NEXT:  }
 # CHECK-NEXT: ],
 # CHECK-NEXT: "3": [
 # CHECK-NEXT:  {
-# CHECK-NEXT:   "start": 16,
-# CHECK-NEXT:   "end": 19
-# CHECK-NEXT:  },
-# CHECK-NEXT:  {
 # CHECK-NEXT:   "start": 6,
 # CHECK-NEXT:   "end": 9
+# CHECK-NEXT:  },
+# CHECK-NEXT:  {
+# CHECK-NEXT:   "start": 16,
+# CHECK-NEXT:   "end": 19
 # CHECK-NEXT:  }
 # CHECK-NEXT: ],
 # CHECK-NEXT: "4": [
 # CHECK-NEXT:  {
-# CHECK-NEXT:   "start": 17,
-# CHECK-NEXT:   "end": 19
-# CHECK-NEXT:  },
-# CHECK-NEXT:  {
 # CHECK-NEXT:   "start": 7,
 # CHECK-NEXT:   "end": 9
+# CHECK-NEXT:  },
+# CHECK-NEXT:  {
+# CHECK-NEXT:   "start": 17,
+# CHECK-NEXT:   "end": 19
 # CHECK-NEXT:  }
 # CHECK-NEXT: ],
 # CHECK-NEXT: "5": [
 # CHECK-NEXT:  {
-# CHECK-NEXT:   "start": 18,
-# CHECK-NEXT:   "end": 19
-# CHECK-NEXT:  },
-# CHECK-NEXT:  {
 # CHECK-NEXT:   "start": 8,
 # CHECK-NEXT:   "end": 9
+# CHECK-NEXT:  },
+# CHECK-NEXT:  {
+# CHECK-NEXT:   "start": 18,
+# CHECK-NEXT:   "end": 19
 # CHECK-NEXT:  }
 # CHECK-NEXT: ]
 # CHECK-NEXT:}

--- a/llvm/test/tools/llvm-sim/single-sim.test
+++ b/llvm/test/tools/llvm-sim/single-sim.test
@@ -5,52 +5,52 @@
 # CHECK: {
 # CHECK-NEXT: "1": [
 # CHECK-NEXT:  {
-# CHECK-NEXT:   "start": 14,
-# CHECK-NEXT:   "end": 19
-# CHECK-NEXT:  },
-# CHECK-NEXT:  {
 # CHECK-NEXT:   "start": 4,
 # CHECK-NEXT:   "end": 9
+# CHECK-NEXT:  },
+# CHECK-NEXT:  {
+# CHECK-NEXT:   "start": 14,
+# CHECK-NEXT:   "end": 19
 # CHECK-NEXT:  }
 # CHECK-NEXT: ],
 # CHECK-NEXT: "2": [
 # CHECK-NEXT:  {
-# CHECK-NEXT:   "start": 15,
-# CHECK-NEXT:   "end": 19
-# CHECK-NEXT:  },
-# CHECK-NEXT:  {
 # CHECK-NEXT:   "start": 5,
 # CHECK-NEXT:   "end": 9
+# CHECK-NEXT:  },
+# CHECK-NEXT:  {
+# CHECK-NEXT:   "start": 15,
+# CHECK-NEXT:   "end": 19
 # CHECK-NEXT:  }
 # CHECK-NEXT: ],
 # CHECK-NEXT: "3": [
 # CHECK-NEXT:  {
-# CHECK-NEXT:   "start": 16,
-# CHECK-NEXT:   "end": 19
-# CHECK-NEXT:  },
-# CHECK-NEXT:  {
 # CHECK-NEXT:   "start": 6,
 # CHECK-NEXT:   "end": 9
+# CHECK-NEXT:  },
+# CHECK-NEXT:  {
+# CHECK-NEXT:   "start": 16,
+# CHECK-NEXT:   "end": 19
 # CHECK-NEXT:  }
 # CHECK-NEXT: ],
 # CHECK-NEXT: "4": [
 # CHECK-NEXT:  {
-# CHECK-NEXT:   "start": 17,
-# CHECK-NEXT:   "end": 19
-# CHECK-NEXT:  },
-# CHECK-NEXT:  {
 # CHECK-NEXT:   "start": 7,
 # CHECK-NEXT:   "end": 9
+# CHECK-NEXT:  },
+# CHECK-NEXT:  {
+# CHECK-NEXT:   "start": 17,
+# CHECK-NEXT:   "end": 19
 # CHECK-NEXT:  }
 # CHECK-NEXT: ],
 # CHECK-NEXT: "5": [
 # CHECK-NEXT:  {
-# CHECK-NEXT:   "start": 18,
-# CHECK-NEXT:   "end": 19
-# CHECK-NEXT:  },
-# CHECK-NEXT:  {
 # CHECK-NEXT:   "start": 8,
 # CHECK-NEXT:   "end": 9
+# CHECK-NEXT:  },
+# CHECK-NEXT:  {
+# CHECK-NEXT:   "start": 18,
+# CHECK-NEXT:   "end": 19
 # CHECK-NEXT:  }
 # CHECK-NEXT: ]
 # CHECK-NEXT:}


### PR DESCRIPTION
We reduce the complexity of the main loop of findCandidates() method from O(n^2) to O(n log n).

We sort RS.StartIndices in SuffixTree and change replace find_if function with a simple check.

For each SuffixTree::RepeatedSubstring RS, the time complexity to find a set of candidates that do not overlap with each other is O(n^2) where n is the number of occurrence of this repeated substring (i.e., the size of RS.StartIndices). This is due to the use of the find_if method which has complexity O(n). The quadratic runtime becomes a problem when n gets larger. For clang, with [3], the maximum n goes from 12k to 100k, and the time to complete the main loop in MachineOutliner::findCandidates() goes from 17 seconds to 120 seconds.

To improve the runtime, we implement a more efficient algorithm with complexity O(n log n), using the fact that once RS.StartIndices is sorted, find_if can be achieved with an O(1) check. The O(n log n) complexity comes from the sorting. For clang, with [1], the time to complete the loop is reduced to only 28 seconds.
