### PR TITLE
InstSimplify: strip bad TODO (NFC)

### DIFF
--- a/llvm/lib/Analysis/InstructionSimplify.cpp
+++ b/llvm/lib/Analysis/InstructionSimplify.cpp
@@ -5346,9 +5346,6 @@ static Value *foldIdentityShuffles(int DestElt, Value *Op0, Value *Op1,
         SourceShuf->getMaskValue(RootElt), RootVec, MaxRecurse);
   }
 
-  // TODO: Look through bitcasts? What if the bitcast changes the vector element
-  // size?
-
   // The source operand is not a shuffle. Initialize the root vector value for
   // this shuffle if that has not been done yet.
   if (!RootVec)


### PR DESCRIPTION
foldIdentityShuffles requires two sets of canceling shuffles. If there are any intervening instructions, they are feeding in the result of the first set of shuffles. To eliminate the two sets of shuffles, you'd have to rewrite the head of the intervening instructions to feed in the operand of the first set of shuffles. Since modifying the IR in any way is disallowed by an analysis, strip this bad TODO.