### PR TITLE
[RISCV] Check that VLMAX is the same when demanding exact VL

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVInsertVSETVLI.cpp
+++ b/llvm/lib/Target/RISCV/RISCVInsertVSETVLI.cpp
@@ -616,7 +616,7 @@ public:
     if (SEWLMULRatioOnly)
       return false;
 
-    if (Used.VLAny && !hasSameAVL(Require))
+    if (Used.VLAny && !(hasSameAVL(Require) && hasSameVLMAX(Require)))
       return false;
 
     if (Used.VLZeroness && !hasEquallyZeroAVL(Require, MRI))


### PR DESCRIPTION
Currently we just check the AVL is the same, but if the AVL is larger than VLMAX then the VL may differ. We need to also check that the VLMAX (a.k.a the SEW/LMUL ratio) is also the same.

This doesn't seem to be a problem in practice beacause coincidentally we only demanded VLAny whenever we also demand SEWLMULRatio, see getDemanded. So I don't think it's possible to create a test case.
