### PR TITLE
Adding memref normalization of affine.prefetch

### DIFF
--- a/mlir/include/mlir/Dialect/Affine/IR/AffineOps.td
+++ b/mlir/include/mlir/Dialect/Affine/IR/AffineOps.td
@@ -742,7 +742,7 @@ def AffineParallelOp : Affine_Op<"parallel",
 }
 
 def AffinePrefetchOp : Affine_Op<"prefetch",
-  [DeclareOpInterfaceMethods<AffineMapAccessInterface>]> {
+  [DeclareOpInterfaceMethods<AffineMapAccessInterface>, MemRefsNormalizable]> {
   let summary = "affine prefetch operation";
   let description = [{
     The `affine.prefetch` op prefetches data from a memref location described

--- a/mlir/include/mlir/Dialect/Affine/IR/AffineOps.td
+++ b/mlir/include/mlir/Dialect/Affine/IR/AffineOps.td
@@ -742,7 +742,8 @@ def AffineParallelOp : Affine_Op<"parallel",
 }
 
 def AffinePrefetchOp : Affine_Op<"prefetch",
-  [DeclareOpInterfaceMethods<AffineMapAccessInterface>, MemRefsNormalizable]> {
+  [DeclareOpInterfaceMethods<AffineMapAccessInterface>,
+   MemRefsNormalizable]> {
   let summary = "affine prefetch operation";
   let description = [{
     The `affine.prefetch` op prefetches data from a memref location described


### PR DESCRIPTION
As of now, `affine.prefetch` cannot be memref normalized; namely the memory reference being prefetch has to be a simple constant-offset based indexing.

For example:
```mlir
func.func @prefetch_normalize(%arg0: memref<512xf32, affine_map<(d0) -> (d0 floordiv 32, d0 mod 32)>>) -> () {
  affine.for %arg3 = 0 to 8  {
    affine.prefetch %arg0[%arg3], read, locality<3>, data : memref<512xf32, affine_map<(d0) -> (d0 floordiv 32, d0 mod 32)>>
  }
  return
}
```
 
cannot be normalized.

Using this PR (which simply add the `MemRefsNormalizable` property to the `affine.prefetch` operation) proper code is being generated, as shown below:

```mlir
func.func @prefetch_normalize(%arg0: memref<16x32xf32>) {
    affine.for %arg1 = 0 to 8 {
      affine.prefetch %arg0[%arg1 floordiv 32, %arg1 mod 32], read, locality<3>, data : memref<16x32xf32>
    }
    return
}
```

PR include a new lit test.