### PR TITLE
[mlir][vector] Add ElementwiseToOuterproduct

### DIFF
--- a/mlir/include/mlir/Dialect/Vector/IR/VectorOps.h
+++ b/mlir/include/mlir/Dialect/Vector/IR/VectorOps.h
@@ -80,6 +80,10 @@ void populateVectorToVectorCanonicalizationPatterns(RewritePatternSet &patterns,
 /// into vector contract for the backends with native support.
 void populateFoldArithExtensionPatterns(RewritePatternSet &patterns);
 
+/// Collect a set of patterns that fold elementwise op on vectors to the vector
+/// dialect.
+void populateElementwiseToVectorOpsPatterns(RewritePatternSet &patterns);
+
 /// Returns the integer type required for subscripts in the vector dialect.
 IntegerType getVectorSubscriptType(Builder &builder);
 

--- a/mlir/include/mlir/Dialect/Vector/TransformOps/VectorTransformOps.td
+++ b/mlir/include/mlir/Dialect/Vector/TransformOps/VectorTransformOps.td
@@ -392,6 +392,17 @@ def ApplyFoldArithExtensionPatternsOp : Op<Transform_Dialect,
   let assemblyFormat = "attr-dict";
 }
 
+def ApplyFoldElementwiseToVectorPatternsOp : Op<Transform_Dialect,
+    "apply_patterns.vector.elementwise_to_vector",
+    [DeclareOpInterfaceMethods<PatternDescriptorOpInterface>]> {
+  let description = [{
+    Collect a set of patterns that fold elementwise op on vectors to the vector 
+    dialect.
+  }];
+
+  let assemblyFormat = "attr-dict";
+}
+
 def ApplyVectorReductionToContractPatternsOp : Op<Transform_Dialect,
     "apply_patterns.vector.reduction_to_contract",
     [DeclareOpInterfaceMethods<PatternDescriptorOpInterface>]> {

--- a/mlir/lib/Dialect/Vector/TransformOps/VectorTransformOps.cpp
+++ b/mlir/lib/Dialect/Vector/TransformOps/VectorTransformOps.cpp
@@ -59,6 +59,11 @@ void transform::ApplyFoldArithExtensionPatternsOp::populatePatterns(
   vector::populateFoldArithExtensionPatterns(patterns);
 }
 
+void transform::ApplyFoldElementwiseToVectorPatternsOp::populatePatterns(
+    RewritePatternSet &patterns) {
+  vector::populateElementwiseToVectorOpsPatterns(patterns);
+}
+
 void transform::ApplyVectorReductionToContractPatternsOp::populatePatterns(
     RewritePatternSet &patterns) {
   vector::populateVectorReductionToContractPatterns(patterns);

--- a/mlir/lib/Dialect/Vector/Transforms/VectorTransforms.cpp
+++ b/mlir/lib/Dialect/Vector/Transforms/VectorTransforms.cpp
@@ -1815,7 +1815,8 @@ private:
 template <typename MulOpType>
 struct ElementwiseToOuterproduct : public OpRewritePattern<MulOpType> {
   using OpRewritePattern<MulOpType>::OpRewritePattern;
-  // Helper function returning the source of the input broadcast if it matches requirements for an outerproduct pattern.
+  // Helper function returning the source of the input broadcast if it matches
+  // requirements for an outerproduct pattern.
   Value getValidBroadcastSource(vector::BroadcastOp broadcastOp) const {
     // Fail if it is not a 1-to-2 dimension to broadcast to avoid generating
     // shape_casts/broadcasts which does not belong in this pattern.

--- a/mlir/lib/Dialect/Vector/Transforms/VectorTransforms.cpp
+++ b/mlir/lib/Dialect/Vector/Transforms/VectorTransforms.cpp
@@ -1797,21 +1797,20 @@ private:
 
 /// Pattern aiming to fold a series of ops mulf(tr(broadcast(A)), broadcast(B))
 /// into vector.outerproduct(A, B) such as :
-/// ```mlir
+///
 ///  %lhsBcast = vector.broadcast %lhs : vector<4xi32> to vector<4x4xi32>
 ///  %lhsT = vector.transpose %lhsBcast, [1, 0] : vector<4x4xi32> to
 ///  vector<4x4xi32> %rhsBcast = vector.broadcast %rhs : vector<4xi32> to
 ///  vector<4x4xi32> %mul = arith.muli %lhsT, %rhsBcast : vector<4x4xi32>
-///```
+///
 /// Becomes :
-///```mlir
+///
 ///  %res = vector.outerproduct %lhs, %rhs : vector<4xi32>, vector<4xi32>
-///```
+///
 /// Edge Cases where broadcast ops are not 1D to 2D as follow are not handled.
 /// %ex1 = vector.broadcast %lhsCast : vector<1x4xf32> to vector<4x4xf32>
 /// %ex2 = vector.broadcast %lhsCast : f32 to vector<4x4xf32>
 /// %ex3 = vector.broadcast %lhsCast : vector<1x1xf32> to vector<4x4xf32>
-
 template <typename MulOpType>
 struct ElementwiseToOuterproduct : public OpRewritePattern<MulOpType> {
   using OpRewritePattern<MulOpType>::OpRewritePattern;

--- a/mlir/lib/Dialect/Vector/Transforms/VectorTransforms.cpp
+++ b/mlir/lib/Dialect/Vector/Transforms/VectorTransforms.cpp
@@ -1795,9 +1795,9 @@ private:
   unsigned maxNumElementsToExtract = 0;
 };
 
-/// Pattern aiming to fold a series of ops mulf(tr(broadcast(A)), broadcast(B))
-/// into vector.outerproduct(A, B) such as :
-///
+/// Fold `mulf(tr(broadcast(A)), broadcast(B))` into `vector.outerproduct(A,
+/// B)`.
+/// Example:
 ///  %lhsBcast = vector.broadcast %lhs : vector<4xi32> to vector<4x4xi32>
 ///  %lhsT = vector.transpose %lhsBcast, [1, 0] : vector<4x4xi32> to
 ///  vector<4x4xi32> %rhsBcast = vector.broadcast %rhs : vector<4xi32> to
@@ -1807,65 +1807,72 @@ private:
 ///
 ///  %res = vector.outerproduct %lhs, %rhs : vector<4xi32>, vector<4xi32>
 ///
-/// Edge Cases where broadcast ops are not 1D to 2D as follow are not handled.
+/// Supports only 1D-to-2D broadcasts. The following cases are not supported.
 /// %ex1 = vector.broadcast %lhsCast : vector<1x4xf32> to vector<4x4xf32>
 /// %ex2 = vector.broadcast %lhsCast : f32 to vector<4x4xf32>
 /// %ex3 = vector.broadcast %lhsCast : vector<1x1xf32> to vector<4x4xf32>
 template <typename MulOpType>
-struct ElementwiseToOuterproduct : public OpRewritePattern<MulOpType> {
+struct FoldArithToVectorOuterProduct : public OpRewritePattern<MulOpType> {
   using OpRewritePattern<MulOpType>::OpRewritePattern;
-  // Helper function returning the source of the input broadcast if it matches
-  // requirements for an outerproduct pattern.
-  Value getValidBroadcastSource(vector::BroadcastOp broadcastOp) const {
+  // Returns whether a vector.broadcast matches requirements for an outerproduct
+  // pattern. aka a 1D-to-2D broadcastOp without broadcasted unit dimension.
+  bool isValidBroadcastSource(vector::BroadcastOp broadcastOp) const {
     // Fail if it is not a 1-to-2 dimension to broadcast to avoid generating
     // shape_casts/broadcasts which does not belong in this pattern.
     if (!broadcastOp.computeBroadcastedUnitDims().empty())
-      return Value();
+      return false;
     // Avoid broadcast like f32 or vector<f32> -> ResType
-    auto srcVT = dyn_cast<VectorType>(broadcastOp.getSourceType());
-    if (!srcVT || srcVT.getRank() != 1)
-      return Value();
-    return broadcastOp.getSource();
+    auto srcType = dyn_cast<VectorType>(broadcastOp.getSourceType());
+    if (!srcType || srcType.getRank() == 2)
+      return false;
+    return true;
   }
 
   LogicalResult matchAndRewrite(MulOpType mulOp,
                                 PatternRewriter &rewriter) const override {
-    auto VT = llvm::cast<VectorType>(mulOp.getResult().getType());
-    if (!VT)
+    auto resType = llvm::cast<VectorType>(mulOp.getResult().getType());
+    if (!resType)
       return failure();
-    if (VT.getRank() != 2)
+    if (resType.getRank() != 2)
       return failure();
-
-    auto canonicalize = [&](Value OperandA,
-                            Value OperandB) -> vector::OuterProductOp {
+    /// If operandA can be written as tr(broadcast(A)) and operandB as
+    /// broadcast(B) where broadcasts are 1D-to-2D, create and return
+    /// vector.outerproduct(A, B). Returns failure() otherwise.
+    auto matchOuterProduct =
+        [&](Value operandA,
+            Value operandB) -> FailureOr<vector::OuterProductOp> {
       vector::TransposeOp transposedLhs =
-          dyn_cast_or_null<vector::TransposeOp>(OperandA.getDefiningOp());
+          dyn_cast_or_null<vector::TransposeOp>(operandA.getDefiningOp());
       if (!transposedLhs)
-        return vector::OuterProductOp();
+        return failure();
       // Fail unless this is a true 2-D matrix transpose.
       ArrayRef<int64_t> permutation = transposedLhs.getPermutation();
-      if (permutation[0] != 1 || permutation[1] != 0)
-        return vector::OuterProductOp();
+      if (permutation.size() != 2 || permutation[0] != 1 || permutation[1] != 0)
+        return failure();
 
-      vector::BroadcastOp broadcastedLhs = dyn_cast<vector::BroadcastOp>(
-          transposedLhs.getVector().getDefiningOp());
-      if (!broadcastedLhs || !getValidBroadcastSource(broadcastedLhs))
-        return vector::OuterProductOp();
+      auto broadcastedLhs =
+          transposedLhs.getVector().getDefiningOp<vector::BroadcastOp>();
+      if (!broadcastedLhs || !isValidBroadcastSource(broadcastedLhs))
+        return failure();
 
-      vector::BroadcastOp broadcastedRhs =
-          dyn_cast<vector::BroadcastOp>(OperandB.getDefiningOp());
-      if (!broadcastedRhs || !getValidBroadcastSource(broadcastedRhs))
-        return vector::OuterProductOp();
+      auto broadcastedRhs = operandB.getDefiningOp<vector::BroadcastOp>();
+      if (!broadcastedRhs || !isValidBroadcastSource(broadcastedRhs))
+        return failure();
 
-      return rewriter.replaceOpWithNewOp<vector::OuterProductOp>(
-          mulOp, VT, broadcastedLhs.getSource(), broadcastedRhs.getSource(),
-          Value(), vector::CombiningKind::ADD);
+      return rewriter.create<vector::OuterProductOp>(
+          mulOp->getLoc(), resType, broadcastedLhs.getSource(),
+          broadcastedRhs.getSource(), Value(), vector::CombiningKind::ADD);
     };
-    Value a = mulOp->getOperand(0), b = mulOp->getOperand(1);
-    vector::OuterProductOp outerP = canonicalize(a, b);
+
+    Value lhs = mulOp->getOperand(0), rhs = mulOp->getOperand(1);
+    auto maybeOuterP = matchOuterProduct(lhs, rhs);
     // Handle commutativity, the transposed op is the outerproduct LHS.
-    outerP = outerP ? outerP : canonicalize(b, a);
-    return outerP ? success() : failure();
+    if (failed(maybeOuterP))
+      maybeOuterP = matchOuterProduct(rhs, lhs);
+    if (failed(maybeOuterP))
+      return failure();
+    rewriter.replaceOp(mulOp, maybeOuterP->getResult());
+    return success();
   }
 };
 
@@ -1958,8 +1965,9 @@ void mlir::vector::populateBreakDownVectorReductionPatterns(
 
 void mlir::vector::populateElementwiseToVectorOpsPatterns(
     RewritePatternSet &patterns) {
-  patterns.add<ElementwiseToOuterproduct<arith::MulFOp>,
-               ElementwiseToOuterproduct<arith::MulIOp>>(patterns.getContext());
+  patterns.add<FoldArithToVectorOuterProduct<arith::MulFOp>,
+               FoldArithToVectorOuterProduct<arith::MulIOp>>(
+      patterns.getContext());
 }
 
 //===----------------------------------------------------------------------===//

--- a/mlir/lib/Dialect/Vector/Transforms/VectorTransforms.cpp
+++ b/mlir/lib/Dialect/Vector/Transforms/VectorTransforms.cpp
@@ -1823,9 +1823,7 @@ struct FoldArithToVectorOuterProduct : public OpRewritePattern<MulOpType> {
       return false;
     // Avoid broadcast like f32 or vector<f32> -> ResType
     auto srcType = dyn_cast<VectorType>(broadcastOp.getSourceType());
-    if (!srcType || srcType.getRank() == 2)
-      return false;
-    return true;
+    return srcType && srcType.getRank() != 2;
   }
 
   LogicalResult matchAndRewrite(MulOpType mulOp,
@@ -1841,8 +1839,7 @@ struct FoldArithToVectorOuterProduct : public OpRewritePattern<MulOpType> {
     auto matchOuterProduct =
         [&](Value operandA,
             Value operandB) -> FailureOr<vector::OuterProductOp> {
-      vector::TransposeOp transposedLhs =
-          dyn_cast_or_null<vector::TransposeOp>(operandA.getDefiningOp());
+      auto transposedLhs = operandA.getDefiningOp<vector::TransposeOp>();
       if (!transposedLhs)
         return failure();
       // Fail unless this is a true 2-D matrix transpose.

--- a/mlir/test/Dialect/Vector/transform-vector.mlir
+++ b/mlir/test/Dialect/Vector/transform-vector.mlir
@@ -121,6 +121,19 @@ func.func @ewise_outerproduct_transposed_rhs(%lhs: vector<16xf32>, %rhs: vector<
   return %mul: vector<16x16xf32>
 }
 
+// CHECK-LABEL: func.func @ewise_outerproduct_different_sizes
+//  CHECK-SAME:   %[[LHS:.*]]: vector<8xf32>,
+//  CHECK-SAME:   %[[RHS:.*]]: vector<4xf32>) -> vector<8x4xf32> {
+//       CHECK:     %[[RES:.*]] = vector.outerproduct %[[LHS]], %[[RHS]] : vector<8xf32>, vector<4xf32>
+//       CHECK:     return %[[RES]] : vector<8x4xf32>
+func.func @ewise_outerproduct_different_sizes(%lhs: vector<8xf32>, %rhs: vector<4xf32>) -> vector<8x4xf32> {
+  %lhsBcast = vector.broadcast %lhs : vector<8xf32> to vector<4x8xf32>
+  %lhsT = vector.transpose %lhsBcast, [1, 0] : vector<4x8xf32> to vector<8x4xf32>
+  %rhsBcast = vector.broadcast %rhs : vector<4xf32> to vector<8x4xf32>
+  %mul = arith.mulf %lhsT, %rhsBcast : vector<8x4xf32>
+  return %mul: vector<8x4xf32>
+}
+
 module attributes {transform.with_named_sequence} {
   transform.named_sequence @__transform_main(%module_op: !transform.any_op {transform.readonly}) {
     %func = transform.structured.match ops{["func.func"]} in %module_op : (!transform.any_op) -> !transform.any_op

--- a/mlir/test/Dialect/Vector/transform-vector.mlir
+++ b/mlir/test/Dialect/Vector/transform-vector.mlir
@@ -95,12 +95,12 @@ module attributes {transform.with_named_sequence} {
 
 // -----
 
-// CHECK-LABEL: func.func @ewise_outerproduct
+// CHECK-LABEL: func.func @arith_to_outerproduct_scalable_i32
 //  CHECK-SAME:   %[[LHS:.*]]: vector<[4]xi32>,
 //  CHECK-SAME:   %[[RHS:.*]]: vector<[4]xi32>) -> vector<[4]x[4]xi32> {
 //       CHECK:     %[[RES:.*]] = vector.outerproduct %[[LHS]], %[[RHS]] : vector<[4]xi32>, vector<[4]xi32>
 //       CHECK:     return %[[RES]] : vector<[4]x[4]xi32>
-func.func @ewise_outerproduct(%lhs: vector<[4]xi32>, %rhs: vector<[4]xi32>) -> vector<[4]x[4]xi32> {
+func.func @arith_to_outerproduct_scalable_i32(%lhs: vector<[4]xi32>, %rhs: vector<[4]xi32>) -> vector<[4]x[4]xi32> {
   %lhsBcast = vector.broadcast %lhs : vector<[4]xi32> to vector<[4]x[4]xi32>
   %lhsT = vector.transpose %lhsBcast, [1, 0] : vector<[4]x[4]xi32> to vector<[4]x[4]xi32>
   %rhsBcast = vector.broadcast %rhs : vector<[4]xi32> to vector<[4]x[4]xi32>
@@ -108,30 +108,17 @@ func.func @ewise_outerproduct(%lhs: vector<[4]xi32>, %rhs: vector<[4]xi32>) -> v
   return %mul: vector<[4]x[4]xi32>
 }
 
-// CHECK-LABEL: func.func @ewise_outerproduct_transposed_rhs
+// CHECK-LABEL: func.func @arith_to_outerproduct_trans_rhs_f32
 //  CHECK-SAME:   %[[LHS:.*]]: vector<16xf32>,
-//  CHECK-SAME:   %[[RHS:.*]]: vector<16xf32>) -> vector<16x16xf32> {
-//       CHECK:     %[[RES:.*]] = vector.outerproduct %[[RHS]], %[[LHS]] : vector<16xf32>, vector<16xf32>
-//       CHECK:     return %[[RES]] : vector<16x16xf32>
-func.func @ewise_outerproduct_transposed_rhs(%lhs: vector<16xf32>, %rhs: vector<16xf32>) -> vector<16x16xf32> {
-  %rhsBcast = vector.broadcast %rhs : vector<16xf32> to vector<16x16xf32>
-  %rhsT = vector.transpose %rhsBcast, [1, 0] : vector<16x16xf32> to vector<16x16xf32>
-  %lhsBcast = vector.broadcast %lhs : vector<16xf32> to vector<16x16xf32>
-  %mul = arith.mulf %lhsBcast, %rhsT : vector<16x16xf32>
-  return %mul: vector<16x16xf32>
-}
-
-// CHECK-LABEL: func.func @ewise_outerproduct_different_sizes
-//  CHECK-SAME:   %[[LHS:.*]]: vector<8xf32>,
-//  CHECK-SAME:   %[[RHS:.*]]: vector<4xf32>) -> vector<8x4xf32> {
-//       CHECK:     %[[RES:.*]] = vector.outerproduct %[[LHS]], %[[RHS]] : vector<8xf32>, vector<4xf32>
-//       CHECK:     return %[[RES]] : vector<8x4xf32>
-func.func @ewise_outerproduct_different_sizes(%lhs: vector<8xf32>, %rhs: vector<4xf32>) -> vector<8x4xf32> {
-  %lhsBcast = vector.broadcast %lhs : vector<8xf32> to vector<4x8xf32>
-  %lhsT = vector.transpose %lhsBcast, [1, 0] : vector<4x8xf32> to vector<8x4xf32>
-  %rhsBcast = vector.broadcast %rhs : vector<4xf32> to vector<8x4xf32>
-  %mul = arith.mulf %lhsT, %rhsBcast : vector<8x4xf32>
-  return %mul: vector<8x4xf32>
+//  CHECK-SAME:   %[[RHS:.*]]: vector<8xf32>) -> vector<8x16xf32> {
+//       CHECK:     %[[RES:.*]] = vector.outerproduct %[[RHS]], %[[LHS]] : vector<8xf32>, vector<16xf32>
+//       CHECK:     return %[[RES]] : vector<8x16xf32>
+func.func @arith_to_outerproduct_trans_rhs_f32(%lhs: vector<16xf32>, %rhs: vector<8xf32>) -> vector<8x16xf32> {
+  %rhsBcast = vector.broadcast %rhs : vector<8xf32> to vector<16x8xf32>
+  %rhsT = vector.transpose %rhsBcast, [1, 0] : vector<16x8xf32> to vector<8x16xf32>
+  %lhsBcast = vector.broadcast %lhs : vector<16xf32> to vector<8x16xf32>
+  %mul = arith.mulf %lhsBcast, %rhsT : vector<8x16xf32>
+  return %mul: vector<8x16xf32>
 }
 
 module attributes {transform.with_named_sequence} {


### PR DESCRIPTION
1D multi-reduction are lowered to arith which can prevent some optimisation. I propose `ElementwiseToOuterproduct` matching a series of ops to generate `vector.outerproduct`.
As part of some `ElementwiseToVectorOpsPatterns`, it could allow to fuse other elementwiseOps to vector dialect.
Originally discussed https://discourse.llvm.org/t/on-improving-arm-sme-lowering-resilience-in-mlir/78543/24.

quote @MacDue
```
%lhsBcast = vector.broadcast %lhsCast : vector<[4]xf32> to vector<[4]x[4]xf32>
%lhsT = vector.transpose %lhsBcast, [1, 0] : vector<[4]x[4]xf32> to vector<[4]x[4]xf32>
%rhsBcast = vector.broadcast %rhs : vector<[4]xf32> to vector<[4]x[4]xf32>
%mul = arith.mulf %lhsT, %rhsBcast : vector<[4]x[4]xf32>
```

This can be rewritten as:

```
%mul = vector.outerproduct $lhs, $rhs : vector<[4]xf32>, vector<[4]xf32>
```
CC @banach-space , @dcaballe .
