### PR TITLE
[BOLT][AArch64] Implement PLTCall optimization

### DIFF
--- a/bolt/include/bolt/Core/MCPlusBuilder.h
+++ b/bolt/include/bolt/Core/MCPlusBuilder.h
@@ -14,7 +14,6 @@
 #ifndef BOLT_CORE_MCPLUSBUILDER_H
 #define BOLT_CORE_MCPLUSBUILDER_H
 
-#include "bolt/Core/BinaryBasicBlock.h"
 #include "bolt/Core/MCPlus.h"
 #include "bolt/Core/Relocation.h"
 #include "llvm/ADT/ArrayRef.h"
@@ -1413,19 +1412,14 @@ public:
     return false;
   }
 
-  /// Modify a direct call instruction pointed by the iterator \p It, with an
-  /// indirect call taking a destination from a memory location pointed by \p
-  /// TargetLocation symbol. If additional instructions need to be prepended
-  /// before \p It, then the iterator must be updated to point to the indirect
-  /// call instruction.
-  ///
-  /// \return true on success
-  virtual bool convertCallToIndirectCall(BinaryBasicBlock &BB,
-                                         BinaryBasicBlock::iterator &It,
-                                         const MCSymbol *TargetLocation,
-                                         MCContext *Ctx) {
+  /// Creates an indirect call to the function within the \p DirectCall PLT
+  /// stub. The function's memory location is pointed by the \p TargetLocation
+  /// symbol.
+  virtual InstructionListType
+  createIndirectPltCall(const MCInst &DirectCall,
+                        const MCSymbol *TargetLocation, MCContext *Ctx) {
     llvm_unreachable("not implemented");
-    return false;
+    return {};
   }
 
   /// Morph an indirect call into a load where \p Reg holds the call target.

--- a/bolt/include/bolt/Core/MCPlusBuilder.h
+++ b/bolt/include/bolt/Core/MCPlusBuilder.h
@@ -14,6 +14,7 @@
 #ifndef BOLT_CORE_MCPLUSBUILDER_H
 #define BOLT_CORE_MCPLUSBUILDER_H
 
+#include "bolt/Core/BinaryBasicBlock.h"
 #include "bolt/Core/MCPlus.h"
 #include "bolt/Core/Relocation.h"
 #include "llvm/ADT/ArrayRef.h"
@@ -1412,9 +1413,15 @@ public:
     return false;
   }
 
-  /// Modify a direct call instruction \p Inst with an indirect call taking
-  /// a destination from a memory location pointed by \p TargetLocation symbol.
-  virtual bool convertCallToIndirectCall(MCInst &Inst,
+  /// Modify a direct call instruction pointed by the iterator \p It, with an
+  /// indirect call taking a destination from a memory location pointed by \p
+  /// TargetLocation symbol. If additional instructions need to be prepended
+  /// before \p It, then the iterator must be updated to point to the indirect
+  /// call instruction.
+  ///
+  /// \return true on success
+  virtual bool convertCallToIndirectCall(BinaryBasicBlock &BB,
+                                         BinaryBasicBlock::iterator &It,
                                          const MCSymbol *TargetLocation,
                                          MCContext *Ctx) {
     llvm_unreachable("not implemented");

--- a/bolt/lib/Passes/PLTCall.cpp
+++ b/bolt/lib/Passes/PLTCall.cpp
@@ -73,6 +73,7 @@ Error PLTCall::runOnFunctions(BinaryContext &BC) {
         const InstructionListType NewCode = BC.MIB->createIndirectPltCall(
             *II, CalleeBF->getPLTSymbol(), BC.Ctx.get());
         II = BB.replaceInstruction(II, NewCode);
+        assert(!NewCode.empty() && "PLT Call replacement must be non-empty");
         std::advance(II, NewCode.size() - 1);
         BC.MIB->addAnnotation(*II, "PLTCall", true);
         ++NumCallsOptimized;

--- a/bolt/lib/Target/AArch64/AArch64MCPlusBuilder.cpp
+++ b/bolt/lib/Target/AArch64/AArch64MCPlusBuilder.cpp
@@ -1055,29 +1055,27 @@ public:
     return true;
   }
 
-  bool convertCallToIndirectCall(BinaryBasicBlock &BB,
-                                 BinaryBasicBlock::iterator &It,
-                                 const MCSymbol *TargetLocation,
-                                 MCContext *Ctx) override {
-    // Generated code:
-    // adrp	x16 <symbol>
-    // ldr	x17, [x16, #<offset>]
-    // bl <label> -> blr	x17  (or covert 'b -> br' for tail calls)
-
-    MCInst &InstCall = *It;
-    bool IsTailCall = isTailCall(InstCall);
-    assert((InstCall.getOpcode() == AArch64::BL ||
-            (InstCall.getOpcode() == AArch64::B && IsTailCall)) &&
+  InstructionListType createIndirectPltCall(const MCInst &DirectCall,
+                                            const MCSymbol *TargetLocation,
+                                            MCContext *Ctx) override {
+    const bool IsTailCall = isTailCall(DirectCall);
+    assert((DirectCall.getOpcode() == AArch64::BL ||
+            (DirectCall.getOpcode() == AArch64::B && IsTailCall)) &&
            "64-bit direct (tail) call instruction expected");
 
-    // Convert the call to an indicrect one by modifying the instruction.
-    InstCall.clear();
-    InstCall.setOpcode(IsTailCall ? AArch64::BR : AArch64::BLR);
-    InstCall.addOperand(MCOperand::createReg(AArch64::X17));
-    if (IsTailCall)
-      setTailCall(*It);
+    InstructionListType Code;
+    // Code sequence for indirect plt call:
+    // adrp	x16 <symbol>
+    // ldr	x17, [x16, #<offset>]
+    // blr	x17  ; or 'br' for tail calls
 
-    // Prepend instructions to load PLT call address from the input symbol.
+    MCInst InstAdrp;
+    InstAdrp.setOpcode(AArch64::ADRP);
+    InstAdrp.addOperand(MCOperand::createReg(AArch64::X16));
+    InstAdrp.addOperand(MCOperand::createImm(0));
+    setOperandToSymbolRef(InstAdrp, /* OpNum */ 1, TargetLocation,
+                          /* Addend */ 0, Ctx, ELF::R_AARCH64_ADR_GOT_PAGE);
+    Code.emplace_back(InstAdrp);
 
     MCInst InstLoad;
     InstLoad.setOpcode(AArch64::LDRXui);
@@ -1086,19 +1084,16 @@ public:
     InstLoad.addOperand(MCOperand::createImm(0));
     setOperandToSymbolRef(InstLoad, /* OpNum */ 2, TargetLocation,
                           /* Addend */ 0, Ctx, ELF::R_AARCH64_LD64_GOT_LO12_NC);
-    It = BB.insertInstruction(It, InstLoad);
+    Code.emplace_back(InstLoad);
 
-    MCInst InstAdrp;
-    InstAdrp.setOpcode(AArch64::ADRP);
-    InstAdrp.clear();
-    InstAdrp.addOperand(MCOperand::createReg(AArch64::X16));
-    InstAdrp.addOperand(MCOperand::createImm(0));
-    setOperandToSymbolRef(InstAdrp, /* OpNum */ 1, TargetLocation,
-                          /* Addend */ 0, Ctx, ELF::R_AARCH64_ADR_GOT_PAGE);
-    It = BB.insertInstruction(It, InstAdrp);
+    MCInst InstCall;
+    InstCall.setOpcode(IsTailCall ? AArch64::BR : AArch64::BLR);
+    InstCall.addOperand(MCOperand::createReg(AArch64::X17));
+    if (IsTailCall)
+      setTailCall(InstCall);
+    Code.emplace_back(InstCall);
 
-    It = It + 2;
-    return true;
+    return Code;
   }
 
   bool lowerTailCall(MCInst &Inst) override {

--- a/bolt/lib/Target/X86/X86MCPlusBuilder.cpp
+++ b/bolt/lib/Target/X86/X86MCPlusBuilder.cpp
@@ -1639,8 +1639,11 @@ public:
     return true;
   }
 
-  bool convertCallToIndirectCall(MCInst &Inst, const MCSymbol *TargetLocation,
+  bool convertCallToIndirectCall(BinaryBasicBlock &BB,
+                                 BinaryBasicBlock::iterator &It,
+                                 const MCSymbol *TargetLocation,
                                  MCContext *Ctx) override {
+    MCInst &Inst = (*It);
     assert((Inst.getOpcode() == X86::CALL64pcrel32 ||
             (Inst.getOpcode() == X86::JMP_4 && isTailCall(Inst))) &&
            "64-bit direct (tail) call instruction expected");

--- a/bolt/lib/Target/X86/X86MCPlusBuilder.cpp
+++ b/bolt/lib/Target/X86/X86MCPlusBuilder.cpp
@@ -1639,14 +1639,16 @@ public:
     return true;
   }
 
-  bool convertCallToIndirectCall(BinaryBasicBlock &BB,
-                                 BinaryBasicBlock::iterator &It,
-                                 const MCSymbol *TargetLocation,
-                                 MCContext *Ctx) override {
-    MCInst &Inst = (*It);
-    assert((Inst.getOpcode() == X86::CALL64pcrel32 ||
-            (Inst.getOpcode() == X86::JMP_4 && isTailCall(Inst))) &&
+  InstructionListType createIndirectPltCall(const MCInst &DirectCall,
+                                            const MCSymbol *TargetLocation,
+                                            MCContext *Ctx) override {
+    assert((DirectCall.getOpcode() == X86::CALL64pcrel32 ||
+            (DirectCall.getOpcode() == X86::JMP_4 && isTailCall(DirectCall))) &&
            "64-bit direct (tail) call instruction expected");
+
+    InstructionListType Code;
+    // Create a new indirect call by converting the previous direct call.
+    MCInst Inst = DirectCall;
     const auto NewOpcode =
         (Inst.getOpcode() == X86::CALL64pcrel32) ? X86::CALL64m : X86::JMP32m;
     Inst.setOpcode(NewOpcode);
@@ -1667,7 +1669,8 @@ public:
     Inst.insert(Inst.begin(),
                 MCOperand::createReg(X86::RIP));        // BaseReg
 
-    return true;
+    Code.emplace_back(Inst);
+    return Code;
   }
 
   void convertIndirectCallToLoad(MCInst &Inst, MCPhysReg Reg) override {

--- a/bolt/test/AArch64/plt-call.test
+++ b/bolt/test/AArch64/plt-call.test
@@ -1,0 +1,16 @@
+// Verify that PLTCall optimization works, including when PLT calls were
+// tail-call optimized.
+
+RUN: %clang %cflags %p/../Inputs/plt-tailcall.c \
+RUN:    -o %t -Wl,-q
+RUN: llvm-bolt %t -o %t.bolt --plt=all --print-plt  --print-only=foo | FileCheck %s
+
+// Call to printf
+CHECK: adrp	x16, printf@GOT
+CHECK: ldr	x17, [x16, :lo12:printf@GOT]
+CHECK: blr	x17 # PLTCall: 1
+
+// Call to puts, that was tail-call optimized
+CHECK: adrp	x16, puts@GOT
+CHECK: ldr	x17, [x16, :lo12:puts@GOT]
+CHECK: br	x17 # TAILCALL  # PLTCall: 1

--- a/bolt/test/Inputs/plt-tailcall.c
+++ b/bolt/test/Inputs/plt-tailcall.c
@@ -1,0 +1,8 @@
+#include "stub.h"
+
+int foo(char *c) {
+  printf("");
+  __attribute__((musttail)) return puts(c);
+}
+
+int main() { return foo("a"); }

--- a/bolt/test/X86/plt-call.test
+++ b/bolt/test/X86/plt-call.test
@@ -5,11 +5,7 @@ RUN:    -o %t -Wl,-q
 RUN: llvm-bolt %t -o %t.bolt --plt=all --print-plt  --print-only=foo | FileCheck %s
 
 // Call to printf
-CHECK: adrp	x16, printf@GOT
-CHECK: ldr	x17, [x16, :lo12:printf@GOT]
-CHECK: blr	x17 # PLTCall: 1
+CHECK: callq *printf@GOT(%rip) # PLTCall: 1
 
 // Call to puts, that was tail-call optimized
-CHECK: adrp	x16, puts@GOT
-CHECK: ldr	x17, [x16, :lo12:puts@GOT]
-CHECK: br	x17 # TAILCALL  # PLTCall: 1
+CHECK: jmpl *puts@GOT(%rip) # TAILCALL # PLTCall: 1


### PR DESCRIPTION
`convertCallToIndirectCall` applies the PLTCall optimization and returns an (updated if needed) iterator to the converted call instruction. Since AArch64 requires to inject additional instructions to implement this pass, the relevant BasicBlock and an iterator was passed to the `convertCallToIndirectCall`.

`NumCallsOptimized` is updated only on successful application of the pass.

Tests:
- Inputs/plt-tailcall.c: an example of a tail call optimized PLT call.
- AArch64/plt-call.test: it is the actual A64 test, that runs the PLTCall optimization on the above input file and verifies the application of the pass to the calls: 'printf' and 'puts'.