### PR TITLE
[Clang][Sema] ASTContext::getUnconstrainedType propagates dependence

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -723,7 +723,7 @@ Bug Fixes to C++ Support
 - Clang now ignores template parameters only used within the exception specification of candidate function
   templates during partial ordering when deducing template arguments from a function declaration or when
   taking the address of a function template.
-- Fix a bug with checking constrained non-type template parameters for equivalence.
+- Fix a bug with checking constrained non-type template parameters for equivalence. Fixes (#GH77377).
 
 Bug Fixes to AST Handling
 ^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -723,6 +723,7 @@ Bug Fixes to C++ Support
 - Clang now ignores template parameters only used within the exception specification of candidate function
   templates during partial ordering when deducing template arguments from a function declaration or when
   taking the address of a function template.
+- Fix a bug with checking constrained non-type template parameters for equivalence.
 
 Bug Fixes to AST Handling
 ^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/clang/lib/AST/ASTContext.cpp
+++ b/clang/lib/AST/ASTContext.cpp
@@ -5910,7 +5910,8 @@ QualType ASTContext::getUnconstrainedType(QualType T) const {
   if (auto *AT = CanonT->getAs<AutoType>()) {
     if (!AT->isConstrained())
       return T;
-    return getQualifiedType(getAutoType(QualType(), AT->getKeyword(), false,
+    return getQualifiedType(getAutoType(QualType(), AT->getKeyword(),
+                                        AT->isDependentType(),
                                         AT->containsUnexpandedParameterPack()),
                             T.getQualifiers());
   }

--- a/clang/test/CXX/temp/temp.decls/temp.fct/temp.func.order/p2.cpp
+++ b/clang/test/CXX/temp/temp.decls/temp.fct/temp.func.order/p2.cpp
@@ -1,11 +1,13 @@
 // RUN: %clang_cc1 -fsyntax-only -verify -std=c++20 %s
 // expected-no-diagnostics
 
-template<typename T>
-concept C = sizeof(T) == sizeof(int);
+namespace GH77377 {
+  template<typename T>
+  concept C = sizeof(T) == sizeof(int);
 
-template<auto N>
-struct A;
+  template<auto N>
+  struct A;
 
-template<C auto N>
-struct A<N>;
+  template<C auto N>
+  struct A<N>;
+}

--- a/clang/test/CXX/temp/temp.decls/temp.fct/temp.func.order/p2.cpp
+++ b/clang/test/CXX/temp/temp.decls/temp.fct/temp.func.order/p2.cpp
@@ -1,0 +1,11 @@
+// RUN: %clang_cc1 -fsyntax-only -verify -std=c++20 %s
+// expected-no-diagnostics
+
+template<typename T>
+concept C = sizeof(T) == sizeof(int);
+
+template<auto N>
+struct A;
+
+template<C auto N>
+struct A<N>;


### PR DESCRIPTION
When the argument passed to `ASTContext::getUnconstrainedType` is an unconstrained `AutoType`, will return the argument unchanged. However, when called with a constrained `AutoType`, an unconstrained, non-dependent `AutoType` will be returned even if the argument was dependent. Consider the following:
```cpp
template<typename T>
concept C = sizeof(T) == sizeof(int);

template<auto N>
struct A;

template<C auto N>
struct A<N>; // error: class template partial specialization is not more specialized than the primary template
```
When comparing the template parameters for equivalence, `ASTContext::getUnconstrainedType` is used to remove the constraints per [[temp.over.link] p6 sentence 2](http://eel.is/c++draft/temp.over.link#6.sentence-2). For the template parameter `N` of the class template, it returns a dependent `AutoType`. For the template parameter `N` of the class template partial specialization, it returns a non-dependent `AutoType`. We subsequently compare the adjusted types and find they are not equivalent, thus we consider the partial specialization to not be more specialized than the primary template per [[temp.func.order] p6.2.2](http://eel.is/c++draft/temp.func.order#6.2.2). 

This patch changes `ASTContext::getUnconstrainedType` such that the dependence of a constrained `AutoType` will propagate to the returned unconstrained `AutoType`. This causes the above example to be correctly accepted, fixing #77377.