### PR TITLE
[compiler-rt] [test] Work around MS CRT stdio format quirks on mingw too

### DIFF
--- a/compiler-rt/test/asan/TestCases/debug_double_free.cpp
+++ b/compiler-rt/test/asan/TestCases/debug_double_free.cpp
@@ -7,9 +7,9 @@
 // FIXME: Doesn't work with DLLs
 // XFAIL: win32-dynamic-asan
 
-// If we use %p with MSVC, it comes out all upper case. Use %08x to get
+// If we use %p with MS CRTs, it comes out all upper case. Use %08x to get
 // lowercase hex.
-#ifdef _MSC_VER
+#ifdef _WIN32
 # ifdef _WIN64
 #  define PTR_FMT "0x%08llx"
 # else

--- a/compiler-rt/test/asan/TestCases/debug_report.cpp
+++ b/compiler-rt/test/asan/TestCases/debug_report.cpp
@@ -22,9 +22,9 @@ int main() {
   return 0;
 }
 
-// If we use %p with MSVC, it comes out all upper case. Use %08x to get
+// If we use %p with MS CRTs, it comes out all upper case. Use %08x to get
 // lowercase hex.
-#ifdef _MSC_VER
+#ifdef _WIN32
 # ifdef _WIN64
 #  define PTR_FMT "0x%08llx"
 # else


### PR DESCRIPTION
So far, these tests have been disabled in mingw build configurations (built as asan-dynamic), but these were enabled in 246234ac70faa1e3281a2bb83dfc4dd206a7d59c, exposing the issue.

(That commit is currently reverted, but will probably be relanded in some form soon.)