### PR TITLE
[flang][OpenMP] Fix bug in emitting `dealloc` logic

### DIFF
--- a/flang/lib/Lower/OpenMP/DataSharingProcessor.cpp
+++ b/flang/lib/Lower/OpenMP/DataSharingProcessor.cpp
@@ -86,7 +86,7 @@ void DataSharingProcessor::insertDeallocs() {
     if (semantics::IsAllocatable(sym->GetUltimate())) {
       if (!useDelayedPrivatization) {
         converter.createHostAssociateVarCloneDealloc(*sym);
-        return;
+        continue;
       }
 
       lower::SymbolBox hsb = converter.lookupOneLevelUpSymbol(*sym);

--- a/flang/test/Lower/OpenMP/allocatable-multiple-vars.f90
+++ b/flang/test/Lower/OpenMP/allocatable-multiple-vars.f90
@@ -1,4 +1,4 @@
-! Test delayed privatization for multiple allocatable variables.
+! Test early privatization for multiple allocatable variables.
 
 ! RUN: %flang_fc1 -emit-hlfir -fopenmp -mmlir --openmp-enable-delayed-privatization=false \
 ! RUN:   -o - %s 2>&1 | FileCheck %s

--- a/flang/test/Lower/OpenMP/allocatable-multiple-vars.f90
+++ b/flang/test/Lower/OpenMP/allocatable-multiple-vars.f90
@@ -1,0 +1,28 @@
+! Test delayed privatization for multiple allocatable variables.
+
+! RUN: %flang_fc1 -emit-hlfir -fopenmp -mmlir --openmp-enable-delayed-privatization=false \
+! RUN:   -o - %s 2>&1 | FileCheck %s
+
+! RUN: bbc -emit-hlfir -fopenmp --openmp-enable-delayed-privatization=false -o - %s 2>&1 |\
+! RUN:   FileCheck %s
+
+subroutine delayed_privatization_allocatable
+  implicit none
+  integer, allocatable :: var1, var2
+
+!$omp parallel private(var1, var2)
+  var1 = 10
+  var2 = 20
+!$omp end parallel
+end subroutine
+
+! Verify that private versions of each variable are both allocated and freed
+! within the parallel region.
+
+! CHECK:      omp.parallel {
+! CHECK:        fir.allocmem
+! CHECK:        fir.allocmem
+! CHECK:        fir.freemem
+! CHECK:        fir.freemem
+! CHECK:        omp.terminator
+! CHECK-NEXT: }


### PR DESCRIPTION
Fixes a bug in emiting deacllocation logic when delayed privatization is disabled. I introduced the bug when implementing delayed privatization for allocatables: when delayed privatization is disabled the deacllocation ops are emitted for only one allocatable variables.