### PR TITLE
[PowerPC][test] Catch any exception when retrieving git revision

### DIFF
--- a/llvm/test/CodeGen/PowerPC/lit.local.cfg
+++ b/llvm/test/CodeGen/PowerPC/lit.local.cfg
@@ -9,8 +9,8 @@ def get_revision(repo_path):
     cmd = ['git', '-C', repo_path, 'rev-parse', 'HEAD']
     try:
         return subprocess.run(cmd, stdout=subprocess.PIPE, check=True).stdout.decode()
-    except subprocess.CalledProcessError:
-        print("An error occurred retrieving the git revision.")
+    except Exception as e:
+        print("An error occurred retrieving the git revision:", e)
         return None
 
 if config.have_vc_rev:


### PR DESCRIPTION
This makes the `vc-rev-enabled` feature unsupported if we fail to retrieve the git revision for any reason, such as if git is not installed.