### PR TITLE
[lldb] fix step in AArch64 trampoline

### DIFF
--- a/lldb/source/Plugins/DynamicLoader/POSIX-DYLD/DynamicLoaderPOSIXDYLD.cpp
+++ b/lldb/source/Plugins/DynamicLoader/POSIX-DYLD/DynamicLoaderPOSIXDYLD.cpp
@@ -506,9 +506,29 @@ DynamicLoaderPOSIXDYLD::GetStepThroughTrampolinePlan(Thread &thread,
   Target &target = thread.GetProcess()->GetTarget();
   const ModuleList &images = target.GetImages();
 
-  images.FindSymbolsWithNameAndType(sym_name, eSymbolTypeCode, target_symbols);
-  if (!target_symbols.GetSize())
-    return thread_plan_sp;
+  llvm::StringRef target_name = sym_name.GetStringRef();
+  // On AArch64, the trampoline name has a prefix (__AArch64ADRPThunk_ or
+  // __AArch64AbsLongThunk_) added to the function name. If we detect a
+  // trampoline with the prefix, we need to remove the prefix to find the
+  // function symbol.
+  if (target_name.consume_front("__AArch64ADRPThunk_")) {
+    // An empty target name can happen when for trampolines generated for
+    // section-referencing relocations.
+    if (!target_name.empty()) {
+      images.FindSymbolsWithNameAndType(ConstString(target_name),
+                                        eSymbolTypeCode, target_symbols);
+    }
+  } else if (target_name.consume_front("__AArch64AbsLongThunk_")) {
+    // An empty target name can happen when for trampolines generated for
+    // section-referencing relocations.
+    if (!target_name.empty()) {
+      images.FindSymbolsWithNameAndType(ConstString(target_name),
+                                        eSymbolTypeCode, target_symbols);
+    }
+  } else {
+    images.FindSymbolsWithNameAndType(sym_name, eSymbolTypeCode,
+                                      target_symbols);
+  }
 
   typedef std::vector<lldb::addr_t> AddressVector;
   AddressVector addrs;

--- a/lldb/source/Plugins/DynamicLoader/POSIX-DYLD/DynamicLoaderPOSIXDYLD.cpp
+++ b/lldb/source/Plugins/DynamicLoader/POSIX-DYLD/DynamicLoaderPOSIXDYLD.cpp
@@ -513,16 +513,15 @@ DynamicLoaderPOSIXDYLD::GetStepThroughTrampolinePlan(Thread &thread,
   // function symbol.
   if (target_name.consume_front("__AArch64ADRPThunk_") ||
       target_name.consume_front("__AArch64AbsLongThunk_")) {
-    // An empty target name can happen when for trampolines generated for
+    // An empty target name can happen for trampolines generated for
     // section-referencing relocations.
     if (!target_name.empty()) {
-      images.FindSymbolsWithNameAndType(ConstString(target_name),
-                                        eSymbolTypeCode, target_symbols);
+      sym_name = ConstString(target_name);
     }
-  } else {
-    images.FindSymbolsWithNameAndType(sym_name, eSymbolTypeCode,
-                                      target_symbols);
   }
+  images.FindSymbolsWithNameAndType(sym_name, eSymbolTypeCode, target_symbols);
+  if (!target_symbols.GetSize())
+    return thread_plan_sp;
 
   typedef std::vector<lldb::addr_t> AddressVector;
   AddressVector addrs;

--- a/lldb/source/Plugins/DynamicLoader/POSIX-DYLD/DynamicLoaderPOSIXDYLD.cpp
+++ b/lldb/source/Plugins/DynamicLoader/POSIX-DYLD/DynamicLoaderPOSIXDYLD.cpp
@@ -511,14 +511,8 @@ DynamicLoaderPOSIXDYLD::GetStepThroughTrampolinePlan(Thread &thread,
   // __AArch64AbsLongThunk_) added to the function name. If we detect a
   // trampoline with the prefix, we need to remove the prefix to find the
   // function symbol.
-  if (target_name.consume_front("__AArch64ADRPThunk_")) {
-    // An empty target name can happen when for trampolines generated for
-    // section-referencing relocations.
-    if (!target_name.empty()) {
-      images.FindSymbolsWithNameAndType(ConstString(target_name),
-                                        eSymbolTypeCode, target_symbols);
-    }
-  } else if (target_name.consume_front("__AArch64AbsLongThunk_")) {
+  if (target_name.consume_front("__AArch64ADRPThunk_") ||
+      target_name.consume_front("__AArch64AbsLongThunk_")) {
     // An empty target name can happen when for trampolines generated for
     // section-referencing relocations.
     if (!target_name.empty()) {

--- a/lldb/test/Shell/ExecControl/StepIn/Inputs/aarch64_thunk.cc
+++ b/lldb/test/Shell/ExecControl/StepIn/Inputs/aarch64_thunk.cc
@@ -1,0 +1,15 @@
+extern "C" int __attribute__((naked)) __AArch64ADRPThunk_step_here() {
+    asm (
+      "adrp x16, step_here\n"
+      "add x16, x16, :lo12:step_here\n"
+      "br x16"
+    );
+}
+
+extern "C" __attribute__((used)) int step_here() {
+    return 47;
+}
+
+int main() {
+  return __AArch64ADRPThunk_step_here();
+}

--- a/lldb/test/Shell/ExecControl/StepIn/step_through-aarch64-thunk.test
+++ b/lldb/test/Shell/ExecControl/StepIn/step_through-aarch64-thunk.test
@@ -1,0 +1,17 @@
+# REQUIRES: native && target-aarch64
+
+# This test is specific to elf platforms.
+# UNSUPPORTED: system-windows, system-darwin
+
+# RUN: %clangxx_host %p/Inputs/aarch64_thunk.cc -g -o %t.out
+# RUN: %lldb %t.out -s %s | FileCheck %s
+
+b main
+# CHECK: Breakpoint 1: where = step_through-aarch64-thunk.test.tmp.out`main
+
+r
+# CHECK: stop reason = breakpoint 1.1
+
+s
+# CHECK: stop reason = step in
+# CHECK:     frame #0: {{.*}} step_through-aarch64-thunk.test.tmp.out`::step_here()


### PR DESCRIPTION
Detects AArch64 trampolines in order to be able to step in a function through a trampoline on AArch64.