### PR TITLE
[Modules] Enable MS Windows test for implicit-module-no-timestamp.cpp

### DIFF
--- a/clang/test/Modules/implicit-module-no-timestamp.cpp
+++ b/clang/test/Modules/implicit-module-no-timestamp.cpp
@@ -1,4 +1,3 @@
-// UNSUPPORTED: system-windows
 // RUN: rm -rf %t
 // RUN: split-file %s %t
 // RUN: cd %t


### PR DESCRIPTION
There is a follow-up commit for #90319. The Windows test was disabled in that commit, but it should pass on this operating system. Therefore, it would be beneficial to have it enabled for MS Windows.