### PR TITLE
[lldb][NFCI] Remove unused DWARF value-to-name functions

### DIFF
--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFDefines.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFDefines.cpp
@@ -23,61 +23,11 @@ llvm::StringRef DW_TAG_value_to_name(dw_tag_t tag) {
   return s_unknown_tag_name;
 }
 
-const char *DW_AT_value_to_name(uint32_t val) {
-  static char invalid[100];
-  llvm::StringRef llvmstr = llvm::dwarf::AttributeString(val);
-  if (llvmstr.empty()) {
-    snprintf(invalid, sizeof(invalid), "Unknown DW_AT constant: 0x%x", val);
-    return invalid;
-  }
-  return llvmstr.data();
-}
-
-const char *DW_FORM_value_to_name(uint32_t val) {
-  static char invalid[100];
-  llvm::StringRef llvmstr = llvm::dwarf::FormEncodingString(val);
-  if (llvmstr.empty()) {
-    snprintf(invalid, sizeof(invalid), "Unknown DW_FORM constant: 0x%x", val);
-    return invalid;
-  }
-  return llvmstr.data();
-}
-
 const char *DW_OP_value_to_name(uint32_t val) {
   static char invalid[100];
   llvm::StringRef llvmstr = llvm::dwarf::OperationEncodingString(val);
   if (llvmstr.empty()) {
     snprintf(invalid, sizeof(invalid), "Unknown DW_OP constant: 0x%x", val);
-    return invalid;
-  }
-  return llvmstr.data();
-}
-
-const char *DW_ATE_value_to_name(uint32_t val) {
-  static char invalid[100];
-  llvm::StringRef llvmstr = llvm::dwarf::AttributeEncodingString(val);
-  if (llvmstr.empty()) {
-    snprintf(invalid, sizeof(invalid), "Unknown DW_ATE constant: 0x%x", val);
-    return invalid;
-  }
-  return llvmstr.data();
-}
-
-const char *DW_LANG_value_to_name(uint32_t val) {
-  static char invalid[100];
-  llvm::StringRef llvmstr = llvm::dwarf::LanguageString(val);
-  if (llvmstr.empty()) {
-    snprintf(invalid, sizeof(invalid), "Unknown DW_LANG constant: 0x%x", val);
-    return invalid;
-  }
-  return llvmstr.data();
-}
-
-const char *DW_LNS_value_to_name(uint32_t val) {
-  static char invalid[100];
-  llvm::StringRef llvmstr = llvm::dwarf::LNStandardString(val);
-  if (llvmstr.empty()) {
-    snprintf(invalid, sizeof(invalid), "Unknown DW_LNS constant: 0x%x", val);
     return invalid;
   }
   return llvmstr.data();

--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFDefines.h
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFDefines.h
@@ -15,21 +15,9 @@
 namespace lldb_private::plugin {
 namespace dwarf {
 
-typedef uint32_t DRC_class; // Holds DRC_* class bitfields
-
 llvm::StringRef DW_TAG_value_to_name(dw_tag_t tag);
 
-const char *DW_AT_value_to_name(uint32_t val);
-
-const char *DW_FORM_value_to_name(uint32_t val);
-
 const char *DW_OP_value_to_name(uint32_t val);
-
-const char *DW_ATE_value_to_name(uint32_t val);
-
-const char *DW_LANG_value_to_name(uint32_t val);
-
-const char *DW_LNS_value_to_name(uint32_t val);
 
 } // namespace dwarf
 } // namespace lldb_private::plugin


### PR DESCRIPTION
I was cleaning up this portion of the code and realized these are completely unused.