### PR TITLE
Revert "[NewPM] Add pass options for `InternalizePass` to preserve GVs."

### DIFF
--- a/llvm/lib/Passes/PassBuilder.cpp
+++ b/llvm/lib/Passes/PassBuilder.cpp
@@ -1142,24 +1142,6 @@ Expected<GlobalMergeOptions> parseGlobalMergeOptions(StringRef Params) {
   return Result;
 }
 
-Expected<SmallVector<std::string, 0>> parseInternalizeGVs(StringRef Params) {
-  SmallVector<std::string, 1> PreservedGVs;
-  while (!Params.empty()) {
-    StringRef ParamName;
-    std::tie(ParamName, Params) = Params.split(';');
-
-    if (ParamName.consume_front("preserve-gv=")) {
-      PreservedGVs.push_back(ParamName.str());
-    } else {
-      return make_error<StringError>(
-          formatv("invalid Internalize pass parameter '{0}' ", ParamName).str(),
-          inconvertibleErrorCode());
-    }
-  }
-
-  return PreservedGVs;
-}
-
 } // namespace
 
 /// Tests whether a pass name starts with a valid prefix for a default pipeline

--- a/llvm/lib/Passes/PassRegistry.def
+++ b/llvm/lib/Passes/PassRegistry.def
@@ -78,6 +78,7 @@ MODULE_PASS("insert-gcov-profiling", GCOVProfilerPass())
 MODULE_PASS("instrorderfile", InstrOrderFilePass())
 MODULE_PASS("instrprof", InstrProfilingLoweringPass())
 MODULE_PASS("ctx-instr-lower", PGOCtxProfLoweringPass())
+MODULE_PASS("internalize", InternalizePass())
 MODULE_PASS("invalidate<all>", InvalidateAllAnalysesPass())
 MODULE_PASS("iroutliner", IROutlinerPass())
 MODULE_PASS("jmc-instrumenter", JMCInstrumenterPass())
@@ -174,20 +175,6 @@ MODULE_PASS_WITH_PARAMS(
     "hwasan", "HWAddressSanitizerPass",
     [](HWAddressSanitizerOptions Opts) { return HWAddressSanitizerPass(Opts); },
     parseHWASanPassOptions, "kernel;recover")
-MODULE_PASS_WITH_PARAMS(
-    "internalize", "InternalizePass",
-    [](SmallVector<std::string, 0> PreservedGVs) {
-      if (PreservedGVs.empty())
-        return InternalizePass();
-      auto MustPreserveGV = [=](const GlobalValue &GV) {
-        for (auto &PreservedGV : PreservedGVs)
-          if (GV.getName() == PreservedGV)
-            return true;
-        return false;
-      };
-      return InternalizePass(MustPreserveGV);
-    },
-    parseInternalizeGVs, "preserve-gv=GV")
 MODULE_PASS_WITH_PARAMS(
     "ipsccp", "IPSCCPPass", [](IPSCCPOptions Opts) { return IPSCCPPass(Opts); },
     parseIPSCCPOptions, "no-func-spec;func-spec")

--- a/llvm/test/Transforms/Internalize/lists.ll
+++ b/llvm/test/Transforms/Internalize/lists.ll
@@ -13,11 +13,6 @@
 ; -file and -list options should be merged, the apifile contains foo and j
 ; RUN: opt < %s -passes=internalize -internalize-public-api-list bar -internalize-public-api-file %S/apifile -S | FileCheck --check-prefix=FOO_J_AND_BAR %s
 
-; specifying through pass builder option
-; RUN: opt < %s -passes='internalize<preserve-gv=foo;preserve-gv=j>' -S | FileCheck --check-prefix=FOO_AND_J %s
-; RUN: opt < %s -passes='internalize<preserve-gv=foo;preserve-gv=bar>' -S | FileCheck --check-prefix=FOO_AND_BAR %s
-; RUN: opt < %s -passes='internalize<preserve-gv=foo;preserve-gv=j;preserve-gv=bar>' -S | FileCheck --check-prefix=FOO_J_AND_BAR %s
-
 ; ALL: @i = internal global
 ; FOO_AND_J: @i = internal global
 ; FOO_AND_BAR: @i = internal global


### PR DESCRIPTION
Reverts llvm/llvm-project#91334

This broke the gcc7 build.
I suspect the issue is a mismatch on user-defined move constructor on the return: `return PreservedGVs;`  does not match the return type of the function.