### PR TITLE
[MLIR][Tensor][Trivial] Fix test for trivial folding of tensor.insert_slice

### DIFF
--- a/mlir/test/Dialect/Tensor/canonicalize.mlir
+++ b/mlir/test/Dialect/Tensor/canonicalize.mlir
@@ -533,7 +533,7 @@ func.func @trivial_slice(%arg0 : tensor<4x6x16x32xi8>) -> tensor<4x6x16x32xi8> {
 
 // CHECK-LABEL: func @trivial_insert_slice
 //  CHECK-SAME:   %[[ARG0:.[a-z0-9A-Z_]+]]: tensor<4x6x16x32xi8>
-//   CHECK-NOT:   tensor.extract_slice
+//   CHECK-NOT:   tensor.insert_slice
 //       CHECK:   return %[[ARG0]] :  tensor<4x6x16x32xi8>
 func.func @trivial_insert_slice(%arg0 : tensor<4x6x16x32xi8>, %arg1 : tensor<4x6x16x32xi8>) -> tensor<4x6x16x32xi8> {
   %0 = tensor.insert_slice %arg0 into %arg1[0, 0, 0, 0] [4, 6, 16, 32] [1, 1, 1, 1] : tensor<4x6x16x32xi8> into tensor<4x6x16x32xi8>


### PR DESCRIPTION
The test in `@trivial_insert_slice` checks for the absence of `tensor.extract_slice`, although the test neither originally contains this operation before canonicalization, nor would this operation be produced. Instead, the check should ensure the absence of `tensor.insert_slice`, which should be elided by the folder.

This is likely to be a copy-and-paste error for the check above.