### PR TITLE
Add isTrivial() and isTriviallyCopyable() AST matchers

### DIFF
--- a/clang/unittests/ASTMatchers/ASTMatchersNarrowingTest.cpp
+++ b/clang/unittests/ASTMatchers/ASTMatchersNarrowingTest.cpp
@@ -1850,6 +1850,33 @@ TEST_P(ASTMatchersTest, IsDeleted) {
                       functionDecl(hasName("Func"), isDeleted())));
 }
 
+TEST_P(ASTMatchersTest, IsTrivial) {
+  if (!GetParam().isCXX()) {
+    return;
+  }
+
+  EXPECT_TRUE(notMatches("class A { A(); };",
+                         cxxRecordDecl(hasName("A"), isTrivial())));
+  EXPECT_TRUE(matches("class B { B() = default; };",
+                      cxxRecordDecl(hasName("B"), isTrivial())));
+
+  EXPECT_TRUE(notMatches("class A { ~A(); }; A::~A() = default;",
+                         cxxMethodDecl(hasName("~A"), isTrivial())));
+  EXPECT_TRUE(matches("class B { ~B() = default; };",
+                      cxxMethodDecl(hasName("~B"), isTrivial())));
+}
+
+TEST_P(ASTMatchersTest, IsTriviallyCopyable) {
+  if (!GetParam().isCXX()) {
+    return;
+  }
+
+  EXPECT_TRUE(notMatches("class A { ~A(); }; A::~A() = default;",
+                         cxxRecordDecl(hasName("A"), isTriviallyCopyable())));
+  EXPECT_TRUE(matches("class B { ~B() = default; };",
+                      cxxRecordDecl(hasName("B"), isTriviallyCopyable())));
+}
+
 TEST_P(ASTMatchersTest, IsNoThrow_DynamicExceptionSpec) {
   if (!GetParam().supportsCXXDynamicExceptionSpecification()) {
     return;


### PR DESCRIPTION
There are currently no AST matchers for the equivalent of `std::is_trivial`, `std::is_trivially_default_constructible`, `std::is_trivially_copyable`, and the like.

This pull request adds matchers to check if records and their member functions are trivial.

It does _not_ attempt to handle other trivial entities (such as pointers).