### PR TITLE
[flang][cuda] Avoid crash by exiting the check if assignment is not usable

### DIFF
--- a/flang/lib/Semantics/check-cuda.cpp
+++ b/flang/lib/Semantics/check-cuda.cpp
@@ -488,8 +488,9 @@ void CUDAChecker::Enter(const parser::AssignmentStmt &x) {
   }
 
   const evaluate::Assignment *assign{semantics::GetAssignment(x)};
-  if (!assign)
+  if (!assign) {
     return;
+  }
 
   int nbLhs{evaluate::GetNbOfCUDASymbols(assign->lhs)};
   int nbRhs{evaluate::GetNbOfCUDASymbols(assign->rhs)};

--- a/flang/lib/Semantics/check-cuda.cpp
+++ b/flang/lib/Semantics/check-cuda.cpp
@@ -488,6 +488,9 @@ void CUDAChecker::Enter(const parser::AssignmentStmt &x) {
   }
 
   const evaluate::Assignment *assign{semantics::GetAssignment(x)};
+  if (!assign)
+    return;
+
   int nbLhs{evaluate::GetNbOfCUDASymbols(assign->lhs)};
   int nbRhs{evaluate::GetNbOfCUDASymbols(assign->rhs)};
 

--- a/flang/test/Semantics/cuf11.cuf
+++ b/flang/test/Semantics/cuf11.cuf
@@ -22,3 +22,11 @@ subroutine sub1()
   ahost = adev + adev
 
 end subroutine
+
+logical function compare_h(a,b)
+!ERROR: Derived type 'h' not found
+  type(h) :: a, b
+!ERROR: 'a' is not an object of derived type; it is implicitly typed
+!ERROR: 'b' is not an object of derived type; it is implicitly typed
+  compare_h = (a%h .eq. b%h)
+end


### PR DESCRIPTION
In the presence of other semantic error, `GetAssignment` would return a nullptr and therefore would make the rest of the check crash when trying to collect symbols. 

Exiting early when we have a nullptr so the compiler doesn't crash and user can get the meaningful semantic error. 