### PR TITLE
[Docs] Fix FAQ and Lexicon links under design overview

### DIFF
--- a/llvm/docs/index.rst
+++ b/llvm/docs/index.rst
@@ -24,6 +24,12 @@ Several introductory papers and presentations.
    FAQ
    Lexicon
 
+:doc:`FAQ`
+  Frequently asked questions.
+
+:doc:`Lexicon`
+  Glossary.
+
 `Introduction to the LLVM Compiler`__
   Presentation providing a users introduction to LLVM.
 


### PR DESCRIPTION
This patch updates the FAQ and lexicon links under design overview to actually work instead of being incomplete and thus completely missing from the output.