### PR TITLE
[NewPM][CodeGen] Refactoring CodeGenPassBuilder

### DIFF
--- a/llvm/include/llvm/Target/TargetMachine.h
+++ b/llvm/include/llvm/Target/TargetMachine.h
@@ -472,7 +472,7 @@ public:
   virtual Error buildCodeGenPipeline(ModulePassManager &, raw_pwrite_stream &,
                                      raw_pwrite_stream *, CodeGenFileType,
                                      const CGPassBuilderOption &,
-                                     PassInstrumentationCallbacks *) {
+                                     PassBuilder &) {
     return make_error<StringError>("buildCodeGenPipeline is not overridden",
                                    inconvertibleErrorCode());
   }

--- a/llvm/lib/Target/X86/X86CodeGenPassBuilder.cpp
+++ b/llvm/lib/Target/X86/X86CodeGenPassBuilder.cpp
@@ -26,25 +26,24 @@ class X86CodeGenPassBuilder
 public:
   explicit X86CodeGenPassBuilder(X86TargetMachine &TM,
                                  const CGPassBuilderOption &Opts,
-                                 PassInstrumentationCallbacks *PIC)
-      : CodeGenPassBuilder(TM, Opts, PIC) {}
-  void addPreISel(AddIRPass &addPass) const;
-  void addAsmPrinter(AddMachinePass &, CreateMCStreamer) const;
-  Error addInstSelector(AddMachinePass &) const;
+                                 PassBuilder &PB)
+      : CodeGenPassBuilder(TM, Opts, PB) {}
+  void addPreISel();
+  void addAsmPrinter(CreateMCStreamer);
+  Error addInstSelector();
 };
 
-void X86CodeGenPassBuilder::addPreISel(AddIRPass &addPass) const {
+void X86CodeGenPassBuilder::addPreISel() {
   // TODO: Add passes pre instruction selection.
 }
 
-void X86CodeGenPassBuilder::addAsmPrinter(AddMachinePass &addPass,
-                                          CreateMCStreamer) const {
+void X86CodeGenPassBuilder::addAsmPrinter(CreateMCStreamer) {
   // TODO: Add AsmPrinter.
 }
 
-Error X86CodeGenPassBuilder::addInstSelector(AddMachinePass &addPass) const {
-  // TODO: Add instruction selector related passes.
-  addPass(X86ISelDAGToDAGPass(TM));
+Error X86CodeGenPassBuilder::addInstSelector() {
+  // TODO: Add instruction selector.
+  addMachineFunctionPass(X86ISelDAGToDAGPass(TM));
   return Error::success();
 }
 
@@ -57,8 +56,7 @@ void X86TargetMachine::registerPassBuilderCallbacks(PassBuilder &PB) {
 
 Error X86TargetMachine::buildCodeGenPipeline(
     ModulePassManager &MPM, raw_pwrite_stream &Out, raw_pwrite_stream *DwoOut,
-    CodeGenFileType FileType, const CGPassBuilderOption &Opt,
-    PassInstrumentationCallbacks *PIC) {
-  auto CGPB = X86CodeGenPassBuilder(*this, Opt, PIC);
+    CodeGenFileType FileType, const CGPassBuilderOption &Opt, PassBuilder &PB) {
+  auto CGPB = X86CodeGenPassBuilder(*this, Opt, PB);
   return CGPB.buildPipeline(MPM, Out, DwoOut, FileType);
 }

--- a/llvm/lib/Target/X86/X86TargetMachine.h
+++ b/llvm/lib/Target/X86/X86TargetMachine.h
@@ -71,7 +71,7 @@ public:
   Error buildCodeGenPipeline(ModulePassManager &, raw_pwrite_stream &,
                              raw_pwrite_stream *, CodeGenFileType,
                              const CGPassBuilderOption &,
-                             PassInstrumentationCallbacks *) override;
+                             PassBuilder &) override;
 
   bool isJIT() const { return IsJIT; }
 

--- a/llvm/tools/llc/NewPMDriver.cpp
+++ b/llvm/tools/llc/NewPMDriver.cpp
@@ -155,7 +155,7 @@ int llvm::compileModuleWithNewPM(
       return 1;
   } else {
     ExitOnErr(LLVMTM.buildCodeGenPipeline(
-        MPM, *OS, DwoOut ? &DwoOut->os() : nullptr, FileType, Opt, &PIC));
+        MPM, *OS, DwoOut ? &DwoOut->os() : nullptr, FileType, Opt, PB));
   }
 
   if (PrintPipelinePasses) {

--- a/llvm/unittests/CodeGen/CMakeLists.txt
+++ b/llvm/unittests/CodeGen/CMakeLists.txt
@@ -25,6 +25,7 @@ add_llvm_unittest(CodeGenTests
   AMDGPUMetadataTest.cpp
   AsmPrinterDwarfTest.cpp
   CCStateTest.cpp
+  CodeGenPassBuilderTest.cpp
   DIEHashTest.cpp
   DIETest.cpp
   DwarfStringPoolEntryRefTest.cpp

--- a/llvm/unittests/CodeGen/CodeGenPassBuilderTest.cpp
+++ b/llvm/unittests/CodeGen/CodeGenPassBuilderTest.cpp
@@ -1,0 +1,128 @@
+//===- llvm/unittest/CodeGen/CodeGenPassBuilderTest.cpp -------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "llvm/Passes/CodeGenPassBuilder.h"
+#include "llvm/CodeGen/MachinePassManager.h"
+#include "llvm/CodeGen/TargetInstrInfo.h"
+#include "llvm/CodeGen/TargetLowering.h"
+#include "llvm/MC/TargetRegistry.h"
+#include "llvm/Passes/PassBuilder.h"
+#include "llvm/Target/TargetMachine.h"
+
+#include "gtest/gtest.h"
+
+using namespace llvm;
+
+namespace {
+
+class TestTargetMachine : public LLVMTargetMachine {
+public:
+  TestTargetMachine()
+      : LLVMTargetMachine(Target(), "", Triple(""), "", "", TargetOptions(),
+                          Reloc::Static, CodeModel::Small,
+                          CodeGenOptLevel::Default) {}
+};
+
+TestTargetMachine &createTargetMachine() {
+  static TestTargetMachine TM;
+  return TM;
+}
+
+struct DisabledMachineFunctionPass
+    : public PassInfoMixin<DisabledMachineFunctionPass> {
+  PreservedAnalyses run(MachineFunction &, MachineFunctionAnalysisManager &) {
+    return PreservedAnalyses::all();
+  }
+};
+
+struct ReplacedMachineFunctionPass
+    : public PassInfoMixin<ReplacedMachineFunctionPass> {
+  PreservedAnalyses run(MachineFunction &, MachineFunctionAnalysisManager &) {
+    return PreservedAnalyses::all();
+  }
+};
+
+class TestCodeGenPassBuilder
+    : public CodeGenPassBuilder<TestCodeGenPassBuilder, TestTargetMachine> {
+
+public:
+  explicit TestCodeGenPassBuilder(PassBuilder &PB)
+      : CodeGenPassBuilder(createTargetMachine(), CGPassBuilderOption(), PB) {
+    // Declare disabled passes in constructor.
+    disablePass<NoOpModulePass>(3); // Disable the third NoOpModulePass.
+    disablePass<DisabledMachineFunctionPass>();
+  }
+
+  // Override substitutePass is also OK.
+  // template <typename PassT> auto substitutePass() {
+  //   if constexpr (std::is_same_v<PassT, ReplacedMachineFunctionPass>)
+  //     return NoOpMachineFunctionPass();
+  //   else
+  //     return;
+  // }
+
+  void buildTestPipeline(ModulePassManager &MPM) {
+    addModulePass<NoOpModulePass, NoOpModulePass>();
+    addFunctionPass<NoOpFunctionPass>();
+    addModulePass<NoOpModulePass>();
+    addMachineFunctionPass<DisabledMachineFunctionPass>();
+    addFunctionPass(NoOpFunctionPass());
+    addMachineFunctionPass<NoOpMachineFunctionPass,
+                           ReplacedMachineFunctionPass>();
+    mergePassManager();
+    MPM.addPass(std::move(getMPM()));
+    getMPM() = ModulePassManager();
+  }
+};
+
+class CodeGenPassBuilderTest : public testing::Test {
+public:
+  CodeGenPassBuilderTest() : PB(&createTargetMachine()) {
+    PIC.addClassToPassName(NoOpModulePass::name(), "no-op-module");
+    PIC.addClassToPassName(NoOpFunctionPass::name(), "no-op-function");
+    PIC.addClassToPassName(NoOpMachineFunctionPass::name(),
+                           "no-op-machine-function");
+    PIC.addClassToPassName(DisabledMachineFunctionPass::name(), "disabled");
+    PIC.addClassToPassName(ReplacedMachineFunctionPass::name(), "replaced");
+  }
+
+  void buildPipeline(ModulePassManager &MPM) {
+    TestCodeGenPassBuilder CGPB(PB);
+    CGPB.buildTestPipeline(MPM);
+  }
+
+  std::string getPipelineText(ModulePassManager &MPM) {
+    std::string PipelineText;
+    raw_string_ostream OS(PipelineText);
+    MPM.printPipeline(
+        OS, [&](StringRef S) { return PIC.getPassNameForClassName(S); });
+    return PipelineText;
+  }
+  PassInstrumentationCallbacks PIC;
+  PassBuilder PB;
+};
+
+} // namespace
+
+using PassBuilderBase =
+    CodeGenPassBuilder<TestCodeGenPassBuilder, TestTargetMachine>;
+
+// Add a specialization to substitute a pass.
+template <>
+template <>
+auto PassBuilderBase::substitutePass<ReplacedMachineFunctionPass>() {
+  return NoOpMachineFunctionPass();
+}
+
+TEST_F(CodeGenPassBuilderTest, Basic) {
+  ModulePassManager MPM;
+  buildPipeline(MPM);
+  EXPECT_EQ(getPipelineText(MPM),
+            "no-op-module,no-op-module,function(no-op-function,no-op-function,"
+            "machine-function(no-op-machine-function,no-op-machine-function))");
+}


### PR DESCRIPTION
- Remove redundant `std::move`.
- Use a unified function to add passes.
- Support pass substitution, i.e. user can specialize `substitutePass` to replace the pass by another pass. Currently `PostRAScheduler` could be substituted by `PostMachineScheduler` in some backends.
Based on #88610.