### PR TITLE
[lldb-dap] Correctly detect alias commands with arguments in repl

### DIFF
--- a/lldb/test/API/tools/lldb-dap/repl-mode/Makefile
+++ b/lldb/test/API/tools/lldb-dap/repl-mode/Makefile
@@ -1,0 +1,3 @@
+CXX_SOURCES := main.cpp
+
+include Makefile.rules

--- a/lldb/test/API/tools/lldb-dap/repl-mode/TestDAP_repl_mode_detection.py
+++ b/lldb/test/API/tools/lldb-dap/repl-mode/TestDAP_repl_mode_detection.py
@@ -1,0 +1,56 @@
+"""
+Test lldb-dap repl mode detection
+"""
+
+import lldbdap_testcase
+import dap_server
+from lldbsuite.test import lldbutil
+from lldbsuite.test.decorators import *
+from lldbsuite.test.lldbtest import *
+
+
+class TestDAP_repl_mode_detection(lldbdap_testcase.DAPTestCaseBase):
+
+    def assertEvaluate(self, expression, regex):
+        self.assertRegex(
+            self.dap_server.request_evaluate(expression, context="repl")["body"][
+                "result"
+            ],
+            regex,
+        )
+
+    def test_completions(self):
+        program = self.getBuildArtifact("a.out")
+        self.build_and_launch(program)
+
+        source = "main.cpp"
+        breakpoint1_line = line_number(source, "// breakpoint 1")
+        breakpoint2_line = line_number(source, "// breakpoint 2")
+
+        self.set_source_breakpoints(source, [breakpoint1_line, breakpoint2_line])
+
+        self.assertEvaluate(
+            "`command regex user_command s/^$/platform/", r"\(lldb\) command regex"
+        )
+        self.assertEvaluate(
+            "`command alias alias_command platform", r"\(lldb\) command alias"
+        )
+        self.assertEvaluate(
+            "`command alias alias_command_with_arg platform select --sysroot %1 remote-linux",
+            r"\(lldb\) command alias",
+        )
+
+        self.continue_to_next_stop()
+        self.assertEvaluate("user_command", "474747")
+        self.assertEvaluate("alias_command", "474747")
+        self.assertEvaluate("alias_command_with_arg", "474747")
+        self.assertEvaluate("platform", "474747")
+
+        self.continue_to_next_stop()
+        platform_help_needle = "Commands to manage and create platforms"
+        self.assertEvaluate("user_command", platform_help_needle)
+        self.assertEvaluate("alias_command", platform_help_needle)
+        self.assertEvaluate(
+            "alias_command_with_arg " + self.getBuildDir(), "Platform: remote-linux"
+        )
+        self.assertEvaluate("platform", platform_help_needle)

--- a/lldb/test/API/tools/lldb-dap/repl-mode/TestDAP_repl_mode_detection.py
+++ b/lldb/test/API/tools/lldb-dap/repl-mode/TestDAP_repl_mode_detection.py
@@ -10,7 +10,6 @@ from lldbsuite.test.lldbtest import *
 
 
 class TestDAP_repl_mode_detection(lldbdap_testcase.DAPTestCaseBase):
-
     def assertEvaluate(self, expression, regex):
         self.assertRegex(
             self.dap_server.request_evaluate(expression, context="repl")["body"][

--- a/lldb/test/API/tools/lldb-dap/repl-mode/main.cpp
+++ b/lldb/test/API/tools/lldb-dap/repl-mode/main.cpp
@@ -1,0 +1,15 @@
+void noop() {}
+
+void fun() {
+  int user_command = 474747;
+  int alias_command = 474747;
+  int alias_command_with_arg = 474747;
+  int platform = 474747; // built-in command
+  noop();                // breakpoint 1
+}
+
+int main() {
+  fun();
+  noop(); // breakpoint 2
+  return 0;
+}

--- a/lldb/tools/lldb-dap/DAP.cpp
+++ b/lldb/tools/lldb-dap/DAP.cpp
@@ -14,6 +14,7 @@
 
 #include "DAP.h"
 #include "LLDBUtils.h"
+#include "lldb/API/SBCommandInterpreter.h"
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/Support/FormatVariadic.h"
 
@@ -405,9 +406,10 @@ ExpressionContext DAP::DetectExpressionContext(lldb::SBFrame frame,
     std::pair<llvm::StringRef, llvm::StringRef> token =
         llvm::getToken(expression);
     std::string term = token.first.str();
-    lldb::SBCommandReturnObject result;
-    debugger.GetCommandInterpreter().ResolveCommand(term.c_str(), result);
-    bool term_is_command = result.Succeeded();
+    lldb::SBCommandInterpreter interpreter = debugger.GetCommandInterpreter();
+    bool term_is_command = interpreter.CommandExists(term.c_str()) ||
+                           interpreter.UserCommandExists(term.c_str()) ||
+                           interpreter.AliasExists(term.c_str());
     bool term_is_variable = frame.FindVariable(term.c_str()).IsValid();
 
     // If we have both a variable and command, warn the user about the conflict.


### PR DESCRIPTION
ResolveCommand will not succeed for an alias command with arguments, and the code wasn't providing any. Replace that with explicit query(ies) for the existence of a command with the given name.