### PR TITLE
[asan] Make frame number checks more flexable

### DIFF
--- a/compiler-rt/test/asan/TestCases/Linux/stack-trace-dlclose.cpp
+++ b/compiler-rt/test/asan/TestCases/Linux/stack-trace-dlclose.cpp
@@ -41,6 +41,6 @@ int main(int argc, char **argv) {
 }
 #endif
 
-// CHECK: {{    #0 0x.* in (__interceptor_)?malloc}}
-// CHECK: {{    #1 0x.* \(<unknown module>\)}}
-// CHECK: {{    #2 0x.* in main}}
+// CHECK: {{    #[0-9]+ 0x.* in (__interceptor_)?malloc}}
+// CHECK: {{    #[0-9]+ 0x.* \(<unknown module>\)}}
+// CHECK: {{    #[0-9]+ 0x.* in main}}

--- a/compiler-rt/test/asan/TestCases/Posix/strndup_oob_test.cpp
+++ b/compiler-rt/test/asan/TestCases/Posix/strndup_oob_test.cpp
@@ -17,9 +17,9 @@ int main(int argc, char **argv) {
   char *copy = strndup(kString, 2);
   int x = copy[2 + argc];  // BOOM
   // CHECK: AddressSanitizer: heap-buffer-overflow
-  // CHECK: #0 {{.*}}main {{.*}}strndup_oob_test.cpp:[[@LINE-2]]
+  // CHECK: #{{[0-9]+}} {{.*}}main {{.*}}strndup_oob_test.cpp:[[@LINE-2]]
   // CHECK-LABEL: allocated by thread T{{.*}} here:
-  // CHECK: #{{[01]}} {{.*}}strndup
+  // CHECK: #{{[0-9]+}} {{.*}}strndup
   // CHECK: #{{.*}}main {{.*}}strndup_oob_test.cpp:[[@LINE-6]]
   // CHECK-LABEL: SUMMARY
   // CHECK: strndup_oob_test.cpp:[[@LINE-7]]

--- a/compiler-rt/test/asan/TestCases/calloc-overflow.cpp
+++ b/compiler-rt/test/asan/TestCases/calloc-overflow.cpp
@@ -10,8 +10,8 @@
 int main() {
   void *p = calloc(-1, 1000);
   // CHECK: {{ERROR: AddressSanitizer: calloc parameters overflow: count \* size \(.* \* 1000\) cannot be represented in type size_t}}
-  // CHECK: {{#0 0x.* in .*calloc}}
-  // CHECK: {{#[1-3] 0x.* in main .*calloc-overflow.cpp:}}[[@LINE-3]]
+  // CHECK: {{#[0-9]+ 0x.* in calloc .*.cpp}}
+  // CHECK: {{#[0-9]+ 0x.* in main .*calloc-overflow.cpp:}}[[@LINE-3]]
   // CHECK: SUMMARY: AddressSanitizer: calloc-overflow
 
   printf("calloc returned: %zu\n", (size_t)p);

--- a/compiler-rt/test/asan/TestCases/debug_stacks.cpp
+++ b/compiler-rt/test/asan/TestCases/debug_stacks.cpp
@@ -64,11 +64,11 @@ int main() {
   // CHECK: ERROR: AddressSanitizer: heap-use-after-free
   // CHECK: WRITE of size 1 at 0x{{.*}}
   // CHECK: freed by thread T0 here:
-  // CHECK: #0 [[FREE_FRAME_0]]
-  // CHECK: #1 [[FREE_FRAME_1]]
+  // CHECK: #{{[0-9]+}} [[FREE_FRAME_0]]
+  // CHECK: #{{[0-9]+}} [[FREE_FRAME_1]]
   // CHECK: previously allocated by thread T0 here:
-  // CHECK: #0 [[ALLOC_FRAME_0]]
-  // CHECK: #1 [[ALLOC_FRAME_1]]
+  // CHECK: #{{[0-9+]}} [[ALLOC_FRAME_0]]
+  // CHECK: #{{[0-9+]}} [[ALLOC_FRAME_1]]
 
   return 0;
 }

--- a/compiler-rt/test/asan/TestCases/double-free.cpp
+++ b/compiler-rt/test/asan/TestCases/double-free.cpp
@@ -18,11 +18,11 @@ int main(int argc, char **argv) {
   free(x);
   free(x + argc - 1);  // BOOM
   // CHECK: AddressSanitizer: attempting double-free{{.*}}in thread T0
-  // CHECK: #0 0x{{.*}} in {{.*}}free
-  // CHECK: #{{[1-3]}} 0x{{.*}} in main {{.*}}double-free.cpp:[[@LINE-3]]
+  // CHECK: #{{[0-9]+}} 0x{{.*}} in {{.*}}free
+  // CHECK: #{{[0-9]+}} 0x{{.*}} in main {{.*}}double-free.cpp:[[@LINE-3]]
   // CHECK: freed by thread T0 here:
   // MALLOC-CTX: #0 0x{{.*}} in {{.*}}free
-  // MALLOC-CTX: #{{[1-3]}} 0x{{.*}} in main {{.*}}double-free.cpp:[[@LINE-7]]
+  // MALLOC-CTX: #{{[0-9]+}} 0x{{.*}} in main {{.*}}double-free.cpp:[[@LINE-7]]
   // CHECK: allocated by thread T0 here:
   // MALLOC-CTX: double-free.cpp:[[@LINE-12]]
   // CHECK-RECOVER: AddressSanitizer: attempting double-free{{.*}}in thread T0

--- a/compiler-rt/test/asan/TestCases/malloc-size-too-big.cpp
+++ b/compiler-rt/test/asan/TestCases/malloc-size-too-big.cpp
@@ -17,8 +17,8 @@ static const size_t kMaxAllowedMallocSizePlusOne =
 int main() {
   void *p = malloc(kMaxAllowedMallocSizePlusOne);
   // CHECK: {{ERROR: AddressSanitizer: requested allocation size .* \(.* after adjustments for alignment, red zones etc\.\) exceeds maximum supported size}}
-  // CHECK: {{#0 0x.* in .*malloc}}
-  // CHECK: {{#[1-3] 0x.* in main .*malloc-size-too-big.cpp:}}[[@LINE-3]]
+  // CHECK: {{#[0-9] 0x.* in .*malloc}}
+  // CHECK: {{#[0-9] 0x.* in main .*malloc-size-too-big.cpp:}}[[@LINE-3]]
   // CHECK: SUMMARY: AddressSanitizer: allocation-size-too-big
 
   printf("malloc returned: %zu\n", (size_t)p);

--- a/compiler-rt/test/asan/TestCases/strcpy-overlap.cpp
+++ b/compiler-rt/test/asan/TestCases/strcpy-overlap.cpp
@@ -36,9 +36,9 @@ __attribute__((noinline)) void bad_function() {
   char buffer[] = "hello";
   // CHECK: strcpy-param-overlap: memory ranges
   // CHECK: [{{0x.*,[ ]*0x.*}}) and [{{0x.*,[ ]*0x.*}}) overlap
-  // CHECK: {{#0 0x.* in .*strcpy}}
-  // CHECK: {{#1 0x.* in bad_function.*strcpy-overlap.cpp:}}[[@LINE+2]]
-  // CHECK: {{#2 0x.* in main .*strcpy-overlap.cpp:}}[[@LINE+5]]
+  // CHECK: {{#[0-9]+ 0x.* in .*strcpy .*.cpp}}
+  // CHECK: {{#[0-9]+ 0x.* in bad_function.*strcpy-overlap.cpp:}}[[@LINE+2]]
+  // CHECK: {{#[0-9]+ 0x.* in main .*strcpy-overlap.cpp:}}[[@LINE+5]]
   strcpy(buffer, buffer + 1); // BOOM
 }
 

--- a/compiler-rt/test/asan/TestCases/strdup_oob_test.cpp
+++ b/compiler-rt/test/asan/TestCases/strdup_oob_test.cpp
@@ -23,7 +23,7 @@ int main(int argc, char **argv) {
   // CHECK: AddressSanitizer: heap-buffer-overflow
   // CHECK: #0 {{.*}}main {{.*}}strdup_oob_test.cpp:[[@LINE-2]]
   // CHECK-LABEL: allocated by thread T{{.*}} here:
-  // CHECK: #{{[01]}} {{.*}}strdup
+  // CHECK: #{{[0-9]}}+ {{.*}}strdup
   // CHECK: #{{.*}}main {{.*}}strdup_oob_test.cpp:[[@LINE-6]]
   // CHECK-LABEL: SUMMARY
   // CHECK: strdup_oob_test.cpp:[[@LINE-7]]

--- a/compiler-rt/test/asan/TestCases/strncpy-overflow.cpp
+++ b/compiler-rt/test/asan/TestCases/strncpy-overflow.cpp
@@ -28,11 +28,11 @@ int main(int argc, char **argv) {
   char *short_buffer = (char*)malloc(9);
   strncpy(short_buffer, hello, 10);  // BOOM
   // CHECK: {{WRITE of size 10 at 0x.* thread T0}}
-  // CHECK: {{    #0 0x.* in .*strncpy}}
-  // CHECK: {{    #1 0x.* in main .*strncpy-overflow.cpp:}}[[@LINE-3]]
+  // CHECK: {{    #[0-9]+ 0x.* in .*strncpy .*.cpp}}
+  // CHECK: {{    #[0-9]+ 0x.* in main .*strncpy-overflow.cpp:}}[[@LINE-3]]
   // CHECK: {{0x.* is located 0 bytes after 9-byte region}}
   // CHECK: {{allocated by thread T0 here:}}
-  // CHECK: {{    #0 0x.* in .*malloc}}
-  // CHECK: {{    #[1-3] 0x.* in main .*strncpy-overflow.cpp:}}[[@LINE-8]]
+  // CHECK: {{    #[0-9]+ 0x.* in .*malloc}}
+  // CHECK: {{    #[0-9]+ 0x.* in main .*strncpy-overflow.cpp:}}[[@LINE-8]]
   return rval + sink_memory(9, short_buffer);
 }

--- a/compiler-rt/test/asan/TestCases/use-after-free-right.cpp
+++ b/compiler-rt/test/asan/TestCases/use-after-free-right.cpp
@@ -15,13 +15,13 @@ int main() {
   // CHECK: {{.*ERROR: AddressSanitizer: heap-use-after-free on address}}
   // CHECK:   {{0x.* at pc 0x.* bp 0x.* sp 0x.*}}
   // CHECK: {{WRITE of size 1 at 0x.* thread T0}}
-  // CHECK: {{    #0 0x.* in main .*use-after-free-right.cpp:}}[[@LINE-4]]
+  // CHECK: {{    #[0-9]+ 0x.* in main .*use-after-free-right.cpp:}}[[@LINE-4]]
   // CHECK: {{0x.* is located 0 bytes inside of 1-byte region .0x.*,0x.*}}
   // CHECK: {{freed by thread T0 here:}}
-  // CHECK: {{    #0 0x.* in .*free}}
-  // CHECK: {{    #[1-3] 0x.* in main .*use-after-free-right.cpp:}}[[@LINE-9]]
+  // CHECK: {{    #[0-9]+ 0x.* in .*free .*.cpp}}
+  // CHECK: {{    #[0-9]+ 0x.* in main .*use-after-free-right.cpp:}}[[@LINE-9]]
 
   // CHECK: {{previously allocated by thread T0 here:}}
-  // CHECK: {{    #0 0x.* in .*malloc}}
-  // CHECK: {{    #[1-3] 0x.* in main .*use-after-free-right.cpp:}}[[@LINE-14]]
+  // CHECK: {{    #[0-9]+ 0x.* in .*malloc}}
+  // CHECK: {{    #[0-9]+ 0x.* in main .*use-after-free-right.cpp:}}[[@LINE-14]]
 }

--- a/compiler-rt/test/asan/TestCases/use-after-free.cpp
+++ b/compiler-rt/test/asan/TestCases/use-after-free.cpp
@@ -12,15 +12,15 @@ int main() {
   // CHECK: {{.*ERROR: AddressSanitizer: heap-use-after-free on address}}
   // CHECK:   {{0x.* at pc 0x.* bp 0x.* sp 0x.*}}
   // CHECK: {{READ of size 1 at 0x.* thread T0}}
-  // CHECK: {{    #0 0x.* in main .*use-after-free.cpp:}}[[@LINE-4]]
+  // CHECK: {{    #[0-9]+ 0x.* in main .*use-after-free.cpp:}}[[@LINE-4]]
   // CHECK: {{0x.* is located 5 bytes inside of 10-byte region .0x.*,0x.*}}
   // CHECK: {{freed by thread T0 here:}}
-  // CHECK: {{    #0 0x.* in .*free}}
-  // CHECK: {{    #[1-3] 0x.* in main .*use-after-free.cpp:}}[[@LINE-9]]
+  // CHECK: {{    #[0-9]+ 0x.* in .*free}}
+  // CHECK: {{    #[0-9]+ 0x.* in main .*use-after-free.cpp:}}[[@LINE-9]]
 
   // CHECK: {{previously allocated by thread T0 here:}}
-  // CHECK: {{    #0 0x.* in .*malloc}}
-  // CHECK: {{    #[1-3] 0x.* in main .*use-after-free.cpp:}}[[@LINE-14]]
+  // CHECK: {{    #[0-9]+ 0x.* in .*malloc}}
+  // CHECK: {{    #[0-9]+ 0x.* in main .*use-after-free.cpp:}}[[@LINE-14]]
   // CHECK: Shadow byte legend (one shadow byte represents {{[0-9]+}} application bytes):
   // CHECK: Global redzone:
   // CHECK: ASan internal:


### PR DESCRIPTION
Use more flexable regex ([0-9]+) for frame number checks. Since the frame numbers might change if some functions are not inlined.

Similar to
* https://github.com/llvm/llvm-project/commit/0360f3218a13666123849f6699216bdbebe64833
* https://github.com/llvm/llvm-project/commit/404bc5ca2ae5fffa45d5240dcf52b7f134988867