### PR TITLE
[Nomination] Add ST representative to Security group

### DIFF
--- a/llvm/docs/Security.rst
+++ b/llvm/docs/Security.rst
@@ -56,6 +56,7 @@ username for an individual isn't available, the brackets will be empty.
 * Shayne Hiet-Block (Microsoft) [@GreatKeeper]
 * Tim Penge (Sony) []
 * Will Huhn (Intel) [@wphuhn-intel]
+* Yvan Roux (ST) [@yroux]
 
 Criteria
 --------


### PR DESCRIPTION
I'd like to nominate myself to join the LLVM Security group as a representative of ST. I work in ST's compiler team contributing to upstream (LLVM and GNU) and several downstream toolchains. We believe that it is important for us to be part of this group to address or report any potential security issues the LLVM project or our toolchains may encounter.