### PR TITLE
gn build: Pass -fno-sanitize=vptr,function with use_ubsan

### DIFF
--- a/llvm/utils/gn/build/BUILD.gn
+++ b/llvm/utils/gn/build/BUILD.gn
@@ -383,6 +383,7 @@ config("compiler_defaults") {
            "ubsan only supported on iOS/Clang, Linux/Clang, or macOS/Clang")
     cflags += [
       "-fsanitize=undefined",
+      "-fno-sanitize=vptr,function",
       "-fno-sanitize-recover=all",
     ]
     ldflags += [ "-fsanitize=undefined" ]


### PR DESCRIPTION
Matches CMake LLVM_UBSAN_FLAGS.
