### PR TITLE
[CI] Disable flang from pre-commit tests when Flang files are not touched

### DIFF
--- a/.ci/generate-buildkite-pipeline-premerge
+++ b/.ci/generate-buildkite-pipeline-premerge
@@ -63,7 +63,7 @@ function compute-projects-to-test() {
       done
     ;;
     llvm)
-      for p in bolt clang clang-tools-extra flang lld lldb mlir polly; do
+      for p in bolt clang clang-tools-extra lld lldb mlir polly; do
         echo $p
       done
     ;;
@@ -74,9 +74,6 @@ function compute-projects-to-test() {
     ;;
     clang-tools-extra)
       echo libc
-    ;;
-    mlir)
-      echo flang
     ;;
     *)
       # Nothing to do
@@ -144,7 +141,6 @@ function exclude-windows() {
     cross-project-tests) ;; # tests failing
     compiler-rt)         ;; # tests taking too long
     openmp)              ;; # TODO: having trouble with the Perl installation
-    flang)               ;; # https://discourse.llvm.org/t/flang-tests-are-extremely-slow-on-windows/78591/40
     libc)                ;; # no Windows support
     lldb)                ;; # tests failing
     bolt)                ;; # tests are not supported yet

--- a/.ci/generate-buildkite-pipeline-premerge
+++ b/.ci/generate-buildkite-pipeline-premerge
@@ -144,6 +144,7 @@ function exclude-windows() {
     cross-project-tests) ;; # tests failing
     compiler-rt)         ;; # tests taking too long
     openmp)              ;; # TODO: having trouble with the Perl installation
+    flang)               ;; # https://discourse.llvm.org/t/flang-tests-are-extremely-slow-on-windows/78591/40
     libc)                ;; # no Windows support
     lldb)                ;; # tests failing
     bolt)                ;; # tests are not supported yet


### PR DESCRIPTION
Flang pre-commit tests are triggered when any file in LLVM or MLIR are touched. However, Flang is not yet achieved a stable CI, which have caused instability to many other completely unrelated PRs. This PR disables Flang tests on non-Flang changes on pre-commit, but does nothing to post-commit tests, which continue to run as is.

Once Flang becomes stable like Clang and MLIR we can re-enable it on pre-commit tests, following our current staged policy on CI, testing and reporting failures.