### PR TITLE
[AST] RecursiveASTVisitor: Don't traverse the alias deduction guides in the default mode.

### DIFF
--- a/clang/unittests/Tooling/RecursiveASTVisitorTests/DeductionGuide.cpp
+++ b/clang/unittests/Tooling/RecursiveASTVisitorTests/DeductionGuide.cpp
@@ -22,17 +22,13 @@ public:
     std::string Storage;
     llvm::raw_string_ostream Stream(Storage);
     D->print(Stream);
-    Match(Stream.str(),D->getLocation());
+    Match(Stream.str(), D->getLocation());
     return true;
   }
 
-  bool shouldVisitTemplateInstantiations() const {
-    return false;
-  }
+  bool shouldVisitTemplateInstantiations() const { return false; }
 
-  bool shouldVisitImplicitCode() const {
-    return ShouldVisitImplicitCode;
-  }
+  bool shouldVisitImplicitCode() const { return ShouldVisitImplicitCode; }
   bool ShouldVisitImplicitCode;
 };
 
@@ -43,7 +39,7 @@ TEST(RecursiveASTVisitor, DeductionGuideNonImplicitMode) {
   Visitor.ExpectMatch("Foo(T) -> Foo<int>", 11, 1);
   Visitor.DisallowMatch("Bar(type-parameter-0-0) -> Foo<int>", 14, 1);
   EXPECT_TRUE(Visitor.runOver(
-    R"cpp(
+      R"cpp(
 template <typename T>
 concept False = true;
 
@@ -58,8 +54,8 @@ Foo(T) -> Foo<int>;
 template <typename U>
 using Bar = Foo<U>;
 Bar s(1); 
-   )cpp"
-  , DeductionGuideVisitor::Lang_CXX2a));
+   )cpp",
+      DeductionGuideVisitor::Lang_CXX2a));
 }
 
 TEST(RecursiveASTVisitor, DeductionGuideImplicitMode) {
@@ -67,7 +63,7 @@ TEST(RecursiveASTVisitor, DeductionGuideImplicitMode) {
   Visitor.ExpectMatch("Foo(T) -> Foo<int>", 11, 1);
   Visitor.ExpectMatch("Bar(type-parameter-0-0) -> Foo<int>", 14, 1);
   EXPECT_TRUE(Visitor.runOver(
-    R"cpp(
+      R"cpp(
 template <typename T>
 concept False = true;
 
@@ -82,8 +78,8 @@ Foo(T) -> Foo<int>;
 template <typename U>
 using Bar = Foo<U>;
 Bar s(1); 
-   )cpp"
-  , DeductionGuideVisitor::Lang_CXX2a));
+   )cpp",
+      DeductionGuideVisitor::Lang_CXX2a));
 }
 
 } // end anonymous namespace

--- a/clang/unittests/Tooling/RecursiveASTVisitorTests/DeductionGuide.cpp
+++ b/clang/unittests/Tooling/RecursiveASTVisitorTests/DeductionGuide.cpp
@@ -1,0 +1,89 @@
+//===- unittest/Tooling/RecursiveASTVisitorTests/DeductionGuide.cpp -------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "TestVisitor.h"
+#include <string>
+
+using namespace clang;
+
+namespace {
+
+class DeductionGuideVisitor
+    : public ExpectedLocationVisitor<DeductionGuideVisitor> {
+public:
+  DeductionGuideVisitor(bool ShouldVisitImplicitCode)
+      : ShouldVisitImplicitCode(ShouldVisitImplicitCode) {}
+  bool VisitCXXDeductionGuideDecl(CXXDeductionGuideDecl *D) {
+    std::string Storage;
+    llvm::raw_string_ostream Stream(Storage);
+    D->print(Stream);
+    Match(Stream.str(),D->getLocation());
+    return true;
+  }
+
+  bool shouldVisitTemplateInstantiations() const {
+    return false;
+  }
+
+  bool shouldVisitImplicitCode() const {
+    return ShouldVisitImplicitCode;
+  }
+  bool ShouldVisitImplicitCode;
+};
+
+TEST(RecursiveASTVisitor, DeductionGuideNonImplicitMode) {
+  DeductionGuideVisitor Visitor(/*ShouldVisitImplicitCode*/ false);
+  // Verify that the synthezied deduction guide for alias is not visited in
+  // RAV's implicit mode.
+  Visitor.ExpectMatch("Foo(T) -> Foo<int>", 11, 1);
+  Visitor.DisallowMatch("Bar(type-parameter-0-0) -> Foo<int>", 14, 1);
+  EXPECT_TRUE(Visitor.runOver(
+    R"cpp(
+template <typename T>
+concept False = true;
+
+template <typename T> 
+struct Foo { 
+  Foo(T);
+};
+
+template<typename T> requires False<T>
+Foo(T) -> Foo<int>;
+
+template <typename U>
+using Bar = Foo<U>;
+Bar s(1); 
+   )cpp"
+  , DeductionGuideVisitor::Lang_CXX2a));
+}
+
+TEST(RecursiveASTVisitor, DeductionGuideImplicitMode) {
+  DeductionGuideVisitor Visitor(/*ShouldVisitImplicitCode*/ true);
+  Visitor.ExpectMatch("Foo(T) -> Foo<int>", 11, 1);
+  Visitor.ExpectMatch("Bar(type-parameter-0-0) -> Foo<int>", 14, 1);
+  EXPECT_TRUE(Visitor.runOver(
+    R"cpp(
+template <typename T>
+concept False = true;
+
+template <typename T> 
+struct Foo { 
+  Foo(T);
+};
+
+template<typename T> requires False<T>
+Foo(T) -> Foo<int>;
+
+template <typename U>
+using Bar = Foo<U>;
+Bar s(1); 
+   )cpp"
+  , DeductionGuideVisitor::Lang_CXX2a));
+}
+
+} // end anonymous namespace


### PR DESCRIPTION
By default (`shouldVisitImplicitCode()` returns `false`), RAV should not traverse AST nodes that are not spelled in the source code. Deduction guides for alias templates are always synthesized, so they should not be traversed.

This is usually done by checking the implicit bit of the Decl. However, this doesn't work deduction guides that are synthesized from explicit user-defined deduction guides, as we must maintain the explicit bit to ensure correct overload resolution.