### PR TITLE
[clangd] Fix unittests in TargetDeclTest bucket

### DIFF
--- a/clang-tools-extra/clangd/unittests/FindTargetTests.cpp
+++ b/clang-tools-extra/clangd/unittests/FindTargetTests.cpp
@@ -427,7 +427,7 @@ TEST_F(TargetDeclTest, Types) {
     [[auto]] X = S{};
   )cpp";
   // FIXME: deduced type missing in AST. https://llvm.org/PR42914
-  EXPECT_DECLS("AutoTypeLoc",);
+  EXPECT_DECLS("AutoTypeLoc", );
 
   Code = R"cpp(
     template <typename... E>
@@ -727,13 +727,13 @@ TEST_F(TargetDeclTest, BuiltinTemplates) {
     template <class T, int N>
     using make_integer_sequence = [[__make_integer_seq]]<integer_sequence, T, N>;
   )cpp";
-  EXPECT_DECLS("TemplateSpecializationTypeLoc",);
+  EXPECT_DECLS("TemplateSpecializationTypeLoc", );
 
   Code = R"cpp(
     template <int N, class... Pack>
     using type_pack_element = [[__type_pack_element]]<N, Pack...>;
   )cpp";
-  EXPECT_DECLS("TemplateSpecializationTypeLoc",);
+  EXPECT_DECLS("TemplateSpecializationTypeLoc", );
 }
 
 TEST_F(TargetDeclTest, MemberOfTemplate) {
@@ -1018,7 +1018,7 @@ TEST_F(TargetDeclTest, DependentTypes) {
           typedef typename waldo<N - 1>::type::[[next]] type;
         };
   )cpp";
-  EXPECT_DECLS("DependentNameTypeLoc",);
+  EXPECT_DECLS("DependentNameTypeLoc", );
 
   // Similar to above but using mutually recursive templates.
   Code = R"cpp(
@@ -1035,7 +1035,7 @@ TEST_F(TargetDeclTest, DependentTypes) {
           using type = typename even<N - 1>::type::[[next]];
         };
   )cpp";
-  EXPECT_DECLS("DependentNameTypeLoc",);
+  EXPECT_DECLS("DependentNameTypeLoc", );
 }
 
 TEST_F(TargetDeclTest, TypedefCascade) {
@@ -1263,14 +1263,14 @@ TEST_F(TargetDeclTest, ObjC) {
     + ([[id]])sharedInstance;
     @end
   )cpp";
-  EXPECT_DECLS("TypedefTypeLoc",);
+  EXPECT_DECLS("TypedefTypeLoc", );
 
   Code = R"cpp(
     @interface Foo
     + ([[instancetype]])sharedInstance;
     @end
   )cpp";
-  EXPECT_DECLS("TypedefTypeLoc",);
+  EXPECT_DECLS("TypedefTypeLoc", );
 }
 
 class FindExplicitReferencesTest : public ::testing::Test {

--- a/clang-tools-extra/clangd/unittests/FindTargetTests.cpp
+++ b/clang-tools-extra/clangd/unittests/FindTargetTests.cpp
@@ -427,7 +427,7 @@ TEST_F(TargetDeclTest, Types) {
     [[auto]] X = S{};
   )cpp";
   // FIXME: deduced type missing in AST. https://llvm.org/PR42914
-  EXPECT_DECLS("AutoTypeLoc");
+  EXPECT_DECLS("AutoTypeLoc",);
 
   Code = R"cpp(
     template <typename... E>
@@ -727,13 +727,13 @@ TEST_F(TargetDeclTest, BuiltinTemplates) {
     template <class T, int N>
     using make_integer_sequence = [[__make_integer_seq]]<integer_sequence, T, N>;
   )cpp";
-  EXPECT_DECLS("TemplateSpecializationTypeLoc");
+  EXPECT_DECLS("TemplateSpecializationTypeLoc",);
 
   Code = R"cpp(
     template <int N, class... Pack>
     using type_pack_element = [[__type_pack_element]]<N, Pack...>;
   )cpp";
-  EXPECT_DECLS("TemplateSpecializationTypeLoc");
+  EXPECT_DECLS("TemplateSpecializationTypeLoc",);
 }
 
 TEST_F(TargetDeclTest, MemberOfTemplate) {
@@ -1018,7 +1018,7 @@ TEST_F(TargetDeclTest, DependentTypes) {
           typedef typename waldo<N - 1>::type::[[next]] type;
         };
   )cpp";
-  EXPECT_DECLS("DependentNameTypeLoc");
+  EXPECT_DECLS("DependentNameTypeLoc",);
 
   // Similar to above but using mutually recursive templates.
   Code = R"cpp(
@@ -1035,7 +1035,7 @@ TEST_F(TargetDeclTest, DependentTypes) {
           using type = typename even<N - 1>::type::[[next]];
         };
   )cpp";
-  EXPECT_DECLS("DependentNameTypeLoc");
+  EXPECT_DECLS("DependentNameTypeLoc",);
 }
 
 TEST_F(TargetDeclTest, TypedefCascade) {
@@ -1263,14 +1263,14 @@ TEST_F(TargetDeclTest, ObjC) {
     + ([[id]])sharedInstance;
     @end
   )cpp";
-  EXPECT_DECLS("TypedefTypeLoc");
+  EXPECT_DECLS("TypedefTypeLoc",);
 
   Code = R"cpp(
     @interface Foo
     + ([[instancetype]])sharedInstance;
     @end
   )cpp";
-  EXPECT_DECLS("TypedefTypeLoc");
+  EXPECT_DECLS("TypedefTypeLoc",);
 }
 
 class FindExplicitReferencesTest : public ::testing::Test {


### PR DESCRIPTION
This PR fixes the build errors for one of the `clangd` unit tests bucket similar to the following:

```
.../clang-tools-extra/clangd/unittests/FindTargetTests.cpp:430:29: error: passing no argument for the '...' parameter of a variadic macro is a C++20 extension [-Werror,-Wc++20-extensions]
  430 |   EXPECT_DECLS("AutoTypeLoc");
      |                             ^
.../clang-tools-extra/clangd/unittests/FindTargetTests.cpp:98:9: note: macro 'EXPECT_DECLS' defined here
   98 | #define EXPECT_DECLS(NodeType, ...)                                            \
      |         ^
```

This happens when using a build compiler with #84520. The fix is to include commas to compensate for empty vararg macro arguments in a few instances.

