### PR TITLE
[workflows] Add a job for requesting a release note on release branch PRs

### DIFF
--- a/.github/workflows/pr-request-release-note.yml
+++ b/.github/workflows/pr-request-release-note.yml
@@ -1,0 +1,43 @@
+name: PR Request Release Note
+
+permissions:
+  contents: read
+  pull-requests: write
+
+on:
+  pull_request:
+    types:
+      - closed
+
+jobs:
+  request-release-note:
+    if: >-
+      github.repository_owner == 'llvm' &&
+      startsWith(github.ref, 'refs/heads/release')
+
+    runs-on: ubuntu-latest
+    steps:
+      # We need to pull the script from the main branch, so that we ensure
+      # we get the latest version of this script.
+      - name: Checkout Scripts
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        with:
+          sparse-checkout: |
+            llvm/utils/git/requirements.txt
+            llvm/utils/git/github-automation.py
+          sparse-checkout-cone-mode: false
+
+      - name: Install Dependencies
+        run: |
+          pip install -r llvm/utils/git/requirements.txt
+
+      - name: Request Release Note
+        env:
+          # We need to use an llvmbot token here, because we are mentioning a user.
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          python3 llvm/utils/git/github-automation.py \
+            --repo "$GITHUB_REPOSITORY" \
+            --token "$GITHUB_TOKEN" \
+            request-release-note \
+            --pr-number ${{ github.event.pull_request.number}}

--- a/llvm/utils/git/github-automation.py
+++ b/llvm/utils/git/github-automation.py
@@ -641,16 +641,16 @@ def request_release_note(token:str, repo_name:str, pr_number:int):
     repo = github.Github(token).get_repo(repo_name)
     pr = repo.get_issue(pr_number).as_pull_request()
     submitter = pr.user.login
-    if submitter == 'llvmbot':
+    if submitter == "llvmbot":
         m = re.search("Requested by: @(.+)$", pr.body)
         if not m:
             submitter = None
             print("Warning could not determine user who requested backport.")
         submitter = m.group(1)
 
-    mention = ''
+    mention = ""
     if submitter:
-        mention = f'@{submitter}'
+        mention = f"@{submitter}"
 
     comment = f"{mention} (or anyone else). If you would like to add a note about this fix in the release notes (completely optional). Please reply to this comment with a one or two sentence description of the fix.  When you are done, please add the release:note label to this PR. "
     pr.as_issue().create_comment(comment)

--- a/llvm/utils/git/github-automation.py
+++ b/llvm/utils/git/github-automation.py
@@ -637,7 +637,7 @@ class ReleaseWorkflow:
         return False
 
 
-def request_release_note(token:str, repo_name:str, pr_number:int):
+def request_release_note(token: str, repo_name: str, pr_number: int):
     repo = github.Github(token).get_repo(repo_name)
     pr = repo.get_issue(pr_number).as_pull_request()
     submitter = pr.user.login

--- a/llvm/utils/git/github-automation.py
+++ b/llvm/utils/git/github-automation.py
@@ -637,6 +637,25 @@ class ReleaseWorkflow:
         return False
 
 
+def request_release_note(token:str, repo_name:str, pr_number:int):
+    repo = github.Github(token).get_repo(repo_name)
+    pr = repo.get_issue(pr_number).as_pull_request()
+    submitter = pr.user.login
+    if submitter == 'llvmbot':
+        m = re.search("Requested by: @(.+)$", pr.body)
+        if not m:
+            submitter = None
+            print("Warning could not determine user who requested backport.")
+        submitter = m.group(1)
+
+    mention = ''
+    if submitter:
+        mention = f'@{submitter}'
+
+    comment = f"{mention} (or anyone else). If you would like to add a note about this fix in the release notes (completely optional). Please reply to this comment with a one or two sentence description of the fix.  When you are done, please add the release:note label to this PR. "
+    pr.as_issue().create_comment(comment)
+
+
 parser = argparse.ArgumentParser()
 parser.add_argument(
     "--token", type=str, required=True, help="GitHub authentication token"
@@ -703,6 +722,18 @@ release_workflow_parser.add_argument(
     help="The user that requested this backport",
 )
 
+request_release_note_parser = subparsers.add_parser(
+    "request-release-note",
+    help="Request a release note for a pull request",
+)
+request_release_note_parser.add_argument(
+    "--pr-number",
+    type=int,
+    required=True,
+    help="The pull request to request the release note",
+)
+
+
 args = parser.parse_args()
 
 if args.command == "issue-subscriber":
@@ -743,3 +774,5 @@ elif args.command == "release-workflow":
             sys.exit(1)
 elif args.command == "setup-llvmbot-git":
     setup_llvmbot_git()
+elif args.command == "request-release-note":
+    request_release_note(args.token, args.repo, args.pr_number)


### PR DESCRIPTION
We have been collecting release notes from the PRs for most of the 18.1.x releases and this just helps automate the process.