### PR TITLE
[lld-macho] Add support for category names in ConcatInputSection's

### DIFF
--- a/lld/MachO/ObjC.cpp
+++ b/lld/MachO/ObjC.cpp
@@ -196,7 +196,7 @@ static StringRef getReferentString(const Reloc &r) {
     return s->getStringRefAtOffset(sym->value + r.addend);
 
   if (isa<ConcatInputSection>(sym->isec())) {
-    auto strData = sym->isec()->data.slice(sym->value);
+    auto strData = sym->isec()->data.slice(sym->value + r.addend);
     uint32_t len = strnlen((const char *)strData.data(), strData.size());
     return StringRef((const char *)strData.data(), len);
   }

--- a/lld/MachO/ObjC.cpp
+++ b/lld/MachO/ObjC.cpp
@@ -192,9 +192,8 @@ static StringRef getReferentString(const Reloc &r) {
   if (auto *isec = r.referent.dyn_cast<InputSection *>())
     return cast<CStringInputSection>(isec)->getStringRefAtOffset(r.addend);
   auto *sym = cast<Defined>(r.referent.get<Symbol *>());
-  if (isa<CStringInputSection>(sym->isec()))
-    return cast<CStringInputSection>(sym->isec())
-        ->getStringRefAtOffset(sym->value + r.addend);
+  if (auto *s = dyn_cast_or_null<CStringInputSection>(sym->isec()))
+    return s->getStringRefAtOffset(sym->value + r.addend);
 
   if (isa<ConcatInputSection>(sym->isec())) {
     auto &data = sym->isec()->data;

--- a/lld/MachO/ObjC.cpp
+++ b/lld/MachO/ObjC.cpp
@@ -196,10 +196,10 @@ static StringRef getReferentString(const Reloc &r) {
     return s->getStringRefAtOffset(sym->value + r.addend);
 
   if (isa<ConcatInputSection>(sym->isec())) {
-    auto &data = sym->isec()->data;
-    const char *pDataStart = reinterpret_cast<const char *>(data.data());
-    uint32_t len = strnlen(pDataStart + sym->value, data.size() - sym->value);
-    return StringRef(pDataStart + sym->value, len);
+    auto paddedData = sym->isec()->data.slice(sym->value);
+    uint32_t len = strnlen((const char *)paddedData.data(), paddedData.size());
+    auto strData = paddedData.slice(0, len);
+    return StringRef((const char *)strData.data(), strData.size());
   }
 
   llvm_unreachable("unknown reference section in getReferentString");

--- a/lld/MachO/ObjC.cpp
+++ b/lld/MachO/ObjC.cpp
@@ -196,10 +196,9 @@ static StringRef getReferentString(const Reloc &r) {
     return s->getStringRefAtOffset(sym->value + r.addend);
 
   if (isa<ConcatInputSection>(sym->isec())) {
-    auto paddedData = sym->isec()->data.slice(sym->value);
-    uint32_t len = strnlen((const char *)paddedData.data(), paddedData.size());
-    auto strData = paddedData.slice(0, len);
-    return StringRef((const char *)strData.data(), strData.size());
+    auto strData = sym->isec()->data.slice(sym->value);
+    uint32_t len = strnlen((const char *)strData.data(), strData.size());
+    return StringRef((const char *)strData.data(), len);
   }
 
   llvm_unreachable("unknown reference section in getReferentString");

--- a/lld/MachO/ObjC.cpp
+++ b/lld/MachO/ObjC.cpp
@@ -201,8 +201,8 @@ static StringRef getReferentString(const Reloc &r) {
 
   if (isa<ConcatInputSection>(symIsec)) {
     auto strData = symIsec->data.slice(symOffset);
-    uint32_t len = strnlen((const char *)strData.data(), strData.size());
-    return StringRef((const char *)strData.data(), len);
+    const char *pszData = reinterpret_cast<const char *>(strData.data());
+    return StringRef(pszData, strnlen(pszData, strData.size()));
   }
 
   llvm_unreachable("unknown reference section in getReferentString");

--- a/lld/test/MachO/objc-category-merging-extern-class-minimal.s
+++ b/lld/test/MachO/objc-category-merging-extern-class-minimal.s
@@ -118,7 +118,7 @@ __OBJC_$_CATEGORY_MyBaseClass_$_Category01:
 	.quad	0
 	.long	64                              ; 0x40
 	.space	4
-	.section	__TEXT,__objc_classname,cstring_literals
+	.section	__DATA,__objc_const
 l_OBJC_CLASS_NAME_.1:                   ; @OBJC_CLASS_NAME_.1
 	.asciz	"Category02"
 	.section	__TEXT,__objc_methname,cstring_literals


### PR DESCRIPTION
In some cases we see strings from categories being part of "data" sections (Ex:`__objc_const`), not part of of sections marked as `cstring_literals`. Since lld treats these sections differently we need to explicitly implement support for reading strings from the non-`cstring_literals` sections.

Adding a test that previously would result in an assert.