### PR TITLE
[clangd] Reduce instantiation depth in `infinite-instantiations.test`

### DIFF
--- a/clang-tools-extra/clangd/test/infinite-instantiation.test
+++ b/clang-tools-extra/clangd/test/infinite-instantiation.test
@@ -1,5 +1,6 @@
-// RUN: cp %s %t.cpp
-// RUN: not clangd -check=%t.cpp 2>&1 | FileCheck -strict-whitespace %s
+// RUN: rm -rf %t.dir && mkdir -p %t.dir
+// RUN: echo '[{"directory": "%/t.dir", "command": "clang -ftemplate-depth=100 -x c++ %s", "file": "%s"}]' > %t.dir/compile_commands.json
+// RUN: not clangd --compile-commands-dir=%t.dir -check=%s 2>&1 | FileCheck -strict-whitespace %s
 
 // CHECK: [template_recursion_depth_exceeded]
 


### PR DESCRIPTION
This patch reduces template instantiation depth in `infinite-instantiations.test`, because it doesn't seem to be concerned with the default instantiation depth in particular, but has a very material impact on testing times of clangd. Which subsequently affects CI run times for all Clang changes.

The following numbers are taken from https://buildkite.com/llvm-project/github-pull-requests/builds/65299, but they are the same for any CI run with clangd:
Linux:
```
Slowest Tests:
--------------------------------------------------------------------------
35.19s: Clangd :: infinite-instantiation.test
5.53s: Clangd :: protocol.test
1.48s: Clang Tools :: clang-tidy/checkers/modernize/use-emplace.cpp
1.40s: Clang Tools :: clang-tidy/checkers/misc/non-private-member-variables-in-classes.cpp
1.17s: Clang Tools :: clang-tidy/checkers/google/upgrade-googletest-case.cpp
1.15s: Clang Tools :: clang-tidy/checkers/bugprone/unsafe-functions.c
1.10s: Clang Tools :: clang-tidy/infrastructure/check_clang_tidy.cpp
1.07s: Clang Tools :: clang-tidy/checkers/readability/redundant-casting.cpp
1.06s: Clang Tools :: clang-tidy/checkers/misc/const-correctness-values.cpp
1.02s: Clang Tools :: clang-tidy/checkers/bugprone/implicit-widening-of-multiplication-result-char.cpp
1.00s: Clang Tools :: clang-tidy/checkers/modernize/loop-convert-reverse.cpp
0.97s: Clang Tools :: clang-tidy/checkers/modernize/loop-convert-basic.cpp
0.95s: Clang Tools :: clang-tidy/checkers/modernize/use-std-print.cpp
0.93s: Clang Tools :: clang-tidy/checkers/modernize/loop-convert-extra.cpp
0.92s: Clang Tools :: clang-tidy/checkers/altera/single-work-item-barrier.cpp
0.90s: Clang Tools :: clang-tidy/checkers/readability/identifier-naming-hungarian-notation-lower-case-prefix.cpp
0.90s: Clang Tools :: clang-tidy/checkers/modernize/use-auto-min-type-name-length.cpp
0.89s: Clang Tools :: clang-tidy/checkers/readability/identifier-naming-hungarian-notation-cfgfile.cpp
0.88s: Clang Tools :: clang-tidy/checkers/readability/identifier-naming-hungarian-notation.cpp
0.85s: Clangd Unit Tests :: ./ClangdTests/Hover/All
```
Windows:
```
Slowest Tests:
--------------------------------------------------------------------------
244.74s: Clangd :: infinite-instantiation.test
11.42s: Clangd :: protocol.test
8.97s: Clang Tools :: clang-tidy/checkers/misc/non-private-member-variables-in-classes.cpp
7.44s: Clang Tools :: clang-tidy/checkers/altera/single-work-item-barrier.cpp
6.71s: Clang Tools :: clang-tidy/checkers/bugprone/unsafe-functions.c
6.61s: Clang Tools :: clang-tidy/checkers/bugprone/implicit-widening-of-multiplication-result-char.cpp
6.42s: Clang Tools :: clang-tidy/infrastructure/check_clang_tidy.cpp
6.32s: Clang Tools :: clang-tidy/checkers/modernize/loop-convert-reverse.cpp
6.01s: Clang Tools :: clang-tidy/checkers/readability/redundant-casting.cpp
5.62s: Clang Tools :: clang-tidy/checkers/modernize/use-auto-min-type-name-length.cpp
5.58s: Clang Tools :: clang-tidy/checkers/modernize/replace-disallow-copy-and-assign-macro.cpp
5.46s: Clang Tools :: clang-tidy/checkers/readability/function-cognitive-complexity-flags.cpp
5.08s: Clang Tools :: clang-tidy/checkers/readability/avoid-return-with-void-value.cpp
5.07s: Clang Tools :: clang-tidy/checkers/readability/redundant-declaration.cpp
4.99s: Clang Tools :: clang-tidy/checkers/readability/identifier-naming-hungarian-notation-lower-case-prefix.cpp
4.91s: Clang Tools :: clang-tidy/checkers/bugprone/implicit-widening-of-multiplication-result-pointer-offset.cpp
4.87s: Clang Tools :: clang-tidy/checkers/readability/identifier-naming-hungarian-notation-cfgfile.cpp
4.79s: Clang Tools :: clang-tidy/checkers/google/upgrade-googletest-case.cpp
4.78s: Clang Tools :: clang-tidy/infrastructure/clean-up-code.cpp
4.76s: Clang Tools :: clang-tidy/checkers/bugprone/implicit-widening-of-multiplication-result-int.cpp
```