### PR TITLE
[SystemZ][z/OS] Implement z/OS XPLINK ABI

### DIFF
--- a/clang/lib/CodeGen/CodeGenModule.cpp
+++ b/clang/lib/CodeGen/CodeGenModule.cpp
@@ -242,6 +242,8 @@ createTargetCodeGenInfo(CodeGenModule &CGM) {
   case llvm::Triple::systemz: {
     bool SoftFloat = CodeGenOpts.FloatABI == "soft";
     bool HasVector = !SoftFloat && Target.getABI() == "vector";
+    if (Triple.getOS() == llvm::Triple::ZOS)
+      return createSystemZ_ZOS_TargetCodeGenInfo(CGM, HasVector, SoftFloat);
     return createSystemZTargetCodeGenInfo(CGM, HasVector, SoftFloat);
   }
 

--- a/clang/lib/CodeGen/TargetInfo.h
+++ b/clang/lib/CodeGen/TargetInfo.h
@@ -537,6 +537,10 @@ createSystemZTargetCodeGenInfo(CodeGenModule &CGM, bool HasVector,
                                bool SoftFloatABI);
 
 std::unique_ptr<TargetCodeGenInfo>
+createSystemZ_ZOS_TargetCodeGenInfo(CodeGenModule &CGM, bool HasVector,
+                                    bool SoftFloatABI);
+
+std::unique_ptr<TargetCodeGenInfo>
 createTCETargetCodeGenInfo(CodeGenModule &CGM);
 
 std::unique_ptr<TargetCodeGenInfo>

--- a/clang/lib/CodeGen/Targets/SystemZ.cpp
+++ b/clang/lib/CodeGen/Targets/SystemZ.cpp
@@ -854,7 +854,7 @@ ABIArgInfo ZOSXPLinkABIInfo::classifyArgumentType(QualType Ty, bool IsNamedArg,
   auto CompTy = getFPTypeOfComplexLikeType(Ty);
   if (IsNamedArg) {
     if (Ty->isComplexType()) {
-      auto AI = ABIArgInfo::getDirectInReg(CGT.ConvertType(Ty));
+      auto AI = ABIArgInfo::getDirect(CGT.ConvertType(Ty));
       AI.setCanBeFlattened(false);
       return AI;
     }
@@ -862,7 +862,7 @@ ABIArgInfo ZOSXPLinkABIInfo::classifyArgumentType(QualType Ty, bool IsNamedArg,
     if (CompTy.has_value()) {
       llvm::Type *FPTy = CGT.ConvertType(*CompTy);
       llvm::Type *CoerceTy = llvm::StructType::get(FPTy, FPTy);
-      auto AI = ABIArgInfo::getDirectInReg(CoerceTy);
+      auto AI = ABIArgInfo::getDirect(CoerceTy);
       AI.setCanBeFlattened(false);
       return AI;
     }

--- a/clang/lib/CodeGen/Targets/SystemZ.cpp
+++ b/clang/lib/CodeGen/Targets/SystemZ.cpp
@@ -547,11 +547,9 @@ public:
   ZOSXPLinkABIInfo(CodeGenTypes &CGT, bool HV) : ABIInfo(CGT), HasVector(HV) {}
 
   bool isPromotableIntegerType(QualType Ty) const;
-  bool isCompoundType(QualType Ty) const;
   bool isVectorArgumentType(QualType Ty) const;
   bool isFPArgumentType(QualType Ty) const;
   QualType getSingleElementType(QualType Ty) const;
-  unsigned getMaxAlignFromTypeDefs(QualType Ty) const;
   std::optional<QualType> getFPTypeOfComplexLikeType(QualType Ty) const;
 
   ABIArgInfo classifyReturnType(QualType RetTy) const;
@@ -613,11 +611,6 @@ bool ZOSXPLinkABIInfo::isPromotableIntegerType(QualType Ty) const {
     }
 
   return false;
-}
-
-bool ZOSXPLinkABIInfo::isCompoundType(QualType Ty) const {
-  return (Ty->isAnyComplexType() || Ty->isVectorType() ||
-          isAggregateTypeForABI(Ty));
 }
 
 bool ZOSXPLinkABIInfo::isVectorArgumentType(QualType Ty) const {
@@ -689,21 +682,6 @@ QualType ZOSXPLinkABIInfo::getSingleElementType(QualType Ty) const {
   }
 
   return Ty;
-}
-
-unsigned ZOSXPLinkABIInfo::getMaxAlignFromTypeDefs(QualType Ty) const {
-  unsigned MaxAlign = 0;
-  while (Ty != Ty.getSingleStepDesugaredType(getContext())) {
-    auto *DesugaredType =
-        Ty.getSingleStepDesugaredType(getContext()).getTypePtr();
-    if (auto *TypedefTy = dyn_cast<TypedefType>(DesugaredType)) {
-      auto *TyDecl = TypedefTy->getDecl();
-      unsigned CurrAlign = TyDecl->getMaxAlignment();
-      MaxAlign = std::max(CurrAlign, MaxAlign);
-    }
-    Ty = Ty.getSingleStepDesugaredType(getContext());
-  }
-  return MaxAlign;
 }
 
 std::optional<QualType>

--- a/clang/lib/CodeGen/Targets/SystemZ.cpp
+++ b/clang/lib/CodeGen/Targets/SystemZ.cpp
@@ -568,8 +568,8 @@ public:
     }
   }
 
-  RValue EmitVAArg(CodeGenFunction &CGF, Address VAListAddr,
-                    QualType Ty, AggValueSlot Slot) const override;
+  RValue EmitVAArg(CodeGenFunction &CGF, Address VAListAddr, QualType Ty,
+                   AggValueSlot Slot) const override;
 };
 
 class ZOSXPLinkTargetCodeGenInfo : public TargetCodeGenInfo {
@@ -808,7 +808,7 @@ ABIArgInfo ZOSXPLinkABIInfo::classifyArgumentType(QualType Ty,
 }
 
 RValue ZOSXPLinkABIInfo::EmitVAArg(CodeGenFunction &CGF, Address VAListAddr,
-                                    QualType Ty, AggValueSlot Slot) const {
+                                   QualType Ty, AggValueSlot Slot) const {
   return emitVoidPtrVAArg(CGF, VAListAddr, Ty, /*indirect*/ false,
                           CGF.getContext().getTypeInfoInChars(Ty),
                           CGF.getPointerSize(),

--- a/clang/test/CodeGen/zos-abi.c
+++ b/clang/test/CodeGen/zos-abi.c
@@ -64,26 +64,26 @@ struct SingleVec pass_SingleVec_agg(struct SingleVec arg) { return arg; };
 // Complex types
 
 _Complex float pass_complex_float(_Complex float arg) { return arg; }
-// CHECK-LABEL: define { float, float } @pass_complex_float({ float, float } inreg %{{.*}})
+// CHECK-LABEL: define { float, float } @pass_complex_float({ float, float } %{{.*}})
 
 _Complex double pass_complex_double(_Complex double arg) { return arg; }
-// CHECK-LABEL: define { double, double } @pass_complex_double({ double, double } inreg %{{.*}})
+// CHECK-LABEL: define { double, double } @pass_complex_double({ double, double } %{{.*}})
 
 _Complex long double pass_complex_longdouble(_Complex long double arg) { return arg; }
-// CHECK-LABEL: define { fp128, fp128 } @pass_complex_longdouble({ fp128, fp128 } inreg %{{.*}})
+// CHECK-LABEL: define { fp128, fp128 } @pass_complex_longdouble({ fp128, fp128 } %{{.*}})
 
 // Verify that the following are complex-like types
 struct complexlike_float { float re, im; };
 struct complexlike_float pass_complexlike_float(struct complexlike_float arg) { return arg; }
-// CHECK-LABEL: define %struct.complexlike_float @pass_complexlike_float({ float, float } inreg %{{.*}})
+// CHECK-LABEL: define %struct.complexlike_float @pass_complexlike_float({ float, float } %{{.*}})
 
 struct complexlike_double { double re, im; };
 struct complexlike_double pass_complexlike_double(struct complexlike_double arg) { return arg; }
-// CHECK-LABEL: define %struct.complexlike_double @pass_complexlike_double({ double, double } inreg %{{.*}})
+// CHECK-LABEL: define %struct.complexlike_double @pass_complexlike_double({ double, double } %{{.*}})
 
 struct complexlike_longdouble { long double re, im; };
 struct complexlike_longdouble pass_complexlike_longdouble(struct complexlike_longdouble arg) { return arg; }
-// CHECK-LABEL: define %struct.complexlike_longdouble @pass_complexlike_longdouble({ fp128, fp128 } inreg %{{.*}})
+// CHECK-LABEL: define %struct.complexlike_longdouble @pass_complexlike_longdouble({ fp128, fp128 } %{{.*}})
 
 // Unnamed types
 

--- a/clang/test/CodeGen/zos-abi.c
+++ b/clang/test/CodeGen/zos-abi.c
@@ -1,0 +1,162 @@
+// RUN: %clang_cc1 -triple s390x-ibm-zos \
+// RUN:   -emit-llvm -no-enable-noundef-analysis -o - %s | FileCheck %s
+// RUN: %clang_cc1 -triple s390x-ibm-zos -target-feature +vector \
+// RUN:   -emit-llvm -no-enable-noundef-analysis -o - %s | FileCheck %s
+// RUN: %clang_cc1 -triple s390x-ibm-zos -target-cpu z13 \
+// RUN:   -emit-llvm -no-enable-noundef-analysis -o - %s | FileCheck %s
+// RUN: %clang_cc1 -triple s390x-ibm-zos -target-cpu arch11 \
+// RUN:   -emit-llvm -no-enable-noundef-analysis -o - %s | FileCheck %s
+// RUN: %clang_cc1 -triple s390x-ibm-zos -target-cpu z14 \
+// RUN:   -emit-llvm -no-enable-noundef-analysis -o - %s | FileCheck %s
+// RUN: %clang_cc1 -triple s390x-ibm-zos -target-cpu arch12 \
+// RUN:   -emit-llvm -no-enable-noundef-analysis -o - %s | FileCheck %s
+// RUN: %clang_cc1 -triple s390x-ibm-zos -target-cpu z15 \
+// RUN:   -emit-llvm -no-enable-noundef-analysis -o - %s | FileCheck %s
+// RUN: %clang_cc1 -triple s390x-ibm-zos -target-cpu arch13 \
+// RUN:   -emit-llvm -no-enable-noundef-analysis -o - %s | FileCheck %s
+
+// RUN: %clang_cc1 -triple s390x-ibm-zos -target-cpu arch11 \
+// RUN:   -DTEST_VEC -fzvector -emit-llvm -no-enable-noundef-analysis \
+// RUN:   -o - %s | FileCheck --check-prefixes=CHECKVEC %s
+
+// Scalar types
+
+signed char pass_schar(signed char arg) { return arg; }
+// CHECK-LABEL: define signext i8 @pass_schar(i8 signext %{{.*}})
+
+unsigned char pass_uchar(unsigned char arg) { return arg; }
+// CHECK-LABEL: define zeroext i8 @pass_uchar(i8 zeroext %{{.*}})
+
+short pass_short(short arg) { return arg; }
+// CHECK-LABEL: define signext i16 @pass_short(i16 signext %{{.*}})
+
+int pass_int(int arg) { return arg; }
+// CHECK-LABEL: define signext i32 @pass_int(i32 signext %{{.*}})
+
+long pass_long(long arg) { return arg; }
+// CHECK-LABEL: define i64 @pass_long(i64 %{{.*}})
+
+long long pass_longlong(long long arg) { return arg; }
+// CHECK-LABEL: define i64 @pass_longlong(i64 %{{.*}})
+
+float pass_float(float arg) { return arg; }
+// CHECK-LABEL: define float @pass_float(float %{{.*}})
+
+double pass_double(double arg) { return arg; }
+// CHECK-LABEL: define double @pass_double(double %{{.*}})
+
+long double pass_longdouble(long double arg) { return arg; }
+// CHECK-LABEL: define fp128 @pass_longdouble(fp128 %{{.*}})
+
+enum Color { Red, Blue };
+enum Color pass_enum(enum Color arg) { return arg; }
+// CHECK-LABEL: define zeroext i32 @pass_enum(i32 zeroext %{{.*}})
+
+#ifdef TEST_VEC
+vector unsigned int pass_vector(vector unsigned int arg) { return arg; };
+// CHECKVEC-LABEL: define <4 x i32> @pass_vector(<4 x i32> %{{.*}})
+
+struct SingleVec { vector unsigned int v; };
+struct SingleVec pass_SingleVec_agg(struct SingleVec arg) { return arg; };
+// CHECKVEC-LABEL: define inreg [2 x i64] @pass_SingleVec_agg([2 x i64] %{{.*}})
+#endif
+
+// Complex types
+
+_Complex float pass_complex_float(_Complex float arg) { return arg; }
+// CHECK-LABEL: define { float, float } @pass_complex_float({ float, float } inreg %{{.*}})
+
+_Complex double pass_complex_double(_Complex double arg) { return arg; }
+// CHECK-LABEL: define { double, double } @pass_complex_double({ double, double } inreg %{{.*}})
+
+_Complex long double pass_complex_longdouble(_Complex long double arg) { return arg; }
+// CHECK-LABEL: define { fp128, fp128 } @pass_complex_longdouble({ fp128, fp128 } inreg %{{.*}})
+
+// Verify that the following are complex-like types
+struct complexlike_float { float re, im; };
+struct complexlike_float pass_complexlike_float(struct complexlike_float arg) { return arg; }
+// CHECK-LABEL: define %struct.complexlike_float @pass_complexlike_float({ float, float } inreg %{{.*}})
+
+struct complexlike_double { double re, im; };
+struct complexlike_double pass_complexlike_double(struct complexlike_double arg) { return arg; }
+// CHECK-LABEL: define %struct.complexlike_double @pass_complexlike_double({ double, double } inreg %{{.*}})
+
+struct complexlike_longdouble { long double re, im; };
+struct complexlike_longdouble pass_complexlike_longdouble(struct complexlike_longdouble arg) { return arg; }
+// CHECK-LABEL: define %struct.complexlike_longdouble @pass_complexlike_longdouble({ fp128, fp128 } inreg %{{.*}})
+
+// Unnamed types
+
+int pass_unnamed_int(int) { return 0; }
+// CHECK-LABEL: define signext i32 @pass_unnamed_int(i32 signext %{{.*}})
+
+signed char pass_unnamed_schar(signed char) { return '0'; }
+// CHECK-LABEL: define signext i8 @pass_unnamed_schar(i8 signext %{{.*}})
+
+long double pass_unnamed_longdouble(long double) { return 0; }
+// CHECK-LABEL: define fp128 @pass_unnamed_longdouble(fp128 %{{.*}})
+
+// Aggregate types
+
+struct agg_1byte { char a[1]; };
+struct agg_1byte pass_agg_1byte(struct agg_1byte arg) { return arg; }
+// CHECK-LABEL: define inreg i64 @pass_agg_1byte(i64 %{{.*}})
+
+struct agg_2byte { char a[2]; };
+struct agg_2byte pass_agg_2byte(struct agg_2byte arg) { return arg; }
+// CHECK-LABEL: define inreg i64 @pass_agg_2byte(i64 %{{.*}})
+
+struct agg_3byte { char a[3]; };
+struct agg_3byte pass_agg_3byte(struct agg_3byte arg) { return arg; }
+// CHECK-LABEL: define inreg i64 @pass_agg_3byte(i64 %{{.*}})
+
+struct agg_4byte { char a[4]; };
+struct agg_4byte pass_agg_4byte(struct agg_4byte arg) { return arg; }
+// CHECK-LABEL: define inreg i64 @pass_agg_4byte(i64 %{{.*}})
+
+struct agg_5byte { char a[5]; };
+struct agg_5byte pass_agg_5byte(struct agg_5byte arg) { return arg; }
+// CHECK-LABEL: define inreg i64 @pass_agg_5byte(i64 %{{.*}})
+
+struct agg_6byte { char a[6]; };
+struct agg_6byte pass_agg_6byte(struct agg_6byte arg) { return arg; }
+// CHECK-LABEL: define inreg i64 @pass_agg_6byte(i64 %{{.*}})
+
+struct agg_7byte { char a[7]; };
+struct agg_7byte pass_agg_7byte(struct agg_7byte arg) { return arg; }
+// CHECK-LABEL: define inreg i64 @pass_agg_7byte(i64 %{{.*}})
+
+struct agg_8byte { char a[8]; };
+struct agg_8byte pass_agg_8byte(struct agg_8byte arg) { return arg; }
+// CHECK-LABEL: define inreg i64 @pass_agg_8byte(i64 %{{.*}})
+
+struct agg_9byte { char a[9]; };
+struct agg_9byte pass_agg_9byte(struct agg_9byte arg) { return arg; }
+// CHECK-LABEL: define inreg [2 x i64] @pass_agg_9byte([2 x i64] %{{.*}})
+
+struct agg_16byte { char a[16]; };
+struct agg_16byte pass_agg_16byte(struct agg_16byte arg) { return arg; }
+// CHECK-LABEL: define inreg [2 x i64] @pass_agg_16byte([2 x i64] %{{.*}})
+
+struct agg_24byte { char a[24]; };
+struct agg_24byte pass_agg_24byte(struct agg_24byte arg) { return arg; }
+// CHECK-LABEL: define inreg [3 x i64] @pass_agg_24byte([3 x i64] %{{.*}})
+
+struct agg_25byte { char a[25]; };
+struct agg_25byte pass_agg_25byte(struct agg_25byte arg) { return arg; }
+// CHECK-LABEL: define void @pass_agg_25byte(ptr dead_on_unwind noalias writable sret{{.*}} align 1 %{{.*}}, [4 x i64] %{{.*}})
+
+// Check that a float-like aggregate type is really passed as aggregate
+struct agg_float { float a; };
+struct agg_float pass_agg_float(struct agg_float arg) { return arg; }
+// CHECK-LABEL: define inreg i64 @pass_agg_float(i64 %{{.*}})
+
+// Verify that the following are *not* float-like aggregate types
+
+struct agg_nofloat2 { float a; int b; };
+struct agg_nofloat2 pass_agg_nofloat2(struct agg_nofloat2 arg) { return arg; }
+// CHECK-LABEL: define inreg i64 @pass_agg_nofloat2(i64 %{{.*}})
+
+struct agg_nofloat3 { float a; int : 0; };
+struct agg_nofloat3 pass_agg_nofloat3(struct agg_nofloat3 arg) { return arg; }
+// CHECK-LABEL: define inreg i64 @pass_agg_nofloat3(i64 %{{.*}})

--- a/clang/test/CodeGen/zos-abi.c
+++ b/clang/test/CodeGen/zos-abi.c
@@ -116,7 +116,13 @@ struct complexlike_struct3 {
 struct complexlike_struct3 pass_complexlike_struct3(struct complexlike_struct3 arg) { return arg; }
 // CHECK-LABEL: define { float, float } @pass_complexlike_struct3({ float, float } %{{.*}})
 
-
+union two_float_union { float a; float b; };
+struct complexlike_struct_with_union {
+  float a;
+  union two_float_union b;
+};
+struct complexlike_struct_with_union pass_complexlike_struct_with_union(struct complexlike_struct_with_union arg) { return arg; }
+// CHECK-LABEL: define inreg i64 @pass_complexlike_struct_with_union(i64 %{{.*}})
 
 // structures with one field as complex type are not considered complex types.
 
@@ -232,3 +238,10 @@ struct agg_nofloat2 pass_agg_nofloat2(struct agg_nofloat2 arg) { return arg; }
 struct agg_nofloat3 { float a; int : 0; };
 struct agg_nofloat3 pass_agg_nofloat3(struct agg_nofloat3 arg) { return arg; }
 // CHECK-LABEL: define inreg i64 @pass_agg_nofloat3(i64 %{{.*}})
+
+char * pass_pointer(char * arg) { return arg; }
+// CHECK-LABEL: define ptr @pass_pointer(ptr %{{.*}})
+
+typedef int vecint __attribute__ ((vector_size(16)));
+vecint pass_vector_type(vecint arg) { return arg; }
+// CHECK-LABEL: define <4 x i32> @pass_vector_type(<4 x i32> %{{.*}})

--- a/clang/test/CodeGen/zos-abi.c
+++ b/clang/test/CodeGen/zos-abi.c
@@ -85,6 +85,28 @@ struct complexlike_longdouble { long double re, im; };
 struct complexlike_longdouble pass_complexlike_longdouble(struct complexlike_longdouble arg) { return arg; }
 // CHECK-LABEL: define %struct.complexlike_longdouble @pass_complexlike_longdouble({ fp128, fp128 } %{{.*}})
 
+// Structures with extra padding are not considered complex types.
+struct complexlike_float_padded1 {
+  float x __attribute__((aligned(8)));
+  float y __attribute__((aligned(8)));
+};
+struct complexlike_float_padded1 pass_complexlike_float_padded1(struct complexlike_float_padded1 arg) { return arg; }
+// CHECK-LABEL: define inreg [2 x i64] @pass_complexlike_float_padded1([2 x i64] %{{.*}})
+struct complexlike_float_padded2 {
+  float x;
+  float y;
+} __attribute__((aligned(16)));
+struct complexlike_float_padded2 pass_complexlike_float_padded2(struct complexlike_float_padded2 arg) { return arg; }
+// CHECK-LABEL: define inreg [2 x i64] @pass_complexlike_float_padded2([2 x i64] %{{.*}})
+
+typedef double align32_double __attribute__((aligned(32)));
+struct complexlike_double_padded {
+  align32_double x;
+  double y;
+};
+struct complexlike_double_padded pass_complexlike_double_padded(struct complexlike_double_padded arg) { return arg; }
+// CHECK-LABEL: define void @pass_complexlike_double_padded(ptr {{.*}} sret(%struct.complexlike_double_padded) align 32 %{{.*}}, [4 x i64] %{{.*}})
+
 // Unnamed types
 
 int pass_unnamed_int(int) { return 0; }

--- a/clang/test/CodeGen/zos-abi.c
+++ b/clang/test/CodeGen/zos-abi.c
@@ -107,17 +107,6 @@ struct complexlike_double_padded {
 struct complexlike_double_padded pass_complexlike_double_padded(struct complexlike_double_padded arg) { return arg; }
 // CHECK-LABEL: define void @pass_complexlike_double_padded(ptr {{.*}} sret(%struct.complexlike_double_padded) align 32 %{{.*}}, [4 x i64] %{{.*}})
 
-// Unnamed types
-
-int pass_unnamed_int(int) { return 0; }
-// CHECK-LABEL: define signext i32 @pass_unnamed_int(i32 signext %{{.*}})
-
-signed char pass_unnamed_schar(signed char) { return '0'; }
-// CHECK-LABEL: define signext i8 @pass_unnamed_schar(i8 signext %{{.*}})
-
-long double pass_unnamed_longdouble(long double) { return 0; }
-// CHECK-LABEL: define fp128 @pass_unnamed_longdouble(fp128 %{{.*}})
-
 // Aggregate types
 
 struct agg_1byte { char a[1]; };

--- a/clang/test/CodeGen/zos-abi.c
+++ b/clang/test/CodeGen/zos-abi.c
@@ -75,15 +75,15 @@ _Complex long double pass_complex_longdouble(_Complex long double arg) { return 
 // Verify that the following are complex-like types
 struct complexlike_float { float re, im; };
 struct complexlike_float pass_complexlike_float(struct complexlike_float arg) { return arg; }
-// CHECK-LABEL: define %struct.complexlike_float @pass_complexlike_float({ float, float } %{{.*}})
+// CHECK-LABEL: define { float, float } @pass_complexlike_float({ float, float } %{{.*}})
 
 struct complexlike_double { double re, im; };
 struct complexlike_double pass_complexlike_double(struct complexlike_double arg) { return arg; }
-// CHECK-LABEL: define %struct.complexlike_double @pass_complexlike_double({ double, double } %{{.*}})
+// CHECK-LABEL: define { double, double } @pass_complexlike_double({ double, double } %{{.*}})
 
 struct complexlike_longdouble { long double re, im; };
 struct complexlike_longdouble pass_complexlike_longdouble(struct complexlike_longdouble arg) { return arg; }
-// CHECK-LABEL: define %struct.complexlike_longdouble @pass_complexlike_longdouble({ fp128, fp128 } %{{.*}})
+// CHECK-LABEL: define { fp128, fp128 } @pass_complexlike_longdouble({ fp128, fp128 } %{{.*}})
 
 struct single_element_float { float f; };
 struct complexlike_struct {
@@ -91,7 +91,7 @@ struct complexlike_struct {
   struct single_element_float y;
 };
 struct complexlike_struct pass_complexlike_struct(struct complexlike_struct arg) { return arg; }
-// CHECK-LABEL: define %struct.complexlike_struct @pass_complexlike_struct({ float, float } %{{.*}})
+// CHECK-LABEL: define { float, float } @pass_complexlike_struct({ float, float } %{{.*}})
 
 struct single_element_float_arr {
   unsigned int :0;
@@ -102,7 +102,7 @@ struct complexlike_struct2 {
   struct single_element_float_arr y;
 };
 struct complexlike_struct2 pass_complexlike_struct2(struct complexlike_struct2 arg) { return arg; }
-// CHECK-LABEL: define %struct.complexlike_struct2 @pass_complexlike_struct2({ float, float } %{{.*}})
+// CHECK-LABEL: define { float, float } @pass_complexlike_struct2({ float, float } %{{.*}})
 
 struct float_and_empties {
   struct S {} s;
@@ -114,7 +114,7 @@ struct complexlike_struct3 {
   struct float_and_empties y;
 };
 struct complexlike_struct3 pass_complexlike_struct3(struct complexlike_struct3 arg) { return arg; }
-// CHECK-LABEL: define %struct.complexlike_struct3 @pass_complexlike_struct3({ float, float } %{{.*}})
+// CHECK-LABEL: define { float, float } @pass_complexlike_struct3({ float, float } %{{.*}})
 
 
 

--- a/clang/test/CodeGen/zos-abi.c
+++ b/clang/test/CodeGen/zos-abi.c
@@ -85,6 +85,47 @@ struct complexlike_longdouble { long double re, im; };
 struct complexlike_longdouble pass_complexlike_longdouble(struct complexlike_longdouble arg) { return arg; }
 // CHECK-LABEL: define %struct.complexlike_longdouble @pass_complexlike_longdouble({ fp128, fp128 } %{{.*}})
 
+struct single_element_float { float f; };
+struct complexlike_struct {
+  struct single_element_float x;
+  struct single_element_float y;
+};
+struct complexlike_struct pass_complexlike_struct(struct complexlike_struct arg) { return arg; }
+// CHECK-LABEL: define %struct.complexlike_struct @pass_complexlike_struct({ float, float } %{{.*}})
+
+struct single_element_float_arr {
+  unsigned int :0;
+  float f[1];
+};
+struct complexlike_struct2 {
+  struct single_element_float_arr x;
+  struct single_element_float_arr y;
+};
+struct complexlike_struct2 pass_complexlike_struct2(struct complexlike_struct2 arg) { return arg; }
+// CHECK-LABEL: define %struct.complexlike_struct2 @pass_complexlike_struct2({ float, float } %{{.*}})
+
+struct float_and_empties {
+  struct S {} s;
+  int a[0];
+  float f;
+};
+struct complexlike_struct3 {
+  struct float_and_empties x;
+  struct float_and_empties y;
+};
+struct complexlike_struct3 pass_complexlike_struct3(struct complexlike_struct3 arg) { return arg; }
+// CHECK-LABEL: define %struct.complexlike_struct3 @pass_complexlike_struct3({ float, float } %{{.*}})
+
+
+
+// structures with one field as complex type are not considered complex types.
+
+struct single_complex_struct {
+  _Complex float f;
+};
+struct single_complex_struct pass_single_complex_struct(struct single_complex_struct arg) {return arg; }
+// CHECK-LABEL: define inreg i64 @pass_single_complex_struct(i64 %{{.*}})
+
 // Structures with extra padding are not considered complex types.
 struct complexlike_float_padded1 {
   float x __attribute__((aligned(8)));
@@ -92,12 +133,32 @@ struct complexlike_float_padded1 {
 };
 struct complexlike_float_padded1 pass_complexlike_float_padded1(struct complexlike_float_padded1 arg) { return arg; }
 // CHECK-LABEL: define inreg [2 x i64] @pass_complexlike_float_padded1([2 x i64] %{{.*}})
+
 struct complexlike_float_padded2 {
   float x;
   float y;
 } __attribute__((aligned(16)));
 struct complexlike_float_padded2 pass_complexlike_float_padded2(struct complexlike_float_padded2 arg) { return arg; }
 // CHECK-LABEL: define inreg [2 x i64] @pass_complexlike_float_padded2([2 x i64] %{{.*}})
+
+struct single_padded_struct {
+  float f;
+  unsigned int :2;
+};
+struct complexlike_float_padded3 {
+  struct single_padded_struct x;
+  struct single_padded_struct y;
+};
+struct complexlike_float_padded3 pass_complexlike_float_padded3(struct complexlike_float_padded3 arg) { return arg; }
+// CHECK-LABEL: define inreg [2 x i64] @pass_complexlike_float_padded3([2 x i64] %{{.*}})
+
+struct multi_element_float_arr { float f[2]; };
+struct complexlike_struct4 {
+  struct multi_element_float_arr x;
+  struct multi_element_float_arr y;
+};
+struct complexlike_struct4 pass_complexlike_struct4(struct complexlike_struct4 arg) { return arg; }
+// CHECK-LABEL: define inreg [2 x i64] @pass_complexlike_struct4([2 x i64] %{{.*}})
 
 typedef double align32_double __attribute__((aligned(32)));
 struct complexlike_double_padded {

--- a/clang/test/CodeGen/zos-abi.cpp
+++ b/clang/test/CodeGen/zos-abi.cpp
@@ -9,7 +9,7 @@ struct complex_like_agg_nofloat_empty pass_complex_like_agg_nofloat_empty(struct
 struct agg_float_empty { float a; [[no_unique_address]] empty dummy; };
 struct complex_like_agg_float_empty { struct agg_float_empty a; struct agg_float_empty b; };
 struct complex_like_agg_float_empty pass_complex_like_agg_float_empty(struct complex_like_agg_float_empty arg) { return arg; }
-// CHECK-LABEL: define %struct.complex_like_agg_float_empty @_Z33pass_complex_like_agg_float_empty28complex_like_agg_float_empty({ float, float } %{{.*}})
+// CHECK-LABEL: define { float, float } @_Z33pass_complex_like_agg_float_empty28complex_like_agg_float_empty({ float, float } %{{.*}})
 
 struct noemptybase { empty dummy; };
 struct agg_nofloat_emptybase : noemptybase { float a; };
@@ -21,4 +21,4 @@ struct emptybase { [[no_unique_address]] empty dummy; };
 struct agg_float_emptybase : emptybase { float a; };
 struct complex_like_agg_float_emptybase { struct agg_float_emptybase a; struct agg_float_emptybase b; };
 struct complex_like_agg_float_emptybase pass_agg_float_emptybase(struct complex_like_agg_float_emptybase arg) { return arg; }
-// CHECK-LABEL: define %struct.complex_like_agg_float_emptybase @_Z24pass_agg_float_emptybase32complex_like_agg_float_emptybase({ float, float } %{{.*}})
+// CHECK-LABEL: define { float, float } @_Z24pass_agg_float_emptybase32complex_like_agg_float_emptybase({ float, float } %{{.*}})

--- a/clang/test/CodeGen/zos-abi.cpp
+++ b/clang/test/CodeGen/zos-abi.cpp
@@ -1,0 +1,24 @@
+// RUN: %clang_cc1 -triple s390x-ibm-zos -emit-llvm -x c++ -o - %s | FileCheck %s
+
+struct empty { };
+struct agg_nofloat_empty { float a; empty dummy; };
+struct complex_like_agg_nofloat_empty { struct agg_nofloat_empty a; struct agg_nofloat_empty b; };
+struct complex_like_agg_nofloat_empty pass_complex_like_agg_nofloat_empty(struct complex_like_agg_nofloat_empty arg) { return arg; }
+// CHECK-LABEL: define inreg [2 x i64] @_Z35pass_complex_like_agg_nofloat_empty30complex_like_agg_nofloat_empty([2 x i64] %{{.*}})
+
+struct agg_float_empty { float a; [[no_unique_address]] empty dummy; };
+struct complex_like_agg_float_empty { struct agg_float_empty a; struct agg_float_empty b; };
+struct complex_like_agg_float_empty pass_complex_like_agg_float_empty(struct complex_like_agg_float_empty arg) { return arg; }
+// CHECK-LABEL: define %struct.complex_like_agg_float_empty @_Z33pass_complex_like_agg_float_empty28complex_like_agg_float_empty({ float, float } %{{.*}})
+
+struct noemptybase { empty dummy; };
+struct agg_nofloat_emptybase : noemptybase { float a; };
+struct complex_like_agg_nofloat_emptybase { struct agg_nofloat_emptybase a; struct agg_nofloat_emptybase b; };
+struct complex_like_agg_nofloat_emptybase pass_agg_nofloat_emptybase(struct complex_like_agg_nofloat_emptybase arg) { return arg; }
+// CHECK-LABEL: define inreg [2 x i64] @_Z26pass_agg_nofloat_emptybase34complex_like_agg_nofloat_emptybase([2 x i64] %{{.*}})
+
+struct emptybase { [[no_unique_address]] empty dummy; };
+struct agg_float_emptybase : emptybase { float a; };
+struct complex_like_agg_float_emptybase { struct agg_float_emptybase a; struct agg_float_emptybase b; };
+struct complex_like_agg_float_emptybase pass_agg_float_emptybase(struct complex_like_agg_float_emptybase arg) { return arg; }
+// CHECK-LABEL: define %struct.complex_like_agg_float_emptybase @_Z24pass_agg_float_emptybase32complex_like_agg_float_emptybase({ float, float } %{{.*}})


### PR DESCRIPTION
The XPLINK calling convention is specified in the Language Environment Vendor Interface, chapter 22,
(https://www.ibm.com/support/knowledgecenter/SSLTBW_2.4.0/com.ibm.zos.v2r4.cee/cee.htm) and in Redbook XPLink: OS/390 Extra Performance Linkage (http://www.redbooks.ibm.com/abstracts/sg245991.html?Open)