### PR TITLE
[Sema] Fix an out-of-bounds crash when diagnosing bad conversion for a function with a parameter pack.

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -629,6 +629,8 @@ Bug Fixes in This Version
 - ``__is_array`` and ``__is_bounded_array`` no longer return ``true`` for
   zero-sized arrays. Fixes (#GH54705).
 
+- Fix an out-of-bounds crash when diagnosing bad conversion for a function with a parameter pack. 
+
 Bug Fixes to Compiler Builtins
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/clang/lib/Sema/SemaOverload.cpp
+++ b/clang/lib/Sema/SemaOverload.cpp
@@ -11305,9 +11305,15 @@ static void DiagnoseBadConversion(Sema &S, OverloadCandidate *Cand,
   if (!isObjectArgument) {
     if (I < Fn->getNumParams())
       ToParamRange = Fn->getParamDecl(I)->getSourceRange();
-    else
-      // parameter pack case.
-      ToParamRange = Fn->parameters().back()->getSourceRange();
+    else {
+      // For the parameter pack case, diagnose on the first pack.
+      for (const auto* ParamDecl : Fn->parameters()) {
+        if (ParamDecl->isParameterPack()) {
+          ToParamRange = ParamDecl->getSourceRange();
+          break;
+        }
+      }
+    }
   }
 
   if (FromTy == S.Context.OverloadTy) {

--- a/clang/lib/Sema/SemaOverload.cpp
+++ b/clang/lib/Sema/SemaOverload.cpp
@@ -11301,8 +11301,14 @@ static void DiagnoseBadConversion(Sema &S, OverloadCandidate *Cand,
   Expr *FromExpr = Conv.Bad.FromExpr;
   QualType FromTy = Conv.Bad.getFromType();
   QualType ToTy = Conv.Bad.getToType();
-  SourceRange ToParamRange =
-      !isObjectArgument ? Fn->getParamDecl(I)->getSourceRange() : SourceRange();
+  SourceRange ToParamRange;
+  if (!isObjectArgument) {
+    if (I < Fn->getNumParams())
+      ToParamRange = Fn->getParamDecl(I)->getSourceRange();
+    else
+      // parameter pack case.
+      ToParamRange = Fn->parameters().back()->getSourceRange();
+  }
 
   if (FromTy == S.Context.OverloadTy) {
     assert(FromExpr && "overload set argument came from implicit argument?");

--- a/clang/test/Misc/diag-overload-cand-ranges.cpp
+++ b/clang/test/Misc/diag-overload-cand-ranges.cpp
@@ -70,3 +70,11 @@ template <short T> class Type1 {};
 template <short T> void Function1(int zz, Type1<T> &x, int ww) {}
 
 void Function() { Function1(33, Type1<-42>(), 66); }
+
+// CHECK:      error: no matching function for call to 'b'
+// CHECK:      :{[[@LINE+1]]:41-[[@LINE+1]]:45}: note: {{.*}} no known conversion from 'int' to 'ForwardClass' for 3rd argument
+template <class T, class...U> void b(T, U...);
+class ForwardClass;
+void NoCrash() {
+  b<int, int, ForwardClass>(1, 1, 0);
+}

--- a/clang/test/Misc/diag-overload-cand-ranges.cpp
+++ b/clang/test/Misc/diag-overload-cand-ranges.cpp
@@ -1,4 +1,4 @@
-// RUN: not %clang_cc1 -fsyntax-only -fdiagnostics-print-source-range-info %s 2>&1 | FileCheck %s --strict-whitespace
+// RUN: not %clang_cc1 -fsyntax-only -fdiagnostics-print-source-range-info -std=c++20 %s 2>&1 | FileCheck %s --strict-whitespace
 // CHECK:      error: no matching function
 template <typename T> struct mcdata {
   typedef int result_type;
@@ -74,7 +74,11 @@ void Function() { Function1(33, Type1<-42>(), 66); }
 // CHECK:      error: no matching function for call to 'b'
 // CHECK:      :{[[@LINE+1]]:41-[[@LINE+1]]:45}: note: {{.*}} no known conversion from 'int' to 'ForwardClass' for 3rd argument
 template <class T, class...U> void b(T, U...);
+// CHECK:      error: no matching function for call to 'abbreviated_func'
+// CHECK:      :{[[@LINE+1]]:23-[[@LINE+1]]:30}: note: {{.*}} no known conversion from 'int' to 'ForwardClass' for 3rd argument
+void abbreviated_func(auto..., auto...); // diagnose on the first parameter
 class ForwardClass;
 void NoCrash() {
   b<int, int, ForwardClass>(1, 1, 0);
+  abbreviated_func<int, int, ForwardClass>(1, 1, 0);
 }


### PR DESCRIPTION
This fixes a regression issue caused by 176981ac58d3e4beb02b9d110524e72be509375d.

When clang diagnoses bad conversion on a particular function parameter, we use the Index `I` to get the corresponding parameter from the primary function decl, the `I` is the index of function parameter after template instantations, so we can hit an out-of-bounds crash when accessing the `I`th function parameter if the function has pack parameters. This PR fixes it. 