### PR TITLE
[mlir][ArmSME] NFC: -force-streaming-compatible-sve rename fixup

### DIFF
--- a/mlir/test/Integration/Dialect/Vector/CPU/ArmSME/test-ssve.mlir
+++ b/mlir/test/Integration/Dialect/Vector/CPU/ArmSME/test-ssve.mlir
@@ -2,7 +2,7 @@
 // DEFINE: %{compile} = mlir-opt %s -test-lower-to-llvm
 // DEFINE: %{run} = %mcr_aarch64_cmd \
 // DEFINE:  -march=aarch64 -mattr=+sve,+sme \
-// DEFINE:  --force-streaming-compatible-sve \
+// DEFINE:  -force-streaming-compatible \
 // DEFINE:  -e %{entry_point} -entry-point-result=i32 \
 // DEFINE:  -shared-libs=%mlir_runner_utils,%mlir_c_runner_utils
 

--- a/mlir/test/Integration/Dialect/Vector/CPU/ArmSME/test-ssve.mlir
+++ b/mlir/test/Integration/Dialect/Vector/CPU/ArmSME/test-ssve.mlir
@@ -2,7 +2,6 @@
 // DEFINE: %{compile} = mlir-opt %s -test-lower-to-llvm
 // DEFINE: %{run} = %mcr_aarch64_cmd \
 // DEFINE:  -march=aarch64 -mattr=+sve,+sme \
-// DEFINE:  -force-streaming-compatible \
 // DEFINE:  -e %{entry_point} -entry-point-result=i32 \
 // DEFINE:  -shared-libs=%mlir_runner_utils,%mlir_c_runner_utils
 


### PR DESCRIPTION
-force-streaming-compatible-sve was renamed in #92774 but this test was missed, no longer required so removing.