### PR TITLE
[libc][test] Fix TEST->TEST_F typo in getenv_and_setenv_test.cpp

### DIFF
--- a/libc/test/src/fenv/getenv_and_setenv_test.cpp
+++ b/libc/test/src/fenv/getenv_and_setenv_test.cpp
@@ -41,7 +41,7 @@ TEST_F(LlvmLibcFEnvTest, GetEnvAndSetEnv) {
   }
 }
 
-TEST(LlvmLibcFenvTest, Set_FE_DFL_ENV) {
+TEST_F(LlvmLibcFEnvTest, Set_FE_DFL_ENV) {
   // We will disable all exceptions to prevent invocation of the exception
   // handler.
   LIBC_NAMESPACE::fputil::disable_except(FE_ALL_EXCEPT);


### PR DESCRIPTION
This manifests as `AddressSanitizer: stack-use-after-return` w/o this change. The `~CheckFEnv()` method of checking fenv seems to only work for test fixtures.