### PR TITLE
[libc][errno] Remove unnecessary include

### DIFF
--- a/libc/src/errno/libc_errno.cpp
+++ b/libc/src/errno/libc_errno.cpp
@@ -36,9 +36,6 @@ void LIBC_NAMESPACE::Errno::operator=(int a) { __llvmlibc_errno = a; }
 LIBC_NAMESPACE::Errno::operator int() { return __llvmlibc_errno; }
 
 #else
-// In overlay mode, we simply use the system errno.
-#include "hdr/errno_macros.h"
-
 void LIBC_NAMESPACE::Errno::operator=(int a) { errno = a; }
 LIBC_NAMESPACE::Errno::operator int() { return errno; }
 


### PR DESCRIPTION
Since https://github.com/llvm/llvm-project/pull/91150, a proxy header for the errno macros is available and gets included in `libc_errno.h` since then.

As `libc_errno.cpp` includes `libc_errno.h`, which already includes the proxy header `hdr/errno_macros.h`, there's no need to include it in `libc_errno.cpp` if we are in overlay mode, because the proxy header takes care to either include our header from libc/include/ (fullbuild) or the corresponding underlying system header (overlay). 