### PR TITLE
[clang codegen][NFC] Delete dead code in constant emission.

### DIFF
--- a/clang/lib/CodeGen/CGExprAgg.cpp
+++ b/clang/lib/CodeGen/CGExprAgg.cpp
@@ -537,7 +537,7 @@ void AggExprEmitter::EmitArrayInit(Address DestPtr, llvm::ArrayType *AType,
     ConstantEmitter Emitter(CGF);
     LangAS AS = ArrayQTy.getAddressSpace();
     if (llvm::Constant *C =
-            Emitter.tryEmitForInitializer(ExprToVisit, AS, ArrayQTy)) {
+            Emitter.tryEmitForInitializer(ExprToVisit, ArrayQTy)) {
       auto GV = new llvm::GlobalVariable(
           CGM.getModule(), C->getType(),
           /* isConstant= */ true, llvm::GlobalValue::PrivateLinkage, C,

--- a/clang/lib/CodeGen/CodeGenModule.cpp
+++ b/clang/lib/CodeGen/CodeGenModule.cpp
@@ -3503,8 +3503,7 @@ ConstantAddress CodeGenModule::GetAddrOfMSGuidDecl(const MSGuidDecl *GD) {
   if (!V.isAbsent()) {
     // If possible, emit the APValue version of the initializer. In particular,
     // this gets the type of the constant right.
-    Init = Emitter.emitForInitializer(
-        GD->getAsAPValue(), GD->getType().getAddressSpace(), GD->getType());
+    Init = Emitter.emitForInitializer(GD->getAsAPValue(), GD->getType());
   } else {
     // As a fallback, directly construct the constant.
     // FIXME: This may get padding wrong under esoteric struct layout rules.
@@ -3552,8 +3551,7 @@ ConstantAddress CodeGenModule::GetAddrOfUnnamedGlobalConstantDecl(
   const APValue &V = GCD->getValue();
 
   assert(!V.isAbsent());
-  Init = Emitter.emitForInitializer(V, GCD->getType().getAddressSpace(),
-                                    GCD->getType());
+  Init = Emitter.emitForInitializer(V, GCD->getType());
 
   auto *GV = new llvm::GlobalVariable(getModule(), Init->getType(),
                                       /*isConstant=*/true,
@@ -3578,7 +3576,7 @@ ConstantAddress CodeGenModule::GetAddrOfTemplateParamObject(
 
   ConstantEmitter Emitter(*this);
   llvm::Constant *Init = Emitter.emitForInitializer(
-        TPO->getValue(), TPO->getType().getAddressSpace(), TPO->getType());
+        TPO->getValue(), TPO->getType());
 
   if (!Init) {
     ErrorUnsupported(TPO, "template parameter object");
@@ -6520,7 +6518,7 @@ ConstantAddress CodeGenModule::GetAddrOfGlobalTemporary(
   if (Value) {
     // The temporary has a constant initializer, use it.
     emitter.emplace(*this);
-    InitialValue = emitter->emitForInitializer(*Value, AddrSpace,
+    InitialValue = emitter->emitForInitializer(*Value,
                                                MaterializedType);
     Constant =
         MaterializedType.isConstantStorage(getContext(), /*ExcludeCtor*/ Value,


### PR DESCRIPTION
This code was apparently added in de0fe07eef, but never used.

I think more of the related code might actually dead, but I haven't tried to dig more deeply.