### PR TITLE
[lldb] Wrap Unix-style path inside appropriate API test Makefiles.

### DIFF
--- a/lldb/test/API/commands/settings/use_source_cache/Makefile
+++ b/lldb/test/API/commands/settings/use_source_cache/Makefile
@@ -5,4 +5,4 @@ include Makefile.rules
 
 # Copy file into the build folder to enable the test to modify it.
 main-copy.cpp: main.cpp
-	cp -f $< $@
+	cp -f $(call path_wrapper,$<) $@

--- a/lldb/test/API/functionalities/breakpoint/comp_dir_symlink/Makefile
+++ b/lldb/test/API/functionalities/breakpoint/comp_dir_symlink/Makefile
@@ -6,4 +6,4 @@ include Makefile.rules
 
 # Force relative filenames by copying it into the build directory.
 relative.cpp: main.cpp
-	cp -f $< $@
+	cp -f $(call path_wrapper,$<) $@

--- a/lldb/test/API/functionalities/inline-sourcefile/Makefile
+++ b/lldb/test/API/functionalities/inline-sourcefile/Makefile
@@ -8,4 +8,4 @@ OBJECTS += inline.o
 $(EXE): main.c inline.o
 
 %.o: %.ll
-	$(CC) $< -c -o $@
+	$(CC) $(call path_wrapper,$<) -c -o $@

--- a/lldb/test/API/functionalities/multiple-slides/Makefile
+++ b/lldb/test/API/functionalities/multiple-slides/Makefile
@@ -8,5 +8,5 @@ include Makefile.rules
 # sliding the binary, the address of `first` and
 # `second` are not slid for some reason on Darwin.
 main.o: main.c
-	$(CC) $(CFLAGS_NO_DEBUG) -c $< -o $@
+	$(CC) $(CFLAGS_NO_DEBUG) -c $(call path_wrapper,$<) -o $@
 

--- a/lldb/test/API/functionalities/postmortem/netbsd-core/GNUmakefile
+++ b/lldb/test/API/functionalities/postmortem/netbsd-core/GNUmakefile
@@ -8,8 +8,8 @@ clean:
 	rm -f $(CORES) $(EXECS)
 
 %.core: %
-	sysctl -w proc.$$$$.corename=$@; ulimit -s 16; ! ./$<
+	sysctl -w proc.$$$$.corename=$@; ulimit -s 16; ! ./$(call path_wrapper,$<)
 %.$(ARCH): %.c
-	$(CC) -o $@ -g $<
+	$(CC) -o $@ -g $(call path_wrapper,$<)
 
 .PHONY: all clean

--- a/lldb/test/API/functionalities/step-avoids-no-debug/Makefile
+++ b/lldb/test/API/functionalities/step-avoids-no-debug/Makefile
@@ -3,4 +3,4 @@ C_SOURCES := with-debug.c without-debug.c
 include Makefile.rules
 
 without-debug.o: without-debug.c
-	$(CC) $(CFLAGS_NO_DEBUG) -c $<
+	$(CC) $(CFLAGS_NO_DEBUG) -c $(call path_wrapper,$<)

--- a/lldb/test/API/functionalities/valobj_errors/Makefile
+++ b/lldb/test/API/functionalities/valobj_errors/Makefile
@@ -4,6 +4,6 @@ LD_EXTRAS = hidden.o
 a.out: hidden.o
 
 hidden.o: hidden.c
-	$(CC) -g0 -c -o $@ $<
+	$(CC) -g0 -c -o $@ $(call path_wrapper,$<)
 
 include Makefile.rules

--- a/lldb/test/API/lang/cpp/operator-overload/Makefile
+++ b/lldb/test/API/lang/cpp/operator-overload/Makefile
@@ -3,4 +3,4 @@ CXX_SOURCES = a.cpp b.cpp
 include Makefile.rules
 
 a.o: a.cpp
-	$(CC) $(CFLAGS_NO_DEBUG) -c $< -o $@
+	$(CC) $(CFLAGS_NO_DEBUG) -c $(call path_wrapper,$<) -o $@

--- a/lldb/test/API/lang/objcxx/class-name-clash/Makefile
+++ b/lldb/test/API/lang/objcxx/class-name-clash/Makefile
@@ -3,4 +3,4 @@ include Makefile.rules
 
 # myobject.o needs to be built without debug info
 myobject.o: myobject.mm
-	$(CXX) $(CFLAGS_NO_DEBUG) -c -o $@ $<
+	$(CXX) $(CFLAGS_NO_DEBUG) -c -o $@ $(call path_wrapper,$<)

--- a/lldb/test/API/linux/add-symbols/Makefile
+++ b/lldb/test/API/linux/add-symbols/Makefile
@@ -4,6 +4,6 @@ LD_EXTRAS := -Wl,--build-id=none
 all: stripped.out
 
 stripped.out : a.out
-	$(OBJCOPY) --remove-section=.note.gnu.build-id --remove-section=.gnu_debuglink --strip-debug $< $@
+	$(OBJCOPY) --remove-section=.note.gnu.build-id --remove-section=.gnu_debuglink --strip-debug $(call path_wrapper,$<) $@
 
 include Makefile.rules

--- a/lldb/test/API/linux/sepdebugsymlink/Makefile
+++ b/lldb/test/API/linux/sepdebugsymlink/Makefile
@@ -5,7 +5,7 @@ all: dirsymlink
 dirreal: a.out
 	$(RM) -r $@
 	mkdir $@
-	$(OBJCOPY) --only-keep-debug $< $@/stripped.debug
+	$(OBJCOPY) --only-keep-debug $(call path_wrapper,$<) $@/stripped.debug
 	$(OBJCOPY) --strip-all --add-gnu-debuglink=$@/stripped.debug $< $@/stripped.out
 
 dirsymlink: dirreal

--- a/lldb/test/API/macosx/function-starts/Makefile
+++ b/lldb/test/API/macosx/function-starts/Makefile
@@ -5,4 +5,4 @@ MAKE_DSYM := NO
 include Makefile.rules
 
 main.o: main.cpp
-	$(CC) $(CFLAGS_NO_DEBUG) -c $< -o $@
+	$(CC) $(CFLAGS_NO_DEBUG) -c $(call path_wrapper,$<) -o $@

--- a/lldb/test/API/macosx/posix_spawn/Makefile
+++ b/lldb/test/API/macosx/posix_spawn/Makefile
@@ -6,13 +6,13 @@ include Makefile.rules
 all: fat.out
 
 x86_64.out: x86_64.c
-	$(CC) -isysroot $(SDKROOT) -target x86_64-apple-macosx10.9 -o x86_64.out $<
+	$(CC) -isysroot $(SDKROOT) -target x86_64-apple-macosx10.9 -o x86_64.out $(call path_wrapper,$<)
 
 x86_64h.out: x86_64h.c
-	$(CC) -isysroot $(SDKROOT) -target x86_64h-apple-macosx10.9 -o x86_64h.out $<
+	$(CC) -isysroot $(SDKROOT) -target x86_64h-apple-macosx10.9 -o x86_64h.out $(call path_wrapper,$<)
 
 arm64.out: arm64.c
-	$(CC) -isysroot $(SDKROOT) -target arm64-apple-macosx10.9 -o arm64.out $<
+	$(CC) -isysroot $(SDKROOT) -target arm64-apple-macosx10.9 -o arm64.out $(call path_wrapper,$<)
 
 fat.out: x86_64.out x86_64h.out arm64.out
 	$(LIPO) -o fat.out -create $^

--- a/lldb/test/API/macosx/universal/Makefile
+++ b/lldb/test/API/macosx/universal/Makefile
@@ -8,13 +8,13 @@ testit: testit.x86_64h testit.x86_64
 	lipo -create -o testit $^
 
 testit.x86_64h: testit.x86_64h.o
-	$(CC) -isysroot $(SDKROOT) -target x86_64h-apple-macosx10.9 -o testit.x86_64h $<
+	$(CC) -isysroot $(SDKROOT) -target x86_64h-apple-macosx10.9 -o testit.x86_64h $(call path_wrapper,$<)
 
 testit.x86_64: testit.x86_64.o
-	$(CC) -isysroot $(SDKROOT) -target x86_64-apple-macosx10.9 -o testit.x86_64 $<
+	$(CC) -isysroot $(SDKROOT) -target x86_64-apple-macosx10.9 -o testit.x86_64 $(call path_wrapper,$<)
 
 testit.x86_64h.o: main.c
-	$(CC) -isysroot $(SDKROOT) -g -O0 -target x86_64h-apple-macosx10.9 -c -o testit.x86_64h.o $<
+	$(CC) -isysroot $(SDKROOT) -g -O0 -target x86_64h-apple-macosx10.9 -c -o testit.x86_64h.o $(call path_wrapper,$<)
 
 testit.x86_64.o: main.c
-	$(CC) -isysroot $(SDKROOT) -g -O0 -target x86_64-apple-macosx10.9 -c -o testit.x86_64.o $<
+	$(CC) -isysroot $(SDKROOT) -g -O0 -target x86_64-apple-macosx10.9 -c -o testit.x86_64.o $(call path_wrapper,$<)

--- a/lldb/test/API/macosx/universal64/Makefile
+++ b/lldb/test/API/macosx/universal64/Makefile
@@ -12,13 +12,13 @@ fat.out: fat.x86_64h.out fat.x86_64.out
 	lipo -fat64 -create -o $@ $^
 
 fat.x86_64.out: fat.x86_64.o
-	$(CC) -isysroot $(SDKROOT) -target x86_64-apple-macosx10.9 -o $@ $<
+	$(CC) -isysroot $(SDKROOT) -target x86_64-apple-macosx10.9 -o $@ $(call path_wrapper,$<)
 
 fat.x86_64h.out: fat.x86_64h.o
-	$(CC) -isysroot $(SDKROOT) -target x86_64h-apple-macosx10.9 -o $@ $<
+	$(CC) -isysroot $(SDKROOT) -target x86_64h-apple-macosx10.9 -o $@ $(call path_wrapper,$<)
 
 fat.x86_64.o: main.c
-	$(CC) -isysroot $(SDKROOT) -g -O0 -target x86_64-apple-macosx10.9 -c -o $@ $<
+	$(CC) -isysroot $(SDKROOT) -g -O0 -target x86_64-apple-macosx10.9 -c -o $@ $(call path_wrapper,$<)
 
 fat.x86_64h.o: main.c
-	$(CC) -isysroot $(SDKROOT) -g -O0 -target x86_64h-apple-macosx10.9 -c -o $@ $<
+	$(CC) -isysroot $(SDKROOT) -g -O0 -target x86_64h-apple-macosx10.9 -c -o $@ $(call path_wrapper,$<)

--- a/lldb/test/API/source-manager/Makefile
+++ b/lldb/test/API/source-manager/Makefile
@@ -4,4 +4,4 @@ include Makefile.rules
 
 # Copy file into the build folder to enable the test to modify it.
 main-copy.c: main.c
-	cp -f $< $@
+	cp -f $(call path_wrapper,$<) $@

--- a/lldb/test/API/tools/lldb-dap/breakpoint/Makefile
+++ b/lldb/test/API/tools/lldb-dap/breakpoint/Makefile
@@ -8,10 +8,10 @@ include Makefile.rules
 
 # We copy the source files to move them to test source mapping
 other-copy.c: other.c
-	cp -f $< $@
+	cp -f $(call path_wrapper,$<) $@
 
 main-copy.cpp: main.cpp
-	cp -f $< $@
+	cp -f $(call path_wrapper,$<) $@
 
 # The following shared library will be used to test breakpoints under dynamic loading
 libother:  other-copy.c


### PR DESCRIPTION
Some of the API tests use Makefiles with the custom rules to manipulate the source code files. This patch normalizes their file pathes to Unix-style on the Windows build host and avoids compiler/linker error because of the broken pathes

Depends on #93639