### PR TITLE
[Coro] Relax a debug-info test

### DIFF
--- a/clang/test/CodeGenCoroutines/coro-dwarf.cpp
+++ b/clang/test/CodeGenCoroutines/coro-dwarf.cpp
@@ -71,14 +71,10 @@ void f_coro(int val, MoveOnly moParam, MoveAndCopy mcParam) {
 // CHECK: !{{[0-9]+}} = !DILocalVariable(name: "mcParam", arg: 3, scope: ![[SP]], file: !{{[0-9]+}}, line: {{[0-9]+}}, type: !{{[0-9]+}})
 // CHECK: !{{[0-9]+}} = !DILocalVariable(name: "__promise",
 
-// CHECK: !{{[0-9]+}} = distinct !DISubprogram(linkageName: "_Z6f_coroi8MoveOnly11MoveAndCopy.__await_suspend_wrapper__init"
-// CHECK-NEXT: !{{[0-9]+}} = !DIFile
-// CHECK-NEXT: !{{[0-9]+}} = !DISubroutineType
-// CHECK-NEXT: !{{[0-9]+}} = !DILocalVariable(arg: 1,
-// CHECK-NEXT: !{{[0-9]+}} = !DILocation
-// CHECK-NEXT: !{{[0-9]+}} = !DILocalVariable(arg: 2,
+// CHECK: ![[INIT:[0-9]+]] = distinct !DISubprogram(linkageName: "_Z6f_coroi8MoveOnly11MoveAndCopy.__await_suspend_wrapper__init"
+// CHECK: !{{[0-9]+}} = !DILocalVariable(arg: 1, scope: ![[INIT]]
+// CHECK: !{{[0-9]+}} = !DILocalVariable(arg: 2, scope: ![[INIT]]
 
-// CHECK: !{{[0-9]+}} = distinct !DISubprogram(linkageName: "_Z6f_coroi8MoveOnly11MoveAndCopy.__await_suspend_wrapper__final"
-// CHECK-NEXT: !{{[0-9]+}} = !DILocalVariable(arg: 1,
-// CHECK-NEXT: !{{[0-9]+}} = !DILocation
-// CHECK-NEXT: !{{[0-9]+}} = !DILocalVariable(arg: 2,
+// CHECK: ![[FINAL:[0-9]+]] = distinct !DISubprogram(linkageName: "_Z6f_coroi8MoveOnly11MoveAndCopy.__await_suspend_wrapper__final"
+// CHECK: !{{[0-9]+}} = !DILocalVariable(arg: 1, scope: ![[FINAL]]
+// CHECK: !{{[0-9]+}} = !DILocalVariable(arg: 2, scope: ![[FINAL]]


### PR DESCRIPTION
Debug-info metadata does not have a strictly defined order. Check that elements are linked to each other correctly, not that metadata appears in a particular order.