### PR TITLE
[flang][cuda] fix parsing of cuda_kernel

### DIFF
--- a/flang/lib/Optimizer/Dialect/FIROps.cpp
+++ b/flang/lib/Optimizer/Dialect/FIROps.cpp
@@ -3904,10 +3904,11 @@ mlir::ParseResult parseCUFKernelValues(
     mlir::OpAsmParser &parser,
     llvm::SmallVectorImpl<mlir::OpAsmParser::UnresolvedOperand> &values,
     llvm::SmallVectorImpl<mlir::Type> &types) {
-  if (mlir::succeeded(parser.parseOptionalStar()))
+  if (mlir::succeeded(parser.parseOptionalStar())) {
     return mlir::success();
+  }
 
-  if (parser.parseOptionalLParen()) {
+  if (mlir::succeeded(parser.parseOptionalLParen())) {
     if (mlir::failed(parser.parseCommaSeparatedList(
             mlir::AsmParser::Delimiter::None, [&]() {
               if (parser.parseOperand(values.emplace_back()))
@@ -3915,11 +3916,17 @@ mlir::ParseResult parseCUFKernelValues(
               return mlir::success();
             })))
       return mlir::failure();
+    auto builder = parser.getBuilder();
+    for (size_t i = 0; i < values.size(); i++) {
+      types.emplace_back(builder.getType<mlir::IntegerType>(32));
+    }
     if (parser.parseRParen())
       return mlir::failure();
   } else {
     if (parser.parseOperand(values.emplace_back()))
       return mlir::failure();
+    auto builder = parser.getBuilder();
+    types.emplace_back(builder.getType<mlir::IntegerType>(32));
     return mlir::success();
   }
   return mlir::success();

--- a/flang/lib/Optimizer/Dialect/FIROps.cpp
+++ b/flang/lib/Optimizer/Dialect/FIROps.cpp
@@ -3926,7 +3926,7 @@ mlir::ParseResult parseCUFKernelValues(
     if (parser.parseOperand(values.emplace_back()))
       return mlir::failure();
     auto builder = parser.getBuilder();
-    types.emplace_back(builder.getType<mlir::IntegerType>(32));
+    types.emplace_back(builder.getI32Type());
     return mlir::success();
   }
   return mlir::success();

--- a/flang/lib/Optimizer/Dialect/FIROps.cpp
+++ b/flang/lib/Optimizer/Dialect/FIROps.cpp
@@ -3904,9 +3904,8 @@ mlir::ParseResult parseCUFKernelValues(
     mlir::OpAsmParser &parser,
     llvm::SmallVectorImpl<mlir::OpAsmParser::UnresolvedOperand> &values,
     llvm::SmallVectorImpl<mlir::Type> &types) {
-  if (mlir::succeeded(parser.parseOptionalStar())) {
+  if (mlir::succeeded(parser.parseOptionalStar()))
     return mlir::success();
-  }
 
   if (mlir::succeeded(parser.parseOptionalLParen())) {
     if (mlir::failed(parser.parseCommaSeparatedList(

--- a/flang/lib/Optimizer/Dialect/FIROps.cpp
+++ b/flang/lib/Optimizer/Dialect/FIROps.cpp
@@ -3918,7 +3918,7 @@ mlir::ParseResult parseCUFKernelValues(
       return mlir::failure();
     auto builder = parser.getBuilder();
     for (size_t i = 0; i < values.size(); i++) {
-      types.emplace_back(builder.getType<mlir::IntegerType>(32));
+      types.emplace_back(builder.getI32Type());
     }
     if (parser.parseRParen())
       return mlir::failure();

--- a/flang/test/Lower/CUDA/cuda-kernel-loop-directive.cuf
+++ b/flang/test/Lower/CUDA/cuda-kernel-loop-directive.cuf
@@ -1,4 +1,5 @@
 ! RUN: bbc -emit-hlfir -fcuda %s -o - | FileCheck %s
+! RUN: bbc -emit-hlfir -fcuda %s -o - | fir-opt | FileCheck %s
 
 ! Test lowering of CUDA kernel loop directive.
 


### PR DESCRIPTION
Fix parsing of cuda_kernel: it missed a mlir::succeeded check and it was not setting up the `types` and causing mismatch between values and types of the grid/block (CUFKernelValues). @clementval 