### PR TITLE
[DebugInfo] Report errors when DWARFUnitHeader::applyIndexEntry fails

### DIFF
--- a/llvm/include/llvm/DebugInfo/DWARF/DWARFUnit.h
+++ b/llvm/include/llvm/DebugInfo/DWARF/DWARFUnit.h
@@ -85,7 +85,7 @@ public:
                 uint64_t *offset_ptr, DWARFSectionKind SectionKind);
   // For units in DWARF Package File, remember the index entry and update
   // the abbreviation offset read by extract().
-  bool applyIndexEntry(const DWARFUnitIndex::Entry *Entry);
+  Error applyIndexEntry(const DWARFUnitIndex::Entry *Entry);
   uint64_t getOffset() const { return Offset; }
   const dwarf::FormParams &getFormParams() const { return FormParams; }
   uint16_t getVersion() const { return FormParams.Version; }

--- a/llvm/lib/DebugInfo/DWARF/DWARFUnit.cpp
+++ b/llvm/lib/DebugInfo/DWARF/DWARFUnit.cpp
@@ -344,7 +344,7 @@ Error DWARFUnitHeader::applyIndexEntry(const DWARFUnitIndex::Entry *Entry) {
   IndexEntry = Entry;
   if (AbbrOffset)
     return createStringError(errc::invalid_argument,
-                             "DWARF package unit from offset 0x%8.8" PRIx64
+                             "DWARF package unit at offset 0x%8.8" PRIx64
                              " has a non-zero abbreviation offset",
                              Offset);
 
@@ -353,7 +353,7 @@ Error DWARFUnitHeader::applyIndexEntry(const DWARFUnitIndex::Entry *Entry) {
       UnitContrib->getLength() != (getLength() + getUnitLengthFieldByteSize()))
     return createStringError(errc::invalid_argument,
                              "DWARF package unit at offset 0x%8.8" PRIx64
-                             "has an inconsistent index",
+                             " has an inconsistent index",
                              Offset);
 
   auto *AbbrEntry = IndexEntry->getContribution(DW_SECT_ABBREV);

--- a/llvm/lib/DebugInfo/DWARF/DWARFUnit.cpp
+++ b/llvm/lib/DebugInfo/DWARF/DWARFUnit.cpp
@@ -349,12 +349,19 @@ Error DWARFUnitHeader::applyIndexEntry(const DWARFUnitIndex::Entry *Entry) {
                              Offset);
 
   auto *UnitContrib = IndexEntry->getContribution();
-  if (!UnitContrib ||
-      UnitContrib->getLength() != (getLength() + getUnitLengthFieldByteSize()))
+  if (!UnitContrib)
     return createStringError(errc::invalid_argument,
                              "DWARF package unit at offset 0x%8.8" PRIx64
-                             " has an inconsistent index",
+                             " has no contribution index",
                              Offset);
+
+  uint64_t IndexLength = getLength() + getUnitLengthFieldByteSize();
+  if (UnitContrib->getLength() != IndexLength)
+    return createStringError(errc::invalid_argument,
+                             "DWARF package unit at offset 0x%8.8" PRIx64
+                             " has an inconsistent index (expected: %" PRIu64
+                             ", actual: %" PRIu64 ")",
+                             Offset, UnitContrib->getLength(), IndexLength);
 
   auto *AbbrEntry = IndexEntry->getContribution(DW_SECT_ABBREV);
   if (!AbbrEntry)

--- a/llvm/lib/DebugInfo/DWARF/DWARFUnit.cpp
+++ b/llvm/lib/DebugInfo/DWARF/DWARFUnit.cpp
@@ -366,8 +366,8 @@ Error DWARFUnitHeader::applyIndexEntry(const DWARFUnitIndex::Entry *Entry) {
   auto *AbbrEntry = IndexEntry->getContribution(DW_SECT_ABBREV);
   if (!AbbrEntry)
     return createStringError(errc::invalid_argument,
-                             "DWARF package unit at offset 0x%8.8 " PRIx64
-                             " mising abbreviation column",
+                             "DWARF package unit at offset 0x%8.8" PRIx64
+                             " missing abbreviation column",
                              Offset);
 
   AbbrOffset = AbbrEntry->getOffset();

--- a/llvm/test/DebugInfo/X86/invalid-cu-abbrev-contribution-dwp.s
+++ b/llvm/test/DebugInfo/X86/invalid-cu-abbrev-contribution-dwp.s
@@ -1,10 +1,7 @@
 # RUN: llvm-mc -triple x86_64-unknown-linux %s -filetype=obj -o - | \
 # RUN:   llvm-dwarfdump -debug-info - 2>&1 | FileCheck %s
 
-## llvm-dwarfdump used to crash with this input because of an invalid size
-## of the compilation unit contribution in the .debug_cu_index section.
-
-# CHECK: warning: DWARF package unit at offset 0x00000000 has an inconsistent index
+# CHECK: warning: DWARF package unit at offset 0x00000000 mising abbreviation column
 
     .section .debug_abbrev.dwo, "e", @progbits
 .LAbbrBegin:
@@ -36,7 +33,7 @@
 ## Header:
     .short 2                    # Version
     .space 2                    # Padding
-    .long 2                     # Section count
+    .long 1                     # Section count (Invalid, should be 2)
     .long 1                     # Unit count
     .long 4                     # Slot count
 ## Hash Table of Signatures:
@@ -52,10 +49,10 @@
 ## Table of Section Offsets:
 ## Row 0:
     .long 1                     # DW_SECT_INFO
-    .long 3                     # DW_SECT_ABBREV
+#    .long 3                     # DW_SECT_ABBREV (Intentionally omitted)
 ## Row 1:
     .long .LCUBegin-.debug_info.dwo     # Offset in .debug_info.dwo
-    .long .LAbbrBegin-.debug_abbrev.dwo # Offset in .debug_abbrev.dwo
+#    .long .LAbbrBegin-.debug_abbrev.dwo # Offset in .debug_abbrev.dwo (Intentionally omitted)
 ## Table of Section Sizes:
-    .long .LCUEnd-.LCUBegin-1           # Size of the contribution in .debug_info.dwo (invalid)
-    .long .LAbbrEnd-.LAbbrBegin
+    .long .LCUEnd-.LCUBegin           # Size of the contribution in .debug_info.dwo
+    .long .LAbbrEnd-.LAbbrBegin       # Size of the contribution in .debug_abbrev.dwo (Intentionally omitted)

--- a/llvm/test/DebugInfo/X86/invalid-cu-abbrev-contribution-dwp.s
+++ b/llvm/test/DebugInfo/X86/invalid-cu-abbrev-contribution-dwp.s
@@ -1,7 +1,7 @@
 # RUN: llvm-mc -triple x86_64-unknown-linux %s -filetype=obj -o - | \
 # RUN:   llvm-dwarfdump -debug-info - 2>&1 | FileCheck %s
 
-# CHECK: warning: DWARF package unit at offset 0x00000000 mising abbreviation column
+# CHECK: warning: DWARF package unit at offset 0x00000000 missing abbreviation column
 
     .section .debug_abbrev.dwo, "e", @progbits
 .LAbbrBegin:

--- a/llvm/test/DebugInfo/X86/invalid-cu-abbrev-offset-dwp.s
+++ b/llvm/test/DebugInfo/X86/invalid-cu-abbrev-offset-dwp.s
@@ -1,10 +1,7 @@
 # RUN: llvm-mc -triple x86_64-unknown-linux %s -filetype=obj -o - | \
 # RUN:   llvm-dwarfdump -debug-info - 2>&1 | FileCheck %s
 
-## llvm-dwarfdump used to crash with this input because of an invalid size
-## of the compilation unit contribution in the .debug_cu_index section.
-
-# CHECK: warning: DWARF package unit at offset 0x00000000 has an inconsistent index
+# CHECK: warning: DWARF package unit at offset 0x00000000 has a non-zero abbreviation offset
 
     .section .debug_abbrev.dwo, "e", @progbits
 .LAbbrBegin:
@@ -25,7 +22,7 @@
     .long .LCUEnd-.LCUVersion   # Length
 .LCUVersion:
     .short 4                    # Version
-    .long 0                     # Abbrev offset
+    .long 1                     # Abbrev offset (Invalid, should be 0)
     .byte 4                     # Address size
     .uleb128 1                  # Abbrev [1] DW_TAG_compile_unit
     .asciz "a.c"                # DW_AT_name
@@ -57,5 +54,5 @@
     .long .LCUBegin-.debug_info.dwo     # Offset in .debug_info.dwo
     .long .LAbbrBegin-.debug_abbrev.dwo # Offset in .debug_abbrev.dwo
 ## Table of Section Sizes:
-    .long .LCUEnd-.LCUBegin-1           # Size of the contribution in .debug_info.dwo (invalid)
+    .long .LCUEnd-.LCUBegin
     .long .LAbbrEnd-.LAbbrBegin

--- a/llvm/test/DebugInfo/X86/invalid-cu-length-dwp.s
+++ b/llvm/test/DebugInfo/X86/invalid-cu-length-dwp.s
@@ -4,7 +4,7 @@
 ## llvm-dwarfdump used to crash with this input because of an invalid size
 ## of the compilation unit contribution in the .debug_cu_index section.
 
-# CHECK: warning: DWARF package unit at offset 0x00000000 has an inconsistent index
+# CHECK: warning: DWARF package unit at offset 0x00000000 has an inconsistent index (expected: 23, actual: 24)
 
     .section .debug_abbrev.dwo, "e", @progbits
 .LAbbrBegin:


### PR DESCRIPTION
Motivation: LLDB is able to report errors about these scenarios whereas LLVM's DWARF parser only gives a boolean success/fail. I want to migrate LLDB to using LLVM's DWARFUnitHeader class, but I don't want to lose some of the error reporting, so I'm adding it to the LLVM class first.