### PR TITLE
[dsymutil] Also detect external downloadable toolchains

### DIFF
--- a/llvm/include/llvm/DWARFLinker/Utils.h
+++ b/llvm/include/llvm/DWARFLinker/Utils.h
@@ -39,7 +39,6 @@ inline Error finiteLoop(function_ref<Expected<bool>()> Iteration,
 /// Make a best effort to guess the
 /// Xcode.app/Contents/Developer path from an SDK path.
 inline StringRef guessDeveloperDir(StringRef SysRoot) {
-  SmallString<128> Result;
   // Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk
   auto it = sys::path::rbegin(SysRoot);
   auto end = sys::path::rend(SysRoot);
@@ -72,6 +71,28 @@ inline StringRef guessDeveloperDir(StringRef SysRoot) {
     ++it;
   }
   return {};
+}
+
+/// Make a best effort to determine whether Path is inside a toolchain.
+inline bool isInToolchainDir(StringRef Path) {
+  // Library/Developer/Toolchains/swift-DEVELOPMENT-SNAPSHOT-2024-05-15-a.xctoolchain/usr/lib/swift/macosx/_StringProcessing.swiftmodule/arm64-apple-macos.private.swiftinterface
+  for (auto it = sys::path::rbegin(Path), end = sys::path::rend(Path);
+       it != end; ++it) {
+    if (it->ends_with(".xctoolchain")) {
+      ++it;
+      if (it == end)
+        return false;
+      if (*it != "Toolchains")
+        return false;
+      ++it;
+      if (it == end)
+        return false;
+      if (*it != "Developer")
+        return false;
+      return true;
+    }
+  }
+  return false;
 }
 
 inline bool isPathAbsoluteOnWindowsOrPosix(const Twine &Path) {

--- a/llvm/lib/DWARFLinker/Classic/DWARFLinker.cpp
+++ b/llvm/lib/DWARFLinker/Classic/DWARFLinker.cpp
@@ -204,6 +204,8 @@ static void analyzeImportedModule(
   StringRef DeveloperDir = guessDeveloperDir(SysRoot);
   if (!DeveloperDir.empty() && Path.starts_with(DeveloperDir))
     return;
+  if (isInToolchainDir(Path))
+    return;
   std::optional<const char *> Name =
       dwarf::toString(DIE.find(dwarf::DW_AT_name));
   if (!Name)

--- a/llvm/lib/DWARFLinker/Parallel/DWARFLinkerCompileUnit.cpp
+++ b/llvm/lib/DWARFLinker/Parallel/DWARFLinkerCompileUnit.cpp
@@ -273,6 +273,8 @@ void CompileUnit::analyzeImportedModule(const DWARFDebugInfoEntry *DieEntry) {
   StringRef DeveloperDir = guessDeveloperDir(SysRoot);
   if (!DeveloperDir.empty() && Path.starts_with(DeveloperDir))
     return;
+  if (isInToolchainDir(Path))
+    return;
   if (std::optional<DWARFFormValue> Val = find(DieEntry, dwarf::DW_AT_name)) {
     Expected<const char *> Name = Val->getAsCString();
     if (!Name) {

--- a/llvm/unittests/DWARFLinkerParallel/DWARFLinkerTest.cpp
+++ b/llvm/unittests/DWARFLinkerParallel/DWARFLinkerTest.cpp
@@ -24,6 +24,12 @@ TEST(DWARFLinker, PathTest) {
                 "/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.4.sdk"),
             DEVELOPER_DIR);
   EXPECT_EQ(guessDeveloperDir(DEVELOPER_DIR "/SDKs/MacOSX.sdk"), DEVELOPER_DIR);
+  EXPECT_TRUE(
+      isInToolchainDir("/Library/Developer/Toolchains/"
+                       "swift-DEVELOPMENT-SNAPSHOT-2024-05-15-a.xctoolchain/"
+                       "usr/lib/swift/macosx/_StringProcessing.swiftmodule/"
+                       "arm64-apple-macos.private.swiftinterface"));
+  EXPECT_FALSE(isInToolchainDir("/Foo/not-an.xctoolchain/Bar/Baz"));
 }
 
 } // anonymous namespace


### PR DESCRIPTION
and reject them when copying Swift interface files, since they can live outside of DEVELOPER_DIR.