### PR TITLE
[memprof] Omit the key length for the record table

### DIFF
--- a/llvm/include/llvm/Support/OnDiskHashTable.h
+++ b/llvm/include/llvm/Support/OnDiskHashTable.h
@@ -377,7 +377,7 @@ public:
 
       // Determine the length of the key and the data.
       const std::pair<offset_type, offset_type> &L =
-          Info::ReadKeyDataLength(Items);
+          InfoPtr->ReadKeyDataLength(Items);
       offset_type ItemLen = L.first + L.second;
 
       // Compare the hashes.  If they are not the same, skip the entry entirely.


### PR DESCRIPTION
The record table has a constant key length, so we don't need to
serialize or deserialize it for every key-data pair.  Omitting the key
length saves 0.06% of the indexed MemProf file size.

Note that it's OK to change the format because Version2 is still under
development.
