### PR TITLE
[mlir][py] fix option passing in transform interpreter

### DIFF
--- a/mlir/python/mlir/dialects/transform/interpreter/__init__.py
+++ b/mlir/python/mlir/dialects/transform/interpreter/__init__.py
@@ -29,7 +29,7 @@ def apply_named_sequence(
     if transform_options is None:
         _cextTransformInterpreter.apply_named_sequence(*args)
     else:
-        _cextTransformInterpreter(*args, transform_options)
+        _cextTransformInterpreter.apply_named_sequence(*args, transform_options)
 
 
 def copy_symbols_and_merge_into(target, other):

--- a/mlir/test/python/dialects/transform_interpreter.py
+++ b/mlir/test/python/dialects/transform_interpreter.py
@@ -46,6 +46,21 @@ def print_other():
 
 
 @test_in_context
+def transform_options():
+    options = interp.TransformOptions()
+    options.expensive_checks = False
+    options.enforce_single_top_level_transform_op = True
+    m = ir.Module.parse(
+        print_root_module.replace("from interpreter", "transform_options")
+    )
+    payload = ir.Module.parse("module attributes { this.is.payload } {}")
+    interp.apply_named_sequence(payload, m.body.operations[0], m, options)
+
+
+# CHECK-LABEL: transform_options
+
+
+@test_in_context
 def failed():
     payload = ir.Module.parse("module attributes { this.is.payload } {}")
     try:


### PR DESCRIPTION
There was a typo in dispatch trampoline.