### PR TITLE
[libc++][test] Mark `optional` test functions as `TEST_CONSTEXPR_CXX20`

### DIFF
--- a/libcxx/test/std/utilities/optional/optional.object/optional.object.assign/emplace.pass.cpp
+++ b/libcxx/test/std/utilities/optional/optional.object/optional.object.assign/emplace.pass.cpp
@@ -210,7 +210,7 @@ void test_on_test_type() {
     }
 }
 
-constexpr bool test_empty_emplace()
+TEST_CONSTEXPR_CXX20 bool test_empty_emplace()
 {
     optional<const int> opt;
     auto &v = opt.emplace(42);

--- a/libcxx/test/std/utilities/optional/optional.object/optional.object.assign/emplace.pass.cpp
+++ b/libcxx/test/std/utilities/optional/optional.object/optional.object.assign/emplace.pass.cpp
@@ -210,16 +210,15 @@ void test_on_test_type() {
     }
 }
 
-TEST_CONSTEXPR_CXX20 bool test_empty_emplace()
-{
-    optional<const int> opt;
-    auto &v = opt.emplace(42);
-    static_assert( std::is_same_v<const int&, decltype(v)>, "" );
-    assert(*opt == 42);
-    assert(   v == 42);
-    opt.emplace();
-    assert(*opt == 0);
-    return true;
+TEST_CONSTEXPR_CXX20 bool test_empty_emplace() {
+  optional<const int> opt;
+  auto& v = opt.emplace(42);
+  static_assert(std::is_same_v<const int&, decltype(v)>, "");
+  assert(*opt == 42);
+  assert(v == 42);
+  opt.emplace();
+  assert(*opt == 0);
+  return true;
 }
 
 int main(int, char**)

--- a/libcxx/test/std/utilities/optional/optional.object/optional.object.mod/reset.pass.cpp
+++ b/libcxx/test/std/utilities/optional/optional.object/optional.object.mod/reset.pass.cpp
@@ -31,7 +31,7 @@ struct X
 
 bool X::dtor_called = false;
 
-constexpr bool check_reset()
+TEST_CONSTEXPR_CXX20 bool check_reset()
 {
     {
         optional<int> opt;

--- a/libcxx/test/std/utilities/optional/optional.object/optional.object.mod/reset.pass.cpp
+++ b/libcxx/test/std/utilities/optional/optional.object/optional.object.mod/reset.pass.cpp
@@ -31,20 +31,19 @@ struct X
 
 bool X::dtor_called = false;
 
-TEST_CONSTEXPR_CXX20 bool check_reset()
-{
-    {
-        optional<int> opt;
-        static_assert(noexcept(opt.reset()) == true, "");
-        opt.reset();
-        assert(static_cast<bool>(opt) == false);
-    }
-    {
-        optional<int> opt(3);
-        opt.reset();
-        assert(static_cast<bool>(opt) == false);
-    }
-    return true;
+TEST_CONSTEXPR_CXX20 bool check_reset() {
+  {
+    optional<int> opt;
+    static_assert(noexcept(opt.reset()) == true, "");
+    opt.reset();
+    assert(static_cast<bool>(opt) == false);
+  }
+  {
+    optional<int> opt(3);
+    opt.reset();
+    assert(static_cast<bool>(opt) == false);
+  }
+  return true;
 }
 
 int main(int, char**)


### PR DESCRIPTION
[P2231R1](https://wg21.link/P2231R1) "Missing `constexpr` in `std::optional` and `std::variant`" was accepted as a C++20 Defect Report, not a C++17 Defect Report. Accordingly, `test_empty_emplace()` and `check_reset()` should be marked as `TEST_CONSTEXPR_CXX20`. Note that their `static_assert`s are properly guarded:

https://github.com/llvm/llvm-project/blob/4ce65423be0ba1d90c11b6a79981d6314e1cf36d/libcxx/test/std/utilities/optional/optional.object/optional.object.assign/emplace.pass.cpp#L270-L272

https://github.com/llvm/llvm-project/blob/4ce65423be0ba1d90c11b6a79981d6314e1cf36d/libcxx/test/std/utilities/optional/optional.object/optional.object.mod/reset.pass.cpp#L53-L55

Found while running libc++'s tests with MSVC's STL, as we activate our `constexpr` here for C++20 and above.