### PR TITLE
Revert "llvm/lib/CodeGen/TargetSchedule.cpp:132:12: warning: Assert statement modifies 'NIter'"

### DIFF
--- a/llvm/lib/CodeGen/TargetSchedule.cpp
+++ b/llvm/lib/CodeGen/TargetSchedule.cpp
@@ -129,8 +129,7 @@ resolveSchedClass(const MachineInstr *MI) const {
   unsigned NIter = 0;
 #endif
   while (SCDesc->isVariant()) {
-    ++NIter;
-    assert(NIter < 6 && "Variants are nested deeper than the magic number");
+    assert(++NIter < 6 && "Variants are nested deeper than the magic number");
 
     SchedClass = STI->resolveSchedClass(SchedClass, MI, this);
     SCDesc = SchedModel.getSchedClassDesc(SchedClass);


### PR DESCRIPTION
Reverts llvm/llvm-project#90982

NIter was only declared in !NDEBUG, and only used for assertions - so it was correct that it was incremented inside the assertion. (& in fact now the non-asserts build fails, because the variable is incremented even though it isn't declared)