### PR TITLE
[mlir] Fixing a regression that '-D' option of llvm-tblgen is unregistered.

### DIFF
--- a/mlir/tools/mlir-src-sharder/mlir-src-sharder.cpp
+++ b/mlir/tools/mlir-src-sharder/mlir-src-sharder.cpp
@@ -62,6 +62,14 @@ int main(int argc, char **argv) {
       "write-if-changed",
       llvm::cl::desc("Only write to the output file if it changed"));
 
+  // `ResetCommandLineParser` at the above unregistered the "D" option
+  // of `llvm-tblgen`, which caused `TestOps.cpp` to fail due to
+  // "Unknnown command line argument '-D...`" when a macros name is
+  // present. The following is a workaround to re-register it again.
+  llvm::cl::list<std::string> MacroNames(
+      "D", llvm::cl::desc("Name of the macro to be defined"),
+      llvm::cl::value_desc("macro name"), llvm::cl::Prefix);
+
   llvm::InitLLVM y(argc, argv);
   llvm::cl::ParseCommandLineOptions(argc, argv);
 

--- a/mlir/tools/mlir-src-sharder/mlir-src-sharder.cpp
+++ b/mlir/tools/mlir-src-sharder/mlir-src-sharder.cpp
@@ -67,7 +67,9 @@ int main(int argc, char **argv) {
   // "Unknnown command line argument '-D...`" when a macros name is
   // present. The following is a workaround to re-register it again.
   llvm::cl::list<std::string> MacroNames(
-      "D", llvm::cl::desc("Name of the macro to be defined"),
+      "D",
+      llvm::cl::desc(
+          "Name of the macro to be defined -- ignored by mlir-src-sharder"),
       llvm::cl::value_desc("macro name"), llvm::cl::Prefix);
 
   llvm::InitLLVM y(argc, argv);


### PR DESCRIPTION
PR #89664 introduced a regression that it unregistered llvm-tblgen option `-D` for macros. The test `TestOps.cpp` failed due to passing a macros to llvm-tblgen. 

It caused our internal build to fail because we append `-DLOCAL_NAME` into `LLVM_TABLEGEN_FLANGS` in `llvm/lib/cmake/llvm/TableGen.cmake` as

```
list(APPEND LLVM_TABLEGEN_FLAGS "-DLOCAL_NAME")
```

And in `./llvm/lib/Target/PowerPC/PPC.td`, we check it for some downstream code as:

```
...
#ifdef LOCAL_NAME
...
#endif
```
Now we got error message from mlir-src-sharder as
```
mlir-src-sharder -op-shard-index=1 -DLOCAL_NAME llvm-project/mlir/test/lib/Dialect/Test/TestOps.cpp --write-if-changed -o tools/mlir/test/lib/Dialect/Test/TestOps.1.cpp -d tools/mlir/test/lib/Dialect/Test/TestOps.1.cpp.d
mlir-src-sharder: Unknown command line argument '-DLOCAL_NAME'.  Try: 'llvm-project/build/bin/mlir-src-sharder --help'
mlir-src-sharder: Did you mean '-I'?
```

This PR is to fix the regression. 