### PR TITLE
[cmake] Allow multiple LibEdit_LIBRARIES

### DIFF
--- a/llvm/cmake/modules/FindLibEdit.cmake
+++ b/llvm/cmake/modules/FindLibEdit.cmake
@@ -59,8 +59,7 @@ find_package_handle_standard_args(LibEdit
 mark_as_advanced(LibEdit_INCLUDE_DIRS LibEdit_LIBRARIES)
 
 if (LibEdit_FOUND AND NOT TARGET LibEdit::LibEdit)
-  add_library(LibEdit::LibEdit UNKNOWN IMPORTED)
-  set_target_properties(LibEdit::LibEdit PROPERTIES
-                        IMPORTED_LOCATION ${LibEdit_LIBRARIES}
-                        INTERFACE_INCLUDE_DIRECTORIES ${LibEdit_INCLUDE_DIRS})
+  add_library(LibEdit::LibEdit INTERFACE IMPORTED)
+  target_link_libraries(LibEdit::LibEdit INTERFACE ${LibEdit_LIBRARIES})
+  target_include_directories(LibEdit::LibEdit INTERFACE ${LibEdit_INCLUDE_DIRS})
 endif()


### PR DESCRIPTION
If built statically, `libedit` may have a private static library dependency on a provider of the `terminfo` API (e.g., `ncurses`). This means that multiple libraries would need to be provided as the value for `LibEdit_LIBRARIES`, but the current implementation of `FindLibEdit` precludes this. This PR allows a list to be passed to `LibEdit_LIBRARIES`.