### PR TITLE
Respect the [[clang::unsafe_buffer_usage]] attribute for field and constructor initializers

### DIFF
--- a/clang/lib/Analysis/UnsafeBufferUsage.cpp
+++ b/clang/lib/Analysis/UnsafeBufferUsage.cpp
@@ -171,6 +171,12 @@ public:
     return VisitorBase::TraverseCXXTypeidExpr(Node);
   }
 
+  bool TraverseCXXDefaultInitExpr(CXXDefaultInitExpr *Node) {
+    if (!TraverseStmt(Node->getExpr()))
+      return false;
+    return VisitorBase::TraverseCXXDefaultInitExpr(Node);
+  }
+
   bool TraverseStmt(Stmt *Node, DataRecursionQueue *Queue = nullptr) {
     if (!Node)
       return true;
@@ -3927,16 +3933,6 @@ void clang::checkUnsafeBufferUsage(const Decl *D,
         Stmts.push_back(CI->getInit());
       }
     }
-  } else if (const auto *FlD = dyn_cast<FieldDecl>(D)) {
-    // Visit in-class initializers for fields.
-    if (!FlD->hasInClassInitializer())
-      return;
-    Stmts.push_back(FlD->getInClassInitializer());
-    // In a FieldDecl there is no function body, there is only a single
-    // statement, and the suggestions machinery is not set up to handle that
-    // kind of structure yet and would give poor suggestions or likely even hit
-    // asserts.
-    EmitSuggestions = false;
   } else if (isa<BlockDecl>(D) || isa<ObjCMethodDecl>(D)) {
     Stmts.push_back(D->getBody());
   }

--- a/clang/lib/Analysis/UnsafeBufferUsage.cpp
+++ b/clang/lib/Analysis/UnsafeBufferUsage.cpp
@@ -1972,14 +1972,18 @@ public:
 };
 
 /// Scan the function and return a list of gadgets found with provided kits.
-static std::tuple<FixableGadgetList, WarningGadgetList, DeclUseTracker>
-findGadgets(const Stmt *S, ASTContext &Ctx,
-            const UnsafeBufferUsageHandler &Handler, bool EmitSuggestions) {
+static void findGadgets(const Stmt *S, ASTContext &Ctx,
+                        const UnsafeBufferUsageHandler &Handler,
+                        bool EmitSuggestions, FixableGadgetList &FixableGadgets,
+                        WarningGadgetList &WarningGadgets,
+                        DeclUseTracker &Tracker) {
 
   struct GadgetFinderCallback : MatchFinder::MatchCallback {
-    FixableGadgetList FixableGadgets;
-    WarningGadgetList WarningGadgets;
-    DeclUseTracker Tracker;
+    GadgetFinderCallback(FixableGadgetList &FixableGadgets,
+                         WarningGadgetList &WarningGadgets,
+                         DeclUseTracker &Tracker)
+        : FixableGadgets(FixableGadgets), WarningGadgets(WarningGadgets),
+          Tracker(Tracker) {}
 
     void run(const MatchFinder::MatchResult &Result) override {
       // In debug mode, assert that we've found exactly one gadget.
@@ -2020,10 +2024,14 @@ findGadgets(const Stmt *S, ASTContext &Ctx,
       assert(numFound >= 1 && "Gadgets not found in match result!");
       assert(numFound <= 1 && "Conflicting bind tags in gadgets!");
     }
+
+    FixableGadgetList &FixableGadgets;
+    WarningGadgetList &WarningGadgets;
+    DeclUseTracker &Tracker;
   };
 
   MatchFinder M;
-  GadgetFinderCallback CB;
+  GadgetFinderCallback CB{FixableGadgets, WarningGadgets, Tracker};
 
   // clang-format off
   M.addMatcher(
@@ -2069,8 +2077,6 @@ findGadgets(const Stmt *S, ASTContext &Ctx,
   }
 
   M.match(*S, Ctx);
-  return {std::move(CB.FixableGadgets), std::move(CB.WarningGadgets),
-          std::move(CB.Tracker)};
 }
 
 // Compares AST nodes by source locations.
@@ -3896,19 +3902,19 @@ void clang::checkUnsafeBufferUsage(const Decl *D,
 
   SmallVector<Stmt *> Stmts;
 
-  // We do not want to visit a Lambda expression defined inside a method
-  // independently. Instead, it should be visited along with the outer method.
-  // FIXME: do we want to do the same thing for `BlockDecl`s?
-  if (const auto *fd = dyn_cast<CXXMethodDecl>(D)) {
-    if (fd->getParent()->isLambda() && fd->getParent()->isLocalClass())
-      return;
-  }
-
-  // Do not emit fixit suggestions for functions declared in an
-  // extern "C" block.
   if (const auto *FD = dyn_cast<FunctionDecl>(D)) {
+    // We do not want to visit a Lambda expression defined inside a method
+    // independently. Instead, it should be visited along with the outer method.
+    // FIXME: do we want to do the same thing for `BlockDecl`s?
+    if (const auto *MD = dyn_cast<CXXMethodDecl>(D)) {
+      if (MD->getParent()->isLambda() && MD->getParent()->isLocalClass())
+        return;
+    }
+
     for (FunctionDecl *FReDecl : FD->redecls()) {
       if (FReDecl->isExternC()) {
+        // Do not emit fixit suggestions for functions declared in an
+        // extern "C" block.
         EmitSuggestions = false;
         break;
       }
@@ -3921,26 +3927,29 @@ void clang::checkUnsafeBufferUsage(const Decl *D,
         Stmts.push_back(CI->getInit());
       }
     }
-  }
-
-  if (const auto *FD = dyn_cast<FieldDecl>(D)) {
+  } else if (const auto *FlD = dyn_cast<FieldDecl>(D)) {
     // Visit in-class initializers for fields.
-    if (!FD->hasInClassInitializer())
+    if (!FlD->hasInClassInitializer())
       return;
-
-    Stmts.push_back(FD->getInClassInitializer());
-  }
-
-  if (isa<BlockDecl>(D) || isa<ObjCMethodDecl>(D)) {
+    Stmts.push_back(FlD->getInClassInitializer());
+    // In a FieldDecl there is no function body, there is only a single
+    // statement, and the suggestions machinery is not set up to handle that
+    // kind of structure yet and would give poor suggestions or likely even hit
+    // asserts.
+    EmitSuggestions = false;
+  } else if (isa<BlockDecl>(D) || isa<ObjCMethodDecl>(D)) {
     Stmts.push_back(D->getBody());
   }
 
   assert(!Stmts.empty());
 
+  FixableGadgetList FixableGadgets;
+  WarningGadgetList WarningGadgets;
+  DeclUseTracker Tracker;
   for (Stmt *S : Stmts) {
-    auto [FixableGadgets, WarningGadgets, Tracker] =
-        findGadgets(S, D->getASTContext(), Handler, EmitSuggestions);
-    applyGadgets(D, std::move(FixableGadgets), std::move(WarningGadgets),
-                 std::move(Tracker), Handler, EmitSuggestions);
+    findGadgets(S, D->getASTContext(), Handler, EmitSuggestions, FixableGadgets,
+                WarningGadgets, Tracker);
   }
+  applyGadgets(D, std::move(FixableGadgets), std::move(WarningGadgets),
+               std::move(Tracker), Handler, EmitSuggestions);
 }

--- a/clang/lib/Sema/AnalysisBasedWarnings.cpp
+++ b/clang/lib/Sema/AnalysisBasedWarnings.cpp
@@ -2510,6 +2510,14 @@ public:
   CallableVisitor(llvm::function_ref<void(const Decl *)> Callback)
       : Callback(Callback) {}
 
+  bool VisitFieldDecl(FieldDecl *Node) {
+    if (cast<DeclContext>(Node->getParent())->isDependentContext())
+      return true; // Not to analyze dependent decl
+    if (Node->hasInClassInitializer())
+      Callback(Node);
+    return true;
+  }
+
   bool VisitFunctionDecl(FunctionDecl *Node) {
     if (cast<DeclContext>(Node)->isDependentContext())
       return true; // Not to analyze dependent decl

--- a/clang/lib/Sema/AnalysisBasedWarnings.cpp
+++ b/clang/lib/Sema/AnalysisBasedWarnings.cpp
@@ -2510,38 +2510,6 @@ public:
   CallableVisitor(llvm::function_ref<void(const Decl *)> Callback)
       : Callback(Callback) {}
 
-  bool VisitFieldDecl(FieldDecl *Node) {
-    DeclContext *DeclCtx;
-    if (auto *ID = dyn_cast<ObjCIvarDecl>(Node)) {
-      DeclCtx = cast<DeclContext>(ID->getContainingInterface());
-    } else {
-      RecordDecl *RD = Node->getParent();
-      if (auto *CCRD = dyn_cast<CXXRecordDecl>(RD);
-          CCRD && CCRD->isAggregate()) {
-        // Aggregates have implicitly generated constructors which are not
-        // traversed by our AST visitors at this time. The field initializers in
-        // an aggregate may never be used if the callers always explicitly
-        // initialize them, in which case we do not need to warn on unsafe
-        // buffer usage in the initializer.
-        //
-        // FIXME: We should go through the implicit aggregate initialization
-        // (either an implicit CXXConstructExpr for value-init or an implicit
-        // ListInitExpr for aggregate-init) to determine if a field's default
-        // initializer (CXXDefaultInitExpr) is actually used. If it is, then we
-        // should visit it, while retaining a reference to the caller for
-        // showing the path to the use of the default initializer in the
-        // warning.
-        return true;
-      }
-      DeclCtx = cast<DeclContext>(RD);
-    }
-    if (DeclCtx->isDependentContext())
-      return true; // Not to analyze dependent decl
-    if (Node->hasInClassInitializer())
-      Callback(Node);
-    return true;
-  }
-
   bool VisitFunctionDecl(FunctionDecl *Node) {
     if (cast<DeclContext>(Node)->isDependentContext())
       return true; // Not to analyze dependent decl

--- a/clang/lib/Sema/AnalysisBasedWarnings.cpp
+++ b/clang/lib/Sema/AnalysisBasedWarnings.cpp
@@ -2511,7 +2511,12 @@ public:
       : Callback(Callback) {}
 
   bool VisitFieldDecl(FieldDecl *Node) {
-    if (cast<DeclContext>(Node->getParent())->isDependentContext())
+    DeclContext *DeclCtx;
+    if (auto *ID = dyn_cast<ObjCIvarDecl>(Node))
+      DeclCtx = cast<DeclContext>(ID->getContainingInterface());
+    else
+      DeclCtx = cast<DeclContext>(Node->getParent());
+    if (DeclCtx->isDependentContext())
       return true; // Not to analyze dependent decl
     if (Node->hasInClassInitializer())
       Callback(Node);

--- a/clang/lib/Sema/AnalysisBasedWarnings.cpp
+++ b/clang/lib/Sema/AnalysisBasedWarnings.cpp
@@ -2512,10 +2512,29 @@ public:
 
   bool VisitFieldDecl(FieldDecl *Node) {
     DeclContext *DeclCtx;
-    if (auto *ID = dyn_cast<ObjCIvarDecl>(Node))
+    if (auto *ID = dyn_cast<ObjCIvarDecl>(Node)) {
       DeclCtx = cast<DeclContext>(ID->getContainingInterface());
-    else
-      DeclCtx = cast<DeclContext>(Node->getParent());
+    } else {
+      RecordDecl *RD = Node->getParent();
+      if (auto *CCRD = dyn_cast<CXXRecordDecl>(RD);
+          CCRD && CCRD->isAggregate()) {
+        // Aggregates have implicitly generated constructors which are not
+        // traversed by our AST visitors at this time. The field initializers in
+        // an aggregate may never be used if the callers always explicitly
+        // initialize them, in which case we do not need to warn on unsafe
+        // buffer usage in the initializer.
+        //
+        // FIXME: We should go through the implicit aggregate initialization
+        // (either an implicit CXXConstructExpr for value-init or an implicit
+        // ListInitExpr for aggregate-init) to determine if a field's default
+        // initializer (CXXDefaultInitExpr) is actually used. If it is, then we
+        // should visit it, while retaining a reference to the caller for
+        // showing the path to the use of the default initializer in the
+        // warning.
+        return true;
+      }
+      DeclCtx = cast<DeclContext>(RD);
+    }
     if (DeclCtx->isDependentContext())
       return true; // Not to analyze dependent decl
     if (Node->hasInClassInitializer())

--- a/clang/test/SemaCXX/warn-unsafe-buffer-usage-function-attr.cpp
+++ b/clang/test/SemaCXX/warn-unsafe-buffer-usage-function-attr.cpp
@@ -142,6 +142,8 @@ struct SubclassUnsafeMembers : public UnsafeMembers {
     {}
 };
 
+// Without an explicit constructor, there is no CXXDefaultInitExpr to anchor on
+// in matchers.
 struct AggregateUnsafeMembers {
     UnsafeMembers f1;
     UnsafeMembers f2{3};  // expected-warning{{function introduces unsafe buffer manipulation}}

--- a/clang/test/SemaCXX/warn-unsafe-buffer-usage-function-attr.cpp
+++ b/clang/test/SemaCXX/warn-unsafe-buffer-usage-function-attr.cpp
@@ -128,7 +128,7 @@ struct HoldsUnsafeMembers {
 
     UnsafeMembers FromCtor;
     UnsafeMembers FromCtor2;
-    UnsafeMembers FromField{3};  // expected-warning{{function introduces unsafe buffer manipulation}}
+    UnsafeMembers FromField{3};  // expected-warning 2{{function introduces unsafe buffer manipulation}}
 };
 
 struct SubclassUnsafeMembers : public UnsafeMembers {

--- a/clang/test/SemaCXX/warn-unsafe-buffer-usage-in-container-span-construct.cpp
+++ b/clang/test/SemaCXX/warn-unsafe-buffer-usage-in-container-span-construct.cpp
@@ -157,3 +157,13 @@ namespace test_flag {
 
   }
 } //namespace test_flag
+
+struct HoldsStdSpan {
+  char* Ptr;
+  unsigned Size;
+  std::span<char> Span{Ptr, Size};  // expected-warning{{the two-parameter std::span construction is unsafe as it can introduce mismatch between buffer size and the bound information}}
+
+  HoldsStdSpan(char* P, unsigned S)
+      : Span(P, S)  // expected-warning{{the two-parameter std::span construction is unsafe as it can introduce mismatch between buffer size and the bound information}}
+  {}
+};

--- a/clang/test/SemaCXX/warn-unsafe-buffer-usage-in-container-span-construct.cpp
+++ b/clang/test/SemaCXX/warn-unsafe-buffer-usage-in-container-span-construct.cpp
@@ -158,12 +158,22 @@ namespace test_flag {
   }
 } //namespace test_flag
 
-struct HoldsStdSpan {
+struct HoldsStdSpanAndInitializedInCtor {
   char* Ptr;
   unsigned Size;
-  std::span<char> Span{Ptr, Size};  // expected-warning{{the two-parameter std::span construction is unsafe as it can introduce mismatch between buffer size and the bound information}}
+  std::span<char> Span{Ptr, Size};  // no-warning (this code is unreachable)
 
-  HoldsStdSpan(char* P, unsigned S)
+  HoldsStdSpanAndInitializedInCtor(char* P, unsigned S)
       : Span(P, S)  // expected-warning{{the two-parameter std::span construction is unsafe as it can introduce mismatch between buffer size and the bound information}}
+  {}
+};
+
+struct HoldsStdSpanAndNotInitializedInCtor {
+  char* Ptr;
+  unsigned Size;
+  std::span<char> Span{Ptr, Size}; // expected-warning{{the two-parameter std::span construction is unsafe as it can introduce mismatch between buffer size and the bound information}}
+
+  HoldsStdSpanAndNotInitializedInCtor(char* P, unsigned S)
+      : Ptr(P), Size(S)
   {}
 };


### PR DESCRIPTION
This is built on top of https://github.com/llvm/llvm-project/pull/91777, and includes the commits there for now.

Issue #80482 