### PR TITLE
[Clang] [NFC] Prevent null pointer dereference in Sema::InstantiateFunctionDefinition

### DIFF
--- a/clang/lib/Sema/SemaTemplateInstantiateDecl.cpp
+++ b/clang/lib/Sema/SemaTemplateInstantiateDecl.cpp
@@ -5183,7 +5183,9 @@ void Sema::InstantiateFunctionDefinition(SourceLocation PointOfInstantiation,
     Function->setTypeSourceInfo(NewSI);
 
     ParmVarDecl *Parm = Function->getParamDecl(0);
+    assert(Parm && "First parameter not found in function declaration.");
     TypeSourceInfo *NewParmSI = IR.TransformType(Parm->getTypeSourceInfo());
+    assert(NewParmSI && "Type transformation failed.");
     Parm->setType(NewParmSI->getType());
     Parm->setTypeSourceInfo(NewParmSI);
   };

--- a/clang/lib/Sema/SemaTemplateInstantiateDecl.cpp
+++ b/clang/lib/Sema/SemaTemplateInstantiateDecl.cpp
@@ -5183,7 +5183,6 @@ void Sema::InstantiateFunctionDefinition(SourceLocation PointOfInstantiation,
     Function->setTypeSourceInfo(NewSI);
 
     ParmVarDecl *Parm = Function->getParamDecl(0);
-    assert(Parm && "First parameter not found in function declaration.");
     TypeSourceInfo *NewParmSI = IR.TransformType(Parm->getTypeSourceInfo());
     assert(NewParmSI && "Type transformation failed.");
     Parm->setType(NewParmSI->getType());


### PR DESCRIPTION
In the lambda function within clang::Sema::InstantiateFunctionDefinition, the return value of a function that may return null is now checked before dereferencing to avoid potential null pointer dereference issues which can lead to crashes or undefined behavior in the program.