### PR TITLE
[lldb][test] Add --target-os argument to dotest.py

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/builders/builder.py
+++ b/lldb/packages/Python/lldbsuite/test/builders/builder.py
@@ -36,6 +36,13 @@ class Builder:
         """Returns the ARCH_CFLAGS for the make system."""
         return []
 
+    def getTargetOsFlag(self, target_os):
+        if target_os is None:
+            target_os = configuration.target_os
+        if target_os is None:
+            return []
+        return ["OS=%s" % target_os]
+
     def getMake(self, test_subdir, test_name):
         """Returns the invocation for GNU make.
         The first argument is a tuple of the relative path to the testcase
@@ -171,6 +178,7 @@ class Builder:
         testdir=None,
         testname=None,
         make_targets=None,
+        target_os=None,
     ):
         debug_info_args = self._getDebugInfoArgs(debug_info)
         if debug_info_args is None:
@@ -182,6 +190,7 @@ class Builder:
             debug_info_args,
             make_targets,
             self.getArchCFlags(architecture),
+            self.getTargetOsFlag(target_os),
             self.getArchSpec(architecture),
             self.getCCSpec(compiler),
             self.getExtraMakeArgs(),

--- a/lldb/packages/Python/lldbsuite/test/configuration.py
+++ b/lldb/packages/Python/lldbsuite/test/configuration.py
@@ -39,6 +39,7 @@ lldb_framework_path = None
 count = 1
 
 # The 'arch' and 'compiler' can be specified via command line.
+target_os = None
 arch = None
 compiler = None
 dsymutil = None

--- a/lldb/packages/Python/lldbsuite/test/dotest.py
+++ b/lldb/packages/Python/lldbsuite/test/dotest.py
@@ -312,6 +312,9 @@ def parseOptionsAndInitTestdirs():
             logging.error("No SDK found with the name %s; aborting...", args.apple_sdk)
             sys.exit(-1)
 
+    if args.target_os:
+        configuration.target_os = args.target_os
+
     if args.arch:
         configuration.arch = args.arch
     else:

--- a/lldb/packages/Python/lldbsuite/test/dotest_args.py
+++ b/lldb/packages/Python/lldbsuite/test/dotest_args.py
@@ -32,6 +32,15 @@ def create_parser():
     # C and Python toolchain options
     group = parser.add_argument_group("Toolchain options")
     group.add_argument(
+        "--target-os",
+        metavar="target_os",
+        dest="target_os",
+        default="",
+        help=textwrap.dedent(
+            """Specify target os for test compilation. This is useful for cross-compilation."""
+        ),
+    )
+    group.add_argument(
         "-A",
         "--arch",
         metavar="arch",

--- a/lldb/packages/Python/lldbsuite/test/lldbtest.py
+++ b/lldb/packages/Python/lldbsuite/test/lldbtest.py
@@ -1454,11 +1454,15 @@ class Base(unittest.TestCase):
     def build(
         self,
         debug_info=None,
+        target_os=None,
         architecture=None,
         compiler=None,
         dictionary=None,
         make_targets=None,
     ):
+        if not target_os and configuration.target_os:
+            target_os = configuration.target_os
+
         """Platform specific way to build binaries."""
         if not architecture and configuration.arch:
             architecture = configuration.arch


### PR DESCRIPTION
Makefile.rules uses HOST_OS and OS variables for determining host and target OSes for LLDB API tests compilation.
HOST_OS is determined using `uname -s` command, and OS is defaulted to HOST_OS.
This argument allows to pass the target OS to the make invocation for the case of Windows-to-Linux cross-testing.

The argument can be set using `LLDB_TEST_USER_ARGS` argument:
```
cmake ...
-DLLDB_TEST_USER_ARGS="...;--target-os;Linux;..."
...
```