### PR TITLE
[flang] Default -g to full debug info.

### DIFF
--- a/clang/lib/Driver/ToolChains/Flang.cpp
+++ b/clang/lib/Driver/ToolChains/Flang.cpp
@@ -118,7 +118,7 @@ void Flang::addOtherOptions(const ArgList &Args, ArgStringList &CmdArgs) const {
     Arg *gNArg = Args.getLastArg(options::OPT_gN_Group);
     DebugInfoKind = debugLevelToInfoKind(*gNArg);
   } else if (Args.hasArg(options::OPT_g_Flag)) {
-    DebugInfoKind = llvm::codegenoptions::DebugLineTablesOnly;
+    DebugInfoKind = llvm::codegenoptions::FullDebugInfo;
   } else {
     DebugInfoKind = llvm::codegenoptions::NoDebugInfo;
   }

--- a/flang/lib/Frontend/CompilerInvocation.cpp
+++ b/flang/lib/Frontend/CompilerInvocation.cpp
@@ -145,6 +145,7 @@ static bool parseDebugArgs(Fortran::frontend::CodeGenOptions &opts,
     }
     opts.setDebugInfo(val.value());
     if (val != llvm::codegenoptions::DebugLineTablesOnly &&
+        val != llvm::codegenoptions::FullDebugInfo &&
         val != llvm::codegenoptions::NoDebugInfo) {
       const auto debugWarning = diags.getCustomDiagID(
           clang::DiagnosticsEngine::Warning, "Unsupported debug option: %0");

--- a/flang/test/Driver/debug-level.f90
+++ b/flang/test/Driver/debug-level.f90
@@ -1,0 +1,7 @@
+! RUN: %flang %s -g -c -### 2>&1 | FileCheck %s --check-prefix=FULL
+! RUN: %flang %s -g1 -c -### 2>&1 | FileCheck %s --check-prefix=LINE
+! RUN: %flang %s -gline-tables-only -c -### 2>&1 | FileCheck %s --check-prefix=LINE
+
+! LINE: -debug-info-kind=line-tables-only
+! FULL: -debug-info-kind=standalone
+


### PR DESCRIPTION
Currently, -g defaults to line tables only. This PR changes that to full debug information. This will allow us to test/use the upcoming debug info changes.