### PR TITLE
[Clang][Sema] fix a bug on constraint check with template friend function

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -630,6 +630,7 @@ Bug Fixes to C++ Support
 - Fix a bug on template partial specialization with issue on deduction of nontype template parameter
   whose type is `decltype(auto)`. Fixes (#GH68885).
 - Clang now correctly treats the noexcept-specifier of a friend function to be a complete-class context.
+- Fix a bug on constraint check with template friend function. Fixes (#GH90349).
 
 Bug Fixes to AST Handling
 ^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/clang/lib/Sema/SemaTemplateInstantiate.cpp
+++ b/clang/lib/Sema/SemaTemplateInstantiate.cpp
@@ -292,7 +292,7 @@ Response HandleFunction(Sema &SemaRef, const FunctionDecl *Function,
         if (TemplatePattern && FunctionPattern &&
             TemplatePattern->getTemplateDepth() ==
                 FunctionPattern->getTemplateDepth())
-          return Response::Done();
+          return Response::UseNextDecl(Function);
       }
 
     // If this function is a generic lambda specialization, we are done.

--- a/clang/lib/Sema/SemaTemplateInstantiate.cpp
+++ b/clang/lib/Sema/SemaTemplateInstantiate.cpp
@@ -281,6 +281,20 @@ Response HandleFunction(Sema &SemaRef, const FunctionDecl *Function,
     if (Function->getPrimaryTemplate()->isMemberSpecialization())
       return Response::Done();
 
+    if (Function->getFriendObjectKind())
+      if (const ClassTemplateSpecializationDecl *TD =
+              dyn_cast<ClassTemplateSpecializationDecl>(
+                  Function->getLexicalDeclContext())) {
+        const CXXRecordDecl *TemplatePattern =
+            TD->getTemplateInstantiationPattern();
+        const FunctionDecl *FunctionPattern =
+            Function->getTemplateInstantiationPattern();
+        if (TemplatePattern && FunctionPattern &&
+            TemplatePattern->getTemplateDepth() ==
+                FunctionPattern->getTemplateDepth())
+          return Response::Done();
+      }
+
     // If this function is a generic lambda specialization, we are done.
     if (!ForConstraintInstantiation &&
         isGenericLambdaCallOperatorOrStaticInvokerSpecialization(Function)) {

--- a/clang/test/SemaCXX/PR90349.cpp
+++ b/clang/test/SemaCXX/PR90349.cpp
@@ -1,0 +1,43 @@
+// RUN: %clang_cc1 -verify -std=c++20 -fsyntax-only %s
+
+// expected-no-diagnostics
+
+namespace std {
+template<class T>
+concept floating_point = __is_same(T,double) || __is_same(T,float);
+
+template<class T>
+concept integral = __is_same(T,int);
+
+}
+
+template<std::integral T, std::floating_point Float>
+class Blob;
+
+template<std::floating_point Float, std::integral T>
+Blob<T, Float> MakeBlob();
+
+template<std::integral T, std::floating_point Float>
+class Blob {
+private:
+    Blob() {}
+
+    friend Blob<T, Float> MakeBlob<Float, T>();
+};
+
+template<std::floating_point Float, std::integral T>
+Blob<T, Float> MakeBlob()
+{
+    return Blob<T, Float>();
+}
+
+template<std::floating_point Float, std::integral T>
+Blob<T, Float> FindBlobs()
+{
+    return MakeBlob<Float, T>();
+}
+
+int main(int argc, const char * argv[]) {
+    FindBlobs<double, int>();
+    return 0;
+}

--- a/clang/test/SemaCXX/PR90349.cpp
+++ b/clang/test/SemaCXX/PR90349.cpp
@@ -41,3 +41,27 @@ int main(int argc, const char * argv[]) {
     FindBlobs<double, int>();
     return 0;
 }
+
+template<typename T, typename U>
+concept D = sizeof(T) == sizeof(U);
+
+template<typename T>
+struct A
+{
+    template<typename U, typename V> requires D<U, V>
+    static void f();
+};
+
+template<typename T, typename U>
+struct B
+{
+    template<typename V>
+    struct C
+    {
+        friend void A<char>::f<T, U>();
+    };
+};
+
+template struct B<int, int>::C<short>;
+
+extern template void A<char>::f<int, int>(); // crash here


### PR DESCRIPTION
attempt to fix https://github.com/llvm/llvm-project/issues/90349
Skip to add outer class template arguments to `MTAL` when the friend function has the same depth with its lexical context(`CXXRecordDecl`).