### PR TITLE
workflows: Disable stage2 of the release builds

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -156,6 +156,8 @@ jobs:
         rm build.tar.zst
 
     - name: Build Stage 2
+      # Re-enable once PGO builds are supported.
+      if: false
       run: |
         ninja -C /mnt/build stage2-instrumented
 


### PR DESCRIPTION
We need to skip this step until PGO is re-enabled for the release builds.