### PR TITLE
[libc++] Fix the signatures of `std::rethrow_if_nested`

### DIFF
--- a/libcxx/include/__exception/nested_exception.h
+++ b/libcxx/include/__exception/nested_exception.h
@@ -84,17 +84,15 @@ struct __can_dynamic_cast
     : _BoolConstant< is_polymorphic<_From>::value &&
                      (!is_base_of<_To, _From>::value || is_convertible<const _From*, const _To*>::value)> {};
 
-template <class _Ep>
-inline _LIBCPP_HIDE_FROM_ABI void
-rethrow_if_nested(const _Ep& __e, __enable_if_t< __can_dynamic_cast<_Ep, nested_exception>::value>* = 0) {
+template <class _Ep, __enable_if_t< __can_dynamic_cast<_Ep, nested_exception>::value, int> = 0>
+inline _LIBCPP_HIDE_FROM_ABI void rethrow_if_nested(const _Ep& __e) {
   const nested_exception* __nep = dynamic_cast<const nested_exception*>(std::addressof(__e));
   if (__nep)
     __nep->rethrow_nested();
 }
 
-template <class _Ep>
-inline _LIBCPP_HIDE_FROM_ABI void
-rethrow_if_nested(const _Ep&, __enable_if_t<!__can_dynamic_cast<_Ep, nested_exception>::value>* = 0) {}
+template <class _Ep, __enable_if_t<!__can_dynamic_cast<_Ep, nested_exception>::value, int> = 0>
+inline _LIBCPP_HIDE_FROM_ABI void rethrow_if_nested(const _Ep&) {}
 
 } // namespace std
 

--- a/libcxx/test/std/language.support/support.exception/except.nested/rethrow_if_nested.pass.cpp
+++ b/libcxx/test/std/language.support/support.exception/except.nested/rethrow_if_nested.pass.cpp
@@ -18,8 +18,10 @@
 // template <class E> void rethrow_if_nested(const E& e);
 
 #include <exception>
+#include <cstddef>
 #include <cstdlib>
 #include <cassert>
+#include <utility>
 
 #include "test_macros.h"
 
@@ -57,6 +59,31 @@ class D : private std::nested_exception {};
 class E1 : public std::nested_exception {};
 class E2 : public std::nested_exception {};
 class E : public E1, public E2 {};
+
+#if TEST_STD_VER >= 11
+template <class, class...>
+struct can_rethrow_if_nested_impl {
+  static constexpr bool value = false;
+};
+
+template <class... Args>
+struct can_rethrow_if_nested_impl<decltype((void)std::rethrow_if_nested(std::declval<Args>()...)), Args...> {
+  static constexpr bool value = true;
+};
+
+template <class... Args>
+struct can_rethrow_if_nested : can_rethrow_if_nested_impl<void, Args...> {};
+
+static_assert(!can_rethrow_if_nested<>::value, "");
+static_assert(can_rethrow_if_nested<A>::value, "");
+static_assert(can_rethrow_if_nested<const A&>::value, "");
+static_assert(can_rethrow_if_nested<B>::value, "");
+static_assert(can_rethrow_if_nested<const B&>::value, "");
+static_assert(!can_rethrow_if_nested<A, int*>::value, "");
+static_assert(!can_rethrow_if_nested<B, int*>::value, "");
+static_assert(!can_rethrow_if_nested<A, std::nullptr_t>::value, "");
+static_assert(!can_rethrow_if_nested<B, std::nullptr_t>::value, "");
+#endif
 
 int main(int, char**)
 {


### PR DESCRIPTION
Fixes #54470.

See [[global.functions]/2](https://eel.is/c++draft/global.functions#2):
> A call to a non-member function signature described in [support] through [thread] and [depr] shall behave as if the implementation declared no additional non-member function signatures.

and [[global.functions]/3](https://eel.is/c++draft/global.functions#3):
> An implementation shall not declare a non-member function signature with additional default arguments.