### PR TITLE
DAG: Skip 0 sign handling in minimum/maximum lowering for _ieee case

### DIFF
--- a/llvm/lib/CodeGen/SelectionDAG/TargetLowering.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/TargetLowering.cpp
@@ -8400,8 +8400,14 @@ SDValue TargetLowering::expandFMINIMUM_FMAXIMUM(SDNode *N,
   SDValue MinMax;
   unsigned CompOpcIeee = IsMax ? ISD::FMAXNUM_IEEE : ISD::FMINNUM_IEEE;
   unsigned CompOpc = IsMax ? ISD::FMAXNUM : ISD::FMINNUM;
+
+  // FIXME: We should probably define fminnum/fmaxnum variants with correct
+  // signed zero behavior.
+  bool MinMaxMustRespectOrderedZero = false;
+
   if (isOperationLegalOrCustom(CompOpcIeee, VT)) {
     MinMax = DAG.getNode(CompOpcIeee, DL, VT, LHS, RHS);
+    MinMaxMustRespectOrderedZero = true;
   } else if (isOperationLegalOrCustom(CompOpc, VT)) {
     MinMax = DAG.getNode(CompOpc, DL, VT, LHS, RHS);
   } else {
@@ -8421,8 +8427,8 @@ SDValue TargetLowering::expandFMINIMUM_FMAXIMUM(SDNode *N,
   }
 
   // fminimum/fmaximum requires -0.0 less than +0.0
-  if (!N->getFlags().hasNoSignedZeros() && !DAG.isKnownNeverZeroFloat(RHS) &&
-      !DAG.isKnownNeverZeroFloat(LHS)) {
+  if (!MinMaxMustRespectOrderedZero && !N->getFlags().hasNoSignedZeros() &&
+      !DAG.isKnownNeverZeroFloat(RHS) && !DAG.isKnownNeverZeroFloat(LHS)) {
     SDValue IsZero = DAG.getSetCC(DL, CCVT, MinMax,
                                   DAG.getConstantFP(0.0, DL, VT), ISD::SETEQ);
     SDValue TestZero =

--- a/llvm/test/CodeGen/AMDGPU/llvm.maximum.f16.ll
+++ b/llvm/test/CodeGen/AMDGPU/llvm.maximum.f16.ll
@@ -18,13 +18,7 @@ define half @v_maximum_f16(half %src0, half %src1) {
 ; GFX7-NEXT:    v_cvt_f32_f16_e32 v0, v0
 ; GFX7-NEXT:    v_max_f32_e32 v3, v0, v1
 ; GFX7-NEXT:    v_cmp_o_f32_e32 vcc, v0, v1
-; GFX7-NEXT:    v_cndmask_b32_e32 v2, v2, v3, vcc
-; GFX7-NEXT:    v_cmp_class_f32_e64 vcc, v0, 64
-; GFX7-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc
-; GFX7-NEXT:    v_cmp_class_f32_e64 vcc, v1, 64
-; GFX7-NEXT:    v_cndmask_b32_e32 v0, v0, v1, vcc
-; GFX7-NEXT:    v_cmp_eq_f32_e32 vcc, 0, v2
-; GFX7-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc
+; GFX7-NEXT:    v_cndmask_b32_e32 v0, v2, v3, vcc
 ; GFX7-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX8-LABEL: v_maximum_f16:
@@ -33,13 +27,7 @@ define half @v_maximum_f16(half %src0, half %src1) {
 ; GFX8-NEXT:    v_max_f16_e32 v2, v0, v1
 ; GFX8-NEXT:    v_mov_b32_e32 v3, 0x7e00
 ; GFX8-NEXT:    v_cmp_o_f16_e32 vcc, v0, v1
-; GFX8-NEXT:    v_cndmask_b32_e32 v2, v3, v2, vcc
-; GFX8-NEXT:    v_cmp_class_f16_e64 vcc, v0, 64
-; GFX8-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc
-; GFX8-NEXT:    v_cmp_class_f16_e64 vcc, v1, 64
-; GFX8-NEXT:    v_cndmask_b32_e32 v0, v0, v1, vcc
-; GFX8-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v2
-; GFX8-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc
+; GFX8-NEXT:    v_cndmask_b32_e32 v0, v3, v2, vcc
 ; GFX8-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX9-LABEL: v_maximum_f16:
@@ -48,13 +36,7 @@ define half @v_maximum_f16(half %src0, half %src1) {
 ; GFX9-NEXT:    v_max_f16_e32 v2, v0, v1
 ; GFX9-NEXT:    v_mov_b32_e32 v3, 0x7e00
 ; GFX9-NEXT:    v_cmp_o_f16_e32 vcc, v0, v1
-; GFX9-NEXT:    v_cndmask_b32_e32 v2, v3, v2, vcc
-; GFX9-NEXT:    v_cmp_class_f16_e64 vcc, v0, 64
-; GFX9-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc
-; GFX9-NEXT:    v_cmp_class_f16_e64 vcc, v1, 64
-; GFX9-NEXT:    v_cndmask_b32_e32 v0, v0, v1, vcc
-; GFX9-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v2
-; GFX9-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v0, v3, v2, vcc
 ; GFX9-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX940-LABEL: v_maximum_f16:
@@ -64,16 +46,7 @@ define half @v_maximum_f16(half %src0, half %src1) {
 ; GFX940-NEXT:    v_mov_b32_e32 v3, 0x7e00
 ; GFX940-NEXT:    v_cmp_o_f16_e32 vcc, v0, v1
 ; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v2, v3, v2, vcc
-; GFX940-NEXT:    v_cmp_class_f16_e64 vcc, v0, 64
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc
-; GFX940-NEXT:    v_cmp_class_f16_e64 vcc, v1, 64
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v0, v0, v1, vcc
-; GFX940-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v2
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc
+; GFX940-NEXT:    v_cndmask_b32_e32 v0, v3, v2, vcc
 ; GFX940-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX10-LABEL: v_maximum_f16:
@@ -81,13 +54,7 @@ define half @v_maximum_f16(half %src0, half %src1) {
 ; GFX10-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX10-NEXT:    v_max_f16_e32 v2, v0, v1
 ; GFX10-NEXT:    v_cmp_o_f16_e32 vcc_lo, v0, v1
-; GFX10-NEXT:    v_cndmask_b32_e32 v2, 0x7e00, v2, vcc_lo
-; GFX10-NEXT:    v_cmp_class_f16_e64 vcc_lo, v0, 64
-; GFX10-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc_lo
-; GFX10-NEXT:    v_cmp_class_f16_e64 vcc_lo, v1, 64
-; GFX10-NEXT:    v_cndmask_b32_e32 v0, v0, v1, vcc_lo
-; GFX10-NEXT:    v_cmp_eq_f16_e32 vcc_lo, 0, v2
-; GFX10-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc_lo
+; GFX10-NEXT:    v_cndmask_b32_e32 v0, 0x7e00, v2, vcc_lo
 ; GFX10-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX11-LABEL: v_maximum_f16:
@@ -95,15 +62,8 @@ define half @v_maximum_f16(half %src0, half %src1) {
 ; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX11-NEXT:    v_max_f16_e32 v2, v0, v1
 ; GFX11-NEXT:    v_cmp_o_f16_e32 vcc_lo, v0, v1
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(SKIP_1) | instid1(VALU_DEP_2)
-; GFX11-NEXT:    v_cndmask_b32_e32 v2, 0x7e00, v2, vcc_lo
-; GFX11-NEXT:    v_cmp_class_f16_e64 vcc_lo, v0, 64
-; GFX11-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc_lo
-; GFX11-NEXT:    v_cmp_class_f16_e64 vcc_lo, v1, 64
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(SKIP_1) | instid1(VALU_DEP_2)
-; GFX11-NEXT:    v_cndmask_b32_e32 v0, v0, v1, vcc_lo
-; GFX11-NEXT:    v_cmp_eq_f16_e32 vcc_lo, 0, v2
-; GFX11-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc_lo
+; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_2)
+; GFX11-NEXT:    v_cndmask_b32_e32 v0, 0x7e00, v2, vcc_lo
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX12-LABEL: v_maximum_f16:
@@ -127,78 +87,37 @@ define half @v_maximum_f16__nnan(half %src0, half %src1) {
 ; GFX7-NEXT:    v_cvt_f16_f32_e32 v0, v0
 ; GFX7-NEXT:    v_cvt_f32_f16_e32 v1, v1
 ; GFX7-NEXT:    v_cvt_f32_f16_e32 v0, v0
-; GFX7-NEXT:    v_max_f32_e32 v2, v0, v1
-; GFX7-NEXT:    v_cmp_class_f32_e64 vcc, v0, 64
-; GFX7-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc
-; GFX7-NEXT:    v_cmp_class_f32_e64 vcc, v1, 64
-; GFX7-NEXT:    v_cndmask_b32_e32 v0, v0, v1, vcc
-; GFX7-NEXT:    v_cmp_eq_f32_e32 vcc, 0, v2
-; GFX7-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc
+; GFX7-NEXT:    v_max_f32_e32 v0, v0, v1
 ; GFX7-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX8-LABEL: v_maximum_f16__nnan:
 ; GFX8:       ; %bb.0:
 ; GFX8-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX8-NEXT:    v_max_f16_e32 v2, v0, v1
-; GFX8-NEXT:    v_cmp_class_f16_e64 vcc, v0, 64
-; GFX8-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc
-; GFX8-NEXT:    v_cmp_class_f16_e64 vcc, v1, 64
-; GFX8-NEXT:    v_cndmask_b32_e32 v0, v0, v1, vcc
-; GFX8-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v2
-; GFX8-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc
+; GFX8-NEXT:    v_max_f16_e32 v0, v0, v1
 ; GFX8-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX9-LABEL: v_maximum_f16__nnan:
 ; GFX9:       ; %bb.0:
 ; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX9-NEXT:    v_max_f16_e32 v2, v0, v1
-; GFX9-NEXT:    v_cmp_class_f16_e64 vcc, v0, 64
-; GFX9-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc
-; GFX9-NEXT:    v_cmp_class_f16_e64 vcc, v1, 64
-; GFX9-NEXT:    v_cndmask_b32_e32 v0, v0, v1, vcc
-; GFX9-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v2
-; GFX9-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc
+; GFX9-NEXT:    v_max_f16_e32 v0, v0, v1
 ; GFX9-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX940-LABEL: v_maximum_f16__nnan:
 ; GFX940:       ; %bb.0:
 ; GFX940-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX940-NEXT:    v_max_f16_e32 v2, v0, v1
-; GFX940-NEXT:    v_cmp_class_f16_e64 vcc, v0, 64
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc
-; GFX940-NEXT:    v_cmp_class_f16_e64 vcc, v1, 64
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v0, v0, v1, vcc
-; GFX940-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v2
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc
+; GFX940-NEXT:    v_max_f16_e32 v0, v0, v1
 ; GFX940-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX10-LABEL: v_maximum_f16__nnan:
 ; GFX10:       ; %bb.0:
 ; GFX10-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX10-NEXT:    v_max_f16_e32 v2, v0, v1
-; GFX10-NEXT:    v_cmp_class_f16_e64 vcc_lo, v0, 64
-; GFX10-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc_lo
-; GFX10-NEXT:    v_cmp_class_f16_e64 vcc_lo, v1, 64
-; GFX10-NEXT:    v_cndmask_b32_e32 v0, v0, v1, vcc_lo
-; GFX10-NEXT:    v_cmp_eq_f16_e32 vcc_lo, 0, v2
-; GFX10-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc_lo
+; GFX10-NEXT:    v_max_f16_e32 v0, v0, v1
 ; GFX10-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX11-LABEL: v_maximum_f16__nnan:
 ; GFX11:       ; %bb.0:
 ; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX11-NEXT:    v_max_f16_e32 v2, v0, v1
-; GFX11-NEXT:    v_cmp_class_f16_e64 vcc_lo, v0, 64
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(SKIP_1) | instid1(VALU_DEP_2)
-; GFX11-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc_lo
-; GFX11-NEXT:    v_cmp_class_f16_e64 vcc_lo, v1, 64
-; GFX11-NEXT:    v_cndmask_b32_e32 v0, v0, v1, vcc_lo
-; GFX11-NEXT:    v_cmp_eq_f16_e32 vcc_lo, 0, v2
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_2)
-; GFX11-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc_lo
+; GFX11-NEXT:    v_max_f16_e32 v0, v0, v1
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX12-LABEL: v_maximum_f16__nnan:
@@ -352,13 +271,7 @@ define half @v_maximum_f16__nnan_src0(half %arg0, half %src1) {
 ; GFX7-NEXT:    v_add_f32_e32 v0, 1.0, v0
 ; GFX7-NEXT:    v_max_f32_e32 v3, v0, v1
 ; GFX7-NEXT:    v_cmp_o_f32_e32 vcc, v0, v1
-; GFX7-NEXT:    v_cndmask_b32_e32 v2, v2, v3, vcc
-; GFX7-NEXT:    v_cmp_class_f32_e64 vcc, v0, 64
-; GFX7-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc
-; GFX7-NEXT:    v_cmp_class_f32_e64 vcc, v1, 64
-; GFX7-NEXT:    v_cndmask_b32_e32 v0, v0, v1, vcc
-; GFX7-NEXT:    v_cmp_eq_f32_e32 vcc, 0, v2
-; GFX7-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc
+; GFX7-NEXT:    v_cndmask_b32_e32 v0, v2, v3, vcc
 ; GFX7-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX8-LABEL: v_maximum_f16__nnan_src0:
@@ -368,13 +281,7 @@ define half @v_maximum_f16__nnan_src0(half %arg0, half %src1) {
 ; GFX8-NEXT:    v_max_f16_e32 v2, v0, v1
 ; GFX8-NEXT:    v_mov_b32_e32 v3, 0x7e00
 ; GFX8-NEXT:    v_cmp_o_f16_e32 vcc, v0, v1
-; GFX8-NEXT:    v_cndmask_b32_e32 v2, v3, v2, vcc
-; GFX8-NEXT:    v_cmp_class_f16_e64 vcc, v0, 64
-; GFX8-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc
-; GFX8-NEXT:    v_cmp_class_f16_e64 vcc, v1, 64
-; GFX8-NEXT:    v_cndmask_b32_e32 v0, v0, v1, vcc
-; GFX8-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v2
-; GFX8-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc
+; GFX8-NEXT:    v_cndmask_b32_e32 v0, v3, v2, vcc
 ; GFX8-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX9-LABEL: v_maximum_f16__nnan_src0:
@@ -384,13 +291,7 @@ define half @v_maximum_f16__nnan_src0(half %arg0, half %src1) {
 ; GFX9-NEXT:    v_max_f16_e32 v2, v0, v1
 ; GFX9-NEXT:    v_mov_b32_e32 v3, 0x7e00
 ; GFX9-NEXT:    v_cmp_o_f16_e32 vcc, v0, v1
-; GFX9-NEXT:    v_cndmask_b32_e32 v2, v3, v2, vcc
-; GFX9-NEXT:    v_cmp_class_f16_e64 vcc, v0, 64
-; GFX9-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc
-; GFX9-NEXT:    v_cmp_class_f16_e64 vcc, v1, 64
-; GFX9-NEXT:    v_cndmask_b32_e32 v0, v0, v1, vcc
-; GFX9-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v2
-; GFX9-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v0, v3, v2, vcc
 ; GFX9-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX940-LABEL: v_maximum_f16__nnan_src0:
@@ -401,16 +302,7 @@ define half @v_maximum_f16__nnan_src0(half %arg0, half %src1) {
 ; GFX940-NEXT:    v_mov_b32_e32 v3, 0x7e00
 ; GFX940-NEXT:    v_cmp_o_f16_e32 vcc, v0, v1
 ; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v2, v3, v2, vcc
-; GFX940-NEXT:    v_cmp_class_f16_e64 vcc, v0, 64
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc
-; GFX940-NEXT:    v_cmp_class_f16_e64 vcc, v1, 64
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v0, v0, v1, vcc
-; GFX940-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v2
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc
+; GFX940-NEXT:    v_cndmask_b32_e32 v0, v3, v2, vcc
 ; GFX940-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX10-LABEL: v_maximum_f16__nnan_src0:
@@ -419,13 +311,7 @@ define half @v_maximum_f16__nnan_src0(half %arg0, half %src1) {
 ; GFX10-NEXT:    v_add_f16_e32 v0, 1.0, v0
 ; GFX10-NEXT:    v_max_f16_e32 v2, v0, v1
 ; GFX10-NEXT:    v_cmp_o_f16_e32 vcc_lo, v0, v1
-; GFX10-NEXT:    v_cndmask_b32_e32 v2, 0x7e00, v2, vcc_lo
-; GFX10-NEXT:    v_cmp_class_f16_e64 vcc_lo, v0, 64
-; GFX10-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc_lo
-; GFX10-NEXT:    v_cmp_class_f16_e64 vcc_lo, v1, 64
-; GFX10-NEXT:    v_cndmask_b32_e32 v0, v0, v1, vcc_lo
-; GFX10-NEXT:    v_cmp_eq_f16_e32 vcc_lo, 0, v2
-; GFX10-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc_lo
+; GFX10-NEXT:    v_cndmask_b32_e32 v0, 0x7e00, v2, vcc_lo
 ; GFX10-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX11-LABEL: v_maximum_f16__nnan_src0:
@@ -435,15 +321,7 @@ define half @v_maximum_f16__nnan_src0(half %arg0, half %src1) {
 ; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_1) | instid1(VALU_DEP_2)
 ; GFX11-NEXT:    v_max_f16_e32 v2, v0, v1
 ; GFX11-NEXT:    v_cmp_o_f16_e32 vcc_lo, v0, v1
-; GFX11-NEXT:    v_cndmask_b32_e32 v2, 0x7e00, v2, vcc_lo
-; GFX11-NEXT:    v_cmp_class_f16_e64 vcc_lo, v0, 64
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(SKIP_1) | instid1(VALU_DEP_2)
-; GFX11-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc_lo
-; GFX11-NEXT:    v_cmp_class_f16_e64 vcc_lo, v1, 64
-; GFX11-NEXT:    v_cndmask_b32_e32 v0, v0, v1, vcc_lo
-; GFX11-NEXT:    v_cmp_eq_f16_e32 vcc_lo, 0, v2
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_2)
-; GFX11-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc_lo
+; GFX11-NEXT:    v_cndmask_b32_e32 v0, 0x7e00, v2, vcc_lo
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX12-LABEL: v_maximum_f16__nnan_src0:
@@ -474,13 +352,7 @@ define half @v_maximum_f16__nnan_src1(half %src0, half %arg1) {
 ; GFX7-NEXT:    v_add_f32_e32 v1, 1.0, v1
 ; GFX7-NEXT:    v_max_f32_e32 v3, v0, v1
 ; GFX7-NEXT:    v_cmp_o_f32_e32 vcc, v0, v1
-; GFX7-NEXT:    v_cndmask_b32_e32 v2, v2, v3, vcc
-; GFX7-NEXT:    v_cmp_class_f32_e64 vcc, v0, 64
-; GFX7-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc
-; GFX7-NEXT:    v_cmp_class_f32_e64 vcc, v1, 64
-; GFX7-NEXT:    v_cndmask_b32_e32 v0, v0, v1, vcc
-; GFX7-NEXT:    v_cmp_eq_f32_e32 vcc, 0, v2
-; GFX7-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc
+; GFX7-NEXT:    v_cndmask_b32_e32 v0, v2, v3, vcc
 ; GFX7-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX8-LABEL: v_maximum_f16__nnan_src1:
@@ -490,13 +362,7 @@ define half @v_maximum_f16__nnan_src1(half %src0, half %arg1) {
 ; GFX8-NEXT:    v_max_f16_e32 v2, v0, v1
 ; GFX8-NEXT:    v_mov_b32_e32 v3, 0x7e00
 ; GFX8-NEXT:    v_cmp_o_f16_e32 vcc, v0, v1
-; GFX8-NEXT:    v_cndmask_b32_e32 v2, v3, v2, vcc
-; GFX8-NEXT:    v_cmp_class_f16_e64 vcc, v0, 64
-; GFX8-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc
-; GFX8-NEXT:    v_cmp_class_f16_e64 vcc, v1, 64
-; GFX8-NEXT:    v_cndmask_b32_e32 v0, v0, v1, vcc
-; GFX8-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v2
-; GFX8-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc
+; GFX8-NEXT:    v_cndmask_b32_e32 v0, v3, v2, vcc
 ; GFX8-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX9-LABEL: v_maximum_f16__nnan_src1:
@@ -506,13 +372,7 @@ define half @v_maximum_f16__nnan_src1(half %src0, half %arg1) {
 ; GFX9-NEXT:    v_max_f16_e32 v2, v0, v1
 ; GFX9-NEXT:    v_mov_b32_e32 v3, 0x7e00
 ; GFX9-NEXT:    v_cmp_o_f16_e32 vcc, v0, v1
-; GFX9-NEXT:    v_cndmask_b32_e32 v2, v3, v2, vcc
-; GFX9-NEXT:    v_cmp_class_f16_e64 vcc, v0, 64
-; GFX9-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc
-; GFX9-NEXT:    v_cmp_class_f16_e64 vcc, v1, 64
-; GFX9-NEXT:    v_cndmask_b32_e32 v0, v0, v1, vcc
-; GFX9-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v2
-; GFX9-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v0, v3, v2, vcc
 ; GFX9-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX940-LABEL: v_maximum_f16__nnan_src1:
@@ -523,16 +383,7 @@ define half @v_maximum_f16__nnan_src1(half %src0, half %arg1) {
 ; GFX940-NEXT:    v_mov_b32_e32 v3, 0x7e00
 ; GFX940-NEXT:    v_cmp_o_f16_e32 vcc, v0, v1
 ; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v2, v3, v2, vcc
-; GFX940-NEXT:    v_cmp_class_f16_e64 vcc, v0, 64
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc
-; GFX940-NEXT:    v_cmp_class_f16_e64 vcc, v1, 64
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v0, v0, v1, vcc
-; GFX940-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v2
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc
+; GFX940-NEXT:    v_cndmask_b32_e32 v0, v3, v2, vcc
 ; GFX940-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX10-LABEL: v_maximum_f16__nnan_src1:
@@ -541,13 +392,7 @@ define half @v_maximum_f16__nnan_src1(half %src0, half %arg1) {
 ; GFX10-NEXT:    v_add_f16_e32 v1, 1.0, v1
 ; GFX10-NEXT:    v_max_f16_e32 v2, v0, v1
 ; GFX10-NEXT:    v_cmp_o_f16_e32 vcc_lo, v0, v1
-; GFX10-NEXT:    v_cndmask_b32_e32 v2, 0x7e00, v2, vcc_lo
-; GFX10-NEXT:    v_cmp_class_f16_e64 vcc_lo, v0, 64
-; GFX10-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc_lo
-; GFX10-NEXT:    v_cmp_class_f16_e64 vcc_lo, v1, 64
-; GFX10-NEXT:    v_cndmask_b32_e32 v0, v0, v1, vcc_lo
-; GFX10-NEXT:    v_cmp_eq_f16_e32 vcc_lo, 0, v2
-; GFX10-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc_lo
+; GFX10-NEXT:    v_cndmask_b32_e32 v0, 0x7e00, v2, vcc_lo
 ; GFX10-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX11-LABEL: v_maximum_f16__nnan_src1:
@@ -557,15 +402,7 @@ define half @v_maximum_f16__nnan_src1(half %src0, half %arg1) {
 ; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_1) | instid1(VALU_DEP_2)
 ; GFX11-NEXT:    v_max_f16_e32 v2, v0, v1
 ; GFX11-NEXT:    v_cmp_o_f16_e32 vcc_lo, v0, v1
-; GFX11-NEXT:    v_cndmask_b32_e32 v2, 0x7e00, v2, vcc_lo
-; GFX11-NEXT:    v_cmp_class_f16_e64 vcc_lo, v0, 64
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(SKIP_1) | instid1(VALU_DEP_2)
-; GFX11-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc_lo
-; GFX11-NEXT:    v_cmp_class_f16_e64 vcc_lo, v1, 64
-; GFX11-NEXT:    v_cndmask_b32_e32 v0, v0, v1, vcc_lo
-; GFX11-NEXT:    v_cmp_eq_f16_e32 vcc_lo, 0, v2
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_2)
-; GFX11-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc_lo
+; GFX11-NEXT:    v_cndmask_b32_e32 v0, 0x7e00, v2, vcc_lo
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX12-LABEL: v_maximum_f16__nnan_src1:
@@ -595,13 +432,7 @@ define void @s_maximum_f16(half inreg %src0, half inreg %src1) {
 ; GFX7-NEXT:    v_cvt_f32_f16_e32 v1, v1
 ; GFX7-NEXT:    v_max_f32_e32 v3, v1, v0
 ; GFX7-NEXT:    v_cmp_o_f32_e32 vcc, v1, v0
-; GFX7-NEXT:    v_cndmask_b32_e32 v2, v2, v3, vcc
-; GFX7-NEXT:    v_cmp_class_f32_e64 vcc, v1, 64
-; GFX7-NEXT:    v_cndmask_b32_e32 v1, v2, v1, vcc
-; GFX7-NEXT:    v_cmp_class_f32_e64 vcc, v0, 64
-; GFX7-NEXT:    v_cndmask_b32_e32 v0, v1, v0, vcc
-; GFX7-NEXT:    v_cmp_eq_f32_e32 vcc, 0, v2
-; GFX7-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc
+; GFX7-NEXT:    v_cndmask_b32_e32 v0, v2, v3, vcc
 ; GFX7-NEXT:    v_cvt_f16_f32_e32 v0, v0
 ; GFX7-NEXT:    ;;#ASMSTART
 ; GFX7-NEXT:    ; use v0
@@ -615,14 +446,7 @@ define void @s_maximum_f16(half inreg %src0, half inreg %src1) {
 ; GFX8-NEXT:    v_max_f16_e32 v1, s4, v0
 ; GFX8-NEXT:    v_mov_b32_e32 v2, 0x7e00
 ; GFX8-NEXT:    v_cmp_o_f16_e32 vcc, s4, v0
-; GFX8-NEXT:    v_cndmask_b32_e32 v1, v2, v1, vcc
-; GFX8-NEXT:    v_mov_b32_e32 v2, s4
-; GFX8-NEXT:    v_cmp_class_f16_e64 vcc, s4, 64
-; GFX8-NEXT:    v_cndmask_b32_e32 v2, v1, v2, vcc
-; GFX8-NEXT:    v_cmp_class_f16_e64 vcc, s5, 64
-; GFX8-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc
-; GFX8-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v1
-; GFX8-NEXT:    v_cndmask_b32_e32 v0, v1, v0, vcc
+; GFX8-NEXT:    v_cndmask_b32_e32 v0, v2, v1, vcc
 ; GFX8-NEXT:    v_and_b32_e32 v0, 0xffff, v0
 ; GFX8-NEXT:    ;;#ASMSTART
 ; GFX8-NEXT:    ; use v0
@@ -636,14 +460,7 @@ define void @s_maximum_f16(half inreg %src0, half inreg %src1) {
 ; GFX9-NEXT:    v_max_f16_e32 v1, s4, v0
 ; GFX9-NEXT:    v_mov_b32_e32 v2, 0x7e00
 ; GFX9-NEXT:    v_cmp_o_f16_e32 vcc, s4, v0
-; GFX9-NEXT:    v_cndmask_b32_e32 v1, v2, v1, vcc
-; GFX9-NEXT:    v_mov_b32_e32 v2, s4
-; GFX9-NEXT:    v_cmp_class_f16_e64 vcc, s4, 64
-; GFX9-NEXT:    v_cndmask_b32_e32 v2, v1, v2, vcc
-; GFX9-NEXT:    v_cmp_class_f16_e64 vcc, s5, 64
-; GFX9-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc
-; GFX9-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v1
-; GFX9-NEXT:    v_cndmask_b32_e32 v0, v1, v0, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v0, v2, v1, vcc
 ; GFX9-NEXT:    v_and_b32_e32 v0, 0xffff, v0
 ; GFX9-NEXT:    ;;#ASMSTART
 ; GFX9-NEXT:    ; use v0
@@ -658,17 +475,7 @@ define void @s_maximum_f16(half inreg %src0, half inreg %src1) {
 ; GFX940-NEXT:    v_mov_b32_e32 v2, 0x7e00
 ; GFX940-NEXT:    v_cmp_o_f16_e32 vcc, s0, v0
 ; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v1, v2, v1, vcc
-; GFX940-NEXT:    v_mov_b32_e32 v2, s0
-; GFX940-NEXT:    v_cmp_class_f16_e64 vcc, s0, 64
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v2, v1, v2, vcc
-; GFX940-NEXT:    v_cmp_class_f16_e64 vcc, s1, 64
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc
-; GFX940-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v1
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v0, v1, v0, vcc
+; GFX940-NEXT:    v_cndmask_b32_e32 v0, v2, v1, vcc
 ; GFX940-NEXT:    v_and_b32_e32 v0, 0xffff, v0
 ; GFX940-NEXT:    ;;#ASMSTART
 ; GFX940-NEXT:    ; use v0
@@ -680,13 +487,7 @@ define void @s_maximum_f16(half inreg %src0, half inreg %src1) {
 ; GFX10-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX10-NEXT:    v_max_f16_e64 v0, s4, s5
 ; GFX10-NEXT:    v_cmp_o_f16_e64 vcc_lo, s4, s5
-; GFX10-NEXT:    v_cmp_class_f16_e64 s6, s4, 64
 ; GFX10-NEXT:    v_cndmask_b32_e32 v0, 0x7e00, v0, vcc_lo
-; GFX10-NEXT:    v_cndmask_b32_e64 v1, v0, s4, s6
-; GFX10-NEXT:    v_cmp_class_f16_e64 s4, s5, 64
-; GFX10-NEXT:    v_cmp_eq_f16_e32 vcc_lo, 0, v0
-; GFX10-NEXT:    v_cndmask_b32_e64 v1, v1, s5, s4
-; GFX10-NEXT:    v_cndmask_b32_e32 v0, v0, v1, vcc_lo
 ; GFX10-NEXT:    v_and_b32_e32 v0, 0xffff, v0
 ; GFX10-NEXT:    ;;#ASMSTART
 ; GFX10-NEXT:    ; use v0
@@ -698,16 +499,8 @@ define void @s_maximum_f16(half inreg %src0, half inreg %src1) {
 ; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX11-NEXT:    v_max_f16_e64 v0, s0, s1
 ; GFX11-NEXT:    v_cmp_o_f16_e64 vcc_lo, s0, s1
-; GFX11-NEXT:    v_cmp_class_f16_e64 s2, s0, 64
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_1)
-; GFX11-NEXT:    v_cndmask_b32_e32 v0, 0x7e00, v0, vcc_lo
-; GFX11-NEXT:    v_cndmask_b32_e64 v1, v0, s0, s2
-; GFX11-NEXT:    v_cmp_class_f16_e64 s0, s1, 64
-; GFX11-NEXT:    v_cmp_eq_f16_e32 vcc_lo, 0, v0
 ; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_1)
-; GFX11-NEXT:    v_cndmask_b32_e64 v1, v1, s1, s0
-; GFX11-NEXT:    v_cndmask_b32_e32 v0, v0, v1, vcc_lo
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX11-NEXT:    v_cndmask_b32_e32 v0, 0x7e00, v0, vcc_lo
 ; GFX11-NEXT:    v_and_b32_e32 v0, 0xffff, v0
 ; GFX11-NEXT:    ;;#ASMSTART
 ; GFX11-NEXT:    ; use v0
@@ -750,22 +543,10 @@ define <2 x half> @v_maximum_v2f16(<2 x half> %src0, <2 x half> %src1) {
 ; GFX7-NEXT:    v_mov_b32_e32 v5, 0x7fc00000
 ; GFX7-NEXT:    v_max_f32_e32 v4, v0, v2
 ; GFX7-NEXT:    v_cmp_o_f32_e32 vcc, v0, v2
-; GFX7-NEXT:    v_cndmask_b32_e32 v4, v5, v4, vcc
-; GFX7-NEXT:    v_cmp_class_f32_e64 vcc, v0, 64
-; GFX7-NEXT:    v_cndmask_b32_e32 v0, v4, v0, vcc
-; GFX7-NEXT:    v_cmp_class_f32_e64 vcc, v2, 64
-; GFX7-NEXT:    v_cndmask_b32_e32 v0, v0, v2, vcc
-; GFX7-NEXT:    v_cmp_eq_f32_e32 vcc, 0, v4
-; GFX7-NEXT:    v_cndmask_b32_e32 v0, v4, v0, vcc
+; GFX7-NEXT:    v_cndmask_b32_e32 v0, v5, v4, vcc
 ; GFX7-NEXT:    v_max_f32_e32 v2, v1, v3
 ; GFX7-NEXT:    v_cmp_o_f32_e32 vcc, v1, v3
-; GFX7-NEXT:    v_cndmask_b32_e32 v2, v5, v2, vcc
-; GFX7-NEXT:    v_cmp_class_f32_e64 vcc, v1, 64
-; GFX7-NEXT:    v_cndmask_b32_e32 v1, v2, v1, vcc
-; GFX7-NEXT:    v_cmp_class_f32_e64 vcc, v3, 64
-; GFX7-NEXT:    v_cndmask_b32_e32 v1, v1, v3, vcc
-; GFX7-NEXT:    v_cmp_eq_f32_e32 vcc, 0, v2
-; GFX7-NEXT:    v_cndmask_b32_e32 v1, v2, v1, vcc
+; GFX7-NEXT:    v_cndmask_b32_e32 v1, v5, v2, vcc
 ; GFX7-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX8-LABEL: v_maximum_v2f16:
@@ -805,23 +586,9 @@ define <2 x half> @v_maximum_v2f16(<2 x half> %src0, <2 x half> %src1) {
 ; GFX9-NEXT:    v_mov_b32_e32 v3, 0x7e00
 ; GFX9-NEXT:    v_cmp_o_f16_e32 vcc, v0, v1
 ; GFX9-NEXT:    v_cndmask_b32_e32 v4, v3, v2, vcc
-; GFX9-NEXT:    v_cmp_class_f16_e64 vcc, v0, 64
-; GFX9-NEXT:    v_cndmask_b32_e32 v5, v4, v0, vcc
-; GFX9-NEXT:    v_cmp_class_f16_e64 vcc, v1, 64
-; GFX9-NEXT:    v_cndmask_b32_e32 v5, v5, v1, vcc
-; GFX9-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v4
-; GFX9-NEXT:    v_lshrrev_b32_e32 v1, 16, v1
-; GFX9-NEXT:    v_lshrrev_b32_e32 v0, 16, v0
-; GFX9-NEXT:    v_cndmask_b32_e32 v4, v4, v5, vcc
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v2, 16, v2
-; GFX9-NEXT:    v_cmp_o_f16_e32 vcc, v0, v1
-; GFX9-NEXT:    v_cndmask_b32_e32 v2, v3, v2, vcc
-; GFX9-NEXT:    v_cmp_class_f16_e64 vcc, v0, 64
-; GFX9-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc
-; GFX9-NEXT:    v_cmp_class_f16_e64 vcc, v1, 64
-; GFX9-NEXT:    v_cndmask_b32_e32 v0, v0, v1, vcc
-; GFX9-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v2
-; GFX9-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc
+; GFX9-NEXT:    v_cmp_o_f16_sdwa vcc, v0, v1 src0_sel:WORD_1 src1_sel:WORD_1
+; GFX9-NEXT:    v_cndmask_b32_e32 v0, v3, v2, vcc
 ; GFX9-NEXT:    s_mov_b32 s4, 0x5040100
 ; GFX9-NEXT:    v_perm_b32 v0, v0, v4, s4
 ; GFX9-NEXT:    s_setpc_b64 s[30:31]
@@ -835,30 +602,10 @@ define <2 x half> @v_maximum_v2f16(<2 x half> %src0, <2 x half> %src1) {
 ; GFX940-NEXT:    s_mov_b32 s0, 0x5040100
 ; GFX940-NEXT:    s_nop 0
 ; GFX940-NEXT:    v_cndmask_b32_e32 v4, v3, v2, vcc
-; GFX940-NEXT:    v_cmp_class_f16_e64 vcc, v0, 64
 ; GFX940-NEXT:    v_lshrrev_b32_e32 v2, 16, v2
-; GFX940-NEXT:    s_nop 0
-; GFX940-NEXT:    v_cndmask_b32_e32 v5, v4, v0, vcc
-; GFX940-NEXT:    v_cmp_class_f16_e64 vcc, v1, 64
-; GFX940-NEXT:    v_lshrrev_b32_e32 v0, 16, v0
-; GFX940-NEXT:    s_nop 0
-; GFX940-NEXT:    v_cndmask_b32_e32 v5, v5, v1, vcc
-; GFX940-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v4
-; GFX940-NEXT:    v_lshrrev_b32_e32 v1, 16, v1
-; GFX940-NEXT:    s_nop 0
-; GFX940-NEXT:    v_cndmask_b32_e32 v4, v4, v5, vcc
-; GFX940-NEXT:    v_cmp_o_f16_e32 vcc, v0, v1
+; GFX940-NEXT:    v_cmp_o_f16_sdwa vcc, v0, v1 src0_sel:WORD_1 src1_sel:WORD_1
 ; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v2, v3, v2, vcc
-; GFX940-NEXT:    v_cmp_class_f16_e64 vcc, v0, 64
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc
-; GFX940-NEXT:    v_cmp_class_f16_e64 vcc, v1, 64
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v0, v0, v1, vcc
-; GFX940-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v2
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc
+; GFX940-NEXT:    v_cndmask_b32_e32 v0, v3, v2, vcc
 ; GFX940-NEXT:    v_perm_b32 v0, v0, v4, s0
 ; GFX940-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -866,26 +613,12 @@ define <2 x half> @v_maximum_v2f16(<2 x half> %src0, <2 x half> %src1) {
 ; GFX10:       ; %bb.0:
 ; GFX10-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX10-NEXT:    v_pk_max_f16 v2, v0, v1
-; GFX10-NEXT:    v_lshrrev_b32_e32 v3, 16, v1
-; GFX10-NEXT:    v_lshrrev_b32_e32 v4, 16, v0
 ; GFX10-NEXT:    v_cmp_o_f16_e32 vcc_lo, v0, v1
-; GFX10-NEXT:    v_lshrrev_b32_e32 v5, 16, v2
+; GFX10-NEXT:    v_lshrrev_b32_e32 v3, 16, v2
 ; GFX10-NEXT:    v_cndmask_b32_e32 v2, 0x7e00, v2, vcc_lo
-; GFX10-NEXT:    v_cmp_o_f16_e32 vcc_lo, v4, v3
-; GFX10-NEXT:    v_cndmask_b32_e32 v5, 0x7e00, v5, vcc_lo
-; GFX10-NEXT:    v_cmp_class_f16_e64 vcc_lo, v0, 64
-; GFX10-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc_lo
-; GFX10-NEXT:    v_cmp_class_f16_e64 vcc_lo, v4, 64
-; GFX10-NEXT:    v_cndmask_b32_e32 v4, v5, v4, vcc_lo
-; GFX10-NEXT:    v_cmp_class_f16_e64 vcc_lo, v1, 64
-; GFX10-NEXT:    v_cndmask_b32_e32 v0, v0, v1, vcc_lo
-; GFX10-NEXT:    v_cmp_class_f16_e64 vcc_lo, v3, 64
-; GFX10-NEXT:    v_cndmask_b32_e32 v1, v4, v3, vcc_lo
-; GFX10-NEXT:    v_cmp_eq_f16_e32 vcc_lo, 0, v2
-; GFX10-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc_lo
-; GFX10-NEXT:    v_cmp_eq_f16_e32 vcc_lo, 0, v5
-; GFX10-NEXT:    v_cndmask_b32_e32 v1, v5, v1, vcc_lo
-; GFX10-NEXT:    v_perm_b32 v0, v1, v0, 0x5040100
+; GFX10-NEXT:    v_cmp_o_f16_sdwa vcc_lo, v0, v1 src0_sel:WORD_1 src1_sel:WORD_1
+; GFX10-NEXT:    v_cndmask_b32_e32 v0, 0x7e00, v3, vcc_lo
+; GFX10-NEXT:    v_perm_b32 v0, v0, v2, 0x5040100
 ; GFX10-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX11-LABEL: v_maximum_v2f16:
@@ -897,25 +630,10 @@ define <2 x half> @v_maximum_v2f16(<2 x half> %src0, <2 x half> %src1) {
 ; GFX11-NEXT:    v_cmp_o_f16_e32 vcc_lo, v0, v1
 ; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(SKIP_1) | instid1(VALU_DEP_4)
 ; GFX11-NEXT:    v_lshrrev_b32_e32 v5, 16, v2
-; GFX11-NEXT:    v_cndmask_b32_e32 v2, 0x7e00, v2, vcc_lo
+; GFX11-NEXT:    v_cndmask_b32_e32 v0, 0x7e00, v2, vcc_lo
 ; GFX11-NEXT:    v_cmp_o_f16_e32 vcc_lo, v4, v3
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(SKIP_1) | instid1(VALU_DEP_4)
-; GFX11-NEXT:    v_cndmask_b32_e32 v5, 0x7e00, v5, vcc_lo
-; GFX11-NEXT:    v_cmp_class_f16_e64 vcc_lo, v0, 64
-; GFX11-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc_lo
-; GFX11-NEXT:    v_cmp_class_f16_e64 vcc_lo, v4, 64
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(SKIP_1) | instid1(VALU_DEP_4)
-; GFX11-NEXT:    v_cndmask_b32_e32 v4, v5, v4, vcc_lo
-; GFX11-NEXT:    v_cmp_class_f16_e64 vcc_lo, v1, 64
-; GFX11-NEXT:    v_cndmask_b32_e32 v0, v0, v1, vcc_lo
-; GFX11-NEXT:    v_cmp_class_f16_e64 vcc_lo, v3, 64
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(SKIP_1) | instid1(VALU_DEP_4)
-; GFX11-NEXT:    v_cndmask_b32_e32 v1, v4, v3, vcc_lo
-; GFX11-NEXT:    v_cmp_eq_f16_e32 vcc_lo, 0, v2
-; GFX11-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc_lo
-; GFX11-NEXT:    v_cmp_eq_f16_e32 vcc_lo, 0, v5
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(NEXT) | instid1(VALU_DEP_1)
-; GFX11-NEXT:    v_cndmask_b32_e32 v1, v5, v1, vcc_lo
+; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX11-NEXT:    v_cndmask_b32_e32 v1, 0x7e00, v5, vcc_lo
 ; GFX11-NEXT:    v_perm_b32 v0, v1, v0, 0x5040100
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -947,22 +665,10 @@ define <2 x half> @v_maximum_v2f16__nnan(<2 x half> %src0, <2 x half> %src1) {
 ; GFX7-NEXT:    v_mov_b32_e32 v5, 0x7fc00000
 ; GFX7-NEXT:    v_max_f32_e32 v4, v0, v2
 ; GFX7-NEXT:    v_cmp_o_f32_e32 vcc, v0, v2
-; GFX7-NEXT:    v_cndmask_b32_e32 v4, v5, v4, vcc
-; GFX7-NEXT:    v_cmp_class_f32_e64 vcc, v0, 64
-; GFX7-NEXT:    v_cndmask_b32_e32 v0, v4, v0, vcc
-; GFX7-NEXT:    v_cmp_class_f32_e64 vcc, v2, 64
-; GFX7-NEXT:    v_cndmask_b32_e32 v0, v0, v2, vcc
-; GFX7-NEXT:    v_cmp_eq_f32_e32 vcc, 0, v4
-; GFX7-NEXT:    v_cndmask_b32_e32 v0, v4, v0, vcc
+; GFX7-NEXT:    v_cndmask_b32_e32 v0, v5, v4, vcc
 ; GFX7-NEXT:    v_max_f32_e32 v2, v1, v3
 ; GFX7-NEXT:    v_cmp_o_f32_e32 vcc, v1, v3
-; GFX7-NEXT:    v_cndmask_b32_e32 v2, v5, v2, vcc
-; GFX7-NEXT:    v_cmp_class_f32_e64 vcc, v1, 64
-; GFX7-NEXT:    v_cndmask_b32_e32 v1, v2, v1, vcc
-; GFX7-NEXT:    v_cmp_class_f32_e64 vcc, v3, 64
-; GFX7-NEXT:    v_cndmask_b32_e32 v1, v1, v3, vcc
-; GFX7-NEXT:    v_cmp_eq_f32_e32 vcc, 0, v2
-; GFX7-NEXT:    v_cndmask_b32_e32 v1, v2, v1, vcc
+; GFX7-NEXT:    v_cndmask_b32_e32 v1, v5, v2, vcc
 ; GFX7-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX8-LABEL: v_maximum_v2f16__nnan:
@@ -993,100 +699,25 @@ define <2 x half> @v_maximum_v2f16__nnan(<2 x half> %src0, <2 x half> %src1) {
 ; GFX9-LABEL: v_maximum_v2f16__nnan:
 ; GFX9:       ; %bb.0:
 ; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX9-NEXT:    v_lshrrev_b32_e32 v2, 16, v0
-; GFX9-NEXT:    v_pk_max_f16 v3, v0, v1
-; GFX9-NEXT:    v_lshrrev_b32_e32 v4, 16, v3
-; GFX9-NEXT:    v_cmp_class_f16_e64 vcc, v2, 64
-; GFX9-NEXT:    v_lshrrev_b32_e32 v5, 16, v1
-; GFX9-NEXT:    v_cndmask_b32_e32 v2, v4, v2, vcc
-; GFX9-NEXT:    v_cmp_class_f16_e64 vcc, v5, 64
-; GFX9-NEXT:    v_cndmask_b32_e32 v2, v2, v5, vcc
-; GFX9-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v4
-; GFX9-NEXT:    v_cndmask_b32_e32 v2, v4, v2, vcc
-; GFX9-NEXT:    v_cmp_class_f16_e64 vcc, v0, 64
-; GFX9-NEXT:    v_cndmask_b32_e32 v0, v3, v0, vcc
-; GFX9-NEXT:    v_cmp_class_f16_e64 vcc, v1, 64
-; GFX9-NEXT:    v_cndmask_b32_e32 v0, v0, v1, vcc
-; GFX9-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v3
-; GFX9-NEXT:    v_cndmask_b32_e32 v0, v3, v0, vcc
-; GFX9-NEXT:    s_mov_b32 s4, 0x5040100
-; GFX9-NEXT:    v_perm_b32 v0, v2, v0, s4
+; GFX9-NEXT:    v_pk_max_f16 v0, v0, v1
 ; GFX9-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX940-LABEL: v_maximum_v2f16__nnan:
 ; GFX940:       ; %bb.0:
 ; GFX940-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX940-NEXT:    v_lshrrev_b32_e32 v2, 16, v0
-; GFX940-NEXT:    v_pk_max_f16 v3, v0, v1
-; GFX940-NEXT:    v_cmp_class_f16_e64 vcc, v2, 64
-; GFX940-NEXT:    v_lshrrev_b32_e32 v4, 16, v3
-; GFX940-NEXT:    v_lshrrev_b32_e32 v5, 16, v1
-; GFX940-NEXT:    v_cndmask_b32_e32 v2, v4, v2, vcc
-; GFX940-NEXT:    v_cmp_class_f16_e64 vcc, v5, 64
-; GFX940-NEXT:    s_mov_b32 s0, 0x5040100
-; GFX940-NEXT:    s_nop 0
-; GFX940-NEXT:    v_cndmask_b32_e32 v2, v2, v5, vcc
-; GFX940-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v4
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v2, v4, v2, vcc
-; GFX940-NEXT:    v_cmp_class_f16_e64 vcc, v0, 64
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v0, v3, v0, vcc
-; GFX940-NEXT:    v_cmp_class_f16_e64 vcc, v1, 64
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v0, v0, v1, vcc
-; GFX940-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v3
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v0, v3, v0, vcc
-; GFX940-NEXT:    v_perm_b32 v0, v2, v0, s0
+; GFX940-NEXT:    v_pk_max_f16 v0, v0, v1
 ; GFX940-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX10-LABEL: v_maximum_v2f16__nnan:
 ; GFX10:       ; %bb.0:
 ; GFX10-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX10-NEXT:    v_pk_max_f16 v2, v0, v1
-; GFX10-NEXT:    v_lshrrev_b32_e32 v3, 16, v0
-; GFX10-NEXT:    v_lshrrev_b32_e32 v5, 16, v1
-; GFX10-NEXT:    v_lshrrev_b32_e32 v4, 16, v2
-; GFX10-NEXT:    v_cmp_class_f16_e64 vcc_lo, v3, 64
-; GFX10-NEXT:    v_cndmask_b32_e32 v3, v4, v3, vcc_lo
-; GFX10-NEXT:    v_cmp_class_f16_e64 vcc_lo, v0, 64
-; GFX10-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc_lo
-; GFX10-NEXT:    v_cmp_class_f16_e64 vcc_lo, v5, 64
-; GFX10-NEXT:    v_cndmask_b32_e32 v3, v3, v5, vcc_lo
-; GFX10-NEXT:    v_cmp_class_f16_e64 vcc_lo, v1, 64
-; GFX10-NEXT:    v_cndmask_b32_e32 v0, v0, v1, vcc_lo
-; GFX10-NEXT:    v_cmp_eq_f16_e32 vcc_lo, 0, v4
-; GFX10-NEXT:    v_cndmask_b32_e32 v1, v4, v3, vcc_lo
-; GFX10-NEXT:    v_cmp_eq_f16_e32 vcc_lo, 0, v2
-; GFX10-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc_lo
-; GFX10-NEXT:    v_perm_b32 v0, v1, v0, 0x5040100
+; GFX10-NEXT:    v_pk_max_f16 v0, v0, v1
 ; GFX10-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX11-LABEL: v_maximum_v2f16__nnan:
 ; GFX11:       ; %bb.0:
 ; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX11-NEXT:    v_pk_max_f16 v2, v0, v1
-; GFX11-NEXT:    v_lshrrev_b32_e32 v3, 16, v0
-; GFX11-NEXT:    v_lshrrev_b32_e32 v5, 16, v1
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_3)
-; GFX11-NEXT:    v_lshrrev_b32_e32 v4, 16, v2
-; GFX11-NEXT:    v_cmp_class_f16_e64 vcc_lo, v3, 64
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(SKIP_3) | instid1(VALU_DEP_4)
-; GFX11-NEXT:    v_cndmask_b32_e32 v3, v4, v3, vcc_lo
-; GFX11-NEXT:    v_cmp_class_f16_e64 vcc_lo, v0, 64
-; GFX11-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc_lo
-; GFX11-NEXT:    v_cmp_class_f16_e64 vcc_lo, v5, 64
-; GFX11-NEXT:    v_cndmask_b32_e32 v3, v3, v5, vcc_lo
-; GFX11-NEXT:    v_cmp_class_f16_e64 vcc_lo, v1, 64
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(SKIP_1) | instid1(VALU_DEP_4)
-; GFX11-NEXT:    v_cndmask_b32_e32 v0, v0, v1, vcc_lo
-; GFX11-NEXT:    v_cmp_eq_f16_e32 vcc_lo, 0, v4
-; GFX11-NEXT:    v_cndmask_b32_e32 v1, v4, v3, vcc_lo
-; GFX11-NEXT:    v_cmp_eq_f16_e32 vcc_lo, 0, v2
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(NEXT) | instid1(VALU_DEP_1)
-; GFX11-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc_lo
-; GFX11-NEXT:    v_perm_b32 v0, v1, v0, 0x5040100
+; GFX11-NEXT:    v_pk_max_f16 v0, v0, v1
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX12-LABEL: v_maximum_v2f16__nnan:
@@ -1117,22 +748,10 @@ define <2 x half> @v_maximum_v2f16__nsz(<2 x half> %src0, <2 x half> %src1) {
 ; GFX7-NEXT:    v_mov_b32_e32 v5, 0x7fc00000
 ; GFX7-NEXT:    v_max_f32_e32 v4, v0, v2
 ; GFX7-NEXT:    v_cmp_o_f32_e32 vcc, v0, v2
-; GFX7-NEXT:    v_cndmask_b32_e32 v4, v5, v4, vcc
-; GFX7-NEXT:    v_cmp_class_f32_e64 vcc, v0, 64
-; GFX7-NEXT:    v_cndmask_b32_e32 v0, v4, v0, vcc
-; GFX7-NEXT:    v_cmp_class_f32_e64 vcc, v2, 64
-; GFX7-NEXT:    v_cndmask_b32_e32 v0, v0, v2, vcc
-; GFX7-NEXT:    v_cmp_eq_f32_e32 vcc, 0, v4
-; GFX7-NEXT:    v_cndmask_b32_e32 v0, v4, v0, vcc
+; GFX7-NEXT:    v_cndmask_b32_e32 v0, v5, v4, vcc
 ; GFX7-NEXT:    v_max_f32_e32 v2, v1, v3
 ; GFX7-NEXT:    v_cmp_o_f32_e32 vcc, v1, v3
-; GFX7-NEXT:    v_cndmask_b32_e32 v2, v5, v2, vcc
-; GFX7-NEXT:    v_cmp_class_f32_e64 vcc, v1, 64
-; GFX7-NEXT:    v_cndmask_b32_e32 v1, v2, v1, vcc
-; GFX7-NEXT:    v_cmp_class_f32_e64 vcc, v3, 64
-; GFX7-NEXT:    v_cndmask_b32_e32 v1, v1, v3, vcc
-; GFX7-NEXT:    v_cmp_eq_f32_e32 vcc, 0, v2
-; GFX7-NEXT:    v_cndmask_b32_e32 v1, v2, v1, vcc
+; GFX7-NEXT:    v_cndmask_b32_e32 v1, v5, v2, vcc
 ; GFX7-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX8-LABEL: v_maximum_v2f16__nsz:
@@ -1239,22 +858,10 @@ define <2 x half> @v_maximum_v2f16__nnan_nsz(<2 x half> %src0, <2 x half> %src1)
 ; GFX7-NEXT:    v_mov_b32_e32 v5, 0x7fc00000
 ; GFX7-NEXT:    v_max_f32_e32 v4, v0, v2
 ; GFX7-NEXT:    v_cmp_o_f32_e32 vcc, v0, v2
-; GFX7-NEXT:    v_cndmask_b32_e32 v4, v5, v4, vcc
-; GFX7-NEXT:    v_cmp_class_f32_e64 vcc, v0, 64
-; GFX7-NEXT:    v_cndmask_b32_e32 v0, v4, v0, vcc
-; GFX7-NEXT:    v_cmp_class_f32_e64 vcc, v2, 64
-; GFX7-NEXT:    v_cndmask_b32_e32 v0, v0, v2, vcc
-; GFX7-NEXT:    v_cmp_eq_f32_e32 vcc, 0, v4
-; GFX7-NEXT:    v_cndmask_b32_e32 v0, v4, v0, vcc
+; GFX7-NEXT:    v_cndmask_b32_e32 v0, v5, v4, vcc
 ; GFX7-NEXT:    v_max_f32_e32 v2, v1, v3
 ; GFX7-NEXT:    v_cmp_o_f32_e32 vcc, v1, v3
-; GFX7-NEXT:    v_cndmask_b32_e32 v2, v5, v2, vcc
-; GFX7-NEXT:    v_cmp_class_f32_e64 vcc, v1, 64
-; GFX7-NEXT:    v_cndmask_b32_e32 v1, v2, v1, vcc
-; GFX7-NEXT:    v_cmp_class_f32_e64 vcc, v3, 64
-; GFX7-NEXT:    v_cndmask_b32_e32 v1, v1, v3, vcc
-; GFX7-NEXT:    v_cmp_eq_f32_e32 vcc, 0, v2
-; GFX7-NEXT:    v_cndmask_b32_e32 v1, v2, v1, vcc
+; GFX7-NEXT:    v_cndmask_b32_e32 v1, v5, v2, vcc
 ; GFX7-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX8-LABEL: v_maximum_v2f16__nnan_nsz:
@@ -1322,23 +929,11 @@ define void @s_maximum_v2f16(<2 x half> inreg %src0, <2 x half> inreg %src1) {
 ; GFX7-NEXT:    v_mov_b32_e32 v5, 0x7fc00000
 ; GFX7-NEXT:    v_max_f32_e32 v4, v1, v0
 ; GFX7-NEXT:    v_cmp_o_f32_e32 vcc, v1, v0
-; GFX7-NEXT:    v_cndmask_b32_e32 v4, v5, v4, vcc
-; GFX7-NEXT:    v_cmp_class_f32_e64 vcc, v1, 64
-; GFX7-NEXT:    v_cndmask_b32_e32 v1, v4, v1, vcc
-; GFX7-NEXT:    v_cmp_class_f32_e64 vcc, v0, 64
-; GFX7-NEXT:    v_cndmask_b32_e32 v0, v1, v0, vcc
-; GFX7-NEXT:    v_cmp_eq_f32_e32 vcc, 0, v4
-; GFX7-NEXT:    v_cndmask_b32_e32 v0, v4, v0, vcc
+; GFX7-NEXT:    v_cndmask_b32_e32 v0, v5, v4, vcc
 ; GFX7-NEXT:    v_max_f32_e32 v1, v3, v2
 ; GFX7-NEXT:    v_cmp_o_f32_e32 vcc, v3, v2
-; GFX7-NEXT:    v_cndmask_b32_e32 v1, v5, v1, vcc
-; GFX7-NEXT:    v_cmp_class_f32_e64 vcc, v3, 64
-; GFX7-NEXT:    v_cndmask_b32_e32 v3, v1, v3, vcc
-; GFX7-NEXT:    v_cmp_class_f32_e64 vcc, v2, 64
-; GFX7-NEXT:    v_cndmask_b32_e32 v2, v3, v2, vcc
-; GFX7-NEXT:    v_cmp_eq_f32_e32 vcc, 0, v1
 ; GFX7-NEXT:    v_cvt_f16_f32_e32 v0, v0
-; GFX7-NEXT:    v_cndmask_b32_e32 v1, v1, v2, vcc
+; GFX7-NEXT:    v_cndmask_b32_e32 v1, v5, v1, vcc
 ; GFX7-NEXT:    v_cvt_f16_f32_e32 v1, v1
 ; GFX7-NEXT:    v_lshlrev_b32_e32 v0, 16, v0
 ; GFX7-NEXT:    v_or_b32_e32 v0, v1, v0
@@ -1389,30 +984,16 @@ define void @s_maximum_v2f16(<2 x half> inreg %src0, <2 x half> inreg %src1) {
 ; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX9-NEXT:    v_mov_b32_e32 v0, s5
 ; GFX9-NEXT:    v_mov_b32_e32 v1, s5
+; GFX9-NEXT:    s_lshr_b32 s5, s5, 16
 ; GFX9-NEXT:    v_pk_max_f16 v1, s4, v1
 ; GFX9-NEXT:    v_mov_b32_e32 v2, 0x7e00
 ; GFX9-NEXT:    v_cmp_o_f16_e32 vcc, s4, v0
-; GFX9-NEXT:    v_cndmask_b32_e32 v3, v2, v1, vcc
-; GFX9-NEXT:    v_mov_b32_e32 v4, s4
-; GFX9-NEXT:    v_cmp_class_f16_e64 vcc, s4, 64
-; GFX9-NEXT:    v_cndmask_b32_e32 v4, v3, v4, vcc
-; GFX9-NEXT:    v_cmp_class_f16_e64 vcc, s5, 64
-; GFX9-NEXT:    v_cndmask_b32_e32 v0, v4, v0, vcc
-; GFX9-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v3
-; GFX9-NEXT:    s_lshr_b32 s5, s5, 16
-; GFX9-NEXT:    v_cndmask_b32_e32 v0, v3, v0, vcc
 ; GFX9-NEXT:    s_lshr_b32 s4, s4, 16
 ; GFX9-NEXT:    v_mov_b32_e32 v3, s5
+; GFX9-NEXT:    v_cndmask_b32_e32 v0, v2, v1, vcc
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v1, 16, v1
 ; GFX9-NEXT:    v_cmp_o_f16_e32 vcc, s4, v3
 ; GFX9-NEXT:    v_cndmask_b32_e32 v1, v2, v1, vcc
-; GFX9-NEXT:    v_mov_b32_e32 v2, s4
-; GFX9-NEXT:    v_cmp_class_f16_e64 vcc, s4, 64
-; GFX9-NEXT:    v_cndmask_b32_e32 v2, v1, v2, vcc
-; GFX9-NEXT:    v_cmp_class_f16_e64 vcc, s5, 64
-; GFX9-NEXT:    v_cndmask_b32_e32 v2, v2, v3, vcc
-; GFX9-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v1
-; GFX9-NEXT:    v_cndmask_b32_e32 v1, v1, v2, vcc
 ; GFX9-NEXT:    v_and_b32_e32 v0, 0xffff, v0
 ; GFX9-NEXT:    v_lshl_or_b32 v0, v1, 16, v0
 ; GFX9-NEXT:    ;;#ASMSTART
@@ -1425,38 +1006,18 @@ define void @s_maximum_v2f16(<2 x half> inreg %src0, <2 x half> inreg %src1) {
 ; GFX940-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX940-NEXT:    v_mov_b32_e32 v0, s1
 ; GFX940-NEXT:    v_mov_b32_e32 v1, s1
+; GFX940-NEXT:    s_lshr_b32 s1, s1, 16
 ; GFX940-NEXT:    v_pk_max_f16 v1, s0, v1
 ; GFX940-NEXT:    v_mov_b32_e32 v2, 0x7e00
 ; GFX940-NEXT:    v_cmp_o_f16_e32 vcc, s0, v0
-; GFX940-NEXT:    v_mov_b32_e32 v4, s0
-; GFX940-NEXT:    s_nop 0
-; GFX940-NEXT:    v_cndmask_b32_e32 v3, v2, v1, vcc
-; GFX940-NEXT:    v_cmp_class_f16_e64 vcc, s0, 64
 ; GFX940-NEXT:    s_lshr_b32 s0, s0, 16
-; GFX940-NEXT:    v_lshrrev_b32_e32 v1, 16, v1
-; GFX940-NEXT:    v_cndmask_b32_e32 v4, v3, v4, vcc
-; GFX940-NEXT:    v_cmp_class_f16_e64 vcc, s1, 64
-; GFX940-NEXT:    s_lshr_b32 s1, s1, 16
-; GFX940-NEXT:    s_nop 0
-; GFX940-NEXT:    v_cndmask_b32_e32 v0, v4, v0, vcc
-; GFX940-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v3
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v0, v3, v0, vcc
 ; GFX940-NEXT:    v_mov_b32_e32 v3, s1
+; GFX940-NEXT:    v_cndmask_b32_e32 v0, v2, v1, vcc
+; GFX940-NEXT:    v_lshrrev_b32_e32 v1, 16, v1
 ; GFX940-NEXT:    v_cmp_o_f16_e32 vcc, s0, v3
 ; GFX940-NEXT:    v_and_b32_e32 v0, 0xffff, v0
 ; GFX940-NEXT:    s_nop 0
 ; GFX940-NEXT:    v_cndmask_b32_e32 v1, v2, v1, vcc
-; GFX940-NEXT:    v_mov_b32_e32 v2, s0
-; GFX940-NEXT:    v_cmp_class_f16_e64 vcc, s0, 64
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v2, v1, v2, vcc
-; GFX940-NEXT:    v_cmp_class_f16_e64 vcc, s1, 64
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v2, v2, v3, vcc
-; GFX940-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v1
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v1, v1, v2, vcc
 ; GFX940-NEXT:    v_lshl_or_b32 v0, v1, 16, v0
 ; GFX940-NEXT:    ;;#ASMSTART
 ; GFX940-NEXT:    ; use v0
@@ -1469,24 +1030,12 @@ define void @s_maximum_v2f16(<2 x half> inreg %src0, <2 x half> inreg %src1) {
 ; GFX10-NEXT:    v_pk_max_f16 v0, s4, s5
 ; GFX10-NEXT:    v_cmp_o_f16_e64 vcc_lo, s4, s5
 ; GFX10-NEXT:    s_lshr_b32 s6, s5, 16
-; GFX10-NEXT:    s_lshr_b32 s7, s4, 16
-; GFX10-NEXT:    v_cmp_class_f16_e64 s8, s4, 64
+; GFX10-NEXT:    s_lshr_b32 s4, s4, 16
 ; GFX10-NEXT:    v_lshrrev_b32_e32 v1, 16, v0
 ; GFX10-NEXT:    v_cndmask_b32_e32 v0, 0x7e00, v0, vcc_lo
-; GFX10-NEXT:    v_cmp_o_f16_e64 vcc_lo, s7, s6
-; GFX10-NEXT:    v_cndmask_b32_e64 v2, v0, s4, s8
-; GFX10-NEXT:    v_cndmask_b32_e32 v1, 0x7e00, v1, vcc_lo
-; GFX10-NEXT:    v_cmp_class_f16_e64 s4, s7, 64
-; GFX10-NEXT:    v_cmp_eq_f16_e32 vcc_lo, 0, v0
-; GFX10-NEXT:    v_cndmask_b32_e64 v3, v1, s7, s4
-; GFX10-NEXT:    v_cmp_class_f16_e64 s4, s5, 64
-; GFX10-NEXT:    v_cndmask_b32_e64 v2, v2, s5, s4
-; GFX10-NEXT:    v_cmp_class_f16_e64 s4, s6, 64
-; GFX10-NEXT:    v_cndmask_b32_e32 v0, v0, v2, vcc_lo
-; GFX10-NEXT:    v_cndmask_b32_e64 v3, v3, s6, s4
-; GFX10-NEXT:    v_cmp_eq_f16_e32 vcc_lo, 0, v1
+; GFX10-NEXT:    v_cmp_o_f16_e64 vcc_lo, s4, s6
 ; GFX10-NEXT:    v_and_b32_e32 v0, 0xffff, v0
-; GFX10-NEXT:    v_cndmask_b32_e32 v1, v1, v3, vcc_lo
+; GFX10-NEXT:    v_cndmask_b32_e32 v1, 0x7e00, v1, vcc_lo
 ; GFX10-NEXT:    v_lshl_or_b32 v0, v1, 16, v0
 ; GFX10-NEXT:    ;;#ASMSTART
 ; GFX10-NEXT:    ; use v0
@@ -1499,27 +1048,14 @@ define void @s_maximum_v2f16(<2 x half> inreg %src0, <2 x half> inreg %src1) {
 ; GFX11-NEXT:    v_pk_max_f16 v0, s0, s1
 ; GFX11-NEXT:    v_cmp_o_f16_e64 vcc_lo, s0, s1
 ; GFX11-NEXT:    s_lshr_b32 s2, s1, 16
-; GFX11-NEXT:    s_lshr_b32 s3, s0, 16
-; GFX11-NEXT:    v_cmp_class_f16_e64 s4, s0, 64
+; GFX11-NEXT:    s_lshr_b32 s0, s0, 16
+; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(SKIP_2) | instid1(VALU_DEP_2)
 ; GFX11-NEXT:    v_lshrrev_b32_e32 v1, 16, v0
 ; GFX11-NEXT:    v_cndmask_b32_e32 v0, 0x7e00, v0, vcc_lo
-; GFX11-NEXT:    v_cmp_o_f16_e64 vcc_lo, s3, s2
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_4)
-; GFX11-NEXT:    v_cndmask_b32_e64 v2, v0, s0, s4
+; GFX11-NEXT:    v_cmp_o_f16_e64 vcc_lo, s0, s2
+; GFX11-NEXT:    v_and_b32_e32 v0, 0xffff, v0
+; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(NEXT) | instid1(VALU_DEP_1)
 ; GFX11-NEXT:    v_cndmask_b32_e32 v1, 0x7e00, v1, vcc_lo
-; GFX11-NEXT:    v_cmp_class_f16_e64 s0, s3, 64
-; GFX11-NEXT:    v_cmp_eq_f16_e32 vcc_lo, 0, v0
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(SKIP_1) | instid1(VALU_DEP_1)
-; GFX11-NEXT:    v_cndmask_b32_e64 v3, v1, s3, s0
-; GFX11-NEXT:    v_cmp_class_f16_e64 s0, s1, 64
-; GFX11-NEXT:    v_cndmask_b32_e64 v2, v2, s1, s0
-; GFX11-NEXT:    v_cmp_class_f16_e64 s0, s2, 64
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_3)
-; GFX11-NEXT:    v_cndmask_b32_e64 v3, v3, s2, s0
-; GFX11-NEXT:    v_cndmask_b32_e32 v0, v0, v2, vcc_lo
-; GFX11-NEXT:    v_cmp_eq_f16_e32 vcc_lo, 0, v1
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_1)
-; GFX11-NEXT:    v_dual_cndmask_b32 v1, v1, v3 :: v_dual_and_b32 v0, 0xffff, v0
 ; GFX11-NEXT:    v_lshl_or_b32 v0, v1, 16, v0
 ; GFX11-NEXT:    ;;#ASMSTART
 ; GFX11-NEXT:    ; use v0
@@ -1552,42 +1088,24 @@ define <3 x half> @v_maximum_v3f16(<3 x half> %src0, <3 x half> %src1) {
 ; GFX7-NEXT:    v_cvt_f16_f32_e32 v0, v0
 ; GFX7-NEXT:    v_cvt_f16_f32_e32 v4, v4
 ; GFX7-NEXT:    v_cvt_f16_f32_e32 v1, v1
-; GFX7-NEXT:    v_cvt_f32_f16_e32 v3, v3
-; GFX7-NEXT:    v_cvt_f32_f16_e32 v0, v0
 ; GFX7-NEXT:    v_cvt_f16_f32_e32 v5, v5
 ; GFX7-NEXT:    v_cvt_f16_f32_e32 v2, v2
+; GFX7-NEXT:    v_cvt_f32_f16_e32 v3, v3
+; GFX7-NEXT:    v_cvt_f32_f16_e32 v0, v0
 ; GFX7-NEXT:    v_cvt_f32_f16_e32 v4, v4
 ; GFX7-NEXT:    v_cvt_f32_f16_e32 v1, v1
+; GFX7-NEXT:    v_cvt_f32_f16_e32 v5, v5
+; GFX7-NEXT:    v_cvt_f32_f16_e32 v2, v2
 ; GFX7-NEXT:    v_max_f32_e32 v6, v0, v3
 ; GFX7-NEXT:    v_mov_b32_e32 v7, 0x7fc00000
 ; GFX7-NEXT:    v_cmp_o_f32_e32 vcc, v0, v3
-; GFX7-NEXT:    v_cndmask_b32_e32 v6, v7, v6, vcc
-; GFX7-NEXT:    v_cmp_class_f32_e64 vcc, v0, 64
-; GFX7-NEXT:    v_cndmask_b32_e32 v0, v6, v0, vcc
-; GFX7-NEXT:    v_cmp_class_f32_e64 vcc, v3, 64
-; GFX7-NEXT:    v_cndmask_b32_e32 v0, v0, v3, vcc
-; GFX7-NEXT:    v_cmp_eq_f32_e32 vcc, 0, v6
-; GFX7-NEXT:    v_cvt_f32_f16_e32 v5, v5
-; GFX7-NEXT:    v_cvt_f32_f16_e32 v2, v2
-; GFX7-NEXT:    v_cndmask_b32_e32 v0, v6, v0, vcc
+; GFX7-NEXT:    v_cndmask_b32_e32 v0, v7, v6, vcc
 ; GFX7-NEXT:    v_max_f32_e32 v3, v1, v4
 ; GFX7-NEXT:    v_cmp_o_f32_e32 vcc, v1, v4
-; GFX7-NEXT:    v_cndmask_b32_e32 v3, v7, v3, vcc
-; GFX7-NEXT:    v_cmp_class_f32_e64 vcc, v1, 64
-; GFX7-NEXT:    v_cndmask_b32_e32 v1, v3, v1, vcc
-; GFX7-NEXT:    v_cmp_class_f32_e64 vcc, v4, 64
-; GFX7-NEXT:    v_cndmask_b32_e32 v1, v1, v4, vcc
-; GFX7-NEXT:    v_cmp_eq_f32_e32 vcc, 0, v3
-; GFX7-NEXT:    v_cndmask_b32_e32 v1, v3, v1, vcc
+; GFX7-NEXT:    v_cndmask_b32_e32 v1, v7, v3, vcc
 ; GFX7-NEXT:    v_max_f32_e32 v3, v2, v5
 ; GFX7-NEXT:    v_cmp_o_f32_e32 vcc, v2, v5
-; GFX7-NEXT:    v_cndmask_b32_e32 v3, v7, v3, vcc
-; GFX7-NEXT:    v_cmp_class_f32_e64 vcc, v2, 64
-; GFX7-NEXT:    v_cndmask_b32_e32 v2, v3, v2, vcc
-; GFX7-NEXT:    v_cmp_class_f32_e64 vcc, v5, 64
-; GFX7-NEXT:    v_cndmask_b32_e32 v2, v2, v5, vcc
-; GFX7-NEXT:    v_cmp_eq_f32_e32 vcc, 0, v3
-; GFX7-NEXT:    v_cndmask_b32_e32 v2, v3, v2, vcc
+; GFX7-NEXT:    v_cndmask_b32_e32 v2, v7, v3, vcc
 ; GFX7-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX8-LABEL: v_maximum_v3f16:
@@ -1598,31 +1116,13 @@ define <3 x half> @v_maximum_v3f16(<3 x half> %src0, <3 x half> %src1) {
 ; GFX8-NEXT:    v_max_f16_e32 v6, v5, v4
 ; GFX8-NEXT:    v_mov_b32_e32 v7, 0x7e00
 ; GFX8-NEXT:    v_cmp_o_f16_e32 vcc, v5, v4
-; GFX8-NEXT:    v_cndmask_b32_e32 v6, v7, v6, vcc
-; GFX8-NEXT:    v_cmp_class_f16_e64 vcc, v5, 64
-; GFX8-NEXT:    v_cndmask_b32_e32 v5, v6, v5, vcc
-; GFX8-NEXT:    v_cmp_class_f16_e64 vcc, v4, 64
-; GFX8-NEXT:    v_cndmask_b32_e32 v4, v5, v4, vcc
-; GFX8-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v6
-; GFX8-NEXT:    v_cndmask_b32_e32 v4, v6, v4, vcc
+; GFX8-NEXT:    v_cndmask_b32_e32 v4, v7, v6, vcc
 ; GFX8-NEXT:    v_max_f16_e32 v5, v1, v3
 ; GFX8-NEXT:    v_cmp_o_f16_e32 vcc, v1, v3
-; GFX8-NEXT:    v_cndmask_b32_e32 v5, v7, v5, vcc
-; GFX8-NEXT:    v_cmp_class_f16_e64 vcc, v1, 64
-; GFX8-NEXT:    v_cndmask_b32_e32 v1, v5, v1, vcc
-; GFX8-NEXT:    v_cmp_class_f16_e64 vcc, v3, 64
-; GFX8-NEXT:    v_cndmask_b32_e32 v1, v1, v3, vcc
-; GFX8-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v5
-; GFX8-NEXT:    v_cndmask_b32_e32 v1, v5, v1, vcc
+; GFX8-NEXT:    v_cndmask_b32_e32 v1, v7, v5, vcc
 ; GFX8-NEXT:    v_max_f16_e32 v3, v0, v2
 ; GFX8-NEXT:    v_cmp_o_f16_e32 vcc, v0, v2
-; GFX8-NEXT:    v_cndmask_b32_e32 v3, v7, v3, vcc
-; GFX8-NEXT:    v_cmp_class_f16_e64 vcc, v0, 64
-; GFX8-NEXT:    v_cndmask_b32_e32 v0, v3, v0, vcc
-; GFX8-NEXT:    v_cmp_class_f16_e64 vcc, v2, 64
-; GFX8-NEXT:    v_cndmask_b32_e32 v0, v0, v2, vcc
-; GFX8-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v3
-; GFX8-NEXT:    v_cndmask_b32_e32 v0, v3, v0, vcc
+; GFX8-NEXT:    v_cndmask_b32_e32 v0, v7, v3, vcc
 ; GFX8-NEXT:    v_lshlrev_b32_e32 v2, 16, v4
 ; GFX8-NEXT:    v_or_b32_sdwa v0, v0, v2 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
 ; GFX8-NEXT:    s_setpc_b64 s[30:31]
@@ -1633,33 +1133,13 @@ define <3 x half> @v_maximum_v3f16(<3 x half> %src0, <3 x half> %src1) {
 ; GFX9-NEXT:    v_pk_max_f16 v4, v1, v3
 ; GFX9-NEXT:    v_mov_b32_e32 v5, 0x7e00
 ; GFX9-NEXT:    v_cmp_o_f16_e32 vcc, v1, v3
-; GFX9-NEXT:    v_cndmask_b32_e32 v4, v5, v4, vcc
-; GFX9-NEXT:    v_cmp_class_f16_e64 vcc, v1, 64
-; GFX9-NEXT:    v_cndmask_b32_e32 v1, v4, v1, vcc
-; GFX9-NEXT:    v_cmp_class_f16_e64 vcc, v3, 64
-; GFX9-NEXT:    v_cndmask_b32_e32 v1, v1, v3, vcc
-; GFX9-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v4
-; GFX9-NEXT:    v_cndmask_b32_e32 v1, v4, v1, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v1, v5, v4, vcc
 ; GFX9-NEXT:    v_pk_max_f16 v3, v0, v2
 ; GFX9-NEXT:    v_cmp_o_f16_e32 vcc, v0, v2
 ; GFX9-NEXT:    v_cndmask_b32_e32 v4, v5, v3, vcc
-; GFX9-NEXT:    v_cmp_class_f16_e64 vcc, v0, 64
-; GFX9-NEXT:    v_cndmask_b32_e32 v6, v4, v0, vcc
-; GFX9-NEXT:    v_cmp_class_f16_e64 vcc, v2, 64
-; GFX9-NEXT:    v_cndmask_b32_e32 v6, v6, v2, vcc
-; GFX9-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v4
-; GFX9-NEXT:    v_lshrrev_b32_e32 v2, 16, v2
-; GFX9-NEXT:    v_lshrrev_b32_e32 v0, 16, v0
-; GFX9-NEXT:    v_cndmask_b32_e32 v4, v4, v6, vcc
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v3, 16, v3
-; GFX9-NEXT:    v_cmp_o_f16_e32 vcc, v0, v2
-; GFX9-NEXT:    v_cndmask_b32_e32 v3, v5, v3, vcc
-; GFX9-NEXT:    v_cmp_class_f16_e64 vcc, v0, 64
-; GFX9-NEXT:    v_cndmask_b32_e32 v0, v3, v0, vcc
-; GFX9-NEXT:    v_cmp_class_f16_e64 vcc, v2, 64
-; GFX9-NEXT:    v_cndmask_b32_e32 v0, v0, v2, vcc
-; GFX9-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v3
-; GFX9-NEXT:    v_cndmask_b32_e32 v0, v3, v0, vcc
+; GFX9-NEXT:    v_cmp_o_f16_sdwa vcc, v0, v2 src0_sel:WORD_1 src1_sel:WORD_1
+; GFX9-NEXT:    v_cndmask_b32_e32 v0, v5, v3, vcc
 ; GFX9-NEXT:    s_mov_b32 s4, 0x5040100
 ; GFX9-NEXT:    v_perm_b32 v0, v0, v4, s4
 ; GFX9-NEXT:    s_setpc_b64 s[30:31]
@@ -1670,46 +1150,16 @@ define <3 x half> @v_maximum_v3f16(<3 x half> %src0, <3 x half> %src1) {
 ; GFX940-NEXT:    v_pk_max_f16 v4, v1, v3
 ; GFX940-NEXT:    v_mov_b32_e32 v5, 0x7e00
 ; GFX940-NEXT:    v_cmp_o_f16_e32 vcc, v1, v3
-; GFX940-NEXT:    s_mov_b32 s0, 0x5040100
-; GFX940-NEXT:    s_nop 0
-; GFX940-NEXT:    v_cndmask_b32_e32 v4, v5, v4, vcc
-; GFX940-NEXT:    v_cmp_class_f16_e64 vcc, v1, 64
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v1, v4, v1, vcc
-; GFX940-NEXT:    v_cmp_class_f16_e64 vcc, v3, 64
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v1, v1, v3, vcc
-; GFX940-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v4
 ; GFX940-NEXT:    v_pk_max_f16 v3, v0, v2
-; GFX940-NEXT:    s_nop 0
-; GFX940-NEXT:    v_cndmask_b32_e32 v1, v4, v1, vcc
+; GFX940-NEXT:    s_mov_b32 s0, 0x5040100
+; GFX940-NEXT:    v_cndmask_b32_e32 v1, v5, v4, vcc
 ; GFX940-NEXT:    v_cmp_o_f16_e32 vcc, v0, v2
 ; GFX940-NEXT:    s_nop 1
 ; GFX940-NEXT:    v_cndmask_b32_e32 v4, v5, v3, vcc
-; GFX940-NEXT:    v_cmp_class_f16_e64 vcc, v0, 64
 ; GFX940-NEXT:    v_lshrrev_b32_e32 v3, 16, v3
-; GFX940-NEXT:    s_nop 0
-; GFX940-NEXT:    v_cndmask_b32_e32 v6, v4, v0, vcc
-; GFX940-NEXT:    v_cmp_class_f16_e64 vcc, v2, 64
-; GFX940-NEXT:    v_lshrrev_b32_e32 v0, 16, v0
-; GFX940-NEXT:    s_nop 0
-; GFX940-NEXT:    v_cndmask_b32_e32 v6, v6, v2, vcc
-; GFX940-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v4
-; GFX940-NEXT:    v_lshrrev_b32_e32 v2, 16, v2
-; GFX940-NEXT:    s_nop 0
-; GFX940-NEXT:    v_cndmask_b32_e32 v4, v4, v6, vcc
-; GFX940-NEXT:    v_cmp_o_f16_e32 vcc, v0, v2
+; GFX940-NEXT:    v_cmp_o_f16_sdwa vcc, v0, v2 src0_sel:WORD_1 src1_sel:WORD_1
 ; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v3, v5, v3, vcc
-; GFX940-NEXT:    v_cmp_class_f16_e64 vcc, v0, 64
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v0, v3, v0, vcc
-; GFX940-NEXT:    v_cmp_class_f16_e64 vcc, v2, 64
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v0, v0, v2, vcc
-; GFX940-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v3
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v0, v3, v0, vcc
+; GFX940-NEXT:    v_cndmask_b32_e32 v0, v5, v3, vcc
 ; GFX940-NEXT:    v_perm_b32 v0, v0, v4, s0
 ; GFX940-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -1717,35 +1167,15 @@ define <3 x half> @v_maximum_v3f16(<3 x half> %src0, <3 x half> %src1) {
 ; GFX10:       ; %bb.0:
 ; GFX10-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX10-NEXT:    v_pk_max_f16 v4, v0, v2
-; GFX10-NEXT:    v_lshrrev_b32_e32 v5, 16, v2
-; GFX10-NEXT:    v_lshrrev_b32_e32 v6, 16, v0
 ; GFX10-NEXT:    v_cmp_o_f16_e32 vcc_lo, v0, v2
-; GFX10-NEXT:    v_pk_max_f16 v8, v1, v3
-; GFX10-NEXT:    v_lshrrev_b32_e32 v7, 16, v4
+; GFX10-NEXT:    v_lshrrev_b32_e32 v5, 16, v4
 ; GFX10-NEXT:    v_cndmask_b32_e32 v4, 0x7e00, v4, vcc_lo
-; GFX10-NEXT:    v_cmp_o_f16_e32 vcc_lo, v6, v5
-; GFX10-NEXT:    v_cndmask_b32_e32 v7, 0x7e00, v7, vcc_lo
-; GFX10-NEXT:    v_cmp_class_f16_e64 vcc_lo, v0, 64
-; GFX10-NEXT:    v_cndmask_b32_e32 v0, v4, v0, vcc_lo
-; GFX10-NEXT:    v_cmp_class_f16_e64 vcc_lo, v6, 64
-; GFX10-NEXT:    v_cndmask_b32_e32 v6, v7, v6, vcc_lo
+; GFX10-NEXT:    v_cmp_o_f16_sdwa vcc_lo, v0, v2 src0_sel:WORD_1 src1_sel:WORD_1
+; GFX10-NEXT:    v_pk_max_f16 v2, v1, v3
+; GFX10-NEXT:    v_cndmask_b32_e32 v0, 0x7e00, v5, vcc_lo
 ; GFX10-NEXT:    v_cmp_o_f16_e32 vcc_lo, v1, v3
-; GFX10-NEXT:    v_cndmask_b32_e32 v8, 0x7e00, v8, vcc_lo
-; GFX10-NEXT:    v_cmp_class_f16_e64 vcc_lo, v2, 64
-; GFX10-NEXT:    v_cndmask_b32_e32 v0, v0, v2, vcc_lo
-; GFX10-NEXT:    v_cmp_class_f16_e64 vcc_lo, v5, 64
-; GFX10-NEXT:    v_cndmask_b32_e32 v2, v6, v5, vcc_lo
-; GFX10-NEXT:    v_cmp_class_f16_e64 vcc_lo, v1, 64
-; GFX10-NEXT:    v_cndmask_b32_e32 v1, v8, v1, vcc_lo
-; GFX10-NEXT:    v_cmp_eq_f16_e32 vcc_lo, 0, v4
-; GFX10-NEXT:    v_cndmask_b32_e32 v0, v4, v0, vcc_lo
-; GFX10-NEXT:    v_cmp_eq_f16_e32 vcc_lo, 0, v7
-; GFX10-NEXT:    v_cndmask_b32_e32 v2, v7, v2, vcc_lo
-; GFX10-NEXT:    v_cmp_class_f16_e64 vcc_lo, v3, 64
-; GFX10-NEXT:    v_perm_b32 v0, v2, v0, 0x5040100
-; GFX10-NEXT:    v_cndmask_b32_e32 v1, v1, v3, vcc_lo
-; GFX10-NEXT:    v_cmp_eq_f16_e32 vcc_lo, 0, v8
-; GFX10-NEXT:    v_cndmask_b32_e32 v1, v8, v1, vcc_lo
+; GFX10-NEXT:    v_perm_b32 v0, v0, v4, 0x5040100
+; GFX10-NEXT:    v_cndmask_b32_e32 v1, 0x7e00, v2, vcc_lo
 ; GFX10-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX11-LABEL: v_maximum_v3f16:
@@ -1755,35 +1185,17 @@ define <3 x half> @v_maximum_v3f16(<3 x half> %src0, <3 x half> %src1) {
 ; GFX11-NEXT:    v_lshrrev_b32_e32 v5, 16, v2
 ; GFX11-NEXT:    v_lshrrev_b32_e32 v6, 16, v0
 ; GFX11-NEXT:    v_cmp_o_f16_e32 vcc_lo, v0, v2
-; GFX11-NEXT:    v_pk_max_f16 v8, v1, v3
+; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(SKIP_1) | instid1(VALU_DEP_4)
 ; GFX11-NEXT:    v_lshrrev_b32_e32 v7, 16, v4
-; GFX11-NEXT:    v_cndmask_b32_e32 v4, 0x7e00, v4, vcc_lo
+; GFX11-NEXT:    v_cndmask_b32_e32 v0, 0x7e00, v4, vcc_lo
 ; GFX11-NEXT:    v_cmp_o_f16_e32 vcc_lo, v6, v5
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(SKIP_1) | instid1(VALU_DEP_4)
-; GFX11-NEXT:    v_cndmask_b32_e32 v7, 0x7e00, v7, vcc_lo
-; GFX11-NEXT:    v_cmp_class_f16_e64 vcc_lo, v0, 64
-; GFX11-NEXT:    v_cndmask_b32_e32 v0, v4, v0, vcc_lo
-; GFX11-NEXT:    v_cmp_class_f16_e64 vcc_lo, v6, 64
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_4)
-; GFX11-NEXT:    v_cndmask_b32_e32 v6, v7, v6, vcc_lo
+; GFX11-NEXT:    v_pk_max_f16 v4, v1, v3
+; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(SKIP_1) | instid1(VALU_DEP_2)
+; GFX11-NEXT:    v_cndmask_b32_e32 v2, 0x7e00, v7, vcc_lo
 ; GFX11-NEXT:    v_cmp_o_f16_e32 vcc_lo, v1, v3
-; GFX11-NEXT:    v_cndmask_b32_e32 v8, 0x7e00, v8, vcc_lo
-; GFX11-NEXT:    v_cmp_class_f16_e64 vcc_lo, v2, 64
-; GFX11-NEXT:    v_cndmask_b32_e32 v0, v0, v2, vcc_lo
-; GFX11-NEXT:    v_cmp_class_f16_e64 vcc_lo, v5, 64
-; GFX11-NEXT:    v_cndmask_b32_e32 v2, v6, v5, vcc_lo
-; GFX11-NEXT:    v_cmp_class_f16_e64 vcc_lo, v1, 64
-; GFX11-NEXT:    v_cndmask_b32_e32 v1, v8, v1, vcc_lo
-; GFX11-NEXT:    v_cmp_eq_f16_e32 vcc_lo, 0, v4
-; GFX11-NEXT:    v_cndmask_b32_e32 v0, v4, v0, vcc_lo
-; GFX11-NEXT:    v_cmp_eq_f16_e32 vcc_lo, 0, v7
-; GFX11-NEXT:    v_cndmask_b32_e32 v2, v7, v2, vcc_lo
-; GFX11-NEXT:    v_cmp_class_f16_e64 vcc_lo, v3, 64
-; GFX11-NEXT:    v_cndmask_b32_e32 v1, v1, v3, vcc_lo
-; GFX11-NEXT:    v_cmp_eq_f16_e32 vcc_lo, 0, v8
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_2)
-; GFX11-NEXT:    v_cndmask_b32_e32 v1, v8, v1, vcc_lo
 ; GFX11-NEXT:    v_perm_b32 v0, v2, v0, 0x5040100
+; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_4)
+; GFX11-NEXT:    v_cndmask_b32_e32 v1, 0x7e00, v4, vcc_lo
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX12-LABEL: v_maximum_v3f16:
@@ -1808,201 +1220,61 @@ define <3 x half> @v_maximum_v3f16__nnan(<3 x half> %src0, <3 x half> %src1) {
 ; GFX7-NEXT:    v_cvt_f16_f32_e32 v0, v0
 ; GFX7-NEXT:    v_cvt_f16_f32_e32 v4, v4
 ; GFX7-NEXT:    v_cvt_f16_f32_e32 v1, v1
-; GFX7-NEXT:    v_cvt_f32_f16_e32 v3, v3
-; GFX7-NEXT:    v_cvt_f32_f16_e32 v0, v0
 ; GFX7-NEXT:    v_cvt_f16_f32_e32 v5, v5
 ; GFX7-NEXT:    v_cvt_f16_f32_e32 v2, v2
+; GFX7-NEXT:    v_cvt_f32_f16_e32 v3, v3
+; GFX7-NEXT:    v_cvt_f32_f16_e32 v0, v0
 ; GFX7-NEXT:    v_cvt_f32_f16_e32 v4, v4
 ; GFX7-NEXT:    v_cvt_f32_f16_e32 v1, v1
+; GFX7-NEXT:    v_cvt_f32_f16_e32 v5, v5
+; GFX7-NEXT:    v_cvt_f32_f16_e32 v2, v2
 ; GFX7-NEXT:    v_max_f32_e32 v6, v0, v3
 ; GFX7-NEXT:    v_mov_b32_e32 v7, 0x7fc00000
 ; GFX7-NEXT:    v_cmp_o_f32_e32 vcc, v0, v3
-; GFX7-NEXT:    v_cndmask_b32_e32 v6, v7, v6, vcc
-; GFX7-NEXT:    v_cmp_class_f32_e64 vcc, v0, 64
-; GFX7-NEXT:    v_cndmask_b32_e32 v0, v6, v0, vcc
-; GFX7-NEXT:    v_cmp_class_f32_e64 vcc, v3, 64
-; GFX7-NEXT:    v_cndmask_b32_e32 v0, v0, v3, vcc
-; GFX7-NEXT:    v_cmp_eq_f32_e32 vcc, 0, v6
-; GFX7-NEXT:    v_cvt_f32_f16_e32 v5, v5
-; GFX7-NEXT:    v_cvt_f32_f16_e32 v2, v2
-; GFX7-NEXT:    v_cndmask_b32_e32 v0, v6, v0, vcc
+; GFX7-NEXT:    v_cndmask_b32_e32 v0, v7, v6, vcc
 ; GFX7-NEXT:    v_max_f32_e32 v3, v1, v4
 ; GFX7-NEXT:    v_cmp_o_f32_e32 vcc, v1, v4
-; GFX7-NEXT:    v_cndmask_b32_e32 v3, v7, v3, vcc
-; GFX7-NEXT:    v_cmp_class_f32_e64 vcc, v1, 64
-; GFX7-NEXT:    v_cndmask_b32_e32 v1, v3, v1, vcc
-; GFX7-NEXT:    v_cmp_class_f32_e64 vcc, v4, 64
-; GFX7-NEXT:    v_cndmask_b32_e32 v1, v1, v4, vcc
-; GFX7-NEXT:    v_cmp_eq_f32_e32 vcc, 0, v3
-; GFX7-NEXT:    v_cndmask_b32_e32 v1, v3, v1, vcc
+; GFX7-NEXT:    v_cndmask_b32_e32 v1, v7, v3, vcc
 ; GFX7-NEXT:    v_max_f32_e32 v3, v2, v5
 ; GFX7-NEXT:    v_cmp_o_f32_e32 vcc, v2, v5
-; GFX7-NEXT:    v_cndmask_b32_e32 v3, v7, v3, vcc
-; GFX7-NEXT:    v_cmp_class_f32_e64 vcc, v2, 64
-; GFX7-NEXT:    v_cndmask_b32_e32 v2, v3, v2, vcc
-; GFX7-NEXT:    v_cmp_class_f32_e64 vcc, v5, 64
-; GFX7-NEXT:    v_cndmask_b32_e32 v2, v2, v5, vcc
-; GFX7-NEXT:    v_cmp_eq_f32_e32 vcc, 0, v3
-; GFX7-NEXT:    v_cndmask_b32_e32 v2, v3, v2, vcc
+; GFX7-NEXT:    v_cndmask_b32_e32 v2, v7, v3, vcc
 ; GFX7-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX8-LABEL: v_maximum_v3f16__nnan:
 ; GFX8:       ; %bb.0:
 ; GFX8-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX8-NEXT:    v_lshrrev_b32_e32 v4, 16, v2
-; GFX8-NEXT:    v_lshrrev_b32_e32 v5, 16, v0
-; GFX8-NEXT:    v_max_f16_e32 v6, v5, v4
-; GFX8-NEXT:    v_cmp_class_f16_e64 vcc, v5, 64
-; GFX8-NEXT:    v_cndmask_b32_e32 v5, v6, v5, vcc
-; GFX8-NEXT:    v_cmp_class_f16_e64 vcc, v4, 64
-; GFX8-NEXT:    v_cndmask_b32_e32 v4, v5, v4, vcc
-; GFX8-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v6
-; GFX8-NEXT:    v_cndmask_b32_e32 v4, v6, v4, vcc
-; GFX8-NEXT:    v_max_f16_e32 v5, v1, v3
-; GFX8-NEXT:    v_cmp_class_f16_e64 vcc, v1, 64
-; GFX8-NEXT:    v_cndmask_b32_e32 v1, v5, v1, vcc
-; GFX8-NEXT:    v_cmp_class_f16_e64 vcc, v3, 64
-; GFX8-NEXT:    v_cndmask_b32_e32 v1, v1, v3, vcc
-; GFX8-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v5
-; GFX8-NEXT:    v_cndmask_b32_e32 v1, v5, v1, vcc
-; GFX8-NEXT:    v_max_f16_e32 v3, v0, v2
-; GFX8-NEXT:    v_cmp_class_f16_e64 vcc, v0, 64
-; GFX8-NEXT:    v_cndmask_b32_e32 v0, v3, v0, vcc
-; GFX8-NEXT:    v_cmp_class_f16_e64 vcc, v2, 64
-; GFX8-NEXT:    v_cndmask_b32_e32 v0, v0, v2, vcc
-; GFX8-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v3
-; GFX8-NEXT:    v_cndmask_b32_e32 v0, v3, v0, vcc
-; GFX8-NEXT:    v_lshlrev_b32_e32 v2, 16, v4
-; GFX8-NEXT:    v_or_b32_sdwa v0, v0, v2 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
+; GFX8-NEXT:    v_max_f16_sdwa v4, v0, v2 dst_sel:WORD_1 dst_unused:UNUSED_PAD src0_sel:WORD_1 src1_sel:WORD_1
+; GFX8-NEXT:    v_max_f16_e32 v0, v0, v2
+; GFX8-NEXT:    v_max_f16_e32 v1, v1, v3
+; GFX8-NEXT:    v_or_b32_e32 v0, v0, v4
 ; GFX8-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX9-LABEL: v_maximum_v3f16__nnan:
 ; GFX9:       ; %bb.0:
 ; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX9-NEXT:    v_lshrrev_b32_e32 v4, 16, v0
-; GFX9-NEXT:    v_pk_max_f16 v5, v0, v2
-; GFX9-NEXT:    v_lshrrev_b32_e32 v6, 16, v5
-; GFX9-NEXT:    v_cmp_class_f16_e64 vcc, v4, 64
-; GFX9-NEXT:    v_lshrrev_b32_e32 v7, 16, v2
-; GFX9-NEXT:    v_cndmask_b32_e32 v4, v6, v4, vcc
-; GFX9-NEXT:    v_cmp_class_f16_e64 vcc, v7, 64
-; GFX9-NEXT:    v_cndmask_b32_e32 v4, v4, v7, vcc
-; GFX9-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v6
-; GFX9-NEXT:    v_cndmask_b32_e32 v4, v6, v4, vcc
-; GFX9-NEXT:    v_pk_max_f16 v6, v1, v3
-; GFX9-NEXT:    v_cmp_class_f16_e64 vcc, v1, 64
-; GFX9-NEXT:    v_cndmask_b32_e32 v1, v6, v1, vcc
-; GFX9-NEXT:    v_cmp_class_f16_e64 vcc, v3, 64
-; GFX9-NEXT:    v_cndmask_b32_e32 v1, v1, v3, vcc
-; GFX9-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v6
-; GFX9-NEXT:    v_cndmask_b32_e32 v1, v6, v1, vcc
-; GFX9-NEXT:    v_cmp_class_f16_e64 vcc, v0, 64
-; GFX9-NEXT:    v_cndmask_b32_e32 v0, v5, v0, vcc
-; GFX9-NEXT:    v_cmp_class_f16_e64 vcc, v2, 64
-; GFX9-NEXT:    v_cndmask_b32_e32 v0, v0, v2, vcc
-; GFX9-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v5
-; GFX9-NEXT:    v_cndmask_b32_e32 v0, v5, v0, vcc
-; GFX9-NEXT:    s_mov_b32 s4, 0x5040100
-; GFX9-NEXT:    v_perm_b32 v0, v4, v0, s4
+; GFX9-NEXT:    v_pk_max_f16 v0, v0, v2
+; GFX9-NEXT:    v_pk_max_f16 v1, v1, v3
 ; GFX9-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX940-LABEL: v_maximum_v3f16__nnan:
 ; GFX940:       ; %bb.0:
 ; GFX940-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX940-NEXT:    v_lshrrev_b32_e32 v4, 16, v0
-; GFX940-NEXT:    v_pk_max_f16 v5, v0, v2
-; GFX940-NEXT:    v_cmp_class_f16_e64 vcc, v4, 64
-; GFX940-NEXT:    v_lshrrev_b32_e32 v6, 16, v5
-; GFX940-NEXT:    v_lshrrev_b32_e32 v7, 16, v2
-; GFX940-NEXT:    v_cndmask_b32_e32 v4, v6, v4, vcc
-; GFX940-NEXT:    v_cmp_class_f16_e64 vcc, v7, 64
-; GFX940-NEXT:    s_mov_b32 s0, 0x5040100
-; GFX940-NEXT:    s_nop 0
-; GFX940-NEXT:    v_cndmask_b32_e32 v4, v4, v7, vcc
-; GFX940-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v6
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v4, v6, v4, vcc
-; GFX940-NEXT:    v_pk_max_f16 v6, v1, v3
-; GFX940-NEXT:    v_cmp_class_f16_e64 vcc, v1, 64
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v1, v6, v1, vcc
-; GFX940-NEXT:    v_cmp_class_f16_e64 vcc, v3, 64
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v1, v1, v3, vcc
-; GFX940-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v6
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v1, v6, v1, vcc
-; GFX940-NEXT:    v_cmp_class_f16_e64 vcc, v0, 64
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v0, v5, v0, vcc
-; GFX940-NEXT:    v_cmp_class_f16_e64 vcc, v2, 64
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v0, v0, v2, vcc
-; GFX940-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v5
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v0, v5, v0, vcc
-; GFX940-NEXT:    v_perm_b32 v0, v4, v0, s0
+; GFX940-NEXT:    v_pk_max_f16 v0, v0, v2
+; GFX940-NEXT:    v_pk_max_f16 v1, v1, v3
 ; GFX940-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX10-LABEL: v_maximum_v3f16__nnan:
 ; GFX10:       ; %bb.0:
 ; GFX10-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX10-NEXT:    v_pk_max_f16 v4, v0, v2
-; GFX10-NEXT:    v_lshrrev_b32_e32 v5, 16, v0
-; GFX10-NEXT:    v_cmp_class_f16_e64 vcc_lo, v0, 64
-; GFX10-NEXT:    v_lshrrev_b32_e32 v7, 16, v2
-; GFX10-NEXT:    v_pk_max_f16 v8, v1, v3
-; GFX10-NEXT:    v_lshrrev_b32_e32 v6, 16, v4
-; GFX10-NEXT:    v_cndmask_b32_e32 v0, v4, v0, vcc_lo
-; GFX10-NEXT:    v_cmp_class_f16_e64 vcc_lo, v5, 64
-; GFX10-NEXT:    v_cndmask_b32_e32 v5, v6, v5, vcc_lo
-; GFX10-NEXT:    v_cmp_class_f16_e64 vcc_lo, v2, 64
-; GFX10-NEXT:    v_cndmask_b32_e32 v0, v0, v2, vcc_lo
-; GFX10-NEXT:    v_cmp_class_f16_e64 vcc_lo, v7, 64
-; GFX10-NEXT:    v_cndmask_b32_e32 v2, v5, v7, vcc_lo
-; GFX10-NEXT:    v_cmp_class_f16_e64 vcc_lo, v1, 64
-; GFX10-NEXT:    v_cndmask_b32_e32 v1, v8, v1, vcc_lo
-; GFX10-NEXT:    v_cmp_eq_f16_e32 vcc_lo, 0, v4
-; GFX10-NEXT:    v_cndmask_b32_e32 v0, v4, v0, vcc_lo
-; GFX10-NEXT:    v_cmp_eq_f16_e32 vcc_lo, 0, v6
-; GFX10-NEXT:    v_cndmask_b32_e32 v2, v6, v2, vcc_lo
-; GFX10-NEXT:    v_cmp_class_f16_e64 vcc_lo, v3, 64
-; GFX10-NEXT:    v_perm_b32 v0, v2, v0, 0x5040100
-; GFX10-NEXT:    v_cndmask_b32_e32 v1, v1, v3, vcc_lo
-; GFX10-NEXT:    v_cmp_eq_f16_e32 vcc_lo, 0, v8
-; GFX10-NEXT:    v_cndmask_b32_e32 v1, v8, v1, vcc_lo
+; GFX10-NEXT:    v_pk_max_f16 v0, v0, v2
+; GFX10-NEXT:    v_pk_max_f16 v1, v1, v3
 ; GFX10-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX11-LABEL: v_maximum_v3f16__nnan:
 ; GFX11:       ; %bb.0:
 ; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX11-NEXT:    v_pk_max_f16 v4, v0, v2
-; GFX11-NEXT:    v_lshrrev_b32_e32 v5, 16, v0
-; GFX11-NEXT:    v_cmp_class_f16_e64 vcc_lo, v0, 64
-; GFX11-NEXT:    v_lshrrev_b32_e32 v7, 16, v2
-; GFX11-NEXT:    v_pk_max_f16 v8, v1, v3
-; GFX11-NEXT:    v_lshrrev_b32_e32 v6, 16, v4
-; GFX11-NEXT:    v_cndmask_b32_e32 v0, v4, v0, vcc_lo
-; GFX11-NEXT:    v_cmp_class_f16_e64 vcc_lo, v5, 64
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(SKIP_1) | instid1(VALU_DEP_4)
-; GFX11-NEXT:    v_cndmask_b32_e32 v5, v6, v5, vcc_lo
-; GFX11-NEXT:    v_cmp_class_f16_e64 vcc_lo, v2, 64
-; GFX11-NEXT:    v_cndmask_b32_e32 v0, v0, v2, vcc_lo
-; GFX11-NEXT:    v_cmp_class_f16_e64 vcc_lo, v7, 64
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_4)
-; GFX11-NEXT:    v_cndmask_b32_e32 v2, v5, v7, vcc_lo
-; GFX11-NEXT:    v_cmp_class_f16_e64 vcc_lo, v1, 64
-; GFX11-NEXT:    v_cndmask_b32_e32 v1, v8, v1, vcc_lo
-; GFX11-NEXT:    v_cmp_eq_f16_e32 vcc_lo, 0, v4
-; GFX11-NEXT:    v_cndmask_b32_e32 v0, v4, v0, vcc_lo
-; GFX11-NEXT:    v_cmp_eq_f16_e32 vcc_lo, 0, v6
-; GFX11-NEXT:    v_cndmask_b32_e32 v2, v6, v2, vcc_lo
-; GFX11-NEXT:    v_cmp_class_f16_e64 vcc_lo, v3, 64
-; GFX11-NEXT:    v_cndmask_b32_e32 v1, v1, v3, vcc_lo
-; GFX11-NEXT:    v_cmp_eq_f16_e32 vcc_lo, 0, v8
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_2)
-; GFX11-NEXT:    v_cndmask_b32_e32 v1, v8, v1, vcc_lo
-; GFX11-NEXT:    v_perm_b32 v0, v2, v0, 0x5040100
+; GFX11-NEXT:    v_pk_max_f16 v0, v0, v2
+; GFX11-NEXT:    v_pk_max_f16 v1, v1, v3
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX12-LABEL: v_maximum_v3f16__nnan:
@@ -2027,42 +1299,24 @@ define <3 x half> @v_maximum_v3f16__nsz(<3 x half> %src0, <3 x half> %src1) {
 ; GFX7-NEXT:    v_cvt_f16_f32_e32 v0, v0
 ; GFX7-NEXT:    v_cvt_f16_f32_e32 v4, v4
 ; GFX7-NEXT:    v_cvt_f16_f32_e32 v1, v1
-; GFX7-NEXT:    v_cvt_f32_f16_e32 v3, v3
-; GFX7-NEXT:    v_cvt_f32_f16_e32 v0, v0
 ; GFX7-NEXT:    v_cvt_f16_f32_e32 v5, v5
 ; GFX7-NEXT:    v_cvt_f16_f32_e32 v2, v2
+; GFX7-NEXT:    v_cvt_f32_f16_e32 v3, v3
+; GFX7-NEXT:    v_cvt_f32_f16_e32 v0, v0
 ; GFX7-NEXT:    v_cvt_f32_f16_e32 v4, v4
 ; GFX7-NEXT:    v_cvt_f32_f16_e32 v1, v1
+; GFX7-NEXT:    v_cvt_f32_f16_e32 v5, v5
+; GFX7-NEXT:    v_cvt_f32_f16_e32 v2, v2
 ; GFX7-NEXT:    v_max_f32_e32 v6, v0, v3
 ; GFX7-NEXT:    v_mov_b32_e32 v7, 0x7fc00000
 ; GFX7-NEXT:    v_cmp_o_f32_e32 vcc, v0, v3
-; GFX7-NEXT:    v_cndmask_b32_e32 v6, v7, v6, vcc
-; GFX7-NEXT:    v_cmp_class_f32_e64 vcc, v0, 64
-; GFX7-NEXT:    v_cndmask_b32_e32 v0, v6, v0, vcc
-; GFX7-NEXT:    v_cmp_class_f32_e64 vcc, v3, 64
-; GFX7-NEXT:    v_cndmask_b32_e32 v0, v0, v3, vcc
-; GFX7-NEXT:    v_cmp_eq_f32_e32 vcc, 0, v6
-; GFX7-NEXT:    v_cvt_f32_f16_e32 v5, v5
-; GFX7-NEXT:    v_cvt_f32_f16_e32 v2, v2
-; GFX7-NEXT:    v_cndmask_b32_e32 v0, v6, v0, vcc
+; GFX7-NEXT:    v_cndmask_b32_e32 v0, v7, v6, vcc
 ; GFX7-NEXT:    v_max_f32_e32 v3, v1, v4
 ; GFX7-NEXT:    v_cmp_o_f32_e32 vcc, v1, v4
-; GFX7-NEXT:    v_cndmask_b32_e32 v3, v7, v3, vcc
-; GFX7-NEXT:    v_cmp_class_f32_e64 vcc, v1, 64
-; GFX7-NEXT:    v_cndmask_b32_e32 v1, v3, v1, vcc
-; GFX7-NEXT:    v_cmp_class_f32_e64 vcc, v4, 64
-; GFX7-NEXT:    v_cndmask_b32_e32 v1, v1, v4, vcc
-; GFX7-NEXT:    v_cmp_eq_f32_e32 vcc, 0, v3
-; GFX7-NEXT:    v_cndmask_b32_e32 v1, v3, v1, vcc
+; GFX7-NEXT:    v_cndmask_b32_e32 v1, v7, v3, vcc
 ; GFX7-NEXT:    v_max_f32_e32 v3, v2, v5
 ; GFX7-NEXT:    v_cmp_o_f32_e32 vcc, v2, v5
-; GFX7-NEXT:    v_cndmask_b32_e32 v3, v7, v3, vcc
-; GFX7-NEXT:    v_cmp_class_f32_e64 vcc, v2, 64
-; GFX7-NEXT:    v_cndmask_b32_e32 v2, v3, v2, vcc
-; GFX7-NEXT:    v_cmp_class_f32_e64 vcc, v5, 64
-; GFX7-NEXT:    v_cndmask_b32_e32 v2, v2, v5, vcc
-; GFX7-NEXT:    v_cmp_eq_f32_e32 vcc, 0, v3
-; GFX7-NEXT:    v_cndmask_b32_e32 v2, v3, v2, vcc
+; GFX7-NEXT:    v_cndmask_b32_e32 v2, v7, v3, vcc
 ; GFX7-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX8-LABEL: v_maximum_v3f16__nsz:
@@ -2177,42 +1431,24 @@ define <3 x half> @v_maximum_v3f16__nnan_nsz(<3 x half> %src0, <3 x half> %src1)
 ; GFX7-NEXT:    v_cvt_f16_f32_e32 v0, v0
 ; GFX7-NEXT:    v_cvt_f16_f32_e32 v4, v4
 ; GFX7-NEXT:    v_cvt_f16_f32_e32 v1, v1
-; GFX7-NEXT:    v_cvt_f32_f16_e32 v3, v3
-; GFX7-NEXT:    v_cvt_f32_f16_e32 v0, v0
 ; GFX7-NEXT:    v_cvt_f16_f32_e32 v5, v5
 ; GFX7-NEXT:    v_cvt_f16_f32_e32 v2, v2
+; GFX7-NEXT:    v_cvt_f32_f16_e32 v3, v3
+; GFX7-NEXT:    v_cvt_f32_f16_e32 v0, v0
 ; GFX7-NEXT:    v_cvt_f32_f16_e32 v4, v4
 ; GFX7-NEXT:    v_cvt_f32_f16_e32 v1, v1
+; GFX7-NEXT:    v_cvt_f32_f16_e32 v5, v5
+; GFX7-NEXT:    v_cvt_f32_f16_e32 v2, v2
 ; GFX7-NEXT:    v_max_f32_e32 v6, v0, v3
 ; GFX7-NEXT:    v_mov_b32_e32 v7, 0x7fc00000
 ; GFX7-NEXT:    v_cmp_o_f32_e32 vcc, v0, v3
-; GFX7-NEXT:    v_cndmask_b32_e32 v6, v7, v6, vcc
-; GFX7-NEXT:    v_cmp_class_f32_e64 vcc, v0, 64
-; GFX7-NEXT:    v_cndmask_b32_e32 v0, v6, v0, vcc
-; GFX7-NEXT:    v_cmp_class_f32_e64 vcc, v3, 64
-; GFX7-NEXT:    v_cndmask_b32_e32 v0, v0, v3, vcc
-; GFX7-NEXT:    v_cmp_eq_f32_e32 vcc, 0, v6
-; GFX7-NEXT:    v_cvt_f32_f16_e32 v5, v5
-; GFX7-NEXT:    v_cvt_f32_f16_e32 v2, v2
-; GFX7-NEXT:    v_cndmask_b32_e32 v0, v6, v0, vcc
+; GFX7-NEXT:    v_cndmask_b32_e32 v0, v7, v6, vcc
 ; GFX7-NEXT:    v_max_f32_e32 v3, v1, v4
 ; GFX7-NEXT:    v_cmp_o_f32_e32 vcc, v1, v4
-; GFX7-NEXT:    v_cndmask_b32_e32 v3, v7, v3, vcc
-; GFX7-NEXT:    v_cmp_class_f32_e64 vcc, v1, 64
-; GFX7-NEXT:    v_cndmask_b32_e32 v1, v3, v1, vcc
-; GFX7-NEXT:    v_cmp_class_f32_e64 vcc, v4, 64
-; GFX7-NEXT:    v_cndmask_b32_e32 v1, v1, v4, vcc
-; GFX7-NEXT:    v_cmp_eq_f32_e32 vcc, 0, v3
-; GFX7-NEXT:    v_cndmask_b32_e32 v1, v3, v1, vcc
+; GFX7-NEXT:    v_cndmask_b32_e32 v1, v7, v3, vcc
 ; GFX7-NEXT:    v_max_f32_e32 v3, v2, v5
 ; GFX7-NEXT:    v_cmp_o_f32_e32 vcc, v2, v5
-; GFX7-NEXT:    v_cndmask_b32_e32 v3, v7, v3, vcc
-; GFX7-NEXT:    v_cmp_class_f32_e64 vcc, v2, 64
-; GFX7-NEXT:    v_cndmask_b32_e32 v2, v3, v2, vcc
-; GFX7-NEXT:    v_cmp_class_f32_e64 vcc, v5, 64
-; GFX7-NEXT:    v_cndmask_b32_e32 v2, v2, v5, vcc
-; GFX7-NEXT:    v_cmp_eq_f32_e32 vcc, 0, v3
-; GFX7-NEXT:    v_cndmask_b32_e32 v2, v3, v2, vcc
+; GFX7-NEXT:    v_cndmask_b32_e32 v2, v7, v3, vcc
 ; GFX7-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX8-LABEL: v_maximum_v3f16__nnan_nsz:
@@ -2274,55 +1510,31 @@ define <4 x half> @v_maximum_v4f16(<4 x half> %src0, <4 x half> %src1) {
 ; GFX7-NEXT:    v_cvt_f16_f32_e32 v0, v0
 ; GFX7-NEXT:    v_cvt_f16_f32_e32 v5, v5
 ; GFX7-NEXT:    v_cvt_f16_f32_e32 v1, v1
-; GFX7-NEXT:    v_cvt_f32_f16_e32 v4, v4
-; GFX7-NEXT:    v_cvt_f32_f16_e32 v0, v0
 ; GFX7-NEXT:    v_cvt_f16_f32_e32 v6, v6
 ; GFX7-NEXT:    v_cvt_f16_f32_e32 v2, v2
+; GFX7-NEXT:    v_cvt_f16_f32_e32 v7, v7
+; GFX7-NEXT:    v_cvt_f16_f32_e32 v3, v3
+; GFX7-NEXT:    v_cvt_f32_f16_e32 v4, v4
+; GFX7-NEXT:    v_cvt_f32_f16_e32 v0, v0
 ; GFX7-NEXT:    v_cvt_f32_f16_e32 v5, v5
 ; GFX7-NEXT:    v_cvt_f32_f16_e32 v1, v1
+; GFX7-NEXT:    v_cvt_f32_f16_e32 v6, v6
+; GFX7-NEXT:    v_cvt_f32_f16_e32 v2, v2
+; GFX7-NEXT:    v_cvt_f32_f16_e32 v7, v7
+; GFX7-NEXT:    v_cvt_f32_f16_e32 v3, v3
 ; GFX7-NEXT:    v_max_f32_e32 v8, v0, v4
 ; GFX7-NEXT:    v_mov_b32_e32 v9, 0x7fc00000
 ; GFX7-NEXT:    v_cmp_o_f32_e32 vcc, v0, v4
-; GFX7-NEXT:    v_cndmask_b32_e32 v8, v9, v8, vcc
-; GFX7-NEXT:    v_cmp_class_f32_e64 vcc, v0, 64
-; GFX7-NEXT:    v_cndmask_b32_e32 v0, v8, v0, vcc
-; GFX7-NEXT:    v_cmp_class_f32_e64 vcc, v4, 64
-; GFX7-NEXT:    v_cndmask_b32_e32 v0, v0, v4, vcc
-; GFX7-NEXT:    v_cmp_eq_f32_e32 vcc, 0, v8
-; GFX7-NEXT:    v_cvt_f16_f32_e32 v7, v7
-; GFX7-NEXT:    v_cvt_f16_f32_e32 v3, v3
-; GFX7-NEXT:    v_cvt_f32_f16_e32 v6, v6
-; GFX7-NEXT:    v_cvt_f32_f16_e32 v2, v2
-; GFX7-NEXT:    v_cndmask_b32_e32 v0, v8, v0, vcc
+; GFX7-NEXT:    v_cndmask_b32_e32 v0, v9, v8, vcc
 ; GFX7-NEXT:    v_max_f32_e32 v4, v1, v5
 ; GFX7-NEXT:    v_cmp_o_f32_e32 vcc, v1, v5
-; GFX7-NEXT:    v_cndmask_b32_e32 v4, v9, v4, vcc
-; GFX7-NEXT:    v_cmp_class_f32_e64 vcc, v1, 64
-; GFX7-NEXT:    v_cndmask_b32_e32 v1, v4, v1, vcc
-; GFX7-NEXT:    v_cmp_class_f32_e64 vcc, v5, 64
-; GFX7-NEXT:    v_cndmask_b32_e32 v1, v1, v5, vcc
-; GFX7-NEXT:    v_cmp_eq_f32_e32 vcc, 0, v4
-; GFX7-NEXT:    v_cvt_f32_f16_e32 v7, v7
-; GFX7-NEXT:    v_cvt_f32_f16_e32 v3, v3
-; GFX7-NEXT:    v_cndmask_b32_e32 v1, v4, v1, vcc
+; GFX7-NEXT:    v_cndmask_b32_e32 v1, v9, v4, vcc
 ; GFX7-NEXT:    v_max_f32_e32 v4, v2, v6
 ; GFX7-NEXT:    v_cmp_o_f32_e32 vcc, v2, v6
-; GFX7-NEXT:    v_cndmask_b32_e32 v4, v9, v4, vcc
-; GFX7-NEXT:    v_cmp_class_f32_e64 vcc, v2, 64
-; GFX7-NEXT:    v_cndmask_b32_e32 v2, v4, v2, vcc
-; GFX7-NEXT:    v_cmp_class_f32_e64 vcc, v6, 64
-; GFX7-NEXT:    v_cndmask_b32_e32 v2, v2, v6, vcc
-; GFX7-NEXT:    v_cmp_eq_f32_e32 vcc, 0, v4
-; GFX7-NEXT:    v_cndmask_b32_e32 v2, v4, v2, vcc
+; GFX7-NEXT:    v_cndmask_b32_e32 v2, v9, v4, vcc
 ; GFX7-NEXT:    v_max_f32_e32 v4, v3, v7
 ; GFX7-NEXT:    v_cmp_o_f32_e32 vcc, v3, v7
-; GFX7-NEXT:    v_cndmask_b32_e32 v4, v9, v4, vcc
-; GFX7-NEXT:    v_cmp_class_f32_e64 vcc, v3, 64
-; GFX7-NEXT:    v_cndmask_b32_e32 v3, v4, v3, vcc
-; GFX7-NEXT:    v_cmp_class_f32_e64 vcc, v7, 64
-; GFX7-NEXT:    v_cndmask_b32_e32 v3, v3, v7, vcc
-; GFX7-NEXT:    v_cmp_eq_f32_e32 vcc, 0, v4
-; GFX7-NEXT:    v_cndmask_b32_e32 v3, v4, v3, vcc
+; GFX7-NEXT:    v_cndmask_b32_e32 v3, v9, v4, vcc
 ; GFX7-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX8-LABEL: v_maximum_v4f16:
@@ -2333,42 +1545,18 @@ define <4 x half> @v_maximum_v4f16(<4 x half> %src0, <4 x half> %src1) {
 ; GFX8-NEXT:    v_max_f16_e32 v6, v5, v4
 ; GFX8-NEXT:    v_mov_b32_e32 v7, 0x7e00
 ; GFX8-NEXT:    v_cmp_o_f16_e32 vcc, v5, v4
-; GFX8-NEXT:    v_cndmask_b32_e32 v6, v7, v6, vcc
-; GFX8-NEXT:    v_cmp_class_f16_e64 vcc, v5, 64
-; GFX8-NEXT:    v_cndmask_b32_e32 v5, v6, v5, vcc
-; GFX8-NEXT:    v_cmp_class_f16_e64 vcc, v4, 64
-; GFX8-NEXT:    v_cndmask_b32_e32 v4, v5, v4, vcc
-; GFX8-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v6
-; GFX8-NEXT:    v_cndmask_b32_e32 v4, v6, v4, vcc
+; GFX8-NEXT:    v_cndmask_b32_e32 v4, v7, v6, vcc
 ; GFX8-NEXT:    v_lshrrev_b32_e32 v5, 16, v2
 ; GFX8-NEXT:    v_lshrrev_b32_e32 v6, 16, v0
 ; GFX8-NEXT:    v_max_f16_e32 v8, v6, v5
 ; GFX8-NEXT:    v_cmp_o_f16_e32 vcc, v6, v5
-; GFX8-NEXT:    v_cndmask_b32_e32 v8, v7, v8, vcc
-; GFX8-NEXT:    v_cmp_class_f16_e64 vcc, v6, 64
-; GFX8-NEXT:    v_cndmask_b32_e32 v6, v8, v6, vcc
-; GFX8-NEXT:    v_cmp_class_f16_e64 vcc, v5, 64
-; GFX8-NEXT:    v_cndmask_b32_e32 v5, v6, v5, vcc
-; GFX8-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v8
-; GFX8-NEXT:    v_cndmask_b32_e32 v5, v8, v5, vcc
+; GFX8-NEXT:    v_cndmask_b32_e32 v5, v7, v8, vcc
 ; GFX8-NEXT:    v_max_f16_e32 v6, v1, v3
 ; GFX8-NEXT:    v_cmp_o_f16_e32 vcc, v1, v3
-; GFX8-NEXT:    v_cndmask_b32_e32 v6, v7, v6, vcc
-; GFX8-NEXT:    v_cmp_class_f16_e64 vcc, v1, 64
-; GFX8-NEXT:    v_cndmask_b32_e32 v1, v6, v1, vcc
-; GFX8-NEXT:    v_cmp_class_f16_e64 vcc, v3, 64
-; GFX8-NEXT:    v_cndmask_b32_e32 v1, v1, v3, vcc
-; GFX8-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v6
-; GFX8-NEXT:    v_cndmask_b32_e32 v1, v6, v1, vcc
+; GFX8-NEXT:    v_cndmask_b32_e32 v1, v7, v6, vcc
 ; GFX8-NEXT:    v_max_f16_e32 v3, v0, v2
 ; GFX8-NEXT:    v_cmp_o_f16_e32 vcc, v0, v2
-; GFX8-NEXT:    v_cndmask_b32_e32 v3, v7, v3, vcc
-; GFX8-NEXT:    v_cmp_class_f16_e64 vcc, v0, 64
-; GFX8-NEXT:    v_cndmask_b32_e32 v0, v3, v0, vcc
-; GFX8-NEXT:    v_cmp_class_f16_e64 vcc, v2, 64
-; GFX8-NEXT:    v_cndmask_b32_e32 v0, v0, v2, vcc
-; GFX8-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v3
-; GFX8-NEXT:    v_cndmask_b32_e32 v0, v3, v0, vcc
+; GFX8-NEXT:    v_cndmask_b32_e32 v0, v7, v3, vcc
 ; GFX8-NEXT:    v_lshlrev_b32_e32 v2, 16, v5
 ; GFX8-NEXT:    v_or_b32_sdwa v0, v0, v2 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
 ; GFX8-NEXT:    v_lshlrev_b32_e32 v2, 16, v4
@@ -2382,43 +1570,15 @@ define <4 x half> @v_maximum_v4f16(<4 x half> %src0, <4 x half> %src1) {
 ; GFX9-NEXT:    v_mov_b32_e32 v5, 0x7e00
 ; GFX9-NEXT:    v_cmp_o_f16_e32 vcc, v1, v3
 ; GFX9-NEXT:    v_cndmask_b32_e32 v6, v5, v4, vcc
-; GFX9-NEXT:    v_cmp_class_f16_e64 vcc, v1, 64
-; GFX9-NEXT:    v_cndmask_b32_e32 v7, v6, v1, vcc
-; GFX9-NEXT:    v_cmp_class_f16_e64 vcc, v3, 64
-; GFX9-NEXT:    v_cndmask_b32_e32 v7, v7, v3, vcc
-; GFX9-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v6
-; GFX9-NEXT:    v_lshrrev_b32_e32 v3, 16, v3
-; GFX9-NEXT:    v_lshrrev_b32_e32 v1, 16, v1
-; GFX9-NEXT:    v_cndmask_b32_e32 v6, v6, v7, vcc
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v4, 16, v4
-; GFX9-NEXT:    v_cmp_o_f16_e32 vcc, v1, v3
-; GFX9-NEXT:    v_cndmask_b32_e32 v4, v5, v4, vcc
-; GFX9-NEXT:    v_cmp_class_f16_e64 vcc, v1, 64
-; GFX9-NEXT:    v_cndmask_b32_e32 v1, v4, v1, vcc
-; GFX9-NEXT:    v_cmp_class_f16_e64 vcc, v3, 64
-; GFX9-NEXT:    v_cndmask_b32_e32 v1, v1, v3, vcc
-; GFX9-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v4
-; GFX9-NEXT:    v_cndmask_b32_e32 v1, v4, v1, vcc
+; GFX9-NEXT:    v_cmp_o_f16_sdwa vcc, v1, v3 src0_sel:WORD_1 src1_sel:WORD_1
+; GFX9-NEXT:    v_cndmask_b32_e32 v1, v5, v4, vcc
 ; GFX9-NEXT:    v_pk_max_f16 v3, v0, v2
 ; GFX9-NEXT:    v_cmp_o_f16_e32 vcc, v0, v2
 ; GFX9-NEXT:    v_cndmask_b32_e32 v4, v5, v3, vcc
-; GFX9-NEXT:    v_cmp_class_f16_e64 vcc, v0, 64
-; GFX9-NEXT:    v_cndmask_b32_e32 v7, v4, v0, vcc
-; GFX9-NEXT:    v_cmp_class_f16_e64 vcc, v2, 64
-; GFX9-NEXT:    v_cndmask_b32_e32 v7, v7, v2, vcc
-; GFX9-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v4
-; GFX9-NEXT:    v_lshrrev_b32_e32 v2, 16, v2
-; GFX9-NEXT:    v_lshrrev_b32_e32 v0, 16, v0
-; GFX9-NEXT:    v_cndmask_b32_e32 v4, v4, v7, vcc
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v3, 16, v3
-; GFX9-NEXT:    v_cmp_o_f16_e32 vcc, v0, v2
-; GFX9-NEXT:    v_cndmask_b32_e32 v3, v5, v3, vcc
-; GFX9-NEXT:    v_cmp_class_f16_e64 vcc, v0, 64
-; GFX9-NEXT:    v_cndmask_b32_e32 v0, v3, v0, vcc
-; GFX9-NEXT:    v_cmp_class_f16_e64 vcc, v2, 64
-; GFX9-NEXT:    v_cndmask_b32_e32 v0, v0, v2, vcc
-; GFX9-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v3
-; GFX9-NEXT:    v_cndmask_b32_e32 v0, v3, v0, vcc
+; GFX9-NEXT:    v_cmp_o_f16_sdwa vcc, v0, v2 src0_sel:WORD_1 src1_sel:WORD_1
+; GFX9-NEXT:    v_cndmask_b32_e32 v0, v5, v3, vcc
 ; GFX9-NEXT:    s_mov_b32 s4, 0x5040100
 ; GFX9-NEXT:    v_perm_b32 v0, v0, v4, s4
 ; GFX9-NEXT:    v_perm_b32 v1, v1, v6, s4
@@ -2433,59 +1593,19 @@ define <4 x half> @v_maximum_v4f16(<4 x half> %src0, <4 x half> %src1) {
 ; GFX940-NEXT:    s_mov_b32 s0, 0x5040100
 ; GFX940-NEXT:    s_nop 0
 ; GFX940-NEXT:    v_cndmask_b32_e32 v6, v5, v4, vcc
-; GFX940-NEXT:    v_cmp_class_f16_e64 vcc, v1, 64
 ; GFX940-NEXT:    v_lshrrev_b32_e32 v4, 16, v4
-; GFX940-NEXT:    s_nop 0
-; GFX940-NEXT:    v_cndmask_b32_e32 v7, v6, v1, vcc
-; GFX940-NEXT:    v_cmp_class_f16_e64 vcc, v3, 64
-; GFX940-NEXT:    v_lshrrev_b32_e32 v1, 16, v1
-; GFX940-NEXT:    s_nop 0
-; GFX940-NEXT:    v_cndmask_b32_e32 v7, v7, v3, vcc
-; GFX940-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v6
-; GFX940-NEXT:    v_lshrrev_b32_e32 v3, 16, v3
-; GFX940-NEXT:    s_nop 0
-; GFX940-NEXT:    v_cndmask_b32_e32 v6, v6, v7, vcc
-; GFX940-NEXT:    v_cmp_o_f16_e32 vcc, v1, v3
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v4, v5, v4, vcc
-; GFX940-NEXT:    v_cmp_class_f16_e64 vcc, v1, 64
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v1, v4, v1, vcc
-; GFX940-NEXT:    v_cmp_class_f16_e64 vcc, v3, 64
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v1, v1, v3, vcc
-; GFX940-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v4
+; GFX940-NEXT:    v_cmp_o_f16_sdwa vcc, v1, v3 src0_sel:WORD_1 src1_sel:WORD_1
 ; GFX940-NEXT:    v_pk_max_f16 v3, v0, v2
 ; GFX940-NEXT:    s_nop 0
-; GFX940-NEXT:    v_cndmask_b32_e32 v1, v4, v1, vcc
+; GFX940-NEXT:    v_cndmask_b32_e32 v1, v5, v4, vcc
 ; GFX940-NEXT:    v_cmp_o_f16_e32 vcc, v0, v2
 ; GFX940-NEXT:    v_perm_b32 v1, v1, v6, s0
 ; GFX940-NEXT:    s_nop 0
 ; GFX940-NEXT:    v_cndmask_b32_e32 v4, v5, v3, vcc
-; GFX940-NEXT:    v_cmp_class_f16_e64 vcc, v0, 64
 ; GFX940-NEXT:    v_lshrrev_b32_e32 v3, 16, v3
-; GFX940-NEXT:    s_nop 0
-; GFX940-NEXT:    v_cndmask_b32_e32 v7, v4, v0, vcc
-; GFX940-NEXT:    v_cmp_class_f16_e64 vcc, v2, 64
-; GFX940-NEXT:    v_lshrrev_b32_e32 v0, 16, v0
-; GFX940-NEXT:    s_nop 0
-; GFX940-NEXT:    v_cndmask_b32_e32 v7, v7, v2, vcc
-; GFX940-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v4
-; GFX940-NEXT:    v_lshrrev_b32_e32 v2, 16, v2
-; GFX940-NEXT:    s_nop 0
-; GFX940-NEXT:    v_cndmask_b32_e32 v4, v4, v7, vcc
-; GFX940-NEXT:    v_cmp_o_f16_e32 vcc, v0, v2
+; GFX940-NEXT:    v_cmp_o_f16_sdwa vcc, v0, v2 src0_sel:WORD_1 src1_sel:WORD_1
 ; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v3, v5, v3, vcc
-; GFX940-NEXT:    v_cmp_class_f16_e64 vcc, v0, 64
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v0, v3, v0, vcc
-; GFX940-NEXT:    v_cmp_class_f16_e64 vcc, v2, 64
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v0, v0, v2, vcc
-; GFX940-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v3
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v0, v3, v0, vcc
+; GFX940-NEXT:    v_cndmask_b32_e32 v0, v5, v3, vcc
 ; GFX940-NEXT:    v_perm_b32 v0, v0, v4, s0
 ; GFX940-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -2494,46 +1614,18 @@ define <4 x half> @v_maximum_v4f16(<4 x half> %src0, <4 x half> %src1) {
 ; GFX10-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX10-NEXT:    v_pk_max_f16 v4, v1, v3
 ; GFX10-NEXT:    v_cmp_o_f16_e32 vcc_lo, v1, v3
-; GFX10-NEXT:    v_lshrrev_b32_e32 v6, 16, v1
-; GFX10-NEXT:    v_pk_max_f16 v7, v0, v2
-; GFX10-NEXT:    v_lshrrev_b32_e32 v5, 16, v3
-; GFX10-NEXT:    v_lshrrev_b32_e32 v9, 16, v2
-; GFX10-NEXT:    v_cndmask_b32_e32 v8, 0x7e00, v4, vcc_lo
-; GFX10-NEXT:    v_cmp_class_f16_e64 vcc_lo, v1, 64
-; GFX10-NEXT:    v_lshrrev_b32_e32 v10, 16, v0
-; GFX10-NEXT:    v_lshrrev_b32_e32 v4, 16, v4
-; GFX10-NEXT:    v_cndmask_b32_e32 v1, v8, v1, vcc_lo
+; GFX10-NEXT:    v_pk_max_f16 v5, v0, v2
+; GFX10-NEXT:    v_cndmask_b32_e32 v6, 0x7e00, v4, vcc_lo
 ; GFX10-NEXT:    v_cmp_o_f16_e32 vcc_lo, v0, v2
-; GFX10-NEXT:    v_cndmask_b32_e32 v11, 0x7e00, v7, vcc_lo
-; GFX10-NEXT:    v_cmp_class_f16_e64 vcc_lo, v3, 64
-; GFX10-NEXT:    v_lshrrev_b32_e32 v7, 16, v7
-; GFX10-NEXT:    v_cndmask_b32_e32 v1, v1, v3, vcc_lo
-; GFX10-NEXT:    v_cmp_o_f16_e32 vcc_lo, v6, v5
-; GFX10-NEXT:    v_cndmask_b32_e32 v3, 0x7e00, v4, vcc_lo
-; GFX10-NEXT:    v_cmp_o_f16_e32 vcc_lo, v10, v9
-; GFX10-NEXT:    v_cndmask_b32_e32 v4, 0x7e00, v7, vcc_lo
-; GFX10-NEXT:    v_cmp_eq_f16_e32 vcc_lo, 0, v8
-; GFX10-NEXT:    v_cndmask_b32_e32 v1, v8, v1, vcc_lo
-; GFX10-NEXT:    v_cmp_class_f16_e64 vcc_lo, v0, 64
-; GFX10-NEXT:    v_cndmask_b32_e32 v0, v11, v0, vcc_lo
-; GFX10-NEXT:    v_cmp_class_f16_e64 vcc_lo, v10, 64
-; GFX10-NEXT:    v_cndmask_b32_e32 v7, v4, v10, vcc_lo
-; GFX10-NEXT:    v_cmp_class_f16_e64 vcc_lo, v6, 64
-; GFX10-NEXT:    v_cndmask_b32_e32 v6, v3, v6, vcc_lo
-; GFX10-NEXT:    v_cmp_class_f16_e64 vcc_lo, v2, 64
-; GFX10-NEXT:    v_cndmask_b32_e32 v0, v0, v2, vcc_lo
-; GFX10-NEXT:    v_cmp_class_f16_e64 vcc_lo, v9, 64
-; GFX10-NEXT:    v_cndmask_b32_e32 v2, v7, v9, vcc_lo
-; GFX10-NEXT:    v_cmp_class_f16_e64 vcc_lo, v5, 64
-; GFX10-NEXT:    v_cndmask_b32_e32 v5, v6, v5, vcc_lo
-; GFX10-NEXT:    v_cmp_eq_f16_e32 vcc_lo, 0, v11
-; GFX10-NEXT:    v_cndmask_b32_e32 v0, v11, v0, vcc_lo
-; GFX10-NEXT:    v_cmp_eq_f16_e32 vcc_lo, 0, v4
-; GFX10-NEXT:    v_cndmask_b32_e32 v2, v4, v2, vcc_lo
-; GFX10-NEXT:    v_cmp_eq_f16_e32 vcc_lo, 0, v3
-; GFX10-NEXT:    v_perm_b32 v0, v2, v0, 0x5040100
-; GFX10-NEXT:    v_cndmask_b32_e32 v3, v3, v5, vcc_lo
-; GFX10-NEXT:    v_perm_b32 v1, v3, v1, 0x5040100
+; GFX10-NEXT:    v_lshrrev_b32_e32 v7, 16, v5
+; GFX10-NEXT:    v_lshrrev_b32_e32 v4, 16, v4
+; GFX10-NEXT:    v_cndmask_b32_e32 v5, 0x7e00, v5, vcc_lo
+; GFX10-NEXT:    v_cmp_o_f16_sdwa vcc_lo, v0, v2 src0_sel:WORD_1 src1_sel:WORD_1
+; GFX10-NEXT:    v_cndmask_b32_e32 v0, 0x7e00, v7, vcc_lo
+; GFX10-NEXT:    v_cmp_o_f16_sdwa vcc_lo, v1, v3 src0_sel:WORD_1 src1_sel:WORD_1
+; GFX10-NEXT:    v_perm_b32 v0, v0, v5, 0x5040100
+; GFX10-NEXT:    v_cndmask_b32_e32 v1, 0x7e00, v4, vcc_lo
+; GFX10-NEXT:    v_perm_b32 v1, v1, v6, 0x5040100
 ; GFX10-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX11-LABEL: v_maximum_v4f16:
@@ -2541,47 +1633,23 @@ define <4 x half> @v_maximum_v4f16(<4 x half> %src0, <4 x half> %src1) {
 ; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX11-NEXT:    v_pk_max_f16 v4, v1, v3
 ; GFX11-NEXT:    v_cmp_o_f16_e32 vcc_lo, v1, v3
+; GFX11-NEXT:    v_lshrrev_b32_e32 v5, 16, v3
 ; GFX11-NEXT:    v_lshrrev_b32_e32 v6, 16, v1
 ; GFX11-NEXT:    v_pk_max_f16 v7, v0, v2
-; GFX11-NEXT:    v_lshrrev_b32_e32 v5, 16, v3
-; GFX11-NEXT:    v_lshrrev_b32_e32 v9, 16, v2
-; GFX11-NEXT:    v_cndmask_b32_e32 v8, 0x7e00, v4, vcc_lo
-; GFX11-NEXT:    v_cmp_class_f16_e64 vcc_lo, v1, 64
-; GFX11-NEXT:    v_lshrrev_b32_e32 v10, 16, v0
-; GFX11-NEXT:    v_lshrrev_b32_e32 v4, 16, v4
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_4)
-; GFX11-NEXT:    v_cndmask_b32_e32 v1, v8, v1, vcc_lo
+; GFX11-NEXT:    v_lshrrev_b32_e32 v8, 16, v2
+; GFX11-NEXT:    v_cndmask_b32_e32 v1, 0x7e00, v4, vcc_lo
+; GFX11-NEXT:    v_lshrrev_b32_e32 v3, 16, v0
 ; GFX11-NEXT:    v_cmp_o_f16_e32 vcc_lo, v0, v2
-; GFX11-NEXT:    v_cndmask_b32_e32 v11, 0x7e00, v7, vcc_lo
-; GFX11-NEXT:    v_cmp_class_f16_e64 vcc_lo, v3, 64
-; GFX11-NEXT:    v_lshrrev_b32_e32 v7, 16, v7
-; GFX11-NEXT:    v_cndmask_b32_e32 v1, v1, v3, vcc_lo
+; GFX11-NEXT:    v_lshrrev_b32_e32 v9, 16, v7
+; GFX11-NEXT:    v_lshrrev_b32_e32 v4, 16, v4
+; GFX11-NEXT:    v_cndmask_b32_e32 v0, 0x7e00, v7, vcc_lo
+; GFX11-NEXT:    v_cmp_o_f16_e32 vcc_lo, v3, v8
+; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(SKIP_1) | instid1(VALU_DEP_2)
+; GFX11-NEXT:    v_cndmask_b32_e32 v2, 0x7e00, v9, vcc_lo
 ; GFX11-NEXT:    v_cmp_o_f16_e32 vcc_lo, v6, v5
-; GFX11-NEXT:    v_cndmask_b32_e32 v3, 0x7e00, v4, vcc_lo
-; GFX11-NEXT:    v_cmp_o_f16_e32 vcc_lo, v10, v9
-; GFX11-NEXT:    v_cndmask_b32_e32 v4, 0x7e00, v7, vcc_lo
-; GFX11-NEXT:    v_cmp_eq_f16_e32 vcc_lo, 0, v8
-; GFX11-NEXT:    v_cndmask_b32_e32 v1, v8, v1, vcc_lo
-; GFX11-NEXT:    v_cmp_class_f16_e64 vcc_lo, v0, 64
-; GFX11-NEXT:    v_cndmask_b32_e32 v0, v11, v0, vcc_lo
-; GFX11-NEXT:    v_cmp_class_f16_e64 vcc_lo, v10, 64
-; GFX11-NEXT:    v_cndmask_b32_e32 v7, v4, v10, vcc_lo
-; GFX11-NEXT:    v_cmp_class_f16_e64 vcc_lo, v6, 64
-; GFX11-NEXT:    v_cndmask_b32_e32 v6, v3, v6, vcc_lo
-; GFX11-NEXT:    v_cmp_class_f16_e64 vcc_lo, v2, 64
-; GFX11-NEXT:    v_cndmask_b32_e32 v0, v0, v2, vcc_lo
-; GFX11-NEXT:    v_cmp_class_f16_e64 vcc_lo, v9, 64
-; GFX11-NEXT:    v_cndmask_b32_e32 v2, v7, v9, vcc_lo
-; GFX11-NEXT:    v_cmp_class_f16_e64 vcc_lo, v5, 64
-; GFX11-NEXT:    v_cndmask_b32_e32 v5, v6, v5, vcc_lo
-; GFX11-NEXT:    v_cmp_eq_f16_e32 vcc_lo, 0, v11
-; GFX11-NEXT:    v_cndmask_b32_e32 v0, v11, v0, vcc_lo
-; GFX11-NEXT:    v_cmp_eq_f16_e32 vcc_lo, 0, v4
-; GFX11-NEXT:    v_cndmask_b32_e32 v2, v4, v2, vcc_lo
-; GFX11-NEXT:    v_cmp_eq_f16_e32 vcc_lo, 0, v3
-; GFX11-NEXT:    v_cndmask_b32_e32 v3, v3, v5, vcc_lo
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_2)
 ; GFX11-NEXT:    v_perm_b32 v0, v2, v0, 0x5040100
+; GFX11-NEXT:    v_cndmask_b32_e32 v3, 0x7e00, v4, vcc_lo
+; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GFX11-NEXT:    v_perm_b32 v1, v3, v1, 0x5040100
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -2607,266 +1675,70 @@ define <4 x half> @v_maximum_v4f16__nnan(<4 x half> %src0, <4 x half> %src1) {
 ; GFX7-NEXT:    v_cvt_f16_f32_e32 v0, v0
 ; GFX7-NEXT:    v_cvt_f16_f32_e32 v5, v5
 ; GFX7-NEXT:    v_cvt_f16_f32_e32 v1, v1
-; GFX7-NEXT:    v_cvt_f32_f16_e32 v4, v4
-; GFX7-NEXT:    v_cvt_f32_f16_e32 v0, v0
 ; GFX7-NEXT:    v_cvt_f16_f32_e32 v6, v6
 ; GFX7-NEXT:    v_cvt_f16_f32_e32 v2, v2
+; GFX7-NEXT:    v_cvt_f16_f32_e32 v7, v7
+; GFX7-NEXT:    v_cvt_f16_f32_e32 v3, v3
+; GFX7-NEXT:    v_cvt_f32_f16_e32 v4, v4
+; GFX7-NEXT:    v_cvt_f32_f16_e32 v0, v0
 ; GFX7-NEXT:    v_cvt_f32_f16_e32 v5, v5
 ; GFX7-NEXT:    v_cvt_f32_f16_e32 v1, v1
+; GFX7-NEXT:    v_cvt_f32_f16_e32 v6, v6
+; GFX7-NEXT:    v_cvt_f32_f16_e32 v2, v2
+; GFX7-NEXT:    v_cvt_f32_f16_e32 v7, v7
+; GFX7-NEXT:    v_cvt_f32_f16_e32 v3, v3
 ; GFX7-NEXT:    v_max_f32_e32 v8, v0, v4
 ; GFX7-NEXT:    v_mov_b32_e32 v9, 0x7fc00000
 ; GFX7-NEXT:    v_cmp_o_f32_e32 vcc, v0, v4
-; GFX7-NEXT:    v_cndmask_b32_e32 v8, v9, v8, vcc
-; GFX7-NEXT:    v_cmp_class_f32_e64 vcc, v0, 64
-; GFX7-NEXT:    v_cndmask_b32_e32 v0, v8, v0, vcc
-; GFX7-NEXT:    v_cmp_class_f32_e64 vcc, v4, 64
-; GFX7-NEXT:    v_cndmask_b32_e32 v0, v0, v4, vcc
-; GFX7-NEXT:    v_cmp_eq_f32_e32 vcc, 0, v8
-; GFX7-NEXT:    v_cvt_f16_f32_e32 v7, v7
-; GFX7-NEXT:    v_cvt_f16_f32_e32 v3, v3
-; GFX7-NEXT:    v_cvt_f32_f16_e32 v6, v6
-; GFX7-NEXT:    v_cvt_f32_f16_e32 v2, v2
-; GFX7-NEXT:    v_cndmask_b32_e32 v0, v8, v0, vcc
+; GFX7-NEXT:    v_cndmask_b32_e32 v0, v9, v8, vcc
 ; GFX7-NEXT:    v_max_f32_e32 v4, v1, v5
 ; GFX7-NEXT:    v_cmp_o_f32_e32 vcc, v1, v5
-; GFX7-NEXT:    v_cndmask_b32_e32 v4, v9, v4, vcc
-; GFX7-NEXT:    v_cmp_class_f32_e64 vcc, v1, 64
-; GFX7-NEXT:    v_cndmask_b32_e32 v1, v4, v1, vcc
-; GFX7-NEXT:    v_cmp_class_f32_e64 vcc, v5, 64
-; GFX7-NEXT:    v_cndmask_b32_e32 v1, v1, v5, vcc
-; GFX7-NEXT:    v_cmp_eq_f32_e32 vcc, 0, v4
-; GFX7-NEXT:    v_cvt_f32_f16_e32 v7, v7
-; GFX7-NEXT:    v_cvt_f32_f16_e32 v3, v3
-; GFX7-NEXT:    v_cndmask_b32_e32 v1, v4, v1, vcc
+; GFX7-NEXT:    v_cndmask_b32_e32 v1, v9, v4, vcc
 ; GFX7-NEXT:    v_max_f32_e32 v4, v2, v6
 ; GFX7-NEXT:    v_cmp_o_f32_e32 vcc, v2, v6
-; GFX7-NEXT:    v_cndmask_b32_e32 v4, v9, v4, vcc
-; GFX7-NEXT:    v_cmp_class_f32_e64 vcc, v2, 64
-; GFX7-NEXT:    v_cndmask_b32_e32 v2, v4, v2, vcc
-; GFX7-NEXT:    v_cmp_class_f32_e64 vcc, v6, 64
-; GFX7-NEXT:    v_cndmask_b32_e32 v2, v2, v6, vcc
-; GFX7-NEXT:    v_cmp_eq_f32_e32 vcc, 0, v4
-; GFX7-NEXT:    v_cndmask_b32_e32 v2, v4, v2, vcc
+; GFX7-NEXT:    v_cndmask_b32_e32 v2, v9, v4, vcc
 ; GFX7-NEXT:    v_max_f32_e32 v4, v3, v7
 ; GFX7-NEXT:    v_cmp_o_f32_e32 vcc, v3, v7
-; GFX7-NEXT:    v_cndmask_b32_e32 v4, v9, v4, vcc
-; GFX7-NEXT:    v_cmp_class_f32_e64 vcc, v3, 64
-; GFX7-NEXT:    v_cndmask_b32_e32 v3, v4, v3, vcc
-; GFX7-NEXT:    v_cmp_class_f32_e64 vcc, v7, 64
-; GFX7-NEXT:    v_cndmask_b32_e32 v3, v3, v7, vcc
-; GFX7-NEXT:    v_cmp_eq_f32_e32 vcc, 0, v4
-; GFX7-NEXT:    v_cndmask_b32_e32 v3, v4, v3, vcc
+; GFX7-NEXT:    v_cndmask_b32_e32 v3, v9, v4, vcc
 ; GFX7-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX8-LABEL: v_maximum_v4f16__nnan:
 ; GFX8:       ; %bb.0:
 ; GFX8-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX8-NEXT:    v_lshrrev_b32_e32 v4, 16, v3
-; GFX8-NEXT:    v_lshrrev_b32_e32 v5, 16, v1
-; GFX8-NEXT:    v_max_f16_e32 v6, v5, v4
-; GFX8-NEXT:    v_cmp_class_f16_e64 vcc, v5, 64
-; GFX8-NEXT:    v_cndmask_b32_e32 v5, v6, v5, vcc
-; GFX8-NEXT:    v_cmp_class_f16_e64 vcc, v4, 64
-; GFX8-NEXT:    v_cndmask_b32_e32 v4, v5, v4, vcc
-; GFX8-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v6
-; GFX8-NEXT:    v_cndmask_b32_e32 v4, v6, v4, vcc
-; GFX8-NEXT:    v_lshrrev_b32_e32 v5, 16, v2
-; GFX8-NEXT:    v_lshrrev_b32_e32 v6, 16, v0
-; GFX8-NEXT:    v_max_f16_e32 v7, v6, v5
-; GFX8-NEXT:    v_cmp_class_f16_e64 vcc, v6, 64
-; GFX8-NEXT:    v_cndmask_b32_e32 v6, v7, v6, vcc
-; GFX8-NEXT:    v_cmp_class_f16_e64 vcc, v5, 64
-; GFX8-NEXT:    v_cndmask_b32_e32 v5, v6, v5, vcc
-; GFX8-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v7
-; GFX8-NEXT:    v_cndmask_b32_e32 v5, v7, v5, vcc
-; GFX8-NEXT:    v_max_f16_e32 v6, v1, v3
-; GFX8-NEXT:    v_cmp_class_f16_e64 vcc, v1, 64
-; GFX8-NEXT:    v_cndmask_b32_e32 v1, v6, v1, vcc
-; GFX8-NEXT:    v_cmp_class_f16_e64 vcc, v3, 64
-; GFX8-NEXT:    v_cndmask_b32_e32 v1, v1, v3, vcc
-; GFX8-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v6
-; GFX8-NEXT:    v_cndmask_b32_e32 v1, v6, v1, vcc
-; GFX8-NEXT:    v_max_f16_e32 v3, v0, v2
-; GFX8-NEXT:    v_cmp_class_f16_e64 vcc, v0, 64
-; GFX8-NEXT:    v_cndmask_b32_e32 v0, v3, v0, vcc
-; GFX8-NEXT:    v_cmp_class_f16_e64 vcc, v2, 64
-; GFX8-NEXT:    v_cndmask_b32_e32 v0, v0, v2, vcc
-; GFX8-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v3
-; GFX8-NEXT:    v_cndmask_b32_e32 v0, v3, v0, vcc
-; GFX8-NEXT:    v_lshlrev_b32_e32 v2, 16, v5
-; GFX8-NEXT:    v_or_b32_sdwa v0, v0, v2 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
-; GFX8-NEXT:    v_lshlrev_b32_e32 v2, 16, v4
-; GFX8-NEXT:    v_or_b32_sdwa v1, v1, v2 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
+; GFX8-NEXT:    v_max_f16_sdwa v4, v1, v3 dst_sel:WORD_1 dst_unused:UNUSED_PAD src0_sel:WORD_1 src1_sel:WORD_1
+; GFX8-NEXT:    v_max_f16_sdwa v5, v0, v2 dst_sel:WORD_1 dst_unused:UNUSED_PAD src0_sel:WORD_1 src1_sel:WORD_1
+; GFX8-NEXT:    v_max_f16_e32 v1, v1, v3
+; GFX8-NEXT:    v_max_f16_e32 v0, v0, v2
+; GFX8-NEXT:    v_or_b32_e32 v0, v0, v5
+; GFX8-NEXT:    v_or_b32_e32 v1, v1, v4
 ; GFX8-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX9-LABEL: v_maximum_v4f16__nnan:
 ; GFX9:       ; %bb.0:
 ; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX9-NEXT:    v_lshrrev_b32_e32 v4, 16, v1
-; GFX9-NEXT:    v_pk_max_f16 v5, v1, v3
-; GFX9-NEXT:    v_lshrrev_b32_e32 v6, 16, v5
-; GFX9-NEXT:    v_cmp_class_f16_e64 vcc, v4, 64
-; GFX9-NEXT:    v_lshrrev_b32_e32 v7, 16, v3
-; GFX9-NEXT:    v_cndmask_b32_e32 v4, v6, v4, vcc
-; GFX9-NEXT:    v_cmp_class_f16_e64 vcc, v7, 64
-; GFX9-NEXT:    v_cndmask_b32_e32 v4, v4, v7, vcc
-; GFX9-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v6
-; GFX9-NEXT:    v_cndmask_b32_e32 v4, v6, v4, vcc
-; GFX9-NEXT:    v_lshrrev_b32_e32 v6, 16, v0
-; GFX9-NEXT:    v_pk_max_f16 v7, v0, v2
-; GFX9-NEXT:    v_lshrrev_b32_e32 v8, 16, v7
-; GFX9-NEXT:    v_cmp_class_f16_e64 vcc, v6, 64
-; GFX9-NEXT:    v_lshrrev_b32_e32 v9, 16, v2
-; GFX9-NEXT:    v_cndmask_b32_e32 v6, v8, v6, vcc
-; GFX9-NEXT:    v_cmp_class_f16_e64 vcc, v9, 64
-; GFX9-NEXT:    v_cndmask_b32_e32 v6, v6, v9, vcc
-; GFX9-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v8
-; GFX9-NEXT:    v_cndmask_b32_e32 v6, v8, v6, vcc
-; GFX9-NEXT:    v_cmp_class_f16_e64 vcc, v1, 64
-; GFX9-NEXT:    v_cndmask_b32_e32 v1, v5, v1, vcc
-; GFX9-NEXT:    v_cmp_class_f16_e64 vcc, v3, 64
-; GFX9-NEXT:    v_cndmask_b32_e32 v1, v1, v3, vcc
-; GFX9-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v5
-; GFX9-NEXT:    v_cndmask_b32_e32 v1, v5, v1, vcc
-; GFX9-NEXT:    v_cmp_class_f16_e64 vcc, v0, 64
-; GFX9-NEXT:    v_cndmask_b32_e32 v0, v7, v0, vcc
-; GFX9-NEXT:    v_cmp_class_f16_e64 vcc, v2, 64
-; GFX9-NEXT:    v_cndmask_b32_e32 v0, v0, v2, vcc
-; GFX9-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v7
-; GFX9-NEXT:    v_cndmask_b32_e32 v0, v7, v0, vcc
-; GFX9-NEXT:    s_mov_b32 s4, 0x5040100
-; GFX9-NEXT:    v_perm_b32 v0, v6, v0, s4
-; GFX9-NEXT:    v_perm_b32 v1, v4, v1, s4
+; GFX9-NEXT:    v_pk_max_f16 v0, v0, v2
+; GFX9-NEXT:    v_pk_max_f16 v1, v1, v3
 ; GFX9-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX940-LABEL: v_maximum_v4f16__nnan:
 ; GFX940:       ; %bb.0:
 ; GFX940-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX940-NEXT:    v_lshrrev_b32_e32 v4, 16, v1
-; GFX940-NEXT:    v_pk_max_f16 v5, v1, v3
-; GFX940-NEXT:    v_cmp_class_f16_e64 vcc, v4, 64
-; GFX940-NEXT:    v_lshrrev_b32_e32 v6, 16, v5
-; GFX940-NEXT:    v_lshrrev_b32_e32 v7, 16, v3
-; GFX940-NEXT:    v_cndmask_b32_e32 v4, v6, v4, vcc
-; GFX940-NEXT:    v_cmp_class_f16_e64 vcc, v7, 64
-; GFX940-NEXT:    v_lshrrev_b32_e32 v9, 16, v2
-; GFX940-NEXT:    s_mov_b32 s0, 0x5040100
-; GFX940-NEXT:    v_cndmask_b32_e32 v4, v4, v7, vcc
-; GFX940-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v6
-; GFX940-NEXT:    v_pk_max_f16 v7, v0, v2
-; GFX940-NEXT:    s_nop 0
-; GFX940-NEXT:    v_cndmask_b32_e32 v4, v6, v4, vcc
-; GFX940-NEXT:    v_lshrrev_b32_e32 v6, 16, v0
-; GFX940-NEXT:    v_lshrrev_b32_e32 v8, 16, v7
-; GFX940-NEXT:    v_cmp_class_f16_e64 vcc, v6, 64
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v6, v8, v6, vcc
-; GFX940-NEXT:    v_cmp_class_f16_e64 vcc, v9, 64
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v6, v6, v9, vcc
-; GFX940-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v8
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v6, v8, v6, vcc
-; GFX940-NEXT:    v_cmp_class_f16_e64 vcc, v1, 64
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v1, v5, v1, vcc
-; GFX940-NEXT:    v_cmp_class_f16_e64 vcc, v3, 64
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v1, v1, v3, vcc
-; GFX940-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v5
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v1, v5, v1, vcc
-; GFX940-NEXT:    v_cmp_class_f16_e64 vcc, v0, 64
-; GFX940-NEXT:    v_perm_b32 v1, v4, v1, s0
-; GFX940-NEXT:    s_nop 0
-; GFX940-NEXT:    v_cndmask_b32_e32 v0, v7, v0, vcc
-; GFX940-NEXT:    v_cmp_class_f16_e64 vcc, v2, 64
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v0, v0, v2, vcc
-; GFX940-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v7
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v0, v7, v0, vcc
-; GFX940-NEXT:    v_perm_b32 v0, v6, v0, s0
+; GFX940-NEXT:    v_pk_max_f16 v0, v0, v2
+; GFX940-NEXT:    v_pk_max_f16 v1, v1, v3
 ; GFX940-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX10-LABEL: v_maximum_v4f16__nnan:
 ; GFX10:       ; %bb.0:
 ; GFX10-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX10-NEXT:    v_pk_max_f16 v4, v1, v3
-; GFX10-NEXT:    v_lshrrev_b32_e32 v5, 16, v1
-; GFX10-NEXT:    v_pk_max_f16 v6, v0, v2
-; GFX10-NEXT:    v_lshrrev_b32_e32 v9, 16, v0
-; GFX10-NEXT:    v_lshrrev_b32_e32 v7, 16, v3
-; GFX10-NEXT:    v_lshrrev_b32_e32 v8, 16, v4
-; GFX10-NEXT:    v_cmp_class_f16_e64 vcc_lo, v5, 64
-; GFX10-NEXT:    v_lshrrev_b32_e32 v11, 16, v6
-; GFX10-NEXT:    v_lshrrev_b32_e32 v10, 16, v2
-; GFX10-NEXT:    v_cndmask_b32_e32 v5, v8, v5, vcc_lo
-; GFX10-NEXT:    v_cmp_class_f16_e64 vcc_lo, v1, 64
-; GFX10-NEXT:    v_cndmask_b32_e32 v1, v4, v1, vcc_lo
-; GFX10-NEXT:    v_cmp_class_f16_e64 vcc_lo, v9, 64
-; GFX10-NEXT:    v_cndmask_b32_e32 v9, v11, v9, vcc_lo
-; GFX10-NEXT:    v_cmp_class_f16_e64 vcc_lo, v7, 64
-; GFX10-NEXT:    v_cndmask_b32_e32 v5, v5, v7, vcc_lo
-; GFX10-NEXT:    v_cmp_class_f16_e64 vcc_lo, v0, 64
-; GFX10-NEXT:    v_cndmask_b32_e32 v0, v6, v0, vcc_lo
-; GFX10-NEXT:    v_cmp_class_f16_e64 vcc_lo, v10, 64
-; GFX10-NEXT:    v_cndmask_b32_e32 v7, v9, v10, vcc_lo
-; GFX10-NEXT:    v_cmp_eq_f16_e32 vcc_lo, 0, v8
-; GFX10-NEXT:    v_cndmask_b32_e32 v5, v8, v5, vcc_lo
-; GFX10-NEXT:    v_cmp_class_f16_e64 vcc_lo, v2, 64
-; GFX10-NEXT:    v_cndmask_b32_e32 v0, v0, v2, vcc_lo
-; GFX10-NEXT:    v_cmp_class_f16_e64 vcc_lo, v3, 64
-; GFX10-NEXT:    v_cndmask_b32_e32 v1, v1, v3, vcc_lo
-; GFX10-NEXT:    v_cmp_eq_f16_e32 vcc_lo, 0, v11
-; GFX10-NEXT:    v_cndmask_b32_e32 v2, v11, v7, vcc_lo
-; GFX10-NEXT:    v_cmp_eq_f16_e32 vcc_lo, 0, v6
-; GFX10-NEXT:    v_cndmask_b32_e32 v0, v6, v0, vcc_lo
-; GFX10-NEXT:    v_cmp_eq_f16_e32 vcc_lo, 0, v4
-; GFX10-NEXT:    v_perm_b32 v0, v2, v0, 0x5040100
-; GFX10-NEXT:    v_cndmask_b32_e32 v1, v4, v1, vcc_lo
-; GFX10-NEXT:    v_perm_b32 v1, v5, v1, 0x5040100
+; GFX10-NEXT:    v_pk_max_f16 v0, v0, v2
+; GFX10-NEXT:    v_pk_max_f16 v1, v1, v3
 ; GFX10-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX11-LABEL: v_maximum_v4f16__nnan:
 ; GFX11:       ; %bb.0:
 ; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX11-NEXT:    v_pk_max_f16 v4, v1, v3
-; GFX11-NEXT:    v_lshrrev_b32_e32 v5, 16, v1
-; GFX11-NEXT:    v_pk_max_f16 v6, v0, v2
-; GFX11-NEXT:    v_lshrrev_b32_e32 v9, 16, v0
-; GFX11-NEXT:    v_lshrrev_b32_e32 v7, 16, v3
-; GFX11-NEXT:    v_lshrrev_b32_e32 v8, 16, v4
-; GFX11-NEXT:    v_cmp_class_f16_e64 vcc_lo, v5, 64
-; GFX11-NEXT:    v_lshrrev_b32_e32 v11, 16, v6
-; GFX11-NEXT:    v_lshrrev_b32_e32 v10, 16, v2
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_4)
-; GFX11-NEXT:    v_cndmask_b32_e32 v5, v8, v5, vcc_lo
-; GFX11-NEXT:    v_cmp_class_f16_e64 vcc_lo, v1, 64
-; GFX11-NEXT:    v_cndmask_b32_e32 v1, v4, v1, vcc_lo
-; GFX11-NEXT:    v_cmp_class_f16_e64 vcc_lo, v9, 64
-; GFX11-NEXT:    v_cndmask_b32_e32 v9, v11, v9, vcc_lo
-; GFX11-NEXT:    v_cmp_class_f16_e64 vcc_lo, v7, 64
-; GFX11-NEXT:    v_cndmask_b32_e32 v5, v5, v7, vcc_lo
-; GFX11-NEXT:    v_cmp_class_f16_e64 vcc_lo, v0, 64
-; GFX11-NEXT:    v_cndmask_b32_e32 v0, v6, v0, vcc_lo
-; GFX11-NEXT:    v_cmp_class_f16_e64 vcc_lo, v10, 64
-; GFX11-NEXT:    v_cndmask_b32_e32 v7, v9, v10, vcc_lo
-; GFX11-NEXT:    v_cmp_eq_f16_e32 vcc_lo, 0, v8
-; GFX11-NEXT:    v_cndmask_b32_e32 v5, v8, v5, vcc_lo
-; GFX11-NEXT:    v_cmp_class_f16_e64 vcc_lo, v2, 64
-; GFX11-NEXT:    v_cndmask_b32_e32 v0, v0, v2, vcc_lo
-; GFX11-NEXT:    v_cmp_class_f16_e64 vcc_lo, v3, 64
-; GFX11-NEXT:    v_cndmask_b32_e32 v1, v1, v3, vcc_lo
-; GFX11-NEXT:    v_cmp_eq_f16_e32 vcc_lo, 0, v11
-; GFX11-NEXT:    v_cndmask_b32_e32 v2, v11, v7, vcc_lo
-; GFX11-NEXT:    v_cmp_eq_f16_e32 vcc_lo, 0, v6
-; GFX11-NEXT:    v_cndmask_b32_e32 v0, v6, v0, vcc_lo
-; GFX11-NEXT:    v_cmp_eq_f16_e32 vcc_lo, 0, v4
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(SKIP_1) | instid1(VALU_DEP_1)
-; GFX11-NEXT:    v_perm_b32 v0, v2, v0, 0x5040100
-; GFX11-NEXT:    v_cndmask_b32_e32 v1, v4, v1, vcc_lo
-; GFX11-NEXT:    v_perm_b32 v1, v5, v1, 0x5040100
+; GFX11-NEXT:    v_pk_max_f16 v0, v0, v2
+; GFX11-NEXT:    v_pk_max_f16 v1, v1, v3
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX12-LABEL: v_maximum_v4f16__nnan:
@@ -2891,55 +1763,31 @@ define <4 x half> @v_maximum_v4f16__nsz(<4 x half> %src0, <4 x half> %src1) {
 ; GFX7-NEXT:    v_cvt_f16_f32_e32 v0, v0
 ; GFX7-NEXT:    v_cvt_f16_f32_e32 v5, v5
 ; GFX7-NEXT:    v_cvt_f16_f32_e32 v1, v1
-; GFX7-NEXT:    v_cvt_f32_f16_e32 v4, v4
-; GFX7-NEXT:    v_cvt_f32_f16_e32 v0, v0
 ; GFX7-NEXT:    v_cvt_f16_f32_e32 v6, v6
 ; GFX7-NEXT:    v_cvt_f16_f32_e32 v2, v2
+; GFX7-NEXT:    v_cvt_f16_f32_e32 v7, v7
+; GFX7-NEXT:    v_cvt_f16_f32_e32 v3, v3
+; GFX7-NEXT:    v_cvt_f32_f16_e32 v4, v4
+; GFX7-NEXT:    v_cvt_f32_f16_e32 v0, v0
 ; GFX7-NEXT:    v_cvt_f32_f16_e32 v5, v5
 ; GFX7-NEXT:    v_cvt_f32_f16_e32 v1, v1
+; GFX7-NEXT:    v_cvt_f32_f16_e32 v6, v6
+; GFX7-NEXT:    v_cvt_f32_f16_e32 v2, v2
+; GFX7-NEXT:    v_cvt_f32_f16_e32 v7, v7
+; GFX7-NEXT:    v_cvt_f32_f16_e32 v3, v3
 ; GFX7-NEXT:    v_max_f32_e32 v8, v0, v4
 ; GFX7-NEXT:    v_mov_b32_e32 v9, 0x7fc00000
 ; GFX7-NEXT:    v_cmp_o_f32_e32 vcc, v0, v4
-; GFX7-NEXT:    v_cndmask_b32_e32 v8, v9, v8, vcc
-; GFX7-NEXT:    v_cmp_class_f32_e64 vcc, v0, 64
-; GFX7-NEXT:    v_cndmask_b32_e32 v0, v8, v0, vcc
-; GFX7-NEXT:    v_cmp_class_f32_e64 vcc, v4, 64
-; GFX7-NEXT:    v_cndmask_b32_e32 v0, v0, v4, vcc
-; GFX7-NEXT:    v_cmp_eq_f32_e32 vcc, 0, v8
-; GFX7-NEXT:    v_cvt_f16_f32_e32 v7, v7
-; GFX7-NEXT:    v_cvt_f16_f32_e32 v3, v3
-; GFX7-NEXT:    v_cvt_f32_f16_e32 v6, v6
-; GFX7-NEXT:    v_cvt_f32_f16_e32 v2, v2
-; GFX7-NEXT:    v_cndmask_b32_e32 v0, v8, v0, vcc
+; GFX7-NEXT:    v_cndmask_b32_e32 v0, v9, v8, vcc
 ; GFX7-NEXT:    v_max_f32_e32 v4, v1, v5
 ; GFX7-NEXT:    v_cmp_o_f32_e32 vcc, v1, v5
-; GFX7-NEXT:    v_cndmask_b32_e32 v4, v9, v4, vcc
-; GFX7-NEXT:    v_cmp_class_f32_e64 vcc, v1, 64
-; GFX7-NEXT:    v_cndmask_b32_e32 v1, v4, v1, vcc
-; GFX7-NEXT:    v_cmp_class_f32_e64 vcc, v5, 64
-; GFX7-NEXT:    v_cndmask_b32_e32 v1, v1, v5, vcc
-; GFX7-NEXT:    v_cmp_eq_f32_e32 vcc, 0, v4
-; GFX7-NEXT:    v_cvt_f32_f16_e32 v7, v7
-; GFX7-NEXT:    v_cvt_f32_f16_e32 v3, v3
-; GFX7-NEXT:    v_cndmask_b32_e32 v1, v4, v1, vcc
+; GFX7-NEXT:    v_cndmask_b32_e32 v1, v9, v4, vcc
 ; GFX7-NEXT:    v_max_f32_e32 v4, v2, v6
 ; GFX7-NEXT:    v_cmp_o_f32_e32 vcc, v2, v6
-; GFX7-NEXT:    v_cndmask_b32_e32 v4, v9, v4, vcc
-; GFX7-NEXT:    v_cmp_class_f32_e64 vcc, v2, 64
-; GFX7-NEXT:    v_cndmask_b32_e32 v2, v4, v2, vcc
-; GFX7-NEXT:    v_cmp_class_f32_e64 vcc, v6, 64
-; GFX7-NEXT:    v_cndmask_b32_e32 v2, v2, v6, vcc
-; GFX7-NEXT:    v_cmp_eq_f32_e32 vcc, 0, v4
-; GFX7-NEXT:    v_cndmask_b32_e32 v2, v4, v2, vcc
+; GFX7-NEXT:    v_cndmask_b32_e32 v2, v9, v4, vcc
 ; GFX7-NEXT:    v_max_f32_e32 v4, v3, v7
 ; GFX7-NEXT:    v_cmp_o_f32_e32 vcc, v3, v7
-; GFX7-NEXT:    v_cndmask_b32_e32 v4, v9, v4, vcc
-; GFX7-NEXT:    v_cmp_class_f32_e64 vcc, v3, 64
-; GFX7-NEXT:    v_cndmask_b32_e32 v3, v4, v3, vcc
-; GFX7-NEXT:    v_cmp_class_f32_e64 vcc, v7, 64
-; GFX7-NEXT:    v_cndmask_b32_e32 v3, v3, v7, vcc
-; GFX7-NEXT:    v_cmp_eq_f32_e32 vcc, 0, v4
-; GFX7-NEXT:    v_cndmask_b32_e32 v3, v4, v3, vcc
+; GFX7-NEXT:    v_cndmask_b32_e32 v3, v9, v4, vcc
 ; GFX7-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX8-LABEL: v_maximum_v4f16__nsz:
@@ -3080,55 +1928,31 @@ define <4 x half> @v_maximum_v4f16__nnan_nsz(<4 x half> %src0, <4 x half> %src1)
 ; GFX7-NEXT:    v_cvt_f16_f32_e32 v0, v0
 ; GFX7-NEXT:    v_cvt_f16_f32_e32 v5, v5
 ; GFX7-NEXT:    v_cvt_f16_f32_e32 v1, v1
-; GFX7-NEXT:    v_cvt_f32_f16_e32 v4, v4
-; GFX7-NEXT:    v_cvt_f32_f16_e32 v0, v0
 ; GFX7-NEXT:    v_cvt_f16_f32_e32 v6, v6
 ; GFX7-NEXT:    v_cvt_f16_f32_e32 v2, v2
+; GFX7-NEXT:    v_cvt_f16_f32_e32 v7, v7
+; GFX7-NEXT:    v_cvt_f16_f32_e32 v3, v3
+; GFX7-NEXT:    v_cvt_f32_f16_e32 v4, v4
+; GFX7-NEXT:    v_cvt_f32_f16_e32 v0, v0
 ; GFX7-NEXT:    v_cvt_f32_f16_e32 v5, v5
 ; GFX7-NEXT:    v_cvt_f32_f16_e32 v1, v1
+; GFX7-NEXT:    v_cvt_f32_f16_e32 v6, v6
+; GFX7-NEXT:    v_cvt_f32_f16_e32 v2, v2
+; GFX7-NEXT:    v_cvt_f32_f16_e32 v7, v7
+; GFX7-NEXT:    v_cvt_f32_f16_e32 v3, v3
 ; GFX7-NEXT:    v_max_f32_e32 v8, v0, v4
 ; GFX7-NEXT:    v_mov_b32_e32 v9, 0x7fc00000
 ; GFX7-NEXT:    v_cmp_o_f32_e32 vcc, v0, v4
-; GFX7-NEXT:    v_cndmask_b32_e32 v8, v9, v8, vcc
-; GFX7-NEXT:    v_cmp_class_f32_e64 vcc, v0, 64
-; GFX7-NEXT:    v_cndmask_b32_e32 v0, v8, v0, vcc
-; GFX7-NEXT:    v_cmp_class_f32_e64 vcc, v4, 64
-; GFX7-NEXT:    v_cndmask_b32_e32 v0, v0, v4, vcc
-; GFX7-NEXT:    v_cmp_eq_f32_e32 vcc, 0, v8
-; GFX7-NEXT:    v_cvt_f16_f32_e32 v7, v7
-; GFX7-NEXT:    v_cvt_f16_f32_e32 v3, v3
-; GFX7-NEXT:    v_cvt_f32_f16_e32 v6, v6
-; GFX7-NEXT:    v_cvt_f32_f16_e32 v2, v2
-; GFX7-NEXT:    v_cndmask_b32_e32 v0, v8, v0, vcc
+; GFX7-NEXT:    v_cndmask_b32_e32 v0, v9, v8, vcc
 ; GFX7-NEXT:    v_max_f32_e32 v4, v1, v5
 ; GFX7-NEXT:    v_cmp_o_f32_e32 vcc, v1, v5
-; GFX7-NEXT:    v_cndmask_b32_e32 v4, v9, v4, vcc
-; GFX7-NEXT:    v_cmp_class_f32_e64 vcc, v1, 64
-; GFX7-NEXT:    v_cndmask_b32_e32 v1, v4, v1, vcc
-; GFX7-NEXT:    v_cmp_class_f32_e64 vcc, v5, 64
-; GFX7-NEXT:    v_cndmask_b32_e32 v1, v1, v5, vcc
-; GFX7-NEXT:    v_cmp_eq_f32_e32 vcc, 0, v4
-; GFX7-NEXT:    v_cvt_f32_f16_e32 v7, v7
-; GFX7-NEXT:    v_cvt_f32_f16_e32 v3, v3
-; GFX7-NEXT:    v_cndmask_b32_e32 v1, v4, v1, vcc
+; GFX7-NEXT:    v_cndmask_b32_e32 v1, v9, v4, vcc
 ; GFX7-NEXT:    v_max_f32_e32 v4, v2, v6
 ; GFX7-NEXT:    v_cmp_o_f32_e32 vcc, v2, v6
-; GFX7-NEXT:    v_cndmask_b32_e32 v4, v9, v4, vcc
-; GFX7-NEXT:    v_cmp_class_f32_e64 vcc, v2, 64
-; GFX7-NEXT:    v_cndmask_b32_e32 v2, v4, v2, vcc
-; GFX7-NEXT:    v_cmp_class_f32_e64 vcc, v6, 64
-; GFX7-NEXT:    v_cndmask_b32_e32 v2, v2, v6, vcc
-; GFX7-NEXT:    v_cmp_eq_f32_e32 vcc, 0, v4
-; GFX7-NEXT:    v_cndmask_b32_e32 v2, v4, v2, vcc
+; GFX7-NEXT:    v_cndmask_b32_e32 v2, v9, v4, vcc
 ; GFX7-NEXT:    v_max_f32_e32 v4, v3, v7
 ; GFX7-NEXT:    v_cmp_o_f32_e32 vcc, v3, v7
-; GFX7-NEXT:    v_cndmask_b32_e32 v4, v9, v4, vcc
-; GFX7-NEXT:    v_cmp_class_f32_e64 vcc, v3, 64
-; GFX7-NEXT:    v_cndmask_b32_e32 v3, v4, v3, vcc
-; GFX7-NEXT:    v_cmp_class_f32_e64 vcc, v7, 64
-; GFX7-NEXT:    v_cndmask_b32_e32 v3, v3, v7, vcc
-; GFX7-NEXT:    v_cmp_eq_f32_e32 vcc, 0, v4
-; GFX7-NEXT:    v_cndmask_b32_e32 v3, v4, v3, vcc
+; GFX7-NEXT:    v_cndmask_b32_e32 v3, v9, v4, vcc
 ; GFX7-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX8-LABEL: v_maximum_v4f16__nnan_nsz:
@@ -3192,107 +2016,59 @@ define <8 x half> @v_maximum_v8f16(<8 x half> %src0, <8 x half> %src1) {
 ; GFX7-NEXT:    v_cvt_f16_f32_e32 v0, v0
 ; GFX7-NEXT:    v_cvt_f16_f32_e32 v9, v9
 ; GFX7-NEXT:    v_cvt_f16_f32_e32 v1, v1
-; GFX7-NEXT:    v_cvt_f32_f16_e32 v8, v8
-; GFX7-NEXT:    v_cvt_f32_f16_e32 v0, v0
 ; GFX7-NEXT:    v_cvt_f16_f32_e32 v10, v10
 ; GFX7-NEXT:    v_cvt_f16_f32_e32 v2, v2
+; GFX7-NEXT:    v_cvt_f16_f32_e32 v11, v11
+; GFX7-NEXT:    v_cvt_f16_f32_e32 v3, v3
+; GFX7-NEXT:    v_cvt_f16_f32_e32 v12, v12
+; GFX7-NEXT:    v_cvt_f16_f32_e32 v4, v4
+; GFX7-NEXT:    v_cvt_f32_f16_e32 v8, v8
+; GFX7-NEXT:    v_cvt_f32_f16_e32 v0, v0
+; GFX7-NEXT:    v_cvt_f16_f32_e32 v13, v13
+; GFX7-NEXT:    v_cvt_f16_f32_e32 v5, v5
 ; GFX7-NEXT:    v_cvt_f32_f16_e32 v9, v9
 ; GFX7-NEXT:    v_cvt_f32_f16_e32 v1, v1
+; GFX7-NEXT:    v_cvt_f16_f32_e32 v14, v14
+; GFX7-NEXT:    v_cvt_f16_f32_e32 v6, v6
+; GFX7-NEXT:    v_cvt_f32_f16_e32 v10, v10
+; GFX7-NEXT:    v_cvt_f32_f16_e32 v2, v2
+; GFX7-NEXT:    v_cvt_f16_f32_e32 v15, v15
+; GFX7-NEXT:    v_cvt_f16_f32_e32 v7, v7
+; GFX7-NEXT:    v_cvt_f32_f16_e32 v11, v11
+; GFX7-NEXT:    v_cvt_f32_f16_e32 v3, v3
+; GFX7-NEXT:    v_cvt_f32_f16_e32 v12, v12
+; GFX7-NEXT:    v_cvt_f32_f16_e32 v4, v4
 ; GFX7-NEXT:    v_max_f32_e32 v16, v0, v8
 ; GFX7-NEXT:    v_mov_b32_e32 v17, 0x7fc00000
 ; GFX7-NEXT:    v_cmp_o_f32_e32 vcc, v0, v8
-; GFX7-NEXT:    v_cndmask_b32_e32 v16, v17, v16, vcc
-; GFX7-NEXT:    v_cmp_class_f32_e64 vcc, v0, 64
-; GFX7-NEXT:    v_cndmask_b32_e32 v0, v16, v0, vcc
-; GFX7-NEXT:    v_cmp_class_f32_e64 vcc, v8, 64
-; GFX7-NEXT:    v_cndmask_b32_e32 v0, v0, v8, vcc
-; GFX7-NEXT:    v_cmp_eq_f32_e32 vcc, 0, v16
-; GFX7-NEXT:    v_cvt_f16_f32_e32 v11, v11
-; GFX7-NEXT:    v_cvt_f16_f32_e32 v3, v3
-; GFX7-NEXT:    v_cvt_f32_f16_e32 v10, v10
-; GFX7-NEXT:    v_cvt_f32_f16_e32 v2, v2
-; GFX7-NEXT:    v_cndmask_b32_e32 v0, v16, v0, vcc
-; GFX7-NEXT:    v_max_f32_e32 v8, v1, v9
-; GFX7-NEXT:    v_cmp_o_f32_e32 vcc, v1, v9
-; GFX7-NEXT:    v_cndmask_b32_e32 v8, v17, v8, vcc
-; GFX7-NEXT:    v_cmp_class_f32_e64 vcc, v1, 64
-; GFX7-NEXT:    v_cndmask_b32_e32 v1, v8, v1, vcc
-; GFX7-NEXT:    v_cmp_class_f32_e64 vcc, v9, 64
-; GFX7-NEXT:    v_cndmask_b32_e32 v1, v1, v9, vcc
-; GFX7-NEXT:    v_cmp_eq_f32_e32 vcc, 0, v8
-; GFX7-NEXT:    v_cvt_f16_f32_e32 v12, v12
-; GFX7-NEXT:    v_cvt_f16_f32_e32 v4, v4
-; GFX7-NEXT:    v_cvt_f32_f16_e32 v11, v11
-; GFX7-NEXT:    v_cvt_f32_f16_e32 v3, v3
-; GFX7-NEXT:    v_cndmask_b32_e32 v1, v8, v1, vcc
-; GFX7-NEXT:    v_max_f32_e32 v8, v2, v10
-; GFX7-NEXT:    v_cmp_o_f32_e32 vcc, v2, v10
-; GFX7-NEXT:    v_cndmask_b32_e32 v8, v17, v8, vcc
-; GFX7-NEXT:    v_cmp_class_f32_e64 vcc, v2, 64
-; GFX7-NEXT:    v_cndmask_b32_e32 v2, v8, v2, vcc
-; GFX7-NEXT:    v_cmp_class_f32_e64 vcc, v10, 64
-; GFX7-NEXT:    v_cndmask_b32_e32 v2, v2, v10, vcc
-; GFX7-NEXT:    v_cmp_eq_f32_e32 vcc, 0, v8
-; GFX7-NEXT:    v_cvt_f16_f32_e32 v13, v13
-; GFX7-NEXT:    v_cvt_f16_f32_e32 v5, v5
-; GFX7-NEXT:    v_cvt_f32_f16_e32 v12, v12
-; GFX7-NEXT:    v_cvt_f32_f16_e32 v4, v4
-; GFX7-NEXT:    v_cndmask_b32_e32 v2, v8, v2, vcc
-; GFX7-NEXT:    v_max_f32_e32 v8, v3, v11
-; GFX7-NEXT:    v_cmp_o_f32_e32 vcc, v3, v11
-; GFX7-NEXT:    v_cndmask_b32_e32 v8, v17, v8, vcc
-; GFX7-NEXT:    v_cmp_class_f32_e64 vcc, v3, 64
-; GFX7-NEXT:    v_cndmask_b32_e32 v3, v8, v3, vcc
-; GFX7-NEXT:    v_cmp_class_f32_e64 vcc, v11, 64
-; GFX7-NEXT:    v_cndmask_b32_e32 v3, v3, v11, vcc
-; GFX7-NEXT:    v_cmp_eq_f32_e32 vcc, 0, v8
-; GFX7-NEXT:    v_cvt_f16_f32_e32 v14, v14
-; GFX7-NEXT:    v_cvt_f16_f32_e32 v6, v6
 ; GFX7-NEXT:    v_cvt_f32_f16_e32 v13, v13
 ; GFX7-NEXT:    v_cvt_f32_f16_e32 v5, v5
-; GFX7-NEXT:    v_cndmask_b32_e32 v3, v8, v3, vcc
-; GFX7-NEXT:    v_max_f32_e32 v8, v4, v12
-; GFX7-NEXT:    v_cmp_o_f32_e32 vcc, v4, v12
-; GFX7-NEXT:    v_cndmask_b32_e32 v8, v17, v8, vcc
-; GFX7-NEXT:    v_cmp_class_f32_e64 vcc, v4, 64
-; GFX7-NEXT:    v_cndmask_b32_e32 v4, v8, v4, vcc
-; GFX7-NEXT:    v_cmp_class_f32_e64 vcc, v12, 64
-; GFX7-NEXT:    v_cndmask_b32_e32 v4, v4, v12, vcc
-; GFX7-NEXT:    v_cmp_eq_f32_e32 vcc, 0, v8
-; GFX7-NEXT:    v_cvt_f16_f32_e32 v15, v15
-; GFX7-NEXT:    v_cvt_f16_f32_e32 v7, v7
+; GFX7-NEXT:    v_cndmask_b32_e32 v0, v17, v16, vcc
+; GFX7-NEXT:    v_max_f32_e32 v8, v1, v9
+; GFX7-NEXT:    v_cmp_o_f32_e32 vcc, v1, v9
 ; GFX7-NEXT:    v_cvt_f32_f16_e32 v14, v14
 ; GFX7-NEXT:    v_cvt_f32_f16_e32 v6, v6
-; GFX7-NEXT:    v_cndmask_b32_e32 v4, v8, v4, vcc
-; GFX7-NEXT:    v_max_f32_e32 v8, v5, v13
-; GFX7-NEXT:    v_cmp_o_f32_e32 vcc, v5, v13
-; GFX7-NEXT:    v_cndmask_b32_e32 v8, v17, v8, vcc
-; GFX7-NEXT:    v_cmp_class_f32_e64 vcc, v5, 64
-; GFX7-NEXT:    v_cndmask_b32_e32 v5, v8, v5, vcc
-; GFX7-NEXT:    v_cmp_class_f32_e64 vcc, v13, 64
-; GFX7-NEXT:    v_cndmask_b32_e32 v5, v5, v13, vcc
-; GFX7-NEXT:    v_cmp_eq_f32_e32 vcc, 0, v8
+; GFX7-NEXT:    v_cndmask_b32_e32 v1, v17, v8, vcc
+; GFX7-NEXT:    v_max_f32_e32 v8, v2, v10
+; GFX7-NEXT:    v_cmp_o_f32_e32 vcc, v2, v10
 ; GFX7-NEXT:    v_cvt_f32_f16_e32 v15, v15
 ; GFX7-NEXT:    v_cvt_f32_f16_e32 v7, v7
-; GFX7-NEXT:    v_cndmask_b32_e32 v5, v8, v5, vcc
+; GFX7-NEXT:    v_cndmask_b32_e32 v2, v17, v8, vcc
+; GFX7-NEXT:    v_max_f32_e32 v8, v3, v11
+; GFX7-NEXT:    v_cmp_o_f32_e32 vcc, v3, v11
+; GFX7-NEXT:    v_cndmask_b32_e32 v3, v17, v8, vcc
+; GFX7-NEXT:    v_max_f32_e32 v8, v4, v12
+; GFX7-NEXT:    v_cmp_o_f32_e32 vcc, v4, v12
+; GFX7-NEXT:    v_cndmask_b32_e32 v4, v17, v8, vcc
+; GFX7-NEXT:    v_max_f32_e32 v8, v5, v13
+; GFX7-NEXT:    v_cmp_o_f32_e32 vcc, v5, v13
+; GFX7-NEXT:    v_cndmask_b32_e32 v5, v17, v8, vcc
 ; GFX7-NEXT:    v_max_f32_e32 v8, v6, v14
 ; GFX7-NEXT:    v_cmp_o_f32_e32 vcc, v6, v14
-; GFX7-NEXT:    v_cndmask_b32_e32 v8, v17, v8, vcc
-; GFX7-NEXT:    v_cmp_class_f32_e64 vcc, v6, 64
-; GFX7-NEXT:    v_cndmask_b32_e32 v6, v8, v6, vcc
-; GFX7-NEXT:    v_cmp_class_f32_e64 vcc, v14, 64
-; GFX7-NEXT:    v_cndmask_b32_e32 v6, v6, v14, vcc
-; GFX7-NEXT:    v_cmp_eq_f32_e32 vcc, 0, v8
-; GFX7-NEXT:    v_cndmask_b32_e32 v6, v8, v6, vcc
+; GFX7-NEXT:    v_cndmask_b32_e32 v6, v17, v8, vcc
 ; GFX7-NEXT:    v_max_f32_e32 v8, v7, v15
 ; GFX7-NEXT:    v_cmp_o_f32_e32 vcc, v7, v15
-; GFX7-NEXT:    v_cndmask_b32_e32 v8, v17, v8, vcc
-; GFX7-NEXT:    v_cmp_class_f32_e64 vcc, v7, 64
-; GFX7-NEXT:    v_cndmask_b32_e32 v7, v8, v7, vcc
-; GFX7-NEXT:    v_cmp_class_f32_e64 vcc, v15, 64
-; GFX7-NEXT:    v_cndmask_b32_e32 v7, v7, v15, vcc
-; GFX7-NEXT:    v_cmp_eq_f32_e32 vcc, 0, v8
-; GFX7-NEXT:    v_cndmask_b32_e32 v7, v8, v7, vcc
+; GFX7-NEXT:    v_cndmask_b32_e32 v7, v17, v8, vcc
 ; GFX7-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX8-LABEL: v_maximum_v8f16:
@@ -3303,82 +2079,34 @@ define <8 x half> @v_maximum_v8f16(<8 x half> %src0, <8 x half> %src1) {
 ; GFX8-NEXT:    v_max_f16_e32 v10, v9, v8
 ; GFX8-NEXT:    v_mov_b32_e32 v11, 0x7e00
 ; GFX8-NEXT:    v_cmp_o_f16_e32 vcc, v9, v8
-; GFX8-NEXT:    v_cndmask_b32_e32 v10, v11, v10, vcc
-; GFX8-NEXT:    v_cmp_class_f16_e64 vcc, v9, 64
-; GFX8-NEXT:    v_cndmask_b32_e32 v9, v10, v9, vcc
-; GFX8-NEXT:    v_cmp_class_f16_e64 vcc, v8, 64
-; GFX8-NEXT:    v_cndmask_b32_e32 v8, v9, v8, vcc
-; GFX8-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v10
-; GFX8-NEXT:    v_cndmask_b32_e32 v8, v10, v8, vcc
+; GFX8-NEXT:    v_cndmask_b32_e32 v8, v11, v10, vcc
 ; GFX8-NEXT:    v_lshrrev_b32_e32 v9, 16, v6
 ; GFX8-NEXT:    v_lshrrev_b32_e32 v10, 16, v2
 ; GFX8-NEXT:    v_max_f16_e32 v12, v10, v9
 ; GFX8-NEXT:    v_cmp_o_f16_e32 vcc, v10, v9
-; GFX8-NEXT:    v_cndmask_b32_e32 v12, v11, v12, vcc
-; GFX8-NEXT:    v_cmp_class_f16_e64 vcc, v10, 64
-; GFX8-NEXT:    v_cndmask_b32_e32 v10, v12, v10, vcc
-; GFX8-NEXT:    v_cmp_class_f16_e64 vcc, v9, 64
-; GFX8-NEXT:    v_cndmask_b32_e32 v9, v10, v9, vcc
-; GFX8-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v12
-; GFX8-NEXT:    v_cndmask_b32_e32 v9, v12, v9, vcc
+; GFX8-NEXT:    v_cndmask_b32_e32 v9, v11, v12, vcc
 ; GFX8-NEXT:    v_lshrrev_b32_e32 v10, 16, v5
 ; GFX8-NEXT:    v_lshrrev_b32_e32 v12, 16, v1
 ; GFX8-NEXT:    v_max_f16_e32 v13, v12, v10
 ; GFX8-NEXT:    v_cmp_o_f16_e32 vcc, v12, v10
-; GFX8-NEXT:    v_cndmask_b32_e32 v13, v11, v13, vcc
-; GFX8-NEXT:    v_cmp_class_f16_e64 vcc, v12, 64
-; GFX8-NEXT:    v_cndmask_b32_e32 v12, v13, v12, vcc
-; GFX8-NEXT:    v_cmp_class_f16_e64 vcc, v10, 64
-; GFX8-NEXT:    v_cndmask_b32_e32 v10, v12, v10, vcc
-; GFX8-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v13
-; GFX8-NEXT:    v_cndmask_b32_e32 v10, v13, v10, vcc
+; GFX8-NEXT:    v_cndmask_b32_e32 v10, v11, v13, vcc
 ; GFX8-NEXT:    v_lshrrev_b32_e32 v12, 16, v4
 ; GFX8-NEXT:    v_lshrrev_b32_e32 v13, 16, v0
 ; GFX8-NEXT:    v_max_f16_e32 v14, v13, v12
 ; GFX8-NEXT:    v_cmp_o_f16_e32 vcc, v13, v12
-; GFX8-NEXT:    v_cndmask_b32_e32 v14, v11, v14, vcc
-; GFX8-NEXT:    v_cmp_class_f16_e64 vcc, v13, 64
-; GFX8-NEXT:    v_cndmask_b32_e32 v13, v14, v13, vcc
-; GFX8-NEXT:    v_cmp_class_f16_e64 vcc, v12, 64
-; GFX8-NEXT:    v_cndmask_b32_e32 v12, v13, v12, vcc
-; GFX8-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v14
-; GFX8-NEXT:    v_cndmask_b32_e32 v12, v14, v12, vcc
+; GFX8-NEXT:    v_cndmask_b32_e32 v12, v11, v14, vcc
 ; GFX8-NEXT:    v_max_f16_e32 v13, v3, v7
 ; GFX8-NEXT:    v_cmp_o_f16_e32 vcc, v3, v7
-; GFX8-NEXT:    v_cndmask_b32_e32 v13, v11, v13, vcc
-; GFX8-NEXT:    v_cmp_class_f16_e64 vcc, v3, 64
-; GFX8-NEXT:    v_cndmask_b32_e32 v3, v13, v3, vcc
-; GFX8-NEXT:    v_cmp_class_f16_e64 vcc, v7, 64
-; GFX8-NEXT:    v_cndmask_b32_e32 v3, v3, v7, vcc
-; GFX8-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v13
-; GFX8-NEXT:    v_cndmask_b32_e32 v3, v13, v3, vcc
+; GFX8-NEXT:    v_cndmask_b32_e32 v3, v11, v13, vcc
 ; GFX8-NEXT:    v_max_f16_e32 v7, v2, v6
 ; GFX8-NEXT:    v_cmp_o_f16_e32 vcc, v2, v6
-; GFX8-NEXT:    v_cndmask_b32_e32 v7, v11, v7, vcc
-; GFX8-NEXT:    v_cmp_class_f16_e64 vcc, v2, 64
-; GFX8-NEXT:    v_cndmask_b32_e32 v2, v7, v2, vcc
-; GFX8-NEXT:    v_cmp_class_f16_e64 vcc, v6, 64
-; GFX8-NEXT:    v_cndmask_b32_e32 v2, v2, v6, vcc
-; GFX8-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v7
-; GFX8-NEXT:    v_cndmask_b32_e32 v2, v7, v2, vcc
+; GFX8-NEXT:    v_cndmask_b32_e32 v2, v11, v7, vcc
 ; GFX8-NEXT:    v_max_f16_e32 v6, v1, v5
 ; GFX8-NEXT:    v_cmp_o_f16_e32 vcc, v1, v5
-; GFX8-NEXT:    v_cndmask_b32_e32 v6, v11, v6, vcc
-; GFX8-NEXT:    v_cmp_class_f16_e64 vcc, v1, 64
-; GFX8-NEXT:    v_cndmask_b32_e32 v1, v6, v1, vcc
-; GFX8-NEXT:    v_cmp_class_f16_e64 vcc, v5, 64
-; GFX8-NEXT:    v_cndmask_b32_e32 v1, v1, v5, vcc
-; GFX8-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v6
-; GFX8-NEXT:    v_cndmask_b32_e32 v1, v6, v1, vcc
+; GFX8-NEXT:    v_cndmask_b32_e32 v1, v11, v6, vcc
 ; GFX8-NEXT:    v_max_f16_e32 v5, v0, v4
 ; GFX8-NEXT:    v_cmp_o_f16_e32 vcc, v0, v4
-; GFX8-NEXT:    v_cndmask_b32_e32 v5, v11, v5, vcc
-; GFX8-NEXT:    v_cmp_class_f16_e64 vcc, v0, 64
-; GFX8-NEXT:    v_cndmask_b32_e32 v0, v5, v0, vcc
-; GFX8-NEXT:    v_cmp_class_f16_e64 vcc, v4, 64
-; GFX8-NEXT:    v_cndmask_b32_e32 v0, v0, v4, vcc
-; GFX8-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v5
-; GFX8-NEXT:    v_cndmask_b32_e32 v0, v5, v0, vcc
+; GFX8-NEXT:    v_cndmask_b32_e32 v0, v11, v5, vcc
 ; GFX8-NEXT:    v_lshlrev_b32_e32 v4, 16, v12
 ; GFX8-NEXT:    v_or_b32_sdwa v0, v0, v4 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
 ; GFX8-NEXT:    v_lshlrev_b32_e32 v4, 16, v10
@@ -3396,83 +2124,27 @@ define <8 x half> @v_maximum_v8f16(<8 x half> %src0, <8 x half> %src1) {
 ; GFX9-NEXT:    v_mov_b32_e32 v9, 0x7e00
 ; GFX9-NEXT:    v_cmp_o_f16_e32 vcc, v3, v7
 ; GFX9-NEXT:    v_cndmask_b32_e32 v10, v9, v8, vcc
-; GFX9-NEXT:    v_cmp_class_f16_e64 vcc, v3, 64
-; GFX9-NEXT:    v_cndmask_b32_e32 v11, v10, v3, vcc
-; GFX9-NEXT:    v_cmp_class_f16_e64 vcc, v7, 64
-; GFX9-NEXT:    v_cndmask_b32_e32 v11, v11, v7, vcc
-; GFX9-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v10
-; GFX9-NEXT:    v_lshrrev_b32_e32 v7, 16, v7
-; GFX9-NEXT:    v_lshrrev_b32_e32 v3, 16, v3
-; GFX9-NEXT:    v_cndmask_b32_e32 v10, v10, v11, vcc
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v8, 16, v8
-; GFX9-NEXT:    v_cmp_o_f16_e32 vcc, v3, v7
-; GFX9-NEXT:    v_cndmask_b32_e32 v8, v9, v8, vcc
-; GFX9-NEXT:    v_cmp_class_f16_e64 vcc, v3, 64
-; GFX9-NEXT:    v_cndmask_b32_e32 v3, v8, v3, vcc
-; GFX9-NEXT:    v_cmp_class_f16_e64 vcc, v7, 64
-; GFX9-NEXT:    v_cndmask_b32_e32 v3, v3, v7, vcc
-; GFX9-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v8
-; GFX9-NEXT:    v_cndmask_b32_e32 v3, v8, v3, vcc
+; GFX9-NEXT:    v_cmp_o_f16_sdwa vcc, v3, v7 src0_sel:WORD_1 src1_sel:WORD_1
+; GFX9-NEXT:    v_cndmask_b32_e32 v3, v9, v8, vcc
 ; GFX9-NEXT:    v_pk_max_f16 v7, v2, v6
 ; GFX9-NEXT:    v_cmp_o_f16_e32 vcc, v2, v6
 ; GFX9-NEXT:    v_cndmask_b32_e32 v8, v9, v7, vcc
-; GFX9-NEXT:    v_cmp_class_f16_e64 vcc, v2, 64
-; GFX9-NEXT:    v_cndmask_b32_e32 v11, v8, v2, vcc
-; GFX9-NEXT:    v_cmp_class_f16_e64 vcc, v6, 64
-; GFX9-NEXT:    v_cndmask_b32_e32 v11, v11, v6, vcc
-; GFX9-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v8
-; GFX9-NEXT:    v_lshrrev_b32_e32 v6, 16, v6
-; GFX9-NEXT:    v_lshrrev_b32_e32 v2, 16, v2
-; GFX9-NEXT:    v_cndmask_b32_e32 v8, v8, v11, vcc
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v7, 16, v7
-; GFX9-NEXT:    v_cmp_o_f16_e32 vcc, v2, v6
-; GFX9-NEXT:    v_cndmask_b32_e32 v7, v9, v7, vcc
-; GFX9-NEXT:    v_cmp_class_f16_e64 vcc, v2, 64
-; GFX9-NEXT:    v_cndmask_b32_e32 v2, v7, v2, vcc
-; GFX9-NEXT:    v_cmp_class_f16_e64 vcc, v6, 64
-; GFX9-NEXT:    v_cndmask_b32_e32 v2, v2, v6, vcc
-; GFX9-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v7
-; GFX9-NEXT:    v_cndmask_b32_e32 v2, v7, v2, vcc
+; GFX9-NEXT:    v_cmp_o_f16_sdwa vcc, v2, v6 src0_sel:WORD_1 src1_sel:WORD_1
+; GFX9-NEXT:    v_cndmask_b32_e32 v2, v9, v7, vcc
 ; GFX9-NEXT:    v_pk_max_f16 v6, v1, v5
 ; GFX9-NEXT:    v_cmp_o_f16_e32 vcc, v1, v5
 ; GFX9-NEXT:    v_cndmask_b32_e32 v7, v9, v6, vcc
-; GFX9-NEXT:    v_cmp_class_f16_e64 vcc, v1, 64
-; GFX9-NEXT:    v_cndmask_b32_e32 v11, v7, v1, vcc
-; GFX9-NEXT:    v_cmp_class_f16_e64 vcc, v5, 64
-; GFX9-NEXT:    v_cndmask_b32_e32 v11, v11, v5, vcc
-; GFX9-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v7
-; GFX9-NEXT:    v_lshrrev_b32_e32 v5, 16, v5
-; GFX9-NEXT:    v_lshrrev_b32_e32 v1, 16, v1
-; GFX9-NEXT:    v_cndmask_b32_e32 v7, v7, v11, vcc
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v6, 16, v6
-; GFX9-NEXT:    v_cmp_o_f16_e32 vcc, v1, v5
-; GFX9-NEXT:    v_cndmask_b32_e32 v6, v9, v6, vcc
-; GFX9-NEXT:    v_cmp_class_f16_e64 vcc, v1, 64
-; GFX9-NEXT:    v_cndmask_b32_e32 v1, v6, v1, vcc
-; GFX9-NEXT:    v_cmp_class_f16_e64 vcc, v5, 64
-; GFX9-NEXT:    v_cndmask_b32_e32 v1, v1, v5, vcc
-; GFX9-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v6
-; GFX9-NEXT:    v_cndmask_b32_e32 v1, v6, v1, vcc
+; GFX9-NEXT:    v_cmp_o_f16_sdwa vcc, v1, v5 src0_sel:WORD_1 src1_sel:WORD_1
+; GFX9-NEXT:    v_cndmask_b32_e32 v1, v9, v6, vcc
 ; GFX9-NEXT:    v_pk_max_f16 v5, v0, v4
 ; GFX9-NEXT:    v_cmp_o_f16_e32 vcc, v0, v4
 ; GFX9-NEXT:    v_cndmask_b32_e32 v6, v9, v5, vcc
-; GFX9-NEXT:    v_cmp_class_f16_e64 vcc, v0, 64
-; GFX9-NEXT:    v_cndmask_b32_e32 v11, v6, v0, vcc
-; GFX9-NEXT:    v_cmp_class_f16_e64 vcc, v4, 64
-; GFX9-NEXT:    v_cndmask_b32_e32 v11, v11, v4, vcc
-; GFX9-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v6
-; GFX9-NEXT:    v_lshrrev_b32_e32 v4, 16, v4
-; GFX9-NEXT:    v_lshrrev_b32_e32 v0, 16, v0
-; GFX9-NEXT:    v_cndmask_b32_e32 v6, v6, v11, vcc
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v5, 16, v5
-; GFX9-NEXT:    v_cmp_o_f16_e32 vcc, v0, v4
-; GFX9-NEXT:    v_cndmask_b32_e32 v5, v9, v5, vcc
-; GFX9-NEXT:    v_cmp_class_f16_e64 vcc, v0, 64
-; GFX9-NEXT:    v_cndmask_b32_e32 v0, v5, v0, vcc
-; GFX9-NEXT:    v_cmp_class_f16_e64 vcc, v4, 64
-; GFX9-NEXT:    v_cndmask_b32_e32 v0, v0, v4, vcc
-; GFX9-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v5
-; GFX9-NEXT:    v_cndmask_b32_e32 v0, v5, v0, vcc
+; GFX9-NEXT:    v_cmp_o_f16_sdwa vcc, v0, v4 src0_sel:WORD_1 src1_sel:WORD_1
+; GFX9-NEXT:    v_cndmask_b32_e32 v0, v9, v5, vcc
 ; GFX9-NEXT:    s_mov_b32 s4, 0x5040100
 ; GFX9-NEXT:    v_perm_b32 v0, v0, v6, s4
 ; GFX9-NEXT:    v_perm_b32 v1, v1, v7, s4
@@ -3489,117 +2161,37 @@ define <8 x half> @v_maximum_v8f16(<8 x half> %src0, <8 x half> %src1) {
 ; GFX940-NEXT:    s_mov_b32 s0, 0x5040100
 ; GFX940-NEXT:    s_nop 0
 ; GFX940-NEXT:    v_cndmask_b32_e32 v10, v9, v8, vcc
-; GFX940-NEXT:    v_cmp_class_f16_e64 vcc, v3, 64
 ; GFX940-NEXT:    v_lshrrev_b32_e32 v8, 16, v8
-; GFX940-NEXT:    s_nop 0
-; GFX940-NEXT:    v_cndmask_b32_e32 v11, v10, v3, vcc
-; GFX940-NEXT:    v_cmp_class_f16_e64 vcc, v7, 64
-; GFX940-NEXT:    v_lshrrev_b32_e32 v3, 16, v3
-; GFX940-NEXT:    s_nop 0
-; GFX940-NEXT:    v_cndmask_b32_e32 v11, v11, v7, vcc
-; GFX940-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v10
-; GFX940-NEXT:    v_lshrrev_b32_e32 v7, 16, v7
-; GFX940-NEXT:    s_nop 0
-; GFX940-NEXT:    v_cndmask_b32_e32 v10, v10, v11, vcc
-; GFX940-NEXT:    v_cmp_o_f16_e32 vcc, v3, v7
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v8, v9, v8, vcc
-; GFX940-NEXT:    v_cmp_class_f16_e64 vcc, v3, 64
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v3, v8, v3, vcc
-; GFX940-NEXT:    v_cmp_class_f16_e64 vcc, v7, 64
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v3, v3, v7, vcc
-; GFX940-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v8
+; GFX940-NEXT:    v_cmp_o_f16_sdwa vcc, v3, v7 src0_sel:WORD_1 src1_sel:WORD_1
 ; GFX940-NEXT:    v_pk_max_f16 v7, v2, v6
 ; GFX940-NEXT:    s_nop 0
-; GFX940-NEXT:    v_cndmask_b32_e32 v3, v8, v3, vcc
+; GFX940-NEXT:    v_cndmask_b32_e32 v3, v9, v8, vcc
 ; GFX940-NEXT:    v_cmp_o_f16_e32 vcc, v2, v6
 ; GFX940-NEXT:    v_perm_b32 v3, v3, v10, s0
 ; GFX940-NEXT:    s_nop 0
 ; GFX940-NEXT:    v_cndmask_b32_e32 v8, v9, v7, vcc
-; GFX940-NEXT:    v_cmp_class_f16_e64 vcc, v2, 64
 ; GFX940-NEXT:    v_lshrrev_b32_e32 v7, 16, v7
-; GFX940-NEXT:    s_nop 0
-; GFX940-NEXT:    v_cndmask_b32_e32 v11, v8, v2, vcc
-; GFX940-NEXT:    v_cmp_class_f16_e64 vcc, v6, 64
-; GFX940-NEXT:    v_lshrrev_b32_e32 v2, 16, v2
-; GFX940-NEXT:    s_nop 0
-; GFX940-NEXT:    v_cndmask_b32_e32 v11, v11, v6, vcc
-; GFX940-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v8
-; GFX940-NEXT:    v_lshrrev_b32_e32 v6, 16, v6
-; GFX940-NEXT:    s_nop 0
-; GFX940-NEXT:    v_cndmask_b32_e32 v8, v8, v11, vcc
-; GFX940-NEXT:    v_cmp_o_f16_e32 vcc, v2, v6
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v7, v9, v7, vcc
-; GFX940-NEXT:    v_cmp_class_f16_e64 vcc, v2, 64
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v2, v7, v2, vcc
-; GFX940-NEXT:    v_cmp_class_f16_e64 vcc, v6, 64
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v2, v2, v6, vcc
-; GFX940-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v7
+; GFX940-NEXT:    v_cmp_o_f16_sdwa vcc, v2, v6 src0_sel:WORD_1 src1_sel:WORD_1
 ; GFX940-NEXT:    v_pk_max_f16 v6, v1, v5
 ; GFX940-NEXT:    s_nop 0
-; GFX940-NEXT:    v_cndmask_b32_e32 v2, v7, v2, vcc
+; GFX940-NEXT:    v_cndmask_b32_e32 v2, v9, v7, vcc
 ; GFX940-NEXT:    v_cmp_o_f16_e32 vcc, v1, v5
 ; GFX940-NEXT:    v_perm_b32 v2, v2, v8, s0
 ; GFX940-NEXT:    s_nop 0
 ; GFX940-NEXT:    v_cndmask_b32_e32 v7, v9, v6, vcc
-; GFX940-NEXT:    v_cmp_class_f16_e64 vcc, v1, 64
 ; GFX940-NEXT:    v_lshrrev_b32_e32 v6, 16, v6
-; GFX940-NEXT:    s_nop 0
-; GFX940-NEXT:    v_cndmask_b32_e32 v11, v7, v1, vcc
-; GFX940-NEXT:    v_cmp_class_f16_e64 vcc, v5, 64
-; GFX940-NEXT:    v_lshrrev_b32_e32 v1, 16, v1
-; GFX940-NEXT:    s_nop 0
-; GFX940-NEXT:    v_cndmask_b32_e32 v11, v11, v5, vcc
-; GFX940-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v7
-; GFX940-NEXT:    v_lshrrev_b32_e32 v5, 16, v5
-; GFX940-NEXT:    s_nop 0
-; GFX940-NEXT:    v_cndmask_b32_e32 v7, v7, v11, vcc
-; GFX940-NEXT:    v_cmp_o_f16_e32 vcc, v1, v5
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v6, v9, v6, vcc
-; GFX940-NEXT:    v_cmp_class_f16_e64 vcc, v1, 64
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v1, v6, v1, vcc
-; GFX940-NEXT:    v_cmp_class_f16_e64 vcc, v5, 64
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v1, v1, v5, vcc
-; GFX940-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v6
+; GFX940-NEXT:    v_cmp_o_f16_sdwa vcc, v1, v5 src0_sel:WORD_1 src1_sel:WORD_1
 ; GFX940-NEXT:    v_pk_max_f16 v5, v0, v4
 ; GFX940-NEXT:    s_nop 0
-; GFX940-NEXT:    v_cndmask_b32_e32 v1, v6, v1, vcc
+; GFX940-NEXT:    v_cndmask_b32_e32 v1, v9, v6, vcc
 ; GFX940-NEXT:    v_cmp_o_f16_e32 vcc, v0, v4
 ; GFX940-NEXT:    v_perm_b32 v1, v1, v7, s0
 ; GFX940-NEXT:    s_nop 0
 ; GFX940-NEXT:    v_cndmask_b32_e32 v6, v9, v5, vcc
-; GFX940-NEXT:    v_cmp_class_f16_e64 vcc, v0, 64
 ; GFX940-NEXT:    v_lshrrev_b32_e32 v5, 16, v5
-; GFX940-NEXT:    s_nop 0
-; GFX940-NEXT:    v_cndmask_b32_e32 v11, v6, v0, vcc
-; GFX940-NEXT:    v_cmp_class_f16_e64 vcc, v4, 64
-; GFX940-NEXT:    v_lshrrev_b32_e32 v0, 16, v0
-; GFX940-NEXT:    s_nop 0
-; GFX940-NEXT:    v_cndmask_b32_e32 v11, v11, v4, vcc
-; GFX940-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v6
-; GFX940-NEXT:    v_lshrrev_b32_e32 v4, 16, v4
-; GFX940-NEXT:    s_nop 0
-; GFX940-NEXT:    v_cndmask_b32_e32 v6, v6, v11, vcc
-; GFX940-NEXT:    v_cmp_o_f16_e32 vcc, v0, v4
+; GFX940-NEXT:    v_cmp_o_f16_sdwa vcc, v0, v4 src0_sel:WORD_1 src1_sel:WORD_1
 ; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v5, v9, v5, vcc
-; GFX940-NEXT:    v_cmp_class_f16_e64 vcc, v0, 64
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v0, v5, v0, vcc
-; GFX940-NEXT:    v_cmp_class_f16_e64 vcc, v4, 64
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v0, v0, v4, vcc
-; GFX940-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v5
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v0, v5, v0, vcc
+; GFX940-NEXT:    v_cndmask_b32_e32 v0, v9, v5, vcc
 ; GFX940-NEXT:    v_perm_b32 v0, v0, v6, s0
 ; GFX940-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -3608,88 +2200,32 @@ define <8 x half> @v_maximum_v8f16(<8 x half> %src0, <8 x half> %src1) {
 ; GFX10-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX10-NEXT:    v_pk_max_f16 v8, v3, v7
 ; GFX10-NEXT:    v_cmp_o_f16_e32 vcc_lo, v3, v7
-; GFX10-NEXT:    v_lshrrev_b32_e32 v10, 16, v7
-; GFX10-NEXT:    v_lshrrev_b32_e32 v11, 16, v3
-; GFX10-NEXT:    v_pk_max_f16 v13, v1, v5
-; GFX10-NEXT:    v_cndmask_b32_e32 v9, 0x7e00, v8, vcc_lo
-; GFX10-NEXT:    v_cmp_class_f16_e64 vcc_lo, v3, 64
-; GFX10-NEXT:    v_lshrrev_b32_e32 v8, 16, v8
-; GFX10-NEXT:    v_cndmask_b32_e32 v3, v9, v3, vcc_lo
-; GFX10-NEXT:    v_cmp_o_f16_e32 vcc_lo, v11, v10
-; GFX10-NEXT:    v_cndmask_b32_e32 v8, 0x7e00, v8, vcc_lo
-; GFX10-NEXT:    v_cmp_class_f16_e64 vcc_lo, v7, 64
-; GFX10-NEXT:    v_cndmask_b32_e32 v3, v3, v7, vcc_lo
-; GFX10-NEXT:    v_cmp_class_f16_e64 vcc_lo, v11, 64
-; GFX10-NEXT:    v_cndmask_b32_e32 v7, v8, v11, vcc_lo
-; GFX10-NEXT:    v_cmp_eq_f16_e32 vcc_lo, 0, v9
-; GFX10-NEXT:    v_pk_max_f16 v11, v2, v6
-; GFX10-NEXT:    v_cndmask_b32_e32 v3, v9, v3, vcc_lo
-; GFX10-NEXT:    v_cmp_class_f16_e64 vcc_lo, v10, 64
-; GFX10-NEXT:    v_lshrrev_b32_e32 v9, 16, v6
-; GFX10-NEXT:    v_lshrrev_b32_e32 v12, 16, v11
-; GFX10-NEXT:    v_cndmask_b32_e32 v7, v7, v10, vcc_lo
-; GFX10-NEXT:    v_lshrrev_b32_e32 v10, 16, v2
+; GFX10-NEXT:    v_pk_max_f16 v9, v2, v6
+; GFX10-NEXT:    v_pk_max_f16 v12, v1, v5
+; GFX10-NEXT:    v_pk_max_f16 v13, v0, v4
+; GFX10-NEXT:    v_cndmask_b32_e32 v10, 0x7e00, v8, vcc_lo
 ; GFX10-NEXT:    v_cmp_o_f16_e32 vcc_lo, v2, v6
-; GFX10-NEXT:    v_cndmask_b32_e32 v11, 0x7e00, v11, vcc_lo
-; GFX10-NEXT:    v_cmp_o_f16_e32 vcc_lo, v10, v9
-; GFX10-NEXT:    v_cndmask_b32_e32 v12, 0x7e00, v12, vcc_lo
+; GFX10-NEXT:    v_lshrrev_b32_e32 v11, 16, v9
+; GFX10-NEXT:    v_lshrrev_b32_e32 v8, 16, v8
+; GFX10-NEXT:    v_cndmask_b32_e32 v9, 0x7e00, v9, vcc_lo
+; GFX10-NEXT:    v_cmp_o_f16_sdwa vcc_lo, v2, v6 src0_sel:WORD_1 src1_sel:WORD_1
+; GFX10-NEXT:    v_cndmask_b32_e32 v2, 0x7e00, v11, vcc_lo
 ; GFX10-NEXT:    v_cmp_o_f16_e32 vcc_lo, v1, v5
-; GFX10-NEXT:    v_cndmask_b32_e32 v14, 0x7e00, v13, vcc_lo
-; GFX10-NEXT:    v_cmp_class_f16_e64 vcc_lo, v2, 64
-; GFX10-NEXT:    v_lshrrev_b32_e32 v13, 16, v13
-; GFX10-NEXT:    v_cndmask_b32_e32 v2, v11, v2, vcc_lo
-; GFX10-NEXT:    v_cmp_class_f16_e64 vcc_lo, v10, 64
-; GFX10-NEXT:    v_cndmask_b32_e32 v10, v12, v10, vcc_lo
-; GFX10-NEXT:    v_cmp_class_f16_e64 vcc_lo, v1, 64
-; GFX10-NEXT:    v_cndmask_b32_e32 v15, v14, v1, vcc_lo
-; GFX10-NEXT:    v_cmp_class_f16_e64 vcc_lo, v6, 64
-; GFX10-NEXT:    v_lshrrev_b32_e32 v1, 16, v1
-; GFX10-NEXT:    v_cndmask_b32_e32 v2, v2, v6, vcc_lo
-; GFX10-NEXT:    v_cmp_class_f16_e64 vcc_lo, v9, 64
-; GFX10-NEXT:    v_cndmask_b32_e32 v6, v10, v9, vcc_lo
-; GFX10-NEXT:    v_cmp_class_f16_e64 vcc_lo, v5, 64
-; GFX10-NEXT:    v_pk_max_f16 v10, v0, v4
-; GFX10-NEXT:    v_cndmask_b32_e32 v9, v15, v5, vcc_lo
-; GFX10-NEXT:    v_cmp_eq_f16_e32 vcc_lo, 0, v11
-; GFX10-NEXT:    v_lshrrev_b32_e32 v5, 16, v5
-; GFX10-NEXT:    v_cndmask_b32_e32 v2, v11, v2, vcc_lo
-; GFX10-NEXT:    v_cmp_eq_f16_e32 vcc_lo, 0, v12
-; GFX10-NEXT:    v_lshrrev_b32_e32 v11, 16, v4
-; GFX10-NEXT:    v_cndmask_b32_e32 v6, v12, v6, vcc_lo
-; GFX10-NEXT:    v_cmp_eq_f16_e32 vcc_lo, 0, v14
-; GFX10-NEXT:    v_lshrrev_b32_e32 v12, 16, v0
-; GFX10-NEXT:    v_perm_b32 v2, v6, v2, 0x5040100
-; GFX10-NEXT:    v_cndmask_b32_e32 v9, v14, v9, vcc_lo
+; GFX10-NEXT:    v_lshrrev_b32_e32 v11, 16, v13
+; GFX10-NEXT:    v_perm_b32 v2, v2, v9, 0x5040100
+; GFX10-NEXT:    v_cndmask_b32_e32 v6, 0x7e00, v12, vcc_lo
 ; GFX10-NEXT:    v_cmp_o_f16_e32 vcc_lo, v0, v4
-; GFX10-NEXT:    v_lshrrev_b32_e32 v14, 16, v10
-; GFX10-NEXT:    v_cndmask_b32_e32 v10, 0x7e00, v10, vcc_lo
-; GFX10-NEXT:    v_cmp_o_f16_e32 vcc_lo, v12, v11
-; GFX10-NEXT:    v_cndmask_b32_e32 v14, 0x7e00, v14, vcc_lo
-; GFX10-NEXT:    v_cmp_o_f16_e32 vcc_lo, v1, v5
+; GFX10-NEXT:    v_lshrrev_b32_e32 v12, 16, v12
 ; GFX10-NEXT:    v_cndmask_b32_e32 v13, 0x7e00, v13, vcc_lo
-; GFX10-NEXT:    v_cmp_class_f16_e64 vcc_lo, v0, 64
-; GFX10-NEXT:    v_cndmask_b32_e32 v0, v10, v0, vcc_lo
-; GFX10-NEXT:    v_cmp_class_f16_e64 vcc_lo, v12, 64
-; GFX10-NEXT:    v_cndmask_b32_e32 v12, v14, v12, vcc_lo
-; GFX10-NEXT:    v_cmp_class_f16_e64 vcc_lo, v1, 64
-; GFX10-NEXT:    v_cndmask_b32_e32 v1, v13, v1, vcc_lo
-; GFX10-NEXT:    v_cmp_class_f16_e64 vcc_lo, v4, 64
-; GFX10-NEXT:    v_cndmask_b32_e32 v0, v0, v4, vcc_lo
-; GFX10-NEXT:    v_cmp_class_f16_e64 vcc_lo, v11, 64
-; GFX10-NEXT:    v_cndmask_b32_e32 v4, v12, v11, vcc_lo
-; GFX10-NEXT:    v_cmp_class_f16_e64 vcc_lo, v5, 64
-; GFX10-NEXT:    v_cndmask_b32_e32 v1, v1, v5, vcc_lo
-; GFX10-NEXT:    v_cmp_eq_f16_e32 vcc_lo, 0, v10
-; GFX10-NEXT:    v_cndmask_b32_e32 v0, v10, v0, vcc_lo
-; GFX10-NEXT:    v_cmp_eq_f16_e32 vcc_lo, 0, v14
-; GFX10-NEXT:    v_cndmask_b32_e32 v4, v14, v4, vcc_lo
-; GFX10-NEXT:    v_cmp_eq_f16_e32 vcc_lo, 0, v13
-; GFX10-NEXT:    v_perm_b32 v0, v4, v0, 0x5040100
-; GFX10-NEXT:    v_cndmask_b32_e32 v1, v13, v1, vcc_lo
-; GFX10-NEXT:    v_cmp_eq_f16_e32 vcc_lo, 0, v8
-; GFX10-NEXT:    v_perm_b32 v1, v1, v9, 0x5040100
-; GFX10-NEXT:    v_cndmask_b32_e32 v5, v8, v7, vcc_lo
-; GFX10-NEXT:    v_perm_b32 v3, v5, v3, 0x5040100
+; GFX10-NEXT:    v_cmp_o_f16_sdwa vcc_lo, v0, v4 src0_sel:WORD_1 src1_sel:WORD_1
+; GFX10-NEXT:    v_cndmask_b32_e32 v0, 0x7e00, v11, vcc_lo
+; GFX10-NEXT:    v_cmp_o_f16_sdwa vcc_lo, v1, v5 src0_sel:WORD_1 src1_sel:WORD_1
+; GFX10-NEXT:    v_perm_b32 v0, v0, v13, 0x5040100
+; GFX10-NEXT:    v_cndmask_b32_e32 v1, 0x7e00, v12, vcc_lo
+; GFX10-NEXT:    v_cmp_o_f16_sdwa vcc_lo, v3, v7 src0_sel:WORD_1 src1_sel:WORD_1
+; GFX10-NEXT:    v_perm_b32 v1, v1, v6, 0x5040100
+; GFX10-NEXT:    v_cndmask_b32_e32 v3, 0x7e00, v8, vcc_lo
+; GFX10-NEXT:    v_perm_b32 v3, v3, v10, 0x5040100
 ; GFX10-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX11-LABEL: v_maximum_v8f16:
@@ -3697,94 +2233,42 @@ define <8 x half> @v_maximum_v8f16(<8 x half> %src0, <8 x half> %src1) {
 ; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX11-NEXT:    v_pk_max_f16 v8, v3, v7
 ; GFX11-NEXT:    v_cmp_o_f16_e32 vcc_lo, v3, v7
-; GFX11-NEXT:    v_lshrrev_b32_e32 v10, 16, v7
-; GFX11-NEXT:    v_lshrrev_b32_e32 v11, 16, v3
-; GFX11-NEXT:    v_pk_max_f16 v13, v1, v5
+; GFX11-NEXT:    v_pk_max_f16 v10, v2, v6
+; GFX11-NEXT:    v_lshrrev_b32_e32 v11, 16, v6
+; GFX11-NEXT:    v_lshrrev_b32_e32 v12, 16, v2
+; GFX11-NEXT:    v_pk_max_f16 v14, v1, v5
 ; GFX11-NEXT:    v_cndmask_b32_e32 v9, 0x7e00, v8, vcc_lo
-; GFX11-NEXT:    v_cmp_class_f16_e64 vcc_lo, v3, 64
-; GFX11-NEXT:    v_lshrrev_b32_e32 v8, 16, v8
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(SKIP_1) | instid1(VALU_DEP_3)
-; GFX11-NEXT:    v_cndmask_b32_e32 v3, v9, v3, vcc_lo
-; GFX11-NEXT:    v_cmp_o_f16_e32 vcc_lo, v11, v10
-; GFX11-NEXT:    v_cndmask_b32_e32 v8, 0x7e00, v8, vcc_lo
-; GFX11-NEXT:    v_cmp_class_f16_e64 vcc_lo, v7, 64
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(SKIP_1) | instid1(VALU_DEP_4)
-; GFX11-NEXT:    v_cndmask_b32_e32 v3, v3, v7, vcc_lo
-; GFX11-NEXT:    v_cmp_class_f16_e64 vcc_lo, v11, 64
-; GFX11-NEXT:    v_cndmask_b32_e32 v7, v8, v11, vcc_lo
-; GFX11-NEXT:    v_cmp_eq_f16_e32 vcc_lo, 0, v9
-; GFX11-NEXT:    v_pk_max_f16 v11, v2, v6
-; GFX11-NEXT:    v_cndmask_b32_e32 v3, v9, v3, vcc_lo
-; GFX11-NEXT:    v_cmp_class_f16_e64 vcc_lo, v10, 64
-; GFX11-NEXT:    v_lshrrev_b32_e32 v9, 16, v6
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(SKIP_4) | instid1(VALU_DEP_3)
-; GFX11-NEXT:    v_lshrrev_b32_e32 v12, 16, v11
-; GFX11-NEXT:    v_cndmask_b32_e32 v7, v7, v10, vcc_lo
-; GFX11-NEXT:    v_lshrrev_b32_e32 v10, 16, v2
 ; GFX11-NEXT:    v_cmp_o_f16_e32 vcc_lo, v2, v6
-; GFX11-NEXT:    v_cndmask_b32_e32 v11, 0x7e00, v11, vcc_lo
-; GFX11-NEXT:    v_cmp_o_f16_e32 vcc_lo, v10, v9
-; GFX11-NEXT:    v_cndmask_b32_e32 v12, 0x7e00, v12, vcc_lo
-; GFX11-NEXT:    v_cmp_o_f16_e32 vcc_lo, v1, v5
-; GFX11-NEXT:    v_cndmask_b32_e32 v14, 0x7e00, v13, vcc_lo
-; GFX11-NEXT:    v_cmp_class_f16_e64 vcc_lo, v2, 64
-; GFX11-NEXT:    v_lshrrev_b32_e32 v13, 16, v13
-; GFX11-NEXT:    v_cndmask_b32_e32 v2, v11, v2, vcc_lo
-; GFX11-NEXT:    v_cmp_class_f16_e64 vcc_lo, v10, 64
-; GFX11-NEXT:    v_cndmask_b32_e32 v10, v12, v10, vcc_lo
-; GFX11-NEXT:    v_cmp_class_f16_e64 vcc_lo, v1, 64
-; GFX11-NEXT:    v_cndmask_b32_e32 v15, v14, v1, vcc_lo
-; GFX11-NEXT:    v_cmp_class_f16_e64 vcc_lo, v6, 64
-; GFX11-NEXT:    v_lshrrev_b32_e32 v1, 16, v1
-; GFX11-NEXT:    v_cndmask_b32_e32 v2, v2, v6, vcc_lo
-; GFX11-NEXT:    v_cmp_class_f16_e64 vcc_lo, v9, 64
-; GFX11-NEXT:    v_cndmask_b32_e32 v6, v10, v9, vcc_lo
-; GFX11-NEXT:    v_cmp_class_f16_e64 vcc_lo, v5, 64
-; GFX11-NEXT:    v_pk_max_f16 v10, v0, v4
-; GFX11-NEXT:    v_cndmask_b32_e32 v9, v15, v5, vcc_lo
-; GFX11-NEXT:    v_cmp_eq_f16_e32 vcc_lo, 0, v11
-; GFX11-NEXT:    v_lshrrev_b32_e32 v5, 16, v5
-; GFX11-NEXT:    v_cndmask_b32_e32 v2, v11, v2, vcc_lo
-; GFX11-NEXT:    v_cmp_eq_f16_e32 vcc_lo, 0, v12
-; GFX11-NEXT:    v_lshrrev_b32_e32 v11, 16, v4
-; GFX11-NEXT:    v_cndmask_b32_e32 v6, v12, v6, vcc_lo
-; GFX11-NEXT:    v_cmp_eq_f16_e32 vcc_lo, 0, v14
-; GFX11-NEXT:    v_lshrrev_b32_e32 v12, 16, v0
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_3)
-; GFX11-NEXT:    v_perm_b32 v2, v6, v2, 0x5040100
-; GFX11-NEXT:    v_cndmask_b32_e32 v9, v14, v9, vcc_lo
-; GFX11-NEXT:    v_cmp_o_f16_e32 vcc_lo, v0, v4
-; GFX11-NEXT:    v_lshrrev_b32_e32 v14, 16, v10
-; GFX11-NEXT:    v_cndmask_b32_e32 v10, 0x7e00, v10, vcc_lo
+; GFX11-NEXT:    v_lshrrev_b32_e32 v13, 16, v10
+; GFX11-NEXT:    v_lshrrev_b32_e32 v7, 16, v7
+; GFX11-NEXT:    v_lshrrev_b32_e32 v3, 16, v3
+; GFX11-NEXT:    v_lshrrev_b32_e32 v8, 16, v8
+; GFX11-NEXT:    v_cndmask_b32_e32 v2, 0x7e00, v10, vcc_lo
 ; GFX11-NEXT:    v_cmp_o_f16_e32 vcc_lo, v12, v11
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_3)
-; GFX11-NEXT:    v_cndmask_b32_e32 v14, 0x7e00, v14, vcc_lo
+; GFX11-NEXT:    v_pk_max_f16 v11, v0, v4
+; GFX11-NEXT:    v_lshrrev_b32_e32 v12, 16, v4
+; GFX11-NEXT:    v_cndmask_b32_e32 v6, 0x7e00, v13, vcc_lo
 ; GFX11-NEXT:    v_cmp_o_f16_e32 vcc_lo, v1, v5
-; GFX11-NEXT:    v_cndmask_b32_e32 v13, 0x7e00, v13, vcc_lo
-; GFX11-NEXT:    v_cmp_class_f16_e64 vcc_lo, v0, 64
-; GFX11-NEXT:    v_cndmask_b32_e32 v0, v10, v0, vcc_lo
-; GFX11-NEXT:    v_cmp_class_f16_e64 vcc_lo, v12, 64
-; GFX11-NEXT:    v_cndmask_b32_e32 v12, v14, v12, vcc_lo
-; GFX11-NEXT:    v_cmp_class_f16_e64 vcc_lo, v1, 64
-; GFX11-NEXT:    v_cndmask_b32_e32 v1, v13, v1, vcc_lo
-; GFX11-NEXT:    v_cmp_class_f16_e64 vcc_lo, v4, 64
-; GFX11-NEXT:    v_cndmask_b32_e32 v0, v0, v4, vcc_lo
-; GFX11-NEXT:    v_cmp_class_f16_e64 vcc_lo, v11, 64
-; GFX11-NEXT:    v_cndmask_b32_e32 v4, v12, v11, vcc_lo
-; GFX11-NEXT:    v_cmp_class_f16_e64 vcc_lo, v5, 64
-; GFX11-NEXT:    v_cndmask_b32_e32 v1, v1, v5, vcc_lo
-; GFX11-NEXT:    v_cmp_eq_f16_e32 vcc_lo, 0, v10
-; GFX11-NEXT:    v_cndmask_b32_e32 v0, v10, v0, vcc_lo
-; GFX11-NEXT:    v_cmp_eq_f16_e32 vcc_lo, 0, v14
-; GFX11-NEXT:    v_cndmask_b32_e32 v4, v14, v4, vcc_lo
-; GFX11-NEXT:    v_cmp_eq_f16_e32 vcc_lo, 0, v13
-; GFX11-NEXT:    v_cndmask_b32_e32 v1, v13, v1, vcc_lo
-; GFX11-NEXT:    v_cmp_eq_f16_e32 vcc_lo, 0, v8
+; GFX11-NEXT:    v_lshrrev_b32_e32 v13, 16, v0
+; GFX11-NEXT:    v_lshrrev_b32_e32 v5, 16, v5
+; GFX11-NEXT:    v_lshrrev_b32_e32 v1, 16, v1
+; GFX11-NEXT:    v_lshrrev_b32_e32 v15, 16, v11
+; GFX11-NEXT:    v_cndmask_b32_e32 v10, 0x7e00, v14, vcc_lo
+; GFX11-NEXT:    v_cmp_o_f16_e32 vcc_lo, v0, v4
+; GFX11-NEXT:    v_lshrrev_b32_e32 v14, 16, v14
+; GFX11-NEXT:    v_perm_b32 v2, v6, v2, 0x5040100
+; GFX11-NEXT:    v_cndmask_b32_e32 v0, 0x7e00, v11, vcc_lo
+; GFX11-NEXT:    v_cmp_o_f16_e32 vcc_lo, v13, v12
+; GFX11-NEXT:    v_cndmask_b32_e32 v4, 0x7e00, v15, vcc_lo
+; GFX11-NEXT:    v_cmp_o_f16_e32 vcc_lo, v1, v5
 ; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(SKIP_2) | instid1(VALU_DEP_2)
-; GFX11-NEXT:    v_perm_b32 v1, v1, v9, 0x5040100
-; GFX11-NEXT:    v_cndmask_b32_e32 v5, v8, v7, vcc_lo
 ; GFX11-NEXT:    v_perm_b32 v0, v4, v0, 0x5040100
-; GFX11-NEXT:    v_perm_b32 v3, v5, v3, 0x5040100
+; GFX11-NEXT:    v_cndmask_b32_e32 v1, 0x7e00, v14, vcc_lo
+; GFX11-NEXT:    v_cmp_o_f16_e32 vcc_lo, v3, v7
+; GFX11-NEXT:    v_perm_b32 v1, v1, v10, 0x5040100
+; GFX11-NEXT:    v_cndmask_b32_e32 v3, 0x7e00, v8, vcc_lo
+; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX11-NEXT:    v_perm_b32 v3, v3, v9, 0x5040100
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX12-LABEL: v_maximum_v8f16:
@@ -3809,381 +2293,189 @@ define <16 x half> @v_maximum_v16f16(<16 x half> %src0, <16 x half> %src1) {
 ; GFX7-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX7-NEXT:    v_cvt_f16_f32_e32 v16, v16
 ; GFX7-NEXT:    v_cvt_f16_f32_e32 v0, v0
-; GFX7-NEXT:    v_cvt_f16_f32_e32 v17, v17
-; GFX7-NEXT:    v_cvt_f16_f32_e32 v1, v1
-; GFX7-NEXT:    v_cvt_f32_f16_e32 v31, v16
-; GFX7-NEXT:    v_cvt_f32_f16_e32 v0, v0
-; GFX7-NEXT:    v_mov_b32_e32 v16, 0x7fc00000
-; GFX7-NEXT:    v_cvt_f32_f16_e32 v17, v17
-; GFX7-NEXT:    v_cvt_f32_f16_e32 v1, v1
-; GFX7-NEXT:    v_max_f32_e32 v32, v0, v31
-; GFX7-NEXT:    v_cmp_o_f32_e32 vcc, v0, v31
-; GFX7-NEXT:    v_cvt_f16_f32_e32 v18, v18
-; GFX7-NEXT:    v_cvt_f16_f32_e32 v2, v2
-; GFX7-NEXT:    v_cndmask_b32_e32 v32, v16, v32, vcc
-; GFX7-NEXT:    v_cmp_class_f32_e64 vcc, v0, 64
-; GFX7-NEXT:    v_cndmask_b32_e32 v0, v32, v0, vcc
-; GFX7-NEXT:    v_cmp_class_f32_e64 vcc, v31, 64
-; GFX7-NEXT:    v_cndmask_b32_e32 v0, v0, v31, vcc
-; GFX7-NEXT:    v_cmp_eq_f32_e32 vcc, 0, v32
-; GFX7-NEXT:    v_cndmask_b32_e32 v0, v32, v0, vcc
-; GFX7-NEXT:    v_max_f32_e32 v31, v1, v17
-; GFX7-NEXT:    v_cmp_o_f32_e32 vcc, v1, v17
-; GFX7-NEXT:    v_cvt_f32_f16_e32 v18, v18
-; GFX7-NEXT:    v_cvt_f32_f16_e32 v2, v2
-; GFX7-NEXT:    v_cndmask_b32_e32 v31, v16, v31, vcc
-; GFX7-NEXT:    v_cmp_class_f32_e64 vcc, v1, 64
-; GFX7-NEXT:    v_cndmask_b32_e32 v1, v31, v1, vcc
-; GFX7-NEXT:    v_cmp_class_f32_e64 vcc, v17, 64
-; GFX7-NEXT:    v_cndmask_b32_e32 v1, v1, v17, vcc
-; GFX7-NEXT:    v_cmp_eq_f32_e32 vcc, 0, v31
-; GFX7-NEXT:    v_cndmask_b32_e32 v1, v31, v1, vcc
-; GFX7-NEXT:    v_max_f32_e32 v17, v2, v18
-; GFX7-NEXT:    v_cmp_o_f32_e32 vcc, v2, v18
-; GFX7-NEXT:    v_cndmask_b32_e32 v17, v16, v17, vcc
-; GFX7-NEXT:    v_cmp_class_f32_e64 vcc, v2, 64
-; GFX7-NEXT:    v_cndmask_b32_e32 v2, v17, v2, vcc
-; GFX7-NEXT:    v_cmp_class_f32_e64 vcc, v18, 64
-; GFX7-NEXT:    v_cndmask_b32_e32 v2, v2, v18, vcc
-; GFX7-NEXT:    v_cvt_f16_f32_e32 v18, v20
-; GFX7-NEXT:    buffer_load_dword v20, off, s[0:3], s32
-; GFX7-NEXT:    v_cvt_f16_f32_e32 v19, v19
-; GFX7-NEXT:    v_cvt_f16_f32_e32 v3, v3
-; GFX7-NEXT:    v_cvt_f16_f32_e32 v4, v4
-; GFX7-NEXT:    v_cmp_eq_f32_e32 vcc, 0, v17
-; GFX7-NEXT:    v_cvt_f32_f16_e32 v19, v19
-; GFX7-NEXT:    v_cvt_f32_f16_e32 v3, v3
-; GFX7-NEXT:    v_cndmask_b32_e32 v2, v17, v2, vcc
-; GFX7-NEXT:    v_cvt_f32_f16_e32 v18, v18
-; GFX7-NEXT:    v_cvt_f32_f16_e32 v4, v4
-; GFX7-NEXT:    v_max_f32_e32 v17, v3, v19
-; GFX7-NEXT:    v_cmp_o_f32_e32 vcc, v3, v19
-; GFX7-NEXT:    v_cndmask_b32_e32 v17, v16, v17, vcc
-; GFX7-NEXT:    v_cmp_class_f32_e64 vcc, v3, 64
-; GFX7-NEXT:    v_cndmask_b32_e32 v3, v17, v3, vcc
-; GFX7-NEXT:    v_cmp_class_f32_e64 vcc, v19, 64
-; GFX7-NEXT:    v_cndmask_b32_e32 v3, v3, v19, vcc
-; GFX7-NEXT:    v_cmp_eq_f32_e32 vcc, 0, v17
-; GFX7-NEXT:    v_cvt_f16_f32_e32 v19, v21
-; GFX7-NEXT:    v_cvt_f16_f32_e32 v5, v5
-; GFX7-NEXT:    v_cndmask_b32_e32 v3, v17, v3, vcc
-; GFX7-NEXT:    v_max_f32_e32 v17, v4, v18
-; GFX7-NEXT:    v_cmp_o_f32_e32 vcc, v4, v18
-; GFX7-NEXT:    v_cndmask_b32_e32 v17, v16, v17, vcc
-; GFX7-NEXT:    v_cmp_class_f32_e64 vcc, v4, 64
-; GFX7-NEXT:    v_cndmask_b32_e32 v4, v17, v4, vcc
-; GFX7-NEXT:    v_cmp_class_f32_e64 vcc, v18, 64
-; GFX7-NEXT:    v_cvt_f32_f16_e32 v19, v19
-; GFX7-NEXT:    v_cvt_f32_f16_e32 v5, v5
-; GFX7-NEXT:    v_cndmask_b32_e32 v4, v4, v18, vcc
-; GFX7-NEXT:    v_cvt_f16_f32_e32 v18, v22
 ; GFX7-NEXT:    v_cvt_f16_f32_e32 v6, v6
-; GFX7-NEXT:    v_cmp_eq_f32_e32 vcc, 0, v17
-; GFX7-NEXT:    v_cndmask_b32_e32 v4, v17, v4, vcc
-; GFX7-NEXT:    v_max_f32_e32 v17, v5, v19
-; GFX7-NEXT:    v_cmp_o_f32_e32 vcc, v5, v19
-; GFX7-NEXT:    v_cvt_f32_f16_e32 v18, v18
-; GFX7-NEXT:    v_cvt_f32_f16_e32 v6, v6
-; GFX7-NEXT:    v_cndmask_b32_e32 v17, v16, v17, vcc
-; GFX7-NEXT:    v_cmp_class_f32_e64 vcc, v5, 64
-; GFX7-NEXT:    v_cndmask_b32_e32 v5, v17, v5, vcc
-; GFX7-NEXT:    v_cmp_class_f32_e64 vcc, v19, 64
-; GFX7-NEXT:    v_cndmask_b32_e32 v5, v5, v19, vcc
-; GFX7-NEXT:    v_cmp_eq_f32_e32 vcc, 0, v17
-; GFX7-NEXT:    v_cvt_f16_f32_e32 v19, v23
 ; GFX7-NEXT:    v_cvt_f16_f32_e32 v7, v7
-; GFX7-NEXT:    v_cndmask_b32_e32 v5, v17, v5, vcc
-; GFX7-NEXT:    v_max_f32_e32 v17, v6, v18
-; GFX7-NEXT:    v_cmp_o_f32_e32 vcc, v6, v18
-; GFX7-NEXT:    v_cndmask_b32_e32 v17, v16, v17, vcc
-; GFX7-NEXT:    v_cmp_class_f32_e64 vcc, v6, 64
-; GFX7-NEXT:    v_cndmask_b32_e32 v6, v17, v6, vcc
-; GFX7-NEXT:    v_cmp_class_f32_e64 vcc, v18, 64
-; GFX7-NEXT:    v_cvt_f32_f16_e32 v19, v19
+; GFX7-NEXT:    v_cvt_f32_f16_e32 v16, v16
+; GFX7-NEXT:    v_cvt_f32_f16_e32 v0, v0
+; GFX7-NEXT:    v_cvt_f32_f16_e32 v6, v6
 ; GFX7-NEXT:    v_cvt_f32_f16_e32 v7, v7
-; GFX7-NEXT:    v_cndmask_b32_e32 v6, v6, v18, vcc
-; GFX7-NEXT:    v_cvt_f16_f32_e32 v18, v24
 ; GFX7-NEXT:    v_cvt_f16_f32_e32 v8, v8
-; GFX7-NEXT:    v_cmp_eq_f32_e32 vcc, 0, v17
-; GFX7-NEXT:    v_cndmask_b32_e32 v6, v17, v6, vcc
-; GFX7-NEXT:    v_max_f32_e32 v17, v7, v19
-; GFX7-NEXT:    v_cmp_o_f32_e32 vcc, v7, v19
-; GFX7-NEXT:    v_cvt_f32_f16_e32 v18, v18
+; GFX7-NEXT:    v_cmp_o_f32_e64 s[12:13], v0, v16
+; GFX7-NEXT:    v_max_f32_e32 v0, v0, v16
+; GFX7-NEXT:    v_cvt_f16_f32_e32 v16, v22
 ; GFX7-NEXT:    v_cvt_f32_f16_e32 v8, v8
-; GFX7-NEXT:    v_cndmask_b32_e32 v17, v16, v17, vcc
-; GFX7-NEXT:    v_cmp_class_f32_e64 vcc, v7, 64
-; GFX7-NEXT:    v_cndmask_b32_e32 v7, v17, v7, vcc
-; GFX7-NEXT:    v_cmp_class_f32_e64 vcc, v19, 64
-; GFX7-NEXT:    v_cndmask_b32_e32 v7, v7, v19, vcc
-; GFX7-NEXT:    v_cmp_eq_f32_e32 vcc, 0, v17
-; GFX7-NEXT:    v_cvt_f16_f32_e32 v19, v25
 ; GFX7-NEXT:    v_cvt_f16_f32_e32 v9, v9
-; GFX7-NEXT:    v_cndmask_b32_e32 v7, v17, v7, vcc
-; GFX7-NEXT:    v_max_f32_e32 v17, v8, v18
-; GFX7-NEXT:    v_cmp_o_f32_e32 vcc, v8, v18
-; GFX7-NEXT:    v_cndmask_b32_e32 v17, v16, v17, vcc
-; GFX7-NEXT:    v_cmp_class_f32_e64 vcc, v8, 64
-; GFX7-NEXT:    v_cndmask_b32_e32 v8, v17, v8, vcc
-; GFX7-NEXT:    v_cmp_class_f32_e64 vcc, v18, 64
-; GFX7-NEXT:    v_cvt_f32_f16_e32 v19, v19
-; GFX7-NEXT:    v_cvt_f32_f16_e32 v9, v9
-; GFX7-NEXT:    v_cndmask_b32_e32 v8, v8, v18, vcc
-; GFX7-NEXT:    v_cvt_f16_f32_e32 v18, v26
 ; GFX7-NEXT:    v_cvt_f16_f32_e32 v10, v10
-; GFX7-NEXT:    v_cmp_eq_f32_e32 vcc, 0, v17
-; GFX7-NEXT:    v_cndmask_b32_e32 v8, v17, v8, vcc
-; GFX7-NEXT:    v_max_f32_e32 v17, v9, v19
-; GFX7-NEXT:    v_cmp_o_f32_e32 vcc, v9, v19
-; GFX7-NEXT:    v_cvt_f32_f16_e32 v18, v18
+; GFX7-NEXT:    v_cvt_f32_f16_e32 v16, v16
+; GFX7-NEXT:    v_cvt_f16_f32_e32 v17, v17
+; GFX7-NEXT:    v_cvt_f32_f16_e32 v9, v9
 ; GFX7-NEXT:    v_cvt_f32_f16_e32 v10, v10
-; GFX7-NEXT:    v_cndmask_b32_e32 v17, v16, v17, vcc
-; GFX7-NEXT:    v_cmp_class_f32_e64 vcc, v9, 64
-; GFX7-NEXT:    v_cndmask_b32_e32 v9, v17, v9, vcc
-; GFX7-NEXT:    v_cmp_class_f32_e64 vcc, v19, 64
-; GFX7-NEXT:    v_cndmask_b32_e32 v9, v9, v19, vcc
-; GFX7-NEXT:    v_cmp_eq_f32_e32 vcc, 0, v17
-; GFX7-NEXT:    v_cvt_f16_f32_e32 v19, v27
+; GFX7-NEXT:    v_cmp_o_f32_e64 s[14:15], v6, v16
+; GFX7-NEXT:    v_max_f32_e32 v6, v6, v16
+; GFX7-NEXT:    v_cvt_f16_f32_e32 v16, v23
+; GFX7-NEXT:    v_cvt_f16_f32_e32 v1, v1
+; GFX7-NEXT:    v_cvt_f32_f16_e32 v17, v17
+; GFX7-NEXT:    v_cvt_f16_f32_e32 v2, v2
+; GFX7-NEXT:    v_cvt_f32_f16_e32 v16, v16
+; GFX7-NEXT:    v_cvt_f32_f16_e32 v1, v1
+; GFX7-NEXT:    v_cvt_f16_f32_e32 v3, v3
+; GFX7-NEXT:    v_cvt_f32_f16_e32 v2, v2
+; GFX7-NEXT:    v_cmp_o_f32_e64 s[16:17], v7, v16
+; GFX7-NEXT:    v_max_f32_e32 v7, v7, v16
+; GFX7-NEXT:    v_cvt_f16_f32_e32 v16, v24
+; GFX7-NEXT:    v_cmp_o_f32_e32 vcc, v1, v17
+; GFX7-NEXT:    v_max_f32_e32 v1, v1, v17
+; GFX7-NEXT:    v_cvt_f16_f32_e32 v17, v18
+; GFX7-NEXT:    v_cvt_f32_f16_e32 v16, v16
+; GFX7-NEXT:    v_cvt_f32_f16_e32 v3, v3
+; GFX7-NEXT:    v_cvt_f16_f32_e32 v4, v4
+; GFX7-NEXT:    v_cvt_f32_f16_e32 v17, v17
+; GFX7-NEXT:    v_cmp_o_f32_e64 s[18:19], v8, v16
+; GFX7-NEXT:    v_max_f32_e32 v8, v8, v16
+; GFX7-NEXT:    v_cvt_f16_f32_e32 v16, v25
+; GFX7-NEXT:    v_cmp_o_f32_e64 s[4:5], v2, v17
+; GFX7-NEXT:    v_max_f32_e32 v2, v2, v17
+; GFX7-NEXT:    v_cvt_f16_f32_e32 v17, v19
+; GFX7-NEXT:    v_cvt_f32_f16_e32 v16, v16
+; GFX7-NEXT:    v_cvt_f32_f16_e32 v4, v4
+; GFX7-NEXT:    v_cvt_f16_f32_e32 v5, v5
+; GFX7-NEXT:    v_cvt_f32_f16_e32 v17, v17
+; GFX7-NEXT:    v_cmp_o_f32_e64 s[20:21], v9, v16
+; GFX7-NEXT:    v_max_f32_e32 v9, v9, v16
+; GFX7-NEXT:    v_cvt_f16_f32_e32 v16, v26
+; GFX7-NEXT:    v_cmp_o_f32_e64 s[6:7], v3, v17
+; GFX7-NEXT:    v_max_f32_e32 v3, v3, v17
+; GFX7-NEXT:    v_cvt_f16_f32_e32 v17, v20
+; GFX7-NEXT:    v_cvt_f32_f16_e32 v16, v16
+; GFX7-NEXT:    v_cvt_f32_f16_e32 v5, v5
 ; GFX7-NEXT:    v_cvt_f16_f32_e32 v11, v11
-; GFX7-NEXT:    v_cndmask_b32_e32 v9, v17, v9, vcc
-; GFX7-NEXT:    v_max_f32_e32 v17, v10, v18
-; GFX7-NEXT:    v_cmp_o_f32_e32 vcc, v10, v18
-; GFX7-NEXT:    v_cndmask_b32_e32 v17, v16, v17, vcc
-; GFX7-NEXT:    v_cmp_class_f32_e64 vcc, v10, 64
-; GFX7-NEXT:    v_cndmask_b32_e32 v10, v17, v10, vcc
-; GFX7-NEXT:    v_cmp_class_f32_e64 vcc, v18, 64
-; GFX7-NEXT:    v_cvt_f32_f16_e32 v19, v19
-; GFX7-NEXT:    v_cvt_f32_f16_e32 v11, v11
-; GFX7-NEXT:    v_cndmask_b32_e32 v10, v10, v18, vcc
-; GFX7-NEXT:    v_cvt_f16_f32_e32 v18, v28
+; GFX7-NEXT:    v_cvt_f32_f16_e32 v17, v17
+; GFX7-NEXT:    v_cmp_o_f32_e64 s[22:23], v10, v16
+; GFX7-NEXT:    v_max_f32_e32 v10, v10, v16
+; GFX7-NEXT:    buffer_load_dword v16, off, s[0:3], s32
+; GFX7-NEXT:    v_cmp_o_f32_e64 s[8:9], v4, v17
+; GFX7-NEXT:    v_max_f32_e32 v4, v4, v17
+; GFX7-NEXT:    v_cvt_f16_f32_e32 v17, v21
+; GFX7-NEXT:    v_cvt_f16_f32_e32 v20, v28
 ; GFX7-NEXT:    v_cvt_f16_f32_e32 v12, v12
-; GFX7-NEXT:    v_cmp_eq_f32_e32 vcc, 0, v17
-; GFX7-NEXT:    v_cndmask_b32_e32 v10, v17, v10, vcc
-; GFX7-NEXT:    v_max_f32_e32 v17, v11, v19
-; GFX7-NEXT:    v_cmp_o_f32_e32 vcc, v11, v19
-; GFX7-NEXT:    v_cvt_f32_f16_e32 v18, v18
-; GFX7-NEXT:    v_cvt_f32_f16_e32 v12, v12
-; GFX7-NEXT:    v_cndmask_b32_e32 v17, v16, v17, vcc
-; GFX7-NEXT:    v_cmp_class_f32_e64 vcc, v11, 64
-; GFX7-NEXT:    v_cndmask_b32_e32 v11, v17, v11, vcc
-; GFX7-NEXT:    v_cmp_class_f32_e64 vcc, v19, 64
-; GFX7-NEXT:    v_cndmask_b32_e32 v11, v11, v19, vcc
-; GFX7-NEXT:    v_cmp_eq_f32_e32 vcc, 0, v17
-; GFX7-NEXT:    v_cndmask_b32_e32 v11, v17, v11, vcc
-; GFX7-NEXT:    v_max_f32_e32 v17, v12, v18
-; GFX7-NEXT:    v_cmp_o_f32_e32 vcc, v12, v18
-; GFX7-NEXT:    v_cndmask_b32_e32 v17, v16, v17, vcc
-; GFX7-NEXT:    v_cmp_class_f32_e64 vcc, v12, 64
-; GFX7-NEXT:    v_cndmask_b32_e32 v12, v17, v12, vcc
-; GFX7-NEXT:    v_cmp_class_f32_e64 vcc, v18, 64
-; GFX7-NEXT:    v_cndmask_b32_e32 v12, v12, v18, vcc
-; GFX7-NEXT:    s_waitcnt vmcnt(0)
-; GFX7-NEXT:    v_cvt_f16_f32_e32 v18, v20
-; GFX7-NEXT:    v_cvt_f16_f32_e32 v20, v29
+; GFX7-NEXT:    v_cvt_f16_f32_e32 v19, v29
+; GFX7-NEXT:    v_cvt_f32_f16_e32 v17, v17
 ; GFX7-NEXT:    v_cvt_f16_f32_e32 v13, v13
-; GFX7-NEXT:    v_cvt_f16_f32_e32 v19, v30
+; GFX7-NEXT:    v_cvt_f16_f32_e32 v18, v30
 ; GFX7-NEXT:    v_cvt_f16_f32_e32 v14, v14
-; GFX7-NEXT:    v_cvt_f32_f16_e32 v20, v20
-; GFX7-NEXT:    v_cvt_f32_f16_e32 v13, v13
-; GFX7-NEXT:    v_cmp_eq_f32_e32 vcc, 0, v17
+; GFX7-NEXT:    v_cmp_o_f32_e64 s[10:11], v5, v17
+; GFX7-NEXT:    v_max_f32_e32 v5, v5, v17
+; GFX7-NEXT:    v_cvt_f16_f32_e32 v17, v27
+; GFX7-NEXT:    v_cvt_f32_f16_e32 v11, v11
 ; GFX7-NEXT:    v_cvt_f16_f32_e32 v15, v15
+; GFX7-NEXT:    v_cvt_f32_f16_e32 v20, v20
+; GFX7-NEXT:    v_cvt_f32_f16_e32 v17, v17
+; GFX7-NEXT:    v_cvt_f32_f16_e32 v12, v12
 ; GFX7-NEXT:    v_cvt_f32_f16_e32 v19, v19
-; GFX7-NEXT:    v_cvt_f32_f16_e32 v14, v14
-; GFX7-NEXT:    v_cndmask_b32_e32 v12, v17, v12, vcc
-; GFX7-NEXT:    v_max_f32_e32 v17, v13, v20
-; GFX7-NEXT:    v_cmp_o_f32_e32 vcc, v13, v20
-; GFX7-NEXT:    v_cndmask_b32_e32 v17, v16, v17, vcc
-; GFX7-NEXT:    v_cmp_class_f32_e64 vcc, v13, 64
-; GFX7-NEXT:    v_cndmask_b32_e32 v13, v17, v13, vcc
-; GFX7-NEXT:    v_cmp_class_f32_e64 vcc, v20, 64
-; GFX7-NEXT:    v_cndmask_b32_e32 v13, v13, v20, vcc
-; GFX7-NEXT:    v_cmp_eq_f32_e32 vcc, 0, v17
+; GFX7-NEXT:    v_cvt_f32_f16_e32 v13, v13
 ; GFX7-NEXT:    v_cvt_f32_f16_e32 v18, v18
+; GFX7-NEXT:    v_cvt_f32_f16_e32 v14, v14
+; GFX7-NEXT:    v_cmp_o_f32_e64 s[24:25], v11, v17
+; GFX7-NEXT:    v_max_f32_e32 v11, v11, v17
+; GFX7-NEXT:    v_mov_b32_e32 v17, 0x7fc00000
 ; GFX7-NEXT:    v_cvt_f32_f16_e32 v15, v15
-; GFX7-NEXT:    v_cndmask_b32_e32 v13, v17, v13, vcc
-; GFX7-NEXT:    v_max_f32_e32 v17, v14, v19
-; GFX7-NEXT:    v_cmp_o_f32_e32 vcc, v14, v19
-; GFX7-NEXT:    v_cndmask_b32_e32 v17, v16, v17, vcc
-; GFX7-NEXT:    v_cmp_class_f32_e64 vcc, v14, 64
-; GFX7-NEXT:    v_cndmask_b32_e32 v14, v17, v14, vcc
-; GFX7-NEXT:    v_cmp_class_f32_e64 vcc, v19, 64
-; GFX7-NEXT:    v_cndmask_b32_e32 v14, v14, v19, vcc
-; GFX7-NEXT:    v_cmp_eq_f32_e32 vcc, 0, v17
-; GFX7-NEXT:    v_cndmask_b32_e32 v14, v17, v14, vcc
-; GFX7-NEXT:    v_max_f32_e32 v17, v15, v18
-; GFX7-NEXT:    v_cmp_o_f32_e32 vcc, v15, v18
-; GFX7-NEXT:    v_cndmask_b32_e32 v16, v16, v17, vcc
-; GFX7-NEXT:    v_cmp_class_f32_e64 vcc, v15, 64
-; GFX7-NEXT:    v_cndmask_b32_e32 v15, v16, v15, vcc
-; GFX7-NEXT:    v_cmp_class_f32_e64 vcc, v18, 64
-; GFX7-NEXT:    v_cndmask_b32_e32 v15, v15, v18, vcc
-; GFX7-NEXT:    v_cmp_eq_f32_e32 vcc, 0, v16
-; GFX7-NEXT:    v_cndmask_b32_e32 v15, v16, v15, vcc
+; GFX7-NEXT:    v_cndmask_b32_e32 v1, v17, v1, vcc
+; GFX7-NEXT:    v_cmp_o_f32_e32 vcc, v12, v20
+; GFX7-NEXT:    v_max_f32_e32 v12, v12, v20
+; GFX7-NEXT:    v_cndmask_b32_e32 v12, v17, v12, vcc
+; GFX7-NEXT:    v_max_f32_e32 v20, v13, v19
+; GFX7-NEXT:    v_cmp_o_f32_e32 vcc, v13, v19
+; GFX7-NEXT:    v_cndmask_b32_e32 v13, v17, v20, vcc
+; GFX7-NEXT:    v_max_f32_e32 v19, v14, v18
+; GFX7-NEXT:    v_cmp_o_f32_e32 vcc, v14, v18
+; GFX7-NEXT:    v_cndmask_b32_e32 v14, v17, v19, vcc
+; GFX7-NEXT:    v_cndmask_b32_e64 v0, v17, v0, s[12:13]
+; GFX7-NEXT:    v_cndmask_b32_e64 v2, v17, v2, s[4:5]
+; GFX7-NEXT:    v_cndmask_b32_e64 v3, v17, v3, s[6:7]
+; GFX7-NEXT:    v_cndmask_b32_e64 v4, v17, v4, s[8:9]
+; GFX7-NEXT:    v_cndmask_b32_e64 v5, v17, v5, s[10:11]
+; GFX7-NEXT:    v_cndmask_b32_e64 v6, v17, v6, s[14:15]
+; GFX7-NEXT:    v_cndmask_b32_e64 v7, v17, v7, s[16:17]
+; GFX7-NEXT:    v_cndmask_b32_e64 v8, v17, v8, s[18:19]
+; GFX7-NEXT:    v_cndmask_b32_e64 v9, v17, v9, s[20:21]
+; GFX7-NEXT:    v_cndmask_b32_e64 v10, v17, v10, s[22:23]
+; GFX7-NEXT:    v_cndmask_b32_e64 v11, v17, v11, s[24:25]
+; GFX7-NEXT:    s_waitcnt vmcnt(0)
+; GFX7-NEXT:    v_cvt_f16_f32_e32 v16, v16
+; GFX7-NEXT:    v_cvt_f32_f16_e32 v16, v16
+; GFX7-NEXT:    v_max_f32_e32 v18, v15, v16
+; GFX7-NEXT:    v_cmp_o_f32_e32 vcc, v15, v16
+; GFX7-NEXT:    v_cndmask_b32_e32 v15, v17, v18, vcc
 ; GFX7-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX8-LABEL: v_maximum_v16f16:
 ; GFX8:       ; %bb.0:
 ; GFX8-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX8-NEXT:    v_lshrrev_b32_e32 v16, 16, v15
-; GFX8-NEXT:    v_lshrrev_b32_e32 v18, 16, v7
-; GFX8-NEXT:    v_max_f16_e32 v19, v18, v16
-; GFX8-NEXT:    v_mov_b32_e32 v17, 0x7e00
-; GFX8-NEXT:    v_cmp_o_f16_e32 vcc, v18, v16
-; GFX8-NEXT:    v_cndmask_b32_e32 v19, v17, v19, vcc
-; GFX8-NEXT:    v_cmp_class_f16_e64 vcc, v18, 64
-; GFX8-NEXT:    v_cndmask_b32_e32 v18, v19, v18, vcc
-; GFX8-NEXT:    v_cmp_class_f16_e64 vcc, v16, 64
-; GFX8-NEXT:    v_cndmask_b32_e32 v16, v18, v16, vcc
-; GFX8-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v19
-; GFX8-NEXT:    v_cndmask_b32_e32 v16, v19, v16, vcc
-; GFX8-NEXT:    v_lshrrev_b32_e32 v18, 16, v14
-; GFX8-NEXT:    v_lshrrev_b32_e32 v19, 16, v6
-; GFX8-NEXT:    v_max_f16_e32 v20, v19, v18
-; GFX8-NEXT:    v_cmp_o_f16_e32 vcc, v19, v18
-; GFX8-NEXT:    v_cndmask_b32_e32 v20, v17, v20, vcc
-; GFX8-NEXT:    v_cmp_class_f16_e64 vcc, v19, 64
-; GFX8-NEXT:    v_cndmask_b32_e32 v19, v20, v19, vcc
-; GFX8-NEXT:    v_cmp_class_f16_e64 vcc, v18, 64
-; GFX8-NEXT:    v_cndmask_b32_e32 v18, v19, v18, vcc
-; GFX8-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v20
-; GFX8-NEXT:    v_cndmask_b32_e32 v18, v20, v18, vcc
-; GFX8-NEXT:    v_lshrrev_b32_e32 v19, 16, v13
+; GFX8-NEXT:    v_lshrrev_b32_e32 v17, 16, v7
+; GFX8-NEXT:    v_max_f16_e32 v18, v17, v16
+; GFX8-NEXT:    v_mov_b32_e32 v19, 0x7e00
+; GFX8-NEXT:    v_cmp_o_f16_e32 vcc, v17, v16
+; GFX8-NEXT:    v_cndmask_b32_e32 v16, v19, v18, vcc
+; GFX8-NEXT:    v_lshrrev_b32_e32 v17, 16, v14
+; GFX8-NEXT:    v_lshrrev_b32_e32 v18, 16, v6
+; GFX8-NEXT:    v_max_f16_e32 v20, v18, v17
+; GFX8-NEXT:    v_cmp_o_f16_e32 vcc, v18, v17
+; GFX8-NEXT:    v_cndmask_b32_e32 v17, v19, v20, vcc
+; GFX8-NEXT:    v_lshrrev_b32_e32 v18, 16, v13
 ; GFX8-NEXT:    v_lshrrev_b32_e32 v20, 16, v5
-; GFX8-NEXT:    v_max_f16_e32 v21, v20, v19
-; GFX8-NEXT:    v_cmp_o_f16_e32 vcc, v20, v19
-; GFX8-NEXT:    v_cndmask_b32_e32 v21, v17, v21, vcc
-; GFX8-NEXT:    v_cmp_class_f16_e64 vcc, v20, 64
-; GFX8-NEXT:    v_cndmask_b32_e32 v20, v21, v20, vcc
-; GFX8-NEXT:    v_cmp_class_f16_e64 vcc, v19, 64
-; GFX8-NEXT:    v_cndmask_b32_e32 v19, v20, v19, vcc
-; GFX8-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v21
-; GFX8-NEXT:    v_cndmask_b32_e32 v19, v21, v19, vcc
+; GFX8-NEXT:    v_max_f16_e32 v21, v20, v18
+; GFX8-NEXT:    v_cmp_o_f16_e32 vcc, v20, v18
+; GFX8-NEXT:    v_cndmask_b32_e32 v18, v19, v21, vcc
 ; GFX8-NEXT:    v_lshrrev_b32_e32 v20, 16, v12
 ; GFX8-NEXT:    v_lshrrev_b32_e32 v21, 16, v4
 ; GFX8-NEXT:    v_max_f16_e32 v22, v21, v20
 ; GFX8-NEXT:    v_cmp_o_f16_e32 vcc, v21, v20
-; GFX8-NEXT:    v_cndmask_b32_e32 v22, v17, v22, vcc
-; GFX8-NEXT:    v_cmp_class_f16_e64 vcc, v21, 64
-; GFX8-NEXT:    v_cndmask_b32_e32 v21, v22, v21, vcc
-; GFX8-NEXT:    v_cmp_class_f16_e64 vcc, v20, 64
-; GFX8-NEXT:    v_cndmask_b32_e32 v20, v21, v20, vcc
-; GFX8-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v22
-; GFX8-NEXT:    v_cndmask_b32_e32 v20, v22, v20, vcc
+; GFX8-NEXT:    v_cndmask_b32_e32 v20, v19, v22, vcc
 ; GFX8-NEXT:    v_lshrrev_b32_e32 v21, 16, v11
 ; GFX8-NEXT:    v_lshrrev_b32_e32 v22, 16, v3
 ; GFX8-NEXT:    v_max_f16_e32 v23, v22, v21
 ; GFX8-NEXT:    v_cmp_o_f16_e32 vcc, v22, v21
-; GFX8-NEXT:    v_cndmask_b32_e32 v23, v17, v23, vcc
-; GFX8-NEXT:    v_cmp_class_f16_e64 vcc, v22, 64
-; GFX8-NEXT:    v_cndmask_b32_e32 v22, v23, v22, vcc
-; GFX8-NEXT:    v_cmp_class_f16_e64 vcc, v21, 64
-; GFX8-NEXT:    v_cndmask_b32_e32 v21, v22, v21, vcc
-; GFX8-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v23
-; GFX8-NEXT:    v_cndmask_b32_e32 v21, v23, v21, vcc
+; GFX8-NEXT:    v_cndmask_b32_e32 v21, v19, v23, vcc
 ; GFX8-NEXT:    v_lshrrev_b32_e32 v22, 16, v10
 ; GFX8-NEXT:    v_lshrrev_b32_e32 v23, 16, v2
 ; GFX8-NEXT:    v_max_f16_e32 v24, v23, v22
 ; GFX8-NEXT:    v_cmp_o_f16_e32 vcc, v23, v22
-; GFX8-NEXT:    v_cndmask_b32_e32 v24, v17, v24, vcc
-; GFX8-NEXT:    v_cmp_class_f16_e64 vcc, v23, 64
-; GFX8-NEXT:    v_cndmask_b32_e32 v23, v24, v23, vcc
-; GFX8-NEXT:    v_cmp_class_f16_e64 vcc, v22, 64
-; GFX8-NEXT:    v_cndmask_b32_e32 v22, v23, v22, vcc
-; GFX8-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v24
-; GFX8-NEXT:    v_cndmask_b32_e32 v22, v24, v22, vcc
+; GFX8-NEXT:    v_cndmask_b32_e32 v22, v19, v24, vcc
 ; GFX8-NEXT:    v_lshrrev_b32_e32 v23, 16, v9
 ; GFX8-NEXT:    v_lshrrev_b32_e32 v24, 16, v1
 ; GFX8-NEXT:    v_max_f16_e32 v25, v24, v23
 ; GFX8-NEXT:    v_cmp_o_f16_e32 vcc, v24, v23
-; GFX8-NEXT:    v_cndmask_b32_e32 v25, v17, v25, vcc
-; GFX8-NEXT:    v_cmp_class_f16_e64 vcc, v24, 64
-; GFX8-NEXT:    v_cndmask_b32_e32 v24, v25, v24, vcc
-; GFX8-NEXT:    v_cmp_class_f16_e64 vcc, v23, 64
-; GFX8-NEXT:    v_cndmask_b32_e32 v23, v24, v23, vcc
-; GFX8-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v25
-; GFX8-NEXT:    v_cndmask_b32_e32 v23, v25, v23, vcc
+; GFX8-NEXT:    v_cndmask_b32_e32 v23, v19, v25, vcc
 ; GFX8-NEXT:    v_lshrrev_b32_e32 v24, 16, v8
 ; GFX8-NEXT:    v_lshrrev_b32_e32 v25, 16, v0
 ; GFX8-NEXT:    v_max_f16_e32 v26, v25, v24
 ; GFX8-NEXT:    v_cmp_o_f16_e32 vcc, v25, v24
-; GFX8-NEXT:    v_cndmask_b32_e32 v26, v17, v26, vcc
-; GFX8-NEXT:    v_cmp_class_f16_e64 vcc, v25, 64
-; GFX8-NEXT:    v_cndmask_b32_e32 v25, v26, v25, vcc
-; GFX8-NEXT:    v_cmp_class_f16_e64 vcc, v24, 64
-; GFX8-NEXT:    v_cndmask_b32_e32 v24, v25, v24, vcc
-; GFX8-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v26
-; GFX8-NEXT:    v_cndmask_b32_e32 v24, v26, v24, vcc
+; GFX8-NEXT:    v_cndmask_b32_e32 v24, v19, v26, vcc
 ; GFX8-NEXT:    v_max_f16_e32 v25, v7, v15
 ; GFX8-NEXT:    v_cmp_o_f16_e32 vcc, v7, v15
-; GFX8-NEXT:    v_cndmask_b32_e32 v25, v17, v25, vcc
-; GFX8-NEXT:    v_cmp_class_f16_e64 vcc, v7, 64
-; GFX8-NEXT:    v_cndmask_b32_e32 v7, v25, v7, vcc
-; GFX8-NEXT:    v_cmp_class_f16_e64 vcc, v15, 64
-; GFX8-NEXT:    v_cndmask_b32_e32 v7, v7, v15, vcc
-; GFX8-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v25
-; GFX8-NEXT:    v_cndmask_b32_e32 v7, v25, v7, vcc
+; GFX8-NEXT:    v_cndmask_b32_e32 v7, v19, v25, vcc
 ; GFX8-NEXT:    v_max_f16_e32 v15, v6, v14
 ; GFX8-NEXT:    v_cmp_o_f16_e32 vcc, v6, v14
-; GFX8-NEXT:    v_cndmask_b32_e32 v15, v17, v15, vcc
-; GFX8-NEXT:    v_cmp_class_f16_e64 vcc, v6, 64
-; GFX8-NEXT:    v_cndmask_b32_e32 v6, v15, v6, vcc
-; GFX8-NEXT:    v_cmp_class_f16_e64 vcc, v14, 64
-; GFX8-NEXT:    v_cndmask_b32_e32 v6, v6, v14, vcc
-; GFX8-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v15
-; GFX8-NEXT:    v_cndmask_b32_e32 v6, v15, v6, vcc
+; GFX8-NEXT:    v_cndmask_b32_e32 v6, v19, v15, vcc
 ; GFX8-NEXT:    v_max_f16_e32 v14, v5, v13
 ; GFX8-NEXT:    v_cmp_o_f16_e32 vcc, v5, v13
-; GFX8-NEXT:    v_cndmask_b32_e32 v14, v17, v14, vcc
-; GFX8-NEXT:    v_cmp_class_f16_e64 vcc, v5, 64
-; GFX8-NEXT:    v_cndmask_b32_e32 v5, v14, v5, vcc
-; GFX8-NEXT:    v_cmp_class_f16_e64 vcc, v13, 64
-; GFX8-NEXT:    v_cndmask_b32_e32 v5, v5, v13, vcc
-; GFX8-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v14
-; GFX8-NEXT:    v_cndmask_b32_e32 v5, v14, v5, vcc
+; GFX8-NEXT:    v_cndmask_b32_e32 v5, v19, v14, vcc
 ; GFX8-NEXT:    v_max_f16_e32 v13, v4, v12
 ; GFX8-NEXT:    v_cmp_o_f16_e32 vcc, v4, v12
-; GFX8-NEXT:    v_cndmask_b32_e32 v13, v17, v13, vcc
-; GFX8-NEXT:    v_cmp_class_f16_e64 vcc, v4, 64
-; GFX8-NEXT:    v_cndmask_b32_e32 v4, v13, v4, vcc
-; GFX8-NEXT:    v_cmp_class_f16_e64 vcc, v12, 64
-; GFX8-NEXT:    v_cndmask_b32_e32 v4, v4, v12, vcc
-; GFX8-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v13
-; GFX8-NEXT:    v_cndmask_b32_e32 v4, v13, v4, vcc
+; GFX8-NEXT:    v_cndmask_b32_e32 v4, v19, v13, vcc
 ; GFX8-NEXT:    v_max_f16_e32 v12, v3, v11
 ; GFX8-NEXT:    v_cmp_o_f16_e32 vcc, v3, v11
-; GFX8-NEXT:    v_cndmask_b32_e32 v12, v17, v12, vcc
-; GFX8-NEXT:    v_cmp_class_f16_e64 vcc, v3, 64
-; GFX8-NEXT:    v_cndmask_b32_e32 v3, v12, v3, vcc
-; GFX8-NEXT:    v_cmp_class_f16_e64 vcc, v11, 64
-; GFX8-NEXT:    v_cndmask_b32_e32 v3, v3, v11, vcc
-; GFX8-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v12
-; GFX8-NEXT:    v_cndmask_b32_e32 v3, v12, v3, vcc
+; GFX8-NEXT:    v_cndmask_b32_e32 v3, v19, v12, vcc
 ; GFX8-NEXT:    v_max_f16_e32 v11, v2, v10
 ; GFX8-NEXT:    v_cmp_o_f16_e32 vcc, v2, v10
-; GFX8-NEXT:    v_cndmask_b32_e32 v11, v17, v11, vcc
-; GFX8-NEXT:    v_cmp_class_f16_e64 vcc, v2, 64
-; GFX8-NEXT:    v_cndmask_b32_e32 v2, v11, v2, vcc
-; GFX8-NEXT:    v_cmp_class_f16_e64 vcc, v10, 64
-; GFX8-NEXT:    v_cndmask_b32_e32 v2, v2, v10, vcc
-; GFX8-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v11
-; GFX8-NEXT:    v_cndmask_b32_e32 v2, v11, v2, vcc
+; GFX8-NEXT:    v_cndmask_b32_e32 v2, v19, v11, vcc
 ; GFX8-NEXT:    v_max_f16_e32 v10, v1, v9
 ; GFX8-NEXT:    v_cmp_o_f16_e32 vcc, v1, v9
-; GFX8-NEXT:    v_cndmask_b32_e32 v10, v17, v10, vcc
-; GFX8-NEXT:    v_cmp_class_f16_e64 vcc, v1, 64
-; GFX8-NEXT:    v_cndmask_b32_e32 v1, v10, v1, vcc
-; GFX8-NEXT:    v_cmp_class_f16_e64 vcc, v9, 64
-; GFX8-NEXT:    v_cndmask_b32_e32 v1, v1, v9, vcc
-; GFX8-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v10
-; GFX8-NEXT:    v_cndmask_b32_e32 v1, v10, v1, vcc
+; GFX8-NEXT:    v_cndmask_b32_e32 v1, v19, v10, vcc
 ; GFX8-NEXT:    v_max_f16_e32 v9, v0, v8
 ; GFX8-NEXT:    v_cmp_o_f16_e32 vcc, v0, v8
-; GFX8-NEXT:    v_cndmask_b32_e32 v9, v17, v9, vcc
-; GFX8-NEXT:    v_cmp_class_f16_e64 vcc, v0, 64
-; GFX8-NEXT:    v_cndmask_b32_e32 v0, v9, v0, vcc
-; GFX8-NEXT:    v_cmp_class_f16_e64 vcc, v8, 64
-; GFX8-NEXT:    v_cndmask_b32_e32 v0, v0, v8, vcc
-; GFX8-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v9
-; GFX8-NEXT:    v_cndmask_b32_e32 v0, v9, v0, vcc
+; GFX8-NEXT:    v_cndmask_b32_e32 v0, v19, v9, vcc
 ; GFX8-NEXT:    v_lshlrev_b32_e32 v8, 16, v24
 ; GFX8-NEXT:    v_or_b32_sdwa v0, v0, v8 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
 ; GFX8-NEXT:    v_lshlrev_b32_e32 v8, 16, v23
@@ -4194,9 +2486,9 @@ define <16 x half> @v_maximum_v16f16(<16 x half> %src0, <16 x half> %src1) {
 ; GFX8-NEXT:    v_or_b32_sdwa v3, v3, v8 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
 ; GFX8-NEXT:    v_lshlrev_b32_e32 v8, 16, v20
 ; GFX8-NEXT:    v_or_b32_sdwa v4, v4, v8 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
-; GFX8-NEXT:    v_lshlrev_b32_e32 v8, 16, v19
-; GFX8-NEXT:    v_or_b32_sdwa v5, v5, v8 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
 ; GFX8-NEXT:    v_lshlrev_b32_e32 v8, 16, v18
+; GFX8-NEXT:    v_or_b32_sdwa v5, v5, v8 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
+; GFX8-NEXT:    v_lshlrev_b32_e32 v8, 16, v17
 ; GFX8-NEXT:    v_or_b32_sdwa v6, v6, v8 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
 ; GFX8-NEXT:    v_lshlrev_b32_e32 v8, 16, v16
 ; GFX8-NEXT:    v_or_b32_sdwa v7, v7, v8 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
@@ -4205,414 +2497,142 @@ define <16 x half> @v_maximum_v16f16(<16 x half> %src0, <16 x half> %src1) {
 ; GFX9-LABEL: v_maximum_v16f16:
 ; GFX9:       ; %bb.0:
 ; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX9-NEXT:    v_pk_max_f16 v18, v7, v15
+; GFX9-NEXT:    v_pk_max_f16 v16, v7, v15
 ; GFX9-NEXT:    v_mov_b32_e32 v17, 0x7e00
 ; GFX9-NEXT:    v_cmp_o_f16_e32 vcc, v7, v15
-; GFX9-NEXT:    v_cndmask_b32_e32 v16, v17, v18, vcc
-; GFX9-NEXT:    v_cmp_class_f16_e64 vcc, v7, 64
-; GFX9-NEXT:    v_cndmask_b32_e32 v19, v16, v7, vcc
-; GFX9-NEXT:    v_cmp_class_f16_e64 vcc, v15, 64
-; GFX9-NEXT:    v_cndmask_b32_e32 v19, v19, v15, vcc
-; GFX9-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v16
+; GFX9-NEXT:    v_cndmask_b32_e32 v18, v17, v16, vcc
+; GFX9-NEXT:    v_lshrrev_b32_e32 v16, 16, v16
+; GFX9-NEXT:    v_cmp_o_f16_sdwa vcc, v7, v15 src0_sel:WORD_1 src1_sel:WORD_1
+; GFX9-NEXT:    v_cndmask_b32_e32 v7, v17, v16, vcc
+; GFX9-NEXT:    v_pk_max_f16 v15, v6, v14
+; GFX9-NEXT:    v_cmp_o_f16_e32 vcc, v6, v14
+; GFX9-NEXT:    v_cndmask_b32_e32 v16, v17, v15, vcc
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v15, 16, v15
-; GFX9-NEXT:    v_lshrrev_b32_e32 v7, 16, v7
-; GFX9-NEXT:    v_cndmask_b32_e32 v16, v16, v19, vcc
-; GFX9-NEXT:    v_lshrrev_b32_e32 v18, 16, v18
-; GFX9-NEXT:    v_cmp_o_f16_e32 vcc, v7, v15
-; GFX9-NEXT:    v_cndmask_b32_e32 v18, v17, v18, vcc
-; GFX9-NEXT:    v_cmp_class_f16_e64 vcc, v7, 64
-; GFX9-NEXT:    v_cndmask_b32_e32 v7, v18, v7, vcc
-; GFX9-NEXT:    v_cmp_class_f16_e64 vcc, v15, 64
-; GFX9-NEXT:    v_cndmask_b32_e32 v7, v7, v15, vcc
-; GFX9-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v18
-; GFX9-NEXT:    v_cndmask_b32_e32 v7, v18, v7, vcc
-; GFX9-NEXT:    v_pk_max_f16 v18, v6, v14
-; GFX9-NEXT:    v_cmp_o_f16_e32 vcc, v6, v14
-; GFX9-NEXT:    v_cndmask_b32_e32 v15, v17, v18, vcc
-; GFX9-NEXT:    v_cmp_class_f16_e64 vcc, v6, 64
-; GFX9-NEXT:    v_cndmask_b32_e32 v19, v15, v6, vcc
-; GFX9-NEXT:    v_cmp_class_f16_e64 vcc, v14, 64
-; GFX9-NEXT:    v_cndmask_b32_e32 v19, v19, v14, vcc
-; GFX9-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v15
+; GFX9-NEXT:    v_cmp_o_f16_sdwa vcc, v6, v14 src0_sel:WORD_1 src1_sel:WORD_1
+; GFX9-NEXT:    v_cndmask_b32_e32 v6, v17, v15, vcc
+; GFX9-NEXT:    v_pk_max_f16 v14, v5, v13
+; GFX9-NEXT:    v_cmp_o_f16_e32 vcc, v5, v13
+; GFX9-NEXT:    v_cndmask_b32_e32 v15, v17, v14, vcc
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v14, 16, v14
-; GFX9-NEXT:    v_lshrrev_b32_e32 v6, 16, v6
-; GFX9-NEXT:    v_cndmask_b32_e32 v15, v15, v19, vcc
-; GFX9-NEXT:    v_lshrrev_b32_e32 v18, 16, v18
-; GFX9-NEXT:    v_cmp_o_f16_e32 vcc, v6, v14
-; GFX9-NEXT:    v_cndmask_b32_e32 v18, v17, v18, vcc
-; GFX9-NEXT:    v_cmp_class_f16_e64 vcc, v6, 64
-; GFX9-NEXT:    v_cndmask_b32_e32 v6, v18, v6, vcc
-; GFX9-NEXT:    v_cmp_class_f16_e64 vcc, v14, 64
-; GFX9-NEXT:    v_cndmask_b32_e32 v6, v6, v14, vcc
-; GFX9-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v18
-; GFX9-NEXT:    v_cndmask_b32_e32 v6, v18, v6, vcc
-; GFX9-NEXT:    v_pk_max_f16 v18, v5, v13
-; GFX9-NEXT:    v_cmp_o_f16_e32 vcc, v5, v13
-; GFX9-NEXT:    v_cndmask_b32_e32 v14, v17, v18, vcc
-; GFX9-NEXT:    v_cmp_class_f16_e64 vcc, v5, 64
-; GFX9-NEXT:    v_cndmask_b32_e32 v19, v14, v5, vcc
-; GFX9-NEXT:    v_cmp_class_f16_e64 vcc, v13, 64
-; GFX9-NEXT:    v_cndmask_b32_e32 v19, v19, v13, vcc
-; GFX9-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v14
-; GFX9-NEXT:    v_lshrrev_b32_e32 v13, 16, v13
-; GFX9-NEXT:    v_lshrrev_b32_e32 v5, 16, v5
-; GFX9-NEXT:    v_cndmask_b32_e32 v14, v14, v19, vcc
-; GFX9-NEXT:    v_lshrrev_b32_e32 v18, 16, v18
-; GFX9-NEXT:    v_cmp_o_f16_e32 vcc, v5, v13
-; GFX9-NEXT:    v_cndmask_b32_e32 v18, v17, v18, vcc
-; GFX9-NEXT:    v_cmp_class_f16_e64 vcc, v5, 64
-; GFX9-NEXT:    v_cndmask_b32_e32 v5, v18, v5, vcc
-; GFX9-NEXT:    v_cmp_class_f16_e64 vcc, v13, 64
-; GFX9-NEXT:    v_cndmask_b32_e32 v5, v5, v13, vcc
-; GFX9-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v18
-; GFX9-NEXT:    v_cndmask_b32_e32 v5, v18, v5, vcc
+; GFX9-NEXT:    v_cmp_o_f16_sdwa vcc, v5, v13 src0_sel:WORD_1 src1_sel:WORD_1
+; GFX9-NEXT:    v_cndmask_b32_e32 v5, v17, v14, vcc
 ; GFX9-NEXT:    v_pk_max_f16 v13, v4, v12
 ; GFX9-NEXT:    v_cmp_o_f16_e32 vcc, v4, v12
-; GFX9-NEXT:    v_cndmask_b32_e32 v18, v17, v13, vcc
-; GFX9-NEXT:    v_cmp_class_f16_e64 vcc, v4, 64
-; GFX9-NEXT:    v_cndmask_b32_e32 v19, v18, v4, vcc
-; GFX9-NEXT:    v_cmp_class_f16_e64 vcc, v12, 64
-; GFX9-NEXT:    v_cndmask_b32_e32 v19, v19, v12, vcc
-; GFX9-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v18
-; GFX9-NEXT:    v_lshrrev_b32_e32 v12, 16, v12
-; GFX9-NEXT:    v_lshrrev_b32_e32 v4, 16, v4
-; GFX9-NEXT:    v_cndmask_b32_e32 v18, v18, v19, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v14, v17, v13, vcc
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v13, 16, v13
-; GFX9-NEXT:    v_cmp_o_f16_e32 vcc, v4, v12
-; GFX9-NEXT:    v_cndmask_b32_e32 v13, v17, v13, vcc
-; GFX9-NEXT:    v_cmp_class_f16_e64 vcc, v4, 64
-; GFX9-NEXT:    v_cndmask_b32_e32 v4, v13, v4, vcc
-; GFX9-NEXT:    v_cmp_class_f16_e64 vcc, v12, 64
-; GFX9-NEXT:    v_cndmask_b32_e32 v4, v4, v12, vcc
-; GFX9-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v13
-; GFX9-NEXT:    v_cndmask_b32_e32 v4, v13, v4, vcc
+; GFX9-NEXT:    v_cmp_o_f16_sdwa vcc, v4, v12 src0_sel:WORD_1 src1_sel:WORD_1
+; GFX9-NEXT:    v_cndmask_b32_e32 v4, v17, v13, vcc
 ; GFX9-NEXT:    v_pk_max_f16 v12, v3, v11
 ; GFX9-NEXT:    v_cmp_o_f16_e32 vcc, v3, v11
 ; GFX9-NEXT:    v_cndmask_b32_e32 v13, v17, v12, vcc
-; GFX9-NEXT:    v_cmp_class_f16_e64 vcc, v3, 64
-; GFX9-NEXT:    v_cndmask_b32_e32 v19, v13, v3, vcc
-; GFX9-NEXT:    v_cmp_class_f16_e64 vcc, v11, 64
-; GFX9-NEXT:    v_cndmask_b32_e32 v19, v19, v11, vcc
-; GFX9-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v13
-; GFX9-NEXT:    v_lshrrev_b32_e32 v11, 16, v11
-; GFX9-NEXT:    v_lshrrev_b32_e32 v3, 16, v3
-; GFX9-NEXT:    v_cndmask_b32_e32 v13, v13, v19, vcc
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v12, 16, v12
-; GFX9-NEXT:    v_cmp_o_f16_e32 vcc, v3, v11
-; GFX9-NEXT:    v_cndmask_b32_e32 v12, v17, v12, vcc
-; GFX9-NEXT:    v_cmp_class_f16_e64 vcc, v3, 64
-; GFX9-NEXT:    v_cndmask_b32_e32 v3, v12, v3, vcc
-; GFX9-NEXT:    v_cmp_class_f16_e64 vcc, v11, 64
-; GFX9-NEXT:    v_cndmask_b32_e32 v3, v3, v11, vcc
-; GFX9-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v12
-; GFX9-NEXT:    v_cndmask_b32_e32 v3, v12, v3, vcc
+; GFX9-NEXT:    v_cmp_o_f16_sdwa vcc, v3, v11 src0_sel:WORD_1 src1_sel:WORD_1
+; GFX9-NEXT:    v_cndmask_b32_e32 v3, v17, v12, vcc
 ; GFX9-NEXT:    v_pk_max_f16 v11, v2, v10
 ; GFX9-NEXT:    v_cmp_o_f16_e32 vcc, v2, v10
 ; GFX9-NEXT:    v_cndmask_b32_e32 v12, v17, v11, vcc
-; GFX9-NEXT:    v_cmp_class_f16_e64 vcc, v2, 64
-; GFX9-NEXT:    v_cndmask_b32_e32 v19, v12, v2, vcc
-; GFX9-NEXT:    v_cmp_class_f16_e64 vcc, v10, 64
-; GFX9-NEXT:    v_cndmask_b32_e32 v19, v19, v10, vcc
-; GFX9-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v12
-; GFX9-NEXT:    v_lshrrev_b32_e32 v10, 16, v10
-; GFX9-NEXT:    v_lshrrev_b32_e32 v2, 16, v2
-; GFX9-NEXT:    v_cndmask_b32_e32 v12, v12, v19, vcc
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v11, 16, v11
-; GFX9-NEXT:    v_cmp_o_f16_e32 vcc, v2, v10
-; GFX9-NEXT:    v_cndmask_b32_e32 v11, v17, v11, vcc
-; GFX9-NEXT:    v_cmp_class_f16_e64 vcc, v2, 64
-; GFX9-NEXT:    v_cndmask_b32_e32 v2, v11, v2, vcc
-; GFX9-NEXT:    v_cmp_class_f16_e64 vcc, v10, 64
-; GFX9-NEXT:    v_cndmask_b32_e32 v2, v2, v10, vcc
-; GFX9-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v11
-; GFX9-NEXT:    v_cndmask_b32_e32 v2, v11, v2, vcc
+; GFX9-NEXT:    v_cmp_o_f16_sdwa vcc, v2, v10 src0_sel:WORD_1 src1_sel:WORD_1
+; GFX9-NEXT:    v_cndmask_b32_e32 v2, v17, v11, vcc
 ; GFX9-NEXT:    v_pk_max_f16 v10, v1, v9
 ; GFX9-NEXT:    v_cmp_o_f16_e32 vcc, v1, v9
 ; GFX9-NEXT:    v_cndmask_b32_e32 v11, v17, v10, vcc
-; GFX9-NEXT:    v_cmp_class_f16_e64 vcc, v1, 64
-; GFX9-NEXT:    v_cndmask_b32_e32 v19, v11, v1, vcc
-; GFX9-NEXT:    v_cmp_class_f16_e64 vcc, v9, 64
-; GFX9-NEXT:    v_cndmask_b32_e32 v19, v19, v9, vcc
-; GFX9-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v11
-; GFX9-NEXT:    v_lshrrev_b32_e32 v9, 16, v9
-; GFX9-NEXT:    v_lshrrev_b32_e32 v1, 16, v1
-; GFX9-NEXT:    v_cndmask_b32_e32 v11, v11, v19, vcc
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v10, 16, v10
-; GFX9-NEXT:    v_cmp_o_f16_e32 vcc, v1, v9
-; GFX9-NEXT:    v_cndmask_b32_e32 v10, v17, v10, vcc
-; GFX9-NEXT:    v_cmp_class_f16_e64 vcc, v1, 64
-; GFX9-NEXT:    v_cndmask_b32_e32 v1, v10, v1, vcc
-; GFX9-NEXT:    v_cmp_class_f16_e64 vcc, v9, 64
-; GFX9-NEXT:    v_cndmask_b32_e32 v1, v1, v9, vcc
-; GFX9-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v10
-; GFX9-NEXT:    v_cndmask_b32_e32 v1, v10, v1, vcc
+; GFX9-NEXT:    v_cmp_o_f16_sdwa vcc, v1, v9 src0_sel:WORD_1 src1_sel:WORD_1
+; GFX9-NEXT:    v_cndmask_b32_e32 v1, v17, v10, vcc
 ; GFX9-NEXT:    v_pk_max_f16 v9, v0, v8
 ; GFX9-NEXT:    v_cmp_o_f16_e32 vcc, v0, v8
 ; GFX9-NEXT:    v_cndmask_b32_e32 v10, v17, v9, vcc
-; GFX9-NEXT:    v_cmp_class_f16_e64 vcc, v0, 64
-; GFX9-NEXT:    v_cndmask_b32_e32 v19, v10, v0, vcc
-; GFX9-NEXT:    v_cmp_class_f16_e64 vcc, v8, 64
-; GFX9-NEXT:    v_cndmask_b32_e32 v19, v19, v8, vcc
-; GFX9-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v10
-; GFX9-NEXT:    v_lshrrev_b32_e32 v8, 16, v8
-; GFX9-NEXT:    v_lshrrev_b32_e32 v0, 16, v0
-; GFX9-NEXT:    v_cndmask_b32_e32 v10, v10, v19, vcc
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v9, 16, v9
-; GFX9-NEXT:    v_cmp_o_f16_e32 vcc, v0, v8
-; GFX9-NEXT:    v_cndmask_b32_e32 v9, v17, v9, vcc
-; GFX9-NEXT:    v_cmp_class_f16_e64 vcc, v0, 64
-; GFX9-NEXT:    v_cndmask_b32_e32 v0, v9, v0, vcc
-; GFX9-NEXT:    v_cmp_class_f16_e64 vcc, v8, 64
-; GFX9-NEXT:    v_cndmask_b32_e32 v0, v0, v8, vcc
-; GFX9-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v9
-; GFX9-NEXT:    v_cndmask_b32_e32 v0, v9, v0, vcc
+; GFX9-NEXT:    v_cmp_o_f16_sdwa vcc, v0, v8 src0_sel:WORD_1 src1_sel:WORD_1
+; GFX9-NEXT:    v_cndmask_b32_e32 v0, v17, v9, vcc
 ; GFX9-NEXT:    s_mov_b32 s4, 0x5040100
 ; GFX9-NEXT:    v_perm_b32 v0, v0, v10, s4
 ; GFX9-NEXT:    v_perm_b32 v1, v1, v11, s4
 ; GFX9-NEXT:    v_perm_b32 v2, v2, v12, s4
 ; GFX9-NEXT:    v_perm_b32 v3, v3, v13, s4
-; GFX9-NEXT:    v_perm_b32 v4, v4, v18, s4
-; GFX9-NEXT:    v_perm_b32 v5, v5, v14, s4
-; GFX9-NEXT:    v_perm_b32 v6, v6, v15, s4
-; GFX9-NEXT:    v_perm_b32 v7, v7, v16, s4
+; GFX9-NEXT:    v_perm_b32 v4, v4, v14, s4
+; GFX9-NEXT:    v_perm_b32 v5, v5, v15, s4
+; GFX9-NEXT:    v_perm_b32 v6, v6, v16, s4
+; GFX9-NEXT:    v_perm_b32 v7, v7, v18, s4
 ; GFX9-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX940-LABEL: v_maximum_v16f16:
 ; GFX940:       ; %bb.0:
 ; GFX940-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX940-NEXT:    v_pk_max_f16 v18, v7, v15
+; GFX940-NEXT:    v_pk_max_f16 v16, v7, v15
 ; GFX940-NEXT:    v_mov_b32_e32 v17, 0x7e00
 ; GFX940-NEXT:    v_cmp_o_f16_e32 vcc, v7, v15
 ; GFX940-NEXT:    s_mov_b32 s0, 0x5040100
 ; GFX940-NEXT:    s_nop 0
-; GFX940-NEXT:    v_cndmask_b32_e32 v16, v17, v18, vcc
-; GFX940-NEXT:    v_cmp_class_f16_e64 vcc, v7, 64
-; GFX940-NEXT:    v_lshrrev_b32_e32 v18, 16, v18
+; GFX940-NEXT:    v_cndmask_b32_e32 v18, v17, v16, vcc
+; GFX940-NEXT:    v_lshrrev_b32_e32 v16, 16, v16
+; GFX940-NEXT:    v_cmp_o_f16_sdwa vcc, v7, v15 src0_sel:WORD_1 src1_sel:WORD_1
+; GFX940-NEXT:    v_pk_max_f16 v15, v6, v14
 ; GFX940-NEXT:    s_nop 0
-; GFX940-NEXT:    v_cndmask_b32_e32 v19, v16, v7, vcc
-; GFX940-NEXT:    v_cmp_class_f16_e64 vcc, v15, 64
-; GFX940-NEXT:    v_lshrrev_b32_e32 v7, 16, v7
+; GFX940-NEXT:    v_cndmask_b32_e32 v7, v17, v16, vcc
+; GFX940-NEXT:    v_cmp_o_f16_e32 vcc, v6, v14
+; GFX940-NEXT:    v_perm_b32 v7, v7, v18, s0
 ; GFX940-NEXT:    s_nop 0
-; GFX940-NEXT:    v_cndmask_b32_e32 v19, v19, v15, vcc
-; GFX940-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v16
+; GFX940-NEXT:    v_cndmask_b32_e32 v16, v17, v15, vcc
 ; GFX940-NEXT:    v_lshrrev_b32_e32 v15, 16, v15
+; GFX940-NEXT:    v_cmp_o_f16_sdwa vcc, v6, v14 src0_sel:WORD_1 src1_sel:WORD_1
+; GFX940-NEXT:    v_pk_max_f16 v14, v5, v13
 ; GFX940-NEXT:    s_nop 0
-; GFX940-NEXT:    v_cndmask_b32_e32 v16, v16, v19, vcc
-; GFX940-NEXT:    v_cmp_o_f16_e32 vcc, v7, v15
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v18, v17, v18, vcc
-; GFX940-NEXT:    v_cmp_class_f16_e64 vcc, v7, 64
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v7, v18, v7, vcc
-; GFX940-NEXT:    v_cmp_class_f16_e64 vcc, v15, 64
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v7, v7, v15, vcc
-; GFX940-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v18
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v7, v18, v7, vcc
-; GFX940-NEXT:    v_pk_max_f16 v18, v6, v14
-; GFX940-NEXT:    v_cmp_o_f16_e32 vcc, v6, v14
-; GFX940-NEXT:    v_perm_b32 v7, v7, v16, s0
+; GFX940-NEXT:    v_cndmask_b32_e32 v6, v17, v15, vcc
+; GFX940-NEXT:    v_cmp_o_f16_e32 vcc, v5, v13
+; GFX940-NEXT:    v_perm_b32 v6, v6, v16, s0
 ; GFX940-NEXT:    s_nop 0
-; GFX940-NEXT:    v_cndmask_b32_e32 v15, v17, v18, vcc
-; GFX940-NEXT:    v_cmp_class_f16_e64 vcc, v6, 64
-; GFX940-NEXT:    v_lshrrev_b32_e32 v18, 16, v18
-; GFX940-NEXT:    s_nop 0
-; GFX940-NEXT:    v_cndmask_b32_e32 v19, v15, v6, vcc
-; GFX940-NEXT:    v_cmp_class_f16_e64 vcc, v14, 64
-; GFX940-NEXT:    v_lshrrev_b32_e32 v6, 16, v6
-; GFX940-NEXT:    s_nop 0
-; GFX940-NEXT:    v_cndmask_b32_e32 v19, v19, v14, vcc
-; GFX940-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v15
+; GFX940-NEXT:    v_cndmask_b32_e32 v15, v17, v14, vcc
 ; GFX940-NEXT:    v_lshrrev_b32_e32 v14, 16, v14
-; GFX940-NEXT:    s_nop 0
-; GFX940-NEXT:    v_cndmask_b32_e32 v15, v15, v19, vcc
-; GFX940-NEXT:    v_cmp_o_f16_e32 vcc, v6, v14
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v18, v17, v18, vcc
-; GFX940-NEXT:    v_cmp_class_f16_e64 vcc, v6, 64
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v6, v18, v6, vcc
-; GFX940-NEXT:    v_cmp_class_f16_e64 vcc, v14, 64
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v6, v6, v14, vcc
-; GFX940-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v18
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v6, v18, v6, vcc
-; GFX940-NEXT:    v_pk_max_f16 v18, v5, v13
-; GFX940-NEXT:    v_cmp_o_f16_e32 vcc, v5, v13
-; GFX940-NEXT:    v_perm_b32 v6, v6, v15, s0
-; GFX940-NEXT:    s_nop 0
-; GFX940-NEXT:    v_cndmask_b32_e32 v14, v17, v18, vcc
-; GFX940-NEXT:    v_cmp_class_f16_e64 vcc, v5, 64
-; GFX940-NEXT:    v_lshrrev_b32_e32 v18, 16, v18
-; GFX940-NEXT:    s_nop 0
-; GFX940-NEXT:    v_cndmask_b32_e32 v19, v14, v5, vcc
-; GFX940-NEXT:    v_cmp_class_f16_e64 vcc, v13, 64
-; GFX940-NEXT:    v_lshrrev_b32_e32 v5, 16, v5
-; GFX940-NEXT:    s_nop 0
-; GFX940-NEXT:    v_cndmask_b32_e32 v19, v19, v13, vcc
-; GFX940-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v14
-; GFX940-NEXT:    v_lshrrev_b32_e32 v13, 16, v13
-; GFX940-NEXT:    s_nop 0
-; GFX940-NEXT:    v_cndmask_b32_e32 v14, v14, v19, vcc
-; GFX940-NEXT:    v_cmp_o_f16_e32 vcc, v5, v13
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v18, v17, v18, vcc
-; GFX940-NEXT:    v_cmp_class_f16_e64 vcc, v5, 64
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v5, v18, v5, vcc
-; GFX940-NEXT:    v_cmp_class_f16_e64 vcc, v13, 64
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v5, v5, v13, vcc
-; GFX940-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v18
+; GFX940-NEXT:    v_cmp_o_f16_sdwa vcc, v5, v13 src0_sel:WORD_1 src1_sel:WORD_1
 ; GFX940-NEXT:    v_pk_max_f16 v13, v4, v12
 ; GFX940-NEXT:    s_nop 0
-; GFX940-NEXT:    v_cndmask_b32_e32 v5, v18, v5, vcc
+; GFX940-NEXT:    v_cndmask_b32_e32 v5, v17, v14, vcc
 ; GFX940-NEXT:    v_cmp_o_f16_e32 vcc, v4, v12
-; GFX940-NEXT:    v_perm_b32 v5, v5, v14, s0
+; GFX940-NEXT:    v_perm_b32 v5, v5, v15, s0
 ; GFX940-NEXT:    s_nop 0
-; GFX940-NEXT:    v_cndmask_b32_e32 v18, v17, v13, vcc
-; GFX940-NEXT:    v_cmp_class_f16_e64 vcc, v4, 64
+; GFX940-NEXT:    v_cndmask_b32_e32 v14, v17, v13, vcc
 ; GFX940-NEXT:    v_lshrrev_b32_e32 v13, 16, v13
-; GFX940-NEXT:    s_nop 0
-; GFX940-NEXT:    v_cndmask_b32_e32 v19, v18, v4, vcc
-; GFX940-NEXT:    v_cmp_class_f16_e64 vcc, v12, 64
-; GFX940-NEXT:    v_lshrrev_b32_e32 v4, 16, v4
-; GFX940-NEXT:    s_nop 0
-; GFX940-NEXT:    v_cndmask_b32_e32 v19, v19, v12, vcc
-; GFX940-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v18
-; GFX940-NEXT:    v_lshrrev_b32_e32 v12, 16, v12
-; GFX940-NEXT:    s_nop 0
-; GFX940-NEXT:    v_cndmask_b32_e32 v18, v18, v19, vcc
-; GFX940-NEXT:    v_cmp_o_f16_e32 vcc, v4, v12
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v13, v17, v13, vcc
-; GFX940-NEXT:    v_cmp_class_f16_e64 vcc, v4, 64
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v4, v13, v4, vcc
-; GFX940-NEXT:    v_cmp_class_f16_e64 vcc, v12, 64
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v4, v4, v12, vcc
-; GFX940-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v13
+; GFX940-NEXT:    v_cmp_o_f16_sdwa vcc, v4, v12 src0_sel:WORD_1 src1_sel:WORD_1
 ; GFX940-NEXT:    v_pk_max_f16 v12, v3, v11
 ; GFX940-NEXT:    s_nop 0
-; GFX940-NEXT:    v_cndmask_b32_e32 v4, v13, v4, vcc
+; GFX940-NEXT:    v_cndmask_b32_e32 v4, v17, v13, vcc
 ; GFX940-NEXT:    v_cmp_o_f16_e32 vcc, v3, v11
-; GFX940-NEXT:    v_perm_b32 v4, v4, v18, s0
+; GFX940-NEXT:    v_perm_b32 v4, v4, v14, s0
 ; GFX940-NEXT:    s_nop 0
 ; GFX940-NEXT:    v_cndmask_b32_e32 v13, v17, v12, vcc
-; GFX940-NEXT:    v_cmp_class_f16_e64 vcc, v3, 64
 ; GFX940-NEXT:    v_lshrrev_b32_e32 v12, 16, v12
-; GFX940-NEXT:    s_nop 0
-; GFX940-NEXT:    v_cndmask_b32_e32 v19, v13, v3, vcc
-; GFX940-NEXT:    v_cmp_class_f16_e64 vcc, v11, 64
-; GFX940-NEXT:    v_lshrrev_b32_e32 v3, 16, v3
-; GFX940-NEXT:    s_nop 0
-; GFX940-NEXT:    v_cndmask_b32_e32 v19, v19, v11, vcc
-; GFX940-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v13
-; GFX940-NEXT:    v_lshrrev_b32_e32 v11, 16, v11
-; GFX940-NEXT:    s_nop 0
-; GFX940-NEXT:    v_cndmask_b32_e32 v13, v13, v19, vcc
-; GFX940-NEXT:    v_cmp_o_f16_e32 vcc, v3, v11
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v12, v17, v12, vcc
-; GFX940-NEXT:    v_cmp_class_f16_e64 vcc, v3, 64
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v3, v12, v3, vcc
-; GFX940-NEXT:    v_cmp_class_f16_e64 vcc, v11, 64
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v3, v3, v11, vcc
-; GFX940-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v12
+; GFX940-NEXT:    v_cmp_o_f16_sdwa vcc, v3, v11 src0_sel:WORD_1 src1_sel:WORD_1
 ; GFX940-NEXT:    v_pk_max_f16 v11, v2, v10
 ; GFX940-NEXT:    s_nop 0
-; GFX940-NEXT:    v_cndmask_b32_e32 v3, v12, v3, vcc
+; GFX940-NEXT:    v_cndmask_b32_e32 v3, v17, v12, vcc
 ; GFX940-NEXT:    v_cmp_o_f16_e32 vcc, v2, v10
 ; GFX940-NEXT:    v_perm_b32 v3, v3, v13, s0
 ; GFX940-NEXT:    s_nop 0
 ; GFX940-NEXT:    v_cndmask_b32_e32 v12, v17, v11, vcc
-; GFX940-NEXT:    v_cmp_class_f16_e64 vcc, v2, 64
 ; GFX940-NEXT:    v_lshrrev_b32_e32 v11, 16, v11
-; GFX940-NEXT:    s_nop 0
-; GFX940-NEXT:    v_cndmask_b32_e32 v19, v12, v2, vcc
-; GFX940-NEXT:    v_cmp_class_f16_e64 vcc, v10, 64
-; GFX940-NEXT:    v_lshrrev_b32_e32 v2, 16, v2
-; GFX940-NEXT:    s_nop 0
-; GFX940-NEXT:    v_cndmask_b32_e32 v19, v19, v10, vcc
-; GFX940-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v12
-; GFX940-NEXT:    v_lshrrev_b32_e32 v10, 16, v10
-; GFX940-NEXT:    s_nop 0
-; GFX940-NEXT:    v_cndmask_b32_e32 v12, v12, v19, vcc
-; GFX940-NEXT:    v_cmp_o_f16_e32 vcc, v2, v10
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v11, v17, v11, vcc
-; GFX940-NEXT:    v_cmp_class_f16_e64 vcc, v2, 64
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v2, v11, v2, vcc
-; GFX940-NEXT:    v_cmp_class_f16_e64 vcc, v10, 64
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v2, v2, v10, vcc
-; GFX940-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v11
+; GFX940-NEXT:    v_cmp_o_f16_sdwa vcc, v2, v10 src0_sel:WORD_1 src1_sel:WORD_1
 ; GFX940-NEXT:    v_pk_max_f16 v10, v1, v9
 ; GFX940-NEXT:    s_nop 0
-; GFX940-NEXT:    v_cndmask_b32_e32 v2, v11, v2, vcc
+; GFX940-NEXT:    v_cndmask_b32_e32 v2, v17, v11, vcc
 ; GFX940-NEXT:    v_cmp_o_f16_e32 vcc, v1, v9
 ; GFX940-NEXT:    v_perm_b32 v2, v2, v12, s0
 ; GFX940-NEXT:    s_nop 0
 ; GFX940-NEXT:    v_cndmask_b32_e32 v11, v17, v10, vcc
-; GFX940-NEXT:    v_cmp_class_f16_e64 vcc, v1, 64
 ; GFX940-NEXT:    v_lshrrev_b32_e32 v10, 16, v10
-; GFX940-NEXT:    s_nop 0
-; GFX940-NEXT:    v_cndmask_b32_e32 v19, v11, v1, vcc
-; GFX940-NEXT:    v_cmp_class_f16_e64 vcc, v9, 64
-; GFX940-NEXT:    v_lshrrev_b32_e32 v1, 16, v1
-; GFX940-NEXT:    s_nop 0
-; GFX940-NEXT:    v_cndmask_b32_e32 v19, v19, v9, vcc
-; GFX940-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v11
-; GFX940-NEXT:    v_lshrrev_b32_e32 v9, 16, v9
-; GFX940-NEXT:    s_nop 0
-; GFX940-NEXT:    v_cndmask_b32_e32 v11, v11, v19, vcc
-; GFX940-NEXT:    v_cmp_o_f16_e32 vcc, v1, v9
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v10, v17, v10, vcc
-; GFX940-NEXT:    v_cmp_class_f16_e64 vcc, v1, 64
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v1, v10, v1, vcc
-; GFX940-NEXT:    v_cmp_class_f16_e64 vcc, v9, 64
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v1, v1, v9, vcc
-; GFX940-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v10
+; GFX940-NEXT:    v_cmp_o_f16_sdwa vcc, v1, v9 src0_sel:WORD_1 src1_sel:WORD_1
 ; GFX940-NEXT:    v_pk_max_f16 v9, v0, v8
 ; GFX940-NEXT:    s_nop 0
-; GFX940-NEXT:    v_cndmask_b32_e32 v1, v10, v1, vcc
+; GFX940-NEXT:    v_cndmask_b32_e32 v1, v17, v10, vcc
 ; GFX940-NEXT:    v_cmp_o_f16_e32 vcc, v0, v8
 ; GFX940-NEXT:    v_perm_b32 v1, v1, v11, s0
 ; GFX940-NEXT:    s_nop 0
 ; GFX940-NEXT:    v_cndmask_b32_e32 v10, v17, v9, vcc
-; GFX940-NEXT:    v_cmp_class_f16_e64 vcc, v0, 64
 ; GFX940-NEXT:    v_lshrrev_b32_e32 v9, 16, v9
-; GFX940-NEXT:    s_nop 0
-; GFX940-NEXT:    v_cndmask_b32_e32 v19, v10, v0, vcc
-; GFX940-NEXT:    v_cmp_class_f16_e64 vcc, v8, 64
-; GFX940-NEXT:    v_lshrrev_b32_e32 v0, 16, v0
-; GFX940-NEXT:    s_nop 0
-; GFX940-NEXT:    v_cndmask_b32_e32 v19, v19, v8, vcc
-; GFX940-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v10
-; GFX940-NEXT:    v_lshrrev_b32_e32 v8, 16, v8
-; GFX940-NEXT:    s_nop 0
-; GFX940-NEXT:    v_cndmask_b32_e32 v10, v10, v19, vcc
-; GFX940-NEXT:    v_cmp_o_f16_e32 vcc, v0, v8
+; GFX940-NEXT:    v_cmp_o_f16_sdwa vcc, v0, v8 src0_sel:WORD_1 src1_sel:WORD_1
 ; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v9, v17, v9, vcc
-; GFX940-NEXT:    v_cmp_class_f16_e64 vcc, v0, 64
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v0, v9, v0, vcc
-; GFX940-NEXT:    v_cmp_class_f16_e64 vcc, v8, 64
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v0, v0, v8, vcc
-; GFX940-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v9
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v0, v9, v0, vcc
+; GFX940-NEXT:    v_cndmask_b32_e32 v0, v17, v9, vcc
 ; GFX940-NEXT:    v_perm_b32 v0, v0, v10, s0
 ; GFX940-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -4621,353 +2641,145 @@ define <16 x half> @v_maximum_v16f16(<16 x half> %src0, <16 x half> %src1) {
 ; GFX10-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX10-NEXT:    v_pk_max_f16 v16, v7, v15
 ; GFX10-NEXT:    v_cmp_o_f16_e32 vcc_lo, v7, v15
-; GFX10-NEXT:    v_lshrrev_b32_e32 v19, 16, v14
-; GFX10-NEXT:    v_lshrrev_b32_e32 v20, 16, v6
-; GFX10-NEXT:    v_cndmask_b32_e32 v17, 0x7e00, v16, vcc_lo
-; GFX10-NEXT:    v_cmp_class_f16_e64 vcc_lo, v7, 64
-; GFX10-NEXT:    v_lshrrev_b32_e32 v16, 16, v16
-; GFX10-NEXT:    v_cndmask_b32_e32 v18, v17, v7, vcc_lo
-; GFX10-NEXT:    v_cmp_class_f16_e64 vcc_lo, v15, 64
-; GFX10-NEXT:    v_lshrrev_b32_e32 v7, 16, v7
-; GFX10-NEXT:    v_cndmask_b32_e32 v18, v18, v15, vcc_lo
-; GFX10-NEXT:    v_lshrrev_b32_e32 v15, 16, v15
-; GFX10-NEXT:    v_cmp_eq_f16_e32 vcc_lo, 0, v17
-; GFX10-NEXT:    v_cndmask_b32_e32 v17, v17, v18, vcc_lo
-; GFX10-NEXT:    v_cmp_o_f16_e32 vcc_lo, v7, v15
 ; GFX10-NEXT:    v_pk_max_f16 v18, v6, v14
+; GFX10-NEXT:    v_pk_max_f16 v19, v3, v11
+; GFX10-NEXT:    v_pk_max_f16 v20, v2, v10
+; GFX10-NEXT:    v_lshrrev_b32_e32 v17, 16, v16
 ; GFX10-NEXT:    v_cndmask_b32_e32 v16, 0x7e00, v16, vcc_lo
+; GFX10-NEXT:    v_cmp_o_f16_sdwa vcc_lo, v7, v15 src0_sel:WORD_1 src1_sel:WORD_1
+; GFX10-NEXT:    v_lshrrev_b32_e32 v15, 16, v18
+; GFX10-NEXT:    v_pk_max_f16 v21, v0, v8
+; GFX10-NEXT:    v_cndmask_b32_e32 v7, 0x7e00, v17, vcc_lo
 ; GFX10-NEXT:    v_cmp_o_f16_e32 vcc_lo, v6, v14
-; GFX10-NEXT:    v_lshrrev_b32_e32 v21, 16, v18
+; GFX10-NEXT:    v_pk_max_f16 v17, v5, v13
+; GFX10-NEXT:    v_lshrrev_b32_e32 v23, 16, v21
+; GFX10-NEXT:    v_perm_b32 v7, v7, v16, 0x5040100
 ; GFX10-NEXT:    v_cndmask_b32_e32 v18, 0x7e00, v18, vcc_lo
-; GFX10-NEXT:    v_cmp_class_f16_e64 vcc_lo, v7, 64
-; GFX10-NEXT:    v_cndmask_b32_e32 v7, v16, v7, vcc_lo
-; GFX10-NEXT:    v_cmp_o_f16_e32 vcc_lo, v20, v19
-; GFX10-NEXT:    v_cndmask_b32_e32 v21, 0x7e00, v21, vcc_lo
-; GFX10-NEXT:    v_cmp_class_f16_e64 vcc_lo, v6, 64
-; GFX10-NEXT:    v_cndmask_b32_e32 v6, v18, v6, vcc_lo
-; GFX10-NEXT:    v_cmp_class_f16_e64 vcc_lo, v15, 64
-; GFX10-NEXT:    v_cndmask_b32_e32 v7, v7, v15, vcc_lo
-; GFX10-NEXT:    v_cmp_class_f16_e64 vcc_lo, v20, 64
-; GFX10-NEXT:    v_cndmask_b32_e32 v15, v21, v20, vcc_lo
-; GFX10-NEXT:    v_cmp_class_f16_e64 vcc_lo, v14, 64
-; GFX10-NEXT:    v_pk_max_f16 v20, v4, v12
-; GFX10-NEXT:    v_cndmask_b32_e32 v6, v6, v14, vcc_lo
-; GFX10-NEXT:    v_cmp_eq_f16_e32 vcc_lo, 0, v16
-; GFX10-NEXT:    v_cndmask_b32_e32 v7, v16, v7, vcc_lo
-; GFX10-NEXT:    v_cmp_class_f16_e64 vcc_lo, v19, 64
-; GFX10-NEXT:    v_lshrrev_b32_e32 v16, 16, v13
-; GFX10-NEXT:    v_perm_b32 v7, v7, v17, 0x5040100
-; GFX10-NEXT:    v_cndmask_b32_e32 v14, v15, v19, vcc_lo
-; GFX10-NEXT:    v_cmp_eq_f16_e32 vcc_lo, 0, v18
-; GFX10-NEXT:    v_pk_max_f16 v15, v5, v13
-; GFX10-NEXT:    v_cndmask_b32_e32 v6, v18, v6, vcc_lo
-; GFX10-NEXT:    v_cmp_eq_f16_e32 vcc_lo, 0, v21
-; GFX10-NEXT:    v_lshrrev_b32_e32 v18, 16, v5
-; GFX10-NEXT:    v_lshrrev_b32_e32 v19, 16, v15
-; GFX10-NEXT:    v_cndmask_b32_e32 v14, v21, v14, vcc_lo
+; GFX10-NEXT:    v_cmp_o_f16_sdwa vcc_lo, v6, v14 src0_sel:WORD_1 src1_sel:WORD_1
+; GFX10-NEXT:    v_lshrrev_b32_e32 v14, 16, v17
+; GFX10-NEXT:    v_cndmask_b32_e32 v6, 0x7e00, v15, vcc_lo
 ; GFX10-NEXT:    v_cmp_o_f16_e32 vcc_lo, v5, v13
-; GFX10-NEXT:    v_perm_b32 v6, v14, v6, 0x5040100
-; GFX10-NEXT:    v_cndmask_b32_e32 v15, 0x7e00, v15, vcc_lo
-; GFX10-NEXT:    v_cmp_o_f16_e32 vcc_lo, v18, v16
-; GFX10-NEXT:    v_cndmask_b32_e32 v19, 0x7e00, v19, vcc_lo
+; GFX10-NEXT:    v_perm_b32 v6, v6, v18, 0x5040100
+; GFX10-NEXT:    v_cndmask_b32_e32 v15, 0x7e00, v17, vcc_lo
+; GFX10-NEXT:    v_cmp_o_f16_sdwa vcc_lo, v5, v13 src0_sel:WORD_1 src1_sel:WORD_1
+; GFX10-NEXT:    v_pk_max_f16 v17, v4, v12
+; GFX10-NEXT:    v_cndmask_b32_e32 v5, 0x7e00, v14, vcc_lo
 ; GFX10-NEXT:    v_cmp_o_f16_e32 vcc_lo, v4, v12
-; GFX10-NEXT:    v_cndmask_b32_e32 v21, 0x7e00, v20, vcc_lo
-; GFX10-NEXT:    v_cmp_class_f16_e64 vcc_lo, v5, 64
-; GFX10-NEXT:    v_cndmask_b32_e32 v5, v15, v5, vcc_lo
-; GFX10-NEXT:    v_cmp_class_f16_e64 vcc_lo, v18, 64
-; GFX10-NEXT:    v_cndmask_b32_e32 v18, v19, v18, vcc_lo
-; GFX10-NEXT:    v_cmp_class_f16_e64 vcc_lo, v4, 64
-; GFX10-NEXT:    v_cndmask_b32_e32 v22, v21, v4, vcc_lo
-; GFX10-NEXT:    v_cmp_class_f16_e64 vcc_lo, v13, 64
-; GFX10-NEXT:    v_lshrrev_b32_e32 v4, 16, v4
-; GFX10-NEXT:    v_cndmask_b32_e32 v5, v5, v13, vcc_lo
-; GFX10-NEXT:    v_cmp_class_f16_e64 vcc_lo, v16, 64
-; GFX10-NEXT:    v_cndmask_b32_e32 v13, v18, v16, vcc_lo
-; GFX10-NEXT:    v_cmp_class_f16_e64 vcc_lo, v12, 64
-; GFX10-NEXT:    v_lshrrev_b32_e32 v18, 16, v20
-; GFX10-NEXT:    v_lshrrev_b32_e32 v20, 16, v3
-; GFX10-NEXT:    v_cndmask_b32_e32 v16, v22, v12, vcc_lo
-; GFX10-NEXT:    v_cmp_eq_f16_e32 vcc_lo, 0, v15
-; GFX10-NEXT:    v_lshrrev_b32_e32 v12, 16, v12
-; GFX10-NEXT:    v_cndmask_b32_e32 v5, v15, v5, vcc_lo
-; GFX10-NEXT:    v_cmp_eq_f16_e32 vcc_lo, 0, v19
-; GFX10-NEXT:    v_cndmask_b32_e32 v13, v19, v13, vcc_lo
-; GFX10-NEXT:    v_cmp_eq_f16_e32 vcc_lo, 0, v21
-; GFX10-NEXT:    v_lshrrev_b32_e32 v19, 16, v11
-; GFX10-NEXT:    v_perm_b32 v5, v13, v5, 0x5040100
-; GFX10-NEXT:    v_cndmask_b32_e32 v15, v21, v16, vcc_lo
-; GFX10-NEXT:    v_cmp_o_f16_e32 vcc_lo, v4, v12
-; GFX10-NEXT:    v_pk_max_f16 v16, v3, v11
-; GFX10-NEXT:    v_cndmask_b32_e32 v18, 0x7e00, v18, vcc_lo
+; GFX10-NEXT:    v_lshrrev_b32_e32 v14, 16, v17
+; GFX10-NEXT:    v_perm_b32 v5, v5, v15, 0x5040100
+; GFX10-NEXT:    v_cndmask_b32_e32 v13, 0x7e00, v17, vcc_lo
 ; GFX10-NEXT:    v_cmp_o_f16_e32 vcc_lo, v3, v11
-; GFX10-NEXT:    v_lshrrev_b32_e32 v21, 16, v16
-; GFX10-NEXT:    v_cndmask_b32_e32 v16, 0x7e00, v16, vcc_lo
-; GFX10-NEXT:    v_cmp_o_f16_e32 vcc_lo, v20, v19
-; GFX10-NEXT:    v_cndmask_b32_e32 v21, 0x7e00, v21, vcc_lo
-; GFX10-NEXT:    v_cmp_class_f16_e64 vcc_lo, v4, 64
-; GFX10-NEXT:    v_cndmask_b32_e32 v4, v18, v4, vcc_lo
-; GFX10-NEXT:    v_cmp_class_f16_e64 vcc_lo, v3, 64
-; GFX10-NEXT:    v_cndmask_b32_e32 v3, v16, v3, vcc_lo
-; GFX10-NEXT:    v_cmp_class_f16_e64 vcc_lo, v20, 64
-; GFX10-NEXT:    v_cndmask_b32_e32 v20, v21, v20, vcc_lo
-; GFX10-NEXT:    v_cmp_class_f16_e64 vcc_lo, v12, 64
-; GFX10-NEXT:    v_cndmask_b32_e32 v4, v4, v12, vcc_lo
-; GFX10-NEXT:    v_cmp_class_f16_e64 vcc_lo, v11, 64
-; GFX10-NEXT:    v_pk_max_f16 v12, v2, v10
-; GFX10-NEXT:    v_cndmask_b32_e32 v3, v3, v11, vcc_lo
-; GFX10-NEXT:    v_cmp_class_f16_e64 vcc_lo, v19, 64
-; GFX10-NEXT:    v_cndmask_b32_e32 v11, v20, v19, vcc_lo
-; GFX10-NEXT:    v_cmp_eq_f16_e32 vcc_lo, 0, v16
-; GFX10-NEXT:    v_pk_max_f16 v19, v1, v9
-; GFX10-NEXT:    v_lshrrev_b32_e32 v20, 16, v10
-; GFX10-NEXT:    v_cndmask_b32_e32 v3, v16, v3, vcc_lo
-; GFX10-NEXT:    v_cmp_eq_f16_e32 vcc_lo, 0, v21
-; GFX10-NEXT:    v_cndmask_b32_e32 v11, v21, v11, vcc_lo
-; GFX10-NEXT:    v_cmp_o_f16_e32 vcc_lo, v2, v10
-; GFX10-NEXT:    v_lshrrev_b32_e32 v21, 16, v2
-; GFX10-NEXT:    v_perm_b32 v3, v11, v3, 0x5040100
-; GFX10-NEXT:    v_cndmask_b32_e32 v16, 0x7e00, v12, vcc_lo
-; GFX10-NEXT:    v_cmp_o_f16_e32 vcc_lo, v1, v9
-; GFX10-NEXT:    v_lshrrev_b32_e32 v12, 16, v12
-; GFX10-NEXT:    v_cndmask_b32_e32 v22, 0x7e00, v19, vcc_lo
-; GFX10-NEXT:    v_cmp_class_f16_e64 vcc_lo, v2, 64
-; GFX10-NEXT:    v_lshrrev_b32_e32 v19, 16, v19
-; GFX10-NEXT:    v_cndmask_b32_e32 v2, v16, v2, vcc_lo
-; GFX10-NEXT:    v_cmp_o_f16_e32 vcc_lo, v21, v20
-; GFX10-NEXT:    v_cndmask_b32_e32 v12, 0x7e00, v12, vcc_lo
-; GFX10-NEXT:    v_cmp_class_f16_e64 vcc_lo, v1, 64
-; GFX10-NEXT:    v_cndmask_b32_e32 v23, v22, v1, vcc_lo
-; GFX10-NEXT:    v_cmp_class_f16_e64 vcc_lo, v10, 64
-; GFX10-NEXT:    v_lshrrev_b32_e32 v1, 16, v1
-; GFX10-NEXT:    v_cndmask_b32_e32 v2, v2, v10, vcc_lo
-; GFX10-NEXT:    v_cmp_class_f16_e64 vcc_lo, v21, 64
-; GFX10-NEXT:    v_cndmask_b32_e32 v10, v12, v21, vcc_lo
-; GFX10-NEXT:    v_cmp_class_f16_e64 vcc_lo, v9, 64
-; GFX10-NEXT:    v_cndmask_b32_e32 v21, v23, v9, vcc_lo
-; GFX10-NEXT:    v_cmp_eq_f16_e32 vcc_lo, 0, v16
-; GFX10-NEXT:    v_lshrrev_b32_e32 v9, 16, v9
-; GFX10-NEXT:    v_cndmask_b32_e32 v2, v16, v2, vcc_lo
-; GFX10-NEXT:    v_cmp_class_f16_e64 vcc_lo, v20, 64
-; GFX10-NEXT:    v_cndmask_b32_e32 v10, v10, v20, vcc_lo
-; GFX10-NEXT:    v_cmp_eq_f16_e32 vcc_lo, 0, v22
-; GFX10-NEXT:    v_pk_max_f16 v20, v0, v8
-; GFX10-NEXT:    v_cndmask_b32_e32 v16, v22, v21, vcc_lo
-; GFX10-NEXT:    v_cmp_o_f16_e32 vcc_lo, v1, v9
-; GFX10-NEXT:    v_lshrrev_b32_e32 v21, 16, v8
-; GFX10-NEXT:    v_lshrrev_b32_e32 v22, 16, v0
-; GFX10-NEXT:    v_lshrrev_b32_e32 v23, 16, v20
+; GFX10-NEXT:    v_lshrrev_b32_e32 v17, 16, v19
 ; GFX10-NEXT:    v_cndmask_b32_e32 v19, 0x7e00, v19, vcc_lo
+; GFX10-NEXT:    v_cmp_o_f16_sdwa vcc_lo, v3, v11 src0_sel:WORD_1 src1_sel:WORD_1
+; GFX10-NEXT:    v_pk_max_f16 v11, v1, v9
+; GFX10-NEXT:    v_cndmask_b32_e32 v3, 0x7e00, v17, vcc_lo
+; GFX10-NEXT:    v_cmp_o_f16_e32 vcc_lo, v2, v10
+; GFX10-NEXT:    v_lshrrev_b32_e32 v22, 16, v11
+; GFX10-NEXT:    v_perm_b32 v3, v3, v19, 0x5040100
+; GFX10-NEXT:    v_cndmask_b32_e32 v17, 0x7e00, v20, vcc_lo
+; GFX10-NEXT:    v_cmp_o_f16_e32 vcc_lo, v1, v9
+; GFX10-NEXT:    v_lshrrev_b32_e32 v20, 16, v20
+; GFX10-NEXT:    v_cndmask_b32_e32 v11, 0x7e00, v11, vcc_lo
+; GFX10-NEXT:    v_cmp_o_f16_sdwa vcc_lo, v1, v9 src0_sel:WORD_1 src1_sel:WORD_1
+; GFX10-NEXT:    v_cndmask_b32_e32 v1, 0x7e00, v22, vcc_lo
 ; GFX10-NEXT:    v_cmp_o_f16_e32 vcc_lo, v0, v8
-; GFX10-NEXT:    v_cndmask_b32_e32 v20, 0x7e00, v20, vcc_lo
-; GFX10-NEXT:    v_cmp_o_f16_e32 vcc_lo, v22, v21
-; GFX10-NEXT:    v_cndmask_b32_e32 v23, 0x7e00, v23, vcc_lo
-; GFX10-NEXT:    v_cmp_class_f16_e64 vcc_lo, v1, 64
-; GFX10-NEXT:    v_cndmask_b32_e32 v1, v19, v1, vcc_lo
-; GFX10-NEXT:    v_cmp_class_f16_e64 vcc_lo, v0, 64
-; GFX10-NEXT:    v_cndmask_b32_e32 v0, v20, v0, vcc_lo
-; GFX10-NEXT:    v_cmp_class_f16_e64 vcc_lo, v22, 64
-; GFX10-NEXT:    v_cndmask_b32_e32 v22, v23, v22, vcc_lo
-; GFX10-NEXT:    v_cmp_class_f16_e64 vcc_lo, v9, 64
-; GFX10-NEXT:    v_cndmask_b32_e32 v1, v1, v9, vcc_lo
-; GFX10-NEXT:    v_cmp_class_f16_e64 vcc_lo, v8, 64
-; GFX10-NEXT:    v_cndmask_b32_e32 v0, v0, v8, vcc_lo
-; GFX10-NEXT:    v_cmp_class_f16_e64 vcc_lo, v21, 64
-; GFX10-NEXT:    v_cndmask_b32_e32 v8, v22, v21, vcc_lo
-; GFX10-NEXT:    v_cmp_eq_f16_e32 vcc_lo, 0, v19
-; GFX10-NEXT:    v_cndmask_b32_e32 v1, v19, v1, vcc_lo
-; GFX10-NEXT:    v_cmp_eq_f16_e32 vcc_lo, 0, v20
-; GFX10-NEXT:    v_perm_b32 v1, v1, v16, 0x5040100
-; GFX10-NEXT:    v_cndmask_b32_e32 v0, v20, v0, vcc_lo
-; GFX10-NEXT:    v_cmp_eq_f16_e32 vcc_lo, 0, v23
-; GFX10-NEXT:    v_cndmask_b32_e32 v8, v23, v8, vcc_lo
-; GFX10-NEXT:    v_cmp_eq_f16_e32 vcc_lo, 0, v12
-; GFX10-NEXT:    v_perm_b32 v0, v8, v0, 0x5040100
-; GFX10-NEXT:    v_cndmask_b32_e32 v9, v12, v10, vcc_lo
-; GFX10-NEXT:    v_cmp_eq_f16_e32 vcc_lo, 0, v18
-; GFX10-NEXT:    v_perm_b32 v2, v9, v2, 0x5040100
-; GFX10-NEXT:    v_cndmask_b32_e32 v4, v18, v4, vcc_lo
-; GFX10-NEXT:    v_perm_b32 v4, v4, v15, 0x5040100
+; GFX10-NEXT:    v_perm_b32 v1, v1, v11, 0x5040100
+; GFX10-NEXT:    v_cndmask_b32_e32 v9, 0x7e00, v21, vcc_lo
+; GFX10-NEXT:    v_cmp_o_f16_sdwa vcc_lo, v0, v8 src0_sel:WORD_1 src1_sel:WORD_1
+; GFX10-NEXT:    v_cndmask_b32_e32 v0, 0x7e00, v23, vcc_lo
+; GFX10-NEXT:    v_cmp_o_f16_sdwa vcc_lo, v2, v10 src0_sel:WORD_1 src1_sel:WORD_1
+; GFX10-NEXT:    v_perm_b32 v0, v0, v9, 0x5040100
+; GFX10-NEXT:    v_cndmask_b32_e32 v2, 0x7e00, v20, vcc_lo
+; GFX10-NEXT:    v_cmp_o_f16_sdwa vcc_lo, v4, v12 src0_sel:WORD_1 src1_sel:WORD_1
+; GFX10-NEXT:    v_perm_b32 v2, v2, v17, 0x5040100
+; GFX10-NEXT:    v_cndmask_b32_e32 v4, 0x7e00, v14, vcc_lo
+; GFX10-NEXT:    v_perm_b32 v4, v4, v13, 0x5040100
 ; GFX10-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX11-LABEL: v_maximum_v16f16:
 ; GFX11:       ; %bb.0:
 ; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX11-NEXT:    v_pk_max_f16 v16, v7, v15
+; GFX11-NEXT:    v_lshrrev_b32_e32 v17, 16, v15
+; GFX11-NEXT:    v_lshrrev_b32_e32 v18, 16, v7
 ; GFX11-NEXT:    v_cmp_o_f16_e32 vcc_lo, v7, v15
-; GFX11-NEXT:    v_lshrrev_b32_e32 v20, 16, v6
-; GFX11-NEXT:    v_lshrrev_b32_e32 v19, 16, v14
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(SKIP_2) | instid1(VALU_DEP_3)
-; GFX11-NEXT:    v_cndmask_b32_e32 v17, 0x7e00, v16, vcc_lo
-; GFX11-NEXT:    v_cmp_class_f16_e64 vcc_lo, v7, 64
-; GFX11-NEXT:    v_lshrrev_b32_e32 v16, 16, v16
-; GFX11-NEXT:    v_cndmask_b32_e32 v18, v17, v7, vcc_lo
-; GFX11-NEXT:    v_cmp_class_f16_e64 vcc_lo, v15, 64
-; GFX11-NEXT:    v_lshrrev_b32_e32 v7, 16, v7
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(SKIP_2) | instid1(VALU_DEP_3)
-; GFX11-NEXT:    v_cndmask_b32_e32 v18, v18, v15, vcc_lo
-; GFX11-NEXT:    v_lshrrev_b32_e32 v15, 16, v15
-; GFX11-NEXT:    v_cmp_eq_f16_e32 vcc_lo, 0, v17
-; GFX11-NEXT:    v_cndmask_b32_e32 v17, v17, v18, vcc_lo
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(SKIP_3) | instid1(VALU_DEP_3)
-; GFX11-NEXT:    v_cmp_o_f16_e32 vcc_lo, v7, v15
-; GFX11-NEXT:    v_pk_max_f16 v18, v6, v14
-; GFX11-NEXT:    v_cndmask_b32_e32 v16, 0x7e00, v16, vcc_lo
-; GFX11-NEXT:    v_cmp_o_f16_e32 vcc_lo, v6, v14
-; GFX11-NEXT:    v_lshrrev_b32_e32 v21, 16, v18
-; GFX11-NEXT:    v_cndmask_b32_e32 v18, 0x7e00, v18, vcc_lo
-; GFX11-NEXT:    v_cmp_class_f16_e64 vcc_lo, v7, 64
-; GFX11-NEXT:    v_cndmask_b32_e32 v7, v16, v7, vcc_lo
-; GFX11-NEXT:    v_cmp_o_f16_e32 vcc_lo, v20, v19
-; GFX11-NEXT:    v_cndmask_b32_e32 v21, 0x7e00, v21, vcc_lo
-; GFX11-NEXT:    v_cmp_class_f16_e64 vcc_lo, v6, 64
-; GFX11-NEXT:    v_cndmask_b32_e32 v6, v18, v6, vcc_lo
-; GFX11-NEXT:    v_cmp_class_f16_e64 vcc_lo, v15, 64
-; GFX11-NEXT:    v_cndmask_b32_e32 v7, v7, v15, vcc_lo
-; GFX11-NEXT:    v_cmp_class_f16_e64 vcc_lo, v20, 64
-; GFX11-NEXT:    v_cndmask_b32_e32 v15, v21, v20, vcc_lo
-; GFX11-NEXT:    v_cmp_class_f16_e64 vcc_lo, v14, 64
+; GFX11-NEXT:    v_pk_max_f16 v15, v6, v14
+; GFX11-NEXT:    v_lshrrev_b32_e32 v19, 16, v16
 ; GFX11-NEXT:    v_pk_max_f16 v20, v4, v12
-; GFX11-NEXT:    v_cndmask_b32_e32 v6, v6, v14, vcc_lo
-; GFX11-NEXT:    v_cmp_eq_f16_e32 vcc_lo, 0, v16
-; GFX11-NEXT:    v_cndmask_b32_e32 v7, v16, v7, vcc_lo
-; GFX11-NEXT:    v_cmp_class_f16_e64 vcc_lo, v19, 64
-; GFX11-NEXT:    v_lshrrev_b32_e32 v16, 16, v13
-; GFX11-NEXT:    v_cndmask_b32_e32 v14, v15, v19, vcc_lo
-; GFX11-NEXT:    v_cmp_eq_f16_e32 vcc_lo, 0, v18
-; GFX11-NEXT:    v_pk_max_f16 v15, v5, v13
-; GFX11-NEXT:    v_cndmask_b32_e32 v6, v18, v6, vcc_lo
-; GFX11-NEXT:    v_cmp_eq_f16_e32 vcc_lo, 0, v21
-; GFX11-NEXT:    v_lshrrev_b32_e32 v18, 16, v5
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_4)
+; GFX11-NEXT:    v_pk_max_f16 v22, v2, v10
+; GFX11-NEXT:    v_cndmask_b32_e32 v7, 0x7e00, v16, vcc_lo
+; GFX11-NEXT:    v_cmp_o_f16_e32 vcc_lo, v18, v17
+; GFX11-NEXT:    v_lshrrev_b32_e32 v17, 16, v14
+; GFX11-NEXT:    v_lshrrev_b32_e32 v18, 16, v6
+; GFX11-NEXT:    v_lshrrev_b32_e32 v23, 16, v8
+; GFX11-NEXT:    v_lshrrev_b32_e32 v24, 16, v0
+; GFX11-NEXT:    v_cndmask_b32_e32 v16, 0x7e00, v19, vcc_lo
+; GFX11-NEXT:    v_cmp_o_f16_e32 vcc_lo, v6, v14
 ; GFX11-NEXT:    v_lshrrev_b32_e32 v19, 16, v15
-; GFX11-NEXT:    v_perm_b32 v7, v7, v17, 0x5040100
-; GFX11-NEXT:    v_cndmask_b32_e32 v14, v21, v14, vcc_lo
+; GFX11-NEXT:    v_pk_max_f16 v14, v5, v13
+; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_4)
+; GFX11-NEXT:    v_perm_b32 v7, v16, v7, 0x5040100
+; GFX11-NEXT:    v_cndmask_b32_e32 v6, 0x7e00, v15, vcc_lo
+; GFX11-NEXT:    v_cmp_o_f16_e32 vcc_lo, v18, v17
+; GFX11-NEXT:    v_lshrrev_b32_e32 v17, 16, v13
+; GFX11-NEXT:    v_lshrrev_b32_e32 v18, 16, v5
+; GFX11-NEXT:    v_cndmask_b32_e32 v15, 0x7e00, v19, vcc_lo
 ; GFX11-NEXT:    v_cmp_o_f16_e32 vcc_lo, v5, v13
-; GFX11-NEXT:    v_cndmask_b32_e32 v15, 0x7e00, v15, vcc_lo
-; GFX11-NEXT:    v_cmp_o_f16_e32 vcc_lo, v18, v16
-; GFX11-NEXT:    v_cndmask_b32_e32 v19, 0x7e00, v19, vcc_lo
-; GFX11-NEXT:    v_cmp_o_f16_e32 vcc_lo, v4, v12
-; GFX11-NEXT:    v_cndmask_b32_e32 v21, 0x7e00, v20, vcc_lo
-; GFX11-NEXT:    v_cmp_class_f16_e64 vcc_lo, v5, 64
-; GFX11-NEXT:    v_cndmask_b32_e32 v5, v15, v5, vcc_lo
-; GFX11-NEXT:    v_cmp_class_f16_e64 vcc_lo, v18, 64
-; GFX11-NEXT:    v_cndmask_b32_e32 v18, v19, v18, vcc_lo
-; GFX11-NEXT:    v_cmp_class_f16_e64 vcc_lo, v4, 64
-; GFX11-NEXT:    v_cndmask_b32_e32 v22, v21, v4, vcc_lo
-; GFX11-NEXT:    v_cmp_class_f16_e64 vcc_lo, v13, 64
-; GFX11-NEXT:    v_lshrrev_b32_e32 v4, 16, v4
-; GFX11-NEXT:    v_cndmask_b32_e32 v5, v5, v13, vcc_lo
-; GFX11-NEXT:    v_cmp_class_f16_e64 vcc_lo, v16, 64
-; GFX11-NEXT:    v_cndmask_b32_e32 v13, v18, v16, vcc_lo
-; GFX11-NEXT:    v_cmp_class_f16_e64 vcc_lo, v12, 64
-; GFX11-NEXT:    v_lshrrev_b32_e32 v18, 16, v20
-; GFX11-NEXT:    v_lshrrev_b32_e32 v20, 16, v3
-; GFX11-NEXT:    v_perm_b32 v6, v14, v6, 0x5040100
-; GFX11-NEXT:    v_cndmask_b32_e32 v16, v22, v12, vcc_lo
-; GFX11-NEXT:    v_cmp_eq_f16_e32 vcc_lo, 0, v15
-; GFX11-NEXT:    v_lshrrev_b32_e32 v12, 16, v12
-; GFX11-NEXT:    v_cndmask_b32_e32 v5, v15, v5, vcc_lo
-; GFX11-NEXT:    v_cmp_eq_f16_e32 vcc_lo, 0, v19
-; GFX11-NEXT:    v_cndmask_b32_e32 v13, v19, v13, vcc_lo
-; GFX11-NEXT:    v_cmp_eq_f16_e32 vcc_lo, 0, v21
-; GFX11-NEXT:    v_lshrrev_b32_e32 v19, 16, v11
+; GFX11-NEXT:    v_lshrrev_b32_e32 v19, 16, v14
 ; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_3)
-; GFX11-NEXT:    v_perm_b32 v5, v13, v5, 0x5040100
-; GFX11-NEXT:    v_cndmask_b32_e32 v15, v21, v16, vcc_lo
+; GFX11-NEXT:    v_perm_b32 v6, v15, v6, 0x5040100
+; GFX11-NEXT:    v_cndmask_b32_e32 v5, 0x7e00, v14, vcc_lo
+; GFX11-NEXT:    v_cmp_o_f16_e32 vcc_lo, v18, v17
+; GFX11-NEXT:    v_pk_max_f16 v17, v3, v11
+; GFX11-NEXT:    v_lshrrev_b32_e32 v18, 16, v20
+; GFX11-NEXT:    v_cndmask_b32_e32 v13, 0x7e00, v19, vcc_lo
 ; GFX11-NEXT:    v_cmp_o_f16_e32 vcc_lo, v4, v12
-; GFX11-NEXT:    v_pk_max_f16 v16, v3, v11
-; GFX11-NEXT:    v_cndmask_b32_e32 v18, 0x7e00, v18, vcc_lo
-; GFX11-NEXT:    v_cmp_o_f16_e32 vcc_lo, v3, v11
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(SKIP_2) | instid1(VALU_DEP_3)
-; GFX11-NEXT:    v_lshrrev_b32_e32 v21, 16, v16
-; GFX11-NEXT:    v_cndmask_b32_e32 v16, 0x7e00, v16, vcc_lo
-; GFX11-NEXT:    v_cmp_o_f16_e32 vcc_lo, v20, v19
-; GFX11-NEXT:    v_cndmask_b32_e32 v21, 0x7e00, v21, vcc_lo
-; GFX11-NEXT:    v_cmp_class_f16_e64 vcc_lo, v4, 64
-; GFX11-NEXT:    v_cndmask_b32_e32 v4, v18, v4, vcc_lo
-; GFX11-NEXT:    v_cmp_class_f16_e64 vcc_lo, v3, 64
-; GFX11-NEXT:    v_cndmask_b32_e32 v3, v16, v3, vcc_lo
-; GFX11-NEXT:    v_cmp_class_f16_e64 vcc_lo, v20, 64
-; GFX11-NEXT:    v_cndmask_b32_e32 v20, v21, v20, vcc_lo
-; GFX11-NEXT:    v_cmp_class_f16_e64 vcc_lo, v12, 64
-; GFX11-NEXT:    v_cndmask_b32_e32 v4, v4, v12, vcc_lo
-; GFX11-NEXT:    v_cmp_class_f16_e64 vcc_lo, v11, 64
-; GFX11-NEXT:    v_pk_max_f16 v12, v2, v10
-; GFX11-NEXT:    v_cndmask_b32_e32 v3, v3, v11, vcc_lo
-; GFX11-NEXT:    v_cmp_class_f16_e64 vcc_lo, v19, 64
-; GFX11-NEXT:    v_cndmask_b32_e32 v11, v20, v19, vcc_lo
-; GFX11-NEXT:    v_cmp_eq_f16_e32 vcc_lo, 0, v16
-; GFX11-NEXT:    v_lshrrev_b32_e32 v20, 16, v10
-; GFX11-NEXT:    v_pk_max_f16 v19, v1, v9
-; GFX11-NEXT:    v_cndmask_b32_e32 v3, v16, v3, vcc_lo
-; GFX11-NEXT:    v_cmp_eq_f16_e32 vcc_lo, 0, v21
-; GFX11-NEXT:    v_cndmask_b32_e32 v11, v21, v11, vcc_lo
-; GFX11-NEXT:    v_cmp_o_f16_e32 vcc_lo, v2, v10
-; GFX11-NEXT:    v_lshrrev_b32_e32 v21, 16, v2
-; GFX11-NEXT:    v_cndmask_b32_e32 v16, 0x7e00, v12, vcc_lo
-; GFX11-NEXT:    v_cmp_o_f16_e32 vcc_lo, v1, v9
+; GFX11-NEXT:    v_lshrrev_b32_e32 v19, 16, v11
+; GFX11-NEXT:    v_lshrrev_b32_e32 v21, 16, v17
 ; GFX11-NEXT:    v_lshrrev_b32_e32 v12, 16, v12
-; GFX11-NEXT:    v_cndmask_b32_e32 v22, 0x7e00, v19, vcc_lo
-; GFX11-NEXT:    v_cmp_class_f16_e64 vcc_lo, v2, 64
-; GFX11-NEXT:    v_lshrrev_b32_e32 v19, 16, v19
-; GFX11-NEXT:    v_cndmask_b32_e32 v2, v16, v2, vcc_lo
-; GFX11-NEXT:    v_cmp_o_f16_e32 vcc_lo, v21, v20
-; GFX11-NEXT:    v_cndmask_b32_e32 v12, 0x7e00, v12, vcc_lo
-; GFX11-NEXT:    v_cmp_class_f16_e64 vcc_lo, v1, 64
-; GFX11-NEXT:    v_cndmask_b32_e32 v23, v22, v1, vcc_lo
-; GFX11-NEXT:    v_cmp_class_f16_e64 vcc_lo, v10, 64
-; GFX11-NEXT:    v_lshrrev_b32_e32 v1, 16, v1
-; GFX11-NEXT:    v_cndmask_b32_e32 v2, v2, v10, vcc_lo
-; GFX11-NEXT:    v_cmp_class_f16_e64 vcc_lo, v21, 64
-; GFX11-NEXT:    v_cndmask_b32_e32 v10, v12, v21, vcc_lo
-; GFX11-NEXT:    v_cmp_class_f16_e64 vcc_lo, v9, 64
-; GFX11-NEXT:    v_cndmask_b32_e32 v21, v23, v9, vcc_lo
-; GFX11-NEXT:    v_cmp_eq_f16_e32 vcc_lo, 0, v16
-; GFX11-NEXT:    v_lshrrev_b32_e32 v9, 16, v9
-; GFX11-NEXT:    v_cndmask_b32_e32 v2, v16, v2, vcc_lo
-; GFX11-NEXT:    v_cmp_class_f16_e64 vcc_lo, v20, 64
-; GFX11-NEXT:    v_cndmask_b32_e32 v10, v10, v20, vcc_lo
-; GFX11-NEXT:    v_cmp_eq_f16_e32 vcc_lo, 0, v22
-; GFX11-NEXT:    v_pk_max_f16 v20, v0, v8
+; GFX11-NEXT:    v_lshrrev_b32_e32 v4, 16, v4
+; GFX11-NEXT:    v_cndmask_b32_e32 v14, 0x7e00, v20, vcc_lo
+; GFX11-NEXT:    v_lshrrev_b32_e32 v20, 16, v3
+; GFX11-NEXT:    v_cmp_o_f16_e32 vcc_lo, v3, v11
+; GFX11-NEXT:    v_perm_b32 v5, v13, v5, 0x5040100
+; GFX11-NEXT:    v_cndmask_b32_e32 v3, 0x7e00, v17, vcc_lo
+; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_4)
+; GFX11-NEXT:    v_cmp_o_f16_e32 vcc_lo, v20, v19
+; GFX11-NEXT:    v_pk_max_f16 v19, v1, v9
+; GFX11-NEXT:    v_lshrrev_b32_e32 v20, 16, v22
+; GFX11-NEXT:    v_cndmask_b32_e32 v11, 0x7e00, v21, vcc_lo
+; GFX11-NEXT:    v_cmp_o_f16_e32 vcc_lo, v2, v10
+; GFX11-NEXT:    v_lshrrev_b32_e32 v10, 16, v10
+; GFX11-NEXT:    v_lshrrev_b32_e32 v2, 16, v2
+; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_4)
 ; GFX11-NEXT:    v_perm_b32 v3, v11, v3, 0x5040100
-; GFX11-NEXT:    v_cndmask_b32_e32 v16, v22, v21, vcc_lo
+; GFX11-NEXT:    v_cndmask_b32_e32 v17, 0x7e00, v22, vcc_lo
 ; GFX11-NEXT:    v_cmp_o_f16_e32 vcc_lo, v1, v9
-; GFX11-NEXT:    v_lshrrev_b32_e32 v21, 16, v8
-; GFX11-NEXT:    v_lshrrev_b32_e32 v22, 16, v0
-; GFX11-NEXT:    v_lshrrev_b32_e32 v23, 16, v20
-; GFX11-NEXT:    v_cndmask_b32_e32 v19, 0x7e00, v19, vcc_lo
+; GFX11-NEXT:    v_lshrrev_b32_e32 v9, 16, v9
+; GFX11-NEXT:    v_lshrrev_b32_e32 v1, 16, v1
+; GFX11-NEXT:    v_pk_max_f16 v22, v0, v8
+; GFX11-NEXT:    v_cndmask_b32_e32 v21, 0x7e00, v19, vcc_lo
+; GFX11-NEXT:    v_lshrrev_b32_e32 v19, 16, v19
+; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(NEXT) | instid1(VALU_DEP_4)
+; GFX11-NEXT:    v_cmp_o_f16_e32 vcc_lo, v1, v9
+; GFX11-NEXT:    v_lshrrev_b32_e32 v25, 16, v22
+; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(SKIP_1) | instid1(VALU_DEP_2)
+; GFX11-NEXT:    v_cndmask_b32_e32 v1, 0x7e00, v19, vcc_lo
 ; GFX11-NEXT:    v_cmp_o_f16_e32 vcc_lo, v0, v8
-; GFX11-NEXT:    v_cndmask_b32_e32 v20, 0x7e00, v20, vcc_lo
-; GFX11-NEXT:    v_cmp_o_f16_e32 vcc_lo, v22, v21
-; GFX11-NEXT:    v_cndmask_b32_e32 v23, 0x7e00, v23, vcc_lo
-; GFX11-NEXT:    v_cmp_class_f16_e64 vcc_lo, v1, 64
-; GFX11-NEXT:    v_cndmask_b32_e32 v1, v19, v1, vcc_lo
-; GFX11-NEXT:    v_cmp_class_f16_e64 vcc_lo, v0, 64
-; GFX11-NEXT:    v_cndmask_b32_e32 v0, v20, v0, vcc_lo
-; GFX11-NEXT:    v_cmp_class_f16_e64 vcc_lo, v22, 64
-; GFX11-NEXT:    v_cndmask_b32_e32 v22, v23, v22, vcc_lo
-; GFX11-NEXT:    v_cmp_class_f16_e64 vcc_lo, v9, 64
-; GFX11-NEXT:    v_cndmask_b32_e32 v1, v1, v9, vcc_lo
-; GFX11-NEXT:    v_cmp_class_f16_e64 vcc_lo, v8, 64
-; GFX11-NEXT:    v_cndmask_b32_e32 v0, v0, v8, vcc_lo
-; GFX11-NEXT:    v_cmp_class_f16_e64 vcc_lo, v21, 64
-; GFX11-NEXT:    v_cndmask_b32_e32 v8, v22, v21, vcc_lo
-; GFX11-NEXT:    v_cmp_eq_f16_e32 vcc_lo, 0, v19
-; GFX11-NEXT:    v_cndmask_b32_e32 v1, v19, v1, vcc_lo
-; GFX11-NEXT:    v_cmp_eq_f16_e32 vcc_lo, 0, v20
-; GFX11-NEXT:    v_cndmask_b32_e32 v0, v20, v0, vcc_lo
-; GFX11-NEXT:    v_cmp_eq_f16_e32 vcc_lo, 0, v23
-; GFX11-NEXT:    v_cndmask_b32_e32 v8, v23, v8, vcc_lo
-; GFX11-NEXT:    v_cmp_eq_f16_e32 vcc_lo, 0, v12
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(SKIP_3) | instid1(VALU_DEP_3)
+; GFX11-NEXT:    v_perm_b32 v1, v1, v21, 0x5040100
+; GFX11-NEXT:    v_cndmask_b32_e32 v0, 0x7e00, v22, vcc_lo
+; GFX11-NEXT:    v_cmp_o_f16_e32 vcc_lo, v24, v23
+; GFX11-NEXT:    v_cndmask_b32_e32 v8, 0x7e00, v25, vcc_lo
+; GFX11-NEXT:    v_cmp_o_f16_e32 vcc_lo, v2, v10
+; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(SKIP_2) | instid1(VALU_DEP_2)
 ; GFX11-NEXT:    v_perm_b32 v0, v8, v0, 0x5040100
-; GFX11-NEXT:    v_cndmask_b32_e32 v9, v12, v10, vcc_lo
-; GFX11-NEXT:    v_cmp_eq_f16_e32 vcc_lo, 0, v18
-; GFX11-NEXT:    v_perm_b32 v1, v1, v16, 0x5040100
-; GFX11-NEXT:    v_perm_b32 v2, v9, v2, 0x5040100
-; GFX11-NEXT:    v_cndmask_b32_e32 v4, v18, v4, vcc_lo
+; GFX11-NEXT:    v_cndmask_b32_e32 v2, 0x7e00, v20, vcc_lo
+; GFX11-NEXT:    v_cmp_o_f16_e32 vcc_lo, v4, v12
+; GFX11-NEXT:    v_perm_b32 v2, v2, v17, 0x5040100
+; GFX11-NEXT:    v_cndmask_b32_e32 v4, 0x7e00, v18, vcc_lo
 ; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; GFX11-NEXT:    v_perm_b32 v4, v4, v15, 0x5040100
+; GFX11-NEXT:    v_perm_b32 v4, v4, v14, 0x5040100
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX12-LABEL: v_maximum_v16f16:

--- a/llvm/test/CodeGen/AMDGPU/llvm.maximum.f32.ll
+++ b/llvm/test/CodeGen/AMDGPU/llvm.maximum.f32.ll
@@ -14,13 +14,7 @@ define float @v_maximum_f32(float %src0, float %src1) {
 ; GFX7-NEXT:    v_max_f32_e32 v2, v0, v1
 ; GFX7-NEXT:    v_mov_b32_e32 v3, 0x7fc00000
 ; GFX7-NEXT:    v_cmp_o_f32_e32 vcc, v0, v1
-; GFX7-NEXT:    v_cndmask_b32_e32 v2, v3, v2, vcc
-; GFX7-NEXT:    v_cmp_class_f32_e64 vcc, v0, 64
-; GFX7-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc
-; GFX7-NEXT:    v_cmp_class_f32_e64 vcc, v1, 64
-; GFX7-NEXT:    v_cndmask_b32_e32 v0, v0, v1, vcc
-; GFX7-NEXT:    v_cmp_eq_f32_e32 vcc, 0, v2
-; GFX7-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc
+; GFX7-NEXT:    v_cndmask_b32_e32 v0, v3, v2, vcc
 ; GFX7-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX8-LABEL: v_maximum_f32:
@@ -29,13 +23,7 @@ define float @v_maximum_f32(float %src0, float %src1) {
 ; GFX8-NEXT:    v_max_f32_e32 v2, v0, v1
 ; GFX8-NEXT:    v_mov_b32_e32 v3, 0x7fc00000
 ; GFX8-NEXT:    v_cmp_o_f32_e32 vcc, v0, v1
-; GFX8-NEXT:    v_cndmask_b32_e32 v2, v3, v2, vcc
-; GFX8-NEXT:    v_cmp_class_f32_e64 vcc, v0, 64
-; GFX8-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc
-; GFX8-NEXT:    v_cmp_class_f32_e64 vcc, v1, 64
-; GFX8-NEXT:    v_cndmask_b32_e32 v0, v0, v1, vcc
-; GFX8-NEXT:    v_cmp_eq_f32_e32 vcc, 0, v2
-; GFX8-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc
+; GFX8-NEXT:    v_cndmask_b32_e32 v0, v3, v2, vcc
 ; GFX8-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX9-LABEL: v_maximum_f32:
@@ -44,13 +32,7 @@ define float @v_maximum_f32(float %src0, float %src1) {
 ; GFX9-NEXT:    v_max_f32_e32 v2, v0, v1
 ; GFX9-NEXT:    v_mov_b32_e32 v3, 0x7fc00000
 ; GFX9-NEXT:    v_cmp_o_f32_e32 vcc, v0, v1
-; GFX9-NEXT:    v_cndmask_b32_e32 v2, v3, v2, vcc
-; GFX9-NEXT:    v_cmp_class_f32_e64 vcc, v0, 64
-; GFX9-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc
-; GFX9-NEXT:    v_cmp_class_f32_e64 vcc, v1, 64
-; GFX9-NEXT:    v_cndmask_b32_e32 v0, v0, v1, vcc
-; GFX9-NEXT:    v_cmp_eq_f32_e32 vcc, 0, v2
-; GFX9-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v0, v3, v2, vcc
 ; GFX9-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX940-LABEL: v_maximum_f32:
@@ -60,16 +42,7 @@ define float @v_maximum_f32(float %src0, float %src1) {
 ; GFX940-NEXT:    v_mov_b32_e32 v3, 0x7fc00000
 ; GFX940-NEXT:    v_cmp_o_f32_e32 vcc, v0, v1
 ; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v2, v3, v2, vcc
-; GFX940-NEXT:    v_cmp_class_f32_e64 vcc, v0, 64
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc
-; GFX940-NEXT:    v_cmp_class_f32_e64 vcc, v1, 64
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v0, v0, v1, vcc
-; GFX940-NEXT:    v_cmp_eq_f32_e32 vcc, 0, v2
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc
+; GFX940-NEXT:    v_cndmask_b32_e32 v0, v3, v2, vcc
 ; GFX940-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX10-LABEL: v_maximum_f32:
@@ -77,13 +50,7 @@ define float @v_maximum_f32(float %src0, float %src1) {
 ; GFX10-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX10-NEXT:    v_max_f32_e32 v2, v0, v1
 ; GFX10-NEXT:    v_cmp_o_f32_e32 vcc_lo, v0, v1
-; GFX10-NEXT:    v_cndmask_b32_e32 v2, 0x7fc00000, v2, vcc_lo
-; GFX10-NEXT:    v_cmp_class_f32_e64 vcc_lo, v0, 64
-; GFX10-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc_lo
-; GFX10-NEXT:    v_cmp_class_f32_e64 vcc_lo, v1, 64
-; GFX10-NEXT:    v_cndmask_b32_e32 v0, v0, v1, vcc_lo
-; GFX10-NEXT:    v_cmp_eq_f32_e32 vcc_lo, 0, v2
-; GFX10-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc_lo
+; GFX10-NEXT:    v_cndmask_b32_e32 v0, 0x7fc00000, v2, vcc_lo
 ; GFX10-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX11-LABEL: v_maximum_f32:
@@ -91,15 +58,8 @@ define float @v_maximum_f32(float %src0, float %src1) {
 ; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX11-NEXT:    v_max_f32_e32 v2, v0, v1
 ; GFX11-NEXT:    v_cmp_o_f32_e32 vcc_lo, v0, v1
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(SKIP_1) | instid1(VALU_DEP_2)
-; GFX11-NEXT:    v_cndmask_b32_e32 v2, 0x7fc00000, v2, vcc_lo
-; GFX11-NEXT:    v_cmp_class_f32_e64 vcc_lo, v0, 64
-; GFX11-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc_lo
-; GFX11-NEXT:    v_cmp_class_f32_e64 vcc_lo, v1, 64
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(SKIP_1) | instid1(VALU_DEP_2)
-; GFX11-NEXT:    v_cndmask_b32_e32 v0, v0, v1, vcc_lo
-; GFX11-NEXT:    v_cmp_eq_f32_e32 vcc_lo, 0, v2
-; GFX11-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc_lo
+; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_2)
+; GFX11-NEXT:    v_cndmask_b32_e32 v0, 0x7fc00000, v2, vcc_lo
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX12-LABEL: v_maximum_f32:
@@ -119,78 +79,37 @@ define float @v_maximum_f32__nnan(float %src0, float %src1) {
 ; GFX7-LABEL: v_maximum_f32__nnan:
 ; GFX7:       ; %bb.0:
 ; GFX7-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX7-NEXT:    v_max_f32_e32 v2, v0, v1
-; GFX7-NEXT:    v_cmp_class_f32_e64 vcc, v0, 64
-; GFX7-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc
-; GFX7-NEXT:    v_cmp_class_f32_e64 vcc, v1, 64
-; GFX7-NEXT:    v_cndmask_b32_e32 v0, v0, v1, vcc
-; GFX7-NEXT:    v_cmp_eq_f32_e32 vcc, 0, v2
-; GFX7-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc
+; GFX7-NEXT:    v_max_f32_e32 v0, v0, v1
 ; GFX7-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX8-LABEL: v_maximum_f32__nnan:
 ; GFX8:       ; %bb.0:
 ; GFX8-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX8-NEXT:    v_max_f32_e32 v2, v0, v1
-; GFX8-NEXT:    v_cmp_class_f32_e64 vcc, v0, 64
-; GFX8-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc
-; GFX8-NEXT:    v_cmp_class_f32_e64 vcc, v1, 64
-; GFX8-NEXT:    v_cndmask_b32_e32 v0, v0, v1, vcc
-; GFX8-NEXT:    v_cmp_eq_f32_e32 vcc, 0, v2
-; GFX8-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc
+; GFX8-NEXT:    v_max_f32_e32 v0, v0, v1
 ; GFX8-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX9-LABEL: v_maximum_f32__nnan:
 ; GFX9:       ; %bb.0:
 ; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX9-NEXT:    v_max_f32_e32 v2, v0, v1
-; GFX9-NEXT:    v_cmp_class_f32_e64 vcc, v0, 64
-; GFX9-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc
-; GFX9-NEXT:    v_cmp_class_f32_e64 vcc, v1, 64
-; GFX9-NEXT:    v_cndmask_b32_e32 v0, v0, v1, vcc
-; GFX9-NEXT:    v_cmp_eq_f32_e32 vcc, 0, v2
-; GFX9-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc
+; GFX9-NEXT:    v_max_f32_e32 v0, v0, v1
 ; GFX9-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX940-LABEL: v_maximum_f32__nnan:
 ; GFX940:       ; %bb.0:
 ; GFX940-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX940-NEXT:    v_max_f32_e32 v2, v0, v1
-; GFX940-NEXT:    v_cmp_class_f32_e64 vcc, v0, 64
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc
-; GFX940-NEXT:    v_cmp_class_f32_e64 vcc, v1, 64
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v0, v0, v1, vcc
-; GFX940-NEXT:    v_cmp_eq_f32_e32 vcc, 0, v2
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc
+; GFX940-NEXT:    v_max_f32_e32 v0, v0, v1
 ; GFX940-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX10-LABEL: v_maximum_f32__nnan:
 ; GFX10:       ; %bb.0:
 ; GFX10-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX10-NEXT:    v_max_f32_e32 v2, v0, v1
-; GFX10-NEXT:    v_cmp_class_f32_e64 vcc_lo, v0, 64
-; GFX10-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc_lo
-; GFX10-NEXT:    v_cmp_class_f32_e64 vcc_lo, v1, 64
-; GFX10-NEXT:    v_cndmask_b32_e32 v0, v0, v1, vcc_lo
-; GFX10-NEXT:    v_cmp_eq_f32_e32 vcc_lo, 0, v2
-; GFX10-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc_lo
+; GFX10-NEXT:    v_max_f32_e32 v0, v0, v1
 ; GFX10-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX11-LABEL: v_maximum_f32__nnan:
 ; GFX11:       ; %bb.0:
 ; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX11-NEXT:    v_max_f32_e32 v2, v0, v1
-; GFX11-NEXT:    v_cmp_class_f32_e64 vcc_lo, v0, 64
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(SKIP_1) | instid1(VALU_DEP_2)
-; GFX11-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc_lo
-; GFX11-NEXT:    v_cmp_class_f32_e64 vcc_lo, v1, 64
-; GFX11-NEXT:    v_cndmask_b32_e32 v0, v0, v1, vcc_lo
-; GFX11-NEXT:    v_cmp_eq_f32_e32 vcc_lo, 0, v2
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_2)
-; GFX11-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc_lo
+; GFX11-NEXT:    v_max_f32_e32 v0, v0, v1
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX12-LABEL: v_maximum_f32__nnan:
@@ -332,13 +251,7 @@ define float @v_maximum_f32__nnan_src0(float %arg0, float %src1) {
 ; GFX7-NEXT:    v_max_f32_e32 v2, v0, v1
 ; GFX7-NEXT:    v_mov_b32_e32 v3, 0x7fc00000
 ; GFX7-NEXT:    v_cmp_o_f32_e32 vcc, v0, v1
-; GFX7-NEXT:    v_cndmask_b32_e32 v2, v3, v2, vcc
-; GFX7-NEXT:    v_cmp_class_f32_e64 vcc, v0, 64
-; GFX7-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc
-; GFX7-NEXT:    v_cmp_class_f32_e64 vcc, v1, 64
-; GFX7-NEXT:    v_cndmask_b32_e32 v0, v0, v1, vcc
-; GFX7-NEXT:    v_cmp_eq_f32_e32 vcc, 0, v2
-; GFX7-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc
+; GFX7-NEXT:    v_cndmask_b32_e32 v0, v3, v2, vcc
 ; GFX7-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX8-LABEL: v_maximum_f32__nnan_src0:
@@ -348,13 +261,7 @@ define float @v_maximum_f32__nnan_src0(float %arg0, float %src1) {
 ; GFX8-NEXT:    v_max_f32_e32 v2, v0, v1
 ; GFX8-NEXT:    v_mov_b32_e32 v3, 0x7fc00000
 ; GFX8-NEXT:    v_cmp_o_f32_e32 vcc, v0, v1
-; GFX8-NEXT:    v_cndmask_b32_e32 v2, v3, v2, vcc
-; GFX8-NEXT:    v_cmp_class_f32_e64 vcc, v0, 64
-; GFX8-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc
-; GFX8-NEXT:    v_cmp_class_f32_e64 vcc, v1, 64
-; GFX8-NEXT:    v_cndmask_b32_e32 v0, v0, v1, vcc
-; GFX8-NEXT:    v_cmp_eq_f32_e32 vcc, 0, v2
-; GFX8-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc
+; GFX8-NEXT:    v_cndmask_b32_e32 v0, v3, v2, vcc
 ; GFX8-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX9-LABEL: v_maximum_f32__nnan_src0:
@@ -364,13 +271,7 @@ define float @v_maximum_f32__nnan_src0(float %arg0, float %src1) {
 ; GFX9-NEXT:    v_max_f32_e32 v2, v0, v1
 ; GFX9-NEXT:    v_mov_b32_e32 v3, 0x7fc00000
 ; GFX9-NEXT:    v_cmp_o_f32_e32 vcc, v0, v1
-; GFX9-NEXT:    v_cndmask_b32_e32 v2, v3, v2, vcc
-; GFX9-NEXT:    v_cmp_class_f32_e64 vcc, v0, 64
-; GFX9-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc
-; GFX9-NEXT:    v_cmp_class_f32_e64 vcc, v1, 64
-; GFX9-NEXT:    v_cndmask_b32_e32 v0, v0, v1, vcc
-; GFX9-NEXT:    v_cmp_eq_f32_e32 vcc, 0, v2
-; GFX9-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v0, v3, v2, vcc
 ; GFX9-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX940-LABEL: v_maximum_f32__nnan_src0:
@@ -381,16 +282,7 @@ define float @v_maximum_f32__nnan_src0(float %arg0, float %src1) {
 ; GFX940-NEXT:    v_mov_b32_e32 v3, 0x7fc00000
 ; GFX940-NEXT:    v_cmp_o_f32_e32 vcc, v0, v1
 ; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v2, v3, v2, vcc
-; GFX940-NEXT:    v_cmp_class_f32_e64 vcc, v0, 64
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc
-; GFX940-NEXT:    v_cmp_class_f32_e64 vcc, v1, 64
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v0, v0, v1, vcc
-; GFX940-NEXT:    v_cmp_eq_f32_e32 vcc, 0, v2
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc
+; GFX940-NEXT:    v_cndmask_b32_e32 v0, v3, v2, vcc
 ; GFX940-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX10-LABEL: v_maximum_f32__nnan_src0:
@@ -399,13 +291,7 @@ define float @v_maximum_f32__nnan_src0(float %arg0, float %src1) {
 ; GFX10-NEXT:    v_add_f32_e32 v0, 1.0, v0
 ; GFX10-NEXT:    v_max_f32_e32 v2, v0, v1
 ; GFX10-NEXT:    v_cmp_o_f32_e32 vcc_lo, v0, v1
-; GFX10-NEXT:    v_cndmask_b32_e32 v2, 0x7fc00000, v2, vcc_lo
-; GFX10-NEXT:    v_cmp_class_f32_e64 vcc_lo, v0, 64
-; GFX10-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc_lo
-; GFX10-NEXT:    v_cmp_class_f32_e64 vcc_lo, v1, 64
-; GFX10-NEXT:    v_cndmask_b32_e32 v0, v0, v1, vcc_lo
-; GFX10-NEXT:    v_cmp_eq_f32_e32 vcc_lo, 0, v2
-; GFX10-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc_lo
+; GFX10-NEXT:    v_cndmask_b32_e32 v0, 0x7fc00000, v2, vcc_lo
 ; GFX10-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX11-LABEL: v_maximum_f32__nnan_src0:
@@ -415,15 +301,7 @@ define float @v_maximum_f32__nnan_src0(float %arg0, float %src1) {
 ; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_1) | instid1(VALU_DEP_2)
 ; GFX11-NEXT:    v_max_f32_e32 v2, v0, v1
 ; GFX11-NEXT:    v_cmp_o_f32_e32 vcc_lo, v0, v1
-; GFX11-NEXT:    v_cndmask_b32_e32 v2, 0x7fc00000, v2, vcc_lo
-; GFX11-NEXT:    v_cmp_class_f32_e64 vcc_lo, v0, 64
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(SKIP_1) | instid1(VALU_DEP_2)
-; GFX11-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc_lo
-; GFX11-NEXT:    v_cmp_class_f32_e64 vcc_lo, v1, 64
-; GFX11-NEXT:    v_cndmask_b32_e32 v0, v0, v1, vcc_lo
-; GFX11-NEXT:    v_cmp_eq_f32_e32 vcc_lo, 0, v2
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_2)
-; GFX11-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc_lo
+; GFX11-NEXT:    v_cndmask_b32_e32 v0, 0x7fc00000, v2, vcc_lo
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX12-LABEL: v_maximum_f32__nnan_src0:
@@ -450,13 +328,7 @@ define float @v_maximum_f32__nnan_src1(float %src0, float %arg1) {
 ; GFX7-NEXT:    v_max_f32_e32 v2, v0, v1
 ; GFX7-NEXT:    v_mov_b32_e32 v3, 0x7fc00000
 ; GFX7-NEXT:    v_cmp_o_f32_e32 vcc, v0, v1
-; GFX7-NEXT:    v_cndmask_b32_e32 v2, v3, v2, vcc
-; GFX7-NEXT:    v_cmp_class_f32_e64 vcc, v0, 64
-; GFX7-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc
-; GFX7-NEXT:    v_cmp_class_f32_e64 vcc, v1, 64
-; GFX7-NEXT:    v_cndmask_b32_e32 v0, v0, v1, vcc
-; GFX7-NEXT:    v_cmp_eq_f32_e32 vcc, 0, v2
-; GFX7-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc
+; GFX7-NEXT:    v_cndmask_b32_e32 v0, v3, v2, vcc
 ; GFX7-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX8-LABEL: v_maximum_f32__nnan_src1:
@@ -466,13 +338,7 @@ define float @v_maximum_f32__nnan_src1(float %src0, float %arg1) {
 ; GFX8-NEXT:    v_max_f32_e32 v2, v0, v1
 ; GFX8-NEXT:    v_mov_b32_e32 v3, 0x7fc00000
 ; GFX8-NEXT:    v_cmp_o_f32_e32 vcc, v0, v1
-; GFX8-NEXT:    v_cndmask_b32_e32 v2, v3, v2, vcc
-; GFX8-NEXT:    v_cmp_class_f32_e64 vcc, v0, 64
-; GFX8-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc
-; GFX8-NEXT:    v_cmp_class_f32_e64 vcc, v1, 64
-; GFX8-NEXT:    v_cndmask_b32_e32 v0, v0, v1, vcc
-; GFX8-NEXT:    v_cmp_eq_f32_e32 vcc, 0, v2
-; GFX8-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc
+; GFX8-NEXT:    v_cndmask_b32_e32 v0, v3, v2, vcc
 ; GFX8-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX9-LABEL: v_maximum_f32__nnan_src1:
@@ -482,13 +348,7 @@ define float @v_maximum_f32__nnan_src1(float %src0, float %arg1) {
 ; GFX9-NEXT:    v_max_f32_e32 v2, v0, v1
 ; GFX9-NEXT:    v_mov_b32_e32 v3, 0x7fc00000
 ; GFX9-NEXT:    v_cmp_o_f32_e32 vcc, v0, v1
-; GFX9-NEXT:    v_cndmask_b32_e32 v2, v3, v2, vcc
-; GFX9-NEXT:    v_cmp_class_f32_e64 vcc, v0, 64
-; GFX9-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc
-; GFX9-NEXT:    v_cmp_class_f32_e64 vcc, v1, 64
-; GFX9-NEXT:    v_cndmask_b32_e32 v0, v0, v1, vcc
-; GFX9-NEXT:    v_cmp_eq_f32_e32 vcc, 0, v2
-; GFX9-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v0, v3, v2, vcc
 ; GFX9-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX940-LABEL: v_maximum_f32__nnan_src1:
@@ -499,16 +359,7 @@ define float @v_maximum_f32__nnan_src1(float %src0, float %arg1) {
 ; GFX940-NEXT:    v_mov_b32_e32 v3, 0x7fc00000
 ; GFX940-NEXT:    v_cmp_o_f32_e32 vcc, v0, v1
 ; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v2, v3, v2, vcc
-; GFX940-NEXT:    v_cmp_class_f32_e64 vcc, v0, 64
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc
-; GFX940-NEXT:    v_cmp_class_f32_e64 vcc, v1, 64
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v0, v0, v1, vcc
-; GFX940-NEXT:    v_cmp_eq_f32_e32 vcc, 0, v2
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc
+; GFX940-NEXT:    v_cndmask_b32_e32 v0, v3, v2, vcc
 ; GFX940-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX10-LABEL: v_maximum_f32__nnan_src1:
@@ -517,13 +368,7 @@ define float @v_maximum_f32__nnan_src1(float %src0, float %arg1) {
 ; GFX10-NEXT:    v_add_f32_e32 v1, 1.0, v1
 ; GFX10-NEXT:    v_max_f32_e32 v2, v0, v1
 ; GFX10-NEXT:    v_cmp_o_f32_e32 vcc_lo, v0, v1
-; GFX10-NEXT:    v_cndmask_b32_e32 v2, 0x7fc00000, v2, vcc_lo
-; GFX10-NEXT:    v_cmp_class_f32_e64 vcc_lo, v0, 64
-; GFX10-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc_lo
-; GFX10-NEXT:    v_cmp_class_f32_e64 vcc_lo, v1, 64
-; GFX10-NEXT:    v_cndmask_b32_e32 v0, v0, v1, vcc_lo
-; GFX10-NEXT:    v_cmp_eq_f32_e32 vcc_lo, 0, v2
-; GFX10-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc_lo
+; GFX10-NEXT:    v_cndmask_b32_e32 v0, 0x7fc00000, v2, vcc_lo
 ; GFX10-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX11-LABEL: v_maximum_f32__nnan_src1:
@@ -533,15 +378,7 @@ define float @v_maximum_f32__nnan_src1(float %src0, float %arg1) {
 ; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_1) | instid1(VALU_DEP_2)
 ; GFX11-NEXT:    v_max_f32_e32 v2, v0, v1
 ; GFX11-NEXT:    v_cmp_o_f32_e32 vcc_lo, v0, v1
-; GFX11-NEXT:    v_cndmask_b32_e32 v2, 0x7fc00000, v2, vcc_lo
-; GFX11-NEXT:    v_cmp_class_f32_e64 vcc_lo, v0, 64
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(SKIP_1) | instid1(VALU_DEP_2)
-; GFX11-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc_lo
-; GFX11-NEXT:    v_cmp_class_f32_e64 vcc_lo, v1, 64
-; GFX11-NEXT:    v_cndmask_b32_e32 v0, v0, v1, vcc_lo
-; GFX11-NEXT:    v_cmp_eq_f32_e32 vcc_lo, 0, v2
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_2)
-; GFX11-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc_lo
+; GFX11-NEXT:    v_cndmask_b32_e32 v0, 0x7fc00000, v2, vcc_lo
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX12-LABEL: v_maximum_f32__nnan_src1:
@@ -568,14 +405,7 @@ define void @s_maximum_f32(float inreg %src0, float inreg %src1) {
 ; GFX7-NEXT:    v_max_f32_e32 v1, s4, v0
 ; GFX7-NEXT:    v_mov_b32_e32 v2, 0x7fc00000
 ; GFX7-NEXT:    v_cmp_o_f32_e32 vcc, s4, v0
-; GFX7-NEXT:    v_cndmask_b32_e32 v1, v2, v1, vcc
-; GFX7-NEXT:    v_mov_b32_e32 v2, s4
-; GFX7-NEXT:    v_cmp_class_f32_e64 vcc, s4, 64
-; GFX7-NEXT:    v_cndmask_b32_e32 v2, v1, v2, vcc
-; GFX7-NEXT:    v_cmp_class_f32_e64 vcc, s5, 64
-; GFX7-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc
-; GFX7-NEXT:    v_cmp_eq_f32_e32 vcc, 0, v1
-; GFX7-NEXT:    v_cndmask_b32_e32 v0, v1, v0, vcc
+; GFX7-NEXT:    v_cndmask_b32_e32 v0, v2, v1, vcc
 ; GFX7-NEXT:    ;;#ASMSTART
 ; GFX7-NEXT:    ; use v0
 ; GFX7-NEXT:    ;;#ASMEND
@@ -588,14 +418,7 @@ define void @s_maximum_f32(float inreg %src0, float inreg %src1) {
 ; GFX8-NEXT:    v_max_f32_e32 v1, s4, v0
 ; GFX8-NEXT:    v_mov_b32_e32 v2, 0x7fc00000
 ; GFX8-NEXT:    v_cmp_o_f32_e32 vcc, s4, v0
-; GFX8-NEXT:    v_cndmask_b32_e32 v1, v2, v1, vcc
-; GFX8-NEXT:    v_mov_b32_e32 v2, s4
-; GFX8-NEXT:    v_cmp_class_f32_e64 vcc, s4, 64
-; GFX8-NEXT:    v_cndmask_b32_e32 v2, v1, v2, vcc
-; GFX8-NEXT:    v_cmp_class_f32_e64 vcc, s5, 64
-; GFX8-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc
-; GFX8-NEXT:    v_cmp_eq_f32_e32 vcc, 0, v1
-; GFX8-NEXT:    v_cndmask_b32_e32 v0, v1, v0, vcc
+; GFX8-NEXT:    v_cndmask_b32_e32 v0, v2, v1, vcc
 ; GFX8-NEXT:    ;;#ASMSTART
 ; GFX8-NEXT:    ; use v0
 ; GFX8-NEXT:    ;;#ASMEND
@@ -608,14 +431,7 @@ define void @s_maximum_f32(float inreg %src0, float inreg %src1) {
 ; GFX9-NEXT:    v_max_f32_e32 v1, s4, v0
 ; GFX9-NEXT:    v_mov_b32_e32 v2, 0x7fc00000
 ; GFX9-NEXT:    v_cmp_o_f32_e32 vcc, s4, v0
-; GFX9-NEXT:    v_cndmask_b32_e32 v1, v2, v1, vcc
-; GFX9-NEXT:    v_mov_b32_e32 v2, s4
-; GFX9-NEXT:    v_cmp_class_f32_e64 vcc, s4, 64
-; GFX9-NEXT:    v_cndmask_b32_e32 v2, v1, v2, vcc
-; GFX9-NEXT:    v_cmp_class_f32_e64 vcc, s5, 64
-; GFX9-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc
-; GFX9-NEXT:    v_cmp_eq_f32_e32 vcc, 0, v1
-; GFX9-NEXT:    v_cndmask_b32_e32 v0, v1, v0, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v0, v2, v1, vcc
 ; GFX9-NEXT:    ;;#ASMSTART
 ; GFX9-NEXT:    ; use v0
 ; GFX9-NEXT:    ;;#ASMEND
@@ -629,17 +445,7 @@ define void @s_maximum_f32(float inreg %src0, float inreg %src1) {
 ; GFX940-NEXT:    v_mov_b32_e32 v2, 0x7fc00000
 ; GFX940-NEXT:    v_cmp_o_f32_e32 vcc, s0, v0
 ; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v1, v2, v1, vcc
-; GFX940-NEXT:    v_mov_b32_e32 v2, s0
-; GFX940-NEXT:    v_cmp_class_f32_e64 vcc, s0, 64
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v2, v1, v2, vcc
-; GFX940-NEXT:    v_cmp_class_f32_e64 vcc, s1, 64
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc
-; GFX940-NEXT:    v_cmp_eq_f32_e32 vcc, 0, v1
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v0, v1, v0, vcc
+; GFX940-NEXT:    v_cndmask_b32_e32 v0, v2, v1, vcc
 ; GFX940-NEXT:    ;;#ASMSTART
 ; GFX940-NEXT:    ; use v0
 ; GFX940-NEXT:    ;;#ASMEND
@@ -650,13 +456,7 @@ define void @s_maximum_f32(float inreg %src0, float inreg %src1) {
 ; GFX10-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX10-NEXT:    v_max_f32_e64 v0, s4, s5
 ; GFX10-NEXT:    v_cmp_o_f32_e64 vcc_lo, s4, s5
-; GFX10-NEXT:    v_cmp_class_f32_e64 s6, s4, 64
 ; GFX10-NEXT:    v_cndmask_b32_e32 v0, 0x7fc00000, v0, vcc_lo
-; GFX10-NEXT:    v_cndmask_b32_e64 v1, v0, s4, s6
-; GFX10-NEXT:    v_cmp_class_f32_e64 s4, s5, 64
-; GFX10-NEXT:    v_cmp_eq_f32_e32 vcc_lo, 0, v0
-; GFX10-NEXT:    v_cndmask_b32_e64 v1, v1, s5, s4
-; GFX10-NEXT:    v_cndmask_b32_e32 v0, v0, v1, vcc_lo
 ; GFX10-NEXT:    ;;#ASMSTART
 ; GFX10-NEXT:    ; use v0
 ; GFX10-NEXT:    ;;#ASMEND
@@ -667,15 +467,8 @@ define void @s_maximum_f32(float inreg %src0, float inreg %src1) {
 ; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX11-NEXT:    v_max_f32_e64 v0, s0, s1
 ; GFX11-NEXT:    v_cmp_o_f32_e64 vcc_lo, s0, s1
-; GFX11-NEXT:    v_cmp_class_f32_e64 s2, s0, 64
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_2)
 ; GFX11-NEXT:    v_cndmask_b32_e32 v0, 0x7fc00000, v0, vcc_lo
-; GFX11-NEXT:    v_cndmask_b32_e64 v1, v0, s0, s2
-; GFX11-NEXT:    v_cmp_class_f32_e64 s0, s1, 64
-; GFX11-NEXT:    v_cmp_eq_f32_e32 vcc_lo, 0, v0
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_1)
-; GFX11-NEXT:    v_cndmask_b32_e64 v1, v1, s1, s0
-; GFX11-NEXT:    v_cndmask_b32_e32 v0, v0, v1, vcc_lo
 ; GFX11-NEXT:    ;;#ASMSTART
 ; GFX11-NEXT:    ; use v0
 ; GFX11-NEXT:    ;;#ASMEND

--- a/llvm/test/CodeGen/AMDGPU/llvm.maximum.f64.ll
+++ b/llvm/test/CodeGen/AMDGPU/llvm.maximum.f64.ll
@@ -13,18 +13,9 @@ define double @v_maximum_f64(double %src0, double %src1) {
 ; GFX7-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX7-NEXT:    v_max_f64 v[4:5], v[0:1], v[2:3]
 ; GFX7-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[2:3]
-; GFX7-NEXT:    v_mov_b32_e32 v6, 0x7ff80000
-; GFX7-NEXT:    v_cmp_class_f64_e64 s[4:5], v[2:3], 64
-; GFX7-NEXT:    v_cndmask_b32_e32 v5, v5, v6, vcc
-; GFX7-NEXT:    v_cndmask_b32_e64 v4, v4, 0, vcc
-; GFX7-NEXT:    v_cmp_class_f64_e64 vcc, v[0:1], 64
-; GFX7-NEXT:    v_cmp_eq_f64_e64 s[6:7], 0, v[4:5]
-; GFX7-NEXT:    v_cndmask_b32_e32 v0, v4, v0, vcc
+; GFX7-NEXT:    v_mov_b32_e32 v1, 0x7ff80000
+; GFX7-NEXT:    v_cndmask_b32_e64 v0, v4, 0, vcc
 ; GFX7-NEXT:    v_cndmask_b32_e32 v1, v5, v1, vcc
-; GFX7-NEXT:    v_cndmask_b32_e64 v0, v0, v2, s[4:5]
-; GFX7-NEXT:    v_cndmask_b32_e64 v1, v1, v3, s[4:5]
-; GFX7-NEXT:    v_cndmask_b32_e64 v0, v4, v0, s[6:7]
-; GFX7-NEXT:    v_cndmask_b32_e64 v1, v5, v1, s[6:7]
 ; GFX7-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX8-LABEL: v_maximum_f64:
@@ -32,18 +23,9 @@ define double @v_maximum_f64(double %src0, double %src1) {
 ; GFX8-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX8-NEXT:    v_max_f64 v[4:5], v[0:1], v[2:3]
 ; GFX8-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[2:3]
-; GFX8-NEXT:    v_mov_b32_e32 v6, 0x7ff80000
-; GFX8-NEXT:    v_cmp_class_f64_e64 s[4:5], v[2:3], 64
-; GFX8-NEXT:    v_cndmask_b32_e32 v5, v5, v6, vcc
-; GFX8-NEXT:    v_cndmask_b32_e64 v4, v4, 0, vcc
-; GFX8-NEXT:    v_cmp_class_f64_e64 vcc, v[0:1], 64
-; GFX8-NEXT:    v_cmp_eq_f64_e64 s[6:7], 0, v[4:5]
-; GFX8-NEXT:    v_cndmask_b32_e32 v0, v4, v0, vcc
+; GFX8-NEXT:    v_mov_b32_e32 v1, 0x7ff80000
+; GFX8-NEXT:    v_cndmask_b32_e64 v0, v4, 0, vcc
 ; GFX8-NEXT:    v_cndmask_b32_e32 v1, v5, v1, vcc
-; GFX8-NEXT:    v_cndmask_b32_e64 v0, v0, v2, s[4:5]
-; GFX8-NEXT:    v_cndmask_b32_e64 v1, v1, v3, s[4:5]
-; GFX8-NEXT:    v_cndmask_b32_e64 v0, v4, v0, s[6:7]
-; GFX8-NEXT:    v_cndmask_b32_e64 v1, v5, v1, s[6:7]
 ; GFX8-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX9-LABEL: v_maximum_f64:
@@ -51,39 +33,20 @@ define double @v_maximum_f64(double %src0, double %src1) {
 ; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX9-NEXT:    v_max_f64 v[4:5], v[0:1], v[2:3]
 ; GFX9-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[2:3]
-; GFX9-NEXT:    v_mov_b32_e32 v6, 0x7ff80000
-; GFX9-NEXT:    v_cmp_class_f64_e64 s[4:5], v[2:3], 64
-; GFX9-NEXT:    v_cndmask_b32_e32 v5, v5, v6, vcc
-; GFX9-NEXT:    v_cndmask_b32_e64 v4, v4, 0, vcc
-; GFX9-NEXT:    v_cmp_class_f64_e64 vcc, v[0:1], 64
-; GFX9-NEXT:    v_cmp_eq_f64_e64 s[6:7], 0, v[4:5]
-; GFX9-NEXT:    v_cndmask_b32_e32 v0, v4, v0, vcc
+; GFX9-NEXT:    v_mov_b32_e32 v1, 0x7ff80000
+; GFX9-NEXT:    v_cndmask_b32_e64 v0, v4, 0, vcc
 ; GFX9-NEXT:    v_cndmask_b32_e32 v1, v5, v1, vcc
-; GFX9-NEXT:    v_cndmask_b32_e64 v0, v0, v2, s[4:5]
-; GFX9-NEXT:    v_cndmask_b32_e64 v1, v1, v3, s[4:5]
-; GFX9-NEXT:    v_cndmask_b32_e64 v0, v4, v0, s[6:7]
-; GFX9-NEXT:    v_cndmask_b32_e64 v1, v5, v1, s[6:7]
 ; GFX9-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX940-LABEL: v_maximum_f64:
 ; GFX940:       ; %bb.0:
 ; GFX940-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX940-NEXT:    v_max_f64 v[4:5], v[0:1], v[2:3]
-; GFX940-NEXT:    v_mov_b32_e32 v6, 0x7ff80000
 ; GFX940-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[2:3]
-; GFX940-NEXT:    v_cmp_class_f64_e64 s[0:1], v[2:3], 64
+; GFX940-NEXT:    v_mov_b32_e32 v1, 0x7ff80000
 ; GFX940-NEXT:    s_nop 0
-; GFX940-NEXT:    v_cndmask_b32_e32 v5, v5, v6, vcc
-; GFX940-NEXT:    v_cndmask_b32_e64 v4, v4, 0, vcc
-; GFX940-NEXT:    v_cmp_class_f64_e64 vcc, v[0:1], 64
-; GFX940-NEXT:    v_cmp_eq_f64_e64 s[2:3], 0, v[4:5]
-; GFX940-NEXT:    s_nop 0
-; GFX940-NEXT:    v_cndmask_b32_e32 v0, v4, v0, vcc
+; GFX940-NEXT:    v_cndmask_b32_e64 v0, v4, 0, vcc
 ; GFX940-NEXT:    v_cndmask_b32_e32 v1, v5, v1, vcc
-; GFX940-NEXT:    v_cndmask_b32_e64 v0, v0, v2, s[0:1]
-; GFX940-NEXT:    v_cndmask_b32_e64 v1, v1, v3, s[0:1]
-; GFX940-NEXT:    v_cndmask_b32_e64 v0, v4, v0, s[2:3]
-; GFX940-NEXT:    v_cndmask_b32_e64 v1, v5, v1, s[2:3]
 ; GFX940-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX10-LABEL: v_maximum_f64:
@@ -91,17 +54,8 @@ define double @v_maximum_f64(double %src0, double %src1) {
 ; GFX10-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX10-NEXT:    v_max_f64 v[4:5], v[0:1], v[2:3]
 ; GFX10-NEXT:    v_cmp_u_f64_e32 vcc_lo, v[0:1], v[2:3]
-; GFX10-NEXT:    v_cmp_class_f64_e64 s4, v[2:3], 64
-; GFX10-NEXT:    v_cndmask_b32_e64 v5, v5, 0x7ff80000, vcc_lo
-; GFX10-NEXT:    v_cndmask_b32_e64 v4, v4, 0, vcc_lo
-; GFX10-NEXT:    v_cmp_class_f64_e64 vcc_lo, v[0:1], 64
-; GFX10-NEXT:    v_cmp_eq_f64_e64 s5, 0, v[4:5]
-; GFX10-NEXT:    v_cndmask_b32_e32 v0, v4, v0, vcc_lo
-; GFX10-NEXT:    v_cndmask_b32_e32 v1, v5, v1, vcc_lo
-; GFX10-NEXT:    v_cndmask_b32_e64 v0, v0, v2, s4
-; GFX10-NEXT:    v_cndmask_b32_e64 v1, v1, v3, s4
-; GFX10-NEXT:    v_cndmask_b32_e64 v0, v4, v0, s5
-; GFX10-NEXT:    v_cndmask_b32_e64 v1, v5, v1, s5
+; GFX10-NEXT:    v_cndmask_b32_e64 v0, v4, 0, vcc_lo
+; GFX10-NEXT:    v_cndmask_b32_e64 v1, v5, 0x7ff80000, vcc_lo
 ; GFX10-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX11-LABEL: v_maximum_f64:
@@ -109,20 +63,9 @@ define double @v_maximum_f64(double %src0, double %src1) {
 ; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX11-NEXT:    v_max_f64 v[4:5], v[0:1], v[2:3]
 ; GFX11-NEXT:    v_cmp_u_f64_e32 vcc_lo, v[0:1], v[2:3]
-; GFX11-NEXT:    v_cmp_class_f64_e64 s0, v[2:3], 64
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_4)
-; GFX11-NEXT:    v_cndmask_b32_e64 v5, v5, 0x7ff80000, vcc_lo
-; GFX11-NEXT:    v_cndmask_b32_e64 v4, v4, 0, vcc_lo
-; GFX11-NEXT:    v_cmp_class_f64_e64 vcc_lo, v[0:1], 64
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(SKIP_1) | instid1(VALU_DEP_1)
-; GFX11-NEXT:    v_cmp_eq_f64_e64 s1, 0, v[4:5]
-; GFX11-NEXT:    v_dual_cndmask_b32 v0, v4, v0 :: v_dual_cndmask_b32 v1, v5, v1
-; GFX11-NEXT:    v_cndmask_b32_e64 v0, v0, v2, s0
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_2)
-; GFX11-NEXT:    v_cndmask_b32_e64 v1, v1, v3, s0
-; GFX11-NEXT:    v_cndmask_b32_e64 v0, v4, v0, s1
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_2)
-; GFX11-NEXT:    v_cndmask_b32_e64 v1, v5, v1, s1
+; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_3)
+; GFX11-NEXT:    v_cndmask_b32_e64 v0, v4, 0, vcc_lo
+; GFX11-NEXT:    v_cndmask_b32_e64 v1, v5, 0x7ff80000, vcc_lo
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX12-LABEL: v_maximum_f64:
@@ -142,93 +85,37 @@ define double @v_maximum_f64__nnan(double %src0, double %src1) {
 ; GFX7-LABEL: v_maximum_f64__nnan:
 ; GFX7:       ; %bb.0:
 ; GFX7-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX7-NEXT:    v_max_f64 v[4:5], v[0:1], v[2:3]
-; GFX7-NEXT:    v_cmp_class_f64_e64 vcc, v[0:1], 64
-; GFX7-NEXT:    v_cmp_class_f64_e64 s[4:5], v[2:3], 64
-; GFX7-NEXT:    v_cmp_eq_f64_e64 s[6:7], 0, v[4:5]
-; GFX7-NEXT:    v_cndmask_b32_e32 v0, v4, v0, vcc
-; GFX7-NEXT:    v_cndmask_b32_e32 v1, v5, v1, vcc
-; GFX7-NEXT:    v_cndmask_b32_e64 v0, v0, v2, s[4:5]
-; GFX7-NEXT:    v_cndmask_b32_e64 v1, v1, v3, s[4:5]
-; GFX7-NEXT:    v_cndmask_b32_e64 v0, v4, v0, s[6:7]
-; GFX7-NEXT:    v_cndmask_b32_e64 v1, v5, v1, s[6:7]
+; GFX7-NEXT:    v_max_f64 v[0:1], v[0:1], v[2:3]
 ; GFX7-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX8-LABEL: v_maximum_f64__nnan:
 ; GFX8:       ; %bb.0:
 ; GFX8-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX8-NEXT:    v_max_f64 v[4:5], v[0:1], v[2:3]
-; GFX8-NEXT:    v_cmp_class_f64_e64 vcc, v[0:1], 64
-; GFX8-NEXT:    v_cmp_class_f64_e64 s[4:5], v[2:3], 64
-; GFX8-NEXT:    v_cmp_eq_f64_e64 s[6:7], 0, v[4:5]
-; GFX8-NEXT:    v_cndmask_b32_e32 v0, v4, v0, vcc
-; GFX8-NEXT:    v_cndmask_b32_e32 v1, v5, v1, vcc
-; GFX8-NEXT:    v_cndmask_b32_e64 v0, v0, v2, s[4:5]
-; GFX8-NEXT:    v_cndmask_b32_e64 v1, v1, v3, s[4:5]
-; GFX8-NEXT:    v_cndmask_b32_e64 v0, v4, v0, s[6:7]
-; GFX8-NEXT:    v_cndmask_b32_e64 v1, v5, v1, s[6:7]
+; GFX8-NEXT:    v_max_f64 v[0:1], v[0:1], v[2:3]
 ; GFX8-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX9-LABEL: v_maximum_f64__nnan:
 ; GFX9:       ; %bb.0:
 ; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX9-NEXT:    v_max_f64 v[4:5], v[0:1], v[2:3]
-; GFX9-NEXT:    v_cmp_class_f64_e64 vcc, v[0:1], 64
-; GFX9-NEXT:    v_cmp_class_f64_e64 s[4:5], v[2:3], 64
-; GFX9-NEXT:    v_cmp_eq_f64_e64 s[6:7], 0, v[4:5]
-; GFX9-NEXT:    v_cndmask_b32_e32 v0, v4, v0, vcc
-; GFX9-NEXT:    v_cndmask_b32_e32 v1, v5, v1, vcc
-; GFX9-NEXT:    v_cndmask_b32_e64 v0, v0, v2, s[4:5]
-; GFX9-NEXT:    v_cndmask_b32_e64 v1, v1, v3, s[4:5]
-; GFX9-NEXT:    v_cndmask_b32_e64 v0, v4, v0, s[6:7]
-; GFX9-NEXT:    v_cndmask_b32_e64 v1, v5, v1, s[6:7]
+; GFX9-NEXT:    v_max_f64 v[0:1], v[0:1], v[2:3]
 ; GFX9-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX940-LABEL: v_maximum_f64__nnan:
 ; GFX940:       ; %bb.0:
 ; GFX940-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX940-NEXT:    v_max_f64 v[4:5], v[0:1], v[2:3]
-; GFX940-NEXT:    v_cmp_class_f64_e64 vcc, v[0:1], 64
-; GFX940-NEXT:    v_cmp_class_f64_e64 s[0:1], v[2:3], 64
-; GFX940-NEXT:    v_cmp_eq_f64_e64 s[2:3], 0, v[4:5]
-; GFX940-NEXT:    v_cndmask_b32_e32 v0, v4, v0, vcc
-; GFX940-NEXT:    v_cndmask_b32_e32 v1, v5, v1, vcc
-; GFX940-NEXT:    v_cndmask_b32_e64 v0, v0, v2, s[0:1]
-; GFX940-NEXT:    v_cndmask_b32_e64 v1, v1, v3, s[0:1]
-; GFX940-NEXT:    v_cndmask_b32_e64 v0, v4, v0, s[2:3]
-; GFX940-NEXT:    v_cndmask_b32_e64 v1, v5, v1, s[2:3]
+; GFX940-NEXT:    v_max_f64 v[0:1], v[0:1], v[2:3]
 ; GFX940-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX10-LABEL: v_maximum_f64__nnan:
 ; GFX10:       ; %bb.0:
 ; GFX10-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX10-NEXT:    v_max_f64 v[4:5], v[0:1], v[2:3]
-; GFX10-NEXT:    v_cmp_class_f64_e64 vcc_lo, v[0:1], 64
-; GFX10-NEXT:    v_cmp_class_f64_e64 s4, v[2:3], 64
-; GFX10-NEXT:    v_cmp_eq_f64_e64 s5, 0, v[4:5]
-; GFX10-NEXT:    v_cndmask_b32_e32 v0, v4, v0, vcc_lo
-; GFX10-NEXT:    v_cndmask_b32_e32 v1, v5, v1, vcc_lo
-; GFX10-NEXT:    v_cndmask_b32_e64 v0, v0, v2, s4
-; GFX10-NEXT:    v_cndmask_b32_e64 v1, v1, v3, s4
-; GFX10-NEXT:    v_cndmask_b32_e64 v0, v4, v0, s5
-; GFX10-NEXT:    v_cndmask_b32_e64 v1, v5, v1, s5
+; GFX10-NEXT:    v_max_f64 v[0:1], v[0:1], v[2:3]
 ; GFX10-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX11-LABEL: v_maximum_f64__nnan:
 ; GFX11:       ; %bb.0:
 ; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX11-NEXT:    v_max_f64 v[4:5], v[0:1], v[2:3]
-; GFX11-NEXT:    v_cmp_class_f64_e64 vcc_lo, v[0:1], 64
-; GFX11-NEXT:    v_cmp_class_f64_e64 s0, v[2:3], 64
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(SKIP_1) | instid1(VALU_DEP_1)
-; GFX11-NEXT:    v_cmp_eq_f64_e64 s1, 0, v[4:5]
-; GFX11-NEXT:    v_dual_cndmask_b32 v0, v4, v0 :: v_dual_cndmask_b32 v1, v5, v1
-; GFX11-NEXT:    v_cndmask_b32_e64 v0, v0, v2, s0
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_2)
-; GFX11-NEXT:    v_cndmask_b32_e64 v1, v1, v3, s0
-; GFX11-NEXT:    v_cndmask_b32_e64 v0, v4, v0, s1
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_2)
-; GFX11-NEXT:    v_cndmask_b32_e64 v1, v5, v1, s1
+; GFX11-NEXT:    v_max_f64 v[0:1], v[0:1], v[2:3]
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX12-LABEL: v_maximum_f64__nnan:
@@ -373,60 +260,33 @@ define double @v_maximum_f64__nnan_src0(double %arg0, double %src1) {
 ; GFX7:       ; %bb.0:
 ; GFX7-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX7-NEXT:    v_add_f64 v[0:1], v[0:1], 1.0
-; GFX7-NEXT:    v_mov_b32_e32 v6, 0x7ff80000
-; GFX7-NEXT:    v_cmp_class_f64_e64 s[4:5], v[2:3], 64
 ; GFX7-NEXT:    v_max_f64 v[4:5], v[0:1], v[2:3]
 ; GFX7-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[2:3]
-; GFX7-NEXT:    v_cndmask_b32_e32 v5, v5, v6, vcc
-; GFX7-NEXT:    v_cndmask_b32_e64 v4, v4, 0, vcc
-; GFX7-NEXT:    v_cmp_class_f64_e64 vcc, v[0:1], 64
-; GFX7-NEXT:    v_cmp_eq_f64_e64 s[6:7], 0, v[4:5]
-; GFX7-NEXT:    v_cndmask_b32_e32 v0, v4, v0, vcc
+; GFX7-NEXT:    v_mov_b32_e32 v1, 0x7ff80000
+; GFX7-NEXT:    v_cndmask_b32_e64 v0, v4, 0, vcc
 ; GFX7-NEXT:    v_cndmask_b32_e32 v1, v5, v1, vcc
-; GFX7-NEXT:    v_cndmask_b32_e64 v0, v0, v2, s[4:5]
-; GFX7-NEXT:    v_cndmask_b32_e64 v1, v1, v3, s[4:5]
-; GFX7-NEXT:    v_cndmask_b32_e64 v0, v4, v0, s[6:7]
-; GFX7-NEXT:    v_cndmask_b32_e64 v1, v5, v1, s[6:7]
 ; GFX7-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX8-LABEL: v_maximum_f64__nnan_src0:
 ; GFX8:       ; %bb.0:
 ; GFX8-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX8-NEXT:    v_add_f64 v[0:1], v[0:1], 1.0
-; GFX8-NEXT:    v_mov_b32_e32 v6, 0x7ff80000
-; GFX8-NEXT:    v_cmp_class_f64_e64 s[4:5], v[2:3], 64
 ; GFX8-NEXT:    v_max_f64 v[4:5], v[0:1], v[2:3]
 ; GFX8-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[2:3]
-; GFX8-NEXT:    v_cndmask_b32_e32 v5, v5, v6, vcc
-; GFX8-NEXT:    v_cndmask_b32_e64 v4, v4, 0, vcc
-; GFX8-NEXT:    v_cmp_class_f64_e64 vcc, v[0:1], 64
-; GFX8-NEXT:    v_cmp_eq_f64_e64 s[6:7], 0, v[4:5]
-; GFX8-NEXT:    v_cndmask_b32_e32 v0, v4, v0, vcc
+; GFX8-NEXT:    v_mov_b32_e32 v1, 0x7ff80000
+; GFX8-NEXT:    v_cndmask_b32_e64 v0, v4, 0, vcc
 ; GFX8-NEXT:    v_cndmask_b32_e32 v1, v5, v1, vcc
-; GFX8-NEXT:    v_cndmask_b32_e64 v0, v0, v2, s[4:5]
-; GFX8-NEXT:    v_cndmask_b32_e64 v1, v1, v3, s[4:5]
-; GFX8-NEXT:    v_cndmask_b32_e64 v0, v4, v0, s[6:7]
-; GFX8-NEXT:    v_cndmask_b32_e64 v1, v5, v1, s[6:7]
 ; GFX8-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX9-LABEL: v_maximum_f64__nnan_src0:
 ; GFX9:       ; %bb.0:
 ; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX9-NEXT:    v_add_f64 v[0:1], v[0:1], 1.0
-; GFX9-NEXT:    v_mov_b32_e32 v6, 0x7ff80000
-; GFX9-NEXT:    v_cmp_class_f64_e64 s[4:5], v[2:3], 64
 ; GFX9-NEXT:    v_max_f64 v[4:5], v[0:1], v[2:3]
 ; GFX9-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[2:3]
-; GFX9-NEXT:    v_cndmask_b32_e32 v5, v5, v6, vcc
-; GFX9-NEXT:    v_cndmask_b32_e64 v4, v4, 0, vcc
-; GFX9-NEXT:    v_cmp_class_f64_e64 vcc, v[0:1], 64
-; GFX9-NEXT:    v_cmp_eq_f64_e64 s[6:7], 0, v[4:5]
-; GFX9-NEXT:    v_cndmask_b32_e32 v0, v4, v0, vcc
+; GFX9-NEXT:    v_mov_b32_e32 v1, 0x7ff80000
+; GFX9-NEXT:    v_cndmask_b32_e64 v0, v4, 0, vcc
 ; GFX9-NEXT:    v_cndmask_b32_e32 v1, v5, v1, vcc
-; GFX9-NEXT:    v_cndmask_b32_e64 v0, v0, v2, s[4:5]
-; GFX9-NEXT:    v_cndmask_b32_e64 v1, v1, v3, s[4:5]
-; GFX9-NEXT:    v_cndmask_b32_e64 v0, v4, v0, s[6:7]
-; GFX9-NEXT:    v_cndmask_b32_e64 v1, v5, v1, s[6:7]
 ; GFX9-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX940-LABEL: v_maximum_f64__nnan_src0:
@@ -434,62 +294,33 @@ define double @v_maximum_f64__nnan_src0(double %arg0, double %src1) {
 ; GFX940-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX940-NEXT:    v_add_f64 v[0:1], v[0:1], 1.0
 ; GFX940-NEXT:    v_max_f64 v[4:5], v[0:1], v[2:3]
-; GFX940-NEXT:    v_mov_b32_e32 v6, 0x7ff80000
 ; GFX940-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[2:3]
-; GFX940-NEXT:    v_cmp_class_f64_e64 s[0:1], v[2:3], 64
+; GFX940-NEXT:    v_mov_b32_e32 v1, 0x7ff80000
 ; GFX940-NEXT:    s_nop 0
-; GFX940-NEXT:    v_cndmask_b32_e32 v5, v5, v6, vcc
-; GFX940-NEXT:    v_cndmask_b32_e64 v4, v4, 0, vcc
-; GFX940-NEXT:    v_cmp_class_f64_e64 vcc, v[0:1], 64
-; GFX940-NEXT:    v_cmp_eq_f64_e64 s[2:3], 0, v[4:5]
-; GFX940-NEXT:    s_nop 0
-; GFX940-NEXT:    v_cndmask_b32_e32 v0, v4, v0, vcc
+; GFX940-NEXT:    v_cndmask_b32_e64 v0, v4, 0, vcc
 ; GFX940-NEXT:    v_cndmask_b32_e32 v1, v5, v1, vcc
-; GFX940-NEXT:    v_cndmask_b32_e64 v0, v0, v2, s[0:1]
-; GFX940-NEXT:    v_cndmask_b32_e64 v1, v1, v3, s[0:1]
-; GFX940-NEXT:    v_cndmask_b32_e64 v0, v4, v0, s[2:3]
-; GFX940-NEXT:    v_cndmask_b32_e64 v1, v5, v1, s[2:3]
 ; GFX940-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX10-LABEL: v_maximum_f64__nnan_src0:
 ; GFX10:       ; %bb.0:
 ; GFX10-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX10-NEXT:    v_add_f64 v[0:1], v[0:1], 1.0
-; GFX10-NEXT:    v_cmp_class_f64_e64 s4, v[2:3], 64
 ; GFX10-NEXT:    v_max_f64 v[4:5], v[0:1], v[2:3]
 ; GFX10-NEXT:    v_cmp_u_f64_e32 vcc_lo, v[0:1], v[2:3]
-; GFX10-NEXT:    v_cndmask_b32_e64 v5, v5, 0x7ff80000, vcc_lo
-; GFX10-NEXT:    v_cndmask_b32_e64 v4, v4, 0, vcc_lo
-; GFX10-NEXT:    v_cmp_class_f64_e64 vcc_lo, v[0:1], 64
-; GFX10-NEXT:    v_cmp_eq_f64_e64 s5, 0, v[4:5]
-; GFX10-NEXT:    v_cndmask_b32_e32 v0, v4, v0, vcc_lo
-; GFX10-NEXT:    v_cndmask_b32_e32 v1, v5, v1, vcc_lo
-; GFX10-NEXT:    v_cndmask_b32_e64 v0, v0, v2, s4
-; GFX10-NEXT:    v_cndmask_b32_e64 v1, v1, v3, s4
-; GFX10-NEXT:    v_cndmask_b32_e64 v0, v4, v0, s5
-; GFX10-NEXT:    v_cndmask_b32_e64 v1, v5, v1, s5
+; GFX10-NEXT:    v_cndmask_b32_e64 v0, v4, 0, vcc_lo
+; GFX10-NEXT:    v_cndmask_b32_e64 v1, v5, 0x7ff80000, vcc_lo
 ; GFX10-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX11-LABEL: v_maximum_f64__nnan_src0:
 ; GFX11:       ; %bb.0:
 ; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX11-NEXT:    v_add_f64 v[0:1], v[0:1], 1.0
-; GFX11-NEXT:    v_cmp_class_f64_e64 s0, v[2:3], 64
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(SKIP_1) | instid1(VALU_DEP_2)
+; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_1) | instid1(VALU_DEP_2)
 ; GFX11-NEXT:    v_max_f64 v[4:5], v[0:1], v[2:3]
 ; GFX11-NEXT:    v_cmp_u_f64_e32 vcc_lo, v[0:1], v[2:3]
-; GFX11-NEXT:    v_cndmask_b32_e64 v5, v5, 0x7ff80000, vcc_lo
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(SKIP_1) | instid1(VALU_DEP_2)
-; GFX11-NEXT:    v_cndmask_b32_e64 v4, v4, 0, vcc_lo
-; GFX11-NEXT:    v_cmp_class_f64_e64 vcc_lo, v[0:1], 64
-; GFX11-NEXT:    v_cmp_eq_f64_e64 s1, 0, v[4:5]
-; GFX11-NEXT:    v_dual_cndmask_b32 v0, v4, v0 :: v_dual_cndmask_b32 v1, v5, v1
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_2)
-; GFX11-NEXT:    v_cndmask_b32_e64 v0, v0, v2, s0
-; GFX11-NEXT:    v_cndmask_b32_e64 v1, v1, v3, s0
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_2)
-; GFX11-NEXT:    v_cndmask_b32_e64 v0, v4, v0, s1
-; GFX11-NEXT:    v_cndmask_b32_e64 v1, v5, v1, s1
+; GFX11-NEXT:    v_cndmask_b32_e64 v0, v4, 0, vcc_lo
+; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_3)
+; GFX11-NEXT:    v_cndmask_b32_e64 v1, v5, 0x7ff80000, vcc_lo
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX12-LABEL: v_maximum_f64__nnan_src0:
@@ -513,60 +344,33 @@ define double @v_maximum_f64__nnan_src1(double %src0, double %arg1) {
 ; GFX7:       ; %bb.0:
 ; GFX7-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX7-NEXT:    v_add_f64 v[2:3], v[2:3], 1.0
-; GFX7-NEXT:    v_mov_b32_e32 v6, 0x7ff80000
 ; GFX7-NEXT:    v_max_f64 v[4:5], v[0:1], v[2:3]
 ; GFX7-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[2:3]
-; GFX7-NEXT:    v_cmp_class_f64_e64 s[4:5], v[2:3], 64
-; GFX7-NEXT:    v_cndmask_b32_e32 v5, v5, v6, vcc
-; GFX7-NEXT:    v_cndmask_b32_e64 v4, v4, 0, vcc
-; GFX7-NEXT:    v_cmp_class_f64_e64 vcc, v[0:1], 64
-; GFX7-NEXT:    v_cmp_eq_f64_e64 s[6:7], 0, v[4:5]
-; GFX7-NEXT:    v_cndmask_b32_e32 v0, v4, v0, vcc
+; GFX7-NEXT:    v_mov_b32_e32 v1, 0x7ff80000
+; GFX7-NEXT:    v_cndmask_b32_e64 v0, v4, 0, vcc
 ; GFX7-NEXT:    v_cndmask_b32_e32 v1, v5, v1, vcc
-; GFX7-NEXT:    v_cndmask_b32_e64 v0, v0, v2, s[4:5]
-; GFX7-NEXT:    v_cndmask_b32_e64 v1, v1, v3, s[4:5]
-; GFX7-NEXT:    v_cndmask_b32_e64 v0, v4, v0, s[6:7]
-; GFX7-NEXT:    v_cndmask_b32_e64 v1, v5, v1, s[6:7]
 ; GFX7-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX8-LABEL: v_maximum_f64__nnan_src1:
 ; GFX8:       ; %bb.0:
 ; GFX8-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX8-NEXT:    v_add_f64 v[2:3], v[2:3], 1.0
-; GFX8-NEXT:    v_mov_b32_e32 v6, 0x7ff80000
 ; GFX8-NEXT:    v_max_f64 v[4:5], v[0:1], v[2:3]
 ; GFX8-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[2:3]
-; GFX8-NEXT:    v_cmp_class_f64_e64 s[4:5], v[2:3], 64
-; GFX8-NEXT:    v_cndmask_b32_e32 v5, v5, v6, vcc
-; GFX8-NEXT:    v_cndmask_b32_e64 v4, v4, 0, vcc
-; GFX8-NEXT:    v_cmp_class_f64_e64 vcc, v[0:1], 64
-; GFX8-NEXT:    v_cmp_eq_f64_e64 s[6:7], 0, v[4:5]
-; GFX8-NEXT:    v_cndmask_b32_e32 v0, v4, v0, vcc
+; GFX8-NEXT:    v_mov_b32_e32 v1, 0x7ff80000
+; GFX8-NEXT:    v_cndmask_b32_e64 v0, v4, 0, vcc
 ; GFX8-NEXT:    v_cndmask_b32_e32 v1, v5, v1, vcc
-; GFX8-NEXT:    v_cndmask_b32_e64 v0, v0, v2, s[4:5]
-; GFX8-NEXT:    v_cndmask_b32_e64 v1, v1, v3, s[4:5]
-; GFX8-NEXT:    v_cndmask_b32_e64 v0, v4, v0, s[6:7]
-; GFX8-NEXT:    v_cndmask_b32_e64 v1, v5, v1, s[6:7]
 ; GFX8-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX9-LABEL: v_maximum_f64__nnan_src1:
 ; GFX9:       ; %bb.0:
 ; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX9-NEXT:    v_add_f64 v[2:3], v[2:3], 1.0
-; GFX9-NEXT:    v_mov_b32_e32 v6, 0x7ff80000
 ; GFX9-NEXT:    v_max_f64 v[4:5], v[0:1], v[2:3]
 ; GFX9-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[2:3]
-; GFX9-NEXT:    v_cmp_class_f64_e64 s[4:5], v[2:3], 64
-; GFX9-NEXT:    v_cndmask_b32_e32 v5, v5, v6, vcc
-; GFX9-NEXT:    v_cndmask_b32_e64 v4, v4, 0, vcc
-; GFX9-NEXT:    v_cmp_class_f64_e64 vcc, v[0:1], 64
-; GFX9-NEXT:    v_cmp_eq_f64_e64 s[6:7], 0, v[4:5]
-; GFX9-NEXT:    v_cndmask_b32_e32 v0, v4, v0, vcc
+; GFX9-NEXT:    v_mov_b32_e32 v1, 0x7ff80000
+; GFX9-NEXT:    v_cndmask_b32_e64 v0, v4, 0, vcc
 ; GFX9-NEXT:    v_cndmask_b32_e32 v1, v5, v1, vcc
-; GFX9-NEXT:    v_cndmask_b32_e64 v0, v0, v2, s[4:5]
-; GFX9-NEXT:    v_cndmask_b32_e64 v1, v1, v3, s[4:5]
-; GFX9-NEXT:    v_cndmask_b32_e64 v0, v4, v0, s[6:7]
-; GFX9-NEXT:    v_cndmask_b32_e64 v1, v5, v1, s[6:7]
 ; GFX9-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX940-LABEL: v_maximum_f64__nnan_src1:
@@ -574,21 +378,11 @@ define double @v_maximum_f64__nnan_src1(double %src0, double %arg1) {
 ; GFX940-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX940-NEXT:    v_add_f64 v[2:3], v[2:3], 1.0
 ; GFX940-NEXT:    v_max_f64 v[4:5], v[0:1], v[2:3]
-; GFX940-NEXT:    v_mov_b32_e32 v6, 0x7ff80000
 ; GFX940-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[2:3]
-; GFX940-NEXT:    v_cmp_class_f64_e64 s[0:1], v[2:3], 64
+; GFX940-NEXT:    v_mov_b32_e32 v1, 0x7ff80000
 ; GFX940-NEXT:    s_nop 0
-; GFX940-NEXT:    v_cndmask_b32_e32 v5, v5, v6, vcc
-; GFX940-NEXT:    v_cndmask_b32_e64 v4, v4, 0, vcc
-; GFX940-NEXT:    v_cmp_class_f64_e64 vcc, v[0:1], 64
-; GFX940-NEXT:    v_cmp_eq_f64_e64 s[2:3], 0, v[4:5]
-; GFX940-NEXT:    s_nop 0
-; GFX940-NEXT:    v_cndmask_b32_e32 v0, v4, v0, vcc
+; GFX940-NEXT:    v_cndmask_b32_e64 v0, v4, 0, vcc
 ; GFX940-NEXT:    v_cndmask_b32_e32 v1, v5, v1, vcc
-; GFX940-NEXT:    v_cndmask_b32_e64 v0, v0, v2, s[0:1]
-; GFX940-NEXT:    v_cndmask_b32_e64 v1, v1, v3, s[0:1]
-; GFX940-NEXT:    v_cndmask_b32_e64 v0, v4, v0, s[2:3]
-; GFX940-NEXT:    v_cndmask_b32_e64 v1, v5, v1, s[2:3]
 ; GFX940-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX10-LABEL: v_maximum_f64__nnan_src1:
@@ -597,39 +391,20 @@ define double @v_maximum_f64__nnan_src1(double %src0, double %arg1) {
 ; GFX10-NEXT:    v_add_f64 v[2:3], v[2:3], 1.0
 ; GFX10-NEXT:    v_max_f64 v[4:5], v[0:1], v[2:3]
 ; GFX10-NEXT:    v_cmp_u_f64_e32 vcc_lo, v[0:1], v[2:3]
-; GFX10-NEXT:    v_cmp_class_f64_e64 s4, v[2:3], 64
-; GFX10-NEXT:    v_cndmask_b32_e64 v5, v5, 0x7ff80000, vcc_lo
-; GFX10-NEXT:    v_cndmask_b32_e64 v4, v4, 0, vcc_lo
-; GFX10-NEXT:    v_cmp_class_f64_e64 vcc_lo, v[0:1], 64
-; GFX10-NEXT:    v_cmp_eq_f64_e64 s5, 0, v[4:5]
-; GFX10-NEXT:    v_cndmask_b32_e32 v0, v4, v0, vcc_lo
-; GFX10-NEXT:    v_cndmask_b32_e32 v1, v5, v1, vcc_lo
-; GFX10-NEXT:    v_cndmask_b32_e64 v0, v0, v2, s4
-; GFX10-NEXT:    v_cndmask_b32_e64 v1, v1, v3, s4
-; GFX10-NEXT:    v_cndmask_b32_e64 v0, v4, v0, s5
-; GFX10-NEXT:    v_cndmask_b32_e64 v1, v5, v1, s5
+; GFX10-NEXT:    v_cndmask_b32_e64 v0, v4, 0, vcc_lo
+; GFX10-NEXT:    v_cndmask_b32_e64 v1, v5, 0x7ff80000, vcc_lo
 ; GFX10-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX11-LABEL: v_maximum_f64__nnan_src1:
 ; GFX11:       ; %bb.0:
 ; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX11-NEXT:    v_add_f64 v[2:3], v[2:3], 1.0
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_2) | instid1(VALU_DEP_3)
+; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_1) | instid1(VALU_DEP_2)
 ; GFX11-NEXT:    v_max_f64 v[4:5], v[0:1], v[2:3]
 ; GFX11-NEXT:    v_cmp_u_f64_e32 vcc_lo, v[0:1], v[2:3]
-; GFX11-NEXT:    v_cmp_class_f64_e64 s0, v[2:3], 64
-; GFX11-NEXT:    v_cndmask_b32_e64 v5, v5, 0x7ff80000, vcc_lo
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(SKIP_1) | instid1(VALU_DEP_2)
-; GFX11-NEXT:    v_cndmask_b32_e64 v4, v4, 0, vcc_lo
-; GFX11-NEXT:    v_cmp_class_f64_e64 vcc_lo, v[0:1], 64
-; GFX11-NEXT:    v_cmp_eq_f64_e64 s1, 0, v[4:5]
-; GFX11-NEXT:    v_dual_cndmask_b32 v0, v4, v0 :: v_dual_cndmask_b32 v1, v5, v1
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_2)
-; GFX11-NEXT:    v_cndmask_b32_e64 v0, v0, v2, s0
-; GFX11-NEXT:    v_cndmask_b32_e64 v1, v1, v3, s0
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_2)
-; GFX11-NEXT:    v_cndmask_b32_e64 v0, v4, v0, s1
-; GFX11-NEXT:    v_cndmask_b32_e64 v1, v5, v1, s1
+; GFX11-NEXT:    v_cndmask_b32_e64 v0, v4, 0, vcc_lo
+; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_3)
+; GFX11-NEXT:    v_cndmask_b32_e64 v1, v5, 0x7ff80000, vcc_lo
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX12-LABEL: v_maximum_f64__nnan_src1:
@@ -654,30 +429,13 @@ define void @s_maximum_f64(double inreg %src0, double inreg %src1) {
 ; GFX7-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX7-NEXT:    v_mov_b32_e32 v0, s6
 ; GFX7-NEXT:    v_mov_b32_e32 v1, s7
-; GFX7-NEXT:    v_cmp_u_f64_e32 vcc, s[4:5], v[0:1]
 ; GFX7-NEXT:    v_max_f64 v[2:3], s[4:5], v[0:1]
-; GFX7-NEXT:    v_cmp_class_f64_e64 s[8:9], s[4:5], 64
-; GFX7-NEXT:    s_and_b64 s[10:11], vcc, exec
-; GFX7-NEXT:    v_readfirstlane_b32 s12, v3
-; GFX7-NEXT:    v_readfirstlane_b32 s10, v2
-; GFX7-NEXT:    s_cselect_b32 s11, 0x7ff80000, s12
-; GFX7-NEXT:    v_cmp_class_f64_e64 s[12:13], s[6:7], 64
-; GFX7-NEXT:    s_cselect_b32 s10, 0, s10
-; GFX7-NEXT:    v_cmp_eq_f64_e64 s[14:15], s[10:11], 0
-; GFX7-NEXT:    s_and_b64 s[16:17], s[8:9], exec
-; GFX7-NEXT:    s_cselect_b32 s5, s5, s11
-; GFX7-NEXT:    s_and_b64 s[16:17], s[12:13], exec
-; GFX7-NEXT:    s_cselect_b32 s5, s7, s5
-; GFX7-NEXT:    s_and_b64 s[16:17], s[14:15], exec
-; GFX7-NEXT:    s_cselect_b32 s5, s5, s11
-; GFX7-NEXT:    s_and_b64 s[8:9], s[8:9], exec
-; GFX7-NEXT:    s_cselect_b32 s4, s4, s10
-; GFX7-NEXT:    s_and_b64 s[8:9], s[12:13], exec
-; GFX7-NEXT:    s_cselect_b32 s4, s6, s4
-; GFX7-NEXT:    s_and_b64 s[6:7], s[14:15], exec
-; GFX7-NEXT:    s_cselect_b32 s4, s4, s10
+; GFX7-NEXT:    v_cmp_u_f64_e32 vcc, s[4:5], v[0:1]
+; GFX7-NEXT:    v_mov_b32_e32 v4, 0x7ff80000
+; GFX7-NEXT:    v_cndmask_b32_e32 v1, v3, v4, vcc
+; GFX7-NEXT:    v_cndmask_b32_e64 v0, v2, 0, vcc
 ; GFX7-NEXT:    ;;#ASMSTART
-; GFX7-NEXT:    ; use s[4:5]
+; GFX7-NEXT:    ; use v[0:1]
 ; GFX7-NEXT:    ;;#ASMEND
 ; GFX7-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -686,30 +444,13 @@ define void @s_maximum_f64(double inreg %src0, double inreg %src1) {
 ; GFX8-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX8-NEXT:    v_mov_b32_e32 v0, s6
 ; GFX8-NEXT:    v_mov_b32_e32 v1, s7
-; GFX8-NEXT:    v_cmp_u_f64_e32 vcc, s[4:5], v[0:1]
 ; GFX8-NEXT:    v_max_f64 v[2:3], s[4:5], v[0:1]
-; GFX8-NEXT:    v_cmp_class_f64_e64 s[8:9], s[4:5], 64
-; GFX8-NEXT:    s_and_b64 s[10:11], vcc, exec
-; GFX8-NEXT:    v_readfirstlane_b32 s12, v3
-; GFX8-NEXT:    v_readfirstlane_b32 s10, v2
-; GFX8-NEXT:    s_cselect_b32 s11, 0x7ff80000, s12
-; GFX8-NEXT:    v_cmp_class_f64_e64 s[12:13], s[6:7], 64
-; GFX8-NEXT:    s_cselect_b32 s10, 0, s10
-; GFX8-NEXT:    v_cmp_eq_f64_e64 s[14:15], s[10:11], 0
-; GFX8-NEXT:    s_and_b64 s[16:17], s[8:9], exec
-; GFX8-NEXT:    s_cselect_b32 s5, s5, s11
-; GFX8-NEXT:    s_and_b64 s[16:17], s[12:13], exec
-; GFX8-NEXT:    s_cselect_b32 s5, s7, s5
-; GFX8-NEXT:    s_and_b64 s[16:17], s[14:15], exec
-; GFX8-NEXT:    s_cselect_b32 s5, s5, s11
-; GFX8-NEXT:    s_and_b64 s[8:9], s[8:9], exec
-; GFX8-NEXT:    s_cselect_b32 s4, s4, s10
-; GFX8-NEXT:    s_and_b64 s[8:9], s[12:13], exec
-; GFX8-NEXT:    s_cselect_b32 s4, s6, s4
-; GFX8-NEXT:    s_and_b64 s[6:7], s[14:15], exec
-; GFX8-NEXT:    s_cselect_b32 s4, s4, s10
+; GFX8-NEXT:    v_cmp_u_f64_e32 vcc, s[4:5], v[0:1]
+; GFX8-NEXT:    v_mov_b32_e32 v4, 0x7ff80000
+; GFX8-NEXT:    v_cndmask_b32_e32 v1, v3, v4, vcc
+; GFX8-NEXT:    v_cndmask_b32_e64 v0, v2, 0, vcc
 ; GFX8-NEXT:    ;;#ASMSTART
-; GFX8-NEXT:    ; use s[4:5]
+; GFX8-NEXT:    ; use v[0:1]
 ; GFX8-NEXT:    ;;#ASMEND
 ; GFX8-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -718,30 +459,13 @@ define void @s_maximum_f64(double inreg %src0, double inreg %src1) {
 ; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX9-NEXT:    v_mov_b32_e32 v0, s6
 ; GFX9-NEXT:    v_mov_b32_e32 v1, s7
-; GFX9-NEXT:    v_cmp_u_f64_e32 vcc, s[4:5], v[0:1]
 ; GFX9-NEXT:    v_max_f64 v[2:3], s[4:5], v[0:1]
-; GFX9-NEXT:    v_cmp_class_f64_e64 s[8:9], s[4:5], 64
-; GFX9-NEXT:    s_and_b64 s[10:11], vcc, exec
-; GFX9-NEXT:    v_readfirstlane_b32 s12, v3
-; GFX9-NEXT:    v_readfirstlane_b32 s10, v2
-; GFX9-NEXT:    s_cselect_b32 s11, 0x7ff80000, s12
-; GFX9-NEXT:    v_cmp_class_f64_e64 s[12:13], s[6:7], 64
-; GFX9-NEXT:    s_cselect_b32 s10, 0, s10
-; GFX9-NEXT:    v_cmp_eq_f64_e64 s[14:15], s[10:11], 0
-; GFX9-NEXT:    s_and_b64 s[16:17], s[8:9], exec
-; GFX9-NEXT:    s_cselect_b32 s5, s5, s11
-; GFX9-NEXT:    s_and_b64 s[16:17], s[12:13], exec
-; GFX9-NEXT:    s_cselect_b32 s5, s7, s5
-; GFX9-NEXT:    s_and_b64 s[16:17], s[14:15], exec
-; GFX9-NEXT:    s_cselect_b32 s5, s5, s11
-; GFX9-NEXT:    s_and_b64 s[8:9], s[8:9], exec
-; GFX9-NEXT:    s_cselect_b32 s4, s4, s10
-; GFX9-NEXT:    s_and_b64 s[8:9], s[12:13], exec
-; GFX9-NEXT:    s_cselect_b32 s4, s6, s4
-; GFX9-NEXT:    s_and_b64 s[6:7], s[14:15], exec
-; GFX9-NEXT:    s_cselect_b32 s4, s4, s10
+; GFX9-NEXT:    v_cmp_u_f64_e32 vcc, s[4:5], v[0:1]
+; GFX9-NEXT:    v_mov_b32_e32 v4, 0x7ff80000
+; GFX9-NEXT:    v_cndmask_b32_e32 v1, v3, v4, vcc
+; GFX9-NEXT:    v_cndmask_b32_e64 v0, v2, 0, vcc
 ; GFX9-NEXT:    ;;#ASMSTART
-; GFX9-NEXT:    ; use s[4:5]
+; GFX9-NEXT:    ; use v[0:1]
 ; GFX9-NEXT:    ;;#ASMEND
 ; GFX9-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -749,30 +473,14 @@ define void @s_maximum_f64(double inreg %src0, double inreg %src1) {
 ; GFX940:       ; %bb.0:
 ; GFX940-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX940-NEXT:    v_mov_b64_e32 v[0:1], s[2:3]
+; GFX940-NEXT:    v_max_f64 v[2:3], s[0:1], v[0:1]
+; GFX940-NEXT:    v_mov_b32_e32 v4, 0x7ff80000
 ; GFX940-NEXT:    v_cmp_u_f64_e32 vcc, s[0:1], v[0:1]
-; GFX940-NEXT:    v_max_f64 v[0:1], s[0:1], v[0:1]
-; GFX940-NEXT:    s_and_b64 s[4:5], vcc, exec
-; GFX940-NEXT:    v_readfirstlane_b32 s6, v1
-; GFX940-NEXT:    v_readfirstlane_b32 s4, v0
-; GFX940-NEXT:    v_cmp_class_f64_e64 s[8:9], s[0:1], 64
-; GFX940-NEXT:    s_cselect_b32 s5, 0x7ff80000, s6
-; GFX940-NEXT:    s_cselect_b32 s4, 0, s4
-; GFX940-NEXT:    s_and_b64 s[10:11], s[8:9], exec
-; GFX940-NEXT:    v_cmp_class_f64_e64 s[10:11], s[2:3], 64
-; GFX940-NEXT:    v_cmp_eq_f64_e64 s[6:7], s[4:5], 0
-; GFX940-NEXT:    s_cselect_b32 s1, s1, s5
-; GFX940-NEXT:    s_and_b64 s[12:13], s[10:11], exec
-; GFX940-NEXT:    s_cselect_b32 s1, s3, s1
-; GFX940-NEXT:    s_and_b64 s[12:13], s[6:7], exec
-; GFX940-NEXT:    s_cselect_b32 s1, s1, s5
-; GFX940-NEXT:    s_and_b64 s[8:9], s[8:9], exec
-; GFX940-NEXT:    s_cselect_b32 s0, s0, s4
-; GFX940-NEXT:    s_and_b64 s[8:9], s[10:11], exec
-; GFX940-NEXT:    s_cselect_b32 s0, s2, s0
-; GFX940-NEXT:    s_and_b64 s[2:3], s[6:7], exec
-; GFX940-NEXT:    s_cselect_b32 s0, s0, s4
+; GFX940-NEXT:    s_nop 1
+; GFX940-NEXT:    v_cndmask_b32_e32 v1, v3, v4, vcc
+; GFX940-NEXT:    v_cndmask_b32_e64 v0, v2, 0, vcc
 ; GFX940-NEXT:    ;;#ASMSTART
-; GFX940-NEXT:    ; use s[0:1]
+; GFX940-NEXT:    ; use v[0:1]
 ; GFX940-NEXT:    ;;#ASMEND
 ; GFX940-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -780,29 +488,11 @@ define void @s_maximum_f64(double inreg %src0, double inreg %src1) {
 ; GFX10:       ; %bb.0:
 ; GFX10-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX10-NEXT:    v_max_f64 v[0:1], s[4:5], s[6:7]
-; GFX10-NEXT:    v_cmp_u_f64_e64 s8, s[4:5], s[6:7]
-; GFX10-NEXT:    v_cmp_class_f64_e64 s11, s[4:5], 64
-; GFX10-NEXT:    v_cmp_class_f64_e64 s12, s[6:7], 64
-; GFX10-NEXT:    v_readfirstlane_b32 s9, v1
-; GFX10-NEXT:    v_readfirstlane_b32 s10, v0
-; GFX10-NEXT:    s_and_b32 s8, s8, exec_lo
-; GFX10-NEXT:    s_cselect_b32 s9, 0x7ff80000, s9
-; GFX10-NEXT:    s_cselect_b32 s8, 0, s10
-; GFX10-NEXT:    s_and_b32 s13, s11, exec_lo
-; GFX10-NEXT:    v_cmp_eq_f64_e64 s10, s[8:9], 0
-; GFX10-NEXT:    s_cselect_b32 s5, s5, s9
-; GFX10-NEXT:    s_and_b32 s13, s12, exec_lo
-; GFX10-NEXT:    s_cselect_b32 s5, s7, s5
-; GFX10-NEXT:    s_and_b32 s7, s10, exec_lo
-; GFX10-NEXT:    s_cselect_b32 s5, s5, s9
-; GFX10-NEXT:    s_and_b32 s7, s11, exec_lo
-; GFX10-NEXT:    s_cselect_b32 s4, s4, s8
-; GFX10-NEXT:    s_and_b32 s7, s12, exec_lo
-; GFX10-NEXT:    s_cselect_b32 s4, s6, s4
-; GFX10-NEXT:    s_and_b32 s6, s10, exec_lo
-; GFX10-NEXT:    s_cselect_b32 s4, s4, s8
+; GFX10-NEXT:    v_cmp_u_f64_e64 s4, s[4:5], s[6:7]
+; GFX10-NEXT:    v_cndmask_b32_e64 v1, v1, 0x7ff80000, s4
+; GFX10-NEXT:    v_cndmask_b32_e64 v0, v0, 0, s4
 ; GFX10-NEXT:    ;;#ASMSTART
-; GFX10-NEXT:    ; use s[4:5]
+; GFX10-NEXT:    ; use v[0:1]
 ; GFX10-NEXT:    ;;#ASMEND
 ; GFX10-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -810,32 +500,12 @@ define void @s_maximum_f64(double inreg %src0, double inreg %src1) {
 ; GFX11:       ; %bb.0:
 ; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX11-NEXT:    v_max_f64 v[0:1], s[0:1], s[2:3]
-; GFX11-NEXT:    v_cmp_u_f64_e64 s4, s[0:1], s[2:3]
-; GFX11-NEXT:    v_cmp_class_f64_e64 s7, s[0:1], 64
-; GFX11-NEXT:    v_cmp_class_f64_e64 s8, s[2:3], 64
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(SKIP_2) | instid1(VALU_DEP_2)
-; GFX11-NEXT:    v_readfirstlane_b32 s5, v1
-; GFX11-NEXT:    v_readfirstlane_b32 s6, v0
-; GFX11-NEXT:    s_and_b32 s4, s4, exec_lo
-; GFX11-NEXT:    s_cselect_b32 s5, 0x7ff80000, s5
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_4)
-; GFX11-NEXT:    s_cselect_b32 s4, 0, s6
-; GFX11-NEXT:    s_and_b32 s9, s7, exec_lo
-; GFX11-NEXT:    v_cmp_eq_f64_e64 s6, s[4:5], 0
-; GFX11-NEXT:    s_cselect_b32 s1, s1, s5
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(SKIP_1) | instid1(VALU_DEP_1)
-; GFX11-NEXT:    s_and_b32 s9, s8, exec_lo
-; GFX11-NEXT:    s_cselect_b32 s1, s3, s1
-; GFX11-NEXT:    s_and_b32 s3, s6, exec_lo
-; GFX11-NEXT:    s_cselect_b32 s1, s1, s5
-; GFX11-NEXT:    s_and_b32 s3, s7, exec_lo
-; GFX11-NEXT:    s_cselect_b32 s0, s0, s4
-; GFX11-NEXT:    s_and_b32 s3, s8, exec_lo
-; GFX11-NEXT:    s_cselect_b32 s0, s2, s0
-; GFX11-NEXT:    s_and_b32 s2, s6, exec_lo
-; GFX11-NEXT:    s_cselect_b32 s0, s0, s4
+; GFX11-NEXT:    v_cmp_u_f64_e64 s0, s[0:1], s[2:3]
+; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_3)
+; GFX11-NEXT:    v_cndmask_b32_e64 v1, v1, 0x7ff80000, s0
+; GFX11-NEXT:    v_cndmask_b32_e64 v0, v0, 0, s0
 ; GFX11-NEXT:    ;;#ASMSTART
-; GFX11-NEXT:    ; use s[0:1]
+; GFX11-NEXT:    ; use v[0:1]
 ; GFX11-NEXT:    ;;#ASMEND
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
 ;

--- a/llvm/test/CodeGen/AMDGPU/llvm.minimum.f16.ll
+++ b/llvm/test/CodeGen/AMDGPU/llvm.minimum.f16.ll
@@ -14,13 +14,7 @@ define half @v_minimum_f16(half %src0, half %src1) {
 ; GFX8-NEXT:    v_min_f16_e32 v2, v0, v1
 ; GFX8-NEXT:    v_mov_b32_e32 v3, 0x7e00
 ; GFX8-NEXT:    v_cmp_o_f16_e32 vcc, v0, v1
-; GFX8-NEXT:    v_cndmask_b32_e32 v2, v3, v2, vcc
-; GFX8-NEXT:    v_cmp_class_f16_e64 vcc, v0, 32
-; GFX8-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc
-; GFX8-NEXT:    v_cmp_class_f16_e64 vcc, v1, 32
-; GFX8-NEXT:    v_cndmask_b32_e32 v0, v0, v1, vcc
-; GFX8-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v2
-; GFX8-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc
+; GFX8-NEXT:    v_cndmask_b32_e32 v0, v3, v2, vcc
 ; GFX8-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX9-LABEL: v_minimum_f16:
@@ -29,13 +23,7 @@ define half @v_minimum_f16(half %src0, half %src1) {
 ; GFX9-NEXT:    v_min_f16_e32 v2, v0, v1
 ; GFX9-NEXT:    v_mov_b32_e32 v3, 0x7e00
 ; GFX9-NEXT:    v_cmp_o_f16_e32 vcc, v0, v1
-; GFX9-NEXT:    v_cndmask_b32_e32 v2, v3, v2, vcc
-; GFX9-NEXT:    v_cmp_class_f16_e64 vcc, v0, 32
-; GFX9-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc
-; GFX9-NEXT:    v_cmp_class_f16_e64 vcc, v1, 32
-; GFX9-NEXT:    v_cndmask_b32_e32 v0, v0, v1, vcc
-; GFX9-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v2
-; GFX9-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v0, v3, v2, vcc
 ; GFX9-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX940-LABEL: v_minimum_f16:
@@ -45,16 +33,7 @@ define half @v_minimum_f16(half %src0, half %src1) {
 ; GFX940-NEXT:    v_mov_b32_e32 v3, 0x7e00
 ; GFX940-NEXT:    v_cmp_o_f16_e32 vcc, v0, v1
 ; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v2, v3, v2, vcc
-; GFX940-NEXT:    v_cmp_class_f16_e64 vcc, v0, 32
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc
-; GFX940-NEXT:    v_cmp_class_f16_e64 vcc, v1, 32
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v0, v0, v1, vcc
-; GFX940-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v2
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc
+; GFX940-NEXT:    v_cndmask_b32_e32 v0, v3, v2, vcc
 ; GFX940-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX10-LABEL: v_minimum_f16:
@@ -62,13 +41,7 @@ define half @v_minimum_f16(half %src0, half %src1) {
 ; GFX10-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX10-NEXT:    v_min_f16_e32 v2, v0, v1
 ; GFX10-NEXT:    v_cmp_o_f16_e32 vcc_lo, v0, v1
-; GFX10-NEXT:    v_cndmask_b32_e32 v2, 0x7e00, v2, vcc_lo
-; GFX10-NEXT:    v_cmp_class_f16_e64 vcc_lo, v0, 32
-; GFX10-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc_lo
-; GFX10-NEXT:    v_cmp_class_f16_e64 vcc_lo, v1, 32
-; GFX10-NEXT:    v_cndmask_b32_e32 v0, v0, v1, vcc_lo
-; GFX10-NEXT:    v_cmp_eq_f16_e32 vcc_lo, 0, v2
-; GFX10-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc_lo
+; GFX10-NEXT:    v_cndmask_b32_e32 v0, 0x7e00, v2, vcc_lo
 ; GFX10-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX11-LABEL: v_minimum_f16:
@@ -76,15 +49,8 @@ define half @v_minimum_f16(half %src0, half %src1) {
 ; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX11-NEXT:    v_min_f16_e32 v2, v0, v1
 ; GFX11-NEXT:    v_cmp_o_f16_e32 vcc_lo, v0, v1
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(SKIP_1) | instid1(VALU_DEP_2)
-; GFX11-NEXT:    v_cndmask_b32_e32 v2, 0x7e00, v2, vcc_lo
-; GFX11-NEXT:    v_cmp_class_f16_e64 vcc_lo, v0, 32
-; GFX11-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc_lo
-; GFX11-NEXT:    v_cmp_class_f16_e64 vcc_lo, v1, 32
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(SKIP_1) | instid1(VALU_DEP_2)
-; GFX11-NEXT:    v_cndmask_b32_e32 v0, v0, v1, vcc_lo
-; GFX11-NEXT:    v_cmp_eq_f16_e32 vcc_lo, 0, v2
-; GFX11-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc_lo
+; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_2)
+; GFX11-NEXT:    v_cndmask_b32_e32 v0, 0x7e00, v2, vcc_lo
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX12-LABEL: v_minimum_f16:
@@ -104,66 +70,31 @@ define half @v_minimum_f16__nnan(half %src0, half %src1) {
 ; GFX8-LABEL: v_minimum_f16__nnan:
 ; GFX8:       ; %bb.0:
 ; GFX8-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX8-NEXT:    v_min_f16_e32 v2, v0, v1
-; GFX8-NEXT:    v_cmp_class_f16_e64 vcc, v0, 32
-; GFX8-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc
-; GFX8-NEXT:    v_cmp_class_f16_e64 vcc, v1, 32
-; GFX8-NEXT:    v_cndmask_b32_e32 v0, v0, v1, vcc
-; GFX8-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v2
-; GFX8-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc
+; GFX8-NEXT:    v_min_f16_e32 v0, v0, v1
 ; GFX8-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX9-LABEL: v_minimum_f16__nnan:
 ; GFX9:       ; %bb.0:
 ; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX9-NEXT:    v_min_f16_e32 v2, v0, v1
-; GFX9-NEXT:    v_cmp_class_f16_e64 vcc, v0, 32
-; GFX9-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc
-; GFX9-NEXT:    v_cmp_class_f16_e64 vcc, v1, 32
-; GFX9-NEXT:    v_cndmask_b32_e32 v0, v0, v1, vcc
-; GFX9-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v2
-; GFX9-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc
+; GFX9-NEXT:    v_min_f16_e32 v0, v0, v1
 ; GFX9-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX940-LABEL: v_minimum_f16__nnan:
 ; GFX940:       ; %bb.0:
 ; GFX940-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX940-NEXT:    v_min_f16_e32 v2, v0, v1
-; GFX940-NEXT:    v_cmp_class_f16_e64 vcc, v0, 32
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc
-; GFX940-NEXT:    v_cmp_class_f16_e64 vcc, v1, 32
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v0, v0, v1, vcc
-; GFX940-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v2
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc
+; GFX940-NEXT:    v_min_f16_e32 v0, v0, v1
 ; GFX940-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX10-LABEL: v_minimum_f16__nnan:
 ; GFX10:       ; %bb.0:
 ; GFX10-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX10-NEXT:    v_min_f16_e32 v2, v0, v1
-; GFX10-NEXT:    v_cmp_class_f16_e64 vcc_lo, v0, 32
-; GFX10-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc_lo
-; GFX10-NEXT:    v_cmp_class_f16_e64 vcc_lo, v1, 32
-; GFX10-NEXT:    v_cndmask_b32_e32 v0, v0, v1, vcc_lo
-; GFX10-NEXT:    v_cmp_eq_f16_e32 vcc_lo, 0, v2
-; GFX10-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc_lo
+; GFX10-NEXT:    v_min_f16_e32 v0, v0, v1
 ; GFX10-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX11-LABEL: v_minimum_f16__nnan:
 ; GFX11:       ; %bb.0:
 ; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX11-NEXT:    v_min_f16_e32 v2, v0, v1
-; GFX11-NEXT:    v_cmp_class_f16_e64 vcc_lo, v0, 32
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(SKIP_1) | instid1(VALU_DEP_2)
-; GFX11-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc_lo
-; GFX11-NEXT:    v_cmp_class_f16_e64 vcc_lo, v1, 32
-; GFX11-NEXT:    v_cndmask_b32_e32 v0, v0, v1, vcc_lo
-; GFX11-NEXT:    v_cmp_eq_f16_e32 vcc_lo, 0, v2
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_2)
-; GFX11-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc_lo
+; GFX11-NEXT:    v_min_f16_e32 v0, v0, v1
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX12-LABEL: v_minimum_f16__nnan:
@@ -290,13 +221,7 @@ define half @v_minimum_f16__nnan_src0(half %arg0, half %src1) {
 ; GFX8-NEXT:    v_min_f16_e32 v2, v0, v1
 ; GFX8-NEXT:    v_mov_b32_e32 v3, 0x7e00
 ; GFX8-NEXT:    v_cmp_o_f16_e32 vcc, v0, v1
-; GFX8-NEXT:    v_cndmask_b32_e32 v2, v3, v2, vcc
-; GFX8-NEXT:    v_cmp_class_f16_e64 vcc, v0, 32
-; GFX8-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc
-; GFX8-NEXT:    v_cmp_class_f16_e64 vcc, v1, 32
-; GFX8-NEXT:    v_cndmask_b32_e32 v0, v0, v1, vcc
-; GFX8-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v2
-; GFX8-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc
+; GFX8-NEXT:    v_cndmask_b32_e32 v0, v3, v2, vcc
 ; GFX8-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX9-LABEL: v_minimum_f16__nnan_src0:
@@ -306,13 +231,7 @@ define half @v_minimum_f16__nnan_src0(half %arg0, half %src1) {
 ; GFX9-NEXT:    v_min_f16_e32 v2, v0, v1
 ; GFX9-NEXT:    v_mov_b32_e32 v3, 0x7e00
 ; GFX9-NEXT:    v_cmp_o_f16_e32 vcc, v0, v1
-; GFX9-NEXT:    v_cndmask_b32_e32 v2, v3, v2, vcc
-; GFX9-NEXT:    v_cmp_class_f16_e64 vcc, v0, 32
-; GFX9-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc
-; GFX9-NEXT:    v_cmp_class_f16_e64 vcc, v1, 32
-; GFX9-NEXT:    v_cndmask_b32_e32 v0, v0, v1, vcc
-; GFX9-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v2
-; GFX9-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v0, v3, v2, vcc
 ; GFX9-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX940-LABEL: v_minimum_f16__nnan_src0:
@@ -323,16 +242,7 @@ define half @v_minimum_f16__nnan_src0(half %arg0, half %src1) {
 ; GFX940-NEXT:    v_mov_b32_e32 v3, 0x7e00
 ; GFX940-NEXT:    v_cmp_o_f16_e32 vcc, v0, v1
 ; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v2, v3, v2, vcc
-; GFX940-NEXT:    v_cmp_class_f16_e64 vcc, v0, 32
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc
-; GFX940-NEXT:    v_cmp_class_f16_e64 vcc, v1, 32
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v0, v0, v1, vcc
-; GFX940-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v2
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc
+; GFX940-NEXT:    v_cndmask_b32_e32 v0, v3, v2, vcc
 ; GFX940-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX10-LABEL: v_minimum_f16__nnan_src0:
@@ -341,13 +251,7 @@ define half @v_minimum_f16__nnan_src0(half %arg0, half %src1) {
 ; GFX10-NEXT:    v_add_f16_e32 v0, 1.0, v0
 ; GFX10-NEXT:    v_min_f16_e32 v2, v0, v1
 ; GFX10-NEXT:    v_cmp_o_f16_e32 vcc_lo, v0, v1
-; GFX10-NEXT:    v_cndmask_b32_e32 v2, 0x7e00, v2, vcc_lo
-; GFX10-NEXT:    v_cmp_class_f16_e64 vcc_lo, v0, 32
-; GFX10-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc_lo
-; GFX10-NEXT:    v_cmp_class_f16_e64 vcc_lo, v1, 32
-; GFX10-NEXT:    v_cndmask_b32_e32 v0, v0, v1, vcc_lo
-; GFX10-NEXT:    v_cmp_eq_f16_e32 vcc_lo, 0, v2
-; GFX10-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc_lo
+; GFX10-NEXT:    v_cndmask_b32_e32 v0, 0x7e00, v2, vcc_lo
 ; GFX10-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX11-LABEL: v_minimum_f16__nnan_src0:
@@ -357,15 +261,7 @@ define half @v_minimum_f16__nnan_src0(half %arg0, half %src1) {
 ; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_1) | instid1(VALU_DEP_2)
 ; GFX11-NEXT:    v_min_f16_e32 v2, v0, v1
 ; GFX11-NEXT:    v_cmp_o_f16_e32 vcc_lo, v0, v1
-; GFX11-NEXT:    v_cndmask_b32_e32 v2, 0x7e00, v2, vcc_lo
-; GFX11-NEXT:    v_cmp_class_f16_e64 vcc_lo, v0, 32
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(SKIP_1) | instid1(VALU_DEP_2)
-; GFX11-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc_lo
-; GFX11-NEXT:    v_cmp_class_f16_e64 vcc_lo, v1, 32
-; GFX11-NEXT:    v_cndmask_b32_e32 v0, v0, v1, vcc_lo
-; GFX11-NEXT:    v_cmp_eq_f16_e32 vcc_lo, 0, v2
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_2)
-; GFX11-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc_lo
+; GFX11-NEXT:    v_cndmask_b32_e32 v0, 0x7e00, v2, vcc_lo
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX12-LABEL: v_minimum_f16__nnan_src0:
@@ -392,13 +288,7 @@ define half @v_minimum_f16__nnan_src1(half %src0, half %arg1) {
 ; GFX8-NEXT:    v_min_f16_e32 v2, v0, v1
 ; GFX8-NEXT:    v_mov_b32_e32 v3, 0x7e00
 ; GFX8-NEXT:    v_cmp_o_f16_e32 vcc, v0, v1
-; GFX8-NEXT:    v_cndmask_b32_e32 v2, v3, v2, vcc
-; GFX8-NEXT:    v_cmp_class_f16_e64 vcc, v0, 32
-; GFX8-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc
-; GFX8-NEXT:    v_cmp_class_f16_e64 vcc, v1, 32
-; GFX8-NEXT:    v_cndmask_b32_e32 v0, v0, v1, vcc
-; GFX8-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v2
-; GFX8-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc
+; GFX8-NEXT:    v_cndmask_b32_e32 v0, v3, v2, vcc
 ; GFX8-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX9-LABEL: v_minimum_f16__nnan_src1:
@@ -408,13 +298,7 @@ define half @v_minimum_f16__nnan_src1(half %src0, half %arg1) {
 ; GFX9-NEXT:    v_min_f16_e32 v2, v0, v1
 ; GFX9-NEXT:    v_mov_b32_e32 v3, 0x7e00
 ; GFX9-NEXT:    v_cmp_o_f16_e32 vcc, v0, v1
-; GFX9-NEXT:    v_cndmask_b32_e32 v2, v3, v2, vcc
-; GFX9-NEXT:    v_cmp_class_f16_e64 vcc, v0, 32
-; GFX9-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc
-; GFX9-NEXT:    v_cmp_class_f16_e64 vcc, v1, 32
-; GFX9-NEXT:    v_cndmask_b32_e32 v0, v0, v1, vcc
-; GFX9-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v2
-; GFX9-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v0, v3, v2, vcc
 ; GFX9-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX940-LABEL: v_minimum_f16__nnan_src1:
@@ -425,16 +309,7 @@ define half @v_minimum_f16__nnan_src1(half %src0, half %arg1) {
 ; GFX940-NEXT:    v_mov_b32_e32 v3, 0x7e00
 ; GFX940-NEXT:    v_cmp_o_f16_e32 vcc, v0, v1
 ; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v2, v3, v2, vcc
-; GFX940-NEXT:    v_cmp_class_f16_e64 vcc, v0, 32
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc
-; GFX940-NEXT:    v_cmp_class_f16_e64 vcc, v1, 32
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v0, v0, v1, vcc
-; GFX940-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v2
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc
+; GFX940-NEXT:    v_cndmask_b32_e32 v0, v3, v2, vcc
 ; GFX940-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX10-LABEL: v_minimum_f16__nnan_src1:
@@ -443,13 +318,7 @@ define half @v_minimum_f16__nnan_src1(half %src0, half %arg1) {
 ; GFX10-NEXT:    v_add_f16_e32 v1, 1.0, v1
 ; GFX10-NEXT:    v_min_f16_e32 v2, v0, v1
 ; GFX10-NEXT:    v_cmp_o_f16_e32 vcc_lo, v0, v1
-; GFX10-NEXT:    v_cndmask_b32_e32 v2, 0x7e00, v2, vcc_lo
-; GFX10-NEXT:    v_cmp_class_f16_e64 vcc_lo, v0, 32
-; GFX10-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc_lo
-; GFX10-NEXT:    v_cmp_class_f16_e64 vcc_lo, v1, 32
-; GFX10-NEXT:    v_cndmask_b32_e32 v0, v0, v1, vcc_lo
-; GFX10-NEXT:    v_cmp_eq_f16_e32 vcc_lo, 0, v2
-; GFX10-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc_lo
+; GFX10-NEXT:    v_cndmask_b32_e32 v0, 0x7e00, v2, vcc_lo
 ; GFX10-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX11-LABEL: v_minimum_f16__nnan_src1:
@@ -459,15 +328,7 @@ define half @v_minimum_f16__nnan_src1(half %src0, half %arg1) {
 ; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_1) | instid1(VALU_DEP_2)
 ; GFX11-NEXT:    v_min_f16_e32 v2, v0, v1
 ; GFX11-NEXT:    v_cmp_o_f16_e32 vcc_lo, v0, v1
-; GFX11-NEXT:    v_cndmask_b32_e32 v2, 0x7e00, v2, vcc_lo
-; GFX11-NEXT:    v_cmp_class_f16_e64 vcc_lo, v0, 32
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(SKIP_1) | instid1(VALU_DEP_2)
-; GFX11-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc_lo
-; GFX11-NEXT:    v_cmp_class_f16_e64 vcc_lo, v1, 32
-; GFX11-NEXT:    v_cndmask_b32_e32 v0, v0, v1, vcc_lo
-; GFX11-NEXT:    v_cmp_eq_f16_e32 vcc_lo, 0, v2
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_2)
-; GFX11-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc_lo
+; GFX11-NEXT:    v_cndmask_b32_e32 v0, 0x7e00, v2, vcc_lo
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX12-LABEL: v_minimum_f16__nnan_src1:
@@ -494,14 +355,7 @@ define void @s_minimum_f16(half inreg %src0, half inreg %src1) {
 ; GFX8-NEXT:    v_min_f16_e32 v1, s4, v0
 ; GFX8-NEXT:    v_mov_b32_e32 v2, 0x7e00
 ; GFX8-NEXT:    v_cmp_o_f16_e32 vcc, s4, v0
-; GFX8-NEXT:    v_cndmask_b32_e32 v1, v2, v1, vcc
-; GFX8-NEXT:    v_mov_b32_e32 v2, s4
-; GFX8-NEXT:    v_cmp_class_f16_e64 vcc, s4, 32
-; GFX8-NEXT:    v_cndmask_b32_e32 v2, v1, v2, vcc
-; GFX8-NEXT:    v_cmp_class_f16_e64 vcc, s5, 32
-; GFX8-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc
-; GFX8-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v1
-; GFX8-NEXT:    v_cndmask_b32_e32 v0, v1, v0, vcc
+; GFX8-NEXT:    v_cndmask_b32_e32 v0, v2, v1, vcc
 ; GFX8-NEXT:    v_and_b32_e32 v0, 0xffff, v0
 ; GFX8-NEXT:    ;;#ASMSTART
 ; GFX8-NEXT:    ; use v0
@@ -515,14 +369,7 @@ define void @s_minimum_f16(half inreg %src0, half inreg %src1) {
 ; GFX9-NEXT:    v_min_f16_e32 v1, s4, v0
 ; GFX9-NEXT:    v_mov_b32_e32 v2, 0x7e00
 ; GFX9-NEXT:    v_cmp_o_f16_e32 vcc, s4, v0
-; GFX9-NEXT:    v_cndmask_b32_e32 v1, v2, v1, vcc
-; GFX9-NEXT:    v_mov_b32_e32 v2, s4
-; GFX9-NEXT:    v_cmp_class_f16_e64 vcc, s4, 32
-; GFX9-NEXT:    v_cndmask_b32_e32 v2, v1, v2, vcc
-; GFX9-NEXT:    v_cmp_class_f16_e64 vcc, s5, 32
-; GFX9-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc
-; GFX9-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v1
-; GFX9-NEXT:    v_cndmask_b32_e32 v0, v1, v0, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v0, v2, v1, vcc
 ; GFX9-NEXT:    v_and_b32_e32 v0, 0xffff, v0
 ; GFX9-NEXT:    ;;#ASMSTART
 ; GFX9-NEXT:    ; use v0
@@ -537,17 +384,7 @@ define void @s_minimum_f16(half inreg %src0, half inreg %src1) {
 ; GFX940-NEXT:    v_mov_b32_e32 v2, 0x7e00
 ; GFX940-NEXT:    v_cmp_o_f16_e32 vcc, s0, v0
 ; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v1, v2, v1, vcc
-; GFX940-NEXT:    v_mov_b32_e32 v2, s0
-; GFX940-NEXT:    v_cmp_class_f16_e64 vcc, s0, 32
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v2, v1, v2, vcc
-; GFX940-NEXT:    v_cmp_class_f16_e64 vcc, s1, 32
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc
-; GFX940-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v1
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v0, v1, v0, vcc
+; GFX940-NEXT:    v_cndmask_b32_e32 v0, v2, v1, vcc
 ; GFX940-NEXT:    v_and_b32_e32 v0, 0xffff, v0
 ; GFX940-NEXT:    ;;#ASMSTART
 ; GFX940-NEXT:    ; use v0
@@ -559,13 +396,7 @@ define void @s_minimum_f16(half inreg %src0, half inreg %src1) {
 ; GFX10-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX10-NEXT:    v_min_f16_e64 v0, s4, s5
 ; GFX10-NEXT:    v_cmp_o_f16_e64 vcc_lo, s4, s5
-; GFX10-NEXT:    v_cmp_class_f16_e64 s6, s4, 32
 ; GFX10-NEXT:    v_cndmask_b32_e32 v0, 0x7e00, v0, vcc_lo
-; GFX10-NEXT:    v_cndmask_b32_e64 v1, v0, s4, s6
-; GFX10-NEXT:    v_cmp_class_f16_e64 s4, s5, 32
-; GFX10-NEXT:    v_cmp_eq_f16_e32 vcc_lo, 0, v0
-; GFX10-NEXT:    v_cndmask_b32_e64 v1, v1, s5, s4
-; GFX10-NEXT:    v_cndmask_b32_e32 v0, v0, v1, vcc_lo
 ; GFX10-NEXT:    v_and_b32_e32 v0, 0xffff, v0
 ; GFX10-NEXT:    ;;#ASMSTART
 ; GFX10-NEXT:    ; use v0
@@ -577,16 +408,8 @@ define void @s_minimum_f16(half inreg %src0, half inreg %src1) {
 ; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX11-NEXT:    v_min_f16_e64 v0, s0, s1
 ; GFX11-NEXT:    v_cmp_o_f16_e64 vcc_lo, s0, s1
-; GFX11-NEXT:    v_cmp_class_f16_e64 s2, s0, 32
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_1)
-; GFX11-NEXT:    v_cndmask_b32_e32 v0, 0x7e00, v0, vcc_lo
-; GFX11-NEXT:    v_cndmask_b32_e64 v1, v0, s0, s2
-; GFX11-NEXT:    v_cmp_class_f16_e64 s0, s1, 32
-; GFX11-NEXT:    v_cmp_eq_f16_e32 vcc_lo, 0, v0
 ; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_1)
-; GFX11-NEXT:    v_cndmask_b32_e64 v1, v1, s1, s0
-; GFX11-NEXT:    v_cndmask_b32_e32 v0, v0, v1, vcc_lo
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX11-NEXT:    v_cndmask_b32_e32 v0, 0x7e00, v0, vcc_lo
 ; GFX11-NEXT:    v_and_b32_e32 v0, 0xffff, v0
 ; GFX11-NEXT:    ;;#ASMSTART
 ; GFX11-NEXT:    ; use v0
@@ -652,23 +475,9 @@ define <2 x half> @v_minimum_v2f16(<2 x half> %src0, <2 x half> %src1) {
 ; GFX9-NEXT:    v_mov_b32_e32 v3, 0x7e00
 ; GFX9-NEXT:    v_cmp_o_f16_e32 vcc, v0, v1
 ; GFX9-NEXT:    v_cndmask_b32_e32 v4, v3, v2, vcc
-; GFX9-NEXT:    v_cmp_class_f16_e64 vcc, v0, 32
-; GFX9-NEXT:    v_cndmask_b32_e32 v5, v4, v0, vcc
-; GFX9-NEXT:    v_cmp_class_f16_e64 vcc, v1, 32
-; GFX9-NEXT:    v_cndmask_b32_e32 v5, v5, v1, vcc
-; GFX9-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v4
-; GFX9-NEXT:    v_lshrrev_b32_e32 v1, 16, v1
-; GFX9-NEXT:    v_lshrrev_b32_e32 v0, 16, v0
-; GFX9-NEXT:    v_cndmask_b32_e32 v4, v4, v5, vcc
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v2, 16, v2
-; GFX9-NEXT:    v_cmp_o_f16_e32 vcc, v0, v1
-; GFX9-NEXT:    v_cndmask_b32_e32 v2, v3, v2, vcc
-; GFX9-NEXT:    v_cmp_class_f16_e64 vcc, v0, 32
-; GFX9-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc
-; GFX9-NEXT:    v_cmp_class_f16_e64 vcc, v1, 32
-; GFX9-NEXT:    v_cndmask_b32_e32 v0, v0, v1, vcc
-; GFX9-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v2
-; GFX9-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc
+; GFX9-NEXT:    v_cmp_o_f16_sdwa vcc, v0, v1 src0_sel:WORD_1 src1_sel:WORD_1
+; GFX9-NEXT:    v_cndmask_b32_e32 v0, v3, v2, vcc
 ; GFX9-NEXT:    s_mov_b32 s4, 0x5040100
 ; GFX9-NEXT:    v_perm_b32 v0, v0, v4, s4
 ; GFX9-NEXT:    s_setpc_b64 s[30:31]
@@ -682,30 +491,10 @@ define <2 x half> @v_minimum_v2f16(<2 x half> %src0, <2 x half> %src1) {
 ; GFX940-NEXT:    s_mov_b32 s0, 0x5040100
 ; GFX940-NEXT:    s_nop 0
 ; GFX940-NEXT:    v_cndmask_b32_e32 v4, v3, v2, vcc
-; GFX940-NEXT:    v_cmp_class_f16_e64 vcc, v0, 32
 ; GFX940-NEXT:    v_lshrrev_b32_e32 v2, 16, v2
-; GFX940-NEXT:    s_nop 0
-; GFX940-NEXT:    v_cndmask_b32_e32 v5, v4, v0, vcc
-; GFX940-NEXT:    v_cmp_class_f16_e64 vcc, v1, 32
-; GFX940-NEXT:    v_lshrrev_b32_e32 v0, 16, v0
-; GFX940-NEXT:    s_nop 0
-; GFX940-NEXT:    v_cndmask_b32_e32 v5, v5, v1, vcc
-; GFX940-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v4
-; GFX940-NEXT:    v_lshrrev_b32_e32 v1, 16, v1
-; GFX940-NEXT:    s_nop 0
-; GFX940-NEXT:    v_cndmask_b32_e32 v4, v4, v5, vcc
-; GFX940-NEXT:    v_cmp_o_f16_e32 vcc, v0, v1
+; GFX940-NEXT:    v_cmp_o_f16_sdwa vcc, v0, v1 src0_sel:WORD_1 src1_sel:WORD_1
 ; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v2, v3, v2, vcc
-; GFX940-NEXT:    v_cmp_class_f16_e64 vcc, v0, 32
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc
-; GFX940-NEXT:    v_cmp_class_f16_e64 vcc, v1, 32
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v0, v0, v1, vcc
-; GFX940-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v2
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc
+; GFX940-NEXT:    v_cndmask_b32_e32 v0, v3, v2, vcc
 ; GFX940-NEXT:    v_perm_b32 v0, v0, v4, s0
 ; GFX940-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -713,26 +502,12 @@ define <2 x half> @v_minimum_v2f16(<2 x half> %src0, <2 x half> %src1) {
 ; GFX10:       ; %bb.0:
 ; GFX10-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX10-NEXT:    v_pk_min_f16 v2, v0, v1
-; GFX10-NEXT:    v_lshrrev_b32_e32 v3, 16, v1
-; GFX10-NEXT:    v_lshrrev_b32_e32 v4, 16, v0
 ; GFX10-NEXT:    v_cmp_o_f16_e32 vcc_lo, v0, v1
-; GFX10-NEXT:    v_lshrrev_b32_e32 v5, 16, v2
+; GFX10-NEXT:    v_lshrrev_b32_e32 v3, 16, v2
 ; GFX10-NEXT:    v_cndmask_b32_e32 v2, 0x7e00, v2, vcc_lo
-; GFX10-NEXT:    v_cmp_o_f16_e32 vcc_lo, v4, v3
-; GFX10-NEXT:    v_cndmask_b32_e32 v5, 0x7e00, v5, vcc_lo
-; GFX10-NEXT:    v_cmp_class_f16_e64 vcc_lo, v0, 32
-; GFX10-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc_lo
-; GFX10-NEXT:    v_cmp_class_f16_e64 vcc_lo, v4, 32
-; GFX10-NEXT:    v_cndmask_b32_e32 v4, v5, v4, vcc_lo
-; GFX10-NEXT:    v_cmp_class_f16_e64 vcc_lo, v1, 32
-; GFX10-NEXT:    v_cndmask_b32_e32 v0, v0, v1, vcc_lo
-; GFX10-NEXT:    v_cmp_class_f16_e64 vcc_lo, v3, 32
-; GFX10-NEXT:    v_cndmask_b32_e32 v1, v4, v3, vcc_lo
-; GFX10-NEXT:    v_cmp_eq_f16_e32 vcc_lo, 0, v2
-; GFX10-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc_lo
-; GFX10-NEXT:    v_cmp_eq_f16_e32 vcc_lo, 0, v5
-; GFX10-NEXT:    v_cndmask_b32_e32 v1, v5, v1, vcc_lo
-; GFX10-NEXT:    v_perm_b32 v0, v1, v0, 0x5040100
+; GFX10-NEXT:    v_cmp_o_f16_sdwa vcc_lo, v0, v1 src0_sel:WORD_1 src1_sel:WORD_1
+; GFX10-NEXT:    v_cndmask_b32_e32 v0, 0x7e00, v3, vcc_lo
+; GFX10-NEXT:    v_perm_b32 v0, v0, v2, 0x5040100
 ; GFX10-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX11-LABEL: v_minimum_v2f16:
@@ -744,25 +519,10 @@ define <2 x half> @v_minimum_v2f16(<2 x half> %src0, <2 x half> %src1) {
 ; GFX11-NEXT:    v_cmp_o_f16_e32 vcc_lo, v0, v1
 ; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(SKIP_1) | instid1(VALU_DEP_4)
 ; GFX11-NEXT:    v_lshrrev_b32_e32 v5, 16, v2
-; GFX11-NEXT:    v_cndmask_b32_e32 v2, 0x7e00, v2, vcc_lo
+; GFX11-NEXT:    v_cndmask_b32_e32 v0, 0x7e00, v2, vcc_lo
 ; GFX11-NEXT:    v_cmp_o_f16_e32 vcc_lo, v4, v3
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(SKIP_1) | instid1(VALU_DEP_4)
-; GFX11-NEXT:    v_cndmask_b32_e32 v5, 0x7e00, v5, vcc_lo
-; GFX11-NEXT:    v_cmp_class_f16_e64 vcc_lo, v0, 32
-; GFX11-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc_lo
-; GFX11-NEXT:    v_cmp_class_f16_e64 vcc_lo, v4, 32
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(SKIP_1) | instid1(VALU_DEP_4)
-; GFX11-NEXT:    v_cndmask_b32_e32 v4, v5, v4, vcc_lo
-; GFX11-NEXT:    v_cmp_class_f16_e64 vcc_lo, v1, 32
-; GFX11-NEXT:    v_cndmask_b32_e32 v0, v0, v1, vcc_lo
-; GFX11-NEXT:    v_cmp_class_f16_e64 vcc_lo, v3, 32
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(SKIP_1) | instid1(VALU_DEP_4)
-; GFX11-NEXT:    v_cndmask_b32_e32 v1, v4, v3, vcc_lo
-; GFX11-NEXT:    v_cmp_eq_f16_e32 vcc_lo, 0, v2
-; GFX11-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc_lo
-; GFX11-NEXT:    v_cmp_eq_f16_e32 vcc_lo, 0, v5
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(NEXT) | instid1(VALU_DEP_1)
-; GFX11-NEXT:    v_cndmask_b32_e32 v1, v5, v1, vcc_lo
+; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX11-NEXT:    v_cndmask_b32_e32 v1, 0x7e00, v5, vcc_lo
 ; GFX11-NEXT:    v_perm_b32 v0, v1, v0, 0x5040100
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -808,100 +568,25 @@ define <2 x half> @v_minimum_v2f16__nnan(<2 x half> %src0, <2 x half> %src1) {
 ; GFX9-LABEL: v_minimum_v2f16__nnan:
 ; GFX9:       ; %bb.0:
 ; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX9-NEXT:    v_lshrrev_b32_e32 v2, 16, v0
-; GFX9-NEXT:    v_pk_min_f16 v3, v0, v1
-; GFX9-NEXT:    v_lshrrev_b32_e32 v4, 16, v3
-; GFX9-NEXT:    v_cmp_class_f16_e64 vcc, v2, 32
-; GFX9-NEXT:    v_lshrrev_b32_e32 v5, 16, v1
-; GFX9-NEXT:    v_cndmask_b32_e32 v2, v4, v2, vcc
-; GFX9-NEXT:    v_cmp_class_f16_e64 vcc, v5, 32
-; GFX9-NEXT:    v_cndmask_b32_e32 v2, v2, v5, vcc
-; GFX9-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v4
-; GFX9-NEXT:    v_cndmask_b32_e32 v2, v4, v2, vcc
-; GFX9-NEXT:    v_cmp_class_f16_e64 vcc, v0, 32
-; GFX9-NEXT:    v_cndmask_b32_e32 v0, v3, v0, vcc
-; GFX9-NEXT:    v_cmp_class_f16_e64 vcc, v1, 32
-; GFX9-NEXT:    v_cndmask_b32_e32 v0, v0, v1, vcc
-; GFX9-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v3
-; GFX9-NEXT:    v_cndmask_b32_e32 v0, v3, v0, vcc
-; GFX9-NEXT:    s_mov_b32 s4, 0x5040100
-; GFX9-NEXT:    v_perm_b32 v0, v2, v0, s4
+; GFX9-NEXT:    v_pk_min_f16 v0, v0, v1
 ; GFX9-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX940-LABEL: v_minimum_v2f16__nnan:
 ; GFX940:       ; %bb.0:
 ; GFX940-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX940-NEXT:    v_lshrrev_b32_e32 v2, 16, v0
-; GFX940-NEXT:    v_pk_min_f16 v3, v0, v1
-; GFX940-NEXT:    v_cmp_class_f16_e64 vcc, v2, 32
-; GFX940-NEXT:    v_lshrrev_b32_e32 v4, 16, v3
-; GFX940-NEXT:    v_lshrrev_b32_e32 v5, 16, v1
-; GFX940-NEXT:    v_cndmask_b32_e32 v2, v4, v2, vcc
-; GFX940-NEXT:    v_cmp_class_f16_e64 vcc, v5, 32
-; GFX940-NEXT:    s_mov_b32 s0, 0x5040100
-; GFX940-NEXT:    s_nop 0
-; GFX940-NEXT:    v_cndmask_b32_e32 v2, v2, v5, vcc
-; GFX940-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v4
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v2, v4, v2, vcc
-; GFX940-NEXT:    v_cmp_class_f16_e64 vcc, v0, 32
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v0, v3, v0, vcc
-; GFX940-NEXT:    v_cmp_class_f16_e64 vcc, v1, 32
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v0, v0, v1, vcc
-; GFX940-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v3
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v0, v3, v0, vcc
-; GFX940-NEXT:    v_perm_b32 v0, v2, v0, s0
+; GFX940-NEXT:    v_pk_min_f16 v0, v0, v1
 ; GFX940-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX10-LABEL: v_minimum_v2f16__nnan:
 ; GFX10:       ; %bb.0:
 ; GFX10-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX10-NEXT:    v_pk_min_f16 v2, v0, v1
-; GFX10-NEXT:    v_lshrrev_b32_e32 v3, 16, v0
-; GFX10-NEXT:    v_lshrrev_b32_e32 v5, 16, v1
-; GFX10-NEXT:    v_lshrrev_b32_e32 v4, 16, v2
-; GFX10-NEXT:    v_cmp_class_f16_e64 vcc_lo, v3, 32
-; GFX10-NEXT:    v_cndmask_b32_e32 v3, v4, v3, vcc_lo
-; GFX10-NEXT:    v_cmp_class_f16_e64 vcc_lo, v0, 32
-; GFX10-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc_lo
-; GFX10-NEXT:    v_cmp_class_f16_e64 vcc_lo, v5, 32
-; GFX10-NEXT:    v_cndmask_b32_e32 v3, v3, v5, vcc_lo
-; GFX10-NEXT:    v_cmp_class_f16_e64 vcc_lo, v1, 32
-; GFX10-NEXT:    v_cndmask_b32_e32 v0, v0, v1, vcc_lo
-; GFX10-NEXT:    v_cmp_eq_f16_e32 vcc_lo, 0, v4
-; GFX10-NEXT:    v_cndmask_b32_e32 v1, v4, v3, vcc_lo
-; GFX10-NEXT:    v_cmp_eq_f16_e32 vcc_lo, 0, v2
-; GFX10-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc_lo
-; GFX10-NEXT:    v_perm_b32 v0, v1, v0, 0x5040100
+; GFX10-NEXT:    v_pk_min_f16 v0, v0, v1
 ; GFX10-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX11-LABEL: v_minimum_v2f16__nnan:
 ; GFX11:       ; %bb.0:
 ; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX11-NEXT:    v_pk_min_f16 v2, v0, v1
-; GFX11-NEXT:    v_lshrrev_b32_e32 v3, 16, v0
-; GFX11-NEXT:    v_lshrrev_b32_e32 v5, 16, v1
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_3)
-; GFX11-NEXT:    v_lshrrev_b32_e32 v4, 16, v2
-; GFX11-NEXT:    v_cmp_class_f16_e64 vcc_lo, v3, 32
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(SKIP_3) | instid1(VALU_DEP_4)
-; GFX11-NEXT:    v_cndmask_b32_e32 v3, v4, v3, vcc_lo
-; GFX11-NEXT:    v_cmp_class_f16_e64 vcc_lo, v0, 32
-; GFX11-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc_lo
-; GFX11-NEXT:    v_cmp_class_f16_e64 vcc_lo, v5, 32
-; GFX11-NEXT:    v_cndmask_b32_e32 v3, v3, v5, vcc_lo
-; GFX11-NEXT:    v_cmp_class_f16_e64 vcc_lo, v1, 32
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(SKIP_1) | instid1(VALU_DEP_4)
-; GFX11-NEXT:    v_cndmask_b32_e32 v0, v0, v1, vcc_lo
-; GFX11-NEXT:    v_cmp_eq_f16_e32 vcc_lo, 0, v4
-; GFX11-NEXT:    v_cndmask_b32_e32 v1, v4, v3, vcc_lo
-; GFX11-NEXT:    v_cmp_eq_f16_e32 vcc_lo, 0, v2
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(NEXT) | instid1(VALU_DEP_1)
-; GFX11-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc_lo
-; GFX11-NEXT:    v_perm_b32 v0, v1, v0, 0x5040100
+; GFX11-NEXT:    v_pk_min_f16 v0, v0, v1
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX12-LABEL: v_minimum_v2f16__nnan:
@@ -1101,30 +786,16 @@ define void @s_minimum_v2f16(<2 x half> inreg %src0, <2 x half> inreg %src1) {
 ; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX9-NEXT:    v_mov_b32_e32 v0, s5
 ; GFX9-NEXT:    v_mov_b32_e32 v1, s5
+; GFX9-NEXT:    s_lshr_b32 s5, s5, 16
 ; GFX9-NEXT:    v_pk_min_f16 v1, s4, v1
 ; GFX9-NEXT:    v_mov_b32_e32 v2, 0x7e00
 ; GFX9-NEXT:    v_cmp_o_f16_e32 vcc, s4, v0
-; GFX9-NEXT:    v_cndmask_b32_e32 v3, v2, v1, vcc
-; GFX9-NEXT:    v_mov_b32_e32 v4, s4
-; GFX9-NEXT:    v_cmp_class_f16_e64 vcc, s4, 32
-; GFX9-NEXT:    v_cndmask_b32_e32 v4, v3, v4, vcc
-; GFX9-NEXT:    v_cmp_class_f16_e64 vcc, s5, 32
-; GFX9-NEXT:    v_cndmask_b32_e32 v0, v4, v0, vcc
-; GFX9-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v3
-; GFX9-NEXT:    s_lshr_b32 s5, s5, 16
-; GFX9-NEXT:    v_cndmask_b32_e32 v0, v3, v0, vcc
 ; GFX9-NEXT:    s_lshr_b32 s4, s4, 16
 ; GFX9-NEXT:    v_mov_b32_e32 v3, s5
+; GFX9-NEXT:    v_cndmask_b32_e32 v0, v2, v1, vcc
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v1, 16, v1
 ; GFX9-NEXT:    v_cmp_o_f16_e32 vcc, s4, v3
 ; GFX9-NEXT:    v_cndmask_b32_e32 v1, v2, v1, vcc
-; GFX9-NEXT:    v_mov_b32_e32 v2, s4
-; GFX9-NEXT:    v_cmp_class_f16_e64 vcc, s4, 32
-; GFX9-NEXT:    v_cndmask_b32_e32 v2, v1, v2, vcc
-; GFX9-NEXT:    v_cmp_class_f16_e64 vcc, s5, 32
-; GFX9-NEXT:    v_cndmask_b32_e32 v2, v2, v3, vcc
-; GFX9-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v1
-; GFX9-NEXT:    v_cndmask_b32_e32 v1, v1, v2, vcc
 ; GFX9-NEXT:    v_and_b32_e32 v0, 0xffff, v0
 ; GFX9-NEXT:    v_lshl_or_b32 v0, v1, 16, v0
 ; GFX9-NEXT:    ;;#ASMSTART
@@ -1137,38 +808,18 @@ define void @s_minimum_v2f16(<2 x half> inreg %src0, <2 x half> inreg %src1) {
 ; GFX940-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX940-NEXT:    v_mov_b32_e32 v0, s1
 ; GFX940-NEXT:    v_mov_b32_e32 v1, s1
+; GFX940-NEXT:    s_lshr_b32 s1, s1, 16
 ; GFX940-NEXT:    v_pk_min_f16 v1, s0, v1
 ; GFX940-NEXT:    v_mov_b32_e32 v2, 0x7e00
 ; GFX940-NEXT:    v_cmp_o_f16_e32 vcc, s0, v0
-; GFX940-NEXT:    v_mov_b32_e32 v4, s0
-; GFX940-NEXT:    s_nop 0
-; GFX940-NEXT:    v_cndmask_b32_e32 v3, v2, v1, vcc
-; GFX940-NEXT:    v_cmp_class_f16_e64 vcc, s0, 32
 ; GFX940-NEXT:    s_lshr_b32 s0, s0, 16
-; GFX940-NEXT:    v_lshrrev_b32_e32 v1, 16, v1
-; GFX940-NEXT:    v_cndmask_b32_e32 v4, v3, v4, vcc
-; GFX940-NEXT:    v_cmp_class_f16_e64 vcc, s1, 32
-; GFX940-NEXT:    s_lshr_b32 s1, s1, 16
-; GFX940-NEXT:    s_nop 0
-; GFX940-NEXT:    v_cndmask_b32_e32 v0, v4, v0, vcc
-; GFX940-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v3
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v0, v3, v0, vcc
 ; GFX940-NEXT:    v_mov_b32_e32 v3, s1
+; GFX940-NEXT:    v_cndmask_b32_e32 v0, v2, v1, vcc
+; GFX940-NEXT:    v_lshrrev_b32_e32 v1, 16, v1
 ; GFX940-NEXT:    v_cmp_o_f16_e32 vcc, s0, v3
 ; GFX940-NEXT:    v_and_b32_e32 v0, 0xffff, v0
 ; GFX940-NEXT:    s_nop 0
 ; GFX940-NEXT:    v_cndmask_b32_e32 v1, v2, v1, vcc
-; GFX940-NEXT:    v_mov_b32_e32 v2, s0
-; GFX940-NEXT:    v_cmp_class_f16_e64 vcc, s0, 32
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v2, v1, v2, vcc
-; GFX940-NEXT:    v_cmp_class_f16_e64 vcc, s1, 32
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v2, v2, v3, vcc
-; GFX940-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v1
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v1, v1, v2, vcc
 ; GFX940-NEXT:    v_lshl_or_b32 v0, v1, 16, v0
 ; GFX940-NEXT:    ;;#ASMSTART
 ; GFX940-NEXT:    ; use v0
@@ -1181,24 +832,12 @@ define void @s_minimum_v2f16(<2 x half> inreg %src0, <2 x half> inreg %src1) {
 ; GFX10-NEXT:    v_pk_min_f16 v0, s4, s5
 ; GFX10-NEXT:    v_cmp_o_f16_e64 vcc_lo, s4, s5
 ; GFX10-NEXT:    s_lshr_b32 s6, s5, 16
-; GFX10-NEXT:    s_lshr_b32 s7, s4, 16
-; GFX10-NEXT:    v_cmp_class_f16_e64 s8, s4, 32
+; GFX10-NEXT:    s_lshr_b32 s4, s4, 16
 ; GFX10-NEXT:    v_lshrrev_b32_e32 v1, 16, v0
 ; GFX10-NEXT:    v_cndmask_b32_e32 v0, 0x7e00, v0, vcc_lo
-; GFX10-NEXT:    v_cmp_o_f16_e64 vcc_lo, s7, s6
-; GFX10-NEXT:    v_cndmask_b32_e64 v2, v0, s4, s8
-; GFX10-NEXT:    v_cndmask_b32_e32 v1, 0x7e00, v1, vcc_lo
-; GFX10-NEXT:    v_cmp_class_f16_e64 s4, s7, 32
-; GFX10-NEXT:    v_cmp_eq_f16_e32 vcc_lo, 0, v0
-; GFX10-NEXT:    v_cndmask_b32_e64 v3, v1, s7, s4
-; GFX10-NEXT:    v_cmp_class_f16_e64 s4, s5, 32
-; GFX10-NEXT:    v_cndmask_b32_e64 v2, v2, s5, s4
-; GFX10-NEXT:    v_cmp_class_f16_e64 s4, s6, 32
-; GFX10-NEXT:    v_cndmask_b32_e32 v0, v0, v2, vcc_lo
-; GFX10-NEXT:    v_cndmask_b32_e64 v3, v3, s6, s4
-; GFX10-NEXT:    v_cmp_eq_f16_e32 vcc_lo, 0, v1
+; GFX10-NEXT:    v_cmp_o_f16_e64 vcc_lo, s4, s6
 ; GFX10-NEXT:    v_and_b32_e32 v0, 0xffff, v0
-; GFX10-NEXT:    v_cndmask_b32_e32 v1, v1, v3, vcc_lo
+; GFX10-NEXT:    v_cndmask_b32_e32 v1, 0x7e00, v1, vcc_lo
 ; GFX10-NEXT:    v_lshl_or_b32 v0, v1, 16, v0
 ; GFX10-NEXT:    ;;#ASMSTART
 ; GFX10-NEXT:    ; use v0
@@ -1211,27 +850,14 @@ define void @s_minimum_v2f16(<2 x half> inreg %src0, <2 x half> inreg %src1) {
 ; GFX11-NEXT:    v_pk_min_f16 v0, s0, s1
 ; GFX11-NEXT:    v_cmp_o_f16_e64 vcc_lo, s0, s1
 ; GFX11-NEXT:    s_lshr_b32 s2, s1, 16
-; GFX11-NEXT:    s_lshr_b32 s3, s0, 16
-; GFX11-NEXT:    v_cmp_class_f16_e64 s4, s0, 32
+; GFX11-NEXT:    s_lshr_b32 s0, s0, 16
+; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(SKIP_2) | instid1(VALU_DEP_2)
 ; GFX11-NEXT:    v_lshrrev_b32_e32 v1, 16, v0
 ; GFX11-NEXT:    v_cndmask_b32_e32 v0, 0x7e00, v0, vcc_lo
-; GFX11-NEXT:    v_cmp_o_f16_e64 vcc_lo, s3, s2
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_4)
-; GFX11-NEXT:    v_cndmask_b32_e64 v2, v0, s0, s4
+; GFX11-NEXT:    v_cmp_o_f16_e64 vcc_lo, s0, s2
+; GFX11-NEXT:    v_and_b32_e32 v0, 0xffff, v0
+; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(NEXT) | instid1(VALU_DEP_1)
 ; GFX11-NEXT:    v_cndmask_b32_e32 v1, 0x7e00, v1, vcc_lo
-; GFX11-NEXT:    v_cmp_class_f16_e64 s0, s3, 32
-; GFX11-NEXT:    v_cmp_eq_f16_e32 vcc_lo, 0, v0
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(SKIP_1) | instid1(VALU_DEP_1)
-; GFX11-NEXT:    v_cndmask_b32_e64 v3, v1, s3, s0
-; GFX11-NEXT:    v_cmp_class_f16_e64 s0, s1, 32
-; GFX11-NEXT:    v_cndmask_b32_e64 v2, v2, s1, s0
-; GFX11-NEXT:    v_cmp_class_f16_e64 s0, s2, 32
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_3)
-; GFX11-NEXT:    v_cndmask_b32_e64 v3, v3, s2, s0
-; GFX11-NEXT:    v_cndmask_b32_e32 v0, v0, v2, vcc_lo
-; GFX11-NEXT:    v_cmp_eq_f16_e32 vcc_lo, 0, v1
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_1)
-; GFX11-NEXT:    v_dual_cndmask_b32 v1, v1, v3 :: v_dual_and_b32 v0, 0xffff, v0
 ; GFX11-NEXT:    v_lshl_or_b32 v0, v1, 16, v0
 ; GFX11-NEXT:    ;;#ASMSTART
 ; GFX11-NEXT:    ; use v0
@@ -1265,31 +891,13 @@ define <3 x half> @v_minimum_v3f16(<3 x half> %src0, <3 x half> %src1) {
 ; GFX8-NEXT:    v_min_f16_e32 v6, v5, v4
 ; GFX8-NEXT:    v_mov_b32_e32 v7, 0x7e00
 ; GFX8-NEXT:    v_cmp_o_f16_e32 vcc, v5, v4
-; GFX8-NEXT:    v_cndmask_b32_e32 v6, v7, v6, vcc
-; GFX8-NEXT:    v_cmp_class_f16_e64 vcc, v5, 32
-; GFX8-NEXT:    v_cndmask_b32_e32 v5, v6, v5, vcc
-; GFX8-NEXT:    v_cmp_class_f16_e64 vcc, v4, 32
-; GFX8-NEXT:    v_cndmask_b32_e32 v4, v5, v4, vcc
-; GFX8-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v6
-; GFX8-NEXT:    v_cndmask_b32_e32 v4, v6, v4, vcc
+; GFX8-NEXT:    v_cndmask_b32_e32 v4, v7, v6, vcc
 ; GFX8-NEXT:    v_min_f16_e32 v5, v1, v3
 ; GFX8-NEXT:    v_cmp_o_f16_e32 vcc, v1, v3
-; GFX8-NEXT:    v_cndmask_b32_e32 v5, v7, v5, vcc
-; GFX8-NEXT:    v_cmp_class_f16_e64 vcc, v1, 32
-; GFX8-NEXT:    v_cndmask_b32_e32 v1, v5, v1, vcc
-; GFX8-NEXT:    v_cmp_class_f16_e64 vcc, v3, 32
-; GFX8-NEXT:    v_cndmask_b32_e32 v1, v1, v3, vcc
-; GFX8-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v5
-; GFX8-NEXT:    v_cndmask_b32_e32 v1, v5, v1, vcc
+; GFX8-NEXT:    v_cndmask_b32_e32 v1, v7, v5, vcc
 ; GFX8-NEXT:    v_min_f16_e32 v3, v0, v2
 ; GFX8-NEXT:    v_cmp_o_f16_e32 vcc, v0, v2
-; GFX8-NEXT:    v_cndmask_b32_e32 v3, v7, v3, vcc
-; GFX8-NEXT:    v_cmp_class_f16_e64 vcc, v0, 32
-; GFX8-NEXT:    v_cndmask_b32_e32 v0, v3, v0, vcc
-; GFX8-NEXT:    v_cmp_class_f16_e64 vcc, v2, 32
-; GFX8-NEXT:    v_cndmask_b32_e32 v0, v0, v2, vcc
-; GFX8-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v3
-; GFX8-NEXT:    v_cndmask_b32_e32 v0, v3, v0, vcc
+; GFX8-NEXT:    v_cndmask_b32_e32 v0, v7, v3, vcc
 ; GFX8-NEXT:    v_lshlrev_b32_e32 v2, 16, v4
 ; GFX8-NEXT:    v_or_b32_sdwa v0, v0, v2 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
 ; GFX8-NEXT:    s_setpc_b64 s[30:31]
@@ -1300,33 +908,13 @@ define <3 x half> @v_minimum_v3f16(<3 x half> %src0, <3 x half> %src1) {
 ; GFX9-NEXT:    v_pk_min_f16 v4, v1, v3
 ; GFX9-NEXT:    v_mov_b32_e32 v5, 0x7e00
 ; GFX9-NEXT:    v_cmp_o_f16_e32 vcc, v1, v3
-; GFX9-NEXT:    v_cndmask_b32_e32 v4, v5, v4, vcc
-; GFX9-NEXT:    v_cmp_class_f16_e64 vcc, v1, 32
-; GFX9-NEXT:    v_cndmask_b32_e32 v1, v4, v1, vcc
-; GFX9-NEXT:    v_cmp_class_f16_e64 vcc, v3, 32
-; GFX9-NEXT:    v_cndmask_b32_e32 v1, v1, v3, vcc
-; GFX9-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v4
-; GFX9-NEXT:    v_cndmask_b32_e32 v1, v4, v1, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v1, v5, v4, vcc
 ; GFX9-NEXT:    v_pk_min_f16 v3, v0, v2
 ; GFX9-NEXT:    v_cmp_o_f16_e32 vcc, v0, v2
 ; GFX9-NEXT:    v_cndmask_b32_e32 v4, v5, v3, vcc
-; GFX9-NEXT:    v_cmp_class_f16_e64 vcc, v0, 32
-; GFX9-NEXT:    v_cndmask_b32_e32 v6, v4, v0, vcc
-; GFX9-NEXT:    v_cmp_class_f16_e64 vcc, v2, 32
-; GFX9-NEXT:    v_cndmask_b32_e32 v6, v6, v2, vcc
-; GFX9-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v4
-; GFX9-NEXT:    v_lshrrev_b32_e32 v2, 16, v2
-; GFX9-NEXT:    v_lshrrev_b32_e32 v0, 16, v0
-; GFX9-NEXT:    v_cndmask_b32_e32 v4, v4, v6, vcc
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v3, 16, v3
-; GFX9-NEXT:    v_cmp_o_f16_e32 vcc, v0, v2
-; GFX9-NEXT:    v_cndmask_b32_e32 v3, v5, v3, vcc
-; GFX9-NEXT:    v_cmp_class_f16_e64 vcc, v0, 32
-; GFX9-NEXT:    v_cndmask_b32_e32 v0, v3, v0, vcc
-; GFX9-NEXT:    v_cmp_class_f16_e64 vcc, v2, 32
-; GFX9-NEXT:    v_cndmask_b32_e32 v0, v0, v2, vcc
-; GFX9-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v3
-; GFX9-NEXT:    v_cndmask_b32_e32 v0, v3, v0, vcc
+; GFX9-NEXT:    v_cmp_o_f16_sdwa vcc, v0, v2 src0_sel:WORD_1 src1_sel:WORD_1
+; GFX9-NEXT:    v_cndmask_b32_e32 v0, v5, v3, vcc
 ; GFX9-NEXT:    s_mov_b32 s4, 0x5040100
 ; GFX9-NEXT:    v_perm_b32 v0, v0, v4, s4
 ; GFX9-NEXT:    s_setpc_b64 s[30:31]
@@ -1337,46 +925,16 @@ define <3 x half> @v_minimum_v3f16(<3 x half> %src0, <3 x half> %src1) {
 ; GFX940-NEXT:    v_pk_min_f16 v4, v1, v3
 ; GFX940-NEXT:    v_mov_b32_e32 v5, 0x7e00
 ; GFX940-NEXT:    v_cmp_o_f16_e32 vcc, v1, v3
-; GFX940-NEXT:    s_mov_b32 s0, 0x5040100
-; GFX940-NEXT:    s_nop 0
-; GFX940-NEXT:    v_cndmask_b32_e32 v4, v5, v4, vcc
-; GFX940-NEXT:    v_cmp_class_f16_e64 vcc, v1, 32
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v1, v4, v1, vcc
-; GFX940-NEXT:    v_cmp_class_f16_e64 vcc, v3, 32
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v1, v1, v3, vcc
-; GFX940-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v4
 ; GFX940-NEXT:    v_pk_min_f16 v3, v0, v2
-; GFX940-NEXT:    s_nop 0
-; GFX940-NEXT:    v_cndmask_b32_e32 v1, v4, v1, vcc
+; GFX940-NEXT:    s_mov_b32 s0, 0x5040100
+; GFX940-NEXT:    v_cndmask_b32_e32 v1, v5, v4, vcc
 ; GFX940-NEXT:    v_cmp_o_f16_e32 vcc, v0, v2
 ; GFX940-NEXT:    s_nop 1
 ; GFX940-NEXT:    v_cndmask_b32_e32 v4, v5, v3, vcc
-; GFX940-NEXT:    v_cmp_class_f16_e64 vcc, v0, 32
 ; GFX940-NEXT:    v_lshrrev_b32_e32 v3, 16, v3
-; GFX940-NEXT:    s_nop 0
-; GFX940-NEXT:    v_cndmask_b32_e32 v6, v4, v0, vcc
-; GFX940-NEXT:    v_cmp_class_f16_e64 vcc, v2, 32
-; GFX940-NEXT:    v_lshrrev_b32_e32 v0, 16, v0
-; GFX940-NEXT:    s_nop 0
-; GFX940-NEXT:    v_cndmask_b32_e32 v6, v6, v2, vcc
-; GFX940-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v4
-; GFX940-NEXT:    v_lshrrev_b32_e32 v2, 16, v2
-; GFX940-NEXT:    s_nop 0
-; GFX940-NEXT:    v_cndmask_b32_e32 v4, v4, v6, vcc
-; GFX940-NEXT:    v_cmp_o_f16_e32 vcc, v0, v2
+; GFX940-NEXT:    v_cmp_o_f16_sdwa vcc, v0, v2 src0_sel:WORD_1 src1_sel:WORD_1
 ; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v3, v5, v3, vcc
-; GFX940-NEXT:    v_cmp_class_f16_e64 vcc, v0, 32
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v0, v3, v0, vcc
-; GFX940-NEXT:    v_cmp_class_f16_e64 vcc, v2, 32
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v0, v0, v2, vcc
-; GFX940-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v3
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v0, v3, v0, vcc
+; GFX940-NEXT:    v_cndmask_b32_e32 v0, v5, v3, vcc
 ; GFX940-NEXT:    v_perm_b32 v0, v0, v4, s0
 ; GFX940-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -1384,35 +942,15 @@ define <3 x half> @v_minimum_v3f16(<3 x half> %src0, <3 x half> %src1) {
 ; GFX10:       ; %bb.0:
 ; GFX10-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX10-NEXT:    v_pk_min_f16 v4, v0, v2
-; GFX10-NEXT:    v_lshrrev_b32_e32 v5, 16, v2
-; GFX10-NEXT:    v_lshrrev_b32_e32 v6, 16, v0
 ; GFX10-NEXT:    v_cmp_o_f16_e32 vcc_lo, v0, v2
-; GFX10-NEXT:    v_pk_min_f16 v8, v1, v3
-; GFX10-NEXT:    v_lshrrev_b32_e32 v7, 16, v4
+; GFX10-NEXT:    v_lshrrev_b32_e32 v5, 16, v4
 ; GFX10-NEXT:    v_cndmask_b32_e32 v4, 0x7e00, v4, vcc_lo
-; GFX10-NEXT:    v_cmp_o_f16_e32 vcc_lo, v6, v5
-; GFX10-NEXT:    v_cndmask_b32_e32 v7, 0x7e00, v7, vcc_lo
-; GFX10-NEXT:    v_cmp_class_f16_e64 vcc_lo, v0, 32
-; GFX10-NEXT:    v_cndmask_b32_e32 v0, v4, v0, vcc_lo
-; GFX10-NEXT:    v_cmp_class_f16_e64 vcc_lo, v6, 32
-; GFX10-NEXT:    v_cndmask_b32_e32 v6, v7, v6, vcc_lo
+; GFX10-NEXT:    v_cmp_o_f16_sdwa vcc_lo, v0, v2 src0_sel:WORD_1 src1_sel:WORD_1
+; GFX10-NEXT:    v_pk_min_f16 v2, v1, v3
+; GFX10-NEXT:    v_cndmask_b32_e32 v0, 0x7e00, v5, vcc_lo
 ; GFX10-NEXT:    v_cmp_o_f16_e32 vcc_lo, v1, v3
-; GFX10-NEXT:    v_cndmask_b32_e32 v8, 0x7e00, v8, vcc_lo
-; GFX10-NEXT:    v_cmp_class_f16_e64 vcc_lo, v2, 32
-; GFX10-NEXT:    v_cndmask_b32_e32 v0, v0, v2, vcc_lo
-; GFX10-NEXT:    v_cmp_class_f16_e64 vcc_lo, v5, 32
-; GFX10-NEXT:    v_cndmask_b32_e32 v2, v6, v5, vcc_lo
-; GFX10-NEXT:    v_cmp_class_f16_e64 vcc_lo, v1, 32
-; GFX10-NEXT:    v_cndmask_b32_e32 v1, v8, v1, vcc_lo
-; GFX10-NEXT:    v_cmp_eq_f16_e32 vcc_lo, 0, v4
-; GFX10-NEXT:    v_cndmask_b32_e32 v0, v4, v0, vcc_lo
-; GFX10-NEXT:    v_cmp_eq_f16_e32 vcc_lo, 0, v7
-; GFX10-NEXT:    v_cndmask_b32_e32 v2, v7, v2, vcc_lo
-; GFX10-NEXT:    v_cmp_class_f16_e64 vcc_lo, v3, 32
-; GFX10-NEXT:    v_perm_b32 v0, v2, v0, 0x5040100
-; GFX10-NEXT:    v_cndmask_b32_e32 v1, v1, v3, vcc_lo
-; GFX10-NEXT:    v_cmp_eq_f16_e32 vcc_lo, 0, v8
-; GFX10-NEXT:    v_cndmask_b32_e32 v1, v8, v1, vcc_lo
+; GFX10-NEXT:    v_perm_b32 v0, v0, v4, 0x5040100
+; GFX10-NEXT:    v_cndmask_b32_e32 v1, 0x7e00, v2, vcc_lo
 ; GFX10-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX11-LABEL: v_minimum_v3f16:
@@ -1422,35 +960,17 @@ define <3 x half> @v_minimum_v3f16(<3 x half> %src0, <3 x half> %src1) {
 ; GFX11-NEXT:    v_lshrrev_b32_e32 v5, 16, v2
 ; GFX11-NEXT:    v_lshrrev_b32_e32 v6, 16, v0
 ; GFX11-NEXT:    v_cmp_o_f16_e32 vcc_lo, v0, v2
-; GFX11-NEXT:    v_pk_min_f16 v8, v1, v3
+; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(SKIP_1) | instid1(VALU_DEP_4)
 ; GFX11-NEXT:    v_lshrrev_b32_e32 v7, 16, v4
-; GFX11-NEXT:    v_cndmask_b32_e32 v4, 0x7e00, v4, vcc_lo
+; GFX11-NEXT:    v_cndmask_b32_e32 v0, 0x7e00, v4, vcc_lo
 ; GFX11-NEXT:    v_cmp_o_f16_e32 vcc_lo, v6, v5
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(SKIP_1) | instid1(VALU_DEP_4)
-; GFX11-NEXT:    v_cndmask_b32_e32 v7, 0x7e00, v7, vcc_lo
-; GFX11-NEXT:    v_cmp_class_f16_e64 vcc_lo, v0, 32
-; GFX11-NEXT:    v_cndmask_b32_e32 v0, v4, v0, vcc_lo
-; GFX11-NEXT:    v_cmp_class_f16_e64 vcc_lo, v6, 32
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_4)
-; GFX11-NEXT:    v_cndmask_b32_e32 v6, v7, v6, vcc_lo
+; GFX11-NEXT:    v_pk_min_f16 v4, v1, v3
+; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(SKIP_1) | instid1(VALU_DEP_2)
+; GFX11-NEXT:    v_cndmask_b32_e32 v2, 0x7e00, v7, vcc_lo
 ; GFX11-NEXT:    v_cmp_o_f16_e32 vcc_lo, v1, v3
-; GFX11-NEXT:    v_cndmask_b32_e32 v8, 0x7e00, v8, vcc_lo
-; GFX11-NEXT:    v_cmp_class_f16_e64 vcc_lo, v2, 32
-; GFX11-NEXT:    v_cndmask_b32_e32 v0, v0, v2, vcc_lo
-; GFX11-NEXT:    v_cmp_class_f16_e64 vcc_lo, v5, 32
-; GFX11-NEXT:    v_cndmask_b32_e32 v2, v6, v5, vcc_lo
-; GFX11-NEXT:    v_cmp_class_f16_e64 vcc_lo, v1, 32
-; GFX11-NEXT:    v_cndmask_b32_e32 v1, v8, v1, vcc_lo
-; GFX11-NEXT:    v_cmp_eq_f16_e32 vcc_lo, 0, v4
-; GFX11-NEXT:    v_cndmask_b32_e32 v0, v4, v0, vcc_lo
-; GFX11-NEXT:    v_cmp_eq_f16_e32 vcc_lo, 0, v7
-; GFX11-NEXT:    v_cndmask_b32_e32 v2, v7, v2, vcc_lo
-; GFX11-NEXT:    v_cmp_class_f16_e64 vcc_lo, v3, 32
-; GFX11-NEXT:    v_cndmask_b32_e32 v1, v1, v3, vcc_lo
-; GFX11-NEXT:    v_cmp_eq_f16_e32 vcc_lo, 0, v8
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_2)
-; GFX11-NEXT:    v_cndmask_b32_e32 v1, v8, v1, vcc_lo
 ; GFX11-NEXT:    v_perm_b32 v0, v2, v0, 0x5040100
+; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_4)
+; GFX11-NEXT:    v_cndmask_b32_e32 v1, 0x7e00, v4, vcc_lo
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX12-LABEL: v_minimum_v3f16:
@@ -1471,160 +991,38 @@ define <3 x half> @v_minimum_v3f16__nnan(<3 x half> %src0, <3 x half> %src1) {
 ; GFX8-LABEL: v_minimum_v3f16__nnan:
 ; GFX8:       ; %bb.0:
 ; GFX8-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX8-NEXT:    v_lshrrev_b32_e32 v4, 16, v2
-; GFX8-NEXT:    v_lshrrev_b32_e32 v5, 16, v0
-; GFX8-NEXT:    v_min_f16_e32 v6, v5, v4
-; GFX8-NEXT:    v_cmp_class_f16_e64 vcc, v5, 32
-; GFX8-NEXT:    v_cndmask_b32_e32 v5, v6, v5, vcc
-; GFX8-NEXT:    v_cmp_class_f16_e64 vcc, v4, 32
-; GFX8-NEXT:    v_cndmask_b32_e32 v4, v5, v4, vcc
-; GFX8-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v6
-; GFX8-NEXT:    v_cndmask_b32_e32 v4, v6, v4, vcc
-; GFX8-NEXT:    v_min_f16_e32 v5, v1, v3
-; GFX8-NEXT:    v_cmp_class_f16_e64 vcc, v1, 32
-; GFX8-NEXT:    v_cndmask_b32_e32 v1, v5, v1, vcc
-; GFX8-NEXT:    v_cmp_class_f16_e64 vcc, v3, 32
-; GFX8-NEXT:    v_cndmask_b32_e32 v1, v1, v3, vcc
-; GFX8-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v5
-; GFX8-NEXT:    v_cndmask_b32_e32 v1, v5, v1, vcc
-; GFX8-NEXT:    v_min_f16_e32 v3, v0, v2
-; GFX8-NEXT:    v_cmp_class_f16_e64 vcc, v0, 32
-; GFX8-NEXT:    v_cndmask_b32_e32 v0, v3, v0, vcc
-; GFX8-NEXT:    v_cmp_class_f16_e64 vcc, v2, 32
-; GFX8-NEXT:    v_cndmask_b32_e32 v0, v0, v2, vcc
-; GFX8-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v3
-; GFX8-NEXT:    v_cndmask_b32_e32 v0, v3, v0, vcc
-; GFX8-NEXT:    v_lshlrev_b32_e32 v2, 16, v4
-; GFX8-NEXT:    v_or_b32_sdwa v0, v0, v2 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
+; GFX8-NEXT:    v_min_f16_sdwa v4, v0, v2 dst_sel:WORD_1 dst_unused:UNUSED_PAD src0_sel:WORD_1 src1_sel:WORD_1
+; GFX8-NEXT:    v_min_f16_e32 v0, v0, v2
+; GFX8-NEXT:    v_min_f16_e32 v1, v1, v3
+; GFX8-NEXT:    v_or_b32_e32 v0, v0, v4
 ; GFX8-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX9-LABEL: v_minimum_v3f16__nnan:
 ; GFX9:       ; %bb.0:
 ; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX9-NEXT:    v_lshrrev_b32_e32 v4, 16, v0
-; GFX9-NEXT:    v_pk_min_f16 v5, v0, v2
-; GFX9-NEXT:    v_lshrrev_b32_e32 v6, 16, v5
-; GFX9-NEXT:    v_cmp_class_f16_e64 vcc, v4, 32
-; GFX9-NEXT:    v_lshrrev_b32_e32 v7, 16, v2
-; GFX9-NEXT:    v_cndmask_b32_e32 v4, v6, v4, vcc
-; GFX9-NEXT:    v_cmp_class_f16_e64 vcc, v7, 32
-; GFX9-NEXT:    v_cndmask_b32_e32 v4, v4, v7, vcc
-; GFX9-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v6
-; GFX9-NEXT:    v_cndmask_b32_e32 v4, v6, v4, vcc
-; GFX9-NEXT:    v_pk_min_f16 v6, v1, v3
-; GFX9-NEXT:    v_cmp_class_f16_e64 vcc, v1, 32
-; GFX9-NEXT:    v_cndmask_b32_e32 v1, v6, v1, vcc
-; GFX9-NEXT:    v_cmp_class_f16_e64 vcc, v3, 32
-; GFX9-NEXT:    v_cndmask_b32_e32 v1, v1, v3, vcc
-; GFX9-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v6
-; GFX9-NEXT:    v_cndmask_b32_e32 v1, v6, v1, vcc
-; GFX9-NEXT:    v_cmp_class_f16_e64 vcc, v0, 32
-; GFX9-NEXT:    v_cndmask_b32_e32 v0, v5, v0, vcc
-; GFX9-NEXT:    v_cmp_class_f16_e64 vcc, v2, 32
-; GFX9-NEXT:    v_cndmask_b32_e32 v0, v0, v2, vcc
-; GFX9-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v5
-; GFX9-NEXT:    v_cndmask_b32_e32 v0, v5, v0, vcc
-; GFX9-NEXT:    s_mov_b32 s4, 0x5040100
-; GFX9-NEXT:    v_perm_b32 v0, v4, v0, s4
+; GFX9-NEXT:    v_pk_min_f16 v0, v0, v2
+; GFX9-NEXT:    v_pk_min_f16 v1, v1, v3
 ; GFX9-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX940-LABEL: v_minimum_v3f16__nnan:
 ; GFX940:       ; %bb.0:
 ; GFX940-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX940-NEXT:    v_lshrrev_b32_e32 v4, 16, v0
-; GFX940-NEXT:    v_pk_min_f16 v5, v0, v2
-; GFX940-NEXT:    v_cmp_class_f16_e64 vcc, v4, 32
-; GFX940-NEXT:    v_lshrrev_b32_e32 v6, 16, v5
-; GFX940-NEXT:    v_lshrrev_b32_e32 v7, 16, v2
-; GFX940-NEXT:    v_cndmask_b32_e32 v4, v6, v4, vcc
-; GFX940-NEXT:    v_cmp_class_f16_e64 vcc, v7, 32
-; GFX940-NEXT:    s_mov_b32 s0, 0x5040100
-; GFX940-NEXT:    s_nop 0
-; GFX940-NEXT:    v_cndmask_b32_e32 v4, v4, v7, vcc
-; GFX940-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v6
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v4, v6, v4, vcc
-; GFX940-NEXT:    v_pk_min_f16 v6, v1, v3
-; GFX940-NEXT:    v_cmp_class_f16_e64 vcc, v1, 32
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v1, v6, v1, vcc
-; GFX940-NEXT:    v_cmp_class_f16_e64 vcc, v3, 32
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v1, v1, v3, vcc
-; GFX940-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v6
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v1, v6, v1, vcc
-; GFX940-NEXT:    v_cmp_class_f16_e64 vcc, v0, 32
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v0, v5, v0, vcc
-; GFX940-NEXT:    v_cmp_class_f16_e64 vcc, v2, 32
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v0, v0, v2, vcc
-; GFX940-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v5
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v0, v5, v0, vcc
-; GFX940-NEXT:    v_perm_b32 v0, v4, v0, s0
+; GFX940-NEXT:    v_pk_min_f16 v0, v0, v2
+; GFX940-NEXT:    v_pk_min_f16 v1, v1, v3
 ; GFX940-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX10-LABEL: v_minimum_v3f16__nnan:
 ; GFX10:       ; %bb.0:
 ; GFX10-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX10-NEXT:    v_pk_min_f16 v4, v0, v2
-; GFX10-NEXT:    v_lshrrev_b32_e32 v5, 16, v0
-; GFX10-NEXT:    v_cmp_class_f16_e64 vcc_lo, v0, 32
-; GFX10-NEXT:    v_lshrrev_b32_e32 v7, 16, v2
-; GFX10-NEXT:    v_pk_min_f16 v8, v1, v3
-; GFX10-NEXT:    v_lshrrev_b32_e32 v6, 16, v4
-; GFX10-NEXT:    v_cndmask_b32_e32 v0, v4, v0, vcc_lo
-; GFX10-NEXT:    v_cmp_class_f16_e64 vcc_lo, v5, 32
-; GFX10-NEXT:    v_cndmask_b32_e32 v5, v6, v5, vcc_lo
-; GFX10-NEXT:    v_cmp_class_f16_e64 vcc_lo, v2, 32
-; GFX10-NEXT:    v_cndmask_b32_e32 v0, v0, v2, vcc_lo
-; GFX10-NEXT:    v_cmp_class_f16_e64 vcc_lo, v7, 32
-; GFX10-NEXT:    v_cndmask_b32_e32 v2, v5, v7, vcc_lo
-; GFX10-NEXT:    v_cmp_class_f16_e64 vcc_lo, v1, 32
-; GFX10-NEXT:    v_cndmask_b32_e32 v1, v8, v1, vcc_lo
-; GFX10-NEXT:    v_cmp_eq_f16_e32 vcc_lo, 0, v4
-; GFX10-NEXT:    v_cndmask_b32_e32 v0, v4, v0, vcc_lo
-; GFX10-NEXT:    v_cmp_eq_f16_e32 vcc_lo, 0, v6
-; GFX10-NEXT:    v_cndmask_b32_e32 v2, v6, v2, vcc_lo
-; GFX10-NEXT:    v_cmp_class_f16_e64 vcc_lo, v3, 32
-; GFX10-NEXT:    v_perm_b32 v0, v2, v0, 0x5040100
-; GFX10-NEXT:    v_cndmask_b32_e32 v1, v1, v3, vcc_lo
-; GFX10-NEXT:    v_cmp_eq_f16_e32 vcc_lo, 0, v8
-; GFX10-NEXT:    v_cndmask_b32_e32 v1, v8, v1, vcc_lo
+; GFX10-NEXT:    v_pk_min_f16 v0, v0, v2
+; GFX10-NEXT:    v_pk_min_f16 v1, v1, v3
 ; GFX10-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX11-LABEL: v_minimum_v3f16__nnan:
 ; GFX11:       ; %bb.0:
 ; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX11-NEXT:    v_pk_min_f16 v4, v0, v2
-; GFX11-NEXT:    v_lshrrev_b32_e32 v5, 16, v0
-; GFX11-NEXT:    v_cmp_class_f16_e64 vcc_lo, v0, 32
-; GFX11-NEXT:    v_lshrrev_b32_e32 v7, 16, v2
-; GFX11-NEXT:    v_pk_min_f16 v8, v1, v3
-; GFX11-NEXT:    v_lshrrev_b32_e32 v6, 16, v4
-; GFX11-NEXT:    v_cndmask_b32_e32 v0, v4, v0, vcc_lo
-; GFX11-NEXT:    v_cmp_class_f16_e64 vcc_lo, v5, 32
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(SKIP_1) | instid1(VALU_DEP_4)
-; GFX11-NEXT:    v_cndmask_b32_e32 v5, v6, v5, vcc_lo
-; GFX11-NEXT:    v_cmp_class_f16_e64 vcc_lo, v2, 32
-; GFX11-NEXT:    v_cndmask_b32_e32 v0, v0, v2, vcc_lo
-; GFX11-NEXT:    v_cmp_class_f16_e64 vcc_lo, v7, 32
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_4)
-; GFX11-NEXT:    v_cndmask_b32_e32 v2, v5, v7, vcc_lo
-; GFX11-NEXT:    v_cmp_class_f16_e64 vcc_lo, v1, 32
-; GFX11-NEXT:    v_cndmask_b32_e32 v1, v8, v1, vcc_lo
-; GFX11-NEXT:    v_cmp_eq_f16_e32 vcc_lo, 0, v4
-; GFX11-NEXT:    v_cndmask_b32_e32 v0, v4, v0, vcc_lo
-; GFX11-NEXT:    v_cmp_eq_f16_e32 vcc_lo, 0, v6
-; GFX11-NEXT:    v_cndmask_b32_e32 v2, v6, v2, vcc_lo
-; GFX11-NEXT:    v_cmp_class_f16_e64 vcc_lo, v3, 32
-; GFX11-NEXT:    v_cndmask_b32_e32 v1, v1, v3, vcc_lo
-; GFX11-NEXT:    v_cmp_eq_f16_e32 vcc_lo, 0, v8
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_2)
-; GFX11-NEXT:    v_cndmask_b32_e32 v1, v8, v1, vcc_lo
-; GFX11-NEXT:    v_perm_b32 v0, v2, v0, 0x5040100
+; GFX11-NEXT:    v_pk_min_f16 v0, v0, v2
+; GFX11-NEXT:    v_pk_min_f16 v1, v1, v3
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX12-LABEL: v_minimum_v3f16__nnan:
@@ -1807,42 +1205,18 @@ define <4 x half> @v_minimum_v4f16(<4 x half> %src0, <4 x half> %src1) {
 ; GFX8-NEXT:    v_min_f16_e32 v6, v5, v4
 ; GFX8-NEXT:    v_mov_b32_e32 v7, 0x7e00
 ; GFX8-NEXT:    v_cmp_o_f16_e32 vcc, v5, v4
-; GFX8-NEXT:    v_cndmask_b32_e32 v6, v7, v6, vcc
-; GFX8-NEXT:    v_cmp_class_f16_e64 vcc, v5, 32
-; GFX8-NEXT:    v_cndmask_b32_e32 v5, v6, v5, vcc
-; GFX8-NEXT:    v_cmp_class_f16_e64 vcc, v4, 32
-; GFX8-NEXT:    v_cndmask_b32_e32 v4, v5, v4, vcc
-; GFX8-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v6
-; GFX8-NEXT:    v_cndmask_b32_e32 v4, v6, v4, vcc
+; GFX8-NEXT:    v_cndmask_b32_e32 v4, v7, v6, vcc
 ; GFX8-NEXT:    v_lshrrev_b32_e32 v5, 16, v2
 ; GFX8-NEXT:    v_lshrrev_b32_e32 v6, 16, v0
 ; GFX8-NEXT:    v_min_f16_e32 v8, v6, v5
 ; GFX8-NEXT:    v_cmp_o_f16_e32 vcc, v6, v5
-; GFX8-NEXT:    v_cndmask_b32_e32 v8, v7, v8, vcc
-; GFX8-NEXT:    v_cmp_class_f16_e64 vcc, v6, 32
-; GFX8-NEXT:    v_cndmask_b32_e32 v6, v8, v6, vcc
-; GFX8-NEXT:    v_cmp_class_f16_e64 vcc, v5, 32
-; GFX8-NEXT:    v_cndmask_b32_e32 v5, v6, v5, vcc
-; GFX8-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v8
-; GFX8-NEXT:    v_cndmask_b32_e32 v5, v8, v5, vcc
+; GFX8-NEXT:    v_cndmask_b32_e32 v5, v7, v8, vcc
 ; GFX8-NEXT:    v_min_f16_e32 v6, v1, v3
 ; GFX8-NEXT:    v_cmp_o_f16_e32 vcc, v1, v3
-; GFX8-NEXT:    v_cndmask_b32_e32 v6, v7, v6, vcc
-; GFX8-NEXT:    v_cmp_class_f16_e64 vcc, v1, 32
-; GFX8-NEXT:    v_cndmask_b32_e32 v1, v6, v1, vcc
-; GFX8-NEXT:    v_cmp_class_f16_e64 vcc, v3, 32
-; GFX8-NEXT:    v_cndmask_b32_e32 v1, v1, v3, vcc
-; GFX8-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v6
-; GFX8-NEXT:    v_cndmask_b32_e32 v1, v6, v1, vcc
+; GFX8-NEXT:    v_cndmask_b32_e32 v1, v7, v6, vcc
 ; GFX8-NEXT:    v_min_f16_e32 v3, v0, v2
 ; GFX8-NEXT:    v_cmp_o_f16_e32 vcc, v0, v2
-; GFX8-NEXT:    v_cndmask_b32_e32 v3, v7, v3, vcc
-; GFX8-NEXT:    v_cmp_class_f16_e64 vcc, v0, 32
-; GFX8-NEXT:    v_cndmask_b32_e32 v0, v3, v0, vcc
-; GFX8-NEXT:    v_cmp_class_f16_e64 vcc, v2, 32
-; GFX8-NEXT:    v_cndmask_b32_e32 v0, v0, v2, vcc
-; GFX8-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v3
-; GFX8-NEXT:    v_cndmask_b32_e32 v0, v3, v0, vcc
+; GFX8-NEXT:    v_cndmask_b32_e32 v0, v7, v3, vcc
 ; GFX8-NEXT:    v_lshlrev_b32_e32 v2, 16, v5
 ; GFX8-NEXT:    v_or_b32_sdwa v0, v0, v2 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
 ; GFX8-NEXT:    v_lshlrev_b32_e32 v2, 16, v4
@@ -1856,43 +1230,15 @@ define <4 x half> @v_minimum_v4f16(<4 x half> %src0, <4 x half> %src1) {
 ; GFX9-NEXT:    v_mov_b32_e32 v5, 0x7e00
 ; GFX9-NEXT:    v_cmp_o_f16_e32 vcc, v1, v3
 ; GFX9-NEXT:    v_cndmask_b32_e32 v6, v5, v4, vcc
-; GFX9-NEXT:    v_cmp_class_f16_e64 vcc, v1, 32
-; GFX9-NEXT:    v_cndmask_b32_e32 v7, v6, v1, vcc
-; GFX9-NEXT:    v_cmp_class_f16_e64 vcc, v3, 32
-; GFX9-NEXT:    v_cndmask_b32_e32 v7, v7, v3, vcc
-; GFX9-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v6
-; GFX9-NEXT:    v_lshrrev_b32_e32 v3, 16, v3
-; GFX9-NEXT:    v_lshrrev_b32_e32 v1, 16, v1
-; GFX9-NEXT:    v_cndmask_b32_e32 v6, v6, v7, vcc
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v4, 16, v4
-; GFX9-NEXT:    v_cmp_o_f16_e32 vcc, v1, v3
-; GFX9-NEXT:    v_cndmask_b32_e32 v4, v5, v4, vcc
-; GFX9-NEXT:    v_cmp_class_f16_e64 vcc, v1, 32
-; GFX9-NEXT:    v_cndmask_b32_e32 v1, v4, v1, vcc
-; GFX9-NEXT:    v_cmp_class_f16_e64 vcc, v3, 32
-; GFX9-NEXT:    v_cndmask_b32_e32 v1, v1, v3, vcc
-; GFX9-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v4
-; GFX9-NEXT:    v_cndmask_b32_e32 v1, v4, v1, vcc
+; GFX9-NEXT:    v_cmp_o_f16_sdwa vcc, v1, v3 src0_sel:WORD_1 src1_sel:WORD_1
+; GFX9-NEXT:    v_cndmask_b32_e32 v1, v5, v4, vcc
 ; GFX9-NEXT:    v_pk_min_f16 v3, v0, v2
 ; GFX9-NEXT:    v_cmp_o_f16_e32 vcc, v0, v2
 ; GFX9-NEXT:    v_cndmask_b32_e32 v4, v5, v3, vcc
-; GFX9-NEXT:    v_cmp_class_f16_e64 vcc, v0, 32
-; GFX9-NEXT:    v_cndmask_b32_e32 v7, v4, v0, vcc
-; GFX9-NEXT:    v_cmp_class_f16_e64 vcc, v2, 32
-; GFX9-NEXT:    v_cndmask_b32_e32 v7, v7, v2, vcc
-; GFX9-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v4
-; GFX9-NEXT:    v_lshrrev_b32_e32 v2, 16, v2
-; GFX9-NEXT:    v_lshrrev_b32_e32 v0, 16, v0
-; GFX9-NEXT:    v_cndmask_b32_e32 v4, v4, v7, vcc
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v3, 16, v3
-; GFX9-NEXT:    v_cmp_o_f16_e32 vcc, v0, v2
-; GFX9-NEXT:    v_cndmask_b32_e32 v3, v5, v3, vcc
-; GFX9-NEXT:    v_cmp_class_f16_e64 vcc, v0, 32
-; GFX9-NEXT:    v_cndmask_b32_e32 v0, v3, v0, vcc
-; GFX9-NEXT:    v_cmp_class_f16_e64 vcc, v2, 32
-; GFX9-NEXT:    v_cndmask_b32_e32 v0, v0, v2, vcc
-; GFX9-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v3
-; GFX9-NEXT:    v_cndmask_b32_e32 v0, v3, v0, vcc
+; GFX9-NEXT:    v_cmp_o_f16_sdwa vcc, v0, v2 src0_sel:WORD_1 src1_sel:WORD_1
+; GFX9-NEXT:    v_cndmask_b32_e32 v0, v5, v3, vcc
 ; GFX9-NEXT:    s_mov_b32 s4, 0x5040100
 ; GFX9-NEXT:    v_perm_b32 v0, v0, v4, s4
 ; GFX9-NEXT:    v_perm_b32 v1, v1, v6, s4
@@ -1907,59 +1253,19 @@ define <4 x half> @v_minimum_v4f16(<4 x half> %src0, <4 x half> %src1) {
 ; GFX940-NEXT:    s_mov_b32 s0, 0x5040100
 ; GFX940-NEXT:    s_nop 0
 ; GFX940-NEXT:    v_cndmask_b32_e32 v6, v5, v4, vcc
-; GFX940-NEXT:    v_cmp_class_f16_e64 vcc, v1, 32
 ; GFX940-NEXT:    v_lshrrev_b32_e32 v4, 16, v4
-; GFX940-NEXT:    s_nop 0
-; GFX940-NEXT:    v_cndmask_b32_e32 v7, v6, v1, vcc
-; GFX940-NEXT:    v_cmp_class_f16_e64 vcc, v3, 32
-; GFX940-NEXT:    v_lshrrev_b32_e32 v1, 16, v1
-; GFX940-NEXT:    s_nop 0
-; GFX940-NEXT:    v_cndmask_b32_e32 v7, v7, v3, vcc
-; GFX940-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v6
-; GFX940-NEXT:    v_lshrrev_b32_e32 v3, 16, v3
-; GFX940-NEXT:    s_nop 0
-; GFX940-NEXT:    v_cndmask_b32_e32 v6, v6, v7, vcc
-; GFX940-NEXT:    v_cmp_o_f16_e32 vcc, v1, v3
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v4, v5, v4, vcc
-; GFX940-NEXT:    v_cmp_class_f16_e64 vcc, v1, 32
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v1, v4, v1, vcc
-; GFX940-NEXT:    v_cmp_class_f16_e64 vcc, v3, 32
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v1, v1, v3, vcc
-; GFX940-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v4
+; GFX940-NEXT:    v_cmp_o_f16_sdwa vcc, v1, v3 src0_sel:WORD_1 src1_sel:WORD_1
 ; GFX940-NEXT:    v_pk_min_f16 v3, v0, v2
 ; GFX940-NEXT:    s_nop 0
-; GFX940-NEXT:    v_cndmask_b32_e32 v1, v4, v1, vcc
+; GFX940-NEXT:    v_cndmask_b32_e32 v1, v5, v4, vcc
 ; GFX940-NEXT:    v_cmp_o_f16_e32 vcc, v0, v2
 ; GFX940-NEXT:    v_perm_b32 v1, v1, v6, s0
 ; GFX940-NEXT:    s_nop 0
 ; GFX940-NEXT:    v_cndmask_b32_e32 v4, v5, v3, vcc
-; GFX940-NEXT:    v_cmp_class_f16_e64 vcc, v0, 32
 ; GFX940-NEXT:    v_lshrrev_b32_e32 v3, 16, v3
-; GFX940-NEXT:    s_nop 0
-; GFX940-NEXT:    v_cndmask_b32_e32 v7, v4, v0, vcc
-; GFX940-NEXT:    v_cmp_class_f16_e64 vcc, v2, 32
-; GFX940-NEXT:    v_lshrrev_b32_e32 v0, 16, v0
-; GFX940-NEXT:    s_nop 0
-; GFX940-NEXT:    v_cndmask_b32_e32 v7, v7, v2, vcc
-; GFX940-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v4
-; GFX940-NEXT:    v_lshrrev_b32_e32 v2, 16, v2
-; GFX940-NEXT:    s_nop 0
-; GFX940-NEXT:    v_cndmask_b32_e32 v4, v4, v7, vcc
-; GFX940-NEXT:    v_cmp_o_f16_e32 vcc, v0, v2
+; GFX940-NEXT:    v_cmp_o_f16_sdwa vcc, v0, v2 src0_sel:WORD_1 src1_sel:WORD_1
 ; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v3, v5, v3, vcc
-; GFX940-NEXT:    v_cmp_class_f16_e64 vcc, v0, 32
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v0, v3, v0, vcc
-; GFX940-NEXT:    v_cmp_class_f16_e64 vcc, v2, 32
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v0, v0, v2, vcc
-; GFX940-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v3
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v0, v3, v0, vcc
+; GFX940-NEXT:    v_cndmask_b32_e32 v0, v5, v3, vcc
 ; GFX940-NEXT:    v_perm_b32 v0, v0, v4, s0
 ; GFX940-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -1968,46 +1274,18 @@ define <4 x half> @v_minimum_v4f16(<4 x half> %src0, <4 x half> %src1) {
 ; GFX10-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX10-NEXT:    v_pk_min_f16 v4, v1, v3
 ; GFX10-NEXT:    v_cmp_o_f16_e32 vcc_lo, v1, v3
-; GFX10-NEXT:    v_lshrrev_b32_e32 v6, 16, v1
-; GFX10-NEXT:    v_pk_min_f16 v7, v0, v2
-; GFX10-NEXT:    v_lshrrev_b32_e32 v5, 16, v3
-; GFX10-NEXT:    v_lshrrev_b32_e32 v9, 16, v2
-; GFX10-NEXT:    v_cndmask_b32_e32 v8, 0x7e00, v4, vcc_lo
-; GFX10-NEXT:    v_cmp_class_f16_e64 vcc_lo, v1, 32
-; GFX10-NEXT:    v_lshrrev_b32_e32 v10, 16, v0
-; GFX10-NEXT:    v_lshrrev_b32_e32 v4, 16, v4
-; GFX10-NEXT:    v_cndmask_b32_e32 v1, v8, v1, vcc_lo
+; GFX10-NEXT:    v_pk_min_f16 v5, v0, v2
+; GFX10-NEXT:    v_cndmask_b32_e32 v6, 0x7e00, v4, vcc_lo
 ; GFX10-NEXT:    v_cmp_o_f16_e32 vcc_lo, v0, v2
-; GFX10-NEXT:    v_cndmask_b32_e32 v11, 0x7e00, v7, vcc_lo
-; GFX10-NEXT:    v_cmp_class_f16_e64 vcc_lo, v3, 32
-; GFX10-NEXT:    v_lshrrev_b32_e32 v7, 16, v7
-; GFX10-NEXT:    v_cndmask_b32_e32 v1, v1, v3, vcc_lo
-; GFX10-NEXT:    v_cmp_o_f16_e32 vcc_lo, v6, v5
-; GFX10-NEXT:    v_cndmask_b32_e32 v3, 0x7e00, v4, vcc_lo
-; GFX10-NEXT:    v_cmp_o_f16_e32 vcc_lo, v10, v9
-; GFX10-NEXT:    v_cndmask_b32_e32 v4, 0x7e00, v7, vcc_lo
-; GFX10-NEXT:    v_cmp_eq_f16_e32 vcc_lo, 0, v8
-; GFX10-NEXT:    v_cndmask_b32_e32 v1, v8, v1, vcc_lo
-; GFX10-NEXT:    v_cmp_class_f16_e64 vcc_lo, v0, 32
-; GFX10-NEXT:    v_cndmask_b32_e32 v0, v11, v0, vcc_lo
-; GFX10-NEXT:    v_cmp_class_f16_e64 vcc_lo, v10, 32
-; GFX10-NEXT:    v_cndmask_b32_e32 v7, v4, v10, vcc_lo
-; GFX10-NEXT:    v_cmp_class_f16_e64 vcc_lo, v6, 32
-; GFX10-NEXT:    v_cndmask_b32_e32 v6, v3, v6, vcc_lo
-; GFX10-NEXT:    v_cmp_class_f16_e64 vcc_lo, v2, 32
-; GFX10-NEXT:    v_cndmask_b32_e32 v0, v0, v2, vcc_lo
-; GFX10-NEXT:    v_cmp_class_f16_e64 vcc_lo, v9, 32
-; GFX10-NEXT:    v_cndmask_b32_e32 v2, v7, v9, vcc_lo
-; GFX10-NEXT:    v_cmp_class_f16_e64 vcc_lo, v5, 32
-; GFX10-NEXT:    v_cndmask_b32_e32 v5, v6, v5, vcc_lo
-; GFX10-NEXT:    v_cmp_eq_f16_e32 vcc_lo, 0, v11
-; GFX10-NEXT:    v_cndmask_b32_e32 v0, v11, v0, vcc_lo
-; GFX10-NEXT:    v_cmp_eq_f16_e32 vcc_lo, 0, v4
-; GFX10-NEXT:    v_cndmask_b32_e32 v2, v4, v2, vcc_lo
-; GFX10-NEXT:    v_cmp_eq_f16_e32 vcc_lo, 0, v3
-; GFX10-NEXT:    v_perm_b32 v0, v2, v0, 0x5040100
-; GFX10-NEXT:    v_cndmask_b32_e32 v3, v3, v5, vcc_lo
-; GFX10-NEXT:    v_perm_b32 v1, v3, v1, 0x5040100
+; GFX10-NEXT:    v_lshrrev_b32_e32 v7, 16, v5
+; GFX10-NEXT:    v_lshrrev_b32_e32 v4, 16, v4
+; GFX10-NEXT:    v_cndmask_b32_e32 v5, 0x7e00, v5, vcc_lo
+; GFX10-NEXT:    v_cmp_o_f16_sdwa vcc_lo, v0, v2 src0_sel:WORD_1 src1_sel:WORD_1
+; GFX10-NEXT:    v_cndmask_b32_e32 v0, 0x7e00, v7, vcc_lo
+; GFX10-NEXT:    v_cmp_o_f16_sdwa vcc_lo, v1, v3 src0_sel:WORD_1 src1_sel:WORD_1
+; GFX10-NEXT:    v_perm_b32 v0, v0, v5, 0x5040100
+; GFX10-NEXT:    v_cndmask_b32_e32 v1, 0x7e00, v4, vcc_lo
+; GFX10-NEXT:    v_perm_b32 v1, v1, v6, 0x5040100
 ; GFX10-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX11-LABEL: v_minimum_v4f16:
@@ -2015,47 +1293,23 @@ define <4 x half> @v_minimum_v4f16(<4 x half> %src0, <4 x half> %src1) {
 ; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX11-NEXT:    v_pk_min_f16 v4, v1, v3
 ; GFX11-NEXT:    v_cmp_o_f16_e32 vcc_lo, v1, v3
+; GFX11-NEXT:    v_lshrrev_b32_e32 v5, 16, v3
 ; GFX11-NEXT:    v_lshrrev_b32_e32 v6, 16, v1
 ; GFX11-NEXT:    v_pk_min_f16 v7, v0, v2
-; GFX11-NEXT:    v_lshrrev_b32_e32 v5, 16, v3
-; GFX11-NEXT:    v_lshrrev_b32_e32 v9, 16, v2
-; GFX11-NEXT:    v_cndmask_b32_e32 v8, 0x7e00, v4, vcc_lo
-; GFX11-NEXT:    v_cmp_class_f16_e64 vcc_lo, v1, 32
-; GFX11-NEXT:    v_lshrrev_b32_e32 v10, 16, v0
-; GFX11-NEXT:    v_lshrrev_b32_e32 v4, 16, v4
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_4)
-; GFX11-NEXT:    v_cndmask_b32_e32 v1, v8, v1, vcc_lo
+; GFX11-NEXT:    v_lshrrev_b32_e32 v8, 16, v2
+; GFX11-NEXT:    v_cndmask_b32_e32 v1, 0x7e00, v4, vcc_lo
+; GFX11-NEXT:    v_lshrrev_b32_e32 v3, 16, v0
 ; GFX11-NEXT:    v_cmp_o_f16_e32 vcc_lo, v0, v2
-; GFX11-NEXT:    v_cndmask_b32_e32 v11, 0x7e00, v7, vcc_lo
-; GFX11-NEXT:    v_cmp_class_f16_e64 vcc_lo, v3, 32
-; GFX11-NEXT:    v_lshrrev_b32_e32 v7, 16, v7
-; GFX11-NEXT:    v_cndmask_b32_e32 v1, v1, v3, vcc_lo
+; GFX11-NEXT:    v_lshrrev_b32_e32 v9, 16, v7
+; GFX11-NEXT:    v_lshrrev_b32_e32 v4, 16, v4
+; GFX11-NEXT:    v_cndmask_b32_e32 v0, 0x7e00, v7, vcc_lo
+; GFX11-NEXT:    v_cmp_o_f16_e32 vcc_lo, v3, v8
+; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(SKIP_1) | instid1(VALU_DEP_2)
+; GFX11-NEXT:    v_cndmask_b32_e32 v2, 0x7e00, v9, vcc_lo
 ; GFX11-NEXT:    v_cmp_o_f16_e32 vcc_lo, v6, v5
-; GFX11-NEXT:    v_cndmask_b32_e32 v3, 0x7e00, v4, vcc_lo
-; GFX11-NEXT:    v_cmp_o_f16_e32 vcc_lo, v10, v9
-; GFX11-NEXT:    v_cndmask_b32_e32 v4, 0x7e00, v7, vcc_lo
-; GFX11-NEXT:    v_cmp_eq_f16_e32 vcc_lo, 0, v8
-; GFX11-NEXT:    v_cndmask_b32_e32 v1, v8, v1, vcc_lo
-; GFX11-NEXT:    v_cmp_class_f16_e64 vcc_lo, v0, 32
-; GFX11-NEXT:    v_cndmask_b32_e32 v0, v11, v0, vcc_lo
-; GFX11-NEXT:    v_cmp_class_f16_e64 vcc_lo, v10, 32
-; GFX11-NEXT:    v_cndmask_b32_e32 v7, v4, v10, vcc_lo
-; GFX11-NEXT:    v_cmp_class_f16_e64 vcc_lo, v6, 32
-; GFX11-NEXT:    v_cndmask_b32_e32 v6, v3, v6, vcc_lo
-; GFX11-NEXT:    v_cmp_class_f16_e64 vcc_lo, v2, 32
-; GFX11-NEXT:    v_cndmask_b32_e32 v0, v0, v2, vcc_lo
-; GFX11-NEXT:    v_cmp_class_f16_e64 vcc_lo, v9, 32
-; GFX11-NEXT:    v_cndmask_b32_e32 v2, v7, v9, vcc_lo
-; GFX11-NEXT:    v_cmp_class_f16_e64 vcc_lo, v5, 32
-; GFX11-NEXT:    v_cndmask_b32_e32 v5, v6, v5, vcc_lo
-; GFX11-NEXT:    v_cmp_eq_f16_e32 vcc_lo, 0, v11
-; GFX11-NEXT:    v_cndmask_b32_e32 v0, v11, v0, vcc_lo
-; GFX11-NEXT:    v_cmp_eq_f16_e32 vcc_lo, 0, v4
-; GFX11-NEXT:    v_cndmask_b32_e32 v2, v4, v2, vcc_lo
-; GFX11-NEXT:    v_cmp_eq_f16_e32 vcc_lo, 0, v3
-; GFX11-NEXT:    v_cndmask_b32_e32 v3, v3, v5, vcc_lo
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_2)
 ; GFX11-NEXT:    v_perm_b32 v0, v2, v0, 0x5040100
+; GFX11-NEXT:    v_cndmask_b32_e32 v3, 0x7e00, v4, vcc_lo
+; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GFX11-NEXT:    v_perm_b32 v1, v3, v1, 0x5040100
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -2077,212 +1331,40 @@ define <4 x half> @v_minimum_v4f16__nnan(<4 x half> %src0, <4 x half> %src1) {
 ; GFX8-LABEL: v_minimum_v4f16__nnan:
 ; GFX8:       ; %bb.0:
 ; GFX8-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX8-NEXT:    v_lshrrev_b32_e32 v4, 16, v3
-; GFX8-NEXT:    v_lshrrev_b32_e32 v5, 16, v1
-; GFX8-NEXT:    v_min_f16_e32 v6, v5, v4
-; GFX8-NEXT:    v_cmp_class_f16_e64 vcc, v5, 32
-; GFX8-NEXT:    v_cndmask_b32_e32 v5, v6, v5, vcc
-; GFX8-NEXT:    v_cmp_class_f16_e64 vcc, v4, 32
-; GFX8-NEXT:    v_cndmask_b32_e32 v4, v5, v4, vcc
-; GFX8-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v6
-; GFX8-NEXT:    v_cndmask_b32_e32 v4, v6, v4, vcc
-; GFX8-NEXT:    v_lshrrev_b32_e32 v5, 16, v2
-; GFX8-NEXT:    v_lshrrev_b32_e32 v6, 16, v0
-; GFX8-NEXT:    v_min_f16_e32 v7, v6, v5
-; GFX8-NEXT:    v_cmp_class_f16_e64 vcc, v6, 32
-; GFX8-NEXT:    v_cndmask_b32_e32 v6, v7, v6, vcc
-; GFX8-NEXT:    v_cmp_class_f16_e64 vcc, v5, 32
-; GFX8-NEXT:    v_cndmask_b32_e32 v5, v6, v5, vcc
-; GFX8-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v7
-; GFX8-NEXT:    v_cndmask_b32_e32 v5, v7, v5, vcc
-; GFX8-NEXT:    v_min_f16_e32 v6, v1, v3
-; GFX8-NEXT:    v_cmp_class_f16_e64 vcc, v1, 32
-; GFX8-NEXT:    v_cndmask_b32_e32 v1, v6, v1, vcc
-; GFX8-NEXT:    v_cmp_class_f16_e64 vcc, v3, 32
-; GFX8-NEXT:    v_cndmask_b32_e32 v1, v1, v3, vcc
-; GFX8-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v6
-; GFX8-NEXT:    v_cndmask_b32_e32 v1, v6, v1, vcc
-; GFX8-NEXT:    v_min_f16_e32 v3, v0, v2
-; GFX8-NEXT:    v_cmp_class_f16_e64 vcc, v0, 32
-; GFX8-NEXT:    v_cndmask_b32_e32 v0, v3, v0, vcc
-; GFX8-NEXT:    v_cmp_class_f16_e64 vcc, v2, 32
-; GFX8-NEXT:    v_cndmask_b32_e32 v0, v0, v2, vcc
-; GFX8-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v3
-; GFX8-NEXT:    v_cndmask_b32_e32 v0, v3, v0, vcc
-; GFX8-NEXT:    v_lshlrev_b32_e32 v2, 16, v5
-; GFX8-NEXT:    v_or_b32_sdwa v0, v0, v2 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
-; GFX8-NEXT:    v_lshlrev_b32_e32 v2, 16, v4
-; GFX8-NEXT:    v_or_b32_sdwa v1, v1, v2 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
+; GFX8-NEXT:    v_min_f16_sdwa v4, v1, v3 dst_sel:WORD_1 dst_unused:UNUSED_PAD src0_sel:WORD_1 src1_sel:WORD_1
+; GFX8-NEXT:    v_min_f16_sdwa v5, v0, v2 dst_sel:WORD_1 dst_unused:UNUSED_PAD src0_sel:WORD_1 src1_sel:WORD_1
+; GFX8-NEXT:    v_min_f16_e32 v1, v1, v3
+; GFX8-NEXT:    v_min_f16_e32 v0, v0, v2
+; GFX8-NEXT:    v_or_b32_e32 v0, v0, v5
+; GFX8-NEXT:    v_or_b32_e32 v1, v1, v4
 ; GFX8-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX9-LABEL: v_minimum_v4f16__nnan:
 ; GFX9:       ; %bb.0:
 ; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX9-NEXT:    v_lshrrev_b32_e32 v4, 16, v1
-; GFX9-NEXT:    v_pk_min_f16 v5, v1, v3
-; GFX9-NEXT:    v_lshrrev_b32_e32 v6, 16, v5
-; GFX9-NEXT:    v_cmp_class_f16_e64 vcc, v4, 32
-; GFX9-NEXT:    v_lshrrev_b32_e32 v7, 16, v3
-; GFX9-NEXT:    v_cndmask_b32_e32 v4, v6, v4, vcc
-; GFX9-NEXT:    v_cmp_class_f16_e64 vcc, v7, 32
-; GFX9-NEXT:    v_cndmask_b32_e32 v4, v4, v7, vcc
-; GFX9-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v6
-; GFX9-NEXT:    v_cndmask_b32_e32 v4, v6, v4, vcc
-; GFX9-NEXT:    v_lshrrev_b32_e32 v6, 16, v0
-; GFX9-NEXT:    v_pk_min_f16 v7, v0, v2
-; GFX9-NEXT:    v_lshrrev_b32_e32 v8, 16, v7
-; GFX9-NEXT:    v_cmp_class_f16_e64 vcc, v6, 32
-; GFX9-NEXT:    v_lshrrev_b32_e32 v9, 16, v2
-; GFX9-NEXT:    v_cndmask_b32_e32 v6, v8, v6, vcc
-; GFX9-NEXT:    v_cmp_class_f16_e64 vcc, v9, 32
-; GFX9-NEXT:    v_cndmask_b32_e32 v6, v6, v9, vcc
-; GFX9-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v8
-; GFX9-NEXT:    v_cndmask_b32_e32 v6, v8, v6, vcc
-; GFX9-NEXT:    v_cmp_class_f16_e64 vcc, v1, 32
-; GFX9-NEXT:    v_cndmask_b32_e32 v1, v5, v1, vcc
-; GFX9-NEXT:    v_cmp_class_f16_e64 vcc, v3, 32
-; GFX9-NEXT:    v_cndmask_b32_e32 v1, v1, v3, vcc
-; GFX9-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v5
-; GFX9-NEXT:    v_cndmask_b32_e32 v1, v5, v1, vcc
-; GFX9-NEXT:    v_cmp_class_f16_e64 vcc, v0, 32
-; GFX9-NEXT:    v_cndmask_b32_e32 v0, v7, v0, vcc
-; GFX9-NEXT:    v_cmp_class_f16_e64 vcc, v2, 32
-; GFX9-NEXT:    v_cndmask_b32_e32 v0, v0, v2, vcc
-; GFX9-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v7
-; GFX9-NEXT:    v_cndmask_b32_e32 v0, v7, v0, vcc
-; GFX9-NEXT:    s_mov_b32 s4, 0x5040100
-; GFX9-NEXT:    v_perm_b32 v0, v6, v0, s4
-; GFX9-NEXT:    v_perm_b32 v1, v4, v1, s4
+; GFX9-NEXT:    v_pk_min_f16 v0, v0, v2
+; GFX9-NEXT:    v_pk_min_f16 v1, v1, v3
 ; GFX9-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX940-LABEL: v_minimum_v4f16__nnan:
 ; GFX940:       ; %bb.0:
 ; GFX940-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX940-NEXT:    v_lshrrev_b32_e32 v4, 16, v1
-; GFX940-NEXT:    v_pk_min_f16 v5, v1, v3
-; GFX940-NEXT:    v_cmp_class_f16_e64 vcc, v4, 32
-; GFX940-NEXT:    v_lshrrev_b32_e32 v6, 16, v5
-; GFX940-NEXT:    v_lshrrev_b32_e32 v7, 16, v3
-; GFX940-NEXT:    v_cndmask_b32_e32 v4, v6, v4, vcc
-; GFX940-NEXT:    v_cmp_class_f16_e64 vcc, v7, 32
-; GFX940-NEXT:    v_lshrrev_b32_e32 v9, 16, v2
-; GFX940-NEXT:    s_mov_b32 s0, 0x5040100
-; GFX940-NEXT:    v_cndmask_b32_e32 v4, v4, v7, vcc
-; GFX940-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v6
-; GFX940-NEXT:    v_pk_min_f16 v7, v0, v2
-; GFX940-NEXT:    s_nop 0
-; GFX940-NEXT:    v_cndmask_b32_e32 v4, v6, v4, vcc
-; GFX940-NEXT:    v_lshrrev_b32_e32 v6, 16, v0
-; GFX940-NEXT:    v_lshrrev_b32_e32 v8, 16, v7
-; GFX940-NEXT:    v_cmp_class_f16_e64 vcc, v6, 32
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v6, v8, v6, vcc
-; GFX940-NEXT:    v_cmp_class_f16_e64 vcc, v9, 32
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v6, v6, v9, vcc
-; GFX940-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v8
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v6, v8, v6, vcc
-; GFX940-NEXT:    v_cmp_class_f16_e64 vcc, v1, 32
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v1, v5, v1, vcc
-; GFX940-NEXT:    v_cmp_class_f16_e64 vcc, v3, 32
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v1, v1, v3, vcc
-; GFX940-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v5
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v1, v5, v1, vcc
-; GFX940-NEXT:    v_cmp_class_f16_e64 vcc, v0, 32
-; GFX940-NEXT:    v_perm_b32 v1, v4, v1, s0
-; GFX940-NEXT:    s_nop 0
-; GFX940-NEXT:    v_cndmask_b32_e32 v0, v7, v0, vcc
-; GFX940-NEXT:    v_cmp_class_f16_e64 vcc, v2, 32
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v0, v0, v2, vcc
-; GFX940-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v7
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v0, v7, v0, vcc
-; GFX940-NEXT:    v_perm_b32 v0, v6, v0, s0
+; GFX940-NEXT:    v_pk_min_f16 v0, v0, v2
+; GFX940-NEXT:    v_pk_min_f16 v1, v1, v3
 ; GFX940-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX10-LABEL: v_minimum_v4f16__nnan:
 ; GFX10:       ; %bb.0:
 ; GFX10-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX10-NEXT:    v_pk_min_f16 v4, v1, v3
-; GFX10-NEXT:    v_lshrrev_b32_e32 v5, 16, v1
-; GFX10-NEXT:    v_pk_min_f16 v6, v0, v2
-; GFX10-NEXT:    v_lshrrev_b32_e32 v9, 16, v0
-; GFX10-NEXT:    v_lshrrev_b32_e32 v7, 16, v3
-; GFX10-NEXT:    v_lshrrev_b32_e32 v8, 16, v4
-; GFX10-NEXT:    v_cmp_class_f16_e64 vcc_lo, v5, 32
-; GFX10-NEXT:    v_lshrrev_b32_e32 v11, 16, v6
-; GFX10-NEXT:    v_lshrrev_b32_e32 v10, 16, v2
-; GFX10-NEXT:    v_cndmask_b32_e32 v5, v8, v5, vcc_lo
-; GFX10-NEXT:    v_cmp_class_f16_e64 vcc_lo, v1, 32
-; GFX10-NEXT:    v_cndmask_b32_e32 v1, v4, v1, vcc_lo
-; GFX10-NEXT:    v_cmp_class_f16_e64 vcc_lo, v9, 32
-; GFX10-NEXT:    v_cndmask_b32_e32 v9, v11, v9, vcc_lo
-; GFX10-NEXT:    v_cmp_class_f16_e64 vcc_lo, v7, 32
-; GFX10-NEXT:    v_cndmask_b32_e32 v5, v5, v7, vcc_lo
-; GFX10-NEXT:    v_cmp_class_f16_e64 vcc_lo, v0, 32
-; GFX10-NEXT:    v_cndmask_b32_e32 v0, v6, v0, vcc_lo
-; GFX10-NEXT:    v_cmp_class_f16_e64 vcc_lo, v10, 32
-; GFX10-NEXT:    v_cndmask_b32_e32 v7, v9, v10, vcc_lo
-; GFX10-NEXT:    v_cmp_eq_f16_e32 vcc_lo, 0, v8
-; GFX10-NEXT:    v_cndmask_b32_e32 v5, v8, v5, vcc_lo
-; GFX10-NEXT:    v_cmp_class_f16_e64 vcc_lo, v2, 32
-; GFX10-NEXT:    v_cndmask_b32_e32 v0, v0, v2, vcc_lo
-; GFX10-NEXT:    v_cmp_class_f16_e64 vcc_lo, v3, 32
-; GFX10-NEXT:    v_cndmask_b32_e32 v1, v1, v3, vcc_lo
-; GFX10-NEXT:    v_cmp_eq_f16_e32 vcc_lo, 0, v11
-; GFX10-NEXT:    v_cndmask_b32_e32 v2, v11, v7, vcc_lo
-; GFX10-NEXT:    v_cmp_eq_f16_e32 vcc_lo, 0, v6
-; GFX10-NEXT:    v_cndmask_b32_e32 v0, v6, v0, vcc_lo
-; GFX10-NEXT:    v_cmp_eq_f16_e32 vcc_lo, 0, v4
-; GFX10-NEXT:    v_perm_b32 v0, v2, v0, 0x5040100
-; GFX10-NEXT:    v_cndmask_b32_e32 v1, v4, v1, vcc_lo
-; GFX10-NEXT:    v_perm_b32 v1, v5, v1, 0x5040100
+; GFX10-NEXT:    v_pk_min_f16 v0, v0, v2
+; GFX10-NEXT:    v_pk_min_f16 v1, v1, v3
 ; GFX10-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX11-LABEL: v_minimum_v4f16__nnan:
 ; GFX11:       ; %bb.0:
 ; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX11-NEXT:    v_pk_min_f16 v4, v1, v3
-; GFX11-NEXT:    v_lshrrev_b32_e32 v5, 16, v1
-; GFX11-NEXT:    v_pk_min_f16 v6, v0, v2
-; GFX11-NEXT:    v_lshrrev_b32_e32 v9, 16, v0
-; GFX11-NEXT:    v_lshrrev_b32_e32 v7, 16, v3
-; GFX11-NEXT:    v_lshrrev_b32_e32 v8, 16, v4
-; GFX11-NEXT:    v_cmp_class_f16_e64 vcc_lo, v5, 32
-; GFX11-NEXT:    v_lshrrev_b32_e32 v11, 16, v6
-; GFX11-NEXT:    v_lshrrev_b32_e32 v10, 16, v2
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_4)
-; GFX11-NEXT:    v_cndmask_b32_e32 v5, v8, v5, vcc_lo
-; GFX11-NEXT:    v_cmp_class_f16_e64 vcc_lo, v1, 32
-; GFX11-NEXT:    v_cndmask_b32_e32 v1, v4, v1, vcc_lo
-; GFX11-NEXT:    v_cmp_class_f16_e64 vcc_lo, v9, 32
-; GFX11-NEXT:    v_cndmask_b32_e32 v9, v11, v9, vcc_lo
-; GFX11-NEXT:    v_cmp_class_f16_e64 vcc_lo, v7, 32
-; GFX11-NEXT:    v_cndmask_b32_e32 v5, v5, v7, vcc_lo
-; GFX11-NEXT:    v_cmp_class_f16_e64 vcc_lo, v0, 32
-; GFX11-NEXT:    v_cndmask_b32_e32 v0, v6, v0, vcc_lo
-; GFX11-NEXT:    v_cmp_class_f16_e64 vcc_lo, v10, 32
-; GFX11-NEXT:    v_cndmask_b32_e32 v7, v9, v10, vcc_lo
-; GFX11-NEXT:    v_cmp_eq_f16_e32 vcc_lo, 0, v8
-; GFX11-NEXT:    v_cndmask_b32_e32 v5, v8, v5, vcc_lo
-; GFX11-NEXT:    v_cmp_class_f16_e64 vcc_lo, v2, 32
-; GFX11-NEXT:    v_cndmask_b32_e32 v0, v0, v2, vcc_lo
-; GFX11-NEXT:    v_cmp_class_f16_e64 vcc_lo, v3, 32
-; GFX11-NEXT:    v_cndmask_b32_e32 v1, v1, v3, vcc_lo
-; GFX11-NEXT:    v_cmp_eq_f16_e32 vcc_lo, 0, v11
-; GFX11-NEXT:    v_cndmask_b32_e32 v2, v11, v7, vcc_lo
-; GFX11-NEXT:    v_cmp_eq_f16_e32 vcc_lo, 0, v6
-; GFX11-NEXT:    v_cndmask_b32_e32 v0, v6, v0, vcc_lo
-; GFX11-NEXT:    v_cmp_eq_f16_e32 vcc_lo, 0, v4
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(SKIP_1) | instid1(VALU_DEP_1)
-; GFX11-NEXT:    v_perm_b32 v0, v2, v0, 0x5040100
-; GFX11-NEXT:    v_cndmask_b32_e32 v1, v4, v1, vcc_lo
-; GFX11-NEXT:    v_perm_b32 v1, v5, v1, 0x5040100
+; GFX11-NEXT:    v_pk_min_f16 v0, v0, v2
+; GFX11-NEXT:    v_pk_min_f16 v1, v1, v3
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX12-LABEL: v_minimum_v4f16__nnan:
@@ -2493,82 +1575,34 @@ define <8 x half> @v_minimum_v8f16(<8 x half> %src0, <8 x half> %src1) {
 ; GFX8-NEXT:    v_min_f16_e32 v10, v9, v8
 ; GFX8-NEXT:    v_mov_b32_e32 v11, 0x7e00
 ; GFX8-NEXT:    v_cmp_o_f16_e32 vcc, v9, v8
-; GFX8-NEXT:    v_cndmask_b32_e32 v10, v11, v10, vcc
-; GFX8-NEXT:    v_cmp_class_f16_e64 vcc, v9, 32
-; GFX8-NEXT:    v_cndmask_b32_e32 v9, v10, v9, vcc
-; GFX8-NEXT:    v_cmp_class_f16_e64 vcc, v8, 32
-; GFX8-NEXT:    v_cndmask_b32_e32 v8, v9, v8, vcc
-; GFX8-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v10
-; GFX8-NEXT:    v_cndmask_b32_e32 v8, v10, v8, vcc
+; GFX8-NEXT:    v_cndmask_b32_e32 v8, v11, v10, vcc
 ; GFX8-NEXT:    v_lshrrev_b32_e32 v9, 16, v6
 ; GFX8-NEXT:    v_lshrrev_b32_e32 v10, 16, v2
 ; GFX8-NEXT:    v_min_f16_e32 v12, v10, v9
 ; GFX8-NEXT:    v_cmp_o_f16_e32 vcc, v10, v9
-; GFX8-NEXT:    v_cndmask_b32_e32 v12, v11, v12, vcc
-; GFX8-NEXT:    v_cmp_class_f16_e64 vcc, v10, 32
-; GFX8-NEXT:    v_cndmask_b32_e32 v10, v12, v10, vcc
-; GFX8-NEXT:    v_cmp_class_f16_e64 vcc, v9, 32
-; GFX8-NEXT:    v_cndmask_b32_e32 v9, v10, v9, vcc
-; GFX8-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v12
-; GFX8-NEXT:    v_cndmask_b32_e32 v9, v12, v9, vcc
+; GFX8-NEXT:    v_cndmask_b32_e32 v9, v11, v12, vcc
 ; GFX8-NEXT:    v_lshrrev_b32_e32 v10, 16, v5
 ; GFX8-NEXT:    v_lshrrev_b32_e32 v12, 16, v1
 ; GFX8-NEXT:    v_min_f16_e32 v13, v12, v10
 ; GFX8-NEXT:    v_cmp_o_f16_e32 vcc, v12, v10
-; GFX8-NEXT:    v_cndmask_b32_e32 v13, v11, v13, vcc
-; GFX8-NEXT:    v_cmp_class_f16_e64 vcc, v12, 32
-; GFX8-NEXT:    v_cndmask_b32_e32 v12, v13, v12, vcc
-; GFX8-NEXT:    v_cmp_class_f16_e64 vcc, v10, 32
-; GFX8-NEXT:    v_cndmask_b32_e32 v10, v12, v10, vcc
-; GFX8-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v13
-; GFX8-NEXT:    v_cndmask_b32_e32 v10, v13, v10, vcc
+; GFX8-NEXT:    v_cndmask_b32_e32 v10, v11, v13, vcc
 ; GFX8-NEXT:    v_lshrrev_b32_e32 v12, 16, v4
 ; GFX8-NEXT:    v_lshrrev_b32_e32 v13, 16, v0
 ; GFX8-NEXT:    v_min_f16_e32 v14, v13, v12
 ; GFX8-NEXT:    v_cmp_o_f16_e32 vcc, v13, v12
-; GFX8-NEXT:    v_cndmask_b32_e32 v14, v11, v14, vcc
-; GFX8-NEXT:    v_cmp_class_f16_e64 vcc, v13, 32
-; GFX8-NEXT:    v_cndmask_b32_e32 v13, v14, v13, vcc
-; GFX8-NEXT:    v_cmp_class_f16_e64 vcc, v12, 32
-; GFX8-NEXT:    v_cndmask_b32_e32 v12, v13, v12, vcc
-; GFX8-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v14
-; GFX8-NEXT:    v_cndmask_b32_e32 v12, v14, v12, vcc
+; GFX8-NEXT:    v_cndmask_b32_e32 v12, v11, v14, vcc
 ; GFX8-NEXT:    v_min_f16_e32 v13, v3, v7
 ; GFX8-NEXT:    v_cmp_o_f16_e32 vcc, v3, v7
-; GFX8-NEXT:    v_cndmask_b32_e32 v13, v11, v13, vcc
-; GFX8-NEXT:    v_cmp_class_f16_e64 vcc, v3, 32
-; GFX8-NEXT:    v_cndmask_b32_e32 v3, v13, v3, vcc
-; GFX8-NEXT:    v_cmp_class_f16_e64 vcc, v7, 32
-; GFX8-NEXT:    v_cndmask_b32_e32 v3, v3, v7, vcc
-; GFX8-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v13
-; GFX8-NEXT:    v_cndmask_b32_e32 v3, v13, v3, vcc
+; GFX8-NEXT:    v_cndmask_b32_e32 v3, v11, v13, vcc
 ; GFX8-NEXT:    v_min_f16_e32 v7, v2, v6
 ; GFX8-NEXT:    v_cmp_o_f16_e32 vcc, v2, v6
-; GFX8-NEXT:    v_cndmask_b32_e32 v7, v11, v7, vcc
-; GFX8-NEXT:    v_cmp_class_f16_e64 vcc, v2, 32
-; GFX8-NEXT:    v_cndmask_b32_e32 v2, v7, v2, vcc
-; GFX8-NEXT:    v_cmp_class_f16_e64 vcc, v6, 32
-; GFX8-NEXT:    v_cndmask_b32_e32 v2, v2, v6, vcc
-; GFX8-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v7
-; GFX8-NEXT:    v_cndmask_b32_e32 v2, v7, v2, vcc
+; GFX8-NEXT:    v_cndmask_b32_e32 v2, v11, v7, vcc
 ; GFX8-NEXT:    v_min_f16_e32 v6, v1, v5
 ; GFX8-NEXT:    v_cmp_o_f16_e32 vcc, v1, v5
-; GFX8-NEXT:    v_cndmask_b32_e32 v6, v11, v6, vcc
-; GFX8-NEXT:    v_cmp_class_f16_e64 vcc, v1, 32
-; GFX8-NEXT:    v_cndmask_b32_e32 v1, v6, v1, vcc
-; GFX8-NEXT:    v_cmp_class_f16_e64 vcc, v5, 32
-; GFX8-NEXT:    v_cndmask_b32_e32 v1, v1, v5, vcc
-; GFX8-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v6
-; GFX8-NEXT:    v_cndmask_b32_e32 v1, v6, v1, vcc
+; GFX8-NEXT:    v_cndmask_b32_e32 v1, v11, v6, vcc
 ; GFX8-NEXT:    v_min_f16_e32 v5, v0, v4
 ; GFX8-NEXT:    v_cmp_o_f16_e32 vcc, v0, v4
-; GFX8-NEXT:    v_cndmask_b32_e32 v5, v11, v5, vcc
-; GFX8-NEXT:    v_cmp_class_f16_e64 vcc, v0, 32
-; GFX8-NEXT:    v_cndmask_b32_e32 v0, v5, v0, vcc
-; GFX8-NEXT:    v_cmp_class_f16_e64 vcc, v4, 32
-; GFX8-NEXT:    v_cndmask_b32_e32 v0, v0, v4, vcc
-; GFX8-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v5
-; GFX8-NEXT:    v_cndmask_b32_e32 v0, v5, v0, vcc
+; GFX8-NEXT:    v_cndmask_b32_e32 v0, v11, v5, vcc
 ; GFX8-NEXT:    v_lshlrev_b32_e32 v4, 16, v12
 ; GFX8-NEXT:    v_or_b32_sdwa v0, v0, v4 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
 ; GFX8-NEXT:    v_lshlrev_b32_e32 v4, 16, v10
@@ -2586,83 +1620,27 @@ define <8 x half> @v_minimum_v8f16(<8 x half> %src0, <8 x half> %src1) {
 ; GFX9-NEXT:    v_mov_b32_e32 v9, 0x7e00
 ; GFX9-NEXT:    v_cmp_o_f16_e32 vcc, v3, v7
 ; GFX9-NEXT:    v_cndmask_b32_e32 v10, v9, v8, vcc
-; GFX9-NEXT:    v_cmp_class_f16_e64 vcc, v3, 32
-; GFX9-NEXT:    v_cndmask_b32_e32 v11, v10, v3, vcc
-; GFX9-NEXT:    v_cmp_class_f16_e64 vcc, v7, 32
-; GFX9-NEXT:    v_cndmask_b32_e32 v11, v11, v7, vcc
-; GFX9-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v10
-; GFX9-NEXT:    v_lshrrev_b32_e32 v7, 16, v7
-; GFX9-NEXT:    v_lshrrev_b32_e32 v3, 16, v3
-; GFX9-NEXT:    v_cndmask_b32_e32 v10, v10, v11, vcc
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v8, 16, v8
-; GFX9-NEXT:    v_cmp_o_f16_e32 vcc, v3, v7
-; GFX9-NEXT:    v_cndmask_b32_e32 v8, v9, v8, vcc
-; GFX9-NEXT:    v_cmp_class_f16_e64 vcc, v3, 32
-; GFX9-NEXT:    v_cndmask_b32_e32 v3, v8, v3, vcc
-; GFX9-NEXT:    v_cmp_class_f16_e64 vcc, v7, 32
-; GFX9-NEXT:    v_cndmask_b32_e32 v3, v3, v7, vcc
-; GFX9-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v8
-; GFX9-NEXT:    v_cndmask_b32_e32 v3, v8, v3, vcc
+; GFX9-NEXT:    v_cmp_o_f16_sdwa vcc, v3, v7 src0_sel:WORD_1 src1_sel:WORD_1
+; GFX9-NEXT:    v_cndmask_b32_e32 v3, v9, v8, vcc
 ; GFX9-NEXT:    v_pk_min_f16 v7, v2, v6
 ; GFX9-NEXT:    v_cmp_o_f16_e32 vcc, v2, v6
 ; GFX9-NEXT:    v_cndmask_b32_e32 v8, v9, v7, vcc
-; GFX9-NEXT:    v_cmp_class_f16_e64 vcc, v2, 32
-; GFX9-NEXT:    v_cndmask_b32_e32 v11, v8, v2, vcc
-; GFX9-NEXT:    v_cmp_class_f16_e64 vcc, v6, 32
-; GFX9-NEXT:    v_cndmask_b32_e32 v11, v11, v6, vcc
-; GFX9-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v8
-; GFX9-NEXT:    v_lshrrev_b32_e32 v6, 16, v6
-; GFX9-NEXT:    v_lshrrev_b32_e32 v2, 16, v2
-; GFX9-NEXT:    v_cndmask_b32_e32 v8, v8, v11, vcc
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v7, 16, v7
-; GFX9-NEXT:    v_cmp_o_f16_e32 vcc, v2, v6
-; GFX9-NEXT:    v_cndmask_b32_e32 v7, v9, v7, vcc
-; GFX9-NEXT:    v_cmp_class_f16_e64 vcc, v2, 32
-; GFX9-NEXT:    v_cndmask_b32_e32 v2, v7, v2, vcc
-; GFX9-NEXT:    v_cmp_class_f16_e64 vcc, v6, 32
-; GFX9-NEXT:    v_cndmask_b32_e32 v2, v2, v6, vcc
-; GFX9-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v7
-; GFX9-NEXT:    v_cndmask_b32_e32 v2, v7, v2, vcc
+; GFX9-NEXT:    v_cmp_o_f16_sdwa vcc, v2, v6 src0_sel:WORD_1 src1_sel:WORD_1
+; GFX9-NEXT:    v_cndmask_b32_e32 v2, v9, v7, vcc
 ; GFX9-NEXT:    v_pk_min_f16 v6, v1, v5
 ; GFX9-NEXT:    v_cmp_o_f16_e32 vcc, v1, v5
 ; GFX9-NEXT:    v_cndmask_b32_e32 v7, v9, v6, vcc
-; GFX9-NEXT:    v_cmp_class_f16_e64 vcc, v1, 32
-; GFX9-NEXT:    v_cndmask_b32_e32 v11, v7, v1, vcc
-; GFX9-NEXT:    v_cmp_class_f16_e64 vcc, v5, 32
-; GFX9-NEXT:    v_cndmask_b32_e32 v11, v11, v5, vcc
-; GFX9-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v7
-; GFX9-NEXT:    v_lshrrev_b32_e32 v5, 16, v5
-; GFX9-NEXT:    v_lshrrev_b32_e32 v1, 16, v1
-; GFX9-NEXT:    v_cndmask_b32_e32 v7, v7, v11, vcc
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v6, 16, v6
-; GFX9-NEXT:    v_cmp_o_f16_e32 vcc, v1, v5
-; GFX9-NEXT:    v_cndmask_b32_e32 v6, v9, v6, vcc
-; GFX9-NEXT:    v_cmp_class_f16_e64 vcc, v1, 32
-; GFX9-NEXT:    v_cndmask_b32_e32 v1, v6, v1, vcc
-; GFX9-NEXT:    v_cmp_class_f16_e64 vcc, v5, 32
-; GFX9-NEXT:    v_cndmask_b32_e32 v1, v1, v5, vcc
-; GFX9-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v6
-; GFX9-NEXT:    v_cndmask_b32_e32 v1, v6, v1, vcc
+; GFX9-NEXT:    v_cmp_o_f16_sdwa vcc, v1, v5 src0_sel:WORD_1 src1_sel:WORD_1
+; GFX9-NEXT:    v_cndmask_b32_e32 v1, v9, v6, vcc
 ; GFX9-NEXT:    v_pk_min_f16 v5, v0, v4
 ; GFX9-NEXT:    v_cmp_o_f16_e32 vcc, v0, v4
 ; GFX9-NEXT:    v_cndmask_b32_e32 v6, v9, v5, vcc
-; GFX9-NEXT:    v_cmp_class_f16_e64 vcc, v0, 32
-; GFX9-NEXT:    v_cndmask_b32_e32 v11, v6, v0, vcc
-; GFX9-NEXT:    v_cmp_class_f16_e64 vcc, v4, 32
-; GFX9-NEXT:    v_cndmask_b32_e32 v11, v11, v4, vcc
-; GFX9-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v6
-; GFX9-NEXT:    v_lshrrev_b32_e32 v4, 16, v4
-; GFX9-NEXT:    v_lshrrev_b32_e32 v0, 16, v0
-; GFX9-NEXT:    v_cndmask_b32_e32 v6, v6, v11, vcc
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v5, 16, v5
-; GFX9-NEXT:    v_cmp_o_f16_e32 vcc, v0, v4
-; GFX9-NEXT:    v_cndmask_b32_e32 v5, v9, v5, vcc
-; GFX9-NEXT:    v_cmp_class_f16_e64 vcc, v0, 32
-; GFX9-NEXT:    v_cndmask_b32_e32 v0, v5, v0, vcc
-; GFX9-NEXT:    v_cmp_class_f16_e64 vcc, v4, 32
-; GFX9-NEXT:    v_cndmask_b32_e32 v0, v0, v4, vcc
-; GFX9-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v5
-; GFX9-NEXT:    v_cndmask_b32_e32 v0, v5, v0, vcc
+; GFX9-NEXT:    v_cmp_o_f16_sdwa vcc, v0, v4 src0_sel:WORD_1 src1_sel:WORD_1
+; GFX9-NEXT:    v_cndmask_b32_e32 v0, v9, v5, vcc
 ; GFX9-NEXT:    s_mov_b32 s4, 0x5040100
 ; GFX9-NEXT:    v_perm_b32 v0, v0, v6, s4
 ; GFX9-NEXT:    v_perm_b32 v1, v1, v7, s4
@@ -2679,117 +1657,37 @@ define <8 x half> @v_minimum_v8f16(<8 x half> %src0, <8 x half> %src1) {
 ; GFX940-NEXT:    s_mov_b32 s0, 0x5040100
 ; GFX940-NEXT:    s_nop 0
 ; GFX940-NEXT:    v_cndmask_b32_e32 v10, v9, v8, vcc
-; GFX940-NEXT:    v_cmp_class_f16_e64 vcc, v3, 32
 ; GFX940-NEXT:    v_lshrrev_b32_e32 v8, 16, v8
-; GFX940-NEXT:    s_nop 0
-; GFX940-NEXT:    v_cndmask_b32_e32 v11, v10, v3, vcc
-; GFX940-NEXT:    v_cmp_class_f16_e64 vcc, v7, 32
-; GFX940-NEXT:    v_lshrrev_b32_e32 v3, 16, v3
-; GFX940-NEXT:    s_nop 0
-; GFX940-NEXT:    v_cndmask_b32_e32 v11, v11, v7, vcc
-; GFX940-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v10
-; GFX940-NEXT:    v_lshrrev_b32_e32 v7, 16, v7
-; GFX940-NEXT:    s_nop 0
-; GFX940-NEXT:    v_cndmask_b32_e32 v10, v10, v11, vcc
-; GFX940-NEXT:    v_cmp_o_f16_e32 vcc, v3, v7
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v8, v9, v8, vcc
-; GFX940-NEXT:    v_cmp_class_f16_e64 vcc, v3, 32
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v3, v8, v3, vcc
-; GFX940-NEXT:    v_cmp_class_f16_e64 vcc, v7, 32
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v3, v3, v7, vcc
-; GFX940-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v8
+; GFX940-NEXT:    v_cmp_o_f16_sdwa vcc, v3, v7 src0_sel:WORD_1 src1_sel:WORD_1
 ; GFX940-NEXT:    v_pk_min_f16 v7, v2, v6
 ; GFX940-NEXT:    s_nop 0
-; GFX940-NEXT:    v_cndmask_b32_e32 v3, v8, v3, vcc
+; GFX940-NEXT:    v_cndmask_b32_e32 v3, v9, v8, vcc
 ; GFX940-NEXT:    v_cmp_o_f16_e32 vcc, v2, v6
 ; GFX940-NEXT:    v_perm_b32 v3, v3, v10, s0
 ; GFX940-NEXT:    s_nop 0
 ; GFX940-NEXT:    v_cndmask_b32_e32 v8, v9, v7, vcc
-; GFX940-NEXT:    v_cmp_class_f16_e64 vcc, v2, 32
 ; GFX940-NEXT:    v_lshrrev_b32_e32 v7, 16, v7
-; GFX940-NEXT:    s_nop 0
-; GFX940-NEXT:    v_cndmask_b32_e32 v11, v8, v2, vcc
-; GFX940-NEXT:    v_cmp_class_f16_e64 vcc, v6, 32
-; GFX940-NEXT:    v_lshrrev_b32_e32 v2, 16, v2
-; GFX940-NEXT:    s_nop 0
-; GFX940-NEXT:    v_cndmask_b32_e32 v11, v11, v6, vcc
-; GFX940-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v8
-; GFX940-NEXT:    v_lshrrev_b32_e32 v6, 16, v6
-; GFX940-NEXT:    s_nop 0
-; GFX940-NEXT:    v_cndmask_b32_e32 v8, v8, v11, vcc
-; GFX940-NEXT:    v_cmp_o_f16_e32 vcc, v2, v6
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v7, v9, v7, vcc
-; GFX940-NEXT:    v_cmp_class_f16_e64 vcc, v2, 32
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v2, v7, v2, vcc
-; GFX940-NEXT:    v_cmp_class_f16_e64 vcc, v6, 32
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v2, v2, v6, vcc
-; GFX940-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v7
+; GFX940-NEXT:    v_cmp_o_f16_sdwa vcc, v2, v6 src0_sel:WORD_1 src1_sel:WORD_1
 ; GFX940-NEXT:    v_pk_min_f16 v6, v1, v5
 ; GFX940-NEXT:    s_nop 0
-; GFX940-NEXT:    v_cndmask_b32_e32 v2, v7, v2, vcc
+; GFX940-NEXT:    v_cndmask_b32_e32 v2, v9, v7, vcc
 ; GFX940-NEXT:    v_cmp_o_f16_e32 vcc, v1, v5
 ; GFX940-NEXT:    v_perm_b32 v2, v2, v8, s0
 ; GFX940-NEXT:    s_nop 0
 ; GFX940-NEXT:    v_cndmask_b32_e32 v7, v9, v6, vcc
-; GFX940-NEXT:    v_cmp_class_f16_e64 vcc, v1, 32
 ; GFX940-NEXT:    v_lshrrev_b32_e32 v6, 16, v6
-; GFX940-NEXT:    s_nop 0
-; GFX940-NEXT:    v_cndmask_b32_e32 v11, v7, v1, vcc
-; GFX940-NEXT:    v_cmp_class_f16_e64 vcc, v5, 32
-; GFX940-NEXT:    v_lshrrev_b32_e32 v1, 16, v1
-; GFX940-NEXT:    s_nop 0
-; GFX940-NEXT:    v_cndmask_b32_e32 v11, v11, v5, vcc
-; GFX940-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v7
-; GFX940-NEXT:    v_lshrrev_b32_e32 v5, 16, v5
-; GFX940-NEXT:    s_nop 0
-; GFX940-NEXT:    v_cndmask_b32_e32 v7, v7, v11, vcc
-; GFX940-NEXT:    v_cmp_o_f16_e32 vcc, v1, v5
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v6, v9, v6, vcc
-; GFX940-NEXT:    v_cmp_class_f16_e64 vcc, v1, 32
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v1, v6, v1, vcc
-; GFX940-NEXT:    v_cmp_class_f16_e64 vcc, v5, 32
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v1, v1, v5, vcc
-; GFX940-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v6
+; GFX940-NEXT:    v_cmp_o_f16_sdwa vcc, v1, v5 src0_sel:WORD_1 src1_sel:WORD_1
 ; GFX940-NEXT:    v_pk_min_f16 v5, v0, v4
 ; GFX940-NEXT:    s_nop 0
-; GFX940-NEXT:    v_cndmask_b32_e32 v1, v6, v1, vcc
+; GFX940-NEXT:    v_cndmask_b32_e32 v1, v9, v6, vcc
 ; GFX940-NEXT:    v_cmp_o_f16_e32 vcc, v0, v4
 ; GFX940-NEXT:    v_perm_b32 v1, v1, v7, s0
 ; GFX940-NEXT:    s_nop 0
 ; GFX940-NEXT:    v_cndmask_b32_e32 v6, v9, v5, vcc
-; GFX940-NEXT:    v_cmp_class_f16_e64 vcc, v0, 32
 ; GFX940-NEXT:    v_lshrrev_b32_e32 v5, 16, v5
-; GFX940-NEXT:    s_nop 0
-; GFX940-NEXT:    v_cndmask_b32_e32 v11, v6, v0, vcc
-; GFX940-NEXT:    v_cmp_class_f16_e64 vcc, v4, 32
-; GFX940-NEXT:    v_lshrrev_b32_e32 v0, 16, v0
-; GFX940-NEXT:    s_nop 0
-; GFX940-NEXT:    v_cndmask_b32_e32 v11, v11, v4, vcc
-; GFX940-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v6
-; GFX940-NEXT:    v_lshrrev_b32_e32 v4, 16, v4
-; GFX940-NEXT:    s_nop 0
-; GFX940-NEXT:    v_cndmask_b32_e32 v6, v6, v11, vcc
-; GFX940-NEXT:    v_cmp_o_f16_e32 vcc, v0, v4
+; GFX940-NEXT:    v_cmp_o_f16_sdwa vcc, v0, v4 src0_sel:WORD_1 src1_sel:WORD_1
 ; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v5, v9, v5, vcc
-; GFX940-NEXT:    v_cmp_class_f16_e64 vcc, v0, 32
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v0, v5, v0, vcc
-; GFX940-NEXT:    v_cmp_class_f16_e64 vcc, v4, 32
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v0, v0, v4, vcc
-; GFX940-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v5
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v0, v5, v0, vcc
+; GFX940-NEXT:    v_cndmask_b32_e32 v0, v9, v5, vcc
 ; GFX940-NEXT:    v_perm_b32 v0, v0, v6, s0
 ; GFX940-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -2798,88 +1696,32 @@ define <8 x half> @v_minimum_v8f16(<8 x half> %src0, <8 x half> %src1) {
 ; GFX10-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX10-NEXT:    v_pk_min_f16 v8, v3, v7
 ; GFX10-NEXT:    v_cmp_o_f16_e32 vcc_lo, v3, v7
-; GFX10-NEXT:    v_lshrrev_b32_e32 v10, 16, v7
-; GFX10-NEXT:    v_lshrrev_b32_e32 v11, 16, v3
-; GFX10-NEXT:    v_pk_min_f16 v13, v1, v5
-; GFX10-NEXT:    v_cndmask_b32_e32 v9, 0x7e00, v8, vcc_lo
-; GFX10-NEXT:    v_cmp_class_f16_e64 vcc_lo, v3, 32
-; GFX10-NEXT:    v_lshrrev_b32_e32 v8, 16, v8
-; GFX10-NEXT:    v_cndmask_b32_e32 v3, v9, v3, vcc_lo
-; GFX10-NEXT:    v_cmp_o_f16_e32 vcc_lo, v11, v10
-; GFX10-NEXT:    v_cndmask_b32_e32 v8, 0x7e00, v8, vcc_lo
-; GFX10-NEXT:    v_cmp_class_f16_e64 vcc_lo, v7, 32
-; GFX10-NEXT:    v_cndmask_b32_e32 v3, v3, v7, vcc_lo
-; GFX10-NEXT:    v_cmp_class_f16_e64 vcc_lo, v11, 32
-; GFX10-NEXT:    v_cndmask_b32_e32 v7, v8, v11, vcc_lo
-; GFX10-NEXT:    v_cmp_eq_f16_e32 vcc_lo, 0, v9
-; GFX10-NEXT:    v_pk_min_f16 v11, v2, v6
-; GFX10-NEXT:    v_cndmask_b32_e32 v3, v9, v3, vcc_lo
-; GFX10-NEXT:    v_cmp_class_f16_e64 vcc_lo, v10, 32
-; GFX10-NEXT:    v_lshrrev_b32_e32 v9, 16, v6
-; GFX10-NEXT:    v_lshrrev_b32_e32 v12, 16, v11
-; GFX10-NEXT:    v_cndmask_b32_e32 v7, v7, v10, vcc_lo
-; GFX10-NEXT:    v_lshrrev_b32_e32 v10, 16, v2
+; GFX10-NEXT:    v_pk_min_f16 v9, v2, v6
+; GFX10-NEXT:    v_pk_min_f16 v12, v1, v5
+; GFX10-NEXT:    v_pk_min_f16 v13, v0, v4
+; GFX10-NEXT:    v_cndmask_b32_e32 v10, 0x7e00, v8, vcc_lo
 ; GFX10-NEXT:    v_cmp_o_f16_e32 vcc_lo, v2, v6
-; GFX10-NEXT:    v_cndmask_b32_e32 v11, 0x7e00, v11, vcc_lo
-; GFX10-NEXT:    v_cmp_o_f16_e32 vcc_lo, v10, v9
-; GFX10-NEXT:    v_cndmask_b32_e32 v12, 0x7e00, v12, vcc_lo
+; GFX10-NEXT:    v_lshrrev_b32_e32 v11, 16, v9
+; GFX10-NEXT:    v_lshrrev_b32_e32 v8, 16, v8
+; GFX10-NEXT:    v_cndmask_b32_e32 v9, 0x7e00, v9, vcc_lo
+; GFX10-NEXT:    v_cmp_o_f16_sdwa vcc_lo, v2, v6 src0_sel:WORD_1 src1_sel:WORD_1
+; GFX10-NEXT:    v_cndmask_b32_e32 v2, 0x7e00, v11, vcc_lo
 ; GFX10-NEXT:    v_cmp_o_f16_e32 vcc_lo, v1, v5
-; GFX10-NEXT:    v_cndmask_b32_e32 v14, 0x7e00, v13, vcc_lo
-; GFX10-NEXT:    v_cmp_class_f16_e64 vcc_lo, v2, 32
-; GFX10-NEXT:    v_lshrrev_b32_e32 v13, 16, v13
-; GFX10-NEXT:    v_cndmask_b32_e32 v2, v11, v2, vcc_lo
-; GFX10-NEXT:    v_cmp_class_f16_e64 vcc_lo, v10, 32
-; GFX10-NEXT:    v_cndmask_b32_e32 v10, v12, v10, vcc_lo
-; GFX10-NEXT:    v_cmp_class_f16_e64 vcc_lo, v1, 32
-; GFX10-NEXT:    v_cndmask_b32_e32 v15, v14, v1, vcc_lo
-; GFX10-NEXT:    v_cmp_class_f16_e64 vcc_lo, v6, 32
-; GFX10-NEXT:    v_lshrrev_b32_e32 v1, 16, v1
-; GFX10-NEXT:    v_cndmask_b32_e32 v2, v2, v6, vcc_lo
-; GFX10-NEXT:    v_cmp_class_f16_e64 vcc_lo, v9, 32
-; GFX10-NEXT:    v_cndmask_b32_e32 v6, v10, v9, vcc_lo
-; GFX10-NEXT:    v_cmp_class_f16_e64 vcc_lo, v5, 32
-; GFX10-NEXT:    v_pk_min_f16 v10, v0, v4
-; GFX10-NEXT:    v_cndmask_b32_e32 v9, v15, v5, vcc_lo
-; GFX10-NEXT:    v_cmp_eq_f16_e32 vcc_lo, 0, v11
-; GFX10-NEXT:    v_lshrrev_b32_e32 v5, 16, v5
-; GFX10-NEXT:    v_cndmask_b32_e32 v2, v11, v2, vcc_lo
-; GFX10-NEXT:    v_cmp_eq_f16_e32 vcc_lo, 0, v12
-; GFX10-NEXT:    v_lshrrev_b32_e32 v11, 16, v4
-; GFX10-NEXT:    v_cndmask_b32_e32 v6, v12, v6, vcc_lo
-; GFX10-NEXT:    v_cmp_eq_f16_e32 vcc_lo, 0, v14
-; GFX10-NEXT:    v_lshrrev_b32_e32 v12, 16, v0
-; GFX10-NEXT:    v_perm_b32 v2, v6, v2, 0x5040100
-; GFX10-NEXT:    v_cndmask_b32_e32 v9, v14, v9, vcc_lo
+; GFX10-NEXT:    v_lshrrev_b32_e32 v11, 16, v13
+; GFX10-NEXT:    v_perm_b32 v2, v2, v9, 0x5040100
+; GFX10-NEXT:    v_cndmask_b32_e32 v6, 0x7e00, v12, vcc_lo
 ; GFX10-NEXT:    v_cmp_o_f16_e32 vcc_lo, v0, v4
-; GFX10-NEXT:    v_lshrrev_b32_e32 v14, 16, v10
-; GFX10-NEXT:    v_cndmask_b32_e32 v10, 0x7e00, v10, vcc_lo
-; GFX10-NEXT:    v_cmp_o_f16_e32 vcc_lo, v12, v11
-; GFX10-NEXT:    v_cndmask_b32_e32 v14, 0x7e00, v14, vcc_lo
-; GFX10-NEXT:    v_cmp_o_f16_e32 vcc_lo, v1, v5
+; GFX10-NEXT:    v_lshrrev_b32_e32 v12, 16, v12
 ; GFX10-NEXT:    v_cndmask_b32_e32 v13, 0x7e00, v13, vcc_lo
-; GFX10-NEXT:    v_cmp_class_f16_e64 vcc_lo, v0, 32
-; GFX10-NEXT:    v_cndmask_b32_e32 v0, v10, v0, vcc_lo
-; GFX10-NEXT:    v_cmp_class_f16_e64 vcc_lo, v12, 32
-; GFX10-NEXT:    v_cndmask_b32_e32 v12, v14, v12, vcc_lo
-; GFX10-NEXT:    v_cmp_class_f16_e64 vcc_lo, v1, 32
-; GFX10-NEXT:    v_cndmask_b32_e32 v1, v13, v1, vcc_lo
-; GFX10-NEXT:    v_cmp_class_f16_e64 vcc_lo, v4, 32
-; GFX10-NEXT:    v_cndmask_b32_e32 v0, v0, v4, vcc_lo
-; GFX10-NEXT:    v_cmp_class_f16_e64 vcc_lo, v11, 32
-; GFX10-NEXT:    v_cndmask_b32_e32 v4, v12, v11, vcc_lo
-; GFX10-NEXT:    v_cmp_class_f16_e64 vcc_lo, v5, 32
-; GFX10-NEXT:    v_cndmask_b32_e32 v1, v1, v5, vcc_lo
-; GFX10-NEXT:    v_cmp_eq_f16_e32 vcc_lo, 0, v10
-; GFX10-NEXT:    v_cndmask_b32_e32 v0, v10, v0, vcc_lo
-; GFX10-NEXT:    v_cmp_eq_f16_e32 vcc_lo, 0, v14
-; GFX10-NEXT:    v_cndmask_b32_e32 v4, v14, v4, vcc_lo
-; GFX10-NEXT:    v_cmp_eq_f16_e32 vcc_lo, 0, v13
-; GFX10-NEXT:    v_perm_b32 v0, v4, v0, 0x5040100
-; GFX10-NEXT:    v_cndmask_b32_e32 v1, v13, v1, vcc_lo
-; GFX10-NEXT:    v_cmp_eq_f16_e32 vcc_lo, 0, v8
-; GFX10-NEXT:    v_perm_b32 v1, v1, v9, 0x5040100
-; GFX10-NEXT:    v_cndmask_b32_e32 v5, v8, v7, vcc_lo
-; GFX10-NEXT:    v_perm_b32 v3, v5, v3, 0x5040100
+; GFX10-NEXT:    v_cmp_o_f16_sdwa vcc_lo, v0, v4 src0_sel:WORD_1 src1_sel:WORD_1
+; GFX10-NEXT:    v_cndmask_b32_e32 v0, 0x7e00, v11, vcc_lo
+; GFX10-NEXT:    v_cmp_o_f16_sdwa vcc_lo, v1, v5 src0_sel:WORD_1 src1_sel:WORD_1
+; GFX10-NEXT:    v_perm_b32 v0, v0, v13, 0x5040100
+; GFX10-NEXT:    v_cndmask_b32_e32 v1, 0x7e00, v12, vcc_lo
+; GFX10-NEXT:    v_cmp_o_f16_sdwa vcc_lo, v3, v7 src0_sel:WORD_1 src1_sel:WORD_1
+; GFX10-NEXT:    v_perm_b32 v1, v1, v6, 0x5040100
+; GFX10-NEXT:    v_cndmask_b32_e32 v3, 0x7e00, v8, vcc_lo
+; GFX10-NEXT:    v_perm_b32 v3, v3, v10, 0x5040100
 ; GFX10-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX11-LABEL: v_minimum_v8f16:
@@ -2887,94 +1729,42 @@ define <8 x half> @v_minimum_v8f16(<8 x half> %src0, <8 x half> %src1) {
 ; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX11-NEXT:    v_pk_min_f16 v8, v3, v7
 ; GFX11-NEXT:    v_cmp_o_f16_e32 vcc_lo, v3, v7
-; GFX11-NEXT:    v_lshrrev_b32_e32 v10, 16, v7
-; GFX11-NEXT:    v_lshrrev_b32_e32 v11, 16, v3
-; GFX11-NEXT:    v_pk_min_f16 v13, v1, v5
+; GFX11-NEXT:    v_pk_min_f16 v10, v2, v6
+; GFX11-NEXT:    v_lshrrev_b32_e32 v11, 16, v6
+; GFX11-NEXT:    v_lshrrev_b32_e32 v12, 16, v2
+; GFX11-NEXT:    v_pk_min_f16 v14, v1, v5
 ; GFX11-NEXT:    v_cndmask_b32_e32 v9, 0x7e00, v8, vcc_lo
-; GFX11-NEXT:    v_cmp_class_f16_e64 vcc_lo, v3, 32
-; GFX11-NEXT:    v_lshrrev_b32_e32 v8, 16, v8
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(SKIP_1) | instid1(VALU_DEP_3)
-; GFX11-NEXT:    v_cndmask_b32_e32 v3, v9, v3, vcc_lo
-; GFX11-NEXT:    v_cmp_o_f16_e32 vcc_lo, v11, v10
-; GFX11-NEXT:    v_cndmask_b32_e32 v8, 0x7e00, v8, vcc_lo
-; GFX11-NEXT:    v_cmp_class_f16_e64 vcc_lo, v7, 32
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(SKIP_1) | instid1(VALU_DEP_4)
-; GFX11-NEXT:    v_cndmask_b32_e32 v3, v3, v7, vcc_lo
-; GFX11-NEXT:    v_cmp_class_f16_e64 vcc_lo, v11, 32
-; GFX11-NEXT:    v_cndmask_b32_e32 v7, v8, v11, vcc_lo
-; GFX11-NEXT:    v_cmp_eq_f16_e32 vcc_lo, 0, v9
-; GFX11-NEXT:    v_pk_min_f16 v11, v2, v6
-; GFX11-NEXT:    v_cndmask_b32_e32 v3, v9, v3, vcc_lo
-; GFX11-NEXT:    v_cmp_class_f16_e64 vcc_lo, v10, 32
-; GFX11-NEXT:    v_lshrrev_b32_e32 v9, 16, v6
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(SKIP_4) | instid1(VALU_DEP_3)
-; GFX11-NEXT:    v_lshrrev_b32_e32 v12, 16, v11
-; GFX11-NEXT:    v_cndmask_b32_e32 v7, v7, v10, vcc_lo
-; GFX11-NEXT:    v_lshrrev_b32_e32 v10, 16, v2
 ; GFX11-NEXT:    v_cmp_o_f16_e32 vcc_lo, v2, v6
-; GFX11-NEXT:    v_cndmask_b32_e32 v11, 0x7e00, v11, vcc_lo
-; GFX11-NEXT:    v_cmp_o_f16_e32 vcc_lo, v10, v9
-; GFX11-NEXT:    v_cndmask_b32_e32 v12, 0x7e00, v12, vcc_lo
-; GFX11-NEXT:    v_cmp_o_f16_e32 vcc_lo, v1, v5
-; GFX11-NEXT:    v_cndmask_b32_e32 v14, 0x7e00, v13, vcc_lo
-; GFX11-NEXT:    v_cmp_class_f16_e64 vcc_lo, v2, 32
-; GFX11-NEXT:    v_lshrrev_b32_e32 v13, 16, v13
-; GFX11-NEXT:    v_cndmask_b32_e32 v2, v11, v2, vcc_lo
-; GFX11-NEXT:    v_cmp_class_f16_e64 vcc_lo, v10, 32
-; GFX11-NEXT:    v_cndmask_b32_e32 v10, v12, v10, vcc_lo
-; GFX11-NEXT:    v_cmp_class_f16_e64 vcc_lo, v1, 32
-; GFX11-NEXT:    v_cndmask_b32_e32 v15, v14, v1, vcc_lo
-; GFX11-NEXT:    v_cmp_class_f16_e64 vcc_lo, v6, 32
-; GFX11-NEXT:    v_lshrrev_b32_e32 v1, 16, v1
-; GFX11-NEXT:    v_cndmask_b32_e32 v2, v2, v6, vcc_lo
-; GFX11-NEXT:    v_cmp_class_f16_e64 vcc_lo, v9, 32
-; GFX11-NEXT:    v_cndmask_b32_e32 v6, v10, v9, vcc_lo
-; GFX11-NEXT:    v_cmp_class_f16_e64 vcc_lo, v5, 32
-; GFX11-NEXT:    v_pk_min_f16 v10, v0, v4
-; GFX11-NEXT:    v_cndmask_b32_e32 v9, v15, v5, vcc_lo
-; GFX11-NEXT:    v_cmp_eq_f16_e32 vcc_lo, 0, v11
-; GFX11-NEXT:    v_lshrrev_b32_e32 v5, 16, v5
-; GFX11-NEXT:    v_cndmask_b32_e32 v2, v11, v2, vcc_lo
-; GFX11-NEXT:    v_cmp_eq_f16_e32 vcc_lo, 0, v12
-; GFX11-NEXT:    v_lshrrev_b32_e32 v11, 16, v4
-; GFX11-NEXT:    v_cndmask_b32_e32 v6, v12, v6, vcc_lo
-; GFX11-NEXT:    v_cmp_eq_f16_e32 vcc_lo, 0, v14
-; GFX11-NEXT:    v_lshrrev_b32_e32 v12, 16, v0
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_3)
-; GFX11-NEXT:    v_perm_b32 v2, v6, v2, 0x5040100
-; GFX11-NEXT:    v_cndmask_b32_e32 v9, v14, v9, vcc_lo
-; GFX11-NEXT:    v_cmp_o_f16_e32 vcc_lo, v0, v4
-; GFX11-NEXT:    v_lshrrev_b32_e32 v14, 16, v10
-; GFX11-NEXT:    v_cndmask_b32_e32 v10, 0x7e00, v10, vcc_lo
+; GFX11-NEXT:    v_lshrrev_b32_e32 v13, 16, v10
+; GFX11-NEXT:    v_lshrrev_b32_e32 v7, 16, v7
+; GFX11-NEXT:    v_lshrrev_b32_e32 v3, 16, v3
+; GFX11-NEXT:    v_lshrrev_b32_e32 v8, 16, v8
+; GFX11-NEXT:    v_cndmask_b32_e32 v2, 0x7e00, v10, vcc_lo
 ; GFX11-NEXT:    v_cmp_o_f16_e32 vcc_lo, v12, v11
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_3)
-; GFX11-NEXT:    v_cndmask_b32_e32 v14, 0x7e00, v14, vcc_lo
+; GFX11-NEXT:    v_pk_min_f16 v11, v0, v4
+; GFX11-NEXT:    v_lshrrev_b32_e32 v12, 16, v4
+; GFX11-NEXT:    v_cndmask_b32_e32 v6, 0x7e00, v13, vcc_lo
 ; GFX11-NEXT:    v_cmp_o_f16_e32 vcc_lo, v1, v5
-; GFX11-NEXT:    v_cndmask_b32_e32 v13, 0x7e00, v13, vcc_lo
-; GFX11-NEXT:    v_cmp_class_f16_e64 vcc_lo, v0, 32
-; GFX11-NEXT:    v_cndmask_b32_e32 v0, v10, v0, vcc_lo
-; GFX11-NEXT:    v_cmp_class_f16_e64 vcc_lo, v12, 32
-; GFX11-NEXT:    v_cndmask_b32_e32 v12, v14, v12, vcc_lo
-; GFX11-NEXT:    v_cmp_class_f16_e64 vcc_lo, v1, 32
-; GFX11-NEXT:    v_cndmask_b32_e32 v1, v13, v1, vcc_lo
-; GFX11-NEXT:    v_cmp_class_f16_e64 vcc_lo, v4, 32
-; GFX11-NEXT:    v_cndmask_b32_e32 v0, v0, v4, vcc_lo
-; GFX11-NEXT:    v_cmp_class_f16_e64 vcc_lo, v11, 32
-; GFX11-NEXT:    v_cndmask_b32_e32 v4, v12, v11, vcc_lo
-; GFX11-NEXT:    v_cmp_class_f16_e64 vcc_lo, v5, 32
-; GFX11-NEXT:    v_cndmask_b32_e32 v1, v1, v5, vcc_lo
-; GFX11-NEXT:    v_cmp_eq_f16_e32 vcc_lo, 0, v10
-; GFX11-NEXT:    v_cndmask_b32_e32 v0, v10, v0, vcc_lo
-; GFX11-NEXT:    v_cmp_eq_f16_e32 vcc_lo, 0, v14
-; GFX11-NEXT:    v_cndmask_b32_e32 v4, v14, v4, vcc_lo
-; GFX11-NEXT:    v_cmp_eq_f16_e32 vcc_lo, 0, v13
-; GFX11-NEXT:    v_cndmask_b32_e32 v1, v13, v1, vcc_lo
-; GFX11-NEXT:    v_cmp_eq_f16_e32 vcc_lo, 0, v8
+; GFX11-NEXT:    v_lshrrev_b32_e32 v13, 16, v0
+; GFX11-NEXT:    v_lshrrev_b32_e32 v5, 16, v5
+; GFX11-NEXT:    v_lshrrev_b32_e32 v1, 16, v1
+; GFX11-NEXT:    v_lshrrev_b32_e32 v15, 16, v11
+; GFX11-NEXT:    v_cndmask_b32_e32 v10, 0x7e00, v14, vcc_lo
+; GFX11-NEXT:    v_cmp_o_f16_e32 vcc_lo, v0, v4
+; GFX11-NEXT:    v_lshrrev_b32_e32 v14, 16, v14
+; GFX11-NEXT:    v_perm_b32 v2, v6, v2, 0x5040100
+; GFX11-NEXT:    v_cndmask_b32_e32 v0, 0x7e00, v11, vcc_lo
+; GFX11-NEXT:    v_cmp_o_f16_e32 vcc_lo, v13, v12
+; GFX11-NEXT:    v_cndmask_b32_e32 v4, 0x7e00, v15, vcc_lo
+; GFX11-NEXT:    v_cmp_o_f16_e32 vcc_lo, v1, v5
 ; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(SKIP_2) | instid1(VALU_DEP_2)
-; GFX11-NEXT:    v_perm_b32 v1, v1, v9, 0x5040100
-; GFX11-NEXT:    v_cndmask_b32_e32 v5, v8, v7, vcc_lo
 ; GFX11-NEXT:    v_perm_b32 v0, v4, v0, 0x5040100
-; GFX11-NEXT:    v_perm_b32 v3, v5, v3, 0x5040100
+; GFX11-NEXT:    v_cndmask_b32_e32 v1, 0x7e00, v14, vcc_lo
+; GFX11-NEXT:    v_cmp_o_f16_e32 vcc_lo, v3, v7
+; GFX11-NEXT:    v_perm_b32 v1, v1, v10, 0x5040100
+; GFX11-NEXT:    v_cndmask_b32_e32 v3, 0x7e00, v8, vcc_lo
+; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX11-NEXT:    v_perm_b32 v3, v3, v9, 0x5040100
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX12-LABEL: v_minimum_v8f16:
@@ -2998,166 +1788,70 @@ define <16 x half> @v_minimum_v16f16(<16 x half> %src0, <16 x half> %src1) {
 ; GFX8:       ; %bb.0:
 ; GFX8-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX8-NEXT:    v_lshrrev_b32_e32 v16, 16, v15
-; GFX8-NEXT:    v_lshrrev_b32_e32 v18, 16, v7
-; GFX8-NEXT:    v_min_f16_e32 v19, v18, v16
-; GFX8-NEXT:    v_mov_b32_e32 v17, 0x7e00
-; GFX8-NEXT:    v_cmp_o_f16_e32 vcc, v18, v16
-; GFX8-NEXT:    v_cndmask_b32_e32 v19, v17, v19, vcc
-; GFX8-NEXT:    v_cmp_class_f16_e64 vcc, v18, 32
-; GFX8-NEXT:    v_cndmask_b32_e32 v18, v19, v18, vcc
-; GFX8-NEXT:    v_cmp_class_f16_e64 vcc, v16, 32
-; GFX8-NEXT:    v_cndmask_b32_e32 v16, v18, v16, vcc
-; GFX8-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v19
-; GFX8-NEXT:    v_cndmask_b32_e32 v16, v19, v16, vcc
-; GFX8-NEXT:    v_lshrrev_b32_e32 v18, 16, v14
-; GFX8-NEXT:    v_lshrrev_b32_e32 v19, 16, v6
-; GFX8-NEXT:    v_min_f16_e32 v20, v19, v18
-; GFX8-NEXT:    v_cmp_o_f16_e32 vcc, v19, v18
-; GFX8-NEXT:    v_cndmask_b32_e32 v20, v17, v20, vcc
-; GFX8-NEXT:    v_cmp_class_f16_e64 vcc, v19, 32
-; GFX8-NEXT:    v_cndmask_b32_e32 v19, v20, v19, vcc
-; GFX8-NEXT:    v_cmp_class_f16_e64 vcc, v18, 32
-; GFX8-NEXT:    v_cndmask_b32_e32 v18, v19, v18, vcc
-; GFX8-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v20
-; GFX8-NEXT:    v_cndmask_b32_e32 v18, v20, v18, vcc
-; GFX8-NEXT:    v_lshrrev_b32_e32 v19, 16, v13
+; GFX8-NEXT:    v_lshrrev_b32_e32 v17, 16, v7
+; GFX8-NEXT:    v_min_f16_e32 v18, v17, v16
+; GFX8-NEXT:    v_mov_b32_e32 v19, 0x7e00
+; GFX8-NEXT:    v_cmp_o_f16_e32 vcc, v17, v16
+; GFX8-NEXT:    v_cndmask_b32_e32 v16, v19, v18, vcc
+; GFX8-NEXT:    v_lshrrev_b32_e32 v17, 16, v14
+; GFX8-NEXT:    v_lshrrev_b32_e32 v18, 16, v6
+; GFX8-NEXT:    v_min_f16_e32 v20, v18, v17
+; GFX8-NEXT:    v_cmp_o_f16_e32 vcc, v18, v17
+; GFX8-NEXT:    v_cndmask_b32_e32 v17, v19, v20, vcc
+; GFX8-NEXT:    v_lshrrev_b32_e32 v18, 16, v13
 ; GFX8-NEXT:    v_lshrrev_b32_e32 v20, 16, v5
-; GFX8-NEXT:    v_min_f16_e32 v21, v20, v19
-; GFX8-NEXT:    v_cmp_o_f16_e32 vcc, v20, v19
-; GFX8-NEXT:    v_cndmask_b32_e32 v21, v17, v21, vcc
-; GFX8-NEXT:    v_cmp_class_f16_e64 vcc, v20, 32
-; GFX8-NEXT:    v_cndmask_b32_e32 v20, v21, v20, vcc
-; GFX8-NEXT:    v_cmp_class_f16_e64 vcc, v19, 32
-; GFX8-NEXT:    v_cndmask_b32_e32 v19, v20, v19, vcc
-; GFX8-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v21
-; GFX8-NEXT:    v_cndmask_b32_e32 v19, v21, v19, vcc
+; GFX8-NEXT:    v_min_f16_e32 v21, v20, v18
+; GFX8-NEXT:    v_cmp_o_f16_e32 vcc, v20, v18
+; GFX8-NEXT:    v_cndmask_b32_e32 v18, v19, v21, vcc
 ; GFX8-NEXT:    v_lshrrev_b32_e32 v20, 16, v12
 ; GFX8-NEXT:    v_lshrrev_b32_e32 v21, 16, v4
 ; GFX8-NEXT:    v_min_f16_e32 v22, v21, v20
 ; GFX8-NEXT:    v_cmp_o_f16_e32 vcc, v21, v20
-; GFX8-NEXT:    v_cndmask_b32_e32 v22, v17, v22, vcc
-; GFX8-NEXT:    v_cmp_class_f16_e64 vcc, v21, 32
-; GFX8-NEXT:    v_cndmask_b32_e32 v21, v22, v21, vcc
-; GFX8-NEXT:    v_cmp_class_f16_e64 vcc, v20, 32
-; GFX8-NEXT:    v_cndmask_b32_e32 v20, v21, v20, vcc
-; GFX8-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v22
-; GFX8-NEXT:    v_cndmask_b32_e32 v20, v22, v20, vcc
+; GFX8-NEXT:    v_cndmask_b32_e32 v20, v19, v22, vcc
 ; GFX8-NEXT:    v_lshrrev_b32_e32 v21, 16, v11
 ; GFX8-NEXT:    v_lshrrev_b32_e32 v22, 16, v3
 ; GFX8-NEXT:    v_min_f16_e32 v23, v22, v21
 ; GFX8-NEXT:    v_cmp_o_f16_e32 vcc, v22, v21
-; GFX8-NEXT:    v_cndmask_b32_e32 v23, v17, v23, vcc
-; GFX8-NEXT:    v_cmp_class_f16_e64 vcc, v22, 32
-; GFX8-NEXT:    v_cndmask_b32_e32 v22, v23, v22, vcc
-; GFX8-NEXT:    v_cmp_class_f16_e64 vcc, v21, 32
-; GFX8-NEXT:    v_cndmask_b32_e32 v21, v22, v21, vcc
-; GFX8-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v23
-; GFX8-NEXT:    v_cndmask_b32_e32 v21, v23, v21, vcc
+; GFX8-NEXT:    v_cndmask_b32_e32 v21, v19, v23, vcc
 ; GFX8-NEXT:    v_lshrrev_b32_e32 v22, 16, v10
 ; GFX8-NEXT:    v_lshrrev_b32_e32 v23, 16, v2
 ; GFX8-NEXT:    v_min_f16_e32 v24, v23, v22
 ; GFX8-NEXT:    v_cmp_o_f16_e32 vcc, v23, v22
-; GFX8-NEXT:    v_cndmask_b32_e32 v24, v17, v24, vcc
-; GFX8-NEXT:    v_cmp_class_f16_e64 vcc, v23, 32
-; GFX8-NEXT:    v_cndmask_b32_e32 v23, v24, v23, vcc
-; GFX8-NEXT:    v_cmp_class_f16_e64 vcc, v22, 32
-; GFX8-NEXT:    v_cndmask_b32_e32 v22, v23, v22, vcc
-; GFX8-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v24
-; GFX8-NEXT:    v_cndmask_b32_e32 v22, v24, v22, vcc
+; GFX8-NEXT:    v_cndmask_b32_e32 v22, v19, v24, vcc
 ; GFX8-NEXT:    v_lshrrev_b32_e32 v23, 16, v9
 ; GFX8-NEXT:    v_lshrrev_b32_e32 v24, 16, v1
 ; GFX8-NEXT:    v_min_f16_e32 v25, v24, v23
 ; GFX8-NEXT:    v_cmp_o_f16_e32 vcc, v24, v23
-; GFX8-NEXT:    v_cndmask_b32_e32 v25, v17, v25, vcc
-; GFX8-NEXT:    v_cmp_class_f16_e64 vcc, v24, 32
-; GFX8-NEXT:    v_cndmask_b32_e32 v24, v25, v24, vcc
-; GFX8-NEXT:    v_cmp_class_f16_e64 vcc, v23, 32
-; GFX8-NEXT:    v_cndmask_b32_e32 v23, v24, v23, vcc
-; GFX8-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v25
-; GFX8-NEXT:    v_cndmask_b32_e32 v23, v25, v23, vcc
+; GFX8-NEXT:    v_cndmask_b32_e32 v23, v19, v25, vcc
 ; GFX8-NEXT:    v_lshrrev_b32_e32 v24, 16, v8
 ; GFX8-NEXT:    v_lshrrev_b32_e32 v25, 16, v0
 ; GFX8-NEXT:    v_min_f16_e32 v26, v25, v24
 ; GFX8-NEXT:    v_cmp_o_f16_e32 vcc, v25, v24
-; GFX8-NEXT:    v_cndmask_b32_e32 v26, v17, v26, vcc
-; GFX8-NEXT:    v_cmp_class_f16_e64 vcc, v25, 32
-; GFX8-NEXT:    v_cndmask_b32_e32 v25, v26, v25, vcc
-; GFX8-NEXT:    v_cmp_class_f16_e64 vcc, v24, 32
-; GFX8-NEXT:    v_cndmask_b32_e32 v24, v25, v24, vcc
-; GFX8-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v26
-; GFX8-NEXT:    v_cndmask_b32_e32 v24, v26, v24, vcc
+; GFX8-NEXT:    v_cndmask_b32_e32 v24, v19, v26, vcc
 ; GFX8-NEXT:    v_min_f16_e32 v25, v7, v15
 ; GFX8-NEXT:    v_cmp_o_f16_e32 vcc, v7, v15
-; GFX8-NEXT:    v_cndmask_b32_e32 v25, v17, v25, vcc
-; GFX8-NEXT:    v_cmp_class_f16_e64 vcc, v7, 32
-; GFX8-NEXT:    v_cndmask_b32_e32 v7, v25, v7, vcc
-; GFX8-NEXT:    v_cmp_class_f16_e64 vcc, v15, 32
-; GFX8-NEXT:    v_cndmask_b32_e32 v7, v7, v15, vcc
-; GFX8-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v25
-; GFX8-NEXT:    v_cndmask_b32_e32 v7, v25, v7, vcc
+; GFX8-NEXT:    v_cndmask_b32_e32 v7, v19, v25, vcc
 ; GFX8-NEXT:    v_min_f16_e32 v15, v6, v14
 ; GFX8-NEXT:    v_cmp_o_f16_e32 vcc, v6, v14
-; GFX8-NEXT:    v_cndmask_b32_e32 v15, v17, v15, vcc
-; GFX8-NEXT:    v_cmp_class_f16_e64 vcc, v6, 32
-; GFX8-NEXT:    v_cndmask_b32_e32 v6, v15, v6, vcc
-; GFX8-NEXT:    v_cmp_class_f16_e64 vcc, v14, 32
-; GFX8-NEXT:    v_cndmask_b32_e32 v6, v6, v14, vcc
-; GFX8-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v15
-; GFX8-NEXT:    v_cndmask_b32_e32 v6, v15, v6, vcc
+; GFX8-NEXT:    v_cndmask_b32_e32 v6, v19, v15, vcc
 ; GFX8-NEXT:    v_min_f16_e32 v14, v5, v13
 ; GFX8-NEXT:    v_cmp_o_f16_e32 vcc, v5, v13
-; GFX8-NEXT:    v_cndmask_b32_e32 v14, v17, v14, vcc
-; GFX8-NEXT:    v_cmp_class_f16_e64 vcc, v5, 32
-; GFX8-NEXT:    v_cndmask_b32_e32 v5, v14, v5, vcc
-; GFX8-NEXT:    v_cmp_class_f16_e64 vcc, v13, 32
-; GFX8-NEXT:    v_cndmask_b32_e32 v5, v5, v13, vcc
-; GFX8-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v14
-; GFX8-NEXT:    v_cndmask_b32_e32 v5, v14, v5, vcc
+; GFX8-NEXT:    v_cndmask_b32_e32 v5, v19, v14, vcc
 ; GFX8-NEXT:    v_min_f16_e32 v13, v4, v12
 ; GFX8-NEXT:    v_cmp_o_f16_e32 vcc, v4, v12
-; GFX8-NEXT:    v_cndmask_b32_e32 v13, v17, v13, vcc
-; GFX8-NEXT:    v_cmp_class_f16_e64 vcc, v4, 32
-; GFX8-NEXT:    v_cndmask_b32_e32 v4, v13, v4, vcc
-; GFX8-NEXT:    v_cmp_class_f16_e64 vcc, v12, 32
-; GFX8-NEXT:    v_cndmask_b32_e32 v4, v4, v12, vcc
-; GFX8-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v13
-; GFX8-NEXT:    v_cndmask_b32_e32 v4, v13, v4, vcc
+; GFX8-NEXT:    v_cndmask_b32_e32 v4, v19, v13, vcc
 ; GFX8-NEXT:    v_min_f16_e32 v12, v3, v11
 ; GFX8-NEXT:    v_cmp_o_f16_e32 vcc, v3, v11
-; GFX8-NEXT:    v_cndmask_b32_e32 v12, v17, v12, vcc
-; GFX8-NEXT:    v_cmp_class_f16_e64 vcc, v3, 32
-; GFX8-NEXT:    v_cndmask_b32_e32 v3, v12, v3, vcc
-; GFX8-NEXT:    v_cmp_class_f16_e64 vcc, v11, 32
-; GFX8-NEXT:    v_cndmask_b32_e32 v3, v3, v11, vcc
-; GFX8-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v12
-; GFX8-NEXT:    v_cndmask_b32_e32 v3, v12, v3, vcc
+; GFX8-NEXT:    v_cndmask_b32_e32 v3, v19, v12, vcc
 ; GFX8-NEXT:    v_min_f16_e32 v11, v2, v10
 ; GFX8-NEXT:    v_cmp_o_f16_e32 vcc, v2, v10
-; GFX8-NEXT:    v_cndmask_b32_e32 v11, v17, v11, vcc
-; GFX8-NEXT:    v_cmp_class_f16_e64 vcc, v2, 32
-; GFX8-NEXT:    v_cndmask_b32_e32 v2, v11, v2, vcc
-; GFX8-NEXT:    v_cmp_class_f16_e64 vcc, v10, 32
-; GFX8-NEXT:    v_cndmask_b32_e32 v2, v2, v10, vcc
-; GFX8-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v11
-; GFX8-NEXT:    v_cndmask_b32_e32 v2, v11, v2, vcc
+; GFX8-NEXT:    v_cndmask_b32_e32 v2, v19, v11, vcc
 ; GFX8-NEXT:    v_min_f16_e32 v10, v1, v9
 ; GFX8-NEXT:    v_cmp_o_f16_e32 vcc, v1, v9
-; GFX8-NEXT:    v_cndmask_b32_e32 v10, v17, v10, vcc
-; GFX8-NEXT:    v_cmp_class_f16_e64 vcc, v1, 32
-; GFX8-NEXT:    v_cndmask_b32_e32 v1, v10, v1, vcc
-; GFX8-NEXT:    v_cmp_class_f16_e64 vcc, v9, 32
-; GFX8-NEXT:    v_cndmask_b32_e32 v1, v1, v9, vcc
-; GFX8-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v10
-; GFX8-NEXT:    v_cndmask_b32_e32 v1, v10, v1, vcc
+; GFX8-NEXT:    v_cndmask_b32_e32 v1, v19, v10, vcc
 ; GFX8-NEXT:    v_min_f16_e32 v9, v0, v8
 ; GFX8-NEXT:    v_cmp_o_f16_e32 vcc, v0, v8
-; GFX8-NEXT:    v_cndmask_b32_e32 v9, v17, v9, vcc
-; GFX8-NEXT:    v_cmp_class_f16_e64 vcc, v0, 32
-; GFX8-NEXT:    v_cndmask_b32_e32 v0, v9, v0, vcc
-; GFX8-NEXT:    v_cmp_class_f16_e64 vcc, v8, 32
-; GFX8-NEXT:    v_cndmask_b32_e32 v0, v0, v8, vcc
-; GFX8-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v9
-; GFX8-NEXT:    v_cndmask_b32_e32 v0, v9, v0, vcc
+; GFX8-NEXT:    v_cndmask_b32_e32 v0, v19, v9, vcc
 ; GFX8-NEXT:    v_lshlrev_b32_e32 v8, 16, v24
 ; GFX8-NEXT:    v_or_b32_sdwa v0, v0, v8 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
 ; GFX8-NEXT:    v_lshlrev_b32_e32 v8, 16, v23
@@ -3168,9 +1862,9 @@ define <16 x half> @v_minimum_v16f16(<16 x half> %src0, <16 x half> %src1) {
 ; GFX8-NEXT:    v_or_b32_sdwa v3, v3, v8 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
 ; GFX8-NEXT:    v_lshlrev_b32_e32 v8, 16, v20
 ; GFX8-NEXT:    v_or_b32_sdwa v4, v4, v8 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
-; GFX8-NEXT:    v_lshlrev_b32_e32 v8, 16, v19
-; GFX8-NEXT:    v_or_b32_sdwa v5, v5, v8 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
 ; GFX8-NEXT:    v_lshlrev_b32_e32 v8, 16, v18
+; GFX8-NEXT:    v_or_b32_sdwa v5, v5, v8 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
+; GFX8-NEXT:    v_lshlrev_b32_e32 v8, 16, v17
 ; GFX8-NEXT:    v_or_b32_sdwa v6, v6, v8 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
 ; GFX8-NEXT:    v_lshlrev_b32_e32 v8, 16, v16
 ; GFX8-NEXT:    v_or_b32_sdwa v7, v7, v8 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:WORD_0 src1_sel:DWORD
@@ -3179,414 +1873,142 @@ define <16 x half> @v_minimum_v16f16(<16 x half> %src0, <16 x half> %src1) {
 ; GFX9-LABEL: v_minimum_v16f16:
 ; GFX9:       ; %bb.0:
 ; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX9-NEXT:    v_pk_min_f16 v18, v7, v15
+; GFX9-NEXT:    v_pk_min_f16 v16, v7, v15
 ; GFX9-NEXT:    v_mov_b32_e32 v17, 0x7e00
 ; GFX9-NEXT:    v_cmp_o_f16_e32 vcc, v7, v15
-; GFX9-NEXT:    v_cndmask_b32_e32 v16, v17, v18, vcc
-; GFX9-NEXT:    v_cmp_class_f16_e64 vcc, v7, 32
-; GFX9-NEXT:    v_cndmask_b32_e32 v19, v16, v7, vcc
-; GFX9-NEXT:    v_cmp_class_f16_e64 vcc, v15, 32
-; GFX9-NEXT:    v_cndmask_b32_e32 v19, v19, v15, vcc
-; GFX9-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v16
+; GFX9-NEXT:    v_cndmask_b32_e32 v18, v17, v16, vcc
+; GFX9-NEXT:    v_lshrrev_b32_e32 v16, 16, v16
+; GFX9-NEXT:    v_cmp_o_f16_sdwa vcc, v7, v15 src0_sel:WORD_1 src1_sel:WORD_1
+; GFX9-NEXT:    v_cndmask_b32_e32 v7, v17, v16, vcc
+; GFX9-NEXT:    v_pk_min_f16 v15, v6, v14
+; GFX9-NEXT:    v_cmp_o_f16_e32 vcc, v6, v14
+; GFX9-NEXT:    v_cndmask_b32_e32 v16, v17, v15, vcc
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v15, 16, v15
-; GFX9-NEXT:    v_lshrrev_b32_e32 v7, 16, v7
-; GFX9-NEXT:    v_cndmask_b32_e32 v16, v16, v19, vcc
-; GFX9-NEXT:    v_lshrrev_b32_e32 v18, 16, v18
-; GFX9-NEXT:    v_cmp_o_f16_e32 vcc, v7, v15
-; GFX9-NEXT:    v_cndmask_b32_e32 v18, v17, v18, vcc
-; GFX9-NEXT:    v_cmp_class_f16_e64 vcc, v7, 32
-; GFX9-NEXT:    v_cndmask_b32_e32 v7, v18, v7, vcc
-; GFX9-NEXT:    v_cmp_class_f16_e64 vcc, v15, 32
-; GFX9-NEXT:    v_cndmask_b32_e32 v7, v7, v15, vcc
-; GFX9-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v18
-; GFX9-NEXT:    v_cndmask_b32_e32 v7, v18, v7, vcc
-; GFX9-NEXT:    v_pk_min_f16 v18, v6, v14
-; GFX9-NEXT:    v_cmp_o_f16_e32 vcc, v6, v14
-; GFX9-NEXT:    v_cndmask_b32_e32 v15, v17, v18, vcc
-; GFX9-NEXT:    v_cmp_class_f16_e64 vcc, v6, 32
-; GFX9-NEXT:    v_cndmask_b32_e32 v19, v15, v6, vcc
-; GFX9-NEXT:    v_cmp_class_f16_e64 vcc, v14, 32
-; GFX9-NEXT:    v_cndmask_b32_e32 v19, v19, v14, vcc
-; GFX9-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v15
+; GFX9-NEXT:    v_cmp_o_f16_sdwa vcc, v6, v14 src0_sel:WORD_1 src1_sel:WORD_1
+; GFX9-NEXT:    v_cndmask_b32_e32 v6, v17, v15, vcc
+; GFX9-NEXT:    v_pk_min_f16 v14, v5, v13
+; GFX9-NEXT:    v_cmp_o_f16_e32 vcc, v5, v13
+; GFX9-NEXT:    v_cndmask_b32_e32 v15, v17, v14, vcc
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v14, 16, v14
-; GFX9-NEXT:    v_lshrrev_b32_e32 v6, 16, v6
-; GFX9-NEXT:    v_cndmask_b32_e32 v15, v15, v19, vcc
-; GFX9-NEXT:    v_lshrrev_b32_e32 v18, 16, v18
-; GFX9-NEXT:    v_cmp_o_f16_e32 vcc, v6, v14
-; GFX9-NEXT:    v_cndmask_b32_e32 v18, v17, v18, vcc
-; GFX9-NEXT:    v_cmp_class_f16_e64 vcc, v6, 32
-; GFX9-NEXT:    v_cndmask_b32_e32 v6, v18, v6, vcc
-; GFX9-NEXT:    v_cmp_class_f16_e64 vcc, v14, 32
-; GFX9-NEXT:    v_cndmask_b32_e32 v6, v6, v14, vcc
-; GFX9-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v18
-; GFX9-NEXT:    v_cndmask_b32_e32 v6, v18, v6, vcc
-; GFX9-NEXT:    v_pk_min_f16 v18, v5, v13
-; GFX9-NEXT:    v_cmp_o_f16_e32 vcc, v5, v13
-; GFX9-NEXT:    v_cndmask_b32_e32 v14, v17, v18, vcc
-; GFX9-NEXT:    v_cmp_class_f16_e64 vcc, v5, 32
-; GFX9-NEXT:    v_cndmask_b32_e32 v19, v14, v5, vcc
-; GFX9-NEXT:    v_cmp_class_f16_e64 vcc, v13, 32
-; GFX9-NEXT:    v_cndmask_b32_e32 v19, v19, v13, vcc
-; GFX9-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v14
-; GFX9-NEXT:    v_lshrrev_b32_e32 v13, 16, v13
-; GFX9-NEXT:    v_lshrrev_b32_e32 v5, 16, v5
-; GFX9-NEXT:    v_cndmask_b32_e32 v14, v14, v19, vcc
-; GFX9-NEXT:    v_lshrrev_b32_e32 v18, 16, v18
-; GFX9-NEXT:    v_cmp_o_f16_e32 vcc, v5, v13
-; GFX9-NEXT:    v_cndmask_b32_e32 v18, v17, v18, vcc
-; GFX9-NEXT:    v_cmp_class_f16_e64 vcc, v5, 32
-; GFX9-NEXT:    v_cndmask_b32_e32 v5, v18, v5, vcc
-; GFX9-NEXT:    v_cmp_class_f16_e64 vcc, v13, 32
-; GFX9-NEXT:    v_cndmask_b32_e32 v5, v5, v13, vcc
-; GFX9-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v18
-; GFX9-NEXT:    v_cndmask_b32_e32 v5, v18, v5, vcc
+; GFX9-NEXT:    v_cmp_o_f16_sdwa vcc, v5, v13 src0_sel:WORD_1 src1_sel:WORD_1
+; GFX9-NEXT:    v_cndmask_b32_e32 v5, v17, v14, vcc
 ; GFX9-NEXT:    v_pk_min_f16 v13, v4, v12
 ; GFX9-NEXT:    v_cmp_o_f16_e32 vcc, v4, v12
-; GFX9-NEXT:    v_cndmask_b32_e32 v18, v17, v13, vcc
-; GFX9-NEXT:    v_cmp_class_f16_e64 vcc, v4, 32
-; GFX9-NEXT:    v_cndmask_b32_e32 v19, v18, v4, vcc
-; GFX9-NEXT:    v_cmp_class_f16_e64 vcc, v12, 32
-; GFX9-NEXT:    v_cndmask_b32_e32 v19, v19, v12, vcc
-; GFX9-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v18
-; GFX9-NEXT:    v_lshrrev_b32_e32 v12, 16, v12
-; GFX9-NEXT:    v_lshrrev_b32_e32 v4, 16, v4
-; GFX9-NEXT:    v_cndmask_b32_e32 v18, v18, v19, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v14, v17, v13, vcc
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v13, 16, v13
-; GFX9-NEXT:    v_cmp_o_f16_e32 vcc, v4, v12
-; GFX9-NEXT:    v_cndmask_b32_e32 v13, v17, v13, vcc
-; GFX9-NEXT:    v_cmp_class_f16_e64 vcc, v4, 32
-; GFX9-NEXT:    v_cndmask_b32_e32 v4, v13, v4, vcc
-; GFX9-NEXT:    v_cmp_class_f16_e64 vcc, v12, 32
-; GFX9-NEXT:    v_cndmask_b32_e32 v4, v4, v12, vcc
-; GFX9-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v13
-; GFX9-NEXT:    v_cndmask_b32_e32 v4, v13, v4, vcc
+; GFX9-NEXT:    v_cmp_o_f16_sdwa vcc, v4, v12 src0_sel:WORD_1 src1_sel:WORD_1
+; GFX9-NEXT:    v_cndmask_b32_e32 v4, v17, v13, vcc
 ; GFX9-NEXT:    v_pk_min_f16 v12, v3, v11
 ; GFX9-NEXT:    v_cmp_o_f16_e32 vcc, v3, v11
 ; GFX9-NEXT:    v_cndmask_b32_e32 v13, v17, v12, vcc
-; GFX9-NEXT:    v_cmp_class_f16_e64 vcc, v3, 32
-; GFX9-NEXT:    v_cndmask_b32_e32 v19, v13, v3, vcc
-; GFX9-NEXT:    v_cmp_class_f16_e64 vcc, v11, 32
-; GFX9-NEXT:    v_cndmask_b32_e32 v19, v19, v11, vcc
-; GFX9-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v13
-; GFX9-NEXT:    v_lshrrev_b32_e32 v11, 16, v11
-; GFX9-NEXT:    v_lshrrev_b32_e32 v3, 16, v3
-; GFX9-NEXT:    v_cndmask_b32_e32 v13, v13, v19, vcc
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v12, 16, v12
-; GFX9-NEXT:    v_cmp_o_f16_e32 vcc, v3, v11
-; GFX9-NEXT:    v_cndmask_b32_e32 v12, v17, v12, vcc
-; GFX9-NEXT:    v_cmp_class_f16_e64 vcc, v3, 32
-; GFX9-NEXT:    v_cndmask_b32_e32 v3, v12, v3, vcc
-; GFX9-NEXT:    v_cmp_class_f16_e64 vcc, v11, 32
-; GFX9-NEXT:    v_cndmask_b32_e32 v3, v3, v11, vcc
-; GFX9-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v12
-; GFX9-NEXT:    v_cndmask_b32_e32 v3, v12, v3, vcc
+; GFX9-NEXT:    v_cmp_o_f16_sdwa vcc, v3, v11 src0_sel:WORD_1 src1_sel:WORD_1
+; GFX9-NEXT:    v_cndmask_b32_e32 v3, v17, v12, vcc
 ; GFX9-NEXT:    v_pk_min_f16 v11, v2, v10
 ; GFX9-NEXT:    v_cmp_o_f16_e32 vcc, v2, v10
 ; GFX9-NEXT:    v_cndmask_b32_e32 v12, v17, v11, vcc
-; GFX9-NEXT:    v_cmp_class_f16_e64 vcc, v2, 32
-; GFX9-NEXT:    v_cndmask_b32_e32 v19, v12, v2, vcc
-; GFX9-NEXT:    v_cmp_class_f16_e64 vcc, v10, 32
-; GFX9-NEXT:    v_cndmask_b32_e32 v19, v19, v10, vcc
-; GFX9-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v12
-; GFX9-NEXT:    v_lshrrev_b32_e32 v10, 16, v10
-; GFX9-NEXT:    v_lshrrev_b32_e32 v2, 16, v2
-; GFX9-NEXT:    v_cndmask_b32_e32 v12, v12, v19, vcc
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v11, 16, v11
-; GFX9-NEXT:    v_cmp_o_f16_e32 vcc, v2, v10
-; GFX9-NEXT:    v_cndmask_b32_e32 v11, v17, v11, vcc
-; GFX9-NEXT:    v_cmp_class_f16_e64 vcc, v2, 32
-; GFX9-NEXT:    v_cndmask_b32_e32 v2, v11, v2, vcc
-; GFX9-NEXT:    v_cmp_class_f16_e64 vcc, v10, 32
-; GFX9-NEXT:    v_cndmask_b32_e32 v2, v2, v10, vcc
-; GFX9-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v11
-; GFX9-NEXT:    v_cndmask_b32_e32 v2, v11, v2, vcc
+; GFX9-NEXT:    v_cmp_o_f16_sdwa vcc, v2, v10 src0_sel:WORD_1 src1_sel:WORD_1
+; GFX9-NEXT:    v_cndmask_b32_e32 v2, v17, v11, vcc
 ; GFX9-NEXT:    v_pk_min_f16 v10, v1, v9
 ; GFX9-NEXT:    v_cmp_o_f16_e32 vcc, v1, v9
 ; GFX9-NEXT:    v_cndmask_b32_e32 v11, v17, v10, vcc
-; GFX9-NEXT:    v_cmp_class_f16_e64 vcc, v1, 32
-; GFX9-NEXT:    v_cndmask_b32_e32 v19, v11, v1, vcc
-; GFX9-NEXT:    v_cmp_class_f16_e64 vcc, v9, 32
-; GFX9-NEXT:    v_cndmask_b32_e32 v19, v19, v9, vcc
-; GFX9-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v11
-; GFX9-NEXT:    v_lshrrev_b32_e32 v9, 16, v9
-; GFX9-NEXT:    v_lshrrev_b32_e32 v1, 16, v1
-; GFX9-NEXT:    v_cndmask_b32_e32 v11, v11, v19, vcc
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v10, 16, v10
-; GFX9-NEXT:    v_cmp_o_f16_e32 vcc, v1, v9
-; GFX9-NEXT:    v_cndmask_b32_e32 v10, v17, v10, vcc
-; GFX9-NEXT:    v_cmp_class_f16_e64 vcc, v1, 32
-; GFX9-NEXT:    v_cndmask_b32_e32 v1, v10, v1, vcc
-; GFX9-NEXT:    v_cmp_class_f16_e64 vcc, v9, 32
-; GFX9-NEXT:    v_cndmask_b32_e32 v1, v1, v9, vcc
-; GFX9-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v10
-; GFX9-NEXT:    v_cndmask_b32_e32 v1, v10, v1, vcc
+; GFX9-NEXT:    v_cmp_o_f16_sdwa vcc, v1, v9 src0_sel:WORD_1 src1_sel:WORD_1
+; GFX9-NEXT:    v_cndmask_b32_e32 v1, v17, v10, vcc
 ; GFX9-NEXT:    v_pk_min_f16 v9, v0, v8
 ; GFX9-NEXT:    v_cmp_o_f16_e32 vcc, v0, v8
 ; GFX9-NEXT:    v_cndmask_b32_e32 v10, v17, v9, vcc
-; GFX9-NEXT:    v_cmp_class_f16_e64 vcc, v0, 32
-; GFX9-NEXT:    v_cndmask_b32_e32 v19, v10, v0, vcc
-; GFX9-NEXT:    v_cmp_class_f16_e64 vcc, v8, 32
-; GFX9-NEXT:    v_cndmask_b32_e32 v19, v19, v8, vcc
-; GFX9-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v10
-; GFX9-NEXT:    v_lshrrev_b32_e32 v8, 16, v8
-; GFX9-NEXT:    v_lshrrev_b32_e32 v0, 16, v0
-; GFX9-NEXT:    v_cndmask_b32_e32 v10, v10, v19, vcc
 ; GFX9-NEXT:    v_lshrrev_b32_e32 v9, 16, v9
-; GFX9-NEXT:    v_cmp_o_f16_e32 vcc, v0, v8
-; GFX9-NEXT:    v_cndmask_b32_e32 v9, v17, v9, vcc
-; GFX9-NEXT:    v_cmp_class_f16_e64 vcc, v0, 32
-; GFX9-NEXT:    v_cndmask_b32_e32 v0, v9, v0, vcc
-; GFX9-NEXT:    v_cmp_class_f16_e64 vcc, v8, 32
-; GFX9-NEXT:    v_cndmask_b32_e32 v0, v0, v8, vcc
-; GFX9-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v9
-; GFX9-NEXT:    v_cndmask_b32_e32 v0, v9, v0, vcc
+; GFX9-NEXT:    v_cmp_o_f16_sdwa vcc, v0, v8 src0_sel:WORD_1 src1_sel:WORD_1
+; GFX9-NEXT:    v_cndmask_b32_e32 v0, v17, v9, vcc
 ; GFX9-NEXT:    s_mov_b32 s4, 0x5040100
 ; GFX9-NEXT:    v_perm_b32 v0, v0, v10, s4
 ; GFX9-NEXT:    v_perm_b32 v1, v1, v11, s4
 ; GFX9-NEXT:    v_perm_b32 v2, v2, v12, s4
 ; GFX9-NEXT:    v_perm_b32 v3, v3, v13, s4
-; GFX9-NEXT:    v_perm_b32 v4, v4, v18, s4
-; GFX9-NEXT:    v_perm_b32 v5, v5, v14, s4
-; GFX9-NEXT:    v_perm_b32 v6, v6, v15, s4
-; GFX9-NEXT:    v_perm_b32 v7, v7, v16, s4
+; GFX9-NEXT:    v_perm_b32 v4, v4, v14, s4
+; GFX9-NEXT:    v_perm_b32 v5, v5, v15, s4
+; GFX9-NEXT:    v_perm_b32 v6, v6, v16, s4
+; GFX9-NEXT:    v_perm_b32 v7, v7, v18, s4
 ; GFX9-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX940-LABEL: v_minimum_v16f16:
 ; GFX940:       ; %bb.0:
 ; GFX940-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX940-NEXT:    v_pk_min_f16 v18, v7, v15
+; GFX940-NEXT:    v_pk_min_f16 v16, v7, v15
 ; GFX940-NEXT:    v_mov_b32_e32 v17, 0x7e00
 ; GFX940-NEXT:    v_cmp_o_f16_e32 vcc, v7, v15
 ; GFX940-NEXT:    s_mov_b32 s0, 0x5040100
 ; GFX940-NEXT:    s_nop 0
-; GFX940-NEXT:    v_cndmask_b32_e32 v16, v17, v18, vcc
-; GFX940-NEXT:    v_cmp_class_f16_e64 vcc, v7, 32
-; GFX940-NEXT:    v_lshrrev_b32_e32 v18, 16, v18
+; GFX940-NEXT:    v_cndmask_b32_e32 v18, v17, v16, vcc
+; GFX940-NEXT:    v_lshrrev_b32_e32 v16, 16, v16
+; GFX940-NEXT:    v_cmp_o_f16_sdwa vcc, v7, v15 src0_sel:WORD_1 src1_sel:WORD_1
+; GFX940-NEXT:    v_pk_min_f16 v15, v6, v14
 ; GFX940-NEXT:    s_nop 0
-; GFX940-NEXT:    v_cndmask_b32_e32 v19, v16, v7, vcc
-; GFX940-NEXT:    v_cmp_class_f16_e64 vcc, v15, 32
-; GFX940-NEXT:    v_lshrrev_b32_e32 v7, 16, v7
+; GFX940-NEXT:    v_cndmask_b32_e32 v7, v17, v16, vcc
+; GFX940-NEXT:    v_cmp_o_f16_e32 vcc, v6, v14
+; GFX940-NEXT:    v_perm_b32 v7, v7, v18, s0
 ; GFX940-NEXT:    s_nop 0
-; GFX940-NEXT:    v_cndmask_b32_e32 v19, v19, v15, vcc
-; GFX940-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v16
+; GFX940-NEXT:    v_cndmask_b32_e32 v16, v17, v15, vcc
 ; GFX940-NEXT:    v_lshrrev_b32_e32 v15, 16, v15
+; GFX940-NEXT:    v_cmp_o_f16_sdwa vcc, v6, v14 src0_sel:WORD_1 src1_sel:WORD_1
+; GFX940-NEXT:    v_pk_min_f16 v14, v5, v13
 ; GFX940-NEXT:    s_nop 0
-; GFX940-NEXT:    v_cndmask_b32_e32 v16, v16, v19, vcc
-; GFX940-NEXT:    v_cmp_o_f16_e32 vcc, v7, v15
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v18, v17, v18, vcc
-; GFX940-NEXT:    v_cmp_class_f16_e64 vcc, v7, 32
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v7, v18, v7, vcc
-; GFX940-NEXT:    v_cmp_class_f16_e64 vcc, v15, 32
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v7, v7, v15, vcc
-; GFX940-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v18
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v7, v18, v7, vcc
-; GFX940-NEXT:    v_pk_min_f16 v18, v6, v14
-; GFX940-NEXT:    v_cmp_o_f16_e32 vcc, v6, v14
-; GFX940-NEXT:    v_perm_b32 v7, v7, v16, s0
+; GFX940-NEXT:    v_cndmask_b32_e32 v6, v17, v15, vcc
+; GFX940-NEXT:    v_cmp_o_f16_e32 vcc, v5, v13
+; GFX940-NEXT:    v_perm_b32 v6, v6, v16, s0
 ; GFX940-NEXT:    s_nop 0
-; GFX940-NEXT:    v_cndmask_b32_e32 v15, v17, v18, vcc
-; GFX940-NEXT:    v_cmp_class_f16_e64 vcc, v6, 32
-; GFX940-NEXT:    v_lshrrev_b32_e32 v18, 16, v18
-; GFX940-NEXT:    s_nop 0
-; GFX940-NEXT:    v_cndmask_b32_e32 v19, v15, v6, vcc
-; GFX940-NEXT:    v_cmp_class_f16_e64 vcc, v14, 32
-; GFX940-NEXT:    v_lshrrev_b32_e32 v6, 16, v6
-; GFX940-NEXT:    s_nop 0
-; GFX940-NEXT:    v_cndmask_b32_e32 v19, v19, v14, vcc
-; GFX940-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v15
+; GFX940-NEXT:    v_cndmask_b32_e32 v15, v17, v14, vcc
 ; GFX940-NEXT:    v_lshrrev_b32_e32 v14, 16, v14
-; GFX940-NEXT:    s_nop 0
-; GFX940-NEXT:    v_cndmask_b32_e32 v15, v15, v19, vcc
-; GFX940-NEXT:    v_cmp_o_f16_e32 vcc, v6, v14
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v18, v17, v18, vcc
-; GFX940-NEXT:    v_cmp_class_f16_e64 vcc, v6, 32
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v6, v18, v6, vcc
-; GFX940-NEXT:    v_cmp_class_f16_e64 vcc, v14, 32
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v6, v6, v14, vcc
-; GFX940-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v18
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v6, v18, v6, vcc
-; GFX940-NEXT:    v_pk_min_f16 v18, v5, v13
-; GFX940-NEXT:    v_cmp_o_f16_e32 vcc, v5, v13
-; GFX940-NEXT:    v_perm_b32 v6, v6, v15, s0
-; GFX940-NEXT:    s_nop 0
-; GFX940-NEXT:    v_cndmask_b32_e32 v14, v17, v18, vcc
-; GFX940-NEXT:    v_cmp_class_f16_e64 vcc, v5, 32
-; GFX940-NEXT:    v_lshrrev_b32_e32 v18, 16, v18
-; GFX940-NEXT:    s_nop 0
-; GFX940-NEXT:    v_cndmask_b32_e32 v19, v14, v5, vcc
-; GFX940-NEXT:    v_cmp_class_f16_e64 vcc, v13, 32
-; GFX940-NEXT:    v_lshrrev_b32_e32 v5, 16, v5
-; GFX940-NEXT:    s_nop 0
-; GFX940-NEXT:    v_cndmask_b32_e32 v19, v19, v13, vcc
-; GFX940-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v14
-; GFX940-NEXT:    v_lshrrev_b32_e32 v13, 16, v13
-; GFX940-NEXT:    s_nop 0
-; GFX940-NEXT:    v_cndmask_b32_e32 v14, v14, v19, vcc
-; GFX940-NEXT:    v_cmp_o_f16_e32 vcc, v5, v13
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v18, v17, v18, vcc
-; GFX940-NEXT:    v_cmp_class_f16_e64 vcc, v5, 32
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v5, v18, v5, vcc
-; GFX940-NEXT:    v_cmp_class_f16_e64 vcc, v13, 32
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v5, v5, v13, vcc
-; GFX940-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v18
+; GFX940-NEXT:    v_cmp_o_f16_sdwa vcc, v5, v13 src0_sel:WORD_1 src1_sel:WORD_1
 ; GFX940-NEXT:    v_pk_min_f16 v13, v4, v12
 ; GFX940-NEXT:    s_nop 0
-; GFX940-NEXT:    v_cndmask_b32_e32 v5, v18, v5, vcc
+; GFX940-NEXT:    v_cndmask_b32_e32 v5, v17, v14, vcc
 ; GFX940-NEXT:    v_cmp_o_f16_e32 vcc, v4, v12
-; GFX940-NEXT:    v_perm_b32 v5, v5, v14, s0
+; GFX940-NEXT:    v_perm_b32 v5, v5, v15, s0
 ; GFX940-NEXT:    s_nop 0
-; GFX940-NEXT:    v_cndmask_b32_e32 v18, v17, v13, vcc
-; GFX940-NEXT:    v_cmp_class_f16_e64 vcc, v4, 32
+; GFX940-NEXT:    v_cndmask_b32_e32 v14, v17, v13, vcc
 ; GFX940-NEXT:    v_lshrrev_b32_e32 v13, 16, v13
-; GFX940-NEXT:    s_nop 0
-; GFX940-NEXT:    v_cndmask_b32_e32 v19, v18, v4, vcc
-; GFX940-NEXT:    v_cmp_class_f16_e64 vcc, v12, 32
-; GFX940-NEXT:    v_lshrrev_b32_e32 v4, 16, v4
-; GFX940-NEXT:    s_nop 0
-; GFX940-NEXT:    v_cndmask_b32_e32 v19, v19, v12, vcc
-; GFX940-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v18
-; GFX940-NEXT:    v_lshrrev_b32_e32 v12, 16, v12
-; GFX940-NEXT:    s_nop 0
-; GFX940-NEXT:    v_cndmask_b32_e32 v18, v18, v19, vcc
-; GFX940-NEXT:    v_cmp_o_f16_e32 vcc, v4, v12
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v13, v17, v13, vcc
-; GFX940-NEXT:    v_cmp_class_f16_e64 vcc, v4, 32
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v4, v13, v4, vcc
-; GFX940-NEXT:    v_cmp_class_f16_e64 vcc, v12, 32
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v4, v4, v12, vcc
-; GFX940-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v13
+; GFX940-NEXT:    v_cmp_o_f16_sdwa vcc, v4, v12 src0_sel:WORD_1 src1_sel:WORD_1
 ; GFX940-NEXT:    v_pk_min_f16 v12, v3, v11
 ; GFX940-NEXT:    s_nop 0
-; GFX940-NEXT:    v_cndmask_b32_e32 v4, v13, v4, vcc
+; GFX940-NEXT:    v_cndmask_b32_e32 v4, v17, v13, vcc
 ; GFX940-NEXT:    v_cmp_o_f16_e32 vcc, v3, v11
-; GFX940-NEXT:    v_perm_b32 v4, v4, v18, s0
+; GFX940-NEXT:    v_perm_b32 v4, v4, v14, s0
 ; GFX940-NEXT:    s_nop 0
 ; GFX940-NEXT:    v_cndmask_b32_e32 v13, v17, v12, vcc
-; GFX940-NEXT:    v_cmp_class_f16_e64 vcc, v3, 32
 ; GFX940-NEXT:    v_lshrrev_b32_e32 v12, 16, v12
-; GFX940-NEXT:    s_nop 0
-; GFX940-NEXT:    v_cndmask_b32_e32 v19, v13, v3, vcc
-; GFX940-NEXT:    v_cmp_class_f16_e64 vcc, v11, 32
-; GFX940-NEXT:    v_lshrrev_b32_e32 v3, 16, v3
-; GFX940-NEXT:    s_nop 0
-; GFX940-NEXT:    v_cndmask_b32_e32 v19, v19, v11, vcc
-; GFX940-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v13
-; GFX940-NEXT:    v_lshrrev_b32_e32 v11, 16, v11
-; GFX940-NEXT:    s_nop 0
-; GFX940-NEXT:    v_cndmask_b32_e32 v13, v13, v19, vcc
-; GFX940-NEXT:    v_cmp_o_f16_e32 vcc, v3, v11
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v12, v17, v12, vcc
-; GFX940-NEXT:    v_cmp_class_f16_e64 vcc, v3, 32
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v3, v12, v3, vcc
-; GFX940-NEXT:    v_cmp_class_f16_e64 vcc, v11, 32
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v3, v3, v11, vcc
-; GFX940-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v12
+; GFX940-NEXT:    v_cmp_o_f16_sdwa vcc, v3, v11 src0_sel:WORD_1 src1_sel:WORD_1
 ; GFX940-NEXT:    v_pk_min_f16 v11, v2, v10
 ; GFX940-NEXT:    s_nop 0
-; GFX940-NEXT:    v_cndmask_b32_e32 v3, v12, v3, vcc
+; GFX940-NEXT:    v_cndmask_b32_e32 v3, v17, v12, vcc
 ; GFX940-NEXT:    v_cmp_o_f16_e32 vcc, v2, v10
 ; GFX940-NEXT:    v_perm_b32 v3, v3, v13, s0
 ; GFX940-NEXT:    s_nop 0
 ; GFX940-NEXT:    v_cndmask_b32_e32 v12, v17, v11, vcc
-; GFX940-NEXT:    v_cmp_class_f16_e64 vcc, v2, 32
 ; GFX940-NEXT:    v_lshrrev_b32_e32 v11, 16, v11
-; GFX940-NEXT:    s_nop 0
-; GFX940-NEXT:    v_cndmask_b32_e32 v19, v12, v2, vcc
-; GFX940-NEXT:    v_cmp_class_f16_e64 vcc, v10, 32
-; GFX940-NEXT:    v_lshrrev_b32_e32 v2, 16, v2
-; GFX940-NEXT:    s_nop 0
-; GFX940-NEXT:    v_cndmask_b32_e32 v19, v19, v10, vcc
-; GFX940-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v12
-; GFX940-NEXT:    v_lshrrev_b32_e32 v10, 16, v10
-; GFX940-NEXT:    s_nop 0
-; GFX940-NEXT:    v_cndmask_b32_e32 v12, v12, v19, vcc
-; GFX940-NEXT:    v_cmp_o_f16_e32 vcc, v2, v10
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v11, v17, v11, vcc
-; GFX940-NEXT:    v_cmp_class_f16_e64 vcc, v2, 32
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v2, v11, v2, vcc
-; GFX940-NEXT:    v_cmp_class_f16_e64 vcc, v10, 32
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v2, v2, v10, vcc
-; GFX940-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v11
+; GFX940-NEXT:    v_cmp_o_f16_sdwa vcc, v2, v10 src0_sel:WORD_1 src1_sel:WORD_1
 ; GFX940-NEXT:    v_pk_min_f16 v10, v1, v9
 ; GFX940-NEXT:    s_nop 0
-; GFX940-NEXT:    v_cndmask_b32_e32 v2, v11, v2, vcc
+; GFX940-NEXT:    v_cndmask_b32_e32 v2, v17, v11, vcc
 ; GFX940-NEXT:    v_cmp_o_f16_e32 vcc, v1, v9
 ; GFX940-NEXT:    v_perm_b32 v2, v2, v12, s0
 ; GFX940-NEXT:    s_nop 0
 ; GFX940-NEXT:    v_cndmask_b32_e32 v11, v17, v10, vcc
-; GFX940-NEXT:    v_cmp_class_f16_e64 vcc, v1, 32
 ; GFX940-NEXT:    v_lshrrev_b32_e32 v10, 16, v10
-; GFX940-NEXT:    s_nop 0
-; GFX940-NEXT:    v_cndmask_b32_e32 v19, v11, v1, vcc
-; GFX940-NEXT:    v_cmp_class_f16_e64 vcc, v9, 32
-; GFX940-NEXT:    v_lshrrev_b32_e32 v1, 16, v1
-; GFX940-NEXT:    s_nop 0
-; GFX940-NEXT:    v_cndmask_b32_e32 v19, v19, v9, vcc
-; GFX940-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v11
-; GFX940-NEXT:    v_lshrrev_b32_e32 v9, 16, v9
-; GFX940-NEXT:    s_nop 0
-; GFX940-NEXT:    v_cndmask_b32_e32 v11, v11, v19, vcc
-; GFX940-NEXT:    v_cmp_o_f16_e32 vcc, v1, v9
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v10, v17, v10, vcc
-; GFX940-NEXT:    v_cmp_class_f16_e64 vcc, v1, 32
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v1, v10, v1, vcc
-; GFX940-NEXT:    v_cmp_class_f16_e64 vcc, v9, 32
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v1, v1, v9, vcc
-; GFX940-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v10
+; GFX940-NEXT:    v_cmp_o_f16_sdwa vcc, v1, v9 src0_sel:WORD_1 src1_sel:WORD_1
 ; GFX940-NEXT:    v_pk_min_f16 v9, v0, v8
 ; GFX940-NEXT:    s_nop 0
-; GFX940-NEXT:    v_cndmask_b32_e32 v1, v10, v1, vcc
+; GFX940-NEXT:    v_cndmask_b32_e32 v1, v17, v10, vcc
 ; GFX940-NEXT:    v_cmp_o_f16_e32 vcc, v0, v8
 ; GFX940-NEXT:    v_perm_b32 v1, v1, v11, s0
 ; GFX940-NEXT:    s_nop 0
 ; GFX940-NEXT:    v_cndmask_b32_e32 v10, v17, v9, vcc
-; GFX940-NEXT:    v_cmp_class_f16_e64 vcc, v0, 32
 ; GFX940-NEXT:    v_lshrrev_b32_e32 v9, 16, v9
-; GFX940-NEXT:    s_nop 0
-; GFX940-NEXT:    v_cndmask_b32_e32 v19, v10, v0, vcc
-; GFX940-NEXT:    v_cmp_class_f16_e64 vcc, v8, 32
-; GFX940-NEXT:    v_lshrrev_b32_e32 v0, 16, v0
-; GFX940-NEXT:    s_nop 0
-; GFX940-NEXT:    v_cndmask_b32_e32 v19, v19, v8, vcc
-; GFX940-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v10
-; GFX940-NEXT:    v_lshrrev_b32_e32 v8, 16, v8
-; GFX940-NEXT:    s_nop 0
-; GFX940-NEXT:    v_cndmask_b32_e32 v10, v10, v19, vcc
-; GFX940-NEXT:    v_cmp_o_f16_e32 vcc, v0, v8
+; GFX940-NEXT:    v_cmp_o_f16_sdwa vcc, v0, v8 src0_sel:WORD_1 src1_sel:WORD_1
 ; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v9, v17, v9, vcc
-; GFX940-NEXT:    v_cmp_class_f16_e64 vcc, v0, 32
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v0, v9, v0, vcc
-; GFX940-NEXT:    v_cmp_class_f16_e64 vcc, v8, 32
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v0, v0, v8, vcc
-; GFX940-NEXT:    v_cmp_eq_f16_e32 vcc, 0, v9
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v0, v9, v0, vcc
+; GFX940-NEXT:    v_cndmask_b32_e32 v0, v17, v9, vcc
 ; GFX940-NEXT:    v_perm_b32 v0, v0, v10, s0
 ; GFX940-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -3595,353 +2017,145 @@ define <16 x half> @v_minimum_v16f16(<16 x half> %src0, <16 x half> %src1) {
 ; GFX10-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX10-NEXT:    v_pk_min_f16 v16, v7, v15
 ; GFX10-NEXT:    v_cmp_o_f16_e32 vcc_lo, v7, v15
-; GFX10-NEXT:    v_lshrrev_b32_e32 v19, 16, v14
-; GFX10-NEXT:    v_lshrrev_b32_e32 v20, 16, v6
-; GFX10-NEXT:    v_cndmask_b32_e32 v17, 0x7e00, v16, vcc_lo
-; GFX10-NEXT:    v_cmp_class_f16_e64 vcc_lo, v7, 32
-; GFX10-NEXT:    v_lshrrev_b32_e32 v16, 16, v16
-; GFX10-NEXT:    v_cndmask_b32_e32 v18, v17, v7, vcc_lo
-; GFX10-NEXT:    v_cmp_class_f16_e64 vcc_lo, v15, 32
-; GFX10-NEXT:    v_lshrrev_b32_e32 v7, 16, v7
-; GFX10-NEXT:    v_cndmask_b32_e32 v18, v18, v15, vcc_lo
-; GFX10-NEXT:    v_lshrrev_b32_e32 v15, 16, v15
-; GFX10-NEXT:    v_cmp_eq_f16_e32 vcc_lo, 0, v17
-; GFX10-NEXT:    v_cndmask_b32_e32 v17, v17, v18, vcc_lo
-; GFX10-NEXT:    v_cmp_o_f16_e32 vcc_lo, v7, v15
 ; GFX10-NEXT:    v_pk_min_f16 v18, v6, v14
+; GFX10-NEXT:    v_pk_min_f16 v19, v3, v11
+; GFX10-NEXT:    v_pk_min_f16 v20, v2, v10
+; GFX10-NEXT:    v_lshrrev_b32_e32 v17, 16, v16
 ; GFX10-NEXT:    v_cndmask_b32_e32 v16, 0x7e00, v16, vcc_lo
+; GFX10-NEXT:    v_cmp_o_f16_sdwa vcc_lo, v7, v15 src0_sel:WORD_1 src1_sel:WORD_1
+; GFX10-NEXT:    v_lshrrev_b32_e32 v15, 16, v18
+; GFX10-NEXT:    v_pk_min_f16 v21, v0, v8
+; GFX10-NEXT:    v_cndmask_b32_e32 v7, 0x7e00, v17, vcc_lo
 ; GFX10-NEXT:    v_cmp_o_f16_e32 vcc_lo, v6, v14
-; GFX10-NEXT:    v_lshrrev_b32_e32 v21, 16, v18
+; GFX10-NEXT:    v_pk_min_f16 v17, v5, v13
+; GFX10-NEXT:    v_lshrrev_b32_e32 v23, 16, v21
+; GFX10-NEXT:    v_perm_b32 v7, v7, v16, 0x5040100
 ; GFX10-NEXT:    v_cndmask_b32_e32 v18, 0x7e00, v18, vcc_lo
-; GFX10-NEXT:    v_cmp_class_f16_e64 vcc_lo, v7, 32
-; GFX10-NEXT:    v_cndmask_b32_e32 v7, v16, v7, vcc_lo
-; GFX10-NEXT:    v_cmp_o_f16_e32 vcc_lo, v20, v19
-; GFX10-NEXT:    v_cndmask_b32_e32 v21, 0x7e00, v21, vcc_lo
-; GFX10-NEXT:    v_cmp_class_f16_e64 vcc_lo, v6, 32
-; GFX10-NEXT:    v_cndmask_b32_e32 v6, v18, v6, vcc_lo
-; GFX10-NEXT:    v_cmp_class_f16_e64 vcc_lo, v15, 32
-; GFX10-NEXT:    v_cndmask_b32_e32 v7, v7, v15, vcc_lo
-; GFX10-NEXT:    v_cmp_class_f16_e64 vcc_lo, v20, 32
-; GFX10-NEXT:    v_cndmask_b32_e32 v15, v21, v20, vcc_lo
-; GFX10-NEXT:    v_cmp_class_f16_e64 vcc_lo, v14, 32
-; GFX10-NEXT:    v_pk_min_f16 v20, v4, v12
-; GFX10-NEXT:    v_cndmask_b32_e32 v6, v6, v14, vcc_lo
-; GFX10-NEXT:    v_cmp_eq_f16_e32 vcc_lo, 0, v16
-; GFX10-NEXT:    v_cndmask_b32_e32 v7, v16, v7, vcc_lo
-; GFX10-NEXT:    v_cmp_class_f16_e64 vcc_lo, v19, 32
-; GFX10-NEXT:    v_lshrrev_b32_e32 v16, 16, v13
-; GFX10-NEXT:    v_perm_b32 v7, v7, v17, 0x5040100
-; GFX10-NEXT:    v_cndmask_b32_e32 v14, v15, v19, vcc_lo
-; GFX10-NEXT:    v_cmp_eq_f16_e32 vcc_lo, 0, v18
-; GFX10-NEXT:    v_pk_min_f16 v15, v5, v13
-; GFX10-NEXT:    v_cndmask_b32_e32 v6, v18, v6, vcc_lo
-; GFX10-NEXT:    v_cmp_eq_f16_e32 vcc_lo, 0, v21
-; GFX10-NEXT:    v_lshrrev_b32_e32 v18, 16, v5
-; GFX10-NEXT:    v_lshrrev_b32_e32 v19, 16, v15
-; GFX10-NEXT:    v_cndmask_b32_e32 v14, v21, v14, vcc_lo
+; GFX10-NEXT:    v_cmp_o_f16_sdwa vcc_lo, v6, v14 src0_sel:WORD_1 src1_sel:WORD_1
+; GFX10-NEXT:    v_lshrrev_b32_e32 v14, 16, v17
+; GFX10-NEXT:    v_cndmask_b32_e32 v6, 0x7e00, v15, vcc_lo
 ; GFX10-NEXT:    v_cmp_o_f16_e32 vcc_lo, v5, v13
-; GFX10-NEXT:    v_perm_b32 v6, v14, v6, 0x5040100
-; GFX10-NEXT:    v_cndmask_b32_e32 v15, 0x7e00, v15, vcc_lo
-; GFX10-NEXT:    v_cmp_o_f16_e32 vcc_lo, v18, v16
-; GFX10-NEXT:    v_cndmask_b32_e32 v19, 0x7e00, v19, vcc_lo
+; GFX10-NEXT:    v_perm_b32 v6, v6, v18, 0x5040100
+; GFX10-NEXT:    v_cndmask_b32_e32 v15, 0x7e00, v17, vcc_lo
+; GFX10-NEXT:    v_cmp_o_f16_sdwa vcc_lo, v5, v13 src0_sel:WORD_1 src1_sel:WORD_1
+; GFX10-NEXT:    v_pk_min_f16 v17, v4, v12
+; GFX10-NEXT:    v_cndmask_b32_e32 v5, 0x7e00, v14, vcc_lo
 ; GFX10-NEXT:    v_cmp_o_f16_e32 vcc_lo, v4, v12
-; GFX10-NEXT:    v_cndmask_b32_e32 v21, 0x7e00, v20, vcc_lo
-; GFX10-NEXT:    v_cmp_class_f16_e64 vcc_lo, v5, 32
-; GFX10-NEXT:    v_cndmask_b32_e32 v5, v15, v5, vcc_lo
-; GFX10-NEXT:    v_cmp_class_f16_e64 vcc_lo, v18, 32
-; GFX10-NEXT:    v_cndmask_b32_e32 v18, v19, v18, vcc_lo
-; GFX10-NEXT:    v_cmp_class_f16_e64 vcc_lo, v4, 32
-; GFX10-NEXT:    v_cndmask_b32_e32 v22, v21, v4, vcc_lo
-; GFX10-NEXT:    v_cmp_class_f16_e64 vcc_lo, v13, 32
-; GFX10-NEXT:    v_lshrrev_b32_e32 v4, 16, v4
-; GFX10-NEXT:    v_cndmask_b32_e32 v5, v5, v13, vcc_lo
-; GFX10-NEXT:    v_cmp_class_f16_e64 vcc_lo, v16, 32
-; GFX10-NEXT:    v_cndmask_b32_e32 v13, v18, v16, vcc_lo
-; GFX10-NEXT:    v_cmp_class_f16_e64 vcc_lo, v12, 32
-; GFX10-NEXT:    v_lshrrev_b32_e32 v18, 16, v20
-; GFX10-NEXT:    v_lshrrev_b32_e32 v20, 16, v3
-; GFX10-NEXT:    v_cndmask_b32_e32 v16, v22, v12, vcc_lo
-; GFX10-NEXT:    v_cmp_eq_f16_e32 vcc_lo, 0, v15
-; GFX10-NEXT:    v_lshrrev_b32_e32 v12, 16, v12
-; GFX10-NEXT:    v_cndmask_b32_e32 v5, v15, v5, vcc_lo
-; GFX10-NEXT:    v_cmp_eq_f16_e32 vcc_lo, 0, v19
-; GFX10-NEXT:    v_cndmask_b32_e32 v13, v19, v13, vcc_lo
-; GFX10-NEXT:    v_cmp_eq_f16_e32 vcc_lo, 0, v21
-; GFX10-NEXT:    v_lshrrev_b32_e32 v19, 16, v11
-; GFX10-NEXT:    v_perm_b32 v5, v13, v5, 0x5040100
-; GFX10-NEXT:    v_cndmask_b32_e32 v15, v21, v16, vcc_lo
-; GFX10-NEXT:    v_cmp_o_f16_e32 vcc_lo, v4, v12
-; GFX10-NEXT:    v_pk_min_f16 v16, v3, v11
-; GFX10-NEXT:    v_cndmask_b32_e32 v18, 0x7e00, v18, vcc_lo
+; GFX10-NEXT:    v_lshrrev_b32_e32 v14, 16, v17
+; GFX10-NEXT:    v_perm_b32 v5, v5, v15, 0x5040100
+; GFX10-NEXT:    v_cndmask_b32_e32 v13, 0x7e00, v17, vcc_lo
 ; GFX10-NEXT:    v_cmp_o_f16_e32 vcc_lo, v3, v11
-; GFX10-NEXT:    v_lshrrev_b32_e32 v21, 16, v16
-; GFX10-NEXT:    v_cndmask_b32_e32 v16, 0x7e00, v16, vcc_lo
-; GFX10-NEXT:    v_cmp_o_f16_e32 vcc_lo, v20, v19
-; GFX10-NEXT:    v_cndmask_b32_e32 v21, 0x7e00, v21, vcc_lo
-; GFX10-NEXT:    v_cmp_class_f16_e64 vcc_lo, v4, 32
-; GFX10-NEXT:    v_cndmask_b32_e32 v4, v18, v4, vcc_lo
-; GFX10-NEXT:    v_cmp_class_f16_e64 vcc_lo, v3, 32
-; GFX10-NEXT:    v_cndmask_b32_e32 v3, v16, v3, vcc_lo
-; GFX10-NEXT:    v_cmp_class_f16_e64 vcc_lo, v20, 32
-; GFX10-NEXT:    v_cndmask_b32_e32 v20, v21, v20, vcc_lo
-; GFX10-NEXT:    v_cmp_class_f16_e64 vcc_lo, v12, 32
-; GFX10-NEXT:    v_cndmask_b32_e32 v4, v4, v12, vcc_lo
-; GFX10-NEXT:    v_cmp_class_f16_e64 vcc_lo, v11, 32
-; GFX10-NEXT:    v_pk_min_f16 v12, v2, v10
-; GFX10-NEXT:    v_cndmask_b32_e32 v3, v3, v11, vcc_lo
-; GFX10-NEXT:    v_cmp_class_f16_e64 vcc_lo, v19, 32
-; GFX10-NEXT:    v_cndmask_b32_e32 v11, v20, v19, vcc_lo
-; GFX10-NEXT:    v_cmp_eq_f16_e32 vcc_lo, 0, v16
-; GFX10-NEXT:    v_pk_min_f16 v19, v1, v9
-; GFX10-NEXT:    v_lshrrev_b32_e32 v20, 16, v10
-; GFX10-NEXT:    v_cndmask_b32_e32 v3, v16, v3, vcc_lo
-; GFX10-NEXT:    v_cmp_eq_f16_e32 vcc_lo, 0, v21
-; GFX10-NEXT:    v_cndmask_b32_e32 v11, v21, v11, vcc_lo
-; GFX10-NEXT:    v_cmp_o_f16_e32 vcc_lo, v2, v10
-; GFX10-NEXT:    v_lshrrev_b32_e32 v21, 16, v2
-; GFX10-NEXT:    v_perm_b32 v3, v11, v3, 0x5040100
-; GFX10-NEXT:    v_cndmask_b32_e32 v16, 0x7e00, v12, vcc_lo
-; GFX10-NEXT:    v_cmp_o_f16_e32 vcc_lo, v1, v9
-; GFX10-NEXT:    v_lshrrev_b32_e32 v12, 16, v12
-; GFX10-NEXT:    v_cndmask_b32_e32 v22, 0x7e00, v19, vcc_lo
-; GFX10-NEXT:    v_cmp_class_f16_e64 vcc_lo, v2, 32
-; GFX10-NEXT:    v_lshrrev_b32_e32 v19, 16, v19
-; GFX10-NEXT:    v_cndmask_b32_e32 v2, v16, v2, vcc_lo
-; GFX10-NEXT:    v_cmp_o_f16_e32 vcc_lo, v21, v20
-; GFX10-NEXT:    v_cndmask_b32_e32 v12, 0x7e00, v12, vcc_lo
-; GFX10-NEXT:    v_cmp_class_f16_e64 vcc_lo, v1, 32
-; GFX10-NEXT:    v_cndmask_b32_e32 v23, v22, v1, vcc_lo
-; GFX10-NEXT:    v_cmp_class_f16_e64 vcc_lo, v10, 32
-; GFX10-NEXT:    v_lshrrev_b32_e32 v1, 16, v1
-; GFX10-NEXT:    v_cndmask_b32_e32 v2, v2, v10, vcc_lo
-; GFX10-NEXT:    v_cmp_class_f16_e64 vcc_lo, v21, 32
-; GFX10-NEXT:    v_cndmask_b32_e32 v10, v12, v21, vcc_lo
-; GFX10-NEXT:    v_cmp_class_f16_e64 vcc_lo, v9, 32
-; GFX10-NEXT:    v_cndmask_b32_e32 v21, v23, v9, vcc_lo
-; GFX10-NEXT:    v_cmp_eq_f16_e32 vcc_lo, 0, v16
-; GFX10-NEXT:    v_lshrrev_b32_e32 v9, 16, v9
-; GFX10-NEXT:    v_cndmask_b32_e32 v2, v16, v2, vcc_lo
-; GFX10-NEXT:    v_cmp_class_f16_e64 vcc_lo, v20, 32
-; GFX10-NEXT:    v_cndmask_b32_e32 v10, v10, v20, vcc_lo
-; GFX10-NEXT:    v_cmp_eq_f16_e32 vcc_lo, 0, v22
-; GFX10-NEXT:    v_pk_min_f16 v20, v0, v8
-; GFX10-NEXT:    v_cndmask_b32_e32 v16, v22, v21, vcc_lo
-; GFX10-NEXT:    v_cmp_o_f16_e32 vcc_lo, v1, v9
-; GFX10-NEXT:    v_lshrrev_b32_e32 v21, 16, v8
-; GFX10-NEXT:    v_lshrrev_b32_e32 v22, 16, v0
-; GFX10-NEXT:    v_lshrrev_b32_e32 v23, 16, v20
+; GFX10-NEXT:    v_lshrrev_b32_e32 v17, 16, v19
 ; GFX10-NEXT:    v_cndmask_b32_e32 v19, 0x7e00, v19, vcc_lo
+; GFX10-NEXT:    v_cmp_o_f16_sdwa vcc_lo, v3, v11 src0_sel:WORD_1 src1_sel:WORD_1
+; GFX10-NEXT:    v_pk_min_f16 v11, v1, v9
+; GFX10-NEXT:    v_cndmask_b32_e32 v3, 0x7e00, v17, vcc_lo
+; GFX10-NEXT:    v_cmp_o_f16_e32 vcc_lo, v2, v10
+; GFX10-NEXT:    v_lshrrev_b32_e32 v22, 16, v11
+; GFX10-NEXT:    v_perm_b32 v3, v3, v19, 0x5040100
+; GFX10-NEXT:    v_cndmask_b32_e32 v17, 0x7e00, v20, vcc_lo
+; GFX10-NEXT:    v_cmp_o_f16_e32 vcc_lo, v1, v9
+; GFX10-NEXT:    v_lshrrev_b32_e32 v20, 16, v20
+; GFX10-NEXT:    v_cndmask_b32_e32 v11, 0x7e00, v11, vcc_lo
+; GFX10-NEXT:    v_cmp_o_f16_sdwa vcc_lo, v1, v9 src0_sel:WORD_1 src1_sel:WORD_1
+; GFX10-NEXT:    v_cndmask_b32_e32 v1, 0x7e00, v22, vcc_lo
 ; GFX10-NEXT:    v_cmp_o_f16_e32 vcc_lo, v0, v8
-; GFX10-NEXT:    v_cndmask_b32_e32 v20, 0x7e00, v20, vcc_lo
-; GFX10-NEXT:    v_cmp_o_f16_e32 vcc_lo, v22, v21
-; GFX10-NEXT:    v_cndmask_b32_e32 v23, 0x7e00, v23, vcc_lo
-; GFX10-NEXT:    v_cmp_class_f16_e64 vcc_lo, v1, 32
-; GFX10-NEXT:    v_cndmask_b32_e32 v1, v19, v1, vcc_lo
-; GFX10-NEXT:    v_cmp_class_f16_e64 vcc_lo, v0, 32
-; GFX10-NEXT:    v_cndmask_b32_e32 v0, v20, v0, vcc_lo
-; GFX10-NEXT:    v_cmp_class_f16_e64 vcc_lo, v22, 32
-; GFX10-NEXT:    v_cndmask_b32_e32 v22, v23, v22, vcc_lo
-; GFX10-NEXT:    v_cmp_class_f16_e64 vcc_lo, v9, 32
-; GFX10-NEXT:    v_cndmask_b32_e32 v1, v1, v9, vcc_lo
-; GFX10-NEXT:    v_cmp_class_f16_e64 vcc_lo, v8, 32
-; GFX10-NEXT:    v_cndmask_b32_e32 v0, v0, v8, vcc_lo
-; GFX10-NEXT:    v_cmp_class_f16_e64 vcc_lo, v21, 32
-; GFX10-NEXT:    v_cndmask_b32_e32 v8, v22, v21, vcc_lo
-; GFX10-NEXT:    v_cmp_eq_f16_e32 vcc_lo, 0, v19
-; GFX10-NEXT:    v_cndmask_b32_e32 v1, v19, v1, vcc_lo
-; GFX10-NEXT:    v_cmp_eq_f16_e32 vcc_lo, 0, v20
-; GFX10-NEXT:    v_perm_b32 v1, v1, v16, 0x5040100
-; GFX10-NEXT:    v_cndmask_b32_e32 v0, v20, v0, vcc_lo
-; GFX10-NEXT:    v_cmp_eq_f16_e32 vcc_lo, 0, v23
-; GFX10-NEXT:    v_cndmask_b32_e32 v8, v23, v8, vcc_lo
-; GFX10-NEXT:    v_cmp_eq_f16_e32 vcc_lo, 0, v12
-; GFX10-NEXT:    v_perm_b32 v0, v8, v0, 0x5040100
-; GFX10-NEXT:    v_cndmask_b32_e32 v9, v12, v10, vcc_lo
-; GFX10-NEXT:    v_cmp_eq_f16_e32 vcc_lo, 0, v18
-; GFX10-NEXT:    v_perm_b32 v2, v9, v2, 0x5040100
-; GFX10-NEXT:    v_cndmask_b32_e32 v4, v18, v4, vcc_lo
-; GFX10-NEXT:    v_perm_b32 v4, v4, v15, 0x5040100
+; GFX10-NEXT:    v_perm_b32 v1, v1, v11, 0x5040100
+; GFX10-NEXT:    v_cndmask_b32_e32 v9, 0x7e00, v21, vcc_lo
+; GFX10-NEXT:    v_cmp_o_f16_sdwa vcc_lo, v0, v8 src0_sel:WORD_1 src1_sel:WORD_1
+; GFX10-NEXT:    v_cndmask_b32_e32 v0, 0x7e00, v23, vcc_lo
+; GFX10-NEXT:    v_cmp_o_f16_sdwa vcc_lo, v2, v10 src0_sel:WORD_1 src1_sel:WORD_1
+; GFX10-NEXT:    v_perm_b32 v0, v0, v9, 0x5040100
+; GFX10-NEXT:    v_cndmask_b32_e32 v2, 0x7e00, v20, vcc_lo
+; GFX10-NEXT:    v_cmp_o_f16_sdwa vcc_lo, v4, v12 src0_sel:WORD_1 src1_sel:WORD_1
+; GFX10-NEXT:    v_perm_b32 v2, v2, v17, 0x5040100
+; GFX10-NEXT:    v_cndmask_b32_e32 v4, 0x7e00, v14, vcc_lo
+; GFX10-NEXT:    v_perm_b32 v4, v4, v13, 0x5040100
 ; GFX10-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX11-LABEL: v_minimum_v16f16:
 ; GFX11:       ; %bb.0:
 ; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX11-NEXT:    v_pk_min_f16 v16, v7, v15
+; GFX11-NEXT:    v_lshrrev_b32_e32 v17, 16, v15
+; GFX11-NEXT:    v_lshrrev_b32_e32 v18, 16, v7
 ; GFX11-NEXT:    v_cmp_o_f16_e32 vcc_lo, v7, v15
-; GFX11-NEXT:    v_lshrrev_b32_e32 v20, 16, v6
-; GFX11-NEXT:    v_lshrrev_b32_e32 v19, 16, v14
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(SKIP_2) | instid1(VALU_DEP_3)
-; GFX11-NEXT:    v_cndmask_b32_e32 v17, 0x7e00, v16, vcc_lo
-; GFX11-NEXT:    v_cmp_class_f16_e64 vcc_lo, v7, 32
-; GFX11-NEXT:    v_lshrrev_b32_e32 v16, 16, v16
-; GFX11-NEXT:    v_cndmask_b32_e32 v18, v17, v7, vcc_lo
-; GFX11-NEXT:    v_cmp_class_f16_e64 vcc_lo, v15, 32
-; GFX11-NEXT:    v_lshrrev_b32_e32 v7, 16, v7
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(SKIP_2) | instid1(VALU_DEP_3)
-; GFX11-NEXT:    v_cndmask_b32_e32 v18, v18, v15, vcc_lo
-; GFX11-NEXT:    v_lshrrev_b32_e32 v15, 16, v15
-; GFX11-NEXT:    v_cmp_eq_f16_e32 vcc_lo, 0, v17
-; GFX11-NEXT:    v_cndmask_b32_e32 v17, v17, v18, vcc_lo
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(SKIP_3) | instid1(VALU_DEP_3)
-; GFX11-NEXT:    v_cmp_o_f16_e32 vcc_lo, v7, v15
-; GFX11-NEXT:    v_pk_min_f16 v18, v6, v14
-; GFX11-NEXT:    v_cndmask_b32_e32 v16, 0x7e00, v16, vcc_lo
-; GFX11-NEXT:    v_cmp_o_f16_e32 vcc_lo, v6, v14
-; GFX11-NEXT:    v_lshrrev_b32_e32 v21, 16, v18
-; GFX11-NEXT:    v_cndmask_b32_e32 v18, 0x7e00, v18, vcc_lo
-; GFX11-NEXT:    v_cmp_class_f16_e64 vcc_lo, v7, 32
-; GFX11-NEXT:    v_cndmask_b32_e32 v7, v16, v7, vcc_lo
-; GFX11-NEXT:    v_cmp_o_f16_e32 vcc_lo, v20, v19
-; GFX11-NEXT:    v_cndmask_b32_e32 v21, 0x7e00, v21, vcc_lo
-; GFX11-NEXT:    v_cmp_class_f16_e64 vcc_lo, v6, 32
-; GFX11-NEXT:    v_cndmask_b32_e32 v6, v18, v6, vcc_lo
-; GFX11-NEXT:    v_cmp_class_f16_e64 vcc_lo, v15, 32
-; GFX11-NEXT:    v_cndmask_b32_e32 v7, v7, v15, vcc_lo
-; GFX11-NEXT:    v_cmp_class_f16_e64 vcc_lo, v20, 32
-; GFX11-NEXT:    v_cndmask_b32_e32 v15, v21, v20, vcc_lo
-; GFX11-NEXT:    v_cmp_class_f16_e64 vcc_lo, v14, 32
+; GFX11-NEXT:    v_pk_min_f16 v15, v6, v14
+; GFX11-NEXT:    v_lshrrev_b32_e32 v19, 16, v16
 ; GFX11-NEXT:    v_pk_min_f16 v20, v4, v12
-; GFX11-NEXT:    v_cndmask_b32_e32 v6, v6, v14, vcc_lo
-; GFX11-NEXT:    v_cmp_eq_f16_e32 vcc_lo, 0, v16
-; GFX11-NEXT:    v_cndmask_b32_e32 v7, v16, v7, vcc_lo
-; GFX11-NEXT:    v_cmp_class_f16_e64 vcc_lo, v19, 32
-; GFX11-NEXT:    v_lshrrev_b32_e32 v16, 16, v13
-; GFX11-NEXT:    v_cndmask_b32_e32 v14, v15, v19, vcc_lo
-; GFX11-NEXT:    v_cmp_eq_f16_e32 vcc_lo, 0, v18
-; GFX11-NEXT:    v_pk_min_f16 v15, v5, v13
-; GFX11-NEXT:    v_cndmask_b32_e32 v6, v18, v6, vcc_lo
-; GFX11-NEXT:    v_cmp_eq_f16_e32 vcc_lo, 0, v21
-; GFX11-NEXT:    v_lshrrev_b32_e32 v18, 16, v5
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_4)
+; GFX11-NEXT:    v_pk_min_f16 v22, v2, v10
+; GFX11-NEXT:    v_cndmask_b32_e32 v7, 0x7e00, v16, vcc_lo
+; GFX11-NEXT:    v_cmp_o_f16_e32 vcc_lo, v18, v17
+; GFX11-NEXT:    v_lshrrev_b32_e32 v17, 16, v14
+; GFX11-NEXT:    v_lshrrev_b32_e32 v18, 16, v6
+; GFX11-NEXT:    v_lshrrev_b32_e32 v23, 16, v8
+; GFX11-NEXT:    v_lshrrev_b32_e32 v24, 16, v0
+; GFX11-NEXT:    v_cndmask_b32_e32 v16, 0x7e00, v19, vcc_lo
+; GFX11-NEXT:    v_cmp_o_f16_e32 vcc_lo, v6, v14
 ; GFX11-NEXT:    v_lshrrev_b32_e32 v19, 16, v15
-; GFX11-NEXT:    v_perm_b32 v7, v7, v17, 0x5040100
-; GFX11-NEXT:    v_cndmask_b32_e32 v14, v21, v14, vcc_lo
+; GFX11-NEXT:    v_pk_min_f16 v14, v5, v13
+; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_4)
+; GFX11-NEXT:    v_perm_b32 v7, v16, v7, 0x5040100
+; GFX11-NEXT:    v_cndmask_b32_e32 v6, 0x7e00, v15, vcc_lo
+; GFX11-NEXT:    v_cmp_o_f16_e32 vcc_lo, v18, v17
+; GFX11-NEXT:    v_lshrrev_b32_e32 v17, 16, v13
+; GFX11-NEXT:    v_lshrrev_b32_e32 v18, 16, v5
+; GFX11-NEXT:    v_cndmask_b32_e32 v15, 0x7e00, v19, vcc_lo
 ; GFX11-NEXT:    v_cmp_o_f16_e32 vcc_lo, v5, v13
-; GFX11-NEXT:    v_cndmask_b32_e32 v15, 0x7e00, v15, vcc_lo
-; GFX11-NEXT:    v_cmp_o_f16_e32 vcc_lo, v18, v16
-; GFX11-NEXT:    v_cndmask_b32_e32 v19, 0x7e00, v19, vcc_lo
-; GFX11-NEXT:    v_cmp_o_f16_e32 vcc_lo, v4, v12
-; GFX11-NEXT:    v_cndmask_b32_e32 v21, 0x7e00, v20, vcc_lo
-; GFX11-NEXT:    v_cmp_class_f16_e64 vcc_lo, v5, 32
-; GFX11-NEXT:    v_cndmask_b32_e32 v5, v15, v5, vcc_lo
-; GFX11-NEXT:    v_cmp_class_f16_e64 vcc_lo, v18, 32
-; GFX11-NEXT:    v_cndmask_b32_e32 v18, v19, v18, vcc_lo
-; GFX11-NEXT:    v_cmp_class_f16_e64 vcc_lo, v4, 32
-; GFX11-NEXT:    v_cndmask_b32_e32 v22, v21, v4, vcc_lo
-; GFX11-NEXT:    v_cmp_class_f16_e64 vcc_lo, v13, 32
-; GFX11-NEXT:    v_lshrrev_b32_e32 v4, 16, v4
-; GFX11-NEXT:    v_cndmask_b32_e32 v5, v5, v13, vcc_lo
-; GFX11-NEXT:    v_cmp_class_f16_e64 vcc_lo, v16, 32
-; GFX11-NEXT:    v_cndmask_b32_e32 v13, v18, v16, vcc_lo
-; GFX11-NEXT:    v_cmp_class_f16_e64 vcc_lo, v12, 32
-; GFX11-NEXT:    v_lshrrev_b32_e32 v18, 16, v20
-; GFX11-NEXT:    v_lshrrev_b32_e32 v20, 16, v3
-; GFX11-NEXT:    v_perm_b32 v6, v14, v6, 0x5040100
-; GFX11-NEXT:    v_cndmask_b32_e32 v16, v22, v12, vcc_lo
-; GFX11-NEXT:    v_cmp_eq_f16_e32 vcc_lo, 0, v15
-; GFX11-NEXT:    v_lshrrev_b32_e32 v12, 16, v12
-; GFX11-NEXT:    v_cndmask_b32_e32 v5, v15, v5, vcc_lo
-; GFX11-NEXT:    v_cmp_eq_f16_e32 vcc_lo, 0, v19
-; GFX11-NEXT:    v_cndmask_b32_e32 v13, v19, v13, vcc_lo
-; GFX11-NEXT:    v_cmp_eq_f16_e32 vcc_lo, 0, v21
-; GFX11-NEXT:    v_lshrrev_b32_e32 v19, 16, v11
+; GFX11-NEXT:    v_lshrrev_b32_e32 v19, 16, v14
 ; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_3)
-; GFX11-NEXT:    v_perm_b32 v5, v13, v5, 0x5040100
-; GFX11-NEXT:    v_cndmask_b32_e32 v15, v21, v16, vcc_lo
+; GFX11-NEXT:    v_perm_b32 v6, v15, v6, 0x5040100
+; GFX11-NEXT:    v_cndmask_b32_e32 v5, 0x7e00, v14, vcc_lo
+; GFX11-NEXT:    v_cmp_o_f16_e32 vcc_lo, v18, v17
+; GFX11-NEXT:    v_pk_min_f16 v17, v3, v11
+; GFX11-NEXT:    v_lshrrev_b32_e32 v18, 16, v20
+; GFX11-NEXT:    v_cndmask_b32_e32 v13, 0x7e00, v19, vcc_lo
 ; GFX11-NEXT:    v_cmp_o_f16_e32 vcc_lo, v4, v12
-; GFX11-NEXT:    v_pk_min_f16 v16, v3, v11
-; GFX11-NEXT:    v_cndmask_b32_e32 v18, 0x7e00, v18, vcc_lo
-; GFX11-NEXT:    v_cmp_o_f16_e32 vcc_lo, v3, v11
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(SKIP_2) | instid1(VALU_DEP_3)
-; GFX11-NEXT:    v_lshrrev_b32_e32 v21, 16, v16
-; GFX11-NEXT:    v_cndmask_b32_e32 v16, 0x7e00, v16, vcc_lo
-; GFX11-NEXT:    v_cmp_o_f16_e32 vcc_lo, v20, v19
-; GFX11-NEXT:    v_cndmask_b32_e32 v21, 0x7e00, v21, vcc_lo
-; GFX11-NEXT:    v_cmp_class_f16_e64 vcc_lo, v4, 32
-; GFX11-NEXT:    v_cndmask_b32_e32 v4, v18, v4, vcc_lo
-; GFX11-NEXT:    v_cmp_class_f16_e64 vcc_lo, v3, 32
-; GFX11-NEXT:    v_cndmask_b32_e32 v3, v16, v3, vcc_lo
-; GFX11-NEXT:    v_cmp_class_f16_e64 vcc_lo, v20, 32
-; GFX11-NEXT:    v_cndmask_b32_e32 v20, v21, v20, vcc_lo
-; GFX11-NEXT:    v_cmp_class_f16_e64 vcc_lo, v12, 32
-; GFX11-NEXT:    v_cndmask_b32_e32 v4, v4, v12, vcc_lo
-; GFX11-NEXT:    v_cmp_class_f16_e64 vcc_lo, v11, 32
-; GFX11-NEXT:    v_pk_min_f16 v12, v2, v10
-; GFX11-NEXT:    v_cndmask_b32_e32 v3, v3, v11, vcc_lo
-; GFX11-NEXT:    v_cmp_class_f16_e64 vcc_lo, v19, 32
-; GFX11-NEXT:    v_cndmask_b32_e32 v11, v20, v19, vcc_lo
-; GFX11-NEXT:    v_cmp_eq_f16_e32 vcc_lo, 0, v16
-; GFX11-NEXT:    v_lshrrev_b32_e32 v20, 16, v10
-; GFX11-NEXT:    v_pk_min_f16 v19, v1, v9
-; GFX11-NEXT:    v_cndmask_b32_e32 v3, v16, v3, vcc_lo
-; GFX11-NEXT:    v_cmp_eq_f16_e32 vcc_lo, 0, v21
-; GFX11-NEXT:    v_cndmask_b32_e32 v11, v21, v11, vcc_lo
-; GFX11-NEXT:    v_cmp_o_f16_e32 vcc_lo, v2, v10
-; GFX11-NEXT:    v_lshrrev_b32_e32 v21, 16, v2
-; GFX11-NEXT:    v_cndmask_b32_e32 v16, 0x7e00, v12, vcc_lo
-; GFX11-NEXT:    v_cmp_o_f16_e32 vcc_lo, v1, v9
+; GFX11-NEXT:    v_lshrrev_b32_e32 v19, 16, v11
+; GFX11-NEXT:    v_lshrrev_b32_e32 v21, 16, v17
 ; GFX11-NEXT:    v_lshrrev_b32_e32 v12, 16, v12
-; GFX11-NEXT:    v_cndmask_b32_e32 v22, 0x7e00, v19, vcc_lo
-; GFX11-NEXT:    v_cmp_class_f16_e64 vcc_lo, v2, 32
-; GFX11-NEXT:    v_lshrrev_b32_e32 v19, 16, v19
-; GFX11-NEXT:    v_cndmask_b32_e32 v2, v16, v2, vcc_lo
-; GFX11-NEXT:    v_cmp_o_f16_e32 vcc_lo, v21, v20
-; GFX11-NEXT:    v_cndmask_b32_e32 v12, 0x7e00, v12, vcc_lo
-; GFX11-NEXT:    v_cmp_class_f16_e64 vcc_lo, v1, 32
-; GFX11-NEXT:    v_cndmask_b32_e32 v23, v22, v1, vcc_lo
-; GFX11-NEXT:    v_cmp_class_f16_e64 vcc_lo, v10, 32
-; GFX11-NEXT:    v_lshrrev_b32_e32 v1, 16, v1
-; GFX11-NEXT:    v_cndmask_b32_e32 v2, v2, v10, vcc_lo
-; GFX11-NEXT:    v_cmp_class_f16_e64 vcc_lo, v21, 32
-; GFX11-NEXT:    v_cndmask_b32_e32 v10, v12, v21, vcc_lo
-; GFX11-NEXT:    v_cmp_class_f16_e64 vcc_lo, v9, 32
-; GFX11-NEXT:    v_cndmask_b32_e32 v21, v23, v9, vcc_lo
-; GFX11-NEXT:    v_cmp_eq_f16_e32 vcc_lo, 0, v16
-; GFX11-NEXT:    v_lshrrev_b32_e32 v9, 16, v9
-; GFX11-NEXT:    v_cndmask_b32_e32 v2, v16, v2, vcc_lo
-; GFX11-NEXT:    v_cmp_class_f16_e64 vcc_lo, v20, 32
-; GFX11-NEXT:    v_cndmask_b32_e32 v10, v10, v20, vcc_lo
-; GFX11-NEXT:    v_cmp_eq_f16_e32 vcc_lo, 0, v22
-; GFX11-NEXT:    v_pk_min_f16 v20, v0, v8
+; GFX11-NEXT:    v_lshrrev_b32_e32 v4, 16, v4
+; GFX11-NEXT:    v_cndmask_b32_e32 v14, 0x7e00, v20, vcc_lo
+; GFX11-NEXT:    v_lshrrev_b32_e32 v20, 16, v3
+; GFX11-NEXT:    v_cmp_o_f16_e32 vcc_lo, v3, v11
+; GFX11-NEXT:    v_perm_b32 v5, v13, v5, 0x5040100
+; GFX11-NEXT:    v_cndmask_b32_e32 v3, 0x7e00, v17, vcc_lo
+; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_4)
+; GFX11-NEXT:    v_cmp_o_f16_e32 vcc_lo, v20, v19
+; GFX11-NEXT:    v_pk_min_f16 v19, v1, v9
+; GFX11-NEXT:    v_lshrrev_b32_e32 v20, 16, v22
+; GFX11-NEXT:    v_cndmask_b32_e32 v11, 0x7e00, v21, vcc_lo
+; GFX11-NEXT:    v_cmp_o_f16_e32 vcc_lo, v2, v10
+; GFX11-NEXT:    v_lshrrev_b32_e32 v10, 16, v10
+; GFX11-NEXT:    v_lshrrev_b32_e32 v2, 16, v2
+; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_4)
 ; GFX11-NEXT:    v_perm_b32 v3, v11, v3, 0x5040100
-; GFX11-NEXT:    v_cndmask_b32_e32 v16, v22, v21, vcc_lo
+; GFX11-NEXT:    v_cndmask_b32_e32 v17, 0x7e00, v22, vcc_lo
 ; GFX11-NEXT:    v_cmp_o_f16_e32 vcc_lo, v1, v9
-; GFX11-NEXT:    v_lshrrev_b32_e32 v21, 16, v8
-; GFX11-NEXT:    v_lshrrev_b32_e32 v22, 16, v0
-; GFX11-NEXT:    v_lshrrev_b32_e32 v23, 16, v20
-; GFX11-NEXT:    v_cndmask_b32_e32 v19, 0x7e00, v19, vcc_lo
+; GFX11-NEXT:    v_lshrrev_b32_e32 v9, 16, v9
+; GFX11-NEXT:    v_lshrrev_b32_e32 v1, 16, v1
+; GFX11-NEXT:    v_pk_min_f16 v22, v0, v8
+; GFX11-NEXT:    v_cndmask_b32_e32 v21, 0x7e00, v19, vcc_lo
+; GFX11-NEXT:    v_lshrrev_b32_e32 v19, 16, v19
+; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(NEXT) | instid1(VALU_DEP_4)
+; GFX11-NEXT:    v_cmp_o_f16_e32 vcc_lo, v1, v9
+; GFX11-NEXT:    v_lshrrev_b32_e32 v25, 16, v22
+; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(SKIP_1) | instid1(VALU_DEP_2)
+; GFX11-NEXT:    v_cndmask_b32_e32 v1, 0x7e00, v19, vcc_lo
 ; GFX11-NEXT:    v_cmp_o_f16_e32 vcc_lo, v0, v8
-; GFX11-NEXT:    v_cndmask_b32_e32 v20, 0x7e00, v20, vcc_lo
-; GFX11-NEXT:    v_cmp_o_f16_e32 vcc_lo, v22, v21
-; GFX11-NEXT:    v_cndmask_b32_e32 v23, 0x7e00, v23, vcc_lo
-; GFX11-NEXT:    v_cmp_class_f16_e64 vcc_lo, v1, 32
-; GFX11-NEXT:    v_cndmask_b32_e32 v1, v19, v1, vcc_lo
-; GFX11-NEXT:    v_cmp_class_f16_e64 vcc_lo, v0, 32
-; GFX11-NEXT:    v_cndmask_b32_e32 v0, v20, v0, vcc_lo
-; GFX11-NEXT:    v_cmp_class_f16_e64 vcc_lo, v22, 32
-; GFX11-NEXT:    v_cndmask_b32_e32 v22, v23, v22, vcc_lo
-; GFX11-NEXT:    v_cmp_class_f16_e64 vcc_lo, v9, 32
-; GFX11-NEXT:    v_cndmask_b32_e32 v1, v1, v9, vcc_lo
-; GFX11-NEXT:    v_cmp_class_f16_e64 vcc_lo, v8, 32
-; GFX11-NEXT:    v_cndmask_b32_e32 v0, v0, v8, vcc_lo
-; GFX11-NEXT:    v_cmp_class_f16_e64 vcc_lo, v21, 32
-; GFX11-NEXT:    v_cndmask_b32_e32 v8, v22, v21, vcc_lo
-; GFX11-NEXT:    v_cmp_eq_f16_e32 vcc_lo, 0, v19
-; GFX11-NEXT:    v_cndmask_b32_e32 v1, v19, v1, vcc_lo
-; GFX11-NEXT:    v_cmp_eq_f16_e32 vcc_lo, 0, v20
-; GFX11-NEXT:    v_cndmask_b32_e32 v0, v20, v0, vcc_lo
-; GFX11-NEXT:    v_cmp_eq_f16_e32 vcc_lo, 0, v23
-; GFX11-NEXT:    v_cndmask_b32_e32 v8, v23, v8, vcc_lo
-; GFX11-NEXT:    v_cmp_eq_f16_e32 vcc_lo, 0, v12
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(SKIP_3) | instid1(VALU_DEP_3)
+; GFX11-NEXT:    v_perm_b32 v1, v1, v21, 0x5040100
+; GFX11-NEXT:    v_cndmask_b32_e32 v0, 0x7e00, v22, vcc_lo
+; GFX11-NEXT:    v_cmp_o_f16_e32 vcc_lo, v24, v23
+; GFX11-NEXT:    v_cndmask_b32_e32 v8, 0x7e00, v25, vcc_lo
+; GFX11-NEXT:    v_cmp_o_f16_e32 vcc_lo, v2, v10
+; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(SKIP_2) | instid1(VALU_DEP_2)
 ; GFX11-NEXT:    v_perm_b32 v0, v8, v0, 0x5040100
-; GFX11-NEXT:    v_cndmask_b32_e32 v9, v12, v10, vcc_lo
-; GFX11-NEXT:    v_cmp_eq_f16_e32 vcc_lo, 0, v18
-; GFX11-NEXT:    v_perm_b32 v1, v1, v16, 0x5040100
-; GFX11-NEXT:    v_perm_b32 v2, v9, v2, 0x5040100
-; GFX11-NEXT:    v_cndmask_b32_e32 v4, v18, v4, vcc_lo
+; GFX11-NEXT:    v_cndmask_b32_e32 v2, 0x7e00, v20, vcc_lo
+; GFX11-NEXT:    v_cmp_o_f16_e32 vcc_lo, v4, v12
+; GFX11-NEXT:    v_perm_b32 v2, v2, v17, 0x5040100
+; GFX11-NEXT:    v_cndmask_b32_e32 v4, 0x7e00, v18, vcc_lo
 ; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; GFX11-NEXT:    v_perm_b32 v4, v4, v15, 0x5040100
+; GFX11-NEXT:    v_perm_b32 v4, v4, v14, 0x5040100
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX12-LABEL: v_minimum_v16f16:

--- a/llvm/test/CodeGen/AMDGPU/llvm.minimum.f32.ll
+++ b/llvm/test/CodeGen/AMDGPU/llvm.minimum.f32.ll
@@ -14,13 +14,7 @@ define float @v_minimum_f32(float %src0, float %src1) {
 ; GFX7-NEXT:    v_min_f32_e32 v2, v0, v1
 ; GFX7-NEXT:    v_mov_b32_e32 v3, 0x7fc00000
 ; GFX7-NEXT:    v_cmp_o_f32_e32 vcc, v0, v1
-; GFX7-NEXT:    v_cndmask_b32_e32 v2, v3, v2, vcc
-; GFX7-NEXT:    v_cmp_class_f32_e64 vcc, v0, 32
-; GFX7-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc
-; GFX7-NEXT:    v_cmp_class_f32_e64 vcc, v1, 32
-; GFX7-NEXT:    v_cndmask_b32_e32 v0, v0, v1, vcc
-; GFX7-NEXT:    v_cmp_eq_f32_e32 vcc, 0, v2
-; GFX7-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc
+; GFX7-NEXT:    v_cndmask_b32_e32 v0, v3, v2, vcc
 ; GFX7-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX8-LABEL: v_minimum_f32:
@@ -29,13 +23,7 @@ define float @v_minimum_f32(float %src0, float %src1) {
 ; GFX8-NEXT:    v_min_f32_e32 v2, v0, v1
 ; GFX8-NEXT:    v_mov_b32_e32 v3, 0x7fc00000
 ; GFX8-NEXT:    v_cmp_o_f32_e32 vcc, v0, v1
-; GFX8-NEXT:    v_cndmask_b32_e32 v2, v3, v2, vcc
-; GFX8-NEXT:    v_cmp_class_f32_e64 vcc, v0, 32
-; GFX8-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc
-; GFX8-NEXT:    v_cmp_class_f32_e64 vcc, v1, 32
-; GFX8-NEXT:    v_cndmask_b32_e32 v0, v0, v1, vcc
-; GFX8-NEXT:    v_cmp_eq_f32_e32 vcc, 0, v2
-; GFX8-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc
+; GFX8-NEXT:    v_cndmask_b32_e32 v0, v3, v2, vcc
 ; GFX8-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX9-LABEL: v_minimum_f32:
@@ -44,13 +32,7 @@ define float @v_minimum_f32(float %src0, float %src1) {
 ; GFX9-NEXT:    v_min_f32_e32 v2, v0, v1
 ; GFX9-NEXT:    v_mov_b32_e32 v3, 0x7fc00000
 ; GFX9-NEXT:    v_cmp_o_f32_e32 vcc, v0, v1
-; GFX9-NEXT:    v_cndmask_b32_e32 v2, v3, v2, vcc
-; GFX9-NEXT:    v_cmp_class_f32_e64 vcc, v0, 32
-; GFX9-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc
-; GFX9-NEXT:    v_cmp_class_f32_e64 vcc, v1, 32
-; GFX9-NEXT:    v_cndmask_b32_e32 v0, v0, v1, vcc
-; GFX9-NEXT:    v_cmp_eq_f32_e32 vcc, 0, v2
-; GFX9-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v0, v3, v2, vcc
 ; GFX9-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX940-LABEL: v_minimum_f32:
@@ -60,16 +42,7 @@ define float @v_minimum_f32(float %src0, float %src1) {
 ; GFX940-NEXT:    v_mov_b32_e32 v3, 0x7fc00000
 ; GFX940-NEXT:    v_cmp_o_f32_e32 vcc, v0, v1
 ; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v2, v3, v2, vcc
-; GFX940-NEXT:    v_cmp_class_f32_e64 vcc, v0, 32
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc
-; GFX940-NEXT:    v_cmp_class_f32_e64 vcc, v1, 32
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v0, v0, v1, vcc
-; GFX940-NEXT:    v_cmp_eq_f32_e32 vcc, 0, v2
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc
+; GFX940-NEXT:    v_cndmask_b32_e32 v0, v3, v2, vcc
 ; GFX940-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX10-LABEL: v_minimum_f32:
@@ -77,13 +50,7 @@ define float @v_minimum_f32(float %src0, float %src1) {
 ; GFX10-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX10-NEXT:    v_min_f32_e32 v2, v0, v1
 ; GFX10-NEXT:    v_cmp_o_f32_e32 vcc_lo, v0, v1
-; GFX10-NEXT:    v_cndmask_b32_e32 v2, 0x7fc00000, v2, vcc_lo
-; GFX10-NEXT:    v_cmp_class_f32_e64 vcc_lo, v0, 32
-; GFX10-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc_lo
-; GFX10-NEXT:    v_cmp_class_f32_e64 vcc_lo, v1, 32
-; GFX10-NEXT:    v_cndmask_b32_e32 v0, v0, v1, vcc_lo
-; GFX10-NEXT:    v_cmp_eq_f32_e32 vcc_lo, 0, v2
-; GFX10-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc_lo
+; GFX10-NEXT:    v_cndmask_b32_e32 v0, 0x7fc00000, v2, vcc_lo
 ; GFX10-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX11-LABEL: v_minimum_f32:
@@ -91,15 +58,8 @@ define float @v_minimum_f32(float %src0, float %src1) {
 ; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX11-NEXT:    v_min_f32_e32 v2, v0, v1
 ; GFX11-NEXT:    v_cmp_o_f32_e32 vcc_lo, v0, v1
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(SKIP_1) | instid1(VALU_DEP_2)
-; GFX11-NEXT:    v_cndmask_b32_e32 v2, 0x7fc00000, v2, vcc_lo
-; GFX11-NEXT:    v_cmp_class_f32_e64 vcc_lo, v0, 32
-; GFX11-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc_lo
-; GFX11-NEXT:    v_cmp_class_f32_e64 vcc_lo, v1, 32
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(SKIP_1) | instid1(VALU_DEP_2)
-; GFX11-NEXT:    v_cndmask_b32_e32 v0, v0, v1, vcc_lo
-; GFX11-NEXT:    v_cmp_eq_f32_e32 vcc_lo, 0, v2
-; GFX11-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc_lo
+; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_2)
+; GFX11-NEXT:    v_cndmask_b32_e32 v0, 0x7fc00000, v2, vcc_lo
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX12-LABEL: v_minimum_f32:
@@ -119,78 +79,37 @@ define float @v_minimum_f32__nnan(float %src0, float %src1) {
 ; GFX7-LABEL: v_minimum_f32__nnan:
 ; GFX7:       ; %bb.0:
 ; GFX7-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX7-NEXT:    v_min_f32_e32 v2, v0, v1
-; GFX7-NEXT:    v_cmp_class_f32_e64 vcc, v0, 32
-; GFX7-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc
-; GFX7-NEXT:    v_cmp_class_f32_e64 vcc, v1, 32
-; GFX7-NEXT:    v_cndmask_b32_e32 v0, v0, v1, vcc
-; GFX7-NEXT:    v_cmp_eq_f32_e32 vcc, 0, v2
-; GFX7-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc
+; GFX7-NEXT:    v_min_f32_e32 v0, v0, v1
 ; GFX7-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX8-LABEL: v_minimum_f32__nnan:
 ; GFX8:       ; %bb.0:
 ; GFX8-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX8-NEXT:    v_min_f32_e32 v2, v0, v1
-; GFX8-NEXT:    v_cmp_class_f32_e64 vcc, v0, 32
-; GFX8-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc
-; GFX8-NEXT:    v_cmp_class_f32_e64 vcc, v1, 32
-; GFX8-NEXT:    v_cndmask_b32_e32 v0, v0, v1, vcc
-; GFX8-NEXT:    v_cmp_eq_f32_e32 vcc, 0, v2
-; GFX8-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc
+; GFX8-NEXT:    v_min_f32_e32 v0, v0, v1
 ; GFX8-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX9-LABEL: v_minimum_f32__nnan:
 ; GFX9:       ; %bb.0:
 ; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX9-NEXT:    v_min_f32_e32 v2, v0, v1
-; GFX9-NEXT:    v_cmp_class_f32_e64 vcc, v0, 32
-; GFX9-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc
-; GFX9-NEXT:    v_cmp_class_f32_e64 vcc, v1, 32
-; GFX9-NEXT:    v_cndmask_b32_e32 v0, v0, v1, vcc
-; GFX9-NEXT:    v_cmp_eq_f32_e32 vcc, 0, v2
-; GFX9-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc
+; GFX9-NEXT:    v_min_f32_e32 v0, v0, v1
 ; GFX9-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX940-LABEL: v_minimum_f32__nnan:
 ; GFX940:       ; %bb.0:
 ; GFX940-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX940-NEXT:    v_min_f32_e32 v2, v0, v1
-; GFX940-NEXT:    v_cmp_class_f32_e64 vcc, v0, 32
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc
-; GFX940-NEXT:    v_cmp_class_f32_e64 vcc, v1, 32
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v0, v0, v1, vcc
-; GFX940-NEXT:    v_cmp_eq_f32_e32 vcc, 0, v2
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc
+; GFX940-NEXT:    v_min_f32_e32 v0, v0, v1
 ; GFX940-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX10-LABEL: v_minimum_f32__nnan:
 ; GFX10:       ; %bb.0:
 ; GFX10-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX10-NEXT:    v_min_f32_e32 v2, v0, v1
-; GFX10-NEXT:    v_cmp_class_f32_e64 vcc_lo, v0, 32
-; GFX10-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc_lo
-; GFX10-NEXT:    v_cmp_class_f32_e64 vcc_lo, v1, 32
-; GFX10-NEXT:    v_cndmask_b32_e32 v0, v0, v1, vcc_lo
-; GFX10-NEXT:    v_cmp_eq_f32_e32 vcc_lo, 0, v2
-; GFX10-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc_lo
+; GFX10-NEXT:    v_min_f32_e32 v0, v0, v1
 ; GFX10-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX11-LABEL: v_minimum_f32__nnan:
 ; GFX11:       ; %bb.0:
 ; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX11-NEXT:    v_min_f32_e32 v2, v0, v1
-; GFX11-NEXT:    v_cmp_class_f32_e64 vcc_lo, v0, 32
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(SKIP_1) | instid1(VALU_DEP_2)
-; GFX11-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc_lo
-; GFX11-NEXT:    v_cmp_class_f32_e64 vcc_lo, v1, 32
-; GFX11-NEXT:    v_cndmask_b32_e32 v0, v0, v1, vcc_lo
-; GFX11-NEXT:    v_cmp_eq_f32_e32 vcc_lo, 0, v2
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_2)
-; GFX11-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc_lo
+; GFX11-NEXT:    v_min_f32_e32 v0, v0, v1
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX12-LABEL: v_minimum_f32__nnan:
@@ -332,13 +251,7 @@ define float @v_minimum_f32__nnan_src0(float %arg0, float %src1) {
 ; GFX7-NEXT:    v_min_f32_e32 v2, v0, v1
 ; GFX7-NEXT:    v_mov_b32_e32 v3, 0x7fc00000
 ; GFX7-NEXT:    v_cmp_o_f32_e32 vcc, v0, v1
-; GFX7-NEXT:    v_cndmask_b32_e32 v2, v3, v2, vcc
-; GFX7-NEXT:    v_cmp_class_f32_e64 vcc, v0, 32
-; GFX7-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc
-; GFX7-NEXT:    v_cmp_class_f32_e64 vcc, v1, 32
-; GFX7-NEXT:    v_cndmask_b32_e32 v0, v0, v1, vcc
-; GFX7-NEXT:    v_cmp_eq_f32_e32 vcc, 0, v2
-; GFX7-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc
+; GFX7-NEXT:    v_cndmask_b32_e32 v0, v3, v2, vcc
 ; GFX7-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX8-LABEL: v_minimum_f32__nnan_src0:
@@ -348,13 +261,7 @@ define float @v_minimum_f32__nnan_src0(float %arg0, float %src1) {
 ; GFX8-NEXT:    v_min_f32_e32 v2, v0, v1
 ; GFX8-NEXT:    v_mov_b32_e32 v3, 0x7fc00000
 ; GFX8-NEXT:    v_cmp_o_f32_e32 vcc, v0, v1
-; GFX8-NEXT:    v_cndmask_b32_e32 v2, v3, v2, vcc
-; GFX8-NEXT:    v_cmp_class_f32_e64 vcc, v0, 32
-; GFX8-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc
-; GFX8-NEXT:    v_cmp_class_f32_e64 vcc, v1, 32
-; GFX8-NEXT:    v_cndmask_b32_e32 v0, v0, v1, vcc
-; GFX8-NEXT:    v_cmp_eq_f32_e32 vcc, 0, v2
-; GFX8-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc
+; GFX8-NEXT:    v_cndmask_b32_e32 v0, v3, v2, vcc
 ; GFX8-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX9-LABEL: v_minimum_f32__nnan_src0:
@@ -364,13 +271,7 @@ define float @v_minimum_f32__nnan_src0(float %arg0, float %src1) {
 ; GFX9-NEXT:    v_min_f32_e32 v2, v0, v1
 ; GFX9-NEXT:    v_mov_b32_e32 v3, 0x7fc00000
 ; GFX9-NEXT:    v_cmp_o_f32_e32 vcc, v0, v1
-; GFX9-NEXT:    v_cndmask_b32_e32 v2, v3, v2, vcc
-; GFX9-NEXT:    v_cmp_class_f32_e64 vcc, v0, 32
-; GFX9-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc
-; GFX9-NEXT:    v_cmp_class_f32_e64 vcc, v1, 32
-; GFX9-NEXT:    v_cndmask_b32_e32 v0, v0, v1, vcc
-; GFX9-NEXT:    v_cmp_eq_f32_e32 vcc, 0, v2
-; GFX9-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v0, v3, v2, vcc
 ; GFX9-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX940-LABEL: v_minimum_f32__nnan_src0:
@@ -381,16 +282,7 @@ define float @v_minimum_f32__nnan_src0(float %arg0, float %src1) {
 ; GFX940-NEXT:    v_mov_b32_e32 v3, 0x7fc00000
 ; GFX940-NEXT:    v_cmp_o_f32_e32 vcc, v0, v1
 ; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v2, v3, v2, vcc
-; GFX940-NEXT:    v_cmp_class_f32_e64 vcc, v0, 32
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc
-; GFX940-NEXT:    v_cmp_class_f32_e64 vcc, v1, 32
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v0, v0, v1, vcc
-; GFX940-NEXT:    v_cmp_eq_f32_e32 vcc, 0, v2
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc
+; GFX940-NEXT:    v_cndmask_b32_e32 v0, v3, v2, vcc
 ; GFX940-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX10-LABEL: v_minimum_f32__nnan_src0:
@@ -399,13 +291,7 @@ define float @v_minimum_f32__nnan_src0(float %arg0, float %src1) {
 ; GFX10-NEXT:    v_add_f32_e32 v0, 1.0, v0
 ; GFX10-NEXT:    v_min_f32_e32 v2, v0, v1
 ; GFX10-NEXT:    v_cmp_o_f32_e32 vcc_lo, v0, v1
-; GFX10-NEXT:    v_cndmask_b32_e32 v2, 0x7fc00000, v2, vcc_lo
-; GFX10-NEXT:    v_cmp_class_f32_e64 vcc_lo, v0, 32
-; GFX10-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc_lo
-; GFX10-NEXT:    v_cmp_class_f32_e64 vcc_lo, v1, 32
-; GFX10-NEXT:    v_cndmask_b32_e32 v0, v0, v1, vcc_lo
-; GFX10-NEXT:    v_cmp_eq_f32_e32 vcc_lo, 0, v2
-; GFX10-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc_lo
+; GFX10-NEXT:    v_cndmask_b32_e32 v0, 0x7fc00000, v2, vcc_lo
 ; GFX10-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX11-LABEL: v_minimum_f32__nnan_src0:
@@ -415,15 +301,7 @@ define float @v_minimum_f32__nnan_src0(float %arg0, float %src1) {
 ; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_1) | instid1(VALU_DEP_2)
 ; GFX11-NEXT:    v_min_f32_e32 v2, v0, v1
 ; GFX11-NEXT:    v_cmp_o_f32_e32 vcc_lo, v0, v1
-; GFX11-NEXT:    v_cndmask_b32_e32 v2, 0x7fc00000, v2, vcc_lo
-; GFX11-NEXT:    v_cmp_class_f32_e64 vcc_lo, v0, 32
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(SKIP_1) | instid1(VALU_DEP_2)
-; GFX11-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc_lo
-; GFX11-NEXT:    v_cmp_class_f32_e64 vcc_lo, v1, 32
-; GFX11-NEXT:    v_cndmask_b32_e32 v0, v0, v1, vcc_lo
-; GFX11-NEXT:    v_cmp_eq_f32_e32 vcc_lo, 0, v2
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_2)
-; GFX11-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc_lo
+; GFX11-NEXT:    v_cndmask_b32_e32 v0, 0x7fc00000, v2, vcc_lo
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX12-LABEL: v_minimum_f32__nnan_src0:
@@ -450,13 +328,7 @@ define float @v_minimum_f32__nnan_src1(float %src0, float %arg1) {
 ; GFX7-NEXT:    v_min_f32_e32 v2, v0, v1
 ; GFX7-NEXT:    v_mov_b32_e32 v3, 0x7fc00000
 ; GFX7-NEXT:    v_cmp_o_f32_e32 vcc, v0, v1
-; GFX7-NEXT:    v_cndmask_b32_e32 v2, v3, v2, vcc
-; GFX7-NEXT:    v_cmp_class_f32_e64 vcc, v0, 32
-; GFX7-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc
-; GFX7-NEXT:    v_cmp_class_f32_e64 vcc, v1, 32
-; GFX7-NEXT:    v_cndmask_b32_e32 v0, v0, v1, vcc
-; GFX7-NEXT:    v_cmp_eq_f32_e32 vcc, 0, v2
-; GFX7-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc
+; GFX7-NEXT:    v_cndmask_b32_e32 v0, v3, v2, vcc
 ; GFX7-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX8-LABEL: v_minimum_f32__nnan_src1:
@@ -466,13 +338,7 @@ define float @v_minimum_f32__nnan_src1(float %src0, float %arg1) {
 ; GFX8-NEXT:    v_min_f32_e32 v2, v0, v1
 ; GFX8-NEXT:    v_mov_b32_e32 v3, 0x7fc00000
 ; GFX8-NEXT:    v_cmp_o_f32_e32 vcc, v0, v1
-; GFX8-NEXT:    v_cndmask_b32_e32 v2, v3, v2, vcc
-; GFX8-NEXT:    v_cmp_class_f32_e64 vcc, v0, 32
-; GFX8-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc
-; GFX8-NEXT:    v_cmp_class_f32_e64 vcc, v1, 32
-; GFX8-NEXT:    v_cndmask_b32_e32 v0, v0, v1, vcc
-; GFX8-NEXT:    v_cmp_eq_f32_e32 vcc, 0, v2
-; GFX8-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc
+; GFX8-NEXT:    v_cndmask_b32_e32 v0, v3, v2, vcc
 ; GFX8-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX9-LABEL: v_minimum_f32__nnan_src1:
@@ -482,13 +348,7 @@ define float @v_minimum_f32__nnan_src1(float %src0, float %arg1) {
 ; GFX9-NEXT:    v_min_f32_e32 v2, v0, v1
 ; GFX9-NEXT:    v_mov_b32_e32 v3, 0x7fc00000
 ; GFX9-NEXT:    v_cmp_o_f32_e32 vcc, v0, v1
-; GFX9-NEXT:    v_cndmask_b32_e32 v2, v3, v2, vcc
-; GFX9-NEXT:    v_cmp_class_f32_e64 vcc, v0, 32
-; GFX9-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc
-; GFX9-NEXT:    v_cmp_class_f32_e64 vcc, v1, 32
-; GFX9-NEXT:    v_cndmask_b32_e32 v0, v0, v1, vcc
-; GFX9-NEXT:    v_cmp_eq_f32_e32 vcc, 0, v2
-; GFX9-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v0, v3, v2, vcc
 ; GFX9-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX940-LABEL: v_minimum_f32__nnan_src1:
@@ -499,16 +359,7 @@ define float @v_minimum_f32__nnan_src1(float %src0, float %arg1) {
 ; GFX940-NEXT:    v_mov_b32_e32 v3, 0x7fc00000
 ; GFX940-NEXT:    v_cmp_o_f32_e32 vcc, v0, v1
 ; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v2, v3, v2, vcc
-; GFX940-NEXT:    v_cmp_class_f32_e64 vcc, v0, 32
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc
-; GFX940-NEXT:    v_cmp_class_f32_e64 vcc, v1, 32
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v0, v0, v1, vcc
-; GFX940-NEXT:    v_cmp_eq_f32_e32 vcc, 0, v2
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc
+; GFX940-NEXT:    v_cndmask_b32_e32 v0, v3, v2, vcc
 ; GFX940-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX10-LABEL: v_minimum_f32__nnan_src1:
@@ -517,13 +368,7 @@ define float @v_minimum_f32__nnan_src1(float %src0, float %arg1) {
 ; GFX10-NEXT:    v_add_f32_e32 v1, 1.0, v1
 ; GFX10-NEXT:    v_min_f32_e32 v2, v0, v1
 ; GFX10-NEXT:    v_cmp_o_f32_e32 vcc_lo, v0, v1
-; GFX10-NEXT:    v_cndmask_b32_e32 v2, 0x7fc00000, v2, vcc_lo
-; GFX10-NEXT:    v_cmp_class_f32_e64 vcc_lo, v0, 32
-; GFX10-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc_lo
-; GFX10-NEXT:    v_cmp_class_f32_e64 vcc_lo, v1, 32
-; GFX10-NEXT:    v_cndmask_b32_e32 v0, v0, v1, vcc_lo
-; GFX10-NEXT:    v_cmp_eq_f32_e32 vcc_lo, 0, v2
-; GFX10-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc_lo
+; GFX10-NEXT:    v_cndmask_b32_e32 v0, 0x7fc00000, v2, vcc_lo
 ; GFX10-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX11-LABEL: v_minimum_f32__nnan_src1:
@@ -533,15 +378,7 @@ define float @v_minimum_f32__nnan_src1(float %src0, float %arg1) {
 ; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_1) | instid1(VALU_DEP_2)
 ; GFX11-NEXT:    v_min_f32_e32 v2, v0, v1
 ; GFX11-NEXT:    v_cmp_o_f32_e32 vcc_lo, v0, v1
-; GFX11-NEXT:    v_cndmask_b32_e32 v2, 0x7fc00000, v2, vcc_lo
-; GFX11-NEXT:    v_cmp_class_f32_e64 vcc_lo, v0, 32
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(SKIP_1) | instid1(VALU_DEP_2)
-; GFX11-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc_lo
-; GFX11-NEXT:    v_cmp_class_f32_e64 vcc_lo, v1, 32
-; GFX11-NEXT:    v_cndmask_b32_e32 v0, v0, v1, vcc_lo
-; GFX11-NEXT:    v_cmp_eq_f32_e32 vcc_lo, 0, v2
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_2)
-; GFX11-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc_lo
+; GFX11-NEXT:    v_cndmask_b32_e32 v0, 0x7fc00000, v2, vcc_lo
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX12-LABEL: v_minimum_f32__nnan_src1:
@@ -568,14 +405,7 @@ define void @s_minimum_f32(float inreg %src0, float inreg %src1) {
 ; GFX7-NEXT:    v_min_f32_e32 v1, s4, v0
 ; GFX7-NEXT:    v_mov_b32_e32 v2, 0x7fc00000
 ; GFX7-NEXT:    v_cmp_o_f32_e32 vcc, s4, v0
-; GFX7-NEXT:    v_cndmask_b32_e32 v1, v2, v1, vcc
-; GFX7-NEXT:    v_mov_b32_e32 v2, s4
-; GFX7-NEXT:    v_cmp_class_f32_e64 vcc, s4, 32
-; GFX7-NEXT:    v_cndmask_b32_e32 v2, v1, v2, vcc
-; GFX7-NEXT:    v_cmp_class_f32_e64 vcc, s5, 32
-; GFX7-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc
-; GFX7-NEXT:    v_cmp_eq_f32_e32 vcc, 0, v1
-; GFX7-NEXT:    v_cndmask_b32_e32 v0, v1, v0, vcc
+; GFX7-NEXT:    v_cndmask_b32_e32 v0, v2, v1, vcc
 ; GFX7-NEXT:    ;;#ASMSTART
 ; GFX7-NEXT:    ; use v0
 ; GFX7-NEXT:    ;;#ASMEND
@@ -588,14 +418,7 @@ define void @s_minimum_f32(float inreg %src0, float inreg %src1) {
 ; GFX8-NEXT:    v_min_f32_e32 v1, s4, v0
 ; GFX8-NEXT:    v_mov_b32_e32 v2, 0x7fc00000
 ; GFX8-NEXT:    v_cmp_o_f32_e32 vcc, s4, v0
-; GFX8-NEXT:    v_cndmask_b32_e32 v1, v2, v1, vcc
-; GFX8-NEXT:    v_mov_b32_e32 v2, s4
-; GFX8-NEXT:    v_cmp_class_f32_e64 vcc, s4, 32
-; GFX8-NEXT:    v_cndmask_b32_e32 v2, v1, v2, vcc
-; GFX8-NEXT:    v_cmp_class_f32_e64 vcc, s5, 32
-; GFX8-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc
-; GFX8-NEXT:    v_cmp_eq_f32_e32 vcc, 0, v1
-; GFX8-NEXT:    v_cndmask_b32_e32 v0, v1, v0, vcc
+; GFX8-NEXT:    v_cndmask_b32_e32 v0, v2, v1, vcc
 ; GFX8-NEXT:    ;;#ASMSTART
 ; GFX8-NEXT:    ; use v0
 ; GFX8-NEXT:    ;;#ASMEND
@@ -608,14 +431,7 @@ define void @s_minimum_f32(float inreg %src0, float inreg %src1) {
 ; GFX9-NEXT:    v_min_f32_e32 v1, s4, v0
 ; GFX9-NEXT:    v_mov_b32_e32 v2, 0x7fc00000
 ; GFX9-NEXT:    v_cmp_o_f32_e32 vcc, s4, v0
-; GFX9-NEXT:    v_cndmask_b32_e32 v1, v2, v1, vcc
-; GFX9-NEXT:    v_mov_b32_e32 v2, s4
-; GFX9-NEXT:    v_cmp_class_f32_e64 vcc, s4, 32
-; GFX9-NEXT:    v_cndmask_b32_e32 v2, v1, v2, vcc
-; GFX9-NEXT:    v_cmp_class_f32_e64 vcc, s5, 32
-; GFX9-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc
-; GFX9-NEXT:    v_cmp_eq_f32_e32 vcc, 0, v1
-; GFX9-NEXT:    v_cndmask_b32_e32 v0, v1, v0, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v0, v2, v1, vcc
 ; GFX9-NEXT:    ;;#ASMSTART
 ; GFX9-NEXT:    ; use v0
 ; GFX9-NEXT:    ;;#ASMEND
@@ -629,17 +445,7 @@ define void @s_minimum_f32(float inreg %src0, float inreg %src1) {
 ; GFX940-NEXT:    v_mov_b32_e32 v2, 0x7fc00000
 ; GFX940-NEXT:    v_cmp_o_f32_e32 vcc, s0, v0
 ; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v1, v2, v1, vcc
-; GFX940-NEXT:    v_mov_b32_e32 v2, s0
-; GFX940-NEXT:    v_cmp_class_f32_e64 vcc, s0, 32
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v2, v1, v2, vcc
-; GFX940-NEXT:    v_cmp_class_f32_e64 vcc, s1, 32
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc
-; GFX940-NEXT:    v_cmp_eq_f32_e32 vcc, 0, v1
-; GFX940-NEXT:    s_nop 1
-; GFX940-NEXT:    v_cndmask_b32_e32 v0, v1, v0, vcc
+; GFX940-NEXT:    v_cndmask_b32_e32 v0, v2, v1, vcc
 ; GFX940-NEXT:    ;;#ASMSTART
 ; GFX940-NEXT:    ; use v0
 ; GFX940-NEXT:    ;;#ASMEND
@@ -650,13 +456,7 @@ define void @s_minimum_f32(float inreg %src0, float inreg %src1) {
 ; GFX10-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX10-NEXT:    v_min_f32_e64 v0, s4, s5
 ; GFX10-NEXT:    v_cmp_o_f32_e64 vcc_lo, s4, s5
-; GFX10-NEXT:    v_cmp_class_f32_e64 s6, s4, 32
 ; GFX10-NEXT:    v_cndmask_b32_e32 v0, 0x7fc00000, v0, vcc_lo
-; GFX10-NEXT:    v_cndmask_b32_e64 v1, v0, s4, s6
-; GFX10-NEXT:    v_cmp_class_f32_e64 s4, s5, 32
-; GFX10-NEXT:    v_cmp_eq_f32_e32 vcc_lo, 0, v0
-; GFX10-NEXT:    v_cndmask_b32_e64 v1, v1, s5, s4
-; GFX10-NEXT:    v_cndmask_b32_e32 v0, v0, v1, vcc_lo
 ; GFX10-NEXT:    ;;#ASMSTART
 ; GFX10-NEXT:    ; use v0
 ; GFX10-NEXT:    ;;#ASMEND
@@ -667,15 +467,8 @@ define void @s_minimum_f32(float inreg %src0, float inreg %src1) {
 ; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX11-NEXT:    v_min_f32_e64 v0, s0, s1
 ; GFX11-NEXT:    v_cmp_o_f32_e64 vcc_lo, s0, s1
-; GFX11-NEXT:    v_cmp_class_f32_e64 s2, s0, 32
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_2)
 ; GFX11-NEXT:    v_cndmask_b32_e32 v0, 0x7fc00000, v0, vcc_lo
-; GFX11-NEXT:    v_cndmask_b32_e64 v1, v0, s0, s2
-; GFX11-NEXT:    v_cmp_class_f32_e64 s0, s1, 32
-; GFX11-NEXT:    v_cmp_eq_f32_e32 vcc_lo, 0, v0
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_1)
-; GFX11-NEXT:    v_cndmask_b32_e64 v1, v1, s1, s0
-; GFX11-NEXT:    v_cndmask_b32_e32 v0, v0, v1, vcc_lo
 ; GFX11-NEXT:    ;;#ASMSTART
 ; GFX11-NEXT:    ; use v0
 ; GFX11-NEXT:    ;;#ASMEND

--- a/llvm/test/CodeGen/AMDGPU/llvm.minimum.f64.ll
+++ b/llvm/test/CodeGen/AMDGPU/llvm.minimum.f64.ll
@@ -13,18 +13,9 @@ define double @v_minimum_f64(double %src0, double %src1) {
 ; GFX7-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX7-NEXT:    v_min_f64 v[4:5], v[0:1], v[2:3]
 ; GFX7-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[2:3]
-; GFX7-NEXT:    v_mov_b32_e32 v6, 0x7ff80000
-; GFX7-NEXT:    v_cmp_class_f64_e64 s[4:5], v[2:3], 32
-; GFX7-NEXT:    v_cndmask_b32_e32 v5, v5, v6, vcc
-; GFX7-NEXT:    v_cndmask_b32_e64 v4, v4, 0, vcc
-; GFX7-NEXT:    v_cmp_class_f64_e64 vcc, v[0:1], 32
-; GFX7-NEXT:    v_cmp_eq_f64_e64 s[6:7], 0, v[4:5]
-; GFX7-NEXT:    v_cndmask_b32_e32 v0, v4, v0, vcc
+; GFX7-NEXT:    v_mov_b32_e32 v1, 0x7ff80000
+; GFX7-NEXT:    v_cndmask_b32_e64 v0, v4, 0, vcc
 ; GFX7-NEXT:    v_cndmask_b32_e32 v1, v5, v1, vcc
-; GFX7-NEXT:    v_cndmask_b32_e64 v0, v0, v2, s[4:5]
-; GFX7-NEXT:    v_cndmask_b32_e64 v1, v1, v3, s[4:5]
-; GFX7-NEXT:    v_cndmask_b32_e64 v0, v4, v0, s[6:7]
-; GFX7-NEXT:    v_cndmask_b32_e64 v1, v5, v1, s[6:7]
 ; GFX7-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX8-LABEL: v_minimum_f64:
@@ -32,18 +23,9 @@ define double @v_minimum_f64(double %src0, double %src1) {
 ; GFX8-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX8-NEXT:    v_min_f64 v[4:5], v[0:1], v[2:3]
 ; GFX8-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[2:3]
-; GFX8-NEXT:    v_mov_b32_e32 v6, 0x7ff80000
-; GFX8-NEXT:    v_cmp_class_f64_e64 s[4:5], v[2:3], 32
-; GFX8-NEXT:    v_cndmask_b32_e32 v5, v5, v6, vcc
-; GFX8-NEXT:    v_cndmask_b32_e64 v4, v4, 0, vcc
-; GFX8-NEXT:    v_cmp_class_f64_e64 vcc, v[0:1], 32
-; GFX8-NEXT:    v_cmp_eq_f64_e64 s[6:7], 0, v[4:5]
-; GFX8-NEXT:    v_cndmask_b32_e32 v0, v4, v0, vcc
+; GFX8-NEXT:    v_mov_b32_e32 v1, 0x7ff80000
+; GFX8-NEXT:    v_cndmask_b32_e64 v0, v4, 0, vcc
 ; GFX8-NEXT:    v_cndmask_b32_e32 v1, v5, v1, vcc
-; GFX8-NEXT:    v_cndmask_b32_e64 v0, v0, v2, s[4:5]
-; GFX8-NEXT:    v_cndmask_b32_e64 v1, v1, v3, s[4:5]
-; GFX8-NEXT:    v_cndmask_b32_e64 v0, v4, v0, s[6:7]
-; GFX8-NEXT:    v_cndmask_b32_e64 v1, v5, v1, s[6:7]
 ; GFX8-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX9-LABEL: v_minimum_f64:
@@ -51,39 +33,20 @@ define double @v_minimum_f64(double %src0, double %src1) {
 ; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX9-NEXT:    v_min_f64 v[4:5], v[0:1], v[2:3]
 ; GFX9-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[2:3]
-; GFX9-NEXT:    v_mov_b32_e32 v6, 0x7ff80000
-; GFX9-NEXT:    v_cmp_class_f64_e64 s[4:5], v[2:3], 32
-; GFX9-NEXT:    v_cndmask_b32_e32 v5, v5, v6, vcc
-; GFX9-NEXT:    v_cndmask_b32_e64 v4, v4, 0, vcc
-; GFX9-NEXT:    v_cmp_class_f64_e64 vcc, v[0:1], 32
-; GFX9-NEXT:    v_cmp_eq_f64_e64 s[6:7], 0, v[4:5]
-; GFX9-NEXT:    v_cndmask_b32_e32 v0, v4, v0, vcc
+; GFX9-NEXT:    v_mov_b32_e32 v1, 0x7ff80000
+; GFX9-NEXT:    v_cndmask_b32_e64 v0, v4, 0, vcc
 ; GFX9-NEXT:    v_cndmask_b32_e32 v1, v5, v1, vcc
-; GFX9-NEXT:    v_cndmask_b32_e64 v0, v0, v2, s[4:5]
-; GFX9-NEXT:    v_cndmask_b32_e64 v1, v1, v3, s[4:5]
-; GFX9-NEXT:    v_cndmask_b32_e64 v0, v4, v0, s[6:7]
-; GFX9-NEXT:    v_cndmask_b32_e64 v1, v5, v1, s[6:7]
 ; GFX9-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX940-LABEL: v_minimum_f64:
 ; GFX940:       ; %bb.0:
 ; GFX940-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX940-NEXT:    v_min_f64 v[4:5], v[0:1], v[2:3]
-; GFX940-NEXT:    v_mov_b32_e32 v6, 0x7ff80000
 ; GFX940-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[2:3]
-; GFX940-NEXT:    v_cmp_class_f64_e64 s[0:1], v[2:3], 32
+; GFX940-NEXT:    v_mov_b32_e32 v1, 0x7ff80000
 ; GFX940-NEXT:    s_nop 0
-; GFX940-NEXT:    v_cndmask_b32_e32 v5, v5, v6, vcc
-; GFX940-NEXT:    v_cndmask_b32_e64 v4, v4, 0, vcc
-; GFX940-NEXT:    v_cmp_class_f64_e64 vcc, v[0:1], 32
-; GFX940-NEXT:    v_cmp_eq_f64_e64 s[2:3], 0, v[4:5]
-; GFX940-NEXT:    s_nop 0
-; GFX940-NEXT:    v_cndmask_b32_e32 v0, v4, v0, vcc
+; GFX940-NEXT:    v_cndmask_b32_e64 v0, v4, 0, vcc
 ; GFX940-NEXT:    v_cndmask_b32_e32 v1, v5, v1, vcc
-; GFX940-NEXT:    v_cndmask_b32_e64 v0, v0, v2, s[0:1]
-; GFX940-NEXT:    v_cndmask_b32_e64 v1, v1, v3, s[0:1]
-; GFX940-NEXT:    v_cndmask_b32_e64 v0, v4, v0, s[2:3]
-; GFX940-NEXT:    v_cndmask_b32_e64 v1, v5, v1, s[2:3]
 ; GFX940-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX10-LABEL: v_minimum_f64:
@@ -91,17 +54,8 @@ define double @v_minimum_f64(double %src0, double %src1) {
 ; GFX10-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX10-NEXT:    v_min_f64 v[4:5], v[0:1], v[2:3]
 ; GFX10-NEXT:    v_cmp_u_f64_e32 vcc_lo, v[0:1], v[2:3]
-; GFX10-NEXT:    v_cmp_class_f64_e64 s4, v[2:3], 32
-; GFX10-NEXT:    v_cndmask_b32_e64 v5, v5, 0x7ff80000, vcc_lo
-; GFX10-NEXT:    v_cndmask_b32_e64 v4, v4, 0, vcc_lo
-; GFX10-NEXT:    v_cmp_class_f64_e64 vcc_lo, v[0:1], 32
-; GFX10-NEXT:    v_cmp_eq_f64_e64 s5, 0, v[4:5]
-; GFX10-NEXT:    v_cndmask_b32_e32 v0, v4, v0, vcc_lo
-; GFX10-NEXT:    v_cndmask_b32_e32 v1, v5, v1, vcc_lo
-; GFX10-NEXT:    v_cndmask_b32_e64 v0, v0, v2, s4
-; GFX10-NEXT:    v_cndmask_b32_e64 v1, v1, v3, s4
-; GFX10-NEXT:    v_cndmask_b32_e64 v0, v4, v0, s5
-; GFX10-NEXT:    v_cndmask_b32_e64 v1, v5, v1, s5
+; GFX10-NEXT:    v_cndmask_b32_e64 v0, v4, 0, vcc_lo
+; GFX10-NEXT:    v_cndmask_b32_e64 v1, v5, 0x7ff80000, vcc_lo
 ; GFX10-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX11-LABEL: v_minimum_f64:
@@ -109,20 +63,9 @@ define double @v_minimum_f64(double %src0, double %src1) {
 ; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX11-NEXT:    v_min_f64 v[4:5], v[0:1], v[2:3]
 ; GFX11-NEXT:    v_cmp_u_f64_e32 vcc_lo, v[0:1], v[2:3]
-; GFX11-NEXT:    v_cmp_class_f64_e64 s0, v[2:3], 32
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_4)
-; GFX11-NEXT:    v_cndmask_b32_e64 v5, v5, 0x7ff80000, vcc_lo
-; GFX11-NEXT:    v_cndmask_b32_e64 v4, v4, 0, vcc_lo
-; GFX11-NEXT:    v_cmp_class_f64_e64 vcc_lo, v[0:1], 32
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(SKIP_1) | instid1(VALU_DEP_1)
-; GFX11-NEXT:    v_cmp_eq_f64_e64 s1, 0, v[4:5]
-; GFX11-NEXT:    v_dual_cndmask_b32 v0, v4, v0 :: v_dual_cndmask_b32 v1, v5, v1
-; GFX11-NEXT:    v_cndmask_b32_e64 v0, v0, v2, s0
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_2)
-; GFX11-NEXT:    v_cndmask_b32_e64 v1, v1, v3, s0
-; GFX11-NEXT:    v_cndmask_b32_e64 v0, v4, v0, s1
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_2)
-; GFX11-NEXT:    v_cndmask_b32_e64 v1, v5, v1, s1
+; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_3)
+; GFX11-NEXT:    v_cndmask_b32_e64 v0, v4, 0, vcc_lo
+; GFX11-NEXT:    v_cndmask_b32_e64 v1, v5, 0x7ff80000, vcc_lo
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX12-LABEL: v_minimum_f64:
@@ -142,93 +85,37 @@ define double @v_minimum_f64__nnan(double %src0, double %src1) {
 ; GFX7-LABEL: v_minimum_f64__nnan:
 ; GFX7:       ; %bb.0:
 ; GFX7-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX7-NEXT:    v_min_f64 v[4:5], v[0:1], v[2:3]
-; GFX7-NEXT:    v_cmp_class_f64_e64 vcc, v[0:1], 32
-; GFX7-NEXT:    v_cmp_class_f64_e64 s[4:5], v[2:3], 32
-; GFX7-NEXT:    v_cmp_eq_f64_e64 s[6:7], 0, v[4:5]
-; GFX7-NEXT:    v_cndmask_b32_e32 v0, v4, v0, vcc
-; GFX7-NEXT:    v_cndmask_b32_e32 v1, v5, v1, vcc
-; GFX7-NEXT:    v_cndmask_b32_e64 v0, v0, v2, s[4:5]
-; GFX7-NEXT:    v_cndmask_b32_e64 v1, v1, v3, s[4:5]
-; GFX7-NEXT:    v_cndmask_b32_e64 v0, v4, v0, s[6:7]
-; GFX7-NEXT:    v_cndmask_b32_e64 v1, v5, v1, s[6:7]
+; GFX7-NEXT:    v_min_f64 v[0:1], v[0:1], v[2:3]
 ; GFX7-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX8-LABEL: v_minimum_f64__nnan:
 ; GFX8:       ; %bb.0:
 ; GFX8-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX8-NEXT:    v_min_f64 v[4:5], v[0:1], v[2:3]
-; GFX8-NEXT:    v_cmp_class_f64_e64 vcc, v[0:1], 32
-; GFX8-NEXT:    v_cmp_class_f64_e64 s[4:5], v[2:3], 32
-; GFX8-NEXT:    v_cmp_eq_f64_e64 s[6:7], 0, v[4:5]
-; GFX8-NEXT:    v_cndmask_b32_e32 v0, v4, v0, vcc
-; GFX8-NEXT:    v_cndmask_b32_e32 v1, v5, v1, vcc
-; GFX8-NEXT:    v_cndmask_b32_e64 v0, v0, v2, s[4:5]
-; GFX8-NEXT:    v_cndmask_b32_e64 v1, v1, v3, s[4:5]
-; GFX8-NEXT:    v_cndmask_b32_e64 v0, v4, v0, s[6:7]
-; GFX8-NEXT:    v_cndmask_b32_e64 v1, v5, v1, s[6:7]
+; GFX8-NEXT:    v_min_f64 v[0:1], v[0:1], v[2:3]
 ; GFX8-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX9-LABEL: v_minimum_f64__nnan:
 ; GFX9:       ; %bb.0:
 ; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX9-NEXT:    v_min_f64 v[4:5], v[0:1], v[2:3]
-; GFX9-NEXT:    v_cmp_class_f64_e64 vcc, v[0:1], 32
-; GFX9-NEXT:    v_cmp_class_f64_e64 s[4:5], v[2:3], 32
-; GFX9-NEXT:    v_cmp_eq_f64_e64 s[6:7], 0, v[4:5]
-; GFX9-NEXT:    v_cndmask_b32_e32 v0, v4, v0, vcc
-; GFX9-NEXT:    v_cndmask_b32_e32 v1, v5, v1, vcc
-; GFX9-NEXT:    v_cndmask_b32_e64 v0, v0, v2, s[4:5]
-; GFX9-NEXT:    v_cndmask_b32_e64 v1, v1, v3, s[4:5]
-; GFX9-NEXT:    v_cndmask_b32_e64 v0, v4, v0, s[6:7]
-; GFX9-NEXT:    v_cndmask_b32_e64 v1, v5, v1, s[6:7]
+; GFX9-NEXT:    v_min_f64 v[0:1], v[0:1], v[2:3]
 ; GFX9-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX940-LABEL: v_minimum_f64__nnan:
 ; GFX940:       ; %bb.0:
 ; GFX940-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX940-NEXT:    v_min_f64 v[4:5], v[0:1], v[2:3]
-; GFX940-NEXT:    v_cmp_class_f64_e64 vcc, v[0:1], 32
-; GFX940-NEXT:    v_cmp_class_f64_e64 s[0:1], v[2:3], 32
-; GFX940-NEXT:    v_cmp_eq_f64_e64 s[2:3], 0, v[4:5]
-; GFX940-NEXT:    v_cndmask_b32_e32 v0, v4, v0, vcc
-; GFX940-NEXT:    v_cndmask_b32_e32 v1, v5, v1, vcc
-; GFX940-NEXT:    v_cndmask_b32_e64 v0, v0, v2, s[0:1]
-; GFX940-NEXT:    v_cndmask_b32_e64 v1, v1, v3, s[0:1]
-; GFX940-NEXT:    v_cndmask_b32_e64 v0, v4, v0, s[2:3]
-; GFX940-NEXT:    v_cndmask_b32_e64 v1, v5, v1, s[2:3]
+; GFX940-NEXT:    v_min_f64 v[0:1], v[0:1], v[2:3]
 ; GFX940-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX10-LABEL: v_minimum_f64__nnan:
 ; GFX10:       ; %bb.0:
 ; GFX10-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX10-NEXT:    v_min_f64 v[4:5], v[0:1], v[2:3]
-; GFX10-NEXT:    v_cmp_class_f64_e64 vcc_lo, v[0:1], 32
-; GFX10-NEXT:    v_cmp_class_f64_e64 s4, v[2:3], 32
-; GFX10-NEXT:    v_cmp_eq_f64_e64 s5, 0, v[4:5]
-; GFX10-NEXT:    v_cndmask_b32_e32 v0, v4, v0, vcc_lo
-; GFX10-NEXT:    v_cndmask_b32_e32 v1, v5, v1, vcc_lo
-; GFX10-NEXT:    v_cndmask_b32_e64 v0, v0, v2, s4
-; GFX10-NEXT:    v_cndmask_b32_e64 v1, v1, v3, s4
-; GFX10-NEXT:    v_cndmask_b32_e64 v0, v4, v0, s5
-; GFX10-NEXT:    v_cndmask_b32_e64 v1, v5, v1, s5
+; GFX10-NEXT:    v_min_f64 v[0:1], v[0:1], v[2:3]
 ; GFX10-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX11-LABEL: v_minimum_f64__nnan:
 ; GFX11:       ; %bb.0:
 ; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX11-NEXT:    v_min_f64 v[4:5], v[0:1], v[2:3]
-; GFX11-NEXT:    v_cmp_class_f64_e64 vcc_lo, v[0:1], 32
-; GFX11-NEXT:    v_cmp_class_f64_e64 s0, v[2:3], 32
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(SKIP_1) | instid1(VALU_DEP_1)
-; GFX11-NEXT:    v_cmp_eq_f64_e64 s1, 0, v[4:5]
-; GFX11-NEXT:    v_dual_cndmask_b32 v0, v4, v0 :: v_dual_cndmask_b32 v1, v5, v1
-; GFX11-NEXT:    v_cndmask_b32_e64 v0, v0, v2, s0
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_2)
-; GFX11-NEXT:    v_cndmask_b32_e64 v1, v1, v3, s0
-; GFX11-NEXT:    v_cndmask_b32_e64 v0, v4, v0, s1
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_2)
-; GFX11-NEXT:    v_cndmask_b32_e64 v1, v5, v1, s1
+; GFX11-NEXT:    v_min_f64 v[0:1], v[0:1], v[2:3]
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX12-LABEL: v_minimum_f64__nnan:
@@ -373,60 +260,33 @@ define double @v_minimum_f64__nnan_src0(double %arg0, double %src1) {
 ; GFX7:       ; %bb.0:
 ; GFX7-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX7-NEXT:    v_add_f64 v[0:1], v[0:1], 1.0
-; GFX7-NEXT:    v_mov_b32_e32 v6, 0x7ff80000
-; GFX7-NEXT:    v_cmp_class_f64_e64 s[4:5], v[2:3], 32
 ; GFX7-NEXT:    v_min_f64 v[4:5], v[0:1], v[2:3]
 ; GFX7-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[2:3]
-; GFX7-NEXT:    v_cndmask_b32_e32 v5, v5, v6, vcc
-; GFX7-NEXT:    v_cndmask_b32_e64 v4, v4, 0, vcc
-; GFX7-NEXT:    v_cmp_class_f64_e64 vcc, v[0:1], 32
-; GFX7-NEXT:    v_cmp_eq_f64_e64 s[6:7], 0, v[4:5]
-; GFX7-NEXT:    v_cndmask_b32_e32 v0, v4, v0, vcc
+; GFX7-NEXT:    v_mov_b32_e32 v1, 0x7ff80000
+; GFX7-NEXT:    v_cndmask_b32_e64 v0, v4, 0, vcc
 ; GFX7-NEXT:    v_cndmask_b32_e32 v1, v5, v1, vcc
-; GFX7-NEXT:    v_cndmask_b32_e64 v0, v0, v2, s[4:5]
-; GFX7-NEXT:    v_cndmask_b32_e64 v1, v1, v3, s[4:5]
-; GFX7-NEXT:    v_cndmask_b32_e64 v0, v4, v0, s[6:7]
-; GFX7-NEXT:    v_cndmask_b32_e64 v1, v5, v1, s[6:7]
 ; GFX7-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX8-LABEL: v_minimum_f64__nnan_src0:
 ; GFX8:       ; %bb.0:
 ; GFX8-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX8-NEXT:    v_add_f64 v[0:1], v[0:1], 1.0
-; GFX8-NEXT:    v_mov_b32_e32 v6, 0x7ff80000
-; GFX8-NEXT:    v_cmp_class_f64_e64 s[4:5], v[2:3], 32
 ; GFX8-NEXT:    v_min_f64 v[4:5], v[0:1], v[2:3]
 ; GFX8-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[2:3]
-; GFX8-NEXT:    v_cndmask_b32_e32 v5, v5, v6, vcc
-; GFX8-NEXT:    v_cndmask_b32_e64 v4, v4, 0, vcc
-; GFX8-NEXT:    v_cmp_class_f64_e64 vcc, v[0:1], 32
-; GFX8-NEXT:    v_cmp_eq_f64_e64 s[6:7], 0, v[4:5]
-; GFX8-NEXT:    v_cndmask_b32_e32 v0, v4, v0, vcc
+; GFX8-NEXT:    v_mov_b32_e32 v1, 0x7ff80000
+; GFX8-NEXT:    v_cndmask_b32_e64 v0, v4, 0, vcc
 ; GFX8-NEXT:    v_cndmask_b32_e32 v1, v5, v1, vcc
-; GFX8-NEXT:    v_cndmask_b32_e64 v0, v0, v2, s[4:5]
-; GFX8-NEXT:    v_cndmask_b32_e64 v1, v1, v3, s[4:5]
-; GFX8-NEXT:    v_cndmask_b32_e64 v0, v4, v0, s[6:7]
-; GFX8-NEXT:    v_cndmask_b32_e64 v1, v5, v1, s[6:7]
 ; GFX8-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX9-LABEL: v_minimum_f64__nnan_src0:
 ; GFX9:       ; %bb.0:
 ; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX9-NEXT:    v_add_f64 v[0:1], v[0:1], 1.0
-; GFX9-NEXT:    v_mov_b32_e32 v6, 0x7ff80000
-; GFX9-NEXT:    v_cmp_class_f64_e64 s[4:5], v[2:3], 32
 ; GFX9-NEXT:    v_min_f64 v[4:5], v[0:1], v[2:3]
 ; GFX9-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[2:3]
-; GFX9-NEXT:    v_cndmask_b32_e32 v5, v5, v6, vcc
-; GFX9-NEXT:    v_cndmask_b32_e64 v4, v4, 0, vcc
-; GFX9-NEXT:    v_cmp_class_f64_e64 vcc, v[0:1], 32
-; GFX9-NEXT:    v_cmp_eq_f64_e64 s[6:7], 0, v[4:5]
-; GFX9-NEXT:    v_cndmask_b32_e32 v0, v4, v0, vcc
+; GFX9-NEXT:    v_mov_b32_e32 v1, 0x7ff80000
+; GFX9-NEXT:    v_cndmask_b32_e64 v0, v4, 0, vcc
 ; GFX9-NEXT:    v_cndmask_b32_e32 v1, v5, v1, vcc
-; GFX9-NEXT:    v_cndmask_b32_e64 v0, v0, v2, s[4:5]
-; GFX9-NEXT:    v_cndmask_b32_e64 v1, v1, v3, s[4:5]
-; GFX9-NEXT:    v_cndmask_b32_e64 v0, v4, v0, s[6:7]
-; GFX9-NEXT:    v_cndmask_b32_e64 v1, v5, v1, s[6:7]
 ; GFX9-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX940-LABEL: v_minimum_f64__nnan_src0:
@@ -434,62 +294,33 @@ define double @v_minimum_f64__nnan_src0(double %arg0, double %src1) {
 ; GFX940-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX940-NEXT:    v_add_f64 v[0:1], v[0:1], 1.0
 ; GFX940-NEXT:    v_min_f64 v[4:5], v[0:1], v[2:3]
-; GFX940-NEXT:    v_mov_b32_e32 v6, 0x7ff80000
 ; GFX940-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[2:3]
-; GFX940-NEXT:    v_cmp_class_f64_e64 s[0:1], v[2:3], 32
+; GFX940-NEXT:    v_mov_b32_e32 v1, 0x7ff80000
 ; GFX940-NEXT:    s_nop 0
-; GFX940-NEXT:    v_cndmask_b32_e32 v5, v5, v6, vcc
-; GFX940-NEXT:    v_cndmask_b32_e64 v4, v4, 0, vcc
-; GFX940-NEXT:    v_cmp_class_f64_e64 vcc, v[0:1], 32
-; GFX940-NEXT:    v_cmp_eq_f64_e64 s[2:3], 0, v[4:5]
-; GFX940-NEXT:    s_nop 0
-; GFX940-NEXT:    v_cndmask_b32_e32 v0, v4, v0, vcc
+; GFX940-NEXT:    v_cndmask_b32_e64 v0, v4, 0, vcc
 ; GFX940-NEXT:    v_cndmask_b32_e32 v1, v5, v1, vcc
-; GFX940-NEXT:    v_cndmask_b32_e64 v0, v0, v2, s[0:1]
-; GFX940-NEXT:    v_cndmask_b32_e64 v1, v1, v3, s[0:1]
-; GFX940-NEXT:    v_cndmask_b32_e64 v0, v4, v0, s[2:3]
-; GFX940-NEXT:    v_cndmask_b32_e64 v1, v5, v1, s[2:3]
 ; GFX940-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX10-LABEL: v_minimum_f64__nnan_src0:
 ; GFX10:       ; %bb.0:
 ; GFX10-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX10-NEXT:    v_add_f64 v[0:1], v[0:1], 1.0
-; GFX10-NEXT:    v_cmp_class_f64_e64 s4, v[2:3], 32
 ; GFX10-NEXT:    v_min_f64 v[4:5], v[0:1], v[2:3]
 ; GFX10-NEXT:    v_cmp_u_f64_e32 vcc_lo, v[0:1], v[2:3]
-; GFX10-NEXT:    v_cndmask_b32_e64 v5, v5, 0x7ff80000, vcc_lo
-; GFX10-NEXT:    v_cndmask_b32_e64 v4, v4, 0, vcc_lo
-; GFX10-NEXT:    v_cmp_class_f64_e64 vcc_lo, v[0:1], 32
-; GFX10-NEXT:    v_cmp_eq_f64_e64 s5, 0, v[4:5]
-; GFX10-NEXT:    v_cndmask_b32_e32 v0, v4, v0, vcc_lo
-; GFX10-NEXT:    v_cndmask_b32_e32 v1, v5, v1, vcc_lo
-; GFX10-NEXT:    v_cndmask_b32_e64 v0, v0, v2, s4
-; GFX10-NEXT:    v_cndmask_b32_e64 v1, v1, v3, s4
-; GFX10-NEXT:    v_cndmask_b32_e64 v0, v4, v0, s5
-; GFX10-NEXT:    v_cndmask_b32_e64 v1, v5, v1, s5
+; GFX10-NEXT:    v_cndmask_b32_e64 v0, v4, 0, vcc_lo
+; GFX10-NEXT:    v_cndmask_b32_e64 v1, v5, 0x7ff80000, vcc_lo
 ; GFX10-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX11-LABEL: v_minimum_f64__nnan_src0:
 ; GFX11:       ; %bb.0:
 ; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX11-NEXT:    v_add_f64 v[0:1], v[0:1], 1.0
-; GFX11-NEXT:    v_cmp_class_f64_e64 s0, v[2:3], 32
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(SKIP_1) | instid1(VALU_DEP_2)
+; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_1) | instid1(VALU_DEP_2)
 ; GFX11-NEXT:    v_min_f64 v[4:5], v[0:1], v[2:3]
 ; GFX11-NEXT:    v_cmp_u_f64_e32 vcc_lo, v[0:1], v[2:3]
-; GFX11-NEXT:    v_cndmask_b32_e64 v5, v5, 0x7ff80000, vcc_lo
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(SKIP_1) | instid1(VALU_DEP_2)
-; GFX11-NEXT:    v_cndmask_b32_e64 v4, v4, 0, vcc_lo
-; GFX11-NEXT:    v_cmp_class_f64_e64 vcc_lo, v[0:1], 32
-; GFX11-NEXT:    v_cmp_eq_f64_e64 s1, 0, v[4:5]
-; GFX11-NEXT:    v_dual_cndmask_b32 v0, v4, v0 :: v_dual_cndmask_b32 v1, v5, v1
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_2)
-; GFX11-NEXT:    v_cndmask_b32_e64 v0, v0, v2, s0
-; GFX11-NEXT:    v_cndmask_b32_e64 v1, v1, v3, s0
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_2)
-; GFX11-NEXT:    v_cndmask_b32_e64 v0, v4, v0, s1
-; GFX11-NEXT:    v_cndmask_b32_e64 v1, v5, v1, s1
+; GFX11-NEXT:    v_cndmask_b32_e64 v0, v4, 0, vcc_lo
+; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_3)
+; GFX11-NEXT:    v_cndmask_b32_e64 v1, v5, 0x7ff80000, vcc_lo
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX12-LABEL: v_minimum_f64__nnan_src0:
@@ -513,60 +344,33 @@ define double @v_minimum_f64__nnan_src1(double %src0, double %arg1) {
 ; GFX7:       ; %bb.0:
 ; GFX7-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX7-NEXT:    v_add_f64 v[2:3], v[2:3], 1.0
-; GFX7-NEXT:    v_mov_b32_e32 v6, 0x7ff80000
 ; GFX7-NEXT:    v_min_f64 v[4:5], v[0:1], v[2:3]
 ; GFX7-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[2:3]
-; GFX7-NEXT:    v_cmp_class_f64_e64 s[4:5], v[2:3], 32
-; GFX7-NEXT:    v_cndmask_b32_e32 v5, v5, v6, vcc
-; GFX7-NEXT:    v_cndmask_b32_e64 v4, v4, 0, vcc
-; GFX7-NEXT:    v_cmp_class_f64_e64 vcc, v[0:1], 32
-; GFX7-NEXT:    v_cmp_eq_f64_e64 s[6:7], 0, v[4:5]
-; GFX7-NEXT:    v_cndmask_b32_e32 v0, v4, v0, vcc
+; GFX7-NEXT:    v_mov_b32_e32 v1, 0x7ff80000
+; GFX7-NEXT:    v_cndmask_b32_e64 v0, v4, 0, vcc
 ; GFX7-NEXT:    v_cndmask_b32_e32 v1, v5, v1, vcc
-; GFX7-NEXT:    v_cndmask_b32_e64 v0, v0, v2, s[4:5]
-; GFX7-NEXT:    v_cndmask_b32_e64 v1, v1, v3, s[4:5]
-; GFX7-NEXT:    v_cndmask_b32_e64 v0, v4, v0, s[6:7]
-; GFX7-NEXT:    v_cndmask_b32_e64 v1, v5, v1, s[6:7]
 ; GFX7-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX8-LABEL: v_minimum_f64__nnan_src1:
 ; GFX8:       ; %bb.0:
 ; GFX8-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX8-NEXT:    v_add_f64 v[2:3], v[2:3], 1.0
-; GFX8-NEXT:    v_mov_b32_e32 v6, 0x7ff80000
 ; GFX8-NEXT:    v_min_f64 v[4:5], v[0:1], v[2:3]
 ; GFX8-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[2:3]
-; GFX8-NEXT:    v_cmp_class_f64_e64 s[4:5], v[2:3], 32
-; GFX8-NEXT:    v_cndmask_b32_e32 v5, v5, v6, vcc
-; GFX8-NEXT:    v_cndmask_b32_e64 v4, v4, 0, vcc
-; GFX8-NEXT:    v_cmp_class_f64_e64 vcc, v[0:1], 32
-; GFX8-NEXT:    v_cmp_eq_f64_e64 s[6:7], 0, v[4:5]
-; GFX8-NEXT:    v_cndmask_b32_e32 v0, v4, v0, vcc
+; GFX8-NEXT:    v_mov_b32_e32 v1, 0x7ff80000
+; GFX8-NEXT:    v_cndmask_b32_e64 v0, v4, 0, vcc
 ; GFX8-NEXT:    v_cndmask_b32_e32 v1, v5, v1, vcc
-; GFX8-NEXT:    v_cndmask_b32_e64 v0, v0, v2, s[4:5]
-; GFX8-NEXT:    v_cndmask_b32_e64 v1, v1, v3, s[4:5]
-; GFX8-NEXT:    v_cndmask_b32_e64 v0, v4, v0, s[6:7]
-; GFX8-NEXT:    v_cndmask_b32_e64 v1, v5, v1, s[6:7]
 ; GFX8-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX9-LABEL: v_minimum_f64__nnan_src1:
 ; GFX9:       ; %bb.0:
 ; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX9-NEXT:    v_add_f64 v[2:3], v[2:3], 1.0
-; GFX9-NEXT:    v_mov_b32_e32 v6, 0x7ff80000
 ; GFX9-NEXT:    v_min_f64 v[4:5], v[0:1], v[2:3]
 ; GFX9-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[2:3]
-; GFX9-NEXT:    v_cmp_class_f64_e64 s[4:5], v[2:3], 32
-; GFX9-NEXT:    v_cndmask_b32_e32 v5, v5, v6, vcc
-; GFX9-NEXT:    v_cndmask_b32_e64 v4, v4, 0, vcc
-; GFX9-NEXT:    v_cmp_class_f64_e64 vcc, v[0:1], 32
-; GFX9-NEXT:    v_cmp_eq_f64_e64 s[6:7], 0, v[4:5]
-; GFX9-NEXT:    v_cndmask_b32_e32 v0, v4, v0, vcc
+; GFX9-NEXT:    v_mov_b32_e32 v1, 0x7ff80000
+; GFX9-NEXT:    v_cndmask_b32_e64 v0, v4, 0, vcc
 ; GFX9-NEXT:    v_cndmask_b32_e32 v1, v5, v1, vcc
-; GFX9-NEXT:    v_cndmask_b32_e64 v0, v0, v2, s[4:5]
-; GFX9-NEXT:    v_cndmask_b32_e64 v1, v1, v3, s[4:5]
-; GFX9-NEXT:    v_cndmask_b32_e64 v0, v4, v0, s[6:7]
-; GFX9-NEXT:    v_cndmask_b32_e64 v1, v5, v1, s[6:7]
 ; GFX9-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX940-LABEL: v_minimum_f64__nnan_src1:
@@ -574,21 +378,11 @@ define double @v_minimum_f64__nnan_src1(double %src0, double %arg1) {
 ; GFX940-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX940-NEXT:    v_add_f64 v[2:3], v[2:3], 1.0
 ; GFX940-NEXT:    v_min_f64 v[4:5], v[0:1], v[2:3]
-; GFX940-NEXT:    v_mov_b32_e32 v6, 0x7ff80000
 ; GFX940-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[2:3]
-; GFX940-NEXT:    v_cmp_class_f64_e64 s[0:1], v[2:3], 32
+; GFX940-NEXT:    v_mov_b32_e32 v1, 0x7ff80000
 ; GFX940-NEXT:    s_nop 0
-; GFX940-NEXT:    v_cndmask_b32_e32 v5, v5, v6, vcc
-; GFX940-NEXT:    v_cndmask_b32_e64 v4, v4, 0, vcc
-; GFX940-NEXT:    v_cmp_class_f64_e64 vcc, v[0:1], 32
-; GFX940-NEXT:    v_cmp_eq_f64_e64 s[2:3], 0, v[4:5]
-; GFX940-NEXT:    s_nop 0
-; GFX940-NEXT:    v_cndmask_b32_e32 v0, v4, v0, vcc
+; GFX940-NEXT:    v_cndmask_b32_e64 v0, v4, 0, vcc
 ; GFX940-NEXT:    v_cndmask_b32_e32 v1, v5, v1, vcc
-; GFX940-NEXT:    v_cndmask_b32_e64 v0, v0, v2, s[0:1]
-; GFX940-NEXT:    v_cndmask_b32_e64 v1, v1, v3, s[0:1]
-; GFX940-NEXT:    v_cndmask_b32_e64 v0, v4, v0, s[2:3]
-; GFX940-NEXT:    v_cndmask_b32_e64 v1, v5, v1, s[2:3]
 ; GFX940-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX10-LABEL: v_minimum_f64__nnan_src1:
@@ -597,39 +391,20 @@ define double @v_minimum_f64__nnan_src1(double %src0, double %arg1) {
 ; GFX10-NEXT:    v_add_f64 v[2:3], v[2:3], 1.0
 ; GFX10-NEXT:    v_min_f64 v[4:5], v[0:1], v[2:3]
 ; GFX10-NEXT:    v_cmp_u_f64_e32 vcc_lo, v[0:1], v[2:3]
-; GFX10-NEXT:    v_cmp_class_f64_e64 s4, v[2:3], 32
-; GFX10-NEXT:    v_cndmask_b32_e64 v5, v5, 0x7ff80000, vcc_lo
-; GFX10-NEXT:    v_cndmask_b32_e64 v4, v4, 0, vcc_lo
-; GFX10-NEXT:    v_cmp_class_f64_e64 vcc_lo, v[0:1], 32
-; GFX10-NEXT:    v_cmp_eq_f64_e64 s5, 0, v[4:5]
-; GFX10-NEXT:    v_cndmask_b32_e32 v0, v4, v0, vcc_lo
-; GFX10-NEXT:    v_cndmask_b32_e32 v1, v5, v1, vcc_lo
-; GFX10-NEXT:    v_cndmask_b32_e64 v0, v0, v2, s4
-; GFX10-NEXT:    v_cndmask_b32_e64 v1, v1, v3, s4
-; GFX10-NEXT:    v_cndmask_b32_e64 v0, v4, v0, s5
-; GFX10-NEXT:    v_cndmask_b32_e64 v1, v5, v1, s5
+; GFX10-NEXT:    v_cndmask_b32_e64 v0, v4, 0, vcc_lo
+; GFX10-NEXT:    v_cndmask_b32_e64 v1, v5, 0x7ff80000, vcc_lo
 ; GFX10-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX11-LABEL: v_minimum_f64__nnan_src1:
 ; GFX11:       ; %bb.0:
 ; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX11-NEXT:    v_add_f64 v[2:3], v[2:3], 1.0
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_2) | instid1(VALU_DEP_3)
+; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_1) | instid1(VALU_DEP_2)
 ; GFX11-NEXT:    v_min_f64 v[4:5], v[0:1], v[2:3]
 ; GFX11-NEXT:    v_cmp_u_f64_e32 vcc_lo, v[0:1], v[2:3]
-; GFX11-NEXT:    v_cmp_class_f64_e64 s0, v[2:3], 32
-; GFX11-NEXT:    v_cndmask_b32_e64 v5, v5, 0x7ff80000, vcc_lo
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(SKIP_1) | instid1(VALU_DEP_2)
-; GFX11-NEXT:    v_cndmask_b32_e64 v4, v4, 0, vcc_lo
-; GFX11-NEXT:    v_cmp_class_f64_e64 vcc_lo, v[0:1], 32
-; GFX11-NEXT:    v_cmp_eq_f64_e64 s1, 0, v[4:5]
-; GFX11-NEXT:    v_dual_cndmask_b32 v0, v4, v0 :: v_dual_cndmask_b32 v1, v5, v1
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_2)
-; GFX11-NEXT:    v_cndmask_b32_e64 v0, v0, v2, s0
-; GFX11-NEXT:    v_cndmask_b32_e64 v1, v1, v3, s0
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_2)
-; GFX11-NEXT:    v_cndmask_b32_e64 v0, v4, v0, s1
-; GFX11-NEXT:    v_cndmask_b32_e64 v1, v5, v1, s1
+; GFX11-NEXT:    v_cndmask_b32_e64 v0, v4, 0, vcc_lo
+; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_3)
+; GFX11-NEXT:    v_cndmask_b32_e64 v1, v5, 0x7ff80000, vcc_lo
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX12-LABEL: v_minimum_f64__nnan_src1:
@@ -654,30 +429,13 @@ define void @s_minimum_f64(double inreg %src0, double inreg %src1) {
 ; GFX7-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX7-NEXT:    v_mov_b32_e32 v0, s6
 ; GFX7-NEXT:    v_mov_b32_e32 v1, s7
-; GFX7-NEXT:    v_cmp_u_f64_e32 vcc, s[4:5], v[0:1]
 ; GFX7-NEXT:    v_min_f64 v[2:3], s[4:5], v[0:1]
-; GFX7-NEXT:    v_cmp_class_f64_e64 s[8:9], s[4:5], 32
-; GFX7-NEXT:    s_and_b64 s[10:11], vcc, exec
-; GFX7-NEXT:    v_readfirstlane_b32 s12, v3
-; GFX7-NEXT:    v_readfirstlane_b32 s10, v2
-; GFX7-NEXT:    s_cselect_b32 s11, 0x7ff80000, s12
-; GFX7-NEXT:    v_cmp_class_f64_e64 s[12:13], s[6:7], 32
-; GFX7-NEXT:    s_cselect_b32 s10, 0, s10
-; GFX7-NEXT:    v_cmp_eq_f64_e64 s[14:15], s[10:11], 0
-; GFX7-NEXT:    s_and_b64 s[16:17], s[8:9], exec
-; GFX7-NEXT:    s_cselect_b32 s5, s5, s11
-; GFX7-NEXT:    s_and_b64 s[16:17], s[12:13], exec
-; GFX7-NEXT:    s_cselect_b32 s5, s7, s5
-; GFX7-NEXT:    s_and_b64 s[16:17], s[14:15], exec
-; GFX7-NEXT:    s_cselect_b32 s5, s5, s11
-; GFX7-NEXT:    s_and_b64 s[8:9], s[8:9], exec
-; GFX7-NEXT:    s_cselect_b32 s4, s4, s10
-; GFX7-NEXT:    s_and_b64 s[8:9], s[12:13], exec
-; GFX7-NEXT:    s_cselect_b32 s4, s6, s4
-; GFX7-NEXT:    s_and_b64 s[6:7], s[14:15], exec
-; GFX7-NEXT:    s_cselect_b32 s4, s4, s10
+; GFX7-NEXT:    v_cmp_u_f64_e32 vcc, s[4:5], v[0:1]
+; GFX7-NEXT:    v_mov_b32_e32 v4, 0x7ff80000
+; GFX7-NEXT:    v_cndmask_b32_e32 v1, v3, v4, vcc
+; GFX7-NEXT:    v_cndmask_b32_e64 v0, v2, 0, vcc
 ; GFX7-NEXT:    ;;#ASMSTART
-; GFX7-NEXT:    ; use s[4:5]
+; GFX7-NEXT:    ; use v[0:1]
 ; GFX7-NEXT:    ;;#ASMEND
 ; GFX7-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -686,30 +444,13 @@ define void @s_minimum_f64(double inreg %src0, double inreg %src1) {
 ; GFX8-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX8-NEXT:    v_mov_b32_e32 v0, s6
 ; GFX8-NEXT:    v_mov_b32_e32 v1, s7
-; GFX8-NEXT:    v_cmp_u_f64_e32 vcc, s[4:5], v[0:1]
 ; GFX8-NEXT:    v_min_f64 v[2:3], s[4:5], v[0:1]
-; GFX8-NEXT:    v_cmp_class_f64_e64 s[8:9], s[4:5], 32
-; GFX8-NEXT:    s_and_b64 s[10:11], vcc, exec
-; GFX8-NEXT:    v_readfirstlane_b32 s12, v3
-; GFX8-NEXT:    v_readfirstlane_b32 s10, v2
-; GFX8-NEXT:    s_cselect_b32 s11, 0x7ff80000, s12
-; GFX8-NEXT:    v_cmp_class_f64_e64 s[12:13], s[6:7], 32
-; GFX8-NEXT:    s_cselect_b32 s10, 0, s10
-; GFX8-NEXT:    v_cmp_eq_f64_e64 s[14:15], s[10:11], 0
-; GFX8-NEXT:    s_and_b64 s[16:17], s[8:9], exec
-; GFX8-NEXT:    s_cselect_b32 s5, s5, s11
-; GFX8-NEXT:    s_and_b64 s[16:17], s[12:13], exec
-; GFX8-NEXT:    s_cselect_b32 s5, s7, s5
-; GFX8-NEXT:    s_and_b64 s[16:17], s[14:15], exec
-; GFX8-NEXT:    s_cselect_b32 s5, s5, s11
-; GFX8-NEXT:    s_and_b64 s[8:9], s[8:9], exec
-; GFX8-NEXT:    s_cselect_b32 s4, s4, s10
-; GFX8-NEXT:    s_and_b64 s[8:9], s[12:13], exec
-; GFX8-NEXT:    s_cselect_b32 s4, s6, s4
-; GFX8-NEXT:    s_and_b64 s[6:7], s[14:15], exec
-; GFX8-NEXT:    s_cselect_b32 s4, s4, s10
+; GFX8-NEXT:    v_cmp_u_f64_e32 vcc, s[4:5], v[0:1]
+; GFX8-NEXT:    v_mov_b32_e32 v4, 0x7ff80000
+; GFX8-NEXT:    v_cndmask_b32_e32 v1, v3, v4, vcc
+; GFX8-NEXT:    v_cndmask_b32_e64 v0, v2, 0, vcc
 ; GFX8-NEXT:    ;;#ASMSTART
-; GFX8-NEXT:    ; use s[4:5]
+; GFX8-NEXT:    ; use v[0:1]
 ; GFX8-NEXT:    ;;#ASMEND
 ; GFX8-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -718,30 +459,13 @@ define void @s_minimum_f64(double inreg %src0, double inreg %src1) {
 ; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX9-NEXT:    v_mov_b32_e32 v0, s6
 ; GFX9-NEXT:    v_mov_b32_e32 v1, s7
-; GFX9-NEXT:    v_cmp_u_f64_e32 vcc, s[4:5], v[0:1]
 ; GFX9-NEXT:    v_min_f64 v[2:3], s[4:5], v[0:1]
-; GFX9-NEXT:    v_cmp_class_f64_e64 s[8:9], s[4:5], 32
-; GFX9-NEXT:    s_and_b64 s[10:11], vcc, exec
-; GFX9-NEXT:    v_readfirstlane_b32 s12, v3
-; GFX9-NEXT:    v_readfirstlane_b32 s10, v2
-; GFX9-NEXT:    s_cselect_b32 s11, 0x7ff80000, s12
-; GFX9-NEXT:    v_cmp_class_f64_e64 s[12:13], s[6:7], 32
-; GFX9-NEXT:    s_cselect_b32 s10, 0, s10
-; GFX9-NEXT:    v_cmp_eq_f64_e64 s[14:15], s[10:11], 0
-; GFX9-NEXT:    s_and_b64 s[16:17], s[8:9], exec
-; GFX9-NEXT:    s_cselect_b32 s5, s5, s11
-; GFX9-NEXT:    s_and_b64 s[16:17], s[12:13], exec
-; GFX9-NEXT:    s_cselect_b32 s5, s7, s5
-; GFX9-NEXT:    s_and_b64 s[16:17], s[14:15], exec
-; GFX9-NEXT:    s_cselect_b32 s5, s5, s11
-; GFX9-NEXT:    s_and_b64 s[8:9], s[8:9], exec
-; GFX9-NEXT:    s_cselect_b32 s4, s4, s10
-; GFX9-NEXT:    s_and_b64 s[8:9], s[12:13], exec
-; GFX9-NEXT:    s_cselect_b32 s4, s6, s4
-; GFX9-NEXT:    s_and_b64 s[6:7], s[14:15], exec
-; GFX9-NEXT:    s_cselect_b32 s4, s4, s10
+; GFX9-NEXT:    v_cmp_u_f64_e32 vcc, s[4:5], v[0:1]
+; GFX9-NEXT:    v_mov_b32_e32 v4, 0x7ff80000
+; GFX9-NEXT:    v_cndmask_b32_e32 v1, v3, v4, vcc
+; GFX9-NEXT:    v_cndmask_b32_e64 v0, v2, 0, vcc
 ; GFX9-NEXT:    ;;#ASMSTART
-; GFX9-NEXT:    ; use s[4:5]
+; GFX9-NEXT:    ; use v[0:1]
 ; GFX9-NEXT:    ;;#ASMEND
 ; GFX9-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -749,30 +473,14 @@ define void @s_minimum_f64(double inreg %src0, double inreg %src1) {
 ; GFX940:       ; %bb.0:
 ; GFX940-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX940-NEXT:    v_mov_b64_e32 v[0:1], s[2:3]
+; GFX940-NEXT:    v_min_f64 v[2:3], s[0:1], v[0:1]
+; GFX940-NEXT:    v_mov_b32_e32 v4, 0x7ff80000
 ; GFX940-NEXT:    v_cmp_u_f64_e32 vcc, s[0:1], v[0:1]
-; GFX940-NEXT:    v_min_f64 v[0:1], s[0:1], v[0:1]
-; GFX940-NEXT:    s_and_b64 s[4:5], vcc, exec
-; GFX940-NEXT:    v_readfirstlane_b32 s6, v1
-; GFX940-NEXT:    v_readfirstlane_b32 s4, v0
-; GFX940-NEXT:    v_cmp_class_f64_e64 s[8:9], s[0:1], 32
-; GFX940-NEXT:    s_cselect_b32 s5, 0x7ff80000, s6
-; GFX940-NEXT:    s_cselect_b32 s4, 0, s4
-; GFX940-NEXT:    s_and_b64 s[10:11], s[8:9], exec
-; GFX940-NEXT:    v_cmp_class_f64_e64 s[10:11], s[2:3], 32
-; GFX940-NEXT:    v_cmp_eq_f64_e64 s[6:7], s[4:5], 0
-; GFX940-NEXT:    s_cselect_b32 s1, s1, s5
-; GFX940-NEXT:    s_and_b64 s[12:13], s[10:11], exec
-; GFX940-NEXT:    s_cselect_b32 s1, s3, s1
-; GFX940-NEXT:    s_and_b64 s[12:13], s[6:7], exec
-; GFX940-NEXT:    s_cselect_b32 s1, s1, s5
-; GFX940-NEXT:    s_and_b64 s[8:9], s[8:9], exec
-; GFX940-NEXT:    s_cselect_b32 s0, s0, s4
-; GFX940-NEXT:    s_and_b64 s[8:9], s[10:11], exec
-; GFX940-NEXT:    s_cselect_b32 s0, s2, s0
-; GFX940-NEXT:    s_and_b64 s[2:3], s[6:7], exec
-; GFX940-NEXT:    s_cselect_b32 s0, s0, s4
+; GFX940-NEXT:    s_nop 1
+; GFX940-NEXT:    v_cndmask_b32_e32 v1, v3, v4, vcc
+; GFX940-NEXT:    v_cndmask_b32_e64 v0, v2, 0, vcc
 ; GFX940-NEXT:    ;;#ASMSTART
-; GFX940-NEXT:    ; use s[0:1]
+; GFX940-NEXT:    ; use v[0:1]
 ; GFX940-NEXT:    ;;#ASMEND
 ; GFX940-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -780,29 +488,11 @@ define void @s_minimum_f64(double inreg %src0, double inreg %src1) {
 ; GFX10:       ; %bb.0:
 ; GFX10-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX10-NEXT:    v_min_f64 v[0:1], s[4:5], s[6:7]
-; GFX10-NEXT:    v_cmp_u_f64_e64 s8, s[4:5], s[6:7]
-; GFX10-NEXT:    v_cmp_class_f64_e64 s11, s[4:5], 32
-; GFX10-NEXT:    v_cmp_class_f64_e64 s12, s[6:7], 32
-; GFX10-NEXT:    v_readfirstlane_b32 s9, v1
-; GFX10-NEXT:    v_readfirstlane_b32 s10, v0
-; GFX10-NEXT:    s_and_b32 s8, s8, exec_lo
-; GFX10-NEXT:    s_cselect_b32 s9, 0x7ff80000, s9
-; GFX10-NEXT:    s_cselect_b32 s8, 0, s10
-; GFX10-NEXT:    s_and_b32 s13, s11, exec_lo
-; GFX10-NEXT:    v_cmp_eq_f64_e64 s10, s[8:9], 0
-; GFX10-NEXT:    s_cselect_b32 s5, s5, s9
-; GFX10-NEXT:    s_and_b32 s13, s12, exec_lo
-; GFX10-NEXT:    s_cselect_b32 s5, s7, s5
-; GFX10-NEXT:    s_and_b32 s7, s10, exec_lo
-; GFX10-NEXT:    s_cselect_b32 s5, s5, s9
-; GFX10-NEXT:    s_and_b32 s7, s11, exec_lo
-; GFX10-NEXT:    s_cselect_b32 s4, s4, s8
-; GFX10-NEXT:    s_and_b32 s7, s12, exec_lo
-; GFX10-NEXT:    s_cselect_b32 s4, s6, s4
-; GFX10-NEXT:    s_and_b32 s6, s10, exec_lo
-; GFX10-NEXT:    s_cselect_b32 s4, s4, s8
+; GFX10-NEXT:    v_cmp_u_f64_e64 s4, s[4:5], s[6:7]
+; GFX10-NEXT:    v_cndmask_b32_e64 v1, v1, 0x7ff80000, s4
+; GFX10-NEXT:    v_cndmask_b32_e64 v0, v0, 0, s4
 ; GFX10-NEXT:    ;;#ASMSTART
-; GFX10-NEXT:    ; use s[4:5]
+; GFX10-NEXT:    ; use v[0:1]
 ; GFX10-NEXT:    ;;#ASMEND
 ; GFX10-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -810,32 +500,12 @@ define void @s_minimum_f64(double inreg %src0, double inreg %src1) {
 ; GFX11:       ; %bb.0:
 ; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX11-NEXT:    v_min_f64 v[0:1], s[0:1], s[2:3]
-; GFX11-NEXT:    v_cmp_u_f64_e64 s4, s[0:1], s[2:3]
-; GFX11-NEXT:    v_cmp_class_f64_e64 s7, s[0:1], 32
-; GFX11-NEXT:    v_cmp_class_f64_e64 s8, s[2:3], 32
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(SKIP_2) | instid1(VALU_DEP_2)
-; GFX11-NEXT:    v_readfirstlane_b32 s5, v1
-; GFX11-NEXT:    v_readfirstlane_b32 s6, v0
-; GFX11-NEXT:    s_and_b32 s4, s4, exec_lo
-; GFX11-NEXT:    s_cselect_b32 s5, 0x7ff80000, s5
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_4)
-; GFX11-NEXT:    s_cselect_b32 s4, 0, s6
-; GFX11-NEXT:    s_and_b32 s9, s7, exec_lo
-; GFX11-NEXT:    v_cmp_eq_f64_e64 s6, s[4:5], 0
-; GFX11-NEXT:    s_cselect_b32 s1, s1, s5
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(SKIP_1) | instid1(VALU_DEP_1)
-; GFX11-NEXT:    s_and_b32 s9, s8, exec_lo
-; GFX11-NEXT:    s_cselect_b32 s1, s3, s1
-; GFX11-NEXT:    s_and_b32 s3, s6, exec_lo
-; GFX11-NEXT:    s_cselect_b32 s1, s1, s5
-; GFX11-NEXT:    s_and_b32 s3, s7, exec_lo
-; GFX11-NEXT:    s_cselect_b32 s0, s0, s4
-; GFX11-NEXT:    s_and_b32 s3, s8, exec_lo
-; GFX11-NEXT:    s_cselect_b32 s0, s2, s0
-; GFX11-NEXT:    s_and_b32 s2, s6, exec_lo
-; GFX11-NEXT:    s_cselect_b32 s0, s0, s4
+; GFX11-NEXT:    v_cmp_u_f64_e64 s0, s[0:1], s[2:3]
+; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_3)
+; GFX11-NEXT:    v_cndmask_b32_e64 v1, v1, 0x7ff80000, s0
+; GFX11-NEXT:    v_cndmask_b32_e64 v0, v0, 0, s0
 ; GFX11-NEXT:    ;;#ASMSTART
-; GFX11-NEXT:    ; use s[0:1]
+; GFX11-NEXT:    ; use v[0:1]
 ; GFX11-NEXT:    ;;#ASMEND
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
 ;

--- a/llvm/test/CodeGen/PowerPC/fminimum-fmaximum.ll
+++ b/llvm/test/CodeGen/PowerPC/fminimum-fmaximum.ll
@@ -45,74 +45,26 @@ define float @f32_minimum(float %a, float %b) {
 ;
 ; VSX-LABEL: f32_minimum:
 ; VSX:       # %bb.0: # %entry
-; VSX-NEXT:    xscvdpspn 0, 1
 ; VSX-NEXT:    fcmpu 0, 1, 2
-; VSX-NEXT:    xscvdpspn 3, 2
-; VSX-NEXT:    mffprwz 3, 0
 ; VSX-NEXT:    bc 12, 3, .LBB0_2
 ; VSX-NEXT:  # %bb.1: # %entry
-; VSX-NEXT:    xsmindp 0, 1, 2
-; VSX-NEXT:    b .LBB0_3
+; VSX-NEXT:    xsmindp 1, 1, 2
+; VSX-NEXT:    blr
 ; VSX-NEXT:  .LBB0_2:
-; VSX-NEXT:    addis 4, 2, .LCPI0_0@toc@ha
-; VSX-NEXT:    lfs 0, .LCPI0_0@toc@l(4)
-; VSX-NEXT:  .LBB0_3: # %entry
-; VSX-NEXT:    xoris 3, 3, 32768
-; VSX-NEXT:    mffprwz 4, 3
-; VSX-NEXT:    cmplwi 3, 0
-; VSX-NEXT:    bc 12, 2, .LBB0_5
-; VSX-NEXT:  # %bb.4: # %entry
-; VSX-NEXT:    fmr 1, 0
-; VSX-NEXT:  .LBB0_5: # %entry
-; VSX-NEXT:    xoris 3, 4, 32768
-; VSX-NEXT:    cmplwi 3, 0
-; VSX-NEXT:    bc 12, 2, .LBB0_7
-; VSX-NEXT:  # %bb.6: # %entry
-; VSX-NEXT:    fmr 2, 1
-; VSX-NEXT:  .LBB0_7: # %entry
-; VSX-NEXT:    xxlxor 1, 1, 1
-; VSX-NEXT:    fcmpu 0, 0, 1
-; VSX-NEXT:    bc 12, 2, .LBB0_9
-; VSX-NEXT:  # %bb.8: # %entry
-; VSX-NEXT:    fmr 2, 0
-; VSX-NEXT:  .LBB0_9: # %entry
-; VSX-NEXT:    fmr 1, 2
+; VSX-NEXT:    addis 3, 2, .LCPI0_0@toc@ha
+; VSX-NEXT:    lfs 1, .LCPI0_0@toc@l(3)
 ; VSX-NEXT:    blr
 ;
 ; AIX-LABEL: f32_minimum:
 ; AIX:       # %bb.0: # %entry
-; AIX-NEXT:    xscvdpspn 0, 1
 ; AIX-NEXT:    fcmpu 0, 1, 2
-; AIX-NEXT:    xscvdpspn 3, 2
-; AIX-NEXT:    mffprwz 3, 0
 ; AIX-NEXT:    bc 12, 3, L..BB0_2
 ; AIX-NEXT:  # %bb.1: # %entry
-; AIX-NEXT:    xsmindp 0, 1, 2
-; AIX-NEXT:    b L..BB0_3
+; AIX-NEXT:    xsmindp 1, 1, 2
+; AIX-NEXT:    blr
 ; AIX-NEXT:  L..BB0_2:
-; AIX-NEXT:    ld 4, L..C0(2) # %const.0
-; AIX-NEXT:    lfs 0, 0(4)
-; AIX-NEXT:  L..BB0_3: # %entry
-; AIX-NEXT:    xoris 3, 3, 32768
-; AIX-NEXT:    mffprwz 4, 3
-; AIX-NEXT:    cmplwi 3, 0
-; AIX-NEXT:    bc 12, 2, L..BB0_5
-; AIX-NEXT:  # %bb.4: # %entry
-; AIX-NEXT:    fmr 1, 0
-; AIX-NEXT:  L..BB0_5: # %entry
-; AIX-NEXT:    xoris 3, 4, 32768
-; AIX-NEXT:    cmplwi 3, 0
-; AIX-NEXT:    bc 12, 2, L..BB0_7
-; AIX-NEXT:  # %bb.6: # %entry
-; AIX-NEXT:    fmr 2, 1
-; AIX-NEXT:  L..BB0_7: # %entry
-; AIX-NEXT:    xxlxor 1, 1, 1
-; AIX-NEXT:    fcmpu 0, 0, 1
-; AIX-NEXT:    bc 12, 2, L..BB0_9
-; AIX-NEXT:  # %bb.8: # %entry
-; AIX-NEXT:    fmr 2, 0
-; AIX-NEXT:  L..BB0_9: # %entry
-; AIX-NEXT:    fmr 1, 2
+; AIX-NEXT:    ld 3, L..C0(2) # %const.0
+; AIX-NEXT:    lfs 1, 0(3)
 ; AIX-NEXT:    blr
 entry:
   %m = call float @llvm.minimum.f32(float %a, float %b)
@@ -159,70 +111,26 @@ define float @f32_maximum(float %a, float %b) {
 ;
 ; VSX-LABEL: f32_maximum:
 ; VSX:       # %bb.0: # %entry
-; VSX-NEXT:    xscvdpspn 0, 1
 ; VSX-NEXT:    fcmpu 0, 1, 2
-; VSX-NEXT:    xscvdpspn 3, 2
-; VSX-NEXT:    mffprwz 3, 0
 ; VSX-NEXT:    bc 12, 3, .LBB1_2
 ; VSX-NEXT:  # %bb.1: # %entry
-; VSX-NEXT:    xsmaxdp 0, 1, 2
-; VSX-NEXT:    b .LBB1_3
+; VSX-NEXT:    xsmaxdp 1, 1, 2
+; VSX-NEXT:    blr
 ; VSX-NEXT:  .LBB1_2:
-; VSX-NEXT:    addis 4, 2, .LCPI1_0@toc@ha
-; VSX-NEXT:    lfs 0, .LCPI1_0@toc@l(4)
-; VSX-NEXT:  .LBB1_3: # %entry
-; VSX-NEXT:    mffprwz 4, 3
-; VSX-NEXT:    cmpwi 3, 0
-; VSX-NEXT:    bc 12, 2, .LBB1_5
-; VSX-NEXT:  # %bb.4: # %entry
-; VSX-NEXT:    fmr 1, 0
-; VSX-NEXT:  .LBB1_5: # %entry
-; VSX-NEXT:    cmpwi 4, 0
-; VSX-NEXT:    bc 12, 2, .LBB1_7
-; VSX-NEXT:  # %bb.6: # %entry
-; VSX-NEXT:    fmr 2, 1
-; VSX-NEXT:  .LBB1_7: # %entry
-; VSX-NEXT:    xxlxor 1, 1, 1
-; VSX-NEXT:    fcmpu 0, 0, 1
-; VSX-NEXT:    bc 12, 2, .LBB1_9
-; VSX-NEXT:  # %bb.8: # %entry
-; VSX-NEXT:    fmr 2, 0
-; VSX-NEXT:  .LBB1_9: # %entry
-; VSX-NEXT:    fmr 1, 2
+; VSX-NEXT:    addis 3, 2, .LCPI1_0@toc@ha
+; VSX-NEXT:    lfs 1, .LCPI1_0@toc@l(3)
 ; VSX-NEXT:    blr
 ;
 ; AIX-LABEL: f32_maximum:
 ; AIX:       # %bb.0: # %entry
-; AIX-NEXT:    xscvdpspn 0, 1
 ; AIX-NEXT:    fcmpu 0, 1, 2
-; AIX-NEXT:    xscvdpspn 3, 2
-; AIX-NEXT:    mffprwz 3, 0
 ; AIX-NEXT:    bc 12, 3, L..BB1_2
 ; AIX-NEXT:  # %bb.1: # %entry
-; AIX-NEXT:    xsmaxdp 0, 1, 2
-; AIX-NEXT:    b L..BB1_3
+; AIX-NEXT:    xsmaxdp 1, 1, 2
+; AIX-NEXT:    blr
 ; AIX-NEXT:  L..BB1_2:
-; AIX-NEXT:    ld 4, L..C1(2) # %const.0
-; AIX-NEXT:    lfs 0, 0(4)
-; AIX-NEXT:  L..BB1_3: # %entry
-; AIX-NEXT:    mffprwz 4, 3
-; AIX-NEXT:    cmpwi 3, 0
-; AIX-NEXT:    bc 12, 2, L..BB1_5
-; AIX-NEXT:  # %bb.4: # %entry
-; AIX-NEXT:    fmr 1, 0
-; AIX-NEXT:  L..BB1_5: # %entry
-; AIX-NEXT:    cmpwi 4, 0
-; AIX-NEXT:    bc 12, 2, L..BB1_7
-; AIX-NEXT:  # %bb.6: # %entry
-; AIX-NEXT:    fmr 2, 1
-; AIX-NEXT:  L..BB1_7: # %entry
-; AIX-NEXT:    xxlxor 1, 1, 1
-; AIX-NEXT:    fcmpu 0, 0, 1
-; AIX-NEXT:    bc 12, 2, L..BB1_9
-; AIX-NEXT:  # %bb.8: # %entry
-; AIX-NEXT:    fmr 2, 0
-; AIX-NEXT:  L..BB1_9: # %entry
-; AIX-NEXT:    fmr 1, 2
+; AIX-NEXT:    ld 3, L..C1(2) # %const.0
+; AIX-NEXT:    lfs 1, 0(3)
 ; AIX-NEXT:    blr
 entry:
   %m = call float @llvm.maximum.f32(float %a, float %b)
@@ -272,69 +180,25 @@ define double @f64_minimum(double %a, double %b) {
 ; VSX-LABEL: f64_minimum:
 ; VSX:       # %bb.0: # %entry
 ; VSX-NEXT:    fcmpu 0, 1, 2
-; VSX-NEXT:    mffprd 3, 1
 ; VSX-NEXT:    bc 12, 3, .LBB2_2
 ; VSX-NEXT:  # %bb.1: # %entry
-; VSX-NEXT:    xsmindp 0, 1, 2
-; VSX-NEXT:    b .LBB2_3
+; VSX-NEXT:    xsmindp 1, 1, 2
+; VSX-NEXT:    blr
 ; VSX-NEXT:  .LBB2_2:
-; VSX-NEXT:    addis 4, 2, .LCPI2_0@toc@ha
-; VSX-NEXT:    lfs 0, .LCPI2_0@toc@l(4)
-; VSX-NEXT:  .LBB2_3: # %entry
-; VSX-NEXT:    li 5, 1
-; VSX-NEXT:    mffprd 4, 2
-; VSX-NEXT:    rldic 5, 5, 63, 0
-; VSX-NEXT:    cmpd 3, 5
-; VSX-NEXT:    bc 12, 2, .LBB2_5
-; VSX-NEXT:  # %bb.4: # %entry
-; VSX-NEXT:    fmr 1, 0
-; VSX-NEXT:  .LBB2_5: # %entry
-; VSX-NEXT:    cmpd 4, 5
-; VSX-NEXT:    bc 12, 2, .LBB2_7
-; VSX-NEXT:  # %bb.6: # %entry
-; VSX-NEXT:    fmr 2, 1
-; VSX-NEXT:  .LBB2_7: # %entry
-; VSX-NEXT:    xxlxor 1, 1, 1
-; VSX-NEXT:    fcmpu 0, 0, 1
-; VSX-NEXT:    bc 12, 2, .LBB2_9
-; VSX-NEXT:  # %bb.8: # %entry
-; VSX-NEXT:    fmr 2, 0
-; VSX-NEXT:  .LBB2_9: # %entry
-; VSX-NEXT:    fmr 1, 2
+; VSX-NEXT:    addis 3, 2, .LCPI2_0@toc@ha
+; VSX-NEXT:    lfs 1, .LCPI2_0@toc@l(3)
 ; VSX-NEXT:    blr
 ;
 ; AIX-LABEL: f64_minimum:
 ; AIX:       # %bb.0: # %entry
 ; AIX-NEXT:    fcmpu 0, 1, 2
-; AIX-NEXT:    mffprd 3, 1
 ; AIX-NEXT:    bc 12, 3, L..BB2_2
 ; AIX-NEXT:  # %bb.1: # %entry
-; AIX-NEXT:    xsmindp 0, 1, 2
-; AIX-NEXT:    b L..BB2_3
+; AIX-NEXT:    xsmindp 1, 1, 2
+; AIX-NEXT:    blr
 ; AIX-NEXT:  L..BB2_2:
-; AIX-NEXT:    ld 4, L..C2(2) # %const.0
-; AIX-NEXT:    lfs 0, 0(4)
-; AIX-NEXT:  L..BB2_3: # %entry
-; AIX-NEXT:    li 5, 1
-; AIX-NEXT:    mffprd 4, 2
-; AIX-NEXT:    rldic 5, 5, 63, 0
-; AIX-NEXT:    cmpd 3, 5
-; AIX-NEXT:    bc 12, 2, L..BB2_5
-; AIX-NEXT:  # %bb.4: # %entry
-; AIX-NEXT:    fmr 1, 0
-; AIX-NEXT:  L..BB2_5: # %entry
-; AIX-NEXT:    cmpd 4, 5
-; AIX-NEXT:    bc 12, 2, L..BB2_7
-; AIX-NEXT:  # %bb.6: # %entry
-; AIX-NEXT:    fmr 2, 1
-; AIX-NEXT:  L..BB2_7: # %entry
-; AIX-NEXT:    xxlxor 1, 1, 1
-; AIX-NEXT:    fcmpu 0, 0, 1
-; AIX-NEXT:    bc 12, 2, L..BB2_9
-; AIX-NEXT:  # %bb.8: # %entry
-; AIX-NEXT:    fmr 2, 0
-; AIX-NEXT:  L..BB2_9: # %entry
-; AIX-NEXT:    fmr 1, 2
+; AIX-NEXT:    ld 3, L..C2(2) # %const.0
+; AIX-NEXT:    lfs 1, 0(3)
 ; AIX-NEXT:    blr
 entry:
   %m = call double @llvm.minimum.f64(double %a, double %b)
@@ -382,65 +246,25 @@ define double @f64_maximum(double %a, double %b) {
 ; VSX-LABEL: f64_maximum:
 ; VSX:       # %bb.0: # %entry
 ; VSX-NEXT:    fcmpu 0, 1, 2
-; VSX-NEXT:    mffprd 3, 1
 ; VSX-NEXT:    bc 12, 3, .LBB3_2
 ; VSX-NEXT:  # %bb.1: # %entry
-; VSX-NEXT:    xsmaxdp 0, 1, 2
-; VSX-NEXT:    b .LBB3_3
+; VSX-NEXT:    xsmaxdp 1, 1, 2
+; VSX-NEXT:    blr
 ; VSX-NEXT:  .LBB3_2:
-; VSX-NEXT:    addis 4, 2, .LCPI3_0@toc@ha
-; VSX-NEXT:    lfs 0, .LCPI3_0@toc@l(4)
-; VSX-NEXT:  .LBB3_3: # %entry
-; VSX-NEXT:    mffprd 4, 2
-; VSX-NEXT:    cmpdi 3, 0
-; VSX-NEXT:    bc 12, 2, .LBB3_5
-; VSX-NEXT:  # %bb.4: # %entry
-; VSX-NEXT:    fmr 1, 0
-; VSX-NEXT:  .LBB3_5: # %entry
-; VSX-NEXT:    cmpdi 4, 0
-; VSX-NEXT:    bc 12, 2, .LBB3_7
-; VSX-NEXT:  # %bb.6: # %entry
-; VSX-NEXT:    fmr 2, 1
-; VSX-NEXT:  .LBB3_7: # %entry
-; VSX-NEXT:    xxlxor 1, 1, 1
-; VSX-NEXT:    fcmpu 0, 0, 1
-; VSX-NEXT:    bc 12, 2, .LBB3_9
-; VSX-NEXT:  # %bb.8: # %entry
-; VSX-NEXT:    fmr 2, 0
-; VSX-NEXT:  .LBB3_9: # %entry
-; VSX-NEXT:    fmr 1, 2
+; VSX-NEXT:    addis 3, 2, .LCPI3_0@toc@ha
+; VSX-NEXT:    lfs 1, .LCPI3_0@toc@l(3)
 ; VSX-NEXT:    blr
 ;
 ; AIX-LABEL: f64_maximum:
 ; AIX:       # %bb.0: # %entry
 ; AIX-NEXT:    fcmpu 0, 1, 2
-; AIX-NEXT:    mffprd 3, 1
 ; AIX-NEXT:    bc 12, 3, L..BB3_2
 ; AIX-NEXT:  # %bb.1: # %entry
-; AIX-NEXT:    xsmaxdp 0, 1, 2
-; AIX-NEXT:    b L..BB3_3
+; AIX-NEXT:    xsmaxdp 1, 1, 2
+; AIX-NEXT:    blr
 ; AIX-NEXT:  L..BB3_2:
-; AIX-NEXT:    ld 4, L..C3(2) # %const.0
-; AIX-NEXT:    lfs 0, 0(4)
-; AIX-NEXT:  L..BB3_3: # %entry
-; AIX-NEXT:    mffprd 4, 2
-; AIX-NEXT:    cmpdi 3, 0
-; AIX-NEXT:    bc 12, 2, L..BB3_5
-; AIX-NEXT:  # %bb.4: # %entry
-; AIX-NEXT:    fmr 1, 0
-; AIX-NEXT:  L..BB3_5: # %entry
-; AIX-NEXT:    cmpdi 4, 0
-; AIX-NEXT:    bc 12, 2, L..BB3_7
-; AIX-NEXT:  # %bb.6: # %entry
-; AIX-NEXT:    fmr 2, 1
-; AIX-NEXT:  L..BB3_7: # %entry
-; AIX-NEXT:    xxlxor 1, 1, 1
-; AIX-NEXT:    fcmpu 0, 0, 1
-; AIX-NEXT:    bc 12, 2, L..BB3_9
-; AIX-NEXT:  # %bb.8: # %entry
-; AIX-NEXT:    fmr 2, 0
-; AIX-NEXT:  L..BB3_9: # %entry
-; AIX-NEXT:    fmr 1, 2
+; AIX-NEXT:    ld 3, L..C3(2) # %const.0
+; AIX-NEXT:    lfs 1, 0(3)
 ; AIX-NEXT:    blr
 entry:
   %m = call double @llvm.maximum.f64(double %a, double %b)


### PR DESCRIPTION
dc9664a8adae17f2083fbcc8e96cfce606c56d57 changed the documentation to assume these order -0 as less than +0.