### PR TITLE
[Support] Added checks to ULEB128/SLEB128 decoding routines checks for pointer past the end of the buffer

### DIFF
--- a/llvm/include/llvm/Support/LEB128.h
+++ b/llvm/include/llvm/Support/LEB128.h
@@ -135,7 +135,7 @@ inline uint64_t decodeULEB128(const uint8_t *p, unsigned *n = nullptr,
   uint64_t Value = 0;
   unsigned Shift = 0;
   do {
-    if (LLVM_UNLIKELY(p == end)) {
+    if (LLVM_UNLIKELY(p >= end)) {
       if (error)
         *error = "malformed uleb128, extends past end";
       Value = 0;
@@ -170,7 +170,7 @@ inline int64_t decodeSLEB128(const uint8_t *p, unsigned *n = nullptr,
   unsigned Shift = 0;
   uint8_t Byte;
   do {
-    if (LLVM_UNLIKELY(p == end)) {
+    if (LLVM_UNLIKELY(p >= end)) {
       if (error)
         *error = "malformed sleb128, extends past end";
       if (n)


### PR DESCRIPTION
I've ran into this when trying to explore exports trie of Mach-O file. Eventually, one of the nodes seems to send me past the end of the buffer, which results in segfaults since `p` is not really equal to the `end` and is dereferenced right after this check.

Still trying to figure out whether I can share the Mach-O files somehow for the testing purposes, but for now I wanted to at least submit it without tests.