### PR TITLE
Fix bug in atomic_ref's calculation of lock_free-ness.

### DIFF
--- a/libcxx/include/__atomic/atomic_ref.h
+++ b/libcxx/include/__atomic/atomic_ref.h
@@ -105,7 +105,7 @@ public:
   // that the pointer is going to be aligned properly at runtime because that is a (checked) precondition
   // of atomic_ref's constructor.
   static constexpr bool is_always_lock_free =
-      __atomic_always_lock_free(sizeof(_Tp), reinterpret_cast<void*>(-required_alignment));
+      __atomic_always_lock_free(sizeof(_Tp), reinterpret_cast<_Tp*>(-required_alignment));
 
   _LIBCPP_HIDE_FROM_ABI bool is_lock_free() const noexcept { return __atomic_is_lock_free(sizeof(_Tp), __ptr_); }
 

--- a/libcxx/include/__atomic/atomic_ref.h
+++ b/libcxx/include/__atomic/atomic_ref.h
@@ -42,6 +42,19 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 
 #if _LIBCPP_STD_VER >= 20
 
+// These types are required to make __atomic_is_always_lock_free work across GCC and Clang.
+// GCC won't allow the reinterpret_cast<_Tp*>(-required_alignment) trick initially used,
+// so we need to actually fake up an instance of a type with the correct alignment.
+template <size_t _Alignment>
+struct __alignment_checker_type {
+  alignas(_Alignment) char __data;
+};
+
+template <size_t _Alignment>
+struct __get_aligner_instance {
+  static constexpr __alignment_checker_type<_Alignment> __instance{};
+};
+
 template <class _Tp>
 struct __atomic_ref_base {
 protected:
@@ -105,7 +118,7 @@ public:
   // that the pointer is going to be aligned properly at runtime because that is a (checked) precondition
   // of atomic_ref's constructor.
   static constexpr bool is_always_lock_free =
-      __atomic_always_lock_free(sizeof(_Tp), reinterpret_cast<_Tp*>(-required_alignment));
+      __atomic_always_lock_free(sizeof(_Tp), &__get_aligner_instance<required_alignment>::__instance);
 
   _LIBCPP_HIDE_FROM_ABI bool is_lock_free() const noexcept { return __atomic_is_lock_free(sizeof(_Tp), __ptr_); }
 
@@ -321,6 +334,7 @@ struct atomic_ref<_Tp> : public __atomic_ref_base<_Tp> {
   _LIBCPP_HIDE_FROM_ABI _Tp operator+=(_Tp __arg) const noexcept { return fetch_add(__arg) + __arg; }
   _LIBCPP_HIDE_FROM_ABI _Tp operator-=(_Tp __arg) const noexcept { return fetch_sub(__arg) - __arg; }
 };
+
 
 template <class _Tp>
 struct atomic_ref<_Tp*> : public __atomic_ref_base<_Tp*> {

--- a/libcxx/include/__atomic/atomic_ref.h
+++ b/libcxx/include/__atomic/atomic_ref.h
@@ -335,7 +335,6 @@ struct atomic_ref<_Tp> : public __atomic_ref_base<_Tp> {
   _LIBCPP_HIDE_FROM_ABI _Tp operator-=(_Tp __arg) const noexcept { return fetch_sub(__arg) - __arg; }
 };
 
-
 template <class _Tp>
 struct atomic_ref<_Tp*> : public __atomic_ref_base<_Tp*> {
   using __base = __atomic_ref_base<_Tp*>;

--- a/libcxx/test/std/atomics/atomics.ref/is_always_lock_free.pass.cpp
+++ b/libcxx/test/std/atomics/atomics.ref/is_always_lock_free.pass.cpp
@@ -20,22 +20,20 @@
 #include "test_macros.h"
 #include "atomic_helpers.h"
 
-
 template <typename T>
-void check_always_lock_free_subsumes_is_lock_free(std::atomic_ref<T> const a) {
+void check_always_lock_free(std::atomic_ref<T> const& a) {
   if (is_lock_free_status_known<T>()) {
-      constexpr LockFreeStatus known_status = get_known_atomic_lock_free_status<T>();
+    constexpr LockFreeStatus known_status = get_known_atomic_lock_free_status<T>();
 
-      static_assert(std::atomic_ref<T>::is_always_lock_free == (known_status == LockFreeStatus::always),
-              "is_always_lock_free is inconsistent with known lock-free status");
-      if (known_status == LockFreeStatus::always) {
-        assert(a.is_lock_free() && "is_lock_free() is inconsistent with known lock-free status");
-      } else if (known_status == LockFreeStatus::never) {
-        assert(!a.is_lock_free() && "is_lock_free() is inconsistent with known lock-free status");
-      } else {
-        assert(a.is_lock_free() || !a.is_lock_free()); // This is kinda dumb, but we might as well call the function once.
-      }
-
+    static_assert(std::atomic_ref<T>::is_always_lock_free == (known_status == LockFreeStatus::always),
+                  "is_always_lock_free is inconsistent with known lock-free status");
+    if (known_status == LockFreeStatus::always) {
+      assert(a.is_lock_free() && "is_lock_free() is inconsistent with known lock-free status");
+    } else if (known_status == LockFreeStatus::never) {
+      assert(!a.is_lock_free() && "is_lock_free() is inconsistent with known lock-free status");
+    } else {
+      assert(a.is_lock_free() || !a.is_lock_free()); // This is kinda dumb, but we might as well call the function once.
+    }
   }
   std::same_as<const bool> decltype(auto) is_always_lock_free = std::atomic_ref<T>::is_always_lock_free;
   if (is_always_lock_free) {
@@ -49,11 +47,10 @@ void check_always_lock_free_subsumes_is_lock_free(std::atomic_ref<T> const a) {
   do {                                                                                                                 \
     typedef T type;                                                                                                    \
     type obj{};                                                                                                        \
-    check_always_lock_free_subsumes_is_lock_free(std::atomic_ref<type>(obj));                                                                \
+    check_always_lock_free(std::atomic_ref<type>(obj));                                                                \
   } while (0)
 
 void check_always_lock_free_types() {
-
   static_assert(std::atomic_ref<int>::is_always_lock_free);
   static_assert(std::atomic_ref<char>::is_always_lock_free);
 }
@@ -65,13 +62,13 @@ void test() {
   check_always_lock_free_types();
 
   int i = 0;
-  check_always_lock_free_subsumes_is_lock_free(std::atomic_ref<int>(i));
+  check_always_lock_free(std::atomic_ref<int>(i));
 
   float f = 0.f;
-  check_always_lock_free_subsumes_is_lock_free(std::atomic_ref<float>(f));
+  check_always_lock_free(std::atomic_ref<float>(f));
 
   int* p = &i;
-  check_always_lock_free_subsumes_is_lock_free(std::atomic_ref<int*>(p));
+  check_always_lock_free(std::atomic_ref<int*>(p));
 
   CHECK_ALWAYS_LOCK_FREE(struct Empty{});
   CHECK_ALWAYS_LOCK_FREE(struct OneInt { int i; });

--- a/libcxx/test/std/atomics/atomics.ref/is_always_lock_free.pass.cpp
+++ b/libcxx/test/std/atomics/atomics.ref/is_always_lock_free.pass.cpp
@@ -18,9 +18,25 @@
 #include <concepts>
 
 #include "test_macros.h"
+#include "atomic_helpers.h"
+
 
 template <typename T>
-void check_always_lock_free(std::atomic_ref<T> const a) {
+void check_always_lock_free_subsumes_is_lock_free(std::atomic_ref<T> const a) {
+  if (is_lock_free_status_known<T>()) {
+      constexpr LockFreeStatus known_status = get_known_atomic_lock_free_status<T>();
+
+      static_assert(std::atomic_ref<T>::is_always_lock_free == (known_status == LockFreeStatus::always),
+              "is_always_lock_free is inconsistent with known lock-free status");
+      if (known_status == LockFreeStatus::always) {
+        assert(a.is_lock_free() && "is_lock_free() is inconsistent with known lock-free status");
+      } else if (known_status == LockFreeStatus::never) {
+        assert(!a.is_lock_free() && "is_lock_free() is inconsistent with known lock-free status");
+      } else {
+        assert(a.is_lock_free() || !a.is_lock_free()); // This is kinda dumb, but we might as well call the function once.
+      }
+
+  }
   std::same_as<const bool> decltype(auto) is_always_lock_free = std::atomic_ref<T>::is_always_lock_free;
   if (is_always_lock_free) {
     std::same_as<bool> decltype(auto) is_lock_free = a.is_lock_free();
@@ -33,18 +49,29 @@ void check_always_lock_free(std::atomic_ref<T> const a) {
   do {                                                                                                                 \
     typedef T type;                                                                                                    \
     type obj{};                                                                                                        \
-    check_always_lock_free(std::atomic_ref<type>(obj));                                                                \
+    check_always_lock_free_subsumes_is_lock_free(std::atomic_ref<type>(obj));                                                                \
   } while (0)
 
+void check_always_lock_free_types() {
+
+  static_assert(std::atomic_ref<int>::is_always_lock_free);
+  static_assert(std::atomic_ref<char>::is_always_lock_free);
+}
+
 void test() {
+  // While it's hard to portably test the value of is_always_lock_free, since different platforms have different support
+  // for atomic operations, it's still very important to do so. Specifically, it's important to have at least
+  // a few tests that have expected values.
+  check_always_lock_free_types();
+
   int i = 0;
-  check_always_lock_free(std::atomic_ref<int>(i));
+  check_always_lock_free_subsumes_is_lock_free(std::atomic_ref<int>(i));
 
   float f = 0.f;
-  check_always_lock_free(std::atomic_ref<float>(f));
+  check_always_lock_free_subsumes_is_lock_free(std::atomic_ref<float>(f));
 
   int* p = &i;
-  check_always_lock_free(std::atomic_ref<int*>(p));
+  check_always_lock_free_subsumes_is_lock_free(std::atomic_ref<int*>(p));
 
   CHECK_ALWAYS_LOCK_FREE(struct Empty{});
   CHECK_ALWAYS_LOCK_FREE(struct OneInt { int i; });

--- a/libcxx/test/std/atomics/atomics.ref/is_always_lock_free.pass.cpp
+++ b/libcxx/test/std/atomics/atomics.ref/is_always_lock_free.pass.cpp
@@ -22,8 +22,10 @@
 
 template <typename T>
 void check_always_lock_free(std::atomic_ref<T> const& a) {
-  if (is_lock_free_status_known<T>()) {
-    constexpr LockFreeStatus known_status = get_known_atomic_lock_free_status<T>();
+  using InfoT = LockFreeStatusInfo<T>;
+
+  if (InfoT::status_known) {
+    constexpr LockFreeStatus known_status = InfoT::value;
 
     static_assert(std::atomic_ref<T>::is_always_lock_free == (known_status == LockFreeStatus::always),
                   "is_always_lock_free is inconsistent with known lock-free status");

--- a/libcxx/test/support/atomic_helpers.h
+++ b/libcxx/test/support/atomic_helpers.h
@@ -50,23 +50,22 @@ constexpr bool msvc_is_lock_free_macro_value() {
 #  error "Unknown compiler"
 #endif
 enum class LockFreeStatus { unknown = -1, never = 0, sometimes = 1, always = 2 };
-#define COMPARE_TYPES(T1, T2) \
-  (sizeof(T1) == sizeof(T2) && alignof(T1) >= alignof(T2))
+#define COMPARE_TYPES(T1, T2) (sizeof(T1) == sizeof(T2) && alignof(T1) >= alignof(T2))
 
 template <class T>
 constexpr inline LockFreeStatus get_known_atomic_lock_free_status() {
-  return LockFreeStatus{COMPARE_TYPES(T, char)
-           ? TEST_ATOMIC_CHAR_LOCK_FREE
-           : (COMPARE_TYPES(T, short)
-                  ? TEST_ATOMIC_SHORT_LOCK_FREE
-                  : (COMPARE_TYPES(T, int)
-                         ? TEST_ATOMIC_INT_LOCK_FREE
-                         : (COMPARE_TYPES(T, long)
-                                ? TEST_ATOMIC_LONG_LOCK_FREE
-                                : (COMPARE_TYPES(T, long long)
-                                       ? TEST_ATOMIC_LLONG_LOCK_FREE
-                                       : (COMPARE_TYPES(T, void*) ? TEST_ATOMIC_POINTER_LOCK_FREE
-                                                                                   : -1)))))};
+  return LockFreeStatus{
+      COMPARE_TYPES(T, char)
+          ? TEST_ATOMIC_CHAR_LOCK_FREE
+          : (COMPARE_TYPES(T, short)
+                 ? TEST_ATOMIC_SHORT_LOCK_FREE
+                 : (COMPARE_TYPES(T, int)
+                        ? TEST_ATOMIC_INT_LOCK_FREE
+                        : (COMPARE_TYPES(T, long)
+                               ? TEST_ATOMIC_LONG_LOCK_FREE
+                               : (COMPARE_TYPES(T, long long)
+                                      ? TEST_ATOMIC_LLONG_LOCK_FREE
+                                      : (COMPARE_TYPES(T, void*) ? TEST_ATOMIC_POINTER_LOCK_FREE : -1)))))};
 }
 
 template <class T>
@@ -80,7 +79,6 @@ static_assert(is_lock_free_status_known<int>(), "");
 static_assert(is_lock_free_status_known<long>(), "");
 static_assert(is_lock_free_status_known<long long>(), "");
 static_assert(is_lock_free_status_known<void*>(), "");
-
 
 // These macros are somewhat suprising to use, since they take the values 0, 1, or 2.
 // To make the tests clearer, get rid of them in preference of AtomicInfo.


### PR DESCRIPTION
The builtin __atomic_always_lock_free takes into account the type of the
pointer provided as the second argument. Because we were passing void*,
rather than T*, the calculation failed. This meant that
atomic_ref<T>::is_always_lock_free was only true for char & bool.

This bug exists elsewhere in the atomic library (when using GCC, we fail
to pass a pointer at all, and we fail to correctly align the atomic like
_Atomic would).

This bug was not initially caught because we don't ever actually expect
a given value for `is_always_lock_free`. This problem is common
throughout atomic, where the tests have been written to assert that
_the value under test_ IS _the value under test_. Which leads to the
admission of bugs like this.

Further work is needed to clean up:

(A) Our detection of has-64-bit-atomics, which uses std::atomic to
determine if std::atomic is supported... (the type `LargeType` may be 64
bits in size, but it's required alignment is only 1 byte). This
configuration test was never intended to provide that information.

(B) The use of __atomic_is_always_lock_free in the GCC atomic
implementation, where we lie about whether a type is always lock free,
when the alignment for the std::atomic<T> is much smaller than required.
For example, struct Counter {int x; int y; };, which _Atomic Counter
aligns to 8 bytes, but our std::atomic<Counter> under GCC only aligns to
4, but still reports that the type is always lock free.

(C) std::atomic_ref<T>::required_alignment should often times be larger
than the natural alignment of the type if the sizeof(T) > alignof(T) and
sizeof(T) 2, 4, 8, or 16. (See the Counter example). In failing to do
so we make many types (Again, see Counter), non-lock free even when
there are atomic instructions on the host that support types of that
size.

(D) We need to actually test against hard coded values throughout our
atomic tests to avoid these sorts of bugs in the future. This probably
means auditing the entire atomic test suite.

This change attempts to start sorting out the testing difficulties
by using the __GCC_ATOMIC_(CHAR|SHORT|INT|LONG|LLONG|POINTER)_IS_LOCK_FREE
predefined macros to establish an expected value for
`is_always_lock_free` and `is_lock_free` for the respective types,
as well as types with matching sizes and compatible alignment values
(Where compatible alignment meants alignof(T) >=
alignof(char|short|int|long|long long) for the matching sized type).

Using these compiler pre-defines we can actually validate that certain
types, like char and int, are actually always lock free like they are
on every platform in the wild(*).

(*) At least for every platform we care about.

Fixing (B) reqires an ABI break where we bump the alignment on the
type std::atomic<T> to match that of _Atomic T (were we under clang).

Fixing (C) also requires an ABI break, but atomic_ref is new enough
that we should consider it ASAP. (Though fixing (C) is arguably more of
a QoI detail, but it's a big one, since we don't want the runtime
alignment of memory to determine the locking behavior of the atomic).
