### PR TITLE
[compiler-rt][ASan] Remove alignment message in ASan error reporting

### DIFF
--- a/compiler-rt/lib/asan/asan_errors.cpp
+++ b/compiler-rt/lib/asan/asan_errors.cpp
@@ -328,8 +328,6 @@ void ErrorBadParamsToAnnotateContiguousContainer::Print() {
       "      new_mid : %p\n",
       (void *)beg, (void *)end, (void *)old_mid, (void *)new_mid);
   uptr granularity = ASAN_SHADOW_GRANULARITY;
-  if (!IsAligned(beg, granularity))
-    Report("ERROR: beg is not aligned by %zu\n", granularity);
   stack->Print();
   ReportErrorSummary(scariness.GetDescription(), stack);
 }
@@ -348,8 +346,6 @@ void ErrorBadParamsToAnnotateDoubleEndedContiguousContainer::Print() {
       (void *)old_container_end, (void *)new_container_beg,
       (void *)new_container_end);
   uptr granularity = ASAN_SHADOW_GRANULARITY;
-  if (!IsAligned(storage_beg, granularity))
-    Report("ERROR: storage_beg is not aligned by %zu\n", granularity);
   stack->Print();
   ReportErrorSummary(scariness.GetDescription(), stack);
 }

--- a/compiler-rt/test/asan/TestCases/contiguous_container_crash.cpp
+++ b/compiler-rt/test/asan/TestCases/contiguous_container_crash.cpp
@@ -1,7 +1,7 @@
 // RUN: %clangxx_asan -O %s -o %t
 // RUN: not %run %t crash 2>&1 | FileCheck --check-prefix=CHECK-CRASH %s
 // RUN: not %run %t bad-bounds 2>&1 | FileCheck --check-prefix=CHECK-BAD-BOUNDS %s
-// RUN: not %run %t unaligned-bad-bounds 2>&1 | FileCheck --check-prefix=CHECK-UNALIGNED-BAD-BOUNDS %s
+// RUN: not %run %t unaligned-bad-bounds 2>&1 | FileCheck --check-prefix=CHECK-UNALIGNED-BAD-BOUNDS %s --implicit-check-not="beg is not aligned by"
 // RUN: not %run %t odd-alignment 2>&1 | FileCheck --check-prefix=CHECK-CRASH %s
 // RUN: not %run %t odd-alignment-end 2>&1 | FileCheck --check-prefix=CHECK-CRASH %s
 // RUN: %env_asan_opts=detect_container_overflow=0 %run %t crash
@@ -39,7 +39,6 @@ void BadBounds() {
 void UnalignedBadBounds() {
   char t[100];
   // CHECK-UNALIGNED-BAD-BOUNDS: ERROR: AddressSanitizer: bad parameters to __sanitizer_annotate_contiguous_container
-  // CHECK-UNALIGNED-BAD-BOUNDS-NOT: beg is not aligned by
   __sanitizer_annotate_contiguous_container(&t[1], &t[0] + 100, &t[0] + 101,
                                             &t[0] + 50);
 }

--- a/compiler-rt/test/asan/TestCases/contiguous_container_crash.cpp
+++ b/compiler-rt/test/asan/TestCases/contiguous_container_crash.cpp
@@ -1,6 +1,7 @@
 // RUN: %clangxx_asan -O %s -o %t
 // RUN: not %run %t crash 2>&1 | FileCheck --check-prefix=CHECK-CRASH %s
 // RUN: not %run %t bad-bounds 2>&1 | FileCheck --check-prefix=CHECK-BAD-BOUNDS %s
+// RUN: not %run %t unaligned-bad-bounds 2>&1 | FileCheck --check-prefix=CHECK-UNALIGNED-BAD-BOUNDS %s
 // RUN: not %run %t odd-alignment 2>&1 | FileCheck --check-prefix=CHECK-CRASH %s
 // RUN: not %run %t odd-alignment-end 2>&1 | FileCheck --check-prefix=CHECK-CRASH %s
 // RUN: %env_asan_opts=detect_container_overflow=0 %run %t crash
@@ -35,6 +36,14 @@ void BadBounds() {
                                             &t[0] + 50);
 }
 
+void UnalignedBadBounds() {
+  char t[100];
+  // CHECK-UNALIGNED-BAD-BOUNDS: ERROR: AddressSanitizer: bad parameters to __sanitizer_annotate_contiguous_container
+  // CHECK-UNALIGNED-BAD-BOUNDS-NOT: beg is not aligned by
+  __sanitizer_annotate_contiguous_container(&t[1], &t[0] + 100, &t[0] + 101,
+                                            &t[0] + 50);
+}
+
 int OddAlignment() {
   int t[100];
   t[60] = 0;
@@ -57,6 +66,8 @@ int main(int argc, char **argv) {
     return TestCrash();
   else if (!strcmp(argv[1], "bad-bounds"))
     BadBounds();
+  else if (!strcmp(argv[1], "unaligned-bad-bounds"))
+    UnalignedBadBounds();
   else if (!strcmp(argv[1], "odd-alignment"))
     return OddAlignment();
   else if (!strcmp(argv[1], "odd-alignment-end"))


### PR DESCRIPTION
This commit removes unnecessary alignment check and message in ASan error reporting functions (like `ErrorBadParamsToAnnotateContiguousContainer::Print()`), as alignment is no longer required starting from LLVM 16.

Without that commit, this message can be observed only when arguments are truly incorrect and `beg` is unaligned. Just unaligned `beg` does not result in any message being printed.

Related commits:
- https://github.com/llvm/llvm-project/commit/dd1b7b797a116eed588fd752fbe61d34deeb24e4
- https://github.com/llvm/llvm-project/commit/1c5ad6d2c01294a0decde43a88e9c27d7437d157