### PR TITLE
[AsmParser] Support calling intrinsics without mangling suffix

### DIFF
--- a/llvm/include/llvm/IR/Intrinsics.h
+++ b/llvm/include/llvm/IR/Intrinsics.h
@@ -235,7 +235,12 @@ namespace Intrinsic {
   /// specified by the .td file. The overloaded types are pushed into the
   /// AgTys vector.
   ///
-  /// Returns false if the given function is not a valid intrinsic call.
+  /// Returns false if the given ID and function type combination is not a
+  /// valid intrinsic call.
+  bool getIntrinsicSignature(Intrinsic::ID, FunctionType *FT,
+                             SmallVectorImpl<Type *> &ArgTys);
+
+  /// Same as previous, but accepts a Function instead of ID and FunctionType.
   bool getIntrinsicSignature(Function *F, SmallVectorImpl<Type *> &ArgTys);
 
   // Checks if the intrinsic name matches with its signature and if not

--- a/llvm/lib/IR/Function.cpp
+++ b/llvm/lib/IR/Function.cpp
@@ -1742,9 +1742,8 @@ Intrinsic::matchIntrinsicVarArg(bool isVarArg,
   return true;
 }
 
-bool Intrinsic::getIntrinsicSignature(Function *F,
+bool Intrinsic::getIntrinsicSignature(Intrinsic::ID ID, FunctionType *FT,
                                       SmallVectorImpl<Type *> &ArgTys) {
-  Intrinsic::ID ID = F->getIntrinsicID();
   if (!ID)
     return false;
 
@@ -1752,15 +1751,19 @@ bool Intrinsic::getIntrinsicSignature(Function *F,
   getIntrinsicInfoTableEntries(ID, Table);
   ArrayRef<Intrinsic::IITDescriptor> TableRef = Table;
 
-  if (Intrinsic::matchIntrinsicSignature(F->getFunctionType(), TableRef,
-                                         ArgTys) !=
+  if (Intrinsic::matchIntrinsicSignature(FT, TableRef, ArgTys) !=
       Intrinsic::MatchIntrinsicTypesResult::MatchIntrinsicTypes_Match) {
     return false;
   }
-  if (Intrinsic::matchIntrinsicVarArg(F->getFunctionType()->isVarArg(),
-                                      TableRef))
+  if (Intrinsic::matchIntrinsicVarArg(FT->isVarArg(), TableRef))
     return false;
   return true;
+}
+
+bool Intrinsic::getIntrinsicSignature(Function *F,
+                                      SmallVectorImpl<Type *> &ArgTys) {
+  return getIntrinsicSignature(F->getIntrinsicID(), F->getFunctionType(),
+                               ArgTys);
 }
 
 std::optional<Function *> Intrinsic::remangleIntrinsicFunction(Function *F) {

--- a/llvm/test/Assembler/implicit-intrinsic-declaration-invalid.ll
+++ b/llvm/test/Assembler/implicit-intrinsic-declaration-invalid.ll
@@ -1,11 +1,10 @@
 ; RUN: not llvm-as < %s 2>&1 | FileCheck %s
 
-; Check that intrinsics do not get automatically declared if they are used
-; with different function types.
+; Use of intrinsic without mangling suffix and invalid signature should
+; be rejected.
 
-; CHECK: error: use of undefined value '@llvm.umax'
+; CHECK: error: invalid intrinsic signature
 define void @test() {
-  call i8 @llvm.umax(i8 0, i8 1)
-  call i16 @llvm.umax(i16 0, i16 1)
+  call i8 @llvm.umax(i8 0, i16 1)
   ret void
 }

--- a/llvm/test/Assembler/implicit-intrinsic-declaration-invalid2.ll
+++ b/llvm/test/Assembler/implicit-intrinsic-declaration-invalid2.ll
@@ -1,0 +1,11 @@
+; RUN: not llvm-as < %s 2>&1 | FileCheck %s
+
+; Use of intrinsic as non-callee should be rejected.
+
+; CHECK: error: intrinsic can only be used as callee
+define void @test() {
+  call void @foo(ptr @llvm.umax)
+  ret void
+}
+
+declare void @foo(ptr)

--- a/llvm/test/Assembler/implicit-intrinsic-declaration-invalid3.ll
+++ b/llvm/test/Assembler/implicit-intrinsic-declaration-invalid3.ll
@@ -1,0 +1,9 @@
+; RUN: not llvm-as < %s 2>&1 | FileCheck %s
+
+; Use of unknown intrinsic without declaration should be rejected.
+
+; CHECK: error: use of undefined value '@llvm.foobar'
+define void @test() {
+  call i8 @llvm.foobar(i8 0, i16 1)
+  ret void
+}

--- a/llvm/test/Assembler/implicit-intrinsic-declaration.ll
+++ b/llvm/test/Assembler/implicit-intrinsic-declaration.ll
@@ -2,10 +2,10 @@
 ; RUN: opt -S < %s | FileCheck %s
 ; RUN: opt -S -passes=instcombine < %s | FileCheck %s --check-prefix=INSTCOMBINE
 
-; llvm.umax is intentionally missing the mangling suffix here, to show that
-; this works fine with auto-upgrade.
-define i16 @test(i8 %x, i8 %y) {
-; CHECK-LABEL: define i16 @test(
+; Two of the llvm.umax calls are intentionally missing the mangling suffix here,
+; to show that it will be added automatically.
+define i32 @test(i8 %x, i8 %y) {
+; CHECK-LABEL: define i32 @test(
 ; CHECK-SAME: i8 [[X:%.*]], i8 [[Y:%.*]]) {
 ; CHECK-NEXT:    [[CMP:%.*]] = icmp sgt i8 [[X]], -1
 ; CHECK-NEXT:    call void @llvm.assume(i1 [[CMP]])
@@ -13,21 +13,27 @@ define i16 @test(i8 %x, i8 %y) {
 ; CHECK-NEXT:    [[X_EXT:%.*]] = zext i8 [[X]] to i16
 ; CHECK-NEXT:    [[Y_EXT:%.*]] = zext i8 [[Y]] to i16
 ; CHECK-NEXT:    [[MAX2:%.*]] = call i16 @llvm.umax.i16(i16 [[X_EXT]], i16 [[Y_EXT]])
-; CHECK-NEXT:    ret i16 [[MAX2]]
+; CHECK-NEXT:    [[X_EXT2:%.*]] = zext i8 [[X]] to i32
+; CHECK-NEXT:    [[Y_EXT2:%.*]] = zext i8 [[Y]] to i32
+; CHECK-NEXT:    [[MAX3:%.*]] = call i32 @llvm.umax.i32(i32 [[X_EXT2]], i32 [[Y_EXT2]])
+; CHECK-NEXT:    ret i32 [[MAX3]]
 ;
-; INSTCOMBINE-LABEL: define i16 @test(
+; INSTCOMBINE-LABEL: define i32 @test(
 ; INSTCOMBINE-SAME: i8 [[X:%.*]], i8 [[Y:%.*]]) {
 ; INSTCOMBINE-NEXT:    [[CMP:%.*]] = icmp sgt i8 [[X]], -1
 ; INSTCOMBINE-NEXT:    call void @llvm.assume(i1 [[CMP]])
 ; INSTCOMBINE-NEXT:    [[TMP1:%.*]] = call i8 @llvm.umax.i8(i8 [[X]], i8 [[Y]])
-; INSTCOMBINE-NEXT:    [[MAX2:%.*]] = zext i8 [[TMP1]] to i16
-; INSTCOMBINE-NEXT:    ret i16 [[MAX2]]
+; INSTCOMBINE-NEXT:    [[MAX3:%.*]] = zext i8 [[TMP1]] to i32
+; INSTCOMBINE-NEXT:    ret i32 [[MAX3]]
 ;
   %cmp = icmp sgt i8 %x, -1
   call void @llvm.assume(i1 %cmp)
   %max1 = call i8 @llvm.umax(i8 %x, i8 %y)
   %x.ext = zext i8 %x to i16
   %y.ext = zext i8 %y to i16
-  %max2 = call i16 @llvm.umax.i16(i16 %x.ext, i16 %y.ext)
-  ret i16 %max2
+  %max2 = call i16 @llvm.umax(i16 %x.ext, i16 %y.ext)
+  %x.ext2 = zext i8 %x to i32
+  %y.ext2 = zext i8 %y to i32
+  %max3 = call i32 @llvm.umax.i32(i32 %x.ext2, i32 %y.ext2)
+  ret i32 %max3
 }


### PR DESCRIPTION
This adds proper support for calling intrinsics without mangling suffix when parsing textual IR. This already worked (mostly by accident) when only a single mangling suffix was in use.

This patch extends support to the case where the intrinsic is used with multiple signatures, and as such multiple different intrinsic declarations have to be inserted. The final IR will have intrinsics with mangling suffix as usual.

Motivated by the discussion at:
https://discourse.llvm.org/t/recent-improvements-to-the-ir-parser/77366