### PR TITLE
[RISCV] Check only demanded VTYPE fields in needVSETVLIPHI

### DIFF
--- a/llvm/test/CodeGen/RISCV/rvv/vsetvli-insert-crossbb.ll
+++ b/llvm/test/CodeGen/RISCV/rvv/vsetvli-insert-crossbb.ll
@@ -494,7 +494,6 @@ define void @saxpy_vec_demanded_fields(i64 %n, float %a, ptr nocapture readonly 
 ; CHECK-NEXT:    beqz a3, .LBB9_2
 ; CHECK-NEXT:  .LBB9_1: # %for.body
 ; CHECK-NEXT:    # =>This Inner Loop Header: Depth=1
-; CHECK-NEXT:    vsetvli zero, a3, e32, m8, ta, ma
 ; CHECK-NEXT:    vle32.v v8, (a1)
 ; CHECK-NEXT:    vle32.v v16, (a2)
 ; CHECK-NEXT:    slli a4, a3, 2


### PR DESCRIPTION
In needVSETVLIPHI we know that the VLs will be the same if the AVL is the output VL of another vsetvli and they have the same VLMAX, so we just check that the VTYPEs are the same. But we don't need to check all the fields if they're not demanded.

This allows us to avoid a vsetvli in some cases where e.g. the VLMAX ratio is the same .

(We still need the VLMAXes to be the same to make sure the VLs are the same, but we could potentially relax this to allow a smaller VLMAX where there's no risk of truncation)
