### PR TITLE
[mlir][linalg]-Fix wrong assertion in the getMatchingYieldValue inter…

### DIFF
--- a/mlir/include/mlir/Dialect/Linalg/IR/LinalgInterfaces.td
+++ b/mlir/include/mlir/Dialect/Linalg/IR/LinalgInterfaces.td
@@ -474,7 +474,7 @@ def LinalgStructuredInterface
         int64_t resultIndex =
             opOperand->getOperandNumber() - $_op.getNumDpsInputs();
         assert(resultIndex >= 0 &&
-               resultIndex < this->getOperation()->getNumResults());
+               resultIndex < $_op.getNumDpsInits());
         Operation *yieldOp = getBlock()->getTerminator();
         return &yieldOp->getOpOperand(resultIndex);
       }]


### PR DESCRIPTION
…face

In order to have a consistent implementation for getMatchingYieldValue for linalg generic with buffer/tensor semantics, we should assert the opOperand index based on the numDpsInits and not numOfResults which may be zero in the buffer semantics.