### PR TITLE
[libc] fixup nascent pthread_condattr_test

### DIFF
--- a/libc/test/src/pthread/CMakeLists.txt
+++ b/libc/test/src/pthread/CMakeLists.txt
@@ -47,9 +47,9 @@ add_libc_unittest(
   SRCS
     pthread_condattr_test.cpp
   DEPENDS
-    libc.include.errno
+    libc.include.llvm-libc-macros.generic_error_number_macros
+    libc.include.llvm-libc-macros.time_macros
     libc.include.pthread
-    libc.include.time
     libc.src.pthread.pthread_condattr_destroy
     libc.src.pthread.pthread_condattr_getclock
     libc.src.pthread.pthread_condattr_getpshared

--- a/libc/test/src/pthread/pthread_condattr_test.cpp
+++ b/libc/test/src/pthread/pthread_condattr_test.cpp
@@ -50,10 +50,13 @@ TEST(LlvmLibcPThreadCondAttrTest, SetGoodValues) {
   int pshared = 42;
 
   ASSERT_EQ(LIBC_NAMESPACE::pthread_condattr_init(&cond), 0);
-  ASSERT_EQ(LIBC_NAMESPACE::pthread_condattr_setclock(&cond, CLOCK_MONOTONIC), 0);
+  ASSERT_EQ(LIBC_NAMESPACE::pthread_condattr_setclock(&cond, CLOCK_MONOTONIC),
+            0);
   ASSERT_EQ(LIBC_NAMESPACE::pthread_condattr_getclock(&cond, &clock), 0);
   ASSERT_EQ(clock, CLOCK_MONOTONIC);
-  ASSERT_EQ(LIBC_NAMESPACE::pthread_condattr_setpshared(&cond, PTHREAD_PROCESS_SHARED), 0);
+  ASSERT_EQ(LIBC_NAMESPACE::pthread_condattr_setpshared(&cond,
+                                                        PTHREAD_PROCESS_SHARED),
+            0);
   ASSERT_EQ(LIBC_NAMESPACE::pthread_condattr_getpshared(&cond, &pshared), 0);
   ASSERT_EQ(pshared, PTHREAD_PROCESS_SHARED);
   ASSERT_EQ(LIBC_NAMESPACE::pthread_condattr_destroy(&cond), 0);
@@ -71,7 +74,8 @@ TEST(LlvmLibcPThreadCondAttrTest, SetBadValues) {
   ASSERT_EQ(LIBC_NAMESPACE::pthread_condattr_setclock(&cond, clock), EINVAL);
   ASSERT_EQ(LIBC_NAMESPACE::pthread_condattr_getclock(&cond, &clock), 0);
   ASSERT_EQ(clock, CLOCK_REALTIME);
-  ASSERT_EQ(LIBC_NAMESPACE::pthread_condattr_setpshared(&cond, pshared), EINVAL);
+  ASSERT_EQ(LIBC_NAMESPACE::pthread_condattr_setpshared(&cond, pshared),
+            EINVAL);
   ASSERT_EQ(LIBC_NAMESPACE::pthread_condattr_getpshared(&cond, &pshared), 0);
   ASSERT_EQ(pshared, PTHREAD_PROCESS_PRIVATE);
   ASSERT_EQ(LIBC_NAMESPACE::pthread_condattr_destroy(&cond), 0);

--- a/libc/test/src/pthread/pthread_condattr_test.cpp
+++ b/libc/test/src/pthread/pthread_condattr_test.cpp
@@ -6,16 +6,23 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "include/llvm-libc-macros/generic-error-number-macros.h" // EINVAL
+#include "include/llvm-libc-macros/time-macros.h" // CLOCK_REALTIME, CLOCK_MONOTONIC
+#include "src/pthread/pthread_condattr_destroy.h"
+#include "src/pthread/pthread_condattr_getclock.h"
+#include "src/pthread/pthread_condattr_getpshared.h"
+#include "src/pthread/pthread_condattr_init.h"
+#include "src/pthread/pthread_condattr_setclock.h"
+#include "src/pthread/pthread_condattr_setpshared.h"
 #include "test/UnitTest/Test.h"
 
-#include <errno.h>
-#include <pthread.h>
-#include <time.h>
+// TODO: https://github.com/llvm/llvm-project/issues/88997
+#include <pthread.h> // PTHREAD_PROCESS_PRIVATE, PTHREAD_PROCESS_SHARED
 
 TEST(LlvmLibcPThreadCondAttrTest, InitAndDestroy) {
   pthread_condattr_t cond;
-  ASSERT_EQ(pthread_condattr_init(&cond), 0);
-  ASSERT_EQ(pthread_condattr_destroy(&cond), 0);
+  ASSERT_EQ(LIBC_NAMESPACE::pthread_condattr_init(&cond), 0);
+  ASSERT_EQ(LIBC_NAMESPACE::pthread_condattr_destroy(&cond), 0);
 }
 
 TEST(LlvmLibcPThreadCondAttrTest, GetDefaultValues) {
@@ -26,12 +33,12 @@ TEST(LlvmLibcPThreadCondAttrTest, GetDefaultValues) {
   // Invalid value.
   int pshared = 42;
 
-  ASSERT_EQ(pthread_condattr_init(&cond), 0);
-  ASSERT_EQ(pthread_condattr_getclock(&cond, &clock), 0);
+  ASSERT_EQ(LIBC_NAMESPACE::pthread_condattr_init(&cond), 0);
+  ASSERT_EQ(LIBC_NAMESPACE::pthread_condattr_getclock(&cond, &clock), 0);
   ASSERT_EQ(clock, CLOCK_REALTIME);
-  ASSERT_EQ(pthread_condattr_getpshared(&cond, &pshared), 0);
+  ASSERT_EQ(LIBC_NAMESPACE::pthread_condattr_getpshared(&cond, &pshared), 0);
   ASSERT_EQ(pshared, PTHREAD_PROCESS_PRIVATE);
-  ASSERT_EQ(pthread_condattr_destroy(&cond), 0);
+  ASSERT_EQ(LIBC_NAMESPACE::pthread_condattr_destroy(&cond), 0);
 }
 
 TEST(LlvmLibcPThreadCondAttrTest, SetGoodValues) {
@@ -42,14 +49,14 @@ TEST(LlvmLibcPThreadCondAttrTest, SetGoodValues) {
   // Invalid value.
   int pshared = 42;
 
-  ASSERT_EQ(pthread_condattr_init(&cond), 0);
-  ASSERT_EQ(pthread_condattr_setclock(&cond, CLOCK_MONOTONIC), 0);
-  ASSERT_EQ(pthread_condattr_getclock(&cond, &clock), 0);
+  ASSERT_EQ(LIBC_NAMESPACE::pthread_condattr_init(&cond), 0);
+  ASSERT_EQ(LIBC_NAMESPACE::pthread_condattr_setclock(&cond, CLOCK_MONOTONIC), 0);
+  ASSERT_EQ(LIBC_NAMESPACE::pthread_condattr_getclock(&cond, &clock), 0);
   ASSERT_EQ(clock, CLOCK_MONOTONIC);
-  ASSERT_EQ(pthread_condattr_setpshared(&cond, PTHREAD_PROCESS_SHARED), 0);
-  ASSERT_EQ(pthread_condattr_getpshared(&cond, &pshared), 0);
+  ASSERT_EQ(LIBC_NAMESPACE::pthread_condattr_setpshared(&cond, PTHREAD_PROCESS_SHARED), 0);
+  ASSERT_EQ(LIBC_NAMESPACE::pthread_condattr_getpshared(&cond, &pshared), 0);
   ASSERT_EQ(pshared, PTHREAD_PROCESS_SHARED);
-  ASSERT_EQ(pthread_condattr_destroy(&cond), 0);
+  ASSERT_EQ(LIBC_NAMESPACE::pthread_condattr_destroy(&cond), 0);
 }
 
 TEST(LlvmLibcPThreadCondAttrTest, SetBadValues) {
@@ -60,12 +67,12 @@ TEST(LlvmLibcPThreadCondAttrTest, SetBadValues) {
   // Invalid value.
   int pshared = 42;
 
-  ASSERT_EQ(pthread_condattr_init(&cond), 0);
-  ASSERT_EQ(pthread_condattr_setclock(&cond, clock), EINVAL);
-  ASSERT_EQ(pthread_condattr_getclock(&cond, &clock), 0);
+  ASSERT_EQ(LIBC_NAMESPACE::pthread_condattr_init(&cond), 0);
+  ASSERT_EQ(LIBC_NAMESPACE::pthread_condattr_setclock(&cond, clock), EINVAL);
+  ASSERT_EQ(LIBC_NAMESPACE::pthread_condattr_getclock(&cond, &clock), 0);
   ASSERT_EQ(clock, CLOCK_REALTIME);
-  ASSERT_EQ(pthread_condattr_setpshared(&cond, pshared), EINVAL);
-  ASSERT_EQ(pthread_condattr_getpshared(&cond, &pshared), 0);
+  ASSERT_EQ(LIBC_NAMESPACE::pthread_condattr_setpshared(&cond, pshared), EINVAL);
+  ASSERT_EQ(LIBC_NAMESPACE::pthread_condattr_getpshared(&cond, &pshared), 0);
   ASSERT_EQ(pshared, PTHREAD_PROCESS_PRIVATE);
-  ASSERT_EQ(pthread_condattr_destroy(&cond), 0);
+  ASSERT_EQ(LIBC_NAMESPACE::pthread_condattr_destroy(&cond), 0);
 }


### PR DESCRIPTION
- use namespaced identifiers
- add corresponding headers for namespaced declarations
- replace time.h and errno.h with finer grain includes
- update cmake

Fixes: #88987
Fixes: #89261
Link: #88997
Link: #89262
