### PR TITLE
[mlir][ODS] Add namespace filtering to `-gen-enum-*`

### DIFF
--- a/mlir/test/mlir-tblgen/enums-gen-namespace-filter.td
+++ b/mlir/test/mlir-tblgen/enums-gen-namespace-filter.td
@@ -1,0 +1,30 @@
+// RUN: mlir-tblgen -gen-enum-decls -enum-namespace=test::ns1 -I %S/../../include %s | FileCheck %s --check-prefix=NS1
+// RUN: mlir-tblgen -gen-enum-decls -enum-namespace=test::ns2 -I %S/../../include %s | FileCheck %s --check-prefix=NS2
+// RUN: mlir-tblgen -gen-enum-decls -enum-namespace=test::ns -I %S/../../include %s | FileCheck %s --check-prefix=NS
+// RUN: mlir-tblgen -gen-enum-decls -enum-namespace=test -I %S/../../include %s | FileCheck %s --check-prefix=TEST-NS
+
+include "mlir/IR/EnumAttr.td"
+include "mlir/IR/OpBase.td"
+
+def EnumNS1 : I32BitEnumAttr<"EnumNS1", "", []> {
+  let genSpecializedAttr = 0;
+  let cppNamespace = "test::ns1";
+}
+
+def EnumNS2 : I32BitEnumAttr<"EnumNS2", "", []> {
+  let genSpecializedAttr = 0;
+  let cppNamespace = "test::ns2";
+}
+
+// NS1-NOT: enum class EnumNS2
+// NS1: enum class EnumNS1
+// NS1-NOT: enum class EnumNS2
+
+// NS2-NOT: enum class EnumNS1
+// NS2: enum class EnumNS2
+
+// NS-NOT: enum class EnumNS1
+// NS-NOT: enum class EnumNS2
+
+// TEST-NS: enum class EnumNS1
+// TEST-NS: enum class EnumNS2


### PR DESCRIPTION
Unlike all other ODS generators, there is currently no way to filter what enums TableGen should be generating. This is problematic if a dialect depends on another dialect and `include`s another dialects TableGen file that contains any enum definitions: The declarations and definitions of the enum will be generated in both dialects and therefore lead to likely a compiler error and a guaranteed linker error.

This PR therefore adds a new command line flag called `-enum-namespace`, inspired by the existing `-(attr|type)-dialect` flags, to restrict the set of enums that should be generated. Unlike attributes and types, enums are not part of a dialect making the same filtering mechanism not possible. As an alternative, filtering via the C++ namespace was implemented instead.