### PR TITLE
[Clang][NFC] Mark P2552 as implemented.

### DIFF
--- a/clang/test/SemaCXX/cxx2c-attributes.cpp
+++ b/clang/test/SemaCXX/cxx2c-attributes.cpp
@@ -1,0 +1,23 @@
+// RUN: %clang_cc1 -x c++ -std=c++11 -triple x86_64-pc-linux -fsyntax-only
+// RUN: %clang_cc1 -x c++ -std=c++11 -triple x86_64-windows-msvc -fsyntax-only
+
+// Check we return non-zero values for supported attributes as per
+// wg21.link/p2552r3.pdf
+static_assert(__has_cpp_attribute(assume));
+
+// The standard does not prescribe a behavior for [[carries_dependency]]
+
+static_assert(__has_cpp_attribute(deprecated));
+static_assert(__has_cpp_attribute(fallthrough));
+static_assert(__has_cpp_attribute(likely));
+static_assert(__has_cpp_attribute(unlikely));
+static_assert(__has_cpp_attribute(maybe_unused));
+static_assert(__has_cpp_attribute(nodiscard));
+static_assert(__has_cpp_attribute(noreturn));
+
+#ifdef _MSC_VER
+// We do not support [[no_unique_address]] in MSVC emulation mode
+static_assert(__has_cpp_attribute(no_unique_address) == 0);
+#else
+static_assert(__has_cpp_attribute(no_unique_address));
+#endif

--- a/clang/test/SemaCXX/cxx2c-attributes.cpp
+++ b/clang/test/SemaCXX/cxx2c-attributes.cpp
@@ -1,8 +1,9 @@
-// RUN: %clang_cc1 -x c++ -std=c++11 -triple x86_64-pc-linux -fsyntax-only
-// RUN: %clang_cc1 -x c++ -std=c++11 -triple x86_64-windows-msvc -fsyntax-only
+// RUN: %clang_cc1 %s -x c++ -std=c++11 -triple x86_64-pc-linux -fsyntax-only -verify -Wno-c++17-extensions
+// RUN: %clang_cc1 %s -x c++ -std=c++11 -triple x86_64-windows-msvc -fsyntax-only -verify=msvc -Wno-c++17-extensions
+// expected-no-diagnostics
 
 // Check we return non-zero values for supported attributes as per
-// wg21.link/p2552r3.pdf
+// wg21.link/P2552
 static_assert(__has_cpp_attribute(assume));
 
 // The standard does not prescribe a behavior for [[carries_dependency]]
@@ -15,9 +16,5 @@ static_assert(__has_cpp_attribute(maybe_unused));
 static_assert(__has_cpp_attribute(nodiscard));
 static_assert(__has_cpp_attribute(noreturn));
 
-#ifdef _MSC_VER
 // We do not support [[no_unique_address]] in MSVC emulation mode
-static_assert(__has_cpp_attribute(no_unique_address) == 0);
-#else
-static_assert(__has_cpp_attribute(no_unique_address));
-#endif
+static_assert(__has_cpp_attribute(no_unique_address)); // msvc-error {{static assertion failed}}

--- a/clang/www/cxx_status.html
+++ b/clang/www/cxx_status.html
@@ -130,7 +130,7 @@ C++23, informally referred to as C++26.</p>
  <tr>
   <td>On the ignorability of standard attributes</td>
   <td><a href="https://wg21.link/P2552R3">P2552R3</a> (<a href="#dr">DR</a>)</td>
-  <td class="none" align="center">No</td>
+  <td class="full" align="center">Yes</td>
  </tr>
  <tr>
   <td>Static storage for braced initializers</td>


### PR DESCRIPTION
wg21.link/P2552 suggest that __has_cpp_attribute
should return a non-zero value for all attributes that the implementation does something interesting with.

Clang does something meaninful with all attributes except for:

- no_unique_address which we do not support for msvc target
- carries_dependency which arguably does nothing interesting. P2552 shies away from specifying a behavior for that attribute (despite being the only one for which a recommandation would have been interesting, arguably)

As such, we have nothing to change for this paper. This paper is a DR and clang always behaved reasonably.