### PR TITLE
[Clang] [NFC] Add release note about libstdc++ bug

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -59,6 +59,18 @@ C++ Specific Potentially Breaking Changes
 - Clang now performs semantic analysis for unary operators with dependent operands
   that are known to be of non-class non-enumeration type prior to instantiation.
 
+  This change uncovered a bug in libstdc++ 14.1.0 which may cause compile failures
+  on systems using that version of libstdc++ and Clang 19, with an error that looks
+  something like this:
+
+  .. code-block:: text
+
+    <source>:4:5: error: expression is not assignable
+    4 |     ++this;
+      |     ^ ~~~~
+
+  To fix this, update libstdc++ to a newer version, such as 14.1.1 or 14.2.
+
 ABI Changes in This Version
 ---------------------------
 - Fixed Microsoft name mangling of implicitly defined variables used for thread

--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -69,7 +69,7 @@ C++ Specific Potentially Breaking Changes
     4 |     ++this;
       |     ^ ~~~~
 
-  To fix this, update libstdc++ to a newer version, such as 14.1.1 or 14.2.
+  To fix this, update libstdc++ to version 14.1.1 or greater.
 
 ABI Changes in This Version
 ---------------------------


### PR DESCRIPTION
Adding a release note about this as discussed in #92439. 

(This is an NFC change, but I’m adding you as reviewers in case there is anything you want to add to this since you were involved in the discussion.)