### PR TITLE
[StandardInstrumentation] Annotate loops with the function name

### DIFF
--- a/llvm/lib/Passes/StandardInstrumentations.cpp
+++ b/llvm/lib/Passes/StandardInstrumentations.cpp
@@ -245,7 +245,8 @@ std::string getIRName(Any IR) {
     return C->getName();
 
   if (const auto *L = unwrapIR<Loop>(IR))
-    return L->getName().str();
+    return "loop %" + L->getName().str() + " in function " +
+           L->getHeader()->getParent()->getName().str();
 
   if (const auto *MF = unwrapIR<MachineFunction>(IR))
     return MF->getName().str();

--- a/llvm/test/Other/dump-before-after-invalidated.ll
+++ b/llvm/test/Other/dump-before-after-invalidated.ll
@@ -7,7 +7,7 @@
 ; RUN: ls %t/logs | count 1
 ; RUN: cat %t/logs/* | FileCheck %s --check-prefix=CHECK-CONTENTS
 
-; CHECK-CONTENTS: ; *** IR Dump After LoopDeletionPass on bb1 (invalidated) ***
+; CHECK-CONTENTS: ; *** IR Dump After LoopDeletionPass on loop %bb1 in function foo (invalidated) ***
 ; CHECK-CONTENTS: define void @foo() {
 ; CHECK-CONTENTS:   br label %bb2
 ; CHECK-CONTENTS: bb2:                                              ; preds = %0

--- a/llvm/test/Other/loop-pass-ordering.ll
+++ b/llvm/test/Other/loop-pass-ordering.ll
@@ -8,11 +8,11 @@
 ;      /      \        \
 ; loop.0.0  loop.0.1  loop.1.0
 ;
-; CHECK: Running pass: NoOpLoopPass on loop.0.0
-; CHECK: Running pass: NoOpLoopPass on loop.0.1
-; CHECK: Running pass: NoOpLoopPass on loop.0
-; CHECK: Running pass: NoOpLoopPass on loop.1.0
-; CHECK: Running pass: NoOpLoopPass on loop.1
+; CHECK: Running pass: NoOpLoopPass on loop %loop.0.0 in function f
+; CHECK: Running pass: NoOpLoopPass on loop %loop.0.1 in function f
+; CHECK: Running pass: NoOpLoopPass on loop %loop.0 in function f
+; CHECK: Running pass: NoOpLoopPass on loop %loop.1.0 in function f
+; CHECK: Running pass: NoOpLoopPass on loop %loop.1 in function f
 
 define void @f() {
 entry:

--- a/llvm/test/Other/loop-print-after-pass-invalidated.ll
+++ b/llvm/test/Other/loop-print-after-pass-invalidated.ll
@@ -3,8 +3,8 @@
 ; RUN:     -print-after=simple-loop-unswitch \
 ; RUN:	   | FileCheck %s
 
-; CHECK: *** IR Dump After SimpleLoopUnswitchPass on for.cond ***
-; CHECK: *** IR Dump After SimpleLoopUnswitchPass on for.cond.us ***
+; CHECK: *** IR Dump After SimpleLoopUnswitchPass on loop %for.cond in function loop ***
+; CHECK: *** IR Dump After SimpleLoopUnswitchPass on loop %for.cond.us in function loop ***
 
 define void @loop(i1 %w)  {
 entry:

--- a/llvm/test/Other/loopnest-pass-ordering.ll
+++ b/llvm/test/Other/loopnest-pass-ordering.ll
@@ -8,8 +8,8 @@
 ;      /      \        \
 ; loop.0.0  loop.0.1  loop.1.0
 ;
-; CHECK: Running pass: NoOpLoopNestPass on loop.0
-; CHECK: Running pass: NoOpLoopNestPass on loop.1
+; CHECK: Running pass: NoOpLoopNestPass on loop %loop.0 in function f
+; CHECK: Running pass: NoOpLoopNestPass on loop %loop.1 in function f
 ; CHECK-NOT: Running pass: NoOpLoopNestPass on {{loop\..*\..*}}
 
 define void @f() {

--- a/llvm/test/Other/print-at-pass-number.ll
+++ b/llvm/test/Other/print-at-pass-number.ll
@@ -4,7 +4,7 @@
 ; RUN: opt -passes="loop(indvars,loop-deletion,loop-unroll-full)" -print-module-scope -print-after-pass-number=2 -S -o /dev/null %s 2>&1 | FileCheck %s --check-prefix=AFTER
 
 define i32 @bar(i32 %arg) {
-; BEFORE: *** IR Dump Before 3-IndVarSimplifyPass on bb1 ***
+; BEFORE: *** IR Dump Before 3-IndVarSimplifyPass on loop %bb1 in function bar ***
 ; BEFORE: define i32 @bar(i32 %arg) {
 ; AFTER:  *** IR Dump After 2-LCSSAPass on bar ***
 ; AFTER:  define i32 @bar(i32 %arg) {
@@ -30,8 +30,8 @@ define i32 @baz(i32 %arg) {
 
 ; NUMBER:  Running pass 1 LoopSimplifyPass on bar
 ; NUMBER-NEXT: Running pass 2 LCSSAPass on bar
-; NUMBER-NEXT: Running pass 3 IndVarSimplifyPass on bb1
-; NUMBER-NEXT: Running pass 4 LoopDeletionPass on bb1
+; NUMBER-NEXT: Running pass 3 IndVarSimplifyPass on loop %bb1 in function bar
+; NUMBER-NEXT: Running pass 4 LoopDeletionPass on loop %bb1 in function bar
 ; NUMBER-NEXT: Running pass 5 LoopSimplifyPass on baz
 ; NUMBER-NEXT: Running pass 6 LCSSAPass on baz
 ; NUMBER-NOT: Running pass

--- a/llvm/test/Transforms/LoopPredication/invalidate-analyses.ll
+++ b/llvm/test/Transforms/LoopPredication/invalidate-analyses.ll
@@ -5,10 +5,10 @@
 ;       please update this test some other analysis that isn't preserved.
 
 ; CHECK: Running analysis: LazyValueAnalysis on drop_a_wc_and_leave_early
-; CHECK: Running pass: LoopPredicationPass on loop
+; CHECK: Running pass: LoopPredicationPass on loop %loop in function drop_a_wc_and_leave_early
 ; CHECK: Invalidating analysis: LazyValueAnalysis on drop_a_wc_and_leave_early
 ; CHECK: Running analysis: LazyValueAnalysis on drop_a_wc_and_leave
-; CHECK: Running pass: LoopPredicationPass on loop
+; CHECK: Running pass: LoopPredicationPass on loop %loop in function drop_a_wc_and_leave
 ; CHECK: Invalidating analysis: LazyValueAnalysis on drop_a_wc_and_leave
 
 

--- a/llvm/test/Transforms/LoopRotate/pr35210.ll
+++ b/llvm/test/Transforms/LoopRotate/pr35210.ll
@@ -17,7 +17,7 @@
 ; CHECK-NEXT: Running analysis: TargetLibraryAnalysis on f
 ; CHECK-NEXT: Running analysis: ScalarEvolutionAnalysis on f
 ; CHECK-NEXT: Running analysis: InnerAnalysisManagerProxy{{.*}} on f
-; CHECK-NEXT: Running pass: LoopRotatePass on bb
+; CHECK-NEXT: Running pass: LoopRotatePass on loop %bb in function f
 ; CHECK-NEXT: Folding loop latch bb4 into bb
 ; CHECK-NEXT: Invalidating analysis: PostDominatorTreeAnalysis on f
 ; CHECK-NEXT: Running pass: ADCEPass on f
@@ -36,7 +36,7 @@
 ; MSSA-NEXT: Running analysis: TargetLibraryAnalysis on f
 ; MSSA-NEXT: Running analysis: ScalarEvolutionAnalysis on f
 ; MSSA-NEXT: Running analysis: InnerAnalysisManagerProxy{{.*}} on f
-; MSSA-NEXT: Running pass: LoopRotatePass on bb
+; MSSA-NEXT: Running pass: LoopRotatePass on loop %bb in function f
 ; MSSA-NEXT: Folding loop latch bb4 into bb
 ; MSSA-NEXT: Invalidating analysis: PostDominatorTreeAnalysis on f
 ; MSSA-NEXT: Running pass: ADCEPass on f

--- a/llvm/test/Transforms/LoopUnroll/revisit.ll
+++ b/llvm/test/Transforms/LoopUnroll/revisit.ll
@@ -33,7 +33,7 @@ l0.0.0.ph:
 l0.0.0:
   %cond.0.0.0 = load volatile i1, ptr %ptr
   br i1 %cond.0.0.0, label %l0.0.0, label %l0.0.1.ph
-; CHECK: LoopFullUnrollPass on l0.0.0
+; CHECK: LoopFullUnrollPass on loop %l0.0.0
 ; CHECK-NOT: LoopFullUnrollPass
 
 l0.0.1.ph:
@@ -42,29 +42,29 @@ l0.0.1.ph:
 l0.0.1:
   %cond.0.0.1 = load volatile i1, ptr %ptr
   br i1 %cond.0.0.1, label %l0.0.1, label %l0.0.latch
-; CHECK: LoopFullUnrollPass on l0.0.1
+; CHECK: LoopFullUnrollPass on loop %l0.0.1 in function full_unroll
 ; CHECK-NOT: LoopFullUnrollPass
 
 l0.0.latch:
   %cmp = icmp slt i32 %iv.next, 2
   br i1 %cmp, label %l0.0, label %l0.latch
-; CHECK: LoopFullUnrollPass on l0.0
+; CHECK: LoopFullUnrollPass on loop %l0.0 in function full_unroll
 ; CHECK-NOT: LoopFullUnrollPass
 ;
 ; Unrolling occurs, so we visit what were the inner loops twice over. First we
 ; visit their clones, and then we visit the original loops re-parented.
-; CHECK: LoopFullUnrollPass on l0.0.1.1
+; CHECK: LoopFullUnrollPass on loop %l0.0.1.1 in function full_unroll 
 ; CHECK-NOT: LoopFullUnrollPass
-; CHECK: LoopFullUnrollPass on l0.0.0.1
+; CHECK: LoopFullUnrollPass on loop %l0.0.0.1 in function full_unroll
 ; CHECK-NOT: LoopFullUnrollPass
-; CHECK: LoopFullUnrollPass on l0.0.1
+; CHECK: LoopFullUnrollPass on loop %l0.0.1 in function full_unroll
 ; CHECK-NOT: LoopFullUnrollPass
-; CHECK: LoopFullUnrollPass on l0.0.0
+; CHECK: LoopFullUnrollPass on loop %l0.0.0 in function full_unroll
 ; CHECK-NOT: LoopFullUnrollPass
 
 l0.latch:
   br label %l0
-; CHECK: LoopFullUnrollPass on l0
+; CHECK: LoopFullUnrollPass on loop %l0 in function full_unroll
 ; CHECK-NOT: LoopFullUnrollPass
 
 exit:

--- a/llvm/test/Transforms/SimpleLoopUnswitch/nontrivial-unswitch-markloopasdeleted.ll
+++ b/llvm/test/Transforms/SimpleLoopUnswitch/nontrivial-unswitch-markloopasdeleted.ll
@@ -17,7 +17,7 @@
 ; SimpleLoopUnswitch not marking the Loop as removed, so we missed clearing
 ; the analysis caches.
 ;
-; CHECK: Running pass: SimpleLoopUnswitchPass on loop_begin
+; CHECK: Running pass: SimpleLoopUnswitchPass on loop %loop_begin in function test6
 ; CHECK-NEXT: Running analysis: OuterAnalysisManagerProxy
 ; CHECK-NEXT: Clearing all analysis results for: loop_a_inner
 


### PR DESCRIPTION
When analyzing pass debug output it is helpful to have the function name along with the loop name.