### PR TITLE
[Clang] Fix LibTooling doc

### DIFF
--- a/clang/include/clang/Tooling/CommonOptionsParser.h
+++ b/clang/include/clang/Tooling/CommonOptionsParser.h
@@ -49,17 +49,22 @@ namespace tooling {
 /// using namespace clang::tooling;
 /// using namespace llvm;
 ///
-/// static cl::OptionCategory MyToolCategory("My tool options");
+/// static cl::OptionCategory MyToolCategory("my-tool options");
 /// static cl::extrahelp CommonHelp(CommonOptionsParser::HelpMessage);
 /// static cl::extrahelp MoreHelp("\nMore help text...\n");
-/// static cl::opt<bool> YourOwnOption(...);
-/// ...
 ///
 /// int main(int argc, const char **argv) {
-///   CommonOptionsParser OptionsParser(argc, argv, MyToolCategory);
+///   auto ExpectedParser =
+///       CommonOptionsParser::create(argc, argv, MyToolCategory);
+///   if (!ExpectedParser) {
+///     llvm::errs() << ExpectedParser.takeError();
+///     return 1;
+///   }
+///   CommonOptionsParser& OptionsParser = ExpectedParser.get();
 ///   ClangTool Tool(OptionsParser.getCompilations(),
 ///                  OptionsParser.getSourcePathList());
-///   return Tool.run(newFrontendActionFactory<SyntaxOnlyAction>().get());
+///   return Tool.run(
+///       newFrontendActionFactory<clang::SyntaxOnlyAction>().get());
 /// }
 /// \endcode
 class CommonOptionsParser {


### PR DESCRIPTION
Replace CommonOptionsParser ctor by factory method ::create.

Found on page https://clang.llvm.org/docs/LibTooling.html