### PR TITLE
[lldb][Docs] Document vFile:exists and vFile:MD5

### DIFF
--- a/lldb/docs/lldb-platform-packets.txt
+++ b/lldb/docs/lldb-platform-packets.txt
@@ -444,8 +444,8 @@ incompatible with the flags that gdb specifies.
 //  request packet contains the ASCII hex encoded filename
 //
 //  If the hash succeeded, the response is "F," followed by the low 64
-//  bits of the result, then the high 64 bits of the result. Both are hex
-//  without a prefix.
+//  bits of the result, and finally the high 64 bits of the result. Both are in
+//  hex format without a prefix.
 //
 //  The response is "F,", followed by "x" if the file did not exist
 //  or failed to hash.

--- a/lldb/docs/lldb-platform-packets.txt
+++ b/lldb/docs/lldb-platform-packets.txt
@@ -429,7 +429,43 @@ incompatible with the flags that gdb specifies.
 //
 //  Response is F, followed by the number of bytes written (base 16)
 
+//----------------------------------------------------------------------
+// vFile:MD5:
+//
+// BRIEF
+//  Generate an MD5 hash of the file at the given path.
+//
+// EXAMPLE
+//
+//  receive: vFile:MD5:2f746d702f61
+//  send (success): F,00000000000000001111111111111111
+//  send (failure): F,x
+//
+//  request packet contains the ASCII hex encoded filename
+//
+//  If the hash succeeded, the response is "F," followed by the low 64
+//  bits of the result, then the high 64 bits of the result. Both are hex
+//  without a prefix.
+//
+//  The response is "F,", followed by "x" if the file did not exist
+//  or failed to hash.
 
+//----------------------------------------------------------------------
+// vFile:exists:
+//
+// BRIEF
+//  Check whether the file at the given path exists.
+//
+// EXAMPLE
+//
+//  receive: vFile:exists:2f746d702f61
+//  send         (exists): F,1
+//  send (does not exist): F,0
+//
+//  request packet contains the ASCII hex encoded filename
+//
+//  The response is a return code where 1 means the file exists
+//  and 0 means it does not.
 
 
 


### PR DESCRIPTION
These are extensions the lldb platform has to:
https://sourceware.org/gdb/current/onlinedocs/gdb.html/Host-I_002fO-Packets.html#Host-I_002fO-Packets