### PR TITLE
[Clang] Fix a crash introduced in PR#88666

### DIFF
--- a/clang/lib/Sema/SemaStmtAttr.cpp
+++ b/clang/lib/Sema/SemaStmtAttr.cpp
@@ -109,7 +109,7 @@ static Attr *handleLoopHintAttr(Sema &S, Stmt *St, const ParsedAttr &A,
     SetHints(LoopHintAttr::Unroll, LoopHintAttr::Disable);
   } else if (PragmaName == "unroll") {
     // #pragma unroll N
-    if (ValueExpr) {
+    if (ValueExpr && !ValueExpr->isValueDependent()) {
       llvm::APSInt ValueAPS;
       ExprResult R = S.VerifyIntegerConstantExpression(ValueExpr, &ValueAPS);
       assert(!R.isInvalid() && "unroll count value must be a valid value, it's "

--- a/clang/test/Sema/unroll-template-value-crash.cpp
+++ b/clang/test/Sema/unroll-template-value-crash.cpp
@@ -1,0 +1,10 @@
+// RUN: %clang_cc1 -x c++ -verify %s
+// expected-no-diagnostics
+
+template <int Unroll> void foo() {
+  #pragma unroll Unroll
+  for (int i = 0; i < Unroll; ++i);
+
+  #pragma GCC unroll Unroll
+  for (int i = 0; i < Unroll; ++i);
+}


### PR DESCRIPTION
The unroll value can be a template variable such that we need to check it before
we verify if it is constant value.
