### PR TITLE
SystemZ: Don't promote atomic store in IR

### DIFF
--- a/llvm/lib/CodeGen/SelectionDAG/LegalizeFloatTypes.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/LegalizeFloatTypes.cpp
@@ -1197,7 +1197,6 @@ SDValue DAGTypeLegalizer::SoftenFloatOp_STORE(SDNode *N, unsigned OpNo) {
 }
 
 SDValue DAGTypeLegalizer::SoftenFloatOp_ATOMIC_STORE(SDNode *N, unsigned OpNo) {
-  assert(ISD::isUNINDEXEDStore(N) && "Indexed store during type legalization!");
   assert(OpNo == 1 && "Can only soften the stored value!");
   AtomicSDNode *ST = cast<AtomicSDNode>(N);
   SDValue Val = ST->getVal();

--- a/llvm/test/CodeGen/SystemZ/atomic-store-08.ll
+++ b/llvm/test/CodeGen/SystemZ/atomic-store-08.ll
@@ -1,5 +1,4 @@
-; Test long double atomic stores. The atomic store is converted to i128 by
-; the AtomicExpand pass.
+; Test long double atomic stores. The atomic store is converted to i128
 ;
 ; RUN: llc < %s -mtriple=s390x-linux-gnu | FileCheck -check-prefixes=CHECK,BASE %s
 ; RUN: llc < %s -mtriple=s390x-linux-gnu -mcpu=z13 | FileCheck -check-prefixes=CHECK,Z13 %s
@@ -7,15 +6,28 @@
 ; TODO: Is it worth testing softfp with vector?
 ; RUN: llc < %s -mtriple=s390x-linux-gnu -mattr=+soft-float | FileCheck -check-prefixes=SOFTFP %s
 
+; TODO: Test soft float
+; RUN: llc < %s -mtriple=s390x-linux-gnu | FileCheck -check-prefixes=CHECK,BASE %s
+; RUN: llc < %s -mtriple=s390x-linux-gnu -mcpu=z13 | FileCheck -check-prefixes=CHECK,Z13 %s
 
+; FIXME: With legal 128-bit operation to bitcast, the base code would
+; be the same as z13
 define void @f1(ptr %dst, ptr %src) {
 ; CHECK-LABEL: f1:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    lg %r1, 8(%r3)
-; CHECK-NEXT:    lg %r0, 0(%r3)
-; CHECK-NEXT:    stpq %r0, 0(%r2)
-; CHECK-NEXT:    bcr 1{{[45]}}, %r0
-; CHECK-NEXT:    br %r14
+; Z13-NEXT:    lg %r1, 8(%r3)
+; Z13-NEXT:    lg %r0, 0(%r3)
+; Z13-NEXT:    stpq %r0, 0(%r2)
+; Z13-NEXT:    bcr 1{{[45]}}, %r0
+; Z13-NEXT:    br %r14
+
+; BASE-NEXT: ld	%f0, 0(%r3)
+; BASE-NEXT: ld	%f2, 8(%r3)
+; BASE-NEXT: lgdr	%r1, %f2
+; BASE-NEXT: lgdr	%r0, %f0
+; BASE-NEXT: stpq	%r0, 0(%r2)
+; BASE-NEXT: bcr	15, %r0
+; BASE-NEXT: br	%r14
 
 ; SOFTFP-LABEL: f1:
 ; SOFTFP:       # %bb.0:

--- a/llvm/test/CodeGen/SystemZ/atomic-store-08.ll
+++ b/llvm/test/CodeGen/SystemZ/atomic-store-08.ll
@@ -6,9 +6,6 @@
 ; TODO: Is it worth testing softfp with vector?
 ; RUN: llc < %s -mtriple=s390x-linux-gnu -mattr=+soft-float | FileCheck -check-prefixes=SOFTFP %s
 
-; TODO: Test soft float
-; RUN: llc < %s -mtriple=s390x-linux-gnu | FileCheck -check-prefixes=CHECK,BASE %s
-; RUN: llc < %s -mtriple=s390x-linux-gnu -mcpu=z13 | FileCheck -check-prefixes=CHECK,Z13 %s
 
 ; FIXME: With legal 128-bit operation to bitcast, the base code would
 ; be the same as z13


### PR DESCRIPTION
This is the mirror to the recent atomic load change. The same bitcast-back-to-integer case is a small code quality regression for the same reason. This would disappear with a bitcastable legal 128-bit type.