### PR TITLE
[clang-tidy] support expect no diagnosis test

### DIFF
--- a/clang-tools-extra/test/clang-tidy/check_clang_tidy.py
+++ b/clang-tools-extra/test/clang-tidy/check_clang_tidy.py
@@ -175,9 +175,19 @@ class CheckRunner:
             if not has_check_fix and not has_check_message and not has_check_note:
                 self.expect_no_diagnosis = True
 
-        assert self.expect_no_diagnosis != (
+        expect_diagnosis = (
             self.has_check_fixes or self.has_check_messages or self.has_check_notes
         )
+        if self.expect_no_diagnosis and expect_diagnosis:
+            sys.exit(
+                "%s, %s or %s not found in the input"
+                % (
+                    self.fixes.prefix,
+                    self.messages.prefix,
+                    self.notes.prefix,
+                )
+            )
+        assert expect_diagnosis or self.expect_no_diagnosis
 
     def prepare_test_inputs(self):
         # Remove the contents of the CHECK lines to avoid CHECKs matching on
@@ -227,7 +237,6 @@ class CheckRunner:
         return clang_tidy_output
 
     def check_no_diagnosis(self, clang_tidy_output):
-        print(clang_tidy_output)
         if clang_tidy_output != "":
             sys.exit("No diagnostics were expected, but found the ones above")
 

--- a/clang-tools-extra/test/clang-tidy/check_clang_tidy.py
+++ b/clang-tools-extra/test/clang-tidy/check_clang_tidy.py
@@ -229,7 +229,7 @@ class CheckRunner:
     def check_no_diagnosis(self, clang_tidy_output):
         print(clang_tidy_output)
         if clang_tidy_output != "":
-            sys.exit("expect no diagnosis")
+            sys.exit("No diagnostics were expected, but found the ones above")
 
     def check_fixes(self):
         if self.has_check_fixes:

--- a/clang-tools-extra/test/clang-tidy/check_clang_tidy.py
+++ b/clang-tools-extra/test/clang-tidy/check_clang_tidy.py
@@ -99,7 +99,7 @@ class CheckRunner:
         self.has_check_fixes = False
         self.has_check_messages = False
         self.has_check_notes = False
-        self.expect_no_diagnosis = args.expect_no_diagnosis
+        self.expect_no_diagnosis = False
         self.export_fixes = args.export_fixes
         self.fixes = MessagePrefix("CHECK-FIXES")
         self.messages = MessagePrefix("CHECK-MESSAGES")
@@ -173,12 +173,11 @@ class CheckRunner:
                 )
 
             if not has_check_fix and not has_check_message and not has_check_note:
-                sys.exit(
-                    "%s, %s or %s not found in the input"
-                    % (self.fixes.prefix, self.messages.prefix, self.notes.prefix)
-                )
+                self.expect_no_diagnosis = True
 
-        assert self.has_check_fixes or self.has_check_messages or self.has_check_notes
+        assert self.expect_no_diagnosis != (
+            self.has_check_fixes or self.has_check_messages or self.has_check_notes
+        )
 
     def prepare_test_inputs(self):
         # Remove the contents of the CHECK lines to avoid CHECKs matching on
@@ -279,7 +278,7 @@ class CheckRunner:
 
     def run(self):
         self.read_input()
-        if self.export_fixes is None and not self.expect_no_diagnosis:
+        if self.export_fixes is None:
             self.get_prefixes()
         self.prepare_test_inputs()
         clang_tidy_output = self.run_clang_tidy()
@@ -318,7 +317,6 @@ def parse_arguments():
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
     parser.add_argument("-expect-clang-tidy-error", action="store_true")
-    parser.add_argument("-expect-no-diagnosis", action="store_true")
     parser.add_argument("-resource-dir")
     parser.add_argument("-assume-filename")
     parser.add_argument("input_file_name")

--- a/clang-tools-extra/test/clang-tidy/check_clang_tidy.py
+++ b/clang-tools-extra/test/clang-tidy/check_clang_tidy.py
@@ -226,11 +226,11 @@ class CheckRunner:
         print(diff_output)
         print("------------------------------------------------------------------")
         return clang_tidy_output
-    
+
     def check_no_diagnosis(self, clang_tidy_output):
         print(clang_tidy_output)
         if clang_tidy_output != "":
-            sys.exit('expect no diagnosis')
+            sys.exit("expect no diagnosis")
 
     def check_fixes(self):
         if self.has_check_fixes:

--- a/clang-tools-extra/test/clang-tidy/check_clang_tidy.py
+++ b/clang-tools-extra/test/clang-tidy/check_clang_tidy.py
@@ -99,6 +99,7 @@ class CheckRunner:
         self.has_check_fixes = False
         self.has_check_messages = False
         self.has_check_notes = False
+        self.expect_no_diagnosis = args.expect_no_diagnosis
         self.export_fixes = args.export_fixes
         self.fixes = MessagePrefix("CHECK-FIXES")
         self.messages = MessagePrefix("CHECK-MESSAGES")
@@ -225,6 +226,11 @@ class CheckRunner:
         print(diff_output)
         print("------------------------------------------------------------------")
         return clang_tidy_output
+    
+    def check_no_diagnosis(self, clang_tidy_output):
+        print(clang_tidy_output)
+        if clang_tidy_output != "":
+            sys.exit('expect no diagnosis')
 
     def check_fixes(self):
         if self.has_check_fixes:
@@ -273,11 +279,13 @@ class CheckRunner:
 
     def run(self):
         self.read_input()
-        if self.export_fixes is None:
+        if self.export_fixes is None and not self.expect_no_diagnosis:
             self.get_prefixes()
         self.prepare_test_inputs()
         clang_tidy_output = self.run_clang_tidy()
-        if self.export_fixes is None:
+        if self.expect_no_diagnosis:
+            self.check_no_diagnosis(clang_tidy_output)
+        elif self.export_fixes is None:
             self.check_fixes()
             self.check_messages(clang_tidy_output)
             self.check_notes(clang_tidy_output)
@@ -310,6 +318,7 @@ def parse_arguments():
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
     parser.add_argument("-expect-clang-tidy-error", action="store_true")
+    parser.add_argument("-expect-no-diagnosis", action="store_true")
     parser.add_argument("-resource-dir")
     parser.add_argument("-assume-filename")
     parser.add_argument("input_file_name")

--- a/clang-tools-extra/test/clang-tidy/checkers/misc/unused-using-decls.hpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/misc/unused-using-decls.hpp
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy %s misc-unused-using-decls -expect-no-diagnosis %t
+// RUN: %check_clang_tidy %s misc-unused-using-decls %t
 
 // Verify that we don't generate the warnings on header files.
 namespace foo { class Foo {}; }

--- a/clang-tools-extra/test/clang-tidy/checkers/misc/unused-using-decls.hpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/misc/unused-using-decls.hpp
@@ -1,0 +1,6 @@
+// RUN: %check_clang_tidy %s misc-unused-using-decls -expect-no-diagnosis %t
+
+// Verify that we don't generate the warnings on header files.
+namespace foo { class Foo {}; }
+
+using foo::Foo;

--- a/clang-tools-extra/test/clang-tidy/checkers/misc/unused-using-decls.hxx
+++ b/clang-tools-extra/test/clang-tidy/checkers/misc/unused-using-decls.hxx
@@ -1,6 +1,0 @@
-// RUN: %check_clang_tidy %s misc-unused-using-decls %t -- --fix-notes -- -fno-delayed-template-parsing -isystem %S/Inputs
-
-// Verify that we don't generate the warnings on header files.
-namespace foo { class Foo {}; }
-
-using foo::Foo;


### PR DESCRIPTION
When someone wants to declare a test case without any diagnosis.
check-clang-tidy will failed with error message

```
CHECK-FIXES, CHECK-MESSAGES or CHECK-NOTES not found in the input
```

This PR want to check there are no diagnosis from clang-tidy when CHECK-FIXES, CHECK-MESSAGES or CHECK-NOTES are not found.

It also changes the extension of a test case. `hxx` is not a valid test case extension and won't be tested. 