### PR TITLE
[Flang][OpenMP] Fix semantics check for nested DISTRIBUTE

### DIFF
--- a/flang/lib/Semantics/check-omp-structure.cpp
+++ b/flang/lib/Semantics/check-omp-structure.cpp
@@ -280,7 +280,8 @@ void OmpStructureChecker::HasInvalidDistributeNesting(
       violation = true;
     } else {
       // `distribute` region has to be strictly nested inside `teams`
-      if (!llvm::omp::topTeamsSet.test(GetContextParent().directive)) {
+      if (!OmpDirectiveSet{llvm::omp::OMPD_teams, llvm::omp::OMPD_target_teams}
+               .test(GetContextParent().directive)) {
         violation = true;
       }
     }

--- a/flang/test/Semantics/OpenMP/nested-distribute.f90
+++ b/flang/test/Semantics/OpenMP/nested-distribute.f90
@@ -74,6 +74,13 @@ program main
    !$omp end distribute
   !$omp end teams
 
+  !$omp target teams
+    !$omp distribute
+    do i = 1, 10
+    end do
+    !$omp end distribute
+  !$omp end target teams
+
   !$omp teams 
       !ERROR: Only `DISTRIBUTE` or `PARALLEL` regions are allowed to be strictly nested inside `TEAMS` region.
       !$omp task


### PR DESCRIPTION
Composite OpenMP constructs where DISTRIBUTE is the first leaf construct, as well as standalone DISTRIBUTE constructs, are allowed inside of TEAMS regions.

Before this patch, nesting a DISTRIBUTE construct inside of a combined TARGET TEAMS construct was disallowed, which it shouldn't be. Now both TEAMS and TARGET TEAMS constructs can be immediate parents of DISTRIBUTE constructs.