### PR TITLE
[lldb][tests] Fix TestStdCXXDisassembly test when running on the remote Linux targets.

### DIFF
--- a/lldb/test/API/lang/cpp/stl/Makefile
+++ b/lldb/test/API/lang/cpp/stl/Makefile
@@ -1,3 +1,5 @@
 CXX_SOURCES := main.cpp
 
+USE_LIBSTDCPP := 1
+
 include Makefile.rules

--- a/lldb/test/API/lang/cpp/stl/TestStdCXXDisassembly.py
+++ b/lldb/test/API/lang/cpp/stl/TestStdCXXDisassembly.py
@@ -44,7 +44,7 @@ class StdCXXDisassembleTestCase(TestBase):
         # module is the corresponding SBModule.
 
         self.expect(
-            lib_stdcxx, "Libraray StdC++ is located", exe=False, substrs=["lib"]
+            lib_stdcxx, "Library StdC++ is located", exe=False, substrs=["lib"]
         )
 
         self.runCmd("image dump symtab '%s'" % lib_stdcxx)


### PR DESCRIPTION
The test expects 'libstdc++' SO module in the module list. Force using StdC++ by specifying USE_LIBSTDCPP := 1 in the test's Makefile.

Depends on #93639