### PR TITLE
[lldb] Fixed TestEchoCommands.test running on a remote target

### DIFF
--- a/lldb/test/Shell/Settings/TestEchoCommands.test
+++ b/lldb/test/Shell/Settings/TestEchoCommands.test
@@ -2,6 +2,8 @@
 # RUN: %lldb -x -b -o 'settings set interpreter.echo-comment-commands false' -s %S/Inputs/EchoCommandsTest.in | FileCheck %S/Inputs/EchoCommandsNoComments.out
 # RUN: %lldb -x -b -o 'settings set interpreter.echo-commands false'         -s %S/Inputs/EchoCommandsTest.in | FileCheck %S/Inputs/EchoCommandsNone.out
 
+XFAIL: remote{{.*}}
+
 RUN: echo start >%t.file
 RUN: %lldb -x -b --source-quietly -s %S/Inputs/EchoCommandsTest.in >>%t.file
 RUN: echo done >>%t.file


### PR DESCRIPTION
EchoCommandsQuiet.out failed in case of a remote target because the platform selection and connection messages.