### PR TITLE
[clang][dataflow] Fully support Environment construction for Stmt analysis.

### DIFF
--- a/clang/include/clang/Analysis/FlowSensitive/DataflowEnvironment.h
+++ b/clang/include/clang/Analysis/FlowSensitive/DataflowEnvironment.h
@@ -734,35 +734,8 @@ private:
   // the implementation of sound analyses.
 
   /// Assigns storage locations and values to all global variables, fields
-  /// and functions referenced in `Source`.
-  template <typename FuncOrStmt>
-  void initFieldsGlobalsAndFuncs(const FuncOrStmt *Source) {
-
-    ReferencedDecls Referenced = getReferencedDecls(*Source);
-
-    // These have to be added before the lines that follow to ensure that
-    // `create*` work correctly for structs.
-    DACtx->addModeledFields(Referenced.Fields);
-
-    for (const VarDecl *D : Referenced.Globals) {
-      if (getStorageLocation(*D) != nullptr)
-        continue;
-
-      // We don't run transfer functions on the initializers of global
-      // variables, so they won't be associated with a value or storage
-      // location. We therefore intentionally don't pass an initializer to
-      // `createObject()`; in particular, this ensures that `createObject()`
-      // will initialize the fields of record-type variables with values.
-      setStorageLocation(*D, createObject(*D, nullptr));
-    }
-
-    for (const FunctionDecl *FD : Referenced.Functions) {
-      if (getStorageLocation(*FD) != nullptr)
-        continue;
-      auto &Loc = createStorageLocation(*FD);
-      setStorageLocation(*FD, Loc);
-    }
-  }
+  /// and functions in `Referenced`.
+  void initFieldsGlobalsAndFuncs(const ReferencedDecls &Referenced);
 
   static PrValueToResultObject
   buildResultObjectMap(DataflowAnalysisContext *DACtx,

--- a/clang/include/clang/Analysis/FlowSensitive/DataflowEnvironment.h
+++ b/clang/include/clang/Analysis/FlowSensitive/DataflowEnvironment.h
@@ -751,7 +751,7 @@ private:
   // `DACtx` is not null and not owned by this object.
   DataflowAnalysisContext *DACtx;
 
-  // FIXME: move the fields `TargetStack`, `ResultObjectMap`, `ReturnVal`,
+  // FIXME: move the fields `CallStack`, `ResultObjectMap`, `ReturnVal`,
   // `ReturnLoc` and `ThisPointeeLoc` into a separate call-context object,
   // shared between environments in the same call.
   // https://github.com/llvm/llvm-project/issues/59005

--- a/clang/include/clang/Analysis/FlowSensitive/DataflowEnvironment.h
+++ b/clang/include/clang/Analysis/FlowSensitive/DataflowEnvironment.h
@@ -667,7 +667,8 @@ public:
 
   /// Returns whether this `Environment` can be extended to analyze the given
   /// `Callee` (i.e. if `pushCall` can be used), with recursion disallowed and a
-  /// given `MaxDepth`.
+  /// given `MaxDepth`. Note that the `MaxDepth` does not count any initial
+  /// target function, which was not called.
   bool canDescend(unsigned MaxDepth, const FunctionDecl *Callee) const;
 
   /// Returns the `DataflowAnalysisContext` used by the environment.

--- a/clang/lib/Analysis/FlowSensitive/DataflowEnvironment.cpp
+++ b/clang/lib/Analysis/FlowSensitive/DataflowEnvironment.cpp
@@ -591,7 +591,7 @@ Environment Environment::fork() const {
 
 bool Environment::canDescend(unsigned MaxDepth,
                              const FunctionDecl *Callee) const {
-  return CallStack.size() <= MaxDepth && !llvm::is_contained(CallStack, Callee);
+  return CallStack.size() < MaxDepth && !llvm::is_contained(CallStack, Callee);
 }
 
 Environment Environment::pushCall(const CallExpr *Call) const {

--- a/clang/lib/Analysis/FlowSensitive/DataflowEnvironment.cpp
+++ b/clang/lib/Analysis/FlowSensitive/DataflowEnvironment.cpp
@@ -773,14 +773,12 @@ Environment Environment::join(const Environment &EnvA, const Environment &EnvB,
   JoinedEnv.LocForRecordReturnVal = EnvA.LocForRecordReturnVal;
   JoinedEnv.ThisPointeeLoc = EnvA.ThisPointeeLoc;
 
-  if (EnvA.TargetStack.empty()) {
+  if (EnvA.TargetStack.empty() || !EnvA.getCurrentFunc()) {
     JoinedEnv.ReturnVal = nullptr;
   } else {
-    auto *Func = EnvA.getCurrentFunc();
-    assert(Func != nullptr);
     JoinedEnv.ReturnVal =
-        joinValues(Func->getReturnType(), EnvA.ReturnVal, EnvA, EnvB.ReturnVal,
-                   EnvB, JoinedEnv, Model);
+        joinValues(EnvA.getCurrentFunc()->getReturnType(), EnvA.ReturnVal, EnvA,
+                   EnvB.ReturnVal, EnvB, JoinedEnv, Model);
   }
 
   if (EnvA.ReturnLoc == EnvB.ReturnLoc)

--- a/clang/lib/Analysis/FlowSensitive/TypeErasedDataflowAnalysis.cpp
+++ b/clang/lib/Analysis/FlowSensitive/TypeErasedDataflowAnalysis.cpp
@@ -476,7 +476,7 @@ runTypeErasedDataflowAnalysis(
   PrettyStackTraceAnalysis CrashInfo(ACFG, "runTypeErasedDataflowAnalysis");
 
   std::optional<Environment> MaybeStartingEnv;
-  if (InitEnv.callStackSize() == 0 && InitEnv.getCurrentFunc()) {
+  if (InitEnv.callStackSize() == 0) {
     MaybeStartingEnv = InitEnv.fork();
     MaybeStartingEnv->initialize();
   }

--- a/clang/lib/Analysis/FlowSensitive/TypeErasedDataflowAnalysis.cpp
+++ b/clang/lib/Analysis/FlowSensitive/TypeErasedDataflowAnalysis.cpp
@@ -476,7 +476,7 @@ runTypeErasedDataflowAnalysis(
   PrettyStackTraceAnalysis CrashInfo(ACFG, "runTypeErasedDataflowAnalysis");
 
   std::optional<Environment> MaybeStartingEnv;
-  if (InitEnv.targetStackSize() == 1) {
+  if (InitEnv.callStackSize() == 0 && InitEnv.getCurrentFunc()) {
     MaybeStartingEnv = InitEnv.fork();
     MaybeStartingEnv->initialize();
   }

--- a/clang/lib/Analysis/FlowSensitive/TypeErasedDataflowAnalysis.cpp
+++ b/clang/lib/Analysis/FlowSensitive/TypeErasedDataflowAnalysis.cpp
@@ -476,7 +476,7 @@ runTypeErasedDataflowAnalysis(
   PrettyStackTraceAnalysis CrashInfo(ACFG, "runTypeErasedDataflowAnalysis");
 
   std::optional<Environment> MaybeStartingEnv;
-  if (InitEnv.callStackSize() == 1) {
+  if (InitEnv.targetStackSize() == 1) {
     MaybeStartingEnv = InitEnv.fork();
     MaybeStartingEnv->initialize();
   }

--- a/clang/unittests/Analysis/FlowSensitive/DataflowEnvironmentTest.cpp
+++ b/clang/unittests/Analysis/FlowSensitive/DataflowEnvironmentTest.cpp
@@ -9,6 +9,8 @@
 #include "clang/Analysis/FlowSensitive/DataflowEnvironment.h"
 #include "TestingSupport.h"
 #include "clang/AST/DeclCXX.h"
+#include "clang/AST/ExprCXX.h"
+#include "clang/AST/Stmt.h"
 #include "clang/ASTMatchers/ASTMatchFinder.h"
 #include "clang/ASTMatchers/ASTMatchers.h"
 #include "clang/Analysis/FlowSensitive/DataflowAnalysisContext.h"
@@ -401,6 +403,37 @@ TEST_F(EnvironmentTest,
   Env.initialize();
   EXPECT_THAT(DAContext.getModeledFields(QualType(Struct->getTypeForDecl(), 0)),
               Contains(Member));
+}
+
+TEST_F(EnvironmentTest, Stmt) {
+  using namespace ast_matchers;
+
+  std::string Code = R"cc(
+      struct S {int i;};
+      void foo() {
+        S AnS = S{1};
+      }
+    )cc";
+  auto Unit =
+      tooling::buildASTFromCodeWithArgs(Code, {"-fsyntax-only", "-std=c++11"});
+  auto &Context = Unit->getASTContext();
+
+  ASSERT_EQ(Context.getDiagnostics().getClient()->getNumErrors(), 0U);
+
+  auto *DeclStatement = const_cast<DeclStmt *>(
+      selectFirst<DeclStmt>("d", match(declStmt().bind("d"), Context)));
+  ASSERT_THAT(DeclStatement, NotNull());
+  auto *ConstructExpr = selectFirst<CXXConstructExpr>(
+      "c", match(cxxConstructExpr().bind("c"), Context));
+  ASSERT_THAT(ConstructExpr, NotNull());
+
+  // Verify that we can retrieve the result object location for the construction
+  // expression when we analyze the DeclStmt for `AnS`.
+  Environment Env(DAContext, *DeclStatement);
+  // Don't crash when initializing.
+  Env.initialize();
+  // And don't crash when retrieving the result object location.
+  Env.getResultObjectLocation(*ConstructExpr);
 }
 
 } // namespace

--- a/clang/unittests/Analysis/FlowSensitive/TestingSupport.h
+++ b/clang/unittests/Analysis/FlowSensitive/TestingSupport.h
@@ -355,8 +355,8 @@ checkDataflow(AnalysisInputs<AnalysisT> AI,
   auto SetupTest = [&StmtToAnnotations,
                     PrevSetupTest = std::move(AI.SetupTest)](
                        AnalysisOutputs &AO) -> llvm::Error {
-    auto MaybeStmtToAnnotations = buildStatementToAnnotationMapping(
-        cast<FunctionDecl>(AO.InitEnv.getDeclCtx()), AO.Code);
+    auto MaybeStmtToAnnotations =
+        buildStatementToAnnotationMapping(AO.InitEnv.getCurrentFunc(), AO.Code);
     if (!MaybeStmtToAnnotations) {
       return MaybeStmtToAnnotations.takeError();
     }


### PR DESCRIPTION
Assume in fewer places that the analysis is of a FunctionDecl, and initialize the Environment properly for Stmts.

Moves constructors for Environment to header to make it more obvious that there are only minor differences between them and very little initialization in the constructors.

Tested with check-clang-tooling.