### PR TITLE
[mlir] add arith dialect dep to fix buildbot failure

### DIFF
--- a/mlir/lib/Dialect/Polynomial/IR/CMakeLists.txt
+++ b/mlir/lib/Dialect/Polynomial/IR/CMakeLists.txt
@@ -18,6 +18,7 @@ add_mlir_dialect_library(MLIRPolynomialDialect
   MLIRBuiltinAttributesIncGen
 
   LINK_LIBS PUBLIC
+  MLIRArithDialect
   MLIRSupport
   MLIRDialect
   MLIRIR


### PR DESCRIPTION
https://lab.llvm.org/buildbot/#/builders/268/builds/14288

```undefined reference to `mlir::detail::TypeIDResolver<mlir::arith::ConstantOp, void>::id'```