### PR TITLE
[libc++] Fix usage of 'exclude_from_explicit_instantiation' attribute on local class members

### DIFF
--- a/libcxx/include/__memory/uses_allocator_construction.h
+++ b/libcxx/include/__memory/uses_allocator_construction.h
@@ -184,20 +184,18 @@ __uses_allocator_construction_args(const _Alloc& __alloc, _Type&& __value) noexc
   struct __pair_constructor {
     using _PairMutable = remove_cv_t<_Pair>;
 
-    _LIBCPP_HIDE_FROM_ABI constexpr auto __do_construct(const _PairMutable& __pair) const {
+    _LIBCPP_HIDDEN constexpr auto __do_construct(const _PairMutable& __pair) const {
       return std::__make_obj_using_allocator<_PairMutable>(__alloc_, __pair);
     }
 
-    _LIBCPP_HIDE_FROM_ABI constexpr auto __do_construct(_PairMutable&& __pair) const {
+    _LIBCPP_HIDDEN constexpr auto __do_construct(_PairMutable&& __pair) const {
       return std::__make_obj_using_allocator<_PairMutable>(__alloc_, std::move(__pair));
     }
 
     const _Alloc& __alloc_;
     _Type& __value_;
 
-    _LIBCPP_HIDE_FROM_ABI constexpr operator _PairMutable() const {
-      return __do_construct(std::forward<_Type>(this->__value_));
-    }
+    _LIBCPP_HIDDEN constexpr operator _PairMutable() const { return __do_construct(std::forward<_Type>(__value_)); }
   };
 
   return std::make_tuple(__pair_constructor{__alloc, __value});

--- a/libcxx/include/variant
+++ b/libcxx/include/variant
@@ -909,8 +909,8 @@ protected:
       __a.__value = std::forward<_Arg>(__arg);
     } else {
       struct {
-        _LIBCPP_HIDE_FROM_ABI void operator()(true_type) const { __this->__emplace<_Ip>(std::forward<_Arg>(__arg)); }
-        _LIBCPP_HIDE_FROM_ABI void operator()(false_type) const {
+        _LIBCPP_HIDDEN void operator()(true_type) const { __this->__emplace<_Ip>(std::forward<_Arg>(__arg)); }
+        _LIBCPP_HIDDEN void operator()(false_type) const {
           __this->__emplace<_Ip>(_Tp(std::forward<_Arg>(__arg)));
         }
         __assignment* __this;


### PR DESCRIPTION
#88777 adds a warning for when the `exclude_from_explicit_instantiation` attribute is applied to local classes and members thereof. This patch addresses the few instances of `exclude_from_explicit_instantiation` being applied to local class members in libc++.