### PR TITLE
[DXIL] Add DXIL SubArch to correspond to version number

### DIFF
--- a/llvm/include/llvm/TargetParser/Triple.h
+++ b/llvm/include/llvm/TargetParser/Triple.h
@@ -167,15 +167,15 @@ public:
     SPIRVSubArch_v16,
 
     // DXIL sub-arch corresponds to its version.
-    DXILSubArch_v10,
-    DXILSubArch_v11,
-    DXILSubArch_v12,
-    DXILSubArch_v13,
-    DXILSubArch_v14,
-    DXILSubArch_v15,
-    DXILSubArch_v16,
-    DXILSubArch_v17,
-    DXILSubArch_v18,
+    DXILSubArch_v1_0,
+    DXILSubArch_v1_1,
+    DXILSubArch_v1_2,
+    DXILSubArch_v1_3,
+    DXILSubArch_v1_4,
+    DXILSubArch_v1_5,
+    DXILSubArch_v1_6,
+    DXILSubArch_v1_7,
+    DXILSubArch_v1_8,
   };
   enum VendorType {
     UnknownVendor,

--- a/llvm/include/llvm/TargetParser/Triple.h
+++ b/llvm/include/llvm/TargetParser/Triple.h
@@ -165,6 +165,17 @@ public:
     SPIRVSubArch_v14,
     SPIRVSubArch_v15,
     SPIRVSubArch_v16,
+
+    // DXIL sub-arch corresponds to its version.
+    DXILSubArch_v10,
+    DXILSubArch_v11,
+    DXILSubArch_v12,
+    DXILSubArch_v13,
+    DXILSubArch_v14,
+    DXILSubArch_v15,
+    DXILSubArch_v16,
+    DXILSubArch_v17,
+    DXILSubArch_v18,
   };
   enum VendorType {
     UnknownVendor,

--- a/llvm/lib/TargetParser/Triple.cpp
+++ b/llvm/lib/TargetParser/Triple.cpp
@@ -573,9 +573,9 @@ static Triple::ArchType parseArch(StringRef ArchName) {
           .Case("csky", Triple::csky)
           .Case("loongarch32", Triple::loongarch32)
           .Case("loongarch64", Triple::loongarch64)
-          .Cases("dxil", "dxilv1.0", "dxilv1.1", "dxilv1.2",
-                 "dxilv1.3", "dxilv1.4", "dxilv1.5", "dxilv1.6",
-                 "dxilv1.7", "dxilv1.8",Triple::dxil)
+          .Cases("dxil", "dxilv1.0", "dxilv1.1", "dxilv1.2", "dxilv1.3",
+                 "dxilv1.4", "dxilv1.5", "dxilv1.6", "dxilv1.7", "dxilv1.8",
+                 Triple::dxil)
           .Case("xtensa", Triple::xtensa)
           .Default(Triple::UnknownArch);
 

--- a/llvm/lib/TargetParser/Triple.cpp
+++ b/llvm/lib/TargetParser/Triple.cpp
@@ -745,15 +745,15 @@ static Triple::SubArchType parseSubArch(StringRef SubArchName) {
 
   if (SubArchName.starts_with("dxil"))
     return StringSwitch<Triple::SubArchType>(SubArchName)
-        .EndsWith("v1.0", Triple::DXILSubArch_v10)
-        .EndsWith("v1.1", Triple::DXILSubArch_v11)
-        .EndsWith("v1.2", Triple::DXILSubArch_v12)
-        .EndsWith("v1.3", Triple::DXILSubArch_v13)
-        .EndsWith("v1.4", Triple::DXILSubArch_v14)
-        .EndsWith("v1.5", Triple::DXILSubArch_v15)
-        .EndsWith("v1.6", Triple::DXILSubArch_v16)
-        .EndsWith("v1.7", Triple::DXILSubArch_v17)
-        .EndsWith("v1.8", Triple::DXILSubArch_v18)
+        .EndsWith("v1.0", Triple::DXILSubArch_v1_0)
+        .EndsWith("v1.1", Triple::DXILSubArch_v1_1)
+        .EndsWith("v1.2", Triple::DXILSubArch_v1_2)
+        .EndsWith("v1.3", Triple::DXILSubArch_v1_3)
+        .EndsWith("v1.4", Triple::DXILSubArch_v1_4)
+        .EndsWith("v1.5", Triple::DXILSubArch_v1_5)
+        .EndsWith("v1.6", Triple::DXILSubArch_v1_6)
+        .EndsWith("v1.7", Triple::DXILSubArch_v1_7)
+        .EndsWith("v1.8", Triple::DXILSubArch_v1_8)
         .Default(Triple::NoSubArch);
 
   StringRef ARMSubArch = ARM::getCanonicalArchName(SubArchName);

--- a/llvm/lib/TargetParser/Triple.cpp
+++ b/llvm/lib/TargetParser/Triple.cpp
@@ -573,7 +573,9 @@ static Triple::ArchType parseArch(StringRef ArchName) {
           .Case("csky", Triple::csky)
           .Case("loongarch32", Triple::loongarch32)
           .Case("loongarch64", Triple::loongarch64)
-          .StartsWith("dxil", Triple::dxil)
+          .Cases("dxil", "dxilv1.0", "dxilv1.1", "dxilv1.2",
+                 "dxilv1.3", "dxilv1.4", "dxilv1.5", "dxilv1.6",
+                 "dxilv1.7", "dxilv1.8",Triple::dxil)
           .Case("xtensa", Triple::xtensa)
           .Default(Triple::UnknownArch);
 

--- a/llvm/lib/TargetParser/Triple.cpp
+++ b/llvm/lib/TargetParser/Triple.cpp
@@ -741,6 +741,19 @@ static Triple::SubArchType parseSubArch(StringRef SubArchName) {
         .EndsWith("v1.6", Triple::SPIRVSubArch_v16)
         .Default(Triple::NoSubArch);
 
+  if (SubArchName.starts_with("dxil"))
+    return StringSwitch<Triple::SubArchType>(SubArchName)
+        .EndsWith("v1.0", Triple::DXILSubArch_v10)
+        .EndsWith("v1.1", Triple::DXILSubArch_v11)
+        .EndsWith("v1.2", Triple::DXILSubArch_v12)
+        .EndsWith("v1.3", Triple::DXILSubArch_v13)
+        .EndsWith("v1.4", Triple::DXILSubArch_v14)
+        .EndsWith("v1.5", Triple::DXILSubArch_v15)
+        .EndsWith("v1.6", Triple::DXILSubArch_v16)
+        .EndsWith("v1.7", Triple::DXILSubArch_v17)
+        .EndsWith("v1.8", Triple::DXILSubArch_v18)
+        .Default(Triple::NoSubArch);
+
   StringRef ARMSubArch = ARM::getCanonicalArchName(SubArchName);
 
   // For now, this is the small part. Early return.

--- a/llvm/lib/TargetParser/Triple.cpp
+++ b/llvm/lib/TargetParser/Triple.cpp
@@ -573,7 +573,7 @@ static Triple::ArchType parseArch(StringRef ArchName) {
           .Case("csky", Triple::csky)
           .Case("loongarch32", Triple::loongarch32)
           .Case("loongarch64", Triple::loongarch64)
-          .Case("dxil", Triple::dxil)
+          .StartsWith("dxil", Triple::dxil)
           .Case("xtensa", Triple::xtensa)
           .Default(Triple::UnknownArch);
 

--- a/llvm/unittests/TargetParser/TripleTest.cpp
+++ b/llvm/unittests/TargetParser/TripleTest.cpp
@@ -971,6 +971,60 @@ TEST(TripleTest, ParsedIDs) {
   EXPECT_EQ(Triple::Amplification, T.getEnvironment());
   EXPECT_FALSE(T.supportsCOMDAT());
 
+  T = Triple("dxilv1.0-unknown-unknown");
+  EXPECT_EQ(Triple::dxil, T.getArch());
+  EXPECT_EQ(Triple::DXILSubArch_v10, T.getSubArch());
+  EXPECT_EQ(Triple::UnknownVendor, T.getVendor());
+  EXPECT_EQ(Triple::UnknownOS, T.getOS());
+
+  T = Triple("dxilv1.1-unknown-unknown");
+  EXPECT_EQ(Triple::dxil, T.getArch());
+  EXPECT_EQ(Triple::DXILSubArch_v11, T.getSubArch());
+  EXPECT_EQ(Triple::UnknownVendor, T.getVendor());
+  EXPECT_EQ(Triple::UnknownOS, T.getOS());
+
+  T = Triple("dxilv1.2-unknown-unknown");
+  EXPECT_EQ(Triple::dxil, T.getArch());
+  EXPECT_EQ(Triple::DXILSubArch_v12, T.getSubArch());
+  EXPECT_EQ(Triple::UnknownVendor, T.getVendor());
+  EXPECT_EQ(Triple::UnknownOS, T.getOS());
+
+  T = Triple("dxilv1.3-unknown-unknown");
+  EXPECT_EQ(Triple::dxil, T.getArch());
+  EXPECT_EQ(Triple::DXILSubArch_v13, T.getSubArch());
+  EXPECT_EQ(Triple::UnknownVendor, T.getVendor());
+  EXPECT_EQ(Triple::UnknownOS, T.getOS());
+
+  T = Triple("dxilv1.4-unknown-unknown");
+  EXPECT_EQ(Triple::dxil, T.getArch());
+  EXPECT_EQ(Triple::DXILSubArch_v14, T.getSubArch());
+  EXPECT_EQ(Triple::UnknownVendor, T.getVendor());
+  EXPECT_EQ(Triple::UnknownOS, T.getOS());
+
+  T = Triple("dxilv1.5-unknown-unknown");
+  EXPECT_EQ(Triple::dxil, T.getArch());
+  EXPECT_EQ(Triple::DXILSubArch_v15, T.getSubArch());
+  EXPECT_EQ(Triple::UnknownVendor, T.getVendor());
+  EXPECT_EQ(Triple::UnknownOS, T.getOS());
+
+  T = Triple("dxilv1.6-unknown-unknown");
+  EXPECT_EQ(Triple::dxil, T.getArch());
+  EXPECT_EQ(Triple::DXILSubArch_v16, T.getSubArch());
+  EXPECT_EQ(Triple::UnknownVendor, T.getVendor());
+  EXPECT_EQ(Triple::UnknownOS, T.getOS());
+
+  T = Triple("dxilv1.7-unknown-unknown");
+  EXPECT_EQ(Triple::dxil, T.getArch());
+  EXPECT_EQ(Triple::DXILSubArch_v17, T.getSubArch());
+  EXPECT_EQ(Triple::UnknownVendor, T.getVendor());
+  EXPECT_EQ(Triple::UnknownOS, T.getOS());
+
+  T = Triple("dxilv1.8-unknown-unknown");
+  EXPECT_EQ(Triple::dxil, T.getArch());
+  EXPECT_EQ(Triple::DXILSubArch_v18, T.getSubArch());
+  EXPECT_EQ(Triple::UnknownVendor, T.getVendor());
+  EXPECT_EQ(Triple::UnknownOS, T.getOS());
+
   T = Triple("xtensa");
   EXPECT_EQ(Triple::xtensa, T.getArch());
   EXPECT_EQ(Triple::UnknownVendor, T.getVendor());

--- a/llvm/unittests/TargetParser/TripleTest.cpp
+++ b/llvm/unittests/TargetParser/TripleTest.cpp
@@ -1025,6 +1025,18 @@ TEST(TripleTest, ParsedIDs) {
   EXPECT_EQ(Triple::UnknownVendor, T.getVendor());
   EXPECT_EQ(Triple::UnknownOS, T.getOS());
 
+  T = Triple("dxilv1.9-unknown-unknown");
+  EXPECT_EQ(Triple::dxil, T.getArch());
+  EXPECT_EQ(Triple::NoSubArch, T.getSubArch());
+  EXPECT_EQ(Triple::UnknownVendor, T.getVendor());
+  EXPECT_EQ(Triple::UnknownOS, T.getOS());
+
+  T = Triple("dxil-unknown-unknown");
+  EXPECT_EQ(Triple::dxil, T.getArch());
+  EXPECT_EQ(Triple::NoSubArch, T.getSubArch());
+  EXPECT_EQ(Triple::UnknownVendor, T.getVendor());
+  EXPECT_EQ(Triple::UnknownOS, T.getOS());
+
   T = Triple("xtensa");
   EXPECT_EQ(Triple::xtensa, T.getArch());
   EXPECT_EQ(Triple::UnknownVendor, T.getVendor());

--- a/llvm/unittests/TargetParser/TripleTest.cpp
+++ b/llvm/unittests/TargetParser/TripleTest.cpp
@@ -1026,7 +1026,7 @@ TEST(TripleTest, ParsedIDs) {
   EXPECT_EQ(Triple::UnknownOS, T.getOS());
 
   T = Triple("dxilv1.9-unknown-unknown");
-  EXPECT_EQ(Triple::dxil, T.getArch());
+  EXPECT_EQ(Triple::UnknownArch, T.getArch());
   EXPECT_EQ(Triple::NoSubArch, T.getSubArch());
   EXPECT_EQ(Triple::UnknownVendor, T.getVendor());
   EXPECT_EQ(Triple::UnknownOS, T.getOS());

--- a/llvm/unittests/TargetParser/TripleTest.cpp
+++ b/llvm/unittests/TargetParser/TripleTest.cpp
@@ -868,6 +868,7 @@ TEST(TripleTest, ParsedIDs) {
 
   T = Triple("dxil-unknown-shadermodel-pixel");
   EXPECT_EQ(Triple::dxil, T.getArch());
+  EXPECT_EQ(Triple::NoSubArch, T.getSubArch());
   EXPECT_EQ(Triple::UnknownVendor, T.getVendor());
   EXPECT_EQ(Triple::ShaderModel, T.getOS());
   EXPECT_EQ(Triple::Pixel, T.getEnvironment());
@@ -875,6 +876,7 @@ TEST(TripleTest, ParsedIDs) {
 
   T = Triple("dxil-unknown-shadermodel-vertex");
   EXPECT_EQ(Triple::dxil, T.getArch());
+  EXPECT_EQ(Triple::NoSubArch, T.getSubArch());
   EXPECT_EQ(Triple::UnknownVendor, T.getVendor());
   EXPECT_EQ(Triple::ShaderModel, T.getOS());
   EXPECT_EQ(Triple::Vertex, T.getEnvironment());
@@ -882,6 +884,7 @@ TEST(TripleTest, ParsedIDs) {
 
   T = Triple("dxil-unknown-shadermodel-geometry");
   EXPECT_EQ(Triple::dxil, T.getArch());
+  EXPECT_EQ(Triple::NoSubArch, T.getSubArch());
   EXPECT_EQ(Triple::UnknownVendor, T.getVendor());
   EXPECT_EQ(Triple::ShaderModel, T.getOS());
   EXPECT_EQ(Triple::Geometry, T.getEnvironment());
@@ -889,6 +892,7 @@ TEST(TripleTest, ParsedIDs) {
 
   T = Triple("dxil-unknown-shadermodel-hull");
   EXPECT_EQ(Triple::dxil, T.getArch());
+  EXPECT_EQ(Triple::NoSubArch, T.getSubArch());
   EXPECT_EQ(Triple::UnknownVendor, T.getVendor());
   EXPECT_EQ(Triple::ShaderModel, T.getOS());
   EXPECT_EQ(Triple::Hull, T.getEnvironment());
@@ -896,6 +900,7 @@ TEST(TripleTest, ParsedIDs) {
 
   T = Triple("dxil-unknown-shadermodel-domain");
   EXPECT_EQ(Triple::dxil, T.getArch());
+  EXPECT_EQ(Triple::NoSubArch, T.getSubArch());
   EXPECT_EQ(Triple::UnknownVendor, T.getVendor());
   EXPECT_EQ(Triple::ShaderModel, T.getOS());
   EXPECT_EQ(Triple::Domain, T.getEnvironment());
@@ -903,6 +908,7 @@ TEST(TripleTest, ParsedIDs) {
 
   T = Triple("dxil-unknown-shadermodel-compute");
   EXPECT_EQ(Triple::dxil, T.getArch());
+  EXPECT_EQ(Triple::NoSubArch, T.getSubArch());
   EXPECT_EQ(Triple::UnknownVendor, T.getVendor());
   EXPECT_EQ(Triple::ShaderModel, T.getOS());
   EXPECT_EQ(Triple::Compute, T.getEnvironment());
@@ -910,6 +916,7 @@ TEST(TripleTest, ParsedIDs) {
 
   T = Triple("dxil-unknown-shadermodel-library");
   EXPECT_EQ(Triple::dxil, T.getArch());
+  EXPECT_EQ(Triple::NoSubArch, T.getSubArch());
   EXPECT_EQ(Triple::UnknownVendor, T.getVendor());
   EXPECT_EQ(Triple::ShaderModel, T.getOS());
   EXPECT_EQ(Triple::Library, T.getEnvironment());
@@ -917,6 +924,7 @@ TEST(TripleTest, ParsedIDs) {
 
   T = Triple("dxil-unknown-shadermodel-raygeneration");
   EXPECT_EQ(Triple::dxil, T.getArch());
+  EXPECT_EQ(Triple::NoSubArch, T.getSubArch());
   EXPECT_EQ(Triple::UnknownVendor, T.getVendor());
   EXPECT_EQ(Triple::ShaderModel, T.getOS());
   EXPECT_EQ(Triple::RayGeneration, T.getEnvironment());
@@ -924,6 +932,7 @@ TEST(TripleTest, ParsedIDs) {
 
   T = Triple("dxil-unknown-shadermodel-intersection");
   EXPECT_EQ(Triple::dxil, T.getArch());
+  EXPECT_EQ(Triple::NoSubArch, T.getSubArch());
   EXPECT_EQ(Triple::UnknownVendor, T.getVendor());
   EXPECT_EQ(Triple::ShaderModel, T.getOS());
   EXPECT_EQ(Triple::Intersection, T.getEnvironment());
@@ -931,6 +940,7 @@ TEST(TripleTest, ParsedIDs) {
 
   T = Triple("dxil-unknown-shadermodel-anyhit");
   EXPECT_EQ(Triple::dxil, T.getArch());
+  EXPECT_EQ(Triple::NoSubArch, T.getSubArch());
   EXPECT_EQ(Triple::UnknownVendor, T.getVendor());
   EXPECT_EQ(Triple::ShaderModel, T.getOS());
   EXPECT_EQ(Triple::AnyHit, T.getEnvironment());
@@ -938,6 +948,7 @@ TEST(TripleTest, ParsedIDs) {
 
   T = Triple("dxil-unknown-shadermodel-closesthit");
   EXPECT_EQ(Triple::dxil, T.getArch());
+  EXPECT_EQ(Triple::NoSubArch, T.getSubArch());
   EXPECT_EQ(Triple::UnknownVendor, T.getVendor());
   EXPECT_EQ(Triple::ShaderModel, T.getOS());
   EXPECT_EQ(Triple::ClosestHit, T.getEnvironment());
@@ -945,6 +956,7 @@ TEST(TripleTest, ParsedIDs) {
 
   T = Triple("dxil-unknown-shadermodel-miss");
   EXPECT_EQ(Triple::dxil, T.getArch());
+  EXPECT_EQ(Triple::NoSubArch, T.getSubArch());
   EXPECT_EQ(Triple::UnknownVendor, T.getVendor());
   EXPECT_EQ(Triple::ShaderModel, T.getOS());
   EXPECT_EQ(Triple::Miss, T.getEnvironment());
@@ -952,6 +964,7 @@ TEST(TripleTest, ParsedIDs) {
 
   T = Triple("dxil-unknown-shadermodel-callable");
   EXPECT_EQ(Triple::dxil, T.getArch());
+  EXPECT_EQ(Triple::NoSubArch, T.getSubArch());
   EXPECT_EQ(Triple::UnknownVendor, T.getVendor());
   EXPECT_EQ(Triple::ShaderModel, T.getOS());
   EXPECT_EQ(Triple::Callable, T.getEnvironment());
@@ -959,6 +972,7 @@ TEST(TripleTest, ParsedIDs) {
 
   T = Triple("dxil-unknown-shadermodel-mesh");
   EXPECT_EQ(Triple::dxil, T.getArch());
+  EXPECT_EQ(Triple::NoSubArch, T.getSubArch());
   EXPECT_EQ(Triple::UnknownVendor, T.getVendor());
   EXPECT_EQ(Triple::ShaderModel, T.getOS());
   EXPECT_EQ(Triple::Mesh, T.getEnvironment());
@@ -966,6 +980,7 @@ TEST(TripleTest, ParsedIDs) {
 
   T = Triple("dxil-unknown-shadermodel-amplification");
   EXPECT_EQ(Triple::dxil, T.getArch());
+  EXPECT_EQ(Triple::NoSubArch, T.getSubArch());
   EXPECT_EQ(Triple::UnknownVendor, T.getVendor());
   EXPECT_EQ(Triple::ShaderModel, T.getOS());
   EXPECT_EQ(Triple::Amplification, T.getEnvironment());
@@ -973,59 +988,61 @@ TEST(TripleTest, ParsedIDs) {
 
   T = Triple("dxilv1.0-unknown-unknown");
   EXPECT_EQ(Triple::dxil, T.getArch());
-  EXPECT_EQ(Triple::DXILSubArch_v10, T.getSubArch());
+  EXPECT_EQ(Triple::DXILSubArch_v1_0, T.getSubArch());
   EXPECT_EQ(Triple::UnknownVendor, T.getVendor());
   EXPECT_EQ(Triple::UnknownOS, T.getOS());
 
   T = Triple("dxilv1.1-unknown-unknown");
   EXPECT_EQ(Triple::dxil, T.getArch());
-  EXPECT_EQ(Triple::DXILSubArch_v11, T.getSubArch());
+  EXPECT_EQ(Triple::DXILSubArch_v1_1, T.getSubArch());
   EXPECT_EQ(Triple::UnknownVendor, T.getVendor());
   EXPECT_EQ(Triple::UnknownOS, T.getOS());
 
   T = Triple("dxilv1.2-unknown-unknown");
   EXPECT_EQ(Triple::dxil, T.getArch());
-  EXPECT_EQ(Triple::DXILSubArch_v12, T.getSubArch());
+  EXPECT_EQ(Triple::DXILSubArch_v1_2, T.getSubArch());
   EXPECT_EQ(Triple::UnknownVendor, T.getVendor());
   EXPECT_EQ(Triple::UnknownOS, T.getOS());
 
   T = Triple("dxilv1.3-unknown-unknown");
   EXPECT_EQ(Triple::dxil, T.getArch());
-  EXPECT_EQ(Triple::DXILSubArch_v13, T.getSubArch());
+  EXPECT_EQ(Triple::DXILSubArch_v1_3, T.getSubArch());
   EXPECT_EQ(Triple::UnknownVendor, T.getVendor());
   EXPECT_EQ(Triple::UnknownOS, T.getOS());
 
   T = Triple("dxilv1.4-unknown-unknown");
   EXPECT_EQ(Triple::dxil, T.getArch());
-  EXPECT_EQ(Triple::DXILSubArch_v14, T.getSubArch());
+  EXPECT_EQ(Triple::DXILSubArch_v1_4, T.getSubArch());
   EXPECT_EQ(Triple::UnknownVendor, T.getVendor());
   EXPECT_EQ(Triple::UnknownOS, T.getOS());
 
   T = Triple("dxilv1.5-unknown-unknown");
   EXPECT_EQ(Triple::dxil, T.getArch());
-  EXPECT_EQ(Triple::DXILSubArch_v15, T.getSubArch());
+  EXPECT_EQ(Triple::DXILSubArch_v1_5, T.getSubArch());
   EXPECT_EQ(Triple::UnknownVendor, T.getVendor());
   EXPECT_EQ(Triple::UnknownOS, T.getOS());
 
   T = Triple("dxilv1.6-unknown-unknown");
   EXPECT_EQ(Triple::dxil, T.getArch());
-  EXPECT_EQ(Triple::DXILSubArch_v16, T.getSubArch());
+  EXPECT_EQ(Triple::DXILSubArch_v1_6, T.getSubArch());
   EXPECT_EQ(Triple::UnknownVendor, T.getVendor());
   EXPECT_EQ(Triple::UnknownOS, T.getOS());
 
   T = Triple("dxilv1.7-unknown-unknown");
   EXPECT_EQ(Triple::dxil, T.getArch());
-  EXPECT_EQ(Triple::DXILSubArch_v17, T.getSubArch());
+  EXPECT_EQ(Triple::DXILSubArch_v1_7, T.getSubArch());
   EXPECT_EQ(Triple::UnknownVendor, T.getVendor());
   EXPECT_EQ(Triple::UnknownOS, T.getOS());
 
   T = Triple("dxilv1.8-unknown-unknown");
   EXPECT_EQ(Triple::dxil, T.getArch());
-  EXPECT_EQ(Triple::DXILSubArch_v18, T.getSubArch());
+  EXPECT_EQ(Triple::DXILSubArch_v1_8, T.getSubArch());
   EXPECT_EQ(Triple::UnknownVendor, T.getVendor());
   EXPECT_EQ(Triple::UnknownOS, T.getOS());
 
-  T = Triple("dxilv1.9-unknown-unknown");
+  // Check specification of unknown SubArch results in
+  // unknown architecture.
+  T = Triple("dxilv1.999-unknown-unknown");
   EXPECT_EQ(Triple::UnknownArch, T.getArch());
   EXPECT_EQ(Triple::NoSubArch, T.getSubArch());
   EXPECT_EQ(Triple::UnknownVendor, T.getVendor());


### PR DESCRIPTION
This change is in line with similar notation in SPIRV. 

Decoupling Version numbering of DXIL and of Shader Model is intended to enable accurate specification of DXIL features that can be targeted by different Shader Model versions. See [here](https://github.com/llvm/llvm-project/pull/88350#discussion_r1566217496) for additional context. 