### PR TITLE
[lldb][tests] Fix passing pthread library to a linker for some API tests.

### DIFF
--- a/lldb/test/API/commands/register/register/aarch64_sme_z_registers/za_dynamic_resize/Makefile
+++ b/lldb/test/API/commands/register/register/aarch64_sme_z_registers/za_dynamic_resize/Makefile
@@ -1,5 +1,6 @@
 C_SOURCES := main.c
 
-CFLAGS_EXTRAS := -march=armv8-a+sve+sme -lpthread
+CFLAGS_EXTRAS := -march=armv8-a+sve+sme
+ENABLE_THREADS := YES
 
 include Makefile.rules

--- a/lldb/test/API/commands/register/register/aarch64_sve_registers/rw_access_dynamic_resize/Makefile
+++ b/lldb/test/API/commands/register/register/aarch64_sve_registers/rw_access_dynamic_resize/Makefile
@@ -1,5 +1,6 @@
 C_SOURCES := main.c
 
-CFLAGS_EXTRAS := -march=armv8-a+sve -lpthread
+CFLAGS_EXTRAS := -march=armv8-a+sve
+ENABLE_THREADS := YES
 
 include Makefile.rules

--- a/lldb/test/API/functionalities/process_save_core_minidump/Makefile
+++ b/lldb/test/API/functionalities/process_save_core_minidump/Makefile
@@ -1,6 +1,6 @@
 CXX_SOURCES := main.cpp
 
-CFLAGS_EXTRAS := -lpthread
+ENABLE_THREADS := YES
 
 include Makefile.rules
 

--- a/lldb/test/API/tools/lldb-dap/threads/Makefile
+++ b/lldb/test/API/tools/lldb-dap/threads/Makefile
@@ -1,4 +1,5 @@
 C_SOURCES := main.c
-CFLAGS_EXTRAS := -lpthread
+
+ENABLE_THREADS := YES
 
 include Makefile.rules


### PR DESCRIPTION
Specify ENABLE_THREADS := YES within test's Makefile instead passing -lpthread throuhg the compiler's CFLAGS options.