### PR TITLE
[msan] Change #ifdef SANITIZER_PPC to #if

### DIFF
--- a/compiler-rt/lib/msan/msan.cpp
+++ b/compiler-rt/lib/msan/msan.cpp
@@ -104,7 +104,7 @@ int msan_report_count = 0;
 // in some configurations (e.g., "relocation R_X86_64_PC32 out of range:
 // ... is not in [-2147483648, 2147483647]; references section '.bss'").
 // We use kNumStackOriginDescrs * (sizeof(char*) + sizeof(uptr)) == 64MB.
-#ifdef SANITIZER_PPC
+#if SANITIZER_PPC
 // soft_rss_limit test (release_origin.c) fails on PPC if kNumStackOriginDescrs
 // is too high
 static const uptr kNumStackOriginDescrs = 1 * 1024 * 1024;


### PR DESCRIPTION
https://github.com/llvm/llvm-project/commit/0e96eebc7f681a7ce41f35909e609c7c61a11455 accidentally turned the prior patch (https://github.com/llvm/llvm-project/commit/57a507930b50c445140feb68bffe1c21af53319e) into a no-op because this macro is always defined (as either 1 or 0). This patch changes it to correctly use #if.