### PR TITLE
[CodeGen] Preserved additional analyses in StackSlotColoring pass.

### DIFF
--- a/llvm/lib/CodeGen/StackSlotColoring.cpp
+++ b/llvm/lib/CodeGen/StackSlotColoring.cpp
@@ -13,6 +13,7 @@
 #include "llvm/ADT/BitVector.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/Statistic.h"
+#include "llvm/CodeGen/LiveDebugVariables.h"
 #include "llvm/CodeGen/LiveInterval.h"
 #include "llvm/CodeGen/LiveIntervalUnion.h"
 #include "llvm/CodeGen/LiveIntervals.h"
@@ -64,6 +65,7 @@ namespace {
     MachineFrameInfo *MFI = nullptr;
     const TargetInstrInfo *TII = nullptr;
     const MachineBlockFrequencyInfo *MBFI = nullptr;
+    SlotIndexes *Indexes = nullptr;
 
     // SSIntervals - Spill slot intervals.
     std::vector<LiveInterval*> SSIntervals;
@@ -152,6 +154,14 @@ namespace {
       AU.addRequired<MachineBlockFrequencyInfo>();
       AU.addPreserved<MachineBlockFrequencyInfo>();
       AU.addPreservedID(MachineDominatorsID);
+
+      // As in some Target's pipeline, register allocation (RA) might be
+      // splitted into multiple phases based on register class. So, this pass
+      // may be invoked multiple times requiring it to save these analyses to be
+      // used by RA later.
+      AU.addPreserved<LiveIntervals>();
+      AU.addPreserved<LiveDebugVariables>();
+
       MachineFunctionPass::getAnalysisUsage(AU);
     }
 
@@ -496,8 +506,10 @@ bool StackSlotColoring::RemoveDeadStores(MachineBasicBlock* MBB) {
     ++I;
   }
 
-  for (MachineInstr *MI : toErase)
+  for (MachineInstr *MI : toErase) {
     MI->eraseFromParent();
+    Indexes->removeMachineInstrFromMaps(*MI);
+  }
 
   return changed;
 }
@@ -515,6 +527,7 @@ bool StackSlotColoring::runOnMachineFunction(MachineFunction &MF) {
   TII = MF.getSubtarget().getInstrInfo();
   LS = &getAnalysis<LiveStacks>();
   MBFI = &getAnalysis<MachineBlockFrequencyInfo>();
+  Indexes = &getAnalysis<SlotIndexes>();
 
   bool Changed = false;
 

--- a/llvm/lib/CodeGen/StackSlotColoring.cpp
+++ b/llvm/lib/CodeGen/StackSlotColoring.cpp
@@ -155,8 +155,8 @@ namespace {
       AU.addPreserved<MachineBlockFrequencyInfo>();
       AU.addPreservedID(MachineDominatorsID);
 
-      // As in some Target's pipeline, register allocation (RA) might be
-      // splitted into multiple phases based on register class. So, this pass
+      // In some Target's pipeline, register allocation (RA) might be
+      // split into multiple phases based on register class. So, this pass
       // may be invoked multiple times requiring it to save these analyses to be
       // used by RA later.
       AU.addPreserved<LiveIntervals>();

--- a/llvm/lib/CodeGen/StackSlotColoring.cpp
+++ b/llvm/lib/CodeGen/StackSlotColoring.cpp
@@ -507,9 +507,8 @@ bool StackSlotColoring::RemoveDeadStores(MachineBasicBlock* MBB) {
   }
 
   for (MachineInstr *MI : toErase) {
-    if (Indexes) {
+    if (Indexes)
       Indexes->removeMachineInstrFromMaps(*MI);
-    }
     MI->eraseFromParent();
   }
 

--- a/llvm/lib/CodeGen/StackSlotColoring.cpp
+++ b/llvm/lib/CodeGen/StackSlotColoring.cpp
@@ -507,8 +507,10 @@ bool StackSlotColoring::RemoveDeadStores(MachineBasicBlock* MBB) {
   }
 
   for (MachineInstr *MI : toErase) {
+    if (Indexes) {
+      Indexes->removeMachineInstrFromMaps(*MI);
+    }
     MI->eraseFromParent();
-    Indexes->removeMachineInstrFromMaps(*MI);
   }
 
   return changed;


### PR DESCRIPTION
The pass pipeline of some architecture splits register allocation phase based on different register classes. As some analyses need to be computed at the beginning of the register allocation and kept alive till all values are assigned to some physical registers.

This poses challenge with objective of introducing StackSlotColoring after partial virtual registers are assigned to physical registers, in order to optimize stack slots usage.As this pass doesn't preserve few analysis yet to be needed by the register allocation of the remaining virtual registers, necessiating them to be kept preserved.