### PR TITLE
[flang][OpenMP] Skip assertion while processing default clause on disallowed constructs

### DIFF
--- a/flang/lib/Semantics/resolve-directives.cpp
+++ b/flang/lib/Semantics/resolve-directives.cpp
@@ -2108,9 +2108,11 @@ void OmpAttributeVisitor::Post(const parser::Name &name) {
           dirContext.defaultDSA == Symbol::Flag::OmpFirstPrivate ||
           dirContext.defaultDSA == Symbol::Flag::OmpShared) {
         // 1) default
-        // Allowed only with parallel, teams and task generating constructs.
-        assert(parallelDir || taskGenDir ||
-            llvm::omp::allTeamsSet.test(dirContext.directive));
+        // Allowed only with parallel, teams and task generating constructs,
+        // skip creating symbols thus.
+        if (!(parallelDir || taskGenDir ||
+                llvm::omp::allTeamsSet.test(dirContext.directive)))
+          return;
         if (dirContext.defaultDSA != Symbol::Flag::OmpShared)
           declNewSymbol(dirContext.defaultDSA);
         else

--- a/flang/test/Semantics/OpenMP/ordered01.f90
+++ b/flang/test/Semantics/OpenMP/ordered01.f90
@@ -9,11 +9,9 @@ program main
   real, external :: foo, bar, baz
  
   !ERROR: DEFAULT clause is not allowed on the DO directive
-  !$omp do ordered default(private)
+  !$omp do default(private)
   do i = 1, N
-     !$omp ordered
        arrayA(i) = arrayA(i) + 1
-     !$omp end ordered
   end do
   !$omp end do
 

--- a/flang/test/Semantics/OpenMP/ordered01.f90
+++ b/flang/test/Semantics/OpenMP/ordered01.f90
@@ -7,6 +7,15 @@ program main
   integer :: i, N = 10
   real :: a, arrayA(10), arrayB(10), arrayC(10)
   real, external :: foo, bar, baz
+ 
+  !ERROR: DEFAULT clause is not allowed on the DO directive
+  !$omp do ordered default(private)
+  do i = 1, N
+     !$omp ordered
+       arrayA(i) = arrayA(i) + 1
+     !$omp end ordered
+  end do
+  !$omp end do
 
   !$omp do ordered
   do i = 1, N


### PR DESCRIPTION
Currently, the handling of default clause on directives enforces an assertion on whether default clause is allowed on the directive. This causes crashes when default is erroneously defined on a directive. This PR skips the assertion, as such semantic checks are handled elsewhere.

Fixes https://github.com/llvm/llvm-project/issues/93437