### PR TITLE
[lldb-dap] Include npm install in the extension installation steps

### DIFF
--- a/lldb/tools/lldb-dap/README.md
+++ b/lldb/tools/lldb-dap/README.md
@@ -46,6 +46,7 @@ Installing the plug-in is very straightforward and involves just a few steps.
 
 ```bash
 cd /path/to/lldb/tools/lldb-dap
+npm install
 npm run package # This also compiles the extension.
 npm run vscode-install
 ```
@@ -69,6 +70,7 @@ no effect.
 ```bash
 # Bump version in package.json
 cd /path/to/lldb/tools/lldb-dap
+npm install
 npm run package
 npm run vscode-install
 ```


### PR DESCRIPTION
Otherwise the build step fails due to missing dependencies.
