### PR TITLE
[clang-format]: Annotate colons found in inline assembly

### DIFF
--- a/clang/lib/Format/TokenAnnotator.cpp
+++ b/clang/lib/Format/TokenAnnotator.cpp
@@ -1427,10 +1427,6 @@ private:
         // This handles a special macro in ObjC code where selectors including
         // the colon are passed as macro arguments.
         Tok->setType(TT_ObjCMethodExpr);
-      } else if (Contexts.back().ContextKind == tok::l_paren &&
-                 !Line.InPragmaDirective && Style.isTableGen() &&
-                 Contexts.back().IsTableGenDAGArg) {
-        Tok->setType(TT_TableGenDAGArgListColon);
       }
       break;
     case tok::pipe:

--- a/clang/lib/Format/TokenAnnotator.cpp
+++ b/clang/lib/Format/TokenAnnotator.cpp
@@ -1358,6 +1358,8 @@ private:
           Line.First->startsSequence(tok::kw_export, Keywords.kw_module) ||
           Line.First->startsSequence(tok::kw_export, Keywords.kw_import)) {
         Tok->setType(TT_ModulePartitionColon);
+      } else if (Line.First->is(tok::kw_asm)) {
+        Tok->setType(TT_InlineASMColon);
       } else if (Contexts.back().ColonIsDictLiteral || Style.isProto()) {
         Tok->setType(TT_DictLiteral);
         if (Style.Language == FormatStyle::LK_TextProto) {

--- a/clang/lib/Format/TokenAnnotator.cpp
+++ b/clang/lib/Format/TokenAnnotator.cpp
@@ -1428,12 +1428,9 @@ private:
         // the colon are passed as macro arguments.
         Tok->setType(TT_ObjCMethodExpr);
       } else if (Contexts.back().ContextKind == tok::l_paren &&
-                 !Line.InPragmaDirective) {
-        if (Style.isTableGen() && Contexts.back().IsTableGenDAGArg) {
-          Tok->setType(TT_TableGenDAGArgListColon);
-          break;
-        }
-        Tok->setType(TT_InlineASMColon);
+                 !Line.InPragmaDirective && Style.isTableGen() &&
+                 Contexts.back().IsTableGenDAGArg) {
+        Tok->setType(TT_TableGenDAGArgListColon);
       }
       break;
     case tok::pipe:

--- a/clang/unittests/Format/TokenAnnotatorTest.cpp
+++ b/clang/unittests/Format/TokenAnnotatorTest.cpp
@@ -1499,31 +1499,7 @@ TEST_F(TokenAnnotatorTest, UnderstandsAsm) {
   EXPECT_TOKEN(Tokens[6], tok::colon, TT_InlineASMColon);
   EXPECT_TOKEN(Tokens[7], tok::r_brace, TT_InlineASMBrace);
 
-  Tokens = annotate("asm{\n"
-                    "\"a\":\n"
-                    ": x\n"
-                    ":};");
-  ASSERT_EQ(Tokens.size(), 10u) << Tokens;
-  EXPECT_TOKEN(Tokens[0], tok::kw_asm, TT_Unknown);
-  EXPECT_TOKEN(Tokens[1], tok::l_brace, TT_InlineASMBrace);
-  EXPECT_TOKEN(Tokens[3], tok::colon, TT_InlineASMColon);
-  EXPECT_TOKEN(Tokens[4], tok::colon, TT_InlineASMColon);
-  EXPECT_TOKEN(Tokens[6], tok::colon, TT_InlineASMColon);
-  EXPECT_TOKEN(Tokens[7], tok::r_brace, TT_InlineASMBrace);
-
-  Tokens = annotate("__asm__{\n"
-                    "\"a\":\n"
-                    ": x\n"
-                    ":};");
-  ASSERT_EQ(Tokens.size(), 10u) << Tokens;
-  EXPECT_TOKEN(Tokens[0], tok::kw_asm, TT_Unknown);
-  EXPECT_TOKEN(Tokens[1], tok::l_brace, TT_InlineASMBrace);
-  EXPECT_TOKEN(Tokens[3], tok::colon, TT_InlineASMColon);
-  EXPECT_TOKEN(Tokens[4], tok::colon, TT_InlineASMColon);
-  EXPECT_TOKEN(Tokens[6], tok::colon, TT_InlineASMColon);
-  EXPECT_TOKEN(Tokens[7], tok::r_brace, TT_InlineASMBrace);
-
-  Tokens = annotate("__asm (\n"
+  Tokens = annotate("__asm(\n"
                     "\"a\":\n"
                     ": x\n"
                     ":);");
@@ -1532,37 +1508,6 @@ TEST_F(TokenAnnotatorTest, UnderstandsAsm) {
   EXPECT_TOKEN(Tokens[3], tok::colon, TT_InlineASMColon);
   EXPECT_TOKEN(Tokens[4], tok::colon, TT_InlineASMColon);
   EXPECT_TOKEN(Tokens[6], tok::colon, TT_InlineASMColon);
-
-  Tokens = annotate("asm (\n"
-                    "\"a\":\n"
-                    ": x\n"
-                    ":);");
-  ASSERT_EQ(Tokens.size(), 10u) << Tokens;
-  EXPECT_TOKEN(Tokens[0], tok::kw_asm, TT_Unknown);
-  EXPECT_TOKEN(Tokens[3], tok::colon, TT_InlineASMColon);
-  EXPECT_TOKEN(Tokens[4], tok::colon, TT_InlineASMColon);
-  EXPECT_TOKEN(Tokens[6], tok::colon, TT_InlineASMColon);
-
-  Tokens = annotate("__asm__ (\n"
-                    "\"a\":\n"
-                    ": x\n"
-                    ":);");
-  ASSERT_EQ(Tokens.size(), 10u) << Tokens;
-  EXPECT_TOKEN(Tokens[0], tok::kw_asm, TT_Unknown);
-  EXPECT_TOKEN(Tokens[3], tok::colon, TT_InlineASMColon);
-  EXPECT_TOKEN(Tokens[4], tok::colon, TT_InlineASMColon);
-  EXPECT_TOKEN(Tokens[6], tok::colon, TT_InlineASMColon);
-
-  Tokens = annotate("__asm volatile (\n"
-                    "\"a_label:\"\n"
-                    ":\n"
-                    ": x\n"
-                    ":);");
-  ASSERT_EQ(Tokens.size(), 11u) << Tokens;
-  EXPECT_TOKEN(Tokens[0], tok::kw_asm, TT_Unknown);
-  EXPECT_TOKEN(Tokens[4], tok::colon, TT_InlineASMColon);
-  EXPECT_TOKEN(Tokens[5], tok::colon, TT_InlineASMColon);
-  EXPECT_TOKEN(Tokens[7], tok::colon, TT_InlineASMColon);
 
   Tokens = annotate("asm volatile (\n"
                     "\"a_label:\"\n"
@@ -1575,40 +1520,7 @@ TEST_F(TokenAnnotatorTest, UnderstandsAsm) {
   EXPECT_TOKEN(Tokens[5], tok::colon, TT_InlineASMColon);
   EXPECT_TOKEN(Tokens[7], tok::colon, TT_InlineASMColon);
 
-  Tokens = annotate("__asm__ volatile (\n"
-                    "\"a_label:\"\n"
-                    ":\n"
-                    ": x\n"
-                    ":);");
-  ASSERT_EQ(Tokens.size(), 11u) << Tokens;
-  EXPECT_TOKEN(Tokens[0], tok::kw_asm, TT_Unknown);
-  EXPECT_TOKEN(Tokens[4], tok::colon, TT_InlineASMColon);
-  EXPECT_TOKEN(Tokens[5], tok::colon, TT_InlineASMColon);
-  EXPECT_TOKEN(Tokens[7], tok::colon, TT_InlineASMColon);
-
-  Tokens = annotate("__asm (\n"
-                    "\"a_label:\"\n"
-                    ": x\n"
-                    ":\n"
-                    ": y);");
-  ASSERT_EQ(Tokens.size(), 11u) << Tokens;
-  EXPECT_TOKEN(Tokens[0], tok::kw_asm, TT_Unknown);
-  EXPECT_TOKEN(Tokens[3], tok::colon, TT_InlineASMColon);
-  EXPECT_TOKEN(Tokens[5], tok::colon, TT_InlineASMColon);
-  EXPECT_TOKEN(Tokens[6], tok::colon, TT_InlineASMColon);
-
-  Tokens = annotate("asm (\n"
-                    "\"a_label:\"\n"
-                    ": x\n"
-                    ":\n"
-                    ": y);");
-  ASSERT_EQ(Tokens.size(), 11u) << Tokens;
-  EXPECT_TOKEN(Tokens[0], tok::kw_asm, TT_Unknown);
-  EXPECT_TOKEN(Tokens[3], tok::colon, TT_InlineASMColon);
-  EXPECT_TOKEN(Tokens[5], tok::colon, TT_InlineASMColon);
-  EXPECT_TOKEN(Tokens[6], tok::colon, TT_InlineASMColon);
-
-  Tokens = annotate("__asm__ (\n"
+  Tokens = annotate("__asm__(\n"
                     "\"a_label:\"\n"
                     ": x\n"
                     ":\n"
@@ -1631,43 +1543,7 @@ TEST_F(TokenAnnotatorTest, UnderstandsAsm) {
   EXPECT_TOKEN(Tokens[6], tok::colon, TT_InlineASMColon);
   EXPECT_TOKEN(Tokens[8], tok::colon, TT_InlineASMColon);
 
-  Tokens = annotate("__asm volatile (\n"
-                    "\"a_label:\"\n"
-                    "\"a b c(%%x)\"\n"
-                    ":\n"
-                    ": x\n"
-                    ":);");
-  ASSERT_EQ(Tokens.size(), 12u) << Tokens;
-  EXPECT_TOKEN(Tokens[0], tok::kw_asm, TT_Unknown);
-  EXPECT_TOKEN(Tokens[5], tok::colon, TT_InlineASMColon);
-  EXPECT_TOKEN(Tokens[6], tok::colon, TT_InlineASMColon);
-  EXPECT_TOKEN(Tokens[8], tok::colon, TT_InlineASMColon);
-
-  Tokens = annotate("asm volatile (\n"
-                    "\"a_label:\"\n"
-                    "\"a b c(%%x)\"\n"
-                    ":\n"
-                    ": x\n"
-                    ":);");
-  ASSERT_EQ(Tokens.size(), 12u) << Tokens;
-  EXPECT_TOKEN(Tokens[0], tok::kw_asm, TT_Unknown);
-  EXPECT_TOKEN(Tokens[5], tok::colon, TT_InlineASMColon);
-  EXPECT_TOKEN(Tokens[6], tok::colon, TT_InlineASMColon);
-  EXPECT_TOKEN(Tokens[8], tok::colon, TT_InlineASMColon);
-
-  Tokens = annotate("__asm__ volatile (\n"
-                    "\"a_label:\"\n"
-                    "\"a b c(%%x)\"\n"
-                    ":\n"
-                    ": x\n"
-                    ":);");
-  ASSERT_EQ(Tokens.size(), 12u) << Tokens;
-  EXPECT_TOKEN(Tokens[0], tok::kw_asm, TT_Unknown);
-  EXPECT_TOKEN(Tokens[5], tok::colon, TT_InlineASMColon);
-  EXPECT_TOKEN(Tokens[6], tok::colon, TT_InlineASMColon);
-  EXPECT_TOKEN(Tokens[8], tok::colon, TT_InlineASMColon);
-
-  Tokens = annotate("__asm (\n"
+  Tokens = annotate("asm(\n"
                     "\"insn\"\n"
                     ": \"=r\" (var1), \"=&r\" (value)\n"
                     ":\n"
@@ -1677,48 +1553,6 @@ TEST_F(TokenAnnotatorTest, UnderstandsAsm) {
   EXPECT_TOKEN(Tokens[3], tok::colon, TT_InlineASMColon);
   EXPECT_TOKEN(Tokens[13], tok::colon, TT_InlineASMColon);
   EXPECT_TOKEN(Tokens[14], tok::colon, TT_InlineASMColon);
-
-  Tokens = annotate("asm (\n"
-                    "\"insn\"\n"
-                    ": \"=r\" (var1), \"=&r\" (value)\n"
-                    ":\n"
-                    ": \"memory\");");
-  ASSERT_EQ(Tokens.size(), 19u) << Tokens;
-  EXPECT_TOKEN(Tokens[0], tok::kw_asm, TT_Unknown);
-  EXPECT_TOKEN(Tokens[3], tok::colon, TT_InlineASMColon);
-  EXPECT_TOKEN(Tokens[13], tok::colon, TT_InlineASMColon);
-  EXPECT_TOKEN(Tokens[14], tok::colon, TT_InlineASMColon);
-
-  Tokens = annotate("__asm__ (\n"
-                    "\"insn\"\n"
-                    ": \"=r\" (var1), \"=&r\" (value)\n"
-                    ":\n"
-                    ": \"memory\");");
-  ASSERT_EQ(Tokens.size(), 19u) << Tokens;
-  EXPECT_TOKEN(Tokens[0], tok::kw_asm, TT_Unknown);
-  EXPECT_TOKEN(Tokens[3], tok::colon, TT_InlineASMColon);
-  EXPECT_TOKEN(Tokens[13], tok::colon, TT_InlineASMColon);
-  EXPECT_TOKEN(Tokens[14], tok::colon, TT_InlineASMColon);
-
-  Tokens = annotate("__asm volatile (\n"
-                    "\"ldr r1, [r0, %%[sym]]\"\n"
-                    ":\n"
-                    ": [sym] \"J\" (aaaaa(aaaa, aaaa))\n"
-                    ");");
-  ASSERT_EQ(Tokens.size(), 21u) << Tokens;
-  EXPECT_TOKEN(Tokens[0], tok::kw_asm, TT_Unknown);
-  EXPECT_TOKEN(Tokens[4], tok::colon, TT_InlineASMColon);
-  EXPECT_TOKEN(Tokens[5], tok::colon, TT_InlineASMColon);
-
-  Tokens = annotate("asm volatile (\n"
-                    "\"ldr r1, [r0, %%[sym]]\"\n"
-                    ":\n"
-                    ": [sym] \"J\" (aaaaa(aaaa, aaaa))\n"
-                    ");");
-  ASSERT_EQ(Tokens.size(), 21u) << Tokens;
-  EXPECT_TOKEN(Tokens[0], tok::kw_asm, TT_Unknown);
-  EXPECT_TOKEN(Tokens[4], tok::colon, TT_InlineASMColon);
-  EXPECT_TOKEN(Tokens[5], tok::colon, TT_InlineASMColon);
 
   Tokens = annotate("__asm__ volatile (\n"
                     "\"ldr r1, [r0, %%[sym]]\"\n"

--- a/clang/unittests/Format/TokenAnnotatorTest.cpp
+++ b/clang/unittests/Format/TokenAnnotatorTest.cpp
@@ -1563,6 +1563,7 @@ TEST_F(TokenAnnotatorTest, UnderstandsAsm) {
   EXPECT_TOKEN(Tokens[0], tok::kw_asm, TT_Unknown);
   EXPECT_TOKEN(Tokens[4], tok::colon, TT_InlineASMColon);
   EXPECT_TOKEN(Tokens[5], tok::colon, TT_InlineASMColon);
+  EXPECT_TOKEN(Tokens[6], tok::l_square, TT_InlineASMSymbolicNameLSquare);
 }
 
 TEST_F(TokenAnnotatorTest, UnderstandsObjCBlock) {

--- a/clang/unittests/Format/TokenAnnotatorTest.cpp
+++ b/clang/unittests/Format/TokenAnnotatorTest.cpp
@@ -1499,27 +1499,61 @@ TEST_F(TokenAnnotatorTest, UnderstandsAsm) {
   EXPECT_TOKEN(Tokens[6], tok::colon, TT_InlineASMColon);
   EXPECT_TOKEN(Tokens[7], tok::r_brace, TT_InlineASMBrace);
 
-  Tokens = annotate("__asm__ volatile (\n"
+  Tokens = annotate("asm{\n"
+                    "\"a\":\n"
+                    ": x\n"
+                    ":};");
+  ASSERT_EQ(Tokens.size(), 10u) << Tokens;
+  EXPECT_TOKEN(Tokens[0], tok::kw_asm, TT_Unknown);
+  EXPECT_TOKEN(Tokens[1], tok::l_brace, TT_InlineASMBrace);
+  EXPECT_TOKEN(Tokens[3], tok::colon, TT_InlineASMColon);
+  EXPECT_TOKEN(Tokens[4], tok::colon, TT_InlineASMColon);
+  EXPECT_TOKEN(Tokens[6], tok::colon, TT_InlineASMColon);
+  EXPECT_TOKEN(Tokens[7], tok::r_brace, TT_InlineASMBrace);
+
+  Tokens = annotate("__asm__{\n"
+                    "\"a\":\n"
+                    ": x\n"
+                    ":};");
+  ASSERT_EQ(Tokens.size(), 10u) << Tokens;
+  EXPECT_TOKEN(Tokens[0], tok::kw_asm, TT_Unknown);
+  EXPECT_TOKEN(Tokens[1], tok::l_brace, TT_InlineASMBrace);
+  EXPECT_TOKEN(Tokens[3], tok::colon, TT_InlineASMColon);
+  EXPECT_TOKEN(Tokens[4], tok::colon, TT_InlineASMColon);
+  EXPECT_TOKEN(Tokens[6], tok::colon, TT_InlineASMColon);
+  EXPECT_TOKEN(Tokens[7], tok::r_brace, TT_InlineASMBrace);
+
+  Tokens = annotate("__asm (\n"
                     "\"a\":\n"
                     ": x\n"
                     ":);");
-  ASSERT_EQ(Tokens.size(), 11u) << Tokens;
+  ASSERT_EQ(Tokens.size(), 10u) << Tokens;
   EXPECT_TOKEN(Tokens[0], tok::kw_asm, TT_Unknown);
+  EXPECT_TOKEN(Tokens[3], tok::colon, TT_InlineASMColon);
   EXPECT_TOKEN(Tokens[4], tok::colon, TT_InlineASMColon);
-  EXPECT_TOKEN(Tokens[5], tok::colon, TT_InlineASMColon);
-  EXPECT_TOKEN(Tokens[7], tok::colon, TT_InlineASMColon);
+  EXPECT_TOKEN(Tokens[6], tok::colon, TT_InlineASMColon);
 
-  Tokens = annotate("asm volatile (\n"
+  Tokens = annotate("asm (\n"
                     "\"a\":\n"
                     ": x\n"
                     ":);");
-  ASSERT_EQ(Tokens.size(), 11u) << Tokens;
+  ASSERT_EQ(Tokens.size(), 10u) << Tokens;
   EXPECT_TOKEN(Tokens[0], tok::kw_asm, TT_Unknown);
+  EXPECT_TOKEN(Tokens[3], tok::colon, TT_InlineASMColon);
   EXPECT_TOKEN(Tokens[4], tok::colon, TT_InlineASMColon);
-  EXPECT_TOKEN(Tokens[5], tok::colon, TT_InlineASMColon);
-  EXPECT_TOKEN(Tokens[7], tok::colon, TT_InlineASMColon);
+  EXPECT_TOKEN(Tokens[6], tok::colon, TT_InlineASMColon);
 
-  Tokens = annotate("__asm__ volatile (\n"
+  Tokens = annotate("__asm__ (\n"
+                    "\"a\":\n"
+                    ": x\n"
+                    ":);");
+  ASSERT_EQ(Tokens.size(), 10u) << Tokens;
+  EXPECT_TOKEN(Tokens[0], tok::kw_asm, TT_Unknown);
+  EXPECT_TOKEN(Tokens[3], tok::colon, TT_InlineASMColon);
+  EXPECT_TOKEN(Tokens[4], tok::colon, TT_InlineASMColon);
+  EXPECT_TOKEN(Tokens[6], tok::colon, TT_InlineASMColon);
+
+  Tokens = annotate("__asm volatile (\n"
                     "\"a_label:\"\n"
                     ":\n"
                     ": x\n"
@@ -1540,6 +1574,86 @@ TEST_F(TokenAnnotatorTest, UnderstandsAsm) {
   EXPECT_TOKEN(Tokens[4], tok::colon, TT_InlineASMColon);
   EXPECT_TOKEN(Tokens[5], tok::colon, TT_InlineASMColon);
   EXPECT_TOKEN(Tokens[7], tok::colon, TT_InlineASMColon);
+
+  Tokens = annotate("__asm__ volatile (\n"
+                    "\"a_label:\"\n"
+                    ":\n"
+                    ": x\n"
+                    ":);");
+  ASSERT_EQ(Tokens.size(), 11u) << Tokens;
+  EXPECT_TOKEN(Tokens[0], tok::kw_asm, TT_Unknown);
+  EXPECT_TOKEN(Tokens[4], tok::colon, TT_InlineASMColon);
+  EXPECT_TOKEN(Tokens[5], tok::colon, TT_InlineASMColon);
+  EXPECT_TOKEN(Tokens[7], tok::colon, TT_InlineASMColon);
+
+  Tokens = annotate("__asm (\n"
+                    "\"a_label:\"\n"
+                    ": x\n"
+                    ":\n"
+                    ": y);");
+  ASSERT_EQ(Tokens.size(), 11u) << Tokens;
+  EXPECT_TOKEN(Tokens[0], tok::kw_asm, TT_Unknown);
+  EXPECT_TOKEN(Tokens[3], tok::colon, TT_InlineASMColon);
+  EXPECT_TOKEN(Tokens[5], tok::colon, TT_InlineASMColon);
+  EXPECT_TOKEN(Tokens[6], tok::colon, TT_InlineASMColon);
+
+  Tokens = annotate("asm (\n"
+                    "\"a_label:\"\n"
+                    ": x\n"
+                    ":\n"
+                    ": y);");
+  ASSERT_EQ(Tokens.size(), 11u) << Tokens;
+  EXPECT_TOKEN(Tokens[0], tok::kw_asm, TT_Unknown);
+  EXPECT_TOKEN(Tokens[3], tok::colon, TT_InlineASMColon);
+  EXPECT_TOKEN(Tokens[5], tok::colon, TT_InlineASMColon);
+  EXPECT_TOKEN(Tokens[6], tok::colon, TT_InlineASMColon);
+
+  Tokens = annotate("__asm__ (\n"
+                    "\"a_label:\"\n"
+                    ": x\n"
+                    ":\n"
+                    ": y);");
+  ASSERT_EQ(Tokens.size(), 11u) << Tokens;
+  EXPECT_TOKEN(Tokens[0], tok::kw_asm, TT_Unknown);
+  EXPECT_TOKEN(Tokens[3], tok::colon, TT_InlineASMColon);
+  EXPECT_TOKEN(Tokens[5], tok::colon, TT_InlineASMColon);
+  EXPECT_TOKEN(Tokens[6], tok::colon, TT_InlineASMColon);
+
+  Tokens = annotate("__asm volatile (\n"
+                    "\"a_label:\"\n"
+                    "\"a b c(%%x)\"\n"
+                    ":\n"
+                    ": x\n"
+                    ":);");
+  ASSERT_EQ(Tokens.size(), 12u) << Tokens;
+  EXPECT_TOKEN(Tokens[0], tok::kw_asm, TT_Unknown);
+  EXPECT_TOKEN(Tokens[5], tok::colon, TT_InlineASMColon);
+  EXPECT_TOKEN(Tokens[6], tok::colon, TT_InlineASMColon);
+  EXPECT_TOKEN(Tokens[8], tok::colon, TT_InlineASMColon);
+
+  Tokens = annotate("__asm volatile (\n"
+                    "\"a_label:\"\n"
+                    "\"a b c(%%x)\"\n"
+                    ":\n"
+                    ": x\n"
+                    ":);");
+  ASSERT_EQ(Tokens.size(), 12u) << Tokens;
+  EXPECT_TOKEN(Tokens[0], tok::kw_asm, TT_Unknown);
+  EXPECT_TOKEN(Tokens[5], tok::colon, TT_InlineASMColon);
+  EXPECT_TOKEN(Tokens[6], tok::colon, TT_InlineASMColon);
+  EXPECT_TOKEN(Tokens[8], tok::colon, TT_InlineASMColon);
+
+  Tokens = annotate("asm volatile (\n"
+                    "\"a_label:\"\n"
+                    "\"a b c(%%x)\"\n"
+                    ":\n"
+                    ": x\n"
+                    ":);");
+  ASSERT_EQ(Tokens.size(), 12u) << Tokens;
+  EXPECT_TOKEN(Tokens[0], tok::kw_asm, TT_Unknown);
+  EXPECT_TOKEN(Tokens[5], tok::colon, TT_InlineASMColon);
+  EXPECT_TOKEN(Tokens[6], tok::colon, TT_InlineASMColon);
+  EXPECT_TOKEN(Tokens[8], tok::colon, TT_InlineASMColon);
 
   Tokens = annotate("__asm__ volatile (\n"
                     "\"a_label:\"\n"
@@ -1553,16 +1667,58 @@ TEST_F(TokenAnnotatorTest, UnderstandsAsm) {
   EXPECT_TOKEN(Tokens[6], tok::colon, TT_InlineASMColon);
   EXPECT_TOKEN(Tokens[8], tok::colon, TT_InlineASMColon);
 
-  Tokens = annotate("__asm__ volatile (\n"
+  Tokens = annotate("__asm (\n"
                     "\"insn\"\n"
                     ": \"=r\" (var1), \"=&r\" (value)\n"
                     ":\n"
                     ": \"memory\");");
-  ASSERT_EQ(Tokens.size(), 20u) << Tokens;
+  ASSERT_EQ(Tokens.size(), 19u) << Tokens;
+  EXPECT_TOKEN(Tokens[0], tok::kw_asm, TT_Unknown);
+  EXPECT_TOKEN(Tokens[3], tok::colon, TT_InlineASMColon);
+  EXPECT_TOKEN(Tokens[13], tok::colon, TT_InlineASMColon);
+  EXPECT_TOKEN(Tokens[14], tok::colon, TT_InlineASMColon);
+
+  Tokens = annotate("asm (\n"
+                    "\"insn\"\n"
+                    ": \"=r\" (var1), \"=&r\" (value)\n"
+                    ":\n"
+                    ": \"memory\");");
+  ASSERT_EQ(Tokens.size(), 19u) << Tokens;
+  EXPECT_TOKEN(Tokens[0], tok::kw_asm, TT_Unknown);
+  EXPECT_TOKEN(Tokens[3], tok::colon, TT_InlineASMColon);
+  EXPECT_TOKEN(Tokens[13], tok::colon, TT_InlineASMColon);
+  EXPECT_TOKEN(Tokens[14], tok::colon, TT_InlineASMColon);
+
+  Tokens = annotate("__asm__ (\n"
+                    "\"insn\"\n"
+                    ": \"=r\" (var1), \"=&r\" (value)\n"
+                    ":\n"
+                    ": \"memory\");");
+  ASSERT_EQ(Tokens.size(), 19u) << Tokens;
+  EXPECT_TOKEN(Tokens[0], tok::kw_asm, TT_Unknown);
+  EXPECT_TOKEN(Tokens[3], tok::colon, TT_InlineASMColon);
+  EXPECT_TOKEN(Tokens[13], tok::colon, TT_InlineASMColon);
+  EXPECT_TOKEN(Tokens[14], tok::colon, TT_InlineASMColon);
+
+  Tokens = annotate("__asm volatile (\n"
+                    "\"ldr r1, [r0, %%[sym]]\"\n"
+                    ":\n"
+                    ": [sym] \"J\" (aaaaa(aaaa, aaaa))\n"
+                    ");");
+  ASSERT_EQ(Tokens.size(), 21u) << Tokens;
   EXPECT_TOKEN(Tokens[0], tok::kw_asm, TT_Unknown);
   EXPECT_TOKEN(Tokens[4], tok::colon, TT_InlineASMColon);
-  EXPECT_TOKEN(Tokens[14], tok::colon, TT_InlineASMColon);
-  EXPECT_TOKEN(Tokens[15], tok::colon, TT_InlineASMColon);
+  EXPECT_TOKEN(Tokens[5], tok::colon, TT_InlineASMColon);
+
+  Tokens = annotate("asm volatile (\n"
+                    "\"ldr r1, [r0, %%[sym]]\"\n"
+                    ":\n"
+                    ": [sym] \"J\" (aaaaa(aaaa, aaaa))\n"
+                    ");");
+  ASSERT_EQ(Tokens.size(), 21u) << Tokens;
+  EXPECT_TOKEN(Tokens[0], tok::kw_asm, TT_Unknown);
+  EXPECT_TOKEN(Tokens[4], tok::colon, TT_InlineASMColon);
+  EXPECT_TOKEN(Tokens[5], tok::colon, TT_InlineASMColon);
 
   Tokens = annotate("__asm__ volatile (\n"
                     "\"ldr r1, [r0, %%[sym]]\"\n"

--- a/clang/unittests/Format/TokenAnnotatorTest.cpp
+++ b/clang/unittests/Format/TokenAnnotatorTest.cpp
@@ -1489,11 +1489,25 @@ TEST_F(TokenAnnotatorTest, RequiresDoesNotChangeParsingOfTheRest) {
 TEST_F(TokenAnnotatorTest, UnderstandsAsm) {
   auto Tokens = annotate("__asm{\n"
                          "a:\n"
-                         "};");
-  ASSERT_EQ(Tokens.size(), 7u) << Tokens;
+                         ": x\n"
+                         ":};");
+  ASSERT_EQ(Tokens.size(), 10u) << Tokens;
   EXPECT_TOKEN(Tokens[0], tok::kw_asm, TT_Unknown);
   EXPECT_TOKEN(Tokens[1], tok::l_brace, TT_InlineASMBrace);
-  EXPECT_TOKEN(Tokens[4], tok::r_brace, TT_InlineASMBrace);
+  EXPECT_TOKEN(Tokens[3], tok::colon, TT_InlineASMColon);
+  EXPECT_TOKEN(Tokens[4], tok::colon, TT_InlineASMColon);
+  EXPECT_TOKEN(Tokens[6], tok::colon, TT_InlineASMColon);
+  EXPECT_TOKEN(Tokens[7], tok::r_brace, TT_InlineASMBrace);
+
+  Tokens = annotate("__asm__ volatile (\n"
+                    "a:\n"
+                    ": x\n"
+                    ":);");
+  ASSERT_EQ(Tokens.size(), 11u) << Tokens;
+  EXPECT_TOKEN(Tokens[0], tok::kw_asm, TT_Unknown);
+  EXPECT_TOKEN(Tokens[4], tok::colon, TT_InlineASMColon);
+  EXPECT_TOKEN(Tokens[5], tok::colon, TT_InlineASMColon);
+  EXPECT_TOKEN(Tokens[7], tok::colon, TT_InlineASMColon);
 }
 
 TEST_F(TokenAnnotatorTest, UnderstandsObjCBlock) {


### PR DESCRIPTION
Short-circuit the parsing of tok::colon to label colons found within lines starting with asm as InlineASMColon.

Fixes #92616.