### PR TITLE
[clang][CoverageMapping] do not emit gap when either end is an `ImplicitValueInitExpr`

### DIFF
--- a/clang/lib/CodeGen/CoverageMappingGen.cpp
+++ b/clang/lib/CodeGen/CoverageMappingGen.cpp
@@ -1208,6 +1208,12 @@ struct CounterCoverageMappingBuilder
   /// Find a valid gap range between \p AfterLoc and \p BeforeLoc.
   std::optional<SourceRange> findGapAreaBetween(SourceLocation AfterLoc,
                                                 SourceLocation BeforeLoc) {
+    // Some statements (like AttributedStmt and ImplicitValueInitExpr) don't
+    // have valid source locations. Do not emit a gap region if this is the case
+    // in either AfterLoc end or BeforeLoc end.
+    if (AfterLoc.isInvalid() || BeforeLoc.isInvalid())
+      return std::nullopt;
+
     // If AfterLoc is in function-like macro, use the right parenthesis
     // location.
     if (AfterLoc.isMacroID()) {
@@ -1368,9 +1374,8 @@ struct CounterCoverageMappingBuilder
     for (const Stmt *Child : S->children())
       if (Child) {
         // If last statement contains terminate statements, add a gap area
-        // between the two statements. Skipping attributed statements, because
-        // they don't have valid start location.
-        if (LastStmt && HasTerminateStmt && !isa<AttributedStmt>(Child)) {
+        // between the two statements.
+        if (LastStmt && HasTerminateStmt) {
           auto Gap = findGapAreaBetween(getEnd(LastStmt), getStart(Child));
           if (Gap)
             fillGapAreaWithCount(Gap->getBegin(), Gap->getEnd(),

--- a/clang/lib/CodeGen/CoverageMappingGen.cpp
+++ b/clang/lib/CodeGen/CoverageMappingGen.cpp
@@ -1368,9 +1368,12 @@ struct CounterCoverageMappingBuilder
     for (const Stmt *Child : S->children())
       if (Child) {
         // If last statement contains terminate statements, add a gap area
-        // between the two statements. Skipping attributed statements, because
-        // they don't have valid start location.
-        if (LastStmt && HasTerminateStmt && !isa<AttributedStmt>(Child)) {
+        // between the two statements. Skipping attributed statements and
+        // implicit initializations, because they don't have valid source
+        // location.
+        if (LastStmt && HasTerminateStmt && !isa<AttributedStmt>(Child) &&
+            !isa<ImplicitValueInitExpr>(Child) &&
+            !isa<ImplicitValueInitExpr>(LastStmt)) {
           auto Gap = findGapAreaBetween(getEnd(LastStmt), getStart(Child));
           if (Gap)
             fillGapAreaWithCount(Gap->getBegin(), Gap->getEnd(),

--- a/clang/lib/CodeGen/CoverageMappingGen.cpp
+++ b/clang/lib/CodeGen/CoverageMappingGen.cpp
@@ -1368,12 +1368,9 @@ struct CounterCoverageMappingBuilder
     for (const Stmt *Child : S->children())
       if (Child) {
         // If last statement contains terminate statements, add a gap area
-        // between the two statements. Skipping attributed statements and
-        // implicit initializations, because they don't have valid source
-        // location.
-        if (LastStmt && HasTerminateStmt && !isa<AttributedStmt>(Child) &&
-            !isa<ImplicitValueInitExpr>(Child) &&
-            !isa<ImplicitValueInitExpr>(LastStmt)) {
+        // between the two statements. Skipping attributed statements, because
+        // they don't have valid start location.
+        if (LastStmt && HasTerminateStmt && !isa<AttributedStmt>(Child)) {
           auto Gap = findGapAreaBetween(getEnd(LastStmt), getStart(Child));
           if (Gap)
             fillGapAreaWithCount(Gap->getBegin(), Gap->getEnd(),

--- a/clang/test/CoverageMapping/statement-expression.c
+++ b/clang/test/CoverageMapping/statement-expression.c
@@ -1,0 +1,36 @@
+// RUN: %clang_cc1 -mllvm -emptyline-comment-coverage=false -fprofile-instrument=clang -fcoverage-mapping -dump-coverage-mapping -emit-llvm-only -main-file-name statement-expression.c %s
+
+// No crash for the following examples, where GNU Statement Expression extension
+// could introduce region terminators (break, goto etc) before implicit
+// initializers in a struct or an array.
+// See https://github.com/llvm/llvm-project/pull/89564
+
+struct Foo {
+  int field1;
+  int field2;
+};
+
+void f1(void) {
+  struct Foo foo = {
+    .field1 = ({
+      switch (0) {
+      case 0:
+        break; // A region terminator
+      }
+      0;
+    }),
+    // ImplicitValueInitExpr introduced here for .field2
+  };
+}
+
+void f2(void) {
+  int arr[3] = {
+    [0] = ({
+        goto L0; // A region terminator
+L0:
+      0;
+    }),
+    // ImplicitValueInitExpr introduced here for subscript [1]
+    [2] = 0,
+  };
+}


### PR DESCRIPTION
Fixes #86998 

Two compiler explorer examples: [1](https://godbolt.org/#g:!((g:!((g:!((h:codeEditor,i:(filename:'1',fontScale:14,fontUsePx:'0',j:1,lang:___c,selection:(endColumn:21,endLineNumber:8,positionColumn:21,positionLineNumber:8,selectionStartColumn:21,selectionStartLineNumber:8,startColumn:21,startLineNumber:8),source:'struct+Foo+%7B%0A++++int+field1%3B%0A++++int+field2%3B%0A%7D%3B%0A%0Aint+main(void)+%7B%0A++++struct+Foo+foo+%3D+%7B%0A++++++++.field1+%3D+(%7B%0A++++++++++++switch+(0)+%7B%0A++++++++++++case+0:%0A++++++++++++++++break%3B%0A+++++++++++++//+%5E%5E%5E%5E%5E+HasTerminateStmt+set%0A++++++++++++%7D%0A++++++++++++0%3B%0A++++++++%7D),%0A++++++++//+%3C--+ImplicitValueInitExpr+introduced+for+.field2%0A++++%7D%3B%0A%7D'),l:'5',n:'0',o:'C+source+%231',t:'0')),k:61.44745998608211,l:'4',n:'0',o:'',s:0,t:'0'),(g:!((g:!((h:compiler,i:(compiler:cclang_assertions_trunk,filters:(b:'0',binary:'1',binaryObject:'1',commentOnly:'0',debugCalls:'1',demangle:'0',directives:'0',execute:'0',intel:'0',libraryCode:'1',trim:'1',verboseDemangling:'0'),flagsViewOpen:'1',fontScale:14,fontUsePx:'0',j:2,lang:___c,libs:!(),options:'-fprofile-instr-generate+-fcoverage-mapping',overrides:!(),selection:(endColumn:45,endLineNumber:3,positionColumn:45,positionLineNumber:3,selectionStartColumn:45,selectionStartLineNumber:3,startColumn:45,startLineNumber:3),source:1),l:'5',n:'0',o:'+x86-64+clang+(assertions+trunk)+(Editor+%231)',t:'0')),k:34.5741843594503,l:'4',m:28.903654485049834,n:'0',o:'',s:0,t:'0'),(g:!((h:output,i:(compilerName:'x86-64+clang+(trunk)',editorid:1,fontScale:14,fontUsePx:'0',j:2,wrap:'1'),l:'5',n:'0',o:'Output+of+x86-64+clang+(assertions+trunk)+(Compiler+%232)',t:'0')),header:(),l:'4',m:71.09634551495017,n:'0',o:'',s:0,t:'0')),k:38.55254001391788,l:'3',n:'0',o:'',t:'0')),l:'2',m:100,n:'0',o:'',t:'0')),version:4), [2](https://godbolt.org/#g:!((g:!((g:!((h:codeEditor,i:(filename:'1',fontScale:14,fontUsePx:'0',j:1,lang:___c,selection:(endColumn:2,endLineNumber:12,positionColumn:2,positionLineNumber:12,selectionStartColumn:2,selectionStartLineNumber:12,startColumn:2,startLineNumber:12),source:'int+main(void)+%7B%0A++++int+arr%5B3%5D+%3D+%7B%0A++++++++%5B0%5D+%3D+(%7B%0A++++++++++++goto+L0%3B%0A+++++++++//+%5E%5E%5E%5E+HasTerminateStmt+set%0AL0:++++++++++++%0A++++++++++++0%3B%0A++++++++%7D),%0A++++++++//+%3C--+ImplicitValueInitExpr+introduced+for+subscript+%5B1%5D%0A++++++++%5B2%5D+%3D+0,%0A++++%7D%3B%0A%7D'),l:'5',n:'0',o:'C+source+%231',t:'0')),k:61.44745998608211,l:'4',n:'0',o:'',s:0,t:'0'),(g:!((g:!((h:compiler,i:(compiler:cclang_assertions_trunk,filters:(b:'0',binary:'1',binaryObject:'1',commentOnly:'0',debugCalls:'1',demangle:'0',directives:'0',execute:'0',intel:'0',libraryCode:'1',trim:'1',verboseDemangling:'0'),flagsViewOpen:'1',fontScale:14,fontUsePx:'0',j:2,lang:___c,libs:!(),options:'-fprofile-instr-generate+-fcoverage-mapping',overrides:!(),selection:(endColumn:1,endLineNumber:1,positionColumn:1,positionLineNumber:1,selectionStartColumn:1,selectionStartLineNumber:1,startColumn:1,startLineNumber:1),source:1),l:'5',n:'0',o:'+x86-64+clang+(assertions+trunk)+(Editor+%231)',t:'0')),k:34.5741843594503,l:'4',m:28.903654485049834,n:'0',o:'',s:0,t:'0'),(g:!((h:output,i:(compilerName:'x86-64+clang+(trunk)',editorid:1,fontScale:14,fontUsePx:'0',j:2,wrap:'1'),l:'5',n:'0',o:'Output+of+x86-64+clang+(assertions+trunk)+(Compiler+%232)',t:'0')),header:(),l:'4',m:71.09634551495017,n:'0',o:'',s:0,t:'0')),k:38.55254001391788,l:'3',n:'0',o:'',t:'0')),l:'2',m:100,n:'0',o:'',t:'0')),version:4)

Cause:

1. When visiting AST and generating mapping regions, a [region terminator](https://github.com/llvm/llvm-project/blob/llvmorg-18.1.4/clang/lib/CodeGen/CoverageMappingGen.cpp#L1197) (like `break` and `goto`) is likely followed by a stmt with `<invalid sloc>` (like `ImplicitValueInitExpr`).
2. Because a terminator is seen, the below branch will be executed when visiting the 2nd stmt:

    https://github.com/llvm/llvm-project/blob/e6c3289804a67ea0bb6a86fadbe454dd93b8d855/clang/lib/CodeGen/CoverageMappingGen.cpp#L1375-L1376

3. However, the 2nd stmt doesn't have a valid source location and will fail some assertions in `findGapAreaBetween()`.





