### PR TITLE
[lldb][tests] Transfer some environment variables into API tests on Windows platform.

### DIFF
--- a/lldb/test/API/lit.cfg.py
+++ b/lldb/test/API/lit.cfg.py
@@ -313,3 +313,22 @@ if "FREEBSD_LEGACY_PLUGIN" in os.environ:
 # Propagate XDG_CACHE_HOME
 if "XDG_CACHE_HOME" in os.environ:
     config.environment["XDG_CACHE_HOME"] = os.environ["XDG_CACHE_HOME"]
+
+# Transfer some environment variables into the tests on Windows build host.
+if platform.system() == "Windows":
+    for v in [
+        "SystemDrive",
+        "SystemRoot",
+        "ALLUSERSPROFILE",
+        "APPDATA",
+        "LOCALAPPDATA",
+        "USERDNSDOMAIN",
+        "USERDOMAIN",
+        "USERNAME",
+        "USERPROFILE",
+        "USERDOMAIN_ROAMINGPROFILE",
+        "COMPUTERNAME",
+        "ProgramData",
+    ]:
+        if v in os.environ:
+            config.environment[v] = os.environ[v]


### PR DESCRIPTION
These environment variables avoid some side effects during execution of the remote API tests on Windows platform.

One of the side effect is a creating of weird folders, such as `<test-root-dir>\%SystemDrive%\...`, within the test directory.