### PR TITLE
[AMDGPU] Speedup SIFormMemoryClauses live-in register set calculation.

### DIFF
--- a/llvm/lib/Target/AMDGPU/SIFormMemoryClauses.cpp
+++ b/llvm/lib/Target/AMDGPU/SIFormMemoryClauses.cpp
@@ -275,10 +275,29 @@ bool SIFormMemoryClauses::runOnMachineFunction(MachineFunction &MF) {
   unsigned FuncMaxClause = MF.getFunction().getFnAttributeAsParsedInteger(
       "amdgpu-max-memory-clause", MaxClause);
 
-  for (MachineBasicBlock &MBB : MF) {
-    GCNDownwardRPTracker RPT(*LIS);
+  SmallVector<MachineInstr *, 16> FirstBBClauseMI;
+  for (auto &MBB : MF) {
+    for (auto &MI : MBB) {
+      if (!MI.isMetaInstruction() &&
+          isValidClauseInst(MI, isVMEMClauseInst(MI))) {
+        FirstBBClauseMI.push_back(&MI);
+        break;
+      }
+    }
+  }
+  if (FirstBBClauseMI.empty())
+    return false;
+
+  auto LRM = getLiveRegMap(FirstBBClauseMI, false /*After*/, *LIS);
+
+  GCNDownwardRPTracker RPT(*LIS);
+  for (auto *FirstMI : FirstBBClauseMI) {
+    auto &MBB = *FirstMI->getParent();
+    RPT.reset(*FirstMI, &LRM[FirstMI]);
     MachineBasicBlock::instr_iterator Next;
-    for (auto I = MBB.instr_begin(), E = MBB.instr_end(); I != E; I = Next) {
+    for (auto I = MachineBasicBlock::instr_iterator(FirstMI),
+              E = MBB.instr_end();
+         I != E; I = Next) {
       MachineInstr &MI = *I;
       Next = std::next(I);
 
@@ -287,12 +306,11 @@ bool SIFormMemoryClauses::runOnMachineFunction(MachineFunction &MF) {
 
       bool IsVMEM = isVMEMClauseInst(MI);
 
-      if (!isValidClauseInst(MI, IsVMEM))
-        continue;
+      if (&MI != FirstMI) {
+        if (!isValidClauseInst(MI, IsVMEM))
+          continue;
 
-      if (!RPT.getNext().isValid())
-        RPT.reset(MI);
-      else { // Advance the state to the current MI.
+        // Advance the state to the current MI.
         RPT.advance(MachineBasicBlock::const_iterator(MI));
         RPT.advanceBeforeNext();
       }


### PR DESCRIPTION
GCNDownwardRPTracker requires live-in set for a start of every memory clause. The live-in set calculation is expensive calculation and instead of calculating a set for one clause at time the patch calculates all sets for all clauses at once. This is faster because start slot indexes for clauses are ordered and LIS live segments for a register are also ordered so the getLiveRegMap finds a range of start slot indexes that fall into a given live segment of a register.

This patch uses the same approach used in GCNScheduleDAGMILive::getBBLiveInMap