### PR TITLE
[memprof] Omit the key length for the call stack table

### DIFF
--- a/llvm/include/llvm/ProfileData/MemProf.h
+++ b/llvm/include/llvm/ProfileData/MemProf.h
@@ -651,8 +651,8 @@ public:
   EmitKeyDataLength(raw_ostream &Out, key_type_ref K, data_type_ref V) {
     using namespace support;
     endian::Writer LE(Out, llvm::endianness::little);
+    // We do not explicitly emit the key length because it is a constant.
     offset_type N = sizeof(K);
-    LE.write<offset_type>(N);
     offset_type M = sizeof(FrameId) * V.size();
     LE.write<offset_type>(M);
     return std::make_pair(N, M);
@@ -696,8 +696,8 @@ public:
   ReadKeyDataLength(const unsigned char *&D) {
     using namespace support;
 
-    offset_type KeyLen =
-        endian::readNext<offset_type, llvm::endianness::little>(D);
+    // We do not explicitly read the key length because it is a constant.
+    offset_type KeyLen = sizeof(external_key_type);
     offset_type DataLen =
         endian::readNext<offset_type, llvm::endianness::little>(D);
     return std::make_pair(KeyLen, DataLen);


### PR DESCRIPTION
The call stack table has a constant key length, so we don't need to
serialize or deserialize it for every key-data pair.  Omitting the key
length saves 0.64% of the indexed MemProf file size.

Note that it's OK to change the format because Version2 is still under
development.
