### PR TITLE
Adjust MSVC version range for ARM64 build performance regression

### DIFF
--- a/clang/lib/CodeGen/CMakeLists.txt
+++ b/clang/lib/CodeGen/CMakeLists.txt
@@ -39,6 +39,7 @@ set(LLVM_LINK_COMPONENTS
 # our goal is to disable the /Og flag while retaining the other optimizations from the /O1|/O2 set
 if(MSVC AND NOT CMAKE_CXX_COMPILER_ID MATCHES Clang
     AND MSVC_VERSION VERSION_GREATER_EQUAL 1932
+    AND MSVC_VERSION VERSION_LESS 1939
     AND CMAKE_SYSTEM_PROCESSOR MATCHES "ARM64")
 
   string(TOUPPER "${CMAKE_BUILD_TYPE}" uppercase_CMAKE_BUILD_TYPE)

--- a/clang/lib/Tooling/Inclusions/Stdlib/CMakeLists.txt
+++ b/clang/lib/Tooling/Inclusions/Stdlib/CMakeLists.txt
@@ -4,6 +4,7 @@
 # our goal is to disable the /Og flag while retaining the other optimizations from the /O1|/O2 set
 if(MSVC AND NOT CMAKE_CXX_COMPILER_ID MATCHES Clang
     AND MSVC_VERSION VERSION_GREATER_EQUAL 1932
+    AND MSVC_VERSION VERSION_LESS 1939
     AND CMAKE_SYSTEM_PROCESSOR MATCHES "ARM64")
 
   string(TOUPPER "${CMAKE_BUILD_TYPE}" uppercase_CMAKE_BUILD_TYPE)


### PR DESCRIPTION
This is follow up for #65215

Mentioned regression was fixed in MSVC 19.39 (VS 17.9.0), so it makes sense to not apply fix for that (and newer) compiler versions.

Same as original change, this patch is narrowly scoped to not affect any other compiler.