### PR TITLE
[libc][NFC] Integrate `quick_mul`, `quick_add`, `multiply_add`, `pow_n` and `mul_pow_2` as member functions of `DyadicFloat`

### DIFF
--- a/libc/src/__support/float_to_string.h
+++ b/libc/src/__support/float_to_string.h
@@ -244,10 +244,10 @@ LIBC_INLINE UInt<MID_INT_SIZE> get_table_positive_df(int exponent, size_t i) {
       false, -276, FIVE_EXP_MINUS_NINE_MANT);
 
   if (i > 0) {
-    fputil::DyadicFloat<INT_SIZE> fives = fputil::pow_n(FIVE_EXP_MINUS_NINE, i);
+    fputil::DyadicFloat<INT_SIZE> fives = FIVE_EXP_MINUS_NINE.pow_n(i);
     num = fives;
   }
-  num = mul_pow_2(num, shift_amount);
+  num = num.mul_pow_2(shift_amount);
 
   // Adding one is part of the formula.
   UInt<INT_SIZE> int_num = static_cast<UInt<INT_SIZE>>(num) + 1;
@@ -349,10 +349,10 @@ LIBC_INLINE UInt<MID_INT_SIZE> get_table_negative_df(int exponent, size_t i) {
                                                           TEN_EXP_NINE_MANT);
 
   if (i > 0) {
-    fputil::DyadicFloat<INT_SIZE> tens = fputil::pow_n(TEN_EXP_NINE, i);
+    fputil::DyadicFloat<INT_SIZE> tens = TEN_EXP_NINE.pow_n(i);
     num = tens;
   }
-  num = mul_pow_2(num, shift_amount);
+  num = num.mul_pow_2(shift_amount);
 
   UInt<INT_SIZE> int_num = static_cast<UInt<INT_SIZE>>(num);
   if (int_num > MOD_SIZE) {

--- a/libc/src/math/generic/exp.cpp
+++ b/libc/src/math/generic/exp.cpp
@@ -126,25 +126,22 @@ Float128 exp_f128(double x, double kd, int idx1, int idx2) {
   double t2 = kd * MLOG_2_EXP2_M12_MID_30;                     // exact
   double t3 = kd * MLOG_2_EXP2_M12_LO;                         // Error < 2^-133
 
-  Float128 dx = fputil::quick_add(
-      Float128(t1), fputil::quick_add(Float128(t2), Float128(t3)));
+  Float128 dx = quick_add(Float128(t1), quick_add(Float128(t2), Float128(t3)));
 
   // TODO: Skip recalculating exp_mid1 and exp_mid2.
-  Float128 exp_mid1 =
-      fputil::quick_add(Float128(EXP2_MID1[idx1].hi),
-                        fputil::quick_add(Float128(EXP2_MID1[idx1].mid),
-                                          Float128(EXP2_MID1[idx1].lo)));
+  Float128 exp_mid1 = quick_add(
+      Float128(EXP2_MID1[idx1].hi),
+      quick_add(Float128(EXP2_MID1[idx1].mid), Float128(EXP2_MID1[idx1].lo)));
 
-  Float128 exp_mid2 =
-      fputil::quick_add(Float128(EXP2_MID2[idx2].hi),
-                        fputil::quick_add(Float128(EXP2_MID2[idx2].mid),
-                                          Float128(EXP2_MID2[idx2].lo)));
+  Float128 exp_mid2 = quick_add(
+      Float128(EXP2_MID2[idx2].hi),
+      quick_add(Float128(EXP2_MID2[idx2].mid), Float128(EXP2_MID2[idx2].lo)));
 
-  Float128 exp_mid = fputil::quick_mul(exp_mid1, exp_mid2);
+  Float128 exp_mid = quick_mul(exp_mid1, exp_mid2);
 
   Float128 p = poly_approx_f128(dx);
 
-  Float128 r = fputil::quick_mul(exp_mid, p);
+  Float128 r = quick_mul(exp_mid, p);
 
   r.exponent += static_cast<int>(kd) >> 12;
 

--- a/libc/src/math/generic/exp10.cpp
+++ b/libc/src/math/generic/exp10.cpp
@@ -126,25 +126,22 @@ Float128 exp10_f128(double x, double kd, int idx1, int idx2) {
   double t2 = kd * MLOG10_2_EXP2_M12_MID_32;                     // exact
   double t3 = kd * MLOG10_2_EXP2_M12_LO; // Error < 2^-144
 
-  Float128 dx = fputil::quick_add(
-      Float128(t1), fputil::quick_add(Float128(t2), Float128(t3)));
+  Float128 dx = quick_add(Float128(t1), quick_add(Float128(t2), Float128(t3)));
 
   // TODO: Skip recalculating exp_mid1 and exp_mid2.
-  Float128 exp_mid1 =
-      fputil::quick_add(Float128(EXP2_MID1[idx1].hi),
-                        fputil::quick_add(Float128(EXP2_MID1[idx1].mid),
-                                          Float128(EXP2_MID1[idx1].lo)));
+  Float128 exp_mid1 = quick_add(
+      Float128(EXP2_MID1[idx1].hi),
+      quick_add(Float128(EXP2_MID1[idx1].mid), Float128(EXP2_MID1[idx1].lo)));
 
-  Float128 exp_mid2 =
-      fputil::quick_add(Float128(EXP2_MID2[idx2].hi),
-                        fputil::quick_add(Float128(EXP2_MID2[idx2].mid),
-                                          Float128(EXP2_MID2[idx2].lo)));
+  Float128 exp_mid2 = quick_add(
+      Float128(EXP2_MID2[idx2].hi),
+      quick_add(Float128(EXP2_MID2[idx2].mid), Float128(EXP2_MID2[idx2].lo)));
 
-  Float128 exp_mid = fputil::quick_mul(exp_mid1, exp_mid2);
+  Float128 exp_mid = quick_mul(exp_mid1, exp_mid2);
 
   Float128 p = poly_approx_f128(dx);
 
-  Float128 r = fputil::quick_mul(exp_mid, p);
+  Float128 r = quick_mul(exp_mid, p);
 
   r.exponent += static_cast<int>(kd) >> 12;
 

--- a/libc/src/math/generic/exp2.cpp
+++ b/libc/src/math/generic/exp2.cpp
@@ -114,21 +114,19 @@ Float128 exp2_f128(double x, int hi, int idx1, int idx2) {
   Float128 dx = Float128(x);
 
   // TODO: Skip recalculating exp_mid1 and exp_mid2.
-  Float128 exp_mid1 =
-      fputil::quick_add(Float128(EXP2_MID1[idx1].hi),
-                        fputil::quick_add(Float128(EXP2_MID1[idx1].mid),
-                                          Float128(EXP2_MID1[idx1].lo)));
+  Float128 exp_mid1 = quick_add(
+      Float128(EXP2_MID1[idx1].hi),
+      quick_add(Float128(EXP2_MID1[idx1].mid), Float128(EXP2_MID1[idx1].lo)));
 
-  Float128 exp_mid2 =
-      fputil::quick_add(Float128(EXP2_MID2[idx2].hi),
-                        fputil::quick_add(Float128(EXP2_MID2[idx2].mid),
-                                          Float128(EXP2_MID2[idx2].lo)));
+  Float128 exp_mid2 = quick_add(
+      Float128(EXP2_MID2[idx2].hi),
+      quick_add(Float128(EXP2_MID2[idx2].mid), Float128(EXP2_MID2[idx2].lo)));
 
-  Float128 exp_mid = fputil::quick_mul(exp_mid1, exp_mid2);
+  Float128 exp_mid = quick_mul(exp_mid1, exp_mid2);
 
   Float128 p = poly_approx_f128(dx);
 
-  Float128 r = fputil::quick_mul(exp_mid, p);
+  Float128 r = quick_mul(exp_mid, p);
 
   r.exponent += hi;
 

--- a/libc/src/math/generic/expm1.cpp
+++ b/libc/src/math/generic/expm1.cpp
@@ -148,34 +148,30 @@ Float128 expm1_f128(double x, double kd, int idx1, int idx2) {
   double t2 = kd * MLOG_2_EXP2_M12_MID_30;                     // exact
   double t3 = kd * MLOG_2_EXP2_M12_LO;                         // Error < 2^-133
 
-  Float128 dx = fputil::quick_add(
-      Float128(t1), fputil::quick_add(Float128(t2), Float128(t3)));
+  Float128 dx = quick_add(Float128(t1), quick_add(Float128(t2), Float128(t3)));
 
   // TODO: Skip recalculating exp_mid1 and exp_mid2.
-  Float128 exp_mid1 =
-      fputil::quick_add(Float128(EXP2_MID1[idx1].hi),
-                        fputil::quick_add(Float128(EXP2_MID1[idx1].mid),
-                                          Float128(EXP2_MID1[idx1].lo)));
+  Float128 exp_mid1 = quick_add(
+      Float128(EXP2_MID1[idx1].hi),
+      quick_add(Float128(EXP2_MID1[idx1].mid), Float128(EXP2_MID1[idx1].lo)));
 
-  Float128 exp_mid2 =
-      fputil::quick_add(Float128(EXP2_MID2[idx2].hi),
-                        fputil::quick_add(Float128(EXP2_MID2[idx2].mid),
-                                          Float128(EXP2_MID2[idx2].lo)));
+  Float128 exp_mid2 = quick_add(
+      Float128(EXP2_MID2[idx2].hi),
+      quick_add(Float128(EXP2_MID2[idx2].mid), Float128(EXP2_MID2[idx2].lo)));
 
-  Float128 exp_mid = fputil::quick_mul(exp_mid1, exp_mid2);
+  Float128 exp_mid = quick_mul(exp_mid1, exp_mid2);
 
   int hi = static_cast<int>(kd) >> 12;
   Float128 minus_one{Sign::NEG, -127 - hi,
                      0x80000000'00000000'00000000'00000000_u128};
 
-  Float128 exp_mid_m1 = fputil::quick_add(exp_mid, minus_one);
+  Float128 exp_mid_m1 = quick_add(exp_mid, minus_one);
 
   Float128 p = poly_approx_f128(dx);
 
   // r = exp_mid * (1 + dx * P) - 1
   //   = (exp_mid - 1) + (dx * exp_mid) * P
-  Float128 r =
-      fputil::multiply_add(fputil::quick_mul(exp_mid, dx), p, exp_mid_m1);
+  Float128 r = multiply_add(quick_mul(exp_mid, dx), p, exp_mid_m1);
 
   r.exponent += hi;
 

--- a/libc/src/math/generic/log.cpp
+++ b/libc/src/math/generic/log.cpp
@@ -714,19 +714,19 @@ constexpr Float128 BIG_COEFFS[3]{
 double log_accurate(int e_x, int index, double m_x) {
 
   Float128 e_x_f128(static_cast<float>(e_x));
-  Float128 sum = fputil::quick_mul(LOG_2, e_x_f128);
-  sum = fputil::quick_add(sum, LOG_TABLE.step_1[index]);
+  Float128 sum = quick_mul(LOG_2, e_x_f128);
+  sum = quick_add(sum, LOG_TABLE.step_1[index]);
 
   Float128 v_f128 = log_range_reduction(m_x, LOG_TABLE, sum);
-  sum = fputil::quick_add(sum, v_f128);
+  sum = quick_add(sum, v_f128);
 
   // Polynomial approximation
-  Float128 p = fputil::quick_mul(v_f128, BIG_COEFFS[0]);
-  p = fputil::quick_mul(v_f128, fputil::quick_add(p, BIG_COEFFS[1]));
-  p = fputil::quick_mul(v_f128, fputil::quick_add(p, BIG_COEFFS[2]));
-  p = fputil::quick_mul(v_f128, p);
+  Float128 p = quick_mul(v_f128, BIG_COEFFS[0]);
+  p = quick_mul(v_f128, quick_add(p, BIG_COEFFS[1]));
+  p = quick_mul(v_f128, quick_add(p, BIG_COEFFS[2]));
+  p = quick_mul(v_f128, p);
 
-  Float128 r = fputil::quick_add(sum, p);
+  Float128 r = quick_add(sum, p);
 
   return static_cast<double>(r);
 }

--- a/libc/src/math/generic/log10.cpp
+++ b/libc/src/math/generic/log10.cpp
@@ -717,18 +717,18 @@ constexpr Float128 BIG_COEFFS[4]{
 double log10_accurate(int e_x, int index, double m_x) {
 
   Float128 e_x_f128(static_cast<float>(e_x));
-  Float128 sum = fputil::quick_mul(LOG10_2, e_x_f128);
-  sum = fputil::quick_add(sum, LOG10_TABLE.step_1[index]);
+  Float128 sum = quick_mul(LOG10_2, e_x_f128);
+  sum = quick_add(sum, LOG10_TABLE.step_1[index]);
 
   Float128 v_f128 = log_range_reduction(m_x, LOG10_TABLE, sum);
 
   // Polynomial approximation
-  Float128 p = fputil::quick_mul(v_f128, BIG_COEFFS[0]);
-  p = fputil::quick_mul(v_f128, fputil::quick_add(p, BIG_COEFFS[1]));
-  p = fputil::quick_mul(v_f128, fputil::quick_add(p, BIG_COEFFS[2]));
-  p = fputil::quick_mul(v_f128, fputil::quick_add(p, BIG_COEFFS[3]));
+  Float128 p = quick_mul(v_f128, BIG_COEFFS[0]);
+  p = quick_mul(v_f128, quick_add(p, BIG_COEFFS[1]));
+  p = quick_mul(v_f128, quick_add(p, BIG_COEFFS[2]));
+  p = quick_mul(v_f128, quick_add(p, BIG_COEFFS[3]));
 
-  Float128 r = fputil::quick_add(sum, p);
+  Float128 r = quick_add(sum, p);
 
   return static_cast<double>(r);
 }

--- a/libc/src/math/generic/log1p.cpp
+++ b/libc/src/math/generic/log1p.cpp
@@ -824,11 +824,11 @@ constexpr Float128 BIG_COEFFS[4]{
 LIBC_INLINE double log1p_accurate(int e_x, int index,
                                   fputil::DoubleDouble m_x) {
   Float128 e_x_f128(static_cast<float>(e_x));
-  Float128 sum = fputil::quick_mul(LOG_2, e_x_f128);
-  sum = fputil::quick_add(sum, LOG_R1[index]);
+  Float128 sum = quick_mul(LOG_2, e_x_f128);
+  sum = quick_add(sum, LOG_R1[index]);
 
   // fputil::DoubleDouble v4;
-  Float128 v = fputil::quick_add(Float128(m_x.hi), Float128(m_x.lo));
+  Float128 v = quick_add(Float128(m_x.hi), Float128(m_x.lo));
 
   // Skip 2nd range reduction step if |m_x| <= 2^-15.
   if (m_x.hi > 0x1p-15 || m_x.hi < -0x1p-15) {
@@ -841,9 +841,9 @@ LIBC_INLINE double log1p_accurate(int e_x, int index,
     // Output range:
     //   -0x1.1037c00000040271p-15 <= v2.hi + v2.lo <= 0x1.108480000008096cp-15
     int idx2 = static_cast<int>(0x1p14 * (m_x.hi + (91 * 0x1p-14 + 0x1p-15)));
-    sum = fputil::quick_add(sum, LOG_R2[idx2]);
+    sum = quick_add(sum, LOG_R2[idx2]);
     Float128 s2 = Float128(S2[idx2]);
-    v = fputil::quick_add(fputil::quick_add(v, s2), fputil::quick_mul(v, s2));
+    v = quick_add(quick_add(v, s2), quick_mul(v, s2));
   }
 
   // Skip 3rd range reduction step if |v| <= 2^-22.
@@ -857,19 +857,19 @@ LIBC_INLINE double log1p_accurate(int e_x, int index,
     //   -0x1.012bb800000800114p-22 <= v3.hi + v3.lo <= 0x1p-22
     int idx3 =
         static_cast<int>(0x1p21 * (double(v) + (69 * 0x1p-21 + 0x1p-22)));
-    sum = fputil::quick_add(sum, LOG_R3[idx3]);
+    sum = quick_add(sum, LOG_R3[idx3]);
     Float128 s3 = Float128(S3[idx3]);
-    v = fputil::quick_add(fputil::quick_add(v, s3), fputil::quick_mul(v, s3));
+    v = quick_add(quick_add(v, s3), quick_mul(v, s3));
   }
 
   // Polynomial approximation
-  Float128 p = fputil::quick_mul(v, BIG_COEFFS[0]);
-  p = fputil::quick_mul(v, fputil::quick_add(p, BIG_COEFFS[1]));
-  p = fputil::quick_mul(v, fputil::quick_add(p, BIG_COEFFS[2]));
-  p = fputil::quick_mul(v, fputil::quick_add(p, BIG_COEFFS[3]));
-  p = fputil::quick_add(v, fputil::quick_mul(v, p));
+  Float128 p = quick_mul(v, BIG_COEFFS[0]);
+  p = quick_mul(v, quick_add(p, BIG_COEFFS[1]));
+  p = quick_mul(v, quick_add(p, BIG_COEFFS[2]));
+  p = quick_mul(v, quick_add(p, BIG_COEFFS[3]));
+  p = quick_add(v, quick_mul(v, p));
 
-  Float128 r = fputil::quick_add(sum, p);
+  Float128 r = quick_add(sum, p);
 
   return static_cast<double>(r);
 }

--- a/libc/src/math/generic/log2.cpp
+++ b/libc/src/math/generic/log2.cpp
@@ -838,17 +838,17 @@ constexpr Float128 BIG_COEFFS[4]{
 double log2_accurate(int e_x, int index, double m_x) {
 
   Float128 sum(static_cast<float>(e_x));
-  sum = fputil::quick_add(sum, LOG2_TABLE.step_1[index]);
+  sum = quick_add(sum, LOG2_TABLE.step_1[index]);
 
   Float128 v_f128 = log_range_reduction(m_x, LOG2_TABLE, sum);
 
   // Polynomial approximation
-  Float128 p = fputil::quick_mul(v_f128, BIG_COEFFS[0]);
-  p = fputil::quick_mul(v_f128, fputil::quick_add(p, BIG_COEFFS[1]));
-  p = fputil::quick_mul(v_f128, fputil::quick_add(p, BIG_COEFFS[2]));
-  p = fputil::quick_mul(v_f128, fputil::quick_add(p, BIG_COEFFS[3]));
+  Float128 p = quick_mul(v_f128, BIG_COEFFS[0]);
+  p = quick_mul(v_f128, quick_add(p, BIG_COEFFS[1]));
+  p = quick_mul(v_f128, quick_add(p, BIG_COEFFS[2]));
+  p = quick_mul(v_f128, quick_add(p, BIG_COEFFS[3]));
 
-  Float128 r = fputil::quick_add(sum, p);
+  Float128 r = quick_add(sum, p);
 
   return static_cast<double>(r);
 }

--- a/libc/src/math/generic/log_range_reduction.h
+++ b/libc/src/math/generic/log_range_reduction.h
@@ -44,7 +44,7 @@ log_range_reduction(double m_x, const LogRR &log_table,
   // Output range: vv2 in [-0x1.3ffcp-15, 0x1.3e3dp-15].
   // idx2 = trunc(2^14 * (v + 2^-8 + 2^-15))
   size_t idx2 = static_cast<size_t>((v + 0x10'2000'0000'0000) >> 46);
-  sum = fputil::quick_add(sum, log_table.step_2[idx2]);
+  sum = quick_add(sum, log_table.step_2[idx2]);
 
   int64_t s2 = static_cast<int64_t>(S2[idx2]); // |s| <= 2^-7, ulp = 2^-16
   int64_t sv2 = s2 * v;             // |s*v| < 2^-14, ulp = 2^(-60-16) = 2^-76
@@ -55,7 +55,7 @@ log_range_reduction(double m_x, const LogRR &log_table,
   // Output range: vv3 in [-0x1.01928p-22 , 0x1p-22]
   // idx3 = trunc(2^21 * (v + 80*2^-21 + 2^-22))
   size_t idx3 = static_cast<size_t>((vv2 + 0x2840'0000'0000'0000) >> 55);
-  sum = fputil::quick_add(sum, log_table.step_3[idx3]);
+  sum = quick_add(sum, log_table.step_3[idx3]);
 
   int64_t s3 = static_cast<int64_t>(S3[idx3]); // |s| < 2^-13, ulp = 2^-21
   int64_t spv3 = (s3 << 55) + vv2;             // |s + v| < 2^-21, ulp = 2^-76
@@ -69,7 +69,7 @@ log_range_reduction(double m_x, const LogRR &log_table,
   // idx4 = trunc(2^21 * (v + 65*2^-28 + 2^-29))
   size_t idx4 = static_cast<size_t>((static_cast<int>(vv3 >> 68) + 131) >> 1);
 
-  sum = fputil::quick_add(sum, log_table.step_4[idx4]);
+  sum = quick_add(sum, log_table.step_4[idx4]);
 
   Int128 s4 = static_cast<Int128>(S4[idx4]); // |s| < 2^-21, ulp = 2^-28
   // |s + v| < 2^-28, ulp = 2^-97


### PR DESCRIPTION
Having `quick_mul`, `quick_add` and `multiply_add` as friend functions simplifies how the functions are written. I also turned `pow_n` and `mul_pow_2` into member functions as they are not used in polymorphic settings. This is preparatory work to have `DyadicFloat` work with regular scalar types such as `__uint128_t`.