### PR TITLE
[run-clang-tidy.py] Refactor, add progress indicator, add type hints

### DIFF
--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -116,6 +116,8 @@ Improvements to clang-tidy
 - Improved :program:`run-clang-tidy.py` script. Added argument `-source-filter`
   to filter source files from the compilation database, via a RegEx. In a
   similar fashion to what `-header-filter` does for header files.
+  Added progress indicator with a number of processed files and the runtime of
+  each invocation after completion.
 
 - Improved :program:`check_clang_tidy.py` script. Added argument `-export-fixes`
   to aid in clang-tidy and test development.


### PR DESCRIPTION
[There is work](https://discourse.llvm.org/t/rfc-upgrading-llvms-minimum-required-python-version/67571) to make Python 3.8 the minimum Python version for LLVM.

I edited this script because I wanted some indicator of progress while going through files.
It now outputs `[XX/YYY]` with the number of processed and total files after each completion.

The current version of this script is compatible downto Python 3.6 (this is PyYAML's minimum version).
It would probably work with older Python 3 versions with an older PyYAML or when YAML is disabled.

With the updates here, it is compatible downto Python 3.7. Python 3.7 was released June 2018.

https://github.com/llvm/llvm-project/pull/89302 is also touching this file, I don't mind rebasing on top of that work if needed.

### Summary

 -  Add type annotations.
 -  Replace `threading` + `queue` with `asyncio`.
 -  **Add indicator of processed files over total files**. This is what I set out to do initially.
 -  Only print the filename after completion, not the entire Clang-Tidy invocation command. I find this neater but the behavior can easily be restored.

### MyPy

```
% python3 -m mypy --strict clang-tools-extra/clang-tidy/tool/run-clang-tidy.py
Success: no issues found in 1 source file
```

### Performance

Just to make sure the `asyncio` change didn't introduce a regression, I ran the previous version and this version 5 times with the following command.

```
time python3 ~/llvm-project/clang-tools-extra/clang-tidy/tool/run-clang-tidy.py \
    -clang-tidy-binary="~/llvm-project/build/bin/clang-tidy" \
    -clang-apply-replacements-binary="~/llvm-project/build/bin/clang-apply-replacements" \
    -checks="-*,modernize-use-starts-ends-with" \
    -source-filter ".*clang-tools-extra/clang-tidy.*" \
    -fix -format
```

Runtimes are identical, no performance regression detected on my setup.

| Version | Time (s)   |
|---------|------------|
| Old     | 92.0 ± 1.4 |
| New     | 92.2 ± 1.5 |