### PR TITLE
[ADT] Add SmallVectorImpl::append_range

### DIFF
--- a/llvm/include/llvm/ADT/SmallVector.h
+++ b/llvm/include/llvm/ADT/SmallVector.h
@@ -689,7 +689,7 @@ public:
   }
 
   template <typename RangeTy> void append_range(RangeTy &&R) {
-    this->append(R.begin(), R.end());
+    this->append(adl_begin(R), adl_end(R));
   }
 
   /// Append \p NumInputs copies of \p Elt to the end.

--- a/llvm/include/llvm/ADT/SmallVector.h
+++ b/llvm/include/llvm/ADT/SmallVector.h
@@ -688,6 +688,10 @@ public:
     this->set_size(this->size() + NumInputs);
   }
 
+  template <typename RangeTy> void append_range(RangeTy &&R) {
+    this->append(R.begin(), R.end());
+  }
+
   /// Append \p NumInputs copies of \p Elt to the end.
   void append(size_type NumInputs, ValueParamT Elt) {
     const T *EltPtr = this->reserveForParamAndGetAddress(Elt, NumInputs);

--- a/llvm/unittests/ADT/SmallVectorTest.cpp
+++ b/llvm/unittests/ADT/SmallVectorTest.cpp
@@ -517,6 +517,19 @@ TYPED_TEST(SmallVectorTest, AppendTest) {
   assertValuesInOrder(V, 3u, 1, 2, 3);
 }
 
+// Append range test
+TYPED_TEST(SmallVectorTest, AppendRangeTest) {
+  SCOPED_TRACE("AppendRangeTest");
+  auto &V = this->theVector;
+  auto &U = this->otherVector;
+  makeSequence(U, 5, 6);
+
+  V.push_back(Constructable(4));
+  V.append_range(U);
+
+  assertValuesInOrder(V, 3u, 4, 5, 6);
+}
+
 // Append repeated test
 TYPED_TEST(SmallVectorTest, AppendRepeatedTest) {
   SCOPED_TRACE("AppendRepeatedTest");


### PR DESCRIPTION
The new function is modeled after std::vector::append_range from
C++23.