### PR TITLE
[LSP] Use std::string for storing the Reply method

### DIFF
--- a/mlir/lib/Tools/lsp-server-support/Transport.cpp
+++ b/mlir/lib/Tools/lsp-server-support/Transport.cpp
@@ -41,7 +41,7 @@ public:
   void operator()(llvm::Expected<llvm::json::Value> reply);
 
 private:
-  StringRef method;
+  std::string method;
   std::atomic<bool> replied = {false};
   llvm::json::Value id;
   JSONTransport *transport;


### PR DESCRIPTION
This was using a StringRef, which is very unsafe because the method name might just get disposed due to the async nature of the response.
This was causing weird characters being printed in the output logs.
