### PR TITLE
[libc++][z/OS] Disable portion of formatter.char.funsigned-char.pass.cpp for no unicode

### DIFF
--- a/libcxx/test/std/utilities/format/format.formatter/format.formatter.spec/formatter.char.funsigned-char.pass.cpp
+++ b/libcxx/test/std/utilities/format/format.formatter/format.formatter.spec/formatter.char.funsigned-char.pass.cpp
@@ -82,7 +82,7 @@ void test() {
     test(STR("'\u00ff'"), STR("?}"), '\xff');
   }
 #    endif // TEST_HAS_NO_WIDE_CHARACTERS
-#  endif // TEST_HAS_NO_UNICODE
+#  endif   // TEST_HAS_NO_UNICODE
 #endif   // TEST_STD_VER > 20
 
   test(STR("10000000"), STR("b}"), char(128));

--- a/libcxx/test/std/utilities/format/format.formatter/format.formatter.spec/formatter.char.funsigned-char.pass.cpp
+++ b/libcxx/test/std/utilities/format/format.formatter/format.formatter.spec/formatter.char.funsigned-char.pass.cpp
@@ -71,16 +71,18 @@ void test() {
 #if TEST_STD_VER > 20
   test(STR(R"('\u{0}')"), STR("?}"), '\x00');
   test(STR("'a'"), STR("?}"), 'a');
+#  ifndef TEST_HAS_NO_UNICODE
   if constexpr (std::same_as<CharT, char>) {
     test(STR(R"('\x{80}')"), STR("?}"), '\x80');
     test(STR(R"('\x{ff}')"), STR("?}"), '\xff');
   }
-#  ifndef TEST_HAS_NO_WIDE_CHARACTERS
+#    ifndef TEST_HAS_NO_WIDE_CHARACTERS
   else {
     test(STR(R"('\u{80}')"), STR("?}"), '\x80');
     test(STR("'\u00ff'"), STR("?}"), '\xff');
   }
-#  endif // TEST_HAS_NO_WIDE_CHARACTERS
+#    endif // TEST_HAS_NO_WIDE_CHARACTERS
+#  endif // TEST_HAS_NO_UNICODE
 #endif   // TEST_STD_VER > 20
 
   test(STR("10000000"), STR("b}"), char(128));


### PR DESCRIPTION
This PR carves out small portion of the test in subject to avoid the following failure when unicode is not available.

```
# | Assertion failure: result == expected .../formatter.char.funsigned-char.pass.cpp 56
# |
# | Format string   ?}
# | Expected output '\x{80}'
# | Actual output   '�'
```

This was traced down to different definition of `__code_point_view::__consume()` under macro_LIBCXX_HAS_NO_UNICODE which is called inside `__formatter::__escape()`. The `__consume()` returns `__ok` and code assumes that escaped sequence was already written but it is not., thus the failure. Here is the snippen code we fall into:

```
    typename __unicode::__consume_result __result = __view.__consume();
    if (__result.__status == __unicode::__consume_result::__ok) {
      __escape = __formatter::__is_escaped_sequence_written(__str, __result.__code_point, __escape, __mark);
```
