### PR TITLE
[libcxx] Add cast to avoid pointer casting warning on Windows

### DIFF
--- a/libcxx/src/chrono.cpp
+++ b/libcxx/src/chrono.cpp
@@ -77,8 +77,8 @@ typedef void(WINAPI* GetSystemTimeAsFileTimePtr)(LPFILETIME);
 class GetSystemTimeInit {
 public:
   GetSystemTimeInit() {
-    fp =
-        (GetSystemTimeAsFileTimePtr)GetProcAddress(GetModuleHandleW(L"kernel32.dll"), "GetSystemTimePreciseAsFileTime");
+    fp = (GetSystemTimeAsFileTimePtr)(void*)GetProcAddress(
+        GetModuleHandleW(L"kernel32.dll"), "GetSystemTimePreciseAsFileTime");
     if (fp == nullptr)
       fp = GetSystemTimeAsFileTime;
   }


### PR DESCRIPTION
This avoids the following build time warning, when building with the latest nightly Clang:

    warning: cast from 'FARPROC' (aka 'int (*)() __attribute__((stdcall))') to
    'GetSystemTimeAsFileTimePtr' (aka 'void (*)(_FILETIME *) __attribute__((stdcall))')
    converts to incompatible function type [-Wcast-function-type-mismatch]

This warning seems to have appeared since Clang commit 999d4f840777bf8de26d45947192aa0728edc0fb, which restructured.

The GetProcAddress function returns a `FARPROC` type, which is `int (WINAPI *)()`. Directly casting this to another function pointer type triggers this warning, but casting to a `void*` inbetween avoids this issue. (On Unix-like platforms, dlsym returns a `void*`, which doesn't exhibit this casting problem.)