### PR TITLE
[lldb] Fixed an invalid error message in the DAP disconnect response

### DIFF
--- a/lldb/tools/lldb-dap/lldb-dap.cpp
+++ b/lldb/tools/lldb-dap/lldb-dap.cpp
@@ -977,7 +977,7 @@ void request_disconnect(const llvm::json::Object &request) {
     g_dap.debugger.SetAsync(false);
     lldb::SBError error = terminateDebuggee ? process.Kill() : process.Detach();
     if (!error.Success())
-      response.try_emplace("error", error.GetCString());
+      response.try_emplace("error", std::string(error.GetCString()));
     g_dap.debugger.SetAsync(true);
     break;
   }

--- a/lldb/tools/lldb-dap/lldb-dap.cpp
+++ b/lldb/tools/lldb-dap/lldb-dap.cpp
@@ -977,7 +977,7 @@ void request_disconnect(const llvm::json::Object &request) {
     g_dap.debugger.SetAsync(false);
     lldb::SBError error = terminateDebuggee ? process.Kill() : process.Detach();
     if (!error.Success())
-      response.try_emplace("error", std::string(error.GetCString()));
+      EmplaceSafeString(response, "error", error.GetCString());
     g_dap.debugger.SetAsync(true);
     break;
   }


### PR DESCRIPTION
The `disconnect` response contains the `error` message with invalid characters (a junk data). To reproduce this issue it is enough to run the `TestDAP_commands` test on Windows host and Linux target. The test will fail to run ELF file on Windows and dap_server will be disconnected unexpectedly.

Note dap_server hangs if read_packet() cannot decode JSON with invalid characters. read_packet() must return None in this case instead of an exception. But dap_server does not require any fix after this patch.