### PR TITLE
[lldb] Allow using a custom 'strip' tool for the API tests.

### DIFF
--- a/lldb/test/API/functionalities/json/symbol-file/Makefile
+++ b/lldb/test/API/functionalities/json/symbol-file/Makefile
@@ -3,6 +3,6 @@ C_SOURCES := main.c
 all: stripped.out
 
 stripped.out : a.out
-	strip a.out -o stripped.out
+	$(STRIP) a.out -o stripped.out
 
 include Makefile.rules

--- a/lldb/test/API/lang/objc/hidden-ivars/Makefile
+++ b/lldb/test/API/lang/objc/hidden-ivars/Makefile
@@ -14,8 +14,8 @@ endif
 
 stripped: a.out libInternalDefiner.dylib
 	mkdir stripped
-	strip -Sx a.out -o stripped/a.out
-	strip -Sx libInternalDefiner.dylib -o stripped/libInternalDefiner.dylib
+	$(STRIP) -Sx a.out -o stripped/a.out
+	$(STRIP) -Sx libInternalDefiner.dylib -o stripped/libInternalDefiner.dylib
 ifneq "$(CODESIGN)" ""
 	$(CODESIGN) -fs - stripped/a.out
 endif

--- a/lldb/test/API/lang/objc/objc-ivar-stripped/Makefile
+++ b/lldb/test/API/lang/objc/objc-ivar-stripped/Makefile
@@ -6,7 +6,7 @@ all:        a.out.stripped
 include Makefile.rules
 
 a.out.stripped: a.out.dSYM
-	strip -o a.out.stripped a.out
+	$(STRIP) -o a.out.stripped a.out
 ifneq "$(CODESIGN)" ""
 	$(CODESIGN) -fs - a.out.stripped
 endif

--- a/lldb/test/API/lang/objc/objc-static-method-stripped/Makefile
+++ b/lldb/test/API/lang/objc/objc-static-method-stripped/Makefile
@@ -4,7 +4,7 @@ LD_EXTRAS := -lobjc -framework Foundation
 default:        a.out.stripped
 
 a.out.stripped: a.out.dSYM
-	strip -o a.out.stripped a.out
+	$(STRIP) -o a.out.stripped a.out
 	ln -sf a.out.dSYM a.out.stripped.dSYM
 
 include Makefile.rules

--- a/lldb/test/API/macosx/add-dsym/Makefile
+++ b/lldb/test/API/macosx/add-dsym/Makefile
@@ -8,7 +8,7 @@ hide.app/Contents/a.out.dSYM:
 	mkdir hide.app
 	mkdir hide.app/Contents
 	mv a.out.dSYM hide.app/Contents
-	strip -x a.out
+	$(STRIP) -x a.out
 ifneq "$(CODESIGN)" ""
 	$(CODESIGN) -fs - a.out
 endif

--- a/lldb/test/API/macosx/dyld-trie-symbols/Makefile
+++ b/lldb/test/API/macosx/dyld-trie-symbols/Makefile
@@ -10,4 +10,4 @@ all: a.out a.out-stripped
 
 a.out-stripped:
 	cp a.out a.out-stripped
-	strip -N a.out-stripped
+	$(STRIP) -N a.out-stripped

--- a/lldb/test/API/tools/lldb-dap/module/Makefile
+++ b/lldb/test/API/tools/lldb-dap/module/Makefile
@@ -10,7 +10,7 @@ include Makefile.rules
 all: a.out.stripped
 
 a.out.stripped:
-	strip -o a.out.stripped a.out
+	$(STRIP) -o a.out.stripped a.out
 
 ifneq "$(CODESIGN)" ""
 	$(CODESIGN) -fs - a.out.stripped

--- a/lldb/test/API/tools/lldb-dap/terminated-event/Makefile
+++ b/lldb/test/API/tools/lldb-dap/terminated-event/Makefile
@@ -10,7 +10,7 @@ include Makefile.rules
 all: a.out.stripped
 
 a.out.stripped:
-	strip -o a.out.stripped a.out
+	$(STRIP) -o a.out.stripped a.out
 
 ifneq "$(CODESIGN)" ""
 	$(CODESIGN) -fs - a.out.stripped


### PR DESCRIPTION
Allow passing any custom 'strip' tool, such as 'llvm-strip', to use with the LLDB API tests.

The tool can be provided via LLDB_TEST_COMMON_ARGS_VAR CMake variable: `..;--env STRIP=${CMAKE_STRIP};...`.

Depends on #93639