### PR TITLE
Let `memref.{expand,collapse}_shape` implement `ReifyRankedShapedTypeOpInterface`

### DIFF
--- a/mlir/include/mlir/Dialect/MemRef/IR/MemRefOps.td
+++ b/mlir/include/mlir/Dialect/MemRef/IR/MemRefOps.td
@@ -1546,8 +1546,11 @@ def MemRef_ReshapeOp: MemRef_Op<"reshape", [
 //===----------------------------------------------------------------------===//
 
 class MemRef_ReassociativeReshapeOp<string mnemonic, list<Trait> traits = []> :
-    MemRef_Op<mnemonic, !listconcat(traits,
-      [Pure, ViewLikeOpInterface])>,
+    MemRef_Op<mnemonic, !listconcat(traits, [
+      Pure,
+      ViewLikeOpInterface,
+      DeclareOpInterfaceMethods<ReifyRankedShapedTypeOpInterface>
+    ])>,
     Arguments<(ins AnyStridedMemRef:$src, IndexListArrayAttr:$reassociation)>,
     Results<(outs AnyStridedMemRef:$result)>{
 

--- a/mlir/test/Dialect/MemRef/resolve-dim-ops.mlir
+++ b/mlir/test/Dialect/MemRef/resolve-dim-ops.mlir
@@ -25,3 +25,35 @@ func.func @dim_out_of_bounds_2(%idx1 : index, %idx2 : index) -> index {
   %0 = tensor.dim %alloc, %idx : tensor<?x?xf32>
   return %0 : index
 }
+
+// -----
+
+// Test case: Folding of memref.dim(memref.expand_shape)
+// CHECK-LABEL: func @dim_of_memref_expand_shape(
+//  CHECK-SAME:     %[[MEM:[0-9a-z]+]]: memref<?x8xi32>
+//  CHECK-NEXT:   %[[IDX:.*]] = arith.constant 0
+//  CHECK-NEXT:   %[[DIM:.*]] = memref.dim %[[MEM]], %[[IDX]] : memref<?x8xi32>
+//       CHECK:   return %[[DIM]] : index
+func.func @dim_of_memref_expand_shape(%arg0: memref<?x8xi32>)
+    -> index {
+  %c1 = arith.constant 1 : index
+  %0 = memref.expand_shape %arg0 [[0, 1], [2, 3]]: memref<?x8xi32> into memref<1x?x2x4xi32>
+  %1 = memref.dim %0, %c1 : memref<1x?x2x4xi32>
+  return %1 : index
+}
+
+// -----
+
+// Test case: Folding of memref.dim(memref.collapse_shape)
+// CHECK-LABEL: func @dim_of_memref_collapse_shape(
+//  CHECK-SAME:     %[[MEM:[0-9a-z]+]]: memref<1x?x2x4xi32>
+//  CHECK-NEXT:   %[[IDX:.*]] = arith.constant 1
+//  CHECK-NEXT:   %[[DIM:.*]] = memref.dim %[[MEM]], %[[IDX]] : memref<1x?x2x4xi32>
+//       CHECK:   return %[[DIM]] : index
+func.func @dim_of_memref_collapse_shape(%arg0: memref<1x?x2x4xi32>)
+    -> index {
+  %c0 = arith.constant 0 : index
+  %0 = memref.collapse_shape %arg0 [[0, 1], [2, 3]]: memref<1x?x2x4xi32> into memref<?x8xi32>
+  %1 = memref.dim %0, %c0 : memref<?x8xi32>
+  return %1 : index
+}


### PR DESCRIPTION
In https://github.com/llvm/llvm-project/pull/88423 I came across a need for folding `memref.dim` into `memref.expand_shape` and it was (IMO rightly) suggested that the proper way to fix that was to implement `ReifyRankedShapedTypeOpInterface`. This PR does that for both `memref.{expand,collapse}_shape` to be consistent, as it would be surprising if these two ops weren't closely mirroring one another.

It would be good to carry on the `ReifyRankedShapedTypeOpInterface` migration, in particular completing it for `memref` and `tensor` ops, particularly to `tensor.{expand,collapse}_shape` to be consistent with this (and then one could drop some existing custom Fold patterns). However, I have heard of an ongoing project to generalize `expand_shape` to relax the requirement that at most one dimension in each reassociation group be dynamic. It would be wise to allow for that project to complete first, as the `ReifyRankedShapedTypeOpInterface` implementation will otherwise entrench the current semantics.

FYI @qedawkins @MaheshRavishankar @Shukla-Gaurav 