### PR TITLE
[libc] Add template deduction guide for cpp::lock_guard.

### DIFF
--- a/libc/src/__support/CPP/mutex.h
+++ b/libc/src/__support/CPP/mutex.h
@@ -40,6 +40,9 @@ public:
   lock_guard(const lock_guard &) = delete;
 };
 
+// Deduction guide for lock_guard to suppress CTAD warnings.
+template <typename T> lock_guard(T &) -> lock_guard<T>;
+
 } // namespace cpp
 } // namespace LIBC_NAMESPACE
 


### PR DESCRIPTION
Fix ctad-maybe-unsupported warnings for `cpp::lock_guard`.