### PR TITLE
[libc][docs] Updates implementation status for some preexisting docgen json files

### DIFF
--- a/libc/utils/docgen/fenv.json
+++ b/libc/utils/docgen/fenv.json
@@ -1,80 +1,61 @@
 {
   "macros": {
     "__STDC_VERSION_FENV_H__": {
-      "defined": "7.6.5",
-      "implemented": false
+      "defined": "7.6.5"
     },
     "FE_DIVBYZERO": {
-      "defined": "7.6.9",
-      "implemented": true
+      "defined": "7.6.9"
     },
     "FE_INEXACT": {
-      "defined": "7.6.9",
-      "implemented": true
+      "defined": "7.6.9"
     },
     "FE_INVALID": {
-      "defined": "7.6.9",
-      "implemented": true
+      "defined": "7.6.9"
     },
     "FE_OVERFLOW": {
-      "defined": "7.6.9",
-      "implemented": true
+      "defined": "7.6.9"
     },
     "FE_UNDERFLOW": {
-      "defined": "7.6.9",
-      "implemented": true
+      "defined": "7.6.9"
     },
     "FE_ALL_EXCEPT": {
-      "defined": "7.6.12",
-      "implemented": true
+      "defined": "7.6.12"
     },
     "FE_DFL_MODE": {
-      "defined": "7.6.11",
-      "implemented": false
+      "defined": "7.6.11"
     },
     "FE_DOWNARD": {
-      "defined": "7.6.13",
-      "implemented": true
+      "defined": "7.6.13"
     },
     "FE_TONEAREST": {
-      "defined": "7.6.13",
-      "implemented": true
+      "defined": "7.6.13"
     },
     "FE_TONEARESTFROMZERO": {
-      "defined": "7.6.13",
-      "implemented": false
+      "defined": "7.6.13"
     },
     "FE_TOWARDZERO": {
-      "defined": "7.6.13",
-      "implemented": true
+      "defined": "7.6.13"
     },
     "FE_UPWARD": {
-      "defined": "7.6.13",
-      "implemented": true
+      "defined": "7.6.13"
     },
     "FE_DEC_DOWNWARD": {
-      "defined": "7.6.14",
-      "implemented": false
+      "defined": "7.6.14"
     },
     "FE_DEC_TONEAREST": {
-      "defined": "7.6.14",
-      "implemented": false
+      "defined": "7.6.14"
     },
     "FE_DEC_TONEARESTFROMZERO": {
-      "defined": "7.6.14",
-      "implemented": false
+      "defined": "7.6.14"
     },
     "FE_DEC_TOWARDZERO": {
-      "defined": "7.6.14",
-      "implemented": false
+      "defined": "7.6.14"
     },
     "FE_DEC_UPWARD": {
-      "defined": "7.6.14",
-      "implemented": false
+      "defined": "7.6.14"
     },
     "FE_DFL_ENV": {
-      "defined": "7.6.17",
-      "implemented": true
+      "defined": "7.6.17"
     }
   },
   "functions": {

--- a/libc/utils/docgen/fenv.json
+++ b/libc/utils/docgen/fenv.json
@@ -1,7 +1,82 @@
 {
-  "macros": [
-    "__STDC_VERSION_FENV_H__"
-  ],
+  "macros": {
+    "__STDC_VERSION_FENV_H__": {
+      "defined": "7.6.5",
+      "implemented": false
+    },
+    "FE_DIVBYZERO": {
+      "defined": "7.6.9",
+      "implemented": true
+    },
+    "FE_INEXACT": {
+      "defined": "7.6.9",
+      "implemented": true
+    },
+    "FE_INVALID": {
+      "defined": "7.6.9",
+      "implemented": true
+    },
+    "FE_OVERFLOW": {
+      "defined": "7.6.9",
+      "implemented": true
+    },
+    "FE_UNDERFLOW": {
+      "defined": "7.6.9",
+      "implemented": true
+    },
+    "FE_ALL_EXCEPT": {
+      "defined": "7.6.12",
+      "implemented": true
+    },
+    "FE_DFL_MODE": {
+      "defined": "7.6.11",
+      "implemented": false
+    },
+    "FE_DOWNARD": {
+      "defined": "7.6.13",
+      "implemented": true
+    },
+    "FE_TONEAREST": {
+      "defined": "7.6.13",
+      "implemented": true
+    },
+    "FE_TONEARESTFROMZERO": {
+      "defined": "7.6.13",
+      "implemented": false
+    },
+    "FE_TOWARDZERO": {
+      "defined": "7.6.13",
+      "implemented": true
+    },
+    "FE_UPWARD": {
+      "defined": "7.6.13",
+      "implemented": true
+    },
+    "FE_DEC_DOWNWARD": {
+      "defined": "7.6.14",
+      "implemented": false
+    },
+    "FE_DEC_TONEAREST": {
+      "defined": "7.6.14",
+      "implemented": false
+    },
+    "FE_DEC_TONEARESTFROMZERO": {
+      "defined": "7.6.14",
+      "implemented": false
+    },
+    "FE_DEC_TOWARDZERO": {
+      "defined": "7.6.14",
+      "implemented": false
+    },
+    "FE_DEC_UPWARD": {
+      "defined": "7.6.14",
+      "implemented": false
+    },
+    "FE_DFL_ENV": {
+      "defined": "7.6.17",
+      "implemented": true
+    }
+  },
   "functions": {
     "feclearexcept": {
       "defined": "7.6.4.1"

--- a/libc/utils/docgen/signal.json
+++ b/libc/utils/docgen/signal.json
@@ -1,16 +1,49 @@
 {
-  "macros": [
-    "SIG_DFL",
-    "SIG_ERR",
-    "SIG_IGN",
-    "SIGABRT",
-    "SIGFPE",
-    "SIGILL",
-    "SIGINT",
-    "SIGSEGV",
-    "SIGTERM"
-  ],
+  "macros": {
+    "SIG_DFL": {
+      "defined": "7.14.3",
+      "implemented": false
+    },
+    "SIG_ERR": {
+      "defined": "7.14.3",
+      "implemented": false
+    },
+    "SIG_IGN": {
+      "defined": "7.14.3",
+      "implemented": false
+    },
+    "SIGABRT": {
+      "defined": "7.14.3",
+      "implemented": true
+    },
+    "SIGFPE": {
+      "defined": "7.14.3",
+      "implemented": true
+    },
+    "SIGILL": {
+      "defined": "7.14.3",
+      "implemented": true
+    },
+    "SIGINT": {
+      "defined": "7.14.3",
+      "implemented": true
+    },
+    "SIGSEGV": {
+      "defined": "7.14.3",
+      "implemented": true
+    },
+    "SIGTERM": {
+      "defined": "7.14.3",
+      "implemented": true
+    }
+  },
   "functions": {
+    "signal": {
+      "defined": "7.14.1.1"
+    },
+    "raise": {
+      "defined": "7.14.2.1"
+    },
     "kill": null,
     "sigaction": null,
     "sigaddset": null,
@@ -18,12 +51,6 @@
     "sigdelset": null,
     "sigemptyset": null,
     "sigfillset": null,
-    "sigprocmask": null,
-    "signal": {
-      "defined": "7.14.1.1"
-    },
-    "raise": {
-      "defined": "7.14.2.1"
-    }
+    "sigprocmask": null
   }
 }

--- a/libc/utils/docgen/signal.json
+++ b/libc/utils/docgen/signal.json
@@ -1,40 +1,31 @@
 {
   "macros": {
     "SIG_DFL": {
-      "defined": "7.14.3",
-      "implemented": false
+      "defined": "7.14.3"
     },
     "SIG_ERR": {
-      "defined": "7.14.3",
-      "implemented": false
+      "defined": "7.14.3"
     },
     "SIG_IGN": {
-      "defined": "7.14.3",
-      "implemented": false
+      "defined": "7.14.3"
     },
     "SIGABRT": {
-      "defined": "7.14.3",
-      "implemented": true
+      "defined": "7.14.3"
     },
     "SIGFPE": {
-      "defined": "7.14.3",
-      "implemented": true
+      "defined": "7.14.3"
     },
     "SIGILL": {
-      "defined": "7.14.3",
-      "implemented": true
+      "defined": "7.14.3"
     },
     "SIGINT": {
-      "defined": "7.14.3",
-      "implemented": true
+      "defined": "7.14.3"
     },
     "SIGSEGV": {
-      "defined": "7.14.3",
-      "implemented": true
+      "defined": "7.14.3"
     },
     "SIGTERM": {
-      "defined": "7.14.3",
-      "implemented": true
+      "defined": "7.14.3"
     }
   },
   "functions": {

--- a/libc/utils/docgen/stdbit.json
+++ b/libc/utils/docgen/stdbit.json
@@ -1,76 +1,58 @@
 {
   "macros": {
     "__STDC_VERSION_STDBIT_H__": {
-      "defined": "7.18.1.2",
-      "implemented": true
+      "defined": "7.18.1.2"
     },
     "__STDC_ENDIAN_LITTLE__": {
-      "defined": "7.18.2.2",
-      "implemented": true
+      "defined": "7.18.2.2"
     },
     "__STDC_ENDIAN_BIG__": {
-      "defined": "7.18.2.2",
-      "implemented": true
+      "defined": "7.18.2.2"
     },
     "__STDC_ENDIAN_NATIVE__": {
-      "defined": "7.18.2.2",
-      "implemented": true
+      "defined": "7.18.2.2"
     },
     "stdc_leading_zeros": {
-      "defined": "7.18.3.1",
-      "implemented": true
+      "defined": "7.18.3.1"
     },
     "stdc_leading_ones": {
-      "defined": "7.18.4.1",
-      "implemented": true
+      "defined": "7.18.4.1"
     },
     "stdc_trailing_zeros": {
-      "defined": "7.18.5.1",
-      "implemented": true
+      "defined": "7.18.5.1"
     },
     "stdc_trailing_ones": {
-      "defined": "7.18.6.1",
-      "implemented": true
+      "defined": "7.18.6.1"
     },
     "stdc_first_leading_zero": {
-      "defined": "7.18.7.1",
-      "implemented": true
+      "defined": "7.18.7.1"
     },
     "stdc_first_leading_one": {
-      "defined": "7.18.8.1",
-      "implemented": true
+      "defined": "7.18.8.1"
     },
     "stdc_first_trailing_zero": {
-      "defined": "7.18.9.1",
-      "implemented": true
+      "defined": "7.18.9.1"
     },
     "stdc_first_trailing_one": {
-      "defined": "7.18.10.1",
-      "implemented": true
+      "defined": "7.18.10.1"
     },
     "stdc_count_zeros": {
-      "defined": "7.18.11.1",
-      "implemented": true
+      "defined": "7.18.11.1"
     },
     "stdc_count_ones": {
-      "defined": "7.18.12.1",
-      "implemented": true
+      "defined": "7.18.12.1"
     },
     "stdc_has_single_bit": {
-      "defined": "7.18.13.1",
-      "implemented": true
+      "defined": "7.18.13.1"
     },
     "stdc_bit_width": {
-      "defined": "7.18.14.1",
-      "implemented": true
+      "defined": "7.18.14.1"
     },
     "stdc_bit_floor": {
-      "defined": "7.18.15.1",
-      "implemented": true
+      "defined": "7.18.15.1"
     },
     "stdc_bit_ceil": {
-      "defined": "7.18.16.1",
-      "implemented": true
+      "defined": "7.18.16.1"
     }
   },
   "functions": {

--- a/libc/utils/docgen/stdbit.json
+++ b/libc/utils/docgen/stdbit.json
@@ -1,24 +1,78 @@
 {
-  "macros": [
-    "__STDC_VERSION_STDBIT_H__",
-    "__STDC_ENDIAN_LITTLE__",
-    "__STDC_ENDIAN_BIG__",
-    "__STDC_ENDIAN_NATIVE__",
-    "stdc_leading_zeros",
-    "stdc_leading_ones",
-    "stdc_trailing_zeros",
-    "stdc_trailing_ones",
-    "stdc_first_leading_zero",
-    "stdc_first_leading_one",
-    "stdc_first_trailing_zero",
-    "stdc_first_trailing_one",
-    "stdc_count_zeros",
-    "stdc_count_ones",
-    "stdc_has_single_bit",
-    "stdc_bit_width",
-    "stdc_bit_floor",
-    "stdc_bit_ceil"
-  ],
+  "macros": {
+    "__STDC_VERSION_STDBIT_H__": {
+      "defined": "7.18.1.2",
+      "implemented": true
+    },
+    "__STDC_ENDIAN_LITTLE__": {
+      "defined": "7.18.2.2",
+      "implemented": true
+    },
+    "__STDC_ENDIAN_BIG__": {
+      "defined": "7.18.2.2",
+      "implemented": true
+    },
+    "__STDC_ENDIAN_NATIVE__": {
+      "defined": "7.18.2.2",
+      "implemented": true
+    },
+    "stdc_leading_zeros": {
+      "defined": "7.18.3.1",
+      "implemented": true
+    },
+    "stdc_leading_ones": {
+      "defined": "7.18.4.1",
+      "implemented": true
+    },
+    "stdc_trailing_zeros": {
+      "defined": "7.18.5.1",
+      "implemented": true
+    },
+    "stdc_trailing_ones": {
+      "defined": "7.18.6.1",
+      "implemented": true
+    },
+    "stdc_first_leading_zero": {
+      "defined": "7.18.7.1",
+      "implemented": true
+    },
+    "stdc_first_leading_one": {
+      "defined": "7.18.8.1",
+      "implemented": true
+    },
+    "stdc_first_trailing_zero": {
+      "defined": "7.18.9.1",
+      "implemented": true
+    },
+    "stdc_first_trailing_one": {
+      "defined": "7.18.10.1",
+      "implemented": true
+    },
+    "stdc_count_zeros": {
+      "defined": "7.18.11.1",
+      "implemented": true
+    },
+    "stdc_count_ones": {
+      "defined": "7.18.12.1",
+      "implemented": true
+    },
+    "stdc_has_single_bit": {
+      "defined": "7.18.13.1",
+      "implemented": true
+    },
+    "stdc_bit_width": {
+      "defined": "7.18.14.1",
+      "implemented": true
+    },
+    "stdc_bit_floor": {
+      "defined": "7.18.15.1",
+      "implemented": true
+    },
+    "stdc_bit_ceil": {
+      "defined": "7.18.16.1",
+      "implemented": true
+    }
+  },
   "functions": {
     "stdc_leading_zeros_uc": {
       "defined": "7.18.3"


### PR DESCRIPTION
Moving towards displaying impl status of standard header macros. The macros aren't handled by docgen yet, so I haven't included updated rst files.

Add @nickdesaulniers for review.