### PR TITLE
workflows: Add a job for auditing release assets

### DIFF
--- a/.github/workflows/release-asset-audit.py
+++ b/.github/workflows/release-asset-audit.py
@@ -1,8 +1,8 @@
 import github
 import sys
 
-def main():
 
+def main():
     token = sys.argv[1]
 
     gh = github.Github(login_or_token=token)
@@ -36,7 +36,9 @@ def main():
         print("Release:", release.title)
         for asset in release.get_assets():
             created_at = asset.created_at
-            updated_at = "" if asset.created_at == asset.updated_at else asset.updated_at
+            updated_at = (
+                "" if asset.created_at == asset.updated_at else asset.updated_at
+            )
             print(
                 f"{asset.name} : {asset.uploader.login} [{created_at} {updated_at}] ( {asset.download_count} )"
             )
@@ -45,5 +47,5 @@ def main():
                 sys.exit(1)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/.github/workflows/release-asset-audit.py
+++ b/.github/workflows/release-asset-audit.py
@@ -1,0 +1,40 @@
+import github
+import sys
+
+token = sys.argv[1]
+
+gh = github.Github(login_or_token=token)
+repo = gh.get_repo('llvm/llvm-project')
+
+uploaders = set([
+    'DimitryAndric',
+    'stefanp-ibm',
+    'lei137',
+    'omjavaid',
+    'nicolerabjohn',
+    'amy-kwan',
+    'mandlebug',
+    'zmodem',
+    'androm3da',
+    'tru',
+    'rovka',
+    'rorth',
+    'quinnlp',
+    'kamaub',
+    'abrisco',
+    'jakeegan',
+    'maryammo',
+    'tstellar',
+    'github-actions[bot]'
+])
+
+for release in repo.get_releases():
+    print("Release:", release.title)
+    for asset in release.get_assets():
+        created_at = asset.created_at
+        updated_at = "" if asset.created_at == asset.updated_at else asset.updated_at
+        print(f'{asset.name} : {asset.uploader.login} [{created_at} {updated_at}] ( {asset.download_count} )')
+        if asset.uploader.login not in uploaders:
+          print("Invalid uploader")
+          sys.exit(1)
+

--- a/.github/workflows/release-asset-audit.py
+++ b/.github/workflows/release-asset-audit.py
@@ -4,37 +4,41 @@ import sys
 token = sys.argv[1]
 
 gh = github.Github(login_or_token=token)
-repo = gh.get_repo('llvm/llvm-project')
+repo = gh.get_repo("llvm/llvm-project")
 
-uploaders = set([
-    'DimitryAndric',
-    'stefanp-ibm',
-    'lei137',
-    'omjavaid',
-    'nicolerabjohn',
-    'amy-kwan',
-    'mandlebug',
-    'zmodem',
-    'androm3da',
-    'tru',
-    'rovka',
-    'rorth',
-    'quinnlp',
-    'kamaub',
-    'abrisco',
-    'jakeegan',
-    'maryammo',
-    'tstellar',
-    'github-actions[bot]'
-])
+uploaders = set(
+    [
+        "DimitryAndric",
+        "stefanp-ibm",
+        "lei137",
+        "omjavaid",
+        "nicolerabjohn",
+        "amy-kwan",
+        "mandlebug",
+        "zmodem",
+        "androm3da",
+        "tru",
+        "rovka",
+        "rorth",
+        "quinnlp",
+        "kamaub",
+        "abrisco",
+        "jakeegan",
+        "maryammo",
+        "tstellar",
+        "github-actions[bot]"
+    ]
+)
 
 for release in repo.get_releases():
     print("Release:", release.title)
     for asset in release.get_assets():
         created_at = asset.created_at
         updated_at = "" if asset.created_at == asset.updated_at else asset.updated_at
-        print(f'{asset.name} : {asset.uploader.login} [{created_at} {updated_at}] ( {asset.download_count} )')
+        print(
+            f"{asset.name} : {asset.uploader.login} [{created_at} {updated_at}] ( {asset.download_count} )"
+        )
         if asset.uploader.login not in uploaders:
-          print("Invalid uploader")
-          sys.exit(1)
+            print("Invalid uploader")
+            sys.exit(1)
 

--- a/.github/workflows/release-asset-audit.py
+++ b/.github/workflows/release-asset-audit.py
@@ -1,43 +1,49 @@
 import github
 import sys
 
-token = sys.argv[1]
+def main():
 
-gh = github.Github(login_or_token=token)
-repo = gh.get_repo("llvm/llvm-project")
+    token = sys.argv[1]
 
-uploaders = set(
-    [
-        "DimitryAndric",
-        "stefanp-ibm",
-        "lei137",
-        "omjavaid",
-        "nicolerabjohn",
-        "amy-kwan",
-        "mandlebug",
-        "zmodem",
-        "androm3da",
-        "tru",
-        "rovka",
-        "rorth",
-        "quinnlp",
-        "kamaub",
-        "abrisco",
-        "jakeegan",
-        "maryammo",
-        "tstellar",
-        "github-actions[bot]",
-    ]
-)
+    gh = github.Github(login_or_token=token)
+    repo = gh.get_repo("llvm/llvm-project")
 
-for release in repo.get_releases():
-    print("Release:", release.title)
-    for asset in release.get_assets():
-        created_at = asset.created_at
-        updated_at = "" if asset.created_at == asset.updated_at else asset.updated_at
-        print(
-            f"{asset.name} : {asset.uploader.login} [{created_at} {updated_at}] ( {asset.download_count} )"
-        )
-        if asset.uploader.login not in uploaders:
-            print("Invalid uploader")
-            sys.exit(1)
+    uploaders = set(
+        [
+            "DimitryAndric",
+            "stefanp-ibm",
+            "lei137",
+            "omjavaid",
+            "nicolerabjohn",
+            "amy-kwan",
+            "mandlebug",
+            "zmodem",
+            "androm3da",
+            "tru",
+            "rovka",
+            "rorth",
+            "quinnlp",
+            "kamaub",
+            "abrisco",
+            "jakeegan",
+            "maryammo",
+            "tstellar",
+            "github-actions[bot]",
+        ]
+    )
+
+    for release in repo.get_releases():
+        print("Release:", release.title)
+        for asset in release.get_assets():
+            created_at = asset.created_at
+            updated_at = "" if asset.created_at == asset.updated_at else asset.updated_at
+            print(
+                f"{asset.name} : {asset.uploader.login} [{created_at} {updated_at}] ( {asset.download_count} )"
+            )
+            if asset.uploader.login not in uploaders:
+                print("Invalid uploader")
+                sys.exit(1)
+
+
+if __name__ == '__main__':
+    main()

--- a/.github/workflows/release-asset-audit.py
+++ b/.github/workflows/release-asset-audit.py
@@ -1,7 +1,6 @@
 import github
 import sys
 
-
 def main():
     token = sys.argv[1]
 
@@ -43,7 +42,8 @@ def main():
                 f"{asset.name} : {asset.uploader.login} [{created_at} {updated_at}] ( {asset.download_count} )"
             )
             if asset.uploader.login not in uploaders:
-                print("Invalid uploader")
+                with open('comment', 'w') as file:
+                    file.write(f'@{asset.uploader.login} is not a valid uploader.')
                 sys.exit(1)
 
 

--- a/.github/workflows/release-asset-audit.py
+++ b/.github/workflows/release-asset-audit.py
@@ -26,7 +26,7 @@ uploaders = set(
         "jakeegan",
         "maryammo",
         "tstellar",
-        "github-actions[bot]"
+        "github-actions[bot]",
     ]
 )
 
@@ -41,4 +41,3 @@ for release in repo.get_releases():
         if asset.uploader.login not in uploaders:
             print("Invalid uploader")
             sys.exit(1)
-

--- a/.github/workflows/release-asset-audit.yml
+++ b/.github/workflows/release-asset-audit.yml
@@ -1,0 +1,45 @@
+name: Release Asset Audit
+
+on:
+  workflow_dispatch:
+  schedule:
+    # * is a special character in YAML so you have to quote this string
+    # Run once an hour
+    - cron:  '5 * * * *'
+
+  pull_request:
+    paths:
+      - ".github/workflows/release-asset-audit.py"
+      - ".github/workflows/release-asset-audit.yml"
+
+permissions:
+  contents: read # Default everything to read-only
+
+
+jobs:
+  audit:
+    name: "Release Asset Audit"
+    runs-on: ubuntu-22.04
+    if: github.repository == 'llvm/llvm-project'
+    steps:
+      - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 #v4.1.6
+      - name: "Run Audit Script"
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          pip install --require-hashes -r ./llvm/utils/git/requirements.txt
+          python3 ./.github/workflows/release-asset-audit.py $GITHUB_TOKEN
+      - name: "File Issue"
+        if: failure()
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea #v7.0.1
+        with:
+          github-token: ${{ secrets.ISSUE_SUBSCRIBER_TOKEN }}
+          script: |
+            const issue = await github.rest.issues.create({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               title: "Release Asset Audit Failed",
+               body: `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+               labels: ['infrastructure']
+            });
+            console.log(issue);

--- a/.github/workflows/release-asset-audit.yml
+++ b/.github/workflows/release-asset-audit.yml
@@ -2,6 +2,7 @@ name: Release Asset Audit
 
 on:
   workflow_dispatch:
+  release:
   schedule:
     # * is a special character in YAML so you have to quote this string
     # Run once an hour
@@ -14,7 +15,6 @@ on:
 
 permissions:
   contents: read # Default everything to read-only
-
 
 jobs:
   audit:
@@ -30,16 +30,25 @@ jobs:
           pip install --require-hashes -r ./llvm/utils/git/requirements.txt
           python3 ./.github/workflows/release-asset-audit.py $GITHUB_TOKEN
       - name: "File Issue"
-        if: failure()
+        if: >-
+          github.event_name != 'pull_request' &&
+          failure()
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea #v7.0.1
         with:
           github-token: ${{ secrets.ISSUE_SUBSCRIBER_TOKEN }}
           script: |
+            var fs = require('fs');
+            var body = ''
+            if (fs.existsSync('./comment')) {
+              body = JSON.parse(fs.readFileSync('./comment')) + "\n\n";
+            }
+            body = body + `\n\nhttps://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`
+
             const issue = await github.rest.issues.create({
                owner: context.repo.owner,
                repo: context.repo.repo,
                title: "Release Asset Audit Failed",
-               body: `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
-               labels: ['infrastructure']
+               labels: ['infrastructure'],
+               body: body
             });
             console.log(issue);


### PR DESCRIPTION
This checks to ensure that uploads are only made by 'approved' uploaders, which is just everyone who has uploaded a release asset in the past.

We could do more, but this is just a simple implementation so we can put something in place and see how it works.

For more discussion see:
https://discourse.llvm.org/t/rfc-improve-binary-security/78121