### PR TITLE
[llvm-objdump][test] Relax directory prefix check in source-interleave test

### DIFF
--- a/llvm/test/tools/llvm-objdump/X86/source-interleave-x86_64.test
+++ b/llvm/test/tools/llvm-objdump/X86/source-interleave-x86_64.test
@@ -11,7 +11,7 @@
 
 # LINES: <main>:
 # LINES-NEXT: ; main():
-# LINES-NEXT: ; {{[ -\(\)_A-Za-z0-9.\\/:]+}}source-interleave-x86_64.c:6
+# LINES-NEXT: ; {{.+}}source-interleave-x86_64.c:6
 
 # SOURCE: <main>:
 # SOURCE-NEXT: ; int main() {


### PR DESCRIPTION
This test currently has an explicit regex for characters that are supposedly valid inside a directory name -- however, it does not actually cover all necessary characters. For example, this test fails if the path contains a tilde.

Instead, replace this with a wildcard.