### PR TITLE
[HLSL] Cleanup TargetInfo handling

### DIFF
--- a/clang/lib/AST/ASTContext.cpp
+++ b/clang/lib/AST/ASTContext.cpp
@@ -1612,15 +1612,7 @@ const llvm::fltSemantics &ASTContext::getFloatTypeSemantics(QualType T) const {
   case BuiltinType::Float16:
     return Target->getHalfFormat();
   case BuiltinType::Half:
-    // For HLSL, when the native half type is disabled, half will be treat as
-    // float.
-    if (getLangOpts().HLSL)
-      if (getLangOpts().NativeHalfType)
-        return Target->getHalfFormat();
-      else
-        return Target->getFloatFormat();
-    else
-      return Target->getHalfFormat();
+    return Target->getHalfFormat();
   case BuiltinType::Float:      return Target->getFloatFormat();
   case BuiltinType::Double:     return Target->getDoubleFormat();
   case BuiltinType::Ibm128:

--- a/clang/lib/Basic/TargetInfo.cpp
+++ b/clang/lib/Basic/TargetInfo.cpp
@@ -406,6 +406,16 @@ void TargetInfo::adjust(DiagnosticsEngine &Diags, LangOptions &Opts) {
     LongDoubleAlign = 64;
   }
 
+  // HLSL explicitly defines the sizes and formats of some data types, and we
+  // need to conform to those regardless of what architecture you are targeting.
+  if (Opts.HLSL) {
+    LongWidth = LongAlign = 64;
+    if (!Opts.NativeHalfType) {
+      HalfFormat = &llvm::APFloat::IEEEsingle();
+      HalfWidth = HalfAlign = 32;
+    }
+  }
+
   if (Opts.OpenCL) {
     // OpenCL C requires specific widths for types, irrespective of
     // what these normally are for the target.

--- a/clang/lib/Basic/Targets/DirectX.h
+++ b/clang/lib/Basic/Targets/DirectX.h
@@ -53,7 +53,6 @@ public:
       : TargetInfo(Triple) {
     TLSSupported = false;
     VLASupported = false;
-    LongWidth = LongAlign = 64;
     AddrSpaceMap = &DirectXAddrSpaceMap;
     UseAddrSpaceMapMangling = true;
     HasLegalHalfType = true;

--- a/clang/test/SemaHLSL/Types/Arithmetic/half_size.hlsl
+++ b/clang/test/SemaHLSL/Types/Arithmetic/half_size.hlsl
@@ -1,0 +1,11 @@
+// RUN: %clang_cc1 -triple dxil-pc-shadermodel6.4-library -verify %s
+// RUN: %clang_cc1 -triple dxil-pc-shadermodel6.4-library -verify -fnative-half-type %s
+// RUN: %clang_cc1 -triple spirv-linux-vulkan-library -verify %s
+// RUN: %clang_cc1 -triple spirv-linux-vulkan-library -verify -fnative-half-type %s
+
+// expected-no-diagnostics
+#ifdef __HLSL_ENABLE_16_BIT
+_Static_assert(sizeof(half) == 2, "half is 2 bytes");
+#else
+_Static_assert(sizeof(half) == 4, "half is 4 bytes");
+#endif


### PR DESCRIPTION
We had some odd places where we set target behaviors. We were setting the long size in target-specific code, but it should be language-based. We were not setting the Half float type semantics correctly, and instead were overriding the query in the AST context.

This change it moves existing code to the right places in the Target so that as we continue working on target and language feature they are controlled in the right places.

It also fixes a bug where the size of `half` was computed incorrectly when native half types are not supported.