### PR TITLE
release/18.x Revert "[SLP]Fix a crash if the argument of call was affected by minbitwidth analysis."

### DIFF
--- a/llvm/lib/Transforms/Vectorize/SLPVectorizer.cpp
+++ b/llvm/lib/Transforms/Vectorize/SLPVectorizer.cpp
@@ -11653,12 +11653,12 @@ Value *BoUpSLP::vectorizeTree(TreeEntry *E, bool PostponedPHIs) {
       if (UseIntrinsic && isVectorIntrinsicWithOverloadTypeAtArg(ID, -1))
         TysForDecl.push_back(
             FixedVectorType::get(CI->getType(), E->Scalars.size()));
-      auto *CEI = cast<CallInst>(VL0);
       for (unsigned I : seq<unsigned>(0, CI->arg_size())) {
         ValueList OpVL;
         // Some intrinsics have scalar arguments. This argument should not be
         // vectorized.
         if (UseIntrinsic && isVectorIntrinsicWithScalarOpAtArg(ID, I)) {
+          CallInst *CEI = cast<CallInst>(VL0);
           ScalarArg = CEI->getArgOperand(I);
           OpVecs.push_back(CEI->getArgOperand(I));
           if (isVectorIntrinsicWithOverloadTypeAtArg(ID, I))
@@ -11670,25 +11670,6 @@ Value *BoUpSLP::vectorizeTree(TreeEntry *E, bool PostponedPHIs) {
         if (E->VectorizedValue) {
           LLVM_DEBUG(dbgs() << "SLP: Diamond merged for " << *VL0 << ".\n");
           return E->VectorizedValue;
-        }
-        auto GetOperandSignedness = [&](unsigned Idx) {
-          const TreeEntry *OpE = getOperandEntry(E, Idx);
-          bool IsSigned = false;
-          auto It = MinBWs.find(OpE);
-          if (It != MinBWs.end())
-            IsSigned = It->second.second;
-          else
-            IsSigned = any_of(OpE->Scalars, [&](Value *R) {
-              return !isKnownNonNegative(R, SimplifyQuery(*DL));
-            });
-          return IsSigned;
-        };
-        ScalarArg = CEI->getArgOperand(I);
-        if (cast<VectorType>(OpVec->getType())->getElementType() !=
-            ScalarArg->getType()) {
-          auto *CastTy = FixedVectorType::get(ScalarArg->getType(),
-                                              VecTy->getNumElements());
-          OpVec = Builder.CreateIntCast(OpVec, CastTy, GetOperandSignedness(I));
         }
         LLVM_DEBUG(dbgs() << "SLP: OpVec[" << I << "]: " << *OpVec << "\n");
         OpVecs.push_back(OpVec);


### PR DESCRIPTION
After reconsidering the words of @nikic, I have decided to revisit the patches I suggested be backported. Upon further analysis, I think there is a high likelihood that this change added to release 18.x was referencing a crash that was caused by a PR that isn't added, and would therefore like to be safe and therefore ask to retract this PR.

I will, however, keep the test that was added just in case.

This reverts commit 6e071cf30599e821be56b75e6041cfedb7872216.