### PR TITLE
[WindowsManifestMerger] Remove deprecated call to xmlKeepBlanksDefault

### DIFF
--- a/llvm/lib/WindowsManifest/WindowsManifestMerger.cpp
+++ b/llvm/lib/WindowsManifest/WindowsManifestMerger.cpp
@@ -669,7 +669,6 @@ WindowsManifestMerger::WindowsManifestMergerImpl::getMergedManifest() {
     xmlDocSetRootElement(OutputDoc.get(), CombinedRoot);
     assert(nullptr == xmlDocGetRootElement(CombinedDoc));
 
-    xmlKeepBlanksDefault(0);
     xmlChar *Buff = nullptr;
     xmlDocDumpFormatMemoryEnc(OutputDoc.get(), &Buff, &BufferSize, "UTF-8", 1);
     Buffer.reset(Buff);


### PR DESCRIPTION
This function has been deprecated in favor of the XML_PARSE_NOBLANKS option. The code already uses the option, so remove the call. If this call served some additional purpose, then it wasn't tested.

Fixes https://github.com/llvm/llvm-project/issues/86029.