### PR TITLE
[NFC] update comments from an earlier version of SuffixTree

### DIFF
--- a/llvm/lib/Support/SuffixTree.cpp
+++ b/llvm/lib/Support/SuffixTree.cpp
@@ -242,8 +242,8 @@ void SuffixTree::RepeatedSubstringIterator::advance() {
     unsigned Length = Curr->getConcatLen();
 
     // Iterate over each child, saving internal nodes for visiting, and
-    // leaf nodes in LeafChildren. Internal nodes represent individual
-    // strings, which may repeat.
+    // leaf nodes' SuffixIdx in RepeatedSubstringStarts. Internal nodes
+    // represent individual strings, which may repeat.
     for (auto &ChildPair : Curr->Children) {
       // Save all of this node's children for processing.
       if (auto *InternalChild =


### PR DESCRIPTION
LeafChildren is used in an earlier version of the SuffixTree implementation to keep track of each nodes' leaf nodes. In the new/current version, this variable is no longer used, but a comment is left behind. This patch updates the comment.