### PR TITLE
Revert "[lldb][lldb-dap] Cleanup breakpoint filters."

### DIFF
--- a/lldb/include/lldb/API/SBDebugger.h
+++ b/lldb/include/lldb/API/SBDebugger.h
@@ -57,8 +57,6 @@ public:
 
   static const char *GetBroadcasterClass();
 
-  static bool SupportsLanguage(lldb::LanguageType language);
-
   lldb::SBBroadcaster GetBroadcaster();
 
   /// Get progress data from a SBEvent whose type is eBroadcastBitProgress.

--- a/lldb/include/lldb/Symbol/TypeSystem.h
+++ b/lldb/include/lldb/Symbol/TypeSystem.h
@@ -209,7 +209,6 @@ public:
   // TypeSystems can support more than one language
   virtual bool SupportsLanguage(lldb::LanguageType language) = 0;
 
-  static bool SupportsLanguageStatic(lldb::LanguageType language);
   // Type Completion
 
   virtual bool GetCompleteType(lldb::opaque_compiler_type_t type) = 0;

--- a/lldb/source/API/SBDebugger.cpp
+++ b/lldb/source/API/SBDebugger.cpp
@@ -1742,7 +1742,3 @@ bool SBDebugger::InterruptRequested()   {
     return m_opaque_sp->InterruptRequested();
   return false;
 }
-
-bool SBDebugger::SupportsLanguage(lldb::LanguageType language) {
-  return TypeSystem::SupportsLanguageStatic(language);
-}

--- a/lldb/source/Symbol/TypeSystem.cpp
+++ b/lldb/source/Symbol/TypeSystem.cpp
@@ -335,14 +335,3 @@ TypeSystemMap::GetTypeSystemForLanguage(lldb::LanguageType language,
   }
   return GetTypeSystemForLanguage(language);
 }
-
-bool TypeSystem::SupportsLanguageStatic(lldb::LanguageType language) {
-  if (language == eLanguageTypeUnknown)
-    return false;
-
-  LanguageSet languages =
-      PluginManager::GetAllTypeSystemSupportedLanguagesForTypes();
-  if (languages.Empty())
-    return false;
-  return languages[language];
-}

--- a/lldb/tools/lldb-dap/DAP.cpp
+++ b/lldb/tools/lldb-dap/DAP.cpp
@@ -32,7 +32,14 @@ namespace lldb_dap {
 DAP g_dap;
 
 DAP::DAP()
-    : broadcaster("lldb-dap"), exception_breakpoints(),
+    : broadcaster("lldb-dap"),
+      exception_breakpoints(
+          {{"cpp_catch", "C++ Catch", lldb::eLanguageTypeC_plus_plus},
+           {"cpp_throw", "C++ Throw", lldb::eLanguageTypeC_plus_plus},
+           {"objc_catch", "Objective-C Catch", lldb::eLanguageTypeObjC},
+           {"objc_throw", "Objective-C Throw", lldb::eLanguageTypeObjC},
+           {"swift_catch", "Swift Catch", lldb::eLanguageTypeSwift},
+           {"swift_throw", "Swift Throw", lldb::eLanguageTypeSwift}}),
       focus_tid(LLDB_INVALID_THREAD_ID), stop_at_entry(false), is_attach(false),
       enable_auto_variable_summaries(false),
       enable_synthetic_child_debugging(false),
@@ -58,32 +65,8 @@ DAP::DAP()
 
 DAP::~DAP() = default;
 
-void DAP::PopulateExceptionBreakpoints() {
-  exception_breakpoints = {};
-  if (debugger.SupportsLanguage(lldb::eLanguageTypeC_plus_plus)) {
-    exception_breakpoints->emplace_back("cpp_catch", "C++ Catch",
-                                        lldb::eLanguageTypeC_plus_plus);
-    exception_breakpoints->emplace_back("cpp_throw", "C++ Throw",
-                                        lldb::eLanguageTypeC_plus_plus);
-  }
-  if (debugger.SupportsLanguage(lldb::eLanguageTypeObjC)) {
-    exception_breakpoints->emplace_back("objc_catch", "Objective-C Catch",
-                                        lldb::eLanguageTypeObjC);
-    exception_breakpoints->emplace_back("objc_throw", "Objective-C Throw",
-                                        lldb::eLanguageTypeObjC);
-  }
-  if (debugger.SupportsLanguage(lldb::eLanguageTypeSwift)) {
-    exception_breakpoints->emplace_back("swift_catch", "Swift Catch",
-                                        lldb::eLanguageTypeSwift);
-    exception_breakpoints->emplace_back("swift_throw", "Swift Throw",
-                                        lldb::eLanguageTypeSwift);
-  }
-}
-
 ExceptionBreakpoint *DAP::GetExceptionBreakpoint(const std::string &filter) {
-  assert(exception_breakpoints.has_value() &&
-         "PopulateExceptionBreakpoints must be called first");
-  for (auto &bp : *exception_breakpoints) {
+  for (auto &bp : exception_breakpoints) {
     if (bp.filter == filter)
       return &bp;
   }
@@ -91,9 +74,7 @@ ExceptionBreakpoint *DAP::GetExceptionBreakpoint(const std::string &filter) {
 }
 
 ExceptionBreakpoint *DAP::GetExceptionBreakpoint(const lldb::break_id_t bp_id) {
-  assert(exception_breakpoints.has_value() &&
-         "PopulateExceptionBreakpoints must be called first");
-  for (auto &bp : *exception_breakpoints) {
+  for (auto &bp : exception_breakpoints) {
     if (bp.bp.GetID() == bp_id)
       return &bp;
   }

--- a/lldb/tools/lldb-dap/DAP.h
+++ b/lldb/tools/lldb-dap/DAP.h
@@ -156,7 +156,7 @@ struct DAP {
   std::unique_ptr<std::ofstream> log;
   llvm::StringMap<SourceBreakpointMap> source_breakpoints;
   FunctionBreakpointMap function_breakpoints;
-  std::optional<std::vector<ExceptionBreakpoint>> exception_breakpoints;
+  std::vector<ExceptionBreakpoint> exception_breakpoints;
   std::vector<std::string> init_commands;
   std::vector<std::string> pre_run_commands;
   std::vector<std::string> post_run_commands;
@@ -227,8 +227,6 @@ struct DAP {
   lldb::SBFrame GetLLDBFrame(const llvm::json::Object &arguments);
 
   llvm::json::Value CreateTopLevelScopes();
-
-  void PopulateExceptionBreakpoints();
 
   /// \return
   ///   Attempt to determine if an expression is a variable expression or

--- a/lldb/tools/lldb-dap/lldb-dap.cpp
+++ b/lldb/tools/lldb-dap/lldb-dap.cpp
@@ -16,7 +16,6 @@
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
-#include <optional>
 #include <sys/stat.h>
 #include <sys/types.h>
 #if defined(_WIN32)
@@ -1587,7 +1586,6 @@ void request_initialize(const llvm::json::Object &request) {
   bool source_init_file = GetBoolean(arguments, "sourceInitFile", true);
 
   g_dap.debugger = lldb::SBDebugger::Create(source_init_file, log_cb, nullptr);
-  g_dap.PopulateExceptionBreakpoints();
   auto cmd = g_dap.debugger.GetCommandInterpreter().AddMultiwordCommand(
       "lldb-dap", "Commands for managing lldb-dap.");
   if (GetBoolean(arguments, "supportsStartDebuggingRequest", false)) {
@@ -1623,7 +1621,7 @@ void request_initialize(const llvm::json::Object &request) {
   body.try_emplace("supportsEvaluateForHovers", true);
   // Available filters or options for the setExceptionBreakpoints request.
   llvm::json::Array filters;
-  for (const auto &exc_bp : *g_dap.exception_breakpoints) {
+  for (const auto &exc_bp : g_dap.exception_breakpoints) {
     filters.emplace_back(CreateExceptionBreakpointFilter(exc_bp));
   }
   body.try_emplace("exceptionBreakpointFilters", std::move(filters));
@@ -2478,7 +2476,7 @@ void request_setExceptionBreakpoints(const llvm::json::Object &request) {
   // Keep a list of any exception breakpoint filter names that weren't set
   // so we can clear any exception breakpoints if needed.
   std::set<std::string> unset_filters;
-  for (const auto &bp : *g_dap.exception_breakpoints)
+  for (const auto &bp : g_dap.exception_breakpoints)
     unset_filters.insert(bp.filter);
 
   for (const auto &value : *filters) {


### PR DESCRIPTION
Reverts llvm/llvm-project#87550 because it broke `TestDAP*` lldb tests.
https://luci-milo.appspot.com/ui/p/fuchsia/builders/toolchain.ci/clang-linux-x64-rbe/b8746585790559468897/overview