### PR TITLE
Sync FuchsiaConfig with downstream's custom_scudo_config.h

### DIFF
--- a/compiler-rt/lib/scudo/standalone/allocator_config.h
+++ b/compiler-rt/lib/scudo/standalone/allocator_config.h
@@ -146,9 +146,11 @@ struct FuchsiaConfig {
     // Support 39-bit VMA for riscv-64
     static const uptr RegionSizeLog = 28U;
     static const uptr GroupSizeLog = 19U;
+    static const bool EnableContiguousRegions = false;
 #else
     static const uptr RegionSizeLog = 30U;
     static const uptr GroupSizeLog = 21U;
+    static const bool EnableContiguousRegions = true;
 #endif
     typedef u32 CompactPtrT;
     static const bool EnableRandomOffset = true;

--- a/compiler-rt/lib/scudo/standalone/allocator_config.h
+++ b/compiler-rt/lib/scudo/standalone/allocator_config.h
@@ -150,7 +150,6 @@ struct FuchsiaConfig {
 #else
     static const uptr RegionSizeLog = 30U;
     static const uptr GroupSizeLog = 21U;
-    static const bool EnableContiguousRegions = true;
 #endif
     typedef u32 CompactPtrT;
     static const bool EnableRandomOffset = true;


### PR DESCRIPTION
Downstream disabled EnableContiguousRegions on RISCV-64 to avoid
running out of virtual memory, but our tests still use the internal
FuchsiaConfig class, which therefore needs to be changed too.
