### PR TITLE
[flang] Don't convert actual arguments when interface is implicit

### DIFF
--- a/flang/lib/Semantics/check-call.cpp
+++ b/flang/lib/Semantics/check-call.cpp
@@ -1929,6 +1929,7 @@ bool CheckArguments(const characteristics::Procedure &proc,
   bool explicitInterface{proc.HasExplicitInterface()};
   evaluate::FoldingContext foldingContext{context.foldingContext()};
   parser::ContextualMessages &messages{foldingContext.messages()};
+  bool allowArgumentConversions{true};
   if (!explicitInterface || treatingExternalAsImplicit) {
     parser::Messages buffer;
     {
@@ -1945,11 +1946,12 @@ bool CheckArguments(const characteristics::Procedure &proc,
       }
       return false; // don't pile on
     }
+    allowArgumentConversions = false;
   }
   if (explicitInterface) {
     auto buffer{CheckExplicitInterface(proc, actuals, context, &scope,
-        intrinsic, /*allowArgumentConversions=*/true, /*extentErrors=*/true,
-        ignoreImplicitVsExplicit)};
+        intrinsic, allowArgumentConversions,
+        /*extentErrors=*/true, ignoreImplicitVsExplicit)};
     if (!buffer.empty()) {
       if (treatingExternalAsImplicit) {
         if (auto *msg{messages.Say(

--- a/flang/lib/Semantics/expression.cpp
+++ b/flang/lib/Semantics/expression.cpp
@@ -2989,8 +2989,8 @@ void ExpressionAnalyzer::Analyze(const parser::CallStmt &callStmt) {
   for (const auto &arg : actualArgList) {
     analyzer.Analyze(arg, true /* is subroutine call */);
   }
-  auto chevrons{AnalyzeChevrons(callStmt)};
-  if (!analyzer.fatalErrors() && chevrons) {
+  if (auto chevrons{AnalyzeChevrons(callStmt)};
+      chevrons && !analyzer.fatalErrors()) {
     if (std::optional<CalleeAndArguments> callee{
             GetCalleeAndArguments(std::get<parser::ProcedureDesignator>(call.t),
                 analyzer.GetActuals(), true /* subroutine */)}) {

--- a/flang/test/Semantics/arg-convert.f90
+++ b/flang/test/Semantics/arg-convert.f90
@@ -1,0 +1,16 @@
+!RUN: %flang_fc1 -fdebug-unparse  %s  2>&1 | FileCheck %s
+!Ensure that argument conversion does not take place when the procedure
+!interface is implicit at the point of call, even when the interface
+!is known due because the procedure's definition is in the same source file.
+
+subroutine test
+!CHECK: warning: If the procedure's interface were explicit, this reference would be in error
+!CHECK: because: Actual argument type 'INTEGER(8)' is not compatible with dummy argument type 'INTEGER(4)'
+!CHECK: CALL samesourcefile((1_8))
+  call sameSourceFile((1_8))
+!CHECK: CALL somewhereelse((2_8))
+  call somewhereElse((2_8))
+end
+
+subroutine sameSourceFile(n)
+end


### PR DESCRIPTION
When the interface of a procedure is implicit at the point of call, don't perform actual argument type conversion to the types of the dummy arguments.  This was inadvertently taking place in a case where the procedure has an implicit interface but was also defined in the same source file, so that its characteristics were known.