### PR TITLE
[Offload] Disable flaky test on host-offloading

### DIFF
--- a/offload/test/offloading/dynamic_module.c
+++ b/offload/test/offloading/dynamic_module.c
@@ -2,6 +2,8 @@
 // RUN: %libomptarget-compile-generic %t.so && %libomptarget-run-generic 2>&1 | %fcheck-generic
 // RUN: %libomptarget-compileopt-generic -DSHARED -fPIC -shared -o %t.so && \
 // RUN: %libomptarget-compileopt-generic %t.so && %libomptarget-run-generic 2>&1 | %fcheck-generic
+//
+// UNSUPPORTED: x86_64-pc-linux-gnu
 
 #ifdef SHARED
 void foo() {}


### PR DESCRIPTION
This test started to be flaky on the AMDGPU buildbot.
To get the bot back into a more useful shape, disable the test while we investigate.

Issue is tracked: https://github.com/llvm/llvm-project/issues/93173