### PR TITLE
[bazel] Reduce output on CI

### DIFF
--- a/utils/bazel/.bazelrc
+++ b/utils/bazel/.bazelrc
@@ -201,6 +201,9 @@ build:ci --keep_going
 # Show test errors.
 build:ci --test_output=errors
 
+# Only show failing tests to reduce output
+build:ci --test_summary=terse
+
 ###############################################################################
 
 # The user.bazelrc file is not checked in but available for local mods.


### PR DESCRIPTION
This makes bazel only show the output for tests that don't pass. This
should reduce a ton of info in the log to make it easier to find
failures. The log is so long now that you can no longer view the whole
thing in 1 buildkite job.
