### PR TITLE
[AMDGPU] Only set Info.memVT when not later overridden

### DIFF
--- a/llvm/lib/Target/AMDGPU/SIISelLowering.cpp
+++ b/llvm/lib/Target/AMDGPU/SIISelLowering.cpp
@@ -1233,13 +1233,13 @@ bool SITargetLowering::getTgtMemIntrinsic(IntrinsicInfo &Info,
       // Atomic
       Info.opc = CI.getType()->isVoidTy() ? ISD::INTRINSIC_VOID :
                                             ISD::INTRINSIC_W_CHAIN;
-      Info.memVT = MVT::getVT(CI.getArgOperand(0)->getType());
       Info.flags |= MachineMemOperand::MOLoad |
                     MachineMemOperand::MOStore |
                     MachineMemOperand::MODereferenceable;
 
       switch (IntrID) {
       default:
+        Info.memVT = MVT::getVT(CI.getArgOperand(0)->getType());
         // XXX - Should this be volatile without known ordering?
         Info.flags |= MachineMemOperand::MOVolatile;
         break;


### PR DESCRIPTION
For the amdgcn_*_buffer_load_lds intrinsics this field is later overriden, so avoid pointlessly calling MVT::getVT in that case. Importantly, this is also the only case I can find in tree where a PointerType is passed to MVT::getVT, so this will allow us to forbid doing so in future, keeping MVT::iPTR as originating solely from TableGen as was claimed next to its definition in MachineValueType.h (but lost in the autogeneration conversion).