### PR TITLE
[alpha.webkit.UncountedCallArgsChecker] Allow trivial operator++

### DIFF
--- a/clang/lib/StaticAnalyzer/Checkers/WebKit/PtrTypesSemantics.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/WebKit/PtrTypesSemantics.cpp
@@ -309,8 +309,8 @@ public:
   bool VisitDefaultStmt(const DefaultStmt *DS) { return VisitChildren(DS); }
 
   bool VisitUnaryOperator(const UnaryOperator *UO) {
-    // Unary operators are trivial if its operand is trivial.
-    return Visit(UO->getSubExpr());
+    // Unary operators are trivial if its operand is trivial except co_await.
+    return UO->getOpcode() != UO_Coawait && Visit(UO->getSubExpr());
   }
 
   bool VisitBinaryOperator(const BinaryOperator *BO) {

--- a/clang/lib/StaticAnalyzer/Checkers/WebKit/PtrTypesSemantics.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/WebKit/PtrTypesSemantics.cpp
@@ -369,7 +369,7 @@ public:
 
     if (Name == "WTFCrashWithInfo" || Name == "WTFBreakpointTrap" ||
         Name == "WTFReportAssertionFailure" ||
-        Name == "compilerFenceForCrash" || Name == "__builtin_unreachable")
+        Name == "compilerFenceForCrash" || Name.find("__builtin") == 0)
       return true;
 
     return TrivialFunctionAnalysis::isTrivialImpl(Callee, Cache);

--- a/clang/test/Analysis/Checkers/WebKit/uncounted-obj-arg.cpp
+++ b/clang/test/Analysis/Checkers/WebKit/uncounted-obj-arg.cpp
@@ -226,6 +226,7 @@ public:
   void trivial35() { v++; }
   void trivial36() { ++(*number); }
   void trivial37() { (*number)++; }
+  void trivial38() { v++; if (__builtin_expect(!!(number), 1)) (*number)++; }
 
   static RefCounted& singleton() {
     static RefCounted s_RefCounted;
@@ -364,6 +365,7 @@ public:
     getFieldTrivial().trivial35(); // no-warning
     getFieldTrivial().trivial36(); // no-warning
     getFieldTrivial().trivial37(); // no-warning
+    getFieldTrivial().trivial38(); // no-warning
 
     RefCounted::singleton().trivial18(); // no-warning
     RefCounted::singleton().someFunction(); // no-warning

--- a/clang/test/Analysis/Checkers/WebKit/uncounted-obj-arg.cpp
+++ b/clang/test/Analysis/Checkers/WebKit/uncounted-obj-arg.cpp
@@ -149,8 +149,11 @@ private:
 class ComplexNumber {
 public:
   ComplexNumber() : real(0), complex(0) { }
+  ComplexNumber(const ComplexNumber&);
   ComplexNumber& operator++() { real.someMethod(); return *this; }
   ComplexNumber operator++(int);
+  ComplexNumber& operator<<(int);
+  ComplexNumber& operator+();
 
 private:
   Number real;
@@ -227,6 +230,8 @@ public:
   void trivial36() { ++(*number); }
   void trivial37() { (*number)++; }
   void trivial38() { v++; if (__builtin_expect(!!(number), 1)) (*number)++; }
+  int trivial39() { return -v; }
+  int trivial40() { return v << 2; }
 
   static RefCounted& singleton() {
     static RefCounted s_RefCounted;
@@ -303,6 +308,8 @@ public:
   int nonTrivial14() { int r = 0xff; r |= otherFunction(); return r; }
   void nonTrivial15() { ++complex; }
   void nonTrivial16() { complex++; }
+  ComplexNumber nonTrivial17() { return complex << 2; }
+  ComplexNumber nonTrivial18() { return +complex; }
 
   unsigned v { 0 };
   Number* number { nullptr };
@@ -366,6 +373,8 @@ public:
     getFieldTrivial().trivial36(); // no-warning
     getFieldTrivial().trivial37(); // no-warning
     getFieldTrivial().trivial38(); // no-warning
+    getFieldTrivial().trivial39(); // no-warning
+    getFieldTrivial().trivial40(); // no-warning
 
     RefCounted::singleton().trivial18(); // no-warning
     RefCounted::singleton().someFunction(); // no-warning
@@ -403,6 +412,10 @@ public:
     getFieldTrivial().nonTrivial15();
     // expected-warning@-1{{Call argument for 'this' parameter is uncounted and unsafe}}
     getFieldTrivial().nonTrivial16();
+    // expected-warning@-1{{Call argument for 'this' parameter is uncounted and unsafe}}
+    getFieldTrivial().nonTrivial17();
+    // expected-warning@-1{{Call argument for 'this' parameter is uncounted and unsafe}}
+    getFieldTrivial().nonTrivial18();
     // expected-warning@-1{{Call argument for 'this' parameter is uncounted and unsafe}}
   }
 };

--- a/clang/test/Analysis/Checkers/WebKit/uncounted-obj-arg.cpp
+++ b/clang/test/Analysis/Checkers/WebKit/uncounted-obj-arg.cpp
@@ -137,9 +137,24 @@ public:
   Number(int v) : v(v) { }
   Number(double);
   Number operator+(const Number&);
+  Number& operator++() { ++v; return *this; }
+  Number operator++(int) { Number returnValue(v); ++v; return returnValue; }
   const int& value() const { return v; }
+  void someMethod();
+
 private:
   int v;
+};
+
+class ComplexNumber {
+public:
+  ComplexNumber() : real(0), complex(0) { }
+  ComplexNumber& operator++() { real.someMethod(); return *this; }
+  ComplexNumber operator++(int);
+
+private:
+  Number real;
+  Number complex;
 };
 
 class RefCounted {
@@ -208,6 +223,9 @@ public:
   unsigned trivial32() { return sizeof(int); }
   unsigned trivial33() { return ~0xff; }
   template <unsigned v> unsigned trivial34() { return v; }
+  void trivial35() { v++; }
+  void trivial36() { ++(*number); }
+  void trivial37() { (*number)++; }
 
   static RefCounted& singleton() {
     static RefCounted s_RefCounted;
@@ -282,9 +300,12 @@ public:
 
   int nonTrivial13() { return ~otherFunction(); }
   int nonTrivial14() { int r = 0xff; r |= otherFunction(); return r; }
+  void nonTrivial15() { ++complex; }
+  void nonTrivial16() { complex++; }
 
   unsigned v { 0 };
   Number* number { nullptr };
+  ComplexNumber complex;
   Enum enumValue { Enum::Value1 };
 };
 
@@ -340,6 +361,9 @@ public:
     getFieldTrivial().trivial32(); // no-warning
     getFieldTrivial().trivial33(); // no-warning
     getFieldTrivial().trivial34<7>(); // no-warning
+    getFieldTrivial().trivial35(); // no-warning
+    getFieldTrivial().trivial36(); // no-warning
+    getFieldTrivial().trivial37(); // no-warning
 
     RefCounted::singleton().trivial18(); // no-warning
     RefCounted::singleton().someFunction(); // no-warning
@@ -373,6 +397,10 @@ public:
     getFieldTrivial().nonTrivial13();
     // expected-warning@-1{{Call argument for 'this' parameter is uncounted and unsafe}}
     getFieldTrivial().nonTrivial14();
+    // expected-warning@-1{{Call argument for 'this' parameter is uncounted and unsafe}}
+    getFieldTrivial().nonTrivial15();
+    // expected-warning@-1{{Call argument for 'this' parameter is uncounted and unsafe}}
+    getFieldTrivial().nonTrivial16();
     // expected-warning@-1{{Call argument for 'this' parameter is uncounted and unsafe}}
   }
 };


### PR DESCRIPTION
This PR adds the support for trivial operator++ implementations. T& operator++() and T operator++(int) are trivial if the calle is trivial.

Also allow incrementing and decrementing of a POD member variable.

Also treat any __builtin_ functions as trivial.