### PR TITLE
[lldb] Fixed the TestGdbRemoteLibrariesSvr4Support test running on a remote target

### DIFF
--- a/lldb/test/API/tools/lldb-server/libraries-svr4/TestGdbRemoteLibrariesSvr4Support.py
+++ b/lldb/test/API/tools/lldb-server/libraries-svr4/TestGdbRemoteLibrariesSvr4Support.py
@@ -6,6 +6,7 @@ from lldbsuite.test.lldbtest import *
 
 # Windows does not allow quotes in file names.
 @skipIf(hostoslist=["windows"])
+@skipIfRemote
 class TestGdbRemoteLibrariesSvr4Support(gdbremote_testcase.GdbRemoteTestCaseBase):
     FEATURE_NAME = "qXfer:libraries-svr4:read"
 


### PR DESCRIPTION
The TestGdbRemoteLibrariesSvr4Support test failed in case of Linux x86_64 host and Linux Aarch64 target. Installing libraries to the remote target is not enough. This test actively uses self.getBuildDir() and os.path.realpath() which does not work in case of the remote target. So, disable this test for remote target now.