### PR TITLE
[lldb][test] Add flags useful for remote cross-platform testing to dotest.py

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/builders/builder.py
+++ b/lldb/packages/Python/lldbsuite/test/builders/builder.py
@@ -36,11 +36,20 @@ class Builder:
         """Returns the ARCH_CFLAGS for the make system."""
         return []
 
+    def getTargetOsFlag(self, target_os):
+        if target_os is None:
+            target_os = configuration.target_os
+        if target_os is None:
+            return []
+        return ["OS=%s" % target_os]
+
     def getMake(self, test_subdir, test_name):
         """Returns the invocation for GNU make.
         The first argument is a tuple of the relative path to the testcase
         and its filename stem."""
-        if platform.system() == "FreeBSD" or platform.system() == "NetBSD":
+        if configuration.make_path is not None:
+            make = configuration.make_path
+        elif platform.system() == "FreeBSD" or platform.system() == "NetBSD":
             make = "gmake"
         else:
             make = "make"
@@ -171,6 +180,7 @@ class Builder:
         testdir=None,
         testname=None,
         make_targets=None,
+        target_os=None,
     ):
         debug_info_args = self._getDebugInfoArgs(debug_info)
         if debug_info_args is None:
@@ -182,6 +192,7 @@ class Builder:
             debug_info_args,
             make_targets,
             self.getArchCFlags(architecture),
+            self.getTargetOsFlag(target_os),
             self.getArchSpec(architecture),
             self.getCCSpec(compiler),
             self.getExtraMakeArgs(),

--- a/lldb/packages/Python/lldbsuite/test/configuration.py
+++ b/lldb/packages/Python/lldbsuite/test/configuration.py
@@ -39,10 +39,12 @@ lldb_framework_path = None
 count = 1
 
 # The 'arch' and 'compiler' can be specified via command line.
+target_os = None
 arch = None
 compiler = None
 dsymutil = None
 sdkroot = None
+make_path = None
 
 # The overriden dwarf verison.
 dwarf_version = 0

--- a/lldb/packages/Python/lldbsuite/test/dotest.py
+++ b/lldb/packages/Python/lldbsuite/test/dotest.py
@@ -266,6 +266,8 @@ def parseOptionsAndInitTestdirs():
                     configuration.compiler = candidate
                     break
 
+    if args.make:
+        configuration.make_path = args.make
     if args.dsymutil:
         configuration.dsymutil = args.dsymutil
     elif platform_system == "Darwin":
@@ -304,13 +306,18 @@ def parseOptionsAndInitTestdirs():
         lldbtest_config.out_of_tree_debugserver = args.out_of_tree_debugserver
 
     # Set SDKROOT if we are using an Apple SDK
-    if platform_system == "Darwin" and args.apple_sdk:
+    if args.sysroot is not None:
+        configuration.sdkroot = args.sysroot
+    elif platform_system == "Darwin" and args.apple_sdk:
         configuration.sdkroot = seven.get_command_output(
             'xcrun --sdk "%s" --show-sdk-path 2> /dev/null' % (args.apple_sdk)
         )
         if not configuration.sdkroot:
             logging.error("No SDK found with the name %s; aborting...", args.apple_sdk)
             sys.exit(-1)
+
+    if args.target_os:
+        configuration.target_os = args.target_os
 
     if args.arch:
         configuration.arch = args.arch

--- a/lldb/packages/Python/lldbsuite/test/dotest_args.py
+++ b/lldb/packages/Python/lldbsuite/test/dotest_args.py
@@ -32,6 +32,15 @@ def create_parser():
     # C and Python toolchain options
     group = parser.add_argument_group("Toolchain options")
     group.add_argument(
+        "--target-os",
+        metavar="target_os",
+        dest="target_os",
+        default="",
+        help=textwrap.dedent(
+            """Specify target os for test compilation. This is useful for cross-compilation."""
+        ),
+    )
+    group.add_argument(
         "-A",
         "--arch",
         metavar="arch",
@@ -47,6 +56,15 @@ def create_parser():
         dest="compiler",
         help=textwrap.dedent(
             """Specify the compiler(s) used to build the inferior executables. The compiler path can be an executable basename or a full path to a compiler executable. This option can be specified multiple times."""
+        ),
+    )
+    group.add_argument(
+        "--sysroot",
+        metavar="sysroot",
+        dest="sysroot",
+        default="",
+        help=textwrap.dedent(
+            """Specify the path to sysroot. This overrides apple_sdk sysroot."""
         ),
     )
     if sys.platform == "darwin":
@@ -87,6 +105,12 @@ def create_parser():
         ),
     )
 
+    group.add_argument(
+        "--make",
+        metavar="make",
+        dest="make",
+        help=textwrap.dedent("Specify which make to use."),
+    )
     group.add_argument(
         "--dsymutil",
         metavar="dsymutil",

--- a/lldb/packages/Python/lldbsuite/test/lldbtest.py
+++ b/lldb/packages/Python/lldbsuite/test/lldbtest.py
@@ -1454,11 +1454,15 @@ class Base(unittest.TestCase):
     def build(
         self,
         debug_info=None,
+        target_os=None,
         architecture=None,
         compiler=None,
         dictionary=None,
         make_targets=None,
     ):
+        if not target_os and configuration.target_os:
+            target_os = configuration.target_os
+
         """Platform specific way to build binaries."""
         if not architecture and configuration.arch:
             architecture = configuration.arch


### PR DESCRIPTION
This commit adds dotest.py flags that come in handy for setting up cross-platform remote runs of API tests.

`--make` argument allows to specify the path to the make executable used by LLDB API tests to compile test programs.

`--sysroot` and `--target-os` arguments allow to pass OS and SDKROOT variables to the make invocation. These variables are used in Makefile rules for tests.

These arguments can be passed to dotest.py from cmake command line through `LLDB_TEST_USER_ARGS` as follows:
```
cmake ... \
-DLLDB_TEST_USER_ARGS="...;--make;/mymake;--sysroot;/sysroot/path/;--target-os;Linux;..." \
...
```