### PR TITLE
[Polly] Use "is" instead of "==" to check for None

### DIFF
--- a/polly/lib/External/isl/interface/python.cc
+++ b/polly/lib/External/isl/interface/python.cc
@@ -347,7 +347,7 @@ static void print_persistent_callback_failure_check(int indent,
 		printf(fmt, 0);
 		printf(", '%s') and ", callback_name.c_str());
 		printf(fmt, 0);
-		printf(".%s['exc_info'] != None:\n", callback_name.c_str());
+		printf(".%s['exc_info'] is not None:\n", callback_name.c_str());
 		print_indent(indent, "    exc_info = ");
 		printf(fmt, 0);
 		printf(".%s['exc_info'][0]\n", callback_name.c_str());

--- a/polly/lib/External/isl/libisl-gdb.py
+++ b/polly/lib/External/isl/libisl-gdb.py
@@ -70,7 +70,7 @@ class IslPrintCommand(gdb.Command):
         arg = gdb.parse_and_eval(arg)
         printer = str_lookup_function(arg)
 
-        if printer == None:
+        if printer is None:
             print("No isl printer for this type")
             return
 
@@ -90,7 +90,7 @@ def str_lookup_function(val):
     lookup_tag = val.type.target()
     regex = re.compile("^isl_(.*)$")
 
-    if lookup_tag == None:
+    if lookup_tag is None:
         return None
 
     m = regex.match(str(lookup_tag))

--- a/polly/lib/External/isl/python/isl.py.top
+++ b/polly/lib/External/isl/python/isl.py.top
@@ -3,7 +3,7 @@ from ctypes import *
 from ctypes.util import find_library
 
 isl_dyld_library_path = os.environ.get('ISL_DYLD_LIBRARY_PATH')
-if isl_dyld_library_path != None:
+if isl_dyld_library_path is not None:
     os.environ['DYLD_LIBRARY_PATH'] =  isl_dyld_library_path
 try:
     isl = cdll.LoadLibrary(isl_dlname)
@@ -29,7 +29,7 @@ class Context:
 
     @staticmethod
     def getDefaultInstance():
-        if Context.defaultInstance == None:
+        if Context.defaultInstance is None:
             Context.defaultInstance = Context()
         return Context.defaultInstance
 

--- a/polly/test/lit.site.cfg.in
+++ b/polly/test/lit.site.cfg.in
@@ -14,7 +14,7 @@ config.extra_paths = "@POLLY_TEST_EXTRA_PATHS@".split(";")
 ## Check the current platform with regex
 import re
 EAT_ERR_ON_X86 = ' '
-if (re.match(r'^x86_64*', '@LLVM_TARGET_TRIPLE@') == None) :
+if (re.match(r'^x86_64*', '@LLVM_TARGET_TRIPLE@') is None) :
   EAT_ERR_ON_X86 = '|| echo \"error is eaten\"'
 
 for arch in config.targets_to_build.split():

--- a/polly/utils/pyscop/isl.py
+++ b/polly/utils/pyscop/isl.py
@@ -24,7 +24,7 @@ class Context:
 
     @staticmethod
     def getDefaultInstance():
-        if Context.defaultInstance == None:
+        if Context.defaultInstance is None:
             Context.defaultInstance = Context()
 
         return Context.defaultInstance
@@ -33,12 +33,12 @@ class Context:
 class IslObject:
     def __init__(self, string="", ctx=None, ptr=None):
         self.initialize_isl_methods()
-        if ptr != None:
+        if ptr is not None:
             self.ptr = ptr
             self.ctx = self.get_isl_method("get_ctx")(self)
             return
 
-        if ctx == None:
+        if ctx is None:
             ctx = Context.getDefaultInstance()
 
         self.ctx = ctx
@@ -236,7 +236,7 @@ class Printer:
     FORMAT_EXT_POLYLIB = 6
 
     def __init__(self, ctx=None):
-        if ctx == None:
+        if ctx is None:
             ctx = Context.getDefaultInstance()
 
         self.ctx = ctx


### PR DESCRIPTION
from PEP8 (https://peps.python.org/pep-0008/#programming-recommendations):

> Comparisons to singletons like None should always be done with is or is not, never the equality operators.