### PR TITLE
[SPIR-V] SPIR-V Backend must generate a valid OCL version if working in OpenCL environment

### DIFF
--- a/llvm/test/CodeGen/SPIRV/empty-module.ll
+++ b/llvm/test/CodeGen/SPIRV/empty-module.ll
@@ -1,9 +1,15 @@
-; RUN: llc -O0 -mtriple=spirv64-unknown-unknown %s -o - | FileCheck %s
+; RUN: llc -O0 -mtriple=spirv64-unknown-unknown %s -o - | FileCheck %s --check-prefixes=CHECK,CHECK-OCL
 ; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv64-unknown-unknown %s -o - -filetype=obj | spirv-val %}
 
-; CHECK-DAG: OpCapability Addresses
-; CHECK-DAG: OpCapability Linkage
-; CHECK-DAG: OpCapability Kernel
-; CHECK:     %1 = OpExtInstImport "OpenCL.std"
-; CHECK:     OpMemoryModel Physical64 OpenCL
-; CHECK:     OpSource Unknown 0
+; RUN: llc -O0 -mtriple=spirv-unknown-unknown %s -o - | FileCheck %s --check-prefixes=CHECK,CHECK-NOOCL
+; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv-unknown-unknown %s -o - -filetype=obj | spirv-val %}
+
+; CHECK-DAG:        OpCapability Linkage
+; CHECK-NOOCL-DAG:  OpCapability Shader
+; CHECK-OCL-DAG:      OpCapability Addresses
+; CHECK-OCL-DAG:      OpCapability Kernel
+; CHECK-OCL:          %1 = OpExtInstImport "OpenCL.std"
+; CHECK-NOOCL:      OpMemoryModel Logical GLSL450
+; CHECK-OCL:          OpMemoryModel Physical64 OpenCL
+; CHECK-NOOCL:      OpSource Unknown 0
+; CHECK-OCL:          OpSource OpenCL_CPP 100000


### PR DESCRIPTION
If there is no information about OpenCL version we are forced to generate OpenCL 1.0 by default for the OpenCL environment to avoid puzzling run-times with Unknown/0.0 version output. For a reference, LLVM-SPIRV Translator avoids potential issues with run-times in a similar manner.