### PR TITLE
[clang] Enable FPContract with optnone

### DIFF
--- a/clang/include/clang/Basic/LangOptions.h
+++ b/clang/include/clang/Basic/LangOptions.h
@@ -968,9 +968,7 @@ public:
       setAllowFPContractAcrossStatement();
   }
 
-  void setDisallowOptimizations() {
-    setFPPreciseEnabled(true);
-  }
+  void setDisallowOptimizations() { setFPPreciseEnabled(true); }
 
   storage_type getAsOpaqueInt() const {
     return (static_cast<storage_type>(Options.getAsOpaqueInt())

--- a/clang/include/clang/Basic/LangOptions.h
+++ b/clang/include/clang/Basic/LangOptions.h
@@ -970,7 +970,6 @@ public:
 
   void setDisallowOptimizations() {
     setFPPreciseEnabled(true);
-    setDisallowFPContract();
   }
 
   storage_type getAsOpaqueInt() const {

--- a/clang/test/AST/ast-dump-fpfeatures.cpp
+++ b/clang/test/AST/ast-dump-fpfeatures.cpp
@@ -198,7 +198,7 @@ float func_19(float x, float y) {
 // CHECK-LABEL: FunctionDecl {{.*}} func_19 'float (float, float)'
 // CHECK:         CompoundStmt {{.*}} MathErrno=1
 // CHECK:           ReturnStmt
-// CHECK:             BinaryOperator {{.*}} 'float' '+' ConstRoundingMode=downward MathErrno=1
+// CHECK:             BinaryOperator {{.*}} 'float' '+' FPContractMode=1 ConstRoundingMode=downward MathErrno=1
 
 __attribute__((optnone))
 float func_20(float x, float y) try {
@@ -210,7 +210,7 @@ float func_20(float x, float y) try {
 // CHECK-LABEL: FunctionDecl {{.*}} func_20 'float (float, float)'
 // CHECK:         CompoundStmt {{.*}} ConstRoundingMode=downward MathErrno=1
 // CHECK:           ReturnStmt
-// CHECK:             BinaryOperator {{.*}} 'float' '+' ConstRoundingMode=downward MathErrno=1
+// CHECK:             BinaryOperator {{.*}} 'float' '+' FPContractMode=1 ConstRoundingMode=downward MathErrno=1
 
 struct C21 {
   C21(float x, float y);
@@ -221,15 +221,15 @@ struct C21 {
 };
 
 // CHECK-LABEL: CXXMethodDecl {{.*}} a_method 'float (float, float)'
-// CHECK:         CompoundStmt {{.*}} ConstRoundingMode=downward MathErrno=1
+// CHECK:         CompoundStmt {{.*}} FPContractMode=1 ConstRoundingMode=downward MathErrno=1
 // CHECK:           ReturnStmt
-// CHECK:             BinaryOperator {{.*}} 'float' '*' ConstRoundingMode=downward MathErrno=1
+// CHECK:             BinaryOperator {{.*}} 'float' '*' FPContractMode=1 ConstRoundingMode=downward MathErrno=1
 
 __attribute__((optnone)) C21::C21(float x, float y) : member(x + y) {}
 
 // CHECK-LABEL: CXXConstructorDecl {{.*}} C21 'void (float, float)'
 // CHECK:         CXXCtorInitializer {{.*}} 'member' 'float'
-// CHECK:           BinaryOperator {{.*}} 'float' '+' ConstRoundingMode=downward MathErrno=1
+// CHECK:           BinaryOperator {{.*}} 'float' '+' FPContractMode=1 ConstRoundingMode=downward MathErrno=1
 
 template <typename T>
 __attribute__((optnone)) T func_22(T x, T y) {
@@ -238,13 +238,13 @@ __attribute__((optnone)) T func_22(T x, T y) {
 
 // CHECK-LABEL: FunctionTemplateDecl {{.*}} func_22
 // CHECK:         FunctionDecl {{.*}} func_22 'T (T, T)'
-// CHECK:           CompoundStmt {{.*}} ConstRoundingMode=downward MathErrno=1
+// CHECK:           CompoundStmt {{.*}} FPContractMode=1 ConstRoundingMode=downward MathErrno=1
 // CHECK:             ReturnStmt
-// CHECK:               BinaryOperator {{.*}} '+' ConstRoundingMode=downward MathErrno=1
+// CHECK:               BinaryOperator {{.*}} '+' FPContractMode=1 ConstRoundingMode=downward MathErrno=1
 // CHECK:         FunctionDecl {{.*}} func_22 'float (float, float)'
-// CHECK:           CompoundStmt {{.*}} ConstRoundingMode=downward MathErrno=1
+// CHECK:           CompoundStmt {{.*}} FPContractMode=1 ConstRoundingMode=downward MathErrno=1
 // CHECK:             ReturnStmt
-// CHECK:               BinaryOperator {{.*}} 'float' '+' ConstRoundingMode=downward MathErrno=1
+// CHECK:               BinaryOperator {{.*}} 'float' '+' FPContractMode=1 ConstRoundingMode=downward MathErrno=1
 
 float func_23(float x, float y) {
   return func_22(x, y);

--- a/clang/test/AST/ast-dump-fpfeatures.m
+++ b/clang/test/AST/ast-dump-fpfeatures.m
@@ -24,6 +24,6 @@
 
 // CHECK-LABEL: ObjCImplementationDecl {{.*}} Adder
 // CHECK:         ObjCMethodDecl {{.*}} - sum:with: 'float'
-// CHECK:           CompoundStmt {{.*}} MathErrno=1
+// CHECK:           CompoundStmt {{.*}} FPContractMode=1 MathErrno=1
 // CHECK-NEXT:        ReturnStmt
-// CHECK-NEXT:          BinaryOperator {{.*}} 'float' '+' MathErrno=1
+// CHECK-NEXT:          BinaryOperator {{.*}} 'float' '+' FPContractMode=1 MathErrno=1

--- a/clang/test/AST/ast-dump-late-parsing.cpp
+++ b/clang/test/AST/ast-dump-late-parsing.cpp
@@ -11,13 +11,13 @@ __attribute__((optnone)) T func_22(T x, T y) {
 
 // CHECK-LABEL: FunctionTemplateDecl {{.*}} func_22
 // CHECK:         FunctionDecl {{.*}} func_22 'T (T, T)'
-// CHECK:           CompoundStmt {{.*}} ConstRoundingMode=downward MathErrno=1
+// CHECK:           CompoundStmt {{.*}} FPContractMode=1 ConstRoundingMode=downward MathErrno=1
 // CHECK:             ReturnStmt
-// CHECK:               BinaryOperator {{.*}} '+' ConstRoundingMode=downward MathErrno=1
+// CHECK:               BinaryOperator {{.*}} '+' FPContractMode=1 ConstRoundingMode=downward MathErrno=1
 // CHECK:         FunctionDecl {{.*}} func_22 'float (float, float)'
-// CHECK:           CompoundStmt {{.*}} ConstRoundingMode=downward MathErrno=1
+// CHECK:           CompoundStmt {{.*}} FPContractMode=1 ConstRoundingMode=downward MathErrno=1
 // CHECK:             ReturnStmt
-// CHECK:               BinaryOperator {{.*}} 'float' '+' ConstRoundingMode=downward MathErrno=1
+// CHECK:               BinaryOperator {{.*}} 'float' '+' FPContractMode=1 ConstRoundingMode=downward MathErrno=1
 
 float func_23(float x, float y) {
   return func_22(x, y);


### PR DESCRIPTION
Previously treatment of the attribute `optnone` was modified in https://github.com/llvm/llvm-project/pull/85605 ([clang] Set correct FPOptions if attribute 'optnone' presents). As a side effect FPContract was disabled for optnone. It created unneeded divergence with the behavior of -O0, which enables this optimization.

In the discussion
https://github.com/llvm/llvm-project/pull/85605#issuecomment-2089350379 it was pointed out that FP contraction should be enabled even if all optimizations are turned off, otherwise results of calculations would be different. This change enables FPContract at optnone.