### PR TITLE
[CodeGen] Use SmallVector for FixedStackPSVs

### DIFF
--- a/llvm/include/llvm/CodeGen/PseudoSourceValueManager.h
+++ b/llvm/include/llvm/CodeGen/PseudoSourceValueManager.h
@@ -13,10 +13,10 @@
 #ifndef LLVM_CODEGEN_PSEUDOSOURCEVALUEMANAGER_H
 #define LLVM_CODEGEN_PSEUDOSOURCEVALUEMANAGER_H
 
+#include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringMap.h"
 #include "llvm/CodeGen/PseudoSourceValue.h"
 #include "llvm/IR/ValueMap.h"
-#include <map>
 
 namespace llvm {
 
@@ -27,7 +27,7 @@ class TargetMachine;
 class PseudoSourceValueManager {
   const TargetMachine &TM;
   const PseudoSourceValue StackPSV, GOTPSV, JumpTablePSV, ConstantPoolPSV;
-  std::map<int, std::unique_ptr<FixedStackPseudoSourceValue>> FSValues;
+  SmallVector<std::unique_ptr<FixedStackPseudoSourceValue>> FSValues;
   StringMap<std::unique_ptr<const ExternalSymbolPseudoSourceValue>>
       ExternalCallEntries;
   ValueMap<const GlobalValue *,

--- a/llvm/lib/CodeGen/PseudoSourceValue.cpp
+++ b/llvm/lib/CodeGen/PseudoSourceValue.cpp
@@ -124,7 +124,7 @@ const PseudoSourceValue *
 PseudoSourceValueManager::getFixedStack(int FI) {
   // Frame index is often continuously positive, but can be negative. Use
   // zig-zag encoding for dense index into FSValues vector.
-  unsigned Idx = FI >= 0 ? FI << 1 : (-FI - 1) << 1 | 1;
+  unsigned Idx = (2 * unsigned(FI)) ^ (FI >> (sizeof(FI) * 8 - 1));
   if (FSValues.size() <= Idx)
     FSValues.resize(Idx + 1);
   std::unique_ptr<FixedStackPseudoSourceValue> &V = FSValues[Idx];

--- a/llvm/lib/CodeGen/PseudoSourceValue.cpp
+++ b/llvm/lib/CodeGen/PseudoSourceValue.cpp
@@ -122,7 +122,12 @@ const PseudoSourceValue *PseudoSourceValueManager::getJumpTable() {
 
 const PseudoSourceValue *
 PseudoSourceValueManager::getFixedStack(int FI) {
-  std::unique_ptr<FixedStackPseudoSourceValue> &V = FSValues[FI];
+  // Frame index is often continuously positive, but can be negative. Use
+  // zig-zag encoding for dense index into FSValues vector.
+  unsigned Idx = FI >= 0 ? FI << 1 : (-FI - 1) << 1 | 1;
+  if (FSValues.size() <= Idx)
+    FSValues.resize(Idx + 1);
+  std::unique_ptr<FixedStackPseudoSourceValue> &V = FSValues[Idx];
   if (!V)
     V = std::make_unique<FixedStackPseudoSourceValue>(FI, TM);
   return V.get();


### PR DESCRIPTION
Frame indices are dense and consecutive, so use a vector instead of a std::map. Due to possibly negative frame indices, use zig-zag encoding. IndexedMap was not usable, as it attempted to copy the null value, which is not possible with a std::unique_ptr.

This is just a minor performance improvement, but a low-hanging fruit.