### PR TITLE
[clang] Add arm64e ABI-defined key assignments to ptrauth.h.

### DIFF
--- a/clang/lib/Headers/ptrauth.h
+++ b/clang/lib/Headers/ptrauth.h
@@ -16,27 +16,17 @@ typedef enum {
   ptrauth_key_asda = 2,
   ptrauth_key_asdb = 3,
 
-#ifdef __APPLE__
-  /* A process-independent key which can be used to sign code pointers.
-     Signing and authenticating with this key is a no-op in processes
-     which disable ABI pointer authentication. */
+  /* A process-independent key which can be used to sign code pointers. */
   ptrauth_key_process_independent_code = ptrauth_key_asia,
 
-  /* A process-specific key which can be used to sign code pointers.
-     Signing and authenticating with this key is enforced even in processes
-     which disable ABI pointer authentication. */
+  /* A process-specific key which can be used to sign code pointers. */
   ptrauth_key_process_dependent_code = ptrauth_key_asib,
 
-  /* A process-independent key which can be used to sign data pointers.
-     Signing and authenticating with this key is a no-op in processes
-     which disable ABI pointer authentication. */
+  /* A process-independent key which can be used to sign data pointers. */
   ptrauth_key_process_independent_data = ptrauth_key_asda,
 
-  /* A process-specific key which can be used to sign data pointers.
-     Signing and authenticating with this key is a no-op in processes
-     which disable ABI pointer authentication. */
+  /* A process-specific key which can be used to sign data pointers. */
   ptrauth_key_process_dependent_data = ptrauth_key_asdb,
-#endif /* __APPLE__ */
 
 } ptrauth_key;
 

--- a/clang/lib/Headers/ptrauth.h
+++ b/clang/lib/Headers/ptrauth.h
@@ -15,6 +15,29 @@ typedef enum {
   ptrauth_key_asib = 1,
   ptrauth_key_asda = 2,
   ptrauth_key_asdb = 3,
+
+#ifdef __APPLE__
+  /* A process-independent key which can be used to sign code pointers.
+     Signing and authenticating with this key is a no-op in processes
+     which disable ABI pointer authentication. */
+  ptrauth_key_process_independent_code = ptrauth_key_asia,
+
+  /* A process-specific key which can be used to sign code pointers.
+     Signing and authenticating with this key is enforced even in processes
+     which disable ABI pointer authentication. */
+  ptrauth_key_process_dependent_code = ptrauth_key_asib,
+
+  /* A process-independent key which can be used to sign data pointers.
+     Signing and authenticating with this key is a no-op in processes
+     which disable ABI pointer authentication. */
+  ptrauth_key_process_independent_data = ptrauth_key_asda,
+
+  /* A process-specific key which can be used to sign data pointers.
+     Signing and authenticating with this key is a no-op in processes
+     which disable ABI pointer authentication. */
+  ptrauth_key_process_dependent_data = ptrauth_key_asdb,
+#endif /* __APPLE__ */
+
 } ptrauth_key;
 
 /* An integer type of the appropriate size for a discriminator argument. */


### PR DESCRIPTION
These are currently gated by `__APPLE__`; we can figure out a way to define these on ELF targets as well, and maybe have them be defined by clang itself, depending on ABI modes.