### PR TITLE
Revert "CompilerRT: Normalize COMPILER_RT_DEFAULT_TARGET_TRIPLE"

### DIFF
--- a/compiler-rt/cmake/Modules/CompilerRTUtils.cmake
+++ b/compiler-rt/cmake/Modules/CompilerRTUtils.cmake
@@ -368,12 +368,6 @@ macro(construct_compiler_rt_default_triple)
           "Default triple for which compiler-rt runtimes will be built.")
   endif()
 
-  if ("${CMAKE_C_COMPILER_ID}" MATCHES "Clang")
-    execute_process(COMMAND ${CMAKE_C_COMPILER} --target=${COMPILER_RT_DEFAULT_TARGET_TRIPLE} -print-effective-triple
-                    OUTPUT_VARIABLE COMPILER_RT_DEFAULT_TARGET_TRIPLE
-                    OUTPUT_STRIP_TRAILING_WHITESPACE)
-  endif()
-
   string(REPLACE "-" ";" LLVM_TARGET_TRIPLE_LIST ${COMPILER_RT_DEFAULT_TARGET_TRIPLE})
   list(GET LLVM_TARGET_TRIPLE_LIST 0 COMPILER_RT_DEFAULT_TARGET_ARCH)
 


### PR DESCRIPTION
Reverts llvm/llvm-project#88835

Break the build:
```
  Host compiler does not support '-fuse-ld=lld'.  Please make sure that 'lld'
  is installed and that your host compiler can compile a simple program when
  given the option '-fuse-ld=lld'.
```