### PR TITLE
[Offload] Fixes typo in aarch64 triple

### DIFF
--- a/offload/plugins-nextgen/host/src/rtl.cpp
+++ b/offload/plugins-nextgen/host/src/rtl.cpp
@@ -431,7 +431,7 @@ struct GenELF64PluginTy final : public GenericPluginTy {
     return llvm::Triple::systemz;
 #elif defined(__aarch64__)
 #ifdef LITTLEENDIAN_CPU
-    return llvm::Triple::aarch64_le;
+    return llvm::Triple::aarch64;
 #else
     return llvm::Triple::aarch64_be;
 #endif


### PR DESCRIPTION
Use llvm::Triple:aarch64 as the little-endian triple.

Fixes commit 3e54768d7a0e1cfa65e892b6602993192ecad91e.