### PR TITLE
[RISCV] Use binary search to look up supported profiles.

### DIFF
--- a/llvm/lib/TargetParser/RISCVISAInfo.cpp
+++ b/llvm/lib/TargetParser/RISCVISAInfo.cpp
@@ -598,14 +598,14 @@ RISCVISAInfo::parseArchString(StringRef Arch, bool EnableExperimentalExtension,
     XLen = 64;
   } else {
     // Try parsing as a profile.
-    const auto *FoundProfile =
-        llvm::find_if(SupportedProfiles, [Arch](const RISCVProfile &Profile) {
-          return Arch.starts_with(Profile.Name);
-        });
+    auto I = llvm::upper_bound(SupportedProfiles, Arch,
+                               [](StringRef Arch, const RISCVProfile &Profile) {
+                                 return Arch < Profile.Name;
+                               });
 
-    if (FoundProfile != std::end(SupportedProfiles)) {
-      std::string NewArch = FoundProfile->MArch.str();
-      StringRef ArchWithoutProfile = Arch.drop_front(FoundProfile->Name.size());
+    if (I != std::begin(SupportedProfiles) && Arch.starts_with((--I)->Name)) {
+      std::string NewArch = I->MArch.str();
+      StringRef ArchWithoutProfile = Arch.drop_front(I->Name.size());
       if (!ArchWithoutProfile.empty()) {
         if (ArchWithoutProfile.front() != '_')
           return createStringError(

--- a/llvm/utils/TableGen/RISCVTargetDefEmitter.cpp
+++ b/llvm/utils/TableGen/RISCVTargetDefEmitter.cpp
@@ -124,7 +124,10 @@ static void emitRISCVProfiles(RecordKeeper &Records, raw_ostream &OS) {
 
   OS << "static constexpr RISCVProfile SupportedProfiles[] = {\n";
 
-  for (const Record *Rec : Records.getAllDerivedDefinitions("RISCVProfile")) {
+  auto Profiles = Records.getAllDerivedDefinitions("RISCVProfile");
+  llvm::sort(Profiles, LessRecordFieldName());
+
+  for (const Record *Rec : Profiles) {
     OS.indent(4) << "{\"" << Rec->getValueAsString("Name") << "\",\"";
     printMArch(OS, Rec->getValueAsListOfDefs("Implies"));
     OS << "\"},\n";


### PR DESCRIPTION
As the list of profiles grow, this will be a more efficient lookup.

Because the profile name is a prefix of the Arch string, we use upper_bound to find the first profile that definitely comes after the Arch string. If that isn't the first supported profile, we move back 1 profile and see if that profile is a prefix of our Arch string.