### PR TITLE
Add option to log debugging to stdout

### DIFF
--- a/llvm/lib/Support/Debug.cpp
+++ b/llvm/lib/Support/Debug.cpp
@@ -166,9 +166,9 @@ static void debug_user_sig_handler(void *Cookie) {
 
 /// dbgs - Return a circular-buffered debug stream.
 raw_ostream &llvm::dbgs() {
-  if (LogDebugToStdOut) {
+  if (LogDebugToStdOut)
     return outs();
-  } else {
+
     // Do one-time initialization in a thread-safe way.
     static struct dbgstream {
       circular_raw_ostream strm;
@@ -186,7 +186,6 @@ raw_ostream &llvm::dbgs() {
     } thestrm;
 
     return thestrm.strm;
-  }
 }
 
 #else
@@ -194,11 +193,7 @@ raw_ostream &llvm::dbgs() {
 namespace llvm {
   /// dbgs - Return errs().
   raw_ostream &dbgs() {
-    if (LogDebugToStdOut) {
-      return outs();
-    } else {
-      return errs();
-    }
+    return LogDebugToStdOut ? outs() : errs();
   }
 }
 void llvm::initDebugOptions() {}

--- a/llvm/lib/Support/Debug.cpp
+++ b/llvm/lib/Support/Debug.cpp
@@ -78,6 +78,11 @@ void setCurrentDebugTypes(const char **Types, unsigned Count) {
 }
 } // namespace llvm
 
+cl::opt<bool> LogDebugToStdOut(
+    "debug-to-stdout",
+    llvm::cl::desc("Log debugging to stdout instead of stderr"),
+    cl::init(false), cl::Hidden);
+
 // All Debug.h functionality is a no-op in NDEBUG mode.
 #ifndef NDEBUG
 
@@ -161,23 +166,27 @@ static void debug_user_sig_handler(void *Cookie) {
 
 /// dbgs - Return a circular-buffered debug stream.
 raw_ostream &llvm::dbgs() {
-  // Do one-time initialization in a thread-safe way.
-  static struct dbgstream {
-    circular_raw_ostream strm;
+  if (LogDebugToStdOut) {
+    return outs();
+  } else {
+    // Do one-time initialization in a thread-safe way.
+    static struct dbgstream {
+      circular_raw_ostream strm;
 
-    dbgstream()
-        : strm(errs(), "*** Debug Log Output ***\n",
-               (!EnableDebugBuffering || !DebugFlag) ? 0 : *DebugBufferSize) {
-      if (EnableDebugBuffering && DebugFlag && *DebugBufferSize != 0)
-        // TODO: Add a handler for SIGUSER1-type signals so the user can
-        // force a debug dump.
-        sys::AddSignalHandler(&debug_user_sig_handler, nullptr);
-      // Otherwise we've already set the debug stream buffer size to
-      // zero, disabling buffering so it will output directly to errs().
-    }
-  } thestrm;
+      dbgstream()
+          : strm(errs(), "*** Debug Log Output ***\n",
+                 (!EnableDebugBuffering || !DebugFlag) ? 0 : *DebugBufferSize) {
+        if (EnableDebugBuffering && DebugFlag && *DebugBufferSize != 0)
+          // TODO: Add a handler for SIGUSER1-type signals so the user can
+          // force a debug dump.
+          sys::AddSignalHandler(&debug_user_sig_handler, nullptr);
+        // Otherwise we've already set the debug stream buffer size to
+        // zero, disabling buffering so it will output directly to errs().
+      }
+    } thestrm;
 
-  return thestrm.strm;
+    return thestrm.strm;
+  }
 }
 
 #else
@@ -185,7 +194,11 @@ raw_ostream &llvm::dbgs() {
 namespace llvm {
   /// dbgs - Return errs().
   raw_ostream &dbgs() {
-    return errs();
+    if (LogDebugToStdOut) {
+      return outs();
+    } else {
+      return errs();
+    }
   }
 }
 void llvm::initDebugOptions() {}


### PR DESCRIPTION
At Compiler-explorer we have been using a patch to llvm to get better performance on retrieving all things on the opt pipeline.

This adds the command line option `--debug-to-stdout` to use the buffered stdout instead of stderr for debug logging.

Our [patches](https://github.com/compiler-explorer/clang-builder/tree/main/build/patches) have been applying cleanly for 2 years, so I'm not worried it will break anytime soon. But I think it would still be nice for this to included by default.
