### PR TITLE
[lldb] Fixed PlatformPOSIX::DoLoadImage() in case of the Windows host

### DIFF
--- a/lldb/source/Plugins/Platform/POSIX/PlatformPOSIX.cpp
+++ b/lldb/source/Plugins/Platform/POSIX/PlatformPOSIX.cpp
@@ -678,8 +678,8 @@ uint32_t PlatformPOSIX::DoLoadImage(lldb_private::Process *process,
     loaded_image->Clear();
 
   std::string path;
-  path = remote_file.GetPath();
-  
+  path = remote_file.GetPath(false);
+
   ThreadSP thread_sp = process->GetThreadList().GetExpressionExecutionThread();
   if (!thread_sp) {
     error.SetErrorString("dlopen error: no thread available to call dlopen.");


### PR DESCRIPTION
Do not denormalize the path. This patch fixes #93092.

BTW, it would be great to be able to pass the style or triple to SBFileSpec. Currently it is impossible to create a posix SBFileSpec on the Windows host.