### PR TITLE
Introduce __config_epilogue suitable for #undef-ing certain defines from __config

### DIFF
--- a/libcxx/include/CMakeLists.txt
+++ b/libcxx/include/CMakeLists.txt
@@ -1025,6 +1025,7 @@ set(files
   )
 
 configure_file("__config_site.in" "${LIBCXX_GENERATED_INCLUDE_TARGET_DIR}/__config_site" @ONLY)
+configure_file("__config_epilogie.in" "${LIBCXX_GENERATED_INCLUDE_TARGET_DIR}/__config_epilogue" @ONLY)
 configure_file("${LIBCXX_ASSERTION_HANDLER_FILE}" "${LIBCXX_GENERATED_INCLUDE_DIR}/__assertion_handler" COPYONLY)
 
 set(_all_includes "${LIBCXX_GENERATED_INCLUDE_TARGET_DIR}/__config_site"

--- a/libcxx/include/__config
+++ b/libcxx/include/__config
@@ -1462,4 +1462,6 @@ typedef __char32_t char32_t;
 
 #endif // __cplusplus
 
+#include <__config_epilogue>
+
 #endif // _LIBCPP___CONFIG

--- a/libcxx/include/__config_epilogue.in
+++ b/libcxx/include/__config_epilogue.in
@@ -1,0 +1,12 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _LIBCPP___CONFIG_SITE
+#define _LIBCPP___CONFIG_SITE
+
+#endif // _LIBCPP___CONFIG_SITE


### PR DESCRIPTION
Certain compilers (e. g. nvcc) do not handle certain features defined by `__has_feature()` builtins.

At the time we have the folloing epilogue

```
#if defined(__CUDACC__)    
    #undef _LIBCPP_DECLSPEC_EMPTY_BASES
    #define _LIBCPP_DECLSPEC_EMPTY_BASES

    #undef _LIBCPP_NODEBUG
    #define _LIBCPP_NODEBUG

    #undef _LIBCPP_PACKED
    #define _LIBCPP_PACKED

    #undef _LIBCPP_USING_IF_EXISTS
    #define _LIBCPP_USING_IF_EXISTS
#endif
```

This PR introduces builtin capability to undef certain flags.