### PR TITLE
[libc++] Deprecates rel_ops.

### DIFF
--- a/libcxx/docs/ReleaseNotes/19.rst
+++ b/libcxx/docs/ReleaseNotes/19.rst
@@ -141,6 +141,8 @@ Deprecations and Removals
   of randomness, and others. Users that were checking whether including a header would fail (e.g. via a script
   or CMake's ``try_compile`` will experience a change in behavior).
 
+- The operators in the ``rel_ops`` namespace have been deprecated. The deprecation is part of the paper
+  P0768R1 "Library Support for the Spaceship (Comparison) Operator".
 
 Upcoming Deprecations and Removals
 ----------------------------------

--- a/libcxx/include/__utility/rel_ops.h
+++ b/libcxx/include/__utility/rel_ops.h
@@ -20,22 +20,22 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 namespace rel_ops {
 
 template <class _Tp>
-inline _LIBCPP_HIDE_FROM_ABI bool operator!=(const _Tp& __x, const _Tp& __y) {
+inline _LIBCPP_DEPRECATED_IN_CXX20 _LIBCPP_HIDE_FROM_ABI bool operator!=(const _Tp& __x, const _Tp& __y) {
   return !(__x == __y);
 }
 
 template <class _Tp>
-inline _LIBCPP_HIDE_FROM_ABI bool operator>(const _Tp& __x, const _Tp& __y) {
+inline _LIBCPP_DEPRECATED_IN_CXX20 _LIBCPP_HIDE_FROM_ABI bool operator>(const _Tp& __x, const _Tp& __y) {
   return __y < __x;
 }
 
 template <class _Tp>
-inline _LIBCPP_HIDE_FROM_ABI bool operator<=(const _Tp& __x, const _Tp& __y) {
+inline _LIBCPP_DEPRECATED_IN_CXX20 _LIBCPP_HIDE_FROM_ABI bool operator<=(const _Tp& __x, const _Tp& __y) {
   return !(__y < __x);
 }
 
 template <class _Tp>
-inline _LIBCPP_HIDE_FROM_ABI bool operator>=(const _Tp& __x, const _Tp& __y) {
+inline _LIBCPP_DEPRECATED_IN_CXX20 _LIBCPP_HIDE_FROM_ABI bool operator>=(const _Tp& __x, const _Tp& __y) {
   return !(__x < __y);
 }
 

--- a/libcxx/test/libcxx/depr/depr.rel_ops/rel_ops.depr_in_cxx20.verify.cpp
+++ b/libcxx/test/libcxx/depr/depr.rel_ops/rel_ops.depr_in_cxx20.verify.cpp
@@ -1,0 +1,35 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// <utility>
+
+// UNSUPPORTED: c++03, c++11, c++14, c++17
+
+#include <utility>
+#include <cassert>
+
+struct A {
+  int data_ = 0;
+};
+
+inline bool operator==(const A& x, const A& y) { return x.data_ == y.data_; }
+
+inline bool operator<(const A& x, const A& y) { return x.data_ < y.data_; }
+
+void test() {
+  using namespace std::rel_ops;
+  A a1{1};
+  A a2{2};
+  (void)(a1 == a1);
+  (void)(a1 != a2);                 // note not deprecated message, due to compiler generated operator.
+  std::rel_ops::operator!=(a1, a2); // expected-warning {{is deprecated}}
+  (void)(a1 < a2);
+  (void)(a1 > a2);  // expected-warning 2 {{is deprecated}}
+  (void)(a1 <= a2); // expected-warning 2 {{is deprecated}}
+  (void)(a1 >= a2); // expected-warning 2 {{is deprecated}}
+}

--- a/libcxx/test/std/containers/iterator.rel_ops.compile.pass.cpp
+++ b/libcxx/test/std/containers/iterator.rel_ops.compile.pass.cpp
@@ -8,6 +8,8 @@
 
 // XFAIL: availability-filesystem-missing
 
+// ADDITIONAL_COMPILE_FLAGS: -D_LIBCPP_DISABLE_DEPRECATION_WARNINGS
+
 // Make sure the various containers' iterators are not broken by the use of `std::rel_ops`.
 
 #include <utility> // for std::rel_ops

--- a/libcxx/test/std/utilities/utility/operators/rel_ops.pass.cpp
+++ b/libcxx/test/std/utilities/utility/operators/rel_ops.pass.cpp
@@ -8,6 +8,8 @@
 
 // test rel_ops
 
+// ADDITIONAL_COMPILE_FLAGS: -D_LIBCPP_DISABLE_DEPRECATION_WARNINGS
+
 #include <utility>
 #include <cassert>
 


### PR DESCRIPTION
These operators were deprecated in
  P0768R1 Library Support for the Spaceship (Comparison) Operator

This was discovered while investigating the paper's implementation status.