### PR TITLE
[ADT] Make hexdigit static

### DIFF
--- a/llvm/include/llvm/ADT/StringExtras.h
+++ b/llvm/include/llvm/ADT/StringExtras.h
@@ -34,7 +34,7 @@ class raw_ostream;
 
 /// hexdigit - Return the hexadecimal character for the
 /// given number \p X (which should be less than 16).
-inline char hexdigit(unsigned X, bool LowerCase = false) {
+static inline char hexdigit(unsigned X, bool LowerCase = false) {
   assert(X < 16);
   static const char LUT[] = "0123456789ABCDEF";
   const uint8_t Offset = LowerCase ? 32 : 0;


### PR DESCRIPTION
By setting hexdigit to static, we avoid inadvertently exposing the symbol when creating an LLVM-based static library.

Without setting it to static, we see the following symbol when calling objdump -t -C on a static library calling LLVM APIs:

.rodata._ZZN4llvm8hexdigitEjbE3LU