### PR TITLE
[DAG] Early exit for flags in canCreateUndefOrPoison [nfc]

### DIFF
--- a/llvm/include/llvm/CodeGen/SelectionDAGNodes.h
+++ b/llvm/include/llvm/CodeGen/SelectionDAGNodes.h
@@ -452,11 +452,9 @@ public:
   bool hasNoFPExcept() const { return NoFPExcept; }
   bool hasUnpredictable() const { return Unpredictable; }
 
-  bool hasAny() const {
+  bool hasPoisonGeneratingFlags() const {
     return NoUnsignedWrap || NoSignedWrap || Exact || Disjoint || NonNeg ||
-           NoNaNs || NoInfs || NoSignedZeros || AllowReciprocal ||
-           AllowContract || ApproximateFuncs || AllowReassociation ||
-           NoFPExcept || Unpredictable;
+           NoNaNs || NoInfs || NoFPExcept || Unpredictable;
   }
 
   /// Clear any flags in this flag set that aren't also set in Flags. All
@@ -1005,6 +1003,10 @@ public:
   /// Clear any flags in this node that aren't also set in Flags.
   /// If Flags is not in a defined state then this has no effect.
   void intersectFlagsWith(const SDNodeFlags Flags);
+
+  bool hasPoisonGeneratingFlags() const {
+    return getFlags().hasPoisonGeneratingFlags();
+  }
 
   void setCFIType(uint32_t Type) { CFIType = Type; }
   uint32_t getCFIType() const { return CFIType; }

--- a/llvm/include/llvm/CodeGen/SelectionDAGNodes.h
+++ b/llvm/include/llvm/CodeGen/SelectionDAGNodes.h
@@ -452,11 +452,6 @@ public:
   bool hasNoFPExcept() const { return NoFPExcept; }
   bool hasUnpredictable() const { return Unpredictable; }
 
-  bool hasPoisonGeneratingFlags() const {
-    return NoUnsignedWrap || NoSignedWrap || Exact || Disjoint || NonNeg ||
-           NoNaNs || NoInfs || NoFPExcept || Unpredictable;
-  }
-
   /// Clear any flags in this flag set that aren't also set in Flags. All
   /// flags will be cleared if Flags are undefined.
   void intersectWith(const SDNodeFlags Flags) {
@@ -1005,7 +1000,10 @@ public:
   void intersectFlagsWith(const SDNodeFlags Flags);
 
   bool hasPoisonGeneratingFlags() const {
-    return getFlags().hasPoisonGeneratingFlags();
+    SDNodeFlags Flags = getFlags();
+    return Flags.hasNoUnsignedWrap() || Flags.hasNoSignedWrap() ||
+           Flags.hasExact() || Flags.hasDisjoint() || Flags.hasNonNeg() ||
+           Flags.hasNoNaNs() || Flags.hasNoInfs();
   }
 
   void setCFIType(uint32_t Type) { CFIType = Type; }

--- a/llvm/include/llvm/CodeGen/SelectionDAGNodes.h
+++ b/llvm/include/llvm/CodeGen/SelectionDAGNodes.h
@@ -452,6 +452,13 @@ public:
   bool hasNoFPExcept() const { return NoFPExcept; }
   bool hasUnpredictable() const { return Unpredictable; }
 
+  bool hasAny() const {
+    return NoUnsignedWrap || NoSignedWrap || Exact || Disjoint || NonNeg ||
+           NoNaNs || NoInfs || NoSignedZeros || AllowReciprocal ||
+           AllowContract || ApproximateFuncs || AllowReassociation ||
+           NoFPExcept || Unpredictable;
+  }
+
   /// Clear any flags in this flag set that aren't also set in Flags. All
   /// flags will be cleared if Flags are undefined.
   void intersectWith(const SDNodeFlags Flags) {

--- a/llvm/lib/CodeGen/SelectionDAG/SelectionDAG.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/SelectionDAG.cpp
@@ -5095,8 +5095,7 @@ bool SelectionDAG::canCreateUndefOrPoison(SDValue Op, const APInt &DemandedElts,
   if (VT.isScalableVector())
     return true;
 
-  // Matches hasPoisonGeneratingFlags().
-  if (ConsiderFlags && Op->getFlags().hasAny())
+  if (ConsiderFlags && Op->hasPoisonGeneratingFlags())
     return true;
 
   unsigned Opcode = Op.getOpcode();


### PR DESCRIPTION
This matches the style used in the Analysis version of this routine, and makes it less likely we'll miss a poison generating flag in future changes.  Unlike IR, the check for poison generating flags doesn't need to switch over opcode since all nodes have the SDFlags storage.