### PR TITLE
[LV] Fix for `VPValue` dump method

### DIFF
--- a/llvm/lib/Transforms/Vectorize/VPlan.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlan.cpp
@@ -58,9 +58,9 @@ extern cl::opt<bool> EnableVPlanNativePath;
 
 #if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 raw_ostream &llvm::operator<<(raw_ostream &OS, const VPValue &V) {
-  const VPInstruction *Instr = dyn_cast<VPInstruction>(&V);
-  VPSlotTracker SlotTracker(
-      (Instr && Instr->getParent()) ? Instr->getParent()->getPlan() : nullptr);
+  const VPRecipeBase *R = V.getDefiningRecipe();
+  VPSlotTracker SlotTracker((R && R->getParent()) ? R->getParent()->getPlan()
+                                                  : nullptr);
   V.print(OS, SlotTracker);
   return OS;
 }
@@ -1381,7 +1381,7 @@ void VPSlotTracker::assignNames(const VPlan &Plan) {
   if (Plan.VFxUF.getNumUsers() > 0)
     assignName(&Plan.VFxUF);
   assignName(&Plan.VectorTripCount);
-  if (Plan.BackedgeTakenCount)
+  if (Plan.BackedgeTakenCount && Plan.BackedgeTakenCount->getNumUsers() > 0)
     assignName(Plan.BackedgeTakenCount);
   for (VPValue *LI : Plan.VPLiveInsToFree)
     assignName(LI);


### PR DESCRIPTION
The logic of getting `VPlan` from a `VPValue` should be in-sync with `VPSlotTracker::getOrCreateName`'s logic