### PR TITLE
[lit] Fix errors with wasm32-wasi

### DIFF
--- a/llvm/utils/lit/lit/llvm/config.py
+++ b/llvm/utils/lit/lit/llvm/config.py
@@ -355,9 +355,8 @@ class LLVMConfig(object):
     def make_itanium_abi_triple(self, triple):
         m = re.match(r"(\w+)-(\w+)-(\w+)", triple)
         if not m:
-            self.lit_config.fatal(
-                "Could not turn '%s' into Itanium ABI triple" % triple
-            )
+            # eg. wasm32-wasi comes here
+            return triple
         if m.group(3).lower() != "windows":
             # All non-windows triples use the Itanium ABI.
             return triple
@@ -366,7 +365,8 @@ class LLVMConfig(object):
     def make_msabi_triple(self, triple):
         m = re.match(r"(\w+)-(\w+)-(\w+)", triple)
         if not m:
-            self.lit_config.fatal("Could not turn '%s' into MS ABI triple" % triple)
+            # eg. wasm32-wasi comes here
+            return triple
         isa = m.group(1).lower()
         vendor = m.group(2).lower()
         os = m.group(3).lower()


### PR DESCRIPTION
This fixes errors like:
```
fatal: Could not turn 'wasm32-wasi' into Itanium ABI triple
```