### PR TITLE
[libc][arm] implement a basic setjmp/longjmp

### DIFF
--- a/libc/config/baremetal/arm/entrypoints.txt
+++ b/libc/config/baremetal/arm/entrypoints.txt
@@ -26,6 +26,10 @@ set(TARGET_LIBC_ENTRYPOINTS
     # errno.h entrypoints
     libc.src.errno.errno
 
+    # setjmp.h entrypoints
+    libc.src.setjmp.longjmp
+    libc.src.setjmp.setjmp
+
     # string.h entrypoints
     libc.src.string.bcmp
     libc.src.string.bcopy

--- a/libc/config/baremetal/arm/headers.txt
+++ b/libc/config/baremetal/arm/headers.txt
@@ -1,13 +1,14 @@
 set(TARGET_PUBLIC_HEADERS
     libc.include.assert
     libc.include.ctype
-    libc.include.fenv
     libc.include.errno
+    libc.include.fenv
     libc.include.float
-    libc.include.stdint
     libc.include.inttypes
     libc.include.math
+    libc.include.setjmp
     libc.include.stdfix
+    libc.include.stdint
     libc.include.stdio
     libc.include.stdlib
     libc.include.string

--- a/libc/config/linux/arm/entrypoints.txt
+++ b/libc/config/linux/arm/entrypoints.txt
@@ -20,6 +20,10 @@ set(TARGET_LIBC_ENTRYPOINTS
     # errno.h entrypoints
     libc.src.errno.errno
 
+    # setjmp.h entrypoints
+    libc.src.setjmp.longjmp
+    libc.src.setjmp.setjmp
+
     # string.h entrypoints
     libc.src.string.bcmp
     libc.src.string.bcopy

--- a/libc/config/linux/arm/headers.txt
+++ b/libc/config/linux/arm/headers.txt
@@ -1,19 +1,20 @@
 set(TARGET_PUBLIC_HEADERS
     libc.include.ctype
-    libc.include.fenv
     libc.include.errno
+    libc.include.fenv
     libc.include.float
-    libc.include.stdint
     libc.include.inttypes
     libc.include.math
-    libc.include.stdckdint
+    libc.include.search
+    libc.include.setjmp
     libc.include.stdbit
+    libc.include.stdckdint
+    libc.include.stdint
     libc.include.stdlib
     libc.include.string
     libc.include.strings
-    libc.include.search
-    libc.include.wchar
     libc.include.uchar
+    libc.include.wchar
 
     # Disabled due to epoll_wait syscalls not being available on this platform.
     # libc.include.sys_epoll

--- a/libc/include/llvm-libc-types/jmp_buf.h
+++ b/libc/include/llvm-libc-types/jmp_buf.h
@@ -34,7 +34,7 @@ typedef struct {
 #endif
 #elif defined(__arm__)
   // r4, r5, r6, r7, r8, r9, r10, r11, r12, lr
-  long opaque [10];
+  long opaque[10];
 #else
 #error "__jmp_buf not available for your target architecture."
 #endif

--- a/libc/include/llvm-libc-types/jmp_buf.h
+++ b/libc/include/llvm-libc-types/jmp_buf.h
@@ -32,6 +32,9 @@ typedef struct {
 #elif defined(__riscv_float_abi_single)
 #error "__jmp_buf not available for your target architecture."
 #endif
+#elif defined(__arm__)
+  // r4, r5, r6, r7, r8, r9, r10, r11, r12, lr
+  long opaque [10];
 #else
 #error "__jmp_buf not available for your target architecture."
 #endif

--- a/libc/include/setjmp.h.def
+++ b/libc/include/setjmp.h.def
@@ -10,6 +10,7 @@
 #define LLVM_LIBC_SETJMP_H
 
 #include "__llvm-libc-common.h"
+#include "llvm-libc-types/jmp_buf.h"
 
 %%public_api()
 

--- a/libc/src/setjmp/arm/CMakeLists.txt
+++ b/libc/src/setjmp/arm/CMakeLists.txt
@@ -1,0 +1,19 @@
+add_entrypoint_object(
+  setjmp
+  SRCS
+    setjmp.cpp
+  HDRS
+    ../setjmp_impl.h
+  DEPENDS
+    libc.include.setjmp
+)
+
+add_entrypoint_object(
+  longjmp
+  SRCS
+    longjmp.cpp
+  HDRS
+    ../longjmp.h
+  DEPENDS
+    libc.include.setjmp
+)

--- a/libc/src/setjmp/arm/longjmp.cpp
+++ b/libc/src/setjmp/arm/longjmp.cpp
@@ -49,7 +49,8 @@ LLVM_LIBC_FUNCTION(void, longjmp, (__jmp_buf * buf, int val)) {
 
 #else // Thumb2 or ARM
 
-// TODO(https://github.com/llvm/llvm-project/issues/94061): fp registers (d0-d16)
+// TODO(https://github.com/llvm/llvm-project/issues/94061): fp registers
+// (d0-d16)
 // TODO(https://github.com/llvm/llvm-project/issues/94062): pac+bti
 [[gnu::naked]]
 LLVM_LIBC_FUNCTION(void, longjmp, (__jmp_buf * buf, int val)) {

--- a/libc/src/setjmp/arm/longjmp.cpp
+++ b/libc/src/setjmp/arm/longjmp.cpp
@@ -14,7 +14,7 @@ namespace LIBC_NAMESPACE {
 
 #if defined(__thumb__) && __ARM_ARCH_ISA_THUMB == 1
 
-[[gnu::naked]]
+[[gnu::naked, gnu::target("thumb")]]
 LLVM_LIBC_FUNCTION(void, longjmp, (__jmp_buf * buf, int val)) {
   asm(R"(
       # Reload r4, r5, r6, r7.

--- a/libc/src/setjmp/arm/longjmp.cpp
+++ b/libc/src/setjmp/arm/longjmp.cpp
@@ -49,6 +49,8 @@ LLVM_LIBC_FUNCTION(void, longjmp, (__jmp_buf * buf, int val)) {
 
 #else // Thumb2 or ARM
 
+// TODO(https://github.com/llvm/llvm-project/issues/94061): fp registers (d0-d16)
+// TODO(https://github.com/llvm/llvm-project/issues/94062): pac+bti
 [[gnu::naked]]
 LLVM_LIBC_FUNCTION(void, longjmp, (__jmp_buf * buf, int val)) {
   asm(R"(

--- a/libc/src/setjmp/arm/longjmp.cpp
+++ b/libc/src/setjmp/arm/longjmp.cpp
@@ -20,27 +20,30 @@ LLVM_LIBC_FUNCTION(void, longjmp, (__jmp_buf * buf, int val)) {
       # Reload r4, r5, r6, r7.
       ldmia r0!, {r4, r5, r6, r7}
 
-      # Reload r8, r9, r10. They cannot appear in register lists so load them
+      # Reload r8, r9. They cannot appear in register lists so load them
       # into the lower registers, then move them into place.
-      ldmia r0!, {r1, r2, r3}
-      mov r8, r1
-      mov r9, r2
-      mov r10, r3
+      ldmia r0!, {r2, r3}
+      mov r8, r2
+      mov r9, r3
 
-      # Reload r11, sp, lr. They cannot appear in register lists so load them
+      # Reload r10, r11. They cannot appear in register lists so load them
       # into the lower registers, then move them into place.
-      ldmia r0!, {r1, r2, r3}
-      mov r11, r1
+      ldmia r0!, {r2, r3}
+      mov r10, r2
+      mov r11, r3
+
+      # Reload sp, lr. They cannot appear in register lists so load them
+      # into the lower registers, then move them into place.
+      ldmia r0!, {r2, r3}
       mov sp, r2
       mov lr, r3
 
       # return val ?: 1;
       movs r0, r1
-      beq .Lret_one
-      bx lr
-
-    .Lret_one:
+      bne .Lret_val
       movs r0, #1
+
+    .Lret_val:
       bx lr)");
 }
 

--- a/libc/src/setjmp/arm/longjmp.cpp
+++ b/libc/src/setjmp/arm/longjmp.cpp
@@ -1,0 +1,31 @@
+
+//===-- Implementation of longjmp -----------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "src/setjmp/longjmp.h"
+#include "src/__support/common.h"
+#include "src/__support/macros/properties/architectures.h"
+
+#if !defined(LIBC_TARGET_ARCH_IS_ARM)
+#error "Invalid file include"
+#endif
+
+namespace LIBC_NAMESPACE {
+
+[[gnu::naked]]
+LLVM_LIBC_FUNCTION(void, longjmp, (__jmp_buf * buf, int val)) {
+  asm("ldm.w r0!, {r4, r5, r6, r7, r8, r9, r10, r11, r12, lr}\n\t"
+      "mov sp, r12\n\t"
+      "movs r0, r1\n\t"
+      "it eq\n\t"
+      "moveq r0, 1\n\t"
+      "bx lr"
+  );
+}
+
+} // namespace LIBC_NAMESPACE

--- a/libc/src/setjmp/arm/longjmp.cpp
+++ b/libc/src/setjmp/arm/longjmp.cpp
@@ -14,12 +14,13 @@ namespace LIBC_NAMESPACE {
 
 [[gnu::naked]]
 LLVM_LIBC_FUNCTION(void, longjmp, (__jmp_buf * buf, int val)) {
-  asm("ldm.w r0!, {r4, r5, r6, r7, r8, r9, r10, r11, r12, lr}\n\t"
-      "mov sp, r12\n\t"
-      "movs r0, r1\n\t"
-      "it eq\n\t"
-      "moveq r0, 1\n\t"
-      "bx lr");
+  asm(R"(
+      ldm r0, {r4-r12, lr}
+      mov sp, r12
+      movs r0, r1
+      it eq
+      moveq r0, #1
+      bx lr)");
 }
 
 } // namespace LIBC_NAMESPACE

--- a/libc/src/setjmp/arm/longjmp.cpp
+++ b/libc/src/setjmp/arm/longjmp.cpp
@@ -9,11 +9,6 @@
 
 #include "src/setjmp/longjmp.h"
 #include "src/__support/common.h"
-#include "src/__support/macros/properties/architectures.h"
-
-#if !defined(LIBC_TARGET_ARCH_IS_ARM)
-#error "Invalid file include"
-#endif
 
 namespace LIBC_NAMESPACE {
 

--- a/libc/src/setjmp/arm/longjmp.cpp
+++ b/libc/src/setjmp/arm/longjmp.cpp
@@ -24,8 +24,7 @@ LLVM_LIBC_FUNCTION(void, longjmp, (__jmp_buf * buf, int val)) {
       "movs r0, r1\n\t"
       "it eq\n\t"
       "moveq r0, 1\n\t"
-      "bx lr"
-  );
+      "bx lr");
 }
 
 } // namespace LIBC_NAMESPACE

--- a/libc/src/setjmp/arm/longjmp.cpp
+++ b/libc/src/setjmp/arm/longjmp.cpp
@@ -18,23 +18,23 @@ namespace LIBC_NAMESPACE {
 LLVM_LIBC_FUNCTION(void, longjmp, (__jmp_buf * buf, int val)) {
   asm(R"(
       # Reload r4, r5, r6, r7.
-      ldmia r0!, {r4, r5, r6, r7}
+      ldmia r0!, {r4-r7}
 
       # Reload r8, r9. They cannot appear in register lists so load them
       # into the lower registers, then move them into place.
-      ldmia r0!, {r2, r3}
+      ldmia r0!, {r2-r3}
       mov r8, r2
       mov r9, r3
 
       # Reload r10, r11. They cannot appear in register lists so load them
       # into the lower registers, then move them into place.
-      ldmia r0!, {r2, r3}
+      ldmia r0!, {r2-r3}
       mov r10, r2
       mov r11, r3
 
       # Reload sp, lr. They cannot appear in register lists so load them
       # into the lower registers, then move them into place.
-      ldmia r0!, {r2, r3}
+      ldmia r0!, {r2-r3}
       mov sp, r2
       mov lr, r3
 

--- a/libc/src/setjmp/arm/setjmp.cpp
+++ b/libc/src/setjmp/arm/setjmp.cpp
@@ -47,7 +47,8 @@ LLVM_LIBC_FUNCTION(int, setjmp, (__jmp_buf * buf)) {
 
 #else // Thumb2 or ARM
 
-// TODO(https://github.com/llvm/llvm-project/issues/94061): fp registers (d0-d16)
+// TODO(https://github.com/llvm/llvm-project/issues/94061): fp registers
+// (d0-d16)
 // TODO(https://github.com/llvm/llvm-project/issues/94062): pac+bti
 [[gnu::naked]]
 LLVM_LIBC_FUNCTION(int, setjmp, (__jmp_buf * buf)) {

--- a/libc/src/setjmp/arm/setjmp.cpp
+++ b/libc/src/setjmp/arm/setjmp.cpp
@@ -11,6 +11,34 @@
 
 namespace LIBC_NAMESPACE {
 
+#if defined(__thumb__) && __ARM_ARCH_ISA_THUMB == 1
+
+[[gnu::naked]]
+LLVM_LIBC_FUNCTION(int, setjmp, (__jmp_buf * buf)) {
+  asm(R"(
+      # Store r4, r5, r6, and r7 into buf.
+      stmia r0!, {r4-r7}
+
+      # Store r8, r9, r10, and r11 into buf. Thumb(1) doesn't support the high
+      # registers > r7 in stmia, so move them into lower GPRs first.
+      mov r4, r8
+      mov r5, r9
+      mov r6, r10
+      mov r7, r11
+      stmia r0!, {r4-r7}
+
+      # Store sp into buf. Thumb(1) doesn't support sp in str, move to GPR
+      # first.
+      mov r4, sp
+      str r4, [r0]
+
+      # Return 0.
+      movs r0, #0
+      bx lr)");
+}
+
+#else // Thumb2 or ARM
+
 [[gnu::naked]]
 LLVM_LIBC_FUNCTION(int, setjmp, (__jmp_buf * buf)) {
   asm(R"(
@@ -19,5 +47,7 @@ LLVM_LIBC_FUNCTION(int, setjmp, (__jmp_buf * buf)) {
       mov r0, #0
       bx lr)");
 }
+
+#endif
 
 } // namespace LIBC_NAMESPACE

--- a/libc/src/setjmp/arm/setjmp.cpp
+++ b/libc/src/setjmp/arm/setjmp.cpp
@@ -47,6 +47,8 @@ LLVM_LIBC_FUNCTION(int, setjmp, (__jmp_buf * buf)) {
 
 #else // Thumb2 or ARM
 
+// TODO(https://github.com/llvm/llvm-project/issues/94061): fp registers (d0-d16)
+// TODO(https://github.com/llvm/llvm-project/issues/94062): pac+bti
 [[gnu::naked]]
 LLVM_LIBC_FUNCTION(int, setjmp, (__jmp_buf * buf)) {
   asm(R"(

--- a/libc/src/setjmp/arm/setjmp.cpp
+++ b/libc/src/setjmp/arm/setjmp.cpp
@@ -23,13 +23,22 @@ LLVM_LIBC_FUNCTION(int, setjmp, (__jmp_buf * buf)) {
       # the high registers > r7 in stmia, so move them into lower GPRs first.
       # Thumb(1) also doesn't support using str with sp or lr, move them
       # together with the rest.
-      mov r2, r8
-      mov r3, r9
-      mov r4, r10
-      mov r5, r11
-      mov r6, sp
-      mov r7, lr
-      stmia r0!, {r2-r7}
+      mov r1, r8
+      mov r2, r9
+      mov r3, r10
+      mov r4, r11
+      mov r5, sp
+      mov r6, lr
+      stmia r0!, {r1-r6}
+
+      # AAPCS32 states
+      # A subroutine must preserve the contents of the registers r4-r8 ...
+      # so rewind the buf pointer by the number of registers saved (i.e. 10
+      # registers: r4, r5, r6, r7, r8, r9, r10, r11, sp, lr), then restore
+      # r4, r5, and r6. r7 and r8 were not clobbered. These register are 4B, so
+      # 10 registers times 4B gives us 40B to rewind buf by.
+      subs r0, r0, #40
+      ldmia r0!, {r4-r6}
 
       # Return 0.
       movs r0, #0

--- a/libc/src/setjmp/arm/setjmp.cpp
+++ b/libc/src/setjmp/arm/setjmp.cpp
@@ -1,0 +1,27 @@
+//===-- Implementation of setjmp ------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "src/__support/common.h"
+#include "src/setjmp/setjmp_impl.h"
+
+#if !defined(LIBC_TARGET_ARCH_IS_ARM)
+#error "Invalid file include"
+#endif
+
+namespace LIBC_NAMESPACE {
+
+[[gnu::naked]]
+LLVM_LIBC_FUNCTION(int, setjmp, (__jmp_buf * buf)) {
+  asm("mov r12, sp\n\t"
+      "stm.w r0!, {r4, r5, r6, r7, r8, r9, r10, r11, r12, lr}\n\t"
+      "mov.w r0, 0\n\t"
+      "bx lr\n\t"
+  );
+}
+
+} // namespace LIBC_NAMESPACE

--- a/libc/src/setjmp/arm/setjmp.cpp
+++ b/libc/src/setjmp/arm/setjmp.cpp
@@ -20,8 +20,7 @@ LLVM_LIBC_FUNCTION(int, setjmp, (__jmp_buf * buf)) {
   asm("mov r12, sp\n\t"
       "stm.w r0!, {r4, r5, r6, r7, r8, r9, r10, r11, r12, lr}\n\t"
       "mov.w r0, 0\n\t"
-      "bx lr\n\t"
-  );
+      "bx lr");
 }
 
 } // namespace LIBC_NAMESPACE

--- a/libc/src/setjmp/arm/setjmp.cpp
+++ b/libc/src/setjmp/arm/setjmp.cpp
@@ -9,10 +9,6 @@
 #include "src/__support/common.h"
 #include "src/setjmp/setjmp_impl.h"
 
-#if !defined(LIBC_TARGET_ARCH_IS_ARM)
-#error "Invalid file include"
-#endif
-
 namespace LIBC_NAMESPACE {
 
 [[gnu::naked]]

--- a/libc/src/setjmp/arm/setjmp.cpp
+++ b/libc/src/setjmp/arm/setjmp.cpp
@@ -13,10 +13,11 @@ namespace LIBC_NAMESPACE {
 
 [[gnu::naked]]
 LLVM_LIBC_FUNCTION(int, setjmp, (__jmp_buf * buf)) {
-  asm("mov r12, sp\n\t"
-      "stm.w r0!, {r4, r5, r6, r7, r8, r9, r10, r11, r12, lr}\n\t"
-      "mov.w r0, 0\n\t"
-      "bx lr");
+  asm(R"(
+      mov r12, sp
+      stm r0, {r4-r12, lr}
+      mov r0, #0
+      bx lr)");
 }
 
 } // namespace LIBC_NAMESPACE

--- a/libc/src/setjmp/arm/setjmp.cpp
+++ b/libc/src/setjmp/arm/setjmp.cpp
@@ -26,19 +26,12 @@ LLVM_LIBC_FUNCTION(int, setjmp, (__jmp_buf * buf)) {
       mov r1, r8
       mov r2, r9
       mov r3, r10
-      mov r4, r11
-      mov r5, sp
-      mov r6, lr
-      stmia r0!, {r1-r6}
+      stmia r0!, {r1-r3}
 
-      # AAPCS32 states
-      # A subroutine must preserve the contents of the registers r4-r8 ...
-      # so rewind the buf pointer by the number of registers saved (i.e. 10
-      # registers: r4, r5, r6, r7, r8, r9, r10, r11, sp, lr), then restore
-      # r4, r5, and r6. r7 and r8 were not clobbered. These register are 4B, so
-      # 10 registers times 4B gives us 40B to rewind buf by.
-      subs r0, r0, #40
-      ldmia r0!, {r4-r6}
+      mov r1, r11
+      mov r2, sp
+      mov r3, lr
+      stmia r0!, {r1-r3}
 
       # Return 0.
       movs r0, #0


### PR DESCRIPTION
Note: our baremetal arm configuration compiles this as
`--target=arm-none-eabi`, so this code is built in -marm mode. It could be
smaller with `--target=armv7-none-eabi -mthumb`. The assembler is valid ARMv5,
or THUMB2, but not THUMB(1). Unclear yet if we need to support THUMB(1); may
depend on whether downstream users are using llvm-libc's cmake.