### PR TITLE
[alpha.webkit.UncountedLocalVarsChecker] Don't warning on inlined functions

### DIFF
--- a/clang/lib/StaticAnalyzer/Checkers/WebKit/UncountedLocalVarsChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/WebKit/UncountedLocalVarsChecker.cpp
@@ -178,6 +178,11 @@ public:
     if (shouldSkipVarDecl(V))
       return;
 
+    if (auto *FD = dyn_cast<FunctionDecl>(V->getDeclContext())) {
+      if (FD->isInlined())
+        return;
+    }
+
     const auto *ArgType = V->getType().getTypePtr();
     if (!ArgType)
       return;


### PR DESCRIPTION
As per the guidelines, trivial inline functions shouldn't be changed to adopt smart pointers.