### PR TITLE
[lldb] fix(lldb/**.py): fix comparison to None

### DIFF
--- a/lldb/bindings/interface/SBBreakpointDocstrings.i
+++ b/lldb/bindings/interface/SBBreakpointDocstrings.i
@@ -39,7 +39,7 @@ TestBreakpointIgnoreCount.py),::
         #lldbutil.print_stacktraces(process)
         from lldbutil import get_stopped_thread
         thread = get_stopped_thread(process, lldb.eStopReasonBreakpoint)
-        self.assertTrue(thread != None, 'There should be a thread stopped due to breakpoint')
+        self.assertTrue(thread is not None, 'There should be a thread stopped due to breakpoint')
         frame0 = thread.GetFrameAtIndex(0)
         frame1 = thread.GetFrameAtIndex(1)
         frame2 = thread.GetFrameAtIndex(2)

--- a/lldb/bindings/interface/SBDataExtensions.i
+++ b/lldb/bindings/interface/SBDataExtensions.i
@@ -40,19 +40,19 @@ STRING_EXTENSION_OUTSIDE(SBData)
                 lldbtarget = lldbdict['target']
             else:
                 lldbtarget = None
-            if target == None and lldbtarget != None and lldbtarget.IsValid():
+            if target is None and lldbtarget is not None and lldbtarget.IsValid():
                 target = lldbtarget
-            if ptr_size == None:
+            if ptr_size is None:
                 if target and target.IsValid():
                     ptr_size = target.addr_size
                 else:
                     ptr_size = 8
-            if endian == None:
+            if endian is None:
                 if target and target.IsValid():
                     endian = target.byte_order
                 else:
                     endian = lldbdict['eByteOrderLittle']
-            if size == None:
+            if size is None:
                 if value > 2147483647:
                     size = 8
                 elif value < -2147483648:

--- a/lldb/docs/use/python.rst
+++ b/lldb/docs/use/python.rst
@@ -75,13 +75,13 @@ later explanations:
    12:     if root_word == word:
    13:         return cur_path
    14:     elif word < root_word:
-   15:         if left_child_ptr.GetValue() == None:
+   15:         if left_child_ptr.GetValue() is None:
    16:             return ""
    17:         else:
    18:             cur_path = cur_path + "L"
    19:             return DFS (left_child_ptr, word, cur_path)
    20:     else:
-   21:         if right_child_ptr.GetValue() == None:
+   21:         if right_child_ptr.GetValue() is None:
    22:             return ""
    23:         else:
    24:             cur_path = cur_path + "R"

--- a/lldb/examples/python/armv7_cortex_m_target_defintion.py
+++ b/lldb/examples/python/armv7_cortex_m_target_defintion.py
@@ -222,7 +222,7 @@ g_target_definition = None
 
 def get_target_definition():
     global g_target_definition
-    if g_target_definition == None:
+    if g_target_definition is None:
         g_target_definition = {}
         offset = 0
         for reg_info in armv7_register_infos:

--- a/lldb/packages/Python/lldbsuite/test/dotest.py
+++ b/lldb/packages/Python/lldbsuite/test/dotest.py
@@ -47,7 +47,7 @@ from ..support import seven
 
 def is_exe(fpath):
     """Returns true if fpath is an executable."""
-    if fpath == None:
+    if fpath is None:
         return False
     if sys.platform == "win32":
         if not fpath.endswith(".exe"):

--- a/lldb/packages/Python/lldbsuite/test/lldbtest.py
+++ b/lldb/packages/Python/lldbsuite/test/lldbtest.py
@@ -229,7 +229,7 @@ def pointer_size():
 
 def is_exe(fpath):
     """Returns true if fpath is an executable."""
-    if fpath == None:
+    if fpath is None:
         return False
     if sys.platform == "win32":
         if not fpath.endswith(".exe"):
@@ -2191,7 +2191,7 @@ class TestBase(Base, metaclass=LLDBTestCaseFactory):
         if num_matches == 0:
             compare_string = str_input
         else:
-            if common_match != None and len(common_match) > 0:
+            if common_match is not None and len(common_match) > 0:
                 compare_string = str_input + common_match
             else:
                 compare_string = ""
@@ -2552,7 +2552,7 @@ FileCheck output:
         if obj.Success():
             self.fail(self._formatMessage(msg, "Error not in a fail state"))
 
-        if error_str == None:
+        if error_str is None:
             return
 
         error = obj.GetCString()

--- a/lldb/packages/Python/lldbsuite/test/lldbutil.py
+++ b/lldb/packages/Python/lldbsuite/test/lldbutil.py
@@ -1594,11 +1594,11 @@ def set_actions_for_signal(
 ):
     return_obj = lldb.SBCommandReturnObject()
     command = "process handle {0}".format(signal_name)
-    if pass_action != None:
+    if pass_action is not None:
         command += " -p {0}".format(pass_action)
-    if stop_action != None:
+    if stop_action is not None:
         command += " -s {0}".format(stop_action)
-    if notify_action != None:
+    if notify_action is not None:
         command += " -n {0}".format(notify_action)
 
     testcase.dbg.GetCommandInterpreter().HandleCommand(command, return_obj)

--- a/lldb/packages/Python/lldbsuite/test/tools/intelpt/intelpt_testcase.py
+++ b/lldb/packages/Python/lldbsuite/test/tools/intelpt/intelpt_testcase.py
@@ -134,7 +134,7 @@ class TraceIntelPTTestCaseBase(TestBase):
             self.assertSBError(trace.Start(configuration), error=error)
         else:
             command = "process trace start"
-            if processBufferSizeLimit != None:
+            if processBufferSizeLimit is not None:
                 command += " -l " + str(processBufferSizeLimit)
             if enableTsc:
                 command += " --tsc"

--- a/lldb/test/API/functionalities/breakpoint/address_breakpoints/TestBadAddressBreakpoints.py
+++ b/lldb/test/API/functionalities/breakpoint/address_breakpoints/TestBadAddressBreakpoints.py
@@ -32,7 +32,7 @@ class BadAddressBreakpointTestCase(TestBase):
         for region_idx in range(regions.GetSize()):
             region = lldb.SBMemoryRegionInfo()
             regions.GetMemoryRegionAtIndex(region_idx, region)
-            if illegal_address == None or region.GetRegionEnd() > illegal_address:
+            if illegal_address is None or region.GetRegionEnd() > illegal_address:
                 illegal_address = region.GetRegionEnd()
 
         if illegal_address is not None:

--- a/lldb/test/API/functionalities/step_scripted/TestStepScripted.py
+++ b/lldb/test/API/functionalities/step_scripted/TestStepScripted.py
@@ -126,7 +126,7 @@ class StepScriptedTestCase(TestBase):
         cmd = "thread step-scripted -C Steps.StepReportsStopOthers -k token -v %s" % (
             token
         )
-        if run_mode != None:
+        if run_mode is not None:
             cmd = cmd + " --run-mode %s" % (run_mode)
         if self.TraceOn():
             print(cmd)

--- a/lldb/test/API/functionalities/stop-on-sharedlibrary-load/TestStopOnSharedlibraryEvents.py
+++ b/lldb/test/API/functionalities/stop-on-sharedlibrary-load/TestStopOnSharedlibraryEvents.py
@@ -99,7 +99,7 @@ class TestStopOnSharedlibraryEvents(TestBase):
             backstop_bkpt_2.GetNumLocations(), 0, "Set our third breakpoint"
         )
 
-        if bkpt_modifier == None:
+        if bkpt_modifier is None:
             process.Continue()
             self.assertState(
                 process.GetState(), lldb.eStateStopped, "We didn't stop for the load"

--- a/lldb/test/API/lua_api/TestLuaAPI.py
+++ b/lldb/test/API/lua_api/TestLuaAPI.py
@@ -115,7 +115,7 @@ def executeCommand(command, cwd=None, env=None, input=None, timeout=0):
         out, err = p.communicate(input=input)
         exitCode = p.wait()
     finally:
-        if timerObject != None:
+        if timerObject is not None:
             timerObject.cancel()
 
     # Ensure the resulting output is always of string type.

--- a/lldb/test/API/macosx/thread_suspend/TestInternalThreadSuspension.py
+++ b/lldb/test/API/macosx/thread_suspend/TestInternalThreadSuspension.py
@@ -92,7 +92,7 @@ class TestSuspendedThreadHandling(TestBase):
         thread = lldb.SBThread()
         for thread in process.threads:
             th_name = thread.GetName()
-            if th_name == None:
+            if th_name is None:
                 continue
             if "Look for me" in th_name:
                 break

--- a/lldb/test/API/python_api/event/TestEvents.py
+++ b/lldb/test/API/python_api/event/TestEvents.py
@@ -335,7 +335,7 @@ class EventAPITestCase(TestBase):
         if state == lldb.eStateStopped:
             restart = lldb.SBProcess.GetRestartedFromEvent(event)
 
-        if expected_state != None:
+        if expected_state is not None:
             self.assertEqual(
                 state, expected_state, "Primary thread got the correct event"
             )

--- a/lldb/test/API/python_api/process/read-mem-cstring/TestReadMemCString.py
+++ b/lldb/test/API/python_api/process/read-mem-cstring/TestReadMemCString.py
@@ -61,4 +61,4 @@ class TestReadMemCString(TestBase):
             invalid_memory_str_addr, 2048, err
         )
         self.assertTrue(err.Fail())
-        self.assertTrue(invalid_memory_string == "" or invalid_memory_string == None)
+        self.assertTrue(invalid_memory_string == "" or invalid_memory_string is None)

--- a/lldb/test/API/python_api/type/TestTypeList.py
+++ b/lldb/test/API/python_api/type/TestTypeList.py
@@ -132,7 +132,7 @@ class TypeAndTypeListTestCase(TestBase):
                         "my_type_is_named has a named type",
                     )
                     self.assertTrue(field.type.IsAggregateType())
-                elif field.name == None:
+                elif field.name is None:
                     self.assertTrue(
                         field.type.IsAnonymousType(), "Nameless type is not anonymous"
                     )

--- a/lldb/test/API/python_api/was_interrupted/interruptible.py
+++ b/lldb/test/API/python_api/was_interrupted/interruptible.py
@@ -45,7 +45,7 @@ class WelcomeCommand(object):
         For the "check" case, it doesn't wait, but just returns whether there was
         an interrupt in force or not."""
 
-        if local_data == None:
+        if local_data is None:
             result.SetError("local data was not set.")
             result.SetStatus(lldb.eReturnStatusFailed)
             return

--- a/lldb/test/Shell/lit.cfg.py
+++ b/lldb/test/Shell/lit.cfg.py
@@ -145,7 +145,7 @@ if config.lldb_enable_lua:
 if config.lldb_enable_lzma:
     config.available_features.add("lzma")
 
-if shutil.which("xz") != None:
+if shutil.which("xz") is not None:
     config.available_features.add("xz")
 
 if config.lldb_system_debugserver:


### PR DESCRIPTION
from PEP8 (https://peps.python.org/pep-0008/#programming-recommendations):

> Comparisons to singletons like None should always be done with is or is not, never the equality operators.