### PR TITLE
[libcxx][test][AIX] Fix the thousands_sep expectation for fr_FR locales

### DIFF
--- a/libcxx/test/std/localization/locale.categories/facet.numpunct/locale.numpunct.byname/thousands_sep.pass.cpp
+++ b/libcxx/test/std/localization/locale.categories/facet.numpunct/locale.numpunct.byname/thousands_sep.pass.cpp
@@ -64,7 +64,7 @@ int main(int, char**)
         std::locale l(LOCALE_fr_FR_UTF_8);
         {
 #if defined(_CS_GNU_LIBC_VERSION) || defined(_WIN32) || defined(_AIX)
-            const char sep = ' ';
+          const char sep = ' ';
 #else
             const char sep = ',';
 #endif
@@ -76,13 +76,13 @@ int main(int, char**)
         {
 #if defined(_CS_GNU_LIBC_VERSION)
             const wchar_t wsep = glibc_version_less_than("2.27") ? L' ' : L'\u202f';
-#elif defined(_AIX)
-	    const wchar_t wsep = L'\u202f';
-#elif defined(_WIN32)
-            const wchar_t wsep = L'\u00A0';
-#else
-            const wchar_t wsep = L',';
-#endif
+#  elif defined(_AIX)
+          const wchar_t wsep = L'\u202f';
+#  elif defined(_WIN32)
+          const wchar_t wsep = L'\u00A0';
+#  else
+          const wchar_t wsep = L',';
+#  endif
             typedef wchar_t C;
             const std::numpunct<C>& np = std::use_facet<std::numpunct<C> >(l);
             assert(np.thousands_sep() == wsep);

--- a/libcxx/test/std/localization/locale.categories/facet.numpunct/locale.numpunct.byname/thousands_sep.pass.cpp
+++ b/libcxx/test/std/localization/locale.categories/facet.numpunct/locale.numpunct.byname/thousands_sep.pass.cpp
@@ -9,7 +9,6 @@
 // NetBSD does not support LC_NUMERIC at the moment
 // XFAIL: netbsd
 
-// XFAIL: LIBCXX-AIX-FIXME
 // XFAIL: LIBCXX-FREEBSD-FIXME
 
 // REQUIRES: locale.en_US.UTF-8
@@ -64,7 +63,7 @@ int main(int, char**)
         // The below tests work around GLIBC's use of U202F as LC_NUMERIC thousands_sep.
         std::locale l(LOCALE_fr_FR_UTF_8);
         {
-#if defined(_CS_GNU_LIBC_VERSION) || defined(_WIN32)
+#if defined(_CS_GNU_LIBC_VERSION) || defined(_WIN32) || defined(_AIX)
             const char sep = ' ';
 #else
             const char sep = ',';
@@ -77,6 +76,8 @@ int main(int, char**)
         {
 #if defined(_CS_GNU_LIBC_VERSION)
             const wchar_t wsep = glibc_version_less_than("2.27") ? L' ' : L'\u202f';
+#elif defined(_AIX)
+	    const wchar_t wsep = L'\u202f';
 #elif defined(_WIN32)
             const wchar_t wsep = L'\u00A0';
 #else

--- a/libcxx/test/std/localization/locale.categories/facet.numpunct/locale.numpunct.byname/thousands_sep.pass.cpp
+++ b/libcxx/test/std/localization/locale.categories/facet.numpunct/locale.numpunct.byname/thousands_sep.pass.cpp
@@ -77,7 +77,7 @@ int main(int, char**)
 #if defined(_CS_GNU_LIBC_VERSION)
             const wchar_t wsep = glibc_version_less_than("2.27") ? L' ' : L'\u202f';
 #  elif defined(_AIX)
-          const wchar_t wsep = L'\u202f';
+          const wchar_t wsep = L'\u202F';
 #  elif defined(_WIN32)
           const wchar_t wsep = L'\u00A0';
 #  else


### PR DESCRIPTION
Similar to some other platforms, AIX uses ' ' for non-wide characters and U202F for wide characters, so this change opts into those paths for AIX as well.