### PR TITLE
[libc++][NFC] Fix unparenthesized comma expression in mem-initializer

### DIFF
--- a/libcxx/test/support/invocable_with_telemetry.h
+++ b/libcxx/test/support/invocable_with_telemetry.h
@@ -31,7 +31,7 @@ public:
   constexpr invocable_with_telemetry(invocable_with_telemetry&& other)
     requires std::move_constructible<F>
       : f_(std::move(other.f_)),
-        telemetry_(assert(other.telemetry_ != nullptr), std::exchange(other.telemetry_, nullptr)) {
+        telemetry_((assert(other.telemetry_ != nullptr), std::exchange(other.telemetry_, nullptr))) {
     ++telemetry_->moves;
   }
 


### PR DESCRIPTION
#84050 resolves class member access expressions naming members of the current instantiation prior to instantiation. In testing, it has revealed a mem-initializer in the move constructor of `invocable_with_telemetry` that uses an unparenthesized comma expression to initialize a non-static data member of pointer type. This patch fixes it. 
