### PR TITLE
[MLIR][AsmPrinter] Print aliases even when not at root operation

### DIFF
--- a/mlir/lib/IR/AsmPrinter.cpp
+++ b/mlir/lib/IR/AsmPrinter.cpp
@@ -3920,7 +3920,7 @@ void Operation::print(raw_ostream &os, const OpPrintingFlags &printerFlags) {
 }
 void Operation::print(raw_ostream &os, AsmState &state) {
   OperationPrinter printer(os, state.getImpl());
-  if (!getParent() && !state.getPrinterFlags().shouldUseLocalScope()) {
+  if (!state.getPrinterFlags().shouldUseLocalScope()) {
     state.getImpl().initializeAliases(this);
     printer.printTopLevelOperation(this);
   } else {


### PR DESCRIPTION
This patch makes Operation::print print aliases even when not at the root operation. Aliases are still only printed if shouldUseLocalScope is specified in printing flags.

This is useful when printing operations that have attributes with a large number of parameters.