### PR TITLE
Fix detection of __datasizeof with Clang.

### DIFF
--- a/libcxx/include/__type_traits/datasizeof.h
+++ b/libcxx/include/__type_traits/datasizeof.h
@@ -26,7 +26,7 @@
 
 _LIBCPP_BEGIN_NAMESPACE_STD
 
-#if __has_extension(datasizeof)
+#if __has_keyword(__datasizeof) || __has_extension(datasizeof)
 template <class _Tp>
 inline const size_t __datasizeof_v = __datasizeof(_Tp);
 #else


### PR DESCRIPTION
The `__has_extension` builtin macro is the same as __has_feature when
-pedantic-errors is specified, which means we don't get the right
information about __datasizeof being available.

Using __has_keyword (really !__is_identifier) will tell the truth
even when -pedantic-errors is specified.

This means we always have __datasizeof under Clang
