### PR TITLE
[Clang][Sema] Fix lookup of dependent operator= named by using-declaration

### DIFF
--- a/clang/test/CXX/basic/basic.lookup/basic.lookup.qual/class.qual/p2.cpp
+++ b/clang/test/CXX/basic/basic.lookup/basic.lookup.qual/class.qual/p2.cpp
@@ -137,17 +137,16 @@ namespace InhCtor {
   int n = b.T(); // expected-error {{'T' is a protected member of 'InhCtor::A'}}
                  // expected-note@-15 {{declared protected here}}
 
-  // FIXME: EDG and GCC reject this too, but it's not clear why it would be
-  // ill-formed.
   template<typename T>
   struct S : T {
-    struct U : S { // expected-note 6{{candidate}}
+    // FIXME: S is incomplete here and we should diagnose this!
+    struct U : S {
       using S::S;
     };
     using T::T;
   };
-  S<A>::U ua(0); // expected-error {{no match}}
-  S<B>::U ub(0); // expected-error {{no match}}
+  S<A>::U ua(0);
+  S<B>::U ub(0);
 
   template<typename T>
   struct X : T {

--- a/clang/test/CXX/temp/temp.res/temp.dep/temp.dep.type/p4.cpp
+++ b/clang/test/CXX/temp/temp.res/temp.dep/temp.dep.type/p4.cpp
@@ -484,6 +484,18 @@ namespace N3 {
 
   template struct E<int>; // expected-note {{in instantiation of template class 'N3::E<int>' requested here}}
 
+  template<typename T>
+  struct F {
+    F& operator=(T);
+    struct G;
+  };
+
+  template<typename T>
+  struct F<T>::G : F<T> {
+    using F::operator=;
+  };
+
+  template struct F<int>;
 } // namespace N3
 
 namespace N4 {


### PR DESCRIPTION
Fixes [this bug](https://github.com/llvm/llvm-project/pull/90152#issuecomment-2100932093) caused by #90152.

Will add tests shortly.