### PR TITLE
[lldb] Disable find-module.test in case of a remote target

### DIFF
--- a/lldb/test/Shell/Minidump/Windows/find-module.test
+++ b/lldb/test/Shell/Minidump/Windows/find-module.test
@@ -1,6 +1,8 @@
 Test that we correctly find a PE/COFF file in our executable search path, and
 use it when opening minidumps.
 
+UNSUPPORTED: remote{{.*}}
+
 RUN: yaml2obj %S/Inputs/find-module.exe.yaml -o %T/find-module.exe
 RUN: yaml2obj %S/Inputs/find-module.dmp.yaml -o %T/find-module.dmp
 RUN: %lldb -O "settings set target.exec-search-paths %T" \

--- a/lldb/test/Shell/Minidump/Windows/find-module.test
+++ b/lldb/test/Shell/Minidump/Windows/find-module.test
@@ -1,7 +1,7 @@
 Test that we correctly find a PE/COFF file in our executable search path, and
 use it when opening minidumps.
 
-UNSUPPORTED: remote{{.*}}
+XFAIL: remote{{.*}}
 
 RUN: yaml2obj %S/Inputs/find-module.exe.yaml -o %T/find-module.exe
 RUN: yaml2obj %S/Inputs/find-module.dmp.yaml -o %T/find-module.dmp


### PR DESCRIPTION
The target arch is `i386-pc-windows` after loading the dump. It updates to `i386-pc-windows-msvc` or `i386-pc-windows-gnu` in lldb\source\Plugins\Process\minidump\ProcessMinidump.cpp, line 218
```
GetTarget().MergeArchitecture(module->GetArchitecture());
```
But in case of the remote target (`remote-linux`) and the `Windows host` lldb executed the following commands at the beginning
```
platform select remote-linux
platform connect connect://<ip>:<port>
```
and then the target arch is `i386-pc-windows-msvc` immediately after loading the dump. GetTarget().MergeArchitecture(module->GetArchitecture()) does not update it to `i386-pc-windows-gnu` when the module arch is `i386-pc-windows-gnu`.