### PR TITLE
[lldb][Windows] Enforce exec permission using Platform::Install() from Windows host

### DIFF
--- a/lldb/source/Target/Platform.cpp
+++ b/lldb/source/Target/Platform.cpp
@@ -1225,11 +1225,7 @@ Status Platform::PutFile(const FileSpec &source, const FileSpec &destination,
 
   uint32_t permissions = source_file.get()->GetPermissions(error);
   if (permissions == 0)
-    permissions = lldb::eFilePermissionsFileDefault;
-
-#if defined(_WIN32)
-  permissions |= lldb::eFilePermissionsUserExecute;
-#endif
+    permissions = lldb::eFilePermissionsUserRWX;
 
   lldb::user_id_t dest_file = OpenFile(
       destination, File::eOpenOptionCanCreate | File::eOpenOptionWriteOnly |

--- a/lldb/source/Target/Platform.cpp
+++ b/lldb/source/Target/Platform.cpp
@@ -1227,6 +1227,10 @@ Status Platform::PutFile(const FileSpec &source, const FileSpec &destination,
   if (permissions == 0)
     permissions = lldb::eFilePermissionsFileDefault;
 
+#if defined(_WIN32)
+  permissions |= lldb::eFilePermissionsUserExecute;
+#endif
+
   lldb::user_id_t dest_file = OpenFile(
       destination, File::eOpenOptionCanCreate | File::eOpenOptionWriteOnly |
                        File::eOpenOptionTruncate | File::eOpenOptionCloseOnExec,


### PR DESCRIPTION
Target::Install() set 0700 permissions for the main executable file. Platform::Install() just copies permissions from the source. But the permission eFilePermissionsUserExecute is missing on the Windows host. A lot of tests failed in case of Windows host and Linux target because of this issue. There is no API to provide the exec flag. This patch set the permission eFilePermissionsUserExecute for all files installed via Platform::Install() from the Windows host. It fixes a lot of tests in case of Windows host and Linux target.