### PR TITLE
LoopInfo: introduce Loop::getLocStr; unify debug output

### DIFF
--- a/llvm/include/llvm/Analysis/LoopInfo.h
+++ b/llvm/include/llvm/Analysis/LoopInfo.h
@@ -385,6 +385,11 @@ public:
   /// Return the source code span of the loop.
   LocRange getLocRange() const;
 
+  /// Return a string containing the location of the loop (file name + line
+  /// number if present, otherwise module name). Meant to be used for debug
+  /// printing within LLVM_DEBUG.
+  std::string getLocStr() const;
+
   StringRef getName() const {
     if (BasicBlock *Header = getHeader())
       if (Header->hasName())
@@ -690,7 +695,6 @@ llvm::MDNode *
 makePostTransformationMetadata(llvm::LLVMContext &Context, MDNode *OrigLoopID,
                                llvm::ArrayRef<llvm::StringRef> RemovePrefixes,
                                llvm::ArrayRef<llvm::MDNode *> AddAttrs);
-
 } // namespace llvm
 
 #endif

--- a/llvm/include/llvm/Analysis/LoopInfo.h
+++ b/llvm/include/llvm/Analysis/LoopInfo.h
@@ -385,8 +385,8 @@ public:
   /// Return the source code span of the loop.
   LocRange getLocRange() const;
 
-  /// Return a string containing the location of the loop (file name + line
-  /// number if present, otherwise module name). Meant to be used for debug
+  /// Return a string containing the debug location of the loop (file name +
+  /// line number if present, otherwise module name). Meant to be used for debug
   /// printing within LLVM_DEBUG.
   std::string getLocStr() const;
 

--- a/llvm/lib/Analysis/LoopAccessAnalysis.cpp
+++ b/llvm/lib/Analysis/LoopAccessAnalysis.cpp
@@ -2374,9 +2374,9 @@ void MemoryDepChecker::Dependence::print(
 
 bool LoopAccessInfo::canAnalyzeLoop() {
   // We need to have a loop header.
-  LLVM_DEBUG(dbgs() << "LAA: Found a loop in "
-                    << TheLoop->getHeader()->getParent()->getName() << ": "
-                    << TheLoop->getHeader()->getName() << '\n');
+  LLVM_DEBUG(dbgs() << "\nLAA: Checking a loop in '"
+                    << TheLoop->getHeader()->getParent()->getName() << "' from "
+                    << TheLoop->getLocStr() << "\n");
 
   // We can only analyze innermost loops.
   if (!TheLoop->isInnermost()) {
@@ -2403,6 +2403,8 @@ bool LoopAccessInfo::canAnalyzeLoop() {
     return false;
   }
 
+  LLVM_DEBUG(dbgs() << "LAA: Found a loop: " << TheLoop->getHeader()->getName()
+                    << "\n");
   return true;
 }
 

--- a/llvm/lib/Analysis/LoopAccessAnalysis.cpp
+++ b/llvm/lib/Analysis/LoopAccessAnalysis.cpp
@@ -2403,8 +2403,8 @@ bool LoopAccessInfo::canAnalyzeLoop() {
     return false;
   }
 
-  LLVM_DEBUG(dbgs() << "LAA: Found a loop: " << TheLoop->getHeader()->getName()
-                    << "\n");
+  LLVM_DEBUG(dbgs() << "LAA: Found an analyzable loop: "
+                    << TheLoop->getHeader()->getName() << "\n");
   return true;
 }
 

--- a/llvm/lib/Analysis/LoopInfo.cpp
+++ b/llvm/lib/Analysis/LoopInfo.cpp
@@ -663,6 +663,17 @@ Loop::LocRange Loop::getLocRange() const {
   return LocRange();
 }
 
+std::string Loop::getLocStr() const {
+  std::string Result;
+  raw_string_ostream OS(Result);
+  if (const DebugLoc LoopDbgLoc = getStartLoc())
+    LoopDbgLoc.print(OS);
+  else
+    // Just print the module name.
+    OS << getHeader()->getParent()->getParent()->getModuleIdentifier();
+  return Result;
+}
+
 #if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 LLVM_DUMP_METHOD void Loop::dump() const { print(dbgs()); }
 

--- a/llvm/lib/Transforms/Scalar/LoopDistribute.cpp
+++ b/llvm/lib/Transforms/Scalar/LoopDistribute.cpp
@@ -659,9 +659,9 @@ public:
   bool processLoop() {
     assert(L->isInnermost() && "Only process inner loops.");
 
-    LLVM_DEBUG(dbgs() << "\nLDist: In \""
-                      << L->getHeader()->getParent()->getName()
-                      << "\" checking " << *L << "\n");
+    LLVM_DEBUG(dbgs() << "\nLDist: Checking a loop in '"
+                      << L->getHeader()->getParent()->getName() << "' from "
+                      << L->getLocStr() << "\n");
 
     // Having a single exit block implies there's also one exiting block.
     if (!L->getExitBlock())
@@ -685,6 +685,9 @@ public:
     auto *Dependences = LAI->getDepChecker().getDependences();
     if (!Dependences || Dependences->empty())
       return fail("NoUnsafeDeps", "no unsafe dependences to isolate");
+
+    LLVM_DEBUG(dbgs() << "LDist: Found a loop: " << L->getHeader()->getName()
+                      << "\n");
 
     InstPartitionContainer Partitions(L, LI, DT);
 

--- a/llvm/lib/Transforms/Scalar/LoopDistribute.cpp
+++ b/llvm/lib/Transforms/Scalar/LoopDistribute.cpp
@@ -686,8 +686,8 @@ public:
     if (!Dependences || Dependences->empty())
       return fail("NoUnsafeDeps", "no unsafe dependences to isolate");
 
-    LLVM_DEBUG(dbgs() << "LDist: Found a loop: " << L->getHeader()->getName()
-                      << "\n");
+    LLVM_DEBUG(dbgs() << "LDist: Found a candidate loop: "
+                      << L->getHeader()->getName() << "\n");
 
     InstPartitionContainer Partitions(L, LI, DT);
 

--- a/llvm/lib/Transforms/Vectorize/LoopVectorize.cpp
+++ b/llvm/lib/Transforms/Vectorize/LoopVectorize.cpp
@@ -1027,23 +1027,6 @@ static void reportVectorization(OptimizationRemarkEmitter *ORE, Loop *TheLoop,
 
 } // end namespace llvm
 
-#ifndef NDEBUG
-/// \return string containing a file name and a line # for the given loop.
-static std::string getDebugLocString(const Loop *L) {
-  std::string Result;
-  if (L) {
-    raw_string_ostream OS(Result);
-    if (const DebugLoc LoopDbgLoc = L->getStartLoc())
-      LoopDbgLoc.print(OS);
-    else
-      // Just print the module name.
-      OS << L->getHeader()->getParent()->getParent()->getModuleIdentifier();
-    OS.flush();
-  }
-  return Result;
-}
-#endif
-
 namespace llvm {
 
 // Loop vectorization cost-model hints how the scalar epilogue loop should be
@@ -9836,13 +9819,9 @@ bool LoopVectorizePass::processLoop(Loop *L) {
   assert((EnableVPlanNativePath || L->isInnermost()) &&
          "VPlan-native path is not enabled. Only process inner loops.");
 
-#ifndef NDEBUG
-  const std::string DebugLocStr = getDebugLocString(L);
-#endif /* NDEBUG */
-
   LLVM_DEBUG(dbgs() << "\nLV: Checking a loop in '"
                     << L->getHeader()->getParent()->getName() << "' from "
-                    << DebugLocStr << "\n");
+                    << L->getLocStr() << "\n");
 
   LoopVectorizeHints Hints(L, InterleaveOnlyWhenForced, *ORE, TTI);
 
@@ -10112,7 +10091,7 @@ bool LoopVectorizePass::processLoop(Loop *L) {
     });
   } else if (VectorizeLoop && !InterleaveLoop) {
     LLVM_DEBUG(dbgs() << "LV: Found a vectorizable loop (" << VF.Width
-                      << ") in " << DebugLocStr << '\n');
+                      << ") in " << L->getLocStr() << '\n');
     ORE->emit([&]() {
       return OptimizationRemarkAnalysis(LV_NAME, IntDiagMsg.first,
                                         L->getStartLoc(), L->getHeader())
@@ -10120,7 +10099,7 @@ bool LoopVectorizePass::processLoop(Loop *L) {
     });
   } else if (VectorizeLoop && InterleaveLoop) {
     LLVM_DEBUG(dbgs() << "LV: Found a vectorizable loop (" << VF.Width
-                      << ") in " << DebugLocStr << '\n');
+                      << ") in " << L->getLocStr() << '\n');
     LLVM_DEBUG(dbgs() << "LV: Interleave Count is " << IC << '\n');
   }
 

--- a/llvm/test/Analysis/LoopAccessAnalysis/debug-loc.ll
+++ b/llvm/test/Analysis/LoopAccessAnalysis/debug-loc.ll
@@ -1,0 +1,33 @@
+; RUN: opt -passes='print<access-info>' -debug-only=loop-accesses \
+; RUN:   -disable-output -S %s 2>&1 | FileCheck %s
+
+define void @negative_step(ptr nocapture %A) {
+; CHECK-LABEL: LAA: Checking a loop in 'negative_step' from negative_step.c:5:2
+entry:
+  %A.plus.1 = getelementptr i32, ptr %A, i64 1
+  br label %loop
+
+loop:
+  %iv = phi i64 [ 1022, %entry ], [ %iv.next, %loop ]
+  %gep.A = getelementptr inbounds i32, ptr %A, i64 %iv
+  %l = load i32, ptr %gep.A, align 4
+  %add = add nsw i32 %l, 1
+  %gep.A.plus.1 = getelementptr i32, ptr %A.plus.1, i64 %iv
+  store i32 %add, ptr %gep.A.plus.1, align 4
+  %iv.next = add nsw i64 %iv, -1
+  %cmp.not = icmp eq i64 %iv, 0
+  br i1 %cmp.not, label %exit, label %loop, !dbg !2
+
+exit:
+  ret void
+}
+
+!llvm.module.flags = !{!5, !6, !7}
+
+!0 = !DIFile(filename: "negative_step.c", directory: "/")
+!1 = distinct !DISubprogram(name: "negative_step", scope: !0, file: !0, unit: !4)
+!2 = !DILocation(line: 5, column: 2, scope: !1)
+!4 = distinct !DICompileUnit(language: DW_LANG_C99, file: !0, producer: "clang")
+!5 = !{i32 1, !"Debug Info Version", i32 3}
+!6 = !{i32 2, !"Dwarf Version", i32 2}
+!7 = !{i32 1, !"PIC Level", i32 2}

--- a/llvm/test/Analysis/LoopAccessAnalysis/debug-loc.ll
+++ b/llvm/test/Analysis/LoopAccessAnalysis/debug-loc.ll
@@ -1,3 +1,4 @@
+; REQUIRES: asserts
 ; RUN: opt -passes='print<access-info>' -debug-only=loop-accesses \
 ; RUN:   -disable-output -S %s 2>&1 | FileCheck %s
 

--- a/llvm/test/Analysis/LoopAccessAnalysis/print-order.ll
+++ b/llvm/test/Analysis/LoopAccessAnalysis/print-order.ll
@@ -6,7 +6,8 @@
 ;    A[i+1] = A[i] + 1;
 ; }
 
-; CHECK: LAA: Found a loop in negative_step: loop
+; CHECK-LABEL: 'negative_step'
+; CHECK: LAA: Found a loop: loop
 ; CHECK: LAA: Checking memory dependencies
 ; CHECK-NEXT: LAA: Src Scev: {(4092 + %A),+,-4}<nw><%loop>Sink Scev: {(4088 + %A)<nuw>,+,-4}<nw><%loop>(Induction step: -1)
 ; CHECK-NEXT: LAA: Distance for   store i32 %add, ptr %gep.A.plus.1, align 4 to   %l = load i32, ptr %gep.A, align 4: -4
@@ -37,7 +38,8 @@ exit:
 ;    A[i-1] = A[i] + 1;
 ; }
 
-; CHECK: LAA: Found a loop in positive_step: loop
+; CHECK-LABEL: 'positive_step'
+; CHECK: LAA: Found a loop: loop
 ; CHECK: LAA: Checking memory dependencies
 ; CHECK-NEXT: LAA: Src Scev: {(4 + %A)<nuw>,+,4}<nuw><%loop>Sink Scev: {%A,+,4}<nw><%loop>(Induction step: 1)
 ; CHECK-NEXT: LAA: Distance for   %l = load i32, ptr %gep.A, align 4 to   store i32 %add, ptr %gep.A.minus.1, align 4: -4

--- a/llvm/test/Analysis/LoopAccessAnalysis/print-order.ll
+++ b/llvm/test/Analysis/LoopAccessAnalysis/print-order.ll
@@ -7,7 +7,7 @@
 ; }
 
 ; CHECK-LABEL: 'negative_step'
-; CHECK: LAA: Found a loop: loop
+; CHECK: LAA: Found an analyzable loop: loop
 ; CHECK: LAA: Checking memory dependencies
 ; CHECK-NEXT: LAA: Src Scev: {(4092 + %A),+,-4}<nw><%loop>Sink Scev: {(4088 + %A)<nuw>,+,-4}<nw><%loop>(Induction step: -1)
 ; CHECK-NEXT: LAA: Distance for   store i32 %add, ptr %gep.A.plus.1, align 4 to   %l = load i32, ptr %gep.A, align 4: -4
@@ -39,7 +39,7 @@ exit:
 ; }
 
 ; CHECK-LABEL: 'positive_step'
-; CHECK: LAA: Found a loop: loop
+; CHECK: LAA: Found an analyzable loop: loop
 ; CHECK: LAA: Checking memory dependencies
 ; CHECK-NEXT: LAA: Src Scev: {(4 + %A)<nuw>,+,4}<nuw><%loop>Sink Scev: {%A,+,4}<nw><%loop>(Induction step: 1)
 ; CHECK-NEXT: LAA: Distance for   %l = load i32, ptr %gep.A, align 4 to   store i32 %add, ptr %gep.A.minus.1, align 4: -4

--- a/llvm/test/Analysis/LoopAccessAnalysis/scalable-vector-regression-tests.ll
+++ b/llvm/test/Analysis/LoopAccessAnalysis/scalable-vector-regression-tests.ll
@@ -25,6 +25,7 @@ loop.end:
 }
 
 ; CHECK-LABEL: 'regression_test_loop_access_scalable_typesize'
+; CHECK: LAA: Found a loop: vector.body
 ; CHECK: LAA: Bad stride - Scalable object:
 define void @regression_test_loop_access_scalable_typesize(ptr %input_ptr) {
 entry:
@@ -43,6 +44,7 @@ end:
 }
 
 ; CHECK-LABEL: 'regression_test_loop_access_scalable_typesize_nonscalable_object'
+; CHECK: LAA: Found a loop: vector.body
 ; CHECK: LAA: Bad stride - Scalable object:
 define void @regression_test_loop_access_scalable_typesize_nonscalable_object(ptr %input_ptr) {
 entry:

--- a/llvm/test/Analysis/LoopAccessAnalysis/scalable-vector-regression-tests.ll
+++ b/llvm/test/Analysis/LoopAccessAnalysis/scalable-vector-regression-tests.ll
@@ -24,7 +24,7 @@ loop.end:
   ret void
 }
 
-; CHECK-LABEL: LAA: Found a loop in regression_test_loop_access_scalable_typesize
+; CHECK-LABEL: 'regression_test_loop_access_scalable_typesize'
 ; CHECK: LAA: Bad stride - Scalable object:
 define void @regression_test_loop_access_scalable_typesize(ptr %input_ptr) {
 entry:
@@ -42,7 +42,7 @@ end:
   ret void
 }
 
-; CHECK-LABEL: LAA: Found a loop in regression_test_loop_access_scalable_typesize_nonscalable_object
+; CHECK-LABEL: 'regression_test_loop_access_scalable_typesize_nonscalable_object'
 ; CHECK: LAA: Bad stride - Scalable object:
 define void @regression_test_loop_access_scalable_typesize_nonscalable_object(ptr %input_ptr) {
 entry:

--- a/llvm/test/Analysis/LoopAccessAnalysis/scalable-vector-regression-tests.ll
+++ b/llvm/test/Analysis/LoopAccessAnalysis/scalable-vector-regression-tests.ll
@@ -25,7 +25,7 @@ loop.end:
 }
 
 ; CHECK-LABEL: 'regression_test_loop_access_scalable_typesize'
-; CHECK: LAA: Found a loop: vector.body
+; CHECK: LAA: Found an analyzable loop: vector.body
 ; CHECK: LAA: Bad stride - Scalable object:
 define void @regression_test_loop_access_scalable_typesize(ptr %input_ptr) {
 entry:
@@ -44,7 +44,7 @@ end:
 }
 
 ; CHECK-LABEL: 'regression_test_loop_access_scalable_typesize_nonscalable_object'
-; CHECK: LAA: Found a loop: vector.body
+; CHECK: LAA: Found an analyzable loop: vector.body
 ; CHECK: LAA: Bad stride - Scalable object:
 define void @regression_test_loop_access_scalable_typesize_nonscalable_object(ptr %input_ptr) {
 entry:

--- a/llvm/test/Transforms/LoopDistribute/debug-loc.ll
+++ b/llvm/test/Transforms/LoopDistribute/debug-loc.ll
@@ -1,3 +1,4 @@
+; REQUIRES: asserts
 ; RUN: opt -passes=loop-distribute -enable-loop-distribute \
 ; RUN:   -debug-only=loop-distribute -disable-output 2>&1 %s | FileCheck %s
 

--- a/llvm/test/Transforms/LoopDistribute/debug-loc.ll
+++ b/llvm/test/Transforms/LoopDistribute/debug-loc.ll
@@ -2,18 +2,7 @@
 ; RUN:   -debug-only=loop-distribute -disable-output 2>&1 %s | FileCheck %s
 
 define void @f(ptr noalias %a, ptr noalias %b, ptr noalias %c, ptr noalias %d, i64 %stride) {
-; CHECK-LABEL: 'f'
-; CHECK:        LDist: Found a candidate loop: for.body
-; CHECK:        Backward dependences:
-; CHECK-NEXT:     Backward:
-; CHECK-NEXT:         %load.a = load i32, ptr %gep.a, align 4 ->
-; CHECK-NEXT:         store i32 %mul.a, ptr %gep.a.plus4, align 4
-; CHECK:        Seeded partitions:
-; CHECK:        Partition 0
-; CHECK:        Partition 1
-; CHECK:        Partition 2
-; CHECK:        Partition 3
-; CHECK:        Distributing loop
+; CHECK-LABEL: LDist: Checking a loop in 'f' from f.c:5:2
 entry:
   br label %for.body
 
@@ -36,8 +25,18 @@ for.body:                                         ; preds = %for.body, %entry
   %gep.c = getelementptr inbounds i32, ptr %c, i64 %ind
   store i32 %mul.c, ptr %gep.c, align 4
   %exitcond = icmp eq i64 %add, 20
-  br i1 %exitcond, label %exit, label %for.body
+  br i1 %exitcond, label %exit, label %for.body, !dbg !2
 
 exit:                                             ; preds = %for.body
   ret void
 }
+
+!llvm.module.flags = !{!5, !6, !7}
+
+!0 = !DIFile(filename: "f.c", directory: "/")
+!1 = distinct !DISubprogram(name: "f", scope: !0, file: !0, unit: !4)
+!2 = !DILocation(line: 5, column: 2, scope: !1)
+!4 = distinct !DICompileUnit(language: DW_LANG_C99, file: !0, producer: "clang")
+!5 = !{i32 1, !"Debug Info Version", i32 3}
+!6 = !{i32 2, !"Dwarf Version", i32 2}
+!7 = !{i32 1, !"PIC Level", i32 2}

--- a/llvm/test/Transforms/LoopDistribute/debug-print.ll
+++ b/llvm/test/Transforms/LoopDistribute/debug-print.ll
@@ -1,0 +1,43 @@
+; RUN: opt -passes=loop-distribute -enable-loop-distribute \
+; RUN:   -debug-only=loop-distribute -disable-output 2>&1 %s | FileCheck %s
+
+define void @f(ptr noalias %a, ptr noalias %b, ptr noalias %c, ptr noalias %d, i64 %stride) {
+; CHECK-LABEL: 'f'
+; CHECK:        LDist: Found a loop: for.body
+; CHECK:        Backward dependences:
+; CHECK-NEXT:     Backward:
+; CHECK-NEXT:         %load.a = load i32, ptr %gep.a, align 4 ->
+; CHECK-NEXT:         store i32 %mul.a, ptr %gep.a.plus4, align 4
+; CHECK:        Seeded partitions:
+; CHECK:        Partition 0
+; CHECK:        Partition 1
+; CHECK:        Partition 2
+; CHECK:        Partition 3
+; CHECK:        Distributing loop
+entry:
+  br label %for.body
+
+for.body:                                         ; preds = %for.body, %entry
+  %ind = phi i64 [ 0, %entry ], [ %add, %for.body ]
+  %gep.a = getelementptr inbounds i32, ptr %a, i64 %ind
+  %load.a = load i32, ptr %gep.a, align 4
+  %gep.b = getelementptr inbounds i32, ptr %b, i64 %ind
+  %load.b = load i32, ptr %gep.b, align 4
+  %mul.a = mul i32 %load.b, %load.a
+  %add = add nuw nsw i64 %ind, 1
+  %gep.a.plus4 = getelementptr inbounds i32, ptr %a, i64 %add
+  store i32 %mul.a, ptr %gep.a.plus4, align 4
+  %gep.d = getelementptr inbounds i32, ptr %d, i64 %ind
+  %loadD = load i32, ptr %gep.d, align 4
+  %mul = mul i64 %ind, %stride
+  %gep.strided.a = getelementptr inbounds i32, ptr %a, i64 %mul
+  %load.strided.a = load i32, ptr %gep.strided.a, align 4
+  %mul.c = mul i32 %loadD, %load.strided.a
+  %gep.c = getelementptr inbounds i32, ptr %c, i64 %ind
+  store i32 %mul.c, ptr %gep.c, align 4
+  %exitcond = icmp eq i64 %add, 20
+  br i1 %exitcond, label %exit, label %for.body
+
+exit:                                             ; preds = %for.body
+  ret void
+}

--- a/llvm/test/Transforms/LoopDistribute/debug-print.ll
+++ b/llvm/test/Transforms/LoopDistribute/debug-print.ll
@@ -1,3 +1,4 @@
+; REQUIRES: asserts
 ; RUN: opt -passes=loop-distribute -enable-loop-distribute \
 ; RUN:   -debug-only=loop-distribute -disable-output 2>&1 %s | FileCheck %s
 

--- a/llvm/test/Transforms/LoopVectorize/ARM/mve-hoist-runtime-checks.ll
+++ b/llvm/test/Transforms/LoopVectorize/ARM/mve-hoist-runtime-checks.ll
@@ -19,6 +19,7 @@ target triple = "thumbv8.1m.main-none-unknown-eabi"
 ; '(i * (n + 1))' vs '(i * n)'.
 
 ; DEBUG-LABEL: 'diff_checks'
+; DEBUG:      LAA: Found a loop: inner.loop
 ; DEBUG:      LAA: Not creating diff runtime check, since these  cannot be hoisted out of the outer loop
 ; DEBUG:      LAA: Adding RT check for range:
 ; DEBUG-NEXT: LAA: Expanded RT check for range to include outer loop in order to permit hoisting

--- a/llvm/test/Transforms/LoopVectorize/ARM/mve-hoist-runtime-checks.ll
+++ b/llvm/test/Transforms/LoopVectorize/ARM/mve-hoist-runtime-checks.ll
@@ -18,7 +18,7 @@ target triple = "thumbv8.1m.main-none-unknown-eabi"
 ; NOTE: The strides of the starting address values in the inner loop differ, i.e.
 ; '(i * (n + 1))' vs '(i * n)'.
 
-; DEBUG-LABEL: LAA: Found a loop in diff_checks:
+; DEBUG-LABEL: 'diff_checks'
 ; DEBUG:      LAA: Not creating diff runtime check, since these  cannot be hoisted out of the outer loop
 ; DEBUG:      LAA: Adding RT check for range:
 ; DEBUG-NEXT: LAA: Expanded RT check for range to include outer loop in order to permit hoisting

--- a/llvm/test/Transforms/LoopVectorize/ARM/mve-hoist-runtime-checks.ll
+++ b/llvm/test/Transforms/LoopVectorize/ARM/mve-hoist-runtime-checks.ll
@@ -19,7 +19,7 @@ target triple = "thumbv8.1m.main-none-unknown-eabi"
 ; '(i * (n + 1))' vs '(i * n)'.
 
 ; DEBUG-LABEL: 'diff_checks'
-; DEBUG:      LAA: Found a loop: inner.loop
+; DEBUG:      LAA: Found an analyzable loop: inner.loop
 ; DEBUG:      LAA: Not creating diff runtime check, since these  cannot be hoisted out of the outer loop
 ; DEBUG:      LAA: Adding RT check for range:
 ; DEBUG-NEXT: LAA: Expanded RT check for range to include outer loop in order to permit hoisting

--- a/llvm/test/Transforms/LoopVectorize/runtime-checks-hoist.ll
+++ b/llvm/test/Transforms/LoopVectorize/runtime-checks-hoist.ll
@@ -18,6 +18,7 @@ target datalayout = "e-m:e-i64:64-i128:128-n32:64-S128"
 ; '(i * (n + 1))' vs '(i * n)'.
 
 ; DEBUG-LABEL: 'diff_checks'
+; DEBUG:      LAA: Found a loop: inner.loop
 ; DEBUG:      LAA: Not creating diff runtime check, since these  cannot be hoisted out of the outer loop
 ; DEBUG:      LAA: Adding RT check for range:
 ; DEBUG-NEXT: LAA: Expanded RT check for range to include outer loop in order to permit hoisting
@@ -150,6 +151,7 @@ outer.exit:
 ; the additional load of 'dst[(i * n) + j]' in the loop.
 
 ; DEBUG-LABEL: 'full_checks'
+; DEBUG: LAA: Found a loop: inner.loop
 ; DEBUG-NOT: LAA: Creating diff runtime check for:
 ; DEBUG: LAA: Adding RT check for range:
 ; DEBUG-NEXT: LAA: Expanded RT check for range to include outer loop in order to permit hoisting
@@ -273,6 +275,7 @@ outer.exit:
 ; runtime checks will vary for each outer loop iteration.
 
 ; DEBUG-LABEL: 'full_checks_diff_strides'
+; DEBUG: LAA: Found a loop: inner.loop
 ; DEBUG-NOT: LAA: Creating diff runtime check for:
 ; DEBUG: LAA: Adding RT check for range:
 ; DEBUG-NEXT: LAA: Expanded RT check for range to include outer loop in order to permit hoisting
@@ -403,6 +406,7 @@ outer.exit:
 ; }
 
 ; DEBUG-LABEL: 'diff_checks_src_start_invariant'
+; DEBUG: LAA: Found a loop: inner.loop
 ; DEBUG-NOT: LAA: Expanded RT check for range to include outer loop in order to permit hoisting
 
 define void @diff_checks_src_start_invariant(ptr nocapture noundef writeonly %dst, ptr nocapture noundef readonly %src, i32 noundef %m, i32 noundef %n) {
@@ -509,6 +513,7 @@ outer.loop.exit:
 ; }
 
 ; DEBUG-LABEL: 'full_checks_src_start_invariant'
+; DEBUG:      LAA: Found a loop: inner.loop
 ; DEBUG:      LAA: Adding RT check for range:
 ; DEBUG-NEXT: LAA: Expanded RT check for range to include outer loop in order to permit hoisting
 ; DEBUG-NEXT: Start: %dst End: ((4 * (zext i32 %m to i64) * (zext i32 %n to i64)) + %dst)
@@ -630,6 +635,7 @@ outer.loop.exit:
 ; innermost loop. Hence we don't expand `src`, although in theory we could do.
 
 ; DEBUG-LABEL: 'triple_nested_loop_mixed_access'
+; DEBUG:      LAA: Found a loop: inner.loop
 ; DEBUG-NOT:  LAA: Creating diff runtime check for:
 ; DEBUG:      LAA: Adding RT check for range:
 ; DEBUG-NEXT: LAA: Expanded RT check for range to include outer loop in order to permit hoisting
@@ -796,6 +802,7 @@ exit:
 ; Outer loop trip count is uncomputable so we shouldn't expand the ranges.
 
 ; DEBUG-LABEL: 'uncomputable_outer_tc'
+; DEBUG:      LAA: Found a loop: inner.loop
 ; DEBUG:      LAA: Adding RT check for range:
 ; DEBUG-NEXT: Start: {%dst,+,(4 * (zext i32 (1 + %n) to i64))<nuw><nsw>}<%outer.loop> End: {((4 * (zext i32 %n to i64))<nuw><nsw> + %dst),+,(4 * (zext i32 (1 + %n) to i64))<nuw><nsw>}<%outer.loop>
 ; DEBUG-NEXT: LAA: Adding RT check for range:
@@ -946,6 +953,7 @@ while.end:
 ; runtime checks correctly to cover the whole loop.
 
 ; DEBUG-LABEL: 'decreasing_inner_iv'
+; DEBUG:      LAA: Found a loop: inner.loop
 ; DEBUG:      LAA: Adding RT check for range:
 ; DEBUG-NEXT: LAA: Expanded RT check for range to include outer loop in order to permit hoisting
 ; DEBUG-NEXT: LAA: ... but need to check stride is positive: (4 * (sext i32 %stride1 to i64))<nsw>
@@ -1112,6 +1120,7 @@ exit:
 ; upon the signedness of stride1.
 
 ; DEBUG-LABEL: 'decreasing_outer_iv'
+; DEBUG:      LAA: Found a loop: inner.loop
 ; DEBUG:      LAA: Adding RT check for range:
 ; DEBUG-NEXT: LAA: Expanded RT check for range to include outer loop in order to permit hoisting
 ; DEBUG-NEXT: LAA: ... but need to check stride is positive: (-4 * (sext i32 %stride1 to i64))<nsw>
@@ -1272,6 +1281,7 @@ exit:
 
 
 ; DEBUG-LABEL: 'unknown_inner_stride'
+; DEBUG:      LAA: Found a loop: inner.loop
 ; DEBUG:      LAA: Adding RT check for range:
 ; DEBUG-NEXT: LAA: Expanded RT check for range to include outer loop in order to permit hoisting
 ; DEBUG-NEXT: Start: %dst End: ((4 * (zext i32 %n to i64))<nuw><nsw> + (4 * (zext i32 (1 + %n) to i64) * (-1 + (zext i32 %m to i64))<nsw>) + %dst)

--- a/llvm/test/Transforms/LoopVectorize/runtime-checks-hoist.ll
+++ b/llvm/test/Transforms/LoopVectorize/runtime-checks-hoist.ll
@@ -17,7 +17,7 @@ target datalayout = "e-m:e-i64:64-i128:128-n32:64-S128"
 ; NOTE: The strides of the starting address values in the inner loop differ, i.e.
 ; '(i * (n + 1))' vs '(i * n)'.
 
-; DEBUG-LABEL: LAA: Found a loop in diff_checks:
+; DEBUG-LABEL: 'diff_checks'
 ; DEBUG:      LAA: Not creating diff runtime check, since these  cannot be hoisted out of the outer loop
 ; DEBUG:      LAA: Adding RT check for range:
 ; DEBUG-NEXT: LAA: Expanded RT check for range to include outer loop in order to permit hoisting
@@ -149,7 +149,7 @@ outer.exit:
 ; We decide to do full runtime checks here (as opposed to diff checks) due to
 ; the additional load of 'dst[(i * n) + j]' in the loop.
 
-; DEBUG-LABEL: LAA: Found a loop in full_checks:
+; DEBUG-LABEL: 'full_checks'
 ; DEBUG-NOT: LAA: Creating diff runtime check for:
 ; DEBUG: LAA: Adding RT check for range:
 ; DEBUG-NEXT: LAA: Expanded RT check for range to include outer loop in order to permit hoisting
@@ -272,7 +272,7 @@ outer.exit:
 ; is accessed with a higher stride compared src, and therefore the inner loop
 ; runtime checks will vary for each outer loop iteration.
 
-; DEBUG-LABEL: LAA: Found a loop in full_checks_diff_strides:
+; DEBUG-LABEL: 'full_checks_diff_strides'
 ; DEBUG-NOT: LAA: Creating diff runtime check for:
 ; DEBUG: LAA: Adding RT check for range:
 ; DEBUG-NEXT: LAA: Expanded RT check for range to include outer loop in order to permit hoisting
@@ -402,7 +402,7 @@ outer.exit:
 ;   }
 ; }
 
-; DEBUG-LABEL: LAA: Found a loop in diff_checks_src_start_invariant:
+; DEBUG-LABEL: 'diff_checks_src_start_invariant'
 ; DEBUG-NOT: LAA: Expanded RT check for range to include outer loop in order to permit hoisting
 
 define void @diff_checks_src_start_invariant(ptr nocapture noundef writeonly %dst, ptr nocapture noundef readonly %src, i32 noundef %m, i32 noundef %n) {
@@ -508,7 +508,7 @@ outer.loop.exit:
 ;   }
 ; }
 
-; DEBUG-LABEL: LAA: Found a loop in full_checks_src_start_invariant:
+; DEBUG-LABEL: 'full_checks_src_start_invariant'
 ; DEBUG:      LAA: Adding RT check for range:
 ; DEBUG-NEXT: LAA: Expanded RT check for range to include outer loop in order to permit hoisting
 ; DEBUG-NEXT: Start: %dst End: ((4 * (zext i32 %m to i64) * (zext i32 %n to i64)) + %dst)
@@ -629,7 +629,7 @@ outer.loop.exit:
 ; The 'src' access varies with the outermost loop, rather than the parent of the
 ; innermost loop. Hence we don't expand `src`, although in theory we could do.
 
-; DEBUG-LABEL: LAA: Found a loop in triple_nested_loop_mixed_access:
+; DEBUG-LABEL: 'triple_nested_loop_mixed_access'
 ; DEBUG-NOT:  LAA: Creating diff runtime check for:
 ; DEBUG:      LAA: Adding RT check for range:
 ; DEBUG-NEXT: LAA: Expanded RT check for range to include outer loop in order to permit hoisting
@@ -795,7 +795,7 @@ exit:
 ; }
 ; Outer loop trip count is uncomputable so we shouldn't expand the ranges.
 
-; DEBUG-LABEL: LAA: Found a loop in uncomputable_outer_tc:
+; DEBUG-LABEL: 'uncomputable_outer_tc'
 ; DEBUG:      LAA: Adding RT check for range:
 ; DEBUG-NEXT: Start: {%dst,+,(4 * (zext i32 (1 + %n) to i64))<nuw><nsw>}<%outer.loop> End: {((4 * (zext i32 %n to i64))<nuw><nsw> + %dst),+,(4 * (zext i32 (1 + %n) to i64))<nuw><nsw>}<%outer.loop>
 ; DEBUG-NEXT: LAA: Adding RT check for range:
@@ -945,7 +945,7 @@ while.end:
 ; Inner IV is decreasing, but this isn't a problem and we can still expand the
 ; runtime checks correctly to cover the whole loop.
 
-; DEBUG-LABEL: LAA: Found a loop in decreasing_inner_iv:
+; DEBUG-LABEL: 'decreasing_inner_iv'
 ; DEBUG:      LAA: Adding RT check for range:
 ; DEBUG-NEXT: LAA: Expanded RT check for range to include outer loop in order to permit hoisting
 ; DEBUG-NEXT: LAA: ... but need to check stride is positive: (4 * (sext i32 %stride1 to i64))<nsw>
@@ -1111,7 +1111,7 @@ exit:
 ; Outer IV is decreasing, but the direction of memory accesses also depends
 ; upon the signedness of stride1.
 
-; DEBUG-LABEL: LAA: Found a loop in decreasing_outer_iv:
+; DEBUG-LABEL: 'decreasing_outer_iv'
 ; DEBUG:      LAA: Adding RT check for range:
 ; DEBUG-NEXT: LAA: Expanded RT check for range to include outer loop in order to permit hoisting
 ; DEBUG-NEXT: LAA: ... but need to check stride is positive: (-4 * (sext i32 %stride1 to i64))<nsw>
@@ -1271,7 +1271,7 @@ exit:
 ; }
 
 
-; DEBUG-LABEL: LAA: Found a loop in unknown_inner_stride:
+; DEBUG-LABEL: 'unknown_inner_stride'
 ; DEBUG:      LAA: Adding RT check for range:
 ; DEBUG-NEXT: LAA: Expanded RT check for range to include outer loop in order to permit hoisting
 ; DEBUG-NEXT: Start: %dst End: ((4 * (zext i32 %n to i64))<nuw><nsw> + (4 * (zext i32 (1 + %n) to i64) * (-1 + (zext i32 %m to i64))<nsw>) + %dst)

--- a/llvm/test/Transforms/LoopVectorize/runtime-checks-hoist.ll
+++ b/llvm/test/Transforms/LoopVectorize/runtime-checks-hoist.ll
@@ -18,7 +18,7 @@ target datalayout = "e-m:e-i64:64-i128:128-n32:64-S128"
 ; '(i * (n + 1))' vs '(i * n)'.
 
 ; DEBUG-LABEL: 'diff_checks'
-; DEBUG:      LAA: Found a loop: inner.loop
+; DEBUG:      LAA: Found an analyzable loop: inner.loop
 ; DEBUG:      LAA: Not creating diff runtime check, since these  cannot be hoisted out of the outer loop
 ; DEBUG:      LAA: Adding RT check for range:
 ; DEBUG-NEXT: LAA: Expanded RT check for range to include outer loop in order to permit hoisting
@@ -151,7 +151,7 @@ outer.exit:
 ; the additional load of 'dst[(i * n) + j]' in the loop.
 
 ; DEBUG-LABEL: 'full_checks'
-; DEBUG: LAA: Found a loop: inner.loop
+; DEBUG: LAA: Found an analyzable loop: inner.loop
 ; DEBUG-NOT: LAA: Creating diff runtime check for:
 ; DEBUG: LAA: Adding RT check for range:
 ; DEBUG-NEXT: LAA: Expanded RT check for range to include outer loop in order to permit hoisting
@@ -275,7 +275,7 @@ outer.exit:
 ; runtime checks will vary for each outer loop iteration.
 
 ; DEBUG-LABEL: 'full_checks_diff_strides'
-; DEBUG: LAA: Found a loop: inner.loop
+; DEBUG: LAA: Found an analyzable loop: inner.loop
 ; DEBUG-NOT: LAA: Creating diff runtime check for:
 ; DEBUG: LAA: Adding RT check for range:
 ; DEBUG-NEXT: LAA: Expanded RT check for range to include outer loop in order to permit hoisting
@@ -406,7 +406,7 @@ outer.exit:
 ; }
 
 ; DEBUG-LABEL: 'diff_checks_src_start_invariant'
-; DEBUG: LAA: Found a loop: inner.loop
+; DEBUG: LAA: Found an analyzable loop: inner.loop
 ; DEBUG-NOT: LAA: Expanded RT check for range to include outer loop in order to permit hoisting
 
 define void @diff_checks_src_start_invariant(ptr nocapture noundef writeonly %dst, ptr nocapture noundef readonly %src, i32 noundef %m, i32 noundef %n) {
@@ -513,7 +513,7 @@ outer.loop.exit:
 ; }
 
 ; DEBUG-LABEL: 'full_checks_src_start_invariant'
-; DEBUG:      LAA: Found a loop: inner.loop
+; DEBUG:      LAA: Found an analyzable loop: inner.loop
 ; DEBUG:      LAA: Adding RT check for range:
 ; DEBUG-NEXT: LAA: Expanded RT check for range to include outer loop in order to permit hoisting
 ; DEBUG-NEXT: Start: %dst End: ((4 * (zext i32 %m to i64) * (zext i32 %n to i64)) + %dst)
@@ -635,7 +635,7 @@ outer.loop.exit:
 ; innermost loop. Hence we don't expand `src`, although in theory we could do.
 
 ; DEBUG-LABEL: 'triple_nested_loop_mixed_access'
-; DEBUG:      LAA: Found a loop: inner.loop
+; DEBUG:      LAA: Found an analyzable loop: inner.loop
 ; DEBUG-NOT:  LAA: Creating diff runtime check for:
 ; DEBUG:      LAA: Adding RT check for range:
 ; DEBUG-NEXT: LAA: Expanded RT check for range to include outer loop in order to permit hoisting
@@ -802,7 +802,7 @@ exit:
 ; Outer loop trip count is uncomputable so we shouldn't expand the ranges.
 
 ; DEBUG-LABEL: 'uncomputable_outer_tc'
-; DEBUG:      LAA: Found a loop: inner.loop
+; DEBUG:      LAA: Found an analyzable loop: inner.loop
 ; DEBUG:      LAA: Adding RT check for range:
 ; DEBUG-NEXT: Start: {%dst,+,(4 * (zext i32 (1 + %n) to i64))<nuw><nsw>}<%outer.loop> End: {((4 * (zext i32 %n to i64))<nuw><nsw> + %dst),+,(4 * (zext i32 (1 + %n) to i64))<nuw><nsw>}<%outer.loop>
 ; DEBUG-NEXT: LAA: Adding RT check for range:
@@ -953,7 +953,7 @@ while.end:
 ; runtime checks correctly to cover the whole loop.
 
 ; DEBUG-LABEL: 'decreasing_inner_iv'
-; DEBUG:      LAA: Found a loop: inner.loop
+; DEBUG:      LAA: Found an analyzable loop: inner.loop
 ; DEBUG:      LAA: Adding RT check for range:
 ; DEBUG-NEXT: LAA: Expanded RT check for range to include outer loop in order to permit hoisting
 ; DEBUG-NEXT: LAA: ... but need to check stride is positive: (4 * (sext i32 %stride1 to i64))<nsw>
@@ -1120,7 +1120,7 @@ exit:
 ; upon the signedness of stride1.
 
 ; DEBUG-LABEL: 'decreasing_outer_iv'
-; DEBUG:      LAA: Found a loop: inner.loop
+; DEBUG:      LAA: Found an analyzable loop: inner.loop
 ; DEBUG:      LAA: Adding RT check for range:
 ; DEBUG-NEXT: LAA: Expanded RT check for range to include outer loop in order to permit hoisting
 ; DEBUG-NEXT: LAA: ... but need to check stride is positive: (-4 * (sext i32 %stride1 to i64))<nsw>
@@ -1281,7 +1281,7 @@ exit:
 
 
 ; DEBUG-LABEL: 'unknown_inner_stride'
-; DEBUG:      LAA: Found a loop: inner.loop
+; DEBUG:      LAA: Found an analyzable loop: inner.loop
 ; DEBUG:      LAA: Adding RT check for range:
 ; DEBUG-NEXT: LAA: Expanded RT check for range to include outer loop in order to permit hoisting
 ; DEBUG-NEXT: Start: %dst End: ((4 * (zext i32 %n to i64))<nuw><nsw> + (4 * (zext i32 (1 + %n) to i64) * (-1 + (zext i32 %m to i64))<nsw>) + %dst)


### PR DESCRIPTION
Introduce a Loop::getLocStr stolen from LoopVectorize's static function getDebugLocString in order to have uniform debug output headers across LoopVectorize, LoopAccessAnalysis, and LoopDistribute. The motivation for this change is to have UpdateTestChecks recognize the headers and automatically generate CHECK lines for debug output, with minimal special-casing.