### PR TITLE
[lldb][DebugNames] Only skip processing of DW_AT_declarations for class/union types

### DIFF
--- a/lldb/source/Plugins/SymbolFile/DWARF/DebugNamesDWARFIndex.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DebugNamesDWARFIndex.cpp
@@ -87,7 +87,8 @@ bool DebugNamesDWARFIndex::ProcessEntry(
     return true;
   // Clang erroneously emits index entries for declaration DIEs in case when the
   // definition is in a type unit (llvm.org/pr77696). Weed those out.
-  if (die.GetAttributeValueAsUnsigned(DW_AT_declaration, 0))
+  if (die.IsStructUnionOrClass() &&
+      die.GetAttributeValueAsUnsigned(DW_AT_declaration, 0))
     return true;
   return callback(die);
 }


### PR DESCRIPTION
This is a follow-up of https://github.com/llvm/llvm-project/pull/92328#issuecomment-2145849441

Clang attaches `DW_AT_declaration` to static inline data members and `dsymutil` indexes these constants. Skipping these caused the expression evaluator to fail to find such constants when using DWARFv5.

Fixes `TestConstStaticIntegralMember.py` on DWARFv5.