### PR TITLE
[flang][cuda] Avoid generating wrong fir.cuda_free op

### DIFF
--- a/flang/include/flang/Semantics/tools.h
+++ b/flang/include/flang/Semantics/tools.h
@@ -224,6 +224,8 @@ inline bool HasCUDAAttr(const Symbol &sym) {
 
 inline bool NeedCUDAAlloc(const Symbol &sym) {
   bool inDeviceSubprogram{IsCUDADeviceContext(&sym.owner())};
+  if (Fortran::semantics::IsDummy(sym))
+    return false;
   if (const auto *details{
           sym.GetUltimate().detailsIf<semantics::ObjectEntityDetails>()}) {
     if (details->cudaDataAttr() &&

--- a/flang/test/Lower/CUDA/cuda-data-attribute.cuf
+++ b/flang/test/Lower/CUDA/cuda-data-attribute.cuf
@@ -85,6 +85,13 @@ end
 ! CHECK: fir.cuda_free %[[DECL_U]]#1 : !fir.ref<i32> {cuda_attr = #fir.cuda<unified>}
 ! CHECK: fir.cuda_free %[[DECL_A]]#1 : !fir.ref<!fir.array<10xf32>> {cuda_attr = #fir.cuda<device>}
 
+subroutine dummy(x)
+  real, target, device :: x
+end subroutine
+
+! CHECK: func.func @_QMcuda_varPdummy
+! CHECK-NOT: fir.cuda_free
+
 end module
 
 


### PR DESCRIPTION
fir.cuda_free operation was wrongly generated for dummy argument. 