### PR TITLE
Recommit "[LoopFlatten] Enable it by default"

### DIFF
--- a/llvm/docs/ReleaseNotes.rst
+++ b/llvm/docs/ReleaseNotes.rst
@@ -42,7 +42,7 @@ Non-comprehensive list of changes in this release
    functionality, or simply have a lot to talk about), see the `NOTE` below
    for adding a new subsection.
 
-* ...
+* The LoopFlatten pass is now enabled by default.
 
 Update on required toolchains to build LLVM
 -------------------------------------------

--- a/llvm/lib/Passes/PassBuilderPipelines.cpp
+++ b/llvm/lib/Passes/PassBuilderPipelines.cpp
@@ -205,7 +205,7 @@ static cl::opt<bool> EnableUnrollAndJam("enable-unroll-and-jam",
                                         cl::init(false), cl::Hidden,
                                         cl::desc("Enable Unroll And Jam Pass"));
 
-static cl::opt<bool> EnableLoopFlatten("enable-loop-flatten", cl::init(false),
+static cl::opt<bool> EnableLoopFlatten("enable-loop-flatten", cl::init(true),
                                        cl::Hidden,
                                        cl::desc("Enable the LoopFlatten Pass"));
 


### PR DESCRIPTION
The enablement of LoopFlatten got reverted by commit [8250180](https://github.com/llvm/llvm-project/commit/8250180238575ad81aed2104ca69b8fdc98d60df) because of a reported miscompilation in #59339. That issue got fixed by commit 161bfa5.