### PR TITLE
[Sanitizers] Fix fake_test_gc not working on devices

### DIFF
--- a/compiler-rt/test/asan/TestCases/Posix/fake_stack_gc.cpp
+++ b/compiler-rt/test/asan/TestCases/Posix/fake_stack_gc.cpp
@@ -1,4 +1,4 @@
-// RUN: %clangxx_asan -O0 -pthread %s -o %t && %env_asan_opts=use_sigaltstack=0 %run not --crash %t 2>&1 | FileCheck %s
+// RUN: %clangxx_asan -O0 -pthread %s -o %t && %env_asan_opts=use_sigaltstack=0 not --crash %run %t 2>&1 | FileCheck %s
 
 // Check that fake stack does not discard frames on the main stack, when GC is
 // triggered from high alt stack.


### PR DESCRIPTION
The way the LIT RUN command is currently constructed ( %run not --crash %t ) causes the test failure on devices - since 'not' is a LLVM built command, not available on devices.

Changing the command to read 'not --crash %run %t' fixes it, as 'not' now executes on the host running the test.

rdar://115914588
