### PR TITLE
[flang] Fix CHECK() crash in module file generator

### DIFF
--- a/flang/lib/Semantics/mod-file.cpp
+++ b/flang/lib/Semantics/mod-file.cpp
@@ -202,7 +202,7 @@ static void HarvestInitializerSymbols(
           HarvestInitializerSymbols(set, *dtSym.scope());
         }
       } else {
-        CHECK(dtSym.has<UseErrorDetails>());
+        CHECK(dtSym.has<UseDetails>() || dtSym.has<UseErrorDetails>());
       }
     } else if (IsNamedConstant(*symbol) || scope.IsDerivedType()) {
       if (const auto *object{symbol->detailsIf<ObjectEntityDetails>()}) {


### PR DESCRIPTION
A sanity CHECK() in mod-file.cpp needs to allow for USE association of a derived type that has the same name as a locally defined generic interface.

Fixes https://github.com/llvm/llvm-project/issues/90192.