### PR TITLE
[mlir] Align num elements type to LLVM ArrayType

### DIFF
--- a/flang/test/Fir/convert-to-llvm.fir
+++ b/flang/test/Fir/convert-to-llvm.fir
@@ -2698,3 +2698,9 @@ func.func @coordinate_array_unknown_size_1d(%arg0: !fir.ptr<!fir.array<? x i32>>
 // CHECK:           %[[VAL_2:.*]] = llvm.getelementptr %[[VAL_0]]{{\[}}%[[VAL_1]]] : (!llvm.ptr, i64) -> !llvm.ptr, i32
 // CHECK:           llvm.return
 // CHECK:         }
+
+// -----
+
+fir.global common @c_(dense<0> : vector<4294967296xi8>) : !fir.array<4294967296xi8>
+
+// CHECK: llvm.mlir.global common @c_(dense<0> : vector<4294967296xi8>) {addr_space = 0 : i32} : !llvm.array<4294967296 x i8>

--- a/mlir/include/mlir/Dialect/LLVMIR/LLVMTypes.td
+++ b/mlir/include/mlir/Dialect/LLVMIR/LLVMTypes.td
@@ -40,7 +40,7 @@ def LLVMArrayType : LLVMType<"LLVMArray", "array", [
     ```
   }];
 
-  let parameters = (ins "Type":$elementType, "unsigned":$numElements);
+  let parameters = (ins "Type":$elementType, "uint64_t":$numElements);
   let assemblyFormat = [{
     `<` $numElements `x` custom<PrettyLLVMType>($elementType) `>`
   }];
@@ -49,7 +49,7 @@ def LLVMArrayType : LLVMType<"LLVMArray", "array", [
 
   let builders = [
     TypeBuilderWithInferredContext<(ins "Type":$elementType,
-                                        "unsigned":$numElements)>
+                                        "uint64_t":$numElements)>
   ];
 
   let extraClassDeclaration = [{

--- a/mlir/lib/Dialect/LLVMIR/IR/LLVMTypes.cpp
+++ b/mlir/lib/Dialect/LLVMIR/IR/LLVMTypes.cpp
@@ -154,14 +154,14 @@ bool LLVMArrayType::isValidElementType(Type type) {
       type);
 }
 
-LLVMArrayType LLVMArrayType::get(Type elementType, unsigned numElements) {
+LLVMArrayType LLVMArrayType::get(Type elementType, uint64_t numElements) {
   assert(elementType && "expected non-null subtype");
   return Base::get(elementType.getContext(), elementType, numElements);
 }
 
 LLVMArrayType
 LLVMArrayType::getChecked(function_ref<InFlightDiagnostic()> emitError,
-                          Type elementType, unsigned numElements) {
+                          Type elementType, uint64_t numElements) {
   assert(elementType && "expected non-null subtype");
   return Base::getChecked(emitError, elementType.getContext(), elementType,
                           numElements);
@@ -169,7 +169,7 @@ LLVMArrayType::getChecked(function_ref<InFlightDiagnostic()> emitError,
 
 LogicalResult
 LLVMArrayType::verify(function_ref<InFlightDiagnostic()> emitError,
-                      Type elementType, unsigned numElements) {
+                      Type elementType, uint64_t numElements) {
   if (!isValidElementType(elementType))
     return emitError() << "invalid array element type: " << elementType;
   return success();

--- a/mlir/lib/Target/LLVMIR/ModuleTranslation.cpp
+++ b/mlir/lib/Target/LLVMIR/ModuleTranslation.cpp
@@ -637,12 +637,24 @@ llvm::Constant *mlir::LLVM::detail::getLLVMConstant(
       } else {
         if (llvm::ConstantDataSequential::isElementTypeCompatible(
                 elementType)) {
-          // TODO: Handle all compatible types. This code only handle i32.
+          // TODO: Handle all compatible types. This code only handles integer.
           if (llvm::IntegerType *iTy =
                   dyn_cast<llvm::IntegerType>(elementType)) {
             if (llvm::ConstantInt *ci = dyn_cast<llvm::ConstantInt>(child)) {
-              if (ci->getBitWidth() == 32) {
+              if (ci->getBitWidth() == 8) {
+                SmallVector<int8_t> constants(numElements, ci->getZExtValue());
+                return llvm::ConstantDataArray::get(elementType->getContext(),
+                                                    constants);
+              } else if (ci->getBitWidth() == 16) {
+                SmallVector<int16_t> constants(numElements, ci->getZExtValue());
+                return llvm::ConstantDataArray::get(elementType->getContext(),
+                                                    constants);
+              } else if (ci->getBitWidth() == 32) {
                 SmallVector<int32_t> constants(numElements, ci->getZExtValue());
+                return llvm::ConstantDataArray::get(elementType->getContext(),
+                                                    constants);
+              } else if (ci->getBitWidth() == 64) {
+                SmallVector<int64_t> constants(numElements, ci->getZExtValue());
                 return llvm::ConstantDataArray::get(elementType->getContext(),
                                                     constants);
               }

--- a/mlir/lib/Target/LLVMIR/ModuleTranslation.cpp
+++ b/mlir/lib/Target/LLVMIR/ModuleTranslation.cpp
@@ -635,7 +635,7 @@ llvm::Constant *mlir::LLVM::detail::getLLVMConstant(
       if (child->isZeroValue()) {
         return llvm::ConstantAggregateZero::get(arrayType);
       } else {
-        llvm::SmallVector<llvm::Constant *, 8> constants(numElements, child);
+        std::vector<llvm::Constant *> constants(numElements, child);
         return llvm::ConstantArray::get(arrayType, constants);
       }
     }

--- a/mlir/lib/Target/LLVMIR/ModuleTranslation.cpp
+++ b/mlir/lib/Target/LLVMIR/ModuleTranslation.cpp
@@ -635,13 +635,16 @@ llvm::Constant *mlir::LLVM::detail::getLLVMConstant(
       if (child->isZeroValue()) {
         return llvm::ConstantAggregateZero::get(arrayType);
       } else {
-        if (llvm::ConstantDataSequential::isElementTypeCompatible(elementType)) {
+        if (llvm::ConstantDataSequential::isElementTypeCompatible(
+                elementType)) {
           // TODO: Handle all compatible types. This code only handle i32.
-          if (llvm::IntegerType *iTy = dyn_cast<llvm::IntegerType>(elementType)) {
+          if (llvm::IntegerType *iTy =
+                  dyn_cast<llvm::IntegerType>(elementType)) {
             if (llvm::ConstantInt *ci = dyn_cast<llvm::ConstantInt>(child)) {
               if (ci->getBitWidth() == 32) {
                 SmallVector<int32_t> constants(numElements, ci->getZExtValue());
-                return llvm::ConstantDataArray::get(elementType->getContext(), constants);
+                return llvm::ConstantDataArray::get(elementType->getContext(),
+                                                    constants);
               }
             }
           }

--- a/mlir/lib/Target/LLVMIR/ModuleTranslation.cpp
+++ b/mlir/lib/Target/LLVMIR/ModuleTranslation.cpp
@@ -635,6 +635,17 @@ llvm::Constant *mlir::LLVM::detail::getLLVMConstant(
       if (child->isZeroValue()) {
         return llvm::ConstantAggregateZero::get(arrayType);
       } else {
+        if (llvm::ConstantDataSequential::isElementTypeCompatible(elementType)) {
+          // TODO: Handle all compatible types. This code only handle i32.
+          if (llvm::IntegerType *iTy = dyn_cast<llvm::IntegerType>(elementType)) {
+            if (llvm::ConstantInt *ci = dyn_cast<llvm::ConstantInt>(child)) {
+              if (ci->getBitWidth() == 32) {
+                SmallVector<int32_t> constants(numElements, ci->getZExtValue());
+                return llvm::ConstantDataArray::get(elementType->getContext(), constants);
+              }
+            }
+          }
+        }
         // std::vector is used here to accomodate large number of elements that
         // exceed SmallVector capacity.
         std::vector<llvm::Constant *> constants(numElements, child);

--- a/mlir/lib/Target/LLVMIR/ModuleTranslation.cpp
+++ b/mlir/lib/Target/LLVMIR/ModuleTranslation.cpp
@@ -635,6 +635,8 @@ llvm::Constant *mlir::LLVM::detail::getLLVMConstant(
       if (child->isZeroValue()) {
         return llvm::ConstantAggregateZero::get(arrayType);
       } else {
+        // std::vector is used here to accomodate large number of elements that
+        // exceed SmallVector capacity.
         std::vector<llvm::Constant *> constants(numElements, child);
         return llvm::ConstantArray::get(arrayType, constants);
       }

--- a/mlir/lib/Target/LLVMIR/ModuleTranslation.cpp
+++ b/mlir/lib/Target/LLVMIR/ModuleTranslation.cpp
@@ -645,15 +645,18 @@ llvm::Constant *mlir::LLVM::detail::getLLVMConstant(
                 SmallVector<int8_t> constants(numElements, ci->getZExtValue());
                 return llvm::ConstantDataArray::get(elementType->getContext(),
                                                     constants);
-              } else if (ci->getBitWidth() == 16) {
+              }
+              if (ci->getBitWidth() == 16) {
                 SmallVector<int16_t> constants(numElements, ci->getZExtValue());
                 return llvm::ConstantDataArray::get(elementType->getContext(),
                                                     constants);
-              } else if (ci->getBitWidth() == 32) {
+              }
+              if (ci->getBitWidth() == 32) {
                 SmallVector<int32_t> constants(numElements, ci->getZExtValue());
                 return llvm::ConstantDataArray::get(elementType->getContext(),
                                                     constants);
-              } else if (ci->getBitWidth() == 64) {
+              }
+              if (ci->getBitWidth() == 64) {
                 SmallVector<int64_t> constants(numElements, ci->getZExtValue());
                 return llvm::ConstantDataArray::get(elementType->getContext(),
                                                     constants);

--- a/mlir/lib/Target/LLVMIR/ModuleTranslation.cpp
+++ b/mlir/lib/Target/LLVMIR/ModuleTranslation.cpp
@@ -632,8 +632,12 @@ llvm::Constant *mlir::LLVM::detail::getLLVMConstant(
           llvm::ElementCount::get(numElements, /*Scalable=*/isScalable), child);
     if (llvmType->isArrayTy()) {
       auto *arrayType = llvm::ArrayType::get(elementType, numElements);
-      std::vector<llvm::Constant *> constants(numElements, child);
-      return llvm::ConstantArray::get(arrayType, constants);
+      if (child->isZeroValue()) {
+        return llvm::ConstantAggregateZero::get(arrayType);
+      } else {
+        llvm::SmallVector<llvm::Constant *, 8> constants(numElements, child);
+        return llvm::ConstantArray::get(arrayType, constants);
+      }
     }
   }
 

--- a/mlir/lib/Target/LLVMIR/ModuleTranslation.cpp
+++ b/mlir/lib/Target/LLVMIR/ModuleTranslation.cpp
@@ -632,7 +632,7 @@ llvm::Constant *mlir::LLVM::detail::getLLVMConstant(
           llvm::ElementCount::get(numElements, /*Scalable=*/isScalable), child);
     if (llvmType->isArrayTy()) {
       auto *arrayType = llvm::ArrayType::get(elementType, numElements);
-      SmallVector<llvm::Constant *, 8> constants(numElements, child);
+      std::vector<llvm::Constant *> constants(numElements, child);
       return llvm::ConstantArray::get(arrayType, constants);
     }
   }

--- a/mlir/test/Target/LLVMIR/llvmir.mlir
+++ b/mlir/test/Target/LLVMIR/llvmir.mlir
@@ -2399,5 +2399,5 @@ llvm.linker_options ["/DEFAULTLIB:", "libcmtd"]
 
 // -----
 
-//CHECK: @big_ = common global [4294967296 x i8] zeroinitializer
+// CHECK: @big_ = common global [4294967296 x i8] zeroinitializer
 llvm.mlir.global common @big_(dense<0> : vector<4294967296xi8>) {addr_space = 0 : i32} : !llvm.array<4294967296 x i8>

--- a/mlir/test/Target/LLVMIR/llvmir.mlir
+++ b/mlir/test/Target/LLVMIR/llvmir.mlir
@@ -2399,5 +2399,5 @@ llvm.linker_options ["/DEFAULTLIB:", "libcmtd"]
 
 // -----
 
-llvm.mlir.global common @big_(dense<0> : vector<4294967296xi8>) {addr_space = 0 : i32} : !llvm.array<4294967296 x i8>
 //CHECK: @big_ = common global [4294967296 x i8] zeroinitializer
+llvm.mlir.global common @big_(dense<0> : vector<4294967296xi8>) {addr_space = 0 : i32} : !llvm.array<4294967296 x i8>

--- a/mlir/test/Target/LLVMIR/llvmir.mlir
+++ b/mlir/test/Target/LLVMIR/llvmir.mlir
@@ -2396,3 +2396,9 @@ llvm.func @zeroinit_complex_local_aggregate() {
 llvm.linker_options ["/DEFAULTLIB:", "libcmt"]
 //CHECK: ![[MD1]] = !{!"/DEFAULTLIB:", !"libcmtd"}
 llvm.linker_options ["/DEFAULTLIB:", "libcmtd"]
+
+// -----
+
+// Translation is currently very slow so the test is not enabled.
+//llvm.mlir.global common @big_(dense<0> : vector<4294967296xi8>) {addr_space = 0 : i32} : !llvm.array<4294967296 x i8>
+//XCHECK: @big_ = common global [4294967296 x i8] zeroinitializer

--- a/mlir/test/Target/LLVMIR/llvmir.mlir
+++ b/mlir/test/Target/LLVMIR/llvmir.mlir
@@ -2399,6 +2399,5 @@ llvm.linker_options ["/DEFAULTLIB:", "libcmtd"]
 
 // -----
 
-// Translation is currently very slow so the test is not enabled.
-//llvm.mlir.global common @big_(dense<0> : vector<4294967296xi8>) {addr_space = 0 : i32} : !llvm.array<4294967296 x i8>
-//XCHECK: @big_ = common global [4294967296 x i8] zeroinitializer
+llvm.mlir.global common @big_(dense<0> : vector<4294967296xi8>) {addr_space = 0 : i32} : !llvm.array<4294967296 x i8>
+//CHECK: @big_ = common global [4294967296 x i8] zeroinitializer


### PR DESCRIPTION
MLIR LLMArrayType is using `unsigned` for the number of elements while LLVM ArrayType is using `uint64_t` https://github.com/llvm/llvm-project/blob/4ae896fe979b7db501cabde4b6b3504478958682/llvm/include/llvm/IR/DerivedTypes.h#L377

This leads to silent truncation when we use it for globals in flang. 

```
program test
  integer(8), parameter :: large = 2**30
  real,  dimension(large) :: bigarray
  common /c/ bigarray
  bigarray(999) = 666
end
```

The above program would result in a segfault since the global would be of size 0 because of the silent truncation. 

```
fir.global common @c_(dense<0> : vector<4294967296xi8>) : !fir.array<4294967296xi8>
```
became
```
llvm.mlir.global common @c_(dense<0> : vector<4294967296xi8>) {addr_space = 0 : i32} : !llvm.array<0 x i8>
```

This patch updates the definition of MLIR ArrayType to take `uint64_t` as argument of the number of elements to be compatible with LLVM. 
