### PR TITLE
[Coroutines][Test] Only run coro-elide-thinlto under x86_64-linux

### DIFF
--- a/clang/test/CodeGenCoroutines/coro-elide-thinlto.cpp
+++ b/clang/test/CodeGenCoroutines/coro-elide-thinlto.cpp
@@ -1,3 +1,4 @@
+// REQUIRES: x86_64-linux
 // This tests that the coroutine elide optimization could happen succesfully with ThinLTO.
 // This test is adapted from coro-elide.cpp and splits functions into two files.
 //


### PR DESCRIPTION
Previous fix #90549 didn't completely address the Buildbot failures. Some target may not recognize the target triple. This time, only run the test under x86_64-linux.