### PR TITLE
[DomTree] Provide a way to query if DFSInfo is valid

### DIFF
--- a/llvm/include/llvm/Support/GenericDomTree.h
+++ b/llvm/include/llvm/Support/GenericDomTree.h
@@ -328,6 +328,8 @@ protected:
   ///
   bool isPostDominator() const { return IsPostDominator; }
 
+  bool isDFSInfoValid() const { return DFSInfoValid; }
+
   /// compare - Return false if the other dominator tree base matches this
   /// dominator tree base. Otherwise return true.
   bool compare(const DominatorTreeBase &Other) const {


### PR DESCRIPTION
Pass like GVNSink modify CFG use DFS numbers for storing basic blocks (See #90995).
Instead of updating DFS numbers after every modification to CFG,
it is more efficient to do lazily i.e., only when DFS numbers are going to be used by the pass.