### PR TITLE
[TableGen][RISCV] Add initial support for marking profiles as experimental

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVProfiles.td
+++ b/llvm/lib/Target/RISCV/RISCVProfiles.td
@@ -8,7 +8,11 @@
 
 class RISCVProfile<string name, list<SubtargetFeature> features>
     : SubtargetFeature<name, "Is" # NAME, "true",
-                       "RISC-V " # name # " profile", features>;
+                       "RISC-V " # name # " profile", features> {
+  // Indicates if the profile is not yet ratified, so should be treated as
+  // experimental.
+  bit Experimental = false;
+}
 
 defvar RVI20U32Features = [Feature32Bit, FeatureStdExtI];
 defvar RVI20U64Features = [Feature64Bit, FeatureStdExtI];

--- a/llvm/test/TableGen/riscv-target-def.td
+++ b/llvm/test/TableGen/riscv-target-def.td
@@ -53,12 +53,19 @@ def FeatureDummy
 
 class RISCVProfile<string name, list<SubtargetFeature> features>
     : SubtargetFeature<name, "Is" # NAME, "true",
-                       "RISC-V " # name # " profile", features>;
+                       "RISC-V " # name # " profile", features> {
+  bit Experimental = false;
+}
+class RISCVExperimentalProfile<string name, list<SubtargetFeature> features>
+    : RISCVProfile<"experimental-"#name, features> {
+  let Experimental = true;
+}
 
 def RVI20U32 : RISCVProfile<"rvi20u32", [Feature32Bit, FeatureStdExtI]>;
 def RVI20U64 : RISCVProfile<"rvi20u64", [Feature64Bit, FeatureStdExtI]>;
 def ProfileDummy : RISCVProfile<"dummy", [Feature64Bit, FeatureStdExtI,
                                           FeatureStdExtF, FeatureStdExtZidummy]>;
+def RVI99U64 : RISCVExperimentalProfile<"rvi99u64", [Feature64Bit, FeatureStdExtI]>;
 
 class RISCVProcessorModel<string n,
                           SchedMachineModel m,
@@ -137,6 +144,10 @@ def ROCKET : RISCVTuneProcessorModel<"rocket",
 // CHECK-NEXT:     {"dummy","rv64i2p1_f2p2_zidummy0p1"},
 // CHECK-NEXT:     {"rvi20u32","rv32i2p1"},
 // CHECK-NEXT:     {"rvi20u64","rv64i2p1"},
+// CHECK-NEXT: };
+
+// CHECK:      static constexpr RISCVProfile SupportedExperimentalProfiles[] = {
+// CHECK-NEXT:     {"experimental-rvi99u64","rv64i2p1"},
 // CHECK-NEXT: };
 
 // CHECK:      #endif // GET_SUPPORTED_PROFILES

--- a/llvm/utils/TableGen/RISCVTargetDefEmitter.cpp
+++ b/llvm/utils/TableGen/RISCVTargetDefEmitter.cpp
@@ -122,6 +122,26 @@ static void printMArch(raw_ostream &OS, const std::vector<Record *> &Features) {
     OS << LS << Ext.first << Ext.second.Major << 'p' << Ext.second.Minor;
 }
 
+static void printProfileTable(raw_ostream &OS,
+                              const std::vector<Record *> &Profiles,
+                              bool Experimental) {
+  OS << "static constexpr RISCVProfile Supported";
+  if (Experimental)
+    OS << "Experimental";
+  OS << "Profiles[] = {\n";
+
+  for (const Record *Rec : Profiles) {
+    if (Rec->getValueAsBit("Experimental") != Experimental)
+      continue;
+
+    OS.indent(4) << "{\"" << Rec->getValueAsString("Name") << "\",\"";
+    printMArch(OS, Rec->getValueAsListOfDefs("Implies"));
+    OS << "\"},\n";
+  }
+
+  OS << "};\n\n";
+}
+
 static void emitRISCVProfiles(RecordKeeper &Records, raw_ostream &OS) {
   OS << "#ifdef GET_SUPPORTED_PROFILES\n";
   OS << "#undef GET_SUPPORTED_PROFILES\n\n";
@@ -129,15 +149,12 @@ static void emitRISCVProfiles(RecordKeeper &Records, raw_ostream &OS) {
   auto Profiles = Records.getAllDerivedDefinitionsIfDefined("RISCVProfile");
 
   if (!Profiles.empty()) {
-    llvm::sort(Profiles, LessRecordFieldName());
-    OS << "static constexpr RISCVProfile SupportedProfiles[] = {\n";
-    for (const Record *Rec : Profiles) {
-      OS.indent(4) << "{\"" << Rec->getValueAsString("Name") << "\",\"";
-      printMArch(OS, Rec->getValueAsListOfDefs("Implies"));
-      OS << "\"},\n";
-    }
-
-    OS << "};\n\n";
+    printProfileTable(OS, Profiles, /*Experimental=*/false);
+    bool HasExperimentalProfiles = any_of(Profiles, [&](auto &Rec) {
+      return Rec->getValueAsBit("Experimental");
+    });
+    if (HasExperimentalProfiles)
+      printProfileTable(OS, Profiles, /*Experimental=*/true);
   }
 
   OS << "#endif // GET_SUPPORTED_PROFILES\n\n";


### PR DESCRIPTION
This is just the TableGen-side changes, split out as the minimal testable unit. It doesn't yet transition RVA23 and friends to be experimental (and add the necessary other changes for this to work).

Although choosing not to emit the SupportedExperimentalProfiles array if no experimental profiles are present isn't consistent with what we do for experimental extensions, we need to do this in order to avoid adding a warning for the empty array when building LLVM for as long as we don't have any experimental profiles defined.