### PR TITLE
[COFF] Rename the COFFShortExport::AliasTarget field. NFC.

### DIFF
--- a/lld/COFF/Config.h
+++ b/lld/COFF/Config.h
@@ -55,7 +55,7 @@ struct Export {
   StringRef name;       // N in /export:N or /export:E=N
   StringRef extName;    // E in /export:E=N
   StringRef exportAs;   // E in /export:N,EXPORTAS,E
-  StringRef aliasTarget; // GNU specific: N in "alias == N"
+  StringRef importName; // GNU specific: N in "othername == N"
   Symbol *sym = nullptr;
   uint16_t ordinal = 0;
   bool noname = false;
@@ -75,7 +75,7 @@ struct Export {
 
   bool operator==(const Export &e) const {
     return (name == e.name && extName == e.extName && exportAs == e.exportAs &&
-            aliasTarget == e.aliasTarget && ordinal == e.ordinal &&
+            importName == e.importName && ordinal == e.ordinal &&
             noname == e.noname && data == e.data && isPrivate == e.isPrivate);
   }
 };

--- a/lld/COFF/Driver.cpp
+++ b/lld/COFF/Driver.cpp
@@ -934,7 +934,7 @@ void LinkerDriver::createImportLibrary(bool asLib) {
     e2.SymbolName = std::string(e1.symbolName);
     e2.ExtName = std::string(e1.extName);
     e2.ExportAs = std::string(e1.exportAs);
-    e2.AliasTarget = std::string(e1.aliasTarget);
+    e2.ImportName = std::string(e1.importName);
     e2.Ordinal = e1.ordinal;
     e2.Noname = e1.noname;
     e2.Data = e1.data;
@@ -1034,7 +1034,7 @@ void LinkerDriver::parseModuleDefs(StringRef path) {
       e2.extName = saver().save(e1.ExtName);
     }
     e2.exportAs = saver().save(e1.ExportAs);
-    e2.aliasTarget = saver().save(e1.AliasTarget);
+    e2.importName = saver().save(e1.ImportName);
     e2.ordinal = e1.Ordinal;
     e2.noname = e1.Noname;
     e2.data = e1.Data;

--- a/llvm/include/llvm/Object/COFFImportFile.h
+++ b/llvm/include/llvm/Object/COFFImportFile.h
@@ -98,9 +98,11 @@ struct COFFShortExport {
   /// "/export:foo=bar", this could be "_bar@8" if bar is stdcall.
   std::string SymbolName;
 
-  /// Creates a weak alias. This is the name of the weak aliasee. In a .def
+  /// Creates an import library entry that imports from a DLL export with a
+  /// different name. This is the name of the DLL export that should be
+  /// referenced when linking against this import library entry. In a .def
   /// file, this is "baz" in "EXPORTS\nfoo = bar == baz".
-  std::string AliasTarget;
+  std::string ImportName;
 
   /// Specifies EXPORTAS name. In a .def file, this is "bar" in
   /// "EXPORTS\nfoo EXPORTAS bar".

--- a/llvm/lib/Object/COFFImportFile.cpp
+++ b/llvm/lib/Object/COFFImportFile.cpp
@@ -690,9 +690,9 @@ Error writeImportLibrary(StringRef ImportName, StringRef Path,
         Name.swap(*ReplacedName);
       }
 
-      if (!E.AliasTarget.empty() && Name != E.AliasTarget) {
-        Members.push_back(OF.createWeakExternal(E.AliasTarget, Name, false, M));
-        Members.push_back(OF.createWeakExternal(E.AliasTarget, Name, true, M));
+      if (!E.ImportName.empty() && Name != E.ImportName) {
+        Members.push_back(OF.createWeakExternal(E.ImportName, Name, false, M));
+        Members.push_back(OF.createWeakExternal(E.ImportName, Name, true, M));
         continue;
       }
 

--- a/llvm/lib/Object/COFFModuleDefinition.cpp
+++ b/llvm/lib/Object/COFFModuleDefinition.cpp
@@ -281,9 +281,9 @@ private:
       }
       if (Tok.K == EqualEqual) {
         read();
-        E.AliasTarget = std::string(Tok.Value);
-        if (AddUnderscores && !isDecorated(E.AliasTarget, MingwDef))
-          E.AliasTarget = std::string("_").append(E.AliasTarget);
+        E.ImportName = std::string(Tok.Value);
+        if (AddUnderscores && !isDecorated(E.ImportName, MingwDef))
+          E.ImportName = std::string("_").append(E.ImportName);
         continue;
       }
       // EXPORTAS must be at the end of export definition

--- a/llvm/lib/ToolDrivers/llvm-dlltool/DlltoolDriver.cpp
+++ b/llvm/lib/ToolDrivers/llvm-dlltool/DlltoolDriver.cpp
@@ -227,7 +227,7 @@ int llvm::dlltoolDriverMain(llvm::ArrayRef<const char *> ArgsArr) {
 
   if (Machine == IMAGE_FILE_MACHINE_I386 && Args.hasArg(OPT_k)) {
     for (COFFShortExport &E : Exports) {
-      if (!E.AliasTarget.empty() || (!E.Name.empty() && E.Name[0] == '?'))
+      if (!E.ImportName.empty() || (!E.Name.empty() && E.Name[0] == '?'))
         continue;
       E.SymbolName = E.Name;
       // Trim off the trailing decoration. Symbols will always have a


### PR DESCRIPTION
It turns out that the previous name is vaguely misleading.

When operating on a def file like "symbolname == dllname", that is supposed to make an import library entry, that when the symbol "symbolname" links against this, it imports the DLL symbol "dllname" from the referenced DLL. This doesn't need to involve any alias, and it doesn't need to imply that "dllname" is available on its own as a separate symbol in the import library at all.

GNU dlltool implements import libraries in the form of "long import library", where each member is a regular object file with section chunks that compose the relevant .idata section pieces. There, this kind of import renaming does not involve any form of aliases, but the right .idata section just gets a different string than the symbol name.