### PR TITLE
[AIX][libc++] Enable clang_modules_include.gen.py tests

### DIFF
--- a/libcxx/test/libcxx/clang_modules_include.gen.py
+++ b/libcxx/test/libcxx/clang_modules_include.gen.py
@@ -31,9 +31,6 @@ for header in public_headers:
 // UNSUPPORTED: windows
 // UNSUPPORTED: buildhost=windows
 
-// The AIX headers don't appear to be compatible with modules
-// UNSUPPORTED: LIBCXX-AIX-FIXME
-
 // The Android headers don't appear to be compatible with modules yet
 // UNSUPPORTED: LIBCXX-ANDROID-FIXME
 
@@ -60,9 +57,6 @@ print(f"""\
 // The Windows headers don't appear to be compatible with modules
 // UNSUPPORTED: windows
 // UNSUPPORTED: buildhost=windows
-
-// The AIX headers don't appear to be compatible with modules
-// UNSUPPORTED: LIBCXX-AIX-FIXME
 
 // The Android headers don't appear to be compatible with modules yet
 // UNSUPPORTED: LIBCXX-ANDROID-FIXME


### PR DESCRIPTION
Enable these tests on AIX since they're passing.