### PR TITLE
[AArch64] Enable cmp + csel fusion for Neoverse V2

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64Processors.td
+++ b/llvm/lib/Target/AArch64/AArch64Processors.td
@@ -485,6 +485,8 @@ def TuneNeoverseV2 : SubtargetFeature<"neoversev2", "ARMProcFamily", "NeoverseV2
                                       "Neoverse V2 ARM processors", [
                                       FeatureFuseAES,
                                       FeatureFuseAdrpAdd,
+                                      FeatureCmpBccFusion,
+                                      FeatureFuseCCSelect,
                                       FeatureALULSLFast,
                                       FeaturePostRAScheduler,
                                       FeatureEnableSelectOptimize,

--- a/llvm/lib/Target/AArch64/AArch64Processors.td
+++ b/llvm/lib/Target/AArch64/AArch64Processors.td
@@ -485,7 +485,6 @@ def TuneNeoverseV2 : SubtargetFeature<"neoversev2", "ARMProcFamily", "NeoverseV2
                                       "Neoverse V2 ARM processors", [
                                       FeatureFuseAES,
                                       FeatureFuseAdrpAdd,
-                                      FeatureCmpBccFusion,
                                       FeatureFuseCCSelect,
                                       FeatureALULSLFast,
                                       FeaturePostRAScheduler,


### PR DESCRIPTION
According to _4.11 instruction fusion section_ in Neoverse V2 software optimization guide [1], neoverse v2 fuses the following patterns
1. CMP/CMN (immediate) + B.cond
2. CMP/CMN (register) + B.cond
3. CMP + CSEL
4. CMP + CSET

LLVM supports `cmp + csel` at this [place](https://github.com/llvm/llvm-project/blob/3d361b225fe89ce1d8c93639f27d689082bd8dad/llvm/lib/Target/AArch64/AArch64MacroFusion.cpp#L468-L469), so enabled it for neoverse v2.

Pattern 1 is tracked in https://github.com/llvm/llvm-project/pull/90608.


[1] https://developer.arm.com/documentation/pjdoc466751330-593177/latest/
 