### PR TITLE
[lldb] Fixed the TestExitDuringExpression test in case of a remote target

### DIFF
--- a/lldb/test/API/functionalities/thread/exit_during_expression/main.c
+++ b/lldb/test/API/functionalities/thread/exit_during_expression/main.c
@@ -3,7 +3,7 @@
 #include <stdio.h>
 #include <unistd.h>
 
-static unsigned int g_timeout = 100000;
+static unsigned int g_timeout = 1000000;
 
 extern int usleep(unsigned int);
 


### PR DESCRIPTION
Sometimes this test failed on the assert `The thread exited` in case of a remote target. Increase the timeout to 1 second to avoid a racing condition.