### PR TITLE
[X86] LowerBITREVERSE - use AND+CMPEQ+MOVMSK trick to lower scalar types

### DIFF
--- a/llvm/lib/Target/X86/X86TargetTransformInfo.cpp
+++ b/llvm/lib/Target/X86/X86TargetTransformInfo.cpp
@@ -4192,6 +4192,8 @@ X86TTIImpl::getIntrinsicInstrCost(const IntrinsicCostAttributes &ICA,
     { ISD::BITREVERSE, MVT::v4i32,   { 16, 20, 11, 21 } },
     { ISD::BITREVERSE, MVT::v8i16,   { 16, 20, 11, 21 } },
     { ISD::BITREVERSE, MVT::v16i8,   { 11, 12, 10, 16 } },
+    { ISD::BITREVERSE, MVT::i16,     {  5,  6,  6, 10 } }, // AND+PCMPEQB+PMOVMSKB
+    { ISD::BITREVERSE, MVT::i8,      {  4,  4,  7,  8 } }, // AND+PCMPEQB+PMOVMSKB
     { ISD::BSWAP,      MVT::v2i64,   {  2,  3,  1,  5 } },
     { ISD::BSWAP,      MVT::v4i32,   {  2,  3,  1,  5 } },
     { ISD::BSWAP,      MVT::v8i16,   {  2,  3,  1,  5 } },

--- a/llvm/test/Analysis/CostModel/X86/bitreverse-codesize.ll
+++ b/llvm/test/Analysis/CostModel/X86/bitreverse-codesize.ll
@@ -101,13 +101,25 @@ define i32 @var_bitreverse_i32(i32 %a) {
 }
 
 define i16 @var_bitreverse_i16(i16 %a) {
-; X86-LABEL: 'var_bitreverse_i16'
-; X86-NEXT:  Cost Model: Found an estimated cost of 17 for instruction: %bitreverse = call i16 @llvm.bitreverse.i16(i16 %a)
-; X86-NEXT:  Cost Model: Found an estimated cost of 1 for instruction: ret i16 %bitreverse
+; SSE2-LABEL: 'var_bitreverse_i16'
+; SSE2-NEXT:  Cost Model: Found an estimated cost of 17 for instruction: %bitreverse = call i16 @llvm.bitreverse.i16(i16 %a)
+; SSE2-NEXT:  Cost Model: Found an estimated cost of 1 for instruction: ret i16 %bitreverse
 ;
-; X64-LABEL: 'var_bitreverse_i16'
-; X64-NEXT:  Cost Model: Found an estimated cost of 17 for instruction: %bitreverse = call i16 @llvm.bitreverse.i16(i16 %a)
-; X64-NEXT:  Cost Model: Found an estimated cost of 1 for instruction: ret i16 %bitreverse
+; SSE42-LABEL: 'var_bitreverse_i16'
+; SSE42-NEXT:  Cost Model: Found an estimated cost of 6 for instruction: %bitreverse = call i16 @llvm.bitreverse.i16(i16 %a)
+; SSE42-NEXT:  Cost Model: Found an estimated cost of 1 for instruction: ret i16 %bitreverse
+;
+; AVX1-LABEL: 'var_bitreverse_i16'
+; AVX1-NEXT:  Cost Model: Found an estimated cost of 6 for instruction: %bitreverse = call i16 @llvm.bitreverse.i16(i16 %a)
+; AVX1-NEXT:  Cost Model: Found an estimated cost of 1 for instruction: ret i16 %bitreverse
+;
+; AVX2-LABEL: 'var_bitreverse_i16'
+; AVX2-NEXT:  Cost Model: Found an estimated cost of 6 for instruction: %bitreverse = call i16 @llvm.bitreverse.i16(i16 %a)
+; AVX2-NEXT:  Cost Model: Found an estimated cost of 1 for instruction: ret i16 %bitreverse
+;
+; AVX512-LABEL: 'var_bitreverse_i16'
+; AVX512-NEXT:  Cost Model: Found an estimated cost of 6 for instruction: %bitreverse = call i16 @llvm.bitreverse.i16(i16 %a)
+; AVX512-NEXT:  Cost Model: Found an estimated cost of 1 for instruction: ret i16 %bitreverse
 ;
 ; XOP-LABEL: 'var_bitreverse_i16'
 ; XOP-NEXT:  Cost Model: Found an estimated cost of 3 for instruction: %bitreverse = call i16 @llvm.bitreverse.i16(i16 %a)
@@ -138,13 +150,25 @@ define i16 @var_bitreverse_i16(i16 %a) {
 }
 
 define i8 @var_bitreverse_i8(i8 %a) {
-; X86-LABEL: 'var_bitreverse_i8'
-; X86-NEXT:  Cost Model: Found an estimated cost of 13 for instruction: %bitreverse = call i8 @llvm.bitreverse.i8(i8 %a)
-; X86-NEXT:  Cost Model: Found an estimated cost of 1 for instruction: ret i8 %bitreverse
+; SSE2-LABEL: 'var_bitreverse_i8'
+; SSE2-NEXT:  Cost Model: Found an estimated cost of 13 for instruction: %bitreverse = call i8 @llvm.bitreverse.i8(i8 %a)
+; SSE2-NEXT:  Cost Model: Found an estimated cost of 1 for instruction: ret i8 %bitreverse
 ;
-; X64-LABEL: 'var_bitreverse_i8'
-; X64-NEXT:  Cost Model: Found an estimated cost of 13 for instruction: %bitreverse = call i8 @llvm.bitreverse.i8(i8 %a)
-; X64-NEXT:  Cost Model: Found an estimated cost of 1 for instruction: ret i8 %bitreverse
+; SSE42-LABEL: 'var_bitreverse_i8'
+; SSE42-NEXT:  Cost Model: Found an estimated cost of 7 for instruction: %bitreverse = call i8 @llvm.bitreverse.i8(i8 %a)
+; SSE42-NEXT:  Cost Model: Found an estimated cost of 1 for instruction: ret i8 %bitreverse
+;
+; AVX1-LABEL: 'var_bitreverse_i8'
+; AVX1-NEXT:  Cost Model: Found an estimated cost of 7 for instruction: %bitreverse = call i8 @llvm.bitreverse.i8(i8 %a)
+; AVX1-NEXT:  Cost Model: Found an estimated cost of 1 for instruction: ret i8 %bitreverse
+;
+; AVX2-LABEL: 'var_bitreverse_i8'
+; AVX2-NEXT:  Cost Model: Found an estimated cost of 7 for instruction: %bitreverse = call i8 @llvm.bitreverse.i8(i8 %a)
+; AVX2-NEXT:  Cost Model: Found an estimated cost of 1 for instruction: ret i8 %bitreverse
+;
+; AVX512-LABEL: 'var_bitreverse_i8'
+; AVX512-NEXT:  Cost Model: Found an estimated cost of 7 for instruction: %bitreverse = call i8 @llvm.bitreverse.i8(i8 %a)
+; AVX512-NEXT:  Cost Model: Found an estimated cost of 1 for instruction: ret i8 %bitreverse
 ;
 ; XOP-LABEL: 'var_bitreverse_i8'
 ; XOP-NEXT:  Cost Model: Found an estimated cost of 3 for instruction: %bitreverse = call i8 @llvm.bitreverse.i8(i8 %a)

--- a/llvm/test/Analysis/CostModel/X86/bitreverse-latency.ll
+++ b/llvm/test/Analysis/CostModel/X86/bitreverse-latency.ll
@@ -101,13 +101,25 @@ define i32 @var_bitreverse_i32(i32 %a) {
 }
 
 define i16 @var_bitreverse_i16(i16 %a) {
-; X86-LABEL: 'var_bitreverse_i16'
-; X86-NEXT:  Cost Model: Found an estimated cost of 12 for instruction: %bitreverse = call i16 @llvm.bitreverse.i16(i16 %a)
-; X86-NEXT:  Cost Model: Found an estimated cost of 1 for instruction: ret i16 %bitreverse
+; SSE2-LABEL: 'var_bitreverse_i16'
+; SSE2-NEXT:  Cost Model: Found an estimated cost of 12 for instruction: %bitreverse = call i16 @llvm.bitreverse.i16(i16 %a)
+; SSE2-NEXT:  Cost Model: Found an estimated cost of 1 for instruction: ret i16 %bitreverse
 ;
-; X64-LABEL: 'var_bitreverse_i16'
-; X64-NEXT:  Cost Model: Found an estimated cost of 12 for instruction: %bitreverse = call i16 @llvm.bitreverse.i16(i16 %a)
-; X64-NEXT:  Cost Model: Found an estimated cost of 1 for instruction: ret i16 %bitreverse
+; SSE42-LABEL: 'var_bitreverse_i16'
+; SSE42-NEXT:  Cost Model: Found an estimated cost of 6 for instruction: %bitreverse = call i16 @llvm.bitreverse.i16(i16 %a)
+; SSE42-NEXT:  Cost Model: Found an estimated cost of 1 for instruction: ret i16 %bitreverse
+;
+; AVX1-LABEL: 'var_bitreverse_i16'
+; AVX1-NEXT:  Cost Model: Found an estimated cost of 6 for instruction: %bitreverse = call i16 @llvm.bitreverse.i16(i16 %a)
+; AVX1-NEXT:  Cost Model: Found an estimated cost of 1 for instruction: ret i16 %bitreverse
+;
+; AVX2-LABEL: 'var_bitreverse_i16'
+; AVX2-NEXT:  Cost Model: Found an estimated cost of 6 for instruction: %bitreverse = call i16 @llvm.bitreverse.i16(i16 %a)
+; AVX2-NEXT:  Cost Model: Found an estimated cost of 1 for instruction: ret i16 %bitreverse
+;
+; AVX512-LABEL: 'var_bitreverse_i16'
+; AVX512-NEXT:  Cost Model: Found an estimated cost of 6 for instruction: %bitreverse = call i16 @llvm.bitreverse.i16(i16 %a)
+; AVX512-NEXT:  Cost Model: Found an estimated cost of 1 for instruction: ret i16 %bitreverse
 ;
 ; XOP-LABEL: 'var_bitreverse_i16'
 ; XOP-NEXT:  Cost Model: Found an estimated cost of 2 for instruction: %bitreverse = call i16 @llvm.bitreverse.i16(i16 %a)
@@ -138,13 +150,25 @@ define i16 @var_bitreverse_i16(i16 %a) {
 }
 
 define i8 @var_bitreverse_i8(i8 %a) {
-; X86-LABEL: 'var_bitreverse_i8'
-; X86-NEXT:  Cost Model: Found an estimated cost of 9 for instruction: %bitreverse = call i8 @llvm.bitreverse.i8(i8 %a)
-; X86-NEXT:  Cost Model: Found an estimated cost of 1 for instruction: ret i8 %bitreverse
+; SSE2-LABEL: 'var_bitreverse_i8'
+; SSE2-NEXT:  Cost Model: Found an estimated cost of 9 for instruction: %bitreverse = call i8 @llvm.bitreverse.i8(i8 %a)
+; SSE2-NEXT:  Cost Model: Found an estimated cost of 1 for instruction: ret i8 %bitreverse
 ;
-; X64-LABEL: 'var_bitreverse_i8'
-; X64-NEXT:  Cost Model: Found an estimated cost of 9 for instruction: %bitreverse = call i8 @llvm.bitreverse.i8(i8 %a)
-; X64-NEXT:  Cost Model: Found an estimated cost of 1 for instruction: ret i8 %bitreverse
+; SSE42-LABEL: 'var_bitreverse_i8'
+; SSE42-NEXT:  Cost Model: Found an estimated cost of 4 for instruction: %bitreverse = call i8 @llvm.bitreverse.i8(i8 %a)
+; SSE42-NEXT:  Cost Model: Found an estimated cost of 1 for instruction: ret i8 %bitreverse
+;
+; AVX1-LABEL: 'var_bitreverse_i8'
+; AVX1-NEXT:  Cost Model: Found an estimated cost of 4 for instruction: %bitreverse = call i8 @llvm.bitreverse.i8(i8 %a)
+; AVX1-NEXT:  Cost Model: Found an estimated cost of 1 for instruction: ret i8 %bitreverse
+;
+; AVX2-LABEL: 'var_bitreverse_i8'
+; AVX2-NEXT:  Cost Model: Found an estimated cost of 4 for instruction: %bitreverse = call i8 @llvm.bitreverse.i8(i8 %a)
+; AVX2-NEXT:  Cost Model: Found an estimated cost of 1 for instruction: ret i8 %bitreverse
+;
+; AVX512-LABEL: 'var_bitreverse_i8'
+; AVX512-NEXT:  Cost Model: Found an estimated cost of 4 for instruction: %bitreverse = call i8 @llvm.bitreverse.i8(i8 %a)
+; AVX512-NEXT:  Cost Model: Found an estimated cost of 1 for instruction: ret i8 %bitreverse
 ;
 ; XOP-LABEL: 'var_bitreverse_i8'
 ; XOP-NEXT:  Cost Model: Found an estimated cost of 2 for instruction: %bitreverse = call i8 @llvm.bitreverse.i8(i8 %a)

--- a/llvm/test/Analysis/CostModel/X86/bitreverse-sizelatency.ll
+++ b/llvm/test/Analysis/CostModel/X86/bitreverse-sizelatency.ll
@@ -101,13 +101,25 @@ define i32 @var_bitreverse_i32(i32 %a) {
 }
 
 define i16 @var_bitreverse_i16(i16 %a) {
-; X86-LABEL: 'var_bitreverse_i16'
-; X86-NEXT:  Cost Model: Found an estimated cost of 19 for instruction: %bitreverse = call i16 @llvm.bitreverse.i16(i16 %a)
-; X86-NEXT:  Cost Model: Found an estimated cost of 1 for instruction: ret i16 %bitreverse
+; SSE2-LABEL: 'var_bitreverse_i16'
+; SSE2-NEXT:  Cost Model: Found an estimated cost of 19 for instruction: %bitreverse = call i16 @llvm.bitreverse.i16(i16 %a)
+; SSE2-NEXT:  Cost Model: Found an estimated cost of 1 for instruction: ret i16 %bitreverse
 ;
-; X64-LABEL: 'var_bitreverse_i16'
-; X64-NEXT:  Cost Model: Found an estimated cost of 19 for instruction: %bitreverse = call i16 @llvm.bitreverse.i16(i16 %a)
-; X64-NEXT:  Cost Model: Found an estimated cost of 1 for instruction: ret i16 %bitreverse
+; SSE42-LABEL: 'var_bitreverse_i16'
+; SSE42-NEXT:  Cost Model: Found an estimated cost of 10 for instruction: %bitreverse = call i16 @llvm.bitreverse.i16(i16 %a)
+; SSE42-NEXT:  Cost Model: Found an estimated cost of 1 for instruction: ret i16 %bitreverse
+;
+; AVX1-LABEL: 'var_bitreverse_i16'
+; AVX1-NEXT:  Cost Model: Found an estimated cost of 10 for instruction: %bitreverse = call i16 @llvm.bitreverse.i16(i16 %a)
+; AVX1-NEXT:  Cost Model: Found an estimated cost of 1 for instruction: ret i16 %bitreverse
+;
+; AVX2-LABEL: 'var_bitreverse_i16'
+; AVX2-NEXT:  Cost Model: Found an estimated cost of 10 for instruction: %bitreverse = call i16 @llvm.bitreverse.i16(i16 %a)
+; AVX2-NEXT:  Cost Model: Found an estimated cost of 1 for instruction: ret i16 %bitreverse
+;
+; AVX512-LABEL: 'var_bitreverse_i16'
+; AVX512-NEXT:  Cost Model: Found an estimated cost of 10 for instruction: %bitreverse = call i16 @llvm.bitreverse.i16(i16 %a)
+; AVX512-NEXT:  Cost Model: Found an estimated cost of 1 for instruction: ret i16 %bitreverse
 ;
 ; XOP-LABEL: 'var_bitreverse_i16'
 ; XOP-NEXT:  Cost Model: Found an estimated cost of 4 for instruction: %bitreverse = call i16 @llvm.bitreverse.i16(i16 %a)
@@ -138,13 +150,25 @@ define i16 @var_bitreverse_i16(i16 %a) {
 }
 
 define i8 @var_bitreverse_i8(i8 %a) {
-; X86-LABEL: 'var_bitreverse_i8'
-; X86-NEXT:  Cost Model: Found an estimated cost of 14 for instruction: %bitreverse = call i8 @llvm.bitreverse.i8(i8 %a)
-; X86-NEXT:  Cost Model: Found an estimated cost of 1 for instruction: ret i8 %bitreverse
+; SSE2-LABEL: 'var_bitreverse_i8'
+; SSE2-NEXT:  Cost Model: Found an estimated cost of 14 for instruction: %bitreverse = call i8 @llvm.bitreverse.i8(i8 %a)
+; SSE2-NEXT:  Cost Model: Found an estimated cost of 1 for instruction: ret i8 %bitreverse
 ;
-; X64-LABEL: 'var_bitreverse_i8'
-; X64-NEXT:  Cost Model: Found an estimated cost of 14 for instruction: %bitreverse = call i8 @llvm.bitreverse.i8(i8 %a)
-; X64-NEXT:  Cost Model: Found an estimated cost of 1 for instruction: ret i8 %bitreverse
+; SSE42-LABEL: 'var_bitreverse_i8'
+; SSE42-NEXT:  Cost Model: Found an estimated cost of 8 for instruction: %bitreverse = call i8 @llvm.bitreverse.i8(i8 %a)
+; SSE42-NEXT:  Cost Model: Found an estimated cost of 1 for instruction: ret i8 %bitreverse
+;
+; AVX1-LABEL: 'var_bitreverse_i8'
+; AVX1-NEXT:  Cost Model: Found an estimated cost of 8 for instruction: %bitreverse = call i8 @llvm.bitreverse.i8(i8 %a)
+; AVX1-NEXT:  Cost Model: Found an estimated cost of 1 for instruction: ret i8 %bitreverse
+;
+; AVX2-LABEL: 'var_bitreverse_i8'
+; AVX2-NEXT:  Cost Model: Found an estimated cost of 8 for instruction: %bitreverse = call i8 @llvm.bitreverse.i8(i8 %a)
+; AVX2-NEXT:  Cost Model: Found an estimated cost of 1 for instruction: ret i8 %bitreverse
+;
+; AVX512-LABEL: 'var_bitreverse_i8'
+; AVX512-NEXT:  Cost Model: Found an estimated cost of 8 for instruction: %bitreverse = call i8 @llvm.bitreverse.i8(i8 %a)
+; AVX512-NEXT:  Cost Model: Found an estimated cost of 1 for instruction: ret i8 %bitreverse
 ;
 ; XOP-LABEL: 'var_bitreverse_i8'
 ; XOP-NEXT:  Cost Model: Found an estimated cost of 4 for instruction: %bitreverse = call i8 @llvm.bitreverse.i8(i8 %a)

--- a/llvm/test/Analysis/CostModel/X86/bitreverse.ll
+++ b/llvm/test/Analysis/CostModel/X86/bitreverse.ll
@@ -101,13 +101,25 @@ define i32 @var_bitreverse_i32(i32 %a) {
 }
 
 define i16 @var_bitreverse_i16(i16 %a) {
-; X86-LABEL: 'var_bitreverse_i16'
-; X86-NEXT:  Cost Model: Found an estimated cost of 9 for instruction: %bitreverse = call i16 @llvm.bitreverse.i16(i16 %a)
-; X86-NEXT:  Cost Model: Found an estimated cost of 0 for instruction: ret i16 %bitreverse
+; SSE2-LABEL: 'var_bitreverse_i16'
+; SSE2-NEXT:  Cost Model: Found an estimated cost of 9 for instruction: %bitreverse = call i16 @llvm.bitreverse.i16(i16 %a)
+; SSE2-NEXT:  Cost Model: Found an estimated cost of 0 for instruction: ret i16 %bitreverse
 ;
-; X64-LABEL: 'var_bitreverse_i16'
-; X64-NEXT:  Cost Model: Found an estimated cost of 9 for instruction: %bitreverse = call i16 @llvm.bitreverse.i16(i16 %a)
-; X64-NEXT:  Cost Model: Found an estimated cost of 0 for instruction: ret i16 %bitreverse
+; SSE42-LABEL: 'var_bitreverse_i16'
+; SSE42-NEXT:  Cost Model: Found an estimated cost of 5 for instruction: %bitreverse = call i16 @llvm.bitreverse.i16(i16 %a)
+; SSE42-NEXT:  Cost Model: Found an estimated cost of 0 for instruction: ret i16 %bitreverse
+;
+; AVX1-LABEL: 'var_bitreverse_i16'
+; AVX1-NEXT:  Cost Model: Found an estimated cost of 5 for instruction: %bitreverse = call i16 @llvm.bitreverse.i16(i16 %a)
+; AVX1-NEXT:  Cost Model: Found an estimated cost of 0 for instruction: ret i16 %bitreverse
+;
+; AVX2-LABEL: 'var_bitreverse_i16'
+; AVX2-NEXT:  Cost Model: Found an estimated cost of 5 for instruction: %bitreverse = call i16 @llvm.bitreverse.i16(i16 %a)
+; AVX2-NEXT:  Cost Model: Found an estimated cost of 0 for instruction: ret i16 %bitreverse
+;
+; AVX512-LABEL: 'var_bitreverse_i16'
+; AVX512-NEXT:  Cost Model: Found an estimated cost of 5 for instruction: %bitreverse = call i16 @llvm.bitreverse.i16(i16 %a)
+; AVX512-NEXT:  Cost Model: Found an estimated cost of 0 for instruction: ret i16 %bitreverse
 ;
 ; XOP-LABEL: 'var_bitreverse_i16'
 ; XOP-NEXT:  Cost Model: Found an estimated cost of 2 for instruction: %bitreverse = call i16 @llvm.bitreverse.i16(i16 %a)
@@ -138,13 +150,25 @@ define i16 @var_bitreverse_i16(i16 %a) {
 }
 
 define i8 @var_bitreverse_i8(i8 %a) {
-; X86-LABEL: 'var_bitreverse_i8'
-; X86-NEXT:  Cost Model: Found an estimated cost of 7 for instruction: %bitreverse = call i8 @llvm.bitreverse.i8(i8 %a)
-; X86-NEXT:  Cost Model: Found an estimated cost of 0 for instruction: ret i8 %bitreverse
+; SSE2-LABEL: 'var_bitreverse_i8'
+; SSE2-NEXT:  Cost Model: Found an estimated cost of 7 for instruction: %bitreverse = call i8 @llvm.bitreverse.i8(i8 %a)
+; SSE2-NEXT:  Cost Model: Found an estimated cost of 0 for instruction: ret i8 %bitreverse
 ;
-; X64-LABEL: 'var_bitreverse_i8'
-; X64-NEXT:  Cost Model: Found an estimated cost of 7 for instruction: %bitreverse = call i8 @llvm.bitreverse.i8(i8 %a)
-; X64-NEXT:  Cost Model: Found an estimated cost of 0 for instruction: ret i8 %bitreverse
+; SSE42-LABEL: 'var_bitreverse_i8'
+; SSE42-NEXT:  Cost Model: Found an estimated cost of 4 for instruction: %bitreverse = call i8 @llvm.bitreverse.i8(i8 %a)
+; SSE42-NEXT:  Cost Model: Found an estimated cost of 0 for instruction: ret i8 %bitreverse
+;
+; AVX1-LABEL: 'var_bitreverse_i8'
+; AVX1-NEXT:  Cost Model: Found an estimated cost of 4 for instruction: %bitreverse = call i8 @llvm.bitreverse.i8(i8 %a)
+; AVX1-NEXT:  Cost Model: Found an estimated cost of 0 for instruction: ret i8 %bitreverse
+;
+; AVX2-LABEL: 'var_bitreverse_i8'
+; AVX2-NEXT:  Cost Model: Found an estimated cost of 4 for instruction: %bitreverse = call i8 @llvm.bitreverse.i8(i8 %a)
+; AVX2-NEXT:  Cost Model: Found an estimated cost of 0 for instruction: ret i8 %bitreverse
+;
+; AVX512-LABEL: 'var_bitreverse_i8'
+; AVX512-NEXT:  Cost Model: Found an estimated cost of 4 for instruction: %bitreverse = call i8 @llvm.bitreverse.i8(i8 %a)
+; AVX512-NEXT:  Cost Model: Found an estimated cost of 0 for instruction: ret i8 %bitreverse
 ;
 ; XOP-LABEL: 'var_bitreverse_i8'
 ; XOP-NEXT:  Cost Model: Found an estimated cost of 2 for instruction: %bitreverse = call i8 @llvm.bitreverse.i8(i8 %a)


### PR DESCRIPTION
By splitting each byte of a scalar type into 8 copies, in reverse order, we can then test each one to see if the bit is set and then use PMOVMSKB/VPTESTMB to pack them back together to get the bit reversal.

So far I've only managed to make this worth it for i8/i16 with SSSE3 (PSHUFB), i32 with AVX2 (AVX1 would be worth it if we can force all 256-bit operations to be split), and i64 with AVX512BW (which can use VPTESTMB).

Fixes #79794