### PR TITLE
[compiler-rt][wasm] Compile atomic.c with atomics and bulk-memory features

### DIFF
--- a/compiler-rt/lib/builtins/CMakeLists.txt
+++ b/compiler-rt/lib/builtins/CMakeLists.txt
@@ -854,11 +854,30 @@ else ()
         list(APPEND BUILTIN_CFLAGS_${arch} -fforce-enable-int128)
       endif()
 
+      set(BUILTIN_OBJECT_LIBS_${arch})
+      # For WebAssembly, we need to compile the atomic.c with different flags than the rest
+      # to enable atomics and bulk-memory features only for the object file.
+      if((arch STREQUAL "wasm32" OR arch STREQUAL "wasm64") AND "atomic.c" IN_LIST ${arch}_SOURCES)
+        set(BUILTIN_ATOMIC_CFLAGS_${arch} ${BUILTIN_CFLAGS_${arch}})
+        list(APPEND BUILTIN_ATOMIC_CFLAGS_${arch} -matomics -mbulk-memory)
+        add_compiler_rt_object_libraries(clang_rt.builtins.${arch}.atomic
+                                         ARCHS ${arch}
+                                         DEPS ${deps_${arch}}
+                                         SOURCES atomic.c
+                                         DEFS ${BUILTIN_DEFS}
+                                         CFLAGS ${BUILTIN_ATOMIC_CFLAGS_${arch}})
+        # Include the atomic object file in the builtins archive
+        list(APPEND BUILTIN_OBJECT_LIBS_${arch} clang_rt.builtins.${arch}.atomic)
+        # Remove atomic.c from the main list of sources
+        list(REMOVE_ITEM ${arch}_SOURCES atomic.c)
+      endif()
+
       add_compiler_rt_runtime(clang_rt.builtins
                               STATIC
                               ARCHS ${arch}
                               DEPS ${deps_${arch}}
                               SOURCES ${${arch}_SOURCES}
+                              OBJECT_LIBS ${BUILTIN_OBJECT_LIBS_${arch}}
                               DEFS ${BUILTIN_DEFS}
                               CFLAGS ${BUILTIN_CFLAGS_${arch}}
                               PARENT_TARGET builtins)


### PR DESCRIPTION
The bulitin object file for `atomic.c` is only referenced by user code when the atomics and bulk-memory features are enabled and libcall is required. However, the atomic.c itself was compiled without those features and it leads to a linker error because all objects have to have the feature when `--shared-memory` is enabled.
This patch compiles `atomic.c` with the atomics and bulk-memory features enabled.

This unlocks atomics with larger types than 64bit on WebAssembly.