### PR TITLE
[CodeGen] Revert "Generate assume loads only with -fstrict-vtable-pointers"

### DIFF
--- a/clang/lib/CodeGen/CGClass.cpp
+++ b/clang/lib/CodeGen/CGClass.cpp
@@ -2258,12 +2258,9 @@ void CodeGenFunction::EmitCXXConstructorCall(const CXXConstructorDecl *D,
   // FIXME: If vtable is used by ctor/dtor, or if vtable is external and we are
   // sure that definition of vtable is not hidden,
   // then we are always safe to refer to it.
-  // FIXME: It looks like InstCombine is very inefficient on dealing with
-  // assumes. Make assumption loads require -fstrict-vtable-pointers temporarily.
   if (CGM.getCodeGenOpts().OptimizationLevel > 0 &&
       ClassDecl->isDynamicClass() && Type != Ctor_Base &&
-      CGM.getCXXABI().canSpeculativelyEmitVTable(ClassDecl) &&
-      CGM.getCodeGenOpts().StrictVTablePointers)
+      CGM.getCXXABI().canSpeculativelyEmitVTable(ClassDecl))
     EmitVTableAssumptionLoads(ClassDecl, This);
 }
 

--- a/clang/test/CodeGenCXX/vtable-assume-load-address-space.cpp
+++ b/clang/test/CodeGenCXX/vtable-assume-load-address-space.cpp
@@ -1,5 +1,4 @@
-// RUN: %clang_cc1 %s -triple=amdgcn-amd-amdhsa -std=c++11 -emit-llvm -o %t.ll -O1 -disable-llvm-passes -fms-extensions -fstrict-vtable-pointers
-// FIXME: Assume load should not require -fstrict-vtable-pointers
+// RUN: %clang_cc1 %s -triple=amdgcn-amd-amdhsa -std=c++11 -emit-llvm -o %t.ll -O1 -disable-llvm-passes -fms-extensions
 
 // RUN: FileCheck --check-prefix=CHECK1 --input-file=%t.ll %s
 // RUN: FileCheck --check-prefix=CHECK2 --input-file=%t.ll %s

--- a/clang/test/CodeGenCXX/vtable-assume-load.cpp
+++ b/clang/test/CodeGenCXX/vtable-assume-load.cpp
@@ -1,6 +1,5 @@
-// RUN: %clang_cc1 %s -triple x86_64-apple-darwin10 -emit-llvm -o %t.ll -O1 -disable-llvm-passes -fms-extensions -fstrict-vtable-pointers
-// RUN: %clang_cc1 %s -triple i686-pc-win32 -emit-llvm -o %t.ms.ll -O1 -disable-llvm-passes -fms-extensions -fstrict-vtable-pointers
-// FIXME: Assume load should not require -fstrict-vtable-pointers
+// RUN: %clang_cc1 %s -triple x86_64-apple-darwin10 -emit-llvm -o %t.ll -O1 -disable-llvm-passes -fms-extensions
+// RUN: %clang_cc1 %s -triple i686-pc-win32 -emit-llvm -o %t.ms.ll -O1 -disable-llvm-passes -fms-extensions
 
 // RUN: FileCheck --check-prefix=CHECK1 --input-file=%t.ll %s
 // RUN: FileCheck --check-prefix=CHECK2 --input-file=%t.ll %s


### PR DESCRIPTION
This reverts commit 69dc971527faad8ccfa754ce7d855908b7a3f923.

This was supposed to be a temporary measure, but unfortunately as things tend to go in software development, temporary measures become permanent.

In the 9 years since then, we have greatly improved the way InstCombine works with assumes.

So, let's not make assumption loads require -fstrict-vtable-pointers.