### PR TITLE
[flang] handle intrinsic interfaces in FunctionRef::GetType

### DIFF
--- a/flang/include/flang/Evaluate/call.h
+++ b/flang/include/flang/Evaluate/call.h
@@ -287,15 +287,19 @@ public:
       : ProcedureRef{std::move(p), std::move(a)} {}
 
   std::optional<DynamicType> GetType() const {
-    if (auto type{proc_.GetType()}) {
-      // TODO: Non constant explicit length parameters of PDTs result should
-      // likely be dropped too. This is not as easy as for characters since some
-      // long lived DerivedTypeSpec pointer would need to be created here. It is
-      // not clear if this is causing any issue so far since the storage size of
-      // PDTs is independent of length parameters.
-      return type->DropNonConstantCharacterLength();
+    if constexpr (IsLengthlessIntrinsicType<A>) {
+      return A::GetType();
+    } else {
+      if (auto type{proc_.GetType()}) {
+        // TODO: Non constant explicit length parameters of PDTs result should
+        // likely be dropped too. This is not as easy as for characters since
+        // some long lived DerivedTypeSpec pointer would need to be created
+        // here. It is not clear if this is causing any issue so far since the
+        // storage size of PDTs is independent of length parameters.
+        return type->DropNonConstantCharacterLength();
+      }
+      return std::nullopt;
     }
-    return std::nullopt;
   }
 };
 } // namespace Fortran::evaluate

--- a/flang/include/flang/Evaluate/call.h
+++ b/flang/include/flang/Evaluate/call.h
@@ -289,15 +289,14 @@ public:
   std::optional<DynamicType> GetType() const {
     if constexpr (IsLengthlessIntrinsicType<A>) {
       return A::GetType();
+    } else if (auto type{proc_.GetType()}) {
+      // TODO: Non constant explicit length parameters of PDTs result should
+      // likely be dropped too. This is not as easy as for characters since some
+      // long lived DerivedTypeSpec pointer would need to be created here. It is
+      // not clear if this is causing any issue so far since the storage size of
+      // PDTs is independent of length parameters.
+      return type->DropNonConstantCharacterLength();
     } else {
-      if (auto type{proc_.GetType()}) {
-        // TODO: Non constant explicit length parameters of PDTs result should
-        // likely be dropped too. This is not as easy as for characters since
-        // some long lived DerivedTypeSpec pointer would need to be created
-        // here. It is not clear if this is causing any issue so far since the
-        // storage size of PDTs is independent of length parameters.
-        return type->DropNonConstantCharacterLength();
-      }
       return std::nullopt;
     }
   }

--- a/flang/test/Lower/HLFIR/calls-f77.f90
+++ b/flang/test/Lower/HLFIR/calls-f77.f90
@@ -186,3 +186,16 @@ subroutine alternate_return_call(n1, n2, k)
   ! CHECK: ^[[block2]]: // pred: ^bb0
 7 k =  1; return
 end
+
+! -----------------------------------------------------------------------------
+!     Test calls to user procedures with intrinsic interfaces
+! -----------------------------------------------------------------------------
+
+! CHECK-NAME: func.func @_QPintrinsic_iface()
+subroutine intrinsic_iface()
+  intrinsic acos
+  real :: x
+  procedure(acos) :: proc
+  x = proc(1.0)
+end subroutine
+! CHECK" fir.call @_QPproc(%{{.*}}) {{.*}}: (!fir.ref<f32>) -> f32


### PR DESCRIPTION
User functions may be declared with an interface that is a specific intrinsic. In such case, there is no result type available from the procedure symbol (at least without using evaluate::Probe), and FunctionRef::GetType() returned nullopt. This caused lowering to crash.
The result type of specific intrinsic procedures is always a lengthless intrinsic type, so it is fully defined in the template argument of FunctionRef. Use it.