### PR TITLE
[Hexagon] Fix hexagon-copy-hoisting.mir

### DIFF
--- a/llvm/test/CodeGen/Hexagon/hexagon-copy-hoisting.mir
+++ b/llvm/test/CodeGen/Hexagon/hexagon-copy-hoisting.mir
@@ -11,7 +11,7 @@
 
 ---
 name:            f0
-tracksRegLiveness: true
+tracksRegLiveness: false
 registers:
   - { id: 0, class: intregs, preferred-register: '' }
   - { id: 1, class: intregs, preferred-register: '' }
@@ -19,15 +19,11 @@ registers:
   - { id: 3, class: predregs, preferred-register: '' }
   - { id: 4, class: intregs, preferred-register: '' }
   - { id: 5, class: intregs, preferred-register: '' }
-liveins:
-  - { reg: '$r0', virtual-reg: '%0' }
-  - { reg: '$r1', virtual-reg: '%1' }
 stack:
   - { id: 0, offset: 0, size: 4, alignment: 8 }
 body: |
   bb.0:
     successors: %bb.1, %bb.2
-    liveins: $r0, $r1
 
     %1:intregs = COPY $r1
     %0:intregs = COPY $r0


### PR DESCRIPTION
The hexagon-copy-hoisting.mir test fails when run with -verify-machineinstrs. This patch fixes this by disabling tracksRegLiveness.