### PR TITLE
[OpenMP][CMake] Revert standalone build LIBOMP_HEADERS_INSTALL_PATH

### DIFF
--- a/openmp/CMakeLists.txt
+++ b/openmp/CMakeLists.txt
@@ -113,17 +113,7 @@ option(OPENMP_ENABLE_LIBOMP_PROFILING "Enable time profiling for libomp." OFF)
 
 # Header install location
 if(${OPENMP_STANDALONE_BUILD})
-  if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-    execute_process(
-      OUTPUT_STRIP_TRAILING_WHITESPACE
-      COMMAND ${CMAKE_CXX_COMPILER} --print-resource-dir
-      RESULT_VARIABLE COMMAND_RETURN_CODE
-      OUTPUT_VARIABLE COMPILER_RESOURCE_DIR
-    )
-    set(LIBOMP_HEADERS_INSTALL_PATH "${COMPILER_RESOURCE_DIR}/include")
-  else()
-    set(LIBOMP_HEADERS_INSTALL_PATH "${CMAKE_INSTALL_INCLUDEDIR}")
-  endif()
+  set(LIBOMP_HEADERS_INSTALL_PATH "${CMAKE_INSTALL_INCLUDEDIR}")
 else()
   include(GetClangResourceDir)
   get_clang_resource_dir(LIBOMP_HEADERS_INSTALL_PATH SUBDIR include)


### PR DESCRIPTION
Revert the portion of https://github.com/llvm/llvm-project/pull/75125 which modified the LIBOMP_HEADERS_INSTALL_PATH in standalone build.

This change is harmful for real standalone builds (i.e. builds where we build openmp by itself), since it tries to overwrite the `omp.h` inside the build compiler. For all-in-one builds with clang, testing shows this change is unnecessary as https://github.com/llvm/llvm-project/pull/88007 already set up that build configuration so that omp.h will be put into the project build's `clang` resource directory.