### PR TITLE
[compiler-rt][CMake] Do not explicitly set CMP0114 to old

### DIFF
--- a/compiler-rt/cmake/Modules/AddCompilerRT.cmake
+++ b/compiler-rt/cmake/Modules/AddCompilerRT.cmake
@@ -2,12 +2,6 @@ include(ExternalProject)
 include(CompilerRTUtils)
 include(HandleCompilerRT)
 
-# CMP0114: ExternalProject step targets fully adopt their steps.
-# New in CMake 3.19: https://cmake.org/cmake/help/latest/policy/CMP0114.html
-if(POLICY CMP0114)
-  cmake_policy(SET CMP0114 OLD)
-endif()
-
 function(set_target_output_directories target output_dir)
   # For RUNTIME_OUTPUT_DIRECTORY variable, Multi-configuration generators
   # append a per-configuration subdirectory to the specified directory.


### PR DESCRIPTION
This was added in def0823f1d2db78c4a18b15084407734a45e96c5 to fix a bot failure, specifically for the standalone build. This does not seem to be an issue anymore, and setting the policy explicitly to OLD causes warnings with newer CMake versions.

This patch removes setting the policy to OLD to get rid of the warning.