### PR TITLE
[alpha.webkit.UncountedLocalVarsChecker] Ignore local vars of JSC::VM& type

### DIFF
--- a/clang/lib/StaticAnalyzer/Checkers/WebKit/ASTUtils.h
+++ b/clang/lib/StaticAnalyzer/Checkers/WebKit/ASTUtils.h
@@ -67,12 +67,13 @@ template <typename T> std::string safeGetName(const T *ASTNode) {
   if (!ND)
     return "";
 
-  // In case F is for example "operator|" the getName() method below would
-  // assert.
-  if (!ND->getDeclName().isIdentifier())
-    return "";
+  if (const auto *Identifier = ND->getIdentifier())
+    return Identifier->getName().str();
 
-  return ND->getName().str();
+  std::string Name;
+  llvm::raw_string_ostream OS(Name);
+  ND->printName(OS);
+  return OS.str().empty() ? "" : OS.str();
 }
 
 } // namespace clang


### PR DESCRIPTION
This patch also updates safeGetName to get names from operators without hitting an assertion