### PR TITLE
[Clang] Add support for -rpath on AIX

### DIFF
--- a/clang/lib/Driver/ToolChains/CommonArgs.cpp
+++ b/clang/lib/Driver/ToolChains/CommonArgs.cpp
@@ -436,6 +436,10 @@ void tools::AddLinkerInputs(const ToolChain &TC, const InputInfoList &Inputs,
       TC.AddCXXStdlibLibArgs(Args, CmdArgs);
     else if (A.getOption().matches(options::OPT_Z_reserved_lib_cckext))
       TC.AddCCKextLibArgs(Args, CmdArgs);
+    // Do not pass OPT_rpath to linker in AIX
+    else if (A.getOption().matches(options::OPT_rpath) &&
+             TC.getTriple().isOSAIX())
+      continue;
     else
       A.renderAsInput(Args, CmdArgs);
   }

--- a/clang/test/Driver/aix-rpath.c
+++ b/clang/test/Driver/aix-rpath.c
@@ -1,0 +1,41 @@
+// Test -R passing search directories to the linker
+// RUN: %clang %s -rpath /dir1/ -rpath /dir2/ -### 2>&1  --target=powerpc-ibm-aix | FileCheck %s
+// RUN: %clang %s -rpath /dir1/ -rpath /dir2/ -### 2>&1  --target=powerpc64-ibm-aix | FileCheck %s
+// RUN: %clang %s -rpath /dir1/ -rpath /dir2/ -bfakelibpath -### 2>&1  --target=powerpc-ibm-aix | FileCheck %s
+// RUN: %clang %s -rpath /dir1/ -rpath /dir2/ -bfakelibpath -### 2>&1  --target=powerpc64-ibm-aix | FileCheck %s
+// RUN: %clang %s -rpath /dir1/ -rpath /dir2/ -Wl,-bloadmap:-blibpath -### 2>&1  --target=powerpc-ibm-aix | FileCheck %s
+// RUN: %clang %s -rpath /dir1/ -rpath /dir2/ -Wl,-bloadmap:-blibpath -### 2>&1  --target=powerpc64-ibm-aix | FileCheck %s
+// RUN: %clang %s -rpath /dir1/ -rpath /dir2/ -Wl,-fakeblibpath -### 2>&1  --target=powerpc-ibm-aix | FileCheck %s
+// RUN: %clang %s -rpath /dir1/ -rpath /dir2/ -Wl,-fakeblibpath -### 2>&1  --target=powerpc64-ibm-aix | FileCheck %s
+
+// RUN: %clang %s -bsvr4 -Wl,-R/dir1/ -Wl,-blibpath:/dir2/ -### 2>&1  --target=powerpc-ibm-aix | FileCheck --check-prefix=CHECK-LAST %s
+// RUN: %clang %s -bsvr4 -Wl,-R/dir1/ -Wl,-blibpath:/dir2/ -### 2>&1  --target=powerpc64-ibm-aix | FileCheck --check-prefix=CHECK-LAST %s
+// RUN: %clang %s -bsvr4 -Xlinker -R/dir1/ -Xlinker -blibpath:/dir2/ -### 2>&1  --target=powerpc-ibm-aix | FileCheck --check-prefix=CHECK-LAST %s
+// RUN: %clang %s -bsvr4 -Xlinker -R/dir1/ -Xlinker -blibpath:/dir2/ -### 2>&1  --target=powerpc64-ibm-aix | FileCheck --check-prefix=CHECK-LAST %s
+//
+// RUN: not %clang %s -rpath /dir1/ -rpath /dir2/ -bnolibpath -### 2>&1  --target=powerpc-ibm-aix | FileCheck --check-prefix=CHECK-ERBN %s
+// RUN: not %clang %s -rpath /dir1/ -rpath /dir2/ -bnolibpath -### 2>&1  --target=powerpc64-ibm-aix | FileCheck --check-prefix=CHECK-ERBN %s
+// RUN: not %clang %s -rpath /dir1/ -rpath /dir2/ -Wl,-bnolibpath -### 2>&1  --target=powerpc-ibm-aix | FileCheck --check-prefix=CHECK-ERWLBN %s
+// RUN: not %clang %s -rpath /dir1/ -rpath /dir2/ -Wl,-bnolibpath -### 2>&1  --target=powerpc64-ibm-aix | FileCheck --check-prefix=CHECK-ERWLBN %s
+// RUN: not %clang %s -rpath /dir1/ -rpath /dir2/ -Wl,-bnoentry,-bnolibpath -### 2>&1  --target=powerpc-ibm-aix | FileCheck --check-prefix=CHECK-ERWLBN %s
+// RUN: not %clang %s -rpath /dir1/ -rpath /dir2/ -Wl,-bnoentry,-bnolibpath -### 2>&1  --target=powerpc64-ibm-aix | FileCheck --check-prefix=CHECK-ERWLBN %s
+// RUN: not %clang %s -rpath /dir1/ -rpath /dir2/ -Xlinker -bnolibpath -### 2>&1  --target=powerpc-ibm-aix | FileCheck --check-prefix=CHECK-ERXBN %s
+// RUN: not %clang %s -rpath /dir1/ -rpath /dir2/ -Xlinker -bnolibpath -### 2>&1  --target=powerpc64-ibm-aix | FileCheck --check-prefix=CHECK-ERXBN %s
+//
+// RUN: not %clang %s -rpath /dir1/ -rpath /dir2/ -blibpath:/dir3/ -### 2>&1  --target=powerpc-ibm-aix | FileCheck --check-prefix=CHECK-ERB %s
+// RUN: not %clang %s -rpath /dir1/ -rpath /dir2/ -blibpath:/dir3/ -### 2>&1  --target=powerpc64-ibm-aix | FileCheck --check-prefix=CHECK-ERB %s
+// RUN: not %clang %s -rpath /dir1/ -rpath /dir2/ -Wl,-blibpath:/dir3/ -### 2>&1  --target=powerpc-ibm-aix | FileCheck --check-prefix=CHECK-ERWL %s
+// RUN: not %clang %s -rpath /dir1/ -rpath /dir2/ -Wl,-blibpath:/dir3/ -### 2>&1  --target=powerpc64-ibm-aix | FileCheck --check-prefix=CHECK-ERWL %s
+// RUN: not %clang %s -rpath /dir1/ -rpath /dir2/ -Wl,-bnoentr,-blibpath:/dir3/ -### 2>&1  --target=powerpc-ibm-aix | FileCheck --check-prefix=CHECK-ERWL %s
+// RUN: not %clang %s -rpath /dir1/ -rpath /dir2/ -Wl,-bnoentr,-blibpath:/dir3/ -### 2>&1  --target=powerpc64-ibm-aix | FileCheck --check-prefix=CHECK-ERWL %s
+// RUN: not %clang %s -rpath /dir1/ -rpath /dir2/ -Xlinker -blibpath:/dir3/ -### 2>&1  --target=powerpc-ibm-aix | FileCheck --check-prefix=CHECK-ERX %s
+// RUN: not %clang %s -rpath /dir1/ -rpath /dir2/ -Xlinker -blibpath:/dir3/ -### 2>&1  --target=powerpc64-ibm-aix | FileCheck --check-prefix=CHECK-ERX %s
+
+//CHECK: -blibpath:/dir1/:/dir2/:/usr/lib:/lib
+//CHECK-LAST: -blibpath:/dir2/
+//CHECK-ERBN: error: cannot specify '-bnolibpath' along with '-rpath'
+//CHECK-ERWLBN: error: cannot specify '-Wl,-bnolibpath' along with '-rpath'
+//CHECK-ERXBN: error: cannot specify '-Xlinker -bnolibpath' along with '-rpath'
+//CHECK-ERB: error: cannot specify '-blibpath:/dir3/' along with '-rpath'
+//CHECK-ERWL: error: cannot specify '-Wl,-blibpath:/dir3/' along with '-rpath'
+//CHECK-ERX: error: cannot specify '-Xlinker -blibpath:/dir3/' along with '-rpath'

--- a/clang/test/Driver/at_file_missing.c
+++ b/clang/test/Driver/at_file_missing.c
@@ -2,6 +2,10 @@
 // stream, and also that @file arguments continue to be processed.
 
 // RUN: echo "-D FOO" > %t.args
-// RUN: %clang -rpath @executable_path/../lib @%t.args %s -### 2>&1 | FileCheck %s
-// CHECK: "-D" "FOO"
+// RUN: %clang -rpath @executable_path/../lib @%t.args %s -### 2>&1 | FileCheck %s \
+// RUN:        --check-prefixes=%if system-aix %{CHECK-AIX,CHECK-ALL%} \
+// RUN:        %else %{CHECK-ALL,CHECK%}
+
+// CHECK-ALL: "-D" "FOO"
 // CHECK: "-rpath" "@executable_path/../lib"
+// CHECK-AIX: "-blibpath:@executable_path/../lib:/usr/lib:/lib"


### PR DESCRIPTION
Add support for existing -rpath option to AIX. Prior to this PR, if -rpath is passed on AIX it gets passed to the linker and crashes as the linker on AIX cannot process it.