### PR TITLE
[RemoveDIs] Update syntax highlighting to include debug records

### DIFF
--- a/llvm/utils/emacs/llvm-mode.el
+++ b/llvm/utils/emacs/llvm-mode.el
@@ -87,6 +87,8 @@
    `(,(regexp-opt '("extractvalue" "insertvalue") 'symbols) . font-lock-keyword-face)
    ;; Metadata types
    `(,(regexp-opt '("distinct") 'symbols) . font-lock-keyword-face)
+   ;; Debug records
+   `(,(concat "#" (regexp-opt '("dbg_assign" "dbg_declare" "dbg_label" "dbg_value") 'symbols)) . font-lock-keyword-face)
    ;; Atomic memory ordering constraints
    `(,(regexp-opt '("unordered" "monotonic" "acquire" "release" "acq_rel" "seq_cst") 'symbols) . font-lock-keyword-face)
    ;; Fast-math flags

--- a/llvm/utils/vim/syntax/llvm.vim
+++ b/llvm/utils/vim/syntax/llvm.vim
@@ -36,6 +36,9 @@ syn keyword llvmStatement sle slt srem store sub switch trunc udiv ueq uge ugt
 syn keyword llvmStatement uitofp ule ult umax umin une uno unreachable unwind
 syn keyword llvmStatement urem va_arg xchg xor zext
 
+" Debug records.
+syn match llvmStatement /\v#dbg_(assign|declare|label|value)/
+
 " Keywords.
 syn keyword llvmKeyword
       \ acq_rel

--- a/llvm/utils/vscode/llvm/syntaxes/ll.tmLanguage.yaml
+++ b/llvm/utils/vscode/llvm/syntaxes/ll.tmLanguage.yaml
@@ -34,7 +34,7 @@ patterns:
     captures:
       1:
         name: storage.type.llvm
-  - match: "(?<=\\s|^)#dbg_(assign|declare|label|value)\\b\
+  - match: "(?<=\\s|^)#dbg_(assign|declare|label|value)\\b|\
             \\badd\\b|\
             \\baddrspacecast\\b|\
             \\balloca\\b|\

--- a/llvm/utils/vscode/llvm/syntaxes/ll.tmLanguage.yaml
+++ b/llvm/utils/vscode/llvm/syntaxes/ll.tmLanguage.yaml
@@ -34,7 +34,8 @@ patterns:
     captures:
       1:
         name: storage.type.llvm
-  - match: "\\badd\\b|\
+  - match: "(?<=\\s|^)#dbg_(assign|declare|label|value)\\b\
+            \\badd\\b|\
             \\baddrspacecast\\b|\
             \\balloca\\b|\
             \\band\\b|\


### PR DESCRIPTION
This patch updates the vim and vscode syntax highlighters to recognize debug records. I wasn't able to build the vscode extensions locally, so I've only tested this pattern by checking that the pattern works in vscode search.