### PR TITLE
Cope with MCOperand null Insts

### DIFF
--- a/llvm/lib/MC/MCInst.cpp
+++ b/llvm/lib/MC/MCInst.cpp
@@ -38,7 +38,10 @@ void MCOperand::print(raw_ostream &OS, const MCRegisterInfo *RegInfo) const {
     OS << "Expr:(" << *getExpr() << ")";
   } else if (isInst()) {
     OS << "Inst:(";
-    getInst()->print(OS, RegInfo);
+    if (const auto *Inst = getInst())
+      Inst->print(OS, RegInfo);
+    else
+      OS << "NULL";
     OS << ")";
   } else
     OS << "UNDEFINED";


### PR DESCRIPTION
I encountered a bolt segfault due to an MCOperand of type Inst with a null pointer.  It seems bolt is intentionally creating such operands, so it would be good for the printer to not barf on them.

The bolt code is bolt/include/bolt/Core/MCPlusBuilder.h where the annotation machinery is.  For example line 131 in setAnnotationOpValue: 
`      Inst.addOperand(MCOperand::createInst(nullptr));`

In my case it was annotating an X86 JCC instruction, and using --debug crashed.

