### PR TITLE
[lldb] Use add_custom_command for SBLanguages.h

### DIFF
--- a/lldb/source/API/CMakeLists.txt
+++ b/lldb/source/API/CMakeLists.txt
@@ -23,13 +23,13 @@ endif()
 # Target to generate SBLanguages.h from Dwarf.def.
 set(sb_languages_file
   ${CMAKE_CURRENT_BINARY_DIR}/../../include/lldb/API/SBLanguages.h)
-add_custom_target(
-  lldb-sbapi-dwarf-enums
-  "${Python3_EXECUTABLE}"
+add_custom_command(
+  COMMENT "Generating SBLanguages.h from Dwarf.def"
+  COMMAND "${Python3_EXECUTABLE}"
       ${LLDB_SOURCE_DIR}/scripts/generate-sbapi-dwarf-enum.py
       ${LLVM_MAIN_INCLUDE_DIR}/llvm/BinaryFormat/Dwarf.def
       -o ${sb_languages_file}
-  BYPRODUCTS ${sb_languages_file}
+  OUTPUT ${sb_languages_file}
   DEPENDS ${LLVM_MAIN_INCLUDE_DIR}/llvm/BinaryFormat/Dwarf.def
   WORKING_DIRECTORY ${LLVM_LIBRARY_OUTPUT_INTDIR}
 )
@@ -113,9 +113,7 @@ add_lldb_library(liblldb SHARED ${option_framework}
   SystemInitializerFull.cpp
   ${lldb_python_wrapper}
   ${lldb_lua_wrapper}
-
-  DEPENDS
-    lldb-sbapi-dwarf-enums
+  ${sb_languages_file}
 
   LINK_LIBS
     lldbBreakpoint


### PR DESCRIPTION
Use add_custom_command instead of add_custom_target to generate SBLanguages.h.