### PR TITLE
[clang][flang][windows] Prefer user-provided library paths (-L)

### DIFF
--- a/clang/lib/Driver/ToolChains/MSVC.cpp
+++ b/clang/lib/Driver/ToolChains/MSVC.cpp
@@ -134,6 +134,10 @@ void visualstudio::Linker::ConstructJob(Compilation &C, const JobAction &JA,
           Args.MakeArgString(std::string("-libpath:") + WindowsSdkLibPath));
   }
 
+  if (!C.getDriver().IsCLMode() && Args.hasArg(options::OPT_L))
+    for (const auto &LibPath : Args.getAllArgValues(options::OPT_L))
+      CmdArgs.push_back(Args.MakeArgString("-libpath:" + LibPath));
+
   if (C.getDriver().IsFlangMode()) {
     addFortranRuntimeLibraryPath(TC, Args, CmdArgs);
     addFortranRuntimeLibs(TC, Args, CmdArgs);
@@ -153,10 +157,6 @@ void visualstudio::Linker::ConstructJob(Compilation &C, const JobAction &JA,
   auto CRTPath = TC.getCompilerRTPath();
   if (TC.getVFS().exists(CRTPath))
     CmdArgs.push_back(Args.MakeArgString("-libpath:" + CRTPath));
-
-  if (!C.getDriver().IsCLMode() && Args.hasArg(options::OPT_L))
-    for (const auto &LibPath : Args.getAllArgValues(options::OPT_L))
-      CmdArgs.push_back(Args.MakeArgString("-libpath:" + LibPath));
 
   CmdArgs.push_back("-nologo");
 

--- a/clang/test/Driver/flang/msvc-link.f90
+++ b/clang/test/Driver/flang/msvc-link.f90
@@ -1,8 +1,5 @@
-! REQUIRES: system-windows
+! RUN: %clang --driver-mode=flang -target x86_64-pc-windows-msvc -### %s -Ltest 2>&1 | FileCheck %s
 !
-! RUN: %clang --driver-mode=flang -### %s -Ltest 2>&1 | FileCheck %s
-!
-! Test that user provided paths come before the Flang runtimes and compiler-rt
+! Test that user provided paths come before the Flang runtimes
 ! CHECK: "-libpath:test"
-! CHECK: "-libpath:{{.*}}\\lib"
-! CHECK: "-libpath:{{.*}}\\lib\\clang\\{{[0-9]+}}\\lib\\windows"
+! CHECK: "-libpath:{{.*(\\|/)}}lib"

--- a/clang/test/Driver/flang/msvc-link.f90
+++ b/clang/test/Driver/flang/msvc-link.f90
@@ -1,0 +1,8 @@
+! REQUIRES: system-windows
+!
+! RUN: %clang --driver-mode=flang -### %s -Ltest 2>&1 | FileCheck %s
+!
+! Test that user provided paths come before the Flang runtimes and compiler-rt
+! CHECK: "-libpath:test"
+! CHECK: "-libpath:{{.*}}\\lib"
+! CHECK: "-libpath:{{.*}}\\lib\\clang\\{{[0-9]+}}\\lib\\windows"

--- a/clang/test/Driver/msvc-link.cpp
+++ b/clang/test/Driver/msvc-link.cpp
@@ -1,0 +1,7 @@
+// REQUIRES: system-windows
+//
+// RUN: %clang -### %s -Ltest 2>&1 | FileCheck %s
+//
+// Test that user provided paths come before compiler-rt
+// CHECK: "-libpath:test"
+// CHECK: "-libpath:{{.*}}\\lib\\clang\\{{[0-9]+}}\\lib\\windows"

--- a/clang/test/Driver/msvc-link.cpp
+++ b/clang/test/Driver/msvc-link.cpp
@@ -1,7 +1,0 @@
-// REQUIRES: system-windows
-//
-// RUN: %clang -### %s -Ltest 2>&1 | FileCheck %s
-//
-// Test that user provided paths come before compiler-rt
-// CHECK: "-libpath:test"
-// CHECK: "-libpath:{{.*}}\\lib\\clang\\{{[0-9]+}}\\lib\\windows"


### PR DESCRIPTION
Currently the paths to compiler-rt and the Flang runtimes from the LLVM build/install directory are preferred over any user-provided library paths. This means a user can't override compiler-rt or the Flang runtimes with custom versions.

This patch changes the link order to prefer library paths specified with -L over the LLVM paths. This matches the behaviour of clang and flang on Linux.