### PR TITLE
Disable test for lsan and x86_64h

### DIFF
--- a/compiler-rt/test/sanitizer_common/TestCases/sanitizer_coverage_trace_pc_guard.cpp
+++ b/compiler-rt/test/sanitizer_common/TestCases/sanitizer_coverage_trace_pc_guard.cpp
@@ -2,8 +2,8 @@
 
 // REQUIRES: has_sancovcc
 // UNSUPPORTED: ubsan,i386-darwin,target={{(powerpc64|s390x|thumb).*}}
-// This test is failing for lsan on darwin on x86_64.
-// UNSUPPORTED: x86_64h && lsan
+// This test is failing for lsan on darwin on x86_64h.
+// UNSUPPORTED: x86_64h && lsan && darwin
 // XFAIL: tsan
 // XFAIL: android && asan
 

--- a/compiler-rt/test/sanitizer_common/TestCases/sanitizer_coverage_trace_pc_guard.cpp
+++ b/compiler-rt/test/sanitizer_common/TestCases/sanitizer_coverage_trace_pc_guard.cpp
@@ -2,6 +2,8 @@
 
 // REQUIRES: has_sancovcc
 // UNSUPPORTED: ubsan,i386-darwin,target={{(powerpc64|s390x|thumb).*}}
+// This test is failing for lsan on darwin on x86_64.
+// UNSUPPORTED: x86_64h && lsan
 // XFAIL: tsan
 // XFAIL: android && asan
 


### PR DESCRIPTION
Disable this test on x86_64h for LSan.

This test is failing with malformed object only on x86_64h.
Disabling for now. 

rdar://125052424
