### PR TITLE
[BOLT][DWARF][NFC] Fix formatting issue in DWARF5 split-dwarf test

### DIFF
--- a/bolt/test/X86/dwarf5-df-input-lowpc-ranges.test
+++ b/bolt/test/X86/dwarf5-df-input-lowpc-ranges.test
@@ -1,7 +1,7 @@
 ; RUN: rm -rf %t
 ; RUN: mkdir %t
 ; RUN: cd %t
-;; RUN: llvm-mc -dwarf-version=5 -filetype=obj -triple x86_64-unknown-linux %p/Inputs/dwarf5-df-input-lowpc-ranges-main.s \
+; RUN: llvm-mc -dwarf-version=5 -filetype=obj -triple x86_64-unknown-linux %p/Inputs/dwarf5-df-input-lowpc-ranges-main.s \
 ; RUN: -split-dwarf-file=main.dwo -o main.o
 ; RUN: %clang %cflags -gdwarf-4 -gsplit-dwarf=split main.o -o main.exe
 ; RUN: llvm-bolt main.exe -o main.exe.bolt --update-debug-sections


### PR DESCRIPTION
Remove double escape characters before a RUN in a test.