### PR TITLE
[X86]Add support for __outbyte/word/dword and __inbyte/word/dword

### DIFF
--- a/clang/lib/Headers/intrin.h
+++ b/clang/lib/Headers/intrin.h
@@ -348,6 +348,23 @@ static inline unsigned long _inpd(unsigned short port) {
   return ret;
 }
 
+static inline int _outp(unsigned short port, int data) {
+  __asm__ volatile("outb %b0, %w1" : : "a"(data), "Nd"(port) : "memory");
+  return data;
+}
+
+static inline unsigned short
+_outpw(unsigned short port, unsigned short data) {
+  __asm__ volatile("outw %w0, %w1" : : "a"(data), "Nd"(port) : "memory");
+  return data;
+}
+
+static inline unsigned long _outpd(unsigned short port,
+                                   unsigned long data) {
+  __asm__ volatile("outl %k0, %w1" : : "a"(data), "Nd"(port) : "memory");
+  return data;
+}
+
 #endif
 
 #if defined(__i386__) || defined(__x86_64__) || defined(__aarch64__)

--- a/clang/lib/Headers/intrin.h
+++ b/clang/lib/Headers/intrin.h
@@ -349,25 +349,22 @@ static inline unsigned long _inpd(unsigned short port) {
 }
 
 static inline int _outp(unsigned short port, int data) {
-  __asm__ volatile("outb %b0, %w1" : : "a"(data), "Nd"(port) : "memory");
+  __asm__ volatile("outb %b0, %w1" : : "a"(data), "Nd"(port));
   return data;
 }
 
 static inline unsigned short
 _outpw(unsigned short port, unsigned short data) {
-  __asm__ volatile("outw %w0, %w1" : : "a"(data), "Nd"(port) : "memory");
+  __asm__ volatile("outw %w0, %w1" : : "a"(data), "Nd"(port));
   return data;
 }
 
 static inline unsigned long _outpd(unsigned short port,
                                    unsigned long data) {
-  __asm__ volatile("outl %k0, %w1" : : "a"(data), "Nd"(port) : "memory");
+  __asm__ volatile("outl %k0, %w1" : : "a"(data), "Nd"(port));
   return data;
 }
 
-#endif
-
-#if defined(__i386__) || defined(__x86_64__) || defined(__aarch64__)
 static __inline__ void __DEFAULT_FN_ATTRS __nop(void) {
   __asm__ volatile("nop");
 }

--- a/clang/lib/Headers/intrin.h
+++ b/clang/lib/Headers/intrin.h
@@ -353,18 +353,18 @@ static inline int _outp(unsigned short port, int data) {
   return data;
 }
 
-static inline unsigned short
-_outpw(unsigned short port, unsigned short data) {
+static inline unsigned short _outpw(unsigned short port, unsigned short data) {
   __asm__ volatile("outw %w0, %w1" : : "a"(data), "Nd"(port));
   return data;
 }
 
-static inline unsigned long _outpd(unsigned short port,
-                                   unsigned long data) {
+static inline unsigned long _outpd(unsigned short port, unsigned long data) {
   __asm__ volatile("outl %k0, %w1" : : "a"(data), "Nd"(port));
   return data;
 }
+#endif
 
+#if defined(__i386__) || defined(__x86_64__) || defined(__aarch64__)
 static __inline__ void __DEFAULT_FN_ATTRS __nop(void) {
   __asm__ volatile("nop");
 }

--- a/clang/lib/Headers/intrin.h
+++ b/clang/lib/Headers/intrin.h
@@ -330,37 +330,34 @@ static __inline__ void __DEFAULT_FN_ATTRS __halt(void) {
   __asm__ volatile("hlt");
 }
 
-static inline int _inp(unsigned short port) {
-  int ret;
+static inline unsigned char __inbyte(unsigned short port) {
+  unsigned char ret;
   __asm__ volatile("inb %w1, %b0" : "=a"(ret) : "Nd"(port));
   return ret;
 }
 
-static inline unsigned short _inpw(unsigned short port) {
+static inline unsigned short __inword(unsigned short port) {
   unsigned short ret;
   __asm__ volatile("inw %w1, %w0" : "=a"(ret) : "Nd"(port));
   return ret;
 }
 
-static inline unsigned long _inpd(unsigned short port) {
+static inline unsigned long __indword(unsigned short port) {
   unsigned long ret;
   __asm__ volatile("inl %w1, %k0" : "=a"(ret) : "Nd"(port));
   return ret;
 }
 
-static inline int _outp(unsigned short port, int data) {
+static inline void __outbyte(unsigned short port, unsigned char data) {
   __asm__ volatile("outb %b0, %w1" : : "a"(data), "Nd"(port));
-  return data;
 }
 
-static inline unsigned short _outpw(unsigned short port, unsigned short data) {
+static inline void __outword(unsigned short port, unsigned short data) {
   __asm__ volatile("outw %w0, %w1" : : "a"(data), "Nd"(port));
-  return data;
 }
 
-static inline unsigned long _outpd(unsigned short port, unsigned long data) {
+static inline void __outdword(unsigned short port, unsigned long data) {
   __asm__ volatile("outl %k0, %w1" : : "a"(data), "Nd"(port));
-  return data;
 }
 #endif
 

--- a/clang/lib/Headers/intrin.h
+++ b/clang/lib/Headers/intrin.h
@@ -332,32 +332,32 @@ static __inline__ void __DEFAULT_FN_ATTRS __halt(void) {
 
 static inline unsigned char __inbyte(unsigned short port) {
   unsigned char ret;
-  __asm__ volatile("inb %w1, %b0" : "=a"(ret) : "Nd"(port));
+  __asm__ __volatile__("inb %w1, %b0" : "=a"(ret) : "Nd"(port));
   return ret;
 }
 
 static inline unsigned short __inword(unsigned short port) {
   unsigned short ret;
-  __asm__ volatile("inw %w1, %w0" : "=a"(ret) : "Nd"(port));
+  __asm__ __volatile__("inw %w1, %w0" : "=a"(ret) : "Nd"(port));
   return ret;
 }
 
 static inline unsigned long __indword(unsigned short port) {
   unsigned long ret;
-  __asm__ volatile("inl %w1, %k0" : "=a"(ret) : "Nd"(port));
+  __asm__ __volatile__("inl %w1, %k0" : "=a"(ret) : "Nd"(port));
   return ret;
 }
 
 static inline void __outbyte(unsigned short port, unsigned char data) {
-  __asm__ volatile("outb %b0, %w1" : : "a"(data), "Nd"(port));
+  __asm__ __volatile__("outb %b0, %w1" : : "a"(data), "Nd"(port));
 }
 
 static inline void __outword(unsigned short port, unsigned short data) {
-  __asm__ volatile("outw %w0, %w1" : : "a"(data), "Nd"(port));
+  __asm__ __volatile__("outw %w0, %w1" : : "a"(data), "Nd"(port));
 }
 
 static inline void __outdword(unsigned short port, unsigned long data) {
-  __asm__ volatile("outl %k0, %w1" : : "a"(data), "Nd"(port));
+  __asm__ __volatile__("outl %k0, %w1" : : "a"(data), "Nd"(port));
 }
 #endif
 

--- a/clang/test/CodeGen/X86/ms-x86-intrinsics.c
+++ b/clang/test/CodeGen/X86/ms-x86-intrinsics.c
@@ -63,6 +63,7 @@ unsigned __int64 test__emulu(unsigned int a, unsigned int b) {
 // CHECK: [[RES:%[0-9]+]] = mul nuw i64 [[Y]], [[X]]
 // CHECK: ret i64 [[RES]]
 
+
 int test_inp(unsigned short port) {
   return _inp(port);
 }
@@ -91,24 +92,27 @@ int test_outp(unsigned short port, int data) {
     return _outp(port, data);
 }
 // CHECK-LABEL: i32 @test_outp(
-// CHECK-SAME:  [[PORT:%.*]], i32 noundef returned [[DATA:%.*]])
-// CHECK-NEXT:  tail call void asm sideeffect "outb ${0:b}, ${1:w}", "{ax},N{dx},~{memory},~{dirflag},~{fpsr},~{flags}"(i32 [[DATA]], i16 [[PORT]]
+// CHECK-SAME:  [[PORT:%.*]],
+// CHECK-SAME:  [[DATA:%.*]])
+// CHECK:       tail call void asm sideeffect "outb ${0:b}, ${1:w}", "{ax},N{dx},~{dirflag},~{fpsr},~{flags}"(i32 [[DATA]], i16 [[PORT]])
 // CHECK-NEXT:  ret i32 [[DATA]]
 
 unsigned short test_outpw(unsigned short port, unsigned short data) {
     return _outpw(port, data);
 }
 // CHECK-LABEL: i16 @test_outpw(
-// CHECK-SAME:  [[PORT:%.*]], i16 noundef returned zeroext [[DATA:%.*]])
-// CHECK-NEXT:  tail call void asm sideeffect "outw ${0:w}, ${1:w}", "{ax},N{dx},~{memory},~{dirflag},~{fpsr},~{flags}"(i16 [[DATA]], i16 [[PORT]])
+// CHECK-SAME:  [[PORT:%.*]],
+// CHECK-SAME:  [[DATA:%.*]])
+// CHECK:       tail call void asm sideeffect "outw ${0:w}, ${1:w}", "{ax},N{dx},~{dirflag},~{fpsr},~{flags}"(i16 [[DATA]], i16 [[PORT]])
 // CHECK-NEXT:  ret i16 [[DATA]]
 
 unsigned long test_outpd(unsigned short port, unsigned long data) {
     return _outpd(port, data);
 }
 // CHECK-LABEL: i32 @test_outpd(
-// CHECK-SAME:  [[PORT:%.*]], i32 noundef returned [[DATA:%.*]])
-// CHECK-NEXT:  tail call void asm sideeffect "outl ${0:k}, ${1:w}", "{ax},N{dx},~{memory},~{dirflag},~{fpsr},~{flags}"(i32 [[DATA]], i16 [[PORT]])
+// CHECK-SAME:  [[PORT:%.*]],
+// CHECK-SAME:  [[DATA:%.*]])
+// CHECK:       tail call void asm sideeffect "outl ${0:k}, ${1:w}", "{ax},N{dx},~{dirflag},~{fpsr},~{flags}"(i32 [[DATA]], i16 [[PORT]])
 // CHECK-NEXT:  ret i32 [[DATA]]
 
 #if defined(__x86_64__)

--- a/clang/test/CodeGen/X86/ms-x86-intrinsics.c
+++ b/clang/test/CodeGen/X86/ms-x86-intrinsics.c
@@ -63,7 +63,6 @@ unsigned __int64 test__emulu(unsigned int a, unsigned int b) {
 // CHECK: [[RES:%[0-9]+]] = mul nuw i64 [[Y]], [[X]]
 // CHECK: ret i64 [[RES]]
 
-
 int test_inp(unsigned short port) {
   return _inp(port);
 }
@@ -87,6 +86,30 @@ unsigned long test_inpd(unsigned short port) {
 // CHECK-SAME:  [[PORT:%.*]])
 // CHECK:       [[TMP0:%.*]] = tail call i32 asm sideeffect "inl ${1:w}, ${0:k}", "={ax},N{dx},~{dirflag},~{fpsr},~{flags}"(i16 [[PORT]])
 // CHECK-NEXT:  ret i32 [[TMP0]]
+
+int test_outp(unsigned short port, int data) {
+    return _outp(port, data);
+}
+// CHECK-LABEL: i32 @test_outp(
+// CHECK-SAME:  [[PORT:%.*]], i32 noundef returned [[DATA:%.*]])
+// CHECK-NEXT:  tail call void asm sideeffect "outb ${0:b}, ${1:w}", "{ax},N{dx},~{memory},~{dirflag},~{fpsr},~{flags}"(i32 [[DATA]], i16 [[PORT]]
+// CHECK-NEXT:  ret i32 [[DATA]]
+
+unsigned short test_outpw(unsigned short port, unsigned short data) {
+    return _outpw(port, data);
+}
+// CHECK-LABEL: i16 @test_outpw(
+// CHECK-SAME:  [[PORT:%.*]], i16 noundef returned zeroext [[DATA:%.*]])
+// CHECK-NEXT:  tail call void asm sideeffect "outw ${0:w}, ${1:w}", "{ax},N{dx},~{memory},~{dirflag},~{fpsr},~{flags}"(i16 [[DATA]], i16 [[PORT]])
+// CHECK-NEXT:  ret i16 [[DATA]]
+
+unsigned long test_outpd(unsigned short port, unsigned long data) {
+    return _outpd(port, data);
+}
+// CHECK-LABEL: i32 @test_outpd(
+// CHECK-SAME:  [[PORT:%.*]], i32 noundef returned [[DATA:%.*]])
+// CHECK-NEXT:  tail call void asm sideeffect "outl ${0:k}, ${1:w}", "{ax},N{dx},~{memory},~{dirflag},~{fpsr},~{flags}"(i32 [[DATA]], i16 [[PORT]])
+// CHECK-NEXT:  ret i32 [[DATA]]
 
 #if defined(__x86_64__)
 

--- a/clang/test/CodeGen/X86/ms-x86-intrinsics.c
+++ b/clang/test/CodeGen/X86/ms-x86-intrinsics.c
@@ -64,56 +64,53 @@ unsigned __int64 test__emulu(unsigned int a, unsigned int b) {
 // CHECK: ret i64 [[RES]]
 
 
-int test_inp(unsigned short port) {
-  return _inp(port);
+unsigned char test_inbyte(unsigned short port) {
+  return __inbyte(port);
 }
-// CHECK-LABEL: i32 @test_inp(i16 noundef
+// CHECK-LABEL: i8 @test_inbyte(i16 noundef
 // CHECK-SAME:  [[PORT:%.*]])
-// CHECK:       [[TMP0:%.*]] = tail call i32 asm sideeffect "inb ${1:w}, ${0:b}", "={ax},N{dx},~{dirflag},~{fpsr},~{flags}"(i16 [[PORT]])
-// CHECK-NEXT:  ret i32 [[TMP0]]
+// CHECK:       [[TMP0:%.*]] = tail call i8 asm sideeffect "inb ${1:w}, ${0:b}", "={ax},N{dx},~{dirflag},~{fpsr},~{flags}"(i16 [[PORT]])
+// CHECK-NEXT:  ret i8 [[TMP0]]
 
-unsigned short test_inpw(unsigned short port) {
-  return _inpw(port);
+unsigned short test_inword(unsigned short port) {
+  return __inword(port);
 }
-// CHECK-LABEL: i16 @test_inpw(i16 noundef
+// CHECK-LABEL: i16 @test_inword(i16 noundef
 // CHECK-SAME:  [[PORT:%.*]])
 // CHECK:       [[TMP0:%.*]] = tail call i16 asm sideeffect "inw ${1:w}, ${0:w}", "={ax},N{dx},~{dirflag},~{fpsr},~{flags}"(i16 [[PORT]])
 // CHECK-NEXT:  ret i16 [[TMP0]]
 
-unsigned long test_inpd(unsigned short port) {
-  return _inpd(port);
+unsigned long test_indword(unsigned short port) {
+  return __indword(port);
 }
-// CHECK-LABEL: i32 @test_inpd(i16 noundef
+// CHECK-LABEL: i32 @test_indword(i16 noundef
 // CHECK-SAME:  [[PORT:%.*]])
 // CHECK:       [[TMP0:%.*]] = tail call i32 asm sideeffect "inl ${1:w}, ${0:k}", "={ax},N{dx},~{dirflag},~{fpsr},~{flags}"(i16 [[PORT]])
 // CHECK-NEXT:  ret i32 [[TMP0]]
 
-int test_outp(unsigned short port, int data) {
-    return _outp(port, data);
+void test_outbyte(unsigned short port, unsigned char data) {
+    return __outbyte(port, data);
 }
-// CHECK-LABEL: i32 @test_outp(
+// CHECK-LABEL: void @test_outbyte(
 // CHECK-SAME:  [[PORT:%.*]],
 // CHECK-SAME:  [[DATA:%.*]])
-// CHECK:       tail call void asm sideeffect "outb ${0:b}, ${1:w}", "{ax},N{dx},~{dirflag},~{fpsr},~{flags}"(i32 [[DATA]], i16 [[PORT]])
-// CHECK-NEXT:  ret i32 [[DATA]]
+// CHECK:       tail call void asm sideeffect "outb ${0:b}, ${1:w}", "{ax},N{dx},~{dirflag},~{fpsr},~{flags}"(i8 [[DATA]], i16 [[PORT]])
 
-unsigned short test_outpw(unsigned short port, unsigned short data) {
-    return _outpw(port, data);
+void test_outword(unsigned short port, unsigned short data) {
+    return __outword(port, data);
 }
-// CHECK-LABEL: i16 @test_outpw(
+// CHECK-LABEL: void @test_outword(
 // CHECK-SAME:  [[PORT:%.*]],
 // CHECK-SAME:  [[DATA:%.*]])
 // CHECK:       tail call void asm sideeffect "outw ${0:w}, ${1:w}", "{ax},N{dx},~{dirflag},~{fpsr},~{flags}"(i16 [[DATA]], i16 [[PORT]])
-// CHECK-NEXT:  ret i16 [[DATA]]
 
-unsigned long test_outpd(unsigned short port, unsigned long data) {
-    return _outpd(port, data);
+void test_outdword(unsigned short port, unsigned long data) {
+    return __outdword(port, data);
 }
-// CHECK-LABEL: i32 @test_outpd(
+// CHECK-LABEL: void @test_outdword(
 // CHECK-SAME:  [[PORT:%.*]],
 // CHECK-SAME:  [[DATA:%.*]])
 // CHECK:       tail call void asm sideeffect "outl ${0:k}, ${1:w}", "{ax},N{dx},~{dirflag},~{fpsr},~{flags}"(i32 [[DATA]], i16 [[PORT]])
-// CHECK-NEXT:  ret i32 [[DATA]]
 
 #if defined(__x86_64__)
 


### PR DESCRIPTION
A previous commit implemented _inp/w/d and renaming that to __inbyte/word/dword

These intrinsics were declared in the header but never implemented.
