### PR TITLE
[FileCheck] improve prefix validation

### DIFF
--- a/llvm/lib/FileCheck/FileCheck.cpp
+++ b/llvm/lib/FileCheck/FileCheck.cpp
@@ -2468,6 +2468,9 @@ FileCheckString::CheckDag(const SourceMgr &SM, StringRef Buffer,
 
 static bool ValidatePrefixes(StringRef Kind, StringSet<> &UniquePrefixes,
                              ArrayRef<StringRef> SuppliedPrefixes) {
+  static const char *Suffixes[] = {"-NEXT",  "-SAME", "-EMPTY", "-NOT",
+                                   "-COUNT", "-DAG",  "-LABEL"};
+
   for (StringRef Prefix : SuppliedPrefixes) {
     if (Prefix.empty()) {
       errs() << "error: supplied " << Kind << " prefix must not be the empty "
@@ -2486,6 +2489,14 @@ static bool ValidatePrefixes(StringRef Kind, StringSet<> &UniquePrefixes,
       errs() << "error: supplied " << Kind << " prefix must be unique among "
              << "check and comment prefixes: '" << Prefix << "'\n";
       return false;
+    }
+    for (StringRef Directive : Suffixes) {
+      if (Prefix.ends_with(Directive)) {
+        errs() << "error: supplied " << Kind << " prefix must not end with "
+               << "directive: '" << Directive << "', prefix: '" << Prefix
+               << "'\n";
+        return false;
+      }
     }
   }
   return true;

--- a/llvm/lib/FileCheck/FileCheck.cpp
+++ b/llvm/lib/FileCheck/FileCheck.cpp
@@ -2474,11 +2474,12 @@ static bool ValidatePrefixes(StringRef Kind, StringSet<> &UniquePrefixes,
              << "string\n";
       return false;
     }
-    static const Regex Validator("^[a-zA-Z0-9_-]*$");
+    // TODO: restrict prefixes to start with only letter eventually
+    static const Regex Validator("^[a-zA-Z0-9][a-zA-Z0-9_-]*$");
     if (!Validator.match(Prefix)) {
       errs() << "error: supplied " << Kind << " prefix must start with a "
-             << "letter and contain only alphanumeric characters, hyphens, and "
-             << "underscores: '" << Prefix << "'\n";
+             << "letter or digit and contain only ascii alphanumeric "
+             << "characters, hyphens, and underscores: '" << Prefix << "'\n";
       return false;
     }
     if (!UniquePrefixes.insert(Prefix).second) {

--- a/llvm/test/FileCheck/comment/bad-comment-prefix.txt
+++ b/llvm/test/FileCheck/comment/bad-comment-prefix.txt
@@ -3,17 +3,17 @@
 # Check empty comment prefix.
 RUN: %ProtectFileCheckOutput not FileCheck /dev/null < /dev/null 2>&1 \
 RUN:                                      -comment-prefixes= | \
-RUN:   FileCheck -check-prefix=PREFIX-EMPTY %s
+RUN:   FileCheck -check-prefix=EMPTY-PREFIX %s
 RUN: %ProtectFileCheckOutput not FileCheck /dev/null < /dev/null 2>&1 \
 RUN:                                      -comment-prefixes=,FOO | \
-RUN:   FileCheck -check-prefix=PREFIX-EMPTY %s
+RUN:   FileCheck -check-prefix=EMPTY-PREFIX %s
 RUN: %ProtectFileCheckOutput not FileCheck /dev/null < /dev/null 2>&1 \
 RUN:                                      -comment-prefixes=FOO, | \
-RUN:   FileCheck -check-prefix=PREFIX-EMPTY %s
+RUN:   FileCheck -check-prefix=EMPTY-PREFIX %s
 RUN: %ProtectFileCheckOutput not FileCheck /dev/null < /dev/null 2>&1 \
 RUN:                                      -comment-prefixes=FOO,,BAR | \
-RUN:   FileCheck -check-prefix=PREFIX-EMPTY %s
-PREFIX-EMPTY: error: supplied comment prefix must not be the empty string
+RUN:   FileCheck -check-prefix=EMPTY-PREFIX %s
+EMPTY-PREFIX: error: supplied comment prefix must not be the empty string
 
 # Check invalid characters in comment prefix.
 RUN: %ProtectFileCheckOutput not FileCheck /dev/null < /dev/null 2>&1 \
@@ -22,8 +22,8 @@ RUN:   FileCheck -check-prefix=PREFIX-BAD-CHAR1 %s
 RUN: %ProtectFileCheckOutput not FileCheck /dev/null < /dev/null 2>&1 \
 RUN:                                       -comment-prefixes='foo ' | \
 RUN:   FileCheck -check-prefix=PREFIX-BAD-CHAR2 %s
-PREFIX-BAD-CHAR1: error: supplied comment prefix must start with a letter and contain only alphanumeric characters, hyphens, and underscores: '.'
-PREFIX-BAD-CHAR2: error: supplied comment prefix must start with a letter and contain only alphanumeric characters, hyphens, and underscores: 'foo '
+PREFIX-BAD-CHAR1: error: supplied comment prefix must start with a letter or digit and contain only ascii alphanumeric characters, hyphens, and underscores: '.'
+PREFIX-BAD-CHAR2: error: supplied comment prefix must start with a letter or digit and contain only ascii alphanumeric characters, hyphens, and underscores: 'foo '
 
 # Check duplicate comment prefixes.
 RUN: %ProtectFileCheckOutput not FileCheck /dev/null < /dev/null 2>&1 \

--- a/llvm/test/FileCheck/comment/suffixes.txt
+++ b/llvm/test/FileCheck/comment/suffixes.txt
@@ -1,5 +1,5 @@
-# Comment prefixes plus check directive suffixes are not comment directives
-# and are treated as plain text.
+# Comment prefixes plus check directive suffixes are forbidden.
+# FIXME: currently not verified bq ValidatePrefixes missing defaulted comment prefixes?
 
 RUN: echo foo                    >  %t.in
 RUN: echo bar                    >> %t.in
@@ -12,11 +12,11 @@ RUN:   FileCheck -check-prefix=CHECK1 %s
 CHECK1: .chk:1:18: remark: CHECK: expected string found in input
 CHECK1: .chk:2:17: remark: CHECK: expected string found in input
 
-# But we can define them as comment prefixes.
+# But we can define them as comment prefixes; still forbidden.
 
 RUN: %ProtectFileCheckOutput \
 RUN: FileCheck -dump-input=never -vv -comment-prefixes=COM,RUN,RUN-NOT %t.chk < %t.in 2>&1 | \
 RUN:   FileCheck -check-prefix=CHECK2 %s
 
-CHECK2: .chk:1:18: remark: CHECK: expected string found in input
+CHECK2: error: supplied comment prefix must not end with directive: '-NOT', prefix: 'RUN-NOT'
 CHECK2-NOT: .chk:2

--- a/llvm/test/FileCheck/numeric-expression.txt
+++ b/llvm/test/FileCheck/numeric-expression.txt
@@ -593,16 +593,16 @@ CALL-MISSING-ARGUMENT-MSG-NEXT: {{C}}ALL-MISSING-ARGUMENT-NEXT: {{\[\[#add\(NUMV
 CALL-MISSING-ARGUMENT-MSG-NEXT:      {{^}}                                          ^{{$}}
 
 RUN: %ProtectFileCheckOutput \
-RUN: not FileCheck -D#NUMVAR=10 --check-prefix CALL-WRONG-ARGUMENT-COUNT --input-file %s %s 2>&1 \
-RUN:   | FileCheck --strict-whitespace --check-prefix CALL-WRONG-ARGUMENT-COUNT-MSG %s
+RUN: not FileCheck -D#NUMVAR=10 --check-prefix CALL-WRONG-ARGUMENT-NUM --input-file %s %s 2>&1 \
+RUN:   | FileCheck --strict-whitespace --check-prefix CALL-WRONG-ARGUMENT-NUM-MSG %s
 
-CALL WRONG ARGUMENT COUNT
+CALL WRONG ARGUMENT NUM
 30
-CALL-WRONG-ARGUMENT-COUNT-LABEL: CALL WRONG ARGUMENT COUNT
-CALL-WRONG-ARGUMENT-COUNT-NEXT: [[#add(NUMVAR)]]
-CALL-WRONG-ARGUMENT-COUNT-MSG: numeric-expression.txt:[[#@LINE-1]]:36: error: function 'add' takes 2 arguments but 1 given
-CALL-WRONG-ARGUMENT-COUNT-MSG-NEXT: {{C}}ALL-WRONG-ARGUMENT-COUNT-NEXT: {{\[\[#add\(NUMVAR\)\]\]}}
-CALL-WRONG-ARGUMENT-COUNT-MSG-NEXT:    {{^}}                                   ^{{$}}
+CALL-WRONG-ARGUMENT-NUM-LABEL: CALL WRONG ARGUMENT NUM
+CALL-WRONG-ARGUMENT-NUM-NEXT: [[#add(NUMVAR)]]
+CALL-WRONG-ARGUMENT-NUM-MSG: numeric-expression.txt:[[#@LINE-1]]:34: error: function 'add' takes 2 arguments but 1 given
+CALL-WRONG-ARGUMENT-NUM-MSG-NEXT: {{C}}ALL-WRONG-ARGUMENT-NUM-NEXT: {{\[\[#add\(NUMVAR\)\]\]}}
+CALL-WRONG-ARGUMENT-NUM-MSG-NEXT:    {{^}}                                 ^{{$}}
 
 RUN: %ProtectFileCheckOutput \
 RUN: not FileCheck -D#NUMVAR=10 --check-prefix CALL-UNDEFINED-FUNCTION --input-file %s %s 2>&1 \

--- a/llvm/test/FileCheck/validate-check-prefix.txt
+++ b/llvm/test/FileCheck/validate-check-prefix.txt
@@ -6,7 +6,7 @@
 foobar
 ; A1a-B_c: foobar
 
-; BAD_PREFIX: supplied check prefix must start with a letter and contain only alphanumeric characters, hyphens, and underscores: 'A!'
+; BAD_PREFIX:  supplied check prefix must start with a letter or digit and contain only ascii alphanumeric characters, hyphens, and underscores: 'A!'
 
 ; DUPLICATE_PREFIX: error: supplied check prefix must be unique among check and comment prefixes: 'REPEAT'
 


### PR DESCRIPTION
First commit fixes already existing check with wrong regex, enforcing actual behavior: "prefix must start with a letter or digit", this should break few tests like: https://github.com/llvm/llvm-project/blob/7621a0d36465cf870769cd54035d254d409c2ce4/llvm/test/CodeGen/AArch64/Atomics/aarch64-atomic-load-outline_atomics.ll#L3
Historically documented was "must start with letter" but not enforced, so tests with prefixes starting with digit was spread across test suites.

Second commit forbids prefixes ends with directive name, like here, to prevent ambiguity: 
Should `CHECK-EXTAB-NEXT: xxx` be parsed as `prefix: xxx` or this is missing prefix `CHECK-EXTAB` with `-NEXT` directive?
https://github.com/llvm/llvm-project/blob/de18f5ecf80ef7183625c80b04445c614a17c483/lld/test/ELF/arm-exidx-shared.s#L5

TODO: mention [filecheck_lint.py](https://github.com/llvm/llvm-project/blob/d187005cad8c2cb7d44ba3dd6b01c5f0e4c14ae7/llvm/utils/filecheck_lint/filecheck_lint.py) in FileCheck docs.