### PR TITLE
[RISCV] Allow extra underscores in parseNormalizedArchString and parseArchString.

### DIFF
--- a/clang/test/Driver/riscv-arch.c
+++ b/clang/test/Driver/riscv-arch.c
@@ -308,11 +308,6 @@
 // RV32-SMINOR0: error: invalid arch name 'rv32ist2p0',
 // RV32-SMINOR0: unsupported standard supervisor-level extension 'st'
 
-// RUN: not %clang --target=riscv32-unknown-elf -march=rv32ixabc_ -### %s \
-// RUN: -fsyntax-only 2>&1 | FileCheck -check-prefix=RV32-XSEP %s
-// RV32-XSEP: error: invalid arch name 'rv32ixabc_',
-// RV32-XSEP: extension name missing after separator '_'
-
 // RUN: not %clang --target=riscv32-unknown-elf -march=rv32ixabc_a -### %s \
 // RUN: -fsyntax-only 2>&1 | FileCheck -check-prefix=RV32-PREFIX %s
 // RV32-PREFIX: error: invalid arch name 'rv32ixabc_a',

--- a/llvm/unittests/TargetParser/RISCVISAInfoTest.cpp
+++ b/llvm/unittests/TargetParser/RISCVISAInfoTest.cpp
@@ -38,8 +38,7 @@ TEST(ParseNormalizedArchString, RejectsInvalidBaseISA) {
 }
 
 TEST(ParseNormalizedArchString, RejectsMalformedInputs) {
-  for (StringRef Input :
-       {"rv64i2p0_", "rv32i2p0__a2p0", "rv64e2p", "rv32i", "rv64ip1"}) {
+  for (StringRef Input : {"rv64e2p", "rv32i", "rv64ip1"}) {
     EXPECT_EQ(
         toString(RISCVISAInfo::parseNormalizedArchString(Input).takeError()),
         "extension lacks version in expected format");
@@ -516,18 +515,6 @@ TEST(ParseArchString,
       toString(
           RISCVISAInfo::parseArchString("rv32i_zba1p0m", true).takeError()),
       "unsupported standard user-level extension 'zba1p0m'");
-}
-
-TEST(ParseArchString, RejectsDoubleOrTrailingUnderscore) {
-  EXPECT_EQ(
-      toString(RISCVISAInfo::parseArchString("rv64i__m", true).takeError()),
-      "extension name missing after separator '_'");
-
-  for (StringRef Input :
-       {"rv32ezicsr__zifencei", "rv32i_", "rv32izicsr_", "rv64im_"}) {
-    EXPECT_EQ(toString(RISCVISAInfo::parseArchString(Input, true).takeError()),
-              "extension name missing after separator '_'");
-  }
 }
 
 TEST(ParseArchString, RejectsDuplicateExtensionNames) {


### PR DESCRIPTION
Allow double underscores and trailing underscores. gcc and binutils allow extra underscores without error.