### PR TITLE
[Driver] Don't default to -mrelax-all for non-RISCV -O0

### DIFF
--- a/clang/test/Driver/integrated-as.c
+++ b/clang/test/Driver/integrated-as.c
@@ -3,7 +3,7 @@
 // RUN: %clang -### -c -save-temps -integrated-as --target=x86_64 %s 2>&1 | FileCheck %s
 
 // CHECK: cc1as
-// CHECK: -mrelax-all
+// CHECK-NOT: -mrelax-all
 
 // RISC-V does not enable -mrelax-all
 // RUN: %clang -### -c -save-temps -integrated-as --target=riscv64 %s 2>&1 | FileCheck %s -check-prefix=RISCV-RELAX


### PR DESCRIPTION
Some assembly mnemonics may assemble to instructions of different
lengths. The longer form is to support instructions like a long branch.
On X86, -mrelax-all enables `MCRelaxAll`, which expands instructions to
the long form regardless of whether a short form suffices, while
-mno-relax-all only expands instructions when needed.

```
// x86 example
void foo(int a) {
  // -mno-relax-all or gas: short jump (2 bytes)
  // -mrelax-all: near jump (6 bytes)
  if (a) bar();
}
```

The -mrelax-all default for non-RISCV -O0 appears to only affect x86 and
increases code size without any compile time difference for a stage-2
x86-64 build of lld.
```
-mrelax-all:    file size: 60.9MiB   VM size: 52.4MiB
-mno-relax-all: file size: 58.2MiB   VM size: 49.7MiB
```

There is no compile time difference (other than noise) GNU assembler
doesn't expand instructions by default. Let's remove the -mrelax-all default.
