### PR TITLE
[clang-scan-deps] Expand response files before the argument adjuster

### DIFF
--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -1030,7 +1030,7 @@ void Clang::AddPreprocessingOptions(Compilation &C, const JobAction &JA,
 
       // If user provided -o, that is the dependency target, except
       // when we are only generating a dependency file.
-      Arg *OutputOpt = Args.getLastArg(options::OPT_o);
+      Arg *OutputOpt = Args.getLastArg(options::OPT_o, options::OPT__SLASH_Fo);
       if (OutputOpt && Output.getType() != types::TY_Dependencies) {
         DepTarget = OutputOpt->getValue();
       } else {

--- a/clang/test/ClangScanDeps/response-file-clang-cl.c
+++ b/clang/test/ClangScanDeps/response-file-clang-cl.c
@@ -1,0 +1,32 @@
+// Check that the scanner can adjust arguments by reading .rsp files in advance.
+
+// RUN: rm -rf %t
+// RUN: split-file %s %t
+// RUN: sed -e "s|DIR|%/t|g" %t/cdb.json.template > %t/cdb.json
+// RUN: echo /Fo%t/tu.obj >> %t/args_nested.rsp
+
+// RUN: clang-scan-deps -compilation-database %t/cdb.json > %t/deps.json
+
+// RUN: cat %t/deps.json | sed 's:\\\\\?:/:g' | FileCheck -DPREFIX=%/t %s
+
+// Here we ensure that we got a qualified .obj with its full path, since that's what we're passing with /Fo
+// CHECK: [[PREFIX]]/tu.obj:
+
+//--- cdb.json.template
+[{
+  "file": "DIR/t.cpp",
+  "directory": "DIR",
+  "command": "clang-cl @DIR/args.rsp"
+}]
+
+//--- args.rsp
+@args_nested.rsp
+/c tu.cpp
+
+//--- args_nested.rsp
+/I include
+
+//--- include/header.h
+
+//--- tu.cpp
+#include "header.h"

--- a/clang/test/ClangScanDeps/response-file-clang-cl.c
+++ b/clang/test/ClangScanDeps/response-file-clang-cl.c
@@ -5,8 +5,12 @@
 // RUN: sed -e "s|DIR|%/t|g" %t/cdb.json.template > %t/cdb.json
 // RUN: echo /Fo%t/tu.obj >> %t/args_nested.rsp
 
+// RUN: echo /c >> %t/args_nested.rsp
 // RUN: clang-scan-deps -compilation-database %t/cdb.json > %t/deps.json
+// RUN: cat %t/deps.json | sed 's:\\\\\?:/:g' | FileCheck -DPREFIX=%/t %s
 
+// RUN: echo /E >> %t/args_nested.rsp
+// RUN: clang-scan-deps -compilation-database %t/cdb.json > %t/deps.json
 // RUN: cat %t/deps.json | sed 's:\\\\\?:/:g' | FileCheck -DPREFIX=%/t %s
 
 // Here we ensure that we got a qualified .obj with its full path, since that's what we're passing with /Fo
@@ -21,7 +25,7 @@
 
 //--- args.rsp
 @args_nested.rsp
-/c tu.cpp
+tu.cpp
 
 //--- args_nested.rsp
 /I include

--- a/clang/test/ClangScanDeps/response-file-clang-cl.c
+++ b/clang/test/ClangScanDeps/response-file-clang-cl.c
@@ -2,33 +2,53 @@
 
 // RUN: rm -rf %t
 // RUN: split-file %s %t
+
+// First run the tests with a .cdb
 // RUN: sed -e "s|DIR|%/t|g" %t/cdb.json.template > %t/cdb.json
-// RUN: echo /Fo%t/tu.obj >> %t/args_nested.rsp
+// RUN: sed -e "s|DIR|%/t|g" %t/args_nested.template > %t/args_nested.rsp
 
-// RUN: echo /c >> %t/args_nested.rsp
-// RUN: clang-scan-deps -compilation-database %t/cdb.json > %t/deps.json
+// RUN: cp %t/args_compilation.rsp %t/args.rsp
+// RUN: clang-scan-deps --compilation-database %t/cdb.json > %t/deps.json
 // RUN: cat %t/deps.json | sed 's:\\\\\?:/:g' | FileCheck -DPREFIX=%/t %s
 
-// RUN: echo /E >> %t/args_nested.rsp
-// RUN: clang-scan-deps -compilation-database %t/cdb.json > %t/deps.json
+// RUN: cp %t/args_preprocess.rsp %t/args.rsp
+// RUN: clang-scan-deps --compilation-database %t/cdb.json > %t/deps.json
 // RUN: cat %t/deps.json | sed 's:\\\\\?:/:g' | FileCheck -DPREFIX=%/t %s
+
+
+// Now run the tests again with a in-place compilation database
+// RUN: cd %t
+
+// RUN: cp args_compilation.rsp args.rsp
+// RUN: clang-scan-deps -o deps.json -- %clang_cl @args.rsp
+// RUN: cat deps.json | sed 's:\\\\\?:/:g' | FileCheck -DPREFIX=%/t %s
+
+// RUN: cp args_preprocess.rsp args.rsp
+// RUN: clang-scan-deps -o deps.json -- %clang_cl @args.rsp
+// RUN: cat deps.json | sed 's:\\\\\?:/:g' | FileCheck -DPREFIX=%/t %s
 
 // Here we ensure that we got a qualified .obj with its full path, since that's what we're passing with /Fo
 // CHECK: [[PREFIX]]/tu.obj:
 
 //--- cdb.json.template
 [{
-  "file": "DIR/t.cpp",
+  "file": "DIR/tu.cpp",
   "directory": "DIR",
   "command": "clang-cl @DIR/args.rsp"
 }]
 
-//--- args.rsp
+//--- args_compilation.rsp
 @args_nested.rsp
-tu.cpp
+/c
 
-//--- args_nested.rsp
+//--- args_preprocess.rsp
+@args_nested.rsp
+/E
+
+//--- args_nested.template
 /I include
+tu.cpp
+/FoDIR/tu.obj
 
 //--- include/header.h
 

--- a/clang/test/Driver/cl-options.c
+++ b/clang/test/Driver/cl-options.c
@@ -740,9 +740,10 @@
 // NOCLANG-SAME: "-vectorize-slp"
 // NOCLANG-NOT: "--dependent-lib=msvcrt"
 
-// RUN: %clang_cl -O2 -MD /clang:-fno-slp-vectorize /clang:-MD /clang:-MF /clang:my_dependency_file.dep -### -- %s 2>&1 | FileCheck -check-prefix=CLANG %s
+// RUN: %clang_cl -O2 -MD /clang:-fno-slp-vectorize /clang:-MD /clang:-MF /clang:my_dependency_file.dep /c /Fo%/t/cl-options.obj -### -- %s 2>&1 | FileCheck -DPREFIX=%/t -check-prefix=CLANG %s
 // CLANG: "--dependent-lib=msvcrt"
 // CLANG-SAME: "-dependency-file" "my_dependency_file.dep"
+// CLANG-SAME: "-MT" "[[PREFIX]]/cl-options.obj"
 // CLANG-NOT: "--dependent-lib=libcmt"
 // CLANG-NOT: "-vectorize-slp"
 

--- a/clang/tools/clang-scan-deps/ClangScanDeps.cpp
+++ b/clang/tools/clang-scan-deps/ClangScanDeps.cpp
@@ -86,6 +86,8 @@ static bool DeprecatedDriverCommand;
 static ResourceDirRecipeKind ResourceDirRecipe;
 static bool Verbose;
 static bool PrintTiming;
+static llvm::BumpPtrAllocator Alloc;
+static llvm::StringSaver Saver{Alloc};
 static std::vector<const char *> CommandLine;
 
 #ifndef NDEBUG
@@ -99,8 +101,6 @@ static bool RoundTripArgs = DoRoundTripDefault;
 static void ParseArgs(int argc, char **argv) {
   ScanDepsOptTable Tbl;
   llvm::StringRef ToolName = argv[0];
-  llvm::BumpPtrAllocator Alloc;
-  llvm::StringSaver Saver{Alloc};
   llvm::opt::InputArgList Args =
       Tbl.parseArgs(argc, argv, OPT_UNKNOWN, Saver, [&](StringRef Msg) {
         llvm::errs() << Msg << '\n';
@@ -794,13 +794,13 @@ int clang_scan_deps_main(int argc, char **argv, const llvm::ToolContext &) {
 
   // Expand response files in advance, so that we can "see" all the arguments
   // when adjusting below.
-  auto ResponseExpander = expandResponseFiles(std::move(Compilations),
-                                              llvm::vfs::getRealFileSystem());
+  Compilations = expandResponseFiles(std::move(Compilations),
+                                     llvm::vfs::getRealFileSystem());
 
   // The command options are rewritten to run Clang in preprocessor only mode.
   auto AdjustingCompilations =
       std::make_unique<tooling::ArgumentsAdjustingCompilations>(
-          std::move(ResponseExpander));
+          std::move(Compilations));
   ResourceDirectoryCache ResourceDirCache;
 
   AdjustingCompilations->appendArgumentsAdjuster(

--- a/clang/tools/clang-scan-deps/ClangScanDeps.cpp
+++ b/clang/tools/clang-scan-deps/ClangScanDeps.cpp
@@ -792,10 +792,15 @@ int clang_scan_deps_main(int argc, char **argv, const llvm::ToolContext &) {
 
   llvm::cl::PrintOptionValues();
 
+  // Expand response files in advance, so that we can "see" all the arguments
+  // when adjusting below.
+  auto ResponseExpander = expandResponseFiles(std::move(Compilations),
+                                              llvm::vfs::getRealFileSystem());
+
   // The command options are rewritten to run Clang in preprocessor only mode.
   auto AdjustingCompilations =
       std::make_unique<tooling::ArgumentsAdjustingCompilations>(
-          std::move(Compilations));
+          std::move(ResponseExpander));
   ResourceDirectoryCache ResourceDirCache;
 
   AdjustingCompilations->appendArgumentsAdjuster(


### PR DESCRIPTION
Previously, since response (.rsp) files weren't expanded at the very beginning of clang-scan-deps, we only parsed the command-line as provided in the Clang .cdb file. Unfortunately, when using Unreal Engine, arguments are always generated in a .rsp file (ie. `/path/to/clang-cl.exe @/path/to/filename_args.rsp`).

After this patch, `/Fo` can be parsed and added to the final command-line. Without this option, the make targets that are emitted are made up from the input file name alone. We have some cases where the same input in the project generates several output files, so we end up with duplicate make targets in the scan-deps emitted dependency file.