### PR TITLE
[lldb][test] Disable PIE for some API tests

### DIFF
--- a/lldb/test/API/commands/target/basic/Makefile
+++ b/lldb/test/API/commands/target/basic/Makefile
@@ -3,4 +3,8 @@
 # C_SOURCES := b.c
 # EXE := b.out
 
+ifndef PIE
+	LDFLAGS := -no-pie
+endif
+
 include Makefile.rules

--- a/lldb/test/API/lang/c/global_variables/Makefile
+++ b/lldb/test/API/lang/c/global_variables/Makefile
@@ -2,5 +2,8 @@ C_SOURCES := main.c
 
 DYLIB_NAME := a
 DYLIB_C_SOURCES := a.c
+ifndef PIE
+	LDFLAGS := -no-pie
+endif
 
 include Makefile.rules

--- a/lldb/test/API/lang/cpp/char8_t/Makefile
+++ b/lldb/test/API/lang/cpp/char8_t/Makefile
@@ -1,4 +1,7 @@
 CXX_SOURCES := main.cpp
 CXXFLAGS_EXTRAS := -std=c++2a -fchar8_t
+ifndef PIE
+	LDFLAGS := -no-pie
+endif
 
 include Makefile.rules


### PR DESCRIPTION
When PIE is enabled on a platform by default, these tests fail since the `target variable` command can't read a global string variable value before running an inferior process.

It fixes the following tests when built with clang on Ubuntu aarch64:
```
commands/target/basic/TestTargetCommand.py
lang/c/global_variables/TestGlobalVariables.py
lang/cpp/char8_t/TestCxxChar8_t.py
```