### PR TITLE
[RISCV] Add list of supported profiles to -print-supported-extensions

### DIFF
--- a/llvm/lib/TargetParser/RISCVISAInfo.cpp
+++ b/llvm/lib/TargetParser/RISCVISAInfo.cpp
@@ -98,6 +98,10 @@ void llvm::riscvExtensionsHelp(StringMap<StringRef> DescMap) {
     PrintExtension(E.first, Version, DescMap["experimental-" + E.first]);
   }
 
+  outs() << "\nSupported Profiles\n";
+  for (const auto &P : SupportedProfiles)
+    outs().indent(4) << P.Name << "\n";
+
   outs() << "\nUse -march to specify the target's extension.\n"
             "For example, clang -march=rv32i_v1p0\n";
 }

--- a/llvm/unittests/TargetParser/RISCVISAInfoTest.cpp
+++ b/llvm/unittests/TargetParser/RISCVISAInfoTest.cpp
@@ -906,6 +906,19 @@ Experimental extensions
     ssqosid              1.0
     supm                 0.8
 
+Supported Profiles
+    rva20s64
+    rva20u64
+    rva22s64
+    rva22u64
+    rva23s64
+    rva23u64
+    rvb23s64
+    rvb23u64
+    rvi20u32
+    rvi20u64
+    rvm23u32
+
 Use -march to specify the target's extension.
 For example, clang -march=rv32i_v1p0)";
   // clang-format on


### PR DESCRIPTION
I tried also printing the -march they correspond to, but it seemed overly verbose and caused line wraps. It might be better if we remove the versions numbers from the string or did a more intelligent line wrap.