### PR TITLE
[flang] Escape '%' in %VAL/%REF messages

### DIFF
--- a/flang/lib/Semantics/check-call.cpp
+++ b/flang/lib/Semantics/check-call.cpp
@@ -961,7 +961,7 @@ static void CheckExplicitDataArg(const characteristics::DummyDataObject &dummy,
   if ((arg.isPercentRef() || arg.isPercentVal()) &&
       dummy.IsPassedByDescriptor(procedure.IsBindC())) {
     messages.Say(
-        "%VAL or %REF are not allowed for %s that must be passed by means of a descriptor"_err_en_US,
+        "%%VAL or %%REF are not allowed for %s that must be passed by means of a descriptor"_err_en_US,
         dummyName);
   }
   if (arg.isPercentVal() &&


### PR DESCRIPTION
flang/test/Semantics/call40.f90 was failing on Darwin:
actual at 27: VAL or REF are not allowed for dummy argument 'a='
  that must be passed by means of a descriptor
expect at 27: %VAL or %REF are not allowed for dummy argument 'a='
  that must be passed by means of a descriptor

When messages.Say() is called with more arguments than just the
fixed text message, the message is treated as a format string,
passed to vsnprintf. Therefore, the '%' chars in it must be
escaped.

Note that no conversion happens when there is only a fixed text
message. Escaping '%' in this case causes "%%" to be outputted.
This can be confusing for someone expecting printf-like behavior.
Processing these text messages with snprintf could solve this,
as a future improvement.
