### PR TITLE
[easy] Fix spacing in help message of 'process save-core' command

### DIFF
--- a/lldb/source/Commands/Options.td
+++ b/lldb/source/Commands/Options.td
@@ -784,7 +784,7 @@ let Command = "process save_core" in {
     EnumArg<"SaveCoreStyle">, Desc<"Request a specific style "
     "of corefile to be saved.">;
   def process_save_core_plugin_name : Option<"plugin-name", "p">,
-    OptionalArg<"Plugin">, Desc<"Specify a plugin name to create the core file."
+    OptionalArg<"Plugin">, Desc<"Specify a plugin name to create the core file. "
     "This allows core files to be saved in different formats.">;
 }
 


### PR DESCRIPTION
Very minor change to help message on `process save-core`. Adds space between two sentences explaining the `-p` option: 

"Specify a plugin name to create the core file.This allows core files to be saved in different formats." 
-->
"Specify a plugin name to create the core file. This allows core files to be saved in different formats."

Before:
```
(lldb) help process save-core
Save the current process as a core file using an appropriate file type.

Syntax: process save-core [-s corefile-style -p plugin-name] FILE

Command Options Usage:
  process save-core [-p[<plugin>]] [-s <corefile-style>] <path>

       -p[<plugin>] ( --plugin-name=[<plugin>] )
            Specify a plugin name to create the core file.This allows core files to be saved in different formats.

       -s <corefile-style> ( --style <corefile-style> )
            Request a specific style of corefile to be saved.
            Values: full | modified-memory | stack

     This command takes options and free-form arguments.  If your arguments resemble option specifiers (i.e., they start with a -
     or --), you must use ' -- ' between the end of the command options and the beginning of the arguments.
```

After:
```
michristensen@devbig356 build/Debug » $HOME/llvm-sand/build/Debug/bin/lldb -x
(lldb) help process save-core
Save the current process as a core file using an appropriate file type.

Syntax: process save-core [-s corefile-style -p plugin-name] FILE

Command Options Usage:
  process save-core [-p[<plugin>]] [-s <corefile-style>] <path>

       -p[<plugin>] ( --plugin-name=[<plugin>] )
            Specify a plugin name to create the core file. This allows core files to be saved in different formats.

       -s <corefile-style> ( --style <corefile-style> )
            Request a specific style of corefile to be saved.
            Values: full | modified-memory | stack

     This command takes options and free-form arguments.  If your arguments resemble option specifiers (i.e., they start with a -
     or --), you must use ' -- ' between the end of the command options and the beginning of the arguments.
```