### PR TITLE
[MLIR][EmitC] Fix bug in EmitC form-expressions pass

### DIFF
--- a/mlir/lib/Dialect/EmitC/Transforms/FormExpressions.cpp
+++ b/mlir/lib/Dialect/EmitC/Transforms/FormExpressions.cpp
@@ -37,7 +37,8 @@ struct FormExpressionsPass
     OpBuilder builder(context);
     auto matchFun = [&](Operation *op) {
       if (op->hasTrait<OpTrait::emitc::CExpression>() &&
-          !op->getParentOfType<emitc::ExpressionOp>())
+          !op->getParentOfType<emitc::ExpressionOp>() &&
+          op->getNumResults() == 1)
         createExpression(op, builder);
     };
     rootOp->walk(matchFun);

--- a/mlir/test/Dialect/EmitC/transforms.mlir
+++ b/mlir/test/Dialect/EmitC/transforms.mlir
@@ -124,3 +124,12 @@ func.func @no_nested_expression(%arg0: i32, %arg1: i32) -> i1 {
   }
   return %a : i1
 }
+
+
+// CHECK-LABEL: func.func @single_result_requirement
+//   CHECK-NOT:  emitc.expression
+
+func.func @single_result_requirement() -> (i32, i32) {
+  %0:2 = emitc.call_opaque "foo" () : () -> (i32, i32)
+  return %0#0, %0#1 : i32, i32
+}


### PR DESCRIPTION
An `emitc.expression` can only yield a single result, but some operations which have the `CExpression` trait can have multiple results, which can result in a crash when applying the `fold-expressions` pass. This change adds a check for the single-result condition and a simple test.