### PR TITLE
[clang] Store FPOptions earlier when parsing function

### DIFF
--- a/clang/lib/Parse/Parser.cpp
+++ b/clang/lib/Parse/Parser.cpp
@@ -1439,6 +1439,8 @@ Decl *Parser::ParseFunctionDefinition(ParsingDeclarator &D,
     }
   }
 
+  Sema::FPFeaturesStateRAII SaveFPFeatures(Actions);
+
   // Tell the actions module that we have entered a function definition with the
   // specified Declarator for the function.
   SkipBodyInfo SkipBody;
@@ -1496,8 +1498,6 @@ Decl *Parser::ParseFunctionDefinition(ParsingDeclarator &D,
     Actions.ActOnSkippedFunctionBody(Res);
     return Actions.ActOnFinishFunctionBody(Res, nullptr, false);
   }
-
-  Sema::FPFeaturesStateRAII SaveFPFeatures(Actions);
 
   if (Tok.is(tok::kw_try))
     return ParseFunctionTryBlock(Res, BodyScope);

--- a/clang/test/PCH/optnone.cpp
+++ b/clang/test/PCH/optnone.cpp
@@ -1,0 +1,6 @@
+// RUN: %clang_cc1 -emit-pch -DHEADER -x c++-header %s -o %t.pch
+// RUN: %clang_cc1 -emit-llvm -include-pch %t.pch %s -o /dev/null
+
+#ifdef HEADER
+__attribute__((optnone)) void foo() {}
+#endif

--- a/clang/test/PCH/optnone.cpp
+++ b/clang/test/PCH/optnone.cpp
@@ -1,6 +1,6 @@
-// RUN: %clang_cc1 -emit-pch -DHEADER -x c++-header %s -o %t.pch
-// RUN: %clang_cc1 -emit-llvm -include-pch %t.pch %s -o /dev/null
+// RUN: %clang_cc1 -emit-pch -x c++-header %s -o %t.pch
+// RUN: %clang_cc1 -emit-llvm -DMAIN -include-pch %t.pch %s -o /dev/null
 
-#ifdef HEADER
+#ifndef MAIN
 __attribute__((optnone)) void foo() {}
 #endif


### PR DESCRIPTION
After https://github.com/llvm/llvm-project/pull/85605 ([clang] Set correct FPOptions if attribute 'optnone' presents) the current FP options in Sema are saved during parsing function because Sema can modify them if optnone is present. However they were saved too late, it caused fails in some cases when precompiled headers are used. This patch moves the storing earlier.