### PR TITLE
[lldb][test] Fix D lang mangling test on Windows

### DIFF
--- a/lldb/test/API/lang/c/non-mangled/TestCNonMangled.py
+++ b/lldb/test/API/lang/c/non-mangled/TestCNonMangled.py
@@ -1,10 +1,8 @@
 import lldbsuite.test.lldbutil as lldbutil
 from lldbsuite.test.lldbtest import *
-from lldbsuite.test.decorators import skipIfWindows
 
 
 class TestCase(TestBase):
-    @skipIfWindows
     def test_functions_having_dlang_mangling_prefix(self):
         """
         Ensure C functions with a '_D' prefix alone are not mistakenly treated

--- a/lldb/test/API/lang/c/non-mangled/TestCNonMangled.py
+++ b/lldb/test/API/lang/c/non-mangled/TestCNonMangled.py
@@ -13,5 +13,14 @@ class TestCase(TestBase):
         """
         self.build()
         _, _, thread, _ = lldbutil.run_to_name_breakpoint(self, "_Dfunction")
-        symbol = thread.frame[0].symbol
-        self.assertEqual(symbol.GetDisplayName(), "_Dfunction")
+        frame = thread.frame[0]
+
+        symbol = frame.symbol
+        # On Windows the function does not have an associated symbol.
+        if symbol.IsValid():
+            self.assertFalse(symbol.mangled)
+            self.assertEqual(symbol.GetDisplayName(), "_Dfunction")
+
+        function = frame.function
+        self.assertFalse(function.mangled)
+        self.assertEqual(function.GetDisplayName(), "_Dfunction")


### PR DESCRIPTION
On Windows the function does not have a symbol associated with it:
       Function: id = {0x000001c9}, name = "_Dfunction", range = [0x0000000140001000-0x0000000140001004)
      LineEntry: <...>

Whereas it does on Linux:
       Function: id = {0x00000023}, name = "_Dfunction", range = [0x0000000000000734-0x0000000000000738)
      LineEntry: <...>
         Symbol: id = {0x00000058}, range = [0x0000000000000734-0x0000000000000738), name="_Dfunction"

This means that frame.symbol is not valid on Windows.

However, frame.function is valid and it also has a "mangled" attribute.

So I've updated the test to check the symbol if we've got it, and the function always.

In both cases we check that mangled is empty (meaning it has not been treated as mangled) and that the display name matches the original symbol name.