### PR TITLE
[DirectX] remove string function attribute DXIL not allowed

### DIFF
--- a/llvm/lib/Target/DirectX/DXILMetadata.cpp
+++ b/llvm/lib/Target/DirectX/DXILMetadata.cpp
@@ -40,6 +40,15 @@ void ValidatorVersionMD::update(VersionTuple ValidatorVer) {
 
 bool ValidatorVersionMD::isEmpty() { return Entry->getNumOperands() == 0; }
 
+VersionTuple ValidatorVersionMD::getAsVersionTuple() {
+  if (isEmpty())
+    return VersionTuple(1, 0);
+  auto *ValVerMD = cast<MDNode>(Entry->getOperand(0));
+  auto *MajorMD = mdconst::extract<ConstantInt>(ValVerMD->getOperand(0));
+  auto *MinorMD = mdconst::extract<ConstantInt>(ValVerMD->getOperand(1));
+  return VersionTuple(MajorMD->getZExtValue(), MinorMD->getZExtValue());
+}
+
 static StringRef getShortShaderStage(Triple::EnvironmentType Env) {
   switch (Env) {
   case Triple::Pixel:

--- a/llvm/lib/Target/DirectX/DXILMetadata.h
+++ b/llvm/lib/Target/DirectX/DXILMetadata.h
@@ -30,6 +30,7 @@ public:
   void update(VersionTuple ValidatorVer);
 
   bool isEmpty();
+  VersionTuple getAsVersionTuple();
 };
 
 void createShaderModelMD(Module &M);

--- a/llvm/lib/Target/DirectX/DXILPrepare.cpp
+++ b/llvm/lib/Target/DirectX/DXILPrepare.cpp
@@ -84,7 +84,7 @@ constexpr bool isValidForDXIL(Attribute::AttrKind Attr) {
 }
 
 static void collectDeadStringAttrs(AttributeMask &DeadAttrs, AttributeSet &&AS,
-                                   StringSet<> LiveKeys) {
+                                   const StringSet<> &LiveKeys) {
   for (auto &Attr : AS) {
     if (!Attr.isStringAttribute())
       continue;
@@ -97,8 +97,8 @@ static void collectDeadStringAttrs(AttributeMask &DeadAttrs, AttributeSet &&AS,
 
 static void removeStringFunctionAttributes(Function &F) {
   AttributeList Attrs = F.getAttributes();
-  StringSet<> LiveKeys = {"waveops-include-helper-lanes"
-                          "fp32-denorm-mode"};
+  const StringSet<> LiveKeys = {"waveops-include-helper-lanes",
+                                "fp32-denorm-mode"};
   // Collect DeadKeys in FnAttrs.
   AttributeMask DeadAttrs;
   collectDeadStringAttrs(DeadAttrs, Attrs.getFnAttrs(), LiveKeys);

--- a/llvm/lib/Target/DirectX/DXILPrepare.cpp
+++ b/llvm/lib/Target/DirectX/DXILPrepare.cpp
@@ -141,7 +141,6 @@ public:
         AttrMask.addAttribute(I);
     }
 
-    
     dxil::ValidatorVersionMD ValVerMD(M);
     VersionTuple ValVer = ValVerMD.getAsVersionTuple();
     bool SkipValidation = ValVer.getMajor() == 0 && ValVer.getMinor() == 0;

--- a/llvm/lib/Target/DirectX/DirectXTargetMachine.cpp
+++ b/llvm/lib/Target/DirectX/DirectXTargetMachine.cpp
@@ -79,8 +79,8 @@ public:
   void addCodeGenPrepare() override {
     addPass(createDXILIntrinsicExpansionLegacyPass());
     addPass(createDXILOpLoweringLegacyPass());
-    addPass(createDXILPrepareModulePass());
     addPass(createDXILTranslateMetadataPass());
+    addPass(createDXILPrepareModulePass());
   }
 };
 

--- a/llvm/test/CodeGen/DirectX/Metadata/shaderModel-cs-val-ver-0.0.ll
+++ b/llvm/test/CodeGen/DirectX/Metadata/shaderModel-cs-val-ver-0.0.ll
@@ -7,9 +7,9 @@ entry:
   ret void
 }
 
-; Make sure extra attribute like hlsl.numthreads are left when validation version is 0.0.
-; CHECK:attributes #0 = { noinline nounwind "hlsl.numthreads"="1,2,1" "hlsl.shader"="compute" } 
-attributes #0 = { noinline nounwind "hlsl.numthreads"="1,2,1" "hlsl.shader"="compute" }
+; Make sure experimental attribute is left when validation version is 0.0.
+; CHECK:attributes #0 = { noinline nounwind "exp-shader"="cs" } 
+attributes #0 = { noinline nounwind "exp-shader"="cs" "hlsl.numthreads"="1,2,1" "hlsl.shader"="compute" }
 
 !dx.valver = !{!0}
 

--- a/llvm/test/CodeGen/DirectX/Metadata/shaderModel-cs-val-ver-0.0.ll
+++ b/llvm/test/CodeGen/DirectX/Metadata/shaderModel-cs-val-ver-0.0.ll
@@ -1,0 +1,16 @@
+; RUN: opt -S -dxil-prepare  %s | FileCheck %s 
+
+target triple = "dxil-pc-shadermodel6.6-compute"
+
+define void @entry() #0 {
+entry:
+  ret void
+}
+
+; Make sure extra attribute like hlsl.numthreads are left when validation version is 0.0.
+; CHECK:attributes #0 = { noinline nounwind "hlsl.numthreads"="1,2,1" "hlsl.shader"="compute" } 
+attributes #0 = { noinline nounwind "hlsl.numthreads"="1,2,1" "hlsl.shader"="compute" }
+
+!dx.valver = !{!0}
+
+!0 = !{i32 0, i32 0}

--- a/llvm/test/CodeGen/DirectX/Metadata/shaderModel-cs.ll
+++ b/llvm/test/CodeGen/DirectX/Metadata/shaderModel-cs.ll
@@ -1,4 +1,6 @@
 ; RUN: opt -S -dxil-metadata-emit %s | FileCheck %s
+; RUN: opt -S -dxil-prepare  %s | FileCheck %s  --check-prefix=REMOVE_EXTRA_ATTRIBUTE
+
 target triple = "dxil-pc-shadermodel6.6-compute"
 
 ; CHECK: !dx.shaderModel = !{![[SM:[0-9]+]]}
@@ -9,4 +11,6 @@ entry:
   ret void
 }
 
+; Make sure extra attribute like hlsl.numthreads are removed.
+; REMOVE_EXTRA_ATTRIBUTE:attributes #0 = { noinline nounwind } 
 attributes #0 = { noinline nounwind "hlsl.numthreads"="1,2,1" "hlsl.shader"="compute" }

--- a/llvm/test/CodeGen/DirectX/Metadata/shaderModel-cs.ll
+++ b/llvm/test/CodeGen/DirectX/Metadata/shaderModel-cs.ll
@@ -12,5 +12,6 @@ entry:
 }
 
 ; Make sure extra attribute like hlsl.numthreads are removed.
+; And experimental attribute is removed when validator version is not 0.0.
 ; REMOVE_EXTRA_ATTRIBUTE:attributes #0 = { noinline nounwind } 
-attributes #0 = { noinline nounwind "hlsl.numthreads"="1,2,1" "hlsl.shader"="compute" }
+attributes #0 = { noinline nounwind "exp-shader"="cs" "hlsl.numthreads"="1,2,1" "hlsl.shader"="compute" }

--- a/llvm/test/CodeGen/DirectX/dxil_ver.ll
+++ b/llvm/test/CodeGen/DirectX/dxil_ver.ll
@@ -1,4 +1,5 @@
 ; RUN: opt -S -dxil-metadata-emit < %s | FileCheck %s
+; RUN: opt -S -dxil-prepare  %s | FileCheck %s  --check-prefix=REMOVE_EXTRA_MODULE_FLAG
 target datalayout = "e-m:e-p:32:32-i1:32-i8:8-i16:16-i32:32-i64:64-f16:16-f32:32-f64:64-n8:16:32:64"
 target triple = "dxil-pc-shadermodel6.3-library"
 
@@ -10,6 +11,10 @@ target triple = "dxil-pc-shadermodel6.3-library"
 ; CHECK-DAG:![[valver]] = !{i32 1, i32 1}
 ; Make sure wchar_size still exist.
 ; CHECK-DAG:!{i32 1, !"wchar_size", i32 4}
+
+; Make sure no !llvm.module.flags left.
+; REMOVE_EXTRA_MODULE_FLAG: target triple = "dxil-pc-shadermodel6.3-library"
+; REMOVE_EXTRA_MODULE_FLAG-NOT: !llvm.module.flags
 
 !llvm.module.flags = !{!0}
 !dx.valver = !{!1}

--- a/llvm/test/CodeGen/DirectX/dxil_ver.ll
+++ b/llvm/test/CodeGen/DirectX/dxil_ver.ll
@@ -1,5 +1,4 @@
 ; RUN: opt -S -dxil-metadata-emit < %s | FileCheck %s
-; RUN: opt -S -dxil-prepare  %s | FileCheck %s  --check-prefix=REMOVE_EXTRA_MODULE_FLAG
 target datalayout = "e-m:e-p:32:32-i1:32-i8:8-i16:16-i32:32-i64:64-f16:16-f32:32-f64:64-n8:16:32:64"
 target triple = "dxil-pc-shadermodel6.3-library"
 
@@ -11,10 +10,6 @@ target triple = "dxil-pc-shadermodel6.3-library"
 ; CHECK-DAG:![[valver]] = !{i32 1, i32 1}
 ; Make sure wchar_size still exist.
 ; CHECK-DAG:!{i32 1, !"wchar_size", i32 4}
-
-; Make sure no !llvm.module.flags left.
-; REMOVE_EXTRA_MODULE_FLAG: target triple = "dxil-pc-shadermodel6.3-library"
-; REMOVE_EXTRA_MODULE_FLAG-NOT: !llvm.module.flags
 
 !llvm.module.flags = !{!0}
 !dx.valver = !{!1}

--- a/llvm/test/tools/dxil-dis/attribute-filter.ll
+++ b/llvm/test/tools/dxil-dis/attribute-filter.ll
@@ -19,8 +19,8 @@ define float @fma2(float %0, float %1, float %2) #1 {
   ret float %5
 }
 
-; CHECK: attributes #0 = { nounwind readnone }
-attributes #0 = { norecurse nounwind readnone willreturn "disable-tail-calls"="false" }
+; CHECK: attributes #0 = { nounwind readnone "fp32-denorm-mode"="any" "waveops-include-helper-lanes" }
+attributes #0 = { norecurse nounwind readnone willreturn "disable-tail-calls"="false" "waveops-include-helper-lanes" "fp32-denorm-mode"="any" }
 
-; CHECK: attributes #1 = { readnone }
-attributes #1 = { norecurse memory(none) willreturn "disable-tail-calls"="false" }
+; CHECK: attributes #1 = { readnone "fp32-denorm-mode"="ftz" "waveops-include-helper-lanes" }
+attributes #1 = { norecurse memory(none) willreturn "disable-tail-calls"="false" "waveops-include-helper-lanes" "fp32-denorm-mode"="ftz" }

--- a/llvm/test/tools/dxil-dis/attribute-filter.ll
+++ b/llvm/test/tools/dxil-dis/attribute-filter.ll
@@ -19,8 +19,8 @@ define float @fma2(float %0, float %1, float %2) #1 {
   ret float %5
 }
 
-; CHECK: attributes #0 = { nounwind readnone "disable-tail-calls"="false" }
+; CHECK: attributes #0 = { nounwind readnone }
 attributes #0 = { norecurse nounwind readnone willreturn "disable-tail-calls"="false" }
 
-; CHECK: attributes #1 = { readnone "disable-tail-calls"="false" }
+; CHECK: attributes #1 = { readnone }
 attributes #1 = { norecurse memory(none) willreturn "disable-tail-calls"="false" }


### PR DESCRIPTION
Remove string function attribute other than "waveops-include-helper-lanes" and "fp32-denorm-mode".

Move DXILPrepareModulePass after DXILTranslateMetadataPass since DXILTranslateMetadataPass needs to use attribute like hlsl.numthreads.

Fixes #90773