### PR TITLE
[Coroutines][NFC] Remove @llvm.coro.id.async intrinsics from CoroElide

### DIFF
--- a/llvm/lib/Transforms/Coroutines/CoroElide.cpp
+++ b/llvm/lib/Transforms/Coroutines/CoroElide.cpp
@@ -464,13 +464,9 @@ bool CoroIdElider::attemptElide() {
   return true;
 }
 
-static bool declaresCoroElideIntrinsics(Module &M) {
-  return coro::declaresIntrinsics(M, {"llvm.coro.id", "llvm.coro.id.async"});
-}
-
 PreservedAnalyses CoroElidePass::run(Function &F, FunctionAnalysisManager &AM) {
   auto &M = *F.getParent();
-  if (!declaresCoroElideIntrinsics(M))
+  if (!coro::declaresIntrinsics(M, {"llvm.coro.id"}))
     return PreservedAnalyses::all();
 
   FunctionElideInfo FEI{&F};


### PR DESCRIPTION
Easy change. There's no mentioning of `coro.id.async` in the pass. The check follow immediately after this is `hasCoroIds`. We are wasting cycles counting `coro.id` instructions when compiling non-switch ABI coroutines. Cleaning this up. 