### PR TITLE
[lldb][Windows] Disable macOS specific test for Windows host instead of Windows target

### DIFF
--- a/lldb/test/API/macosx/duplicate-archive-members/TestDuplicateMembers.py
+++ b/lldb/test/API/macosx/duplicate-archive-members/TestDuplicateMembers.py
@@ -9,7 +9,7 @@ from lldbsuite.test import lldbutil
 
 class BSDArchivesTestCase(TestBase):
     @expectedFailureAll(
-        oslist=["windows"],
+        hostoslist=["windows"],
         bugnumber="llvm.org/pr24527.  Makefile.rules doesn't know how to build static libs on Windows",
     )
     def test(self):


### PR DESCRIPTION
This test failed in case of Windows host and Linux target.