### PR TITLE
[lldb] Improve identification of Dlang mangled names

### DIFF
--- a/lldb/source/Core/Mangled.cpp
+++ b/lldb/source/Core/Mangled.cpp
@@ -19,6 +19,7 @@
 #include "lldb/Utility/Stream.h"
 #include "lldb/lldb-enumerations.h"
 
+#include "llvm/ADT/StringExtras.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Demangle/Demangle.h"
 #include "llvm/Support/Compiler.h"
@@ -48,8 +49,14 @@ Mangled::ManglingScheme Mangled::GetManglingScheme(llvm::StringRef const name) {
   if (name.starts_with("_R"))
     return Mangled::eManglingSchemeRustV0;
 
-  if (name.starts_with("_D"))
-    return Mangled::eManglingSchemeD;
+  if (name.starts_with("_D")) {
+    // A dlang mangled name begins with `_D`, followed by a numeric length.
+    // See `SymbolName` and `LName` in
+    // https://dlang.org/spec/abi.html#name_mangling
+    llvm::StringRef buf = name.drop_front(2);
+    if (!buf.empty() && llvm::isDigit(buf.front()))
+      return Mangled::eManglingSchemeD;
+  }
 
   if (name.starts_with("_Z"))
     return Mangled::eManglingSchemeItanium;

--- a/lldb/test/API/lang/c/non-mangled/Makefile
+++ b/lldb/test/API/lang/c/non-mangled/Makefile
@@ -1,0 +1,4 @@
+C_SOURCES := main.c
+CFLAGS_EXTRAS := -std=c99
+
+include Makefile.rules

--- a/lldb/test/API/lang/c/non-mangled/TestCNonMangled.py
+++ b/lldb/test/API/lang/c/non-mangled/TestCNonMangled.py
@@ -3,7 +3,6 @@ from lldbsuite.test.lldbtest import *
 
 
 class TestCase(TestBase):
-
     def test_functions_having_dlang_mangling_prefix(self):
         """
         Ensure C functions with a '_D' prefix alone are not mistakenly treated

--- a/lldb/test/API/lang/c/non-mangled/TestCNonMangled.py
+++ b/lldb/test/API/lang/c/non-mangled/TestCNonMangled.py
@@ -1,0 +1,16 @@
+import lldbsuite.test.lldbutil as lldbutil
+from lldbsuite.test.lldbtest import *
+
+
+class TestCase(TestBase):
+
+    def test_functions_having_dlang_mangling_prefix(self):
+        """
+        Ensure C functions with a '_D' prefix alone are not mistakenly treated
+        as a Dlang mangled name. A proper Dlang mangling will have digits
+        immediately following the '_D' prefix.
+        """
+        self.build()
+        _, _, thread, _ = lldbutil.run_to_name_breakpoint(self, "_Dfunction")
+        symbol = thread.frame[0].symbol
+        self.assertEqual(symbol.GetDisplayName(), "_Dfunction")

--- a/lldb/test/API/lang/c/non-mangled/main.c
+++ b/lldb/test/API/lang/c/non-mangled/main.c
@@ -1,0 +1,8 @@
+#include <stdio.h>
+
+void _Dfunction() {}
+
+int main() {
+  _Dfunction();
+  return 0;
+}


### PR DESCRIPTION
Reduce false positive identification of C names as Dlang mangled names. This happens when a C function uses the prefix `_D`.

The [Dlang ABI](https://dlang.org/spec/abi.html#name_mangling) shows that mangled names have a length immediately following the `_D` prefix. This change checks for a digit after the `_D` prefix, when identifying the mangling scheme of a symbol. This doesn't prevent false positives entirely, but does make it less likely.