### PR TITLE
[libcxx] [modules] Add _LIBCPP_USING_IF_EXISTS on aligned_alloc

### DIFF
--- a/libcxx/modules/std.compat/cstdlib.inc
+++ b/libcxx/modules/std.compat/cstdlib.inc
@@ -25,7 +25,7 @@ export {
   using ::system;
 
   // [c.malloc], C library memory allocation
-  using ::aligned_alloc;
+  using ::aligned_alloc _LIBCPP_USING_IF_EXISTS;
   using ::calloc;
   using ::free;
   using ::malloc;


### PR DESCRIPTION
This is missing e.g. on Windows. With this change, it's possible to make the libcxx std module work on mingw-w64 (although that requires a few fixes to those headers).

In the regular cstdlib header, we have _LIBCPP_USING_IF_EXISTS flagged on every single reexported function (since a9c9183ca42629fa83cdda297d1d30c7bc1d7c91), but the modules seem to only have _LIBCPP_USING_IF_EXISTS set on a few individual functions.