### PR TITLE
[Object] Provide operator< for ELFSymbolRef

### DIFF
--- a/llvm/include/llvm/Object/ELFObjectFile.h
+++ b/llvm/include/llvm/Object/ELFObjectFile.h
@@ -204,7 +204,7 @@ inline bool operator<(const ELFSymbolRef &A, const ELFSymbolRef &B) {
   const DataRefImpl &DRIB = B.getRawDataRefImpl();
   if (DRIA.d.a == DRIB.d.a)
     return DRIA.d.b < DRIB.d.b;
-  return DRIA.d.a < DRIB.d.b;
+  return DRIA.d.a < DRIB.d.a;
 }
 
 class elf_symbol_iterator : public symbol_iterator {

--- a/llvm/include/llvm/Object/ELFObjectFile.h
+++ b/llvm/include/llvm/Object/ELFObjectFile.h
@@ -199,6 +199,14 @@ public:
   }
 };
 
+inline bool operator<(const ELFSymbolRef &A, const ELFSymbolRef &B) {
+  const DataRefImpl &DRIA = A.getRawDataRefImpl();
+  const DataRefImpl &DRIB = B.getRawDataRefImpl();
+  if (DRIA.d.a == DRIB.d.a)
+    return DRIA.d.b < DRIB.d.b;
+  return DRIA.d.a < DRIB.d.b;
+}
+
 class elf_symbol_iterator : public symbol_iterator {
 public:
   elf_symbol_iterator(const basic_symbol_iterator &B)

--- a/llvm/unittests/Object/ELFObjectFileTest.cpp
+++ b/llvm/unittests/Object/ELFObjectFileTest.cpp
@@ -1519,52 +1519,43 @@ FileHeader:
   ASSERT_THAT_EXPECTED(ElfOrErr, Succeeded());
   const ELFObjectFile<ELF64LE> &Obj = *ElfOrErr;
 
-  const uint32_t Val1 = 0x00000001;
-  const uint32_t Val2 = 0x00000100;
+  const uint32_t ValLow = 0x00000001;
+  const uint32_t ValHigh = 0x00000100;
 
-  DataRefImpl Data1, Data2, Data3, Data4;
+  auto MakeSymbol = [&Obj](size_t SymtabIndex, size_t SymbolIndex) {
+    DataRefImpl Data;
+    Data.d.a = SymtabIndex;
+    Data.d.b = SymbolIndex;
+    SymbolRef Sym(Data, &Obj);
+    return ELFSymbolRef(Sym);
+  };
 
-  // Symtab index
-  Data1.d.a = Data2.d.a = Val1;
-  Data3.d.a = Data4.d.a = Val2;
-
-  // Symbol index
-  Data1.d.b = Data3.d.b = Val1;
-  Data2.d.b = Data4.d.b = Val2;
-
-  SymbolRef Symbol1(Data1, &Obj), Symbol2(Data2, &Obj), Symbol3(Data3, &Obj),
-      Symbol4(Data4, &Obj);
-  ELFSymbolRef ELFSymbol1(Symbol1), ELFSymbol2(Symbol2), ELFSymbol3(Symbol3),
-      ELFSymbol4(Symbol4);
+  ELFSymbolRef ELFSymLowLow = MakeSymbol(ValLow, ValLow);
+  ELFSymbolRef ELFSymLowHigh = MakeSymbol(ValLow, ValHigh);
+  ELFSymbolRef ELFSymHighLow = MakeSymbol(ValHigh, ValLow);
+  ELFSymbolRef ELFSymHighHigh = MakeSymbol(ValHigh, ValHigh);
 
   // Symtab index match
-  // left sym index is lower
-  EXPECT_TRUE(ELFSymbol1 < ELFSymbol2);
-  EXPECT_TRUE(ELFSymbol3 < ELFSymbol4);
-  // right sym index is lower
-  EXPECT_FALSE(ELFSymbol2 < ELFSymbol1);
-  EXPECT_FALSE(ELFSymbol4 < ELFSymbol3);
-  // sym indexes match
-  EXPECT_FALSE(ELFSymbol1 < ELFSymbol1);
-  EXPECT_FALSE(ELFSymbol2 < ELFSymbol2);
-  EXPECT_FALSE(ELFSymbol3 < ELFSymbol3);
-  EXPECT_FALSE(ELFSymbol4 < ELFSymbol4);
+  // Left symbol index is lower
+  EXPECT_TRUE(ELFSymLowLow < ELFSymLowHigh);
+  // Right symbol index is lower
+  EXPECT_FALSE(ELFSymLowHigh < ELFSymLowLow);
+  // Symbol indices match
+  EXPECT_FALSE(ELFSymLowLow < ELFSymLowLow);
 
   // Left symtab index is lower
-  // left sym index is lower
-  EXPECT_TRUE(ELFSymbol1 < ELFSymbol4);
-  // right sym index is lower
-  EXPECT_TRUE(ELFSymbol2 < ELFSymbol3);
-  // sym indexes match
-  EXPECT_TRUE(ELFSymbol1 < ELFSymbol3);
-  EXPECT_TRUE(ELFSymbol2 < ELFSymbol4);
+  // Left symbol index is lower
+  EXPECT_TRUE(ELFSymLowLow < ELFSymHighHigh);
+  // Right symbol index is lower
+  EXPECT_TRUE(ELFSymLowHigh < ELFSymHighLow);
+  // Symbol indices match
+  EXPECT_TRUE(ELFSymLowLow < ELFSymHighLow);
 
   // Right symtab index is lower
-  // left sym index is lower
-  EXPECT_FALSE(ELFSymbol3 < ELFSymbol2);
-  // right sym index is lower
-  EXPECT_FALSE(ELFSymbol4 < ELFSymbol1);
-  // sym indexes match
-  EXPECT_FALSE(ELFSymbol3 < ELFSymbol1);
-  EXPECT_FALSE(ELFSymbol4 < ELFSymbol2);
+  // Left symbol index is lower
+  EXPECT_FALSE(ELFSymHighLow < ELFSymLowHigh);
+  // Right symbol index is lower
+  EXPECT_FALSE(ELFSymHighHigh < ELFSymLowLow);
+  // Symbol indices match
+  EXPECT_FALSE(ELFSymHighLow < ELFSymLowLow);
 }

--- a/llvm/unittests/Object/ELFObjectFileTest.cpp
+++ b/llvm/unittests/Object/ELFObjectFileTest.cpp
@@ -1535,27 +1535,15 @@ FileHeader:
   ELFSymbolRef ELFSymHighLow = MakeSymbol(ValHigh, ValLow);
   ELFSymbolRef ELFSymHighHigh = MakeSymbol(ValHigh, ValHigh);
 
-  // Symtab index match
-  // Left symbol index is lower
   EXPECT_TRUE(ELFSymLowLow < ELFSymLowHigh);
-  // Right symbol index is lower
   EXPECT_FALSE(ELFSymLowHigh < ELFSymLowLow);
-  // Symbol indices match
   EXPECT_FALSE(ELFSymLowLow < ELFSymLowLow);
 
-  // Left symtab index is lower
-  // Left symbol index is lower
   EXPECT_TRUE(ELFSymLowLow < ELFSymHighHigh);
-  // Right symbol index is lower
   EXPECT_TRUE(ELFSymLowHigh < ELFSymHighLow);
-  // Symbol indices match
   EXPECT_TRUE(ELFSymLowLow < ELFSymHighLow);
 
-  // Right symtab index is lower
-  // Left symbol index is lower
   EXPECT_FALSE(ELFSymHighLow < ELFSymLowHigh);
-  // Right symbol index is lower
   EXPECT_FALSE(ELFSymHighHigh < ELFSymLowLow);
-  // Symbol indices match
   EXPECT_FALSE(ELFSymHighLow < ELFSymLowLow);
 }


### PR DESCRIPTION
Normally, operator< accepting DataRefImpl is used when comparing
SymbolRef/ELFSymbolRef. However, it uses std::memcmp which interprets
DataRefImpl union as char string so that the result depends on host endianness.
For ELFSymbolRef a specialized operator< can be used instead to produce
consistent ordering regardless of endianness by comparing the symbol table index
and symbol index fields separately.
