### PR TITLE
[webkit.RefCntblBaseVirtualDtor] Ignore a base class which has a specialized deref function for a given derived class.

### DIFF
--- a/clang/lib/StaticAnalyzer/Checkers/WebKit/RefCntblBaseVirtualDtorChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/WebKit/RefCntblBaseVirtualDtorChecker.cpp
@@ -49,13 +49,9 @@ class DerefAnalysisVisitor
 public:
   DerefAnalysisVisitor(const TemplateArgumentList &ArgList,
                        const CXXRecordDecl *ClassDecl)
-    : ArgList(&ArgList)
-    , ClassDecl(ClassDecl)
-  { }
+      : ArgList(&ArgList) , ClassDecl(ClassDecl) {}
 
-  DerefAnalysisVisitor(const CXXRecordDecl *ClassDecl)
-    : ClassDecl(ClassDecl)
-  { }
+  DerefAnalysisVisitor(const CXXRecordDecl *ClassDecl) : ClassDecl(ClassDecl) {}
 
   bool HasSpecializedDelete(CXXMethodDecl *Decl) {
     if (auto *Tmpl = Decl->getTemplateInstantiationPattern())
@@ -128,8 +124,8 @@ public:
   bool VisitLambdaExpr(const LambdaExpr *) { return false; }
 
 private:
-  const TemplateArgumentList* ArgList { nullptr };
-  const CXXRecordDecl* ClassDecl;
+  const TemplateArgumentList *ArgList{nullptr};
+  const CXXRecordDecl *ClassDecl;
   llvm::DenseSet<const Stmt *> VisitedBody;
 };
 
@@ -309,11 +305,11 @@ public:
       return false;
     }
     for (auto *MethodDecl : C->methods()) {
-        if (safeGetName(MethodDecl) == "deref") {
-          DerefAnalysisVisitor DerefAnalysis(DerivedClass);
-          if (DerefAnalysis.HasSpecializedDelete(MethodDecl))
-            return true;
-        }
+      if (safeGetName(MethodDecl) == "deref") {
+        DerefAnalysisVisitor DerefAnalysis(DerivedClass);
+        if (DerefAnalysis.HasSpecializedDelete(MethodDecl))
+          return true;
+      }
     }
     return false;
   }

--- a/clang/lib/StaticAnalyzer/Checkers/WebKit/RefCntblBaseVirtualDtorChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/WebKit/RefCntblBaseVirtualDtorChecker.cpp
@@ -49,7 +49,7 @@ class DerefAnalysisVisitor
 public:
   DerefAnalysisVisitor(const TemplateArgumentList &ArgList,
                        const CXXRecordDecl *ClassDecl)
-      : ArgList(&ArgList) , ClassDecl(ClassDecl) {}
+      : ArgList(&ArgList), ClassDecl(ClassDecl) {}
 
   DerefAnalysisVisitor(const CXXRecordDecl *ClassDecl) : ClassDecl(ClassDecl) {}
 

--- a/clang/lib/StaticAnalyzer/Checkers/WebKit/RefCntblBaseVirtualDtorChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/WebKit/RefCntblBaseVirtualDtorChecker.cpp
@@ -208,8 +208,8 @@ public:
         return true;
       }
 
-      llvm::SetVector<const CXXRecordDecl*> Decls;
-      llvm::DenseSet<const CXXRecordDecl*> CRTPs;
+      llvm::SetVector<const CXXRecordDecl *> Decls;
+      llvm::DenseSet<const CXXRecordDecl *> CRTPs;
     };
 
     LocalVisitor visitor(this);
@@ -276,16 +276,18 @@ public:
       auto HasSpecializedDelete = isClassWithSpecializedDelete(C, RD);
       if (!HasSpecializedDelete || *HasSpecializedDelete)
         continue;
-      if (C->lookupInBases([&](const CXXBaseSpecifier *Base, CXXBasePath &) {
-        auto *T = Base->getType().getTypePtrOrNull();
-        if (!T)
-          return false;
-        auto *R = T->getAsCXXRecordDecl();
-        if (!R)
-          return false;
-        auto Result = isClassWithSpecializedDelete(R, RD);
-        return Result && *Result;
-        }, Paths, /*LookupInDependent =*/true))
+      if (C->lookupInBases(
+              [&](const CXXBaseSpecifier *Base, CXXBasePath &) {
+                auto *T = Base->getType().getTypePtrOrNull();
+                if (!T)
+                  return false;
+                auto *R = T->getAsCXXRecordDecl();
+                if (!R)
+                  return false;
+                auto Result = isClassWithSpecializedDelete(R, RD);
+                return Result && *Result;
+              },
+              Paths, /*LookupInDependent =*/true))
         continue;
 
       const auto *Dtor = C->getDestructor();

--- a/clang/lib/StaticAnalyzer/Checkers/WebKit/RefCntblBaseVirtualDtorChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/WebKit/RefCntblBaseVirtualDtorChecker.cpp
@@ -111,7 +111,8 @@ public:
           } else if (auto *RD = dyn_cast<RecordType>(PointeeType)) {
             if (RD->getDecl() == ClassDecl)
               return true;
-          } else if (auto* ST = dyn_cast<SubstTemplateTypeParmType>(PointeeType)) {
+          } else if (auto *ST =
+                         dyn_cast<SubstTemplateTypeParmType>(PointeeType)) {
             auto Type = ST->getReplacementType();
             if (auto *RD = dyn_cast<RecordType>(Type)) {
               if (RD->getDecl() == ClassDecl)
@@ -180,7 +181,7 @@ public:
     if (shouldSkipDecl(RD))
       return;
 
-    for (auto& Base : RD->bases()) {
+    for (auto &Base : RD->bases()) {
       const auto AccSpec = Base.getAccessSpecifier();
       if (AccSpec == AS_protected || AccSpec == AS_private ||
           (AccSpec == AS_none && RD->isClass()))
@@ -202,8 +203,7 @@ public:
 
       bool AnyInconclusiveBase = false;
       const auto hasPublicRefInBase =
-          [&AnyInconclusiveBase](const CXXBaseSpecifier *Base,
-                                 CXXBasePath &) {
+          [&AnyInconclusiveBase](const CXXBaseSpecifier *Base, CXXBasePath &) {
             auto hasRefInBase = clang::hasPublicMethodInBase(Base, "ref");
             if (!hasRefInBase) {
               AnyInconclusiveBase = true;
@@ -235,8 +235,8 @@ public:
 
       const auto *Dtor = C->getDestructor();
       if (!Dtor || !Dtor->isVirtual()) {
-        auto* ProblematicBaseSpecifier = &Base;
-        auto* ProblematicBaseClass = C;
+        auto *ProblematicBaseSpecifier = &Base;
+        auto *ProblematicBaseClass = C;
         reportBug(RD, ProblematicBaseSpecifier, ProblematicBaseClass);
       }
     }
@@ -284,8 +284,9 @@ public:
             ClsName == "ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr");
   }
 
-  static std::optional<bool> isClassWithSpecializedDelete(
-      const CXXRecordDecl *C, const CXXRecordDecl *DerivedClass) {
+  static std::optional<bool>
+  isClassWithSpecializedDelete(const CXXRecordDecl *C,
+                               const CXXRecordDecl *DerivedClass) {
     if (auto *ClsTmplSpDecl = dyn_cast<ClassTemplateSpecializationDecl>(C)) {
       for (auto *MethodDecl : C->methods()) {
         if (safeGetName(MethodDecl) == "deref") {

--- a/clang/lib/StaticAnalyzer/Checkers/WebKit/RefCntblBaseVirtualDtorChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/WebKit/RefCntblBaseVirtualDtorChecker.cpp
@@ -172,7 +172,7 @@ public:
     if (shouldSkipDecl(RD))
       return;
 
-    for (auto& Base : RD->bases()) {
+    for (auto &Base : RD->bases()) {
       const auto AccSpec = Base.getAccessSpecifier();
       if (AccSpec == AS_protected || AccSpec == AS_private ||
           (AccSpec == AS_none && RD->isClass()))
@@ -194,8 +194,7 @@ public:
 
       bool AnyInconclusiveBase = false;
       const auto hasPublicRefInBase =
-          [&AnyInconclusiveBase](const CXXBaseSpecifier *Base,
-                                 CXXBasePath &) {
+          [&AnyInconclusiveBase](const CXXBaseSpecifier *Base, CXXBasePath &) {
             auto hasRefInBase = clang::hasPublicMethodInBase(Base, "ref");
             if (!hasRefInBase) {
               AnyInconclusiveBase = true;
@@ -203,16 +202,15 @@ public:
             }
             return (*hasRefInBase) != nullptr;
           };
-      const auto hasPublicDerefInBase = [&AnyInconclusiveBase](
-                                            const CXXBaseSpecifier *Base,
-                                            CXXBasePath &) {
-        auto hasDerefInBase = clang::hasPublicMethodInBase(Base, "deref");
-        if (!hasDerefInBase) {
-          AnyInconclusiveBase = true;
-          return false;
-        }
-        return (*hasDerefInBase) != nullptr;
-      };
+      const auto hasPublicDerefInBase =
+          [&AnyInconclusiveBase](const CXXBaseSpecifier *Base, CXXBasePath &) {
+            auto hasDerefInBase = clang::hasPublicMethodInBase(Base, "deref");
+            if (!hasDerefInBase) {
+              AnyInconclusiveBase = true;
+              return false;
+            }
+            return (*hasDerefInBase) != nullptr;
+          };
       CXXBasePaths Paths;
       Paths.setOrigin(C);
       hasRef = hasRef || C->lookupInBases(hasPublicRefInBase, Paths,
@@ -227,8 +225,8 @@ public:
 
       const auto *Dtor = C->getDestructor();
       if (!Dtor || !Dtor->isVirtual()) {
-        auto* ProblematicBaseSpecifier = &Base;
-        auto* ProblematicBaseClass = C;
+        auto *ProblematicBaseSpecifier = &Base;
+        auto *ProblematicBaseClass = C;
         reportBug(RD, ProblematicBaseSpecifier, ProblematicBaseClass);
       }
     }

--- a/clang/test/Analysis/Checkers/WebKit/ref-cntbl-base-virtual-dtor-templates.cpp
+++ b/clang/test/Analysis/Checkers/WebKit/ref-cntbl-base-virtual-dtor-templates.cpp
@@ -276,3 +276,9 @@ private:
 
 class RecursiveDerivedClass : public RecursiveBaseClass { };
 // expected-warning@-1{{Class 'RecursiveBaseClass' is used as a base of class 'RecursiveDerivedClass' but doesn't have virtual destructor}}
+
+class DerivedClass14 : public WTF::RefCounted<DerivedClass14> {
+public:
+  virtual ~DerivedClass14() { }
+};
+class DerivedClass15 : public DerivedClass14 { };

--- a/clang/test/Analysis/Checkers/WebKit/ref-cntbl-base-virtual-dtor-templates.cpp
+++ b/clang/test/Analysis/Checkers/WebKit/ref-cntbl-base-virtual-dtor-templates.cpp
@@ -10,8 +10,7 @@ struct DerivedClassTmpl1 : T { };
 // expected-warning@-1{{Struct 'RefCntblBase' is used as a base of struct 'DerivedClassTmpl1<RefCntblBase>' but doesn't have virtual destructor}}
 
 DerivedClassTmpl1<RefCntblBase> a;
-
-
+void foo(DerivedClassTmpl1<RefCntblBase>& obj) { obj.deref(); }
 
 template<class T>
 struct DerivedClassTmpl2 : T { };
@@ -21,14 +20,12 @@ template<class T> int foo(T) { DerivedClassTmpl2<T> f; return 42; }
 int b = foo(RefCntblBase{});
 
 
-
 template<class T>
 struct DerivedClassTmpl3 : T { };
 // expected-warning@-1{{Struct 'RefCntblBase' is used as a base of struct 'DerivedClassTmpl3<RefCntblBase>' but doesn't have virtual destructor}}
 
 typedef DerivedClassTmpl3<RefCntblBase> Foo;
 Foo c;
-
 
 namespace WTF {
 
@@ -98,6 +95,93 @@ private:
   mutable unsigned refCount { 0 };
 };
 
+namespace Detail {
+
+  template<typename Out, typename... In>
+  class CallableWrapperBase {
+  public:
+    virtual ~CallableWrapperBase() { }
+    virtual Out call(In...) = 0;
+  };
+
+  template<typename, typename, typename...> class CallableWrapper;
+
+  template<typename CallableType, typename Out, typename... In>
+  class CallableWrapper : public CallableWrapperBase<Out, In...> {
+  public:
+    explicit CallableWrapper(CallableType&& callable)
+        : m_callable(WTFMove(callable)) { }
+    CallableWrapper(const CallableWrapper&) = delete;
+    CallableWrapper& operator=(const CallableWrapper&) = delete;
+    Out call(In... in) final { return m_callable(in...); }
+  private:
+    CallableType m_callable;
+  };
+
+} // namespace Detail
+
+template<typename> class Function;
+
+template <typename Out, typename... In>
+class Function<Out(In...)> {
+public:
+  using Impl = Detail::CallableWrapperBase<Out, In...>;
+
+  Function() = default;
+
+  template<typename CallableType>
+  Function(CallableType&& callable)
+      : m_callableWrapper(new Detail::CallableWrapper<CallableType, Out, In...>>(callable)) { }
+
+  template<typename FunctionType>
+  Function(FunctionType f)
+      : m_callableWrapper(new Detail::CallableWrapper<FunctionType, Out, In...>>(f)) { }
+
+  ~Function() {
+  }
+
+  Out operator()(In... in) const {
+      ASSERT(m_callableWrapper);
+      return m_callableWrapper->call(in...);
+  }
+
+  explicit operator bool() const { return !!m_callableWrapper; }
+
+private:
+  Impl* m_callableWrapper;
+};
+
+void ensureOnMainThread(const Function<void()>&& function);
+
+enum class DestructionThread { Any, MainThread };
+
+template <typename T, DestructionThread destructionThread = DestructionThread::Any>
+class FancyDeref2 {
+public:
+  void ref() const
+  {
+    ++refCount;
+  }
+
+  void deref() const
+  {
+    --refCount;
+    if (refCount)
+      return;
+    const_cast<FancyDeref2<T, destructionThread>*>(this)->destroy();
+  }
+
+private:
+  void destroy() {
+    delete static_cast<T*>(this);
+  }
+  mutable unsigned refCount { 0 };
+};
+
+template <typename S>
+class DerivedFancyDeref2 : public FancyDeref2<S> {
+};
+
 template <typename T>
 class BadFancyDeref {
 public:
@@ -132,36 +216,16 @@ private:
   mutable unsigned refCount { 0 };
 };
 
-class ThreadSafeRefCountedControlBlock {
-public:
-  ThreadSafeRefCountedControlBlock(void* object) : object(object) { }
-  void strongRef() const { ++refCount; }
-  template <typename T>
-  void strongDeref() const {
-    --refCount;
-    if (refCount)
-      return;
-
-    auto deleteObject = [&] {
-      delete static_cast<const T*>(object);
-      delete this;
-    };
-
-    deleteObject();
-  }
-private:
-  mutable unsigned refCount { 0 };
-  mutable void* object { nullptr };
-};
-
 template <typename T>
 class ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr {
 public:
-  ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr() { }
-  void ref() const { controlBlock.strongRef(); }
-  void deref() const { controlBlock.template strongDeref<T>(); }
+  void ref() const { ++refCount; }
+  void deref() const {
+    if (!--refCount)
+      delete const_cast<T*>(static_cast<const T*>(this));
+  }
 private:
-  ThreadSafeRefCountedControlBlock& controlBlock { *new ThreadSafeRefCountedControlBlock(static_cast<T*>(this)) };
+  mutable unsigned refCount { 0 };
 };
 
 } // namespace WTF
@@ -170,34 +234,39 @@ class DerivedClass4 : public WTF::RefCounted<DerivedClass4> { };
 
 class DerivedClass4b : public WTF::ExoticRefCounted<int, DerivedClass4b> { };
 
-class OtherType;
-class DerivedClass4c : public WTF::BadBase<OtherType, DerivedClass4c> { };
-// expected-warning@-1{{Class 'WTF::BadBase<OtherType, DerivedClass4c>' is used as a base of class 'DerivedClass4c' but doesn't have virtual destructor}}
-class OtherType : public DerivedClass4c { };
-// expected-warning@-1{{Class 'DerivedClass4c' is used as a base of class 'OtherType' but doesn't have virtual destructor}}
-void UseDerived4c(DerivedClass4c &obj) { obj.deref(); }
+class DerivedClass4cSub;
+class DerivedClass4c : public WTF::BadBase<DerivedClass4cSub, DerivedClass4c> { };
+// expected-warning@-1{{Class 'WTF::BadBase<DerivedClass4cSub, DerivedClass4c>' is used as a base of class 'DerivedClass4c' but doesn't have virtual destructor}}
+class DerivedClass4cSub : public DerivedClass4c { };
+void UseDerivedClass4c(DerivedClass4c &obj) { obj.deref(); }
 
 class DerivedClass5 : public DerivedClass4 { };
 // expected-warning@-1{{Class 'DerivedClass4' is used as a base of class 'DerivedClass5' but doesn't have virtual destructor}}
+void UseDerivedClass5(DerivedClass5 &obj) { obj.deref(); }
 
 class DerivedClass6 : public WTF::ThreadSafeRefCounted<DerivedClass6> { };
+void UseDerivedClass6(DerivedClass6 &obj) { obj.deref(); }
 
 class DerivedClass7 : public DerivedClass6 { };
 // expected-warning@-1{{Class 'DerivedClass6' is used as a base of class 'DerivedClass7' but doesn't have virtual destructor}}
+void UseDerivedClass7(DerivedClass7 &obj) { obj.deref(); }
 
 class DerivedClass8 : public WTF::ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<DerivedClass8> { };
-
-class DerivedClass8b : public WTF::ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<DerivedClass8b> { };
-void UseDerived8b(DerivedClass8b &obj) { obj.deref(); }
+void UseDerivedClass8(DerivedClass8 &obj) { obj.deref(); }
 
 class DerivedClass9 : public DerivedClass8 { };
 // expected-warning@-1{{Class 'DerivedClass8' is used as a base of class 'DerivedClass9' but doesn't have virtual destructor}}
+void UseDerivedClass9(DerivedClass9 &obj) { obj.deref(); }
 
 class DerivedClass10 : public WTF::FancyDeref<DerivedClass10> { };
+void UseDerivedClass10(DerivedClass10 &obj) { obj.deref(); }
 
-class DerivedClass10b : public WTF::BadFancyDeref<DerivedClass10b> { };
-// expected-warning@-1{{Class 'WTF::BadFancyDeref<DerivedClass10b>' is used as a base of class 'DerivedClass10b' but doesn't have virtual destructor}}
-void UseDerived10b(DerivedClass10b &obj) { obj.deref(); }
+class DerivedClass10b : public WTF::DerivedFancyDeref2<DerivedClass10b> { };
+void UseDerivedClass10b(DerivedClass10b &obj) { obj.deref(); }
+
+class DerivedClass10c : public WTF::BadFancyDeref<DerivedClass10c> { };
+// expected-warning@-1{{Class 'WTF::BadFancyDeref<DerivedClass10c>' is used as a base of class 'DerivedClass10c' but doesn't have virtual destructor}}
+void UseDerivedClass10c(DerivedClass10c &obj) { obj.deref(); }
 
 class BaseClass1 {
 public:
@@ -225,6 +294,8 @@ void BaseClass1::deref() const
   }
 }
 
+void UseDerivedClass11(DerivedClass11& obj) { obj.deref(); }
+
 class BaseClass2;
 static void deleteBase2(BaseClass2*);
 
@@ -244,6 +315,8 @@ private:
 class DerivedClass12 : public BaseClass2 {
   bool isDerived() final { return true; }
 };
+
+void UseDerivedClass11(DerivedClass12& obj) { obj.deref(); }
 
 void deleteBase2(BaseClass2* obj) {
   if (obj->isDerived())
@@ -271,6 +344,8 @@ private:
 class DerivedClass13 : public BaseClass3 {
   bool isDerived() final { return true; }
 };
+
+void UseDerivedClass11(DerivedClass13& obj) { obj.deref(); }
 
 void BaseClass3::destory() {
   if (isDerived())
@@ -309,4 +384,9 @@ class DerivedClass14 : public WTF::RefCounted<DerivedClass14> {
 public:
   virtual ~DerivedClass14() { }
 };
+
+void UseDerivedClass14(DerivedClass14& obj) { obj.deref(); }
+
 class DerivedClass15 : public DerivedClass14 { };
+
+void UseDerivedClass15(DerivedClass15& obj) { obj.deref(); }

--- a/clang/test/Analysis/Checkers/WebKit/ref-cntbl-base-virtual-dtor-templates.cpp
+++ b/clang/test/Analysis/Checkers/WebKit/ref-cntbl-base-virtual-dtor-templates.cpp
@@ -56,7 +56,7 @@ protected:
 };
 
 template <typename X, typename T>
-class ExoticRefCounted : RefCountedBase {
+class ExoticRefCounted : public RefCountedBase {
 public:
   void deref() const {
     if (derefBase())
@@ -239,6 +239,12 @@ class DerivedClass4c : public WTF::BadBase<DerivedClass4cSub, DerivedClass4c> { 
 // expected-warning@-1{{Class 'WTF::BadBase<DerivedClass4cSub, DerivedClass4c>' is used as a base of class 'DerivedClass4c' but doesn't have virtual destructor}}
 class DerivedClass4cSub : public DerivedClass4c { };
 void UseDerivedClass4c(DerivedClass4c &obj) { obj.deref(); }
+
+class DerivedClass4d : public WTF::RefCounted<DerivedClass4d> {
+public:
+  virtual ~DerivedClass4d() { }
+};
+class DerivedClass4dSub : public DerivedClass4d { };
 
 class DerivedClass5 : public DerivedClass4 { };
 // expected-warning@-1{{Class 'DerivedClass4' is used as a base of class 'DerivedClass5' but doesn't have virtual destructor}}


### PR DESCRIPTION
When a base class B has a deref function which calls delete operator on a derived class D, don't emit a warning for B even if it did not have a virtual destructor.