### PR TITLE
[lldb][NFC] Handle UnresolvedTemplate type in TypeSystemClang.cpp after 7a484d3

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp
+++ b/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp
@@ -3983,6 +3983,7 @@ TypeSystemClang::GetMinimumLanguage(lldb::opaque_compiler_type_t type) {
 
       case clang::BuiltinType::Dependent:
       case clang::BuiltinType::Overload:
+      case clang::BuiltinType::UnresolvedTemplate:
       case clang::BuiltinType::BoundMember:
       case clang::BuiltinType::UnknownAny:
         break;
@@ -5962,6 +5963,7 @@ uint32_t TypeSystemClang::GetNumPointeeChildren(clang::QualType type) {
     case clang::BuiltinType::LongDouble:
     case clang::BuiltinType::Dependent:
     case clang::BuiltinType::Overload:
+    case clang::BuiltinType::UnresolvedTemplate:
     case clang::BuiltinType::ObjCId:
     case clang::BuiltinType::ObjCClass:
     case clang::BuiltinType::ObjCSel:


### PR DESCRIPTION
The fix per se seems trivial (given the nature of the new built-in type), and hence I don't think we need extra tests.