### PR TITLE
fix(polly/**.py): fix comparison to True/False

### DIFF
--- a/polly/lib/External/isl/imath/tests/gmp-compat-test/genpytest.py
+++ b/polly/lib/External/isl/imath/tests/gmp-compat-test/genpytest.py
@@ -54,7 +54,7 @@ def run_test(test, line, name, gmp_test_so, imath_test_so, *args):
   if childpid == 0:
     eq = test(line, name, gmp_test_so, imath_test_so, *args)
     if fork:
-      sys.exit(eq != True)
+      sys.exit(not eq)
     else:
       return eq
   else:


### PR DESCRIPTION
from PEP8 (https://peps.python.org/pep-0008/#programming-recommendations):

> Comparisons to singletons like None should always be done with is or is not, never the equality operators.