### PR TITLE
[SPIR-V] New validation tests for pointer and primitive types

### DIFF
--- a/llvm/test/CodeGen/SPIRV/pointers/argument-ptr-to-struct.ll
+++ b/llvm/test/CodeGen/SPIRV/pointers/argument-ptr-to-struct.ll
@@ -1,0 +1,37 @@
+; RUN: llc -O0 -mtriple=spirv64-unknown-unknown %s -o - | FileCheck %s
+; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv64-unknown-unknown %s -o - -filetype=obj | spirv-val %}
+
+; CHECK-DAG: %[[#VOID:]] = OpTypeVoid
+; CHECK-DAG: %[[#FLOAT:]] = OpTypeFloat 32
+; CHECK-DAG: %[[#UCHAR:]] = OpTypeInt 8 0
+; CHECK-DAG: %[[#UINT:]] = OpTypeInt 32 0
+; CHECK-DAG: %[[#STRUCT_S:]] = OpTypeStruct %[[#FLOAT]] %[[#UCHAR]] %[[#UINT]]
+; CHECK-DAG: %[[#PTR_STRUCT_S:]] = OpTypePointer Function %[[#STRUCT_S]]
+; CHECK-DAG: %[[#FUNC_TYPE_K:]] = OpTypeFunction %[[#VOID]] %[[#PTR_STRUCT_S]]
+; CHECK-DAG: %[[#FUNC_TYPE_H:]] = OpTypeFunction %[[#UINT]] %[[#PTR_STRUCT_S]]
+
+; CHECK: %[[#]] = OpFunction %[[#VOID]] None %[[#FUNC_TYPE_K]]
+; CHECK: %[[#]] = OpFunctionParameter %[[#PTR_STRUCT_S]]
+
+; CHECK: %[[#]] = OpFunction %[[#UINT]] None %[[#FUNC_TYPE_H]]
+; CHECK: %[[#]] = OpFunctionParameter %[[#PTR_STRUCT_S]]
+
+%struct.s = type { float, i8, i32 }
+
+define spir_kernel void @k(ptr noundef byval(%struct.s) align 4 %x) {
+entry:
+  %c = getelementptr inbounds %struct.s, ptr %x, i32 0, i32 2
+  %l = load i32, ptr %c, align 4
+  %add = add nsw i32 %l, 1
+  %c1 = getelementptr inbounds %struct.s, ptr %x, i32 0, i32 2
+  store i32 %add, ptr %c1, align 4
+  ret void
+}
+
+define spir_func i32 @h(ptr noundef byval(%struct.s) align 4 %x) {
+entry:
+  %c = getelementptr inbounds %struct.s, ptr %x, i32 0, i32 2
+  %l = load i32, ptr %c, align 4
+  %add = add nsw i32 %l, 1
+  ret i32 %add
+}

--- a/llvm/test/CodeGen/SPIRV/pointers/variables-storage-class.ll
+++ b/llvm/test/CodeGen/SPIRV/pointers/variables-storage-class.ll
@@ -1,0 +1,19 @@
+; RUN: llc -O0 -mtriple=spirv64-unknown-unknown %s -o - | FileCheck %s
+; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv64-unknown-unknown %s -o - -filetype=obj | spirv-val %}
+
+@Ptr = addrspace(1) global ptr addrspace(1) null
+@Init = private addrspace(2) constant i32 123
+
+; CHECK-DAG: %[[#PTR:]] = OpVariable %[[#]] UniformConstant %[[#]]
+; CHECK-DAG: %[[#INIT:]] = OpVariable %[[#]] CrossWorkgroup %[[#]]
+
+; CHECK: %[[#]] = OpLoad %[[#]] %[[#INIT]] Aligned 8
+; CHECK: OpCopyMemorySized %[[#]] %[[#PTR]] %[[#]] Aligned 4
+
+define spir_kernel void @Foo() {
+  %l = load ptr addrspace(1), ptr addrspace(1) @Ptr, align 8
+  call void @llvm.memcpy.p1.p2.i64(ptr addrspace(1) align 4 %l, ptr addrspace(2) align 1 @Init, i64 4, i1 false)
+  ret void
+}
+
+declare void @llvm.memcpy.p1.p2.i64(ptr addrspace(1) noalias nocapture writeonly, ptr addrspace(2) noalias nocapture readonly, i64, i1 immarg)

--- a/llvm/test/CodeGen/SPIRV/types/or-i1.ll
+++ b/llvm/test/CodeGen/SPIRV/types/or-i1.ll
@@ -1,0 +1,17 @@
+; RUN: llc -O0 -mtriple=spirv64-unknown-unknown %s -o - | FileCheck %s
+; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv64-unknown-unknown %s -o - -filetype=obj | spirv-val %}
+
+; CHECK-DAG: %[[#BOOL:]] = OpTypeBool
+; CHECK: %[[#BOOL:]] = OpLogicalOr %[[#BOOL]] %[[#]] %[[#]]
+
+define spir_kernel void @foo(
+  ptr addrspace(1) nocapture noundef writeonly %Dst,
+  i32 %a, i32 %b) local_unnamed_addr #0 {
+entry:
+  %a1 = trunc i32 %a to i1
+  %b1 = trunc i32 %b to i1
+  %ab1 = or i1 %a1, %b1
+  %ab32 = zext i1 %ab1 to i32
+  store i32 %ab32, ptr addrspace(1) %Dst
+  ret void
+}


### PR DESCRIPTION
This patch adds new tests mostly checking SPIR-V validation of pointer and primitive types.