### PR TITLE
NFC: fix clang format spacing and documentation

### DIFF
--- a/llvm/lib/Target/PowerPC/MCTargetDesc/PPCMCTargetDesc.cpp
+++ b/llvm/lib/Target/PowerPC/MCTargetDesc/PPCMCTargetDesc.cpp
@@ -63,45 +63,45 @@ const char *PPC::stripRegisterPrefix(const char *RegName) {
   switch (RegName[0]) {
     case 'a':
       if (RegName[1] == 'c' && RegName[2] == 'c')
-	return RegName + 3;
+        return RegName + 3;
       break;
     case 'f':
       if (RegName[1] == 'p')
-	return RegName + 2;
+        return RegName + 2;
       [[fallthrough]];
     case 'r':
     case 'v':
       if (RegName[1] == 's') {
-	if (RegName[2] == 'p')
-	  return RegName + 3;
-	return RegName + 2;
+        if (RegName[2] == 'p')
+          return RegName + 3;
+        return RegName + 2;
       }
       return RegName + 1;
     case 'c':
       if (RegName[1] == 'r')
-	return RegName + 2;
+        return RegName + 2;
       break;
     case 'w':
       // For wacc and wacc_hi
       if (RegName[1] == 'a' && RegName[2] == 'c' && RegName[3] == 'c') {
-	if (RegName[4] == '_')
-	  return RegName + 7;
-	else
-	  return RegName + 4;
+        if (RegName[4] == '_')
+          return RegName + 7;
+        else
+          return RegName + 4;
       }
       break;
     case 'd':
       // For dmr, dmrp, dmrrow, dmrrowp
       if (RegName[1] == 'm' && RegName[2] == 'r') {
-	if (RegName[3] == 'r' && RegName[4] == 'o' && RegName[5] == 'w' &&
-	    RegName[6] == 'p')
-	  return RegName + 7;
-	else if (RegName[3] == 'r' && RegName[4] == 'o' && RegName[5] == 'w')
-	  return RegName + 6;
-	else if (RegName[3] == 'p')
-	  return RegName + 4;
-	else
-	  return RegName + 3;
+        if (RegName[3] == 'r' && RegName[4] == 'o' && RegName[5] == 'w' &&
+            RegName[6] == 'p')
+          return RegName + 7;
+        else if (RegName[3] == 'r' && RegName[4] == 'o' && RegName[5] == 'w')
+          return RegName + 6;
+        else if (RegName[3] == 'p')
+          return RegName + 4;
+        else
+          return RegName + 3;
       }
       break;
   }

--- a/llvm/lib/Target/PowerPC/PPCISelDAGToDAG.cpp
+++ b/llvm/lib/Target/PowerPC/PPCISelDAGToDAG.cpp
@@ -6141,12 +6141,12 @@ void PPCDAGToDAGISel::Select(SDNode *N) {
     assert((isPPC64 || (isAIXABI && !isPPC64)) && "We are dealing with 64-bit"
            " ELF/AIX or 32-bit AIX in the following.");
 
-    // Transforms the ISD::TOC_ENTRY node for 32-bit AIX large code model mode
-    // or 64-bit medium (ELF-only) or large (ELF and AIX) code model code non
-    // toc-data symbols.
+    // Transforms the ISD::TOC_ENTRY node for 32-bit AIX large code model mode,
+    // or 64-bit medium (ELF-only), or large (ELF and AIX) code model code that
+    // does not conain TOC data symbols.
     // We generate two instructions as described below. The first source
-    // operand is a symbol reference. If it must be toc-referenced according to
-    // Subtarget, we generate:
+    // operand is a symbol reference. If it must be referenced via the toc
+    // according to Subtarget, we generate:
     // [32-bit AIX]
     //   LWZtocL(@sym, ADDIStocHA(%r2, @sym))
     // [64-bit ELF/AIX]
@@ -6154,7 +6154,7 @@ void PPCDAGToDAGISel::Select(SDNode *N) {
     // Otherwise we generate:
     //   ADDItocL8(ADDIStocHA8(%x2, @sym), @sym)
 
-    // For large code model toc-data symbols we generate:
+    // For large code model with TOC data symbols we generate:
     // [32-bit AIX]
     //   ADDItocL(ADDIStocHA(%x2, @sym), @sym)
     // [64-bit AIX]
@@ -6167,9 +6167,8 @@ void PPCDAGToDAGISel::Select(SDNode *N) {
     SDNode *Tmp = CurDAG->getMachineNode(
         isPPC64 ? PPC::ADDIStocHA8 : PPC::ADDIStocHA, dl, VT, TOCbase, GA);
 
-    // On AIX if the symbol has the toc-data attribute it will be defined
-    // in the TOC entry, so we use an ADDItocL similar to the medium code
-    // model ELF abi.
+    // On AIX, if the symbol has the toc-data attribute it will be defined
+    // in the TOC entry, so we use an ADDItocL/ADDItocL8.
     if (isAIXABI && hasTocDataAttr(GA)) {
       if (isPPC64)
         report_fatal_error(


### PR DESCRIPTION
Some minor fixes to clean up tabs and language in code documentation.