### PR TITLE
Add a requires `lto` instrprof-gc-sections.c

### DIFF
--- a/compiler-rt/test/profile/instrprof-gc-sections.c
+++ b/compiler-rt/test/profile/instrprof-gc-sections.c
@@ -1,4 +1,4 @@
-// REQUIRES: linux, lld-available
+// REQUIRES: linux, lld-available, lto
 
 // FIXME: Investigate and fix.
 // XFAIL: powerpc64-target-arch


### PR DESCRIPTION
The test has a run with `flto` so it makes sense to require `lto` in some way. Currently it relies on requires `lld-available` to imply that `lto` is supported, but it would help to separate the two notions in that `lto` should require up to date components (https://github.com/llvm/llvm-project/pull/92752) while `lld-available` may not.
