### PR TITLE
[NFC] Prefer `str.resize(len)` over `str.substr(0, len)`

### DIFF
--- a/llvm/include/llvm/Analysis/DOTGraphTraitsPass.h
+++ b/llvm/include/llvm/Analysis/DOTGraphTraitsPass.h
@@ -87,13 +87,12 @@ private:
 };
 
 static inline void shortenFileName(std::string &FN, unsigned char len = 250) {
-
-  FN = FN.substr(0, len);
-
+  if (FN.length() > len)
+    FN.resize(len);
   auto strLen = FN.length();
   while (strLen > 0) {
-    if (auto it = nameObj.find(FN); it != nameObj.end()) {
-      FN = FN.substr(0, --len);
+    if (nameObj.find(FN) != nameObj.end()) {
+      FN.resize(--len);
     } else {
       nameObj.insert(FN);
       break;


### PR DESCRIPTION
Fixes #90323.