### PR TITLE
Fix null pointer dereference in logging in mlir TransformOps

### DIFF
--- a/mlir/lib/Dialect/Transform/IR/TransformOps.cpp
+++ b/mlir/lib/Dialect/Transform/IR/TransformOps.cpp
@@ -648,13 +648,14 @@ LogicalResult transform::ApplyConversionPatternsOp::verify() {
     if (!llvm::hasSingleElement(typeConverterRegion.front()))
       return emitOpError()
              << "expected exactly one op in default type converter region";
+    Operation *maybeTypeConverter = &typeConverterRegion.front().front();
     auto typeConverterOp = dyn_cast<transform::TypeConverterBuilderOpInterface>(
-        &typeConverterRegion.front().front());
+        maybeTypeConverter);
     if (!typeConverterOp) {
       InFlightDiagnostic diag = emitOpError()
                                 << "expected default converter child op to "
                                    "implement TypeConverterBuilderOpInterface";
-      diag.attachNote(typeConverterOp->getLoc()) << "op without interface";
+      diag.attachNote(maybeTypeConverter->getLoc()) << "op without interface";
       return diag;
     }
     // Check default type converter type.


### PR DESCRIPTION
Hi,

I found with static analysis a possible null pointer overflow during error logging at mlir IR/TransformOps.cpp:
https://github.com/llvm/llvm-project/blob/b2c5e9b9bf2a1cb4a8d4fc67f3201db55ae2cae1/mlir/lib/Dialect/Transform/IR/TransformOps.cpp#L653-L657

A variable `typeConverterOp` may be nullptr after dynamic cast. There is a security guard for this, but during logging error message the variable getting dereferenced.