### PR TITLE
[BOLT] Emit synthetic FILE symbol for local cold fragments of global symbols

### DIFF
--- a/bolt/include/bolt/Rewrite/RewriteInstance.h
+++ b/bolt/include/bolt/Rewrite/RewriteInstance.h
@@ -426,6 +426,9 @@ private:
   static StringRef getEHFrameSectionName() { return ".eh_frame"; }
   static StringRef getRelaDynSectionName() { return ".rela.dyn"; }
 
+  /// FILE symbol name used for local fragments of global functions.
+  static StringRef getBOLTFileSymbolName() { return "bolt-pseudo.o"; }
+
   /// An instance of the input binary we are processing, externally owned.
   llvm::object::ELFObjectFileBase *InputFile;
 

--- a/bolt/lib/Rewrite/RewriteInstance.cpp
+++ b/bolt/lib/Rewrite/RewriteInstance.cpp
@@ -4493,7 +4493,7 @@ void RewriteInstance::updateELFSymbolTable(
   // Symbols for the new symbol table.
   std::vector<ELFSymTy> Symbols;
 
-  bool EmittedColdFileSymbol{false};
+  bool EmittedColdFileSymbol = false;
 
   auto getNewSectionIndex = [&](uint32_t OldIndex) {
     // For dynamic symbol table, the section index could be wrong on the input,
@@ -4559,7 +4559,7 @@ void RewriteInstance::updateELFSymbolTable(
           FunctionSymbol.getBinding() == ELF::STB_GLOBAL) {
         ELFSymTy FileSymbol;
         FileSymbol.st_shndx = ELF::SHN_ABS;
-        FileSymbol.st_name = AddToStrTab("bolt_cold.o");
+        FileSymbol.st_name = AddToStrTab("llvm-bolt-pseudo.o");
         FileSymbol.st_value = 0;
         FileSymbol.st_size = 0;
         FileSymbol.st_other = 0;

--- a/bolt/lib/Rewrite/RewriteInstance.cpp
+++ b/bolt/lib/Rewrite/RewriteInstance.cpp
@@ -4559,7 +4559,7 @@ void RewriteInstance::updateELFSymbolTable(
           FunctionSymbol.getBinding() == ELF::STB_GLOBAL) {
         ELFSymTy FileSymbol;
         FileSymbol.st_shndx = ELF::SHN_ABS;
-        FileSymbol.st_name = AddToStrTab("llvm-bolt-pseudo.o");
+        FileSymbol.st_name = AddToStrTab(getBOLTFileSymbolName());
         FileSymbol.st_value = 0;
         FileSymbol.st_size = 0;
         FileSymbol.st_other = 0;

--- a/bolt/lib/Rewrite/RewriteInstance.cpp
+++ b/bolt/lib/Rewrite/RewriteInstance.cpp
@@ -4493,6 +4493,17 @@ void RewriteInstance::updateELFSymbolTable(
   // Symbols for the new symbol table.
   std::vector<ELFSymTy> Symbols;
 
+  // Prepend synthetic FILE symbol to prevent local cold fragments from
+  // colliding with existing symbols with the same name.
+  ELFSymTy FileSymbol;
+  FileSymbol.st_shndx =
+      BC->getUniqueSectionByName(BC->getColdCodeSectionName())->getIndex();
+  FileSymbol.st_name = AddToStrTab("bolt-synthetic");
+  FileSymbol.st_value = 0;
+  FileSymbol.st_size = 0;
+  FileSymbol.setBindingAndType(ELF::STB_LOCAL, ELF::STT_FILE);
+  Symbols.emplace_back(FileSymbol);
+
   auto getNewSectionIndex = [&](uint32_t OldIndex) {
     // For dynamic symbol table, the section index could be wrong on the input,
     // and its value is ignored by the runtime if it's different from

--- a/bolt/test/X86/cdsplit-symbol-names.s
+++ b/bolt/test/X86/cdsplit-symbol-names.s
@@ -10,7 +10,7 @@
 # RUN:         --call-scale=2 --data=%t.fdata --reorder-blocks=ext-tsp
 # RUN: llvm-objdump --syms %t.bolt | FileCheck %s --check-prefix=CHECK-SYMS-WARM
 
-# CHECK-SYMS-WARM: 0000000000000000 l df *ABS* 0000000000000000 llvm-bolt-pseudo.o
+# CHECK-SYMS-WARM: 0000000000000000 l df *ABS* 0000000000000000 bolt-pseudo.o
 # CHECK-SYMS-WARM: .text.warm
 # CHECK-SYMS-WARM-SAME: chain.warm
 # CHECK-SYMS-WARM: .text.cold

--- a/bolt/test/X86/cdsplit-symbol-names.s
+++ b/bolt/test/X86/cdsplit-symbol-names.s
@@ -10,7 +10,7 @@
 # RUN:         --call-scale=2 --data=%t.fdata --reorder-blocks=ext-tsp
 # RUN: llvm-objdump --syms %t.bolt | FileCheck %s --check-prefix=CHECK-SYMS-WARM
 
-# CHECK-SYMS-WARM: [[#%X,VALUE:0]] l df *ABS* [[#%X,SIZE:0]] bolt-synthetic
+# CHECK-SYMS-WARM: 0000000000000000 l df *ABS* 0000000000000000 bolt_cold.o
 # CHECK-SYMS-WARM: .text.warm
 # CHECK-SYMS-WARM-SAME: chain.warm
 # CHECK-SYMS-WARM: .text.cold

--- a/bolt/test/X86/cdsplit-symbol-names.s
+++ b/bolt/test/X86/cdsplit-symbol-names.s
@@ -10,7 +10,7 @@
 # RUN:         --call-scale=2 --data=%t.fdata --reorder-blocks=ext-tsp
 # RUN: llvm-objdump --syms %t.bolt | FileCheck %s --check-prefix=CHECK-SYMS-WARM
 
-# CHECK-SYMS-WARM: 0000000000000000 l df *ABS* 0000000000000000 bolt_cold.o
+# CHECK-SYMS-WARM: 0000000000000000 l df *ABS* 0000000000000000 llvm-bolt-pseudo.o
 # CHECK-SYMS-WARM: .text.warm
 # CHECK-SYMS-WARM-SAME: chain.warm
 # CHECK-SYMS-WARM: .text.cold

--- a/bolt/test/X86/cdsplit-symbol-names.s
+++ b/bolt/test/X86/cdsplit-symbol-names.s
@@ -10,6 +10,7 @@
 # RUN:         --call-scale=2 --data=%t.fdata --reorder-blocks=ext-tsp
 # RUN: llvm-objdump --syms %t.bolt | FileCheck %s --check-prefix=CHECK-SYMS-WARM
 
+# CHECK-SYMS-WARM: [[#%X,VALUE:0]] l df *ABS* [[#%X,SIZE:0]] bolt-synthetic
 # CHECK-SYMS-WARM: .text.warm
 # CHECK-SYMS-WARM-SAME: chain.warm
 # CHECK-SYMS-WARM: .text.cold


### PR DESCRIPTION
Follow-up to https://github.com/llvm/llvm-project/pull/89648.

Emit a FILE symbol to distinguish BOLT-created local symbols for cold
fragments of global split functions, to prevent polluting the namespace
of the last file symbol.

This eliminates the possibility of emitting the fragment under the file
that already contains the parent and fragment with the same name, which
can break cold fragment parent lookup in `registerFragment`.

This issue is more probable with LTO binaries where many symbols are
emitted under `ld-temp.o`.
 
Test Plan: Updated cdsplit-symbol-names.s
