### PR TITLE
[test]: fix filecheck annotation typos

### DIFF
--- a/polly/test/CodeGen/alias_metadata_too_many_arrays.ll
+++ b/polly/test/CodeGen/alias_metadata_too_many_arrays.ll
@@ -16,7 +16,7 @@
 ;      }
 ;    }
 ;
-; CHECK-LABEL @manyarrays
+; CHECK-LABEL: @manyarrays
 ; CHECK: load{{.*}}!alias.scope
 ; CHECK: store{{.*}}!alias.scope
 ; CHECK: load{{.*}}!alias.scope


### PR DESCRIPTION
Similar to https://github.com/rust-lang/rust/pull/125007

This fixes few filecheck annotation typos across llvm repo.

i **did not** checked if it passes test after that, so some help appreciated.

Feel free to copy fixes into separate pr and merge it if it will be simpler, than describe what need to be fixed there.