### PR TITLE
Fix spurious non-strict availability warning

### DIFF
--- a/clang/include/clang/Sema/Initialization.h
+++ b/clang/include/clang/Sema/Initialization.h
@@ -212,7 +212,7 @@ private:
     struct C Capture;
   };
 
-  InitializedEntity() {};
+  InitializedEntity() {}
 
   /// Create the initialization entity for a variable.
   InitializedEntity(VarDecl *Var, EntityKind EK = EK_Variable)

--- a/clang/lib/Sema/SemaAvailability.cpp
+++ b/clang/lib/Sema/SemaAvailability.cpp
@@ -12,6 +12,7 @@
 
 #include "clang/AST/Attr.h"
 #include "clang/AST/Decl.h"
+#include "clang/AST/DeclTemplate.h"
 #include "clang/AST/RecursiveASTVisitor.h"
 #include "clang/Basic/DiagnosticSema.h"
 #include "clang/Basic/IdentifierTable.h"
@@ -46,6 +47,10 @@ static const AvailabilityAttr *getAttrForPlatform(ASTContext &Context,
   // Check each AvailabilityAttr to find the one for this platform.
   // For multiple attributes with the same platform try to find one for this
   // environment.
+  // The attribute is always on the FunctionDecl, not on the
+  // FunctionTemplateDecl.
+  if (const auto *FTD = dyn_cast<FunctionTemplateDecl>(D))
+    D = FTD->getTemplatedDecl();
   for (const auto *A : D->attrs()) {
     if (const auto *Avail = dyn_cast<AvailabilityAttr>(A)) {
       // FIXME: this is copied from CheckAvailability. We should try to

--- a/clang/test/Sema/attr-availability-macosx.cpp
+++ b/clang/test/Sema/attr-availability-macosx.cpp
@@ -1,0 +1,17 @@
+// RUN: %clang_cc1 "-triple" "arm64-apple-macosx10.15" -fsyntax-only -verify %s
+
+__attribute__((availability(macos,introduced=11)))
+inline bool try_acquire() {
+  return true;
+}
+
+template <class T>
+__attribute__((availability(macos,introduced=11)))
+bool try_acquire_for(T duration) { // expected-note{{'try_acquire_for<int>' has been marked as being introduced in macOS 11 here, but the deployment target is macOS 10.15}}
+  return try_acquire();
+}
+
+int main() {
+  try_acquire_for(1); // expected-warning{{'try_acquire_for<int>' is only available on macOS 11 or newer}}
+  // expected-note@-1{{enclose 'try_acquire_for<int>' in a __builtin_available check to silence this warning}}
+}


### PR DESCRIPTION
The availability attributes are stored on the function declarations. The code was looking for them in the function template declarations. This resulted in spuriously diagnosing (non-strict) availablity issues in contexts that are not available.