### PR TITLE
[lldb/crashlog] Update incorrect help message for `--no-crashed-only` option

### DIFF
--- a/lldb/examples/python/crashlog.py
+++ b/lldb/examples/python/crashlog.py
@@ -1631,7 +1631,8 @@ def CreateSymbolicateCrashLogOptions(
         "--no-crashed-only",
         action="store_false",
         dest="crashed_only",
-        help="do not symbolicate the crashed thread",
+        help="in batch mode, symbolicate all threads, not only the crashed one",
+        default=False,
     )
     arg_parser.add_argument(
         "--disasm-depth",


### PR DESCRIPTION
This patch rephrases the crashlog `--no-crashed-only` option help message. This option is mainly used in batch mode to symbolicate and dump all the threads backtraces, instead of only doing it for the crashed thread which is the default behavior.

rdar://127391524