### PR TITLE
[OpenMP] Fix comparison to None in openmp/**.py

### DIFF
--- a/openmp/libompd/gdb-plugin/ompd/ompd_callbacks.py
+++ b/openmp/libompd/gdb-plugin/ompd/ompd_callbacks.py
@@ -84,7 +84,7 @@ def _thread_context(*args):
             m = re.search(r"(0x[a-fA-F0-9]+)", line)
         elif lwp:
             m = re.search(r"\([^)]*?(\d+)[^)]*?\)", line)
-        if m == None:
+        if m is None:
             continue
         pid = int(m.group(1), 0)
         if pid == thread_id:


### PR DESCRIPTION
from PEP8 (https://peps.python.org/pep-0008/#programming-recommendations):

> Comparisons to singletons like None should always be done with is or is not, never the equality operators.