### PR TITLE
[clang][tools] Adjust the dependency libraries of c-arcmt-test and c-index-test to meet LLVM_BUILD_STATIC=ON.

### DIFF
--- a/clang/tools/c-arcmt-test/CMakeLists.txt
+++ b/clang/tools/c-arcmt-test/CMakeLists.txt
@@ -5,7 +5,7 @@ add_clang_executable(c-arcmt-test
 if (LLVM_BUILD_STATIC)
   target_link_libraries(c-arcmt-test
     PRIVATE
-    libclang_static
+    libclang
     )
 else()
   target_link_libraries(c-arcmt-test

--- a/clang/tools/c-index-test/CMakeLists.txt
+++ b/clang/tools/c-index-test/CMakeLists.txt
@@ -17,7 +17,7 @@ endif()
 if (LLVM_BUILD_STATIC)
   target_link_libraries(c-index-test
     PRIVATE
-    libclang_static
+    libclang
     clangCodeGen
     clangIndex
   )


### PR DESCRIPTION

Close:https://github.com/llvm/llvm-project/issues/59507