### PR TITLE
[X86] Add support for MS inp functions.

### DIFF
--- a/clang/lib/Headers/intrin.h
+++ b/clang/lib/Headers/intrin.h
@@ -329,6 +329,28 @@ static __inline__ void __DEFAULT_FN_ATTRS __stosq(unsigned __int64 *__dst,
 static __inline__ void __DEFAULT_FN_ATTRS __halt(void) {
   __asm__ volatile("hlt");
 }
+
+static inline int _inp(unsigned short port) {
+  int ret;
+  __asm__ volatile("inb %b1, %b0" : "=a"(ret) : "Nd"(port));
+  return ret;
+}
+
+static inline unsigned short _inpw(unsigned short port) {
+  unsigned short ret;
+  __asm__ volatile("inb %w1, %b0" : "=a"(ret) : "Nd"(port));
+  return ret;
+}
+
+static inline unsigned long _inpd(unsigned short port) {
+  unsigned long ret;
+  __asm__ volatile("inb %k1, %b0" : "=a"(ret) : "Nd"(port));
+  return ret;
+}
+
+#define inp(port) _inp((port))
+#define inpw(port) _inpw((port))
+
 #endif
 
 #if defined(__i386__) || defined(__x86_64__) || defined(__aarch64__)

--- a/clang/lib/Headers/intrin.h
+++ b/clang/lib/Headers/intrin.h
@@ -332,19 +332,19 @@ static __inline__ void __DEFAULT_FN_ATTRS __halt(void) {
 
 static inline int _inp(unsigned short port) {
   int ret;
-  __asm__ volatile("inb %b1, %b0" : "=a"(ret) : "Nd"(port));
+  __asm__ volatile("inb %w1, %b0" : "=a"(ret) : "Nd"(port));
   return ret;
 }
 
 static inline unsigned short _inpw(unsigned short port) {
   unsigned short ret;
-  __asm__ volatile("inw %w1, %b0" : "=a"(ret) : "Nd"(port));
+  __asm__ volatile("inw %w1, %w0" : "=a"(ret) : "Nd"(port));
   return ret;
 }
 
 static inline unsigned long _inpd(unsigned short port) {
   unsigned long ret;
-  __asm__ volatile("inl %k1, %b0" : "=a"(ret) : "Nd"(port));
+  __asm__ volatile("inl %w1, %k0" : "=a"(ret) : "Nd"(port));
   return ret;
 }
 

--- a/clang/lib/Headers/intrin.h
+++ b/clang/lib/Headers/intrin.h
@@ -348,9 +348,6 @@ static inline unsigned long _inpd(unsigned short port) {
   return ret;
 }
 
-#define inp(port) _inp((port))
-#define inpw(port) _inpw((port))
-
 #endif
 
 #if defined(__i386__) || defined(__x86_64__) || defined(__aarch64__)

--- a/clang/lib/Headers/intrin.h
+++ b/clang/lib/Headers/intrin.h
@@ -338,13 +338,13 @@ static inline int _inp(unsigned short port) {
 
 static inline unsigned short _inpw(unsigned short port) {
   unsigned short ret;
-  __asm__ volatile("inb %w1, %b0" : "=a"(ret) : "Nd"(port));
+  __asm__ volatile("inw %w1, %b0" : "=a"(ret) : "Nd"(port));
   return ret;
 }
 
 static inline unsigned long _inpd(unsigned short port) {
   unsigned long ret;
-  __asm__ volatile("inb %k1, %b0" : "=a"(ret) : "Nd"(port));
+  __asm__ volatile("inl %k1, %b0" : "=a"(ret) : "Nd"(port));
   return ret;
 }
 

--- a/clang/test/CodeGen/X86/ms-x86-intrinsics.c
+++ b/clang/test/CodeGen/X86/ms-x86-intrinsics.c
@@ -88,22 +88,6 @@ unsigned long test_inpd(unsigned short port) {
 // CHECK:       [[TMP0:%.*]] = tail call i32 asm sideeffect "inl ${1:w}, ${0:k}", "={ax},N{dx},~{dirflag},~{fpsr},~{flags}"(i16 [[PORT]])
 // CHECK-NEXT:  ret i32 [[TMP0]]
 
-int test_inp2(unsigned short port) {
-  return inp(port);
-}
-// CHECK-LABEL: i32 @test_inp2(i16 noundef
-// CHECK-SAME:  [[PORT:%.*]])
-// CHECK:       [[TMP0:%.*]] = tail call i32 asm sideeffect "inb ${1:w}, ${0:b}", "={ax},N{dx},~{dirflag},~{fpsr},~{flags}"(i16 [[PORT]])
-// CHECK-NEXT:  ret i32 [[TMP0]]
-
-unsigned short test_inpw2(unsigned short port) {
-  return inpw(port);
-}
-// CHECK-LABEL: i16 @test_inpw2(i16 noundef
-// CHECK-SAME:  [[PORT:%.*]])
-// CHECK:       [[TMP0:%.*]] = tail call i16 asm sideeffect "inw ${1:w}, ${0:w}", "={ax},N{dx},~{dirflag},~{fpsr},~{flags}"(i16 [[PORT]])
-// CHECK-NEXT:  ret i16 [[TMP0]]
-
 #if defined(__x86_64__)
 
 char test__readgsbyte(unsigned long Offset) {

--- a/clang/test/CodeGen/X86/ms-x86-intrinsics.c
+++ b/clang/test/CodeGen/X86/ms-x86-intrinsics.c
@@ -69,7 +69,7 @@ int test_inp(unsigned short port) {
 }
 // CHECK-LABEL: i32 @test_inp(i16 noundef
 // CHECK-SAME:  [[PORT:%.*]])
-// CHECK:       [[TMP0:%.*]] = tail call i32 asm sideeffect "inb ${1:b}, ${0:b}", "={ax},N{dx},~{dirflag},~{fpsr},~{flags}"(i16 [[PORT]])
+// CHECK:       [[TMP0:%.*]] = tail call i32 asm sideeffect "inb ${1:w}, ${0:b}", "={ax},N{dx},~{dirflag},~{fpsr},~{flags}"(i16 [[PORT]])
 // CHECK-NEXT:  ret i32 [[TMP0]]
 
 unsigned short test_inpw(unsigned short port) {
@@ -77,7 +77,7 @@ unsigned short test_inpw(unsigned short port) {
 }
 // CHECK-LABEL: i16 @test_inpw(i16 noundef
 // CHECK-SAME:  [[PORT:%.*]])
-// CHECK:       [[TMP0:%.*]] = tail call i16 asm sideeffect "inw ${1:w}, ${0:b}", "={ax},N{dx},~{dirflag},~{fpsr},~{flags}"(i16 [[PORT]])
+// CHECK:       [[TMP0:%.*]] = tail call i16 asm sideeffect "inw ${1:w}, ${0:w}", "={ax},N{dx},~{dirflag},~{fpsr},~{flags}"(i16 [[PORT]])
 // CHECK-NEXT:  ret i16 [[TMP0]]
 
 unsigned long test_inpd(unsigned short port) {
@@ -85,7 +85,7 @@ unsigned long test_inpd(unsigned short port) {
 }
 // CHECK-LABEL: i32 @test_inpd(i16 noundef
 // CHECK-SAME:  [[PORT:%.*]])
-// CHECK:       [[TMP0:%.*]] = tail call i32 asm sideeffect "inl ${1:k}, ${0:b}", "={ax},N{dx},~{dirflag},~{fpsr},~{flags}"(i16 [[PORT]])
+// CHECK:       [[TMP0:%.*]] = tail call i32 asm sideeffect "inl ${1:w}, ${0:k}", "={ax},N{dx},~{dirflag},~{fpsr},~{flags}"(i16 [[PORT]])
 // CHECK-NEXT:  ret i32 [[TMP0]]
 
 int test_inp2(unsigned short port) {
@@ -93,7 +93,7 @@ int test_inp2(unsigned short port) {
 }
 // CHECK-LABEL: i32 @test_inp2(i16 noundef
 // CHECK-SAME:  [[PORT:%.*]])
-// CHECK:       [[TMP0:%.*]] = tail call i32 asm sideeffect "inb ${1:b}, ${0:b}", "={ax},N{dx},~{dirflag},~{fpsr},~{flags}"(i16 [[PORT]])
+// CHECK:       [[TMP0:%.*]] = tail call i32 asm sideeffect "inb ${1:w}, ${0:b}", "={ax},N{dx},~{dirflag},~{fpsr},~{flags}"(i16 [[PORT]])
 // CHECK-NEXT:  ret i32 [[TMP0]]
 
 unsigned short test_inpw2(unsigned short port) {
@@ -101,7 +101,7 @@ unsigned short test_inpw2(unsigned short port) {
 }
 // CHECK-LABEL: i16 @test_inpw2(i16 noundef
 // CHECK-SAME:  [[PORT:%.*]])
-// CHECK:       [[TMP0:%.*]] = tail call i16 asm sideeffect "inw ${1:w}, ${0:b}", "={ax},N{dx},~{dirflag},~{fpsr},~{flags}"(i16 [[PORT]])
+// CHECK:       [[TMP0:%.*]] = tail call i16 asm sideeffect "inw ${1:w}, ${0:w}", "={ax},N{dx},~{dirflag},~{fpsr},~{flags}"(i16 [[PORT]])
 // CHECK-NEXT:  ret i16 [[TMP0]]
 
 #if defined(__x86_64__)

--- a/clang/test/CodeGen/X86/ms-x86-intrinsics.c
+++ b/clang/test/CodeGen/X86/ms-x86-intrinsics.c
@@ -77,7 +77,7 @@ unsigned short test_inpw(unsigned short port) {
 }
 // CHECK-LABEL: i16 @test_inpw(i16 noundef
 // CHECK-SAME:  [[PORT:%.*]])
-// CHECK:       [[TMP0:%.*]] = tail call i16 asm sideeffect "inb ${1:w}, ${0:b}", "={ax},N{dx},~{dirflag},~{fpsr},~{flags}"(i16 [[PORT]])
+// CHECK:       [[TMP0:%.*]] = tail call i16 asm sideeffect "inw ${1:w}, ${0:b}", "={ax},N{dx},~{dirflag},~{fpsr},~{flags}"(i16 [[PORT]])
 // CHECK-NEXT:  ret i16 [[TMP0]]
 
 unsigned long test_inpd(unsigned short port) {
@@ -85,7 +85,7 @@ unsigned long test_inpd(unsigned short port) {
 }
 // CHECK-LABEL: i32 @test_inpd(i16 noundef
 // CHECK-SAME:  [[PORT:%.*]])
-// CHECK:       [[TMP0:%.*]] = tail call i32 asm sideeffect "inb ${1:k}, ${0:b}", "={ax},N{dx},~{dirflag},~{fpsr},~{flags}"(i16 [[PORT]])
+// CHECK:       [[TMP0:%.*]] = tail call i32 asm sideeffect "inl ${1:k}, ${0:b}", "={ax},N{dx},~{dirflag},~{fpsr},~{flags}"(i16 [[PORT]])
 // CHECK-NEXT:  ret i32 [[TMP0]]
 
 int test_inp2(unsigned short port) {
@@ -101,7 +101,7 @@ unsigned short test_inpw2(unsigned short port) {
 }
 // CHECK-LABEL: i16 @test_inpw2(i16 noundef
 // CHECK-SAME:  [[PORT:%.*]])
-// CHECK:       [[TMP0:%.*]] = tail call i16 asm sideeffect "inb ${1:w}, ${0:b}", "={ax},N{dx},~{dirflag},~{fpsr},~{flags}"(i16 [[PORT]])
+// CHECK:       [[TMP0:%.*]] = tail call i16 asm sideeffect "inw ${1:w}, ${0:b}", "={ax},N{dx},~{dirflag},~{fpsr},~{flags}"(i16 [[PORT]])
 // CHECK-NEXT:  ret i16 [[TMP0]]
 
 #if defined(__x86_64__)

--- a/clang/test/CodeGen/X86/ms-x86-intrinsics.c
+++ b/clang/test/CodeGen/X86/ms-x86-intrinsics.c
@@ -67,77 +67,42 @@ unsigned __int64 test__emulu(unsigned int a, unsigned int b) {
 int test_inp(unsigned short port) {
   return _inp(port);
 }
-// CHECK-I386-LABEL: define dso_local i32 @test_inp(
-// CHECK-I386-SAME: i16 noundef zeroext [[PORT:%.*]])
-// CHECK-I386-NEXT:  entry:
-// CHECK-I386-NEXT:    [[TMP0:%.*]] = tail call i32 asm sideeffect "inb ${1:b}, ${0:b}", "={ax},N{dx},~{dirflag},~{fpsr},~{flags}"(i16 [[PORT]])
-// CHECK-I386-NEXT:    ret i32 [[TMP0]]
-//
-// CHECK-X64-LABEL: define dso_local i32 @test_inp(
-// CHECK-X64-SAME: i16 noundef [[PORT:%.*]])
-// CHECK-X64-NEXT:  entry:
-// CHECK-X64-NEXT:    [[TMP0:%.*]] = tail call i32 asm sideeffect "inb ${1:b}, ${0:b}", "={ax},N{dx},~{dirflag},~{fpsr},~{flags}"(i16 [[PORT]])
-// CHECK-X64-NEXT:    ret i32 [[TMP0]]
+// CHECK-LABEL: i32 @test_inp(i16 noundef
+// CHECK-SAME:  [[PORT:%.*]])
+// CHECK:       [[TMP0:%.*]] = tail call i32 asm sideeffect "inb ${1:b}, ${0:b}", "={ax},N{dx},~{dirflag},~{fpsr},~{flags}"(i16 [[PORT]])
+// CHECK-NEXT:  ret i32 [[TMP0]]
 
 unsigned short test_inpw(unsigned short port) {
   return _inpw(port);
 }
-// CHECK-I386-LABEL: define dso_local zeroext i16 @test_inpw(
-// CHECK-I386-SAME: i16 noundef zeroext [[PORT:%.*]])
-// CHECK-I386-NEXT:  entry:
-// CHECK-I386-NEXT:    [[TMP0:%.*]] = tail call i16 asm sideeffect "inb ${1:w}, ${0:b}", "={ax},N{dx},~{dirflag},~{fpsr},~{flags}"(i16 [[PORT]])
-// CHECK-I386-NEXT:    ret i16 [[TMP0]]
-//
-// CHECK-X64-LABEL: define dso_local i16 @test_inpw(
-// CHECK-X64-SAME: i16 noundef [[PORT:%.*]])
-// CHECK-X64-NEXT:  entry:
-// CHECK-X64-NEXT:    [[TMP0:%.*]] = tail call i16 asm sideeffect "inb ${1:w}, ${0:b}", "={ax},N{dx},~{dirflag},~{fpsr},~{flags}"(i16 [[PORT]])
-// CHECK-X64-NEXT:    ret i16 [[TMP0]]
+// CHECK-LABEL: i16 @test_inpw(i16 noundef
+// CHECK-SAME:  [[PORT:%.*]])
+// CHECK:       [[TMP0:%.*]] = tail call i16 asm sideeffect "inb ${1:w}, ${0:b}", "={ax},N{dx},~{dirflag},~{fpsr},~{flags}"(i16 [[PORT]])
+// CHECK-NEXT:  ret i16 [[TMP0]]
 
 unsigned long test_inpd(unsigned short port) {
   return _inpd(port);
 }
-// CHECK-I386-LABEL: define dso_local i32 @test_inpd(
-// CHECK-I386-SAME: i16 noundef zeroext [[PORT:%.*]])
-// CHECK-I386-NEXT:  entry:
-// CHECK-I386-NEXT:    [[TMP0:%.*]] = tail call i32 asm sideeffect "inb ${1:k}, ${0:b}", "={ax},N{dx},~{dirflag},~{fpsr},~{flags}"(i16 [[PORT]])
-// CHECK-I386-NEXT:    ret i32 [[TMP0]]
-//
-// CHECK-X64-LABEL: define dso_local i32 @test_inpd(
-// CHECK-X64-SAME: i16 noundef [[PORT:%.*]])
-// CHECK-X64-NEXT:  entry:
-// CHECK-X64-NEXT:    [[TMP0:%.*]] = tail call i32 asm sideeffect "inb ${1:k}, ${0:b}", "={ax},N{dx},~{dirflag},~{fpsr},~{flags}"(i16 [[PORT]])
-// CHECK-X64-NEXT:    ret i32 [[TMP0]]
+// CHECK-LABEL: i32 @test_inpd(i16 noundef
+// CHECK-SAME:  [[PORT:%.*]])
+// CHECK:       [[TMP0:%.*]] = tail call i32 asm sideeffect "inb ${1:k}, ${0:b}", "={ax},N{dx},~{dirflag},~{fpsr},~{flags}"(i16 [[PORT]])
+// CHECK-NEXT:  ret i32 [[TMP0]]
 
 int test_inp2(unsigned short port) {
   return inp(port);
 }
-// CHECK-I386-LABEL: define dso_local i32 @test_inp2(
-// CHECK-I386-SAME: i16 noundef zeroext [[PORT:%.*]])
-// CHECK-I386-NEXT:  entry:
-// CHECK-I386-NEXT:    [[TMP0:%.*]] = tail call i32 asm sideeffect "inb ${1:b}, ${0:b}", "={ax},N{dx},~{dirflag},~{fpsr},~{flags}"(i16 [[PORT]])
-// CHECK-I386-NEXT:    ret i32 [[TMP0]]
-//
-// CHECK-X64-LABEL: define dso_local i32 @test_inp2(
-// CHECK-X64-SAME: i16 noundef [[PORT:%.*]])
-// CHECK-X64-NEXT:  entry:
-// CHECK-X64-NEXT:    [[TMP0:%.*]] = tail call i32 asm sideeffect "inb ${1:b}, ${0:b}", "={ax},N{dx},~{dirflag},~{fpsr},~{flags}"(i16 [[PORT]])
-// CHECK-X64-NEXT:    ret i32 [[TMP0]]
+// CHECK-LABEL: i32 @test_inp2(i16 noundef
+// CHECK-SAME:  [[PORT:%.*]])
+// CHECK:       [[TMP0:%.*]] = tail call i32 asm sideeffect "inb ${1:b}, ${0:b}", "={ax},N{dx},~{dirflag},~{fpsr},~{flags}"(i16 [[PORT]])
+// CHECK-NEXT:  ret i32 [[TMP0]]
 
 unsigned short test_inpw2(unsigned short port) {
   return inpw(port);
 }
-// CHECK-I386-LABEL: define dso_local zeroext i16 @test_inpw2(
-// CHECK-I386-SAME: i16 noundef zeroext [[PORT:%.*]])
-// CHECK-I386-NEXT:  entry:
-// CHECK-I386-NEXT:    [[TMP0:%.*]] = tail call i16 asm sideeffect "inb ${1:w}, ${0:b}", "={ax},N{dx},~{dirflag},~{fpsr},~{flags}"(i16 [[PORT]])
-// CHECK-I386-NEXT:    ret i16 [[TMP0]]
-//
-// CHECK-X64-LABEL: define dso_local i16 @test_inpw2(
-// CHECK-X64-SAME: i16 noundef [[PORT:%.*]])
-// CHECK-X64-NEXT:  entry:
-// CHECK-X64-NEXT:    [[TMP0:%.*]] = tail call i16 asm sideeffect "inb ${1:w}, ${0:b}", "={ax},N{dx},~{dirflag},~{fpsr},~{flags}"(i16 [[PORT]])
-// CHECK-X64-NEXT:    ret i16 [[TMP0]]
+// CHECK-LABEL: i16 @test_inpw2(i16 noundef
+// CHECK-SAME:  [[PORT:%.*]])
+// CHECK:       [[TMP0:%.*]] = tail call i16 asm sideeffect "inb ${1:w}, ${0:b}", "={ax},N{dx},~{dirflag},~{fpsr},~{flags}"(i16 [[PORT]])
+// CHECK-NEXT:  ret i16 [[TMP0]]
 
 #if defined(__x86_64__)
 

--- a/clang/test/CodeGen/X86/ms-x86-intrinsics.c
+++ b/clang/test/CodeGen/X86/ms-x86-intrinsics.c
@@ -63,6 +63,82 @@ unsigned __int64 test__emulu(unsigned int a, unsigned int b) {
 // CHECK: [[RES:%[0-9]+]] = mul nuw i64 [[Y]], [[X]]
 // CHECK: ret i64 [[RES]]
 
+
+int test_inp(unsigned short port) {
+  return _inp(port);
+}
+// CHECK-I386-LABEL: define dso_local i32 @test_inp(
+// CHECK-I386-SAME: i16 noundef zeroext [[PORT:%.*]])
+// CHECK-I386-NEXT:  entry:
+// CHECK-I386-NEXT:    [[TMP0:%.*]] = tail call i32 asm sideeffect "inb ${1:b}, ${0:b}", "={ax},N{dx},~{dirflag},~{fpsr},~{flags}"(i16 [[PORT]])
+// CHECK-I386-NEXT:    ret i32 [[TMP0]]
+//
+// CHECK-X64-LABEL: define dso_local i32 @test_inp(
+// CHECK-X64-SAME: i16 noundef [[PORT:%.*]])
+// CHECK-X64-NEXT:  entry:
+// CHECK-X64-NEXT:    [[TMP0:%.*]] = tail call i32 asm sideeffect "inb ${1:b}, ${0:b}", "={ax},N{dx},~{dirflag},~{fpsr},~{flags}"(i16 [[PORT]])
+// CHECK-X64-NEXT:    ret i32 [[TMP0]]
+
+unsigned short test_inpw(unsigned short port) {
+  return _inpw(port);
+}
+// CHECK-I386-LABEL: define dso_local zeroext i16 @test_inpw(
+// CHECK-I386-SAME: i16 noundef zeroext [[PORT:%.*]])
+// CHECK-I386-NEXT:  entry:
+// CHECK-I386-NEXT:    [[TMP0:%.*]] = tail call i16 asm sideeffect "inb ${1:w}, ${0:b}", "={ax},N{dx},~{dirflag},~{fpsr},~{flags}"(i16 [[PORT]])
+// CHECK-I386-NEXT:    ret i16 [[TMP0]]
+//
+// CHECK-X64-LABEL: define dso_local i16 @test_inpw(
+// CHECK-X64-SAME: i16 noundef [[PORT:%.*]])
+// CHECK-X64-NEXT:  entry:
+// CHECK-X64-NEXT:    [[TMP0:%.*]] = tail call i16 asm sideeffect "inb ${1:w}, ${0:b}", "={ax},N{dx},~{dirflag},~{fpsr},~{flags}"(i16 [[PORT]])
+// CHECK-X64-NEXT:    ret i16 [[TMP0]]
+
+unsigned long test_inpd(unsigned short port) {
+  return _inpd(port);
+}
+// CHECK-I386-LABEL: define dso_local i32 @test_inpd(
+// CHECK-I386-SAME: i16 noundef zeroext [[PORT:%.*]])
+// CHECK-I386-NEXT:  entry:
+// CHECK-I386-NEXT:    [[TMP0:%.*]] = tail call i32 asm sideeffect "inb ${1:k}, ${0:b}", "={ax},N{dx},~{dirflag},~{fpsr},~{flags}"(i16 [[PORT]])
+// CHECK-I386-NEXT:    ret i32 [[TMP0]]
+//
+// CHECK-X64-LABEL: define dso_local i32 @test_inpd(
+// CHECK-X64-SAME: i16 noundef [[PORT:%.*]])
+// CHECK-X64-NEXT:  entry:
+// CHECK-X64-NEXT:    [[TMP0:%.*]] = tail call i32 asm sideeffect "inb ${1:k}, ${0:b}", "={ax},N{dx},~{dirflag},~{fpsr},~{flags}"(i16 [[PORT]])
+// CHECK-X64-NEXT:    ret i32 [[TMP0]]
+
+int test_inp2(unsigned short port) {
+  return inp(port);
+}
+// CHECK-I386-LABEL: define dso_local i32 @test_inp2(
+// CHECK-I386-SAME: i16 noundef zeroext [[PORT:%.*]])
+// CHECK-I386-NEXT:  entry:
+// CHECK-I386-NEXT:    [[TMP0:%.*]] = tail call i32 asm sideeffect "inb ${1:b}, ${0:b}", "={ax},N{dx},~{dirflag},~{fpsr},~{flags}"(i16 [[PORT]])
+// CHECK-I386-NEXT:    ret i32 [[TMP0]]
+//
+// CHECK-X64-LABEL: define dso_local i32 @test_inp2(
+// CHECK-X64-SAME: i16 noundef [[PORT:%.*]])
+// CHECK-X64-NEXT:  entry:
+// CHECK-X64-NEXT:    [[TMP0:%.*]] = tail call i32 asm sideeffect "inb ${1:b}, ${0:b}", "={ax},N{dx},~{dirflag},~{fpsr},~{flags}"(i16 [[PORT]])
+// CHECK-X64-NEXT:    ret i32 [[TMP0]]
+
+unsigned short test_inpw2(unsigned short port) {
+  return inpw(port);
+}
+// CHECK-I386-LABEL: define dso_local zeroext i16 @test_inpw2(
+// CHECK-I386-SAME: i16 noundef zeroext [[PORT:%.*]])
+// CHECK-I386-NEXT:  entry:
+// CHECK-I386-NEXT:    [[TMP0:%.*]] = tail call i16 asm sideeffect "inb ${1:w}, ${0:b}", "={ax},N{dx},~{dirflag},~{fpsr},~{flags}"(i16 [[PORT]])
+// CHECK-I386-NEXT:    ret i16 [[TMP0]]
+//
+// CHECK-X64-LABEL: define dso_local i16 @test_inpw2(
+// CHECK-X64-SAME: i16 noundef [[PORT:%.*]])
+// CHECK-X64-NEXT:  entry:
+// CHECK-X64-NEXT:    [[TMP0:%.*]] = tail call i16 asm sideeffect "inb ${1:w}, ${0:b}", "={ax},N{dx},~{dirflag},~{fpsr},~{flags}"(i16 [[PORT]])
+// CHECK-X64-NEXT:    ret i16 [[TMP0]]
+
 #if defined(__x86_64__)
 
 char test__readgsbyte(unsigned long Offset) {


### PR DESCRIPTION
support _inp, _inpw, _inpd.
These functions were removed from the Windows runtime library, but aare still supported for kernel mode development.