### PR TITLE
[flang][OpenMP] Add -fopenmp-version=52 to teams.f90

### DIFF
--- a/flang/test/Lower/OpenMP/teams.f90
+++ b/flang/test/Lower/OpenMP/teams.f90
@@ -1,6 +1,6 @@
 ! REQUIRES: openmp_runtime
 
-! RUN: %flang_fc1 -emit-hlfir -fopenmp %s -o - | FileCheck %s
+! RUN: %flang_fc1 -emit-hlfir -fopenmp -fopenmp-version=52 %s -o - | FileCheck %s
 
 ! CHECK-LABEL: func @_QPteams_simple
 subroutine teams_simple()


### PR DESCRIPTION
One of the functions in the test has `teams if(...)`. The `if` clause was only allowed on the `teams` directive in OpenMP 5.2.