### PR TITLE
[flang] Prevent crash from unfoldable TRANSFER()

### DIFF
--- a/flang/lib/Evaluate/fold.cpp
+++ b/flang/lib/Evaluate/fold.cpp
@@ -272,6 +272,7 @@ std::optional<Expr<SomeType>> FoldTransfer(
     }
   }
   if (sourceBytes && IsActuallyConstant(*source) && moldType && extents &&
+      !moldType->IsPolymorphic() &&
       (moldLength || moldType->category() != TypeCategory::Character)) {
     std::size_t elements{
         extents->empty() ? 1 : static_cast<std::size_t>((*extents)[0])};


### PR DESCRIPTION
When the MOLD= argument's type is polymorphic, the type of the result cannot be known at compilation time, so the call cannot be folded even when the SOURCE= is constant.

Fixes https://github.com/llvm/llvm-project/issues/92264.