### PR TITLE
[clang] Fix loss of `dllexport` for exported template specialization

### DIFF
--- a/clang/lib/CodeGen/CodeGenModule.cpp
+++ b/clang/lib/CodeGen/CodeGenModule.cpp
@@ -4554,8 +4554,11 @@ llvm::Constant *CodeGenModule::GetOrCreateLLVMFunction(
         Entry->setLinkage(llvm::Function::ExternalLinkage);
     }
 
-    // Handle dropped DLL attributes.
-    if (D && !D->hasAttr<DLLImportAttr>() && !D->hasAttr<DLLExportAttr>() &&
+    // Handle dropped dllimport.
+    if (D &&
+        (Entry->getDLLStorageClass() ==
+         llvm::GlobalVariable::DLLImportStorageClass) &&
+        !D->hasAttr<DLLImportAttr>() &&
         !shouldMapVisibilityToDLLExport(cast_or_null<NamedDecl>(D))) {
       Entry->setDLLStorageClass(llvm::GlobalValue::DefaultStorageClass);
       setDSOLocal(Entry);
@@ -4849,9 +4852,12 @@ CodeGenModule::GetOrCreateLLVMGlobal(StringRef MangledName, llvm::Type *Ty,
         Entry->setLinkage(llvm::Function::ExternalLinkage);
     }
 
-    // Handle dropped DLL attributes.
-    if (D && !D->hasAttr<DLLImportAttr>() && !D->hasAttr<DLLExportAttr>() &&
-        !shouldMapVisibilityToDLLExport(D))
+    // Handle dropped dllimport.
+    if (D &&
+        (Entry->getDLLStorageClass() ==
+         llvm::GlobalVariable::DLLImportStorageClass) &&
+        !D->hasAttr<DLLImportAttr>() &&
+        !shouldMapVisibilityToDLLExport(cast_or_null<NamedDecl>(D)))
       Entry->setDLLStorageClass(llvm::GlobalValue::DefaultStorageClass);
 
     if (LangOpts.OpenMP && !LangOpts.OpenMPSimd && D)

--- a/clang/lib/CodeGen/CodeGenModule.cpp
+++ b/clang/lib/CodeGen/CodeGenModule.cpp
@@ -4856,8 +4856,7 @@ CodeGenModule::GetOrCreateLLVMGlobal(StringRef MangledName, llvm::Type *Ty,
     if (D &&
         (Entry->getDLLStorageClass() ==
          llvm::GlobalVariable::DLLImportStorageClass) &&
-        !D->hasAttr<DLLImportAttr>() &&
-        !shouldMapVisibilityToDLLExport(D))
+        !D->hasAttr<DLLImportAttr>() && !shouldMapVisibilityToDLLExport(D))
       Entry->setDLLStorageClass(llvm::GlobalValue::DefaultStorageClass);
 
     if (LangOpts.OpenMP && !LangOpts.OpenMPSimd && D)

--- a/clang/lib/CodeGen/CodeGenModule.cpp
+++ b/clang/lib/CodeGen/CodeGenModule.cpp
@@ -4559,7 +4559,7 @@ llvm::Constant *CodeGenModule::GetOrCreateLLVMFunction(
         (Entry->getDLLStorageClass() ==
          llvm::GlobalVariable::DLLImportStorageClass) &&
         !D->hasAttr<DLLImportAttr>() &&
-        !shouldMapVisibilityToDLLExport(cast_or_null<NamedDecl>(D))) {
+        !shouldMapVisibilityToDLLExport(cast<NamedDecl>(D))) {
       Entry->setDLLStorageClass(llvm::GlobalValue::DefaultStorageClass);
       setDSOLocal(Entry);
     }
@@ -4857,7 +4857,7 @@ CodeGenModule::GetOrCreateLLVMGlobal(StringRef MangledName, llvm::Type *Ty,
         (Entry->getDLLStorageClass() ==
          llvm::GlobalVariable::DLLImportStorageClass) &&
         !D->hasAttr<DLLImportAttr>() &&
-        !shouldMapVisibilityToDLLExport(cast_or_null<NamedDecl>(D)))
+        !shouldMapVisibilityToDLLExport(D))
       Entry->setDLLStorageClass(llvm::GlobalValue::DefaultStorageClass);
 
     if (LangOpts.OpenMP && !LangOpts.OpenMPSimd && D)

--- a/clang/test/CodeGenCXX/windows-instantiate-dllexport-template-specialization.cpp
+++ b/clang/test/CodeGenCXX/windows-instantiate-dllexport-template-specialization.cpp
@@ -1,0 +1,18 @@
+// RUN: %clang_cc1 -triple i686-windows         -fdeclspec -emit-llvm %s -o - | FileCheck %s -check-prefix CHECK-MS
+// RUN: %clang_cc1 -triple i686-windows-itanium -fdeclspec -emit-llvm %s -o - | FileCheck %s
+// RUN: %clang_cc1 -triple x86_64-scei-ps4      -fdeclspec -emit-llvm %s -o - | FileCheck %s
+// RUN: %clang_cc1 -triple x86_64-sie-ps5       -fdeclspec -emit-llvm %s -o - | FileCheck %s
+
+struct s {
+  template <bool b = true> static bool f();
+};
+
+template <typename T> bool template_using_f(T) { return s::f(); }
+
+bool use_template_using_f() { return template_using_f(0); }
+
+template<>
+bool __declspec(dllexport) s::f<true>() { return true; }
+
+// CHECK-MS: dllexport {{.*}} @"??$f@$00@s@@SA_NXZ"
+// CHECK: dllexport {{.*}} @_ZN1s1fILb1EEEbv


### PR DESCRIPTION
In commit 0a20f541, "Better codegen support for DLL attributes being dropped after the first declaration (PR20792)", code was added to enable "dropping" of DLL attributes. The specific issue and example given was related to `dllimport` and this was the test case that was added in that commit.

However, the code also included the "dropping" of `dllexport` but no test case for this was added. This "dropping" of `dllexport` can cause a `dllexport` template specialization to incorrectly lose its `dllexport` attribute as shown by the test case in this patch.

As there appears to be no need for the "dropping" of `dllexport`, remove this code to fix this issue.