### PR TITLE
[AArch64][MC]Add diagnostic message for Multiple of 2/4 for ZPR128

### DIFF
--- a/llvm/lib/Target/AArch64/AsmParser/AArch64AsmParser.cpp
+++ b/llvm/lib/Target/AArch64/AsmParser/AArch64AsmParser.cpp
@@ -6136,6 +6136,7 @@ bool AArch64AsmParser::showMatchError(SMLoc Loc, unsigned ErrCode,
   case Match_InvalidSVEVectorListMul2x16:
   case Match_InvalidSVEVectorListMul2x32:
   case Match_InvalidSVEVectorListMul2x64:
+  case Match_InvalidSVEVectorListMul2x128:
     return Error(Loc, "Invalid vector list, expected list with 2 consecutive "
                       "SVE vectors, where the first vector is a multiple of 2 "
                       "and with matching element types");
@@ -6143,6 +6144,7 @@ bool AArch64AsmParser::showMatchError(SMLoc Loc, unsigned ErrCode,
   case Match_InvalidSVEVectorListMul4x16:
   case Match_InvalidSVEVectorListMul4x32:
   case Match_InvalidSVEVectorListMul4x64:
+  case Match_InvalidSVEVectorListMul4x128:
     return Error(Loc, "Invalid vector list, expected list with 4 consecutive "
                       "SVE vectors, where the first vector is a multiple of 4 "
                       "and with matching element types");
@@ -6739,10 +6741,12 @@ bool AArch64AsmParser::MatchAndEmitInstruction(SMLoc IDLoc, unsigned &Opcode,
   case Match_InvalidSVEVectorListMul2x16:
   case Match_InvalidSVEVectorListMul2x32:
   case Match_InvalidSVEVectorListMul2x64:
+  case Match_InvalidSVEVectorListMul2x128:
   case Match_InvalidSVEVectorListMul4x8:
   case Match_InvalidSVEVectorListMul4x16:
   case Match_InvalidSVEVectorListMul4x32:
   case Match_InvalidSVEVectorListMul4x64:
+  case Match_InvalidSVEVectorListMul4x128:
   case Match_InvalidSVEVectorListStrided2x8:
   case Match_InvalidSVEVectorListStrided2x16:
   case Match_InvalidSVEVectorListStrided2x32:

--- a/llvm/test/MC/AArch64/FP8_SME2/lut-diagnostics.s
+++ b/llvm/test/MC/AArch64/FP8_SME2/lut-diagnostics.s
@@ -25,3 +25,13 @@ luti4   {z0.b - z12.b}, zt0, {z0-z1}
 // CHECK: [[@LINE-1]]:{{[0-9]+}}: error: invalid number of vectors
 // CHECK-NEXT: luti4   {z0.b - z12.b}, zt0, {z0-z1}
 // CHECK-NOT: [[@LINE-1]]:{{[0-9]+}}:
+
+zip {z1.q-z2.q}, z0.q, z0.q
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: Invalid vector list, expected list with 2 consecutive SVE vectors, where the first vector is a multiple of 2 and with matching element types
+// CHECK-NEXT: zip {z1.q-z2.q}, z0.q, z0.q
+// CHECK-NOT: [[@LINE-1]]:{{[0-9]+}}:
+
+zip {z1.q-z4.q}, z0.q, z0.q
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: Invalid vector list, expected list with 4 consecutive SVE vectors, where the first vector is a multiple of 4 and with matching element types
+// CHECK-NEXT: zip {z1.q-z4.q}, z0.q, z0.q
+// CHECK-NOT: [[@LINE-1]]:{{[0-9]+}}:

--- a/llvm/test/MC/AArch64/FP8_SME2/lut-diagnostics.s
+++ b/llvm/test/MC/AArch64/FP8_SME2/lut-diagnostics.s
@@ -25,13 +25,3 @@ luti4   {z0.b - z12.b}, zt0, {z0-z1}
 // CHECK: [[@LINE-1]]:{{[0-9]+}}: error: invalid number of vectors
 // CHECK-NEXT: luti4   {z0.b - z12.b}, zt0, {z0-z1}
 // CHECK-NOT: [[@LINE-1]]:{{[0-9]+}}:
-
-zip {z1.q-z2.q}, z0.q, z0.q
-// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: Invalid vector list, expected list with 2 consecutive SVE vectors, where the first vector is a multiple of 2 and with matching element types
-// CHECK-NEXT: zip {z1.q-z2.q}, z0.q, z0.q
-// CHECK-NOT: [[@LINE-1]]:{{[0-9]+}}:
-
-zip {z1.q-z4.q}, z0.q, z0.q
-// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: Invalid vector list, expected list with 4 consecutive SVE vectors, where the first vector is a multiple of 4 and with matching element types
-// CHECK-NEXT: zip {z1.q-z4.q}, z0.q, z0.q
-// CHECK-NOT: [[@LINE-1]]:{{[0-9]+}}:

--- a/llvm/test/MC/AArch64/SME2/zip-diagnostics.s
+++ b/llvm/test/MC/AArch64/SME2/zip-diagnostics.s
@@ -23,3 +23,12 @@ zip {z20.b-z23.b}, {z9.b-z12.b}
 // CHECK-NEXT: zip {z20.b-z23.b}, {z9.b-z12.b}
 // CHECK-NOT: [[@LINE-1]]:{{[0-9]+}}:
 
+zip {z1.q-z2.q}, z0.q, z0.q
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: Invalid vector list, expected list with 2 consecutive SVE vectors, where the first vector is a multiple of 2 and with matching element types
+// CHECK-NEXT: zip {z1.q-z2.q}, z0.q, z0.q
+// CHECK-NOT: [[@LINE-1]]:{{[0-9]+}}:
+
+zip {z1.q-z4.q}, z0.q, z0.q
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: Invalid vector list, expected list with 4 consecutive SVE vectors, where the first vector is a multiple of 4 and with matching element types
+// CHECK-NEXT: zip {z1.q-z4.q}, z0.q, z0.q
+// CHECK-NOT: [[@LINE-1]]:{{[0-9]+}}:


### PR DESCRIPTION
This patch fix the crash reported in:
https://github.com/llvm/llvm-project/issues/90589