### PR TITLE
Revert "[AIX][CMake] Use top-level tools in llvm_ExternalProject_Add"

### DIFF
--- a/llvm/cmake/modules/LLVMExternalProjectUtils.cmake
+++ b/llvm/cmake/modules/LLVMExternalProjectUtils.cmake
@@ -261,7 +261,7 @@ function(llvm_ExternalProject_Add name source_dir)
     set(sysroot_arg -DCMAKE_SYSROOT=${CMAKE_SYSROOT})
   endif()
 
-  if(CMAKE_CROSSCOMPILING OR _cmake_system_name STREQUAL AIX)
+  if(CMAKE_CROSSCOMPILING)
     set(compiler_args -DCMAKE_ASM_COMPILER=${CMAKE_ASM_COMPILER}
                       -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
                       -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
@@ -273,8 +273,6 @@ function(llvm_ExternalProject_Add name source_dir)
                       -DCMAKE_OBJDUMP=${CMAKE_OBJDUMP}
                       -DCMAKE_STRIP=${CMAKE_STRIP}
                       -DCMAKE_READELF=${CMAKE_READELF})
-  endif()
-  if(CMAKE_CROSSCOMPILING)
     set(llvm_config_path ${LLVM_CONFIG_PATH})
 
     if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")


### PR DESCRIPTION
This reverts commit 11066449d49e20f18f46757df07455c6abcedcf1.

As noted in the original patch, this was designed to reverted once https://reviews.llvm.org/D142479 and https://reviews.llvm.org/D142660 landed, which has long since happened.