### PR TITLE
[mlir][scf] `scf.while` uplifting: Add preparation patterns.

### DIFF
--- a/mlir/include/mlir/Dialect/SCF/Transforms/Patterns.h
+++ b/mlir/include/mlir/Dialect/SCF/Transforms/Patterns.h
@@ -79,6 +79,10 @@ void populateSCFLoopPipeliningPatterns(RewritePatternSet &patterns,
 /// loop bounds and loop steps are canonicalized.
 void populateSCFForLoopCanonicalizationPatterns(RewritePatternSet &patterns);
 
+/// Populate patterns to prepare scf.while loops for upliting, e.g. for before
+/// block cleanup.
+void populatePrepareUpliftWhileToForPatterns(RewritePatternSet &patterns);
+
 /// Populate patterns to uplift `scf.while` ops to `scf.for`.
 /// Uplifitng expects a specific ops pattern:
 ///  * `before` block consisting of single arith.cmp op

--- a/mlir/test/Dialect/SCF/uplift-while-prepare.mlir
+++ b/mlir/test/Dialect/SCF/uplift-while-prepare.mlir
@@ -1,0 +1,74 @@
+// RUN: mlir-opt %s -pass-pipeline='builtin.module(func.func(test-scf-prepare-uplift-while-to-for))' -split-input-file -allow-unregistered-dialect | FileCheck %s
+
+// CHECK-LABEL: func.func @test()
+//       CHECK:  scf.while
+//   CHECK-NOT:  "test.test1"
+//       CHECK:  scf.condition(%{{.*}})
+//       CHECK:  } do {
+//       CHECK:  "test.test1"() : () -> ()
+//       CHECK:  "test.test2"() : () -> ()
+//       CHECK:  scf.yield
+//       CHECK:  "test.test1"() : () -> ()
+//       CHECK:  return
+func.func @test() {
+  scf.while () : () -> () {
+    %1 = "test.cond"() : () -> i1
+    "test.test1"() : () -> ()
+    scf.condition(%1)
+  } do {
+  ^bb0():
+    "test.test2"() : () -> ()
+    scf.yield
+  }
+  return
+}
+
+// -----
+
+// CHECK-LABEL: func.func @test()
+//       CHECK:  scf.while
+//   CHECK-NOT:  "test.test1"
+//       CHECK:  scf.condition(%{{.*}})
+//       CHECK:  } do {
+//       CHECK:  %[[R1:.*]]:2 = "test.test1"() : () -> (i32, i64)
+//       CHECK:  "test.test2"(%[[R1]]#1, %[[R1]]#0) : (i64, i32) -> ()
+//       CHECK:  scf.yield
+//       CHECK:  %[[R2:.*]]:2 = "test.test1"() : () -> (i32, i64)
+//       CHECK:  return %[[R2]]#1, %[[R2]]#0 : i64, i32
+func.func @test() -> (i64, i32) {
+  %0:2 = scf.while () : () -> (i64, i32) {
+    %1 = "test.cond"() : () -> i1
+    %2:2 = "test.test1"() : () -> (i32, i64)
+    scf.condition(%1) %2#1, %2#0 : i64, i32
+  } do {
+  ^bb0(%arg1: i64, %arg2: i32):
+    "test.test2"(%arg1, %arg2) : (i64, i32) -> ()
+    scf.yield
+  }
+  return %0#0, %0#1 : i64, i32
+}
+
+// -----
+
+// CHECK-LABEL: func.func @test
+//  CHECK-SAME:  (%[[ARG0:.*]]: index)
+//       CHECK:  %[[RES:.*]] = scf.while (%[[ARG1:.*]] = %[[ARG0]]) : (index) -> index {
+//   CHECK-NOT:  arith.addi
+//       CHECK:  scf.condition(%{{.*}}) %[[ARG1]] : index
+//       CHECK:  } do {
+//       CHECK:  ^bb0(%[[ARG2:.*]]: index):
+//       CHECK:  %[[A1:.*]] = arith.addi %[[ARG0]], %[[ARG2]] : index
+//       CHECK:  scf.yield %[[A1]]
+//       CHECK:  %[[A2:.*]] = arith.addi %[[ARG0]], %[[RES]] : index
+//       CHECK:  return %[[A2]]
+func.func @test(%arg0: index) -> index {
+  %res = scf.while (%arg1 = %arg0) : (index) -> (index) {
+    %0 = arith.addi %arg0, %arg1 : index
+    %1 = "test.cond"() : () -> i1
+    scf.condition(%1) %0 : index
+  } do {
+  ^bb0(%arg2: index):
+    scf.yield %arg2 : index
+  }
+  return %res : index
+}

--- a/mlir/test/lib/Dialect/SCF/TestUpliftWhileToFor.cpp
+++ b/mlir/test/lib/Dialect/SCF/TestUpliftWhileToFor.cpp
@@ -19,6 +19,28 @@ using namespace mlir;
 
 namespace {
 
+struct TestSCFPrepareUpliftWhileToFor
+    : public PassWrapper<TestSCFPrepareUpliftWhileToFor, OperationPass<void>> {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(TestSCFPrepareUpliftWhileToFor)
+
+  StringRef getArgument() const final {
+    return "test-scf-prepare-uplift-while-to-for";
+  }
+
+  StringRef getDescription() const final {
+    return "test scf while to for uplifting preparation";
+  }
+
+  void runOnOperation() override {
+    Operation *op = getOperation();
+    MLIRContext *ctx = op->getContext();
+    RewritePatternSet patterns(ctx);
+    scf::populatePrepareUpliftWhileToForPatterns(patterns);
+    if (failed(applyPatternsAndFoldGreedily(op, std::move(patterns))))
+      signalPassFailure();
+  }
+};
+
 struct TestSCFUpliftWhileToFor
     : public PassWrapper<TestSCFUpliftWhileToFor, OperationPass<void>> {
   MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(TestSCFUpliftWhileToFor)
@@ -44,6 +66,7 @@ struct TestSCFUpliftWhileToFor
 namespace mlir {
 namespace test {
 void registerTestSCFUpliftWhileToFor() {
+  PassRegistration<TestSCFPrepareUpliftWhileToFor>();
   PassRegistration<TestSCFUpliftWhileToFor>();
 }
 } // namespace test


### PR DESCRIPTION
`scf.while` -> `scf.for` uplifting expects `before` block consisting of single cmp op, so we need to cleanup it before running the uplifting. One of the possible cleanups is LICM.
Second one is moving and duplicating ops from `before` block to `after` block and after the loop. Add the pattern for such transformation.