### PR TITLE
[TableGen][CMake] Add missing dependency to intrinsics_gen

### DIFF
--- a/llvm/utils/TableGen/Common/CMakeLists.txt
+++ b/llvm/utils/TableGen/Common/CMakeLists.txt
@@ -40,6 +40,7 @@ add_llvm_library(LLVMTableGenCommon STATIC OBJECT EXCLUDE_FROM_ALL
 
   DEPENDS
   vt_gen
+  intrinsics_gen
   )
 set_target_properties(LLVMTableGenCommon PROPERTIES FOLDER "Tablegenning")
 


### PR DESCRIPTION
A missing dependency resulted in `fatal error: 'llvm/IR/Attributes.inc' file not found` errors when performing an Apple-stage2 build with LLVM_ENABLE_MODULES enabled.
This resolves the scheduling issue when building LLVMTableGenCommon library target.

resolves: rdar://128536914