### PR TITLE
[lld,test] fix few filecheck annotation typos

### DIFF
--- a/lld/test/MachO/install-name.s
+++ b/lld/test/MachO/install-name.s
@@ -31,7 +31,7 @@
 
 # ID:          cmd LC_ID_DYLIB
 # ID-NEXT: cmdsize
-# LID-NEXT:   name foo
+# ID-NEXT:   name foo
 
 .globl _main
 _main:

--- a/lld/test/MachO/objc-methname.s
+++ b/lld/test/MachO/objc-methname.s
@@ -16,7 +16,7 @@
 
 # CSTRING: Contents of (__TEXT,__cstring) section
 # CSTRING-NEXT: existing-cstring
-# CSTIRNG-EMPTY:
+# CSTRING-EMPTY:
 
 # METHNAME: Contents of (__TEXT,__objc_methname) section
 # METHNAME-NEXT: existing_methname


### PR DESCRIPTION
Plus few places where i don't know how to resolve issues:

https://github.com/llvm/llvm-project/blob/f39e75b45160ae69222d6ae197ee20c365146717/lld/test/MachO/export-options.s#L200-L204 unknown prefix

https://github.com/llvm/llvm-project/blob/f39e75b45160ae69222d6ae197ee20c365146717/lld/test/MachO/export-options.s#L211 unused prefix

https://github.com/llvm/llvm-project/blame/421862f8e4ffddf57e210a205984a0ee39c57d96/lld/test/ELF/riscv-gp.s#L19-L21 unknown prefix

https://github.com/llvm/llvm-project/blame/421862f8e4ffddf57e210a205984a0ee39c57d96/lld/test/ELF/ppc64-reloc-addr.s#L9 unkown prefix HEXBE
https://github.com/llvm/llvm-project/blame/421862f8e4ffddf57e210a205984a0ee39c57d96/lld/test/ELF/ppc64-toc-relax-ifunc.s#L24-L26 unknown prefox REL
https://github.com/llvm/llvm-project/blame/main/lld/test/ELF/ppc64-pcrel-call-to-extern.s  unknown prefixes 'SEC-OG', 'REL-NEXT-OG'
https://github.com/llvm/llvm-project/blame/421862f8e4ffddf57e210a205984a0ee39c57d96/lld/test/ELF/ppc32-reloc-rel.s#L25-L26 unknown prefix HEX
https://github.com/llvm/llvm-project/blame/d187005cad8c2cb7d44ba3dd6b01c5f0e4c14ae7/lld/test/ELF/mips-tls-hilo.s#L31-L39 unknown prefix SO
https://github.com/llvm/llvm-project/blame/main/lld/test/ELF/arm-exidx-shared.s prefix uses filecheck command as part of name: CHECK-EXTAB-NEXT, ambiguity