### PR TITLE
[NewPM][BPF] Add `BPFCodeGenPassBuilder`

### DIFF
--- a/llvm/lib/Target/BPF/BPFCodeGenPassBuilder.cpp
+++ b/llvm/lib/Target/BPF/BPFCodeGenPassBuilder.cpp
@@ -1,0 +1,30 @@
+//===-- BPFCodeGenPassBuilder.cpp -----------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements BPFCodeGenPassBuilder class.
+//
+//===----------------------------------------------------------------------===//
+
+#include "BPFCodeGenPassBuilder.h"
+#include "BPFTargetMachine.h"
+
+using namespace llvm;
+
+BPFCodeGenPassBuilder::BPFCodeGenPassBuilder(BPFTargetMachine &TM,
+                                             const CGPassBuilderOption &Opts,
+                                             PassInstrumentationCallbacks *PIC)
+    : CodeGenPassBuilder(TM, Opts, PIC) {}
+
+void BPFCodeGenPassBuilder::addPreISel(AddIRPass &addPass) const {
+  // TODO: Add passes pre instruction selection.
+}
+
+void BPFCodeGenPassBuilder::addAsmPrinter(AddMachinePass &addPass,
+                                          CreateMCStreamer) const {
+  // TODO: Add AsmPrinter.
+}

--- a/llvm/lib/Target/BPF/BPFCodeGenPassBuilder.h
+++ b/llvm/lib/Target/BPF/BPFCodeGenPassBuilder.h
@@ -1,0 +1,31 @@
+//===- BPFCodeGenPassBuilder.h - Build BPF codegen pipeline -----*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIB_TARGET_BPF_BPFCODEGENPASSBUILDER_H
+#define LLVM_LIB_TARGET_BPF_BPFCODEGENPASSBUILDER_H
+
+#include "llvm/MC/MCStreamer.h"
+#include "llvm/Passes/CodeGenPassBuilder.h"
+
+namespace llvm {
+
+class BPFTargetMachine;
+
+class BPFCodeGenPassBuilder
+    : public CodeGenPassBuilder<BPFCodeGenPassBuilder, BPFTargetMachine> {
+public:
+  BPFCodeGenPassBuilder(BPFTargetMachine &TM, const CGPassBuilderOption &Opts,
+                        PassInstrumentationCallbacks *PIC);
+
+  void addPreISel(AddIRPass &addPass) const;
+  void addAsmPrinter(AddMachinePass &, CreateMCStreamer) const;
+};
+
+} // namespace llvm
+
+#endif // LLVM_LIB_TARGET_BPF_BPFCODEGENPASSBUILDER_H

--- a/llvm/lib/Target/BPF/BPFTargetMachine.cpp
+++ b/llvm/lib/Target/BPF/BPFTargetMachine.cpp
@@ -12,6 +12,7 @@
 
 #include "BPFTargetMachine.h"
 #include "BPF.h"
+#include "BPFCodeGenPassBuilder.h"
 #include "BPFTargetTransformInfo.h"
 #include "MCTargetDesc/BPFMCAsmInfo.h"
 #include "TargetInfo/BPFTargetInfo.h"
@@ -106,6 +107,14 @@ public:
 
 TargetPassConfig *BPFTargetMachine::createPassConfig(PassManagerBase &PM) {
   return new BPFPassConfig(*this, PM);
+}
+
+Error BPFTargetMachine::buildCodeGenPipeline(
+    ModulePassManager &MPM, raw_pwrite_stream &Out, raw_pwrite_stream *DwoOut,
+    CodeGenFileType FileType, const CGPassBuilderOption &Opts,
+    PassInstrumentationCallbacks *PIC) {
+  BPFCodeGenPassBuilder CGPB(*this, Opts, PIC);
+  return CGPB.buildPipeline(MPM, Out, DwoOut, FileType);
 }
 
 static Expected<bool> parseBPFPreserveStaticOffsetOptions(StringRef Params) {

--- a/llvm/lib/Target/BPF/BPFTargetMachine.h
+++ b/llvm/lib/Target/BPF/BPFTargetMachine.h
@@ -36,6 +36,11 @@ public:
 
   TargetPassConfig *createPassConfig(PassManagerBase &PM) override;
 
+  Error buildCodeGenPipeline(ModulePassManager &, raw_pwrite_stream &,
+                             raw_pwrite_stream *, CodeGenFileType,
+                             const CGPassBuilderOption &,
+                             PassInstrumentationCallbacks *) override;
+
   TargetTransformInfo getTargetTransformInfo(const Function &F) const override;
 
   TargetLoweringObjectFile *getObjFileLowering() const override {

--- a/llvm/lib/Target/BPF/CMakeLists.txt
+++ b/llvm/lib/Target/BPF/CMakeLists.txt
@@ -26,6 +26,7 @@ add_llvm_target(BPFCodeGen
   BPFAsmPrinter.cpp
   BPFASpaceCastSimplifyPass.cpp
   BPFCheckAndAdjustIR.cpp
+  BPFCodeGenPassBuilder.cpp
   BPFFrameLowering.cpp
   BPFInstrInfo.cpp
   BPFIRPeephole.cpp


### PR DESCRIPTION
We need a simple enough target to make codegen pipeline short, so we can handle important passes (e.g. asm printer) as soon as possible.