### PR TITLE
[NFC][llvm-cov]: show supported options for each output format

### DIFF
--- a/llvm/tools/llvm-cov/CodeCoverage.cpp
+++ b/llvm/tools/llvm-cov/CodeCoverage.cpp
@@ -666,12 +666,13 @@ int CodeCoverageTool::run(Command Cmd, int argc, const char **argv) {
 
   cl::opt<CoverageViewOptions::OutputFormat> Format(
       "format", cl::desc("Output format for line-based coverage reports"),
-      cl::values(clEnumValN(CoverageViewOptions::OutputFormat::Text, "text",
-                            "Text output"),
-                 clEnumValN(CoverageViewOptions::OutputFormat::HTML, "html",
-                            "HTML output"),
-                 clEnumValN(CoverageViewOptions::OutputFormat::Lcov, "lcov",
-                            "lcov tracefile output")),
+      cl::values(
+          clEnumValN(CoverageViewOptions::OutputFormat::Text, "text",
+                     "Text output"),
+          clEnumValN(CoverageViewOptions::OutputFormat::HTML, "html",
+                     "HTML output (only available with 'show')"),
+          clEnumValN(CoverageViewOptions::OutputFormat::Lcov, "lcov",
+                     "lcov tracefile output (only available with 'export')")),
       cl::init(CoverageViewOptions::OutputFormat::Text));
 
   cl::opt<std::string> PathRemap(


### PR DESCRIPTION
When looking into https://github.com/llvm/llvm-project/issues/85780 one can see:
```
  --format=<value>                   - Output format for line-based coverage reports
    =text                            -   Text output
    =html                            -   HTML output
    =lcov                            -   lcov tracefile output
```

with this patch at least looks clearer from the help what output format can be used.

fixes https://github.com/llvm/llvm-project/issues/85780 (hmmm sort-of, at least makes it better)
