### PR TITLE
[WebAssembly] Define __WASM_EXCEPTIONS__ for -fwasm-exceptions

### DIFF
--- a/clang/lib/Frontend/InitPreprocessor.cpp
+++ b/clang/lib/Frontend/InitPreprocessor.cpp
@@ -1006,6 +1006,8 @@ static void InitializePredefinedMacros(const TargetInfo &TI,
   else if (LangOpts.hasDWARFExceptions() &&
            (TI.getTriple().isThumb() || TI.getTriple().isARM()))
     Builder.defineMacro("__ARM_DWARF_EH__");
+  else if (LangOpts.hasWasmExceptions())
+    Builder.defineMacro("__USING_WASM_EXCEPTIONS__");
 
   if (LangOpts.Deprecated)
     Builder.defineMacro("__DEPRECATED");

--- a/clang/lib/Frontend/InitPreprocessor.cpp
+++ b/clang/lib/Frontend/InitPreprocessor.cpp
@@ -1007,7 +1007,7 @@ static void InitializePredefinedMacros(const TargetInfo &TI,
            (TI.getTriple().isThumb() || TI.getTriple().isARM()))
     Builder.defineMacro("__ARM_DWARF_EH__");
   else if (LangOpts.hasWasmExceptions() && TI.getTriple().isWasm())
-    Builder.defineMacro("__USING_WASM_EXCEPTIONS__");
+    Builder.defineMacro("__WASM_EXCEPTIONS__");
 
   if (LangOpts.Deprecated)
     Builder.defineMacro("__DEPRECATED");

--- a/clang/lib/Frontend/InitPreprocessor.cpp
+++ b/clang/lib/Frontend/InitPreprocessor.cpp
@@ -1006,7 +1006,7 @@ static void InitializePredefinedMacros(const TargetInfo &TI,
   else if (LangOpts.hasDWARFExceptions() &&
            (TI.getTriple().isThumb() || TI.getTriple().isARM()))
     Builder.defineMacro("__ARM_DWARF_EH__");
-  else if (LangOpts.hasWasmExceptions())
+  else if (LangOpts.hasWasmExceptions() && TI.getTriple().isWasm())
     Builder.defineMacro("__USING_WASM_EXCEPTIONS__");
 
   if (LangOpts.Deprecated)

--- a/clang/test/CodeGenCXX/wasm-eh.cpp
+++ b/clang/test/CodeGenCXX/wasm-eh.cpp
@@ -1,4 +1,8 @@
 // REQUIRES: webassembly-registered-target
+
+// RUN: %clang -E -dM %s -target wasm32-unknown-unknown -fwasm-exceptions | FileCheck %s -check-prefix PREPROCESSOR
+// PREPROCESSOR: #define __USING_WASM_EXCEPTIONS__ 1
+
 // RUN: %clang_cc1 %s -triple wasm32-unknown-unknown -fms-extensions -fexceptions -fcxx-exceptions -mllvm -wasm-enable-eh -exception-model=wasm -target-feature +exception-handling -emit-llvm -o - -std=c++11 | FileCheck %s
 // RUN: %clang_cc1 %s -triple wasm64-unknown-unknown -fms-extensions -fexceptions -fcxx-exceptions -mllvm -wasm-enable-eh -exception-model=wasm -target-feature +exception-handling -emit-llvm -o - -std=c++11 | FileCheck %s
 

--- a/clang/test/CodeGenCXX/wasm-eh.cpp
+++ b/clang/test/CodeGenCXX/wasm-eh.cpp
@@ -1,7 +1,7 @@
 // REQUIRES: webassembly-registered-target
 
 // RUN: %clang -E -dM %s -target wasm32-unknown-unknown -fwasm-exceptions | FileCheck %s -check-prefix PREPROCESSOR
-// PREPROCESSOR: #define __USING_WASM_EXCEPTIONS__ 1
+// PREPROCESSOR: #define __WASM_EXCEPTIONS__ 1
 
 // RUN: %clang_cc1 %s -triple wasm32-unknown-unknown -fms-extensions -fexceptions -fcxx-exceptions -mllvm -wasm-enable-eh -exception-model=wasm -target-feature +exception-handling -emit-llvm -o - -std=c++11 | FileCheck %s
 // RUN: %clang_cc1 %s -triple wasm64-unknown-unknown -fms-extensions -fexceptions -fcxx-exceptions -mllvm -wasm-enable-eh -exception-model=wasm -target-feature +exception-handling -emit-llvm -o - -std=c++11 | FileCheck %s


### PR DESCRIPTION
When using other specific exception options in Clang, such as `-fseh-exceptions` or `-fsjlj-exceptions`, Clang defines a corresponding preprocessor such as `-D__USING_SJLJ_EXCEPTIONS__`. Emscripten does that in our own build system:
https://github.com/emscripten-core/emscripten/blob/7dcd7f40749918e141dc33397d2f4311dd80637a/tools/system_libs.py#L1577-L1578

But to make Wasm EH usable in non-Emscripten toolchain, this has to be defined somewhere else. This PR makes Wasm EH consistent with other exception scheme by letting it defined by Clang depending on the exception option.

We have been using `__USING_WASM_EXCEPTIONS__` in our current library code, but this changes it to `__WASM_EXCEPTIONS__` for its conciseness, and I will update other parts of LLVM as follow-ups. This does not break anything currently working, because we have not been defining anything in Clang so far.