### PR TITLE
[clang CodeGen] Restrict return statements nested in return statements.

### DIFF
--- a/clang/test/CodeGenCXX/nested-return.cpp
+++ b/clang/test/CodeGenCXX/nested-return.cpp
@@ -1,0 +1,22 @@
+// RUN: %clang_cc1 -triple x86_64-linux -verify -emit-llvm-only %s
+
+// Reject this function; there's no way to correctly destroy the temporary
+struct S { S(); ~S(); };
+struct S2 { S s1, s2; };
+S2 f() {
+    return {S(), ({
+        while (true) {
+            return {S(), ({break; S();})}; // expected-error {{cannot compile this nested return statement yet}}
+        }
+        S();})};
+}
+
+// This variant doesn't have any temporaries, so it's allowed.
+struct Simple { int s1, s2; };
+Simple f2() {
+    return {1, ({
+        while (true) {
+            return {2, ({break; 3;})};
+        }
+        3;})};
+}


### PR DESCRIPTION
The construct has unclear semantics in general, and it's not really interesting to try to support. So diagnose it.

Some subset of the cases this rejects might be possible to handle, if this shows up in practice.  But I don't think it's worth the effort without a specific use-case.

Fixes #91761