### PR TITLE
[lldb] fix(lldb/**.py): fix comparison to True/False

### DIFF
--- a/lldb/examples/python/crashlog.py
+++ b/lldb/examples/python/crashlog.py
@@ -166,7 +166,7 @@ class CrashLog(symbolication.Symbolicator):
             this_thread_crashed = self.app_specific_backtrace
             if not this_thread_crashed:
                 this_thread_crashed = self.did_crash()
-                if options.crashed_only and this_thread_crashed == False:
+                if options.crashed_only and not this_thread_crashed:
                     return
 
             print("%s" % self)

--- a/lldb/examples/python/disasm-stress-test.py
+++ b/lldb/examples/python/disasm-stress-test.py
@@ -95,13 +95,13 @@ import lldb
 
 debugger = lldb.SBDebugger.Create()
 
-if debugger.IsValid() == False:
+if not debugger.IsValid():
     print("Couldn't create an SBDebugger")
     sys.exit(-1)
 
 target = debugger.CreateTargetWithFileAndArch(None, arg_ns.arch)
 
-if target.IsValid() == False:
+if not target.IsValid():
     print("Couldn't create an SBTarget for architecture " + arg_ns.arch)
     sys.exit(-1)
 

--- a/lldb/examples/summaries/cocoa/CFString.py
+++ b/lldb/examples/summaries/cocoa/CFString.py
@@ -253,9 +253,9 @@ class CFStringSynthProvider:
             elif (
                 self.inline
                 and self.explicit
-                and self.unicode == False
-                and self.special == False
-                and self.mutable == False
+                and not self.unicode
+                and not self.special
+                and not self.mutable
             ):
                 return self.handle_inline_explicit()
             elif self.unicode:

--- a/lldb/examples/summaries/pysummary.py
+++ b/lldb/examples/summaries/pysummary.py
@@ -2,7 +2,7 @@ import lldb
 
 
 def pyobj_summary(value, unused):
-    if value is None or value.IsValid() == False or value.GetValueAsUnsigned(0) == 0:
+    if value is None or not value.IsValid() or value.GetValueAsUnsigned(0) == 0:
         return "<invalid>"
     refcnt = value.GetChildMemberWithName("ob_refcnt")
     expr = "(char*)PyString_AsString( (PyObject*)PyObject_Str( (PyObject*)0x%x) )" % (

--- a/lldb/examples/synthetic/bitfield/example.py
+++ b/lldb/examples/synthetic/bitfield/example.py
@@ -51,7 +51,7 @@ class MaskedData_SyntheticChildrenProvider:
             return None
         if index > self.num_children():
             return None
-        if self.valobj.IsValid() == False:
+        if not self.valobj.IsValid():
             return None
         if index == 0:
             return self.valobj.GetChildMemberWithName("value")

--- a/lldb/packages/Python/lldbsuite/test/lldbtest.py
+++ b/lldb/packages/Python/lldbsuite/test/lldbtest.py
@@ -2446,7 +2446,7 @@ FileCheck output:
                 log_lines.append(pattern_line)
 
                 # Convert to bool because match objects
-                # are True-ish but != True itself
+                # are True-ish but is not True itself
                 matched = bool(matched)
                 if matched != matching:
                     break

--- a/lldb/test/API/commands/command/script/welcome.py
+++ b/lldb/test/API/commands/command/script/welcome.py
@@ -45,7 +45,7 @@ def print_wait_impl(debugger, args, result, dict):
 def check_for_synchro(debugger, args, result, dict):
     if debugger.GetAsync():
         print("I am running async", file=result)
-    if debugger.GetAsync() == False:
+    if not debugger.GetAsync():
         print("I am running sync", file=result)
 
 

--- a/lldb/test/API/commands/expression/call-throws/TestCallThatThrows.py
+++ b/lldb/test/API/commands/expression/call-throws/TestCallThatThrows.py
@@ -61,7 +61,7 @@ class ExprCommandWithThrowTestCase(TestBase):
 
         value = frame.EvaluateExpression("[my_class callMeIThrow]", options)
 
-        self.assertTrue(value.IsValid() and value.GetError().Success() == False)
+        self.assertTrue(value.IsValid() and not value.GetError().Success())
         self.check_after_call()
 
         # Now set the ObjC language breakpoint and make sure that doesn't
@@ -76,7 +76,7 @@ class ExprCommandWithThrowTestCase(TestBase):
 
         value = frame.EvaluateExpression("[my_class callMeIThrow]", options)
 
-        self.assertTrue(value.IsValid() and value.GetError().Success() == False)
+        self.assertTrue(value.IsValid() and not value.GetError().Success())
         self.check_after_call()
 
         # Now turn off exception trapping, and call a function that catches the exceptions,
@@ -95,5 +95,5 @@ class ExprCommandWithThrowTestCase(TestBase):
         options.SetUnwindOnError(False)
         value = frame.EvaluateExpression("[my_class callMeIThrow]", options)
 
-        self.assertTrue(value.IsValid() and value.GetError().Success() == False)
+        self.assertTrue(value.IsValid() and not value.GetError().Success())
         self.check_after_call()

--- a/lldb/test/API/functionalities/disassemble/aarch64-adrp-add/TestAArch64AdrpAdd.py
+++ b/lldb/test/API/functionalities/disassemble/aarch64-adrp-add/TestAArch64AdrpAdd.py
@@ -57,7 +57,7 @@ class TestAArch64AdrpAdd(TestBase):
                 found_hi_string = True
             if "foo" in i.GetComment(target):
                 found_foo = True
-        if found_hi_string == False or found_foo == False:
+        if not found_hi_string or not found_foo:
             print(
                 'Did not find "HI" string or "foo" in disassembly symbolication in %s'
                 % binaryname

--- a/lldb/test/API/functionalities/gdb_remote_client/TestNoWatchpointSupportInfo.py
+++ b/lldb/test/API/functionalities/gdb_remote_client/TestNoWatchpointSupportInfo.py
@@ -61,7 +61,7 @@ class TestNoWatchpointSupportInfo(GDBRemoteTestBase):
         wp_opts = lldb.SBWatchpointOptions()
         wp_opts.SetWatchpointTypeWrite(lldb.eWatchpointWriteTypeOnModify)
         wp = target.WatchpointCreateByAddress(0x100, 8, wp_opts, err)
-        if self.TraceOn() and (err.Fail() or wp.IsValid == False):
+        if self.TraceOn() and (err.Fail() or not wp.IsValid):
             strm = lldb.SBStream()
             err.GetDescription(strm)
             print("watchpoint failed: %s" % strm.GetData())

--- a/lldb/test/API/tools/lldb-server/TestAppleSimulatorOSType.py
+++ b/lldb/test/API/tools/lldb-server/TestAppleSimulatorOSType.py
@@ -39,7 +39,7 @@ class TestAppleSimulatorOSType(gdbremote_testcase.GdbRemoteTestCaseBase):
             for device in devices:
                 if "availability" in device and device["availability"] != "(available)":
                     continue
-                if "isAvailable" in device and device["isAvailable"] != True:
+                if "isAvailable" in device and not device["isAvailable"]:
                     continue
                 if deviceRuntime and runtime < deviceRuntime:
                     continue

--- a/lldb/test/API/tools/lldb-server/TestLldbGdbServer.py
+++ b/lldb/test/API/tools/lldb-server/TestLldbGdbServer.py
@@ -953,7 +953,7 @@ class LldbGdbServerTestCase(
         z_packet_type = 0
 
         # If hardware breakpoint is requested set packet type to Z1
-        if want_hardware == True:
+        if want_hardware:
             z_packet_type = 1
 
         self.reset_test_sequence()


### PR DESCRIPTION
from PEP8 (https://peps.python.org/pep-0008/#programming-recommendations):

> Comparisons to singletons like None should always be done with is or is not, never the equality operators.