### PR TITLE
[lldb][Windows] Skip the TestDataFormatterLibcxxChrono test to avoid python crash

### DIFF
--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libcxx/chrono/TestDataFormatterLibcxxChrono.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libcxx/chrono/TestDataFormatterLibcxxChrono.py
@@ -12,6 +12,9 @@ from lldbsuite.test import lldbutil
 class LibcxxChronoDataFormatterTestCase(TestBase):
     @add_test_categories(["libc++"])
     @skipIf(compiler="clang", compiler_version=["<", "17.0"])
+    @skipIf(
+        hostoslist=["windows"], bugnumber="github.com/llvm/llvm-project/issues/92574"
+    )
     def test_with_run_command(self):
         """Test that that file and class static variables display correctly."""
         self.build()


### PR DESCRIPTION
The python crashed with the exit code 0xC0000409 (STATUS_STACK_BUFFER_OVERRUN) on the command `frame variable ss_neg_seconds` running on Windows x86_64. See this issue for details https://github.com/llvm/llvm-project/issues/92574