### PR TITLE
release/18.x: [libclc] Fix linking against libIRReader

### DIFF
--- a/libclc/CMakeLists.txt
+++ b/libclc/CMakeLists.txt
@@ -114,6 +114,7 @@ include_directories( ${LLVM_INCLUDE_DIRS} )
 set(LLVM_LINK_COMPONENTS
   BitReader
   BitWriter
+  IRReader
   Core
   Support
 )


### PR DESCRIPTION
Fixes #91551:

- https://github.com/llvm/llvm-project/issues/91551

The patch is not needed in `main` because another larger patch already merged in `main` includes this change: https://github.com/llvm/llvm-project/commit/61efea7142e904e6492e1ce0566ec23d9d221c1e .

This one line patch is enough to fix the build on LLVM 18 branch so it's probably a good idea to merge it, it's obvious, non-intrusive and can't do harm.