### PR TITLE
LoopVectorize: don't verify metadata

### DIFF
--- a/llvm/include/llvm/IR/Verifier.h
+++ b/llvm/include/llvm/IR/Verifier.h
@@ -85,7 +85,8 @@ public:
 /// If there are no errors, the function returns false. If an error is found,
 /// a message describing the error is written to OS (if non-null) and true is
 /// returned.
-bool verifyFunction(const Function &F, raw_ostream *OS = nullptr);
+bool verifyFunction(const Function &F, raw_ostream *OS = nullptr,
+                    bool ShouldVerifyMD = true);
 
 /// Check a module for errors.
 ///
@@ -98,7 +99,7 @@ bool verifyFunction(const Function &F, raw_ostream *OS = nullptr);
 /// error and instead *BrokenDebugInfo will be set to true. Debug
 /// info errors can be "recovered" from by stripping the debug info.
 bool verifyModule(const Module &M, raw_ostream *OS = nullptr,
-                  bool *BrokenDebugInfo = nullptr);
+                  bool *BrokenDebugInfo = nullptr, bool ShouldVerifyMD = true);
 
 FunctionPass *createVerifierPass(bool FatalErrors = true);
 

--- a/llvm/lib/Transforms/Vectorize/LoopVectorize.cpp
+++ b/llvm/lib/Transforms/Vectorize/LoopVectorize.cpp
@@ -9677,7 +9677,8 @@ static bool processLoopInVPlanNativePath(
 
   // Mark the loop as already vectorized to avoid vectorizing again.
   Hints.setAlreadyVectorized();
-  assert(!verifyFunction(*L->getHeader()->getParent(), &dbgs()));
+  assert(!verifyFunction(*L->getHeader()->getParent(), &dbgs(),
+                         /* ShouldVerifyMD = */ false));
   return true;
 }
 
@@ -10286,7 +10287,8 @@ bool LoopVectorizePass::processLoop(Loop *L) {
     Hints.setAlreadyVectorized();
   }
 
-  assert(!verifyFunction(*L->getHeader()->getParent(), &dbgs()));
+  assert(!verifyFunction(*L->getHeader()->getParent(), &dbgs(),
+                         /* ShouldVerifyMD = */ false));
   return true;
 }
 


### PR DESCRIPTION
The Verifier is called anyway at the beginning and end of the pass pipeline, and some complex transformations like LoopVectorize call the Verifier anyway in order to report errors early. It can be argued that verifying metadata after vectorization is inessential, and not doing this can significantly improve compile-times on debug builds. With this patch, although the Verifier itself verifies metadata, change the calls to the Verifier in LoopVectorize to skip this check.

Fixes #47056.