### PR TITLE
LiveRangeEdit: Replace setIsDead with an assert

### DIFF
--- a/llvm/lib/CodeGen/LiveRangeEdit.cpp
+++ b/llvm/lib/CodeGen/LiveRangeEdit.cpp
@@ -414,7 +414,7 @@ void LiveRangeEdit::eliminateDeadDef(MachineInstr *MI, ToShrinkSet &ToShrink) {
       DeadRemats->insert(MI);
       const TargetRegisterInfo &TRI = *MRI.getTargetRegisterInfo();
       MI->substituteRegister(Dest, NewLI.reg(), 0, TRI);
-      MI->getOperand(0).setIsDead(true);
+      assert(MI->registerDefIsDead(NewLI.reg(), &TRI));
     } else {
       if (TheDelegate)
         TheDelegate->LRE_WillEraseInstruction(MI);


### PR DESCRIPTION
I noticed this was possibly buggy with implicit operands with the same dest register, and should maybe be using addRegisterDead. However, this is never called in a situation where the operand wasn't already marked dead. This is eliminateDeadDef, implying the def was already known to be dead.

Add an assert to detect inconsistencies in dead flags. This was apparently added in 9a16d655c71826bef98b7d6e9590e4494ac0e1a9.