### PR TITLE
[AMDGPU][SplitModule] Keep looking for more dependencies after finding an indirect call

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPUSplitModule.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUSplitModule.cpp
@@ -340,7 +340,7 @@ static void addAllDependencies(SplitModuleLogger &SML, const CallGraph &CG,
         // TODO: Print an ORE as well ?
         addAllIndirectCallDependencies(M, Fns);
         HadIndirectCall = true;
-        return;
+        continue;
       }
 
       if (Callee->isDeclaration())

--- a/llvm/test/tools/llvm-split/AMDGPU/kernels-dependency-indirect.ll
+++ b/llvm/test/tools/llvm-split/AMDGPU/kernels-dependency-indirect.ll
@@ -10,13 +10,17 @@
 ; We default to putting A/B in P0, alongside a copy
 ; of all helpers who have their address taken.
 ; The other kernels can still go into separate partitions.
+;
+; Note that dependency discovery shouldn't stop upon finding an
+; indirect call. HelperC/D should also end up in P0 as they
+; are dependencies of HelperB.
 
 ; CHECK0-NOT: define
 ; CHECK0: define hidden void @HelperA
 ; CHECK0: define hidden void @HelperB
 ; CHECK0: define hidden void @CallCandidate
-; CHECK0-NOT: define {{.*}} @HelperC
-; CHECK0-NOT: define {{.*}} @HelperD
+; CHECK0: define internal void @HelperC
+; CHECK0: define internal void @HelperD
 ; CHECK0: define amdgpu_kernel void @A
 ; CHECK0: define amdgpu_kernel void @B
 ; CHECK0-NOT: define
@@ -39,7 +43,9 @@ define internal void @HelperA(ptr %call) {
 }
 
 define internal void @HelperB(ptr %call) {
+  call void @HelperC()
   call void %call()
+  call void @HelperD()
   ret void
 }
 


### PR DESCRIPTION
This is just something I noticed while going over this pass logic one more time and didn't cause issues (yet). If we find an indirect call, we stop looking assuming we added all functions to the list, but if not all functions in the module were indirectly callable, some may still be missing.

Just to be safe, keep looking until we did everything we could to find dependencies, so we don't accidentally miss one.