### PR TITLE
[HipStdPar] Fix globle variable

### DIFF
--- a/llvm/lib/Transforms/HipStdPar/HipStdPar.cpp
+++ b/llvm/lib/Transforms/HipStdPar/HipStdPar.cpp
@@ -133,6 +133,7 @@ static inline void maybeHandleGlobals(Module &M) {
       continue;
 
     G.setLinkage(GlobalVariable::ExternalWeakLinkage);
+    G.setInitializer(nullptr);
     G.setExternallyInitialized(true);
   }
 }

--- a/llvm/test/Transforms/HipStdPar/global-var.ll
+++ b/llvm/test/Transforms/HipStdPar/global-var.ll
@@ -1,0 +1,11 @@
+; RUN: opt -S -mtriple=amdgcn-amd-amdhsa -passes=hipstdpar-select-accelerator-code \
+; RUN: %s | FileCheck %s
+
+; CHECK: @var = extern_weak addrspace(1) externally_initialized global i32, align 4
+@var = addrspace(1) global i32 0, align 4
+
+define amdgpu_kernel void @kernel() {
+entry:
+  store i32 1, ptr addrspace(1) @var, align 4
+  ret void
+}


### PR DESCRIPTION
HipStdParAcceleratorCodeSelectionPass changes linkage of global variables to extern_weak, which does not allow initializer.

An extern_weak global variable with initializer will cause llvm-as and llc to fail.