### PR TITLE
[AMDGPU] NFC: Add BBLiveOutMap & LiveOut Cache

### DIFF
--- a/llvm/lib/Target/AMDGPU/GCNSchedStrategy.cpp
+++ b/llvm/lib/Target/AMDGPU/GCNSchedStrategy.cpp
@@ -648,7 +648,7 @@ GCNScheduleDAGMILive::getBBLiveOutMap() const {
   for (; I != E; I++)
     BBEnders.push_back(getLastMIForRegion(I->first, I->second));
 
-  return getLiveRegMap(BBEnders, /*After= */true, *LIS);
+  return getLiveRegMap(BBEnders, /*After= */ true, *LIS);
 }
 
 void GCNScheduleDAGMILive::finalizeSchedule() {

--- a/llvm/lib/Target/AMDGPU/GCNSchedStrategy.cpp
+++ b/llvm/lib/Target/AMDGPU/GCNSchedStrategy.cpp
@@ -643,7 +643,6 @@ GCNScheduleDAGMILive::getBBLiveOutMap() const {
 
 void RegionPressureMap::buildLiveRegMap() {
   IdxToInstruction.clear();
-  BBLiveRegMap.clear();
 
   BBLiveRegMap = IsLiveOut ? DAG->getBBLiveOutMap() : DAG->getBBLiveInMap();
   for (unsigned I = 0; I < DAG->Regions.size(); I++) {

--- a/llvm/lib/Target/AMDGPU/GCNSchedStrategy.h
+++ b/llvm/lib/Target/AMDGPU/GCNSchedStrategy.h
@@ -205,6 +205,9 @@ class GCNScheduleDAGMILive final : public ScheduleDAGMILive {
   // Region live-in cache.
   SmallVector<GCNRPTracker::LiveRegSet, 32> LiveIns;
 
+  // Region live-out cache.
+  SmallVector<GCNRPTracker::LiveRegSet, 32> LiveOuts;
+
   // Region pressure cache.
   SmallVector<GCNRegPressure, 32> Pressure;
 
@@ -214,6 +217,10 @@ class GCNScheduleDAGMILive final : public ScheduleDAGMILive {
   DenseMap<MachineInstr *, GCNRPTracker::LiveRegSet> BBLiveInMap;
 
   DenseMap<MachineInstr *, GCNRPTracker::LiveRegSet> getBBLiveInMap() const;
+
+  DenseMap<MachineInstr *, GCNRPTracker::LiveRegSet> BBLiveOutMap;
+
+  DenseMap<MachineInstr *, GCNRPTracker::LiveRegSet> getBBLiveOutMap() const;
 
   // Return current region pressure.
   GCNRegPressure getRealRegPressure(unsigned RegionIdx) const;

--- a/llvm/lib/Target/AMDGPU/GCNSchedStrategy.h
+++ b/llvm/lib/Target/AMDGPU/GCNSchedStrategy.h
@@ -173,8 +173,6 @@ class RegionPressureMap {
   DenseMap<unsigned, MachineInstr *> IdxToInstruction;
   // Whether we are calculating LiveOuts or LiveIns
   bool IsLiveOut;
-  // Whether or not the maps have been generated
-  bool IsMapGenerated = false;
 
 public:
   RegionPressureMap() {}
@@ -185,7 +183,6 @@ public:
 
   // Retrieve the LiveReg for a given RegionIdx
   GCNRPTracker::LiveRegSet &getLiveRegsForRegionIdx(unsigned RegionIdx) {
-    assert(IsMapGenerated);
     assert(IdxToInstruction.find(RegionIdx) != IdxToInstruction.end());
     MachineInstr *Key = IdxToInstruction[RegionIdx];
     return BBLiveRegMap[Key];

--- a/llvm/lib/Target/AMDGPU/GCNSchedStrategy.h
+++ b/llvm/lib/Target/AMDGPU/GCNSchedStrategy.h
@@ -238,12 +238,21 @@ class GCNScheduleDAGMILive final : public ScheduleDAGMILive {
   // Temporary basic block live-in cache.
   DenseMap<const MachineBasicBlock *, GCNRPTracker::LiveRegSet> MBBLiveIns;
 
+  // The map of the initial first region instruction to region live in registers
   DenseMap<MachineInstr *, GCNRPTracker::LiveRegSet> BBLiveInMap;
 
-  DenseMap<MachineInstr *, GCNRPTracker::LiveRegSet> getBBLiveInMap() const;
+  // Calculate the map of the initial first region instruction to region live in
+  // registers
+  DenseMap<MachineInstr *, GCNRPTracker::LiveRegSet> getRegionLiveInMap() const;
 
-  DenseMap<MachineInstr *, GCNRPTracker::LiveRegSet> getBBLiveOutMap() const;
+  // Calculate the map of the initial last region instruction to region live out
+  // registers
+  DenseMap<MachineInstr *, GCNRPTracker::LiveRegSet>
+  getRegionLiveOutMap() const;
 
+  // The live out registers per region. These are internally stored as a map of
+  // the initial last region instruction to region live out registers, but can
+  // be retreived with the regionIdx by calls to getLiveRegsForRegionIdx.
   RegionPressureMap RegionLiveOuts;
 
   // Return current region pressure.


### PR DESCRIPTION
This is part of a series of PRs which enable using the GCNRPTrackers during scheduling. I've split them up to (hopefully) make reviewing easier. For context see https://github.com/llvm/llvm-project/pull/88797 .

This PR uses getLiveRegMap to calculate BBLiveOutMap, which ultimately provides the per-region liveouts to the RPTrackers.