### PR TITLE
[clang][dataflow] Don't propagate result objects in nested declarations.

### DIFF
--- a/clang/lib/Analysis/FlowSensitive/DataflowEnvironment.cpp
+++ b/clang/lib/Analysis/FlowSensitive/DataflowEnvironment.cpp
@@ -339,7 +339,7 @@ public:
     // - We don't model fields that are used only in these nested declaration,
     //   so trying to propagate a result object to initializers of such fields
     //   would cause an error.
-    if (isa<RecordDecl>(D) || isa<FunctionDecl>(D))
+    if (isa_and_nonnull<RecordDecl>(D) || isa_and_nonnull<FunctionDecl>(D))
       return true;
 
     return RecursiveASTVisitor<ResultObjectVisitor>::TraverseDecl(D);

--- a/clang/lib/Analysis/FlowSensitive/DataflowEnvironment.cpp
+++ b/clang/lib/Analysis/FlowSensitive/DataflowEnvironment.cpp
@@ -333,6 +333,18 @@ public:
     }
   }
 
+  bool TraverseDecl(Decl *D) {
+    // Don't traverse nested record or function declarations.
+    // - We won't be analyzing code contained in these anyway
+    // - We don't model fields that are used only in these nested declaration,
+    //   so trying to propagate a result object to initializers of such fields
+    //   would cause an error.
+    if (isa<RecordDecl>(D) || isa<FunctionDecl>(D))
+      return true;
+
+    return RecursiveASTVisitor<ResultObjectVisitor>::TraverseDecl(D);
+  }
+
   bool TraverseBindingDecl(BindingDecl *BD) {
     // `RecursiveASTVisitor` doesn't traverse holding variables for
     // `BindingDecl`s by itself, so we need to tell it to.


### PR DESCRIPTION
Trying to do so can cause crashes -- see newly added test and the comments in
the fix.
