### PR TITLE
Set ObjectFile's assignment operator to also be deleted like its copy constructor

### DIFF
--- a/llvm/include/llvm/Object/ObjectFile.h
+++ b/llvm/include/llvm/Object/ObjectFile.h
@@ -302,6 +302,7 @@ protected:
 public:
   ObjectFile() = delete;
   ObjectFile(const ObjectFile &other) = delete;
+  ObjectFile &operator=(const ObjectFile &other) = delete;
 
   uint64_t getCommonSymbolSize(DataRefImpl Symb) const {
     Expected<uint32_t> SymbolFlagsOrErr = getSymbolFlags(Symb);


### PR DESCRIPTION
Reapply https://github.com/llvm/llvm-project/pull/92942, this time double checking it compiles. @vgvassilev, @compnerd.