### PR TITLE
workflows: Remove top-level permissions from release-tasks.yml

### DIFF
--- a/.github/workflows/release-tasks.yml
+++ b/.github/workflows/release-tasks.yml
@@ -1,7 +1,7 @@
 name: Release Task
 
 permissions:
-  contents: write
+  contents: read
 
 on:
   push:
@@ -27,6 +27,8 @@ jobs:
   release-create:
     name: Create a New Release
     runs-on: ubuntu-latest
+    permissions:
+      contents: write # For creating the release.
     needs: validate-tag
 
     steps:
@@ -55,6 +57,8 @@ jobs:
 
   release-doxygen:
     name: Build and Upload Release Doxygen
+    permissions:
+      contents: write
     needs:
       - validate-tag
       - release-create
@@ -72,6 +76,8 @@ jobs:
 
   release-binaries:
     name: Build Release Binaries
+    permissions:
+      contents: write
     needs:
       - validate-tag
       - release-create


### PR DESCRIPTION
This is the recommend best practice and we also don't need write access for all jobs.