### PR TITLE
Revert "[X86] Use generic CPU tuning when tune-cpu is empty"

### DIFF
--- a/llvm/lib/Target/X86/X86Subtarget.cpp
+++ b/llvm/lib/Target/X86/X86Subtarget.cpp
@@ -252,7 +252,7 @@ void X86Subtarget::initSubtargetFeatures(StringRef CPU, StringRef TuneCPU,
     CPU = "generic";
 
   if (TuneCPU.empty())
-    TuneCPU = HasX86_64 ? "generic" : "i586";
+    TuneCPU = "i586"; // FIXME: "generic" is more modern than llc tests expect.
 
   std::string FullFS = X86_MC::ParseX86Triple(TargetTriple);
   assert(!FullFS.empty() && "Failed to parse X86 triple");


### PR DESCRIPTION
Reverts llvm/llvm-project#83631

Using `HasX86_64` is incorrect.