### PR TITLE
[LoongArch] Enable all -target-abi options

### DIFF
--- a/llvm/lib/Target/LoongArch/LoongArchISelLowering.cpp
+++ b/llvm/lib/Target/LoongArch/LoongArchISelLowering.cpp
@@ -3575,15 +3575,14 @@ static bool CC_LoongArch(const DataLayout &DL, LoongArchABI::ABI ABI,
   switch (ABI) {
   default:
     llvm_unreachable("Unexpected ABI");
-  case LoongArchABI::ABI_ILP32S:
+    break;
   case LoongArchABI::ABI_ILP32F:
   case LoongArchABI::ABI_LP64F:
-    report_fatal_error("Unimplemented ABI");
-    break;
   case LoongArchABI::ABI_ILP32D:
   case LoongArchABI::ABI_LP64D:
     UseGPRForFloat = !IsFixed;
     break;
+  case LoongArchABI::ABI_ILP32S:
   case LoongArchABI::ABI_LP64S:
     break;
   }

--- a/llvm/lib/Target/LoongArch/MCTargetDesc/LoongArchBaseInfo.cpp
+++ b/llvm/lib/Target/LoongArch/MCTargetDesc/LoongArchBaseInfo.cpp
@@ -14,12 +14,43 @@
 #include "LoongArchBaseInfo.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/MC/MCSubtargetInfo.h"
+#include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/raw_ostream.h"
 #include "llvm/TargetParser/Triple.h"
 
 namespace llvm {
 
 namespace LoongArchABI {
+
+// Check if ABI has been standardized; issue a warning if it hasn't.
+// FIXME: Once all ABIs are standardized, this will be removed.
+static ABI checkABIStandardized(ABI Abi) {
+  bool IsStandardized = false;
+  StringRef ABIName;
+  switch (Abi) {
+  case ABI_ILP32S:
+    ABIName = "ilp32s";
+    break;
+  case ABI_ILP32F:
+    ABIName = "ilp32f";
+    break;
+  case ABI_ILP32D:
+    ABIName = "ilp32d";
+    break;
+  case ABI_LP64F:
+    ABIName = "lp64f";
+    break;
+  case ABI_LP64S:
+  case ABI_LP64D:
+    IsStandardized = true;
+    break;
+  default:
+    llvm_unreachable("");
+  }
+  if (!IsStandardized)
+    errs() << "warning: '" << ABIName << "' has not been standardized\n";
+  return Abi;
+}
 
 ABI computeTargetABI(const Triple &TT, StringRef ABIName) {
   ABI ArgProvidedABI = getTargetABI(ABIName);
@@ -50,7 +81,7 @@ ABI computeTargetABI(const Triple &TT, StringRef ABIName) {
       errs() << "'" << ABIName
              << "' is not a recognized ABI for this target, ignoring and using "
                 "triple-implied ABI\n";
-    return TripleABI;
+    return checkABIStandardized(TripleABI);
 
   case LoongArchABI::ABI_ILP32S:
   case LoongArchABI::ABI_ILP32F:
@@ -58,7 +89,7 @@ ABI computeTargetABI(const Triple &TT, StringRef ABIName) {
     if (Is64Bit) {
       errs() << "32-bit ABIs are not supported for 64-bit targets, ignoring "
                 "target-abi and using triple-implied ABI\n";
-      return TripleABI;
+      return checkABIStandardized(TripleABI);
     }
     break;
 
@@ -68,7 +99,7 @@ ABI computeTargetABI(const Triple &TT, StringRef ABIName) {
     if (!Is64Bit) {
       errs() << "64-bit ABIs are not supported for 32-bit targets, ignoring "
                 "target-abi and using triple-implied ABI\n";
-      return TripleABI;
+      return checkABIStandardized(TripleABI);
     }
     break;
   }
@@ -77,7 +108,7 @@ ABI computeTargetABI(const Triple &TT, StringRef ABIName) {
     errs() << "warning: triple-implied ABI conflicts with provided target-abi '"
            << ABIName << "', using target-abi\n";
 
-  return ArgProvidedABI;
+  return checkABIStandardized(ArgProvidedABI);
 }
 
 ABI getTargetABI(StringRef ABIName) {

--- a/llvm/lib/Target/LoongArch/MCTargetDesc/LoongArchBaseInfo.cpp
+++ b/llvm/lib/Target/LoongArch/MCTargetDesc/LoongArchBaseInfo.cpp
@@ -25,7 +25,6 @@ namespace LoongArchABI {
 // Check if ABI has been standardized; issue a warning if it hasn't.
 // FIXME: Once all ABIs are standardized, this will be removed.
 static ABI checkABIStandardized(ABI Abi) {
-  bool IsStandardized = false;
   StringRef ABIName;
   switch (Abi) {
   case ABI_ILP32S:
@@ -42,13 +41,11 @@ static ABI checkABIStandardized(ABI Abi) {
     break;
   case ABI_LP64S:
   case ABI_LP64D:
-    IsStandardized = true;
-    break;
+    return Abi;
   default:
     llvm_unreachable("");
   }
-  if (!IsStandardized)
-    errs() << "warning: '" << ABIName << "' has not been standardized\n";
+  errs() << "warning: '" << ABIName << "' has not been standardized\n";
   return Abi;
 }
 

--- a/llvm/test/CodeGen/LoongArch/target-abi.ll
+++ b/llvm/test/CodeGen/LoongArch/target-abi.ll
@@ -1,0 +1,26 @@
+; RUN: llc --mtriple=loongarch32 --mattr=+d --target-abi=ilp32s < %s 2>&1 \
+; RUN:   | FileCheck %s -DABI=ilp32s --check-prefixes=CHECK,WARNING
+; RUN: llc --mtriple=loongarch32 --mattr=+d --target-abi=ilp32f < %s 2>&1 \
+; RUN:   | FileCheck %s -DABI=ilp32f --check-prefixes=CHECK,WARNING
+; RUN: llc --mtriple=loongarch32 --mattr=+d --target-abi=ilp32d < %s 2>&1 \
+; RUN:   | FileCheck %s -DABI=ilp32d --check-prefixes=CHECK,WARNING
+; RUN: llc --mtriple=loongarch64 --mattr=+d --target-abi=lp64f < %s 2>&1 \
+; RUN:   | FileCheck %s -DABI=lp64f --check-prefixes=CHECK,WARNING
+
+; RUN: llc --mtriple=loongarch64 --mattr=+d --target-abi=lp64s < %s 2>&1 \
+; RUN:   | FileCheck %s --check-prefixes=CHECK,NO-WARNING
+; RUN: llc --mtriple=loongarch64 --mattr=+d --target-abi=lp64d < %s 2>&1 \
+; RUN:   | FileCheck %s --check-prefixes=CHECK,NO-WARNING
+
+;; Check if the ABI has been standardized; issue a warning if it hasn't.
+
+; WARNING: warning: '[[ABI]]' has not been standardized
+
+; NO-WARNING-NOT: warning
+
+define void @nothing() nounwind {
+; CHECK-LABEL: nothing:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:  ret
+  ret void
+}


### PR DESCRIPTION
This is a pre-commit for modifying `computeTargetABI` logic.

This patch will provide warning prompts when using those ABIs that have
not yet been standardized.
