### PR TITLE
[Clang][Sema] Fix crash when diagnosing near-match for 'constexpr' redeclaration in C++11

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -743,7 +743,7 @@ Bug Fixes to C++ Support
 - Fix a bug where the last argument was not considered when considering the most viable function for
   explicit object argument member functions. Fixes (#GH92188).
 - Fix a C++11 crash when a non-const non-static member function is defined out-of-line with
-  the ``constexpr`` specifier.
+  the ``constexpr`` specifier. Fixes (#GH61004).
 
 Bug Fixes to AST Handling
 ^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -742,6 +742,8 @@ Bug Fixes to C++ Support
 - Fix a bug with checking constrained non-type template parameters for equivalence. Fixes (#GH77377).
 - Fix a bug where the last argument was not considered when considering the most viable function for
   explicit object argument member functions. Fixes (#GH92188).
+- Fix a C++11 crash when a non-const non-static member function is defined out-of-line with
+  the ``constexpr`` specifier.
 
 Bug Fixes to AST Handling
 ^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/clang/include/clang/Sema/DeclSpec.h
+++ b/clang/include/clang/Sema/DeclSpec.h
@@ -1527,20 +1527,20 @@ struct DeclaratorChunk {
 
     /// Retrieve the location of the 'const' qualifier.
     SourceLocation getConstQualifierLoc() const {
-      assert(MethodQualifiers);
-      return MethodQualifiers->getConstSpecLoc();
+      return MethodQualifiers ? MethodQualifiers->getConstSpecLoc()
+                              : SourceLocation();
     }
 
     /// Retrieve the location of the 'volatile' qualifier.
     SourceLocation getVolatileQualifierLoc() const {
-      assert(MethodQualifiers);
-      return MethodQualifiers->getVolatileSpecLoc();
+      return MethodQualifiers ? MethodQualifiers->getVolatileSpecLoc()
+                              : SourceLocation();
     }
 
     /// Retrieve the location of the 'restrict' qualifier.
     SourceLocation getRestrictQualifierLoc() const {
-      assert(MethodQualifiers);
-      return MethodQualifiers->getRestrictSpecLoc();
+      return MethodQualifiers ? MethodQualifiers->getRestrictSpecLoc()
+                              : SourceLocation();
     }
 
     /// Retrieve the location of the 'mutable' qualifier, if any.

--- a/clang/include/clang/Sema/DeclSpec.h
+++ b/clang/include/clang/Sema/DeclSpec.h
@@ -1527,20 +1527,20 @@ struct DeclaratorChunk {
 
     /// Retrieve the location of the 'const' qualifier.
     SourceLocation getConstQualifierLoc() const {
-      return MethodQualifiers ? MethodQualifiers->getConstSpecLoc()
-                              : SourceLocation();
+      assert(MethodQualifiers);
+      return MethodQualifiers->getConstSpecLoc();
     }
 
     /// Retrieve the location of the 'volatile' qualifier.
     SourceLocation getVolatileQualifierLoc() const {
-      return MethodQualifiers ? MethodQualifiers->getVolatileSpecLoc()
-                              : SourceLocation();
+      assert(MethodQualifiers);
+      return MethodQualifiers->getVolatileSpecLoc();
     }
 
     /// Retrieve the location of the 'restrict' qualifier.
     SourceLocation getRestrictQualifierLoc() const {
-      return MethodQualifiers ? MethodQualifiers->getRestrictSpecLoc()
-                              : SourceLocation();
+      assert(MethodQualifiers);
+      return MethodQualifiers->getRestrictSpecLoc();
     }
 
     /// Retrieve the location of the 'mutable' qualifier, if any.

--- a/clang/lib/Sema/SemaDecl.cpp
+++ b/clang/lib/Sema/SemaDecl.cpp
@@ -9223,13 +9223,14 @@ static NamedDecl *DiagnoseInvalidRedeclaration(
       if (const auto &FTI = ExtraArgs.D.getFunctionTypeInfo(); !NewFDisConst)
         DB << FixItHint::CreateInsertion(FTI.getRParenLoc().getLocWithOffset(1),
                                          " const");
-      else if (SourceLocation ConstLoc = FTI.getConstQualifierLoc();
-               ConstLoc.isValid())
-        DB << FixItHint::CreateRemoval(ConstLoc);
-    } else
+      else if (FTI.hasMethodTypeQualifiers() &&
+               FTI.getConstQualifierLoc().isValid())
+        DB << FixItHint::CreateRemoval(FTI.getConstQualifierLoc());
+    } else {
       SemaRef.Diag(FD->getLocation(),
                    IsMember ? diag::note_member_def_close_match
                             : diag::note_local_decl_close_match);
+    }
   }
   return nullptr;
 }

--- a/clang/lib/Sema/SemaDecl.cpp
+++ b/clang/lib/Sema/SemaDecl.cpp
@@ -9217,15 +9217,15 @@ static NamedDecl *DiagnoseInvalidRedeclaration(
         << Idx << FDParam->getType()
         << NewFD->getParamDecl(Idx - 1)->getType();
     } else if (FDisConst != NewFDisConst) {
-      SemaRef.Diag(FD->getLocation(), diag::note_member_def_close_const_match)
-          << NewFDisConst << FD->getSourceRange().getEnd()
-          << (NewFDisConst
-                  ? FixItHint::CreateRemoval(ExtraArgs.D.getFunctionTypeInfo()
-                                                 .getConstQualifierLoc())
-                  : FixItHint::CreateInsertion(ExtraArgs.D.getFunctionTypeInfo()
-                                                   .getRParenLoc()
-                                                   .getLocWithOffset(1),
-                                               " const"));
+      auto DB = SemaRef.Diag(FD->getLocation(),
+                             diag::note_member_def_close_const_match)
+                << NewFDisConst << FD->getSourceRange().getEnd();
+      if (const auto &FTI = ExtraArgs.D.getFunctionTypeInfo(); !NewFDisConst)
+        DB << FixItHint::CreateInsertion(FTI.getRParenLoc().getLocWithOffset(1),
+                                         " const");
+      else if (SourceLocation ConstLoc = FTI.getConstQualifierLoc();
+               ConstLoc.isValid())
+        DB << FixItHint::CreateRemoval(ConstLoc);
     } else
       SemaRef.Diag(FD->getLocation(),
                    IsMember ? diag::note_member_def_close_match

--- a/clang/test/CXX/dcl.dcl/dcl.spec/dcl.constexpr/p1.cpp
+++ b/clang/test/CXX/dcl.dcl/dcl.spec/dcl.constexpr/p1.cpp
@@ -154,3 +154,14 @@ namespace {
   // FIXME: We should diagnose this prior to C++17.
   const int &r = A::n;
 }
+
+#if __cplusplus < 201402L
+namespace ImplicitConstexprDef {
+  struct A {
+    void f(); // expected-note {{member declaration does not match because it is not const qualified}}
+  };
+
+  constexpr void A::f() { } // expected-warning {{'constexpr' non-static member function will not be implicitly 'const' in C++14; add 'const' to avoid a change in behavior}}
+                            // expected-error@-1 {{out-of-line definition of 'f' does not match any declaration in 'ImplicitConstexprDef::A'}}
+}
+#endif


### PR DESCRIPTION
Clang crashes when diagnosing the following invalid redeclaration in C++11:
```cpp
struct A {
  void f();
};

constexpr void A::f() { } // crash here
```
This happens because `DiagnoseInvalidRedeclaration` tries to create a fix-it to remove `const` from the out-of-line declaration of `f`, but there is no `SourceLocation` for the `const` qualifier (it's implicitly `const` due to `constexpr`) and an assert in `FunctionTypeInfo::getConstQualifierLoc` fails. 

This patch changes the accessors for _cv-qualifier-seq_ `SourceLocations` in `FunctionTypeInfo` to return an invalid `SourceLocation` if no _cv-qualifier-seq_ is present, and changes `DiagnoseInvalidRedeclaration` to only suggest the removal of the `const` qualifier when it was explicitly specified. 