### PR TITLE
[lldb][nfc] Remove unused member Disassembler::m_base_addr

### DIFF
--- a/lldb/include/lldb/Core/Disassembler.h
+++ b/lldb/include/lldb/Core/Disassembler.h
@@ -547,7 +547,6 @@ protected:
   // Classes that inherit from Disassembler can see and modify these
   ArchSpec m_arch;
   InstructionList m_instruction_list;
-  lldb::addr_t m_base_addr;
   std::string m_flavor;
 
 private:

--- a/lldb/source/Core/Disassembler.cpp
+++ b/lldb/source/Core/Disassembler.cpp
@@ -1117,8 +1117,7 @@ size_t Disassembler::ParseInstructions(Target &target, Address start,
 
 // Disassembler copy constructor
 Disassembler::Disassembler(const ArchSpec &arch, const char *flavor)
-    : m_arch(arch), m_instruction_list(), m_base_addr(LLDB_INVALID_ADDRESS),
-      m_flavor() {
+    : m_arch(arch), m_instruction_list(), m_flavor() {
   if (flavor == nullptr)
     m_flavor.assign("default");
   else


### PR DESCRIPTION
This member variable is completely unused. I also don't think it makes a ton of sense since (1) The "base address" can be obtained from the first Instruction in its InstructionList, and (2) InstructionLists may not be a series of contiguous instructions (even though they are most of the time).