### PR TITLE
[libc++] [test] Cleanup compile-only tests

### DIFF
--- a/libcxx/test/std/atomics/atomics.ref/member_types.compile.pass.cpp
+++ b/libcxx/test/std/atomics/atomics.ref/member_types.compile.pass.cpp
@@ -128,5 +128,3 @@ void testall() {
   test<long double>();
   // + TODO extended floating-point types
 }
-
-int main(int, char**) { return 0; }

--- a/libcxx/test/std/concepts/concepts.compare/concepts.totallyordered/totally_ordered.compile.pass.cpp
+++ b/libcxx/test/std/concepts/concepts.compare/concepts.totallyordered/totally_ordered.compile.pass.cpp
@@ -74,25 +74,25 @@ static_assert(!std::totally_ordered<int (S::*)() noexcept>);
 static_assert(!std::totally_ordered<int (S::*)() &>);
 static_assert(!std::totally_ordered<int (S::*)() & noexcept>);
 static_assert(!std::totally_ordered<int (S::*)() &&>);
-static_assert(!std::totally_ordered < int (S::*)() && noexcept >);
+static_assert(!std::totally_ordered < int(S::*)() && noexcept >);
 static_assert(!std::totally_ordered<int (S::*)() const>);
 static_assert(!std::totally_ordered<int (S::*)() const noexcept>);
 static_assert(!std::totally_ordered<int (S::*)() const&>);
 static_assert(!std::totally_ordered<int (S::*)() const & noexcept>);
 static_assert(!std::totally_ordered<int (S::*)() const&&>);
-static_assert(!std::totally_ordered < int (S::*)() const&& noexcept >);
+static_assert(!std::totally_ordered < int(S::*)() const&& noexcept >);
 static_assert(!std::totally_ordered<int (S::*)() volatile>);
 static_assert(!std::totally_ordered<int (S::*)() volatile noexcept>);
 static_assert(!std::totally_ordered<int (S::*)() volatile&>);
 static_assert(!std::totally_ordered<int (S::*)() volatile & noexcept>);
 static_assert(!std::totally_ordered<int (S::*)() volatile&&>);
-static_assert(!std::totally_ordered < int (S::*)() volatile&& noexcept >);
+static_assert(!std::totally_ordered < int(S::*)() volatile && noexcept >);
 static_assert(!std::totally_ordered<int (S::*)() const volatile>);
 static_assert(!std::totally_ordered<int (S::*)() const volatile noexcept>);
 static_assert(!std::totally_ordered<int (S::*)() const volatile&>);
 static_assert(!std::totally_ordered<int (S::*)() const volatile & noexcept>);
 static_assert(!std::totally_ordered<int (S::*)() const volatile&&>);
-static_assert(!std::totally_ordered < int (S::*)() const volatile&& noexcept >);
+static_assert(!std::totally_ordered < int(S::*)() const volatile&& noexcept >);
 
 static_assert(!std::totally_ordered<void>);
 } // namespace fundamentals
@@ -146,14 +146,10 @@ static_assert(!std::totally_ordered<wrong_return_type>);
 
 static_assert(!std::totally_ordered<cxx20_member_eq_operator_with_deleted_ne>);
 static_assert(!std::totally_ordered<cxx20_friend_eq_operator_with_deleted_ne>);
-static_assert(
-    !std::totally_ordered<member_three_way_comparable_with_deleted_eq>);
-static_assert(
-    !std::totally_ordered<member_three_way_comparable_with_deleted_ne>);
-static_assert(
-    !std::totally_ordered<friend_three_way_comparable_with_deleted_eq>);
-static_assert(
-    !std::totally_ordered<friend_three_way_comparable_with_deleted_ne>);
+static_assert(!std::totally_ordered<member_three_way_comparable_with_deleted_eq>);
+static_assert(!std::totally_ordered<member_three_way_comparable_with_deleted_ne>);
+static_assert(!std::totally_ordered<friend_three_way_comparable_with_deleted_eq>);
+static_assert(!std::totally_ordered<friend_three_way_comparable_with_deleted_ne>);
 
 static_assert(!std::totally_ordered<eq_returns_explicit_bool>);
 static_assert(!std::totally_ordered<ne_returns_explicit_bool>);

--- a/libcxx/test/std/concepts/concepts.compare/concepts.totallyordered/totally_ordered.compile.pass.cpp
+++ b/libcxx/test/std/concepts/concepts.compare/concepts.totallyordered/totally_ordered.compile.pass.cpp
@@ -168,5 +168,3 @@ static_assert(std::totally_ordered<partial_ordering_totally_ordered_with>);
 static_assert(std::totally_ordered<weak_ordering_totally_ordered_with>);
 static_assert(std::totally_ordered<strong_ordering_totally_ordered_with>);
 } // namespace types_fit_for_purpose
-
-int main(int, char**) { return 0; }

--- a/libcxx/test/std/concepts/concepts.compare/concepts.totallyordered/totally_ordered_with.compile.pass.cpp
+++ b/libcxx/test/std/concepts/concepts.compare/concepts.totallyordered/totally_ordered_with.compile.pass.cpp
@@ -71,34 +71,25 @@ static_assert(!check_totally_ordered_with<int, int (S::*)() noexcept>());
 static_assert(!check_totally_ordered_with<int, int (S::*)() const>());
 static_assert(!check_totally_ordered_with<int, int (S::*)() const noexcept>());
 static_assert(!check_totally_ordered_with<int, int (S::*)() volatile>());
-static_assert(
-    !check_totally_ordered_with<int, int (S::*)() volatile noexcept>());
+static_assert(!check_totally_ordered_with<int, int (S::*)() volatile noexcept>());
 static_assert(!check_totally_ordered_with<int, int (S::*)() const volatile>());
-static_assert(
-    !check_totally_ordered_with<int, int (S::*)() const volatile noexcept>());
+static_assert(!check_totally_ordered_with<int, int (S::*)() const volatile noexcept>());
 static_assert(!check_totally_ordered_with<int, int (S::*)() &>());
 static_assert(!check_totally_ordered_with<int, int (S::*)() & noexcept>());
 static_assert(!check_totally_ordered_with<int, int (S::*)() const&>());
-static_assert(
-    !check_totally_ordered_with<int, int (S::*)() const & noexcept>());
+static_assert(!check_totally_ordered_with<int, int (S::*)() const & noexcept>());
 static_assert(!check_totally_ordered_with<int, int (S::*)() volatile&>());
-static_assert(
-    !check_totally_ordered_with<int, int (S::*)() volatile & noexcept>());
+static_assert(!check_totally_ordered_with<int, int (S::*)() volatile & noexcept>());
 static_assert(!check_totally_ordered_with<int, int (S::*)() const volatile&>());
-static_assert(
-    !check_totally_ordered_with<int, int (S::*)() const volatile & noexcept>());
+static_assert(!check_totally_ordered_with<int, int (S::*)() const volatile & noexcept>());
 static_assert(!check_totally_ordered_with<int, int (S::*)() &&>());
 static_assert(!check_totally_ordered_with < int, int (S::*)() && noexcept > ());
 static_assert(!check_totally_ordered_with<int, int (S::*)() const&&>());
-static_assert(!check_totally_ordered_with < int,
-              int (S::*)() const&& noexcept > ());
+static_assert(!check_totally_ordered_with < int, int (S::*)() const&& noexcept > ());
 static_assert(!check_totally_ordered_with<int, int (S::*)() volatile&&>());
-static_assert(!check_totally_ordered_with < int,
-              int (S::*)() volatile&& noexcept > ());
-static_assert(
-    !check_totally_ordered_with<int, int (S::*)() const volatile&&>());
-static_assert(!check_totally_ordered_with < int,
-              int (S::*)() const volatile&& noexcept > ());
+static_assert(!check_totally_ordered_with < int, int (S::*)() volatile&& noexcept > ());
+static_assert(!check_totally_ordered_with<int, int (S::*)() const volatile&&>());
+static_assert(!check_totally_ordered_with < int, int (S::*)() const volatile&& noexcept > ());
 
 static_assert(check_totally_ordered_with<int*, int*>());
 static_assert(check_totally_ordered_with<int*, int[5]>());
@@ -109,36 +100,25 @@ static_assert(!check_totally_ordered_with<int*, int (S::*)() noexcept>());
 static_assert(!check_totally_ordered_with<int*, int (S::*)() const>());
 static_assert(!check_totally_ordered_with<int*, int (S::*)() const noexcept>());
 static_assert(!check_totally_ordered_with<int*, int (S::*)() volatile>());
-static_assert(
-    !check_totally_ordered_with<int*, int (S::*)() volatile noexcept>());
+static_assert(!check_totally_ordered_with<int*, int (S::*)() volatile noexcept>());
 static_assert(!check_totally_ordered_with<int*, int (S::*)() const volatile>());
-static_assert(
-    !check_totally_ordered_with<int*, int (S::*)() const volatile noexcept>());
+static_assert(!check_totally_ordered_with<int*, int (S::*)() const volatile noexcept>());
 static_assert(!check_totally_ordered_with<int*, int (S::*)() &>());
 static_assert(!check_totally_ordered_with<int*, int (S::*)() & noexcept>());
 static_assert(!check_totally_ordered_with<int*, int (S::*)() const&>());
-static_assert(
-    !check_totally_ordered_with<int*, int (S::*)() const & noexcept>());
+static_assert(!check_totally_ordered_with<int*, int (S::*)() const & noexcept>());
 static_assert(!check_totally_ordered_with<int*, int (S::*)() volatile&>());
-static_assert(
-    !check_totally_ordered_with<int*, int (S::*)() volatile & noexcept>());
-static_assert(
-    !check_totally_ordered_with<int*, int (S::*)() const volatile&>());
-static_assert(!check_totally_ordered_with<int*, int (S::*)() const volatile &
-                                                    noexcept>());
+static_assert(!check_totally_ordered_with<int*, int (S::*)() volatile & noexcept>());
+static_assert(!check_totally_ordered_with<int*, int (S::*)() const volatile&>());
+static_assert(!check_totally_ordered_with<int*, int (S::*)() const volatile & noexcept>());
 static_assert(!check_totally_ordered_with<int*, int (S::*)() &&>());
-static_assert(!check_totally_ordered_with < int*,
-              int (S::*)() && noexcept > ());
+static_assert(!check_totally_ordered_with < int*, int (S::*)() && noexcept > ());
 static_assert(!check_totally_ordered_with<int*, int (S::*)() const&&>());
-static_assert(!check_totally_ordered_with < int*,
-              int (S::*)() const&& noexcept > ());
+static_assert(!check_totally_ordered_with < int*, int (S::*)() const&& noexcept > ());
 static_assert(!check_totally_ordered_with<int*, int (S::*)() volatile&&>());
-static_assert(!check_totally_ordered_with < int*,
-              int (S::*)() volatile&& noexcept > ());
-static_assert(
-    !check_totally_ordered_with<int*, int (S::*)() const volatile&&>());
-static_assert(!check_totally_ordered_with < int*,
-              int (S::*)() const volatile&& noexcept > ());
+static_assert(!check_totally_ordered_with < int*, int (S::*)() volatile&& noexcept > ());
+static_assert(!check_totally_ordered_with<int*, int (S::*)() const volatile&&>());
+static_assert(!check_totally_ordered_with < int*, int (S::*)() const volatile&& noexcept > ());
 
 static_assert(check_totally_ordered_with<int[5], int[5]>());
 static_assert(!check_totally_ordered_with<int[5], int (*)()>());
@@ -146,762 +126,411 @@ static_assert(!check_totally_ordered_with<int[5], int (&)()>());
 static_assert(!check_totally_ordered_with<int[5], int (S::*)()>());
 static_assert(!check_totally_ordered_with<int[5], int (S::*)() noexcept>());
 static_assert(!check_totally_ordered_with<int[5], int (S::*)() const>());
-static_assert(
-    !check_totally_ordered_with<int[5], int (S::*)() const noexcept>());
+static_assert(!check_totally_ordered_with<int[5], int (S::*)() const noexcept>());
 static_assert(!check_totally_ordered_with<int[5], int (S::*)() volatile>());
-static_assert(
-    !check_totally_ordered_with<int[5], int (S::*)() volatile noexcept>());
-static_assert(
-    !check_totally_ordered_with<int[5], int (S::*)() const volatile>());
-static_assert(!check_totally_ordered_with<
-              int[5], int (S::*)() const volatile noexcept>());
+static_assert(!check_totally_ordered_with<int[5], int (S::*)() volatile noexcept>());
+static_assert(!check_totally_ordered_with<int[5], int (S::*)() const volatile>());
+static_assert(!check_totally_ordered_with< int[5], int (S::*)() const volatile noexcept>());
 static_assert(!check_totally_ordered_with<int[5], int (S::*)() &>());
 static_assert(!check_totally_ordered_with<int[5], int (S::*)() & noexcept>());
 static_assert(!check_totally_ordered_with<int[5], int (S::*)() const&>());
-static_assert(
-    !check_totally_ordered_with<int[5], int (S::*)() const & noexcept>());
+static_assert(!check_totally_ordered_with<int[5], int (S::*)() const & noexcept>());
 static_assert(!check_totally_ordered_with<int[5], int (S::*)() volatile&>());
-static_assert(
-    !check_totally_ordered_with<int[5], int (S::*)() volatile & noexcept>());
-static_assert(
-    !check_totally_ordered_with<int[5], int (S::*)() const volatile&>());
-static_assert(!check_totally_ordered_with<int[5], int (S::*)() const volatile &
-                                                      noexcept>());
+static_assert(!check_totally_ordered_with<int[5], int (S::*)() volatile & noexcept>());
+static_assert(!check_totally_ordered_with<int[5], int (S::*)() const volatile&>());
+static_assert(!check_totally_ordered_with<int[5], int (S::*)() const volatile & noexcept>());
 static_assert(!check_totally_ordered_with<int[5], int (S::*)() &&>());
-static_assert(!check_totally_ordered_with < int[5],
-              int (S::*)() && noexcept > ());
+static_assert(!check_totally_ordered_with < int[5], int (S::*)() && noexcept > ());
 static_assert(!check_totally_ordered_with<int[5], int (S::*)() const&&>());
-static_assert(!check_totally_ordered_with < int[5],
-              int (S::*)() const&& noexcept > ());
+static_assert(!check_totally_ordered_with < int[5], int (S::*)() const&& noexcept > ());
 static_assert(!check_totally_ordered_with<int[5], int (S::*)() volatile&&>());
-static_assert(!check_totally_ordered_with < int[5],
-              int (S::*)() volatile&& noexcept > ());
-static_assert(
-    !check_totally_ordered_with<int[5], int (S::*)() const volatile&&>());
-static_assert(!check_totally_ordered_with < int[5],
-              int (S::*)() const volatile&& noexcept > ());
+static_assert(!check_totally_ordered_with < int[5], int (S::*)() volatile&& noexcept > ());
+static_assert(!check_totally_ordered_with<int[5], int (S::*)() const volatile&&>());
+static_assert(!check_totally_ordered_with < int[5], int (S::*)() const volatile&& noexcept > ());
 
 static_assert(check_totally_ordered_with<int (*)(), int (*)()>());
 static_assert(check_totally_ordered_with<int (*)(), int (&)()>());
 static_assert(!check_totally_ordered_with<int (*)(), int (S::*)()>());
 static_assert(!check_totally_ordered_with<int (*)(), int (S::*)() noexcept>());
 static_assert(!check_totally_ordered_with<int (*)(), int (S::*)() const>());
-static_assert(
-    !check_totally_ordered_with<int (*)(), int (S::*)() const noexcept>());
+static_assert(!check_totally_ordered_with<int (*)(), int (S::*)() const noexcept>());
 static_assert(!check_totally_ordered_with<int (*)(), int (S::*)() volatile>());
-static_assert(
-    !check_totally_ordered_with<int (*)(), int (S::*)() volatile noexcept>());
-static_assert(
-    !check_totally_ordered_with<int (*)(), int (S::*)() const volatile>());
-static_assert(!check_totally_ordered_with<
-              int (*)(), int (S::*)() const volatile noexcept>());
+static_assert(!check_totally_ordered_with<int (*)(), int (S::*)() volatile noexcept>());
+static_assert(!check_totally_ordered_with<int (*)(), int (S::*)() const volatile>());
+static_assert(!check_totally_ordered_with< int (*)(), int (S::*)() const volatile noexcept>());
 static_assert(!check_totally_ordered_with<int (*)(), int (S::*)() &>());
-static_assert(
-    !check_totally_ordered_with<int (*)(), int (S::*)() & noexcept>());
+static_assert(!check_totally_ordered_with<int (*)(), int (S::*)() & noexcept>());
 static_assert(!check_totally_ordered_with<int (*)(), int (S::*)() const&>());
-static_assert(
-    !check_totally_ordered_with<int (*)(), int (S::*)() const & noexcept>());
+static_assert(!check_totally_ordered_with<int (*)(), int (S::*)() const & noexcept>());
 static_assert(!check_totally_ordered_with<int (*)(), int (S::*)() volatile&>());
-static_assert(
-    !check_totally_ordered_with<int (*)(), int (S::*)() volatile & noexcept>());
-static_assert(
-    !check_totally_ordered_with<int (*)(), int (S::*)() const volatile&>());
-static_assert(!check_totally_ordered_with<
-              int (*)(), int (S::*)() const volatile & noexcept>());
+static_assert(!check_totally_ordered_with<int (*)(), int (S::*)() volatile & noexcept>());
+static_assert(!check_totally_ordered_with<int (*)(), int (S::*)() const volatile&>());
+static_assert(!check_totally_ordered_with< int (*)(), int (S::*)() const volatile & noexcept>());
 static_assert(!check_totally_ordered_with<int (*)(), int (S::*)() &&>());
-static_assert(!check_totally_ordered_with < int (*)(),
-              int (S::*)() && noexcept > ());
+static_assert(!check_totally_ordered_with < int (*)(), int (S::*)() && noexcept > ());
 static_assert(!check_totally_ordered_with<int (*)(), int (S::*)() const&&>());
-static_assert(!check_totally_ordered_with < int (*)(),
-              int (S::*)() const&& noexcept > ());
-static_assert(
-    !check_totally_ordered_with<int (*)(), int (S::*)() volatile&&>());
-static_assert(!check_totally_ordered_with < int (*)(),
-              int (S::*)() volatile&& noexcept > ());
-static_assert(
-    !check_totally_ordered_with<int (*)(), int (S::*)() const volatile&&>());
-static_assert(!check_totally_ordered_with < int (*)(),
-              int (S::*)() const volatile&& noexcept > ());
+static_assert(!check_totally_ordered_with < int (*)(), int (S::*)() const&& noexcept > ());
+static_assert(!check_totally_ordered_with<int (*)(), int (S::*)() volatile&&>());
+static_assert(!check_totally_ordered_with < int (*)(), int (S::*)() volatile&& noexcept > ());
+static_assert(!check_totally_ordered_with<int (*)(), int (S::*)() const volatile&&>());
+static_assert(!check_totally_ordered_with < int (*)(), int (S::*)() const volatile&& noexcept > ());
 
 static_assert(check_totally_ordered_with<int (&)(), int (&)()>());
 static_assert(!check_totally_ordered_with<int (&)(), int (S::*)()>());
 static_assert(!check_totally_ordered_with<int (&)(), int (S::*)() noexcept>());
 static_assert(!check_totally_ordered_with<int (&)(), int (S::*)() const>());
-static_assert(
-    !check_totally_ordered_with<int (&)(), int (S::*)() const noexcept>());
+static_assert(!check_totally_ordered_with<int (&)(), int (S::*)() const noexcept>());
 static_assert(!check_totally_ordered_with<int (&)(), int (S::*)() volatile>());
-static_assert(
-    !check_totally_ordered_with<int (&)(), int (S::*)() volatile noexcept>());
-static_assert(
-    !check_totally_ordered_with<int (&)(), int (S::*)() const volatile>());
-static_assert(!check_totally_ordered_with<
-              int (&)(), int (S::*)() const volatile noexcept>());
+static_assert(!check_totally_ordered_with<int (&)(), int (S::*)() volatile noexcept>());
+static_assert(!check_totally_ordered_with<int (&)(), int (S::*)() const volatile>());
+static_assert(!check_totally_ordered_with< int (&)(), int (S::*)() const volatile noexcept>());
 static_assert(!check_totally_ordered_with<int (&)(), int (S::*)() &>());
-static_assert(
-    !check_totally_ordered_with<int (&)(), int (S::*)() & noexcept>());
+static_assert(!check_totally_ordered_with<int (&)(), int (S::*)() & noexcept>());
 static_assert(!check_totally_ordered_with<int (&)(), int (S::*)() const&>());
-static_assert(
-    !check_totally_ordered_with<int (&)(), int (S::*)() const & noexcept>());
+static_assert(!check_totally_ordered_with<int (&)(), int (S::*)() const & noexcept>());
 static_assert(!check_totally_ordered_with<int (&)(), int (S::*)() volatile&>());
-static_assert(
-    !check_totally_ordered_with<int (&)(), int (S::*)() volatile & noexcept>());
-static_assert(
-    !check_totally_ordered_with<int (&)(), int (S::*)() const volatile&>());
-static_assert(!check_totally_ordered_with<
-              int (&)(), int (S::*)() const volatile & noexcept>());
+static_assert(!check_totally_ordered_with<int (&)(), int (S::*)() volatile & noexcept>());
+static_assert(!check_totally_ordered_with<int (&)(), int (S::*)() const volatile&>());
+static_assert(!check_totally_ordered_with< int (&)(), int (S::*)() const volatile & noexcept>());
 static_assert(!check_totally_ordered_with<int (&)(), int (S::*)() &&>());
-static_assert(!check_totally_ordered_with < int (&)(),
-              int (S::*)() && noexcept > ());
+static_assert(!check_totally_ordered_with < int (&)(), int (S::*)() && noexcept > ());
 static_assert(!check_totally_ordered_with<int (&)(), int (S::*)() const&&>());
-static_assert(!check_totally_ordered_with < int (&)(),
-              int (S::*)() const&& noexcept > ());
-static_assert(
-    !check_totally_ordered_with<int (&)(), int (S::*)() volatile&&>());
-static_assert(!check_totally_ordered_with < int (&)(),
-              int (S::*)() volatile&& noexcept > ());
-static_assert(
-    !check_totally_ordered_with<int (&)(), int (S::*)() const volatile&&>());
-static_assert(!check_totally_ordered_with < int (&)(),
-              int (S::*)() const volatile&& noexcept > ());
+static_assert(!check_totally_ordered_with < int (&)(), int (S::*)() const&& noexcept > ());
+static_assert(!check_totally_ordered_with<int (&)(), int (S::*)() volatile&&>());
+static_assert(!check_totally_ordered_with < int (&)(), int (S::*)() volatile&& noexcept > ());
+static_assert(!check_totally_ordered_with<int (&)(), int (S::*)() const volatile&&>());
+static_assert(!check_totally_ordered_with < int (&)(), int (S::*)() const volatile&& noexcept > ());
 
 static_assert(!check_totally_ordered_with<int (S::*)(), int (S::*)()>());
-static_assert(
-    !check_totally_ordered_with<int (S::*)(), int (S::*)() noexcept>());
+static_assert(!check_totally_ordered_with<int (S::*)(), int (S::*)() noexcept>());
 static_assert(!check_totally_ordered_with<int (S::*)(), int (S::*)() const>());
-static_assert(
-    !check_totally_ordered_with<int (S::*)(), int (S::*)() const noexcept>());
-static_assert(
-    !check_totally_ordered_with<int (S::*)(), int (S::*)() volatile>());
-static_assert(!check_totally_ordered_with<int (S::*)(),
-                                          int (S::*)() volatile noexcept>());
-static_assert(
-    !check_totally_ordered_with<int (S::*)(), int (S::*)() const volatile>());
-static_assert(!check_totally_ordered_with<
-              int (S::*)(), int (S::*)() const volatile noexcept>());
+static_assert(!check_totally_ordered_with<int (S::*)(), int (S::*)() const noexcept>());
+static_assert(!check_totally_ordered_with<int (S::*)(), int (S::*)() volatile>());
+static_assert(!check_totally_ordered_with<int (S::*)(), int (S::*)() volatile noexcept>());
+static_assert(!check_totally_ordered_with<int (S::*)(), int (S::*)() const volatile>());
+static_assert(!check_totally_ordered_with< int (S::*)(), int (S::*)() const volatile noexcept>());
 static_assert(!check_totally_ordered_with<int (S::*)(), int (S::*)() &>());
-static_assert(
-    !check_totally_ordered_with<int (S::*)(), int (S::*)() & noexcept>());
+static_assert(!check_totally_ordered_with<int (S::*)(), int (S::*)() & noexcept>());
 static_assert(!check_totally_ordered_with<int (S::*)(), int (S::*)() const&>());
-static_assert(
-    !check_totally_ordered_with<int (S::*)(), int (S::*)() const & noexcept>());
-static_assert(
-    !check_totally_ordered_with<int (S::*)(), int (S::*)() volatile&>());
-static_assert(!check_totally_ordered_with<int (S::*)(),
-                                          int (S::*)() volatile & noexcept>());
-static_assert(
-    !check_totally_ordered_with<int (S::*)(), int (S::*)() const volatile&>());
-static_assert(!check_totally_ordered_with<
-              int (S::*)(), int (S::*)() const volatile & noexcept>());
+static_assert(!check_totally_ordered_with<int (S::*)(), int (S::*)() const & noexcept>());
+static_assert(!check_totally_ordered_with<int (S::*)(), int (S::*)() volatile&>());
+static_assert(!check_totally_ordered_with<int (S::*)(), int (S::*)() volatile & noexcept>());
+static_assert(!check_totally_ordered_with<int (S::*)(), int (S::*)() const volatile&>());
+static_assert(!check_totally_ordered_with< int (S::*)(), int (S::*)() const volatile & noexcept>());
 static_assert(!check_totally_ordered_with<int (S::*)(), int (S::*)() &&>());
-static_assert(!check_totally_ordered_with < int (S::*)(),
-              int (S::*)() && noexcept > ());
-static_assert(
-    !check_totally_ordered_with<int (S::*)(), int (S::*)() const&&>());
-static_assert(!check_totally_ordered_with < int (S::*)(),
-              int (S::*)() const&& noexcept > ());
-static_assert(
-    !check_totally_ordered_with<int (S::*)(), int (S::*)() volatile&&>());
-static_assert(!check_totally_ordered_with < int (S::*)(),
-              int (S::*)() volatile&& noexcept > ());
-static_assert(
-    !check_totally_ordered_with<int (S::*)(), int (S::*)() const volatile&&>());
-static_assert(!check_totally_ordered_with < int (S::*)(),
-              int (S::*)() const volatile&& noexcept > ());
+static_assert(!check_totally_ordered_with < int(S::*)(), int (S::*)() && noexcept > ());
+static_assert(!check_totally_ordered_with<int (S::*)(), int (S::*)() const&&>());
+static_assert(!check_totally_ordered_with < int(S::*)(), int (S::*)() const&& noexcept > ());
+static_assert(!check_totally_ordered_with<int (S::*)(), int (S::*)() volatile&&>());
+static_assert(!check_totally_ordered_with < int(S::*)(), int (S::*)() volatile&& noexcept > ());
+static_assert(!check_totally_ordered_with<int (S::*)(), int (S::*)() const volatile&&>());
+static_assert(!check_totally_ordered_with < int(S::*)(), int (S::*)() const volatile&& noexcept > ());
 
-static_assert(!check_totally_ordered_with<int (S::*)() noexcept,
-                                          int (S::*)() noexcept>());
-static_assert(
-    !check_totally_ordered_with<int (S::*)() noexcept, int (S::*)() const>());
-static_assert(!check_totally_ordered_with<int (S::*)() noexcept,
-                                          int (S::*)() const noexcept>());
-static_assert(!check_totally_ordered_with<int (S::*)() noexcept,
-                                          int (S::*)() volatile>());
-static_assert(!check_totally_ordered_with<int (S::*)() noexcept,
-                                          int (S::*)() volatile noexcept>());
-static_assert(!check_totally_ordered_with<int (S::*)() noexcept,
-                                          int (S::*)() const volatile>());
-static_assert(!check_totally_ordered_with<
-              int (S::*)() noexcept, int (S::*)() const volatile noexcept>());
-static_assert(
-    !check_totally_ordered_with<int (S::*)() noexcept, int (S::*)() &>());
-static_assert(!check_totally_ordered_with<int (S::*)() noexcept,
-                                          int (S::*)() & noexcept>());
-static_assert(
-    !check_totally_ordered_with<int (S::*)() noexcept, int (S::*)() const&>());
-static_assert(!check_totally_ordered_with<int (S::*)() noexcept,
-                                          int (S::*)() const & noexcept>());
-static_assert(!check_totally_ordered_with<int (S::*)() noexcept,
-                                          int (S::*)() volatile&>());
-static_assert(!check_totally_ordered_with<int (S::*)() noexcept,
-                                          int (S::*)() volatile & noexcept>());
-static_assert(!check_totally_ordered_with<int (S::*)() noexcept,
-                                          int (S::*)() const volatile&>());
-static_assert(!check_totally_ordered_with<
-              int (S::*)() noexcept, int (S::*)() const volatile & noexcept>());
-static_assert(
-    !check_totally_ordered_with<int (S::*)() noexcept, int (S::*)() &&>());
-static_assert(!check_totally_ordered_with < int (S::*)() noexcept,
-              int (S::*)() && noexcept > ());
-static_assert(
-    !check_totally_ordered_with<int (S::*)() noexcept, int (S::*)() const&&>());
-static_assert(!check_totally_ordered_with < int (S::*)() noexcept,
-              int (S::*)() const&& noexcept > ());
-static_assert(!check_totally_ordered_with<int (S::*)() noexcept,
-                                          int (S::*)() volatile&&>());
-static_assert(!check_totally_ordered_with < int (S::*)() noexcept,
-              int (S::*)() volatile&& noexcept > ());
-static_assert(!check_totally_ordered_with<int (S::*)() noexcept,
-                                          int (S::*)() const volatile&&>());
-static_assert(!check_totally_ordered_with < int (S::*)() noexcept,
-              int (S::*)() const volatile&& noexcept > ());
+static_assert(!check_totally_ordered_with<int (S::*)() noexcept, int (S::*)() noexcept>());
+static_assert(!check_totally_ordered_with<int (S::*)() noexcept, int (S::*)() const>());
+static_assert(!check_totally_ordered_with<int (S::*)() noexcept, int (S::*)() const noexcept>());
+static_assert(!check_totally_ordered_with<int (S::*)() noexcept, int (S::*)() volatile>());
+static_assert(!check_totally_ordered_with<int (S::*)() noexcept, int (S::*)() volatile noexcept>());
+static_assert(!check_totally_ordered_with<int (S::*)() noexcept, int (S::*)() const volatile>());
+static_assert(!check_totally_ordered_with< int (S::*)() noexcept, int (S::*)() const volatile noexcept>());
+static_assert(!check_totally_ordered_with<int (S::*)() noexcept, int (S::*)() &>());
+static_assert(!check_totally_ordered_with<int (S::*)() noexcept, int (S::*)() & noexcept>());
+static_assert(!check_totally_ordered_with<int (S::*)() noexcept, int (S::*)() const&>());
+static_assert(!check_totally_ordered_with<int (S::*)() noexcept, int (S::*)() const & noexcept>());
+static_assert(!check_totally_ordered_with<int (S::*)() noexcept, int (S::*)() volatile&>());
+static_assert(!check_totally_ordered_with<int (S::*)() noexcept, int (S::*)() volatile & noexcept>());
+static_assert(!check_totally_ordered_with<int (S::*)() noexcept, int (S::*)() const volatile&>());
+static_assert(!check_totally_ordered_with< int (S::*)() noexcept, int (S::*)() const volatile & noexcept>());
+static_assert(!check_totally_ordered_with<int (S::*)() noexcept, int (S::*)() &&>());
+static_assert(!check_totally_ordered_with < int(S::*)() noexcept, int (S::*)() && noexcept > ());
+static_assert(!check_totally_ordered_with<int (S::*)() noexcept, int (S::*)() const&&>());
+static_assert(!check_totally_ordered_with < int(S::*)() noexcept, int (S::*)() const&& noexcept > ());
+static_assert(!check_totally_ordered_with<int (S::*)() noexcept, int (S::*)() volatile&&>());
+static_assert(!check_totally_ordered_with < int(S::*)() noexcept, int (S::*)() volatile&& noexcept > ());
+static_assert(!check_totally_ordered_with<int (S::*)() noexcept, int (S::*)() const volatile&&>());
+static_assert(!check_totally_ordered_with < int(S::*)() noexcept, int (S::*)() const volatile&& noexcept > ());
 
-static_assert(
-    !check_totally_ordered_with<int (S::*)() const, int (S::*)() const>());
-static_assert(!check_totally_ordered_with<int (S::*)() const,
-                                          int (S::*)() const noexcept>());
-static_assert(
-    !check_totally_ordered_with<int (S::*)() const, int (S::*)() volatile>());
-static_assert(!check_totally_ordered_with<int (S::*)() const,
-                                          int (S::*)() volatile noexcept>());
-static_assert(!check_totally_ordered_with<int (S::*)() const,
-                                          int (S::*)() const volatile>());
-static_assert(!check_totally_ordered_with<
-              int (S::*)() const, int (S::*)() const volatile noexcept>());
-static_assert(
-    !check_totally_ordered_with<int (S::*)() const, int (S::*)() &>());
-static_assert(
-    !check_totally_ordered_with<int (S::*)() const, int (S::*)() & noexcept>());
-static_assert(
-    !check_totally_ordered_with<int (S::*)() const, int (S::*)() const&>());
-static_assert(!check_totally_ordered_with<int (S::*)() const,
-                                          int (S::*)() const & noexcept>());
-static_assert(
-    !check_totally_ordered_with<int (S::*)() const, int (S::*)() volatile&>());
-static_assert(!check_totally_ordered_with<int (S::*)() const,
-                                          int (S::*)() volatile & noexcept>());
-static_assert(!check_totally_ordered_with<int (S::*)() const,
-                                          int (S::*)() const volatile&>());
-static_assert(!check_totally_ordered_with<
-              int (S::*)() const, int (S::*)() const volatile & noexcept>());
-static_assert(
-    !check_totally_ordered_with<int (S::*)() const, int (S::*)() &&>());
-static_assert(!check_totally_ordered_with < int (S::*)() const,
-              int (S::*)() && noexcept > ());
-static_assert(
-    !check_totally_ordered_with<int (S::*)() const, int (S::*)() const&&>());
-static_assert(!check_totally_ordered_with < int (S::*)() const,
-              int (S::*)() const&& noexcept > ());
-static_assert(
-    !check_totally_ordered_with<int (S::*)() const, int (S::*)() volatile&&>());
-static_assert(!check_totally_ordered_with < int (S::*)() const,
-              int (S::*)() volatile&& noexcept > ());
-static_assert(!check_totally_ordered_with<int (S::*)() const,
-                                          int (S::*)() const volatile&&>());
-static_assert(!check_totally_ordered_with < int (S::*)() const,
-              int (S::*)() const volatile&& noexcept > ());
+static_assert(!check_totally_ordered_with<int (S::*)() const, int (S::*)() const>());
+static_assert(!check_totally_ordered_with<int (S::*)() const, int (S::*)() const noexcept>());
+static_assert(!check_totally_ordered_with<int (S::*)() const, int (S::*)() volatile>());
+static_assert(!check_totally_ordered_with<int (S::*)() const, int (S::*)() volatile noexcept>());
+static_assert(!check_totally_ordered_with<int (S::*)() const, int (S::*)() const volatile>());
+static_assert(!check_totally_ordered_with< int (S::*)() const, int (S::*)() const volatile noexcept>());
+static_assert(!check_totally_ordered_with<int (S::*)() const, int (S::*)() &>());
+static_assert(!check_totally_ordered_with<int (S::*)() const, int (S::*)() & noexcept>());
+static_assert(!check_totally_ordered_with<int (S::*)() const, int (S::*)() const&>());
+static_assert(!check_totally_ordered_with<int (S::*)() const, int (S::*)() const & noexcept>());
+static_assert(!check_totally_ordered_with<int (S::*)() const, int (S::*)() volatile&>());
+static_assert(!check_totally_ordered_with<int (S::*)() const, int (S::*)() volatile & noexcept>());
+static_assert(!check_totally_ordered_with<int (S::*)() const, int (S::*)() const volatile&>());
+static_assert(!check_totally_ordered_with< int (S::*)() const, int (S::*)() const volatile & noexcept>());
+static_assert(!check_totally_ordered_with<int (S::*)() const, int (S::*)() &&>());
+static_assert(!check_totally_ordered_with < int(S::*)() const, int (S::*)() && noexcept > ());
+static_assert(!check_totally_ordered_with<int (S::*)() const, int (S::*)() const&&>());
+static_assert(!check_totally_ordered_with < int(S::*)() const, int (S::*)() const&& noexcept > ());
+static_assert(!check_totally_ordered_with<int (S::*)() const, int (S::*)() volatile&&>());
+static_assert(!check_totally_ordered_with < int(S::*)() const, int (S::*)() volatile&& noexcept > ());
+static_assert(!check_totally_ordered_with<int (S::*)() const, int (S::*)() const volatile&&>());
+static_assert(!check_totally_ordered_with < int(S::*)() const, int (S::*)() const volatile&& noexcept > ());
 
-static_assert(!check_totally_ordered_with<int (S::*)() const noexcept,
-                                          int (S::*)() const noexcept>());
-static_assert(!check_totally_ordered_with<int (S::*)() const noexcept,
-                                          int (S::*)() volatile>());
-static_assert(!check_totally_ordered_with<int (S::*)() const noexcept,
-                                          int (S::*)() volatile noexcept>());
-static_assert(!check_totally_ordered_with<int (S::*)() const noexcept,
-                                          int (S::*)() const volatile>());
-static_assert(
-    !check_totally_ordered_with<int (S::*)() const noexcept,
-                                int (S::*)() const volatile noexcept>());
-static_assert(
-    !check_totally_ordered_with<int (S::*)() const noexcept, int (S::*)() &>());
-static_assert(!check_totally_ordered_with<int (S::*)() const noexcept,
-                                          int (S::*)() & noexcept>());
-static_assert(!check_totally_ordered_with<int (S::*)() const noexcept,
-                                          int (S::*)() const&>());
-static_assert(!check_totally_ordered_with<int (S::*)() const noexcept,
-                                          int (S::*)() const & noexcept>());
-static_assert(!check_totally_ordered_with<int (S::*)() const noexcept,
-                                          int (S::*)() volatile&>());
-static_assert(!check_totally_ordered_with<int (S::*)() const noexcept,
-                                          int (S::*)() volatile & noexcept>());
-static_assert(!check_totally_ordered_with<int (S::*)() const noexcept,
-                                          int (S::*)() const volatile&>());
-static_assert(
-    !check_totally_ordered_with<int (S::*)() const noexcept,
-                                int (S::*)() const volatile & noexcept>());
-static_assert(!check_totally_ordered_with<int (S::*)() const noexcept,
-                                          int (S::*)() &&>());
-static_assert(!check_totally_ordered_with < int (S::*)() const noexcept,
-              int (S::*)() && noexcept > ());
-static_assert(!check_totally_ordered_with<int (S::*)() const noexcept,
-                                          int (S::*)() const&&>());
-static_assert(!check_totally_ordered_with < int (S::*)() const noexcept,
-              int (S::*)() const&& noexcept > ());
-static_assert(!check_totally_ordered_with<int (S::*)() const noexcept,
-                                          int (S::*)() volatile&&>());
-static_assert(!check_totally_ordered_with < int (S::*)() const noexcept,
-              int (S::*)() volatile&& noexcept > ());
-static_assert(!check_totally_ordered_with<int (S::*)() const noexcept,
-                                          int (S::*)() const volatile&&>());
-static_assert(!check_totally_ordered_with < int (S::*)() const noexcept,
-              int (S::*)() const volatile&& noexcept > ());
+static_assert(!check_totally_ordered_with<int (S::*)() const noexcept, int (S::*)() const noexcept>());
+static_assert(!check_totally_ordered_with<int (S::*)() const noexcept, int (S::*)() volatile>());
+static_assert(!check_totally_ordered_with<int (S::*)() const noexcept, int (S::*)() volatile noexcept>());
+static_assert(!check_totally_ordered_with<int (S::*)() const noexcept, int (S::*)() const volatile>());
+static_assert(!check_totally_ordered_with<int (S::*)() const noexcept, int (S::*)() const volatile noexcept>());
+static_assert(!check_totally_ordered_with<int (S::*)() const noexcept, int (S::*)() &>());
+static_assert(!check_totally_ordered_with<int (S::*)() const noexcept, int (S::*)() & noexcept>());
+static_assert(!check_totally_ordered_with<int (S::*)() const noexcept, int (S::*)() const&>());
+static_assert(!check_totally_ordered_with<int (S::*)() const noexcept, int (S::*)() const & noexcept>());
+static_assert(!check_totally_ordered_with<int (S::*)() const noexcept, int (S::*)() volatile&>());
+static_assert(!check_totally_ordered_with<int (S::*)() const noexcept, int (S::*)() volatile & noexcept>());
+static_assert(!check_totally_ordered_with<int (S::*)() const noexcept, int (S::*)() const volatile&>());
+static_assert(!check_totally_ordered_with<int (S::*)() const noexcept, int (S::*)() const volatile & noexcept>());
+static_assert(!check_totally_ordered_with<int (S::*)() const noexcept, int (S::*)() &&>());
+static_assert(!check_totally_ordered_with < int(S::*)() const noexcept, int (S::*)() && noexcept > ());
+static_assert(!check_totally_ordered_with<int (S::*)() const noexcept, int (S::*)() const&&>());
+static_assert(!check_totally_ordered_with < int(S::*)() const noexcept, int (S::*)() const&& noexcept > ());
+static_assert(!check_totally_ordered_with<int (S::*)() const noexcept, int (S::*)() volatile&&>());
+static_assert(!check_totally_ordered_with < int(S::*)() const noexcept, int (S::*)() volatile&& noexcept > ());
+static_assert(!check_totally_ordered_with<int (S::*)() const noexcept, int (S::*)() const volatile&&>());
+static_assert(!check_totally_ordered_with < int(S::*)() const noexcept, int (S::*)() const volatile&& noexcept > ());
 
-static_assert(!check_totally_ordered_with<int (S::*)() volatile,
-                                          int (S::*)() volatile>());
-static_assert(!check_totally_ordered_with<int (S::*)() volatile,
-                                          int (S::*)() volatile noexcept>());
-static_assert(!check_totally_ordered_with<int (S::*)() volatile,
-                                          int (S::*)() const volatile>());
-static_assert(!check_totally_ordered_with<
-              int (S::*)() volatile, int (S::*)() const volatile noexcept>());
-static_assert(
-    !check_totally_ordered_with<int (S::*)() volatile, int (S::*)() &>());
-static_assert(!check_totally_ordered_with<int (S::*)() volatile,
-                                          int (S::*)() & noexcept>());
-static_assert(
-    !check_totally_ordered_with<int (S::*)() volatile, int (S::*)() const&>());
-static_assert(!check_totally_ordered_with<int (S::*)() volatile,
-                                          int (S::*)() const & noexcept>());
-static_assert(!check_totally_ordered_with<int (S::*)() volatile,
-                                          int (S::*)() volatile&>());
-static_assert(!check_totally_ordered_with<int (S::*)() volatile,
-                                          int (S::*)() volatile & noexcept>());
-static_assert(!check_totally_ordered_with<int (S::*)() volatile,
-                                          int (S::*)() const volatile&>());
-static_assert(!check_totally_ordered_with<
-              int (S::*)() volatile, int (S::*)() const volatile & noexcept>());
-static_assert(
-    !check_totally_ordered_with<int (S::*)() volatile, int (S::*)() &&>());
-static_assert(!check_totally_ordered_with < int (S::*)() volatile,
-              int (S::*)() && noexcept > ());
-static_assert(
-    !check_totally_ordered_with<int (S::*)() volatile, int (S::*)() const&&>());
-static_assert(!check_totally_ordered_with < int (S::*)() volatile,
-              int (S::*)() const&& noexcept > ());
-static_assert(!check_totally_ordered_with<int (S::*)() volatile,
-                                          int (S::*)() volatile&&>());
-static_assert(!check_totally_ordered_with < int (S::*)() volatile,
-              int (S::*)() volatile&& noexcept > ());
-static_assert(!check_totally_ordered_with<int (S::*)() volatile,
-                                          int (S::*)() const volatile&&>());
-static_assert(!check_totally_ordered_with < int (S::*)() volatile,
-              int (S::*)() const volatile&& noexcept > ());
+static_assert(!check_totally_ordered_with<int (S::*)() volatile, int (S::*)() volatile>());
+static_assert(!check_totally_ordered_with<int (S::*)() volatile, int (S::*)() volatile noexcept>());
+static_assert(!check_totally_ordered_with<int (S::*)() volatile, int (S::*)() const volatile>());
+static_assert(!check_totally_ordered_with< int (S::*)() volatile, int (S::*)() const volatile noexcept>());
+static_assert(!check_totally_ordered_with<int (S::*)() volatile, int (S::*)() &>());
+static_assert(!check_totally_ordered_with<int (S::*)() volatile, int (S::*)() & noexcept>());
+static_assert(!check_totally_ordered_with<int (S::*)() volatile, int (S::*)() const&>());
+static_assert(!check_totally_ordered_with<int (S::*)() volatile, int (S::*)() const & noexcept>());
+static_assert(!check_totally_ordered_with<int (S::*)() volatile, int (S::*)() volatile&>());
+static_assert(!check_totally_ordered_with<int (S::*)() volatile, int (S::*)() volatile & noexcept>());
+static_assert(!check_totally_ordered_with<int (S::*)() volatile, int (S::*)() const volatile&>());
+static_assert(!check_totally_ordered_with< int (S::*)() volatile, int (S::*)() const volatile & noexcept>());
+static_assert(!check_totally_ordered_with<int (S::*)() volatile, int (S::*)() &&>());
+static_assert(!check_totally_ordered_with < int(S::*)() volatile, int (S::*)() && noexcept > ());
+static_assert(!check_totally_ordered_with<int (S::*)() volatile, int (S::*)() const&&>());
+static_assert(!check_totally_ordered_with < int(S::*)() volatile, int (S::*)() const&& noexcept > ());
+static_assert(!check_totally_ordered_with<int (S::*)() volatile, int (S::*)() volatile&&>());
+static_assert(!check_totally_ordered_with < int(S::*)() volatile, int (S::*)() volatile&& noexcept > ());
+static_assert(!check_totally_ordered_with<int (S::*)() volatile, int (S::*)() const volatile&&>());
+static_assert(!check_totally_ordered_with < int(S::*)() volatile, int (S::*)() const volatile&& noexcept > ());
 
-static_assert(!check_totally_ordered_with<int (S::*)() volatile noexcept,
-                                          int (S::*)() volatile noexcept>());
-static_assert(!check_totally_ordered_with<int (S::*)() volatile noexcept,
-                                          int (S::*)() const volatile>());
-static_assert(
-    !check_totally_ordered_with<int (S::*)() volatile noexcept,
-                                int (S::*)() const volatile noexcept>());
-static_assert(!check_totally_ordered_with<int (S::*)() volatile noexcept,
-                                          int (S::*)() &>());
-static_assert(!check_totally_ordered_with<int (S::*)() volatile noexcept,
-                                          int (S::*)() & noexcept>());
-static_assert(!check_totally_ordered_with<int (S::*)() volatile noexcept,
-                                          int (S::*)() const&>());
-static_assert(!check_totally_ordered_with<int (S::*)() volatile noexcept,
-                                          int (S::*)() const & noexcept>());
-static_assert(!check_totally_ordered_with<int (S::*)() volatile noexcept,
-                                          int (S::*)() volatile&>());
-static_assert(!check_totally_ordered_with<int (S::*)() volatile noexcept,
-                                          int (S::*)() volatile & noexcept>());
-static_assert(!check_totally_ordered_with<int (S::*)() volatile noexcept,
-                                          int (S::*)() const volatile&>());
-static_assert(
-    !check_totally_ordered_with<int (S::*)() volatile noexcept,
-                                int (S::*)() const volatile & noexcept>());
-static_assert(!check_totally_ordered_with<int (S::*)() volatile noexcept,
-                                          int (S::*)() &&>());
-static_assert(!check_totally_ordered_with < int (S::*)() volatile noexcept,
-              int (S::*)() && noexcept > ());
-static_assert(!check_totally_ordered_with<int (S::*)() volatile noexcept,
-                                          int (S::*)() const&&>());
-static_assert(!check_totally_ordered_with < int (S::*)() volatile noexcept,
-              int (S::*)() const&& noexcept > ());
-static_assert(!check_totally_ordered_with<int (S::*)() volatile noexcept,
-                                          int (S::*)() volatile&&>());
-static_assert(!check_totally_ordered_with < int (S::*)() volatile noexcept,
-              int (S::*)() volatile&& noexcept > ());
-static_assert(!check_totally_ordered_with<int (S::*)() volatile noexcept,
-                                          int (S::*)() const volatile&&>());
-static_assert(!check_totally_ordered_with < int (S::*)() volatile noexcept,
-              int (S::*)() const volatile&& noexcept > ());
+static_assert(!check_totally_ordered_with<int (S::*)() volatile noexcept, int (S::*)() volatile noexcept>());
+static_assert(!check_totally_ordered_with<int (S::*)() volatile noexcept, int (S::*)() const volatile>());
+static_assert(!check_totally_ordered_with<int (S::*)() volatile noexcept, int (S::*)() const volatile noexcept>());
+static_assert(!check_totally_ordered_with<int (S::*)() volatile noexcept, int (S::*)() &>());
+static_assert(!check_totally_ordered_with<int (S::*)() volatile noexcept, int (S::*)() & noexcept>());
+static_assert(!check_totally_ordered_with<int (S::*)() volatile noexcept, int (S::*)() const&>());
+static_assert(!check_totally_ordered_with<int (S::*)() volatile noexcept, int (S::*)() const & noexcept>());
+static_assert(!check_totally_ordered_with<int (S::*)() volatile noexcept, int (S::*)() volatile&>());
+static_assert(!check_totally_ordered_with<int (S::*)() volatile noexcept, int (S::*)() volatile & noexcept>());
+static_assert(!check_totally_ordered_with<int (S::*)() volatile noexcept, int (S::*)() const volatile&>());
+static_assert(!check_totally_ordered_with<int (S::*)() volatile noexcept, int (S::*)() const volatile & noexcept>());
+static_assert(!check_totally_ordered_with<int (S::*)() volatile noexcept, int (S::*)() &&>());
+static_assert(!check_totally_ordered_with < int(S::*)() volatile noexcept, int (S::*)() && noexcept > ());
+static_assert(!check_totally_ordered_with<int (S::*)() volatile noexcept, int (S::*)() const&&>());
+static_assert(!check_totally_ordered_with < int(S::*)() volatile noexcept, int (S::*)() const&& noexcept > ());
+static_assert(!check_totally_ordered_with<int (S::*)() volatile noexcept, int (S::*)() volatile&&>());
+static_assert(!check_totally_ordered_with < int(S::*)() volatile noexcept, int (S::*)() volatile&& noexcept > ());
+static_assert(!check_totally_ordered_with<int (S::*)() volatile noexcept, int (S::*)() const volatile&&>());
+static_assert(!check_totally_ordered_with < int(S::*)() volatile noexcept, int (S::*)() const volatile&& noexcept > ());
 
-static_assert(!check_totally_ordered_with<int (S::*)() const volatile,
-                                          int (S::*)() const volatile>());
-static_assert(
-    !check_totally_ordered_with<int (S::*)() const volatile,
-                                int (S::*)() const volatile noexcept>());
-static_assert(
-    !check_totally_ordered_with<int (S::*)() const volatile, int (S::*)() &>());
-static_assert(!check_totally_ordered_with<int (S::*)() const volatile,
-                                          int (S::*)() & noexcept>());
-static_assert(!check_totally_ordered_with<int (S::*)() const volatile,
-                                          int (S::*)() const&>());
-static_assert(!check_totally_ordered_with<int (S::*)() const volatile,
-                                          int (S::*)() const & noexcept>());
-static_assert(!check_totally_ordered_with<int (S::*)() const volatile,
-                                          int (S::*)() volatile&>());
-static_assert(!check_totally_ordered_with<int (S::*)() const volatile,
-                                          int (S::*)() volatile & noexcept>());
-static_assert(!check_totally_ordered_with<int (S::*)() const volatile,
-                                          int (S::*)() const volatile&>());
-static_assert(
-    !check_totally_ordered_with<int (S::*)() const volatile,
-                                int (S::*)() const volatile & noexcept>());
-static_assert(!check_totally_ordered_with<int (S::*)() const volatile,
-                                          int (S::*)() &&>());
-static_assert(!check_totally_ordered_with < int (S::*)() const volatile,
-              int (S::*)() && noexcept > ());
-static_assert(!check_totally_ordered_with<int (S::*)() const volatile,
-                                          int (S::*)() const&&>());
-static_assert(!check_totally_ordered_with < int (S::*)() const volatile,
-              int (S::*)() const&& noexcept > ());
-static_assert(!check_totally_ordered_with<int (S::*)() const volatile,
-                                          int (S::*)() volatile&&>());
-static_assert(!check_totally_ordered_with < int (S::*)() const volatile,
-              int (S::*)() volatile&& noexcept > ());
-static_assert(!check_totally_ordered_with<int (S::*)() const volatile,
-                                          int (S::*)() const volatile&&>());
-static_assert(!check_totally_ordered_with < int (S::*)() const volatile,
-              int (S::*)() const volatile&& noexcept > ());
+static_assert(!check_totally_ordered_with<int (S::*)() const volatile, int (S::*)() const volatile>());
+static_assert(!check_totally_ordered_with<int (S::*)() const volatile, int (S::*)() const volatile noexcept>());
+static_assert(!check_totally_ordered_with<int (S::*)() const volatile, int (S::*)() &>());
+static_assert(!check_totally_ordered_with<int (S::*)() const volatile, int (S::*)() & noexcept>());
+static_assert(!check_totally_ordered_with<int (S::*)() const volatile, int (S::*)() const&>());
+static_assert(!check_totally_ordered_with<int (S::*)() const volatile, int (S::*)() const & noexcept>());
+static_assert(!check_totally_ordered_with<int (S::*)() const volatile, int (S::*)() volatile&>());
+static_assert(!check_totally_ordered_with<int (S::*)() const volatile, int (S::*)() volatile & noexcept>());
+static_assert(!check_totally_ordered_with<int (S::*)() const volatile, int (S::*)() const volatile&>());
+static_assert(!check_totally_ordered_with<int (S::*)() const volatile, int (S::*)() const volatile & noexcept>());
+static_assert(!check_totally_ordered_with<int (S::*)() const volatile, int (S::*)() &&>());
+static_assert(!check_totally_ordered_with < int(S::*)() const volatile, int (S::*)() && noexcept > ());
+static_assert(!check_totally_ordered_with<int (S::*)() const volatile, int (S::*)() const&&>());
+static_assert(!check_totally_ordered_with < int(S::*)() const volatile, int (S::*)() const&& noexcept > ());
+static_assert(!check_totally_ordered_with<int (S::*)() const volatile, int (S::*)() volatile&&>());
+static_assert(!check_totally_ordered_with < int(S::*)() const volatile, int (S::*)() volatile&& noexcept > ());
+static_assert(!check_totally_ordered_with<int (S::*)() const volatile, int (S::*)() const volatile&&>());
+static_assert(!check_totally_ordered_with < int(S::*)() const volatile, int (S::*)() const volatile&& noexcept > ());
 
 static_assert(
-    !check_totally_ordered_with<int (S::*)() const volatile noexcept,
-                                int (S::*)() const volatile noexcept>());
-static_assert(!check_totally_ordered_with<int (S::*)() const volatile noexcept,
-                                          int (S::*)() &>());
-static_assert(!check_totally_ordered_with<int (S::*)() const volatile noexcept,
-                                          int (S::*)() & noexcept>());
-static_assert(!check_totally_ordered_with<int (S::*)() const volatile noexcept,
-                                          int (S::*)() const&>());
-static_assert(!check_totally_ordered_with<int (S::*)() const volatile noexcept,
-                                          int (S::*)() const & noexcept>());
-static_assert(!check_totally_ordered_with<int (S::*)() const volatile noexcept,
-                                          int (S::*)() volatile&>());
-static_assert(!check_totally_ordered_with<int (S::*)() const volatile noexcept,
-                                          int (S::*)() volatile & noexcept>());
-static_assert(!check_totally_ordered_with<int (S::*)() const volatile noexcept,
-                                          int (S::*)() const volatile&>());
+    !check_totally_ordered_with<int (S::*)() const volatile noexcept, int (S::*)() const volatile noexcept>());
+static_assert(!check_totally_ordered_with<int (S::*)() const volatile noexcept, int (S::*)() &>());
+static_assert(!check_totally_ordered_with<int (S::*)() const volatile noexcept, int (S::*)() & noexcept>());
+static_assert(!check_totally_ordered_with<int (S::*)() const volatile noexcept, int (S::*)() const&>());
+static_assert(!check_totally_ordered_with<int (S::*)() const volatile noexcept, int (S::*)() const & noexcept>());
+static_assert(!check_totally_ordered_with<int (S::*)() const volatile noexcept, int (S::*)() volatile&>());
+static_assert(!check_totally_ordered_with<int (S::*)() const volatile noexcept, int (S::*)() volatile & noexcept>());
+static_assert(!check_totally_ordered_with<int (S::*)() const volatile noexcept, int (S::*)() const volatile&>());
 static_assert(
-    !check_totally_ordered_with<int (S::*)() const volatile noexcept,
-                                int (S::*)() const volatile & noexcept>());
-static_assert(!check_totally_ordered_with<int (S::*)() const volatile noexcept,
-                                          int (S::*)() &&>());
-static_assert(!check_totally_ordered_with < int (S::*)()
-                                                const volatile noexcept,
-              int (S::*)() && noexcept > ());
-static_assert(!check_totally_ordered_with<int (S::*)() const volatile noexcept,
-                                          int (S::*)() const&&>());
-static_assert(!check_totally_ordered_with < int (S::*)()
-                                                const volatile noexcept,
-              int (S::*)() const&& noexcept > ());
-static_assert(!check_totally_ordered_with<int (S::*)() const volatile noexcept,
-                                          int (S::*)() volatile&&>());
-static_assert(!check_totally_ordered_with < int (S::*)()
-                                                const volatile noexcept,
-              int (S::*)() volatile&& noexcept > ());
-static_assert(!check_totally_ordered_with<int (S::*)() const volatile noexcept,
-                                          int (S::*)() const volatile&&>());
-static_assert(!check_totally_ordered_with < int (S::*)()
-                                                const volatile noexcept,
+    !check_totally_ordered_with<int (S::*)() const volatile noexcept, int (S::*)() const volatile & noexcept>());
+static_assert(!check_totally_ordered_with<int (S::*)() const volatile noexcept, int (S::*)() &&>());
+static_assert(!check_totally_ordered_with < int(S::*)() const volatile noexcept, int (S::*)() && noexcept > ());
+static_assert(!check_totally_ordered_with<int (S::*)() const volatile noexcept, int (S::*)() const&&>());
+static_assert(!check_totally_ordered_with < int(S::*)() const volatile noexcept, int (S::*)() const&& noexcept > ());
+static_assert(!check_totally_ordered_with<int (S::*)() const volatile noexcept, int (S::*)() volatile&&>());
+static_assert(!check_totally_ordered_with < int(S::*)() const volatile noexcept, int (S::*)() volatile&& noexcept > ());
+static_assert(!check_totally_ordered_with<int (S::*)() const volatile noexcept, int (S::*)() const volatile&&>());
+static_assert(!check_totally_ordered_with < int(S::*)() const volatile noexcept,
               int (S::*)() const volatile&& noexcept > ());
 
 static_assert(!check_totally_ordered_with<int (S::*)() &, int (S::*)() &>());
-static_assert(
-    !check_totally_ordered_with<int (S::*)() &, int (S::*)() & noexcept>());
-static_assert(
-    !check_totally_ordered_with<int (S::*)() &, int (S::*)() const&>());
-static_assert(!check_totally_ordered_with<int (S::*)() &,
-                                          int (S::*)() const & noexcept>());
-static_assert(
-    !check_totally_ordered_with<int (S::*)() &, int (S::*)() volatile&>());
-static_assert(!check_totally_ordered_with<int (S::*)() &,
-                                          int (S::*)() volatile & noexcept>());
-static_assert(!check_totally_ordered_with<int (S::*)() &,
-                                          int (S::*)() const volatile&>());
-static_assert(!check_totally_ordered_with<
-              int (S::*)() &, int (S::*)() const volatile & noexcept>());
+static_assert(!check_totally_ordered_with<int (S::*)() &, int (S::*)() & noexcept>());
+static_assert(!check_totally_ordered_with<int (S::*)() &, int (S::*)() const&>());
+static_assert(!check_totally_ordered_with<int (S::*)() &, int (S::*)() const & noexcept>());
+static_assert(!check_totally_ordered_with<int (S::*)() &, int (S::*)() volatile&>());
+static_assert(!check_totally_ordered_with<int (S::*)() &, int (S::*)() volatile & noexcept>());
+static_assert(!check_totally_ordered_with<int (S::*)() &, int (S::*)() const volatile&>());
+static_assert(!check_totally_ordered_with< int (S::*)() &, int (S::*)() const volatile & noexcept>());
 static_assert(!check_totally_ordered_with<int (S::*)() &, int (S::*)() &&>());
-static_assert(!check_totally_ordered_with < int (S::*)() &,
-              int (S::*)() && noexcept > ());
-static_assert(
-    !check_totally_ordered_with<int (S::*)() &, int (S::*)() const&&>());
-static_assert(!check_totally_ordered_with < int (S::*)() &,
-              int (S::*)() const&& noexcept > ());
-static_assert(
-    !check_totally_ordered_with<int (S::*)() &, int (S::*)() volatile&&>());
-static_assert(!check_totally_ordered_with < int (S::*)() &,
-              int (S::*)() volatile&& noexcept > ());
-static_assert(!check_totally_ordered_with<int (S::*)() &,
-                                          int (S::*)() const volatile&&>());
-static_assert(!check_totally_ordered_with < int (S::*)() &,
+static_assert(!check_totally_ordered_with < int(S::*)() &, int (S::*)() && noexcept > ());
+static_assert(!check_totally_ordered_with<int (S::*)() &, int (S::*)() const&&>());
+static_assert(!check_totally_ordered_with < int(S::*)() &, int (S::*)() const&& noexcept > ());
+static_assert(!check_totally_ordered_with<int (S::*)() &, int (S::*)() volatile&&>());
+static_assert(!check_totally_ordered_with < int(S::*)() &, int (S::*)() volatile&& noexcept > ());
+static_assert(!check_totally_ordered_with<int (S::*)() &, int (S::*)() const volatile&&>());
+static_assert(!check_totally_ordered_with < int(S::*)() &, int (S::*)() const volatile&& noexcept > ());
+
+static_assert(!check_totally_ordered_with<int (S::*)() & noexcept, int (S::*)() & noexcept>());
+static_assert(!check_totally_ordered_with<int (S::*)() & noexcept, int (S::*)() const&>());
+static_assert(!check_totally_ordered_with<int (S::*)() & noexcept, int (S::*)() const & noexcept>());
+static_assert(!check_totally_ordered_with<int (S::*)() & noexcept, int (S::*)() volatile&>());
+static_assert(!check_totally_ordered_with<int (S::*)() & noexcept, int (S::*)() volatile & noexcept>());
+static_assert(!check_totally_ordered_with<int (S::*)() & noexcept, int (S::*)() const volatile&>());
+static_assert(!check_totally_ordered_with<int (S::*)() & noexcept, int (S::*)() const volatile & noexcept>());
+static_assert(!check_totally_ordered_with<int (S::*)() & noexcept, int (S::*)() &&>());
+static_assert(!check_totally_ordered_with < int(S::*)() & noexcept, int (S::*)() && noexcept > ());
+static_assert(!check_totally_ordered_with<int (S::*)() & noexcept, int (S::*)() const&&>());
+static_assert(!check_totally_ordered_with < int(S::*)() & noexcept, int (S::*)() const&& noexcept > ());
+static_assert(!check_totally_ordered_with<int (S::*)() & noexcept, int (S::*)() volatile&&>());
+static_assert(!check_totally_ordered_with < int(S::*)() & noexcept, int (S::*)() volatile&& noexcept > ());
+static_assert(!check_totally_ordered_with<int (S::*)() & noexcept, int (S::*)() const volatile&&>());
+static_assert(!check_totally_ordered_with < int(S::*)() & noexcept, int (S::*)() const volatile&& noexcept > ());
+
+static_assert(!check_totally_ordered_with<int (S::*)() const&, int (S::*)() const&>());
+static_assert(!check_totally_ordered_with<int (S::*)() const&, int (S::*)() const & noexcept>());
+static_assert(!check_totally_ordered_with<int (S::*)() const&, int (S::*)() volatile&>());
+static_assert(!check_totally_ordered_with<int (S::*)() const&, int (S::*)() volatile & noexcept>());
+static_assert(!check_totally_ordered_with<int (S::*)() const&, int (S::*)() const volatile&>());
+static_assert(!check_totally_ordered_with< int (S::*)() const&, int (S::*)() const volatile & noexcept>());
+static_assert(!check_totally_ordered_with<int (S::*)() const&, int (S::*)() &&>());
+static_assert(!check_totally_ordered_with < int(S::*)() const&, int (S::*)() && noexcept > ());
+static_assert(!check_totally_ordered_with<int (S::*)() const&, int (S::*)() const&&>());
+static_assert(!check_totally_ordered_with < int(S::*)() const&, int (S::*)() const&& noexcept > ());
+static_assert(!check_totally_ordered_with<int (S::*)() const&, int (S::*)() volatile&&>());
+static_assert(!check_totally_ordered_with < int(S::*)() const&, int (S::*)() volatile&& noexcept > ());
+static_assert(!check_totally_ordered_with<int (S::*)() const&, int (S::*)() const volatile&&>());
+static_assert(!check_totally_ordered_with < int(S::*)() const&, int (S::*)() const volatile&& noexcept > ());
+
+static_assert(!check_totally_ordered_with<int (S::*)() const & noexcept, int (S::*)() const & noexcept>());
+static_assert(!check_totally_ordered_with<int (S::*)() const & noexcept, int (S::*)() volatile&>());
+static_assert(!check_totally_ordered_with<int (S::*)() const & noexcept, int (S::*)() volatile & noexcept>());
+static_assert(!check_totally_ordered_with<int (S::*)() const & noexcept, int (S::*)() const volatile&>());
+static_assert(!check_totally_ordered_with<int (S::*)() const & noexcept, int (S::*)() const volatile & noexcept>());
+static_assert(!check_totally_ordered_with<int (S::*)() const & noexcept, int (S::*)() &&>());
+static_assert(!check_totally_ordered_with < int(S::*)() const& noexcept, int (S::*)() && noexcept > ());
+static_assert(!check_totally_ordered_with<int (S::*)() const & noexcept, int (S::*)() const&&>());
+static_assert(!check_totally_ordered_with < int(S::*)() const& noexcept, int (S::*)() const&& noexcept > ());
+static_assert(!check_totally_ordered_with<int (S::*)() const & noexcept, int (S::*)() volatile&&>());
+static_assert(!check_totally_ordered_with < int(S::*)() const& noexcept, int (S::*)() volatile&& noexcept > ());
+static_assert(!check_totally_ordered_with<int (S::*)() const & noexcept, int (S::*)() const volatile&&>());
+static_assert(!check_totally_ordered_with < int(S::*)() const& noexcept, int (S::*)() const volatile&& noexcept > ());
+
+static_assert(!check_totally_ordered_with<int (S::*)() volatile&, int (S::*)() volatile&>());
+static_assert(!check_totally_ordered_with<int (S::*)() volatile&, int (S::*)() volatile & noexcept>());
+static_assert(!check_totally_ordered_with<int (S::*)() volatile&, int (S::*)() const volatile&>());
+static_assert(!check_totally_ordered_with<int (S::*)() volatile&, int (S::*)() const volatile & noexcept>());
+static_assert(!check_totally_ordered_with<int (S::*)() volatile&, int (S::*)() &&>());
+static_assert(!check_totally_ordered_with < int(S::*)() volatile&, int (S::*)() && noexcept > ());
+static_assert(!check_totally_ordered_with<int (S::*)() volatile&, int (S::*)() const&&>());
+static_assert(!check_totally_ordered_with < int(S::*)() volatile&, int (S::*)() const&& noexcept > ());
+static_assert(!check_totally_ordered_with<int (S::*)() volatile&, int (S::*)() volatile&&>());
+static_assert(!check_totally_ordered_with < int(S::*)() volatile&, int (S::*)() volatile&& noexcept > ());
+static_assert(!check_totally_ordered_with<int (S::*)() volatile&, int (S::*)() const volatile&&>());
+static_assert(!check_totally_ordered_with < int(S::*)() volatile&, int (S::*)() const volatile&& noexcept > ());
+
+static_assert(!check_totally_ordered_with<int (S::*)() volatile & noexcept, int (S::*)() volatile & noexcept>());
+static_assert(!check_totally_ordered_with<int (S::*)() volatile & noexcept, int (S::*)() const volatile&>());
+static_assert(!check_totally_ordered_with<int (S::*)() volatile & noexcept, int (S::*)() const volatile & noexcept>());
+static_assert(!check_totally_ordered_with<int (S::*)() volatile & noexcept, int (S::*)() &&>());
+static_assert(!check_totally_ordered_with < int(S::*)() volatile & noexcept, int (S::*)() && noexcept > ());
+static_assert(!check_totally_ordered_with<int (S::*)() volatile & noexcept, int (S::*)() const&&>());
+static_assert(!check_totally_ordered_with < int(S::*)() volatile & noexcept, int (S::*)() const&& noexcept > ());
+static_assert(!check_totally_ordered_with<int (S::*)() volatile & noexcept, int (S::*)() volatile&&>());
+static_assert(!check_totally_ordered_with < int(S::*)() volatile & noexcept, int (S::*)() volatile&& noexcept > ());
+static_assert(!check_totally_ordered_with<int (S::*)() volatile & noexcept, int (S::*)() const volatile&&>());
+static_assert(!check_totally_ordered_with < int(S::*)() volatile & noexcept,
               int (S::*)() const volatile&& noexcept > ());
 
-static_assert(!check_totally_ordered_with<int (S::*)() & noexcept,
-                                          int (S::*)() & noexcept>());
-static_assert(!check_totally_ordered_with<int (S::*)() & noexcept,
-                                          int (S::*)() const&>());
-static_assert(!check_totally_ordered_with<int (S::*)() & noexcept,
-                                          int (S::*)() const & noexcept>());
-static_assert(!check_totally_ordered_with<int (S::*)() & noexcept,
-                                          int (S::*)() volatile&>());
-static_assert(!check_totally_ordered_with<int (S::*)() & noexcept,
-                                          int (S::*)() volatile & noexcept>());
-static_assert(!check_totally_ordered_with<int (S::*)() & noexcept,
-                                          int (S::*)() const volatile&>());
-static_assert(
-    !check_totally_ordered_with<int (S::*)() & noexcept,
-                                int (S::*)() const volatile & noexcept>());
-static_assert(
-    !check_totally_ordered_with<int (S::*)() & noexcept, int (S::*)() &&>());
-static_assert(!check_totally_ordered_with < int (S::*)() & noexcept,
-              int (S::*)() && noexcept > ());
-static_assert(!check_totally_ordered_with<int (S::*)() & noexcept,
-                                          int (S::*)() const&&>());
-static_assert(!check_totally_ordered_with < int (S::*)() & noexcept,
-              int (S::*)() const&& noexcept > ());
-static_assert(!check_totally_ordered_with<int (S::*)() & noexcept,
-                                          int (S::*)() volatile&&>());
-static_assert(!check_totally_ordered_with < int (S::*)() & noexcept,
-              int (S::*)() volatile&& noexcept > ());
-static_assert(!check_totally_ordered_with<int (S::*)() & noexcept,
-                                          int (S::*)() const volatile&&>());
-static_assert(!check_totally_ordered_with < int (S::*)() & noexcept,
-              int (S::*)() const volatile&& noexcept > ());
+static_assert(!check_totally_ordered_with<int (S::*)() const volatile&, int (S::*)() const volatile&>());
+static_assert(!check_totally_ordered_with<int (S::*)() const volatile&, int (S::*)() const volatile & noexcept>());
+static_assert(!check_totally_ordered_with<int (S::*)() const volatile&, int (S::*)() &&>());
+static_assert(!check_totally_ordered_with < int(S::*)() const volatile&, int (S::*)() && noexcept > ());
+static_assert(!check_totally_ordered_with<int (S::*)() const volatile&, int (S::*)() const&&>());
+static_assert(!check_totally_ordered_with < int(S::*)() const volatile&, int (S::*)() const&& noexcept > ());
+static_assert(!check_totally_ordered_with<int (S::*)() const volatile&, int (S::*)() volatile&&>());
+static_assert(!check_totally_ordered_with < int(S::*)() const volatile&, int (S::*)() volatile&& noexcept > ());
+static_assert(!check_totally_ordered_with<int (S::*)() const volatile&, int (S::*)() const volatile&&>());
+static_assert(!check_totally_ordered_with < int(S::*)() const volatile&, int (S::*)() const volatile&& noexcept > ());
 
 static_assert(
-    !check_totally_ordered_with<int (S::*)() const&, int (S::*)() const&>());
-static_assert(!check_totally_ordered_with<int (S::*)() const&,
-                                          int (S::*)() const & noexcept>());
-static_assert(
-    !check_totally_ordered_with<int (S::*)() const&, int (S::*)() volatile&>());
-static_assert(!check_totally_ordered_with<int (S::*)() const&,
-                                          int (S::*)() volatile & noexcept>());
-static_assert(!check_totally_ordered_with<int (S::*)() const&,
-                                          int (S::*)() const volatile&>());
-static_assert(!check_totally_ordered_with<
-              int (S::*)() const&, int (S::*)() const volatile & noexcept>());
-static_assert(
-    !check_totally_ordered_with<int (S::*)() const&, int (S::*)() &&>());
-static_assert(!check_totally_ordered_with < int (S::*)() const&,
-              int (S::*)() && noexcept > ());
-static_assert(
-    !check_totally_ordered_with<int (S::*)() const&, int (S::*)() const&&>());
-static_assert(!check_totally_ordered_with < int (S::*)() const&,
-              int (S::*)() const&& noexcept > ());
-static_assert(!check_totally_ordered_with<int (S::*)() const&,
-                                          int (S::*)() volatile&&>());
-static_assert(!check_totally_ordered_with < int (S::*)() const&,
+    !check_totally_ordered_with<int (S::*)() const volatile & noexcept, int (S::*)() const volatile & noexcept>());
+static_assert(!check_totally_ordered_with< int (S::*)() const volatile & noexcept, int (S::*)() &&>());
+static_assert(!check_totally_ordered_with < int(S::*)() const volatile& noexcept, int (S::*)() && noexcept > ());
+static_assert(!check_totally_ordered_with< int (S::*)() const volatile & noexcept, int (S::*)() const&&>());
+static_assert(!check_totally_ordered_with < int(S::*)() const volatile& noexcept, int (S::*)() const&& noexcept > ());
+static_assert(!check_totally_ordered_with<int (S::*)() const volatile & noexcept, int (S::*)() volatile&&>());
+static_assert(!check_totally_ordered_with < int(S::*)() const volatile& noexcept,
               int (S::*)() volatile&& noexcept > ());
-static_assert(!check_totally_ordered_with<int (S::*)() const&,
-                                          int (S::*)() const volatile&&>());
-static_assert(!check_totally_ordered_with < int (S::*)() const&,
-              int (S::*)() const volatile&& noexcept > ());
-
-static_assert(!check_totally_ordered_with<int (S::*)() const & noexcept,
-                                          int (S::*)() const & noexcept>());
-static_assert(!check_totally_ordered_with<int (S::*)() const & noexcept,
-                                          int (S::*)() volatile&>());
-static_assert(!check_totally_ordered_with<int (S::*)() const & noexcept,
-                                          int (S::*)() volatile & noexcept>());
-static_assert(!check_totally_ordered_with<int (S::*)() const & noexcept,
-                                          int (S::*)() const volatile&>());
-static_assert(
-    !check_totally_ordered_with<int (S::*)() const & noexcept,
-                                int (S::*)() const volatile & noexcept>());
-static_assert(!check_totally_ordered_with<int (S::*)() const & noexcept,
-                                          int (S::*)() &&>());
-static_assert(!check_totally_ordered_with < int (S::*)() const& noexcept,
-              int (S::*)() && noexcept > ());
-static_assert(!check_totally_ordered_with<int (S::*)() const & noexcept,
-                                          int (S::*)() const&&>());
-static_assert(!check_totally_ordered_with < int (S::*)() const& noexcept,
-              int (S::*)() const&& noexcept > ());
-static_assert(!check_totally_ordered_with<int (S::*)() const & noexcept,
-                                          int (S::*)() volatile&&>());
-static_assert(!check_totally_ordered_with < int (S::*)() const& noexcept,
-              int (S::*)() volatile&& noexcept > ());
-static_assert(!check_totally_ordered_with<int (S::*)() const & noexcept,
-                                          int (S::*)() const volatile&&>());
-static_assert(!check_totally_ordered_with < int (S::*)() const& noexcept,
-              int (S::*)() const volatile&& noexcept > ());
-
-static_assert(!check_totally_ordered_with<int (S::*)() volatile&,
-                                          int (S::*)() volatile&>());
-static_assert(!check_totally_ordered_with<int (S::*)() volatile&,
-                                          int (S::*)() volatile & noexcept>());
-static_assert(!check_totally_ordered_with<int (S::*)() volatile&,
-                                          int (S::*)() const volatile&>());
-static_assert(
-    !check_totally_ordered_with<int (S::*)() volatile&,
-                                int (S::*)() const volatile & noexcept>());
-static_assert(
-    !check_totally_ordered_with<int (S::*)() volatile&, int (S::*)() &&>());
-static_assert(!check_totally_ordered_with < int (S::*)() volatile&,
-              int (S::*)() && noexcept > ());
-static_assert(!check_totally_ordered_with<int (S::*)() volatile&,
-                                          int (S::*)() const&&>());
-static_assert(!check_totally_ordered_with < int (S::*)() volatile&,
-              int (S::*)() const&& noexcept > ());
-static_assert(!check_totally_ordered_with<int (S::*)() volatile&,
-                                          int (S::*)() volatile&&>());
-static_assert(!check_totally_ordered_with < int (S::*)() volatile&,
-              int (S::*)() volatile&& noexcept > ());
-static_assert(!check_totally_ordered_with<int (S::*)() volatile&,
-                                          int (S::*)() const volatile&&>());
-static_assert(!check_totally_ordered_with < int (S::*)() volatile&,
-              int (S::*)() const volatile&& noexcept > ());
-
-static_assert(!check_totally_ordered_with<int (S::*)() volatile & noexcept,
-                                          int (S::*)() volatile & noexcept>());
-static_assert(!check_totally_ordered_with<int (S::*)() volatile & noexcept,
-                                          int (S::*)() const volatile&>());
-static_assert(
-    !check_totally_ordered_with<int (S::*)() volatile & noexcept,
-                                int (S::*)() const volatile & noexcept>());
-static_assert(!check_totally_ordered_with<int (S::*)() volatile & noexcept,
-                                          int (S::*)() &&>());
-static_assert(!check_totally_ordered_with < int (S::*)() volatile& noexcept,
-              int (S::*)() && noexcept > ());
-static_assert(!check_totally_ordered_with<int (S::*)() volatile & noexcept,
-                                          int (S::*)() const&&>());
-static_assert(!check_totally_ordered_with < int (S::*)() volatile& noexcept,
-              int (S::*)() const&& noexcept > ());
-static_assert(!check_totally_ordered_with<int (S::*)() volatile & noexcept,
-                                          int (S::*)() volatile&&>());
-static_assert(!check_totally_ordered_with < int (S::*)() volatile& noexcept,
-              int (S::*)() volatile&& noexcept > ());
-static_assert(!check_totally_ordered_with<int (S::*)() volatile & noexcept,
-                                          int (S::*)() const volatile&&>());
-static_assert(!check_totally_ordered_with < int (S::*)() volatile& noexcept,
-              int (S::*)() const volatile&& noexcept > ());
-
-static_assert(!check_totally_ordered_with<int (S::*)() const volatile&,
-                                          int (S::*)() const volatile&>());
-static_assert(
-    !check_totally_ordered_with<int (S::*)() const volatile&,
-                                int (S::*)() const volatile & noexcept>());
-static_assert(!check_totally_ordered_with<int (S::*)() const volatile&,
-                                          int (S::*)() &&>());
-static_assert(!check_totally_ordered_with < int (S::*)() const volatile&,
-              int (S::*)() && noexcept > ());
-static_assert(!check_totally_ordered_with<int (S::*)() const volatile&,
-                                          int (S::*)() const&&>());
-static_assert(!check_totally_ordered_with < int (S::*)() const volatile&,
-              int (S::*)() const&& noexcept > ());
-static_assert(!check_totally_ordered_with<int (S::*)() const volatile&,
-                                          int (S::*)() volatile&&>());
-static_assert(!check_totally_ordered_with < int (S::*)() const volatile&,
-              int (S::*)() volatile&& noexcept > ());
-static_assert(!check_totally_ordered_with<int (S::*)() const volatile&,
-                                          int (S::*)() const volatile&&>());
-static_assert(!check_totally_ordered_with < int (S::*)() const volatile&,
-              int (S::*)() const volatile&& noexcept > ());
-
-static_assert(
-    !check_totally_ordered_with<int (S::*)() const volatile & noexcept,
-                                int (S::*)() const volatile & noexcept>());
-static_assert(!check_totally_ordered_with<
-              int (S::*)() const volatile & noexcept, int (S::*)() &&>());
-static_assert(!check_totally_ordered_with < int (S::*)()
-                                                const volatile& noexcept,
-              int (S::*)() && noexcept > ());
-static_assert(!check_totally_ordered_with<
-              int (S::*)() const volatile & noexcept, int (S::*)() const&&>());
-static_assert(!check_totally_ordered_with < int (S::*)()
-                                                const volatile& noexcept,
-              int (S::*)() const&& noexcept > ());
-static_assert(
-    !check_totally_ordered_with<int (S::*)() const volatile & noexcept,
-                                int (S::*)() volatile&&>());
-static_assert(!check_totally_ordered_with < int (S::*)()
-                                                const volatile& noexcept,
-              int (S::*)() volatile&& noexcept > ());
-static_assert(
-    !check_totally_ordered_with<int (S::*)() const volatile & noexcept,
-                                int (S::*)() const volatile&&>());
-static_assert(!check_totally_ordered_with < int (S::*)()
-                                                const volatile& noexcept,
+static_assert(!check_totally_ordered_with<int (S::*)() const volatile & noexcept, int (S::*)() const volatile&&>());
+static_assert(!check_totally_ordered_with < int(S::*)() const volatile& noexcept,
               int (S::*)() const volatile&& noexcept > ());
 
 static_assert(!check_totally_ordered_with<int (S::*)() &&, int (S::*)() &&>());
-static_assert(!check_totally_ordered_with < int (S::*)() &&,
-              int (S::*)() && noexcept > ());
-static_assert(
-    !check_totally_ordered_with<int (S::*)() &&, int (S::*)() const&&>());
-static_assert(!check_totally_ordered_with < int (S::*)() &&,
-              int (S::*)() const&& noexcept > ());
-static_assert(
-    !check_totally_ordered_with<int (S::*)() &&, int (S::*)() volatile&&>());
-static_assert(!check_totally_ordered_with < int (S::*)() &&,
-              int (S::*)() volatile&& noexcept > ());
-static_assert(!check_totally_ordered_with<int (S::*)() &&,
-                                          int (S::*)() const volatile&&>());
-static_assert(!check_totally_ordered_with < int (S::*)() &&,
+static_assert(!check_totally_ordered_with < int(S::*)() &&, int (S::*)() && noexcept > ());
+static_assert(!check_totally_ordered_with<int (S::*)() &&, int (S::*)() const&&>());
+static_assert(!check_totally_ordered_with < int(S::*)() &&, int (S::*)() const&& noexcept > ());
+static_assert(!check_totally_ordered_with<int (S::*)() &&, int (S::*)() volatile&&>());
+static_assert(!check_totally_ordered_with < int(S::*)() &&, int (S::*)() volatile&& noexcept > ());
+static_assert(!check_totally_ordered_with<int (S::*)() &&, int (S::*)() const volatile&&>());
+static_assert(!check_totally_ordered_with < int(S::*)() &&, int (S::*)() const volatile&& noexcept > ());
+
+static_assert(!check_totally_ordered_with < int(S::*)() && noexcept, int (S::*)() && noexcept > ());
+static_assert(!check_totally_ordered_with < int(S::*)() && noexcept, int (S::*)() const&& > ());
+static_assert(!check_totally_ordered_with < int(S::*)() && noexcept, int (S::*)() const&& noexcept > ());
+static_assert(!check_totally_ordered_with < int(S::*)() && noexcept, int (S::*)() volatile&& > ());
+static_assert(!check_totally_ordered_with < int(S::*)() && noexcept, int (S::*)() volatile&& noexcept > ());
+static_assert(!check_totally_ordered_with < int(S::*)() && noexcept, int (S::*)() const volatile&& > ());
+static_assert(!check_totally_ordered_with < int(S::*)() && noexcept, int (S::*)() const volatile&& noexcept > ());
+
+static_assert(!check_totally_ordered_with<int (S::*)() const&&, int (S::*)() const&&>());
+static_assert(!check_totally_ordered_with < int(S::*)() const&&, int (S::*)() const&& noexcept > ());
+static_assert(!check_totally_ordered_with<int (S::*)() const&&, int (S::*)() volatile&&>());
+static_assert(!check_totally_ordered_with < int(S::*)() const&&, int (S::*)() volatile&& noexcept > ());
+static_assert(!check_totally_ordered_with<int (S::*)() const&&, int (S::*)() const volatile&&>());
+static_assert(!check_totally_ordered_with < int(S::*)() const&&, int (S::*)() const volatile&& noexcept > ());
+
+static_assert(!check_totally_ordered_with < int(S::*)() const&& noexcept, int (S::*)() const&& noexcept > ());
+static_assert(!check_totally_ordered_with < int(S::*)() const&& noexcept, int (S::*)() volatile&& > ());
+static_assert(!check_totally_ordered_with < int(S::*)() const&& noexcept, int (S::*)() volatile&& noexcept > ());
+static_assert(!check_totally_ordered_with < int(S::*)() const&& noexcept, int (S::*)() const volatile&& > ());
+static_assert(!check_totally_ordered_with < int(S::*)() const&& noexcept, int (S::*)() const volatile&& noexcept > ());
+
+static_assert(!check_totally_ordered_with<int (S::*)() volatile&&, int (S::*)() volatile&&>());
+static_assert(!check_totally_ordered_with < int(S::*)() volatile&&, int (S::*)() volatile&& noexcept > ());
+static_assert(!check_totally_ordered_with<int (S::*)() volatile&&, int (S::*)() const volatile&&>());
+static_assert(!check_totally_ordered_with < int(S::*)() volatile&&, int (S::*)() const volatile&& noexcept > ());
+
+static_assert(!check_totally_ordered_with < int(S::*)() volatile && noexcept, int (S::*)() volatile&& noexcept > ());
+static_assert(!check_totally_ordered_with < int(S::*)() volatile && noexcept, int (S::*)() const volatile&& > ());
+static_assert(!check_totally_ordered_with < int(S::*)() volatile && noexcept,
               int (S::*)() const volatile&& noexcept > ());
 
-static_assert(!check_totally_ordered_with < int (S::*)() && noexcept,
-              int (S::*)() && noexcept > ());
-static_assert(!check_totally_ordered_with < int (S::*)() && noexcept,
-              int (S::*)() const&& > ());
-static_assert(!check_totally_ordered_with < int (S::*)() && noexcept,
-              int (S::*)() const&& noexcept > ());
-static_assert(!check_totally_ordered_with < int (S::*)() && noexcept,
-              int (S::*)() volatile&& > ());
-static_assert(!check_totally_ordered_with < int (S::*)() && noexcept,
-              int (S::*)() volatile&& noexcept > ());
-static_assert(!check_totally_ordered_with < int (S::*)() && noexcept,
-              int (S::*)() const volatile&& > ());
-static_assert(!check_totally_ordered_with < int (S::*)() && noexcept,
-              int (S::*)() const volatile&& noexcept > ());
-
-static_assert(
-    !check_totally_ordered_with<int (S::*)() const&&, int (S::*)() const&&>());
-static_assert(!check_totally_ordered_with < int (S::*)() const&&,
-              int (S::*)() const&& noexcept > ());
-static_assert(!check_totally_ordered_with<int (S::*)() const&&,
-                                          int (S::*)() volatile&&>());
-static_assert(!check_totally_ordered_with < int (S::*)() const&&,
-              int (S::*)() volatile&& noexcept > ());
-static_assert(!check_totally_ordered_with<int (S::*)() const&&,
-                                          int (S::*)() const volatile&&>());
-static_assert(!check_totally_ordered_with < int (S::*)() const&&,
-              int (S::*)() const volatile&& noexcept > ());
-
-static_assert(!check_totally_ordered_with < int (S::*)() const&& noexcept,
-              int (S::*)() const&& noexcept > ());
-static_assert(!check_totally_ordered_with < int (S::*)() const&& noexcept,
-              int (S::*)() volatile&& > ());
-static_assert(!check_totally_ordered_with < int (S::*)() const&& noexcept,
-              int (S::*)() volatile&& noexcept > ());
-static_assert(!check_totally_ordered_with < int (S::*)() const&& noexcept,
-              int (S::*)() const volatile&& > ());
-static_assert(!check_totally_ordered_with < int (S::*)() const&& noexcept,
-              int (S::*)() const volatile&& noexcept > ());
-
-static_assert(!check_totally_ordered_with<int (S::*)() volatile&&,
-                                          int (S::*)() volatile&&>());
-static_assert(!check_totally_ordered_with < int (S::*)() volatile&&,
-              int (S::*)() volatile&& noexcept > ());
-static_assert(!check_totally_ordered_with<int (S::*)() volatile&&,
-                                          int (S::*)() const volatile&&>());
-static_assert(!check_totally_ordered_with < int (S::*)() volatile&&,
-              int (S::*)() const volatile&& noexcept > ());
-
-static_assert(!check_totally_ordered_with < int (S::*)() volatile&& noexcept,
-              int (S::*)() volatile&& noexcept > ());
-static_assert(!check_totally_ordered_with < int (S::*)() volatile&& noexcept,
-              int (S::*)() const volatile&& > ());
-static_assert(!check_totally_ordered_with < int (S::*)() volatile&& noexcept,
-              int (S::*)() const volatile&& noexcept > ());
-
-static_assert(!check_totally_ordered_with<int (S::*)() const volatile&&,
-                                          int (S::*)() const volatile&&>());
-static_assert(!check_totally_ordered_with < int (S::*)() const volatile&&,
-              int (S::*)() const volatile&& noexcept > ());
-static_assert(!check_totally_ordered_with < int (S::*)()
-                                                const volatile&& noexcept,
+static_assert(!check_totally_ordered_with<int (S::*)() const volatile&&, int (S::*)() const volatile&&>());
+static_assert(!check_totally_ordered_with < int(S::*)() const volatile&&, int (S::*)() const volatile&& noexcept > ());
+static_assert(!check_totally_ordered_with < int(S::*)() const volatile&& noexcept,
               int (S::*)() const volatile&& noexcept > ());
 
 #if !defined(TEST_COMPILER_GCC)
@@ -915,50 +544,29 @@ static_assert(!check_totally_ordered_with<std::nullptr_t, int (&)()>());
 #endif
 
 static_assert(!check_totally_ordered_with<std::nullptr_t, int (S::*)()>());
-static_assert(
-    !check_totally_ordered_with<std::nullptr_t, int (S::*)() noexcept>());
-static_assert(
-    !check_totally_ordered_with<std::nullptr_t, int (S::*)() const>());
-static_assert(
-    !check_totally_ordered_with<std::nullptr_t, int (S::*)() const noexcept>());
-static_assert(
-    !check_totally_ordered_with<std::nullptr_t, int (S::*)() volatile>());
-static_assert(!check_totally_ordered_with<std::nullptr_t,
-                                          int (S::*)() volatile noexcept>());
-static_assert(
-    !check_totally_ordered_with<std::nullptr_t, int (S::*)() const volatile>());
-static_assert(!check_totally_ordered_with<
-              std::nullptr_t, int (S::*)() const volatile noexcept>());
+static_assert(!check_totally_ordered_with<std::nullptr_t, int (S::*)() noexcept>());
+static_assert(!check_totally_ordered_with<std::nullptr_t, int (S::*)() const>());
+static_assert(!check_totally_ordered_with<std::nullptr_t, int (S::*)() const noexcept>());
+static_assert(!check_totally_ordered_with<std::nullptr_t, int (S::*)() volatile>());
+static_assert(!check_totally_ordered_with<std::nullptr_t, int (S::*)() volatile noexcept>());
+static_assert(!check_totally_ordered_with<std::nullptr_t, int (S::*)() const volatile>());
+static_assert(!check_totally_ordered_with< std::nullptr_t, int (S::*)() const volatile noexcept>());
 static_assert(!check_totally_ordered_with<std::nullptr_t, int (S::*)() &>());
-static_assert(
-    !check_totally_ordered_with<std::nullptr_t, int (S::*)() & noexcept>());
-static_assert(
-    !check_totally_ordered_with<std::nullptr_t, int (S::*)() const&>());
-static_assert(!check_totally_ordered_with<std::nullptr_t,
-                                          int (S::*)() const & noexcept>());
-static_assert(
-    !check_totally_ordered_with<std::nullptr_t, int (S::*)() volatile&>());
-static_assert(!check_totally_ordered_with<std::nullptr_t,
-                                          int (S::*)() volatile & noexcept>());
-static_assert(!check_totally_ordered_with<std::nullptr_t,
-                                          int (S::*)() const volatile&>());
-static_assert(!check_totally_ordered_with<
-              std::nullptr_t, int (S::*)() const volatile & noexcept>());
+static_assert(!check_totally_ordered_with<std::nullptr_t, int (S::*)() & noexcept>());
+static_assert(!check_totally_ordered_with<std::nullptr_t, int (S::*)() const&>());
+static_assert(!check_totally_ordered_with<std::nullptr_t, int (S::*)() const & noexcept>());
+static_assert(!check_totally_ordered_with<std::nullptr_t, int (S::*)() volatile&>());
+static_assert(!check_totally_ordered_with<std::nullptr_t, int (S::*)() volatile & noexcept>());
+static_assert(!check_totally_ordered_with<std::nullptr_t, int (S::*)() const volatile&>());
+static_assert(!check_totally_ordered_with< std::nullptr_t, int (S::*)() const volatile & noexcept>());
 static_assert(!check_totally_ordered_with<std::nullptr_t, int (S::*)() &&>());
-static_assert(!check_totally_ordered_with < std::nullptr_t,
-              int (S::*)() && noexcept > ());
-static_assert(
-    !check_totally_ordered_with<std::nullptr_t, int (S::*)() const&&>());
-static_assert(!check_totally_ordered_with < std::nullptr_t,
-              int (S::*)() const&& noexcept > ());
-static_assert(
-    !check_totally_ordered_with<std::nullptr_t, int (S::*)() volatile&&>());
-static_assert(!check_totally_ordered_with < std::nullptr_t,
-              int (S::*)() volatile&& noexcept > ());
-static_assert(!check_totally_ordered_with<std::nullptr_t,
-                                          int (S::*)() const volatile&&>());
-static_assert(!check_totally_ordered_with < std::nullptr_t,
-              int (S::*)() const volatile&& noexcept > ());
+static_assert(!check_totally_ordered_with < std::nullptr_t, int (S::*)() && noexcept > ());
+static_assert(!check_totally_ordered_with<std::nullptr_t, int (S::*)() const&&>());
+static_assert(!check_totally_ordered_with < std::nullptr_t, int (S::*)() const&& noexcept > ());
+static_assert(!check_totally_ordered_with<std::nullptr_t, int (S::*)() volatile&&>());
+static_assert(!check_totally_ordered_with < std::nullptr_t, int (S::*)() volatile&& noexcept > ());
+static_assert(!check_totally_ordered_with<std::nullptr_t, int (S::*)() const volatile&&>());
+static_assert(!check_totally_ordered_with < std::nullptr_t, int (S::*)() const volatile&& noexcept > ());
 
 static_assert(!std::equality_comparable_with<void, int>);
 static_assert(!std::equality_comparable_with<void, int*>);
@@ -970,67 +578,44 @@ static_assert(!std::equality_comparable_with<void, int S::*>);
 static_assert(!std::equality_comparable_with<void, int (S::*)()>);
 static_assert(!std::equality_comparable_with<void, int (S::*)() noexcept>);
 static_assert(!std::equality_comparable_with<void, int (S::*)() const>);
-static_assert(
-    !std::equality_comparable_with<void, int (S::*)() const noexcept>);
+static_assert(!std::equality_comparable_with<void, int (S::*)() const noexcept>);
 static_assert(!std::equality_comparable_with<void, int (S::*)() volatile>);
-static_assert(
-    !std::equality_comparable_with<void, int (S::*)() volatile noexcept>);
-static_assert(
-    !std::equality_comparable_with<void, int (S::*)() const volatile>);
-static_assert(
-    !std::equality_comparable_with<void, int (S::*)() const volatile noexcept>);
+static_assert(!std::equality_comparable_with<void, int (S::*)() volatile noexcept>);
+static_assert(!std::equality_comparable_with<void, int (S::*)() const volatile>);
+static_assert(!std::equality_comparable_with<void, int (S::*)() const volatile noexcept>);
 static_assert(!std::equality_comparable_with<void, int (S::*)() &>);
 static_assert(!std::equality_comparable_with<void, int (S::*)() & noexcept>);
 static_assert(!std::equality_comparable_with<void, int (S::*)() const&>);
-static_assert(
-    !std::equality_comparable_with<void, int (S::*)() const & noexcept>);
+static_assert(!std::equality_comparable_with<void, int (S::*)() const & noexcept>);
 static_assert(!std::equality_comparable_with<void, int (S::*)() volatile&>);
-static_assert(
-    !std::equality_comparable_with<void, int (S::*)() volatile & noexcept>);
-static_assert(
-    !std::equality_comparable_with<void, int (S::*)() const volatile&>);
-static_assert(!std::equality_comparable_with<void, int (S::*)() const volatile &
-                                                       noexcept>);
+static_assert(!std::equality_comparable_with<void, int (S::*)() volatile & noexcept>);
+static_assert(!std::equality_comparable_with<void, int (S::*)() const volatile&>);
+static_assert(!std::equality_comparable_with<void, int (S::*)() const volatile & noexcept>);
 static_assert(!std::equality_comparable_with<void, int (S::*)() &&>);
-static_assert(!std::equality_comparable_with < void,
-              int (S::*)() && noexcept >);
+static_assert(!std::equality_comparable_with < void, int (S::*)() && noexcept >);
 static_assert(!std::equality_comparable_with<void, int (S::*)() const&&>);
-static_assert(!std::equality_comparable_with < void,
-              int (S::*)() const&& noexcept >);
+static_assert(!std::equality_comparable_with < void, int (S::*)() const&& noexcept >);
 static_assert(!std::equality_comparable_with<void, int (S::*)() volatile&&>);
-static_assert(!std::equality_comparable_with < void,
-              int (S::*)() volatile&& noexcept >);
-static_assert(
-    !std::equality_comparable_with<void, int (S::*)() const volatile&&>);
-static_assert(!std::equality_comparable_with < void,
-              int (S::*)() const volatile&& noexcept >);
+static_assert(!std::equality_comparable_with < void, int (S::*)() volatile&& noexcept >);
+static_assert(!std::equality_comparable_with<void, int (S::*)() const volatile&&>);
+static_assert(!std::equality_comparable_with < void, int (S::*)() const volatile&& noexcept >);
 } // namespace fundamentals
 
 namespace standard_types {
-static_assert(
-    check_totally_ordered_with<std::array<int, 10>, std::array<int, 10> >());
-static_assert(!check_totally_ordered_with<std::array<int, 10>,
-                                          std::array<double, 10> >());
+static_assert(check_totally_ordered_with<std::array<int, 10>, std::array<int, 10> >());
+static_assert(!check_totally_ordered_with<std::array<int, 10>, std::array<double, 10> >());
 static_assert(check_totally_ordered_with<std::deque<int>, std::deque<int> >());
-static_assert(
-    !check_totally_ordered_with<std::deque<int>, std::vector<int> >());
-static_assert(check_totally_ordered_with<std::forward_list<int>,
-                                         std::forward_list<int> >());
-static_assert(
-    !check_totally_ordered_with<std::forward_list<int>, std::vector<int> >());
+static_assert(!check_totally_ordered_with<std::deque<int>, std::vector<int> >());
+static_assert(check_totally_ordered_with<std::forward_list<int>, std::forward_list<int> >());
+static_assert(!check_totally_ordered_with<std::forward_list<int>, std::vector<int> >());
 static_assert(check_totally_ordered_with<std::list<int>, std::list<int> >());
 static_assert(!check_totally_ordered_with<std::list<int>, std::vector<int> >());
 
-static_assert(
-    check_totally_ordered_with<std::map<int, void*>, std::map<int, void*> >());
-static_assert(
-    !check_totally_ordered_with<std::map<int, void*>, std::vector<int> >());
-static_assert(check_totally_ordered_with<std::optional<std::vector<int> >,
-                                         std::optional<std::vector<int> > >());
-static_assert(check_totally_ordered_with<std::optional<std::vector<int> >,
-                                         std::vector<int> >());
-static_assert(
-    check_totally_ordered_with<std::vector<int>, std::vector<int> >());
+static_assert(check_totally_ordered_with<std::map<int, void*>, std::map<int, void*> >());
+static_assert(!check_totally_ordered_with<std::map<int, void*>, std::vector<int> >());
+static_assert(check_totally_ordered_with<std::optional<std::vector<int> >, std::optional<std::vector<int> > >());
+static_assert(check_totally_ordered_with<std::optional<std::vector<int> >, std::vector<int> >());
+static_assert(check_totally_ordered_with<std::vector<int>, std::vector<int> >());
 static_assert(!check_totally_ordered_with<std::vector<int>, int>());
 
 struct A {};
@@ -1038,8 +623,7 @@ static_assert(!check_totally_ordered_with<std::optional<std::vector<A> >, std::o
 static_assert(!check_totally_ordered_with<std::optional<std::vector<A> >, std::vector<A> >());
 struct B {};
 static_assert(!check_totally_ordered_with<std::vector<A>, std::vector<B> >());
-static_assert(
-    !check_totally_ordered_with<std::optional<A>, std::optional<B> >());
+static_assert(!check_totally_ordered_with<std::optional<A>, std::optional<B> >());
 } // namespace standard_types
 
 namespace types_fit_for_purpose {
@@ -1047,90 +631,51 @@ static_assert(!check_totally_ordered_with<cxx20_member_eq, cxx20_member_eq>());
 static_assert(!check_totally_ordered_with<cxx20_friend_eq, cxx20_friend_eq>());
 static_assert(!check_totally_ordered_with<cxx20_member_eq, cxx20_friend_eq>());
 
-static_assert(check_totally_ordered_with<member_three_way_comparable,
-                                         member_three_way_comparable>());
-static_assert(check_totally_ordered_with<friend_three_way_comparable,
-                                         friend_three_way_comparable>());
-static_assert(!check_totally_ordered_with<member_three_way_comparable,
-                                          friend_three_way_comparable>());
+static_assert(check_totally_ordered_with<member_three_way_comparable, member_three_way_comparable>());
+static_assert(check_totally_ordered_with<friend_three_way_comparable, friend_three_way_comparable>());
+static_assert(!check_totally_ordered_with<member_three_way_comparable, friend_three_way_comparable>());
 
-static_assert(
-    check_totally_ordered_with<explicit_operators, explicit_operators>());
-static_assert(!check_totally_ordered_with<equality_comparable_with_ec1,
-                                          equality_comparable_with_ec1>());
-static_assert(check_totally_ordered_with<different_return_types,
-                                         different_return_types>());
-static_assert(!check_totally_ordered_with<explicit_operators,
-                                          equality_comparable_with_ec1>());
-static_assert(
-    check_totally_ordered_with<explicit_operators, different_return_types>());
+static_assert(check_totally_ordered_with<explicit_operators, explicit_operators>());
+static_assert(!check_totally_ordered_with<equality_comparable_with_ec1, equality_comparable_with_ec1>());
+static_assert(check_totally_ordered_with<different_return_types, different_return_types>());
+static_assert(!check_totally_ordered_with<explicit_operators, equality_comparable_with_ec1>());
+static_assert(check_totally_ordered_with<explicit_operators, different_return_types>());
 
 static_assert(!check_totally_ordered_with<one_way_eq, one_way_eq>());
-static_assert(
-    std::common_reference_with<one_way_eq const&, explicit_operators const&> &&
-    !check_totally_ordered_with<one_way_eq, explicit_operators>());
+static_assert(std::common_reference_with<one_way_eq const&, explicit_operators const&> &&
+              !check_totally_ordered_with<one_way_eq, explicit_operators>());
 
 static_assert(!check_totally_ordered_with<one_way_ne, one_way_ne>());
-static_assert(
-    std::common_reference_with<one_way_ne const&, explicit_operators const&> &&
-    !check_totally_ordered_with<one_way_ne, explicit_operators>());
+static_assert(std::common_reference_with<one_way_ne const&, explicit_operators const&> &&
+              !check_totally_ordered_with<one_way_ne, explicit_operators>());
 
-static_assert(
-    check_totally_ordered_with<totally_ordered_with_others,
-                               partial_ordering_totally_ordered_with>());
-static_assert(check_totally_ordered_with<totally_ordered_with_others,
-                                         weak_ordering_totally_ordered_with>());
-static_assert(
-    check_totally_ordered_with<totally_ordered_with_others,
-                               strong_ordering_totally_ordered_with>());
+static_assert(check_totally_ordered_with<totally_ordered_with_others, partial_ordering_totally_ordered_with>());
+static_assert(check_totally_ordered_with<totally_ordered_with_others, weak_ordering_totally_ordered_with>());
+static_assert(check_totally_ordered_with<totally_ordered_with_others, strong_ordering_totally_ordered_with>());
 
-static_assert(!check_totally_ordered_with<totally_ordered_with_others,
-                                          eq_returns_explicit_bool>());
-static_assert(!check_totally_ordered_with<totally_ordered_with_others,
-                                          ne_returns_explicit_bool>());
-static_assert(std::equality_comparable_with<totally_ordered_with_others,
-                                            lt_returns_explicit_bool> &&
-              !check_totally_ordered_with<totally_ordered_with_others,
-                                          lt_returns_explicit_bool>());
-static_assert(std::equality_comparable_with<totally_ordered_with_others,
-                                            gt_returns_explicit_bool> &&
-              !check_totally_ordered_with<totally_ordered_with_others,
-                                          gt_returns_explicit_bool>());
-static_assert(std::equality_comparable_with<totally_ordered_with_others,
-                                            le_returns_explicit_bool> &&
-              !check_totally_ordered_with<totally_ordered_with_others,
-                                          le_returns_explicit_bool>());
-static_assert(std::equality_comparable_with<totally_ordered_with_others,
-                                            ge_returns_explicit_bool> &&
-              !check_totally_ordered_with<totally_ordered_with_others,
-                                          ge_returns_explicit_bool>());
-static_assert(check_totally_ordered_with<totally_ordered_with_others,
-                                         returns_true_type>());
-static_assert(
-    check_totally_ordered_with<totally_ordered_with_others, returns_int_ptr>());
+static_assert(!check_totally_ordered_with<totally_ordered_with_others, eq_returns_explicit_bool>());
+static_assert(!check_totally_ordered_with<totally_ordered_with_others, ne_returns_explicit_bool>());
+static_assert(std::equality_comparable_with<totally_ordered_with_others, lt_returns_explicit_bool> &&
+              !check_totally_ordered_with<totally_ordered_with_others, lt_returns_explicit_bool>());
+static_assert(std::equality_comparable_with<totally_ordered_with_others, gt_returns_explicit_bool> &&
+              !check_totally_ordered_with<totally_ordered_with_others, gt_returns_explicit_bool>());
+static_assert(std::equality_comparable_with<totally_ordered_with_others, le_returns_explicit_bool> &&
+              !check_totally_ordered_with<totally_ordered_with_others, le_returns_explicit_bool>());
+static_assert(std::equality_comparable_with<totally_ordered_with_others, ge_returns_explicit_bool> &&
+              !check_totally_ordered_with<totally_ordered_with_others, ge_returns_explicit_bool>());
+static_assert(check_totally_ordered_with<totally_ordered_with_others, returns_true_type>());
+static_assert(check_totally_ordered_with<totally_ordered_with_others, returns_int_ptr>());
 
-static_assert(
-    std::totally_ordered<no_lt_not_totally_ordered_with>&&
-        std::equality_comparable_with<totally_ordered_with_others,
-                                      no_lt_not_totally_ordered_with> &&
-    !check_totally_ordered_with<totally_ordered_with_others,
-                                no_lt_not_totally_ordered_with>());
-static_assert(
-    std::totally_ordered<no_gt_not_totally_ordered_with>&&
-        std::equality_comparable_with<totally_ordered_with_others,
-                                      no_gt_not_totally_ordered_with> &&
-    !check_totally_ordered_with<totally_ordered_with_others,
-                                no_gt_not_totally_ordered_with>());
-static_assert(
-    std::totally_ordered<no_le_not_totally_ordered_with>&&
-        std::equality_comparable_with<totally_ordered_with_others,
-                                      no_le_not_totally_ordered_with> &&
-    !check_totally_ordered_with<totally_ordered_with_others,
-                                no_le_not_totally_ordered_with>());
-static_assert(
-    std::totally_ordered<no_ge_not_totally_ordered_with>&&
-        std::equality_comparable_with<totally_ordered_with_others,
-                                      no_ge_not_totally_ordered_with> &&
-    !check_totally_ordered_with<totally_ordered_with_others,
-                                no_ge_not_totally_ordered_with>());
+static_assert(std::totally_ordered<no_lt_not_totally_ordered_with> &&
+              std::equality_comparable_with<totally_ordered_with_others, no_lt_not_totally_ordered_with> &&
+              !check_totally_ordered_with<totally_ordered_with_others, no_lt_not_totally_ordered_with>());
+static_assert(std::totally_ordered<no_gt_not_totally_ordered_with> &&
+              std::equality_comparable_with<totally_ordered_with_others, no_gt_not_totally_ordered_with> &&
+              !check_totally_ordered_with<totally_ordered_with_others, no_gt_not_totally_ordered_with>());
+static_assert(std::totally_ordered<no_le_not_totally_ordered_with> &&
+              std::equality_comparable_with<totally_ordered_with_others, no_le_not_totally_ordered_with> &&
+              !check_totally_ordered_with<totally_ordered_with_others, no_le_not_totally_ordered_with>());
+static_assert(std::totally_ordered<no_ge_not_totally_ordered_with> &&
+              std::equality_comparable_with<totally_ordered_with_others, no_ge_not_totally_ordered_with> &&
+              !check_totally_ordered_with<totally_ordered_with_others, no_ge_not_totally_ordered_with>());
 } // namespace types_fit_for_purpose

--- a/libcxx/test/std/concepts/concepts.compare/concepts.totallyordered/totally_ordered_with.compile.pass.cpp
+++ b/libcxx/test/std/concepts/concepts.compare/concepts.totallyordered/totally_ordered_with.compile.pass.cpp
@@ -1134,5 +1134,3 @@ static_assert(
     !check_totally_ordered_with<totally_ordered_with_others,
                                 no_ge_not_totally_ordered_with>());
 } // namespace types_fit_for_purpose
-
-int main(int, char**) { return 0; }

--- a/libcxx/test/std/concepts/concepts.lang/concepts.arithmetic/floating_point.compile.pass.cpp
+++ b/libcxx/test/std/concepts/concepts.lang/concepts.arithmetic/floating_point.compile.pass.cpp
@@ -40,7 +40,7 @@ constexpr bool CheckFloatingPointQualifiers() {
 
   static_assert(!std::floating_point<T (*)()>);
   static_assert(!std::floating_point<T (&)()>);
-  static_assert(!std::floating_point<T(&&)()>);
+  static_assert(!std::floating_point<T (&&)()>);
 
   return result;
 }

--- a/libcxx/test/std/concepts/concepts.lang/concepts.arithmetic/floating_point.compile.pass.cpp
+++ b/libcxx/test/std/concepts/concepts.lang/concepts.arithmetic/floating_point.compile.pass.cpp
@@ -74,5 +74,3 @@ static_assert(!CheckFloatingPointQualifiers<ScopedEnum>());
 static_assert(!CheckFloatingPointQualifiers<EmptyStruct>());
 static_assert(!CheckFloatingPointQualifiers<int EmptyStruct::*>());
 static_assert(!CheckFloatingPointQualifiers<int (EmptyStruct::*)()>());
-
-int main(int, char**) { return 0; }

--- a/libcxx/test/std/concepts/concepts.lang/concepts.arithmetic/integral.compile.pass.cpp
+++ b/libcxx/test/std/concepts/concepts.lang/concepts.arithmetic/integral.compile.pass.cpp
@@ -88,5 +88,3 @@ static_assert(!CheckIntegralQualifiers<int (EmptyStruct::*)()>());
 
 static_assert(CheckSubsumption(0));
 static_assert(CheckSubsumption(0U));
-
-int main(int, char**) { return 0; }

--- a/libcxx/test/std/concepts/concepts.lang/concepts.arithmetic/integral.compile.pass.cpp
+++ b/libcxx/test/std/concepts/concepts.lang/concepts.arithmetic/integral.compile.pass.cpp
@@ -41,7 +41,7 @@ constexpr bool CheckIntegralQualifiers() {
 
   static_assert(!std::integral<T (*)()>);
   static_assert(!std::integral<T (&)()>);
-  static_assert(!std::integral<T(&&)()>);
+  static_assert(!std::integral<T (&&)()>);
 
   return result;
 }

--- a/libcxx/test/std/concepts/concepts.lang/concepts.arithmetic/signed_integral.compile.pass.cpp
+++ b/libcxx/test/std/concepts/concepts.lang/concepts.arithmetic/signed_integral.compile.pass.cpp
@@ -41,7 +41,7 @@ constexpr bool CheckSignedIntegralQualifiers() {
 
   static_assert(!std::signed_integral<T (*)()>);
   static_assert(!std::signed_integral<T (&)()>);
-  static_assert(!std::signed_integral<T(&&)()>);
+  static_assert(!std::signed_integral<T (&&)()>);
 
   return result;
 }
@@ -54,16 +54,12 @@ static_assert(CheckSignedIntegralQualifiers<long>());
 static_assert(CheckSignedIntegralQualifiers<long long>());
 
 // bool and character *may* be signed
-static_assert(CheckSignedIntegralQualifiers<wchar_t>() ==
-              std::is_signed_v<wchar_t>);
+static_assert(CheckSignedIntegralQualifiers<wchar_t>() == std::is_signed_v<wchar_t>);
 static_assert(CheckSignedIntegralQualifiers<bool>() == std::is_signed_v<bool>);
 static_assert(CheckSignedIntegralQualifiers<char>() == std::is_signed_v<char>);
-static_assert(CheckSignedIntegralQualifiers<char8_t>() ==
-              std::is_signed_v<char8_t>);
-static_assert(CheckSignedIntegralQualifiers<char16_t>() ==
-              std::is_signed_v<char16_t>);
-static_assert(CheckSignedIntegralQualifiers<char32_t>() ==
-              std::is_signed_v<char32_t>);
+static_assert(CheckSignedIntegralQualifiers<char8_t>() == std::is_signed_v<char8_t>);
+static_assert(CheckSignedIntegralQualifiers<char16_t>() == std::is_signed_v<char16_t>);
+static_assert(CheckSignedIntegralQualifiers<char32_t>() == std::is_signed_v<char32_t>);
 
 // integers that aren't signed integrals
 static_assert(!CheckSignedIntegralQualifiers<unsigned char>());

--- a/libcxx/test/std/concepts/concepts.lang/concepts.arithmetic/signed_integral.compile.pass.cpp
+++ b/libcxx/test/std/concepts/concepts.lang/concepts.arithmetic/signed_integral.compile.pass.cpp
@@ -92,5 +92,3 @@ static_assert(!CheckSignedIntegralQualifiers<int (EmptyStruct::*)()>());
 
 static_assert(CheckSubsumption(0));
 static_assert(CheckSubsumption(0U));
-
-int main(int, char**) { return 0; }

--- a/libcxx/test/std/concepts/concepts.lang/concepts.arithmetic/unsigned_integral.compile.pass.cpp
+++ b/libcxx/test/std/concepts/concepts.lang/concepts.arithmetic/unsigned_integral.compile.pass.cpp
@@ -41,7 +41,7 @@ constexpr bool CheckUnsignedIntegralQualifiers() {
 
   static_assert(!std::unsigned_integral<T (*)()>);
   static_assert(!std::unsigned_integral<T (&)()>);
-  static_assert(!std::unsigned_integral<T(&&)()>);
+  static_assert(!std::unsigned_integral<T (&&)()>);
 
   return result;
 }
@@ -54,18 +54,12 @@ static_assert(CheckUnsignedIntegralQualifiers<unsigned long>());
 static_assert(CheckUnsignedIntegralQualifiers<unsigned long long>());
 
 // Whether bool and character types are signed or unsigned is impl-defined
-static_assert(CheckUnsignedIntegralQualifiers<wchar_t>() ==
-              !std::is_signed_v<wchar_t>);
-static_assert(CheckUnsignedIntegralQualifiers<bool>() ==
-              !std::is_signed_v<bool>);
-static_assert(CheckUnsignedIntegralQualifiers<char>() ==
-              !std::is_signed_v<char>);
-static_assert(CheckUnsignedIntegralQualifiers<char8_t>() ==
-              !std::is_signed_v<char8_t>);
-static_assert(CheckUnsignedIntegralQualifiers<char16_t>() ==
-              !std::is_signed_v<char16_t>);
-static_assert(CheckUnsignedIntegralQualifiers<char32_t>() ==
-              !std::is_signed_v<char32_t>);
+static_assert(CheckUnsignedIntegralQualifiers<wchar_t>() == !std::is_signed_v<wchar_t>);
+static_assert(CheckUnsignedIntegralQualifiers<bool>() == !std::is_signed_v<bool>);
+static_assert(CheckUnsignedIntegralQualifiers<char>() == !std::is_signed_v<char>);
+static_assert(CheckUnsignedIntegralQualifiers<char8_t>() == !std::is_signed_v<char8_t>);
+static_assert(CheckUnsignedIntegralQualifiers<char16_t>() == !std::is_signed_v<char16_t>);
+static_assert(CheckUnsignedIntegralQualifiers<char32_t>() == !std::is_signed_v<char32_t>);
 
 // extended integers
 #ifndef TEST_HAS_NO_INT128

--- a/libcxx/test/std/concepts/concepts.lang/concepts.arithmetic/unsigned_integral.compile.pass.cpp
+++ b/libcxx/test/std/concepts/concepts.lang/concepts.arithmetic/unsigned_integral.compile.pass.cpp
@@ -93,5 +93,3 @@ static_assert(!CheckUnsignedIntegralQualifiers<int (EmptyStruct::*)()>());
 
 static_assert(CheckSubsumption(0));
 static_assert(CheckSubsumption(0U));
-
-int main(int, char**) { return 0; }

--- a/libcxx/test/std/containers/associative/map/gcc_workaround.compile.pass.cpp
+++ b/libcxx/test/std/containers/associative/map/gcc_workaround.compile.pass.cpp
@@ -9,9 +9,9 @@
 // Tests workaround for https://gcc.gnu.org/bugzilla/show_bug.cgi?id=37804
 
 #include <map>
-std::map<int,int>::iterator it;
+std::map<int, int>::iterator it;
 #include <set>
 
 #include "test_macros.h"
-using std::set;
 using std::multiset;
+using std::set;

--- a/libcxx/test/std/containers/associative/map/gcc_workaround.compile.pass.cpp
+++ b/libcxx/test/std/containers/associative/map/gcc_workaround.compile.pass.cpp
@@ -15,5 +15,3 @@ std::map<int,int>::iterator it;
 #include "test_macros.h"
 using std::set;
 using std::multiset;
-
-int main(int, char**) { return 0; }

--- a/libcxx/test/std/containers/associative/map/map.cons/default_recursive.compile.pass.cpp
+++ b/libcxx/test/std/containers/associative/map/map.cons/default_recursive.compile.pass.cpp
@@ -16,14 +16,13 @@
 
 #include "test_macros.h"
 
-struct X
-{
-    std::map<int, X> m;
-    std::map<int, X>::iterator i;
-    std::map<int, X>::const_iterator ci;
+struct X {
+  std::map<int, X> m;
+  std::map<int, X>::iterator i;
+  std::map<int, X>::const_iterator ci;
 #if TEST_STD_VER <= 17
-    // These reverse_iterator specializations require X to be complete in C++20.
-    std::map<int, X>::reverse_iterator ri;
-    std::map<int, X>::const_reverse_iterator cri;
+  // These reverse_iterator specializations require X to be complete in C++20.
+  std::map<int, X>::reverse_iterator ri;
+  std::map<int, X>::const_reverse_iterator cri;
 #endif // TEST_STD_VER <= 17
 };

--- a/libcxx/test/std/containers/associative/map/map.cons/default_recursive.compile.pass.cpp
+++ b/libcxx/test/std/containers/associative/map/map.cons/default_recursive.compile.pass.cpp
@@ -27,5 +27,3 @@ struct X
     std::map<int, X>::const_reverse_iterator cri;
 #endif // TEST_STD_VER <= 17
 };
-
-int main(int, char**) { return 0; }

--- a/libcxx/test/std/containers/associative/multimap/multimap.cons/default_recursive.compile.pass.cpp
+++ b/libcxx/test/std/containers/associative/multimap/multimap.cons/default_recursive.compile.pass.cpp
@@ -27,5 +27,3 @@ struct X
     std::multimap<int, X>::const_reverse_iterator cri;
 #endif // TEST_STD_VER <= 17
 };
-
-int main(int, char**) { return 0; }

--- a/libcxx/test/std/containers/associative/multimap/multimap.cons/default_recursive.compile.pass.cpp
+++ b/libcxx/test/std/containers/associative/multimap/multimap.cons/default_recursive.compile.pass.cpp
@@ -16,14 +16,13 @@
 
 #include "test_macros.h"
 
-struct X
-{
-    std::multimap<int, X> m;
-    std::multimap<int, X>::iterator i;
-    std::multimap<int, X>::const_iterator ci;
+struct X {
+  std::multimap<int, X> m;
+  std::multimap<int, X>::iterator i;
+  std::multimap<int, X>::const_iterator ci;
 #if TEST_STD_VER <= 17
-    // These reverse_iterator specializations require X to be complete in C++20.
-    std::multimap<int, X>::reverse_iterator ri;
-    std::multimap<int, X>::const_reverse_iterator cri;
+  // These reverse_iterator specializations require X to be complete in C++20.
+  std::multimap<int, X>::reverse_iterator ri;
+  std::multimap<int, X>::const_reverse_iterator cri;
 #endif // TEST_STD_VER <= 17
 };

--- a/libcxx/test/std/containers/associative/set/gcc_workaround.compile.pass.cpp
+++ b/libcxx/test/std/containers/associative/set/gcc_workaround.compile.pass.cpp
@@ -6,4 +6,12 @@
 //
 //===----------------------------------------------------------------------===//
 
-int main(int, char**) { return 0; }
+// Tests workaround for https://gcc.gnu.org/bugzilla/show_bug.cgi?id=37804
+
+#include <set>
+std::set<int> s;
+#include <map>
+
+#include "test_macros.h"
+using std::map;
+using std::multimap;

--- a/libcxx/test/std/iterators/iterator.requirements/iterator.assoc.types/readable.traits/iter_value_t.compile.pass.cpp
+++ b/libcxx/test/std/iterators/iterator.requirements/iterator.assoc.types/readable.traits/iter_value_t.compile.pass.cpp
@@ -40,7 +40,7 @@ static_assert(check_iter_value_t<std::vector<int>::iterator, int>());
 static_assert(check_iter_value_t<std::shared_ptr<int>, int>());
 
 struct both_members {
-  using value_type = double;
+  using value_type   = double;
   using element_type = double;
 };
 static_assert(check_iter_value_t<both_members, double>());
@@ -65,7 +65,7 @@ struct S {};
 static_assert(check_no_iter_value_t<S>());
 
 struct different_value_element_members {
-  using value_type = int;
+  using value_type   = int;
   using element_type = long;
 };
 static_assert(check_no_iter_value_t<different_value_element_members>());

--- a/libcxx/test/std/iterators/iterator.requirements/iterator.assoc.types/readable.traits/iter_value_t.compile.pass.cpp
+++ b/libcxx/test/std/iterators/iterator.requirements/iterator.assoc.types/readable.traits/iter_value_t.compile.pass.cpp
@@ -69,5 +69,3 @@ struct different_value_element_members {
   using element_type = long;
 };
 static_assert(check_no_iter_value_t<different_value_element_members>());
-
-int main(int, char**) { return 0; }

--- a/libcxx/test/std/numerics/numbers/user_type.compile.pass.cpp
+++ b/libcxx/test/std/numerics/numbers/user_type.compile.pass.cpp
@@ -52,5 +52,3 @@ user std::numbers::egamma_v<user>{};
 
 template <>
 user std::numbers::phi_v<user>{};
-
-int main(int, char**) { return 0; }

--- a/libcxx/test/std/strings/char.traits/char.traits.require/nothing_to_do.compile.pass.cpp
+++ b/libcxx/test/std/strings/char.traits/char.traits.require/nothing_to_do.compile.pass.cpp
@@ -5,5 +5,3 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-
-int main(int, char**) { return 0; }

--- a/libcxx/test/std/strings/char.traits/char.traits.typedefs/nothing_to_do.compile.pass.cpp
+++ b/libcxx/test/std/strings/char.traits/char.traits.typedefs/nothing_to_do.compile.pass.cpp
@@ -5,7 +5,3 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-
-#include <string_view>
-
-int main(int, char**) { return 0; }

--- a/libcxx/test/std/strings/string.view/string.view.synop/nothing_to_do.compile.pass.cpp
+++ b/libcxx/test/std/strings/string.view/string.view.synop/nothing_to_do.compile.pass.cpp
@@ -6,14 +6,4 @@
 //
 //===----------------------------------------------------------------------===//
 
-// Tests workaround for https://gcc.gnu.org/bugzilla/show_bug.cgi?id=37804
-
-#include <set>
-std::set<int> s;
-#include <map>
-
-#include "test_macros.h"
-using std::map;
-using std::multimap;
-
-int main(int, char**) { return 0; }
+#include <string_view>

--- a/libcxx/test/std/strings/strings.general/nothing_to_do.compile.pass.cpp
+++ b/libcxx/test/std/strings/strings.general/nothing_to_do.compile.pass.cpp
@@ -5,5 +5,3 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-
-int main(int, char**) { return 0; }


### PR DESCRIPTION
I noticed that these tests had empty `main` functions. Dropping them and renaming the tests to `MEOW.compile.pass.cpp` will slightly improve test throughput.