### PR TITLE
[RISCV] Check dead flag on VL def op in RISCVCoalesceVSETVLI. NFC

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVInsertVSETVLI.cpp
+++ b/llvm/lib/Target/RISCV/RISCVInsertVSETVLI.cpp
@@ -1600,9 +1600,7 @@ bool RISCVCoalesceVSETVLI::coalesceVSETVLIs(MachineBasicBlock &MBB) {
       continue;
     }
 
-    Register RegDef = MI.getOperand(0).getReg();
-    assert(RegDef == RISCV::X0 || RegDef.isVirtual());
-    if (RegDef != RISCV::X0 && !MRI->use_nodbg_empty(RegDef))
+    if (!MI.getOperand(0).isDead())
       Used.demandVL();
 
     if (NextMI) {


### PR DESCRIPTION
Because LiveVariables has been run, we no longer need to lookup the users in MachineRegisterInfo anymore and can instead just check for the dead flag.
