### PR TITLE
A few updates around "transcript"

### DIFF
--- a/lldb/include/lldb/API/SBCommandInterpreter.h
+++ b/lldb/include/lldb/API/SBCommandInterpreter.h
@@ -321,12 +321,16 @@ public:
   /// Returns a list of handled commands, output and error. Each element in
   /// the list is a dictionary with the following keys/values:
   /// - "command" (string): The command that was given by the user.
-  /// - "resolvedCommand" (string): The expanded command that was executed.
+  /// - "commandName" (string): The name of the executed command.
+  /// - "commandArguments" (string): The arguments of the executed command.
   /// - "output" (string): The output of the command. Empty ("") if no output.
   /// - "error" (string): The error of the command. Empty ("") if no error.
   /// - "durationInSeconds" (float): The time it took to execute the command.
   /// - "timestampInEpochSeconds" (int): The timestamp when the command is
   ///   executed.
+  ///
+  /// Turn on settings `interpreter.save-transcript` for LLDB to populate
+  /// this list. Otherwise this list is empty.
   SBStructuredData GetTranscript();
 
 protected:

--- a/lldb/include/lldb/API/SBCommandInterpreter.h
+++ b/lldb/include/lldb/API/SBCommandInterpreter.h
@@ -324,7 +324,9 @@ public:
   /// - "resolvedCommand" (string): The expanded command that was executed.
   /// - "output" (string): The output of the command. Empty ("") if no output.
   /// - "error" (string): The error of the command. Empty ("") if no error.
-  /// - "seconds" (float): The time it took to execute the command.
+  /// - "durationInSeconds" (float): The time it took to execute the command.
+  /// - "timestampInEpochSeconds" (int): The timestamp when the command is
+  ///   executed.
   SBStructuredData GetTranscript();
 
 protected:

--- a/lldb/include/lldb/API/SBCommandInterpreter.h
+++ b/lldb/include/lldb/API/SBCommandInterpreter.h
@@ -320,7 +320,8 @@ public:
 
   /// Returns a list of handled commands, output and error. Each element in
   /// the list is a dictionary with the following keys/values:
-  /// - "command" (string): The command that was executed.
+  /// - "command" (string): The command that was given by the user.
+  /// - "resolvedCommand" (string): The expanded command that was executed.
   /// - "output" (string): The output of the command. Empty ("") if no output.
   /// - "error" (string): The error of the command. Empty ("") if no error.
   /// - "seconds" (float): The time it took to execute the command.

--- a/lldb/include/lldb/Interpreter/CommandInterpreter.h
+++ b/lldb/include/lldb/Interpreter/CommandInterpreter.h
@@ -777,7 +777,8 @@ private:
   /// Contains a list of handled commands and their details. Each element in
   /// the list is a dictionary with the following keys/values:
   /// - "command" (string): The command that was given by the user.
-  /// - "resolvedCommand" (string): The expanded command that was executed.
+  /// - "commandName" (string): The name of the executed command.
+  /// - "commandArguments" (string): The arguments of the executed command.
   /// - "output" (string): The output of the command. Empty ("") if no output.
   /// - "error" (string): The error of the command. Empty ("") if no error.
   /// - "durationInSeconds" (float): The time it took to execute the command.

--- a/lldb/include/lldb/Interpreter/CommandInterpreter.h
+++ b/lldb/include/lldb/Interpreter/CommandInterpreter.h
@@ -580,7 +580,7 @@ public:
   void SetEchoCommentCommands(bool enable);
 
   bool GetRepeatPreviousCommand() const;
-  
+
   bool GetRequireCommandOverwrite() const;
 
   const CommandObject::CommandMap &GetUserCommands() const {
@@ -780,7 +780,9 @@ private:
   /// - "resolvedCommand" (string): The expanded command that was executed.
   /// - "output" (string): The output of the command. Empty ("") if no output.
   /// - "error" (string): The error of the command. Empty ("") if no error.
-  /// - "seconds" (float): The time it took to execute the command.
+  /// - "durationInSeconds" (float): The time it took to execute the command.
+  /// - "timestampInEpochSeconds" (int): The timestamp when the command is
+  ///   executed.
   ///
   /// Turn on settings `interpreter.save-transcript` for LLDB to populate
   /// this list. Otherwise this list is empty.

--- a/lldb/include/lldb/Interpreter/CommandInterpreter.h
+++ b/lldb/include/lldb/Interpreter/CommandInterpreter.h
@@ -580,7 +580,7 @@ public:
   void SetEchoCommentCommands(bool enable);
 
   bool GetRepeatPreviousCommand() const;
-
+  
   bool GetRequireCommandOverwrite() const;
 
   const CommandObject::CommandMap &GetUserCommands() const {

--- a/lldb/include/lldb/Interpreter/CommandInterpreter.h
+++ b/lldb/include/lldb/Interpreter/CommandInterpreter.h
@@ -580,7 +580,7 @@ public:
   void SetEchoCommentCommands(bool enable);
 
   bool GetRepeatPreviousCommand() const;
-  
+
   bool GetRequireCommandOverwrite() const;
 
   const CommandObject::CommandMap &GetUserCommands() const {
@@ -776,7 +776,8 @@ private:
 
   /// Contains a list of handled commands and their details. Each element in
   /// the list is a dictionary with the following keys/values:
-  /// - "command" (string): The command that was executed.
+  /// - "command" (string): The command that was given by the user.
+  /// - "resolvedCommand" (string): The expanded command that was executed.
   /// - "output" (string): The output of the command. Empty ("") if no output.
   /// - "error" (string): The error of the command. Empty ("") if no error.
   /// - "seconds" (float): The time it took to execute the command.

--- a/lldb/include/lldb/Target/Statistics.h
+++ b/lldb/include/lldb/Target/Statistics.h
@@ -133,6 +133,7 @@ struct ConstStringStats {
 struct StatisticsOptions {
   bool summary_only = false;
   bool load_all_debug_info = false;
+  bool include_transcript = false;
 };
 
 /// A class that represents statistics for a since lldb_private::Target.

--- a/lldb/source/Commands/CommandObjectStats.cpp
+++ b/lldb/source/Commands/CommandObjectStats.cpp
@@ -81,6 +81,9 @@ class CommandObjectStatsDump : public CommandObjectParsed {
       case 'f':
         m_stats_options.load_all_debug_info = true;
         break;
+      case 't':
+        m_stats_options.include_transcript = true;
+        break;
       default:
         llvm_unreachable("Unimplemented option");
       }

--- a/lldb/source/Commands/Options.td
+++ b/lldb/source/Commands/Options.td
@@ -1425,4 +1425,6 @@ let Command = "statistics dump" in {
     Desc<"Dump the total possible debug info statistics. "
     "Force loading all the debug information if not yet loaded, and collect "
     "statistics with those.">;
+  def statistics_dump_transcript: Option<"transcript", "t">, Group<1>,
+    Desc<"Include transcript.">;
 }

--- a/lldb/source/Commands/Options.td
+++ b/lldb/source/Commands/Options.td
@@ -1426,5 +1426,7 @@ let Command = "statistics dump" in {
     "Force loading all the debug information if not yet loaded, and collect "
     "statistics with those.">;
   def statistics_dump_transcript: Option<"transcript", "t">, Group<1>,
-    Desc<"Include transcript.">;
+    Desc<"If the setting interpreter.save-transcript is enabled and this "
+    "option is specified, include a JSON array with all commands the user and/"
+    "or scripts executed during a debug session.">;
 }

--- a/lldb/source/Interpreter/CommandInterpreter.cpp
+++ b/lldb/source/Interpreter/CommandInterpreter.cpp
@@ -2017,12 +2017,6 @@ bool CommandInterpreter::HandleCommand(const char *command_line,
               wants_raw_input ? "True" : "False");
   }
 
-  // To test whether or not transcript should be saved, `transcript_item` is
-  // used instead of `GetSaveTrasncript()`. This is because the latter will
-  // fail when the command is "settings set interpreter.save-transcript true".
-  if (transcript_item)
-    transcript_item->AddStringItem("resolvedCommand", command_string);
-
   // Phase 2.
   // Take care of things like setting up the history command & calling the
   // appropriate Execute method on the CommandObject, with the appropriate
@@ -2067,6 +2061,14 @@ bool CommandInterpreter::HandleCommand(const char *command_line,
     LLDB_LOGF(
         log, "HandleCommand, command line after removing command name(s): '%s'",
         remainder.c_str());
+
+    // To test whether or not transcript should be saved, `transcript_item` is
+    // used instead of `GetSaveTrasncript()`. This is because the latter will
+    // fail when the command is "settings set interpreter.save-transcript true".
+    if (transcript_item) {
+      transcript_item->AddStringItem("commandName", cmd_obj->GetCommandName());
+      transcript_item->AddStringItem("commandArguments", remainder);
+    }
 
     ElapsedTime elapsed(execute_time);
     cmd_obj->Execute(remainder.c_str(), result);

--- a/lldb/source/Interpreter/CommandInterpreter.cpp
+++ b/lldb/source/Interpreter/CommandInterpreter.cpp
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include <chrono>
 #include <cstdlib>
 #include <limits>
 #include <memory>
@@ -1909,6 +1910,11 @@ bool CommandInterpreter::HandleCommand(const char *command_line,
 
     transcript_item = std::make_shared<StructuredData::Dictionary>();
     transcript_item->AddStringItem("command", command_line);
+    transcript_item->AddIntegerItem(
+        "timestampInEpochSeconds",
+        std::chrono::duration_cast<std::chrono::seconds>(
+            std::chrono::system_clock::now().time_since_epoch())
+            .count());
     m_transcript.AddItem(transcript_item);
   }
 
@@ -2078,7 +2084,8 @@ bool CommandInterpreter::HandleCommand(const char *command_line,
 
     transcript_item->AddStringItem("output", result.GetOutputData());
     transcript_item->AddStringItem("error", result.GetErrorData());
-    transcript_item->AddFloatItem("seconds", execute_time.get().count());
+    transcript_item->AddFloatItem("durationInSeconds",
+                                  execute_time.get().count());
   }
 
   return result.Succeeded();

--- a/lldb/source/Interpreter/CommandInterpreter.cpp
+++ b/lldb/source/Interpreter/CommandInterpreter.cpp
@@ -2011,6 +2011,12 @@ bool CommandInterpreter::HandleCommand(const char *command_line,
               wants_raw_input ? "True" : "False");
   }
 
+  // To test whether or not transcript should be saved, `transcript_item` is
+  // used instead of `GetSaveTrasncript()`. This is because the latter will
+  // fail when the command is "settings set interpreter.save-transcript true".
+  if (transcript_item)
+    transcript_item->AddStringItem("resolvedCommand", command_string);
+
   // Phase 2.
   // Take care of things like setting up the history command & calling the
   // appropriate Execute method on the CommandObject, with the appropriate

--- a/lldb/source/Target/Statistics.cpp
+++ b/lldb/source/Target/Statistics.cpp
@@ -226,6 +226,7 @@ llvm::json::Value DebuggerStats::ReportStatistics(
 
   const bool summary_only = options.summary_only;
   const bool load_all_debug_info = options.load_all_debug_info;
+  const bool include_transcript = options.include_transcript;
 
   json::Array json_targets;
   json::Array json_modules;
@@ -363,16 +364,17 @@ llvm::json::Value DebuggerStats::ReportStatistics(
     global_stats.try_emplace("modules", std::move(json_modules));
     global_stats.try_emplace("memory", std::move(json_memory));
     global_stats.try_emplace("commands", std::move(cmd_stats));
+  }
 
+  if (include_transcript) {
     // When transcript is available, add it to the to-be-returned statistics.
     //
     // NOTE:
     // When the statistics is polled by an LLDB command:
     // - The transcript in the returned statistics *will NOT* contain the
-    //   returned statistics itself.
+    //   returned statistics itself (otherwise infinite recursion).
     // - The returned statistics *will* be written to the internal transcript
-    //   buffer as the output of the said LLDB command. It *will* appear in
-    //   the next statistcs or transcript poll.
+    //   buffer. It *will* appear in the next statistcs or transcript poll.
     //
     // For example, let's say the following commands are run in order:
     // - "version"

--- a/lldb/test/API/commands/statistics/basic/TestStats.py
+++ b/lldb/test/API/commands/statistics/basic/TestStats.py
@@ -624,7 +624,7 @@ class TestCase(TestBase):
         # modules with debugInfoHadVariableErrors is greater than zero
         self.assertGreater(stats["totalModuleCountWithVariableErrors"], 0)
 
-    def test_transcript(self):
+    def test_transcript_happy_path(self):
         """
         Test "statistics dump" and the transcript information.
         """
@@ -635,24 +635,38 @@ class TestCase(TestBase):
         self.runCmd("version")
 
         # Verify the output of a first "statistics dump"
-        debug_stats = self.get_stats()
+        debug_stats = self.get_stats("--transcript")
         self.assertIn("transcript", debug_stats)
         transcript = debug_stats["transcript"]
         self.assertEqual(len(transcript), 2)
-        self.assertEqual(transcript[0]["resolvedCommand"], "version")
-        self.assertEqual(transcript[1]["resolvedCommand"], "statistics dump")
+        self.assertEqual(transcript[0]["commandName"], "version")
+        self.assertEqual(transcript[1]["commandName"], "statistics dump")
         # The first "statistics dump" in the transcript should have no output
         self.assertNotIn("output", transcript[1])
 
         # Verify the output of a second "statistics dump"
-        debug_stats = self.get_stats()
+        debug_stats = self.get_stats("--transcript")
         self.assertIn("transcript", debug_stats)
         transcript = debug_stats["transcript"]
         self.assertEqual(len(transcript), 3)
-        self.assertEqual(transcript[0]["resolvedCommand"], "version")
-        self.assertEqual(transcript[1]["resolvedCommand"], "statistics dump")
+        self.assertEqual(transcript[0]["commandName"], "version")
+        self.assertEqual(transcript[1]["commandName"], "statistics dump")
         # The first "statistics dump" in the transcript should have output now
         self.assertIn("output", transcript[1])
-        self.assertEqual(transcript[2]["resolvedCommand"], "statistics dump")
+        self.assertEqual(transcript[2]["commandName"], "statistics dump")
         # The second "statistics dump" in the transcript should have no output
         self.assertNotIn("output", transcript[2])
+
+    def test_transcript_should_not_exist_when_not_asked_for(self):
+        """
+        Test "statistics dump" and the transcript information.
+        """
+        self.build()
+        exe = self.getBuildArtifact("a.out")
+        target = self.createTestTarget(file_path=exe)
+        self.runCmd("settings set interpreter.save-transcript true")
+        self.runCmd("version")
+
+        # Verify the output of a first "statistics dump"
+        debug_stats = self.get_stats() # Not with "--transcript"
+        self.assertNotIn("transcript", debug_stats)

--- a/lldb/test/API/commands/statistics/basic/TestStats.py
+++ b/lldb/test/API/commands/statistics/basic/TestStats.py
@@ -668,5 +668,5 @@ class TestCase(TestBase):
         self.runCmd("version")
 
         # Verify the output of a first "statistics dump"
-        debug_stats = self.get_stats() # Not with "--transcript"
+        debug_stats = self.get_stats()  # Not with "--transcript"
         self.assertNotIn("transcript", debug_stats)

--- a/lldb/test/API/commands/statistics/basic/TestStats.py
+++ b/lldb/test/API/commands/statistics/basic/TestStats.py
@@ -624,33 +624,39 @@ class TestCase(TestBase):
         # modules with debugInfoHadVariableErrors is greater than zero
         self.assertGreater(stats["totalModuleCountWithVariableErrors"], 0)
 
+    def test_transcript(self):
+        """
+        Test "statistics dump" and the transcript information.
+        """
+        self.build()
+        exe = self.getBuildArtifact("a.out")
+        target = self.createTestTarget(file_path=exe)
+        self.runCmd("settings set interpreter.save-transcript true")
+        self.runCmd("version")
 
-def test_transcript(self):
-    """
-    Test "statistics dump" and the transcript information.
-    """
-    self.build()
-    exe = self.getBuildArtifact("a.out")
-    target = self.createTestTarget(file_path=exe)
-    self.runCmd("settings set target.save-transcript true")
-    self.runCmd("version")
+        # Verify the output of a first "statistics dump"
+        debug_stats = self.get_stats()
+        self.assertIn("transcript", debug_stats)
+        transcript = debug_stats["transcript"]
+        print("DEBUG1")
+        print(transcript)
+        self.assertEqual(len(transcript), 2)
+        self.assertEqual(transcript[0]["resolvedCommand"], "version")
+        self.assertEqual(transcript[1]["resolvedCommand"], "statistics dump")
+        # The first "statistics dump" in the transcript should have no output
+        self.assertNotIn("output", transcript[1])
 
-    # Verify the output of a first "statistics dump"
-    debug_stats = self.get_stats()
-    self.assertIn("transcript", debug_stats)
-    transcript = debug_stats["transcript"]
-    self.assertEqual(len(transcript), 2)
-    self.assertEqual(transcript[0]["command"], "version")
-    self.assertEqual(transcript[1]["command"], "statistics dump")
-    self.assertEqual(transcript[1]["output"], "")
-
-    # Verify the output of a second "statistics dump"
-    debug_stats = self.get_stats()
-    self.assertIn("transcript", debug_stats)
-    transcript = debug_stats["transcript"]
-    self.assertEqual(len(transcript), 3)
-    self.assertEqual(transcript[0]["command"], "version")
-    self.assertEqual(transcript[1]["command"], "statistics dump")
-    self.assertNotEqual(transcript[1]["output"], "")
-    self.assertEqual(transcript[2]["command"], "statistics dump")
-    self.assertEqual(transcript[2]["output"], "")
+        # Verify the output of a second "statistics dump"
+        debug_stats = self.get_stats()
+        self.assertIn("transcript", debug_stats)
+        transcript = debug_stats["transcript"]
+        print("DEBUG2")
+        print(transcript)
+        self.assertEqual(len(transcript), 3)
+        self.assertEqual(transcript[0]["resolvedCommand"], "version")
+        self.assertEqual(transcript[1]["resolvedCommand"], "statistics dump")
+        # The first "statistics dump" in the transcript should have output now
+        self.assertIn("output", transcript[1])
+        self.assertEqual(transcript[2]["resolvedCommand"], "statistics dump")
+        # The second "statistics dump" in the transcript should have no output
+        self.assertNotIn("output", transcript[2])

--- a/lldb/test/API/commands/statistics/basic/TestStats.py
+++ b/lldb/test/API/commands/statistics/basic/TestStats.py
@@ -623,3 +623,33 @@ class TestCase(TestBase):
         # Verify that the top level statistic that aggregates the number of
         # modules with debugInfoHadVariableErrors is greater than zero
         self.assertGreater(stats["totalModuleCountWithVariableErrors"], 0)
+
+def test_transcript(self):
+        """
+        Test "statistics dump" and the transcript information.
+        """
+        self.build()
+        exe = self.getBuildArtifact("a.out")
+        target = self.createTestTarget(file_path=exe)
+        self.runCmd("settings set target.save-transcript true")
+        self.runCmd("version")
+
+        # Verify the output of a first "statistics dump"
+        debug_stats = self.get_stats()
+        self.assertIn("transcript", debug_stats)
+        transcript = debug_stats["transcript"]
+        self.assertEqual(len(transcript), 2)
+        self.assertEqual(transcript[0]["command"], "version")
+        self.assertEqual(transcript[1]["command"], "statistics dump")
+        self.assertEqual(transcript[1]["output"], "")
+
+        # Verify the output of a second "statistics dump"
+        debug_stats = self.get_stats()
+        self.assertIn("transcript", debug_stats)
+        transcript = debug_stats["transcript"]
+        self.assertEqual(len(transcript), 3)
+        self.assertEqual(transcript[0]["command"], "version")
+        self.assertEqual(transcript[1]["command"], "statistics dump")
+        self.assertNotEqual(transcript[1]["output"], "")
+        self.assertEqual(transcript[2]["command"], "statistics dump")
+        self.assertEqual(transcript[2]["output"], "")

--- a/lldb/test/API/commands/statistics/basic/TestStats.py
+++ b/lldb/test/API/commands/statistics/basic/TestStats.py
@@ -638,8 +638,6 @@ class TestCase(TestBase):
         debug_stats = self.get_stats()
         self.assertIn("transcript", debug_stats)
         transcript = debug_stats["transcript"]
-        print("DEBUG1")
-        print(transcript)
         self.assertEqual(len(transcript), 2)
         self.assertEqual(transcript[0]["resolvedCommand"], "version")
         self.assertEqual(transcript[1]["resolvedCommand"], "statistics dump")
@@ -650,8 +648,6 @@ class TestCase(TestBase):
         debug_stats = self.get_stats()
         self.assertIn("transcript", debug_stats)
         transcript = debug_stats["transcript"]
-        print("DEBUG2")
-        print(transcript)
         self.assertEqual(len(transcript), 3)
         self.assertEqual(transcript[0]["resolvedCommand"], "version")
         self.assertEqual(transcript[1]["resolvedCommand"], "statistics dump")

--- a/lldb/test/API/commands/statistics/basic/TestStats.py
+++ b/lldb/test/API/commands/statistics/basic/TestStats.py
@@ -624,32 +624,33 @@ class TestCase(TestBase):
         # modules with debugInfoHadVariableErrors is greater than zero
         self.assertGreater(stats["totalModuleCountWithVariableErrors"], 0)
 
+
 def test_transcript(self):
-        """
-        Test "statistics dump" and the transcript information.
-        """
-        self.build()
-        exe = self.getBuildArtifact("a.out")
-        target = self.createTestTarget(file_path=exe)
-        self.runCmd("settings set target.save-transcript true")
-        self.runCmd("version")
+    """
+    Test "statistics dump" and the transcript information.
+    """
+    self.build()
+    exe = self.getBuildArtifact("a.out")
+    target = self.createTestTarget(file_path=exe)
+    self.runCmd("settings set target.save-transcript true")
+    self.runCmd("version")
 
-        # Verify the output of a first "statistics dump"
-        debug_stats = self.get_stats()
-        self.assertIn("transcript", debug_stats)
-        transcript = debug_stats["transcript"]
-        self.assertEqual(len(transcript), 2)
-        self.assertEqual(transcript[0]["command"], "version")
-        self.assertEqual(transcript[1]["command"], "statistics dump")
-        self.assertEqual(transcript[1]["output"], "")
+    # Verify the output of a first "statistics dump"
+    debug_stats = self.get_stats()
+    self.assertIn("transcript", debug_stats)
+    transcript = debug_stats["transcript"]
+    self.assertEqual(len(transcript), 2)
+    self.assertEqual(transcript[0]["command"], "version")
+    self.assertEqual(transcript[1]["command"], "statistics dump")
+    self.assertEqual(transcript[1]["output"], "")
 
-        # Verify the output of a second "statistics dump"
-        debug_stats = self.get_stats()
-        self.assertIn("transcript", debug_stats)
-        transcript = debug_stats["transcript"]
-        self.assertEqual(len(transcript), 3)
-        self.assertEqual(transcript[0]["command"], "version")
-        self.assertEqual(transcript[1]["command"], "statistics dump")
-        self.assertNotEqual(transcript[1]["output"], "")
-        self.assertEqual(transcript[2]["command"], "statistics dump")
-        self.assertEqual(transcript[2]["output"], "")
+    # Verify the output of a second "statistics dump"
+    debug_stats = self.get_stats()
+    self.assertIn("transcript", debug_stats)
+    transcript = debug_stats["transcript"]
+    self.assertEqual(len(transcript), 3)
+    self.assertEqual(transcript[0]["command"], "version")
+    self.assertEqual(transcript[1]["command"], "statistics dump")
+    self.assertNotEqual(transcript[1]["output"], "")
+    self.assertEqual(transcript[2]["command"], "statistics dump")
+    self.assertEqual(transcript[2]["output"], "")

--- a/lldb/test/API/python_api/interpreter/TestCommandInterpreterAPI.py
+++ b/lldb/test/API/python_api/interpreter/TestCommandInterpreterAPI.py
@@ -130,7 +130,8 @@ class CommandInterpreterAPICase(TestBase):
         # All commands should have expected fields.
         for command in transcript:
             self.assertIn("command", command)
-            self.assertIn("resolvedCommand", command)
+            # Unresolved commands don't have "commandName"/"commandArguments".
+            # We will validate these fields below, instead of here.
             self.assertIn("output", command)
             self.assertIn("error", command)
             self.assertIn("durationInSeconds", command)
@@ -149,7 +150,8 @@ class CommandInterpreterAPICase(TestBase):
 
         # (lldb) version
         self.assertEqual(transcript[0]["command"], "version")
-        self.assertEqual(transcript[0]["resolvedCommand"], "version")
+        self.assertEqual(transcript[0]["commandName"], "version")
+        self.assertEqual(transcript[0]["commandArguments"], "")
         self.assertIn("lldb version", transcript[0]["output"])
         self.assertEqual(transcript[0]["error"], "")
 
@@ -157,24 +159,23 @@ class CommandInterpreterAPICase(TestBase):
         self.assertEqual(transcript[1],
             {
                 "command": "an-unknown-command",
-                "resolvedCommand": "an-unknown-command",
+                # Unresolved commands don't have "commandName"/"commandArguments"
                 "output": "",
                 "error": "error: 'an-unknown-command' is not a valid command.\n",
             })
 
         # (lldb) br s -f main.c -l <line>
         self.assertEqual(transcript[2]["command"], "br s -f main.c -l %d" % self.line)
-        self.assertEqual(
-            transcript[2]["resolvedCommand"],
-            "breakpoint set -f main.c -l %d" % self.line,
-        )
+        self.assertEqual(transcript[2]["commandName"], "breakpoint set")
+        self.assertEqual(transcript[2]["commandArguments"], "-f main.c -l %d" % self.line)
         # Breakpoint 1: where = a.out`main + 29 at main.c:5:3, address = 0x0000000100000f7d
         self.assertIn("Breakpoint 1: where = a.out`main ", transcript[2]["output"])
         self.assertEqual(transcript[2]["error"], "")
 
         # (lldb) r
         self.assertEqual(transcript[3]["command"], "r")
-        self.assertEqual(transcript[3]["resolvedCommand"], "process launch -X true --")
+        self.assertEqual(transcript[3]["commandName"], "process launch")
+        self.assertEqual(transcript[3]["commandArguments"], "-X true --")
         # Process 25494 launched: '<path>/TestCommandInterpreterAPI.test_structured_transcript/a.out' (x86_64)
         self.assertIn("Process", transcript[3]["output"])
         self.assertIn("launched", transcript[3]["output"])
@@ -184,14 +185,16 @@ class CommandInterpreterAPICase(TestBase):
         self.assertEqual(transcript[4],
             {
                 "command": "p a",
-                "resolvedCommand": "dwim-print -- a",
+                "commandName": "dwim-print",
+                "commandArguments": "-- a",
                 "output": "(int) 123\n",
                 "error": "",
             })
 
         # (lldb) statistics dump
         self.assertEqual(transcript[5]["command"], "statistics dump")
-        self.assertEqual(transcript[5]["resolvedCommand"], "statistics dump")
+        self.assertEqual(transcript[5]["commandName"], "statistics dump")
+        self.assertEqual(transcript[5]["commandArguments"], "")
         self.assertEqual(transcript[5]["error"], "")
         statistics_dump = json.loads(transcript[5]["output"])
         # Dump result should be valid JSON

--- a/lldb/test/API/python_api/interpreter/TestCommandInterpreterAPI.py
+++ b/lldb/test/API/python_api/interpreter/TestCommandInterpreterAPI.py
@@ -167,7 +167,9 @@ class CommandInterpreterAPICase(TestBase):
         # (lldb) br s -f main.c -l <line>
         self.assertEqual(transcript[2]["command"], "br s -f main.c -l %d" % self.line)
         self.assertEqual(transcript[2]["commandName"], "breakpoint set")
-        self.assertEqual(transcript[2]["commandArguments"], "-f main.c -l %d" % self.line)
+        self.assertEqual(
+            transcript[2]["commandArguments"], "-f main.c -l %d" % self.line
+        )
         # Breakpoint 1: where = a.out`main + 29 at main.c:5:3, address = 0x0000000100000f7d
         self.assertIn("Breakpoint 1: where = a.out`main ", transcript[2]["output"])
         self.assertEqual(transcript[2]["error"], "")

--- a/lldb/test/API/python_api/interpreter/TestCommandInterpreterAPI.py
+++ b/lldb/test/API/python_api/interpreter/TestCommandInterpreterAPI.py
@@ -104,7 +104,7 @@ class CommandInterpreterAPICase(TestBase):
 
         return json.loads(stream.GetData())
 
-    def test_structured_transcript(self):
+    def test_get_transcript(self):
         """Test structured transcript generation and retrieval."""
         ci = self.buildAndCreateTarget()
 
@@ -118,7 +118,7 @@ class CommandInterpreterAPICase(TestBase):
         res = lldb.SBCommandReturnObject()
         ci.HandleCommand("version", res)
         ci.HandleCommand("an-unknown-command", res)
-        ci.HandleCommand("breakpoint set -f main.c -l %d" % self.line, res)
+        ci.HandleCommand("br set -f main.c -l %d" % self.line, res)
         ci.HandleCommand("r", res)
         ci.HandleCommand("p a", res)
         ci.HandleCommand("statistics dump", res)
@@ -130,6 +130,7 @@ class CommandInterpreterAPICase(TestBase):
         # All commands should have expected fields.
         for command in transcript:
             self.assertIn("command", command)
+            self.assertIn("resolvedCommand", command)
             self.assertIn("output", command)
             self.assertIn("error", command)
             self.assertIn("seconds", command)
@@ -146,6 +147,7 @@ class CommandInterpreterAPICase(TestBase):
 
         # (lldb) version
         self.assertEqual(transcript[0]["command"], "version")
+        self.assertEqual(transcript[0]["resolvedCommand"], "version")
         self.assertIn("lldb version", transcript[0]["output"])
         self.assertEqual(transcript[0]["error"], "")
 
@@ -153,18 +155,21 @@ class CommandInterpreterAPICase(TestBase):
         self.assertEqual(transcript[1],
             {
                 "command": "an-unknown-command",
+                "resolvedCommand": "an-unknown-command",
                 "output": "",
                 "error": "error: 'an-unknown-command' is not a valid command.\n",
             })
 
-        # (lldb) breakpoint set -f main.c -l <line>
-        self.assertEqual(transcript[2]["command"], "breakpoint set -f main.c -l %d" % self.line)
+        # (lldb) br set -f main.c -l <line>
+        self.assertEqual(transcript[2]["command"], "br set -f main.c -l %d" % self.line)
+        self.assertEqual(transcript[2]["resolvedCommand"], "breakpoint set -f main.c -l %d" % self.line)
         # Breakpoint 1: where = a.out`main + 29 at main.c:5:3, address = 0x0000000100000f7d
         self.assertIn("Breakpoint 1: where = a.out`main ", transcript[2]["output"])
         self.assertEqual(transcript[2]["error"], "")
 
         # (lldb) r
         self.assertEqual(transcript[3]["command"], "r")
+        self.assertEqual(transcript[3]["resolvedCommand"], "process launch -X true --")
         # Process 25494 launched: '<path>/TestCommandInterpreterAPI.test_structured_transcript/a.out' (x86_64)
         self.assertIn("Process", transcript[3]["output"])
         self.assertIn("launched", transcript[3]["output"])
@@ -174,11 +179,15 @@ class CommandInterpreterAPICase(TestBase):
         self.assertEqual(transcript[4],
             {
                 "command": "p a",
+                "resolvedCommand": "dwim-print -- a",
                 "output": "(int) 123\n",
                 "error": "",
             })
 
         # (lldb) statistics dump
+        self.assertEqual(transcript[5]["command"], "statistics dump")
+        self.assertEqual(transcript[5]["resolvedCommand"], "statistics dump")
+        self.assertEqual(transcript[5]["error"], "")
         statistics_dump = json.loads(transcript[5]["output"])
         # Dump result should be valid JSON
         self.assertTrue(statistics_dump is not json.JSONDecodeError)
@@ -194,7 +203,6 @@ class CommandInterpreterAPICase(TestBase):
 
         # The setting's default value should be "false"
         self.runCmd("settings show interpreter.save-transcript", "interpreter.save-transcript (boolean) = false\n")
-        # self.assertEqual(res.GetOutput(), )
 
     def test_save_transcript_setting_off(self):
         ci = self.buildAndCreateTarget()
@@ -220,7 +228,7 @@ class CommandInterpreterAPICase(TestBase):
         self.assertEqual(len(transcript), 1)
         self.assertEqual(transcript[0]["command"], "version")
 
-    def test_save_transcript_returns_copy(self):
+    def test_get_transcript_returns_copy(self):
         """
         Test that the returned structured data is *at least* a shallow copy.
 

--- a/lldb/test/API/python_api/interpreter/TestCommandInterpreterAPI.py
+++ b/lldb/test/API/python_api/interpreter/TestCommandInterpreterAPI.py
@@ -118,7 +118,7 @@ class CommandInterpreterAPICase(TestBase):
         res = lldb.SBCommandReturnObject()
         ci.HandleCommand("version", res)
         ci.HandleCommand("an-unknown-command", res)
-        ci.HandleCommand("br set -f main.c -l %d" % self.line, res)
+        ci.HandleCommand("br s -f main.c -l %d" % self.line, res)
         ci.HandleCommand("r", res)
         ci.HandleCommand("p a", res)
         ci.HandleCommand("statistics dump", res)
@@ -161,7 +161,7 @@ class CommandInterpreterAPICase(TestBase):
             })
 
         # (lldb) br set -f main.c -l <line>
-        self.assertEqual(transcript[2]["command"], "br set -f main.c -l %d" % self.line)
+        self.assertEqual(transcript[2]["command"], "br s -f main.c -l %d" % self.line)
         self.assertEqual(transcript[2]["resolvedCommand"], "breakpoint set -f main.c -l %d" % self.line)
         # Breakpoint 1: where = a.out`main + 29 at main.c:5:3, address = 0x0000000100000f7d
         self.assertIn("Breakpoint 1: where = a.out`main ", transcript[2]["output"])

--- a/lldb/test/API/python_api/interpreter/TestCommandInterpreterAPI.py
+++ b/lldb/test/API/python_api/interpreter/TestCommandInterpreterAPI.py
@@ -154,15 +154,13 @@ class CommandInterpreterAPICase(TestBase):
         self.assertEqual(transcript[0]["error"], "")
 
         # (lldb) an-unknown-command
-        self.assertEqual(
-            transcript[1],
+        self.assertEqual(transcript[1],
             {
                 "command": "an-unknown-command",
                 "resolvedCommand": "an-unknown-command",
                 "output": "",
                 "error": "error: 'an-unknown-command' is not a valid command.\n",
-            },
-        )
+            })
 
         # (lldb) br s -f main.c -l <line>
         self.assertEqual(transcript[2]["command"], "br s -f main.c -l %d" % self.line)
@@ -183,15 +181,13 @@ class CommandInterpreterAPICase(TestBase):
         self.assertEqual(transcript[3]["error"], "")
 
         # (lldb) p a
-        self.assertEqual(
-            transcript[4],
+        self.assertEqual(transcript[4],
             {
                 "command": "p a",
                 "resolvedCommand": "dwim-print -- a",
                 "output": "(int) 123\n",
                 "error": "",
-            },
-        )
+            })
 
         # (lldb) statistics dump
         self.assertEqual(transcript[5]["command"], "statistics dump")
@@ -211,10 +207,7 @@ class CommandInterpreterAPICase(TestBase):
         res = lldb.SBCommandReturnObject()
 
         # The setting's default value should be "false"
-        self.runCmd(
-            "settings show interpreter.save-transcript",
-            "interpreter.save-transcript (boolean) = false\n",
-        )
+        self.runCmd("settings show interpreter.save-transcript", "interpreter.save-transcript (boolean) = false\n")
 
     def test_save_transcript_setting_off(self):
         ci = self.buildAndCreateTarget()
@@ -259,37 +252,17 @@ class CommandInterpreterAPICase(TestBase):
         structured_data_1 = ci.GetTranscript()
         self.assertTrue(structured_data_1.IsValid())
         self.assertEqual(structured_data_1.GetSize(), 1)
-        self.assertEqual(
-            structured_data_1.GetItemAtIndex(0)
-            .GetValueForKey("command")
-            .GetStringValue(100),
-            "version",
-        )
+        self.assertEqual(structured_data_1.GetItemAtIndex(0).GetValueForKey("command").GetStringValue(100), "version")
 
         # Run some more commands and get the transcript as structured data again
         self.runCmd("help")
         structured_data_2 = ci.GetTranscript()
         self.assertTrue(structured_data_2.IsValid())
         self.assertEqual(structured_data_2.GetSize(), 2)
-        self.assertEqual(
-            structured_data_2.GetItemAtIndex(0)
-            .GetValueForKey("command")
-            .GetStringValue(100),
-            "version",
-        )
-        self.assertEqual(
-            structured_data_2.GetItemAtIndex(1)
-            .GetValueForKey("command")
-            .GetStringValue(100),
-            "help",
-        )
+        self.assertEqual(structured_data_2.GetItemAtIndex(0).GetValueForKey("command").GetStringValue(100), "version")
+        self.assertEqual(structured_data_2.GetItemAtIndex(1).GetValueForKey("command").GetStringValue(100), "help")
 
         # Now, the first structured data should remain unchanged
         self.assertTrue(structured_data_1.IsValid())
         self.assertEqual(structured_data_1.GetSize(), 1)
-        self.assertEqual(
-            structured_data_1.GetItemAtIndex(0)
-            .GetValueForKey("command")
-            .GetStringValue(100),
-            "version",
-        )
+        self.assertEqual(structured_data_1.GetItemAtIndex(0).GetValueForKey("command").GetStringValue(100), "version")

--- a/lldb/test/API/python_api/interpreter/TestCommandInterpreterAPI.py
+++ b/lldb/test/API/python_api/interpreter/TestCommandInterpreterAPI.py
@@ -160,7 +160,7 @@ class CommandInterpreterAPICase(TestBase):
                 "error": "error: 'an-unknown-command' is not a valid command.\n",
             })
 
-        # (lldb) br set -f main.c -l <line>
+        # (lldb) br s -f main.c -l <line>
         self.assertEqual(transcript[2]["command"], "br s -f main.c -l %d" % self.line)
         self.assertEqual(transcript[2]["resolvedCommand"], "breakpoint set -f main.c -l %d" % self.line)
         # Breakpoint 1: where = a.out`main + 29 at main.c:5:3, address = 0x0000000100000f7d


### PR DESCRIPTION
# Changes

1. Changes to the structured transcript.
    1. Add fields `commandName` and `commandArguments`. They will hold the name and the arguments string of the expanded/executed command (e.g. `breakpoint set` and `-f main.cpp -l 4`). This is not to be confused with the `command` field, which holds the user input (e.g. `br s -f main.cpp -l 4`).
    2. Add field `timestampInEpochSeconds`. It will hold the timestamp when the command is executed.
    3. Rename field `seconds` to `durationInSeconds`, to improve readability, especially since `timestampInEpochSeconds` is added.
2. When transcript is available and the newly added option `--transcript` is present, add the transcript to the output of `statistics dump`, as a JSON array under a new field `transcript`.
3. A few test name and comment changes.


# Test

```
bin/llvm-lit -sv ../external/llvm-project/lldb/test/API/commands/statistics/basic/TestStats.py
```

```
bin/llvm-lit -sv ../external/llvm-project/lldb/test/API/python_api/interpreter/TestCommandInterpreterAPI.py
```
