### PR TITLE
[TableGen][SubtargetEmitter] Remove isSubClassOf check for WriteResDefs and ReadAdvanceDefs where possible

### DIFF
--- a/llvm/utils/TableGen/Common/CodeGenSchedule.h
+++ b/llvm/utils/TableGen/Common/CodeGenSchedule.h
@@ -239,8 +239,13 @@ struct CodeGenProcModel {
   // This list is empty if the Processor has no UnsupportedFeatures.
   RecVec UnsupportedFeaturesDefs;
 
-  // All read/write resources associated with this processor.
+  // All WriteRes records associated with this processor. Does not contain
+  // SchedWriteRes records (unless a custom class that inherits both was used).
   RecVec WriteResDefs;
+
+  // All ReadAdvance records associated with this processor. Does not contain
+  // SchedReadAdvance records (unless a custom class that inherits both was
+  // used).
   RecVec ReadAdvanceDefs;
 
   // Per-operand machine model resources associated with this processor.
@@ -644,9 +649,14 @@ private:
   void addProcResource(Record *ProcResourceKind, CodeGenProcModel &PM,
                        ArrayRef<SMLoc> Loc);
 
-  void addWriteRes(Record *ProcWriteResDef, unsigned PIdx);
+  // Add resources for a SchedWrite to this processor if they don't exist.
+  // IsWriteRes is true if ProcWriteResDef isSubClassOf("WriteRes").
+  void addWriteRes(Record *ProcWriteResDef, unsigned PIdx, bool IsWriteRes);
 
-  void addReadAdvance(Record *ProcReadAdvanceDef, unsigned PIdx);
+  // Add resources for a ReadAdvance to this processor if they don't exist.
+  // IsReadAdvance is true if ProcReadAdvanceDef->isSubClassOf("ReadAdvance").
+  void addReadAdvance(Record *ProcReadAdvanceDef, unsigned PIdx,
+                      bool IsReadAdvance);
 };
 
 } // namespace llvm

--- a/llvm/utils/TableGen/SubtargetEmitter.cpp
+++ b/llvm/utils/TableGen/SubtargetEmitter.cpp
@@ -900,8 +900,6 @@ SubtargetEmitter::FindWriteResources(const CodeGenSchedRW &SchedWrite,
   // Check this processor's list of write resources.
   Record *ResDef = nullptr;
   for (Record *WR : ProcModel.WriteResDefs) {
-    if (!WR->isSubClassOf("WriteRes"))
-      continue;
     Record *WRDef = WR->getValueAsDef("WriteType");
     if (AliasDef == WRDef || SchedWrite.TheDef == WRDef) {
       if (ResDef) {
@@ -959,8 +957,6 @@ Record *SubtargetEmitter::FindReadAdvance(const CodeGenSchedRW &SchedRead,
   // Check this processor's ReadAdvanceList.
   Record *ResDef = nullptr;
   for (Record *RA : ProcModel.ReadAdvanceDefs) {
-    if (!RA->isSubClassOf("ReadAdvance"))
-      continue;
     Record *RADef = RA->getValueAsDef("ReadType");
     if (AliasDef == RADef || SchedRead.TheDef == RADef) {
       if (ResDef) {


### PR DESCRIPTION
WriteResDefs contained WriteRes and SchedWriteRes records. WriteRes and SchedWriteRes are not subclasses of eachother.

ReadAdvanceDefs contained ReadAdvance and SchedReadAdvance records. ReadAdvance and SchedReadAdvance are not subclasses of eachother.

FindWriteResources and FindReadAdvance are the only users of WriteResDefs and ReadAdvanceDefs respectively. These functions call isSubClassOf to skip records that are not WriteRes or ReadAdvance. That means that SchedWriteRes and SchedReadAdvance records are added to the list but always skipped over.

We opt to not put them in the list in the first place so we can remove the isSubClassOf checks in FindWriteResources and FindReadAdvance.

We still call addWriteRes and addReadAdvance for SchedWriteRes and SchedReadAdvance because those functions perform error checking and discover processor resources.

If we were to assume that there is no SchedWriteRes that also `isSubClassOf(WriteRes)`, and there is no SchedReadAdvance that is also `isSubClassOf(ReadAdvance)`, then we could remove the `isSubClassOf` checks passed to `addWriteRes` and `addReadAdvance` where the def is a SchedWriteRes or SchedReadAdvance. Although unlikely, I think its possible for a subtarget to define a `Foo : SchedWriteRes, WriteRes`. Feedback on whether we can make this assumption would be appreciated.

This improves gen-subtarget on RISC-V by 1% upstream and by 10% downstream.