### PR TITLE
[clang] Add tests for some CWG issues from 2024-05-31 telecon

### DIFF
--- a/clang/test/CXX/drs/cwg28xx.cpp
+++ b/clang/test/CXX/drs/cwg28xx.cpp
@@ -1,10 +1,10 @@
-// RUN: %clang_cc1 -std=c++98 -verify=expected %s
-// RUN: %clang_cc1 -std=c++11 -verify=expected %s
-// RUN: %clang_cc1 -std=c++14 -verify=expected %s
-// RUN: %clang_cc1 -std=c++17 -verify=expected %s
-// RUN: %clang_cc1 -std=c++20 -verify=expected,since-cxx20 %s
-// RUN: %clang_cc1 -std=c++23 -verify=expected,since-cxx20,since-cxx23 %s
-// RUN: %clang_cc1 -std=c++2c -verify=expected,since-cxx20,since-cxx23,since-cxx26 %s
+// RUN: %clang_cc1 -std=c++98 -pedantic-errors -verify=expected,cxx98 %s
+// RUN: %clang_cc1 -std=c++11 -pedantic-errors -verify=expected %s
+// RUN: %clang_cc1 -std=c++14 -pedantic-errors -verify=expected %s
+// RUN: %clang_cc1 -std=c++17 -pedantic-errors -verify=expected %s
+// RUN: %clang_cc1 -std=c++20 -pedantic-errors -verify=expected,since-cxx20 %s
+// RUN: %clang_cc1 -std=c++23 -pedantic-errors -verify=expected,since-cxx20,since-cxx23 %s
+// RUN: %clang_cc1 -std=c++2c -pedantic-errors -verify=expected,since-cxx20,since-cxx23,since-cxx26 %s
 
 namespace cwg2819 { // cwg2819: 19 tentatively ready 2023-12-01
 #if __cpp_constexpr >= 202306L
@@ -110,6 +110,26 @@ struct A {
 
 } // namespace cwg2858
 
+namespace cwg2877 { // cwg2877: no tentatively ready 2024-05-31
+#if __cplusplus >= 202002L
+enum E { x };
+void f() {
+  int E;
+  // FIXME: OK, names ::E
+  using enum E;
+  // since-cxx20-error@-1 {{unknown type name E}}
+}
+using F = E;
+using enum F;     // OK, designates ::E
+template<class T> using EE = T;
+void g() {
+  // FIXME: OK, designates ::E
+  using enum EE<E>;
+  // since-cxx20-error@-1 {{using enum requires an enum or typedef name}}
+}
+#endif
+} // namespace cwg2877
+
 namespace cwg2881 { // cwg2881: 19 tentatively ready 2024-04-19
 
 #if __cplusplus >= 202302L
@@ -180,3 +200,64 @@ void f() {
 
 } // namespace cwg2881
 
+namespace cwg2882 { // cwg2882: 2.7 tentatively ready 2024-05-31
+struct C {
+  operator void() = delete;
+  // expected-warning@-1 {{conversion function converting 'cwg2882::C' to 'void' will never be used}}
+  // cxx98-error@-2 {{deleted function definitions are a C++11 extension}}
+};
+
+void f(C c) {
+  (void)c;
+}
+} // namespace cwg2882
+
+namespace cwg2883 { // cwg2883: no tentatively ready 2024-05-31
+#if __cplusplus >= 201103L
+void f() {
+  int x;
+  (void)[&] {
+    return x;
+  };
+}
+#endif
+#if __cplusplus >= 202002L
+struct A {
+  A() = default;
+  A(const A &) = delete; // #cwg2883-A-copy-ctor
+  constexpr operator int() { return 42; }
+};
+void g() {
+  constexpr A a;
+  // FIXME: OK, not odr-usable from a default template argument, and not odr-used
+  (void)[=]<typename T, int = a> {};
+  // since-cxx20-error@-1 {{call to deleted constructor of 'const A'}}
+  //   since-cxx20-note@#cwg2883-A-copy-ctor {{'A' has been explicitly marked deleted here}}
+}
+#endif
+} // namespace cwg2883
+
+namespace cwg2885 { // cwg2885: 16 tentatively ready 2024-05-31
+#if __cplusplus >= 202002L
+template <class T>
+struct A {
+  A() requires (false) = default;
+  A() : t(42) {}
+  T t;
+};
+
+struct B : A<int> {};
+static_assert(!__is_trivially_constructible(B));
+#endif
+} // namespace cwg2885
+
+namespace cwg2886 { // cwg2886: 9 tentatively ready 2024-05-31
+#if __cplusplus >= 201103L
+struct C {
+  C() = default;
+  ~C() noexcept(false) = default;
+};
+
+static_assert(noexcept(C()), "");
+#endif
+} // namespace cwg2886

--- a/clang/www/cxx_dr_status.html
+++ b/clang/www/cxx_dr_status.html
@@ -17071,7 +17071,7 @@ objects</td>
     <td><a href="https://cplusplus.github.io/CWG/issues/2877.html">2877</a></td>
     <td>tentatively ready</td>
     <td>Type-only lookup for <I>using-enum-declarator</I></td>
-    <td align="center">Not resolved</td>
+    <td title="Clang does not implement 2024-05-31 resolution" align="center">Not Resolved*</td>
   </tr>
   <tr class="open" id="2878">
     <td><a href="https://cplusplus.github.io/CWG/issues/2878.html">2878</a></td>
@@ -17101,13 +17101,13 @@ objects</td>
     <td><a href="https://cplusplus.github.io/CWG/issues/2882.html">2882</a></td>
     <td>tentatively ready</td>
     <td>Unclear treatment of conversion to <TT>void</TT></td>
-    <td align="center">Not resolved</td>
+    <td title="Clang 2.7 implements 2024-05-31 resolution" align="center">Not Resolved*</td>
   </tr>
   <tr class="open" id="2883">
     <td><a href="https://cplusplus.github.io/CWG/issues/2883.html">2883</a></td>
     <td>tentatively ready</td>
     <td>Definition of "odr-usable" ignores lambda scopes</td>
-    <td align="center">Not resolved</td>
+    <td title="Clang does not implement 2024-05-31 resolution" align="center">Not Resolved*</td>
   </tr>
   <tr id="2884">
     <td><a href="https://cplusplus.github.io/CWG/issues/2884.html">2884</a></td>
@@ -17119,13 +17119,13 @@ objects</td>
     <td><a href="https://cplusplus.github.io/CWG/issues/2885.html">2885</a></td>
     <td>tentatively ready</td>
     <td>Non-eligible trivial default constructors</td>
-    <td align="center">Not resolved</td>
+    <td title="Clang 16 implements 2024-05-31 resolution" align="center">Not Resolved*</td>
   </tr>
   <tr class="open" id="2886">
     <td><a href="https://cplusplus.github.io/CWG/issues/2886.html">2886</a></td>
     <td>tentatively ready</td>
     <td>Temporaries and trivial potentially-throwing special member functions</td>
-    <td align="center">Not resolved</td>
+    <td title="Clang 9 implements 2024-05-31 resolution" align="center">Not Resolved*</td>
   </tr>
   <tr class="open" id="2887">
     <td><a href="https://cplusplus.github.io/CWG/issues/2887.html">2887</a></td>


### PR DESCRIPTION
This patch adds tests for some CWG issues that were discussed at 2024-05-31 telecon. While all of them are tentatively ready at the moment, I'm expecting them to be moved to DRs without changes. CWG issues that are expected to have follow-ups are not included in this PR.

I also realized that `cwg28xx.cpp` has been testing without `-pedantic-errors`. I fixed that. Fortunately, no existing tests had anything hidden by the lack of this flag.

The following CWG issues are covered:
[CWG2877](https://cplusplus.github.io/CWG/issues/2877.html) "Type-only lookup for _using-enum-declarator_"
[CWG2882](https://cplusplus.github.io/CWG/issues/2882.html) "Unclear treatment of conversion to `void`"
[CWG2883](https://cplusplus.github.io/CWG/issues/2883.html) "Definition of "odr-usable" ignores lambda scopes"
[CWG2885](https://cplusplus.github.io/CWG/issues/2885.html) "Non-eligible trivial default constructors"
[CWG2886](https://cplusplus.github.io/CWG/issues/2886.html) "Temporaries and trivial potentially-throwing special member functions"