### PR TITLE
[llvm][AArch64] Add missing default cases

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64InstrInfo.h
+++ b/llvm/lib/Target/AArch64/AArch64InstrInfo.h
@@ -724,9 +724,8 @@ static inline unsigned getAUTOpcodeForKey(AArch64PACKey::ID K, bool Zero) {
   case IB: return Zero ? AArch64::AUTIZB : AArch64::AUTIB;
   case DA: return Zero ? AArch64::AUTDZA : AArch64::AUTDA;
   case DB: return Zero ? AArch64::AUTDZB : AArch64::AUTDB;
-  default:
-    return 0;
   }
+  llvm_unreachable("Unhandled AArch64PACKey::ID enum");
 }
 
 /// Return PAC opcode to be used for a ptrauth sign using the given key, or its
@@ -738,9 +737,8 @@ static inline unsigned getPACOpcodeForKey(AArch64PACKey::ID K, bool Zero) {
   case IB: return Zero ? AArch64::PACIZB : AArch64::PACIB;
   case DA: return Zero ? AArch64::PACDZA : AArch64::PACDA;
   case DB: return Zero ? AArch64::PACDZB : AArch64::PACDB;
-  default:
-    return 0;
   }
+  llvm_unreachable("Unhandled AArch64PACKey::ID enum");
 }
 
 // struct TSFlags {

--- a/llvm/lib/Target/AArch64/AArch64InstrInfo.h
+++ b/llvm/lib/Target/AArch64/AArch64InstrInfo.h
@@ -724,6 +724,7 @@ static inline unsigned getAUTOpcodeForKey(AArch64PACKey::ID K, bool Zero) {
   case IB: return Zero ? AArch64::AUTIZB : AArch64::AUTIB;
   case DA: return Zero ? AArch64::AUTDZA : AArch64::AUTDA;
   case DB: return Zero ? AArch64::AUTDZB : AArch64::AUTDB;
+  default: return 0;
   }
 }
 
@@ -736,6 +737,7 @@ static inline unsigned getPACOpcodeForKey(AArch64PACKey::ID K, bool Zero) {
   case IB: return Zero ? AArch64::PACIZB : AArch64::PACIB;
   case DA: return Zero ? AArch64::PACDZA : AArch64::PACDA;
   case DB: return Zero ? AArch64::PACDZB : AArch64::PACDB;
+  default: return 0;
   }
 }
 

--- a/llvm/lib/Target/AArch64/AArch64InstrInfo.h
+++ b/llvm/lib/Target/AArch64/AArch64InstrInfo.h
@@ -724,7 +724,8 @@ static inline unsigned getAUTOpcodeForKey(AArch64PACKey::ID K, bool Zero) {
   case IB: return Zero ? AArch64::AUTIZB : AArch64::AUTIB;
   case DA: return Zero ? AArch64::AUTDZA : AArch64::AUTDA;
   case DB: return Zero ? AArch64::AUTDZB : AArch64::AUTDB;
-  default: return 0;
+  default:
+    return 0;
   }
 }
 
@@ -737,7 +738,8 @@ static inline unsigned getPACOpcodeForKey(AArch64PACKey::ID K, bool Zero) {
   case IB: return Zero ? AArch64::PACIZB : AArch64::PACIB;
   case DA: return Zero ? AArch64::PACDZA : AArch64::PACDA;
   case DB: return Zero ? AArch64::PACDZB : AArch64::PACDB;
-  default: return 0;
+  default:
+    return 0;
   }
 }
 


### PR DESCRIPTION
Addresses issue #89709.

Functions getAUTOpcodeForKey() and getPACOpcodeForKey() contain switch statements without default cases. Resolved by adding a call to llvm_unreachable() at the end of each function.