### PR TITLE
[scudo][gwp_asan] Clean up Fuchsia zxtest framework integration

### DIFF
--- a/compiler-rt/lib/gwp_asan/tests/harness.h
+++ b/compiler-rt/lib/gwp_asan/tests/harness.h
@@ -11,7 +11,7 @@
 
 #include <stdarg.h>
 
-#if defined(__Fuchsia__)
+#ifdef LIBC_COPT_TEST_USE_ZXTEST
 #define ZXTEST_USE_STREAMABLE_MACROS
 #include <zxtest/zxtest.h>
 namespace testing = zxtest;

--- a/compiler-rt/lib/scudo/standalone/tests/scudo_unit_test.h
+++ b/compiler-rt/lib/scudo/standalone/tests/scudo_unit_test.h
@@ -8,7 +8,7 @@
 
 #include "platform.h"
 
-#if SCUDO_FUCHSIA
+#ifdef LIBC_COPT_TEST_USE_ZXTEST
 #include <zxtest/zxtest.h>
 using Test = ::zxtest::Test;
 #else


### PR DESCRIPTION
This brings the scudo and gwp_asan code in line with how the
llvm-libc code selects using zxtest vs gtest on Fuchsia.
