### PR TITLE
[Bitcode][Asm] Read metadata value from operand bundles in and out

### DIFF
--- a/llvm/test/Bitcode/2021-07-22-Metadata-Operand-Bundles.ll
+++ b/llvm/test/Bitcode/2021-07-22-Metadata-Operand-Bundles.ll
@@ -1,0 +1,12 @@
+; This test ensures that we get a metadata operand bundle value in and out.
+; RUN: llvm-as < %s | llvm-dis | FileCheck %s
+
+declare void @callee()
+
+; CHECK-LABEL: call_with_operand_bundle(
+define void @call_with_operand_bundle() {
+  ; CHECK: call void @op_bundle_callee() [ "op_type"(metadata !"metadata_string") ]
+  call void @callee() [ "op_type"(metadata !"metadata_string") ]
+
+  ret void
+}

--- a/llvm/test/Bitcode/compatibility.ll
+++ b/llvm/test/Bitcode/compatibility.ll
@@ -1819,6 +1819,14 @@ define void @call_with_operand_bundle4(ptr %ptr) {
   ret void
 }
 
+define void @call_with_operand_bundle5(ptr %ptr) {
+; CHECK-LABEL: call_with_operand_bundle5(
+ entry:
+  call void @op_bundle_callee_0() [ "foo"(metadata !"metadata_string") ]
+; CHECK: call void @op_bundle_callee_0() [ "foo"(metadata !"metadata_string") ]
+  ret void
+}
+
 ; Invoke versions of the above tests:
 
 
@@ -1906,6 +1914,19 @@ define void @invoke_with_operand_bundle4(ptr %ptr) personality i8 3 {
   invoke void @op_bundle_callee_1(i32 10, i32 %x) [ "foo"(i32 42, i64 100, i32 %x), "foo"(i32 42, float  0.000000e+00, i32 %l) ]
         to label %normal unwind label %exception
 ; CHECK: invoke void @op_bundle_callee_1(i32 10, i32 %x) [ "foo"(i32 42, i64 100, i32 %x), "foo"(i32 42, float  0.000000e+00, i32 %l) ]
+
+exception:
+  %cleanup = landingpad i8 cleanup
+  br label %normal
+normal:
+  ret void
+}
+
+define void @invoke_with_operand_bundle5(ptr %ptr) personality i8 3 {
+; CHECK-LABEL: @invoke_with_operand_bundle5(
+ entry:
+  invoke void @op_bundle_callee_0() [ "foo"(metadata !"metadata_string") ] to label %normal unwind label %exception
+; CHECK: invoke void @op_bundle_callee_0() [ "foo"(metadata !"metadata_string") ]
 
 exception:
   %cleanup = landingpad i8 cleanup

--- a/llvm/test/Bitcode/operand-bundles.ll
+++ b/llvm/test/Bitcode/operand-bundles.ll
@@ -58,6 +58,13 @@ define void @f4(i32* %ptr) {
 
 ; Invoke versions of the above tests:
 
+define void @f5(i32* %ptr) {
+; CHECK-LABEL: @f5(
+ entry:
+  call void @callee0() [ "foo"(metadata !"metadata_string") ]
+; CHECK: call void @callee0() [ "foo"(metadata !"metadata_string") ]
+  ret void
+}
 
 define void @g0(i32* %ptr) personality i8 3 {
 ; CHECK-LABEL: @g0(
@@ -143,6 +150,19 @@ define void @g4(i32* %ptr) personality i8 3 {
   invoke void @callee1(i32 10, i32 %x) [ "foo"(i32 42, i64 100, i32 %x), "foo"(i32 42, float  0.000000e+00, i32 %l) ]
         to label %normal unwind label %exception
 ; CHECK: invoke void @callee1(i32 10, i32 %x) [ "foo"(i32 42, i64 100, i32 %x), "foo"(i32 42, float  0.000000e+00, i32 %l) ]
+
+exception:
+  %cleanup = landingpad i8 cleanup
+  br label %normal
+normal:
+  ret void
+}
+
+define void @g5(i32* %ptr) personality i8 3 {
+; CHECK-LABEL: @g5(
+ entry:
+  invoke void @callee0() [ "foo"(metadata !"metadata_string") ] to label %normal unwind label %exception
+; CHECK: invoke void @callee0() [ "foo"(metadata !"metadata_string") ]
 
 exception:
   %cleanup = landingpad i8 cleanup


### PR DESCRIPTION
Metadata operand bundle value is garbage when LLVM IR is compiled to
bitcode. A small reproducer and a potential test that tests the fix for
this problem.

Differential revision: https://reviews.llvm.org/D107039
