### PR TITLE
[SelectionDAG] Remove redundant KnownBits smin and smax operations

### DIFF
--- a/llvm/lib/CodeGen/SelectionDAG/SelectionDAG.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/SelectionDAG.cpp
@@ -5399,9 +5399,6 @@ bool SelectionDAG::isKnownNeverZero(SDValue Op, unsigned Depth) const {
     if (Op1.isNonZero() && Op0.isNonZero())
       return true;
 
-    if (KnownBits::smax(Op0, Op1).isNonZero())
-      return true;
-
     return isKnownNeverZero(Op.getOperand(1), Depth + 1) &&
            isKnownNeverZero(Op.getOperand(0), Depth + 1);
   }
@@ -5415,9 +5412,6 @@ bool SelectionDAG::isKnownNeverZero(SDValue Op, unsigned Depth) const {
       return true;
 
     if (Op1.isNonZero() && Op0.isNonZero())
-      return true;
-
-    if (KnownBits::smin(Op0, Op1).isNonZero())
       return true;
 
     return isKnownNeverZero(Op.getOperand(1), Depth + 1) &&


### PR DESCRIPTION
It turns out that if any of the operations can be zero, and neither of the operands can be proven to be positive, it is possible for smax to be zero, and KnownBits cannot prove otherwise even with KnownBits::smax. In fact, proving it based on the KnownBits itself at that point without increasing the depth is actually, provably impossible.

Same with smin.

This covers all the possible cases and is proven to be complete.