### PR TITLE
[clang] Processing real directories added as virtual ones

### DIFF
--- a/clang/include/clang/Basic/FileManager.h
+++ b/clang/include/clang/Basic/FileManager.h
@@ -299,6 +299,8 @@ private:
   getBufferForFileImpl(StringRef Filename, int64_t FileSize, bool isVolatile,
                        bool RequiresNullTerminator) const;
 
+  DirectoryEntry *&getRealDirEntry(const llvm::vfs::Status &Status);
+
 public:
   /// Get the 'stat' information for the given \p Path.
   ///

--- a/clang/test/Modules/implicit-module-remap.cpp
+++ b/clang/test/Modules/implicit-module-remap.cpp
@@ -1,0 +1,21 @@
+// RUN: rm -rf %t
+// RUN: split-file %s %t
+// RUN: cd %t
+//
+// RUN: %clang_cc1 -fmodules -fmodule-map-file=module.modulemap -fmodules-cache-path=%t -remap-file "test.cpp;%t/test.cpp"  %t/test.cpp
+
+//--- a.h
+#define FOO
+
+//--- module.modulemap
+module a {
+  header "a.h"
+}
+
+//--- test.cpp
+#include "a.h"
+
+#ifndef FOO
+#error foo
+#endif
+


### PR DESCRIPTION
The `FileManager` might create a virtual directory that can be used later as a search path. This is the case when we use remapping, as demonstrated in the suggested LIT test. 

We might encounter a **false cache miss** and add the same directory twice into `FileManager::SeenDirEntries` if the added record is a real directory that is present on a disk:
- Once as a virtual directory 
- And once as a real one

This isn't a problem if the added directories have the same name, as in this case, we will get a cache hit. However, it could lead to compilation errors if the directory names are different but point to the same folder. For example, one might use an absolute name and another a relative one. For instance, the **implicit-module-remap.cpp** LIT test will fail with the following message:
```
/.../implicit-module-remap.cpp.tmp/test.cpp:1:2: fatal error: module 'a' was built in directory 
'/.../implicit-module-remap.cpp.tmp' but now resides in directory '.'
    1 | #include "a.h"
      |  ^
1 error generated.
```

The suggested fix checks if the added virtual directory is present on the disk and handles it as a real one if that is the case.