### PR TITLE
[lldb] Use packaging module instead of pkg_resources

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/decorators.py
+++ b/lldb/packages/Python/lldbsuite/test/decorators.py
@@ -1,6 +1,6 @@
 # System modules
 from functools import wraps
-from pkg_resources import packaging
+from packaging.version import parse
 import ctypes
 import locale
 import os
@@ -66,9 +66,7 @@ def _check_expected_version(comparison, expected, actual):
         "<=": fn_leq,
     }
 
-    return op_lookup[comparison](
-        packaging.version.parse(actual), packaging.version.parse(expected)
-    )
+    return op_lookup[comparison](parse(actual), parse(expected))
 
 
 def _match_decorator_property(expected, actual):

--- a/lldb/packages/Python/lldbsuite/test/decorators.py
+++ b/lldb/packages/Python/lldbsuite/test/decorators.py
@@ -1,6 +1,6 @@
 # System modules
 from functools import wraps
-from packaging.version import parse
+from packaging import version
 import ctypes
 import locale
 import os
@@ -66,7 +66,7 @@ def _check_expected_version(comparison, expected, actual):
         "<=": fn_leq,
     }
 
-    return op_lookup[comparison](parse(actual), parse(expected))
+    return op_lookup[comparison](version.parse(actual), version.parse(expected))
 
 
 def _match_decorator_property(expected, actual):

--- a/lldb/packages/Python/lldbsuite/test/lldbplatformutil.py
+++ b/lldb/packages/Python/lldbsuite/test/lldbplatformutil.py
@@ -8,8 +8,7 @@ import re
 import subprocess
 import sys
 import os
-from urllib.parse import urlparse
-from pkg_resources import packaging
+from packaging.version import parse
 
 # LLDB modules
 import lldb
@@ -309,8 +308,8 @@ def expectedCompilerVersion(compiler_version):
         # Assume the compiler version is at or near the top of trunk.
         return operator in [">", ">=", "!", "!=", "not"]
 
-    version = packaging.version.parse(version_str)
-    test_compiler_version = packaging.version.parse(test_compiler_version_str)
+    version = parse(version_str)
+    test_compiler_version = parse(test_compiler_version_str)
 
     if operator == ">":
         return test_compiler_version > version

--- a/lldb/packages/Python/lldbsuite/test/lldbplatformutil.py
+++ b/lldb/packages/Python/lldbsuite/test/lldbplatformutil.py
@@ -8,7 +8,7 @@ import re
 import subprocess
 import sys
 import os
-from packaging.version import parse
+from packaging import version
 
 # LLDB modules
 import lldb
@@ -308,17 +308,17 @@ def expectedCompilerVersion(compiler_version):
         # Assume the compiler version is at or near the top of trunk.
         return operator in [">", ">=", "!", "!=", "not"]
 
-    version = parse(version_str)
-    test_compiler_version = parse(test_compiler_version_str)
+    actual_version = version.parse(version_str)
+    test_compiler_version = version.parse(test_compiler_version_str)
 
     if operator == ">":
-        return test_compiler_version > version
+        return test_compiler_version > actual_version
     if operator == ">=" or operator == "=>":
-        return test_compiler_version >= version
+        return test_compiler_version >= actual_version
     if operator == "<":
-        return test_compiler_version < version
+        return test_compiler_version < actual_version
     if operator == "<=" or operator == "=<":
-        return test_compiler_version <= version
+        return test_compiler_version <= actual_version
     if operator == "!=" or operator == "!" or operator == "not":
         return version_str not in test_compiler_version_str
     return version_str in test_compiler_version_str

--- a/lldb/test/API/tools/lldb-server/TestAppleSimulatorOSType.py
+++ b/lldb/test/API/tools/lldb-server/TestAppleSimulatorOSType.py
@@ -61,9 +61,9 @@ class TestAppleSimulatorOSType(gdbremote_testcase.GdbRemoteTestCaseBase):
 
         # Older versions of watchOS (<7.0) only support i386
         if platform_name == "watchos":
-            from packaging.version import parse
+            from packaging import version
 
-            if parse(vers) < parse("7.0"):
+            if version.parse(vers) < version.parse("7.0"):
                 arch = "i386"
 
         triple = "-".join([arch, "apple", platform_name + vers, "simulator"])

--- a/lldb/test/API/tools/lldb-server/TestAppleSimulatorOSType.py
+++ b/lldb/test/API/tools/lldb-server/TestAppleSimulatorOSType.py
@@ -61,9 +61,9 @@ class TestAppleSimulatorOSType(gdbremote_testcase.GdbRemoteTestCaseBase):
 
         # Older versions of watchOS (<7.0) only support i386
         if platform_name == "watchos":
-            from pkg_resources import packaging
+            from packaging.version import parse
 
-            if packaging.version.parse(vers) < packaging.version.parse("7.0"):
+            if parse(vers) < parse("7.0"):
                 arch = "i386"
 
         triple = "-".join([arch, "apple", platform_name + vers, "simulator"])

--- a/lldb/test/Shell/helper/build.py
+++ b/lldb/test/Shell/helper/build.py
@@ -519,9 +519,9 @@ class MsvcBuilder(Builder):
 
             # Windows SDK version numbers consist of 4 dotted components, so we
             # have to use LooseVersion, as StrictVersion supports 3 or fewer.
-            from pkg_resources import packaging
+            from packaging.version import parse
 
-            sdk_versions.sort(key=lambda x: packaging.version.parse(x), reverse=True)
+            sdk_versions.sort(key=lambda x: parse(x), reverse=True)
             option_value_name = "OptionId.DesktopCPP" + self.msvc_arch_str
             for v in sdk_versions:
                 try:

--- a/lldb/test/Shell/helper/build.py
+++ b/lldb/test/Shell/helper/build.py
@@ -441,9 +441,9 @@ class MsvcBuilder(Builder):
         if not subdirs:
             return None
 
-        from distutils.version import StrictVersion
+        from packaging import version
 
-        subdirs.sort(key=lambda x: StrictVersion(x))
+        subdirs.sort(key=lambda x: version.parse(x))
 
         if self.verbose:
             full_path = os.path.join(vcinstalldir, subdirs[-1])
@@ -517,11 +517,9 @@ class MsvcBuilder(Builder):
             if not sdk_versions:
                 return (None, None)
 
-            # Windows SDK version numbers consist of 4 dotted components, so we
-            # have to use LooseVersion, as StrictVersion supports 3 or fewer.
-            from packaging.version import parse
+            from packaging import version
 
-            sdk_versions.sort(key=lambda x: parse(x), reverse=True)
+            sdk_versions.sort(key=lambda x: version.parse(x), reverse=True)
             option_value_name = "OptionId.DesktopCPP" + self.msvc_arch_str
             for v in sdk_versions:
                 try:


### PR DESCRIPTION
Use the packaging [1] module for parsing version numbers, instead of pkg_resources which is distributed with setuptools. I recently switched over to using the latter, knowing it was deprecated (in favor of the packaging module) because it comes with Python out of the box. Newer versions of setuptools have removed `pkg_resources` so we have to use packaging.

[1] https://pypi.org/project/packaging/