### PR TITLE
[lldb][DWARF] Fix adding children to clang type that hasn't started definition.

### DIFF
--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserClang.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserClang.cpp
@@ -2233,9 +2233,9 @@ bool DWARFASTParserClang::CompleteRecordType(const DWARFDIE &die,
       // created.
       TypeSystemClang::StartTagDeclarationDefinition(clang_type);
     } else {
-      assert(
-          clang_type.IsBeingDefined() &&
-          "Trying to complete a definition without a prior call to StartTagDeclarationDefinition.");
+      assert(clang_type.IsBeingDefined() &&
+             "Trying to complete a definition without a prior call to "
+             "StartTagDeclarationDefinition.");
     }
 
     AccessType default_accessibility = eAccessNone;

--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserClang.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserClang.cpp
@@ -2232,6 +2232,11 @@ bool DWARFASTParserClang::CompleteRecordType(const DWARFDIE &die,
       // For objective C we don't start the definition when the class is
       // created.
       TypeSystemClang::StartTagDeclarationDefinition(clang_type);
+    } else if (!clang_type.IsBeingDefined()) {
+      // In case of some weired DWARF causing we don't start definition on this
+      // definition DIE because we failed to find existing clang_type from
+      // UniqueDWARFASTTypeMap due to overstrict checking.
+      TypeSystemClang::StartTagDeclarationDefinition(clang_type);
     }
 
     AccessType default_accessibility = eAccessNone;

--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserClang.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserClang.cpp
@@ -2235,7 +2235,7 @@ bool DWARFASTParserClang::CompleteRecordType(const DWARFDIE &die,
     } else {
       assert(
           clang_type.IsBeingDefined() &&
-          "The clang type should already start its definition at this point.");
+          "Trying to complete a definition without a prior call to StartTagDeclarationDefinition.");
     }
 
     AccessType default_accessibility = eAccessNone;

--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserClang.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserClang.cpp
@@ -2232,11 +2232,10 @@ bool DWARFASTParserClang::CompleteRecordType(const DWARFDIE &die,
       // For objective C we don't start the definition when the class is
       // created.
       TypeSystemClang::StartTagDeclarationDefinition(clang_type);
-    } else if (!clang_type.IsBeingDefined()) {
-      // In case of some weired DWARF causing we don't start definition on this
-      // definition DIE because we failed to find existing clang_type from
-      // UniqueDWARFASTTypeMap due to overstrict checking.
-      TypeSystemClang::StartTagDeclarationDefinition(clang_type);
+    } else {
+      assert(
+          clang_type.IsBeingDefined() &&
+          "The clang type should already start its definition at this point.");
     }
 
     AccessType default_accessibility = eAccessNone;


### PR DESCRIPTION
This fixes https://github.com/llvm/llvm-project/pull/92328#issuecomment-2139339444 by not differentiating `DW_TAG_class_type` and `DW_TAG_structure_type` in `UniqueDWARFASTTypeList`, because it's possible that DIE for a type is `DW_TAG_class_type` in one CU but is `DW_TAG_structure_type` in a different CU.
