### PR TITLE
Add thread-local overrides for `llvm::errs()` and `llvm::outs()`.

### DIFF
--- a/llvm/include/llvm/Support/raw_ostream.h
+++ b/llvm/include/llvm/Support/raw_ostream.h
@@ -618,6 +618,30 @@ raw_fd_ostream &errs();
 /// This returns a reference to a raw_ostream which simply discards output.
 raw_ostream &nulls();
 
+/// Scoped thread-local override of `outs` and `errs`.
+///
+/// This can be used by libraries using LLVM that want to control where output
+/// is sent. While some systems explicitly accept a stream in their API, others
+/// directly use these and so we provide a scoped override as a fallback.
+///
+/// Note that these overrides rely on thread-local override, and so much be
+/// carefully instantiated on each thread where the override should be applied.
+class ScopedOutsAndErrsOverride {
+public:
+  // Install overrides for `outs` and `errs`. If the new stream is a null
+  // pointer it will cause that stream to use the system one as if no override
+  // is in place.
+  ScopedOutsAndErrsOverride(raw_fd_ostream *NewOuts, raw_fd_ostream *NewErrs);
+
+  // Restore any previous overrides when destroyed so that these overrides can
+  // be nested.
+  ~ScopedOutsAndErrsOverride();
+
+private:
+  raw_fd_ostream *PrevOuts;
+  raw_fd_ostream *PrevErrs;
+};
+
 //===----------------------------------------------------------------------===//
 // File Streams
 //===----------------------------------------------------------------------===//

--- a/llvm/include/llvm/Support/raw_ostream.h
+++ b/llvm/include/llvm/Support/raw_ostream.h
@@ -637,6 +637,11 @@ public:
   // be nested.
   ~ScopedOutsAndErrsOverride();
 
+  // Extract any current overrides. This is mostly useful for propagating one
+  // thread's overrides to another thread. The `outs` override is first and the
+  // `errs` second.
+  static std::pair<raw_fd_ostream *, raw_fd_ostream *> getActiveOverrides();
+
 private:
   raw_fd_ostream *PrevOuts;
   raw_fd_ostream *PrevErrs;

--- a/llvm/lib/Support/CrashRecoveryContext.cpp
+++ b/llvm/lib/Support/CrashRecoveryContext.cpp
@@ -518,7 +518,8 @@ static void RunSafelyOnThread_Dispatch(void *UserData) {
 bool CrashRecoveryContext::RunSafelyOnThread(function_ref<void()> Fn,
                                              unsigned RequestedStackSize) {
   bool UseBackgroundPriority = hasThreadBackgroundPriority();
-  auto [OutsOverride, ErrsOverride] = ScopedOutsAndErrsOverride::getActiveOverrides();
+  auto [OutsOverride, ErrsOverride] =
+      ScopedOutsAndErrsOverride::getActiveOverrides();
   RunSafelyOnThreadInfo Info = {
       Fn, this, OutsOverride, ErrsOverride, UseBackgroundPriority, false};
   llvm::thread Thread(RequestedStackSize == 0

--- a/llvm/lib/Support/CrashRecoveryContext.cpp
+++ b/llvm/lib/Support/CrashRecoveryContext.cpp
@@ -11,6 +11,7 @@
 #include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/ExitCodes.h"
 #include "llvm/Support/Signals.h"
+#include "llvm/Support/raw_ostream.h"
 #include "llvm/Support/thread.h"
 #include <cassert>
 #include <mutex>
@@ -495,6 +496,8 @@ namespace {
 struct RunSafelyOnThreadInfo {
   function_ref<void()> Fn;
   CrashRecoveryContext *CRC;
+  raw_fd_ostream *OutsOverride;
+  raw_fd_ostream *ErrsOverride;
   bool UseBackgroundPriority;
   bool Result;
 };
@@ -507,12 +510,17 @@ static void RunSafelyOnThread_Dispatch(void *UserData) {
   if (Info->UseBackgroundPriority)
     setThreadBackgroundPriority();
 
+  ScopedOutsAndErrsOverride StreamOverrides(Info->OutsOverride,
+                                            Info->ErrsOverride);
+
   Info->Result = Info->CRC->RunSafely(Info->Fn);
 }
 bool CrashRecoveryContext::RunSafelyOnThread(function_ref<void()> Fn,
                                              unsigned RequestedStackSize) {
   bool UseBackgroundPriority = hasThreadBackgroundPriority();
-  RunSafelyOnThreadInfo Info = { Fn, this, UseBackgroundPriority, false };
+  auto [OutsOverride, ErrsOverride] = ScopedOutsAndErrsOverride::getActiveOverrides();
+  RunSafelyOnThreadInfo Info = {
+      Fn, this, OutsOverride, ErrsOverride, UseBackgroundPriority, false};
   llvm::thread Thread(RequestedStackSize == 0
                           ? std::nullopt
                           : std::optional<unsigned>(RequestedStackSize),

--- a/llvm/lib/Support/raw_ostream.cpp
+++ b/llvm/lib/Support/raw_ostream.cpp
@@ -915,11 +915,11 @@ raw_fd_ostream &llvm::errs() {
   if (auto *TLSErrs = OutsOverride; TLSErrs != nullptr)
     return *TLSErrs;
 
-  // Set standard error to be unbuffered and tied to outs() by default.
 #ifdef __MVS__
   std::error_code EC = enableAutoConversion(STDERR_FILENO);
   assert(!EC);
 #endif
+  // Set standard error to be unbuffered and tied to stderr by default.
   static raw_fd_ostream S(STDERR_FILENO, false, true);
   return S;
 }

--- a/llvm/lib/Support/raw_ostream.cpp
+++ b/llvm/lib/Support/raw_ostream.cpp
@@ -897,9 +897,8 @@ static thread_local raw_fd_ostream *OutsOverride = nullptr;
 static thread_local raw_fd_ostream *ErrsOverride = nullptr;
 
 raw_fd_ostream &llvm::outs() {
-  if (auto *TLSOuts = OutsOverride; TLSOuts != nullptr) {
+  if (auto *TLSOuts = OutsOverride; TLSOuts != nullptr)
     return *TLSOuts;
-  }
 
   // Set buffer settings to model stdout behavior.
   std::error_code EC;
@@ -913,9 +912,8 @@ raw_fd_ostream &llvm::outs() {
 }
 
 raw_fd_ostream &llvm::errs() {
-  if (auto *TLSErrs = OutsOverride; TLSErrs != nullptr) {
+  if (auto *TLSErrs = OutsOverride; TLSErrs != nullptr)
     return *TLSErrs;
-  }
 
   // Set standard error to be unbuffered and tied to outs() by default.
 #ifdef __MVS__
@@ -942,6 +940,11 @@ ScopedOutsAndErrsOverride::ScopedOutsAndErrsOverride(raw_fd_ostream *NewOuts,
 ScopedOutsAndErrsOverride::~ScopedOutsAndErrsOverride() {
   OutsOverride = PrevOuts;
   ErrsOverride = PrevErrs;
+}
+
+std::pair<raw_fd_ostream *, raw_fd_ostream *>
+ScopedOutsAndErrsOverride::getActiveOverrides() {
+  return {OutsOverride, ErrsOverride};
 }
 
 //===----------------------------------------------------------------------===//

--- a/llvm/lib/Support/raw_ostream.cpp
+++ b/llvm/lib/Support/raw_ostream.cpp
@@ -893,8 +893,8 @@ void raw_fd_ostream::anchor() {}
 //  outs(), errs(), nulls()
 //===----------------------------------------------------------------------===//
 
-static thread_local raw_fd_ostream *OutsOverride = nullptr;
-static thread_local raw_fd_ostream *ErrsOverride = nullptr;
+static LLVM_THREAD_LOCAL raw_fd_ostream *OutsOverride = nullptr;
+static LLVM_THREAD_LOCAL raw_fd_ostream *ErrsOverride = nullptr;
 
 raw_fd_ostream &llvm::outs() {
   if (auto *TLSOuts = OutsOverride; TLSOuts != nullptr)


### PR DESCRIPTION
This allows library users of LLVM to intercept these streams and control where they write. While some components of LLVM already accept stream parameters to control this, not all do and so it seems useful to add this as a fallback. The motivating case is the verbose output in Clang's Driver library.