### PR TITLE
[sanitizer_common] Change allocator base in test case for compatibili…

### DIFF
--- a/compiler-rt/lib/sanitizer_common/tests/sanitizer_allocator_test.cpp
+++ b/compiler-rt/lib/sanitizer_common/tests/sanitizer_allocator_test.cpp
@@ -69,12 +69,17 @@ const uptr kAllocatorSpace = ~(uptr)0;
 const uptr kAllocatorSize = 0x2000000000ULL;  // 128G.
 static const u64 kAddressSpaceSize = 1ULL << 38;
 typedef VeryDenseSizeClassMap SizeClassMap;
-#else
+#    elif SANITIZER_APPLE
 static const uptr kAllocatorSpace = 0x700000000000ULL;
 static const uptr kAllocatorSize  = 0x010000000000ULL;  // 1T.
 static const u64 kAddressSpaceSize = 1ULL << 47;
 typedef DefaultSizeClassMap SizeClassMap;
-#endif
+#    else
+static const uptr kAllocatorSpace = 0x500000000000ULL;
+static const uptr kAllocatorSize = 0x010000000000ULL;  // 1T.
+static const u64 kAddressSpaceSize = 1ULL << 47;
+typedef DefaultSizeClassMap SizeClassMap;
+#    endif
 
 template <typename AddressSpaceViewTy>
 struct AP64 {  // Allocator Params. Short name for shorter demangled names..


### PR DESCRIPTION
…ty with high-entropy ASLR

With high-entropy ASLR (e.g., 32-bits == 16TB), the allocator base of 0x700000000000 (112TB) may collide with the placement of the libraries (e.g., on Linux, the mmap base could be 128TB - 16TB == 112TB). This results in a segfault in the test case.

This patch moves the allocator base below the PIE program segment, inspired by fb77ca05ffb4f8e666878f2f6718a9fb4d686839. As per that patch: 1) we are leaving the old behavior for Apple 2) since ASLR cannot be set above 32-bits for x86-64 Linux, we expect this new layout to be durable.

Note that this is only changing a test case, not the behavior of sanitizers. Sanitizers have their own settings for initializing the allocator base.

Reproducer:
1. ninja check-sanitizer # Just to build the test binary needed below; no need to actually run the tests here
2. sudo sysctl vm.mmap_rnd_bits=32 # Increase ASLR entropy
3. for f in `seq 1 10000`; do echo $f; GTEST_FILTER=*SizeClassAllocator64Dense ./projects/compiler-rt/lib/sanitizer_common/tests/Sanitizer-x86_64-Test > /tmp/x; if [ $? -ne 0 ]; then cat /tmp/x; fi; done