### PR TITLE
[Clang][Sema] Use correct TemplateName when transforming TemplateSpecializationType

### DIFF
--- a/clang/test/SemaCXX/PR91677.cpp
+++ b/clang/test/SemaCXX/PR91677.cpp
@@ -1,0 +1,14 @@
+// RUN: %clang_cc1 -verify -std=c++20 -fsyntax-only %s
+// expected-no-diagnostics
+
+template <typename> struct t1 {
+  template <typename>
+  struct t2 {};
+};
+
+template <typename T>
+t1<T>::template t2<T> f1();
+
+void f2() {
+  f1<bool>();
+}

--- a/clang/test/SemaTemplate/typename-specifier-3.cpp
+++ b/clang/test/SemaTemplate/typename-specifier-3.cpp
@@ -28,16 +28,17 @@ namespace PR12884_original {
       typedef int arg;
     };
     struct C {
-      typedef B::X<typename B::arg> x; // precxx17-warning{{missing 'typename' prior to dependent type name B::X; implicit 'typename' is a C++20 extension}}
+      typedef B::X<typename B::arg> x; // precxx17-warning{{missing 'typename' prior to dependent type name B::X; implicit 'typename' is a C++20 extension}} \
+                                       cxx17-error{{typename specifier refers to non-type member 'arg' in 'PR12884_original::A<int>::B'}}
     };
   };
 
   template <> struct A<int>::B {
     template <int N> struct X {};
-    static const int arg = 0;
+    static const int arg = 0; // cxx17-note{{referenced member 'arg' is declared here}}
   };
 
-  A<int>::C::x a;
+  A<int>::C::x a; // cxx17-note{{in instantiation of member class 'PR12884_original::A<int>::C' requested here}}
 }
 namespace PR12884_half_fixed {
   template <typename T> struct A {


### PR DESCRIPTION
Consider the following testcase:
```cpp
namespace PR12884_original {
  template <typename T> struct A {
    struct B { ##1
      template <typename U> struct X {};
      typedef int arg;
    };
    struct C {
      typedef B::X<typename B::arg> x; 
    };
  };

  template <> struct A<int>::B { ##2
    template <int N> struct X {};
    static const int arg = 0;
  };

  A<int>::C::x a;
}
```
It will crash when compiling with `clang(assertions trunk)`. The reason is that we lookup `X`(`B::X`) in `##1` when instantiating `typedef B::X<typename B::arg> x; ` during instantiating `A<int>::C::x`. This is incorrect because we should lookup `X` in `##2` when we see the declaration `A<int>::C::x a;`. Since clang parse `A<T>::B<T>` to an `ElaboratedType`(`typename` is not required while compiling with `-std=c++20`)  while `typename A<T>::B<T>` turns to be a `DependentTemplateSpecializationType`, we should rebuild the `TemplateName` with transformed `Qualifier`(whose type is `NestedNameSpecifier`) to make sure the lookup context is correct.
This patch also attempts to fix #91677 which crashes with the same reason.