### PR TITLE
[NFC][clang][analyzer] Initialize pointer field in StreamOperationEvaluator

### DIFF
--- a/clang/lib/StaticAnalyzer/Checkers/StreamChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/StreamChecker.cpp
@@ -600,7 +600,7 @@ struct StreamOperationEvaluator {
   SValBuilder &SVB;
   const ASTContext &ACtx;
 
-  SymbolRef StreamSym;
+  SymbolRef StreamSym = nullptr;
   const StreamState *SS = nullptr;
   const CallExpr *CE = nullptr;
   StreamErrorState NewES;


### PR DESCRIPTION
Add an initializer for StreamSym, which is a pointer. The pointers in this class are set in the Init function, but all should be initialized in the constructor to avoid confusion and static verifier hits.