### PR TITLE
[libc++][z/OS] Correct a definition of __native_vector_size

### DIFF
--- a/libcxx/include/__algorithm/simd_utils.h
+++ b/libcxx/include/__algorithm/simd_utils.h
@@ -46,7 +46,7 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 // This isn't specialized for 64 byte vectors on purpose. They have the potential to significantly reduce performance
 // in mixed simd/non-simd workloads and don't provide any performance improvement for currently vectorized algorithms
 // as far as benchmarks are concerned.
-#  if defined(__AVX__)
+#  if defined(__AVX__) || defined(__MVS__)
 template <class _Tp>
 inline constexpr size_t __native_vector_size = 32 / sizeof(_Tp);
 #  elif defined(__SSE__) || defined(__ARM_NEON__)


### PR DESCRIPTION
Fix  `std/ranges/range.adaptors/range.lazy.split/general.pass.cpp` which started failing on z/OS after this [commit](https://github.com/llvm/llvm-project/commit/985c1a44f8d49e0af).

This test case is passing on other platforms such as AIX. This is because the `__ALTIVEC__` macro is defined and  `__mismatch` under `_LIBCPP_VECTORIZE_ALGORITHMS` guard is compiled out.  However, on z/OS  `_LIBCPP_VECTORIZE_ALGORITHMS`  is defined. Analyzing the algorithm of `__mismatch` shows that the culprit is the definition of `__native_vector_size` which was defined wrongly as 1. This PR corrects the definition of `__native_vector_size` and fixes the affected test.

Here is a subset of original test which fails on z/OS:

```
#include <ranges>
#include <cassert>
#include <vector>

template <class Char>
class BasicSmallString {
  std::vector<Char> buffer_{};

public:
  constexpr BasicSmallString(std::basic_string_view<Char> v)
    requires (std::same_as<Char, char> ||
              std::same_as<Char, wchar_t> ||
              std::same_as<Char, char8_t> ||
              std::same_as<Char, char16_t> ||
              std::same_as<Char, char32_t>)
    : buffer_(v.begin(), v.end())
  {}

  template <class I, class S>
  constexpr BasicSmallString(I b, const S& e) {
    for (; b != e; ++b) {
      buffer_.push_back(*b);
    }
  }

  template <std::ranges::range R>
  constexpr BasicSmallString(R&& from) : BasicSmallString(from.begin(), from.end()) {}

  friend constexpr bool operator==(const BasicSmallString& lhs, const BasicSmallString& rhs) {
    return lhs.buffer_ == rhs.buffer_;
  }
};

template <std::ranges::view View, std::ranges::range Expected>
constexpr bool is_equal(View& view, const Expected& expected) {
  using Char = std::ranges::range_value_t<std::ranges::range_value_t<View>>;
  using Str = BasicSmallString<Char>;

  auto actual_it = view.begin();
  auto expected_it = expected.begin();
  for (; actual_it != view.end() && expected_it != expected.end(); ++actual_it, ++expected_it) {
    if (Str(*actual_it) != Str(*expected_it))
      return false;
  }

  return actual_it == view.end() && expected_it == expected.end();
}

int main() {
  using namespace std::string_view_literals;
  auto overlapping_sep = "ab"sv;
  std::array expected = {"a"sv, "aa"sv, ""sv, "b"sv};
  std::ranges::lazy_split_view v("aabaaababb"sv, overlapping_sep);
  assert(is_equal(v, expected));
  return 0;
}
```