### PR TITLE
[Clang] Remove parameter that shouldn't be there

### DIFF
--- a/clang/lib/CodeGen/CGExpr.cpp
+++ b/clang/lib/CodeGen/CGExpr.cpp
@@ -4701,7 +4701,7 @@ LValue CodeGenFunction::EmitLValueForLambdaField(const FieldDecl *Field,
     if (ThisTy != LambdaTy) {
       const CXXCastPath &BasePathArray = getContext().LambdaCastPaths.at(MD);
       Address Base = GetAddressOfBaseClass(
-          LambdaLV.getAddress(*this), ThisTy, BasePathArray.begin(),
+          LambdaLV.getAddress(), ThisTy, BasePathArray.begin(),
           BasePathArray.end(), /*NullCheckValue=*/false, SourceLocation());
       LambdaLV = MakeAddrLValue(Base, QualType{LambdaTy->getTypeForDecl(), 0});
     }


### PR DESCRIPTION
The parameter of `getAddress()` was not being used, as I recall, and seems to have been removed in the meantime. Merging this w/o review since this is breaking builds.