### PR TITLE
[libc][errno] Remove non asm generic error number

### DIFF
--- a/libc/include/llvm-libc-macros/generic-error-number-macros.h
+++ b/libc/include/llvm-libc-macros/generic-error-number-macros.h
@@ -43,7 +43,6 @@
 #define EPIPE 32
 #define EDOM 33
 #define ERANGE 34
-#define EILSEQ 35
 #define ENAMETOOLONG 36
 #define EOVERFLOW 75
 


### PR DESCRIPTION
The following small thing caught my eye:

1) `EILSEQ` is not part of the generic asm error number macros. See the [full list of generic asm errno codes](https://github.com/torvalds/linux/blob/4b95dc87362aa57bdd0dcbad109ca5e5ef3cbb6c/include/uapi/asm-generic/errno-base.h). AFAIK the generic asm errno numbers are common between different operating systems and architectures. `EILSEQ` is not part of this common set of errno's.

2) `EILSEQ`'s value is wrong. During the addition of `EILSEQ` in https://reviews.llvm.org/D151129, the value `35` was probably chosen as its the consecutive number. This is not correct. The actual values can be looked up for example here: 
    * [For Linux kernel](https://github.com/search?q=repo%3Atorvalds%2Flinux+EILSEQ&type=code&p=1): `EILSEQ = 84` (uapi; i.e. x86_64), `EILSEQ = 88` (mips), `EILSEQ = 47` (parisc)
    * [For Darwin kernel](https://github.com/apple-oss-distributions/xnu/blob/main/bsd/sys/errno.h#L237): `EILSEQ = 92`