### PR TITLE
[flang] C_LOC is PURE

### DIFF
--- a/flang/lib/Evaluate/intrinsics.cpp
+++ b/flang/lib/Evaluate/intrinsics.cpp
@@ -2862,7 +2862,8 @@ std::optional<SpecificCall> IntrinsicProcTable::Implementation::HandleC_Loc(
                                       characteristics::DummyArgument{"x"s,
                                           characteristics::DummyDataObject{
                                               std::move(*typeAndShape)}}},
-                                  characteristics::Procedure::Attrs{}}},
+                                  characteristics::Procedure::Attrs{
+                                      characteristics::Procedure::Attr::Pure}}},
           std::move(arguments)};
     }
   }

--- a/flang/module/__fortran_builtins.f90
+++ b/flang/module/__fortran_builtins.f90
@@ -18,6 +18,7 @@ module __fortran_builtins
   private
 
   intrinsic :: __builtin_c_loc
+  public :: __builtin_c_loc
 
   intrinsic :: __builtin_c_f_pointer
   public :: __builtin_c_f_pointer
@@ -55,8 +56,6 @@ module __fortran_builtins
   integer, parameter, public :: __builtin_atomic_int_kind = selected_int_kind(18)
   integer, parameter, public :: &
     __builtin_atomic_logical_kind = __builtin_atomic_int_kind
-
-  procedure(type(__builtin_c_ptr)), public :: __builtin_c_loc
 
   type, public :: __builtin_dim3
     integer :: x=1, y=1, z=1


### PR DESCRIPTION
The standard defines C_LOC as being PURE (actually SIMPLE now in F'2023); characterize it appropriately.

Fixes https://github.com/llvm/llvm-project/issues/88747.