### PR TITLE
[libc++] [test] Fix `__has_include` usage, expand condvarany and spaceship coverage

### DIFF
--- a/libcxx/test/std/concepts/concepts.compare/concepts.totallyordered/totally_ordered.pass.cpp
+++ b/libcxx/test/std/concepts/concepts.compare/concepts.totallyordered/totally_ordered.pass.cpp
@@ -111,13 +111,12 @@ static_assert(!std::totally_ordered<std::unordered_map<int, void*> >);
 static_assert(!std::totally_ordered<std::unordered_set<int> >);
 
 struct A {};
-// FIXME(cjdb): uncomment when operator<=> is implemented for each of these types.
-// static_assert(!std::totally_ordered<std::array<A, 10> >);
-// static_assert(!std::totally_ordered<std::deque<A> >);
-// static_assert(!std::totally_ordered<std::forward_list<A> >);
-// static_assert(!std::totally_ordered<std::list<A> >);
-// static_assert(!std::totally_ordered<std::set<A> >);
-// static_assert(!std::totally_ordered<std::vector<A> >);
+static_assert(!std::totally_ordered<std::array<A, 10> >);
+static_assert(!std::totally_ordered<std::deque<A> >);
+static_assert(!std::totally_ordered<std::forward_list<A> >);
+static_assert(!std::totally_ordered<std::list<A> >);
+static_assert(!std::totally_ordered<std::set<A> >);
+static_assert(!std::totally_ordered<std::vector<A> >);
 } // namespace standard_types
 
 namespace types_fit_for_purpose {

--- a/libcxx/test/std/concepts/concepts.compare/concepts.totallyordered/totally_ordered_with.pass.cpp
+++ b/libcxx/test/std/concepts/concepts.compare/concepts.totallyordered/totally_ordered_with.pass.cpp
@@ -1034,11 +1034,10 @@ static_assert(
 static_assert(!check_totally_ordered_with<std::vector<int>, int>());
 
 struct A {};
-// FIXME(cjdb): uncomment when operator<=> is implemented for each of these types.
-// static_assert(!check_totally_ordered_with<std::optional<std::vector<A> >,
-//                                          std::optional<std::vector<A> > >());
-// static_assert(!check_totally_ordered_with<std::optional<std::vector<A> >,
-//                                          std::vector<A> >());
+static_assert(!check_totally_ordered_with<std::optional<std::vector<A> >,
+                                         std::optional<std::vector<A> > >());
+static_assert(!check_totally_ordered_with<std::optional<std::vector<A> >,
+                                         std::vector<A> >());
 struct B {};
 static_assert(!check_totally_ordered_with<std::vector<A>, std::vector<B> >());
 static_assert(

--- a/libcxx/test/std/concepts/concepts.compare/concepts.totallyordered/totally_ordered_with.pass.cpp
+++ b/libcxx/test/std/concepts/concepts.compare/concepts.totallyordered/totally_ordered_with.pass.cpp
@@ -1034,10 +1034,8 @@ static_assert(
 static_assert(!check_totally_ordered_with<std::vector<int>, int>());
 
 struct A {};
-static_assert(!check_totally_ordered_with<std::optional<std::vector<A> >,
-                                         std::optional<std::vector<A> > >());
-static_assert(!check_totally_ordered_with<std::optional<std::vector<A> >,
-                                         std::vector<A> >());
+static_assert(!check_totally_ordered_with<std::optional<std::vector<A> >, std::optional<std::vector<A> > >());
+static_assert(!check_totally_ordered_with<std::optional<std::vector<A> >, std::vector<A> >());
 struct B {};
 static_assert(!check_totally_ordered_with<std::vector<A>, std::vector<B> >());
 static_assert(

--- a/libcxx/test/std/thread/thread.condition/thread.condition.condvarany/wait_for_pred.pass.cpp
+++ b/libcxx/test/std/thread/thread.condition/thread.condition.condvarany/wait_for_pred.pass.cpp
@@ -162,4 +162,10 @@ void test() {
   }
 }
 
-int main(int, char**) { return 0; }
+int main(int, char**) {
+  test<std::unique_lock<std::mutex>>();
+  test<std::unique_lock<std::timed_mutex>>();
+  test<MyLock<std::mutex>>();
+  test<MyLock<std::timed_mutex>>();
+  return 0;
+}

--- a/libcxx/test/support/test_macros.h
+++ b/libcxx/test/support/test_macros.h
@@ -11,7 +11,7 @@
 #define SUPPORT_TEST_MACROS_HPP
 
 #ifdef __has_include
-#  if __has_include("<version>")
+#  if __has_include(<version>)
 #    include <version>
 #  else
 #    include <ciso646>


### PR DESCRIPTION
Three unrelated, small improvements:

* `test_macros.h` was incorrectly saying `__has_include("<version>")` instead of `__has_include(<version>)`.
  + This caused `<ciso646>` to always be included (noticed because MSVC's STL emitted a deprecation warning).
  + I searched all of LLVM and found no other occurrences.
* `thread.condition.condvarany/wait_for_pred.pass.cpp` forgot to test anything.
  + I followed what `wait_for.pass.cpp` is testing.
* Uncomment spaceship test coverage.