### PR TITLE
[CombinerHelper]: Use undef for handling divisors of one

### DIFF
--- a/llvm/include/llvm/Passes/MachinePassRegistry.def
+++ b/llvm/include/llvm/Passes/MachinePassRegistry.def
@@ -128,6 +128,7 @@ MACHINE_FUNCTION_PASS("no-op-machine-function", NoOpMachineFunctionPass())
 MACHINE_FUNCTION_PASS("print", PrintMIRPass())
 MACHINE_FUNCTION_PASS("require-all-machine-function-properties",
                       RequireAllMachineFunctionPropertiesPass())
+MACHINE_FUNCTION_PASS("trigger-verifier-error", TriggerVerifierErrorPass())
 #undef MACHINE_FUNCTION_PASS
 
 // After a pass is converted to new pass manager, its entry should be moved from

--- a/llvm/lib/CodeGen/GlobalISel/CombinerHelper.cpp
+++ b/llvm/lib/CodeGen/GlobalISel/CombinerHelper.cpp
@@ -5075,6 +5075,8 @@ MachineInstr *CombinerHelper::buildUDivUsingMul(MachineInstr &MI) {
   auto &MIB = Builder;
 
   bool UseNPQ = false;
+  bool UsePreShift = false;
+  bool UsePostShift = false;
   SmallVector<Register, 16> PreShifts, PostShifts, MagicFactors, NPQFactors;
 
   auto BuildUDIVPattern = [&](const Constant *C) {
@@ -5087,26 +5089,27 @@ MachineInstr *CombinerHelper::buildUDivUsingMul(MachineInstr &MI) {
 
     // Magic algorithm doesn't work for division by 1. We need to emit a select
     // at the end.
-    // TODO: Use undef values for divisor of 1.
-    if (!Divisor.isOne()) {
-
-      // UnsignedDivisionByConstantInfo doesn't work correctly if leading zeros
-      // in the dividend exceeds the leading zeros for the divisor.
-      UnsignedDivisionByConstantInfo magics =
-          UnsignedDivisionByConstantInfo::get(
-              Divisor, std::min(KnownLeadingZeros, Divisor.countl_zero()));
-
-      Magic = std::move(magics.Magic);
-
-      assert(magics.PreShift < Divisor.getBitWidth() &&
-             "We shouldn't generate an undefined shift!");
-      assert(magics.PostShift < Divisor.getBitWidth() &&
-             "We shouldn't generate an undefined shift!");
-      assert((!magics.IsAdd || magics.PreShift == 0) && "Unexpected pre-shift");
-      PreShift = magics.PreShift;
-      PostShift = magics.PostShift;
-      SelNPQ = magics.IsAdd;
+    if (Divisor.isOne()) {
+      PreShifts.push_back(MIB.buildUndef(ScalarShiftAmtTy).getReg(0));
+      MagicFactors.push_back(MIB.buildUndef(ScalarTy).getReg(0));
+      NPQFactors.push_back(MIB.buildUndef(ScalarTy).getReg(0));
+      PostShifts.push_back(MIB.buildUndef(ScalarShiftAmtTy).getReg(0));
+      return true;
     }
+
+    UnsignedDivisionByConstantInfo magics = UnsignedDivisionByConstantInfo::get(
+        Divisor, std::min(KnownLeadingZeros, Divisor.countl_zero()));
+
+    Magic = std::move(magics.Magic);
+
+    assert(magics.PreShift < Divisor.getBitWidth() &&
+           "We shouldn't generate an undefined shift!");
+    assert(magics.PostShift < Divisor.getBitWidth() &&
+           "We shouldn't generate an undefined shift!");
+    assert((!magics.IsAdd || magics.PreShift == 0) && "Unexpected pre-shift");
+    PreShift = magics.PreShift;
+    PostShift = magics.PostShift;
+    SelNPQ = magics.IsAdd;
 
     PreShifts.push_back(
         MIB.buildConstant(ScalarShiftAmtTy, PreShift).getReg(0));
@@ -5119,6 +5122,8 @@ MachineInstr *CombinerHelper::buildUDivUsingMul(MachineInstr &MI) {
     PostShifts.push_back(
         MIB.buildConstant(ScalarShiftAmtTy, PostShift).getReg(0));
     UseNPQ |= SelNPQ;
+    UsePreShift |= PreShift != 0;
+    UsePostShift |= magics.PostShift != 0;
     return true;
   };
 
@@ -5143,7 +5148,9 @@ MachineInstr *CombinerHelper::buildUDivUsingMul(MachineInstr &MI) {
   }
 
   Register Q = LHS;
-  Q = MIB.buildLShr(Ty, Q, PreShift).getReg(0);
+
+  if (UsePreShift)
+    Q = MIB.buildLShr(Ty, Q, PreShift).getReg(0);
 
   // Multiply the numerator (operand 0) by the magic value.
   Q = MIB.buildUMulH(Ty, Q, MagicFactor).getReg(0);
@@ -5161,7 +5168,8 @@ MachineInstr *CombinerHelper::buildUDivUsingMul(MachineInstr &MI) {
     Q = MIB.buildAdd(Ty, NPQ, Q).getReg(0);
   }
 
-  Q = MIB.buildLShr(Ty, Q, PostShift).getReg(0);
+  if (UsePostShift)
+    Q = MIB.buildLShr(Ty, Q, PostShift).getReg(0);
   auto One = MIB.buildConstant(Ty, 1);
   auto IsOne = MIB.buildICmp(
       CmpInst::Predicate::ICMP_EQ,

--- a/llvm/lib/Passes/PassBuilder.cpp
+++ b/llvm/lib/Passes/PassBuilder.cpp
@@ -93,6 +93,7 @@
 #include "llvm/CodeGen/MIRPrinter.h"
 #include "llvm/CodeGen/MachineFunctionAnalysis.h"
 #include "llvm/CodeGen/MachinePassManager.h"
+#include "llvm/CodeGen/MachineRegisterInfo.h"
 #include "llvm/CodeGen/PreISelIntrinsicLowering.h"
 #include "llvm/CodeGen/SafeStack.h"
 #include "llvm/CodeGen/SelectOptimize.h"
@@ -361,6 +362,14 @@ public:
     BasicBlock &BB = F.getEntryBlock();
     new UnreachableInst(F.getContext(), BB.getTerminator()->getIterator());
     return PreservedAnalyses::none();
+  }
+
+  PreservedAnalyses run(MachineFunction &MF, MachineFunctionAnalysisManager &) {
+    // Intentionally create a virtual register and set NoVRegs property.
+    auto &MRI = MF.getRegInfo();
+    MRI.createGenericVirtualRegister(LLT::scalar(8));
+    MF.getProperties().set(MachineFunctionProperties::Property::NoVRegs);
+    return PreservedAnalyses::all();
   }
 
   static StringRef name() { return "TriggerVerifierErrorPass"; }

--- a/llvm/lib/Passes/StandardInstrumentations.cpp
+++ b/llvm/lib/Passes/StandardInstrumentations.cpp
@@ -1487,6 +1487,17 @@ void VerifyInstrumentation::registerCallbacks(
                                          "\"{0}\", compilation aborted!",
                                          P));
           }
+
+          // TODO: Use complete MachineVerifierPass.
+          if (auto *MF = unwrapIR<MachineFunction>(IR)) {
+            if (DebugLogging)
+              dbgs() << "Verifying machine function " << MF->getName() << '\n';
+            verifyMachineFunction(
+                formatv("Broken machine function found after pass "
+                        "\"{0}\", compilation aborted!",
+                        P),
+                *MF);
+          }
         }
       });
 }

--- a/llvm/test/CodeGen/AArch64/GlobalISel/combine-udiv.ll
+++ b/llvm/test/CodeGen/AArch64/GlobalISel/combine-udiv.ll
@@ -169,17 +169,17 @@ define <16 x i8> @combine_vec_udiv_nonuniform4(<16 x i8> %x) {
 ;
 ; GISEL-LABEL: combine_vec_udiv_nonuniform4:
 ; GISEL:       // %bb.0:
-; GISEL-NEXT:    adrp x8, .LCPI4_2
-; GISEL-NEXT:    adrp x9, .LCPI4_0
-; GISEL-NEXT:    ldr q1, [x8, :lo12:.LCPI4_2]
-; GISEL-NEXT:    adrp x8, .LCPI4_1
-; GISEL-NEXT:    ldr q4, [x9, :lo12:.LCPI4_0]
-; GISEL-NEXT:    ldr q3, [x8, :lo12:.LCPI4_1]
+; GISEL-NEXT:    mov w8, #171 // =0xab
+; GISEL-NEXT:    fmov s1, w8
+; GISEL-NEXT:    adrp x8, .LCPI4_0
+; GISEL-NEXT:    ldr q3, [x8, :lo12:.LCPI4_0]
+; GISEL-NEXT:    mov w8, #7 // =0x7
 ; GISEL-NEXT:    umull2 v2.8h, v0.16b, v1.16b
 ; GISEL-NEXT:    umull v1.8h, v0.8b, v1.8b
+; GISEL-NEXT:    shl v3.16b, v3.16b, #7
 ; GISEL-NEXT:    uzp2 v1.16b, v1.16b, v2.16b
-; GISEL-NEXT:    neg v2.16b, v3.16b
-; GISEL-NEXT:    shl v3.16b, v4.16b, #7
+; GISEL-NEXT:    fmov s2, w8
+; GISEL-NEXT:    neg v2.16b, v2.16b
 ; GISEL-NEXT:    ushl v1.16b, v1.16b, v2.16b
 ; GISEL-NEXT:    sshr v2.16b, v3.16b, #7
 ; GISEL-NEXT:    bif v0.16b, v1.16b, v2.16b
@@ -217,25 +217,66 @@ define <8 x i16> @pr38477(<8 x i16> %a0) {
 ;
 ; GISEL-LABEL: pr38477:
 ; GISEL:       // %bb.0:
-; GISEL-NEXT:    adrp x8, .LCPI5_3
-; GISEL-NEXT:    ldr q1, [x8, :lo12:.LCPI5_3]
-; GISEL-NEXT:    adrp x8, .LCPI5_2
-; GISEL-NEXT:    ldr q3, [x8, :lo12:.LCPI5_2]
-; GISEL-NEXT:    adrp x8, .LCPI5_0
-; GISEL-NEXT:    umull2 v2.4s, v0.8h, v1.8h
+; GISEL-NEXT:    mov w8, #4957 // =0x135d
+; GISEL-NEXT:    mov w9, #16385 // =0x4001
+; GISEL-NEXT:    fmov s1, w8
+; GISEL-NEXT:    mov w8, #57457 // =0xe071
+; GISEL-NEXT:    fmov s4, w9
+; GISEL-NEXT:    fmov s2, w8
+; GISEL-NEXT:    mov w8, #4103 // =0x1007
+; GISEL-NEXT:    mov w9, #35545 // =0x8ad9
+; GISEL-NEXT:    fmov s5, w9
+; GISEL-NEXT:    mov w9, #2048 // =0x800
+; GISEL-NEXT:    mov v1.h[1], v1.h[0]
+; GISEL-NEXT:    fmov s6, w9
+; GISEL-NEXT:    adrp x9, .LCPI5_0
+; GISEL-NEXT:    mov v1.h[2], v2.h[0]
+; GISEL-NEXT:    fmov s2, w8
+; GISEL-NEXT:    mov w8, #32768 // =0x8000
+; GISEL-NEXT:    fmov s3, w8
+; GISEL-NEXT:    mov w8, #0 // =0x0
+; GISEL-NEXT:    mov v1.h[3], v2.h[0]
+; GISEL-NEXT:    mov v2.h[1], v3.h[0]
+; GISEL-NEXT:    mov v1.h[4], v4.h[0]
+; GISEL-NEXT:    fmov s4, w8
+; GISEL-NEXT:    mov w8, #6 // =0x6
+; GISEL-NEXT:    mov v2.h[2], v4.h[0]
+; GISEL-NEXT:    mov v1.h[5], v5.h[0]
+; GISEL-NEXT:    fmov s5, w8
+; GISEL-NEXT:    mov w8, #2115 // =0x843
+; GISEL-NEXT:    mov v2.h[3], v4.h[0]
+; GISEL-NEXT:    mov v7.h[1], v5.h[0]
+; GISEL-NEXT:    mov v1.h[6], v6.h[0]
+; GISEL-NEXT:    fmov s6, w8
+; GISEL-NEXT:    mov w8, #12 // =0xc
+; GISEL-NEXT:    mov v2.h[4], v4.h[0]
+; GISEL-NEXT:    mov v7.h[2], v5.h[0]
+; GISEL-NEXT:    mov v1.h[7], v6.h[0]
+; GISEL-NEXT:    fmov s6, w8
+; GISEL-NEXT:    mov w8, #14 // =0xe
+; GISEL-NEXT:    fmov s16, w8
+; GISEL-NEXT:    mov w8, #4 // =0x4
+; GISEL-NEXT:    mov v2.h[5], v4.h[0]
+; GISEL-NEXT:    mov v7.h[3], v6.h[0]
+; GISEL-NEXT:    umull2 v6.4s, v0.8h, v1.8h
 ; GISEL-NEXT:    umull v1.4s, v0.4h, v1.4h
-; GISEL-NEXT:    uzp2 v1.8h, v1.8h, v2.8h
-; GISEL-NEXT:    sub v2.8h, v0.8h, v1.8h
-; GISEL-NEXT:    umull2 v4.4s, v2.8h, v3.8h
-; GISEL-NEXT:    umull v2.4s, v2.4h, v3.4h
-; GISEL-NEXT:    ldr d3, [x8, :lo12:.LCPI5_0]
-; GISEL-NEXT:    adrp x8, .LCPI5_1
-; GISEL-NEXT:    ushll v3.8h, v3.8b, #0
+; GISEL-NEXT:    mov v2.h[6], v4.h[0]
+; GISEL-NEXT:    mov v7.h[4], v16.h[0]
+; GISEL-NEXT:    uzp2 v1.8h, v1.8h, v6.8h
+; GISEL-NEXT:    mov v2.h[7], v3.h[0]
+; GISEL-NEXT:    mov v7.h[5], v5.h[0]
+; GISEL-NEXT:    ldr d5, [x9, :lo12:.LCPI5_0]
+; GISEL-NEXT:    sub v3.8h, v0.8h, v1.8h
+; GISEL-NEXT:    mov v7.h[6], v4.h[0]
+; GISEL-NEXT:    umull2 v4.4s, v3.8h, v2.8h
+; GISEL-NEXT:    umull v2.4s, v3.4h, v2.4h
+; GISEL-NEXT:    fmov s3, w8
+; GISEL-NEXT:    mov v7.h[7], v3.h[0]
 ; GISEL-NEXT:    uzp2 v2.8h, v2.8h, v4.8h
-; GISEL-NEXT:    ldr q4, [x8, :lo12:.LCPI5_1]
+; GISEL-NEXT:    ushll v3.8h, v5.8b, #0
 ; GISEL-NEXT:    shl v3.8h, v3.8h, #15
 ; GISEL-NEXT:    add v1.8h, v2.8h, v1.8h
-; GISEL-NEXT:    neg v2.8h, v4.8h
+; GISEL-NEXT:    neg v2.8h, v7.8h
 ; GISEL-NEXT:    ushl v1.8h, v1.8h, v2.8h
 ; GISEL-NEXT:    sshr v2.8h, v3.8h, #15
 ; GISEL-NEXT:    bif v0.16b, v1.16b, v2.16b

--- a/llvm/test/CodeGen/AArch64/GlobalISel/combine-udiv.mir
+++ b/llvm/test/CodeGen/AArch64/GlobalISel/combine-udiv.mir
@@ -228,16 +228,16 @@ body:             |
     ; CHECK: liveins: $q0
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(<16 x s8>) = COPY $q0
-    ; CHECK-NEXT: [[C:%[0-9]+]]:_(s8) = G_CONSTANT i8 0
-    ; CHECK-NEXT: [[C1:%[0-9]+]]:_(s8) = G_CONSTANT i8 -85
-    ; CHECK-NEXT: [[C2:%[0-9]+]]:_(s8) = G_CONSTANT i8 7
-    ; CHECK-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<16 x s8>) = G_BUILD_VECTOR [[C1]](s8), [[C]](s8), [[C]](s8), [[C]](s8), [[C]](s8), [[C]](s8), [[C]](s8), [[C]](s8), [[C]](s8), [[C]](s8), [[C]](s8), [[C]](s8), [[C]](s8), [[C]](s8), [[C]](s8), [[C]](s8)
-    ; CHECK-NEXT: [[BUILD_VECTOR1:%[0-9]+]]:_(<16 x s8>) = G_BUILD_VECTOR [[C2]](s8), [[C]](s8), [[C]](s8), [[C]](s8), [[C]](s8), [[C]](s8), [[C]](s8), [[C]](s8), [[C]](s8), [[C]](s8), [[C]](s8), [[C]](s8), [[C]](s8), [[C]](s8), [[C]](s8), [[C]](s8)
+    ; CHECK-NEXT: [[C:%[0-9]+]]:_(s8) = G_CONSTANT i8 -85
+    ; CHECK-NEXT: [[C1:%[0-9]+]]:_(s8) = G_CONSTANT i8 7
+    ; CHECK-NEXT: [[DEF:%[0-9]+]]:_(s8) = G_IMPLICIT_DEF
+    ; CHECK-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<16 x s8>) = G_BUILD_VECTOR [[C]](s8), [[DEF]](s8), [[DEF]](s8), [[DEF]](s8), [[DEF]](s8), [[DEF]](s8), [[DEF]](s8), [[DEF]](s8), [[DEF]](s8), [[DEF]](s8), [[DEF]](s8), [[DEF]](s8), [[DEF]](s8), [[DEF]](s8), [[DEF]](s8), [[DEF]](s8)
+    ; CHECK-NEXT: [[BUILD_VECTOR1:%[0-9]+]]:_(<16 x s8>) = G_BUILD_VECTOR [[C1]](s8), [[DEF]](s8), [[DEF]](s8), [[DEF]](s8), [[DEF]](s8), [[DEF]](s8), [[DEF]](s8), [[DEF]](s8), [[DEF]](s8), [[DEF]](s8), [[DEF]](s8), [[DEF]](s8), [[DEF]](s8), [[DEF]](s8), [[DEF]](s8), [[DEF]](s8)
     ; CHECK-NEXT: [[UMULH:%[0-9]+]]:_(<16 x s8>) = G_UMULH [[COPY]], [[BUILD_VECTOR]]
     ; CHECK-NEXT: [[LSHR:%[0-9]+]]:_(<16 x s8>) = G_LSHR [[UMULH]], [[BUILD_VECTOR1]](<16 x s8>)
-    ; CHECK-NEXT: [[C3:%[0-9]+]]:_(s1) = G_CONSTANT i1 false
-    ; CHECK-NEXT: [[C4:%[0-9]+]]:_(s1) = G_CONSTANT i1 true
-    ; CHECK-NEXT: [[BUILD_VECTOR2:%[0-9]+]]:_(<16 x s1>) = G_BUILD_VECTOR [[C3]](s1), [[C4]](s1), [[C4]](s1), [[C4]](s1), [[C4]](s1), [[C4]](s1), [[C4]](s1), [[C4]](s1), [[C4]](s1), [[C4]](s1), [[C4]](s1), [[C4]](s1), [[C4]](s1), [[C4]](s1), [[C4]](s1), [[C4]](s1)
+    ; CHECK-NEXT: [[C2:%[0-9]+]]:_(s1) = G_CONSTANT i1 false
+    ; CHECK-NEXT: [[C3:%[0-9]+]]:_(s1) = G_CONSTANT i1 true
+    ; CHECK-NEXT: [[BUILD_VECTOR2:%[0-9]+]]:_(<16 x s1>) = G_BUILD_VECTOR [[C2]](s1), [[C3]](s1), [[C3]](s1), [[C3]](s1), [[C3]](s1), [[C3]](s1), [[C3]](s1), [[C3]](s1), [[C3]](s1), [[C3]](s1), [[C3]](s1), [[C3]](s1), [[C3]](s1), [[C3]](s1), [[C3]](s1), [[C3]](s1)
     ; CHECK-NEXT: [[SELECT:%[0-9]+]]:_(<16 x s8>) = G_SELECT [[BUILD_VECTOR2]](<16 x s1>), [[COPY]], [[LSHR]]
     ; CHECK-NEXT: $q0 = COPY [[SELECT]](<16 x s8>)
     ; CHECK-NEXT: RET_ReallyLR implicit $q0
@@ -264,6 +264,7 @@ body:             |
     ; CHECK: liveins: $q0
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(<8 x s16>) = COPY $q0
+    ; CHECK-NEXT: [[DEF:%[0-9]+]]:_(s16) = G_IMPLICIT_DEF
     ; CHECK-NEXT: [[C:%[0-9]+]]:_(s16) = G_CONSTANT i16 0
     ; CHECK-NEXT: [[C1:%[0-9]+]]:_(s16) = G_CONSTANT i16 4957
     ; CHECK-NEXT: [[C2:%[0-9]+]]:_(s16) = G_CONSTANT i16 -32768
@@ -277,9 +278,9 @@ body:             |
     ; CHECK-NEXT: [[C10:%[0-9]+]]:_(s16) = G_CONSTANT i16 2048
     ; CHECK-NEXT: [[C11:%[0-9]+]]:_(s16) = G_CONSTANT i16 2115
     ; CHECK-NEXT: [[C12:%[0-9]+]]:_(s16) = G_CONSTANT i16 4
-    ; CHECK-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<8 x s16>) = G_BUILD_VECTOR [[C]](s16), [[C1]](s16), [[C4]](s16), [[C5]](s16), [[C7]](s16), [[C9]](s16), [[C10]](s16), [[C11]](s16)
-    ; CHECK-NEXT: [[BUILD_VECTOR1:%[0-9]+]]:_(<8 x s16>) = G_BUILD_VECTOR [[C]](s16), [[C2]](s16), [[C]](s16), [[C]](s16), [[C]](s16), [[C]](s16), [[C]](s16), [[C2]](s16)
-    ; CHECK-NEXT: [[BUILD_VECTOR2:%[0-9]+]]:_(<8 x s16>) = G_BUILD_VECTOR [[C]](s16), [[C3]](s16), [[C3]](s16), [[C6]](s16), [[C8]](s16), [[C3]](s16), [[C]](s16), [[C12]](s16)
+    ; CHECK-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<8 x s16>) = G_BUILD_VECTOR [[DEF]](s16), [[C1]](s16), [[C4]](s16), [[C5]](s16), [[C7]](s16), [[C9]](s16), [[C10]](s16), [[C11]](s16)
+    ; CHECK-NEXT: [[BUILD_VECTOR1:%[0-9]+]]:_(<8 x s16>) = G_BUILD_VECTOR [[DEF]](s16), [[C2]](s16), [[C]](s16), [[C]](s16), [[C]](s16), [[C]](s16), [[C]](s16), [[C2]](s16)
+    ; CHECK-NEXT: [[BUILD_VECTOR2:%[0-9]+]]:_(<8 x s16>) = G_BUILD_VECTOR [[DEF]](s16), [[C3]](s16), [[C3]](s16), [[C6]](s16), [[C8]](s16), [[C3]](s16), [[C]](s16), [[C12]](s16)
     ; CHECK-NEXT: [[UMULH:%[0-9]+]]:_(<8 x s16>) = G_UMULH [[COPY]], [[BUILD_VECTOR]]
     ; CHECK-NEXT: [[SUB:%[0-9]+]]:_(<8 x s16>) = G_SUB [[COPY]], [[UMULH]]
     ; CHECK-NEXT: [[UMULH1:%[0-9]+]]:_(<8 x s16>) = G_UMULH [[SUB]], [[BUILD_VECTOR1]]

--- a/llvm/test/CodeGen/MIR/X86/machine-verifier.mir
+++ b/llvm/test/CodeGen/MIR/X86/machine-verifier.mir
@@ -1,5 +1,5 @@
 # RUN: not --crash llc -march=x86-64 -run-pass none -o /dev/null %s 2>&1 | FileCheck %s
-# This test ensures that the MIR parser runs the machine verifier after parsing.
+# This test ensures that the VerifyInstrumentation works for machine function.
 
 --- |
 

--- a/llvm/test/tools/llc/new-pm/verify.mir
+++ b/llvm/test/tools/llc/new-pm/verify.mir
@@ -1,0 +1,10 @@
+# RUN: not --crash llc -mtriple=x86_64-pc-linux-gnu -debug-pass-manager -passes='module(function(machine-function(trigger-verifier-error)))' -filetype=null %s 2>&1 | FileCheck %s
+
+# CHECK: Verifying machine function f
+# CHECK: Broken machine function found after pass "TriggerVerifierErrorPass"
+---
+name: f
+body: |
+  bb.0:
+    RET 0
+...

--- a/llvm/tools/llc/NewPMDriver.cpp
+++ b/llvm/tools/llc/NewPMDriver.cpp
@@ -115,7 +115,7 @@ int llvm::compileModuleWithNewPM(
   MachineModuleInfo MMI(&LLVMTM);
 
   PassInstrumentationCallbacks PIC;
-  StandardInstrumentations SI(Context, Opt.DebugPM);
+  StandardInstrumentations SI(Context, Opt.DebugPM, !NoVerify);
   SI.registerCallbacks(PIC);
   registerCodeGenCallback(PIC, LLVMTM);
 


### PR DESCRIPTION
I need to figure out if these changes are regressions and how to mitigate them, but they do follow the logic in TargetLowering now.