### PR TITLE
[libc++] Adjust XFAIL for quick_exit

### DIFF
--- a/libcxx/test/std/language.support/support.start.term/quick_exit.pass.cpp
+++ b/libcxx/test/std/language.support/support.start.term/quick_exit.pass.cpp
@@ -11,8 +11,8 @@
 // ::quick_exit and ::at_quick_exit were not implemented in older versions of macOS
 // TODO: We should never be using `darwin` as the triple, but LLVM's config.guess script
 //       guesses the host triple to be darwin instead of macosx when on macOS.
-// XFAIL: target={{.+}}-apple-macos10.{{13|14|15}}
-// XFAIL: target={{.+}}-apple-macos{{11|12|13|14}}{{(.+)?}}
+// XFAIL: target={{.+}}-apple-macosx10.{{13|14|15}}
+// XFAIL: target={{.+}}-apple-macosx{{11|12|13|14}}{{(.+)?}}
 // XFAIL: target={{.+}}-apple-darwin{{17|18|19|20|21|22|23}}{{(.+)?}}
 
 // test quick_exit and at_quick_exit

--- a/libcxx/test/std/language.support/support.start.term/quick_exit.pass.cpp
+++ b/libcxx/test/std/language.support/support.start.term/quick_exit.pass.cpp
@@ -8,11 +8,12 @@
 
 // UNSUPPORTED: c++03
 
-// ::quick_exit and ::at_quick_exit are not implemented on macOS.
+// ::quick_exit and ::at_quick_exit were not implemented in older versions of macOS
 // TODO: We should never be using `darwin` as the triple, but LLVM's config.guess script
 //       guesses the host triple to be darwin instead of macosx when on macOS.
-// XFAIL: target={{.+}}-apple-macos{{.*}}
-// XFAIL: target={{.+}}-apple-darwin{{.+}}
+// XFAIL: target={{.+}}-apple-macos10.{{13|14|15}}
+// XFAIL: target={{.+}}-apple-macos{{11|12|13|14}}{{(.+)?}}
+// XFAIL: target={{.+}}-apple-darwin{{17|18|19|20|21|22|23}}{{(.+)?}}
 
 // test quick_exit and at_quick_exit
 


### PR DESCRIPTION
This avoids making the assumption that quick_exit will never be implemented on macOS.