### PR TITLE
[FileCheck] forbid filecheck check prefix definitions to end with directive name

### DIFF
--- a/clang-tools-extra/test/clang-move/move-class.cpp
+++ b/clang-tools-extra/test/clang-move/move-class.cpp
@@ -9,8 +9,8 @@
 // RUN: clang-move -names="a::Foo" -new_cc=%T/clang-move/new_test.cpp -new_header=%T/clang-move/new_test.h -old_cc=../src/test.cpp -old_header=../include/test.h %T/clang-move/src/test.cpp
 // RUN: FileCheck -input-file=%T/clang-move/new_test.cpp -check-prefix=CHECK-NEW-TEST-CPP %s
 // RUN: FileCheck -input-file=%T/clang-move/new_test.h -check-prefix=CHECK-NEW-TEST-H %s
-// RUN: FileCheck -input-file=%T/clang-move/src/test.cpp -check-prefix=CHECK-OLD-TEST-EMPTY -allow-empty %s
-// RUN: FileCheck -input-file=%T/clang-move/include/test.h -check-prefix=CHECK-OLD-TEST-EMPTY -allow-empty %s
+// RUN: FileCheck -input-file=%T/clang-move/src/test.cpp -check-prefix=CHECK-OLD-TEST -allow-empty %s
+// RUN: FileCheck -input-file=%T/clang-move/include/test.h -check-prefix=CHECK-OLD-TEST -allow-empty %s
 //
 // RUN: cp %S/Inputs/test.h  %T/clang-move/include
 // RUN: cp %S/Inputs/test.cpp %T/clang-move/src
@@ -18,8 +18,8 @@
 // RUN: clang-move -names="a::Foo" -new_cc=%T/clang-move/new_test.cpp -new_header=%T/clang-move/new_test.h -old_cc=%T/clang-move/src/test.cpp -old_header=%T/clang-move/include/test.h %T/clang-move/src/test.cpp
 // RUN: FileCheck -input-file=%T/clang-move/new_test.cpp -check-prefix=CHECK-NEW-TEST-CPP %s
 // RUN: FileCheck -input-file=%T/clang-move/new_test.h -check-prefix=CHECK-NEW-TEST-H %s
-// RUN: FileCheck -input-file=%T/clang-move/src/test.cpp -check-prefix=CHECK-OLD-TEST-EMPTY -allow-empty %s
-// RUN: FileCheck -input-file=%T/clang-move/include/test.h -check-prefix=CHECK-OLD-TEST-EMPTY -allow-empty %s
+// RUN: FileCheck -input-file=%T/clang-move/src/test.cpp -check-prefix=CHECK-OLD-TEST -allow-empty %s
+// RUN: FileCheck -input-file=%T/clang-move/include/test.h -check-prefix=CHECK-OLD-TEST -allow-empty %s
 //
 //
 // CHECK-NEW-TEST-H: #ifndef TEST_H // comment 1
@@ -40,4 +40,4 @@
 // CHECK-NEW-TEST-CPP: int Foo::f2(int a, int b) { return a + b; }
 // CHECK-NEW-TEST-CPP: } // namespace a
 //
-// CHECK-OLD-TEST-EMPTY: {{^}}{{$}}
+// CHECK-OLD-TEST: {{^}}{{$}}

--- a/clang-tools-extra/test/clang-move/move-enum-decl.cpp
+++ b/clang-tools-extra/test/clang-move/move-enum-decl.cpp
@@ -39,6 +39,6 @@
 // RUN: cp %S/Inputs/enum.h  %T/move-enum/enum.h
 // RUN: echo '#include "enum.h"' > %T/move-enum/enum.cpp
 // RUN: clang-move -names="a::C::E3" -new_cc=%T/move-enum/new_test.cpp -new_header=%T/move-enum/new_test.h -old_cc=%T/move-enum/enum.cpp -old_header=%T/move-enum/enum.h %T/move-enum/enum.cpp -- -std=c++11
-// RUN: FileCheck -input-file=%T/move-enum/new_test.h -allow-empty -check-prefix=CHECK-EMPTY %s
+// RUN: FileCheck -input-file=%T/move-enum/new_test.h -allow-empty -check-prefix=CHECK-CLEAN %s
 
-// CHECK-EMPTY: {{^}}{{$}}
+// CHECK-CLEAN: {{^}}{{$}}

--- a/clang-tools-extra/test/clang-move/move-function.cpp
+++ b/clang-tools-extra/test/clang-move/move-function.cpp
@@ -42,9 +42,9 @@
 //
 // RUN: cat %S/Inputs/function_test.h > %T/move-function/function_test.h
 // RUN: cat %S/Inputs/function_test.cpp > %T/move-function/function_test.cpp
-// RUN: clang-move -names="A::f" -new_header=%T/move-function/new_function_test.h -new_cc=%T/move-function/new_function_test.cpp -old_header=../move-function/function_test.h -old_cc=../move-function/function_test.cpp %T/move-function/function_test.cpp -dump_result -- | FileCheck %s -check-prefix=CHECK-EMPTY
+// RUN: clang-move -names="A::f" -new_header=%T/move-function/new_function_test.h -new_cc=%T/move-function/new_function_test.cpp -old_header=../move-function/function_test.h -old_cc=../move-function/function_test.cpp %T/move-function/function_test.cpp -dump_result -- | FileCheck %s -check-prefix=CHECK-CLEAN
 //
-// CHECK-EMPTY: [{{[[:space:]]*}}]
+// CHECK-CLEAN: [{{[[:space:]]*}}]
 //
 // RUN: cat %S/Inputs/function_test.h > %T/move-function/function_test.h
 // RUN: cat %S/Inputs/function_test.cpp > %T/move-function/function_test.cpp

--- a/clang-tools-extra/test/clang-move/move-multiple-classes.cpp
+++ b/clang-tools-extra/test/clang-move/move-multiple-classes.cpp
@@ -1,14 +1,14 @@
 // RUN: mkdir -p %T/move-multiple-classes
 // RUN: cp %S/Inputs/multiple_class_test*  %T/move-multiple-classes/
 // RUN: cd %T/move-multiple-classes
-// RUN: clang-move -names="c::EnclosingMove5::Nested" -new_cc=%T/move-multiple-classes/new_multiple_class_test.cpp -new_header=%T/move-multiple-classes/new_multiple_class_test.h -old_cc=%T/move-multiple-classes/multiple_class_test.cpp -old_header=../move-multiple-classes/multiple_class_test.h -dump_result %T/move-multiple-classes/multiple_class_test.cpp -- -std=c++11| FileCheck %s -check-prefix=CHECK-EMPTY
+// RUN: clang-move -names="c::EnclosingMove5::Nested" -new_cc=%T/move-multiple-classes/new_multiple_class_test.cpp -new_header=%T/move-multiple-classes/new_multiple_class_test.h -old_cc=%T/move-multiple-classes/multiple_class_test.cpp -old_header=../move-multiple-classes/multiple_class_test.h -dump_result %T/move-multiple-classes/multiple_class_test.cpp -- -std=c++11| FileCheck %s -check-prefix=CHECK-CLEAN
 // RUN: clang-move -names="a::Move1, b::Move2,c::Move3,c::Move4,c::EnclosingMove5" -new_cc=%T/move-multiple-classes/new_multiple_class_test.cpp -new_header=%T/move-multiple-classes/new_multiple_class_test.h -old_cc=%T/move-multiple-classes/multiple_class_test.cpp -old_header=../move-multiple-classes/multiple_class_test.h %T/move-multiple-classes/multiple_class_test.cpp -- -std=c++11
 // RUN: FileCheck -input-file=%T/move-multiple-classes/new_multiple_class_test.cpp -check-prefix=CHECK-NEW-TEST-CPP %s
 // RUN: FileCheck -input-file=%T/move-multiple-classes/new_multiple_class_test.h -check-prefix=CHECK-NEW-TEST-H %s
 // RUN: FileCheck -input-file=%T/move-multiple-classes/multiple_class_test.cpp -check-prefix=CHECK-OLD-TEST-CPP %s
 // RUN: FileCheck -input-file=%T/move-multiple-classes/multiple_class_test.h -check-prefix=CHECK-OLD-TEST-H %s
 //
-// CHECK-EMPTY: [{{[[:space:]]*}}]
+// CHECK-CLEAN: [{{[[:space:]]*}}]
 //
 // CHECK-OLD-TEST-H: namespace c {
 // CHECK-OLD-TEST-H: class NoMove {

--- a/clang-tools-extra/test/clang-move/move-template-class.cpp
+++ b/clang-tools-extra/test/clang-move/move-template-class.cpp
@@ -2,8 +2,8 @@
 // RUN: cp %S/Inputs/template_class_test*  %T/move-template-class
 // RUN: cd %T/move-template-class
 // RUN: clang-move -names="A,B" -new_cc=%T/move-template-class/new_template_class_test.cpp -new_header=%T/move-template-class/new_template_class_test.h -old_cc=%T/move-template-class/template_class_test.cpp -old_header=../move-template-class/template_class_test.h %T/move-template-class/template_class_test.cpp --
-// RUN: FileCheck -input-file=%T/move-template-class/template_class_test.cpp -check-prefix=CHECK-OLD-TEST-EMPTY -allow-empty %s
-// RUN: FileCheck -input-file=%T/move-template-class/template_class_test.h -check-prefix=CHECK-OLD-TEST-EMPTY -allow-empty %s
+// RUN: FileCheck -input-file=%T/move-template-class/template_class_test.cpp -check-prefix=CHECK-OLD-TEST -allow-empty %s
+// RUN: FileCheck -input-file=%T/move-template-class/template_class_test.h -check-prefix=CHECK-OLD-TEST -allow-empty %s
 // RUN: FileCheck -input-file=%T/move-template-class/new_template_class_test.cpp -check-prefix=CHECK-NEW-TEST-CPP-CASE1 %s
 // RUN: FileCheck -input-file=%T/move-template-class/new_template_class_test.h -check-prefix=CHECK-NEW-TEST-H-CASE1 %s
 //
@@ -15,7 +15,7 @@
 // RUN: FileCheck -input-file=%T/move-template-class/new_template_class_test.cpp -check-prefix=CHECK-NEW-TEST-CPP-CASE2 %s
 //
 //
-// CHECK-OLD-TEST-EMPTY: {{^}}{{$}}
+// CHECK-OLD-TEST: {{^}}{{$}}
 //
 // CHECK-NEW-TEST-H-CASE1: #ifndef TEMPLATE_CLASS_TEST_H // comment 1
 // CHECK-NEW-TEST-H-CASE1: #define TEMPLATE_CLASS_TEST_H

--- a/clang-tools-extra/test/clang-move/move-type-alias.cpp
+++ b/clang-tools-extra/test/clang-move/move-type-alias.cpp
@@ -47,6 +47,6 @@
 // RUN: cp %S/Inputs/type_alias.h  %T/move-type-alias/type_alias.h
 // RUN: echo '#include "type_alias.h"' > %T/move-type-alias/type_alias.cpp
 // RUN: clang-move -names="C::Int3" -new_cc=%T/move-type-alias/new_test.cpp -new_header=%T/move-type-alias/new_test.h -old_cc=%T/move-type-alias/type_alias.cpp -old_header=%T/move-type-alias/type_alias.h %T/move-type-alias/type_alias.cpp -- -std=c++11
-// RUN: FileCheck -input-file=%T/move-type-alias/new_test.h -allow-empty -check-prefix=CHECK-EMPTY %s
+// RUN: FileCheck -input-file=%T/move-type-alias/new_test.h -allow-empty -check-prefix=CHECK-CLEAN %s
 
-// CHECK-EMPTY: {{^}}{{$}}
+// CHECK-CLEAN: {{^}}{{$}}

--- a/clang-tools-extra/test/clang-move/move-used-helper-decls.cpp
+++ b/clang-tools-extra/test/clang-move/move-used-helper-decls.cpp
@@ -298,8 +298,8 @@
 // RUN: clang-move -names="a::Class1, a::Class2, a::Class3, a::Class4, a::Class5, a::Class5, a::Class6, a::Class7, a::Fun1, a::Fun2, b::Fun3" -new_cc=%T/used-helper-decls/new_helper_decls_test.cpp -new_header=%T/used-helper-decls/new_helper_decls_test.h -old_cc=%T/used-helper-decls/helper_decls_test.cpp -old_header=../used-helper-decls/helper_decls_test.h %T/used-helper-decls/helper_decls_test.cpp -- -std=c++11
 // RUN: FileCheck -input-file=%T/used-helper-decls/new_helper_decls_test.h -check-prefix=CHECK-NEW-H %s
 // RUN: FileCheck -input-file=%T/used-helper-decls/new_helper_decls_test.cpp -check-prefix=CHECK-NEW-CPP %s
-// RUN: FileCheck -input-file=%T/used-helper-decls/helper_decls_test.h -allow-empty -check-prefix=CHECK-EMPTY %s
-// RUN: FileCheck -input-file=%T/used-helper-decls/helper_decls_test.cpp -allow-empty -check-prefix=CHECK-EMPTY %s
+// RUN: FileCheck -input-file=%T/used-helper-decls/helper_decls_test.h -allow-empty -check-prefix=CHECK-CLEAN %s
+// RUN: FileCheck -input-file=%T/used-helper-decls/helper_decls_test.cpp -allow-empty -check-prefix=CHECK-CLEAN %s
 
 
 // CHECK-NEW-H: namespace a {
@@ -435,4 +435,4 @@
 // CHECK-NEW-CPP-NEXT: } // namespace
 // CHECK-NEW-CPP-NEXT: } // namespace b
 
-// CHECK-EMPTY: {{^}}{{$}}
+// CHECK-CLEAN: {{^}}{{$}}

--- a/clang-tools-extra/test/clang-move/no-move-macro-helpers.cpp
+++ b/clang-tools-extra/test/clang-move/no-move-macro-helpers.cpp
@@ -30,8 +30,8 @@
 //
 // RUN: FileCheck -input-file=%T/no-move-macro-helper/new_test.h -check-prefix=CHECK-NEW-TEST-CASE2-H %s
 // RUN: FileCheck -input-file=%T/no-move-macro-helper/new_test.cpp -check-prefix=CHECK-NEW-TEST-CASE2-CPP %s
-// RUN: FileCheck -input-file=%T/no-move-macro-helper/macro_helper_test.h -allow-empty -check-prefix=CHECK-EMPTY %s
-// RUN: FileCheck -input-file=%T/no-move-macro-helper/macro_helper_test.cpp -allow-empty -check-prefix=CHECK-EMPTY %s
+// RUN: FileCheck -input-file=%T/no-move-macro-helper/macro_helper_test.h -allow-empty -check-prefix=CHECK-CLEAN %s
+// RUN: FileCheck -input-file=%T/no-move-macro-helper/macro_helper_test.cpp -allow-empty -check-prefix=CHECK-CLEAN %s
 
 // CHECK-NEW-TEST-CASE2-H: class A {};
 // CHECK-NEW-TEST-CASE2-H-NEXT:void f1();
@@ -40,4 +40,4 @@
 // CHECK-NEW-TEST-CASE2-CPP: DEFINE(test)
 // CHECK-NEW-TEST-CASE2-CPP: void f1() {}
 
-// CHECK-EMPTY: {{^}}{{$}}
+// CHECK-CLEAN: {{^}}{{$}}

--- a/clang/test/CXX/special/class.temporary/p6.cpp
+++ b/clang/test/CXX/special/class.temporary/p6.cpp
@@ -1,5 +1,5 @@
 // RUN: %clang_cc1 -std=c++17 %s -triple x86_64-linux-gnu -emit-llvm -o - | FileCheck %s --implicit-check-not='call{{.*}}dtor'
-// RUN: %clang_cc1 -std=c++23 %s -triple x86_64-linux-gnu -emit-llvm -o - | FileCheck %s --check-prefixes=CHECK-CXX23,CHECK-CXX23-NEXT,CHECK-CXX23-LABEL
+// RUN: %clang_cc1 -std=c++23 %s -triple x86_64-linux-gnu -emit-llvm -o - | FileCheck %s --check-prefixes=CHECK-CXX23
 
 namespace std {
   typedef decltype(sizeof(int)) size_t;

--- a/clang/test/CodeCompletion/ignore-ns-level-decls.cpp
+++ b/clang/test/CodeCompletion/ignore-ns-level-decls.cpp
@@ -15,7 +15,7 @@ void test() {
 // CHECK-1-DAG: COMPLETION: baz : baz
 // CHECK-1-DAG: COMPLETION: func : [#int#]func(<#int a#>, <#bar b#>, <#baz c#>)
 
-// RUN: %clang_cc1 -fsyntax-only -code-completion-at=%s:%(line-6):7 -no-code-completion-ns-level-decls %s -o - | FileCheck %s --allow-empty --check-prefix=CHECK-EMPTY
-// CHECK-EMPTY-NOT: COMPLETION: bar : bar
-// CHECK-EMPTY: {{^}}{{$}}
+// RUN: %clang_cc1 -fsyntax-only -code-completion-at=%s:%(line-6):7 -no-code-completion-ns-level-decls %s -o - | FileCheck %s --allow-empty --check-prefix=CHECK-CLEAN
+// CHECK-CLEAN-NOT: COMPLETION: bar : bar
+// CHECK-CLEAN: {{^}}{{$}}
 }

--- a/clang/test/CodeGen/thinlto_backend.ll
+++ b/clang/test/CodeGen/thinlto_backend.ll
@@ -16,9 +16,9 @@
 ; would not import f2
 ; RUN: touch %t4.thinlto.bc
 ; RUN: %clang -target x86_64-unknown-linux-gnu -O2 -o %t4.o -x ir %t1.o -c -fthinlto-index=%t4.thinlto.bc
-; RUN: llvm-nm %t4.o | FileCheck --check-prefix=CHECK-OBJ-IGNORE-EMPTY %s
-; CHECK-OBJ-IGNORE-EMPTY: T f1
-; CHECK-OBJ-IGNORE-EMPTY: U f2
+; RUN: llvm-nm %t4.o | FileCheck --check-prefix=CHECK-OBJ-IGNORE-CLEAN %s
+; CHECK-OBJ-IGNORE-CLEAN: T f1
+; CHECK-OBJ-IGNORE-CLEAN: U f2
 
 ; Ensure we don't fail with index and non-ThinLTO object file, and output must
 ; be empty file.

--- a/clang/test/CodeGenObjC/constant-strings.m
+++ b/clang/test/CodeGenObjC/constant-strings.m
@@ -1,11 +1,11 @@
 // REQUIRES: x86-registered-target
 
 // RUN: %clang_cc1 -triple x86_64-macho -emit-llvm -o %t %s
-// RUN: FileCheck --check-prefix=CHECK-NEXT < %t %s
+// RUN: FileCheck --check-prefix=CHECK-ALIGN < %t %s
 
 // Check that we set alignment 1 on the string.
 //
-// CHECK-NEXT: @.str = {{.*}}constant [13 x i8] c"Hello World!\00", section "__TEXT,__cstring,cstring_literals", align 1
+// CHECK-ALIGN: @.str = {{.*}}constant [13 x i8] c"Hello World!\00", section "__TEXT,__cstring,cstring_literals", align 1
 
 // RUN: %clang_cc1 -triple x86_64-macho -fobjc-runtime=gcc -emit-llvm -o %t %s
 // RUN: FileCheck --check-prefix=CHECK-GNU < %t %s

--- a/clang/test/Driver/clang_f_opts.c
+++ b/clang/test/Driver/clang_f_opts.c
@@ -190,8 +190,8 @@
 // RUN: %clang -### -S -frounding-math %s 2>&1 | FileCheck -check-prefix=CHECK-ROUNDING-MATH %s
 // CHECK-ROUNDING-MATH: "-cc1"
 // CHECK-ROUNDING-MATH: "-frounding-math"
-// CHECK-ROUNDING-MATH-NOT: "-fno-rounding-math"
-// RUN: %clang -### -S %s 2>&1 | FileCheck -check-prefix=CHECK-ROUNDING-MATH-NOT %s
+// CHECK-NO-ROUNDING-MATH: "-fno-rounding-math"
+// RUN: %clang -### -S %s 2>&1 | FileCheck -check-prefix=CHECK-NO-ROUNDING-MATH %s
 // RUN: not %clang -### -S -ffp-model=imprecise %s 2>&1 | FileCheck -check-prefix=CHECK-FPMODEL %s
 // CHECK-FPMODEL: unsupported argument 'imprecise' to option '-ffp-model='
 // RUN: %clang -### -S -ffp-model=precise %s 2>&1 | FileCheck -check-prefix=IGNORE %s

--- a/clang/test/Driver/darwin-version.c
+++ b/clang/test/Driver/darwin-version.c
@@ -231,9 +231,9 @@
 // CHECK-VERSION-TNO-OSV4: overriding '-miphoneos-version-min=10.1.0.1' option with '-target arm64-apple-ios10.1.0'
 
 // RUN: %clang -target x86_64-apple-macos10.6 -mmacos-version-min=10.6 -c %s -### 2>&1 | \
-// RUN:   FileCheck --check-prefix=CHECK-VERSION-TNO-SAME %s
-// CHECK-VERSION-TNO-SAME-NOT: overriding
-// CHECK-VERSION-TNO-SAME-NOT: argument unused during compilation
+// RUN:   FileCheck --check-prefix=CHECK-VERSION-SAME-TNO %s
+// CHECK-VERSION-SAME-TNO-NOT: overriding
+// CHECK-VERSION-SAME-TNO-NOT: argument unused during compilation
 
 // Target with OS version is not overridden by -m<os>-version-min variables:
 

--- a/clang/test/Driver/debug-prefix-map.c
+++ b/clang/test/Driver/debug-prefix-map.c
@@ -17,12 +17,12 @@
 // RUN: %clang -### -ffile-prefix-map=old=n=ew %s 2>&1 | FileCheck %s -check-prefix CHECK-MACRO-COMPLEX
 // RUN: %clang -### -ffile-prefix-map=old=n=ew %s 2>&1 | FileCheck %s -check-prefix CHECK-COVERAGE-COMPLEX
 
-// RUN: %clang -### -fdebug-prefix-map=old= %s 2>&1 | FileCheck %s -check-prefix CHECK-DEBUG-EMPTY
-// RUN: %clang -### -fmacro-prefix-map=old= %s 2>&1 | FileCheck %s -check-prefix CHECK-MACRO-EMPTY
-// RUN: %clang -### -fcoverage-prefix-map=old= %s 2>&1 | FileCheck %s -check-prefix CHECK-COVERAGE-EMPTY
-// RUN: %clang -### -ffile-prefix-map=old= %s 2>&1 | FileCheck %s -check-prefix CHECK-DEBUG-EMPTY
-// RUN: %clang -### -ffile-prefix-map=old= %s 2>&1 | FileCheck %s -check-prefix CHECK-MACRO-EMPTY
-// RUN: %clang -### -ffile-prefix-map=old= %s 2>&1 | FileCheck %s -check-prefix CHECK-COVERAGE-EMPTY
+// RUN: %clang -### -fdebug-prefix-map=old= %s 2>&1 | FileCheck %s -check-prefix CHECK-DEBUG-CLEAN
+// RUN: %clang -### -fmacro-prefix-map=old= %s 2>&1 | FileCheck %s -check-prefix CHECK-MACRO-CLEAN
+// RUN: %clang -### -fcoverage-prefix-map=old= %s 2>&1 | FileCheck %s -check-prefix CHECK-COVERAGE-CLEAN
+// RUN: %clang -### -ffile-prefix-map=old= %s 2>&1 | FileCheck %s -check-prefix CHECK-DEBUG-CLEAN
+// RUN: %clang -### -ffile-prefix-map=old= %s 2>&1 | FileCheck %s -check-prefix CHECK-MACRO-CLEAN
+// RUN: %clang -### -ffile-prefix-map=old= %s 2>&1 | FileCheck %s -check-prefix CHECK-COVERAGE-CLEAN
 
 // CHECK-DEBUG-INVALID: error: invalid argument 'old' to -fdebug-prefix-map
 // CHECK-MACRO-INVALID: error: invalid argument 'old' to -fmacro-prefix-map
@@ -34,6 +34,6 @@
 // CHECK-DEBUG-COMPLEX: fdebug-prefix-map=old=n=ew
 // CHECK-MACRO-COMPLEX: fmacro-prefix-map=old=n=ew
 // CHECK-COVERAGE-COMPLEX: fcoverage-prefix-map=old=n=ew
-// CHECK-DEBUG-EMPTY: fdebug-prefix-map=old=
-// CHECK-MACRO-EMPTY: fmacro-prefix-map=old=
-// CHECK-COVERAGE-EMPTY: fcoverage-prefix-map=old=
+// CHECK-DEBUG-CLEAN: fdebug-prefix-map=old=
+// CHECK-MACRO-CLEAN: fmacro-prefix-map=old=
+// CHECK-COVERAGE-CLEAN: fcoverage-prefix-map=old=

--- a/clang/test/PCH/badpch.c
+++ b/clang/test/PCH/badpch.c
@@ -1,4 +1,4 @@
-// RUN: not %clang_cc1 -fsyntax-only -include-pch %S/Inputs/badpch-empty.h.gch %s 2>&1 | FileCheck -check-prefix=CHECK-EMPTY %s
+// RUN: not %clang_cc1 -fsyntax-only -include-pch %S/Inputs/badpch-empty.h.gch %s 2>&1 | FileCheck -check-prefix=CHECK-CLEAN %s
 // RUN: not %clang_cc1 -fsyntax-only -include-pch %S/Inputs/badpch-dir.h.gch %s 2>&1 | FileCheck -check-prefix=CHECK-DIR %s
 
 // The purpose of this test is to verify that various invalid PCH files are
@@ -9,5 +9,5 @@
 // message still did not contain the name of the PCH. Also, r149918 which was
 // submitted on 2012-02-06 introduced a segfault in the case where the PCH is
 // an empty file and clang was built with assertions.
-// CHECK-EMPTY: error: input is not a PCH file: '{{.*[/\\]}}badpch-empty.h.gch'
+// CHECK-CLEAN: error: input is not a PCH file: '{{.*[/\\]}}badpch-empty.h.gch'
 // CHECK-DIR:error: no suitable precompiled header file found in directory '{{.*[/\\]}}badpch-dir.h.gch

--- a/lld/test/ELF/debug-names-bad.s
+++ b/lld/test/ELF/debug-names-bad.s
@@ -10,10 +10,10 @@
 
 # RUN: sed '/Header: name count/s/[0-9]/4/' %S/Inputs/debug-names-a.s > bad-name-count.s
 # RUN: llvm-mc -filetype=obj -triple=x86_64 bad-name-count.s -o bad-name-count.o
-# RUN: not ld.lld --debug-names bad-name-count.o 2>&1 | FileCheck %s --check-prefix=BAD-NAME-COUNT --implicit-check-not=error:
+# RUN: not ld.lld --debug-names bad-name-count.o 2>&1 | FileCheck %s --check-prefix=BAD-NAME-NUM --implicit-check-not=error:
 
 ## Test errors in offsets.
-# BAD-NAME-COUNT: error: bad-name-count.o:(.debug_names): Section too small: cannot read abbreviations.
+# BAD-NAME-NUM: error: bad-name-count.o:(.debug_names): Section too small: cannot read abbreviations.
 
 # RUN: sed '/Offset in Bucket/s/long/byte/' %S/Inputs/debug-names-a.s > entry-offset-in-byte.s
 # RUN: llvm-mc -filetype=obj -triple=x86_64 entry-offset-in-byte.s -o entry-offset-in-byte.o

--- a/lld/test/ELF/lto/devirt_validate_vtable_typeinfos.ll
+++ b/lld/test/ELF/lto/devirt_validate_vtable_typeinfos.ll
@@ -27,17 +27,17 @@
 ;; Index based WPD
 ; RUN: ld.lld %t1.o %t2.o -o %t3_index -save-temps --lto-whole-program-visibility \
 ; RUN:   -mllvm -pass-remarks=. 2>&1 | FileCheck %s --check-prefix=REMARK
-; RUN: llvm-dis %t1.o.4.opt.bc -o - | FileCheck %s --check-prefixes=CHECK-COMMON-IR-LABEL,CHECK-IR
+; RUN: llvm-dis %t1.o.4.opt.bc -o - | FileCheck %s --check-prefixes=CHECK-COMMON-IR,CHECK-IR
 
 ;; Hybrid WPD
 ; RUN: ld.lld %t1_hybrid.o %t2.o -o %t3_hybrid -save-temps --lto-whole-program-visibility \
 ; RUN:   -mllvm -pass-remarks=. 2>&1 | FileCheck %s --check-prefix=REMARK
-; RUN: llvm-dis %t1_hybrid.o.4.opt.bc -o - | FileCheck %s --check-prefixes=CHECK-COMMON-IR-LABEL,CHECK-IR
+; RUN: llvm-dis %t1_hybrid.o.4.opt.bc -o - | FileCheck %s --check-prefixes=CHECK-COMMON-IR,CHECK-IR
 
 ;; Regular LTO WPD
 ; RUN: ld.lld %t1_regular.o %t2.o -o %t3_regular -save-temps --lto-whole-program-visibility \
 ; RUN:   -mllvm -pass-remarks=. 2>&1 | FileCheck %s --check-prefix=REMARK
-; RUN: llvm-dis %t3_regular.0.4.opt.bc -o - | FileCheck %s --check-prefixes=CHECK-COMMON-IR-LABEL,CHECK-IR
+; RUN: llvm-dis %t3_regular.0.4.opt.bc -o - | FileCheck %s --check-prefixes=CHECK-COMMON-IR,CHECK-IR
 
 ; REMARK-DAG: single-impl: devirtualized a call to _ZN1A1nEi
 ; REMARK-DAG: single-impl: devirtualized a call to _ZN1D1mEi
@@ -49,34 +49,34 @@
 ;; Index based WPD
 ; RUN: ld.lld %t1.o %t2.o -o %t4_index -save-temps --lto-whole-program-visibility --lto-validate-all-vtables-have-type-infos \
 ; RUN:   -mllvm -pass-remarks=. 2>&1 | FileCheck %s --check-prefix=VALIDATE
-; RUN: llvm-dis %t1.o.4.opt.bc -o - | FileCheck %s --check-prefixes=CHECK-COMMON-IR-LABEL,CHECK-VALIDATE-IR
+; RUN: llvm-dis %t1.o.4.opt.bc -o - | FileCheck %s --check-prefixes=CHECK-COMMON-IR,CHECK-VALIDATE-IR
 
 ;; Hybrid WPD
 ; RUN: ld.lld %t1_hybrid.o %t2.o -o %t4_hybrid -save-temps --lto-whole-program-visibility --lto-validate-all-vtables-have-type-infos \
 ; RUN:   -mllvm -pass-remarks=. 2>&1 | FileCheck %s --check-prefix=VALIDATE
-; RUN: llvm-dis %t1_hybrid.o.4.opt.bc -o - | FileCheck %s --check-prefixes=CHECK-COMMON-IR-LABEL,CHECK-VALIDATE-IR
+; RUN: llvm-dis %t1_hybrid.o.4.opt.bc -o - | FileCheck %s --check-prefixes=CHECK-COMMON-IR,CHECK-VALIDATE-IR
 
 ;; Regular LTO WPD
 ; RUN: ld.lld %t1_regular.o %t2.o -o %t4_regular -save-temps --lto-whole-program-visibility --lto-validate-all-vtables-have-type-infos \
 ; RUN:   -mllvm -pass-remarks=. 2>&1 | FileCheck %s --check-prefix=VALIDATE
-; RUN: llvm-dis %t4_regular.0.4.opt.bc -o - | FileCheck %s --check-prefixes=CHECK-COMMON-IR-LABEL,CHECK-VALIDATE-IR
+; RUN: llvm-dis %t4_regular.0.4.opt.bc -o - | FileCheck %s --check-prefixes=CHECK-COMMON-IR,CHECK-VALIDATE-IR
 
 ;; DSOs behave similarly
 
 ;; Index based WPD
 ; RUN: ld.lld %t1.o %t2.so -o %t5_index -save-temps --lto-whole-program-visibility --lto-validate-all-vtables-have-type-infos \
 ; RUN:   -mllvm -pass-remarks=. 2>&1 | FileCheck %s --check-prefix=VALIDATE
-; RUN: llvm-dis %t1.o.4.opt.bc -o - | FileCheck %s --check-prefixes=CHECK-COMMON-IR-LABEL,CHECK-VALIDATE-IR
+; RUN: llvm-dis %t1.o.4.opt.bc -o - | FileCheck %s --check-prefixes=CHECK-COMMON-IR,CHECK-VALIDATE-IR
 
 ;; Hybrid WPD
 ; RUN: ld.lld %t1_hybrid.o %t2.so -o %t5_hybrid -save-temps --lto-whole-program-visibility --lto-validate-all-vtables-have-type-infos \
 ; RUN:   -mllvm -pass-remarks=. 2>&1 | FileCheck %s --check-prefix=VALIDATE
-; RUN: llvm-dis %t1_hybrid.o.4.opt.bc -o - | FileCheck %s --check-prefixes=CHECK-COMMON-IR-LABEL,CHECK-VALIDATE-IR
+; RUN: llvm-dis %t1_hybrid.o.4.opt.bc -o - | FileCheck %s --check-prefixes=CHECK-COMMON-IR,CHECK-VALIDATE-IR
 
 ;; Regular LTO WPD
 ; RUN: ld.lld %t1_regular.o %t2.so -o %t5_regular -save-temps --lto-whole-program-visibility --lto-validate-all-vtables-have-type-infos \
 ; RUN:   -mllvm -pass-remarks=. 2>&1 | FileCheck %s --check-prefix=VALIDATE
-; RUN: llvm-dis %t5_regular.0.4.opt.bc -o - | FileCheck %s --check-prefixes=CHECK-COMMON-IR-LABEL,CHECK-VALIDATE-IR
+; RUN: llvm-dis %t5_regular.0.4.opt.bc -o - | FileCheck %s --check-prefixes=CHECK-COMMON-IR,CHECK-VALIDATE-IR
 
 ; VALIDATE-NOT: single-impl:
 ; VALIDATE:     single-impl: devirtualized a call to _ZN1D1mEi
@@ -88,34 +88,34 @@
 ;; Index based WPD
 ; RUN: ld.lld %t1.o %t2_nortti.o -o %t6_index -save-temps --lto-whole-program-visibility --lto-validate-all-vtables-have-type-infos \
 ; RUN:   -mllvm -pass-remarks=. 2>&1 | FileCheck %s --check-prefix=NO-RTTI
-; RUN: llvm-dis %t1.o.4.opt.bc -o - | FileCheck %s --check-prefixes=CHECK-COMMON-IR-LABEL,CHECK-NO-RTTI-IR
+; RUN: llvm-dis %t1.o.4.opt.bc -o - | FileCheck %s --check-prefixes=CHECK-COMMON-IR,CHECK-NO-RTTI-IR
 
 ;; Hybrid WPD
 ; RUN: ld.lld %t1_hybrid.o %t2_nortti.o -o %t6_hybrid -save-temps --lto-whole-program-visibility --lto-validate-all-vtables-have-type-infos \
 ; RUN:   -mllvm -pass-remarks=. 2>&1 | FileCheck %s --check-prefix=NO-RTTI
-; RUN: llvm-dis %t1_hybrid.o.4.opt.bc -o - | FileCheck %s --check-prefixes=CHECK-COMMON-IR-LABEL,CHECK-NO-RTTI-IR
+; RUN: llvm-dis %t1_hybrid.o.4.opt.bc -o - | FileCheck %s --check-prefixes=CHECK-COMMON-IR,CHECK-NO-RTTI-IR
 
 ;; Regular LTO WPD
 ; RUN: ld.lld %t1_regular.o %t2_nortti.o -o %t6_regular -save-temps --lto-whole-program-visibility --lto-validate-all-vtables-have-type-infos \
 ; RUN:   -mllvm -pass-remarks=. 2>&1 | FileCheck %s --check-prefix=NO-RTTI
-; RUN: llvm-dis %t6_regular.0.4.opt.bc -o - | FileCheck %s --check-prefixes=CHECK-COMMON-IR-LABEL,CHECK-NO-RTTI-IR
+; RUN: llvm-dis %t6_regular.0.4.opt.bc -o - | FileCheck %s --check-prefixes=CHECK-COMMON-IR,CHECK-NO-RTTI-IR
 
 ;; DSOs behave similarly
 
 ;; Index based WPD
 ; RUN: ld.lld %t1.o %t2_nortti.so -o %t7_index -save-temps --lto-whole-program-visibility --lto-validate-all-vtables-have-type-infos \
 ; RUN:   -mllvm -pass-remarks=. 2>&1 | FileCheck %s --check-prefix=NO-RTTI
-; RUN: llvm-dis %t1.o.4.opt.bc -o - | FileCheck %s --check-prefixes=CHECK-COMMON-IR-LABEL,CHECK-NO-RTTI-IR
+; RUN: llvm-dis %t1.o.4.opt.bc -o - | FileCheck %s --check-prefixes=CHECK-COMMON-IR,CHECK-NO-RTTI-IR
 
 ;; Hybrid WPD
 ; RUN: ld.lld %t1_hybrid.o %t2_nortti.so -o %t7_hybrid -save-temps --lto-whole-program-visibility --lto-validate-all-vtables-have-type-infos \
 ; RUN:   -mllvm -pass-remarks=. 2>&1 | FileCheck %s --check-prefix=NO-RTTI
-; RUN: llvm-dis %t1_hybrid.o.4.opt.bc -o - | FileCheck %s --check-prefixes=CHECK-COMMON-IR-LABEL,CHECK-NO-RTTI-IR
+; RUN: llvm-dis %t1_hybrid.o.4.opt.bc -o - | FileCheck %s --check-prefixes=CHECK-COMMON-IR,CHECK-NO-RTTI-IR
 
 ;; Regular LTO WPD
 ; RUN: ld.lld %t1_regular.o %t2_nortti.so -o %t7_regular -save-temps --lto-whole-program-visibility --lto-validate-all-vtables-have-type-infos \
 ; RUN:   -mllvm -pass-remarks=. 2>&1 | FileCheck %s --check-prefix=NO-RTTI
-; RUN: llvm-dis %t7_regular.0.4.opt.bc -o - | FileCheck %s --check-prefixes=CHECK-COMMON-IR-LABEL,CHECK-NO-RTTI-IR
+; RUN: llvm-dis %t7_regular.0.4.opt.bc -o - | FileCheck %s --check-prefixes=CHECK-COMMON-IR,CHECK-NO-RTTI-IR
 
 ; NO-RTTI-DAG: --lto-validate-all-vtables-have-type-infos: RTTI missing for vtable _ZTV6Native, --lto-whole-program-visibility disabled
 ; NO-RTTI-DAG: single-impl: devirtualized a call to _ZN1D1mEi
@@ -126,17 +126,17 @@
 ;; Index based WPD
 ; RUN: ld.lld %t1.o %t2_nortti.o -o %t8_index -save-temps --lto-whole-program-visibility --lto-validate-all-vtables-have-type-infos \
 ; RUN:   --lto-known-safe-vtables='_ZTV6N*' -mllvm -pass-remarks=. 2>&1 | FileCheck %s --check-prefix=REMARK
-; RUN: llvm-dis %t1.o.4.opt.bc -o - | FileCheck %s --check-prefixes=CHECK-COMMON-IR-LABEL,CHECK-IR
+; RUN: llvm-dis %t1.o.4.opt.bc -o - | FileCheck %s --check-prefixes=CHECK-COMMON-IR,CHECK-IR
 
 ;; Hybrid WPD
 ; RUN: ld.lld %t1_hybrid.o %t2_nortti.o -o %t8_hybrid -save-temps --lto-whole-program-visibility --lto-validate-all-vtables-have-type-infos \
 ; RUN:   --lto-known-safe-vtables='_ZTV6N*' -mllvm -pass-remarks=. 2>&1 | FileCheck %s --check-prefix=REMARK
-; RUN: llvm-dis %t1_hybrid.o.4.opt.bc -o - | FileCheck %s --check-prefixes=CHECK-COMMON-IR-LABEL,CHECK-IR
+; RUN: llvm-dis %t1_hybrid.o.4.opt.bc -o - | FileCheck %s --check-prefixes=CHECK-COMMON-IR,CHECK-IR
 
 ;; Regular LTO WPD
 ; RUN: ld.lld %t1_regular.o %t2_nortti.o -o %t8_regular -save-temps --lto-whole-program-visibility --lto-validate-all-vtables-have-type-infos \
 ; RUN:   --lto-known-safe-vtables='_ZTV6N*' -mllvm -pass-remarks=. 2>&1 | FileCheck %s --check-prefix=REMARK
-; RUN: llvm-dis %t8_regular.0.4.opt.bc -o - | FileCheck %s --check-prefixes=CHECK-COMMON-IR-LABEL,CHECK-IR
+; RUN: llvm-dis %t8_regular.0.4.opt.bc -o - | FileCheck %s --check-prefixes=CHECK-COMMON-IR,CHECK-IR
 
 ;; Only check for definitions of vtables symbols, just having a reference does not allow a type to
 ;; be derived from
@@ -144,17 +144,17 @@
 ;; Index based WPD
 ; RUN: ld.lld %t1.o %t2_undef.o -o %t9_index -save-temps --lto-whole-program-visibility --lto-validate-all-vtables-have-type-infos \
 ; RUN:   -mllvm -pass-remarks=. 2>&1 | FileCheck %s --check-prefix=REMARK
-; RUN: llvm-dis %t1.o.4.opt.bc -o - | FileCheck %s --check-prefixes=CHECK-COMMON-IR-LABEL,CHECK-IR
+; RUN: llvm-dis %t1.o.4.opt.bc -o - | FileCheck %s --check-prefixes=CHECK-COMMON-IR,CHECK-IR
 
 ;; Hybrid WPD
 ; RUN: ld.lld %t1_hybrid.o %t2_undef.o -o %t9_hybrid -save-temps --lto-whole-program-visibility --lto-validate-all-vtables-have-type-infos \
 ; RUN:   -mllvm -pass-remarks=. 2>&1 | FileCheck %s --check-prefix=REMARK
-; RUN: llvm-dis %t1_hybrid.o.4.opt.bc -o - | FileCheck %s --check-prefixes=CHECK-COMMON-IR-LABEL,CHECK-IR
+; RUN: llvm-dis %t1_hybrid.o.4.opt.bc -o - | FileCheck %s --check-prefixes=CHECK-COMMON-IR,CHECK-IR
 
 ;; Regular LTO WPD
 ; RUN: ld.lld %t1_regular.o %t2_undef.o -o %t9_regular -save-temps --lto-whole-program-visibility --lto-validate-all-vtables-have-type-infos \
 ; RUN:   -mllvm -pass-remarks=. 2>&1 | FileCheck %s --check-prefix=REMARK
-; RUN: llvm-dis %t9_regular.0.4.opt.bc -o - | FileCheck %s --check-prefixes=CHECK-COMMON-IR-LABEL,CHECK-IR
+; RUN: llvm-dis %t9_regular.0.4.opt.bc -o - | FileCheck %s --check-prefixes=CHECK-COMMON-IR,CHECK-IR
 
 target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
 target triple = "x86_64-unknown-linux-gnu"

--- a/lld/test/ELF/lto/devirt_validate_vtable_typeinfos_no_rtti.ll
+++ b/lld/test/ELF/lto/devirt_validate_vtable_typeinfos_no_rtti.ll
@@ -15,17 +15,17 @@
 ;; Index based WPD
 ; RUN: ld.lld %t1.o -o %t3_index -save-temps --lto-whole-program-visibility \
 ; RUN:   -mllvm -pass-remarks=. 2>&1 | FileCheck %s --check-prefix=REMARK
-; RUN: llvm-dis %t1.o.4.opt.bc -o - | FileCheck %s --check-prefixes=CHECK-COMMON-IR-LABEL,CHECK-IR
+; RUN: llvm-dis %t1.o.4.opt.bc -o - | FileCheck %s --check-prefixes=CHECK-COMMON-IR,CHECK-IR
 
 ;; Hybrid WPD
 ; RUN: ld.lld %t1_hybrid.o -o %t3_hybrid -save-temps --lto-whole-program-visibility \
 ; RUN:   -mllvm -pass-remarks=. 2>&1 | FileCheck %s --check-prefix=REMARK
-; RUN: llvm-dis %t1_hybrid.o.4.opt.bc -o - | FileCheck %s --check-prefixes=CHECK-COMMON-IR-LABEL,CHECK-IR
+; RUN: llvm-dis %t1_hybrid.o.4.opt.bc -o - | FileCheck %s --check-prefixes=CHECK-COMMON-IR,CHECK-IR
 
 ;; Regular LTO WPD
 ; RUN: ld.lld %t1_regular.o -o %t3_regular -save-temps --lto-whole-program-visibility \
 ; RUN:   -mllvm -pass-remarks=. 2>&1 | FileCheck %s --check-prefix=REMARK
-; RUN: llvm-dis %t3_regular.0.4.opt.bc -o - | FileCheck %s --check-prefixes=CHECK-COMMON-IR-LABEL,CHECK-IR
+; RUN: llvm-dis %t3_regular.0.4.opt.bc -o - | FileCheck %s --check-prefixes=CHECK-COMMON-IR,CHECK-IR
 
 ; REMARK-DAG: single-impl: devirtualized a call to _ZN1A1nEi
 ; REMARK-DAG: single-impl: devirtualized a call to _ZN1D1mEi
@@ -38,17 +38,17 @@
 ;; Index based WPD
 ; RUN: ld.lld %t1.o -o %t3_index -save-temps --lto-whole-program-visibility --lto-validate-all-vtables-have-type-infos \
 ; RUN:   -mllvm -pass-remarks=. 2>&1 | FileCheck %s --check-prefix=VALIDATE
-; RUN: llvm-dis %t1.o.4.opt.bc -o - | FileCheck %s --check-prefixes=CHECK-COMMON-IR-LABEL,CHECK-VALIDATE-IR
+; RUN: llvm-dis %t1.o.4.opt.bc -o - | FileCheck %s --check-prefixes=CHECK-COMMON-IR,CHECK-VALIDATE-IR
 
 ;; Hybrid WPD
 ; RUN: ld.lld %t1_hybrid.o -o %t3_hybrid -save-temps --lto-whole-program-visibility --lto-validate-all-vtables-have-type-infos \
 ; RUN:   -mllvm -pass-remarks=. 2>&1 | FileCheck %s --check-prefix=VALIDATE
-; RUN: llvm-dis %t1_hybrid.o.4.opt.bc -o - | FileCheck %s --check-prefixes=CHECK-COMMON-IR-LABEL,CHECK-VALIDATE-IR
+; RUN: llvm-dis %t1_hybrid.o.4.opt.bc -o - | FileCheck %s --check-prefixes=CHECK-COMMON-IR,CHECK-VALIDATE-IR
 
 ;; Regular LTO WPD
 ; RUN: ld.lld %t1_regular.o -o %t3_regular -save-temps --lto-whole-program-visibility --lto-validate-all-vtables-have-type-infos \
 ; RUN:   -mllvm -pass-remarks=. 2>&1 | FileCheck %s --check-prefix=VALIDATE
-; RUN: llvm-dis %t3_regular.0.4.opt.bc -o - | FileCheck %s --check-prefixes=CHECK-COMMON-IR-LABEL,CHECK-VALIDATE-IR
+; RUN: llvm-dis %t3_regular.0.4.opt.bc -o - | FileCheck %s --check-prefixes=CHECK-COMMON-IR,CHECK-VALIDATE-IR
 
 ; VALIDATE-DAG: single-impl: devirtualized a call to _ZN1D1mEi
 

--- a/lld/test/MachO/icf-options.s
+++ b/lld/test/MachO/icf-options.s
@@ -3,21 +3,21 @@
 
 # RUN: llvm-mc -filetype=obj -triple=x86_64-apple-darwin %s -o %t/main.o
 # RUN: %lld -lSystem --icf=all -o %t/all %t/main.o 2>&1 \
-# RUN:     | FileCheck %s --check-prefix=DIAG-EMPTY --allow-empty
+# RUN:     | FileCheck %s --check-prefix=DIAG-CLEAN --allow-empty
 # RUN: %lld -lSystem --icf=none -o %t/none %t/main.o 2>&1 \
-# RUN:     | FileCheck %s --check-prefix=DIAG-EMPTY --allow-empty
+# RUN:     | FileCheck %s --check-prefix=DIAG-CLEAN --allow-empty
 # RUN: %lld -lSystem -no_deduplicate -o %t/no_dedup %t/main.o 2>&1 \
-# RUN:     | FileCheck %s --check-prefix=DIAG-EMPTY --allow-empty
+# RUN:     | FileCheck %s --check-prefix=DIAG-CLEAN --allow-empty
 # RUN: %lld -lSystem --icf=safe -o %t/safe %t/main.o 2>&1 \
-# RUN:     | FileCheck %s --check-prefix=DIAG-EMPTY --allow-empty
+# RUN:     | FileCheck %s --check-prefix=DIAG-CLEAN --allow-empty
 # RUN: not %lld -lSystem --icf=junk -o %t/junk %t/main.o 2>&1 \
 # RUN:     | FileCheck %s --check-prefix=DIAG-JUNK
 # RUN: %lld -lSystem --icf=all -no_deduplicate -o %t/none2 %t/main.o 2>&1 \
-# RUN:     | FileCheck %s --check-prefix=DIAG-EMPTY --allow-empty
+# RUN:     | FileCheck %s --check-prefix=DIAG-CLEAN --allow-empty
 # RUN: %lld -lSystem -no_deduplicate --icf=all -o %t/all2 %t/main.o 2>&1 \
-# RUN:     | FileCheck %s --check-prefix=DIAG-EMPTY --allow-empty
+# RUN:     | FileCheck %s --check-prefix=DIAG-CLEAN --allow-empty
 
-# DIAG-EMPTY-NOT: {{.}}
+# DIAG-CLEAN-NOT: {{.}}
 # DIAG-JUNK: unknown --icf=OPTION `junk', defaulting to `none'
 
 # RUN: llvm-objdump -d --syms %t/all | FileCheck %s --check-prefix=FOLD

--- a/llvm/docs/CommandGuide/FileCheck.rst
+++ b/llvm/docs/CommandGuide/FileCheck.rst
@@ -43,8 +43,10 @@ and from the command line.
  "``:``") one or more prefixes to match. Multiple prefixes are useful for tests
  which might change for different run options, but most lines remain the same.
 
- FileCheck does not permit duplicate prefixes, even if one is a check prefix
- and one is a comment prefix (see :option:`--comment-prefixes` below).
+ FileCheck does not permit:
+
+ * duplicate prefixes, even if one is a check prefix and one is a comment prefix (see :option:`--comment-prefixes` below).
+ * check prefixes ending with directives (i.e. ``--check-prefix=FOO-NEXT``)
 
 .. option:: --check-prefixes prefix1,prefix2,...
 

--- a/llvm/test/Assembler/inline-asm-constraint-error.ll
+++ b/llvm/test/Assembler/inline-asm-constraint-error.ll
@@ -7,7 +7,7 @@
 ; RUN: not llvm-as < %t/incorrect-struct-elements.ll 2>&1 | FileCheck %s --check-prefix=CHECK-INCORRECT-STRUCT-ELEMENTS
 ; RUN: not llvm-as < %t/incorrect-arg-num.ll 2>&1 | FileCheck %s --check-prefix=CHECK-INCORRECT-ARG-NUM
 ; RUN: not llvm-as < %t/label-after-clobber.ll 2>&1 | FileCheck %s --check-prefix=CHECK-LABEL-AFTER-CLOBBER
-; RUN: not llvm-as < %t/output-after-label.ll 2>&1 | FileCheck %s --check-prefix=CHECK-OUTPUT-AFTER-LABEL
+; RUN: not llvm-as < %t/output-after-label.ll 2>&1 | FileCheck %s --check-prefix=CHECK-OUTPUT-AFTER-LBL
 
 ;--- parse-fail.ll
 ; CHECK-PARSE-FAIL: failed to parse constraints
@@ -71,7 +71,7 @@ define void @foo() {
 }
 
 ;--- output-after-label.ll
-; CHECK-OUTPUT-AFTER-LABEL: output constraint occurs after input, clobber or label constraint
+; CHECK-OUTPUT-AFTER-LBL: output constraint occurs after input, clobber or label constraint
 define void @foo() {
   %res = callbr i32 asm sideeffect "", "!i,=r,~{flags}"()
   to label %1 [label %2]

--- a/llvm/test/Bitcode/invalid.test
+++ b/llvm/test/Bitcode/invalid.test
@@ -1,6 +1,6 @@
 RUN: export LSAN_OPTIONS=detect_leaks=0
 RUN: not llvm-dis -disable-output %p/Inputs/invalid-empty.bc 2>&1 | \
-RUN:   FileCheck --check-prefix=INVALID-EMPTY %s
+RUN:   FileCheck --check-prefix=INVALID-EMPTY-FILE %s
 RUN: not llvm-dis -disable-output %p/Inputs/invalid-pr20485.bc 2>&1 | \
 RUN:   FileCheck --check-prefix=INVALID-ENCODING %s
 RUN: not llvm-dis -disable-output %p/Inputs/invalid-abbrev.bc 2>&1 | \
@@ -22,7 +22,7 @@ RUN:   FileCheck --check-prefix=MISMATCHED-EXPLICIT-INVOKE %s
 RUN: not llvm-dis -disable-output %p/Inputs/invalid-invoke-non-function-explicit-type.bc 2>&1 | \
 RUN:   FileCheck --check-prefix=NON-FUNCTION-EXPLICIT-INVOKE %s
 
-INVALID-EMPTY: error: file too small to contain bitcode header
+INVALID-EMPTY-FILE: error: file too small to contain bitcode header
 INVALID-ENCODING: Invalid encoding
 BAD-ABBREV: error: can't skip to bit
 UNEXPECTED-EOF: error: can't skip to bit

--- a/llvm/test/DebugInfo/PDB/pdbdump-mergeids.test
+++ b/llvm/test/DebugInfo/PDB/pdbdump-mergeids.test
@@ -2,7 +2,7 @@
 ; RUN: llvm-pdbutil yaml2pdb -pdb=%t.2.pdb %p/Inputs/merge-ids-2.yaml
 ; RUN: llvm-pdbutil merge -pdb=%t.3.pdb %t.1.pdb %t.2.pdb
 ; RUN: llvm-pdbutil dump -ids %t.3.pdb | FileCheck -check-prefix=MERGED %s
-; RUN: llvm-pdbutil dump -types %t.3.pdb | FileCheck -check-prefix=TPI-EMPTY %s
+; RUN: llvm-pdbutil dump -types %t.3.pdb | FileCheck -check-prefix=NO-TPI %s
 
 
 MERGED:                          Types (IPI Stream)
@@ -19,6 +19,6 @@ MERGED-NEXT:            0x1004: `SubTwo`
 MERGED-NEXT:   0x1006 | LF_STRING_ID [size = 16] ID: 0x1005, String: Main
 MERGED-NEXT:   0x1007 | LF_STRING_ID [size = 24] ID: <no type>, String: OnlyInSecond
 
-TPI-EMPTY:                     Types (TPI Stream)
-TPI-EMPTY-NEXT: ============================================================
-TPI-EMPTY-NEXT:   Showing 0 records
+NO-TPI:                     Types (TPI Stream)
+NO-TPI-NEXT: ============================================================
+NO-TPI-NEXT:   Showing 0 records

--- a/llvm/test/FileCheck/check-prefix-ends-with-def.txt
+++ b/llvm/test/FileCheck/check-prefix-ends-with-def.txt
@@ -1,0 +1,12 @@
+# Defining check prefix name ending with directive are forbidden.
+
+foo
+foo2
+
+; FOO: foo
+; FOO-NEXT: foo2
+
+; RUN: %ProtectFileCheckOutput not FileCheck -check-prefixes=FOO,FOO-NEXT -input-file %s %s 2>&1 | \
+; RUN:   FileCheck -check-prefix=BAR %s
+
+; BAR: supplied check prefix must not end with directive: '-NEXT', prefix: 'FOO-NEXT'

--- a/llvm/test/FileCheck/comment-prefix-ends-with-def.txt
+++ b/llvm/test/FileCheck/comment-prefix-ends-with-def.txt
@@ -1,0 +1,13 @@
+# Defining comment prefix name ending with directive are ok, but meaningless,
+# this line will be simply ignored.
+
+foo
+foo2
+
+; COMZ: FOO: foo
+; COMZ-NOT: FOO-NEXT: foo2
+
+; RUN: %ProtectFileCheckOutput not FileCheck -check-prefix=FOO -comment-prefixes=COMZ -input-file %s %s 2>&1 | \
+; RUN:   FileCheck -check-prefix=BAR %s
+
+; BAR: error: found 'FOO-NEXT' without previous 'FOO: line

--- a/llvm/test/FileCheck/comment/bad-comment-prefix.txt
+++ b/llvm/test/FileCheck/comment/bad-comment-prefix.txt
@@ -3,17 +3,17 @@
 # Check empty comment prefix.
 RUN: %ProtectFileCheckOutput not FileCheck /dev/null < /dev/null 2>&1 \
 RUN:                                      -comment-prefixes= | \
-RUN:   FileCheck -check-prefix=PREFIX-EMPTY %s
+RUN:   FileCheck -check-prefix=EMPTY-PREFIX %s
 RUN: %ProtectFileCheckOutput not FileCheck /dev/null < /dev/null 2>&1 \
 RUN:                                      -comment-prefixes=,FOO | \
-RUN:   FileCheck -check-prefix=PREFIX-EMPTY %s
+RUN:   FileCheck -check-prefix=EMPTY-PREFIX %s
 RUN: %ProtectFileCheckOutput not FileCheck /dev/null < /dev/null 2>&1 \
 RUN:                                      -comment-prefixes=FOO, | \
-RUN:   FileCheck -check-prefix=PREFIX-EMPTY %s
+RUN:   FileCheck -check-prefix=EMPTY-PREFIX %s
 RUN: %ProtectFileCheckOutput not FileCheck /dev/null < /dev/null 2>&1 \
 RUN:                                      -comment-prefixes=FOO,,BAR | \
-RUN:   FileCheck -check-prefix=PREFIX-EMPTY %s
-PREFIX-EMPTY: error: supplied comment prefix must not be the empty string
+RUN:   FileCheck -check-prefix=EMPTY-PREFIX %s
+EMPTY-PREFIX: error: supplied comment prefix must not be the empty string
 
 # Check invalid characters in comment prefix.
 RUN: %ProtectFileCheckOutput not FileCheck /dev/null < /dev/null 2>&1 \

--- a/llvm/test/FileCheck/numeric-expression.txt
+++ b/llvm/test/FileCheck/numeric-expression.txt
@@ -593,16 +593,16 @@ CALL-MISSING-ARGUMENT-MSG-NEXT: {{C}}ALL-MISSING-ARGUMENT-NEXT: {{\[\[#add\(NUMV
 CALL-MISSING-ARGUMENT-MSG-NEXT:      {{^}}                                          ^{{$}}
 
 RUN: %ProtectFileCheckOutput \
-RUN: not FileCheck -D#NUMVAR=10 --check-prefix CALL-WRONG-ARGUMENT-COUNT --input-file %s %s 2>&1 \
-RUN:   | FileCheck --strict-whitespace --check-prefix CALL-WRONG-ARGUMENT-COUNT-MSG %s
+RUN: not FileCheck -D#NUMVAR=10 --check-prefix CALL-WRONG-ARGUMENT-NUM --input-file %s %s 2>&1 \
+RUN:   | FileCheck --strict-whitespace --check-prefix CALL-WRONG-ARGUMENT-NUM-MSG %s
 
-CALL WRONG ARGUMENT COUNT
+CALL WRONG ARGUMENT NUM
 30
-CALL-WRONG-ARGUMENT-COUNT-LABEL: CALL WRONG ARGUMENT COUNT
-CALL-WRONG-ARGUMENT-COUNT-NEXT: [[#add(NUMVAR)]]
-CALL-WRONG-ARGUMENT-COUNT-MSG: numeric-expression.txt:[[#@LINE-1]]:36: error: function 'add' takes 2 arguments but 1 given
-CALL-WRONG-ARGUMENT-COUNT-MSG-NEXT: {{C}}ALL-WRONG-ARGUMENT-COUNT-NEXT: {{\[\[#add\(NUMVAR\)\]\]}}
-CALL-WRONG-ARGUMENT-COUNT-MSG-NEXT:    {{^}}                                   ^{{$}}
+CALL-WRONG-ARGUMENT-NUM-LABEL: CALL WRONG ARGUMENT NUM
+CALL-WRONG-ARGUMENT-NUM-NEXT: [[#add(NUMVAR)]]
+CALL-WRONG-ARGUMENT-NUM-MSG: numeric-expression.txt:[[#@LINE-1]]:34: error: function 'add' takes 2 arguments but 1 given
+CALL-WRONG-ARGUMENT-NUM-MSG-NEXT: {{C}}ALL-WRONG-ARGUMENT-NUM-NEXT: {{\[\[#add\(NUMVAR\)\]\]}}
+CALL-WRONG-ARGUMENT-NUM-MSG-NEXT:    {{^}}                                 ^{{$}}
 
 RUN: %ProtectFileCheckOutput \
 RUN: not FileCheck -D#NUMVAR=10 --check-prefix CALL-UNDEFINED-FUNCTION --input-file %s %s 2>&1 \

--- a/llvm/test/Object/invalid.test
+++ b/llvm/test/Object/invalid.test
@@ -20,9 +20,9 @@ Sections:
 ## .shstrtab has an invalid zero-size.
 
 # RUN: yaml2obj %s --docnum=2 -o %t2
-# RUN: not llvm-objdump -s %t2 2>&1 | FileCheck %s -DFILE=%t2 --check-prefix=STRTAB-EMPTY
+# RUN: not llvm-objdump -s %t2 2>&1 | FileCheck %s -DFILE=%t2 --check-prefix=STRTAB-EMPTY-TABLE
 
-# STRTAB-EMPTY: error: '[[FILE]]': SHT_STRTAB string table section [index 1] is empty
+# STRTAB-EMPTY-TABLE: error: '[[FILE]]': SHT_STRTAB string table section [index 1] is empty
 
 --- !ELF
 FileHeader:

--- a/llvm/test/Object/macho-invalid.test
+++ b/llvm/test/Object/macho-invalid.test
@@ -356,8 +356,8 @@ INVALID-ENCRYPT-CRYPTOFF-CRYPTSIZE: macho-invalid-encrypt64-cryptoff-cryptsize':
 RUN: not llvm-objdump --macho --private-headers %p/Inputs/macho-invalid-linkopt-bad-size 2>&1 | FileCheck --check-prefix=INVALID-LINKOPT-BAD-SIZE %s
 INVALID-LINKOPT-BAD-SIZE: macho-invalid-linkopt-bad-size': truncated or malformed object (load command 0 LC_LINKER_OPTION cmdsize too small)
 
-RUN: not llvm-objdump --macho --private-headers %p/Inputs/macho-invalid-linkopt-bad-count 2>&1 | FileCheck --check-prefix=INVALID-LINKOPT-BAD-COUNT %s
-INVALID-LINKOPT-BAD-COUNT: macho-invalid-linkopt-bad-count': truncated or malformed object (load command 0 LC_LINKER_OPTION string count 3 does not match number of strings)
+RUN: not llvm-objdump --macho --private-headers %p/Inputs/macho-invalid-linkopt-bad-count 2>&1 | FileCheck --check-prefix=INVALID-LINKOPT-BAD-NUM %s
+INVALID-LINKOPT-BAD-NUM: macho-invalid-linkopt-bad-count': truncated or malformed object (load command 0 LC_LINKER_OPTION string count 3 does not match number of strings)
 
 RUN: not llvm-objdump --macho --private-headers %p/Inputs/macho-invalid-subframe-small 2>&1 | FileCheck --check-prefix=INVALID-SUBFRAME-SMALL %s
 INVALID-SUBFRAME-SMALL: macho-invalid-subframe-small': truncated or malformed object (load command 0 LC_SUB_FRAMEWORK cmdsize too small)

--- a/llvm/test/Transforms/SampleProfile/profile-inference-islands.ll
+++ b/llvm/test/Transforms/SampleProfile/profile-inference-islands.ll
@@ -1,5 +1,5 @@
 ; RUN: opt < %s -passes=pseudo-probe,sample-profile -sample-profile-use-profi -sample-profile-file=%S/Inputs/profile-inference-islands.prof -S -o %t
-; RUN: FileCheck %s < %t -check-prefix=CHECK-ENTRY-COUNT
+; RUN: FileCheck %s < %t -check-prefix=CHECK-ENTRY-NUM
 ; RUN: opt < %t -passes='print<block-freq>' -disable-output 2>&1 | FileCheck %s
 
 
@@ -209,4 +209,4 @@ attributes #2 = { nounwind }
 !8 = !{i64 -7683376842751444845, i64 69495280403, !"islands_2"}
 !9 = !{i64 -9095645063288297061, i64 156608410269, !"islands_3"}
 
-; CHECK-ENTRY-COUNT: = !{!"function_entry_count", i64 2}
+; CHECK-ENTRY-NUM: = !{!"function_entry_count", i64 2}

--- a/llvm/test/tools/llvm-readobj/ELF/note-core-ntfile-bad.test
+++ b/llvm/test/tools/llvm-readobj/ELF/note-core-ntfile-bad.test
@@ -75,10 +75,10 @@ ProgramHeaders:
     LastSec:  .note.foo
 
 # RUN: yaml2obj --docnum=3 %s -o %t3.o
-# RUN: llvm-readelf -n %t3.o 2>&1 | FileCheck -DFILE=%t3.o %s --check-prefix=ERR-FILE-COUNT
-# RUN: llvm-readobj -n %t3.o 2>&1 | FileCheck -DFILE=%t3.o %s --check-prefix=ERR-FILE-COUNT
+# RUN: llvm-readelf -n %t3.o 2>&1 | FileCheck -DFILE=%t3.o %s --check-prefix=ERR-FILE-NUM
+# RUN: llvm-readobj -n %t3.o 2>&1 | FileCheck -DFILE=%t3.o %s --check-prefix=ERR-FILE-NUM
 
-# ERR-FILE-COUNT: warning: '[[FILE]]': unable to read note with index 0 from the PT_NOTE segment with index 0: unable to read file mappings (found 2): the note of size 0x2c is too short
+# ERR-FILE-NUM: warning: '[[FILE]]': unable to read note with index 0 from the PT_NOTE segment with index 0: unable to read file mappings (found 2): the note of size 0x2c is too short
 
 # .section ".note.foo", "a"
 #       .align 4

--- a/llvm/test/tools/yaml2obj/ELF/section-offset.yaml
+++ b/llvm/test/tools/yaml2obj/ELF/section-offset.yaml
@@ -75,15 +75,15 @@ Sections:
 
 ## Case 1: set the same value for 'Offset' and 'ShOffset' keys.
 # RUN: yaml2obj --docnum=3 %s -o %t5 -DSHOFFSET=0x100 -DOFFSET=0x100
-# RUN: llvm-readelf --headers --sections %t5 | FileCheck %s --check-prefix=BOTH-SAME
+# RUN: llvm-readelf --headers --sections %t5 | FileCheck %s --check-prefix=BOTH-EQUAL
 
 ## The same offset as in the Case 3.
-# BOTH-SAME: Start of section headers: 288 (bytes into file)
+# BOTH-EQUAL: Start of section headers: 288 (bytes into file)
 
-# BOTH-SAME:      [Nr] Name     Type     Address          Off
-# BOTH-SAME:      [ 1] .foo     PROGBITS 0000000000000000 000100
-# BOTH-SAME-NEXT: [ 2] .bar     PROGBITS 0000000000000000 000101
-# BOTH-SAME-NEXT: [ 3] .strtab  STRTAB   0000000000000000 000102
+# BOTH-EQUAL:      [Nr] Name     Type     Address          Off
+# BOTH-EQUAL:      [ 1] .foo     PROGBITS 0000000000000000 000100
+# BOTH-EQUAL-NEXT: [ 2] .bar     PROGBITS 0000000000000000 000101
+# BOTH-EQUAL-NEXT: [ 3] .strtab  STRTAB   0000000000000000 000102
 
 ## Case 2: set the 'Offset' value to be less than the 'ShOffset'.
 


### PR DESCRIPTION
Split from https://github.com/llvm/llvm-project/pull/92248

This should resolve ambiguity in cases like: `-check-prefixes=FOO,FOO-NEXT`
```
FOO: xxx
FOO-NEXT: yyy
```
where it unknown how to parse `FOO-NEXT`: like `FOO-NEXT` prefix or `FOO` with `-NEXT` directive?

Current PR checks only prefix definition, not usages.