### PR TITLE
[lld-macho] Category Merger: add support for addrsig references

### DIFF
--- a/lld/MachO/ObjC.cpp
+++ b/lld/MachO/ObjC.cpp
@@ -1211,8 +1211,7 @@ void ObjcCategoryMerger::removeRefsToErasedIsecs() {
     if (isec->getName() != section_names::addrSig)
       continue;
 
-    auto &_erasedIsecs = erasedIsecs;
-    auto removeRelocs = [&_erasedIsecs](Reloc &r) {
+    auto removeRelocs = [this](Reloc &r) {
       auto *isec = dyn_cast_or_null<ConcatInputSection>(
           r.referent.dyn_cast<InputSection *>());
       if (!isec) {
@@ -1223,7 +1222,7 @@ void ObjcCategoryMerger::removeRefsToErasedIsecs() {
       }
       if (!isec)
         return false;
-      return _erasedIsecs.count(isec) > 0;
+      return erasedIsecs.count(isec) > 0;
     };
 
     isec->relocs.erase(

--- a/lld/MachO/ObjC.cpp
+++ b/lld/MachO/ObjC.cpp
@@ -21,8 +21,6 @@
 #include "llvm/Bitcode/BitcodeReader.h"
 #include "llvm/Support/TimeProfiler.h"
 
-#include <unordered_set>
-
 using namespace llvm;
 using namespace llvm::MachO;
 using namespace lld;
@@ -483,7 +481,7 @@ private:
   // Map of base class Symbol to list of InfoInputCategory's for it
   DenseMap<const Symbol *, std::vector<InfoInputCategory>> categoryMap;
   // Set for tracking InputSection erased via eraseISec
-  std::unordered_set<InputSection *> erasedIsecs;
+  DenseSet<InputSection *> erasedIsecs;
 
   // Normally, the binary data comes from the input files, but since we're
   // generating binary data ourselves, we use the below array to store it in.
@@ -1225,9 +1223,7 @@ void ObjcCategoryMerger::removeRefsToErasedIsecs() {
       return erasedIsecs.count(isec) > 0;
     };
 
-    isec->relocs.erase(
-        std::remove_if(isec->relocs.begin(), isec->relocs.end(), removeRelocs),
-        isec->relocs.end());
+    llvm::erase_if(isec->relocs, removeRelocs);
   }
 }
 

--- a/lld/MachO/ObjC.cpp
+++ b/lld/MachO/ObjC.cpp
@@ -462,7 +462,6 @@ private:
                                      uint32_t offset);
   void tryEraseDefinedAtIsecOffset(const ConcatInputSection *isec,
                                    uint32_t offset);
-  void eraseSymbolAtIsecOffset(ConcatInputSection *isec, uint32_t offset);
 
   // Allocate a null-terminated StringRef backed by generatedSectionData
   StringRef newStringData(const char *str);
@@ -552,10 +551,9 @@ void ObjcCategoryMerger::tryEraseDefinedAtIsecOffset(
   if (!sym)
     return;
 
-  if (auto *cisec = dyn_cast_or_null<ConcatInputSection>(sym->isec())) {
+  if (auto *cisec = dyn_cast_or_null<ConcatInputSection>(sym->isec()))
     eraseISec(cisec);
-  } else if (auto *csisec =
-                 dyn_cast_or_null<CStringInputSection>(sym->isec())) {
+  else if (auto *csisec = dyn_cast_or_null<CStringInputSection>(sym->isec())) {
     uint32_t totalOffset = sym->value + reloc->addend;
     StringPiece &piece = csisec->getStringPiece(totalOffset);
     piece.live = false;

--- a/lld/test/MachO/objc-category-merging-extern-class-minimal.s
+++ b/lld/test/MachO/objc-category-merging-extern-class-minimal.s
@@ -153,3 +153,6 @@ L_OBJC_IMAGE_INFO:
 	.long	0
 	.long	96
 .subsections_via_symbols
+
+.addrsig
+.addrsig_sym __OBJC_$_CATEGORY_MyBaseClass_$_Category01


### PR DESCRIPTION
When generating categories, clang sometimes will generate references in the `.addrsig` section to the various category data items. Since we may erase such items after merging them, we also need to remove them from the `.addrsig` section - otherwise this will cause runtime asserts with the `.addrsig` section trying to access invalid data.

Implementation wise, we use a hashset to keep track of all erased `InputSection`'s and then go through all `.addrsig` sections and remove references to any erased `InputSection`.