### PR TITLE
[DirectX backend] generate ISG1, OSG1 part for compute shader

### DIFF
--- a/llvm/lib/Target/DirectX/DXContainerGlobals.cpp
+++ b/llvm/lib/Target/DirectX/DXContainerGlobals.cpp
@@ -34,9 +34,9 @@ class DXContainerGlobals : public llvm::ModulePass {
                                        StringRef Name, StringRef SectionName);
   GlobalVariable *getFeatureFlags(Module &M);
   GlobalVariable *computeShaderHash(Module &M);
-  GlobalVariable *buildSingature(Module &M, Signature &Sig, StringRef Name,
+  GlobalVariable *buildSignature(Module &M, Signature &Sig, StringRef Name,
                                  StringRef SectionName);
-  void addSingature(Module &M, SmallVector<GlobalValue *> &Globals);
+  void addSignature(Module &M, SmallVector<GlobalValue *> &Globals);
 
 public:
   static char ID; // Pass identification, replacement for typeid
@@ -62,7 +62,7 @@ bool DXContainerGlobals::runOnModule(Module &M) {
   llvm::SmallVector<GlobalValue *> Globals;
   Globals.push_back(getFeatureFlags(M));
   Globals.push_back(computeShaderHash(M));
-  addSingature(M, Globals);
+  addSignature(M, Globals);
   appendToCompilerUsed(M, Globals);
   return true;
 }
@@ -110,7 +110,7 @@ GlobalVariable *DXContainerGlobals::buildContainerGlobal(
   return GV;
 }
 
-GlobalVariable *DXContainerGlobals::buildSingature(Module &M, Signature &Sig,
+GlobalVariable *DXContainerGlobals::buildSignature(Module &M, Signature &Sig,
                                                    StringRef Name,
                                                    StringRef SectionName) {
   SmallString<256> Data;
@@ -121,16 +121,16 @@ GlobalVariable *DXContainerGlobals::buildSingature(Module &M, Signature &Sig,
   return buildContainerGlobal(M, Constant, Name, SectionName);
 }
 
-void DXContainerGlobals::addSingature(Module &M,
+void DXContainerGlobals::addSignature(Module &M,
                                       SmallVector<GlobalValue *> &Globals) {
   // FIXME: support graphics shader.
   //  see issue https://github.com/llvm/llvm-project/issues/90504.
 
   Signature InputSig;
-  Globals.emplace_back(buildSingature(M, InputSig, "dx.isg1", "ISG1"));
+  Globals.emplace_back(buildSignature(M, InputSig, "dx.isg1", "ISG1"));
 
   Signature OutputSig;
-  Globals.emplace_back(buildSingature(M, OutputSig, "dx.osg1", "OSG1"));
+  Globals.emplace_back(buildSignature(M, OutputSig, "dx.osg1", "OSG1"));
 }
 
 char DXContainerGlobals::ID = 0;

--- a/llvm/lib/Target/DirectX/DXContainerGlobals.cpp
+++ b/llvm/lib/Target/DirectX/DXContainerGlobals.cpp
@@ -75,12 +75,7 @@ GlobalVariable *DXContainerGlobals::getFeatureFlags(Module &M) {
 
   Constant *FeatureFlagsConstant =
       ConstantInt::get(M.getContext(), APInt(64, FeatureFlags));
-  auto *GV = new llvm::GlobalVariable(M, FeatureFlagsConstant->getType(), true,
-                                      GlobalValue::PrivateLinkage,
-                                      FeatureFlagsConstant, "dx.sfi0");
-  GV->setSection("SFI0");
-  GV->setAlignment(Align(4));
-  return GV;
+  return buildContainerGlobal(M, FeatureFlagsConstant, "dx.sfi0", "SFI0");
 }
 
 GlobalVariable *DXContainerGlobals::computeShaderHash(Module &M) {
@@ -103,12 +98,7 @@ GlobalVariable *DXContainerGlobals::computeShaderHash(Module &M) {
 
   Constant *ModuleConstant =
       ConstantDataArray::get(M.getContext(), arrayRefFromStringRef(Data));
-  auto *GV = new llvm::GlobalVariable(M, ModuleConstant->getType(), true,
-                                      GlobalValue::PrivateLinkage,
-                                      ModuleConstant, "dx.hash");
-  GV->setSection("HASH");
-  GV->setAlignment(Align(4));
-  return GV;
+  return buildContainerGlobal(M, ModuleConstant, "dx.hash", "HASH");
 }
 
 GlobalVariable *DXContainerGlobals::buildContainerGlobal(
@@ -133,12 +123,13 @@ GlobalVariable *DXContainerGlobals::buildSingature(Module &M, Signature &Sig,
 
 void DXContainerGlobals::addSingature(Module &M,
                                       SmallVector<GlobalValue *> &Globals) {
-  Signature InputSig;
-  Signature OutputSig;
   // FIXME: support graphics shader.
   //  see issue https://github.com/llvm/llvm-project/issues/90504.
 
+  Signature InputSig;
   Globals.emplace_back(buildSingature(M, InputSig, "dx.isg1", "ISG1"));
+
+  Signature OutputSig;
   Globals.emplace_back(buildSingature(M, OutputSig, "dx.osg1", "OSG1"));
 }
 

--- a/llvm/lib/Target/DirectX/DXContainerGlobals.cpp
+++ b/llvm/lib/Target/DirectX/DXContainerGlobals.cpp
@@ -36,7 +36,7 @@ class DXContainerGlobals : public llvm::ModulePass {
   GlobalVariable *computeShaderHash(Module &M);
   GlobalVariable *buildSingature(Module &M, Signature &Sig, StringRef Name,
                                  StringRef SectionName);
-  void addSingature(Module &M, SmallVector<GlobalValue *> &Globals, Triple &TT);
+  void addSingature(Module &M, SmallVector<GlobalValue *> &Globals);
 
 public:
   static char ID; // Pass identification, replacement for typeid
@@ -62,8 +62,7 @@ bool DXContainerGlobals::runOnModule(Module &M) {
   llvm::SmallVector<GlobalValue *> Globals;
   Globals.push_back(getFeatureFlags(M));
   Globals.push_back(computeShaderHash(M));
-  Triple TT(M.getTargetTriple());
-  addSingature(M, Globals, TT);
+  addSingature(M, Globals);
   appendToCompilerUsed(M, Globals);
   return true;
 }
@@ -133,8 +132,7 @@ GlobalVariable *DXContainerGlobals::buildSingature(Module &M, Signature &Sig,
 }
 
 void DXContainerGlobals::addSingature(Module &M,
-                                      SmallVector<GlobalValue *> &Globals,
-                                      Triple &TT) {
+                                      SmallVector<GlobalValue *> &Globals) {
   Signature InputSig;
   Signature OutputSig;
   // FIXME: support graphics shader.

--- a/llvm/lib/Target/DirectX/DXContainerGlobals.cpp
+++ b/llvm/lib/Target/DirectX/DXContainerGlobals.cpp
@@ -124,10 +124,9 @@ GlobalVariable *DXContainerGlobals::buildContainerGlobal(
 GlobalVariable *DXContainerGlobals::buildSingature(Module &M, Signature &Sig,
                                                    StringRef Name,
                                                    StringRef SectionName) {
-  std::string Data;
-  raw_string_ostream OS(Data);
+  SmallString<256> Data;
+  raw_svector_ostream OS(Data);
   Sig.write(OS);
-  OS.flush();
   Constant *Constant =
       ConstantDataArray::getString(M.getContext(), Data, /*AddNull*/ false);
   return buildContainerGlobal(M, Constant, Name, SectionName);

--- a/llvm/test/CodeGen/DirectX/ContainerData/EmptySignature.ll
+++ b/llvm/test/CodeGen/DirectX/ContainerData/EmptySignature.ll
@@ -2,8 +2,9 @@
 ; RUN: llc %s --filetype=obj -o - | obj2yaml | FileCheck %s --check-prefix=DXC
 target triple = "dxil-unknown-shadermodel6.0-compute"
 
-; CHECK: @dx.isg1 = private constant { i32, i32 } { i32 0, i32 8 }, section "ISG1", align 4
-; CHECK: @dx.osg1 = private constant { i32, i32 } { i32 0, i32 8 }, section "OSG1", align 4
+; CHECK: @dx.isg1 = private constant [8 x i8] c"\00\00\00\00\08\00\00\00", section "ISG1", align 4
+; CHECK: @dx.osg1 = private constant [8 x i8] c"\00\00\00\00\08\00\00\00", section "OSG1", align 4
+
 define void @main() #0 {
 entry:
   ret void

--- a/llvm/test/CodeGen/DirectX/ContainerData/EmptySignature.ll
+++ b/llvm/test/CodeGen/DirectX/ContainerData/EmptySignature.ll
@@ -1,0 +1,25 @@
+; RUN: opt %s -dxil-embed -dxil-globals -S -o - | FileCheck %s
+; RUN: llc %s --filetype=obj -o - | obj2yaml | FileCheck %s --check-prefix=DXC
+target triple = "dxil-unknown-shadermodel6.0-compute"
+
+; CHECK: @dx.isg1 = private constant { i32, i32 } { i32 0, i32 8 }, section "ISG1", align 4
+; CHECK: @dx.osg1 = private constant { i32, i32 } { i32 0, i32 8 }, section "OSG1", align 4
+define void @main() #0 {
+entry:
+  ret void
+}
+
+attributes #0 = { "hlsl.numthreads"="1,1,1" "hlsl.shader"="compute" }
+
+!dx.valver = !{!0}
+
+!0 = !{i32 1, i32 7}
+
+; DXC: - Name:            ISG1
+; DXC-NEXT:   Size:            8
+; DXC-NEXT:   Signature:
+; DXC-NEXT:     Parameters:      []
+; DXC: - Name:            OSG1
+; DXC-NEXT:   Size:            8
+; DXC-NEXT:   Signature:
+; DXC-NEXT:     Parameters:      []


### PR DESCRIPTION
Empty ISG1 and OSG1 parts are generated for compute shader since there's no signature for compute shader.

Fixes #88778