### PR TITLE
[ThinLTO]Mark referencers of local ifunc not eligible for import

### DIFF
--- a/llvm/lib/Analysis/ModuleSummaryAnalysis.cpp
+++ b/llvm/lib/Analysis/ModuleSummaryAnalysis.cpp
@@ -96,7 +96,7 @@ extern cl::opt<unsigned> MaxNumVTableAnnotations;
 // instruction in it takes an address of any basic block, because instruction
 // can only take an address of basic block located in the same function.
 // Set `RefLocalLinkageIFunc` to true if the analyzed value references a
-// local-linkage ifunc;
+// local-linkage ifunc.
 static bool findRefEdges(ModuleSummaryIndex &Index, const User *CurUser,
                          SetVector<ValueInfo, std::vector<ValueInfo>> &RefEdges,
                          SmallPtrSet<const User *, 8> &Visited,

--- a/llvm/test/ThinLTO/X86/ref-ifunc.ll
+++ b/llvm/test/ThinLTO/X86/ref-ifunc.ll
@@ -1,0 +1,49 @@
+; RUN: opt -module-summary %s -o %t.bc
+
+; RUN: llvm-dis %t.bc -o - | FileCheck %s
+
+; Tests that caller is not eligible to import and it doesn't have refs to ifunc 'callee'
+
+; CHECK: gv: (name: "caller", summaries: (function: ({{.*}}, flags: ({{.*}}notEligibleToImport: 1
+; CHECK-NOT: refs
+; CHECK-SAME: guid = 16677772384402303968
+
+target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-unknown-linux-gnu"
+
+@__cpu_model = external global { i32, i32, i32, [1 x i32] }
+
+@callee = internal ifunc void(), ptr @callee.resolver
+
+define void @dispatch(ptr %func) {
+    tail call void %func()
+    ret void
+}
+
+
+define void @caller() {
+entry:
+  tail call void @dispatch(ptr @callee)
+  ret void
+}
+
+define internal ptr @callee.resolver() {
+resolver_entry:
+  tail call void @__cpu_indicator_init()
+  %0 = load i32, ptr getelementptr inbounds ({ i32, i32, i32, [1 x i32] }, ptr @__cpu_model, i64 0, i32 3, i64 0)
+  %1 = and i32 %0, 1024
+  %.not = icmp eq i32 %1, 0
+  %func_sel = select i1 %.not, ptr @callee.default.1, ptr @callee.avx2.0
+  ret ptr %func_sel
+}
+
+define internal void @callee.default.1(i32 %a) {
+  ret void
+}
+
+define internal void @callee.avx2.0(i32 %a) {
+  ret void
+}
+
+declare i32 @rand()
+declare void @__cpu_indicator_init()

--- a/llvm/test/ThinLTO/X86/ref-ifunc.ll
+++ b/llvm/test/ThinLTO/X86/ref-ifunc.ll
@@ -20,9 +20,7 @@ define void @dispatch(ptr %func) {
     ret void
 }
 
-
 define void @caller() {
-entry:
   tail call void @dispatch(ptr @callee)
   ret void
 }
@@ -45,5 +43,4 @@ define internal void @callee.avx2.0(i32 %a) {
   ret void
 }
 
-declare i32 @rand()
 declare void @__cpu_indicator_init()

--- a/llvm/test/ThinLTO/X86/ref-ifunc.ll
+++ b/llvm/test/ThinLTO/X86/ref-ifunc.ll
@@ -2,7 +2,11 @@
 
 ; RUN: llvm-dis %t.bc -o - | FileCheck %s
 
-; Tests that caller is not eligible to import and it doesn't have refs to ifunc 'callee'
+; Tests that var and caller are not eligible to import and they don't have refs to ifunc 'callee'
+
+; CHECK: gv: (name: "var", summaries: (variable: ({{.*}}, flags: ({{.*}}notEligibleToImport: 1
+; CHECK-NOT: refs
+; CHECK-SAME: guid = 7919382516565939378
 
 ; CHECK: gv: (name: "caller", summaries: (function: ({{.*}}, flags: ({{.*}}notEligibleToImport: 1
 ; CHECK-NOT: refs
@@ -14,6 +18,8 @@ target triple = "x86_64-unknown-linux-gnu"
 @__cpu_model = external global { i32, i32, i32, [1 x i32] }
 
 @callee = internal ifunc void(), ptr @callee.resolver
+
+@var = constant { [1 x ptr] } { [1 x ptr] [ptr @callee]}
 
 define void @dispatch(ptr %func) {
     tail call void %func()


### PR DESCRIPTION
If an ifunc has local linkage, do not add it into ref edges and mark its referencer (a function or global variable) not eligible for import. An ifunc doesn't have summary and ThinLTO cannot promote it. Importing the referencer may cause linkage errors.

To reference a similar fix, https://reviews.llvm.org/D158961 marks callers of local ifunc not eligible for import to fix https://github.com/llvm/llvm-project/issues/58740

