### PR TITLE
[EarlyIfConversion] Fix the logic to determine predictable branch.

### DIFF
--- a/llvm/lib/CodeGen/EarlyIfConversion.cpp
+++ b/llvm/lib/CodeGen/EarlyIfConversion.cpp
@@ -881,10 +881,10 @@ bool EarlyIfConverter::shouldConvertIf() {
   // read to same value multiple times.
   if (CurrentLoop && all_of(IfConv.Cond, [&](MachineOperand &MO) {
         if (!MO.isReg() || !MO.isUse())
-          return false;
+          return true;
         Register Reg = MO.getReg();
         if (Register::isPhysicalRegister(Reg))
-          return false;
+          return true;
 
         MachineInstr *Def = MRI->getVRegDef(Reg);
         return CurrentLoop->isLoopInvariant(*Def) ||
@@ -892,10 +892,10 @@ bool EarlyIfConverter::shouldConvertIf() {
                  if (Op.isImm())
                    return true;
                  if (!MO.isReg() || !MO.isUse())
-                   return false;
+                   return true;
                  Register Reg = MO.getReg();
                  if (Register::isPhysicalRegister(Reg))
-                   return false;
+                   return true;
 
                  MachineInstr *Def = MRI->getVRegDef(Reg);
                  return CurrentLoop->isLoopInvariant(*Def);

--- a/llvm/lib/CodeGen/EarlyIfConversion.cpp
+++ b/llvm/lib/CodeGen/EarlyIfConversion.cpp
@@ -879,7 +879,7 @@ bool EarlyIfConverter::shouldConvertIf() {
   // from a loop-invariant address predictable; we were unable to prove that it
   // doesn't alias any of the memory-writes in the loop, but it is likely to
   // read to same value multiple times.
-  if (CurrentLoop && any_of(IfConv.Cond, [&](MachineOperand &MO) {
+  if (CurrentLoop && all_of(IfConv.Cond, [&](MachineOperand &MO) {
         if (!MO.isReg() || !MO.isUse())
           return false;
         Register Reg = MO.getReg();


### PR DESCRIPTION
Branch is considered predictable when ALL of the operands used to evaluate condition are loop-invariant.