### PR TITLE
[libc++] Stop using strict availability markup on Apple

### DIFF
--- a/libcxx/include/__availability
+++ b/libcxx/include/__availability
@@ -120,7 +120,7 @@
 // LLVM 4
 #  if defined(__ENVIRONMENT_WATCH_OS_VERSION_MIN_REQUIRED__) && __ENVIRONMENT_WATCH_OS_VERSION_MIN_REQUIRED__ < 50000
 #    define _LIBCPP_INTRODUCED_IN_LLVM_4 0
-#    define _LIBCPP_INTRODUCED_IN_LLVM_4_ATTRIBUTE __attribute__((availability(watchos, strict, introduced = 5.0)))
+#    define _LIBCPP_INTRODUCED_IN_LLVM_4_ATTRIBUTE __attribute__((availability(watchos, introduced = 5.0)))
 #  else
 #    define _LIBCPP_INTRODUCED_IN_LLVM_4 1
 #    define _LIBCPP_INTRODUCED_IN_LLVM_4_ATTRIBUTE /* nothing */
@@ -135,16 +135,14 @@
 // clang-format on
 #    define _LIBCPP_INTRODUCED_IN_LLVM_9 0
 #    define _LIBCPP_INTRODUCED_IN_LLVM_9_ATTRIBUTE                                                                     \
-      __attribute__((availability(macos, strict, introduced = 10.15)))                                                 \
-      __attribute__((availability(ios, strict, introduced = 13.0)))                                                    \
-      __attribute__((availability(tvos, strict, introduced = 13.0)))                                                   \
-      __attribute__((availability(watchos, strict, introduced = 6.0)))
+      __attribute__((availability(macos, introduced = 10.15))) __attribute__((availability(ios, introduced = 13.0)))   \
+      __attribute__((availability(tvos, introduced = 13.0))) __attribute__((availability(watchos, introduced = 6.0)))
 // clang-format off
-#    define _LIBCPP_INTRODUCED_IN_LLVM_9_ATTRIBUTE_PUSH                                                                               \
-      _Pragma("clang attribute push(__attribute__((availability(macos,strict,introduced=10.15))), apply_to=any(function,record))") \
-      _Pragma("clang attribute push(__attribute__((availability(ios,strict,introduced=13.0))), apply_to=any(function,record))")    \
-      _Pragma("clang attribute push(__attribute__((availability(tvos,strict,introduced=13.0))), apply_to=any(function,record))")   \
-      _Pragma("clang attribute push(__attribute__((availability(watchos,strict,introduced=6.0))), apply_to=any(function,record))")
+#    define _LIBCPP_INTRODUCED_IN_LLVM_9_ATTRIBUTE_PUSH                                                                       \
+      _Pragma("clang attribute push(__attribute__((availability(macos, introduced=10.15))), apply_to=any(function, record))") \
+      _Pragma("clang attribute push(__attribute__((availability(ios, introduced=13.0))), apply_to=any(function, record))")    \
+      _Pragma("clang attribute push(__attribute__((availability(tvos, introduced=13.0))), apply_to=any(function, record))")   \
+      _Pragma("clang attribute push(__attribute__((availability(watchos, introduced=6.0))), apply_to=any(function, record))")
 #    define _LIBCPP_INTRODUCED_IN_LLVM_9_ATTRIBUTE_POP                                                                    \
       _Pragma("clang attribute pop") \
       _Pragma("clang attribute pop") \
@@ -167,10 +165,8 @@
 // clang-format on
 #    define _LIBCPP_INTRODUCED_IN_LLVM_10 0
 #    define _LIBCPP_INTRODUCED_IN_LLVM_10_ATTRIBUTE                                                                    \
-      __attribute__((availability(macos, strict, introduced = 11.0)))                                                  \
-      __attribute__((availability(ios, strict, introduced = 14.0)))                                                    \
-      __attribute__((availability(tvos, strict, introduced = 14.0)))                                                   \
-      __attribute__((availability(watchos, strict, introduced = 7.0)))
+      __attribute__((availability(macos, introduced = 11.0))) __attribute__((availability(ios, introduced = 14.0)))    \
+      __attribute__((availability(tvos, introduced = 14.0))) __attribute__((availability(watchos, introduced = 7.0)))
 #  else
 #    define _LIBCPP_INTRODUCED_IN_LLVM_10 1
 #    define _LIBCPP_INTRODUCED_IN_LLVM_10_ATTRIBUTE /* nothing */
@@ -185,10 +181,8 @@
 // clang-format on
 #    define _LIBCPP_INTRODUCED_IN_LLVM_12 0
 #    define _LIBCPP_INTRODUCED_IN_LLVM_12_ATTRIBUTE                                                                    \
-      __attribute__((availability(macos, strict, introduced = 12.0)))                                                  \
-      __attribute__((availability(ios, strict, introduced = 15.0)))                                                    \
-      __attribute__((availability(tvos, strict, introduced = 15.0)))                                                   \
-      __attribute__((availability(watchos, strict, introduced = 8.0)))
+      __attribute__((availability(macos, introduced = 12.0))) __attribute__((availability(ios, introduced = 15.0)))    \
+      __attribute__((availability(tvos, introduced = 15.0))) __attribute__((availability(watchos, introduced = 8.0)))
 #  else
 #    define _LIBCPP_INTRODUCED_IN_LLVM_12 1
 #    define _LIBCPP_INTRODUCED_IN_LLVM_12_ATTRIBUTE /* nothing */
@@ -203,10 +197,8 @@
 // clang-format on
 #    define _LIBCPP_INTRODUCED_IN_LLVM_14 0
 #    define _LIBCPP_INTRODUCED_IN_LLVM_14_ATTRIBUTE                                                                    \
-      __attribute__((availability(macos, strict, introduced = 13.4)))                                                  \
-      __attribute__((availability(ios, strict, introduced = 16.5)))                                                    \
-      __attribute__((availability(tvos, strict, introduced = 16.5)))                                                   \
-      __attribute__((availability(watchos, strict, introduced = 9.5)))
+      __attribute__((availability(macos, introduced = 13.4))) __attribute__((availability(ios, introduced = 16.5)))    \
+      __attribute__((availability(tvos, introduced = 16.5))) __attribute__((availability(watchos, introduced = 9.5)))
 #  else
 #    define _LIBCPP_INTRODUCED_IN_LLVM_14 1
 #    define _LIBCPP_INTRODUCED_IN_LLVM_14_ATTRIBUTE /* nothing */
@@ -223,10 +215,8 @@
 // clang-format on
 #    define _LIBCPP_INTRODUCED_IN_LLVM_16 0
 #    define _LIBCPP_INTRODUCED_IN_LLVM_16_ATTRIBUTE                                                                    \
-      __attribute__((availability(macos, strict, introduced = 14.0)))                                                  \
-      __attribute__((availability(ios, strict, introduced = 17.0)))                                                    \
-      __attribute__((availability(tvos, strict, introduced = 17.0)))                                                   \
-      __attribute__((availability(watchos, strict, introduced = 10.0)))
+      __attribute__((availability(macos, introduced = 14.0))) __attribute__((availability(ios, introduced = 17.0)))    \
+      __attribute__((availability(tvos, introduced = 17.0))) __attribute__((availability(watchos, introduced = 10.0)))
 #  else
 #    define _LIBCPP_INTRODUCED_IN_LLVM_16 1
 #    define _LIBCPP_INTRODUCED_IN_LLVM_16_ATTRIBUTE /* nothing */

--- a/libcxx/include/print
+++ b/libcxx/include/print
@@ -211,7 +211,6 @@ _LIBCPP_HIDE_FROM_ABI inline bool __is_terminal([[maybe_unused]] FILE* __stream)
 #  endif
 }
 
-template <class = void> // TODO PRINT template or availability markup fires too eagerly (http://llvm.org/PR61563).
 _LIBCPP_HIDE_FROM_ABI inline void
 __vprint_nonunicode(FILE* __stream, string_view __fmt, format_args __args, bool __write_nl) {
   _LIBCPP_ASSERT_NON_NULL(__stream, "__stream must be a valid pointer to an output C stream");
@@ -234,7 +233,6 @@ __vprint_nonunicode(FILE* __stream, string_view __fmt, format_args __args, bool 
 // terminal when the output is redirected. Typically during testing the
 // output is redirected to be able to capture it. This makes it hard to
 // test this code path.
-template <class = void> // TODO PRINT template or availability markup fires too eagerly (http://llvm.org/PR61563).
 _LIBCPP_HIDE_FROM_ABI inline void
 __vprint_unicode_posix(FILE* __stream, string_view __fmt, format_args __args, bool __write_nl, bool __is_terminal) {
   // TODO PRINT Should flush errors throw too?
@@ -245,7 +243,6 @@ __vprint_unicode_posix(FILE* __stream, string_view __fmt, format_args __args, bo
 }
 
 #    ifndef _LIBCPP_HAS_NO_WIDE_CHARACTERS
-template <class = void> // TODO PRINT template or availability markup fires too eagerly (http://llvm.org/PR61563).
 _LIBCPP_HIDE_FROM_ABI inline void
 __vprint_unicode_windows(FILE* __stream, string_view __fmt, format_args __args, bool __write_nl, bool __is_terminal) {
   if (!__is_terminal)
@@ -284,7 +281,6 @@ __vprint_unicode_windows(FILE* __stream, string_view __fmt, format_args __args, 
 }
 #    endif // _LIBCPP_HAS_NO_WIDE_CHARACTERS
 
-template <class = void> // TODO PRINT template or availability markup fires too eagerly (http://llvm.org/PR61563).
 _LIBCPP_HIDE_FROM_ABI inline void
 __vprint_unicode([[maybe_unused]] FILE* __stream,
                  [[maybe_unused]] string_view __fmt,
@@ -358,10 +354,8 @@ _LIBCPP_HIDE_FROM_ABI void println(FILE* __stream, format_string<_Args...> __fmt
 #  endif // _LIBCPP_HAS_NO_UNICODE
 }
 
-template <class = void> // TODO PRINT template or availability markup fires too eagerly (http://llvm.org/PR61563).
 _LIBCPP_HIDE_FROM_ABI inline void println(FILE* __stream) { std::print(__stream, "\n"); }
 
-template <class = void> // TODO PRINT template or availability markup fires too eagerly (http://llvm.org/PR61563).
 _LIBCPP_HIDE_FROM_ABI inline void println() { println(stdout); }
 
 template <class... _Args>
@@ -370,24 +364,20 @@ _LIBCPP_HIDE_FROM_ABI void println(format_string<_Args...> __fmt, _Args&&... __a
 }
 
 #  ifndef _LIBCPP_HAS_NO_UNICODE
-template <class = void> // TODO PRINT template or availability markup fires too eagerly (http://llvm.org/PR61563).
 _LIBCPP_HIDE_FROM_ABI inline void vprint_unicode(FILE* __stream, string_view __fmt, format_args __args) {
   __print::__vprint_unicode(__stream, __fmt, __args, false);
 }
 
-template <class = void> // TODO PRINT template or availability markup fires too eagerly (http://llvm.org/PR61563).
 _LIBCPP_HIDE_FROM_ABI inline void vprint_unicode(string_view __fmt, format_args __args) {
   std::vprint_unicode(stdout, __fmt, __args);
 }
 
 #  endif // _LIBCPP_HAS_NO_UNICODE
 
-template <class = void> // TODO PRINT template or availability markup fires too eagerly (http://llvm.org/PR61563).
 _LIBCPP_HIDE_FROM_ABI inline void vprint_nonunicode(FILE* __stream, string_view __fmt, format_args __args) {
   __print::__vprint_nonunicode(__stream, __fmt, __args, false);
 }
 
-template <class = void> // TODO PRINT template or availability markup fires too eagerly (http://llvm.org/PR61563).
 _LIBCPP_HIDE_FROM_ABI inline void vprint_nonunicode(string_view __fmt, format_args __args) {
   std::vprint_nonunicode(stdout, __fmt, __args);
 }

--- a/libcxx/test/libcxx/diagnostics/format.nodiscard.verify.cpp
+++ b/libcxx/test/libcxx/diagnostics/format.nodiscard.verify.cpp
@@ -8,9 +8,6 @@
 
 // Check that format functions are marked [[nodiscard]] as a conforming extension
 
-// TODO FMT This test should not require std::to_chars(floating-point)
-// XFAIL: availability-fp_to_chars-missing
-
 // UNSUPPORTED: c++03, c++11, c++14, c++17
 
 #include <format>

--- a/libcxx/test/libcxx/input.output/iostream.format/print.fun/vprint_unicode_posix.pass.cpp
+++ b/libcxx/test/libcxx/input.output/iostream.format/print.fun/vprint_unicode_posix.pass.cpp
@@ -9,8 +9,6 @@
 // UNSUPPORTED: no-filesystem
 // UNSUPPORTED: GCC-ALWAYS_INLINE-FIXME
 
-// XFAIL: availability-fp_to_chars-missing
-
 // fmemopen is available starting in Android M (API 23)
 // XFAIL: target={{.+}}-android{{(eabi)?(21|22)}}
 

--- a/libcxx/test/libcxx/input.output/iostream.format/print.fun/vprint_unicode_windows.pass.cpp
+++ b/libcxx/test/libcxx/input.output/iostream.format/print.fun/vprint_unicode_windows.pass.cpp
@@ -13,8 +13,6 @@
 // Clang modules do not work with the definiton of _LIBCPP_TESTING_PRINT_WRITE_TO_WINDOWS_CONSOLE_FUNCTION
 // XFAIL: clang-modules-build
 
-// XFAIL: availability-fp_to_chars-missing
-
 // <print>
 
 // Tests the implementation of

--- a/libcxx/test/libcxx/thread/atomic.availability.verify.cpp
+++ b/libcxx/test/libcxx/thread/atomic.availability.verify.cpp
@@ -19,59 +19,61 @@ void f() {
         std::atomic<int> i(3);
         std::memory_order m = std::memory_order_relaxed;
 
-        i.wait(4); // expected-error {{is unavailable}}
-        i.wait(4, m); // expected-error {{is unavailable}}
-        i.notify_one(); // expected-error {{is unavailable}}
-        i.notify_all(); // expected-error {{is unavailable}}
+        i.wait(4); // expected-warning {{'wait' is only available on}}
+        i.wait(4, m); // expected-warning {{'wait' is only available on}}
+        i.notify_one(); // expected-warning {{'notify_one' is only available on}}
+        i.notify_all(); // expected-warning {{'notify_all' is only available on}}
 
-        std::atomic_wait(&i, 4); // expected-error {{is unavailable}}
-        std::atomic_wait_explicit(&i, 4, m); // expected-error {{is unavailable}}
-        std::atomic_notify_one(&i); // expected-error {{is unavailable}}
-        std::atomic_notify_all(&i); // expected-error {{is unavailable}}
+        std::atomic_wait(&i, 4); // expected-warning {{'atomic_wait<int>' is only available on}}
+        std::atomic_wait_explicit(&i, 4, m); // expected-warning {{'atomic_wait_explicit<int>' is only available on}}
+        std::atomic_notify_one(&i); // expected-warning {{'atomic_notify_one<int>' is only available on}}
+        std::atomic_notify_all(&i); // expected-warning {{'atomic_notify_all<int>' is only available on}}
     }
 
     {
         std::atomic<int> volatile i(3);
         std::memory_order m = std::memory_order_relaxed;
 
-        i.wait(4); // expected-error {{is unavailable}}
-        i.wait(4, m); // expected-error {{is unavailable}}
-        i.notify_one(); // expected-error {{is unavailable}}
-        i.notify_all(); // expected-error {{is unavailable}}
+        i.wait(4); // expected-warning {{'wait' is only available on}}
+        i.wait(4, m); // expected-warning {{'wait' is only available on}}
+        i.notify_one(); // expected-warning {{'notify_one' is only available on}}
+        i.notify_all(); // expected-warning {{'notify_all' is only available on}}
 
-        std::atomic_wait(&i, 4); // expected-error {{is unavailable}}
-        std::atomic_wait_explicit(&i, 4, m); // expected-error {{is unavailable}}
-        std::atomic_notify_one(&i); // expected-error {{is unavailable}}
-        std::atomic_notify_all(&i); // expected-error {{is unavailable}}
+        std::atomic_wait(&i, 4); // expected-warning {{'atomic_wait<int>' is only available on}}
+        std::atomic_wait_explicit(&i, 4, m); // expected-warning {{'atomic_wait_explicit<int>' is only available on}}
+        std::atomic_notify_one(&i); // expected-warning {{'atomic_notify_one<int>' is only available on}}
+        std::atomic_notify_all(&i); // expected-warning {{'atomic_notify_all<int>' is only available on}}
     }
 
     {
         std::atomic_flag flag;
         bool b = false;
         std::memory_order m = std::memory_order_relaxed;
-        flag.wait(b); // expected-error {{is unavailable}}
-        flag.wait(b, m); // expected-error {{is unavailable}}
-        flag.notify_one(); // expected-error {{is unavailable}}
-        flag.notify_all(); // expected-error {{is unavailable}}
 
-        std::atomic_flag_wait(&flag, b); // expected-error {{is unavailable}}
-        std::atomic_flag_wait_explicit(&flag, b, m); // expected-error {{is unavailable}}
-        std::atomic_flag_notify_one(&flag); // expected-error {{is unavailable}}
-        std::atomic_flag_notify_all(&flag); // expected-error {{is unavailable}}
+        flag.wait(b); // expected-warning {{'wait' is only available on}}
+        flag.wait(b, m); // expected-warning {{'wait' is only available on}}
+        flag.notify_one(); // expected-warning {{'notify_one' is only available on}}
+        flag.notify_all(); // expected-warning {{'notify_all' is only available on}}
+
+        std::atomic_flag_wait(&flag, b); // expected-warning {{'atomic_flag_wait' is only available on}}
+        std::atomic_flag_wait_explicit(&flag, b, m); // expected-warning {{'atomic_flag_wait_explicit' is only available on}}
+        std::atomic_flag_notify_one(&flag); // expected-warning {{'atomic_flag_notify_one' is only available on}}
+        std::atomic_flag_notify_all(&flag); // expected-warning {{'atomic_flag_notify_all' is only available on}}
     }
 
     {
         std::atomic_flag volatile flag;
         bool b = false;
         std::memory_order m = std::memory_order_relaxed;
-        flag.wait(b); // expected-error {{is unavailable}}
-        flag.wait(b, m); // expected-error {{is unavailable}}
-        flag.notify_one(); // expected-error {{is unavailable}}
-        flag.notify_all(); // expected-error {{is unavailable}}
 
-        std::atomic_flag_wait(&flag, b); // expected-error {{is unavailable}}
-        std::atomic_flag_wait_explicit(&flag, b, m); // expected-error {{is unavailable}}
-        std::atomic_flag_notify_one(&flag); // expected-error {{is unavailable}}
-        std::atomic_flag_notify_all(&flag); // expected-error {{is unavailable}}
+        flag.wait(b); // expected-warning {{'wait' is only available on}}
+        flag.wait(b, m); // expected-warning {{'wait' is only available on}}
+        flag.notify_one(); // expected-warning {{'notify_one' is only available on}}
+        flag.notify_all(); // expected-warning {{'notify_all' is only available on}}
+
+        std::atomic_flag_wait(&flag, b); // expected-warning {{'atomic_flag_wait' is only available on}}
+        std::atomic_flag_wait_explicit(&flag, b, m); // expected-warning {{'atomic_flag_wait_explicit' is only available on}}
+        std::atomic_flag_notify_one(&flag); // expected-warning {{'atomic_flag_notify_one' is only available on}}
+        std::atomic_flag_notify_all(&flag); // expected-warning {{'atomic_flag_notify_all' is only available on}}
     }
 }

--- a/libcxx/test/libcxx/thread/barrier.availability.verify.cpp
+++ b/libcxx/test/libcxx/thread/barrier.availability.verify.cpp
@@ -21,21 +21,21 @@ struct CompletionF {
 void f() {
     // Availability markup on std::barrier<>
     {
-        std::barrier<> b(10); // expected-error {{is unavailable}}
-        auto token = b.arrive(); // expected-error {{is unavailable}}
-        (void)b.arrive(10); // expected-error {{is unavailable}}
-        b.wait(std::move(token)); // expected-error {{is unavailable}}
-        b.arrive_and_wait(); // expected-error {{is unavailable}}
-        b.arrive_and_drop(); // expected-error {{is unavailable}}
+        std::barrier<> b(10);
+        auto token = b.arrive(); // expected-warning {{'arrive' is only available on}}
+        (void)b.arrive(10); // expected-warning {{'arrive' is only available on}}
+        b.wait(std::move(token)); // expected-warning {{'wait' is only available on}}
+        b.arrive_and_wait(); // expected-warning {{'arrive_and_wait' is only available on}}
+        b.arrive_and_drop(); // expected-warning {{'arrive_and_drop' is only available on}}
     }
 
     // Availability markup on std::barrier<CompletionF> with non-default CompletionF
     {
-        std::barrier<CompletionF> b(10); // expected-error {{is unavailable}}
-        auto token = b.arrive(); // expected-error {{is unavailable}}
-        (void)b.arrive(10); // expected-error {{is unavailable}}
-        b.wait(std::move(token)); // expected-error {{is unavailable}}
-        b.arrive_and_wait(); // expected-error {{is unavailable}}
-        b.arrive_and_drop(); // expected-error {{is unavailable}}
+        std::barrier<CompletionF> b(10);
+        auto token = b.arrive(); // expected-warning {{'arrive' is only available on}}
+        (void)b.arrive(10); // expected-warning {{'arrive' is only available on}}
+        b.wait(std::move(token)); // expected-warning {{'wait' is only available on}}
+        b.arrive_and_wait(); // expected-warning {{'arrive_and_wait' is only available on}}
+        b.arrive_and_drop(); // expected-warning {{'arrive_and_drop' is only available on}}
     }
 }

--- a/libcxx/test/libcxx/thread/latch.availability.verify.cpp
+++ b/libcxx/test/libcxx/thread/latch.availability.verify.cpp
@@ -15,9 +15,9 @@
 
 void f() {
     std::latch latch(10);
-    latch.count_down(); // expected-error {{is unavailable}}
-    latch.count_down(3); // expected-error {{is unavailable}}
-    latch.wait(); // expected-error {{is unavailable}}
-    latch.arrive_and_wait(); // expected-error {{is unavailable}}
-    latch.arrive_and_wait(3); // expected-error {{is unavailable}}
+    latch.count_down(); // expected-warning {{'count_down' is only available on}}
+    latch.count_down(3); // expected-warning {{'count_down' is only available on}}
+    latch.wait(); // expected-warning {{'wait' is only available on}}
+    latch.arrive_and_wait(); // expected-warning {{'arrive_and_wait' is only available on}}
+    latch.arrive_and_wait(3); // expected-warning {{'arrive_and_wait' is only available on}}
 }

--- a/libcxx/test/libcxx/thread/semaphore.availability.verify.cpp
+++ b/libcxx/test/libcxx/thread/semaphore.availability.verify.cpp
@@ -18,31 +18,31 @@ void f() {
     {
         // Tests for std::counting_semaphore with non-default template argument
         std::counting_semaphore<20> sem(10);
-        sem.release(); // expected-error {{is unavailable}}
-        sem.release(5); // expected-error {{is unavailable}}
-        sem.acquire(); // expected-error {{is unavailable}}
-        sem.try_acquire_for(std::chrono::milliseconds{3}); // expected-error 1-2 {{is unavailable}}
-        sem.try_acquire(); // expected-error {{is unavailable}}
-        sem.try_acquire_until(std::chrono::steady_clock::now()); // expected-error 1-2 {{is unavailable}}
+        sem.release(); // expected-warning {{'release' is only available on}}
+        sem.release(5); // expected-warning {{'release' is only available on}}
+        sem.acquire(); // expected-warning {{'acquire' is only available on}}
+        sem.try_acquire_for(std::chrono::milliseconds{3}); // expected-warning-re {{'try_acquire_for<{{.+}}>' is only available on}}
+        sem.try_acquire(); // expected-warning {{'try_acquire' is only available on}}
+        sem.try_acquire_until(std::chrono::steady_clock::now()); // expected-warning-re {{'try_acquire_until<{{.+}}>' is only available on}}
     }
     {
         // Tests for std::counting_semaphore with default template argument
         std::counting_semaphore<> sem(10);
-        sem.release(); // expected-error {{is unavailable}}
-        sem.release(5); // expected-error {{is unavailable}}
-        sem.acquire(); // expected-error {{is unavailable}}
-        sem.try_acquire_for(std::chrono::milliseconds{3}); // expected-error 1-2 {{is unavailable}}
-        sem.try_acquire(); // expected-error {{is unavailable}}
-        sem.try_acquire_until(std::chrono::steady_clock::now()); // expected-error 1-2 {{is unavailable}}
+        sem.release(); // expected-warning {{'release' is only available on}}
+        sem.release(5); // expected-warning {{'release' is only available on}}
+        sem.acquire(); // expected-warning {{'acquire' is only available on}}
+        sem.try_acquire_for(std::chrono::milliseconds{3}); // expected-warning-re {{'try_acquire_for<{{.+}}>' is only available on}}
+        sem.try_acquire(); // expected-warning {{'try_acquire' is only available on}}
+        sem.try_acquire_until(std::chrono::steady_clock::now()); // expected-warning-re {{'try_acquire_until<{{.+}}>' is only available on}}
     }
     {
         // Tests for std::binary_semaphore
         std::binary_semaphore sem(10);
-        sem.release(); // expected-error {{is unavailable}}
-        sem.release(5); // expected-error {{is unavailable}}
-        sem.acquire(); // expected-error {{is unavailable}}
-        sem.try_acquire_for(std::chrono::milliseconds{3}); // expected-error 1-2 {{is unavailable}}
-        sem.try_acquire(); // expected-error {{is unavailable}}
-        sem.try_acquire_until(std::chrono::steady_clock::now()); // expected-error 1-2 {{is unavailable}}
+        sem.release(); // expected-warning {{'release' is only available on}}
+        sem.release(5); // expected-warning {{'release' is only available on}}
+        sem.acquire(); // expected-warning {{'acquire' is only available on}}
+        sem.try_acquire_for(std::chrono::milliseconds{3}); // expected-warning-re {{'try_acquire_for<{{.+}}>' is only available on}}
+        sem.try_acquire(); // expected-warning {{'try_acquire' is only available on}}
+        sem.try_acquire_until(std::chrono::steady_clock::now()); // expected-warning-re {{'try_acquire_until<{{.+}}>' is only available on}}
     }
 }

--- a/libcxx/test/libcxx/time/time.zone/time.zone.info/time.zone.info.local/ostream.pass.cpp
+++ b/libcxx/test/libcxx/time/time.zone/time.zone.info/time.zone.info.local/ostream.pass.cpp
@@ -9,9 +9,6 @@
 // UNSUPPORTED: c++03, c++11, c++14, c++17
 // UNSUPPORTED: no-localization
 
-// TODO FMT This test should not require std::to_chars(floating-point)
-// XFAIL: availability-fp_to_chars-missing
-
 // XFAIL: libcpp-has-no-experimental-tzdb
 
 // <chrono>

--- a/libcxx/test/libcxx/time/time.zone/time.zone.info/time.zone.info.sys/ostream.pass.cpp
+++ b/libcxx/test/libcxx/time/time.zone/time.zone.info/time.zone.info.sys/ostream.pass.cpp
@@ -9,9 +9,6 @@
 // UNSUPPORTED: c++03, c++11, c++14, c++17
 // UNSUPPORTED: no-localization
 
-// TODO FMT This test should not require std::to_chars(floating-point)
-// XFAIL: availability-fp_to_chars-missing
-
 // XFAIL: libcpp-has-no-experimental-tzdb
 
 // <chrono>

--- a/libcxx/test/libcxx/utilities/format/format.functions/ascii.pass.cpp
+++ b/libcxx/test/libcxx/utilities/format/format.functions/ascii.pass.cpp
@@ -11,9 +11,6 @@
 // Force unicode to be disabled.
 // ADDITIONAL_COMPILE_FLAGS: -D_LIBCPP_HAS_NO_UNICODE
 
-// TODO FMT This test should not require std::to_chars(floating-point)
-// XFAIL: availability-fp_to_chars-missing
-
 // <format>
 
 // Tests Unicode is ignored and handled as ASCII.

--- a/libcxx/test/libcxx/utilities/format/format.functions/escaped_output.ascii.pass.cpp
+++ b/libcxx/test/libcxx/utilities/format/format.functions/escaped_output.ascii.pass.cpp
@@ -8,9 +8,6 @@
 // UNSUPPORTED: c++03, c++11, c++14, c++17, c++20
 // UNSUPPORTED: GCC-ALWAYS_INLINE-FIXME
 
-// TODO FMT This test should not require std::to_chars(floating-point)
-// XFAIL: availability-fp_to_chars-missing
-
 // Force unicode to be disabled.
 // ADDITIONAL_COMPILE_FLAGS: -D_LIBCPP_HAS_NO_UNICODE
 

--- a/libcxx/test/std/atomics/atomics.types.generic/general.compile.pass.cpp
+++ b/libcxx/test/std/atomics/atomics.types.generic/general.compile.pass.cpp
@@ -8,8 +8,6 @@
 
 // UNSUPPORTED: c++03
 
-// XFAIL: availability-synchronization_library-missing
-
 // <atomic>
 
 // Tests the basic features and makes sure they work with a hijacking operator&.

--- a/libcxx/test/std/atomics/atomics.types.generic/pointer.compile.pass.cpp
+++ b/libcxx/test/std/atomics/atomics.types.generic/pointer.compile.pass.cpp
@@ -8,8 +8,6 @@
 
 // UNSUPPORTED: c++03
 
-// XFAIL: availability-synchronization_library-missing
-
 // <atomic>
 
 // Tests the basic features and makes sure they work with a hijacking operator&.

--- a/libcxx/test/std/containers/sequences/vector.bool/vector.bool.fmt/format.functions.format.pass.cpp
+++ b/libcxx/test/std/containers/sequences/vector.bool/vector.bool.fmt/format.functions.format.pass.cpp
@@ -9,9 +9,6 @@
 
 // UNSUPPORTED: GCC-ALWAYS_INLINE-FIXME
 
-// TODO FMT This test should not require std::to_chars(floating-point)
-// XFAIL: availability-fp_to_chars-missing
-
 // <vector>
 
 // template<class T, class charT>

--- a/libcxx/test/std/containers/sequences/vector.bool/vector.bool.fmt/format.functions.vformat.pass.cpp
+++ b/libcxx/test/std/containers/sequences/vector.bool/vector.bool.fmt/format.functions.vformat.pass.cpp
@@ -9,8 +9,6 @@
 
 // UNSUPPORTED: GCC-ALWAYS_INLINE-FIXME
 
-// XFAIL: availability-fp_to_chars-missing
-
 // <vector>
 
 // template<class T, class charT>

--- a/libcxx/test/std/input.output/iostream.format/print.fun/no_file_description.pass.cpp
+++ b/libcxx/test/std/input.output/iostream.format/print.fun/no_file_description.pass.cpp
@@ -10,7 +10,6 @@
 // UNSUPPORTED: GCC-ALWAYS_INLINE-FIXME
 
 // XFAIL: msvc, target={{.+}}-windows-gnu
-// XFAIL: availability-fp_to_chars-missing
 
 // fmemopen is available starting in Android M (API 23)
 // XFAIL: target={{.+}}-android{{(eabi)?(21|22)}}

--- a/libcxx/test/std/input.output/iostream.format/print.fun/print.file.pass.cpp
+++ b/libcxx/test/std/input.output/iostream.format/print.fun/print.file.pass.cpp
@@ -9,8 +9,6 @@
 // UNSUPPORTED: no-filesystem
 // UNSUPPORTED: GCC-ALWAYS_INLINE-FIXME
 
-// XFAIL: availability-fp_to_chars-missing
-
 // The error exception has no system error string.
 // XFAIL: LIBCXX-ANDROID-FIXME
 

--- a/libcxx/test/std/input.output/iostream.format/print.fun/print.sh.cpp
+++ b/libcxx/test/std/input.output/iostream.format/print.fun/print.sh.cpp
@@ -9,8 +9,6 @@
 // UNSUPPORTED: no-filesystem
 // UNSUPPORTED: GCC-ALWAYS_INLINE-FIXME
 
-// XFAIL: availability-fp_to_chars-missing
-
 // <print>
 
 // template<class... Args>

--- a/libcxx/test/std/input.output/iostream.format/print.fun/println.file.pass.cpp
+++ b/libcxx/test/std/input.output/iostream.format/print.fun/println.file.pass.cpp
@@ -9,8 +9,6 @@
 // UNSUPPORTED: no-filesystem
 // UNSUPPORTED: GCC-ALWAYS_INLINE-FIXME
 
-// XFAIL: availability-fp_to_chars-missing
-
 // The error exception has no system error string.
 // XFAIL: LIBCXX-ANDROID-FIXME
 

--- a/libcxx/test/std/input.output/iostream.format/print.fun/println.sh.cpp
+++ b/libcxx/test/std/input.output/iostream.format/print.fun/println.sh.cpp
@@ -13,8 +13,6 @@
 // FIXME PRINT How to test println on Windows?
 // XFAIL: msvc, target={{.+}}-windows-gnu
 
-// XFAIL: availability-fp_to_chars-missing
-
 // <print>
 
 // template<class... Args>

--- a/libcxx/test/std/input.output/iostream.format/print.fun/vprint_nonunicode.file.pass.cpp
+++ b/libcxx/test/std/input.output/iostream.format/print.fun/vprint_nonunicode.file.pass.cpp
@@ -14,8 +14,6 @@
 // https://lab.llvm.org/buildbot/#/builders/237/builds/3578
 // UNSUPPORTED: asan, hwasan, msan
 
-// XFAIL: availability-fp_to_chars-missing
-
 // The error exception has no system error string.
 // XFAIL: LIBCXX-ANDROID-FIXME
 

--- a/libcxx/test/std/input.output/iostream.format/print.fun/vprint_nonunicode.sh.cpp
+++ b/libcxx/test/std/input.output/iostream.format/print.fun/vprint_nonunicode.sh.cpp
@@ -9,8 +9,6 @@
 // UNSUPPORTED: no-filesystem
 // UNSUPPORTED: GCC-ALWAYS_INLINE-FIXME
 
-// XFAIL: availability-fp_to_chars-missing
-
 // <print>
 
 //  void vprint_nonunicode(string_view fmt, format_args args);

--- a/libcxx/test/std/input.output/iostream.format/print.fun/vprint_unicode.file.pass.cpp
+++ b/libcxx/test/std/input.output/iostream.format/print.fun/vprint_unicode.file.pass.cpp
@@ -15,8 +15,6 @@
 // https://lab.llvm.org/buildbot/#/builders/237/builds/3578
 // UNSUPPORTED: asan, hwasan, msan
 
-// XFAIL: availability-fp_to_chars-missing
-
 // The error exception has no system error string.
 // XFAIL: LIBCXX-ANDROID-FIXME
 

--- a/libcxx/test/std/input.output/iostream.format/print.fun/vprint_unicode.sh.cpp
+++ b/libcxx/test/std/input.output/iostream.format/print.fun/vprint_unicode.sh.cpp
@@ -9,8 +9,6 @@
 // UNSUPPORTED: no-filesystem
 // UNSUPPORTED: GCC-ALWAYS_INLINE-FIXME
 
-// XFAIL: availability-fp_to_chars-missing
-
 // <print>
 
 //  void vprint_unicode(string_view fmt, format_args args);

--- a/libcxx/test/std/thread/thread.threads/thread.thread.class/thread.thread.id/format.functions.format.pass.cpp
+++ b/libcxx/test/std/thread/thread.threads/thread.thread.class/thread.thread.id/format.functions.format.pass.cpp
@@ -10,9 +10,6 @@
 
 // UNSUPPORTED: GCC-ALWAYS_INLINE-FIXME
 
-// TODO FMT This test should not require std::to_chars(floating-point)
-// XFAIL: availability-fp_to_chars-missing
-
 // <thread>
 
 // template<class charT>

--- a/libcxx/test/std/thread/thread.threads/thread.thread.class/thread.thread.id/format.functions.vformat.pass.cpp
+++ b/libcxx/test/std/thread/thread.threads/thread.thread.class/thread.thread.id/format.functions.vformat.pass.cpp
@@ -10,9 +10,6 @@
 
 // UNSUPPORTED: GCC-ALWAYS_INLINE-FIXME
 
-// TODO FMT This test should not require std::to_chars(floating-point)
-// XFAIL: availability-fp_to_chars-missing
-
 // <thread>
 
 // template<class charT>

--- a/libcxx/test/std/thread/thread.threads/thread.thread.class/thread.thread.id/stream.pass.cpp
+++ b/libcxx/test/std/thread/thread.threads/thread.thread.class/thread.thread.id/stream.pass.cpp
@@ -12,9 +12,6 @@
 
 // REQUIRES: locale.fr_FR.UTF-8
 
-// TODO FMT This test should not require std::to_chars(floating-point)
-// XFAIL: availability-fp_to_chars-missing
-
 // <thread>
 
 // class thread::id

--- a/libcxx/test/std/time/time.cal/time.cal.day/time.cal.day.nonmembers/ostream.pass.cpp
+++ b/libcxx/test/std/time/time.cal/time.cal.day/time.cal.day.nonmembers/ostream.pass.cpp
@@ -10,9 +10,6 @@
 // UNSUPPORTED: no-localization
 // UNSUPPORTED: GCC-ALWAYS_INLINE-FIXME
 
-// TODO FMT This test should not require std::to_chars(floating-point)
-// XFAIL: availability-fp_to_chars-missing
-
 // REQUIRES: locale.fr_FR.UTF-8
 // REQUIRES: locale.ja_JP.UTF-8
 

--- a/libcxx/test/std/time/time.cal/time.cal.md/time.cal.md.nonmembers/ostream.pass.cpp
+++ b/libcxx/test/std/time/time.cal/time.cal.md/time.cal.md.nonmembers/ostream.pass.cpp
@@ -10,9 +10,6 @@
 // UNSUPPORTED: no-localization
 // UNSUPPORTED: GCC-ALWAYS_INLINE-FIXME
 
-// TODO FMT This test should not require std::to_chars(floating-point)
-// XFAIL: availability-fp_to_chars-missing
-
 // REQUIRES: locale.fr_FR.UTF-8
 // REQUIRES: locale.ja_JP.UTF-8
 

--- a/libcxx/test/std/time/time.cal/time.cal.mdlast/ostream.pass.cpp
+++ b/libcxx/test/std/time/time.cal/time.cal.mdlast/ostream.pass.cpp
@@ -10,9 +10,6 @@
 // UNSUPPORTED: no-localization
 // UNSUPPORTED: GCC-ALWAYS_INLINE-FIXME
 
-// TODO FMT This test should not require std::to_chars(floating-point)
-// XFAIL: availability-fp_to_chars-missing
-
 // REQUIRES: locale.fr_FR.UTF-8
 // REQUIRES: locale.ja_JP.UTF-8
 

--- a/libcxx/test/std/time/time.cal/time.cal.month/time.cal.month.nonmembers/ostream.pass.cpp
+++ b/libcxx/test/std/time/time.cal/time.cal.month/time.cal.month.nonmembers/ostream.pass.cpp
@@ -10,9 +10,6 @@
 // UNSUPPORTED: no-localization
 // UNSUPPORTED: GCC-ALWAYS_INLINE-FIXME
 
-// TODO FMT This test should not require std::to_chars(floating-point)
-// XFAIL: availability-fp_to_chars-missing
-
 // REQUIRES: locale.fr_FR.UTF-8
 // REQUIRES: locale.ja_JP.UTF-8
 

--- a/libcxx/test/std/time/time.cal/time.cal.mwd/time.cal.mwd.nonmembers/ostream.pass.cpp
+++ b/libcxx/test/std/time/time.cal/time.cal.mwd/time.cal.mwd.nonmembers/ostream.pass.cpp
@@ -10,9 +10,6 @@
 // UNSUPPORTED: no-localization
 // UNSUPPORTED: GCC-ALWAYS_INLINE-FIXME
 
-// TODO FMT This test should not require std::to_chars(floating-point)
-// XFAIL: availability-fp_to_chars-missing
-
 // REQUIRES: locale.fr_FR.UTF-8
 // REQUIRES: locale.ja_JP.UTF-8
 

--- a/libcxx/test/std/time/time.cal/time.cal.mwdlast/time.cal.mwdlast.nonmembers/ostream.pass.cpp
+++ b/libcxx/test/std/time/time.cal/time.cal.mwdlast/time.cal.mwdlast.nonmembers/ostream.pass.cpp
@@ -10,9 +10,6 @@
 // UNSUPPORTED: no-localization
 // UNSUPPORTED: GCC-ALWAYS_INLINE-FIXME
 
-// TODO FMT This test should not require std::to_chars(floating-point)
-// XFAIL: availability-fp_to_chars-missing
-
 // REQUIRES: locale.fr_FR.UTF-8
 // REQUIRES: locale.ja_JP.UTF-8
 

--- a/libcxx/test/std/time/time.cal/time.cal.wdidx/time.cal.wdidx.nonmembers/ostream.pass.cpp
+++ b/libcxx/test/std/time/time.cal/time.cal.wdidx/time.cal.wdidx.nonmembers/ostream.pass.cpp
@@ -10,9 +10,6 @@
 // UNSUPPORTED: no-localization
 // UNSUPPORTED: GCC-ALWAYS_INLINE-FIXME
 
-// TODO FMT This test should not require std::to_chars(floating-point)
-// XFAIL: availability-fp_to_chars-missing
-
 // REQUIRES: locale.fr_FR.UTF-8
 // REQUIRES: locale.ja_JP.UTF-8
 

--- a/libcxx/test/std/time/time.cal/time.cal.wdlast/time.cal.wdlast.nonmembers/ostream.pass.cpp
+++ b/libcxx/test/std/time/time.cal/time.cal.wdlast/time.cal.wdlast.nonmembers/ostream.pass.cpp
@@ -10,9 +10,6 @@
 // UNSUPPORTED: no-localization
 // UNSUPPORTED: GCC-ALWAYS_INLINE-FIXME
 
-// TODO FMT This test should not require std::to_chars(floating-point)
-// XFAIL: availability-fp_to_chars-missing
-
 // REQUIRES: locale.fr_FR.UTF-8
 // REQUIRES: locale.ja_JP.UTF-8
 

--- a/libcxx/test/std/time/time.cal/time.cal.weekday/time.cal.weekday.nonmembers/ostream.pass.cpp
+++ b/libcxx/test/std/time/time.cal/time.cal.weekday/time.cal.weekday.nonmembers/ostream.pass.cpp
@@ -10,9 +10,6 @@
 // UNSUPPORTED: no-localization
 // UNSUPPORTED: GCC-ALWAYS_INLINE-FIXME
 
-// TODO FMT This test should not require std::to_chars(floating-point)
-// XFAIL: availability-fp_to_chars-missing
-
 // REQUIRES: locale.fr_FR.UTF-8
 // REQUIRES: locale.ja_JP.UTF-8
 

--- a/libcxx/test/std/time/time.cal/time.cal.year/time.cal.year.nonmembers/ostream.pass.cpp
+++ b/libcxx/test/std/time/time.cal/time.cal.year/time.cal.year.nonmembers/ostream.pass.cpp
@@ -10,9 +10,6 @@
 // UNSUPPORTED: no-localization
 // UNSUPPORTED: GCC-ALWAYS_INLINE-FIXME
 
-// TODO FMT This test should not require std::to_chars(floating-point)
-// XFAIL: availability-fp_to_chars-missing
-
 // REQUIRES: locale.fr_FR.UTF-8
 // REQUIRES: locale.ja_JP.UTF-8
 

--- a/libcxx/test/std/time/time.cal/time.cal.ym/time.cal.ym.nonmembers/ostream.pass.cpp
+++ b/libcxx/test/std/time/time.cal/time.cal.ym/time.cal.ym.nonmembers/ostream.pass.cpp
@@ -10,9 +10,6 @@
 // UNSUPPORTED: no-localization
 // UNSUPPORTED: GCC-ALWAYS_INLINE-FIXME
 
-// TODO FMT This test should not require std::to_chars(floating-point)
-// XFAIL: availability-fp_to_chars-missing
-
 // REQUIRES: locale.fr_FR.UTF-8
 // REQUIRES: locale.ja_JP.UTF-8
 

--- a/libcxx/test/std/time/time.cal/time.cal.ymd/time.cal.ymd.nonmembers/ostream.pass.cpp
+++ b/libcxx/test/std/time/time.cal/time.cal.ymd/time.cal.ymd.nonmembers/ostream.pass.cpp
@@ -10,9 +10,6 @@
 // UNSUPPORTED: no-localization
 // UNSUPPORTED: GCC-ALWAYS_INLINE-FIXME
 
-// TODO FMT This test should not require std::to_chars(floating-point)
-// XFAIL: availability-fp_to_chars-missing
-
 // REQUIRES: locale.fr_FR.UTF-8
 // REQUIRES: locale.ja_JP.UTF-8
 

--- a/libcxx/test/std/time/time.cal/time.cal.ymdlast/time.cal.ymdlast.nonmembers/ostream.pass.cpp
+++ b/libcxx/test/std/time/time.cal/time.cal.ymdlast/time.cal.ymdlast.nonmembers/ostream.pass.cpp
@@ -10,9 +10,6 @@
 // UNSUPPORTED: no-localization
 // UNSUPPORTED: GCC-ALWAYS_INLINE-FIXME
 
-// TODO FMT This test should not require std::to_chars(floating-point)
-// XFAIL: availability-fp_to_chars-missing
-
 // REQUIRES: locale.fr_FR.UTF-8
 // REQUIRES: locale.ja_JP.UTF-8
 

--- a/libcxx/test/std/time/time.cal/time.cal.ymwd/time.cal.ymwd.nonmembers/ostream.pass.cpp
+++ b/libcxx/test/std/time/time.cal/time.cal.ymwd/time.cal.ymwd.nonmembers/ostream.pass.cpp
@@ -10,9 +10,6 @@
 // UNSUPPORTED: no-localization
 // UNSUPPORTED: GCC-ALWAYS_INLINE-FIXME
 
-// TODO FMT This test should not require std::to_chars(floating-point)
-// XFAIL: availability-fp_to_chars-missing
-
 // REQUIRES: locale.fr_FR.UTF-8
 // REQUIRES: locale.ja_JP.UTF-8
 

--- a/libcxx/test/std/time/time.cal/time.cal.ymwdlast/time.cal.ymwdlast.nonmembers/ostream.pass.cpp
+++ b/libcxx/test/std/time/time.cal/time.cal.ymwdlast/time.cal.ymwdlast.nonmembers/ostream.pass.cpp
@@ -10,9 +10,6 @@
 // UNSUPPORTED: no-localization
 // UNSUPPORTED: GCC-ALWAYS_INLINE-FIXME
 
-// TODO FMT This test should not require std::to_chars(floating-point)
-// XFAIL: availability-fp_to_chars-missing
-
 // REQUIRES: locale.fr_FR.UTF-8
 // REQUIRES: locale.ja_JP.UTF-8
 

--- a/libcxx/test/std/time/time.duration/time.duration.nonmember/ostream.pass.cpp
+++ b/libcxx/test/std/time/time.duration/time.duration.nonmember/ostream.pass.cpp
@@ -10,9 +10,6 @@
 // UNSUPPORTED: no-localization
 // UNSUPPORTED: GCC-ALWAYS_INLINE-FIXME
 
-// TODO FMT This test should not require std::to_chars(floating-point)
-// XFAIL: availability-fp_to_chars-missing
-
 // REQUIRES: locale.fr_FR.UTF-8
 // REQUIRES: locale.ja_JP.UTF-8
 

--- a/libcxx/test/std/time/time.syn/formatter.day.pass.cpp
+++ b/libcxx/test/std/time/time.syn/formatter.day.pass.cpp
@@ -9,9 +9,6 @@
 // UNSUPPORTED: no-localization
 // UNSUPPORTED: GCC-ALWAYS_INLINE-FIXME
 
-// TODO FMT This test should not require std::to_chars(floating-point)
-// XFAIL: availability-fp_to_chars-missing
-
 // TODO FMT Investigate Windows issues.
 // XFAIL: msvc
 

--- a/libcxx/test/std/time/time.syn/formatter.file_time.pass.cpp
+++ b/libcxx/test/std/time/time.syn/formatter.file_time.pass.cpp
@@ -9,9 +9,6 @@
 // UNSUPPORTED: no-localization
 // UNSUPPORTED: GCC-ALWAYS_INLINE-FIXME
 
-// TODO FMT This test should not require std::to_chars(floating-point)
-// XFAIL: availability-fp_to_chars-missing
-
 // REQUIRES: locale.fr_FR.UTF-8
 // REQUIRES: locale.ja_JP.UTF-8
 

--- a/libcxx/test/std/time/time.syn/formatter.hh_mm_ss.pass.cpp
+++ b/libcxx/test/std/time/time.syn/formatter.hh_mm_ss.pass.cpp
@@ -9,8 +9,6 @@
 // UNSUPPORTED: no-localization
 // UNSUPPORTED: GCC-ALWAYS_INLINE-FIXME
 
-// XFAIL: availability-fp_to_chars-missing
-
 // REQUIRES: locale.fr_FR.UTF-8
 // REQUIRES: locale.ja_JP.UTF-8
 

--- a/libcxx/test/std/time/time.syn/formatter.local_time.pass.cpp
+++ b/libcxx/test/std/time/time.syn/formatter.local_time.pass.cpp
@@ -9,9 +9,6 @@
 // UNSUPPORTED: no-localization
 // UNSUPPORTED: GCC-ALWAYS_INLINE-FIXME
 
-// TODO FMT This test should not require std::to_chars(floating-point)
-// XFAIL: availability-fp_to_chars-missing
-
 // REQUIRES: locale.fr_FR.UTF-8
 // REQUIRES: locale.ja_JP.UTF-8
 

--- a/libcxx/test/std/time/time.syn/formatter.month.pass.cpp
+++ b/libcxx/test/std/time/time.syn/formatter.month.pass.cpp
@@ -9,9 +9,6 @@
 // UNSUPPORTED: no-localization
 // UNSUPPORTED: GCC-ALWAYS_INLINE-FIXME
 
-// TODO FMT This test should not require std::to_chars(floating-point)
-// XFAIL: availability-fp_to_chars-missing
-
 // REQUIRES: locale.fr_FR.UTF-8
 // REQUIRES: locale.ja_JP.UTF-8
 

--- a/libcxx/test/std/time/time.syn/formatter.month_day.pass.cpp
+++ b/libcxx/test/std/time/time.syn/formatter.month_day.pass.cpp
@@ -9,9 +9,6 @@
 // UNSUPPORTED: no-localization
 // UNSUPPORTED: GCC-ALWAYS_INLINE-FIXME
 
-// TODO FMT This test should not require std::to_chars(floating-point)
-// XFAIL: availability-fp_to_chars-missing
-
 // TODO FMT Investigate Windows issues.
 // XFAIL: msvc
 

--- a/libcxx/test/std/time/time.syn/formatter.month_day_last.pass.cpp
+++ b/libcxx/test/std/time/time.syn/formatter.month_day_last.pass.cpp
@@ -9,9 +9,6 @@
 // UNSUPPORTED: no-localization
 // UNSUPPORTED: GCC-ALWAYS_INLINE-FIXME
 
-// TODO FMT This test should not require std::to_chars(floating-point)
-// XFAIL: availability-fp_to_chars-missing
-
 // REQUIRES: locale.fr_FR.UTF-8
 // REQUIRES: locale.ja_JP.UTF-8
 

--- a/libcxx/test/std/time/time.syn/formatter.month_weekday.pass.cpp
+++ b/libcxx/test/std/time/time.syn/formatter.month_weekday.pass.cpp
@@ -9,9 +9,6 @@
 // UNSUPPORTED: no-localization
 // UNSUPPORTED: GCC-ALWAYS_INLINE-FIXME
 
-// TODO FMT This test should not require std::to_chars(floating-point)
-// XFAIL: availability-fp_to_chars-missing
-
 // REQUIRES: locale.fr_FR.UTF-8
 // REQUIRES: locale.ja_JP.UTF-8
 

--- a/libcxx/test/std/time/time.syn/formatter.sys_time.pass.cpp
+++ b/libcxx/test/std/time/time.syn/formatter.sys_time.pass.cpp
@@ -9,9 +9,6 @@
 // UNSUPPORTED: no-localization
 // UNSUPPORTED: GCC-ALWAYS_INLINE-FIXME
 
-// TODO FMT This test should not require std::to_chars(floating-point)
-// XFAIL: availability-fp_to_chars-missing
-
 // REQUIRES: locale.fr_FR.UTF-8
 // REQUIRES: locale.ja_JP.UTF-8
 

--- a/libcxx/test/std/time/time.syn/formatter.weekday.pass.cpp
+++ b/libcxx/test/std/time/time.syn/formatter.weekday.pass.cpp
@@ -9,9 +9,6 @@
 // UNSUPPORTED: no-localization
 // UNSUPPORTED: GCC-ALWAYS_INLINE-FIXME
 
-// TODO FMT This test should not require std::to_chars(floating-point)
-// XFAIL: availability-fp_to_chars-missing
-
 // TODO FMT Investigate Windows issues.
 // XFAIL: msvc
 

--- a/libcxx/test/std/time/time.syn/formatter.weekday_index.pass.cpp
+++ b/libcxx/test/std/time/time.syn/formatter.weekday_index.pass.cpp
@@ -9,9 +9,6 @@
 // UNSUPPORTED: no-localization
 // UNSUPPORTED: GCC-ALWAYS_INLINE-FIXME
 
-// TODO FMT This test should not require std::to_chars(floating-point)
-// XFAIL: availability-fp_to_chars-missing
-
 // TODO FMT Investigate Windows issues.
 // XFAIL: msvc
 

--- a/libcxx/test/std/time/time.syn/formatter.weekday_last.pass.cpp
+++ b/libcxx/test/std/time/time.syn/formatter.weekday_last.pass.cpp
@@ -9,9 +9,6 @@
 // UNSUPPORTED: no-localization
 // UNSUPPORTED: GCC-ALWAYS_INLINE-FIXME
 
-// TODO FMT This test should not require std::to_chars(floating-point)
-// XFAIL: availability-fp_to_chars-missing
-
 // TODO FMT Investigate Windows issues.
 // XFAIL: msvc
 

--- a/libcxx/test/std/time/time.syn/formatter.year.pass.cpp
+++ b/libcxx/test/std/time/time.syn/formatter.year.pass.cpp
@@ -9,9 +9,6 @@
 // UNSUPPORTED: no-localization
 // UNSUPPORTED: GCC-ALWAYS_INLINE-FIXME
 
-// TODO FMT This test should not require std::to_chars(floating-point)
-// XFAIL: availability-fp_to_chars-missing
-
 // REQUIRES: locale.fr_FR.UTF-8
 // REQUIRES: locale.ja_JP.UTF-8
 

--- a/libcxx/test/std/time/time.syn/formatter.year_month.pass.cpp
+++ b/libcxx/test/std/time/time.syn/formatter.year_month.pass.cpp
@@ -9,9 +9,6 @@
 // UNSUPPORTED: no-localization
 // UNSUPPORTED: GCC-ALWAYS_INLINE-FIXME
 
-// TODO FMT This test should not require std::to_chars(floating-point)
-// XFAIL: availability-fp_to_chars-missing
-
 // REQUIRES: locale.fr_FR.UTF-8
 // REQUIRES: locale.ja_JP.UTF-8
 

--- a/libcxx/test/std/time/time.syn/formatter.year_month_day.pass.cpp
+++ b/libcxx/test/std/time/time.syn/formatter.year_month_day.pass.cpp
@@ -9,9 +9,6 @@
 // UNSUPPORTED: no-localization
 // UNSUPPORTED: GCC-ALWAYS_INLINE-FIXME
 
-// TODO FMT This test should not require std::to_chars(floating-point)
-// XFAIL: availability-fp_to_chars-missing
-
 // TODO FMT Investigate Windows issues.
 // XFAIL: msvc
 

--- a/libcxx/test/std/time/time.syn/formatter.year_month_day_last.pass.cpp
+++ b/libcxx/test/std/time/time.syn/formatter.year_month_day_last.pass.cpp
@@ -9,9 +9,6 @@
 // UNSUPPORTED: no-localization
 // UNSUPPORTED: GCC-ALWAYS_INLINE-FIXME
 
-// TODO FMT This test should not require std::to_chars(floating-point)
-// XFAIL: availability-fp_to_chars-missing
-
 // REQUIRES: locale.fr_FR.UTF-8
 // REQUIRES: locale.ja_JP.UTF-8
 

--- a/libcxx/test/std/time/time.syn/formatter.year_month_weekday.pass.cpp
+++ b/libcxx/test/std/time/time.syn/formatter.year_month_weekday.pass.cpp
@@ -9,9 +9,6 @@
 // UNSUPPORTED: no-localization
 // UNSUPPORTED: GCC-ALWAYS_INLINE-FIXME
 
-// TODO FMT This test should not require std::to_chars(floating-point)
-// XFAIL: availability-fp_to_chars-missing
-
 // REQUIRES: locale.fr_FR.UTF-8
 // REQUIRES: locale.ja_JP.UTF-8
 

--- a/libcxx/test/std/time/time.syn/formatter.year_month_weekday_last.pass.cpp
+++ b/libcxx/test/std/time/time.syn/formatter.year_month_weekday_last.pass.cpp
@@ -9,9 +9,6 @@
 // UNSUPPORTED: no-localization
 // UNSUPPORTED: GCC-ALWAYS_INLINE-FIXME
 
-// TODO FMT This test should not require std::to_chars(floating-point)
-// XFAIL: availability-fp_to_chars-missing
-
 // REQUIRES: locale.fr_FR.UTF-8
 // REQUIRES: locale.ja_JP.UTF-8
 

--- a/libcxx/test/std/time/time.zone/time.zone.info/time.zone.info.local/ostream.pass.cpp
+++ b/libcxx/test/std/time/time.zone/time.zone.info/time.zone.info.local/ostream.pass.cpp
@@ -9,9 +9,6 @@
 // UNSUPPORTED: c++03, c++11, c++14, c++17
 // UNSUPPORTED: no-localization
 
-// TODO FMT This test should not require std::to_chars(floating-point)
-// XFAIL: availability-fp_to_chars-missing
-
 // XFAIL: libcpp-has-no-experimental-tzdb
 
 // <chrono>

--- a/libcxx/test/std/utilities/format/format.functions/P2418.pass.cpp
+++ b/libcxx/test/std/utilities/format/format.functions/P2418.pass.cpp
@@ -8,9 +8,6 @@
 // UNSUPPORTED: c++03, c++11, c++14, c++17
 // UNSUPPORTED: GCC-ALWAYS_INLINE-FIXME
 
-// TODO FMT This test should not require std::to_chars(floating-point)
-// XFAIL: availability-fp_to_chars-missing
-
 // Tests whether a move only type can be formatted. This is required by
 // P2418R2 "Add support for std::generator-like types to std::format"
 

--- a/libcxx/test/std/utilities/format/format.functions/escaped_output.unicode.pass.cpp
+++ b/libcxx/test/std/utilities/format/format.functions/escaped_output.unicode.pass.cpp
@@ -11,9 +11,6 @@
 // This version runs the test when the platform has Unicode support.
 // UNSUPPORTED: libcpp-has-no-unicode
 
-// TODO FMT This test should not require std::to_chars(floating-point)
-// XFAIL: availability-fp_to_chars-missing
-
 // <format>
 
 // This test the debug string type for the formatter specializations for char

--- a/libcxx/test/std/utilities/format/format.functions/fill.unicode.pass.cpp
+++ b/libcxx/test/std/utilities/format/format.functions/fill.unicode.pass.cpp
@@ -11,8 +11,6 @@
 // This version runs the test when the platform has Unicode support.
 // UNSUPPORTED: libcpp-has-no-unicode
 
-// XFAIL: availability-fp_to_chars-missing
-
 // <format>
 
 // The paper

--- a/libcxx/test/std/utilities/format/format.functions/format.locale.verify.cpp
+++ b/libcxx/test/std/utilities/format/format.functions/format.locale.verify.cpp
@@ -8,9 +8,6 @@
 // UNSUPPORTED: c++03, c++11, c++14, c++17
 // UNSUPPORTED: no-localization
 
-// TODO FMT This test should not require std::to_chars(floating-point)
-// XFAIL: availability-fp_to_chars-missing
-
 // Basic test to validate ill-formed code is properly detected.
 
 // <format>

--- a/libcxx/test/std/utilities/format/format.functions/format.verify.cpp
+++ b/libcxx/test/std/utilities/format/format.functions/format.verify.cpp
@@ -7,9 +7,6 @@
 
 // UNSUPPORTED: c++03, c++11, c++14, c++17
 
-// TODO FMT This test should not require std::to_chars(floating-point)
-// XFAIL: availability-fp_to_chars-missing
-
 // Basic test to validate ill-formed code is properly detected.
 
 // <format>

--- a/libcxx/test/std/utilities/format/format.functions/format_to.locale.verify.cpp
+++ b/libcxx/test/std/utilities/format/format.functions/format_to.locale.verify.cpp
@@ -8,9 +8,6 @@
 // UNSUPPORTED: c++03, c++11, c++14, c++17
 // UNSUPPORTED: no-localization
 
-// TODO FMT This test should not require std::to_chars(floating-point)
-// XFAIL: availability-fp_to_chars-missing
-
 // Basic test to validate ill-formed code is properly detected.
 
 // <format>

--- a/libcxx/test/std/utilities/format/format.functions/format_to.verify.cpp
+++ b/libcxx/test/std/utilities/format/format.functions/format_to.verify.cpp
@@ -7,9 +7,6 @@
 
 // UNSUPPORTED: c++03, c++11, c++14, c++17
 
-// TODO FMT This test should not require std::to_chars(floating-point)
-// XFAIL: availability-fp_to_chars-missing
-
 // <format>
 
 // Basic test to validate ill-formed code is properly detected.

--- a/libcxx/test/std/utilities/format/format.functions/format_to_n.locale.verify.cpp
+++ b/libcxx/test/std/utilities/format/format.functions/format_to_n.locale.verify.cpp
@@ -8,9 +8,6 @@
 // UNSUPPORTED: c++03, c++11, c++14, c++17
 // UNSUPPORTED: no-localization
 
-// TODO FMT This test should not require std::to_chars(floating-point)
-// XFAIL: availability-fp_to_chars-missing
-
 // Basic test to validate ill-formed code is properly detected.
 
 // <format>

--- a/libcxx/test/std/utilities/format/format.functions/format_to_n.verify.cpp
+++ b/libcxx/test/std/utilities/format/format.functions/format_to_n.verify.cpp
@@ -7,9 +7,6 @@
 
 // UNSUPPORTED: c++03, c++11, c++14, c++17
 
-// TODO FMT This test should not require std::to_chars(floating-point)
-// XFAIL: availability-fp_to_chars-missing
-
 // Basic test to validate ill-formed code is properly detected.
 
 // <format>

--- a/libcxx/test/std/utilities/format/format.functions/formatted_size.locale.verify.cpp
+++ b/libcxx/test/std/utilities/format/format.functions/formatted_size.locale.verify.cpp
@@ -8,9 +8,6 @@
 // UNSUPPORTED: c++03, c++11, c++14, c++17
 // UNSUPPORTED: no-localization
 
-// TODO FMT This test should not require std::to_chars(floating-point)
-// XFAIL: availability-fp_to_chars-missing
-
 // Basic test to validate ill-formed code is properly detected.
 
 // <format>

--- a/libcxx/test/std/utilities/format/format.functions/formatted_size.verify.cpp
+++ b/libcxx/test/std/utilities/format/format.functions/formatted_size.verify.cpp
@@ -7,9 +7,6 @@
 
 // UNSUPPORTED: c++03, c++11, c++14, c++17
 
-// TODO FMT This test should not require std::to_chars(floating-point)
-// XFAIL: availability-fp_to_chars-missing
-
 // Basic test to validate ill-formed code is properly detected.
 
 // <format>

--- a/libcxx/test/std/utilities/format/format.functions/unicode.pass.cpp
+++ b/libcxx/test/std/utilities/format/format.functions/unicode.pass.cpp
@@ -11,9 +11,6 @@
 // This version runs the test when the platform has Unicode support.
 // UNSUPPORTED: libcpp-has-no-unicode
 
-// TODO FMT This test should not require std::to_chars(floating-point)
-// XFAIL: availability-fp_to_chars-missing
-
 // <format>
 
 // Tests the Unicode width support of the standard format specifiers.

--- a/libcxx/test/std/utilities/format/format.range/format.range.fmtstr/format.functions.format.pass.cpp
+++ b/libcxx/test/std/utilities/format/format.range/format.range.fmtstr/format.functions.format.pass.cpp
@@ -9,8 +9,6 @@
 
 // UNSUPPORTED: GCC-ALWAYS_INLINE-FIXME
 
-// XFAIL: availability-fp_to_chars-missing
-
 // <format>
 
 // template<ranges::input_range R, class charT>

--- a/libcxx/test/std/utilities/format/format.range/format.range.fmtstr/format.functions.vformat.pass.cpp
+++ b/libcxx/test/std/utilities/format/format.range/format.range.fmtstr/format.functions.vformat.pass.cpp
@@ -9,8 +9,6 @@
 
 // UNSUPPORTED: GCC-ALWAYS_INLINE-FIXME
 
-// XFAIL: availability-fp_to_chars-missing
-
 // <format>
 
 // template<ranges::input_range R, class charT>

--- a/libcxx/test/std/utilities/format/format.string/format.string.std/lwg3720_arg_id_width_precision_allowed_types.pass.cpp
+++ b/libcxx/test/std/utilities/format/format.string/format.string.std/lwg3720_arg_id_width_precision_allowed_types.pass.cpp
@@ -8,8 +8,6 @@
 // UNSUPPORTED: c++03, c++11, c++14, c++17
 // UNSUPPORTED: GCC-ALWAYS_INLINE-FIXME
 
-// XFAIL: availability-fp_to_chars-missing
-
 // <format>
 
 // [format.string.std]/8

--- a/libcxx/test/std/utilities/format/format.string/format.string.std/lwg3720_arg_id_width_precision_allowed_types.verify.cpp
+++ b/libcxx/test/std/utilities/format/format.string/format.string.std/lwg3720_arg_id_width_precision_allowed_types.verify.cpp
@@ -7,8 +7,6 @@
 
 // UNSUPPORTED: c++03, c++11, c++14, c++17
 
-// XFAIL: availability-fp_to_chars-missing
-
 // <format>
 
 // [format.string.std]/8

--- a/libcxx/test/std/utilities/format/format.tuple/format.functions.format.pass.cpp
+++ b/libcxx/test/std/utilities/format/format.tuple/format.functions.format.pass.cpp
@@ -9,9 +9,6 @@
 
 // UNSUPPORTED: GCC-ALWAYS_INLINE-FIXME
 
-// TODO FMT This test should not require std::to_chars(floating-point)
-// XFAIL: availability-fp_to_chars-missing
-
 // <format>
 
 // template<class charT, formattable<charT>... Ts>

--- a/libcxx/test/std/utilities/format/format.tuple/format.functions.format.verify.cpp
+++ b/libcxx/test/std/utilities/format/format.tuple/format.functions.format.verify.cpp
@@ -7,9 +7,6 @@
 
 // UNSUPPORTED: c++03, c++11, c++14, c++17, c++20
 
-// TODO FMT This test should not require std::to_chars(floating-point)
-// XFAIL: availability-fp_to_chars-missing
-
 #include <format>
 
 #include <utility>

--- a/libcxx/test/std/utilities/format/format.tuple/format.functions.vformat.pass.cpp
+++ b/libcxx/test/std/utilities/format/format.tuple/format.functions.vformat.pass.cpp
@@ -8,8 +8,6 @@
 // UNSUPPORTED: c++03, c++11, c++14, c++17, c++20
 // UNSUPPORTED: GCC-ALWAYS_INLINE-FIXME
 
-// XFAIL: availability-fp_to_chars-missing
-
 // <format>
 
 // template<class charT, formattable<charT>... Ts>


### PR DESCRIPTION
We've been increasingly running into issues with availability markup in the library lately. In particular, the fact that `strict` availability markup causes functions to act as-if they were deleted breaks the library in various ways, making it impossible AFAICT to enable availability markup for PMR. It also causes a lot of spurious diagnostics in e.g. `<format>`, as can be seen by the multiple TODO comments removed in this patch.

This patch uses non-strict availability markup instead, which is used much more widely on Apple platforms. The difference is that using an unavailable API will trigger a warning instead of an error, and it will cause a weak-definition to be emitted (so it is possible to check at runtime whether the API is available).

This should resolve several difficulties we've been having with availability markup, which I believe to have tracked down to fundamental implementation constraints with the `strict` version of availability. In other words, `strict` has some properties which are fundamentally undesirable for us, and it was always possible to work around them but it isn't anymore.

This will also make it possible for users to branch on whether an API is available at runtime, which has been requested by users.

As a follow-up to this patch, it should be possible to clean up even more availability workarounds in the library and to add availability markup for std::pmr.

rdar://100138498

Differential Revision: https://reviews.llvm.org/D158282