### PR TITLE
[libcxx][ci] In picolib build, ask clang for the normalised triple

### DIFF
--- a/libcxx/utils/ci/run-buildbot
+++ b/libcxx/utils/ci/run-buildbot
@@ -217,7 +217,19 @@ function test-armv7m-picolibc() {
         "${@}"
 
     ${NINJA} -vC "${BUILD_DIR}/compiler-rt" install
-    mv "${BUILD_DIR}/install/lib/armv7m-none-unknown-eabi"/* "${BUILD_DIR}/install/lib"
+
+    # Prior to clang 19, armv7m-none-eabi normalised to armv7m-none-unknown-eabi.
+    # clang 19 changed this to armv7m-unknown-none-eabi. So for as long as 18.x
+    # is supported, we have to ask clang what the triple will be.
+    if [ ! -z "${CC}" ]
+    then
+        C_COMPILER=${CC};
+    else
+        C_COMPILER=cc;
+    fi
+    NORMALISED_TARGET_TRIPLE=$(${C_COMPILER} --target=armv7m-none-eabi -print-target-triple)
+    # Without this step linking fails later in the build.
+    mv "${BUILD_DIR}/install/lib/${NORMALISED_TARGET_TRIPLE}"/* "${BUILD_DIR}/install/lib"
 
     check-runtimes
 }

--- a/libcxx/utils/ci/run-buildbot
+++ b/libcxx/utils/ci/run-buildbot
@@ -221,13 +221,7 @@ function test-armv7m-picolibc() {
     # Prior to clang 19, armv7m-none-eabi normalised to armv7m-none-unknown-eabi.
     # clang 19 changed this to armv7m-unknown-none-eabi. So for as long as 18.x
     # is supported, we have to ask clang what the triple will be.
-    if [ ! -z "${CC}" ]
-    then
-        C_COMPILER=${CC};
-    else
-        C_COMPILER=cc;
-    fi
-    NORMALISED_TARGET_TRIPLE=$(${C_COMPILER} --target=armv7m-none-eabi -print-target-triple)
+    NORMALISED_TARGET_TRIPLE=$(${CC-cc} --target=armv7m-none-eabi -print-target-triple)
     # Without this step linking fails later in the build.
     mv "${BUILD_DIR}/install/lib/${NORMALISED_TARGET_TRIPLE}"/* "${BUILD_DIR}/install/lib"
 


### PR DESCRIPTION
This is needed for a workaround to make sure the link later succeeds. I don't know the reason for that but it is definitely needed.

https://github.com/llvm/llvm-project/pull/89234 will/wants to correct the triple normalisation for -none- and this means that clang prior to 19, and clang 19 and above will have different answers and therefore different library paths.

I don't want to bootstrap a clang just for libcxx CI, or require that anyone building for Arm do the same, so ask the compiler what the triple should be.

This will be compatible with 17 and 19 when we do update to that version.

I'm assuming $CC is what anyone locally would set to override the compiler, and `cc` is the binary name in our CI containers. It's not perfect but it should cover most use cases.