### PR TITLE
[lto pipeline] Add flag to skip module optimization passes in the prelink lto pipeline

### DIFF
--- a/llvm/lib/Passes/PassBuilderPipelines.cpp
+++ b/llvm/lib/Passes/PassBuilderPipelines.cpp
@@ -298,6 +298,11 @@ static cl::opt<bool> UseLoopVersioningLICM(
     "enable-loop-versioning-licm", cl::init(false), cl::Hidden,
     cl::desc("Enable the experimental Loop Versioning LICM pass"));
 
+static cl::opt<bool> DisableFullLTOPrelinkOptimization(
+    "disable-full-lto-prelink-optimization", cl::init(false), cl::Hidden,
+    cl::desc("Disable the module optimization pipeline for the FullLTO prelink "
+             "pipeline"));
+
 namespace llvm {
 extern cl::opt<bool> EnableMemProfContextDisambiguation;
 
@@ -1553,7 +1558,9 @@ PassBuilder::buildPerModuleDefaultPipeline(OptimizationLevel Level,
   MPM.addPass(buildModuleSimplificationPipeline(Level, LTOPhase));
 
   // Now add the optimization pipeline.
-  MPM.addPass(buildModuleOptimizationPipeline(Level, LTOPhase));
+  if (LTOPhase != ThinOrFullLTOPhase::FullLTOPreLink ||
+      !DisableFullLTOPrelinkOptimization)
+    MPM.addPass(buildModuleOptimizationPipeline(Level, LTOPhase));
 
   if (PGOOpt && PGOOpt->PseudoProbeForProfiling &&
       PGOOpt->Action == PGOOptions::SampleUse)


### PR DESCRIPTION
As Nikita Popov calls out in
https://www.npopov.com/2023/04/07/LLVM-middle-end-pipeline.html#the-lto-pipelines,
the FullLTO prelink pipeline is pretty suboptimal. The fact that it runs
optimization passes before the LTO pipeline causes it to degrade
the effectiveness of simplification passes during LTO. I've measured
size improvements from `Oz` builds from toggling this flag on.

Add an option to remove that here. In reality, we could probably just
enable this always, but there's often push back to churn to potentially
invasive changes. So just add a flag for now.
