### PR TITLE
[clang][lldb] Don't assert structure layout correctness for layouts provided by LLDB

### DIFF
--- a/clang/lib/CodeGen/CGRecordLayoutBuilder.cpp
+++ b/clang/lib/CodeGen/CGRecordLayoutBuilder.cpp
@@ -1154,7 +1154,7 @@ CodeGenTypes::ComputeRecordLayout(const RecordDecl *D, llvm::StructType *Ty) {
 
     if (!Context.getLangOpts().DebuggerSupport)
       assert(AlignedNonVirtualTypeSizeInBits ==
-             getDataLayout().getTypeAllocSizeInBits(BaseTy) &&
+                 getDataLayout().getTypeAllocSizeInBits(BaseTy) &&
              "Type size mismatch!");
   }
 

--- a/lldb/test/API/lang/cpp/no_unique_address/Makefile
+++ b/lldb/test/API/lang/cpp/no_unique_address/Makefile
@@ -1,0 +1,3 @@
+CXX_SOURCES := main.cpp
+
+include Makefile.rules

--- a/lldb/test/API/lang/cpp/no_unique_address/TestNoUniqueAddress.py
+++ b/lldb/test/API/lang/cpp/no_unique_address/TestNoUniqueAddress.py
@@ -8,6 +8,7 @@ from lldbsuite.test.decorators import *
 from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
+
 class NoUniqueAddressTestCase(TestBase):
     def test(self):
         self.build()
@@ -16,34 +17,50 @@ class NoUniqueAddressTestCase(TestBase):
         )
 
         # Qualified/unqualified lookup to templates in namespace
-        self.expect_expr("b1", result_type="basic::Foo", result_children=[ValueCheck(
-            name="a", type="Empty"
-        )])
+        self.expect_expr(
+            "b1",
+            result_type="basic::Foo",
+            result_children=[ValueCheck(name="a", type="Empty")],
+        )
 
-        self.expect_expr("b2", result_type="bases::Foo", result_children=[
-            ValueCheck(type="bases::B", children=[
-                ValueCheck(name="x", type="Empty")
-            ]),
-            ValueCheck(type="bases::A", children=[
-                ValueCheck(name="c", type="long", value="1"),
-                ValueCheck(name="d", type="long", value="2")
-            ]),
-            ValueCheck(type="bases::C", children=[
-                ValueCheck(name="x", type="Empty")
-            ]),
-        ])
-        self.expect_expr("b3", result_type="bases::Bar", result_children=[
-            ValueCheck(type="bases::B", children=[
-                ValueCheck(name="x", type="Empty")
-            ]),
-            ValueCheck(type="bases::C", children=[
-                ValueCheck(name="x", type="Empty")
-            ]),
-            ValueCheck(type="bases::A", children=[
-                ValueCheck(name="c", type="long", value="5"),
-                ValueCheck(name="d", type="long", value="6")
-            ]),
-        ])
+        self.expect_expr(
+            "b2",
+            result_type="bases::Foo",
+            result_children=[
+                ValueCheck(
+                    type="bases::B", children=[ValueCheck(name="x", type="Empty")]
+                ),
+                ValueCheck(
+                    type="bases::A",
+                    children=[
+                        ValueCheck(name="c", type="long", value="1"),
+                        ValueCheck(name="d", type="long", value="2"),
+                    ],
+                ),
+                ValueCheck(
+                    type="bases::C", children=[ValueCheck(name="x", type="Empty")]
+                ),
+            ],
+        )
+        self.expect_expr(
+            "b3",
+            result_type="bases::Bar",
+            result_children=[
+                ValueCheck(
+                    type="bases::B", children=[ValueCheck(name="x", type="Empty")]
+                ),
+                ValueCheck(
+                    type="bases::C", children=[ValueCheck(name="x", type="Empty")]
+                ),
+                ValueCheck(
+                    type="bases::A",
+                    children=[
+                        ValueCheck(name="c", type="long", value="5"),
+                        ValueCheck(name="d", type="long", value="6"),
+                    ],
+                ),
+            ],
+        )
 
         self.expect("frame var b1")
         self.expect("frame var b2")

--- a/lldb/test/API/lang/cpp/no_unique_address/TestNoUniqueAddress.py
+++ b/lldb/test/API/lang/cpp/no_unique_address/TestNoUniqueAddress.py
@@ -1,0 +1,50 @@
+"""
+Test that LLDB correctly handles fields
+marked with [[no_unique_address]].
+"""
+
+import lldb
+from lldbsuite.test.decorators import *
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test import lldbutil
+
+class NoUniqueAddressTestCase(TestBase):
+    def test(self):
+        self.build()
+        lldbutil.run_to_source_breakpoint(
+            self, "return 0", lldb.SBFileSpec("main.cpp", False)
+        )
+
+        # Qualified/unqualified lookup to templates in namespace
+        self.expect_expr("b1", result_type="basic::Foo", result_children=[ValueCheck(
+            name="a", type="Empty"
+        )])
+
+        self.expect_expr("b2", result_type="bases::Foo", result_children=[
+            ValueCheck(type="bases::B", children=[
+                ValueCheck(name="x", type="Empty")
+            ]),
+            ValueCheck(type="bases::A", children=[
+                ValueCheck(name="c", type="long", value="1"),
+                ValueCheck(name="d", type="long", value="2")
+            ]),
+            ValueCheck(type="bases::C", children=[
+                ValueCheck(name="x", type="Empty")
+            ]),
+        ])
+        self.expect_expr("b3", result_type="bases::Bar", result_children=[
+            ValueCheck(type="bases::B", children=[
+                ValueCheck(name="x", type="Empty")
+            ]),
+            ValueCheck(type="bases::C", children=[
+                ValueCheck(name="x", type="Empty")
+            ]),
+            ValueCheck(type="bases::A", children=[
+                ValueCheck(name="c", type="long", value="5"),
+                ValueCheck(name="d", type="long", value="6")
+            ]),
+        ])
+
+        self.expect("frame var b1")
+        self.expect("frame var b2")
+        self.expect("frame var b3")

--- a/lldb/test/API/lang/cpp/no_unique_address/main.cpp
+++ b/lldb/test/API/lang/cpp/no_unique_address/main.cpp
@@ -1,0 +1,35 @@
+struct Empty {};
+
+namespace basic {
+struct Foo {
+  [[no_unique_address]] Empty a;
+};
+} // namespace basic
+
+namespace bases {
+struct A {
+  long c, d;
+};
+
+struct B {
+  [[no_unique_address]] Empty x;
+};
+
+struct C {
+  [[no_unique_address]] Empty x;
+};
+
+struct Foo : B, A, C {};
+struct Bar : B, C, A {};
+} // namespace bases
+
+int main() {
+  basic::Foo b1;
+  bases::Foo b2;
+  bases::Bar b3;
+  b2.c = 1;
+  b2.d = 2;
+  b3.c = 5;
+  b3.d = 6;
+  return 0;
+}


### PR DESCRIPTION
This is the outcome of the discussions we had in
https://discourse.llvm.org/t/rfc-lldb-handling-no-unique-address-in-lldb/77483

To summarize, LLDB creates AST nodes by parsing debug-info and hands those off to Clang for codegen. There are certain Clang attributes that affect structure layout which are not encoded in DWARF, one of which is `[[no_unique_address]]`. But the effects of such attributes *are* encoded in DWARF in terms of member offsets and sizes. So some of the correctness checks that the `RecordLayoutBuilder` performs aren't really necessary for layouts provided by LLDB since we know that the offsets we get from DWARF are correct (modulo corrupt DWARF). Hence this patch guards those asserts behind the `DebuggerSupport` flag.

This unblocks the libc++ `compressed_pair` refactor in https://github.com/llvm/llvm-project/issues/93069