### PR TITLE
[SDPatternMatch] Add m_CondCode, m_NoneOf, and some SExt improvements

### DIFF
--- a/llvm/include/llvm/CodeGen/SDPatternMatch.h
+++ b/llvm/include/llvm/CodeGen/SDPatternMatch.h
@@ -780,12 +780,11 @@ inline auto m_False() {
 
 struct CondCode_match {
   std::optional<ISD::CondCode> CCToMatch;
-  ISD::CondCode *BindCC;
+  ISD::CondCode *BindCC = nullptr;
 
-  explicit CondCode_match(ISD::CondCode CC) : CCToMatch(CC), BindCC(nullptr) {}
+  explicit CondCode_match(ISD::CondCode CC) : CCToMatch(CC) {}
 
-  explicit CondCode_match(ISD::CondCode *CC)
-      : CCToMatch(std::nullopt), BindCC(CC) {}
+  explicit CondCode_match(ISD::CondCode *CC) : BindCC(CC) {}
 
   template <typename MatchContext> bool match(const MatchContext &, SDValue N) {
     if (auto *CC = dyn_cast<CondCodeSDNode>(N.getNode())) {

--- a/llvm/include/llvm/CodeGen/SDPatternMatch.h
+++ b/llvm/include/llvm/CodeGen/SDPatternMatch.h
@@ -371,6 +371,10 @@ template <typename Pred> struct Not {
 // Explicit deduction guide.
 template <typename Pred> Not(const Pred &P) -> Not<Pred>;
 
+template <typename Pred> inline Not<Pred> m_IsNot(const Pred &P) {
+  return Not{P};
+}
+
 template <typename... Preds> And<Preds...> m_AllOf(Preds &&...preds) {
   return And<Preds...>(std::forward<Preds>(preds)...);
 }
@@ -380,7 +384,7 @@ template <typename... Preds> Or<Preds...> m_AnyOf(Preds &&...preds) {
 }
 
 template <typename... Preds> auto m_NoneOf(Preds &&...preds) {
-  return Not{m_AnyOf(std::forward<Preds>(preds)...)};
+  return m_IsNot(m_AnyOf(std::forward<Preds>(preds)...));
 }
 
 // === Generic node matching ===

--- a/llvm/include/llvm/CodeGen/SDPatternMatch.h
+++ b/llvm/include/llvm/CodeGen/SDPatternMatch.h
@@ -633,6 +633,10 @@ inline UnaryOpc_match<Opnd, true> m_ChainedUnaryOp(unsigned Opc,
   return UnaryOpc_match<Opnd, true>(Opc, Op);
 }
 
+template <typename Opnd> inline UnaryOpc_match<Opnd> m_ZExt(const Opnd &Op) {
+  return UnaryOpc_match<Opnd>(ISD::ZERO_EXTEND, Op);
+}
+
 template <typename Opnd> inline auto m_SExt(Opnd &&Op) {
   return m_AnyOf(
       UnaryOpc_match<Opnd>(ISD::SIGN_EXTEND, Op),
@@ -645,6 +649,12 @@ template <typename Opnd> inline UnaryOpc_match<Opnd> m_AnyExt(const Opnd &Op) {
 
 template <typename Opnd> inline UnaryOpc_match<Opnd> m_Trunc(const Opnd &Op) {
   return UnaryOpc_match<Opnd>(ISD::TRUNCATE, Op);
+}
+
+/// Match a zext or identity
+/// Allows to peek through optional extensions
+template <typename Opnd> inline auto m_ZExtOrSelf(Opnd &&Op) {
+  return m_AnyOf(m_ZExt(std::forward<Opnd>(Op)), std::forward<Opnd>(Op));
 }
 
 /// Match a sext or identity
@@ -722,20 +732,6 @@ inline SpecificInt_match m_SpecificInt(uint64_t V) {
 inline SpecificInt_match m_Zero() { return m_SpecificInt(0U); }
 inline SpecificInt_match m_One() { return m_SpecificInt(1U); }
 inline SpecificInt_match m_AllOnes() { return m_SpecificInt(~0U); }
-
-// FIXME: We probably ought to move constant matchers before
-// most of the others so that m_ZExt/m_ZExtOrSelf can be
-// with other extension matchers.
-template <typename Opnd> inline auto m_ZExt(const Opnd &Op) {
-  return m_AnyOf(UnaryOpc_match<Opnd>(ISD::ZERO_EXTEND, Op),
-                 m_And(Op, m_AllOnes()));
-}
-
-/// Match a zext or identity
-/// Allows to peek through optional extensions
-template <typename Opnd> inline auto m_ZExtOrSelf(Opnd &&Op) {
-  return m_AnyOf(m_ZExt(std::forward<Opnd>(Op)), std::forward<Opnd>(Op));
-}
 
 /// Match true boolean value based on the information provided by
 /// TargetLowering.

--- a/llvm/include/llvm/CodeGen/SDPatternMatch.h
+++ b/llvm/include/llvm/CodeGen/SDPatternMatch.h
@@ -371,7 +371,8 @@ template <typename Pred> struct Not {
 // Explicit deduction guide.
 template <typename Pred> Not(const Pred &P) -> Not<Pred>;
 
-template <typename Pred> inline Not<Pred> m_IsNot(const Pred &P) {
+/// Match if the inner pattern does NOT match.
+template <typename Pred> inline Not<Pred> m_Unless(const Pred &P) {
   return Not{P};
 }
 
@@ -384,7 +385,7 @@ template <typename... Preds> Or<Preds...> m_AnyOf(Preds &&...preds) {
 }
 
 template <typename... Preds> auto m_NoneOf(Preds &&...preds) {
-  return m_IsNot(m_AnyOf(std::forward<Preds>(preds)...));
+  return m_Unless(m_AnyOf(std::forward<Preds>(preds)...));
 }
 
 // === Generic node matching ===

--- a/llvm/include/llvm/CodeGen/SDPatternMatch.h
+++ b/llvm/include/llvm/CodeGen/SDPatternMatch.h
@@ -806,6 +806,7 @@ inline CondCode_match m_CondCode() { return CondCode_match(nullptr); }
 inline CondCode_match m_CondCode(ISD::CondCode &CC) {
   return CondCode_match(&CC);
 }
+/// Match a conditional code SDNode with a specific ISD::CondCode.
 inline CondCode_match m_SpecificCondCode(ISD::CondCode CC) {
   return CondCode_match(CC);
 }

--- a/llvm/unittests/CodeGen/SelectionDAGPatternMatchTest.cpp
+++ b/llvm/unittests/CodeGen/SelectionDAGPatternMatchTest.cpp
@@ -268,8 +268,6 @@ TEST_F(SelectionDAGPatternMatchTest, optionalResizing) {
   SDValue Op32 = DAG->getCopyFromReg(DAG->getEntryNode(), DL, 1, Int32VT);
   SDValue Op64 = DAG->getCopyFromReg(DAG->getEntryNode(), DL, 1, Int64VT);
   SDValue ZExt = DAG->getNode(ISD::ZERO_EXTEND, DL, Int64VT, Op32);
-  SDValue AndZExt = DAG->getNode(ISD::AND, DL, Int64VT, Op64,
-                                 DAG->getConstant(~0U, DL, Int64VT));
   SDValue SExt = DAG->getNode(ISD::SIGN_EXTEND, DL, Int64VT, Op32);
   SDValue SExtInReg = DAG->getNode(ISD::SIGN_EXTEND_INREG, DL, Int64VT, Op64,
                                    DAG->getValueType(Int32VT));
@@ -282,8 +280,6 @@ TEST_F(SelectionDAGPatternMatchTest, optionalResizing) {
   EXPECT_TRUE(A == Op32);
   EXPECT_TRUE(sd_match(ZExt, m_ZExtOrSelf(m_Value(A))));
   EXPECT_TRUE(A == Op32);
-  EXPECT_TRUE(sd_match(AndZExt, m_ZExtOrSelf(m_Value(A))));
-  EXPECT_TRUE(A == Op64);
   EXPECT_TRUE(sd_match(Op64, m_SExtOrSelf(m_Value(A))));
   EXPECT_TRUE(A == Op64);
   EXPECT_TRUE(sd_match(SExt, m_SExtOrSelf(m_Value(A))));

--- a/llvm/unittests/CodeGen/SelectionDAGPatternMatchTest.cpp
+++ b/llvm/unittests/CodeGen/SelectionDAGPatternMatchTest.cpp
@@ -217,6 +217,7 @@ TEST_F(SelectionDAGPatternMatchTest, matchConstants) {
   SDValue Zero = DAG->getConstant(0, DL, Int32VT);
   SDValue One = DAG->getConstant(1, DL, Int32VT);
   SDValue AllOnes = DAG->getConstant(APInt::getAllOnes(32), DL, Int32VT);
+  SDValue SetCC = DAG->getSetCC(DL, Int32VT, Arg0, Const3, ISD::SETULT);
 
   using namespace SDPatternMatch;
   EXPECT_TRUE(sd_match(Const87, m_ConstInt()));
@@ -233,6 +234,13 @@ TEST_F(SelectionDAGPatternMatchTest, matchConstants) {
   EXPECT_TRUE(sd_match(Zero, DAG.get(), m_False()));
   EXPECT_TRUE(sd_match(One, DAG.get(), m_True()));
   EXPECT_FALSE(sd_match(AllOnes, DAG.get(), m_True()));
+
+  ISD::CondCode CC;
+  EXPECT_TRUE(sd_match(
+      SetCC, m_Node(ISD::SETCC, m_Value(), m_Value(), m_CondCode(CC))));
+  EXPECT_EQ(CC, ISD::SETULT);
+  EXPECT_TRUE(sd_match(SetCC, m_Node(ISD::SETCC, m_Value(), m_Value(),
+                                     m_SpecificCondCode(ISD::SETULT))));
 }
 
 TEST_F(SelectionDAGPatternMatchTest, patternCombinators) {
@@ -249,6 +257,7 @@ TEST_F(SelectionDAGPatternMatchTest, patternCombinators) {
   EXPECT_TRUE(sd_match(
       Sub, m_AnyOf(m_Opc(ISD::ADD), m_Opc(ISD::SUB), m_Opc(ISD::MUL))));
   EXPECT_TRUE(sd_match(Add, m_AllOf(m_Opc(ISD::ADD), m_OneUse())));
+  EXPECT_TRUE(sd_match(Add, m_NoneOf(m_Opc(ISD::SUB), m_Opc(ISD::MUL))));
 }
 
 TEST_F(SelectionDAGPatternMatchTest, optionalResizing) {
@@ -259,7 +268,11 @@ TEST_F(SelectionDAGPatternMatchTest, optionalResizing) {
   SDValue Op32 = DAG->getCopyFromReg(DAG->getEntryNode(), DL, 1, Int32VT);
   SDValue Op64 = DAG->getCopyFromReg(DAG->getEntryNode(), DL, 1, Int64VT);
   SDValue ZExt = DAG->getNode(ISD::ZERO_EXTEND, DL, Int64VT, Op32);
+  SDValue AndZExt = DAG->getNode(ISD::AND, DL, Int64VT, Op64,
+                                 DAG->getConstant(~0U, DL, Int64VT));
   SDValue SExt = DAG->getNode(ISD::SIGN_EXTEND, DL, Int64VT, Op32);
+  SDValue SExtInReg = DAG->getNode(ISD::SIGN_EXTEND_INREG, DL, Int64VT, Op64,
+                                   DAG->getValueType(Int32VT));
   SDValue AExt = DAG->getNode(ISD::ANY_EXTEND, DL, Int64VT, Op32);
   SDValue Trunc = DAG->getNode(ISD::TRUNCATE, DL, Int32VT, Op64);
 
@@ -269,10 +282,14 @@ TEST_F(SelectionDAGPatternMatchTest, optionalResizing) {
   EXPECT_TRUE(A == Op32);
   EXPECT_TRUE(sd_match(ZExt, m_ZExtOrSelf(m_Value(A))));
   EXPECT_TRUE(A == Op32);
+  EXPECT_TRUE(sd_match(AndZExt, m_ZExtOrSelf(m_Value(A))));
+  EXPECT_TRUE(A == Op64);
   EXPECT_TRUE(sd_match(Op64, m_SExtOrSelf(m_Value(A))));
   EXPECT_TRUE(A == Op64);
   EXPECT_TRUE(sd_match(SExt, m_SExtOrSelf(m_Value(A))));
   EXPECT_TRUE(A == Op32);
+  EXPECT_TRUE(sd_match(SExtInReg, m_SExtOrSelf(m_Value(A))));
+  EXPECT_TRUE(A == Op64);
   EXPECT_TRUE(sd_match(Op32, m_AExtOrSelf(m_Value(A))));
   EXPECT_TRUE(A == Op32);
   EXPECT_TRUE(sd_match(AExt, m_AExtOrSelf(m_Value(A))));


### PR DESCRIPTION
  - Add m_CondCode to match the ISD::CondCode value from CondCodeSDNode
  - Add m_NoneOf combinator
  - m_SExt now recognizes sext_inreg