### PR TITLE
[RISCV] Remove IsEABI from RISCVZC::getStackAdjBase.

### DIFF
--- a/llvm/lib/Target/RISCV/AsmParser/RISCVAsmParser.cpp
+++ b/llvm/lib/Target/RISCV/AsmParser/RISCVAsmParser.cpp
@@ -2596,9 +2596,8 @@ ParseStatus RISCVAsmParser::parseZcmpStackAdj(OperandVector &Operands,
   unsigned Spimm = 0;
   unsigned RlistVal = static_cast<RISCVOperand *>(Operands[1].get())->Rlist.Val;
 
-  bool IsEABI = isRVE();
   if (Negative != ExpectNegative ||
-      !RISCVZC::getSpimm(RlistVal, Spimm, StackAdjustment, isRV64(), IsEABI))
+      !RISCVZC::getSpimm(RlistVal, Spimm, StackAdjustment, isRV64()))
     return ParseStatus::NoMatch;
   Operands.push_back(RISCVOperand::createSpimm(Spimm << 4, S));
   getLexer().Lex();

--- a/llvm/lib/Target/RISCV/MCTargetDesc/RISCVBaseInfo.h
+++ b/llvm/lib/Target/RISCV/MCTargetDesc/RISCVBaseInfo.h
@@ -526,12 +526,9 @@ inline unsigned encodeRlist(MCRegister EndReg, bool IsRV32E = false) {
   }
 }
 
-inline static unsigned getStackAdjBase(unsigned RlistVal, bool IsRV64,
-                                       bool IsEABI) {
+inline static unsigned getStackAdjBase(unsigned RlistVal, bool IsRV64) {
   assert(RlistVal != RLISTENCODE::INVALID_RLIST &&
          "{ra, s0-s10} is not supported, s11 must be included.");
-  if (IsEABI)
-    return 16;
   if (!IsRV64) {
     switch (RlistVal) {
     case RLISTENCODE::RA:
@@ -578,10 +575,10 @@ inline static unsigned getStackAdjBase(unsigned RlistVal, bool IsRV64,
 }
 
 inline static bool getSpimm(unsigned RlistVal, unsigned &SpimmVal,
-                            int64_t StackAdjustment, bool IsRV64, bool IsEABI) {
+                            int64_t StackAdjustment, bool IsRV64) {
   if (RlistVal == RLISTENCODE::INVALID_RLIST)
     return false;
-  unsigned StackAdjBase = getStackAdjBase(RlistVal, IsRV64, IsEABI);
+  unsigned StackAdjBase = getStackAdjBase(RlistVal, IsRV64);
   StackAdjustment -= StackAdjBase;
   if (StackAdjustment % 16 != 0)
     return false;

--- a/llvm/lib/Target/RISCV/MCTargetDesc/RISCVInstPrinter.cpp
+++ b/llvm/lib/Target/RISCV/MCTargetDesc/RISCVInstPrinter.cpp
@@ -297,11 +297,10 @@ void RISCVInstPrinter::printStackAdj(const MCInst *MI, unsigned OpNo,
                                      bool Negate) {
   int64_t Imm = MI->getOperand(OpNo).getImm();
   bool IsRV64 = STI.hasFeature(RISCV::Feature64Bit);
-  bool IsEABI = STI.hasFeature(RISCV::FeatureRVE);
   int64_t StackAdj = 0;
   auto RlistVal = MI->getOperand(0).getImm();
   assert(RlistVal != 16 && "Incorrect rlist.");
-  auto Base = RISCVZC::getStackAdjBase(RlistVal, IsRV64, IsEABI);
+  auto Base = RISCVZC::getStackAdjBase(RlistVal, IsRV64);
   StackAdj = Imm + Base;
   assert((StackAdj >= Base && StackAdj <= Base + 48) &&
          "Incorrect stack adjust");

--- a/llvm/test/MC/RISCV/rv64e-zcmp-valid.s
+++ b/llvm/test/MC/RISCV/rv64e-zcmp-valid.s
@@ -1,0 +1,73 @@
+# RUN: llvm-mc %s -triple=riscv64 -mattr=zcmp,+e -riscv-no-aliases -show-encoding \
+# RUN:     | FileCheck -check-prefixes=CHECK-ASM,CHECK-ASM-AND-OBJ %s
+# RUN: llvm-mc -filetype=obj -triple=riscv64 -mattr=zcmp < %s \
+# RUN:     | llvm-objdump --mattr=-c,zcmp -M no-aliases -d -r - \
+# RUN:     | FileCheck --check-prefixes=CHECK-ASM-AND-OBJ %s
+
+# CHECK-ASM-AND-OBJ: cm.mvsa01 s1, s0
+# CHECK-ASM: encoding: [0xa2,0xac]
+cm.mvsa01 s1, s0
+
+# CHECK-ASM-AND-OBJ: cm.mva01s s1, s0
+# CHECK-ASM: encoding: [0xe2,0xac]
+cm.mva01s s1, s0
+
+# CHECK-ASM-AND-OBJ: cm.popret   {ra}, 16
+# CHECK-ASM: encoding: [0x42,0xbe]
+cm.popret {ra}, 16
+
+# CHECK-ASM-AND-OBJ: cm.popret   {ra}, 32
+# CHECK-ASM: encoding: [0x46,0xbe]
+cm.popret {ra}, 32
+
+# CHECK-ASM-AND-OBJ: cm.popret   {ra, s0}, 64
+# CHECK-ASM: encoding: [0x5e,0xbe]
+cm.popret {ra, s0}, 64
+
+# CHECK-ASM-AND-OBJ: cm.popret   {ra, s0-s1}, 32
+# CHECK-ASM: encoding: [0x66,0xbe]
+cm.popret {ra,s0-s1}, 32
+
+# CHECK-ASM-AND-OBJ: cm.popretz   {ra}, 16
+# CHECK-ASM: encoding: [0x42,0xbc]
+cm.popretz {ra}, 16
+
+# CHECK-ASM-AND-OBJ: cm.popretz   {ra}, 32
+# CHECK-ASM: encoding: [0x46,0xbc]
+cm.popretz {ra}, 32
+
+# CHECK-ASM-AND-OBJ: cm.popretz   {ra, s0}, 64
+# CHECK-ASM: encoding: [0x5e,0xbc]
+cm.popretz {ra, s0}, 64
+
+# CHECK-ASM-AND-OBJ: cm.popretz   {ra, s0-s1}, 32
+# CHECK-ASM: encoding: [0x66,0xbc]
+cm.popretz {ra, s0-s1}, 32
+
+# CHECK-ASM-AND-OBJ: cm.pop  {ra}, 16
+# CHECK-ASM: encoding: [0x42,0xba]
+cm.pop {ra}, 16
+
+# CHECK-ASM-AND-OBJ: cm.pop  {ra}, 32
+# CHECK-ASM: encoding: [0x46,0xba]
+cm.pop {ra}, 32
+
+# CHECK-ASM-AND-OBJ: cm.pop  {ra, s0}, 16
+# CHECK-ASM: encoding: [0x52,0xba]
+cm.pop {ra, s0}, 16
+
+# CHECK-ASM-AND-OBJ: cm.pop  {ra, s0-s1}, 32
+# CHECK-ASM: encoding: [0x66,0xba]
+cm.pop {ra, s0-s1}, 32
+
+# CHECK-ASM-AND-OBJ: cm.push {ra}, -16
+# CHECK-ASM: encoding: [0x42,0xb8]
+cm.push {ra}, -16
+
+# CHECK-ASM-AND-OBJ: cm.push {ra, s0}, -32
+# CHECK-ASM: encoding: [0x56,0xb8]
+cm.push {ra, s0}, -32
+
+# CHECK-ASM-AND-OBJ: cm.push {ra, s0-s1}, -32
+# CHECK-ASM: encoding: [0x66,0xb8]
+cm.push {ra, s0-s1}, -32

--- a/llvm/test/MC/RISCV/rv64e-zcmp-valid.s
+++ b/llvm/test/MC/RISCV/rv64e-zcmp-valid.s
@@ -25,7 +25,7 @@ cm.popret {ra}, 32
 cm.popret {ra, s0}, 64
 
 # CHECK-ASM-AND-OBJ: cm.popret   {ra, s0-s1}, 32
-# CHECK-ASM: encoding: [0x66,0xbe]
+# CHECK-ASM: encoding: [0x62,0xbe]
 cm.popret {ra,s0-s1}, 32
 
 # CHECK-ASM-AND-OBJ: cm.popretz   {ra}, 16
@@ -41,7 +41,7 @@ cm.popretz {ra}, 32
 cm.popretz {ra, s0}, 64
 
 # CHECK-ASM-AND-OBJ: cm.popretz   {ra, s0-s1}, 32
-# CHECK-ASM: encoding: [0x66,0xbc]
+# CHECK-ASM: encoding: [0x62,0xbc]
 cm.popretz {ra, s0-s1}, 32
 
 # CHECK-ASM-AND-OBJ: cm.pop  {ra}, 16
@@ -57,7 +57,7 @@ cm.pop {ra}, 32
 cm.pop {ra, s0}, 16
 
 # CHECK-ASM-AND-OBJ: cm.pop  {ra, s0-s1}, 32
-# CHECK-ASM: encoding: [0x66,0xba]
+# CHECK-ASM: encoding: [0x62,0xba]
 cm.pop {ra, s0-s1}, 32
 
 # CHECK-ASM-AND-OBJ: cm.push {ra}, -16
@@ -69,5 +69,5 @@ cm.push {ra}, -16
 cm.push {ra, s0}, -32
 
 # CHECK-ASM-AND-OBJ: cm.push {ra, s0-s1}, -32
-# CHECK-ASM: encoding: [0x66,0xb8]
+# CHECK-ASM: encoding: [0x62,0xb8]
 cm.push {ra, s0-s1}, -32


### PR DESCRIPTION
The usage of IsEABI was only valid for RV32E. For RV64E, the stack adjust
base needs to be 32 when ra,s0-s1 are being saved. Since it takes more
than 16 bytes to save 3 64-bit registers.
    
The spec lists the rv32e behavior explicitly, but not rv64e. My
assumption is that the only thing that changes with rv64e is which
registers can be used in the register list, not how the register
list affects the stack_adj_base.