### PR TITLE
[libc] Implement forward iterators for libc fixed_vector

### DIFF
--- a/libc/src/__support/fixedvector.h
+++ b/libc/src/__support/fixedvector.h
@@ -63,6 +63,10 @@ public:
     return reverse_iterator{&store[item_count]};
   }
   LIBC_INLINE constexpr reverse_iterator rend() { return store.rend(); }
+
+  using iterator = typename cpp::array<T, CAPACITY>::iterator;
+  LIBC_INLINE constexpr iterator begin() { return store.begin(); }
+  LIBC_INLINE constexpr iterator end() { return iterator{&store[item_count]}; }
 };
 
 } // namespace LIBC_NAMESPACE

--- a/libc/test/src/__support/CPP/array_test.cpp
+++ b/libc/test/src/__support/CPP/array_test.cpp
@@ -28,6 +28,11 @@ TEST(LlvmLibcArrayTest, Basic) {
   ASSERT_EQ(*(++it), 1);
   ASSERT_EQ(*(++it), 0);
 
+  auto forward_it = a.begin();
+  ASSERT_EQ(*forward_it, 0);
+  ASSERT_EQ(*(++forward_it), 1);
+  ASSERT_EQ(*(++forward_it), 2);
+
   for (int &x : a)
     ASSERT_GE(x, 0);
 }

--- a/libc/test/src/__support/CPP/array_test.cpp
+++ b/libc/test/src/__support/CPP/array_test.cpp
@@ -28,11 +28,6 @@ TEST(LlvmLibcArrayTest, Basic) {
   ASSERT_EQ(*(++it), 1);
   ASSERT_EQ(*(++it), 0);
 
-  auto forward_it = a.begin();
-  ASSERT_EQ(*forward_it, 0);
-  ASSERT_EQ(*(++forward_it), 1);
-  ASSERT_EQ(*(++forward_it), 2);
-
   for (int &x : a)
     ASSERT_GE(x, 0);
 }

--- a/libc/test/src/__support/fixedvector_test.cpp
+++ b/libc/test/src/__support/fixedvector_test.cpp
@@ -58,4 +58,14 @@ TEST(LlvmLibcFixedVectorTest, Iteration) {
   ASSERT_TRUE(++it == v.rend());
   for (auto it = v.rbegin(), e = v.rend(); it != e; ++it)
     ASSERT_GT(*it, -1);
+
+  auto forward_it = v.begin();
+  ASSERT_EQ(*forward_it, 0);
+  ASSERT_EQ(*++forward_it, 1);
+  ASSERT_EQ(*++forward_it, 2);
+  ASSERT_TRUE(++forward_it == v.end());
+  for (auto it = v.begin(), e = v.end(); it != e; ++it)
+    ASSERT_GT(*it, -1);
+  for (int &x : v)
+    ASSERT_GE(x, 0);
 }


### PR DESCRIPTION
- Implements forward iterators for `cpp::fixed_vector` to use in https://github.com/llvm/llvm-project/pull/92009