### PR TITLE
[llvm-install-name-tool] Error on non-Mach-O binaries

### DIFF
--- a/llvm/test/tools/llvm-objcopy/MachO/install-name-tool.test
+++ b/llvm/test/tools/llvm-objcopy/MachO/install-name-tool.test
@@ -1,0 +1,26 @@
+## This test checks general llvm-install-name-tool behavior
+
+# RUN: yaml2obj %s -o %t
+
+## Passing a non-Mach-O binary
+# RUN: not llvm-install-name-tool -add_rpath foo %t 2>&1 | FileCheck %s --check-prefix=NON_MACH_O
+
+# NON_MACH_O: llvm-install-name-tool: error: input file: {{.*}} is not a Mach-O file
+
+--- !ELF
+FileHeader:
+  Class:           ELFCLASS64
+  Data:            ELFDATA2LSB
+  Type:            ET_EXEC
+  Machine:         EM_X86_64
+Sections:
+  - Name:            .bss
+    Type:            SHT_NOBITS
+    Flags:           [ SHF_ALLOC ]
+    AddressAlign:    0x0000000000000010
+    Size:            64
+  - Name:            .text
+    Type:            SHT_PROGBITS
+    Flags:           [ SHF_ALLOC, SHF_EXECINSTR ]
+    AddressAlign:    0x0000000000000010
+    Content:         "00000000"

--- a/llvm/test/tools/llvm-objcopy/MachO/install-name-tool.test
+++ b/llvm/test/tools/llvm-objcopy/MachO/install-name-tool.test
@@ -10,7 +10,7 @@
 ## Passing a non-Mach-O binary
 # RUN: not llvm-install-name-tool -add_rpath foo %t 2>&1 | FileCheck %s --check-prefix=NON_MACH_O -DFILE=%t
 
-# NON_MACH_O: llvm-install-name-tool: error: input file: [[FILE]] is not a Mach-O file
+# NON_MACH_O: error: input file: [[FILE]] is not a Mach-O file
 
 --- !ELF
 FileHeader:

--- a/llvm/test/tools/llvm-objcopy/MachO/install-name-tool.test
+++ b/llvm/test/tools/llvm-objcopy/MachO/install-name-tool.test
@@ -1,26 +1,19 @@
-## This test checks general llvm-install-name-tool behavior
+## This test checks general llvm-install-name-tool behavior.
 
 # RUN: yaml2obj %s -o %t
 
-## Passing a non-Mach-O binary
-# RUN: not llvm-install-name-tool -add_rpath foo %t 2>&1 | FileCheck %s --check-prefix=NON_MACH_O
+## Passing something that doesn't exist
+# RUN: not llvm-install-name-tool -add_rpath foo non-existent-binary 2>&1 | FileCheck %s --check-prefix=DOES_NOT_EXIST
 
-# NON_MACH_O: llvm-install-name-tool: error: input file: {{.*}} is not a Mach-O file
+# DOES_NOT_EXIST: {{.*}}non-existent-binary
+
+## Passing a non-Mach-O binary
+# RUN: not llvm-install-name-tool -add_rpath foo %t 2>&1 | FileCheck %s --check-prefix=NON_MACH_O -DFILE=%t
+
+# NON_MACH_O: llvm-install-name-tool: error: input file: [[FILE]] is not a Mach-O file
 
 --- !ELF
 FileHeader:
   Class:           ELFCLASS64
   Data:            ELFDATA2LSB
   Type:            ET_EXEC
-  Machine:         EM_X86_64
-Sections:
-  - Name:            .bss
-    Type:            SHT_NOBITS
-    Flags:           [ SHF_ALLOC ]
-    AddressAlign:    0x0000000000000010
-    Size:            64
-  - Name:            .text
-    Type:            SHT_PROGBITS
-    Flags:           [ SHF_ALLOC, SHF_EXECINSTR ]
-    AddressAlign:    0x0000000000000010
-    Content:         "00000000"

--- a/llvm/tools/llvm-objcopy/ObjcopyOptions.cpp
+++ b/llvm/tools/llvm-objcopy/ObjcopyOptions.cpp
@@ -15,6 +15,7 @@
 #include "llvm/ObjCopy/CommonConfig.h"
 #include "llvm/ObjCopy/ConfigManager.h"
 #include "llvm/ObjCopy/MachO/MachOConfig.h"
+#include "llvm/Object/Binary.h"
 #include "llvm/Option/Arg.h"
 #include "llvm/Option/ArgList.h"
 #include "llvm/Support/CRC.h"
@@ -1241,6 +1242,16 @@ objcopy::parseInstallNameToolOptions(ArrayRef<const char *> ArgsArr) {
         "llvm-install-name-tool expects a single input file");
   Config.InputFilename = Positional[0];
   Config.OutputFilename = Positional[0];
+
+  Expected<llvm::object::OwningBinary<llvm::object::Binary>> BinaryOrErr =
+      llvm::object::createBinary(Config.InputFilename);
+  if (!BinaryOrErr)
+    return createFileError(Config.InputFilename, BinaryOrErr.takeError());
+  auto *Binary = (*BinaryOrErr).getBinary();
+  if (!Binary->isMachO() && !Binary->isMachOUniversalBinary())
+    return createStringError(errc::invalid_argument,
+                             "input file: %s is not a Mach-O file",
+                             Config.InputFilename.str().c_str());
 
   DC.CopyConfigs.push_back(std::move(ConfigMgr));
   return std::move(DC);

--- a/llvm/tools/llvm-objcopy/ObjcopyOptions.cpp
+++ b/llvm/tools/llvm-objcopy/ObjcopyOptions.cpp
@@ -27,6 +27,7 @@
 
 using namespace llvm;
 using namespace llvm::objcopy;
+using namespace llvm::object;
 using namespace llvm::opt;
 
 namespace {
@@ -1243,8 +1244,8 @@ objcopy::parseInstallNameToolOptions(ArrayRef<const char *> ArgsArr) {
   Config.InputFilename = Positional[0];
   Config.OutputFilename = Positional[0];
 
-  Expected<llvm::object::OwningBinary<llvm::object::Binary>> BinaryOrErr =
-      llvm::object::createBinary(Config.InputFilename);
+  Expected<OwningBinary<Binary>> BinaryOrErr =
+      createBinary(Config.InputFilename);
   if (!BinaryOrErr)
     return createFileError(Config.InputFilename, BinaryOrErr.takeError());
   auto *Binary = (*BinaryOrErr).getBinary();


### PR DESCRIPTION
Previously if you passed an ELF binary it would be silently copied with no changes.