### PR TITLE
[lldb] Fix Dlang symbol test breakage

### DIFF
--- a/lldb/source/Core/Mangled.cpp
+++ b/lldb/source/Core/Mangled.cpp
@@ -50,11 +50,12 @@ Mangled::ManglingScheme Mangled::GetManglingScheme(llvm::StringRef const name) {
     return Mangled::eManglingSchemeRustV0;
 
   if (name.starts_with("_D")) {
-    // A dlang mangled name begins with `_D`, followed by a numeric length.
+    // A dlang mangled name begins with `_D`, followed by a numeric length. One
+    // known exception is the symbol `_Dmain`.
     // See `SymbolName` and `LName` in
     // https://dlang.org/spec/abi.html#name_mangling
     llvm::StringRef buf = name.drop_front(2);
-    if (!buf.empty() && llvm::isDigit(buf.front()))
+    if (!buf.empty() && (llvm::isDigit(buf.front()) || name == "_Dmain"))
       return Mangled::eManglingSchemeD;
   }
 

--- a/lldb/unittests/Core/MangledTest.cpp
+++ b/lldb/unittests/Core/MangledTest.cpp
@@ -81,12 +81,12 @@ TEST(MangledTest, ResultForValidDLangName) {
   EXPECT_STREQ(expected_result.GetCString(), the_demangled.GetCString());
 }
 
-TEST(MangledTest, EmptyForInvalidDLangName) {
+TEST(MangledTest, SameForInvalidDLangPrefixedName) {
   ConstString mangled_name("_DDD");
   Mangled the_mangled(mangled_name);
   ConstString the_demangled = the_mangled.GetDemangledName();
 
-  EXPECT_STREQ("", the_demangled.GetCString());
+  EXPECT_STREQ("_DDD", the_demangled.GetCString());
 }
 
 TEST(MangledTest, RecognizeSwiftMangledNames) {


### PR DESCRIPTION
Follow up to #93881. Updates missed tests and handles `_Dmain`.