### PR TITLE
Disable compiling and testing Flang on Clang changes

### DIFF
--- a/.ci/generate-buildkite-pipeline-premerge
+++ b/.ci/generate-buildkite-pipeline-premerge
@@ -68,7 +68,7 @@ function compute-projects-to-test() {
       done
     ;;
     clang)
-      for p in clang-tools-extra compiler-rt flang lldb cross-project-tests; do
+      for p in clang-tools-extra compiler-rt lldb cross-project-tests; do
         echo $p
       done
     ;;

--- a/clang/examples/PrintFunctionNames/PrintFunctionNames.cpp
+++ b/clang/examples/PrintFunctionNames/PrintFunctionNames.cpp
@@ -72,7 +72,7 @@ public:
           *sema.LateParsedTemplateMap.find(FD)->second;
       sema.LateTemplateParser(sema.OpaqueParser, LPT);
       llvm::errs() << "late-parsed-decl: \"" << FD->getNameAsString() << "\"\n";
-    }   
+    }
   }
 };
 

--- a/clang/examples/PrintFunctionNames/PrintFunctionNames.cpp
+++ b/clang/examples/PrintFunctionNames/PrintFunctionNames.cpp
@@ -72,7 +72,7 @@ public:
           *sema.LateParsedTemplateMap.find(FD)->second;
       sema.LateTemplateParser(sema.OpaqueParser, LPT);
       llvm::errs() << "late-parsed-decl: \"" << FD->getNameAsString() << "\"\n";
-    }
+    }   
   }
 };
 


### PR DESCRIPTION
This patch aims to rectify the Windows CI situation by decoupling Clang changes from Flang test suite, which is causing Windows CI to "pause" for 20 minutes (details can be found [here](https://discourse.llvm.org/t/flang-tests-are-extremely-slow-on-windows/78591/11)). This even seems desirable in the long run, because it was highlighted that the only part of Clang that Flang depends on is Driver ([Discourse post](https://discourse.llvm.org/t/flang-tests-are-extremely-slow-on-windows/78591/14)).

Importantly, this patch leaves the question of _entirely_ disabling Flang tests on Windows CI out of scope.