### PR TITLE
[Flang][OpenMP] Parse and semantically analyze common blocks in map clauses correctly

### DIFF
--- a/flang/lib/Semantics/resolve-directives.cpp
+++ b/flang/lib/Semantics/resolve-directives.cpp
@@ -633,6 +633,8 @@ public:
               [&](const auto &name) {},
           },
           ompObj.u);
+
+      ResolveOmpObject(ompObj, ompFlag);
     }
   }
 

--- a/flang/test/Semantics/OpenMP/map-clause.f90
+++ b/flang/test/Semantics/OpenMP/map-clause.f90
@@ -2,9 +2,12 @@
 ! Check OpenMP MAP clause validity. Section 5.8.3 OpenMP 5.2.
 
 subroutine sb(arr)
+  implicit none
   real(8) :: arr(*)
   real :: a
-
+  integer:: b, c, i
+  common /var/ b, c  
+  
   !ERROR: Assumed-size whole arrays may not appear on the MAP clause
   !$omp target map(arr)
   do i = 1, 100
@@ -12,6 +15,7 @@ subroutine sb(arr)
   enddo
   !$omp end target
 
+  !ERROR: Assumed-size array 'arr' must have explicit final subscript upper bound value
   !$omp target map(arr(:))
   do i = 1, 100
      a = 3.14
@@ -23,4 +27,9 @@ subroutine sb(arr)
      a = 3.14
   enddo
   !$omp end target
+
+ !$omp target map(tofrom: /var/)
+   b = 1
+   c = 2
+ !$omp end target
 end subroutine


### PR DESCRIPTION
Currently, you cannot provide the common block syntax that you should be able to provide for map clauses (and that you can for declare target) e.g.:

` !$omp target map(tofrom: /var/)`

This PR seeks to change that and allow this syntax via a small tweak, which may also allow a wider range of types to be provided without issue as well via the utilisation of ResolveOmpObject a helper function used by the majority of other OmpObject handling clauses.

A by product of this change, is that we now emit an error for the following syntax, when provided to map clauses with an assumed size array:

`!$omp target map(arr(:))`

This seems inline with the specification from what I understand of it (do feel free to correct me if that is not your reading or I am incorrect!) and other OpenMP compilers i.e. gfortran, ifx, ifort.