### PR TITLE
[libc] Move from alias(X) to asm(X) for aliasing

### DIFF
--- a/libc/src/__support/common.h
+++ b/libc/src/__support/common.h
@@ -25,7 +25,7 @@
 #define LLVM_LIBC_FUNCTION_IMPL(type, name, arglist)                           \
   LLVM_LIBC_FUNCTION_ATTR decltype(LIBC_NAMESPACE::name)                       \
       __##name##_impl__ __asm__(#name);                                        \
-  decltype(LIBC_NAMESPACE::name) name [[gnu::alias(#name)]];                   \
+  decltype(LIBC_NAMESPACE::name) name asm(#name);                              \
   type __##name##_impl__ arglist
 #else
 #define LLVM_LIBC_FUNCTION_IMPL(type, name, arglist) type name arglist


### PR DESCRIPTION
The previous method of aliasing a function internally was
`[[gnu::alias(#name)]]`, but that ran into issues with gcc under some
circumstances. By using `asm(#name);` instead, those issues are avoided.
