### PR TITLE
[clang-repl] Introduce common fixture class in unittests (NFC)

### DIFF
--- a/clang/unittests/Interpreter/CodeCompletionTest.cpp
+++ b/clang/unittests/Interpreter/CodeCompletionTest.cpp
@@ -1,3 +1,17 @@
+//===- unittests/Interpreter/CodeCompletionTest.cpp -----------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Unit tests for Clang's Interpreter library.
+//
+//===----------------------------------------------------------------------===//
+
+#include "InterpreterTestFixture.h"
+
 #include "clang/Interpreter/CodeCompletion.h"
 #include "clang/Frontend/CompilerInstance.h"
 #include "clang/Interpreter/Interpreter.h"
@@ -12,132 +26,86 @@
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
-#if defined(_AIX) || defined(__MVS__)
-#define CLANG_INTERPRETER_PLATFORM_CANNOT_CREATE_LLJIT
-#endif
-
 using namespace clang;
 namespace {
 auto CB = clang::IncrementalCompilerBuilder();
 
-static std::unique_ptr<Interpreter> createInterpreter() {
-  auto CI = cantFail(CB.CreateCpp());
-  return cantFail(clang::Interpreter::create(std::move(CI)));
-}
+class CodeCompletionTest : public InterpreterTestBase {
+public:
+  std::unique_ptr<CompilerInstance> CI;
+  std::unique_ptr<Interpreter> Interp;
 
-static std::vector<std::string> runComp(clang::Interpreter &MainInterp,
-                                        llvm::StringRef Input,
-                                        llvm::Error &ErrR) {
-  auto CI = CB.CreateCpp();
-  if (auto Err = CI.takeError()) {
-    ErrR = std::move(Err);
-    return {};
+  CodeCompletionTest() : CI(cantFail(CB.CreateCpp())), Interp(cantFail(clang::Interpreter::create(std::move(CI)))) {}
+
+  std::vector<std::string> runComp(llvm::StringRef Input,
+                                   llvm::Error &ErrR) {
+    auto ComplCI = CB.CreateCpp();
+    if (auto Err = ComplCI.takeError()) {
+      ErrR = std::move(Err);
+      return {};
+    }
+
+    auto ComplInterp = clang::Interpreter::create(std::move(*ComplCI));
+    if (auto Err = ComplInterp.takeError()) {
+      ErrR = std::move(Err);
+      return {};
+    }
+
+    std::vector<std::string> Results;
+    std::vector<std::string> Comps;
+    auto *ParentCI = this->Interp->getCompilerInstance();
+    auto *MainCI = (*ComplInterp)->getCompilerInstance();
+    auto CC = ReplCodeCompleter();
+    CC.codeComplete(MainCI, Input, /* Lines */ 1, Input.size() + 1,
+                    ParentCI, Results);
+
+    for (auto Res : Results)
+      if (Res.find(CC.Prefix) == 0)
+        Comps.push_back(Res);
+    return Comps;
   }
+};
 
-  auto Interp = clang::Interpreter::create(std::move(*CI));
-  if (auto Err = Interp.takeError()) {
-    // log the error and returns an empty vector;
-    ErrR = std::move(Err);
-
-    return {};
-  }
-
-  std::vector<std::string> Results;
-  std::vector<std::string> Comps;
-  auto *MainCI = (*Interp)->getCompilerInstance();
-  auto CC = ReplCodeCompleter();
-  CC.codeComplete(MainCI, Input, /* Lines */ 1, Input.size() + 1,
-                  MainInterp.getCompilerInstance(), Results);
-
-  for (auto Res : Results)
-    if (Res.find(CC.Prefix) == 0)
-      Comps.push_back(Res);
-  return Comps;
-}
-
-static bool HostSupportsJit() {
-  auto J = llvm::orc::LLJITBuilder().create();
-  if (J)
-    return true;
-  LLVMConsumeError(llvm::wrap(J.takeError()));
-  return false;
-}
-
-#ifdef CLANG_INTERPRETER_PLATFORM_CANNOT_CREATE_LLJIT
-TEST(CodeCompletionTest, DISABLED_Sanity) {
-#else
-TEST(CodeCompletionTest, Sanity) {
-#endif
-  if (!HostSupportsJit())
-    GTEST_SKIP();
-  auto Interp = createInterpreter();
+TEST_F(CodeCompletionTest, Sanity) {
   cantFail(Interp->Parse("int foo = 12;"));
   auto Err = llvm::Error::success();
-  auto comps = runComp(*Interp, "f", Err);
+  auto comps = runComp("f", Err);
   EXPECT_EQ((size_t)2, comps.size()); // float and foo
   EXPECT_EQ(comps[0], std::string("float"));
   EXPECT_EQ(comps[1], std::string("foo"));
   EXPECT_EQ((bool)Err, false);
 }
 
-#ifdef CLANG_INTERPRETER_PLATFORM_CANNOT_CREATE_LLJIT
-TEST(CodeCompletionTest, DISABLED_SanityNoneValid) {
-#else
-TEST(CodeCompletionTest, SanityNoneValid) {
-#endif
-  if (!HostSupportsJit())
-    GTEST_SKIP();
-  auto Interp = createInterpreter();
+TEST_F(CodeCompletionTest, SanityNoneValid) {
   cantFail(Interp->Parse("int foo = 12;"));
   auto Err = llvm::Error::success();
-  auto comps = runComp(*Interp, "babanana", Err);
+  auto comps = runComp("babanana", Err);
   EXPECT_EQ((size_t)0, comps.size()); // foo and float
   EXPECT_EQ((bool)Err, false);
 }
 
-#ifdef CLANG_INTERPRETER_PLATFORM_CANNOT_CREATE_LLJIT
-TEST(CodeCompletionTest, DISABLED_TwoDecls) {
-#else
-TEST(CodeCompletionTest, TwoDecls) {
-#endif
-  if (!HostSupportsJit())
-    GTEST_SKIP();
-  auto Interp = createInterpreter();
+TEST_F(CodeCompletionTest, TwoDecls) {
   cantFail(Interp->Parse("int application = 12;"));
   cantFail(Interp->Parse("int apple = 12;"));
   auto Err = llvm::Error::success();
-  auto comps = runComp(*Interp, "app", Err);
+  auto comps = runComp("app", Err);
   EXPECT_EQ((size_t)2, comps.size());
   EXPECT_EQ((bool)Err, false);
 }
 
-#ifdef CLANG_INTERPRETER_PLATFORM_CANNOT_CREATE_LLJIT
-TEST(CodeCompletionTest, DISABLED_CompFunDeclsNoError) {
-#else
-TEST(CodeCompletionTest, CompFunDeclsNoError) {
-#endif
-  if (!HostSupportsJit())
-    GTEST_SKIP();
-  auto Interp = createInterpreter();
+TEST_F(CodeCompletionTest, CompFunDeclsNoError) {
   auto Err = llvm::Error::success();
-  auto comps = runComp(*Interp, "void app(", Err);
+  auto comps = runComp("void app(", Err);
   EXPECT_EQ((bool)Err, false);
 }
 
-#ifdef CLANG_INTERPRETER_PLATFORM_CANNOT_CREATE_LLJIT
-TEST(CodeCompletionTest, DISABLED_TypedDirected) {
-#else
-TEST(CodeCompletionTest, TypedDirected) {
-#endif
-  if (!HostSupportsJit())
-    GTEST_SKIP();
-  auto Interp = createInterpreter();
+TEST_F(CodeCompletionTest, TypedDirected) {
   cantFail(Interp->Parse("int application = 12;"));
   cantFail(Interp->Parse("char apple = '2';"));
   cantFail(Interp->Parse("void add(int &SomeInt){}"));
   {
     auto Err = llvm::Error::success();
-    auto comps = runComp(*Interp, std::string("add("), Err);
+    auto comps = runComp(std::string("add("), Err);
     EXPECT_EQ((size_t)1, comps.size());
     EXPECT_EQ((bool)Err, false);
   }
@@ -146,7 +114,7 @@ TEST(CodeCompletionTest, TypedDirected) {
 
   {
     auto Err = llvm::Error::success();
-    auto comps = runComp(*Interp, std::string("add("), Err);
+    auto comps = runComp(std::string("add("), Err);
     EXPECT_EQ((size_t)2, comps.size());
     EXPECT_EQ(comps[0], "application");
     EXPECT_EQ(comps[1], "banana");
@@ -155,21 +123,14 @@ TEST(CodeCompletionTest, TypedDirected) {
 
   {
     auto Err = llvm::Error::success();
-    auto comps = runComp(*Interp, std::string("add(b"), Err);
+    auto comps = runComp(std::string("add(b"), Err);
     EXPECT_EQ((size_t)1, comps.size());
     EXPECT_EQ(comps[0], "banana");
     EXPECT_EQ((bool)Err, false);
   }
 }
 
-#ifdef CLANG_INTERPRETER_PLATFORM_CANNOT_CREATE_LLJIT
-TEST(CodeCompletionTest, DISABLED_SanityClasses) {
-#else
-TEST(CodeCompletionTest, SanityClasses) {
-#endif
-  if (!HostSupportsJit())
-    GTEST_SKIP();
-  auto Interp = createInterpreter();
+TEST_F(CodeCompletionTest, SanityClasses) {
   cantFail(Interp->Parse("struct Apple{};"));
   cantFail(Interp->Parse("void takeApple(Apple &a1){}"));
   cantFail(Interp->Parse("Apple a1;"));
@@ -177,107 +138,72 @@ TEST(CodeCompletionTest, SanityClasses) {
 
   {
     auto Err = llvm::Error::success();
-    auto comps = runComp(*Interp, "takeApple(", Err);
+    auto comps = runComp("takeApple(", Err);
     EXPECT_EQ((size_t)1, comps.size());
     EXPECT_EQ(comps[0], std::string("a1"));
     EXPECT_EQ((bool)Err, false);
   }
   {
     auto Err = llvm::Error::success();
-    auto comps = runComp(*Interp, std::string("takeAppleCopy("), Err);
+    auto comps = runComp(std::string("takeAppleCopy("), Err);
     EXPECT_EQ((size_t)1, comps.size());
     EXPECT_EQ(comps[0], std::string("a1"));
     EXPECT_EQ((bool)Err, false);
   }
 }
 
-#ifdef CLANG_INTERPRETER_PLATFORM_CANNOT_CREATE_LLJIT
-TEST(CodeCompletionTest, DISABLED_SubClassing) {
-#else
-TEST(CodeCompletionTest, SubClassing) {
-#endif
-  if (!HostSupportsJit())
-    GTEST_SKIP();
-  auto Interp = createInterpreter();
+TEST_F(CodeCompletionTest, SubClassing) {
   cantFail(Interp->Parse("struct Fruit {};"));
   cantFail(Interp->Parse("struct Apple : Fruit{};"));
   cantFail(Interp->Parse("void takeFruit(Fruit &f){}"));
   cantFail(Interp->Parse("Apple a1;"));
   cantFail(Interp->Parse("Fruit f1;"));
   auto Err = llvm::Error::success();
-  auto comps = runComp(*Interp, std::string("takeFruit("), Err);
+  auto comps = runComp(std::string("takeFruit("), Err);
   EXPECT_EQ((size_t)2, comps.size());
   EXPECT_EQ(comps[0], std::string("a1"));
   EXPECT_EQ(comps[1], std::string("f1"));
   EXPECT_EQ((bool)Err, false);
 }
 
-#ifdef CLANG_INTERPRETER_PLATFORM_CANNOT_CREATE_LLJIT
-TEST(CodeCompletionTest, DISABLED_MultipleArguments) {
-#else
-TEST(CodeCompletionTest, MultipleArguments) {
-#endif
-  if (!HostSupportsJit())
-    GTEST_SKIP();
-  auto Interp = createInterpreter();
+TEST_F(CodeCompletionTest, MultipleArguments) {
   cantFail(Interp->Parse("int foo = 42;"));
   cantFail(Interp->Parse("char fowl = 'A';"));
   cantFail(Interp->Parse("void takeTwo(int &a, char b){}"));
   auto Err = llvm::Error::success();
-  auto comps = runComp(*Interp, std::string("takeTwo(foo,  "), Err);
+  auto comps = runComp(std::string("takeTwo(foo,  "), Err);
   EXPECT_EQ((size_t)1, comps.size());
   EXPECT_EQ(comps[0], std::string("fowl"));
   EXPECT_EQ((bool)Err, false);
 }
 
-#ifdef CLANG_INTERPRETER_PLATFORM_CANNOT_CREATE_LLJIT
-TEST(CodeCompletionTest, DISABLED_Methods) {
-#else
-TEST(CodeCompletionTest, Methods) {
-#endif
-  if (!HostSupportsJit())
-    GTEST_SKIP();
-  auto Interp = createInterpreter();
+TEST_F(CodeCompletionTest, Methods) {
   cantFail(Interp->Parse(
       "struct Foo{int add(int a){return 42;} int par(int b){return 42;}};"));
   cantFail(Interp->Parse("Foo f1;"));
 
   auto Err = llvm::Error::success();
-  auto comps = runComp(*Interp, std::string("f1."), Err);
+  auto comps = runComp(std::string("f1."), Err);
   EXPECT_EQ((size_t)2, comps.size());
   EXPECT_EQ(comps[0], std::string("add"));
   EXPECT_EQ(comps[1], std::string("par"));
   EXPECT_EQ((bool)Err, false);
 }
 
-#ifdef CLANG_INTERPRETER_PLATFORM_CANNOT_CREATE_LLJIT
-TEST(CodeCompletionTest, DISABLED_MethodsInvocations) {
-#else
-TEST(CodeCompletionTest, MethodsInvocations) {
-#endif
-  if (!HostSupportsJit())
-    GTEST_SKIP();
-  auto Interp = createInterpreter();
+TEST_F(CodeCompletionTest, MethodsInvocations) {
   cantFail(Interp->Parse(
       "struct Foo{int add(int a){return 42;} int par(int b){return 42;}};"));
   cantFail(Interp->Parse("Foo f1;"));
   cantFail(Interp->Parse("int a = 84;"));
 
   auto Err = llvm::Error::success();
-  auto comps = runComp(*Interp, std::string("f1.add("), Err);
+  auto comps = runComp(std::string("f1.add("), Err);
   EXPECT_EQ((size_t)1, comps.size());
   EXPECT_EQ(comps[0], std::string("a"));
   EXPECT_EQ((bool)Err, false);
 }
 
-#ifdef CLANG_INTERPRETER_PLATFORM_CANNOT_CREATE_LLJIT
-TEST(CodeCompletionTest, DISABLED_NestedInvocations) {
-#else
-TEST(CodeCompletionTest, NestedInvocations) {
-#endif
-  if (!HostSupportsJit())
-    GTEST_SKIP();
-  auto Interp = createInterpreter();
+TEST_F(CodeCompletionTest, NestedInvocations) {
   cantFail(Interp->Parse(
       "struct Foo{int add(int a){return 42;} int par(int b){return 42;}};"));
   cantFail(Interp->Parse("Foo f1;"));
@@ -285,26 +211,19 @@ TEST(CodeCompletionTest, NestedInvocations) {
   cantFail(Interp->Parse("int plus(int a, int b) { return a + b; }"));
 
   auto Err = llvm::Error::success();
-  auto comps = runComp(*Interp, std::string("plus(42, f1.add("), Err);
+  auto comps = runComp(std::string("plus(42, f1.add("), Err);
   EXPECT_EQ((size_t)1, comps.size());
   EXPECT_EQ(comps[0], std::string("a"));
   EXPECT_EQ((bool)Err, false);
 }
 
-#ifdef CLANG_INTERPRETER_PLATFORM_CANNOT_CREATE_LLJIT
-TEST(CodeCompletionTest, DISABLED_TemplateFunctions) {
-#else
-TEST(CodeCompletionTest, TemplateFunctions) {
-#endif
-  if (!HostSupportsJit())
-    GTEST_SKIP();
-  auto Interp = createInterpreter();
+TEST_F(CodeCompletionTest, TemplateFunctions) {
   cantFail(
       Interp->Parse("template <typename T> T id(T a) { return a;} "));
   cantFail(Interp->Parse("int apple = 84;"));
   {
     auto Err = llvm::Error::success();
-    auto comps = runComp(*Interp, std::string("id<int>("), Err);
+    auto comps = runComp(std::string("id<int>("), Err);
     EXPECT_EQ((size_t)1, comps.size());
     EXPECT_EQ(comps[0], std::string("apple"));
     EXPECT_EQ((bool)Err, false);
@@ -315,7 +234,7 @@ TEST(CodeCompletionTest, TemplateFunctions) {
   cantFail(Interp->Parse("char pear = '4';"));
   {
     auto Err = llvm::Error::success();
-    auto comps = runComp(*Interp, std::string("pickFirst(apple, "), Err);
+    auto comps = runComp(std::string("pickFirst(apple, "), Err);
     EXPECT_EQ((size_t)1, comps.size());
     EXPECT_EQ(comps[0], std::string("apple"));
     EXPECT_EQ((bool)Err, false);

--- a/clang/unittests/Interpreter/CodeCompletionTest.cpp
+++ b/clang/unittests/Interpreter/CodeCompletionTest.cpp
@@ -35,10 +35,11 @@ public:
   std::unique_ptr<CompilerInstance> CI;
   std::unique_ptr<Interpreter> Interp;
 
-  CodeCompletionTest() : CI(cantFail(CB.CreateCpp())), Interp(cantFail(clang::Interpreter::create(std::move(CI)))) {}
+  CodeCompletionTest()
+      : CI(cantFail(CB.CreateCpp())),
+        Interp(cantFail(clang::Interpreter::create(std::move(CI)))) {}
 
-  std::vector<std::string> runComp(llvm::StringRef Input,
-                                   llvm::Error &ErrR) {
+  std::vector<std::string> runComp(llvm::StringRef Input, llvm::Error &ErrR) {
     auto ComplCI = CB.CreateCpp();
     if (auto Err = ComplCI.takeError()) {
       ErrR = std::move(Err);
@@ -56,8 +57,8 @@ public:
     auto *ParentCI = this->Interp->getCompilerInstance();
     auto *MainCI = (*ComplInterp)->getCompilerInstance();
     auto CC = ReplCodeCompleter();
-    CC.codeComplete(MainCI, Input, /* Lines */ 1, Input.size() + 1,
-                    ParentCI, Results);
+    CC.codeComplete(MainCI, Input, /* Lines */ 1, Input.size() + 1, ParentCI,
+                    Results);
 
     for (auto Res : Results)
       if (Res.find(CC.Prefix) == 0)

--- a/clang/unittests/Interpreter/InterpreterTestFixture.h
+++ b/clang/unittests/Interpreter/InterpreterTestFixture.h
@@ -44,24 +44,18 @@ protected:
 #endif
   }
 
-  void TearDown() override {
-  }
+  void TearDown() override {}
 
   static void SetUpTestSuite() {
     llvm::InitializeNativeTarget();
     llvm::InitializeNativeTargetAsmPrinter();
   }
 
-  static void TearDownTestSuite() {
-    llvm::llvm_shutdown();
-  }
+  static void TearDownTestSuite() { llvm::llvm_shutdown(); }
 };
-
-class InterpreterTestWithParams : public InterpreterTestBase,
-                                  public ::testing::WithParamInterface<TestClangConfig> {};
 
 } // namespace clang
 
-//#undef CLANG_INTERPRETER_PLATFORM_CANNOT_CREATE_LLJIT
+#undef CLANG_INTERPRETER_PLATFORM_CANNOT_CREATE_LLJIT
 
 #endif // LLVM_CLANG_UNITTESTS_INTERPRETER_INTERPRETERTESTBASE_H

--- a/clang/unittests/Interpreter/InterpreterTestFixture.h
+++ b/clang/unittests/Interpreter/InterpreterTestFixture.h
@@ -1,0 +1,67 @@
+//===- unittests/Interpreter/InterpreterTestBase.h ------------------ C++ -===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_CLANG_UNITTESTS_INTERPRETER_INTERPRETERTESTBASE_H
+#define LLVM_CLANG_UNITTESTS_INTERPRETER_INTERPRETERTESTBASE_H
+
+#include "clang/Testing/TestClangConfig.h"
+#include "clang/Tooling/Tooling.h"
+
+#include "llvm/ExecutionEngine/Orc/LLJIT.h"
+#include "llvm/Support/Error.h"
+#include "llvm/Support/TargetSelect.h"
+
+#include "gtest/gtest.h"
+
+#if defined(_AIX) || defined(__MVS__)
+#define CLANG_INTERPRETER_PLATFORM_CANNOT_CREATE_LLJIT
+#endif
+
+namespace clang {
+
+class InterpreterTestBase : public ::testing::Test {
+protected:
+  static bool HostSupportsJIT() {
+    if (auto JIT = llvm::orc::LLJITBuilder().create()) {
+      return true;
+    } else {
+      llvm::consumeError(JIT.takeError());
+      return false;
+    }
+  }
+
+  void SetUp() override {
+#ifdef CLANG_INTERPRETER_PLATFORM_CANNOT_CREATE_LLJIT
+    GTEST_SKIP();
+#else
+    if (!HostSupportsJIT())
+      GTEST_SKIP();
+#endif
+  }
+
+  void TearDown() override {
+  }
+
+  static void SetUpTestSuite() {
+    llvm::InitializeNativeTarget();
+    llvm::InitializeNativeTargetAsmPrinter();
+  }
+
+  static void TearDownTestSuite() {
+    llvm::llvm_shutdown();
+  }
+};
+
+class InterpreterTestWithParams : public InterpreterTestBase,
+                                  public ::testing::WithParamInterface<TestClangConfig> {};
+
+} // namespace clang
+
+//#undef CLANG_INTERPRETER_PLATFORM_CANNOT_CREATE_LLJIT
+
+#endif // LLVM_CLANG_UNITTESTS_INTERPRETER_INTERPRETERTESTBASE_H


### PR DESCRIPTION
Reduce code bloat by checking test requirements in a common test fixture