### PR TITLE
[LV] run verifyFunction once

### DIFF
--- a/llvm/CMakeLists.txt
+++ b/llvm/CMakeLists.txt
@@ -624,7 +624,7 @@ option(LLVM_ENABLE_DUMP "Enable dump functions even when assertions are disabled
 option(LLVM_UNREACHABLE_OPTIMIZE "Optimize llvm_unreachable() as undefined behavior (default), guaranteed trap when OFF" ON)
 
 if( NOT uppercase_CMAKE_BUILD_TYPE STREQUAL "DEBUG" )
-  option(LLVM_ENABLE_ASSERTIONS "Enable assertions" OFF)
+  option(LLVM_ENABLE_ASSERTIONS "Enable assertions" ON)
 else()
   option(LLVM_ENABLE_ASSERTIONS "Enable assertions" ON)
 endif()

--- a/llvm/CMakeLists.txt
+++ b/llvm/CMakeLists.txt
@@ -624,7 +624,7 @@ option(LLVM_ENABLE_DUMP "Enable dump functions even when assertions are disabled
 option(LLVM_UNREACHABLE_OPTIMIZE "Optimize llvm_unreachable() as undefined behavior (default), guaranteed trap when OFF" ON)
 
 if( NOT uppercase_CMAKE_BUILD_TYPE STREQUAL "DEBUG" )
-  option(LLVM_ENABLE_ASSERTIONS "Enable assertions" ON)
+  option(LLVM_ENABLE_ASSERTIONS "Enable assertions" OFF)
 else()
   option(LLVM_ENABLE_ASSERTIONS "Enable assertions" ON)
 endif()


### PR DESCRIPTION
In an effort to cut compile-times on debug builds, run verifyFunction once per function in LoopVectorize, as opposed to running it as many times as there are loops in the function. The downside of this is that, in cases of a broken function, the user won't be informed exactly which loop transformation failed, but this is perhaps an acceptable price to pay for cutting down compile-times.

Statistics from LLVM Compile Time Tracker: https://llvm-compile-time-tracker.com/compare.php?from=67c18fe6ca0d491bde18dc7f8e7c6e32e52f4dbb&to=cbfebd1b531f905efde60c913c9dd35b6b161019&stat=instructions:u