### PR TITLE
[NewPM][Instrumentation] Support `MachineOptimizationRemarkEmitter` 

### DIFF
--- a/llvm/include/llvm/IR/PassManager.h
+++ b/llvm/include/llvm/IR/PassManager.h
@@ -547,6 +547,11 @@ public:
     return true;
   }
 
+  /// Query whether an analysis pass is registered.
+  template <typename PassT> bool isRegistered() {
+    return AnalysisPasses.contains(PassT::ID());
+  }
+
   /// Invalidate cached analyses for an IR unit.
   ///
   /// Walk through all of the analyses pertaining to this unit of IR and

--- a/llvm/include/llvm/Passes/StandardInstrumentations.h
+++ b/llvm/include/llvm/Passes/StandardInstrumentations.h
@@ -577,6 +577,15 @@ private:
   static void SignalHandler(void *);
 };
 
+class InstrCountChangedReporter {
+  LLVMContext &Context;
+
+public:
+  InstrCountChangedReporter(LLVMContext &Context) : Context(Context) {}
+  void registerCallbacks(PassInstrumentationCallbacks &PIC,
+                         ModuleAnalysisManager &MAM);
+};
+
 /// This class provides an interface to register all the standard pass
 /// instrumentations and manages their state (if any).
 class StandardInstrumentations {
@@ -594,6 +603,7 @@ class StandardInstrumentations {
   PrintCrashIRInstrumentation PrintCrashIR;
   IRChangedTester ChangeTester;
   VerifyInstrumentation Verify;
+  InstrCountChangedReporter EmitMFSizeRemarks;
 
   bool VerifyEach;
 
@@ -605,7 +615,8 @@ public:
   // Register all the standard instrumentation callbacks. If \p FAM is nullptr
   // then PreservedCFGChecker is not enabled.
   void registerCallbacks(PassInstrumentationCallbacks &PIC,
-                         ModuleAnalysisManager *MAM = nullptr);
+                         ModuleAnalysisManager *MAM = nullptr,
+                         bool RegisterCodeGenCallbacks = false);
 
   TimePassesHandler &getTimePasses() { return TimePasses; }
 };

--- a/llvm/include/llvm/Passes/StandardInstrumentations.h
+++ b/llvm/include/llvm/Passes/StandardInstrumentations.h
@@ -615,8 +615,7 @@ public:
   // Register all the standard instrumentation callbacks. If \p FAM is nullptr
   // then PreservedCFGChecker is not enabled.
   void registerCallbacks(PassInstrumentationCallbacks &PIC,
-                         ModuleAnalysisManager *MAM = nullptr,
-                         bool RegisterCodeGenCallbacks = false);
+                         ModuleAnalysisManager *MAM = nullptr);
 
   TimePassesHandler &getTimePasses() { return TimePasses; }
 };

--- a/llvm/lib/Passes/StandardInstrumentations.cpp
+++ b/llvm/lib/Passes/StandardInstrumentations.cpp
@@ -2564,7 +2564,8 @@ void PrintCrashIRInstrumentation::registerCallbacks(
 void InstrCountChangedReporter::registerCallbacks(
     PassInstrumentationCallbacks &PIC, ModuleAnalysisManager &MAM) {
 
-  if (!Context.getDiagHandlerPtr()->isAnalysisRemarkEnabled("size-info"))
+  if (!Context.getDiagHandlerPtr()->isAnalysisRemarkEnabled("size-info") ||
+      !MAM.isRegistered<MachineFunctionAnalysisManagerModuleProxy>())
     return;
 
   PIC.registerBeforeNonSkippedPassCallback([this, &MAM, Registered = false](
@@ -2631,8 +2632,7 @@ void InstrCountChangedReporter::registerCallbacks(
 }
 
 void StandardInstrumentations::registerCallbacks(
-    PassInstrumentationCallbacks &PIC, ModuleAnalysisManager *MAM,
-    bool RegisterCodeGenCallbacks) {
+    PassInstrumentationCallbacks &PIC, ModuleAnalysisManager *MAM) {
   PrintIR.registerCallbacks(PIC);
   PrintPass.registerCallbacks(PIC);
   TimePasses.registerCallbacks(PIC);
@@ -2648,8 +2648,7 @@ void StandardInstrumentations::registerCallbacks(
   PrintCrashIR.registerCallbacks(PIC);
   if (MAM) {
     PreservedCFGChecker.registerCallbacks(PIC, *MAM);
-    if (RegisterCodeGenCallbacks)
-      EmitMFSizeRemarks.registerCallbacks(PIC, *MAM);
+    EmitMFSizeRemarks.registerCallbacks(PIC, *MAM);
   }
 
   // TimeProfiling records the pass running time cost.

--- a/llvm/lib/Passes/StandardInstrumentations.cpp
+++ b/llvm/lib/Passes/StandardInstrumentations.cpp
@@ -19,9 +19,13 @@
 #include "llvm/Analysis/CallGraphSCCPass.h"
 #include "llvm/Analysis/LazyCallGraph.h"
 #include "llvm/Analysis/LoopInfo.h"
+#include "llvm/Analysis/OptimizationRemarkEmitter.h"
 #include "llvm/CodeGen/MIRPrinter.h"
 #include "llvm/CodeGen/MachineFunction.h"
+#include "llvm/CodeGen/MachineFunctionAnalysis.h"
 #include "llvm/CodeGen/MachineModuleInfo.h"
+#include "llvm/CodeGen/MachineOptimizationRemarkEmitter.h"
+#include "llvm/CodeGen/MachinePassManager.h"
 #include "llvm/IR/Constants.h"
 #include "llvm/IR/Function.h"
 #include "llvm/IR/Module.h"
@@ -48,6 +52,7 @@
 #include <vector>
 
 using namespace llvm;
+using namespace ore;
 
 static cl::opt<bool> VerifyAnalysisInvalidation("verify-analysis-invalidation",
                                                 cl::Hidden,
@@ -373,6 +378,14 @@ bool isInteresting(Any IR, StringRef PassID, StringRef PassName) {
   if (const auto *F = unwrapIR<Function>(IR))
     return isInterestingFunction(*F);
   return true;
+}
+
+bool isMachineModulePass(StringRef PassID) {
+#define MACHINE_MODULE_PASS(NAME, CREATE_PASS)                                 \
+  if (PassID == std::remove_reference_t<decltype(CREATE_PASS)>::name())        \
+    return true;
+#include "llvm/Passes/MachinePassRegistry.def"
+  return false;
 }
 
 } // namespace
@@ -1329,6 +1342,49 @@ struct PreservedModuleHashAnalysis
 };
 
 AnalysisKey PreservedModuleHashAnalysis::Key;
+
+struct MachineInstrCounterAnalysis
+    : public AnalysisInfoMixin<MachineInstrCounterAnalysis> {
+  static AnalysisKey Key;
+
+  struct Result {
+    bool invalidate(MachineFunction &MF, const PreservedAnalyses &,
+                    MachineFunctionAnalysisManager::Invalidator &) {
+      return false;
+    }
+
+    void emitRemark(MachineFunction &MF, StringRef PassID) {
+      CountAfter = MF.getInstructionCount();
+      if (CountBefore == CountAfter)
+        return;
+
+      MachineOptimizationRemarkEmitter MORE(MF, nullptr);
+      MORE.emit([&]() {
+        int64_t Delta = static_cast<int64_t>(CountAfter) -
+                        static_cast<int64_t>(CountBefore);
+        MachineOptimizationRemarkAnalysis R("size-info", "FunctionMISizeChange",
+                                            MF.getFunction().getSubprogram(),
+                                            &MF.front());
+        R << NV("Pass", PassID)
+          << ": Function: " << NV("Function", MF.getName()) << ": "
+          << "MI Instruction count changed from "
+          << NV("MIInstrsBefore", CountBefore) << " to "
+          << NV("MIInstrsAfter", CountAfter)
+          << "; Delta: " << NV("Delta", Delta);
+        return R;
+      });
+    }
+
+    unsigned CountBefore = 0;
+    unsigned CountAfter = 0;
+  };
+
+  Result run(MachineFunction &MF, MachineFunctionAnalysisManager &MFAM) {
+    return Result();
+  }
+};
+
+AnalysisKey MachineInstrCounterAnalysis::Key;
 
 bool PreservedCFGCheckerInstrumentation::CFG::invalidate(
     Function &F, const PreservedAnalyses &PA,
@@ -2436,8 +2492,7 @@ void DotCfgChangeReporter::registerCallbacks(
 StandardInstrumentations::StandardInstrumentations(
     LLVMContext &Context, bool DebugLogging, bool VerifyEach,
     PrintPassOptions PrintPassOpts)
-    : PrintPass(DebugLogging, PrintPassOpts),
-      OptNone(DebugLogging),
+    : PrintPass(DebugLogging, PrintPassOpts), OptNone(DebugLogging),
       OptPassGate(Context),
       PrintChangedIR(PrintChanged == ChangePrinter::Verbose),
       PrintChangedDiff(PrintChanged == ChangePrinter::DiffVerbose ||
@@ -2445,7 +2500,8 @@ StandardInstrumentations::StandardInstrumentations(
                        PrintChanged == ChangePrinter::ColourDiffVerbose ||
                            PrintChanged == ChangePrinter::ColourDiffQuiet),
       WebsiteChangeReporter(PrintChanged == ChangePrinter::DotCfgVerbose),
-      Verify(DebugLogging), VerifyEach(VerifyEach) {}
+      Verify(DebugLogging), VerifyEach(VerifyEach), EmitMFSizeRemarks(Context) {
+}
 
 PrintCrashIRInstrumentation *PrintCrashIRInstrumentation::CrashReporter =
     nullptr;
@@ -2505,8 +2561,78 @@ void PrintCrashIRInstrumentation::registerCallbacks(
       });
 }
 
+void InstrCountChangedReporter::registerCallbacks(
+    PassInstrumentationCallbacks &PIC, ModuleAnalysisManager &MAM) {
+
+  if (!Context.getDiagHandlerPtr()->isAnalysisRemarkEnabled("size-info"))
+    return;
+
+  PIC.registerBeforeNonSkippedPassCallback([this, &MAM, Registered = false](
+                                               StringRef PassID,
+                                               Any IR) mutable {
+    if (isIgnored(PassID))
+      return;
+
+    auto &MFAM = MAM.getResult<MachineFunctionAnalysisManagerModuleProxy>(
+                        const_cast<Module &>(*unwrapModule(IR)))
+                     .getManager();
+    if (!Registered) {
+      MFAM.registerPass([] { return MachineInstrCounterAnalysis(); });
+      Registered = true;
+    }
+
+    if (auto *MF =
+            const_cast<MachineFunction *>(unwrapIR<MachineFunction>(IR))) {
+      MFAM.getResult<MachineInstrCounterAnalysis>(*MF).CountBefore =
+          MF->getInstructionCount();
+      return;
+    }
+
+    // FIXME: Currently except debugify passes, `MachineOutlinerPass`
+    // is the only "machine module pass".
+    if (!isMachineModulePass(PassID))
+      return;
+    if (auto *M = const_cast<Module *>(unwrapIR<Module>(IR))) {
+      auto &FAM =
+          MAM.getResult<FunctionAnalysisManagerModuleProxy>(*M).getManager();
+      for (auto &F : *M) {
+        auto &MF = FAM.getResult<MachineFunctionAnalysis>(F).getMF();
+        MFAM.getResult<MachineInstrCounterAnalysis>(MF).CountBefore =
+            MF.getInstructionCount();
+      }
+    }
+  });
+
+  PIC.registerAfterPassCallback([this, &MAM](StringRef PassID, Any IR,
+                                             const PreservedAnalyses &) {
+    if (isIgnored(PassID))
+      return;
+
+    auto &MFAM = MAM.getResult<MachineFunctionAnalysisManagerModuleProxy>(
+                        const_cast<Module &>(*unwrapModule(IR)))
+                     .getManager();
+    if (auto *MF =
+            const_cast<MachineFunction *>(unwrapIR<MachineFunction>(IR))) {
+      MFAM.getResult<MachineInstrCounterAnalysis>(*MF).emitRemark(*MF, PassID);
+      return;
+    }
+
+    if (!isMachineModulePass(PassID))
+      return;
+    if (auto *M = const_cast<Module *>(unwrapIR<Module>(IR))) {
+      auto &FAM =
+          MAM.getResult<FunctionAnalysisManagerModuleProxy>(*M).getManager();
+      for (auto &F : *M) {
+        auto &MF = FAM.getResult<MachineFunctionAnalysis>(F).getMF();
+        MFAM.getResult<MachineInstrCounterAnalysis>(MF).emitRemark(MF, PassID);
+      }
+    }
+  });
+}
+
 void StandardInstrumentations::registerCallbacks(
-    PassInstrumentationCallbacks &PIC, ModuleAnalysisManager *MAM) {
+    PassInstrumentationCallbacks &PIC, ModuleAnalysisManager *MAM,
+    bool RegisterCodeGenCallbacks) {
   PrintIR.registerCallbacks(PIC);
   PrintPass.registerCallbacks(PIC);
   TimePasses.registerCallbacks(PIC);
@@ -2520,8 +2646,11 @@ void StandardInstrumentations::registerCallbacks(
   WebsiteChangeReporter.registerCallbacks(PIC);
   ChangeTester.registerCallbacks(PIC);
   PrintCrashIR.registerCallbacks(PIC);
-  if (MAM)
+  if (MAM) {
     PreservedCFGChecker.registerCallbacks(PIC, *MAM);
+    if (RegisterCodeGenCallbacks)
+      EmitMFSizeRemarks.registerCallbacks(PIC, *MAM);
+  }
 
   // TimeProfiling records the pass running time cost.
   // Its 'BeforePassCallback' can be appended at the tail of all the

--- a/llvm/test/tools/llc/new-pm/size-remark-emitter.mir
+++ b/llvm/test/tools/llc/new-pm/size-remark-emitter.mir
@@ -1,0 +1,44 @@
+# REQUIRES: x86-registered-target
+
+# RUN: llc -mtriple=x86_64-unknown-linux-gnu -filetype=null %s \
+# RUN: -p dead-mi-elimination -pass-remarks-analysis='size-info' \
+# RUN: -pass-remarks-output=%t.yaml < %s 2> %t; \
+# RUN: cat %t %t.yaml | FileCheck %s
+
+--- |
+  source_filename = "size-remark-emitter.mir"
+  target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
+  target triple = "x86_64-unknown-linux-gnu"
+  
+  define void @test() {
+  entry:
+    unreachable
+  }
+
+...
+---
+name:            test
+body:             |
+  bb.0:
+    %1:gr64 = MOV64ri 0
+    %2:gr64 = MOV64ri 0
+    $eax = COPY %1
+    RET64 implicit $eax
+...
+
+# CHECK: --- !Analysis
+# CHECK: Pass:            size-info
+# CHECK: Name:            FunctionMISizeChange
+# CHECK: Function:        test
+# CHECK: Args:
+# CHECK:   - Pass:            DeadMachineInstructionElimPass
+# CHECK:   - String:          ': Function: '
+# CHECK:   - Function:        test
+# CHECK:   - String:          ': '
+# CHECK:   - String:          'MI Instruction count changed from '
+# CHECK:   - MIInstrsBefore:  '4'
+# CHECK:   - String:          ' to '
+# CHECK:   - MIInstrsAfter:   '3'
+# CHECK:   - String:          '; Delta: '
+# CHECK:   - Delta:           '-1'
+# CHECK: ...

--- a/llvm/test/tools/llc/new-pm/size-remark-emitter.mir
+++ b/llvm/test/tools/llc/new-pm/size-remark-emitter.mir
@@ -5,17 +5,6 @@
 # RUN: -pass-remarks-output=%t.yaml < %s 2> %t; \
 # RUN: cat %t %t.yaml | FileCheck %s
 
---- |
-  source_filename = "size-remark-emitter.mir"
-  target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
-  target triple = "x86_64-unknown-linux-gnu"
-  
-  define void @test() {
-  entry:
-    unreachable
-  }
-
-...
 ---
 name:            test
 body:             |

--- a/llvm/tools/llc/NewPMDriver.cpp
+++ b/llvm/tools/llc/NewPMDriver.cpp
@@ -116,7 +116,6 @@ int llvm::compileModuleWithNewPM(
 
   PassInstrumentationCallbacks PIC;
   StandardInstrumentations SI(Context, Opt.DebugPM, !NoVerify);
-  SI.registerCallbacks(PIC);
   registerCodeGenCallback(PIC, LLVMTM);
 
   MachineFunctionAnalysisManager MFAM;
@@ -124,6 +123,7 @@ int llvm::compileModuleWithNewPM(
   FunctionAnalysisManager FAM;
   CGSCCAnalysisManager CGAM;
   ModuleAnalysisManager MAM;
+  SI.registerCallbacks(PIC, &MAM);
   PassBuilder PB(Target.get(), PipelineTuningOptions(), std::nullopt, &PIC);
   PB.registerModuleAnalyses(MAM);
   PB.registerCGSCCAnalyses(CGAM);


### PR DESCRIPTION
Port size remark emitter part to instrumentation. It supports both machine module pass and machine function pass, so we can remove the workaround in `MachineOutliner` in future.