### PR TITLE
[clang-format] Remove YAML hack to emit a BasedOnStyle comment

### DIFF
--- a/clang/lib/Format/Format.cpp
+++ b/clang/lib/Format/Format.cpp
@@ -807,12 +807,18 @@ template <> struct MappingTraits<FormatStyle> {
         FormatStyle PredefinedStyle;
         if (getPredefinedStyle(StyleName, Style.Language, &PredefinedStyle) &&
             Style == PredefinedStyle) {
-          IO.mapOptional("# BasedOnStyle", StyleName);
+          // For convenience, emit the info which style this matches. However,
+          // setting BasedOnStyle will override all other keys when importing,
+          // so we set a helper key that is ignored when importing.
+          // Ideally, we'd want a YAML comment here, but that's not supported.
+          IO.mapOptional("OrigBasedOnStyle", StyleName);
           BasedOnStyle = StyleName;
           break;
         }
       }
     } else {
+      StringRef OrigBasedOnStyle; // ignored
+      IO.mapOptional("OrigBasedOnStyle", OrigBasedOnStyle);
       IO.mapOptional("BasedOnStyle", BasedOnStyle);
       if (!BasedOnStyle.empty()) {
         FormatStyle::LanguageKind OldLanguage = Style.Language;

--- a/clang/lib/Format/Format.cpp
+++ b/clang/lib/Format/Format.cpp
@@ -807,18 +807,11 @@ template <> struct MappingTraits<FormatStyle> {
         FormatStyle PredefinedStyle;
         if (getPredefinedStyle(StyleName, Style.Language, &PredefinedStyle) &&
             Style == PredefinedStyle) {
-          // For convenience, emit the info which style this matches. However,
-          // setting BasedOnStyle will override all other keys when importing,
-          // so we set a helper key that is ignored when importing.
-          // Ideally, we'd want a YAML comment here, but that's not supported.
-          IO.mapOptional("OrigBasedOnStyle", StyleName);
           BasedOnStyle = StyleName;
           break;
         }
       }
     } else {
-      StringRef OrigBasedOnStyle; // ignored
-      IO.mapOptional("OrigBasedOnStyle", OrigBasedOnStyle);
       IO.mapOptional("BasedOnStyle", BasedOnStyle);
       if (!BasedOnStyle.empty()) {
         FormatStyle::LanguageKind OldLanguage = Style.Language;


### PR DESCRIPTION
When serializing a formatting style to YAML, we were emitting a comment `# BasedOnStyle: <style>` if the serialized formatting style matches one of the known styles. This is useful, but mis-uses the YAML API.

An upcoming change to fix keys with special characters by quoting them breaks this, 
and will emit a non-comment **key** `'# BasedOnStyle': <style>` instead.
(https://github.com/llvm/llvm-project/pull/88763)

Thus, remove this hack.
Instead, we emit an ordinary key OrigBasedOnStyle that is ignored when reading back the data. 
An alternative would be to just remove it completely.

Ideally, we'd emit a proper comment, but our YAML API doesn't support that.