### PR TITLE
[mlir] `int-range-optmizations`: Fix referencing of deleted ops

### DIFF
--- a/mlir/include/mlir/Analysis/DataFlowFramework.h
+++ b/mlir/include/mlir/Analysis/DataFlowFramework.h
@@ -242,6 +242,17 @@ public:
     return static_cast<const StateT *>(it->second.get());
   }
 
+  /// Erase any analysis state associated with the given program point.
+  template <typename PointT>
+  void eraseState(PointT point) {
+    ProgramPoint pp(point);
+
+    for (auto it = analysisStates.begin(); it != analysisStates.end(); ++it) {
+      if (it->first.first == pp)
+        analysisStates.erase(it);
+    }
+  }
+
   /// Get a uniqued program point instance. If one is not present, it is
   /// created with the provided arguments.
   template <typename PointT, typename... Args>


### PR DESCRIPTION
The pass runs a `DataFlowSolver` and collects state information on the input IR. Then, the rewrite driver and folding is applied. During pattern application and folding it can happen that an Op from the input IR is deleted and a new Op is created at the same address. When the newly created Ops is looked up in the `DataFlowSolver` state memory, the state of the original Op is returned.

This patch adds a method to `DataFlowSolver` which removes all state related to a `ProgramPoint`. It also adds a listener to the Pass which clears the state information of deleted Ops from the `DataFlowSolver`.

This doesn't seem like the prettiest solution, maybe someone can advise on how to fix this in a nicer way? This pattern of using a `DataFlowSolver` throughout a pass with multiple pattern applications/foldings happens in other Passes, too. So it seems worth to find a proper solution for this. The bugs and crashes resulting from this are elusive and annoying to debug because they are dependent on how things are allocated.

Fix https://github.com/llvm/llvm-project/issues/81228