### PR TITLE
[lldb][test] Fix failing test TestAddressRange.py

### DIFF
--- a/lldb/test/API/python_api/address_range/TestAddressRange.py
+++ b/lldb/test/API/python_api/address_range/TestAddressRange.py
@@ -191,7 +191,7 @@ class AddressRangeTestCase(TestBase):
         interp.HandleCommand(script, result, False)
         self.assertTrue(result.Succeeded(), "script command succeeded")
         # [0x1000-0x2000] // Resolved with target or addresses without sections
-        self.assertRegex(result.GetOutput(), "^\[0x[0-9a-f]+\-0x[0-9a-f]+\)$")
+        self.assertRegex(result.GetOutput(), "^\[0x[0-9a-f]+\-0x[0-9a-f]+\)")
         process.Kill()
 
     def test_address_range_print_no_section_resolved(self):


### PR DESCRIPTION
Summary:
Test llvm-project/lldb/test/API/python_api/address_range/TestAddressRange.py is failing on Windows due adding a carriage return character at the end of line. Original PR is #93836.

Test Plan:
llvm-lit -sv llvm-project/lldb/test/API/python_api/address_range/TestAddressRange.py


Reviewers: clayborg

Subscribers:

Tasks:

Tags: