### PR TITLE
[Nomination] Add an extra Red Hat representative to the security group

### DIFF
--- a/llvm/docs/Security.rst
+++ b/llvm/docs/Security.rst
@@ -55,6 +55,7 @@ username for an individual isn't available, the brackets will be empty.
 * Serge Guelton (Mozilla) [@serge-sans-paille]
 * Shayne Hiet-Block (Microsoft) [@GreatKeeper]
 * Tim Penge (Sony) []
+* Tulio Magno Quites Machado Filho (Red Hat) [@tuliom]
 * Will Huhn (Intel) [@wphuhn-intel]
 
 Criteria


### PR DESCRIPTION
I'd like to nominate myself as another Red Hat representative. I work at the LLVM team at Red Hat contributing to upstream and downstream.