### PR TITLE
[lldb] Fixed the TestCompletion test running on a remote target

### DIFF
--- a/lldb/test/API/functionalities/completion/TestCompletion.py
+++ b/lldb/test/API/functionalities/completion/TestCompletion.py
@@ -107,20 +107,16 @@ class CommandLineCompletionTestCase(TestBase):
             self, "// Break here", lldb.SBFileSpec("main.cpp")
         )
         err = lldb.SBError()
-        if lldb.remote_platform:
-            self.process().LoadImage(
-                lldb.SBFileSpec(self.getBuildArtifact("libshared.so")),
-                lldb.SBFileSpec(
-                    lldbutil.append_to_process_working_directory(self, "libshared.so"),
-                    False,
-                ),
-                err,
+        local_spec = lldb.SBFileSpec(self.getBuildArtifact("libshared.so"))
+        remote_spec = (
+            lldb.SBFileSpec(
+                lldbutil.append_to_process_working_directory(self, "libshared.so"),
+                False,
             )
-        else:
-            self.process().LoadImage(
-                lldb.SBFileSpec(self.getBuildArtifact("libshared.so")),
-                err,
-            )
+            if lldb.remote_platform
+            else lldb.SBFileSpec()
+        )
+        self.process().LoadImage(local_spec, remote_spec, err)
         self.assertSuccess(err)
 
         self.complete_from_to("process unload ", "process unload 0")
@@ -484,7 +480,7 @@ class CommandLineCompletionTestCase(TestBase):
         self.complete_from_to("my_test_cmd main.cp", ["main.cpp"])
         self.expect("my_test_cmd main.cpp", substrs=["main.cpp"])
 
-    @skipIfWindows
+    @skipIf(hostoslist=["windows"])
     def test_completion_target_create_from_root_dir(self):
         """Tests source file completion by completing ."""
         root_dir = os.path.abspath(os.sep)

--- a/lldb/test/API/functionalities/completion/TestCompletion.py
+++ b/lldb/test/API/functionalities/completion/TestCompletion.py
@@ -107,9 +107,20 @@ class CommandLineCompletionTestCase(TestBase):
             self, "// Break here", lldb.SBFileSpec("main.cpp")
         )
         err = lldb.SBError()
-        self.process().LoadImage(
-            lldb.SBFileSpec(self.getBuildArtifact("libshared.so")), err
-        )
+        if lldb.remote_platform:
+            self.process().LoadImage(
+                lldb.SBFileSpec(self.getBuildArtifact("libshared.so")),
+                lldb.SBFileSpec(
+                    lldbutil.append_to_process_working_directory(self, "libshared.so"),
+                    False,
+                ),
+                err,
+            )
+        else:
+            self.process().LoadImage(
+                lldb.SBFileSpec(self.getBuildArtifact("libshared.so")),
+                err,
+            )
         self.assertSuccess(err)
 
         self.complete_from_to("process unload ", "process unload 0")


### PR DESCRIPTION
Install the image to the remote target if necessary. Platform::LoadImage() uses the following logic before DoLoadImage()
```
if (IsRemote() || local_file != remote_file) {
  error = Install(local_file, remote_file);
  ...
}
```
The FileSpec for the local path may be resolved, so it is necessary to use the condition `if lldb.remote_platform:`.