### PR TITLE
[Clang] Fix synthesis of defaulted operator==/<=> when class has an anonymous struct member

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -794,6 +794,8 @@ Bug Fixes to C++ Support
   Fixes (#GH87210), (GH89541).
 - Clang no longer tries to check if an expression is immediate-escalating in an unevaluated context.
   Fixes (#GH91308).
+- Fix defaulted ``operator==``/``operator<=>`` not working properly with
+  classes that have anonymous struct members (#GH92497).
 
 Bug Fixes to AST Handling
 ^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Fixes #92497

The existing implementation did try to drill into anonymous structs and compare them member by member, but it did not properly build up the member access expressions to include the anonymous struct members.

Note that this is different behaviour from GCC's anonymous struct extension where the defaulted comparison would compare `LHS.<anonymous struct>` with `RHS.<anonymous struct>`, which would fail if there is no overload for those types.

Example of the difference:

```c++
struct X {
    struct {
        bool b;
    };
    bool c;
    template<typename T>
    friend constexpr bool operator==(T& L, T& R) {
        // With GCC, T is the type of the anonymous struct
        // With Clang, this operator isn't used
        // (L.b and R.b are compared directly in the below operator==)
        static_assert(sizeof(T) == sizeof(bool));
        return L.b == R.b;
    }
    friend constexpr bool operator==(const X& L, const X& R) = default;
};

static_assert(X{} == X{});
```

This appears to be consistent with the Microsoft extension for anonymous structs