### PR TITLE
[libc++][ranges] export `std::ranges::range_adaptor_closure`

### DIFF
--- a/libcxx/modules/std/ranges.inc
+++ b/libcxx/modules/std/ranges.inc
@@ -138,8 +138,10 @@ export namespace std {
     }
 #endif // _LIBCPP_HAS_NO_LOCALIZATION
 
+#if _LIBCPP_STD_VER >= 23
     // [range.adaptor.object], range adaptor objects
-    // using std::ranges::range_adaptor_closure;
+    using std::ranges::range_adaptor_closure;
+#endif
 
     // [range.all], all view
     namespace views {


### PR DESCRIPTION
## Abstract

This pull request exports the `std::ranges::range_adaptor_closure` class template implemented in #89148.

```cpp
// [range.adaptor.object], range adaptor objects
template<class D>
  requires is_class_v<D> && same_as<D, remove_cv_t<D>>
class range_adaptor_closure { };
```

## Reference

- [P2387R3: Pipe support for user-defined range adaptors](https://wg21.link/P2387R3)
- [C++ Draft Standard: [range.adaptor.object]](https://eel.is/c++draft/range.adaptor.object)
- #89148