### PR TITLE
[CodeGenPrepare] Preserve flags (such as nsw/nuw) in SinkCast

### DIFF
--- a/llvm/lib/CodeGen/CodeGenPrepare.cpp
+++ b/llvm/lib/CodeGen/CodeGenPrepare.cpp
@@ -1431,10 +1431,8 @@ static bool SinkCast(CastInst *CI) {
     if (!InsertedCast) {
       BasicBlock::iterator InsertPt = UserBB->getFirstInsertionPt();
       assert(InsertPt != UserBB->end());
-      InsertedCast = CastInst::Create(CI->getOpcode(), CI->getOperand(0),
-                                      CI->getType(), "");
+      InsertedCast = static_cast<CastInst *>(CI->clone());
       InsertedCast->insertBefore(*UserBB, InsertPt);
-      InsertedCast->setDebugLoc(CI->getDebugLoc());
     }
 
     // Replace a use of the cast with a use of the new cast.

--- a/llvm/lib/CodeGen/CodeGenPrepare.cpp
+++ b/llvm/lib/CodeGen/CodeGenPrepare.cpp
@@ -1431,7 +1431,7 @@ static bool SinkCast(CastInst *CI) {
     if (!InsertedCast) {
       BasicBlock::iterator InsertPt = UserBB->getFirstInsertionPt();
       assert(InsertPt != UserBB->end());
-      InsertedCast = static_cast<CastInst *>(CI->clone());
+      InsertedCast = cast<CastInst>(CI->clone());
       InsertedCast->insertBefore(*UserBB, InsertPt);
     }
 

--- a/llvm/test/Transforms/CodeGenPrepare/RISCV/noop-copy-sink.ll
+++ b/llvm/test/Transforms/CodeGenPrepare/RISCV/noop-copy-sink.ll
@@ -16,11 +16,10 @@ fnend:
 }
 
 ; The flags on the original trunc should be preserved.
-; FIXME: Flags are currently dropped.
 define i16 @sink_trunc2(i64 %a) {
 ; CHECK-LABEL: @sink_trunc2(
 ; CHECK-NEXT:  fnend:
-; CHECK-NEXT:    [[TMP0:%.*]] = trunc i64 [[A:%.*]] to i16
+; CHECK-NEXT:    [[TMP0:%.*]] = trunc nuw nsw i64 [[A:%.*]] to i16
 ; CHECK-NEXT:    ret i16 [[TMP0]]
 ;
   %trunc = trunc nuw nsw i64 %a to i16


### PR DESCRIPTION
As demonstrated in the test change, when deciding to sink a trunc we were losing its flags. This patch moves to cloning the original instruction instead.

CC @elhewaty 