### PR TITLE
[clang] solve crash due to function overloading.

### DIFF
--- a/clang/lib/CodeGen/CodeGenModule.cpp
+++ b/clang/lib/CodeGen/CodeGenModule.cpp
@@ -5711,9 +5711,8 @@ static void replaceUsesOfNonProtoConstant(llvm::Constant *old,
   SmallVector<llvm::CallBase *> callSitesToBeRemovedFromParent;
 
   for (llvm::Value::use_iterator ui = old->use_begin(), ue = old->use_end();
-       ui != ue;) {
-    llvm::Value::use_iterator use = ui++; // Increment before the use is erased.
-    llvm::User *user = use->getUser();
+       ui != ue; ui++) {
+    llvm::User *user = ui->getUser();
 
     // Recognize and replace uses of bitcasts.  Most calls to
     // unprototyped functions will use bitcasts.
@@ -5727,7 +5726,7 @@ static void replaceUsesOfNonProtoConstant(llvm::Constant *old,
     llvm::CallBase *callSite = dyn_cast<llvm::CallBase>(user);
     if (!callSite)
       continue;
-    if (!callSite->isCallee(&*use))
+    if (!callSite->isCallee(&*ui))
       continue;
 
     // If the return types don't match exactly, then we can't

--- a/clang/lib/CodeGen/CodeGenModule.cpp
+++ b/clang/lib/CodeGen/CodeGenModule.cpp
@@ -5702,13 +5702,16 @@ CodeGenModule::getLLVMLinkageVarDefinition(const VarDecl *VD) {
 static void replaceUsesOfNonProtoConstant(llvm::Constant *old,
                                           llvm::Function *newFn) {
   // Fast path.
-  if (old->use_empty()) return;
+  if (old->use_empty())
+    return;
 
   llvm::Type *newRetTy = newFn->getReturnType();
-  SmallVector<llvm::Value*, 4> newArgs;
+  SmallVector<llvm::Value *, 4> newArgs;
+
+  SmallVector<llvm::CallBase *> callSitesToBeRemovedFromParent;
 
   for (llvm::Value::use_iterator ui = old->use_begin(), ue = old->use_end();
-         ui != ue; ) {
+       ui != ue;) {
     llvm::Value::use_iterator use = ui++; // Increment before the use is erased.
     llvm::User *user = use->getUser();
 
@@ -5722,7 +5725,8 @@ static void replaceUsesOfNonProtoConstant(llvm::Constant *old,
 
     // Recognize calls to the function.
     llvm::CallBase *callSite = dyn_cast<llvm::CallBase>(user);
-    if (!callSite) continue;
+    if (!callSite)
+      continue;
     if (!callSite->isCallee(&*use))
       continue;
 
@@ -5792,6 +5796,10 @@ static void replaceUsesOfNonProtoConstant(llvm::Constant *old,
     if (callSite->getDebugLoc())
       newCall->setDebugLoc(callSite->getDebugLoc());
 
+    callSitesToBeRemovedFromParent.push_back(callSite);
+  }
+
+  for (auto *callSite : callSitesToBeRemovedFromParent) {
     callSite->eraseFromParent();
   }
 }

--- a/clang/test/CodeGen/function_overload_crash.c
+++ b/clang/test/CodeGen/function_overload_crash.c
@@ -1,7 +1,0 @@
-// RUN: %clang_cc1 -emit-llvm < %s
-
-int b();
-int main() { return b(b); }
-int b(int (*f)()){
-  return 0;
-}

--- a/clang/test/CodeGen/function_overload_crash.c
+++ b/clang/test/CodeGen/function_overload_crash.c
@@ -1,0 +1,7 @@
+// RUN: %clang_cc1 -emit-llvm < %s
+
+int b();
+int main() { return b(b); }
+int b(int (*f)()){
+  return 0;
+}

--- a/clang/test/CodeGen/functions.c
+++ b/clang/test/CodeGen/functions.c
@@ -61,3 +61,15 @@ static void test9_helper(void) {}
 void test9(void) {
   (void) test9_helper;
 }
+
+// PR88917: don't crash
+int b();
+
+int main() {
+	return b(b);
+	// CHECK: call i32 @b(ptr noundef @b)
+}
+int b(int (*f)()){
+  return 0;
+}
+// CHECK-LABEL: define{{.*}} i32 @b(ptr noundef %f)


### PR DESCRIPTION
Closes #88917 

I am a newby in llvm development. 

I followed the suggestion for solving the issue. I added just a simple test to verify that the compilation does not crash.

Should the test not be good enough or any problems are found, please let me know, eager to learn :)