### PR TITLE
[Nomination] New Intel representative for the security group

### DIFF
--- a/llvm/docs/Security.rst
+++ b/llvm/docs/Security.rst
@@ -53,9 +53,9 @@ username for an individual isn't available, the brackets will be empty.
 * Peter Smith (ARM) [@smithp35]
 * Pietro Albini (Ferrous Systems; Rust) [@pietroalbini]
 * Serge Guelton (Mozilla) [@serge-sans-paille]
-* Sergey Maslov (Intel) [@smaslov-intel]
 * Shayne Hiet-Block (Microsoft) [@GreatKeeper]
 * Tim Penge (Sony) []
+* Will Huhn (Intel) [@wphuhn-intel]
 
 Criteria
 --------


### PR DESCRIPTION
Sergey Malsov has left Intel. I would like to nominate Will Huhn to replace
him as an Intel representative in the LLVM security group. Will is a security
champion for the Intel compiler team. I believe he will be a valuable addition
to the LLVM security group as a second representative from Intel. He has more
security-specific expertise than me. I regularly consult with Will about
topics the LLVM security group is considering, and it will be useful to have
him more directly involved.
