### PR TITLE
[llvm][AArch64] Fix Arm 32 bit build warnings

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
+++ b/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
@@ -16649,13 +16649,13 @@ bool AArch64TargetLowering::isLegalAddScalableImmediate(int64_t Imm) const {
 
   // inch|dech
   if (Imm % 8 == 0)
-    return std::labs(Imm / 8) <= 16;
+    return std::abs(Imm / 8) <= 16;
   // incw|decw
   if (Imm % 4 == 0)
-    return std::labs(Imm / 4) <= 16;
+    return std::abs(Imm / 4) <= 16;
   // incd|decd
   if (Imm % 2 == 0)
-    return std::labs(Imm / 2) <= 16;
+    return std::abs(Imm / 2) <= 16;
 
   return false;
 }


### PR DESCRIPTION
https://github.com/llvm/llvm-project/pull/84173 added uses of std::labs on an int64_t which leads to this warning on Arm 32 bit:
```
/home/david.spickett/llvm-project/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp:16655:12: warning: absolute value function 'labs' given an argument of type 'long long' but has parameter of type 'long' which may cause truncation of value [-Wabsolute-value]
    return std::labs(Imm / 4) <= 16;
           ^
/home/david.spickett/llvm-project/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp:16655:12: note: use function 'std::abs' instead
    return std::labs(Imm / 4) <= 16;
           ^~~~~~~~~
           std::abs
```

Since int64_t is "long long" on Arm, not "long".

Use std::abs instead since it has versions for "long" and "long long", we'll pick up the right one at compile time
(https://en.cppreference.com/w/cpp/numeric/math/abs).