### PR TITLE
[RISCV][TableGen] Generate RISCVTargetParserDef.inc from the new RISCVExtension tblgen information.

### DIFF
--- a/llvm/test/TableGen/riscv-target-def.td
+++ b/llvm/test/TableGen/riscv-target-def.td
@@ -5,7 +5,7 @@ include "llvm/Target/Target.td"
 class RISCVExtension<string name, int major, int minor, string fieldname,
                      string desc, list<SubtargetFeature> implies = [],
                      string value = "true">
-  : SubtargetFeature<name, fieldname, value, desc, implies> {
+    : SubtargetFeature<name, fieldname, value, desc, implies> {
   int MajorVersion = major;
   int MinorVersion = minor;
   bit Experimental = false;
@@ -37,7 +37,7 @@ class RISCVProcessorModel<string n,
                           list<SubtargetFeature> f,
                           list<SubtargetFeature> tunef = [],
                           string default_march = "">
-      :  ProcessorModel<n, m, f, tunef> {
+    :  ProcessorModel<n, m, f, tunef> {
   string DefaultMarch = default_march;
 }
 
@@ -45,7 +45,7 @@ class RISCVTuneProcessorModel<string n,
                               SchedMachineModel m,
                               list<SubtargetFeature> tunef = [],
                               list<SubtargetFeature> f = []>
-      : ProcessorModel<n, m, f,tunef>;
+    : ProcessorModel<n, m, f,tunef>;
 
 def GENERIC_RV32 : RISCVProcessorModel<"generic-rv32",
                                        NoSchedModel,

--- a/llvm/test/TableGen/riscv-target-def.td
+++ b/llvm/test/TableGen/riscv-target-def.td
@@ -1,0 +1,96 @@
+// RUN: llvm-tblgen -gen-riscv-target-def -I %p/../../include %s | FileCheck %s
+
+include "llvm/Target/Target.td"
+
+class RISCVExtension<string name, int major, int minor, string fieldname,
+                     string desc, list<SubtargetFeature> implies = [],
+                     string value = "true">
+  : SubtargetFeature<name, fieldname, value, desc, implies> {
+  int MajorVersion = major;
+  int MinorVersion = minor;
+  bit Experimental = false;
+}
+
+def FeatureStdExtI
+    : RISCVExtension<"i", 2, 1, "HasStdExtI",
+                     "'I' (Base Integer Instruction Set)">;
+
+def FeatureStdExtZicsr
+    : RISCVExtension<"zicsr", 2, 0, "HasStdExtZicsr",
+                     "'zicsr' (CSRs)">;
+
+def FeatureStdExtZifencei
+    : RISCVExtension<"zifencei", 2, 0, "HasStdExtZifencei",
+                     "'Zifencei' (fence.i)">;
+
+def Feature32Bit
+    : SubtargetFeature<"32bit", "IsRV32", "true", "Implements RV32">;
+def Feature64Bit
+    : SubtargetFeature<"64bit", "IsRV64", "true", "Implements RV64">;
+
+// Dummy feature that isn't an extension.
+def FeatureDummy
+    : SubtargetFeature<"dummy", "Dummy", "true", "Dummy">;
+
+class RISCVProcessorModel<string n,
+                          SchedMachineModel m,
+                          list<SubtargetFeature> f,
+                          list<SubtargetFeature> tunef = [],
+                          string default_march = "">
+      :  ProcessorModel<n, m, f, tunef> {
+  string DefaultMarch = default_march;
+}
+
+class RISCVTuneProcessorModel<string n,
+                              SchedMachineModel m,
+                              list<SubtargetFeature> tunef = [],
+                              list<SubtargetFeature> f = []>
+      : ProcessorModel<n, m, f,tunef>;
+
+def GENERIC_RV32 : RISCVProcessorModel<"generic-rv32",
+                                       NoSchedModel,
+                                       [Feature32Bit,
+                                        FeatureStdExtI]>;
+def GENERIC_RV64 : RISCVProcessorModel<"generic-rv64",
+                                       NoSchedModel,
+                                       [Feature64Bit,
+                                        FeatureStdExtI]>;
+def GENERIC : RISCVTuneProcessorModel<"generic", NoSchedModel>;
+
+
+def ROCKET_RV32 : RISCVProcessorModel<"rocket-rv32",
+                                      NoSchedModel,
+                                      [Feature32Bit,
+                                       FeatureStdExtI,
+                                       FeatureStdExtZifencei,
+                                       FeatureStdExtZicsr,
+                                       FeatureDummy]>;
+def ROCKET_RV64 : RISCVProcessorModel<"rocket-rv64",
+                                      NoSchedModel,
+                                      [Feature64Bit,
+                                       FeatureStdExtI,
+                                       FeatureStdExtZifencei,
+                                       FeatureStdExtZicsr,
+                                       FeatureDummy]>;
+def ROCKET : RISCVTuneProcessorModel<"rocket",
+                                     NoSchedModel>;
+
+// CHECK: #ifndef PROC
+// CHECK: #define PROC(ENUM, NAME, DEFAULT_MARCH, FAST_UNALIGNED_ACCESS)
+// CHECK: #endif
+
+// CHECK: PROC(GENERIC_RV32, {"generic-rv32"}, {"rv32i2p1"}, 0)
+// CHECK: PROC(GENERIC_RV64, {"generic-rv64"}, {"rv64i2p1"}, 0)
+// CHECK: PROC(ROCKET_RV32, {"rocket-rv32"}, {"rv32i2p1_zicsr2p0_zifencei2p0"}, 0)
+// CHECK: PROC(ROCKET_RV64, {"rocket-rv64"}, {"rv64i2p1_zicsr2p0_zifencei2p0"}, 0)
+
+// CHECK: #undef PROC
+
+// CHECK: #ifndef TUNE_PROC
+// CHECK: #define TUNE_PROC(ENUM, NAME)
+// CHECK: #endif
+
+// CHECK: TUNE_PROC(GENERIC, "generic")
+// CHECK: TUNE_PROC(ROCKET, "rocket")
+
+// CHECK: #undef TUNE_PROC

--- a/llvm/utils/TableGen/RISCVTargetDefEmitter.cpp
+++ b/llvm/utils/TableGen/RISCVTargetDefEmitter.cpp
@@ -67,9 +67,8 @@ static void EmitRISCVTargetDef(RecordKeeper &RK, raw_ostream &OS) {
     bool FastUnalignedAccess =
         FastScalarUnalignedAccess && FastVectorUnalignedAccess;
 
-    OS << "PROC(" << Rec->getName() << ", "
-       << "{\"" << Rec->getValueAsString("Name") << "\"}, "
-       << "{\"";
+    OS << "PROC(" << Rec->getName() << ", {\"" << Rec->getValueAsString("Name")
+       << "\"}, {\"";
 
     StringRef MArch = Rec->getValueAsString("DefaultMarch");
 

--- a/llvm/utils/TableGen/RISCVTargetDefEmitter.cpp
+++ b/llvm/utils/TableGen/RISCVTargetDefEmitter.cpp
@@ -27,7 +27,7 @@ static void printMArch(raw_ostream &OS, const Record &Rec) {
   std::map<std::string, std::pair<unsigned, unsigned>,
            RISCVISAInfo::ExtensionComparator>
       Extensions;
-  unsigned XLen = 32;
+  unsigned XLen = 0;
 
   // Convert features to FeatureVector.
   for (auto *Feature : Rec.getValueAsListOfDefs("Features")) {
@@ -36,9 +36,16 @@ static void printMArch(raw_ostream &OS, const Record &Rec) {
       unsigned Major = Feature->getValueAsInt("MajorVersion");
       unsigned Minor = Feature->getValueAsInt("MinorVersion");
       Extensions.try_emplace(FeatureName.str(), Major, Minor);
-    } else if (FeatureName == "64bit")
+    } else if (FeatureName == "64bit") {
+      assert(XLen == 0 && "Already determined XLen");
       XLen = 64;
+    } else if (FeatureName == "32bit") {
+      assert(XLen == 0 && "Already determined XLen");
+      XLen = 32;
+    }
   }
+
+  assert(XLen != 0 && "Unable to determine XLen");
 
   OS << "rv" << XLen;
 

--- a/llvm/utils/TableGen/RISCVTargetDefEmitter.cpp
+++ b/llvm/utils/TableGen/RISCVTargetDefEmitter.cpp
@@ -24,7 +24,7 @@ using namespace llvm;
 // This is almost the same as RISCVFeatures::parseFeatureBits, except that we
 // get feature name from feature records instead of feature bits.
 static void printMArch(raw_ostream &OS, const Record &Rec) {
-  std::map<std::string, std::pair<unsigned, unsigned>,
+  std::map<std::string, RISCVISAInfo::ExtensionVersion,
            RISCVISAInfo::ExtensionComparator>
       Extensions;
   unsigned XLen = 0;
@@ -35,7 +35,7 @@ static void printMArch(raw_ostream &OS, const Record &Rec) {
     if (Feature->isSubClassOf("RISCVExtension")) {
       unsigned Major = Feature->getValueAsInt("MajorVersion");
       unsigned Minor = Feature->getValueAsInt("MinorVersion");
-      Extensions.try_emplace(FeatureName.str(), Major, Minor);
+      Extensions[FeatureName.str()] = {Major, Minor};
     } else if (FeatureName == "64bit") {
       assert(XLen == 0 && "Already determined XLen");
       XLen = 64;
@@ -51,7 +51,7 @@ static void printMArch(raw_ostream &OS, const Record &Rec) {
 
   ListSeparator LS("_");
   for (auto const &Ext : Extensions)
-    OS << LS << Ext.first << Ext.second.first << 'p' << Ext.second.second;
+    OS << LS << Ext.first << Ext.second.Major << 'p' << Ext.second.Minor;
 }
 
 static void EmitRISCVTargetDef(RecordKeeper &RK, raw_ostream &OS) {


### PR DESCRIPTION
Instead of using RISCVISAInfo's extension information, use the extension found in tblgen after #89326.
    
We still need to use RISCVISAInfo code to get the sorting rules for the ISA string.
    
The ISA string we generate now is not quite the same extension we had before. No implied extensions are included in the generate string unless they are explicitly listed in RISCVProcessors.td. This primarily affects Zicsr being implied by F, V implying Zve*, and Zvl*b implying a smaller Zvl*b. All of these implication should be picked up when the string is used by the frontend.
    
The benefit is that we get a more manageable ISA string for humans to deal with.
    
This is a step towards generating RISCVISAInfo's extension list from tblgen.