### PR TITLE
[StringMap] Move free into StringMapImpl dtor (NFC)

### DIFF
--- a/llvm/include/llvm/ADT/StringMap.h
+++ b/llvm/include/llvm/ADT/StringMap.h
@@ -53,6 +53,7 @@ protected:
   }
 
   StringMapImpl(unsigned InitSize, unsigned ItemSize);
+  ~StringMapImpl() { free(TheTable); }
   unsigned RehashTable(unsigned BucketNo = 0);
 
   /// LookupBucketFor - Look up the bucket that the specified string should end
@@ -203,7 +204,6 @@ public:
         }
       }
     }
-    free(TheTable);
   }
 
   using AllocTy::getAllocator;


### PR DESCRIPTION
StringMapImpl allocates the memory for the table, but does not have a dtor that free it. Instead, StringMap (which inherits from StringMapImpl) contains the free call. I don't really see a good reason why this free is performed in the "wrong" class, so move it into StringMapImpl.

(I have no motivation for this change beyond seeing this in a static analyzer report.)