### PR TITLE
Documentation: Fix C++ examples in MemorySSA documentation

### DIFF
--- a/llvm/docs/MemorySSA.rst
+++ b/llvm/docs/MemorySSA.rst
@@ -297,7 +297,7 @@ A code snippet for such a walk looks like this:
   MemoryDef *Def;  // find who's optimized or defining for this MemoryDef
   for (auto &U : Def->uses()) {
     MemoryAccess *MA = cast<MemoryAccess>(U.getUser());
-    if (auto *DefUser = cast_or_null<MemoryDef>(MA))
+    if (auto *DefUser = dyn_cast<MemoryDef>(MA))
       if (DefUser->isOptimized() && DefUser->getOptimized() == Def) {
         // User who is optimized to Def
       } else {
@@ -314,7 +314,7 @@ the store.
   checkUses(MemoryAccess *Def) { // Def can be a MemoryDef or a MemoryPhi.
     for (auto &U : Def->uses()) {
       MemoryAccess *MA = cast<MemoryAccess>(U.getUser());
-      if (auto *MU = cast_or_null<MemoryUse>(MA)) {
+      if (auto *MU = dyn_cast<MemoryUse>(MA)) {
         // Process MemoryUse as needed.
       } else {
         // Process MemoryDef or MemoryPhi as needed.

--- a/llvm/docs/MemorySSA.rst
+++ b/llvm/docs/MemorySSA.rst
@@ -295,9 +295,9 @@ A code snippet for such a walk looks like this:
 .. code-block:: c++
 
   MemoryDef *Def;  // find who's optimized or defining for this MemoryDef
-  for (auto& U : Def->uses()) {
-    MemoryAccess *MA = cast<MemoryAccess>(Use.getUser());
-    if (auto *DefUser = cast_of_null<MemoryDef>MA)
+  for (auto &U : Def->uses()) {
+    MemoryAccess *MA = cast<MemoryAccess>(U.getUser());
+    if (auto *DefUser = cast_of_null<MemoryDef>(MA))
       if (DefUser->isOptimized() && DefUser->getOptimized() == Def) {
         // User who is optimized to Def
       } else {
@@ -312,19 +312,18 @@ the store.
 .. code-block:: c++
 
   checkUses(MemoryAccess *Def) { // Def can be a MemoryDef or a MemoryPhi.
-    for (auto& U : Def->uses()) {
-      MemoryAccess *MA = cast<MemoryAccess>(Use.getUser());
-      if (auto *MU = cast_of_null<MemoryUse>MA) {
+    for (auto &U : Def->uses()) {
+      MemoryAccess *MA = cast<MemoryAccess>(U.getUser());
+      if (auto *MU = cast_of_null<MemoryUse>(MA)) {
         // Process MemoryUse as needed.
-      }
-      else {
+      } else {
         // Process MemoryDef or MemoryPhi as needed.
 
         // As a user can come up twice, as an optimized access and defining
         // access, keep a visited list.
 
         // Check transitive uses as needed
-        checkUses (MA); // use a worklist for an iterative algorithm
+        checkUses(MA); // use a worklist for an iterative algorithm
       }
     }
   }

--- a/llvm/docs/MemorySSA.rst
+++ b/llvm/docs/MemorySSA.rst
@@ -297,7 +297,7 @@ A code snippet for such a walk looks like this:
   MemoryDef *Def;  // find who's optimized or defining for this MemoryDef
   for (auto &U : Def->uses()) {
     MemoryAccess *MA = cast<MemoryAccess>(U.getUser());
-    if (auto *DefUser = cast_of_null<MemoryDef>(MA))
+    if (auto *DefUser = cast_or_null<MemoryDef>(MA))
       if (DefUser->isOptimized() && DefUser->getOptimized() == Def) {
         // User who is optimized to Def
       } else {
@@ -314,7 +314,7 @@ the store.
   checkUses(MemoryAccess *Def) { // Def can be a MemoryDef or a MemoryPhi.
     for (auto &U : Def->uses()) {
       MemoryAccess *MA = cast<MemoryAccess>(U.getUser());
-      if (auto *MU = cast_of_null<MemoryUse>(MA)) {
+      if (auto *MU = cast_or_null<MemoryUse>(MA)) {
         // Process MemoryUse as needed.
       } else {
         // Process MemoryDef or MemoryPhi as needed.


### PR DESCRIPTION
No running code change. 
The code examples here used the wrong variable names and are missing parens. Fixed them plus a few styling issues. 