### PR TITLE
[clang][test] Fix instantiation-depth-default.cpp under ubsan config on Windows

### DIFF
--- a/clang/test/SemaTemplate/instantiation-depth-default.cpp
+++ b/clang/test/SemaTemplate/instantiation-depth-default.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -fsyntax-only -verify -ftemplate-backtrace-limit=2 %s
+// RUN: %clang_cc1 -fsyntax-only -verify -ftemplate-backtrace-limit=2 %if {{ubsan}} %{ -Wno-stack-exhausted %} %s
 //
 // FIXME: Disable this test when Clang was built with ASan, because ASan
 // increases our per-frame stack usage enough that this test no longer fits


### PR DESCRIPTION
Clang test `instantiation-depth-default.cpp` fails on Windows when built with `ubsan` due to extra warnings printed by the compiler:
```console
File instantiation-depth-default.cpp Line 11: stack nearly exhausted; compilation time may suffer, and crashes due to stack overflow are likely
```

Originally in https://github.com/llvm/llvm-project/pull/75254 this test was enabled for `asan` as well but later started to cause failures in Linux ASAN buildbots. I have excluded `asan` from this change.