### PR TITLE
[compiler-rt] Avoid assertions when using LLVM_ENABLE_PER_TARGET_RUNTIME_DIR

### DIFF
--- a/compiler-rt/test/ctx_profile/Unit/lit.site.cfg.py.in
+++ b/compiler-rt/test/ctx_profile/Unit/lit.site.cfg.py.in
@@ -20,7 +20,9 @@ config.test_source_root = config.test_exec_root
 
 # When LLVM_ENABLE_PER_TARGET_RUNTIME_DIR=on, the initial value of
 # config.compiler_rt_libdir (COMPILER_RT_RESOLVED_LIBRARY_OUTPUT_DIR) has the
-# host triple as the trailing path component. Adjust config.compiler_rt_libdir
-# accordingly.
+# host triple as the trailing path component. The value is incorrect for i386
+# tests on x86_64 hosts and vice versa. But, since only x86_64 is enabled as
+# target, and we don't support different environments for building and,
+# respectively, running tests, we we only need to fix up the x86_64 case.
 if config.enable_per_target_runtime_dir and config.target_arch != config.host_arch:
     config.compiler_rt_libdir = re.sub(r'/i386(?=-[^/]+$)', '/x86_64', config.compiler_rt_libdir)

--- a/compiler-rt/test/ctx_profile/Unit/lit.site.cfg.py.in
+++ b/compiler-rt/test/ctx_profile/Unit/lit.site.cfg.py.in
@@ -21,7 +21,11 @@ config.test_source_root = config.test_exec_root
 # When LLVM_ENABLE_PER_TARGET_RUNTIME_DIR=on, the initial value of
 # config.compiler_rt_libdir (COMPILER_RT_RESOLVED_LIBRARY_OUTPUT_DIR) has the
 # host triple as the trailing path component. The value is incorrect for i386
-# tests on x86_64 hosts and vice versa. But, since only x86_64 is enabled as
-# target, and we don't support different environments for building and,
-# respectivelly, running tests, we shouldn't see this case.
-assert not config.enable_per_target_runtime_dir or config.target_arch == config.host_arch
+# tests on x86_64 hosts and vice versa. Adjust config.compiler_rt_libdir
+# accordingly.
+if config.enable_per_target_runtime_dir and config.target_arch != config.host_arch:
+    if config.target_arch == 'i386':
+        config.compiler_rt_libdir = re.sub(r'/x86_64(?=-[^/]+$)', '/i386', config.compiler_rt_libdir)
+    elif config.target_arch == 'x86_64':
+        config.compiler_rt_libdir = re.sub(r'/i386(?=-[^/]+$)', '/x86_64', config.compiler_rt_libdir)
+

--- a/compiler-rt/test/ctx_profile/Unit/lit.site.cfg.py.in
+++ b/compiler-rt/test/ctx_profile/Unit/lit.site.cfg.py.in
@@ -20,12 +20,7 @@ config.test_source_root = config.test_exec_root
 
 # When LLVM_ENABLE_PER_TARGET_RUNTIME_DIR=on, the initial value of
 # config.compiler_rt_libdir (COMPILER_RT_RESOLVED_LIBRARY_OUTPUT_DIR) has the
-# host triple as the trailing path component. The value is incorrect for i386
-# tests on x86_64 hosts and vice versa. Adjust config.compiler_rt_libdir
+# host triple as the trailing path component. Adjust config.compiler_rt_libdir
 # accordingly.
 if config.enable_per_target_runtime_dir and config.target_arch != config.host_arch:
-    if config.target_arch == 'i386':
-        config.compiler_rt_libdir = re.sub(r'/x86_64(?=-[^/]+$)', '/i386', config.compiler_rt_libdir)
-    elif config.target_arch == 'x86_64':
-        config.compiler_rt_libdir = re.sub(r'/i386(?=-[^/]+$)', '/x86_64', config.compiler_rt_libdir)
-
+    config.compiler_rt_libdir = re.sub(r'/i386(?=-[^/]+$)', '/x86_64', config.compiler_rt_libdir)

--- a/compiler-rt/test/memprof/Unit/lit.site.cfg.py.in
+++ b/compiler-rt/test/memprof/Unit/lit.site.cfg.py.in
@@ -20,8 +20,10 @@ config.test_source_root = config.test_exec_root
 
 # When LLVM_ENABLE_PER_TARGET_RUNTIME_DIR=on, the initial value of
 # config.compiler_rt_libdir (COMPILER_RT_RESOLVED_LIBRARY_OUTPUT_DIR) has the
-# host triple as the trailing path component. Adjust config.compiler_rt_libdir
-# accordingly.
+# host triple as the trailing path component. The value is incorrect for i386
+# tests on x86_64 hosts and vice versa. But, since only x86_64 is enabled as
+# target, and we don't support different environments for building and,
+# respectively, running tests, we we only need to fix up the x86_64 case.
 if config.enable_per_target_runtime_dir and config.target_arch != config.host_arch:
     config.compiler_rt_libdir = re.sub(r'/i386(?=-[^/]+$)', '/x86_64', config.compiler_rt_libdir)
 

--- a/compiler-rt/test/memprof/Unit/lit.site.cfg.py.in
+++ b/compiler-rt/test/memprof/Unit/lit.site.cfg.py.in
@@ -20,14 +20,10 @@ config.test_source_root = config.test_exec_root
 
 # When LLVM_ENABLE_PER_TARGET_RUNTIME_DIR=on, the initial value of
 # config.compiler_rt_libdir (COMPILER_RT_RESOLVED_LIBRARY_OUTPUT_DIR) has the
-# host triple as the trailing path component. The value is incorrect for i386
-# tests on x86_64 hosts and vice versa. Adjust config.compiler_rt_libdir
+# host triple as the trailing path component. Adjust config.compiler_rt_libdir
 # accordingly.
 if config.enable_per_target_runtime_dir and config.target_arch != config.host_arch:
-    if config.target_arch == 'i386':
-        config.compiler_rt_libdir = re.sub(r'/x86_64(?=-[^/]+$)', '/i386', config.compiler_rt_libdir)
-    elif config.target_arch == 'x86_64':
-        config.compiler_rt_libdir = re.sub(r'/i386(?=-[^/]+$)', '/x86_64', config.compiler_rt_libdir)
+    config.compiler_rt_libdir = re.sub(r'/i386(?=-[^/]+$)', '/x86_64', config.compiler_rt_libdir)
 
 if not config.parallelism_group:
   config.parallelism_group = 'shadow-memory'

--- a/compiler-rt/test/memprof/Unit/lit.site.cfg.py.in
+++ b/compiler-rt/test/memprof/Unit/lit.site.cfg.py.in
@@ -21,10 +21,13 @@ config.test_source_root = config.test_exec_root
 # When LLVM_ENABLE_PER_TARGET_RUNTIME_DIR=on, the initial value of
 # config.compiler_rt_libdir (COMPILER_RT_RESOLVED_LIBRARY_OUTPUT_DIR) has the
 # host triple as the trailing path component. The value is incorrect for i386
-# tests on x86_64 hosts and vice versa.  But, since only x86_64 is enabled as
-# target, and we don't support different environments for building and,
-# respectivelly, running tests, we shouldn't see this case.
-assert not config.enable_per_target_runtime_dir or config.target_arch == config.host_arch
+# tests on x86_64 hosts and vice versa. Adjust config.compiler_rt_libdir
+# accordingly.
+if config.enable_per_target_runtime_dir and config.target_arch != config.host_arch:
+    if config.target_arch == 'i386':
+        config.compiler_rt_libdir = re.sub(r'/x86_64(?=-[^/]+$)', '/i386', config.compiler_rt_libdir)
+    elif config.target_arch == 'x86_64':
+        config.compiler_rt_libdir = re.sub(r'/i386(?=-[^/]+$)', '/x86_64', config.compiler_rt_libdir)
 
 if not config.parallelism_group:
   config.parallelism_group = 'shadow-memory'


### PR DESCRIPTION
Previously, the memprof and ctx_profile lit.site.cfg would assert
if the enable_per_target_runtime_dir was set and the
config.target_arch != config.host_arch. However, config.host_arch would
never be set, meaning this would always fail in a when using
LLVM_ENABLE_PER_TARGET_RUNTIME_DIR.

This patch follows the example in the ASAN lit.site.cfg.py that updates
the compiler_rt_libdir appropriately.
