### PR TITLE
[CloneFunction] Remove check that is no longer necessary

### DIFF
--- a/llvm/lib/Transforms/Utils/CloneFunction.cpp
+++ b/llvm/lib/Transforms/Utils/CloneFunction.cpp
@@ -825,13 +825,6 @@ void llvm::CloneAndPruneIntoFromInst(Function *NewFunc, const Function *OldFunc,
       if (!NewI)
         continue;
 
-      // Skip over non-intrinsic callsites, we don't want to remove any nodes
-      // from the CGSCC.
-      CallBase *CB = dyn_cast<CallBase>(NewI);
-      if (CB && CB->getCalledFunction() &&
-          !CB->getCalledFunction()->isIntrinsic())
-        continue;
-
       if (Value *V = simplifyInstruction(NewI, DL)) {
         NewI->replaceAllUsesWith(V);
 


### PR DESCRIPTION
We do not need to concern ourselves with CGSCC since all remaining CG related updates went away in fa6ea7a419f37befbed04368bcb8af4c718facbb as pointed out by @nikic in https://github.com/llvm/llvm-project/pull/87963#issuecomment-2113937182.