### PR TITLE
[Workflows] Re-write release-binaries workflow

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -106,7 +106,7 @@ jobs:
     - name: Build Stage 1 Clang
       run: |
         sudo chown $USER:$USER /mnt/
-        cmake -G Ninja -C clang/cmake/caches/Release.cmake -DCMAKE_C_COMPILER_LAUNCHER=sccache -DCMAKE_CXX_COMPILER_LAUNCHER=sccache -DCMAKE_POSITION_INDEPENDENT_CODE=ON -S llvm -B /mnt/build
+        cmake -G Ninja -C clang/cmake/caches/Release.cmake -DCMAKE_C_COMPILER_LAUNCHER=sccache -DCMAKE_CXX_COMPILER_LAUNCHER=sccache -S llvm -B /mnt/build
         ninja -v -C /mnt/build
 
     # We need to create an archive of the build directory, because it has too

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -38,9 +38,6 @@ jobs:
     if: github.repository == 'llvm/llvm-project'
     outputs:
       release-version: ${{ steps.vars.outputs.release-version }}
-      flags: ${{ steps.vars.outputs.flags }}
-      build-dir: ${{ steps.vars.outputs.build-dir }}
-      rc-flags: ${{ steps.vars.outputs.rc-flags }}
       ref: ${{ steps.vars.outputs.ref }}
       upload: ${{ steps.vars.outputs.upload }}
 
@@ -85,17 +82,11 @@ jobs:
         fi
         bash .github/workflows/set-release-binary-outputs.sh "$tag" "$upload"
 
-  # Try to get around the 6 hour timeout by first running a job to fill
-  # the build cache.
-  fill-cache:
-    name: "Fill Cache ${{ matrix.os }}"
+  build-stage1-linux:
+    name: "Build Stage 1 Linux"
     needs: prepare
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-22.04
     if: github.repository == 'llvm/llvm-project'
-    strategy:
-      matrix:
-        os:
-          - ubuntu-22.04
     steps:
     - name: Checkout LLVM
       uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
@@ -109,81 +100,216 @@ jobs:
       uses: hendrikmuhs/ccache-action@ca3acd2731eef11f1572ccb126356c2f9298d35e # v1.2.9
       with:
         max-size: 250M
-        key: sccache-${{ matrix.os }}-release
+        key: sccache-${{ runner.os }}-release
         variant: sccache
 
-    - name: Build Clang
+    - name: Build Stage 1 Clang
       run: |
-        cmake -G Ninja -C clang/cmake/caches/Release.cmake -DCMAKE_C_COMPILER_LAUNCHER=sccache -DCMAKE_CXX_COMPILER_LAUNCHER=sccache -DCMAKE_POSITION_INDEPENDENT_CODE=ON -S llvm -B build
-        ninja -v -C build clang
+        sudo chown $USER:$USER /mnt/
+        mkdir -p /mnt/build
+        cmake -G Ninja -C clang/cmake/caches/Release.cmake -DCMAKE_C_COMPILER_LAUNCHER=sccache -DCMAKE_CXX_COMPILER_LAUNCHER=sccache -DCMAKE_POSITION_INDEPENDENT_CODE=ON -S llvm -B /mnt/build
+        ninja -v -C /mnt/build
 
+    # We need to create an archive of the build directory, because it has too
+    # many files to upload.
+    - name: Package Build and Source Directories
+      run: |
+        tar -czf ${{ github.workspace }}/../llvm-project.tar.gz .
+        mv ../llvm-project.tar.gz ${{ github.workspace }}
+        tar -C /mnt/ -czf ${{ github.workspace }}/build.tar.gz build/
 
-  build-binaries:
-    name: ${{ matrix.target.triple }}
-    permissions:
-      contents: write # To upload assets to release.
+    - name: Upload Stage 1 Source
+      uses: actions/upload-artifact@26f96dfa697d77e81fd5907df203aa23a56210a8 #v4.3.0
+      with:
+        name: stage1-source
+        path: ${{ github.workspace }}/llvm-project.tar.gz
+        retention-days: 2
+
+    - name: Upload Stage 1 Build Dir
+      uses: actions/upload-artifact@26f96dfa697d77e81fd5907df203aa23a56210a8 #v4.3.0
+      with:
+        name: stage1-build
+        path: ${{ github.workspace }}/build.tar.gz
+        retention-days: 2
+
+  build-stage2-linux:
+    name: "Build Stage 2 Linux"
     needs:
       - prepare
-      - fill-cache
-    runs-on: ${{ matrix.target.runs-on }}
+      - build-stage1-linux
+    runs-on: ubuntu-22.04
     if: github.repository == 'llvm/llvm-project'
-    strategy:
-      fail-fast: false
-      matrix:
-        target:
-          - triple: x86_64-linux-gnu-ubuntu-22.04
-            os: ubuntu-22.04
-            runs-on: ubuntu-22.04-16x64
-            debian-build-deps: >
-              chrpath
-              gcc-multilib
-              ninja-build
+    steps:
+    - name: Install Ninja
+      uses: llvm/actions/install-ninja@22e9f909d35b50bd1181709564bfe816eaeaae81 # main
+
+    - name: Download Stage 1 Artifacts
+      uses: actions/download-artifact@6b208ae046db98c579e8a3aa621ab581ff575935 # v4.1.1
+      with:
+        pattern: stage1-*
+        merge-multiple: true
+
+    - name: Unpack Artifacts
+      run: |
+        tar -xzf llvm-project.tar.gz
+        rm llvm-project.tar.gz
+        sudo chown $USER:$USER /mnt/
+        tar -C /mnt -xzf build.tar.gz
+        rm build.tar.gz
+
+    - name: Build Stage 2
+      run: |
+        ninja -C /mnt/build stage2-instrumented
+
+    # We need to create an archive of the build directory, because it has too
+    # many files to upload.
+    - name: Save Build and Source Directories
+      run: |
+        tar -czf ${{ github.workspace }}/../llvm-project.tar.gz .
+        mv ../llvm-project.tar.gz ${{ github.workspace }}
+        tar -C /mnt/ -czf ${{ github.workspace }}/build.tar.gz build/
+
+    - name: Upload Stage 2 Source
+      uses: actions/upload-artifact@26f96dfa697d77e81fd5907df203aa23a56210a8 #v4.3.0
+      with:
+        name: stage2-source
+        path: ${{ github.workspace }}/llvm-project.tar.gz
+        retention-days: 2
+
+    - name: Upload Stage 2 Build Dir
+      uses: actions/upload-artifact@26f96dfa697d77e81fd5907df203aa23a56210a8 #v4.3.0
+      with:
+        name: stage2-build
+        path: ${{ github.workspace }}/build.tar.gz
+        retention-days: 2
+
+
+  build-stage3-linux:
+    name: "Build Stage 3 Linux"
+    needs:
+      - prepare
+      - build-stage2-linux
+    outputs:
+      filename: ${{ steps.package-info.outputs.release-filename }}
+    runs-on: ubuntu-22.04-16x64
+    if: github.repository == 'llvm/llvm-project'
+    steps:
+    - name: Install Ninja
+      uses: llvm/actions/install-ninja@22e9f909d35b50bd1181709564bfe816eaeaae81 # main
+
+    - name: 'Download artifact'
+      uses: actions/download-artifact@6b208ae046db98c579e8a3aa621ab581ff575935 # v4.1.1
+      with:
+        pattern: stage2-*
+        merge-multiple: true
+
+    - name: Unpack Artifact
+      run: |
+        tar -xzf llvm-project.tar.gz
+        rm llvm-project.tar.gz
+        sudo chown $USER:$USER /mnt/
+        tar -C /mnt -xzf build.tar.gz
+        rm build.tar.gz
+
+    - name: Build Release Package
+      run: |
+        ninja -C /mnt/build stage2-package
+
+    - id: package-info
+      run: |
+        filename="LLVM-${{ needs.prepare.outputs.release-version }}-Linux.tar.Z"
+        echo "filename=$filename" >> $GITHUB_OUTPUT
+        echo "path=/mnt/build/tools/clang/stage2-instrumented-bins/tools/clang/stage2-bins/$filename" >> $GITHUB_OUTPUT
+
+    - uses: actions/upload-artifact@26f96dfa697d77e81fd5907df203aa23a56210a8 #v4.3.0
+      if: always()
+      with:
+        name: release-binary
+        path: ${{ steps.package-info.outputs.path }}
+
+    # Clean up some build files to reduce size of artifact.
+    - name: Clean Up Build Directory
+      run: |
+        find /mnt/build -iname ${{ steps.package-info.outputs.filename }} -delete
+
+    # We need to create an archive of the build directory, because it has too
+    # many files to upload.
+    - name: Save Build and Source Directories
+      run: |
+        sudo apt-get update
+        sudo apt-get install pbzip2
+        tar -czf ${{ github.workspace }}/../llvm-project.tar.gz .
+        mv ../llvm-project.tar.gz ${{ github.workspace }}
+        # Use bzip2 for better compression since this file will be huge.
+        tar -C /mnt/ -c build/ | pbzip2 -c > ${{ github.workspace }}/build.tar.bz2
+
+    - name: Upload Stage 3 Source
+      uses: actions/upload-artifact@26f96dfa697d77e81fd5907df203aa23a56210a8 #v4.3.0
+      with:
+        name: stage3-source
+        path: ${{ github.workspace }}/llvm-project.tar.gz
+        retention-days: 2
+
+    - name: Upload Stage 3 Build Dir
+      uses: actions/upload-artifact@26f96dfa697d77e81fd5907df203aa23a56210a8 #v4.3.0
+      with:
+        name: stage3-build
+        path: ${{ github.workspace }}/build.tar.bz2
+        retention-days: 2
+
+  upload-release-binaries-linux:
+    name: "Upload Linux Release Binaries"
+    needs:
+      - prepare
+      - build-stage3-linux
+    if : ${{ needs.prepare.outputs.upload == 'true' }}
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: write # For release uploads
 
     steps:
-    - name: Checkout LLVM
-      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+    - name: 'Download artifact'
+      uses: actions/download-artifact@6b208ae046db98c579e8a3aa621ab581ff575935 # v4.1.1
       with:
-        ref: ${{ needs.prepare.outputs.ref }}
-        path: ${{ needs.prepare.outputs.build-dir }}/llvm-project
+        name: release-binary
 
-    - name: Setup sccache
-      uses: hendrikmuhs/ccache-action@ca3acd2731eef11f1572ccb126356c2f9298d35e # v1.2.9
-      with:
-        max-size: 250M
-        key: sccache-${{ matrix.target.os }}-release
-        save: false
-        variant: sccache
-
-    - name: Install Brew build dependencies
-      if: matrix.target.brew-build-deps != ''
-      run: brew install ${{ matrix.target.brew-build-deps }}
-
-    - name: Install Debian build dependencies
-      if: matrix.target.debian-build-deps != ''
-      run: sudo apt install ${{ matrix.target.debian-build-deps }}
-
-    - name: Set macOS build env variables
-      if: runner.os == 'macOS'
-      run: |
-        echo "MACOSX_DEPLOYMENT_TARGET=10.9" >> "$GITHUB_ENV"
-
-    - name: Build and test release
-      run: |
-        ${{ needs.prepare.outputs.build-dir }}/llvm-project/llvm/utils/release/test-release.sh \
-        ${{ needs.prepare.outputs.flags }} \
-        -triple ${{ matrix.target.triple }} \
-        -use-ninja \
-        -no-checkout \
-        -use-cmake-cache \
-        -no-test-suite \
-        -configure-flags "-DCMAKE_C_COMPILER_LAUNCHER=sccache -DCMAKE_CXX_COMPILER_LAUNCHER=sccache"
-
-    - name: Upload binaries
-      if: ${{ always() && needs.prepare.outputs.upload == 'true' }}
+    - name: Upload Release
       run: |
         sudo apt install python3-github
-        ${{ needs.prepare.outputs.build-dir }}/llvm-project/llvm/utils/release/github-upload-release.py \
+        ./llvm-project/llvm/utils/release/github-upload-release.py \
         --token ${{ github.token }} \
         --release ${{ needs.prepare.outputs.release-version }} \
         upload \
-        --files ${{ needs.prepare.outputs.build-dir }}/clang+llvm-${{ needs.prepare.outputs.release-version }}-${{ matrix.target.triple }}.tar.xz
+        --files ${{ needs.build-stage3-linux.outputs.release-filename }}
+
+
+  test-stage3-linux:
+    name: "Test Stage 3 Linux"
+    needs:
+      - prepare
+      - build-stage3-linux
+    runs-on: ubuntu-22.04
+    if: github.repository == 'llvm/llvm-project'
+    steps:
+    - name: Install Ninja
+      uses: llvm/actions/install-ninja@22e9f909d35b50bd1181709564bfe816eaeaae81 # main
+
+    - name: 'Download artifact'
+      uses: actions/download-artifact@6b208ae046db98c579e8a3aa621ab581ff575935 # v4.1.1
+      with:
+        pattern: stage3-*
+        merge-multiple: true
+
+    - name: Unpack Artifact
+      run: |
+        sudo apt-get update
+        sudo apt-get install bzip2
+        tar -xzf llvm-project.tar.gz
+        rm llvm-project.tar.gz
+        sudo chown $USER:$USER /mnt/
+        tar -C /mnt -xjf build.tar.bz2
+        rm build.tar.bz2
+
+    - name: Run Tests
+      run: |
+        ninja -C /mnt/build stage2-check-all

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -106,7 +106,6 @@ jobs:
     - name: Build Stage 1 Clang
       run: |
         sudo chown $USER:$USER /mnt/
-        mkdir -p /mnt/build
         cmake -G Ninja -C clang/cmake/caches/Release.cmake -DCMAKE_C_COMPILER_LAUNCHER=sccache -DCMAKE_CXX_COMPILER_LAUNCHER=sccache -DCMAKE_POSITION_INDEPENDENT_CODE=ON -S llvm -B /mnt/build
         ninja -v -C /mnt/build
 
@@ -114,22 +113,22 @@ jobs:
     # many files to upload.
     - name: Package Build and Source Directories
       run: |
-        tar -czf ${{ github.workspace }}/../llvm-project.tar.gz .
-        mv ../llvm-project.tar.gz ${{ github.workspace }}
-        tar -C /mnt/ -czf ${{ github.workspace }}/build.tar.gz build/
+        tar -czf /mnt/build/llvm-project.tar.gz .
+        mv /mnt/build/llvm-project.tar.gz .
+        tar -C /mnt/ -czf build.tar.gz build/
 
     - name: Upload Stage 1 Source
       uses: actions/upload-artifact@26f96dfa697d77e81fd5907df203aa23a56210a8 #v4.3.0
       with:
         name: stage1-source
-        path: ${{ github.workspace }}/llvm-project.tar.gz
+        path: llvm-project.tar.gz
         retention-days: 2
 
     - name: Upload Stage 1 Build Dir
       uses: actions/upload-artifact@26f96dfa697d77e81fd5907df203aa23a56210a8 #v4.3.0
       with:
         name: stage1-build
-        path: ${{ github.workspace }}/build.tar.gz
+        path: build.tar.gz
         retention-days: 2
 
   build-stage2-linux:
@@ -165,9 +164,9 @@ jobs:
     # many files to upload.
     - name: Save Build and Source Directories
       run: |
-        tar -czf ${{ github.workspace }}/../llvm-project.tar.gz .
-        mv ../llvm-project.tar.gz ${{ github.workspace }}
-        tar -C /mnt/ -czf ${{ github.workspace }}/build.tar.gz build/
+        tar -czf /mnt/build/llvm-project.tar.gz .
+        mv /mnt/build/llvm-project.tar.gz .
+        tar -C /mnt/ -czf build.tar.gz build/
 
     - name: Upload Stage 2 Source
       uses: actions/upload-artifact@26f96dfa697d77e81fd5907df203aa23a56210a8 #v4.3.0
@@ -217,7 +216,7 @@ jobs:
 
     - id: package-info
       run: |
-        filename="LLVM-${{ needs.prepare.outputs.release-version }}-Linux.tar.Z"
+        filename="LLVM-${{ needs.prepare.outputs.release-version }}-Linux.tar.gz"
         echo "filename=$filename" >> $GITHUB_OUTPUT
         echo "path=/mnt/build/tools/clang/stage2-instrumented-bins/tools/clang/stage2-bins/$filename" >> $GITHUB_OUTPUT
 
@@ -236,25 +235,22 @@ jobs:
     # many files to upload.
     - name: Save Build and Source Directories
       run: |
-        sudo apt-get update
-        sudo apt-get install pbzip2
-        tar -czf ${{ github.workspace }}/../llvm-project.tar.gz .
-        mv ../llvm-project.tar.gz ${{ github.workspace }}
-        # Use bzip2 for better compression since this file will be huge.
-        tar -C /mnt/ -c build/ | pbzip2 -c > ${{ github.workspace }}/build.tar.bz2
+        tar -czf /mnt/build/llvm-project.tar.gz .
+        mv /mnt/build/llvm-project.tar.gz .
+        tar -C /mnt/ -c build/ | zstd -T0 -c > build.tar.zst
 
     - name: Upload Stage 3 Source
       uses: actions/upload-artifact@26f96dfa697d77e81fd5907df203aa23a56210a8 #v4.3.0
       with:
         name: stage3-source
-        path: ${{ github.workspace }}/llvm-project.tar.gz
+        path: llvm-project.tar.gz
         retention-days: 2
 
     - name: Upload Stage 3 Build Dir
       uses: actions/upload-artifact@26f96dfa697d77e81fd5907df203aa23a56210a8 #v4.3.0
       with:
         name: stage3-build
-        path: ${{ github.workspace }}/build.tar.bz2
+        path: build.tar.zst
         retention-days: 2
 
   upload-release-binaries-linux:
@@ -302,13 +298,11 @@ jobs:
 
     - name: Unpack Artifact
       run: |
-        sudo apt-get update
-        sudo apt-get install bzip2
         tar -xzf llvm-project.tar.gz
         rm llvm-project.tar.gz
         sudo chown $USER:$USER /mnt/
-        tar -C /mnt -xjf build.tar.bz2
-        rm build.tar.bz2
+        tar --zstd -C /mnt -xf build.tar.zst
+        rm build.tar.zst
 
     - name: Run Tests
       run: |

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -216,7 +216,7 @@ jobs:
       run: |
         filename="LLVM-${{ needs.prepare.outputs.release-version }}-Linux.tar.gz"
         echo "filename=$filename" >> $GITHUB_OUTPUT
-        echo "path=/mnt/build/tools/clang/stage2-instrumented-bins/tools/clang/stage2-bins/$filename" >> $GITHUB_OUTPUT
+        echo "path=/mnt/build/tools/clang/stage2-bins/$filename" >> $GITHUB_OUTPUT
 
     - uses: actions/upload-artifact@26f96dfa697d77e81fd5907df203aa23a56210a8 #v4.3.0
       if: always()

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -113,22 +113,21 @@ jobs:
     # many files to upload.
     - name: Package Build and Source Directories
       run: |
-        tar -czf /mnt/build/llvm-project.tar.gz .
-        mv /mnt/build/llvm-project.tar.gz .
-        tar -C /mnt/ -czf build.tar.gz build/
+        tar -c . | zstd -T0 -c > llvm-project.tar.zst
+        tar -C /mnt/ -c build/ | zstd -T0 -c > build.tar.zst
 
     - name: Upload Stage 1 Source
       uses: actions/upload-artifact@26f96dfa697d77e81fd5907df203aa23a56210a8 #v4.3.0
       with:
         name: stage1-source
-        path: llvm-project.tar.gz
+        path: llvm-project.tar.zst
         retention-days: 2
 
     - name: Upload Stage 1 Build Dir
       uses: actions/upload-artifact@26f96dfa697d77e81fd5907df203aa23a56210a8 #v4.3.0
       with:
         name: stage1-build
-        path: build.tar.gz
+        path: build.tar.zst
         retention-days: 2
 
   build-stage2-linux:
@@ -150,11 +149,11 @@ jobs:
 
     - name: Unpack Artifacts
       run: |
-        tar -xzf llvm-project.tar.gz
-        rm llvm-project.tar.gz
+        tar --zstd -xf llvm-project.tar.zst
+        rm llvm-project.tar.zst
         sudo chown $USER:$USER /mnt/
-        tar -C /mnt -xzf build.tar.gz
-        rm build.tar.gz
+        tar --zstd -C /mnt -xf build.tar.zst
+        rm build.tar.zst
 
     - name: Build Stage 2
       run: |
@@ -164,22 +163,21 @@ jobs:
     # many files to upload.
     - name: Save Build and Source Directories
       run: |
-        tar -czf /mnt/build/llvm-project.tar.gz .
-        mv /mnt/build/llvm-project.tar.gz .
-        tar -C /mnt/ -czf build.tar.gz build/
+        tar -c . | zstd -T0 -c > llvm-project.tar.zst
+        tar -C /mnt/ -c build/ | zstd -T0 -c > build.tar.zst
 
     - name: Upload Stage 2 Source
       uses: actions/upload-artifact@26f96dfa697d77e81fd5907df203aa23a56210a8 #v4.3.0
       with:
         name: stage2-source
-        path: ${{ github.workspace }}/llvm-project.tar.gz
+        path: ${{ github.workspace }}/llvm-project.tar.zst
         retention-days: 2
 
     - name: Upload Stage 2 Build Dir
       uses: actions/upload-artifact@26f96dfa697d77e81fd5907df203aa23a56210a8 #v4.3.0
       with:
         name: stage2-build
-        path: ${{ github.workspace }}/build.tar.gz
+        path: ${{ github.workspace }}/build.tar.zst
         retention-days: 2
 
 
@@ -204,11 +202,11 @@ jobs:
 
     - name: Unpack Artifact
       run: |
-        tar -xzf llvm-project.tar.gz
-        rm llvm-project.tar.gz
+        tar --zstd -xf llvm-project.tar.zst
+        rm llvm-project.tar.zst
         sudo chown $USER:$USER /mnt/
-        tar -C /mnt -xzf build.tar.gz
-        rm build.tar.gz
+        tar --zstd -C /mnt -xf build.tar.zst
+        rm build.tar.zst
 
     - name: Build Release Package
       run: |
@@ -235,15 +233,14 @@ jobs:
     # many files to upload.
     - name: Save Build and Source Directories
       run: |
-        tar -czf /mnt/build/llvm-project.tar.gz .
-        mv /mnt/build/llvm-project.tar.gz .
+        tar -c . | zstd -T0 -c > llvm-project.tar.zst
         tar -C /mnt/ -c build/ | zstd -T0 -c > build.tar.zst
 
     - name: Upload Stage 3 Source
       uses: actions/upload-artifact@26f96dfa697d77e81fd5907df203aa23a56210a8 #v4.3.0
       with:
         name: stage3-source
-        path: llvm-project.tar.gz
+        path: llvm-project.tar.zst
         retention-days: 2
 
     - name: Upload Stage 3 Build Dir
@@ -298,8 +295,8 @@ jobs:
 
     - name: Unpack Artifact
       run: |
-        tar -xzf llvm-project.tar.gz
-        rm llvm-project.tar.gz
+        tar --zstd -xf llvm-project.tar.zst
+        rm llvm-project.tar.zst
         sudo chown $USER:$USER /mnt/
         tar --zstd -C /mnt -xf build.tar.zst
         rm build.tar.zst

--- a/.github/workflows/set-release-binary-outputs.sh
+++ b/.github/workflows/set-release-binary-outputs.sh
@@ -15,10 +15,8 @@ if echo $tag | grep -e '^[0-9a-f]\+$'; then
   # This is a plain commit.
   # TODO: Don't hardcode this.
   release_version="18"
-  build_dir="$tag"
   upload='false'
   ref="$tag"
-  flags="-git-ref $tag -test-asserts"
 
 else
 
@@ -30,12 +28,7 @@ else
   fi
   release_version=`echo "$tag" | sed 's/llvmorg-//g'`
   release=`echo "$release_version" | sed 's/-.*//g'`
-  build_dir=`echo "$release_version" | sed 's,^[^-]\+,final,' | sed 's,[^-]\+-rc\(.\+\),rc\1,'`
-  rc_flags=`echo "$release_version" | sed 's,^[^-]\+,-final,' | sed 's,[^-]\+-rc\(.\+\),-rc \1 -test-asserts,' | sed 's,--,-,'`
-  flags="-release $release $rc_flags"
 fi
 echo "release-version=$release_version" >> $GITHUB_OUTPUT
-echo "build-dir=$build_dir" >> $GITHUB_OUTPUT
-echo "flags=$flags" >> $GITHUB_OUTPUT
 echo "upload=$upload" >> $GITHUB_OUTPUT
 echo "ref=$tag" >> $GITHUB_OUTPUT


### PR DESCRIPTION
This updates the release-binaries workflow so that the different build stages are split across multiple jobs.  This saves money by reducing the time spent on the larger github runners and also makes it easier to debug, because now it's possible to build a smaller release package (with clang and lld) using only the free GitHub runners.

The workflow no longer uses the test-release.sh script but instead uses the Release.cmake cache.  This gives the workflow more flexibility and ensures that the binary package will always be created even if the tests fail.

This idea to split the stages comes from the "LLVM Precommit CI through Github Actions" RFC:
https://discourse.llvm.org/t/rfc-llvm-precommit-ci-through-github-actions/76456