### PR TITLE
[libc++][ASan] Fix std::basic_string trait type

### DIFF
--- a/libcxx/include/string
+++ b/libcxx/include/string
@@ -741,8 +741,8 @@ public:
   // is kept inside objects memory (short string optimization), instead of in allocated
   // external memory. In such cases, the destructor is responsible for unpoisoning
   // the memory to avoid triggering false positives.
-  // Therefore it's crucial to ensure the destructor is called
-  using __trivially_relocatable = false_type;
+  // Therefore it's crucial to ensure the destructor is called.
+  using __trivially_relocatable = void;
 #else
   using __trivially_relocatable = __conditional_t<
       __libcpp_is_trivially_relocatable<allocator_type>::value && __libcpp_is_trivially_relocatable<pointer>::value,


### PR DESCRIPTION
Addresses the comment: https://github.com/llvm/llvm-project/pull/79536#discussion_r1593652240

Changes the type to `void` instead of `false_type`.

The value is used here:

https://github.com/llvm/llvm-project/blob/6f1013a5b3f92d3ae6e378d6706584a2a44e6964/libcxx/include/__type_traits/is_trivially_relocatable.h#L35-L38