### PR TITLE
fix(llvm/**.py): fix comparison to None

### DIFF
--- a/llvm/utils/indirect_calls.py
+++ b/llvm/utils/indirect_calls.py
@@ -34,7 +34,7 @@ def look_for_indirect(file):
         if line.startswith(" ") == False:
             function = line
         result = re.search("(call|jmp).*\*", line)
-        if result != None:
+        if result is not None:
             # TODO: Perhaps use cxxfilt to demangle functions?
             print(function)
             print(line)

--- a/llvm/utils/lit/lit/TestRunner.py
+++ b/llvm/utils/lit/lit/TestRunner.py
@@ -197,7 +197,7 @@ def executeShCmd(cmd, shenv, results, timeout=0):
     timeout
     """
     # Use the helper even when no timeout is required to make
-    # other code simpler (i.e. avoid bunch of ``!= None`` checks)
+    # other code simpler (i.e. avoid bunch of ``is not None`` checks)
     timeoutHelper = TimeoutHelper(timeout)
     if timeout > 0:
         timeoutHelper.startTimer()

--- a/llvm/utils/lit/lit/util.py
+++ b/llvm/utils/lit/lit/util.py
@@ -408,7 +408,7 @@ def executeCommand(
         out, err = p.communicate(input=input)
         exitCode = p.wait()
     finally:
-        if timerObject != None:
+        if timerObject is not None:
             timerObject.cancel()
 
     # Ensure the resulting output is always of string type.

--- a/llvm/utils/schedcover.py
+++ b/llvm/utils/schedcover.py
@@ -25,7 +25,7 @@ def add(instr, model, resource=None):
 def filter_model(m):
     global filt
     if m and filt:
-        return filt.search(m) != None
+        return filt.search(m) is not None
     else:
         return True
 

--- a/llvm/utils/shuffle_select_fuzz_tester.py
+++ b/llvm/utils/shuffle_select_fuzz_tester.py
@@ -157,7 +157,7 @@ class ShufInstr(Instruction):
         )
 
     def calc_value(self):
-        if self.value != None:
+        if self.value is not None:
             print("Trying to calculate the value of a shuffle instruction twice")
             exit(1)
 
@@ -199,7 +199,7 @@ class SelectInstr(Instruction):
         )
 
     def calc_value(self):
-        if self.value != None:
+        if self.value is not None:
             print("Trying to calculate the value of a select instruction twice")
             exit(1)
 
@@ -237,7 +237,7 @@ def gen_inputs(ty, num):
 # In case one of the dimensions (scalar type/number of elements) is provided,
 # fill the blank dimension and return appropriate Type object.
 def get_random_type(ty, num_elts):
-    if ty != None:
+    if ty is not None:
         if ty == "i8":
             is_float = False
             width = 8
@@ -260,10 +260,10 @@ def get_random_type(ty, num_elts):
     int_elt_widths = [8, 16, 32, 64]
     float_elt_widths = [32, 64]
 
-    if num_elts == None:
+    if num_elts is None:
         num_elts = random.choice(range(2, 65))
 
-    if ty == None:
+    if ty is None:
         # 1 for integer type, 0 for floating-point
         if random.randint(0, 1):
             is_float = False
@@ -388,7 +388,7 @@ def main():
     ), "Minimum value greater than maximum."
     assert args.type in [None, "i8", "i16", "i32", "i64", "f32", "f64"], "Illegal type."
     assert (
-        args.num_elts == None or args.num_elts > 0
+        args.num_elts is None or args.num_elts > 0
     ), "num_elts must be a positive integer."
 
     random.seed(args.seed)


### PR DESCRIPTION
from PEP8 (https://peps.python.org/pep-0008/#programming-recommendations):

> Comparisons to singletons like None should always be done with is or is not, never the equality operators.