### PR TITLE
[lldb] Fixed the test TestThreadStates when run with a remote target

### DIFF
--- a/lldb/test/API/functionalities/thread/state/TestThreadStates.py
+++ b/lldb/test/API/functionalities/thread/state/TestThreadStates.py
@@ -102,10 +102,6 @@ class ThreadStateTestCase(TestBase):
 
     def wait_for_running_event(self, process):
         listener = self.dbg.GetListener()
-        if lldb.remote_platform:
-            lldbutil.expect_state_changes(
-                self, listener, process, [lldb.eStateConnected]
-            )
         lldbutil.expect_state_changes(self, listener, process, [lldb.eStateRunning])
 
     def thread_state_after_continue_test(self):


### PR DESCRIPTION
self.wait_for_running_event(process) is always called after self.runCmd("continue"). It is strange to expect eStateConnected here. This test failed in case of a remote target. The correct state is eStateRunning. Removed incorrect checking.