### PR TITLE
[LLVM][Coroutines] Check variable decl scope instead of optimization level for hoisted DbgDeclare Loc

### DIFF
--- a/llvm/test/Transforms/Coroutines/coro-debug-frame-variable-inlined.ll
+++ b/llvm/test/Transforms/Coroutines/coro-debug-frame-variable-inlined.ll
@@ -1,5 +1,5 @@
-; RUN: opt < %s -passes='module(coro-early),cgscc(inline,coro-split<reuse-storage>)' -S | FileCheck %s
-; RUN: opt --try-experimental-debuginfo-iterators < %s -passes='module(coro-early),cgscc(inline,coro-split<reuse-storage>)' -S | FileCheck %s
+; RUN: opt < %s -passes='module(coro-early),cgscc(inline,coro-split)' -S | FileCheck %s
+; RUN: opt --try-experimental-debuginfo-iterators < %s -passes='module(coro-early),cgscc(inline,coro-split)' -S | FileCheck %s
 
 ; Simplified version from pr#75104.
 ; Make sure we do not update debug location for hosited dbg.declare intrinsics when optimizing coro frame.


### PR DESCRIPTION
Minor patch following up on https://github.com/llvm/llvm-project/pull/75402.

The more generalized version of [this error](https://github.com/llvm/llvm-project/pull/75104#issuecomment-1853497609) is whenever we have a debug variable created in one subprogram scope inlined into another subprogram scope. So instead of checking optimization level, it is safer to just check whether the subprogram scope of the variable matches the subprogram scope of the hoisted position.