### PR TITLE
[Clang][Sema] Fix template name lookup for operator=

### DIFF
--- a/clang/test/CXX/temp/temp.res/temp.dep/temp.dep.type/p4.cpp
+++ b/clang/test/CXX/temp/temp.res/temp.dep/temp.dep.type/p4.cpp
@@ -453,6 +453,24 @@ namespace N3 {
       this->A::operator=(*this);
     }
   };
+
+  template<typename T>
+  struct C {
+    template<typename U>
+    void operator=(int);
+
+    void not_instantiated() {
+      operator=<int>(0);
+      C::operator=<int>(0);
+      this->operator=<int>(0);
+      this->C::operator=<int>(0);
+
+      operator=(*this);
+      C::operator=(*this);
+      this->operator=(*this);
+      this->C::operator=(*this);
+    }
+  };
 } // namespace N3
 
 namespace N4 {


### PR DESCRIPTION
This fixes a bug in #90152 where `operator=` was never looked up in the current instantiation, resulting in `<` never being interpreted as the start of a template argument list.

Since function templates are not copy/move assignment operators, the fix is accomplished by allowing lookup in the current instantiation for `operator=` when looking up a template name. 

Still needs tests (which are currently in progress). Not sure whether a release note is needed as this fixes something introduced in this release.