### PR TITLE
Allow PTO to be modified in PassBuilder

### DIFF
--- a/llvm/include/llvm/Passes/PassBuilder.h
+++ b/llvm/include/llvm/Passes/PassBuilder.h
@@ -679,6 +679,10 @@ public:
                                               StringRef OptionName,
                                               StringRef PassName);
 
+  void setPipelineTuningOptions(PipelineTuningOptions Options) {
+    PTO = Options;
+  }
+
 private:
   // O1 pass pipeline
   FunctionPassManager


### PR DESCRIPTION
llvmlite (and likely other LLVM-as-a-library users) allows changing Pipeline Tuning Options (PTO) of an existing PassBuilder. This seems meaningful enough to support directly instead of having to recreate a new PassBuilder for any modifications to PTO and all the memory management that comes along with this.

Testing:

ninja check