### PR TITLE
[Asan] Teach FunctionStackPoisoner to filter out struct type with scalable vector type.

### DIFF
--- a/llvm/lib/Transforms/Instrumentation/AddressSanitizer.cpp
+++ b/llvm/lib/Transforms/Instrumentation/AddressSanitizer.cpp
@@ -1139,16 +1139,10 @@ struct FunctionStackPoisoner : public InstVisitor<FunctionStackPoisoner> {
   /// Collect Alloca instructions we want (and can) handle.
   void visitAllocaInst(AllocaInst &AI) {
     // FIXME: Handle scalable vectors instead of ignoring them.
-    auto IsScalableVecTy = [](const Type *Ty) {
-      if (const auto *STy = dyn_cast<StructType>(Ty))
-        return any_of(STy->elements(), [](const Type *ElemTy) {
-          return isa<ScalableVectorType>(ElemTy);
-        });
-      return isa<ScalableVectorType>(Ty);
-    };
-
-    if (!ASan.isInterestingAlloca(AI) ||
-        IsScalableVecTy(AI.getAllocatedType())) {
+    const Type *AllocaType = AI.getAllocatedType();
+    const auto *STy = dyn_cast<StructType>(AllocaType);
+    if (!ASan.isInterestingAlloca(AI) || isa<ScalableVectorType>(AllocaType) ||
+        (STy && STy->containsHomogeneousScalableVectorTypes())) {
       if (AI.isStaticAlloca()) {
         // Skip over allocas that are present *before* the first instrumented
         // alloca, we don't want to move those around.

--- a/llvm/test/Instrumentation/AddressSanitizer/asan-struct-scalable.ll
+++ b/llvm/test/Instrumentation/AddressSanitizer/asan-struct-scalable.ll
@@ -1,0 +1,11 @@
+; RUN: opt -passes=asan -disable-output -S %s
+; Check not crash.
+
+define void @test() #0 {
+entry:
+  %t0 = alloca { <vscale x 2 x i32>, <vscale x 2 x i32> }, align 4
+  call void null(ptr null, ptr %t0, i64 0)
+  ret void
+}
+
+attributes #0 = { sanitize_address }


### PR DESCRIPTION
FunctionStackPoisoner does not serve for `AllocaInst` with scalable vector type, but it does not filter out struct type with scalable vector introduced by c8eb535aed0368c20b25fe05bca563ab38dd91e9.
Currently, llvm does not allows an element of a struct type with scalable vector is an element of a struct type vector, so we only need to check the first layer of the struct type of the `AllocaInst`.