### PR TITLE
[clang-format] Fix bad spacing of macro after lambda introducer

### DIFF
--- a/clang/lib/Format/TokenAnnotator.cpp
+++ b/clang/lib/Format/TokenAnnotator.cpp
@@ -76,6 +76,13 @@ static bool isLambdaParameterList(const FormatToken *Left) {
          Left->Previous->MatchingParen->is(TT_LambdaLSquare);
 }
 
+/// Returns \c true if the token is the right square bracket of a lambda
+/// introducer.
+static bool isLambdaRightIntroducerBracket(const FormatToken &Tok) {
+  return Tok.is(tok::r_square) && Tok.MatchingParen &&
+    Tok.MatchingParen->is(TT_LambdaLSquare);
+}
+
 /// Returns \c true if the token is followed by a boolean condition, \c false
 /// otherwise.
 static bool isKeywordWithCondition(const FormatToken &Tok) {
@@ -4645,6 +4652,23 @@ bool TokenAnnotator::spaceRequiredBetween(const AnnotatedLine &Line,
     if (Left.is(TT_AttributeRParen) ||
         (Left.is(tok::r_square) && Left.is(TT_AttributeSquare))) {
       return true;
+    }
+    if (Left.is(tok::identifier) && Left.Previous &&
+        isLambdaRightIntroducerBracket(*Left.Previous)) {
+      // Check if Right is part of a macro call
+      if (Right.MatchingParen && Right.MatchingParen->Next &&
+          Right.MatchingParen->Next->is(tok::l_paren)) {
+        return false;
+      }
+      return true;
+    }
+    if (Left.is(tok::r_paren) && Left.MatchingParen &&
+        Left.MatchingParen->Previous) {
+      auto const *LeftParenPrev = Left.MatchingParen->Previous;
+      if (LeftParenPrev->is(tok::identifier) && LeftParenPrev->Previous &&
+          isLambdaRightIntroducerBracket(*LeftParenPrev->Previous)) {
+        return true;
+      }
     }
     if (Left.is(TT_ForEachMacro)) {
       return Style.SpaceBeforeParensOptions.AfterForeachMacros ||

--- a/clang/unittests/Format/FormatTest.cpp
+++ b/clang/unittests/Format/FormatTest.cpp
@@ -16639,6 +16639,9 @@ TEST_F(FormatTest, ConfigurableSpaceBeforeParens) {
   verifyFormat("T A::operator()();", NoSpace);
   verifyFormat("X A::operator++(T);", NoSpace);
   verifyFormat("auto lambda = []() { return 0; };", NoSpace);
+  verifyFormat("auto lambda = [] [[attr]] () { return 0; };", NoSpace);
+  verifyFormat("auto lambda = [] MACRO_ATTR () { return 0; };", NoSpace);
+  verifyFormat("auto lambda = [] FN_MACRO_ATTR(a, (b + c)) () { return 0; };", NoSpace);
   verifyFormat("#if (foo || bar) && baz\n"
                "#elif ((a || b) && c) || d\n"
                "#endif",
@@ -16696,6 +16699,9 @@ TEST_F(FormatTest, ConfigurableSpaceBeforeParens) {
   verifyFormat("T A::operator() ();", Space);
   verifyFormat("X A::operator++ (T);", Space);
   verifyFormat("auto lambda = [] () { return 0; };", Space);
+  verifyFormat("auto lambda = [] [[attr]] () { return 0; };", Space);
+  verifyFormat("auto lambda = [] MACRO_ATTR () { return 0; };", Space);
+  verifyFormat("auto lambda = [] FN_MACRO_ATTR(a, (b + c)) () { return 0; };", Space);
   verifyFormat("int x = int (y);", Space);
   verifyFormat("#define F(...) __VA_OPT__ (__VA_ARGS__)", Space);
   verifyFormat("__builtin_LINE ()", Space);
@@ -16756,6 +16762,9 @@ TEST_F(FormatTest, ConfigurableSpaceBeforeParens) {
   verifyFormat("X A::operator++ (T);", SomeSpace);
   verifyFormat("int x = int (y);", SomeSpace);
   verifyFormat("auto lambda = []() { return 0; };", SomeSpace);
+  verifyFormat("auto lambda = [] [[attr]] () { return 0; };", SomeSpace);
+  verifyFormat("auto lambda = [] MACRO_ATTR () { return 0; };", SomeSpace);
+  verifyFormat("auto lambda = [] FN_MACRO_ATTR(a, (b + c)) () { return 0; };", SomeSpace);
 
   FormatStyle SpaceControlStatements = getLLVMStyle();
   SpaceControlStatements.SpaceBeforeParens = FormatStyle::SBPO_Custom;


### PR DESCRIPTION
Fixes  #92661.

Also fixes the same problem applied to function-style macros, which I didn't consider when creating that issue.