### PR TITLE
[CodeExtractor] Fix indexing of aggregated arguments

### DIFF
--- a/llvm/lib/Transforms/Utils/CodeExtractor.cpp
+++ b/llvm/lib/Transforms/Utils/CodeExtractor.cpp
@@ -1173,8 +1173,8 @@ CallInst *CodeExtractor::emitCallAndSwitchStatement(Function *newFunction,
       params.push_back(input);
       if (input->isSwiftError())
         SwiftErrorArgs.push_back(ScalarInputArgNo);
+      ++ScalarInputArgNo;
     }
-    ++ScalarInputArgNo;
   }
 
   // Create allocas for the outputs

--- a/llvm/unittests/Transforms/Utils/CodeExtractorTest.cpp
+++ b/llvm/unittests/Transforms/Utils/CodeExtractorTest.cpp
@@ -7,8 +7,8 @@
 //===----------------------------------------------------------------------===//
 
 #include "llvm/Transforms/Utils/CodeExtractor.h"
-#include "llvm/AsmParser/Parser.h"
 #include "llvm/Analysis/AssumptionCache.h"
+#include "llvm/AsmParser/Parser.h"
 #include "llvm/IR/BasicBlock.h"
 #include "llvm/IR/Constants.h"
 #include "llvm/IR/Dominators.h"
@@ -56,9 +56,9 @@ TEST(CodeExtractor, ExitStub) {
                                                 Err, Ctx));
 
   Function *Func = M->getFunction("foo");
-  SmallVector<BasicBlock *, 3> Candidates{ getBlockByName(Func, "header"),
-                                           getBlockByName(Func, "body1"),
-                                           getBlockByName(Func, "body2") };
+  SmallVector<BasicBlock *, 3> Candidates{getBlockByName(Func, "header"),
+                                          getBlockByName(Func, "body1"),
+                                          getBlockByName(Func, "body2")};
 
   CodeExtractor CE(Candidates);
   EXPECT_TRUE(CE.isEligible());
@@ -173,8 +173,8 @@ TEST(CodeExtractor, AggInputOutputMonitoring) {
   SetVector<Value *> Inputs, Outputs;
   Function *Outlined = CE.extractCodeRegion(CEAC, Inputs, Outputs);
   EXPECT_TRUE(Outlined);
-  //Ensure that the outlined function has a single argument with
-  //the input and output values in an aggregated structure.
+  // Ensure that the outlined function has a single argument with
+  // the input and output values in an aggregated structure.
   EXPECT_EQ(Outlined->arg_size(), 1u);
 
   EXPECT_EQ(Inputs.size(), 3u);
@@ -183,12 +183,13 @@ TEST(CodeExtractor, AggInputOutputMonitoring) {
   EXPECT_EQ(Inputs[2], Func->getArg(1));
 
   EXPECT_EQ(Outputs.size(), 1u);
-  //The output value must be stored in the appropriate element inside the
-  //aggregated structure.
-  GetElementPtrInst *GEP = cast<GetElementPtrInst>(Outlined->getArg(0)->user_back());
+  // The output value must be stored in the appropriate element inside the
+  // aggregated structure.
+  GetElementPtrInst *GEP =
+      cast<GetElementPtrInst>(Outlined->getArg(0)->user_back());
   APInt Offset(M->getDataLayout().getMaxIndexSizeInBits(), 0);
   EXPECT_TRUE(GEP->accumulateConstantOffset(M->getDataLayout(), Offset));
-  EXPECT_EQ(Offset, 3u*4u); //Fourth i32 element, with 4-bytes each.
+  EXPECT_EQ(Offset, 3u * 4u); // Fourth i32 element, with 4-bytes each.
   StoreInst *SI = cast<StoreInst>(GEP->user_back());
   Value *OutputVal = SI->getValueOperand();
   EXPECT_EQ(Outputs[0], OutputVal);
@@ -232,9 +233,9 @@ TEST(CodeExtractor, ExitBlockOrderingPhis) {
   )invalid",
                                                 Err, Ctx));
   Function *Func = M->getFunction("foo");
-  SmallVector<BasicBlock *, 3> Candidates{ getBlockByName(Func, "test0"),
-                                           getBlockByName(Func, "test1"),
-                                           getBlockByName(Func, "test") };
+  SmallVector<BasicBlock *, 3> Candidates{getBlockByName(Func, "test0"),
+                                          getBlockByName(Func, "test1"),
+                                          getBlockByName(Func, "test")};
 
   CodeExtractor CE(Candidates);
   EXPECT_TRUE(CE.isEligible());
@@ -289,9 +290,9 @@ TEST(CodeExtractor, ExitBlockOrdering) {
   )invalid",
                                                 Err, Ctx));
   Function *Func = M->getFunction("foo");
-  SmallVector<BasicBlock *, 3> Candidates{ getBlockByName(Func, "test0"),
-                                           getBlockByName(Func, "test1"),
-                                           getBlockByName(Func, "test") };
+  SmallVector<BasicBlock *, 3> Candidates{getBlockByName(Func, "test0"),
+                                          getBlockByName(Func, "test1"),
+                                          getBlockByName(Func, "test")};
 
   CodeExtractor CE(Candidates);
   EXPECT_TRUE(CE.isEligible());
@@ -344,13 +345,12 @@ TEST(CodeExtractor, ExitPHIOnePredFromRegion) {
       %1 = phi i32 [ 3, %extracted2 ], [ 4, %pred ]
       ret i32 %1
     }
-  )invalid", Err, Ctx));
+  )invalid",
+                                                Err, Ctx));
 
   Function *Func = M->getFunction("foo");
   SmallVector<BasicBlock *, 2> ExtractedBlocks{
-    getBlockByName(Func, "extracted1"),
-    getBlockByName(Func, "extracted2")
-  };
+      getBlockByName(Func, "extracted1"), getBlockByName(Func, "extracted2")};
 
   CodeExtractor CE(ExtractedBlocks);
   EXPECT_TRUE(CE.isEligible());
@@ -363,9 +363,9 @@ TEST(CodeExtractor, ExitPHIOnePredFromRegion) {
   // Ensure that PHIs in exits are not splitted (since that they have only one
   // incoming value from extracted region).
   EXPECT_TRUE(Exit1 &&
-          cast<PHINode>(Exit1->front()).getNumIncomingValues() == 2);
+              cast<PHINode>(Exit1->front()).getNumIncomingValues() == 2);
   EXPECT_TRUE(Exit2 &&
-          cast<PHINode>(Exit2->front()).getNumIncomingValues() == 2);
+              cast<PHINode>(Exit2->front()).getNumIncomingValues() == 2);
   EXPECT_FALSE(verifyFunction(*Outlined));
   EXPECT_FALSE(verifyFunction(*Func));
 }
@@ -410,9 +410,10 @@ TEST(CodeExtractor, StoreOutputInvokeResultAfterEHPad) {
         %ex.2 = phi i8* [ %ex.1, %lpad2 ], [ null, %lpad ]
         unreachable
     }
-  )invalid", Err, Ctx));
+  )invalid",
+                                                Err, Ctx));
 
-	if (!M) {
+  if (!M) {
     Err.print("unit", errs());
     exit(1);
   }
@@ -421,11 +422,8 @@ TEST(CodeExtractor, StoreOutputInvokeResultAfterEHPad) {
   EXPECT_FALSE(verifyFunction(*Func, &errs()));
 
   SmallVector<BasicBlock *, 2> ExtractedBlocks{
-    getBlockByName(Func, "catch"),
-    getBlockByName(Func, "invoke.cont2"),
-    getBlockByName(Func, "invoke.cont3"),
-    getBlockByName(Func, "lpad2")
-  };
+      getBlockByName(Func, "catch"), getBlockByName(Func, "invoke.cont2"),
+      getBlockByName(Func, "invoke.cont3"), getBlockByName(Func, "lpad2")};
 
   CodeExtractor CE(ExtractedBlocks);
   EXPECT_TRUE(CE.isEligible());
@@ -459,8 +457,8 @@ TEST(CodeExtractor, StoreOutputInvokeResultInExitStub) {
                                                 Err, Ctx));
 
   Function *Func = M->getFunction("foo");
-  SmallVector<BasicBlock *, 1> Blocks{ getBlockByName(Func, "entry"),
-                                       getBlockByName(Func, "lpad") };
+  SmallVector<BasicBlock *, 1> Blocks{getBlockByName(Func, "entry"),
+                                      getBlockByName(Func, "lpad")};
 
   CodeExtractor CE(Blocks);
   EXPECT_TRUE(CE.isEligible());
@@ -512,7 +510,7 @@ TEST(CodeExtractor, ExtractAndInvalidateAssumptionCache) {
 
   assert(M && "Could not parse module?");
   Function *Func = M->getFunction("test");
-  SmallVector<BasicBlock *, 1> Blocks{ getBlockByName(Func, "if.else") };
+  SmallVector<BasicBlock *, 1> Blocks{getBlockByName(Func, "if.else")};
   AssumptionCache AC(*Func);
   CodeExtractor CE(Blocks, nullptr, false, nullptr, nullptr, &AC);
   EXPECT_TRUE(CE.isEligible());


### PR DESCRIPTION
The LLVM CodeExtractor utility class is used for extracting a list of basic blocks into a separate function (outlining). The input and output arguments can be passed to the extracted function either as a list of separate arguments or aggregated together into a single argument. It seems that the aggregated arguments is currently not widely used by the LLVM passes, neither are they thoroughly tested. I have encountered a bug in the CodeExtractor for when using aggregated arguments to extract a function that requires to update output values. The code was counting aggregated input arguments as both aggregated and scalar (individual) arguments, causing an out of bounds issue when trying to use the number of scalar input arguments as an offset to access the output arguments. It always needs to count both scalar and aggregated arguments, as an extracted functions can also have mixed arguments. However, when forcing all arguments to be passed as an aggregated structure, both the ScalarInputArgNo and the NumAggregatedInputs had the same numbers in the CodeExtractor::emitCallAndSwitchStatement, even though ScalarInputArgNo should be zero.

The new unit test AggInputOutputMonitoring exercises this issue. This unit test uses the same example as the InputOutputMonitoring one, but it forces the CodeExtractor to use aggregated arguments. This new unit test, AggInputOutputMonitoring, then ensures that the outlined function has a single aggregated argument and that the update of the output value is performed correctly.

This bug fix ensures that the new unit test works correctly while preserving the correctness of all other tests.