### PR TITLE
[libfuzzer] Prevent MSan false positive when printing log with -jobs

### DIFF
--- a/compiler-rt/lib/fuzzer/FuzzerDriver.cpp
+++ b/compiler-rt/lib/fuzzer/FuzzerDriver.cpp
@@ -229,6 +229,7 @@ static void PulseThread() {
 
 static void WorkerThread(const Command &BaseCmd, std::atomic<unsigned> *Counter,
                          unsigned NumJobs, std::atomic<bool> *HasErrors) {
+  ScopedDisableMsanInterceptorChecks S;
   while (true) {
     unsigned C = (*Counter)++;
     if (C >= NumJobs) break;

--- a/compiler-rt/lib/fuzzer/FuzzerIO.cpp
+++ b/compiler-rt/lib/fuzzer/FuzzerIO.cpp
@@ -8,10 +8,10 @@
 // IO functions.
 //===----------------------------------------------------------------------===//
 
+#include "FuzzerIO.h"
 #include "FuzzerDefs.h"
 #include "FuzzerExtFunctions.h"
 #include "FuzzerInternal.h"
-#include "FuzzerIO.h"
 #include "FuzzerUtil.h"
 #include <algorithm>
 #include <cstdarg>

--- a/compiler-rt/lib/fuzzer/FuzzerIO.cpp
+++ b/compiler-rt/lib/fuzzer/FuzzerIO.cpp
@@ -8,10 +8,9 @@
 // IO functions.
 //===----------------------------------------------------------------------===//
 
-#include "FuzzerIO.h"
 #include "FuzzerDefs.h"
 #include "FuzzerExtFunctions.h"
-#include "FuzzerInternal.h"
+#include "FuzzerIO.h"
 #include "FuzzerUtil.h"
 #include <algorithm>
 #include <cstdarg>
@@ -66,7 +65,6 @@ std::string FileToString(const std::string &Path) {
 }
 
 void CopyFileToErr(const std::string &Path) {
-  ScopedDisableMsanInterceptorChecks S;
   Puts(FileToString(Path).c_str());
 }
 

--- a/compiler-rt/lib/fuzzer/FuzzerIO.cpp
+++ b/compiler-rt/lib/fuzzer/FuzzerIO.cpp
@@ -10,6 +10,7 @@
 
 #include "FuzzerDefs.h"
 #include "FuzzerExtFunctions.h"
+#include "FuzzerInternal.h"
 #include "FuzzerIO.h"
 #include "FuzzerUtil.h"
 #include <algorithm>
@@ -65,6 +66,7 @@ std::string FileToString(const std::string &Path) {
 }
 
 void CopyFileToErr(const std::string &Path) {
+  ScopedDisableMsanInterceptorChecks S;
   Puts(FileToString(Path).c_str());
 }
 


### PR DESCRIPTION
libfuzzer's -jobs option will, depending on the number of CPUs, spin up a
WorkerThread and end up printing the log file using CopyFileToErr.
This leads to an MSan false positive. This patch disables the MSan interceptor checks,
similarly to other instances in https://reviews.llvm.org/D48891

Side-note: this false positive issue first appeared when printf()
was replaced by puts() (90b4d1bcb20180c591385131b12fa90d2e4860b1).
The interceptor check was always present; however, MSan does not
check_printf by default.
