### PR TITLE
[lldb/DWARF] Follow DW_AT_signature when computing type contexts

### DIFF
--- a/lldb/test/Shell/SymbolFile/DWARF/x86/Inputs/debug-types-basic.cpp
+++ b/lldb/test/Shell/SymbolFile/DWARF/x86/Inputs/debug-types-basic.cpp
@@ -10,6 +10,15 @@ struct A {
   EC ec;
 };
 
+struct Outer {
+  int i;
+  struct Inner {
+    long l;
+  };
+};
+
 extern constexpr A a{42, 47l, 4.2f, 4.7, e1, EC::e3};
 extern constexpr E e(e2);
 extern constexpr EC ec(EC::e2);
+extern constexpr Outer outer{47};
+extern constexpr Outer::Inner outer_inner{42l};

--- a/lldb/test/Shell/SymbolFile/DWARF/x86/debug-types-basic.test
+++ b/lldb/test/Shell/SymbolFile/DWARF/x86/debug-types-basic.test
@@ -51,6 +51,12 @@ type lookup EC
 # CHECK-NEXT:   e3
 # CHECK-NEXT: }
 
+type lookup Outer::Inner
+# CHECK-LABEL: type lookup Outer::Inner
+# CHECK:      struct Inner {
+# CHECK-NEXT:   long l;
+# CHECK-NEXT: }
+
 expression (E) 1
 # CHECK-LABEL: expression (E) 1
 # CHECK: (E) $0 = e2
@@ -59,8 +65,9 @@ expression (EC) 1
 # CHECK-LABEL: expression (EC) 1
 # CHECK: (EC) $1 = e2
 
-target variable a e ec
+target variable a e ec outer_inner
 # CHECK-LABEL: target variable a e ec
 # CHECK: (const A) a = (i = 42, l = 47, f = 4.{{[12].*}}, d = 4.{{[67].*}}, e = e1, ec = e3)
 # CHECK: (const E) e = e2
 # CHECK: (const EC) ec = e2
+# CHECK: (const Outer::Inner) outer_inner = (l = 42)


### PR DESCRIPTION
This is necessary to correctly resolve the context within types, as the name of the type is only present in the type unit.

(The DWARFYAML enthusiasm didn't last long, as it does not support type units. It can still be used for testing a lot of other things though.)