### PR TITLE
[flang] Disable test on Windows

### DIFF
--- a/flang/test/Semantics/call40.f90
+++ b/flang/test/Semantics/call40.f90
@@ -1,4 +1,5 @@
 ! RUN: %python %S/test_errors.py %s %flang_fc1
+! XFAIL: system-windows
 ! %VAL en %REF legacy extension semantic tests.
 
 subroutine val_errors(array, string, polymorphic, derived)


### PR DESCRIPTION
flang/test/Semantics/call40.f90 is behaving weirdly on Windows, perhaps due to a percent sign in a message that shouldn't be interpreted as a formatting character.  Disable the test for now so that CI isn't producing confusing errors.