### PR TITLE
[flang][runtime] add IsAssumedSize API

### DIFF
--- a/flang/include/flang/Runtime/support.h
+++ b/flang/include/flang/Runtime/support.h
@@ -34,6 +34,9 @@ extern "C" {
 // Predicate: is the storage described by a Descriptor contiguous in memory?
 bool RTDECL(IsContiguous)(const Descriptor &);
 
+// Predicate: is this descriptor describing an assumed-size array?
+bool RTDECL(IsAssumedSize)(const Descriptor &);
+
 // Copy "from" descriptor into "to" descriptor and update "to" dynamic type,
 // CFI_attribute, and lower bounds according to the other arguments.
 // "newDynamicType" may be a null pointer in which case "to" dynamic type is the

--- a/flang/runtime/support.cpp
+++ b/flang/runtime/support.cpp
@@ -7,6 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "flang/Runtime/support.h"
+#include "ISO_Fortran_util.h"
 #include "type-info.h"
 #include "flang/Runtime/descriptor.h"
 
@@ -16,6 +17,10 @@ RT_EXT_API_GROUP_BEGIN
 
 bool RTDEF(IsContiguous)(const Descriptor &descriptor) {
   return descriptor.IsContiguous();
+}
+
+bool RTDEF(IsAssumedSize)(const Descriptor &descriptor) {
+  return ISO::IsAssumedSize(&descriptor.raw());
 }
 
 void RTDEF(CopyAndUpdateDescriptor)(Descriptor &to, const Descriptor &from,

--- a/flang/unittests/Runtime/Support.cpp
+++ b/flang/unittests/Runtime/Support.cpp
@@ -56,3 +56,14 @@ TEST(CopyAndUpdateDescriptor, Basic) {
   EXPECT_EQ(result.GetDimension(1).Extent(), x->GetDimension(1).Extent());
   EXPECT_EQ(result.GetDimension(1).LowerBound(), 1);
 }
+
+TEST(IsAssumedSize, Basic) {
+  auto x{MakeArray<TypeCategory::Integer, 4>(
+      std::vector<int>{2, 3}, std::vector<std::int32_t>{0, 1, 2, 3, 4, 5})};
+  EXPECT_FALSE(RTNAME(IsAssumedSize)(*x));
+  x->GetDimension(1).SetExtent(-1);
+  EXPECT_TRUE(RTNAME(IsAssumedSize)(*x));
+  auto scalar{MakeArray<TypeCategory::Integer, 4>(
+      std::vector<int>{}, std::vector<std::int32_t>{0})};
+  EXPECT_FALSE(RTNAME(IsAssumedSize)(*scalar));
+}


### PR DESCRIPTION
Needed for SELECT RANK implementation. I want to stay away from generating the `rank > 0 && ...` logic in FIR codegen for now.