### PR TITLE
Add a dependency from lldb-sbapi-dwarf-enums as a dependency of libll…

### DIFF
--- a/lldb/cmake/modules/LLDBFramework.cmake
+++ b/lldb/cmake/modules/LLDBFramework.cmake
@@ -105,7 +105,7 @@ foreach(header
 endforeach()
 
 # Wrap output in a target, so lldb-framework can depend on it.
-add_custom_target(liblldb-resource-headers DEPENDS ${lldb_staged_headers})
+add_custom_target(liblldb-resource-headers DEPENDS lldb-sbapi-dwarf-enums ${lldb_staged_headers})
 set_target_properties(liblldb-resource-headers PROPERTIES FOLDER "lldb misc")
 add_dependencies(liblldb liblldb-resource-headers)
 


### PR DESCRIPTION
…db-resource-headers

The Xcode build otherwise fails with
```
CMake Error in source/API/CMakeLists.txt:
  The custom command generating

    /Users/ec2-user/jenkins/workspace/llvm.org/lldb-cmake-standalone/lldb-xcode-build/include/lldb/API/SBLanguages.h

  is attached to multiple targets:

    lldb-sbapi-dwarf-enums
    liblldb-resource-headers

  but none of these is a common dependency of the other(s).  This is not
  allowed by the Xcode "new build system".

CMake Generate step failed.  Build files cannot be regenerated correctly.
```