### PR TITLE
[lldb] Allow specific 'make' tool for LLDB testsuite.

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/builders/builder.py
+++ b/lldb/packages/Python/lldbsuite/test/builders/builder.py
@@ -40,7 +40,9 @@ class Builder:
         """Returns the invocation for GNU make.
         The first argument is a tuple of the relative path to the testcase
         and its filename stem."""
-        if platform.system() == "FreeBSD" or platform.system() == "NetBSD":
+        if configuration.make_path is not None:
+            make = configuration.make_path
+        elif platform.system() == "FreeBSD" or platform.system() == "NetBSD":
             make = "gmake"
         else:
             make = "make"

--- a/lldb/packages/Python/lldbsuite/test/configuration.py
+++ b/lldb/packages/Python/lldbsuite/test/configuration.py
@@ -43,6 +43,7 @@ arch = None
 compiler = None
 dsymutil = None
 sdkroot = None
+make_path = None
 
 # The overriden dwarf verison.
 dwarf_version = 0

--- a/lldb/packages/Python/lldbsuite/test/dotest.py
+++ b/lldb/packages/Python/lldbsuite/test/dotest.py
@@ -266,6 +266,8 @@ def parseOptionsAndInitTestdirs():
                     configuration.compiler = candidate
                     break
 
+    if args.make:
+        configuration.make_path = args.make
     if args.dsymutil:
         configuration.dsymutil = args.dsymutil
     elif platform_system == "Darwin":

--- a/lldb/packages/Python/lldbsuite/test/dotest_args.py
+++ b/lldb/packages/Python/lldbsuite/test/dotest_args.py
@@ -88,6 +88,12 @@ def create_parser():
     )
 
     group.add_argument(
+        "--make",
+        metavar="make",
+        dest="make",
+        help=textwrap.dedent("Specify which make to use."),
+    )
+    group.add_argument(
         "--dsymutil",
         metavar="dsymutil",
         dest="dsymutil",

--- a/lldb/test/API/lit.cfg.py
+++ b/lldb/test/API/lit.cfg.py
@@ -227,6 +227,9 @@ if is_configured("clang_module_cache"):
 if is_configured("lldb_executable"):
     dotest_cmd += ["--executable", config.lldb_executable]
 
+if is_configured("make_executable"):
+    dotest_cmd += ["--make", config.make_executable]
+
 if is_configured("test_compiler"):
     dotest_cmd += ["--compiler", config.test_compiler]
 

--- a/lldb/test/API/lit.site.cfg.py.in
+++ b/lldb/test/API/lit.site.cfg.py.in
@@ -21,6 +21,7 @@ config.target_triple = "@LLVM_TARGET_TRIPLE@"
 config.lldb_build_directory = "@LLDB_TEST_BUILD_DIRECTORY@"
 config.python_executable = "@Python3_EXECUTABLE@"
 config.lua_executable = "@Lua_EXECUTABLE@"
+config.make_executable = "@Make_EXECUTABLE@"
 config.lua_test_entry = "TestLuaAPI.py"
 config.dotest_common_args_str = lit_config.substitute("@LLDB_TEST_COMMON_ARGS@")
 config.dotest_user_args_str = lit_config.substitute("@LLDB_TEST_USER_ARGS@")

--- a/lldb/test/CMakeLists.txt
+++ b/lldb/test/CMakeLists.txt
@@ -9,6 +9,16 @@ if (NOT DEFINED Python3_EXECUTABLE)
     "`LLDB_INCLUDE_TESTS=OFF`.")
 endif()
 
+if (NOT DEFINED Make_EXECUTABLE)
+  find_program(Make_EXECUTABLE NAMES make
+               PATH_SUFFIXES bin
+               DOC "Make build tool"
+               # Avoid searching with CMAKE_SYSROOT for the target platform.
+               # The target platform could be a binary incompatible.
+               NO_CMAKE_FIND_ROOT_PATH
+               REQUIRED)
+endif()
+
 if(LLDB_ENFORCE_STRICT_TEST_REQUIREMENTS)
   message(STATUS "Enforcing strict test requirements for LLDB")
   # Lit uses psutil to do per-test timeouts.

--- a/lldb/test/Shell/lit.site.cfg.py.in
+++ b/lldb/test/Shell/lit.site.cfg.py.in
@@ -16,6 +16,7 @@ config.lldb_lit_tools_dir = lit_config.substitute(r"@LLDB_LIT_TOOLS_DIR@")
 config.cmake_sysroot = lit_config.substitute("@CMAKE_SYSROOT@")
 config.target_triple = "@LLVM_TARGET_TRIPLE@"
 config.python_executable = "@Python3_EXECUTABLE@"
+config.make_executable = "@Make_EXECUTABLE@"
 config.have_zlib = @LLVM_ENABLE_ZLIB@
 config.objc_gnustep_dir = "@LLDB_TEST_OBJC_GNUSTEP_DIR@"
 config.lldb_enable_lzma = @LLDB_ENABLE_LZMA@

--- a/lldb/test/Unit/lit.site.cfg.py.in
+++ b/lldb/test/Unit/lit.site.cfg.py.in
@@ -10,6 +10,7 @@ config.lldb_obj_root = "@LLDB_BINARY_DIR@"
 config.lldb_src_root = "@LLDB_SOURCE_DIR@"
 config.target_triple = "@LLVM_TARGET_TRIPLE@"
 config.python_executable = "@Python3_EXECUTABLE@"
+config.make_executable = "@Make_EXECUTABLE@"
 
 import lit.llvm
 lit.llvm.initialize(lit_config, config)

--- a/lldb/test/lit.site.cfg.py.in
+++ b/lldb/test/lit.site.cfg.py.in
@@ -10,6 +10,7 @@ config.lldb_obj_root = "@LLDB_BINARY_DIR@"
 config.lldb_src_root = "@LLDB_SOURCE_DIR@"
 config.target_triple = "@LLVM_TARGET_TRIPLE@"
 config.python_executable = "@Python3_EXECUTABLE@"
+config.make_executable = "@Make_EXECUTABLE@"
 
 import lit.llvm
 lit.llvm.initialize(lit_config, config)

--- a/lldb/utils/lldb-dotest/lldb-dotest.in
+++ b/lldb/utils/lldb-dotest/lldb-dotest.in
@@ -19,6 +19,7 @@ has_libcxx = @LLDB_HAS_LIBCXX@
 libcxx_libs_dir = "@LIBCXX_LIBRARY_DIR@"
 libcxx_include_dir = "@LIBCXX_GENERATED_INCLUDE_DIR@"
 libcxx_include_target_dir = "@LIBCXX_GENERATED_INCLUDE_TARGET_DIR@"
+make_executable = "@Make_EXECUTABLE@"
 
 if __name__ == '__main__':
     wrapper_args = sys.argv[1:]
@@ -46,6 +47,8 @@ if __name__ == '__main__':
         cmd.extend(['--framework', lldb_framework_dir])
     if lldb_build_intel_pt == "1":
         cmd.extend(['--enable-plugin', 'intel-pt'])
+    if make_executable:
+        cmd.extend(['--make', make_executable])
     cmd.extend(['--lldb-obj-root', lldb_obj_root])
     cmd.extend(wrapper_args)
     # Invoke dotest.py and return exit code.


### PR DESCRIPTION
Because the 'make' tool is required to run the lldb testsuite a detection of this program was added to the CMake script. If 'make' tool is missed on the host CMake raises a fatal error now.

It is possible to provide a full path to the 'make' tool via 'Make_EXECUTABLE' CMake variable through the command line:

```
  cmake -DMake_EXECUTABLE=c:\path\to\make.exe ...
```

The found tool gets passed into the lldb testsuite scripts using a newly added argument --make. This option also can be used directly via LLDB_TEST_USER_ARGS CMake configuraion parameter:

```
  cmake ...
    -DLLDB_TEST_USER_ARGS="...;--make;C:\\Path\\to\\make.exe;..."
    ...
```

These options are useful on the Windows build hosts.