### PR TITLE
[libc] set cmake dependencies for condattr test

### DIFF
--- a/libc/src/pthread/pthread_condattr_destroy.cpp
+++ b/libc/src/pthread/pthread_condattr_destroy.cpp
@@ -14,7 +14,8 @@
 
 namespace LIBC_NAMESPACE {
 
-LLVM_LIBC_FUNCTION(int, pthread_condattr_destroy, (pthread_condattr_t * attr [[gnu::unused]])) {
+LLVM_LIBC_FUNCTION(int, pthread_condattr_destroy,
+                   (pthread_condattr_t * attr [[gnu::unused]])) {
   // Initializing a pthread_condattr_t acquires no resources, so this is a
   // no-op.
   return 0;

--- a/libc/src/pthread/pthread_condattr_destroy.cpp
+++ b/libc/src/pthread/pthread_condattr_destroy.cpp
@@ -14,7 +14,7 @@
 
 namespace LIBC_NAMESPACE {
 
-LLVM_LIBC_FUNCTION(int, pthread_condattr_destroy, (pthread_condattr_t * attr)) {
+LLVM_LIBC_FUNCTION(int, pthread_condattr_destroy, (pthread_condattr_t * attr [[gnu::unused]])) {
   // Initializing a pthread_condattr_t acquires no resources, so this is a
   // no-op.
   return 0;

--- a/libc/test/src/pthread/CMakeLists.txt
+++ b/libc/test/src/pthread/CMakeLists.txt
@@ -50,4 +50,10 @@ add_libc_unittest(
     libc.include.errno
     libc.include.pthread
     libc.include.time
+    libc.src.pthread.pthread_condattr_destroy
+    libc.src.pthread.pthread_condattr_getclock
+    libc.src.pthread.pthread_condattr_getpshared
+    libc.src.pthread.pthread_condattr_init
+    libc.src.pthread.pthread_condattr_setclock
+    libc.src.pthread.pthread_condattr_setpshared
   )


### PR DESCRIPTION
The entrypoints are not yet exposed on non-x86.  Express this dependency to
unbreak post submit.

Fixes #88987
