### PR TITLE
[mlir] Fix warning due to non ISO standard __FUNCTION__ usage

### DIFF
--- a/mlir/test/CAPI/transform_interpreter.c
+++ b/mlir/test/CAPI/transform_interpreter.c
@@ -18,7 +18,7 @@
 #include <stdlib.h>
 
 int testApplyNamedSequence(MlirContext ctx) {
-  fprintf(stderr, "%s\n", __FUNCTION__);
+  fprintf(stderr, "%s\n", __func__);
 
   const char module[] =
       "module attributes {transform.with_named_sequence} {"


### PR DESCRIPTION
This PR fixes the warning message due to the non ISO standard usage of `__FUNCTION__`

```
/home/lewuathe/llvm-project/mlir/test/CAPI/transform_interpreter.c: In function ‘testApplyNamedSequence’:
/home/lewuathe/llvm-project/mlir/test/CAPI/transform_interpreter.c:21:27: warning: ISO C does not support ‘__FUNCTION__’ predefined identifier [-Wpedantic]
   21 |   fprintf(stderr, "%s\n", __FUNCTION__);
      |  
```

As `__FUNCTION__` is another name of `__func__` and it conforms to the specification. We should be able to use `__func__` here.  

Ref: https://stackoverflow.com/questions/52962812/how-to-silence-gcc-pedantic-wpedantic-warning-regarding-function


Compiler

```
Ubuntu clang version 18.1.3 (1)
Target: x86_64-pc-linux-gnu
```