### PR TITLE
[lldb] UpdateFormatsIfNeeded should respect the dynamic value type

### DIFF
--- a/lldb/source/Core/ValueObject.cpp
+++ b/lldb/source/Core/ValueObject.cpp
@@ -216,7 +216,7 @@ bool ValueObject::UpdateFormatsIfNeeded() {
     m_last_format_mgr_revision = DataVisualization::GetCurrentRevision();
     any_change = true;
 
-    SetValueFormat(DataVisualization::GetFormat(*this, eNoDynamicValues));
+    SetValueFormat(DataVisualization::GetFormat(*this, GetDynamicValueType()));
     SetSummaryFormat(
         DataVisualization::GetSummaryFormat(*this, GetDynamicValueType()));
     SetSyntheticChildren(


### PR DESCRIPTION
UpdateFormatsIfNeeded has hardcoded the call to GetFormat with no dynamic values. GetFormat will try to find the synthetic children of the ValueObject, and passing the wrong one can fail, which can be bad for performance but should not be user visible. Fix the performace bug by passing the dynamic value type of the ValueObject.

rdar://122506593