### PR TITLE
[lldb] Fix redundant condition in Target.cpp

### DIFF
--- a/lldb/source/Target/Target.cpp
+++ b/lldb/source/Target/Target.cpp
@@ -841,12 +841,14 @@ static bool CheckIfWatchpointsSupported(Target *target, Status &error) {
   if (!num_supported_hardware_watchpoints)
     return true;
 
-  if (num_supported_hardware_watchpoints == 0) {
-    error.SetErrorStringWithFormat(
-        "Target supports (%u) hardware watchpoint slots.\n",
-        *num_supported_hardware_watchpoints);
-    return false;
-  }
+  // If num_supported_hardware_watchpoints is zero, set an 
+  //error message and return false.
+
+  error.SetErrorStringWithFormat(
+      "Target supports (%u) hardware watchpoint slots.\n",
+      *num_supported_hardware_watchpoints);
+  return false;
+  
   return true;
 }
 

--- a/lldb/source/Target/Target.cpp
+++ b/lldb/source/Target/Target.cpp
@@ -841,14 +841,12 @@ static bool CheckIfWatchpointsSupported(Target *target, Status &error) {
   if (!num_supported_hardware_watchpoints)
     return true;
 
-  // If num_supported_hardware_watchpoints is zero, set an 
-  //error message and return false.
-
-  error.SetErrorStringWithFormat(
-      "Target supports (%u) hardware watchpoint slots.\n",
-      *num_supported_hardware_watchpoints);
-  return false;
-  
+  if (*num_supported_hardware_watchpoints == 0) {
+    error.SetErrorStringWithFormat(
+        "Target supports (%u) hardware watchpoint slots.\n",
+        *num_supported_hardware_watchpoints);
+    return false;
+  }
   return true;
 }
 


### PR DESCRIPTION
This commit addresses issue #87244, where a redundant condition was found in the Target.cpp file. Static analyzer cppcheck flagged the issue in the Target.cpp file
fix #87244 