### PR TITLE
[SYCL] Allow neon attributes for ARM host

### DIFF
--- a/clang/lib/Sema/SemaType.cpp
+++ b/clang/lib/Sema/SemaType.cpp
@@ -8287,10 +8287,10 @@ static bool verifyValidIntegerConstantExpr(Sema &S, const ParsedAttr &Attr,
 /// match one of the standard Neon vector types.
 static void HandleNeonVectorTypeAttr(QualType &CurType, const ParsedAttr &Attr,
                                      Sema &S, VectorKind VecKind) {
-  bool IsTargetCUDAAndHostARM = false;
-  if (S.getLangOpts().CUDAIsDevice) {
+  bool IsTargetDeviceAndHostARM = false;
+  if (S.getLangOpts().CUDAIsDevice || S.getLangOpts().SYCLIsDevice) {
     const TargetInfo *AuxTI = S.getASTContext().getAuxTargetInfo();
-    IsTargetCUDAAndHostARM =
+    IsTargetDeviceAndHostARM =
         AuxTI && (AuxTI->getTriple().isAArch64() || AuxTI->getTriple().isARM());
   }
 
@@ -8327,7 +8327,7 @@ static void HandleNeonVectorTypeAttr(QualType &CurType, const ParsedAttr &Attr,
 
   // Only certain element types are supported for Neon vectors.
   if (!isPermittedNeonBaseType(CurType, VecKind, S) &&
-      !IsTargetCUDAAndHostARM) {
+      !IsTargetDeviceAndHostARM) {
     S.Diag(Attr.getLoc(), diag::err_attribute_invalid_vector_type) << CurType;
     Attr.setInvalid();
     return;

--- a/clang/test/SemaSYCL/neon-attrs.cpp
+++ b/clang/test/SemaSYCL/neon-attrs.cpp
@@ -1,0 +1,10 @@
+// Host compilation on ARM with neon enabled (no errors expected).
+// RUN: %clang_cc1 -triple aarch64-linux-gnu -target-feature +neon -fsyntax-only -verify=quiet %s
+
+// Device compilation on ARM (no errors expected).
+// RUN: %clang_cc1 -triple spirv64 -aux-triple aarch64-linux-gnu -fsycl-is-device -fsyntax-only -verify=quiet %s
+
+// quiet-no-diagnostics
+typedef __attribute__((neon_vector_type(4))) float float32x4_t;
+typedef unsigned char poly8_t;
+typedef __attribute__((neon_polyvector_type(8))) poly8_t poly8x8_t;


### PR DESCRIPTION
We permit neon attributes in CUDA device code, but this permission was only for CUDA device code. The same permission makes sense for SYCL device code as well, especially now that neon attributes are used in glibc headers.