### PR TITLE
[lldb] Fixed the TestDAP_repl_mode_detection test in case of a remote target

### DIFF
--- a/lldb/test/API/tools/lldb-dap/repl-mode/TestDAP_repl_mode_detection.py
+++ b/lldb/test/API/tools/lldb-dap/repl-mode/TestDAP_repl_mode_detection.py
@@ -18,6 +18,7 @@ class TestDAP_repl_mode_detection(lldbdap_testcase.DAPTestCaseBase):
             regex,
         )
 
+    @skipIfRemote
     def test_completions(self):
         program = self.getBuildArtifact("a.out")
         self.build_and_launch(program)


### PR DESCRIPTION
This test is based on dap_server which runs locally. This test failed in case of Windows host and Linux target.