### PR TITLE
[Clang] Fix Null Pointer Dereference in Sema::BuildClassMessageImplicit()

### DIFF
--- a/clang/lib/Sema/SemaExprObjC.cpp
+++ b/clang/lib/Sema/SemaExprObjC.cpp
@@ -2440,10 +2440,12 @@ ExprResult Sema::BuildClassMessageImplicit(QualType ReceiverType,
   assert(((isSuperReceiver && Loc.isValid()) || receiverTypeInfo) &&
          "Either the super receiver location needs to be valid or the receiver "
          "needs valid type source information");
-  return BuildClassMessage(receiverTypeInfo, ReceiverType,
-                          /*SuperLoc=*/isSuperReceiver ? Loc : SourceLocation(),
-                           Sel, Method, Loc, Loc, Loc, Args,
-                           /*isImplicit=*/true);
+  if (receiverTypeInfo) {
+    return BuildClassMessage(receiverTypeInfo, ReceiverType,
+                            /*SuperLoc=*/isSuperReceiver ? Loc : SourceLocation(),
+                             Sel, Method, Loc, Loc, Loc, Args,
+                             /*isImplicit=*/true);
+  }
 }
 
 static void applyCocoaAPICheck(Sema &S, const ObjCMessageExpr *Msg,

--- a/clang/lib/Sema/SemaExprObjC.cpp
+++ b/clang/lib/Sema/SemaExprObjC.cpp
@@ -2441,10 +2441,11 @@ ExprResult Sema::BuildClassMessageImplicit(QualType ReceiverType,
          "Either the super receiver location needs to be valid or the receiver "
          "needs valid type source information");
   if (receiverTypeInfo) {
-    return BuildClassMessage(receiverTypeInfo, ReceiverType,
-                            /*SuperLoc=*/isSuperReceiver ? Loc : SourceLocation(),
-                             Sel, Method, Loc, Loc, Loc, Args,
-                             /*isImplicit=*/true);
+    return BuildClassMessage(
+        receiverTypeInfo, ReceiverType,
+        /*SuperLoc=*/isSuperReceiver ? Loc : SourceLocation(), Sel, Method, Loc,
+        Loc, Loc, Args,
+        /*isImplicit=*/true);
   }
 }
 


### PR DESCRIPTION
The issue arises in the assert statement.

The code asserts that either isSuperReceiver && Loc.isValid() is true or receiverTypeInfo is not null.

However, the subsequent line (return BuildClassMessage(...)) dereferences receiverTypeInfo without explicitly checking if it’s null.

The fix involves ensuring that the receiverTypeInfo pointer is not null before dereferencing it.

By adding a null check for receiverTypeInfo, we prevent potential undefined behavior due to null pointer dereference.