### PR TITLE
[InstCombine] Allow overflowing selects to work on commutative arguments

### DIFF
--- a/llvm/test/Transforms/InstCombine/overflow_to_sat.ll
+++ b/llvm/test/Transforms/InstCombine/overflow_to_sat.ll
@@ -15,10 +15,7 @@ define i32 @uadd(i32 %x, i32 %y) {
 
 define i32 @uadd_comm(i32 %x, i32 %y) {
 ; CHECK-LABEL: @uadd_comm(
-; CHECK-NEXT:    [[AO:%.*]] = tail call { i32, i1 } @llvm.uadd.with.overflow.i32(i32 [[X:%.*]], i32 [[Y:%.*]])
-; CHECK-NEXT:    [[O:%.*]] = extractvalue { i32, i1 } [[AO]], 1
-; CHECK-NEXT:    [[A:%.*]] = add i32 [[Y]], [[X]]
-; CHECK-NEXT:    [[S:%.*]] = select i1 [[O]], i32 -1, i32 [[A]]
+; CHECK-NEXT:    [[S:%.*]] = call i32 @llvm.uadd.sat.i32(i32 [[X:%.*]], i32 [[Y:%.*]])
 ; CHECK-NEXT:    ret i32 [[S]]
 ;
   %ao = tail call { i32, i1 } @llvm.uadd.with.overflow.i32(i32 %x, i32 %y)
@@ -666,12 +663,7 @@ define i32 @sadd_i32(i32 %x, i32 %y) {
 
 define i32 @sadd_i32_no_extract(i32 %x, i32 %y) {
 ; CHECK-LABEL: @sadd_i32_no_extract(
-; CHECK-NEXT:    [[AO:%.*]] = tail call { i32, i1 } @llvm.sadd.with.overflow.i32(i32 [[X:%.*]], i32 [[Y:%.*]])
-; CHECK-NEXT:    [[O:%.*]] = extractvalue { i32, i1 } [[AO]], 1
-; CHECK-NEXT:    [[A:%.*]] = add i32 [[Y]], [[X]]
-; CHECK-NEXT:    [[C:%.*]] = icmp slt i32 [[X]], 0
-; CHECK-NEXT:    [[S:%.*]] = select i1 [[C]], i32 -2147483648, i32 2147483647
-; CHECK-NEXT:    [[R:%.*]] = select i1 [[O]], i32 [[S]], i32 [[A]]
+; CHECK-NEXT:    [[R:%.*]] = call i32 @llvm.sadd.sat.i32(i32 [[X:%.*]], i32 [[Y:%.*]])
 ; CHECK-NEXT:    ret i32 [[R]]
 ;
   %ao = tail call { i32, i1 } @llvm.sadd.with.overflow.i32(i32 %x, i32 %y)

--- a/llvm/test/Transforms/InstCombine/overflow_to_sat.ll
+++ b/llvm/test/Transforms/InstCombine/overflow_to_sat.ll
@@ -13,6 +13,21 @@ define i32 @uadd(i32 %x, i32 %y) {
   ret i32 %s
 }
 
+define i32 @uadd_comm(i32 %x, i32 %y) {
+; CHECK-LABEL: @uadd_comm(
+; CHECK-NEXT:    [[AO:%.*]] = tail call { i32, i1 } @llvm.uadd.with.overflow.i32(i32 [[X:%.*]], i32 [[Y:%.*]])
+; CHECK-NEXT:    [[O:%.*]] = extractvalue { i32, i1 } [[AO]], 1
+; CHECK-NEXT:    [[A:%.*]] = add i32 [[Y]], [[X]]
+; CHECK-NEXT:    [[S:%.*]] = select i1 [[O]], i32 -1, i32 [[A]]
+; CHECK-NEXT:    ret i32 [[S]]
+;
+  %ao = tail call { i32, i1 } @llvm.uadd.with.overflow.i32(i32 %x, i32 %y)
+  %o = extractvalue { i32, i1 } %ao, 1
+  %a = add i32 %y, %x
+  %s = select i1 %o, i32 -1, i32 %a
+  ret i32 %s
+}
+
 define i32 @usub(i32 %x, i32 %y) {
 ; CHECK-LABEL: @usub(
 ; CHECK-NEXT:    [[S:%.*]] = call i32 @llvm.usub.sat.i32(i32 [[X:%.*]], i32 [[Y:%.*]])
@@ -24,7 +39,6 @@ define i32 @usub(i32 %x, i32 %y) {
   %s = select i1 %o, i32 0, i32 %a
   ret i32 %s
 }
-
 
 define i8 @sadd_x_lt_min(i8 %x, i8 %y) {
 ; CHECK-LABEL: @sadd_x_lt_min(
@@ -644,6 +658,25 @@ define i32 @sadd_i32(i32 %x, i32 %y) {
   %ao = tail call { i32, i1 } @llvm.sadd.with.overflow.i32(i32 %x, i32 %y)
   %o = extractvalue { i32, i1 } %ao, 1
   %a = extractvalue { i32, i1 } %ao, 0
+  %c = icmp slt i32 %x, 0
+  %s = select i1 %c, i32 -2147483648, i32 2147483647
+  %r = select i1 %o, i32 %s, i32 %a
+  ret i32 %r
+}
+
+define i32 @sadd_i32_no_extract(i32 %x, i32 %y) {
+; CHECK-LABEL: @sadd_i32_no_extract(
+; CHECK-NEXT:    [[AO:%.*]] = tail call { i32, i1 } @llvm.sadd.with.overflow.i32(i32 [[X:%.*]], i32 [[Y:%.*]])
+; CHECK-NEXT:    [[O:%.*]] = extractvalue { i32, i1 } [[AO]], 1
+; CHECK-NEXT:    [[A:%.*]] = add i32 [[Y]], [[X]]
+; CHECK-NEXT:    [[C:%.*]] = icmp slt i32 [[X]], 0
+; CHECK-NEXT:    [[S:%.*]] = select i1 [[C]], i32 -2147483648, i32 2147483647
+; CHECK-NEXT:    [[R:%.*]] = select i1 [[O]], i32 [[S]], i32 [[A]]
+; CHECK-NEXT:    ret i32 [[R]]
+;
+  %ao = tail call { i32, i1 } @llvm.sadd.with.overflow.i32(i32 %x, i32 %y)
+  %o = extractvalue { i32, i1 } %ao, 1
+  %a = add i32 %y, %x
   %c = icmp slt i32 %x, 0
   %s = select i1 %c, i32 -2147483648, i32 2147483647
   %r = select i1 %o, i32 %s, i32 %a


### PR DESCRIPTION
This came up when working on a patch for systemd, where the code would not simplify because the code read:

```
unsigned int u(unsigned int x, unsigned int y)
{
    unsigned int z;
    if (__builtin_uadd_overflow(x, y, &z))
         return UINT_MAX; /* indicate overflow */
    return x + y;
}
```
Instead of:
```
unsigned int u(unsigned int x, unsigned int y)
{
    unsigned int z;
    if (__builtin_uadd_overflow(x, y, &z))
         return UINT_MAX; /* indicate overflow */
    return z;
}
```