### PR TITLE
[ADT] Remove llvm::erase_value

### DIFF
--- a/llvm/include/llvm/ADT/STLExtras.h
+++ b/llvm/include/llvm/ADT/STLExtras.h
@@ -2060,12 +2060,6 @@ void erase(Container &C, ValueType V) {
   C.erase(std::remove(C.begin(), C.end(), V), C.end());
 }
 
-template <typename Container, typename ValueType>
-LLVM_DEPRECATED("Use erase instead", "erase")
-void erase_value(Container &C, ValueType V) {
-  erase(C, V);
-}
-
 /// Wrapper function to append range `R` to container `C`.
 ///
 /// C.insert(C.end(), R.begin(), R.end());


### PR DESCRIPTION
The function has been deprecated since:

  commit f9306f6de3bd19a2dcacd64566852a5f92c86e77
  Author: Kazu Hirata <kazu@google.com>
  Date:   Tue Oct 24 23:03:13 2023 -0700