### PR TITLE
[arm] Support reserving r4 and r5 alongside r9

### DIFF
--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -4766,6 +4766,10 @@ def mrestrict_it: Flag<["-"], "mrestrict-it">, Group<m_arm_Features_Group>,
 def mno_restrict_it: Flag<["-"], "mno-restrict-it">, Group<m_arm_Features_Group>,
   HelpText<"Allow generation of complex IT blocks.">;
 def marm : Flag<["-"], "marm">, Alias<mno_thumb>;
+def ffixed_r4 : Flag<["-"], "ffixed-r4">, Group<m_arm_Features_Group>,
+  HelpText<"Reserve the r4 register (ARM only)">;
+def ffixed_r5 : Flag<["-"], "ffixed-r5">, Group<m_arm_Features_Group>,
+  HelpText<"Reserve the r5 register (ARM only)">;
 def ffixed_r9 : Flag<["-"], "ffixed-r9">, Group<m_arm_Features_Group>,
   HelpText<"Reserve the r9 register (ARM only)">;
 def mno_movt : Flag<["-"], "mno-movt">, Group<m_arm_Features_Group>,

--- a/clang/lib/Driver/ToolChains/Arch/ARM.cpp
+++ b/clang/lib/Driver/ToolChains/Arch/ARM.cpp
@@ -920,6 +920,11 @@ fp16_fml_fallthrough:
   if (Args.hasArg(options::OPT_ffixed_r9))
     Features.push_back("+reserve-r9");
 
+  if (Args.hasArg(options::OPT_ffixed_r4))
+    Features.push_back("+reserve-r4");
+  if (Args.hasArg(options::OPT_ffixed_r5))
+    Features.push_back("+reserve-r5");
+
   // The kext linker doesn't know how to deal with movw/movt.
   if (KernelOrKext || Args.hasArg(options::OPT_mno_movt))
     Features.push_back("+no-movt");

--- a/llvm/lib/Target/ARM/ARMBaseRegisterInfo.cpp
+++ b/llvm/lib/Target/ARM/ARMBaseRegisterInfo.cpp
@@ -211,9 +211,13 @@ getReservedRegs(const MachineFunction &MF) const {
     markSuperRegs(Reserved, STI.getFramePointerReg());
   if (hasBasePointer(MF))
     markSuperRegs(Reserved, BasePtr);
-  // Some targets reserve R9.
+  // Some targets reserve R4,R5 or R9.
   if (STI.isR9Reserved())
     markSuperRegs(Reserved, ARM::R9);
+  if (STI.isReserveR4()) 
+    markSuperRegs(Reserved, ARM::R4);
+  if (STI.isReserveR5()) 
+    markSuperRegs(Reserved, ARM::R5);
   // Reserve D16-D31 if the subtarget doesn't support them.
   if (!STI.hasD32()) {
     static_assert(ARM::D31 == ARM::D16 + 15, "Register list not consecutive!");

--- a/llvm/lib/Target/ARM/ARMBaseRegisterInfo.cpp
+++ b/llvm/lib/Target/ARM/ARMBaseRegisterInfo.cpp
@@ -214,9 +214,9 @@ getReservedRegs(const MachineFunction &MF) const {
   // Some targets reserve R4,R5 or R9.
   if (STI.isR9Reserved())
     markSuperRegs(Reserved, ARM::R9);
-  if (STI.isReserveR4()) 
+  if (STI.isR4Reserved()) 
     markSuperRegs(Reserved, ARM::R4);
-  if (STI.isReserveR5()) 
+  if (STI.isR5Reserved()) 
     markSuperRegs(Reserved, ARM::R5);
   // Reserve D16-D31 if the subtarget doesn't support them.
   if (!STI.hasD32()) {

--- a/llvm/lib/Target/ARM/ARMFeatures.td
+++ b/llvm/lib/Target/ARM/ARMFeatures.td
@@ -458,6 +458,14 @@ def FeatureExecuteOnly    : SubtargetFeature<"execute-only",
 def FeatureReserveR9      : SubtargetFeature<"reserve-r9", "ReserveR9", "true",
                                              "Reserve R9, making it unavailable"
                                              " as GPR">;
+// True if R4 is not available as a general purpose register.
+def FeatureReserveR4      : SubtargetFeature<"reserve-r4", "ReserveR4", "true",
+                                             "Reserve R4, making it unavailable"
+                                             " as GPR">;
+// True if R5 is not available as a general purpose register.
+def FeatureReserveR5      : SubtargetFeature<"reserve-r5", "ReserveR5", "true",
+                                             "Reserve R5, making it unavailable"
+                                             " as GPR">;
 
 // True if MOVT / MOVW pairs are not used for materialization of
 // 32-bit imms (including global addresses).

--- a/llvm/lib/Target/ARM/ARMSubtarget.h
+++ b/llvm/lib/Target/ARM/ARMSubtarget.h
@@ -437,6 +437,14 @@ public:
   bool isRClass() const { return ARMProcClass == RClass; }
   bool isAClass() const { return ARMProcClass == AClass; }
 
+  bool isR4Reserved() const {
+    return ReserveR4;
+  }
+
+  bool isR5Reserved() const {
+    return ReserveR5;
+  }
+
   bool isR9Reserved() const {
     return isTargetMachO() ? (ReserveR9 || !HasV6Ops) : ReserveR9;
   }

--- a/llvm/lib/Target/ARM/ARMTargetTransformInfo.h
+++ b/llvm/lib/Target/ARM/ARMTargetTransformInfo.h
@@ -92,8 +92,9 @@ class ARMTTIImpl : public BasicTTIImplBase<ARMTTIImpl> {
       ARM::FeatureHasNoBranchPredictor, ARM::FeatureDSP, ARM::FeatureMP,
       ARM::FeatureVirtualization, ARM::FeatureMClass, ARM::FeatureRClass,
       ARM::FeatureAClass, ARM::FeatureNaClTrap, ARM::FeatureStrictAlign,
-      ARM::FeatureLongCalls, ARM::FeatureExecuteOnly, ARM::FeatureReserveR9,
-      ARM::FeatureNoMovt, ARM::FeatureNoNegativeImmediates
+      ARM::FeatureLongCalls, ARM::FeatureExecuteOnly, ARM::FeatureReserveR4, 
+      ARM::FeatureReserveR5, ARM::FeatureReserveR9, ARM::FeatureNoMovt,
+      ARM::FeatureNoNegativeImmediates
   };
 
   const ARMSubtarget *getST() const { return ST; }


### PR DESCRIPTION
I accidentally closed [this pr](https://github.com/llvm/llvm-project/pull/88981) when trying to fix a conflict that arose.

