### PR TITLE
[libc][docs] improvements to docgen, adds threads.h implementation status docs

### DIFF
--- a/libc/docs/ctype.rst
+++ b/libc/docs/ctype.rst
@@ -1,7 +1,11 @@
 .. include:: check.rst
 
-ctype.h Functions
-=================
+=======
+ctype.h
+=======
+
+Functions
+=========
 
 .. list-table::
   :widths: auto

--- a/libc/docs/fenv.rst
+++ b/libc/docs/fenv.rst
@@ -1,7 +1,80 @@
 .. include:: check.rst
 
-fenv.h Functions
-================
+======
+fenv.h
+======
+
+Macros
+======
+
+.. list-table::
+  :widths: auto
+  :align: center
+  :header-rows: 1
+
+  * - Function
+    - Implemented
+    - Standard
+  * - FE_ALL_EXCEPT
+    - |check|
+    - 7.6.12
+  * - FE_DEC_DOWNWARD
+    -
+    - 7.6.14
+  * - FE_DEC_TONEAREST
+    -
+    - 7.6.14
+  * - FE_DEC_TONEARESTFROMZERO
+    -
+    - 7.6.14
+  * - FE_DEC_TOWARDZERO
+    -
+    - 7.6.14
+  * - FE_DEC_UPWARD
+    -
+    - 7.6.14
+  * - FE_DFL_ENV
+    - |check|
+    - 7.6.17
+  * - FE_DFL_MODE
+    -
+    - 7.6.11
+  * - FE_DIVBYZERO
+    - |check|
+    - 7.6.9
+  * - FE_DOWNARD
+    - |check|
+    - 7.6.13
+  * - FE_INEXACT
+    - |check|
+    - 7.6.9
+  * - FE_INVALID
+    - |check|
+    - 7.6.9
+  * - FE_OVERFLOW
+    - |check|
+    - 7.6.9
+  * - FE_TONEAREST
+    - |check|
+    - 7.6.13
+  * - FE_TONEARESTFROMZERO
+    -
+    - 7.6.13
+  * - FE_TOWARDZERO
+    - |check|
+    - 7.6.13
+  * - FE_UNDERFLOW
+    - |check|
+    - 7.6.9
+  * - FE_UPWARD
+    - |check|
+    - 7.6.13
+  * - __STDC_VERSION_FENV_H__
+    -
+    - 7.6.5
+
+Functions
+=========
 
 .. list-table::
   :widths: auto

--- a/libc/docs/index.rst
+++ b/libc/docs/index.rst
@@ -71,6 +71,7 @@ stages there is no ABI stability in any form.
    c23
    ctype
    signal
+   threads
 
 .. toctree::
    :hidden:

--- a/libc/docs/signal.rst
+++ b/libc/docs/signal.rst
@@ -1,7 +1,50 @@
 .. include:: check.rst
 
-signal.h Functions
-==================
+========
+signal.h
+========
+
+Macros
+======
+
+.. list-table::
+  :widths: auto
+  :align: center
+  :header-rows: 1
+
+  * - Function
+    - Implemented
+    - Standard
+  * - SIGABRT
+    - |check|
+    - 7.14.3
+  * - SIGFPE
+    - |check|
+    - 7.14.3
+  * - SIGILL
+    - |check|
+    - 7.14.3
+  * - SIGINT
+    - |check|
+    - 7.14.3
+  * - SIGSEGV
+    - |check|
+    - 7.14.3
+  * - SIGTERM
+    - |check|
+    - 7.14.3
+  * - SIG_DFL
+    -
+    - 7.14.3
+  * - SIG_ERR
+    -
+    - 7.14.3
+  * - SIG_IGN
+    -
+    - 7.14.3
+
+Functions
+=========
 
 .. list-table::
   :widths: auto

--- a/libc/docs/stdbit.rst
+++ b/libc/docs/stdbit.rst
@@ -1,7 +1,77 @@
 .. include:: check.rst
 
-stdbit.h Functions
-==================
+========
+stdbit.h
+========
+
+Macros
+======
+
+.. list-table::
+  :widths: auto
+  :align: center
+  :header-rows: 1
+
+  * - Function
+    - Implemented
+    - Standard
+  * - __STDC_ENDIAN_BIG__
+    - |check|
+    - 7.18.2.2
+  * - __STDC_ENDIAN_LITTLE__
+    - |check|
+    - 7.18.2.2
+  * - __STDC_ENDIAN_NATIVE__
+    - |check|
+    - 7.18.2.2
+  * - __STDC_VERSION_STDBIT_H__
+    - |check|
+    - 7.18.1.2
+  * - stdc_bit_ceil
+    - |check|
+    - 7.18.16.1
+  * - stdc_bit_floor
+    - |check|
+    - 7.18.15.1
+  * - stdc_bit_width
+    - |check|
+    - 7.18.14.1
+  * - stdc_count_ones
+    - |check|
+    - 7.18.12.1
+  * - stdc_count_zeros
+    - |check|
+    - 7.18.11.1
+  * - stdc_first_leading_one
+    - |check|
+    - 7.18.8.1
+  * - stdc_first_leading_zero
+    - |check|
+    - 7.18.7.1
+  * - stdc_first_trailing_one
+    - |check|
+    - 7.18.10.1
+  * - stdc_first_trailing_zero
+    - |check|
+    - 7.18.9.1
+  * - stdc_has_single_bit
+    - |check|
+    - 7.18.13.1
+  * - stdc_leading_ones
+    - |check|
+    - 7.18.4.1
+  * - stdc_leading_zeros
+    - |check|
+    - 7.18.3.1
+  * - stdc_trailing_ones
+    - |check|
+    - 7.18.6.1
+  * - stdc_trailing_zeros
+    - |check|
+    - 7.18.5.1
+
+Functions
+=========
 
 .. list-table::
   :widths: auto

--- a/libc/docs/threads.rst
+++ b/libc/docs/threads.rst
@@ -1,0 +1,110 @@
+.. include:: check.rst
+
+=========
+threads.h
+=========
+
+Macros
+======
+
+.. list-table::
+  :widths: auto
+  :align: center
+  :header-rows: 1
+
+  * - Function
+    - Implemented
+    - Standard
+  * - ONCE_FLAG_INIT
+    - |check|
+    - 7.28.1.3
+  * - TSS_DTOR_ITERATIONS
+    -
+    - 7.28.1.3
+
+Functions
+=========
+
+.. list-table::
+  :widths: auto
+  :align: center
+  :header-rows: 1
+
+  * - Function
+    - Implemented
+    - Standard
+  * - call_once
+    - |check|
+    - 7.28.2.1
+  * - cnd_broadcast
+    - |check|
+    - 7.28.3.1
+  * - cnd_destroy
+    - |check|
+    - 7.28.3.2
+  * - cnd_init
+    - |check|
+    - 7.28.3.3
+  * - cnd_signal
+    - |check|
+    - 7.28.3.4
+  * - cnd_timedwait
+    -
+    - 7.28.3.5
+  * - cnd_wait
+    - |check|
+    - 7.28.3.6
+  * - mtx_destroy
+    - |check|
+    - 7.28.4.1
+  * - mtx_init
+    - |check|
+    - 7.28.4.2
+  * - mtx_lock
+    - |check|
+    - 7.28.4.3
+  * - mtx_timedlock
+    -
+    - 7.28.4.4
+  * - mtx_trylock
+    -
+    - 7.28.4.5
+  * - mtx_unlock
+    - |check|
+    - 7.28.4.6
+  * - thrd_create
+    - |check|
+    - 7.28.5.1
+  * - thrd_current
+    - |check|
+    - 7.28.5.2
+  * - thrd_detach
+    - |check|
+    - 7.28.5.3
+  * - thrd_equal
+    - |check|
+    - 7.28.5.4
+  * - thrd_exit
+    - |check|
+    - 7.28.5.5
+  * - thrd_join
+    - |check|
+    - 7.28.5.6
+  * - thrd_sleep
+    -
+    - 7.28.5.7
+  * - thrd_yield
+    -
+    - 7.28.5.8
+  * - tss_create
+    - |check|
+    - 7.28.6.1
+  * - tss_delete
+    - |check|
+    - 7.28.6.2
+  * - tss_get
+    - |check|
+    - 7.28.6.3
+  * - tss_set
+    - |check|
+    - 7.28.6.4

--- a/libc/utils/docgen/docgen-api-schema.json
+++ b/libc/utils/docgen/docgen-api-schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "docgen API format",
-  "description": "This schema specifies the format used by docgen to automatically generate standard header implementation statuses for libc. See the other JSON files in $LLVM_PROJECT/libc/docgen/ for files implementing following this API format.",
+  "description": "This schema specifies the format used by docgen to automatically generate standard header implementation statuses for libc. See the other JSON files in $LLVM_PROJECT/libc/docgen/ for files implementing this API format.",
   "type": "object",
   "properties": {
     "macros": {

--- a/libc/utils/docgen/docgen-api-schema.json
+++ b/libc/utils/docgen/docgen-api-schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "docgen API format",
-  "description": "This schema specifies the format used by docgen to automatically generate standard header implementation statuses for libc. See the other JSON files in $LLVM_PROJECT/libc/docgen/ for files implementing this API format.",
+  "description": "This schema specifies the format used by docgen to automatically generate standard header implementation statuses for libc. See the other JSON files in $LLVM_PROJECT/libc/utils/docgen/ for files implementing this API format.",
   "type": "object",
   "properties": {
     "macros": {

--- a/libc/utils/docgen/docgen-api-schema.json
+++ b/libc/utils/docgen/docgen-api-schema.json
@@ -1,0 +1,47 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "docgen API format",
+  "description": "This schema specifies the format used by docgen to automatically generate standard header implementation statuses for libc. See the other JSON files in $LLVM_PROJECT/libc/docgen/ for files implementing following this API format.",
+  "type": "object",
+  "properties": {
+    "macros": {
+      "description": "Implementation status of macros in this header",
+      "type": "object",
+      "patternProperties": {
+        ".+": {
+          "description": "Implementation status of a specific macro",
+          "type": "object",
+          "properties": {
+            "implemented": {
+              "description": "true or false, not computed automatically unlike individual functions described in the schema below",
+              "type": "boolean"
+            },
+            "defined": {
+              "$ref": "#/c-standard-reference"
+            }
+          },
+          "required": ["implemented", "defined"]
+        }
+      }
+    },
+    "functions": {
+      "patternProperties": {
+        ".+": {
+          "description": "Implementation status of functions in this header",
+          "type": ["object", "null"],
+          "properties": {
+            "defined": {
+              "$ref": "#/c-standard-reference"
+            }
+          },
+          "required": ["defined"]
+        }
+      }
+    }
+  },
+  "c-standard-reference": {
+    "description": "What subsection and paragraph number (if applicable) is this defined in the standard?",
+    "type": "string",
+    "pattern": "^7\\.([0-9]+\\.)*[0-9]+$"
+  }
+}

--- a/libc/utils/docgen/fenv.json
+++ b/libc/utils/docgen/fenv.json
@@ -1,7 +1,82 @@
 {
-  "macros": [
-    "__STDC_VERSION_FENV_H__"
-  ],
+  "macros": {
+    "__STDC_VERSION_FENV_H__": {
+      "defined": "7.6.5",
+      "implemented": false
+    },
+    "FE_DIVBYZERO": {
+      "defined": "7.6.9",
+      "implemented": true
+    },
+    "FE_INEXACT": {
+      "defined": "7.6.9",
+      "implemented": true
+    },
+    "FE_INVALID": {
+      "defined": "7.6.9",
+      "implemented": true
+    },
+    "FE_OVERFLOW": {
+      "defined": "7.6.9",
+      "implemented": true
+    },
+    "FE_UNDERFLOW": {
+      "defined": "7.6.9",
+      "implemented": true
+    },
+    "FE_ALL_EXCEPT": {
+      "defined": "7.6.12",
+      "implemented": true
+    },
+    "FE_DFL_MODE": {
+      "defined": "7.6.11",
+      "implemented": false
+    },
+    "FE_DOWNARD": {
+      "defined": "7.6.13",
+      "implemented": true
+    },
+    "FE_TONEAREST": {
+      "defined": "7.6.13",
+      "implemented": true
+    },
+    "FE_TONEARESTFROMZERO": {
+      "defined": "7.6.13",
+      "implemented": false
+    },
+    "FE_TOWARDZERO": {
+      "defined": "7.6.13",
+      "implemented": true
+    },
+    "FE_UPWARD": {
+      "defined": "7.6.13",
+      "implemented": true
+    },
+    "FE_DEC_DOWNWARD": {
+      "defined": "7.6.14",
+      "implemented": false
+    },
+    "FE_DEC_TONEAREST": {
+      "defined": "7.6.14",
+      "implemented": false
+    },
+    "FE_DEC_TONEARESTFROMZERO": {
+      "defined": "7.6.14",
+      "implemented": false
+    },
+    "FE_DEC_TOWARDZERO": {
+      "defined": "7.6.14",
+      "implemented": false
+    },
+    "FE_DEC_UPWARD": {
+      "defined": "7.6.14",
+      "implemented": false
+    },
+    "FE_DFL_ENV": {
+      "defined": "7.6.17",
+      "implemented": true
+    }
+  },
   "functions": {
     "feclearexcept": {
       "defined": "7.6.4.1"

--- a/libc/utils/docgen/signal.json
+++ b/libc/utils/docgen/signal.json
@@ -1,16 +1,49 @@
 {
-  "macros": [
-    "SIG_DFL",
-    "SIG_ERR",
-    "SIG_IGN",
-    "SIGABRT",
-    "SIGFPE",
-    "SIGILL",
-    "SIGINT",
-    "SIGSEGV",
-    "SIGTERM"
-  ],
+  "macros": {
+    "SIG_DFL": {
+      "defined": "7.14.3",
+      "implemented": false
+    },
+    "SIG_ERR": {
+      "defined": "7.14.3",
+      "implemented": false
+    },
+    "SIG_IGN": {
+      "defined": "7.14.3",
+      "implemented": false
+    },
+    "SIGABRT": {
+      "defined": "7.14.3",
+      "implemented": true
+    },
+    "SIGFPE": {
+      "defined": "7.14.3",
+      "implemented": true
+    },
+    "SIGILL": {
+      "defined": "7.14.3",
+      "implemented": true
+    },
+    "SIGINT": {
+      "defined": "7.14.3",
+      "implemented": true
+    },
+    "SIGSEGV": {
+      "defined": "7.14.3",
+      "implemented": true
+    },
+    "SIGTERM": {
+      "defined": "7.14.3",
+      "implemented": true
+    }
+  },
   "functions": {
+    "signal": {
+      "defined": "7.14.1.1"
+    },
+    "raise": {
+      "defined": "7.14.2.1"
+    },
     "kill": null,
     "sigaction": null,
     "sigaddset": null,
@@ -18,12 +51,6 @@
     "sigdelset": null,
     "sigemptyset": null,
     "sigfillset": null,
-    "sigprocmask": null,
-    "signal": {
-      "defined": "7.14.1.1"
-    },
-    "raise": {
-      "defined": "7.14.2.1"
-    }
+    "sigprocmask": null
   }
 }

--- a/libc/utils/docgen/stdbit.json
+++ b/libc/utils/docgen/stdbit.json
@@ -1,24 +1,78 @@
 {
-  "macros": [
-    "__STDC_VERSION_STDBIT_H__",
-    "__STDC_ENDIAN_LITTLE__",
-    "__STDC_ENDIAN_BIG__",
-    "__STDC_ENDIAN_NATIVE__",
-    "stdc_leading_zeros",
-    "stdc_leading_ones",
-    "stdc_trailing_zeros",
-    "stdc_trailing_ones",
-    "stdc_first_leading_zero",
-    "stdc_first_leading_one",
-    "stdc_first_trailing_zero",
-    "stdc_first_trailing_one",
-    "stdc_count_zeros",
-    "stdc_count_ones",
-    "stdc_has_single_bit",
-    "stdc_bit_width",
-    "stdc_bit_floor",
-    "stdc_bit_ceil"
-  ],
+  "macros": {
+    "__STDC_VERSION_STDBIT_H__": {
+      "defined": "7.18.1.2",
+      "implemented": true
+    },
+    "__STDC_ENDIAN_LITTLE__": {
+      "defined": "7.18.2.2",
+      "implemented": true
+    },
+    "__STDC_ENDIAN_BIG__": {
+      "defined": "7.18.2.2",
+      "implemented": true
+    },
+    "__STDC_ENDIAN_NATIVE__": {
+      "defined": "7.18.2.2",
+      "implemented": true
+    },
+    "stdc_leading_zeros": {
+      "defined": "7.18.3.1",
+      "implemented": true
+    },
+    "stdc_leading_ones": {
+      "defined": "7.18.4.1",
+      "implemented": true
+    },
+    "stdc_trailing_zeros": {
+      "defined": "7.18.5.1",
+      "implemented": true
+    },
+    "stdc_trailing_ones": {
+      "defined": "7.18.6.1",
+      "implemented": true
+    },
+    "stdc_first_leading_zero": {
+      "defined": "7.18.7.1",
+      "implemented": true
+    },
+    "stdc_first_leading_one": {
+      "defined": "7.18.8.1",
+      "implemented": true
+    },
+    "stdc_first_trailing_zero": {
+      "defined": "7.18.9.1",
+      "implemented": true
+    },
+    "stdc_first_trailing_one": {
+      "defined": "7.18.10.1",
+      "implemented": true
+    },
+    "stdc_count_zeros": {
+      "defined": "7.18.11.1",
+      "implemented": true
+    },
+    "stdc_count_ones": {
+      "defined": "7.18.12.1",
+      "implemented": true
+    },
+    "stdc_has_single_bit": {
+      "defined": "7.18.13.1",
+      "implemented": true
+    },
+    "stdc_bit_width": {
+      "defined": "7.18.14.1",
+      "implemented": true
+    },
+    "stdc_bit_floor": {
+      "defined": "7.18.15.1",
+      "implemented": true
+    },
+    "stdc_bit_ceil": {
+      "defined": "7.18.16.1",
+      "implemented": true
+    }
+  },
   "functions": {
     "stdc_leading_zeros_uc": {
       "defined": "7.18.3"

--- a/libc/utils/docgen/threads.json
+++ b/libc/utils/docgen/threads.json
@@ -1,0 +1,89 @@
+{
+  "macros": {
+    "ONCE_FLAG_INIT": {
+      "defined": "7.28.1.3",
+      "implemented": true
+    },
+    "TSS_DTOR_ITERATIONS": {
+      "defined": "7.28.1.3",
+      "implemented": false
+    }
+  },
+  "functions": {
+    "call_once": {
+      "defined": "7.28.2.1"
+    },
+    "cnd_broadcast": {
+      "defined": "7.28.3.1"
+    },
+    "cnd_destroy": {
+      "defined": "7.28.3.2"
+    },
+    "cnd_init": {
+      "defined": "7.28.3.3"
+    },
+    "cnd_signal": {
+      "defined": "7.28.3.4"
+    },
+    "cnd_timedwait": {
+      "defined": "7.28.3.5"
+    },
+    "cnd_wait": {
+      "defined": "7.28.3.6"
+    },
+    "mtx_destroy": {
+      "defined": "7.28.4.1"
+    },
+    "mtx_init": {
+      "defined": "7.28.4.2"
+    },
+    "mtx_lock": {
+      "defined": "7.28.4.3"
+    },
+    "mtx_timedlock": {
+      "defined": "7.28.4.4"
+    },
+    "mtx_trylock": {
+      "defined": "7.28.4.5"
+    },
+    "mtx_unlock": {
+      "defined": "7.28.4.6"
+    },
+    "thrd_create": {
+      "defined": "7.28.5.1"
+    },
+    "thrd_current": {
+      "defined": "7.28.5.2"
+    },
+    "thrd_detach": {
+      "defined": "7.28.5.3"
+    },
+    "thrd_equal": {
+      "defined": "7.28.5.4"
+    },
+    "thrd_exit": {
+      "defined": "7.28.5.5"
+    },
+    "thrd_join": {
+      "defined": "7.28.5.6"
+    },
+    "thrd_sleep": {
+      "defined": "7.28.5.7"
+    },
+    "thrd_yield": {
+      "defined": "7.28.5.8"
+    },
+    "tss_create": {
+      "defined": "7.28.6.1"
+    },
+    "tss_delete": {
+      "defined": "7.28.6.2"
+    },
+    "tss_get": {
+      "defined": "7.28.6.3"
+    },
+    "tss_set": {
+      "defined": "7.28.6.4"
+    }
+  }
+}


### PR DESCRIPTION
adds macro support to docgen.py. since the docgen.py file is getting more specific to our idea of what the json files should look like, i've also added a schema file to validate that the json files match what docgen.py expects. i've left validation as a an optional command-line flag since it adds a dependency on `jsonschema`, and i'm not sure how people feel about adding more dependencies. maybe it should just be run on PR checks? what are folks' thoughts?

for macros, i've added a manually set boolean called `implemented` in the docgen json files to specify if a macro has been implemented yet. if automatically computing them is preferred, we could check if the macro is listed in `libc/spec/stdc.td`. thoughts?

converts the already existing docgen json files to use the new format for macros. 

adds more macro definitions for those not already in the docgen json files, like some of the fenv.h macros.

leaving implementation status of posix macros and functions to a later PR.

also adds threads.h

tagging @nickdesaulniers for review

closes #88067 