### PR TITLE
[libc][test] adds LINK_LIBRARIES pthread to pthreads test cmake

### DIFF
--- a/libc/test/src/pthread/CMakeLists.txt
+++ b/libc/test/src/pthread/CMakeLists.txt
@@ -19,8 +19,6 @@ add_libc_unittest(
     libc.src.pthread.pthread_attr_setguardsize
     libc.src.pthread.pthread_attr_setstacksize
     libc.src.pthread.pthread_attr_setstack
-  LINK_LIBRARIES
-    -lpthread
 )
 
 add_libc_unittest(
@@ -40,8 +38,6 @@ add_libc_unittest(
     libc.src.pthread.pthread_mutexattr_setpshared
     libc.src.pthread.pthread_mutexattr_setrobust
     libc.src.pthread.pthread_mutexattr_settype
-  LINK_LIBRARIES
-    -pthread
 )
 
 add_libc_unittest(

--- a/libc/test/src/pthread/CMakeLists.txt
+++ b/libc/test/src/pthread/CMakeLists.txt
@@ -19,6 +19,8 @@ add_libc_unittest(
     libc.src.pthread.pthread_attr_setguardsize
     libc.src.pthread.pthread_attr_setstacksize
     libc.src.pthread.pthread_attr_setstack
+  LINK_LIBRARIES
+    -lpthread
 )
 
 add_libc_unittest(
@@ -38,6 +40,8 @@ add_libc_unittest(
     libc.src.pthread.pthread_mutexattr_setpshared
     libc.src.pthread.pthread_mutexattr_setrobust
     libc.src.pthread.pthread_mutexattr_settype
+  LINK_LIBRARIES
+    -pthread
 )
 
 add_libc_unittest(
@@ -56,4 +60,6 @@ add_libc_unittest(
     libc.src.pthread.pthread_condattr_init
     libc.src.pthread.pthread_condattr_setclock
     libc.src.pthread.pthread_condattr_setpshared
+  LINK_LIBRARIES
+    -pthread
   )


### PR DESCRIPTION
Fixes #89261.

cc @nickdesaulniers 

fixes this for me. seems like others might not have the same issue, so lmk if i'm just building this wrong.