### PR TITLE
[clang] Add flag to experiment with cold function attributes

### DIFF
--- a/clang/test/CodeGen/pgo-force-function-attrs.ll
+++ b/clang/test/CodeGen/pgo-force-function-attrs.ll
@@ -1,0 +1,12 @@
+; RUN: %clang_cc1 -O2 -mllvm -pgo-cold-func-opt=optsize -mllvm -enable-pgo-force-function-attrs -fprofile-sample-use=%S/Inputs/pgo-sample.prof %s -emit-llvm -o - | FileCheck %s --check-prefix=OPTSIZE
+; Check that no profile means no optsize
+; RUN: %clang_cc1 -O2 -mllvm -pgo-cold-func-opt=optsize -mllvm -enable-pgo-force-function-attrs %s -emit-llvm -o - | FileCheck %s --check-prefix=NONE
+; Check that no -pgo-cold-func-opt=optsize means no optsize
+; RUN: %clang_cc1 -O2 -mllvm -enable-pgo-force-function-attrs -fprofile-sample-use=%S/Inputs/pgo-sample.prof %s -emit-llvm -o - | FileCheck %s --check-prefix=NONE
+
+; NONE-NOT: optsize
+; OPTSIZE: optsize
+
+define void @f() cold {
+  ret void
+}


### PR DESCRIPTION
To be removed and promoted to a proper driver flag if experiments turn out fruitful.

For now, this can be experimented with `-mllvm -pgo-cold-func-opt=[optsize|minsize|optnone|default] -mllvm -enable-pgo-force-function-attrs`.

Original LLVM patch for this functionality: #69030