### PR TITLE
[CodeGen][ARM64EC] Use function symbol type for function alias symbols.

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64AsmPrinter.cpp
+++ b/llvm/lib/Target/AArch64/AArch64AsmPrinter.cpp
@@ -1168,6 +1168,10 @@ void AArch64AsmPrinter::emitFunctionEntryLabel() {
     // For ARM64EC targets, a function definition's name is mangled differently
     // from the normal symbol, emit required aliases here.
     auto emitFunctionAlias = [&](MCSymbol *Src, MCSymbol *Dst) {
+      OutStreamer->beginCOFFSymbolDef(Src);
+      OutStreamer->emitCOFFSymbolType(COFF::IMAGE_SYM_DTYPE_FUNCTION
+                                      << COFF::SCT_COMPLEX_TYPE_SHIFT);
+      OutStreamer->endCOFFSymbolDef();
       OutStreamer->emitSymbolAttribute(Src, MCSA_WeakAntiDep);
       OutStreamer->emitAssignment(
           Src, MCSymbolRefExpr::create(Dst, MCSymbolRefExpr::VK_WEAKREF,

--- a/llvm/test/CodeGen/AArch64/arm64ec-symbols.ll
+++ b/llvm/test/CodeGen/AArch64/arm64ec-symbols.ll
@@ -1,0 +1,25 @@
+; RUN: llc -mtriple=arm64ec-pc-windows-msvc < %s | FileCheck %s
+
+declare void @func() nounwind;
+
+define void @caller() nounwind {
+  call void @func()
+  ret void
+}
+
+; CHECK:      .def    caller;
+; CHECK-NEXT: .type   32;
+; CHECK-NEXT: .endef
+; CHECK-NEXT: .weak_anti_dep  caller
+; CHECK-NEXT: .set caller, "#caller"@WEAKREF
+
+; CHECK:      .def    func;
+; CHECK-NEXT: .type   32;
+; CHECK-NEXT: .endef
+; CHECK-NEXT: .weak_anti_dep  func
+; CHECK-NEXT: .set func, "#func"@WEAKREF
+; CHECK-NEXT: .def    "#func";
+; CHECK-NEXT: .type   32;
+; CHECK-NEXT: .endef
+; CHECK-NEXT: .weak_anti_dep  "#func"
+; CHECK-NEXT: .set "#func", "#func$exit_thunk"@WEAKREF


### PR DESCRIPTION
Depends on #92098. I noticed that that's what MSVC does and it seems reasonable.