### PR TITLE
CompilerRT: Normalize COMPILER_RT_DEFAULT_TARGET_TRIPLE

### DIFF
--- a/compiler-rt/cmake/Modules/CompilerRTUtils.cmake
+++ b/compiler-rt/cmake/Modules/CompilerRTUtils.cmake
@@ -368,6 +368,12 @@ macro(construct_compiler_rt_default_triple)
           "Default triple for which compiler-rt runtimes will be built.")
   endif()
 
+  if ("${CMAKE_C_COMPILER_ID}" MATCHES "Clang")
+    execute_process(COMMAND ${CMAKE_C_COMPILER} --target=${COMPILER_RT_DEFAULT_TARGET_TRIPLE} -print-target-triple
+                    OUTPUT_VARIABLE COMPILER_RT_DEFAULT_TARGET_TRIPLE
+                    OUTPUT_STRIP_TRAILING_WHITESPACE)
+  endif()
+
   string(REPLACE "-" ";" LLVM_TARGET_TRIPLE_LIST ${COMPILER_RT_DEFAULT_TARGET_TRIPLE})
   list(GET LLVM_TARGET_TRIPLE_LIST 0 COMPILER_RT_DEFAULT_TARGET_ARCH)
 

--- a/libcxx/utils/ci/run-buildbot
+++ b/libcxx/utils/ci/run-buildbot
@@ -217,7 +217,7 @@ function test-armv7m-picolibc() {
         "${@}"
 
     ${NINJA} -vC "${BUILD_DIR}/compiler-rt" install
-    mv "${BUILD_DIR}/install/lib/armv7m-none-eabi"/* "${BUILD_DIR}/install/lib"
+    mv "${BUILD_DIR}/install/lib/armv7m-none-unknown-eabi"/* "${BUILD_DIR}/install/lib"
 
     check-runtimes
 }


### PR DESCRIPTION
If LLVM is configured with -DLLVM_DEFAULT_TARGET_TRIPLE, or compiler_rt is configured with -DCOMPILER_RT_DEFAULT_TARGET_TRIPLE, while the argument is not normalized, such as Debian-style vendor-less triple, clang will try to find libclang_rt in lib/<normalized_triple>, while libclang_rt is placed into lib/<triple_arg>.

Let's also place libclang_rt into lib/<normalized_triple>.
`libcxx/utils/ci/run-buildbot` is also updated to use `armv7m-none-unknown-eabi` as normalized triple instead of
current `armv7m-none-eabi`.

ChangeLog of this PR:
This patch has been applied and revert twice:
1. The first try is https://github.com/llvm/llvm-project/pull/88407, and then it is found that it causes some CI failures.
    https://lab.llvm.org/buildbot/#/builders/98/builds/36366
    It is then resolved by another commit: https://github.com/llvm/llvm-project/commit/1693009679313282afbed38778dd3fad62641e1b

    https://lab.llvm.org/buildbot/#/builders/77/builds/36372
    It is caused that `COMPILER_RT_DEFAULT_TARGET_TRIPLE` is overwrite without taking care about `CACHE`.

2. The second try https://github.com/llvm/llvm-project/pull/88835,
     resolves https://lab.llvm.org/buildbot/#/builders/77/builds/36372
     and in fact only one `execute_process` is needed.

Then we find some other CI failures. 
https://github.com/mstorsjo/llvm-mingw/actions/runs/8730621159
https://buildkite.com/llvm-project/libcxx-ci/builds/34897#018eec06-612c-47f1-9931-d3bd88bf7ced

It is due to misunderstanding `-print-effective-triple`: which will output `thumbv7-w64-windows-gnu` for `armv7-w64-windows-gnu` or some other thumb-enabled arm triples.
In fact we should use `-print-target-triple`.

For armv7m-picolibc, `armv7m-none-eabi` is hardcoded in libcxx/utils/ci/run-buildbot, while in fact `armv7m-none-unknown-eabi` is the real normalized triple.
