### PR TITLE
[Clang] \ is not valid in a raw string literal

### DIFF
--- a/clang/include/clang/Basic/CharInfo.h
+++ b/clang/include/clang/Basic/CharInfo.h
@@ -176,7 +176,7 @@ LLVM_READONLY inline bool isRawStringDelimBody(unsigned char c) {
   using namespace charinfo;
   return (InfoTable[c] & (CHAR_UPPER | CHAR_LOWER | CHAR_PERIOD | CHAR_DIGIT |
                           CHAR_UNDER | CHAR_PUNCT)) != 0 &&
-         c != '(' && c != ')';
+         c != '(' && c != ')' && c != '\\';
 }
 
 enum class EscapeChar {

--- a/clang/test/Lexer/cxx2c-raw-strings.cpp
+++ b/clang/test/Lexer/cxx2c-raw-strings.cpp
@@ -1,12 +1,24 @@
-// RUN: %clang_cc1 -std=c++11 -fsyntax-only -verify -Wc++26-extensions %s
-// RUN: %clang_cc1 -std=c++2c -fsyntax-only -verify=cxx26 -Wpre-c++26-compat %s
+// RUN: %clang_cc1 -std=c++11 -fsyntax-only -verify=precxx26,expected -Wc++26-extensions %s
+// RUN: %clang_cc1 -std=c++2c -fsyntax-only -verify=cxx26,expected -Wpre-c++26-compat %s
 
 int main() {
   (void) R"abc`@$(foobar)abc`@$";
-  //expected-warning@-1 {{'`' in a raw string literal delimiter is a C++2c extension}}
-  //expected-warning@-2 {{'@' in a raw string literal delimiter is a C++2c extension}}
-  //expected-warning@-3 {{'$' in a raw string literal delimiter is a C++2c extension}}
+  //precxx26-warning@-1 {{'`' in a raw string literal delimiter is a C++2c extension}}
+  //precxx26-warning@-2 {{'@' in a raw string literal delimiter is a C++2c extension}}
+  //precxx26-warning@-3 {{'$' in a raw string literal delimiter is a C++2c extension}}
   //cxx26-warning@-4 {{'`' in a raw string literal delimiter is incompatible with standards before C++2c}}
   //cxx26-warning@-5 {{'@' in a raw string literal delimiter is incompatible with standards before C++2c}}
   //cxx26-warning@-6 {{'$' in a raw string literal delimiter is incompatible with standards before C++2c}}
+
+  (void) R"\t()\t";
+  // expected-error@-1 {{invalid character '\' in raw string delimiter}}
+  // expected-error@-2 {{expected expression}}
+
+  (void) R" () ";
+  // expected-error@-1 {{invalid character ' ' in raw string delimiter}}
+  // expected-error@-2 {{expected expression}}
+
+  (void) R"\()\";
+  // expected-error@-1 {{invalid character '\' in raw string delimiter}}
+  // expected-error@-2 {{expected expression}}
 }


### PR DESCRIPTION
Fix regression introduced by #93216