### PR TITLE
[TableGen] Ignore inaccessible memory when checking pattern flags

### DIFF
--- a/llvm/utils/TableGen/Common/CodeGenDAGPatterns.cpp
+++ b/llvm/utils/TableGen/Common/CodeGenDAGPatterns.cpp
@@ -3616,7 +3616,15 @@ public:
       hasChain = true;
 
     if (const CodeGenIntrinsic *IntInfo = N.getIntrinsicInfo(CDP)) {
-      ModRefInfo MR = IntInfo->ME.getModRef();
+      // Ignore reads/writes to inaccessible memory. These should not imply
+      // mayLoad/mayStore on the instruction because they are often used to
+      // model dependencies that Machine IR expresses as uses/defs of a
+      // special physical register.
+      ModRefInfo MR = ModRefInfo::NoModRef;
+      for (MemoryEffects::Location Loc : MemoryEffects::locations()) {
+        if (Loc != MemoryEffects::Location::InaccessibleMem)
+          MR |= IntInfo->ME.getModRef();
+      }
       // If this is an intrinsic, analyze it.
       if (isRefSet(MR))
         mayLoad = true; // These may load memory.


### PR DESCRIPTION
In the AMDGPU backend we have some cases where we'd like to mark an
intrinsic as IntrInaccessibleMemOnly to model dependencies, but the
corresponding MachineInstrs use uses/defs of a special physical register
to express the same thing. In this case TableGen would complain:

  Pattern doesn't match mayLoad/mayStore = 0

but the error is not useful.
