### PR TITLE
[clang-tidy] Ignore casts from void to void in bugprone-casting-through-void

### DIFF
--- a/clang-tools-extra/clang-tidy/bugprone/CastingThroughVoidCheck.cpp
+++ b/clang-tools-extra/clang-tidy/bugprone/CastingThroughVoidCheck.cpp
@@ -7,12 +7,10 @@
 //===----------------------------------------------------------------------===//
 
 #include "CastingThroughVoidCheck.h"
-#include "clang/AST/ASTContext.h"
 #include "clang/AST/Expr.h"
 #include "clang/AST/Type.h"
 #include "clang/ASTMatchers/ASTMatchFinder.h"
 #include "clang/ASTMatchers/ASTMatchers.h"
-#include "llvm/ADT/StringSet.h"
 
 using namespace clang::ast_matchers;
 
@@ -27,7 +25,8 @@ void CastingThroughVoidCheck::registerMatchers(MatchFinder *Finder) {
           hasSourceExpression(
               explicitCastExpr(
                   hasSourceExpression(
-                      expr(hasType(qualType().bind("source_type")))),
+                      expr(hasType(qualType(unless(pointsTo(voidType())))
+                                       .bind("source_type")))),
                   hasDestinationType(
                       qualType(pointsTo(voidType())).bind("void_type")))
                   .bind("cast"))),

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -173,6 +173,11 @@ Changes in existing checks
   <clang-tidy/checks/bugprone/assert-side-effect>` check by detecting side
   effect from calling a method with non-const reference parameters.
 
+- Improved :doc:`bugprone-casting-through-void
+  <clang-tidy/checks/bugprone/casting-through-void>` check by ignoring casts
+  where source is already a ``void``` pointer, making middle ``void`` pointer
+  casts bug-free.
+
 - Improved :doc:`bugprone-forwarding-reference-overload
   <clang-tidy/checks/bugprone/forwarding-reference-overload>`
   check to ignore deleted constructors which won't hide other overloads.

--- a/clang-tools-extra/test/clang-tidy/checkers/bugprone/casting-through-void.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/bugprone/casting-through-void.cpp
@@ -89,3 +89,10 @@ void bit_cast() {
   __builtin_bit_cast(int *, static_cast<void *>(&d));
   // CHECK-MESSAGES: :[[@LINE-1]]:29: warning: do not cast 'double *' to 'int *' through 'void *' [bugprone-casting-through-void]
 }
+
+namespace PR87069 {
+  void castconstVoidToVoid() {
+    const void* ptr = nullptr;
+    int* numberPtr = static_cast<int*>(const_cast<void*>(ptr));
+  }
+}


### PR DESCRIPTION
Improved bugprone-casting-through-void check by ignoring casts where source is already a void pointer, making middle void pointer casts bug-free.

Closes #87069