### PR TITLE
Improve performance of .debug_names lookups when DW_IDX_parent attributes are used

### DIFF
--- a/lldb/source/Plugins/SymbolFile/DWARF/DebugNamesDWARFIndex.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DebugNamesDWARFIndex.cpp
@@ -83,6 +83,10 @@ bool DebugNamesDWARFIndex::ProcessEntry(
   DWARFDIE die = dwarf.GetDIE(*ref);
   if (!die)
     return true;
+  // Watch out for forward declarations that appear in the .debug_names tables
+  // only due to being there for a DW_IDX_parent.
+  if (die.GetAttributeValueAsUnsigned(DW_AT_declaration, 0))
+    return true;
   return callback(die);
 }
 

--- a/lldb/source/Plugins/SymbolFile/DWARF/DebugNamesDWARFIndex.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DebugNamesDWARFIndex.cpp
@@ -83,8 +83,8 @@ bool DebugNamesDWARFIndex::ProcessEntry(
   DWARFDIE die = dwarf.GetDIE(*ref);
   if (!die)
     return true;
-  // Watch out for forward declarations that appear in the .debug_names tables
-  // only due to being there for a DW_IDX_parent.
+  // Clang erroneously emits index entries for declaration DIEs in case when the
+  // definition is in a type unit (llvm.org/pr77696). Weed those out.
   if (die.GetAttributeValueAsUnsigned(DW_AT_declaration, 0))
     return true;
   return callback(die);


### PR DESCRIPTION
When a .debug_names table has entries that use the DW_IDX_parent attributes, we can end up with entries in the .debug_names table that are not full definitions. This is because a class that is foward declared, can contain types. For example:
```
0x0090cdbf: DW_TAG_compile_unit
              DW_AT_producer	("clang version 15.0.7")
              DW_AT_language	(DW_LANG_C_plus_plus_14)
              DW_AT_name	("UniqueInstance.cpp")

0x0090cdc7:   DW_TAG_namespace
                DW_AT_name	("std")

0x0090cdd5:     DW_TAG_class_type
                  DW_AT_name	("ios_base")
                  DW_AT_declaration	(true)

0x0090cdd7:       DW_TAG_class_type
                    DW_AT_name	("Init")
                    DW_AT_declaration	(true)

0x0090cdda:       DW_TAG_typedef
                    DW_AT_type	(0x0090ce4e "std::_Ios_Seekdir")
                    DW_AT_name	("seekdir")
                    DW_AT_decl_file	(0x11)
                    DW_AT_decl_line	(479)

0x0090cde4:       DW_TAG_typedef
                    DW_AT_type	(0x0090ce45 "std::_Ios_Openmode")
                    DW_AT_name	("openmode")
                    DW_AT_decl_file	(0x11)
                    DW_AT_decl_line	(447)

0x0090cdee:       DW_TAG_typedef
                    DW_AT_type	(0x0090ce3c "std::_Ios_Iostate")
                    DW_AT_name	("iostate")
                    DW_AT_decl_file	(0x11)
                    DW_AT_decl_line	(416)

0x0090cdf8:       NULL
```

"std::ios_base" is forward declared and it contains typedefs whose entries in the .debug_names table will point to the DIE at offset 0x0090cdd5. These entries cause our type lookups to try and parse a TON of forward declarations and waste time and resources.

This fix makes sure when/if we find an entry in the .debug_names table, we don't process it if it has a DW_AT_declaration(true) attribute.