### PR TITLE
[clang-repl] Test explicit emission of dtors in runtime interface builder (NFC)

### DIFF
--- a/clang/test/Interpreter/force-codegen-dtor.cpp
+++ b/clang/test/Interpreter/force-codegen-dtor.cpp
@@ -11,7 +11,7 @@ extern "C" int printf(const char *, ...);
 template <class T> GuardX<T>::~GuardX() { delete x; printf("Running dtor\n"); }
 
 // Let's make sure that the RuntimeInterfaceBuilder requests it explicitly:
-(GuardX(x))
+(GuardX<int>(x))
 
 // CHECK-NOT: Symbols not found
 // CHECK: Running dtor

--- a/clang/test/Interpreter/force-codegen-dtor.cpp
+++ b/clang/test/Interpreter/force-codegen-dtor.cpp
@@ -1,13 +1,17 @@
+// REQUIRES: host-supports-jit
 // UNSUPPORTED: system-aix
 
 // RUN: cat %s | clang-repl | FileCheck %s
 int *x = new int();
 template <class T> struct GuardX { T *&x; GuardX(T *&x) : x(x) {}; ~GuardX(); };
-template <class T> GuardX<T>::~GuardX() { delete x; x = nullptr; }
 
-// clang would normally defer codegen for ~GuardX()
-// Make sure that RuntimeInterfaceBuilder requests it explicitly
+// clang normally defers codegen for this out-of-line ~GuardX(), which would
+// cause the JIT to report Symbols not found: [ _ZN6GuardXIiED2Ev ]
+extern "C" int printf(const char *, ...);
+template <class T> GuardX<T>::~GuardX() { delete x; printf("Running dtor\n"); }
+
+// Let's make sure that the RuntimeInterfaceBuilder requests it explicitly:
 (GuardX(x))
 
 // CHECK-NOT: Symbols not found
-// CHECK-NOT: _ZN6GuardXIiED2Ev
+// CHECK: Running dtor

--- a/clang/test/Interpreter/force-codegen-dtor.cpp
+++ b/clang/test/Interpreter/force-codegen-dtor.cpp
@@ -1,0 +1,13 @@
+// UNSUPPORTED: system-aix
+
+// RUN: cat %s | clang-repl | FileCheck %s
+int *x = new int();
+template <class T> struct GuardX { T *&x; GuardX(T *&x) : x(x) {}; ~GuardX(); };
+template <class T> GuardX<T>::~GuardX() { delete x; x = nullptr; }
+
+// clang would normally defer codegen for ~GuardX()
+// Make sure that RuntimeInterfaceBuilder requests it explicitly
+(GuardX(x))
+
+// CHECK-NOT: Symbols not found
+// CHECK-NOT: _ZN6GuardXIiED2Ev


### PR DESCRIPTION
This patch adds test coverage for an edge case that is supported already.