### PR TITLE
[PDLL] Add MLIRPDLLParser library to mlir install.

### DIFF
--- a/mlir/lib/Tools/PDLL/Parser/CMakeLists.txt
+++ b/mlir/lib/Tools/PDLL/Parser/CMakeLists.txt
@@ -15,3 +15,7 @@ llvm_add_library(MLIRPDLLParser STATIC
   MLIRSupport
   MLIRTableGen
   )
+
+mlir_check_all_link_libraries(MLIRPDLLParser)
+
+add_mlir_library_install(MLIRPDLLParser)


### PR DESCRIPTION
`MLIRPDLLParser` is currently not added during cmake installation.

[mlir/lib/TableGen/CMakeLists.txt](https://github.com/llvm/llvm-project/blob/ad1e10ae1109fa7204ab70422bb611fe88391228/mlir/lib/TableGen/CMakeLists.txt) explains of why PDLL uses a strange cmake configuration. For a similar implementation see [mlir/lib/Tools/mlir-tblgen/CMakeLists.txt](https://github.com/llvm/llvm-project/blob/ad1e10ae1109fa7204ab70422bb611fe88391228/mlir/lib/Tools/mlir-tblgen/CMakeLists.txt)
