### PR TITLE
[lldb][test] Make archflags for gcc and clang -march

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/make/Makefile.rules
+++ b/lldb/packages/Python/lldbsuite/test/make/Makefile.rules
@@ -212,6 +212,20 @@ else
 	endif
 endif
 
+ifneq (,$(findstring gcc,$(CC)))
+	ARCHFLAG :=-march=
+endif
+ifneq (,$(findstring g++,$(CC)))
+	ARCHFLAG :=-march=
+endif
+ifneq (,$(findstring clang,$(CC)))
+	ARCHFLAG :=-march=
+endif
+ifneq (,$(findstring clang++,$(CC)))
+	ARCHFLAG :=-march=
+endif
+
+
 LIMIT_DEBUG_INFO_FLAGS =
 NO_LIMIT_DEBUG_INFO_FLAGS =
 MODULE_DEBUG_INFO_FLAGS =


### PR DESCRIPTION
Hi

It seems that by default
```
# On non-Apple platforms, -arch becomes -m
```

This patch overrides this behavior, and if it is used clang or gcc/g++, flag becomes `-march`

