### PR TITLE
[mlir][flang] Improve handling of fortran module variables.

### DIFF
--- a/mlir/lib/Target/LLVMIR/ModuleTranslation.cpp
+++ b/mlir/lib/Target/LLVMIR/ModuleTranslation.cpp
@@ -1029,10 +1029,15 @@ LogicalResult ModuleTranslation::convertGlobals() {
           debugTranslation->translateGlobalVariableExpression(op.getDbgExpr());
       llvm::DIGlobalVariable *diGlobalVar = diGlobalExpr->getVariable();
       var->addDebugInfo(diGlobalExpr);
-      // For fortran, the scope hierarchy can be
+
+      // There is no `globals` field in DICompileUnitAttr which can be directly
+      // assigned to DICompileUnit. We have to build the list by looking at the
+      // dbgExpr of all the GlobalOps. The scope of the variable is used to get
+      // the DICompileUnit in which to add it. But for the languages that
+      // support modules, the scope hierarchy can be
       // variable -> module -> compile unit
-      // If a variable scope points to Module then we get its parent scope so
-      // that globals get added to the compile unit.
+      // If a variable scope points to the module then we use the scope of the
+      // module to get the compile unit.
       llvm::DIScope *scope = diGlobalVar->getScope();
       if (llvm::DIModule *mod = dyn_cast_if_present<llvm::DIModule>(scope))
         scope = mod->getScope();

--- a/mlir/test/Target/LLVMIR/llvmir-debug.mlir
+++ b/mlir/test/Target/LLVMIR/llvmir-debug.mlir
@@ -311,6 +311,29 @@ llvm.mlir.global external @global_with_expr_2() {addr_space = 0 : i32, dbg_expr 
 
 // -----
 
+// CHECK: @module_global_1 = external global i64, !dbg {{.*}}
+// CHECK: @module_global_2 = external global i64, !dbg {{.*}}
+// CHECK: !llvm.module.flags = !{{{.*}}}
+// CHECK: !llvm.dbg.cu = !{{{.*}}}
+// CHECK-DAG: ![[FILE:.*]] = !DIFile(filename: "test.f90", directory: "existence")
+// CHECK-DAG: ![[TYPE:.*]] = !DIBasicType(name: "integer", size: 64, encoding: DW_ATE_signed)
+// CHECK-DAG: ![[SCOPE:.*]] = distinct !DICompileUnit(language: DW_LANG_Fortran95, file: ![[FILE]], producer: "MLIR", isOptimized: true, runtimeVersion: 0, emissionKind: FullDebug, globals: ![[GVALS:.*]])
+// CHECK-DAG: ![[SCOPE1:.*]] = !DIModule(scope: ![[SCOPE]], name: "module2", file: ![[FILE]], line: 120)
+// CHECK-DAG: ![[GVAR0:.*]] = distinct !DIGlobalVariable(name: "module_global_1", linkageName: "module_global_1", scope: ![[SCOPE1]], file: ![[FILE]], line: 121, type: ![[TYPE]], isLocal: false, isDefinition: true)
+// CHECK-DAG: ![[GVAR1:.*]] = distinct !DIGlobalVariable(name: "module_global_2", linkageName: "module_global_2", scope: ![[SCOPE1]], file: ![[FILE]], line: 122, type: ![[TYPE]], isLocal: false, isDefinition: true)
+// CHECK-DAG: ![[GEXPR0:.*]] = !DIGlobalVariableExpression(var: ![[GVAR0]], expr: !DIExpression())
+// CHECK-DAG: ![[GEXPR1:.*]] = !DIGlobalVariableExpression(var: ![[GVAR1]], expr: !DIExpression())
+// CHECK-DAG: ![[GVALS]] = !{![[GEXPR0]], ![[GEXPR1]]}
+
+#di_file = #llvm.di_file<"test.f90" in "existence">
+#di_compile_unit = #llvm.di_compile_unit<id = distinct[0]<>, sourceLanguage = DW_LANG_Fortran95, file = #di_file, producer = "MLIR", isOptimized = true, emissionKind = Full>
+#di_basic_type = #llvm.di_basic_type<tag = DW_TAG_base_type, name = "integer", sizeInBits = 64, encoding = DW_ATE_signed>
+#di_module = #llvm.di_module<file = #di_file, scope = #di_compile_unit, name = "module2", configMacros = "", includePath = "", apinotes = "", line = 120, isDecl = false >
+llvm.mlir.global external @module_global_1() {dbg_expr = #llvm.di_global_variable_expression<var = <scope = #di_module, name = "module_global_1", linkageName = "module_global_1", file = #di_file, line = 121, type = #di_basic_type, isLocalToUnit = false, isDefined = true>, expr = <>>} : i64
+llvm.mlir.global external @module_global_2() {dbg_expr = #llvm.di_global_variable_expression<var = <scope = #di_module, name = "module_global_2", linkageName = "module_global_2", file = #di_file, line = 122, type = #di_basic_type, isLocalToUnit = false, isDefined = true>, expr = <>>} : i64
+
+// -----
+
 // Nameless and scopeless global constant.
 
 // CHECK-LABEL: @.str.1 = external constant [10 x i8]

--- a/mlir/test/Target/LLVMIR/llvmir-debug.mlir
+++ b/mlir/test/Target/LLVMIR/llvmir-debug.mlir
@@ -311,26 +311,22 @@ llvm.mlir.global external @global_with_expr_2() {addr_space = 0 : i32, dbg_expr 
 
 // -----
 
-// CHECK: @module_global_1 = external global i64, !dbg {{.*}}
-// CHECK: @module_global_2 = external global i64, !dbg {{.*}}
+// CHECK: @module_global = external global i64, !dbg {{.*}}
 // CHECK: !llvm.module.flags = !{{{.*}}}
 // CHECK: !llvm.dbg.cu = !{{{.*}}}
 // CHECK-DAG: ![[FILE:.*]] = !DIFile(filename: "test.f90", directory: "existence")
 // CHECK-DAG: ![[TYPE:.*]] = !DIBasicType(name: "integer", size: 64, encoding: DW_ATE_signed)
 // CHECK-DAG: ![[SCOPE:.*]] = distinct !DICompileUnit(language: DW_LANG_Fortran95, file: ![[FILE]], producer: "MLIR", isOptimized: true, runtimeVersion: 0, emissionKind: FullDebug, globals: ![[GVALS:.*]])
 // CHECK-DAG: ![[SCOPE1:.*]] = !DIModule(scope: ![[SCOPE]], name: "module2", file: ![[FILE]], line: 120)
-// CHECK-DAG: ![[GVAR0:.*]] = distinct !DIGlobalVariable(name: "module_global_1", linkageName: "module_global_1", scope: ![[SCOPE1]], file: ![[FILE]], line: 121, type: ![[TYPE]], isLocal: false, isDefinition: true)
-// CHECK-DAG: ![[GVAR1:.*]] = distinct !DIGlobalVariable(name: "module_global_2", linkageName: "module_global_2", scope: ![[SCOPE1]], file: ![[FILE]], line: 122, type: ![[TYPE]], isLocal: false, isDefinition: true)
-// CHECK-DAG: ![[GEXPR0:.*]] = !DIGlobalVariableExpression(var: ![[GVAR0]], expr: !DIExpression())
-// CHECK-DAG: ![[GEXPR1:.*]] = !DIGlobalVariableExpression(var: ![[GVAR1]], expr: !DIExpression())
-// CHECK-DAG: ![[GVALS]] = !{![[GEXPR0]], ![[GEXPR1]]}
+// CHECK-DAG: ![[GVAR:.*]] = distinct !DIGlobalVariable(name: "module_global", linkageName: "module_global", scope: ![[SCOPE1]], file: ![[FILE]], line: 121, type: ![[TYPE]], isLocal: false, isDefinition: true)
+// CHECK-DAG: ![[GEXPR:.*]] = !DIGlobalVariableExpression(var: ![[GVAR]], expr: !DIExpression())
+// CHECK-DAG: ![[GVALS]] = !{![[GEXPR]]}
 
 #di_file = #llvm.di_file<"test.f90" in "existence">
 #di_compile_unit = #llvm.di_compile_unit<id = distinct[0]<>, sourceLanguage = DW_LANG_Fortran95, file = #di_file, producer = "MLIR", isOptimized = true, emissionKind = Full>
 #di_basic_type = #llvm.di_basic_type<tag = DW_TAG_base_type, name = "integer", sizeInBits = 64, encoding = DW_ATE_signed>
 #di_module = #llvm.di_module<file = #di_file, scope = #di_compile_unit, name = "module2", configMacros = "", includePath = "", apinotes = "", line = 120, isDecl = false >
-llvm.mlir.global external @module_global_1() {dbg_expr = #llvm.di_global_variable_expression<var = <scope = #di_module, name = "module_global_1", linkageName = "module_global_1", file = #di_file, line = 121, type = #di_basic_type, isLocalToUnit = false, isDefined = true>, expr = <>>} : i64
-llvm.mlir.global external @module_global_2() {dbg_expr = #llvm.di_global_variable_expression<var = <scope = #di_module, name = "module_global_2", linkageName = "module_global_2", file = #di_file, line = 122, type = #di_basic_type, isLocalToUnit = false, isDefined = true>, expr = <>>} : i64
+llvm.mlir.global external @module_global() {dbg_expr = #llvm.di_global_variable_expression<var = <scope = #di_module, name = "module_global", linkageName = "module_global", file = #di_file, line = 121, type = #di_basic_type, isLocalToUnit = false, isDefined = true>, expr = <>>} : i64
 
 // -----
 


### PR DESCRIPTION
Currently, only those global variables which are at compile unit scope are added to the 'globals' list of the DICompileUnit. This does not work for module variables of Fortran where hierarchy can be variable -> module -> compile unit.

To fix this, if a variable scope points to a module, we walk one level up and see if module is in the compile unit scope.

This was initially part of #91582 which adds debug information for Fortran module variables. @kiranchandramohan pointed out that MLIR changes should go in separate PRs.