### PR TITLE
[clang][CodeComplete] Recurse into the subexpression of deref operator in getApproximateType

### DIFF
--- a/clang/lib/Sema/SemaCodeComplete.cpp
+++ b/clang/lib/Sema/SemaCodeComplete.cpp
@@ -5680,8 +5680,16 @@ QualType getApproximateType(const Expr *E) {
     }
   }
   if (const auto *UO = llvm::dyn_cast<UnaryOperator>(E)) {
-    if (UO->getOpcode() == UnaryOperatorKind::UO_Deref)
-      return UO->getSubExpr()->getType()->getPointeeType();
+    if (UO->getOpcode() == UnaryOperatorKind::UO_Deref) {
+      // We recurse into the subexpression because it could be of dependent
+      // type.
+      QualType SubType = getApproximateType(UO->getSubExpr());
+      if (auto Pointee = SubType->getPointeeType(); !Pointee.isNull())
+        return Pointee;
+      // Our caller expects a non-null result, even though the SubType is
+      // supposed to have a pointee.
+      return SubType;
+    }
   }
   return Unresolved;
 }

--- a/clang/lib/Sema/SemaCodeComplete.cpp
+++ b/clang/lib/Sema/SemaCodeComplete.cpp
@@ -5683,12 +5683,11 @@ QualType getApproximateType(const Expr *E) {
     if (UO->getOpcode() == UnaryOperatorKind::UO_Deref) {
       // We recurse into the subexpression because it could be of dependent
       // type.
-      QualType SubType = getApproximateType(UO->getSubExpr());
-      if (auto Pointee = SubType->getPointeeType(); !Pointee.isNull())
+      if (auto Pointee = getApproximateType(UO->getSubExpr())->getPointeeType();
+          !Pointee.isNull())
         return Pointee;
       // Our caller expects a non-null result, even though the SubType is
-      // supposed to have a pointee.
-      return SubType;
+      // supposed to have a pointee. Fall through to Unresolved anyway.
     }
   }
   return Unresolved;

--- a/clang/test/CodeCompletion/member-access.cpp
+++ b/clang/test/CodeCompletion/member-access.cpp
@@ -367,4 +367,20 @@ class A {
 // CHECK-DEREF-THIS: [#void#]function()
   }
 };
+
+template <typename Element>
+struct RepeatedField {
+  void Add();
+};
+
+template <typename T>
+RepeatedField<T>* MutableRepeatedField() {}
+
+template <class T>
+void Foo() {
+  auto& C = *MutableRepeatedField<T>();
+  C.
+}
+// RUN: %clang_cc1 -fsyntax-only -code-completion-at=%s:382:5 %s -o - | FileCheck -check-prefix=CHECK-DEREF-DEPENDENT %s
+// CHECK-DEREF-DEPENDENT: [#void#]Add()
 }


### PR DESCRIPTION
The issue with the previous implementation bc31be7 was that getApproximateType could potentially return a null QualType for a dereferencing operator, which is not what its caller wants.