### PR TITLE
[RISCV] Teach .option arch to support experimental extensions.

### DIFF
--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -8449,11 +8449,6 @@ void ClangAs::AddRISCVTargetArgs(const ArgList &Args,
       CmdArgs.push_back("-mllvm");
       CmdArgs.push_back("-riscv-add-build-attributes");
   }
-
-  if (!Args.hasArg(options::OPT_menable_experimental_extensions)) {
-    CmdArgs.push_back("-mllvm");
-    CmdArgs.push_back("-riscv-disable-experimental-ext");
-  }
 }
 
 void ClangAs::ConstructJob(Compilation &C, const JobAction &JA,

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -8449,6 +8449,11 @@ void ClangAs::AddRISCVTargetArgs(const ArgList &Args,
       CmdArgs.push_back("-mllvm");
       CmdArgs.push_back("-riscv-add-build-attributes");
   }
+
+  if (!Args.hasArg(options::OPT_menable_experimental_extensions)) {
+    CmdArgs.push_back("-mllvm");
+    CmdArgs.push_back("-riscv-disable-experimental-ext");
+  }
 }
 
 void ClangAs::ConstructJob(Compilation &C, const JobAction &JA,

--- a/clang/test/Driver/riscv-option-arch.c
+++ b/clang/test/Driver/riscv-option-arch.c
@@ -1,0 +1,7 @@
+// RUN: %clang --target=riscv64 -menable-experimental-extensions -c -o /dev/null %s
+// RUN: ! %clang --target=riscv64 -c -o /dev/null %s 2>&1 | FileCheck -check-prefixes=CHECK-ERR %s
+
+void foo() {
+  asm volatile (".option arch, +zicfiss");
+  // CHECK-ERR: Unexpected experimental extensions.
+}

--- a/clang/test/Driver/riscv-option-arch.s
+++ b/clang/test/Driver/riscv-option-arch.s
@@ -1,0 +1,5 @@
+# RUN: %clang --target=riscv64 -menable-experimental-extensions -c -o /dev/null %s
+# RUN: ! %clang --target=riscv64 -c -o /dev/null %s 2>&1 | FileCheck -check-prefixes=CHECK-ERR %s
+
+.option arch, +zicfiss
+# CHECK-ERR: Unexpected experimental extensions.

--- a/llvm/lib/Target/RISCV/AsmParser/RISCVAsmParser.cpp
+++ b/llvm/lib/Target/RISCV/AsmParser/RISCVAsmParser.cpp
@@ -51,6 +51,7 @@ STATISTIC(RISCVNumInstrsCompressed,
 
 static cl::opt<bool> AddBuildAttributes("riscv-add-build-attributes",
                                         cl::init(false));
+
 namespace llvm {
 extern const SubtargetFeatureKV RISCVFeatureKV[RISCV::NumSubtargetFeatures];
 } // namespace llvm
@@ -2831,8 +2832,7 @@ bool RISCVAsmParser::parseDirectiveOption() {
           StringRef(Feature).starts_with("experimental-"))
         return Error(Loc, "Unexpected experimental extensions.");
       auto Ext = llvm::lower_bound(RISCVFeatureKV, Feature);
-      if (Ext == std::end(RISCVFeatureKV) || StringRef(Ext->Key) != Feature ||
-          !RISCVISAInfo::isSupportedExtension(Arch)) {
+      if (Ext == std::end(RISCVFeatureKV) || StringRef(Ext->Key) != Feature) {
         if (isDigit(Arch.back()))
           return Error(
               Loc,

--- a/llvm/lib/Target/RISCV/AsmParser/RISCVAsmParser.cpp
+++ b/llvm/lib/Target/RISCV/AsmParser/RISCVAsmParser.cpp
@@ -2827,18 +2827,17 @@ bool RISCVAsmParser::parseDirectiveOption() {
         break;
       }
 
+      if (isDigit(Arch.back()))
+        return Error(
+            Loc, "Extension version number parsing not currently implemented");
+
       std::string Feature = RISCVISAInfo::getTargetFeatureForExtension(Arch);
       if (!enableExperimentalExtension() &&
           StringRef(Feature).starts_with("experimental-"))
         return Error(Loc, "Unexpected experimental extensions.");
       auto Ext = llvm::lower_bound(RISCVFeatureKV, Feature);
-      if (Ext == std::end(RISCVFeatureKV) || StringRef(Ext->Key) != Feature) {
-        if (isDigit(Arch.back()))
-          return Error(
-              Loc,
-              "Extension version number parsing not currently implemented");
+      if (Ext == std::end(RISCVFeatureKV) || StringRef(Ext->Key) != Feature)
         return Error(Loc, "unknown extension feature");
-      }
 
       Args.emplace_back(Type, Arch.str());
 

--- a/llvm/lib/Target/RISCV/AsmParser/RISCVAsmParser.cpp
+++ b/llvm/lib/Target/RISCV/AsmParser/RISCVAsmParser.cpp
@@ -2827,7 +2827,7 @@ bool RISCVAsmParser::parseDirectiveOption() {
         break;
       }
 
-      std::string &&Feature = RISCVISAInfo::getTargetFeatureForExtension(Arch);
+      std::string Feature = RISCVISAInfo::getTargetFeatureForExtension(Arch);
       if (DisableExperimentalExtension &&
           StringRef(Feature).starts_with("experimental-"))
         return Error(Loc, "Unexpected experimental extensions.");

--- a/llvm/lib/Target/RISCV/AsmParser/RISCVAsmParser.cpp
+++ b/llvm/lib/Target/RISCV/AsmParser/RISCVAsmParser.cpp
@@ -2824,8 +2824,9 @@ bool RISCVAsmParser::parseDirectiveOption() {
         break;
       }
 
-      auto Ext = llvm::lower_bound(RISCVFeatureKV, Arch);
-      if (Ext == std::end(RISCVFeatureKV) || StringRef(Ext->Key) != Arch ||
+      std::string &&Feature = RISCVISAInfo::getTargetFeatureForExtension(Arch);
+      auto Ext = llvm::lower_bound(RISCVFeatureKV, Feature);
+      if (Ext == std::end(RISCVFeatureKV) || StringRef(Ext->Key) != Feature ||
           !RISCVISAInfo::isSupportedExtension(Arch)) {
         if (isDigit(Arch.back()))
           return Error(
@@ -2834,7 +2835,7 @@ bool RISCVAsmParser::parseDirectiveOption() {
         return Error(Loc, "unknown extension feature");
       }
 
-      Args.emplace_back(Type, Ext->Key);
+      Args.emplace_back(Type, Arch.str());
 
       if (Type == RISCVOptionArchArgType::Plus) {
         FeatureBitset OldFeatureBits = STI->getFeatureBits();

--- a/llvm/lib/Target/RISCV/AsmParser/RISCVAsmParser.cpp
+++ b/llvm/lib/Target/RISCV/AsmParser/RISCVAsmParser.cpp
@@ -51,6 +51,9 @@ STATISTIC(RISCVNumInstrsCompressed,
 
 static cl::opt<bool> AddBuildAttributes("riscv-add-build-attributes",
                                         cl::init(false));
+static cl::opt<bool>
+    DisableExperimentalExtension("riscv-disable-experimental-ext",
+                                 cl::init(false));
 
 namespace llvm {
 extern const SubtargetFeatureKV RISCVFeatureKV[RISCV::NumSubtargetFeatures];
@@ -2825,6 +2828,9 @@ bool RISCVAsmParser::parseDirectiveOption() {
       }
 
       std::string &&Feature = RISCVISAInfo::getTargetFeatureForExtension(Arch);
+      if (DisableExperimentalExtension &&
+          StringRef(Feature).starts_with("experimental-"))
+        return Error(Loc, "Unexpected experimental extensions.");
       auto Ext = llvm::lower_bound(RISCVFeatureKV, Feature);
       if (Ext == std::end(RISCVFeatureKV) || StringRef(Ext->Key) != Feature ||
           !RISCVISAInfo::isSupportedExtension(Arch)) {

--- a/llvm/lib/Target/RISCV/AsmParser/RISCVAsmParser.cpp
+++ b/llvm/lib/Target/RISCV/AsmParser/RISCVAsmParser.cpp
@@ -51,10 +51,6 @@ STATISTIC(RISCVNumInstrsCompressed,
 
 static cl::opt<bool> AddBuildAttributes("riscv-add-build-attributes",
                                         cl::init(false));
-static cl::opt<bool>
-    DisableExperimentalExtension("riscv-disable-experimental-ext",
-                                 cl::init(false));
-
 namespace llvm {
 extern const SubtargetFeatureKV RISCVFeatureKV[RISCV::NumSubtargetFeatures];
 } // namespace llvm
@@ -87,6 +83,9 @@ class RISCVAsmParser : public MCTargetAsmParser {
   SMLoc getLoc() const { return getParser().getTok().getLoc(); }
   bool isRV64() const { return getSTI().hasFeature(RISCV::Feature64Bit); }
   bool isRVE() const { return getSTI().hasFeature(RISCV::FeatureStdExtE); }
+  bool enableExperimentalExtension() const {
+    return getSTI().hasFeature(RISCV::Experimental);
+  }
 
   RISCVTargetStreamer &getTargetStreamer() {
     assert(getParser().getStreamer().getTargetStreamer() &&
@@ -2828,7 +2827,7 @@ bool RISCVAsmParser::parseDirectiveOption() {
       }
 
       std::string Feature = RISCVISAInfo::getTargetFeatureForExtension(Arch);
-      if (DisableExperimentalExtension &&
+      if (!enableExperimentalExtension() &&
           StringRef(Feature).starts_with("experimental-"))
         return Error(Loc, "Unexpected experimental extensions.");
       auto Ext = llvm::lower_bound(RISCVFeatureKV, Feature);

--- a/llvm/test/MC/RISCV/option-arch.s
+++ b/llvm/test/MC/RISCV/option-arch.s
@@ -1,6 +1,6 @@
-# RUN: llvm-mc -triple riscv32 -show-encoding < %s \
+# RUN: llvm-mc -triple riscv32 -mattr=+experimental -show-encoding < %s \
 # RUN:   | FileCheck -check-prefixes=CHECK %s
-# RUN: llvm-mc -triple riscv32 -filetype=obj < %s \
+# RUN: llvm-mc -triple riscv32 -mattr=+experimental -filetype=obj < %s \
 # RUN:   | llvm-objdump  --triple=riscv32 --mattr=+c,+m,+a,+f,+zba,+experimental-zicfiss -d -M no-aliases - \
 # RUN:   | FileCheck -check-prefixes=CHECK-INST %s
 

--- a/llvm/test/MC/RISCV/option-arch.s
+++ b/llvm/test/MC/RISCV/option-arch.s
@@ -1,7 +1,7 @@
 # RUN: llvm-mc -triple riscv32 -show-encoding < %s \
 # RUN:   | FileCheck -check-prefixes=CHECK %s
 # RUN: llvm-mc -triple riscv32 -filetype=obj < %s \
-# RUN:   | llvm-objdump  --triple=riscv32 --mattr=+c,+m,+a,+f,+zba -d -M no-aliases - \
+# RUN:   | llvm-objdump  --triple=riscv32 --mattr=+c,+m,+a,+f,+zba,+experimental-zicfiss -d -M no-aliases - \
 # RUN:   | FileCheck -check-prefixes=CHECK-INST %s
 
 # Test '.option arch, +' and '.option arch, -' directive
@@ -77,6 +77,13 @@ lr.w t0, (t1)
 # CHECK-INST: sh1add t0, t1, t2
 # CHECK: encoding: [0xb3,0x22,0x73,0x20]
 sh1add t0, t1, t2
+
+# Test experimental extension
+# CHECK: .option arch, +zicfiss
+.option arch, +zicfiss
+# CHECK-INST: sspopchk ra
+# CHECK: encoding: [0x73,0xc0,0xc0,0xcd]
+sspopchk ra
 
 # Test '.option arch, <arch-string>' directive
 # CHECK: .option arch, rv32i2p1_m2p0_a2p1_c2p0


### PR DESCRIPTION
Previously `.option arch` denied extenions are not belongs to RISC-V features. But experimental features have experimental- prefix, so `.option arch` can not serve for experimental extension.
This patch uses the features of extensions to identify extension existance.