### PR TITLE
remove references to hard-coded gc strategies

### DIFF
--- a/llvm/lib/IR/Value.cpp
+++ b/llvm/lib/IR/Value.cpp
@@ -20,6 +20,7 @@
 #include "llvm/IR/DebugInfo.h"
 #include "llvm/IR/DerivedTypes.h"
 #include "llvm/IR/DerivedUser.h"
+#include "llvm/IR/GCStrategy.h"
 #include "llvm/IR/GetElementPtrTypeIterator.h"
 #include "llvm/IR/InstrTypes.h"
 #include "llvm/IR/Instructions.h"
@@ -826,14 +827,11 @@ bool Value::canBeFreed() const {
   // which is why we need the explicit opt in on a per collector basis.
   if (!F->hasGC())
     return true;
-  
-  const auto &GCName = F->getGC();
-  if (GCName == "statepoint-example") {
+
+  const auto &GCStrategy = getGCStrategy(F->getGC());
+  if (GCStrategy->useStatepoints()) {
     auto *PT = cast<PointerType>(this->getType());
-    if (PT->getAddressSpace() != 1)
-      // For the sake of this example GC, we arbitrarily pick addrspace(1) as
-      // our GC managed heap.  This must match the same check in
-      // RewriteStatepointsForGC (and probably needs better factored.)
+    if (GCStrategy->isGCManagedPointer(PT) == false)
       return true;
 
     // It is cheaper to scan for a declaration than to scan for a use in this

--- a/llvm/lib/Transforms/Scalar/PlaceSafepoints.cpp
+++ b/llvm/lib/Transforms/Scalar/PlaceSafepoints.cpp
@@ -58,6 +58,7 @@
 #include "llvm/Analysis/ScalarEvolution.h"
 #include "llvm/Analysis/TargetLibraryInfo.h"
 #include "llvm/IR/Dominators.h"
+#include "llvm/IR/GCStrategy.h"
 #include "llvm/IR/IntrinsicInst.h"
 #include "llvm/IR/LegacyPassManager.h"
 #include "llvm/IR/Statepoint.h"
@@ -600,13 +601,9 @@ static bool isGCSafepointPoll(Function &F) {
 /// polls and parseable call sites.  The main point of this function is to be
 /// an extension point for custom logic.
 static bool shouldRewriteFunction(Function &F) {
-  // TODO: This should check the GCStrategy
   if (F.hasGC()) {
-    const auto &FunctionGCName = F.getGC();
-    const StringRef StatepointExampleName("statepoint-example");
-    const StringRef CoreCLRName("coreclr");
-    return (StatepointExampleName == FunctionGCName) ||
-           (CoreCLRName == FunctionGCName);
+    const auto &GCStrategy = getGCStrategy(F.getGC());
+    return GCStrategy->useStatepoints();
   } else
     return false;
 }


### PR DESCRIPTION
There remains a few places in the LLVM codebase where, instead of using the GC strategy object to decide whether or not to make use of a particular piece of statepoint-related logic, we are still checking the gc strategy name against a hard-coded string. This is obviously undesirable because it means that plugins cannot easily make use of this functionality to create their own GC strategies without sacrificing some of the logic that is supposedly available to them.

This PR quite simply replaces these call sites with calls to `getGCStrategy`, which returns a GCStrategy object for a particular named strategy, and then calls the relevant getter methods on the resulting GCStrategy pointer.