### PR TITLE
[OpenMP][AIX] Implement __kmp_get_load_balance() for AIX

### DIFF
--- a/openmp/runtime/CMakeLists.txt
+++ b/openmp/runtime/CMakeLists.txt
@@ -132,10 +132,13 @@ set(LIBOMP_ASMFLAGS "" CACHE STRING
   "Appended user specified assembler flags.")
 set(LIBOMP_LDFLAGS "" CACHE STRING
   "Appended user specified linker flags.")
-if("${LIBOMP_ARCH}" STREQUAL "ppc" AND ${CMAKE_SYSTEM_NAME} MATCHES "AIX")
-  # PPC (32-bit) on AIX needs libatomic for __atomic_load_8, etc.
-  set(LIBOMP_LIBFLAGS "-latomic" CACHE STRING
+if(${CMAKE_SYSTEM_NAME} MATCHES "AIX")
+  set(LIBOMP_LIBFLAGS "-lperfstat" CACHE STRING
     "Appended user specified linked libs flags. (e.g., -lm)")
+  if("${LIBOMP_ARCH}" STREQUAL "ppc")
+    # PPC (32-bit) on AIX needs libatomic for __atomic_load_8, etc.
+    set(LIBOMP_LIBFLAGS "${LIBOMP_LIBFLAGS} -latomic")
+  endif()
 else()
   set(LIBOMP_LIBFLAGS "" CACHE STRING
     "Appended user specified linked libs flags. (e.g., -lm)")


### PR DESCRIPTION
AIX has the `proc` filesystem where `/proc/<pid>/lwp/<tid>/lwpsinfo` has the thread state in binary, similar to Linux's `/proc/<pid>/task/<tid>/stat` where the state is in ASCII. However, the definition of state info `R` in `lwpsinfo` is `runnable`. In Linux, state `R` means the thread is `running`. Therefore, `lwpsinfo` is not ideal for our purpose of getting the current load of the system. This patch uses `perfstat_cpu()` in AIX system library `libperfstat.a` to obtain the number of threads current running on logical CPUs.