### PR TITLE
[OpenMP][MLIR] Fix llvm::sort comparator.

### DIFF
--- a/mlir/lib/Target/LLVMIR/Dialect/OpenMP/OpenMPToLLVMIRTranslation.cpp
+++ b/mlir/lib/Target/LLVMIR/Dialect/OpenMP/OpenMPToLLVMIRTranslation.cpp
@@ -2155,17 +2155,13 @@ getFirstOrLastMappedMemberPtr(mlir::omp::MapInfoOp mapInfo, bool first) {
           int aIndex = indexValues[a * shape[1] + i];
           int bIndex = indexValues[b * shape[1] + i];
 
+          if (aIndex == bIndex) continue;
+
           if (aIndex != -1 && bIndex == -1)
             return false;
 
           if (aIndex == -1 && bIndex != -1)
             return true;
-
-          if (aIndex == -1)
-            return first;
-
-          if (bIndex == -1)
-            return !first;
 
           // A is earlier in the record type layout than B
           if (aIndex < bIndex)

--- a/mlir/lib/Target/LLVMIR/Dialect/OpenMP/OpenMPToLLVMIRTranslation.cpp
+++ b/mlir/lib/Target/LLVMIR/Dialect/OpenMP/OpenMPToLLVMIRTranslation.cpp
@@ -2155,7 +2155,8 @@ getFirstOrLastMappedMemberPtr(mlir::omp::MapInfoOp mapInfo, bool first) {
           int aIndex = indexValues[a * shape[1] + i];
           int bIndex = indexValues[b * shape[1] + i];
 
-          if (aIndex == bIndex) continue;
+          if (aIndex == bIndex)
+            continue;
 
           if (aIndex != -1 && bIndex == -1)
             return false;


### PR DESCRIPTION
The current comparator doesn't work correctly when two identical entries with -1 are compared. The comparator returns `first` is case when `aIndex == -1 && bIndex == -1`, but it should `continue` as those indexes are the same.