### PR TITLE
[mlir][spirv] Add vector.interleave to spirv.VectorShuffle conversion

### DIFF
--- a/mlir/lib/Conversion/VectorToSPIRV/CMakeLists.txt
+++ b/mlir/lib/Conversion/VectorToSPIRV/CMakeLists.txt
@@ -14,6 +14,5 @@ add_mlir_conversion_library(MLIRVectorToSPIRV
   MLIRSPIRVDialect
   MLIRSPIRVConversion
   MLIRVectorDialect
-  MLIRVectorTransforms
   MLIRTransforms
   )

--- a/mlir/lib/Conversion/VectorToSPIRV/VectorToSPIRV.cpp
+++ b/mlir/lib/Conversion/VectorToSPIRV/VectorToSPIRV.cpp
@@ -586,7 +586,7 @@ struct VectorInterleaveOpConvert final
   matchAndRewrite(vector::InterleaveOp interleaveOp, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     // Check the source vector type
-    auto sourceType = interleaveOp.getSourceVectorType();
+    VectorType sourceType = interleaveOp.getSourceVectorType();
     if (sourceType.getRank() != 1 || sourceType.isScalable()) {
       return rewriter.notifyMatchFailure(interleaveOp,
                                          "unsupported source vector type");

--- a/mlir/lib/Conversion/VectorToSPIRV/VectorToSPIRV.cpp
+++ b/mlir/lib/Conversion/VectorToSPIRV/VectorToSPIRV.cpp
@@ -585,24 +585,22 @@ struct VectorInterleaveOpConvert final
   LogicalResult
   matchAndRewrite(vector::InterleaveOp interleaveOp, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
-    // Check the result vector type
+    // Check the result vector type.
     VectorType oldResultType = interleaveOp.getResultVectorType();
     Type newResultType = getTypeConverter()->convertType(oldResultType);
     if (!newResultType)
       return rewriter.notifyMatchFailure(interleaveOp,
                                          "unsupported result vector type");
 
-    // Interleave the indices
+    // Interleave the indices.
     VectorType sourceType = interleaveOp.getSourceVectorType();
     int n = sourceType.getNumElements();
 
     // Input vectors of size 1 are converted to scalars by the type converter.
-    // We cannot use spirv::VectorShuffleOp directly in this case, and need to
-    // use spirv::CompositeConstructOp.
+    // We cannot use `spirv::VectorShuffleOp` directly in this case, and need to
+    // use `spirv::CompositeConstructOp`.
     if (n == 1) {
-      SmallVector<Value> newOperands(2);
-      newOperands[0] = adaptor.getLhs();
-      newOperands[1] = adaptor.getRhs();
+      Value newOperands[] = {adaptor.getLhs(), adaptor.getRhs()};
       rewriter.replaceOpWithNewOp<spirv::CompositeConstructOp>(
           interleaveOp, newResultType, newOperands);
       return success();

--- a/mlir/lib/Conversion/VectorToSPIRV/VectorToSPIRV.cpp
+++ b/mlir/lib/Conversion/VectorToSPIRV/VectorToSPIRV.cpp
@@ -593,7 +593,7 @@ struct VectorInterleaveOpConvert final
     }
 
     // Check the result vector type
-    auto oldResultType = interleaveOp.getResultVectorType();
+    VectorType oldResultType = interleaveOp.getResultVectorType();
     Type newResultType = getTypeConverter()->convertType(oldResultType);
     if (!newResultType)
       return rewriter.notifyMatchFailure(interleaveOp,

--- a/mlir/lib/Conversion/VectorToSPIRV/VectorToSPIRV.cpp
+++ b/mlir/lib/Conversion/VectorToSPIRV/VectorToSPIRV.cpp
@@ -608,7 +608,7 @@ struct VectorInterleaveOpConvert final
 
     auto seq = llvm::seq<int64_t>(2 * n);
     auto indices = llvm::map_to_vector(
-      seq, [n](int i) { return (i % 2 ? n : 0) + i / 2; });
+        seq, [n](int i) { return (i % 2 ? n : 0) + i / 2; });
 
     // Emit a SPIR-V shuffle.
     rewriter.replaceOpWithNewOp<spirv::VectorShuffleOp>(

--- a/mlir/lib/Conversion/VectorToSPIRV/VectorToSPIRV.cpp
+++ b/mlir/lib/Conversion/VectorToSPIRV/VectorToSPIRV.cpp
@@ -607,8 +607,8 @@ struct VectorInterleaveOpConvert final
     }
 
     auto seq = llvm::seq<int64_t>(2 * n);
-    auto indices = llvm::to_vector(
-        llvm::map_range(seq, [n](int i) { return (i % 2 ? n : 0) + i / 2; }));
+    auto indices = llvm::map_to_vector(
+      seq, [n](int i) { return (i % 2 ? n : 0) + i / 2; });
 
     // Emit a SPIR-V shuffle.
     rewriter.replaceOpWithNewOp<spirv::VectorShuffleOp>(

--- a/mlir/test/Conversion/VectorToSPIRV/vector-to-spirv.mlir
+++ b/mlir/test/Conversion/VectorToSPIRV/vector-to-spirv.mlir
@@ -494,6 +494,19 @@ func.func @interleave(%a: vector<2xf32>, %b: vector<2xf32>) -> vector<4xf32> {
 
 // -----
 
+// CHECK-LABEL: func @interleave_size1
+// CHECK-SAME: (%[[ARG0:.+]]: vector<1xf32>, %[[ARG1:.+]]: vector<1xf32>)
+//       CHECK: %[[V0:.*]] = builtin.unrealized_conversion_cast %[[ARG0]] : vector<1xf32> to f32
+//       CHECK: %[[V1:.*]] = builtin.unrealized_conversion_cast %[[ARG1]] : vector<1xf32> to f32
+//       CHECK: %[[RES:.*]] = spirv.CompositeConstruct %[[V0]], %[[V1]] : (f32, f32) -> vector<2xf32>
+//       CHECK: return %[[RES]]
+func.func @interleave_size1(%a: vector<1xf32>, %b: vector<1xf32>) -> vector<2xf32> {
+  %0 = vector.interleave %a, %b : vector<1xf32>
+  return %0 : vector<2xf32>
+}
+
+// -----
+
 // CHECK-LABEL: func @reduction_add
 //  CHECK-SAME: (%[[V:.+]]: vector<4xi32>)
 //       CHECK:   %[[S0:.+]] = spirv.CompositeExtract %[[V]][0 : i32] : vector<4xi32>

--- a/mlir/test/Conversion/VectorToSPIRV/vector-to-spirv.mlir
+++ b/mlir/test/Conversion/VectorToSPIRV/vector-to-spirv.mlir
@@ -501,7 +501,7 @@ func.func @interleave(%a: vector<2xf32>, %b: vector<2xf32>) -> vector<4xf32> {
 //       CHECK: %[[RES:.*]] = spirv.CompositeConstruct %[[V0]], %[[V1]] : (f32, f32) -> vector<2xf32>
 //       CHECK: return %[[RES]]
 func.func @interleave_size1(%a: vector<1xf32>, %b: vector<1xf32>) -> vector<2xf32> {
-  %0 = vector.interleave %a, %b : vector<1xf32>
+  %0 = vector.interleave %a, %b : vector<1xf32> -> vector<2xf32>
   return %0 : vector<2xf32>
 }
 

--- a/utils/bazel/llvm-project-overlay/mlir/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/mlir/BUILD.bazel
@@ -4976,7 +4976,6 @@ cc_library(
         ":VectorToLLVM",
         ":VectorToSCF",
         ":VectorTransformOpsIncGen",
-        ":VectorTransforms",
         ":X86VectorTransforms",
     ],
 )


### PR DESCRIPTION
- Add `vector.interleave` to `spirv.VectorShuffle` conversion,
- Remove the `vector.interleave` to `vector.shuffle` conversion from `populateVectorToSPIRVPatterns` and CMake/Bazel dependencies