### PR TITLE
[Clang] Fix Undefined Behavior introduced by #91199

### DIFF
--- a/clang/lib/Sema/SemaExprCXX.cpp
+++ b/clang/lib/Sema/SemaExprCXX.cpp
@@ -5627,11 +5627,9 @@ static bool EvaluateUnaryTypeTrait(Sema &Self, TypeTrait UTT,
 static bool EvaluateBinaryTypeTrait(Sema &Self, TypeTrait BTT, const TypeSourceInfo *Lhs,
                                     const TypeSourceInfo *Rhs, SourceLocation KeyLoc);
 
-static ExprResult CheckConvertibilityForTypeTraits(Sema &Self,
-                                                   const TypeSourceInfo *Lhs,
-                                                   const TypeSourceInfo *Rhs,
-                                                   SourceLocation KeyLoc,
-                                                   llvm::BumpPtrAllocator & OpaqueExprAllocator) {
+static ExprResult CheckConvertibilityForTypeTraits(
+    Sema &Self, const TypeSourceInfo *Lhs, const TypeSourceInfo *Rhs,
+    SourceLocation KeyLoc, llvm::BumpPtrAllocator &OpaqueExprAllocator) {
 
   QualType LhsT = Lhs->getType();
   QualType RhsT = Rhs->getType();
@@ -5676,9 +5674,9 @@ static ExprResult CheckConvertibilityForTypeTraits(Sema &Self,
 
   // Build a fake source and destination for initialization.
   InitializedEntity To(InitializedEntity::InitializeTemporary(RhsT));
-  Expr* From = new (OpaqueExprAllocator.Allocate<OpaqueValueExpr>())
-          OpaqueValueExpr(KeyLoc, LhsT.getNonLValueExprType(Self.Context),
-                       Expr::getValueKindForType(LhsT));
+  Expr *From = new (OpaqueExprAllocator.Allocate<OpaqueValueExpr>())
+      OpaqueValueExpr(KeyLoc, LhsT.getNonLValueExprType(Self.Context),
+                      Expr::getValueKindForType(LhsT));
   InitializationKind Kind =
       InitializationKind::CreateCopy(KeyLoc, SourceLocation());
 
@@ -5820,7 +5818,8 @@ static bool EvaluateBooleanTypeTrait(Sema &S, TypeTrait Kind,
           S.Context.getPointerType(T.getNonReferenceType()));
       TypeSourceInfo *UPtr = S.Context.CreateTypeSourceInfo(
           S.Context.getPointerType(U.getNonReferenceType()));
-      return !CheckConvertibilityForTypeTraits(S, UPtr, TPtr, RParenLoc, OpaqueExprAllocator)
+      return !CheckConvertibilityForTypeTraits(S, UPtr, TPtr, RParenLoc,
+                                               OpaqueExprAllocator)
                   .isInvalid();
     }
 
@@ -6030,8 +6029,8 @@ static bool EvaluateBinaryTypeTrait(Sema &Self, TypeTrait BTT, const TypeSourceI
     if (RhsT->isVoidType())
       return LhsT->isVoidType();
     llvm::BumpPtrAllocator OpaqueExprAllocator;
-    ExprResult Result =
-        CheckConvertibilityForTypeTraits(Self, Lhs, Rhs, KeyLoc, OpaqueExprAllocator);
+    ExprResult Result = CheckConvertibilityForTypeTraits(Self, Lhs, Rhs, KeyLoc,
+                                                         OpaqueExprAllocator);
     if (Result.isInvalid())
       return false;
 


### PR DESCRIPTION
We stack allocated an OpaqueExpr that woukd be used after it was destroyed.

https://lab.llvm.org/buildbot/#/builders/57/builds/34909