### PR TITLE
[SelectionDAG] Fix the assertion failure in Release build after #91747

### DIFF
--- a/llvm/lib/CodeGen/SelectionDAG/SelectionDAG.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/SelectionDAG.cpp
@@ -11293,10 +11293,12 @@ void SelectionDAG::ReplaceAllUsesWith(SDNode *From, const SDValue *To) {
     return ReplaceAllUsesWith(SDValue(From, 0), To[0]);
 
   for (unsigned i = 0, e = From->getNumValues(); i != e; ++i) {
-    // Preserve Debug Info.
-    transferDbgValues(SDValue(From, i), To[i]);
-    // Preserve extra info.
-    copyExtraInfo(From, To[i].getNode());
+    if (From->hasAnyUseOfValue(i)) {
+      // Preserve Debug Info.
+      transferDbgValues(SDValue(From, i), To[i]);
+      // Preserve extra info.
+      copyExtraInfo(From, To[i].getNode());
+    }
   }
 
   // Iterate over just the existing users of From. See the comments in


### PR DESCRIPTION
In #91747, we changed the SDNode from `X86ISD::SUB` (FROM) to `X86ISD::CCMP` (TO) in the DAGCombine. The value type of X86ISD::SUB can be `i8, i32` while the value type of X86ISD::CCMP is `i32`.

That means the `SDValue(FROM, 0)` is unused and may be removed. However, `transferDbgValues` assumes the value is not null, which is called by `ReplaceAllUsesWith(SDNode *, const SDValue *)`. So we need to check if the value has any use before calling the function.

Note: We already have same check in `ReplaceAllUsesWith(SDNode *, SDNode *)`.

This fix the error

```
SelectionDAG.cpp:10942: void
llvm::SelectionDAG::transferDbgValues(llvm::SDValue, llvm::SDValue,
unsigned int, unsigned int, bool): Assertion `FromNode && ToNode &&
"Can't modify dbg values"' failed.
```

for tests

llvm/test/CodeGen/X86/apx/ccmp.ll
llvm/test/CodeGen/X86/apx/ctest.ll

in Release build when LLVM_ENABLE_ASSERTIONS is on.