### PR TITLE
[MLIR][OpenMP] NFC: Remove redundant check

### DIFF
--- a/mlir/lib/Target/LLVMIR/Dialect/OpenMP/OpenMPToLLVMIRTranslation.cpp
+++ b/mlir/lib/Target/LLVMIR/Dialect/OpenMP/OpenMPToLLVMIRTranslation.cpp
@@ -925,10 +925,6 @@ convertOmpWsloop(Operation &opInst, llvm::IRBuilderBase &builder,
   auto loopOp = cast<omp::LoopNestOp>(wsloopOp.getWrappedLoop());
   const bool isByRef = wsloopOp.getByref();
 
-  // TODO: this should be in the op verifier instead.
-  if (loopOp.getLowerBound().empty())
-    return failure();
-
   // Static is the default.
   auto schedule =
       wsloopOp.getScheduleVal().value_or(omp::ClauseScheduleKind::Static);


### PR DESCRIPTION
The check removed by this patch in the OpenMP to LLVM IR translation pass already exists as part of the op verifier for `omp.loop_nest`.