### PR TITLE
IR: Add module level attribution language-standard

### DIFF
--- a/clang/lib/CodeGen/ModuleBuilder.cpp
+++ b/clang/lib/CodeGen/ModuleBuilder.cpp
@@ -153,6 +153,9 @@ namespace {
 
       M->setTargetTriple(Ctx->getTargetInfo().getTriple().getTriple());
       M->setDataLayout(Ctx->getTargetInfo().getDataLayoutString());
+      M->setLanguageStandard(
+          LangStandard::getLangStandardForKind(Ctx->getLangOpts().LangStd)
+              .getName());
       const auto &SDKVersion = Ctx->getTargetInfo().getSDKVersion();
       if (!SDKVersion.empty())
         M->setSDKVersion(SDKVersion);

--- a/llvm/include/llvm/Bitcode/LLVMBitCodes.h
+++ b/llvm/include/llvm/Bitcode/LLVMBitCodes.h
@@ -120,6 +120,9 @@ enum ModuleCodes {
 
   // IFUNC: [ifunc value type, addrspace, resolver val#, linkage, visibility]
   MODULE_CODE_IFUNC = 18,
+
+  // LANGUAGE_STANDARD: [strchr x N]
+  MODULE_CODE_LANGUAGE_STANDARD = 19,
 };
 
 /// PARAMATTR blocks have code for defining a parameter attribute set.

--- a/llvm/include/llvm/IR/Module.h
+++ b/llvm/include/llvm/IR/Module.h
@@ -196,6 +196,7 @@ private:
                                   ///< recorded in bitcode.
   std::string TargetTriple;       ///< Platform target triple Module compiled on
                                   ///< Format: (arch)(sub)-(vendor)-(sys0-(abi)
+  std::string LanguageStandard;   ///< Language standard: c89/c99/c11/c23 etc.
   NamedMDSymTabType NamedMDSymTab;  ///< NamedMDNode names.
   DataLayout DL;                  ///< DataLayout associated with the module
   StringMap<unsigned>
@@ -277,6 +278,9 @@ public:
   /// contain the source file name.
   const std::string &getSourceFileName() const { return SourceFileName; }
 
+  /// Get the module's language standard.
+  const std::string &getLanguageStandard() const { return LanguageStandard; }
+
   /// Get a short "name" for the module.
   ///
   /// This is useful for debugging or logging. It is essentially a convenience
@@ -338,6 +342,9 @@ public:
 
   /// Set the target triple.
   void setTargetTriple(StringRef T) { TargetTriple = std::string(T); }
+
+  /// Set the language standard.
+  void setLanguageStandard(StringRef S) { LanguageStandard = std::string(S); }
 
   /// Set the module-scope inline assembly blocks.
   /// A trailing newline is added if the input doesn't have one.

--- a/llvm/lib/IR/AsmWriter.cpp
+++ b/llvm/lib/IR/AsmWriter.cpp
@@ -2928,6 +2928,12 @@ void AssemblyWriter::printModule(const Module *M) {
   if (!M->getTargetTriple().empty())
     Out << "target triple = \"" << M->getTargetTriple() << "\"\n";
 
+  if (!M->getLanguageStandard().empty()) {
+    Out << "language_standard = \"";
+    printEscapedString(M->getLanguageStandard(), Out);
+    Out << "\"\n";
+  }
+
   if (!M->getModuleInlineAsm().empty()) {
     Out << '\n';
 

--- a/llvm/lib/IR/Module.cpp
+++ b/llvm/lib/IR/Module.cpp
@@ -71,8 +71,8 @@ template class llvm::SymbolTableListTraits<GlobalIFunc>;
 
 Module::Module(StringRef MID, LLVMContext &C)
     : Context(C), ValSymTab(std::make_unique<ValueSymbolTable>(-1)),
-      ModuleID(std::string(MID)), SourceFileName(std::string(MID)), DL(""),
-      IsNewDbgInfoFormat(false) {
+      ModuleID(std::string(MID)), SourceFileName(std::string(MID)),
+      LanguageStandard(""), DL(""), IsNewDbgInfoFormat(false) {
   Context.addModule(this);
 }
 


### PR DESCRIPTION
The backend may have interest on the language-standard level of source file. Let's pass it to IR.

In a ll file, it looks like
   language-standard = "gnu17"