### PR TITLE
[lldb/crashlog] Fix test failure when creating a target using command options

### DIFF
--- a/lldb/examples/python/crashlog.py
+++ b/lldb/examples/python/crashlog.py
@@ -1494,6 +1494,7 @@ def load_crashlog_in_scripted_process(debugger, crashlog_path, options, result):
             raise InteractiveCrashLogException(
                 "couldn't create target provided by the user (%s)" % options.target_path
             )
+        crashlog.target = target
 
     # 2. If the user didn't provide a target, try to create a target using the symbolicator
     if not target or not target.IsValid():


### PR DESCRIPTION
This should fix the various crashlog test failures on the bots:

```
  lldb-shell :: ScriptInterpreter/Python/Crashlog/app_specific_backtrace_crashlog.test
  lldb-shell :: ScriptInterpreter/Python/Crashlog/interactive_crashlog_json.test
  lldb-shell :: ScriptInterpreter/Python/Crashlog/interactive_crashlog_legacy.test
  lldb-shell :: ScriptInterpreter/Python/Crashlog/last_exception_backtrace_crashlog.test
  lldb-shell :: ScriptInterpreter/Python/Crashlog/skipped_status_interactive_crashlog.test
```

When we create a target by using the command option, we don't set it in the crashlog object which later on cause us to fail loading the images.

rdar://127832961