### PR TITLE
[lldb][DWARF] Sort ranges list in dwarf 5.

### DIFF
--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFUnit.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFUnit.cpp
@@ -1062,6 +1062,7 @@ DWARFUnit::FindRnglistFromOffset(dw_offset_t offset) {
     ranges.Append(DWARFRangeList::Entry(llvm_range.LowPC,
                                         llvm_range.HighPC - llvm_range.LowPC));
   }
+  ranges.Sort();
   return ranges;
 }
 

--- a/lldb/test/Shell/SymbolFile/DWARF/x86/debug_rnglists.s
+++ b/lldb/test/Shell/SymbolFile/DWARF/x86/debug_rnglists.s
@@ -125,11 +125,11 @@ lookup_rnglists2:
         .long   .Ldebug_ranges0-.Lrnglists_table_base0
 .Ldebug_ranges0:
         .byte   4                       # DW_RLE_offset_pair
-        .uleb128 .Lblock1_begin-rnglists  #   starting offset
-        .uleb128 .Lblock1_end-rnglists    #   ending offset
-        .byte   4                       # DW_RLE_offset_pair
         .uleb128 .Lblock2_begin-rnglists  #   starting offset
         .uleb128 .Lblock2_end-rnglists    #   ending offset
+        .byte   4                       # DW_RLE_offset_pair
+        .uleb128 .Lblock1_begin-rnglists  #   starting offset
+        .uleb128 .Lblock1_end-rnglists    #   ending offset
         .byte   0                       # DW_RLE_end_of_list
 .Ldebug_rnglist_table_end0:
 


### PR DESCRIPTION
Dwarf 5 says "There is no requirement that the entries be ordered in any particular way" in 2.17.3 Non-Contiguous Address Ranges for rnglist. Some places assume the ranges are already sorted but it's not.

For example, when [parsing function info](https://github.com/llvm/llvm-project/blob/bc8a42762057d7036f6871211e62b1c3efb2738a/lldb/source/Plugins/SymbolFile/DWARF/SymbolFileDWARF.cpp#L922-L927), it validates low and hi address of the function: GetMinRangeBase returns the first range entry base and GetMaxRangeEnd returns the last range end. If low >= hi, it stops parsing this function. This causes missing inline stack frames for those functions.

This change fixes it and updates the test `lldb/test/Shell/SymbolFile/DWARF/x86/debug_rnglists.s` so that two ranges in `.debug_rnglists` are out of order and `image lookup -v -s lookup_rnglists` is still able to produce sorted ranges for the inner block.