### PR TITLE
[Linker] Propagate `nobuiltin` attributes when linking known libcalls #89431

### DIFF
--- a/llvm/include/llvm/Linker/IRMover.h
+++ b/llvm/include/llvm/Linker/IRMover.h
@@ -12,11 +12,14 @@
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/FunctionExtras.h"
+#include "llvm/ADT/StringSet.h"
+#include "llvm/IR/GlobalValue.h"
+#include "llvm/Support/StringSaver.h"
+#include "llvm/TargetParser/Triple.h"
 #include <functional>
 
 namespace llvm {
 class Error;
-class GlobalValue;
 class Metadata;
 class Module;
 class StructType;
@@ -60,6 +63,26 @@ public:
     bool hasType(StructType *Ty);
   };
 
+  /// Utility for handling linking of known libcall functions. If a merged
+  /// module contains a recognized library call we can no longer perform any
+  /// libcall related transformations.
+  class LibcallHandler {
+    StringSet<> Libcalls;
+    StringSet<> Triples;
+
+    BumpPtrAllocator Alloc;
+    StringSaver Saver;
+
+  public:
+    LibcallHandler() : Saver(Alloc) {}
+
+    void updateLibcalls(const Triple &TheTriple);
+
+    bool checkLibcalls(GlobalValue &GV);
+
+    bool HasLibcalls = false;
+  };
+
   IRMover(Module &M);
 
   typedef std::function<void(GlobalValue &)> ValueAdder;
@@ -84,6 +107,7 @@ private:
   Module &Composite;
   IdentifiedStructTypeSet IdentifiedStructTypes;
   MDMapT SharedMDs; ///< A Metadata map to use for all calls to \a move().
+  LibcallHandler Libcalls;
 };
 
 } // End llvm namespace

--- a/llvm/lib/Linker/CMakeLists.txt
+++ b/llvm/lib/Linker/CMakeLists.txt
@@ -9,6 +9,7 @@ add_llvm_component_library(LLVMLinker
   intrinsics_gen
 
   LINK_COMPONENTS
+  Analysis
   Core
   Object
   Support

--- a/llvm/test/Linker/Inputs/has-libcalls.ll
+++ b/llvm/test/Linker/Inputs/has-libcalls.ll
@@ -1,0 +1,5 @@
+target triple = "x86_64-unknown-linux-gnu"
+
+!llvm.module.flags = !{!0}
+
+!0 = !{i32 4, !"llvm-libcalls", i32 1}

--- a/llvm/test/Linker/Inputs/strlen.ll
+++ b/llvm/test/Linker/Inputs/strlen.ll
@@ -1,0 +1,21 @@
+target triple = "x86_64-unknown-linux-gnu"
+
+define i64 @strlen(ptr %s) #0 {
+entry:
+  br label %for.cond
+
+for.cond:
+  %s.addr.0 = phi ptr [ %s, %entry ], [ %incdec.ptr, %for.cond ]
+  %0 = load i8, ptr %s.addr.0, align 1
+  %tobool.not = icmp eq i8 %0, 0
+  %incdec.ptr = getelementptr inbounds i8, ptr %s.addr.0, i64 1
+  br i1 %tobool.not, label %for.end, label %for.cond
+
+for.end:
+  %sub.ptr.lhs.cast = ptrtoint ptr %s.addr.0 to i64
+  %sub.ptr.rhs.cast = ptrtoint ptr %s to i64
+  %sub.ptr.sub = sub i64 %sub.ptr.lhs.cast, %sub.ptr.rhs.cast
+  ret i64 %sub.ptr.sub
+}
+
+attributes #0 = { noinline }

--- a/llvm/test/Linker/libcalls-module.ll
+++ b/llvm/test/Linker/libcalls-module.ll
@@ -1,0 +1,16 @@
+; RUN: llvm-link %s %S/Inputs/has-libcalls.ll -S -o - 2>%t.a.err | FileCheck %s
+; RUN: llvm-link %S/Inputs/has-libcalls.ll %s -S -o - 2>%t.a.err | FileCheck %s
+
+target triple = "x86_64-unknown-linux-gnu"
+
+; CHECK: define void @foo() #[[ATTR0:[0-9]+]]
+define void @foo() #0 {
+  ret void
+}
+
+attributes #0 = { noinline }
+
+; CHECK: attributes #[[ATTR0]] = { nobuiltin noinline "no-builtins" }
+
+; CHECK: !llvm.module.flags = !{!0}
+; CHECK: !0 = !{i32 4, !"llvm-libcalls", i32 1}

--- a/llvm/test/Linker/libcalls.ll
+++ b/llvm/test/Linker/libcalls.ll
@@ -1,0 +1,39 @@
+; RUN: llvm-link %s %S/Inputs/strlen.ll -S -o - 2>%t.a.err | FileCheck %s --check-prefix=CHECK1
+; RUN: llvm-link %S/Inputs/strlen.ll %s -S -o - 2>%t.a.err | FileCheck %s --check-prefix=CHECK2
+
+target triple = "x86_64-unknown-linux-gnu"
+
+@.str = private unnamed_addr constant [7 x i8] c"string\00", align 1
+@str = dso_local global ptr @.str, align 8
+
+define void @foo() #0 {
+  ret void
+}
+
+declare i64 @strlen(ptr)
+
+define void @bar() #0 {
+  ret void
+}
+
+define i64 @baz() #0 {
+entry:
+  %0 = load ptr, ptr @str, align 8
+  %call = call i64 @strlen(ptr noundef %0)
+  ret i64 %call
+}
+
+attributes #0 = { noinline }
+
+; CHECK1: define void @foo() #[[ATTR0:[0-9]+]]
+; CHECK1: define void @bar() #[[ATTR0:[0-9]+]]
+; CHECK1: define i64 @baz() #[[ATTR0:[0-9]+]]
+; CHECK1: define i64 @strlen(ptr [[S:%.*]]) #[[ATTR0]]
+
+; CHECK2: define i64 @strlen(ptr [[S:%.*]]) #[[ATTR0:[0-9]+]]
+; CHECK2: define void @foo() #[[ATTR0:[0-9]+]]
+; CHECK2: define void @bar() #[[ATTR0:[0-9]+]]
+; CHECK2: define i64 @baz() #[[ATTR0]]
+
+; CHECK1: attributes #[[ATTR0]] = { nobuiltin noinline "no-builtins" }
+; CHECK2: attributes #[[ATTR0]] = { nobuiltin noinline "no-builtins" }


### PR DESCRIPTION
Summary:
As discussed in
https://discourse.llvm.org/t/rfc-libc-ffreestanding-fno-builtin.

LLVM ascribes special semantics to several functions that are known to
be `libcalls`. These are functions that middle-end optimizations may
transforms calls into or perform optimizations based off of known
semantics. However, these assumptions require an opaque function call to
be known valid. In situations like LTO or IR linking it is possible to
bring a libcall definition into the current module. Once this happens,
we can no longer make any guarantees about the semantics of these
functions.

We currently attempt to solve this by preventing all inlining if the
called function has `no-builtin` https://reviews.llvm.org/D74162.
However, this is overly pessimistic as it prevents all inlining even for
non-libcall functions.

This patch modifies the IRMover class to track known libcalls enabled
for the given target. If we encounter a known libcall during IR linking,
we then need to append the `nobuiltin` attribute to the destination
module. Afterwards, all new definitions we link in will be applied as
well.
