### PR TITLE
[AMDGPU] Remove unnecessary predicates from aliases. NFC.

### DIFF
--- a/llvm/lib/Target/AMDGPU/EXPInstructions.td
+++ b/llvm/lib/Target/AMDGPU/EXPInstructions.td
@@ -125,7 +125,6 @@ multiclass VEXPORT_Real_gfx12 {
   }
   def : AMDGPUMnemonicAlias<"exp", "export"> {
     let AssemblerPredicate = isGFX12Plus;
-    let OtherPredicates = [HasExportInsts];
   }
 }
 

--- a/llvm/lib/Target/AMDGPU/MIMGInstructions.td
+++ b/llvm/lib/Target/AMDGPU/MIMGInstructions.td
@@ -1079,7 +1079,6 @@ multiclass MIMG_Atomic_Addr_Helper_m <mimgopc op, string asm,
   if !and(op.HAS_GFX12, !not(!empty(renamed))) then
     def : AMDGPUMnemonicAlias<asm, renamed> {
       let AssemblerPredicate = isGFX12Plus;
-      let OtherPredicates = [HasImageInsts];
       bit IsAtomicRet; // Unused
       MIMGBaseOpcode BaseOpcode; // Unused
       int VDataDwords; // Unused


### PR DESCRIPTION
So long as the target of the alias is predicated with HasImageInsts or
similar, the alias itself does not need this predicate.
