### PR TITLE
[RISCV] Defer creating RISCVInsertVSETVLI to avoid leak with -stop-after

### DIFF
--- a/llvm/lib/Target/RISCV/RISCV.h
+++ b/llvm/lib/Target/RISCV/RISCV.h
@@ -60,6 +60,7 @@ void initializeRISCVExpandAtomicPseudoPass(PassRegistry &);
 
 FunctionPass *createRISCVInsertVSETVLIPass();
 void initializeRISCVInsertVSETVLIPass(PassRegistry &);
+extern char &RISCVInsertVSETVLIID;
 
 FunctionPass *createRISCVCoalesceVSETVLIPass();
 void initializeRISCVCoalesceVSETVLIPass(PassRegistry &);

--- a/llvm/lib/Target/RISCV/RISCVInsertVSETVLI.cpp
+++ b/llvm/lib/Target/RISCV/RISCVInsertVSETVLI.cpp
@@ -868,6 +868,7 @@ private:
 } // end anonymous namespace
 
 char RISCVInsertVSETVLI::ID = 0;
+char &llvm::RISCVInsertVSETVLIID = RISCVInsertVSETVLI::ID;
 
 INITIALIZE_PASS(RISCVInsertVSETVLI, DEBUG_TYPE, RISCV_INSERT_VSETVLI_NAME,
                 false, false)

--- a/llvm/lib/Target/RISCV/RISCVTargetMachine.cpp
+++ b/llvm/lib/Target/RISCV/RISCVTargetMachine.cpp
@@ -548,9 +548,9 @@ void RISCVPassConfig::addPreRegAlloc() {
   // Run RISCVInsertVSETVLI after PHI elimination. On O1 and above do it after
   // register coalescing so needVSETVLIPHI doesn't need to look through COPYs.
   if (TM->getOptLevel() == CodeGenOptLevel::None)
-    insertPass(&PHIEliminationID, createRISCVInsertVSETVLIPass());
+    insertPass(&PHIEliminationID, &RISCVInsertVSETVLIID);
   else
-    insertPass(&RegisterCoalescerID, createRISCVInsertVSETVLIPass());
+    insertPass(&RegisterCoalescerID, &RISCVInsertVSETVLIID);
 }
 
 void RISCVPassConfig::addFastRegAlloc() {


### PR DESCRIPTION
As noted in https://github.com/llvm/llvm-project/pull/91440#discussion_r1601976425, if the pass pipeline stops early because of -stop-after any allocated passes added with insertPass will not be freed if they haven't already been added.

This was showing up as a failure on the address sanitizer buildbots. We can fix it by instead passing the pass ID instead so that allocation is deferred.
