### PR TITLE
[RemoveDIs] C API: Add before-dbg-record versions of IRBuilder position funcs

### DIFF
--- a/llvm/bindings/ocaml/llvm/llvm.ml
+++ b/llvm/bindings/ocaml/llvm/llvm.ml
@@ -1135,8 +1135,9 @@ external delete_instruction : llvalue -> unit = "llvm_delete_instruction"
 external builder : llcontext -> llbuilder = "llvm_builder"
 external position_builder : (llbasicblock, llvalue) llpos -> llbuilder -> unit
                           = "llvm_position_builder"
-external position_builder2 : (llbasicblock, llvalue) llpos -> bool -> llbuilder ->
-                            unit = "llvm_position_builder2"
+external position_builder_before_dbg_records : (llbasicblock, llvalue) llpos ->
+                                               llbuilder -> unit
+                                  = "llvm_position_builder_before_dbg_records"
 external insertion_block : llbuilder -> llbasicblock = "llvm_insertion_block"
 external insert_into_builder : llvalue -> string -> llbuilder -> unit
                              = "llvm_insert_into_builder"
@@ -1150,7 +1151,8 @@ let builder_before context i = builder_at context (Before i)
 let builder_at_end context bb = builder_at context (At_end bb)
 
 let position_before i = position_builder (Before i)
-let position_before_dbg_records i = position_builder2 (Before i) true
+let position_before_dbg_records i =
+  position_builder_before_dbg_records (Before i)
 let position_at_end bb = position_builder (At_end bb)
 
 

--- a/llvm/bindings/ocaml/llvm/llvm.ml
+++ b/llvm/bindings/ocaml/llvm/llvm.ml
@@ -1133,22 +1133,22 @@ external delete_instruction : llvalue -> unit = "llvm_delete_instruction"
 
 (*===-- Instruction builders ----------------------------------------------===*)
 external builder : llcontext -> llbuilder = "llvm_builder"
-external position_builder : (llbasicblock, llvalue) llpos -> llbuilder -> unit
-                          = "llvm_position_builder"
+external position_builder : (llbasicblock, llvalue) llpos -> bool -> llbuilder ->
+                            unit = "llvm_position_builder"
 external insertion_block : llbuilder -> llbasicblock = "llvm_insertion_block"
 external insert_into_builder : llvalue -> string -> llbuilder -> unit
                              = "llvm_insert_into_builder"
 
-let builder_at context ip =
+let builder_at context ip before_dbg_records =
   let b = builder context in
-  position_builder ip b;
+  position_builder ip before_dbg_records b;
   b
 
-let builder_before context i = builder_at context (Before i)
-let builder_at_end context bb = builder_at context (At_end bb)
+let builder_before context i before_dbg_records = builder_at context (Before i) before_dbg_records
+let builder_at_end context bb = builder_at context (At_end bb) false
 
-let position_before i = position_builder (Before i)
-let position_at_end bb = position_builder (At_end bb)
+let position_before i before_dbg_records = position_builder (Before i) before_dbg_records
+let position_at_end bb = position_builder (At_end bb) false
 
 
 (*--... Metadata ...........................................................--*)

--- a/llvm/bindings/ocaml/llvm/llvm.ml
+++ b/llvm/bindings/ocaml/llvm/llvm.ml
@@ -1133,22 +1133,22 @@ external delete_instruction : llvalue -> unit = "llvm_delete_instruction"
 
 (*===-- Instruction builders ----------------------------------------------===*)
 external builder : llcontext -> llbuilder = "llvm_builder"
-external position_builder : (llbasicblock, llvalue) llpos -> bool -> llbuilder ->
-                            unit = "llvm_position_builder"
+external position_builder : (llbasicblock, llvalue) llpos -> llbuilder -> unit
+                          = "llvm_position_builder"
 external insertion_block : llbuilder -> llbasicblock = "llvm_insertion_block"
 external insert_into_builder : llvalue -> string -> llbuilder -> unit
                              = "llvm_insert_into_builder"
 
-let builder_at context ip before_dbg_records =
+let builder_at context ip =
   let b = builder context in
-  position_builder ip before_dbg_records b;
+  position_builder ip b;
   b
 
-let builder_before context i before_dbg_records = builder_at context (Before i) before_dbg_records
-let builder_at_end context bb = builder_at context (At_end bb) false
+let builder_before context i = builder_at context (Before i)
+let builder_at_end context bb = builder_at context (At_end bb)
 
-let position_before i before_dbg_records = position_builder (Before i) before_dbg_records
-let position_at_end bb = position_builder (At_end bb) false
+let position_before i = position_builder (Before i)
+let position_at_end bb = position_builder (At_end bb)
 
 
 (*--... Metadata ...........................................................--*)

--- a/llvm/bindings/ocaml/llvm/llvm.ml
+++ b/llvm/bindings/ocaml/llvm/llvm.ml
@@ -1135,6 +1135,8 @@ external delete_instruction : llvalue -> unit = "llvm_delete_instruction"
 external builder : llcontext -> llbuilder = "llvm_builder"
 external position_builder : (llbasicblock, llvalue) llpos -> llbuilder -> unit
                           = "llvm_position_builder"
+external position_builder2 : (llbasicblock, llvalue) llpos -> bool -> llbuilder ->
+                            unit = "llvm_position_builder2"
 external insertion_block : llbuilder -> llbasicblock = "llvm_insertion_block"
 external insert_into_builder : llvalue -> string -> llbuilder -> unit
                              = "llvm_insert_into_builder"
@@ -1148,6 +1150,7 @@ let builder_before context i = builder_at context (Before i)
 let builder_at_end context bb = builder_at context (At_end bb)
 
 let position_before i = position_builder (Before i)
+let position_before_dbg_records i = position_builder2 (Before i) true
 let position_at_end bb = position_builder (At_end bb)
 
 

--- a/llvm/bindings/ocaml/llvm/llvm.mli
+++ b/llvm/bindings/ocaml/llvm/llvm.mli
@@ -1874,8 +1874,20 @@ val builder_at_end : llcontext -> llbasicblock -> llbuilder
     See the constructor for [llvm::LLVMBuilder]. *)
 val position_builder : (llbasicblock, llvalue) llpos -> llbuilder -> unit
 
+(** [position_builder2 ip bb before_dbg_records] moves the instruction builder
+    [bb] to the position [ip]. [before_dbg_records] determines whether the
+    insertion point is before debug records attached to [ip].
+    See the constructor for [llvm::LLVMBuilder]. *)
+val position_builder2 : (llbasicblock, llvalue) llpos -> bool -> llbuilder ->
+                        unit
+
 (** [position_before ins b] moves the instruction builder [b] to before the
     instruction [isn]. See the method [llvm::LLVMBuilder::SetInsertPoint]. *)
+val position_before : llvalue -> llbuilder -> unit
+
+(** [position_before_dbg_records ins b] moves the instruction builder [b] to
+    before the instruction [isn] and any debug records attached to it.
+    See the method [llvm::LLVMBuilder::SetInsertPoint]. *)
 val position_before : llvalue -> llbuilder -> unit
 
 (** [position_at_end bb b] moves the instruction builder [b] to the end of the

--- a/llvm/bindings/ocaml/llvm/llvm.mli
+++ b/llvm/bindings/ocaml/llvm/llvm.mli
@@ -1857,26 +1857,33 @@ val incoming : llvalue -> (llvalue * llbasicblock) list
     for [llvm::LLVMBuilder]. *)
 val builder : llcontext -> llbuilder
 
-(** [builder_at ip] creates an instruction builder positioned at [ip].
+(** [builder_at ip before_dbg_records] creates an instruction builder
+    positioned at [ip]. [before_dbg_records] determines whether the insertion
+    point is before debug records attached to [ip].
     See the constructor for [llvm::LLVMBuilder]. *)
-val builder_at : llcontext -> (llbasicblock, llvalue) llpos -> llbuilder
+val builder_at : llcontext -> (llbasicblock, llvalue) llpos ->
+                 bool -> llbuilder
 
-(** [builder_before ins] creates an instruction builder positioned before the
-    instruction [isn]. See the constructor for [llvm::LLVMBuilder]. *)
-val builder_before : llcontext -> llvalue -> llbuilder
+(** [builder_before ins before_dbg_records] creates an instruction builder
+    positioned before the instruction [isn]. [before_dbg_records] determines
+    whether the insertion point is before debug records attached to [isn].
+    See the constructor for [llvm::LLVMBuilder]. *)
+val builder_before : llcontext -> llvalue -> bool -> llbuilder
 
 (** [builder_at_end bb] creates an instruction builder positioned at the end of
     the basic block [bb]. See the constructor for [llvm::LLVMBuilder]. *)
 val builder_at_end : llcontext -> llbasicblock -> llbuilder
 
-(** [position_builder ip bb] moves the instruction builder [bb] to the position
-    [ip].
+(** [position_builder ip bb before_dbg_records] moves the instruction builder
+    [bb] to the position [ip]. [before_dbg_records] determines whether the
+    insertion point is before debug records attached to [ip].
     See the constructor for [llvm::LLVMBuilder]. *)
-val position_builder : (llbasicblock, llvalue) llpos -> llbuilder -> unit
+val position_builder : (llbasicblock, llvalue) llpos -> bool -> llbuilder ->
+                        unit
 
 (** [position_before ins b] moves the instruction builder [b] to before the
     instruction [isn]. See the method [llvm::LLVMBuilder::SetInsertPoint]. *)
-val position_before : llvalue -> llbuilder -> unit
+val position_before : llvalue -> bool -> llbuilder -> unit
 
 (** [position_at_end bb b] moves the instruction builder [b] to the end of the
     basic block [bb]. See the method [llvm::LLVMBuilder::SetInsertPoint]. *)

--- a/llvm/bindings/ocaml/llvm/llvm.mli
+++ b/llvm/bindings/ocaml/llvm/llvm.mli
@@ -1857,33 +1857,26 @@ val incoming : llvalue -> (llvalue * llbasicblock) list
     for [llvm::LLVMBuilder]. *)
 val builder : llcontext -> llbuilder
 
-(** [builder_at ip before_dbg_records] creates an instruction builder
-    positioned at [ip]. [before_dbg_records] determines whether the insertion
-    point is before debug records attached to [ip].
+(** [builder_at ip] creates an instruction builder positioned at [ip].
     See the constructor for [llvm::LLVMBuilder]. *)
-val builder_at : llcontext -> (llbasicblock, llvalue) llpos ->
-                 bool -> llbuilder
+val builder_at : llcontext -> (llbasicblock, llvalue) llpos -> llbuilder
 
-(** [builder_before ins before_dbg_records] creates an instruction builder
-    positioned before the instruction [isn]. [before_dbg_records] determines
-    whether the insertion point is before debug records attached to [isn].
-    See the constructor for [llvm::LLVMBuilder]. *)
-val builder_before : llcontext -> llvalue -> bool -> llbuilder
+(** [builder_before ins] creates an instruction builder positioned before the
+    instruction [isn]. See the constructor for [llvm::LLVMBuilder]. *)
+val builder_before : llcontext -> llvalue -> llbuilder
 
 (** [builder_at_end bb] creates an instruction builder positioned at the end of
     the basic block [bb]. See the constructor for [llvm::LLVMBuilder]. *)
 val builder_at_end : llcontext -> llbasicblock -> llbuilder
 
-(** [position_builder ip bb before_dbg_records] moves the instruction builder
-    [bb] to the position [ip]. [before_dbg_records] determines whether the
-    insertion point is before debug records attached to [ip].
+(** [position_builder ip bb] moves the instruction builder [bb] to the position
+    [ip].
     See the constructor for [llvm::LLVMBuilder]. *)
-val position_builder : (llbasicblock, llvalue) llpos -> bool -> llbuilder ->
-                        unit
+val position_builder : (llbasicblock, llvalue) llpos -> llbuilder -> unit
 
 (** [position_before ins b] moves the instruction builder [b] to before the
     instruction [isn]. See the method [llvm::LLVMBuilder::SetInsertPoint]. *)
-val position_before : llvalue -> bool -> llbuilder -> unit
+val position_before : llvalue -> llbuilder -> unit
 
 (** [position_at_end bb b] moves the instruction builder [b] to the end of the
     basic block [bb]. See the method [llvm::LLVMBuilder::SetInsertPoint]. *)

--- a/llvm/bindings/ocaml/llvm/llvm.mli
+++ b/llvm/bindings/ocaml/llvm/llvm.mli
@@ -1874,21 +1874,21 @@ val builder_at_end : llcontext -> llbasicblock -> llbuilder
     See the constructor for [llvm::LLVMBuilder]. *)
 val position_builder : (llbasicblock, llvalue) llpos -> llbuilder -> unit
 
-(** [position_builder2 ip bb before_dbg_records] moves the instruction builder
-    [bb] to the position [ip]. [before_dbg_records] determines whether the
-    insertion point is before debug records attached to [ip].
+(** [position_builder_before_dbg_records ip bb before_dbg_records] moves the
+    instruction builder [bb] to the position [ip], before any debug records
+    there.
     See the constructor for [llvm::LLVMBuilder]. *)
-val position_builder2 : (llbasicblock, llvalue) llpos -> bool -> llbuilder ->
-                        unit
+val position_builder_before_dbg_records : (llbasicblock, llvalue) llpos ->
+                                          llbuilder -> unit
 
 (** [position_before ins b] moves the instruction builder [b] to before the
     instruction [isn]. See the method [llvm::LLVMBuilder::SetInsertPoint]. *)
 val position_before : llvalue -> llbuilder -> unit
 
-(** [position_before_dbg_records ins b] moves the instruction builder [b] to
-    before the instruction [isn] and any debug records attached to it.
+(** [position_before_dbg_records ins b] moves the instruction builder [b]
+    to before the instruction [isn] and any debug records attached to it.
     See the method [llvm::LLVMBuilder::SetInsertPoint]. *)
-val position_before : llvalue -> llbuilder -> unit
+val position_before_dbg_records : llvalue -> llbuilder -> unit
 
 (** [position_at_end bb b] moves the instruction builder [b] to the end of the
     basic block [bb]. See the method [llvm::LLVMBuilder::SetInsertPoint]. *)

--- a/llvm/bindings/ocaml/llvm/llvm_ocaml.c
+++ b/llvm/bindings/ocaml/llvm/llvm_ocaml.c
@@ -2004,16 +2004,26 @@ value llvm_builder(value C) {
   return alloc_builder(LLVMCreateBuilderInContext(Context_val(C)));
 }
 
-/* (llbasicblock, llvalue) llpos -> llbuilder -> unit */
-value llvm_position_builder(value Pos, value B) {
+static value llvm_position_builder_impl(value Pos, value B,
+                                        LLVMBool BeforeDbgRecords) {
   if (Tag_val(Pos) == 0) {
     LLVMBasicBlockRef BB = BasicBlock_val(Field(Pos, 0));
     LLVMPositionBuilderAtEnd(Builder_val(B), BB);
   } else {
     LLVMValueRef I = Value_val(Field(Pos, 0));
-    LLVMPositionBuilderBefore(Builder_val(B), I);
+    LLVMPositionBuilderBefore2(Builder_val(B), I, BeforeDbgRecords);
   }
   return Val_unit;
+}
+
+/* (llbasicblock, llvalue) llpos -> bool -> llbuilder -> unit */
+value llvm_position_builder2(value Pos, value BeforeDbgRecords, value B) {
+  return llvm_position_builder_impl(Pos, B, Bool_val(BeforeDbgRecords));
+}
+
+/* (llbasicblock, llvalue) llpos -> llbuilder -> unit */
+value llvm_position_builder(value Pos, value B) {
+  return llvm_position_builder_impl(Pos, B, /*BeforeDbgRecords=*/0);
 }
 
 /* llbuilder -> llbasicblock */

--- a/llvm/bindings/ocaml/llvm/llvm_ocaml.c
+++ b/llvm/bindings/ocaml/llvm/llvm_ocaml.c
@@ -2004,14 +2004,14 @@ value llvm_builder(value C) {
   return alloc_builder(LLVMCreateBuilderInContext(Context_val(C)));
 }
 
-/* (llbasicblock, llvalue) llpos -> bool -> llbuilder -> unit */
-value llvm_position_builder(value Pos, value BeforeDbgRecords, value B) {
+/* (llbasicblock, llvalue) llpos -> llbuilder -> unit */
+value llvm_position_builder(value Pos, value B) {
   if (Tag_val(Pos) == 0) {
     LLVMBasicBlockRef BB = BasicBlock_val(Field(Pos, 0));
     LLVMPositionBuilderAtEnd(Builder_val(B), BB);
   } else {
     LLVMValueRef I = Value_val(Field(Pos, 0));
-    LLVMPositionBuilderBefore(Builder_val(B), I, Bool_val(BeforeDbgRecords));
+    LLVMPositionBuilderBefore(Builder_val(B), I);
   }
   return Val_unit;
 }

--- a/llvm/bindings/ocaml/llvm/llvm_ocaml.c
+++ b/llvm/bindings/ocaml/llvm/llvm_ocaml.c
@@ -2004,26 +2004,28 @@ value llvm_builder(value C) {
   return alloc_builder(LLVMCreateBuilderInContext(Context_val(C)));
 }
 
-static value llvm_position_builder_impl(value Pos, value B,
-                                        LLVMBool BeforeDbgRecords) {
+/* (llbasicblock, llvalue) llpos -> llbuilder -> unit */
+value llvm_position_builder_before_dbg_records(value Pos, value B) {
   if (Tag_val(Pos) == 0) {
     LLVMBasicBlockRef BB = BasicBlock_val(Field(Pos, 0));
     LLVMPositionBuilderAtEnd(Builder_val(B), BB);
   } else {
     LLVMValueRef I = Value_val(Field(Pos, 0));
-    LLVMPositionBuilderBefore2(Builder_val(B), I, BeforeDbgRecords);
+    LLVMPositionBuilderBeforeInstrAndDbgRecords(Builder_val(B), I);
   }
   return Val_unit;
 }
 
-/* (llbasicblock, llvalue) llpos -> bool -> llbuilder -> unit */
-value llvm_position_builder2(value Pos, value BeforeDbgRecords, value B) {
-  return llvm_position_builder_impl(Pos, B, Bool_val(BeforeDbgRecords));
-}
-
 /* (llbasicblock, llvalue) llpos -> llbuilder -> unit */
 value llvm_position_builder(value Pos, value B) {
-  return llvm_position_builder_impl(Pos, B, /*BeforeDbgRecords=*/0);
+  if (Tag_val(Pos) == 0) {
+    LLVMBasicBlockRef BB = BasicBlock_val(Field(Pos, 0));
+    LLVMPositionBuilderAtEnd(Builder_val(B), BB);
+  } else {
+    LLVMValueRef I = Value_val(Field(Pos, 0));
+    LLVMPositionBuilderBefore(Builder_val(B), I);
+  }
+  return Val_unit;
 }
 
 /* llbuilder -> llbasicblock */

--- a/llvm/bindings/ocaml/llvm/llvm_ocaml.c
+++ b/llvm/bindings/ocaml/llvm/llvm_ocaml.c
@@ -2004,14 +2004,14 @@ value llvm_builder(value C) {
   return alloc_builder(LLVMCreateBuilderInContext(Context_val(C)));
 }
 
-/* (llbasicblock, llvalue) llpos -> llbuilder -> unit */
-value llvm_position_builder(value Pos, value B) {
+/* (llbasicblock, llvalue) llpos -> bool -> llbuilder -> unit */
+value llvm_position_builder(value Pos, value BeforeDbgRecords, value B) {
   if (Tag_val(Pos) == 0) {
     LLVMBasicBlockRef BB = BasicBlock_val(Field(Pos, 0));
     LLVMPositionBuilderAtEnd(Builder_val(B), BB);
   } else {
     LLVMValueRef I = Value_val(Field(Pos, 0));
-    LLVMPositionBuilderBefore(Builder_val(B), I);
+    LLVMPositionBuilderBefore(Builder_val(B), I, Bool_val(BeforeDbgRecords));
   }
   return Val_unit;
 }

--- a/llvm/docs/ReleaseNotes.rst
+++ b/llvm/docs/ReleaseNotes.rst
@@ -214,7 +214,7 @@ Changes to the C API
   * ``LLVMConstICmp``
   * ``LLVMConstFCmp``
 
-* Added ``LLVMPositionBuilder2`` and ``LLVMPositionBuilderBefore2``. Same as ``LLVMPositionBuilder`` and ``LLVMPositionBuilderBefore2`` with a new ``BeforeDbgRecords`` parameter which indicates whether or not the insertion position should also be before the debug records that precede the instruction. See the `debug info migration guide <https://llvm.org/docs/RemoveDIsDebugInfo.html>`_ for more info. ``LLVMPositionBuilder`` and ``LLVMPositionBuilderBefore`` are unchanged. They insert before the indicated instruction but after any attached debug records (equivalent to calling the new variants with ``BeforeDbgRecords`` set to ``false``).
+* Added ``LLVMPositionBuilder2`` and ``LLVMPositionBuilderBefore2``. Same as ``LLVMPositionBuilder`` and ``LLVMPositionBuilderBefore`` with a new ``BeforeDbgRecords`` parameter which indicates whether or not the insertion position should also be before the debug records that precede the instruction. See the `debug info migration guide <https://llvm.org/docs/RemoveDIsDebugInfo.html>`_ for more info. ``LLVMPositionBuilder`` and ``LLVMPositionBuilderBefore`` are unchanged. They insert before the indicated instruction but after any attached debug records (equivalent to calling the new variants with ``BeforeDbgRecords`` set to ``false``).
 
 Changes to the CodeGen infrastructure
 -------------------------------------

--- a/llvm/docs/ReleaseNotes.rst
+++ b/llvm/docs/ReleaseNotes.rst
@@ -214,6 +214,32 @@ Changes to the C API
   * ``LLVMConstICmp``
   * ``LLVMConstFCmp``
 
+* Added the following functions for querying and setting the debug info format and for explicitly building either debug intrinsics (old format) or records (new format). These functions will be deprecated and removed in the future as we move towards removing support for the old debug format. See the `debug info migration guide <https://llvm.org/docs/RemoveDIsDebugInfo.html>`_ for more info.
+
+  * ``LLVMIsNewDbgInfoFormat``
+  * ``LLVMSetIsNewDbgInfoFormat``
+  * ``LLVMDIBuilderInsertDeclareIntrinsicBefore``
+  * ``LLVMDIBuilderInsertDeclareIntrinsicAtEnd``
+  * ``LLVMDIBuilderInsertDbgValueIntrinsicBefore``
+  * ``LLVMDIBuilderInsertDbgValueIntrinsicAtEnd``
+  * ``LLVMDIBuilderInsertDeclareRecordBefore``
+  * ``LLVMDIBuilderInsertDeclareRecordAtEnd``
+  * ``LLVMDIBuilderInsertDbgValueRecordBefore``
+  * ``LLVMDIBuilderInsertDbgValueRecordAtEnd``
+
+* Modified the following functions which now always insert debug records (new debug info format) rather than debug intrinsics (old debug info format). See the `debug info migration guide <https://llvm.org/docs/RemoveDIsDebugInfo.html>`_ for more info.
+
+  * ``LLVMDIBuilderInsertDeclareBefore``
+  * ``LLVMDIBuilderInsertDeclareBefore``
+  * ``LLVMDIBuilderInsertDeclareAtEnd``
+  * ``LLVMDIBuilderInsertDbgValueBefore``
+  * ``LLVMDIBuilderInsertDbgValueAtEnd``
+
+* Modified the following functions, adding a new `BeforeDbgRecords` parameter which indicates whether or not the insertion position should also be before the debug records that precede the instruction. See the `debug info migration guide <https://llvm.org/docs/RemoveDIsDebugInfo.html>`_ for more info.
+
+  * ``LLVMPositionBuilder``
+  * ``LLVMPositionBuilderBefore``
+
 Changes to the CodeGen infrastructure
 -------------------------------------
 

--- a/llvm/docs/ReleaseNotes.rst
+++ b/llvm/docs/ReleaseNotes.rst
@@ -214,7 +214,7 @@ Changes to the C API
   * ``LLVMConstICmp``
   * ``LLVMConstFCmp``
 
-* Added ``LLVMPositionBuilder2`` and ``LLVMPositionBuilderBefore2``. Same as ``LLVMPositionBuilder`` and ``LLVMPositionBuilderBefore`` with a new ``BeforeDbgRecords`` parameter which indicates whether or not the insertion position should also be before the debug records that precede the instruction. See the `debug info migration guide <https://llvm.org/docs/RemoveDIsDebugInfo.html>`_ for more info. ``LLVMPositionBuilder`` and ``LLVMPositionBuilderBefore`` are unchanged. They insert before the indicated instruction but after any attached debug records (equivalent to calling the new variants with ``BeforeDbgRecords`` set to ``false``).
+* Added ``LLVMPositionBuilderBeforeDbgRecords`` and ``LLVMPositionBuilderBeforeInstrAndDbgRecords``. Same as ``LLVMPositionBuilder`` and ``LLVMPositionBuilderBefore`` except the insertion position is set to before the debug records that precede the target instruction. See the `debug info migration guide <https://llvm.org/docs/RemoveDIsDebugInfo.html>`_ for more info. ``LLVMPositionBuilder`` and ``LLVMPositionBuilderBefore`` are unchanged; they insert before the indicated instruction but after any attached debug records.
 
 Changes to the CodeGen infrastructure
 -------------------------------------

--- a/llvm/docs/ReleaseNotes.rst
+++ b/llvm/docs/ReleaseNotes.rst
@@ -214,10 +214,7 @@ Changes to the C API
   * ``LLVMConstICmp``
   * ``LLVMConstFCmp``
 
-* Modified the following functions, adding a new `BeforeDbgRecords` parameter which indicates whether or not the insertion position should also be before the debug records that precede the instruction. See the `debug info migration guide <https://llvm.org/docs/RemoveDIsDebugInfo.html>`_ for more info.
-
-  * ``LLVMPositionBuilder``
-  * ``LLVMPositionBuilderBefore``
+* Added ``LLVMPositionBuilder2`` and ``LLVMPositionBuilderBefore2``. Same as ``LLVMPositionBuilder`` and ``LLVMPositionBuilderBefore2`` with a new ``BeforeDbgRecords`` parameter which indicates whether or not the insertion position should also be before the debug records that precede the instruction. See the `debug info migration guide <https://llvm.org/docs/RemoveDIsDebugInfo.html>`_ for more info. ``LLVMPositionBuilder`` and ``LLVMPositionBuilderBefore`` are unchanged. They insert before the indicated instruction but after any attached debug records (equivalent to calling the new variants with ``BeforeDbgRecords`` set to ``false``).
 
 Changes to the CodeGen infrastructure
 -------------------------------------

--- a/llvm/docs/ReleaseNotes.rst
+++ b/llvm/docs/ReleaseNotes.rst
@@ -214,27 +214,6 @@ Changes to the C API
   * ``LLVMConstICmp``
   * ``LLVMConstFCmp``
 
-* Added the following functions for querying and setting the debug info format and for explicitly building either debug intrinsics (old format) or records (new format). These functions will be deprecated and removed in the future as we move towards removing support for the old debug format. See the `debug info migration guide <https://llvm.org/docs/RemoveDIsDebugInfo.html>`_ for more info.
-
-  * ``LLVMIsNewDbgInfoFormat``
-  * ``LLVMSetIsNewDbgInfoFormat``
-  * ``LLVMDIBuilderInsertDeclareIntrinsicBefore``
-  * ``LLVMDIBuilderInsertDeclareIntrinsicAtEnd``
-  * ``LLVMDIBuilderInsertDbgValueIntrinsicBefore``
-  * ``LLVMDIBuilderInsertDbgValueIntrinsicAtEnd``
-  * ``LLVMDIBuilderInsertDeclareRecordBefore``
-  * ``LLVMDIBuilderInsertDeclareRecordAtEnd``
-  * ``LLVMDIBuilderInsertDbgValueRecordBefore``
-  * ``LLVMDIBuilderInsertDbgValueRecordAtEnd``
-
-* Modified the following functions which now always insert debug records (new debug info format) rather than debug intrinsics (old debug info format). See the `debug info migration guide <https://llvm.org/docs/RemoveDIsDebugInfo.html>`_ for more info.
-
-  * ``LLVMDIBuilderInsertDeclareBefore``
-  * ``LLVMDIBuilderInsertDeclareBefore``
-  * ``LLVMDIBuilderInsertDeclareAtEnd``
-  * ``LLVMDIBuilderInsertDbgValueBefore``
-  * ``LLVMDIBuilderInsertDbgValueAtEnd``
-
 * Modified the following functions, adding a new `BeforeDbgRecords` parameter which indicates whether or not the insertion position should also be before the debug records that precede the instruction. See the `debug info migration guide <https://llvm.org/docs/RemoveDIsDebugInfo.html>`_ for more info.
 
   * ``LLVMPositionBuilder``

--- a/llvm/docs/RemoveDIsDebugInfo.md
+++ b/llvm/docs/RemoveDIsDebugInfo.md
@@ -67,7 +67,7 @@ LLVMPositionBuilderBeforeDbgRecords          # See info below.
 LLVMPositionBuilderBeforeInstrAndDbgRecords  # See info below.
 ```
 
-`LLVMPositionBuilderBeforeDbgRecords` and `LLVMPositionBuilderBeforeInstrAndDbgRecords` behave the same as `LLVMPositionBuilder` and `LLVMPositionBuilderBefore` except the insition position is set before the debug records that precede the target instruction. Note that this doesn't mean that debug intrinsics before the chosen instruction are skipped, only debug records (which unlike debug records are not themselves instructions).
+`LLVMPositionBuilderBeforeDbgRecords` and `LLVMPositionBuilderBeforeInstrAndDbgRecords` behave the same as `LLVMPositionBuilder` and `LLVMPositionBuilderBefore` except the insertion position is set before the debug records that precede the target instruction. Note that this doesn't mean that debug intrinsics before the chosen instruction are skipped, only debug records (which unlike debug records are not themselves instructions).
 
 If you don't know which function to call then follow this rule:
 If you are trying to insert at the start of a block, or purposfully skip debug intrinsics to determine the insertion point for any other reason, then call the new functions.

--- a/llvm/docs/RemoveDIsDebugInfo.md
+++ b/llvm/docs/RemoveDIsDebugInfo.md
@@ -60,7 +60,17 @@ LLVMDIBuilderInsertDeclareBefore   # Insert a debug record (new debug info forma
 LLVMDIBuilderInsertDeclareAtEnd    # Same as above.
 LLVMDIBuilderInsertDbgValueBefore  # Same as above.
 LLVMDIBuilderInsertDbgValueAtEnd   # Same as above.
+
+Existing functions (new parameter)
+----------------------------------
+LLVMPositionBuilder               # Added BeforeDbgRecords parameter. See info below.
+LLVMPositionBuilderBefore         # Same as above.
 ```
+
+`LLVMPositionBuilder` and `LLVMPositionBuilderBefore` have gained a parameter `BeforeDbgRecords` which indicates whether or not the insertion position should also be before the debug records that precede the instruction. Note that this doesn't mean that debug intrinsics before the chosen instruction are skipped, only debug records (which unlike debug records are not themselves instructions).
+
+If you don't know whether it should be true or false then follow this rule:
+If you are trying to insert at the start of a block, or purposfully skip debug intrinsics to determine the insertion point for any other reason, then set it to true. Otherwise set it to false.
 
 # The new "Debug Record" model
 

--- a/llvm/docs/RemoveDIsDebugInfo.md
+++ b/llvm/docs/RemoveDIsDebugInfo.md
@@ -63,16 +63,16 @@ LLVMDIBuilderInsertDbgValueAtEnd   # Same as above.
 
 New functions (no plans to deprecate)
 ----------------------------------
-LLVMPositionBuilder2               # LLVMPositionBuilder but with BeforeDbgRecords parameter. See info below.
-LLVMPositionBuilderBefore2         # Same as above.
+LLVMPositionBuilderBeforeDbgRecords          # See info below.
+LLVMPositionBuilderBeforeInstrAndDbgRecords  # See info below.
 ```
 
-`LLVMPositionBuilder2` and `LLVMPositionBuilderBefore2` have a parameter `BeforeDbgRecords` which indicates whether or not the insertion position should also be before the debug records that precede the instruction. Note that this doesn't mean that debug intrinsics before the chosen instruction are skipped, only debug records (which unlike debug records are not themselves instructions).
+`LLVMPositionBuilderBeforeDbgRecords` and `LLVMPositionBuilderBeforeInstrAndDbgRecords` behave the same as `LLVMPositionBuilder` and `LLVMPositionBuilderBefore` except the insition position is set before the debug records that precede the target instruction. Note that this doesn't mean that debug intrinsics before the chosen instruction are skipped, only debug records (which unlike debug records are not themselves instructions).
 
-If you don't know whether it should be true or false then follow this rule:
-If you are trying to insert at the start of a block, or purposfully skip debug intrinsics to determine the insertion point for any other reason, then set it to true. Otherwise set it to false.
+If you don't know which function to call then follow this rule:
+If you are trying to insert at the start of a block, or purposfully skip debug intrinsics to determine the insertion point for any other reason, then call the new functions.
 
-`LLVMPositionBuilder` and `LLVMPositionBuilderBefore` are unchanged. They insert before the indicated instruction but after any attached debug records (equivalent to calling the new variants with `BeforeDbgRecords` set to `false`).
+`LLVMPositionBuilder` and `LLVMPositionBuilderBefore` are unchanged. They insert before the indicated instruction but after any attached debug records.
 
 # The new "Debug Record" model
 

--- a/llvm/docs/RemoveDIsDebugInfo.md
+++ b/llvm/docs/RemoveDIsDebugInfo.md
@@ -36,7 +36,7 @@ For a more in-depth overview of how to update existing code to support debug rec
 
 # C-API changes
 
-All the functions that have been added are temporary and will be deprecated in the future. The intention is that they'll help downstream projects adapt during the transition period.
+Some new functions that have been added are temporary and will be deprecated in the future. The intention is that they'll help downstream projects adapt during the transition period.
 
 ```
 New functions (all to be deprecated)
@@ -61,16 +61,18 @@ LLVMDIBuilderInsertDeclareAtEnd    # Same as above.
 LLVMDIBuilderInsertDbgValueBefore  # Same as above.
 LLVMDIBuilderInsertDbgValueAtEnd   # Same as above.
 
-Existing functions (new parameter)
+New functions (no plans to deprecate)
 ----------------------------------
-LLVMPositionBuilder               # Added BeforeDbgRecords parameter. See info below.
-LLVMPositionBuilderBefore         # Same as above.
+LLVMPositionBuilder2               # LLVMPositionBuilder but with BeforeDbgRecords parameter. See info below.
+LLVMPositionBuilderBefore2         # Same as above.
 ```
 
-`LLVMPositionBuilder` and `LLVMPositionBuilderBefore` have gained a parameter `BeforeDbgRecords` which indicates whether or not the insertion position should also be before the debug records that precede the instruction. Note that this doesn't mean that debug intrinsics before the chosen instruction are skipped, only debug records (which unlike debug records are not themselves instructions).
+`LLVMPositionBuilder2` and `LLVMPositionBuilderBefore2` have a parameter `BeforeDbgRecords` which indicates whether or not the insertion position should also be before the debug records that precede the instruction. Note that this doesn't mean that debug intrinsics before the chosen instruction are skipped, only debug records (which unlike debug records are not themselves instructions).
 
 If you don't know whether it should be true or false then follow this rule:
 If you are trying to insert at the start of a block, or purposfully skip debug intrinsics to determine the insertion point for any other reason, then set it to true. Otherwise set it to false.
+
+`LLVMPositionBuilder` and `LLVMPositionBuilderBefore` are unchanged. They insert before the indicated instruction but after any attached debug records (equivalent to calling the new variants with `BeforeDbgRecords` set to `false`).
 
 # The new "Debug Record" model
 

--- a/llvm/include/llvm-c/Core.h
+++ b/llvm/include/llvm-c/Core.h
@@ -3962,11 +3962,12 @@ LLVMBuilderRef LLVMCreateBuilderInContext(LLVMContextRef C);
 LLVMBuilderRef LLVMCreateBuilder(void);
 void LLVMPositionBuilder(LLVMBuilderRef Builder, LLVMBasicBlockRef Block,
                          LLVMValueRef Instr);
-void LLVMPositionBuilder2(LLVMBuilderRef Builder, LLVMBasicBlockRef Block,
-                          LLVMValueRef Instr, LLVMBool BeforeDbgRecords);
+void LLVMPositionBuilderBeforeDbgRecords(LLVMBuilderRef Builder,
+                                         LLVMBasicBlockRef Block,
+                                         LLVMValueRef Inst);
 void LLVMPositionBuilderBefore(LLVMBuilderRef Builder, LLVMValueRef Instr);
-void LLVMPositionBuilderBefore2(LLVMBuilderRef Builder, LLVMValueRef Instr,
-                                LLVMBool BeforeDbgRecords);
+void LLVMPositionBuilderBeforeInstrAndDbgRecords(LLVMBuilderRef Builder,
+                                                 LLVMValueRef Instr);
 void LLVMPositionBuilderAtEnd(LLVMBuilderRef Builder, LLVMBasicBlockRef Block);
 LLVMBasicBlockRef LLVMGetInsertBlock(LLVMBuilderRef Builder);
 void LLVMClearInsertionPosition(LLVMBuilderRef Builder);

--- a/llvm/include/llvm-c/Core.h
+++ b/llvm/include/llvm-c/Core.h
@@ -3946,21 +3946,27 @@ const unsigned *LLVMGetIndices(LLVMValueRef Inst);
  * An instruction builder represents a point within a basic block and is
  * the exclusive means of building instructions using the C interface.
  *
- * Some insertion-position-setting methods have a "BeforeDbgRecords"
+ * Some insertion-position-setting functions have a "BeforeDbgRecords"
  * parameter. Set to true if the insertion point should be in front of debug
  * records, for example when inserting a phi. If you are trying to insert at the
  * start of a block, or purposfully skip debug intrinsics to determine the
  * insertion point for any other reason, then set it to true. Otherwise set it
- * to false.
+ * to false. Insertion-position-setting functions without the parameter always
+ * set the position after any attached debug records (i.e., as if
+ * "BeforeDbgRecords" is false).
+ *
  * @{
  */
 
 LLVMBuilderRef LLVMCreateBuilderInContext(LLVMContextRef C);
 LLVMBuilderRef LLVMCreateBuilder(void);
 void LLVMPositionBuilder(LLVMBuilderRef Builder, LLVMBasicBlockRef Block,
-                         LLVMValueRef Instr, LLVMBool BeforeDbgRecords);
-void LLVMPositionBuilderBefore(LLVMBuilderRef Builder, LLVMValueRef Instr,
-                               LLVMBool BeforeDbgRecords);
+                         LLVMValueRef Instr);
+void LLVMPositionBuilder2(LLVMBuilderRef Builder, LLVMBasicBlockRef Block,
+                          LLVMValueRef Instr, LLVMBool BeforeDbgRecords);
+void LLVMPositionBuilderBefore(LLVMBuilderRef Builder, LLVMValueRef Instr);
+void LLVMPositionBuilderBefore2(LLVMBuilderRef Builder, LLVMValueRef Instr,
+                                LLVMBool BeforeDbgRecords);
 void LLVMPositionBuilderAtEnd(LLVMBuilderRef Builder, LLVMBasicBlockRef Block);
 LLVMBasicBlockRef LLVMGetInsertBlock(LLVMBuilderRef Builder);
 void LLVMClearInsertionPosition(LLVMBuilderRef Builder);

--- a/llvm/include/llvm-c/Core.h
+++ b/llvm/include/llvm-c/Core.h
@@ -3946,14 +3946,21 @@ const unsigned *LLVMGetIndices(LLVMValueRef Inst);
  * An instruction builder represents a point within a basic block and is
  * the exclusive means of building instructions using the C interface.
  *
+ * Some insertion-position-setting methods have a "BeforeDbgRecords"
+ * parameter. Set to true if the insertion point should be in front of debug
+ * records, for example when inserting a phi. If you are trying to insert at the
+ * start of a block, or purposfully skip debug intrinsics to determine the
+ * insertion point for any other reason, then set it to true. Otherwise set it
+ * to false.
  * @{
  */
 
 LLVMBuilderRef LLVMCreateBuilderInContext(LLVMContextRef C);
 LLVMBuilderRef LLVMCreateBuilder(void);
 void LLVMPositionBuilder(LLVMBuilderRef Builder, LLVMBasicBlockRef Block,
-                         LLVMValueRef Instr);
-void LLVMPositionBuilderBefore(LLVMBuilderRef Builder, LLVMValueRef Instr);
+                         LLVMValueRef Instr, LLVMBool BeforeDbgRecords);
+void LLVMPositionBuilderBefore(LLVMBuilderRef Builder, LLVMValueRef Instr,
+                               LLVMBool BeforeDbgRecords);
 void LLVMPositionBuilderAtEnd(LLVMBuilderRef Builder, LLVMBasicBlockRef Block);
 LLVMBasicBlockRef LLVMGetInsertBlock(LLVMBuilderRef Builder);
 void LLVMClearInsertionPosition(LLVMBuilderRef Builder);

--- a/llvm/include/llvm-c/Core.h
+++ b/llvm/include/llvm-c/Core.h
@@ -3946,26 +3946,31 @@ const unsigned *LLVMGetIndices(LLVMValueRef Inst);
  * An instruction builder represents a point within a basic block and is
  * the exclusive means of building instructions using the C interface.
  *
- * Some insertion-position-setting functions have a "BeforeDbgRecords"
- * parameter. Set to true if the insertion point should be in front of debug
- * records, for example when inserting a phi. If you are trying to insert at the
- * start of a block, or purposfully skip debug intrinsics to determine the
- * insertion point for any other reason, then set it to true. Otherwise set it
- * to false. Insertion-position-setting functions without the parameter always
- * set the position after any attached debug records (i.e., as if
- * "BeforeDbgRecords" is false).
- *
  * @{
  */
 
 LLVMBuilderRef LLVMCreateBuilderInContext(LLVMContextRef C);
 LLVMBuilderRef LLVMCreateBuilder(void);
+/**
+ * Set the builder poisiton before Instr but after any attached debug records,
+ * or if Instr is null set the position to the end of Block.
+ */
 void LLVMPositionBuilder(LLVMBuilderRef Builder, LLVMBasicBlockRef Block,
                          LLVMValueRef Instr);
+/**
+ * Set the builder poisiton before Instr and any attached debug records,
+ * or if Instr is null set the position to the end of Block.
+ */
 void LLVMPositionBuilderBeforeDbgRecords(LLVMBuilderRef Builder,
                                          LLVMBasicBlockRef Block,
                                          LLVMValueRef Inst);
+/**
+ * Set the builder poisiton before Instr but after any attached debug records.
+ */
 void LLVMPositionBuilderBefore(LLVMBuilderRef Builder, LLVMValueRef Instr);
+/**
+ * Set the builder poisiton before Instr and any attached debug records.
+ */
 void LLVMPositionBuilderBeforeInstrAndDbgRecords(LLVMBuilderRef Builder,
                                                  LLVMValueRef Instr);
 void LLVMPositionBuilderAtEnd(LLVMBuilderRef Builder, LLVMBasicBlockRef Block);

--- a/llvm/lib/IR/Core.cpp
+++ b/llvm/lib/IR/Core.cpp
@@ -3138,15 +3138,24 @@ LLVMBuilderRef LLVMCreateBuilder(void) {
 }
 
 void LLVMPositionBuilder(LLVMBuilderRef Builder, LLVMBasicBlockRef Block,
-                         LLVMValueRef Instr, LLVMBool BeforeDbgRecords) {
+                         LLVMValueRef Instr) {
+  return LLVMPositionBuilder2(Builder, Block, Instr, false);
+}
+
+void LLVMPositionBuilder2(LLVMBuilderRef Builder, LLVMBasicBlockRef Block,
+                          LLVMValueRef Instr, LLVMBool BeforeDbgRecords) {
   BasicBlock *BB = unwrap(Block);
   auto I = Instr ? unwrap<Instruction>(Instr)->getIterator() : BB->end();
   I.setHeadBit(BeforeDbgRecords);
   unwrap(Builder)->SetInsertPoint(BB, I);
 }
 
-void LLVMPositionBuilderBefore(LLVMBuilderRef Builder, LLVMValueRef Instr,
-                               LLVMBool BeforeDbgRecords) {
+void LLVMPositionBuilderBefore(LLVMBuilderRef Builder, LLVMValueRef Instr) {
+  return LLVMPositionBuilderBefore2(Builder, Instr, false);
+}
+
+void LLVMPositionBuilderBefore2(LLVMBuilderRef Builder, LLVMValueRef Instr,
+                                LLVMBool BeforeDbgRecords) {
   Instruction *I = unwrap<Instruction>(Instr);
   BasicBlock::iterator It = I->getIterator();
   It.setHeadBit(BeforeDbgRecords);

--- a/llvm/lib/IR/Core.cpp
+++ b/llvm/lib/IR/Core.cpp
@@ -3138,15 +3138,19 @@ LLVMBuilderRef LLVMCreateBuilder(void) {
 }
 
 void LLVMPositionBuilder(LLVMBuilderRef Builder, LLVMBasicBlockRef Block,
-                         LLVMValueRef Instr) {
+                         LLVMValueRef Instr, LLVMBool BeforeDbgRecords) {
   BasicBlock *BB = unwrap(Block);
   auto I = Instr ? unwrap<Instruction>(Instr)->getIterator() : BB->end();
+  I.setHeadBit(BeforeDbgRecords);
   unwrap(Builder)->SetInsertPoint(BB, I);
 }
 
-void LLVMPositionBuilderBefore(LLVMBuilderRef Builder, LLVMValueRef Instr) {
+void LLVMPositionBuilderBefore(LLVMBuilderRef Builder, LLVMValueRef Instr,
+                               LLVMBool BeforeDbgRecords) {
   Instruction *I = unwrap<Instruction>(Instr);
-  unwrap(Builder)->SetInsertPoint(I->getParent(), I->getIterator());
+  BasicBlock::iterator It = I->getIterator();
+  It.setHeadBit(BeforeDbgRecords);
+  unwrap(Builder)->SetInsertPoint(I->getParent(), It);
 }
 
 void LLVMPositionBuilderAtEnd(LLVMBuilderRef Builder, LLVMBasicBlockRef Block) {

--- a/llvm/test/Bindings/OCaml/core.ml
+++ b/llvm/test/Bindings/OCaml/core.ml
@@ -1150,7 +1150,7 @@ let test_builder () =
     (* CHECK: ret{{.*}}P1
      *)
     let ret = build_ret p1 atentry in
-    position_before ret atentry
+    position_before_dbg_records ret atentry
   end;
 
   (* see test/Feature/exception.ll *)

--- a/llvm/test/Bindings/OCaml/core.ml
+++ b/llvm/test/Bindings/OCaml/core.ml
@@ -830,7 +830,7 @@ let test_instructions () =
     let fty = function_type void_type [| i32_type; i32_type |] in
     let f = define_function "f" fty m in
     let bb = entry_block f in
-    let b = builder_at context (At_end bb) in
+    let b = builder_at context (At_end bb) false in
 
     insist (At_end bb = instr_begin bb);
     insist (At_start bb = instr_end bb);
@@ -1150,7 +1150,7 @@ let test_builder () =
     (* CHECK: ret{{.*}}P1
      *)
     let ret = build_ret p1 atentry in
-    position_before ret atentry
+    position_before ret false atentry
   end;
 
   (* see test/Feature/exception.ll *)

--- a/llvm/test/Bindings/OCaml/core.ml
+++ b/llvm/test/Bindings/OCaml/core.ml
@@ -830,7 +830,7 @@ let test_instructions () =
     let fty = function_type void_type [| i32_type; i32_type |] in
     let f = define_function "f" fty m in
     let bb = entry_block f in
-    let b = builder_at context (At_end bb) false in
+    let b = builder_at context (At_end bb) in
 
     insist (At_end bb = instr_begin bb);
     insist (At_start bb = instr_end bb);
@@ -1150,7 +1150,7 @@ let test_builder () =
     (* CHECK: ret{{.*}}P1
      *)
     let ret = build_ret p1 atentry in
-    position_before ret false atentry
+    position_before ret atentry
   end;
 
   (* see test/Feature/exception.ll *)

--- a/llvm/test/Bindings/OCaml/debuginfo.ml
+++ b/llvm/test/Bindings/OCaml/debuginfo.ml
@@ -273,7 +273,7 @@ let test_variables f dibuilder file_di fun_di =
   stdout_metadata auto_var;
   (* CHECK: [[LOCAL_VAR_PTR:<0x[0-9a-f]*>]] = !DILocalVariable(name: "my_local", scope: <{{0x[0-9a-f]*}}>, file: <{{0x[0-9a-f]*}}>, line: 10, type: [[INT64TY_PTR]])
   *)
-  let builder = Llvm.builder_before context entry_term in
+  let builder = Llvm.builder_before context entry_term false in
   let all = Llvm.build_alloca (Llvm.i64_type context)  "my_alloca" builder in
   let scope =
     Llvm_debuginfo.dibuild_create_lexical_block dibuilder ~scope:fun_di

--- a/llvm/test/Bindings/OCaml/debuginfo.ml
+++ b/llvm/test/Bindings/OCaml/debuginfo.ml
@@ -273,7 +273,7 @@ let test_variables f dibuilder file_di fun_di =
   stdout_metadata auto_var;
   (* CHECK: [[LOCAL_VAR_PTR:<0x[0-9a-f]*>]] = !DILocalVariable(name: "my_local", scope: <{{0x[0-9a-f]*}}>, file: <{{0x[0-9a-f]*}}>, line: 10, type: [[INT64TY_PTR]])
   *)
-  let builder = Llvm.builder_before context entry_term false in
+  let builder = Llvm.builder_before context entry_term in
   let all = Llvm.build_alloca (Llvm.i64_type context)  "my_alloca" builder in
   let scope =
     Llvm_debuginfo.dibuild_create_lexical_block dibuilder ~scope:fun_di

--- a/llvm/test/Bindings/llvm-c/debug_info.ll
+++ b/llvm/test/Bindings/llvm-c/debug_info.ll
@@ -10,7 +10,10 @@
 ; CHECK-NEXT:   call void @llvm.dbg.declare(metadata i64 0, metadata !40, metadata !DIExpression()), !dbg !43
 ; CHECK-NEXT:   br label %vars
 ; CHECK:      vars:
+; CHECK-NEXT:   %p1 = phi i64 [ 0, %entry ]
+; CHECK-NEXT:   %p2 = phi i64 [ 0, %entry ]
 ; CHECK-NEXT:   call void @llvm.dbg.value(metadata i64 0, metadata !41, metadata !DIExpression(DW_OP_constu, 0, DW_OP_stack_value)), !dbg !44
+; CHECK-NEXT:   %a = add i64 %p1, %p2
 ; CHECK-NEXT:   ret i64 0
 ; CHECK-NEXT: }
 

--- a/llvm/test/Bindings/llvm-c/debug_info_new_format.ll
+++ b/llvm/test/Bindings/llvm-c/debug_info_new_format.ll
@@ -11,7 +11,10 @@
 ; CHECK-NEXT:     #dbg_declare(i64 0, !40, !DIExpression(), !43)
 ; CHECK-NEXT:   br label %vars
 ; CHECK:      vars:
+; CHECK-NEXT:   %p1 = phi i64 [ 0, %entry ]
+; CHECK-NEXT:   %p2 = phi i64 [ 0, %entry ]
 ; CHECK-NEXT:     #dbg_value(i64 0, !41, !DIExpression(DW_OP_constu, 0, DW_OP_stack_value), !44)
+; CHECK-NEXT:   %a = add i64 %p1, %p2
 ; CHECK-NEXT:   ret i64 0
 ; CHECK-NEXT: }
 

--- a/llvm/tools/llvm-c-test/debuginfo.c
+++ b/llvm/tools/llvm-c-test/debuginfo.c
@@ -235,16 +235,16 @@ int llvm_test_dibuilder(bool NewDebugInfoFormat) {
   // will come before the `phi` (and be absorbed onto it) which is an invalid
   // state.
   LLVMValueRef InsertPos = LLVMGetFirstInstruction(FooVarBlock);
-  LLVMPositionBuilderBefore2(Builder, InsertPos, true);
+  LLVMPositionBuilderBeforeInstrAndDbgRecords(Builder, InsertPos);
   LLVMValueRef Phi1 = LLVMBuildPhi(Builder, I64, "p1");
   LLVMAddIncoming(Phi1, &Zero, &FooEntryBlock, 1);
   // Do the same again using the other position-setting function.
-  LLVMPositionBuilder2(Builder, FooVarBlock, InsertPos, true);
+  LLVMPositionBuilderBeforeDbgRecords(Builder, FooVarBlock, InsertPos);
   LLVMValueRef Phi2 = LLVMBuildPhi(Builder, I64, "p2");
   LLVMAddIncoming(Phi2, &Zero, &FooEntryBlock, 1);
   // Insert a non-phi before the `ret` but not before the debug records to
   // test that works as expected.
-  LLVMPositionBuilder2(Builder, FooVarBlock, Ret, false);
+  LLVMPositionBuilder(Builder, FooVarBlock, Ret);
   LLVMBuildAdd(Builder, Phi1, Phi2, "a");
 
   char *MStr = LLVMPrintModuleToString(M);

--- a/llvm/tools/llvm-c-test/debuginfo.c
+++ b/llvm/tools/llvm-c-test/debuginfo.c
@@ -228,7 +228,24 @@ int llvm_test_dibuilder(bool NewDebugInfoFormat) {
   LLVMPositionBuilderAtEnd(Builder, FooVarBlock);
   LLVMTypeRef I64 = LLVMInt64TypeInContext(Ctx);
   LLVMValueRef Zero = LLVMConstInt(I64, 0, false);
-  LLVMBuildRet(Builder, Zero);
+  LLVMValueRef Ret = LLVMBuildRet(Builder, Zero);
+
+  // Insert a `phi` before the `ret`. In the new debug info mode we need to
+  // be careful to insert before debug records too, else the debug records
+  // will come before the `phi` (and be absorbed onto it) which is an invalid
+  // state.
+  LLVMValueRef InsertPos = LLVMGetFirstInstruction(FooVarBlock);
+  LLVMPositionBuilderBefore(Builder, InsertPos, true);
+  LLVMValueRef Phi1 = LLVMBuildPhi(Builder, I64, "p1");
+  LLVMAddIncoming(Phi1, &Zero, &FooEntryBlock, 1);
+  // Do the same again using the other position-setting function.
+  LLVMPositionBuilder(Builder, FooVarBlock, InsertPos, true);
+  LLVMValueRef Phi2 = LLVMBuildPhi(Builder, I64, "p2");
+  LLVMAddIncoming(Phi2, &Zero, &FooEntryBlock, 1);
+  // Insert a non-phi before the `ret` but not before the debug records to
+  // test that works as expected.
+  LLVMPositionBuilder(Builder, FooVarBlock, Ret, false);
+  LLVMBuildAdd(Builder, Phi1, Phi2, "a");
 
   char *MStr = LLVMPrintModuleToString(M);
   puts(MStr);

--- a/llvm/tools/llvm-c-test/debuginfo.c
+++ b/llvm/tools/llvm-c-test/debuginfo.c
@@ -235,16 +235,16 @@ int llvm_test_dibuilder(bool NewDebugInfoFormat) {
   // will come before the `phi` (and be absorbed onto it) which is an invalid
   // state.
   LLVMValueRef InsertPos = LLVMGetFirstInstruction(FooVarBlock);
-  LLVMPositionBuilderBefore(Builder, InsertPos, true);
+  LLVMPositionBuilderBefore2(Builder, InsertPos, true);
   LLVMValueRef Phi1 = LLVMBuildPhi(Builder, I64, "p1");
   LLVMAddIncoming(Phi1, &Zero, &FooEntryBlock, 1);
   // Do the same again using the other position-setting function.
-  LLVMPositionBuilder(Builder, FooVarBlock, InsertPos, true);
+  LLVMPositionBuilder2(Builder, FooVarBlock, InsertPos, true);
   LLVMValueRef Phi2 = LLVMBuildPhi(Builder, I64, "p2");
   LLVMAddIncoming(Phi2, &Zero, &FooEntryBlock, 1);
   // Insert a non-phi before the `ret` but not before the debug records to
   // test that works as expected.
-  LLVMPositionBuilder(Builder, FooVarBlock, Ret, false);
+  LLVMPositionBuilder2(Builder, FooVarBlock, Ret, false);
   LLVMBuildAdd(Builder, Phi1, Phi2, "a");
 
   char *MStr = LLVMPrintModuleToString(M);


### PR DESCRIPTION
Add `LLVMPositionBuilderBeforeDbgRecords` and
`LLVMPositionBuilderBeforeInstrAndDbgRecords` to `llvm/include/llvm-c/Core.h`
which behave the same as `LLVMPositionBuilder` and `LVMPositionBuilderBefore`
except that the position is set before debug records attached to the target
instruction (the existing functions set the insertion point to after any
attached debug records).

More info on debug records and the migration towards using them can be found
here: https://llvm.org/docs/RemoveDIsDebugInfo.html
 
The distinction is important in some situations. An important example is when
inserting a phi before another instruction which has debug records attached to
it (these come "before" the instruction). Inserting before the instruction but
after the debug records would result in having debug records before a phi,
which is illegal. That results in an assertion failure:

`llvm/lib/IR/Instruction.cpp:166: Assertion '!isa<PHINode>(this) && "Inserting PHI after debug-records!"' failed.`

In llvm (C++) we've added bit to instruction iterators that carries around the
extra information. Adding dedicated functions seemed like the least invasive
and least suprising way to update the C API.

Update llvm/tools/llvm-c-test/debuginfo.c to test this functionality.

Update the OCaml bindings, the migration docs and release notes.
