### PR TITLE
[libc++] Use remove_pointer builtin as library traits

### DIFF
--- a/libcxx/include/__type_traits/remove_pointer.h
+++ b/libcxx/include/__type_traits/remove_pointer.h
@@ -22,9 +22,6 @@ template <class _Tp>
 struct remove_pointer {
   using type _LIBCPP_NODEBUG = __remove_pointer(_Tp);
 };
-
-template <class _Tp>
-using __remove_pointer_t = __remove_pointer(_Tp);
 #else
 // clang-format off
 template <class _Tp> struct _LIBCPP_TEMPLATE_VIS remove_pointer                      {typedef _LIBCPP_NODEBUG _Tp type;};
@@ -33,10 +30,10 @@ template <class _Tp> struct _LIBCPP_TEMPLATE_VIS remove_pointer<_Tp* const>     
 template <class _Tp> struct _LIBCPP_TEMPLATE_VIS remove_pointer<_Tp* volatile>       {typedef _LIBCPP_NODEBUG _Tp type;};
 template <class _Tp> struct _LIBCPP_TEMPLATE_VIS remove_pointer<_Tp* const volatile> {typedef _LIBCPP_NODEBUG _Tp type;};
 // clang-format on
+#endif // !defined(_LIBCPP_WORKAROUND_OBJCXX_COMPILER_INTRINSICS) && __has_builtin(__remove_pointer)
 
 template <class _Tp>
 using __remove_pointer_t = typename remove_pointer<_Tp>::type;
-#endif // !defined(_LIBCPP_WORKAROUND_OBJCXX_COMPILER_INTRINSICS) && __has_builtin(__remove_pointer)
 
 #if _LIBCPP_STD_VER >= 14
 template <class _Tp>


### PR DESCRIPTION
In new GCC release (such as 14.1), a new warning is added that
all traits are not to be used directly but library traits.

Keep the same structure with gcc's library traits to prevent future
issues.

see https://github.com/gcc-mirror/gcc/blob/master/libstdc%2B%2B-v3/include/std/type_traits#L2105
and https://github.com/gcc-mirror/gcc/blob/master/libstdc%2B%2B-v3/include/std/type_traits#L2146.

Fixes #91831.
