### PR TITLE
[libc++] Move some macOS CI jobs to Github actions

### DIFF
--- a/.github/workflows/libcxx-build-and-test.yaml
+++ b/.github/workflows/libcxx-build-and-test.yaml
@@ -191,6 +191,42 @@ jobs:
             **/CMakeError.log
             **/CMakeOutput.log
             **/crash_diagnostics/*
+
+  macos:
+    runs-on: macos-14
+    needs: [ stage1 ]
+    strategy:
+      fail-fast: true
+      matrix:
+        config: [
+          generic-cxx03,
+          generic-cxx23,
+          generic-modules,
+          apple-configuration
+        ]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: 'latest-stable'
+      - uses: seanmiddleditch/gha-setup-ninja@master
+      - name: Build and test
+        run: |
+          python3 -m venv .venv
+          source .venv/bin/activate
+          python -m pip install psutil
+          bash libcxx/utils/ci/run-buildbot ${{ matrix.config }}
+      - uses: actions/upload-artifact@26f96dfa697d77e81fd5907df203aa23a56210a8 # v4.3.0
+        if: always()  # Upload artifacts even if the build or test suite fails
+        with:
+          name: macos-${{ matrix.config }}-results
+          path: |
+            **/test-results.xml
+            **/*.abilist
+            **/CMakeError.log
+            **/CMakeOutput.log
+            **/crash_diagnostics/*
+
   windows:
     runs-on: windows-2022
     needs: [ stage1 ]

--- a/libcxx/utils/ci/buildkite-pipeline.yml
+++ b/libcxx/utils/ci/buildkite-pipeline.yml
@@ -39,45 +39,6 @@ definitions:
 steps:
 - group: ':mac: Apple'
   steps:
-  - label: MacOS x86_64
-    command: libcxx/utils/ci/run-buildbot generic-cxx23
-    agents:
-      queue: libcxx-builders
-      os: macos
-      arch: x86_64
-    <<: *common
-
-  - label: MacOS arm64
-    command: libcxx/utils/ci/run-buildbot generic-cxx23
-    agents:
-      queue: libcxx-builders
-      os: macos
-      arch: arm64
-    <<: *common
-
-  - label: MacOS with Modules
-    command: libcxx/utils/ci/run-buildbot generic-modules
-    agents:
-      queue: libcxx-builders
-      os: macos
-    <<: *common
-
-  - label: MacOS with C++03
-    command: libcxx/utils/ci/run-buildbot generic-cxx03
-    agents:
-      queue: libcxx-builders
-      os: macos
-    <<: *common
-
-    # Build with the configuration we use to generate libc++.dylib on Apple platforms
-  - label: Apple system configuration
-    command: libcxx/utils/ci/run-buildbot apple-configuration
-    agents:
-      queue: libcxx-builders
-      os: macos
-      arch: arm64 # This can technically run on any architecture, but we have more resources on arm64 so we pin this job to arm64
-    <<: *common
-
   - label: Apple back-deployment macosx10.13
     command: libcxx/utils/ci/run-buildbot apple-system-backdeployment-10.13
     agents:
@@ -101,6 +62,22 @@ steps:
       os: macos
       arch: x86_64 # TODO: Remove this once we are able to run back-deployment on arm64 again, since this isn't x86_64 specific
     <<: *common
+
+    # TODO: Re-enable this once we've figured out how to run back-deployment testing on arm64 on recent OSes
+    # - label: "Apple back-deployment macosx11.0 arm64"
+    #   command: "libcxx/utils/ci/run-buildbot apple-system-backdeployment-11.0"
+    #   artifact_paths:
+    #     - "**/test-results.xml"
+    #     - "**/*.abilist"
+    #   agents:
+    #     queue: "libcxx-builders"
+    #     os: "macos"
+    #     arch: "arm64"
+    #   retry:
+    #     automatic:
+    #       - exit_status: -1  # Agent was lost
+    #         limit: 2
+    #   timeout_in_minutes: 120
 
 - group: ARM
   steps:
@@ -211,20 +188,3 @@ steps:
       queue: libcxx-builders
       os: android
     <<: *common
-
-
-    # TODO: Re-enable this once we've figured out how to run back-deployment testing on arm64 on recent OSes
-    # - label: "Apple back-deployment macosx11.0 arm64"
-    #   command: "libcxx/utils/ci/run-buildbot apple-system-backdeployment-11.0"
-    #   artifact_paths:
-    #     - "**/test-results.xml"
-    #     - "**/*.abilist"
-    #   agents:
-    #     queue: "libcxx-builders"
-    #     os: "macos"
-    #     arch: "arm64"
-    #   retry:
-    #     automatic:
-    #       - exit_status: -1  # Agent was lost
-    #         limit: 2
-    #   timeout_in_minutes: 120


### PR DESCRIPTION
This patch decouples macOS CI testing from BuildKite, which makes the
maintenance of macOS CI easier and more accessible to all contributors.
Right now, the macOS CI is running entirely on machines owned by the
LLVM Foundation with only a small set of contributors having direct
access to them. In particular, updating these machines is currently
a very time-consuming manual process that requires taking the machines
offline, and using Github-provided instances makes that an order of
magnitude easier.

The story for performing back-deployment testing still needs to be
figured out, so for now we are retaining some jobs under BuildKite.