### PR TITLE
[Frontend][OpenMP] Add `order` clause as allowed for `distribute`

### DIFF
--- a/llvm/include/llvm/Frontend/OpenMP/OMP.td
+++ b/llvm/include/llvm/Frontend/OpenMP/OMP.td
@@ -1173,7 +1173,8 @@ def OMP_Distribute : Directive<"distribute"> {
     VersionedClause<OMPC_Private>,
     VersionedClause<OMPC_FirstPrivate>,
     VersionedClause<OMPC_LastPrivate>,
-    VersionedClause<OMPC_Allocate>
+    VersionedClause<OMPC_Allocate>,
+    VersionedClause<OMPC_Order, 51>
   ];
   let allowedOnceClauses = [
     VersionedClause<OMPC_Collapse>,


### PR DESCRIPTION
Starting from OpenMP spec 5.1, the `order` clause is allowed on the `distribute` directive.