### PR TITLE
[analyzer] Fix a test issue in mingw configurations

### DIFF
--- a/clang/unittests/StaticAnalyzer/MemRegionDescriptiveNameTest.cpp
+++ b/clang/unittests/StaticAnalyzer/MemRegionDescriptiveNameTest.cpp
@@ -90,7 +90,7 @@ void reportDescriptiveName(int *p);
 extern int* ptr;
 extern int array[3];
 void top() {
-  reportDescriptiveName(&array[(long)ptr]);
+  reportDescriptiveName(&array[(long long)ptr]);
 })cpp";
 
   std::string Output;


### PR DESCRIPTION
On Windows, long is always 32 bit, thus one can't use long for casting pointers to integers, on 64 bit architectures.

Instead use long long, which should be large enough.

This avoids errors like "error: cast from pointer to smaller type 'long' loses information" in this testcase.

This condition only seems to be an error in mingw mode; in MSVC mode (clang-cl), this is only a warning.