### PR TITLE
[RemoveDIs] Fix SIGSEGV caused by splitBasicBlock

### DIFF
--- a/llvm/lib/IR/BasicBlock.cpp
+++ b/llvm/lib/IR/BasicBlock.cpp
@@ -1009,9 +1009,9 @@ void BasicBlock::spliceDebugInfoImpl(BasicBlock::iterator Dest, BasicBlock *Src,
     // generate the iterator with begin() / getFirstInsertionPt(), it means
     // any trailing debug-info at the end of the block would "normally" have
     // been pushed in front of "First". Move it there now.
-    DbgMarker *FirstMarker = getMarker(First);
     DbgMarker *TrailingDbgRecords = getTrailingDbgRecords();
     if (TrailingDbgRecords) {
+      DbgMarker *FirstMarker = createMarker(First);
       FirstMarker->absorbDebugValues(*TrailingDbgRecords, true);
       TrailingDbgRecords->eraseFromParent();
       deleteTrailingDbgRecords();


### PR DESCRIPTION
See `llvm/unittests/IR/BasicBlockDbgInfoTest.cpp` for a test case.

The SIGSEGV is like below:

```
 #0 0x0000000000d5142b llvm::sys::PrintStackTrace(llvm::raw_ostream&, int) (/media/d/work/learn-riscv/llvm-project/build-r/unittests/IR/./IRTests+0xd5142b)
 #1 0x0000000000d4f10b SignalHandler(int) Signals.cpp:0:0
 #2 0x00007f2eb3a5c9a0 __restore_rt (/lib64/libc.so.6+0x3e9a0)
 #3 0x0000000000b863b8 llvm::DbgMarker::absorbDebugValues(llvm::DbgMarker&, bool) (/media/d/work/learn-riscv/llvm-project/build-r/unittests/IR/./IRTests+0xb863b8)
 #4 0x0000000000b031cc llvm::BasicBlock::spliceDebugInfoImpl(llvm::ilist_iterator_w_bits<llvm::ilist_detail::node_options<llvm::Instruction, false, false, void, true>, false, false>, llvm::BasicBlock*, llvm::ilist_iterator_w_bits<llvm::ilist_detail::node_options<llvm::Instruction, false, false, void, true>, false, false>, llvm::ilist_iterator_w_bits<llvm::ilist_detail::node_options<llvm::Instruction, false, false, void, true>, false, false>) (/media/d/work/learn-riscv/llvm-project/build-r/unittests/IR/./IRTests+0xb031cc)
 #5 0x0000000000b03e37 llvm::BasicBlock::splice(llvm::ilist_iterator_w_bits<llvm::ilist_detail::node_options<llvm::Instruction, false, false, void, true>, false, false>, llvm::BasicBlock*, llvm::ilist_iterator_w_bits<llvm::ilist_detail::node_options<llvm::Instruction, false, false, void, true>, false, false>, llvm::ilist_iterator_w_bits<llvm::ilist_detail::node_options<llvm::Instruction, false, false, void, true>, false, false>) (/media/d/work/learn-riscv/llvm-project/build-r/unittests/IR/./IRTests+0xb03e37)
 #6 0x0000000000b04495 llvm::BasicBlock::splitBasicBlockBefore(llvm::ilist_iterator_w_bits<llvm::ilist_detail::node_options<llvm::Instruction, false, false, void, true>, false, false>, llvm::Twine const&) (/media/d/work/learn-riscv/llvm-project/build-r/unittests/IR/./IRTests+0xb04495)
 #7 0x000000000050e257 (anonymous namespace)::BasicBlockDbgInfoTest_SplitBasicBlockBefore_Test::TestBody() BasicBlockDbgInfoTest.cpp:0:0
 #8 0x0000000001231c23 testing::Test::Run() (.part.0) gtest-all.cc:0:0
 #9 0x0000000001236a2a testing::TestInfo::Run() (/media/d/work/learn-riscv/llvm-project/build-r/unittests/IR/./IRTests+0x1236a2a)
#10 0x000000000123705c testing::TestSuite::Run() (.part.0) gtest-all.cc:0:0
#11 0x000000000123dff0 testing::internal::UnitTestImpl::RunAllTests() (/media/d/work/learn-riscv/llvm-project/build-r/unittests/IR/./IRTests+0x123dff0)
#12 0x000000000123136e testing::UnitTest::Run() (/media/d/work/learn-riscv/llvm-project/build-r/unittests/IR/./IRTests+0x123136e)
#13 0x000000000048bd76 main (/media/d/work/learn-riscv/llvm-project/build-r/unittests/IR/./IRTests+0x48bd76)
#14 0x00007f2eb3a4614a __libc_start_call_main (/lib64/libc.so.6+0x2814a)
#15 0x00007f2eb3a4620b __libc_start_main@GLIBC_2.2.5 (/lib64/libc.so.6+0x2820b)
#16 0x00000000004e9745 _start (/media/d/work/learn-riscv/llvm-project/build-r/unittests/IR/./IRTests+0x4e9745)
```