### PR TITLE
[libc] Fix assert dependency on macro header

### DIFF
--- a/libc/include/CMakeLists.txt
+++ b/libc/include/CMakeLists.txt
@@ -142,6 +142,7 @@ add_gen_header(
   GEN_HDR assert.h
   DEPENDS
     .llvm_libc_common_h
+    .llvm-libc-macros.assert_macros
 )
 
 add_gen_header(


### PR DESCRIPTION
Summary:
This file was missing a dependency so it wasn't being installed.
