### PR TITLE
Revert "[RISCV] Support Zama16b1p0"

### DIFF
--- a/clang/test/Preprocessor/riscv-target-features.c
+++ b/clang/test/Preprocessor/riscv-target-features.c
@@ -79,7 +79,6 @@
 // CHECK-NOT: __riscv_za128rs {{.*$}}
 // CHECK-NOT: __riscv_za64rs {{.*$}}
 // CHECK-NOT: __riscv_zacas {{.*$}}
-// CHECK-NOT: __riscv_zama16b {{.*$}}
 // CHECK-NOT: __riscv_zawrs {{.*$}}
 // CHECK-NOT: __riscv_zba {{.*$}}
 // CHECK-NOT: __riscv_zbb {{.*$}}
@@ -704,12 +703,6 @@
 // RUN:   -march=rv64i_zacas1p0 -E -dM %s \
 // RUN:   -o - | FileCheck --check-prefix=CHECK-ZACAS-EXT %s
 // CHECK-ZACAS-EXT: __riscv_zacas 1000000{{$}}
-
-// RUN: %clang --target=riscv32 -march=rv32izama16b -x c -E -dM %s \
-// RUN:   -o - | FileCheck --check-prefix=CHECK-ZAMA16B-EXT %s
-// RUN: %clang --target=riscv64 -march=rv64izama16b  -x c -E -dM %s \
-// RUN:   -o - | FileCheck --check-prefix=CHECK-ZAMA16B-EXT %s
-// CHECK-ZAMA16B-EXT: __riscv_zama16b  1000000{{$}}
 
 // RUN: %clang --target=riscv32-unknown-linux-gnu \
 // RUN:   -march=rv32izawrs -E -dM %s \

--- a/llvm/docs/RISCVUsage.rst
+++ b/llvm/docs/RISCVUsage.rst
@@ -119,7 +119,6 @@ on support follow.
      ``Za128rs``       Supported (`See note <#riscv-profiles-extensions-note>`__)
      ``Za64rs``        Supported (`See note <#riscv-profiles-extensions-note>`__)
      ``Zacas``         Supported (`See note <#riscv-zacas-note>`__)
-     ``Zama16b``       Supported (`See note <#riscv-profiles-extensions-note>`__)
      ``Zawrs``         Assembly Support
      ``Zba``           Supported
      ``Zbb``           Supported
@@ -238,7 +237,7 @@ Supported
 
 .. _riscv-profiles-extensions-note:
 
-``Za128rs``, ``Za64rs``, ``Zama16b``, ``Zic64b``, ``Ziccamoa``, ``Ziccif``, ``Zicclsm``, ``Ziccrse``, ``Shcounterenvw``, ``Shgatpa``, ``Shtvala``, ``Shvsatpa``, ``Shvstvala``, ``Shvstvecd``, ``Ssccptr``, ``Sscounterenw``, ``Ssstateen``, ``Ssstrict``, ``Sstvala``, ``Sstvecd``, ``Ssu64xl``, ``Svade``, ``Svbare``
+``Za128rs``, ``Za64rs``, ``Zic64b``, ``Ziccamoa``, ``Ziccif``, ``Zicclsm``, ``Ziccrse``, ``Shcounterenvw``, ``Shgatpa``, ``Shtvala``, ``Shvsatpa``, ``Shvstvala``, ``Shvstvecd``, ``Ssccptr``, ``Sscounterenw``, ``Ssstateen``, ``Ssstrict``, ``Sstvala``, ``Sstvecd``, ``Ssu64xl``, ``Svade``, ``Svbare``
   These extensions are defined as part of the `RISC-V Profiles specification <https://github.com/riscv/riscv-profiles/releases/tag/v1.0>`__.  They do not introduce any new features themselves, but instead describe existing hardware features.
 
   .. _riscv-zacas-note:

--- a/llvm/lib/Support/RISCVISAInfo.cpp
+++ b/llvm/lib/Support/RISCVISAInfo.cpp
@@ -119,7 +119,6 @@ static const RISCVSupportedExtension SupportedExtensions[] = {
     {"za128rs", {1, 0}},
     {"za64rs", {1, 0}},
     {"zacas", {1, 0}},
-    {"zama16b", {1, 0}},
     {"zawrs", {1, 0}},
 
     {"zba", {1, 0}},

--- a/llvm/lib/Target/RISCV/RISCVFeatures.td
+++ b/llvm/lib/Target/RISCV/RISCVFeatures.td
@@ -208,13 +208,6 @@ def HasStdExtAOrZalrsc
                          "'A' (Atomic Instructions) or "
                          "'Zalrsc' (Load-Reserved/Store-Conditional)">;
 
-def FeatureStdExtZama16b
-    : SubtargetFeature<"zama16b", "HasStdExtZama16b", "true",
-                       "'Zama16b' (Atomic 16-byte misaligned loads, stores and AMOs)">;
-def HasStdExtZama16b : Predicate<"Subtarget->hasStdExtZama16b()">,
-                       AssemblerPredicate<(all_of FeatureStdExtZama16b),
-                           "'Zama16b' (Atomic 16-byte misaligned loads, stores and AMOs)">;
-
 def FeatureStdExtZawrs : SubtargetFeature<"zawrs", "HasStdExtZawrs", "true",
                                           "'Zawrs' (Wait on Reservation Set)">;
 def HasStdExtZawrs : Predicate<"Subtarget->hasStdExtZawrs()">,

--- a/llvm/test/CodeGen/RISCV/attributes.ll
+++ b/llvm/test/CodeGen/RISCV/attributes.ll
@@ -115,7 +115,6 @@
 ; RUN: llc -mtriple=riscv32 -mattr=+zacas %s -o - | FileCheck --check-prefix=RV32ZACAS %s
 ; RUN: llc -mtriple=riscv32 -mattr=+experimental-zalasr %s -o - | FileCheck --check-prefix=RV32ZALASR %s
 ; RUN: llc -mtriple=riscv32 -mattr=+experimental-zalrsc %s -o - | FileCheck --check-prefix=RV32ZALRSC %s
-; RUN: llc -mtriple=riscv32 -mattr=+zama16b %s -o - | FileCheck --check-prefixes=CHECK,RV32ZAMA16B %s
 ; RUN: llc -mtriple=riscv32 -mattr=+experimental-zicfilp %s -o - | FileCheck --check-prefix=RV32ZICFILP %s
 ; RUN: llc -mtriple=riscv32 -mattr=+experimental-zabha %s -o - | FileCheck --check-prefix=RV32ZABHA %s
 ; RUN: llc -mtriple=riscv32 -mattr=+experimental-ssnpm  %s -o - | FileCheck --check-prefix=RV32SSNPM %s
@@ -200,7 +199,6 @@
 ; RUN: llc -mtriple=riscv64 -mattr=+xtheadvdot %s -o - | FileCheck --check-prefixes=CHECK,RV64XTHEADVDOT %s
 ; RUN: llc -mtriple=riscv64 -mattr=+za64rs %s -o - | FileCheck --check-prefixes=CHECK,RV64ZA64RS %s
 ; RUN: llc -mtriple=riscv64 -mattr=+za128rs %s -o - | FileCheck --check-prefixes=CHECK,RV64ZA128RS %s
-; RUN: llc -mtriple=riscv64 -mattr=+zama16b %s -o - | FileCheck --check-prefixes=CHECK,RV64ZAMA16B %s
 ; RUN: llc -mtriple=riscv64 -mattr=+zawrs %s -o - | FileCheck --check-prefixes=CHECK,RV64ZAWRS %s
 ; RUN: llc -mtriple=riscv64 -mattr=+experimental-ztso %s -o - | FileCheck --check-prefixes=CHECK,RV64ZTSO %s
 ; RUN: llc -mtriple=riscv64 -mattr=+zca %s -o - | FileCheck --check-prefixes=CHECK,RV64ZCA %s
@@ -372,7 +370,6 @@
 ; RV32ZACAS: .attribute 5, "rv32i2p1_a2p1_zacas1p0"
 ; RV32ZALASR: .attribute 5, "rv32i2p1_zalasr0p1"
 ; RV32ZALRSC: .attribute 5, "rv32i2p1_zalrsc0p2"
-; RV32ZAMA16B: .attribute 5, "rv32i2p1_zama16b1p0"
 ; RV32ZICFILP: .attribute 5, "rv32i2p1_zicfilp0p4"
 ; RV32ZABHA: .attribute 5, "rv32i2p1_a2p1_zabha1p0"
 ; RV32SSNPM: .attribute 5, "rv32i2p1_ssnpm0p8"
@@ -421,7 +418,6 @@
 ; RV64ZICBOZ: .attribute 5, "rv64i2p1_zicboz1p0"
 ; RV64ZA64RS: .attribute 5, "rv64i2p1_za64rs1p0"
 ; RV64ZA128RS: .attribute 5, "rv64i2p1_za128rs1p0"
-; RV64ZAMA16B: .attribute 5, "rv64i2p1_zama16b1p0"
 ; RV64ZAWRS: .attribute 5, "rv64i2p1_zawrs1p0"
 ; RV64ZICBOP: .attribute 5, "rv64i2p1_zicbop1p0"
 ; RV64SHCOUNTERENW: .attribute 5, "rv64i2p1_shcounterenw1p0"

--- a/llvm/test/MC/RISCV/attribute-arch.s
+++ b/llvm/test/MC/RISCV/attribute-arch.s
@@ -270,9 +270,6 @@
 .attribute arch, "rv32iza64rs1p0"
 # CHECK: attribute      5, "rv32i2p1_za64rs1p0"
 
-.attribute arch, "rv32izama16b"
-# CHECK: attribute      5, "rv32i2p1_zama16b1p0"
-
 .attribute arch, "rv32izawrs1p0"
 # CHECK: attribute      5, "rv32i2p1_zawrs1p0"
 

--- a/llvm/unittests/Support/RISCVISAInfoTest.cpp
+++ b/llvm/unittests/Support/RISCVISAInfoTest.cpp
@@ -769,7 +769,6 @@ R"(All available -march extensions for RISC-V
     za128rs              1.0
     za64rs               1.0
     zacas                1.0
-    zama16b              1.0
     zawrs                1.0
     zfa                  1.0
     zfh                  1.0


### PR DESCRIPTION
Reverts llvm/llvm-project#88474

```CMake Error at /[tmpfs/src/git/out/llvm-project/llvm/cmake/modules/HandleLLVMOptions.cmake:396](https://cs.corp.google.com/piper///depot/google3/tmpfs/src/git/out/llvm-project/llvm/cmake/modules/HandleLLVMOptions.cmake?l=396) (message):
  Host compiler does not support '-fuse-ld=lld'.  Please make sure that 'lld'
  is installed and that your host compiler can compile a simple program when
  given the option '-fuse-ld=lld'.
```

And reproduce the error locally.
```
fatal error: error in backend: Cannot select: 0x562ab44b6480: nxv2i32 = RISCVISD::VZEXT_VL 0x562ab44d4570, 0x562ab44b6330, Register:i64 $x0
  0x562ab44d4570: nxv2i1 = setcc 0x562ab44d46c0, 0x562ab4570f10, seteq:ch
    0x562ab44d46c0: nxv2i64 = vselect 0x562ab44d41f0, 0x562ab45711b0, 0x562ab44d48f0
      0x562ab44d41f0: nxv2i1 = setcc 0x562ab4571370, 0x562ab44d3fc0, seteq:ch
        0x562ab4571370: nxv2i8 = and 0x562ab44d40a0, 0x562ab44d4a40
          0x562ab44d40a0: nxv2i8,ch = llvm.riscv.vlse<(load unknown-size from %ir.68, align 1)> 0x562ab71f9970, TargetConstant:i64<10129>, undef:nxv2i8, 0x562ab44d4ab0, Constant:i64<24>, Register:i64 $x0
            0x562ab44d42d0: i64 = TargetConstant<10129>
            0x562ab44d47a0: nxv2i8 = undef
            0x562ab44d4ab0: i64,ch = CopyFromReg 0x562ab71f9970, Register:i64 %14
              0x562ab44d4b20: i64 = Register %14
            0x562ab44d4260: i64 = Constant<24>
            0x562ab44b62c0: i64 = Register $x0
          0x562ab44d4a40: nxv2i8 = RISCVISD::VMV_V_X_VL undef:nxv2i8, Constant:i64<1>, Register:i64 $x0
            0x562ab44d47a0: nxv2i8 = undef
            0x562ab45710d0: i64 = Constant<1>
            0x562ab44b62c0: i64 = Register $x0
        0x562ab44d3fc0: nxv2i8 = RISCVISD::VMV_V_X_VL undef:nxv2i8, Constant:i64<0>, Register:i64 $x0
          0x562ab44d47a0: nxv2i8 = undef
          0x562ab4570960: i64 = Constant<0>
          0x562ab44b62c0: i64 = Register $x0
      0x562ab45711b0: nxv2i64 = zero_extend nneg 0x562ab4570ab0
        0x562ab4570ab0: nxv2i8 = srl 0x562ab44d40a0, 0x562ab44d4a40
          0x562ab44d40a0: nxv2i8,ch = llvm.riscv.vlse<(load unknown-size from %ir.68, align 1)> 0x562ab71f9970, TargetConstant:i64<10129>, undef:nxv2i8, 0x562ab44d4ab0, Constant:i64<24>, Register:i64 $x0
            0x562ab44d42d0: i64 = TargetConstant<10129>
            0x562ab44d47a0: nxv2i8 = undef
            0x562ab44d4ab0: i64,ch = CopyFromReg 0x562ab71f9970, Register:i64 %14
              0x562ab44d4b20: i64 = Register %14
            0x562ab44d4260: i64 = Constant<24>
            0x562ab44b62c0: i64 = Register $x0
          0x562ab44d4a40: nxv2i8 = RISCVISD::VMV_V_X_VL undef:nxv2i8, Constant:i64<1>, Register:i64 $x0
            0x562ab44d47a0: nxv2i8 = undef
            0x562ab45710d0: i64 = Constant<1>
            0x562ab44b62c0: i64 = Register $x0
      0x562ab44d48f0: nxv2i64,ch = llvm.riscv.vluxei<(load unknown-size, align 8, !alias.scope !49)> 0x562ab71f9970, TargetConstant:i64<10173>, undef:nxv2i64, 0x562ab4571450, 0x562ab44d4500, Register:i64 $x0
        0x562ab4570ff0: i64 = TargetConstant<10173>
        0x562ab4570a40: nxv2i64 = undef
        0x562ab4571450: i64 = add 0x562ab44d4ab0, Constant:i64<8>
          0x562ab44d4ab0: i64,ch = CopyFromReg 0x562ab71f9970, Register:i64 %14
            0x562ab44d4b20: i64 = Register %14
          0x562ab45707a0: i64 = Constant<8>
        0x562ab44d4500: nxv2i64,ch = CopyFromReg 0x562ab71f9970, Register:nxv2i64 %11
          0x562ab44d49d0: nxv2i64 = Register %11
        0x562ab44b62c0: i64 = Register $x0
    0x562ab4570f10: nxv2i64 = RISCVISD::VMV_V_X_VL undef:nxv2i64, Constant:i64<0>, Register:i64 $x0
      0x562ab4570a40: nxv2i64 = undef
      0x562ab4570960: i64 = Constant<0>
      0x562ab44b62c0: i64 = Register $x0
  0x562ab44b6330: nxv2i1 = RISCVISD::VMSET_VL Register:i64 $x0
    0x562ab44b62c0: i64 = Register $x0
  0x562ab44b62c0: i64 = Register $x0
In function: _ZNSt3__114__scan_keywordB8ne180000INS_19istreambuf_iteratorIcNS_11char_traitsIcEEEEPKNS_12basic_stringIcS3_NS_9allocatorIcEEEENS_5ctypeIcEEEET0_RT_SE_SD_SD_RKT1_Rjb
PLEASE submit a bug report to https://github.com/android-ndk/ndk/issues and include the crash backtrace, preprocessed source, and associated run script.
Stack dump:
0.      Program arguments: /usr/local/google/home/zijunzhao/llvm-toolchain/out/stage2-install/bin/clang++ --target=riscv64-linux-android35 --sysroot=/usr/local/google/home/zijunzhao/llvm-toolchain/out/sysroots/platform/riscv64 -DLIBCXX_BUILDING_LIBCXXABI -D_LIBCPP_BUILDING_LIBRARY -D_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER -D_LIBCPP_REMOVE_TRANSITIVE_INCLUDES -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS -I/usr/local/google/home/zijunzhao/llvm-toolchain/out/llvm-project/libcxx/src -I/usr/local/google/home/zijunzhao/llvm-toolchain/out/lib/device-libcxx-riscv64/include/c++/v1 -I/usr/local/google/home/zijunzhao/llvm-toolchain/out/llvm-project/libcxxabi/include -ffile-prefix-map=/usr/local/google/home/zijunzhao/llvm-toolchain/= --target=riscv64-linux-android35 -ffunction-sections -fdata-sections -isystem /usr/local/google/home/zijunzhao/llvm-toolchain/out/sysroots/platform/riscv64/usr/include/riscv64-linux-android -D_LIBCPP_AVAILABILITY_HAS_NO_VERBOSE_ABORT=1 --sysroot=/usr/local/google/home/zijunzhao/llvm-toolchain/out/sysroots/platform/riscv64 -stdlib=libc++ -fvisibility-inlines-hidden -Wall -Wextra -Wno-unused-parameter -Wwrite-strings -Wcast-qual -Wmissing-field-initializers -Wno-noexcept-type -Wnon-virtual-dtor -Wdelete-non-virtual-dtor -Wsuggest-override -fdiagnostics-color -O3 -DNDEBUG -fPIC -faligned-allocation -nostdinc++ -fvisibility-inlines-hidden -fvisibility=hidden -Wall -Wextra -Wnewline-eof -Wshadow -Wwrite-strings -Wno-unused-parameter -Wno-long-long -Werror=return-type -Wextra-semi -Wundef -Wunused-template -Wformat-nonliteral -Wno-user-defined-literals -Wno-covered-switch-default -Wno-suggest-override -Wno-error -std=c++2b -MD -MT libcxx/src/CMakeFiles/cxx_shared.dir/locale.cpp.o -MF libcxx/src/CMakeFiles/cxx_shared.dir/locale.cpp.o.d -o libcxx/src/CMakeFiles/cxx_shared.dir/locale.cpp.o -c /usr/local/google/home/zijunzhao/llvm-toolchain/out/llvm-project/libcxx/src/locale.cpp
1.      <eof> parser at end of file
2.      Code generation
3.      Running pass 'Function Pass Manager' on module '/usr/local/google/home/zijunzhao/llvm-toolchain/out/llvm-project/libcxx/src/locale.cpp'.
4.      Running pass 'RISC-V DAG->DAG Pattern Instruction Selection' on function '@_ZNSt3__114__scan_keywordB8ne180000INS_19istreambuf_iteratorIcNS_11char_traitsIcEEEEPKNS_12basic_stringIcS3_NS_9allocatorIcEEEENS_5ctypeIcEEEET0_RT_SE_SD_SD_RKT1_Rjb'
 #0 0x0000562ab0c20d68 llvm::sys::PrintStackTrace(llvm::raw_ostream&, int) (/usr/local/google/home/zijunzhao/llvm-toolchain/out/stage2-install/bin/clang+++0x31c4d68)
 #1 0x0000562ab0c1eb7e llvm::sys::RunSignalHandlers() (/usr/local/google/home/zijunzhao/llvm-toolchain/out/stage2-install/bin/clang+++0x31c2b7e)
 #2 0x0000562ab0c2024e llvm::sys::CleanupOnSignal(unsigned long) (/usr/local/google/home/zijunzhao/llvm-toolchain/out/stage2-install/bin/clang+++0x31c424e)
 #3 0x0000562ab0bab4ae (anonymous namespace)::CrashRecoveryContextImpl::HandleCrash(int, unsigned long) CrashRecoveryContext.cpp:0:0
 #4 0x0000562ab0bab46b (/usr/local/google/home/zijunzhao/llvm-toolchain/out/stage2-install/bin/clang+++0x314f46b)
 #5 0x0000562ab0c1bcf7 llvm::sys::Process::Exit(int, bool) (/usr/local/google/home/zijunzhao/llvm-toolchain/out/stage2-install/bin/clang+++0x31bfcf7)
 #6 0x0000562aaf94d9e3 (/usr/local/google/home/zijunzhao/llvm-toolchain/out/stage2-install/bin/clang+++0x1ef19e3)
 #7 0x0000562ab0bae202 llvm::report_fatal_error(llvm::Twine const&, bool) (/usr/local/google/home/zijunzhao/llvm-toolchain/out/stage2-install/bin/clang+++0x3152202)
 #8 0x0000562ab19d7f6c (/usr/local/google/home/zijunzhao/llvm-toolchain/out/stage2-install/bin/clang+++0x3f7bf6c)
 #9 0x0000562ab19d7525 (/usr/local/google/home/zijunzhao/llvm-toolchain/out/stage2-install/bin/clang+++0x3f7b525)
#10 0x0000562aafe5df0e llvm::RISCVDAGToDAGISel::Select(llvm::SDNode*) RISCVISelDAGToDAG.cpp:0:0
#11 0x0000562ab19cec4f llvm::SelectionDAGISel::DoInstructionSelection() (/usr/local/google/home/zijunzhao/llvm-toolchain/out/stage2-install/bin/clang+++0x3f72c4f)
#12 0x0000562ab19ce3b9 llvm::SelectionDAGISel::CodeGenAndEmitDAG() (/usr/local/google/home/zijunzhao/llvm-toolchain/out/stage2-install/bin/clang+++0x3f723b9)
#13 0x0000562ab19cd551 llvm::SelectionDAGISel::SelectAllBasicBlocks(llvm::Function const&) (/usr/local/google/home/zijunzhao/llvm-toolchain/out/stage2-install/bin/clang+++0x3f71551)
#14 0x0000562ab19cb634 llvm::SelectionDAGISel::runOnMachineFunction(llvm::MachineFunction&) (/usr/local/google/home/zijunzhao/llvm-toolchain/out/stage2-install/bin/clang+++0x3f6f634)
#15 0x0000562ab04ca167 llvm::MachineFunctionPass::runOnFunction(llvm::Function&) (/usr/local/google/home/zijunzhao/llvm-toolchain/out/stage2-install/bin/clang+++0x2a6e167)
#16 0x0000562ab087c676 llvm::FPPassManager::runOnFunction(llvm::Function&) (/usr/local/google/home/zijunzhao/llvm-toolchain/out/stage2-install/bin/clang+++0x2e20676)
#17 0x0000562ab0883433 llvm::FPPassManager::runOnModule(llvm::Module&) (/usr/local/google/home/zijunzhao/llvm-toolchain/out/stage2-install/bin/clang+++0x2e27433)
#18 0x0000562ab087d28b llvm::legacy::PassManagerImpl::run(llvm::Module&) (/usr/local/google/home/zijunzhao/llvm-toolchain/out/stage2-install/bin/clang+++0x2e2128b)
#19 0x0000562ab11d1714 clang::EmitBackendOutput(clang::DiagnosticsEngine&, clang::HeaderSearchOptions const&, clang::CodeGenOptions const&, clang::TargetOptions const&, clang::LangOptions const&, llvm::StringRef, llvm::Module*, clang::BackendAction, llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem>, std::__1::unique_ptr<llvm::raw_pwrite_stream, std::__1::default_delete<llvm::raw_pwrite_stream>>, clang::BackendConsumer*) (/usr/local/google/home/zijunzhao/llvm-toolchain/out/stage2-install/bin/clang+++0x3775714)
#20 0x0000562ab11eafb9 clang::BackendConsumer::HandleTranslationUnit(clang::ASTContext&) (/usr/local/google/home/zijunzhao/llvm-toolchain/out/stage2-install/bin/clang+++0x378efb9)
#21 0x0000562ab27b4216 clang::ParseAST(clang::Sema&, bool, bool) (/usr/local/google/home/zijunzhao/llvm-toolchain/out/stage2-install/bin/clang+++0x4d58216)
#22 0x0000562ab1574ef6 clang::FrontendAction::Execute() (/usr/local/google/home/zijunzhao/llvm-toolchain/out/stage2-install/bin/clang+++0x3b18ef6)
#23 0x0000562ab14efd84 clang::CompilerInstance::ExecuteAction(clang::FrontendAction&) (/usr/local/google/home/zijunzhao/llvm-toolchain/out/stage2-install/bin/clang+++0x3a93d84)
#24 0x0000562ab1606f55 clang::ExecuteCompilerInvocation(clang::CompilerInstance*) (/usr/local/google/home/zijunzhao/llvm-toolchain/out/stage2-install/bin/clang+++0x3baaf55)
#25 0x0000562aaf94cead cc1_main(llvm::ArrayRef<char const*>, char const*, void*) (/usr/local/google/home/zijunzhao/llvm-toolchain/out/stage2-install/bin/clang+++0x1ef0ead)
#26 0x0000562aaf94a910 ExecuteCC1Tool(llvm::SmallVectorImpl<char const*>&, llvm::ToolContext const&) driver.cpp:0:0
#27 0x0000562ab135a019 void llvm::function_ref<void ()>::callback_fn<clang::driver::CC1Command::Execute(llvm::ArrayRef<std::__1::optional<llvm::StringRef>>, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>*, bool*) const::$_0>(long) Job.cpp:0:0
#28 0x0000562ab0bab44c llvm::CrashRecoveryContext::RunSafely(llvm::function_ref<void ()>) (/usr/local/google/home/zijunzhao/llvm-toolchain/out/stage2-install/bin/clang+++0x314f44c)
#29 0x0000562ab1359a26 clang::driver::CC1Command::Execute(llvm::ArrayRef<std::__1::optional<llvm::StringRef>>, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>*, bool*) const (/usr/local/google/home/zijunzhao/llvm-toolchain/out/stage2-install/bin/clang+++0x38fda26)
#30 0x0000562ab131eb70 clang::driver::Compilation::ExecuteCommand(clang::driver::Command const&, clang::driver::Command const*&, bool) const (/usr/local/google/home/zijunzhao/llvm-toolchain/out/stage2-install/bin/clang+++0x38c2b70)
#31 0x0000562ab131f07e clang::driver::Compilation::ExecuteJobs(clang::driver::JobList const&, llvm::SmallVectorImpl<std::__1::pair<int, clang::driver::Command const*>>&, bool) const (/usr/local/google/home/zijunzhao/llvm-toolchain/out/stage2-install/bin/clang+++0x38c307e)
#32 0x0000562ab133ca8f clang::driver::Driver::ExecuteCompilation(clang::driver::Compilation&, llvm::SmallVectorImpl<std::__1::pair<int, clang::driver::Command const*>>&) (/usr/local/google/home/zijunzhao/llvm-toolchain/out/stage2-install/bin/clang+++0x38e0a8f)
#33 0x0000562aaf949ceb clang_main(int, char**, llvm::ToolContext const&) (/usr/local/google/home/zijunzhao/llvm-toolchain/out/stage2-install/bin/clang+++0x1eedceb)
#34 0x0000562aaf957f01 main (/usr/local/google/home/zijunzhao/llvm-toolchain/out/stage2-install/bin/clang+++0x1efbf01)
#35 0x00007fcced00d6ca __libc_start_call_main ./csu/../sysdeps/nptl/libc_start_call_main.h:74:3
#36 0x00007fcced00d785 call_init ./csu/../csu/libc-start.c:128:20
#37 0x00007fcced00d785 __libc_start_main ./csu/../csu/libc-start.c:347:5
#38 0x0000562aaf946a69 _start (/usr/local/google/home/zijunzhao/llvm-toolchain/out/stage2-install/bin/clang+++0x1eeaa69)
clang++: error: clang frontend command failed with exit code 70 (use -v to see invocation)
Android (2277, -pgo, -bolt, -lto, -mlgo, ANDROID_LLVM_NEXT, based on r99999999) clang version 18.0.0 (https://android.googlesource.com/toolchain/llvm-project d8003a456d14a3deb8054cdaa529ffbf02d9b262)
Target: riscv64-unknown-linux-android35
Thread model: posix
InstalledDir: /usr/local/google/home/zijunzhao/llvm-toolchain/out/stage2-install/bin
clang++: note: diagnostic msg: 
********************

PLEASE ATTACH THE FOLLOWING FILES TO THE BUG REPORT:
Preprocessed source(s) and associated run script(s) are located at:
clang++: note: diagnostic msg: /tmp/locale-d1d3e9.cpp
clang++: note: diagnostic msg: /tmp/locale-d1d3e9.sh
clang++: note: diagnostic msg: 

********************
ninja: build stopped: subcommand failed.
```