### PR TITLE
[lldb] Recognize DW_TAG_LLVM_ptrauth_type as a type qual

### DIFF
--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserClang.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserClang.cpp
@@ -495,6 +495,7 @@ TypeSP DWARFASTParserClang::ParseTypeFromDWARF(const SymbolContext &sc,
   case DW_TAG_const_type:
   case DW_TAG_restrict_type:
   case DW_TAG_volatile_type:
+  case DW_TAG_LLVM_ptrauth_type:
   case DW_TAG_atomic_type:
   case DW_TAG_unspecified_type: {
     type_sp = ParseTypeModifier(sc, die, attrs);


### PR DESCRIPTION
Jonas upstreamed recognition of DW_TAG_LLVM_ptrauth_type https://reviews.llvm.org/D130215 but it isn't recognized as a type qualifier tag in DWARFASTParserClang::ParseTypeFromDWARF.