### PR TITLE
[memprof] Add accessors to Frame::SymbolName

### DIFF
--- a/llvm/include/llvm/ProfileData/MemProf.h
+++ b/llvm/include/llvm/ProfileData/MemProf.h
@@ -237,6 +237,17 @@ struct Frame {
 
   bool operator!=(const Frame &Other) const { return !operator==(Other); }
 
+  bool hasSymbolName() const { return SymbolName.has_value(); }
+
+  StringRef getSymbolName() const {
+    assert(SymbolName.has_value());
+    return *SymbolName;
+  }
+
+  std::string getSymbolNameOr(StringRef Alt) const {
+    return std::string(hasSymbolName() ? getSymbolName() : Alt);
+  }
+
   // Write the contents of the frame to the ostream \p OS.
   void serialize(raw_ostream &OS) const {
     using namespace support;
@@ -279,7 +290,7 @@ struct Frame {
   void printYAML(raw_ostream &OS) const {
     OS << "      -\n"
        << "        Function: " << Function << "\n"
-       << "        SymbolName: " << SymbolName.value_or("<None>") << "\n"
+       << "        SymbolName: " << getSymbolNameOr("<None>") << "\n"
        << "        LineOffset: " << LineOffset << "\n"
        << "        Column: " << Column << "\n"
        << "        Inline: " << IsInlineFrame << "\n";


### PR DESCRIPTION
This patch adds accessors to Frame::SymbolName so that we can change
the underlying type of SymbolName without affecting downstream users
once they switch to the new accessors.

Note that SymbolName is only used for debugging.  Changing the type of
SymbolName from std::optional<std::string> to
std::unique_ptr<std::string> cuts down sizeof(Frame) by half -- from
64 bytes to 32 bytes.  (std::optional<T> sets aside the storage in
case T is instantiated.)

During deserialization, the memory usage is dominated by Frames.
Shrinking the type cuts down the memory usage and deserialization time
nearly by half.