### PR TITLE
[lldb][DWARF] Remove m_forward_decl_die_to_compiler_type as it never actually being used.

### DIFF
--- a/lldb/source/Plugins/SymbolFile/DWARF/SymbolFileDWARF.h
+++ b/lldb/source/Plugins/SymbolFile/DWARF/SymbolFileDWARF.h
@@ -335,14 +335,6 @@ public:
 
   virtual DIEToTypePtr &GetDIEToType() { return m_die_to_type; }
 
-  typedef llvm::DenseMap<const DWARFDebugInfoEntry *,
-                         lldb::opaque_compiler_type_t>
-      DIEToCompilerType;
-
-  virtual DIEToCompilerType &GetForwardDeclDIEToCompilerType() {
-    return m_forward_decl_die_to_compiler_type;
-  }
-
   typedef llvm::DenseMap<lldb::opaque_compiler_type_t, DIERef>
       CompilerTypeToDIE;
 
@@ -543,7 +535,6 @@ protected:
   UniqueDWARFASTTypeMap m_unique_ast_type_map;
   DIEToTypePtr m_die_to_type;
   DIEToVariableSP m_die_to_variable_sp;
-  DIEToCompilerType m_forward_decl_die_to_compiler_type;
   CompilerTypeToDIE m_forward_decl_compiler_type_to_die;
   llvm::DenseMap<dw_offset_t, std::unique_ptr<SupportFileList>>
       m_type_unit_support_files;

--- a/lldb/source/Plugins/SymbolFile/DWARF/SymbolFileDWARFDwo.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/SymbolFileDWARFDwo.cpp
@@ -110,11 +110,6 @@ SymbolFileDWARF::DIEToVariableSP &SymbolFileDWARFDwo::GetDIEToVariable() {
   return GetBaseSymbolFile().GetDIEToVariable();
 }
 
-SymbolFileDWARF::DIEToCompilerType &
-SymbolFileDWARFDwo::GetForwardDeclDIEToCompilerType() {
-  return GetBaseSymbolFile().GetForwardDeclDIEToCompilerType();
-}
-
 SymbolFileDWARF::CompilerTypeToDIE &
 SymbolFileDWARFDwo::GetForwardDeclCompilerTypeToDIE() {
   return GetBaseSymbolFile().GetForwardDeclCompilerTypeToDIE();

--- a/lldb/source/Plugins/SymbolFile/DWARF/SymbolFileDWARFDwo.h
+++ b/lldb/source/Plugins/SymbolFile/DWARF/SymbolFileDWARFDwo.h
@@ -72,8 +72,6 @@ protected:
 
   DIEToVariableSP &GetDIEToVariable() override;
 
-  DIEToCompilerType &GetForwardDeclDIEToCompilerType() override;
-
   CompilerTypeToDIE &GetForwardDeclCompilerTypeToDIE() override;
 
   UniqueDWARFASTTypeMap &GetUniqueDWARFASTTypeMap() override;


### PR DESCRIPTION
This removes `m_forward_decl_die_to_compiler_type` which is a map from `const DWARFDebugInfoEntry *` to `lldb::opaque_compiler_type_t`. This map is currently used in `DWARFASTParserClang::ParseEnum` and `DWARFASTParserClang::ParseStructureLikeDIE` to avoid creating duplicate CompilerType for the specific DIE. But before entering these two functions in `DWARFASTParserClang::ParseTypeFromDWARF`, we already checked with `SymbolFileDWARF::GetDIEToType()`  if we have a Type created from this DIE to avoid trying to parse the same DIE twice. So, this map is unnecessary and not useful.