### PR TITLE
[Github]Update PGO with more filepaths

### DIFF
--- a/.github/new-prs-labeler.yml
+++ b/.github/new-prs-labeler.yml
@@ -54,6 +54,9 @@ llvm-lit:
   - llvm/utils/lit/**/*
 
 PGO:
+  - llvm/**/ProfileData/**/*
+  - llvm/**/SampleProfile*
+  - llvm/**/CodeGen/MIRSampleProfile*
   - llvm/lib/Transforms/Instrumentation/CGProfile.cpp
   - llvm/lib/Transforms/Instrumentation/ControlHeightReduction.cpp
   - llvm/lib/Transforms/Instrumentation/IndirectCallPromotion.cpp
@@ -62,9 +65,9 @@ PGO:
   - llvm/lib/Transforms/Instrumentation/ValueProfile*
   - llvm/test/Instrumentation/InstrProfiling/**/*
   - llvm/test/Transforms/PGOProfile/**/*
+  - llvm/test/Transforms/SampleProfile/**/*
   - llvm/**/llvm-profdata/**/*
   - llvm/**/llvm-profgen/**/*
-  - llvm/unittests/ProfileData/**/*
 
 vectorization:
   - llvm/lib/Transforms/Vectorize/**/*


### PR DESCRIPTION
- `llvm/**/ProfileData/**/*` intends to cover `llvm/include/llvm/ProfileData/` and `llvm/lib/ProfileData/`
- `llvm/**/SampleProfile*` intends to cover a bunch of SamplePGO files and their headers.
    -  For example, `SampleProfile.cpp`, `SampleProfileMatcher.cpp`, `SampleProfileProbe.cpp`, `SampleProfileInference.cpp`, `SampleProfileLoaderBaseUtil.cpp`
- `llvm/**/CodeGen/MIRSampleProfile*` intends to cover MIRSampleProfile.cpp and its header.
- `llvm/test/Transforms/SampleProfile/**/*` intends to cover unit tests.