### PR TITLE
Add option to avoid generating coverage mappings for unused functions

### DIFF
--- a/clang/include/clang/Basic/CodeGenOptions.def
+++ b/clang/include/clang/Basic/CodeGenOptions.def
@@ -222,6 +222,9 @@ CODEGENOPT(CoverageMapping , 1, 0) ///< Generate coverage mapping regions to
                                    ///< enable code coverage analysis.
 CODEGENOPT(DumpCoverageMapping , 1, 0) ///< Dump the generated coverage mapping
                                        ///< regions.
+CODEGENOPT(NoUnusedCoverage , 1, 0) ///< Turn off coverage mapping for code that
+                                    ///< is not emitted.
+
 CODEGENOPT(MCDCCoverage , 1, 0) ///< Enable MC/DC code coverage criteria.
 
   /// If -fpcc-struct-return or -freg-struct-return is specified.

--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -7065,6 +7065,9 @@ def coverage_version_EQ : Joined<["-"], "coverage-version=">,
 def dump_coverage_mapping : Flag<["-"], "dump-coverage-mapping">,
   HelpText<"Dump the coverage mapping records, for testing">,
   MarshallingInfoFlag<CodeGenOpts<"DumpCoverageMapping">>;
+def no_unused_coverage : Flag<["-"], "no-unused-coverage">,
+  HelpText<"Turn off coverage mapping for code that is not emitted">,
+  MarshallingInfoFlag<CodeGenOpts<"NoUnusedCoverage">>;
 def fuse_register_sized_bitfield_access: Flag<["-"], "fuse-register-sized-bitfield-access">,
   HelpText<"Use register sized accesses to bit-fields, when possible.">,
   MarshallingInfoFlag<CodeGenOpts<"UseRegisterSizedBitfieldAccess">>;

--- a/clang/lib/CodeGen/CodeGenModule.cpp
+++ b/clang/lib/CodeGen/CodeGenModule.cpp
@@ -891,7 +891,9 @@ void CodeGenModule::Release() {
   EmitGlobalAnnotations();
   EmitStaticExternCAliases();
   checkAliases();
-  EmitDeferredUnusedCoverageMappings();
+  if (!CodeGenOpts.NoUnusedCoverage) {
+    EmitDeferredUnusedCoverageMappings();
+  }
   CodeGenPGO(*this).setValueProfilingFlag(getModule());
   CodeGenPGO(*this).setProfileVersion(getModule());
   if (CoverageMapping)

--- a/clang/test/CoverageMapping/deferred_unused_names.c
+++ b/clang/test/CoverageMapping/deferred_unused_names.c
@@ -1,0 +1,11 @@
+// RUN: %clang_cc1 -mllvm -emptyline-comment-coverage=false -mllvm -enable-name-compression=false -no-unused-coverage -fprofile-instrument=clang -fcoverage-mapping -emit-llvm -main-file-name unused_names.c -o - %s > %t
+// RUN: FileCheck -input-file %t %s
+
+// There should only be a prf_names entry for bar, as the other two functions are
+// unused.
+//
+// CHECK-DAG: @__llvm_prf_nm = private constant [5 x i8] c"\03\00bar", section "{{.*__llvm_prf_names|\.lprfn\$M}}"
+
+int bar(void) { return 0; }
+inline int baz(void) { return 0; }
+static int qux(void) { return 42; }


### PR DESCRIPTION
This change adds an option which prevents generating coverage mapping data for functions which aren't used.  This reduces binary size in cases where many unused static inline functions are automatically generated.