### PR TITLE
[BOLT][NFC] Add HasInternalCalls BinaryFunction property

### DIFF
--- a/bolt/include/bolt/Core/BinaryFunction.h
+++ b/bolt/include/bolt/Core/BinaryFunction.h
@@ -361,6 +361,9 @@ private:
   /// True if another function body was merged into this one.
   bool HasFunctionsFoldedInto{false};
 
+  /// True if the function has internal calls.
+  bool HasInternalCalls{false};
+
   /// Name for the section this function code should reside in.
   std::string CodeSectionName;
 
@@ -1333,6 +1336,9 @@ public:
 
   /// Return true if other functions were folded into this one.
   bool hasFunctionsFoldedInto() const { return HasFunctionsFoldedInto; }
+
+  /// Return true if the function has internal calls.
+  bool hasInternalCalls() const { return HasInternalCalls; }
 
   /// If this function was folded, return the function it was folded into.
   BinaryFunction *getFoldedIntoFunction() const { return FoldedIntoFunction; }

--- a/bolt/lib/Core/BinaryFunction.cpp
+++ b/bolt/lib/Core/BinaryFunction.cpp
@@ -1281,6 +1281,7 @@ Error BinaryFunction::disassemble() {
             // Recursive call.
             TargetSymbol = getSymbol();
           } else {
+            HasInternalCalls = true;
             if (BC.isX86()) {
               // Dangerous old-style x86 PIC code. We may need to freeze this
               // function, so preserve the function as is for now.

--- a/bolt/lib/Passes/ValidateInternalCalls.cpp
+++ b/bolt/lib/Passes/ValidateInternalCalls.cpp
@@ -309,15 +309,10 @@ Error ValidateInternalCalls::runOnFunctions(BinaryContext &BC) {
   std::set<BinaryFunction *> NeedsValidation;
   for (auto &BFI : BC.getBinaryFunctions()) {
     BinaryFunction &Function = BFI.second;
-    for (BinaryBasicBlock &BB : Function) {
-      for (MCInst &Inst : BB) {
-        if (getInternalCallTarget(Function, Inst)) {
-          NeedsValidation.insert(&Function);
-          Function.setSimple(false);
-          break;
-        }
-      }
-    }
+    if (!Function.hasInternalCalls())
+      continue;
+    NeedsValidation.insert(&Function);
+    Function.setSimple(false);
   }
 
   // Skip validation for non-relocation mode


### PR DESCRIPTION
Use HasInternalCalls in ValidateInternalCalls to avoid re-checking all
functions.

Test Plan: NFC
