### PR TITLE
[mlir][python] allow passing in PYTHONPATH to lit tests

### DIFF
--- a/mlir/test/lit.cfg.py
+++ b/mlir/test/lit.cfg.py
@@ -204,7 +204,7 @@ config.environment["FILECHECK_OPTS"] = "-enable-var-scope --allow-unused-prefixe
 # binaries come from the build tree. This should be unified to the build tree
 # by copying/linking sources to build.
 if config.enable_bindings_python:
-    config.environment["PYTHONPATH"] = os.getenv("PYTHONPATH", "")
+    config.environment["PYTHONPATH"] = os.getenv("MLIR_LIT_PYTHONPATH", "")
     llvm_config.with_environment(
         "PYTHONPATH",
         [

--- a/mlir/test/lit.cfg.py
+++ b/mlir/test/lit.cfg.py
@@ -204,6 +204,7 @@ config.environment["FILECHECK_OPTS"] = "-enable-var-scope --allow-unused-prefixe
 # binaries come from the build tree. This should be unified to the build tree
 # by copying/linking sources to build.
 if config.enable_bindings_python:
+    config.environment["PYTHONPATH"] = os.getenv("PYTHONPATH", "")
     llvm_config.with_environment(
         "PYTHONPATH",
         [


### PR DESCRIPTION
Right now there's no way to pass in the current PYTHONPATH to lit tests.