### PR TITLE
[IR] Fix IWYU violation

### DIFF
--- a/llvm/include/llvm/IR/GEPNoWrapFlags.h
+++ b/llvm/include/llvm/IR/GEPNoWrapFlags.h
@@ -13,6 +13,8 @@
 #ifndef LLVM_IR_GEPNOWRAPFLAGS_H
 #define LLVM_IR_GEPNOWRAPFLAGS_H
 
+#include <assert.h>
+
 namespace llvm {
 
 /// Represents flags for the getelementptr instruction/expression.


### PR DESCRIPTION
GEPNoWrapFlags.h calls `assert` creating a undeclared identifier error when running an Apple-stage2 build with LLVM_ENABLE_MODULES enabled.

resolves: rdar://129031201 