### PR TITLE
[CodeGen] Don't allow function alignment less than the target's minimum

### DIFF
--- a/llvm/test/CodeGen/AArch64/func-alignment.ll
+++ b/llvm/test/CodeGen/AArch64/func-alignment.ll
@@ -1,0 +1,19 @@
+; RUN: llc -mtriple=aarch64 -O0 -fast-isel < %s | FileCheck %s
+
+; Verify that Clang's C++ ABI alignment for functions of 2 does not
+; result in underaligned functions when they are in special sections.
+; (#90415)
+
+define void @noSection() align 2 {
+; CHECK:	.p2align	2
+entry:
+  ret void
+}
+
+define void @withSection() section "__TEXT,__foo,regular,pure_instructions" align 2 {
+; CHECK:	.p2align	2
+entry:
+  ret void
+}
+
+


### PR DESCRIPTION
See #90358 

The C++ ABI forces all class methods to have an explicit alignment of 2. This ends up overriding `MachineFunction`'s alignment (on arm64, 4) on functions in special text sections. Add a check: don't align code at less than the target's minimum function alignment.

(Are there other objects which can occur in text sections and which should be allowed to be aligned at smaller than the minimum function alignment?)