### PR TITLE
DXIL: Use correct type ID when writing ValueAsMetadata.

### DIFF
--- a/llvm/lib/Target/DirectX/DXILWriter/DXILBitcodeWriter.cpp
+++ b/llvm/lib/Target/DirectX/DXILWriter/DXILBitcodeWriter.cpp
@@ -1345,7 +1345,7 @@ void DXILBitcodeWriter::writeValueAsMetadata(
     Ty = TypedPointerType::get(F->getFunctionType(), F->getAddressSpace());
   else if (GlobalVariable *GV = dyn_cast<GlobalVariable>(V))
     Ty = TypedPointerType::get(GV->getValueType(), GV->getAddressSpace());
-  Record.push_back(getTypeID(Ty));
+  Record.push_back(getTypeID(Ty, V));
   Record.push_back(VE.getValueID(V));
   Stream.EmitRecord(bitc::METADATA_VALUE, Record, 0);
   Record.clear();

--- a/llvm/test/tools/dxil-dis/metadata.ll
+++ b/llvm/test/tools/dxil-dis/metadata.ll
@@ -1,13 +1,21 @@
-; RUN: llc --filetype=obj %s -o - | dxil-dis 
+; RUN: llc --filetype=obj %s -o - | dxil-dis
 target triple = "dxil-unknown-shadermodel6.7-library"
+
+define void @kernel(ptr addrspace(1)) {
+    ret void
+}
 
 !llvm.foo = !{!0}
 !llvm.bar = !{!1}
+!llvm.baz = !{!2}
 
 !0 = !{i32 42}
 !1 = !{!"Some MDString"}
+!2 = !{ptr @kernel}
 
 ; CHECK: !llvm.foo = !{!0}
 ; CHECK: !llvm.bar = !{!1}
+; CHECK: !llvm.baz = !{!2}
 ; CHECK: !0 = !{i32 42}
 ; CHECK: !1 = !{!"Some MDString"}
+; CHECK: !2 = !{void (i8 addrspace(1)*)* @kernel}

--- a/llvm/tools/dxil-dis/CMakeLists.txt
+++ b/llvm/tools/dxil-dis/CMakeLists.txt
@@ -25,7 +25,9 @@ include(ExternalProject)
 
 set(SOURCE_DIR ${CMAKE_CURRENT_BINARY_DIR}/DXC-src)
 set(BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/DXC-bins)
-set(GIT_SETTINGS GIT_REPOSITORY https://github.com/microsoft/DirectXShaderCompiler.git)
+set(GIT_SETTINGS
+    GIT_REPOSITORY https://github.com/microsoft/DirectXShaderCompiler.git
+    GIT_TAG main)
 
 if (DXC_SOURCE_DIR)
   set(SOURCE_DIR ${DXC_SOURCE_DIR})


### PR DESCRIPTION
Small drive-by PR (I'm not working on DXIL, but am working on a similar IR downgrader based on the opaque pointer handling developed for DXIL): It looks like the `ValueAsMetadata` handling currently is broken when writing references to functions. For example:

```llvm
target datalayout = "e-m:e-p:32:32-i1:32-i8:8-i16:16-i32:32-i64:64-f16:16-f32:32-f64:64-n8:16:32:64"
target triple = "dxil-unknown-shadermodel6.7-library"

define void @kernel(ptr addrspace(1)) {
    ret void
}

!kernel = !{!0}
!0 = !{ptr @kernel}
```

Assembling this with `llc` and disassembling the contained IR with `llvm-dis` from LLVM 12 (again, I'm not working on DXIL so I don't have `dxil-dis` handy) breaks:

```
Assertion failed: (V && "Unexpected null Value"), function get, file Metadata.cpp, line 350.
PLEASE submit a bug report to https://bugs.llvm.org/ and include the crash backtrace.
Stack dump:
0.	Program arguments: /Users/tim/Julia/src/llvm-12/build/bin/llvm-dis reduced.dxil -o -
Stack dump without symbol names (ensure you have llvm-symbolizer in your PATH or set the environment var `LLVM_SYMBOLIZER_PATH` to point to it):
0  llvm-dis                 0x0000000102f421bc llvm::sys::PrintStackTrace(llvm::raw_ostream&, int) + 80
1  llvm-dis                 0x0000000102f42720 PrintStackTraceSignalHandler(void*) + 28
2  llvm-dis                 0x0000000102f40890 llvm::sys::RunSignalHandlers() + 140
3  llvm-dis                 0x0000000102f43c14 SignalHandler(int) + 276
4  libsystem_platform.dylib 0x000000018611f584 _sigtramp + 56
5  libsystem_pthread.dylib  0x00000001860eec20 pthread_kill + 288
6  libsystem_c.dylib        0x0000000185ffba30 abort + 180
7  libsystem_c.dylib        0x0000000185ffad20 err + 0
8  llvm-dis                 0x0000000102ce8db4 llvm::ValueAsMetadata::get(llvm::Value*) + 100
9  llvm-dis                 0x00000001029d672c llvm::MetadataLoader::MetadataLoaderImpl::parseOneMetadata(llvm::SmallVectorImpl<unsigned long long>&, unsigned int, (anonymous namespace)::(anonymous namespace)::PlaceholderQueue&, llvm::StringRef, unsigned int&) + 2184
10 llvm-dis                 0x00000001029d5a78 llvm::MetadataLoader::MetadataLoaderImpl::parseMetadata(bool) + 1448
11 llvm-dis                 0x00000001029df7fc llvm::MetadataLoader::parseMetadata(bool) + 60
12 llvm-dis                 0x000000010298634c llvm::MetadataLoader::parseModuleMetadata() + 40
13 llvm-dis                 0x0000000102982f2c (anonymous namespace)::BitcodeReader::parseModule(unsigned long long, bool, llvm::function_ref<llvm::Optional<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > > (llvm::StringRef)>) + 2272
```

IIUC, this is because the value emitted here is of type `typedptr(void (ptr addrspace(1)), 0)`, while the type is simply `void (i8*)*` because it's not looked up in the PointerAnalysisMap. Passing `V` along fixes this.

cc @bogner @llvm-beanz