### PR TITLE
[mlir][cl_parser] Support cl::Required/cl::OneOrMore flags for Pass options

### DIFF
--- a/llvm/include/llvm/Support/CommandLine.h
+++ b/llvm/include/llvm/Support/CommandLine.h
@@ -2290,6 +2290,9 @@ void ResetCommandLineParser();
 /// Parses `Arg` into the option handler `Handler`.
 bool ProvidePositionalOption(Option *Handler, StringRef Arg, int i);
 
+/// Verify that every Required/OneOrMore option has a value.
+bool CheckRequiredValues(const StringMap<Option *> &OptionsMap);
+
 } // end namespace cl
 
 } // end namespace llvm

--- a/llvm/lib/Support/CommandLine.cpp
+++ b/llvm/lib/Support/CommandLine.cpp
@@ -792,6 +792,17 @@ static bool EatsUnboundedNumberOfValues(const Option *O) {
          O->getNumOccurrencesFlag() == cl::OneOrMore;
 }
 
+bool llvm::cl::CheckRequiredValues(const StringMap<Option *> &OptionsMap) {
+  // Loop over args and make sure all required args are specified!
+  for (const auto &Opt : OptionsMap) {
+    if (RequiresValue(Opt.second) && Opt.second->getNumOccurrences() == 0) {
+      Opt.second->error("must be specified at least once!");
+      return false;
+    }
+  }
+  return true;
+}
+
 static bool isWhitespace(char C) {
   return C == ' ' || C == '\t' || C == '\r' || C == '\n';
 }
@@ -1795,20 +1806,8 @@ bool CommandLineParser::ParseCommandLineOptions(int argc,
                                   PositionalVals[ValNo].second);
   }
 
-  // Loop over args and make sure all required args are specified!
-  for (const auto &Opt : OptionsMap) {
-    switch (Opt.second->getNumOccurrencesFlag()) {
-    case Required:
-    case OneOrMore:
-      if (Opt.second->getNumOccurrences() == 0) {
-        Opt.second->error("must be specified at least once!");
-        ErrorParsing = true;
-      }
-      [[fallthrough]];
-    default:
-      break;
-    }
-  }
+  if (!CheckRequiredValues(OptionsMap))
+    ErrorParsing = true;
 
   // Now that we know if -debug is specified, we can use it.
   // Note that if ReadResponseFiles == true, this must be done before the

--- a/mlir/lib/Pass/PassRegistry.cpp
+++ b/mlir/lib/Pass/PassRegistry.cpp
@@ -299,6 +299,9 @@ LogicalResult detail::PassOptions::parseFromString(StringRef options,
       return failure();
   }
 
+  if (!llvm::cl::CheckRequiredValues(OptionsMap))
+    return failure();
+
   return success();
 }
 


### PR DESCRIPTION
This PR export and add the sanity check performed in `CommandLineParser::ParseCommandLineOptions()` to `PassOptions::parseFromString()`, so that `cl::Required` and `cl::OneOrMore` flags on Pass option behave the same as regular `cl::opt` in the global command parser.