### PR TITLE
[Clang] Implement resolution for CWG1835

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -306,6 +306,9 @@ Resolutions to C++ Defect Reports
 - Clang now considers ``noexcept(typeid(expr))`` more carefully, instead of always assuming that ``std::bad_typeid`` can be thrown.
   (`CWG2191: Incorrect result for noexcept(typeid(v)) <https://cplusplus.github.io/CWG/issues/2191.html>`_).
 
+- Clang now correctly implements lookup for the terminal name of a member-qualified nested-name-specifier.
+  (`CWG1835: Dependent member lookup before < <https://cplusplus.github.io/CWG/issues/1835.html>`_).
+
 C Language Changes
 ------------------
 

--- a/clang/include/clang/AST/ExprCXX.h
+++ b/clang/include/clang/AST/ExprCXX.h
@@ -3676,11 +3676,9 @@ public:
 /// an implicit access if a qualifier is provided.
 class CXXDependentScopeMemberExpr final
     : public Expr,
-      private llvm::TrailingObjects<CXXDependentScopeMemberExpr,
-                                    NestedNameSpecifierLoc,
-                                    DeclAccessPair,
-                                    ASTTemplateKWAndArgsInfo,
-                                    TemplateArgumentLoc> {
+      private llvm::TrailingObjects<
+          CXXDependentScopeMemberExpr, NestedNameSpecifierLoc, DeclAccessPair,
+          ASTTemplateKWAndArgsInfo, TemplateArgumentLoc> {
   friend class ASTStmtReader;
   friend class ASTStmtWriter;
   friend TrailingObjects;
@@ -3756,10 +3754,8 @@ class CXXDependentScopeMemberExpr final
 
 public:
   static CXXDependentScopeMemberExpr *
-  Create(const ASTContext &Ctx, Expr *Base,
-         QualType BaseType, bool IsArrow,
-         SourceLocation OperatorLoc,
-         NestedNameSpecifierLoc QualifierLoc,
+  Create(const ASTContext &Ctx, Expr *Base, QualType BaseType, bool IsArrow,
+         SourceLocation OperatorLoc, NestedNameSpecifierLoc QualifierLoc,
          SourceLocation TemplateKWLoc,
          ArrayRef<DeclAccessPair> UnqualifiedLookups,
          DeclarationNameInfo MemberNameInfo,
@@ -3767,8 +3763,7 @@ public:
 
   static CXXDependentScopeMemberExpr *
   CreateEmpty(const ASTContext &Ctx, bool HasQualifier,
-              unsigned NumUnqualifiedLookups,
-              bool HasTemplateKWAndArgsInfo,
+              unsigned NumUnqualifiedLookups, bool HasTemplateKWAndArgsInfo,
               unsigned NumTemplateArgs);
 
   /// True if this is an implicit access, i.e. one in which the
@@ -3794,9 +3789,7 @@ public:
   bool isArrow() const { return CXXDependentScopeMemberExprBits.IsArrow; }
 
   /// Retrieve the location of the '->' or '.' operator.
-  SourceLocation getOperatorLoc() const {
-    return OperatorLoc;
-  }
+  SourceLocation getOperatorLoc() const { return OperatorLoc; }
 
   /// Determines whether this member expression had a nested-name-specifier
   /// prior to the name of the member, e.g., x->Base::foo.
@@ -3819,8 +3812,7 @@ public:
     return getQualifierLoc().getNestedNameSpecifier();
   }
 
-
-  #if 0
+#if 0
   /// Retrieve the first part of the nested-name-specifier that was
   /// found in the scope of the member access expression when the member access
   /// was initially parsed.
@@ -3837,7 +3829,7 @@ public:
       return nullptr;
     return *getTrailingObjects<NamedDecl *>();
   }
-  #endif
+#endif
 
   ArrayRef<DeclAccessPair> unqualified_lookups() const {
     if (!getNumUnqualifiedLookups())

--- a/clang/include/clang/AST/ExprCXX.h
+++ b/clang/include/clang/AST/ExprCXX.h
@@ -3812,25 +3812,8 @@ public:
     return getQualifierLoc().getNestedNameSpecifier();
   }
 
-#if 0
-  /// Retrieve the first part of the nested-name-specifier that was
-  /// found in the scope of the member access expression when the member access
-  /// was initially parsed.
-  ///
-  /// This function only returns a useful result when member access expression
-  /// uses a qualified member name, e.g., "x.Base::f". Here, the declaration
-  /// returned by this function describes what was found by unqualified name
-  /// lookup for the identifier "Base" within the scope of the member access
-  /// expression itself. At template instantiation time, this information is
-  /// combined with the results of name lookup into the type of the object
-  /// expression itself (the class type of x).
-  NamedDecl *getFirstQualifierFoundInScope() const {
-    if (!hasFirstQualifierFoundInScope())
-      return nullptr;
-    return *getTrailingObjects<NamedDecl *>();
-  }
-#endif
-
+  /// Retrieve the declarations found by unqualified lookup for the first
+  /// component name of the nested-name-specifier, if any.
   ArrayRef<DeclAccessPair> unqualified_lookups() const {
     if (!getNumUnqualifiedLookups())
       return std::nullopt;

--- a/clang/include/clang/AST/ExprCXX.h
+++ b/clang/include/clang/AST/ExprCXX.h
@@ -3677,8 +3677,10 @@ public:
 class CXXDependentScopeMemberExpr final
     : public Expr,
       private llvm::TrailingObjects<CXXDependentScopeMemberExpr,
+                                    NestedNameSpecifierLoc,
+                                    DeclAccessPair,
                                     ASTTemplateKWAndArgsInfo,
-                                    TemplateArgumentLoc, NamedDecl *> {
+                                    TemplateArgumentLoc> {
   friend class ASTStmtReader;
   friend class ASTStmtWriter;
   friend TrailingObjects;
@@ -3691,16 +3693,14 @@ class CXXDependentScopeMemberExpr final
   /// implicit accesses.
   QualType BaseType;
 
-  /// The nested-name-specifier that precedes the member name, if any.
-  /// FIXME: This could be in principle store as a trailing object.
-  /// However the performance impact of doing so should be investigated first.
-  NestedNameSpecifierLoc QualifierLoc;
-
   /// The member to which this member expression refers, which
   /// can be name, overloaded operator, or destructor.
   ///
   /// FIXME: could also be a template-id
   DeclarationNameInfo MemberNameInfo;
+
+  /// The location of the '->' or '.' operator.
+  SourceLocation OperatorLoc;
 
   // CXXDependentScopeMemberExpr is followed by several trailing objects,
   // some of which optional. They are in order:
@@ -3721,8 +3721,16 @@ class CXXDependentScopeMemberExpr final
     return CXXDependentScopeMemberExprBits.HasTemplateKWAndArgsInfo;
   }
 
-  bool hasFirstQualifierFoundInScope() const {
-    return CXXDependentScopeMemberExprBits.HasFirstQualifierFoundInScope;
+  unsigned getNumUnqualifiedLookups() const {
+    return CXXDependentScopeMemberExprBits.NumUnqualifiedLookups;
+  }
+
+  unsigned numTrailingObjects(OverloadToken<NestedNameSpecifierLoc>) const {
+    return hasQualifier();
+  }
+
+  unsigned numTrailingObjects(OverloadToken<DeclAccessPair>) const {
+    return getNumUnqualifiedLookups();
   }
 
   unsigned numTrailingObjects(OverloadToken<ASTTemplateKWAndArgsInfo>) const {
@@ -3733,33 +3741,35 @@ class CXXDependentScopeMemberExpr final
     return getNumTemplateArgs();
   }
 
-  unsigned numTrailingObjects(OverloadToken<NamedDecl *>) const {
-    return hasFirstQualifierFoundInScope();
-  }
-
   CXXDependentScopeMemberExpr(const ASTContext &Ctx, Expr *Base,
                               QualType BaseType, bool IsArrow,
                               SourceLocation OperatorLoc,
                               NestedNameSpecifierLoc QualifierLoc,
                               SourceLocation TemplateKWLoc,
-                              NamedDecl *FirstQualifierFoundInScope,
+                              ArrayRef<DeclAccessPair> UnqualifiedLookups,
                               DeclarationNameInfo MemberNameInfo,
                               const TemplateArgumentListInfo *TemplateArgs);
 
-  CXXDependentScopeMemberExpr(EmptyShell Empty, bool HasTemplateKWAndArgsInfo,
-                              bool HasFirstQualifierFoundInScope);
+  CXXDependentScopeMemberExpr(EmptyShell Empty, bool HasQualifier,
+                              unsigned NumUnqualifiedLookups,
+                              bool HasTemplateKWAndArgsInfo);
 
 public:
   static CXXDependentScopeMemberExpr *
-  Create(const ASTContext &Ctx, Expr *Base, QualType BaseType, bool IsArrow,
-         SourceLocation OperatorLoc, NestedNameSpecifierLoc QualifierLoc,
-         SourceLocation TemplateKWLoc, NamedDecl *FirstQualifierFoundInScope,
+  Create(const ASTContext &Ctx, Expr *Base,
+         QualType BaseType, bool IsArrow,
+         SourceLocation OperatorLoc,
+         NestedNameSpecifierLoc QualifierLoc,
+         SourceLocation TemplateKWLoc,
+         ArrayRef<DeclAccessPair> UnqualifiedLookups,
          DeclarationNameInfo MemberNameInfo,
          const TemplateArgumentListInfo *TemplateArgs);
 
   static CXXDependentScopeMemberExpr *
-  CreateEmpty(const ASTContext &Ctx, bool HasTemplateKWAndArgsInfo,
-              unsigned NumTemplateArgs, bool HasFirstQualifierFoundInScope);
+  CreateEmpty(const ASTContext &Ctx, bool HasQualifier,
+              unsigned NumUnqualifiedLookups,
+              bool HasTemplateKWAndArgsInfo,
+              unsigned NumTemplateArgs);
 
   /// True if this is an implicit access, i.e. one in which the
   /// member being accessed was not written in the source.  The source
@@ -3785,18 +3795,32 @@ public:
 
   /// Retrieve the location of the '->' or '.' operator.
   SourceLocation getOperatorLoc() const {
-    return CXXDependentScopeMemberExprBits.OperatorLoc;
+    return OperatorLoc;
   }
 
-  /// Retrieve the nested-name-specifier that qualifies the member name.
+  /// Determines whether this member expression had a nested-name-specifier
+  /// prior to the name of the member, e.g., x->Base::foo.
+  bool hasQualifier() const {
+    return CXXDependentScopeMemberExprBits.HasQualifier;
+  }
+
+  /// If the member name was qualified, retrieves the nested-name-specifier
+  /// that precedes the member name, with source-location information.
+  NestedNameSpecifierLoc getQualifierLoc() const {
+    if (!hasQualifier())
+      return NestedNameSpecifierLoc();
+    return *getTrailingObjects<NestedNameSpecifierLoc>();
+  }
+
+  /// If the member name was qualified, retrieves the
+  /// nested-name-specifier that precedes the member name. Otherwise, returns
+  /// NULL.
   NestedNameSpecifier *getQualifier() const {
-    return QualifierLoc.getNestedNameSpecifier();
+    return getQualifierLoc().getNestedNameSpecifier();
   }
 
-  /// Retrieve the nested-name-specifier that qualifies the member
-  /// name, with source location information.
-  NestedNameSpecifierLoc getQualifierLoc() const { return QualifierLoc; }
 
+  #if 0
   /// Retrieve the first part of the nested-name-specifier that was
   /// found in the scope of the member access expression when the member access
   /// was initially parsed.
@@ -3812,6 +3836,13 @@ public:
     if (!hasFirstQualifierFoundInScope())
       return nullptr;
     return *getTrailingObjects<NamedDecl *>();
+  }
+  #endif
+
+  ArrayRef<DeclAccessPair> unqualified_lookups() const {
+    if (!getNumUnqualifiedLookups())
+      return std::nullopt;
+    return {getTrailingObjects<DeclAccessPair>(), getNumUnqualifiedLookups()};
   }
 
   /// Retrieve the name of the member that this expression refers to.

--- a/clang/include/clang/AST/Stmt.h
+++ b/clang/include/clang/AST/Stmt.h
@@ -1020,18 +1020,25 @@ protected:
     LLVM_PREFERRED_TYPE(bool)
     unsigned IsArrow : 1;
 
+    /// True if this member expression used a nested-name-specifier to
+    /// refer to the member, e.g., "x->Base::f".
+    LLVM_PREFERRED_TYPE(bool)
+    unsigned HasQualifier : 1;
+
     /// Whether this member expression has info for explicit template
     /// keyword and arguments.
     LLVM_PREFERRED_TYPE(bool)
     unsigned HasTemplateKWAndArgsInfo : 1;
 
+    #if 0
     /// See getFirstQualifierFoundInScope() and the comment listing
     /// the trailing objects.
     LLVM_PREFERRED_TYPE(bool)
     unsigned HasFirstQualifierFoundInScope : 1;
-
-    /// The location of the '->' or '.' operator.
-    SourceLocation OperatorLoc;
+    #endif
+    /// Number of declarations found by unqualified lookup for the
+    /// first component name of the nested-name-specifier.
+    unsigned NumUnqualifiedLookups;
   };
 
   class OverloadExprBitfields {

--- a/clang/include/clang/AST/Stmt.h
+++ b/clang/include/clang/AST/Stmt.h
@@ -1030,12 +1030,12 @@ protected:
     LLVM_PREFERRED_TYPE(bool)
     unsigned HasTemplateKWAndArgsInfo : 1;
 
-    #if 0
+#if 0
     /// See getFirstQualifierFoundInScope() and the comment listing
     /// the trailing objects.
     LLVM_PREFERRED_TYPE(bool)
     unsigned HasFirstQualifierFoundInScope : 1;
-    #endif
+#endif
     /// Number of declarations found by unqualified lookup for the
     /// first component name of the nested-name-specifier.
     unsigned NumUnqualifiedLookups;

--- a/clang/include/clang/AST/Stmt.h
+++ b/clang/include/clang/AST/Stmt.h
@@ -1030,12 +1030,6 @@ protected:
     LLVM_PREFERRED_TYPE(bool)
     unsigned HasTemplateKWAndArgsInfo : 1;
 
-#if 0
-    /// See getFirstQualifierFoundInScope() and the comment listing
-    /// the trailing objects.
-    LLVM_PREFERRED_TYPE(bool)
-    unsigned HasFirstQualifierFoundInScope : 1;
-#endif
     /// Number of declarations found by unqualified lookup for the
     /// first component name of the nested-name-specifier.
     unsigned NumUnqualifiedLookups;

--- a/clang/include/clang/AST/UnresolvedSet.h
+++ b/clang/include/clang/AST/UnresolvedSet.h
@@ -97,6 +97,10 @@ public:
     decls().push_back(DeclAccessPair::make(D, AS));
   }
 
+  void addAllDecls(ArrayRef<DeclAccessPair> Other) {
+    append(iterator(Other.begin()), iterator(Other.end()));
+  }
+
   /// Replaces the given declaration with the new one, once.
   ///
   /// \return true if the set changed

--- a/clang/include/clang/Basic/DiagnosticParseKinds.td
+++ b/clang/include/clang/Basic/DiagnosticParseKinds.td
@@ -895,9 +895,7 @@ def missing_template_arg_list_after_template_kw : Extension<
   "keyword">, InGroup<DiagGroup<"missing-template-arg-list-after-template-kw">>,
   DefaultError;
 
-def err_missing_dependent_template_keyword : Error<
-  "use 'template' keyword to treat '%0' as a dependent template name">;
-def warn_missing_dependent_template_keyword : ExtWarn<
+def ext_missing_dependent_template_keyword : ExtWarn<
   "use 'template' keyword to treat '%0' as a dependent template name">;
 
 def ext_extern_template : Extension<

--- a/clang/include/clang/Parse/Parser.h
+++ b/clang/include/clang/Parse/Parser.h
@@ -3368,16 +3368,11 @@ private:
   BaseResult ParseBaseSpecifier(Decl *ClassDecl);
   AccessSpecifier getAccessSpecifierIfPresent() const;
 
-  bool ParseUnqualifiedIdTemplateId(CXXScopeSpec &SS,
-                                    ParsedType ObjectType,
-                                    bool ObjectHadErrors,
-                                    SourceLocation TemplateKWLoc,
-                                    SourceLocation TildeLoc,
-                                    IdentifierInfo *Name,
-                                    SourceLocation NameLoc,
-                                    bool EnteringContext,
-                                    UnqualifiedId &Id,
-                                    bool AssumeTemplateId);
+  bool ParseUnqualifiedIdTemplateId(
+      CXXScopeSpec &SS, ParsedType ObjectType, bool ObjectHadErrors,
+      SourceLocation TemplateKWLoc, SourceLocation TildeLoc,
+      IdentifierInfo *Name, SourceLocation NameLoc, bool EnteringContext,
+      UnqualifiedId &Id, bool AssumeTemplateId);
   bool ParseUnqualifiedIdOperator(CXXScopeSpec &SS, bool EnteringContext,
                                   ParsedType ObjectType,
                                   UnqualifiedId &Result);

--- a/clang/include/clang/Parse/Parser.h
+++ b/clang/include/clang/Parse/Parser.h
@@ -3376,7 +3376,8 @@ private:
                                     SourceLocation NameLoc,
                                     bool EnteringContext,
                                     UnqualifiedId &Id,
-                                    bool AssumeTemplateId);
+                                    bool AssumeTemplateId,
+                                    bool ForDestructor);
   bool ParseUnqualifiedIdOperator(CXXScopeSpec &SS, bool EnteringContext,
                                   ParsedType ObjectType,
                                   UnqualifiedId &Result);

--- a/clang/include/clang/Parse/Parser.h
+++ b/clang/include/clang/Parse/Parser.h
@@ -3372,12 +3372,12 @@ private:
                                     ParsedType ObjectType,
                                     bool ObjectHadErrors,
                                     SourceLocation TemplateKWLoc,
+                                    SourceLocation TildeLoc,
                                     IdentifierInfo *Name,
                                     SourceLocation NameLoc,
                                     bool EnteringContext,
                                     UnqualifiedId &Id,
-                                    bool AssumeTemplateId,
-                                    bool ForDestructor);
+                                    bool AssumeTemplateId);
   bool ParseUnqualifiedIdOperator(CXXScopeSpec &SS, bool EnteringContext,
                                   ParsedType ObjectType,
                                   UnqualifiedId &Result);

--- a/clang/include/clang/Sema/DeclSpec.h
+++ b/clang/include/clang/Sema/DeclSpec.h
@@ -75,7 +75,7 @@ class CXXScopeSpec {
   SourceRange Range;
   NestedNameSpecifierLocBuilder Builder;
   ArrayRef<TemplateParameterList *> TemplateParamLists;
-  NamedDecl *FoundFirstQualifierInScope;
+  ArrayRef<DeclAccessPair> UnqualifiedLookups;
 
 public:
   SourceRange getRange() const { return Range; }
@@ -92,11 +92,11 @@ public:
     return TemplateParamLists;
   }
 
-  void setFoundFirstQualifierInScope(NamedDecl *Found) {
-    FoundFirstQualifierInScope = Found;
+  void setUnqualifiedLookups(ArrayRef<DeclAccessPair> Found) {
+    UnqualifiedLookups = Found;
   }
-  NamedDecl *getFirstQualifierFoundInScope() const {
-    return FoundFirstQualifierInScope;
+  ArrayRef<DeclAccessPair> getUnqualifiedLookups() const {
+    return UnqualifiedLookups;
   }
 
   /// Retrieve the representation of the nested-name-specifier.

--- a/clang/include/clang/Sema/DeclSpec.h
+++ b/clang/include/clang/Sema/DeclSpec.h
@@ -75,6 +75,7 @@ class CXXScopeSpec {
   SourceRange Range;
   NestedNameSpecifierLocBuilder Builder;
   ArrayRef<TemplateParameterList *> TemplateParamLists;
+  NamedDecl *FoundFirstQualifierInScope;
 
 public:
   SourceRange getRange() const { return Range; }
@@ -89,6 +90,13 @@ public:
   }
   ArrayRef<TemplateParameterList *> getTemplateParamLists() const {
     return TemplateParamLists;
+  }
+
+  void setFoundFirstQualifierInScope(NamedDecl *Found) {
+    FoundFirstQualifierInScope = Found;
+  }
+  NamedDecl *getFirstQualifierFoundInScope() const {
+    return FoundFirstQualifierInScope;
   }
 
   /// Retrieve the representation of the nested-name-specifier.

--- a/clang/include/clang/Sema/Lookup.h
+++ b/clang/include/clang/Sema/Lookup.h
@@ -483,11 +483,15 @@ public:
     ResultKind = Found;
   }
 
+  void addAllDecls(ArrayRef<DeclAccessPair> Other) {
+    Decls.addAllDecls(Other);
+    ResultKind = Found;
+  }
+
   /// Add all the declarations from another set of lookup
   /// results.
   void addAllDecls(const LookupResult &Other) {
-    Decls.append(Other.Decls.begin(), Other.Decls.end());
-    ResultKind = Found;
+    addAllDecls(Other.Decls.pairs());
   }
 
   /// Determine whether no result was found because we could not

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -11122,7 +11122,8 @@ public:
                      QualType ObjectType, bool EnteringContext,
                      RequiredTemplateKind RequiredTemplate = SourceLocation(),
                      AssumedTemplateKind *ATK = nullptr,
-                     bool AllowTypoCorrection = true);
+                     bool AllowTypoCorrection = true,
+                     bool MayBeNNS = false);
 
   TemplateNameKind isTemplateName(Scope *S, CXXScopeSpec &SS,
                                   bool hasTemplateKeyword,
@@ -11130,7 +11131,8 @@ public:
                                   ParsedType ObjectType, bool EnteringContext,
                                   TemplateTy &Template,
                                   bool &MemberOfUnknownSpecialization,
-                                  bool Disambiguation = false);
+                                  bool Disambiguation = false,
+                                  bool MayBeNNS = false);
 
   /// Try to resolve an undeclared template name as a type template.
   ///
@@ -11464,7 +11466,8 @@ public:
                                      const UnqualifiedId &Name,
                                      ParsedType ObjectType,
                                      bool EnteringContext, TemplateTy &Template,
-                                     bool AllowInjectedClassName = false);
+                                     bool AllowInjectedClassName = false,
+                                     bool MayBeNNS = false);
 
   DeclResult ActOnClassTemplateSpecialization(
       Scope *S, unsigned TagSpec, TagUseKind TUK, SourceLocation KWLoc,

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -8584,7 +8584,7 @@ public:
   ///   decl; this is an ugly hack around the fact that Objective-C
   ///   \@implementations aren't properly put in the context chain
   ExprResult ActOnMemberAccessExpr(Scope *S, Expr *Base, SourceLocation OpLoc,
-                                   bool IsArrow, CXXScopeSpec &SS,
+                                   tok::TokenKind OpKind, CXXScopeSpec &SS,
                                    SourceLocation TemplateKWLoc,
                                    UnqualifiedId &Member, Decl *ObjCImpDecl);
 

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -8583,7 +8583,7 @@ public:
   ///   decl; this is an ugly hack around the fact that Objective-C
   ///   \@implementations aren't properly put in the context chain
   ExprResult ActOnMemberAccessExpr(Scope *S, Expr *Base, SourceLocation OpLoc,
-                                   tok::TokenKind OpKind, CXXScopeSpec &SS,
+                                   bool IsArrow, CXXScopeSpec &SS,
                                    SourceLocation TemplateKWLoc,
                                    UnqualifiedId &Member, Decl *ObjCImpDecl);
 

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -2843,9 +2843,6 @@ public:
   /// \param EnteringContext If true, enter the context specified by the
   ///        nested-name-specifier.
   /// \param SS Optional nested name specifier preceding the identifier.
-  /// \param ScopeLookupResult Provides the result of name lookup within the
-  ///        scope of the nested-name-specifier that was computed at template
-  ///        definition time.
   /// \param ErrorRecoveryLookup Specifies if the method is called to improve
   ///        error recovery and what kind of recovery is performed.
   /// \param IsCorrectedToColon If not null, suggestion of replace '::' -> ':'
@@ -2853,11 +2850,6 @@ public:
   ///       'true' if the identifier is treated as if it was followed by ':',
   ///        not '::'.
   /// \param OnlyNamespace If true, only considers namespaces in lookup.
-  ///
-  /// This routine differs only slightly from ActOnCXXNestedNameSpecifier, in
-  /// that it contains an extra parameter \p ScopeLookupResult, which provides
-  /// the result of name lookup within the scope of the nested-name-specifier
-  /// that was computed at template definition time.
   ///
   /// If ErrorRecoveryLookup is true, then this call is used to improve error
   /// recovery.  This means that it should not emit diagnostics, it should

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -2802,7 +2802,7 @@ public:
   /// (e.g., Base::), perform name lookup for that identifier as a
   /// nested-name-specifier within the given scope, and return the result of
   /// that name lookup.
-  NamedDecl *FindFirstQualifierInScope(Scope *S, NestedNameSpecifier *NNS);
+  bool LookupFirstQualifierInScope(Scope *S, NestedNameSpecifier *NNS, UnresolvedSetImpl &R);
 
   /// Keeps information about an identifier in a nested-name-spec.
   ///
@@ -2866,7 +2866,6 @@ public:
   /// specifier.
   bool BuildCXXNestedNameSpecifier(Scope *S, NestedNameSpecInfo &IdInfo,
                                    bool EnteringContext, CXXScopeSpec &SS,
-                                   NamedDecl *ScopeLookupResult,
                                    bool ErrorRecoveryLookup,
                                    bool *IsCorrectedToColon = nullptr,
                                    bool OnlyNamespace = false);
@@ -8569,7 +8568,7 @@ public:
   ExprResult ActOnDependentMemberExpr(
       Expr *Base, QualType BaseType, bool IsArrow, SourceLocation OpLoc,
       const CXXScopeSpec &SS, SourceLocation TemplateKWLoc,
-      NamedDecl *FirstQualifierInScope, const DeclarationNameInfo &NameInfo,
+      const DeclarationNameInfo &NameInfo,
       const TemplateArgumentListInfo *TemplateArgs);
 
   /// The main callback when the parser finds something like
@@ -8626,15 +8625,14 @@ public:
   ExprResult BuildMemberReferenceExpr(
       Expr *Base, QualType BaseType, SourceLocation OpLoc, bool IsArrow,
       CXXScopeSpec &SS, SourceLocation TemplateKWLoc,
-      NamedDecl *FirstQualifierInScope, const DeclarationNameInfo &NameInfo,
+      const DeclarationNameInfo &NameInfo,
       const TemplateArgumentListInfo *TemplateArgs, const Scope *S,
       ActOnMemberAccessExtraArgs *ExtraArgs = nullptr);
 
   ExprResult
   BuildMemberReferenceExpr(Expr *Base, QualType BaseType, SourceLocation OpLoc,
                            bool IsArrow, const CXXScopeSpec &SS,
-                           SourceLocation TemplateKWLoc,
-                           NamedDecl *FirstQualifierInScope, LookupResult &R,
+                           SourceLocation TemplateKWLoc, LookupResult &R,
                            const TemplateArgumentListInfo *TemplateArgs,
                            const Scope *S, bool SuppressQualifierCheck = false,
                            ActOnMemberAccessExtraArgs *ExtraArgs = nullptr);

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -2802,7 +2802,8 @@ public:
   /// (e.g., Base::), perform name lookup for that identifier as a
   /// nested-name-specifier within the given scope, and return the result of
   /// that name lookup.
-  bool LookupFirstQualifierInScope(Scope *S, NestedNameSpecifier *NNS, UnresolvedSetImpl &R);
+  bool LookupFirstQualifierInScope(Scope *S, NestedNameSpecifier *NNS,
+                                   UnresolvedSetImpl &R);
 
   /// Keeps information about an identifier in a nested-name-spec.
   ///
@@ -8565,11 +8566,12 @@ public:
                           const TemplateArgumentListInfo *TemplateArgs,
                           bool IsDefiniteInstance, const Scope *S);
 
-  ExprResult ActOnDependentMemberExpr(
-      Expr *Base, QualType BaseType, bool IsArrow, SourceLocation OpLoc,
-      const CXXScopeSpec &SS, SourceLocation TemplateKWLoc,
-      const DeclarationNameInfo &NameInfo,
-      const TemplateArgumentListInfo *TemplateArgs);
+  ExprResult
+  ActOnDependentMemberExpr(Expr *Base, QualType BaseType, bool IsArrow,
+                           SourceLocation OpLoc, const CXXScopeSpec &SS,
+                           SourceLocation TemplateKWLoc,
+                           const DeclarationNameInfo &NameInfo,
+                           const TemplateArgumentListInfo *TemplateArgs);
 
   /// The main callback when the parser finds something like
   ///   expression . [nested-name-specifier] identifier

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -11122,17 +11122,14 @@ public:
                      QualType ObjectType, bool EnteringContext,
                      RequiredTemplateKind RequiredTemplate = SourceLocation(),
                      AssumedTemplateKind *ATK = nullptr,
-                     bool AllowTypoCorrection = true,
-                     bool MayBeNNS = false);
+                     bool AllowTypoCorrection = true, bool MayBeNNS = false);
 
-  TemplateNameKind isTemplateName(Scope *S, CXXScopeSpec &SS,
-                                  bool hasTemplateKeyword,
-                                  const UnqualifiedId &Name,
-                                  ParsedType ObjectType, bool EnteringContext,
-                                  TemplateTy &Template,
-                                  bool &MemberOfUnknownSpecialization,
-                                  bool Disambiguation = false,
-                                  bool MayBeNNS = false);
+  TemplateNameKind
+  isTemplateName(Scope *S, CXXScopeSpec &SS, bool hasTemplateKeyword,
+                 const UnqualifiedId &Name, ParsedType ObjectType,
+                 bool EnteringContext, TemplateTy &Template,
+                 bool &MemberOfUnknownSpecialization,
+                 bool Disambiguation = false, bool MayBeNNS = false);
 
   /// Try to resolve an undeclared template name as a type template.
   ///
@@ -11461,13 +11458,11 @@ public:
   /// For example, given "x.MetaFun::template apply", the scope specifier
   /// \p SS will be "MetaFun::", \p TemplateKWLoc contains the location
   /// of the "template" keyword, and "apply" is the \p Name.
-  TemplateNameKind ActOnTemplateName(Scope *S, CXXScopeSpec &SS,
-                                     SourceLocation TemplateKWLoc,
-                                     const UnqualifiedId &Name,
-                                     ParsedType ObjectType,
-                                     bool EnteringContext, TemplateTy &Template,
-                                     bool AllowInjectedClassName = false,
-                                     bool MayBeNNS = false);
+  TemplateNameKind
+  ActOnTemplateName(Scope *S, CXXScopeSpec &SS, SourceLocation TemplateKWLoc,
+                    const UnqualifiedId &Name, ParsedType ObjectType,
+                    bool EnteringContext, TemplateTy &Template,
+                    bool AllowInjectedClassName = false, bool MayBeNNS = false);
 
   DeclResult ActOnClassTemplateSpecialization(
       Scope *S, unsigned TagSpec, TagUseKind TUK, SourceLocation KWLoc,

--- a/clang/lib/AST/ASTImporter.cpp
+++ b/clang/lib/AST/ASTImporter.cpp
@@ -8439,8 +8439,15 @@ ExpectedStmt ASTNodeImporter::VisitCXXDependentScopeMemberExpr(
   auto ToOperatorLoc = importChecked(Err, E->getOperatorLoc());
   auto ToQualifierLoc = importChecked(Err, E->getQualifierLoc());
   auto ToTemplateKeywordLoc = importChecked(Err, E->getTemplateKeywordLoc());
-  auto ToFirstQualifierFoundInScope =
-      importChecked(Err, E->getFirstQualifierFoundInScope());
+
+
+  UnresolvedSet<8> ToUnqualifiedLookups;
+  for (auto D : E->unqualified_lookups())
+    if (auto ToDOrErr = import(D.getDecl()))
+      ToUnqualifiedLookups.addDecl(*ToDOrErr);
+    else
+      return ToDOrErr.takeError();
+
   if (Err)
     return std::move(Err);
 
@@ -8474,7 +8481,7 @@ ExpectedStmt ASTNodeImporter::VisitCXXDependentScopeMemberExpr(
 
   return CXXDependentScopeMemberExpr::Create(
       Importer.getToContext(), ToBase, ToType, E->isArrow(), ToOperatorLoc,
-      ToQualifierLoc, ToTemplateKeywordLoc, ToFirstQualifierFoundInScope,
+      ToQualifierLoc, ToTemplateKeywordLoc, ToUnqualifiedLookups.pairs(),
       ToMemberNameInfo, ResInfo);
 }
 

--- a/clang/lib/AST/ASTImporter.cpp
+++ b/clang/lib/AST/ASTImporter.cpp
@@ -8440,7 +8440,6 @@ ExpectedStmt ASTNodeImporter::VisitCXXDependentScopeMemberExpr(
   auto ToQualifierLoc = importChecked(Err, E->getQualifierLoc());
   auto ToTemplateKeywordLoc = importChecked(Err, E->getTemplateKeywordLoc());
 
-
   UnresolvedSet<8> ToUnqualifiedLookups;
   for (auto D : E->unqualified_lookups())
     if (auto ToDOrErr = import(D.getDecl()))

--- a/clang/lib/AST/ExprCXX.cpp
+++ b/clang/lib/AST/ExprCXX.cpp
@@ -1497,8 +1497,7 @@ CXXDependentScopeMemberExpr::CXXDependentScopeMemberExpr(
       Base(Base), BaseType(BaseType), OperatorLoc(OperatorLoc),
       MemberNameInfo(MemberNameInfo) {
   CXXDependentScopeMemberExprBits.IsArrow = IsArrow;
-  CXXDependentScopeMemberExprBits.HasQualifier =
-      QualifierLoc.hasQualifier();
+  CXXDependentScopeMemberExprBits.HasQualifier = QualifierLoc.hasQualifier();
   CXXDependentScopeMemberExprBits.NumUnqualifiedLookups =
       UnqualifiedLookups.size();
   CXXDependentScopeMemberExprBits.HasTemplateKWAndArgsInfo =
@@ -1509,7 +1508,8 @@ CXXDependentScopeMemberExpr::CXXDependentScopeMemberExpr(
         NestedNameSpecifierLoc(QualifierLoc);
 
   std::uninitialized_copy_n(UnqualifiedLookups.data(),
-      UnqualifiedLookups.size(), getTrailingObjects<DeclAccessPair>());
+                            UnqualifiedLookups.size(),
+                            getTrailingObjects<DeclAccessPair>());
 
   if (TemplateArgs) {
     auto Deps = TemplateArgumentDependence::None;
@@ -1529,8 +1529,7 @@ CXXDependentScopeMemberExpr::CXXDependentScopeMemberExpr(
     bool HasTemplateKWAndArgsInfo)
     : Expr(CXXDependentScopeMemberExprClass, Empty) {
   CXXDependentScopeMemberExprBits.HasQualifier = HasQualifier;
-  CXXDependentScopeMemberExprBits.NumUnqualifiedLookups =
-      NumUnqualifiedLookups;
+  CXXDependentScopeMemberExprBits.NumUnqualifiedLookups = NumUnqualifiedLookups;
   CXXDependentScopeMemberExprBits.HasTemplateKWAndArgsInfo =
       HasTemplateKWAndArgsInfo;
 }
@@ -1547,12 +1546,11 @@ CXXDependentScopeMemberExpr *CXXDependentScopeMemberExpr::Create(
   bool HasTemplateKWAndArgsInfo =
       (TemplateArgs != nullptr) || TemplateKWLoc.isValid();
   unsigned NumTemplateArgs = TemplateArgs ? TemplateArgs->size() : 0;
-  unsigned Size = totalSizeToAlloc<NestedNameSpecifierLoc,
-                                   DeclAccessPair,
-                                   ASTTemplateKWAndArgsInfo,
-                                   TemplateArgumentLoc>(
-      HasQualifier, NumUnqualifiedLookups,
-      HasTemplateKWAndArgsInfo, NumTemplateArgs);
+  unsigned Size =
+      totalSizeToAlloc<NestedNameSpecifierLoc, DeclAccessPair,
+                       ASTTemplateKWAndArgsInfo, TemplateArgumentLoc>(
+          HasQualifier, NumUnqualifiedLookups, HasTemplateKWAndArgsInfo,
+          NumTemplateArgs);
 
   void *Mem = Ctx.Allocate(Size, alignof(CXXDependentScopeMemberExpr));
   return new (Mem) CXXDependentScopeMemberExpr(
@@ -1566,16 +1564,16 @@ CXXDependentScopeMemberExpr *CXXDependentScopeMemberExpr::CreateEmpty(
   assert(!NumTemplateArgs || HasTemplateKWAndArgsInfo);
   assert(!NumUnqualifiedLookups || HasQualifier);
 
-  unsigned Size = totalSizeToAlloc<NestedNameSpecifierLoc,
-                                   DeclAccessPair,
-                                   ASTTemplateKWAndArgsInfo,
-                                   TemplateArgumentLoc>(
-      HasQualifier, NumUnqualifiedLookups,
-      HasTemplateKWAndArgsInfo, NumTemplateArgs);
+  unsigned Size =
+      totalSizeToAlloc<NestedNameSpecifierLoc, DeclAccessPair,
+                       ASTTemplateKWAndArgsInfo, TemplateArgumentLoc>(
+          HasQualifier, NumUnqualifiedLookups, HasTemplateKWAndArgsInfo,
+          NumTemplateArgs);
 
   void *Mem = Ctx.Allocate(Size, alignof(CXXDependentScopeMemberExpr));
-  return new (Mem) CXXDependentScopeMemberExpr(
-      EmptyShell(), HasQualifier, NumUnqualifiedLookups, HasTemplateKWAndArgsInfo);
+  return new (Mem) CXXDependentScopeMemberExpr(EmptyShell(), HasQualifier,
+                                               NumUnqualifiedLookups,
+                                               HasTemplateKWAndArgsInfo);
 }
 
 CXXThisExpr *CXXThisExpr::Create(const ASTContext &Ctx, SourceLocation L,

--- a/clang/lib/AST/ExprCXX.cpp
+++ b/clang/lib/AST/ExprCXX.cpp
@@ -1494,8 +1494,8 @@ CXXDependentScopeMemberExpr::CXXDependentScopeMemberExpr(
     const TemplateArgumentListInfo *TemplateArgs)
     : Expr(CXXDependentScopeMemberExprClass, Ctx.DependentTy, VK_LValue,
            OK_Ordinary),
-      Base(Base), BaseType(BaseType), OperatorLoc(OperatorLoc),
-      MemberNameInfo(MemberNameInfo) {
+      Base(Base), BaseType(BaseType), MemberNameInfo(MemberNameInfo),
+      OperatorLoc(OperatorLoc) {
   CXXDependentScopeMemberExprBits.IsArrow = IsArrow;
   CXXDependentScopeMemberExprBits.HasQualifier = QualifierLoc.hasQualifier();
   CXXDependentScopeMemberExprBits.NumUnqualifiedLookups =

--- a/clang/lib/AST/ExprCXX.cpp
+++ b/clang/lib/AST/ExprCXX.cpp
@@ -1489,19 +1489,27 @@ SourceLocation CXXUnresolvedConstructExpr::getBeginLoc() const {
 CXXDependentScopeMemberExpr::CXXDependentScopeMemberExpr(
     const ASTContext &Ctx, Expr *Base, QualType BaseType, bool IsArrow,
     SourceLocation OperatorLoc, NestedNameSpecifierLoc QualifierLoc,
-    SourceLocation TemplateKWLoc, NamedDecl *FirstQualifierFoundInScope,
+    SourceLocation TemplateKWLoc, ArrayRef<DeclAccessPair> UnqualifiedLookups,
     DeclarationNameInfo MemberNameInfo,
     const TemplateArgumentListInfo *TemplateArgs)
     : Expr(CXXDependentScopeMemberExprClass, Ctx.DependentTy, VK_LValue,
            OK_Ordinary),
-      Base(Base), BaseType(BaseType), QualifierLoc(QualifierLoc),
+      Base(Base), BaseType(BaseType), OperatorLoc(OperatorLoc),
       MemberNameInfo(MemberNameInfo) {
   CXXDependentScopeMemberExprBits.IsArrow = IsArrow;
+  CXXDependentScopeMemberExprBits.HasQualifier =
+      QualifierLoc.hasQualifier();
+  CXXDependentScopeMemberExprBits.NumUnqualifiedLookups =
+      UnqualifiedLookups.size();
   CXXDependentScopeMemberExprBits.HasTemplateKWAndArgsInfo =
       (TemplateArgs != nullptr) || TemplateKWLoc.isValid();
-  CXXDependentScopeMemberExprBits.HasFirstQualifierFoundInScope =
-      FirstQualifierFoundInScope != nullptr;
-  CXXDependentScopeMemberExprBits.OperatorLoc = OperatorLoc;
+
+  if (hasQualifier())
+    new (getTrailingObjects<NestedNameSpecifierLoc>())
+        NestedNameSpecifierLoc(QualifierLoc);
+
+  std::uninitialized_copy_n(UnqualifiedLookups.data(),
+      UnqualifiedLookups.size(), getTrailingObjects<DeclAccessPair>());
 
   if (TemplateArgs) {
     auto Deps = TemplateArgumentDependence::None;
@@ -1513,54 +1521,61 @@ CXXDependentScopeMemberExpr::CXXDependentScopeMemberExpr(
         TemplateKWLoc);
   }
 
-  if (hasFirstQualifierFoundInScope())
-    *getTrailingObjects<NamedDecl *>() = FirstQualifierFoundInScope;
   setDependence(computeDependence(this));
 }
 
 CXXDependentScopeMemberExpr::CXXDependentScopeMemberExpr(
-    EmptyShell Empty, bool HasTemplateKWAndArgsInfo,
-    bool HasFirstQualifierFoundInScope)
+    EmptyShell Empty, bool HasQualifier, unsigned NumUnqualifiedLookups,
+    bool HasTemplateKWAndArgsInfo)
     : Expr(CXXDependentScopeMemberExprClass, Empty) {
+  CXXDependentScopeMemberExprBits.HasQualifier = HasQualifier;
+  CXXDependentScopeMemberExprBits.NumUnqualifiedLookups =
+      NumUnqualifiedLookups;
   CXXDependentScopeMemberExprBits.HasTemplateKWAndArgsInfo =
       HasTemplateKWAndArgsInfo;
-  CXXDependentScopeMemberExprBits.HasFirstQualifierFoundInScope =
-      HasFirstQualifierFoundInScope;
 }
 
 CXXDependentScopeMemberExpr *CXXDependentScopeMemberExpr::Create(
     const ASTContext &Ctx, Expr *Base, QualType BaseType, bool IsArrow,
     SourceLocation OperatorLoc, NestedNameSpecifierLoc QualifierLoc,
-    SourceLocation TemplateKWLoc, NamedDecl *FirstQualifierFoundInScope,
+    SourceLocation TemplateKWLoc, ArrayRef<DeclAccessPair> UnqualifiedLookups,
     DeclarationNameInfo MemberNameInfo,
     const TemplateArgumentListInfo *TemplateArgs) {
+  bool HasQualifier = QualifierLoc.hasQualifier();
+  unsigned NumUnqualifiedLookups = UnqualifiedLookups.size();
+  assert(!NumUnqualifiedLookups || HasQualifier);
   bool HasTemplateKWAndArgsInfo =
       (TemplateArgs != nullptr) || TemplateKWLoc.isValid();
   unsigned NumTemplateArgs = TemplateArgs ? TemplateArgs->size() : 0;
-  bool HasFirstQualifierFoundInScope = FirstQualifierFoundInScope != nullptr;
-
-  unsigned Size = totalSizeToAlloc<ASTTemplateKWAndArgsInfo,
-                                   TemplateArgumentLoc, NamedDecl *>(
-      HasTemplateKWAndArgsInfo, NumTemplateArgs, HasFirstQualifierFoundInScope);
+  unsigned Size = totalSizeToAlloc<NestedNameSpecifierLoc,
+                                   DeclAccessPair,
+                                   ASTTemplateKWAndArgsInfo,
+                                   TemplateArgumentLoc>(
+      HasQualifier, NumUnqualifiedLookups,
+      HasTemplateKWAndArgsInfo, NumTemplateArgs);
 
   void *Mem = Ctx.Allocate(Size, alignof(CXXDependentScopeMemberExpr));
   return new (Mem) CXXDependentScopeMemberExpr(
       Ctx, Base, BaseType, IsArrow, OperatorLoc, QualifierLoc, TemplateKWLoc,
-      FirstQualifierFoundInScope, MemberNameInfo, TemplateArgs);
+      UnqualifiedLookups, MemberNameInfo, TemplateArgs);
 }
 
 CXXDependentScopeMemberExpr *CXXDependentScopeMemberExpr::CreateEmpty(
-    const ASTContext &Ctx, bool HasTemplateKWAndArgsInfo,
-    unsigned NumTemplateArgs, bool HasFirstQualifierFoundInScope) {
-  assert(NumTemplateArgs == 0 || HasTemplateKWAndArgsInfo);
+    const ASTContext &Ctx, bool HasQualifier, unsigned NumUnqualifiedLookups,
+    bool HasTemplateKWAndArgsInfo, unsigned NumTemplateArgs) {
+  assert(!NumTemplateArgs || HasTemplateKWAndArgsInfo);
+  assert(!NumUnqualifiedLookups || HasQualifier);
 
-  unsigned Size = totalSizeToAlloc<ASTTemplateKWAndArgsInfo,
-                                   TemplateArgumentLoc, NamedDecl *>(
-      HasTemplateKWAndArgsInfo, NumTemplateArgs, HasFirstQualifierFoundInScope);
+  unsigned Size = totalSizeToAlloc<NestedNameSpecifierLoc,
+                                   DeclAccessPair,
+                                   ASTTemplateKWAndArgsInfo,
+                                   TemplateArgumentLoc>(
+      HasQualifier, NumUnqualifiedLookups,
+      HasTemplateKWAndArgsInfo, NumTemplateArgs);
 
   void *Mem = Ctx.Allocate(Size, alignof(CXXDependentScopeMemberExpr));
   return new (Mem) CXXDependentScopeMemberExpr(
-      EmptyShell(), HasTemplateKWAndArgsInfo, HasFirstQualifierFoundInScope);
+      EmptyShell(), HasQualifier, NumUnqualifiedLookups, HasTemplateKWAndArgsInfo);
 }
 
 CXXThisExpr *CXXThisExpr::Create(const ASTContext &Ctx, SourceLocation L,

--- a/clang/lib/AST/ItaniumMangle.cpp
+++ b/clang/lib/AST/ItaniumMangle.cpp
@@ -597,8 +597,7 @@ private:
                         ArrayRef<DeclAccessPair> UnqualifiedLookups,
                         DeclarationName name,
                         const TemplateArgumentLoc *TemplateArgs,
-                        unsigned NumTemplateArgs,
-                        unsigned knownArity);
+                        unsigned NumTemplateArgs, unsigned knownArity);
   void mangleCastExpression(const Expr *E, StringRef CastEncoding);
   void mangleInitListElements(const InitListExpr *InitList);
   void mangleRequirement(SourceLocation RequiresExprLoc,
@@ -4496,14 +4495,11 @@ void CXXNameMangler::mangleMemberExprBase(const Expr *Base, bool IsArrow) {
 }
 
 /// Mangles a member expression.
-void CXXNameMangler::mangleMemberExpr(const Expr *base,
-                                      bool isArrow,
-                                      NestedNameSpecifier *qualifier,
-                                      ArrayRef<DeclAccessPair> UnqualifiedLookups,
-                                      DeclarationName member,
-                                      const TemplateArgumentLoc *TemplateArgs,
-                                      unsigned NumTemplateArgs,
-                                      unsigned arity) {
+void CXXNameMangler::mangleMemberExpr(
+    const Expr *base, bool isArrow, NestedNameSpecifier *qualifier,
+    ArrayRef<DeclAccessPair> UnqualifiedLookups, DeclarationName member,
+    const TemplateArgumentLoc *TemplateArgs, unsigned NumTemplateArgs,
+    unsigned arity) {
   // <expression> ::= dt <expression> <unresolved-name>
   //              ::= pt <expression> <unresolved-name>
   if (base)
@@ -4985,11 +4981,9 @@ recurse:
   case Expr::MemberExprClass: {
     NotPrimaryExpr();
     const MemberExpr *ME = cast<MemberExpr>(E);
-    mangleMemberExpr(ME->getBase(), ME->isArrow(),
-                     ME->getQualifier(), std::nullopt,
-                     ME->getMemberDecl()->getDeclName(),
-                     ME->getTemplateArgs(), ME->getNumTemplateArgs(),
-                     Arity);
+    mangleMemberExpr(ME->getBase(), ME->isArrow(), ME->getQualifier(),
+                     std::nullopt, ME->getMemberDecl()->getDeclName(),
+                     ME->getTemplateArgs(), ME->getNumTemplateArgs(), Arity);
     break;
   }
 
@@ -4998,9 +4992,8 @@ recurse:
     const UnresolvedMemberExpr *ME = cast<UnresolvedMemberExpr>(E);
     mangleMemberExpr(ME->isImplicitAccess() ? nullptr : ME->getBase(),
                      ME->isArrow(), ME->getQualifier(), std::nullopt,
-                     ME->getMemberName(),
-                     ME->getTemplateArgs(), ME->getNumTemplateArgs(),
-                     Arity);
+                     ME->getMemberName(), ME->getTemplateArgs(),
+                     ME->getNumTemplateArgs(), Arity);
     break;
   }
 
@@ -5010,10 +5003,8 @@ recurse:
       = cast<CXXDependentScopeMemberExpr>(E);
     mangleMemberExpr(ME->isImplicitAccess() ? nullptr : ME->getBase(),
                      ME->isArrow(), ME->getQualifier(),
-                     ME->unqualified_lookups(),
-                     ME->getMember(),
-                     ME->getTemplateArgs(), ME->getNumTemplateArgs(),
-                     Arity);
+                     ME->unqualified_lookups(), ME->getMember(),
+                     ME->getTemplateArgs(), ME->getNumTemplateArgs(), Arity);
     break;
   }
 

--- a/clang/lib/AST/ItaniumMangle.cpp
+++ b/clang/lib/AST/ItaniumMangle.cpp
@@ -594,7 +594,7 @@ private:
   void mangleMemberExprBase(const Expr *base, bool isArrow);
   void mangleMemberExpr(const Expr *base, bool isArrow,
                         NestedNameSpecifier *qualifier,
-                        NamedDecl *firstQualifierLookup,
+                        ArrayRef<DeclAccessPair> UnqualifiedLookups,
                         DeclarationName name,
                         const TemplateArgumentLoc *TemplateArgs,
                         unsigned NumTemplateArgs,
@@ -4499,7 +4499,7 @@ void CXXNameMangler::mangleMemberExprBase(const Expr *Base, bool IsArrow) {
 void CXXNameMangler::mangleMemberExpr(const Expr *base,
                                       bool isArrow,
                                       NestedNameSpecifier *qualifier,
-                                      NamedDecl *firstQualifierLookup,
+                                      ArrayRef<DeclAccessPair> UnqualifiedLookups,
                                       DeclarationName member,
                                       const TemplateArgumentLoc *TemplateArgs,
                                       unsigned NumTemplateArgs,
@@ -4986,7 +4986,7 @@ recurse:
     NotPrimaryExpr();
     const MemberExpr *ME = cast<MemberExpr>(E);
     mangleMemberExpr(ME->getBase(), ME->isArrow(),
-                     ME->getQualifier(), nullptr,
+                     ME->getQualifier(), std::nullopt,
                      ME->getMemberDecl()->getDeclName(),
                      ME->getTemplateArgs(), ME->getNumTemplateArgs(),
                      Arity);
@@ -4997,7 +4997,7 @@ recurse:
     NotPrimaryExpr();
     const UnresolvedMemberExpr *ME = cast<UnresolvedMemberExpr>(E);
     mangleMemberExpr(ME->isImplicitAccess() ? nullptr : ME->getBase(),
-                     ME->isArrow(), ME->getQualifier(), nullptr,
+                     ME->isArrow(), ME->getQualifier(), std::nullopt,
                      ME->getMemberName(),
                      ME->getTemplateArgs(), ME->getNumTemplateArgs(),
                      Arity);
@@ -5010,7 +5010,7 @@ recurse:
       = cast<CXXDependentScopeMemberExpr>(E);
     mangleMemberExpr(ME->isImplicitAccess() ? nullptr : ME->getBase(),
                      ME->isArrow(), ME->getQualifier(),
-                     ME->getFirstQualifierFoundInScope(),
+                     ME->unqualified_lookups(),
                      ME->getMember(),
                      ME->getTemplateArgs(), ME->getNumTemplateArgs(),
                      Arity);

--- a/clang/lib/Parse/ParseDeclCXX.cpp
+++ b/clang/lib/Parse/ParseDeclCXX.cpp
@@ -728,7 +728,7 @@ Parser::DeclGroupPtrTy Parser::ParseUsingDeclaration(
       return nullptr;
     }
     CXXScopeSpec SS;
-    if (ParseOptionalCXXScopeSpecifier(SS, /*ObjectType=*/nullptr,
+    if (ParseOptionalCXXScopeSpecifier(SS, /*ParsedType=*/nullptr,
                                        /*ObectHasErrors=*/false,
                                        /*EnteringConttext=*/false,
                                        /*MayBePseudoDestructor=*/nullptr,

--- a/clang/lib/Parse/ParseDeclCXX.cpp
+++ b/clang/lib/Parse/ParseDeclCXX.cpp
@@ -728,7 +728,7 @@ Parser::DeclGroupPtrTy Parser::ParseUsingDeclaration(
       return nullptr;
     }
     CXXScopeSpec SS;
-    if (ParseOptionalCXXScopeSpecifier(SS, /*ParsedType=*/nullptr,
+    if (ParseOptionalCXXScopeSpecifier(SS, /*ObjectType=*/nullptr,
                                        /*ObectHasErrors=*/false,
                                        /*EnteringConttext=*/false,
                                        /*MayBePseudoDestructor=*/nullptr,

--- a/clang/lib/Parse/ParseExpr.cpp
+++ b/clang/lib/Parse/ParseExpr.cpp
@@ -2343,10 +2343,9 @@ Parser::ParsePostfixExpressionSuffix(ExprResult LHS) {
       }
 
       if (!LHS.isInvalid())
-        LHS = Actions.ActOnMemberAccessExpr(getCurScope(), LHS.get(), OpLoc,
-                                            OpKind, SS, TemplateKWLoc, Name,
-                                 CurParsedObjCImpl ? CurParsedObjCImpl->Dcl
-                                                   : nullptr);
+        LHS = Actions.ActOnMemberAccessExpr(
+            getCurScope(), LHS.get(), OpLoc, OpKind, SS, TemplateKWLoc, Name,
+            CurParsedObjCImpl ? CurParsedObjCImpl->Dcl : nullptr);
       if (!LHS.isInvalid()) {
         if (Tok.is(tok::less))
           checkPotentialAngleBracket(LHS);

--- a/clang/lib/Parse/ParseExpr.cpp
+++ b/clang/lib/Parse/ParseExpr.cpp
@@ -2269,6 +2269,7 @@ Parser::ParsePostfixExpressionSuffix(ExprResult LHS) {
           }
           break;
         }
+
         ParseOptionalCXXScopeSpecifier(
             SS, ObjectType, LHS.get() && LHS.get()->containsErrors(),
             /*EnteringContext=*/false, &MayBePseudoDestructor);
@@ -2343,10 +2344,10 @@ Parser::ParsePostfixExpressionSuffix(ExprResult LHS) {
       }
 
       if (!LHS.isInvalid())
-        LHS = Actions.ActOnMemberAccessExpr(getCurScope(), LHS.get(), OpLoc,
-                                            OpKind, SS, TemplateKWLoc, Name,
-                                 CurParsedObjCImpl ? CurParsedObjCImpl->Dcl
-                                                   : nullptr);
+        LHS = Actions.ActOnMemberAccessExpr(
+            getCurScope(), LHS.get(), OpLoc, OpKind == tok::arrow, SS,
+            TemplateKWLoc, Name,
+            CurParsedObjCImpl ? CurParsedObjCImpl->Dcl : nullptr);
       if (!LHS.isInvalid()) {
         if (Tok.is(tok::less))
           checkPotentialAngleBracket(LHS);

--- a/clang/lib/Parse/ParseExpr.cpp
+++ b/clang/lib/Parse/ParseExpr.cpp
@@ -2269,7 +2269,6 @@ Parser::ParsePostfixExpressionSuffix(ExprResult LHS) {
           }
           break;
         }
-
         ParseOptionalCXXScopeSpecifier(
             SS, ObjectType, LHS.get() && LHS.get()->containsErrors(),
             /*EnteringContext=*/false, &MayBePseudoDestructor);
@@ -2344,10 +2343,10 @@ Parser::ParsePostfixExpressionSuffix(ExprResult LHS) {
       }
 
       if (!LHS.isInvalid())
-        LHS = Actions.ActOnMemberAccessExpr(
-            getCurScope(), LHS.get(), OpLoc, OpKind == tok::arrow, SS,
-            TemplateKWLoc, Name,
-            CurParsedObjCImpl ? CurParsedObjCImpl->Dcl : nullptr);
+        LHS = Actions.ActOnMemberAccessExpr(getCurScope(), LHS.get(), OpLoc,
+                                            OpKind, SS, TemplateKWLoc, Name,
+                                 CurParsedObjCImpl ? CurParsedObjCImpl->Dcl
+                                                   : nullptr);
       if (!LHS.isInvalid()) {
         if (Tok.is(tok::less))
           checkPotentialAngleBracket(LHS);

--- a/clang/lib/Parse/ParseExprCXX.cpp
+++ b/clang/lib/Parse/ParseExprCXX.cpp
@@ -1910,45 +1910,21 @@ Parser::ParseCXXPseudoDestructor(Expr *Base, SourceLocation OpLoc,
   IdentifierInfo *Name = Tok.getIdentifierInfo();
   SourceLocation NameLoc = ConsumeToken();
   SecondTypeName.setIdentifier(Name, NameLoc);
-// SecondTypeName.setDestructorName(TildeLoc, nullptr, NameLoc);
 
-// If there is a '<', the second type name is a template-id. Parse
-// it as such.
-//
-// FIXME: This is not a context in which a '<' is assumed to start a template
-// argument list. This affects examples such as
-//   void f(auto *p) { p->~X<int>(); }
-// ... but there's no ambiguity, and nowhere to write 'template' in such an
-// example, so we accept it anyway.
-#if 1
+  // If there is a '<', the second type name is a template-id. Parse
+  // it as such.
+  //
+  // FIXME: This is not a context in which a '<' is assumed to start a template
+  // argument list. This affects examples such as
+  //   void f(auto *p) { p->~X<int>(); }
+  // ... but there's no ambiguity, and nowhere to write 'template' in such an
+  // example, so we accept it anyway
   if (Tok.is(tok::less) && ParseUnqualifiedIdTemplateId(
                                SS, ObjectType, Base && Base->containsErrors(),
                                /*TemplateKWLoc=*/SourceLocation(), TildeLoc,
                                Name, NameLoc, false, SecondTypeName,
                                /*AssumeTemplateId=*/true))
     return ExprError();
-#endif
-#if 0
-  if (Tok.is(tok::less)) {
-    TemplateTy Template;
-    TemplateNameKind TNK = Actions.ActOnTemplateName(
-        getCurScope(), SS, /*TemplateKWLoc=*/SourceLocation(),
-        SecondTypeName, ObjectType,
-        /*EnteringContext=*/false, Template,
-        /*AllowInjectedClassName*/true,
-        /*MayBeNNS=*/true);
-    if (TNK == TNK_Non_template)
-      return ExprError();
-
-    if (AnnotateTemplateIdToken(Template, TNK, SS,
-                                /*TemplateKWLoc=*/SourceLocation(),
-                                SecondTypeName, /*AllowTypeAnnotation=*/false))
-      return ExprError();
-    assert(Tok.is(tok::annot_template_id));
-    SecondTypeName.setTemplateId(takeTemplateIdAnnotation(Tok));
-    ConsumeAnnotationToken();
-  }
-#endif
 
   return Actions.ActOnPseudoDestructorExpr(getCurScope(), Base, OpLoc, OpKind,
                                            SS, FirstTypeName, CCLoc, TildeLoc,

--- a/clang/lib/Parse/ParseExprCXX.cpp
+++ b/clang/lib/Parse/ParseExprCXX.cpp
@@ -1912,6 +1912,7 @@ Parser::ParseCXXPseudoDestructor(Expr *Base, SourceLocation OpLoc,
   IdentifierInfo *Name = Tok.getIdentifierInfo();
   SourceLocation NameLoc = ConsumeToken();
   SecondTypeName.setIdentifier(Name, NameLoc);
+  // SecondTypeName.setDestructorName(TildeLoc, nullptr, NameLoc);
 
   // If there is a '<', the second type name is a template-id. Parse
   // it as such.
@@ -1924,9 +1925,10 @@ Parser::ParseCXXPseudoDestructor(Expr *Base, SourceLocation OpLoc,
   #if 1
   if (Tok.is(tok::less) &&
       ParseUnqualifiedIdTemplateId(
-          SS, ObjectType, Base && Base->containsErrors(), SourceLocation(),
+          SS, ObjectType, Base && Base->containsErrors(),
+          /*TemplateKWLoc=*/SourceLocation(), TildeLoc,
           Name, NameLoc, false, SecondTypeName,
-          /*AssumeTemplateId=*/true, /*ForDestructor=*/true))
+          /*AssumeTemplateId=*/true))
     return ExprError();
   #endif
   #if 0
@@ -2555,9 +2557,9 @@ bool Parser::ParseCXXTypeSpecifierSeq(DeclSpec &DS, DeclaratorContext Context) {
 /// \returns true if a parse error occurred, false otherwise.
 bool Parser::ParseUnqualifiedIdTemplateId(
     CXXScopeSpec &SS, ParsedType ObjectType, bool ObjectHadErrors,
-    SourceLocation TemplateKWLoc, IdentifierInfo *Name, SourceLocation NameLoc,
-    bool EnteringContext, UnqualifiedId &Id, bool AssumeTemplateId,
-    bool ForDestructor) {
+    SourceLocation TemplateKWLoc, SourceLocation TildeLoc,
+    IdentifierInfo *Name, SourceLocation NameLoc, bool EnteringContext,
+    UnqualifiedId &Id, bool AssumeTemplateId) {
   assert(Tok.is(tok::less) && "Expected '<' to finish parsing a template-id");
 
   TemplateTy Template;
@@ -2572,7 +2574,7 @@ bool Parser::ParseUnqualifiedIdTemplateId(
       TNK = Actions.ActOnTemplateName(getCurScope(), SS, TemplateKWLoc, Id,
                                       ObjectType, EnteringContext, Template,
                                       /*AllowInjectedClassName=*/true,
-                                      ForDestructor);
+                                      TildeLoc.isValid());
     } else {
       bool MemberOfUnknownSpecialization;
       TNK = Actions.isTemplateName(getCurScope(), SS,
@@ -2580,7 +2582,7 @@ bool Parser::ParseUnqualifiedIdTemplateId(
                                    ObjectType, EnteringContext, Template,
                                    MemberOfUnknownSpecialization,
                                    /*Disambiguation=*/false,
-                                   ForDestructor);
+                                   TildeLoc.isValid());
       // If lookup found nothing but we're assuming that this is a template
       // name, double-check that makes sense syntactically before committing
       // to it.
@@ -2613,7 +2615,7 @@ bool Parser::ParseUnqualifiedIdTemplateId(
         }
         TNK = Actions.ActOnTemplateName(
             getCurScope(), SS, TemplateKWLoc, Id, ObjectType, EnteringContext,
-            Template, /*AllowInjectedClassName=*/true, ForDestructor);
+            Template, /*AllowInjectedClassName=*/true, TildeLoc.isValid());
       } else if (TNK == TNK_Non_template) {
         return false;
       }
@@ -2710,7 +2712,7 @@ bool Parser::ParseUnqualifiedIdTemplateId(
   if (Id.getKind() == UnqualifiedIdKind::IK_ConstructorName)
     Id.setConstructorName(Type.get(), NameLoc, RAngleLoc);
   else
-    Id.setDestructorName(Id.StartLocation, Type.get(), RAngleLoc);
+    Id.setDestructorName(TildeLoc, Type.get(), RAngleLoc);
 
   return false;
 }
@@ -3058,8 +3060,9 @@ bool Parser::ParseUnqualifiedId(CXXScopeSpec &SS, ParsedType ObjectType,
     if (Tok.is(tok::less))
       return ParseUnqualifiedIdTemplateId(
           SS, ObjectType, ObjectHadErrors,
-          TemplateKWLoc ? *TemplateKWLoc : SourceLocation(), Id, IdLoc,
-          EnteringContext, Result, TemplateSpecified, /*ForDestructor=*/false);
+          TemplateKWLoc ? *TemplateKWLoc : SourceLocation(),
+          /*TildeLoc=*/SourceLocation(), Id, IdLoc,
+          EnteringContext, Result, TemplateSpecified);
 
     if (TemplateSpecified) {
       TemplateNameKind TNK =
@@ -3154,9 +3157,9 @@ bool Parser::ParseUnqualifiedId(CXXScopeSpec &SS, ParsedType ObjectType,
         Tok.is(tok::less))
       return ParseUnqualifiedIdTemplateId(
           SS, ObjectType, ObjectHadErrors,
-          TemplateKWLoc ? *TemplateKWLoc : SourceLocation(), nullptr,
-          SourceLocation(), EnteringContext, Result, TemplateSpecified,
-          /*ForDestructor=*/false);
+          TemplateKWLoc ? *TemplateKWLoc : SourceLocation(),
+          /*TildeLoc=*/SourceLocation(), /*Name=*/nullptr,
+          /*NameLoc=*/SourceLocation(), EnteringContext, Result, TemplateSpecified);
     else if (TemplateSpecified &&
              Actions.ActOnTemplateName(
                  getCurScope(), SS, *TemplateKWLoc, Result, ObjectType,
@@ -3251,9 +3254,8 @@ bool Parser::ParseUnqualifiedId(CXXScopeSpec &SS, ParsedType ObjectType,
       Result.setDestructorName(TildeLoc, nullptr, ClassNameLoc);
       return ParseUnqualifiedIdTemplateId(
           SS, ObjectType, ObjectHadErrors,
-          TemplateKWLoc ? *TemplateKWLoc : SourceLocation(), ClassName,
-          ClassNameLoc, EnteringContext, Result, TemplateSpecified,
-          /*ForDestructor=*/true);
+          TemplateKWLoc ? *TemplateKWLoc : SourceLocation(),
+          TildeLoc, ClassName, ClassNameLoc, EnteringContext, Result, TemplateSpecified);
     }
 
     // Note that this is a destructor name.

--- a/clang/lib/Parse/ParseExprCXX.cpp
+++ b/clang/lib/Parse/ParseExprCXX.cpp
@@ -566,11 +566,7 @@ bool Parser::ParseOptionalCXXScopeSpecifier(
           // member of an unknown specialization. However, this will only
           // parse correctly as a template, so suggest the keyword 'template'
           // before 'getAs' and treat this as a dependent template name.
-          unsigned DiagID = diag::err_missing_dependent_template_keyword;
-          if (getLangOpts().MicrosoftExt)
-            DiagID = diag::warn_missing_dependent_template_keyword;
-
-          Diag(Tok.getLocation(), DiagID)
+          Diag(Tok.getLocation(), diag::ext_missing_dependent_template_keyword)
               << II.getName()
               << FixItHint::CreateInsertion(Tok.getLocation(), "template ");
         }
@@ -2580,7 +2576,7 @@ bool Parser::ParseUnqualifiedIdTemplateId(
             else
               Name += Id.Identifier->getName();
           }
-          Diag(Id.StartLocation, diag::err_missing_dependent_template_keyword)
+          Diag(Id.StartLocation, diag::ext_missing_dependent_template_keyword)
               << Name
               << FixItHint::CreateInsertion(Id.StartLocation, "template ");
         }

--- a/clang/lib/Parse/ParseExprCXX.cpp
+++ b/clang/lib/Parse/ParseExprCXX.cpp
@@ -354,7 +354,7 @@ bool Parser::ParseOptionalCXXScopeSpecifier(
       TemplateTy Template;
       TemplateNameKind TNK = Actions.ActOnTemplateName(
           getCurScope(), SS, TemplateKWLoc, TemplateName, ObjectType,
-          EnteringContext, Template, /*AllowInjectedClassName*/true,
+          EnteringContext, Template, /*AllowInjectedClassName*/ true,
           /*MayBeNNS=*/true);
       if (AnnotateTemplateIdToken(Template, TNK, SS, TemplateKWLoc,
                                   TemplateName, false))
@@ -529,21 +529,19 @@ bool Parser::ParseOptionalCXXScopeSpecifier(
       UnqualifiedId TemplateName;
       TemplateName.setIdentifier(&II, Tok.getLocation());
       bool MemberOfUnknownSpecialization;
-      if (TemplateNameKind TNK = Actions.isTemplateName(getCurScope(), SS,
-                                              /*hasTemplateKeyword=*/false,
-                                                        TemplateName,
-                                                        ObjectType,
-                                                        EnteringContext,
-                                                        Template,
-                                              MemberOfUnknownSpecialization,
-                                              /*Disambiguation=*/false,
-                                              /*MayBeNNS=*/true)) {
+      if (TemplateNameKind TNK = Actions.isTemplateName(
+              getCurScope(), SS,
+              /*hasTemplateKeyword=*/false, TemplateName, ObjectType,
+              EnteringContext, Template, MemberOfUnknownSpecialization,
+              /*Disambiguation=*/false,
+              /*MayBeNNS=*/true)) {
         // If lookup didn't find anything, we treat the name as a template-name
         // anyway. C++20 requires this, and in prior language modes it improves
         // error recovery. But before we commit to this, check that we actually
         // have something that looks like a template-argument-list next.
-        if (!IsTypename && (TNK == TNK_Undeclared_template ||
-            (!HasScopeSpecifier && ObjectType)) &&
+        if (!IsTypename &&
+            (TNK == TNK_Undeclared_template ||
+             (!HasScopeSpecifier && ObjectType)) &&
             isTemplateArgumentList(1) == TPResult::False)
           break;
 
@@ -1912,26 +1910,25 @@ Parser::ParseCXXPseudoDestructor(Expr *Base, SourceLocation OpLoc,
   IdentifierInfo *Name = Tok.getIdentifierInfo();
   SourceLocation NameLoc = ConsumeToken();
   SecondTypeName.setIdentifier(Name, NameLoc);
-  // SecondTypeName.setDestructorName(TildeLoc, nullptr, NameLoc);
+// SecondTypeName.setDestructorName(TildeLoc, nullptr, NameLoc);
 
-  // If there is a '<', the second type name is a template-id. Parse
-  // it as such.
-  //
-  // FIXME: This is not a context in which a '<' is assumed to start a template
-  // argument list. This affects examples such as
-  //   void f(auto *p) { p->~X<int>(); }
-  // ... but there's no ambiguity, and nowhere to write 'template' in such an
-  // example, so we accept it anyway.
-  #if 1
-  if (Tok.is(tok::less) &&
-      ParseUnqualifiedIdTemplateId(
-          SS, ObjectType, Base && Base->containsErrors(),
-          /*TemplateKWLoc=*/SourceLocation(), TildeLoc,
-          Name, NameLoc, false, SecondTypeName,
-          /*AssumeTemplateId=*/true))
+// If there is a '<', the second type name is a template-id. Parse
+// it as such.
+//
+// FIXME: This is not a context in which a '<' is assumed to start a template
+// argument list. This affects examples such as
+//   void f(auto *p) { p->~X<int>(); }
+// ... but there's no ambiguity, and nowhere to write 'template' in such an
+// example, so we accept it anyway.
+#if 1
+  if (Tok.is(tok::less) && ParseUnqualifiedIdTemplateId(
+                               SS, ObjectType, Base && Base->containsErrors(),
+                               /*TemplateKWLoc=*/SourceLocation(), TildeLoc,
+                               Name, NameLoc, false, SecondTypeName,
+                               /*AssumeTemplateId=*/true))
     return ExprError();
-  #endif
-  #if 0
+#endif
+#if 0
   if (Tok.is(tok::less)) {
     TemplateTy Template;
     TemplateNameKind TNK = Actions.ActOnTemplateName(
@@ -1951,7 +1948,7 @@ Parser::ParseCXXPseudoDestructor(Expr *Base, SourceLocation OpLoc,
     SecondTypeName.setTemplateId(takeTemplateIdAnnotation(Tok));
     ConsumeAnnotationToken();
   }
-  #endif
+#endif
 
   return Actions.ActOnPseudoDestructorExpr(getCurScope(), Base, OpLoc, OpKind,
                                            SS, FirstTypeName, CCLoc, TildeLoc,
@@ -2557,9 +2554,9 @@ bool Parser::ParseCXXTypeSpecifierSeq(DeclSpec &DS, DeclaratorContext Context) {
 /// \returns true if a parse error occurred, false otherwise.
 bool Parser::ParseUnqualifiedIdTemplateId(
     CXXScopeSpec &SS, ParsedType ObjectType, bool ObjectHadErrors,
-    SourceLocation TemplateKWLoc, SourceLocation TildeLoc,
-    IdentifierInfo *Name, SourceLocation NameLoc, bool EnteringContext,
-    UnqualifiedId &Id, bool AssumeTemplateId) {
+    SourceLocation TemplateKWLoc, SourceLocation TildeLoc, IdentifierInfo *Name,
+    SourceLocation NameLoc, bool EnteringContext, UnqualifiedId &Id,
+    bool AssumeTemplateId) {
   assert(Tok.is(tok::less) && "Expected '<' to finish parsing a template-id");
 
   TemplateTy Template;
@@ -2577,12 +2574,10 @@ bool Parser::ParseUnqualifiedIdTemplateId(
                                       TildeLoc.isValid());
     } else {
       bool MemberOfUnknownSpecialization;
-      TNK = Actions.isTemplateName(getCurScope(), SS,
-                                   TemplateKWLoc.isValid(), Id,
-                                   ObjectType, EnteringContext, Template,
-                                   MemberOfUnknownSpecialization,
-                                   /*Disambiguation=*/false,
-                                   TildeLoc.isValid());
+      TNK = Actions.isTemplateName(
+          getCurScope(), SS, TemplateKWLoc.isValid(), Id, ObjectType,
+          EnteringContext, Template, MemberOfUnknownSpecialization,
+          /*Disambiguation=*/false, TildeLoc.isValid());
       // If lookup found nothing but we're assuming that this is a template
       // name, double-check that makes sense syntactically before committing
       // to it.
@@ -2640,15 +2635,14 @@ bool Parser::ParseUnqualifiedIdTemplateId(
     bool MemberOfUnknownSpecialization;
     TemplateName.setIdentifier(Name, NameLoc);
     if (ObjectType) {
-      TNK = Actions.ActOnTemplateName(
-          getCurScope(), SS, TemplateKWLoc, TemplateName, ObjectType,
-          EnteringContext, Template, /*AllowInjectedClassName=*/true,
-          /*MayBeNNS=*/true);
+      TNK = Actions.ActOnTemplateName(getCurScope(), SS, TemplateKWLoc,
+                                      TemplateName, ObjectType, EnteringContext,
+                                      Template, /*AllowInjectedClassName=*/true,
+                                      /*MayBeNNS=*/true);
     } else {
       TNK = Actions.isTemplateName(getCurScope(), SS, TemplateKWLoc.isValid(),
-                                   TemplateName, ObjectType,
-                                   EnteringContext, Template,
-                                   MemberOfUnknownSpecialization,
+                                   TemplateName, ObjectType, EnteringContext,
+                                   Template, MemberOfUnknownSpecialization,
                                    /*Disambiguation=*/false,
                                    /*MayBeNNS=*/true);
 
@@ -3061,8 +3055,8 @@ bool Parser::ParseUnqualifiedId(CXXScopeSpec &SS, ParsedType ObjectType,
       return ParseUnqualifiedIdTemplateId(
           SS, ObjectType, ObjectHadErrors,
           TemplateKWLoc ? *TemplateKWLoc : SourceLocation(),
-          /*TildeLoc=*/SourceLocation(), Id, IdLoc,
-          EnteringContext, Result, TemplateSpecified);
+          /*TildeLoc=*/SourceLocation(), Id, IdLoc, EnteringContext, Result,
+          TemplateSpecified);
 
     if (TemplateSpecified) {
       TemplateNameKind TNK =
@@ -3159,7 +3153,8 @@ bool Parser::ParseUnqualifiedId(CXXScopeSpec &SS, ParsedType ObjectType,
           SS, ObjectType, ObjectHadErrors,
           TemplateKWLoc ? *TemplateKWLoc : SourceLocation(),
           /*TildeLoc=*/SourceLocation(), /*Name=*/nullptr,
-          /*NameLoc=*/SourceLocation(), EnteringContext, Result, TemplateSpecified);
+          /*NameLoc=*/SourceLocation(), EnteringContext, Result,
+          TemplateSpecified);
     else if (TemplateSpecified &&
              Actions.ActOnTemplateName(
                  getCurScope(), SS, *TemplateKWLoc, Result, ObjectType,
@@ -3254,8 +3249,8 @@ bool Parser::ParseUnqualifiedId(CXXScopeSpec &SS, ParsedType ObjectType,
       Result.setDestructorName(TildeLoc, nullptr, ClassNameLoc);
       return ParseUnqualifiedIdTemplateId(
           SS, ObjectType, ObjectHadErrors,
-          TemplateKWLoc ? *TemplateKWLoc : SourceLocation(),
-          TildeLoc, ClassName, ClassNameLoc, EnteringContext, Result, TemplateSpecified);
+          TemplateKWLoc ? *TemplateKWLoc : SourceLocation(), TildeLoc,
+          ClassName, ClassNameLoc, EnteringContext, Result, TemplateSpecified);
     }
 
     // Note that this is a destructor name.

--- a/clang/lib/Sema/SemaCXXScopeSpec.cpp
+++ b/clang/lib/Sema/SemaCXXScopeSpec.cpp
@@ -422,7 +422,7 @@ bool Sema::BuildCXXNestedNameSpecifier(Scope *S, NestedNameSpecInfo &IdInfo,
                                        bool ErrorRecoveryLookup,
                                        bool *IsCorrectedToColon,
                                        bool OnlyNamespace) {
- #if 0
+#if 0
   if (IdInfo.Identifier->isEditorPlaceholder())
     return true;
   LookupResult Found(*this, IdInfo.Identifier, IdInfo.IdentifierLoc,
@@ -518,7 +518,6 @@ bool Sema::BuildCXXNestedNameSpecifier(Scope *S, NestedNameSpecInfo &IdInfo,
 #endif
 #endif
 
-
   if (IdInfo.Identifier->isEditorPlaceholder())
     return true;
   if (IsCorrectedToColon)
@@ -548,8 +547,7 @@ bool Sema::BuildCXXNestedNameSpecifier(Scope *S, NestedNameSpecInfo &IdInfo,
   }
 
   bool ObjectTypeSearchedInScope = false;
-  bool LookupFirstQualifierInScope =
-      Found.empty() && !ObjectType.isNull();
+  bool LookupFirstQualifierInScope = Found.empty() && !ObjectType.isNull();
 
   if (LookupFirstQualifierInScope) {
     if (S) {
@@ -597,9 +595,10 @@ bool Sema::BuildCXXNestedNameSpecifier(Scope *S, NestedNameSpecInfo &IdInfo,
     }
   }
 
-  DeclContext *LookupCtx = SS.isSet()
-      ? computeDeclContext(SS, EnteringContext)
-      : (!ObjectType.isNull() ? computeDeclContext(ObjectType) : nullptr);
+  DeclContext *LookupCtx =
+      SS.isSet()
+          ? computeDeclContext(SS, EnteringContext)
+          : (!ObjectType.isNull() ? computeDeclContext(ObjectType) : nullptr);
 
   if (Found.empty() && !ErrorRecoveryLookup && !getLangOpts().MSVCCompat) {
     // We haven't found anything, and we're not recovering from a

--- a/clang/lib/Sema/SemaCXXScopeSpec.cpp
+++ b/clang/lib/Sema/SemaCXXScopeSpec.cpp
@@ -356,7 +356,12 @@ bool Sema::isAcceptableNestedNameSpecifier(const NamedDecl *SD,
   return false;
 }
 
-bool Sema::LookupFirstQualifierInScope(Scope *S, NestedNameSpecifier *NNS, UnresolvedSetImpl &R) {
+/// If the given nested-name-specifier begins with a bare identifier
+/// (e.g., Base::), perform name lookup for that identifier as a
+/// nested-name-specifier within the given scope, and return the result of that
+/// name lookup.
+bool Sema::LookupFirstQualifierInScope(Scope *S, NestedNameSpecifier *NNS,
+                                       UnresolvedSetImpl &R) {
   if (!S)
     return false;
 
@@ -468,7 +473,7 @@ bool Sema::BuildCXXNestedNameSpecifier(Scope *S, NestedNameSpecInfo &IdInfo,
     if (S) {
       LookupName(Found, S);
     } else if (LookupFirstQualifierInScope &&
-        !SS.getUnqualifiedLookups().empty()) {
+               !SS.getUnqualifiedLookups().empty()) {
       Found.addAllDecls(SS.getUnqualifiedLookups());
       Found.resolveKind();
     }

--- a/clang/lib/Sema/SemaCXXScopeSpec.cpp
+++ b/clang/lib/Sema/SemaCXXScopeSpec.cpp
@@ -363,6 +363,8 @@ NamedDecl *Sema::FindFirstQualifierInScope(Scope *S, NestedNameSpecifier *NNS) {
   while (NNS->getPrefix())
     NNS = NNS->getPrefix();
 
+  // FIXME: This is a rather nasty hack! Ideally we should get the results
+  // from LookupTemplateName/BuildCXXNestedNameSpecifier.
   const IdentifierInfo *II = NNS->getAsIdentifier();
   if (!II) {
     if (const auto *DTST =

--- a/clang/lib/Sema/SemaCoroutine.cpp
+++ b/clang/lib/Sema/SemaCoroutine.cpp
@@ -307,7 +307,7 @@ static ExprResult buildMemberCall(Sema &S, Expr *Base, SourceLocation Loc,
   CXXScopeSpec SS;
   ExprResult Result = S.BuildMemberReferenceExpr(
       Base, Base->getType(), Loc, /*IsPtr=*/false, SS,
-      SourceLocation(), nullptr, NameInfo, /*TemplateArgs=*/nullptr,
+      SourceLocation(), NameInfo, /*TemplateArgs=*/nullptr,
       /*Scope=*/nullptr);
   if (Result.isInvalid())
     return ExprError();

--- a/clang/lib/Sema/SemaCoroutine.cpp
+++ b/clang/lib/Sema/SemaCoroutine.cpp
@@ -306,8 +306,8 @@ static ExprResult buildMemberCall(Sema &S, Expr *Base, SourceLocation Loc,
   // FIXME: Fix BuildMemberReferenceExpr to take a const CXXScopeSpec&.
   CXXScopeSpec SS;
   ExprResult Result = S.BuildMemberReferenceExpr(
-      Base, Base->getType(), Loc, /*IsPtr=*/false, SS,
-      SourceLocation(), NameInfo, /*TemplateArgs=*/nullptr,
+      Base, Base->getType(), Loc, /*IsPtr=*/false, SS, SourceLocation(),
+      NameInfo, /*TemplateArgs=*/nullptr,
       /*Scope=*/nullptr);
   if (Result.isInvalid())
     return ExprError();

--- a/clang/lib/Sema/SemaDeclCXX.cpp
+++ b/clang/lib/Sema/SemaDeclCXX.cpp
@@ -4903,15 +4903,12 @@ BuildImplicitMemberInitializer(Sema &SemaRef, CXXConstructorDecl *Constructor,
     MemberLookup.addDecl(Indirect ? cast<ValueDecl>(Indirect)
                                   : cast<ValueDecl>(Field), AS_public);
     MemberLookup.resolveKind();
-    ExprResult CtorArg
-      = SemaRef.BuildMemberReferenceExpr(MemberExprBase,
-                                         ParamType, Loc,
-                                         /*IsArrow=*/false,
-                                         SS,
-                                         /*TemplateKWLoc=*/SourceLocation(),
-                                         MemberLookup,
-                                         /*TemplateArgs=*/nullptr,
-                                         /*S=*/nullptr);
+    ExprResult CtorArg = SemaRef.BuildMemberReferenceExpr(
+        MemberExprBase, ParamType, Loc,
+        /*IsArrow=*/false, SS,
+        /*TemplateKWLoc=*/SourceLocation(), MemberLookup,
+        /*TemplateArgs=*/nullptr,
+        /*S=*/nullptr);
     if (CtorArg.isInvalid())
       return true;
 
@@ -14337,9 +14334,10 @@ class MemberBuilder: public ExprBuilder {
 public:
   Expr *build(Sema &S, SourceLocation Loc) const override {
     return assertNotNull(S.BuildMemberReferenceExpr(
-        Builder.build(S, Loc), Type, Loc, IsArrow, SS,
-        /*TemplateKwLoc=*/SourceLocation(), MemberLookup,
-        /*TemplateArgs=*/nullptr, /*S=*/nullptr).get());
+                              Builder.build(S, Loc), Type, Loc, IsArrow, SS,
+                              /*TemplateKwLoc=*/SourceLocation(), MemberLookup,
+                              /*TemplateArgs=*/nullptr, /*S=*/nullptr)
+                             .get());
   }
 
   MemberBuilder(const ExprBuilder &Builder, QualType Type, bool IsArrow,
@@ -14545,12 +14543,11 @@ buildSingleCopyAssignRecursively(Sema &S, SourceLocation Loc, QualType T,
                    Loc);
 
     // Create the reference to operator=.
-    ExprResult OpEqualRef
-      = S.BuildMemberReferenceExpr(To.build(S, Loc), T, Loc, /*IsArrow=*/false,
-                                   SS, /*TemplateKWLoc=*/SourceLocation(),
-                                   OpLookup,
-                                   /*TemplateArgs=*/nullptr, /*S*/nullptr,
-                                   /*SuppressQualifierCheck=*/true);
+    ExprResult OpEqualRef = S.BuildMemberReferenceExpr(
+        To.build(S, Loc), T, Loc, /*IsArrow=*/false, SS,
+        /*TemplateKWLoc=*/SourceLocation(), OpLookup,
+        /*TemplateArgs=*/nullptr, /*S*/ nullptr,
+        /*SuppressQualifierCheck=*/true);
     if (OpEqualRef.isInvalid())
       return StmtError();
 

--- a/clang/lib/Sema/SemaDeclCXX.cpp
+++ b/clang/lib/Sema/SemaDeclCXX.cpp
@@ -1275,9 +1275,11 @@ static bool checkTupleLikeDecomposition(Sema &S,
     if (UseMemberGet) {
       //   if [lookup of member get] finds at least one declaration, the
       //   initializer is e.get<i-1>().
-      E = S.BuildMemberReferenceExpr(E.get(), DecompType, Loc, false,
-                                     CXXScopeSpec(), SourceLocation(), nullptr,
-                                     MemberGet, &Args, nullptr);
+      E = S.BuildMemberReferenceExpr(E.get(), DecompType, Loc,
+                                     /*IsArrow=*/false,
+                                     /*SS=*/CXXScopeSpec(),
+                                     /*TemplateKWLoc=*/SourceLocation(),
+                                     MemberGet, &Args, /*S=*/nullptr);
       if (E.isInvalid())
         return true;
 
@@ -4907,10 +4909,9 @@ BuildImplicitMemberInitializer(Sema &SemaRef, CXXConstructorDecl *Constructor,
                                          /*IsArrow=*/false,
                                          SS,
                                          /*TemplateKWLoc=*/SourceLocation(),
-                                         /*FirstQualifierInScope=*/nullptr,
                                          MemberLookup,
                                          /*TemplateArgs=*/nullptr,
-                                         /*S*/nullptr);
+                                         /*S=*/nullptr);
     if (CtorArg.isInvalid())
       return true;
 
@@ -14336,8 +14337,9 @@ class MemberBuilder: public ExprBuilder {
 public:
   Expr *build(Sema &S, SourceLocation Loc) const override {
     return assertNotNull(S.BuildMemberReferenceExpr(
-        Builder.build(S, Loc), Type, Loc, IsArrow, SS, SourceLocation(),
-        nullptr, MemberLookup, nullptr, nullptr).get());
+        Builder.build(S, Loc), Type, Loc, IsArrow, SS,
+        /*TemplateKwLoc=*/SourceLocation(), MemberLookup,
+        /*TemplateArgs=*/nullptr, /*S=*/nullptr).get());
   }
 
   MemberBuilder(const ExprBuilder &Builder, QualType Type, bool IsArrow,
@@ -14546,7 +14548,6 @@ buildSingleCopyAssignRecursively(Sema &S, SourceLocation Loc, QualType T,
     ExprResult OpEqualRef
       = S.BuildMemberReferenceExpr(To.build(S, Loc), T, Loc, /*IsArrow=*/false,
                                    SS, /*TemplateKWLoc=*/SourceLocation(),
-                                   /*FirstQualifierInScope=*/nullptr,
                                    OpLookup,
                                    /*TemplateArgs=*/nullptr, /*S*/nullptr,
                                    /*SuppressQualifierCheck=*/true);
@@ -17155,8 +17156,9 @@ bool Sema::EvaluateStaticAssertMessageAsString(Expr *Message,
 
   auto BuildExpr = [&](LookupResult &LR) {
     ExprResult Res = BuildMemberReferenceExpr(
-        Message, Message->getType(), Message->getBeginLoc(), false,
-        CXXScopeSpec(), SourceLocation(), nullptr, LR, nullptr, nullptr);
+        Message, Message->getType(), Message->getBeginLoc(), /*IsArrow=*/false,
+        /*SS=*/CXXScopeSpec(), /*TemplateKWLoc=*/SourceLocation(), LR,
+        /*TemplateArgs=*/nullptr, /*S=*/nullptr);
     if (Res.isInvalid())
       return ExprError();
     Res = BuildCallExpr(nullptr, Res.get(), Loc, std::nullopt, Loc, nullptr,

--- a/clang/lib/Sema/SemaExpr.cpp
+++ b/clang/lib/Sema/SemaExpr.cpp
@@ -2624,7 +2624,7 @@ recoverFromMSUnqualifiedLookup(Sema &S, ASTContext &Context,
     return CXXDependentScopeMemberExpr::Create(
         Context, /*This=*/nullptr, ThisType, /*IsArrow=*/true,
         /*Op=*/SourceLocation(), NestedNameSpecifierLoc(), TemplateKWLoc,
-        /*FirstQualifierFoundInScope=*/nullptr, NameInfo, TemplateArgs);
+        /*UnqualifiedLookups=*/std::nullopt, NameInfo, TemplateArgs);
   }
 
   // Synthesize a fake NNS that points to the derived class.  This will

--- a/clang/lib/Sema/SemaExprMember.cpp
+++ b/clang/lib/Sema/SemaExprMember.cpp
@@ -1043,7 +1043,7 @@ Sema::BuildMemberReferenceExpr(Expr *BaseExpr, QualType BaseExprType,
       if (RetryExpr.isUsable() && !Trap.hasErrorOccurred()) {
         CXXScopeSpec TempSS(SS);
         RetryExpr = ActOnMemberAccessExpr(
-            ExtraArgs->S, RetryExpr.get(), OpLoc, tok::arrow, TempSS,
+            ExtraArgs->S, RetryExpr.get(), OpLoc, /*IsArrow=*/true, TempSS,
             TemplateKWLoc, ExtraArgs->Id, ExtraArgs->ObjCImpDecl);
       }
       if (Trap.hasErrorOccurred())
@@ -1746,8 +1746,8 @@ static ExprResult LookupMemberExpr(Sema &S, LookupResult &R,
 }
 
 ExprResult Sema::ActOnMemberAccessExpr(Scope *S, Expr *Base,
-                                       SourceLocation OpLoc,
-                                       tok::TokenKind OpKind, CXXScopeSpec &SS,
+                                       SourceLocation OpLoc, bool IsArrow,
+                                       CXXScopeSpec &SS,
                                        SourceLocation TemplateKWLoc,
                                        UnqualifiedId &Id, Decl *ObjCImpDecl) {
   // Warn about the explicit constructor calls Microsoft extension.
@@ -1763,8 +1763,6 @@ ExprResult Sema::ActOnMemberAccessExpr(Scope *S, Expr *Base,
   const TemplateArgumentListInfo *TemplateArgs;
   DecomposeUnqualifiedId(Id, TemplateArgsBuffer,
                          NameInfo, TemplateArgs);
-
-  bool IsArrow = (OpKind == tok::arrow);
 
   if (getLangOpts().HLSL && IsArrow)
     return ExprError(Diag(OpLoc, diag::err_hlsl_operator_unsupported) << 2);

--- a/clang/lib/Sema/SemaExprMember.cpp
+++ b/clang/lib/Sema/SemaExprMember.cpp
@@ -552,9 +552,8 @@ static Decl *FindGetterSetterNameDecl(const ObjCObjectPointerType *QIdTy,
 }
 
 ExprResult
-Sema::ActOnDependentMemberExpr(Expr *BaseExpr, QualType BaseType,
-                               bool IsArrow, SourceLocation OpLoc,
-                               const CXXScopeSpec &SS,
+Sema::ActOnDependentMemberExpr(Expr *BaseExpr, QualType BaseType, bool IsArrow,
+                               SourceLocation OpLoc, const CXXScopeSpec &SS,
                                SourceLocation TemplateKWLoc,
                                const DeclarationNameInfo &NameInfo,
                                const TemplateArgumentListInfo *TemplateArgs) {
@@ -828,11 +827,9 @@ ExprResult Sema::BuildMemberReferenceExpr(
   if (SS.isInvalid())
     return ExprError();
 
-  return BuildMemberReferenceExpr(Base, BaseType,
-                                  OpLoc, IsArrow, SS, TemplateKWLoc,
-                                  R, TemplateArgs, S,
-                                  /*SuppressQualifierCheck=*/false,
-                                  ExtraArgs);
+  return BuildMemberReferenceExpr(Base, BaseType, OpLoc, IsArrow, SS,
+                                  TemplateKWLoc, R, TemplateArgs, S,
+                                  /*SuppressQualifierCheck=*/false, ExtraArgs);
 }
 
 ExprResult
@@ -970,16 +967,11 @@ static bool IsInFnTryBlockHandler(const Scope *S) {
   return false;
 }
 
-ExprResult
-Sema::BuildMemberReferenceExpr(Expr *BaseExpr, QualType BaseExprType,
-                               SourceLocation OpLoc, bool IsArrow,
-                               const CXXScopeSpec &SS,
-                               SourceLocation TemplateKWLoc,
-                               LookupResult &R,
-                               const TemplateArgumentListInfo *TemplateArgs,
-                               const Scope *S,
-                               bool SuppressQualifierCheck,
-                               ActOnMemberAccessExtraArgs *ExtraArgs) {
+ExprResult Sema::BuildMemberReferenceExpr(
+    Expr *BaseExpr, QualType BaseExprType, SourceLocation OpLoc, bool IsArrow,
+    const CXXScopeSpec &SS, SourceLocation TemplateKWLoc, LookupResult &R,
+    const TemplateArgumentListInfo *TemplateArgs, const Scope *S,
+    bool SuppressQualifierCheck, ActOnMemberAccessExtraArgs *ExtraArgs) {
   assert(!SS.isInvalid() && "nested-name-specifier cannot be invalid");
   // If the member wasn't found in the current instantiation, or if the
   // arrow operator was used with a dependent non-pointer object expression,
@@ -1195,9 +1187,9 @@ Sema::BuildMemberReferenceExpr(Expr *BaseExpr, QualType BaseExprType,
 
     // Non-dependent member, but dependent template arguments.
     if (!VDecl.get())
-      return ActOnDependentMemberExpr(
-          BaseExpr, BaseExpr->getType(), IsArrow, OpLoc, SS, TemplateKWLoc,
-          MemberNameInfo, TemplateArgs);
+      return ActOnDependentMemberExpr(BaseExpr, BaseExpr->getType(), IsArrow,
+                                      OpLoc, SS, TemplateKWLoc, MemberNameInfo,
+                                      TemplateArgs);
 
     VarDecl *Var = cast<VarDecl>(VDecl.get());
     if (!Var->getTemplateSpecializationKind())
@@ -1768,7 +1760,8 @@ ExprResult Sema::ActOnMemberAccessExpr(Scope *S, Expr *Base,
     return ExprError(Diag(OpLoc, diag::err_hlsl_operator_unsupported) << 2);
 
   UnresolvedSet<4> UnqualifiedLookups;
-  if (SS.isValid() && LookupFirstQualifierInScope(S, SS.getScopeRep(), UnqualifiedLookups)) {
+  if (SS.isValid() &&
+      LookupFirstQualifierInScope(S, SS.getScopeRep(), UnqualifiedLookups)) {
     SS.setUnqualifiedLookups(UnqualifiedLookups.pairs());
   }
   // This is a postfix expression, so get rid of ParenListExprs.
@@ -1778,8 +1771,8 @@ ExprResult Sema::ActOnMemberAccessExpr(Scope *S, Expr *Base,
 
   ActOnMemberAccessExtraArgs ExtraArgs = {S, Id, ObjCImpDecl};
   ExprResult Res = BuildMemberReferenceExpr(
-      Base, Base->getType(), OpLoc, IsArrow, SS, TemplateKWLoc,
-      NameInfo, TemplateArgs, S, &ExtraArgs);
+      Base, Base->getType(), OpLoc, IsArrow, SS, TemplateKWLoc, NameInfo,
+      TemplateArgs, S, &ExtraArgs);
 
   if (!Res.isInvalid() && isa<MemberExpr>(Res.get()))
     CheckMemberAccessOfNoDeref(cast<MemberExpr>(Res.get()));
@@ -1923,9 +1916,8 @@ Sema::BuildImplicitMemberExpr(const CXXScopeSpec &SS,
     baseExpr = BuildCXXThisExpr(loc, ThisTy, /*IsImplicit=*/true);
   }
 
-  return BuildMemberReferenceExpr(
-      baseExpr, ThisTy,
-      /*OpLoc=*/SourceLocation(),
-      /*IsArrow=*/!getLangOpts().HLSL, SS,
-      TemplateKWLoc, R, TemplateArgs, S);
+  return BuildMemberReferenceExpr(baseExpr, ThisTy,
+                                  /*OpLoc=*/SourceLocation(),
+                                  /*IsArrow=*/!getLangOpts().HLSL, SS,
+                                  TemplateKWLoc, R, TemplateArgs, S);
 }

--- a/clang/lib/Sema/SemaExprMember.cpp
+++ b/clang/lib/Sema/SemaExprMember.cpp
@@ -556,7 +556,6 @@ Sema::ActOnDependentMemberExpr(Expr *BaseExpr, QualType BaseType,
                                bool IsArrow, SourceLocation OpLoc,
                                const CXXScopeSpec &SS,
                                SourceLocation TemplateKWLoc,
-                               NamedDecl *FirstQualifierInScope,
                                const DeclarationNameInfo &NameInfo,
                                const TemplateArgumentListInfo *TemplateArgs) {
   // Even in dependent contexts, try to diagnose base expressions with
@@ -590,8 +589,8 @@ Sema::ActOnDependentMemberExpr(Expr *BaseExpr, QualType BaseType,
   // must have pointer type, and the accessed type is the pointee.
   return CXXDependentScopeMemberExpr::Create(
       Context, BaseExpr, BaseType, IsArrow, OpLoc,
-      SS.getWithLocInContext(Context), TemplateKWLoc, FirstQualifierInScope,
-      NameInfo, TemplateArgs);
+      SS.getWithLocInContext(Context), TemplateKWLoc,
+      SS.getUnqualifiedLookups(), NameInfo, TemplateArgs);
 }
 
 /// We know that the given qualified member reference points only to
@@ -767,8 +766,9 @@ static bool LookupMemberExprInRecord(Sema &SemaRef, LookupResult &R,
           R.addDecl(ND);
         R.resolveKind();
         return SemaRef.BuildMemberReferenceExpr(
-            BaseExpr, BaseExpr->getType(), OpLoc, IsArrow, SS, SourceLocation(),
-            nullptr, R, nullptr, nullptr);
+            BaseExpr, BaseExpr->getType(), OpLoc, IsArrow, SS,
+            /*TemplateKWLoc=*/SourceLocation(), R, /*TemplateArgs=*/nullptr,
+            /*S=*/nullptr);
       },
       Sema::CTK_ErrorRecovery, DC);
 
@@ -784,7 +784,7 @@ static ExprResult LookupMemberExpr(Sema &S, LookupResult &R,
 ExprResult Sema::BuildMemberReferenceExpr(
     Expr *Base, QualType BaseType, SourceLocation OpLoc, bool IsArrow,
     CXXScopeSpec &SS, SourceLocation TemplateKWLoc,
-    NamedDecl *FirstQualifierInScope, const DeclarationNameInfo &NameInfo,
+    const DeclarationNameInfo &NameInfo,
     const TemplateArgumentListInfo *TemplateArgs, const Scope *S,
     ActOnMemberAccessExtraArgs *ExtraArgs) {
   LookupResult R(*this, NameInfo, LookupMemberName);
@@ -830,8 +830,9 @@ ExprResult Sema::BuildMemberReferenceExpr(
 
   return BuildMemberReferenceExpr(Base, BaseType,
                                   OpLoc, IsArrow, SS, TemplateKWLoc,
-                                  FirstQualifierInScope, R, TemplateArgs, S,
-                                  false, ExtraArgs);
+                                  R, TemplateArgs, S,
+                                  /*SuppressQualifierCheck=*/false,
+                                  ExtraArgs);
 }
 
 ExprResult
@@ -974,7 +975,6 @@ Sema::BuildMemberReferenceExpr(Expr *BaseExpr, QualType BaseExprType,
                                SourceLocation OpLoc, bool IsArrow,
                                const CXXScopeSpec &SS,
                                SourceLocation TemplateKWLoc,
-                               NamedDecl *FirstQualifierInScope,
                                LookupResult &R,
                                const TemplateArgumentListInfo *TemplateArgs,
                                const Scope *S,
@@ -989,8 +989,8 @@ Sema::BuildMemberReferenceExpr(Expr *BaseExpr, QualType BaseExprType,
        (SS.isSet() ? SS.getScopeRep()->isDependent()
                    : BaseExprType->isDependentType())))
     return ActOnDependentMemberExpr(BaseExpr, BaseExprType, IsArrow, OpLoc, SS,
-                                    TemplateKWLoc, FirstQualifierInScope,
-                                    R.getLookupNameInfo(), TemplateArgs);
+                                    TemplateKWLoc, R.getLookupNameInfo(),
+                                    TemplateArgs);
 
   QualType BaseType = BaseExprType;
   if (IsArrow) {
@@ -1197,7 +1197,7 @@ Sema::BuildMemberReferenceExpr(Expr *BaseExpr, QualType BaseExprType,
     if (!VDecl.get())
       return ActOnDependentMemberExpr(
           BaseExpr, BaseExpr->getType(), IsArrow, OpLoc, SS, TemplateKWLoc,
-          FirstQualifierInScope, MemberNameInfo, TemplateArgs);
+          MemberNameInfo, TemplateArgs);
 
     VarDecl *Var = cast<VarDecl>(VDecl.get());
     if (!Var->getTemplateSpecializationKind())
@@ -1767,9 +1767,10 @@ ExprResult Sema::ActOnMemberAccessExpr(Scope *S, Expr *Base,
   if (getLangOpts().HLSL && IsArrow)
     return ExprError(Diag(OpLoc, diag::err_hlsl_operator_unsupported) << 2);
 
-  NamedDecl *FirstQualifierInScope
-    = (!SS.isSet() ? nullptr : FindFirstQualifierInScope(S, SS.getScopeRep()));
-
+  UnresolvedSet<4> UnqualifiedLookups;
+  if (SS.isValid() && LookupFirstQualifierInScope(S, SS.getScopeRep(), UnqualifiedLookups)) {
+    SS.setUnqualifiedLookups(UnqualifiedLookups.pairs());
+  }
   // This is a postfix expression, so get rid of ParenListExprs.
   ExprResult Result = MaybeConvertParenListExprToParenExpr(S, Base);
   if (Result.isInvalid()) return ExprError();
@@ -1778,7 +1779,7 @@ ExprResult Sema::ActOnMemberAccessExpr(Scope *S, Expr *Base,
   ActOnMemberAccessExtraArgs ExtraArgs = {S, Id, ObjCImpDecl};
   ExprResult Res = BuildMemberReferenceExpr(
       Base, Base->getType(), OpLoc, IsArrow, SS, TemplateKWLoc,
-      FirstQualifierInScope, NameInfo, TemplateArgs, S, &ExtraArgs);
+      NameInfo, TemplateArgs, S, &ExtraArgs);
 
   if (!Res.isInvalid() && isa<MemberExpr>(Res.get()))
     CheckMemberAccessOfNoDeref(cast<MemberExpr>(Res.get()));
@@ -1925,6 +1926,6 @@ Sema::BuildImplicitMemberExpr(const CXXScopeSpec &SS,
   return BuildMemberReferenceExpr(
       baseExpr, ThisTy,
       /*OpLoc=*/SourceLocation(),
-      /*IsArrow=*/!getLangOpts().HLSL, SS, TemplateKWLoc,
-      /*FirstQualifierInScope=*/nullptr, R, TemplateArgs, S);
+      /*IsArrow=*/!getLangOpts().HLSL, SS,
+      TemplateKWLoc, R, TemplateArgs, S);
 }

--- a/clang/lib/Sema/SemaExprMember.cpp
+++ b/clang/lib/Sema/SemaExprMember.cpp
@@ -1035,7 +1035,7 @@ ExprResult Sema::BuildMemberReferenceExpr(
       if (RetryExpr.isUsable() && !Trap.hasErrorOccurred()) {
         CXXScopeSpec TempSS(SS);
         RetryExpr = ActOnMemberAccessExpr(
-            ExtraArgs->S, RetryExpr.get(), OpLoc, /*IsArrow=*/true, TempSS,
+            ExtraArgs->S, RetryExpr.get(), OpLoc, tok::arrow, TempSS,
             TemplateKWLoc, ExtraArgs->Id, ExtraArgs->ObjCImpDecl);
       }
       if (Trap.hasErrorOccurred())
@@ -1738,10 +1738,12 @@ static ExprResult LookupMemberExpr(Sema &S, LookupResult &R,
 }
 
 ExprResult Sema::ActOnMemberAccessExpr(Scope *S, Expr *Base,
-                                       SourceLocation OpLoc, bool IsArrow,
+                                       SourceLocation OpLoc,
+                                       tok::TokenKind OpKind,
                                        CXXScopeSpec &SS,
                                        SourceLocation TemplateKWLoc,
-                                       UnqualifiedId &Id, Decl *ObjCImpDecl) {
+                                       UnqualifiedId &Id,
+                                       Decl *ObjCImpDecl) {
   // Warn about the explicit constructor calls Microsoft extension.
   if (getLangOpts().MicrosoftExt &&
       Id.getKind() == UnqualifiedIdKind::IK_ConstructorName)
@@ -1755,6 +1757,7 @@ ExprResult Sema::ActOnMemberAccessExpr(Scope *S, Expr *Base,
   const TemplateArgumentListInfo *TemplateArgs;
   DecomposeUnqualifiedId(Id, TemplateArgsBuffer,
                          NameInfo, TemplateArgs);
+  bool IsArrow = OpKind == tok::arrow;
 
   if (getLangOpts().HLSL && IsArrow)
     return ExprError(Diag(OpLoc, diag::err_hlsl_operator_unsupported) << 2);

--- a/clang/lib/Sema/SemaExprMember.cpp
+++ b/clang/lib/Sema/SemaExprMember.cpp
@@ -1739,11 +1739,9 @@ static ExprResult LookupMemberExpr(Sema &S, LookupResult &R,
 
 ExprResult Sema::ActOnMemberAccessExpr(Scope *S, Expr *Base,
                                        SourceLocation OpLoc,
-                                       tok::TokenKind OpKind,
-                                       CXXScopeSpec &SS,
+                                       tok::TokenKind OpKind, CXXScopeSpec &SS,
                                        SourceLocation TemplateKWLoc,
-                                       UnqualifiedId &Id,
-                                       Decl *ObjCImpDecl) {
+                                       UnqualifiedId &Id, Decl *ObjCImpDecl) {
   // Warn about the explicit constructor calls Microsoft extension.
   if (getLangOpts().MicrosoftExt &&
       Id.getKind() == UnqualifiedIdKind::IK_ConstructorName)

--- a/clang/lib/Sema/SemaOverload.cpp
+++ b/clang/lib/Sema/SemaOverload.cpp
@@ -16045,9 +16045,8 @@ Sema::BuildForRangeBeginEndCall(SourceLocation Loc,
   if (!MemberLookup.empty()) {
     ExprResult MemberRef =
         BuildMemberReferenceExpr(Range, Range->getType(), Loc,
-                                 /*IsPtr=*/false, CXXScopeSpec(),
+                                 /*IsPtr=*/false, /*SS=*/CXXScopeSpec(),
                                  /*TemplateKWLoc=*/SourceLocation(),
-                                 /*FirstQualifierInScope=*/nullptr,
                                  MemberLookup,
                                  /*TemplateArgs=*/nullptr, S);
     if (MemberRef.isInvalid()) {

--- a/clang/lib/Sema/SemaOverload.cpp
+++ b/clang/lib/Sema/SemaOverload.cpp
@@ -16043,12 +16043,11 @@ Sema::BuildForRangeBeginEndCall(SourceLocation Loc,
 
   CandidateSet->clear(OverloadCandidateSet::CSK_Normal);
   if (!MemberLookup.empty()) {
-    ExprResult MemberRef =
-        BuildMemberReferenceExpr(Range, Range->getType(), Loc,
-                                 /*IsPtr=*/false, /*SS=*/CXXScopeSpec(),
-                                 /*TemplateKWLoc=*/SourceLocation(),
-                                 MemberLookup,
-                                 /*TemplateArgs=*/nullptr, S);
+    ExprResult MemberRef = BuildMemberReferenceExpr(
+        Range, Range->getType(), Loc,
+        /*IsPtr=*/false, /*SS=*/CXXScopeSpec(),
+        /*TemplateKWLoc=*/SourceLocation(), MemberLookup,
+        /*TemplateArgs=*/nullptr, S);
     if (MemberRef.isInvalid()) {
       *CallExpr = ExprError();
       return FRS_DiagnosticIssued;

--- a/clang/lib/Sema/SemaPseudoObject.cpp
+++ b/clang/lib/Sema/SemaPseudoObject.cpp
@@ -1395,10 +1395,10 @@ ExprResult MSPropertyOpBuilder::buildGet() {
   GetterName.setIdentifier(II, RefExpr->getMemberLoc());
   CXXScopeSpec SS;
   SS.Adopt(RefExpr->getQualifierLoc());
-  ExprResult GetterExpr =
-      S.ActOnMemberAccessExpr(S.getCurScope(), InstanceBase, SourceLocation(),
-                              RefExpr->isArrow() ? tok::arrow : tok::period, SS,
-                              SourceLocation(), GetterName, nullptr);
+  ExprResult GetterExpr = S.ActOnMemberAccessExpr(
+      S.getCurScope(), InstanceBase, /*OpLoc=*/SourceLocation(),
+      RefExpr->isArrow(), SS, /*TemplateKWLoc=*/SourceLocation(), GetterName,
+      /*ObjCImpDecl=*/nullptr);
   if (GetterExpr.isInvalid()) {
     S.Diag(RefExpr->getMemberLoc(),
            diag::err_cannot_find_suitable_accessor) << 0 /* getter */
@@ -1424,10 +1424,10 @@ ExprResult MSPropertyOpBuilder::buildSet(Expr *op, SourceLocation sl,
   SetterName.setIdentifier(II, RefExpr->getMemberLoc());
   CXXScopeSpec SS;
   SS.Adopt(RefExpr->getQualifierLoc());
-  ExprResult SetterExpr =
-      S.ActOnMemberAccessExpr(S.getCurScope(), InstanceBase, SourceLocation(),
-                              RefExpr->isArrow() ? tok::arrow : tok::period, SS,
-                              SourceLocation(), SetterName, nullptr);
+  ExprResult SetterExpr = S.ActOnMemberAccessExpr(
+      S.getCurScope(), InstanceBase, /*OpLoc=*/SourceLocation(),
+      RefExpr->isArrow(), SS, /*TemplateKWLoc=*/SourceLocation(), SetterName,
+      /*ObjCImpDecl=*/nullptr);
   if (SetterExpr.isInvalid()) {
     S.Diag(RefExpr->getMemberLoc(),
            diag::err_cannot_find_suitable_accessor) << 1 /* setter */

--- a/clang/lib/Sema/SemaPseudoObject.cpp
+++ b/clang/lib/Sema/SemaPseudoObject.cpp
@@ -1395,10 +1395,10 @@ ExprResult MSPropertyOpBuilder::buildGet() {
   GetterName.setIdentifier(II, RefExpr->getMemberLoc());
   CXXScopeSpec SS;
   SS.Adopt(RefExpr->getQualifierLoc());
-  ExprResult GetterExpr = S.ActOnMemberAccessExpr(
-      S.getCurScope(), InstanceBase, /*OpLoc=*/SourceLocation(),
-      RefExpr->isArrow(), SS, /*TemplateKWLoc=*/SourceLocation(), GetterName,
-      /*ObjCImpDecl=*/nullptr);
+  ExprResult GetterExpr =
+      S.ActOnMemberAccessExpr(S.getCurScope(), InstanceBase, SourceLocation(),
+                              RefExpr->isArrow() ? tok::arrow : tok::period, SS,
+                              SourceLocation(), GetterName, nullptr);
   if (GetterExpr.isInvalid()) {
     S.Diag(RefExpr->getMemberLoc(),
            diag::err_cannot_find_suitable_accessor) << 0 /* getter */
@@ -1424,10 +1424,10 @@ ExprResult MSPropertyOpBuilder::buildSet(Expr *op, SourceLocation sl,
   SetterName.setIdentifier(II, RefExpr->getMemberLoc());
   CXXScopeSpec SS;
   SS.Adopt(RefExpr->getQualifierLoc());
-  ExprResult SetterExpr = S.ActOnMemberAccessExpr(
-      S.getCurScope(), InstanceBase, /*OpLoc=*/SourceLocation(),
-      RefExpr->isArrow(), SS, /*TemplateKWLoc=*/SourceLocation(), SetterName,
-      /*ObjCImpDecl=*/nullptr);
+  ExprResult SetterExpr =
+      S.ActOnMemberAccessExpr(S.getCurScope(), InstanceBase, SourceLocation(),
+                              RefExpr->isArrow() ? tok::arrow : tok::period, SS,
+                              SourceLocation(), SetterName, nullptr);
   if (SetterExpr.isInvalid()) {
     S.Diag(RefExpr->getMemberLoc(),
            diag::err_cannot_find_suitable_accessor) << 1 /* setter */

--- a/clang/lib/Sema/SemaStmtAsm.cpp
+++ b/clang/lib/Sema/SemaStmtAsm.cpp
@@ -900,7 +900,8 @@ Sema::LookupInlineAsmVarDeclField(Expr *E, StringRef Member,
     return CXXDependentScopeMemberExpr::Create(
         Context, E, T, /*IsArrow=*/false, AsmLoc, NestedNameSpecifierLoc(),
         SourceLocation(),
-        /*UnqualifiedLookups=*/std::nullopt, NameInfo, /*TemplateArgs=*/nullptr);
+        /*UnqualifiedLookups=*/std::nullopt, NameInfo,
+        /*TemplateArgs=*/nullptr);
   }
 
   const RecordType *RT = T->getAs<RecordType>();
@@ -924,7 +925,7 @@ Sema::LookupInlineAsmVarDeclField(Expr *E, StringRef Member,
   // Make an Expr to thread through OpDecl.
   ExprResult Result = BuildMemberReferenceExpr(
       E, E->getType(), AsmLoc, /*IsArrow=*/false, /*SS=*/CXXScopeSpec(),
-      /*TemplateKWLoc*/SourceLocation(), FieldResult,
+      /*TemplateKWLoc*/ SourceLocation(), FieldResult,
       /*TemplateArgs=*/nullptr, /*S=*/nullptr);
 
   return Result;

--- a/clang/lib/Sema/SemaStmtAsm.cpp
+++ b/clang/lib/Sema/SemaStmtAsm.cpp
@@ -900,7 +900,7 @@ Sema::LookupInlineAsmVarDeclField(Expr *E, StringRef Member,
     return CXXDependentScopeMemberExpr::Create(
         Context, E, T, /*IsArrow=*/false, AsmLoc, NestedNameSpecifierLoc(),
         SourceLocation(),
-        /*FirstQualifierFoundInScope=*/nullptr, NameInfo, /*TemplateArgs=*/nullptr);
+        /*UnqualifiedLookups=*/std::nullopt, NameInfo, /*TemplateArgs=*/nullptr);
   }
 
   const RecordType *RT = T->getAs<RecordType>();
@@ -923,8 +923,9 @@ Sema::LookupInlineAsmVarDeclField(Expr *E, StringRef Member,
 
   // Make an Expr to thread through OpDecl.
   ExprResult Result = BuildMemberReferenceExpr(
-      E, E->getType(), AsmLoc, /*IsArrow=*/false, CXXScopeSpec(),
-      SourceLocation(), nullptr, FieldResult, nullptr, nullptr);
+      E, E->getType(), AsmLoc, /*IsArrow=*/false, /*SS=*/CXXScopeSpec(),
+      /*TemplateKWLoc*/SourceLocation(), FieldResult,
+      /*TemplateArgs=*/nullptr, /*S=*/nullptr);
 
   return Result;
 }

--- a/clang/lib/Sema/SemaTemplate.cpp
+++ b/clang/lib/Sema/SemaTemplate.cpp
@@ -472,7 +472,7 @@ bool Sema::LookupTemplateName(LookupResult &Found, Scope *S, CXXScopeSpec &SS,
     if (S) {
       LookupName(Found, S);
     } else if (LookupFirstQualifierInScope &&
-        !SS.getUnqualifiedLookups().empty()) {
+               !SS.getUnqualifiedLookups().empty()) {
       Found.addAllDecls(SS.getUnqualifiedLookups());
       Found.resolveKind();
     }

--- a/clang/lib/Sema/SemaTemplate.cpp
+++ b/clang/lib/Sema/SemaTemplate.cpp
@@ -400,8 +400,8 @@ bool Sema::LookupTemplateName(LookupResult &Found, Scope *S, CXXScopeSpec &SS,
   // vector component name, and look up a template name if not. And similarly
   // for lookups into Objective-C class and object types, where the same
   // problem can arise.
-  if (!ObjectType.isNull() &&
-      (ObjectType->isVectorType() || ObjectType->isObjCObjectOrInterfaceType())) {
+  if (!ObjectType.isNull() && (ObjectType->isVectorType() ||
+                               ObjectType->isObjCObjectOrInterfaceType())) {
     Found.clear();
     return false;
   }
@@ -412,7 +412,7 @@ bool Sema::LookupTemplateName(LookupResult &Found, Scope *S, CXXScopeSpec &SS,
   if (Found.wasNotFoundInCurrentInstantiation())
     return false;
 
-  #if 0
+#if 0
   // Determine where to perform name lookup
   DeclContext *LookupCtx = nullptr;
   bool IsDependent = false;
@@ -475,10 +475,9 @@ bool Sema::LookupTemplateName(LookupResult &Found, Scope *S, CXXScopeSpec &SS,
     // unknown specialization when we come to instantiate the template.
     IsDependent |= Found.wasNotFoundInCurrentInstantiation();
   }
-  #endif
+#endif
 
-
-  #if 0
+#if 0
   bool ObjectTypeSearchedInScope = false;
   bool LookupFirstQualifierInScope =
       MayBeNNS && Found.empty() && !ObjectType.isNull() && !IsDependent;
@@ -508,7 +507,7 @@ bool Sema::LookupTemplateName(LookupResult &Found, Scope *S, CXXScopeSpec &SS,
 
     IsDependent |= Found.wasNotFoundInCurrentInstantiation();
   }
-  #endif
+#endif
 
   bool ObjectTypeSearchedInScope = false;
   bool LookupFirstQualifierInScope =
@@ -558,9 +557,10 @@ bool Sema::LookupTemplateName(LookupResult &Found, Scope *S, CXXScopeSpec &SS,
     // to correct any typos.
     DeclarationName Name = Found.getLookupName();
     Found.clear();
-    DeclContext *LookupCtx = SS.isSet()
-        ? computeDeclContext(SS, EnteringContext)
-        : (!ObjectType.isNull() ? computeDeclContext(ObjectType) : nullptr);
+    DeclContext *LookupCtx =
+        SS.isSet()
+            ? computeDeclContext(SS, EnteringContext)
+            : (!ObjectType.isNull() ? computeDeclContext(ObjectType) : nullptr);
     // Simple filter callback that, for keywords, only accepts the C++ *_cast
     DefaultFilterCCC FilterCCC{};
     FilterCCC.WantTypeSpecifiers = false;

--- a/clang/lib/Sema/SemaTemplate.cpp
+++ b/clang/lib/Sema/SemaTemplate.cpp
@@ -469,10 +469,13 @@ bool Sema::LookupTemplateName(LookupResult &Found, Scope *S, CXXScopeSpec &SS,
     //   expression. If the identifier is not found, it is then looked up in
     //   the context of the entire postfix-expression and shall name a class
     //   template.
-    if (S)
+    if (S) {
       LookupName(Found, S);
-    else if (LookupFirstQualifierInScope && SS.getFirstQualifierFoundInScope())
-      Found.addDecl(SS.getFirstQualifierFoundInScope());
+    } else if (LookupFirstQualifierInScope &&
+        !SS.getUnqualifiedLookups().empty()) {
+      Found.addAllDecls(SS.getUnqualifiedLookups());
+      Found.resolveKind();
+    }
 
     if (!ObjectType.isNull())
       ObjectTypeSearchedInScope = true;
@@ -744,7 +747,7 @@ Sema::ActOnDependentIdExpression(const CXXScopeSpec &SS,
         /*IsArrow=*/!Context.getLangOpts().HLSL,
         /*OperatorLoc=*/SourceLocation(),
         /*QualifierLoc=*/NestedNameSpecifierLoc(), TemplateKWLoc,
-        /*FirstQualifierFoundInScope=*/nullptr, NameInfo, TemplateArgs);
+        /*UnqualifiedLookups=*/std::nullopt, NameInfo, TemplateArgs);
   }
   return BuildDependentDeclRefExpr(SS, TemplateKWLoc, NameInfo, TemplateArgs);
 }

--- a/clang/lib/Sema/SemaTemplate.cpp
+++ b/clang/lib/Sema/SemaTemplate.cpp
@@ -409,111 +409,59 @@ bool Sema::LookupTemplateName(LookupResult &Found, Scope *S, CXXScopeSpec &SS,
   LookupParsedName(Found, S, &SS, ObjectType,
                    /*AllowBuiltinCreation=*/false, EnteringContext);
 
+  // C++ [basic.lookup.qual.general]p3:
+  //   [...] Unless otherwise specified, a qualified name undergoes qualified
+  //   name lookup in its lookup context from the point where it appears unless
+  //   the lookup context either is dependent and is not the current
+  //   instantiation or is not a class or class template.
+  //
+  // The lookup context is dependent and either:
+  // - it is not the current instantiation, or
+  // - it is the current instantiation, it has at least one dependent base
+  //   class, and qualified lookup found nothing.
+  //
+  // If this is a member-qualified name that is the terminal name of a
+  // nested-name-specifier, we perform unqualified lookup and store the results
+  // so we can replicate the lookup during instantiation. The results of the
+  // unqualified loookup are *not* used to determine whether '<' is interpreted
+  // as the delimiter of a template-argument-list.
+  //
+  // For example:
+  //
+  //   template<typename T>
+  //   struct A {
+  //     int x;
+  //   };
+  //
+  //   template<typename T>
+  //   using B = A<T>;
+  //
+  //   template<typename T>
+  //   void f(A<T> a, A<int> b) {
+  //     a.B<T>::x; // error: missing 'template' before 'B'
+  //     b.B<int>::x; // ok, lookup context is not dependent
+  //   }
   if (Found.wasNotFoundInCurrentInstantiation())
     return false;
 
-#if 0
-  // Determine where to perform name lookup
-  DeclContext *LookupCtx = nullptr;
-  bool IsDependent = false;
-  if (!ObjectType.isNull()) {
-    // This nested-name-specifier occurs in a member access expression, e.g.,
-    // x->B::f, and we are looking into the type of the object.
-    assert(SS.isEmpty() && "ObjectType and scope specifier cannot coexist");
-    LookupCtx = computeDeclContext(ObjectType);
-    IsDependent = !LookupCtx && ObjectType->isDependentType();
-    assert((IsDependent || !ObjectType->isIncompleteType() ||
-            !ObjectType->getAs<TagType>() ||
-            ObjectType->castAs<TagType>()->isBeingDefined()) &&
-           "Caller should have completed object type");
-
-    // Template names cannot appear inside an Objective-C class or object type
-    // or a vector type.
-    //
-    // FIXME: This is wrong. For example:
-    //
-    //   template<typename T> using Vec = T __attribute__((ext_vector_type(4)));
-    //   Vec<int> vi;
-    //   vi.Vec<int>::~Vec<int>();
-    //
-    // ... should be accepted but we will not treat 'Vec' as a template name
-    // here. The right thing to do would be to check if the name is a valid
-    // vector component name, and look up a template name if not. And similarly
-    // for lookups into Objective-C class and object types, where the same
-    // problem can arise.
-    if (ObjectType->isObjCObjectOrInterfaceType() ||
-        ObjectType->isVectorType()) {
-      Found.clear();
-      return false;
-    }
-  } else if (SS.isNotEmpty()) {
-    // This nested-name-specifier occurs after another nested-name-specifier,
-    // so long into the context associated with the prior nested-name-specifier.
-    LookupCtx = computeDeclContext(SS, EnteringContext);
-    IsDependent = !LookupCtx && isDependentScopeSpecifier(SS);
-
-    // The declaration context must be complete.
-    if (LookupCtx && RequireCompleteDeclContext(SS, LookupCtx))
-      return true;
-  }
-
   bool ObjectTypeSearchedInScope = false;
-  if (LookupCtx) {
-    // Perform "qualified" name lookup into the declaration context we
-    // computed, which is either the type of the base of a member access
-    // expression or the declaration context associated with a prior
-    // nested-name-specifier.
-    LookupQualifiedName(Found, LookupCtx);
 
-    // FIXME: The C++ standard does not clearly specify what happens in the
-    // case where the object type is dependent, and implementations vary. In
-    // Clang, we treat a name after a . or -> as a template-name if lookup
-    // finds a non-dependent member or member of the current instantiation that
-    // is a type template, or finds no such members and lookup in the context
-    // of the postfix-expression finds a type template. In the latter case, the
-    // name is nonetheless dependent, and we may resolve it to a member of an
-    // unknown specialization when we come to instantiate the template.
-    IsDependent |= Found.wasNotFoundInCurrentInstantiation();
-  }
-#endif
-
-#if 0
-  bool ObjectTypeSearchedInScope = false;
-  bool LookupFirstQualifierInScope =
-      MayBeNNS && Found.empty() && !ObjectType.isNull() && !IsDependent;
-  // FIXME: We should still do the lookup if the object expression is dependent,
-  // but instead of using them we should store them via
-  // setFirstQualifierFoundInScope and pretend we found nothing.
-  if (SS.isEmpty() && (ObjectType.isNull() || LookupFirstQualifierInScope)) {
-    // C++ [basic.lookup.classref]p1:
-    //   In a class member access expression (5.2.5), if the . or -> token is
-    //   immediately followed by an identifier followed by a <, the
-    //   identifier must be looked up to determine whether the < is the
-    //   beginning of a template argument list (14.2) or a less-than operator.
-    //   The identifier is first looked up in the class of the object
-    //   expression. If the identifier is not found, it is then looked up in
-    //   the context of the entire postfix-expression and shall name a class
-    //   template.
-    if (S) {
-      LookupName(Found, S);
-    } else if (LookupFirstQualifierInScope &&
-               !SS.getUnqualifiedLookups().empty()) {
-      Found.addAllDecls(SS.getUnqualifiedLookups());
-      Found.resolveKind();
-    }
-
-    if (!ObjectType.isNull())
-      ObjectTypeSearchedInScope = true;
-
-    IsDependent |= Found.wasNotFoundInCurrentInstantiation();
-  }
-#endif
-
-  bool ObjectTypeSearchedInScope = false;
-  bool LookupFirstQualifierInScope =
-      MayBeNNS && Found.empty() && !ObjectType.isNull();
-
-  if (LookupFirstQualifierInScope) {
+  // C++ [basic.lookup.qual.general]p2:
+  //   A member-qualified name is the (unique) component name, if any, of
+  //   - an unqualified-id or
+  //   - a nested-name-specifier of the form type-name :: or namespace-name ::
+  //   in the id-expression of a class member access expression.
+  //
+  // C++ [basic.lookup.qual.general]p3:
+  //   [...] If nothing is found by qualified lookup for a member-qualified
+  //   name that is the terminal name of a nested-name-specifier and is not
+  //   dependent, it undergoes unqualified lookup.
+  //
+  // In 'x.A::B::y', 'A' will undergo unqualified lookup if qualified lookup
+  // in the type of 'x' finds nothing. If the lookup context is dependent,
+  // we perform the unqualified lookup in the template definition context
+  // and store the results so we can replicate the lookup during instantiation.
+  if (MayBeNNS && Found.empty() && !ObjectType.isNull()) {
     if (S) {
       LookupName(Found, S);
     } else if (!SS.getUnqualifiedLookups().empty()) {

--- a/clang/lib/Sema/SemaTemplate.cpp
+++ b/clang/lib/Sema/SemaTemplate.cpp
@@ -173,16 +173,12 @@ bool Sema::hasAnyAcceptableTemplateNames(LookupResult &R,
   return false;
 }
 
-TemplateNameKind Sema::isTemplateName(Scope *S,
-                                      CXXScopeSpec &SS,
-                                      bool hasTemplateKeyword,
-                                      const UnqualifiedId &Name,
-                                      ParsedType ObjectTypePtr,
-                                      bool EnteringContext,
-                                      TemplateTy &TemplateResult,
-                                      bool &MemberOfUnknownSpecialization,
-                                      bool Disambiguation,
-                                      bool MayBeNNS) {
+TemplateNameKind
+Sema::isTemplateName(Scope *S, CXXScopeSpec &SS, bool hasTemplateKeyword,
+                     const UnqualifiedId &Name, ParsedType ObjectTypePtr,
+                     bool EnteringContext, TemplateTy &TemplateResult,
+                     bool &MemberOfUnknownSpecialization, bool Disambiguation,
+                     bool MayBeNNS) {
   assert(getLangOpts().CPlusPlus && "No template names in C!");
 
   DeclarationName TName;
@@ -213,8 +209,7 @@ TemplateNameKind Sema::isTemplateName(Scope *S,
   if (LookupTemplateName(R, S, SS, ObjectType, EnteringContext,
                          /*RequiredTemplate=*/SourceLocation(),
                          &AssumedTemplate,
-                         /*AllowTypoCorrection=*/!Disambiguation,
-                         MayBeNNS))
+                         /*AllowTypoCorrection=*/!Disambiguation, MayBeNNS))
     return TNK_Non_template;
 
   MemberOfUnknownSpecialization = R.wasNotFoundInCurrentInstantiation();
@@ -382,8 +377,7 @@ bool Sema::LookupTemplateName(LookupResult &Found, Scope *S, CXXScopeSpec &SS,
                               QualType ObjectType, bool EnteringContext,
                               RequiredTemplateKind RequiredTemplate,
                               AssumedTemplateKind *ATK,
-                              bool AllowTypoCorrection,
-                              bool MayBeNNS) {
+                              bool AllowTypoCorrection, bool MayBeNNS) {
   if (ATK)
     *ATK = AssumedTemplateKind::None;
 
@@ -456,8 +450,7 @@ bool Sema::LookupTemplateName(LookupResult &Found, Scope *S, CXXScopeSpec &SS,
   }
 
   bool LookupFirstQualifierInScope =
-      MayBeNNS && Found.empty() &&
-      !ObjectType.isNull() && !IsDependent;
+      MayBeNNS && Found.empty() && !ObjectType.isNull() && !IsDependent;
 
   // FIXME: We should still do the lookup if the object expression is dependent,
   // but instead of using them we should store them via
@@ -5703,15 +5696,10 @@ ExprResult Sema::BuildQualifiedTemplateIdExpr(
   return BuildTemplateIdExpr(SS, TemplateKWLoc, R, /*ADL=*/false, TemplateArgs);
 }
 
-TemplateNameKind Sema::ActOnTemplateName(Scope *S,
-                                         CXXScopeSpec &SS,
-                                         SourceLocation TemplateKWLoc,
-                                         const UnqualifiedId &Name,
-                                         ParsedType ObjectType,
-                                         bool EnteringContext,
-                                         TemplateTy &Result,
-                                         bool AllowInjectedClassName,
-                                         bool MayBeNNS) {
+TemplateNameKind Sema::ActOnTemplateName(
+    Scope *S, CXXScopeSpec &SS, SourceLocation TemplateKWLoc,
+    const UnqualifiedId &Name, ParsedType ObjectType, bool EnteringContext,
+    TemplateTy &Result, bool AllowInjectedClassName, bool MayBeNNS) {
   if (TemplateKWLoc.isValid() && S && !S->getTemplateParamParent())
     Diag(TemplateKWLoc,
          getLangOpts().CPlusPlus11 ?
@@ -5746,10 +5734,10 @@ TemplateNameKind Sema::ActOnTemplateName(Scope *S,
   // "template" keyword is now permitted). We follow the C++0x
   // rules, even in C++03 mode with a warning, retroactively applying the DR.
   bool MemberOfUnknownSpecialization;
-  TemplateNameKind TNK = isTemplateName(S, SS, TemplateKWLoc.isValid(), Name,
-                                        ObjectType, EnteringContext, Result,
-                                        MemberOfUnknownSpecialization,
-                                        /*Disambiguation=*/false, MayBeNNS);
+  TemplateNameKind TNK =
+      isTemplateName(S, SS, TemplateKWLoc.isValid(), Name, ObjectType,
+                     EnteringContext, Result, MemberOfUnknownSpecialization,
+                     /*Disambiguation=*/false, MayBeNNS);
   if (TNK != TNK_Non_template) {
     // We resolved this to a (non-dependent) template name. Return it.
     auto *LookupRD = dyn_cast_or_null<CXXRecordDecl>(LookupCtx);

--- a/clang/lib/Sema/SemaTemplateInstantiate.cpp
+++ b/clang/lib/Sema/SemaTemplateInstantiate.cpp
@@ -1519,7 +1519,6 @@ namespace {
     TransformTemplateName(CXXScopeSpec &SS, TemplateName Name,
                           SourceLocation NameLoc,
                           QualType ObjectType = QualType(),
-                          NamedDecl *FirstQualifierInScope = nullptr,
                           bool AllowInjectedClassName = false);
 
     const CXXAssumeAttr *TransformCXXAssumeAttr(const CXXAssumeAttr *AA);
@@ -1952,8 +1951,7 @@ TemplateInstantiator::RebuildElaboratedType(SourceLocation KeywordLoc,
 
 TemplateName TemplateInstantiator::TransformTemplateName(
     CXXScopeSpec &SS, TemplateName Name, SourceLocation NameLoc,
-    QualType ObjectType, NamedDecl *FirstQualifierInScope,
-    bool AllowInjectedClassName) {
+    QualType ObjectType, bool AllowInjectedClassName) {
   if (TemplateTemplateParmDecl *TTP
        = dyn_cast_or_null<TemplateTemplateParmDecl>(Name.getAsTemplateDecl())) {
     if (TTP->getDepth() < TemplateArgs.getNumLevels()) {
@@ -2025,7 +2023,6 @@ TemplateName TemplateInstantiator::TransformTemplateName(
   }
 
   return inherited::TransformTemplateName(SS, Name, NameLoc, ObjectType,
-                                          FirstQualifierInScope,
                                           AllowInjectedClassName);
 }
 

--- a/clang/lib/Sema/SemaTemplateInstantiate.cpp
+++ b/clang/lib/Sema/SemaTemplateInstantiate.cpp
@@ -1518,7 +1518,8 @@ namespace {
     TemplateName TransformTemplateName(CXXScopeSpec &SS, TemplateName Name,
                                        SourceLocation NameLoc,
                                        QualType ObjectType = QualType(),
-                                       bool AllowInjectedClassName = false);
+                                       bool AllowInjectedClassName = false,
+                                       bool MayBeNNS = false);
 
     const CXXAssumeAttr *TransformCXXAssumeAttr(const CXXAssumeAttr *AA);
     const LoopHintAttr *TransformLoopHintAttr(const LoopHintAttr *LH);
@@ -1950,7 +1951,7 @@ TemplateInstantiator::RebuildElaboratedType(SourceLocation KeywordLoc,
 
 TemplateName TemplateInstantiator::TransformTemplateName(
     CXXScopeSpec &SS, TemplateName Name, SourceLocation NameLoc,
-    QualType ObjectType, bool AllowInjectedClassName) {
+    QualType ObjectType, bool AllowInjectedClassName, bool MayBeNNS) {
   if (TemplateTemplateParmDecl *TTP
        = dyn_cast_or_null<TemplateTemplateParmDecl>(Name.getAsTemplateDecl())) {
     if (TTP->getDepth() < TemplateArgs.getNumLevels()) {
@@ -2022,7 +2023,7 @@ TemplateName TemplateInstantiator::TransformTemplateName(
   }
 
   return inherited::TransformTemplateName(SS, Name, NameLoc, ObjectType,
-                                          AllowInjectedClassName);
+                                          AllowInjectedClassName, MayBeNNS);
 }
 
 ExprResult

--- a/clang/lib/Sema/SemaTemplateInstantiate.cpp
+++ b/clang/lib/Sema/SemaTemplateInstantiate.cpp
@@ -1515,11 +1515,10 @@ namespace {
                                    NestedNameSpecifierLoc QualifierLoc,
                                    QualType T);
 
-    TemplateName
-    TransformTemplateName(CXXScopeSpec &SS, TemplateName Name,
-                          SourceLocation NameLoc,
-                          QualType ObjectType = QualType(),
-                          bool AllowInjectedClassName = false);
+    TemplateName TransformTemplateName(CXXScopeSpec &SS, TemplateName Name,
+                                       SourceLocation NameLoc,
+                                       QualType ObjectType = QualType(),
+                                       bool AllowInjectedClassName = false);
 
     const CXXAssumeAttr *TransformCXXAssumeAttr(const CXXAssumeAttr *AA);
     const LoopHintAttr *TransformLoopHintAttr(const LoopHintAttr *LH);

--- a/clang/lib/Sema/TreeTransform.h
+++ b/clang/lib/Sema/TreeTransform.h
@@ -1310,8 +1310,7 @@ public:
                                    SourceLocation TemplateKWLoc,
                                    const IdentifierInfo &Name,
                                    SourceLocation NameLoc, QualType ObjectType,
-                                   bool AllowInjectedClassName,
-                                   bool MayBeNNS);
+                                   bool AllowInjectedClassName, bool MayBeNNS);
 
   /// Build a new template name given a nested name specifier and the
   /// overloaded operator name that is referred to as a template.

--- a/clang/lib/Sema/TreeTransform.h
+++ b/clang/lib/Sema/TreeTransform.h
@@ -2894,6 +2894,8 @@ public:
 
     CXXScopeSpec SS;
     SS.Adopt(QualifierLoc);
+    if (FirstQualifierInScope)
+      SS.setFoundFirstQualifierInScope(FirstQualifierInScope);
 
     Base = BaseResult.get();
     if (Base->containsErrors())
@@ -3585,6 +3587,9 @@ public:
     CXXScopeSpec SS;
     SS.Adopt(QualifierLoc);
 
+    if (FirstQualifierInScope)
+      SS.setFoundFirstQualifierInScope(FirstQualifierInScope);
+
     return SemaRef.BuildMemberReferenceExpr(BaseE, BaseType,
                                             OperatorLoc, IsArrow,
                                             SS, TemplateKWLoc,
@@ -3607,6 +3612,9 @@ public:
                                 const TemplateArgumentListInfo *TemplateArgs) {
     CXXScopeSpec SS;
     SS.Adopt(QualifierLoc);
+
+    if (FirstQualifierInScope)
+      SS.setFoundFirstQualifierInScope(FirstQualifierInScope);
 
     return SemaRef.BuildMemberReferenceExpr(BaseE, BaseType,
                                             OperatorLoc, IsArrow,
@@ -4395,6 +4403,8 @@ NestedNameSpecifierLoc TreeTransform<Derived>::TransformNestedNameSpecifierLoc(
   insertNNS(NNS);
 
   CXXScopeSpec SS;
+  if (FirstQualifierInScope)
+    SS.setFoundFirstQualifierInScope(FirstQualifierInScope);
   while (!Qualifiers.empty()) {
     NestedNameSpecifierLoc Q = Qualifiers.pop_back_val();
     NestedNameSpecifier *QNNS = Q.getNestedNameSpecifier();
@@ -5191,6 +5201,9 @@ TypeSourceInfo *TreeTransform<Derived>::TransformTSIInObjectScope(
 
   TypeLocBuilder TLB;
   QualType Result;
+
+  if (UnqualLookup)
+    SS.setFoundFirstQualifierInScope(UnqualLookup);
 
   if (isa<TemplateSpecializationType>(T)) {
     TemplateSpecializationTypeLoc SpecTL =
@@ -16288,6 +16301,8 @@ TreeTransform<Derived>::RebuildTemplateName(CXXScopeSpec &SS,
   UnqualifiedId TemplateName;
   TemplateName.setIdentifier(&Name, NameLoc);
   Sema::TemplateTy Template;
+  if (FirstQualifierInScope)
+    SS.setFoundFirstQualifierInScope(FirstQualifierInScope);
   getSema().ActOnTemplateName(/*Scope=*/nullptr, SS, TemplateKWLoc,
                               TemplateName, ParsedType::make(ObjectType),
                               /*EnteringContext=*/false, Template,

--- a/clang/lib/Sema/TreeTransform.h
+++ b/clang/lib/Sema/TreeTransform.h
@@ -2925,7 +2925,7 @@ public:
     return getSema().BuildMemberReferenceExpr(Base, BaseType, OpLoc, isArrow,
                                               SS, TemplateKWLoc, R,
                                               ExplicitTemplateArgs,
-                                              /*S*/ nullptr);
+                                              /*S=*/nullptr);
   }
 
   /// Build a new binary operator expression.

--- a/clang/lib/Sema/TreeTransform.h
+++ b/clang/lib/Sema/TreeTransform.h
@@ -14743,15 +14743,6 @@ TreeTransform<Derived>::TransformCXXDependentScopeMemberExpr(
     ObjectType = BaseType->castAs<PointerType>()->getPointeeType();
   }
 
-#if 0
-  // Transform the first part of the nested-name-specifier that qualifies
-  // the member name.
-  NamedDecl *FirstQualifierInScope
-    = getDerived().TransformFirstQualifierInScope(
-                                            E->getFirstQualifierFoundInScope(),
-                                            E->getQualifierLoc().getBeginLoc());
-#endif
-
   UnresolvedSet<4> UnqualifiedLookups;
   for (auto D : E->unqualified_lookups()) {
     if (NamedDecl *InstD = getDerived().TransformFirstQualifierInScope(

--- a/clang/lib/Sema/TreeTransform.h
+++ b/clang/lib/Sema/TreeTransform.h
@@ -541,10 +541,9 @@ public:
   /// By default, transforms all of the types and declarations within the
   /// nested-name-specifier. Subclasses may override this function to provide
   /// alternate behavior.
-  NestedNameSpecifierLoc
-  TransformNestedNameSpecifierLoc(NestedNameSpecifierLoc NNS,
-                                  QualType ObjectType = QualType(),
-                                  ArrayRef<DeclAccessPair> UnqualifiedLookups = std::nullopt);
+  NestedNameSpecifierLoc TransformNestedNameSpecifierLoc(
+      NestedNameSpecifierLoc NNS, QualType ObjectType = QualType(),
+      ArrayRef<DeclAccessPair> UnqualifiedLookups = std::nullopt);
 
   /// Transform the given declaration name.
   ///
@@ -585,11 +584,10 @@ public:
   /// By default, transforms the template name by transforming the declarations
   /// and nested-name-specifiers that occur within the template name.
   /// Subclasses may override this function to provide alternate behavior.
-  TemplateName
-  TransformTemplateName(CXXScopeSpec &SS, TemplateName Name,
-                        SourceLocation NameLoc,
-                        QualType ObjectType = QualType(),
-                        bool AllowInjectedClassName = false);
+  TemplateName TransformTemplateName(CXXScopeSpec &SS, TemplateName Name,
+                                     SourceLocation NameLoc,
+                                     QualType ObjectType = QualType(),
+                                     bool AllowInjectedClassName = false);
 
   /// Transform the given template argument.
   ///
@@ -1139,8 +1137,7 @@ public:
     CXXScopeSpec SS;
     SS.Adopt(QualifierLoc);
     TemplateName InstName = getDerived().RebuildTemplateName(
-        SS, TemplateKWLoc, *Name, NameLoc, QualType(),
-        AllowInjectedClassName);
+        SS, TemplateKWLoc, *Name, NameLoc, QualType(), AllowInjectedClassName);
 
     if (InstName.isNull())
       return QualType();
@@ -2847,15 +2844,14 @@ public:
   ///
   /// By default, performs semantic analysis to build the new expression.
   /// Subclasses may override this routine to provide different behavior.
-  ExprResult RebuildMemberExpr(Expr *Base, SourceLocation OpLoc,
-                               bool isArrow,
-                               NestedNameSpecifierLoc QualifierLoc,
-                               SourceLocation TemplateKWLoc,
-                               const DeclarationNameInfo &MemberNameInfo,
-                               ValueDecl *Member,
-                               NamedDecl *FoundDecl,
-                        const TemplateArgumentListInfo *ExplicitTemplateArgs,
-                               ArrayRef<DeclAccessPair> UnqualifiedLookups) {
+  ExprResult
+  RebuildMemberExpr(Expr *Base, SourceLocation OpLoc, bool isArrow,
+                    NestedNameSpecifierLoc QualifierLoc,
+                    SourceLocation TemplateKWLoc,
+                    const DeclarationNameInfo &MemberNameInfo,
+                    ValueDecl *Member, NamedDecl *FoundDecl,
+                    const TemplateArgumentListInfo *ExplicitTemplateArgs,
+                    ArrayRef<DeclAccessPair> UnqualifiedLookups) {
     ExprResult BaseResult = getSema().PerformMemberExprBaseConversion(Base,
                                                                       isArrow);
     if (!Member->getDeclName()) {
@@ -2925,9 +2921,9 @@ public:
     }
 
     return getSema().BuildMemberReferenceExpr(Base, BaseType, OpLoc, isArrow,
-                                              SS, TemplateKWLoc,
-                                              R, ExplicitTemplateArgs,
-                                              /*S*/nullptr);
+                                              SS, TemplateKWLoc, R,
+                                              ExplicitTemplateArgs,
+                                              /*S*/ nullptr);
   }
 
   /// Build a new binary operator expression.
@@ -3002,7 +2998,7 @@ public:
     return getSema().BuildMemberReferenceExpr(
         Base, Base->getType(), OpLoc, IsArrow, SS,
         /*TemplateKWLoc=*/SourceLocation(), NameInfo,
-        /*TemplateArgs=*/ nullptr, /*S=*/nullptr);
+        /*TemplateArgs=*/nullptr, /*S=*/nullptr);
   }
 
   /// Build a new initializer list expression.
@@ -3570,46 +3566,37 @@ public:
   ///
   /// By default, performs semantic analysis to build the new expression.
   /// Subclasses may override this routine to provide different behavior.
-  ExprResult RebuildCXXDependentScopeMemberExpr(Expr *BaseE,
-                                                QualType BaseType,
-                                                bool IsArrow,
-                                                SourceLocation OperatorLoc,
-                                          NestedNameSpecifierLoc QualifierLoc,
-                                                SourceLocation TemplateKWLoc,
-                                  ArrayRef<DeclAccessPair> UnqualifiedLookups,
-                                   const DeclarationNameInfo &MemberNameInfo,
-                              const TemplateArgumentListInfo *TemplateArgs) {
+  ExprResult RebuildCXXDependentScopeMemberExpr(
+      Expr *BaseE, QualType BaseType, bool IsArrow, SourceLocation OperatorLoc,
+      NestedNameSpecifierLoc QualifierLoc, SourceLocation TemplateKWLoc,
+      ArrayRef<DeclAccessPair> UnqualifiedLookups,
+      const DeclarationNameInfo &MemberNameInfo,
+      const TemplateArgumentListInfo *TemplateArgs) {
     CXXScopeSpec SS;
     SS.Adopt(QualifierLoc);
     SS.setUnqualifiedLookups(UnqualifiedLookups);
 
-    return SemaRef.BuildMemberReferenceExpr(BaseE, BaseType,
-                                            OperatorLoc, IsArrow,
-                                            SS, TemplateKWLoc,
-                                            MemberNameInfo,
-                                            TemplateArgs, /*S=*/nullptr);
+    return SemaRef.BuildMemberReferenceExpr(
+        BaseE, BaseType, OperatorLoc, IsArrow, SS, TemplateKWLoc,
+        MemberNameInfo, TemplateArgs, /*S=*/nullptr);
   }
 
   /// Build a new member reference expression.
   ///
   /// By default, performs semantic analysis to build the new expression.
   /// Subclasses may override this routine to provide different behavior.
-  ExprResult RebuildUnresolvedMemberExpr(Expr *BaseE, QualType BaseType,
-                                         SourceLocation OperatorLoc,
-                                         bool IsArrow,
-                                         NestedNameSpecifierLoc QualifierLoc,
-                                         SourceLocation TemplateKWLoc,
-                                         ArrayRef<DeclAccessPair> UnqualifiedLookups,
-                                         LookupResult &R,
-                                const TemplateArgumentListInfo *TemplateArgs) {
+  ExprResult RebuildUnresolvedMemberExpr(
+      Expr *BaseE, QualType BaseType, SourceLocation OperatorLoc, bool IsArrow,
+      NestedNameSpecifierLoc QualifierLoc, SourceLocation TemplateKWLoc,
+      ArrayRef<DeclAccessPair> UnqualifiedLookups, LookupResult &R,
+      const TemplateArgumentListInfo *TemplateArgs) {
     CXXScopeSpec SS;
     SS.Adopt(QualifierLoc);
     SS.setUnqualifiedLookups(UnqualifiedLookups);
 
-    return SemaRef.BuildMemberReferenceExpr(BaseE, BaseType,
-                                            OperatorLoc, IsArrow,
-                                            SS, TemplateKWLoc,
-                                            R, TemplateArgs, /*S=*/nullptr);
+    return SemaRef.BuildMemberReferenceExpr(BaseE, BaseType, OperatorLoc,
+                                            IsArrow, SS, TemplateKWLoc, R,
+                                            TemplateArgs, /*S=*/nullptr);
   }
 
   /// Build a new noexcept expression.
@@ -3844,13 +3831,12 @@ public:
                                         SourceLocation PropertyLoc) {
     CXXScopeSpec SS;
     DeclarationNameInfo NameInfo(Property->getDeclName(), PropertyLoc);
-    return getSema().BuildMemberReferenceExpr(BaseArg, BaseArg->getType(),
-                                              /*FIXME:*/PropertyLoc,
-                                              /*IsArrow=*/false,
-                                              SS, /*TemplateKWLoc=*/SourceLocation(),
-                                              NameInfo,
-                                              /*TemplateArgs=*/nullptr,
-                                              /*S=*/nullptr);
+    return getSema().BuildMemberReferenceExpr(
+        BaseArg, BaseArg->getType(),
+        /*FIXME:*/ PropertyLoc,
+        /*IsArrow=*/false, SS, /*TemplateKWLoc=*/SourceLocation(), NameInfo,
+        /*TemplateArgs=*/nullptr,
+        /*S=*/nullptr);
   }
 
   /// Build a new Objective-C property reference expression.
@@ -3877,12 +3863,11 @@ public:
                                 SourceLocation OpLoc, bool IsArrow) {
     CXXScopeSpec SS;
     DeclarationNameInfo NameInfo(&getSema().Context.Idents.get("isa"), IsaLoc);
-    return getSema().BuildMemberReferenceExpr(BaseArg, BaseArg->getType(),
-                                              OpLoc, IsArrow,
-                                              SS, /*TemplateKWLoc=*/SourceLocation(),
-                                              NameInfo,
-                                              /*TemplateArgs=*/nullptr,
-                                              /*S=*/nullptr);
+    return getSema().BuildMemberReferenceExpr(
+        BaseArg, BaseArg->getType(), OpLoc, IsArrow, SS,
+        /*TemplateKWLoc=*/SourceLocation(), NameInfo,
+        /*TemplateArgs=*/nullptr,
+        /*S=*/nullptr);
   }
 
   /// Build a new shuffle vector expression.
@@ -4047,16 +4032,14 @@ public:
   }
 
 private:
-  TypeLoc TransformTypeInObjectScope(TypeLoc TL,
-                                     QualType ObjectType,
+  TypeLoc TransformTypeInObjectScope(TypeLoc TL, QualType ObjectType,
                                      CXXScopeSpec &SS);
 
   TypeSourceInfo *TransformTypeInObjectScope(TypeSourceInfo *TSInfo,
                                              QualType ObjectType,
                                              CXXScopeSpec &SS);
 
-  TypeSourceInfo *TransformTSIInObjectScope(TypeLoc TL,
-                                            QualType ObjectType,
+  TypeSourceInfo *TransformTSIInObjectScope(TypeLoc TL, QualType ObjectType,
                                             CXXScopeSpec &SS);
 
   QualType TransformDependentNameType(TypeLocBuilder &TLB,
@@ -4398,8 +4381,8 @@ NestedNameSpecifierLoc TreeTransform<Derived>::TransformNestedNameSpecifierLoc(
                                       Q.getLocalBeginLoc(), Q.getLocalEndLoc(),
                                       ObjectType);
       if (SemaRef.BuildCXXNestedNameSpecifier(/*Scope=*/nullptr, IdInfo,
-                                              /*EnteringContext=*/false,
-                                              SS, /*ErrorRecoveryLookup=*/false))
+                                              /*EnteringContext=*/false, SS,
+                                              /*ErrorRecoveryLookup=*/false))
         return NestedNameSpecifierLoc();
       break;
     }
@@ -4553,13 +4536,10 @@ TreeTransform<Derived>
   llvm_unreachable("Unknown name kind.");
 }
 
-template<typename Derived>
-TemplateName
-TreeTransform<Derived>::TransformTemplateName(CXXScopeSpec &SS,
-                                              TemplateName Name,
-                                              SourceLocation NameLoc,
-                                              QualType ObjectType,
-                                              bool AllowInjectedClassName) {
+template <typename Derived>
+TemplateName TreeTransform<Derived>::TransformTemplateName(
+    CXXScopeSpec &SS, TemplateName Name, SourceLocation NameLoc,
+    QualType ObjectType, bool AllowInjectedClassName) {
   if (QualifiedTemplateName *QTN = Name.getAsQualifiedTemplateName()) {
     TemplateDecl *Template = QTN->getUnderlyingTemplate().getAsTemplateDecl();
     assert(Template && "qualified template name must refer to a template");
@@ -4595,12 +4575,9 @@ TreeTransform<Derived>::TransformTemplateName(CXXScopeSpec &SS,
     SourceLocation TemplateKWLoc = NameLoc;
 
     if (DTN->isIdentifier()) {
-      return getDerived().RebuildTemplateName(SS,
-                                              TemplateKWLoc,
-                                              *DTN->getIdentifier(),
-                                              NameLoc,
-                                              ObjectType,
-                                              AllowInjectedClassName);
+      return getDerived().RebuildTemplateName(
+          SS, TemplateKWLoc, *DTN->getIdentifier(), NameLoc, ObjectType,
+          AllowInjectedClassName);
     }
 
     return getDerived().RebuildTemplateName(SS, TemplateKWLoc,
@@ -5144,26 +5121,22 @@ QualType TreeTransform<Derived>::RebuildQualifiedType(QualType T,
   return SemaRef.BuildQualifiedType(T, Loc, Quals);
 }
 
-template<typename Derived>
-TypeLoc
-TreeTransform<Derived>::TransformTypeInObjectScope(TypeLoc TL,
-                                                   QualType ObjectType,
-                                                   CXXScopeSpec &SS) {
+template <typename Derived>
+TypeLoc TreeTransform<Derived>::TransformTypeInObjectScope(TypeLoc TL,
+                                                           QualType ObjectType,
+                                                           CXXScopeSpec &SS) {
   if (getDerived().AlreadyTransformed(TL.getType()))
     return TL;
 
-  TypeSourceInfo *TSI =
-      TransformTSIInObjectScope(TL, ObjectType, SS);
+  TypeSourceInfo *TSI = TransformTSIInObjectScope(TL, ObjectType, SS);
   if (TSI)
     return TSI->getTypeLoc();
   return TypeLoc();
 }
 
-template<typename Derived>
-TypeSourceInfo *
-TreeTransform<Derived>::TransformTypeInObjectScope(TypeSourceInfo *TSInfo,
-                                                   QualType ObjectType,
-                                                   CXXScopeSpec &SS) {
+template <typename Derived>
+TypeSourceInfo *TreeTransform<Derived>::TransformTypeInObjectScope(
+    TypeSourceInfo *TSInfo, QualType ObjectType, CXXScopeSpec &SS) {
   if (getDerived().AlreadyTransformed(TSInfo->getType()))
     return TSInfo;
 
@@ -5195,13 +5168,11 @@ TypeSourceInfo *TreeTransform<Derived>::TransformTSIInObjectScope(
     DependentTemplateSpecializationTypeLoc SpecTL =
         TL.castAs<DependentTemplateSpecializationTypeLoc>();
 
-    TemplateName Template
-      = getDerived().RebuildTemplateName(SS,
-                                         SpecTL.getTemplateKeywordLoc(),
-                                         *SpecTL.getTypePtr()->getIdentifier(),
-                                         SpecTL.getTemplateNameLoc(),
-                                         ObjectType,
-                                         /*AllowInjectedClassName=*/true);
+    TemplateName Template = getDerived().RebuildTemplateName(
+        SS, SpecTL.getTemplateKeywordLoc(),
+        *SpecTL.getTypePtr()->getIdentifier(), SpecTL.getTemplateNameLoc(),
+        ObjectType,
+        /*AllowInjectedClassName=*/true);
     if (Template.isNull())
       return nullptr;
 
@@ -12353,16 +12324,11 @@ TreeTransform<Derived>::TransformMemberExpr(MemberExpr *E) {
       return ExprError();
   }
 
-  return getDerived().RebuildMemberExpr(Base.get(), FakeOperatorLoc,
-                                        E->isArrow(),
-                                        QualifierLoc,
-                                        TemplateKWLoc,
-                                        MemberNameInfo,
-                                        Member,
-                                        FoundDecl,
-                                        (E->hasExplicitTemplateArgs()
-                                           ? &TransArgs : nullptr),
-                                        UnqualifiedLookups);
+  return getDerived().RebuildMemberExpr(
+      Base.get(), FakeOperatorLoc, E->isArrow(), QualifierLoc, TemplateKWLoc,
+      MemberNameInfo, Member, FoundDecl,
+      (E->hasExplicitTemplateArgs() ? &TransArgs : nullptr),
+      UnqualifiedLookups);
 }
 
 template<typename Derived>
@@ -13489,9 +13455,8 @@ TreeTransform<Derived>::TransformCXXPseudoDestructorExpr(
 
   PseudoDestructorTypeStorage Destroyed;
   if (E->getDestroyedTypeInfo()) {
-    TypeSourceInfo *DestroyedTypeInfo
-      = getDerived().TransformTypeInObjectScope(E->getDestroyedTypeInfo(),
-                                                ObjectType, SS);
+    TypeSourceInfo *DestroyedTypeInfo = getDerived().TransformTypeInObjectScope(
+        E->getDestroyedTypeInfo(), ObjectType, SS);
     if (!DestroyedTypeInfo)
       return ExprError();
     Destroyed = DestroyedTypeInfo;
@@ -13517,7 +13482,7 @@ TreeTransform<Derived>::TransformCXXPseudoDestructorExpr(
   if (E->getScopeTypeInfo()) {
     CXXScopeSpec EmptySS;
     ScopeTypeInfo = getDerived().TransformTypeInObjectScope(
-                      E->getScopeTypeInfo(), ObjectType, EmptySS);
+        E->getScopeTypeInfo(), ObjectType, EmptySS);
     if (!ScopeTypeInfo)
       return ExprError();
   }
@@ -14778,28 +14743,26 @@ TreeTransform<Derived>::TransformCXXDependentScopeMemberExpr(
     ObjectType = BaseType->castAs<PointerType>()->getPointeeType();
   }
 
-  #if 0
+#if 0
   // Transform the first part of the nested-name-specifier that qualifies
   // the member name.
   NamedDecl *FirstQualifierInScope
     = getDerived().TransformFirstQualifierInScope(
                                             E->getFirstQualifierFoundInScope(),
                                             E->getQualifierLoc().getBeginLoc());
-  #endif
+#endif
 
   UnresolvedSet<4> UnqualifiedLookups;
   for (auto D : E->unqualified_lookups()) {
     if (NamedDecl *InstD = getDerived().TransformFirstQualifierInScope(
-        D.getDecl(), E->getQualifierLoc().getBeginLoc()))
+            D.getDecl(), E->getQualifierLoc().getBeginLoc()))
       UnqualifiedLookups.addDecl(InstD);
   }
 
   NestedNameSpecifierLoc QualifierLoc;
   if (E->getQualifier()) {
-    QualifierLoc
-      = getDerived().TransformNestedNameSpecifierLoc(E->getQualifierLoc(),
-                                                     ObjectType,
-                                                     UnqualifiedLookups.pairs());
+    QualifierLoc = getDerived().TransformNestedNameSpecifierLoc(
+        E->getQualifierLoc(), ObjectType, UnqualifiedLookups.pairs());
     if (!QualifierLoc)
       return ExprError();
   }
@@ -14818,23 +14781,16 @@ TreeTransform<Derived>::TransformCXXDependentScopeMemberExpr(
   if (!E->hasExplicitTemplateArgs()) {
     // This is a reference to a member without an explicitly-specified
     // template argument list. Optimize for this common case.
-    if (!getDerived().AlwaysRebuild() &&
-        Base.get() == OldBase &&
-        BaseType == E->getBaseType() &&
-        QualifierLoc == E->getQualifierLoc() &&
+    if (!getDerived().AlwaysRebuild() && Base.get() == OldBase &&
+        BaseType == E->getBaseType() && QualifierLoc == E->getQualifierLoc() &&
         NameInfo.getName() == E->getMember() &&
         UnqualifiedLookups.pairs() == E->unqualified_lookups())
       return E;
 
-    return getDerived().RebuildCXXDependentScopeMemberExpr(Base.get(),
-                                                       BaseType,
-                                                       E->isArrow(),
-                                                       E->getOperatorLoc(),
-                                                       QualifierLoc,
-                                                       TemplateKWLoc,
-                                                       UnqualifiedLookups.pairs(),
-                                                       NameInfo,
-                                                       /*TemplateArgs*/nullptr);
+    return getDerived().RebuildCXXDependentScopeMemberExpr(
+        Base.get(), BaseType, E->isArrow(), E->getOperatorLoc(), QualifierLoc,
+        TemplateKWLoc, UnqualifiedLookups.pairs(), NameInfo,
+        /*TemplateArgs*/ nullptr);
   }
 
   TemplateArgumentListInfo TransArgs(E->getLAngleLoc(), E->getRAngleLoc());
@@ -14843,15 +14799,9 @@ TreeTransform<Derived>::TransformCXXDependentScopeMemberExpr(
                                               TransArgs))
     return ExprError();
 
-  return getDerived().RebuildCXXDependentScopeMemberExpr(Base.get(),
-                                                     BaseType,
-                                                     E->isArrow(),
-                                                     E->getOperatorLoc(),
-                                                     QualifierLoc,
-                                                     TemplateKWLoc,
-                                                     UnqualifiedLookups.pairs(),
-                                                     NameInfo,
-                                                     &TransArgs);
+  return getDerived().RebuildCXXDependentScopeMemberExpr(
+      Base.get(), BaseType, E->isArrow(), E->getOperatorLoc(), QualifierLoc,
+      TemplateKWLoc, UnqualifiedLookups.pairs(), NameInfo, &TransArgs);
 }
 
 template <typename Derived>
@@ -16273,14 +16223,10 @@ TreeTransform<Derived>::RebuildTemplateName(CXXScopeSpec &SS,
                                                   TemplateName(Template));
 }
 
-template<typename Derived>
-TemplateName
-TreeTransform<Derived>::RebuildTemplateName(CXXScopeSpec &SS,
-                                            SourceLocation TemplateKWLoc,
-                                            const IdentifierInfo &Name,
-                                            SourceLocation NameLoc,
-                                            QualType ObjectType,
-                                            bool AllowInjectedClassName) {
+template <typename Derived>
+TemplateName TreeTransform<Derived>::RebuildTemplateName(
+    CXXScopeSpec &SS, SourceLocation TemplateKWLoc, const IdentifierInfo &Name,
+    SourceLocation NameLoc, QualType ObjectType, bool AllowInjectedClassName) {
   UnqualifiedId TemplateName;
   TemplateName.setIdentifier(&Name, NameLoc);
   Sema::TemplateTy Template;
@@ -16435,12 +16381,10 @@ TreeTransform<Derived>::RebuildCXXPseudoDestructorExpr(Expr *Base,
   }
 
   SourceLocation TemplateKWLoc; // FIXME: retrieve it from caller.
-  return getSema().BuildMemberReferenceExpr(Base, BaseType,
-                                            OperatorLoc, isArrow,
-                                            SS, TemplateKWLoc,
-                                            NameInfo,
-                                            /*TemplateArgs=*/nullptr,
-                                            /*S=*/nullptr);
+  return getSema().BuildMemberReferenceExpr(
+      Base, BaseType, OperatorLoc, isArrow, SS, TemplateKWLoc, NameInfo,
+      /*TemplateArgs=*/nullptr,
+      /*S=*/nullptr);
 }
 
 template<typename Derived>

--- a/clang/lib/Serialization/ASTReaderStmt.cpp
+++ b/clang/lib/Serialization/ASTReaderStmt.cpp
@@ -2024,52 +2024,12 @@ void ASTStmtReader::VisitCXXDependentScopeMemberExpr(
     auto AS = (AccessSpecifier)Record.readInt();
     E->getTrailingObjects<DeclAccessPair>()[I] =
         DeclAccessPair::make(FoundD, AS);
-    ;
   }
 
   if (HasTemplateInfo)
     ReadTemplateKWAndArgsInfo(
         *E->getTrailingObjects<ASTTemplateKWAndArgsInfo>(),
         E->getTrailingObjects<TemplateArgumentLoc>(), NumTemplateArgs);
-
-#if 0
-  unsigned NumTemplateArgs = Record.readInt();
-  CurrentUnpackingBits.emplace(Record.readInt());
-  bool HasTemplateKWAndArgsInfo = CurrentUnpackingBits->getNextBit();
-  bool HasFirstQualifierFoundInScope = CurrentUnpackingBits->getNextBit();
-
-  assert((HasTemplateKWAndArgsInfo == E->hasTemplateKWAndArgsInfo()) &&
-         "Wrong HasTemplateKWAndArgsInfo!");
-  assert(
-      (HasFirstQualifierFoundInScope == E->hasFirstQualifierFoundInScope()) &&
-      "Wrong HasFirstQualifierFoundInScope!");
-
-  if (HasTemplateKWAndArgsInfo)
-    ReadTemplateKWAndArgsInfo(
-        *E->getTrailingObjects<ASTTemplateKWAndArgsInfo>(),
-        E->getTrailingObjects<TemplateArgumentLoc>(), NumTemplateArgs);
-
-  assert((NumTemplateArgs == E->getNumTemplateArgs()) &&
-         "Wrong NumTemplateArgs!");
-
-  E->CXXDependentScopeMemberExprBits.IsArrow =
-      CurrentUnpackingBits->getNextBit();
-
-  E->BaseType = Record.readType();
-  E->QualifierLoc = Record.readNestedNameSpecifierLoc();
-  // not ImplicitAccess
-  if (CurrentUnpackingBits->getNextBit())
-    E->Base = Record.readSubExpr();
-  else
-    E->Base = nullptr;
-
-  E->CXXDependentScopeMemberExprBits.OperatorLoc = readSourceLocation();
-
-  if (HasFirstQualifierFoundInScope)
-    *E->getTrailingObjects<NamedDecl *>() = readDeclAs<NamedDecl>();
-
-  E->MemberNameInfo = Record.readDeclarationNameInfo();
-#endif
 }
 
 void
@@ -4116,16 +4076,6 @@ Stmt *ASTReader::ReadStmtFromStream(ModuleFile &F) {
       break;
 
     case EXPR_CXX_DEPENDENT_SCOPE_MEMBER: {
-
-#if 0
-      unsigned NumTemplateArgs = Record[ASTStmtReader::NumExprFields];
-      BitsUnpacker DependentScopeMemberBits(
-          Record[ASTStmtReader::NumExprFields + 1]);
-      bool HasTemplateKWAndArgsInfo = DependentScopeMemberBits.getNextBit();
-
-      bool HasFirstQualifierFoundInScope =
-          DependentScopeMemberBits.getNextBit();
-#endif
       BitsUnpacker DependentScopeMemberBits(
           Record[ASTStmtReader::NumExprFields]);
       bool HasQualifier = DependentScopeMemberBits.getNextBit();

--- a/clang/lib/Serialization/ASTReaderStmt.cpp
+++ b/clang/lib/Serialization/ASTReaderStmt.cpp
@@ -1993,6 +1993,43 @@ void ASTStmtReader::VisitCXXDependentScopeMemberExpr(
     CXXDependentScopeMemberExpr *E) {
   VisitExpr(E);
 
+  CurrentUnpackingBits.emplace(Record.readInt());
+  bool HasQualifier = CurrentUnpackingBits->getNextBit();
+  bool HasTemplateInfo = CurrentUnpackingBits->getNextBit();
+  unsigned NumUnqualifiedLookups = Record.readInt();
+  unsigned NumTemplateArgs = Record.readInt();
+  E->CXXDependentScopeMemberExprBits.HasQualifier = HasQualifier;
+  E->CXXDependentScopeMemberExprBits.NumUnqualifiedLookups = NumUnqualifiedLookups;
+  E->CXXDependentScopeMemberExprBits.HasTemplateKWAndArgsInfo = HasTemplateInfo;
+
+  E->BaseType = Record.readType();
+  E->CXXDependentScopeMemberExprBits.IsArrow = CurrentUnpackingBits->getNextBit();
+
+  if (CurrentUnpackingBits->getNextBit())
+    E->Base = Record.readSubExpr();
+  else
+    E->Base = nullptr;
+
+  E->OperatorLoc = Record.readSourceLocation();
+  E->MemberNameInfo = Record.readDeclarationNameInfo();
+
+  if (HasQualifier)
+    new (E->getTrailingObjects<NestedNameSpecifierLoc>())
+        NestedNameSpecifierLoc(Record.readNestedNameSpecifierLoc());
+
+  for (unsigned I = 0; I != NumUnqualifiedLookups; ++I) {
+    auto *FoundD = Record.readDeclAs<NamedDecl>();
+    auto AS = (AccessSpecifier)Record.readInt();
+    E->getTrailingObjects<DeclAccessPair>()[I] = DeclAccessPair::make(FoundD, AS);;
+  }
+
+  if (HasTemplateInfo)
+    ReadTemplateKWAndArgsInfo(
+        *E->getTrailingObjects<ASTTemplateKWAndArgsInfo>(),
+        E->getTrailingObjects<TemplateArgumentLoc>(), NumTemplateArgs);
+
+
+  #if 0
   unsigned NumTemplateArgs = Record.readInt();
   CurrentUnpackingBits.emplace(Record.readInt());
   bool HasTemplateKWAndArgsInfo = CurrentUnpackingBits->getNextBit();
@@ -2029,6 +2066,7 @@ void ASTStmtReader::VisitCXXDependentScopeMemberExpr(
     *E->getTrailingObjects<NamedDecl *>() = readDeclAs<NamedDecl>();
 
   E->MemberNameInfo = Record.readDeclarationNameInfo();
+  #endif
 }
 
 void
@@ -4075,6 +4113,8 @@ Stmt *ASTReader::ReadStmtFromStream(ModuleFile &F) {
       break;
 
     case EXPR_CXX_DEPENDENT_SCOPE_MEMBER: {
+
+      #if 0
       unsigned NumTemplateArgs = Record[ASTStmtReader::NumExprFields];
       BitsUnpacker DependentScopeMemberBits(
           Record[ASTStmtReader::NumExprFields + 1]);
@@ -4082,9 +4122,16 @@ Stmt *ASTReader::ReadStmtFromStream(ModuleFile &F) {
 
       bool HasFirstQualifierFoundInScope =
           DependentScopeMemberBits.getNextBit();
+      #endif
+      BitsUnpacker DependentScopeMemberBits(Record[ASTStmtReader::NumExprFields]);
+      bool HasQualifier = DependentScopeMemberBits.getNextBit();
+      bool HasTemplateInfo = DependentScopeMemberBits.getNextBit();
+      unsigned NumUnqualifiedLookups = Record[ASTStmtReader::NumExprFields + 1];
+      unsigned NumTemplateArgs = Record[ASTStmtReader::NumExprFields + 2];
+
       S = CXXDependentScopeMemberExpr::CreateEmpty(
-          Context, HasTemplateKWAndArgsInfo, NumTemplateArgs,
-          HasFirstQualifierFoundInScope);
+          Context, HasQualifier, NumUnqualifiedLookups,
+          HasTemplateInfo, NumTemplateArgs);
       break;
     }
 

--- a/clang/lib/Serialization/ASTReaderStmt.cpp
+++ b/clang/lib/Serialization/ASTReaderStmt.cpp
@@ -1999,11 +1999,13 @@ void ASTStmtReader::VisitCXXDependentScopeMemberExpr(
   unsigned NumUnqualifiedLookups = Record.readInt();
   unsigned NumTemplateArgs = Record.readInt();
   E->CXXDependentScopeMemberExprBits.HasQualifier = HasQualifier;
-  E->CXXDependentScopeMemberExprBits.NumUnqualifiedLookups = NumUnqualifiedLookups;
+  E->CXXDependentScopeMemberExprBits.NumUnqualifiedLookups =
+      NumUnqualifiedLookups;
   E->CXXDependentScopeMemberExprBits.HasTemplateKWAndArgsInfo = HasTemplateInfo;
 
   E->BaseType = Record.readType();
-  E->CXXDependentScopeMemberExprBits.IsArrow = CurrentUnpackingBits->getNextBit();
+  E->CXXDependentScopeMemberExprBits.IsArrow =
+      CurrentUnpackingBits->getNextBit();
 
   if (CurrentUnpackingBits->getNextBit())
     E->Base = Record.readSubExpr();
@@ -2020,7 +2022,9 @@ void ASTStmtReader::VisitCXXDependentScopeMemberExpr(
   for (unsigned I = 0; I != NumUnqualifiedLookups; ++I) {
     auto *FoundD = Record.readDeclAs<NamedDecl>();
     auto AS = (AccessSpecifier)Record.readInt();
-    E->getTrailingObjects<DeclAccessPair>()[I] = DeclAccessPair::make(FoundD, AS);;
+    E->getTrailingObjects<DeclAccessPair>()[I] =
+        DeclAccessPair::make(FoundD, AS);
+    ;
   }
 
   if (HasTemplateInfo)
@@ -2028,8 +2032,7 @@ void ASTStmtReader::VisitCXXDependentScopeMemberExpr(
         *E->getTrailingObjects<ASTTemplateKWAndArgsInfo>(),
         E->getTrailingObjects<TemplateArgumentLoc>(), NumTemplateArgs);
 
-
-  #if 0
+#if 0
   unsigned NumTemplateArgs = Record.readInt();
   CurrentUnpackingBits.emplace(Record.readInt());
   bool HasTemplateKWAndArgsInfo = CurrentUnpackingBits->getNextBit();
@@ -2066,7 +2069,7 @@ void ASTStmtReader::VisitCXXDependentScopeMemberExpr(
     *E->getTrailingObjects<NamedDecl *>() = readDeclAs<NamedDecl>();
 
   E->MemberNameInfo = Record.readDeclarationNameInfo();
-  #endif
+#endif
 }
 
 void
@@ -4114,7 +4117,7 @@ Stmt *ASTReader::ReadStmtFromStream(ModuleFile &F) {
 
     case EXPR_CXX_DEPENDENT_SCOPE_MEMBER: {
 
-      #if 0
+#if 0
       unsigned NumTemplateArgs = Record[ASTStmtReader::NumExprFields];
       BitsUnpacker DependentScopeMemberBits(
           Record[ASTStmtReader::NumExprFields + 1]);
@@ -4122,16 +4125,17 @@ Stmt *ASTReader::ReadStmtFromStream(ModuleFile &F) {
 
       bool HasFirstQualifierFoundInScope =
           DependentScopeMemberBits.getNextBit();
-      #endif
-      BitsUnpacker DependentScopeMemberBits(Record[ASTStmtReader::NumExprFields]);
+#endif
+      BitsUnpacker DependentScopeMemberBits(
+          Record[ASTStmtReader::NumExprFields]);
       bool HasQualifier = DependentScopeMemberBits.getNextBit();
       bool HasTemplateInfo = DependentScopeMemberBits.getNextBit();
       unsigned NumUnqualifiedLookups = Record[ASTStmtReader::NumExprFields + 1];
       unsigned NumTemplateArgs = Record[ASTStmtReader::NumExprFields + 2];
 
       S = CXXDependentScopeMemberExpr::CreateEmpty(
-          Context, HasQualifier, NumUnqualifiedLookups,
-          HasTemplateInfo, NumTemplateArgs);
+          Context, HasQualifier, NumUnqualifiedLookups, HasTemplateInfo,
+          NumTemplateArgs);
       break;
     }
 

--- a/clang/lib/Serialization/ASTWriterStmt.cpp
+++ b/clang/lib/Serialization/ASTWriterStmt.cpp
@@ -2023,7 +2023,7 @@ void ASTStmtWriter::VisitCXXDependentScopeMemberExpr(
     AddTemplateKWAndArgsInfo(*E->getTrailingObjects<ASTTemplateKWAndArgsInfo>(),
                              E->getTrailingObjects<TemplateArgumentLoc>());
 
-  #if 0
+#if 0
   // Don't emit anything here (or if you do you will have to update
   // the corresponding deserialization function).
   Record.push_back(E->getNumTemplateArgs());
@@ -2052,7 +2052,7 @@ void ASTStmtWriter::VisitCXXDependentScopeMemberExpr(
     Record.AddDeclRef(E->getFirstQualifierFoundInScope());
 
   Record.AddDeclarationNameInfo(E->MemberNameInfo);
-  #endif
+#endif
 
   Code = serialization::EXPR_CXX_DEPENDENT_SCOPE_MEMBER;
 }

--- a/clang/lib/Serialization/ASTWriterStmt.cpp
+++ b/clang/lib/Serialization/ASTWriterStmt.cpp
@@ -2023,37 +2023,6 @@ void ASTStmtWriter::VisitCXXDependentScopeMemberExpr(
     AddTemplateKWAndArgsInfo(*E->getTrailingObjects<ASTTemplateKWAndArgsInfo>(),
                              E->getTrailingObjects<TemplateArgumentLoc>());
 
-#if 0
-  // Don't emit anything here (or if you do you will have to update
-  // the corresponding deserialization function).
-  Record.push_back(E->getNumTemplateArgs());
-  CurrentPackingBits.updateBits();
-  CurrentPackingBits.addBit(E->hasTemplateKWAndArgsInfo());
-  CurrentPackingBits.addBit(E->hasFirstQualifierFoundInScope());
-
-  if (E->hasTemplateKWAndArgsInfo()) {
-    const ASTTemplateKWAndArgsInfo &ArgInfo =
-        *E->getTrailingObjects<ASTTemplateKWAndArgsInfo>();
-    AddTemplateKWAndArgsInfo(ArgInfo,
-                             E->getTrailingObjects<TemplateArgumentLoc>());
-  }
-
-  CurrentPackingBits.addBit(E->isArrow());
-
-  Record.AddTypeRef(E->getBaseType());
-  Record.AddNestedNameSpecifierLoc(E->getQualifierLoc());
-  CurrentPackingBits.addBit(!E->isImplicitAccess());
-  if (!E->isImplicitAccess())
-    Record.AddStmt(E->getBase());
-
-  Record.AddSourceLocation(E->getOperatorLoc());
-
-  if (E->hasFirstQualifierFoundInScope())
-    Record.AddDeclRef(E->getFirstQualifierFoundInScope());
-
-  Record.AddDeclarationNameInfo(E->MemberNameInfo);
-#endif
-
   Code = serialization::EXPR_CXX_DEPENDENT_SCOPE_MEMBER;
 }
 

--- a/clang/test/CXX/basic/basic.lookup/basic.lookup.classref/p1-cxx11.cpp
+++ b/clang/test/CXX/basic/basic.lookup/basic.lookup.classref/p1-cxx11.cpp
@@ -65,9 +65,7 @@ namespace PR11856 {
     if (it1->end < it1->end) { }
 
     X *x;
-    if (x->end < 7) { } // expected-error{{expected '>'}}
-                        // expected-note@-1{{to match this '<'}}
-                        // expected-error@-2{{expected unqualified-id}}
+    if (x->end < 7) { } // expected-error{{no member named 'end' in 'PR11856::X'}}
 
     Y *y;
     if (y->end < 7) { }

--- a/clang/test/CXX/basic/basic.lookup/basic.lookup.classref/p1-cxx11.cpp
+++ b/clang/test/CXX/basic/basic.lookup/basic.lookup.classref/p1-cxx11.cpp
@@ -55,15 +55,21 @@ namespace PR11856 {
 
   template<typename T> T *end(T*);
 
-  class X { };
+  struct X { };
+  struct Y {
+    int end;
+  };
   template <typename T>
   void Foo2() {
     T it1;
-    if (it1->end < it1->end) {
-    }
+    if (it1->end < it1->end) { }
 
     X *x;
-    if (x->end < 7) {  // expected-error{{no member named 'end' in 'PR11856::X'}}
-    }
+    if (x->end < 7) { } // expected-error{{expected '>'}}
+                        // expected-note@-1{{to match this '<'}}
+                        // expected-error@-2{{expected unqualified-id}}
+
+    Y *y;
+    if (y->end < 7) { }
   }
 }

--- a/clang/test/CXX/basic/basic.lookup/basic.lookup.classref/p1.cpp
+++ b/clang/test/CXX/basic/basic.lookup/basic.lookup.classref/p1.cpp
@@ -86,15 +86,21 @@ namespace PR11856 {
 
   template<typename T> T *end(T*);
 
-  class X { };
+  struct X { };
+  struct Y {
+    int end;
+  };
   template <typename T>
   void Foo2() {
     T it1;
-    if (it1->end < it1->end) {
-    }
+    if (it1->end < it1->end) { }
 
     X *x;
-    if (x->end < 7) {  // expected-error{{no member named 'end' in 'PR11856::X'}}
-    }
+    if (x->end < 7) { } // expected-error{{expected '>'}}
+                        // expected-note@-1{{to match this '<'}}
+                        // expected-error@-2{{expected unqualified-id}}
+
+    Y *y;
+    if (y->end < 7) { }
   }
 }

--- a/clang/test/CXX/basic/basic.lookup/basic.lookup.classref/p1.cpp
+++ b/clang/test/CXX/basic/basic.lookup/basic.lookup.classref/p1.cpp
@@ -96,9 +96,7 @@ namespace PR11856 {
     if (it1->end < it1->end) { }
 
     X *x;
-    if (x->end < 7) { } // expected-error{{expected '>'}}
-                        // expected-note@-1{{to match this '<'}}
-                        // expected-error@-2{{expected unqualified-id}}
+    if (x->end < 7) { } // expected-error{{no member named 'end' in 'PR11856::X'}}
 
     Y *y;
     if (y->end < 7) { }

--- a/clang/test/CXX/basic/basic.lookup/basic.lookup.qual/basic.lookup.qual.general/p3-example3.cpp
+++ b/clang/test/CXX/basic/basic.lookup/basic.lookup.qual/basic.lookup.qual.general/p3-example3.cpp
@@ -1,0 +1,27 @@
+// RUN: %clang_cc1 -std=c++23 %s -verify
+
+int f();
+
+struct A {
+  int B, C; // expected-note {{declared as a non-template here}}
+  template<int> using D = void;
+  using T = void;
+  void f();
+};
+
+using B = A;
+template<int> using C = A;
+template<int> using D = A;
+template<int> using X = A;
+
+template<class T>
+void g(T *p) {
+  p->X<0>::f(); // expected-error {{no member named 'X' in 'A'}}
+  p->template X<0>::f();
+  p->B::f();
+  p->template C<0>::f(); // expected-error {{'C' following the 'template' keyword does not refer to a template}}
+  p->template D<0>::f(); // expected-error {{type 'template D<0>' (aka 'void') cannot be used prior to '::' because it has no members}}
+  p->T::f(); // expected-error {{'A::T' (aka 'void') is not a class, namespace, or enumeration}}
+}
+
+template void g(A*); // expected-note {{in instantiation of}}

--- a/clang/test/CXX/basic/basic.lookup/basic.lookup.qual/basic.lookup.qual.general/p3.cpp
+++ b/clang/test/CXX/basic/basic.lookup/basic.lookup.qual/basic.lookup.qual.general/p3.cpp
@@ -1,0 +1,71 @@
+// RUN: %clang_cc1 -std=c++23 -Wno-unused %s -verify
+
+struct A {
+  int x;
+
+  template<typename T>
+  using C = A;
+};
+
+using B = A;
+
+template<typename T>
+using D = A;
+
+using E = void;
+
+struct F : A {
+  void non_template() {
+    this->x;
+    this->A::x;
+    this->B::x;
+    this->C<int>::x;
+    this->D<int>::x;
+    this->E::x; // expected-error {{'E' (aka 'void') is not a class, namespace, or enumeration}}
+  }
+};
+
+template<typename T>
+void not_instantiated(T t) {
+  t.x;
+  t.A::x;
+  t.B::x;
+  t.C<int>::x; // expected-error {{use 'template' keyword to treat 'C' as a dependent template name}}
+  t.template C<int>::x;
+  t.D<int>::x; // expected-error {{use 'template' keyword to treat 'D' as a dependent template name}}
+  t.template D<int>::x;
+  t.E::x;
+}
+
+template<typename T>
+void instantiated_valid(T t) {
+  t.x;
+  t.A::x;
+  t.B::x;
+  t.template C<int>::x;
+  t.template D<int>::x;
+  t.E::x;
+}
+
+template<typename T>
+void instantiated_invalid(T t) {
+  t.x;
+  t.A::x;
+  t.B::x; // expected-error {{'Invalid::B' (aka 'void') is not a class, namespace, or enumeration}}
+  t.template C<int>::x;
+  t.template D<int>::x; // expected-error {{'D' following the 'template' keyword does not refer to a template}}
+  t.E::x; // expected-error {{'E' (aka 'void') is not a class, namespace, or enumeration}}
+}
+
+struct Valid : A {
+  using E = A;
+};
+
+template void instantiated_valid(Valid);
+
+struct Invalid : A {
+  using B = void;
+  using D = A; // expected-note {{declared as a non-template here}}
+};
+
+template void instantiated_invalid(Invalid); // expected-note {{in instantiation of}}

--- a/clang/test/CXX/basic/basic.lookup/basic.lookup.qual/basic.lookup.qual.general/p3.cpp
+++ b/clang/test/CXX/basic/basic.lookup/basic.lookup.qual/basic.lookup.qual.general/p3.cpp
@@ -1,71 +1,98 @@
 // RUN: %clang_cc1 -std=c++23 -Wno-unused %s -verify
 
-struct A {
-  int x;
+namespace Unambiguous {
+  struct A {
+    int x;
+
+    template<typename T>
+    using C = A;
+  };
+
+  using B = A;
 
   template<typename T>
-  using C = A;
-};
+  using D = A;
 
-using B = A;
+  using E = void;
 
-template<typename T>
-using D = A;
+  struct F : A {
+    void non_template() {
+      this->x;
+      this->A::x;
+      this->B::x;
+      this->C<int>::x;
+      this->D<int>::x;
+      this->E::x; // expected-error {{'Unambiguous::E' (aka 'void') is not a class, namespace, or enumeration}}
+    }
+  };
 
-using E = void;
-
-struct F : A {
-  void non_template() {
-    this->x;
-    this->A::x;
-    this->B::x;
-    this->C<int>::x;
-    this->D<int>::x;
-    this->E::x; // expected-error {{'E' (aka 'void') is not a class, namespace, or enumeration}}
+  template<typename T>
+  void not_instantiated(T t) {
+    t.x;
+    t.A::x;
+    t.B::x;
+    t.C<int>::x; // expected-error {{use 'template' keyword to treat 'C' as a dependent template name}}
+    t.template C<int>::x;
+    t.D<int>::x; // expected-error {{use 'template' keyword to treat 'D' as a dependent template name}}
+    t.template D<int>::x;
+    t.E::x;
   }
-};
 
-template<typename T>
-void not_instantiated(T t) {
-  t.x;
-  t.A::x;
-  t.B::x;
-  t.C<int>::x; // expected-error {{use 'template' keyword to treat 'C' as a dependent template name}}
-  t.template C<int>::x;
-  t.D<int>::x; // expected-error {{use 'template' keyword to treat 'D' as a dependent template name}}
-  t.template D<int>::x;
-  t.E::x;
-}
+  template<typename T>
+  void instantiated_valid(T t) {
+    t.x;
+    t.A::x;
+    t.B::x;
+    t.template C<int>::x;
+    t.template D<int>::x;
+    t.E::x;
+  }
 
-template<typename T>
-void instantiated_valid(T t) {
-  t.x;
-  t.A::x;
-  t.B::x;
-  t.template C<int>::x;
-  t.template D<int>::x;
-  t.E::x;
-}
+  template<typename T>
+  void instantiated_invalid(T t) {
+    t.x;
+    t.A::x;
+    t.B::x; // expected-error {{'Unambiguous::Invalid::B' (aka 'void') is not a class, namespace, or enumeration}}
+    t.template C<int>::x;
+    t.template D<int>::x; // expected-error {{'D' following the 'template' keyword does not refer to a template}}
+    t.E::x; // expected-error {{'Unambiguous::E' (aka 'void') is not a class, namespace, or enumeration}}
+  }
 
-template<typename T>
-void instantiated_invalid(T t) {
-  t.x;
-  t.A::x;
-  t.B::x; // expected-error {{'Invalid::B' (aka 'void') is not a class, namespace, or enumeration}}
-  t.template C<int>::x;
-  t.template D<int>::x; // expected-error {{'D' following the 'template' keyword does not refer to a template}}
-  t.E::x; // expected-error {{'E' (aka 'void') is not a class, namespace, or enumeration}}
-}
+  struct Valid : A {
+    using E = A;
+  };
 
-struct Valid : A {
-  using E = A;
-};
+  template void instantiated_valid(Valid);
 
-template void instantiated_valid(Valid);
+  struct Invalid : A {
+    using B = void;
+    using D = A; // expected-note {{declared as a non-template here}}
+  };
 
-struct Invalid : A {
-  using B = void;
-  using D = A; // expected-note {{declared as a non-template here}}
-};
+  template void instantiated_invalid(Invalid); // expected-note {{in instantiation of}}
+} // namespace Unambiguous
 
-template void instantiated_invalid(Invalid); // expected-note {{in instantiation of}}
+namespace Ambiguous {
+  inline namespace N {
+    struct A { }; // expected-note {{candidate found by name lookup is 'Ambiguous::N::A'}}
+  }
+
+  struct A { }; // expected-note {{candidate found by name lookup is 'Ambiguous::A'}}
+
+  template<typename T>
+  void f(T t) {
+    t.A::x; // expected-error {{reference to 'A' is ambiguous}}
+  }
+
+  struct B {
+    using A = B;
+
+    int x;
+  };
+
+  struct C { };
+
+  template void f(B);
+  template void f(C); // expected-note {{in instantiation of}}
+
+} // namespace Ambiguous

--- a/clang/test/CXX/basic/basic.lookup/basic.lookup.qual/basic.lookup.qual.general/p3.cpp
+++ b/clang/test/CXX/basic/basic.lookup/basic.lookup.qual/basic.lookup.qual.general/p3.cpp
@@ -31,9 +31,9 @@ namespace Unambiguous {
     t.x;
     t.A::x;
     t.B::x;
-    t.C<int>::x; // expected-error {{use 'template' keyword to treat 'C' as a dependent template name}}
+    t.C<int>::x; // expected-warning {{use 'template' keyword to treat 'C' as a dependent template name}}
     t.template C<int>::x;
-    t.D<int>::x; // expected-error {{use 'template' keyword to treat 'D' as a dependent template name}}
+    t.D<int>::x; // expected-warning {{use 'template' keyword to treat 'D' as a dependent template name}}
     t.template D<int>::x;
     t.E::x;
   }

--- a/clang/test/CXX/class.derived/class.member.lookup/p8.cpp
+++ b/clang/test/CXX/class.derived/class.member.lookup/p8.cpp
@@ -47,8 +47,8 @@ template<typename T>
 void DerivedT<T>::Inner() {
   Derived1T<T>::Foo();
   Derived2T<T>::Member = 42;
-  this->Derived1T<T>::Foo(); // expected-error{{use 'template' keyword to treat 'Derived1T' as a dependent template name}}
-  this->Derived2T<T>::Member = 42; // expected-error{{use 'template' keyword to treat 'Derived2T' as a dependent template name}}
+  this->Derived1T<T>::Foo(); // expected-warning{{use 'template' keyword to treat 'Derived1T' as a dependent template name}}
+  this->Derived2T<T>::Member = 42; // expected-warning{{use 'template' keyword to treat 'Derived2T' as a dependent template name}}
   this->Foo(); // expected-error{{non-static member 'Foo' found in multiple base-class subobjects of type 'BaseT<int>'}}
 }
 

--- a/clang/test/CXX/class.derived/class.member.lookup/p8.cpp
+++ b/clang/test/CXX/class.derived/class.member.lookup/p8.cpp
@@ -47,8 +47,8 @@ template<typename T>
 void DerivedT<T>::Inner() {
   Derived1T<T>::Foo();
   Derived2T<T>::Member = 42;
-  this->Derived1T<T>::Foo();
-  this->Derived2T<T>::Member = 42;
+  this->Derived1T<T>::Foo(); // expected-error{{use 'template' keyword to treat 'Derived1T' as a dependent template name}}
+  this->Derived2T<T>::Member = 42; // expected-error{{use 'template' keyword to treat 'Derived2T' as a dependent template name}}
   this->Foo(); // expected-error{{non-static member 'Foo' found in multiple base-class subobjects of type 'BaseT<int>'}}
 }
 

--- a/clang/test/CXX/drs/cwg1xx.cpp
+++ b/clang/test/CXX/drs/cwg1xx.cpp
@@ -615,7 +615,6 @@ namespace cwg141 { // cwg141: 3.1
     //   cxx98-note@#cwg141-S {{lookup from the current scope refers here}}
     // expected-error@#cwg141-a {{no member named 'n' in 'cwg141::A::S<int>'; did you mean '::cwg141::S<int>::n'?}}
     //   expected-note@#cwg141-S {{'::cwg141::S<int>::n' declared here}}
-    // FIXME: we issue a useful diagnostic first, then some bogus ones.
     b.f<int>();
     // expected-error@-1 {{no member named 'f' in 'cwg141::B'}}
     (void)b.S<int>::n;

--- a/clang/test/CXX/drs/cwg1xx.cpp
+++ b/clang/test/CXX/drs/cwg1xx.cpp
@@ -618,7 +618,6 @@ namespace cwg141 { // cwg141: 3.1
     // FIXME: we issue a useful diagnostic first, then some bogus ones.
     b.f<int>();
     // expected-error@-1 {{no member named 'f' in 'cwg141::B'}}
-    // expected-error@-2 +{{}}
     (void)b.S<int>::n;
   }
   template<typename T> struct C {
@@ -628,10 +627,12 @@ namespace cwg141 { // cwg141: 3.1
       // expected-error@-1 {{use 'template' keyword to treat 'f' as a dependent template name}}
     }
     void h() {
-      (void)t.S<int>::n; // ok
+      (void)t.S<int>::n;
+      // expected-error@-1 {{use 'template' keyword to treat 'S' as a dependent template name}}
     }
     void i() {
-      (void)t.S<int>(); // ok!
+      (void)t.S<int>();
+      // expected-error@-1 {{use 'template' keyword to treat 'S' as a dependent template name}}
     }
   };
   void h() { C<B>().h(); } // ok

--- a/clang/test/CXX/drs/cwg3xx.cpp
+++ b/clang/test/CXX/drs/cwg3xx.cpp
@@ -443,7 +443,7 @@ namespace cwg329 { // cwg329: 3.5
     //   expected-note@#cwg329-b {{in instantiation of template class 'cwg329::A<char>' requested here}}
     //   expected-note@#cwg329-i {{previous definition is here}}
   };
-  A<int> a; 
+  A<int> a;
   A<char> b; // #cwg329-b
 
   void test() {
@@ -684,9 +684,9 @@ namespace cwg341 { // cwg341: sup 1708
   namespace B {
     extern "C" int &cwg341_a = cwg341_a;
     // expected-error@-1 {{redefinition of 'cwg341_a'}}
-    //   expected-note@#cwg341_a {{previous definition is here}} 
+    //   expected-note@#cwg341_a {{previous definition is here}}
   }
-  extern "C" void cwg341_b(); // #cwg341_b 
+  extern "C" void cwg341_b(); // #cwg341_b
 }
 int cwg341_a;
 // expected-error@-1 {{declaration of 'cwg341_a' in global scope conflicts with declaration with C language linkage}}
@@ -704,7 +704,7 @@ namespace cwg341 {
   // expected-error@-1 {{declaration of 'cwg341_d' with C language linkage conflicts with declaration in global scope}}
   //   expected-note@#cwg341_d {{declared in global scope here}}
 
-  namespace A { extern "C" int cwg341_e; } // #cwg341_e 
+  namespace A { extern "C" int cwg341_e; } // #cwg341_e
   namespace B { extern "C" void cwg341_e(); }
   // expected-error@-1 {{redefinition of 'cwg341_e' as different kind of symbol}}
   //   expected-note@#cwg341_e {{previous definition is here}}
@@ -1106,7 +1106,7 @@ namespace cwg364 { // cwg364: yes
 }
 
 // cwg366: yes
-#if "foo" // expected-error {{invalid token at start of a preprocessor expression}} 
+#if "foo" // expected-error {{invalid token at start of a preprocessor expression}}
 #endif
 
 namespace cwg367 { // cwg367: yes

--- a/clang/test/CXX/drs/cwg3xx.cpp
+++ b/clang/test/CXX/drs/cwg3xx.cpp
@@ -443,7 +443,7 @@ namespace cwg329 { // cwg329: 3.5
     //   expected-note@#cwg329-b {{in instantiation of template class 'cwg329::A<char>' requested here}}
     //   expected-note@#cwg329-i {{previous definition is here}}
   };
-  A<int> a;
+  A<int> a; 
   A<char> b; // #cwg329-b
 
   void test() {
@@ -684,9 +684,9 @@ namespace cwg341 { // cwg341: sup 1708
   namespace B {
     extern "C" int &cwg341_a = cwg341_a;
     // expected-error@-1 {{redefinition of 'cwg341_a'}}
-    //   expected-note@#cwg341_a {{previous definition is here}}
+    //   expected-note@#cwg341_a {{previous definition is here}} 
   }
-  extern "C" void cwg341_b(); // #cwg341_b
+  extern "C" void cwg341_b(); // #cwg341_b 
 }
 int cwg341_a;
 // expected-error@-1 {{declaration of 'cwg341_a' in global scope conflicts with declaration with C language linkage}}
@@ -704,7 +704,7 @@ namespace cwg341 {
   // expected-error@-1 {{declaration of 'cwg341_d' with C language linkage conflicts with declaration in global scope}}
   //   expected-note@#cwg341_d {{declared in global scope here}}
 
-  namespace A { extern "C" int cwg341_e; } // #cwg341_e
+  namespace A { extern "C" int cwg341_e; } // #cwg341_e 
   namespace B { extern "C" void cwg341_e(); }
   // expected-error@-1 {{redefinition of 'cwg341_e' as different kind of symbol}}
   //   expected-note@#cwg341_e {{previous definition is here}}
@@ -1106,7 +1106,7 @@ namespace cwg364 { // cwg364: yes
 }
 
 // cwg366: yes
-#if "foo" // expected-error {{invalid token at start of a preprocessor expression}}
+#if "foo" // expected-error {{invalid token at start of a preprocessor expression}} 
 #endif
 
 namespace cwg367 { // cwg367: yes

--- a/clang/test/CXX/drs/cwg4xx.cpp
+++ b/clang/test/CXX/drs/cwg4xx.cpp
@@ -20,7 +20,7 @@ namespace cwg400 { // cwg400: yes
   struct A { int a; struct a {}; }; // #cwg400-A
   struct B { int a; struct a {}; }; // #cwg400-B
   struct C : A, B { using A::a; struct a b; };
-  struct D : A, B { 
+  struct D : A, B {
     using A::a;
     // FIXME: we should issue a single diagnostic
     using B::a; // #cwg400-using-B-a

--- a/clang/test/CXX/drs/cwg4xx.cpp
+++ b/clang/test/CXX/drs/cwg4xx.cpp
@@ -20,7 +20,7 @@ namespace cwg400 { // cwg400: yes
   struct A { int a; struct a {}; }; // #cwg400-A
   struct B { int a; struct a {}; }; // #cwg400-B
   struct C : A, B { using A::a; struct a b; };
-  struct D : A, B {
+  struct D : A, B { 
     using A::a;
     // FIXME: we should issue a single diagnostic
     using B::a; // #cwg400-using-B-a

--- a/clang/test/CXX/temp/temp.names/p3-23.cpp
+++ b/clang/test/CXX/temp/temp.names/p3-23.cpp
@@ -1,0 +1,250 @@
+// RUN: %clang_cc1 -std=c++23 %s -verify
+
+namespace FoundNothing {
+  template<typename T>
+  void f0(T &t) {
+    t.x<0;
+    t.x<0>; // expected-error {{expected expression}}
+    t.x<0>1;
+  }
+
+  template<typename T>
+  struct A {
+    void f1() {
+      this->x<0; // expected-error {{no member named 'x' in 'A<T>'}}
+      this->x<0>; // expected-error {{expected expression}}
+                  // expected-error@-1 {{no member named 'x' in 'A<T>'}}
+      this->x<0>1; // expected-error {{no member named 'x' in 'A<T>'}}
+    }
+  };
+} // namespace FoundNothing
+
+namespace FoundSingleNonTemplate {
+  void f0();
+
+  struct A0;
+
+  template<typename T>
+  void g0(T &t) {
+    t.f0<0;
+    t.f0<0>; // expected-error {{expected expression}}
+    t.f0<0> 1;
+
+    t.A0<0;
+    t.A0<0>; // expected-error {{expected expression}}
+    t.A0<0>1;
+  }
+
+  template<typename T>
+  struct B {
+    void f1();
+
+    struct A1; // expected-note 3{{member 'A1' declared here}}
+
+    void g1() {
+      this->f0<0; // expected-error {{no member named 'f0' in 'B<T>'}}
+      this->f0<0>; // expected-error {{expected expression}}
+                   // expected-error@-1 {{no member named 'f0' in 'B<T>'}}
+      this->f0<0>1; // expected-error {{no member named 'f0' in 'B<T>'}}
+
+      this->A0<0; // expected-error {{no member named 'A0' in 'B<T>'}}
+      this->A0<0>; // expected-error {{expected expression}}
+                   // expected-error@-1 {{no member named 'A0' in 'B<T>'}}
+      this->A0<0>1; // expected-error {{no member named 'A0' in 'B<T>'}}
+
+      this->f1<0; // expected-error {{reference to non-static member function must be called}}
+      this->f1<0>; // expected-error {{expected expression}}
+                   // expected-error@-1 {{reference to non-static member function must be called}}
+      this->f1<0>1; // expected-error {{reference to non-static member function must be called}}
+
+      this->A1<0; // expected-error {{cannot refer to type member 'A1' in 'B<T>' with '->'}}
+      this->A1<0>; // expected-error {{expected expression}}
+                   // expected-error@-1 {{cannot refer to type member 'A1' in 'B<T>' with '->'}}
+      this->A1<0>1; // expected-error {{cannot refer to type member 'A1' in 'B<T>' with '->'}}
+    }
+  };
+} // namespace FoundSingleNonTemplate
+
+namespace FoundSingleTemplate {
+  template<int I>
+  void f0();
+
+  template<int I>
+  struct A0;
+
+  template<typename T>
+  void g0(T &t) {
+    t.f0<0;
+    t.f0<0>; // expected-error {{expected expression}}
+    t.f0<0>1;
+
+    t.A0<0;
+    t.A0<0>; // expected-error {{expected expression}}
+    t.A0<0>1;
+  }
+
+  template<typename T>
+  struct B {
+    template<int I>
+    void f1(); // expected-note 2{{possible target for call}}
+
+    template<int I>
+    struct A1; // expected-note 2{{member 'A1' declared here}}
+
+    void g1() {
+      this->f0<0; // expected-error {{expected '>'}}
+                  // expected-note@-1 {{to match this '<'}}
+                  // expected-error@-2 {{expected unqualified-id}}
+      this->f0<0>; // expected-error {{no member named 'f0' in 'B<T>'}}
+      this->f0<0>1; // expected-error {{no member named 'f0' in 'B<T>'}}
+                    // expected-error@-1 {{expected ';' after expression}}
+
+      this->A0<0; // expected-error {{expected '>'}}
+                  // expected-note@-1 {{to match this '<'}}
+                  // expected-error@-2 {{expected unqualified-id}}
+      this->A0<0>; // expected-error {{no member named 'A0' in 'B<T>'}}
+      this->A0<0>1; // expected-error {{no member named 'A0' in 'B<T>'}}
+                    // expected-error@-1 {{expected ';' after expression}}
+
+
+      this->f1<0; // expected-error {{expected '>'}}
+                  // expected-note@-1 {{to match this '<'}}
+                  // expected-error@-2 {{expected unqualified-id}}
+      this->f1<0>; // expected-error {{reference to non-static member function must be called}}
+      this->f1<0>1; // expected-error {{reference to non-static member function must be called}}
+                    // expected-error@-1 {{expected ';' after expression}}
+
+      this->A1<0; // expected-error {{expected '>'}}
+                  // expected-note@-1 {{to match this '<'}}
+                  // expected-error@-2 {{expected unqualified-id}}
+      this->A1<0>; // expected-error {{cannot refer to member 'A1' in 'B<T>' with '->'}}
+      this->A1<0>1; // expected-error {{cannot refer to member 'A1' in 'B<T>' with '->'}}
+                    // expected-error@-1 {{expected ';' after expression}}
+    }
+  };
+} // namespace FoundSingleTemplate
+
+namespace FoundAmbiguousNonTemplate {
+  inline namespace N {
+    int f0;
+
+    struct A0;
+  } // namespace N
+
+  void f0();
+
+  struct A0;
+
+  template<typename T>
+  void g0(T &t) {
+    t.f0<0;
+    t.f0<0>; // expected-error {{expected expression}}
+    t.f0<0>1;
+
+    t.A0<0;
+    t.A0<0>; // expected-error {{expected expression}}
+    t.A0<0>1;
+  }
+
+  template<typename T>
+  struct B {
+    void f1();
+
+    struct A1; // expected-note 3{{member 'A1' declared here}}
+
+    void g1() {
+      this->f0<0; // expected-error {{no member named 'f0' in 'B<T>'}}
+      this->f0<0>; // expected-error {{expected expression}}
+                   // expected-error@-1 {{no member named 'f0' in 'B<T>'}}
+      this->f0<0>1; // expected-error {{no member named 'f0' in 'B<T>'}}
+
+      this->A0<0; // expected-error {{no member named 'A0' in 'B<T>'}}
+      this->A0<0>; // expected-error {{expected expression}}
+                   // expected-error@-1 {{no member named 'A0' in 'B<T>'}}
+      this->A0<0>1; // expected-error {{no member named 'A0' in 'B<T>'}}
+
+      this->f1<0; // expected-error {{reference to non-static member function must be called}}
+      this->f1<0>; // expected-error {{expected expression}}
+                   // expected-error@-1 {{reference to non-static member function must be called}}
+      this->f1<0>1; // expected-error {{reference to non-static member function must be called}}
+
+      this->A1<0; // expected-error {{cannot refer to type member 'A1' in 'B<T>' with '->'}}
+      this->A1<0>; // expected-error {{expected expression}}
+                   // expected-error@-1 {{cannot refer to type member 'A1' in 'B<T>' with '->'}}
+      this->A1<0>1; // expected-error {{cannot refer to type member 'A1' in 'B<T>' with '->'}}
+    }
+  };
+} // namespace FoundAmbiguousNonTemplates
+
+namespace FoundAmbiguousTemplate {
+  inline namespace N {
+    template<int I>
+    int f0; // expected-note 3{{candidate found by name lookup is 'FoundAmbiguousTemplate::N::f0'}}
+
+    template<int I>
+    struct A0; // expected-note 3{{candidate found by name lookup is 'FoundAmbiguousTemplate::N::A0'}}
+  } // namespace N
+
+  template<int I>
+  void f0(); // expected-note 3{{candidate found by name lookup is 'FoundAmbiguousTemplate::f0'}}
+
+  template<int I>
+  struct A0; // expected-note 3{{candidate found by name lookup is 'FoundAmbiguousTemplate::A0'}}
+
+  template<typename T>
+  void g0(T &t) {
+    t.f0<0;
+    t.f0<0>; // expected-error {{expected expression}}
+    t.f0<0>1;
+
+    t.A0<0;
+    t.A0<0>; // expected-error {{expected expression}}
+    t.A0<0>1;
+  }
+
+  template<typename T>
+  struct B {
+    template<int I>
+    void f1(); // expected-note 2{{possible target for call}}
+
+    template<int I>
+    struct A1; // expected-note 2{{member 'A1' declared here}}
+
+    void g1() {
+      this->f0<0; // expected-error {{expected '>'}}
+                  // expected-note@-1 {{to match this '<'}}
+                  // expected-error@-2 {{expected unqualified-id}}
+                  // expected-error@-3 {{reference to 'f0' is ambiguous}}
+      this->f0<0>; // expected-error {{no member named 'f0' in 'B<T>'}}
+                   // expected-error@-1 {{reference to 'f0' is ambiguous}}
+      this->f0<0>1; // expected-error {{no member named 'f0' in 'B<T>'}}
+                    // expected-error@-1 {{expected ';' after expression}}
+                    // expected-error@-2 {{reference to 'f0' is ambiguous}}
+
+      this->A0<0; // expected-error {{expected '>'}}
+                  // expected-note@-1 {{to match this '<'}}
+                  // expected-error@-2 {{expected unqualified-id}}
+                  // expected-error@-3 {{reference to 'A0' is ambiguous}}
+      this->A0<0>; // expected-error {{no member named 'A0' in 'B<T>'}}
+                   // expected-error@-1 {{reference to 'A0' is ambiguous}}
+      this->A0<0>1; // expected-error {{no member named 'A0' in 'B<T>'}}
+                    // expected-error@-1 {{expected ';' after expression}}
+                    // expected-error@-2 {{reference to 'A0' is ambiguous}}
+
+
+      this->f1<0; // expected-error {{expected '>'}}
+                  // expected-note@-1 {{to match this '<'}}
+                  // expected-error@-2 {{expected unqualified-id}}
+      this->f1<0>; // expected-error {{reference to non-static member function must be called}}
+      this->f1<0>1; // expected-error {{reference to non-static member function must be called}}
+                    // expected-error@-1 {{expected ';' after expression}}
+
+      this->A1<0; // expected-error {{expected '>'}}
+                  // expected-note@-1 {{to match this '<'}}
+                  // expected-error@-2 {{expected unqualified-id}}
+      this->A1<0>; // expected-error {{cannot refer to member 'A1' in 'B<T>' with '->'}}
+      this->A1<0>1; // expected-error {{cannot refer to member 'A1' in 'B<T>' with '->'}}
+                    // expected-error@-1 {{expected ';' after expression}}
+    }
+  };
+} // namespace FoundAmbiguousTemplate

--- a/clang/test/CXX/temp/temp.names/p3-23.cpp
+++ b/clang/test/CXX/temp/temp.names/p3-23.cpp
@@ -92,16 +92,12 @@ namespace FoundSingleTemplate {
     struct A1; // expected-note 2{{member 'A1' declared here}}
 
     void g1() {
-      this->f0<0; // expected-error {{expected '>'}}
-                  // expected-note@-1 {{to match this '<'}}
-                  // expected-error@-2 {{expected unqualified-id}}
+      this->f0<0; // expected-error {{no member named 'f0' in 'B<T>'}}
       this->f0<0>; // expected-error {{no member named 'f0' in 'B<T>'}}
       this->f0<0>1; // expected-error {{no member named 'f0' in 'B<T>'}}
                     // expected-error@-1 {{expected ';' after expression}}
 
-      this->A0<0; // expected-error {{expected '>'}}
-                  // expected-note@-1 {{to match this '<'}}
-                  // expected-error@-2 {{expected unqualified-id}}
+      this->A0<0; // expected-error {{no member named 'A0' in 'B<T>'}}
       this->A0<0>; // expected-error {{no member named 'A0' in 'B<T>'}}
       this->A0<0>1; // expected-error {{no member named 'A0' in 'B<T>'}}
                     // expected-error@-1 {{expected ';' after expression}}
@@ -109,14 +105,12 @@ namespace FoundSingleTemplate {
 
       this->f1<0; // expected-error {{expected '>'}}
                   // expected-note@-1 {{to match this '<'}}
-                  // expected-error@-2 {{expected unqualified-id}}
       this->f1<0>; // expected-error {{reference to non-static member function must be called}}
       this->f1<0>1; // expected-error {{reference to non-static member function must be called}}
                     // expected-error@-1 {{expected ';' after expression}}
 
       this->A1<0; // expected-error {{expected '>'}}
                   // expected-note@-1 {{to match this '<'}}
-                  // expected-error@-2 {{expected unqualified-id}}
       this->A1<0>; // expected-error {{cannot refer to member 'A1' in 'B<T>' with '->'}}
       this->A1<0>1; // expected-error {{cannot refer to member 'A1' in 'B<T>' with '->'}}
                     // expected-error@-1 {{expected ';' after expression}}
@@ -211,37 +205,30 @@ namespace FoundAmbiguousTemplate {
     struct A1; // expected-note 2{{member 'A1' declared here}}
 
     void g1() {
-      this->f0<0; // expected-error {{expected '>'}}
-                  // expected-note@-1 {{to match this '<'}}
-                  // expected-error@-2 {{expected unqualified-id}}
-                  // expected-error@-3 {{reference to 'f0' is ambiguous}}
+      this->f0<0; // expected-error {{no member named 'f0' in 'B<T>'}}
+                  // expected-error@-1 {{reference to 'f0' is ambiguous}}
       this->f0<0>; // expected-error {{no member named 'f0' in 'B<T>'}}
                    // expected-error@-1 {{reference to 'f0' is ambiguous}}
       this->f0<0>1; // expected-error {{no member named 'f0' in 'B<T>'}}
                     // expected-error@-1 {{expected ';' after expression}}
                     // expected-error@-2 {{reference to 'f0' is ambiguous}}
 
-      this->A0<0; // expected-error {{expected '>'}}
-                  // expected-note@-1 {{to match this '<'}}
-                  // expected-error@-2 {{expected unqualified-id}}
-                  // expected-error@-3 {{reference to 'A0' is ambiguous}}
+      this->A0<0; // expected-error {{no member named 'A0' in 'B<T>'}}
+                  // expected-error@-1 {{reference to 'A0' is ambiguous}}
       this->A0<0>; // expected-error {{no member named 'A0' in 'B<T>'}}
                    // expected-error@-1 {{reference to 'A0' is ambiguous}}
       this->A0<0>1; // expected-error {{no member named 'A0' in 'B<T>'}}
                     // expected-error@-1 {{expected ';' after expression}}
                     // expected-error@-2 {{reference to 'A0' is ambiguous}}
 
-
       this->f1<0; // expected-error {{expected '>'}}
                   // expected-note@-1 {{to match this '<'}}
-                  // expected-error@-2 {{expected unqualified-id}}
       this->f1<0>; // expected-error {{reference to non-static member function must be called}}
       this->f1<0>1; // expected-error {{reference to non-static member function must be called}}
                     // expected-error@-1 {{expected ';' after expression}}
 
       this->A1<0; // expected-error {{expected '>'}}
                   // expected-note@-1 {{to match this '<'}}
-                  // expected-error@-2 {{expected unqualified-id}}
       this->A1<0>; // expected-error {{cannot refer to member 'A1' in 'B<T>' with '->'}}
       this->A1<0>1; // expected-error {{cannot refer to member 'A1' in 'B<T>' with '->'}}
                     // expected-error@-1 {{expected ';' after expression}}

--- a/clang/test/CXX/temp/temp.names/p3-23.cpp
+++ b/clang/test/CXX/temp/temp.names/p3-23.cpp
@@ -28,7 +28,7 @@ namespace FoundSingleNonTemplate {
   void g0(T &t) {
     t.f0<0;
     t.f0<0>; // expected-error {{expected expression}}
-    t.f0<0> 1;
+    t.f0<0>1;
 
     t.A0<0;
     t.A0<0>; // expected-error {{expected expression}}

--- a/clang/test/CXX/temp/temp.names/p3-23.cpp
+++ b/clang/test/CXX/temp/temp.names/p3-23.cpp
@@ -12,8 +12,8 @@ namespace FoundNothing {
   struct A {
     void f1() {
       this->x<0; // expected-error {{no member named 'x' in 'A<T>'}}
-      this->x<0>; // expected-error {{expected expression}}
-                  // expected-error@-1 {{no member named 'x' in 'A<T>'}}
+      this->x<0>; // expected-error {{no member named 'x' in 'A<T>'}}
+                  // expected-error@-1 {{expected expression}}
       this->x<0>1; // expected-error {{no member named 'x' in 'A<T>'}}
     }
   };
@@ -43,23 +43,23 @@ namespace FoundSingleNonTemplate {
 
     void g1() {
       this->f0<0; // expected-error {{no member named 'f0' in 'B<T>'}}
-      this->f0<0>; // expected-error {{expected expression}}
-                   // expected-error@-1 {{no member named 'f0' in 'B<T>'}}
+      this->f0<0>; // expected-error {{no member named 'f0' in 'B<T>'}}
+                   // expected-error@-1 {{expected expression}}
       this->f0<0>1; // expected-error {{no member named 'f0' in 'B<T>'}}
 
       this->A0<0; // expected-error {{no member named 'A0' in 'B<T>'}}
-      this->A0<0>; // expected-error {{expected expression}}
-                   // expected-error@-1 {{no member named 'A0' in 'B<T>'}}
+      this->A0<0>; // expected-error {{no member named 'A0' in 'B<T>'}}
+                   // expected-error@-1 {{expected expression}}
       this->A0<0>1; // expected-error {{no member named 'A0' in 'B<T>'}}
 
       this->f1<0; // expected-error {{reference to non-static member function must be called}}
-      this->f1<0>; // expected-error {{expected expression}}
-                   // expected-error@-1 {{reference to non-static member function must be called}}
+      this->f1<0>; // expected-error {{reference to non-static member function must be called}}
+                   // expected-error@-1 {{expected expression}}
       this->f1<0>1; // expected-error {{reference to non-static member function must be called}}
 
       this->A1<0; // expected-error {{cannot refer to type member 'A1' in 'B<T>' with '->'}}
-      this->A1<0>; // expected-error {{expected expression}}
-                   // expected-error@-1 {{cannot refer to type member 'A1' in 'B<T>' with '->'}}
+      this->A1<0>; // expected-error {{cannot refer to type member 'A1' in 'B<T>' with '->'}}
+                   // expected-error@-1 {{expected expression}}
       this->A1<0>1; // expected-error {{cannot refer to type member 'A1' in 'B<T>' with '->'}}
     }
   };
@@ -148,23 +148,23 @@ namespace FoundAmbiguousNonTemplate {
 
     void g1() {
       this->f0<0; // expected-error {{no member named 'f0' in 'B<T>'}}
-      this->f0<0>; // expected-error {{expected expression}}
-                   // expected-error@-1 {{no member named 'f0' in 'B<T>'}}
+      this->f0<0>; // expected-error {{no member named 'f0' in 'B<T>'}}
+                   // expected-error@-1 {{expected expression}}
       this->f0<0>1; // expected-error {{no member named 'f0' in 'B<T>'}}
 
       this->A0<0; // expected-error {{no member named 'A0' in 'B<T>'}}
-      this->A0<0>; // expected-error {{expected expression}}
-                   // expected-error@-1 {{no member named 'A0' in 'B<T>'}}
+      this->A0<0>; // expected-error {{no member named 'A0' in 'B<T>'}}
+                   // expected-error@-1 {{expected expression}}
       this->A0<0>1; // expected-error {{no member named 'A0' in 'B<T>'}}
 
       this->f1<0; // expected-error {{reference to non-static member function must be called}}
-      this->f1<0>; // expected-error {{expected expression}}
-                   // expected-error@-1 {{reference to non-static member function must be called}}
+      this->f1<0>; // expected-error {{reference to non-static member function must be called}}
+                   // expected-error@-1 {{expected expression}}
       this->f1<0>1; // expected-error {{reference to non-static member function must be called}}
 
       this->A1<0; // expected-error {{cannot refer to type member 'A1' in 'B<T>' with '->'}}
-      this->A1<0>; // expected-error {{expected expression}}
-                   // expected-error@-1 {{cannot refer to type member 'A1' in 'B<T>' with '->'}}
+      this->A1<0>; // expected-error {{cannot refer to type member 'A1' in 'B<T>' with '->'}}
+                   // expected-error@-1 {{expected expression}}
       this->A1<0>1; // expected-error {{cannot refer to type member 'A1' in 'B<T>' with '->'}}
     }
   };

--- a/clang/test/CXX/temp/temp.names/p3-23.cpp
+++ b/clang/test/CXX/temp/temp.names/p3-23.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -std=c++23 %s -verify
+// RUN: %clang_cc1 -std=c++23 -Wno-unused %s -verify
 
 namespace FoundNothing {
   template<typename T>

--- a/clang/test/CXX/temp/temp.res/p3.cpp
+++ b/clang/test/CXX/temp/temp.res/p3.cpp
@@ -30,6 +30,6 @@ template<typename T> int A<T>::template C<int>::*f5() {} // expected-error {{has
 template<typename T> template<typename U> struct A<T>::B {
   friend A<T>::C<T> f6(); // ok, same as 'friend T f6();'
 
-  friend A<U>::C<T> f7(); // expected-error {{use 'template' keyword to treat 'C' as a dependent template name}} expected-warning {{missing 'typename'}}
+  friend A<U>::C<T> f7(); // expected-warning {{use 'template' keyword to treat 'C' as a dependent template name}} expected-warning {{missing 'typename'}}
   friend A<U>::template C<T> f8(); // expected-warning {{missing 'typename'}}
 };

--- a/clang/test/FixIt/fixit.cpp
+++ b/clang/test/FixIt/fixit.cpp
@@ -158,12 +158,12 @@ public:
  
 template<class T>
 class F2  {
-  typename F1<T>:: /*template*/  Iterator<0> Mypos; // expected-error {{use 'template' keyword to treat 'Iterator' as a dependent template name}}
+  typename F1<T>:: /*template*/  Iterator<0> Mypos; // expected-warning {{use 'template' keyword to treat 'Iterator' as a dependent template name}}
 };
 
 template <class T>
 void f(){
-  typename F1<T>:: /*template*/ Iterator<0> Mypos; // expected-error {{use 'template' keyword to treat 'Iterator' as a dependent template name}}
+  typename F1<T>:: /*template*/ Iterator<0> Mypos; // expected-warning {{use 'template' keyword to treat 'Iterator' as a dependent template name}}
 }
 
 // Tests for &/* fixits

--- a/clang/test/Misc/warning-flags.c
+++ b/clang/test/Misc/warning-flags.c
@@ -21,6 +21,7 @@ The list of warnings below should NEVER grow.  It should gradually shrink to 0.
 CHECK: Warnings without flags (65):
 
 CHECK-NEXT:   ext_expected_semi_decl_list
+CHECK-NEXT:   ext_missing_dependent_template_keyword
 CHECK-NEXT:   ext_missing_whitespace_after_macro_name
 CHECK-NEXT:   ext_new_paren_array_nonconst
 CHECK-NEXT:   ext_plain_complex
@@ -61,7 +62,6 @@ CHECK-NEXT:   warn_invalid_cpu_supports
 CHECK-NEXT:   warn_maynot_respond
 CHECK-NEXT:   warn_method_param_redefinition
 CHECK-NEXT:   warn_missing_case_for_condition
-CHECK-NEXT:   warn_missing_dependent_template_keyword
 CHECK-NEXT:   warn_missing_whitespace_after_macro_name
 CHECK-NEXT:   warn_mt_message
 CHECK-NEXT:   warn_no_constructor_for_refconst

--- a/clang/test/Parser/cxx2a-concepts-requires-expr.cpp
+++ b/clang/test/Parser/cxx2a-concepts-requires-expr.cpp
@@ -78,7 +78,7 @@ bool r22 = requires { typename s::~s; };
 
 template<typename T>
 bool r23 = requires { typename identity<T>::temp<T>; };
-// expected-error@-1 {{use 'template' keyword to treat 'temp' as a dependent template name}}
+// expected-warning@-1 {{use 'template' keyword to treat 'temp' as a dependent template name}}
 
 template<typename T>
 bool r24 = requires {

--- a/clang/test/SemaCXX/cxx0x-noexcept-expression.cpp
+++ b/clang/test/SemaCXX/cxx0x-noexcept-expression.cpp
@@ -127,7 +127,7 @@ void f1() {
   // `dependent` should be type-dependent because the noexcept-expression should be value-dependent
   // (it is true if T is int*, false if T is Polymorphic<false, false>* for example)
   dependent.f<void>();  // This should need to be `.template f` to parse as a template
-  // expected-error@-1 {{use 'template' keyword to treat 'f' as a dependent template name}}
+  // expected-warning@-1 {{use 'template' keyword to treat 'f' as a dependent template name}}
 }
 template<typename... T>
 void f2() {
@@ -135,14 +135,14 @@ void f2() {
   // X<true> when T...[0] is a type with some operator&& which returns int*
   // X<false> when sizeof...(T) == 0
   dependent.f<void>();
-  // expected-error@-1 {{use 'template' keyword to treat 'f' as a dependent template name}}
+  // expected-warning@-1 {{use 'template' keyword to treat 'f' as a dependent template name}}
 }
 template<typename T>
 void f3() {
   X<noexcept(typeid(*static_cast<T*>(nullptr)))> dependent;
   // X<true> when T is int, X<false> when T is Polymorphic<false, false>
   dependent.f<void>();
-  // expected-error@-1 {{use 'template' keyword to treat 'f' as a dependent template name}}
+  // expected-warning@-1 {{use 'template' keyword to treat 'f' as a dependent template name}}
 }
 template<typename T>
 void f4() {

--- a/clang/test/SemaCXX/pseudo-destructors.cpp
+++ b/clang/test/SemaCXX/pseudo-destructors.cpp
@@ -22,21 +22,21 @@ void cv_test(const volatile T* cvt) {
 void f(A* a, Foo *f, int *i, double *d, int ii) {
   a->~A();
   a->A::~A();
-  
+
   a->~foo(); // expected-error{{undeclared identifier 'foo' in destructor name}}
-  
+
   a->~Bar(); // expected-error{{destructor type 'Bar' (aka 'Foo') in object destruction expression does not match the type 'A' of the object being destroyed}}
-  
+
   f->~Bar();
   f->~Foo();
   i->~Bar(); // expected-error{{does not match}}
-  
+
   g().~Bar(); // expected-error{{non-scalar}}
-  
+
   f->::~Bar(); // expected-error {{not a structure or union}}
   f->::Bar::~Bar();
   f->N::~Wibble(); // expected-error{{'N' does not refer to a type}} expected-error{{'Wibble' does not refer to a type}}
-  
+
   f->Bar::~Bar(17, 42); // expected-error{{cannot have any arguments}}
 
   i->~Integer();
@@ -148,12 +148,12 @@ namespace TwoPhaseLookup {
   namespace Template {
     template<typename T> struct Y {};
     template<class U> using G = Y<U>;
-    template<typename T> void f(T *p) { p->~G<int>(); } // expected-error {{no member named '~Y'}}
+    template<typename T> void f(T *p) { p->~G<int>(); } // expected-error {{no member named 'G'}}
     void h1(Y<int> *p) { p->~G<int>(); }
-    void h2(Y<int> *p) { f(p); }
+    void h2(Y<int> *p) { f(p); } // expected-note {{instantiation of}}
     namespace N { template<typename T> struct G {}; }
     void h3(N::G<int> *p) { p->~G<int>(); }
-    void h4(N::G<int> *p) { f(p); } // expected-note {{instantiation of}}
+    void h4(N::G<int> *p) { f(p); }
   }
 
   namespace TemplateUndeclared {

--- a/clang/test/SemaCXX/static-assert-cxx17.cpp
+++ b/clang/test/SemaCXX/static-assert-cxx17.cpp
@@ -96,7 +96,7 @@ void foo6() {
   // expected-error@-1{{static assertion failed due to requirement 'static_cast<const X<int> *>(nullptr)'}}
   static_assert((const X<typename T::T>[]){} == nullptr);
   // expected-error@-1{{static assertion failed due to requirement '(const X<int>[0]){} == nullptr'}}
-  static_assert(sizeof(X<decltype(X<typename T::T>().X<typename T::T>::~X())>) == 0);
+  static_assert(sizeof(X<decltype(X<typename T::T>().template X<typename T::T>::~X())>) == 0);
   // expected-error@-1{{static assertion failed due to requirement 'sizeof(X<void>) == 0'}} \
   // expected-note@-1 {{evaluates to '8 == 0'}}
   static_assert(constexpr_return_false<typename T::T, typename T::U>());

--- a/clang/test/SemaTemplate/dependent-base-classes.cpp
+++ b/clang/test/SemaTemplate/dependent-base-classes.cpp
@@ -1,12 +1,12 @@
 // RUN: %clang_cc1 -fsyntax-only -verify %s
 
 template<typename T, typename U>
-struct X0 : T::template apply<U> { 
+struct X0 : T::template apply<U> {
   X0(U u) : T::template apply<U>(u) { }
 };
 
 template<typename T, typename U>
-struct X1 : T::apply<U> { }; // expected-error{{use 'template' keyword to treat 'apply' as a dependent template name}}
+struct X1 : T::apply<U> { }; // expected-warning{{use 'template' keyword to treat 'apply' as a dependent template name}}
 
 template<typename T>
 struct X2 : vector<T> { }; // expected-error{{no template named 'vector'}}
@@ -85,7 +85,7 @@ namespace PR6081 {
   struct A { };
 
   template<typename T>
-  class B : public A<T> 
+  class B : public A<T>
   {
   public:
     template< class X >
@@ -109,9 +109,9 @@ namespace PR6081 {
 
 namespace PR6413 {
   template <typename T> class Base_A { };
-  
+
   class Base_B { };
-  
+
   template <typename T>
   class Derived
     : public virtual Base_A<T>
@@ -120,12 +120,12 @@ namespace PR6413 {
 }
 
 namespace PR5812 {
-  template <class T> struct Base { 
-    Base* p; 
-  }; 
+  template <class T> struct Base {
+    Base* p;
+  };
 
-  template <class T> struct Derived: public Base<T> { 
-    typename Derived::Base* p; // meaning Derived::Base<T> 
+  template <class T> struct Derived: public Base<T> {
+    typename Derived::Base* p; // meaning Derived::Base<T>
   };
 
   Derived<int> di;

--- a/clang/test/SemaTemplate/dependent-template-recover.cpp
+++ b/clang/test/SemaTemplate/dependent-template-recover.cpp
@@ -2,15 +2,15 @@
 template<typename T, typename U, int N>
 struct X {
   void f(T* t) {
-    t->f0<U>(); // expected-error{{use 'template' keyword to treat 'f0' as a dependent template name}}
-    t->f0<int>(); // expected-error{{use 'template' keyword to treat 'f0' as a dependent template name}}
+    t->f0<U>(); // expected-warning{{use 'template' keyword to treat 'f0' as a dependent template name}}
+    t->f0<int>(); // expected-warning{{use 'template' keyword to treat 'f0' as a dependent template name}}
 
-    t->operator+<U const, 1>(1); // expected-error{{use 'template' keyword to treat 'operator +' as a dependent template name}}
-    t->f1<int const, 2>(1); // expected-error{{use 'template' keyword to treat 'f1' as a dependent template name}}
+    t->operator+<U const, 1>(1); // expected-warning{{use 'template' keyword to treat 'operator +' as a dependent template name}}
+    t->f1<int const, 2>(1); // expected-warning{{use 'template' keyword to treat 'f1' as a dependent template name}}
     t->f1<3, int const>(1); // expected-error{{missing 'template' keyword prior to dependent template name 'f1'}}
 
-    T::getAs<U>(); // expected-error{{use 'template' keyword to treat 'getAs' as a dependent template name}}
-    t->T::getAs<U>(); // expected-error{{use 'template' keyword to treat 'getAs' as a dependent template name}}
+    T::getAs<U>(); // expected-warning{{use 'template' keyword to treat 'getAs' as a dependent template name}}
+    t->T::getAs<U>(); // expected-warning{{use 'template' keyword to treat 'getAs' as a dependent template name}}
 
     (*t).f2<N>(); // expected-error{{missing 'template' keyword prior to dependent template name 'f2'}}
     (*t).f2<0>(); // expected-error{{missing 'template' keyword prior to dependent template name 'f2'}}

--- a/clang/test/SemaTemplate/temp_arg_nontype_cxx20.cpp
+++ b/clang/test/SemaTemplate/temp_arg_nontype_cxx20.cpp
@@ -115,7 +115,7 @@ namespace CopyCounting {
   static_assert(f(X<A{}>()) == 0);
 
   template<A a> struct Y { void f(); };
-  template<A a> void g(Y<a> y) { y.Y<a>::f(); }
+  template<A a> void g(Y<a> y) { y.template Y<a>::f(); }
   void h() { constexpr A a; g<a>(Y<a>{}); }
 
   template<A a> struct Z {

--- a/clang/test/SemaTemplate/template-id-expr.cpp
+++ b/clang/test/SemaTemplate/template-id-expr.cpp
@@ -19,7 +19,7 @@ template<typename T>
 struct X0 {
   template<typename U>
   void f1();
-  
+
   template<typename U>
   void f2(U) {
     f1<U>();
@@ -39,9 +39,9 @@ struct Y {
 template<int I>
 struct X {
   X(int, int);
-  void f() { 
-    Y<X<I> >(X<I>(0, 0)); 
-    Y<X<I> >(::X<I>(0, 0)); 
+  void f() {
+    Y<X<I> >(X<I>(0, 0));
+    Y<X<I> >(::X<I>(0, 0));
   }
 };
 
@@ -149,11 +149,11 @@ struct Y2 : Y1<T> {
 
     int x;
     x = Y1::f4(0);
-    x = Y1::f4<int>(0); // expected-error {{use 'template'}} expected-error {{assigning to 'int' from incompatible type 'void'}}
+    x = Y1::f4<int>(0); // expected-warning {{use 'template'}} expected-error {{assigning to 'int' from incompatible type 'void'}}
     x = Y1::template f4(0); // expected-error {{assigning to 'int' from incompatible type 'void'}} expected-error {{a template argument list is expected after a name prefixed by the template keyword}}
 
     x = p->f4(0);
-    x = p->f4<int>(0); // expected-error {{assigning to 'int' from incompatible type 'void'}} expected-error {{use 'template'}}
+    x = p->f4<int>(0); // expected-error {{assigning to 'int' from incompatible type 'void'}} expected-warning {{use 'template'}}
     x = p->template f4(0); // expected-error {{assigning to 'int' from incompatible type 'void'}} expected-error {{a template argument list is expected after a name prefixed by the template keyword}}
   }
 };
@@ -184,7 +184,7 @@ class E {
 #if __cplusplus <= 199711L
 // expected-warning@+2 {{extension}}
 #endif
-template<typename T> using D = int; // expected-note {{declared here}} 
+template<typename T> using D = int; // expected-note {{declared here}}
 E<D> ed; // expected-note {{instantiation of}}
 
 namespace non_functions {

--- a/clang/test/SemaTemplate/typename-specifier-3.cpp
+++ b/clang/test/SemaTemplate/typename-specifier-3.cpp
@@ -46,7 +46,7 @@ namespace PR12884_half_fixed {
       typedef int arg;
     };
     struct C {
-      typedef typename B::X<typename B::arg> x; // expected-error {{use 'template'}} expected-error {{refers to non-type}}
+      typedef typename B::X<typename B::arg> x; // expected-warning {{use 'template'}} expected-error {{refers to non-type}}
     };
   };
 

--- a/libcxx/include/regex
+++ b/libcxx/include/regex
@@ -4214,7 +4214,7 @@ public:
   _LIBCPP_HIDE_FROM_ABI int compare(const value_type* __s) const { return str().compare(__s); }
 
   _LIBCPP_HIDE_FROM_ABI void swap(sub_match& __s) _NOEXCEPT_(__is_nothrow_swappable_v<_BidirectionalIterator>) {
-    this->pair<_BidirectionalIterator, _BidirectionalIterator>::swap(__s);
+    this->template pair<_BidirectionalIterator, _BidirectionalIterator>::swap(__s);
     std::swap(matched, __s.matched);
   }
 };


### PR DESCRIPTION
[CWG1835](https://cplusplus.github.io/CWG/issues/1835.html) was one of the many core issues resolved by [P1787R6: Declarations and where to find them](http://wg21.link/p1787r6). Its resolution changes how [member-qualified names](http://eel.is/c++draft/basic.lookup.qual.general#2) are looked up. This patch is a draft implementation of that resolution.

Previously, an _identifier_ following `.` or `->` would be first looked up in the type of the object expression (i.e. qualified lookup), and then in the context of the _postfix-expression_ (i.e. unqualified lookup) if nothing was found; the result of the second lookup was required to name a class template. Notably, this second lookup would occur even when the object expression was dependent, and its result would be used to determine whether a `<` token is the start of a _template-argument_list_. 

The new wording in [[basic.lookup.qual.general] p2](eel.is/c++draft/basic.lookup.qual.general#2) states:
> A member-qualified name is the (unique) component name, if any, of
> - an _unqualified-id_ or
> - a _nested-name-specifier_ of the form _`type-name ::`_ or _`namespace-name ::`​_
>
> in the id-expression of a class member access expression. A ***qualified name*** is
> - a member-qualified name or
> - the terminal name of
>     - a _qualified-id_,
>     - a _using-declarator_,
>     - a _typename-specifier_,
>     - a _qualified-namespace-specifier_, or
>     - a _nested-name-specifier_, _elaborated-type-specifier_, or _class-or-decltype_ that has a _nested-name-specifier_.
>
>  The _lookup context_ of a member-qualified name is the type of its associated object expression (considered dependent if the object expression is type-dependent). The lookup context of any other qualified name is the type, template, or namespace nominated by the preceding _nested-name-specifier_.

And [[basic.lookup.qual.general] p3](eel.is/c++draft/basic.lookup.qual.general#3) now states:
> _Qualified name lookup_ in a class, namespace, or enumeration performs a search of the scope associated with it except as specified below. Unless otherwise specified, a qualified name undergoes qualified name lookup in its lookup context from the point where it appears unless the lookup context either is dependent and is not the current instantiation or is not a class or class template. If nothing is found by qualified lookup for a member-qualified name that is the terminal name of a _nested-name-specifier_ and is not dependent, it undergoes unqualified lookup.

In non-standardese terms, these two paragraphs essentially state the following:
- A name that immediately follows `.` or `->` in a class member access expression is a member-qualified name
- A member-qualified name will be first looked up in the type of the object expression `T` unless `T` is a dependent type that is _not_ the current instantiation, e.g.
```cpp
template<typename T>
struct A
{
    void f(T* t)
    {
        this->x; // type of the object expression is 'A<T>'. although 'A<T>' is dependent, it is the
                 // current instantiation so we look up 'x' in the template definition context.
        
        t->y; // type of the object expression is 'T' ('->' is transformed to '.' per [expr.ref]). 
              // 'T' is dependent and is *not* the current instantiation, so we lookup 'y' in the 
              // template instantiation context.
    }
};
```
- If the first lookup finds nothing and:
    - the member-qualified name is the first component of a _nested-name-specifier_ (which could be an _identifier_ or a _simple-template-id_), and either:
        - the type of the object expression is the current instantiation and it has no dependent base classes, or
        - the type of the object expression is not dependent

  then we lookup the name again, this time via unqualified lookup.

Although the second (unqualified) lookup is stated not to occur when the member-qualified name is dependent, a dependent name will _not_ be dependent once the template is instantiated, so the second lookup must "occur" during instantiation if qualified lookup does not find anything. This means that we must perform the second (unqualified) lookup during parsing even when the type of the object expression is dependent, but those results are _not_ used to determine whether a `<` token is the start of a _template-argument_list_; they are stored so we can replicate the second lookup during instantiation. 

In even simpler terms (paraphrasing the [meeting minutes from the review of P1787](https://wiki.edg.com/bin/view/Wg21summer2020/P1787%28Lookup%29Review2020-06-15Through2020-06-18)):
- Unqualified lookup always happens for the first name in a _nested-name-specifier_ that follows `.` or `->`
- The result of that lookup is only used to determine whether `<` is the start of a _template-argument-list_ if the first (qualified) lookup found nothing and the lookup context:
    - is not dependent, or 
    - is the current instantiation and has no dependent base classes.

An example:
```cpp
struct A 
{
     void f();
};

template<typename T>
using B = A;

template<typename T>
struct C : A
{
    template<typename U>
    void g();

    void h(T* t)
    {
        this->g<int>(); // ok, '<' is the start of a template-argument-list ('g' was found via qualified lookup in the current instantiation)
        this->B<void>::f(); // ok, '<' is the start of a template-argument-list (current instantiation has no dependent bases, 'B' was found via unqualified lookup)
        t->g<int>(); // error: '<' means less than (unqualified lookup does not occur for a member-qualified name that isn't the first component of a nested-name-specifier)
        t->B<void>::f(); // error: '<' means less than (unqualified lookup does not occur if the name is dependent)
        t->template B<void>::f(); // ok: '<' is the start of a template-argument-list ('template' keyword used)
    }
};
```

Some additional notes:
- Per [[basic.lookup.qual.general] p1](http://eel.is/c++draft/basic.lookup.qual.general#1), lookup for a member-qualified name only considers namespaces, types, and templates whose specializations are types if it's an _identifier_ followed by `::`; lookup for the component name of a _simple-template-id_ followed by `::` is _not_ subject to this rule. 
- The wording which specifies when the second unqualified lookup occurs appears to be paradoxical. We are supposed to do it only for the first component name of a _nested-name-specifier_ that follows `.` or `->` when qualified lookup finds nothing. However, when that name is followed by `<` (potentially starting a _simple-template-id_) we don't _know_ whether it will be the start of a _nested-name-specifier_ until we do the lookup -- but we aren't supposed to do the lookup until we know it's part of a _nested-name-specifier_! ***However***, since we only do the second lookup when the first lookup finds nothing (and the name isn't dependent), ***and*** since neither lookup is type-only, the only valid option is for the name to be the _template-name_ in a _simple-template-id_ that is followed by `::` (it can't be an _unqualified-id_ naming a member because we already determined that the lookup context doesn't have a member with that name). Thus, we can lock into the _nested-name-specifier_ interpretation and do the second lookup without having to know whether the _simple-template-id_ will be followed by `::` yet.
