### PR TITLE
[lldb] Fixed the TestDebuggerAPI test running on a remote target

### DIFF
--- a/lldb/test/API/python_api/debugger/TestDebuggerAPI.py
+++ b/lldb/test/API/python_api/debugger/TestDebuggerAPI.py
@@ -92,7 +92,6 @@ class DebuggerAPITestCase(TestBase):
         self.assertEqual(get_cache_line_size(), new_cache_line_size)
 
     @expectedFailureAll(
-        hostoslist=["windows"],
         remote=True,
         bugnumber="github.com/llvm/llvm-project/issues/92419",
     )


### PR DESCRIPTION
Recently we have disabled this test for Windows host and Linux target. Now we faced the same issue #92419 in case of Linux x86_64 host and Linux Aarch64 target.