### PR TITLE
[flang][cuda] Relax semantic for device variable in block construct

### DIFF
--- a/flang/lib/Semantics/check-declarations.cpp
+++ b/flang/lib/Semantics/check-declarations.cpp
@@ -1042,9 +1042,10 @@ void CheckHelper::CheckObjectEntity(
             parser::ToUpperCaseLetters(common::EnumToString(attr)));
       }
     } else if (!subpDetails && symbol.owner().kind() != Scope::Kind::Module &&
-        symbol.owner().kind() != Scope::Kind::MainProgram) {
+        symbol.owner().kind() != Scope::Kind::MainProgram &&
+        symbol.owner().kind() != Scope::Kind::BlockConstruct) {
       messages_.Say(
-          "ATTRIBUTES(%s) may apply only to module, host subprogram, or device subprogram data"_err_en_US,
+          "ATTRIBUTES(%s) may apply only to module, host subprogram, block, or device subprogram data"_err_en_US,
           parser::ToUpperCaseLetters(common::EnumToString(attr)));
     }
   }

--- a/flang/test/Semantics/cuf03.cuf
+++ b/flang/test/Semantics/cuf03.cuf
@@ -85,6 +85,11 @@ module m
     real, unified :: ru ! ok
     type(t1), unified :: tu ! ok
     type(t2) :: t ! ok
+
+    block
+      real, device :: a(100) ! ok
+    end block
   end subroutine
+
 
 end module

--- a/flang/test/Semantics/cuf12.cuf
+++ b/flang/test/Semantics/cuf12.cuf
@@ -1,0 +1,8 @@
+! RUN: %python %S/test_errors.py %s %flang_fc1
+
+program test
+  real, device :: b(100) ! ok
+  block
+    real, device :: a(100) ! ok
+  end block
+end program


### PR DESCRIPTION
There is no restriction for device variable to be in a block construct. Semantic check was raising an error. This patch relax the check to allow the code in tests. 

https://docs.nvidia.com/hpc-sdk/compilers/cuda-fortran-prog-guide/#cfref-var-attr-device-data

