### PR TITLE
[clang-tidy] Improve sizeof(pointer) handling in bugprone-sizeof-expression

### DIFF
--- a/clang-tools-extra/clang-tidy/bugprone/SizeofExpressionCheck.cpp
+++ b/clang-tools-extra/clang-tidy/bugprone/SizeofExpressionCheck.cpp
@@ -177,8 +177,7 @@ void SizeofExpressionCheck::registerMatchers(MatchFinder *Finder) {
 
     const auto ZeroLiteral = ignoringParenImpCasts(integerLiteral(equals(0)));
     const auto SubscriptExprWithZeroIndex =
-        arraySubscriptExpr(
-            hasIndex(ZeroLiteral));
+        arraySubscriptExpr(hasIndex(ZeroLiteral));
     const auto DerefExpr =
         ignoringParenImpCasts(unaryOperator(hasOperatorName("*")));
 

--- a/clang-tools-extra/clang-tidy/bugprone/SizeofExpressionCheck.h
+++ b/clang-tools-extra/clang-tidy/bugprone/SizeofExpressionCheck.h
@@ -30,6 +30,7 @@ private:
   const bool WarnOnSizeOfThis;
   const bool WarnOnSizeOfCompareToConstant;
   const bool WarnOnSizeOfPointerToAggregate;
+  const bool WarnOnSizeOfPointer;
 };
 
 } // namespace clang::tidy::bugprone

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -230,7 +230,7 @@ Changes in existing checks
 - Improved :doc:`bugprone-sizeof-expression
   <clang-tidy/checks/bugprone/sizeof-expression>` check by eliminating some
   false positives and adding a new (off-by-default) option
-  ``WarnOnSizeOfPointer`` that reports all ``sizeof(pointer)`` expressions
+  `WarnOnSizeOfPointer` that reports all ``sizeof(pointer)`` expressions
   (except for a few that are idiomatic).
 
 - Improved :doc:`bugprone-suspicious-include

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -227,6 +227,12 @@ Changes in existing checks
   <clang-tidy/checks/bugprone/optional-value-conversion>` check by eliminating
   false positives resulting from use of optionals in unevaluated context.
 
+- Improved :doc:`bugprone-sizeof-expression
+  <clang-tidy/checks/bugprone/sizeof-expression>` check by eliminating some
+  false positives and adding a new (off-by-default) option
+  ``WarnOnSizeOfPointer`` that reports all ``sizeof(pointer)`` expressions
+  (except for a few that are idiomatic).
+
 - Improved :doc:`bugprone-suspicious-include
   <clang-tidy/checks/bugprone/suspicious-include>` check by replacing the local
   options `HeaderFileExtensions` and `ImplementationFileExtensions` by the

--- a/clang-tools-extra/docs/clang-tidy/checks/bugprone/sizeof-expression.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/bugprone/sizeof-expression.rst
@@ -190,11 +190,15 @@ Options
 
 .. option:: WarnOnSizeOfPointerToAggregate
 
-   When `true`, the check will warn on an expression like
-   ``sizeof(expr)`` where the expression is a pointer
-   to aggregate. Default is `true`.
+   When `true`, the check will warn when the argument of ``sizeof`` is either a
+   pointer-to-aggregate type, an expression returning a pointer-to-aggregate
+   value or an expression that returns a pointer from an array-to-pointer
+   conversion (that may be implicit or explicit, for example ``array + 2`` or
+   ``(int *)array``). Default is `true`.
 
 .. option:: WarnOnSizeOfPointer
 
-   When `true`, the check will warn on an expression like ``sizeof(expr)``
-   where the expression is a pointer. Default is `false`.
+   When `true`, the check will report all expressions where the argument of
+   ``sizeof`` is an expression that produces a pointer (except for a few
+   idiomatic expressions that are probably intentional and correct).
+   This detects occurrences of CWE 467. Default is `false`.

--- a/clang-tools-extra/docs/clang-tidy/checks/bugprone/sizeof-expression.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/bugprone/sizeof-expression.rst
@@ -193,3 +193,8 @@ Options
    When `true`, the check will warn on an expression like
    ``sizeof(expr)`` where the expression is a pointer
    to aggregate. Default is `true`.
+
+.. option:: WarnOnSizeOfPointer
+
+   When `true`, the check will warn on an expression like ``sizeof(expr)``
+   where the expression is a pointer. Default is `false`.

--- a/clang-tools-extra/test/clang-tidy/checkers/bugprone/sizeof-expression-2.c
+++ b/clang-tools-extra/test/clang-tidy/checkers/bugprone/sizeof-expression-2.c
@@ -34,24 +34,24 @@ int Test5() {
 
   int sum = 0;
   sum += sizeof(&S);
-  // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: suspicious usage of 'sizeof(A*)'; pointer to aggregate
+  // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: suspicious usage of 'sizeof()' on an expression that results in a pointer
   sum += sizeof(__typeof(&S));
   sum += sizeof(&TS);
-  // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: suspicious usage of 'sizeof(A*)'; pointer to aggregate
+  // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: suspicious usage of 'sizeof()' on an expression that results in a pointer
   sum += sizeof(__typeof(&TS));
   sum += sizeof(STRKWD MyStruct*);
   sum += sizeof(__typeof(STRKWD MyStruct*));
   sum += sizeof(TypedefStruct*);
   sum += sizeof(__typeof(TypedefStruct*));
   sum += sizeof(PTTS);
-  // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: suspicious usage of 'sizeof(A*)'; pointer to aggregate
+  // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: suspicious usage of 'sizeof()' on an expression that results in a pointer
   sum += sizeof(PMyStruct);
   sum += sizeof(PS);
-  // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: suspicious usage of 'sizeof(A*)'; pointer to aggregate
+  // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: suspicious usage of 'sizeof()' on an expression that results in a pointer
   sum += sizeof(PS2);
-  // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: suspicious usage of 'sizeof(A*)'; pointer to aggregate
+  // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: suspicious usage of 'sizeof()' on an expression that results in a pointer
   sum += sizeof(&A10);
-  // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: suspicious usage of 'sizeof(A*)'; pointer to aggregate
+  // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: suspicious usage of 'sizeof()' on an expression that results in a pointer
 
 #ifdef __cplusplus
   MyStruct &rS = S;

--- a/clang-tools-extra/test/clang-tidy/checkers/bugprone/sizeof-expression-any-pointer.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/bugprone/sizeof-expression-any-pointer.cpp
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy %s bugprone-sizeof-expression %t -- -config="{CheckOptions: {bugprone-sizeof-expression.WarnOnSizeOfIntegerExpression: true}}" --
+// RUN: %check_clang_tidy %s bugprone-sizeof-expression %t -- -config="{CheckOptions: {bugprone-sizeof-expression.WarnOnSizeOfIntegerExpression: true, bugprone-sizeof-expression.WarnOnSizeOfPointer: true}}" --
 
 class C {
   int size() { return sizeof(this); }
@@ -28,47 +28,6 @@ struct M {
   E AsEnum() { return E_VALUE; }
   S AsStruct() { return {}; }
 };
-
-int ReturnOverload(int) { return {}; }
-S ReturnOverload(S) { return {}; }
-
-template <class T>
-T ReturnTemplate(T) { return {}; }
-
-template <class T>
-bool TestTrait1() {
-  return sizeof(ReturnOverload(T{})) == sizeof(A);
-}
-
-template <class T>
-bool TestTrait2() {
-  return sizeof(ReturnTemplate(T{})) == sizeof(A);
-}
-
-template <class T>
-bool TestTrait3() {
-  return sizeof(ReturnOverload(0)) == sizeof(T{});
-  // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: suspicious usage of 'sizeof()' on an expression that results in an integer
-}
-
-template <class T>
-bool TestTrait4() {
-  return sizeof(ReturnTemplate(0)) == sizeof(T{});
-  // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: suspicious usage of 'sizeof()' on an expression that results in an integer
-}
-
-bool TestTemplates() {
-  bool b = true;
-  b &= TestTrait1<int>();
-  b &= TestTrait1<S>();
-  b &= TestTrait2<int>();
-  b &= TestTrait2<S>();
-  b &= TestTrait3<int>();
-  b &= TestTrait3<S>();
-  b &= TestTrait4<int>();
-  b &= TestTrait4<S>();
-  return b;
-}
 
 int Test1(const char* ptr) {
   int sum = 0;
@@ -113,21 +72,22 @@ int Test1(const char* ptr) {
   sum += sizeof(B[0]) / sizeof(A);
   // CHECK-MESSAGES: :[[@LINE-1]]:23: warning: suspicious usage of 'sizeof(...)/sizeof(...)'; numerator is not a multiple of denominator
   sum += sizeof(ptr) / sizeof(char);
-  // CHECK-MESSAGES: :[[@LINE-1]]:22: warning: suspicious usage of sizeof pointer 'sizeof(T*)/sizeof(T)'
+  // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: suspicious usage of 'sizeof()' on an expression that results in a pointer
   sum += sizeof(ptr) / sizeof(ptr[0]);
-  // CHECK-MESSAGES: :[[@LINE-1]]:22: warning: suspicious usage of sizeof pointer 'sizeof(T*)/sizeof(T)'
+  // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: suspicious usage of 'sizeof()' on an expression that results in a pointer
   sum += sizeof(ptr) / sizeof(char*);
-  // CHECK-MESSAGES: :[[@LINE-1]]:22: warning: suspicious usage of sizeof pointer 'sizeof(P*)/sizeof(Q*)'
+  // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: suspicious usage of 'sizeof()' on an expression that results in a pointer
   sum += sizeof(ptr) / sizeof(void*);
-  // CHECK-MESSAGES: :[[@LINE-1]]:22: warning: suspicious usage of sizeof pointer 'sizeof(P*)/sizeof(Q*)'
+  // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: suspicious usage of 'sizeof()' on an expression that results in a pointer
   sum += sizeof(ptr) / sizeof(const void volatile*);
-  // CHECK-MESSAGES: :[[@LINE-1]]:22: warning: suspicious usage of sizeof pointer 'sizeof(P*)/sizeof(Q*)'
+  // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: suspicious usage of 'sizeof()' on an expression that results in a pointer
   sum += sizeof(ptr) / sizeof(char);
-  // CHECK-MESSAGES: :[[@LINE-1]]:22: warning: suspicious usage of sizeof pointer 'sizeof(T*)/sizeof(T)'
+  // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: suspicious usage of 'sizeof()' on an expression that results in a pointer
   sum += sizeof(int) * sizeof(char);
   // CHECK-MESSAGES: :[[@LINE-1]]:22: warning: suspicious 'sizeof' by 'sizeof' multiplication
   sum += sizeof(ptr) * sizeof(ptr[0]);
-  // CHECK-MESSAGES: :[[@LINE-1]]:22: warning: suspicious 'sizeof' by 'sizeof' multiplication
+  // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: suspicious usage of 'sizeof()' on an expression that results in a pointer
+  // CHECK-MESSAGES: :[[@LINE-2]]:22: warning: suspicious 'sizeof' by 'sizeof' multiplication
   sum += sizeof(int) * (2 * sizeof(char));
   // CHECK-MESSAGES: :[[@LINE-1]]:22: warning: suspicious 'sizeof' by 'sizeof' multiplication
   sum += (2 * sizeof(char)) * sizeof(int);
@@ -136,50 +96,6 @@ int Test1(const char* ptr) {
   // CHECK-MESSAGES: :[[@LINE-1]]:17: warning: suspicious comparison of 'sizeof(expr)' to a constant
   if (sizeof(A) <= 0xFFFFFFFEU) sum += 42;
   // CHECK-MESSAGES: :[[@LINE-1]]:17: warning: suspicious comparison of 'sizeof(expr)' to a constant
-  return sum;
-}
-
-typedef char MyChar;
-typedef const MyChar MyConstChar;
-
-int CE0 = sizeof sizeof(char);
-// CHECK-MESSAGES: :[[@LINE-1]]:11: warning: suspicious usage of 'sizeof(sizeof(...))'
-int CE1 = sizeof +sizeof(char);
-// CHECK-MESSAGES: :[[@LINE-1]]:11: warning: suspicious usage of 'sizeof(sizeof(...))'
-int CE2 = sizeof sizeof(const char*);
-// CHECK-MESSAGES: :[[@LINE-1]]:11: warning: suspicious usage of 'sizeof(sizeof(...))'
-int CE3 = sizeof sizeof(const volatile char* const*);
-// CHECK-MESSAGES: :[[@LINE-1]]:11: warning: suspicious usage of 'sizeof(sizeof(...))'
-int CE4 = sizeof sizeof(MyConstChar);
-// CHECK-MESSAGES: :[[@LINE-1]]:11: warning: suspicious usage of 'sizeof(sizeof(...))'
-
-int Test2(MyConstChar* A) {
-  int sum = 0;
-  sum += sizeof(MyConstChar) / sizeof(char);
-  // CHECK-MESSAGES: :[[@LINE-1]]:30: warning: suspicious usage of sizeof pointer 'sizeof(T)/sizeof(T)'
-  sum += sizeof(MyConstChar) / sizeof(MyChar);
-  // CHECK-MESSAGES: :[[@LINE-1]]:30: warning: suspicious usage of sizeof pointer 'sizeof(T)/sizeof(T)'
-  sum += sizeof(A[0]) / sizeof(char);
-  // CHECK-MESSAGES: :[[@LINE-1]]:23: warning: suspicious usage of sizeof pointer 'sizeof(T)/sizeof(T)'
-  return sum;
-}
-
-template <int T>
-int Foo() { int A[T]; return sizeof(T); }
-// CHECK-MESSAGES: :[[@LINE-1]]:30: warning: suspicious usage of 'sizeof(K)'
-template <typename T>
-int Bar() { T A[5]; return sizeof(A[0]) / sizeof(T); }
-// CHECK-MESSAGES: :[[@LINE-1]]:41: warning: suspicious usage of sizeof pointer 'sizeof(T)/sizeof(T)'
-int Test3() { return Foo<42>() + Bar<char>(); }
-
-static const char* kABC = "abc";
-static const wchar_t* kDEF = L"def";
-int Test4(const char A[10]) {
-  int sum = 0;
-  sum += sizeof(kABC);
-  // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: suspicious usage of 'sizeof(char*)'
-  sum += sizeof(kDEF);
-  // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: suspicious usage of 'sizeof(char*)'
   return sum;
 }
 
@@ -254,52 +170,17 @@ int Test5() {
   // CHECK-MESSAGES: :[[@LINE-1]]:25: warning: suspicious usage of 'sizeof(...)/sizeof(...)'; numerator is not a multiple of denominator
   // CHECK-MESSAGES: :[[@LINE-2]]:27: warning: suspicious usage of 'sizeof()' on an expression that results in a pointer
 
-  // These pointers do not point to aggregate types, so they are not reported in this mode:
   sum += sizeof(PChar);
+  // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: suspicious usage of 'sizeof()' on an expression that results in a pointer
   sum += sizeof(PInt);
+  // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: suspicious usage of 'sizeof()' on an expression that results in a pointer
   sum += sizeof(PPInt);
+  // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: suspicious usage of 'sizeof()' on an expression that results in a pointer
   sum += sizeof(PPMyStruct);
+  // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: suspicious usage of 'sizeof()' on an expression that results in a pointer
 
   return sum;
 }
-
-int Test6() {
-  int sum = 0;
-
-  struct S A = AsStruct(), B = AsStruct();
-  struct S *P = &A, *Q = &B;
-  sum += sizeof(struct S) == P - Q;
-  // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: suspicious usage of 'sizeof(...)' in pointer arithmetic
-  sum += 5 * sizeof(S) != P - Q;
-  // CHECK-MESSAGES: :[[@LINE-1]]:14: warning: suspicious usage of 'sizeof(...)' in pointer arithmetic
-  sum += sizeof(S) < P - Q;
-  // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: suspicious usage of 'sizeof(...)' in pointer arithmetic
-  sum += 5 * sizeof(S) <= P - Q;
-  // CHECK-MESSAGES: :[[@LINE-1]]:14: warning: suspicious usage of 'sizeof(...)' in pointer arithmetic
-  sum += 5 * sizeof(*P) >= P - Q;
-  // CHECK-MESSAGES: :[[@LINE-1]]:14: warning: suspicious usage of 'sizeof(...)' in pointer arithmetic
-  sum += Q - P > 3 * sizeof(*P);
-  // CHECK-MESSAGES: :[[@LINE-1]]:22: warning: suspicious usage of 'sizeof(...)' in pointer arithmetic
-  sum += sizeof(S) + (P - Q);
-  // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: suspicious usage of 'sizeof(...)' in pointer arithmetic
-  sum += 5 * sizeof(S) - (P - Q);
-  // CHECK-MESSAGES: :[[@LINE-1]]:14: warning: suspicious usage of 'sizeof(...)' in pointer arithmetic
-  sum += (P - Q) / sizeof(S);
-  // CHECK-MESSAGES: :[[@LINE-1]]:20: warning: suspicious usage of 'sizeof(...)' in pointer arithmetic
-  sum += (P - Q) / sizeof(*Q);
-  // CHECK-MESSAGES: :[[@LINE-1]]:20: warning: suspicious usage of 'sizeof(...)' in pointer arithmetic
-
-  return sum;
-}
-
-#ifdef __SIZEOF_INT128__
-template <__int128_t N>
-#else
-template <long N> // Fallback for platforms which do not define `__int128_t`
-#endif
-bool Baz() { return sizeof(A) < N; }
-// CHECK-MESSAGES: :[[@LINE-1]]:31: warning: suspicious comparison of 'sizeof(expr)' to a constant
-bool Test7() { return Baz<-1>(); }
 
 void some_generic_function(const void *arg, int argsize);
 int **IntPP;
@@ -329,7 +210,9 @@ int ValidExpressions() {
   sum += sizeof(AsStruct());
   sum += sizeof(M{}.AsStruct());
   sum += sizeof(A[sizeof(A) / sizeof(int)]);
+  // Here the outer sizeof is reported, but the inner ones are accepted:
   sum += sizeof(&A[sizeof(A) / sizeof(int)]);
+  // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: suspicious usage of 'sizeof()' on an expression that results in a pointer
   sum += sizeof(sizeof(0));  // Special case: sizeof size_t.
   sum += sizeof(void*);
   sum += sizeof(void const *);

--- a/clang-tools-extra/test/clang-tidy/checkers/bugprone/sizeof-expression-any-pointer.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/bugprone/sizeof-expression-any-pointer.cpp
@@ -180,8 +180,8 @@ int Test5() {
 }
 
 void some_generic_function(const void *arg, int argsize);
-int **IntPP;
-C **ClassPP;
+int *IntP, **IntPP;
+C *ClassP, **ClassPP;
 
 void GenericFunctionTest() {
   // The `sizeof(pointer)` checks ignore situations where the pointer is
@@ -190,8 +190,19 @@ void GenericFunctionTest() {
   // a generic function which emulates dynamic typing within C.
   some_generic_function(IntPP, sizeof(*IntPP));
   some_generic_function(ClassPP, sizeof(*ClassPP));
+  // Using `...[0]` instead of the dereference operator is another common
+  // variant, which is also widespread in the idiomatic array-size calculation:
+  // `sizeof(array) / sizeof(array[0])`.
   some_generic_function(IntPP, sizeof(IntPP[0]));
   some_generic_function(ClassPP, sizeof(ClassPP[0]));
+  // FIXME: There is a third common pattern where the generic function is
+  // called with `&Variable` and `sizeof(Variable)`. Right now these are
+  // reported by the `sizeof(pointer)` checks, but this causes some false
+  // positives, so it would be good to create an exception for them.
+  some_generic_function(&IntPP, sizeof(IntP));
+  // CHECK-MESSAGES: :[[@LINE-1]]:33: warning: suspicious usage of 'sizeof()' on an expression that results in a pointer
+  some_generic_function(&ClassPP, sizeof(ClassP));
+  // CHECK-MESSAGES: :[[@LINE-1]]:35: warning: suspicious usage of 'sizeof()' on an expression that results in a pointer
 }
 
 int ValidExpressions() {

--- a/clang-tools-extra/test/clang-tidy/checkers/bugprone/sizeof-expression-any-pointer.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/bugprone/sizeof-expression-any-pointer.cpp
@@ -161,14 +161,11 @@ int Test5() {
   sum += sizeof(PtrArray) / sizeof(PtrArray[1]);
   // CHECK-MESSAGES: :[[@LINE-1]]:29: warning: suspicious usage of 'sizeof()' on an expression that results in a pointer
   sum += sizeof(A10) / sizeof(PtrArray[0]);
-  // CHECK-MESSAGES: :[[@LINE-1]]:24: warning: suspicious usage of 'sizeof()' on an expression that results in a pointer
   sum += sizeof(PC) / sizeof(PtrArray[0]);
   // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: suspicious usage of 'sizeof()' on an expression that results in a pointer
   // CHECK-MESSAGES: :[[@LINE-2]]:21: warning: suspicious usage of sizeof pointer 'sizeof(T)/sizeof(T)'
-  // CHECK-MESSAGES: :[[@LINE-3]]:23: warning: suspicious usage of 'sizeof()' on an expression that results in a pointer
   sum += sizeof(ArrayC) / sizeof(PtrArray[0]);
   // CHECK-MESSAGES: :[[@LINE-1]]:25: warning: suspicious usage of 'sizeof(...)/sizeof(...)'; numerator is not a multiple of denominator
-  // CHECK-MESSAGES: :[[@LINE-2]]:27: warning: suspicious usage of 'sizeof()' on an expression that results in a pointer
 
   sum += sizeof(PChar);
   // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: suspicious usage of 'sizeof()' on an expression that results in a pointer
@@ -193,6 +190,8 @@ void GenericFunctionTest() {
   // a generic function which emulates dynamic typing within C.
   some_generic_function(IntPP, sizeof(*IntPP));
   some_generic_function(ClassPP, sizeof(*ClassPP));
+  some_generic_function(IntPP, sizeof(IntPP[0]));
+  some_generic_function(ClassPP, sizeof(ClassPP[0]));
 }
 
 int ValidExpressions() {

--- a/clang-tools-extra/test/clang-tidy/checkers/bugprone/sizeof-expression.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/bugprone/sizeof-expression.cpp
@@ -245,14 +245,11 @@ int Test5() {
   sum += sizeof(PtrArray) / sizeof(PtrArray[1]);
   // CHECK-MESSAGES: :[[@LINE-1]]:29: warning: suspicious usage of 'sizeof()' on an expression that results in a pointer
   sum += sizeof(A10) / sizeof(PtrArray[0]);
-  // CHECK-MESSAGES: :[[@LINE-1]]:24: warning: suspicious usage of 'sizeof()' on an expression that results in a pointer
   sum += sizeof(PC) / sizeof(PtrArray[0]);
   // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: suspicious usage of 'sizeof()' on an expression that results in a pointer
   // CHECK-MESSAGES: :[[@LINE-2]]:21: warning: suspicious usage of sizeof pointer 'sizeof(T)/sizeof(T)'
-  // CHECK-MESSAGES: :[[@LINE-3]]:23: warning: suspicious usage of 'sizeof()' on an expression that results in a pointer
   sum += sizeof(ArrayC) / sizeof(PtrArray[0]);
   // CHECK-MESSAGES: :[[@LINE-1]]:25: warning: suspicious usage of 'sizeof(...)/sizeof(...)'; numerator is not a multiple of denominator
-  // CHECK-MESSAGES: :[[@LINE-2]]:27: warning: suspicious usage of 'sizeof()' on an expression that results in a pointer
 
   // These pointers do not point to aggregate types, so they are not reported in this mode:
   sum += sizeof(PChar);
@@ -312,6 +309,8 @@ void GenericFunctionTest() {
   // a generic function which emulates dynamic typing within C.
   some_generic_function(IntPP, sizeof(*IntPP));
   some_generic_function(ClassPP, sizeof(*ClassPP));
+  some_generic_function(IntPP, sizeof(IntPP[0]));
+  some_generic_function(ClassPP, sizeof(ClassPP[0]));
 }
 
 int ValidExpressions() {

--- a/clang-tools-extra/test/clang-tidy/checkers/bugprone/sizeof-expression.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/bugprone/sizeof-expression.cpp
@@ -299,8 +299,8 @@ bool Baz() { return sizeof(A) < N; }
 bool Test7() { return Baz<-1>(); }
 
 void some_generic_function(const void *arg, int argsize);
-int **IntPP;
-C **ClassPP;
+int *IntP, **IntPP;
+C *ClassP, **ClassPP;
 
 void GenericFunctionTest() {
   // The `sizeof(pointer)` checks ignore situations where the pointer is
@@ -309,8 +309,19 @@ void GenericFunctionTest() {
   // a generic function which emulates dynamic typing within C.
   some_generic_function(IntPP, sizeof(*IntPP));
   some_generic_function(ClassPP, sizeof(*ClassPP));
+  // Using `...[0]` instead of the dereference operator is another common
+  // variant, which is also widespread in the idiomatic array-size calculation:
+  // `sizeof(array) / sizeof(array[0])`.
   some_generic_function(IntPP, sizeof(IntPP[0]));
   some_generic_function(ClassPP, sizeof(ClassPP[0]));
+  // FIXME: There is a third common pattern where the generic function is
+  // called with `&Variable` and `sizeof(Variable)`. Right now these are
+  // reported by the `sizeof(pointer)` checks, but this causes some false
+  // positives, so it would be good to create an exception for them.
+  // NOTE: `sizeof(IntP)` is only reported with `WarnOnSizeOfPointer=true`.
+  some_generic_function(&IntPP, sizeof(IntP));
+  some_generic_function(&ClassPP, sizeof(ClassP));
+  // CHECK-MESSAGES: :[[@LINE-1]]:35: warning: suspicious usage of 'sizeof()' on an expression that results in a pointer
 }
 
 int ValidExpressions() {


### PR DESCRIPTION
This commit reimplements the functionality of the Clang Static Analyzer checker `alpha.core.SizeofPointer` within clang-tidy by adding a new (off-by-default) option to bugprone-sizeof-expression which activates reporting all the `sizeof(ptr)` expressions (where ptr is an expression that produces a pointer).

The main motivation for this change is that `alpha.core.SizeofPointer` was an AST-based checker, which did not rely on the path sensitive capabilities of the Static Analyzer, so there was no reason to keep it in the Static Analyzer instead of the more lightweight clang-tidy.

After this commit I'm planning to create a separate commit that deletes `alpha.core.SizeofPointer` from Clang Static Analyzer.

It was natural to place this moved logic in bugprone-sizeof-expression, because that check already provided several heuristics that reported various especially suspicious classes of `sizeof(ptr)` expressions.

The new mode `WarnOnSizeOfPointer` is off-by-default, so it won't surprise the existing users; but it can provide a more through coverage for the vulnerability CWE-467 ("Use of sizeof() on a Pointer Type") than the existing partial heuristics.

Previously this checker had an exception that the RHS of a `sizeof(array) / sizeof(array[0])` expression is not reported; I generalized this to an exception that the check doesn't report `sizeof(expr[0])` and `sizeof(*expr)`. This idea is taken from the Static Analyzer checker `alpha.core.SizeofPointer` (which had an exception for `*expr`), but analysis of open source projects confirmed that this indeed eliminates lots of unwanted results.

Note that the suppression of  `sizeof(expr[0])` and `sizeof(*expr)` reports also affects the "old" mode `WarnOnSizeOfPointerToAggregate` which is enabled by default.

This commit also replaces the old message "suspicious usage of 'sizeof(A*)'; pointer to aggregate" with two more concrete messages; but I feel that this tidy check would deserve a through cleanup of all the diagnostic messages that it can produce. (I added a FIXME to mark one outright misleading message.)