### PR TITLE
[RemoveDIs][Clang] Resolve DILocalVariables used by DbgRecords

### DIFF
--- a/clang/lib/CodeGen/CGVTables.cpp
+++ b/clang/lib/CodeGen/CGVTables.cpp
@@ -131,6 +131,12 @@ static void resolveTopLevelMetadata(llvm::Function *Fn,
   // they are referencing.
   for (auto &BB : *Fn) {
     for (auto &I : BB) {
+      for (llvm::DbgVariableRecord &DVR :
+           llvm::filterDbgVars(I.getDbgRecordRange())) {
+        auto *DILocal = DVR.getVariable();
+        if (!DILocal->isResolved())
+          DILocal->resolve();
+      }
       if (auto *DII = dyn_cast<llvm::DbgVariableIntrinsic>(&I)) {
         auto *DILocal = DII->getVariable();
         if (!DILocal->isResolved())

--- a/clang/test/CodeGenCXX/tmp-md-nodes2.cpp
+++ b/clang/test/CodeGenCXX/tmp-md-nodes2.cpp
@@ -1,6 +1,8 @@
 // REQUIRES: asserts
 // RUN: %clang_cc1 -O0 -triple %itanium_abi_triple -debug-info-kind=limited -S -emit-llvm %s -o - | \
 // RUN: FileCheck %s
+// RUN: %clang_cc1 -O0 -triple %itanium_abi_triple -debug-info-kind=limited -S -emit-llvm -mllvm --experimental-debuginfo-iterators=true %s -o - | \
+// RUN: FileCheck %s
 
 // This test simply checks that the varargs thunk is created. The failing test
 // case asserts.


### PR DESCRIPTION
This patch fixes debug records in clang, by adding support for debug records to the only remaining place that refers to DbgVariableIntrinsics directly and does not handle DbgVariableRecords.