### PR TITLE
[bazel] Rework liblldb

### DIFF
--- a/utils/bazel/llvm-project-overlay/lldb/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/lldb/BUILD.bazel
@@ -749,6 +749,10 @@ genrule(
     cmd = "sed 's/^/_/g' $(SRCS) > $(OUTS)",
 )
 
+# Create a shared library using linkshared=True for liblldb. This uses
+# cc_binary instead of cc_shared_library since the latter expects you to
+# re-export all transitive dependencies vs them being relinked into other
+# binaries.
 cc_binary(
     name = "lldb{}".format(PACKAGE_VERSION),
     additional_linker_inputs = select({
@@ -776,8 +780,11 @@ cc_binary(
     ],
 )
 
+# cc_binary targets using linkshared=True to build a shared library cannot be
+# imported directly and instead need to be referenced indirectly through
+# cc_import
 cc_import(
-    name = "liblldb_wrapper",
+    name = "liblldb.wrapper",
     shared_library = "lldb{}".format(PACKAGE_VERSION),
 )
 
@@ -814,7 +821,7 @@ cc_binary(
     deps = [
         ":APIHeaders",
         ":Host",
-        ":liblldb_wrapper",
+        ":liblldb.wrapper",
         ":lldb_options_inc_gen",
         "//llvm:Option",
         "//llvm:Support",

--- a/utils/bazel/llvm-project-overlay/lldb/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/lldb/BUILD.bazel
@@ -728,37 +728,57 @@ cc_library(
     ],
 )
 
-cc_library(
-    name = "liblldb.static",
+genrule(
+    name = "gen_exports_file_linux",
+    srcs = ["//lldb:source/API/liblldb-private.exports"],
+    outs = ["exports_linux.txt"],
+    cmd = """
+cat > $(OUTS) <<EOF
+{
+  global:
+    $$(sed 's/$$/;/g' $(SRCS))
+};
+EOF
+""",
+)
+
+genrule(
+    name = "gen_exports_file_macos",
+    srcs = ["//lldb:source/API/liblldb-private.exports"],
+    outs = ["exports_macos.txt"],
+    cmd = "sed 's/^/_/g' $(SRCS) > $(OUTS)",
+)
+
+cc_binary(
+    name = "lldb{}".format(PACKAGE_VERSION),
+    additional_linker_inputs = select({
+        "@platforms//os:linux": [
+            ":gen_exports_file_linux",
+        ],
+        "@platforms//os:macos": [
+            ":gen_exports_file_macos",
+        ],
+        "//conditions:default": [],
+    }),
+    linkopts = select({
+        "@platforms//os:linux": [
+            "-Wl,--export-dynamic-symbol-list=$(location :gen_exports_file_linux)",
+        ],
+        "@platforms//os:macos": [
+            "-Wl,-exported_symbols_list,$(location :gen_exports_file_macos)",
+        ],
+        "//conditions:default": [],
+    }),
+    linkshared = True,
     deps = [
         ":API",
         ":Interpreter",
     ],
 )
 
-cc_shared_library(
-    name = "liblldb",
-    # TODO: Remove once fixed https://github.com/bazelbuild/bazel/issues/21893
-    additional_linker_inputs = select({
-        "@platforms//os:macos": [
-            ":HostMacOSXObjCXX",
-            "//lldb/source/Plugins:PluginPlatformMacOSXObjCXX",
-        ],
-        "//conditions:default": [],
-    }),
-    shared_lib_name = select({
-        "@platforms//os:macos": "liblldb{}.dylib".format(PACKAGE_VERSION),
-        "@platforms//os:linux": "liblldb{}.so".format(PACKAGE_VERSION),
-    }),
-    # TODO: Remove once fixed https://github.com/bazelbuild/bazel/issues/21893
-    user_link_flags = select({
-        "@platforms//os:macos": [
-            "$(location :HostMacOSXObjCXX)",
-            "$(location //lldb/source/Plugins:PluginPlatformMacOSXObjCXX)",
-        ],
-        "//conditions:default": [],
-    }),
-    deps = [":liblldb.static"],
+cc_import(
+    name = "liblldb_wrapper",
+    shared_library = "lldb{}".format(PACKAGE_VERSION),
 )
 
 gentbl_cc_library(
@@ -794,7 +814,7 @@ cc_binary(
     deps = [
         ":APIHeaders",
         ":Host",
-        ":liblldb.static",
+        ":liblldb_wrapper",
         ":lldb_options_inc_gen",
         "//llvm:Option",
         "//llvm:Support",


### PR DESCRIPTION
Previously we were linking liblldb as a shared library, but also linking the contents into the lldb binary. This is invalid and results in subtle runtime issues because of duplicate constants, like the global plugin registry. This now links the dylib to lldb directly. This requires we switch to cc_binary instead because cc_shared_library expects your library to export all symbols in your transitive dependency tree, where we only want to export lldb symbols.