### PR TITLE
[Clang] Don't diagnose VLA for `-std=gnu++*` by default

### DIFF
--- a/clang/include/clang/Basic/DiagnosticGroups.td
+++ b/clang/include/clang/Basic/DiagnosticGroups.td
@@ -870,7 +870,8 @@ def VectorConversion : DiagGroup<"vector-conversion">;      // clang specific
 def VexingParse : DiagGroup<"vexing-parse">;
 def VLAUseStaticAssert : DiagGroup<"vla-extension-static-assert">;
 def VLACxxExtension : DiagGroup<"vla-cxx-extension", [VLAUseStaticAssert]>;
-def VLAExtension : DiagGroup<"vla-extension", [VLACxxExtension]>;
+def GNUVLACxxExtension : DiagGroup<"gnu-vla-cxx-extension", [VLACxxExtension]>;
+def VLAExtension : DiagGroup<"vla-extension", [GNUVLACxxExtension]>;
 def VLA : DiagGroup<"vla", [VLAExtension]>;
 def VolatileRegisterVar : DiagGroup<"volatile-register-var">;
 def Visibility : DiagGroup<"visibility">;

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -143,12 +143,12 @@ def ext_vla_cxx : ExtWarn<
   "variable length arrays in C++ are a Clang extension">,
   InGroup<VLACxxExtension>;
 def ext_vla_cxx_in_gnu_mode : Extension<ext_vla_cxx.Summary>,
-  InGroup<VLACxxExtension>;
+  InGroup<GNUVLACxxExtension>;
 def ext_vla_cxx_static_assert : ExtWarn<
   "variable length arrays in C++ are a Clang extension; did you mean to use "
   "'static_assert'?">, InGroup<VLAUseStaticAssert>;
 def ext_vla_cxx_in_gnu_mode_static_assert : Extension<
-  ext_vla_cxx_static_assert.Summary>, InGroup<VLAUseStaticAssert>;
+  ext_vla_cxx_static_assert.Summary>, InGroup<GNUVLACxxExtension>;
 def warn_vla_used : Warning<"variable length array used">,
   InGroup<VLA>, DefaultIgnore;
 def err_vla_in_sfinae : Error<

--- a/clang/test/Sema/vla-ext.c
+++ b/clang/test/Sema/vla-ext.c
@@ -3,6 +3,7 @@
  * RUN: %clang_cc1 -verify -pedantic -std=c89 %s
  * RUN: %clang_cc1 -verify -Wvla-extension -std=c89 %s
  * RUN: %clang_cc1 -verify=off -Wvla-cxx-extension -std=c89 %s
+ * RUN: %clang_cc1 -verify=off -Wgnu-vla-cxx-extension -std=c89 %s
  * RUN: %clang_cc1 -verify=off -pedantic -std=c99 %s
  * RUN: %clang_cc1 -verify=off -Wall -std=c99 %s
  * RUN: %clang_cc1 -verify=off -std=c99 -Wvla-extension %s

--- a/clang/test/SemaCXX/c99-variable-length-array.cpp
+++ b/clang/test/SemaCXX/c99-variable-length-array.cpp
@@ -1,4 +1,5 @@
 // RUN: %clang_cc1 -fsyntax-only -verify -Wvla-extension %s
+// RUN: %clang_cc1 -fsyntax-only -verify -Wgnu-vla-cxx-extension %s
 struct NonPOD {
   NonPOD();
 };

--- a/clang/test/SemaCXX/coroutine-vla.cpp
+++ b/clang/test/SemaCXX/coroutine-vla.cpp
@@ -1,4 +1,5 @@
 // RUN: %clang_cc1 %s -std=c++20 -fsyntax-only -Wno-vla-cxx-extension -verify
+// RUN: %clang_cc1 %s -std=c++20 -fsyntax-only -Wno-gnu-vla-cxx-extension -verify
 #include "Inputs/std-coroutine.h"
 
 struct promise;


### PR DESCRIPTION
The changeset aims to keep Clang's behavior prior to `7339c0f` and to match current behavior in GCC until GCC community decides what should be default: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=110848