### PR TITLE
[lldb] Fixed the TestFdLeak test

### DIFF
--- a/lldb/test/API/functionalities/avoids-fd-leak/TestFdLeak.py
+++ b/lldb/test/API/functionalities/avoids-fd-leak/TestFdLeak.py
@@ -26,7 +26,10 @@ class AvoidsFdLeakTestCase(TestBase):
     @skipIfTargetAndroid()  # Android have some other file descriptors open by the shell
     @skipIfDarwinEmbedded  # <rdar://problem/33888742>  # debugserver on ios has an extra fd open on launch
     def test_fd_leak_log(self):
-        self.do_test(["log enable -f '/dev/null' lldb commands"])
+        if lldbplatformutil.getHostPlatform() == "windows":
+            self.do_test(["log enable -f 'NUL' lldb commands"])
+        else:
+            self.do_test(["log enable -f '/dev/null' lldb commands"])
 
     def do_test(self, commands):
         self.build()

--- a/lldb/test/API/functionalities/avoids-fd-leak/TestFdLeak.py
+++ b/lldb/test/API/functionalities/avoids-fd-leak/TestFdLeak.py
@@ -26,10 +26,7 @@ class AvoidsFdLeakTestCase(TestBase):
     @skipIfTargetAndroid()  # Android have some other file descriptors open by the shell
     @skipIfDarwinEmbedded  # <rdar://problem/33888742>  # debugserver on ios has an extra fd open on launch
     def test_fd_leak_log(self):
-        if lldbplatformutil.getHostPlatform() == "windows":
-            self.do_test(["log enable -f 'NUL' lldb commands"])
-        else:
-            self.do_test(["log enable -f '/dev/null' lldb commands"])
+        self.do_test(["log enable -f '{}' lldb commands".format(os.devnull)])
 
     def do_test(self, commands):
         self.build()


### PR DESCRIPTION
Use `NUL` instead of `/dev/null` in case of the Windows host.