### PR TITLE
[lldb][ELF] Move address class map into the symbol table

### DIFF
--- a/lldb/include/lldb/Symbol/Symtab.h
+++ b/lldb/include/lldb/Symbol/Symtab.h
@@ -23,6 +23,8 @@ class Symtab {
 public:
   typedef std::vector<uint32_t> IndexCollection;
   typedef UniqueCStringMap<uint32_t> NameToIndexMap;
+  typedef std::map<lldb::addr_t, lldb_private::AddressClass>
+      FileAddressToAddressClassMap;
 
   enum Debug {
     eDebugNo,  // Not a debug symbol
@@ -239,6 +241,16 @@ public:
   }
   /// \}
 
+  /// Set the address class for the given address.
+  void SetAddressClass(lldb::addr_t addr,
+                       lldb_private::AddressClass addr_class);
+
+  /// Lookup the address class of the given address.
+  ///
+  /// \return
+  ///   The address' class, if it is known, otherwise AddressClass::eCode.
+  lldb_private::AddressClass GetAddressClass(lldb::addr_t addr);
+
 protected:
   typedef std::vector<Symbol> collection;
   typedef collection::iterator iterator;
@@ -273,6 +285,9 @@ protected:
   ObjectFile *m_objfile;
   collection m_symbols;
   FileRangeToIndexMap m_file_addr_to_index;
+
+  /// The address class for each symbol in the elf file
+  FileAddressToAddressClassMap m_address_class_map;
 
   /// Maps function names to symbol indices (grouped by FunctionNameTypes)
   std::map<lldb::FunctionNameType, UniqueCStringMap<uint32_t>>

--- a/lldb/source/Plugins/ObjectFile/ELF/ObjectFileELF.h
+++ b/lldb/source/Plugins/ObjectFile/ELF/ObjectFileELF.h
@@ -187,9 +187,6 @@ private:
   typedef DynamicSymbolColl::iterator DynamicSymbolCollIter;
   typedef DynamicSymbolColl::const_iterator DynamicSymbolCollConstIter;
 
-  typedef std::map<lldb::addr_t, lldb_private::AddressClass>
-      FileAddressToAddressClassMap;
-
   /// Version of this reader common to all plugins based on this class.
   static const uint32_t m_plugin_version = 1;
   static const uint32_t g_core_uuid_magic;
@@ -226,9 +223,6 @@ private:
 
   /// The architecture detected from parsing elf file contents.
   lldb_private::ArchSpec m_arch_spec;
-
-  /// The address class for each symbol in the elf file
-  FileAddressToAddressClassMap m_address_class_map;
 
   /// Returns the index of the given section header.
   size_t SectionIndex(const SectionHeaderCollIter &I);

--- a/lldb/source/Symbol/Symtab.cpp
+++ b/lldb/source/Symbol/Symtab.cpp
@@ -1372,3 +1372,22 @@ bool Symtab::LoadFromCache() {
     SetWasLoadedFromCache();
   return result;
 }
+
+void Symtab::SetAddressClass(lldb::addr_t addr,
+                             lldb_private::AddressClass addr_class) {
+  m_address_class_map.insert_or_assign(addr, addr_class);
+}
+
+lldb_private::AddressClass Symtab::GetAddressClass(lldb::addr_t addr) {
+  auto ub = m_address_class_map.upper_bound(addr);
+  if (ub == m_address_class_map.begin()) {
+    // No entry in the address class map before the address. Return default
+    // address class for an address in a code section.
+    return AddressClass::eCode;
+  }
+
+  // Move iterator to the address class entry preceding address
+  --ub;
+
+  return ub->second;
+}


### PR DESCRIPTION
Code in https://github.com/llvm/llvm-project/pull/90622 exposed a situation where a symbol table may be loaded via a second copy of the same object.

This resulted in the first copy having its address class map updated, but not the second. And it was that second one we used for symbol lookups, since it was found by a plugin and we assume those to be more specific.

(the plugins returning the same file may itself be a bug)

I tried fixing this by returning the address map changes from the symbol table parsing. Which works but it's awkward to make sure both object's maps get updated.

Instead, this change moves the address class map into the symbol table, which is shared between the objects already. ObjectFileELF::GetAddressClass was already checking whether the symbol table existed anyway, so we are ok to use it.