### PR TITLE
[analyzer] Use explicit call description mode in more checkers

### DIFF
--- a/clang/lib/StaticAnalyzer/Checkers/BlockInCriticalSectionChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/BlockInCriticalSectionChecker.cpp
@@ -148,35 +148,28 @@ using MutexDescriptor =
 class BlockInCriticalSectionChecker : public Checker<check::PostCall> {
 private:
   const std::array<MutexDescriptor, 8> MutexDescriptors{
-      MemberMutexDescriptor(
-          {/*MatchAs=*/CDM::CXXMethod,
-           /*QualifiedName=*/{"std", "mutex", "lock"},
-           /*RequiredArgs=*/0},
-          {CDM::CXXMethod, {"std", "mutex", "unlock"}, 0}),
-      FirstArgMutexDescriptor(
-          {CDM::CLibrary, {"pthread_mutex_lock"}, 1},
-          {CDM::CLibrary, {"pthread_mutex_unlock"}, 1}),
-      FirstArgMutexDescriptor(
-          {CDM::CLibrary, {"mtx_lock"}, 1},
-          {CDM::CLibrary, {"mtx_unlock"}, 1}),
-      FirstArgMutexDescriptor(
-          {CDM::CLibrary, {"pthread_mutex_trylock"}, 1},
-          {CDM::CLibrary, {"pthread_mutex_unlock"}, 1}),
-      FirstArgMutexDescriptor(
-          {CDM::CLibrary, {"mtx_trylock"}, 1},
-          {CDM::CLibrary, {"mtx_unlock"}, 1}),
-      FirstArgMutexDescriptor(
-          {CDM::CLibrary, {"mtx_timedlock"}, 1},
-          {CDM::CLibrary, {"mtx_unlock"}, 1}),
+      MemberMutexDescriptor({/*MatchAs=*/CDM::CXXMethod,
+                             /*QualifiedName=*/{"std", "mutex", "lock"},
+                             /*RequiredArgs=*/0},
+                            {CDM::CXXMethod, {"std", "mutex", "unlock"}, 0}),
+      FirstArgMutexDescriptor({CDM::CLibrary, {"pthread_mutex_lock"}, 1},
+                              {CDM::CLibrary, {"pthread_mutex_unlock"}, 1}),
+      FirstArgMutexDescriptor({CDM::CLibrary, {"mtx_lock"}, 1},
+                              {CDM::CLibrary, {"mtx_unlock"}, 1}),
+      FirstArgMutexDescriptor({CDM::CLibrary, {"pthread_mutex_trylock"}, 1},
+                              {CDM::CLibrary, {"pthread_mutex_unlock"}, 1}),
+      FirstArgMutexDescriptor({CDM::CLibrary, {"mtx_trylock"}, 1},
+                              {CDM::CLibrary, {"mtx_unlock"}, 1}),
+      FirstArgMutexDescriptor({CDM::CLibrary, {"mtx_timedlock"}, 1},
+                              {CDM::CLibrary, {"mtx_unlock"}, 1}),
       RAIIMutexDescriptor("lock_guard"),
       RAIIMutexDescriptor("unique_lock")};
 
-  const CallDescriptionSet BlockingFunctions{
-      {CDM::CLibrary, {"sleep"}},
-      {CDM::CLibrary, {"getc"}},
-      {CDM::CLibrary, {"fgets"}},
-      {CDM::CLibrary, {"read"}},
-      {CDM::CLibrary, {"recv"}}};
+  const CallDescriptionSet BlockingFunctions{{CDM::CLibrary, {"sleep"}},
+                                             {CDM::CLibrary, {"getc"}},
+                                             {CDM::CLibrary, {"fgets"}},
+                                             {CDM::CLibrary, {"read"}},
+                                             {CDM::CLibrary, {"recv"}}};
 
   const BugType BlockInCritSectionBugType{
       this, "Call to blocking function in critical section", "Blocking Error"};

--- a/clang/lib/StaticAnalyzer/Checkers/BlockInCriticalSectionChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/BlockInCriticalSectionChecker.cpp
@@ -149,34 +149,34 @@ class BlockInCriticalSectionChecker : public Checker<check::PostCall> {
 private:
   const std::array<MutexDescriptor, 8> MutexDescriptors{
       MemberMutexDescriptor(
-          CallDescription(/*MatchAs=*/CDM::CXXMethod,
-                          /*QualifiedName=*/{"std", "mutex", "lock"},
-                          /*RequiredArgs=*/0),
-          CallDescription(CDM::CXXMethod, {"std", "mutex", "unlock"}, 0)),
+          {/*MatchAs=*/CDM::CXXMethod,
+           /*QualifiedName=*/{"std", "mutex", "lock"},
+           /*RequiredArgs=*/0},
+          {CDM::CXXMethod, {"std", "mutex", "unlock"}, 0}),
       FirstArgMutexDescriptor(
-          CallDescription(CDM::CLibrary, {"pthread_mutex_lock"}, 1),
-          CallDescription(CDM::CLibrary, {"pthread_mutex_unlock"}, 1)),
+          {CDM::CLibrary, {"pthread_mutex_lock"}, 1},
+          {CDM::CLibrary, {"pthread_mutex_unlock"}, 1}),
       FirstArgMutexDescriptor(
-          CallDescription(CDM::CLibrary, {"mtx_lock"}, 1),
-          CallDescription(CDM::CLibrary, {"mtx_unlock"}, 1)),
+          {CDM::CLibrary, {"mtx_lock"}, 1},
+          {CDM::CLibrary, {"mtx_unlock"}, 1}),
       FirstArgMutexDescriptor(
-          CallDescription(CDM::CLibrary, {"pthread_mutex_trylock"}, 1),
-          CallDescription(CDM::CLibrary, {"pthread_mutex_unlock"}, 1)),
+          {CDM::CLibrary, {"pthread_mutex_trylock"}, 1},
+          {CDM::CLibrary, {"pthread_mutex_unlock"}, 1}),
       FirstArgMutexDescriptor(
-          CallDescription(CDM::CLibrary, {"mtx_trylock"}, 1),
-          CallDescription(CDM::CLibrary, {"mtx_unlock"}, 1)),
+          {CDM::CLibrary, {"mtx_trylock"}, 1},
+          {CDM::CLibrary, {"mtx_unlock"}, 1}),
       FirstArgMutexDescriptor(
-          CallDescription(CDM::CLibrary, {"mtx_timedlock"}, 1),
-          CallDescription(CDM::CLibrary, {"mtx_unlock"}, 1)),
+          {CDM::CLibrary, {"mtx_timedlock"}, 1},
+          {CDM::CLibrary, {"mtx_unlock"}, 1}),
       RAIIMutexDescriptor("lock_guard"),
       RAIIMutexDescriptor("unique_lock")};
 
-  const std::array<CallDescription, 5> BlockingFunctions{
-      CallDescription(CDM::CLibrary, {"sleep"}),
-      CallDescription(CDM::CLibrary, {"getc"}),
-      CallDescription(CDM::CLibrary, {"fgets"}),
-      CallDescription(CDM::CLibrary, {"read"}),
-      CallDescription(CDM::CLibrary, {"recv"})};
+  const CallDescriptionSet BlockingFunctions{
+      {CDM::CLibrary, {"sleep"}},
+      {CDM::CLibrary, {"getc"}},
+      {CDM::CLibrary, {"fgets"}},
+      {CDM::CLibrary, {"read"}},
+      {CDM::CLibrary, {"recv"}}};
 
   const BugType BlockInCritSectionBugType{
       this, "Call to blocking function in critical section", "Blocking Error"};
@@ -299,8 +299,7 @@ void BlockInCriticalSectionChecker::handleUnlock(
 
 bool BlockInCriticalSectionChecker::isBlockingInCritSection(
     const CallEvent &Call, CheckerContext &C) const {
-  return llvm::any_of(BlockingFunctions,
-                      [&Call](auto &&Fn) { return Fn.matches(Call); }) &&
+  return BlockingFunctions.contains(Call) &&
          !C.getState()->get<ActiveCritSections>().isEmpty();
 }
 

--- a/clang/lib/StaticAnalyzer/Checkers/BlockInCriticalSectionChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/BlockInCriticalSectionChecker.cpp
@@ -149,26 +149,34 @@ class BlockInCriticalSectionChecker : public Checker<check::PostCall> {
 private:
   const std::array<MutexDescriptor, 8> MutexDescriptors{
       MemberMutexDescriptor(
-          CallDescription(/*QualifiedName=*/{"std", "mutex", "lock"},
+          CallDescription(/*MatchAs=*/CDM::CXXMethod,
+                          /*QualifiedName=*/{"std", "mutex", "lock"},
                           /*RequiredArgs=*/0),
-          CallDescription({"std", "mutex", "unlock"}, 0)),
-      FirstArgMutexDescriptor(CallDescription({"pthread_mutex_lock"}, 1),
-                              CallDescription({"pthread_mutex_unlock"}, 1)),
-      FirstArgMutexDescriptor(CallDescription({"mtx_lock"}, 1),
-                              CallDescription({"mtx_unlock"}, 1)),
-      FirstArgMutexDescriptor(CallDescription({"pthread_mutex_trylock"}, 1),
-                              CallDescription({"pthread_mutex_unlock"}, 1)),
-      FirstArgMutexDescriptor(CallDescription({"mtx_trylock"}, 1),
-                              CallDescription({"mtx_unlock"}, 1)),
-      FirstArgMutexDescriptor(CallDescription({"mtx_timedlock"}, 1),
-                              CallDescription({"mtx_unlock"}, 1)),
+          CallDescription(CDM::CXXMethod, {"std", "mutex", "unlock"}, 0)),
+      FirstArgMutexDescriptor(
+          CallDescription(CDM::CLibrary, {"pthread_mutex_lock"}, 1),
+          CallDescription(CDM::CLibrary, {"pthread_mutex_unlock"}, 1)),
+      FirstArgMutexDescriptor(
+          CallDescription(CDM::CLibrary, {"mtx_lock"}, 1),
+          CallDescription(CDM::CLibrary, {"mtx_unlock"}, 1)),
+      FirstArgMutexDescriptor(
+          CallDescription(CDM::CLibrary, {"pthread_mutex_trylock"}, 1),
+          CallDescription(CDM::CLibrary, {"pthread_mutex_unlock"}, 1)),
+      FirstArgMutexDescriptor(
+          CallDescription(CDM::CLibrary, {"mtx_trylock"}, 1),
+          CallDescription(CDM::CLibrary, {"mtx_unlock"}, 1)),
+      FirstArgMutexDescriptor(
+          CallDescription(CDM::CLibrary, {"mtx_timedlock"}, 1),
+          CallDescription(CDM::CLibrary, {"mtx_unlock"}, 1)),
       RAIIMutexDescriptor("lock_guard"),
       RAIIMutexDescriptor("unique_lock")};
 
   const std::array<CallDescription, 5> BlockingFunctions{
-      ArrayRef{StringRef{"sleep"}}, ArrayRef{StringRef{"getc"}},
-      ArrayRef{StringRef{"fgets"}}, ArrayRef{StringRef{"read"}},
-      ArrayRef{StringRef{"recv"}}};
+      CallDescription(CDM::CLibrary, {"sleep"}),
+      CallDescription(CDM::CLibrary, {"getc"}),
+      CallDescription(CDM::CLibrary, {"fgets"}),
+      CallDescription(CDM::CLibrary, {"read"}),
+      CallDescription(CDM::CLibrary, {"recv"})};
 
   const BugType BlockInCritSectionBugType{
       this, "Call to blocking function in critical section", "Blocking Error"};

--- a/clang/lib/StaticAnalyzer/Checkers/CStringChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/CStringChecker.cpp
@@ -189,8 +189,8 @@ public:
   };
 
   // These require a bit of special handling.
-  CallDescription StdCopy{{"std", "copy"}, 3},
-      StdCopyBackward{{"std", "copy_backward"}, 3};
+  CallDescription StdCopy{CDM::SimpleFunc, {"std", "copy"}, 3},
+      StdCopyBackward{CDM::SimpleFunc, {"std", "copy_backward"}, 3};
 
   FnCheck identifyCall(const CallEvent &Call, CheckerContext &C) const;
   void evalMemcpy(CheckerContext &C, const CallEvent &Call, CharKind CK) const;

--- a/clang/lib/StaticAnalyzer/Checkers/SmartPtrModeling.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/SmartPtrModeling.cpp
@@ -86,14 +86,14 @@ private:
   using SmartPtrMethodHandlerFn =
       void (SmartPtrModeling::*)(const CallEvent &Call, CheckerContext &) const;
   CallDescriptionMap<SmartPtrMethodHandlerFn> SmartPtrMethodHandlers{
-      {{{"reset"}}, &SmartPtrModeling::handleReset},
-      {{{"release"}}, &SmartPtrModeling::handleRelease},
-      {{{"swap"}, 1}, &SmartPtrModeling::handleSwapMethod},
-      {{{"get"}}, &SmartPtrModeling::handleGet}};
-  const CallDescription StdSwapCall{{"std", "swap"}, 2};
-  const CallDescription StdMakeUniqueCall{{"std", "make_unique"}};
-  const CallDescription StdMakeUniqueForOverwriteCall{
-      {"std", "make_unique_for_overwrite"}};
+      {{CDM::CXXMethod, {"reset"}}, &SmartPtrModeling::handleReset},
+      {{CDM::CXXMethod, {"release"}}, &SmartPtrModeling::handleRelease},
+      {{CDM::CXXMethod, {"swap"}, 1}, &SmartPtrModeling::handleSwapMethod},
+      {{CDM::CXXMethod, {"get"}}, &SmartPtrModeling::handleGet}};
+  const CallDescription StdSwapCall{CDM::SimpleFunc, {"std", "swap"}, 2};
+  const CallDescriptionSet MakeUniqueVariants{
+      {CDM::SimpleFunc, {"std", "make_unique"}},
+      {CDM::SimpleFunc, {"std", "make_unique_for_overwrite"}}};
 };
 } // end of anonymous namespace
 
@@ -296,7 +296,7 @@ bool SmartPtrModeling::evalCall(const CallEvent &Call,
     return handleSwap(State, Call.getArgSVal(0), Call.getArgSVal(1), C);
   }
 
-  if (matchesAny(Call, StdMakeUniqueCall, StdMakeUniqueForOverwriteCall)) {
+  if (MakeUniqueVariants.contains(Call)) {
     if (!ModelSmartPtrDereference)
       return false;
 

--- a/clang/lib/StaticAnalyzer/Checkers/StreamChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/StreamChecker.cpp
@@ -388,17 +388,19 @@ private:
   };
 
   CallDescriptionMap<FnDescription> FnTestDescriptions = {
-      {{{"StreamTesterChecker_make_feof_stream"}, 1},
+      {{CDM::SimpleFunc, {"StreamTesterChecker_make_feof_stream"}, 1},
        {nullptr,
         std::bind(&StreamChecker::evalSetFeofFerror, _1, _2, _3, _4, ErrorFEof,
                   false),
         0}},
-      {{{"StreamTesterChecker_make_ferror_stream"}, 1},
+      {{CDM::SimpleFunc, {"StreamTesterChecker_make_ferror_stream"}, 1},
        {nullptr,
         std::bind(&StreamChecker::evalSetFeofFerror, _1, _2, _3, _4,
                   ErrorFError, false),
         0}},
-      {{{"StreamTesterChecker_make_ferror_indeterminate_stream"}, 1},
+      {{CDM::SimpleFunc,
+        {"StreamTesterChecker_make_ferror_indeterminate_stream"},
+        1},
        {nullptr,
         std::bind(&StreamChecker::evalSetFeofFerror, _1, _2, _3, _4,
                   ErrorFError, true),


### PR DESCRIPTION
This commit explicitly specifies the matching mode (C library function, any non-method function, or C++ method) for the `CallDescription`s constructed in various checkers.

Some code was simplified to use `CallDescriptionSet`s instead of individual `CallDescription`s.

This change won't cause major functional changes, but isn't NFC because it ensures that e.g. call descriptions for a non-method function won't accidentally match a method that has the same name.

Separate commits have already performed this change in other checkers:
- easy cases: e2f1cbae45f81f3cd9a4d3c2bcf69a094eb060fa
- MallocChecker: d6d84b5d1448e4f2e24b467a0abcf42fe9d543e9
- iterator checkers: 06eedffe0d2782922e63cc25cb927f4acdaf7b30
- InvalidPtr checker: 024281d4d26344f9613b9115ea1fcbdbdba23235

... and follow-up commits will handle the remaining checkers.

My goal is to ensure that the call description mode is always explicitly specified and eliminate (or strongly restrict) the vague "may be either a method or a simple function" mode that's the current default.