### PR TITLE
[RISCV][NFC] Remove redundant test cases.

### DIFF
--- a/clang/test/Driver/riscv-option-arch.c
+++ b/clang/test/Driver/riscv-option-arch.c
@@ -1,8 +1,0 @@
-// REQUIRES: riscv-registered-target
-// RUN: %clang --target=riscv64 -menable-experimental-extensions -c -o /dev/null %s
-// RUN: ! %clang --target=riscv64 -c -o /dev/null %s 2>&1 | FileCheck -check-prefixes=CHECK-ERR %s
-
-void foo() {
-  asm volatile (".option arch, +zicfiss");
-  // CHECK-ERR: Unexpected experimental extensions.
-}

--- a/clang/test/Driver/riscv-option-arch.s
+++ b/clang/test/Driver/riscv-option-arch.s
@@ -1,6 +1,0 @@
-# REQUIRES: riscv-registered-target
-# RUN: %clang --target=riscv64 -menable-experimental-extensions -c -o /dev/null %s
-# RUN: ! %clang --target=riscv64 -c -o /dev/null %s 2>&1 | FileCheck -check-prefixes=CHECK-ERR %s
-
-.option arch, +zicfiss
-# CHECK-ERR: Unexpected experimental extensions.


### PR DESCRIPTION
PR #89727 added the two test cases to verify `.option arch` should only work when having -menable-experimental-extensions. And the test idea could be splitted to
1. When having menable-experimental-extensions, clang passes +experimental.
2. `.option arch` only enabled when +experimental enabled. 

And we already had the two kind of tests.