### PR TITLE
[flang] Fix build on Darwin after #92571

### DIFF
--- a/flang/runtime/time-intrinsic.cpp
+++ b/flang/runtime/time-intrinsic.cpp
@@ -400,7 +400,7 @@ void RTNAME(Etime)(const Descriptor *values, const Descriptor *time,
   }
 #else
   struct tms tms;
-  if (times(&tms) != -1) {
+  if (times(&tms) != (clock_t)-1) {
     usrTime = ((double)(tms.tms_utime)) / sysconf(_SC_CLK_TCK);
     sysTime = ((double)(tms.tms_stime)) / sysconf(_SC_CLK_TCK);
     realTime = usrTime + sysTime;


### PR DESCRIPTION
flang/runtime/time-intrinsic.cpp:403:19: error: comparison of
integers of different signs: 'clock_t' (aka 'unsigned long') and
'int' [-Werror,-Wsign-compare]
  if (times(&tms) != -1) {
