### PR TITLE
[MLIR][JitRunner] Correctly register symbol map

### DIFF
--- a/mlir/lib/ExecutionEngine/JitRunner.cpp
+++ b/mlir/lib/ExecutionEngine/JitRunner.cpp
@@ -201,6 +201,8 @@ compileAndExecute(Options &options, Operation *module, StringRef entryPoint,
     return expectedEngine.takeError();
 
   auto engine = std::move(*expectedEngine);
+  if (config.runtimeSymbolMap)
+    engine->registerSymbols(config.runtimeSymbolMap);
 
   auto expectedFPtr = engine->lookupPacked(entryPoint);
   if (!expectedFPtr)

--- a/mlir/unittests/ExecutionEngine/CMakeLists.txt
+++ b/mlir/unittests/ExecutionEngine/CMakeLists.txt
@@ -11,6 +11,7 @@ target_link_libraries(MLIRExecutionEngineTests
   MLIRExecutionEngine
   MLIRMemRefToLLVM
   MLIRReconcileUnrealizedCasts
+  MLIRJitRunner
   ${dialect_libs}
 
 )


### PR DESCRIPTION
Fixed an issue of JitRunner, which ignores the runtimeSymbolMap passed by the user. Added the code to call `registerSymbols` on the ExecutionEngine.