### PR TITLE
[OpenMP][OMPX] Fix ompx_ballot_sync test

### DIFF
--- a/offload/test/offloading/ompx_bare_ballot_sync.c
+++ b/offload/test/offloading/ompx_bare_ballot_sync.c
@@ -7,12 +7,6 @@
 // UNSUPPORTED: s390x-ibm-linux-gnu
 // UNSUPPORTED: s390x-ibm-linux-gnu-LTO
 
-#if defined __AMDGCN_WAVEFRONT_SIZE && __AMDGCN_WAVEFRONT_SIZE == 64
-#define MASK 0xaaaaaaaaaaaaaaaa
-#else
-#define MASK 0xaaaaaaaa
-#endif
-
 #include <assert.h>
 #include <ompx.h>
 #include <stdint.h>
@@ -23,23 +17,27 @@ int main(int argc, char *argv[]) {
   const int num_blocks = 1;
   const int block_size = 256;
   const int N = num_blocks * block_size;
-  uint64_t *data = (uint64_t *)malloc(N * sizeof(uint64_t));
+  int *res = (int *)malloc(N * sizeof(int));
 
-  for (int i = 0; i < N; ++i)
-    data[i] = i & 0x1;
-
-#pragma omp target teams ompx_bare num_teams(num_blocks) thread_limit(block_size) map(tofrom: data[0:N])
+#pragma omp target teams ompx_bare num_teams(num_blocks) thread_limit(block_size) \
+        map(from: res[0:N])
   {
     int tid = ompx_thread_id_x();
-    uint64_t mask = ompx_ballot_sync(~0U, data[tid]);
-    data[tid] += mask;
+    uint64_t mask = ompx_ballot_sync(~0LU, tid & 0x1);
+#if defined __AMDGCN_WAVEFRONT_SIZE && __AMDGCN_WAVEFRONT_SIZE == 64
+    res[tid] = mask == 0xaaaaaaaaaaaaaaaa;
+#else
+    res[tid] = mask == 0xaaaaaaaa;
+#endif
   }
 
   for (int i = 0; i < N; ++i)
-    assert(data[i] == ((i & 0x1) + MASK));
+    assert(res[i]);
 
   // CHECK: PASS
   printf("PASS\n");
+
+  free(res);
 
   return 0;
 }


### PR DESCRIPTION
The current test is not really correct because the mask is set to 0xffffffff
even if it is on an AMDGPU whose wavefront size is 64. Besides,
`__AMDGCN_WAVEFRONT_SIZE` is not set on host compilation so the verification
happens to work.
