### PR TITLE
[lit] Resolve extra_args in ToolSubst

### DIFF
--- a/llvm/utils/lit/lit/llvm/subst.py
+++ b/llvm/utils/lit/lit/llvm/subst.py
@@ -119,7 +119,7 @@ class ToolSubst(object):
 
         if command_str:
             if self.extra_args:
-                command_str = " ".join([command_str] + self.extra_args)
+                command_str = " ".join(str(a) for a in [command_str] + self.extra_args)
         else:
             if self.unresolved == "warn":
                 # Warn, but still provide a substitution.


### PR DESCRIPTION
We are working on lldb shell tests running on a remote target. This patch is necessary for flexible lldb params.