### PR TITLE
[flang][driver] Accept -fallow-argument-mismatch with a warning instead of rejecting it

### DIFF
--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -2540,6 +2540,8 @@ def fsanitize_undefined_strip_path_components_EQ : Joined<["-"], "fsanitize-unde
 
 } // end -f[no-]sanitize* flags
 
+def fallow_argument_mismatch : Flag<["-"], "fallow-argument-mismatch">, Visibility<[FlangOption, FC1Option]>;
+
 def funsafe_math_optimizations : Flag<["-"], "funsafe-math-optimizations">,
   Group<f_Group>, Visibility<[ClangOption, CC1Option]>,
   HelpText<"Allow unsafe floating-point math optimizations which may decrease precision">,

--- a/flang/test/Driver/allow-argument-mismatch.f90
+++ b/flang/test/Driver/allow-argument-mismatch.f90
@@ -1,0 +1,15 @@
+! Test that -fallow-argument-mismatch flag is accepted with warning, while
+! -fno-allow-argument-mismatch is rejected with error
+
+! RUN: %flang -S %s -fallow-argument-mismatch -o /dev/null 2>&1 | FileCheck %s --check-prefix=CHECK-WARNING
+! RUN: %flang_fc1 -S %s -fallow-argument-mismatch -o /dev/null
+! RUN: not %flang -S %s -fno-allow-argument-mismatch -o /dev/null 2>&1 | FileCheck %s --check-prefix=CHECK-ERROR
+! RUN: not %flang_fc1 -S %s -fno-allow-argument-mismatch -o /dev/null 2>&1 | FileCheck %s --check-prefix=CHECK-ERROR
+
+! CHECK-WARNING: warning:
+! CHECK_WARNING-SAME: argument unused
+! CHECK_WARNING-SAME: -fallow-argument-mismatch
+
+! CHECK-ERROR: error:
+! CHECK-ERROR-SAME: unknown argument
+! CHECK-ERROR-SAME: -fno-allow-argument-mismatch


### PR DESCRIPTION
Many autotools-utilizing projects (mpich among them) fail to complete the `configure` step since it tries to invoke the (unknown to them) Fortran compiler always with the `-fallow-argument-mismatch` flag.

As the use of this flag has no impact on flang, there is no definite need to reject it. It would be better to accept it with a warning and reject the opposite flag `-fno-allow-argument-mismatch` with an error.

With this patch, mpich compiles and works.
