### PR TITLE
[clang-tidy][NFC] Fix broken link in documentation of cert-env33-c

### DIFF
--- a/clang-tools-extra/docs/clang-tidy/checks/cert/env33-c.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/cert/env33-c.rst
@@ -10,4 +10,4 @@ but does not actually attempt to execute a command.
 
 This check corresponds to the CERT C Coding Standard rule
 `ENV33-C. Do not call system()
-<https://www.securecoding.cert.org/confluence/pages/viewpage.action?pageId=2130132>`_.
+<https://www.securecoding.cert.org/confluence/display/c/ENV33-C.+Do+not+call+system()>`_.


### PR DESCRIPTION
It seems that the description of the SEI CERT rules was moved from `www.securecoding.cert.org` to `wiki.sei.cmu.edu` and the page IDs were not preserved during the transition.

However, the old domain name redirects to the new one and permalinks derived from the name of the rule still work, so I kept using the old domain name to be consistent with other documentation files using it.