### PR TITLE
[llvm-readobj][COFF] Consistent PDBGUID Formatting

### DIFF
--- a/lld/test/COFF/rsds.test
+++ b/lld/test/COFF/rsds.test
@@ -60,7 +60,7 @@
 # CHECK:     PointerToRawData: 0x{{[^0]}}
 # CHECK:     PDBInfo {
 # CHECK:       PDBSignature: 0x53445352
-# CHECK:       PDBGUID: [[GUID:\(([A-Za-z0-9]{2} ?){16}\)]]
+# CHECK:       PDBGUID: [[GUID:\{[A-Za-z0-9\-]{36}\}]]
 # CHECK:       PDBAge: 1
 # CHECK:       PDBFileName: {{.*}}.pdb
 # CHECK:     }
@@ -99,7 +99,7 @@
 # TWOPDBS:     PointerToRawData: 0x{{[^0]}}
 # TWOPDBS:     PDBInfo {
 # TWOPDBS:       PDBSignature: 0x53445352
-# TWOPDBS:       PDBGUID: [[GUID:\(([A-Za-z0-9]{2} ?){16}\)]]
+# TWOPDBS:       PDBGUID: [[GUID:\{[A-Za-z0-9\-]{36}\}]]
 # TWOPDBS:       PDBAge: 1
 # TWOPDBS:       PDBFileName: {{.*}}.pdb
 # TWOPDBS:     }
@@ -182,7 +182,7 @@
 # BUILDID:     PointerToRawData: 0x{{[^0]}}
 # BUILDID:     PDBInfo {
 # BUILDID:       PDBSignature: 0x53445352
-# BUILDID:       PDBGUID: [[GUID:\(([A-Za-z0-9]{2} ?){16}\)]]
+# BUILDID:       PDBGUID: [[GUID:\{[A-Za-z0-9\-]{36}\}]]
 # BUILDID:       PDBAge: 1
 # BUILDID:       PDBFileName:
 # BUILDID:     }

--- a/llvm/test/tools/llvm-readobj/COFF/debug-directory.test
+++ b/llvm/test/tools/llvm-readobj/COFF/debug-directory.test
@@ -12,7 +12,7 @@ CHECK:     AddressOfRawData: 0x5B068
 CHECK:     PointerToRawData: 0x5A268
 CHECK:     PDBInfo {
 CHECK:       PDBSignature: 0x53445352
-CHECK:       PDBGUID: (96 83 40 42 81 07 9D 40 90 1B 4A 3C 0D 4F 56 32)
+CHECK:       PDBGUID: {42408396-0781-409D-901B-4A3C0D4F5632}
 CHECK:       PDBAge: 3
 CHECK:       PDBFileName: D:\src\llvm\build\has_pdb.pdb
 CHECK:     }

--- a/llvm/tools/llvm-readobj/COFFDumper.cpp
+++ b/llvm/tools/llvm-readobj/COFFDumper.cpp
@@ -27,6 +27,7 @@
 #include "llvm/DebugInfo/CodeView/DebugInlineeLinesSubsection.h"
 #include "llvm/DebugInfo/CodeView/DebugLinesSubsection.h"
 #include "llvm/DebugInfo/CodeView/DebugStringTableSubsection.h"
+#include "llvm/DebugInfo/CodeView/Formatters.h"
 #include "llvm/DebugInfo/CodeView/LazyRandomTypeCollection.h"
 #include "llvm/DebugInfo/CodeView/Line.h"
 #include "llvm/DebugInfo/CodeView/MergingTypeTableBuilder.h"
@@ -793,7 +794,9 @@ void COFFDumper::printCOFFDebugDirectory() {
       DictScope PDBScope(W, "PDBInfo");
       W.printHex("PDBSignature", DebugInfo->Signature.CVSignature);
       if (DebugInfo->Signature.CVSignature == OMF::Signature::PDB70) {
-        W.printBinary("PDBGUID", ArrayRef(DebugInfo->PDB70.Signature));
+        W.printString(
+            "PDBGUID",
+            formatv("{0}", fmt_guid(DebugInfo->PDB70.Signature)).str());
         W.printNumber("PDBAge", DebugInfo->PDB70.Age);
         W.printString("PDBFileName", PDBFileName);
       }


### PR DESCRIPTION
## Consistent PDB GUID in `llvm-readobj`

Currently, the PDB GUID is shown as a byte array:
`PDBGUID: (D8 4C 88 D9 26 15 1F 11 4C 4C 44 20 50 44 42 2E)`

This is inconsistent with `llvm-pdbutil` (e.g. `llvm-pdbutil dump --summary`) which shows it as a hexadecimal string.
Additionally, `yaml2obj` uses the same hexadecimal string format.

In general, the hexadecimal string is the common representation for PDB GUIDs on Windows.

This PR changes it to be consistent as shown below:
`PDBGUID: {D9884CD8-1526-111F-4C4C-44205044422E}`