### PR TITLE
[Flang] Add fallthrough annotations in visit.h

### DIFF
--- a/flang/include/flang/Common/visit.h
+++ b/flang/include/flang/Common/visit.h
@@ -23,6 +23,7 @@
 
 #include "variant.h"
 #include "flang/Common/api-attrs.h"
+#include "llvm/Support/Compiler.h"
 #include <type_traits>
 
 namespace Fortran::common {
@@ -40,11 +41,17 @@ inline RT_API_ATTRS RESULT Log2VisitHelper(
       return visitor(std::get<(LOW + N)>(std::forward<VARIANT>(u))...); \
     }
       VISIT_CASE_N(1)
+      LLVM_FALLTHROUGH;
       VISIT_CASE_N(2)
+      LLVM_FALLTHROUGH;
       VISIT_CASE_N(3)
+      LLVM_FALLTHROUGH;
       VISIT_CASE_N(4)
+      LLVM_FALLTHROUGH;
       VISIT_CASE_N(5)
+      LLVM_FALLTHROUGH;
       VISIT_CASE_N(6)
+      LLVM_FALLTHROUGH;
       VISIT_CASE_N(7)
 #undef VISIT_CASE_N
     }


### PR DESCRIPTION
Add fallthrough annotations to avoid warnings if -Wimplicit-fallthrough is enabled.
Note, LLVM_FALLTHROUGH can't be  included into VISIT_CASE_N - it would cause a compile error for the last case.

Test plan: ninja check-all