### PR TITLE
Revert "NFC: Make clang resource headers an interface library (#88317)"

### DIFF
--- a/clang/lib/Headers/CMakeLists.txt
+++ b/clang/lib/Headers/CMakeLists.txt
@@ -437,14 +437,14 @@ foreach( f ${generated_files} )
 endforeach( f )
 
 function(add_header_target target_name file_list)
-  add_library(${target_name} INTERFACE ${file_list})
+  add_custom_target(${target_name} DEPENDS ${file_list})
   set_target_properties(${target_name} PROPERTIES
     FOLDER "Misc"
     RUNTIME_OUTPUT_DIRECTORY "${output_dir}")
 endfunction()
 
 # The catch-all clang-resource-headers target
-add_library(clang-resource-headers INTERFACE ${out_files})
+add_custom_target("clang-resource-headers" ALL DEPENDS ${out_files})
 set_target_properties("clang-resource-headers" PROPERTIES
   FOLDER "Misc"
   RUNTIME_OUTPUT_DIRECTORY "${output_dir}")
@@ -501,10 +501,6 @@ add_header_target("windows-resource-headers" ${windows_only_files})
 add_header_target("utility-resource-headers" ${utility_files})
 
 get_clang_resource_dir(header_install_dir SUBDIR include)
-target_include_directories(clang-resource-headers INTERFACE
-  $<BUILD_INTERFACE:${output_dir}>
-  $<INSTALL_INTERFACE:${header_install_dir}>)
-set_property(GLOBAL APPEND PROPERTY CLANG_EXPORTS clang-resource-headers)
 
 #############################################################
 # Install rules for the catch-all clang-resource-headers target

--- a/lldb/cmake/modules/LLDBFramework.cmake
+++ b/lldb/cmake/modules/LLDBFramework.cmake
@@ -119,7 +119,7 @@ add_custom_command(TARGET liblldb POST_BUILD
 if(NOT APPLE_EMBEDDED)
   if (TARGET clang-resource-headers)
     add_dependencies(liblldb clang-resource-headers)
-    set(clang_resource_headers_dir $<TARGET_PROPERTY:clang-resource-headers,INTERFACE_INCLUDE_DIRECTORIES>)
+    set(clang_resource_headers_dir $<TARGET_PROPERTY:clang-resource-headers,RUNTIME_OUTPUT_DIRECTORY>)
   else()
     set(clang_resource_headers_dir ${LLDB_EXTERNAL_CLANG_RESOURCE_DIR}/include)
     if(NOT EXISTS ${clang_resource_headers_dir})


### PR DESCRIPTION
This reverts commit 8d468c132eed7ffe34d601b224220efd51655eb3.

@ayermolo reports seeing the following error when the clang-resource-headers are a library instead of a custom target:
```
CMake Error at CMakeLists.txt:86 (get_property):
  get_property could not find TARGET clang-resource-headers.  Perhaps it has
  not yet been created.
```
I don't see this line in the LLVM repository, and I'm not sure how it worked as a custom target since this change doesn't affect whether or not the CMake target is generated, nor does it impact the order that targets are created in. 