### PR TITLE
[MC] Explicitly request executable stacks

### DIFF
--- a/llvm/include/llvm/MC/MCAsmInfo.h
+++ b/llvm/include/llvm/MC/MCAsmInfo.h
@@ -580,6 +580,13 @@ public:
     return nullptr;
   }
 
+  /// Targets can implement this method to specify a section to switch to if
+  /// the translation unit does have trampolines that require an executable
+  /// stack.
+  virtual MCSection *getExecutableStackSection(MCContext &Ctx) const {
+    return nullptr;
+  }
+
   /// True if the section is atomized using the symbols in it.
   /// This is false if the section is not atomized at all (most ELF sections) or
   /// if it is atomized based on its contents (MachO' __TEXT,__cstring for

--- a/llvm/include/llvm/MC/MCAsmInfoELF.h
+++ b/llvm/include/llvm/MC/MCAsmInfoELF.h
@@ -16,6 +16,7 @@ namespace llvm {
 class MCAsmInfoELF : public MCAsmInfo {
   virtual void anchor();
   MCSection *getNonexecutableStackSection(MCContext &Ctx) const final;
+  MCSection *getExecutableStackSection(MCContext &Ctx) const final;
 
 protected:
   MCAsmInfoELF();

--- a/llvm/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
@@ -2532,9 +2532,15 @@ bool AsmPrinter::doFinalization(Module &M) {
   // If we don't have any trampolines, then we don't require stack memory
   // to be executable. Some targets have a directive to declare this.
   Function *InitTrampolineIntrinsic = M.getFunction("llvm.init.trampoline");
-  if (!InitTrampolineIntrinsic || InitTrampolineIntrinsic->use_empty())
+  if (!InitTrampolineIntrinsic || InitTrampolineIntrinsic->use_empty()) {
     if (MCSection *S = MAI->getNonexecutableStackSection(OutContext))
       OutStreamer->switchSection(S);
+  } else {
+    // This is platform dependent, so we better explicitly request an executable
+    // stack.
+    if (MCSection *S = MAI->getExecutableStackSection(OutContext))
+      OutStreamer->switchSection(S);
+  }
 
   if (TM.Options.EmitAddrsig) {
     // Emit address-significance attributes for all globals.

--- a/llvm/lib/MC/MCAsmInfoELF.cpp
+++ b/llvm/lib/MC/MCAsmInfoELF.cpp
@@ -28,6 +28,16 @@ MCSection *MCAsmInfoELF::getNonexecutableStackSection(MCContext &Ctx) const {
   return Ctx.getELFSection(".note.GNU-stack", ELF::SHT_PROGBITS, 0);
 }
 
+// We use this to effectively force an executable stack
+MCSection *MCAsmInfoELF::getExecutableStackSection(MCContext &Ctx) const {
+  // Solaris doesn't know/doesn't care about .note.GNU-stack sections, so
+  // don't emit them.
+  if (Ctx.getTargetTriple().isOSSolaris())
+    return nullptr;
+  return Ctx.getELFSection(".note.GNU-stack", ELF::SHT_PROGBITS,
+                           ELF::SHF_EXECINSTR);
+}
+
 MCAsmInfoELF::MCAsmInfoELF() {
   HasIdentDirective = true;
   WeakRefDirective = "\t.weak\t";

--- a/llvm/test/CodeGen/X86/2011-08-23-Trampoline.ll
+++ b/llvm/test/CodeGen/X86/2011-08-23-Trampoline.ll
@@ -14,3 +14,5 @@ declare void @gnat__perfect_hash_generators__select_char_position__build_identic
 
 declare void @llvm.init.trampoline(ptr, ptr, ptr) nounwind 
 declare ptr @llvm.adjust.trampoline(ptr) nounwind 
+
+; CHECK: .section ".note.GNU-stack","x",@progbits


### PR DESCRIPTION
We are working on Fortran applications on RISC-V and some of them rely on passing a pointer to an internal (aka nested) function that uses the enclosing context (e.g., a variable of the enclosing function). [Flang uses trampolines](https://flang.llvm.org/docs/InternalProcedureTrampolines.html) which rely on `llvm.init.trampoline` and `llvm.adjust.trampoline`. Those rely on having an executable stack.

This change is a preliminary step to support trampolines on RISC-V.

According to GNU ld's manual

> If an input file does not have a .note.GNU-stack section present then
> the default behaviour is target specific.

We currently disable explicit stacks by default. But when we do need them, we instead rely on the default of them being enabled. This is not true for all the architectures. In special for RISC-V where executable stacks are disabled by default.

This changes to always emit the note.GNU-stack section.

The updated test belongs to X86 because at this point RISC-V still does not support trampolines. This will come in a later change.