### PR TITLE
[OpenMP] Fix comparison to True/False in openmp/**.py

### DIFF
--- a/openmp/libompd/gdb-plugin/ompd/ompd.py
+++ b/openmp/libompd/gdb-plugin/ompd/ompd.py
@@ -50,7 +50,7 @@ class ompd_init(gdb.Command):
                     "No ompd_dll_locations symbol in execution, make sure to have an OMPD enabled OpenMP runtime"
                 )
 
-            while gdb.parse_and_eval("(char**)ompd_dll_locations") == False:
+            while not gdb.parse_and_eval("(char**)ompd_dll_locations"):
                 gdb.execute("tbreak ompd_dll_locations_valid")
                 gdb.execute("continue")
 

--- a/openmp/tools/archer/tests/lit.cfg
+++ b/openmp/tools/archer/tests/lit.cfg
@@ -83,7 +83,7 @@ if config.operating_system == 'Darwin':
 if 'Linux' in config.operating_system:
     config.available_features.add("linux")
 
-if config.has_tsan == True:
+if config.has_tsan:
     config.available_features.add("tsan")
 
 # to run with icc INTEL_LICENSE_FILE must be set


### PR DESCRIPTION
from PEP8 (https://peps.python.org/pep-0008/#programming-recommendations):

> Comparisons to singletons like None should always be done with is or is not, never the equality operators.