### PR TITLE
[MLIR][LLVM] Add vector exception to composite type element ignore mode

### DIFF
--- a/mlir/lib/Target/LLVMIR/DebugImporter.cpp
+++ b/mlir/lib/Target/LLVMIR/DebugImporter.cpp
@@ -71,7 +71,10 @@ DICompileUnitAttr DebugImporter::translateImpl(llvm::DICompileUnit *node) {
 DICompositeTypeAttr DebugImporter::translateImpl(llvm::DICompositeType *node) {
   std::optional<DIFlags> flags = symbolizeDIFlags(node->getFlags());
   SmallVector<DINodeAttr> elements;
-  if (!dropDICompositeTypeElements) {
+
+  // A vector always requires an element.
+  bool isVectorType = flags && bitEnumContainsAll(*flags, DIFlags::Vector);
+  if (isVectorType || !dropDICompositeTypeElements) {
     for (llvm::DINode *element : node->getElements()) {
       assert(element && "expected a non-null element type");
       elements.push_back(translate(element));

--- a/mlir/test/Target/LLVMIR/Import/ignore-composite-type-elements.ll
+++ b/mlir/test/Target/LLVMIR/Import/ignore-composite-type-elements.ll
@@ -1,4 +1,4 @@
-; RUN: mlir-translate -import-llvm -mlir-print-debuginfo -split-input-file -drop-di-composite-type-elements %s | FileCheck %s
+; RUN: mlir-translate -import-llvm -mlir-print-debuginfo -split-input-file -drop-di-composite-type-elements -split-input-file  %s | FileCheck %s
 
 ; Verifies that the according flag avoids the conversion of the elements of the
 ; DICompositeType.
@@ -23,3 +23,25 @@ define void @composite_type() !dbg !3 {
 !7 = !{!9}
 !8 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !6, flags: DIFlagArtificial | DIFlagObjectPointer)
 !9 = !DIDerivedType(tag: DW_TAG_member, name: "call_field", file: !2, baseType: !8)
+
+; // -----
+
+; CHECK: #{{.+}} = #llvm.di_composite_type<tag = DW_TAG_array_type, name = "vector",
+; CHECK-SAME: baseType = #{{.*}}, flags = Vector, elements = #llvm.di_subrange<count = 4 : i64>
+
+define void @composite_type() !dbg !3 {
+  ret void
+}
+
+!llvm.dbg.cu = !{!1}
+!llvm.module.flags = !{!0}
+!0 = !{i32 2, !"Debug Info Version", i32 3}
+!1 = distinct !DICompileUnit(language: DW_LANG_C, file: !2)
+!2 = !DIFile(filename: "debug-info.ll", directory: "/")
+!3 = distinct !DISubprogram(name: "composite_type", scope: !2, file: !2, spFlags: DISPFlagDefinition, unit: !1, type: !4)
+!4 = !DISubroutineType(types: !5)
+!5 = !{!7}
+!6 = !DIBasicType(name: "int")
+!7 = !DICompositeType(tag: DW_TAG_array_type, name: "vector", flags: DIFlagVector, elements: !8, baseType: !6)
+!8 = !{!9}
+!9 = !DISubrange(count: 4)


### PR DESCRIPTION
This commit fixes a bug in the DICompositeType element ignore mode. It seems that vectors require the presence of elements, as they otherwise do not pass the verifier.