### PR TITLE
Clean up a few tests using clang_lto_profgen

### DIFF
--- a/compiler-rt/test/profile/instrprof-darwin-dead-strip.c
+++ b/compiler-rt/test/profile/instrprof-darwin-dead-strip.c
@@ -10,7 +10,7 @@
 // RUN: otool -V -s __DATA __llvm_prf_names %t | FileCheck %s -check-prefix=PRF_NAMES
 // RUN: otool -V -s __DATA __llvm_prf_cnts %t | FileCheck %s -check-prefix=PRF_CNTS
 
-// RUN: %clang_lto_profgen=%t.lto.profraw -fcoverage-mapping -mllvm -enable-name-compression=false -DCODE=1 -Wl,-dead_strip -flto -o %t.lto %s
+// RUN: %clang_lto_profgen=%t.lto.profraw -fcoverage-mapping -mllvm -enable-name-compression=false -DCODE=1 -Wl,-dead_strip -o %t.lto %s
 // RUN: %run %t.lto
 // RUN: llvm-profdata merge -o %t.lto.profdata %t.lto.profraw
 // RUN: llvm-profdata show --all-functions %t.lto.profdata | FileCheck %s -check-prefix=PROF

--- a/compiler-rt/test/profile/instrprof-gc-sections.c
+++ b/compiler-rt/test/profile/instrprof-gc-sections.c
@@ -1,4 +1,4 @@
-// REQUIRES: linux, lld-available
+// REQUIRES: linux, lld-available, lto
 
 // FIXME: Investigate and fix.
 // XFAIL: powerpc64-target-arch
@@ -14,7 +14,7 @@
 // RUN: llvm-size -A %t | FileCheck %s -check-prefix=PRF_CNTS
 
 // RUN: rm -rf %t.lto.profraw
-// RUN: %clang_lto_profgen=%t.lto.profraw -fuse-ld=lld -fcoverage-mapping -mllvm -enable-name-compression=false -DCODE=1 -ffunction-sections -fdata-sections -Wl,--gc-sections -flto -o %t.lto %s
+// RUN: %clang_lto_profgen=%t.lto.profraw -fuse-ld=lld -fcoverage-mapping -mllvm -enable-name-compression=false -DCODE=1 -ffunction-sections -fdata-sections -Wl,--gc-sections -o %t.lto %s
 // RUN: %run %t.lto
 // RUN: llvm-profdata merge -o %t.lto.profdata %t.lto.profraw
 // RUN: llvm-profdata show --all-functions %t.lto.profdata | FileCheck %s -check-prefix=PROF


### PR DESCRIPTION
(1) clang_lto_profgen will add `-flto` (or `-flto=thin`) when `lto_supported`:
- https://github.com/llvm/llvm-project/blob/ec36145f58d2cf93d86bc4e3be617ad7d7d8ace7/compiler-rt/test/profile/lit.cfg.py#L67
- https://github.com/llvm/llvm-project/blob/f0b3654701bde1cf7821d60698b42383edaff9f3/compiler-rt/test/lit.common.cfg.py#L775
so we may not need to add `-flto` explicitly (otherwise there is some
confusing about which is used)

(2) two tests use `clang_lto_profgen`, but only one requires `lto`.
It seems like both should require `lto` since it intends to test
`clang_lto_profgen`.

Item (2) may partially help with https://github.com/llvm/llvm-project/pull/90692#issuecomment-2113250317
At the moment, some bots see LLD, but is using an old copy of LLD which
will break if we increase the `ModuleSummaryIndex::BitCodeSummaryVersion`
since the old copy of LLD does not understand the new version.
