### PR TITLE
[ThinLTO]Sort imported GUIDs before cache key update

### DIFF
--- a/llvm/lib/LTO/LTO.cpp
+++ b/llvm/lib/LTO/LTO.cpp
@@ -209,9 +209,7 @@ void llvm::computeLTOCacheKey(
     ImportedGUIDs.clear();
     for (auto &Fn : Entry.getFunctions())
       ImportedGUIDs.push_back(Fn);
-
     llvm::sort(ImportedGUIDs);
-
     for (auto &GUID : ImportedGUIDs)
       AddUint64(GUID);
   }

--- a/llvm/lib/LTO/LTO.cpp
+++ b/llvm/lib/LTO/LTO.cpp
@@ -199,13 +199,21 @@ void llvm::computeLTOCacheKey(
              [](const ImportModule &Lhs, const ImportModule &Rhs) -> bool {
                return Lhs.getHash() < Rhs.getHash();
              });
+  std::vector<uint64_t> ImportedGUIDs;
   for (const ImportModule &Entry : ImportModulesVector) {
     auto ModHash = Entry.getHash();
     Hasher.update(ArrayRef<uint8_t>((uint8_t *)&ModHash[0], sizeof(ModHash)));
 
     AddUint64(Entry.getFunctions().size());
+
+    ImportedGUIDs.clear();
     for (auto &Fn : Entry.getFunctions())
-      AddUint64(Fn);
+      ImportedGUIDs.push_back(Fn);
+
+    llvm::sort(ImportedGUIDs);
+
+    for (auto &GUID : ImportedGUIDs)
+      AddUint64(GUID);
   }
 
   // Include the hash for the resolved ODR.


### PR DESCRIPTION
@MaskRay points out `std::` doesn't randomize the iteration order of `unordered_{set,map}`, and the iteration order for single build is deterministic.

Specifically, add 'sort' here since it's helpful when container type changes (for example, https://github.com/llvm/llvm-project/pull/88024 wants to change container type from `unordered_set` to `DenseMap)