### PR TITLE
[CodeGen] Enable `HandleUnknown` for pointer types

### DIFF
--- a/llvm/lib/Target/X86/X86TargetTransformInfo.cpp
+++ b/llvm/lib/Target/X86/X86TargetTransformInfo.cpp
@@ -6257,7 +6257,9 @@ InstructionCost X86TTIImpl::getInterleavedMemoryOpCostAVX512(
                                 AddressSpace, CostKind);
 
   unsigned VF = VecTy->getNumElements() / Factor;
-  MVT VT = MVT::getVectorVT(MVT::getVT(VecTy->getScalarType()), VF);
+  // FIXME: Handle this case correctly
+  bool IgnorePtrTy = VecTy->getScalarType()->isPointerTy();
+  MVT VT = MVT::getVectorVT(MVT::getVT(VecTy->getScalarType(), IgnorePtrTy), VF);
 
   InstructionCost MaskCost;
   if (UseMaskedMemOp) {


### PR DESCRIPTION
This is a temporary workaround for the build issues we are observing after https://github.com/llvm/llvm-project/pull/92671. It re-enables the handling of pointer types by simply passing the HandleUnknown flag to getVT set to true whenever a PointerTy is encountered.

I don't know if this is acceptable, or preferred over a revert of the referenced patch.