### PR TITLE
[CodeGen][AArch64] Added -mno-va-float to skip FP save in variadic functions

### DIFF
--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -4877,6 +4877,9 @@ foreach i = {8-15,18} in
   def fcall_saved_x#i : Flag<["-"], "fcall-saved-x"#i>, Group<m_aarch64_Features_Group>,
     HelpText<"Make the x"#i#" register call-saved (AArch64 only)">;
 
+def mno_va_float : Flag<["-"], "mno-va-float">, Group<m_aarch64_Features_Group>,
+  HelpText<"Do not generate code to save FP in variadic functions">;
+
 def msve_vector_bits_EQ : Joined<["-"], "msve-vector-bits=">, Group<m_aarch64_Features_Group>,
   Visibility<[ClangOption, FlangOption]>,
   HelpText<"Specify the size in bits of an SVE vector register. Defaults to the"

--- a/clang/lib/Driver/ToolChains/Arch/AArch64.cpp
+++ b/clang/lib/Driver/ToolChains/Arch/AArch64.cpp
@@ -432,6 +432,9 @@ void aarch64::getAArch64TargetFeatures(const Driver &D,
   if (Args.hasArg(options::OPT_mno_neg_immediates))
     Features.push_back("+no-neg-immediates");
 
+  if (Args.hasArg(options::OPT_mno_va_float))
+    Features.push_back("+no-va-float");
+
   if (Arg *A = Args.getLastArg(options::OPT_mfix_cortex_a53_835769,
                                options::OPT_mno_fix_cortex_a53_835769)) {
     if (A->getOption().matches(options::OPT_mfix_cortex_a53_835769))

--- a/llvm/lib/Target/AArch64/AArch64Features.td
+++ b/llvm/lib/Target/AArch64/AArch64Features.td
@@ -788,6 +788,8 @@ def FeaturePAuthLR : Extension<"pauth-lr", "PAuthLR",
 def FeatureTLBIW : Extension<"tlbiw", "TLBIW",
   "Enable ARMv9.5-A TLBI VMALL for Dirty State (FEAT_TLBIW)">;
 
+def FeatureVariadicSaveFP : SubtargetFeature<"no-va-float", "HasNoVaFloat",
+    "true", "Do not generate code to save FP in variadic functions">;
 
 //===----------------------------------------------------------------------===//
 // Architectures.

--- a/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
+++ b/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
@@ -7470,7 +7470,7 @@ void AArch64TargetLowering::saveVarArgRegisters(CCState &CCInfo,
   FuncInfo->setVarArgsGPRIndex(GPRIdx);
   FuncInfo->setVarArgsGPRSize(GPRSaveSize);
 
-  if (Subtarget->hasFPARMv8() && !IsWin64) {
+  if (Subtarget->hasFPARMv8() && !IsWin64 && !Subtarget->hasNoVaFloat()) {
     auto FPRArgRegs = AArch64::getFPRArgRegs();
     const unsigned NumFPRArgRegs = FPRArgRegs.size();
     unsigned FirstVariadicFPR = CCInfo.getFirstUnallocated(FPRArgRegs);

--- a/llvm/test/CodeGen/AArch64/mno-va-float.ll
+++ b/llvm/test/CodeGen/AArch64/mno-va-float.ll
@@ -1,0 +1,21 @@
+; RUN: llc < %s -march=aarch64 -mattr=+no-va-float | FileCheck %s
+
+target datalayout = "e-m:e-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128"
+target triple = "arm64"
+
+%struct.__va_list = type { i8*, i8*, i8*, i32, i32 }
+
+declare i32 @vfunc(i8*, i8*)
+declare void @llvm.va_start(i8*)
+declare void @llvm.va_end(i8*)
+
+define i32 @func(i8*, double, ...) {
+entry:
+  %argp = alloca %struct.__va_list, align 8
+  %argp1 = bitcast %struct.__va_list* %argp to i8*
+  call void @llvm.va_start(i8* %argp1)
+; CHECK-NOT: {{stp.*q[0-9]+}}
+  %ret = call i32 @vfunc(i8* %0, i8* %argp1)
+  call void @llvm.va_end(i8* %argp1)
+  ret i32 %ret
+}

--- a/llvm/test/CodeGen/AArch64/mva-float.ll
+++ b/llvm/test/CodeGen/AArch64/mva-float.ll
@@ -1,0 +1,21 @@
+; RUN: llc < %s -march=aarch64 | FileCheck %s
+
+target datalayout = "e-m:e-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128"
+target triple = "arm64"
+
+%struct.__va_list = type { i8*, i8*, i8*, i32, i32 }
+
+declare i32 @vfunc(i8*, i8*)
+declare void @llvm.va_start(i8*)
+declare void @llvm.va_end(i8*)
+
+define i32 @func(i8*, double, ...) {
+entry:
+  %argp = alloca %struct.__va_list, align 8
+  %argp1 = bitcast %struct.__va_list* %argp to i8*
+  call void @llvm.va_start(i8* %argp1)
+; CHECK: {{stp.*q[0-9]+}}
+  %ret = call i32 @vfunc(i8* %0, i8* %argp1)
+  call void @llvm.va_end(i8* %argp1)
+  ret i32 %ret
+}


### PR DESCRIPTION
This patch adds a new option for AArch64, -mno-va-float which can be used to disable the generation of code that saves FP in variadic functions