### PR TITLE
[IRInterpreter] Return zero address for missing weak function

### DIFF
--- a/lldb/source/Expression/IRInterpreter.cpp
+++ b/lldb/source/Expression/IRInterpreter.cpp
@@ -264,7 +264,7 @@ public:
         lldb_private::ConstString name(constant_func->getName());
         bool missing_weak = false;
         lldb::addr_t addr = m_execution_unit.FindSymbol(name, missing_weak);
-        if (addr == LLDB_INVALID_ADDRESS || missing_weak)
+        if (addr == LLDB_INVALID_ADDRESS)
           return false;
         value = APInt(m_target_data.getPointerSizeInBits(), addr);
         return true;


### PR DESCRIPTION
If a weak function is missing, still return it's address (zero) rather than failing interpretation. Otherwise we have a mismatch between Interpret() and CanInterpret() resulting in failures that would not occur with JIT execution.

Alternatively, we could try to look for weak symbols in CanInterpret() and generally reject them there.

This is the root cause for the issue exposed by
https://github.com/llvm/llvm-project/pull/92885. Previously, the case affected by that always fell back to JIT because an icmp constant expression was used, which is not supported by the interpreter. Now a normal icmp instruction is used, which is supported. However, we fail to interpret due to incorrect handling of weak function addresses.