### PR TITLE
[clang] Fix a "!CodeSynthesisContexts.empty()" assertion failure when constructing aggregate deduction guides.

### DIFF
--- a/clang/lib/Sema/SemaTemplate.cpp
+++ b/clang/lib/Sema/SemaTemplate.cpp
@@ -3044,8 +3044,8 @@ FunctionTemplateDecl *DeclareAggregateDeductionGuideForTypeAlias(
 
   LocalInstantiationScope Scope(SemaRef);
   Sema::InstantiatingTemplate BuildingDeductionGuides(
-        SemaRef, AliasTemplate->getLocation(), RHSDeductionGuide,
-        Sema::InstantiatingTemplate::BuildingDeductionGuidesTag{});
+      SemaRef, AliasTemplate->getLocation(), RHSDeductionGuide,
+      Sema::InstantiatingTemplate::BuildingDeductionGuidesTag{});
   if (BuildingDeductionGuides.isInvalid())
     return nullptr;
 

--- a/clang/lib/Sema/SemaTemplate.cpp
+++ b/clang/lib/Sema/SemaTemplate.cpp
@@ -3043,6 +3043,11 @@ FunctionTemplateDecl *DeclareAggregateDeductionGuideForTypeAlias(
     return nullptr;
 
   LocalInstantiationScope Scope(SemaRef);
+  Sema::InstantiatingTemplate BuildingDeductionGuides(
+        SemaRef, AliasTemplate->getLocation(), RHSDeductionGuide,
+        Sema::InstantiatingTemplate::BuildingDeductionGuidesTag{});
+  if (BuildingDeductionGuides.isInvalid())
+    return nullptr;
 
   // Build a new template parameter list for the synthesized aggregate deduction
   // guide by transforming the one from RHSDeductionGuide.

--- a/clang/test/SemaCXX/cxx20-ctad-type-alias.cpp
+++ b/clang/test/SemaCXX/cxx20-ctad-type-alias.cpp
@@ -279,3 +279,13 @@ Bar t = Foo<K<Container>>();
 
 Bar s = 1; // expected-error {{no viable constructor or deduction guide for deduction of template arguments of}}
 } // namespace test20
+
+namespace test21 {
+template <typename T, unsigned N>
+struct Array { const T member[N]; };
+template <unsigned N>
+using String = Array<char, N>;
+
+// Verify no crash on constructing the aggregate deduction guides.
+String s("hello");
+} // namespace test21


### PR DESCRIPTION
We were missing to push an record to the instantiation stack in `DeclareAggregateDeductionGuideForTypeAlias`.  This patch fixes that.