### PR TITLE
[clang] visit constraint of NTTP

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -707,6 +707,7 @@ Bug Fixes to C++ Support
   initialized, rather than evaluating them as a part of the larger manifestly constant evaluated
   expression.
 - Fix a bug in access control checking due to dealyed checking of friend declaration. Fixes (#GH12361).
+- Fix a bug on template class partial specialization due to traverse of constraint of NTTP. Fixes (#GH77377).
 
 Bug Fixes to AST Handling
 ^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/clang/lib/AST/StmtProfile.cpp
+++ b/clang/lib/AST/StmtProfile.cpp
@@ -2257,6 +2257,10 @@ void StmtProfiler::VisitSubstNonTypeTemplateParmExpr(
     const SubstNonTypeTemplateParmExpr *E) {
   // Profile exactly as the replacement expression.
   Visit(E->getReplacement());
+  if (auto *NTTP = dyn_cast<NonTypeTemplateParmDecl>(E->getParameter());
+      NTTP && NTTP->getPlaceholderTypeConstraint()) {
+    Visit(NTTP->getPlaceholderTypeConstraint());
+  }
 }
 
 void StmtProfiler::VisitFunctionParmPackExpr(const FunctionParmPackExpr *S) {

--- a/clang/test/CXX/temp/temp.decls/temp.fct/temp.func.order/p6.cpp
+++ b/clang/test/CXX/temp/temp.decls/temp.fct/temp.func.order/p6.cpp
@@ -79,14 +79,14 @@ template<C     T, int I> struct Y2<T*, I, I+1+1> {}; // expected-note {{partial 
 template<C T, C auto I, int W, A S, template<typename, auto, int, A, typename...> class U, typename... Z>
 struct Y3 { Y3()=delete; };
 template<C T, D auto I, int W, A S, template<typename, auto, int, A, typename...> class U, typename... Z>
-struct Y3<T, I, W, S, U, Z...> { Y3()=delete; };
+struct Y3<T, I, W, S, U, Z...> { Y3()=delete; }; // expected-note {{partial specialization matches [with T = int, I = 1, W = 1, S = A{}, U = S, Z = <int>]}}
 template<C T, E auto I, int W, A S, template<typename, auto, int, A, typename...> class U, typename... Z>
-struct Y3<T, I, W, S, U, Z...> {};
+struct Y3<T, I, W, S, U, Z...> {}; // expected-note {{partial specialization matches [with T = int, I = 1, W = 1, S = A{}, U = S, Z = <int>]}}
 
 void f() {
   Y1<int, 2> a;
   Y2<char*, 1, 3> b; // expected-error {{ambiguous partial specializations}}
-  Y3<int, 1, 1, A{}, S, int> c;
+  Y3<int, 1, 1, A{}, S, int> c; // expected-error {{ambiguous partial specializations of 'Y3<int, 1, 1, A{}, S, int>'}}
 }
 
 // Per [temp.func.order]p6.2.2, specifically "if the function parameters that

--- a/clang/test/SemaCXX/PR77377.cpp
+++ b/clang/test/SemaCXX/PR77377.cpp
@@ -1,0 +1,19 @@
+// RUN: %clang_cc1 -verify -std=c++20 -fsyntax-only %s
+// expected-no-diagnostics
+
+template<typename T, typename U>
+constexpr bool is_same_v = false;
+
+template<typename T>
+constexpr bool is_same_v<T, T> = true;
+
+template<typename T, typename U>
+concept same_as = is_same_v<T, U>;
+
+template <auto>
+struct A {};
+
+template <same_as<int> auto p>
+struct A<p> {};
+
+A<0> a;


### PR DESCRIPTION
attempt to fix https://github.com/llvm/llvm-project/issues/77377
`isSameTemplateArg` returns incorrect result since clang didn't visit constraint of NTTP. Furthermore,  It makes class template partial specialization not more specialized than the class template itself.