### PR TITLE
[NFC] Fix hasQualifier comment

### DIFF
--- a/clang/include/clang/AST/NestedNameSpecifier.h
+++ b/clang/include/clang/AST/NestedNameSpecifier.h
@@ -266,7 +266,7 @@ public:
   explicit operator bool() const { return Qualifier; }
 
   /// Evaluates true when this nested-name-specifier location is
-  /// empty.
+  /// non-empty.
   bool hasQualifier() const { return Qualifier; }
 
   /// Retrieve the nested-name-specifier to which this instance


### PR DESCRIPTION
operator bool from NestedNameSpecifierLoc and
member function hasQualifier both do the same thing, returning true iff the private data member Qualifier is not nullptr, so clearly one of the comments is wrong, and in this case it is the second one.

fixes https://github.com/llvm/llvm-project/issues/90472