### PR TITLE
[Clang] Ensure ``if consteval`` consititute an immediate function context

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -707,6 +707,7 @@ Bug Fixes to C++ Support
   initialized, rather than evaluating them as a part of the larger manifestly constant evaluated
   expression.
 - Fix a bug in access control checking due to dealyed checking of friend declaration. Fixes (#GH12361).
+- Correctly treat the compound statement of an ``if consteval`` as an immediate context. Fixes (#GH91509).
 
 Bug Fixes to AST Handling
 ^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/clang/lib/Sema/TreeTransform.h
+++ b/clang/lib/Sema/TreeTransform.h
@@ -7964,6 +7964,15 @@ TreeTransform<Derived>::TransformIfStmt(IfStmt *S) {
   // Transform the "then" branch.
   StmtResult Then;
   if (!ConstexprConditionValue || *ConstexprConditionValue) {
+    Sema::ExpressionEvaluationContext Context =
+        S->isNonNegatedConsteval()
+            ? Sema::ExpressionEvaluationContext::ImmediateFunctionContext
+            : Sema::ExpressionEvaluationContext::PotentiallyEvaluated;
+
+    EnterExpressionEvaluationContext Ctx(
+        getSema(), Context, nullptr,
+        Sema::ExpressionEvaluationContextRecord::EK_Other);
+
     Then = getDerived().TransformStmt(S->getThen());
     if (Then.isInvalid())
       return StmtError();
@@ -7978,6 +7987,15 @@ TreeTransform<Derived>::TransformIfStmt(IfStmt *S) {
   // Transform the "else" branch.
   StmtResult Else;
   if (!ConstexprConditionValue || !*ConstexprConditionValue) {
+    Sema::ExpressionEvaluationContext Context =
+        S->isNegatedConsteval()
+            ? Sema::ExpressionEvaluationContext::ImmediateFunctionContext
+            : Sema::ExpressionEvaluationContext::PotentiallyEvaluated;
+
+    EnterExpressionEvaluationContext Ctx(
+        getSema(), Context, nullptr,
+        Sema::ExpressionEvaluationContextRecord::EK_Other);
+
     Else = getDerived().TransformStmt(S->getElse());
     if (Else.isInvalid())
       return StmtError();

--- a/clang/lib/Sema/TreeTransform.h
+++ b/clang/lib/Sema/TreeTransform.h
@@ -7964,14 +7964,10 @@ TreeTransform<Derived>::TransformIfStmt(IfStmt *S) {
   // Transform the "then" branch.
   StmtResult Then;
   if (!ConstexprConditionValue || *ConstexprConditionValue) {
-    Sema::ExpressionEvaluationContext Context =
-        S->isNonNegatedConsteval()
-            ? Sema::ExpressionEvaluationContext::ImmediateFunctionContext
-            : Sema::ExpressionEvaluationContext::PotentiallyEvaluated;
-
     EnterExpressionEvaluationContext Ctx(
-        getSema(), Context, nullptr,
-        Sema::ExpressionEvaluationContextRecord::EK_Other);
+        getSema(), Sema::ExpressionEvaluationContext::ImmediateFunctionContext,
+        nullptr, Sema::ExpressionEvaluationContextRecord::EK_Other,
+        S->isNonNegatedConsteval());
 
     Then = getDerived().TransformStmt(S->getThen());
     if (Then.isInvalid())
@@ -7987,14 +7983,10 @@ TreeTransform<Derived>::TransformIfStmt(IfStmt *S) {
   // Transform the "else" branch.
   StmtResult Else;
   if (!ConstexprConditionValue || !*ConstexprConditionValue) {
-    Sema::ExpressionEvaluationContext Context =
-        S->isNegatedConsteval()
-            ? Sema::ExpressionEvaluationContext::ImmediateFunctionContext
-            : Sema::ExpressionEvaluationContext::PotentiallyEvaluated;
-
     EnterExpressionEvaluationContext Ctx(
-        getSema(), Context, nullptr,
-        Sema::ExpressionEvaluationContextRecord::EK_Other);
+        getSema(), Sema::ExpressionEvaluationContext::ImmediateFunctionContext,
+        nullptr, Sema::ExpressionEvaluationContextRecord::EK_Other,
+        S->isNegatedConsteval());
 
     Else = getDerived().TransformStmt(S->getElse());
     if (Else.isInvalid())

--- a/clang/test/SemaCXX/cxx2b-consteval-propagate.cpp
+++ b/clang/test/SemaCXX/cxx2b-consteval-propagate.cpp
@@ -420,3 +420,29 @@ int f = *fn().value + fn2();  // expected-error {{call to consteval function 'lv
                               // expected-note {{pointer to heap-allocated object}}
 }
 #endif
+
+
+#if __cplusplus >= 202302L
+
+namespace GH91509 {
+
+consteval int f(int) { return 0; }
+
+template<typename T>
+constexpr int g(int x) {
+    if consteval {
+        return f(x);
+    }
+    if !consteval {}
+    else {
+        return f(x);
+    }
+    return 1;
+}
+
+int h(int x) {
+    return g<void>(x);
+}
+}
+
+#endif


### PR DESCRIPTION
We did not set the correct evaluation context for the compound statement of an ``if consteval`` statement
in a templated entity in TreeTransform.

Fixes #91509