### PR TITLE
[TableGen][SubtargetEmitter] Refactor hasReadOfWrite to CodeGenProcModel

### DIFF
--- a/llvm/utils/TableGen/Common/CodeGenSchedule.cpp
+++ b/llvm/utils/TableGen/Common/CodeGenSchedule.cpp
@@ -746,15 +746,21 @@ unsigned CodeGenSchedModels::getSchedRWIdx(const Record *Def,
   return I == RWVec.end() ? 0 : std::distance(RWVec.begin(), I);
 }
 
-bool CodeGenSchedModels::hasReadOfWrite(Record *WriteDef) const {
-  for (auto &ProcModel : ProcModels) {
-    const RecVec &RADefs = ProcModel.ReadAdvanceDefs;
-    for (auto &RADef : RADefs) {
-      RecVec ValidWrites = RADef->getValueAsListOfDefs("ValidWrites");
-      if (is_contained(ValidWrites, WriteDef))
-        return true;
-    }
+bool CodeGenSchedModels::hasReadOfWrite(
+    Record *WriteDef, const CodeGenProcModel &ProcModel) const {
+  const RecVec &RADefs = ProcModel.ReadAdvanceDefs;
+  for (auto &RADef : RADefs) {
+    RecVec ValidWrites = RADef->getValueAsListOfDefs("ValidWrites");
+    if (is_contained(ValidWrites, WriteDef))
+      return true;
   }
+  return false;
+}
+
+bool CodeGenSchedModels::hasReadOfWrite(Record *WriteDef) const {
+  for (auto &ProcModel : ProcModels)
+    if (hasReadOfWrite(WriteDef, ProcModel))
+      return true;
   return false;
 }
 

--- a/llvm/utils/TableGen/Common/CodeGenSchedule.cpp
+++ b/llvm/utils/TableGen/Common/CodeGenSchedule.cpp
@@ -746,24 +746,6 @@ unsigned CodeGenSchedModels::getSchedRWIdx(const Record *Def,
   return I == RWVec.end() ? 0 : std::distance(RWVec.begin(), I);
 }
 
-bool CodeGenSchedModels::hasReadOfWrite(
-    Record *WriteDef, const CodeGenProcModel &ProcModel) const {
-  const RecVec &RADefs = ProcModel.ReadAdvanceDefs;
-  for (auto &RADef : RADefs) {
-    RecVec ValidWrites = RADef->getValueAsListOfDefs("ValidWrites");
-    if (is_contained(ValidWrites, WriteDef))
-      return true;
-  }
-  return false;
-}
-
-bool CodeGenSchedModels::hasReadOfWrite(Record *WriteDef) const {
-  for (auto &ProcModel : ProcModels)
-    if (hasReadOfWrite(WriteDef, ProcModel))
-      return true;
-  return false;
-}
-
 static void splitSchedReadWrites(const RecVec &RWDefs, RecVec &WriteDefs,
                                  RecVec &ReadDefs) {
   for (Record *RWDef : RWDefs) {
@@ -2228,6 +2210,15 @@ bool CodeGenProcModel::isUnsupported(const CodeGenInstruction &Inst) const {
       if (TheDef->getName() == PredDef->getName())
         return true;
     }
+  }
+  return false;
+}
+
+bool CodeGenProcModel::hasReadOfWrite(Record *WriteDef) const {
+  for (auto &RADef : ReadAdvanceDefs) {
+    RecVec ValidWrites = RADef->getValueAsListOfDefs("ValidWrites");
+    if (is_contained(ValidWrites, WriteDef))
+      return true;
   }
   return false;
 }

--- a/llvm/utils/TableGen/Common/CodeGenSchedule.h
+++ b/llvm/utils/TableGen/Common/CodeGenSchedule.h
@@ -536,7 +536,13 @@ public:
 
   unsigned getSchedRWIdx(const Record *Def, bool IsRead) const;
 
-  // Return true if the given write record is referenced by a ReadAdvance.
+  // Return true if the given write record is referenced by a ReadAdvance for
+  // the specified ProcModel.
+  bool hasReadOfWrite(Record *WriteDef,
+                      const CodeGenProcModel &ProcModel) const;
+
+  // Return true if the given write record is referenced by a ReadAdvance by any
+  // ProcModel.
   bool hasReadOfWrite(Record *WriteDef) const;
 
   // Get a SchedClass from its index.

--- a/llvm/utils/TableGen/Common/CodeGenSchedule.h
+++ b/llvm/utils/TableGen/Common/CodeGenSchedule.h
@@ -277,6 +277,9 @@ struct CodeGenProcModel {
 
   bool isUnsupported(const CodeGenInstruction &Inst) const;
 
+  // Return true if the given write record is referenced by a ReadAdvance.
+  bool hasReadOfWrite(Record *WriteDef) const;
+
 #ifndef NDEBUG
   void dump() const;
 #endif
@@ -535,15 +538,6 @@ public:
   }
 
   unsigned getSchedRWIdx(const Record *Def, bool IsRead) const;
-
-  // Return true if the given write record is referenced by a ReadAdvance for
-  // the specified ProcModel.
-  bool hasReadOfWrite(Record *WriteDef,
-                      const CodeGenProcModel &ProcModel) const;
-
-  // Return true if the given write record is referenced by a ReadAdvance by any
-  // ProcModel.
-  bool hasReadOfWrite(Record *WriteDef) const;
 
   // Get a SchedClass from its index.
   CodeGenSchedClass &getSchedClass(unsigned Idx) {

--- a/llvm/utils/TableGen/SubtargetEmitter.cpp
+++ b/llvm/utils/TableGen/SubtargetEmitter.cpp
@@ -1122,10 +1122,8 @@ void SubtargetEmitter::GenSchedClassTables(const CodeGenProcModel &ProcModel,
       WriterNames.push_back(SchedModels.getSchedWrite(WriteID).Name);
       // If this Write is not referenced by a ReadAdvance, don't distinguish it
       // from other WriteLatency entries.
-      if (!SchedModels.hasReadOfWrite(SchedModels.getSchedWrite(WriteID).TheDef,
-                                      ProcModel)) {
+      if (!ProcModel.hasReadOfWrite(SchedModels.getSchedWrite(WriteID).TheDef))
         WriteID = 0;
-      }
       WLEntry.WriteResourceID = WriteID;
 
       for (unsigned WS : WriteSeq) {

--- a/llvm/utils/TableGen/SubtargetEmitter.cpp
+++ b/llvm/utils/TableGen/SubtargetEmitter.cpp
@@ -1122,8 +1122,8 @@ void SubtargetEmitter::GenSchedClassTables(const CodeGenProcModel &ProcModel,
       WriterNames.push_back(SchedModels.getSchedWrite(WriteID).Name);
       // If this Write is not referenced by a ReadAdvance, don't distinguish it
       // from other WriteLatency entries.
-      if (!SchedModels.hasReadOfWrite(
-              SchedModels.getSchedWrite(WriteID).TheDef)) {
+      if (!SchedModels.hasReadOfWrite(SchedModels.getSchedWrite(WriteID).TheDef,
+                                      ProcModel)) {
         WriteID = 0;
       }
       WLEntry.WriteResourceID = WriteID;


### PR DESCRIPTION
SubtargetEmitter::GenSchedClassTables takes a CodeGenProcModel, but calls hasReadOfWrite which loops over all ProcModels. We move hasReadOfWrite to CodeGenProcModel and remove the loop over all ProcModels. This leads to a 144% speedup on the RISC-V backend of our downstream.