### PR TITLE
[clang][AST] fix ast-print of `extern <lang>` with >=2 declarators

### DIFF
--- a/clang/test/AST/ast-print-language-linkage.cpp
+++ b/clang/test/AST/ast-print-language-linkage.cpp
@@ -1,0 +1,31 @@
+// RUN: %clang_cc1 -ast-print %s -o - | FileCheck %s
+
+// CHECK: extern "C" int printf(const char *, ...);
+extern "C" int printf(const char *...);
+
+// CHECK: extern "C++" int f(int);
+// CHECK-NEXT: extern "C++" int g(int);
+extern "C++" int f(int), g(int);
+
+// CHECK: extern "C" char a;
+// CHECK-NEXT: extern "C" char b;
+extern "C" char a, b;
+
+// CHECK: extern "C" {
+// CHECK-NEXT:  void foo();
+// CHECK-NEXT:  int x;
+// CHECK-NEXT:  int y;
+// CHECK-NEXT:  extern short z;
+// CHECK-NEXT: }
+extern "C" {
+  void foo(void);
+  int x, y;
+  extern short z;
+}
+
+// CHECK: extern "C" {
+// CHECK-NEXT: }
+extern "C" {}
+
+// CHECK: extern "C++";
+extern "C++";


### PR DESCRIPTION
Problem: the printer used to ignore all but the first declarator for unbraced language linkage declarators. Furthemore, that one would be printed without the final semicolon.

Solution: when there is more than one declarator, we print them in a braced `extern <lang>` block. If the original declaration was unbraced and there is one or less declarator, we omit the braces, but add the semicolon.

**N.B.** We are printing braces which were, in some cases, absent from the original CST. If that's an issue, I'll work on it. See the tests for the examples.