### PR TITLE
[coverage] Add option for keeping mappings order

### DIFF
--- a/llvm/include/llvm/ProfileData/Coverage/CoverageMappingWriter.h
+++ b/llvm/include/llvm/ProfileData/Coverage/CoverageMappingWriter.h
@@ -42,13 +42,15 @@ class CoverageMappingWriter {
   ArrayRef<unsigned> VirtualFileMapping;
   ArrayRef<CounterExpression> Expressions;
   MutableArrayRef<CounterMappingRegion> MappingRegions;
+  bool KeepMappingOrder;
 
 public:
   CoverageMappingWriter(ArrayRef<unsigned> VirtualFileMapping,
                         ArrayRef<CounterExpression> Expressions,
-                        MutableArrayRef<CounterMappingRegion> MappingRegions)
+                        MutableArrayRef<CounterMappingRegion> MappingRegions,
+                        bool KeepMappingOrder = false)
       : VirtualFileMapping(VirtualFileMapping), Expressions(Expressions),
-        MappingRegions(MappingRegions) {}
+        MappingRegions(MappingRegions), KeepMappingOrder(KeepMappingOrder) {}
 
   /// Write encoded coverage mapping data to the given output stream.
   void write(raw_ostream &OS);


### PR DESCRIPTION
This patch fixes possible exceptions due to processing mcdc coverage code from rust with [nested decisions](https://github.com/rust-lang/rust/pull/124255).

Rust now supports nested decisions such as 
```rust
fn inner_decision(a: bool) -> bool {
    !a
}

fn foo(a: bool, b: bool, c: bool, d: bool) {
    if inner_decision(a || b || c) && d {
        println!("true");
    }
}

fn main() {
    foo(true, false, true, false);
}
```
But this example could make llvm-cov panic. We can reproduce it with:
```bash
# Ensure installed latest nightly rust
cargo +nightly rustc --bin foo -- -Cinstrument-coverage -Zcoverage-options=mcdc
LLVM_PROFILE_FILE="foo.profraw" target/debug/foo
llvm-profdata merge -sparse foo.profraw -o foo.profdata
llvm-cov show target/debug/foo -instr-profile="foo.profdata" --show-mcdc
```

For now llvm-cov could generate wrong result with such kind of code when:
* Some conditions of the nested decision are located in front of at least one condition of the outer.
* The nested decision's start location is behind of the outer decision.

It would panic when:
* The nested decision has more conditions than the outer.

Let's consider that example still. The example code generate 2 decision:
* D1: the nested decision, comes from `a || b || c`, with 3 conditions `a`, `b`, `c`.
* D2: the outer decision, comes from `inner_decision(a || b || c) && d` , with 2 conditions `inner_decision(a || b || c)`, `d`.

After the sort, the order of mappings would become:
Conditions: `inner_decision(a || b || c)`, `a`, `b`, `c`, `d`
Decisions:   D2, D1
due to the start location comparison.
Then llvm-cov reconstructs mapping between decisions and conditions:
1. Try to bind `inner_decision(a || b || c)` with D2, ok. -> right
2. Try to bind `a` with D2, but D2 already has a condition with id 1. So bind `a` with D1, ok -> right
3. Try to bind `b` with D2, clearly span of D2 dominates `b`, thus ok -> wrong, `b` should be a condition of D1.

Note that `b` has a false next condition id 3 and is taken as condition of D2. Hence when llvm-cov tries to construct the decision tree of D2, it attempts to visit the third element of a vector with length 2, leading to boom.

Though we can forbid people to write code in such style, macros in rust also could generate code like it, even something more dreadful like `if if a || b || c { true } else { false } && d`.

Another reason to persist the nested decision implementation is that rust has pattern matching and there might be some code like 
```rust
// let-chains
if let Ok(Some(IpAddr::V4(addr)) = ip && let Some(size) = val { /*...*/ }
```
Here `Ok(Some(IpAddr::V4(addr))` could generate a mcdc decision because it also means branching in CFG.

The most painless way to fix it might keep the relative order of branch mappings and decision mappins, so that llvm-cov can regroup them in same order.