### PR TITLE
[lldb] Fixed the test TestSettings when run with a remote target

### DIFF
--- a/lldb/test/API/commands/settings/TestSettings.py
+++ b/lldb/test/API/commands/settings/TestSettings.py
@@ -953,7 +953,7 @@ class SettingsCommandTestCase(TestBase):
 
         # Test OptionValueFileSpec
         self.verify_setting_value_json(
-            "platform.module-cache-directory", self.get_process_working_directory()
+            "platform.module-cache-directory", self.getBuildDir()
         )
 
         # Test OptionValueArray


### PR DESCRIPTION
The setting `platform.module-cache-directory` is a local path on the host. It cannot be set to a working directory from the remote target. This test failed in case of Windows host and Linux target because of the incompatible path. Use the local build dir instead.