### PR TITLE
Use zlib cmake target rather than variables

### DIFF
--- a/llvm/cmake/config-ix.cmake
+++ b/llvm/cmake/config-ix.cmake
@@ -137,7 +137,7 @@ if(LLVM_ENABLE_ZLIB)
     # library on a 64-bit system which would result in a link-time failure.
     cmake_push_check_state()
     list(APPEND CMAKE_REQUIRED_INCLUDES ${ZLIB_INCLUDE_DIRS})
-    list(APPEND CMAKE_REQUIRED_LIBRARIES ${ZLIB_LIBRARY})
+    list(APPEND CMAKE_REQUIRED_LIBRARIES ZLIB::ZLIB)
     check_symbol_exists(compress2 zlib.h HAVE_ZLIB)
     cmake_pop_check_state()
     if(LLVM_ENABLE_ZLIB STREQUAL FORCE_ON AND NOT HAVE_ZLIB)

--- a/llvm/lib/Support/CMakeLists.txt
+++ b/llvm/lib/Support/CMakeLists.txt
@@ -300,16 +300,7 @@ set(llvm_system_libs ${system_libs})
 # This block is only needed for llvm-config. When we deprecate llvm-config and
 # move to using CMake export, this block can be removed.
 if(LLVM_ENABLE_ZLIB)
-  # CMAKE_BUILD_TYPE is only meaningful to single-configuration generators.
-  if(CMAKE_BUILD_TYPE)
-    string(TOUPPER ${CMAKE_BUILD_TYPE} build_type)
-    get_property(zlib_library TARGET ZLIB::ZLIB PROPERTY LOCATION_${build_type})
-  endif()
-  if(NOT zlib_library)
-    get_property(zlib_library TARGET ZLIB::ZLIB PROPERTY LOCATION)
-  endif()
-  get_library_name(${zlib_library} zlib_library)
-  set(llvm_system_libs ${llvm_system_libs} "${zlib_library}")
+  list(APPEND llvm_system_libs ZLIB::ZLIB)
 endif()
 
 if(LLVM_ENABLE_ZSTD)


### PR DESCRIPTION
Use `ZLIB::ZLIB` target rather than the library variables. This enables zlib to be provided by the conan package manager as an alternative to the system library.