### PR TITLE
[PPC][lit] Catch and ignore any exception running 'git'.

### DIFF
--- a/llvm/test/CodeGen/PowerPC/lit.local.cfg
+++ b/llvm/test/CodeGen/PowerPC/lit.local.cfg
@@ -9,7 +9,7 @@ def get_revision(repo_path):
     cmd = ['git', '-C', repo_path, 'rev-parse', 'HEAD']
     try:
         return subprocess.run(cmd, stdout=subprocess.PIPE, check=True).stdout.decode()
-    except subprocess.CalledProcessError:
+    except:
         print("An error occurred retrieving the git revision.")
         return None
 


### PR DESCRIPTION
specifically, OSError for difficulties executing
(e.g., no such file or directory).

Fixes building in environment where git isn't available.