### PR TITLE
[Clang] Propagate 'SystemDrive' environment variable for unit tests

### DIFF
--- a/clang/test/Unit/lit.cfg.py
+++ b/clang/test/Unit/lit.cfg.py
@@ -25,15 +25,9 @@ config.test_format = lit.formats.GoogleTest(config.llvm_build_mode, "Tests")
 
 # Propagate the temp directory. Windows requires this because it uses \Windows\
 # if none of these are present.
-if "TMP" in os.environ:
-    config.environment["TMP"] = os.environ["TMP"]
-if "TEMP" in os.environ:
-    config.environment["TEMP"] = os.environ["TEMP"]
-
-if "HOME" in os.environ:
-    config.environment["HOME"] = os.environ["HOME"]
-if "SystemDrive" in os.environ:
-    config.environment["SystemDrive"] = os.environ["SystemDrive"]
+for v in ["TMP", "TEMP", "HOME", "SystemDrive"]:
+    if v in os.environ:
+        config.environment[v] = os.environ[v]
 
 # Propagate sanitizer options.
 for var in [

--- a/clang/test/Unit/lit.cfg.py
+++ b/clang/test/Unit/lit.cfg.py
@@ -32,6 +32,8 @@ if "TEMP" in os.environ:
 
 if "HOME" in os.environ:
     config.environment["HOME"] = os.environ["HOME"]
+if "SystemDrive" in os.environ:
+    config.environment["SystemDrive"] = os.environ["SystemDrive"]
 
 # Propagate sanitizer options.
 for var in [


### PR DESCRIPTION
On windows, running unit tests by directly invoking `llvm-lit.py` (e.g. `python3 llvm-lit.py clang/test/Unit`) will (at least on my system) create a folder named `%SystemDrive%` in the working directory. This seems to happen because `lit.cfg.py` in `clang/test/Unit` does not propagate the `SystemDrive` environment variable.
