### PR TITLE
[RemoveDIs] Add release note for C API changes

### DIFF
--- a/llvm/docs/ReleaseNotes.rst
+++ b/llvm/docs/ReleaseNotes.rst
@@ -180,6 +180,27 @@ Changes to the C API
   * ``LLVMGetCallBrNumIndirectDests``
   * ``LLVMGetCallBrIndirectDest``
 
+* Added the following functions for querying and setting the debug info format and for explicitly building either debug intrinsics (old format) or records (new format). These functions will be deprecated and removed in the future as we move towards removing support for the old debug format. See the `debug info migration guide <https://llvm.org/docs/RemoveDIsDebugInfo.html>`_ for more info.
+
+  * ``LLVMIsNewDbgInfoFormat``
+  * ``LLVMSetIsNewDbgInfoFormat``
+  * ``LLVMDIBuilderInsertDeclareIntrinsicBefore``
+  * ``LLVMDIBuilderInsertDeclareIntrinsicAtEnd``
+  * ``LLVMDIBuilderInsertDbgValueIntrinsicBefore``
+  * ``LLVMDIBuilderInsertDbgValueIntrinsicAtEnd``
+  * ``LLVMDIBuilderInsertDeclareRecordBefore``
+  * ``LLVMDIBuilderInsertDeclareRecordAtEnd``
+  * ``LLVMDIBuilderInsertDbgValueRecordBefore``
+  * ``LLVMDIBuilderInsertDbgValueRecordAtEnd``
+
+* Modified the following functions which now always insert debug records (new debug info format) rather than debug intrinsics (old debug info format). See the `debug info migration guide <https://llvm.org/docs/RemoveDIsDebugInfo.html>`_ for more info.
+
+  * ``LLVMDIBuilderInsertDeclareBefore``
+  * ``LLVMDIBuilderInsertDeclareBefore``
+  * ``LLVMDIBuilderInsertDeclareAtEnd``
+  * ``LLVMDIBuilderInsertDbgValueBefore``
+  * ``LLVMDIBuilderInsertDbgValueAtEnd``
+
 Changes to the CodeGen infrastructure
 -------------------------------------
 


### PR DESCRIPTION
The changes have been documented in the migration guide [llvm/docs/RemoveDIsDebugInfo.md](https://llvm.org/docs/RemoveDIsDebugInfo.html#c-api-changes) - add the info to the release notes.