### PR TITLE
Revert "Remove redundant move in return statement"

### DIFF
--- a/llvm/include/llvm/ExecutionEngine/Orc/IndirectionUtils.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/IndirectionUtils.h
@@ -77,7 +77,7 @@ public:
     std::lock_guard<std::mutex> Lock(TPMutex);
     if (AvailableTrampolines.empty()) {
       if (auto Err = grow())
-        return Err;
+        return std::move(Err);
     }
     assert(!AvailableTrampolines.empty() && "Failed to grow trampoline pool");
     auto TrampolineAddr = AvailableTrampolines.back();

--- a/llvm/include/llvm/ExecutionEngine/Orc/LLJIT.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/LLJIT.h
@@ -488,18 +488,18 @@ public:
   /// Create an instance of the JIT.
   Expected<std::unique_ptr<JITType>> create() {
     if (auto Err = impl().prepareForConstruction())
-      return Err;
+      return std::move(Err);
 
     Error Err = Error::success();
     std::unique_ptr<JITType> J(new JITType(impl(), Err));
     if (Err)
-      return Err;
+      return std::move(Err);
 
     if (impl().NotifyCreated)
       if (Error Err = impl().NotifyCreated(*J))
-        return Err;
+        return std::move(Err);
 
-    return J;
+    return std::move(J);
   }
 
 protected:


### PR DESCRIPTION
Reverts llvm/llvm-project#90546

This broke some bots, seems like some toolchain don’t consider the implicit move here.