### PR TITLE
fix(clang/**.py): fix comparison to None

### DIFF
--- a/clang/docs/DebuggingCoroutines.rst
+++ b/clang/docs/DebuggingCoroutines.rst
@@ -513,7 +513,7 @@ So we can use the ``continuation`` field to construct the asynchronous stack:
           self.coro_frame = coro_frame
           self.resume_func = dereference(self.coro_frame.resume_addr)
           self.resume_func_block = gdb.block_for_pc(self.resume_func)
-          if self.resume_func_block == None:
+          if self.resume_func_block is None:
               raise Exception('Not stackless coroutine.')
           self.line_info = gdb.find_pc_line(self.resume_func)
 
@@ -543,8 +543,8 @@ So we can use the ``continuation`` field to construct the asynchronous stack:
           self.function_name = f
 
       def __str__(self, shift = 2):
-          addr = "" if self.address() == None else '%#x' % self.address() + " in "
-          location = "" if self.filename() == None else " at " + self.filename() + ":" + str(self.line())
+          addr = "" if self.address() is None else '%#x' % self.address() + " in "
+          location = "" if self.filename() is None else " at " + self.filename() + ":" + str(self.line())
           return addr + self.function() + " " + str([str(args) for args in self.frame_args()]) + location
 
   class CoroutineFilter:
@@ -598,7 +598,7 @@ So we can use the ``continuation`` field to construct the asynchronous stack:
 
           addr = int(argv[0], 16)
           block = gdb.block_for_pc(long(cast_addr2long_pointer(addr).dereference()))
-          if block == None:
+          if block is None:
               print "block " + str(addr) + "  is none."
               return
 

--- a/clang/tools/include-mapping/gen_std.py
+++ b/clang/tools/include-mapping/gen_std.py
@@ -215,7 +215,7 @@ def GetCCompatibilitySymbols(symbol):
     # Introduce two more entries, both in the global namespace, one using the
     # C++-compat header and another using the C header.
     results = []
-    if symbol.namespace != None:
+    if symbol.namespace is not None:
         # avoid printing duplicated entries, for C macros!
         results.append(cppreference_parser.Symbol(symbol.name, None, [header]))
     c_header = "<" + header[2:-1] + ".h>"  # <cstdio> => <stdio.h>

--- a/clang/utils/check_cfc/obj_diff.py
+++ b/clang/utils/check_cfc/obj_diff.py
@@ -57,7 +57,7 @@ def first_diff(a, b, fromfile, tofile):
             first_diff_idx = idx
             break
 
-    if first_diff_idx == None:
+    if first_diff_idx is None:
         # No difference
         return None
 

--- a/clang/utils/module-deps-to-rsp.py
+++ b/clang/utils/module-deps-to-rsp.py
@@ -74,7 +74,7 @@ def main():
 
         if args.module_name:
             cmd = findModule(args.module_name, full_deps)["command-line"]
-        elif args.tu_index != None:
+        elif args.tu_index is not None:
             tu = full_deps.translation_units[args.tu_index]
             cmd = tu["commands"][args.tu_cmd_index]["command-line"]
 


### PR DESCRIPTION
from PEP8 (https://peps.python.org/pep-0008/#programming-recommendations):

> Comparisons to singletons like None should always be done with is or is not, never the equality operators.