### PR TITLE
[CMake] Add INTERFACE_INCLUDE_DIRECTORIES property to add_llvm_library macro

### DIFF
--- a/llvm/cmake/modules/AddLLVM.cmake
+++ b/llvm/cmake/modules/AddLLVM.cmake
@@ -911,7 +911,8 @@ macro(add_llvm_library name)
               ${export_to_llvmexports}
               LIBRARY DESTINATION lib${LLVM_LIBDIR_SUFFIX} COMPONENT ${name}
               ARCHIVE DESTINATION lib${LLVM_LIBDIR_SUFFIX} COMPONENT ${name}
-              RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}" COMPONENT ${name})
+              RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}" COMPONENT ${name}
+              INCLUDES DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
 
       if (NOT LLVM_ENABLE_IDE)
         add_llvm_install_targets(install-${name}


### PR DESCRIPTION
As mentioned in issue #53568, the current directions for using LLVM libraries in other projects, requiring
```
include_directories(${LLVM_INCLUDE_DIRS})
```
shouldn't be necessary. This adds `INCLUDES DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"` to the `add_llvm_library` macro in `AddLLVM.cmake`.

We may also want to add this to `add_clang_library` and other places, but I'm not familiar with the full details of LLVM's cmake setup either, so I'd appreciate feedback on this as a draft.