### PR TITLE
[RISCV] Don't use MachineInstr::isIdenticalTo in hasSameAVL

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVInsertVSETVLI.cpp
+++ b/llvm/lib/Target/RISCV/RISCVInsertVSETVLI.cpp
@@ -568,8 +568,8 @@ public:
 
   bool hasSameAVL(const VSETVLIInfo &Other) const {
     if (hasAVLReg() && Other.hasAVLReg())
-      return getAVLDefMI().isIdenticalTo(Other.getAVLDefMI()) &&
-             getAVLReg() == Other.getAVLReg();
+      return AVLRegDef.DefMI == Other.AVLRegDef.DefMI &&
+             AVLRegDef.DefReg == Other.AVLRegDef.DefReg;
 
     if (hasAVLImm() && Other.hasAVLImm())
       return getAVLImm() == Other.getAVLImm();


### PR DESCRIPTION
MachineInstr::isIdenticalTo compares that the operands and flags are the same IIUC, but I think we actually want to check that it's the same MachineInstr * with respect to position in the block etc.
