### PR TITLE
[libc++][modules] Attach declarations to the global module.

### DIFF
--- a/libcxx/include/__config
+++ b/libcxx/include/__config
@@ -837,6 +837,17 @@ typedef __char32_t char32_t;
 #  define _LIBCPP_END_NAMESPACE_FILESYSTEM }} _LIBCPP_END_NAMESPACE_STD
 // clang-format on
 
+// Named declarations included in the headers are part of the global module
+// fragment. These declarations are attached to the global module. The using
+// declarations in the module should also attach their declarations to the
+// global module. This is done by using a linkage specification.
+#  if defined(_LIBCPP_CLANG_VER) && _LIBCPP_CLANG_VER < 1800
+// Clang-17 does not support extern "C++" export
+#    define _LIBCPP_MODULE_EXPORT export
+#  else
+#    define _LIBCPP_MODULE_EXPORT extern "C++" export
+#  endif
+
 #  if __has_attribute(__enable_if__)
 #    define _LIBCPP_PREFERRED_OVERLOAD __attribute__((__enable_if__(true, "")))
 #  endif

--- a/libcxx/modules/std.compat/cassert.inc
+++ b/libcxx/modules/std.compat/cassert.inc
@@ -7,6 +7,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-export {
+_LIBCPP_MODULE_EXPORT {
   // This module exports nothing.
-} // export
+} // _LIBCPP_MODULE_EXPORT

--- a/libcxx/modules/std.compat/cctype.inc
+++ b/libcxx/modules/std.compat/cctype.inc
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-export {
+_LIBCPP_MODULE_EXPORT {
   using ::isalnum _LIBCPP_USING_IF_EXISTS;
   using ::isalpha _LIBCPP_USING_IF_EXISTS;
   using ::isblank _LIBCPP_USING_IF_EXISTS;
@@ -22,4 +22,4 @@ export {
   using ::isxdigit _LIBCPP_USING_IF_EXISTS;
   using ::tolower _LIBCPP_USING_IF_EXISTS;
   using ::toupper _LIBCPP_USING_IF_EXISTS;
-} // export
+} // _LIBCPP_MODULE_EXPORT

--- a/libcxx/modules/std.compat/cerrno.inc
+++ b/libcxx/modules/std.compat/cerrno.inc
@@ -7,6 +7,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-export {
+_LIBCPP_MODULE_EXPORT {
   // This module exports nothing.
-} // export
+} // _LIBCPP_MODULE_EXPORT

--- a/libcxx/modules/std.compat/cfenv.inc
+++ b/libcxx/modules/std.compat/cfenv.inc
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-export {
+_LIBCPP_MODULE_EXPORT {
   // types
   using ::fenv_t _LIBCPP_USING_IF_EXISTS;
   using ::fexcept_t _LIBCPP_USING_IF_EXISTS;
@@ -26,4 +26,4 @@ export {
   using ::feholdexcept _LIBCPP_USING_IF_EXISTS;
   using ::fesetenv _LIBCPP_USING_IF_EXISTS;
   using ::feupdateenv _LIBCPP_USING_IF_EXISTS;
-} // export
+} // _LIBCPP_MODULE_EXPORT

--- a/libcxx/modules/std.compat/cfloat.inc
+++ b/libcxx/modules/std.compat/cfloat.inc
@@ -7,6 +7,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-export {
+_LIBCPP_MODULE_EXPORT {
   // This module exports nothing.
-} // export
+} // _LIBCPP_MODULE_EXPORT

--- a/libcxx/modules/std.compat/cinttypes.inc
+++ b/libcxx/modules/std.compat/cinttypes.inc
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-export {
+_LIBCPP_MODULE_EXPORT {
   using ::imaxdiv_t _LIBCPP_USING_IF_EXISTS;
 
   using ::imaxabs _LIBCPP_USING_IF_EXISTS;
@@ -22,4 +22,4 @@ export {
 
   // div is conditionally here, but always present in cstdlib.cppm. To avoid
   // conflicing declarations omit the using here.
-} // export
+} // _LIBCPP_MODULE_EXPORT

--- a/libcxx/modules/std.compat/climits.inc
+++ b/libcxx/modules/std.compat/climits.inc
@@ -7,6 +7,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-export {
+_LIBCPP_MODULE_EXPORT {
   // This module exports nothing.
-} // export
+} // _LIBCPP_MODULE_EXPORT

--- a/libcxx/modules/std.compat/clocale.inc
+++ b/libcxx/modules/std.compat/clocale.inc
@@ -7,11 +7,11 @@
 //
 //===----------------------------------------------------------------------===//
 
-export {
+_LIBCPP_MODULE_EXPORT {
 #ifndef _LIBCPP_HAS_NO_LOCALIZATION
   using ::lconv _LIBCPP_USING_IF_EXISTS;
 
   using ::localeconv _LIBCPP_USING_IF_EXISTS;
   using ::setlocale _LIBCPP_USING_IF_EXISTS;
 #endif // _LIBCPP_HAS_NO_LOCALIZATION
-} // export
+} // _LIBCPP_MODULE_EXPORT

--- a/libcxx/modules/std.compat/cmath.inc
+++ b/libcxx/modules/std.compat/cmath.inc
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-export {
+_LIBCPP_MODULE_EXPORT {
   using ::double_t _LIBCPP_USING_IF_EXISTS;
   using ::float_t _LIBCPP_USING_IF_EXISTS;
 
@@ -265,4 +265,4 @@ export {
   using ::signbit _LIBCPP_USING_IF_EXISTS;
 
   // [sf.cmath], mathematical special functions
-} // export
+} // _LIBCPP_MODULE_EXPORT

--- a/libcxx/modules/std.compat/csetjmp.inc
+++ b/libcxx/modules/std.compat/csetjmp.inc
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-export {
+_LIBCPP_MODULE_EXPORT {
   using ::jmp_buf _LIBCPP_USING_IF_EXISTS;
   using ::longjmp _LIBCPP_USING_IF_EXISTS;
-} // export
+} // _LIBCPP_MODULE_EXPORT

--- a/libcxx/modules/std.compat/csignal.inc
+++ b/libcxx/modules/std.compat/csignal.inc
@@ -7,11 +7,11 @@
 //
 //===----------------------------------------------------------------------===//
 
-export {
+_LIBCPP_MODULE_EXPORT {
   using ::sig_atomic_t _LIBCPP_USING_IF_EXISTS;
 
   // [support.signal], signal handlers
   using ::signal _LIBCPP_USING_IF_EXISTS;
 
   using ::raise _LIBCPP_USING_IF_EXISTS;
-} // export
+} // _LIBCPP_MODULE_EXPORT

--- a/libcxx/modules/std.compat/cstdarg.inc
+++ b/libcxx/modules/std.compat/cstdarg.inc
@@ -7,4 +7,4 @@
 //
 //===----------------------------------------------------------------------===//
 
-export { using ::va_list _LIBCPP_USING_IF_EXISTS; } // export
+_LIBCPP_MODULE_EXPORT { using ::va_list _LIBCPP_USING_IF_EXISTS; } // _LIBCPP_MODULE_EXPORT

--- a/libcxx/modules/std.compat/cstddef.inc
+++ b/libcxx/modules/std.compat/cstddef.inc
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-export {
+_LIBCPP_MODULE_EXPORT {
   using ::max_align_t _LIBCPP_USING_IF_EXISTS;
   using ::nullptr_t;
   using ::ptrdiff_t _LIBCPP_USING_IF_EXISTS;
@@ -19,4 +19,4 @@ export {
   // function templates described in [support.types.byteops]. ...
 
   // [support.types.byteops], byte type operations
-} // export
+} // _LIBCPP_MODULE_EXPORT

--- a/libcxx/modules/std.compat/cstdint.inc
+++ b/libcxx/modules/std.compat/cstdint.inc
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-export {
+_LIBCPP_MODULE_EXPORT {
   // signed
   using ::int8_t _LIBCPP_USING_IF_EXISTS;
   using ::int16_t _LIBCPP_USING_IF_EXISTS;
@@ -47,4 +47,4 @@ export {
   using ::uintmax_t _LIBCPP_USING_IF_EXISTS;
 
   using ::uintptr_t _LIBCPP_USING_IF_EXISTS;
-} // export
+} // _LIBCPP_MODULE_EXPORT

--- a/libcxx/modules/std.compat/cstdio.inc
+++ b/libcxx/modules/std.compat/cstdio.inc
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-export {
+_LIBCPP_MODULE_EXPORT {
   using ::FILE _LIBCPP_USING_IF_EXISTS;
   using ::fpos_t _LIBCPP_USING_IF_EXISTS;
   using ::size_t _LIBCPP_USING_IF_EXISTS;
@@ -58,4 +58,4 @@ export {
   using ::vsprintf _LIBCPP_USING_IF_EXISTS;
   using ::vsscanf _LIBCPP_USING_IF_EXISTS;
 
-} // export
+} // _LIBCPP_MODULE_EXPORT

--- a/libcxx/modules/std.compat/cstdlib.inc
+++ b/libcxx/modules/std.compat/cstdlib.inc
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-export {
+_LIBCPP_MODULE_EXPORT {
   using ::div_t _LIBCPP_USING_IF_EXISTS;
   using ::ldiv_t _LIBCPP_USING_IF_EXISTS;
   using ::lldiv_t _LIBCPP_USING_IF_EXISTS;
@@ -69,4 +69,4 @@ export {
   using ::ldiv _LIBCPP_USING_IF_EXISTS;
   using ::lldiv _LIBCPP_USING_IF_EXISTS;
 
-} // export
+} // _LIBCPP_MODULE_EXPORT

--- a/libcxx/modules/std.compat/cstring.inc
+++ b/libcxx/modules/std.compat/cstring.inc
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-export {
+_LIBCPP_MODULE_EXPORT {
   using ::size_t _LIBCPP_USING_IF_EXISTS;
 
   using ::memchr _LIBCPP_USING_IF_EXISTS;
@@ -33,4 +33,4 @@ export {
   using ::strtok _LIBCPP_USING_IF_EXISTS;
   using ::strxfrm _LIBCPP_USING_IF_EXISTS;
 
-} // export
+} // _LIBCPP_MODULE_EXPORT

--- a/libcxx/modules/std.compat/ctime.inc
+++ b/libcxx/modules/std.compat/ctime.inc
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-export {
+_LIBCPP_MODULE_EXPORT {
   using ::clock_t _LIBCPP_USING_IF_EXISTS;
   using ::size_t _LIBCPP_USING_IF_EXISTS;
   using ::time_t _LIBCPP_USING_IF_EXISTS;
@@ -25,4 +25,4 @@ export {
   using ::strftime _LIBCPP_USING_IF_EXISTS;
   using ::time _LIBCPP_USING_IF_EXISTS;
   using ::timespec_get _LIBCPP_USING_IF_EXISTS;
-} // export
+} // _LIBCPP_MODULE_EXPORT

--- a/libcxx/modules/std.compat/cuchar.inc
+++ b/libcxx/modules/std.compat/cuchar.inc
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-export {
+_LIBCPP_MODULE_EXPORT {
   // Note the Standard does not mark these symbols optional, but libc++'s header
   // does. So this seems strictly not to be conforming.
 
@@ -25,4 +25,4 @@ export {
   using ::c16rtomb _LIBCPP_USING_IF_EXISTS;
   using ::mbrtoc32 _LIBCPP_USING_IF_EXISTS;
   using ::c32rtomb _LIBCPP_USING_IF_EXISTS;
-} // export
+} // _LIBCPP_MODULE_EXPORT

--- a/libcxx/modules/std.compat/cwchar.inc
+++ b/libcxx/modules/std.compat/cwchar.inc
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-export {
+_LIBCPP_MODULE_EXPORT {
 #ifndef _LIBCPP_HAS_NO_WIDE_CHARACTERS
   using ::mbstate_t _LIBCPP_USING_IF_EXISTS;
   using ::size_t _LIBCPP_USING_IF_EXISTS;
@@ -77,4 +77,4 @@ export {
   using ::wcrtomb _LIBCPP_USING_IF_EXISTS;
   using ::wcsrtombs _LIBCPP_USING_IF_EXISTS;
 #endif // _LIBCPP_HAS_NO_WIDE_CHARACTERS
-} // export
+} // _LIBCPP_MODULE_EXPORT

--- a/libcxx/modules/std.compat/cwctype.inc
+++ b/libcxx/modules/std.compat/cwctype.inc
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-export {
+_LIBCPP_MODULE_EXPORT {
 #ifndef _LIBCPP_HAS_NO_WIDE_CHARACTERS
   using ::wctrans_t _LIBCPP_USING_IF_EXISTS;
   using ::wctype_t _LIBCPP_USING_IF_EXISTS;
@@ -32,4 +32,4 @@ export {
   using ::wctrans _LIBCPP_USING_IF_EXISTS;
   using ::wctype _LIBCPP_USING_IF_EXISTS;
 #endif // _LIBCPP_HAS_NO_WIDE_CHARACTERS
-} // export
+} // _LIBCPP_MODULE_EXPORT

--- a/libcxx/modules/std/algorithm.inc
+++ b/libcxx/modules/std/algorithm.inc
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-export namespace std {
+_LIBCPP_MODULE_EXPORT namespace std {
   namespace ranges {
     // [algorithms.results], algorithm result types
     using std::ranges::in_found_result;

--- a/libcxx/modules/std/any.inc
+++ b/libcxx/modules/std/any.inc
@@ -7,8 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-export namespace std {
-
+_LIBCPP_MODULE_EXPORT namespace std {
   // [any.bad.any.cast], class bad_any_cast
   using std::bad_any_cast;
 

--- a/libcxx/modules/std/array.inc
+++ b/libcxx/modules/std/array.inc
@@ -7,8 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-export namespace std {
-
+_LIBCPP_MODULE_EXPORT namespace std {
   // [array], class template array
   using std::array;
 

--- a/libcxx/modules/std/atomic.inc
+++ b/libcxx/modules/std/atomic.inc
@@ -7,8 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-export namespace std {
-
+_LIBCPP_MODULE_EXPORT namespace std {
   // [atomics.order], order and consistency
   using std::memory_order _LIBCPP_USING_IF_EXISTS;
   using std::memory_order_acq_rel _LIBCPP_USING_IF_EXISTS;

--- a/libcxx/modules/std/barrier.inc
+++ b/libcxx/modules/std/barrier.inc
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-export namespace std {
+_LIBCPP_MODULE_EXPORT namespace std {
 #ifndef _LIBCPP_HAS_NO_THREADS
   using std::barrier;
 #endif // _LIBCPP_HAS_NO_THREADS

--- a/libcxx/modules/std/bit.inc
+++ b/libcxx/modules/std/bit.inc
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-export namespace std {
+_LIBCPP_MODULE_EXPORT namespace std {
   // [bit.cast], bit_cast
   using std::bit_cast;
 

--- a/libcxx/modules/std/bitset.inc
+++ b/libcxx/modules/std/bitset.inc
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-export namespace std {
+_LIBCPP_MODULE_EXPORT namespace std {
   using std::bitset;
 
   // [bitset.operators], bitset operators

--- a/libcxx/modules/std/cassert.inc
+++ b/libcxx/modules/std/cassert.inc
@@ -7,6 +7,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-export namespace std {
+_LIBCPP_MODULE_EXPORT namespace std {
   // This module exports nothing.
 } // namespace std

--- a/libcxx/modules/std/cctype.inc
+++ b/libcxx/modules/std/cctype.inc
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-export namespace std {
+_LIBCPP_MODULE_EXPORT namespace std {
   using std::isalnum _LIBCPP_USING_IF_EXISTS;
   using std::isalpha _LIBCPP_USING_IF_EXISTS;
   using std::isblank _LIBCPP_USING_IF_EXISTS;

--- a/libcxx/modules/std/cerrno.inc
+++ b/libcxx/modules/std/cerrno.inc
@@ -7,6 +7,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-export namespace std {
+_LIBCPP_MODULE_EXPORT namespace std {
   // This module exports nothing.
 } // namespace std

--- a/libcxx/modules/std/cfenv.inc
+++ b/libcxx/modules/std/cfenv.inc
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-export namespace std {
+_LIBCPP_MODULE_EXPORT namespace std {
   // types
   using std::fenv_t _LIBCPP_USING_IF_EXISTS;
   using std::fexcept_t _LIBCPP_USING_IF_EXISTS;

--- a/libcxx/modules/std/cfloat.inc
+++ b/libcxx/modules/std/cfloat.inc
@@ -7,6 +7,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-export namespace std {
+_LIBCPP_MODULE_EXPORT namespace std {
   // This module exports nothing.
 } // namespace std

--- a/libcxx/modules/std/charconv.inc
+++ b/libcxx/modules/std/charconv.inc
@@ -7,8 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-export namespace std {
-
+_LIBCPP_MODULE_EXPORT namespace std {
   // floating-point format for primitive numerical conversion
   using std::chars_format;
 

--- a/libcxx/modules/std/chrono.inc
+++ b/libcxx/modules/std/chrono.inc
@@ -7,8 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-export namespace std {
-
+_LIBCPP_MODULE_EXPORT namespace std {
   namespace chrono {
     using std::chrono::duration;
     using std::chrono::time_point;
@@ -292,7 +291,7 @@ export namespace std {
   } // namespace chrono
 
 } // namespace std
-export namespace std::inline literals::inline chrono_literals {
+_LIBCPP_MODULE_EXPORT namespace std::inline literals::inline chrono_literals {
   // [time.duration.literals], suffixes for duration literals
   using std::literals::chrono_literals::operator""h;
   using std::literals::chrono_literals::operator""min;

--- a/libcxx/modules/std/cinttypes.inc
+++ b/libcxx/modules/std/cinttypes.inc
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-export namespace std {
+_LIBCPP_MODULE_EXPORT namespace std {
   using std::imaxdiv_t _LIBCPP_USING_IF_EXISTS;
 
   using std::imaxabs _LIBCPP_USING_IF_EXISTS;

--- a/libcxx/modules/std/climits.inc
+++ b/libcxx/modules/std/climits.inc
@@ -7,6 +7,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-export namespace std {
+_LIBCPP_MODULE_EXPORT namespace std {
   // This module exports nothing.
 } // namespace std

--- a/libcxx/modules/std/clocale.inc
+++ b/libcxx/modules/std/clocale.inc
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-export namespace std {
+_LIBCPP_MODULE_EXPORT namespace std {
 #ifndef _LIBCPP_HAS_NO_LOCALIZATION
   using std::lconv _LIBCPP_USING_IF_EXISTS;
 

--- a/libcxx/modules/std/cmath.inc
+++ b/libcxx/modules/std/cmath.inc
@@ -7,8 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-export namespace std {
-
+_LIBCPP_MODULE_EXPORT namespace std {
   using std::double_t _LIBCPP_USING_IF_EXISTS;
   using std::float_t _LIBCPP_USING_IF_EXISTS;
 

--- a/libcxx/modules/std/codecvt.inc
+++ b/libcxx/modules/std/codecvt.inc
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-export namespace std {
+_LIBCPP_MODULE_EXPORT namespace std {
 #ifndef _LIBCPP_HAS_NO_LOCALIZATION
 #  if _LIBCPP_STD_VER < 26 || defined(_LIBCPP_ENABLE_CXX26_REMOVED_CODECVT)
   using std::codecvt_mode;

--- a/libcxx/modules/std/compare.inc
+++ b/libcxx/modules/std/compare.inc
@@ -7,8 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-export namespace std {
-
+_LIBCPP_MODULE_EXPORT namespace std {
   // [cmp.categories], comparison category types
   using std::partial_ordering;
   using std::strong_ordering;

--- a/libcxx/modules/std/complex.inc
+++ b/libcxx/modules/std/complex.inc
@@ -7,8 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-export namespace std {
-
+_LIBCPP_MODULE_EXPORT namespace std {
   // [complex], class template complex
   using std::complex;
 

--- a/libcxx/modules/std/concepts.inc
+++ b/libcxx/modules/std/concepts.inc
@@ -7,8 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-export namespace std {
-
+_LIBCPP_MODULE_EXPORT namespace std {
   // [concepts.lang], language-related concepts
   // [concept.same], concept same_as
   using std::same_as;

--- a/libcxx/modules/std/condition_variable.inc
+++ b/libcxx/modules/std/condition_variable.inc
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-export namespace std {
+_LIBCPP_MODULE_EXPORT namespace std {
 #ifndef _LIBCPP_HAS_NO_THREADS
   // [thread.condition.condvar], class condition_variable
   using std::condition_variable;

--- a/libcxx/modules/std/coroutine.inc
+++ b/libcxx/modules/std/coroutine.inc
@@ -7,8 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-export namespace std {
-
+_LIBCPP_MODULE_EXPORT namespace std {
   // [coroutine.traits], coroutine traits
   using std::coroutine_traits;
 

--- a/libcxx/modules/std/csetjmp.inc
+++ b/libcxx/modules/std/csetjmp.inc
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-export namespace std {
+_LIBCPP_MODULE_EXPORT namespace std {
   using std::jmp_buf _LIBCPP_USING_IF_EXISTS;
   using std::longjmp _LIBCPP_USING_IF_EXISTS;
 } // namespace std

--- a/libcxx/modules/std/csignal.inc
+++ b/libcxx/modules/std/csignal.inc
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-export namespace std {
+_LIBCPP_MODULE_EXPORT namespace std {
   using std::sig_atomic_t _LIBCPP_USING_IF_EXISTS;
 
   // [support.signal], signal handlers

--- a/libcxx/modules/std/cstdarg.inc
+++ b/libcxx/modules/std/cstdarg.inc
@@ -7,6 +7,4 @@
 //
 //===----------------------------------------------------------------------===//
 
-export namespace std {
-  using std::va_list _LIBCPP_USING_IF_EXISTS;
-} // namespace std
+_LIBCPP_MODULE_EXPORT namespace std { using std::va_list _LIBCPP_USING_IF_EXISTS; } // namespace std

--- a/libcxx/modules/std/cstddef.inc
+++ b/libcxx/modules/std/cstddef.inc
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-export namespace std {
+_LIBCPP_MODULE_EXPORT namespace std {
   using std::max_align_t _LIBCPP_USING_IF_EXISTS;
   using std::nullptr_t;
   using std::ptrdiff_t _LIBCPP_USING_IF_EXISTS;

--- a/libcxx/modules/std/cstdint.inc
+++ b/libcxx/modules/std/cstdint.inc
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-export namespace std {
+_LIBCPP_MODULE_EXPORT namespace std {
   // signed
   using std::int8_t _LIBCPP_USING_IF_EXISTS;
   using std::int16_t _LIBCPP_USING_IF_EXISTS;

--- a/libcxx/modules/std/cstdio.inc
+++ b/libcxx/modules/std/cstdio.inc
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-export namespace std {
+_LIBCPP_MODULE_EXPORT namespace std {
   using std::FILE _LIBCPP_USING_IF_EXISTS;
   using std::fpos_t _LIBCPP_USING_IF_EXISTS;
   using std::size_t _LIBCPP_USING_IF_EXISTS;

--- a/libcxx/modules/std/cstdlib.inc
+++ b/libcxx/modules/std/cstdlib.inc
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-export namespace std {
+_LIBCPP_MODULE_EXPORT namespace std {
   using std::div_t _LIBCPP_USING_IF_EXISTS;
   using std::ldiv_t _LIBCPP_USING_IF_EXISTS;
   using std::lldiv_t _LIBCPP_USING_IF_EXISTS;

--- a/libcxx/modules/std/cstring.inc
+++ b/libcxx/modules/std/cstring.inc
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-export namespace std {
+_LIBCPP_MODULE_EXPORT namespace std {
   using std::size_t _LIBCPP_USING_IF_EXISTS;
 
   using std::memchr _LIBCPP_USING_IF_EXISTS;

--- a/libcxx/modules/std/ctime.inc
+++ b/libcxx/modules/std/ctime.inc
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-export namespace std {
+_LIBCPP_MODULE_EXPORT namespace std {
   using std::clock_t _LIBCPP_USING_IF_EXISTS;
   using std::size_t _LIBCPP_USING_IF_EXISTS;
   using std::time_t _LIBCPP_USING_IF_EXISTS;

--- a/libcxx/modules/std/cuchar.inc
+++ b/libcxx/modules/std/cuchar.inc
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-export namespace std {
+_LIBCPP_MODULE_EXPORT namespace std {
   // Note the Standard does not mark these symbols optional, but libc++'s header
   // does. So this seems strictly not to be conforming.
 

--- a/libcxx/modules/std/cwchar.inc
+++ b/libcxx/modules/std/cwchar.inc
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-export namespace std {
+_LIBCPP_MODULE_EXPORT namespace std {
 #ifndef _LIBCPP_HAS_NO_WIDE_CHARACTERS
   using std::mbstate_t _LIBCPP_USING_IF_EXISTS;
   using std::size_t _LIBCPP_USING_IF_EXISTS;

--- a/libcxx/modules/std/cwctype.inc
+++ b/libcxx/modules/std/cwctype.inc
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-export namespace std {
+_LIBCPP_MODULE_EXPORT namespace std {
 #ifndef _LIBCPP_HAS_NO_WIDE_CHARACTERS
   using std::wctrans_t _LIBCPP_USING_IF_EXISTS;
   using std::wctype_t _LIBCPP_USING_IF_EXISTS;

--- a/libcxx/modules/std/deque.inc
+++ b/libcxx/modules/std/deque.inc
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-export namespace std {
+_LIBCPP_MODULE_EXPORT namespace std {
   // [deque], class template deque
   using std::deque;
 

--- a/libcxx/modules/std/exception.inc
+++ b/libcxx/modules/std/exception.inc
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-export namespace std {
+_LIBCPP_MODULE_EXPORT namespace std {
   using std::bad_exception;
   using std::current_exception;
   using std::exception;

--- a/libcxx/modules/std/execution.inc
+++ b/libcxx/modules/std/execution.inc
@@ -8,13 +8,13 @@
 //===----------------------------------------------------------------------===//
 
 #ifdef _LIBCPP_ENABLE_EXPERIMENTAL
-export namespace std {
+_LIBCPP_MODULE_EXPORT namespace std {
   // [execpol.type], execution policy type trait
   using std::is_execution_policy;
   using std::is_execution_policy_v;
 } // namespace std
 
-export namespace std::execution {
+_LIBCPP_MODULE_EXPORT namespace std::execution {
   // [execpol.seq], sequenced execution policy
   using std::execution::sequenced_policy;
 

--- a/libcxx/modules/std/expected.inc
+++ b/libcxx/modules/std/expected.inc
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-export namespace std {
+_LIBCPP_MODULE_EXPORT namespace std {
 #if _LIBCPP_STD_VER >= 23
   // [expected.unexpected], class template unexpected
   using std::unexpected;

--- a/libcxx/modules/std/filesystem.inc
+++ b/libcxx/modules/std/filesystem.inc
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-export namespace std::filesystem {
+_LIBCPP_MODULE_EXPORT namespace std::filesystem {
   // [fs.class.path], paths
   using std::filesystem::path;
 
@@ -109,11 +109,9 @@ export namespace std::filesystem {
 } // namespace std::filesystem
 
 // [fs.path.hash], hash support
-export namespace std {
-  using std::hash;
-}
+_LIBCPP_MODULE_EXPORT namespace std { using std::hash; }
 
-export namespace std::ranges {
+_LIBCPP_MODULE_EXPORT namespace std::ranges {
 #ifndef _LIBCPP_HAS_NO_FILESYSTEM
   using std::ranges::enable_borrowed_range;
   using std::ranges::enable_view;

--- a/libcxx/modules/std/flat_map.inc
+++ b/libcxx/modules/std/flat_map.inc
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-export namespace std {
+_LIBCPP_MODULE_EXPORT namespace std {
 #if 0
   // [flat.map], class template flat_­map
   using std::flat_map;

--- a/libcxx/modules/std/flat_set.inc
+++ b/libcxx/modules/std/flat_set.inc
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-export namespace std {
+_LIBCPP_MODULE_EXPORT namespace std {
 #if 0
   // [flat.set], class template flat_­set
   using std::flat_set;

--- a/libcxx/modules/std/format.inc
+++ b/libcxx/modules/std/format.inc
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-export namespace std {
+_LIBCPP_MODULE_EXPORT namespace std {
   // [format.context], class template basic_format_context
   using std::basic_format_context;
   using std::format_context;

--- a/libcxx/modules/std/forward_list.inc
+++ b/libcxx/modules/std/forward_list.inc
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-export namespace std {
+_LIBCPP_MODULE_EXPORT namespace std {
   // [forward.list], class template forward_list
   using std::forward_list;
 

--- a/libcxx/modules/std/fstream.inc
+++ b/libcxx/modules/std/fstream.inc
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-export namespace std {
+_LIBCPP_MODULE_EXPORT namespace std {
 #ifndef _LIBCPP_HAS_NO_LOCALIZATION
   using std::basic_filebuf;
 

--- a/libcxx/modules/std/functional.inc
+++ b/libcxx/modules/std/functional.inc
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-export namespace std {
+_LIBCPP_MODULE_EXPORT namespace std {
   // [func.invoke], invoke
   using std::invoke;
 #if _LIBCPP_STD_VER >= 23

--- a/libcxx/modules/std/future.inc
+++ b/libcxx/modules/std/future.inc
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-export namespace std {
+_LIBCPP_MODULE_EXPORT namespace std {
 #ifndef _LIBCPP_HAS_NO_THREADS
   using std::future_errc;
   using std::future_status;

--- a/libcxx/modules/std/generator.inc
+++ b/libcxx/modules/std/generator.inc
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-export namespace std {
+_LIBCPP_MODULE_EXPORT namespace std {
 #if 0
   using std::generator;
 #endif

--- a/libcxx/modules/std/hazard_pointer.inc
+++ b/libcxx/modules/std/hazard_pointer.inc
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-export namespace std {
+_LIBCPP_MODULE_EXPORT namespace std {
 #if 0
 #  if _LIBCPP_STD_VER >= 23
   // 4.1.3, class template hazard_pointer_obj_base

--- a/libcxx/modules/std/initializer_list.inc
+++ b/libcxx/modules/std/initializer_list.inc
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-export namespace std {
+_LIBCPP_MODULE_EXPORT namespace std {
   using std::initializer_list;
 
   // [support.initlist.range], initializer list range access

--- a/libcxx/modules/std/iomanip.inc
+++ b/libcxx/modules/std/iomanip.inc
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-export namespace std {
+_LIBCPP_MODULE_EXPORT namespace std {
 #ifndef _LIBCPP_HAS_NO_LOCALIZATION
   using std::get_money;
   using std::get_time;

--- a/libcxx/modules/std/ios.inc
+++ b/libcxx/modules/std/ios.inc
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-export namespace std {
+_LIBCPP_MODULE_EXPORT namespace std {
 #ifndef _LIBCPP_HAS_NO_LOCALIZATION
   using std::fpos;
   // based on [tab:fpos.operations]

--- a/libcxx/modules/std/iosfwd.inc
+++ b/libcxx/modules/std/iosfwd.inc
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-export namespace std {
+_LIBCPP_MODULE_EXPORT namespace std {
   using std::streampos;
 #ifndef _LIBCPP_HAS_NO_WIDE_CHARACTERS
   using std::wstreampos;

--- a/libcxx/modules/std/iostream.inc
+++ b/libcxx/modules/std/iostream.inc
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-export namespace std {
+_LIBCPP_MODULE_EXPORT namespace std {
 #ifndef _LIBCPP_HAS_NO_LOCALIZATION
   using std::cerr;
   using std::cin;

--- a/libcxx/modules/std/istream.inc
+++ b/libcxx/modules/std/istream.inc
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-export namespace std {
+_LIBCPP_MODULE_EXPORT namespace std {
 #ifndef _LIBCPP_HAS_NO_LOCALIZATION
   using std::basic_istream;
 

--- a/libcxx/modules/std/iterator.inc
+++ b/libcxx/modules/std/iterator.inc
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-export namespace std {
+_LIBCPP_MODULE_EXPORT namespace std {
   // [iterator.assoc.types], associated types
   // [incrementable.traits], incrementable traits
   using std::incrementable_traits;

--- a/libcxx/modules/std/latch.inc
+++ b/libcxx/modules/std/latch.inc
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-export namespace std {
+_LIBCPP_MODULE_EXPORT namespace std {
 #ifndef _LIBCPP_HAS_NO_THREADS
   using std::latch;
 #endif // _LIBCPP_HAS_NO_THREADS

--- a/libcxx/modules/std/limits.inc
+++ b/libcxx/modules/std/limits.inc
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-export namespace std {
+_LIBCPP_MODULE_EXPORT namespace std {
   // [fp.style], floating-point type properties
   using std::float_denorm_style;
   using std::float_round_style;

--- a/libcxx/modules/std/list.inc
+++ b/libcxx/modules/std/list.inc
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-export namespace std {
+_LIBCPP_MODULE_EXPORT namespace std {
   // [list], class template list
   using std::list;
 

--- a/libcxx/modules/std/locale.inc
+++ b/libcxx/modules/std/locale.inc
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-export namespace std {
+_LIBCPP_MODULE_EXPORT namespace std {
 #ifndef _LIBCPP_HAS_NO_LOCALIZATION
   // [locale], locale
   using std::has_facet;

--- a/libcxx/modules/std/map.inc
+++ b/libcxx/modules/std/map.inc
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-export namespace std {
+_LIBCPP_MODULE_EXPORT namespace std {
   // [map], class template map
   using std::map;
 

--- a/libcxx/modules/std/mdspan.inc
+++ b/libcxx/modules/std/mdspan.inc
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-export namespace std {
+_LIBCPP_MODULE_EXPORT namespace std {
 #if _LIBCPP_STD_VER >= 23
   // [mdspan.extents], class template extents
   using std::extents;

--- a/libcxx/modules/std/memory.inc
+++ b/libcxx/modules/std/memory.inc
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-export namespace std {
+_LIBCPP_MODULE_EXPORT namespace std {
   // [pointer.traits], pointer traits
   using std::pointer_traits;
 

--- a/libcxx/modules/std/memory_resource.inc
+++ b/libcxx/modules/std/memory_resource.inc
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-export namespace std::pmr {
+_LIBCPP_MODULE_EXPORT namespace std::pmr {
   // [mem.res.class], class memory_resource
   using std::pmr::memory_resource;
 

--- a/libcxx/modules/std/mutex.inc
+++ b/libcxx/modules/std/mutex.inc
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-export namespace std {
+_LIBCPP_MODULE_EXPORT namespace std {
 #ifndef _LIBCPP_HAS_NO_THREADS
   // [thread.mutex.class], class mutex
   using std::mutex;

--- a/libcxx/modules/std/new.inc
+++ b/libcxx/modules/std/new.inc
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-export namespace std {
+_LIBCPP_MODULE_EXPORT namespace std {
   // [alloc.errors], storage allocation errors
   using std::bad_alloc;
   using std::bad_array_new_length;
@@ -34,9 +34,9 @@ export namespace std {
 #endif
 } // namespace std
 
-export {
+_LIBCPP_MODULE_EXPORT {
   using ::operator new;
   using ::operator delete;
   using ::operator new[];
   using ::operator delete[];
-} // export
+} // _LIBCPP_MODULE_EXPORT

--- a/libcxx/modules/std/numbers.inc
+++ b/libcxx/modules/std/numbers.inc
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-export namespace std::numbers {
+_LIBCPP_MODULE_EXPORT namespace std::numbers {
   using std::numbers::e_v;
   using std::numbers::egamma_v;
   using std::numbers::inv_pi_v;

--- a/libcxx/modules/std/numeric.inc
+++ b/libcxx/modules/std/numeric.inc
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-export namespace std {
+_LIBCPP_MODULE_EXPORT namespace std {
   // [accumulate], accumulate
   using std::accumulate;
 

--- a/libcxx/modules/std/optional.inc
+++ b/libcxx/modules/std/optional.inc
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-export namespace std {
+_LIBCPP_MODULE_EXPORT namespace std {
   // [optional.optional], class template optional
   using std::optional;
 

--- a/libcxx/modules/std/ostream.inc
+++ b/libcxx/modules/std/ostream.inc
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-export namespace std {
+_LIBCPP_MODULE_EXPORT namespace std {
 #ifndef _LIBCPP_HAS_NO_LOCALIZATION
   using std::basic_ostream;
 

--- a/libcxx/modules/std/print.inc
+++ b/libcxx/modules/std/print.inc
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-export namespace std {
+_LIBCPP_MODULE_EXPORT namespace std {
 #if _LIBCPP_STD_VER >= 23
   // [print.fun], print functions
   using std::print;

--- a/libcxx/modules/std/queue.inc
+++ b/libcxx/modules/std/queue.inc
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-export namespace std {
+_LIBCPP_MODULE_EXPORT namespace std {
   // [queue], class template queue
   using std::queue;
 

--- a/libcxx/modules/std/random.inc
+++ b/libcxx/modules/std/random.inc
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-export namespace std {
+_LIBCPP_MODULE_EXPORT namespace std {
   // [rand.req.urng], uniform random bit generator requirements
   using std::uniform_random_bit_generator;
 

--- a/libcxx/modules/std/ranges.inc
+++ b/libcxx/modules/std/ranges.inc
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-export namespace std {
+_LIBCPP_MODULE_EXPORT namespace std {
   namespace ranges {
     inline namespace __cpo {
       // [range.access], range access

--- a/libcxx/modules/std/ratio.inc
+++ b/libcxx/modules/std/ratio.inc
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-export namespace std {
+_LIBCPP_MODULE_EXPORT namespace std {
   // [ratio.ratio], class template ratio
   using std::ratio;
 

--- a/libcxx/modules/std/rcu.inc
+++ b/libcxx/modules/std/rcu.inc
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-export namespace std {
+_LIBCPP_MODULE_EXPORT namespace std {
 #if 0
 #  if _LIBCPP_STD_VER >= 23
   // 2.2.3, class template rcu_obj_base using std::rcu_obj_base;

--- a/libcxx/modules/std/regex.inc
+++ b/libcxx/modules/std/regex.inc
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-export namespace std {
+_LIBCPP_MODULE_EXPORT namespace std {
 #ifndef _LIBCPP_HAS_NO_LOCALIZATION
   // [re.const], regex constants
   namespace regex_constants {

--- a/libcxx/modules/std/scoped_allocator.inc
+++ b/libcxx/modules/std/scoped_allocator.inc
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-export namespace std {
+_LIBCPP_MODULE_EXPORT namespace std {
   // class template scoped_allocator_adaptor
   using std::scoped_allocator_adaptor;
 

--- a/libcxx/modules/std/semaphore.inc
+++ b/libcxx/modules/std/semaphore.inc
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-export namespace std {
+_LIBCPP_MODULE_EXPORT namespace std {
 #ifndef _LIBCPP_HAS_NO_THREADS
   // [thread.sema.cnt], class template counting_semaphore
   using std::counting_semaphore;

--- a/libcxx/modules/std/set.inc
+++ b/libcxx/modules/std/set.inc
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-export namespace std {
+_LIBCPP_MODULE_EXPORT namespace std {
   // [set], class template set
   using std::set;
 

--- a/libcxx/modules/std/shared_mutex.inc
+++ b/libcxx/modules/std/shared_mutex.inc
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-export namespace std {
+_LIBCPP_MODULE_EXPORT namespace std {
 #ifndef _LIBCPP_HAS_NO_THREADS
   // [thread.sharedmutex.class], class shared_­mutex
   using std::shared_mutex;

--- a/libcxx/modules/std/source_location.inc
+++ b/libcxx/modules/std/source_location.inc
@@ -7,6 +7,4 @@
 //
 //===----------------------------------------------------------------------===//
 
-export namespace std {
-  using std::source_location;
-} // namespace std
+_LIBCPP_MODULE_EXPORT namespace std { using std::source_location; } // namespace std

--- a/libcxx/modules/std/span.inc
+++ b/libcxx/modules/std/span.inc
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-export namespace std {
+_LIBCPP_MODULE_EXPORT namespace std {
   // constants
   using std::dynamic_extent;
 

--- a/libcxx/modules/std/spanstream.inc
+++ b/libcxx/modules/std/spanstream.inc
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-export namespace std {
+_LIBCPP_MODULE_EXPORT namespace std {
 #if 0
   using std::basic_spanbuf;
 

--- a/libcxx/modules/std/sstream.inc
+++ b/libcxx/modules/std/sstream.inc
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-export namespace std {
+_LIBCPP_MODULE_EXPORT namespace std {
 #ifndef _LIBCPP_HAS_NO_LOCALIZATION
   using std::basic_stringbuf;
 

--- a/libcxx/modules/std/stack.inc
+++ b/libcxx/modules/std/stack.inc
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-export namespace std {
+_LIBCPP_MODULE_EXPORT namespace std {
   // [stack], class template stack
   using std::stack;
 

--- a/libcxx/modules/std/stacktrace.inc
+++ b/libcxx/modules/std/stacktrace.inc
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-export namespace std {
+_LIBCPP_MODULE_EXPORT namespace std {
 #if 0
   // [stacktrace.entry], class stacktrace_­entry
   using std::stacktrace_entry;

--- a/libcxx/modules/std/stdexcept.inc
+++ b/libcxx/modules/std/stdexcept.inc
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-export namespace std {
+_LIBCPP_MODULE_EXPORT namespace std {
   using std::domain_error;
   using std::invalid_argument;
   using std::length_error;

--- a/libcxx/modules/std/stdfloat.inc
+++ b/libcxx/modules/std/stdfloat.inc
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-export namespace std {
+_LIBCPP_MODULE_EXPORT namespace std {
 #if defined(__STDCPP_FLOAT16_T__)
   using std::float16_t;
 #endif

--- a/libcxx/modules/std/stop_token.inc
+++ b/libcxx/modules/std/stop_token.inc
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-export namespace std {
+_LIBCPP_MODULE_EXPORT namespace std {
 #ifndef _LIBCPP_HAS_NO_THREADS
 #  ifdef _LIBCPP_ENABLE_EXPERIMENTAL
   // [stoptoken], class stop_­token

--- a/libcxx/modules/std/streambuf.inc
+++ b/libcxx/modules/std/streambuf.inc
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-export namespace std {
+_LIBCPP_MODULE_EXPORT namespace std {
 #ifndef _LIBCPP_HAS_NO_LOCALIZATION
   using std::basic_streambuf;
   using std::streambuf;

--- a/libcxx/modules/std/string.inc
+++ b/libcxx/modules/std/string.inc
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-export namespace std {
+_LIBCPP_MODULE_EXPORT namespace std {
   // [char.traits], character traits
   using std::char_traits;
 

--- a/libcxx/modules/std/string_view.inc
+++ b/libcxx/modules/std/string_view.inc
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-export namespace std {
+_LIBCPP_MODULE_EXPORT namespace std {
   // [string.view.template], class template basic_string_view
   using std::basic_string_view;
 

--- a/libcxx/modules/std/strstream.inc
+++ b/libcxx/modules/std/strstream.inc
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-export namespace std {
+_LIBCPP_MODULE_EXPORT namespace std {
 #ifndef _LIBCPP_HAS_NO_LOCALIZATION
 #  if _LIBCPP_STD_VER < 26 || defined(_LIBCPP_ENABLE_CXX26_REMOVED_STRSTREAM)
   using std::istrstream;

--- a/libcxx/modules/std/syncstream.inc
+++ b/libcxx/modules/std/syncstream.inc
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-export namespace std {
+_LIBCPP_MODULE_EXPORT namespace std {
 #if !defined(_LIBCPP_HAS_NO_LOCALIZATION) && !defined(_LIBCPP_HAS_NO_EXPERIMENTAL_SYNCSTREAM)
   using std::basic_syncbuf;
 

--- a/libcxx/modules/std/system_error.inc
+++ b/libcxx/modules/std/system_error.inc
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-export namespace std {
+_LIBCPP_MODULE_EXPORT namespace std {
   using std::error_category;
   using std::generic_category;
   using std::system_category;

--- a/libcxx/modules/std/text_encoding.inc
+++ b/libcxx/modules/std/text_encoding.inc
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-export namespace std {
+_LIBCPP_MODULE_EXPORT namespace std {
 #if 0
 #  if _LIBCPP_STD_VER >= 23
   using std::text_encoding;

--- a/libcxx/modules/std/thread.inc
+++ b/libcxx/modules/std/thread.inc
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-export namespace std {
+_LIBCPP_MODULE_EXPORT namespace std {
 #ifndef _LIBCPP_HAS_NO_THREADS
   // [thread.thread.class], class thread
   using std::thread;

--- a/libcxx/modules/std/tuple.inc
+++ b/libcxx/modules/std/tuple.inc
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-export namespace std {
+_LIBCPP_MODULE_EXPORT namespace std {
   // [tuple.tuple], class template tuple
   using std::tuple;
 

--- a/libcxx/modules/std/type_traits.inc
+++ b/libcxx/modules/std/type_traits.inc
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-export namespace std {
+_LIBCPP_MODULE_EXPORT namespace std {
   // [meta.help], helper class
   using std::integral_constant;
 

--- a/libcxx/modules/std/typeindex.inc
+++ b/libcxx/modules/std/typeindex.inc
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-export namespace std {
+_LIBCPP_MODULE_EXPORT namespace std {
   using std::hash;
   using std::type_index;
 } // namespace std

--- a/libcxx/modules/std/typeinfo.inc
+++ b/libcxx/modules/std/typeinfo.inc
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-export namespace std {
+_LIBCPP_MODULE_EXPORT namespace std {
   using std::bad_cast;
   using std::bad_typeid;
   using std::type_info;

--- a/libcxx/modules/std/unordered_map.inc
+++ b/libcxx/modules/std/unordered_map.inc
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-export namespace std {
+_LIBCPP_MODULE_EXPORT namespace std {
   // [unord.map], class template unordered_­map
   using std::unordered_map;
 

--- a/libcxx/modules/std/unordered_set.inc
+++ b/libcxx/modules/std/unordered_set.inc
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-export namespace std {
+_LIBCPP_MODULE_EXPORT namespace std {
   // [unord.set], class template unordered_­set
   using std::unordered_set;
 

--- a/libcxx/modules/std/utility.inc
+++ b/libcxx/modules/std/utility.inc
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-export namespace std {
+_LIBCPP_MODULE_EXPORT namespace std {
   // [utility.swap], swap
   using std::swap;
 

--- a/libcxx/modules/std/valarray.inc
+++ b/libcxx/modules/std/valarray.inc
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-export namespace std {
+_LIBCPP_MODULE_EXPORT namespace std {
   using std::gslice;
   using std::gslice_array;
   using std::indirect_array;

--- a/libcxx/modules/std/variant.inc
+++ b/libcxx/modules/std/variant.inc
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-export namespace std {
+_LIBCPP_MODULE_EXPORT namespace std {
   // [variant.variant], class template variant
   using std::variant;
 

--- a/libcxx/modules/std/vector.inc
+++ b/libcxx/modules/std/vector.inc
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-export namespace std {
+_LIBCPP_MODULE_EXPORT namespace std {
   // [vector], class template vector
   using std::vector;
 

--- a/libcxx/modules/std/version.inc
+++ b/libcxx/modules/std/version.inc
@@ -7,6 +7,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-export namespace std {
+_LIBCPP_MODULE_EXPORT namespace std {
   // This module exports nothing.
 } // namespace std

--- a/libcxx/test/tools/clang_tidy_checks/header_exportable_declarations.cpp
+++ b/libcxx/test/tools/clang_tidy_checks/header_exportable_declarations.cpp
@@ -261,9 +261,16 @@ void header_exportable_declarations::check(const clang::ast_matchers::MatchFinde
       return;
 
     // For modules only take the declarations exported.
-    if (is_module(file_type_))
+    if (is_module(file_type_)) {
       if (decl->getModuleOwnershipKind() != clang::Decl::ModuleOwnershipKind::VisibleWhenImported)
         return;
+
+      // The named declarations included in the global module fragment are
+      // attached to the global module. The exported named declarations should
+      // also be attached to the global module.
+      if (!decl->getOwningModule()->isGlobalModule())
+        return;
+    }
 
     if (!is_valid_declaration_context(*decl, name, file_type_))
       return;

--- a/libcxx/utils/libcxx/test/modules.py
+++ b/libcxx/utils/libcxx/test/modules.py
@@ -118,6 +118,9 @@ class module_test_generator:
 // The GCC compiler flags are not always compatible with clang-tidy.
 // UNSUPPORTED: gcc
 
+// Clang 17 does not attach the declarations to the global module.
+// UNSUPPORTED: clang-17
+
 // MODULE_DEPENDENCIES: {self.module}
 
 // RUN: echo -n > {self.tmp_prefix}.all_partitions


### PR DESCRIPTION
Declarations in the global module fragment (the included headers) are attached to the global module. The using declarations in the module std and std.compat were attached to their module.

This violates

  [basic.link]/10
  If two declarations of an entity are attached to different modules, the
  program is ill-formed; no diagnostic is required if neither is reachable from
  the other.

Instead attach the delarations in the module to the global module by using a linkage-specification. ([module.unit]/7)

Thanks to @DanielaE for pointing out this issue.