### PR TITLE
[BOLT,test] Make linker scripts less sensitive to lld's orphan placement

### DIFF
--- a/bolt/test/AArch64/Inputs/array_end.lld_script
+++ b/bolt/test/AArch64/Inputs/array_end.lld_script
@@ -1,4 +1,7 @@
 SECTIONS {
+  .interp : { *(.interp) }
+
+  . = ALIGN(CONSTANT(MAXPAGESIZE));
   .fini_array    :
   {
     PROVIDE_HIDDEN (__fini_array_start = .);

--- a/bolt/test/Inputs/lsda.ldscript
+++ b/bolt/test/Inputs/lsda.ldscript
@@ -1,5 +1,8 @@
 SECTIONS {
+  .interp : { *(.interp) }
+  . = ALIGN(CONSTANT(MAXPAGESIZE));
   .text : { *(.text*) }
+  . = ALIGN(CONSTANT(MAXPAGESIZE));
   .gcc_except_table.main : { *(.gcc_except_table*) }
   . = 0x20000;
   .eh_frame : { *(.eh_frame) }


### PR DESCRIPTION
Then two tests rely on .interp being the first section.
llvm-bolt would crash if lld places .interp after .got
(f639b57f7993cadb82ee9c36f04703ae4430ed85).

For best portability, when a linker scripts specifies a SECTIONS
command, the first section for each PT_LOAD segment should be specified
with a MAXPAGESIZE alignment. Otherwise, linkers have freedom to decide
how to place orphan sections, which might break intention.
