### PR TITLE
[nfc][InstrFDO]Encapsulate header writes in a class member function

### DIFF
--- a/llvm/include/llvm/ProfileData/InstrProfWriter.h
+++ b/llvm/include/llvm/ProfileData/InstrProfWriter.h
@@ -222,9 +222,11 @@ private:
 
   // Writes known header fields and preserves space for fields whose value are
   // known only after payloads are written.
-  // Returns the number of bytes written and outputs the byte offset for back
-  // patching.
-  uint64_t writeHeader(ProfOStream &OS, HeaderFieldOffsets &Offsets);
+  // Returns the number of bytes written and records the start offset for back
+  // patching in `BackPatchStartOffset`.
+  size_t writeHeader(IndexedInstrProf::Header &header,
+                     const bool WritePrevVersion, ProfOStream &OS,
+                     size_t &BackPatchStartOffset);
 };
 
 } // end namespace llvm

--- a/llvm/include/llvm/ProfileData/InstrProfWriter.h
+++ b/llvm/include/llvm/ProfileData/InstrProfWriter.h
@@ -206,8 +206,8 @@ private:
   Error writeImpl(ProfOStream &OS);
 
   // Writes known header fields and reserves space for fields whose value are
-  // known only after payloads are written. Returns the number of bytes written
-  // and records the start offset for back patching in `BackPatchStartOffset`.
+  // known only after payloads are written. Returns the start byte offset for
+  // back patching.
   uint64_t writeHeader(const IndexedInstrProf::Header &header,
                        const bool WritePrevVersion, ProfOStream &OS);
 };

--- a/llvm/include/llvm/ProfileData/InstrProfWriter.h
+++ b/llvm/include/llvm/ProfileData/InstrProfWriter.h
@@ -197,21 +197,6 @@ public:
                      const OverlapFuncFilters &FuncFilter);
 
 private:
-  // A profile (with header and payloads) is written out in one pass; profile
-  // header records the byte offsets of individual payload sections.
-  // When the byte size of a payload section is not known before being written
-  // into the output stream, profile writer reserves space for the byte offset
-  // of this section to allow back patching at the specified offset later.
-  //
-  // This struct is produced by `InstrProfWriter::writeHeader` to store the byte
-  // offset of header fields, and used later for back patching.
-  struct HeaderFieldOffsets {
-    uint64_t HashTableStartFieldOffset;
-    uint64_t MemProfSectionOffset;
-    uint64_t BinaryIdSectionOffset;
-    uint64_t TemporalProfTracesOffset;
-    uint64_t VTableNamesOffset;
-  };
   void addRecord(StringRef Name, uint64_t Hash, InstrProfRecord &&I,
                  uint64_t Weight, function_ref<void(Error)> Warn);
   bool shouldEncodeData(const ProfilingData &PD);
@@ -221,9 +206,8 @@ private:
   Error writeImpl(ProfOStream &OS);
 
   // Writes known header fields and preserves space for fields whose value are
-  // known only after payloads are written.
-  // Returns the number of bytes written and records the start offset for back
-  // patching in `BackPatchStartOffset`.
+  // known only after payloads are written. Returns the number of bytes written
+  // and records the start offset for back patching in `BackPatchStartOffset`.
   size_t writeHeader(IndexedInstrProf::Header &header,
                      const bool WritePrevVersion, ProfOStream &OS,
                      size_t &BackPatchStartOffset);

--- a/llvm/include/llvm/ProfileData/InstrProfWriter.h
+++ b/llvm/include/llvm/ProfileData/InstrProfWriter.h
@@ -208,9 +208,8 @@ private:
   // Writes known header fields and preserves space for fields whose value are
   // known only after payloads are written. Returns the number of bytes written
   // and records the start offset for back patching in `BackPatchStartOffset`.
-  size_t writeHeader(IndexedInstrProf::Header &header,
-                     const bool WritePrevVersion, ProfOStream &OS,
-                     size_t &BackPatchStartOffset);
+  uint64_t writeHeader(const IndexedInstrProf::Header &header,
+                       const bool WritePrevVersion, ProfOStream &OS);
 };
 
 } // end namespace llvm

--- a/llvm/include/llvm/ProfileData/InstrProfWriter.h
+++ b/llvm/include/llvm/ProfileData/InstrProfWriter.h
@@ -205,7 +205,7 @@ private:
 
   Error writeImpl(ProfOStream &OS);
 
-  // Writes known header fields and preserves space for fields whose value are
+  // Writes known header fields and reserves space for fields whose value are
   // known only after payloads are written. Returns the number of bytes written
   // and records the start offset for back patching in `BackPatchStartOffset`.
   uint64_t writeHeader(const IndexedInstrProf::Header &header,

--- a/llvm/include/llvm/ProfileData/InstrProfWriter.h
+++ b/llvm/include/llvm/ProfileData/InstrProfWriter.h
@@ -197,6 +197,14 @@ public:
                      const OverlapFuncFilters &FuncFilter);
 
 private:
+  // A profile (with header and payloads) is written out in one pass; profile
+  // header records the byte offsets of individual payload sections.
+  // When the byte size of a payload section is not known before being written
+  // into the output stream, profile writer reserves space for the byte offset
+  // of this section to allow back patching at the specified offset later.
+  //
+  // This struct is produced by `InstrProfWriter::writeHeader` to store the byte
+  // offset of header fields, and used later for back patching.
   struct HeaderFieldOffsets {
     uint64_t HashTableStartFieldOffset;
     uint64_t MemProfSectionOffset;

--- a/llvm/include/llvm/ProfileData/InstrProfWriter.h
+++ b/llvm/include/llvm/ProfileData/InstrProfWriter.h
@@ -197,6 +197,13 @@ public:
                      const OverlapFuncFilters &FuncFilter);
 
 private:
+  struct HeaderFieldOffsets {
+    uint64_t HashTableStartFieldOffset;
+    uint64_t MemProfSectionOffset;
+    uint64_t BinaryIdSectionOffset;
+    uint64_t TemporalProfTracesOffset;
+    uint64_t VTableNamesOffset;
+  };
   void addRecord(StringRef Name, uint64_t Hash, InstrProfRecord &&I,
                  uint64_t Weight, function_ref<void(Error)> Warn);
   bool shouldEncodeData(const ProfilingData &PD);
@@ -204,6 +211,12 @@ private:
   void addTemporalProfileTrace(TemporalProfTraceTy Trace);
 
   Error writeImpl(ProfOStream &OS);
+
+  // Writes known header fields and preserves space for fields whose value are
+  // known only after payloads are written.
+  // Returns the number of bytes written and outputs the byte offset for back
+  // patching.
+  uint64_t writeHeader(ProfOStream &OS, HeaderFieldOffsets &Offsets);
 };
 
 } // end namespace llvm

--- a/llvm/lib/ProfileData/InstrProfWriter.cpp
+++ b/llvm/lib/ProfileData/InstrProfWriter.cpp
@@ -555,7 +555,7 @@ static Error writeMemProf(
 uint64_t InstrProfWriter::writeHeader(const IndexedInstrProf::Header &Header,
                                       const bool WritePrevVersion,
                                       ProfOStream &OS) {
-  // Records the offset before writing any fields.
+  // Record the offset before writing any fields.
   const uint64_t StartOffset = OS.tell();
   // Only write out the first four fields. We need to remember the offset of the
   // remaining fields to allow back patching later.

--- a/llvm/lib/ProfileData/InstrProfWriter.cpp
+++ b/llvm/lib/ProfileData/InstrProfWriter.cpp
@@ -557,11 +557,11 @@ uint64_t InstrProfWriter::writeHeader(const IndexedInstrProf::Header &Header,
                                       ProfOStream &OS) {
   // Record the offset before writing any fields.
   const uint64_t StartOffset = OS.tell();
-  // Only write out the first four fields. We need to remember the offset of the
-  // remaining fields to allow back patching later.
+  // Only write out the first four fields.
   for (int I = 0; I < 4; I++)
     OS.write(reinterpret_cast<const uint64_t *>(&Header)[I]);
 
+  // Remember the offset of the remaining fields to allow back patching later.
   auto BackPatchStartOffset = OS.tell();
 
   // Reserve the space for back patching later.

--- a/llvm/lib/ProfileData/InstrProfWriter.cpp
+++ b/llvm/lib/ProfileData/InstrProfWriter.cpp
@@ -555,8 +555,6 @@ static Error writeMemProf(
 uint64_t InstrProfWriter::writeHeader(const IndexedInstrProf::Header &Header,
                                       const bool WritePrevVersion,
                                       ProfOStream &OS) {
-  // Record the offset before writing any fields.
-  const uint64_t StartOffset = OS.tell();
   // Only write out the first four fields.
   for (int I = 0; I < 4; I++)
     OS.write(reinterpret_cast<const uint64_t *>(&Header)[I]);

--- a/llvm/lib/ProfileData/InstrProfWriter.cpp
+++ b/llvm/lib/ProfileData/InstrProfWriter.cpp
@@ -552,10 +552,61 @@ static Error writeMemProf(
               memprof::MaximumSupportedVersion));
 }
 
-uint64_t InstrProfWriter::writeHeader(ProfOStream &OS,
-                                      HeaderFieldOffsets &Offsets) {
+size_t InstrProfWriter::writeHeader(IndexedInstrProf::Header &Header,
+                                    const bool WritePrevVersion,
+                                    ProfOStream &OS,
+                                    size_t &BackPatchStartOffset) {
   // Records the offset before writing any fields.
   const uint64_t StartOffset = OS.tell();
+  // Only write out the first four fields. We need to remember the offset of the
+  // remaining fields to allow back patching later.
+  for (int I = 0; I < 4; I++)
+    OS.write(reinterpret_cast<uint64_t *>(&Header)[I]);
+
+  BackPatchStartOffset = OS.tell();
+
+  // Reserve the space for HashOffset field.
+  OS.write(0);
+
+  // Reserve space for the MemProf table field to be patched later if this
+  // profile contains memory profile information.
+  OS.write(0);
+
+  // Reserve space for the BinaryIdOffset field to be patched later if this
+  // profile contains binary ids.
+  OS.write(0);
+
+  // Reserve space for temporal profile traces for back patching later.
+  OS.write(0);
+
+  // Reserve space for vtable names for back patching later.
+  if (!WritePrevVersion)
+    OS.write(0);
+
+  // Returns the number of bytes written in the header section.
+  return OS.tell() - StartOffset;
+}
+
+Error InstrProfWriter::writeImpl(ProfOStream &OS) {
+  using namespace IndexedInstrProf;
+  using namespace support;
+
+  OnDiskChainedHashTableGenerator<InstrProfRecordWriterTrait> Generator;
+
+  InstrProfSummaryBuilder ISB(ProfileSummaryBuilder::DefaultCutoffs);
+  InfoObj->SummaryBuilder = &ISB;
+  InstrProfSummaryBuilder CSISB(ProfileSummaryBuilder::DefaultCutoffs);
+  InfoObj->CSSummaryBuilder = &CSISB;
+
+  // Populate the hash table generator.
+  SmallVector<std::pair<StringRef, const ProfilingData *>> OrderedData;
+  for (const auto &I : FunctionData)
+    if (shouldEncodeData(I.getValue()))
+      OrderedData.emplace_back((I.getKey()), &I.getValue());
+  llvm::sort(OrderedData, less_first());
+  for (const auto &I : OrderedData)
+    Generator.insert(I.first, I.second);
+
   // Write the header.
   IndexedInstrProf::Header Header;
   Header.Magic = IndexedInstrProf::Magic;
@@ -590,63 +641,8 @@ uint64_t InstrProfWriter::writeHeader(ProfOStream &OS,
   Header.TemporalProfTracesOffset = 0;
   Header.VTableNamesOffset = 0;
 
-  // Only write out the first four fields. We need to remember the offset of the
-  // remaining fields to allow back patching later.
-  for (int I = 0; I < 4; I++)
-    OS.write(reinterpret_cast<uint64_t *>(&Header)[I]);
-
-  // Save the location of Header.HashOffset field in \c OS.
-  Offsets.HashTableStartFieldOffset = OS.tell();
-  // Reserve the space for HashOffset field.
-  OS.write(0);
-
-  // Save the location of MemProf profile data. This is stored in two parts as
-  // the schema and as a separate on-disk chained hashtable.
-  Offsets.MemProfSectionOffset = OS.tell();
-  // Reserve space for the MemProf table field to be patched later if this
-  // profile contains memory profile information.
-  OS.write(0);
-
-  // Save the location of binary ids section.
-  Offsets.BinaryIdSectionOffset = OS.tell();
-  // Reserve space for the BinaryIdOffset field to be patched later if this
-  // profile contains binary ids.
-  OS.write(0);
-
-  Offsets.TemporalProfTracesOffset = OS.tell();
-  OS.write(0);
-
-  Offsets.VTableNamesOffset = OS.tell();
-  if (!WritePrevVersion)
-    OS.write(0);
-
-  return OS.tell() - StartOffset;
-}
-
-Error InstrProfWriter::writeImpl(ProfOStream &OS) {
-  HeaderFieldOffsets Offsets;
-
-  // FIXME: The return value will be used in a future patch.
-  (void)this->writeHeader(OS, Offsets);
-
-  using namespace IndexedInstrProf;
-  using namespace support;
-
-  OnDiskChainedHashTableGenerator<InstrProfRecordWriterTrait> Generator;
-
-  InstrProfSummaryBuilder ISB(ProfileSummaryBuilder::DefaultCutoffs);
-  InfoObj->SummaryBuilder = &ISB;
-  InstrProfSummaryBuilder CSISB(ProfileSummaryBuilder::DefaultCutoffs);
-  InfoObj->CSSummaryBuilder = &CSISB;
-
-  // Populate the hash table generator.
-  SmallVector<std::pair<StringRef, const ProfilingData *>> OrderedData;
-  for (const auto &I : FunctionData)
-    if (shouldEncodeData(I.getValue()))
-      OrderedData.emplace_back((I.getKey()), &I.getValue());
-  llvm::sort(OrderedData, less_first());
-  for (const auto &I : OrderedData)
-    Generator.insert(I.first, I.second);
+  size_t BackPatchStartOffset = 0;
+  this->writeHeader(Header, WritePrevVersion, OS, BackPatchStartOffset);
 
   // Reserve space to write profile summary data.
   uint32_t NumEntries = ProfileSummaryBuilder::DefaultCutoffs.size();
@@ -775,20 +771,29 @@ Error InstrProfWriter::writeImpl(ProfOStream &OS) {
   }
   InfoObj->CSSummaryBuilder = nullptr;
 
+  const size_t MemProfOffset =
+      BackPatchStartOffset + sizeof(IndexedInstrProf::Header::HashOffset);
+  const size_t BinaryIdOffset =
+      MemProfOffset + sizeof(IndexedInstrProf::Header::MemProfOffset);
+  const size_t TemporalProfTracesOffset =
+      BinaryIdOffset + sizeof(IndexedInstrProf::Header::BinaryIdOffset);
+  const size_t VTableNamesOffset =
+      TemporalProfTracesOffset +
+      sizeof(IndexedInstrProf::Header::TemporalProfTracesOffset);
   if (!WritePrevVersion) {
     // Now do the final patch:
     PatchItem PatchItems[] = {
         // Patch the Header.HashOffset field.
-        {Offsets.HashTableStartFieldOffset, &HashTableStart, 1},
+        {BackPatchStartOffset, &HashTableStart, 1},
         // Patch the Header.MemProfOffset (=0 for profiles without MemProf
         // data).
-        {Offsets.MemProfSectionOffset, &MemProfSectionStart, 1},
+        {MemProfOffset, &MemProfSectionStart, 1},
         // Patch the Header.BinaryIdSectionOffset.
-        {Offsets.BinaryIdSectionOffset, &BinaryIdSectionStart, 1},
+        {BinaryIdOffset, &BinaryIdSectionStart, 1},
         // Patch the Header.TemporalProfTracesOffset (=0 for profiles without
         // traces).
-        {Offsets.TemporalProfTracesOffset, &TemporalProfTracesSectionStart, 1},
-        {Offsets.VTableNamesOffset, &VTableNamesSectionStart, 1},
+        {TemporalProfTracesOffset, &TemporalProfTracesSectionStart, 1},
+        {VTableNamesOffset, &VTableNamesSectionStart, 1},
         // Patch the summary data.
         {SummaryOffset, reinterpret_cast<uint64_t *>(TheSummary.get()),
          (int)(SummarySize / sizeof(uint64_t))},
@@ -800,15 +805,15 @@ Error InstrProfWriter::writeImpl(ProfOStream &OS) {
     // Now do the final patch:
     PatchItem PatchItems[] = {
         // Patch the Header.HashOffset field.
-        {Offsets.HashTableStartFieldOffset, &HashTableStart, 1},
+        {BackPatchStartOffset, &HashTableStart, 1},
         // Patch the Header.MemProfOffset (=0 for profiles without MemProf
         // data).
-        {Offsets.MemProfSectionOffset, &MemProfSectionStart, 1},
+        {MemProfOffset, &MemProfSectionStart, 1},
         // Patch the Header.BinaryIdSectionOffset.
-        {Offsets.BinaryIdSectionOffset, &BinaryIdSectionStart, 1},
+        {BinaryIdOffset, &BinaryIdSectionStart, 1},
         // Patch the Header.TemporalProfTracesOffset (=0 for profiles without
         // traces).
-        {Offsets.TemporalProfTracesOffset, &TemporalProfTracesSectionStart, 1},
+        {TemporalProfTracesOffset, &TemporalProfTracesSectionStart, 1},
         // Patch the summary data.
         {SummaryOffset, reinterpret_cast<uint64_t *>(TheSummary.get()),
          (int)(SummarySize / sizeof(uint64_t))},

--- a/llvm/lib/ProfileData/InstrProfWriter.cpp
+++ b/llvm/lib/ProfileData/InstrProfWriter.cpp
@@ -624,6 +624,11 @@ uint64_t InstrProfWriter::writeHeader(ProfOStream &OS,
 }
 
 Error InstrProfWriter::writeImpl(ProfOStream &OS) {
+  HeaderFieldOffsets Offsets;
+
+  // FIXME: The return value will be used in a future patch.
+  (void)this->writeHeader(OS, Offsets);
+
   using namespace IndexedInstrProf;
   using namespace support;
 
@@ -635,17 +640,13 @@ Error InstrProfWriter::writeImpl(ProfOStream &OS) {
   InfoObj->CSSummaryBuilder = &CSISB;
 
   // Populate the hash table generator.
-  SmallVector<std::pair<StringRef, const ProfilingData *>, 0> OrderedData;
+  SmallVector<std::pair<StringRef, const ProfilingData *>> OrderedData;
   for (const auto &I : FunctionData)
     if (shouldEncodeData(I.getValue()))
       OrderedData.emplace_back((I.getKey()), &I.getValue());
   llvm::sort(OrderedData, less_first());
   for (const auto &I : OrderedData)
     Generator.insert(I.first, I.second);
-
-  HeaderFieldOffsets Offsets;
-
-  (void)this->writeHeader(OS, Offsets);
 
   // Reserve space to write profile summary data.
   uint32_t NumEntries = ProfileSummaryBuilder::DefaultCutoffs.size();

--- a/llvm/lib/ProfileData/InstrProfWriter.cpp
+++ b/llvm/lib/ProfileData/InstrProfWriter.cpp
@@ -645,7 +645,7 @@ Error InstrProfWriter::writeImpl(ProfOStream &OS) {
 
   HeaderFieldOffsets Offsets;
 
-  this->writeHeader(OS, Offsets);
+  (void)this->writeHeader(OS, Offsets);
 
   // Reserve space to write profile summary data.
   uint32_t NumEntries = ProfileSummaryBuilder::DefaultCutoffs.size();


### PR DESCRIPTION
The smaller class member are more focused and easier to maintain. This also paves the way for partial header forward compatibility in https://github.com/llvm/llvm-project/pull/88212