### PR TITLE
[libc] Add __FE_DENORM to the fenv macros

### DIFF
--- a/libc/hdr/fenv_macros.h
+++ b/libc/hdr/fenv_macros.h
@@ -17,6 +17,11 @@
 
 #include <fenv.h>
 
+// If this is not provided by the system, define it for use internally.
+#ifndef __FE_DENORM
+#define __FE_DENORM (1 << 6)
+#endif
+
 #endif // LLVM_LIBC_FULL_BUILD
 
 #endif // LLVM_LIBC_HDR_FENV_MACROS_H

--- a/libc/include/llvm-libc-macros/fenv-macros.h
+++ b/libc/include/llvm-libc-macros/fenv-macros.h
@@ -9,11 +9,12 @@
 #ifndef LLVM_LIBC_MACROS_FENV_MACROS_H
 #define LLVM_LIBC_MACROS_FENV_MACROS_H
 
-#define FE_DIVBYZERO 1
-#define FE_INEXACT 2
-#define FE_INVALID 4
-#define FE_OVERFLOW 8
-#define FE_UNDERFLOW 16
+#define FE_DIVBYZERO 0x1
+#define FE_INEXACT 0x2
+#define FE_INVALID 0x4
+#define FE_OVERFLOW 0x8
+#define FE_UNDERFLOW 0x10
+#define __FE_DENORM 0x20
 #define FE_ALL_EXCEPT                                                          \
   (FE_DIVBYZERO | FE_INEXACT | FE_INVALID | FE_OVERFLOW | FE_UNDERFLOW)
 


### PR DESCRIPTION
Summary:
Some targets support denormals as floating point exceptions. This is
provided as an extension in the GNU headers as __FE_DENORM.

This provides it in our headers, however I'm unsure if we should make it
internal or external. I do not think it should be in all exception as it
doesn't represent an exceptional behavior as far as the standard is
concerned, but I'm not an expert.
