### PR TITLE
[lldb] Refactor string manipulation in Debugger.cpp

### DIFF
--- a/lldb/source/Core/Debugger.cpp
+++ b/lldb/source/Core/Debugger.cpp
@@ -2067,7 +2067,7 @@ void Debugger::HandleProgressEvent(const lldb::EventSP &event_sp) {
   const uint32_t term_width = GetTerminalWidth();
   const uint32_t ellipsis = 3;
   if (message.size() + ellipsis >= term_width)
-    message = message.substr(0, term_width - ellipsis);
+    message.resize(message.size() - ellipsis);
 
   const bool use_color = GetUseColor();
   llvm::StringRef ansi_prefix = GetShowProgressAnsiPrefix();

--- a/lldb/source/Core/Debugger.cpp
+++ b/lldb/source/Core/Debugger.cpp
@@ -2067,7 +2067,7 @@ void Debugger::HandleProgressEvent(const lldb::EventSP &event_sp) {
   const uint32_t term_width = GetTerminalWidth();
   const uint32_t ellipsis = 3;
   if (message.size() + ellipsis >= term_width)
-    message.resize(message.size() - ellipsis);
+    message.resize(term_width - ellipsis);
 
   const bool use_color = GetUseColor();
   llvm::StringRef ansi_prefix = GetShowProgressAnsiPrefix();


### PR DESCRIPTION
Summary of Changes:

Replaced the ineffective call to `substr` with a more efficient use of `resize` to truncate the string.
Adjusted the code to use 'resize' instead of 'substr' for better performance and readability.
Removed unwanted file from the previous commit.
Fixes: #91209 