### PR TITLE
Enable unguarded availability diagnostic on instantiated template functions

### DIFF
--- a/clang/lib/Sema/SemaAvailability.cpp
+++ b/clang/lib/Sema/SemaAvailability.cpp
@@ -928,11 +928,6 @@ void Sema::DiagnoseUnguardedAvailabilityViolations(Decl *D) {
   Stmt *Body = nullptr;
 
   if (auto *FD = D->getAsFunction()) {
-    // FIXME: We only examine the pattern decl for availability violations now,
-    // but we should also examine instantiated templates.
-    if (FD->isTemplateInstantiation())
-      return;
-
     Body = FD->getBody();
 
     if (auto *CD = dyn_cast<CXXConstructorDecl>(FD))

--- a/clang/test/SemaObjC/unguarded-availability.m
+++ b/clang/test/SemaObjC/unguarded-availability.m
@@ -181,15 +181,24 @@ int f(char) AVAILABLE_10_12; // #f_char_def
 int f(int);
 
 template <class T> int use_f() {
+  if (@available(macos 10.12, *)) {
+    return f(T()); // no warning expected
+  } else {
   // expected-warning@#f_call {{'f' is only available on macOS 10.12 or newer}}
   // expected-note@#f_char_inst {{in instantiation of function template specialization 'use_f<char>' requested here}}
   // expected-note@#f_char_def {{'f' has been marked as being introduced in macOS 10.12 here, but the deployment target is macOS 10.9}}
   // expected-note@#f_call {{enclose 'f' in an @available check to silence this warning}}
-  return f(T()); // #f_call
+    return f(T()); // #f_call
+  }
 }
 
 int a = use_f<int>();
 int b = use_f<char>(); // #f_char_inst
+
+int use_f2() AVAILABLE_10_12 {
+  int c = use_f<int>();
+  int d = use_f<char>(); // no warning expected
+}
 
 template <class> int use_at_available() {
   if (@available(macos 10.12, *))

--- a/clang/test/SemaObjC/unguarded-availability.m
+++ b/clang/test/SemaObjC/unguarded-availability.m
@@ -177,16 +177,19 @@ void justAtAvailable(void) {
 
 #ifdef OBJCPP
 
-int f(char) AVAILABLE_10_12;
+int f(char) AVAILABLE_10_12; // #f_char_def
 int f(int);
 
 template <class T> int use_f() {
-  // FIXME: We should warn here!
-  return f(T());
+  // expected-warning@#f_call {{'f' is only available on macOS 10.12 or newer}}
+  // expected-note@#f_char_inst {{in instantiation of function template specialization 'use_f<char>' requested here}}
+  // expected-note@#f_char_def {{'f' has been marked as being introduced in macOS 10.12 here, but the deployment target is macOS 10.9}}
+  // expected-note@#f_call {{enclose 'f' in an @available check to silence this warning}}
+  return f(T()); // #f_call
 }
 
 int a = use_f<int>();
-int b = use_f<char>();
+int b = use_f<char>(); // #f_char_inst
 
 template <class> int use_at_available() {
   if (@available(macos 10.12, *))


### PR DESCRIPTION
Availability diagnostic in instantiated template functions was intentionally skipped in the original [commit](https://github.com/llvm/llvm-project/commit/5cd57177a51abc7b0bfe18f70566572dbccab9a0) years ago with a FIXME note.

I ran into this when working on diagnostics for HLSL. When I remove the skip, it seems to be working just fine outputting expected messages. So, unless I am missing something, I would keep it enabled and use it for checking availability in HLSL templates as well.