### PR TITLE
Added clarifying comment to 'LLVMLinkInMCJIT' and 'LLVMLinkInInterpreter'

### DIFF
--- a/llvm/include/llvm-c/ExecutionEngine.h
+++ b/llvm/include/llvm-c/ExecutionEngine.h
@@ -33,8 +33,16 @@ LLVM_C_EXTERN_C_BEGIN
  * @{
  */
 
-void LLVMLinkInMCJIT(void);
-void LLVMLinkInInterpreter(void);
+/**
+ * Empty function used to force the linker to link MCJIT.
+ * Hidden because it does not apply to the dylib interface.
+ */
+LLVM_ATTRIBUTE_VISIBILITY_HIDDEN void LLVMLinkInMCJIT(void);
+/**
+ * Empty function used to force the linker to link the LLVM interpreter.
+ * Hidden because it does not apply to the dylib interface.
+ */
+LLVM_ATTRIBUTE_VISIBILITY_HIDDEN void LLVMLinkInInterpreter(void);
 
 typedef struct LLVMOpaqueGenericValue *LLVMGenericValueRef;
 typedef struct LLVMOpaqueExecutionEngine *LLVMExecutionEngineRef;

--- a/llvm/include/llvm-c/ExecutionEngine.h
+++ b/llvm/include/llvm-c/ExecutionEngine.h
@@ -23,7 +23,6 @@
 #include "llvm-c/Target.h"
 #include "llvm-c/TargetMachine.h"
 #include "llvm-c/Types.h"
-#include "llvm/Support/Compiler.h"
 
 LLVM_C_EXTERN_C_BEGIN
 
@@ -36,14 +35,14 @@ LLVM_C_EXTERN_C_BEGIN
 
 /**
  * Empty function used to force the linker to link MCJIT.
- * Hidden because it does not apply to the dylib interface.
+ * Has no effect when called on a pre-built library (dylib interface).
  */
-LLVM_ATTRIBUTE_VISIBILITY_HIDDEN void LLVMLinkInMCJIT(void);
+void LLVMLinkInMCJIT(void);
 /**
  * Empty function used to force the linker to link the LLVM interpreter.
- * Hidden because it does not apply to the dylib interface.
+ * Has no effect when called on a pre-built library (dylib interface).
  */
-LLVM_ATTRIBUTE_VISIBILITY_HIDDEN void LLVMLinkInInterpreter(void);
+void LLVMLinkInInterpreter(void);
 
 typedef struct LLVMOpaqueGenericValue *LLVMGenericValueRef;
 typedef struct LLVMOpaqueExecutionEngine *LLVMExecutionEngineRef;

--- a/llvm/include/llvm-c/ExecutionEngine.h
+++ b/llvm/include/llvm-c/ExecutionEngine.h
@@ -23,6 +23,7 @@
 #include "llvm-c/Target.h"
 #include "llvm-c/TargetMachine.h"
 #include "llvm-c/Types.h"
+#include "llvm/Support/Compiler.h"
 
 LLVM_C_EXTERN_C_BEGIN
 


### PR DESCRIPTION
## Issue

- The purpose of `LLVMLinkInMCJIT` and `LLVMLinkInInterpreter` is not obvious (especially when using a pre-built library)
- [Many projects](https://github.com/search?q=LLVMLinkInMCJIT%28%29+%28language%3AJava+OR+language%3AKotlin%29&type=code) call these functions when using pre-built LLVM libraries

## Changes

- Added clarifying comment to `LLVMLinkInMCJIT` and `LLVMLinkInInterpreter`