### PR TITLE
fix(llvm/**.py): fix comparison to True/False

### DIFF
--- a/llvm/utils/indirect_calls.py
+++ b/llvm/utils/indirect_calls.py
@@ -31,7 +31,7 @@ def look_for_indirect(file):
 
     function = ""
     for line in stdout.splitlines():
-        if line.startswith(" ") == False:
+        if not line.startswith(" "):
             function = line
         result = re.search("(call|jmp).*\*", line)
         if result is not None:


### PR DESCRIPTION
from PEP8 (https://peps.python.org/pep-0008/#programming-recommendations):

> Comparisons to singletons like None should always be done with is or is not, never the equality operators.