### PR TITLE
clang/utils/TableGen/ClangOptionDocEmitter.cpp:220: Pointless string copy ? (#94373)

### DIFF
--- a/clang/utils/TableGen/ClangOptionDocEmitter.cpp
+++ b/clang/utils/TableGen/ClangOptionDocEmitter.cpp
@@ -217,7 +217,7 @@ bool canSphinxCopeWithOption(const Record *Option) {
   return false;
 }
 
-void emitHeading(int Depth, std::string Heading, raw_ostream &OS) {
+void emitHeading(int Depth, const std::string &Heading, raw_ostream &OS) {
   assert(Depth < 8 && "groups nested too deeply");
   OS << Heading << '\n'
      << std::string(Heading.size(), "=~-_'+<>"[Depth]) << "\n";


### PR DESCRIPTION
modified parameter for code quality