### PR TITLE
[flang] Fix CMake dependency in CUF/Attributes

### DIFF
--- a/flang/lib/Optimizer/Dialect/CUF/Attributes/CMakeLists.txt
+++ b/flang/lib/Optimizer/Dialect/CUF/Attributes/CMakeLists.txt
@@ -5,6 +5,7 @@ add_flang_library(CUFAttrs
   DEPENDS
   MLIRIR
   CUFAttrsIncGen
+  CUFOpsIncGen
 
   LINK_LIBS
   MLIRTargetLLVMIRExport


### PR DESCRIPTION
flang/lib/Optimizer/Dialect/CUF/Attributes/CUFAttr.cpp includes
CUFDialect.h.inc, but the target generating that isn't currently
depended on in CUF/Attributes. This patch adds that missing dependency.

Fixes #92635
