### PR TITLE
[libc++][test] Fix `new_delete_resource.pass.cpp` by passing correct size to `deallocate`

### DIFF
--- a/libcxx/test/std/utilities/utility/mem.res/mem.res.global/new_delete_resource.pass.cpp
+++ b/libcxx/test/std/utilities/utility/mem.res/mem.res.global/new_delete_resource.pass.cpp
@@ -76,7 +76,7 @@ void test_allocate_deallocate() {
   ASSERT_WITH_LIBRARY_INTERNAL_ALLOCATIONS(globalMemCounter.checkOutstandingNewEq(1));
   ASSERT_WITH_LIBRARY_INTERNAL_ALLOCATIONS(globalMemCounter.checkLastNewSizeEq(50));
 
-  r1.deallocate(ret, 1);
+  r1.deallocate(ret, 50);
   assert(globalMemCounter.checkOutstandingNewEq(0));
   ASSERT_WITH_LIBRARY_INTERNAL_ALLOCATIONS(globalMemCounter.checkDeleteCalledEq(1));
 }


### PR DESCRIPTION
`memory_resource` requires that the value passed to `deallocate` matches the argument of `allocate` ([\[mem.res.private\]/4](http://eel.is/c++draft/mem.res.private#4)). Apparently this matters for ASAN (see https://lab.llvm.org/buildbot/#/builders/168/builds/20464).