### PR TITLE
LLD: Fix getFdePC with sdata2 or sdata4

### DIFF
--- a/lld/test/ELF/Inputs/mips32-kseg0.lds
+++ b/lld/test/ELF/Inputs/mips32-kseg0.lds
@@ -1,0 +1,8 @@
+OUTPUT_ARCH(mips)
+SECTIONS
+{
+    . = 0x80000000;
+    .text : { *(.text) }
+    .data : { *(.data) }
+    .bss : { *(.bss) }
+}

--- a/lld/test/ELF/mips-eh_frame-pic.s
+++ b/lld/test/ELF/mips-eh_frame-pic.s
@@ -23,15 +23,20 @@
 # RUN: llvm-dwarfdump --eh-frame %t-nopic32.o | FileCheck %s --check-prefix=ABS32-EH-FRAME
 # RUN: llvm-readobj -r %t-nopic32.o | FileCheck %s --check-prefixes=RELOCS,ABS32-RELOCS
 # RUN: not ld.lld -shared %t-nopic32.o -o /dev/null 2>&1 | FileCheck %s --check-prefix=NOPIC32-ERR
+# RUN: ld.lld %t-nopic32.o -T %p/Inputs/mips32-kseg0.lds -eh-frame-hdr -static -o /dev/null 2>&1 \
+# RUN:      | FileCheck %s --check-prefix=NOPIC32-ABSPTR
 ## Note: ld.bfd can link this file because it rewrites the .eh_frame section to use
 ## relative addressing.
 # NOPIC32-ERR: ld.lld: error: relocation R_MIPS_32 cannot be used against local symbol
+# NOPIC32-ABSPTR: cannot find entry symbol __start
 
 ## For -fPIC, .eh_frame should contain DW_EH_PE_pcrel | DW_EH_PE_sdata4 values:
 # RUN: llvm-mc -filetype=obj -triple=mips-unknown-linux --position-independent %s -o %t-pic32.o
 # RUN: llvm-readobj -r %t-pic32.o | FileCheck %s --check-prefixes=RELOCS,PIC32-RELOCS
 # RUN: ld.lld -shared %t-pic32.o -o %t-pic32.so
+# RUN: ld.lld -shared -T %p/Inputs/mips32-kseg0.lds %t-pic32.o -o %t-pic32-kseg0.so
 # RUN: llvm-dwarfdump --eh-frame %t-pic32.so | FileCheck %s --check-prefix=PIC32-EH-FRAME
+# RUN: llvm-dwarfdump --eh-frame %t-pic32-kseg0.so | FileCheck %s --check-prefix=PIC32-EH-FRAME
 
 # RELOCS:            .rel{{a?}}.eh_frame {
 # ABS32-RELOCS-NEXT:   0x1C R_MIPS_32 .text


### PR DESCRIPTION
LLD uses uint64_t to hold PC value. If an Fde is DW_EH_PE_absptr with data type sdata, getFdePc may return a negtive value and then convert to uint64_t. It will fail to so some add/sub with other address values:
   PC offset is too large: 0xffffffff00000040 is expected.

So if Fde is DW_EH_PE_absptr, let's convert its value to uint16_t(sdata2) or uint32_t(sdata4).

We also do similiar things to DW_EH_PE_pcrel: the value of it should be a signed offset, thus, let's convert them to signed values before use them to add with other address values.

Fixes: #88852.