### PR TITLE
[llvm][ELF] Correctly set the .llvm.lto section type

### DIFF
--- a/llvm/lib/CodeGen/TargetLoweringObjectFileImpl.cpp
+++ b/llvm/lib/CodeGen/TargetLoweringObjectFileImpl.cpp
@@ -527,6 +527,9 @@ static unsigned getELFSectionType(StringRef Name, SectionKind K) {
   if (K.isBSS() || K.isThreadBSS())
     return ELF::SHT_NOBITS;
 
+  if(hasPrefix(Name, ".llvm.lto"))
+    return ELF::SHT_LLVM_LTO;
+
   return ELF::SHT_PROGBITS;
 }
 

--- a/llvm/lib/CodeGen/TargetLoweringObjectFileImpl.cpp
+++ b/llvm/lib/CodeGen/TargetLoweringObjectFileImpl.cpp
@@ -527,7 +527,7 @@ static unsigned getELFSectionType(StringRef Name, SectionKind K) {
   if (K.isBSS() || K.isThreadBSS())
     return ELF::SHT_NOBITS;
 
-  if(hasPrefix(Name, ".llvm.lto"))
+  if (hasPrefix(Name, ".llvm.lto"))
     return ELF::SHT_LLVM_LTO;
 
   return ELF::SHT_PROGBITS;

--- a/llvm/test/CodeGen/X86/fat-lto-section.ll
+++ b/llvm/test/CodeGen/X86/fat-lto-section.ll
@@ -5,6 +5,6 @@
 ; RUN:   | FileCheck %s --check-prefix=EXCLUDE
 
 ; EXCLUDE: Name               Type     {{.*}} ES Flg Lk Inf Al
-; EXCLUDE: .llvm.lto          PROGBITS {{.*}} 00   E  0   0  1
+; EXCLUDE: .llvm.lto          LLVM_LTO {{.*}} 00   E  0   0  1
 
 @a = global i32 1


### PR DESCRIPTION
Support for the SHT_LLVM_LTO section type was added in
https://github.com/llvm/llvm-project/commit/a484e020d75d398049e1fcbeb0157d57011714b3,
but the `.llvm.lto` section type was never set. This patch sets the ELF
section type to SHT_LLVM_LTO for sections with a `.llvm.lto` prefix, which
should only be emitted when using FatLTO.
