### PR TITLE
[cmake][runtimes] Add missing dependency on LLVMgold.so

### DIFF
--- a/llvm/cmake/modules/LLVMExternalProjectUtils.cmake
+++ b/llvm/cmake/modules/LLVMExternalProjectUtils.cmake
@@ -240,6 +240,11 @@ function(llvm_ExternalProject_Add name source_dir)
       list(APPEND compiler_args -DCMAKE_RC_COMPILER=${LLVM_RUNTIME_OUTPUT_INTDIR}/llvm-rc${CMAKE_EXECUTABLE_SUFFIX})
     endif()
     list(APPEND ARG_DEPENDS ${TOOLCHAIN_TOOLS})
+    # Add LLVMgold.so dependency if it is available, as clang may need it for
+    # LTO.
+    if(CLANG_IN_TOOLCHAIN AND TARGET LLVMgold)
+      list(APPEND ARG_DEPENDS LLVMgold)
+    endif()
   endif()
 
   if(ARG_STRIP_TOOL)


### PR DESCRIPTION
When doing a runtimes build with LTO using ld.bfd (or ld.gold), the build starts failing with [ninja 1.12](https://github.com/ninja-build/ninja/releases/tag/v1.12.0), which added a new critical path scheduler. The reason is that LLVMgold.so is not available yet at the point where runtimes start being build, leading to configuration failures in the nested cmake invocation.

Fix this by adding an explicit dependency on LLVMgold.so if it is available. (It may not always be necessary, e.g. if the used linker is lld, but it would be hard to detect when exactly it may or may not be needed, so always adding the dependency is safer.)