### PR TITLE
[IR] Add support for trunc's nuw/nsw flags in `copyIRFlags`

### DIFF
--- a/llvm/lib/IR/Instruction.cpp
+++ b/llvm/lib/IR/Instruction.cpp
@@ -636,6 +636,13 @@ void Instruction::copyIRFlags(const Value *V, bool IncludeWrapFlags) {
     }
   }
 
+  if (auto *TI = dyn_cast<TruncInst>(V)) {
+    if (isa<TruncInst>(this)) {
+      setHasNoSignedWrap(TI->hasNoSignedWrap());
+      setHasNoUnsignedWrap(TI->hasNoUnsignedWrap());
+    }
+  }
+
   // Copy the exact flag.
   if (auto *PE = dyn_cast<PossiblyExactOperator>(V))
     if (isa<PossiblyExactOperator>(this))

--- a/llvm/test/Transforms/Scalarizer/basic.ll
+++ b/llvm/test/Transforms/Scalarizer/basic.ll
@@ -868,9 +868,9 @@ define <2 x float> @f25(<2 x float> %src) {
 define <2 x i8> @test_copy_trunc_flags(<2 x i32> %src) {
 ; CHECK-LABEL: @test_copy_trunc_flags(
 ; CHECK-NEXT:    [[SRC_I0:%.*]] = extractelement <2 x i32> [[SRC:%.*]], i64 0
-; CHECK-NEXT:    [[TRUNC_I0:%.*]] = trunc i32 [[SRC_I0]] to i8
+; CHECK-NEXT:    [[TRUNC_I0:%.*]] = trunc nuw nsw i32 [[SRC_I0]] to i8
 ; CHECK-NEXT:    [[SRC_I1:%.*]] = extractelement <2 x i32> [[SRC]], i64 1
-; CHECK-NEXT:    [[TRUNC_I1:%.*]] = trunc i32 [[SRC_I1]] to i8
+; CHECK-NEXT:    [[TRUNC_I1:%.*]] = trunc nuw nsw i32 [[SRC_I1]] to i8
 ; CHECK-NEXT:    [[TRUNC_UPTO0:%.*]] = insertelement <2 x i8> poison, i8 [[TRUNC_I0]], i64 0
 ; CHECK-NEXT:    [[TRUNC:%.*]] = insertelement <2 x i8> [[TRUNC_UPTO0]], i8 [[TRUNC_I1]], i64 1
 ; CHECK-NEXT:    ret <2 x i8> [[TRUNC]]

--- a/llvm/test/Transforms/Scalarizer/basic.ll
+++ b/llvm/test/Transforms/Scalarizer/basic.ll
@@ -283,13 +283,13 @@ end:
 define <4 x float> @f6(<4 x float> %x) {
 ; CHECK-LABEL: @f6(
 ; CHECK-NEXT:    [[X_I0:%.*]] = extractelement <4 x float> [[X:%.*]], i64 0
-; CHECK-NEXT:    [[RES_I0:%.*]] = fadd float [[X_I0]], 1.000000e+00, !fpmath !9
+; CHECK-NEXT:    [[RES_I0:%.*]] = fadd float [[X_I0]], 1.000000e+00, !fpmath [[META9:![0-9]+]]
 ; CHECK-NEXT:    [[X_I1:%.*]] = extractelement <4 x float> [[X]], i64 1
-; CHECK-NEXT:    [[RES_I1:%.*]] = fadd float [[X_I1]], 2.000000e+00, !fpmath !9
+; CHECK-NEXT:    [[RES_I1:%.*]] = fadd float [[X_I1]], 2.000000e+00, !fpmath [[META9]]
 ; CHECK-NEXT:    [[X_I2:%.*]] = extractelement <4 x float> [[X]], i64 2
-; CHECK-NEXT:    [[RES_I2:%.*]] = fadd float [[X_I2]], 3.000000e+00, !fpmath !9
+; CHECK-NEXT:    [[RES_I2:%.*]] = fadd float [[X_I2]], 3.000000e+00, !fpmath [[META9]]
 ; CHECK-NEXT:    [[X_I3:%.*]] = extractelement <4 x float> [[X]], i64 3
-; CHECK-NEXT:    [[RES_I3:%.*]] = fadd float [[X_I3]], 4.000000e+00, !fpmath !9
+; CHECK-NEXT:    [[RES_I3:%.*]] = fadd float [[X_I3]], 4.000000e+00, !fpmath [[META9]]
 ; CHECK-NEXT:    [[RES_UPTO0:%.*]] = insertelement <4 x float> poison, float [[RES_I0]], i64 0
 ; CHECK-NEXT:    [[RES_UPTO1:%.*]] = insertelement <4 x float> [[RES_UPTO0]], float [[RES_I1]], i64 1
 ; CHECK-NEXT:    [[RES_UPTO2:%.*]] = insertelement <4 x float> [[RES_UPTO1]], float [[RES_I2]], i64 2
@@ -863,6 +863,20 @@ define <2 x float> @f25(<2 x float> %src) {
   %frz = freeze <2 x float> %add
   %mul = fmul <2 x float> %frz, %frz
   ret <2 x float> %mul
+}
+
+define <2 x i8> @test_copy_trunc_flags(<2 x i32> %src) {
+; CHECK-LABEL: @test_copy_trunc_flags(
+; CHECK-NEXT:    [[SRC_I0:%.*]] = extractelement <2 x i32> [[SRC:%.*]], i64 0
+; CHECK-NEXT:    [[TRUNC_I0:%.*]] = trunc i32 [[SRC_I0]] to i8
+; CHECK-NEXT:    [[SRC_I1:%.*]] = extractelement <2 x i32> [[SRC]], i64 1
+; CHECK-NEXT:    [[TRUNC_I1:%.*]] = trunc i32 [[SRC_I1]] to i8
+; CHECK-NEXT:    [[TRUNC_UPTO0:%.*]] = insertelement <2 x i8> poison, i8 [[TRUNC_I0]], i64 0
+; CHECK-NEXT:    [[TRUNC:%.*]] = insertelement <2 x i8> [[TRUNC_UPTO0]], i8 [[TRUNC_I1]], i64 1
+; CHECK-NEXT:    ret <2 x i8> [[TRUNC]]
+;
+  %trunc = trunc nuw nsw <2 x i32> %src to <2 x i8>
+  ret <2 x i8> %trunc
 }
 
 !0 = !{ !"root" }


### PR DESCRIPTION
This patch fixes https://github.com/llvm/llvm-project/pull/85592#issuecomment-2065865020.

I found this while fixing flag propagation in my ["vectorizer"](https://github.com/dtcxzyw/llvm-codegen-benchmark/blob/main/vectorize.cpp).
