### PR TITLE
[AArch64] Optimize when storing symmetry constants

### DIFF
--- a/llvm/test/CodeGen/AArch64/movimm-expand-ldst.ll
+++ b/llvm/test/CodeGen/AArch64/movimm-expand-ldst.ll
@@ -93,3 +93,190 @@ define i64 @testuu0xf555f555f555f555() {
 ; CHECK-NEXT:    ret
   ret i64 u0xf555f555f555f555
 }
+
+define void @test_store_0x1234567812345678(ptr %x) {
+; CHECK-LABEL: test_store_0x1234567812345678:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    mov x8, #22136 // =0x5678
+; CHECK-NEXT:    movk x8, #4660, lsl #16
+; CHECK-NEXT:    orr x8, x8, x8, lsl #32
+; CHECK-NEXT:    str x8, [x0]
+; CHECK-NEXT:    ret
+  store i64 u0x1234567812345678, ptr %x
+  ret void
+}
+
+define void @test_store_0xff3456ffff3456ff(ptr %x) {
+; CHECK-LABEL: test_store_0xff3456ffff3456ff:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    mov x8, #22271 // =0x56ff
+; CHECK-NEXT:    movk x8, #65332, lsl #16
+; CHECK-NEXT:    orr x8, x8, x8, lsl #32
+; CHECK-NEXT:    str x8, [x0]
+; CHECK-NEXT:    ret
+  store i64 u0xff3456ffff3456ff, ptr %x
+  ret void
+}
+
+define void @test_store_0x00345600345600(ptr %x) {
+; CHECK-LABEL: test_store_0x00345600345600:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    mov x8, #22016 // =0x5600
+; CHECK-NEXT:    movk x8, #52, lsl #16
+; CHECK-NEXT:    movk x8, #13398, lsl #32
+; CHECK-NEXT:    str x8, [x0]
+; CHECK-NEXT:    ret
+  store i64 u0x00345600345600, ptr %x
+  ret void
+}
+
+define void @test_store_0x5555555555555555(ptr %x) {
+; CHECK-LABEL: test_store_0x5555555555555555:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    mov x8, #6148914691236517205 // =0x5555555555555555
+; CHECK-NEXT:    str x8, [x0]
+; CHECK-NEXT:    ret
+  store i64 u0x5555555555555555, ptr %x
+  ret void
+}
+
+define void @test_store_0x5055555550555555(ptr %x) {
+; CHECK-LABEL: test_store_0x5055555550555555:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    mov x8, #6148914691236517205 // =0x5555555555555555
+; CHECK-NEXT:    and x8, x8, #0xf0fffffff0ffffff
+; CHECK-NEXT:    str x8, [x0]
+; CHECK-NEXT:    ret
+  store i64 u0x5055555550555555, ptr %x
+  ret void
+}
+
+define void @test_store_0x0000555555555555(ptr %x) {
+; CHECK-LABEL: test_store_0x0000555555555555:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    mov x8, #6148914691236517205 // =0x5555555555555555
+; CHECK-NEXT:    movk x8, #0, lsl #48
+; CHECK-NEXT:    str x8, [x0]
+; CHECK-NEXT:    ret
+  store i64 u0x0000555555555555, ptr %x
+  ret void
+}
+
+define void @test_store_0x0000555500005555(ptr %x) {
+; CHECK-LABEL: test_store_0x0000555500005555:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    mov x8, #21845 // =0x5555
+; CHECK-NEXT:    movk x8, #21845, lsl #32
+; CHECK-NEXT:    str x8, [x0]
+; CHECK-NEXT:    ret
+  store i64 u0x0000555500005555, ptr %x
+  ret void
+}
+
+define void @test_store_0x5555000055550000(ptr %x) {
+; CHECK-LABEL: test_store_0x5555000055550000:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    mov x8, #1431633920 // =0x55550000
+; CHECK-NEXT:    movk x8, #21845, lsl #48
+; CHECK-NEXT:    str x8, [x0]
+; CHECK-NEXT:    ret
+  store i64 u0x5555000055550000, ptr %x
+  ret void
+}
+
+define void @test_store_u0xffff5555ffff5555(ptr %x) {
+; CHECK-LABEL: test_store_u0xffff5555ffff5555:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    mov x8, #-43691 // =0xffffffffffff5555
+; CHECK-NEXT:    movk x8, #21845, lsl #32
+; CHECK-NEXT:    str x8, [x0]
+; CHECK-NEXT:    ret
+  store i64 u0xffff5555ffff5555, ptr %x
+  ret void
+}
+
+define void @test_store_0x8888ffff8888ffff(ptr %x) {
+; CHECK-LABEL: test_store_0x8888ffff8888ffff:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    mov x8, #-2004287489 // =0xffffffff8888ffff
+; CHECK-NEXT:    movk x8, #34952, lsl #48
+; CHECK-NEXT:    str x8, [x0]
+; CHECK-NEXT:    ret
+  store i64 u0x8888ffff8888ffff, ptr %x
+  ret void
+}
+
+define void @test_store_uu0xfffff555f555f555(ptr %x) {
+; CHECK-LABEL: test_store_uu0xfffff555f555f555:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    mov x8, #-2731 // =0xfffffffffffff555
+; CHECK-NEXT:    movk x8, #62805, lsl #16
+; CHECK-NEXT:    movk x8, #62805, lsl #32
+; CHECK-NEXT:    str x8, [x0]
+; CHECK-NEXT:    ret
+  store i64 u0xfffff555f555f555, ptr %x
+  ret void
+}
+
+define void @test_store_uu0xf555f555f555f555(ptr %x) {
+; CHECK-LABEL: test_store_uu0xf555f555f555f555:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    mov x8, #6148914691236517205 // =0x5555555555555555
+; CHECK-NEXT:    orr x8, x8, #0xe001e001e001e001
+; CHECK-NEXT:    str x8, [x0]
+; CHECK-NEXT:    ret
+  store i64 u0xf555f555f555f555, ptr %x
+  ret void
+}
+
+define void @test_store_0x1234567812345678_offset_range(ptr %x) {
+; CHECK-LABEL: test_store_0x1234567812345678_offset_range:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    mov x8, #22136 // =0x5678
+; CHECK-NEXT:    movk x8, #4660, lsl #16
+; CHECK-NEXT:    orr x8, x8, x8, lsl #32
+; CHECK-NEXT:    str x8, [x0, #32]
+; CHECK-NEXT:    ret
+  %g = getelementptr i64, ptr %x, i64 4
+  store i64 u0x1234567812345678, ptr %g
+  ret void
+}
+
+define void @test_store_0x1234567812345678_offset_min(ptr %x) {
+; CHECK-LABEL: test_store_0x1234567812345678_offset_min:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    mov x8, #22136 // =0x5678
+; CHECK-NEXT:    movk x8, #4660, lsl #16
+; CHECK-NEXT:    orr x8, x8, x8, lsl #32
+; CHECK-NEXT:    str x8, [x0]
+; CHECK-NEXT:    ret
+  %g = getelementptr i8, ptr %x, i32 0
+  store i64 u0x1234567812345678, ptr %g
+  ret void
+}
+
+define void @test_store_0x1234567812345678_offset_max(ptr %x) {
+; CHECK-LABEL: test_store_0x1234567812345678_offset_max:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    mov x8, #22136 // =0x5678
+; CHECK-NEXT:    movk x8, #4660, lsl #16
+; CHECK-NEXT:    orr x8, x8, x8, lsl #32
+; CHECK-NEXT:    str x8, [x0, #248]
+; CHECK-NEXT:    ret
+  %g = getelementptr i8, ptr %x, i32 248
+  store i64 u0x1234567812345678, ptr %g
+  ret void
+}
+
+define void @test_store_0x1234567812345678_offset_max_over(ptr %x) {
+; CHECK-LABEL: test_store_0x1234567812345678_offset_max_over:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    mov x8, #22136 // =0x5678
+; CHECK-NEXT:    movk x8, #4660, lsl #16
+; CHECK-NEXT:    orr x8, x8, x8, lsl #32
+; CHECK-NEXT:    stur x8, [x0, #249]
+; CHECK-NEXT:    ret
+  %g = getelementptr i8, ptr %x, i32 249
+  store i64 u0x1234567812345678, ptr %g
+  ret void
+}

--- a/llvm/test/CodeGen/AArch64/movimm-expand-ldst.ll
+++ b/llvm/test/CodeGen/AArch64/movimm-expand-ldst.ll
@@ -99,8 +99,7 @@ define void @test_store_0x1234567812345678(ptr %x) {
 ; CHECK:       // %bb.0:
 ; CHECK-NEXT:    mov x8, #22136 // =0x5678
 ; CHECK-NEXT:    movk x8, #4660, lsl #16
-; CHECK-NEXT:    orr x8, x8, x8, lsl #32
-; CHECK-NEXT:    str x8, [x0]
+; CHECK-NEXT:    stp w8, w8, [x0]
 ; CHECK-NEXT:    ret
   store i64 u0x1234567812345678, ptr %x
   ret void
@@ -111,8 +110,7 @@ define void @test_store_0xff3456ffff3456ff(ptr %x) {
 ; CHECK:       // %bb.0:
 ; CHECK-NEXT:    mov x8, #22271 // =0x56ff
 ; CHECK-NEXT:    movk x8, #65332, lsl #16
-; CHECK-NEXT:    orr x8, x8, x8, lsl #32
-; CHECK-NEXT:    str x8, [x0]
+; CHECK-NEXT:    stp w8, w8, [x0]
 ; CHECK-NEXT:    ret
   store i64 u0xff3456ffff3456ff, ptr %x
   ret void
@@ -166,8 +164,7 @@ define void @test_store_0x0000555500005555(ptr %x) {
 ; CHECK-LABEL: test_store_0x0000555500005555:
 ; CHECK:       // %bb.0:
 ; CHECK-NEXT:    mov x8, #21845 // =0x5555
-; CHECK-NEXT:    movk x8, #21845, lsl #32
-; CHECK-NEXT:    str x8, [x0]
+; CHECK-NEXT:    stp w8, w8, [x0]
 ; CHECK-NEXT:    ret
   store i64 u0x0000555500005555, ptr %x
   ret void
@@ -177,8 +174,7 @@ define void @test_store_0x5555000055550000(ptr %x) {
 ; CHECK-LABEL: test_store_0x5555000055550000:
 ; CHECK:       // %bb.0:
 ; CHECK-NEXT:    mov x8, #1431633920 // =0x55550000
-; CHECK-NEXT:    movk x8, #21845, lsl #48
-; CHECK-NEXT:    str x8, [x0]
+; CHECK-NEXT:    stp w8, w8, [x0]
 ; CHECK-NEXT:    ret
   store i64 u0x5555000055550000, ptr %x
   ret void
@@ -234,8 +230,7 @@ define void @test_store_0x1234567812345678_offset_range(ptr %x) {
 ; CHECK:       // %bb.0:
 ; CHECK-NEXT:    mov x8, #22136 // =0x5678
 ; CHECK-NEXT:    movk x8, #4660, lsl #16
-; CHECK-NEXT:    orr x8, x8, x8, lsl #32
-; CHECK-NEXT:    str x8, [x0, #32]
+; CHECK-NEXT:    stp w8, w8, [x0, #32]
 ; CHECK-NEXT:    ret
   %g = getelementptr i64, ptr %x, i64 4
   store i64 u0x1234567812345678, ptr %g
@@ -247,8 +242,7 @@ define void @test_store_0x1234567812345678_offset_min(ptr %x) {
 ; CHECK:       // %bb.0:
 ; CHECK-NEXT:    mov x8, #22136 // =0x5678
 ; CHECK-NEXT:    movk x8, #4660, lsl #16
-; CHECK-NEXT:    orr x8, x8, x8, lsl #32
-; CHECK-NEXT:    str x8, [x0]
+; CHECK-NEXT:    stp w8, w8, [x0]
 ; CHECK-NEXT:    ret
   %g = getelementptr i8, ptr %x, i32 0
   store i64 u0x1234567812345678, ptr %g
@@ -260,8 +254,7 @@ define void @test_store_0x1234567812345678_offset_max(ptr %x) {
 ; CHECK:       // %bb.0:
 ; CHECK-NEXT:    mov x8, #22136 // =0x5678
 ; CHECK-NEXT:    movk x8, #4660, lsl #16
-; CHECK-NEXT:    orr x8, x8, x8, lsl #32
-; CHECK-NEXT:    str x8, [x0, #248]
+; CHECK-NEXT:    stp w8, w8, [x0, #248]
 ; CHECK-NEXT:    ret
   %g = getelementptr i8, ptr %x, i32 248
   store i64 u0x1234567812345678, ptr %g

--- a/llvm/test/CodeGen/AArch64/movimm-expand-ldst.mir
+++ b/llvm/test/CodeGen/AArch64/movimm-expand-ldst.mir
@@ -32,3 +32,137 @@ body:             |
     ; CHECK-NEXT: RET undef $lr, implicit $x0
     renamable $x0 = MOVi64imm -4550323095879417536
     RET_ReallyLR implicit $x0
+...
+---
+name: test_fold_repeating_constant_store
+tracksRegLiveness: true
+body:             |
+  bb.0:
+    liveins: $x0
+    ; CHECK-LABEL: name: test_fold_repeating_constant_store
+    ; CHECK: liveins: $x0
+    ; CHECK-NEXT: {{  $}}
+    ; CHECK-NEXT: renamable $x8 = MOVZXi 49370, 0
+    ; CHECK-NEXT: renamable $x8 = MOVKXi $x8, 320, 16
+    ; CHECK-NEXT: renamable $x8 = ORRXrs $x8, $x8, 32
+    ; CHECK-NEXT: STRXui killed renamable $x8, killed renamable $x0, 0
+    ; CHECK-NEXT: RET undef $lr
+    renamable $x8 = MOVi64imm 90284035103834330
+    STRXui killed renamable $x8, killed renamable $x0, 0
+    RET_ReallyLR
+...
+---
+name: test_fold_repeating_constant_store_neg
+tracksRegLiveness: true
+body:             |
+  bb.0:
+    liveins: $x0
+    ; CHECK-LABEL: name: test_fold_repeating_constant_store_neg
+    ; CHECK: liveins: $x0
+    ; CHECK-NEXT: {{  $}}
+    ; CHECK-NEXT: renamable $x8 = MOVZXi 320, 0
+    ; CHECK-NEXT: renamable $x8 = MOVKXi $x8, 49370, 16
+    ; CHECK-NEXT: renamable $x8 = ORRXrs $x8, $x8, 32
+    ; CHECK-NEXT: STRXui killed renamable $x8, killed renamable $x0, 0
+    ; CHECK-NEXT: RET undef $lr
+    renamable $x8 = MOVi64imm -4550323095879417536
+    STRXui killed renamable $x8, killed renamable $x0, 0
+    RET_ReallyLR
+...
+---
+name: test_fold_repeating_constant_store_16bit_unit
+tracksRegLiveness: true
+body:             |
+  bb.0:
+    liveins: $x0
+    ; CHECK-LABEL: name: test_fold_repeating_constant_store_16bit_unit
+    ; CHECK: liveins: $x0
+    ; CHECK-NEXT: {{  $}}
+    ; CHECK-NEXT: renamable $x8 = MOVZXi 21845, 16
+    ; CHECK-NEXT: renamable $x8 = MOVKXi $x8, 21845, 48
+    ; CHECK-NEXT: STRXui killed renamable $x8, killed renamable $x0, 0
+    ; CHECK-NEXT: RET undef $lr
+    renamable $x8 = MOVZXi 21845, 16
+    renamable $x8 = MOVKXi $x8, 21845, 48
+    STRXui killed renamable $x8, killed renamable $x0, 0
+    RET undef $lr
+...
+---
+name: test_fold_repeating_constant_store_offset_min
+tracksRegLiveness: true
+body:             |
+  bb.0:
+    liveins: $x0
+    ; CHECK-LABEL: name: test_fold_repeating_constant_store_offset_min
+    ; CHECK: liveins: $x0
+    ; CHECK-NEXT: {{  $}}
+    ; CHECK-NEXT: renamable $x8 = MOVZXi 22136, 0
+    ; CHECK-NEXT: renamable $x8 = MOVKXi $x8, 4660, 16
+    ; CHECK-NEXT: renamable $x8 = ORRXrs $x8, $x8, 32
+    ; CHECK-NEXT: STRXui killed renamable $x8, killed renamable $x0, 0
+    ; CHECK-NEXT: RET undef $lr
+    renamable $x8 = MOVZXi 22136, 0
+    renamable $x8 = MOVKXi $x8, 4660, 16
+    renamable $x8 = ORRXrs $x8, $x8, 32
+    STRXui killed renamable $x8, killed renamable $x0, 0
+    RET undef $lr
+...
+---
+name: test_fold_repeating_constant_store_offset_max
+tracksRegLiveness: true
+body:             |
+  bb.0:
+    liveins: $x0
+    ; CHECK-LABEL: name: test_fold_repeating_constant_store_offset_max
+    ; CHECK: liveins: $x0
+    ; CHECK-NEXT: {{  $}}
+    ; CHECK-NEXT: renamable $x8 = MOVZXi 22136, 0
+    ; CHECK-NEXT: renamable $x8 = MOVKXi $x8, 4660, 16
+    ; CHECK-NEXT: renamable $x8 = ORRXrs $x8, $x8, 32
+    ; CHECK-NEXT: STRXui killed renamable $x8, killed renamable $x0, 31
+    ; CHECK-NEXT: RET undef $lr
+    renamable $x8 = MOVZXi 22136, 0
+    renamable $x8 = MOVKXi $x8, 4660, 16
+    renamable $x8 = ORRXrs $x8, $x8, 32
+    STRXui killed renamable $x8, killed renamable $x0, 31
+    RET undef $lr
+...
+---
+name: test_fold_repeating_constant_store_offset_min_lower
+tracksRegLiveness: true
+body:             |
+  bb.0:
+    liveins: $x0
+    ; CHECK-LABEL: name: test_fold_repeating_constant_store_offset_min_lower
+    ; CHECK: liveins: $x0
+    ; CHECK-NEXT: {{  $}}
+    ; CHECK-NEXT: renamable $x8 = MOVZXi 22136, 0
+    ; CHECK-NEXT: renamable $x8 = MOVKXi $x8, 4660, 16
+    ; CHECK-NEXT: renamable $x8 = ORRXrs $x8, $x8, 32
+    ; CHECK-NEXT: STRXui killed renamable $x8, killed renamable $x0, 0
+    ; CHECK-NEXT: RET undef $lr
+    renamable $x8 = MOVZXi 22136, 0
+    renamable $x8 = MOVKXi $x8, 4660, 16
+    renamable $x8 = ORRXrs $x8, $x8, 32
+    STRXui killed renamable $x8, killed renamable $x0, 0
+    RET undef $lr
+...
+---
+name: test_fold_repeating_constant_store_offset_max_over
+tracksRegLiveness: true
+body:             |
+  bb.0:
+    liveins: $x0
+    ; CHECK-LABEL: name: test_fold_repeating_constant_store_offset_max_over
+    ; CHECK: liveins: $x0
+    ; CHECK-NEXT: {{  $}}
+    ; CHECK-NEXT: renamable $x8 = MOVZXi 22136, 0
+    ; CHECK-NEXT: renamable $x8 = MOVKXi $x8, 4660, 16
+    ; CHECK-NEXT: renamable $x8 = ORRXrs $x8, $x8, 32
+    ; CHECK-NEXT: STRXui killed renamable $x8, killed renamable $x0, 32
+    ; CHECK-NEXT: RET undef $lr
+    renamable $x8 = MOVZXi 22136, 0
+    renamable $x8 = MOVKXi $x8, 4660, 16
+    renamable $x8 = ORRXrs $x8, $x8, 32
+    STRXui killed renamable $x8, killed renamable $x0, 32
+    RET undef $lr

--- a/llvm/test/CodeGen/AArch64/movimm-expand-ldst.mir
+++ b/llvm/test/CodeGen/AArch64/movimm-expand-ldst.mir
@@ -44,8 +44,7 @@ body:             |
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: renamable $x8 = MOVZXi 49370, 0
     ; CHECK-NEXT: renamable $x8 = MOVKXi $x8, 320, 16
-    ; CHECK-NEXT: renamable $x8 = ORRXrs $x8, $x8, 32
-    ; CHECK-NEXT: STRXui killed renamable $x8, killed renamable $x0, 0
+    ; CHECK-NEXT: STPWi killed renamable $w8, killed renamable $w8, killed renamable $x0, 0
     ; CHECK-NEXT: RET undef $lr
     renamable $x8 = MOVi64imm 90284035103834330
     STRXui killed renamable $x8, killed renamable $x0, 0
@@ -62,8 +61,7 @@ body:             |
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: renamable $x8 = MOVZXi 320, 0
     ; CHECK-NEXT: renamable $x8 = MOVKXi $x8, 49370, 16
-    ; CHECK-NEXT: renamable $x8 = ORRXrs $x8, $x8, 32
-    ; CHECK-NEXT: STRXui killed renamable $x8, killed renamable $x0, 0
+    ; CHECK-NEXT: STPWi killed renamable $w8, killed renamable $w8, killed renamable $x0, 0
     ; CHECK-NEXT: RET undef $lr
     renamable $x8 = MOVi64imm -4550323095879417536
     STRXui killed renamable $x8, killed renamable $x0, 0
@@ -79,8 +77,7 @@ body:             |
     ; CHECK: liveins: $x0
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: renamable $x8 = MOVZXi 21845, 16
-    ; CHECK-NEXT: renamable $x8 = MOVKXi $x8, 21845, 48
-    ; CHECK-NEXT: STRXui killed renamable $x8, killed renamable $x0, 0
+    ; CHECK-NEXT: STPWi killed renamable $w8, killed renamable $w8, killed renamable $x0, 0
     ; CHECK-NEXT: RET undef $lr
     renamable $x8 = MOVZXi 21845, 16
     renamable $x8 = MOVKXi $x8, 21845, 48
@@ -98,8 +95,7 @@ body:             |
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: renamable $x8 = MOVZXi 22136, 0
     ; CHECK-NEXT: renamable $x8 = MOVKXi $x8, 4660, 16
-    ; CHECK-NEXT: renamable $x8 = ORRXrs $x8, $x8, 32
-    ; CHECK-NEXT: STRXui killed renamable $x8, killed renamable $x0, 0
+    ; CHECK-NEXT: STPWi killed renamable $w8, killed renamable $w8, killed renamable $x0, 0
     ; CHECK-NEXT: RET undef $lr
     renamable $x8 = MOVZXi 22136, 0
     renamable $x8 = MOVKXi $x8, 4660, 16
@@ -118,8 +114,7 @@ body:             |
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: renamable $x8 = MOVZXi 22136, 0
     ; CHECK-NEXT: renamable $x8 = MOVKXi $x8, 4660, 16
-    ; CHECK-NEXT: renamable $x8 = ORRXrs $x8, $x8, 32
-    ; CHECK-NEXT: STRXui killed renamable $x8, killed renamable $x0, 31
+    ; CHECK-NEXT: STPWi killed renamable $w8, killed renamable $w8, killed renamable $x0, 62
     ; CHECK-NEXT: RET undef $lr
     renamable $x8 = MOVZXi 22136, 0
     renamable $x8 = MOVKXi $x8, 4660, 16
@@ -138,8 +133,7 @@ body:             |
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: renamable $x8 = MOVZXi 22136, 0
     ; CHECK-NEXT: renamable $x8 = MOVKXi $x8, 4660, 16
-    ; CHECK-NEXT: renamable $x8 = ORRXrs $x8, $x8, 32
-    ; CHECK-NEXT: STRXui killed renamable $x8, killed renamable $x0, 0
+    ; CHECK-NEXT: STPWi killed renamable $w8, killed renamable $w8, killed renamable $x0, 0
     ; CHECK-NEXT: RET undef $lr
     renamable $x8 = MOVZXi 22136, 0
     renamable $x8 = MOVKXi $x8, 4660, 16


### PR DESCRIPTION
This change looks for instructions of storing symmetric constants
instruction 32-bit units. usually consisting of several 'MOV' and
one or less 'ORR'.

If found, load only the lower 32-bit constant and change it to copy
and save to the upper 32-bit using the 'STP' instruction.

For example:
  renamable $x8 = MOVZXi 49370, 0
  renamable $x8 = MOVKXi $x8, 320, 16
  renamable $x8 = ORRXrs $x8, $x8, 32
  STRXui killed renamable $x8, killed renamable $x0, 0
becomes
  $w8 = MOVZWi 49370, 0
  $w8 = MOVKWi $w8, 320, 16
  STPWi killed renamable $w8, killed renamable $w8, killed renamable $x0, 0


related issue : https://github.com/llvm/llvm-project/issues/51483