### PR TITLE
[ctx_profile] Fix integration test  when `LLVM_ENABLE_PER_TARGET_RUNTIME_DIR=Off`

### DIFF
--- a/compiler-rt/test/ctx_profile/TestCases/generate-context.cpp
+++ b/compiler-rt/test/ctx_profile/TestCases/generate-context.cpp
@@ -5,7 +5,7 @@
 // RUN: cp %llvm_src/include/llvm/ProfileData/CtxInstrContextNode.h %t_include/
 //
 // Compile with ctx instrumentation "on". We treat "theRoot" as callgraph root.
-// RUN: %clangxx %s -lclang_rt.ctx_profile -I%t_include -O2 -o %t.bin -mllvm -profile-context-root=theRoot
+// RUN: %clangxx %s %libctxprof -I%t_include -O2 -o %t.bin -mllvm -profile-context-root=theRoot
 //
 // Run the binary, and observe the profile fetch handler's output.
 // RUN: %t.bin | FileCheck %s

--- a/compiler-rt/test/ctx_profile/lit.cfg.py
+++ b/compiler-rt/test/ctx_profile/lit.cfg.py
@@ -33,3 +33,15 @@ config.suffixes = [".c", ".cpp", ".test"]
 config.substitutions.append(
     ("%clangxx ", " ".join([config.clang] + config.cxx_mode_flags) + " -ldl -lpthread ")
 )
+
+config.substitutions.append(
+    (
+        "%libctxprof",
+        " ".join(
+            [
+                f"-lclang_rt.ctx_profile{config.target_suffix}",
+                f"-L{config.compiler_rt_libdir}",
+            ]
+        ),
+    )
+)


### PR DESCRIPTION
When `LLVM_ENABLE_PER_TARGET_RUNTIME_DIR=Off` the library name has the architecture part of its name. Just passing `-lclang_rt.ctx_profile` isn't sufficient, we need to append the suffix and also pass the lib dir.

(Follow-up from #92456)