### PR TITLE
[compiler-rt] Fix CMake configure on Windows

### DIFF
--- a/compiler-rt/cmake/Modules/CompilerRTUtils.cmake
+++ b/compiler-rt/cmake/Modules/CompilerRTUtils.cmake
@@ -369,11 +369,11 @@ macro(construct_compiler_rt_default_triple)
   endif()
 
   if ("${CMAKE_C_COMPILER_ID}" MATCHES "Clang")
-    set(cmd_prefix "")
+    set(option_prefix "")
     if (CMAKE_C_SIMULATE_ID MATCHES "MSVC")
-      set(cmd_prefix "/clang:")
+      set(option_prefix "/clang:")
     endif()
-    execute_process(COMMAND ${CMAKE_C_COMPILER} ${cmd_prefix}--target=${COMPILER_RT_DEFAULT_TARGET_TRIPLE} ${cmd_prefix}-print-target-triple
+    execute_process(COMMAND ${CMAKE_C_COMPILER} ${option_prefix}--target=${COMPILER_RT_DEFAULT_TARGET_TRIPLE} ${option_prefix}-print-target-triple
                     OUTPUT_VARIABLE COMPILER_RT_DEFAULT_TARGET_TRIPLE
                     OUTPUT_STRIP_TRAILING_WHITESPACE)
   endif()

--- a/compiler-rt/cmake/Modules/CompilerRTUtils.cmake
+++ b/compiler-rt/cmake/Modules/CompilerRTUtils.cmake
@@ -369,7 +369,11 @@ macro(construct_compiler_rt_default_triple)
   endif()
 
   if ("${CMAKE_C_COMPILER_ID}" MATCHES "Clang")
-    execute_process(COMMAND ${CMAKE_C_COMPILER} --target=${COMPILER_RT_DEFAULT_TARGET_TRIPLE} -print-target-triple
+    set(cmd_prefix "")
+    if (CMAKE_C_SIMULATE_ID MATCHES "MSVC")
+      set(cmd_prefix "/clang:")
+    endif()
+    execute_process(COMMAND ${CMAKE_C_COMPILER} ${cmd_prefix}--target=${COMPILER_RT_DEFAULT_TARGET_TRIPLE} ${cmd_prefix}-print-target-triple
                     OUTPUT_VARIABLE COMPILER_RT_DEFAULT_TARGET_TRIPLE
                     OUTPUT_STRIP_TRAILING_WHITESPACE)
   endif()


### PR DESCRIPTION
CMake configure compiler-rt got broken as a result of following commit: d3925e65a7ab88eb0ba68d3ab79cd95db5629951

This patch fixes the break by porting the above commit for clang-cl.

This problem was not caught on Windows buildbots beacuase it appeared when compiler-rt was included via LLVM_ENABLE_PROJECTS while buildbots include compiler-rt project using LLVM_ENABLE_RUNTIMES flag.