### PR TITLE
Check if LLD is built when checking if lto_supported

### DIFF
--- a/compiler-rt/test/lit.common.cfg.py
+++ b/compiler-rt/test/lit.common.cfg.py
@@ -744,6 +744,13 @@ def is_binutils_lto_supported():
     return True
 
 
+def is_lld_lto_supported():
+    # We require LLD does support LTO, but we require it to be built with the
+    # latest changes to claim support. Otherwise older copies of LLD may not
+    # understand new bitcode versions.
+    return os.path.exists(os.path.join(config.llvm_tools_dir, "lld"))
+
+
 def is_windows_lto_supported():
     if not target_is_msvc:
         return True
@@ -755,7 +762,7 @@ if config.host_os == "Darwin" and is_darwin_lto_supported():
     config.lto_flags = ["-Wl,-lto_library," + liblto_path()]
 elif config.host_os in ["Linux", "FreeBSD", "NetBSD"]:
     config.lto_supported = False
-    if config.use_lld:
+    if config.use_lld and is_lld_lto_supported():
         config.lto_supported = True
     if is_binutils_lto_supported():
         config.available_features.add("binutils_lto")

--- a/compiler-rt/test/lit.common.cfg.py
+++ b/compiler-rt/test/lit.common.cfg.py
@@ -745,8 +745,8 @@ def is_binutils_lto_supported():
 
 
 def is_lld_lto_supported():
-    # We require LLD does support LTO, but we require it to be built with the
-    # latest changes to claim support. Otherwise older copies of LLD may not
+    # LLD does support LTO, but we require it to be built with the latest
+    # changes to claim support. Otherwise older copies of LLD may not
     # understand new bitcode versions.
     return os.path.exists(os.path.join(config.llvm_tools_dir, "lld"))
 


### PR DESCRIPTION
Otherwise, older copies of LLD may not understand the latest bitcode
versions (for example, if we increase `ModuleSummaryIndex::BitCodeSummaryVersion`)

Related to https://github.com/llvm/llvm-project/pull/90692#issuecomment-2113250317