### PR TITLE
[Mips] Use ANDi in for zero-extend in subword atomic umax/umin for both r2 and pre-R2

### DIFF
--- a/llvm/lib/Target/Mips/MipsExpandPseudo.cpp
+++ b/llvm/lib/Target/Mips/MipsExpandPseudo.cpp
@@ -479,13 +479,13 @@ bool MipsExpandPseudo::expandAtomicBinOpSubword(
     BuildMI(loopMBB, DL, TII->get(Mips::SRAV), StoreVal)
         .addReg(OldVal)
         .addReg(ShiftAmnt);
-    if (STI->hasMips32r2() && !IsUnsigned) {
-      BuildMI(loopMBB, DL, TII->get(SEOp), StoreVal).addReg(StoreVal);
-    } else if (STI->hasMips32r2() && IsUnsigned) {
+    if (IsUnsigned) {
       const unsigned OpMask = SEOp == Mips::SEH ? 0xffff : 0xff;
       BuildMI(loopMBB, DL, TII->get(Mips::ANDi), StoreVal)
           .addReg(StoreVal)
           .addImm(OpMask);
+    } else if (STI->hasMips32r2()) {
+      BuildMI(loopMBB, DL, TII->get(SEOp), StoreVal).addReg(StoreVal);
     } else {
       const unsigned ShiftImm = SEOp == Mips::SEH ? 16 : 24;
       const unsigned SROp = IsUnsigned ? Mips::SRL : Mips::SRA;

--- a/llvm/test/CodeGen/Mips/atomic-min-max.ll
+++ b/llvm/test/CodeGen/Mips/atomic-min-max.ll
@@ -2156,8 +2156,7 @@ define i16 @test_umax_16(ptr nocapture %ptr, i16 signext %val) {
 ; MIPS32-NEXT:    # =>This Inner Loop Header: Depth=1
 ; MIPS32-NEXT:    ll $2, 0($6)
 ; MIPS32-NEXT:    srav $4, $2, $10
-; MIPS32-NEXT:    sll $4, $4, 16
-; MIPS32-NEXT:    srl $4, $4, 16
+; MIPS32-NEXT:    andi $4, $4, 65535
 ; MIPS32-NEXT:    or $1, $zero, $4
 ; MIPS32-NEXT:    sllv $4, $4, $10
 ; MIPS32-NEXT:    sltu $5, $4, $7
@@ -2695,8 +2694,7 @@ define i16 @test_umin_16(ptr nocapture %ptr, i16 signext %val) {
 ; MIPS32-NEXT:    # =>This Inner Loop Header: Depth=1
 ; MIPS32-NEXT:    ll $2, 0($6)
 ; MIPS32-NEXT:    srav $4, $2, $10
-; MIPS32-NEXT:    sll $4, $4, 16
-; MIPS32-NEXT:    srl $4, $4, 16
+; MIPS32-NEXT:    andi $4, $4, 65535
 ; MIPS32-NEXT:    or $1, $zero, $4
 ; MIPS32-NEXT:    sllv $4, $4, $10
 ; MIPS32-NEXT:    sltu $5, $4, $7
@@ -4313,8 +4311,7 @@ define i8 @test_umax_8(ptr nocapture %ptr, i8 signext %val) {
 ; MIPS32-NEXT:    # =>This Inner Loop Header: Depth=1
 ; MIPS32-NEXT:    ll $2, 0($6)
 ; MIPS32-NEXT:    srav $4, $2, $10
-; MIPS32-NEXT:    sll $4, $4, 24
-; MIPS32-NEXT:    srl $4, $4, 24
+; MIPS32-NEXT:    andi $4, $4, 255
 ; MIPS32-NEXT:    or $1, $zero, $4
 ; MIPS32-NEXT:    sllv $4, $4, $10
 ; MIPS32-NEXT:    sltu $5, $4, $7
@@ -4852,8 +4849,7 @@ define i8 @test_umin_8(ptr nocapture %ptr, i8 signext %val) {
 ; MIPS32-NEXT:    # =>This Inner Loop Header: Depth=1
 ; MIPS32-NEXT:    ll $2, 0($6)
 ; MIPS32-NEXT:    srav $4, $2, $10
-; MIPS32-NEXT:    sll $4, $4, 24
-; MIPS32-NEXT:    srl $4, $4, 24
+; MIPS32-NEXT:    andi $4, $4, 255
 ; MIPS32-NEXT:    or $1, $zero, $4
 ; MIPS32-NEXT:    sllv $4, $4, $10
 ; MIPS32-NEXT:    sltu $5, $4, $7


### PR DESCRIPTION
About unsigned max/min, ANDi is available for all ISA revisions in extend before slt insn.
So that we can reduce one instruction.