### PR TITLE
[libc][bazel] fix fenv tests after refactor

### DIFF
--- a/utils/bazel/llvm-project-overlay/libc/test/UnitTest/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/test/UnitTest/BUILD.bazel
@@ -84,13 +84,15 @@ libc_support_library(
         "//libc:__support_cpp_bitset",
         "//libc:__support_cpp_span",
         "//libc:__support_cpp_type_traits",
+        "//libc:__support_cpp_utility",
         "//libc:__support_fputil_fenv_impl",
         "//libc:__support_fputil_fp_bits",
         "//libc:__support_fputil_fpbits_str",
         "//libc:__support_fputil_rounding_mode",
+        "//libc:__support_macros_properties_architectures",
+        "//libc:hdr_fenv_macros",
         "//libc:hdr_math_macros",
-	    "//libc:hdr_fenv_macros",
-	    "//libc:types_fenv_t",
+        "//libc:types_fenv_t",
     ],
 )
 

--- a/utils/bazel/llvm-project-overlay/libc/test/src/fenv/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/test/src/fenv/BUILD.bazel
@@ -4,11 +4,20 @@
 
 # Tests for LLVM libc math.h functions.
 
+load("//libc:libc_build_rules.bzl", "libc_support_library")
 load("//libc/test:libc_test_rules.bzl", "libc_test")
 
 package(default_visibility = ["//visibility:public"])
 
 licenses(["notice"])
+
+libc_support_library(
+    name = "excepts",
+    hdrs = ["excepts.h"],
+    deps = [
+        "//libc:hdr_fenv_macros",
+    ],
+)
 
 libc_test(
     name = "exception_status_test",
@@ -20,8 +29,10 @@ libc_test(
         "//libc:fetestexcept",
     ],
     deps = [
+        ":excepts",
         "//libc:__support_fputil_fenv_impl",
-	"//libc:hdr_fenv_macros",
+        "//libc:hdr_fenv_macros",
+        "//libc/test/UnitTest:fp_test_helpers",
     ],
 )
 
@@ -32,7 +43,11 @@ libc_test(
         "//libc:fegetround",
         "//libc:fesetround",
     ],
-    deps = ["//libc:hdr_fenv_macros"],
+    deps = [
+        ":excepts",
+        "//libc:hdr_fenv_macros",
+        "//libc/test/UnitTest:fp_test_helpers",
+    ],
 )
 
 libc_test(
@@ -45,11 +60,12 @@ libc_test(
     ],
     tags = ["nosan"],
     deps = [
+        ":excepts",
         "//libc:__support_common",
         "//libc:__support_fputil_fenv_impl",
         "//libc:__support_macros_properties_architectures",
+        "//libc:hdr_fenv_macros",
         "//libc/test/UnitTest:fp_test_helpers",
-	"//libc:hdr_fenv_macros",
     ],
 )
 
@@ -61,11 +77,12 @@ libc_test(
     ],
     tags = ["nosan"],
     deps = [
+        ":excepts",
         "//libc:__support_common",
         "//libc:__support_fputil_fenv_impl",
         "//libc:__support_macros_properties_architectures",
+        "//libc:types_fenv_t",
         "//libc/test/UnitTest:fp_test_helpers",
-	"//libc:types_fenv_t",
     ],
 )
 
@@ -78,8 +95,10 @@ libc_test(
         "//libc:fetestexceptflag",
     ],
     deps = [
+        ":excepts",
         "//libc:__support_fputil_fenv_impl",
-	"//libc:types_fexcept_t",
+        "//libc:types_fexcept_t",
+        "//libc/test/UnitTest:fp_test_helpers",
     ],
 )
 
@@ -90,8 +109,10 @@ libc_test(
         "//libc:feclearexcept",
     ],
     deps = [
+        ":excepts",
         "//libc:__support_fputil_fenv_impl",
-	"//libc:hdr_fenv_macros",
+        "//libc:hdr_fenv_macros",
+        "//libc/test/UnitTest:fp_test_helpers",
     ],
 )
 
@@ -104,9 +125,11 @@ libc_test(
         "//libc:fegetexcept",
     ],
     deps = [
+        ":excepts",
         "//libc:__support_common",
         "//libc:__support_macros_properties_architectures",
-	"//libc:hdr_fenv_macros",
+        "//libc:hdr_fenv_macros",
+        "//libc/test/UnitTest:fp_test_helpers",
     ],
 )
 
@@ -117,8 +140,10 @@ libc_test(
         "//libc:feupdateenv",
     ],
     deps = [
+        ":excepts",
         "//libc:__support_fputil_fenv_impl",
-	"//libc:types_fenv_t",
+        "//libc:types_fenv_t",
+        "//libc/test/UnitTest:fp_test_helpers",
     ],
 )
 
@@ -132,7 +157,9 @@ libc_test(
         "//libc:fesetround",
     ],
     deps = [
+        ":excepts",
         "//libc:__support_fputil_fenv_impl",
-	"//libc:types_fenv_t",
+        "//libc:types_fenv_t",
+        "//libc/test/UnitTest:fp_test_helpers",
     ],
 )


### PR DESCRIPTION
The PR #89658 updated up the fenv tests work, this patch updates the
bazel to match.
