### PR TITLE
[BOLT] Ignore returns in DataAggregator

### DIFF
--- a/bolt/include/bolt/Core/BinaryFunction.h
+++ b/bolt/include/bolt/Core/BinaryFunction.h
@@ -930,8 +930,7 @@ public:
     return const_cast<BinaryFunction *>(this)->getInstructionAtOffset(Offset);
   }
 
-  const std::optional<MCInst>
-  disassembleInstructionAtOffset(uint64_t Offset) const;
+  std::optional<MCInst> disassembleInstructionAtOffset(uint64_t Offset) const;
 
   /// Return offset for the first instruction. If there is data at the
   /// beginning of a function then offset of the first instruction could

--- a/bolt/include/bolt/Core/BinaryFunction.h
+++ b/bolt/include/bolt/Core/BinaryFunction.h
@@ -361,9 +361,6 @@ private:
   /// True if another function body was merged into this one.
   bool HasFunctionsFoldedInto{false};
 
-  /// True if the function has internal calls.
-  bool HasInternalCalls{false};
-
   /// Name for the section this function code should reside in.
   std::string CodeSectionName;
 
@@ -1336,9 +1333,6 @@ public:
 
   /// Return true if other functions were folded into this one.
   bool hasFunctionsFoldedInto() const { return HasFunctionsFoldedInto; }
-
-  /// Return true if the function has internal calls.
-  bool hasInternalCalls() const { return HasInternalCalls; }
 
   /// If this function was folded, return the function it was folded into.
   BinaryFunction *getFoldedIntoFunction() const { return FoldedIntoFunction; }

--- a/bolt/include/bolt/Core/BinaryFunction.h
+++ b/bolt/include/bolt/Core/BinaryFunction.h
@@ -361,6 +361,9 @@ private:
   /// True if another function body was merged into this one.
   bool HasFunctionsFoldedInto{false};
 
+  /// True if the function has internal calls.
+  bool HasInternalCalls{false};
+
   /// Name for the section this function code should reside in.
   std::string CodeSectionName;
 
@@ -1333,6 +1336,9 @@ public:
 
   /// Return true if other functions were folded into this one.
   bool hasFunctionsFoldedInto() const { return HasFunctionsFoldedInto; }
+
+  /// Return true if the function has internal calls.
+  bool hasInternalCalls() const { return HasInternalCalls; }
 
   /// If this function was folded, return the function it was folded into.
   BinaryFunction *getFoldedIntoFunction() const { return FoldedIntoFunction; }

--- a/bolt/lib/Core/BinaryFunction.cpp
+++ b/bolt/lib/Core/BinaryFunction.cpp
@@ -1281,6 +1281,7 @@ Error BinaryFunction::disassemble() {
             // Recursive call.
             TargetSymbol = getSymbol();
           } else {
+            HasInternalCalls = true;
             if (BC.isX86()) {
               // Dangerous old-style x86 PIC code. We may need to freeze this
               // function, so preserve the function as is for now.
@@ -1435,11 +1436,6 @@ add_instruction:
     Labels[Offset] = BC.Ctx->createNamedTempSymbol();
 
   clearList(Relocations);
-
-  if (!IsSimple) {
-    clearList(Instructions);
-    return createNonFatalBOLTError("");
-  }
 
   updateState(State::Disassembled);
 

--- a/bolt/lib/Core/BinaryFunction.cpp
+++ b/bolt/lib/Core/BinaryFunction.cpp
@@ -1167,7 +1167,7 @@ void BinaryFunction::handleAArch64IndirectCall(MCInst &Instruction,
   }
 }
 
-const std::optional<MCInst>
+std::optional<MCInst>
 BinaryFunction::disassembleInstructionAtOffset(uint64_t Offset) const {
   assert(CurrentState == State::Empty);
   assert(Offset < MaxSize && "invalid offset");

--- a/bolt/lib/Core/BinaryFunction.cpp
+++ b/bolt/lib/Core/BinaryFunction.cpp
@@ -1281,7 +1281,6 @@ Error BinaryFunction::disassemble() {
             // Recursive call.
             TargetSymbol = getSymbol();
           } else {
-            HasInternalCalls = true;
             if (BC.isX86()) {
               // Dangerous old-style x86 PIC code. We may need to freeze this
               // function, so preserve the function as is for now.
@@ -1436,6 +1435,11 @@ add_instruction:
     Labels[Offset] = BC.Ctx->createNamedTempSymbol();
 
   clearList(Relocations);
+
+  if (!IsSimple) {
+    clearList(Instructions);
+    return createNonFatalBOLTError("");
+  }
 
   updateState(State::Disassembled);
 

--- a/bolt/lib/Core/BinaryFunction.cpp
+++ b/bolt/lib/Core/BinaryFunction.cpp
@@ -1169,10 +1169,10 @@ void BinaryFunction::handleAArch64IndirectCall(MCInst &Instruction,
 
 std::optional<MCInst>
 BinaryFunction::disassembleInstructionAtOffset(uint64_t Offset) const {
-  assert(CurrentState == State::Empty);
-  assert(Offset < MaxSize && "invalid offset");
+  assert(CurrentState == State::Empty && "Function should not be disassembled");
+  assert(Offset < MaxSize && "Invalid offset");
   ErrorOr<ArrayRef<unsigned char>> FunctionData = getData();
-  assert(FunctionData && "cannot get function as data");
+  assert(FunctionData && "Cannot get function as data");
   MCInst Instr;
   uint64_t InstrSize = 0;
   const uint64_t InstrAddress = getAddress() + Offset;

--- a/bolt/lib/Core/BinaryFunction.cpp
+++ b/bolt/lib/Core/BinaryFunction.cpp
@@ -1177,7 +1177,7 @@ BinaryFunction::disassembleInstructionAtOffset(uint64_t Offset) const {
   uint64_t InstrSize = 0;
   const uint64_t InstrAddress = getAddress() + Offset;
   if (BC.DisAsm->getInstruction(Instr, InstrSize, FunctionData->slice(Offset),
-                                 InstrAddress, nulls()))
+                                InstrAddress, nulls()))
     return Instr;
   return std::nullopt;
 }

--- a/bolt/lib/Passes/ValidateInternalCalls.cpp
+++ b/bolt/lib/Passes/ValidateInternalCalls.cpp
@@ -309,15 +309,10 @@ Error ValidateInternalCalls::runOnFunctions(BinaryContext &BC) {
   std::set<BinaryFunction *> NeedsValidation;
   for (auto &BFI : BC.getBinaryFunctions()) {
     BinaryFunction &Function = BFI.second;
-    for (BinaryBasicBlock &BB : Function) {
-      for (MCInst &Inst : BB) {
-        if (getInternalCallTarget(Function, Inst)) {
-          NeedsValidation.insert(&Function);
-          Function.setSimple(false);
-          break;
-        }
-      }
-    }
+    if (!Function.hasInternalCalls())
+      continue;
+    NeedsValidation.insert(&Function);
+    Function.setSimple(false);
   }
 
   // Skip validation for non-relocation mode

--- a/bolt/lib/Passes/ValidateInternalCalls.cpp
+++ b/bolt/lib/Passes/ValidateInternalCalls.cpp
@@ -309,10 +309,15 @@ Error ValidateInternalCalls::runOnFunctions(BinaryContext &BC) {
   std::set<BinaryFunction *> NeedsValidation;
   for (auto &BFI : BC.getBinaryFunctions()) {
     BinaryFunction &Function = BFI.second;
-    if (!Function.hasInternalCalls())
-      continue;
-    NeedsValidation.insert(&Function);
-    Function.setSimple(false);
+    for (BinaryBasicBlock &BB : Function) {
+      for (MCInst &Inst : BB) {
+        if (getInternalCallTarget(Function, Inst)) {
+          NeedsValidation.insert(&Function);
+          Function.setSimple(false);
+          break;
+        }
+      }
+    }
   }
 
   // Skip validation for non-relocation mode

--- a/bolt/lib/Profile/DataAggregator.cpp
+++ b/bolt/lib/Profile/DataAggregator.cpp
@@ -778,13 +778,13 @@ bool DataAggregator::doBranch(uint64_t From, uint64_t To, uint64_t Count,
     if (BinaryFunction *Func = getBinaryFunctionContainingAddress(Addr)) {
       Addr -= Func->getAddress();
       if (IsFrom) {
-        if (Func->hasInstructions()) {
-          if (MCInst *Inst = Func->getInstructionAtOffset(Addr))
-            IsReturn = BC->MIB->isReturn(*Inst);
-        } else if (std::optional<MCInst> Inst =
-                Func->disassembleInstructionAtOffset(Addr)) {
-          IsReturn = BC->MIB->isReturn(*Inst);
-        }
+        auto checkReturn = [&](auto MaybeInst) {
+          IsReturn = MaybeInst && BC->MIB->isReturn(*MaybeInst);
+        };
+        if (Func->hasInstructions())
+          checkReturn(Func->getInstructionAtOffset(Addr));
+        else
+          checkReturn(Func->disassembleInstructionAtOffset(Addr));
       }
 
       if (BAT)

--- a/bolt/lib/Rewrite/RewriteInstance.cpp
+++ b/bolt/lib/Rewrite/RewriteInstance.cpp
@@ -3343,8 +3343,7 @@ void RewriteInstance::disassembleFunctions() {
 
     if (!Function.isSimple()) {
       assert((!BC->HasRelocations || Function.getSize() == 0 ||
-              Function.hasIndirectTargetToSplitFragment() ||
-              Function.hasInternalCalls()) &&
+              Function.hasIndirectTargetToSplitFragment()) &&
              "unexpected non-simple function in relocation mode");
       continue;
     }

--- a/bolt/lib/Rewrite/RewriteInstance.cpp
+++ b/bolt/lib/Rewrite/RewriteInstance.cpp
@@ -3343,7 +3343,8 @@ void RewriteInstance::disassembleFunctions() {
 
     if (!Function.isSimple()) {
       assert((!BC->HasRelocations || Function.getSize() == 0 ||
-              Function.hasIndirectTargetToSplitFragment()) &&
+              Function.hasIndirectTargetToSplitFragment() ||
+              Function.hasInternalCalls()) &&
              "unexpected non-simple function in relocation mode");
       continue;
     }


### PR DESCRIPTION
Returns are ignored in perf/pre-aggregated/fdata profile reader (see
DataReader::convertBranchData). They are also omitted in
YAMLProfileWriter by virtue of not having the profile attached to them
in the reader, and YAMLProfileWriter converting the profile attached to
BinaryFunctions. Thus, return profile is universally ignored across all
profile types except BAT YAML.

To make returns ignored for YAML produced in BAT mode, we can:
1) ignore them in YAMLProfileReader,
2) omit them from YAML profile in profile conversion/writing.

The first option is prone to profile staleness issue, where the profiled
binary doesn't match the one to be optimized, and thus returns in the
profile can no longer be reliably detected (as we don't distinguish them
from calls in the profile).

The second option is robust to staleness but requires disassembling the
branch source instruction.

Test Plan: Updated bolt-address-translation-yaml.test
