### PR TITLE
[PowerPC][NFC] Allow different orders of .extern in some test cases

### DIFF
--- a/llvm/test/CodeGen/PowerPC/aix-tls-gd-double.ll
+++ b/llvm/test/CodeGen/PowerPC/aix-tls-gd-double.ll
@@ -612,14 +612,14 @@ entry:
 
 ; External symbol reference checks for .__tls_get_addr/.__tls_get_mod
 
-; SMALL32: .extern .__tls_get_addr[PR]
-; SMALL32: .extern .__tls_get_mod[PR]
-; SMALL64: .extern .__tls_get_addr[PR]
-; SMALL64: .extern .__tls_get_mod[PR]
-; LARGE32: .extern .__tls_get_addr[PR]
-; LARGE32: .extern .__tls_get_mod[PR]
-; LARGE64: .extern .__tls_get_addr[PR]
-; LARGE64: .extern .__tls_get_mod[PR]
+; SMALL32: .extern .{{__tls_get_addr|__tls_get_mod}}[PR]
+; SMALL32: .extern .{{__tls_get_addr|__tls_get_mod}}[PR]
+; SMALL64: .extern .{{__tls_get_addr|__tls_get_mod}}[PR]
+; SMALL64: .extern .{{__tls_get_addr|__tls_get_mod}}[PR]
+; LARGE32: .extern .{{__tls_get_addr|__tls_get_mod}}[PR]
+; LARGE32: .extern .{{__tls_get_addr|__tls_get_mod}}[PR]
+; LARGE64: .extern .{{__tls_get_addr|__tls_get_mod}}[PR]
+; LARGE64: .extern .{{__tls_get_addr|__tls_get_mod}}[PR]
 
 ; TOC entry checks
 

--- a/llvm/test/CodeGen/PowerPC/aix-tls-gd-int.ll
+++ b/llvm/test/CodeGen/PowerPC/aix-tls-gd-int.ll
@@ -627,14 +627,14 @@ entry:
 
 ; External symbol reference checks for .__tls_get_addr/.__tls_get_mod
 
-; SMALL32: .extern .__tls_get_addr[PR]
-; SMALL32: .extern .__tls_get_mod[PR]
-; SMALL64: .extern .__tls_get_addr[PR]
-; SMALL64: .extern .__tls_get_mod[PR]
-; LARGE32: .extern .__tls_get_addr[PR]
-; LARGE32: .extern .__tls_get_mod[PR]
-; LARGE64: .extern .__tls_get_addr[PR]
-; LARGE64: .extern .__tls_get_mod[PR]
+; SMALL32: .extern .{{__tls_get_addr|__tls_get_mod}}[PR]
+; SMALL32: .extern .{{__tls_get_addr|__tls_get_mod}}[PR]
+; SMALL64: .extern .{{__tls_get_addr|__tls_get_mod}}[PR]
+; SMALL64: .extern .{{__tls_get_addr|__tls_get_mod}}[PR]
+; LARGE32: .extern .{{__tls_get_addr|__tls_get_mod}}[PR]
+; LARGE32: .extern .{{__tls_get_addr|__tls_get_mod}}[PR]
+; LARGE64: .extern .{{__tls_get_addr|__tls_get_mod}}[PR]
+; LARGE64: .extern .{{__tls_get_addr|__tls_get_mod}}[PR]
 
 ; TOC entry checks
 

--- a/llvm/test/CodeGen/PowerPC/aix-tls-gd-longlong.ll
+++ b/llvm/test/CodeGen/PowerPC/aix-tls-gd-longlong.ll
@@ -667,14 +667,14 @@ entry:
 
 ; External symbol reference checks for .__tls_get_addr/.__tls_get_mod
 
-; SMALL32: .extern .__tls_get_addr[PR]
-; SMALL32: .extern .__tls_get_mod[PR]
-; SMALL64: .extern .__tls_get_addr[PR]
-; SMALL64: .extern .__tls_get_mod[PR]
-; LARGE32: .extern .__tls_get_addr[PR]
-; LARGE32: .extern .__tls_get_mod[PR]
-; LARGE64: .extern .__tls_get_addr[PR]
-; LARGE64: .extern .__tls_get_mod[PR]
+; SMALL32: .extern .{{__tls_get_addr|__tls_get_mod}}[PR]
+; SMALL32: .extern .{{__tls_get_addr|__tls_get_mod}}[PR]
+; SMALL64: .extern .{{__tls_get_addr|__tls_get_mod}}[PR]
+; SMALL64: .extern .{{__tls_get_addr|__tls_get_mod}}[PR]
+; LARGE32: .extern .{{__tls_get_addr|__tls_get_mod}}[PR]
+; LARGE32: .extern .{{__tls_get_addr|__tls_get_mod}}[PR]
+; LARGE64: .extern .{{__tls_get_addr|__tls_get_mod}}[PR]
+; LARGE64: .extern .{{__tls_get_addr|__tls_get_mod}}[PR]
 
 ; TOC entry checks
 


### PR DESCRIPTION
The order of .externs is irrelevant to the functionality, however [reverse-iteration](https://lab.llvm.org/buildbot/#/builders/54) buildbot check that.