### PR TITLE
[DFSan] Replace `cat` with `cmake -E cat`

### DIFF
--- a/compiler-rt/lib/dfsan/CMakeLists.txt
+++ b/compiler-rt/lib/dfsan/CMakeLists.txt
@@ -63,7 +63,8 @@ add_custom_command(OUTPUT ${dfsan_abilist_filename}
                    COMMAND
                     ${CMAKE_COMMAND} -E make_directory ${dfsan_abilist_dir}
                    COMMAND
-                     cat ${CMAKE_CURRENT_SOURCE_DIR}/done_abilist.txt
+                    ${CMAKE_COMMAND} -E cat
+                         ${CMAKE_CURRENT_SOURCE_DIR}/done_abilist.txt
                          ${CMAKE_CURRENT_SOURCE_DIR}/libc_ubuntu1404_abilist.txt
                          > ${dfsan_abilist_filename}
                    DEPENDS done_abilist.txt libc_ubuntu1404_abilist.txt)


### PR DESCRIPTION
`CMake` supports [this command](https://cmake.org/cmake/help/latest/manual/cmake.1.html#cmdoption-cmake-E-arg-cat) as of version 3.18. [D151344](https://reviews.llvm.org/D151344) bumped the minimum version to 3.20, so, it is now possible to remove the dependency on the external utility. This helps to cross-compile from Windows to Linux without installing additional tools, such as MSYS2.