### PR TITLE
[Flang] Add missing 'CUFOpsIncGen' build dependency

### DIFF
--- a/flang/lib/Optimizer/Dialect/CUF/Attributes/CMakeLists.txt
+++ b/flang/lib/Optimizer/Dialect/CUF/Attributes/CMakeLists.txt
@@ -5,6 +5,7 @@ add_flang_library(CUFAttrs
   DEPENDS
   MLIRIR
   CUFAttrsIncGen
+  CUFOpsIncGen
 
   LINK_LIBS
   MLIRTargetLLVMIRExport


### PR DESCRIPTION
Fixes the following build error:

```
$ ninja FIRDialect
[ 98%/1.897s :: 2->1->102 (of 104)] Building CXX object tools/flang/lib/Optimizer/Dialect/CUF/Attributes/CMakeFiles/obj.CUFAttrs.dir/CUFAttr.cpp.o
FAILED: tools/flang/lib/Optimizer/Dialect/CUF/Attributes/CMakeFiles/obj.CUFAttrs.dir/CUFAttr.cpp.o
ccache /usr/bin/clang++ -DFLANG_INCLUDE_TESTS=1 -DFLANG_LITTLE_ENDIAN=1 -DGTEST_HAS_RTTI=0 -D_DEBUG -D_GLIBCXX_ASSERTIONS -D_GNU_SOURCE -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS -I/home/meinersbur/build/llvm-project/release_clang/tools/flang/lib/Optimizer/Dialect/CUF/Attributes -I/home/meinersbur/src/llvm-project/flang/lib/Optimizer/Dialect/CUF/Attributes -I/home/meinersbur/src/llvm-project/flang/include -I/home/meinersbur/build/llvm-project/release_clang/tools/flang/include -I/home/meinersbur/build/llvm-project/release_clang/include -I/home/meinersbur/src/llvm-project/llvm/include -isystem /home/meinersbur/src/llvm-project/llvm/../mlir/include -isystem /home/meinersbur/build/llvm-project/release_clang/tools/mlir/include -isystem /home/meinersbur/build/llvm-project/release_clang/tools/clang/include -isystem /home/meinersbur/src/llvm-project/llvm/../clang/include -ferror-limit=1 -fPIC -fno-semantic-interposition -fvisibility-inlines-hidden -Werror=date-time -Werror=unguarded-availability-new -Wall -Wextra -Wno-unused-parameter -Wwrite-strings -Wcast-qual -Wmissing-field-initializers -pedantic -Wno-long-long -Wc++98-compat-extra-semi -Wimplicit-fallthrough -Wcovered-switch-default -Wno-noexcept-type -Wnon-virtual-dtor -Wdelete-non-virtual-dtor -Wsuggest-override -Wstring-conversion -Wmisleading-indentation -Wctad-maybe-unsupported -fdiagnostics-color -ffunction-sections -fdata-sections -Wno-deprecated-copy -Wno-string-conversion -Wno-ctad-maybe-unsupported -Wno-unused-command-line-argument -Wstring-conversion           -Wcovered-switch-default -Wno-nested-anon-types -O3 -DNDEBUG -std=c++17  -fno-exceptions -funwind-tables -fno-rtti -UNDEBUG -MD -MT tools/flang/lib/Optimizer/Dialect/CUF/Attributes/CMakeFiles/obj.CUFAttrs.dir/CUFAttr.cpp.o -MF tools/flang/lib/Optimizer/Dialect/CUF/Attributes/CMakeFiles/obj.CUFAttrs.dir/CUFAttr.cpp.o.d -o tools/flang/lib/Optimizer/Dialect/CUF/Attributes/CMakeFiles/obj.CUFAttrs.dir/CUFAttr.cpp.o -c /home/meinersbur/src/llvm-project/flang/lib/Optimizer/Dialect/CUF/Attributes/CUFAttr.cpp
In file included from /home/meinersbur/src/llvm-project/flang/lib/Optimizer/Dialect/CUF/Attributes/CUFAttr.cpp:14:
/home/meinersbur/src/llvm-project/flang/include/flang/Optimizer/Dialect/CUF/CUFDialect.h:24:10: fatal error: 'flang/Optimizer/Dialect/CUF/CUFDialect.h.inc' file not found
#include "flang/Optimizer/Dialect/CUF/CUFDialect.h.inc"
         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
1 error generated.
ninja: build stopped: cannot make progress due to previous errors.       
```