### PR TITLE
[clang] Migrate clang-rename to OptTable parsing

### DIFF
--- a/clang/include/clang/Tooling/CommonOptionsParser.h
+++ b/clang/include/clang/Tooling/CommonOptionsParser.h
@@ -86,6 +86,24 @@ public:
          llvm::cl::NumOccurrencesFlag OccurrencesFlag = llvm::cl::OneOrMore,
          const char *Overview = nullptr);
 
+  struct Args {
+    std::string BuildPath;
+    std::vector<std::string> SourcePaths;
+    std::vector<std::string> ArgsAfter;
+    std::vector<std::string> ArgsBefore;
+  };
+
+  using ArgParserCallback =
+      std::function<llvm::Expected<Args>(int &argc, const char **argv)>;
+
+  /// A factory method that is similar to the above factory method, except
+  /// this does not force use of cl::opt argument parsing. The function passed
+  /// in is expected to handle argument parsing, and must return values needed
+  /// by CommonOptionsParser.
+  static llvm::Expected<CommonOptionsParser>
+  create(int &argc, const char **argv, ArgParserCallback ArgsCallback,
+         llvm::cl::NumOccurrencesFlag OccurrencesFlag = llvm::cl::OneOrMore);
+
   /// Returns a reference to the loaded compilations database.
   CompilationDatabase &getCompilations() {
     return *Compilations;
@@ -105,10 +123,9 @@ public:
 private:
   CommonOptionsParser() = default;
 
-  llvm::Error init(int &argc, const char **argv,
-                   llvm::cl::OptionCategory &Category,
-                   llvm::cl::NumOccurrencesFlag OccurrencesFlag,
-                   const char *Overview);
+  llvm::Error
+  init(int &argc, const char **argv, ArgParserCallback ArgsCallback,
+       llvm::cl::NumOccurrencesFlag OccurrencesFlag = llvm::cl::OneOrMore);
 
   std::unique_ptr<CompilationDatabase> Compilations;
   std::vector<std::string> SourcePathList;

--- a/clang/include/clang/Tooling/CommonOptionsParser.td
+++ b/clang/include/clang/Tooling/CommonOptionsParser.td
@@ -1,0 +1,14 @@
+include "llvm/Option/OptParser.td"
+
+multiclass Eq<string name, string help> {
+  def NAME#_EQ : Joined<["--", "-"], name#"=">, HelpText<help>;
+  def : Separate<["--", "-"], name>, Alias<!cast<Joined>(NAME#_EQ)>;
+}
+
+defm build_path : Eq<"p", "Build path.">;
+defm extra_arg
+    : Eq<"extra-arg",
+         "Additional argument to append to the compiler command line.">;
+defm extra_arg_before
+    : Eq<"extra-arg-before",
+         "Additional argument to prepend to the compiler command line.">;

--- a/clang/tools/clang-rename/CMakeLists.txt
+++ b/clang/tools/clang-rename/CMakeLists.txt
@@ -3,8 +3,15 @@ set(LLVM_LINK_COMPONENTS
   Support
   )
 
+set(LLVM_TARGET_DEFINITIONS Opts.td)
+tablegen(LLVM Opts.inc -gen-opt-parser-defs)
+add_public_tablegen_target(ClangRenameOptsTableGen)
+
 add_clang_tool(clang-rename
   ClangRename.cpp
+
+  DEPENDS
+  ClangRenameOptsTableGen
   )
 
 clang_target_link_libraries(clang-rename

--- a/clang/tools/clang-rename/Opts.td
+++ b/clang/tools/clang-rename/Opts.td
@@ -1,0 +1,32 @@
+include "llvm/Option/OptParser.td"
+include "clang/Tooling/CommonOptionsParser.td"
+
+class F<string name, string help> : Flag<["--", "-"], name>, HelpText<help>;
+class Short<string name, string help> : Flag<["--", "-"], name>, HelpText<help>;
+
+def help : Flag<["--"], "help">, HelpText<"Display this help">;
+def version : Flag<["--"], "version">, HelpText<"Display the version">;
+
+defm offset : Eq<"offset",
+                 "Locates the symbol by offset as opposed to <line>:<column>.">;
+
+def inplace : Flag<["-", "--"], "i">, HelpText<"Overwrite edited <file>s.">;
+
+defm qualified_name
+    : Eq<"qualified-name", "The fully qualified name of the symbol.">;
+
+defm new_name : Eq<"new-name", "The new name to change the symbol to.">;
+
+def print_name
+    : F<"pn", "Print the found symbol's name prior to renaming to stderr.">;
+
+def print_locations
+    : F<"pl", "Print the locations affected by renaming to stderr.">;
+
+defm export_fixes
+    : Eq<"export-fixes", "YAML file to store suggested fixes in.">,
+      MetaVarName<"<filename>">;
+
+defm input : Eq<"input", "YAML file to load oldname-newname pairs from.">;
+
+def force : F<"force", "Ignore nonexistent qualified names.">;

--- a/utils/bazel/llvm-project-overlay/clang/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/clang/BUILD.bazel
@@ -2544,16 +2544,33 @@ cc_binary(
     ],
 )
 
+gentbl(
+    name = "ClangRenameTableGen",
+    strip_include_prefix = "tools/clang-rename",
+    tbl_outs = [(
+        "-gen-opt-parser-defs",
+        "tools/clang-rename/Opts.inc",
+    )],
+    tblgen = "//llvm:llvm-tblgen",
+    td_file = "tools/clang-rename/Opts.td",
+    td_srcs = [
+        "//llvm:include/llvm/Option/OptParser.td",
+        "include/clang/Tooling/CommonOptionsParser.td",
+    ],
+)
+
 cc_binary(
     name = "clang-rename",
     srcs = glob(["tools/clang-rename/*.cpp"]),
     stamp = 0,
     deps = [
+        ":ClangRenameTableGen",
         ":basic",
         ":frontend",
         ":rewrite",
         ":tooling",
         ":tooling_refactoring",
+        "//llvm:Option",
         "//llvm:Support",
     ],
 )
@@ -2629,9 +2646,9 @@ cc_library(
         "lib/ExtractAPI/**/*.cpp",
     ]),
     hdrs = glob([
-       "include/clang/ExtractAPI/**/*.h",
+        "include/clang/ExtractAPI/**/*.h",
     ]) + [
-       "include/clang/ExtractAPI/APIRecords.inc",
+        "include/clang/ExtractAPI/APIRecords.inc",
     ],
     includes = ["include"],
     deps = [


### PR DESCRIPTION
Using OptTable to parse will allow including this tool in llvm-driver.

Because CommonOptionsParser is widely used and makes use of `cl::opt` flags, it needs to be refactored to handle both. The existing `CommonOptionsParser::create()` method should continue to work for downstream users. An additional overload allows a general function to be passed in, which can do arg parsing however it likes, as long as it returns the fields that CommonOptionsParser needs.

Many other simple `clang-*` tools can be similarly migrated after this.