### PR TITLE
[ELF] Change build-id default to sha1

### DIFF
--- a/lld/ELF/Options.td
+++ b/lld/ELF/Options.td
@@ -57,7 +57,7 @@ def Bstatic: F<"Bstatic">, HelpText<"Do not link against shared libraries">;
 
 def build_id: J<"build-id=">, HelpText<"Generate build ID note">,
   MetaVarName<"[fast,md5,sha1,uuid,0x<hexstring>]">;
-def : F<"build-id">, Alias<build_id>, AliasArgs<["fast"]>, HelpText<"Alias for --build-id=fast">;
+def : F<"build-id">, Alias<build_id>, AliasArgs<["sha1"]>, HelpText<"Alias for --build-id=sha1">;
 
 defm check_sections: B<"check-sections",
     "Check section addresses for overlaps (default)",

--- a/lld/docs/ReleaseNotes.rst
+++ b/lld/docs/ReleaseNotes.rst
@@ -48,6 +48,9 @@ ELF Improvements
   and combine relocation sections if their relocated section group members are
   placed to the same output section.
   (`#94704 <https://github.com/llvm/llvm-project/pull/94704>`_)
+* ``--build-id`` now defaults to generating a 20-byte digest ("sha1") instead
+  of 8-byte ("fast"). This improves compatibility with RPM packaging tools.
+  (`#93943 <https://github.com/llvm/llvm-project/pull/93943>`_)
 
 Breaking changes
 ----------------

--- a/lld/docs/ld.lld.1
+++ b/lld/docs/ld.lld.1
@@ -119,7 +119,7 @@ are calculated from the object contents.
 is not intended to be cryptographically secure.
 .It Fl -build-id
 Synonym for
-.Fl -build-id Ns = Ns Cm fast .
+.Fl -build-id Ns = Ns Cm sha1 .
 .It Fl -call-graph-profile-sort Ns = Ns Ar algorithm
 .Ar algorithm
 may be:

--- a/lld/test/ELF/build-id.s
+++ b/lld/test/ELF/build-id.s
@@ -6,11 +6,12 @@
 # RUN: llvm-readobj -S %t2 | FileCheck -check-prefix=ALIGN %s
 
 # RUN: ld.lld --build-id %t -o %t2
-# RUN: llvm-objdump -s %t2 | FileCheck --check-prefix=DEFAULT %s
-# RUN: ld.lld --build-id=fast %t -o %t2
-# RUN: llvm-objdump -s %t2 | FileCheck --check-prefix=DEFAULT %s
+# RUN: llvm-objdump -s %t2 | FileCheck --check-prefix=SHA1 %s
 # RUN: ld.lld --build-id %t -o %t2 --threads=1
-# RUN: llvm-objdump -s %t2 | FileCheck --check-prefix=DEFAULT %s
+# RUN: llvm-objdump -s %t2 | FileCheck --check-prefix=SHA1 %s
+
+# RUN: ld.lld --build-id=fast %t -o %t2
+# RUN: llvm-objdump -s %t2 | FileCheck --check-prefix=FAST %s
 
 # RUN: ld.lld --build-id=md5 %t -o %t2
 # RUN: llvm-objdump -s %t2 | FileCheck --check-prefix=MD5 %s
@@ -41,7 +42,7 @@
 # RUN: ld.lld --build-id --build-id=none %t -o %t2
 # RUN: llvm-objdump -s %t2 | FileCheck --check-prefix=NONE %s
 # RUN: ld.lld --build-id=none --build-id %t -o %t2
-# RUN: llvm-objdump -s %t2 | FileCheck --check-prefix=DEFAULT %s
+# RUN: llvm-objdump -s %t2 | FileCheck --check-prefix=SHA1 %s
 
 .globl _start
 _start:
@@ -62,10 +63,10 @@ _start:
 # ALIGN-NEXT: Info:
 # ALIGN-NEXT: AddressAlignment: 4
 
-# DEFAULT:      Contents of section .note.test:
-# DEFAULT:      Contents of section .note.gnu.build-id:
-# DEFAULT-NEXT: 04000000 08000000 03000000 474e5500  ............GNU.
-# DEFAULT-NEXT: 630bc2f5 a2584763
+# FAST:      Contents of section .note.test:
+# FAST:      Contents of section .note.gnu.build-id:
+# FAST-NEXT: 04000000 08000000 03000000 474e5500  ............GNU.
+# FAST-NEXT: 630bc2f5 a2584763
 
 # MD5:      Contents of section .note.gnu.build-id:
 # MD5-NEXT: 04000000 10000000 03000000 474e5500  ............GNU.


### PR DESCRIPTION
The current default, build-id=fast, is only 8 bytes due to the usage of 64-bit XXH3. This is incompatible with RPM packaging tools which requires >=16 bytes [1].

In Clang the ENABLE_LINKER_BUILD_ID define makes it pass --build-id without a specific hash type. When also defaulting to LLD, this provides a pretty broken default out-of-box.

Using XXH3 was a considerable performance advantage when build-id was first implemented, because sha1 was really sha1 and rather slow. Nowadays sha1 is just 160-bit BLAKE3 which is decently fast and not cryptographically broken, so it should be a good default.

Note that the default remains "fast" for wasm because sha1 for wasm is still real sha1.

Close https://github.com/llvm/llvm-project/issues/43483.

[1]: https://github.com/rpm-software-management/rpm/blob/b7d427728b8ba8734ba47d51849a5736bdd727cd/build/files.c#L1883