### PR TITLE
[RuntimeDyldChecker][AArch32] Add a PC offset to next_PC for ARM targets

### DIFF
--- a/llvm/lib/ExecutionEngine/RuntimeDyld/RuntimeDyldChecker.cpp
+++ b/llvm/lib/ExecutionEngine/RuntimeDyld/RuntimeDyldChecker.cpp
@@ -354,6 +354,26 @@ private:
           EvalResult(("Cannot decode unknown symbol '" + Symbol + "'").str()),
           "");
 
+    // if there is an offset number expr
+    int64_t SymbolOffset = 0;
+    BinOpToken BinOp;
+    std::tie(BinOp, RemainingExpr) = parseBinOpToken(RemainingExpr);
+    switch (BinOp) {
+    case BinOpToken::Add: {
+      EvalResult Number;
+      std::tie(Number, RemainingExpr) = evalNumberExpr(RemainingExpr);
+      SymbolOffset = Number.getValue();
+      break;
+    }
+    case BinOpToken::Invalid:
+      break;
+    default:
+      return std::make_pair(
+          unexpectedToken(RemainingExpr, RemainingExpr,
+                          "expected '+' for offset or ')' if no offset"),
+          "");
+    }
+
     if (!RemainingExpr.starts_with(")"))
       return std::make_pair(
           unexpectedToken(RemainingExpr, RemainingExpr, "expected ')'"), "");
@@ -361,14 +381,14 @@ private:
 
     MCInst Inst;
     uint64_t InstSize;
-    if (!decodeInst(Symbol, Inst, InstSize, 0))
+    if (!decodeInst(Symbol, Inst, InstSize, SymbolOffset))
       return std::make_pair(
           EvalResult(("Couldn't decode instruction at '" + Symbol + "'").str()),
           "");
 
-    uint64_t SymbolAddr = PCtx.IsInsideLoad
-                              ? Checker.getSymbolLocalAddr(Symbol)
-                              : Checker.getSymbolRemoteAddr(Symbol);
+    uint64_t SymbolAddr =
+        PCtx.IsInsideLoad ? Checker.getSymbolLocalAddr(Symbol)
+                          : Checker.getSymbolRemoteAddr(Symbol) + SymbolOffset;
 
     // ARM mode adds an offset of 4 bytes to PC
     auto TT = Checker.getTripleForSymbol(Checker.getTargetFlag(Symbol));

--- a/llvm/lib/ExecutionEngine/RuntimeDyld/RuntimeDyldChecker.cpp
+++ b/llvm/lib/ExecutionEngine/RuntimeDyld/RuntimeDyldChecker.cpp
@@ -354,26 +354,6 @@ private:
           EvalResult(("Cannot decode unknown symbol '" + Symbol + "'").str()),
           "");
 
-    // if there is an offset number expr
-    int64_t SymbolOffset = 0;
-    BinOpToken BinOp;
-    std::tie(BinOp, RemainingExpr) = parseBinOpToken(RemainingExpr);
-    switch (BinOp) {
-    case BinOpToken::Add: {
-      EvalResult Number;
-      std::tie(Number, RemainingExpr) = evalNumberExpr(RemainingExpr);
-      SymbolOffset = Number.getValue();
-      break;
-    }
-    case BinOpToken::Invalid:
-      break;
-    default:
-      return std::make_pair(
-          unexpectedToken(RemainingExpr, RemainingExpr,
-                          "expected '+' for offset or ')' if no offset"),
-          "");
-    }
-
     if (!RemainingExpr.starts_with(")"))
       return std::make_pair(
           unexpectedToken(RemainingExpr, RemainingExpr, "expected ')'"), "");
@@ -381,14 +361,14 @@ private:
 
     MCInst Inst;
     uint64_t InstSize;
-    if (!decodeInst(Symbol, Inst, InstSize, SymbolOffset))
+    if (!decodeInst(Symbol, Inst, InstSize, 0))
       return std::make_pair(
           EvalResult(("Couldn't decode instruction at '" + Symbol + "'").str()),
           "");
 
-    uint64_t SymbolAddr =
-        PCtx.IsInsideLoad ? Checker.getSymbolLocalAddr(Symbol)
-                          : Checker.getSymbolRemoteAddr(Symbol) + SymbolOffset;
+    uint64_t SymbolAddr = PCtx.IsInsideLoad
+                              ? Checker.getSymbolLocalAddr(Symbol)
+                              : Checker.getSymbolRemoteAddr(Symbol);
 
     // ARM mode adds an offset of 4 bytes to PC
     auto TT = Checker.getTripleForSymbol(Checker.getTargetFlag(Symbol));

--- a/llvm/lib/ExecutionEngine/RuntimeDyld/RuntimeDyldChecker.cpp
+++ b/llvm/lib/ExecutionEngine/RuntimeDyld/RuntimeDyldChecker.cpp
@@ -369,7 +369,19 @@ private:
     uint64_t SymbolAddr = PCtx.IsInsideLoad
                               ? Checker.getSymbolLocalAddr(Symbol)
                               : Checker.getSymbolRemoteAddr(Symbol);
-    uint64_t NextPC = SymbolAddr + InstSize;
+
+    uint64_t PCOffset = 0;
+    auto TT = Checker.getTripleForSymbol(Checker.getTargetFlag(Symbol));
+    switch (TT.getArch()) {
+    case Triple::ArchType::arm:
+      // ARM mode adds an offset of 4 bytes to PC
+      PCOffset = 4;
+      break;
+    default:
+      PCOffset = 0;
+    }
+
+    uint64_t NextPC = SymbolAddr + InstSize + PCOffset;
 
     return std::make_pair(EvalResult(NextPC), RemainingExpr);
   }

--- a/llvm/lib/ExecutionEngine/RuntimeDyld/RuntimeDyldChecker.cpp
+++ b/llvm/lib/ExecutionEngine/RuntimeDyld/RuntimeDyldChecker.cpp
@@ -370,7 +370,8 @@ private:
                               ? Checker.getSymbolLocalAddr(Symbol)
                               : Checker.getSymbolRemoteAddr(Symbol);
 
-    // ARM mode adds an offset of 4 bytes to PC
+    // ARM PC offset is 8 instead of 4, because it accounts for an additional
+    // prefetch instruction that increments PC even though it is implicit.
     auto TT = Checker.getTripleForSymbol(Checker.getTargetFlag(Symbol));
     uint64_t PCOffset = TT.getArch() == Triple::ArchType::arm ? 4 : 0;
 

--- a/llvm/lib/ExecutionEngine/RuntimeDyld/RuntimeDyldChecker.cpp
+++ b/llvm/lib/ExecutionEngine/RuntimeDyld/RuntimeDyldChecker.cpp
@@ -370,16 +370,9 @@ private:
                               ? Checker.getSymbolLocalAddr(Symbol)
                               : Checker.getSymbolRemoteAddr(Symbol);
 
-    uint64_t PCOffset = 0;
+    // ARM mode adds an offset of 4 bytes to PC
     auto TT = Checker.getTripleForSymbol(Checker.getTargetFlag(Symbol));
-    switch (TT.getArch()) {
-    case Triple::ArchType::arm:
-      // ARM mode adds an offset of 4 bytes to PC
-      PCOffset = 4;
-      break;
-    default:
-      PCOffset = 0;
-    }
+    uint64_t PCOffset = TT.getArch() == Triple::ArchType::arm ? 4 : 0;
 
     uint64_t NextPC = SymbolAddr + InstSize + PCOffset;
 

--- a/llvm/test/ExecutionEngine/JITLink/AArch32/ELF_relocations_arm.s
+++ b/llvm/test/ExecutionEngine/JITLink/AArch32/ELF_relocations_arm.s
@@ -29,7 +29,7 @@
 # CHECK-INSTR: 	0000000c <call_target_arm>
 # CHECK-INSTR: 	00000010 <call_target_thumb>
 # jitlink-check: decode_operand(call_site + 0, 0) = call_target_arm   - next_pc(call_site)
-# jitlink-check: decode_operand(call_site + 4, 0) = call_target_thumb - next_pc(call_site + 4)
+# jitlink-check: decode_operand(call_site + 4, 0) = call_target_thumb - (call_site + 12)
 	.globl	call_site
 	.type	call_site,%function
 	.p2align	2

--- a/llvm/test/ExecutionEngine/JITLink/AArch32/ELF_relocations_arm.s
+++ b/llvm/test/ExecutionEngine/JITLink/AArch32/ELF_relocations_arm.s
@@ -28,9 +28,7 @@
 # CHECK-INSTR: 	       4: ebfffffe     bl
 # CHECK-INSTR: 	0000000c <call_target_arm>
 # CHECK-INSTR: 	00000010 <call_target_thumb>
-# ARM branch offset is 8, because it accounts for an additional prefetch
-# instruction that increments PC even though it is implicit
-# jitlink-check: decode_operand(call_site + 0, 0) = call_target_arm   - (call_site +  8)
+# jitlink-check: decode_operand(call_site + 0, 0) = call_target_arm   - next_pc(call_site)
 # jitlink-check: decode_operand(call_site + 4, 0) = call_target_thumb - (call_site + 12)
 	.globl	call_site
 	.type	call_site,%function
@@ -62,7 +60,7 @@ call_target_thumb:
 # CHECK-INSTR: 	00000014 <jump24_site>:
 # CHECK-INSTR: 	      14: eafffffe     b
 # CHECK-INSTR: 	00000018 <jump24_target>
-# jitlink-check: decode_operand(jump24_site, 0) = jump24_target - (jump24_site + 8)
+# jitlink-check: decode_operand(jump24_site, 0) = jump24_target - next_pc(jump24_site)
 	.globl	jump24_site
 	.type	jump24_site,%function
 	.p2align	2

--- a/llvm/test/ExecutionEngine/JITLink/AArch32/ELF_relocations_arm.s
+++ b/llvm/test/ExecutionEngine/JITLink/AArch32/ELF_relocations_arm.s
@@ -23,21 +23,29 @@
 	.syntax unified
 
 # CHECK-TYPE: {{[0-9a-f]+}} R_ARM_CALL call_target_arm
-# CHECK-INSTR: 	00000000 <call_site>:
+# CHECK-INSTR: 	00000000 <call_site_a2a>:
 # CHECK-INSTR: 	       0: ebfffffe     bl
-# CHECK-INSTR: 	       4: ebfffffe     bl
-# CHECK-INSTR: 	0000000c <call_target_arm>
-# CHECK-INSTR: 	00000010 <call_target_thumb>
-# jitlink-check: decode_operand(call_site + 0, 0) = call_target_arm   - next_pc(call_site)
-# jitlink-check: decode_operand(call_site + 4, 0) = call_target_thumb - (call_site + 12)
-	.globl	call_site
-	.type	call_site,%function
+# CHECK-INSTR: 	00000008 <call_site_a2t>:
+# CHECK-INSTR: 	       8: ebfffffe     bl
+# CHECK-INSTR: 	00000010 <call_target_arm>
+# CHECK-INSTR: 	00000014 <call_target_thumb>
+# jitlink-check: decode_operand(call_site_a2a, 0) = call_target_arm   - next_pc(call_site_a2a)
+# jitlink-check: decode_operand(call_site_a2t, 0) = call_target_thumb - next_pc(call_site_a2t)
+	.globl	call_site_a2a
+	.type	call_site_a2a, %function
 	.p2align	2
-call_site:
+call_site_a2a:
 	bl	call_target_arm
+	bx	lr
+	.size	call_site_a2a, .-call_site_a2a
+
+	.globl	call_site_a2t
+	.type	call_site_a2t,%function
+	.p2align	2
+call_site_a2t:
 	bl	call_target_thumb
 	bx	lr
-	.size	call_site, .-call_site
+	.size	call_site_a2t, .-call_site_a2t
 
 	.globl	call_target_arm
 	.type	call_target_arm,%function
@@ -57,9 +65,9 @@ call_target_thumb:
 	.code 32
 
 # CHECK-TYPE: {{[0-9a-f]+}} R_ARM_JUMP24 jump24_target
-# CHECK-INSTR: 	00000014 <jump24_site>:
-# CHECK-INSTR: 	      14: eafffffe     b
-# CHECK-INSTR: 	00000018 <jump24_target>
+# CHECK-INSTR: 	00000018 <jump24_site>:
+# CHECK-INSTR: 	      18: eafffffe     b
+# CHECK-INSTR: 	0000001c <jump24_target>
 # jitlink-check: decode_operand(jump24_site, 0) = jump24_target - next_pc(jump24_site)
 	.globl	jump24_site
 	.type	jump24_site,%function

--- a/llvm/test/ExecutionEngine/JITLink/AArch32/ELF_relocations_arm.s
+++ b/llvm/test/ExecutionEngine/JITLink/AArch32/ELF_relocations_arm.s
@@ -29,7 +29,7 @@
 # CHECK-INSTR: 	0000000c <call_target_arm>
 # CHECK-INSTR: 	00000010 <call_target_thumb>
 # jitlink-check: decode_operand(call_site + 0, 0) = call_target_arm   - next_pc(call_site)
-# jitlink-check: decode_operand(call_site + 4, 0) = call_target_thumb - (call_site + 12)
+# jitlink-check: decode_operand(call_site + 4, 0) = call_target_thumb - next_pc(call_site + 4)
 	.globl	call_site
 	.type	call_site,%function
 	.p2align	2

--- a/llvm/test/ExecutionEngine/JITLink/AArch32/ELF_relocations_data.s
+++ b/llvm/test/ExecutionEngine/JITLink/AArch32/ELF_relocations_data.s
@@ -50,7 +50,7 @@ target1_abs32:
 # The +12 accounts for the ARM branch offset (8) and the .LPC offset (4), which
 # is stored as initial addend inline.
 # FIXME: We shouldn't need to substract the 64-bit sign-extension manually.
-# jitlink-check: *{4}got_prel_offset = got_addr(out.o, target) - (got_prel + 12) - 0xffffffff00000000
+# jitlink-check: *{4}got_prel_offset = got_addr(out.o, target) - (next_pc(got_prel) + 4) - 0xffffffff00000000
 	.globl	got_prel
 	.type	got_prel,%function
 	.p2align	2

--- a/llvm/test/ExecutionEngine/JITLink/AArch32/ELF_relocations_thumbv6m.s
+++ b/llvm/test/ExecutionEngine/JITLink/AArch32/ELF_relocations_thumbv6m.s
@@ -30,7 +30,7 @@
 # CHECK-INSTR: f7ff fffe     bl
 # We decode the operand with index 2, because bl generates two leading implicit
 # predicate operands that we have to skip in order to decode the call_target operand
-# jitlink-check: decode_operand(call_site, 2) = call_target_thumb - (call_site + 4)
+# jitlink-check: decode_operand(call_site, 2) = call_target_thumb - next_pc(call_site)
 	.globl	call_site
 	.type	call_site,%function
 	.p2align	1

--- a/llvm/test/ExecutionEngine/JITLink/AArch32/ELF_stubs_arm.s
+++ b/llvm/test/ExecutionEngine/JITLink/AArch32/ELF_stubs_arm.s
@@ -27,7 +27,7 @@
 # hard-code it in the immediate field.
 
 # The external function ext will return to the caller directly.
-# jitlink-check: decode_operand(test_arm_jump, 0) = stub_addr(out.o, ext) - (test_arm_jump + 8)
+# jitlink-check: decode_operand(test_arm_jump, 0) = stub_addr(out.o, ext) - next_pc(test_arm_jump)
 	.globl	test_arm_jump
 	.type	test_arm_jump,%function
 	.p2align	2
@@ -38,7 +38,7 @@ test_arm_jump:
 # The branch-with-link sets the LR register so that the external function ext
 # returns to us. We have to save the register (push) and return to main manually
 # (pop). This adds the +4 offset for the bl instruction we decode:
-# jitlink-check: decode_operand(test_arm_call + 4, 0) = stub_addr(out.o, ext) - (test_arm_call + 8) - 4
+# jitlink-check: decode_operand(test_arm_call + 4, 0) = stub_addr(out.o, ext) - next_pc(test_arm_call) - 4
 	.globl  test_arm_call
 	.type	test_arm_call,%function
 	.p2align	2

--- a/llvm/test/ExecutionEngine/JITLink/AArch32/ELF_stubs_multi.s
+++ b/llvm/test/ExecutionEngine/JITLink/AArch32/ELF_stubs_multi.s
@@ -13,7 +13,7 @@
 # ascending size (because the default memory manager lays out blocks by size).
 
 # Thumb relocation site emits thumb stub
-# jitlink-check: decode_operand(test_stub_thumb, 0) = stub_addr(out.o, ext, thumb) - (test_stub_thumb + 4)
+# jitlink-check: decode_operand(test_stub_thumb, 0) = stub_addr(out.o, ext, thumb) - next_pc(test_stub_thumb)
 	.globl  test_stub_thumb
 	.type	test_stub_thumb,%function
 	.p2align	1
@@ -24,7 +24,7 @@ test_stub_thumb:
 	.size	test_stub_thumb, .-test_stub_thumb
 
 # Arm relocation site emits arm stub
-# jitlink-check: decode_operand(test_stub_arm, 0) = stub_addr(out.o, ext, arm) - (test_stub_arm + 8)
+# jitlink-check: decode_operand(test_stub_arm, 0) = stub_addr(out.o, ext, arm) - next_pc(test_stub_arm)
 	.globl  test_stub_arm
 	.type	test_stub_arm,%function
 	.p2align	2


### PR DESCRIPTION
In ARM mode, the Program Counter (PC) points to the current instruction's
address + 8 instead of + 4. This offset is added to RuntimeDyldChecker to
use `next_pc` expression in JITLink tests.
