### PR TITLE
[libc] fix FEnvImpl not using the proxy header

### DIFF
--- a/libc/src/__support/FPUtil/FEnvImpl.h
+++ b/libc/src/__support/FPUtil/FEnvImpl.h
@@ -9,11 +9,12 @@
 #ifndef LLVM_LIBC_SRC___SUPPORT_FPUTIL_FENVIMPL_H
 #define LLVM_LIBC_SRC___SUPPORT_FPUTIL_FENVIMPL_H
 
+#include "hdr/fenv_macros.h"
 #include "hdr/math_macros.h"
+#include "hdr/types/fenv_t.h"
 #include "src/__support/macros/attributes.h" // LIBC_INLINE
 #include "src/__support/macros/properties/architectures.h"
 #include "src/errno/libc_errno.h"
-#include <fenv.h>
 
 #if defined(LIBC_TARGET_ARCH_IS_AARCH64)
 #if defined(__APPLE__)

--- a/libc/src/__support/FPUtil/riscv/FEnvImpl.h
+++ b/libc/src/__support/FPUtil/riscv/FEnvImpl.h
@@ -15,7 +15,6 @@
 #include "src/__support/macros/attributes.h" // For LIBC_INLINE_ASM
 #include "src/__support/macros/config.h"     // For LIBC_INLINE
 
-#include <fenv.h>
 #include <stdint.h>
 
 namespace LIBC_NAMESPACE {


### PR DESCRIPTION
In the recent fenv.h header cleanup, two FEnvImpl.h files were missed,
causing build issues. This patch fixes that.
