### PR TITLE
[MachineScheduler][ScheduleDAG] Add ability to bias scheduling by longest paths

### DIFF
--- a/llvm/include/llvm/CodeGen/ScheduleDAG.h
+++ b/llvm/include/llvm/CodeGen/ScheduleDAG.h
@@ -454,6 +454,10 @@ class TargetRegisterInfo;
     /// edge occurs first.
     void biasCriticalPath();
 
+    /// Orders this node's predecessor edges such that the edges are sorted by
+    /// decreasing depth.
+    void biasLongerPaths();
+
     void dumpAttributes() const;
 
   private:

--- a/llvm/lib/CodeGen/ScheduleDAG.cpp
+++ b/llvm/lib/CodeGen/ScheduleDAG.cpp
@@ -341,6 +341,9 @@ void SUnit::biasCriticalPath() {
 }
 
 void SUnit::biasLongerPaths() {
+  if (NumPreds < 2)
+    return;
+
   llvm::stable_sort(Preds, [](SDep A, SDep B) {
     // B should only be ordered before A if it is a data dependency and its
     // depth is larger.

--- a/llvm/lib/CodeGen/ScheduleDAG.cpp
+++ b/llvm/lib/CodeGen/ScheduleDAG.cpp
@@ -340,6 +340,18 @@ void SUnit::biasCriticalPath() {
     std::swap(*Preds.begin(), *BestI);
 }
 
+void SUnit::biasLongerPaths() {
+  llvm::stable_sort(Preds, [](SDep A, SDep B) {
+    // B should only be ordered before A if it is a data dependency and its
+    // depth is larger.
+    if (B.getKind() == SDep::Data &&
+        A.getSUnit()->getDepth() > B.getSUnit()->getDepth())
+      return true;
+    // Preserve order in all other instances
+    return false;
+  });
+}
+
 #if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 LLVM_DUMP_METHOD void SUnit::dumpAttributes() const {
   dbgs() << "  # preds left       : " << NumPredsLeft << "\n";


### PR DESCRIPTION
Currently the scheduler only biases by critical path. However, it is possible that there are paths that are long (but not the longest). Bias paths by decreasing order of depth to bias the longest paths.

I saw a small improvement on spec2017/523.xalancbmk_r in dynamic instruction count and in runtime with this change on RISC-V.

I am disabling this feature by default to make minimal impact to targets tuned with the algorithm prior to this patch.