### PR TITLE
[bazel] Move HostMacOSXPrivateHeaders to macOS only dep

### DIFF
--- a/utils/bazel/llvm-project-overlay/lldb/source/Plugins/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/lldb/source/Plugins/BUILD.bazel
@@ -281,7 +281,6 @@ cc_library(
         "//lldb:Core",
         "//lldb:Headers",
         "//lldb:Host",
-        "//lldb:HostMacOSXPrivateHeaders",
         "//lldb:InterpreterHeaders",
         "//lldb:SymbolHeaders",
         "//lldb:TargetHeaders",
@@ -292,6 +291,7 @@ cc_library(
         "@platforms//os:macos": [
             ":PluginPlatformMacOSXObjCXX",
             ":PluginPlatformMacOSXObjCXXHeaders",
+            "//lldb:HostMacOSXPrivateHeaders",
         ],
         "//conditions:default": [],
     }),


### PR DESCRIPTION
Otherwise this makes more targets that we want un-buildable on Linux. This import is only used in a `#if defined(__APPLE__)` anyways.