### PR TITLE
[clang] Fix `remove{CVR|Fast}Qualifiers` with 64-bit `Qualifiers::Mask`

### DIFF
--- a/clang/include/clang/AST/Type.h
+++ b/clang/include/clang/AST/Type.h
@@ -480,7 +480,7 @@ public:
   }
   void removeCVRQualifiers(unsigned mask) {
     assert(!(mask & ~CVRMask) && "bitmask contains non-CVR bits");
-    Mask &= ~mask;
+    Mask &= ~static_cast<uint64_t>(mask);
   }
   void removeCVRQualifiers() {
     removeCVRQualifiers(CVRMask);
@@ -609,7 +609,7 @@ public:
   }
   void removeFastQualifiers(unsigned mask) {
     assert(!(mask & ~FastMask) && "bitmask contains non-fast qualifier bits");
-    Mask &= ~mask;
+    Mask &= ~static_cast<uint64_t>(mask);
   }
   void removeFastQualifiers() {
     removeFastQualifiers(FastMask);


### PR DESCRIPTION
After #84384, `Qualifiers::Mask` becomes 64-bit. So, operations like `Mask &= ~U32` where `U32` is `unsigned` produce undesirable results since higher 32 bits of `Mask` become zeroed while they should be preserved. Fix that by explicitly casting `unsigned` values to `uint64_t` in such operations. Signatures of fixed functions are intentionally left intact instead of changing the argument itself to `uint64_t` to keep things consistent with other functions working with the same qualifiers and to emphasize that 64-bit masks should not be used for these types of qualifiers.