### PR TITLE
[clang][CodeGen] Fix EmitInvariantStart for non-zero addrspace

### DIFF
--- a/clang/lib/CodeGen/CGDeclCXX.cpp
+++ b/clang/lib/CodeGen/CGDeclCXX.cpp
@@ -162,7 +162,8 @@ void CodeGenFunction::EmitInvariantStart(llvm::Constant *Addr, CharUnits Size) {
   // Grab the llvm.invariant.start intrinsic.
   llvm::Intrinsic::ID InvStartID = llvm::Intrinsic::invariant_start;
   // Overloaded address space type.
-  llvm::Type *ObjectPtr[1] = {Int8PtrTy};
+  assert(Addr->getType()->isPointerTy() && "Address must be a pointer");
+  llvm::Type *ObjectPtr[1] = {Addr->getType()};
   llvm::Function *InvariantStart = CGM.getIntrinsic(InvStartID, ObjectPtr);
 
   // Emit a call with the size in bytes of the object.

--- a/clang/test/CodeGenCXX/init-invariant.cpp
+++ b/clang/test/CodeGenCXX/init-invariant.cpp
@@ -46,6 +46,8 @@ extern const C c = C();
 int f();
 // CHECK: @d ={{.*}} global i32 0
 extern const int d = f();
+// CHECK: @d2 ={{.*}} addrspace(10) global i32 0
+extern const int __attribute__((address_space(10))) d2 = f();
 
 void e() {
   static const A a = A();
@@ -66,6 +68,10 @@ void e() {
 // CHECK: call noundef i32 @_Z1fv(
 // CHECK: store {{.*}}, ptr @d
 // CHECK: call {{.*}}@llvm.invariant.start.p0(i64 4, ptr @d)
+
+// CHECK: call noundef i32 @_Z1fv(
+// CHECK: store {{.*}}, ptr addrspace(10) @d2
+// CHECK: call {{.*}}@llvm.invariant.start.p10(i64 4, ptr addrspace(10) @d2)
 
 // CHECK-LABEL: define{{.*}} void @_Z1ev(
 // CHECK: call void @_ZN1AC1Ev(ptr noundef {{[^,]*}} @_ZZ1evE1a)


### PR DESCRIPTION
The `llvm.invariant.start` intrinsic is already overloaded to work with memory objects in any address space. We simply instantiate the intrinsic with the appropriate pointer type.

Fixes #94345.