### PR TITLE
[clang][driver] add pointer qualifier to auto type

### DIFF
--- a/clang/lib/Driver/Action.cpp
+++ b/clang/lib/Driver/Action.cpp
@@ -246,8 +246,8 @@ void OffloadAction::doOnHostDependence(const OffloadActionWorkTy &Work) const {
 
 void OffloadAction::doOnEachDeviceDependence(
     const OffloadActionWorkTy &Work) const {
-  auto I = getInputs().begin();
-  auto E = getInputs().end();
+  auto *I = getInputs().begin();
+  auto *E = getInputs().end();
   if (I == E)
     return;
 
@@ -261,7 +261,7 @@ void OffloadAction::doOnEachDeviceDependence(
   if (HostTC)
     ++I;
 
-  auto TI = DevToolChains.begin();
+  auto *TI = DevToolChains.begin();
   for (; I != E; ++I, ++TI)
     Work(*I, *TI, (*I)->getOffloadingArch());
 }


### PR DESCRIPTION
Fix an LLVM coding standards inconformity by adding pointer qualifiers to `auto`-typed variables that deduce to pointer types.

See what the coding standards state [here](https://llvm.org/docs/CodingStandards.html#beware-unnecessary-copies-with-auto).