### PR TITLE
[flang][OpenMP] Diagnose invalid reduction modifiers

### DIFF
--- a/flang/lib/Semantics/check-omp-structure.cpp
+++ b/flang/lib/Semantics/check-omp-structure.cpp
@@ -2418,8 +2418,8 @@ void OmpStructureChecker::CheckReductionModifier(
     if (dirCtx.directive != llvm::omp::Directive::OMPD_parallel &&
         !llvm::is_contained(worksharing, dirCtx.directive)) {
       context_.Say(GetContext().clauseSource,
-                   "Modifier 'TASK' on REDUCTION clause is only allowed with "
-                   "PARALLEL or worksharing directive"_err_en_US);
+          "Modifier 'TASK' on REDUCTION clause is only allowed with "
+          "PARALLEL or worksharing directive"_err_en_US);
     }
   } else if (modifier == ReductionModifier::Inscan) {
     // "Inscan" is only allowed on worksharing-loop, worksharing-loop simd,
@@ -2427,19 +2427,21 @@ void OmpStructureChecker::CheckReductionModifier(
     // The worksharing-loop directives are OMPD_do and OMPD_for. Only the
     // former is allowed in Fortran.
     switch (dirCtx.directive) {
-    case llvm::omp::Directive::OMPD_do:      // worksharing-loop
+    case llvm::omp::Directive::OMPD_do: // worksharing-loop
     case llvm::omp::Directive::OMPD_do_simd: // worksharing-loop simd
-    case llvm::omp::Directive::OMPD_simd:    // "simd"
+    case llvm::omp::Directive::OMPD_simd: // "simd"
       break;
     default:
       context_.Say(GetContext().clauseSource,
-                   "Modifier 'INSCAN' on REDUCTION clause is only allowed with "
-                   "worksharing-loop, worksharing-loop simd, "
-                   "or SIMD directive"_err_en_US);
+          "Modifier 'INSCAN' on REDUCTION clause is only allowed with "
+          "worksharing-loop, worksharing-loop simd, "
+          "or SIMD directive"_err_en_US);
     }
   } else {
-    context_.Say(GetContext().clauseSource, "Unexpected modifier on REDUCTION "
-                                            "clause"_err_en_US);
+    // Catch-all for potential future modifiers to make sure that this
+    // function is up-tp-date.
+    context_.Say(GetContext().clauseSource,
+          "Unexpected modifier on REDUCTION clause"_err_en_US);
   }
 }
 

--- a/flang/lib/Semantics/check-omp-structure.cpp
+++ b/flang/lib/Semantics/check-omp-structure.cpp
@@ -2441,7 +2441,7 @@ void OmpStructureChecker::CheckReductionModifier(
     // Catch-all for potential future modifiers to make sure that this
     // function is up-tp-date.
     context_.Say(GetContext().clauseSource,
-          "Unexpected modifier on REDUCTION clause"_err_en_US);
+        "Unexpected modifier on REDUCTION clause"_err_en_US);
   }
 }
 

--- a/flang/lib/Semantics/check-omp-structure.cpp
+++ b/flang/lib/Semantics/check-omp-structure.cpp
@@ -2415,13 +2415,12 @@ void OmpStructureChecker::CheckReductionModifier(
   if (modifier == ReductionModifier::Task) {
     // "Task" is only allowed on worksharing or "parallel" directive.
     static llvm::omp::Directive worksharing[]{
-        llvm::omp::Directive::OMPD_do,
-        // llvm::omp::Directive::OMPD_for, C++ only
-        llvm::omp::Directive::OMPD_scope,
+        llvm::omp::Directive::OMPD_do, llvm::omp::Directive::OMPD_scope,
         llvm::omp::Directive::OMPD_sections,
-        // "single" and "workshare" are worksharing directives, but
-        // they don't allow reduction clause.
-        // "loop" is also worksharing, but has different restrictions.
+        // There are more worksharing directives, but they do not apply:
+        // "for" is C++ only,
+        // "single" and "workshare" don't allow reduction clause,
+        // "loop" has different restrictions (checked above).
     };
     if (dirCtx.directive != llvm::omp::Directive::OMPD_parallel &&
         !llvm::is_contained(worksharing, dirCtx.directive)) {

--- a/flang/lib/Semantics/check-omp-structure.cpp
+++ b/flang/lib/Semantics/check-omp-structure.cpp
@@ -2422,7 +2422,7 @@ void OmpStructureChecker::CheckReductionModifier(
                    "PARALLEL or worksharing directive"_err_en_US);
     }
   } else if (modifier == ReductionModifier::Inscan) {
-    // Inscan is only allowed on worksharing-loop, worksharing-loop simd,
+    // "Inscan" is only allowed on worksharing-loop, worksharing-loop simd,
     // or "simd" directive.
     // The worksharing-loop directives are OMPD_do and OMPD_for. Only the
     // former is allowed in Fortran.

--- a/flang/lib/Semantics/check-omp-structure.h
+++ b/flang/lib/Semantics/check-omp-structure.h
@@ -205,6 +205,7 @@ private:
   bool CheckIntrinsicOperator(
       const parser::DefinedOperator::IntrinsicOperator &);
   void CheckReductionTypeList(const parser::OmpClause::Reduction &);
+  void CheckReductionModifier(const parser::OmpClause::Reduction &);
   void CheckMasterNesting(const parser::OpenMPBlockConstruct &x);
   void ChecksOnOrderedAsBlock();
   void CheckBarrierNesting(const parser::OpenMPSimpleStandaloneConstruct &x);

--- a/flang/test/Lower/OpenMP/invalid-reduction-modifier.f90
+++ b/flang/test/Lower/OpenMP/invalid-reduction-modifier.f90
@@ -1,6 +1,4 @@
-!Remove the --crash below once we can diagnose the issue more gracefully.
-!REQUIRES: asserts
-!RUN: not --crash %flang_fc1 -fopenmp -emit-hlfir -o - %s
+!RUN: not %flang_fc1 -fopenmp -emit-hlfir -o - %s
 
 ! Check that we reject the "task" reduction modifier on the "simd" directive.
 

--- a/flang/test/Semantics/OpenMP/reduction-modifiers.f90
+++ b/flang/test/Semantics/OpenMP/reduction-modifiers.f90
@@ -22,7 +22,6 @@ subroutine mod_task2(x)
   !$omp end sections
 end
 
-
 subroutine mod_task3(x)
   integer, intent(inout) :: x
 
@@ -88,4 +87,3 @@ subroutine mod_inscan5(x)
   enddo
   !$omp end sections
 end
-

--- a/flang/test/Semantics/OpenMP/reduction-modifiers.f90
+++ b/flang/test/Semantics/OpenMP/reduction-modifiers.f90
@@ -1,0 +1,91 @@
+! RUN: %python %S/../test_errors.py %s %flang_fc1 -fopenmp -fopenmp-version=52
+
+subroutine mod_task1(x)
+  integer, intent(inout) :: x
+
+  !Correct: "parallel" directive.
+  !$omp parallel reduction(task, +:x)
+  do i = 1, 100
+    x = foo(i)
+  enddo
+  !$omp end parallel
+end
+
+subroutine mod_task2(x)
+  integer, intent(inout) :: x
+
+  !Correct: worksharing directive.
+  !$omp sections reduction(task, +:x)
+  do i = 1, 100
+    x = foo(i)
+  enddo
+  !$omp end sections
+end
+
+
+subroutine mod_task3(x)
+  integer, intent(inout) :: x
+
+  !ERROR: Modifier 'TASK' on REDUCTION clause is only allowed with PARALLEL or worksharing directive
+  !$omp simd reduction(task, +:x)
+  do i = 1, 100
+    x = foo(i)
+  enddo
+  !$omp end simd
+end
+
+subroutine mod_inscan1(x)
+  integer, intent(inout) :: x
+
+  !Correct: worksharing-loop directive
+  !$omp do reduction(inscan, +:x)
+  do i = 1, 100
+    x = foo(i)
+  enddo
+  !$omp end do
+end
+
+subroutine mod_inscan2(x)
+  integer, intent(inout) :: x
+
+  !Correct: worksharing-loop simd directive
+  !$omp do simd reduction(inscan, +:x)
+  do i = 1, 100
+    x = foo(i)
+  enddo
+  !$omp end do simd
+end
+
+subroutine mod_inscan3(x)
+  integer, intent(inout) :: x
+
+  !Correct: "simd" directive
+  !$omp simd reduction(inscan, +:x)
+  do i = 1, 100
+    x = foo(i)
+  enddo
+  !$omp end simd
+end
+
+subroutine mod_inscan4(x)
+  integer, intent(inout) :: x
+
+  !ERROR: Modifier 'INSCAN' on REDUCTION clause is only allowed with worksharing-loop, worksharing-loop simd, or SIMD directive
+  !$omp parallel reduction(inscan, +:x)
+  do i = 1, 100
+    x = foo(i)
+  enddo
+  !$omp end parallel
+end
+
+subroutine mod_inscan5(x)
+  integer, intent(inout) :: x
+
+  !ERROR: Modifier 'INSCAN' on REDUCTION clause is only allowed with worksharing-loop, worksharing-loop simd, or SIMD directive
+  !$omp sections reduction(inscan, +:x)
+  do i = 1, 100
+    x = foo(i)
+  enddo
+  !$omp end sections
+end
+


### PR DESCRIPTION
Emit diagnostic messages for invalid modifiers in "reduction" clause.

Fixes https://github.com/llvm/llvm-project/issues/92397