### PR TITLE
[CMake] Do not set CMP0114 explicitly to old

### DIFF
--- a/cmake/Modules/CMakePolicy.cmake
+++ b/cmake/Modules/CMakePolicy.cmake
@@ -1,10 +1,5 @@
 # CMake policy settings shared between LLVM projects
 
-# CMP0114: ExternalProject step targets fully adopt their steps.
-# New in CMake 3.19: https://cmake.org/cmake/help/latest/policy/CMP0114.html
-if(POLICY CMP0114)
-  cmake_policy(SET CMP0114 OLD)
-endif()
 # CMP0116: Ninja generators transform `DEPFILE`s from `add_custom_command()`
 # New in CMake 3.20. https://cmake.org/cmake/help/latest/policy/CMP0116.html
 if(POLICY CMP0116)


### PR DESCRIPTION
CMP0114 was originally set to old to get rid of warnings. However, this behavior is now set to new by default with the minimum CMake version that LLVM requires so does not produce any warnings, and setting it explicitly to old does produce a warning in newer CMake versions. Due to these reasons, remove this check for now.

Splitting off from removing the CMP0116 check just in case something breaks.

Partially fixes #83727.