### PR TITLE
[flang][cuda] Allow PINNED argument to host dummy

### DIFF
--- a/flang/lib/Common/Fortran.cpp
+++ b/flang/lib/Common/Fortran.cpp
@@ -103,6 +103,9 @@ bool AreCompatibleCUDADataAttrs(std::optional<CUDADataAttr> x,
     return true;
   } else if (x && y && *x == *y) {
     return true;
+  } else if ((!x && y && *y == CUDADataAttr::Pinned) ||
+      (x && *x == CUDADataAttr::Pinned && !y)) {
+    return true;
   } else if (ignoreTKR.test(IgnoreTKR::Device) &&
       x.value_or(CUDADataAttr::Device) == CUDADataAttr::Device &&
       y.value_or(CUDADataAttr::Device) == CUDADataAttr::Device) {

--- a/flang/test/Semantics/cuf13.cuf
+++ b/flang/test/Semantics/cuf13.cuf
@@ -1,0 +1,28 @@
+! RUN: %python %S/test_errors.py %s %flang_fc1
+
+module matching
+  interface sub
+    module procedure sub_host
+    module procedure sub_device
+  end interface
+
+contains
+  subroutine sub_host(a)
+    integer :: a(:)
+  end
+
+  subroutine sub_device(a)
+    integer, device :: a(:)
+  end
+
+end module
+
+program m
+  use matching
+
+  integer, pinned, allocatable :: a(:)
+  logical :: plog
+  allocate(a(100), pinned = plog)
+
+  call sub(a)
+end


### PR DESCRIPTION
Update the `AreCompatibleCUDADataAttrs` function to return true when one argument has the `PINNED` attribute and the other argument is just host data. 