### PR TITLE
[mlir][Bazel] Add a comment and move deps list into an extra line.

### DIFF
--- a/utils/bazel/llvm-project-overlay/mlir/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/mlir/BUILD.bazel
@@ -6270,18 +6270,22 @@ cc_library(
     srcs = ["lib/Target/LLVM/NVVM/Target.cpp"],
     hdrs = glob(["include/mlir/Target/LLVM/NVVM/*.h"]),
     includes = ["include"],
-    deps = [
-        ":GPUDialect",
-        ":GPUToLLVMIRTranslation",
-        ":LLVMToLLVMIRTranslation",
-        ":NVVMDialect",
-        ":NVVMToLLVMIRTranslation",
-        ":TargetLLVM",
-        ":ToLLVMIRTranslation",
-        "//llvm:NVPTXCodeGen",
-        "//llvm:Support",
-        "//llvm:config",
-    ],
+    deps =
+        # Start the deps list in an extra line. This makes it easier for
+        # downstream users to transform the BUILD file and add extra deps behind
+        # guards.
+        [
+            ":GPUDialect",
+            ":GPUToLLVMIRTranslation",
+            ":LLVMToLLVMIRTranslation",
+            ":NVVMDialect",
+            ":NVVMToLLVMIRTranslation",
+            ":TargetLLVM",
+            ":ToLLVMIRTranslation",
+            "//llvm:NVPTXCodeGen",
+            "//llvm:Support",
+            "//llvm:config",
+        ],
 )
 
 td_library(


### PR DESCRIPTION
This is a non-functional change in OSS, but makes it easier for downstream users to run transforms on NVVMTarget.