### PR TITLE
[Sema] Avoid an undesired pack expansion while transforming PackIndexingType

### DIFF
--- a/clang/lib/AST/ExprClassification.cpp
+++ b/clang/lib/AST/ExprClassification.cpp
@@ -217,7 +217,7 @@ static Cl::Kinds ClassifyInternal(ASTContext &Ctx, const Expr *E) {
                  cast<SubstNonTypeTemplateParmExpr>(E)->getReplacement());
 
   case Expr::PackIndexingExprClass: {
-    // A pack-index-expression always expand to an id-expression. 
+    // A pack-index-expression always expands to an id-expression. 
     // Consider it as an LValue expression.
     if (cast<PackIndexingExpr>(E)->isInstantiationDependent())
       return Cl::CL_LValue;

--- a/clang/lib/AST/ExprClassification.cpp
+++ b/clang/lib/AST/ExprClassification.cpp
@@ -217,9 +217,8 @@ static Cl::Kinds ClassifyInternal(ASTContext &Ctx, const Expr *E) {
                  cast<SubstNonTypeTemplateParmExpr>(E)->getReplacement());
 
   case Expr::PackIndexingExprClass: {
-    // A dependent pack-index-expression is now supposed to denote a function
-    // parameter pack, an NTTP pack, or the pack introduced by a structured
-    // binding. Consider it as an LValue expression.
+    // A pack-index-expression always expand to an id-expression. 
+    // Consider it as an LValue expression.
     if (cast<PackIndexingExpr>(E)->isInstantiationDependent())
       return Cl::CL_LValue;
     return ClassifyInternal(Ctx, cast<PackIndexingExpr>(E)->getSelectedExpr());

--- a/clang/lib/AST/ExprClassification.cpp
+++ b/clang/lib/AST/ExprClassification.cpp
@@ -217,7 +217,7 @@ static Cl::Kinds ClassifyInternal(ASTContext &Ctx, const Expr *E) {
                  cast<SubstNonTypeTemplateParmExpr>(E)->getReplacement());
 
   case Expr::PackIndexingExprClass: {
-    // A pack-index-expression always expands to an id-expression. 
+    // A pack-index-expression always expands to an id-expression.
     // Consider it as an LValue expression.
     if (cast<PackIndexingExpr>(E)->isInstantiationDependent())
       return Cl::CL_LValue;

--- a/clang/lib/AST/ExprClassification.cpp
+++ b/clang/lib/AST/ExprClassification.cpp
@@ -216,8 +216,14 @@ static Cl::Kinds ClassifyInternal(ASTContext &Ctx, const Expr *E) {
     return ClassifyInternal(Ctx,
                  cast<SubstNonTypeTemplateParmExpr>(E)->getReplacement());
 
-  case Expr::PackIndexingExprClass:
+  case Expr::PackIndexingExprClass: {
+    // A dependent pack-index-expression is now supposed to denote a function
+    // parameter pack, an NTTP pack, or the pack introduced by a structured
+    // binding. Consider it as an LValue expression.
+    if (cast<PackIndexingExpr>(E)->isInstantiationDependent())
+      return Cl::CL_LValue;
     return ClassifyInternal(Ctx, cast<PackIndexingExpr>(E)->getSelectedExpr());
+  }
 
     // C, C++98 [expr.sub]p1: The result is an lvalue of type "T".
     // C++11 (DR1213): in the case of an array operand, the result is an lvalue

--- a/clang/lib/Sema/TreeTransform.h
+++ b/clang/lib/Sema/TreeTransform.h
@@ -6649,6 +6649,9 @@ TreeTransform<Derived>::TransformPackIndexingType(TypeLocBuilder &TLB,
     }
   }
 
+  // We may be doing this in the context of expanding the Pattern. Forget that
+  // because it has been handled above.
+  Sema::ArgumentPackSubstitutionIndexRAII SubstIndex(getSema(), -1);
   QualType Result = getDerived().TransformType(TLB, TL.getPatternLoc());
 
   QualType Out = getDerived().RebuildPackIndexingType(

--- a/clang/lib/Sema/TreeTransform.h
+++ b/clang/lib/Sema/TreeTransform.h
@@ -6649,8 +6649,9 @@ TreeTransform<Derived>::TransformPackIndexingType(TypeLocBuilder &TLB,
     }
   }
 
-  // We may be doing this in the context of expanding the Pattern. Forget that
-  // because it has been handled above.
+  // A pack indexing type can appear in a larger pack expansion,
+  // e.g. `Pack...[pack_of_indexes]...`
+  // so we need to temporarily disable substitution of pack elements
   Sema::ArgumentPackSubstitutionIndexRAII SubstIndex(getSema(), -1);
   QualType Result = getDerived().TransformType(TLB, TL.getPatternLoc());
 

--- a/clang/test/SemaCXX/cxx2c-pack-indexing.cpp
+++ b/clang/test/SemaCXX/cxx2c-pack-indexing.cpp
@@ -160,3 +160,22 @@ namespace GH88929 {
     using E = P...[0]; // expected-error {{unknown type name 'P'}} \
                        // expected-error {{expected ';' after alias declaration}}
 }
+
+namespace GH88925 {
+template <typename...> struct S {};
+
+template <int...> struct sequence {};
+
+template <typename... Args, int... indices> auto f(sequence<indices...>) {
+  return S<Args...[indices]...>(); // #use
+}
+
+void g() {
+  static_assert(__is_same(decltype(f<int>(sequence<0, 0>())), S<int, int>));
+  static_assert(__is_same(decltype(f<int, long>(sequence<0, 0>())), S<int, int>));
+  static_assert(__is_same(decltype(f<int, long>(sequence<0, 1>())), S<int, long>));
+  f<int, long>(sequence<3>());
+  // expected-error@#use {{invalid index 3 for pack 'Args' of size 2}}}
+  // expected-note-re@-2 {{function template specialization '{{.*}}' requested here}}
+}
+}


### PR DESCRIPTION
 A pack indexing type can appear in a larger pack expansion, e.g `Pack...[pack_of_indexes]...` so we need to temporarily disable substitution of pack elements.

Besides, this patch also fixes an assertion failure in `PackIndexingExpr::classify`: dependent `PackIndexingExpr`s are always LValues and thus we don't need to consider their `IndexExpr`s.

Fixes https://github.com/llvm/llvm-project/issues/88925