### PR TITLE
[ADT] Add back ability to compare StringSet

### DIFF
--- a/llvm/include/llvm/ADT/StringMap.h
+++ b/llvm/include/llvm/ADT/StringMap.h
@@ -291,8 +291,10 @@ public:
       if (FindInRHS == RHS.end())
         return false;
 
-      if (!(KeyValue.getValue() == FindInRHS->getValue()))
-        return false;
+      if constexpr (!std::is_same_v<ValueTy, std::nullopt_t>) {
+        if (!(KeyValue.getValue() == FindInRHS->getValue()))
+          return false;
+      }
     }
 
     return true;

--- a/llvm/unittests/ADT/StringSetTest.cpp
+++ b/llvm/unittests/ADT/StringSetTest.cpp
@@ -73,4 +73,12 @@ TEST_F(StringSetTest, Contains) {
   EXPECT_FALSE(Set.contains("test"));
 }
 
+TEST_F(StringSetTest, Equal) {
+  StringSet<> A = {"A"};
+  StringSet<> B = {"B"};
+  ASSERT_TRUE(A != B);
+  ASSERT_FALSE(A == B);
+  ASSERT_TRUE(A == A);
+}
+
 } // end anonymous namespace


### PR DESCRIPTION
StringSet comparison was broken after moving from llvm::Optional to std::optional because std::nullopt_t is not equality-comparable. Without this patch a try to compare objects of StringSet type leads to compilation error:
```
llvm-project/llvm/include/llvm/ADT/StringMap.h:294:33: error: no match for ‘operator==’ (operand types are ‘std::nullopt_t’ and ‘std::nullopt_t’)
294 |       if (!(KeyValue.getValue() == FindInRHS->getValue()))
```