### PR TITLE
 [SPIR-V] Fix tracking ptr null constants of builtin types in calls with mangling

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVCallLowering.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVCallLowering.cpp
@@ -258,8 +258,7 @@ static SPIRVType *getArgSPIRVType(const Function &F, unsigned ArgIdx,
             cast<ConstantInt>(II->getOperand(2))->getZExtValue(), ST));
   }
 
-  std::string DemangledFuncName =
-      getOclOrSpirvBuiltinDemangledName(F.getName());
+  std::string DemangledFuncName = demangleBuiltinCall(F.getName());
   if (!DemangledFuncName.empty()) {
     Type *BuiltinType = SPIRV::parseBuiltinCallArgumentBaseType(
         DemangledFuncName, ArgIdx, F.getContext());
@@ -521,7 +520,7 @@ bool SPIRVCallLowering::lowerCall(MachineIRBuilder &MIRBuilder,
   // globally later.
   if (Info.Callee.isGlobal()) {
     std::string FuncName = Info.Callee.getGlobal()->getName().str();
-    DemangledName = getOclOrSpirvBuiltinDemangledName(FuncName);
+    DemangledName = demangleBuiltinCall(FuncName);
     CF = dyn_cast_or_null<const Function>(Info.Callee.getGlobal());
     // TODO: support constexpr casts and indirect calls.
     if (CF == nullptr)

--- a/llvm/lib/Target/SPIRV/SPIRVCallLowering.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVCallLowering.cpp
@@ -211,12 +211,15 @@ static SPIRVType *getArgSPIRVType(const Function &F, unsigned ArgIdx,
         addressSpaceToStorageClass(getPointerAddressSpace(ArgType), ST));
   }
 
-  // In case OriginalArgType is of untyped pointer type, there are three
+  // In case OriginalArgType is of untyped pointer type, there are four
   // possibilities:
   // 1) This is a pointer of an LLVM IR element type, passed byval/byref.
   // 2) This is an OpenCL/SPIR-V builtin type if there is spv_assign_type
   //    intrinsic assigning a TargetExtType.
-  // 3) This is a pointer, try to retrieve pointer element type from a
+  // 3) This is an OpenCL/SPIR-V builtin type if the mangled function name
+  //    contains type information (the Arg's function is a builtin, has no
+  //    body).
+  // 4) This is a pointer, try to retrieve pointer element type from a
   // spv_assign_ptr_type intrinsic or otherwise use default pointer element
   // type.
   if (hasPointeeTypeAttr(Arg)) {
@@ -253,6 +256,15 @@ static SPIRVType *getArgSPIRVType(const Function &F, unsigned ArgIdx,
         ElementType, MIRBuilder,
         addressSpaceToStorageClass(
             cast<ConstantInt>(II->getOperand(2))->getZExtValue(), ST));
+  }
+
+  std::string DemangledFuncName =
+      getOclOrSpirvBuiltinDemangledName(F.getName());
+  if (!DemangledFuncName.empty()) {
+    Type *BuiltinType = SPIRV::parseBuiltinCallArgumentBaseType(
+        DemangledFuncName, ArgIdx, F.getContext());
+    if (BuiltinType && BuiltinType->isTargetExtTy())
+      return GR->getOrCreateSPIRVType(BuiltinType, MIRBuilder, ArgAccessQual);
   }
 
   // Replace PointerType with TypedPointerType to be able to map SPIR-V types to

--- a/llvm/lib/Target/SPIRV/SPIRVPreLegalizer.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVPreLegalizer.cpp
@@ -81,13 +81,14 @@ addConstantsToTrack(MachineFunction &MF, SPIRVGlobalRegistry *GR,
           }
           GR->add(Const, &MF, SrcReg);
           if (Const->getType()->isTargetExtTy()) {
-            // remember association so that we can restore it when assign types
+            // Remember association so that we can restore it when assign types.
             MachineInstr *SrcMI = MRI.getVRegDef(SrcReg);
             if (SrcMI && (SrcMI->getOpcode() == TargetOpcode::G_CONSTANT ||
                           SrcMI->getOpcode() == TargetOpcode::G_IMPLICIT_DEF))
               TargetExtConstTypes[SrcMI] = Const->getType();
             if (Const->isNullValue()) {
               MachineIRBuilder MIB(MF);
+              MIB.setInsertPt(*MI.getParent(), MI);
               SPIRVType *ExtType =
                   GR->getOrCreateSPIRVType(Const->getType(), MIB);
               SrcMI->setDesc(STI.getInstrInfo()->get(SPIRV::OpConstantNull));

--- a/llvm/lib/Target/SPIRV/SPIRVUtils.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVUtils.cpp
@@ -332,7 +332,7 @@ static bool isNonMangledOCLBuiltin(StringRef Name) {
          Name == "__translate_sampler_initializer";
 }
 
-std::string getOclOrSpirvBuiltinDemangledName(StringRef Name) {
+std::string demangleBuiltinCall(StringRef Name) {
   bool IsNonMangledOCL = isNonMangledOCLBuiltin(Name);
   bool IsNonMangledSPIRV = Name.starts_with("__spirv_");
   bool IsNonMangledHLSL = Name.starts_with("__hlsl_");

--- a/llvm/lib/Target/SPIRV/SPIRVUtils.h
+++ b/llvm/lib/Target/SPIRV/SPIRVUtils.h
@@ -90,9 +90,9 @@ bool isSpvIntrinsic(const MachineInstr &MI, Intrinsic::ID IntrinsicID);
 // Get type of i-th operand of the metadata node.
 Type *getMDOperandAsType(const MDNode *N, unsigned I);
 
-// If OpenCL or SPIR-V builtin function name is recognized, return a demangled
-// name, otherwise return an empty string.
-std::string getOclOrSpirvBuiltinDemangledName(StringRef Name);
+// If SPIR-V builtin function name is recognized, return a demangled name,
+// otherwise return an empty string.
+std::string demangleBuiltinCall(StringRef Name);
 
 // Check if a string contains a builtin prefix.
 bool hasBuiltinTypePrefix(StringRef Name);

--- a/llvm/test/CodeGen/SPIRV/pointers/builtin-call-multiple-ptr-null-args-one-of-builtin-type.ll
+++ b/llvm/test/CodeGen/SPIRV/pointers/builtin-call-multiple-ptr-null-args-one-of-builtin-type.ll
@@ -1,0 +1,13 @@
+; RUN: llc -O0 -mtriple=spirv64-unknown-unknown %s -o - | FileCheck %s
+; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv64-unknown-unknown %s -o - -filetype=obj | spirv-val %}
+
+; CHECK-DAG: %[[#EVENT:]] = OpTypeEvent
+; CHECK-DAG: %[[#EVENT_NULL:]] = OpConstantNull %[[#EVENT]]
+; CHECK-DAG: %[[#]] = OpFunctionCall %[[#]] %[[#]] %[[#]] %[[#]] %[[#]] %[[#]] %[[#EVENT_NULL]]
+
+define spir_kernel void @foo() {
+  %call = call spir_func ptr @_Z29async_work_group_strided_copyPU3AS3hPU3AS1Khmm9ocl_event(ptr null, ptr null, i64 1, i64 1, ptr null)
+  ret void
+}
+
+declare spir_func ptr @_Z29async_work_group_strided_copyPU3AS3hPU3AS1Khmm9ocl_event(ptr, ptr, i64, i64, ptr)

--- a/llvm/test/CodeGen/SPIRV/pointers/builtin-call-ptr-null-arg-of-builtin-type.ll
+++ b/llvm/test/CodeGen/SPIRV/pointers/builtin-call-ptr-null-arg-of-builtin-type.ll
@@ -1,0 +1,13 @@
+; RUN: llc -O0 -mtriple=spirv64-unknown-unknown %s -o - | FileCheck %s
+; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv64-unknown-unknown %s -o - -filetype=obj | spirv-val %}
+
+; CHECK-DAG: %[[#EVENT:]] = OpTypeEvent
+; CHECK-DAG: %[[#EVENT_NULL:]] = OpConstantNull %[[#EVENT]]
+; CHECK-DAG: %[[#]] = OpFunctionCall %[[#]] %[[#]] %[[#]] %[[#]] %[[#]] %[[#]] %[[#EVENT_NULL]]
+
+define spir_kernel void @foo(ptr %a, ptr %b) {
+  %call = call spir_func ptr @_Z29async_work_group_strided_copyPU3AS3hPU3AS1Khmm9ocl_event(ptr %a, ptr %b, i64 1, i64 1, ptr null)
+  ret void
+}
+
+declare spir_func ptr @_Z29async_work_group_strided_copyPU3AS3hPU3AS1Khmm9ocl_event(ptr, ptr, i64, i64, ptr)

--- a/llvm/test/CodeGen/SPIRV/pointers/builtin-function-ptr-arg-of-builtin-type.ll
+++ b/llvm/test/CodeGen/SPIRV/pointers/builtin-function-ptr-arg-of-builtin-type.ll
@@ -1,0 +1,15 @@
+; RUN: llc -O0 -mtriple=spirv64-unknown-unknown %s -o - | FileCheck %s
+; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv64-unknown-unknown %s -o - -filetype=obj | spirv-val %}
+
+; CHECK-DAG: %[[#INT8:]] = OpTypeInt 8 0
+; CHECK-DAG: %[[#PTR_INT8:]] = OpTypePointer Function %[[#INT8]]
+; CHECK-DAG: %[[#EVENT:]] = OpTypeEvent
+; CHECK-DAG: %[[#FUNC_TY:]] = OpTypeFunction %[[#]] %[[#PTR_INT8]] %[[#PTR_INT8]] %[[#]] %[[#]] %[[#EVENT]]
+; CHECK-DAG: %[[#]] = OpFunction %[[#]] None %[[#FUNC_TY]]
+
+define spir_kernel void @foo(ptr %a, ptr %b) {
+  %call = call spir_func ptr @_Z29async_work_group_strided_copyPU3AS3hPU3AS1Khmm9ocl_event(ptr %a, ptr %b, i64 1, i64 1, ptr null)
+  ret void
+}
+
+declare spir_func ptr @_Z29async_work_group_strided_copyPU3AS3hPU3AS1Khmm9ocl_event(ptr, ptr, i64, i64, ptr)


### PR DESCRIPTION
This change makes sure that ptr null (constant) arguments of builtin
function calls are assigned proper builtin types if such are deduced
from mangled names.

Two tests demonstrating the expected bahavior (as in the SPIR-V
Translator) are added.

WIP:
- The test builtin-call-multiple-ptr-null-args-one-of-builtin-
type.ll is failing and requires additional work.

- processInstrAfterVisit method must be simplified. TrackConstants can
  be removed.