### PR TITLE
[clang][analyzer] Ignore try-statements in UnreachableCode checker

### DIFF
--- a/clang/lib/StaticAnalyzer/Checkers/UnreachableCodeChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/UnreachableCodeChecker.cpp
@@ -159,6 +159,8 @@ void UnreachableCodeChecker::checkEndAnalysis(ExplodedGraph &G,
       SL = DL.asLocation();
       if (SR.isInvalid() || !SL.isValid())
         continue;
+      if (isa<CXXTryStmt>(S))
+        continue;
     }
     else
       continue;

--- a/clang/test/Analysis/unreachable-code-exceptions.cpp
+++ b/clang/test/Analysis/unreachable-code-exceptions.cpp
@@ -4,9 +4,10 @@
 
 void foo();
 
-void f4() {
-  try {
+void fp_90162() {
+  try { // no-warning: The TryStmt shouldn't be unreachable.
     foo();
   } catch (int) {
+    foo(); // We assume that catch handlers are reachable.
   }
 }

--- a/clang/test/Analysis/unreachable-code-exceptions.cpp
+++ b/clang/test/Analysis/unreachable-code-exceptions.cpp
@@ -1,0 +1,12 @@
+// RUN: %clang_analyze_cc1 -verify %s -fcxx-exceptions -fexceptions -analyzer-checker=core -analyzer-checker=alpha.deadcode.UnreachableCode
+
+// expected-no-diagnostics
+
+void foo();
+
+void f4() {
+  try {
+    foo();
+  } catch (int) {
+  }
+}

--- a/clang/test/Analysis/unreachable-code-exceptions.cpp
+++ b/clang/test/Analysis/unreachable-code-exceptions.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_analyze_cc1 -verify %s -fcxx-exceptions -fexceptions -analyzer-checker=core -analyzer-checker=alpha.deadcode.UnreachableCode
+// RUN: %clang_analyze_cc1 -verify %s -fcxx-exceptions -fexceptions -analyzer-checker=core,alpha.deadcode.UnreachableCode
 
 // expected-no-diagnostics
 


### PR DESCRIPTION
Fixes #90162. Simplest approach I could come up with was to skip cxxtry statements. Let me know if you have any suggestions. Thanks!