### PR TITLE
[memprof] Omit the key/data lengths for the frame table

### DIFF
--- a/llvm/lib/ProfileData/InstrProfReader.cpp
+++ b/llvm/lib/ProfileData/InstrProfReader.cpp
@@ -1272,7 +1272,7 @@ Error IndexedMemProfReader::deserialize(const unsigned char *Start,
   MemProfFrameTable.reset(MemProfFrameHashTable::Create(
       /*Buckets=*/Start + FrameTableOffset,
       /*Payload=*/Start + FramePayloadOffset,
-      /*Base=*/Start));
+      /*Base=*/Start, memprof::FrameLookupTrait(Version)));
 
   if (Version >= memprof::Version2)
     MemProfCallStackTable.reset(MemProfCallStackHashTable::Create(


### PR DESCRIPTION
The frame table has constant key/data lengths, so we don't need to
serialize or deserialize them for every key-data pair.  Omitting the
key/data lengths saves 0.21% of the indexed MemProf file size.

Note that it's OK to change the format because Version2 is still under
development.
