### PR TITLE
[SLP][NFCI] Address issues seen in downstream Coverity scan.

### DIFF
--- a/llvm/lib/Transforms/Vectorize/SLPVectorizer.cpp
+++ b/llvm/lib/Transforms/Vectorize/SLPVectorizer.cpp
@@ -11700,7 +11700,8 @@ public:
       R.eraseInstruction(EI);
     }
     if (NumParts == 1 || UniqueBases.size() == 1) {
-      return VecBase ? castToScalarTyElem(VecBase) : nullptr;
+      assert(VecBase && "Expected vectorized value.");
+      return castToScalarTyElem(VecBase);
     }
     UseVecBaseAsInput = true;
     auto TransformToIdentity = [](MutableArrayRef<int> Mask) {

--- a/llvm/lib/Transforms/Vectorize/SLPVectorizer.cpp
+++ b/llvm/lib/Transforms/Vectorize/SLPVectorizer.cpp
@@ -11700,8 +11700,7 @@ public:
       R.eraseInstruction(EI);
     }
     if (NumParts == 1 || UniqueBases.size() == 1) {
-      VecBase = castToScalarTyElem(VecBase);
-      return VecBase;
+      return VecBase ? castToScalarTyElem(VecBase) : nullptr;
     }
     UseVecBaseAsInput = true;
     auto TransformToIdentity = [](MutableArrayRef<int> Mask) {
@@ -15837,7 +15836,7 @@ bool SLPVectorizerPass::vectorizeStores(
       while (true) {
         ++Repeat;
         bool RepeatChanged = false;
-        bool AnyProfitableGraph;
+        bool AnyProfitableGraph = false;
         for (unsigned Size : CandidateVFs) {
           AnyProfitableGraph = false;
           unsigned StartIdx = std::distance(


### PR DESCRIPTION
- Prevent null dereference: if the Mask given to
  `ShuffleInstructionBuilder::adjustExtracts()` is empty or all-poison,
  then `VecBase` will be `nullptr` and the call to
  `castToScalarTyElem(VecBase)` will dereference it. Add an assert
  to guard against this.

- Prevent use of uninitialized scalar: in the unlikely event that
  `CandidateVFs` is empty, then `AnyProfitableGraph` will be
  uninitialized in `if` condition following the loop. (This seems like a
  false-positive, but I submitted this change anyways as initializing
  bools costs nothing and is generally good practice)