### PR TITLE
[HLSL] support packoffset in clang codeGen

### DIFF
--- a/clang/include/clang/AST/Decl.h
+++ b/clang/include/clang/AST/Decl.h
@@ -4959,6 +4959,11 @@ public:
                                 SourceLocation LBrace);
   static HLSLBufferDecl *CreateDeserialized(ASTContext &C, GlobalDeclID ID);
 
+  // Calculate the size of a legacy cbuffer type based on
+  // https://learn.microsoft.com/en-us/windows/win32/direct3dhlsl/dx-graphics-hlsl-packing-rules
+  static unsigned calculateLegacyCbufferSize(const ASTContext &Context,
+                                             QualType T);
+
   SourceRange getSourceRange() const override LLVM_READONLY {
     return SourceRange(getLocStart(), RBraceLoc);
   }

--- a/clang/lib/CodeGen/CGHLSLRuntime.h
+++ b/clang/lib/CodeGen/CGHLSLRuntime.h
@@ -95,8 +95,14 @@ public:
     // IsCBuffer - Whether the buffer is a cbuffer (and not a tbuffer).
     bool IsCBuffer;
     BufferResBinding Binding;
+    struct Constant {
+      llvm::GlobalVariable *GV;
+      unsigned Offset;
+      unsigned Size;
+      unsigned ElementIndex;
+    };
     // Global variable and offset for each constant.
-    std::vector<std::pair<llvm::GlobalVariable *, unsigned>> Constants;
+    std::vector<Constant> Constants;
     llvm::StructType *LayoutStruct = nullptr;
   };
 

--- a/clang/lib/Sema/SemaHLSL.cpp
+++ b/clang/lib/Sema/SemaHLSL.cpp
@@ -39,41 +39,6 @@ Decl *SemaHLSL::ActOnStartBuffer(Scope *BufferScope, bool CBuffer,
   return Result;
 }
 
-// Calculate the size of a legacy cbuffer type based on
-// https://learn.microsoft.com/en-us/windows/win32/direct3dhlsl/dx-graphics-hlsl-packing-rules
-static unsigned calculateLegacyCbufferSize(const ASTContext &Context,
-                                           QualType T) {
-  unsigned Size = 0;
-  constexpr unsigned CBufferAlign = 128;
-  if (const RecordType *RT = T->getAs<RecordType>()) {
-    const RecordDecl *RD = RT->getDecl();
-    for (const FieldDecl *Field : RD->fields()) {
-      QualType Ty = Field->getType();
-      unsigned FieldSize = calculateLegacyCbufferSize(Context, Ty);
-      unsigned FieldAlign = 32;
-      if (Ty->isAggregateType())
-        FieldAlign = CBufferAlign;
-      Size = llvm::alignTo(Size, FieldAlign);
-      Size += FieldSize;
-    }
-  } else if (const ConstantArrayType *AT = Context.getAsConstantArrayType(T)) {
-    if (unsigned ElementCount = AT->getSize().getZExtValue()) {
-      unsigned ElementSize =
-          calculateLegacyCbufferSize(Context, AT->getElementType());
-      unsigned AlignedElementSize = llvm::alignTo(ElementSize, CBufferAlign);
-      Size = AlignedElementSize * (ElementCount - 1) + ElementSize;
-    }
-  } else if (const VectorType *VT = T->getAs<VectorType>()) {
-    unsigned ElementCount = VT->getNumElements();
-    unsigned ElementSize =
-        calculateLegacyCbufferSize(Context, VT->getElementType());
-    Size = ElementSize * ElementCount;
-  } else {
-    Size = Context.getTypeSize(T);
-  }
-  return Size;
-}
-
 void SemaHLSL::ActOnFinishBuffer(Decl *Dcl, SourceLocation RBrace) {
   auto *BufDecl = cast<HLSLBufferDecl>(Dcl);
   BufDecl->setRBraceLoc(RBrace);
@@ -110,7 +75,8 @@ void SemaHLSL::ActOnFinishBuffer(Decl *Dcl, SourceLocation RBrace) {
     for (unsigned i = 0; i < PackOffsetVec.size() - 1; i++) {
       VarDecl *Var = PackOffsetVec[i].first;
       HLSLPackOffsetAttr *Attr = PackOffsetVec[i].second;
-      unsigned Size = calculateLegacyCbufferSize(Context, Var->getType());
+      unsigned Size =
+          HLSLBufferDecl::calculateLegacyCbufferSize(Context, Var->getType());
       unsigned Begin = Attr->getOffset() * 32;
       unsigned End = Begin + Size;
       unsigned NextBegin = PackOffsetVec[i + 1].second->getOffset() * 32;

--- a/clang/test/CodeGenHLSL/cbuf.hlsl
+++ b/clang/test/CodeGenHLSL/cbuf.hlsl
@@ -2,13 +2,13 @@
 // RUN:   dxil-pc-shadermodel6.3-library %s \
 // RUN:   -emit-llvm -disable-llvm-passes -o - | FileCheck %s
 
-// CHECK: @[[CB:.+]] = external constant { float, double }
+// CHECK: @[[CB:.+]] = external constant { float, [4 x i8], double }
 cbuffer A : register(b0, space2) {
   float a;
   double b;
 }
 
-// CHECK: @[[TB:.+]] = external constant { float, double }
+// CHECK: @[[TB:.+]] = external constant { float, [4 x i8], double }
 tbuffer A : register(t2, space1) {
   float c;
   double d;
@@ -16,9 +16,9 @@ tbuffer A : register(t2, space1) {
 
 float foo() {
 // CHECK: load float, ptr @[[CB]], align 4
-// CHECK: load double, ptr getelementptr inbounds ({ float, double }, ptr @[[CB]], i32 0, i32 1), align 8
+// CHECK: load double, ptr getelementptr inbounds ({ float, [4 x i8], double }, ptr @[[CB]], i32 0, i32 2), align 8
 // CHECK: load float, ptr @[[TB]], align 4
-// CHECK: load double, ptr getelementptr inbounds ({ float, double }, ptr @[[TB]], i32 0, i32 1), align 8
+// CHECK: load double, ptr getelementptr inbounds ({ float, [4 x i8], double }, ptr @[[TB]], i32 0, i32 2), align 8
   return a + b + c*d;
 }
 

--- a/clang/test/CodeGenHLSL/packoffset.hlsl
+++ b/clang/test/CodeGenHLSL/packoffset.hlsl
@@ -1,0 +1,109 @@
+// RUN: %clang_cc1 -finclude-default-header -x hlsl -triple \
+// RUN:   dxil-pc-shadermodel6.3-library %s -fnative-half-type \
+// RUN:   -emit-llvm -disable-llvm-passes -o - | FileCheck %s
+
+// CHECK: @A.cb. = external constant { [8 x i8], double, [8 x i8], float, float, half, i16, [4 x i8], i64, i32 }
+cbuffer A {
+  float a : packoffset(c1.z);
+  double b : packoffset(c0.z);
+  float  c;
+  half   d;
+  int16_t e;
+  int64_t f;
+  int     g;
+}
+
+// CHECK: @B.cb. = external constant { [24 x i8], float, [4 x i8], double, [8 x i8], <3 x float>, [4 x i8], <3 x double>, half, [6 x i8], <2 x double>, float, <3 x half>, <3 x half> }
+cbuffer B {
+  double  B0;
+  float3  B1;
+  float   B2 : packoffset(c1.z);
+  double3 B3;
+  half    B4;
+  double2 B5;
+  float   B6;
+  half3   B7;
+  half3   B8;
+}
+
+// CHECK: @C.cb. = external constant { [2 x double], [8 x i8], [3 x <3 x float>], float, [3 x double], half, [6 x i8], [1 x <2 x double>], float, [12 x i8], [2 x <3 x half>], <3 x half> }
+cbuffer C {
+  double C0[2] : packoffset(c0);
+  float3 C1[3];
+  float  C2;
+  double C3[3];
+  half   C4;
+  double2 C5[1];
+  float  C6;
+  half3  C7[2];
+  half3  C8;
+}
+
+// CHECK: @D.cb. = external constant { [3 x <3 x double>], <3 x half> }
+cbuffer D {
+  double3 D9[3] : packoffset(c);
+  half3 D10;
+}
+                                
+struct S0
+{
+    double B0;
+    float3 B1;
+    float B2;
+    double3 B3;
+    half B4;
+    double2 B5;
+    float B6;
+    half3 B7;
+    half3 B8;
+};
+
+struct S1
+{
+    float A0;
+    double A1;
+    float A2;
+    half A3;
+    int16_t A4;
+    int64_t A5;
+    int A6;
+};
+
+struct S2
+{
+    double B0;
+    float3 B1;
+    float B2;
+    double3 B3;
+    half B4;
+    double2 B5;
+    float B6;
+    half3 B7;
+    half3 B8;
+};
+
+struct S3
+{
+    S1 C0;
+    float C1[1];
+    S2 C2[2];
+    half C3;
+};           
+
+// CHECK: @E.cb. = external constant { [16 x i8], half, [2 x i8], i32, double, %struct.S3, [206 x i8], %struct.S0 }
+cbuffer E {
+  int E0 : packoffset(c1.y);
+  S0  E1 : packoffset(c31);
+  half E2 : packoffset(c1);
+  S3 E3 : packoffset(c2);
+  double E4 : packoffset(c1.z);
+}
+
+float foo() {
+// CHECK: %[[a:.+]] = load float, ptr getelementptr inbounds ({ [8 x i8], double, [8 x i8], float, float, half, i16, [4 x i8], i64, i32 }, ptr @A.cb., i32 0, i32 3), align 4
+// CHECK: %[[B2:.+]] = load float, ptr getelementptr inbounds ({ [24 x i8], float, [4 x i8], double, [8 x i8], <3 x float>, [4 x i8], <3 x double>, half, [6 x i8], <2 x double>, float, <3 x half>, <3 x half> }, ptr @B.cb., i32 0, i32 1), align 4
+// CHECK: %[[C6:.+]] = load float, ptr getelementptr inbounds ({ [2 x double], [8 x i8], [3 x <3 x float>], float, [3 x double], half, [6 x i8], [1 x <2 x double>], float, [12 x i8], [2 x <3 x half>], <3 x half> }, ptr @C.cb., i32 0, i32 8), align 4
+// CHECK: %[[D10:.+]] = load <3 x half>, ptr getelementptr inbounds ({ [3 x <3 x double>], <3 x half> }, ptr @D.cb., i32 0, i32 1), align 8
+// CHECK: %[[E0:.+]] = load i32, ptr getelementptr inbounds ({ [16 x i8], half, [2 x i8], i32, double, %struct.S3, [206 x i8], %struct.S0 }, ptr @E.cb., i32 0, i32 3), align 4
+  return a + B2 + C6*D10.z + E0;
+}

--- a/clang/unittests/AST/CMakeLists.txt
+++ b/clang/unittests/AST/CMakeLists.txt
@@ -29,6 +29,7 @@ add_clang_unittest(ASTTests
   DeclTest.cpp
   EvaluateAsRValueTest.cpp
   ExternalASTSourceTest.cpp
+  HLSLLegacyCbufferTypeSizeTest.cpp
   NamedDeclPrinterTest.cpp
   RandstructTest.cpp
   RecursiveASTVisitorTest.cpp

--- a/clang/unittests/AST/HLSLLegacyCbufferTypeSizeTest.cpp
+++ b/clang/unittests/AST/HLSLLegacyCbufferTypeSizeTest.cpp
@@ -1,0 +1,576 @@
+//===- unittests/AST/HLSLLegacyCbufferTypeSizeTest.cpp -- cbuf size test --===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file contains tests for HLSLBufferDecl::calculateLegacyCbufferSize.
+//
+//===----------------------------------------------------------------------===//
+
+#include "clang/AST/ASTContext.h"
+#include "clang/AST/Decl.h"
+#include "clang/ASTMatchers/ASTMatchFinder.h"
+#include "clang/Tooling/Tooling.h"
+#include "llvm/ADT/SmallString.h"
+#include "gtest/gtest.h"
+
+using namespace clang;
+using namespace ast_matchers;
+using namespace tooling;
+
+// FIXME: Let buildASTFromCodeWithArgs find hlsl.h instead of using "nostdinc".
+
+TEST(HLSLLegacyCbufferTypeSize, BasicTypes) {
+  constexpr char Code[] = R"hlsl(
+    namespace hlsl {
+    // built-in scalar data types:
+
+    #ifdef __HLSL_ENABLE_16_BIT
+    // 16-bit integer.
+    typedef short int16_t;
+    #endif
+
+    // 64-bit integer.
+    typedef long int64_t;
+
+    } // namespace hlsl
+
+    struct A {
+      float a;
+      double b;
+      float  c;
+      half   d;
+      int16_t e;
+      int64_t f;
+      int     g;
+    };
+  )hlsl";
+  auto AST =
+      tooling::buildASTFromCodeWithArgs(Code,
+                                        /*Args=*/
+                                        {"--driver-mode=dxc", "-T", "lib_6_3",
+                                         "-enable-16bit-types", "-nostdinc"},
+                                        /* FileName*/ "input.hlsl");
+  ASTContext &Ctx = AST->getASTContext();
+
+  auto Results = match(decl(cxxRecordDecl(hasName("A")).bind("A")), Ctx);
+
+  //  struct A
+  //  {
+
+  //      float a;                                      ; Offset:    0
+  //      double b;                                     ; Offset:    8
+  //      float c;                                      ; Offset:   16
+  //      half d;                                       ; Offset:   20
+  //      int16_t e;                                    ; Offset:   22
+  //      int64_t f;                                    ; Offset:   24
+  //      int g;                                        ; Offset:   32
+
+  //  } A;                                              ; Offset:    0 Size: 36
+  auto const *A = selectFirst<RecordDecl>("A", Results);
+  unsigned SizeA = HLSLBufferDecl::calculateLegacyCbufferSize(
+      Ctx, QualType(A->getTypeForDecl(), 0));
+  ASSERT_EQ(SizeA, 36u * 8u);
+}
+
+TEST(HLSLLegacyCbufferTypeSize, VectorTypes) {
+  constexpr char Code[] = R"hlsl(
+    namespace hlsl {
+    // built-in scalar data types:
+
+    #ifdef __HLSL_ENABLE_16_BIT
+    // 16-bit integer.
+    typedef short int16_t;
+    #endif
+
+    // 64-bit integer.
+    typedef long int64_t;
+
+    // built-in vector data types:
+
+    typedef vector<half, 2> half2;
+    typedef vector<half, 3> half3;
+    typedef vector<half, 4> half4;
+
+    typedef vector<float, 2> float2;
+    typedef vector<float, 3> float3;
+    typedef vector<float, 4> float4;
+    typedef vector<double, 2> double2;
+    typedef vector<double, 3> double3;
+    typedef vector<double, 4> double4;
+
+    } // namespace hlsl
+
+    struct A {
+      double  B0;
+      float3  B1;
+      float   B2;
+      double3 B3;
+      half    B4;
+      double2 B5;
+      float   B6;
+      half3   B7;
+      half3   B8;
+    };
+  )hlsl";
+  auto AST =
+      tooling::buildASTFromCodeWithArgs(Code,
+                                        /*Args=*/
+                                        {"--driver-mode=dxc", "-T", "lib_6_3",
+                                         "-enable-16bit-types", "-nostdinc"},
+                                        /* FileName*/ "input.hlsl");
+  ASTContext &Ctx = AST->getASTContext();
+
+  auto Results = match(decl(cxxRecordDecl(hasName("A")).bind("A")), Ctx);
+  //  struct A
+  //  {
+
+  //      double B0;                                    ; Offset:    0
+  //      float3 B1;                                    ; Offset:   16
+  //      float B2;                                     ; Offset:   28
+  //      double3 B3;                                   ; Offset:   32
+  //      half B4;                                      ; Offset:   56
+  //      double2 B5;                                   ; Offset:   64
+  //      float B6;                                     ; Offset:   80
+  //      half3 B7;                                     ; Offset:   84
+  //      half3 B8;                                     ; Offset:   90
+
+  //  } A;                                              ; Offset:    0 Size: 96
+  auto const *A = selectFirst<RecordDecl>("A", Results);
+  unsigned SizeA = HLSLBufferDecl::calculateLegacyCbufferSize(
+      Ctx, QualType(A->getTypeForDecl(), 0));
+  ASSERT_EQ(SizeA, 96u * 8u);
+}
+
+TEST(HLSLLegacyCbufferTypeSize, ArrayTypes) {
+  constexpr char Code[] = R"hlsl(
+    namespace hlsl {
+    // built-in scalar data types:
+
+    #ifdef __HLSL_ENABLE_16_BIT
+    // 16-bit integer.
+    typedef short int16_t;
+    #endif
+
+    // 64-bit integer.
+    typedef long int64_t;
+
+    // built-in vector data types:
+
+    typedef vector<half, 2> half2;
+    typedef vector<half, 3> half3;
+    typedef vector<half, 4> half4;
+
+    typedef vector<float, 2> float2;
+    typedef vector<float, 3> float3;
+    typedef vector<float, 4> float4;
+    typedef vector<double, 2> double2;
+    typedef vector<double, 3> double3;
+    typedef vector<double, 4> double4;
+
+    } // namespace hlsl
+
+    struct A {
+      double C0[2];
+      float3 C1[3];
+      float  C2;
+      double C3[3];
+      half   C4;
+      double2 C5[1];
+      float  C6;
+      half3  C7[2];
+      half3  C8;
+    };
+  )hlsl";
+  auto AST =
+      tooling::buildASTFromCodeWithArgs(Code,
+                                        /*Args=*/
+                                        {"--driver-mode=dxc", "-T", "lib_6_3",
+                                         "-enable-16bit-types", "-nostdinc"},
+                                        /* FileName*/ "input.hlsl");
+  ASTContext &Ctx = AST->getASTContext();
+
+  auto Results = match(decl(cxxRecordDecl(hasName("A")).bind("A")), Ctx);
+
+  //  struct A
+  //  {
+
+  //      double C0[2];                                 ; Offset:    0
+  //      float3 C1[3];                                 ; Offset:   32
+  //      float C2;                                     ; Offset:   76
+  //      double C3[3];                                 ; Offset:   80
+  //      half C4;                                      ; Offset:  120
+  //      double2 C5[1];                                ; Offset:  128
+  //      float C6;                                     ; Offset:  144
+  //      half3 C7[2];                                  ; Offset:  160
+  //      half3 C8;                                     ; Offset:  182
+
+  //  } A;                                              ; Offset:    0 Size: 188
+  auto const *A = selectFirst<RecordDecl>("A", Results);
+  unsigned SizeA = HLSLBufferDecl::calculateLegacyCbufferSize(
+      Ctx, QualType(A->getTypeForDecl(), 0));
+  ASSERT_EQ(SizeA, 188u * 8u);
+}
+
+TEST(HLSLLegacyCbufferTypeSize, Vec3) {
+  constexpr char Code[] = R"hlsl(
+    namespace hlsl {
+    // built-in scalar data types:
+
+    #ifdef __HLSL_ENABLE_16_BIT
+    // 16-bit integer.
+    typedef short int16_t;
+    #endif
+
+    // 64-bit integer.
+    typedef long int64_t;
+
+    // built-in vector data types:
+
+    typedef vector<half, 2> half2;
+    typedef vector<half, 3> half3;
+    typedef vector<half, 4> half4;
+
+    typedef vector<float, 2> float2;
+    typedef vector<float, 3> float3;
+    typedef vector<float, 4> float4;
+    typedef vector<double, 2> double2;
+    typedef vector<double, 3> double3;
+    typedef vector<double, 4> double4;
+
+    } // namespace hlsl
+
+    struct A {
+      double3 D9[3];
+      half3 D10;
+    };
+  )hlsl";
+  auto AST =
+      tooling::buildASTFromCodeWithArgs(Code,
+                                        /*Args=*/
+                                        {"--driver-mode=dxc", "-T", "lib_6_3",
+                                         "-enable-16bit-types", "-nostdinc"},
+                                        /* FileName*/ "input.hlsl");
+  ASTContext &Ctx = AST->getASTContext();
+
+  auto Results = match(decl(cxxRecordDecl(hasName("A")).bind("A")), Ctx);
+
+  //  struct A
+  //  {
+  //
+  //      double3 D9[3];                                ; Offset:    0
+  //      half3 D10;                                    ; Offset:   88
+  //
+  //  } A;                                              ; Offset:    0 Size: 94
+  auto const *A = selectFirst<RecordDecl>("A", Results);
+  unsigned SizeA = HLSLBufferDecl::calculateLegacyCbufferSize(
+      Ctx, QualType(A->getTypeForDecl(), 0));
+  ASSERT_EQ(SizeA, 94u * 8u);
+}
+
+TEST(HLSLLegacyCbufferTypeSize, NestedStruct) {
+  constexpr char Code[] = R"hlsl(
+    namespace hlsl {
+    // built-in scalar data types:
+
+    #ifdef __HLSL_ENABLE_16_BIT
+    // 16-bit integer.
+    typedef short int16_t;
+    #endif
+
+    // 64-bit integer.
+    typedef long int64_t;
+
+    // built-in vector data types:
+
+    typedef vector<half, 2> half2;
+    typedef vector<half, 3> half3;
+    typedef vector<half, 4> half4;
+
+    typedef vector<float, 2> float2;
+    typedef vector<float, 3> float3;
+    typedef vector<float, 4> float4;
+    typedef vector<double, 2> double2;
+    typedef vector<double, 3> double3;
+    typedef vector<double, 4> double4;
+
+    } // namespace hlsl
+
+    struct S0
+    {
+        double B0;
+        float3 B1;
+        float B2;
+        double3 B3;
+        half B4;
+        double2 B5;
+        float B6;
+        half3 B7;
+        half3 B8;
+    };
+
+    struct S1
+    {
+        float A0;
+        double A1;
+        float A2;
+        half A3;
+        int16_t A4;
+        int64_t A5;
+        int A6;
+    };
+
+    struct S2
+    {
+        double B0;
+        float3 B1;
+        float B2;
+        double3 B3;
+        half B4;
+        double2 B5;
+        float B6;
+        half3 B7;
+        half3 B8;
+    };
+
+    struct S3
+    {
+        S1 C0;
+        float C1[1];
+        S2 C2[2];
+        half C3;
+    };           
+
+    struct A {
+      int E0;
+      S0  E1;
+      half E2;
+      S3 E3;
+      double E4;
+    };
+  )hlsl";
+
+  auto AST =
+      tooling::buildASTFromCodeWithArgs(Code,
+                                        /*Args=*/
+                                        {"--driver-mode=dxc", "-T", "lib_6_3",
+                                         "-enable-16bit-types", "-nostdinc"},
+                                        /* FileName*/ "input.hlsl");
+  ASTContext &Ctx = AST->getASTContext();
+
+  auto Results = match(decl(cxxRecordDecl(hasName("A")).bind("A")), Ctx);
+
+  //  struct E
+  //  {
+  //      int E0;                                       ; Offset:    0
+  //      struct struct.S0
+  //      {
+
+  //          double B0;                                ; Offset:   16
+  //          float3 B1;                                ; Offset:   32
+  //          float B2;                                 ; Offset:   44
+  //          double3 B3;                               ; Offset:   48
+  //          half B4;                                  ; Offset:   72
+  //          double2 B5;                               ; Offset:   80
+  //          float B6;                                 ; Offset:   96
+  //          half3 B7;                                 ; Offset:  100
+  //          half3 B8;                                 ; Offset:  106
+
+  //      } E1;                                         ; Offset:   16
+
+  //      half E2;                                      ; Offset:  112
+  //      struct struct.S3
+  //      {
+
+  //          struct struct.S1
+  //          {
+
+  //              float A0;                             ; Offset:  128
+  //              double A1;                            ; Offset:  136
+  //              float A2;                             ; Offset:  144
+  //              half A3;                              ; Offset:  148
+  //              int16_t A4;                           ; Offset:  150
+  //              int64_t A5;                           ; Offset:  152
+  //              int A6;                               ; Offset:  160
+
+  //          } C0;                                     ; Offset:  128
+
+  //          float C1[1];                              ; Offset:  176
+  //          struct struct.S2
+  //          {
+
+  //              double B0;                            ; Offset:  192
+  //              float3 B1;                            ; Offset:  208
+  //              float B2;                             ; Offset:  220
+  //              double3 B3;                           ; Offset:  224
+  //              half B4;                              ; Offset:  248
+  //              double2 B5;                           ; Offset:  256
+  //              float B6;                             ; Offset:  272
+  //              half3 B7;                             ; Offset:  276
+  //              half3 B8;                             ; Offset:  282
+
+  //          } C2[2];;                                 ; Offset:  192
+
+  //          half C3;                                  ; Offset:  384
+
+  //      } E3;                                         ; Offset:  128
+
+  //      double E4;                                    ; Offset:  392
+
+  //  } E;                                              ; Offset:    0 Size: 400
+
+  auto const *A = selectFirst<RecordDecl>("A", Results);
+  unsigned SizeA = HLSLBufferDecl::calculateLegacyCbufferSize(
+      Ctx, QualType(A->getTypeForDecl(), 0));
+  ASSERT_EQ(SizeA, 400u * 8u);
+}
+
+TEST(HLSLLegacyCbufferTypeSize, NestedStructDisable16bitTypes) {
+  constexpr char Code[] = R"hlsl(
+    namespace hlsl {
+
+    // built-in vector data types:
+
+    typedef vector<half, 2> half2;
+    typedef vector<half, 3> half3;
+    typedef vector<half, 4> half4;
+
+    typedef vector<float, 2> float2;
+    typedef vector<float, 3> float3;
+    typedef vector<float, 4> float4;
+    typedef vector<double, 2> double2;
+    typedef vector<double, 3> double3;
+    typedef vector<double, 4> double4;
+
+    } // namespace hlsl
+
+    struct S0
+    {
+        double B0;
+        float3 B1;
+        float B2;
+        double3 B3;
+        half B4;
+        double2 B5;
+        float B6;
+        half3 B7;
+        half3 B8;
+    };
+
+    struct S1
+    {
+        float A0;
+        double A1;
+        float A2;
+        half A3;
+        half A4;
+        double A5;
+        int A6;
+    };
+
+    struct S2
+    {
+        double B0;
+        float3 B1;
+        float B2;
+        double3 B3;
+        half B4;
+        double2 B5;
+        float B6;
+        half3 B7;
+        half3 B8;
+    };
+
+    struct S3
+    {
+        S1 C0;
+        float C1[1];
+        S2 C2[2];
+        half C3;
+    };           
+
+    struct A {
+      int E0;
+      S0  E1;
+      half E2;
+      S3 E3;
+      double E4;
+    };
+  )hlsl";
+
+  auto AST = tooling::buildASTFromCodeWithArgs(
+      Code,
+      /*Args=*/{"--driver-mode=dxc", "-T", "lib_6_3", "-nostdinc"},
+      /* FileName*/ "input.hlsl");
+  ASTContext &Ctx = AST->getASTContext();
+
+  auto Results = match(decl(cxxRecordDecl(hasName("A")).bind("A")), Ctx);
+
+  //  struct E
+  //  {
+
+  //      int E0;                                       ; Offset:    0
+  //      struct struct.S0
+  //      {
+
+  //          double B0;                                ; Offset:   16
+  //          float3 B1;                                ; Offset:   32
+  //          float B2;                                 ; Offset:   44
+  //          double3 B3;                               ; Offset:   48
+  //          float B4;                                 ; Offset:   72
+  //          double2 B5;                               ; Offset:   80
+  //          float B6;                                 ; Offset:   96
+  //          float3 B7;                                ; Offset:  100
+  //          float3 B8;                                ; Offset:  112
+
+  //      } E1;                                         ; Offset:   16
+
+  //      float E2;                                     ; Offset:  124
+  //      struct struct.S3
+  //      {
+
+  //          struct struct.S1
+  //          {
+
+  //              float A0;                             ; Offset:  128
+  //              double A1;                            ; Offset:  136
+  //              float A2;                             ; Offset:  144
+  //              float A3;                             ; Offset:  148
+  //              float A4;                             ; Offset:  152
+  //              double A5;                            ; Offset:  160
+  //              int A6;                               ; Offset:  168
+
+  //          } C0;                                     ; Offset:  128
+
+  //          float C1[1];                              ; Offset:  176
+  //          struct struct.S2
+  //          {
+
+  //              double B0;                            ; Offset:  192
+  //              float3 B1;                            ; Offset:  208
+  //              float B2;                             ; Offset:  220
+  //              double3 B3;                           ; Offset:  224
+  //              float B4;                             ; Offset:  248
+  //              double2 B5;                           ; Offset:  256
+  //              float B6;                             ; Offset:  272
+  //              float3 B7;                            ; Offset:  276
+  //              float3 B8;                            ; Offset:  288
+
+  //          } C2[2];;                                 ; Offset:  192
+
+  //          float C3;                                 ; Offset:  412
+
+  //      } E3;                                         ; Offset:  128
+
+  //      double E4;                                    ; Offset:  416
+
+  //  } E;                                              ; Offset:    0 Size: 424
+
+  auto const *A = selectFirst<RecordDecl>("A", Results);
+  unsigned SizeA = HLSLBufferDecl::calculateLegacyCbufferSize(
+      Ctx, QualType(A->getTypeForDecl(), 0));
+  ASSERT_EQ(SizeA, 424u * 8u);
+}


### PR DESCRIPTION
Implement packoffset as offset in the layouted struct for cbuffer.
```
cbuffer CB {
  float a : packoffset(c2);
  float b : packoffset(c4);
  float2 c : packoffset(c2.z);
}
```
will get layout struct like
```
struct CBLayout {
  uint8_t padding0[32]; // c0/c1
  float a;         // c2.x
  uint8_t padding1[4];  // c2.y
  float2 c;        // c2.zw
  uint8_t padding[8];  // c3
  float b;         // c4.x
}
```
The padding will only be added between the fields of the CBLayout struct, not any other types. For this hlsl code:
```
struct S {
  float f;
  double d;
};
cbuffer CB {
    S s;
    float f;
}
```
The S::f and S::d will not have paddings in between since it is not the struct created for layout a cbuffer.


And the padding will only be added when there's gap.
If the original layout is already packed tight, no padding will be added.