### PR TITLE
[flang] Fix exec.f90 test on LIT integrated shell

### DIFF
--- a/flang/test/Driver/exec.f90
+++ b/flang/test/Driver/exec.f90
@@ -2,7 +2,7 @@
 ! Verify that flang can correctly build executables.
 
 ! RUN: %flang %s -o %t
-! RUN: LD_LIBRARY_PATH="$LD_LIBRARY_PATH:%llvmshlibdir" %t | FileCheck %s
+! RUN: env LD_LIBRARY_PATH="$LD_LIBRARY_PATH:%llvmshlibdir" %t | FileCheck %s
 ! RUN: rm -f %t
 
 ! CHECK: Hello, World!


### PR DESCRIPTION
The exec.f90 test sets an environment variable for a specific command directly
rather than using env, which doesn't work on shells that don't support this
syntax, most notably the LIT integrated shell. This patch simply adds env so
that this works on the integrated shell.
