### PR TITLE
Remove redundant move in return statement

### DIFF
--- a/llvm/include/llvm/ExecutionEngine/Orc/IndirectionUtils.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/IndirectionUtils.h
@@ -77,7 +77,7 @@ public:
     std::lock_guard<std::mutex> Lock(TPMutex);
     if (AvailableTrampolines.empty()) {
       if (auto Err = grow())
-        return std::move(Err);
+        return Err;
     }
     assert(!AvailableTrampolines.empty() && "Failed to grow trampoline pool");
     auto TrampolineAddr = AvailableTrampolines.back();

--- a/llvm/include/llvm/ExecutionEngine/Orc/LLJIT.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/LLJIT.h
@@ -488,18 +488,18 @@ public:
   /// Create an instance of the JIT.
   Expected<std::unique_ptr<JITType>> create() {
     if (auto Err = impl().prepareForConstruction())
-      return std::move(Err);
+      return Err;
 
     Error Err = Error::success();
     std::unique_ptr<JITType> J(new JITType(impl(), Err));
     if (Err)
-      return std::move(Err);
+      return Err;
 
     if (impl().NotifyCreated)
       if (Error Err = impl().NotifyCreated(*J))
-        return std::move(Err);
+        return Err;
 
-    return std::move(J);
+    return J;
   }
 
 protected:


### PR DESCRIPTION
This pull request reopen [PR 90546](https://github.com/llvm/llvm-project/pull/90546) to remove unnecessary move in the return statement to suppress compilation warnings.