### PR TITLE
[clang-tidy] Add 'cert-int09-c' alias for 'readability-enum-initial-value'

### DIFF
--- a/clang-tools-extra/clang-tidy/cert/CERTTidyModule.cpp
+++ b/clang-tools-extra/clang-tidy/cert/CERTTidyModule.cpp
@@ -25,6 +25,7 @@
 #include "../misc/StaticAssertCheck.h"
 #include "../misc/ThrowByValueCatchByReferenceCheck.h"
 #include "../performance/MoveConstructorInitCheck.h"
+#include "../readability/EnumInitialValueCheck.h"
 #include "../readability/UppercaseLiteralSuffixCheck.h"
 #include "CommandProcessorCheck.h"
 #include "DefaultOperatorNewAlignmentCheck.h"
@@ -299,6 +300,9 @@ public:
         "cert-flp37-c");
     // FIO
     CheckFactories.registerCheck<misc::NonCopyableObjectsCheck>("cert-fio38-c");
+    // INT
+    CheckFactories.registerCheck<readability::EnumInitialValueCheck>(
+        "cert-int09-c");
     // MSC
     CheckFactories.registerCheck<bugprone::UnsafeFunctionsCheck>(
         "cert-msc24-c");

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -166,6 +166,10 @@ New checks
 New check aliases
 ^^^^^^^^^^^^^^^^^
 
+- New alias :doc:`cert-int09-c <clang-tidy/checks/cert/int09-c>` to
+  :doc:`readability-enum-initial-value <clang-tidy/checks/readability/enum-initial-value>`
+  was added.
+
 Changes in existing checks
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/clang-tools-extra/docs/clang-tidy/checks/cert/int09-c.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/cert/int09-c.rst
@@ -1,0 +1,10 @@
+.. title:: clang-tidy - cert-int09-c
+.. meta::
+   :http-equiv=refresh: 5;URL=../readability/enum-initial-value.html
+
+cert-int09-c
+============
+
+The `cert-int09-c` check is an alias, please see
+:doc:`readability-enum-initial-value <../readability/enum-initial-value>` for
+more information.

--- a/clang-tools-extra/docs/clang-tidy/checks/list.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/list.rst
@@ -395,8 +395,10 @@ Clang-Tidy Checks
    :doc:`readability-use-std-min-max <readability/use-std-min-max>`, "Yes"
    :doc:`zircon-temporary-objects <zircon/temporary-objects>`,
 
+Check aliases
+-------------
 
-.. csv-table:: Aliases..
+.. csv-table::
    :header: "Name", "Redirect", "Offers fixes"
 
    :doc:`bugprone-narrowing-conversions <bugprone/narrowing-conversions>`, :doc:`cppcoreguidelines-narrowing-conversions <cppcoreguidelines/narrowing-conversions>`,
@@ -413,6 +415,7 @@ Clang-Tidy Checks
    :doc:`cert-exp42-c <cert/exp42-c>`, :doc:`bugprone-suspicious-memory-comparison <bugprone/suspicious-memory-comparison>`,
    :doc:`cert-fio38-c <cert/fio38-c>`, :doc:`misc-non-copyable-objects <misc/non-copyable-objects>`,
    :doc:`cert-flp37-c <cert/flp37-c>`, :doc:`bugprone-suspicious-memory-comparison <bugprone/suspicious-memory-comparison>`,
+   :doc:`cert-int09-c <cert/int09-c>`, :doc:`readability-enum-initial-value <readability/enum-initial-value>`, "Yes"
    :doc:`cert-msc24-c <cert/msc24-c>`, :doc:`bugprone-unsafe-functions <bugprone/unsafe-functions>`,
    :doc:`cert-msc30-c <cert/msc30-c>`, :doc:`cert-msc50-cpp <cert/msc50-cpp>`,
    :doc:`cert-msc32-c <cert/msc32-c>`, :doc:`cert-msc51-cpp <cert/msc51-cpp>`,

--- a/clang-tools-extra/docs/clang-tidy/checks/readability/enum-initial-value.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/readability/enum-initial-value.rst
@@ -6,70 +6,83 @@ readability-enum-initial-value
 Enforces consistent style for enumerators' initialization, covering three
 styles: none, first only, or all initialized explicitly.
 
-When adding new enumerations, inconsistent initial value will cause potential
-enumeration value conflicts.
+An inconsistent style and strictness to defining the initializing value of
+enumerators may cause issues if the enumeration is extended with new
+enumerators that obtain their integer representation implicitly.
 
-In an enumeration, the following three cases are accepted. 
-1. none of enumerators are explicit initialized.
-2. the first enumerator is explicit initialized.
-3. all of enumerators are explicit initialized.
+The following three cases are accepted:
+
+#. **No** enumerators are explicit initialized.
+#. Exactly **the first** enumerator is explicit initialized.
+#. **All** enumerators are explicit initialized.
 
 .. code-block:: c++
 
-  // valid, none of enumerators are initialized.
-  enum A {
-    e0,
-    e1,
-    e2,
+  enum A {    // (1) Valid, none of enumerators are initialized.
+    a0,
+    a1,
+    a2,
   };
 
-  // valid, the first enumerator is initialized.
-  enum A {
-    e0 = 0,
-    e1,
-    e2,
+  enum B {    // (2) Valid, the first enumerator is initialized.
+    b0 = 0,
+    b1,
+    b2,
   };
 
-  // valid, all of enumerators are initialized.
-  enum A {
+  enum C {    // (3) Valid, all of enumerators are initialized.
+    c0 = 0,
+    c1 = 1,
+    c2 = 2,
+  };
+
+  enum D {    // Invalid, d1 is not explicitly initialized!
+    d0 = 0,
+    d1,
+    d2 = 2,
+  };
+
+  enum E {    // Invalid, e1, e3, and e5 are not explicitly initialized.
     e0 = 0,
-    e1 = 1,
+    e1,
     e2 = 2,
+    e3,       // Dangerous, as the numeric values of e3 and e5 are both 3, and this is not explicitly visible in the code!
+    e4 = 2,
+    e5,
   };
 
-  // invalid, e1 is not explicit initialized.
-  enum A {
-    e0 = 0,
-    e1,
-    e2 = 2,
-  };
+This check corresponds to the CERT C Coding Standard recommendation `INT09-C. Ensure enumeration constants map to unique values
+<https://wiki.sei.cmu.edu/confluence/display/c/INT09-C.+Ensure+enumeration+constants+map+to+unique+values>`_.
+
+`cert-int09-c` redirects here as an alias of this check.
 
 Options
 -------
 
 .. option:: AllowExplicitZeroFirstInitialValue
 
-  If set to `false`, the first enumerator must not be explicitly initialized.
-  See examples below. Default is `true`.
+  If set to `false`, the first enumerator must not be explicitly initialized to
+  a literal ``0``.
+  Default is `true`.
 
   .. code-block:: c++
 
-    enum A {
-      e0 = 0, // not allowed if AllowExplicitZeroFirstInitialValue is false
-      e1,
-      e2,
+    enum F {
+      f0 = 0, // Not allowed if AllowExplicitZeroFirstInitialValue is false.
+      f1,
+      f2,
     };
 
 
 .. option:: AllowExplicitSequentialInitialValues
 
-  If set to `false`, sequential initializations are not allowed.
-  See examples below. Default is `true`.
+  If set to `false`, explicit initialization to sequential values are not
+  allowed.
+  Default is `true`.
 
   .. code-block:: c++
 
-    enum A {
-      e0 = 1, // not allowed if AllowExplicitSequentialInitialValues is false
-      e1 = 2,
-      e2 = 3,
-    };
+    enum G {
+      g0 = 1, // Not allowed if AllowExplicitSequentialInitialValues is false.
+      g1 = 2,
+      g2 = 3,


### PR DESCRIPTION
The check's ruling exactly matches the corresponding CERT C Recommendation, and, as such, worth a trivial alias.