### PR TITLE
[Codegen] (NFC) Faster algorithm for MachineBlockPlacement

### DIFF
--- a/llvm/lib/CodeGen/MachineBlockPlacement.cpp
+++ b/llvm/lib/CodeGen/MachineBlockPlacement.cpp
@@ -3157,11 +3157,8 @@ bool MachineBlockPlacement::maybeTailDuplicateBlock(
         }
 
         // Handle the filter set
-        if (BlockFilter) {
-          if (*PrevUnplacedBlockInFilterIt == RemBB)
-            PrevUnplacedBlockInFilterIt++;
+        if (BlockFilter)
           BlockFilter->remove(RemBB);
-        }
 
         // Remove the block from loop info.
         MLI->removeBlock(RemBB);

--- a/llvm/lib/CodeGen/MachineBlockPlacement.cpp
+++ b/llvm/lib/CodeGen/MachineBlockPlacement.cpp
@@ -3158,9 +3158,9 @@ bool MachineBlockPlacement::maybeTailDuplicateBlock(
 
         // Handle the filter set
         if (BlockFilter) {
-          BlockFilter->remove(RemBB);
           if (*PrevUnplacedBlockInFilterIt == RemBB)
             PrevUnplacedBlockInFilterIt++;
+          BlockFilter->remove(RemBB);
         }
 
         // Remove the block from loop info.

--- a/llvm/lib/CodeGen/MachineBlockPlacement.cpp
+++ b/llvm/lib/CodeGen/MachineBlockPlacement.cpp
@@ -3159,11 +3159,17 @@ bool MachineBlockPlacement::maybeTailDuplicateBlock(
         // Handle the filter set
         if (BlockFilter) {
           auto It = llvm::find(*BlockFilter, RemBB);
+          // Erase RemBB from BlockFilter, and keep PrevUnplacedBlockInFilterIt
+          // pointing to the same element as before.
           if (It != BlockFilter->end()) {
             if (It < PrevUnplacedBlockInFilterIt) {
+              // BlockFilter is a SmallVector so all elements after RemBB are
+              // shifted to the front by 1 after its deletion.
               auto Distance = PrevUnplacedBlockInFilterIt - It - 1;
               PrevUnplacedBlockInFilterIt = BlockFilter->erase(It) + Distance;
             } else if (It == PrevUnplacedBlockInFilterIt)
+              // The block pointed by PrevUnplacedBlockInFilterIt is erased, we
+              // have to set it to the next element.
               PrevUnplacedBlockInFilterIt = BlockFilter->erase(It);
             else
               BlockFilter->erase(It);


### PR DESCRIPTION
In MachineBlockPlacement, the function getFirstUnplacedBlock is inefficient because in most cases (for usual loop CFG), this function fails to find a candidate, and its complexity becomes O(#(loops in function) * #(blocks in function)). This makes the compilation of very long functions slow. This update reduces it to O(k * #(blocks in function)) where k is the maximum loop nesting depth, by iterating through the BlockFilter instead.