### PR TITLE
[Flang] Get fir::SequenceType from hlfir::ExprType before getShape.

### DIFF
--- a/flang/lib/Lower/ConvertCall.cpp
+++ b/flang/lib/Lower/ConvertCall.cpp
@@ -1190,8 +1190,7 @@ static PreparedDummyArgument preparePresentUserCallActualArgument(
         arg.isSequenceAssociatedDescriptor()) {
       mlir::Type actualTy =
           hlfir::getFortranElementOrSequenceType(actual.getType());
-      dummyTypeWithActualRank =
-          baseBoxDummy.getBoxTypeWithNewShape(actualTy);
+      dummyTypeWithActualRank = baseBoxDummy.getBoxTypeWithNewShape(actualTy);
     }
   }
   // Preserve the actual type in the argument preparation in case IgnoreTKR(t)

--- a/flang/lib/Lower/ConvertCall.cpp
+++ b/flang/lib/Lower/ConvertCall.cpp
@@ -1184,12 +1184,16 @@ static PreparedDummyArgument preparePresentUserCallActualArgument(
   // actual argument shape information. A descriptor with the dummy shape
   // information will be created later when all actual arguments are ready.
   mlir::Type dummyTypeWithActualRank = dummyType;
-  if (auto baseBoxDummy = mlir::dyn_cast<fir::BaseBoxType>(dummyType))
+  if (auto baseBoxDummy = mlir::dyn_cast<fir::BaseBoxType>(dummyType)) {
     if (baseBoxDummy.isAssumedRank() ||
         arg.testTKR(Fortran::common::IgnoreTKR::Rank) ||
-        arg.isSequenceAssociatedDescriptor())
+        arg.isSequenceAssociatedDescriptor()) {
+      mlir::Type actualTy =
+          hlfir::getFortranElementOrSequenceType(actual.getType());
       dummyTypeWithActualRank =
-          baseBoxDummy.getBoxTypeWithNewShape(actual.getType());
+          baseBoxDummy.getBoxTypeWithNewShape(actualTy);
+    }
+  }
   // Preserve the actual type in the argument preparation in case IgnoreTKR(t)
   // is set (descriptors must be created with the actual type in this case, and
   // copy-in/copy-out should be driven by the contiguity with regard to the


### PR DESCRIPTION
This PR is to fix issue #88889 . 
Because the type of an actual argument of an array expression of character has type of `hlfir::ExprType`, we need to transform it to `fir::SequenceType` before calling `getBoxTypeWithNewShape`. 
Calling `hlfir::ExprType::getShape` inside of `getBoxTypeWithNewShape` will introduce a circular dependency on FIRDialect and HLFIRDialect libraries.