### PR TITLE
[llvm] Do not use Console API if the output isn't a console device

### DIFF
--- a/llvm/lib/Support/raw_ostream.cpp
+++ b/llvm/lib/Support/raw_ostream.cpp
@@ -645,6 +645,11 @@ raw_fd_ostream::raw_fd_ostream(int fd, bool shouldClose, bool unbuffered,
   // Check if this is a console device. This is not equivalent to isatty.
   IsWindowsConsole =
       ::GetFileType((HANDLE)::_get_osfhandle(fd)) == FILE_TYPE_CHAR;
+
+  // If this isn't a console device, don't try to use the API to set the color.
+  // Switch to ANSI escape codes instead.
+  if (!IsWindowsConsole)
+    llvm::sys::Process::UseANSIEscapeCodes(true);
 #endif
 
   // Get the starting position.


### PR DESCRIPTION
This fixes the `-fcolor-diagnostics` to properly enable color output when not outputting to console devices, such as when using Ninja.

This affects only Windows.