### PR TITLE
[Clang][OpenMP] Fix multi arch compilation for -march option

### DIFF
--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -4486,7 +4486,8 @@ Driver::getOffloadArchs(Compilation &C, const llvm::opt::DerivedArgList &Args,
 
     // Add or remove the seen architectures in order of appearance. If an
     // invalid architecture is given we simply exit.
-    if (Arg->getOption().matches(options::OPT_offload_arch_EQ)) {
+    if (Arg->getOption().matches(options::OPT_offload_arch_EQ)||
+        Arg->getOption().matches(options::OPT_march_EQ)) {
       for (StringRef Arch : llvm::split(Arg->getValue(), ",")) {
         if (Arch == "native" || Arch.empty()) {
           auto GPUsOrErr = TC->getSystemGPUArchs(Args);

--- a/clang/test/Driver/amdgpu-openmp-toolchain.c
+++ b/clang/test/Driver/amdgpu-openmp-toolchain.c
@@ -18,17 +18,47 @@
 // CHECK-PHASES: 0: input, "[[INPUT:.+]]", c, (host-openmp)
 // CHECK-PHASES: 1: preprocessor, {0}, cpp-output, (host-openmp)
 // CHECK-PHASES: 2: compiler, {1}, ir, (host-openmp)
-// CHECK-PHASES: 3: input, "[[INPUT]]", c, (device-openmp)
-// CHECK-PHASES: 4: preprocessor, {3}, cpp-output, (device-openmp)
-// CHECK-PHASES: 5: compiler, {4}, ir, (device-openmp)
-// CHECK-PHASES: 6: offload, "host-openmp (x86_64-unknown-linux-gnu)" {2}, "device-openmp (amdgcn-amd-amdhsa)" {5}, ir
-// CHECK-PHASES: 7: backend, {6}, ir, (device-openmp)
-// CHECK-PHASES: 8: offload, "device-openmp (amdgcn-amd-amdhsa)" {7}, ir
+// CHECK-PHASES: 3: input, "[[INPUT]]", c, (device-openmp, gfx906)
+// CHECK-PHASES: 4: preprocessor, {3}, cpp-output, (device-openmp, gfx906)
+// CHECK-PHASES: 5: compiler, {4}, ir, (device-openmp, gfx906)
+// CHECK-PHASES: 6: offload, "host-openmp (x86_64-unknown-linux-gnu)" {2}, "device-openmp (amdgcn-amd-amdhsa:gfx906)" {5}, ir
+// CHECK-PHASES: 7: backend, {6}, ir, (device-openmp, gfx906)
+// CHECK-PHASES: 8: offload, "device-openmp (amdgcn-amd-amdhsa:gfx906)" {7}, ir
 // CHECK-PHASES: 9: clang-offload-packager, {8}, image, (device-openmp)
 // CHECK-PHASES: 10: offload, "host-openmp (x86_64-unknown-linux-gnu)" {2}, "device-openmp (x86_64-unknown-linux-gnu)" {9}, ir
 // CHECK-PHASES: 11: backend, {10}, assembler, (host-openmp)
 // CHECK-PHASES: 12: assembler, {11}, object, (host-openmp)
 // CHECK-PHASES: 13: clang-linker-wrapper, {12}, image, (host-openmp)
+
+// RUN:   %clang -ccc-print-phases --target=x86_64-unknown-linux-gnu -fopenmp -fopenmp-targets=amdgcn-amd-amdhsa \
+// RUN:   -Xopenmp-target=amdgcn-amd-amdhsa -march=gfx90a:xnack+ \
+// RUN:   -Xopenmp-target=amdgcn-amd-amdhsa -march=gfx90a:xnack- %s 2>&1 \
+// RUN:   | FileCheck --check-prefix=CHECK-PHASES-MULTI %s
+
+// RUN:   %clang -ccc-print-phases --target=x86_64-unknown-linux-gnu -fopenmp -fopenmp-targets=amdgcn-amd-amdhsa \
+// RUN:   -Xopenmp-target=amdgcn-amd-amdhsa -march=gfx90a:xnack+,gfx90a:xnack- %s 2>&1 \
+// RUN:   | FileCheck --check-prefix=CHECK-PHASES-MULTI %s
+
+// CHECK-PHASES-MULTI: 0: input, "[[INPUT:.+]]", c, (host-openmp)
+// CHECK-PHASES-MULTI: 1: preprocessor, {0}, cpp-output, (host-openmp)
+// CHECK-PHASES-MULTI: 2: compiler, {1}, ir, (host-openmp)
+// CHECK-PHASES-MULTI: 3: input, "[[INPUT]]", c, (device-openmp, gfx90a:xnack+)
+// CHECK-PHASES-MULTI: 4: preprocessor, {3}, cpp-output, (device-openmp, gfx90a:xnack+)
+// CHECK-PHASES-MULTI: 5: compiler, {4}, ir, (device-openmp, gfx90a:xnack+)
+// CHECK-PHASES-MULTI: 6: offload, "host-openmp (x86_64-unknown-linux-gnu)" {2}, "device-openmp (amdgcn-amd-amdhsa:gfx90a:xnack+)" {5}, ir
+// CHECK-PHASES-MULTI: 7: backend, {6}, ir, (device-openmp, gfx90a:xnack+)
+// CHECK-PHASES-MULTI: 8: offload, "device-openmp (amdgcn-amd-amdhsa:gfx90a:xnack+)" {7}, ir
+// CHECK-PHASES-MULTI: 9: input, "[[INPUT]]", c, (device-openmp, gfx90a:xnack-)
+// CHECK-PHASES-MULTI: 10: preprocessor, {9}, cpp-output, (device-openmp, gfx90a:xnack-)
+// CHECK-PHASES-MULTI: 11: compiler, {10}, ir, (device-openmp, gfx90a:xnack-)
+// CHECK-PHASES-MULTI: 12: offload, "host-openmp (x86_64-unknown-linux-gnu)" {2}, "device-openmp (amdgcn-amd-amdhsa:gfx90a:xnack-)" {11}, ir
+// CHECK-PHASES-MULTI: 13: backend, {12}, ir, (device-openmp, gfx90a:xnack-)
+// CHECK-PHASES-MULTI: 14: offload, "device-openmp (amdgcn-amd-amdhsa:gfx90a:xnack-)" {13}, ir
+// CHECK-PHASES-MULTI: 15: clang-offload-packager, {8, 14}, image, (device-openmp)
+// CHECK-PHASES-MULTI: 16: offload, "host-openmp (x86_64-unknown-linux-gnu)" {2}, "device-openmp (x86_64-unknown-linux-gnu)" {15}, ir
+// CHECK-PHASES-MULTI: 17: backend, {16}, assembler, (host-openmp)
+// CHECK-PHASES-MULTI: 18: assembler, {17}, object, (host-openmp)
+// CHECK-PHASES-MULTI: 19: clang-linker-wrapper, {18}, image, (host-openmp)
 
 // RUN:   %clang -### --target=x86_64-unknown-linux-gnu -ccc-print-bindings -fopenmp -fopenmp-targets=amdgcn-amd-amdhsa -Xopenmp-target=amdgcn-amd-amdhsa -march=gfx803 -nogpulib %s 2>&1 | FileCheck %s --check-prefix=CHECK-BINDINGS
 // RUN:   %clang -### --target=x86_64-unknown-linux-gnu -ccc-print-bindings -fopenmp -fopenmp-targets=amdgcn-amd-amdhsa --offload-arch=gfx803 -nogpulib %s 2>&1 | FileCheck %s --check-prefix=CHECK-BINDINGS


### PR DESCRIPTION
Legacy toolchain to handle multiple target architectures specified
using `-Xopenmp-target=<triple> -march=<arch>` was only
processing a single architecture. This patch also fixes the use of
comma to specify multiple archs for a single triple.