### PR TITLE
[Bounds-Safety] Reserve slot in SanitizerHandler enum for Bounds-Safety

### DIFF
--- a/clang/lib/CodeGen/CodeGenFunction.h
+++ b/clang/lib/CodeGen/CodeGenFunction.h
@@ -137,7 +137,8 @@ enum TypeEvaluationKind {
   SANITIZER_CHECK(SubOverflow, sub_overflow, 0)                                \
   SANITIZER_CHECK(TypeMismatch, type_mismatch, 1)                              \
   SANITIZER_CHECK(AlignmentAssumption, alignment_assumption, 0)                \
-  SANITIZER_CHECK(VLABoundNotPositive, vla_bound_not_positive, 0)
+  SANITIZER_CHECK(VLABoundNotPositive, vla_bound_not_positive, 0)              \
+  SANITIZER_CHECK(BoundsSafety, bounds_safety, 0)
 
 enum SanitizerHandler {
 #define SANITIZER_CHECK(Enum, Name, Version) Enum,


### PR DESCRIPTION
Due to how `CodeGenFunction::EmitTrapCheck` is implemented `SanitizerHandler` with numeric value 0x19 needs to be reserved because `-fbounds-safety` generates trap instructions with that value embedded in the trap instructions for x86_64 and arm64 just like for UBSan traps.

** x86_64 **

```
ud1l   0x19(%eax), %eax
```

** arm64 **

```
brk    #0x5519
```

To avoid upstream Clang and AppleClang diverging their ABIs for `-fbounds-safety` the slot is being reserved in this patch.

`SanitizerHandler::BoundsSafety` currently has no uses in the code but uses will be introduced when the CodeGen side of `-fbounds-safety`'s implementation is upstreamed.

rdar://126884014