### PR TITLE
[Flang] Allow using common::visit with Clang

### DIFF
--- a/flang/include/flang/Common/visit.h
+++ b/flang/include/flang/Common/visit.h
@@ -82,7 +82,7 @@ inline RT_API_ATTRS auto visit(VISITOR &&visitor, VARIANT &&...u)
 // Some versions of clang have bugs that cause compilation to hang
 // on these templates.  MSVC and older GCC versions may work but are
 // not well tested.  So enable only for GCC 9 and better.
-#if __GNUC__ < 9
+#if __GNUC__ < 9 && !defined(__clang__)
 #define FLANG_USE_STD_VISIT
 #endif
 


### PR DESCRIPTION
Allow using common::visit with Clang.

Test plan: ninja check-all

P.S. would need to redo the measurements, but looks like it has improved the build time quite significantly