### PR TITLE
[Deprecated][SampleFDO] Stale profile call-graph matching 

### DIFF
--- a/llvm/include/llvm/Transforms/IPO/SampleProfileMatcher.h
+++ b/llvm/include/llvm/Transforms/IPO/SampleProfileMatcher.h
@@ -35,7 +35,7 @@ class SampleProfileMatcher {
   // in the profile.
   StringMap<LocToLocMap> FuncMappings;
 
-  // Match state for an anchor/callsite.
+  // Match state for an anchor/callsite or function.
   enum class MatchState {
     Unknown = 0,
     // Initial match between input profile and current IR.
@@ -186,6 +186,12 @@ private:
   void runStaleProfileMatching(const Function &F, const AnchorMap &IRAnchors,
                                const AnchorMap &ProfileAnchors,
                                LocToLocMap &IRToProfileLocationMap);
+  /// Find the existing or new matched function using the profile name.
+  ///
+  /// \returns The function and a match state.
+  std::pair<Function *, MatchState>
+  findFunction(const FunctionId &ProfFunc,
+               const FunctionMap &OldProfToNewSymbolMap) const;
   /// Find the function using the profile name. If the function is not found but
   /// the \p NewIRCallees is provided, try to match the function profile with
   /// all functions in \p NewIRCallees and return the matched function.
@@ -194,9 +200,8 @@ private:
   /// \param OldProfToNewSymbolMap The map from old profile name to new symbol.
   /// \param NewIRCallees The new candidate callees in the same scope to match.
   ///
-  /// \returns The matched function and a bool value indicating whether the
-  /// function is new(matched).
-  std::pair<Function *, bool>
+  /// \returns The matched function and a match state.
+  std::pair<Function *, MatchState>
   findOrMatchFunction(const FunctionId &ProfFunc,
                       FunctionMap &OldProfToNewSymbolMap,
                       const std::vector<Function *> &NewIRCallees);

--- a/llvm/include/llvm/Transforms/IPO/SampleProfileMatcher.h
+++ b/llvm/include/llvm/Transforms/IPO/SampleProfileMatcher.h
@@ -186,22 +186,42 @@ private:
   void runStaleProfileMatching(const Function &F, const AnchorMap &IRAnchors,
                                const AnchorMap &ProfileAnchors,
                                LocToLocMap &IRToProfileLocationMap);
+  /// Find the function using the profile name. If the function is not found but
+  /// the \p NewIRCallees is provided, try to match the function profile with
+  /// all functions in \p NewIRCallees and return the matched function.
+  ///
+  /// \param ProfCallee The profile name of the callee.
+  /// \param OldProfToNewSymbolMap The map from old profile name to new symbol.
+  /// \param NewIRCallees The new candidate callees in the same scope to match.
+  ///
+  /// \returns The matched function and a bool value indicating whether the
+  /// function is new(matched).
   std::pair<Function *, bool>
   findOrMatchFunction(const FunctionId &ProfCallee,
                       FunctionMap &OldProfToNewSymbolMap,
                       const std::vector<Function *> &NewIRCallees);
   std::vector<FunctionSamples *> sortFuncProfiles(SampleProfileMap &ProfileMap);
   void findNewIRCallees(Function &Caller,
-                        const StringMap<Function *> &newIRFunctions,
+                        const StringMap<Function *> &NewIRFunctions,
                         std::vector<Function *> &NewIRCallees);
   bool functionMatchesProfileHelper(const Function &IRFunc,
                                     const FunctionId &ProfFunc);
+  /// Determine if the function matches profile by computing a similarity ratio
+  /// between two callsite anchors extracted from function and profile. If it's
+  /// above the threshold, the function matches the profile.
+  ///
+  /// \returns True if the function matches profile.
   bool functionMatchesProfile(const Function &IRFunc,
                               const FunctionId &ProfFunc);
-  void matchProfileForNewFunctions(const StringMap<Function *> &newIRFunctions,
+  void matchProfileForNewFunctions(const StringMap<Function *> &NewIRFunctions,
                                    FunctionSamples &FS,
                                    FunctionMap &OldProfToNewSymbolMap);
-  void findNewIRFunctions(StringMap<Function *> &newIRFunctions);
+  /// Find functions that don't show in the profile or profile symbol list,
+  /// which are supposed to be new functions. We use them as the targets for
+  /// renaming matching.
+  ///
+  /// \param NewIRFunctions The map from function name to the IR function.
+  void findNewIRFunctions(StringMap<Function *> &NewIRFunctions);
   void runCallGraphMatching();
   void reportOrPersistProfileStats();
 };

--- a/llvm/include/llvm/Transforms/IPO/SampleProfileMatcher.h
+++ b/llvm/include/llvm/Transforms/IPO/SampleProfileMatcher.h
@@ -15,7 +15,6 @@
 #define LLVM_TRANSFORMS_IPO_SAMPLEPROFILEMATCHER_H
 
 #include "llvm/ADT/StringSet.h"
-#include "llvm/Analysis/ProfileSummaryInfo.h"
 #include "llvm/Transforms/Utils/SampleProfileLoaderBaseImpl.h"
 
 namespace llvm {
@@ -187,15 +186,22 @@ private:
   void runStaleProfileMatching(const Function &F, const AnchorMap &IRAnchors,
                                const AnchorMap &ProfileAnchors,
                                LocToLocMap &IRToProfileLocationMap);
+  std::pair<Function *, bool>
+  findOrMatchFunction(const FunctionId &ProfCallee,
+                      FunctionMap &OldProfToNewSymbolMap,
+                      const std::vector<Function *> &NewIRCallees);
+  std::vector<FunctionSamples *> sortFuncProfiles(SampleProfileMap &ProfileMap);
   void findNewIRCallees(Function &Caller,
                         const StringMap<Function *> &newIRFunctions,
                         std::vector<Function *> &NewIRCallees);
+  bool functionMatchesProfileHelper(const Function &IRFunc,
+                                    const FunctionId &ProfFunc);
   bool functionMatchesProfile(const Function &IRFunc,
                               const FunctionId &ProfFunc);
   void matchProfileForNewFunctions(const StringMap<Function *> &newIRFunctions,
                                    FunctionSamples &FS,
                                    FunctionMap &OldProfToNewSymbolMap);
-  void findnewIRFunctions(StringMap<Function *> &newIRFunctions);
+  void findNewIRFunctions(StringMap<Function *> &newIRFunctions);
   void runCallGraphMatching();
   void reportOrPersistProfileStats();
 };

--- a/llvm/include/llvm/Transforms/IPO/SampleProfileMatcher.h
+++ b/llvm/include/llvm/Transforms/IPO/SampleProfileMatcher.h
@@ -190,14 +190,14 @@ private:
   /// the \p NewIRCallees is provided, try to match the function profile with
   /// all functions in \p NewIRCallees and return the matched function.
   ///
-  /// \param ProfCallee The profile name of the callee.
+  /// \param ProfFunc The function profile name.
   /// \param OldProfToNewSymbolMap The map from old profile name to new symbol.
   /// \param NewIRCallees The new candidate callees in the same scope to match.
   ///
   /// \returns The matched function and a bool value indicating whether the
   /// function is new(matched).
   std::pair<Function *, bool>
-  findOrMatchFunction(const FunctionId &ProfCallee,
+  findOrMatchFunction(const FunctionId &ProfFunc,
                       FunctionMap &OldProfToNewSymbolMap,
                       const std::vector<Function *> &NewIRCallees);
   std::vector<FunctionSamples *> sortFuncProfiles(SampleProfileMap &ProfileMap);

--- a/llvm/include/llvm/Transforms/IPO/SampleProfileMatcher.h
+++ b/llvm/include/llvm/Transforms/IPO/SampleProfileMatcher.h
@@ -34,7 +34,7 @@ class SampleProfileMatcher {
   // in the profile.
   StringMap<LocToLocMap> FuncMappings;
 
-  // Match state for an anchor/callsite or function.
+  // Match state for an anchor/callsite.
   enum class MatchState {
     Unknown = 0,
     // Initial match between input profile and current IR.

--- a/llvm/include/llvm/Transforms/IPO/SampleProfileMatcher.h
+++ b/llvm/include/llvm/Transforms/IPO/SampleProfileMatcher.h
@@ -79,10 +79,7 @@ class SampleProfileMatcher {
   // the profile is unused(to be matched) or not.
   HashKeyMap<std::unordered_map, FunctionId, Function *> *SymbolMap;
 
-  // A map from the caller to its new callees, this is used as a cache for the
-  // candidate callees.
-  std::unordered_map<Function *, std::vector<Function *>> FuncToNewCalleesMap;
-
+  // The new functions from IR.
   HashKeyMap<std::unordered_map, FunctionId, Function *> NewIRFunctions;
 
   // Pointer to the Profile Symbol List in the reader.
@@ -101,6 +98,10 @@ class SampleProfileMatcher {
   uint64_t MismatchedFunctionSamples = 0;
   uint64_t MismatchedCallsiteSamples = 0;
   uint64_t RecoveredCallsiteSamples = 0;
+
+  // Profile call-graph matching statstics:
+  uint64_t NumRecoveredUnusedSamples = 0;
+  uint64_t NumRecoveredUnusedFunc = 0;
 
   // A dummy name for unknown indirect callee, used to differentiate from a
   // non-call instruction that also has an empty callee name.
@@ -121,6 +122,10 @@ public:
     // will be used for sample loader.
     FuncCallsiteMatchStates.clear();
     FlattenedProfiles.clear();
+
+    NewIRFunctions.clear();
+    FunctionProfileNameMap.clear();
+    ProfileNameToFuncMap.clear();
   }
 
 private:
@@ -224,11 +229,6 @@ private:
   void findNewIRFunctions();
   void updateProfillesAndSymbolMap();
   void updateProfileWithNewName(FunctionSamples &FuncProfile);
-
-  void clearCacheData() {
-    FunctionProfileNameMap.clear();
-    ProfileNameToFuncMap.clear();
-  }
   void runCallGraphMatching();
   void reportOrPersistProfileStats();
 };

--- a/llvm/include/llvm/Transforms/IPO/SampleProfileMatcher.h
+++ b/llvm/include/llvm/Transforms/IPO/SampleProfileMatcher.h
@@ -69,7 +69,7 @@ class SampleProfileMatcher {
   // matching result.
   std::unordered_map<std::pair<const Function *, FunctionId>, bool,
                      FuncProfNameMapHash>
-      FunctionProfileNameMap;
+      FuncToProfileNameMap;
   // The new functions found by the call graph matching. The map's key is the
   // old profile name and value is the new(renamed) function.
   HashKeyMap<std::unordered_map, FunctionId, Function *> ProfileNameToFuncMap;
@@ -115,7 +115,7 @@ public:
       HashKeyMap<std::unordered_map, FunctionId, Function *> &SymMap,
       std::shared_ptr<ProfileSymbolList> PSL)
       : M(M), Reader(Reader), ProbeManager(ProbeManager), LTOPhase(LTOPhase),
-        SymbolMap(&SymMap), PSL(PSL){};
+        SymbolMap(&SymMap), PSL(PSL) {};
   void runOnModule(std::vector<Function *> &OrderedFuncList);
   void clearMatchingData() {
     // Do not clear FuncMappings, it stores IRLoc to ProfLoc remappings which
@@ -124,7 +124,7 @@ public:
     FlattenedProfiles.clear();
 
     NewIRFunctions.clear();
-    FunctionProfileNameMap.clear();
+    FuncToProfileNameMap.clear();
     ProfileNameToFuncMap.clear();
   }
 

--- a/llvm/lib/Transforms/IPO/SampleProfile.cpp
+++ b/llvm/lib/Transforms/IPO/SampleProfile.cpp
@@ -544,7 +544,7 @@ protected:
 
   /// Profle Symbol list tells whether a function name appears in the binary
   /// used to generate the current profile.
-  std::unique_ptr<ProfileSymbolList> PSL;
+  std::shared_ptr<ProfileSymbolList> PSL;
 
   /// Total number of samples collected in this profile.
   ///
@@ -2077,7 +2077,7 @@ bool SampleProfileLoader::doInitialization(Module &M,
   if (ReportProfileStaleness || PersistProfileStaleness ||
       SalvageStaleProfile) {
     MatchingManager = std::make_unique<SampleProfileMatcher>(
-        M, *Reader, ProbeManager.get(), LTOPhase);
+        M, *Reader, ProbeManager.get(), LTOPhase, PSL);
   }
 
   return true;
@@ -2198,7 +2198,7 @@ bool SampleProfileLoader::runOnModule(Module &M, ModuleAnalysisManager *AM,
 
   if (ReportProfileStaleness || PersistProfileStaleness ||
       SalvageStaleProfile) {
-    MatchingManager->runOnModule();
+    MatchingManager->runOnModule(SymbolMap);
     MatchingManager->clearMatchingData();
   }
 

--- a/llvm/lib/Transforms/IPO/SampleProfileMatcher.cpp
+++ b/llvm/lib/Transforms/IPO/SampleProfileMatcher.cpp
@@ -676,20 +676,20 @@ void SampleProfileMatcher::findNewIRCallees(
 }
 
 std::pair<Function *, bool> SampleProfileMatcher::findOrMatchFunction(
-    const FunctionId &ProfCallee, FunctionMap &OldProfToNewSymbolMap,
+    const FunctionId &ProfFunc, FunctionMap &OldProfToNewSymbolMap,
     const std::vector<Function *> &NewIRCallees = std::vector<Function *>()) {
-  auto F = SymbolMap->find(ProfCallee);
+  auto F = SymbolMap->find(ProfFunc);
   if (F != SymbolMap->end())
     return {F->second, false};
 
   // Existing matched function is found.
-  auto NewF = OldProfToNewSymbolMap.find(ProfCallee);
+  auto NewF = OldProfToNewSymbolMap.find(ProfFunc);
   if (NewF != OldProfToNewSymbolMap.end())
     return {NewF->second, true};
 
   for (auto *IRCallee : NewIRCallees)
-    if (functionMatchesProfile(*IRCallee, ProfCallee)) {
-      OldProfToNewSymbolMap[ProfCallee] = IRCallee;
+    if (functionMatchesProfile(*IRCallee, ProfFunc)) {
+      OldProfToNewSymbolMap[ProfFunc] = IRCallee;
       return {IRCallee, true};
     }
   return {nullptr, false};

--- a/llvm/lib/Transforms/IPO/SampleProfileMatcher.cpp
+++ b/llvm/lib/Transforms/IPO/SampleProfileMatcher.cpp
@@ -783,6 +783,8 @@ void SampleProfileMatcher::matchProfileForNewFunctions(
 
   // Match non-inline callees.
   for (auto &BS : const_cast<BodySampleMap &>(CallerFS.getBodySamples())) {
+    if (NewIRCallees.empty())
+      break;
     // New function to old function pairs used to update the CallTargetMap.
     std::vector<std::pair<FunctionId, FunctionId>> CallTargetsToUpdate;
     SampleRecord::CallTargetMap &CTM =

--- a/llvm/lib/Transforms/IPO/SampleProfileMatcher.cpp
+++ b/llvm/lib/Transforms/IPO/SampleProfileMatcher.cpp
@@ -630,8 +630,8 @@ void SampleProfileMatcher::findNewIRFunctions(
   }
 
   for (auto &F : M) {
-    // Skip declarations, as even if the function can be recognized renamed, we
-    // have nothing to do with it.
+    // Skip declarations, as even if the function can be matched, we have
+    // nothing to do with it.
     if (F.isDeclaration())
       continue;
 
@@ -797,7 +797,7 @@ void SampleProfileMatcher::matchProfileForNewFunctions(
   // Find the new candidate IR callees in the current caller scope.
   std::vector<Function *> *IRCalleesToMatch = nullptr;
   if (auto *IRCaller = findFuncByProfileName(FuncProfile.getFunction())) {
-    // No callees for external function, skip the rename matching.
+    // No callees for external function, skip the call graph matching.
     if (IRCaller->isDeclaration())
       return;
     IRCalleesToMatch = findNewIRCallees(*IRCaller, NewIRFunctions);

--- a/llvm/lib/Transforms/IPO/SampleProfileMatcher.cpp
+++ b/llvm/lib/Transforms/IPO/SampleProfileMatcher.cpp
@@ -790,15 +790,15 @@ bool SampleProfileMatcher::functionMatchesProfileHelper(
 bool SampleProfileMatcher::functionMatchesProfile(Function &IRFunc,
                                                   const FunctionId &ProfFunc,
                                                   bool FindMatchedProfileOnly) {
-  auto R = FunctionProfileNameMap.find({&IRFunc, ProfFunc});
-  if (R != FunctionProfileNameMap.end())
+  auto R = FuncToProfileNameMap.find({&IRFunc, ProfFunc});
+  if (R != FuncToProfileNameMap.end())
     return R->second;
 
   if (FindMatchedProfileOnly)
     return false;
 
   bool Matched = functionMatchesProfileHelper(IRFunc, ProfFunc);
-  FunctionProfileNameMap[{&IRFunc, ProfFunc}] = Matched;
+  FuncToProfileNameMap[{&IRFunc, ProfFunc}] = Matched;
   if (Matched) {
     ProfileNameToFuncMap[ProfFunc] = &IRFunc;
     LLVM_DEBUG(dbgs() << "Function:" << IRFunc.getName()

--- a/llvm/test/Transforms/SampleProfile/Inputs/pseudo-probe-stale-profile-renaming.prof
+++ b/llvm/test/Transforms/SampleProfile/Inputs/pseudo-probe-stale-profile-renaming.prof
@@ -1,0 +1,62 @@
+main:47:0
+ 1: 0
+ 2: 2
+ 3: 0
+ 4: 3
+ 7: 2 test_noninline:2
+ 8: 2
+ 9: 0
+ 5: foo:24
+  1: 3
+  2: 3 bar:3
+  4: 3 bar:3
+  5: 1 mismatch:1
+  3: baz:15
+   1: 3
+   2: block_only:12
+    1: 3
+    3: 3
+    5: 3
+    10: 3
+    !CFGChecksum: 206551239323
+   !CFGChecksum: 281479271677951
+  !CFGChecksum: 123456
+ 6: baz:14
+  1: 3
+  2: block_only:11
+   1: 3
+   3: 3
+   5: 3
+   10: 2
+   !CFGChecksum: 206551239323
+  !CFGChecksum: 281479271677951
+ 10: cold_func:0
+  1: 0
+  2: block_only:0
+   1: 0
+   3: 0
+   5: 0
+   10: 0
+   !CFGChecksum: 206551239323
+  !CFGChecksum: 281479271677951
+ !CFGChecksum: 1126003093360596
+test_noninline:22:2
+ 1: 2
+ 2: foo:20
+  1: 2
+  2: 2 bar:3
+  4: 3 bar:3
+  3: baz:13
+   1: 2
+   2: block_only:11
+    1: 2
+    3: 3
+    5: 3
+    10: 3
+    !CFGChecksum: 206551239323
+   !CFGChecksum: 281479271677951
+  !CFGChecksum: 123456
+ !CFGChecksum: 281479271677951
+bar:12:12
+ 1: 12
+ !CFGChecksum: 4294967295

--- a/llvm/test/Transforms/SampleProfile/Inputs/pseudo-probe-stale-profile-renaming.prof
+++ b/llvm/test/Transforms/SampleProfile/Inputs/pseudo-probe-stale-profile-renaming.prof
@@ -32,18 +32,13 @@ main:47:0
   !CFGChecksum: 281479271677951
  10: cold_func:0
   1: 0
-  2: block_only:0
-   1: 0
-   3: 0
-   5: 0
-   10: 0
-   !CFGChecksum: 206551239323
+  2: 0 block_only:0
   !CFGChecksum: 281479271677951
  !CFGChecksum: 1126003093360596
 test_noninline:22:2
  1: 2
  2: foo:20
-  1: 2
+  1: 3
   2: 2 bar:3
   4: 3 bar:3
   3: baz:13

--- a/llvm/test/Transforms/SampleProfile/non-probe-stale-profile-matching.ll
+++ b/llvm/test/Transforms/SampleProfile/non-probe-stale-profile-matching.ll
@@ -48,17 +48,17 @@
 ;    }
 ;  }
 
-; CHECK: Run stale profile matching for bar
-
-; CHECK: Run stale profile matching for foo
-; CHECK: Callsite with callee:bar is matched from 1.15 to 1.15
-; CHECK: Callsite with callee:bar is matched from 2 to 2
-
 ; CHECK: Run stale profile matching for main
 ; CHECK: Callsite with callee:foo is matched from 4 to 2
 ; CHECK: Callsite with callee:bar is matched from 5 to 3
 ; CHECK: Callsite with callee:foo is matched from 8 to 4
 ; CHECK: Callsite with callee:bar is matched from 9 to 5
+
+; CHECK: Run stale profile matching for foo
+; CHECK: Callsite with callee:bar is matched from 1.15 to 1.15
+; CHECK: Callsite with callee:bar is matched from 2 to 2
+
+; CHECK: Run stale profile matching for bar
 
 target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
 target triple = "x86_64-unknown-linux-gnu"

--- a/llvm/test/Transforms/SampleProfile/pseudo-probe-stale-profile-matching-LCS.ll
+++ b/llvm/test/Transforms/SampleProfile/pseudo-probe-stale-profile-matching-LCS.ll
@@ -2,17 +2,6 @@
 ; REQUIRES: asserts
 ; RUN: opt < %s -passes=sample-profile -sample-profile-file=%S/Inputs/pseudo-probe-stale-profile-matching-LCS.prof --salvage-stale-profile -S --debug-only=sample-profile,sample-profile-matcher,sample-profile-impl 2>&1 | FileCheck %s
 
-; CHECK: Run stale profile matching for test_direct_call
-; CHECK: Location is matched from 1 to 1
-; CHECK: Location is matched from 2 to 2
-; CHECK: Location is matched from 3 to 3
-; CHECK: Callsite with callee:C is matched from 4 to 2
-; CHECK: Location is rematched backwards from 3 to 1
-; CHECK: Callsite with callee:A is matched from 5 to 4
-; CHECK: Callsite with callee:B is matched from 6 to 5
-; CHECK: Location is matched from 7 to 6
-; CHECK: Callsite with callee:A is matched from 8 to 6
-
 ; CHECK: Run stale profile matching for test_indirect_call
 ; CHECK: Location is matched from 1 to 1
 ; CHECK: Location is matched from 2 to 2
@@ -26,6 +15,17 @@
 ; CHECK: Location is matched from 8 to 5
 ; CHECK: Callsite with callee:unknown.indirect.callee is matched from 9 to 6
 ; CHECK: Callsite with callee:C is matched from 10 to 7
+
+; CHECK: Run stale profile matching for test_direct_call
+; CHECK: Location is matched from 1 to 1
+; CHECK: Location is matched from 2 to 2
+; CHECK: Location is matched from 3 to 3
+; CHECK: Callsite with callee:C is matched from 4 to 2
+; CHECK: Location is rematched backwards from 3 to 1
+; CHECK: Callsite with callee:A is matched from 5 to 4
+; CHECK: Callsite with callee:B is matched from 6 to 5
+; CHECK: Location is matched from 7 to 6
+; CHECK: Callsite with callee:A is matched from 8 to 6
 
 
 target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"

--- a/llvm/test/Transforms/SampleProfile/pseudo-probe-stale-profile-renaming.ll
+++ b/llvm/test/Transforms/SampleProfile/pseudo-probe-stale-profile-renaming.ll
@@ -1,6 +1,6 @@
 ; REQUIRES: x86_64-linux
 ; REQUIRES: asserts
-; RUN: opt < %s -passes=sample-profile -sample-profile-file=%S/Inputs/pseudo-probe-stale-profile-renaming.prof --salvage-stale-profile --salvage-function-renaming -S --debug-only=sample-profile,sample-profile-matcher,sample-profile-impl 2>&1 | FileCheck %s
+; RUN: opt < %s -passes=sample-profile -sample-profile-file=%S/Inputs/pseudo-probe-stale-profile-renaming.prof --salvage-stale-profile --salvage-renamed-profile -S --debug-only=sample-profile,sample-profile-matcher,sample-profile-impl 2>&1 | FileCheck %s
 
 
 ; CHECK: Function new_block_only is not in profile or symbol list table.

--- a/llvm/test/Transforms/SampleProfile/pseudo-probe-stale-profile-renaming.ll
+++ b/llvm/test/Transforms/SampleProfile/pseudo-probe-stale-profile-renaming.ll
@@ -1,0 +1,297 @@
+; REQUIRES: x86_64-linux
+; REQUIRES: asserts
+; RUN: opt < %s -passes=sample-profile -sample-profile-file=%S/Inputs/pseudo-probe-stale-profile-renaming.prof --salvage-stale-profile --salvage-function-renaming -S --debug-only=sample-profile,sample-profile-matcher,sample-profile-impl 2>&1 | FileCheck %s
+
+
+; CHECK: Function new_block_only is not in profile or symbol list table.
+; CHECK: Function new_foo is not in profile or symbol list table.
+
+; CHECK: The similarity between new_foo(IR) and foo(profile) is 0.86
+; CHECK: Callee renaming is found in function main, changing profile name from foo to new_foo
+; CHECK: The similarity between new_block_only(IR) and block_only(profile) is 1.00
+; CHECK: Callee renaming is found in function baz, changing profile name from block_only to new_block_only
+; CHECK: Existing callee renaming is found in function baz, changing profile name from block_only to new_block_only
+; CHECK: Existing callee renaming is found in function cold_func, changing profile name from block_only to new_block_only
+; CHECK: Existing callee renaming is found in function test_noninline, changing profile name from foo to new_foo
+; CHECK: Existing callee renaming is found in function baz, changing profile name from block_only to new_block_only
+
+target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-unknown-linux-gnu"
+
+@x = dso_local global i32 0, align 4, !dbg !0
+
+; Function Attrs: noinline nounwind uwtable
+define dso_local i32 @bar(i32 noundef %x) #0 !dbg !22 {
+entry:
+    #dbg_value(i32 %x, !26, !DIExpression(), !27)
+  call void @llvm.pseudoprobe(i64 -2012135647395072713, i64 1, i32 0, i64 -1), !dbg !28
+  %add = add nsw i32 %x, 1, !dbg !29
+  ret i32 %add, !dbg !30
+}
+
+; Function Attrs: mustprogress nocallback nofree nosync nounwind speculatable willreturn memory(none)
+declare void @llvm.dbg.declare(metadata, metadata, metadata) #1
+
+; Function Attrs: nounwind uwtable
+define dso_local void @new_block_only() #2 !dbg !31 {
+entry:
+  call void @llvm.pseudoprobe(i64 2964250471062803127, i64 1, i32 0, i64 -1), !dbg !34
+  %0 = load volatile i32, ptr @x, align 4, !dbg !34, !tbaa !36
+  %cmp = icmp eq i32 %0, 9999, !dbg !40
+  br i1 %cmp, label %if.then, label %if.else, !dbg !41
+
+if.then:                                          ; preds = %entry
+  call void @llvm.pseudoprobe(i64 2964250471062803127, i64 2, i32 0, i64 -1), !dbg !42
+  %1 = load volatile i32, ptr @x, align 4, !dbg !42, !tbaa !36
+  %add = add nsw i32 %1, 1000, !dbg !42
+  store volatile i32 %add, ptr @x, align 4, !dbg !42, !tbaa !36
+  br label %if.end10, !dbg !43
+
+if.else:                                          ; preds = %entry
+  call void @llvm.pseudoprobe(i64 2964250471062803127, i64 3, i32 0, i64 -1), !dbg !44
+  %2 = load volatile i32, ptr @x, align 4, !dbg !44, !tbaa !36
+  %cmp1 = icmp eq i32 %2, 999, !dbg !46
+  br i1 %cmp1, label %if.then2, label %if.else4, !dbg !47
+
+if.then2:                                         ; preds = %if.else
+  call void @llvm.pseudoprobe(i64 2964250471062803127, i64 4, i32 0, i64 -1), !dbg !48
+  %3 = load volatile i32, ptr @x, align 4, !dbg !48, !tbaa !36
+  %add3 = add nsw i32 %3, 100, !dbg !48
+  store volatile i32 %add3, ptr @x, align 4, !dbg !48, !tbaa !36
+  br label %if.end10, !dbg !49
+
+if.else4:                                         ; preds = %if.else
+  call void @llvm.pseudoprobe(i64 2964250471062803127, i64 5, i32 0, i64 -1), !dbg !50
+  %4 = load volatile i32, ptr @x, align 4, !dbg !50, !tbaa !36
+  %cmp5 = icmp eq i32 %4, 99, !dbg !52
+  br i1 %cmp5, label %if.then6, label %if.else8, !dbg !53
+
+if.then6:                                         ; preds = %if.else4
+  call void @llvm.pseudoprobe(i64 2964250471062803127, i64 6, i32 0, i64 -1), !dbg !54
+  %5 = load volatile i32, ptr @x, align 4, !dbg !54, !tbaa !36
+  %add7 = add nsw i32 %5, 10, !dbg !54
+  store volatile i32 %add7, ptr @x, align 4, !dbg !54, !tbaa !36
+  br label %if.end10, !dbg !55
+
+if.else8:                                         ; preds = %if.else4
+  call void @llvm.pseudoprobe(i64 2964250471062803127, i64 7, i32 0, i64 -1), !dbg !56
+  %6 = load volatile i32, ptr @x, align 4, !dbg !56, !tbaa !36
+  %inc = add nsw i32 %6, 1, !dbg !56
+  store volatile i32 %inc, ptr @x, align 4, !dbg !56, !tbaa !36
+  br label %if.end10
+
+if.end10:                                         ; preds = %if.then2, %if.else8, %if.then6, %if.then
+  call void @llvm.pseudoprobe(i64 2964250471062803127, i64 10, i32 0, i64 -1), !dbg !57
+  ret void, !dbg !57
+}
+
+; Function Attrs: nounwind uwtable
+define dso_local void @baz() #2 !dbg !58 {
+entry:
+  call void @llvm.pseudoprobe(i64 7546896869197086323, i64 1, i32 0, i64 -1), !dbg !59
+  call void @new_block_only(), !dbg !60
+  ret void, !dbg !62
+}
+
+; Function Attrs: nounwind uwtable
+define dso_local void @new_foo() #2 !dbg !63 {
+entry:
+  call void @llvm.pseudoprobe(i64 5381804724291869009, i64 1, i32 0, i64 -1), !dbg !64
+  %0 = load volatile i32, ptr @x, align 4, !dbg !64, !tbaa !36
+  %call = call i32 @bar(i32 noundef %0), !dbg !65
+  %1 = load volatile i32, ptr @x, align 4, !dbg !67, !tbaa !36
+  %add = add nsw i32 %1, %call, !dbg !67
+  store volatile i32 %add, ptr @x, align 4, !dbg !67, !tbaa !36
+  call void @baz(), !dbg !68
+  %2 = load volatile i32, ptr @x, align 4, !dbg !70, !tbaa !36
+  %call1 = call i32 @bar(i32 noundef %2), !dbg !71
+  %3 = load volatile i32, ptr @x, align 4, !dbg !73, !tbaa !36
+  %add2 = add nsw i32 %3, %call1, !dbg !73
+  store volatile i32 %add2, ptr @x, align 4, !dbg !73, !tbaa !36
+  ret void, !dbg !74
+}
+
+; Function Attrs: noinline nounwind uwtable
+define dso_local void @test_noninline() #0 !dbg !75 {
+entry:
+  call void @llvm.pseudoprobe(i64 -5610330892148506720, i64 1, i32 0, i64 -1), !dbg !76
+  call void @new_foo(), !dbg !77
+  ret void, !dbg !79
+}
+
+; Function Attrs: nounwind uwtable
+define dso_local void @cold_func() #2 !dbg !80 {
+entry:
+  call void @llvm.pseudoprobe(i64 2711072140522378707, i64 1, i32 0, i64 -1), !dbg !81
+  call void @new_block_only(), !dbg !82
+  ret void, !dbg !84
+}
+
+; Function Attrs: nounwind uwtable
+define dso_local i32 @main() #2 !dbg !85 {
+entry:
+  call void @llvm.pseudoprobe(i64 -2624081020897602054, i64 1, i32 0, i64 -1), !dbg !91
+    #dbg_value(i32 0, !89, !DIExpression(), !92)
+  br label %for.cond, !dbg !93
+
+for.cond:                                         ; preds = %for.body, %entry
+  %i.0 = phi i32 [ 0, %entry ], [ %inc, %for.body ], !dbg !94
+    #dbg_value(i32 %i.0, !89, !DIExpression(), !92)
+  call void @llvm.pseudoprobe(i64 -2624081020897602054, i64 2, i32 0, i64 -1), !dbg !95
+  %cmp = icmp slt i32 %i.0, 1000000, !dbg !97
+  br i1 %cmp, label %for.body, label %for.cond.cleanup, !dbg !98
+
+for.cond.cleanup:                                 ; preds = %for.cond
+  call void @llvm.pseudoprobe(i64 -2624081020897602054, i64 3, i32 0, i64 -1), !dbg !99
+  call void @llvm.pseudoprobe(i64 -2624081020897602054, i64 9, i32 0, i64 -1), !dbg !100
+  call void @cold_func(), !dbg !101
+  ret i32 0, !dbg !103
+
+for.body:                                         ; preds = %for.cond
+  call void @llvm.pseudoprobe(i64 -2624081020897602054, i64 4, i32 0, i64 -1), !dbg !104
+  call void @new_foo(), !dbg !106
+  call void @baz(), !dbg !108
+  call void @test_noninline(), !dbg !110
+  call void @llvm.pseudoprobe(i64 -2624081020897602054, i64 8, i32 0, i64 -1), !dbg !112
+  %inc = add nsw i32 %i.0, 1, !dbg !112
+    #dbg_value(i32 %inc, !89, !DIExpression(), !92)
+  br label %for.cond, !dbg !113, !llvm.loop !114
+}
+
+; Function Attrs: mustprogress nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.lifetime.start.p0(i64 immarg, ptr nocapture) #3
+
+; Function Attrs: mustprogress nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.lifetime.end.p0(i64 immarg, ptr nocapture) #3
+
+; Function Attrs: mustprogress nocallback nofree nosync nounwind willreturn memory(inaccessiblemem: readwrite)
+declare void @llvm.pseudoprobe(i64, i64, i32, i64) #4
+
+attributes #0 = { noinline nounwind uwtable "min-legal-vector-width"="0" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cmov,+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "tune-cpu"="generic" "use-sample-profile" }
+attributes #1 = { mustprogress nocallback nofree nosync nounwind speculatable willreturn memory(none) }
+attributes #2 = { nounwind uwtable "min-legal-vector-width"="0" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cmov,+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "tune-cpu"="generic" "use-sample-profile" }
+attributes #3 = { mustprogress nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
+attributes #4 = { mustprogress nocallback nofree nosync nounwind willreturn memory(inaccessiblemem: readwrite) }
+
+!llvm.dbg.cu = !{!2}
+!llvm.module.flags = !{!7, !8, !9, !10, !11, !12, !13}
+!llvm.ident = !{!14}
+!llvm.pseudo_probe_desc = !{!15, !16, !17, !18, !19, !20, !21}
+
+!0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
+!1 = distinct !DIGlobalVariable(name: "x", scope: !2, file: !3, line: 1, type: !5, isLocal: false, isDefinition: true)
+!2 = distinct !DICompileUnit(language: DW_LANG_C11, file: !3, producer: "clang version 19.0.0git (https://github.com/llvm/llvm-project.git 2e1509152224d8ffbeac84c489920dcbaeefc2b2)", isOptimized: true, runtimeVersion: 0, emissionKind: FullDebug, globals: !4, splitDebugInlining: false, nameTableKind: None)
+!3 = !DIFile(filename: "test_rename.c", directory: "/home/wlei/local/toytest/rename", checksumkind: CSK_MD5, checksum: "b07f600b3cdefd40bd44932bc13c33f5")
+!4 = !{!0}
+!5 = !DIDerivedType(tag: DW_TAG_volatile_type, baseType: !6)
+!6 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+!7 = !{i32 7, !"Dwarf Version", i32 5}
+!8 = !{i32 2, !"Debug Info Version", i32 3}
+!9 = !{i32 1, !"wchar_size", i32 4}
+!10 = !{i32 8, !"PIC Level", i32 2}
+!11 = !{i32 7, !"PIE Level", i32 2}
+!12 = !{i32 7, !"uwtable", i32 2}
+!13 = !{i32 7, !"debug-info-assignment-tracking", i1 true}
+!14 = !{!"clang version 19.0.0git (https://github.com/llvm/llvm-project.git 2e1509152224d8ffbeac84c489920dcbaeefc2b2)"}
+!15 = !{i64 -2012135647395072713, i64 4294967295, !"bar"}
+!16 = !{i64 2964250471062803127, i64 206551239323, !"new_block_only"}
+!17 = !{i64 7546896869197086323, i64 281479271677951, !"baz"}
+!18 = !{i64 5381804724291869009, i64 844429225099263, !"new_foo"}
+!19 = !{i64 -5610330892148506720, i64 281479271677951, !"test_noninline"}
+!20 = !{i64 2711072140522378707, i64 281479271677951, !"cold_func"}
+!21 = !{i64 -2624081020897602054, i64 1126003093360596, !"main"}
+!22 = distinct !DISubprogram(name: "bar", scope: !3, file: !3, line: 3, type: !23, scopeLine: 3, flags: DIFlagPrototyped | DIFlagAllCallsDescribed, spFlags: DISPFlagDefinition | DISPFlagOptimized, unit: !2, retainedNodes: !25)
+!23 = !DISubroutineType(types: !24)
+!24 = !{!6, !6}
+!25 = !{!26}
+!26 = !DILocalVariable(name: "x", arg: 1, scope: !22, file: !3, line: 3, type: !6)
+!27 = !DILocation(line: 0, scope: !22)
+!28 = !DILocation(line: 4, column: 10, scope: !22)
+!29 = !DILocation(line: 4, column: 12, scope: !22)
+!30 = !DILocation(line: 4, column: 3, scope: !22)
+!31 = distinct !DISubprogram(name: "new_block_only", scope: !3, file: !3, line: 7, type: !32, scopeLine: 7, flags: DIFlagAllCallsDescribed, spFlags: DISPFlagDefinition | DISPFlagOptimized, unit: !2)
+!32 = !DISubroutineType(types: !33)
+!33 = !{null}
+!34 = !DILocation(line: 8, column: 6, scope: !35)
+!35 = distinct !DILexicalBlock(scope: !31, file: !3, line: 8, column: 6)
+!36 = !{!37, !37, i64 0}
+!37 = !{!"int", !38, i64 0}
+!38 = !{!"omnipotent char", !39, i64 0}
+!39 = !{!"Simple C/C++ TBAA"}
+!40 = !DILocation(line: 8, column: 8, scope: !35)
+!41 = !DILocation(line: 8, column: 6, scope: !31)
+!42 = !DILocation(line: 9, column: 7, scope: !35)
+!43 = !DILocation(line: 9, column: 5, scope: !35)
+!44 = !DILocation(line: 10, column: 12, scope: !45)
+!45 = distinct !DILexicalBlock(scope: !35, file: !3, line: 10, column: 12)
+!46 = !DILocation(line: 10, column: 14, scope: !45)
+!47 = !DILocation(line: 10, column: 12, scope: !35)
+!48 = !DILocation(line: 11, column: 7, scope: !45)
+!49 = !DILocation(line: 11, column: 5, scope: !45)
+!50 = !DILocation(line: 12, column: 12, scope: !51)
+!51 = distinct !DILexicalBlock(scope: !45, file: !3, line: 12, column: 12)
+!52 = !DILocation(line: 12, column: 14, scope: !51)
+!53 = !DILocation(line: 12, column: 12, scope: !45)
+!54 = !DILocation(line: 13, column: 7, scope: !51)
+!55 = !DILocation(line: 13, column: 5, scope: !51)
+!56 = !DILocation(line: 15, column: 6, scope: !51)
+!57 = !DILocation(line: 16, column: 1, scope: !31)
+!58 = distinct !DISubprogram(name: "baz", scope: !3, file: !3, line: 18, type: !32, scopeLine: 18, flags: DIFlagAllCallsDescribed, spFlags: DISPFlagDefinition | DISPFlagOptimized, unit: !2)
+!59 = !DILocation(line: 19, column: 3, scope: !58)
+!60 = !DILocation(line: 19, column: 3, scope: !61)
+!61 = !DILexicalBlockFile(scope: !58, file: !3, discriminator: 186646551)
+!62 = !DILocation(line: 20, column: 1, scope: !58)
+!63 = distinct !DISubprogram(name: "new_foo", scope: !3, file: !3, line: 22, type: !32, scopeLine: 22, flags: DIFlagAllCallsDescribed, spFlags: DISPFlagDefinition | DISPFlagOptimized, unit: !2)
+!64 = !DILocation(line: 23, column: 12, scope: !63)
+!65 = !DILocation(line: 23, column: 8, scope: !66)
+!66 = !DILexicalBlockFile(scope: !63, file: !3, discriminator: 186646551)
+!67 = !DILocation(line: 23, column: 5, scope: !63)
+!68 = !DILocation(line: 24, column: 3, scope: !69)
+!69 = !DILexicalBlockFile(scope: !63, file: !3, discriminator: 186646559)
+!70 = !DILocation(line: 25, column: 12, scope: !63)
+!71 = !DILocation(line: 25, column: 8, scope: !72)
+!72 = !DILexicalBlockFile(scope: !63, file: !3, discriminator: 186646567)
+!73 = !DILocation(line: 25, column: 5, scope: !63)
+!74 = !DILocation(line: 26, column: 1, scope: !63)
+!75 = distinct !DISubprogram(name: "test_noninline", scope: !3, file: !3, line: 28, type: !32, scopeLine: 28, flags: DIFlagAllCallsDescribed, spFlags: DISPFlagDefinition | DISPFlagOptimized, unit: !2)
+!76 = !DILocation(line: 29, column: 3, scope: !75)
+!77 = !DILocation(line: 29, column: 3, scope: !78)
+!78 = !DILexicalBlockFile(scope: !75, file: !3, discriminator: 186646551)
+!79 = !DILocation(line: 30, column: 1, scope: !75)
+!80 = distinct !DISubprogram(name: "cold_func", scope: !3, file: !3, line: 32, type: !32, scopeLine: 32, flags: DIFlagAllCallsDescribed, spFlags: DISPFlagDefinition | DISPFlagOptimized, unit: !2)
+!81 = !DILocation(line: 32, column: 20, scope: !80)
+!82 = !DILocation(line: 32, column: 20, scope: !83)
+!83 = !DILexicalBlockFile(scope: !80, file: !3, discriminator: 186646551)
+!84 = !DILocation(line: 32, column: 37, scope: !80)
+!85 = distinct !DISubprogram(name: "main", scope: !3, file: !3, line: 34, type: !86, scopeLine: 34, flags: DIFlagPrototyped | DIFlagAllCallsDescribed, spFlags: DISPFlagDefinition | DISPFlagOptimized, unit: !2, retainedNodes: !88)
+!86 = !DISubroutineType(types: !87)
+!87 = !{!6}
+!88 = !{!89}
+!89 = !DILocalVariable(name: "i", scope: !90, file: !3, line: 35, type: !6)
+!90 = distinct !DILexicalBlock(scope: !85, file: !3, line: 35, column: 3)
+!91 = !DILocation(line: 35, column: 12, scope: !90)
+!92 = !DILocation(line: 0, scope: !90)
+!93 = !DILocation(line: 35, column: 8, scope: !90)
+!94 = !DILocation(line: 35, scope: !90)
+!95 = !DILocation(line: 35, column: 19, scope: !96)
+!96 = distinct !DILexicalBlock(scope: !90, file: !3, line: 35, column: 3)
+!97 = !DILocation(line: 35, column: 21, scope: !96)
+!98 = !DILocation(line: 35, column: 3, scope: !90)
+!99 = !DILocation(line: 0, scope: !85)
+!100 = !DILocation(line: 40, column: 3, scope: !85)
+!101 = !DILocation(line: 40, column: 3, scope: !102)
+!102 = !DILexicalBlockFile(scope: !85, file: !3, discriminator: 186646615)
+!103 = !DILocation(line: 41, column: 1, scope: !85)
+!104 = !DILocation(line: 36, column: 7, scope: !105)
+!105 = distinct !DILexicalBlock(scope: !96, file: !3, line: 35, column: 41)
+!106 = !DILocation(line: 36, column: 7, scope: !107)
+!107 = !DILexicalBlockFile(scope: !105, file: !3, discriminator: 186646575)
+!108 = !DILocation(line: 37, column: 7, scope: !109)
+!109 = !DILexicalBlockFile(scope: !105, file: !3, discriminator: 186646583)
+!110 = !DILocation(line: 38, column: 7, scope: !111)
+!111 = !DILexicalBlockFile(scope: !105, file: !3, discriminator: 186646591)
+!112 = !DILocation(line: 35, column: 37, scope: !96)
+!113 = !DILocation(line: 35, column: 3, scope: !96)
+!114 = distinct !{!114, !98, !115, !116}
+!115 = !DILocation(line: 39, column: 3, scope: !90)
+!116 = !{!"llvm.loop.mustprogress"}

--- a/llvm/test/Transforms/SampleProfile/pseudo-probe-stale-profile-renaming.ll
+++ b/llvm/test/Transforms/SampleProfile/pseudo-probe-stale-profile-renaming.ll
@@ -1,7 +1,7 @@
 ; REQUIRES: x86_64-linux
 ; REQUIRES: asserts
-; RUN: opt < %s -passes=sample-profile -sample-profile-file=%S/Inputs/pseudo-probe-stale-profile-renaming.prof --salvage-stale-profile --salvage-renamed-profile -S --debug-only=sample-profile,sample-profile-matcher,sample-profile-impl -pass-remarks=inline --min-call-for-cg-matching=0 --min-bb-for-cg-matching=0 2>&1 | FileCheck %s
-; RUN: opt < %s -passes=sample-profile -sample-profile-file=%S/Inputs/pseudo-probe-stale-profile-renaming.prof --salvage-stale-profile --salvage-renamed-profile -S --debug-only=sample-profile,sample-profile-matcher,sample-profile-impl --min-call-for-cg-matching=10 --min-bb-for-cg-matching=10 2>&1 | FileCheck %s  --check-prefix=TINY-FUNC
+; RUN: opt < %s -passes=sample-profile -sample-profile-file=%S/Inputs/pseudo-probe-stale-profile-renaming.prof --salvage-stale-profile --salvage-unused-profile -S --debug-only=sample-profile,sample-profile-matcher,sample-profile-impl -pass-remarks=inline --min-call-count-for-cg-matching=0 --min-func-count-for-cg-matching=0 2>&1 | FileCheck %s
+; RUN: opt < %s -passes=sample-profile -sample-profile-file=%S/Inputs/pseudo-probe-stale-profile-renaming.prof --salvage-stale-profile --salvage-unused-profile -S --debug-only=sample-profile,sample-profile-matcher,sample-profile-impl --min-call-count-for-cg-matching=10 --min-func-count-for-cg-matching=10 2>&1 | FileCheck %s  --check-prefix=TINY-FUNC
 
 
 ; CHECK: Function new_block_only is not in profile or symbol list table.

--- a/llvm/test/Transforms/SampleProfile/pseudo-probe-stale-profile-renaming.ll
+++ b/llvm/test/Transforms/SampleProfile/pseudo-probe-stale-profile-renaming.ll
@@ -3,18 +3,28 @@
 ; RUN: opt < %s -passes=sample-profile -sample-profile-file=%S/Inputs/pseudo-probe-stale-profile-renaming.prof --salvage-stale-profile --salvage-unused-profile -S --debug-only=sample-profile,sample-profile-matcher,sample-profile-impl -pass-remarks=inline --min-call-count-for-cg-matching=0 --min-func-count-for-cg-matching=0 2>&1 | FileCheck %s
 ; RUN: opt < %s -passes=sample-profile -sample-profile-file=%S/Inputs/pseudo-probe-stale-profile-renaming.prof --salvage-stale-profile --salvage-unused-profile -S --debug-only=sample-profile,sample-profile-matcher,sample-profile-impl --min-call-count-for-cg-matching=10 --min-func-count-for-cg-matching=10 2>&1 | FileCheck %s  --check-prefix=TINY-FUNC
 
-
+; Verify find new IR functions.
 ; CHECK: Function new_block_only is not in profile or symbol list table.
 ; CHECK: Function new_foo is not in profile or symbol list table.
 
+; CHECK: Run stale profile matching for main
 ; CHECK: The similarity between new_foo(IR) and foo(profile) is 0.86
-; CHECK: In function main, changing profile name from foo to new_foo
-; CHECK: The checksums for new_block_only(IR) and block_only(Profile) match
-; CHECK: In function baz, changing profile name from block_only to new_block_only
-; CHECK: In function baz, changing profile name from block_only to new_block_only
-; CHECK: In function cold_func, changing profile name from block_only to new_block_only
-; CHECK: In function test_noninline, changing profile name from foo to new_foo
-; CHECK: In function baz, changing profile name from block_only to new_block_only
+; CHECK: Function:new_foo matches profile:foo
+; CHECK: Run stale profile matching for test_noninline
+; CHECK: Run stale profile matching for cold_func
+; CHECK: The checksums for new_block_only(IR) and block_only(Profile) match.
+; CHECK: Function:new_block_only matches profile:block_only
+; CHECK: Run stale profile matching for baz
+; CHECK: Run stale profile matching for bar
+
+; Verify profile new name update.
+; CHECK-DAG: Profile name is updated from foo to new_foo under caller: test_noninline
+; CHECK-DAG: Profile name is updated from block_only to new_block_only under caller: baz
+; CHECK-DAG: Profile name is updated from foo to new_foo under caller: main
+; CHECK-DAG: Profile name is updated from block_only to new_block_only under caller: baz
+; CHECK-DAG: Profile name is updated from block_only to new_block_only under caller: baz
+; CHECK-DAG: Profile name is updated from block_only to new_block_only under caller: cold_func
+
 
 ; Verify the matched function is updated correctly by checking the inlining.
 ; CHECK: 'new_foo' inlined into 'main' to match profiling context with (cost=110, threshold=3000) at callsite main:2:7.5;
@@ -22,8 +32,8 @@
 ; CHECK: 'new_block_only' inlined into 'main' to match profiling context with (cost=75, threshold=3000) at callsite baz:1:3.2 @ new_foo:2:3.3 @ main:2:7.5;
 ; CHECK: 'new_foo' inlined into 'test_noninline' to match profiling context with (cost=110, threshold=3000) at callsite test_noninline:1:3.2;
 
-; TINY-FUNC-NOT: block_only to new_block_only
-; TINY-FUNC-NOT: from foo to new_foo
+; TINY-FUNC-NOT: Function:new_foo matches profile:foo
+; TINY-FUNC-NOT: Function:new_block_only matches profile:block_only
 
 
 target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"


### PR DESCRIPTION
Replaced by "https://github.com/llvm/llvm-project/pull/95135"

Profile staleness could be due to function renaming. Given that sample profile loader relies on exact string matching, a trivial change in the function signature( such as `int foo()` --> `long foo()` ) can make the mangled name different, the function profile(including all nested children profile) becomes unavailable. 

This patch introduces stale profile call-graph level matching, targeting at identifying the trivial function renaming and reusing the old function profile. The main idea is to leverage the call-site anchor similarity to determine the renaming and limit the matching scope into profiled call-graph edges.

Some noteworthy details:
1. Use CG edge info to reduce the matching scope. 
- As our goal is to salvage the profile, we don't need to run all possible renaming check. Instead, if we can salvage every edges in the profiled CG, i,e, make sure the caller profile can find the callee profile, that should be enough. The high-level steps for the algorithm:
- 1) Find all the new functions that show only in the IR, use them as the matching candidates to compute new callees.
- 2) Traverse all the nodes in the profiled call-graph.
   -  For each function caller scope:
   -  a) Find a set of callees in the IR that doesn't exist in the profile. See `findNewIRCallees`.
  -   b) Find a set of callees in the profile that doesn't exist in the IR. See `matchCalleeProfile`.
   -  c) Match the callee pairs between a and b. See ` MatchProfileForNewFunctions`.
  - d) Update the profile with the matched name in-place.

2.  Determine the renaming by call-site anchor similarity check
   -  The inputs are the two new function(doesn't appear in other side) lists from IR and Profile, say a) `IRRenamingFuncList`. b) `ProfileRenamingFuncList`. A new function `functionMatchesProfile(IRFunc, ProfFunc)` is used to check the renaming for the possible <IRFunc, ProfFunc> pair in `IRRenamingFuncList`  X  `ProfileRenamingFuncList`

   - In`functionMatchesProfile(IRFunc, ProfFunc)`, extract call-site anchors and use the LCS(diff) matching to compute the equal set and we define: `Similarity = |equalSet * 2| / (|A| + |B|)`.  The profile name is marked as renamed if the similarity is above a threshold(`--renamed-func-similarity-threshold`) and update the profile using the new name. 



3. Added a new switch `--salvage-renamed-profile` to control this, default is false. 

4. This is also complementary to the CFG level(block/call) matching, which is after the CG matching, the new identified function can further be run by the CFG matching. 

Verified on one Meta's internal big service, confirmed 90%+ of the found renaming pair is good. (There could be incorrect renaming pair if the num of the anchor is small, but checked that those functions are simple cold function) 
