### PR TITLE
[ADT] Reimplement operator==(StringRef, StringRef) (NFC)

### DIFF
--- a/llvm/include/llvm/ADT/StringRef.h
+++ b/llvm/include/llvm/ADT/StringRef.h
@@ -871,7 +871,11 @@ namespace llvm {
   /// @{
 
   inline bool operator==(StringRef LHS, StringRef RHS) {
-    return LHS.equals(RHS);
+    if (LHS.size() != RHS.size())
+      return 0;
+    if (LHS.empty())
+      return 1;
+    return ::memcmp(LHS.data(), RHS.data(), LHS.size()) == 0;
   }
 
   inline bool operator!=(StringRef LHS, StringRef RHS) { return !(LHS == RHS); }

--- a/llvm/include/llvm/ADT/StringRef.h
+++ b/llvm/include/llvm/ADT/StringRef.h
@@ -872,9 +872,9 @@ namespace llvm {
 
   inline bool operator==(StringRef LHS, StringRef RHS) {
     if (LHS.size() != RHS.size())
-      return 0;
+      return false;
     if (LHS.empty())
-      return 1;
+      return true;
     return ::memcmp(LHS.data(), RHS.data(), LHS.size()) == 0;
   }
 


### PR DESCRIPTION
I'm planning to deprecate and eventually remove StringRef::equals in
favor of operator==.  This patch reimplements operator== without using
StringRef::equals.

I'm not sure if there is a good way to make StringRef::compareMemory
available to operator==, which is not a member function.  "friend"
works to some extent but breaks corner cases, which is why I've chosen
to "inline" compareMemory.