### PR TITLE
[PAC][MC][AArch64] Fix error message for AUTH_ABS64 reloc with ILP32

### DIFF
--- a/llvm/test/MC/AArch64/ilp32-diagnostics.s
+++ b/llvm/test/MC/AArch64/ilp32-diagnostics.s
@@ -10,6 +10,14 @@
 // CHECK-ERROR: error: ILP32 8 byte absolute data relocation not supported (LP64 eqv: ABS64)
 // CHECK-ERROR: ^
 
+        .xword sym@AUTH(da,42)
+// CHECK-ERROR: error: ILP32 8 byte absolute data relocation not supported (LP64 eqv: AUTH_ABS64)
+// CHECK-ERROR: ^
+
+        .xword sym@AUTH(da,42,addr)
+// CHECK-ERROR: error: ILP32 8 byte absolute data relocation not supported (LP64 eqv: AUTH_ABS64)
+// CHECK-ERROR: ^
+
         movz x7, #:abs_g3:some_label
 // CHECK-ERROR: error: ILP32 absolute MOV relocation not supported (LP64 eqv: MOVW_UABS_G3)
 // CHECK-ERROR:        movz x7, #:abs_g3:some_label


### PR DESCRIPTION
The `LP64 eqv:` should say that the equivalent is `AUTH_ABS64` rather than `ABS64` when trying to emit an AUTH absolute reloc with ILP32.