### PR TITLE
[mlir][vector] Support MaskableOpRewritePattern of op without a result.

### DIFF
--- a/mlir/include/mlir/Dialect/Vector/Utils/VectorUtils.h
+++ b/mlir/include/mlir/Dialect/Vector/Utils/VectorUtils.h
@@ -157,7 +157,10 @@ private:
     if (failed(newOp))
       return failure();
 
-    rewriter.replaceOp(rootOp, *newOp);
+    if (rootOp->getNumResults() == 0 || *newOp == Value())
+      rewriter.eraseOp(rootOp);
+    else
+      rewriter.replaceOp(rootOp, *newOp);
     return success();
   }
 


### PR DESCRIPTION
`MaskableOpRewritePattern` implements a wrapper of `MatchAndRewrite` as a solution to rewrite masked operators to prevent rewritepatterns to generate multiple ops inside a `MaskOp` (illegal).

This fix aims to target the case where the target op does not have a result (such as a transfer_write at memref_level). `replaceOp` would break if given an empty value.
Stems from : https://github.com/llvm/llvm-project/pull/91987