### PR TITLE
[lldb/aarch64] Allow unaligned PC addresses below a trap handler

### DIFF
--- a/lldb/test/Shell/Unwind/Inputs/unaligned-pc-sigbus.c
+++ b/lldb/test/Shell/Unwind/Inputs/unaligned-pc-sigbus.c
@@ -1,0 +1,21 @@
+#include <signal.h>
+#include <stdint.h>
+#include <unistd.h>
+
+void sigbus_handler(int signo) { _exit(47); }
+
+int target_function() { return 47; }
+
+int main() {
+  signal(SIGBUS, sigbus_handler);
+
+  // Generate a SIGBUS by deliverately calling through an unaligned function
+  // pointer.
+  union {
+    int (*t)();
+    uintptr_t p;
+  } u;
+  u.t = target_function;
+  u.p |= 1;
+  return u.t();
+}

--- a/lldb/test/Shell/Unwind/unaligned-pc-sigbus.test
+++ b/lldb/test/Shell/Unwind/unaligned-pc-sigbus.test
@@ -1,0 +1,26 @@
+# REQUIRES: (target-aarch64 || target-arm) && native
+# UNSUPPORTED: system-windows
+
+# RUN: %clang_host %S/Inputs/unaligned-pc-sigbus.c -o %t
+# RUN: %lldb -s %s -o exit %t | FileCheck %s
+
+breakpoint set -n sigbus_handler
+# CHECK: Breakpoint 1: where = {{.*}}`sigbus_handler
+
+run
+# CHECK: thread #1, {{.*}} stop reason = signal SIGBUS
+
+thread backtrace
+# CHECK: (lldb) thread backtrace
+# CHECK: frame #0: [[TARGET:0x[0-9a-fA-F]*]] {{.*}}`target_function
+
+continue
+# CHECK: thread #1, {{.*}} stop reason = breakpoint 1
+
+
+thread backtrace
+# CHECK: (lldb) thread backtrace
+# CHECK: frame #0: {{.*}}`sigbus_handler
+# Unknown number of signal trampoline frames
+# CHECK: frame #{{[0-9]+}}: [[TARGET]] {{.*}}`target_function
+

--- a/lldb/test/Shell/Unwind/unaligned-pc-sigbus.test
+++ b/lldb/test/Shell/Unwind/unaligned-pc-sigbus.test
@@ -1,8 +1,13 @@
 # REQUIRES: (target-aarch64 || target-arm) && native
 # UNSUPPORTED: system-windows
+# llvm.org/pr91610, rdar://128031075
+# XFAIL: system-darwin
 
 # RUN: %clang_host %S/Inputs/unaligned-pc-sigbus.c -o %t
 # RUN: %lldb -s %s -o exit %t | FileCheck %s
+
+# Convert EXC_BAD_ACCESS into SIGBUS on darwin.
+settings set platform.plugin.darwin.ignored-exceptions EXC_BAD_ACCESS
 
 breakpoint set -n sigbus_handler
 # CHECK: Breakpoint 1: where = {{.*}}`sigbus_handler


### PR DESCRIPTION
The stack validation heuristic is counter-productive in this case, as the unaligned address is most likely the thing that caused the signal in the first place.