### PR TITLE
[clang] add unnamed_addr function attribute

### DIFF
--- a/clang/include/clang/Basic/Attr.td
+++ b/clang/include/clang/Basic/Attr.td
@@ -1947,7 +1947,7 @@ def ReturnsTwice : InheritableAttr {
 def UnnamedAddr : InheritableAttr {
   let Spellings = [Clang<"unnamed_addr">];
   let Subjects = SubjectList<[Function]>;
-  let Documentation = [Undocumented];
+  let Documentation = [UnnamedAddrDocs];
   let SimpleHandler = 1;
 }
 

--- a/clang/include/clang/Basic/Attr.td
+++ b/clang/include/clang/Basic/Attr.td
@@ -1944,6 +1944,13 @@ def ReturnsTwice : InheritableAttr {
   let SimpleHandler = 1;
 }
 
+def UnnamedAddr : InheritableAttr {
+  let Spellings = [Clang<"unnamed_addr">];
+  let Subjects = SubjectList<[Function]>;
+  let Documentation = [Undocumented];
+  let SimpleHandler = 1;
+}
+
 def DisableTailCalls : InheritableAttr {
   let Spellings = [Clang<"disable_tail_calls">];
   let Subjects = SubjectList<[Function, ObjCMethod]>;

--- a/clang/include/clang/Basic/AttrDocs.td
+++ b/clang/include/clang/Basic/AttrDocs.td
@@ -4960,6 +4960,19 @@ templates.
   }];
 }
 
+def UnnamedAddrDocs : Documentation {
+  let Category = DocCatFunction;
+  let Content = [{
+The ``unnamed_addr`` attribute instructs the backend that the pointer of
+the marked function is not significant.
+While this attribute opens a possibility of certain optimizations like
+function merging, it should be used carefully because it weakens C/C++'s
+pointer uniqueness guarantee. It's safe to use this attribute if it's known
+that the pointer of the marked function is never used for comparisons with
+other pointers.
+  }];
+}
+
 def DisableTailCallsDocs : Documentation {
   let Category = DocCatFunction;
   let Content = [{

--- a/clang/lib/CodeGen/CodeGenModule.cpp
+++ b/clang/lib/CodeGen/CodeGenModule.cpp
@@ -2506,6 +2506,10 @@ void CodeGenModule::SetLLVMFunctionAttributesForDefinition(const Decl *D,
       B.addAttribute(llvm::Attribute::MinSize);
   }
 
+  if (D->hasAttr<UnnamedAddrAttr>()) {
+    F->setUnnamedAddr(llvm::GlobalValue::UnnamedAddr::Global);
+  }
+
   F->addFnAttrs(B);
 
   unsigned alignment = D->getMaxAlignment() / Context.getCharWidth();

--- a/clang/lib/CodeGen/CodeGenModule.cpp
+++ b/clang/lib/CodeGen/CodeGenModule.cpp
@@ -2506,9 +2506,8 @@ void CodeGenModule::SetLLVMFunctionAttributesForDefinition(const Decl *D,
       B.addAttribute(llvm::Attribute::MinSize);
   }
 
-  if (D->hasAttr<UnnamedAddrAttr>()) {
+  if (D->hasAttr<UnnamedAddrAttr>())
     F->setUnnamedAddr(llvm::GlobalValue::UnnamedAddr::Global);
-  }
 
   F->addFnAttrs(B);
 

--- a/clang/test/Misc/pragma-attribute-supported-attributes-list.test
+++ b/clang/test/Misc/pragma-attribute-supported-attributes-list.test
@@ -199,6 +199,7 @@
 // CHECK-NEXT: TestTypestate (SubjectMatchRule_function_is_member)
 // CHECK-NEXT: TrivialABI (SubjectMatchRule_record)
 // CHECK-NEXT: Uninitialized (SubjectMatchRule_variable_is_local)
+// CHECK-NEXT: UnnamedAddr (SubjectMatchRule_function)
 // CHECK-NEXT: UnsafeBufferUsage (SubjectMatchRule_function)
 // CHECK-NEXT: UseHandle (SubjectMatchRule_variable_is_parameter)
 // CHECK-NEXT: VecReturn (SubjectMatchRule_record)


### PR DESCRIPTION
It simply applies the LLVM attribute with the same name to the function.

Sometimes, a programmer knows that function pointer uniqueness doesn't really matter for some of their functions. In that case, this attribute opens a possibility of certain optimizations like mergefunc with aliases. It's especially useful for code generators.