### PR TITLE
[lldb] Fixed the test TestQuoting

### DIFF
--- a/lldb/test/API/commands/settings/quoting/TestQuoting.py
+++ b/lldb/test/API/commands/settings/quoting/TestQuoting.py
@@ -51,9 +51,7 @@ class SettingsCommandTestCase(TestBase):
         outfile = self.getBuildArtifact(filename)
 
         if lldb.remote_platform:
-            outfile_arg = lldbutil.append_to_process_working_directory(
-                self, filename
-            )
+            outfile_arg = lldbutil.append_to_process_working_directory(self, filename)
         else:
             outfile_arg = outfile
 

--- a/lldb/test/API/commands/settings/quoting/TestQuoting.py
+++ b/lldb/test/API/commands/settings/quoting/TestQuoting.py
@@ -51,8 +51,8 @@ class SettingsCommandTestCase(TestBase):
         outfile = self.getBuildArtifact(filename)
 
         if lldb.remote_platform:
-            outfile_arg = os.path.join(
-                lldb.remote_platform.GetWorkingDirectory(), filename
+            outfile_arg = lldbutil.append_to_process_working_directory(
+                self, filename
             )
         else:
             outfile_arg = outfile


### PR DESCRIPTION
os.path.join() uses the path separator of the host OS by default. outfile_arg will be incorrect in case of Windows host and Linux target. Use lldbutil.append_to_process_working_directory() instead.