### PR TITLE
[sanitizer] Disable writes to log files for binaries in a secure context.

### DIFF
--- a/compiler-rt/lib/sanitizer_common/sanitizer_common.h
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_common.h
@@ -1096,6 +1096,11 @@ inline u32 GetNumberOfCPUsCached() {
   return NumberOfCPUsCached;
 }
 
+// Returns true if the our runtime has special privileges (e.g. setuid) and
+// should be treated with caution when dealing with untrusted user input.
+// For example, when writing files or executing user-specified binaries.
+bool ShouldTreatRuntimeSecurely();
+
 }  // namespace __sanitizer
 
 inline void *operator new(__sanitizer::usize size,

--- a/compiler-rt/lib/sanitizer_common/sanitizer_common_nolibc.cpp
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_common_nolibc.cpp
@@ -26,6 +26,7 @@ void LogMessageOnPrintf(const char *str) {}
 void WriteToSyslog(const char *buffer) {}
 void Abort() { internal__exit(1); }
 bool CreateDir(const char *pathname) { return false; }
+bool ShouldTreatRuntimeSecurely() { return false; }
 #endif // !SANITIZER_WINDOWS
 
 #if !SANITIZER_WINDOWS && !SANITIZER_APPLE

--- a/compiler-rt/lib/sanitizer_common/sanitizer_common_nolibc.cpp
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_common_nolibc.cpp
@@ -26,6 +26,7 @@ void LogMessageOnPrintf(const char *str) {}
 void WriteToSyslog(const char *buffer) {}
 void Abort() { internal__exit(1); }
 bool CreateDir(const char *pathname) { return false; }
+// TODO: Revisit using insecure by default approach for no-libc binaries.
 bool ShouldTreatRuntimeSecurely() { return false; }
 #endif // !SANITIZER_WINDOWS
 

--- a/compiler-rt/lib/sanitizer_common/sanitizer_file.cpp
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_file.cpp
@@ -104,6 +104,16 @@ void ReportFile::SetReportPath(const char *path) {
     }
   }
 
+  if (path && ShouldTreatRuntimeSecurely() &&
+      internal_strcmp(path, "stderr") != 0 &&
+      internal_strcmp(path, "stdout") != 0) {
+    Report(
+        "ERROR: log_path must be 'stderr' or 'stdout' for AT_SECURE and/or "
+        "setuid binaries, is '%s'\n",
+        path);
+    Die();
+  }
+
   SpinMutexLock l(mu);
   if (fd != kStdoutFd && fd != kStderrFd && fd != kInvalidFd)
     CloseFile(fd);

--- a/compiler-rt/lib/sanitizer_common/sanitizer_win.cpp
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_win.cpp
@@ -1199,6 +1199,8 @@ void LogFullErrorReport(const char *buffer) {
 
 void InitializePlatformCommonFlags(CommonFlags *cf) {}
 
+bool ShouldTreatRuntimeSecurely() { return false; }
+
 }  // namespace __sanitizer
 
 #endif  // _WIN32

--- a/compiler-rt/lib/sanitizer_common/sanitizer_win.cpp
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_win.cpp
@@ -1199,6 +1199,8 @@ void LogFullErrorReport(const char *buffer) {
 
 void InitializePlatformCommonFlags(CommonFlags *cf) {}
 
+// FIXME: implement on this platform.
+// Windows analog to such runtime would be auto-elevated binaries.
 bool ShouldTreatRuntimeSecurely() { return false; }
 
 }  // namespace __sanitizer


### PR DESCRIPTION
Fix for https://github.com/google/sanitizers/issues/1130.

An original issue described by Szabolcs Nagy at https://seclists.org/oss-sec/2016/q1/363.

Implemented by disabling setting `log_path` in ASAN_OPTIONS to values other then "stderr" and "stdout".

The fix provided for Linux and Android API 18+ based on `AT_SECURE`  auxv variable (`man 3 getauxval` is your friend)..

