### PR TITLE
[mlir-c] Add mlirIRDLLoadDialects

### DIFF
--- a/mlir/include/mlir-c/Dialect/IRDL.h
+++ b/mlir/include/mlir-c/Dialect/IRDL.h
@@ -1,0 +1,28 @@
+//===-- mlir-c/Dialect/IRDL.h - C API for IRDL dialect ------------*- C -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM
+// Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef MLIR_C_DIALECT_IRDL_H
+#define MLIR_C_DIALECT_IRDL_H
+
+#include "mlir-c/IR.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+MLIR_DECLARE_CAPI_DIALECT_REGISTRATION(IRDL, irdl);
+
+/// Load all the dialects defined in the module.
+MLIR_CAPI_EXPORTED MlirLogicalResult mlirIRDLLoadDialects(MlirModule module);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // MLIR_C_DIALECT_IRDL_H

--- a/mlir/lib/CAPI/Dialect/CMakeLists.txt
+++ b/mlir/lib/CAPI/Dialect/CMakeLists.txt
@@ -40,6 +40,15 @@ add_mlir_upstream_c_api_library(MLIRCAPIControlFlow
   MLIRControlFlowDialect
 )
 
+add_mlir_upstream_c_api_library(MLIRCAPIIRDL
+  IRDL.cpp
+
+  PARTIAL_SOURCES_INTENDED
+  LINK_LIBS PUBLIC
+  MLIRCAPIIR
+  MLIRIRDL
+)
+
 add_mlir_upstream_c_api_library(MLIRCAPIMath
   Math.cpp
 

--- a/mlir/lib/CAPI/Dialect/IRDL.cpp
+++ b/mlir/lib/CAPI/Dialect/IRDL.cpp
@@ -1,0 +1,20 @@
+//===- IRDL.cpp - C Interface for IRDL dialect ------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "mlir-c/Dialect/IRDL.h"
+#include "mlir/CAPI/Registration.h"
+#include "mlir/Dialect/IRDL/IR/IRDL.h"
+#include "mlir/Dialect/IRDL/IRDLLoading.h"
+
+using namespace mlir;
+
+MLIR_DEFINE_CAPI_DIALECT_REGISTRATION(IRDL, irdl, irdl::IRDLDialect)
+
+extern "C" MlirLogicalResult mlirIRDLLoadDialects(MlirModule module) {
+  return wrap(irdl::loadDialects(unwrap(module)));
+}

--- a/mlir/test/CAPI/CMakeLists.txt
+++ b/mlir/test/CAPI/CMakeLists.txt
@@ -38,6 +38,14 @@ _add_capi_test_executable(mlir-capi-ir-test
     MLIRCAPIRegisterEverything
 )
 
+_add_capi_test_executable(mlir-capi-irdl-test
+  irdl.c
+  LINK_LIBS PRIVATE
+    MLIRCAPIIR
+    MLIRCAPIIRDL
+    MLIRCAPIRegisterEverything
+)
+
 _add_capi_test_executable(mlir-capi-llvm-test
   llvm.c
   LINK_LIBS PRIVATE

--- a/mlir/test/CAPI/irdl.c
+++ b/mlir/test/CAPI/irdl.c
@@ -1,0 +1,69 @@
+//===- irdl.c - Test of IRDL dialect C API --------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM
+// Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: mlir-capi-irdl-test 2>&1 | FileCheck %s
+
+#include "mlir-c/Dialect/IRDL.h"
+#include "mlir-c/IR.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+
+// CHECK-LABEL: testLoadDialect
+int testLoadDialect(MlirContext ctx) {
+  fprintf(stderr, "testLoadDialect\n");
+
+  const char *moduleString = "irdl.dialect @cmath {"
+                             "  irdl.type @complex {"
+                             "    %0 = irdl.is f32"
+                             "    %1 = irdl.is f64"
+                             "    %2 = irdl.any_of(%0, %1)"
+                             "    irdl.parameters(%2)"
+                             "  }"
+                             "  irdl.operation @mul {"
+                             "    %0 = irdl.is f32"
+                             "    %1 = irdl.is f64"
+                             "    %2 = irdl.any_of(%0, %1)"
+                             "    %3 = irdl.parametric @complex<%2>"
+                             "    irdl.operands(%3, %3)"
+                             "    irdl.results(%3)"
+                             "  }"
+                             "}";
+
+  MlirModule module =
+      mlirModuleCreateParse(ctx, mlirStringRefCreateFromCString(moduleString));
+
+  if (mlirModuleIsNull(module))
+    return 1;
+
+  MlirLogicalResult result = mlirIRDLLoadDialects(module);
+  if (mlirLogicalResultIsFailure(result))
+    return 2;
+
+  if (!mlirContextIsRegisteredOperation(
+          ctx, mlirStringRefCreateFromCString("cmath.mul")))
+    return 3;
+
+  mlirModuleDestroy(module);
+
+  return 0;
+}
+
+int main(void) {
+  MlirContext ctx = mlirContextCreate();
+  if (mlirContextIsNull(ctx))
+    return 1;
+  mlirDialectHandleRegisterDialect(mlirGetDialectHandle__irdl__(), ctx);
+  int result = testLoadDialect(ctx);
+  mlirContextDestroy(ctx);
+  if (result)
+    return result;
+
+  return EXIT_SUCCESS;
+}

--- a/mlir/test/CMakeLists.txt
+++ b/mlir/test/CMakeLists.txt
@@ -101,6 +101,7 @@ configure_lit_site_cfg(
 set(MLIR_TEST_DEPENDS
   FileCheck count not split-file
   mlir-capi-ir-test
+  mlir-capi-irdl-test
   mlir-capi-llvm-test
   mlir-capi-pass-test
   mlir-capi-quant-test


### PR DESCRIPTION
This allows C-API users to load IRDL dialects.

I noticed in https://github.com/llvm/llvm-project/pull/86329 that `MlirModule` is being depriviledged in favour of `MlirOperation` so I am not sure if I need to change the signature of `mlirIRDLLoadDialects` to `mlirIRDLLoadDialects(MlirOperation)`.