### PR TITLE
[RISCV] Add Smcsrind and Sscsrind extension

### DIFF
--- a/clang/test/Preprocessor/riscv-target-features.c
+++ b/clang/test/Preprocessor/riscv-target-features.c
@@ -28,6 +28,7 @@
 // CHECK-NOT: __riscv_shvstvecd {{.*$}}
 // CHECK-NOT: __riscv_smaia {{.*$}}
 // CHECK-NOT: __riscv_smcdeleg {{.*$}}
+// CHECK-NOT: __riscv_smcsrind {{.*$}}
 // CHECK-NOT: __riscv_smepmp {{.*$}}
 // CHECK-NOT: __riscv_smstateen {{.*$}}
 // CHECK-NOT: __riscv_ssaia {{.*$}}
@@ -35,6 +36,7 @@
 // CHECK-NOT: __riscv_ssccptr {{.*$}}
 // CHECK-NOT: __riscv_sscofpmf {{.*$}}
 // CHECK-NOT: __riscv_sscounterenw {{.*$}}
+// CHECK-NOT: __riscv_sscsrind {{.*$}}
 // CHECK-NOT: __riscv_ssstateen {{.*$}}
 // CHECK-NOT: __riscv_ssstrict {{.*$}}
 // CHECK-NOT: __riscv_sstc {{.*$}}
@@ -1402,6 +1404,22 @@
 // RUN:   -march=rv64issaia1p0 -E -dM %s \
 // RUN:   -o - | FileCheck --check-prefix=CHECK-SSAIA-EXT %s
 // CHECK-SSAIA-EXT: __riscv_ssaia  1000000{{$}}
+
+// RUN: %clang --target=riscv32 \
+// RUN:   -march=rv32ismcsrind1p0 -E -dM %s \
+// RUN:   -o - | FileCheck --check-prefix=CHECK-SMCSRIND-EXT %s
+// RUN: %clang --target=riscv64 \
+// RUN:   -march=rv64ismcsrind1p0 -E -dM %s \
+// RUN:   -o - | FileCheck --check-prefix=CHECK-SMCSRIND-EXT %s
+// CHECK-SMCSRIND-EXT: __riscv_smcsrind  1000000{{$}}
+
+// RUN: %clang --target=riscv32 \
+// RUN:   -march=rv32isscsrind1p0 -E -dM %s \
+// RUN:   -o - | FileCheck --check-prefix=CHECK-SSCSRIND-EXT %s
+// RUN: %clang --target=riscv64 \
+// RUN:   -march=rv64isscsrind1p0 -E -dM %s \
+// RUN:   -o - | FileCheck --check-prefix=CHECK-SSCSRIND-EXT %s
+// CHECK-SSCSRIND-EXT: __riscv_sscsrind  1000000{{$}}
 
 // RUN: %clang --target=riscv32 \
 // RUN:   -march=rv32ismcdeleg1p0 -E -dM %s \

--- a/llvm/docs/RISCVUsage.rst
+++ b/llvm/docs/RISCVUsage.rst
@@ -100,6 +100,7 @@ on support follow.
      ``Shvstvecd``     Assembly Support (`See note <#riscv-profiles-extensions-note>`__)
      ``Smaia``         Supported
      ``Smcdeleg``      Supported
+     ``Smcsrind``      Supported
      ``Smepmp``        Supported
      ``Smstateen``     Assembly Support
      ``Ssaia``         Supported
@@ -107,6 +108,7 @@ on support follow.
      ``Ssccptr``       Assembly Support (`See note <#riscv-profiles-extensions-note>`__)
      ``Sscofpmf``      Assembly Support
      ``Sscounterenw``  Assembly Support (`See note <#riscv-profiles-extensions-note>`__)
+     ``Sscsrind``      Supported
      ``Ssstateen``     Assembly Support (`See note <#riscv-profiles-extensions-note>`__)
      ``Ssstrict``      Assembly Support (`See note <#riscv-profiles-extensions-note>`__)
      ``Sstc``          Assembly Support

--- a/llvm/docs/ReleaseNotes.rst
+++ b/llvm/docs/ReleaseNotes.rst
@@ -158,6 +158,7 @@ Changes to the RISC-V Backend
 * Zabha is no longer experimental.
 * B (the collection of the Zba, Zbb, Zbs extensions) is supported.
 * Added smcdeleg and ssccfg extensions to -march.
+* Added smcsrind and sscsrind extensions to -march. CSR names for them were already supported.
 
 Changes to the WebAssembly Backend
 ----------------------------------

--- a/llvm/docs/ReleaseNotes.rst
+++ b/llvm/docs/ReleaseNotes.rst
@@ -157,8 +157,7 @@ Changes to the RISC-V Backend
 * Processors that enable post reg-alloc scheduling (PostMachineScheduler) by default should use the `UsePostRAScheduler` subtarget feature. Setting `PostRAScheduler = 1` in the scheduler model will have no effect on the enabling of the PostMachineScheduler.
 * Zabha is no longer experimental.
 * B (the collection of the Zba, Zbb, Zbs extensions) is supported.
-* Added smcdeleg and ssccfg extensions to -march.
-* Added smcsrind and sscsrind extensions to -march. CSR names for them were already supported.
+* Added smcdeleg, ssccfg, smcsrind, and sscsrind extensions to -march.
 
 Changes to the WebAssembly Backend
 ----------------------------------

--- a/llvm/lib/Target/RISCV/RISCVFeatures.td
+++ b/llvm/lib/Target/RISCV/RISCVFeatures.td
@@ -855,6 +855,13 @@ def FeatureStdExtSsaia
                      "'Ssaia' (Advanced Interrupt Architecture Supervisor "
                      "Level)">;
 
+def FeatureStdExtSmcsrind
+    : RISCVExtension<"smcsrind", 1, 0,
+                     "'Smcsrind' (Indirect CSR Access Machine Level)">;
+def FeatureStdExtSscsrind
+    : RISCVExtension<"sscsrind", 1, 0,
+                     "'Sscsrind' (Indirect CSR Access Supervisor Level)">;
+
 def FeatureStdExtSmepmp
     : RISCVExtension<"smepmp", 1, 0,
                      "'Smepmp' (Enhanced Physical Memory Protection)">;

--- a/llvm/lib/Target/RISCV/RISCVSystemOperands.td
+++ b/llvm/lib/Target/RISCV/RISCVSystemOperands.td
@@ -382,6 +382,12 @@ def SEED : SysReg<"seed", 0x015>;
 // Machine-level CSRs
 def : SysReg<"miselect", 0x350>;
 def : SysReg<"mireg", 0x351>;
+foreach i = 2...3 in {
+  def : SysReg<"mireg"#i, !add(0x350, i)>;
+}
+foreach i = 4...6 in {
+  def : SysReg<"mireg"#i, !add(0x351, i)>;
+}
 def : SysReg<"mtopei", 0x35C>;
 def : SysReg<"mtopi", 0xFB0>;
 def : SysReg<"mvien", 0x308>;
@@ -397,6 +403,12 @@ def : SysReg<"miph", 0x354>;
 // Supervisor-level CSRs
 def : SysReg<"siselect", 0x150>;
 def : SysReg<"sireg", 0x151>;
+foreach i = 2...3 in {
+  def : SysReg<"sireg"#i, !add(0x150, i)>;
+}
+foreach i = 4...6 in {
+  def : SysReg<"sireg"#i, !add(0x151, i)>;
+}
 def : SysReg<"stopei", 0x15C>;
 def : SysReg<"stopi", 0xDB0>;
 let isRV32Only = 1 in {
@@ -411,6 +423,12 @@ def : SysReg<"hviprio1", 0x646>;
 def : SysReg<"hviprio2", 0x647>;
 def : SysReg<"vsiselect", 0x250>;
 def : SysReg<"vsireg", 0x251>;
+foreach i = 2...3 in {
+  def : SysReg<"vsireg"#i, !add(0x250, i)>;
+}
+foreach i = 4...6 in {
+  def : SysReg<"vsireg"#i, !add(0x251, i)>;
+}
 def : SysReg<"vstopei", 0x25C>;
 def : SysReg<"vstopi", 0xEB0>;
 let isRV32Only = 1 in {

--- a/llvm/test/CodeGen/RISCV/attributes.ll
+++ b/llvm/test/CodeGen/RISCV/attributes.ll
@@ -112,6 +112,8 @@
 ; RUN: llc -mtriple=riscv32 -mattr=+zcmop %s -o - | FileCheck --check-prefix=RV32ZCMOP %s
 ; RUN: llc -mtriple=riscv32 -mattr=+smaia %s -o - | FileCheck --check-prefixes=CHECK,RV32SMAIA %s
 ; RUN: llc -mtriple=riscv32 -mattr=+ssaia %s -o - | FileCheck --check-prefixes=CHECK,RV32SSAIA %s
+; RUN: llc -mtriple=riscv32 -mattr=+smcsrind %s -o - | FileCheck --check-prefixes=CHECK,RV32SMCSRIND %s
+; RUN: llc -mtriple=riscv32 -mattr=+sscsrind %s -o - | FileCheck --check-prefixes=CHECK,RV32SSCSRIND %s
 ; RUN: llc -mtriple=riscv32 -mattr=+smcdeleg %s -o - | FileCheck --check-prefixes=CHECK,RV32SMCDELEG %s
 ; RUN: llc -mtriple=riscv32 -mattr=+smepmp %s -o - | FileCheck --check-prefixes=CHECK,RV32SMEPMP %s
 ; RUN: llc -mtriple=riscv32 -mattr=+experimental-zfbfmin %s -o - | FileCheck --check-prefixes=CHECK,RV32ZFBFMIN %s
@@ -248,6 +250,8 @@
 ; RUN: llc -mtriple=riscv64 -mattr=+zcmop %s -o - | FileCheck --check-prefix=RV64ZCMOP %s
 ; RUN: llc -mtriple=riscv64 -mattr=+smaia %s -o - | FileCheck --check-prefixes=CHECK,RV64SMAIA %s
 ; RUN: llc -mtriple=riscv64 -mattr=+ssaia %s -o - | FileCheck --check-prefixes=CHECK,RV64SSAIA %s
+; RUN: llc -mtriple=riscv64 -mattr=+smcsrind %s -o - | FileCheck --check-prefixes=CHECK,RV64SMCSRIND %s
+; RUN: llc -mtriple=riscv64 -mattr=+sscsrind %s -o - | FileCheck --check-prefixes=CHECK,RV64SSCSRIND %s
 ; RUN: llc -mtriple=riscv64 -mattr=+smcdeleg %s -o - | FileCheck --check-prefixes=CHECK,RV64SMCDELEG %s
 ; RUN: llc -mtriple=riscv64 -mattr=+smepmp %s -o - | FileCheck --check-prefixes=CHECK,RV64SMEPMP %s
 ; RUN: llc -mtriple=riscv64 -mattr=+experimental-zfbfmin %s -o - | FileCheck --check-prefixes=CHECK,RV64ZFBFMIN %s
@@ -390,6 +394,8 @@
 ; RV32ZCMOP: .attribute 5, "rv32i2p1_zca1p0_zcmop1p0"
 ; RV32SMAIA: .attribute 5, "rv32i2p1_smaia1p0"
 ; RV32SSAIA: .attribute 5, "rv32i2p1_ssaia1p0"
+; RV32SMCSRIND: .attribute 5, "rv32i2p1_smcsrind1p0"
+; RV32SSCSRIND: .attribute 5, "rv32i2p1_sscsrind1p0"
 ; RV32SMCDELEG: .attribute 5, "rv32i2p1_smcdeleg1p0"
 ; RV32SMEPMP: .attribute 5, "rv32i2p1_smepmp1p0"
 ; RV32ZFBFMIN: .attribute 5, "rv32i2p1_f2p2_zicsr2p0_zfbfmin1p0"
@@ -525,6 +531,8 @@
 ; RV64ZCMOP: .attribute 5, "rv64i2p1_zca1p0_zcmop1p0"
 ; RV64SMAIA: .attribute 5, "rv64i2p1_smaia1p0"
 ; RV64SSAIA: .attribute 5, "rv64i2p1_ssaia1p0"
+; RV64SMCSRIND: .attribute 5, "rv64i2p1_smcsrind1p0"
+; RV64SSCSRIND: .attribute 5, "rv64i2p1_sscsrind1p0"
 ; RV64SMCDELEG: .attribute 5, "rv64i2p1_smcdeleg1p0"
 ; RV64SMEPMP: .attribute 5, "rv64i2p1_smepmp1p0"
 ; RV64ZFBFMIN: .attribute 5, "rv64i2p1_f2p2_zicsr2p0_zfbfmin1p0"

--- a/llvm/test/MC/RISCV/attribute-arch.s
+++ b/llvm/test/MC/RISCV/attribute-arch.s
@@ -315,6 +315,12 @@
 .attribute arch, "rv32i_ssaia1p0"
 # CHECK: attribute      5, "rv32i2p1_ssaia1p0"
 
+.attribute arch, "rv32i_smcsrind1p0"
+# CHECK: attribute      5, "rv32i2p1_smcsrind1p0"
+
+.attribute arch, "rv32i_sscsrind1p0"
+# CHECK: attribute      5, "rv32i2p1_sscsrind1p0"
+
 .attribute arch, "rv32i_smcdeleg1p0"
 # CHECK: attribute      5, "rv32i2p1_smcdeleg1p0"
 

--- a/llvm/test/MC/RISCV/hypervisor-csr-names.s
+++ b/llvm/test/MC/RISCV/hypervisor-csr-names.s
@@ -536,6 +536,76 @@ csrrs t1, vsireg, zero
 # uimm12
 csrrs t2, 0x251, zero
 
+# vsireg2
+# name
+# CHECK-INST: csrrs t1, vsireg2, zero
+# CHECK-ENC: encoding: [0x73,0x23,0x20,0x25]
+# CHECK-INST-ALIAS: csrr t1, vsireg2
+# uimm12
+# CHECK-INST: csrrs t2, vsireg2, zero
+# CHECK-ENC: encoding: [0xf3,0x23,0x20,0x25]
+# CHECK-INST-ALIAS: csrr t2, vsireg2
+# name
+csrrs t1, vsireg2, zero
+# uimm12
+csrrs t2, 0x252, zero
+
+# vsireg3
+# name
+# CHECK-INST: csrrs t1, vsireg3, zero
+# CHECK-ENC: encoding: [0x73,0x23,0x30,0x25]
+# CHECK-INST-ALIAS: csrr t1, vsireg3
+# uimm12
+# CHECK-INST: csrrs t2, vsireg3, zero
+# CHECK-ENC: encoding: [0xf3,0x23,0x30,0x25]
+# CHECK-INST-ALIAS: csrr t2, vsireg3
+# name
+csrrs t1, vsireg3, zero
+# uimm12
+csrrs t2, 0x253, zero
+
+# vsireg4
+# name
+# CHECK-INST: csrrs t1, vsireg4, zero
+# CHECK-ENC: encoding: [0x73,0x23,0x50,0x25]
+# CHECK-INST-ALIAS: csrr t1, vsireg4
+# uimm12
+# CHECK-INST: csrrs t2, vsireg4, zero
+# CHECK-ENC: encoding: [0xf3,0x23,0x50,0x25]
+# CHECK-INST-ALIAS: csrr t2, vsireg4
+# name
+csrrs t1, vsireg4, zero
+# uimm12
+csrrs t2, 0x255, zero
+
+# vsireg5
+# name
+# CHECK-INST: csrrs t1, vsireg5, zero
+# CHECK-ENC: encoding: [0x73,0x23,0x60,0x25]
+# CHECK-INST-ALIAS: csrr t1, vsireg5
+# uimm12
+# CHECK-INST: csrrs t2, vsireg5, zero
+# CHECK-ENC: encoding: [0xf3,0x23,0x60,0x25]
+# CHECK-INST-ALIAS: csrr t2, vsireg5
+# name
+csrrs t1, vsireg5, zero
+# uimm12
+csrrs t2, 0x256, zero
+
+# vsireg6
+# name
+# CHECK-INST: csrrs t1, vsireg6, zero
+# CHECK-ENC: encoding: [0x73,0x23,0x70,0x25]
+# CHECK-INST-ALIAS: csrr t1, vsireg6
+# uimm12
+# CHECK-INST: csrrs t2, vsireg6, zero
+# CHECK-ENC: encoding: [0xf3,0x23,0x70,0x25]
+# CHECK-INST-ALIAS: csrr t2, vsireg6
+# name
+csrrs t1, vsireg6, zero
+# uimm12
+csrrs t2, 0x257, zero
+
 # vstopei
 # name
 # CHECK-INST: csrrs t1, vstopei, zero

--- a/llvm/test/MC/RISCV/machine-csr-names.s
+++ b/llvm/test/MC/RISCV/machine-csr-names.s
@@ -2443,6 +2443,76 @@ csrrs t1, mireg, zero
 # uimm12
 csrrs t2, 0x351, zero
 
+# mireg2
+# name
+# CHECK-INST: csrrs t1, mireg2, zero
+# CHECK-ENC: encoding: [0x73,0x23,0x20,0x35]
+# CHECK-INST-ALIAS: csrr t1, mireg2
+# uimm12
+# CHECK-INST: csrrs t2, mireg2, zero
+# CHECK-ENC: encoding: [0xf3,0x23,0x20,0x35]
+# CHECK-INST-ALIAS: csrr t2, mireg2
+# name
+csrrs t1, mireg2, zero
+# uimm12
+csrrs t2, 0x352, zero
+
+# mireg3
+# name
+# CHECK-INST: csrrs t1, mireg3, zero
+# CHECK-ENC: encoding: [0x73,0x23,0x30,0x35]
+# CHECK-INST-ALIAS: csrr t1, mireg3
+# uimm12
+# CHECK-INST: csrrs t2, mireg3, zero
+# CHECK-ENC: encoding: [0xf3,0x23,0x30,0x35]
+# CHECK-INST-ALIAS: csrr t2, mireg3
+# name
+csrrs t1, mireg3, zero
+# uimm12
+csrrs t2, 0x353, zero
+
+# mireg4
+# name
+# CHECK-INST: csrrs t1, mireg4, zero
+# CHECK-ENC: encoding: [0x73,0x23,0x50,0x35]
+# CHECK-INST-ALIAS: csrr t1, mireg4
+# uimm12
+# CHECK-INST: csrrs t2, mireg4, zero
+# CHECK-ENC: encoding: [0xf3,0x23,0x50,0x35]
+# CHECK-INST-ALIAS: csrr t2, mireg4
+# name
+csrrs t1, mireg4, zero
+# uimm12
+csrrs t2, 0x355, zero
+
+# mireg5
+# name
+# CHECK-INST: csrrs t1, mireg5, zero
+# CHECK-ENC: encoding: [0x73,0x23,0x60,0x35]
+# CHECK-INST-ALIAS: csrr t1, mireg5
+# uimm12
+# CHECK-INST: csrrs t2, mireg5, zero
+# CHECK-ENC: encoding: [0xf3,0x23,0x60,0x35]
+# CHECK-INST-ALIAS: csrr t2, mireg5
+# name
+csrrs t1, mireg5, zero
+# uimm12
+csrrs t2, 0x356, zero
+
+# mireg6
+# name
+# CHECK-INST: csrrs t1, mireg6, zero
+# CHECK-ENC: encoding: [0x73,0x23,0x70,0x35]
+# CHECK-INST-ALIAS: csrr t1, mireg6
+# uimm12
+# CHECK-INST: csrrs t2, mireg6, zero
+# CHECK-ENC: encoding: [0xf3,0x23,0x70,0x35]
+# CHECK-INST-ALIAS: csrr t2, mireg6
+# name
+csrrs t1, mireg6, zero
+# uimm12
+csrrs t2, 0x357, zero
+
 # mtopei
 # name
 # CHECK-INST: csrrs t1, mtopei, zero

--- a/llvm/test/MC/RISCV/supervisor-csr-names.s
+++ b/llvm/test/MC/RISCV/supervisor-csr-names.s
@@ -342,6 +342,76 @@ csrrs t1, sireg, zero
 # uimm12
 csrrs t2, 0x151, zero
 
+# sireg2
+# name
+# CHECK-INST: csrrs t1, sireg2, zero
+# CHECK-ENC: encoding: [0x73,0x23,0x20,0x15]
+# CHECK-INST-ALIAS: csrr t1, sireg2
+# uimm12
+# CHECK-INST: csrrs t2, sireg2, zero
+# CHECK-ENC: encoding: [0xf3,0x23,0x20,0x15]
+# CHECK-INST-ALIAS: csrr t2, sireg2
+# name
+csrrs t1, sireg2, zero
+# uimm12
+csrrs t2, 0x152, zero
+
+# sireg3
+# name
+# CHECK-INST: csrrs t1, sireg3, zero
+# CHECK-ENC: encoding: [0x73,0x23,0x30,0x15]
+# CHECK-INST-ALIAS: csrr t1, sireg3
+# uimm12
+# CHECK-INST: csrrs t2, sireg3, zero
+# CHECK-ENC: encoding: [0xf3,0x23,0x30,0x15]
+# CHECK-INST-ALIAS: csrr t2, sireg3
+# name
+csrrs t1, sireg3, zero
+# uimm12
+csrrs t2, 0x153, zero
+
+# sireg4
+# name
+# CHECK-INST: csrrs t1, sireg4, zero
+# CHECK-ENC: encoding: [0x73,0x23,0x50,0x15]
+# CHECK-INST-ALIAS: csrr t1, sireg4
+# uimm12
+# CHECK-INST: csrrs t2, sireg4, zero
+# CHECK-ENC: encoding: [0xf3,0x23,0x50,0x15]
+# CHECK-INST-ALIAS: csrr t2, sireg4
+# name
+csrrs t1, sireg4, zero
+# uimm12
+csrrs t2, 0x155, zero
+
+# sireg5
+# name
+# CHECK-INST: csrrs t1, sireg5, zero
+# CHECK-ENC: encoding: [0x73,0x23,0x60,0x15]
+# CHECK-INST-ALIAS: csrr t1, sireg5
+# uimm12
+# CHECK-INST: csrrs t2, sireg5, zero
+# CHECK-ENC: encoding: [0xf3,0x23,0x60,0x15]
+# CHECK-INST-ALIAS: csrr t2, sireg5
+# name
+csrrs t1, sireg5, zero
+# uimm12
+csrrs t2, 0x156, zero
+
+# sireg6
+# name
+# CHECK-INST: csrrs t1, sireg6, zero
+# CHECK-ENC: encoding: [0x73,0x23,0x70,0x15]
+# CHECK-INST-ALIAS: csrr t1, sireg6
+# uimm12
+# CHECK-INST: csrrs t2, sireg6, zero
+# CHECK-ENC: encoding: [0xf3,0x23,0x70,0x15]
+# CHECK-INST-ALIAS: csrr t2, sireg6
+# name
+csrrs t1, sireg6, zero
+# uimm12
+csrrs t2, 0x157, zero
+
 # stopei
 # name
 # CHECK-INST: csrrs t1, stopei, zero

--- a/llvm/unittests/TargetParser/RISCVISAInfoTest.cpp
+++ b/llvm/unittests/TargetParser/RISCVISAInfoTest.cpp
@@ -1010,6 +1010,7 @@ R"(All available -march extensions for RISC-V
     shvstvecd            1.0
     smaia                1.0
     smcdeleg             1.0
+    smcsrind             1.0
     smepmp               1.0
     smstateen            1.0
     ssaia                1.0
@@ -1017,6 +1018,7 @@ R"(All available -march extensions for RISC-V
     ssccptr              1.0
     sscofpmf             1.0
     sscounterenw         1.0
+    sscsrind             1.0
     ssstateen            1.0
     ssstrict             1.0
     sstc                 1.0


### PR DESCRIPTION
Specification link: https://github.com/riscv/riscv-isa-manual/blob/main/src/indirect-csr.adoc


Some CSRs (`*ireg` and `*iselect`) in Smcsrind/Sscsrind extensions are originally defined as part of the Smaia/Ssaia extensions and are already supported in LLVM. The missing CSRs (`*ireg2` to `*ireg6` for `m`, `s`, and `vs`) are added in this PR.