### PR TITLE
[ValueTracking] Fix assertion failure when `computeKnownFPClass` returns fcNone

### DIFF
--- a/llvm/lib/Analysis/ValueTracking.cpp
+++ b/llvm/lib/Analysis/ValueTracking.cpp
@@ -1126,11 +1126,9 @@ static void computeKnownBitsFromOperator(const Operator *I,
       KnownFPClass Result = computeKnownFPClass(V, fcAllFlags, Depth + 1, Q);
       FPClassTest FPClasses = Result.KnownFPClasses;
 
-      // Treat it as zero if the use of I is unreachable.
-      if (FPClasses == fcNone) {
-        Known.setAllZero();
+      // TODO: Treat it as zero/poison if the use of I is unreachable.
+      if (FPClasses == fcNone)
         break;
-      }
 
       if (Result.isKnownNever(fcNormal | fcSubnormal | fcNan)) {
         Known.Zero.setAllBits();

--- a/llvm/lib/Analysis/ValueTracking.cpp
+++ b/llvm/lib/Analysis/ValueTracking.cpp
@@ -1126,7 +1126,8 @@ static void computeKnownBitsFromOperator(const Operator *I,
       KnownFPClass Result = computeKnownFPClass(V, fcAllFlags, Depth + 1, Q);
       FPClassTest FPClasses = Result.KnownFPClasses;
 
-      if (Result.isKnownNever(fcNormal | fcSubnormal | fcNan)) {
+      if (FPClasses != fcNone &&
+          Result.isKnownNever(fcNormal | fcSubnormal | fcNan)) {
         Known.Zero.setAllBits();
         Known.One.setAllBits();
 

--- a/llvm/lib/Analysis/ValueTracking.cpp
+++ b/llvm/lib/Analysis/ValueTracking.cpp
@@ -1126,8 +1126,13 @@ static void computeKnownBitsFromOperator(const Operator *I,
       KnownFPClass Result = computeKnownFPClass(V, fcAllFlags, Depth + 1, Q);
       FPClassTest FPClasses = Result.KnownFPClasses;
 
-      if (FPClasses != fcNone &&
-          Result.isKnownNever(fcNormal | fcSubnormal | fcNan)) {
+      // Treat it as zero if the use of I is unreachable.
+      if (FPClasses == fcNone) {
+        Known.setAllZero();
+        break;
+      }
+
+      if (Result.isKnownNever(fcNormal | fcSubnormal | fcNan)) {
         Known.Zero.setAllBits();
         Known.One.setAllBits();
 

--- a/llvm/test/Transforms/InstCombine/known-bits.ll
+++ b/llvm/test/Transforms/InstCombine/known-bits.ll
@@ -1666,7 +1666,9 @@ define i64 @pr92084(double %x) {
 ; CHECK:       if.then1:
 ; CHECK-NEXT:    br i1 [[CMP]], label [[IF_ELSE]], label [[IF_THEN2:%.*]]
 ; CHECK:       if.then2:
-; CHECK-NEXT:    ret i64 0
+; CHECK-NEXT:    [[CAST:%.*]] = bitcast double [[X]] to i64
+; CHECK-NEXT:    [[AND:%.*]] = and i64 [[CAST]], 1
+; CHECK-NEXT:    ret i64 [[AND]]
 ; CHECK:       if.else:
 ; CHECK-NEXT:    ret i64 0
 ;
@@ -1687,7 +1689,9 @@ if.else:
 
 define i32 @test_none(float nofpclass(all) %x) {
 ; CHECK-LABEL: @test_none(
-; CHECK-NEXT:    ret i32 0
+; CHECK-NEXT:    [[Y:%.*]] = bitcast float [[X:%.*]] to i32
+; CHECK-NEXT:    [[AND:%.*]] = and i32 [[Y]], 4194304
+; CHECK-NEXT:    ret i32 [[AND]]
 ;
   %y = bitcast float %x to i32
   %and = and i32 %y, 4194304

--- a/llvm/test/Transforms/InstCombine/known-bits.ll
+++ b/llvm/test/Transforms/InstCombine/known-bits.ll
@@ -1666,9 +1666,7 @@ define i64 @pr92084(double %x) {
 ; CHECK:       if.then1:
 ; CHECK-NEXT:    br i1 [[CMP]], label [[IF_ELSE]], label [[IF_THEN2:%.*]]
 ; CHECK:       if.then2:
-; CHECK-NEXT:    [[CAST:%.*]] = bitcast double [[X]] to i64
-; CHECK-NEXT:    [[AND:%.*]] = and i64 [[CAST]], 1
-; CHECK-NEXT:    ret i64 [[AND]]
+; CHECK-NEXT:    ret i64 0
 ; CHECK:       if.else:
 ; CHECK-NEXT:    ret i64 0
 ;
@@ -1689,9 +1687,7 @@ if.else:
 
 define i32 @test_none(float nofpclass(all) %x) {
 ; CHECK-LABEL: @test_none(
-; CHECK-NEXT:    [[Y:%.*]] = bitcast float [[X:%.*]] to i32
-; CHECK-NEXT:    [[AND:%.*]] = and i32 [[Y]], 4194304
-; CHECK-NEXT:    ret i32 [[AND]]
+; CHECK-NEXT:    ret i32 0
 ;
   %y = bitcast float %x to i32
   %and = and i32 %y, 4194304


### PR DESCRIPTION
Fixes https://github.com/llvm/llvm-project/pull/92084#issuecomment-2114083188.
