### PR TITLE
[mlir] fix IRDL dialect docs

### DIFF
--- a/mlir/include/mlir/Dialect/IRDL/IR/CMakeLists.txt
+++ b/mlir/include/mlir/Dialect/IRDL/IR/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_mlir_dialect(IRDL irdl)
-add_mlir_doc(IRDL IRDL Dialects/ -gen-dialect-doc)
+add_mlir_doc(IRDLOps IRDL Dialects/ -gen-dialect-doc)
 
 # Add IRDL interfaces
 set(LLVM_TARGET_DEFINITIONS IRDLInterfaces.td)


### PR DESCRIPTION
Currently the irdl dialect page has no content beyond the header.

By referring to the Ops.td in the CMake config, it pulls in all the types, attributes, etc., so that the doc generation can include them all in the page.

Rendered locally to confirm it fixes the issue

![image](https://github.com/llvm/llvm-project/assets/2467754/8758f324-6bc3-4f0e-8fa9-8962cdb0177f)
