### PR TITLE
[flang][Semantics][OpenMP] Fix ICE for unknown reduction starting with .

### DIFF
--- a/flang/lib/Semantics/check-omp-structure.cpp
+++ b/flang/lib/Semantics/check-omp-structure.cpp
@@ -2321,9 +2321,17 @@ bool OmpStructureChecker::CheckReductionOperators(
   common::visit(
       common::visitors{
           [&](const parser::DefinedOperator &dOpr) {
-            const auto &intrinsicOp{
-                std::get<parser::DefinedOperator::IntrinsicOperator>(dOpr.u)};
-            ok = CheckIntrinsicOperator(intrinsicOp);
+            const auto *intrinsicOp{
+                std::get_if<parser::DefinedOperator::IntrinsicOperator>(
+                    &dOpr.u)};
+            if (intrinsicOp) {
+              ok = CheckIntrinsicOperator(*intrinsicOp);
+            } else {
+              context_.Say(GetContext().clauseSource,
+                  "Invalid reduction operator in REDUCTION "
+                  "clause."_err_en_US,
+                  ContextDirectiveAsFortran());
+            }
           },
           [&](const parser::ProcedureDesignator &procD) {
             const parser::Name *name{std::get_if<parser::Name>(&procD.u)};

--- a/flang/lib/Semantics/check-omp-structure.cpp
+++ b/flang/lib/Semantics/check-omp-structure.cpp
@@ -2321,15 +2321,13 @@ bool OmpStructureChecker::CheckReductionOperators(
   common::visit(
       common::visitors{
           [&](const parser::DefinedOperator &dOpr) {
-            const auto *intrinsicOp{
-                std::get_if<parser::DefinedOperator::IntrinsicOperator>(
-                    &dOpr.u)};
-            if (intrinsicOp) {
+            if (const auto *intrinsicOp{
+                    std::get_if<parser::DefinedOperator::IntrinsicOperator>(
+                        &dOpr.u)}) {
               ok = CheckIntrinsicOperator(*intrinsicOp);
             } else {
               context_.Say(GetContext().clauseSource,
-                  "Invalid reduction operator in REDUCTION "
-                  "clause."_err_en_US,
+                  "Invalid reduction operator in REDUCTION clause."_err_en_US,
                   ContextDirectiveAsFortran());
             }
           },

--- a/flang/test/Semantics/OpenMP/reduction13.f90
+++ b/flang/test/Semantics/OpenMP/reduction13.f90
@@ -1,0 +1,10 @@
+! RUN: %python %S/../test_errors.py %s %flang_fc1 -fopenmp
+! OpenMP Version 4.5
+! 2.15.3.6 Reduction Clause
+program omp_reduction
+  integer :: k
+  ! miss-spelling. Should be "min"
+  !ERROR: Invalid reduction operator in REDUCTION clause.
+  !$omp parallel reduction(.min.:k)
+  !$omp end parallel
+end program omp_reduction

--- a/flang/test/Semantics/OpenMP/reduction13.f90
+++ b/flang/test/Semantics/OpenMP/reduction13.f90
@@ -3,7 +3,7 @@
 ! 2.15.3.6 Reduction Clause
 program omp_reduction
   integer :: k
-  ! miss-spelling. Should be "min"
+  ! misspelling. Should be "min"
   !ERROR: Invalid reduction operator in REDUCTION clause.
   !$omp parallel reduction(.min.:k)
   !$omp end parallel


### PR DESCRIPTION
In this case the union inside of the `parser::DefinedOperator` contains a string name instead of the expected
`parser::DefinedOperator::IntrinsicOperator`. This led to a `std::abort`.

This patch adapts the code so that if it contains a string name we emit a semantic error.