### PR TITLE
[CI] Disable Flang from pre-commit tests when Flang files are not touched on Windows Only

### DIFF
--- a/.ci/generate-buildkite-pipeline-premerge
+++ b/.ci/generate-buildkite-pipeline-premerge
@@ -53,7 +53,10 @@ echo "Directories modified:" >&2
 echo "$modified_dirs" >&2
 
 function compute-projects-to-test() {
+  isForWindows=$1
+  shift
   projects=${@}
+  echo "isForWindows : $isForWindows ; projects: $projects " >&2
   for project in ${projects}; do
     echo "${project}"
     case ${project} in
@@ -63,9 +66,13 @@ function compute-projects-to-test() {
       done
     ;;
     llvm)
-      for p in bolt clang clang-tools-extra flang lld lldb mlir polly; do
+      for p in bolt clang clang-tools-extra lld lldb mlir polly; do
         echo $p
       done
+      # Flang is not stable in Windows CI at the moment
+      if [[ $isForWindows == 0 ]]; then
+        echo flang
+      fi
     ;;
     clang)
       for p in clang-tools-extra compiler-rt lldb cross-project-tests; do
@@ -76,7 +83,10 @@ function compute-projects-to-test() {
       echo libc
     ;;
     mlir)
-      echo flang
+      # Flang is not stable in Windows CI at the moment
+      if [[ $isForWindows == 0 ]]; then
+        echo flang
+      fi
     ;;
     *)
       # Nothing to do
@@ -241,7 +251,7 @@ fi
 all_projects="bolt clang clang-tools-extra compiler-rt cross-project-tests flang libc libclc lld lldb llvm mlir openmp polly pstl"
 modified_projects="$(keep-modified-projects ${all_projects})"
 
-linux_projects_to_test=$(exclude-linux $(compute-projects-to-test ${modified_projects}))
+linux_projects_to_test=$(exclude-linux $(compute-projects-to-test 0 ${modified_projects}))
 linux_check_targets=$(check-targets ${linux_projects_to_test} | sort | uniq)
 linux_projects=$(add-dependencies ${linux_projects_to_test} | sort | uniq)
 
@@ -249,7 +259,7 @@ linux_runtimes_to_test=$(compute-runtimes-to-test ${linux_projects_to_test})
 linux_runtime_check_targets=$(check-targets ${linux_runtimes_to_test} | sort | uniq)
 linux_runtimes=$(echo ${linux_runtimes_to_test} | sort | uniq)
 
-windows_projects_to_test=$(exclude-windows $(compute-projects-to-test ${modified_projects}))
+windows_projects_to_test=$(exclude-windows $(compute-projects-to-test 1 ${modified_projects}))
 windows_check_targets=$(check-targets ${windows_projects_to_test} | sort | uniq)
 windows_projects=$(add-dependencies ${windows_projects_to_test} | sort | uniq)
 


### PR DESCRIPTION
Flang triggers some OOM on Windows CI right now. This is disruptive to MLIR and LLVM changes that don't touch Flang, as such we disable building Flang on Windows only for these PR that don't touch flang. The testing on Linux is unchanged, and the post-merge Windows testing is still fully covering here.