### PR TITLE
[lldb][Windows] Fixed the test gdb_remote_client/TestGDBRemotePlatformFile

### DIFF
--- a/lldb/test/API/functionalities/gdb_remote_client/TestGDBRemotePlatformFile.py
+++ b/lldb/test/API/functionalities/gdb_remote_client/TestGDBRemotePlatformFile.py
@@ -148,6 +148,7 @@ class TestGDBRemotePlatformFile(GDBPlatformClientTestBase):
         )
 
     @skipIfWindows
+    @skipIf(hostoslist=["windows"])
     def test_file_permissions(self):
         """Test 'platform get-permissions'"""
 
@@ -168,6 +169,7 @@ class TestGDBRemotePlatformFile(GDBPlatformClientTestBase):
         )
 
     @skipIfWindows
+    @skipIf(hostoslist=["windows"])
     def test_file_permissions_fallback(self):
         """Test 'platform get-permissions' fallback to fstat"""
 

--- a/lldb/test/API/functionalities/gdb_remote_client/TestGDBRemotePlatformFile.py
+++ b/lldb/test/API/functionalities/gdb_remote_client/TestGDBRemotePlatformFile.py
@@ -147,7 +147,6 @@ class TestGDBRemotePlatformFile(GDBPlatformClientTestBase):
             log=server2.responder.packetLog,
         )
 
-    @skipIfWindows
     @skipIf(hostoslist=["windows"])
     def test_file_permissions(self):
         """Test 'platform get-permissions'"""
@@ -168,7 +167,6 @@ class TestGDBRemotePlatformFile(GDBPlatformClientTestBase):
             ]
         )
 
-    @skipIfWindows
     @skipIf(hostoslist=["windows"])
     def test_file_permissions_fallback(self):
         """Test 'platform get-permissions' fallback to fstat"""

--- a/lldb/test/API/functionalities/gdb_remote_client/TestGDBRemotePlatformFile.py
+++ b/lldb/test/API/functionalities/gdb_remote_client/TestGDBRemotePlatformFile.py
@@ -147,7 +147,9 @@ class TestGDBRemotePlatformFile(GDBPlatformClientTestBase):
             log=server2.responder.packetLog,
         )
 
-    @skipIf(hostoslist=["windows"])
+    @expectedFailureAll(
+        hostoslist=["windows"], bugnumber="github.com/llvm/llvm-project/issues/92255"
+    )
     def test_file_permissions(self):
         """Test 'platform get-permissions'"""
 
@@ -167,7 +169,9 @@ class TestGDBRemotePlatformFile(GDBPlatformClientTestBase):
             ]
         )
 
-    @skipIf(hostoslist=["windows"])
+    @expectedFailureAll(
+        hostoslist=["windows"], bugnumber="github.com/llvm/llvm-project/issues/92255"
+    )
     def test_file_permissions_fallback(self):
         """Test 'platform get-permissions' fallback to fstat"""
 


### PR DESCRIPTION
The tests `test_file_permissions` and `test_file_permissions_fallback` are disabled for Windows target. These tests use MockGDBServerResponder and do not depend on the real target. These tests failed in case of Windows host and Linux target. Disable them for Windows host too.