### PR TITLE
[flang] Add fir.declare handling in --fir-to-llvm-ir

### DIFF
--- a/flang/lib/Optimizer/CodeGen/CodeGen.cpp
+++ b/flang/lib/Optimizer/CodeGen/CodeGen.cpp
@@ -171,11 +171,12 @@ genAllocationScaleSize(OP op, mlir::Type ity,
 }
 
 namespace {
-struct DeclareOpConversion : public fir::FIROpConversion<fir::cg::XDeclareOp> {
-public:
-  using FIROpConversion::FIROpConversion;
+template <typename OP>
+struct DeclareCommonConversion : public fir::FIROpConversion<OP> {
+  using fir::FIROpConversion<OP>::FIROpConversion;
+  using OpAdaptor = typename OP::Adaptor;
   mlir::LogicalResult
-  matchAndRewrite(fir::cg::XDeclareOp declareOp, OpAdaptor adaptor,
+  matchAndRewrite(OP declareOp, OpAdaptor adaptor,
                   mlir::ConversionPatternRewriter &rewriter) const override {
     auto memRef = adaptor.getOperands()[0];
     if (auto fusedLoc = mlir::dyn_cast<mlir::FusedLoc>(declareOp.getLoc())) {
@@ -3752,19 +3753,21 @@ void fir::populateFIRToLLVMConversionPatterns(
       BoxOffsetOpConversion, BoxProcHostOpConversion, BoxRankOpConversion,
       BoxTypeCodeOpConversion, BoxTypeDescOpConversion, CallOpConversion,
       CmpcOpConversion, ConstcOpConversion, ConvertOpConversion,
-      CoordinateOpConversion, DTEntryOpConversion, DeclareOpConversion,
-      DivcOpConversion, EmboxOpConversion, EmboxCharOpConversion,
-      EmboxProcOpConversion, ExtractValueOpConversion, FieldIndexOpConversion,
-      FirEndOpConversion, FreeMemOpConversion, GlobalLenOpConversion,
-      GlobalOpConversion, HasValueOpConversion, InsertOnRangeOpConversion,
-      InsertValueOpConversion, IsPresentOpConversion, LenParamIndexOpConversion,
-      LoadOpConversion, MulcOpConversion, NegcOpConversion,
-      NoReassocOpConversion, SelectCaseOpConversion, SelectOpConversion,
-      SelectRankOpConversion, SelectTypeOpConversion, ShapeOpConversion,
-      ShapeShiftOpConversion, ShiftOpConversion, SliceOpConversion,
-      StoreOpConversion, StringLitOpConversion, SubcOpConversion,
-      TypeDescOpConversion, TypeInfoOpConversion, UnboxCharOpConversion,
-      UnboxProcOpConversion, UndefOpConversion, UnreachableOpConversion,
+      CoordinateOpConversion, DTEntryOpConversion,
+      DeclareCommonConversion<fir::cg::XDeclareOp>,
+      DeclareCommonConversion<fir::DeclareOp>, DivcOpConversion,
+      EmboxOpConversion, EmboxCharOpConversion, EmboxProcOpConversion,
+      ExtractValueOpConversion, FieldIndexOpConversion, FirEndOpConversion,
+      FreeMemOpConversion, GlobalLenOpConversion, GlobalOpConversion,
+      HasValueOpConversion, InsertOnRangeOpConversion, InsertValueOpConversion,
+      IsPresentOpConversion, LenParamIndexOpConversion, LoadOpConversion,
+      MulcOpConversion, NegcOpConversion, NoReassocOpConversion,
+      SelectCaseOpConversion, SelectOpConversion, SelectRankOpConversion,
+      SelectTypeOpConversion, ShapeOpConversion, ShapeShiftOpConversion,
+      ShiftOpConversion, SliceOpConversion, StoreOpConversion,
+      StringLitOpConversion, SubcOpConversion, TypeDescOpConversion,
+      TypeInfoOpConversion, UnboxCharOpConversion, UnboxProcOpConversion,
+      UndefOpConversion, UnreachableOpConversion,
       UnrealizedConversionCastOpConversion, XArrayCoorOpConversion,
       XEmboxOpConversion, XReboxOpConversion, ZeroOpConversion>(converter,
                                                                 options);

--- a/flang/test/Fir/convert-to-llvm.fir
+++ b/flang/test/Fir/convert-to-llvm.fir
@@ -2708,7 +2708,7 @@ func.func @_QPsub() {
   return
 }
 // CHECK-LABEL: llvm.func @_QPsub() {
-// CHECK:         %0 = llvm.mlir.constant(1 : i64) : i64
-// CHECK:         %1 = llvm.alloca %0 x i32 {bindc_name = "x"} : (i64) -> !llvm.ptr
+// CHECK:         %[[VAL_0:.*]] = llvm.mlir.constant(1 : i64) : i64
+// CHECK:         %[[VAL_1:.*]] = llvm.alloca %[[VAL_0]] x i32 {bindc_name = "x"} : (i64) -> !llvm.ptr
 // CHECK:         llvm.return
 // CHECK:       }

--- a/flang/test/Fir/convert-to-llvm.fir
+++ b/flang/test/Fir/convert-to-llvm.fir
@@ -2698,3 +2698,17 @@ func.func @coordinate_array_unknown_size_1d(%arg0: !fir.ptr<!fir.array<? x i32>>
 // CHECK:           %[[VAL_2:.*]] = llvm.getelementptr %[[VAL_0]]{{\[}}%[[VAL_1]]] : (!llvm.ptr, i64) -> !llvm.ptr, i32
 // CHECK:           llvm.return
 // CHECK:         }
+
+// -----
+
+// Test `fir.declare` conversion.
+func.func @_QPsub() {
+  %0 = fir.alloca i32 {bindc_name = "x", uniq_name = "_QFsubEx"}
+  %1 = fir.declare %0 {uniq_name = "_QFsubEx"} : (!fir.ref<i32>) -> !fir.ref<i32>
+  return
+}
+// CHECK-LABEL: llvm.func @_QPsub() {
+// CHECK:         %0 = llvm.mlir.constant(1 : i64) : i64
+// CHECK:         %1 = llvm.alloca %0 x i32 {bindc_name = "x"} : (i64) -> !llvm.ptr
+// CHECK:         llvm.return
+// CHECK:       }


### PR DESCRIPTION

```
func.func @_QPsub() {
  %0 = fir.alloca i32 {bindc_name = "x", uniq_name = "_QFsubEx"}
  %1 = fir.declare %0 {uniq_name = "_QFsubEx"} : (!fir.ref<i32>) -> !fir.ref<i32>
  return
}
```
Currently, `fir.declare` is not recognized in `--fir-to-llvm-ir`.
```
$ fir-opt --fir-to-llvm-ir declare.mlir 
declare.mlir:3:10: error: failed to legalize operation 'fir.declare'
    %1 = fir.declare %0 {uniq_name = "_QFsubEx"} : (!fir.ref<i32>) -> !fir.ref<i32>
         ^
declare.mlir:3:10: note: see current operation: %3 = "fir.declare"(%2) <{operandSegmentSizes = array<i32: 1, 0, 0, 0>, uniq_name = "_QFsubEx"}> : (!fir.ref<i32>) -> !fir.ref<i32>
```
