### PR TITLE
[ASTImporter] Fix infinite recurse on return type declared inside body (#68775)

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -545,7 +545,8 @@ Bug Fixes to AST Handling
 Miscellaneous Bug Fixes
 ^^^^^^^^^^^^^^^^^^^^^^^
 
-- Fixed an infinite recursion on return type declared inside body (#GH68775).
+- Fixed an infinite recursion in ASTImporter, on return type declared inside
+  body of C++11 lambda without trailing return (#GH68775).
 
 Miscellaneous Clang Crashes Fixed
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -545,6 +545,8 @@ Bug Fixes to AST Handling
 Miscellaneous Bug Fixes
 ^^^^^^^^^^^^^^^^^^^^^^^
 
+- Fixed an infinite recursion on return type declared inside body (#GH68775).
+
 Miscellaneous Clang Crashes Fixed
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/clang/lib/AST/ASTImporter.cpp
+++ b/clang/lib/AST/ASTImporter.cpp
@@ -3655,7 +3655,7 @@ bool ASTNodeImporter::hasReturnTypeDeclaredInside(FunctionDecl *D) {
   assert(FromFPT && "Must be called on FunctionProtoType");
 
   auto IsCXX11LambdaWithouTrailingReturn = [&]() {
-    if (!Importer.FromContext.getLangOpts().CPlusPlus11)
+    if (Importer.FromContext.getLangOpts().CPlusPlus14) // C++14 or later
       return false;
 
     if (FromFPT->hasTrailingReturn())

--- a/clang/lib/AST/ASTImporter.cpp
+++ b/clang/lib/AST/ASTImporter.cpp
@@ -3522,7 +3522,6 @@ public:
       : ParentDC(ParentDC) {}
 
   bool CheckType(QualType T) {
-    T->isUndeducedType();
     // Check the chain of "sugar" types.
     // The "sugar" types are typedef or similar types that have the same
     // canonical type.

--- a/clang/unittests/AST/ASTImporterTest.cpp
+++ b/clang/unittests/AST/ASTImporterTest.cpp
@@ -6721,6 +6721,22 @@ TEST_P(ASTImporterOptionSpecificTestBase, LambdaInFunctionBody) {
   EXPECT_FALSE(FromL->isDependentLambda());
 }
 
+TEST_P(ASTImporterOptionSpecificTestBase, LambdaReturnTypeDeclaredInside) {
+  Decl *From, *To;
+  std::tie(From, To) = getImportedDecl(
+      R"(
+      void foo() {
+        (void) []() {
+          struct X {};
+          return X();
+        };
+      }
+      )",
+      Lang_CXX11, "", Lang_CXX11, "foo");
+  auto *ToLambda = FirstDeclMatcher<LambdaExpr>().match(To, lambdaExpr());
+  EXPECT_TRUE(ToLambda);
+}
+
 TEST_P(ASTImporterOptionSpecificTestBase, LambdaInFunctionParam) {
   Decl *FromTU = getTuDecl(
       R"(

--- a/clang/unittests/AST/ASTImporterTest.cpp
+++ b/clang/unittests/AST/ASTImporterTest.cpp
@@ -6721,7 +6721,8 @@ TEST_P(ASTImporterOptionSpecificTestBase, LambdaInFunctionBody) {
   EXPECT_FALSE(FromL->isDependentLambda());
 }
 
-TEST_P(ASTImporterOptionSpecificTestBase, LambdaReturnTypeDeclaredInside) {
+TEST_P(ASTImporterOptionSpecificTestBase,
+       ReturnTypeDeclaredInsideOfCXX11LambdaWithoutTrailingReturn) {
   Decl *From, *To;
   std::tie(From, To) = getImportedDecl(
       R"(
@@ -6732,7 +6733,7 @@ TEST_P(ASTImporterOptionSpecificTestBase, LambdaReturnTypeDeclaredInside) {
         };
       }
       )",
-      Lang_CXX11, "", Lang_CXX11, "foo");
+      Lang_CXX11, "", Lang_CXX11, "foo"); // c++11 only
   auto *ToLambda = FirstDeclMatcher<LambdaExpr>().match(To, lambdaExpr());
   EXPECT_TRUE(ToLambda);
 }


### PR DESCRIPTION
Lambda without trailing auto could have return type declared inside the body too.

Fixes #68775 