### PR TITLE
[clang] Fix self-capturing `__block` variables

### DIFF
--- a/clang/include/clang/AST/Decl.h
+++ b/clang/include/clang/AST/Decl.h
@@ -1103,6 +1103,11 @@ protected:
 
     LLVM_PREFERRED_TYPE(bool)
     unsigned IsCXXCondDecl : 1;
+
+    /// Whether this is a __block variable that is captured by a block
+    /// referenced in its own initializer.
+    LLVM_PREFERRED_TYPE(bool)
+    unsigned CapturedByOwnInit : 1;
   };
 
   union {
@@ -1588,9 +1593,22 @@ public:
   /// escaping block.
   bool isNonEscapingByref() const;
 
-  void setEscapingByref() {
-    NonParmVarDeclBits.EscapingByref = true;
+  void setEscapingByref();
+
+  /// Indicates this is a __block variable that is captured by a block
+  /// referenced in its own initializer.
+  bool isCapturedByOwnInit() const {
+    return !isa<ParmVarDecl>(this) && NonParmVarDeclBits.CapturedByOwnInit;
   }
+
+  void setCapturedByOwnInit() {
+    assert(!isa<ParmVarDecl>(this));
+    NonParmVarDeclBits.CapturedByOwnInit = true;
+  }
+
+  /// Check if this is a __block variable which needs to be initialized
+  /// directly on the heap.
+  bool needsInitOnHeap() const;
 
   bool isCXXCondDecl() const {
     return isa<ParmVarDecl>(this) ? false : NonParmVarDeclBits.IsCXXCondDecl;

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -2358,6 +2358,12 @@ def note_var_fixit_add_initialization : Note<
 def note_uninit_fixit_remove_cond : Note<
   "remove the %select{'%1' if its condition|condition if it}0 "
   "is always %select{false|true}2">;
+def warn_implicit_block_var_alloc : Warning<
+  "variable %q0 will be initialized in a heap allocation">,
+  InGroup<DiagGroup<"implicit-block-var-alloc">>, DefaultIgnore;
+def note_because_captured_by_block : Note<
+  "because it is captured by a block used in its own initializer">;
+
 def err_init_incomplete_type : Error<"initialization of incomplete type %0">;
 def err_list_init_in_parens : Error<
   "cannot initialize %select{non-class|reference}0 type %1 with a "

--- a/clang/lib/AST/Decl.cpp
+++ b/clang/lib/AST/Decl.cpp
@@ -2680,6 +2680,19 @@ bool VarDecl::isNonEscapingByref() const {
   return hasAttr<BlocksAttr>() && !NonParmVarDeclBits.EscapingByref;
 }
 
+void VarDecl::setEscapingByref() {
+  assert(!isa<ParmVarDecl>(this) && hasAttr<BlocksAttr>());
+  NonParmVarDeclBits.EscapingByref = true;
+}
+
+bool VarDecl::needsInitOnHeap() const {
+  // We need direct initialization on the heap for self-capturing __block
+  // variables of types that cause CodeGenFunction::getEvaluationKind to return
+  // TEK_Aggregate.  The only such types that can be captured are records.
+  return isCapturedByOwnInit() &&
+         getType().getAtomicUnqualifiedType()->isRecordType();
+}
+
 bool VarDecl::hasDependentAlignment() const {
   QualType T = getType();
   return T->isDependentType() || T->isUndeducedType() ||

--- a/clang/lib/CodeGen/CGBlocks.cpp
+++ b/clang/lib/CodeGen/CGBlocks.cpp
@@ -2417,6 +2417,8 @@ generateByrefDisposeHelper(CodeGenFunction &CGF,
 
       Address initializedAddr = CGF.Builder.CreateStructGEP(
           addr, byrefInfo.IndexOfInitializedFlag, "byref.initialized");
+      // This is safe to load non-atomically because the store of true (if any)
+      // happens while the creating function still holds a reference.
       llvm::Value *initialized =
           CGF.Builder.CreateFlagLoad(initializedAddr.emitRawPointer(CGF));
 

--- a/clang/lib/CodeGen/CGBlocks.h
+++ b/clang/lib/CodeGen/CGBlocks.h
@@ -139,6 +139,7 @@ public:
   unsigned FieldIndex;
   CharUnits ByrefAlignment;
   CharUnits FieldOffset;
+  bool ForceNoopCopy;
 };
 
 /// Represents a type of copy/destroy operation that should be performed for an

--- a/clang/lib/CodeGen/CGBlocks.h
+++ b/clang/lib/CodeGen/CGBlocks.h
@@ -136,10 +136,14 @@ inline BlockFieldFlags operator|(BlockFieldFlag_t l, BlockFieldFlag_t r) {
 class BlockByrefInfo {
 public:
   llvm::StructType *Type;
+  /// Index of the field for the variable itself.
   unsigned FieldIndex;
   CharUnits ByrefAlignment;
   CharUnits FieldOffset;
-  bool ForceNoopCopy;
+  /// Whether this will be initialized directly on the heap.
+  bool ForInitOnHeap;
+  /// If ForInitOnHeap is true, index of the 'initialized' field.
+  unsigned IndexOfInitializedFlag;
 };
 
 /// Represents a type of copy/destroy operation that should be performed for an

--- a/clang/lib/CodeGen/CodeGenFunction.h
+++ b/clang/lib/CodeGen/CodeGenFunction.h
@@ -2313,7 +2313,8 @@ public:
 
   class AutoVarEmission;
 
-  void emitByrefInitOnHeap(llvm::Value *P);
+  void emitByrefHeapAlloc(llvm::Value *fakeByref, QualType declType);
+  void emitByrefMarkInitialized(const AutoVarEmission &emission);
   void emitByrefStructureInit(const AutoVarEmission &emission);
 
   /// Enter a cleanup to destroy a __block variable.  Note that this

--- a/clang/lib/CodeGen/CodeGenFunction.h
+++ b/clang/lib/CodeGen/CodeGenFunction.h
@@ -2313,6 +2313,7 @@ public:
 
   class AutoVarEmission;
 
+  void emitByrefInitOnHeap(llvm::Value *P);
   void emitByrefStructureInit(const AutoVarEmission &emission);
 
   /// Enter a cleanup to destroy a __block variable.  Note that this
@@ -3356,6 +3357,14 @@ public:
     /// escaping block.
     bool IsEscapingByRef;
 
+    /// True if the variable is a __block variable that is captured by a block
+    // referenced in its own initializer.
+    bool IsCapturedByOwnInit;
+
+    /// True if the variable is a __block variable that needs to be initialized
+    /// directly on the heap.
+    bool NeedsInitOnHeap;
+
     /// True if the variable is of aggregate type and has a constant
     /// initializer.
     bool IsConstantAggregate;
@@ -3374,7 +3383,8 @@ public:
 
     AutoVarEmission(const VarDecl &variable)
         : Variable(&variable), Addr(Address::invalid()), NRVOFlag(nullptr),
-          IsEscapingByRef(false), IsConstantAggregate(false),
+          IsEscapingByRef(false), IsCapturedByOwnInit(false),
+          NeedsInitOnHeap(false), IsConstantAggregate(false),
           SizeForLifetimeMarkers(nullptr), AllocaAddr(RawAddress::invalid()) {}
 
     bool wasEmittedAsGlobal() const { return !Addr.isValid(); }

--- a/clang/lib/CodeGen/CodeGenModule.h
+++ b/clang/lib/CodeGen/CodeGenModule.h
@@ -84,6 +84,7 @@ class InitSegAttr;
 
 namespace CodeGen {
 
+class BlockByrefInfo;
 class CodeGenFunction;
 class CodeGenTBAA;
 class CGCXXABI;
@@ -257,13 +258,16 @@ public:
   /// have different helper functions.
   CharUnits Alignment;
 
-  BlockByrefHelpers(CharUnits alignment)
-      : CopyHelper(nullptr), DisposeHelper(nullptr), Alignment(alignment) {}
+  /// Emit a trivial copy helper; true if the variable is NeedsInitOnHeap.
+  bool ForceNoopCopy;
+
+  BlockByrefHelpers(const BlockByrefInfo &byrefInfo);
   BlockByrefHelpers(const BlockByrefHelpers &) = default;
   virtual ~BlockByrefHelpers();
 
   void Profile(llvm::FoldingSetNodeID &id) const {
     id.AddInteger(Alignment.getQuantity());
+    id.AddInteger(ForceNoopCopy);
     profileImpl(id);
   }
   virtual void profileImpl(llvm::FoldingSetNodeID &id) const = 0;

--- a/clang/lib/CodeGen/CodeGenModule.h
+++ b/clang/lib/CodeGen/CodeGenModule.h
@@ -84,7 +84,6 @@ class InitSegAttr;
 
 namespace CodeGen {
 
-class BlockByrefInfo;
 class CodeGenFunction;
 class CodeGenTBAA;
 class CGCXXABI;
@@ -258,16 +257,13 @@ public:
   /// have different helper functions.
   CharUnits Alignment;
 
-  /// Emit a trivial copy helper; true if the variable is NeedsInitOnHeap.
-  bool ForceNoopCopy;
-
-  BlockByrefHelpers(const BlockByrefInfo &byrefInfo);
+  BlockByrefHelpers(CharUnits alignment)
+      : CopyHelper(nullptr), DisposeHelper(nullptr), Alignment(alignment) {}
   BlockByrefHelpers(const BlockByrefHelpers &) = default;
   virtual ~BlockByrefHelpers();
 
   void Profile(llvm::FoldingSetNodeID &id) const {
     id.AddInteger(Alignment.getQuantity());
-    id.AddInteger(ForceNoopCopy);
     profileImpl(id);
   }
   virtual void profileImpl(llvm::FoldingSetNodeID &id) const = 0;

--- a/clang/lib/Sema/Sema.cpp
+++ b/clang/lib/Sema/Sema.cpp
@@ -2177,6 +2177,13 @@ static void checkEscapingByref(VarDecl *VD, Sema &S) {
   SourceLocation Loc = VD->getLocation();
   Expr *VarRef =
       new (S.Context) DeclRefExpr(S.Context, VD, false, T, VK_LValue, Loc);
+  // Note: If needsInitOnHeap is true, the move/copy constructor will not
+  // actually be called, so in theory we don't have to require that it exists.
+  // But needsInitOnHeap is based on a conservative estimate of __block
+  // variables that might be retained in their own initializers; it could be
+  // refined in the future, which could cause variables to suddenly start
+  // requiring move constructors again.  To avoid the backwards compatibility
+  // hazard, require a move/copy constructor regardless of needsInitOnHeap.
   ExprResult Result;
   auto IE = InitializedEntity::InitializeBlock(Loc, T);
   if (S.getLangOpts().CPlusPlus23) {
@@ -2202,6 +2209,62 @@ static void checkEscapingByref(VarDecl *VD, Sema &S) {
       auto *FPT = DD->getType()->castAs<FunctionProtoType>();
       S.ResolveExceptionSpec(Loc, FPT);
     }
+}
+
+namespace {
+// Find blocks within a __block variable's initializer that capture that __block
+// variable.
+class CapturedByOwnInitVisitor
+    : public EvaluatedExprVisitor<CapturedByOwnInitVisitor> {
+  typedef EvaluatedExprVisitor<CapturedByOwnInitVisitor> Inherited;
+  VarDecl *const VD;
+
+public:
+  const BlockExpr *FoundBE;
+  CapturedByOwnInitVisitor(Sema &S, VarDecl *VD)
+      : Inherited(S.getASTContext()), VD(VD), FoundBE(nullptr) {}
+
+  void VisitBlockExpr(const BlockExpr *BE) {
+    if (FoundBE)
+      return; // No more work to do if already found.
+    for (const BlockDecl::Capture &BC : BE->getBlockDecl()->captures()) {
+      if (BC.getVariable() == VD) {
+        FoundBE = BE;
+        return;
+      }
+    }
+  }
+};
+} // namespace
+
+static void checkCapturedByOwnInit(VarDecl *VD, Sema &S) {
+  Expr *I = VD->getInit();
+  if (!I)
+    return;
+
+  // Check whether the variable is captured by a block literal within its own
+  // initializer.
+  CapturedByOwnInitVisitor V(S, VD);
+  V.Visit(I);
+  if (!V.FoundBE)
+    return;
+
+  if (VD->hasConstantInitialization()) {
+    // Block literals with captures can't be constant-evaluated.  But we can
+    // still reach here if the initializer syntactically contains a block
+    // literal that's never actually evaluated.  And if it's never evaluated,
+    // then we don't need to care about the capture.
+    return;
+  }
+
+  // Mark as self-capturing.
+  VD->setCapturedByOwnInit();
+  // If this is a record type, then it will need an implicit heap
+  // allocation, so warn.
+  if (VD->needsInitOnHeap()) {
+    S.Diag(VD->getLocation(), diag::warn_implicit_block_var_alloc) << VD;
+    S.Diag(V.FoundBE->getCaretLocation(), diag::note_because_captured_by_block);
+  }
 }
 
 static void markEscapingByrefs(const FunctionScopeInfo &FSI, Sema &S) {
@@ -2233,6 +2296,9 @@ static void markEscapingByrefs(const FunctionScopeInfo &FSI, Sema &S) {
     // __block variables might require us to capture a copy-initializer.
     if (!VD->isEscapingByref())
       continue;
+
+    checkCapturedByOwnInit(VD, S);
+
     // It's currently invalid to ever have a __block variable with an
     // array type; should we diagnose that here?
     // Regardless, we don't want to ignore array nesting when

--- a/clang/lib/Serialization/ASTReaderDecl.cpp
+++ b/clang/lib/Serialization/ASTReaderDecl.cpp
@@ -1629,6 +1629,7 @@ ASTDeclReader::RedeclarableResult ASTDeclReader::VisitVarDeclImpl(VarDecl *VD) {
         VarDeclBits.getNextBit();
 
     VD->NonParmVarDeclBits.EscapingByref = VarDeclBits.getNextBit();
+    VD->NonParmVarDeclBits.CapturedByOwnInit = VarDeclBits.getNextBit();
     HasDeducedType = VarDeclBits.getNextBit();
     VD->NonParmVarDeclBits.ImplicitParamKind =
         VarDeclBits.getNextBits(/*Width*/ 3);

--- a/clang/lib/Serialization/ASTWriterDecl.cpp
+++ b/clang/lib/Serialization/ASTWriterDecl.cpp
@@ -1153,6 +1153,7 @@ void ASTDeclWriter::VisitVarDecl(VarDecl *D) {
     VarDeclBits.addBit(D->isPreviousDeclInSameBlockScope());
 
     VarDeclBits.addBit(D->isEscapingByref());
+    VarDeclBits.addBit(D->isCapturedByOwnInit());
     HasDeducedType = D->getType()->getContainedDeducedType();
     VarDeclBits.addBit(HasDeducedType);
 
@@ -2513,13 +2514,14 @@ void ASTWriter::WriteDeclAbbrevs() {
   // VarDecl
   Abv->Add(BitCodeAbbrevOp(
       BitCodeAbbrevOp::Fixed,
-      21)); // Packed Var Decl bits:  Linkage, ModulesCodegen,
+      22)); // Packed Var Decl bits:  Linkage, ModulesCodegen,
             // SClass, TSCSpec, InitStyle,
             // isARCPseudoStrong, IsThisDeclarationADemotedDefinition,
             // isExceptionVariable, isNRVOVariable, isCXXForRangeDecl,
             // isInline, isInlineSpecified, isConstexpr,
             // isInitCapture, isPrevDeclInSameScope,
-            // EscapingByref, HasDeducedType, ImplicitParamKind, isObjCForDecl
+            // EscapingByref, CapturedByOwnInit, HasDeducedType,
+            // ImplicitParamKind, isObjCForDecl
   Abv->Add(BitCodeAbbrevOp(0));                         // VarKind (local enum)
   // Type Source Info
   Abv->Add(BitCodeAbbrevOp(BitCodeAbbrevOp::Array));

--- a/clang/test/CodeGenCXX/block-capture.cpp
+++ b/clang/test/CodeGenCXX/block-capture.cpp
@@ -1,4 +1,5 @@
-// RUN: %clang_cc1 -x c++ -std=c++11 -fblocks -emit-llvm %s -o - | FileCheck %s
+// RUN: %clang_cc1 -triple arm64e-apple-ios -x c++ -std=c++20 -fblocks -Wimplicit-block-var-alloc -verify -emit-llvm %s -o - | \
+// RUN:    FileCheck --implicit-check-not "call{{.*}}_ZN3Big" %s
 
 // CHECK: %struct.__block_byref_baz = type { ptr, ptr, i32, i32, i32 }
 // CHECK: [[baz:%[0-9a-z_]*]] = alloca %struct.__block_byref_baz
@@ -6,8 +7,128 @@
 // CHECK: store ptr [[baz]], ptr [[bazref]]
 // CHECK: call void @_Block_object_dispose(ptr [[baz]]
 
-int main() {
+int a() {
   __block int baz = [&]() { return 0; }();
-  ^{ (void)baz; };
+  (void)^{
+    (void)baz;
+  };
   return 0;
+}
+
+class Big {
+public:
+  Big(const Big &);
+  ~Big();
+
+private:
+  Big();
+  int s[100];
+};
+Big getBig(Big * (^)());
+
+// CHECK: define void @_Z11heapInitBigv
+// CHECK: call void @_Block_object_assign(ptr {{.*}}, ptr {{.*}}, i32 8)
+// CHECK: call void @_Block_object_dispose(ptr {{.*}}, i32 8)
+// CHECK: %B1 = getelementptr inbounds %struct.__block_byref_B, ptr %{{.*}}, i32 0, i32 6
+// CHECK: call void @_Z6getBigU13block_pointerFP3BigvE({{[^,]*}} %B1,
+// CHECK: call void @_Block_object_dispose
+// (no call to destructor, enforced by --implicit-check-not)
+
+// CHECK: define internal void @__Block_byref_object_copy_
+// (no call to copy constructor, enforced by --implicit-check-not)
+
+// CHECK: define internal void @__Block_byref_object_dispose_
+// CHECK: call {{.*}} @_ZN3BigD1Ev(
+
+void heapInitBig() {
+  // expected-warning@+1{{variable 'B' will be initialized in a heap allocation}}
+  __block Big B = ({ // Make sure this works with statement expressions.
+    getBig(
+        // expected-note@+1{{because it is captured by a block used in its own initializer}}
+        ^{
+          return &B;
+        });
+  });
+}
+
+struct Small {
+  int x[2];
+};
+extern Small getSmall(const void * (^)());
+extern Small getSmall(const void * (^)(), const void * (^)());
+extern Small getSmall(__SIZE_TYPE__);
+extern int getInt(const void *(^)());
+
+// CHECK: %S11 = getelementptr inbounds %struct.__block_byref_S1, ptr %{{.*}}, i32 0, i32 4
+// CHECK: [[call:%[0-9a-z_\.]*]] = call i64 @_Z8getSmallU13block_pointerFPKvvE(
+// CHECK: [[dive:%[0-9a-z_\.]*]] = getelementptr inbounds %struct.Small, ptr %S11, i32 0, i32 0
+// CHECK: store i64 [[call]], ptr [[dive]], align 8
+
+void heapInitSmallAtomic() {
+  // expected-warning@+1{{variable 'S1' will be initialized in a heap allocation}}
+  __block _Atomic(Small) S1 = getSmall(
+      // expected-note@+1{{because it is captured by a block used in its own initializer}}
+      ^const void * {
+        return &S1;
+      });
+}
+
+// With multiple blocks capturing the same variable, we only note the first one.
+// In theory it would be more helpful to note each block, but that would mess up
+// the grammar of the diagnostic.
+void heapInitTwoSmall() {
+  // expected-warning@+1{{variable 'S2' will be initialized in a heap allocation}}
+  __block Small S2 = getSmall(
+      // expected-note@+1{{because it is captured by a block used in its own initializer}}
+      ^const void * {
+        return &S2;
+      },
+      ^const void * {
+        return &S2;
+      });
+}
+
+// This used to cause an ICE because the type of the variable makes it eligible
+// for constant initialization (but the actual initializer doesn't).
+//
+// It's also not actually a self-reference, so we should not get the warning.
+// The block is not capturing itself; it's only capturing a pointer to itself
+// (thus, e.g., calling Block_copy would not make it safe to use after the
+// function returns).  You might expect C++ lifetime extension to affect this
+// but it doesn't.
+void constRef() {
+  __block const Small &S = getSmall(^const void * {
+    return &S;
+  });
+}
+
+// This is also not actually a self-reference because the block literal
+// is in an unevaluated expression.  We should not get the warning.
+void unevaluated() {
+  __block Small S = getSmall(sizeof(^const void * {
+    return &S;
+  }));
+}
+
+// These are not self-references because the initializers are
+// const-evaluated and the block literal happens to never get executed
+// (despite not being in an "unevaluated expression" type-system-wise).
+void constInits() {
+  __block constexpr const int I = true ? 1000 : getInt(^const void *{
+    return &I;
+  });
+  __block constexpr Small S = true ? Small{2000, 3000} : getSmall(^const void *{
+    return &S;
+  });
+  __block const Small &S2 = true ? Small{4000, 5000} : getSmall(^const void *{
+    return &S2;
+  });
+}
+
+// This is definitely not a self-reference.
+void irrelevantVariable() {
+  __block Small Irrelevant;
+  __block Small NotCaptured = getSmall(^const void * {
+    return &Irrelevant;
+  });
 }


### PR DESCRIPTION
This is an updated version of https://reviews.llvm.org/D90434 from 2020.  Due to time constraints I stopped working on the patch, and unfortunately never got back around to it until now.

Clang special-cases `__block` variables whose initializer contains a block literal that captures the variable itself.  But this special case doesn't work for variables of record types, causing Clang to emit broken code.

Fix this by initializing such variables directly on the heap, and add a warning for when this needs to be done.

### Background on the special case

`__block` variables are unique in that their address can change during the lifetime of the variable.  Each `__block` variable starts on the stack.  But when a block is retained using `Block_copy`, both the block itself and any `__block` variables it captures are moved to the heap.

What's tricky is when this move happens while the variable is still being initialized.  For example:

```c
int copyBlockAndReturnInt(void (^block)(void)) {
    Block_copy(block);
    return 42;
}

int main() {
  __block int val = copyBlockAndReturnInt(^{
      printf("%d\n", val);
  });
}
```

Here, when `Block_copy` is called, `val` is moved to the heap while still in an uninitialized state.  Then when `copyBlockAndReturnInt` returns, `main` needs to store the return value to the variable's new location, not to the original stack slot.

This can only happen if a block literal that captures the variable is located syntactically within the initializer itself.  If it's before the initializer then it couldn't capture the variable, and if it's after the initializer then it couldn't execute during initialization.

So Clang detects when such a literal exists inside the initializer; `CGDecl.cpp` refers to this condition as `capturedByInit`.  If it does, then the initialization code operates in a special mode.  In several functions in that file, there's an `LValue` object and an accompanying `capturedByInit` flag. If `capturedByInit` is false (the typical case), then the lvalue points to the object being initialized.  But if it's true, the lvalue points to the byref header.  Then, depending on the type of the variable, you end up at one of many checks of the form:

```cpp
if (capturedByInit)
  drillIntoBlockVariable(*this, lvalue, cast<VarDecl>(D));
```

`drillIntoBlockVariable` emits a load of the forwarding pointer from the byref header (to find the object's current location), and then modifies `lvalue` to point to the object, unifying the two cases.  Importantly, this happens at the last minute: after emitting code to evaluate the initializer, but before emitting the `store` instruction to write the evaluated value into the variable.

Okay, but then why are there two different code paths?  If the address calculation can be safely deferred, why not just do that all the time rather than having a separate mode just for self-capturing `__block` variables?

Because it *can't* always be safely deferred.

### Harder cases

First, consider the case where variable being initialized is a C struct.  This is already problematic.  `drillIntoBlockVariable` is supposed to be called after evaluating the initializer but before doing a `store`.  But when initializing a struct, Clang doesn't evaluate the whole initializer before storing.  Instead it evaluates the first field, stores the first field, evaluates the second field, stores the second field, and so on.  This is actually necessary for correctness[^1] given code like:

```c
struct Foo { int a, b; };
struct Foo foo = {1, foo.a};
```

But if any one of the field evaluations can move the object, then Clang would need to reload the forwarding pointer before storing each field.  And that would need to apply recursively to any subfields.  Such a scheme is definitely possible, but Clang doesn't implement it.

And if instead of a C struct you have a C++ class, supporting relocation to the heap becomes flat-out impossible.  Consider:

```cpp
struct Foo {
    void (^block_)(void);
    Foo(void (^block)(void)) {
        printf("I am at %p\n", this);
        block_ = Block_copy(block);
        printf("I am now at %p\n", this); // shouldn't change!
    }
};

__block Foo foo(^{
    printf("%p\n", &foo);
});
```

C++ constructors can observe the address of the object being constructed, and expect that address not to change.  Once the object has finished being constructed, it can be relocated by calling the move or copy constructor, and that's what Clang uses for block captures in the non-self-capturing case.  But in this case, `Block_copy` is called while the stack object is still running its constructor.  It would be nonsensical to try to move out of it in this state.

### Clang's current behavior

So what does Clang currently do?  Well, for both C structs and C++ classes (as well as unions[^2]), it runs into this TODO dating to 2011:

```cpp
case TEK_Aggregate:
  [...]
    // TODO: how can we delay here if D is captured by its initializer?
```

Clang simply neglects to call `drillIntoBlockVariable` and falls into its normal initialization code.  That means the lvalue is initialized as if it pointed to the object, when it actually points to the byref header.  As such, the generated code is non-functional.  And this is true for all `__block` variables of record type that Clang detects as self-capturing, even if the initializer never actually calls `Block_copy`.

### Solution

As stated, it's impossible for self-capturing variables of at least some record types to support moving to the heap.  But there is a way to make them work regardless.  Any given `__block` variable can move at most once, from the stack to the heap.  Once on the heap, it never needs to move again.  So, as suggested by @rjmccall in 2020, we can create a heap allocation before initialization even starts, and then initialize the object directly on the heap, knowing its address will remain stable.

This patch applies this approach to all self-capturing `__block` variables with record type, i.e. all variables that previously triggered the broken code generation.

The obvious downside of the approach that we pay the cost of a heap allocation even if `Block_copy` is never called.  Conveniently, this can never be a performance regression *per se*, since the affected cases didn't work at all before.  Still, there is room for future improvement, such as by making mid-initialization relocation work for C structs[^3], or detecting initializers that do contain a block literal but can't possibly call `Block_copy` on it.

To assist performance-sensitive codebases, this patch adds a warning, `-Wimplicit-block-var-alloc`, that triggers whenever a block requires an implicit allocation.  Since most codebases probably don't care, this warning is disabled by default and is not included in any standard warning groups.

### Allocation failure

Another downside of the approach is that because the heap allocation is completely implicit, there is no way to check for allocation failure.  Normally, heap allocation happens only when you call `Block_copy`, which means you can catch allocation failure by checking whether `Block_copy` returns NULL.

...Or so I thought.  It turns out that checking `Block_copy`'s return value is only a half-measure.  `Block_copy` does return NULL if there's an allocation failure when moving the block itself to the heap.  But then `Block_copy` calls into the copy helper to move captured variables to the heap, which can also fail.  If it does, the copy helper has no way to report that failure.  Instead you just get a crash (which should probably be a proper abort; Apple folks, see rdar://126632757).  This limitation is more or less baked into the ABI, since copy helpers return void.  Even xnu, which uses blocks in kernel space, does not support allocation failure for them - though, luckily, xnu's version [waits for memory to be available rather than crashing](https://github.com/apple-oss-distributions/xnu/blob/94d3b452840153a99b38a3a9659680b2a006908e/libkern/libclosure/runtime.cpp#L49).

The point is, if recovery from allocation failure is already not a thing, then this patch isn't responsible for breaking it.  Even if blocks are changed someday to support it, it would probably be desired only by a tiny minority of codebases, and those codebases could avoid implicit allocations by enabling the new warning and setting it as an error.

### ABI limitation

The blocks runtime has no API to allocate a byref struct directly on the heap, because it's never been necessary before.  There is only `_Block_object_assign` to move one from the stack to the heap.  It would be nice to add an API to allocate directly on the heap, but for the dual sakes of backward compatibility and laziness, I have not attempted to do so.

Instead, the codegen works with the existing runtime, as follows.  First, a byref struct is allocated on the stack (including space for the object), but only the header is initialized; the object part is left uninitialized.  Then `_Block_object_assign` is called to migrate it to the heap (which unfortunately pays the cost of memcpying the uninitialized stack memory to the heap).  This produces the desired heap allocation, but also increases the reference count, which is balanced by immediately calling `_Block_object_dispose`.  After that, the object can finally be initialized inside the new heap allocation.

### Improved self-capture analysis

The existing check for self-capturing `__block` variables is implemented in the function `isCapturedBy`.  But it turns out that that implementation is overcomplicated for no good reason.  In ancient days (2011), `isCapturedBy` only worked on `Expr`s, and it recursed on the `Expr`'s children, which it assumed would also be `Expr`s.  This assumption turned out to be false for GNU statement expressions.  The simple fix would have been to change `isCapturedBy` to accept and recurse on arbitrary `Stmt`s instead, since `children()` is defined for all `Stmt`s, not just `Expr`s.  I'm not sure if there was some reason that wasn't possible at the time, but what happened instead is that a special case was added for statement expressions, which over a series of patches got more and more convoluted.

This patch replaces the whole thing with an `EvaluatedExprVisitor` (another suggestion from @rjmccall).  This is not only simpler, but also more precise, eliminating false positive self-captures including:

- Block literals in unevaluated contexts (`sizeof(^{ ... })`).

- Some types of statements inside GNU statement expressions.

This patch also moves the self-capture check earlier in the compilation process, from CodeGen to Sema.  This is necessary in order to support the aforementioned warning.

### Constant initialization

This patch also fixes a related bug where self-capturing `__block` variables could trigger this assert:

```cpp
assert(!capturedByInit && "constant init contains a capturing block?");
```

The assert is important, because constant initialization doesn't support the `drillIntoBlockVariable` mechanism.  Now, a constant initializer obviously can't include a call to `Block_copy`; in fact, it can't include block literals at all unless they have no captures.  But I found two cases where the assert can be triggered anyway.

First, the initializer can syntactically contain a capturing block literal but never evaluate it:

```cpp
__block constexpr int foo = true ? 1 : ^{ return foo; }();
```

This is addressed in this patch by forcing constant-initialized variables to be treated as non-self-capturing.

Second, the initializer can simply not be constant.  With variables of types like `const int`, Clang first tries to constant-evaluate the initializer, then falls back to runtime initialization if that fails.  But the assert is located in a place where it triggers just based on the try.  This is addressed in this patch by moving the assert down and conditioning it on constant evaluation succeeding.

[^1]: Supporting such code appears to be required by the C++ spec (see
    https://timsong-cpp.github.io/cppwp/n4861/dcl.init.aggr#6), though not
    by the C spec (see https://port70.net/~nsz/c/c11/n1570.html#6.7.9p23).

[^2]: There are other `TEK_Aggregate` types besides records, but all such
    types either can't be captured by blocks (arrays) or can't be the
    type of a local variable at all.

[^3]: Though even in C, moving mid-initializer could break code that took the address of the variable:

    ```c
    struct Foo { void *a; void *(^b)(void); };
    __block struct Foo x = {&x.b, Block_copy(^{ return x.a; })};
    assert(x.a == &x.b); // fails without up-front heap allocation
    ```

    However, it's a bit less obvious that such code *needs* to work; perhaps the user should just be aware the variable will be moving.  It's not like C++ where construction is clearly an indivisible operation performed at a single address.

