### PR TITLE
[lldb][Windows] Fixed the TestIOHandlerResizeNoEditline test

### DIFF
--- a/lldb/test/API/iohandler/resize/TestIOHandlerResizeNoEditline.py
+++ b/lldb/test/API/iohandler/resize/TestIOHandlerResizeNoEditline.py
@@ -18,3 +18,4 @@ class TestCase(TestBase):
         dbg.RunCommandInterpreter(True, True, opts, 0, False, False)
         # Try resizing the terminal which shouldn't crash.
         dbg.SetTerminalWidth(47)
+        dbg.GetInputFile().Close()


### PR DESCRIPTION
This test caused python crash on Windows x86_64 host with the exit code 0xC0000409 (STATUS_STACK_BUFFER_OVERRUN). Close the input stream before exit to avoid this crash.