### PR TITLE
[sanitizer_symbolizer] Use correct format strings for uptr

### DIFF
--- a/compiler-rt/lib/sanitizer_common/sanitizer_symbolizer_markup.cpp
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_symbolizer_markup.cpp
@@ -28,7 +28,7 @@ void MarkupStackTracePrinter::RenderData(InternalScopedString *buffer,
                                          const char *format, const DataInfo *DI,
                                          const char *strip_path_prefix) {
   RenderContext(buffer);
-  buffer->AppendF(kFormatData, DI->start);
+  buffer->AppendF(kFormatData, reinterpret_cast<void *>(DI->start));
 }
 
 bool MarkupStackTracePrinter::RenderNeedsSymbolization(const char *format) {
@@ -43,12 +43,13 @@ void MarkupStackTracePrinter::RenderFrame(InternalScopedString *buffer,
                                           const char *strip_path_prefix) {
   CHECK(!RenderNeedsSymbolization(format));
   RenderContext(buffer);
-  buffer->AppendF(kFormatFrame, frame_no, address);
+  buffer->AppendF(kFormatFrame, frame_no, reinterpret_cast<void *>(address));
 }
 
 bool MarkupSymbolizerTool::SymbolizePC(uptr addr, SymbolizedStack *stack) {
   char buffer[kFormatFunctionMax];
-  internal_snprintf(buffer, sizeof(buffer), kFormatFunction, addr);
+  internal_snprintf(buffer, sizeof(buffer), kFormatFunction,
+                    reinterpret_cast<void *>(addr));
   stack->info.function = internal_strdup(buffer);
   return true;
 }
@@ -96,7 +97,7 @@ static void RenderModule(InternalScopedString *buffer,
   for (uptr i = 0; i < module.uuid_size(); i++)
     buildIdBuffer.AppendF("%02x", module.uuid()[i]);
 
-  buffer->AppendF(kFormatModule, moduleId, module.full_name(),
+  buffer->AppendF(kFormatModule, static_cast<int>(moduleId), module.full_name(),
                   buildIdBuffer.data());
   buffer->Append("\n");
 }
@@ -118,7 +119,8 @@ static void RenderMmaps(InternalScopedString *buffer,
     // module.base_address == dlpi_addr
     // range.beg == dlpi_addr + p_vaddr
     // relative address == p_vaddr == range.beg - module.base_address
-    buffer->AppendF(kFormatMmap, range.beg, range.end - range.beg, moduleId,
+    buffer->AppendF(kFormatMmap, reinterpret_cast<void *>(range.beg),
+                    range.end - range.beg, static_cast<int>(moduleId),
                     accessBuffer.data(), range.beg - module.base_address());
 
     buffer->Append("\n");

--- a/compiler-rt/lib/sanitizer_common/sanitizer_symbolizer_markup.cpp
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_symbolizer_markup.cpp
@@ -97,7 +97,7 @@ static void RenderModule(InternalScopedString *buffer,
   for (uptr i = 0; i < module.uuid_size(); i++)
     buildIdBuffer.AppendF("%02x", module.uuid()[i]);
 
-  buffer->AppendF(kFormatModule, static_cast<int>(moduleId), module.full_name(),
+  buffer->AppendF(kFormatModule, moduleId, module.full_name(),
                   buildIdBuffer.data());
   buffer->Append("\n");
 }

--- a/compiler-rt/lib/sanitizer_common/sanitizer_symbolizer_markup_constants.h
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_symbolizer_markup_constants.h
@@ -36,7 +36,7 @@ constexpr const char *kFormatData = "{{{data:%p}}}";
 constexpr const char *kFormatFrame = "{{{bt:%d:%p}}}";
 
 // Module contextual element.
-constexpr const char *kFormatModule = "{{{module:%d:%s:elf:%s}}}";
+constexpr const char *kFormatModule = "{{{module:%zu:%s:elf:%s}}}";
 
 // mmap for a module segment.
 constexpr const char *kFormatMmap = "{{{mmap:%p:0x%zx:load:%d:%s:0x%zx}}}";

--- a/compiler-rt/lib/sanitizer_common/sanitizer_symbolizer_markup_constants.h
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_symbolizer_markup_constants.h
@@ -33,13 +33,13 @@ constexpr uptr kFormatFunctionMax = 64;  // More than big enough for 64-bit hex.
 constexpr const char *kFormatData = "{{{data:%p}}}";
 
 // One frame in a backtrace (printed on a line by itself).
-constexpr const char *kFormatFrame = "{{{bt:%u:%p}}}";
+constexpr const char *kFormatFrame = "{{{bt:%d:%p}}}";
 
 // Module contextual element.
 constexpr const char *kFormatModule = "{{{module:%d:%s:elf:%s}}}";
 
 // mmap for a module segment.
-constexpr const char *kFormatMmap = "{{{mmap:%p:0x%x:load:%d:%s:0x%x}}}";
+constexpr const char *kFormatMmap = "{{{mmap:%p:0x%zx:load:%d:%s:0x%zx}}}";
 
 // Dump trigger element.
 #define FORMAT_DUMPFILE "{{{dumpfile:%s:%s}}}"


### PR DESCRIPTION
When compiling the common sanitizer libraries, there are many warnings about format specifiers, similar to:

    compiler-rt/lib/sanitizer_common/sanitizer_symbolizer_markup.cpp:31:32: warning: format specifies type 'void *' but the argument has type 'uptr' (aka 'unsigned long') [-Wformat]
       31 |   buffer->AppendF(kFormatData, DI->start);
          |                   ~~~~~~~~~~~  ^~~~~~~~~
    compiler-rt/lib/sanitizer_common/sanitizer_symbolizer_markup_constants.h:33:46: note: format string is defined here
       33 | constexpr const char *kFormatData = "{{{data:%p}}}";
          |                                              ^~
          |                                              %lu
    compiler-rt/lib/sanitizer_common/sanitizer_symbolizer_markup.cpp:46:43: warning: format specifies type 'void *' but the argument has type 'uptr' (aka 'unsigned long') [-Wformat]
       46 |   buffer->AppendF(kFormatFrame, frame_no, address);
          |                   ~~~~~~~~~~~~            ^~~~~~~
    compiler-rt/lib/sanitizer_common/sanitizer_symbolizer_markup_constants.h:36:48: note: format string is defined here
       36 | constexpr const char *kFormatFrame = "{{{bt:%u:%p}}}";
          |                                                ^~
          |                                                %lu
    ...

This is because `uptr` is dependent on the platform, and can be either `unsigned long long`, `unsigned long`, or `unsigned int`.

To fix the warnings, define the correct printf modifier for `uptr` and `sptr` as `SANITIZER_PTR_MOD`, and use it in the various format strings in `sanitizer_symbolizer_markup_constants.h`.