### PR TITLE
Revert "Set ObjectFile's assignment operator to also be deleted like its copy constructor"

### DIFF
--- a/llvm/include/llvm/Object/ObjectFile.h
+++ b/llvm/include/llvm/Object/ObjectFile.h
@@ -302,7 +302,6 @@ protected:
 public:
   ObjectFile() = delete;
   ObjectFile(const ObjectFile &other) = delete;
-  ObjectFile &opeartor = (const ObjectFile &other) = delete;
 
   uint64_t getCommonSymbolSize(DataRefImpl Symb) const {
     Expected<uint32_t> SymbolFlagsOrErr = getSymbolFlags(Symb);


### PR DESCRIPTION
Reverts llvm/llvm-project#92942