### PR TITLE
Summarize std::string's when created from data.

### DIFF
--- a/lldb/source/Core/ValueObject.cpp
+++ b/lldb/source/Core/ValueObject.cpp
@@ -1405,7 +1405,7 @@ addr_t ValueObject::GetAddressOf(bool scalar_is_load_address,
   case Value::ValueType::HostAddress: {
     if (address_type)
       *address_type = m_value.GetValueAddressType();
-    return LLDB_INVALID_ADDRESS;
+    return m_value.GetScalar().ULongLong(LLDB_INVALID_ADDRESS);
   } break;
   }
   if (address_type)
@@ -2745,7 +2745,7 @@ ValueObjectSP ValueObject::DoCast(const CompilerType &compiler_type) {
 ValueObjectSP ValueObject::Cast(const CompilerType &compiler_type) {
   // Only allow casts if the original type is equal or larger than the cast
   // type, unless we know this is a load address.  Getting the size wrong for
-  // a host side storage could leak lldb memory, so we absolutely want to 
+  // a host side storage could leak lldb memory, so we absolutely want to
   // prevent that.  We may not always get the right value, for instance if we
   // have an expression result value that's copied into a storage location in
   // the target may not have copied enough memory.  I'm not trying to fix that
@@ -2764,7 +2764,7 @@ ValueObjectSP ValueObject::Cast(const CompilerType &compiler_type) {
       = ExecutionContext(GetExecutionContextRef())
           .GetBestExecutionContextScope();
   if (compiler_type.GetByteSize(exe_scope)
-      <= GetCompilerType().GetByteSize(exe_scope) 
+      <= GetCompilerType().GetByteSize(exe_scope)
       || m_value.GetValueType() == Value::ValueType::LoadAddress)
         return DoCast(compiler_type);
 

--- a/lldb/source/Core/ValueObject.cpp
+++ b/lldb/source/Core/ValueObject.cpp
@@ -2763,10 +2763,10 @@ ValueObjectSP ValueObject::Cast(const CompilerType &compiler_type) {
   ExecutionContextScope *exe_scope
       = ExecutionContext(GetExecutionContextRef())
           .GetBestExecutionContextScope();
-  if (compiler_type.GetByteSize(exe_scope)
-      <= GetCompilerType().GetByteSize(exe_scope)
-      || m_value.GetValueType() == Value::ValueType::LoadAddress)
-        return DoCast(compiler_type);
+  if (compiler_type.GetByteSize(exe_scope) <=
+          GetCompilerType().GetByteSize(exe_scope) ||
+      m_value.GetValueType() == Value::ValueType::LoadAddress)
+    return DoCast(compiler_type);
 
   error.SetErrorString("Can only cast to a type that is equal to or smaller "
                        "than the orignal type.");

--- a/lldb/source/Plugins/Language/CPlusPlus/LibStdcpp.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibStdcpp.cpp
@@ -292,18 +292,16 @@ bool lldb_private::formatters::LibStdcppStringSummaryProvider(
         return true;
     } break;
     case eAddressTypeHost: {
-      // For std::strings created as data, the valueobject points to char * pointer
-      // so we can get the address of our pointer from the value object
+      // For std::strings created as data, the valueobject points to char *
+      // pointer so we can get the address of our pointer from the value object
       // and then just read the char* as the summary value
       ProcessSP process_sp(valobj.GetProcessSP());
       if (!process_sp)
         return false;
       StringPrinter::ReadStringAndDumpToStreamOptions options(valobj);
-      DataExtractor data = DataExtractor(
-        (void*)addr_of_string,
-        process_sp->GetAddressByteSize(),
-        process_sp->GetByteOrder(),
-        8);
+      DataExtractor data = DataExtractor((void *)addr_of_string,
+                                         process_sp->GetAddressByteSize(),
+                                         process_sp->GetByteOrder(), 8);
       Status error;
       lldb::offset_t offset = 0;
       lldb::addr_t addr_of_string_from_data = data.GetAddress(&offset);

--- a/lldb/source/Plugins/Language/CPlusPlus/LibStdcpp.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibStdcpp.cpp
@@ -281,6 +281,7 @@ bool lldb_private::formatters::LibStdcppStringSummaryProvider(
           addr_of_string + process_sp->GetAddressByteSize(), error);
       if (error.Fail())
         return false;
+
       options.SetSourceSize(size_of_data);
       options.SetHasSourceSize(true);
 
@@ -301,15 +302,13 @@ bool lldb_private::formatters::LibStdcppStringSummaryProvider(
 
       lldb::offset_t offset = 0;
       AddressType child_addressType = valobj.GetAddressTypeOfChildren();
-      if (child_addressType == eAddressTypeLoad)
-      {
+      if (child_addressType == eAddressTypeLoad) {
         // We have the host address of our std::string
         // But we need to read the pointee data from the debugged process.
         ProcessSP process_sp(valobj.GetProcessSP());
         // We want to read the address from std::string, which is the first 8 bytes.
         lldb::addr_t addr = data.GetAddress(&offset);
-        if (!addr)
-        {
+        if (!addr) {
           stream.Printf("nullptr");
           return true;
         }
@@ -322,8 +321,7 @@ bool lldb_private::formatters::LibStdcppStringSummaryProvider(
         return true;
       }
 
-      if (child_addressType == eAddressTypeHost)
-      {
+      if (child_addressType == eAddressTypeHost) {
         lldb::offset_t size = data.GetByteSize();
         const void* dataStart = data.GetData(&offset, size);
         if (!dataStart)

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libstdcpp/string/ConvertToDataFormatter.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libstdcpp/string/ConvertToDataFormatter.py
@@ -1,0 +1,50 @@
+# coding=utf8
+"""
+Helper formmater to verify Std::String by created via SBData
+"""
+
+import lldb
+
+class SyntheticFormatter:
+    def __init__(self, valobj, dict):
+        self.valobj = valobj
+
+    def num_children(self):
+        return 6
+
+    def has_children(self):
+        return True
+
+    def get_child_at_index(self, index):
+        name = None
+        match index:
+            case 0:
+                name = "short_string"
+            case 1:
+                name = "long_string"
+            case 2:
+                name = "short_string_ptr"
+            case 3:
+                name = "long_string_ptr"
+            case 4:
+                name = "short_string_ref"
+            case 5:
+                name = "long_string_ref"
+            case _:
+                return None
+
+        child = self.valobj.GetChildMemberWithName(name)
+        valType = child.GetType()
+        return self.valobj.CreateValueFromData(name,
+                child.GetData(),
+                valType)
+
+
+def __lldb_init_module(debugger, dict):
+    typeName = "string_container"
+    debugger.HandleCommand(
+        'type synthetic add -x "'
+        + typeName
+        + '" --python-class '
+        + f"{__name__}.SyntheticFormatter"
+    )

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libstdcpp/string/ConvertToDataFormatter.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libstdcpp/string/ConvertToDataFormatter.py
@@ -5,6 +5,7 @@ Helper formmater to verify Std::String by created via SBData
 
 import lldb
 
+
 class SyntheticFormatter:
     def __init__(self, valobj, dict):
         self.valobj = valobj
@@ -35,9 +36,7 @@ class SyntheticFormatter:
 
         child = self.valobj.GetChildMemberWithName(name)
         valType = child.GetType()
-        return self.valobj.CreateValueFromData(name,
-                child.GetData(),
-                valType)
+        return self.valobj.CreateValueFromData(name, child.GetData(), valType)
 
 
 def __lldb_init_module(debugger, dict):

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libstdcpp/string/TestDataFormatterStdString.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libstdcpp/string/TestDataFormatterStdString.py
@@ -37,6 +37,8 @@ class StdStringDataFormatterTestCase(TestBase):
             substrs=["stopped", "stop reason = breakpoint"],
         )
 
+        self.runCmd("command script import ./ConvertToDataFormatter.py", check=True)
+
         # This is the function to remove the custom formats in order to have a
         # clean slate for the next test case.
         def cleanup():
@@ -60,6 +62,7 @@ class StdStringDataFormatterTestCase(TestBase):
         var_rQ = self.frame().FindVariable("rQ")
         var_pq = self.frame().FindVariable("pq")
         var_pQ = self.frame().FindVariable("pQ")
+        var_str_container = self.frame().FindVariable("sc")
 
         self.assertEqual(var_wempty.GetSummary(), 'L""', "wempty summary wrong")
         self.assertEqual(
@@ -88,6 +91,31 @@ class StdStringDataFormatterTestCase(TestBase):
             '"quite a long std::strin with lots of info inside it"',
             "pQ summary wrong",
         )
+
+        self.assertEqual(
+            var_str_container.GetChildAtIndex(0).GetSummary(),
+            '"u22"',
+            "string container child wrong")
+        self.assertEqual(
+            var_str_container.GetChildAtIndex(1).GetSummary(),
+            '"quite a long std::string with lots of info inside it inside a struct"',
+            "string container child wrong")
+        self.assertEqual(
+            var_str_container.GetChildAtIndex(2).GetSummary(),
+            '"u22"',
+            "string container child wrong")
+        self.assertEqual(
+            var_str_container.GetChildAtIndex(3).GetSummary(),
+            '"quite a long std::string with lots of info inside it inside a struct"',
+            "string container child wrong")
+        self.assertEqual(
+            var_str_container.GetChildAtIndex(4).GetSummary(),
+            '"u22"',
+            "string container child wrong")
+        self.assertEqual(
+            var_str_container.GetChildAtIndex(5).GetSummary(),
+            '"quite a long std::string with lots of info inside it inside a struct"',
+            "string container child wrong")
 
         self.runCmd("next")
 

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libstdcpp/string/TestDataFormatterStdString.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libstdcpp/string/TestDataFormatterStdString.py
@@ -46,7 +46,6 @@ class StdStringDataFormatterTestCase(TestBase):
             substrs=["stopped", "stop reason = breakpoint"],
         )
 
-
         # Execute the cleanup function during test case tear down.
         self.addTearDownHook(self.cleanup())
 
@@ -94,7 +93,6 @@ class StdStringDataFormatterTestCase(TestBase):
 
         self.assertEqual(var_S.GetSummary(), 'L"!!!!!"', "new S summary wrong")
 
-
     @add_test_categories(["libstdcxx"])
     @expectedFailureAll(bugnumber="llvm.org/pr50861", compiler="gcc")
     def test_std_string_as_data(self):
@@ -124,24 +122,30 @@ class StdStringDataFormatterTestCase(TestBase):
         self.assertEqual(
             var_str_container.GetChildAtIndex(0).GetSummary(),
             '"u22"',
-            "string container child wrong")
+            "string container child wrong",
+        )
         self.assertEqual(
             var_str_container.GetChildAtIndex(1).GetSummary(),
             '"quite a long std::string with lots of info inside it inside a struct"',
-            "string container child wrong")
+            "string container child wrong",
+        )
         self.assertEqual(
             var_str_container.GetChildAtIndex(2).GetSummary(),
             '"u22"',
-            "string container child wrong")
+            "string container child wrong",
+        )
         self.assertEqual(
             var_str_container.GetChildAtIndex(3).GetSummary(),
             '"quite a long std::string with lots of info inside it inside a struct"',
-            "string container child wrong")
+            "string container child wrong",
+        )
         self.assertEqual(
             var_str_container.GetChildAtIndex(4).GetSummary(),
             '"u22"',
-            "string container child wrong")
+            "string container child wrong",
+        )
         self.assertEqual(
             var_str_container.GetChildAtIndex(5).GetSummary(),
             '"quite a long std::string with lots of info inside it inside a struct"',
-            "string container child wrong")
+            "string container child wrong",
+        )

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libstdcpp/string/main.cpp
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libstdcpp/string/main.cpp
@@ -1,5 +1,14 @@
 #include <string>
 
+struct string_container {
+    std::string short_string;
+    std::string long_string;
+    std::string *short_string_ptr = &short_string;
+    std::string *long_string_ptr = &long_string;
+    std::string &short_string_ref = short_string;
+    std::string &long_string_ref = long_string;
+};
+
 int main()
 {
     std::wstring wempty(L"");
@@ -11,6 +20,10 @@ int main()
     std::string Q("quite a long std::strin with lots of info inside it");
     auto &rq = q, &rQ = Q;
     std::string *pq = &q, *pQ = &Q;
+    string_container sc;
+    sc.short_string = "u22";
+    sc.long_string = "quite a long std::string with lots of info inside it inside a struct";
+
     S.assign(L"!!!!!"); // Set break point at this line.
     return 0;
 }

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libstdcpp/string/main.cpp
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libstdcpp/string/main.cpp
@@ -1,12 +1,12 @@
 #include <string>
 
 struct string_container {
-    std::string short_string;
-    std::string long_string;
-    std::string *short_string_ptr = &short_string;
-    std::string *long_string_ptr = &long_string;
-    std::string &short_string_ref = short_string;
-    std::string &long_string_ref = long_string;
+  std::string short_string;
+  std::string long_string;
+  std::string *short_string_ptr = &short_string;
+  std::string *long_string_ptr = &long_string;
+  std::string &short_string_ref = short_string;
+  std::string &long_string_ref = long_string;
 };
 
 int main()
@@ -22,7 +22,8 @@ int main()
     std::string *pq = &q, *pQ = &Q;
     string_container sc;
     sc.short_string = "u22";
-    sc.long_string = "quite a long std::string with lots of info inside it inside a struct";
+    sc.long_string =
+        "quite a long std::string with lots of info inside it inside a struct";
 
     S.assign(L"!!!!!"); // Set break point at this line.
     return 0;


### PR DESCRIPTION
std::string children are normally formatted as their summary [my_string_prop] = "hello world". Sbvalues/ValueObjects created from data do not follow the same summary formatter path and instead hit the value object printer. This change fixes that and adds tests for the future.

Example:
![image](https://github.com/llvm/llvm-project/assets/25160653/43328cc1-44dd-4d00-a816-84322a6638aa)

Will now summarize like all other strings to "test3"

Added tests in TestDataFormatterStdString.py and a formatter for a custom struct.