### PR TITLE
[analyzer] New optin.taint.TaintedAlloc checker for catching unbounded memory allocation calls

### DIFF
--- a/clang/docs/analyzer/checkers.rst
+++ b/clang/docs/analyzer/checkers.rst
@@ -599,7 +599,47 @@ Warns when a nullable pointer is returned from a function that has _Nonnull retu
 optin
 ^^^^^
 
-Checkers for portability, performance or coding style specific rules.
+Checkers for portability, performance, optional security and coding style specific rules.
+
+.. _optin-taint-TaintMalloc:
+
+optin.taint.TaintMalloc
+"""""""""""""""""""""""
+
+This checker warns for cases when the ``size`` parameter of the ``malloc`` ,
+``calloc``, ``realloc``, ``alloca`` is tainted (potentially attacker controlled).
+If an attacker can inject a large value as the size parameter, memory exhaustion
+denial of service attack can be carried out.
+
+The ``alpha.security.taint.TaintPropagation`` checker also needs to be enabled for
+this checker to give warnings.
+
+The analyzer emits warning only if it cannot prove that the size parameter is
+within reasonable bounds (``<= SIZE_MAX/4``). This functionality partially
+covers the SEI Cert coding standard rule `INT04-C
+<https://wiki.sei.cmu.edu/confluence/display/c/INT04-C.+Enforce+limits+on+integer+values+originating+from+tainted+sources>`_.
+
+You can silence this warning either by bound checking the ``size`` parameter, or
+by explicitly marking the ``size`` parameter as sanitized. See the
+:ref:`alpha-security-taint-TaintPropagation` checker for more details.
+
+.. code-block:: c
+
+  void t1(void) {
+    size_t size;
+    scanf("%zu", &size);
+    int *p = malloc(size); // warn: malloc is called with a tainted (potentially attacker controlled) value
+    free(p);
+  }
+
+  void t3(void) {
+    size_t size = 0;
+    scanf("%zu", &size);
+    if (1024 < size)
+      return;
+    int *p = malloc(size); // No warning expected as the the user input is bound
+    free(p);
+  }
 
 .. _optin-core-EnumCastOutOfRange:
 
@@ -1313,41 +1353,6 @@ Check for memory leaks, double free, and use-after-free problems. Traces memory 
 
 .. literalinclude:: checkers/unix_malloc_example.c
     :language: c
-
-If the ``alpha.security.taint.TaintPropagation`` checker is enabled, the checker
-warns for cases when the ``size`` parameter of the ``malloc`` , ``calloc``,
-``realloc``, ``alloca`` is tainted (potentially attacker controlled). If an
-attacker can inject a large value as the size parameter, memory exhaustion
-denial of service attack can be carried out.
-
-The analyzer emits warning only if it cannot prove that the size parameter is
-within reasonable bounds (``<= SIZE_MAX/4``). This functionality partially
-covers the SEI Cert coding standard rule `INT04-C
-<https://wiki.sei.cmu.edu/confluence/display/c/INT04-C.+Enforce+limits+on+integer+values+originating+from+tainted+sources>`_.
-
-You can silence this warning either by bound checking the ``size`` parameter, or
-by explicitly marking the ``size`` parameter as sanitized. See the
-:ref:`alpha-security-taint-TaintPropagation` checker for more details.
-
-.. code-block:: c
-
-  void t1(void) {
-    size_t size;
-    scanf("%zu", &size);
-    int *p = malloc(size); // warn: malloc is called with a tainted (potentially attacker controlled) value
-    free(p);
-  }
-
-  void t3(void) {
-    size_t size;
-    scanf("%zu", &size);
-    if (1024<size)
-      return;
-    int *p = malloc(size); // No warning expected as the the user input is bound
-    free(p);
-  }
-
-.. _unix-MismatchedDeallocator:
 
 .. _unix-MallocSizeof:
 

--- a/clang/docs/analyzer/checkers.rst
+++ b/clang/docs/analyzer/checkers.rst
@@ -963,14 +963,14 @@ by explicitly marking the ``size`` parameter as sanitized. See the
 
 .. code-block:: c
 
-  void t1(void) {
+  void vulnerable(void) {
     size_t size;
     scanf("%zu", &size);
     int *p = malloc(size); // warn: malloc is called with a tainted (potentially attacker controlled) value
     free(p);
   }
 
-  void t3(void) {
+  void not_vulnerable(void) {
     size_t size = 0;
     scanf("%zu", &size);
     if (1024 < size)
@@ -979,7 +979,7 @@ by explicitly marking the ``size`` parameter as sanitized. See the
     free(p);
   }
 
-  void tcpp(void) {
+  void vulnerable_cpp(void) {
     size_t size = 0;
     scanf("%zu", &size);
     int *ptr = new int[size];// warn: Memory allocation function is called with a tainted (potentially attacker controlled) value

--- a/clang/docs/analyzer/checkers.rst
+++ b/clang/docs/analyzer/checkers.rst
@@ -1314,6 +1314,41 @@ Check for memory leaks, double free, and use-after-free problems. Traces memory 
 .. literalinclude:: checkers/unix_malloc_example.c
     :language: c
 
+If the ``alpha.security.taint.TaintPropagation`` checker is enabled, the checker
+warns for cases when the ``size`` parameter of the ``malloc`` , ``calloc``,
+``realloc``, ``alloca`` is tainted (potentially attacker controlled). If an
+attacker can inject a large value as the size parameter, memory exhaustion
+denial of service attack can be carried out.
+
+The analyzer emits warning only if it cannot prove that the size parameter is
+within reasonable bounds (``<= SIZE_MAX/4``). This functionality partially
+covers the SEI Cert coding standard rule `INT04-C
+<https://wiki.sei.cmu.edu/confluence/display/c/INT04-C.+Enforce+limits+on+integer+values+originating+from+tainted+sources>`_.
+
+You can silence this warning either by bound checking the ``size`` parameter, or
+by explicitly marking the ``size`` parameter as sanitized. See the
+:ref:`alpha-security-taint-TaintPropagation` checker for more details.
+
+.. code-block:: c
+
+  void t1(void) {
+    size_t size;
+    scanf("%zu", &size);
+    int *p = malloc(size); // warn: malloc is called with a tainted (potentially attacker controlled) value
+    free(p);
+  }
+
+  void t3(void) {
+    size_t size;
+    scanf("%zu", &size);
+    if (1024<size)
+      return;
+    int *p = malloc(size); // No warning expected as the the user input is bound
+    free(p);
+  }
+
+.. _unix-MismatchedDeallocator:
+
 .. _unix-MallocSizeof:
 
 unix.MallocSizeof (C)

--- a/clang/docs/analyzer/checkers.rst
+++ b/clang/docs/analyzer/checkers.rst
@@ -601,46 +601,6 @@ optin
 
 Checkers for portability, performance, optional security and coding style specific rules.
 
-.. _optin-taint-TaintMalloc:
-
-optin.taint.TaintMalloc
-"""""""""""""""""""""""
-
-This checker warns for cases when the ``size`` parameter of the ``malloc`` ,
-``calloc``, ``realloc``, ``alloca`` is tainted (potentially attacker controlled).
-If an attacker can inject a large value as the size parameter, memory exhaustion
-denial of service attack can be carried out.
-
-The ``alpha.security.taint.TaintPropagation`` checker also needs to be enabled for
-this checker to give warnings.
-
-The analyzer emits warning only if it cannot prove that the size parameter is
-within reasonable bounds (``<= SIZE_MAX/4``). This functionality partially
-covers the SEI Cert coding standard rule `INT04-C
-<https://wiki.sei.cmu.edu/confluence/display/c/INT04-C.+Enforce+limits+on+integer+values+originating+from+tainted+sources>`_.
-
-You can silence this warning either by bound checking the ``size`` parameter, or
-by explicitly marking the ``size`` parameter as sanitized. See the
-:ref:`alpha-security-taint-TaintPropagation` checker for more details.
-
-.. code-block:: c
-
-  void t1(void) {
-    size_t size;
-    scanf("%zu", &size);
-    int *p = malloc(size); // warn: malloc is called with a tainted (potentially attacker controlled) value
-    free(p);
-  }
-
-  void t3(void) {
-    size_t size = 0;
-    scanf("%zu", &size);
-    if (1024 < size)
-      return;
-    int *p = malloc(size); // No warning expected as the the user input is bound
-    free(p);
-  }
-
 .. _optin-core-EnumCastOutOfRange:
 
 optin.core.EnumCastOutOfRange (C, C++)
@@ -978,6 +938,45 @@ optin.portability.UnixAPI
 """""""""""""""""""""""""
 Finds implementation-defined behavior in UNIX/Posix functions.
 
+.. _optin-taint-TaintMalloc:
+
+optin.taint.TaintMalloc
+"""""""""""""""""""""""
+
+This checker warns for cases when the ``size`` parameter of the ``malloc`` ,
+``calloc``, ``realloc``, ``alloca`` is tainted (potentially attacker controlled).
+If an attacker can inject a large value as the size parameter, memory exhaustion
+denial of service attack can be carried out.
+
+The ``alpha.security.taint.TaintPropagation`` checker also needs to be enabled for
+this checker to give warnings.
+
+The analyzer emits warning only if it cannot prove that the size parameter is
+within reasonable bounds (``<= SIZE_MAX/4``). This functionality partially
+covers the SEI Cert coding standard rule `INT04-C
+<https://wiki.sei.cmu.edu/confluence/display/c/INT04-C.+Enforce+limits+on+integer+values+originating+from+tainted+sources>`_.
+
+You can silence this warning either by bound checking the ``size`` parameter, or
+by explicitly marking the ``size`` parameter as sanitized. See the
+:ref:`alpha-security-taint-TaintPropagation` checker for more details.
+
+.. code-block:: c
+
+  void t1(void) {
+    size_t size;
+    scanf("%zu", &size);
+    int *p = malloc(size); // warn: malloc is called with a tainted (potentially attacker controlled) value
+    free(p);
+  }
+
+  void t3(void) {
+    size_t size = 0;
+    scanf("%zu", &size);
+    if (1024 < size)
+      return;
+    int *p = malloc(size); // No warning expected as the the user input is bound
+    free(p);
+  }
 
 .. _security-checkers:
 

--- a/clang/docs/analyzer/checkers.rst
+++ b/clang/docs/analyzer/checkers.rst
@@ -938,13 +938,14 @@ optin.portability.UnixAPI
 """""""""""""""""""""""""
 Finds implementation-defined behavior in UNIX/Posix functions.
 
-.. _optin-taint-TaintMalloc:
+.. _optin-taint-TaintAlloc:
 
-optin.taint.TaintMalloc
-"""""""""""""""""""""""
+optin.taint.TaintAlloc (C, C++)
+"""""""""""""""""""""""""""""""
 
 This checker warns for cases when the ``size`` parameter of the ``malloc`` ,
-``calloc``, ``realloc``, ``alloca`` is tainted (potentially attacker controlled).
+``calloc``, ``realloc``, ``alloca`` or the size parameter of the
+array new C++ operator is tainted (potentially attacker controlled).
 If an attacker can inject a large value as the size parameter, memory exhaustion
 denial of service attack can be carried out.
 
@@ -976,6 +977,13 @@ by explicitly marking the ``size`` parameter as sanitized. See the
       return;
     int *p = malloc(size); // No warning expected as the the user input is bound
     free(p);
+  }
+
+  void tcpp(void) {
+    size_t size = 0;
+    scanf("%zu", &size);
+    int *ptr = new int[size];// warn: Memory allocation function is called with a tainted (potentially attacker controlled) value
+    delete[] ptr;
   }
 
 .. _security-checkers:

--- a/clang/docs/analyzer/checkers.rst
+++ b/clang/docs/analyzer/checkers.rst
@@ -964,7 +964,7 @@ by explicitly marking the ``size`` parameter as sanitized. See the
 .. code-block:: c
 
   void vulnerable(void) {
-    size_t size;
+    size_t size = 0;
     scanf("%zu", &size);
     int *p = malloc(size); // warn: malloc is called with a tainted (potentially attacker controlled) value
     free(p);

--- a/clang/docs/analyzer/checkers.rst
+++ b/clang/docs/analyzer/checkers.rst
@@ -941,7 +941,7 @@ Finds implementation-defined behavior in UNIX/Posix functions.
 .. _optin-taint-TaintedAlloc:
 
 optin.taint.TaintedAlloc (C, C++)
-"""""""""""""""""""""""""""""""
+"""""""""""""""""""""""""""""""""
 
 This checker warns for cases when the ``size`` parameter of the ``malloc`` ,
 ``calloc``, ``realloc``, ``alloca`` or the size parameter of the

--- a/clang/docs/analyzer/checkers.rst
+++ b/clang/docs/analyzer/checkers.rst
@@ -938,9 +938,9 @@ optin.portability.UnixAPI
 """""""""""""""""""""""""
 Finds implementation-defined behavior in UNIX/Posix functions.
 
-.. _optin-taint-TaintAlloc:
+.. _optin-taint-TaintedAlloc:
 
-optin.taint.TaintAlloc (C, C++)
+optin.taint.TaintedAlloc (C, C++)
 """""""""""""""""""""""""""""""
 
 This checker warns for cases when the ``size`` parameter of the ``malloc`` ,

--- a/clang/include/clang/StaticAnalyzer/Checkers/Checkers.td
+++ b/clang/include/clang/StaticAnalyzer/Checkers/Checkers.td
@@ -1729,7 +1729,7 @@ def UnixAPIPortabilityChecker : Checker<"UnixAPI">,
 
 let ParentPackage = TaintOptIn in {
 
-def TaintMallocChecker: Checker<"TaintMalloc">,
+def TaintAllocChecker: Checker<"TaintAlloc">,
   HelpText<"Check for memory allocations, where the size parameter "
            "might be a tainted (attacker controlled) value.">,
   Dependencies<[DynamicMemoryModeling]>,

--- a/clang/include/clang/StaticAnalyzer/Checkers/Checkers.td
+++ b/clang/include/clang/StaticAnalyzer/Checkers/Checkers.td
@@ -36,7 +36,6 @@ def CoreAlpha : Package<"core">, ParentPackage<Alpha>;
 // Note: OptIn is *not* intended for checkers that are too noisy to be on by
 // default. Such checkers belong in the alpha package.
 def OptIn : Package<"optin">;
-def TaintOptIn : Package<"taint">, ParentPackage<OptIn>;
 
 def CoreOptIn : Package<"core">, ParentPackage<OptIn>;
 
@@ -44,6 +43,9 @@ def CoreOptIn : Package<"core">, ParentPackage<OptIn>;
 // implementation-defined behavior. Such checks are wanted for cross-platform
 // development, but unwanted for developers who target only a single platform.
 def PortabilityOptIn : Package<"portability">, ParentPackage<OptIn>;
+
+// Optional checkers related to taint security analysis.
+def TaintOptIn : Package<"taint">, ParentPackage<OptIn>;
 
 def Nullability : Package<"nullability">,
   PackageOptions<[
@@ -454,7 +456,6 @@ def EnumCastOutOfRangeChecker : Checker<"EnumCastOutOfRange">,
 
 } // end "optin.core"
 
-
 //===----------------------------------------------------------------------===//
 // Unix API checkers.
 //===----------------------------------------------------------------------===//
@@ -627,16 +628,6 @@ def BlockInCriticalSectionChecker : Checker<"BlockInCriticalSection">,
   Documentation<HasDocumentation>;
 
 } // end "alpha.unix"
-
-let ParentPackage = TaintOptIn in {
-
-def TaintMallocChecker: Checker<"TaintMalloc">,
-  HelpText<"Check for memory allocations, where the size parameter "
-           "might be a tainted (attacker controlled) value.">,
-  Dependencies<[DynamicMemoryModeling]>,
-  Documentation<HasDocumentation>;
-
-} // end "optin.taint"
 
 //===----------------------------------------------------------------------===//
 // C++ checkers.
@@ -1730,6 +1721,21 @@ def UnixAPIPortabilityChecker : Checker<"UnixAPI">,
   Documentation<NotDocumented>;
 
 } // end optin.portability
+
+
+//===----------------------------------------------------------------------===//
+// Taint checkers.
+//===----------------------------------------------------------------------===//
+
+let ParentPackage = TaintOptIn in {
+
+def TaintMallocChecker: Checker<"TaintMalloc">,
+  HelpText<"Check for memory allocations, where the size parameter "
+           "might be a tainted (attacker controlled) value.">,
+  Dependencies<[DynamicMemoryModeling]>,
+  Documentation<HasDocumentation>;
+
+} // end "optin.taint"
 
 //===----------------------------------------------------------------------===//
 // NonDeterminism checkers.

--- a/clang/include/clang/StaticAnalyzer/Checkers/Checkers.td
+++ b/clang/include/clang/StaticAnalyzer/Checkers/Checkers.td
@@ -36,6 +36,8 @@ def CoreAlpha : Package<"core">, ParentPackage<Alpha>;
 // Note: OptIn is *not* intended for checkers that are too noisy to be on by
 // default. Such checkers belong in the alpha package.
 def OptIn : Package<"optin">;
+def TaintOptIn : Package<"taint">, ParentPackage<OptIn>;
+
 def CoreOptIn : Package<"core">, ParentPackage<OptIn>;
 
 // In the Portability package reside checkers for finding code that relies on
@@ -452,6 +454,7 @@ def EnumCastOutOfRangeChecker : Checker<"EnumCastOutOfRange">,
 
 } // end "optin.core"
 
+
 //===----------------------------------------------------------------------===//
 // Unix API checkers.
 //===----------------------------------------------------------------------===//
@@ -624,6 +627,16 @@ def BlockInCriticalSectionChecker : Checker<"BlockInCriticalSection">,
   Documentation<HasDocumentation>;
 
 } // end "alpha.unix"
+
+let ParentPackage = TaintOptIn in {
+
+def TaintMallocChecker: Checker<"TaintMalloc">,
+  HelpText<"Check for memory allocations, where the size parameter "
+           "might be a tainted (attacker controlled) value.">,
+  Dependencies<[DynamicMemoryModeling]>,
+  Documentation<HasDocumentation>;
+
+} // end "optin.taint"
 
 //===----------------------------------------------------------------------===//
 // C++ checkers.

--- a/clang/include/clang/StaticAnalyzer/Checkers/Checkers.td
+++ b/clang/include/clang/StaticAnalyzer/Checkers/Checkers.td
@@ -1733,6 +1733,8 @@ def TaintAllocChecker: Checker<"TaintAlloc">,
   HelpText<"Check for memory allocations, where the size parameter "
            "might be a tainted (attacker controlled) value.">,
   Dependencies<[DynamicMemoryModeling]>,
+  //FIXME: GenericTaintChecker should be a dependency, but only after it
+  //is transformed into a modeling checker
   Documentation<HasDocumentation>;
 
 } // end "optin.taint"

--- a/clang/include/clang/StaticAnalyzer/Checkers/Checkers.td
+++ b/clang/include/clang/StaticAnalyzer/Checkers/Checkers.td
@@ -1729,7 +1729,7 @@ def UnixAPIPortabilityChecker : Checker<"UnixAPI">,
 
 let ParentPackage = TaintOptIn in {
 
-def TaintAllocChecker: Checker<"TaintAlloc">,
+def TaintedAllocChecker: Checker<"TaintedAlloc">,
   HelpText<"Check for memory allocations, where the size parameter "
            "might be a tainted (attacker controlled) value.">,
   Dependencies<[DynamicMemoryModeling]>,

--- a/clang/lib/StaticAnalyzer/Checkers/MallocChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/MallocChecker.cpp
@@ -1708,8 +1708,7 @@ MallocChecker::processNewAllocation(const CXXAllocatorCall &Call,
   // existing binding.
   SVal Target = Call.getObjectUnderConstruction();
   if (Call.getOriginExpr()->isArray()) {
-    std::optional<const Expr *> SizeEx = NE->getArraySize();
-    if (SizeEx)
+    if (auto SizeEx = NE->getArraySize())
       checkTaintedness(C, Call, C.getSVal(*SizeEx), State, AF_CXXNewArray);
   }
 

--- a/clang/lib/StaticAnalyzer/Checkers/MallocChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/MallocChecker.cpp
@@ -323,7 +323,7 @@ public:
     CK_NewDeleteLeaksChecker,
     CK_MismatchedDeallocatorChecker,
     CK_InnerPointerChecker,
-    CK_TaintAllocChecker,
+    CK_TaintedAllocChecker,
     CK_NumCheckKinds
   };
 
@@ -1810,7 +1810,7 @@ void MallocChecker::reportTaintBug(StringRef Msg, ProgramStateRef State,
                                    AllocationFamily Family) const {
   if (ExplodedNode *N = C.generateNonFatalErrorNode(State, this)) {
     if (!BT_TaintedAlloc)
-      BT_TaintedAlloc.reset(new BugType(CheckNames[CK_TaintAllocChecker],
+      BT_TaintedAlloc.reset(new BugType(CheckNames[CK_TaintedAllocChecker],
                                         "Tainted Memory Allocation",
                                         categories::TaintedData));
     auto R = std::make_unique<PathSensitiveBugReport>(*BT_TaintedAlloc, Msg, N);
@@ -1824,7 +1824,7 @@ void MallocChecker::reportTaintBug(StringRef Msg, ProgramStateRef State,
 void MallocChecker::checkTaintedness(CheckerContext &C, const CallEvent &Call,
                                      const SVal SizeSVal, ProgramStateRef State,
                                      AllocationFamily Family) const {
-  if (!ChecksEnabled[CK_TaintAllocChecker])
+  if (!ChecksEnabled[CK_TaintedAllocChecker])
     return;
   std::vector<SymbolRef> TaintedSyms =
       taint::getTaintedSymbols(State, SizeSVal);
@@ -3805,4 +3805,4 @@ REGISTER_CHECKER(MallocChecker)
 REGISTER_CHECKER(NewDeleteChecker)
 REGISTER_CHECKER(NewDeleteLeaksChecker)
 REGISTER_CHECKER(MismatchedDeallocatorChecker)
-REGISTER_CHECKER(TaintAllocChecker)
+REGISTER_CHECKER(TaintedAllocChecker)

--- a/clang/test/Analysis/malloc.c
+++ b/clang/test/Analysis/malloc.c
@@ -5,7 +5,7 @@
 // RUN:   -analyzer-checker=unix \
 // RUN:   -analyzer-checker=debug.ExprInspection \
 // RUN:   -analyzer-checker=alpha.security.taint.TaintPropagation \
-// RUN:   -analyzer-checker=optin.taint.TaintMalloc
+// RUN:   -analyzer-checker=optin.taint.TaintAlloc
 
 #include "Inputs/system-header-simulator.h"
 

--- a/clang/test/Analysis/malloc.c
+++ b/clang/test/Analysis/malloc.c
@@ -4,7 +4,8 @@
 // RUN:   -analyzer-checker=alpha.core.CastSize \
 // RUN:   -analyzer-checker=unix \
 // RUN:   -analyzer-checker=debug.ExprInspection \
-// RUN:   -analyzer-checker=alpha.security.taint.TaintPropagation
+// RUN:   -analyzer-checker=alpha.security.taint.TaintPropagation \
+// RUN:   -analyzer-checker=optin.taint.TaintMalloc
 
 #include "Inputs/system-header-simulator.h"
 
@@ -50,41 +51,41 @@ void myfooint(int p);
 char *fooRetPtr(void);
 
 void t1(void) {
-  size_t size;
+  size_t size = 0;
   scanf("%zu", &size);
   int *p = malloc(size); // expected-warning{{malloc is called with a tainted (potentially attacker controlled) value}}
   free(p);
 }
 
 void t2(void) {
-  size_t size;
+  size_t size = 0;
   scanf("%zu", &size);
   int *p = calloc(size,2); // expected-warning{{calloc is called with a tainted (potentially attacker controlled) value}}
   free(p);
 }
 
 void t3(void) {
-  size_t size;
+  size_t size = 0;
   scanf("%zu", &size);
-  if (1024<size)
+  if (1024 < size)
     return;
   int *p = malloc(size); // No warning expected as the the user input is bound
   free(p);
 }
 
 void t4(void) {
-  size_t size;
-  int *p = malloc(sizeof(int)); 
-  scanf("%zu", &size);  
-  p = (int*) realloc((void*) p, size); // // expected-warning{{realloc is called with a tainted (potentially attacker controlled) value}}
+  size_t size = 0;
+  int *p = malloc(sizeof(int));
+  scanf("%zu", &size);
+  p = (int*) realloc((void*) p, size); // expected-warning{{realloc is called with a tainted (potentially attacker controlled) value}}
   free(p);
 }
 
 void t5(void) {
-  size_t size;
-  int *p = alloca(sizeof(int)); 
-  scanf("%zu", &size);  
-  p = (int*) alloca(size); // // expected-warning{{alloca is called with a tainted (potentially attacker controlled) value}}  
+  size_t size = 0;
+  int *p = alloca(sizeof(int));
+  scanf("%zu", &size);
+  p = (int*) alloca(size); // expected-warning{{alloca is called with a tainted (potentially attacker controlled) value}}
 }
 
 

--- a/clang/test/Analysis/malloc.c
+++ b/clang/test/Analysis/malloc.c
@@ -3,7 +3,8 @@
 // RUN:   -analyzer-checker=alpha.deadcode.UnreachableCode \
 // RUN:   -analyzer-checker=alpha.core.CastSize \
 // RUN:   -analyzer-checker=unix \
-// RUN:   -analyzer-checker=debug.ExprInspection
+// RUN:   -analyzer-checker=debug.ExprInspection \
+// RUN:   -analyzer-checker=alpha.security.taint.TaintPropagation
 
 #include "Inputs/system-header-simulator.h"
 
@@ -47,6 +48,45 @@ void *_alloca(size_t size);
 void myfoo(int *p);
 void myfooint(int p);
 char *fooRetPtr(void);
+
+void t1(void) {
+  size_t size;
+  scanf("%zu", &size);
+  int *p = malloc(size); // expected-warning{{malloc is called with a tainted (potentially attacker controlled) value}}
+  free(p);
+}
+
+void t2(void) {
+  size_t size;
+  scanf("%zu", &size);
+  int *p = calloc(size,2); // expected-warning{{calloc is called with a tainted (potentially attacker controlled) value}}
+  free(p);
+}
+
+void t3(void) {
+  size_t size;
+  scanf("%zu", &size);
+  if (1024<size)
+    return;
+  int *p = malloc(size); // No warning expected as the the user input is bound
+  free(p);
+}
+
+void t4(void) {
+  size_t size;
+  int *p = malloc(sizeof(int)); 
+  scanf("%zu", &size);  
+  p = (int*) realloc((void*) p, size); // // expected-warning{{realloc is called with a tainted (potentially attacker controlled) value}}
+  free(p);
+}
+
+void t5(void) {
+  size_t size;
+  int *p = alloca(sizeof(int)); 
+  scanf("%zu", &size);  
+  p = (int*) alloca(size); // // expected-warning{{alloca is called with a tainted (potentially attacker controlled) value}}  
+}
+
 
 void f1(void) {
   int *p = malloc(12);

--- a/clang/test/Analysis/malloc.c
+++ b/clang/test/Analysis/malloc.c
@@ -5,7 +5,7 @@
 // RUN:   -analyzer-checker=unix \
 // RUN:   -analyzer-checker=debug.ExprInspection \
 // RUN:   -analyzer-checker=alpha.security.taint.TaintPropagation \
-// RUN:   -analyzer-checker=optin.taint.TaintAlloc
+// RUN:   -analyzer-checker=optin.taint.TaintedAlloc
 
 #include "Inputs/system-header-simulator.h"
 

--- a/clang/test/Analysis/malloc.cpp
+++ b/clang/test/Analysis/malloc.cpp
@@ -3,7 +3,9 @@
 // RUN:   -analyzer-checker=alpha.deadcode.UnreachableCode \
 // RUN:   -analyzer-checker=alpha.core.CastSize \
 // RUN:   -analyzer-checker=unix.Malloc \
-// RUN:   -analyzer-checker=cplusplus.NewDelete
+// RUN:   -analyzer-checker=cplusplus.NewDelete \
+// RUN:   -analyzer-checker=alpha.security.taint.TaintPropagation \
+// RUN:   -analyzer-checker=optin.taint.TaintAlloc
 
 // RUN: %clang_analyze_cc1 -w -verify %s \
 // RUN:   -triple i386-unknown-linux-gnu \
@@ -11,14 +13,18 @@
 // RUN:   -analyzer-checker=alpha.deadcode.UnreachableCode \
 // RUN:   -analyzer-checker=alpha.core.CastSize \
 // RUN:   -analyzer-checker=unix.Malloc \
-// RUN:   -analyzer-checker=cplusplus.NewDelete
+// RUN:   -analyzer-checker=cplusplus.NewDelete \
+// RUN:   -analyzer-checker=alpha.security.taint.TaintPropagation \
+// RUN:   -analyzer-checker=optin.taint.TaintAlloc
 
 // RUN: %clang_analyze_cc1 -w -verify %s -DTEST_INLINABLE_ALLOCATORS \
 // RUN:   -analyzer-checker=core \
 // RUN:   -analyzer-checker=alpha.deadcode.UnreachableCode \
 // RUN:   -analyzer-checker=alpha.core.CastSize \
 // RUN:   -analyzer-checker=unix.Malloc \
-// RUN:   -analyzer-checker=cplusplus.NewDelete
+// RUN:   -analyzer-checker=cplusplus.NewDelete \
+// RUN:   -analyzer-checker=alpha.security.taint.TaintPropagation \
+// RUN:   -analyzer-checker=optin.taint.TaintAlloc
 
 // RUN: %clang_analyze_cc1 -w -verify %s -DTEST_INLINABLE_ALLOCATORS \
 // RUN:   -triple i386-unknown-linux-gnu \
@@ -26,7 +32,9 @@
 // RUN:   -analyzer-checker=alpha.deadcode.UnreachableCode \
 // RUN:   -analyzer-checker=alpha.core.CastSize \
 // RUN:   -analyzer-checker=unix.Malloc \
-// RUN:   -analyzer-checker=cplusplus.NewDelete
+// RUN:   -analyzer-checker=cplusplus.NewDelete \
+// RUN:   -analyzer-checker=alpha.security.taint.TaintPropagation \
+// RUN:   -analyzer-checker=optin.taint.TaintAlloc
 
 #include "Inputs/system-header-simulator-cxx.h"
 
@@ -36,6 +44,14 @@ void free(void *);
 void *realloc(void *ptr, size_t size);
 void *calloc(size_t nmemb, size_t size);
 char *strdup(const char *s);
+int scanf( const char* format, ... );
+
+void taintAlloc() {
+  size_t size = 0;
+  scanf("%zu", &size);
+  int *ptr = new int[size];// expected-warning{{Memory allocation function is called with a tainted (potentially attacker controlled) value}}
+  delete[] ptr;
+}
 
 void checkThatMallocCheckerIsRunning() {
   malloc(4);

--- a/clang/test/Analysis/malloc.cpp
+++ b/clang/test/Analysis/malloc.cpp
@@ -5,7 +5,7 @@
 // RUN:   -analyzer-checker=unix.Malloc \
 // RUN:   -analyzer-checker=cplusplus.NewDelete \
 // RUN:   -analyzer-checker=alpha.security.taint.TaintPropagation \
-// RUN:   -analyzer-checker=optin.taint.TaintAlloc
+// RUN:   -analyzer-checker=optin.taint.TaintedAlloc
 
 // RUN: %clang_analyze_cc1 -w -verify %s \
 // RUN:   -triple i386-unknown-linux-gnu \
@@ -15,7 +15,7 @@
 // RUN:   -analyzer-checker=unix.Malloc \
 // RUN:   -analyzer-checker=cplusplus.NewDelete \
 // RUN:   -analyzer-checker=alpha.security.taint.TaintPropagation \
-// RUN:   -analyzer-checker=optin.taint.TaintAlloc
+// RUN:   -analyzer-checker=optin.taint.TaintedAlloc
 
 // RUN: %clang_analyze_cc1 -w -verify %s -DTEST_INLINABLE_ALLOCATORS \
 // RUN:   -analyzer-checker=core \
@@ -24,7 +24,7 @@
 // RUN:   -analyzer-checker=unix.Malloc \
 // RUN:   -analyzer-checker=cplusplus.NewDelete \
 // RUN:   -analyzer-checker=alpha.security.taint.TaintPropagation \
-// RUN:   -analyzer-checker=optin.taint.TaintAlloc
+// RUN:   -analyzer-checker=optin.taint.TaintedAlloc
 
 // RUN: %clang_analyze_cc1 -w -verify %s -DTEST_INLINABLE_ALLOCATORS \
 // RUN:   -triple i386-unknown-linux-gnu \
@@ -34,7 +34,7 @@
 // RUN:   -analyzer-checker=unix.Malloc \
 // RUN:   -analyzer-checker=cplusplus.NewDelete \
 // RUN:   -analyzer-checker=alpha.security.taint.TaintPropagation \
-// RUN:   -analyzer-checker=optin.taint.TaintAlloc
+// RUN:   -analyzer-checker=optin.taint.TaintedAlloc
 
 #include "Inputs/system-header-simulator-cxx.h"
 

--- a/clang/test/Analysis/taint-diagnostic-visitor.c
+++ b/clang/test/Analysis/taint-diagnostic-visitor.c
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -analyze -analyzer-checker=alpha.security.taint,core,alpha.security.ArrayBoundV2 -analyzer-output=text -verify %s
+// RUN: %clang_cc1 -analyze -analyzer-checker=alpha.security.taint,core,alpha.security.ArrayBoundV2,optin.taint.TaintMalloc -analyzer-output=text -verify %s
 
 // This file is for testing enhanced diagnostics produced by the GenericTaintChecker
 
@@ -114,4 +114,14 @@ void multipleTaintedArgs(void) {
   strcat(buf, file);// expected-note {{Taint propagated to the 1st argument}}
   system(buf); // expected-warning {{Untrusted data is passed to a system call}}
                // expected-note@-1{{Untrusted data is passed to a system call}}
+}
+
+void testTaintedMalloc(){
+  size_t size = 0;
+  scanf("%zu", &size); // expected-note {{Value assigned to 'size'}}
+                       // expected-note@-1 {{Taint originated here}}
+                       // expected-note@-2 {{Taint propagated to the 2nd argument}}
+  int *p = malloc(size);// expected-warning{{malloc is called with a tainted (potentially attacker controlled) value}}
+                    // expected-note@-1{{malloc is called with a tainted (potentially attacker controlled) value}}
+  free(p);
 }

--- a/clang/test/Analysis/taint-diagnostic-visitor.c
+++ b/clang/test/Analysis/taint-diagnostic-visitor.c
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -analyze -analyzer-checker=alpha.security.taint,core,alpha.security.ArrayBoundV2,optin.taint.TaintMalloc -analyzer-output=text -verify %s
+// RUN: %clang_cc1 -analyze -analyzer-checker=alpha.security.taint,core,alpha.security.ArrayBoundV2,optin.taint.TaintAlloc -analyzer-output=text -verify %s
 
 // This file is for testing enhanced diagnostics produced by the GenericTaintChecker
 
@@ -118,9 +118,8 @@ void multipleTaintedArgs(void) {
 
 void testTaintedMalloc(){
   size_t size = 0;
-  scanf("%zu", &size); // expected-note {{Value assigned to 'size'}}
-                       // expected-note@-1 {{Taint originated here}}
-                       // expected-note@-2 {{Taint propagated to the 2nd argument}}
+  scanf("%zu", &size); // expected-note {{Taint originated here}}
+                       // expected-note@-1 {{Taint propagated to the 2nd argument}}
   int *p = malloc(size);// expected-warning{{malloc is called with a tainted (potentially attacker controlled) value}}
                     // expected-note@-1{{malloc is called with a tainted (potentially attacker controlled) value}}
   free(p);

--- a/clang/test/Analysis/taint-diagnostic-visitor.c
+++ b/clang/test/Analysis/taint-diagnostic-visitor.c
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -analyze -analyzer-checker=alpha.security.taint,core,alpha.security.ArrayBoundV2,optin.taint.TaintAlloc -analyzer-output=text -verify %s
+// RUN: %clang_cc1 -analyze -analyzer-checker=alpha.security.taint,core,alpha.security.ArrayBoundV2,optin.taint.TaintedAlloc -analyzer-output=text -verify %s
 
 // This file is for testing enhanced diagnostics produced by the GenericTaintChecker
 


### PR DESCRIPTION
A new optional checker (optin.taint.TaintedAlloc) will warn if a memory allocation function (malloc, calloc, realloc, alloca, operator new[]) is called with a tainted (attacker controlled) size parameter.
A large, maliciously set size value can trigger memory exhaustion. To get this warning, the alpha.security.taint.TaintPropagation checker also needs to be switched on.

The warning will only be emitted, if the analyzer cannot prove that the size is below reasonable bounds (<SIZE_MAX/4).

There were no new reports with this extension on the following open source projects.

| Project | New Reports | Resolved Reports |
|---------|-------------|------------------|
| memcached | No reports | No reports 
| tmux | No reports | No reports 
| curl | No reports | No reports 
| twin | No reports | No reports 
| vim | No reports | No reports 
| openssl | No reports | No reports 
| sqlite | No reports | No reports 
| ffmpeg | No reports | No reports 
| postgres | No reports | No reports 
| xerces | No reports | No reports 

