### PR TITLE
Reduce llvm-gsymutil memory usage

### DIFF
--- a/llvm/include/llvm/DebugInfo/DWARF/DWARFUnit.h
+++ b/llvm/include/llvm/DebugInfo/DWARF/DWARFUnit.h
@@ -258,6 +258,7 @@ class DWARFUnit {
 
   std::shared_ptr<DWARFUnit> DWO;
 
+  mutable llvm::sys::RWMutex CUDieFreeMutex;
   mutable llvm::sys::RWMutex CUDieArrayMutex;
   mutable llvm::sys::RWMutex AllDieArrayMutex;
 

--- a/llvm/include/llvm/DebugInfo/DWARF/DWARFUnit.h
+++ b/llvm/include/llvm/DebugInfo/DWARF/DWARFUnit.h
@@ -258,8 +258,8 @@ class DWARFUnit {
 
   std::shared_ptr<DWARFUnit> DWO;
 
-  mutable llvm::sys::RWMutex m_cu_die_array_mutex;
-  mutable llvm::sys::RWMutex m_all_die_array_mutex;
+  mutable llvm::sys::RWMutex CUDieArrayMutex;
+  mutable llvm::sys::RWMutex AllDieArrayMutex;
 
 protected:
   friend dwarf_linker::parallel::CompileUnit;

--- a/llvm/include/llvm/DebugInfo/DWARF/DWARFUnit.h
+++ b/llvm/include/llvm/DebugInfo/DWARF/DWARFUnit.h
@@ -585,8 +585,16 @@ private:
   /// hasn't already been done
   void extractDIEsIfNeeded(bool CUDieOnly);
 
+  /// extracCUDieIfNeeded - Parse CU DIE if it hasn't already been done.
+  /// Only to be used from extractDIEsIfNeeded, which holds the correct locks.
+  bool extractCUDieIfNeeded(bool CUDieOnly, bool &HasCUDie);
+
+  /// extractAllDIEsIfNeeded - Parses non-CU DIE's for a given CU if needed.
+  /// Only to be used from extractDIEsIfNeeded, which holds the correct locks.
+  Error extractAllDIEsIfNeeded(bool HasCUDie);
+
   /// extractAllDIEsHelper - helper to be invoked *only* from inside
-  /// tryExtractDIEsIfNeeded, which holds correct locks.
+  /// tryExtractDIEsIfNeeded, which holds the correct locks.
   Error extractAllDIEsHelper();
 
   /// extractDIEsToVector - Appends all parsed DIEs to a vector.

--- a/llvm/include/llvm/DebugInfo/DWARF/DWARFUnit.h
+++ b/llvm/include/llvm/DebugInfo/DWARF/DWARFUnit.h
@@ -585,6 +585,10 @@ private:
   /// hasn't already been done
   void extractDIEsIfNeeded(bool CUDieOnly);
 
+  /// extractAllDIEsHelper - helper to be invoked *only* from inside
+  /// tryExtractDIEsIfNeeded, which holds correct locks.
+  Error extractAllDIEsHelper();
+
   /// extractDIEsToVector - Appends all parsed DIEs to a vector.
   void extractDIEsToVector(bool AppendCUDie, bool AppendNonCUDIEs,
                            std::vector<DWARFDebugInfoEntry> &DIEs) const;

--- a/llvm/include/llvm/DebugInfo/DWARF/DWARFUnit.h
+++ b/llvm/include/llvm/DebugInfo/DWARF/DWARFUnit.h
@@ -566,6 +566,8 @@ public:
 
   Error tryExtractDIEsIfNeeded(bool CUDieOnly);
 
+  void freeDIEs();
+
 private:
   /// Size in bytes of the .debug_info data associated with this compile unit.
   size_t getDebugInfoSize() const {

--- a/llvm/include/llvm/DebugInfo/DWARF/DWARFUnit.h
+++ b/llvm/include/llvm/DebugInfo/DWARF/DWARFUnit.h
@@ -258,9 +258,9 @@ class DWARFUnit {
 
   std::shared_ptr<DWARFUnit> DWO;
 
-  mutable llvm::sys::RWMutex CUDieFreeMutex;
-  mutable llvm::sys::RWMutex CUDieArrayMutex;
-  mutable llvm::sys::RWMutex AllDieArrayMutex;
+  mutable llvm::sys::RWMutex FreeDIEsMutex;
+  mutable llvm::sys::RWMutex ExtractCUDieMutex;
+  mutable llvm::sys::RWMutex ExtractNonCUDIEsMutex;
 
 protected:
   friend dwarf_linker::parallel::CompileUnit;
@@ -589,13 +589,13 @@ private:
   /// Only to be used from extractDIEsIfNeeded, which holds the correct locks.
   bool extractCUDieIfNeeded(bool CUDieOnly, bool &HasCUDie);
 
-  /// extractAllDIEsIfNeeded - Parses non-CU DIE's for a given CU if needed.
+  /// extractNonCUDIEsIfNeeded - Parses non-CU DIE's for a given CU if needed.
   /// Only to be used from extractDIEsIfNeeded, which holds the correct locks.
-  Error extractAllDIEsIfNeeded(bool HasCUDie);
+  Error extractNonCUDIEsIfNeeded(bool HasCUDie);
 
-  /// extractAllDIEsHelper - helper to be invoked *only* from inside
+  /// extractNonCUDIEsHelper - helper to be invoked *only* from inside
   /// tryExtractDIEsIfNeeded, which holds the correct locks.
-  Error extractAllDIEsHelper();
+  Error extractNonCUDIEsHelper();
 
   /// extractDIEsToVector - Appends all parsed DIEs to a vector.
   void extractDIEsToVector(bool AppendCUDie, bool AppendNonCUDIEs,

--- a/llvm/lib/DebugInfo/DWARF/DWARFUnit.cpp
+++ b/llvm/lib/DebugInfo/DWARF/DWARFUnit.cpp
@@ -495,26 +495,43 @@ void DWARFUnit::extractDIEsIfNeeded(bool CUDieOnly) {
     Context.getRecoverableErrorHandler()(std::move(e));
 }
 
-void DWARFUnit::freeDIEs() {
-  if (DieArray.capacity())
-    std::vector<DWARFDebugInfoEntry>().swap(DieArray);
-}
-
 Error DWARFUnit::tryExtractDIEsIfNeeded(bool CUDieOnly) {
-  if ((CUDieOnly && !DieArray.empty()) ||
-      DieArray.size() > 1)
-    return Error::success(); // Already parsed.
+  // read-lock:
+  {
+    llvm::sys::ScopedReader Lock(m_cu_die_array_mutex);
+    if ((CUDieOnly && !DieArray.empty()) ||
+        DieArray.size() > 1)
+      return Error::success(); // Already parsed.
+  }
+  bool HasCUDie = false;
+  // write-lock:
+  {
+    llvm::sys::ScopedWriter Lock(m_cu_die_array_mutex);
+    if ((CUDieOnly && !DieArray.empty()) ||
+        DieArray.size() > 1)
+      return Error::success(); // Already parsed.
+    HasCUDie = !DieArray.empty();
+    extractDIEsToVector(!HasCUDie, !CUDieOnly, DieArray);
+  }
 
-  bool HasCUDie = !DieArray.empty();
-  extractDIEsToVector(!HasCUDie, !CUDieOnly, DieArray);
-
+  // read-lock:
+{
+  llvm::sys::ScopedReader Lock(m_all_die_array_mutex);
   if (DieArray.empty())
     return Error::success();
 
   // If CU DIE was just parsed, copy several attribute values from it.
   if (HasCUDie)
     return Error::success();
+}
+  // write-lock:
+llvm::sys::ScopedWriter Lock(m_all_die_array_mutex);
+  if (DieArray.empty())
+    return Error::success();
 
+  // If CU DIE was just parsed, copy several attribute values from it.
+  if (HasCUDie)
+    return Error::success();
   DWARFDie UnitDie(this, &DieArray[0]);
   if (std::optional<uint64_t> DWOId =
           toUnsigned(UnitDie.find(DW_AT_GNU_dwo_id)))
@@ -663,6 +680,8 @@ void DWARFUnit::clearDIEs(bool KeepCUDie) {
   // It depends on the implementation whether the request is fulfilled.
   // Create a new vector with a small capacity and assign it to the DieArray to
   // have previous contents freed.
+  llvm::sys::ScopedWriter CULock(m_cu_die_array_mutex);
+  llvm::sys::ScopedWriter AllLock(m_all_die_array_mutex);
   DieArray = (KeepCUDie && !DieArray.empty())
                  ? std::vector<DWARFDebugInfoEntry>({DieArray[0]})
                  : std::vector<DWARFDebugInfoEntry>();

--- a/llvm/lib/DebugInfo/DWARF/DWARFUnit.cpp
+++ b/llvm/lib/DebugInfo/DWARF/DWARFUnit.cpp
@@ -496,6 +496,7 @@ void DWARFUnit::extractDIEsIfNeeded(bool CUDieOnly) {
 }
 
 Error DWARFUnit::tryExtractDIEsIfNeeded(bool CUDieOnly) {
+  llvm::sys::ScopedReader FreeLock(CUDieFreeMutex);
   {
     llvm::sys::ScopedReader Lock(CUDieArrayMutex);
     if ((CUDieOnly && !DieArray.empty()) || DieArray.size() > 1)
@@ -673,6 +674,7 @@ void DWARFUnit::clearDIEs(bool KeepCUDie) {
   // It depends on the implementation whether the request is fulfilled.
   // Create a new vector with a small capacity and assign it to the DieArray to
   // have previous contents freed.
+  llvm::sys::ScopedWriter FreeLock(CUDieFreeMutex);
   llvm::sys::ScopedWriter CULock(CUDieArrayMutex);
   llvm::sys::ScopedWriter AllLock(AllDieArrayMutex);
   DieArray = (KeepCUDie && !DieArray.empty())

--- a/llvm/lib/DebugInfo/DWARF/DWARFUnit.cpp
+++ b/llvm/lib/DebugInfo/DWARF/DWARFUnit.cpp
@@ -712,8 +712,6 @@ void DWARFUnit::clearDIEs(bool KeepCUDie) {
   // Create a new vector with a small capacity and assign it to the DieArray to
   // have previous contents freed.
   llvm::sys::ScopedWriter FreeLock(CUDieFreeMutex);
-  llvm::sys::ScopedWriter CULock(CUDieArrayMutex);
-  llvm::sys::ScopedWriter AllLock(AllDieArrayMutex);
   DieArray = (KeepCUDie && !DieArray.empty())
                  ? std::vector<DWARFDebugInfoEntry>({DieArray[0]})
                  : std::vector<DWARFDebugInfoEntry>();

--- a/llvm/lib/DebugInfo/DWARF/DWARFUnit.cpp
+++ b/llvm/lib/DebugInfo/DWARF/DWARFUnit.cpp
@@ -495,6 +495,11 @@ void DWARFUnit::extractDIEsIfNeeded(bool CUDieOnly) {
     Context.getRecoverableErrorHandler()(std::move(e));
 }
 
+void DWARFUnit::freeDIEs() {
+  if (DieArray.capacity())
+    std::vector<DWARFDebugInfoEntry>().swap(DieArray);
+}
+
 Error DWARFUnit::tryExtractDIEsIfNeeded(bool CUDieOnly) {
   if ((CUDieOnly && !DieArray.empty()) ||
       DieArray.size() > 1)

--- a/llvm/lib/DebugInfo/DWARF/DWARFUnit.cpp
+++ b/llvm/lib/DebugInfo/DWARF/DWARFUnit.cpp
@@ -543,7 +543,13 @@ Error DWARFUnit::tryExtractDIEsIfNeeded(bool CUDieOnly) {
   };
 
   // Lambda to extract all the DIEs using the helper function
-  auto ExtractAllDies = [this, &Result]() { Result = extractAllDIEsHelper(); };
+  auto ExtractAllDies = [this, &Result]() {
+    if (Error E = extractAllDIEsHelper()) {
+      // Consume the success placeholder and save the actual error
+      consumeError(std::move(Result));
+      Result = std::move(E);
+    }
+  };
 
   // Safely check if *all* the DIEs have been parsed already. If not, then parse
   // them.

--- a/llvm/lib/DebugInfo/GSYM/DwarfTransformer.cpp
+++ b/llvm/lib/DebugInfo/GSYM/DwarfTransformer.cpp
@@ -625,8 +625,9 @@ Error DwarfTransformer::convert(uint32_t NumThreads, OutputAggregator &Out) {
             StrStream.flush();
             Out << storage;
           }
-          // Release the line table, once we're done.
+          // Release the line table and DIEs once we're done.
           DICtx.clearLineTableForUnit(CU.get());
+          CU->freeDIEs();
 
           Out.Merge(ThreadOut);
         });
@@ -634,6 +635,8 @@ Error DwarfTransformer::convert(uint32_t NumThreads, OutputAggregator &Out) {
     }
     pool.wait();
   }
+  for (const auto &CU : DICtx.compile_units())
+    CU->freeDIEs();
   size_t FunctionsAddedCount = Gsym.getNumFunctionInfos() - NumBefore;
   Out << "Loaded " << FunctionsAddedCount << " functions from DWARF.\n";
   return Error::success();

--- a/llvm/lib/DebugInfo/GSYM/DwarfTransformer.cpp
+++ b/llvm/lib/DebugInfo/GSYM/DwarfTransformer.cpp
@@ -591,7 +591,7 @@ Error DwarfTransformer::convert(uint32_t NumThreads, OutputAggregator &Out) {
       DICtx.clearLineTableForUnit(CU.get());
       // Free any DIEs that were allocated by the DWARF parser.
       // If/when they're needed by other CU's, they'll be recreated.
-      CU->clearDIEs(false);
+      CU->clearDIEs(/*KeepCUDie=*/false);
     }
   } else {
     // LLVM Dwarf parser is not thread-safe and we need to parse all DWARF up
@@ -626,7 +626,7 @@ Error DwarfTransformer::convert(uint32_t NumThreads, OutputAggregator &Out) {
           DICtx.clearLineTableForUnit(CU.get());
           // Free any DIEs that were allocated by the DWARF parser.
           // If/when they're needed by other CU's, they'll be recreated.
-          CU->clearDIEs(false);
+          CU->clearDIEs(/*KeepCUDie=*/false);
           // Print ThreadLogStorage lines into an actual stream under a lock
           std::lock_guard<std::mutex> guard(LogMutex);
           if (Out.GetOS()) {
@@ -641,7 +641,7 @@ Error DwarfTransformer::convert(uint32_t NumThreads, OutputAggregator &Out) {
   }
   // Now get rid of all the DIEs that may have been recreated
   for (const auto &CU : DICtx.compile_units())
-    CU->clearDIEs(false);
+    CU->clearDIEs(/*KeepCUDie=*/false);
   size_t FunctionsAddedCount = Gsym.getNumFunctionInfos() - NumBefore;
   Out << "Loaded " << FunctionsAddedCount << " functions from DWARF.\n";
   return Error::success();

--- a/llvm/lib/DebugInfo/GSYM/DwarfTransformer.cpp
+++ b/llvm/lib/DebugInfo/GSYM/DwarfTransformer.cpp
@@ -589,6 +589,9 @@ Error DwarfTransformer::convert(uint32_t NumThreads, OutputAggregator &Out) {
       handleDie(Out, CUI, Die);
       // Release the line table, once we're done.
       DICtx.clearLineTableForUnit(CU.get());
+      // Free any DIEs that were allocated by the DWARF parser.
+      // If/when they're needed by other CU's, they'll be recreated.
+      CU->clearDIEs(false);
     }
   } else {
     // LLVM Dwarf parser is not thread-safe and we need to parse all DWARF up
@@ -631,7 +634,6 @@ Error DwarfTransformer::convert(uint32_t NumThreads, OutputAggregator &Out) {
             Out << storage;
           }
           Out.Merge(ThreadOut);
-
         });
       }
     }


### PR DESCRIPTION
llvm-gsymutil eats a lot of RAM. On some large binaries, it causes OOM's on smaller hardware, consuming well over 64GB of RAM. This change frees line tables once we're done with them, and frees DWARFUnits's DIE's when we finish processing each DU, though they may get reconstituted if there are references from other DU's during processing. Once the conversion is complete, all DIE's are freed. The reduction in peak memory usage from these changes showed between 7-12% in my tests.

The double-checked locking around the creation & freeing of the data structures was tested on a 166 core system. I validated that it trivially malfunctioned without the locks (and with stupid reordering of the locks) and worked reliably with them.