### PR TITLE
Revert "[symbolizer] Empty string is not an error"

### DIFF
--- a/llvm/test/tools/llvm-symbolizer/get-input-file.test
+++ b/llvm/test/tools/llvm-symbolizer/get-input-file.test
@@ -1,9 +1,9 @@
 # If binary input file is not specified, llvm-symbolizer assumes it is the first
 # item in the command.
 
-# No input items at all. Report an unknown line, but do not produce any output on stderr.
+# No input items at all, complain about missing input file.
 RUN: echo | llvm-symbolizer 2>%t.1.err | FileCheck %s --check-prefix=NOSOURCE
-RUN: FileCheck --input-file=%t.1.err --implicit-check-not={{.}} --allow-empty %s
+RUN: FileCheck --input-file=%t.1.err --check-prefix=NOFILE %s
 
 # Only one input item, complain about missing addresses.
 RUN: llvm-symbolizer "foo" 2>%t.2.err | FileCheck %s --check-prefix=NOSOURCE
@@ -31,6 +31,8 @@ RUN: FileCheck --input-file=%t.7.err --check-prefix=BAD-QUOTE %s
 
 NOSOURCE:      ??
 NOSOURCE-NEXT: ??:0:0
+
+NOFILE: error: no input filename has been specified
 
 NOADDR: error: 'foo': no module offset has been specified
 

--- a/llvm/tools/llvm-symbolizer/llvm-symbolizer.cpp
+++ b/llvm/tools/llvm-symbolizer/llvm-symbolizer.cpp
@@ -337,14 +337,6 @@ static void symbolizeInput(const opt::InputArgList &Args,
   object::BuildID BuildID(IncomingBuildID.begin(), IncomingBuildID.end());
   uint64_t Offset = 0;
   StringRef Symbol;
-
-  // An empty input string may be used to check if the process is alive and
-  // responding to input. Do not emit a message on stderr in this case but
-  // respond on stdout.
-  if (InputString.empty()) {
-    printUnknownLineInfo(ModuleName, Printer);
-    return;
-  }
   if (Error E = parseCommand(Args.getLastArgValue(OPT_obj_EQ), IsAddr2Line,
                              StringRef(InputString), Cmd, ModuleName, BuildID,
                              Symbol, Offset)) {


### PR DESCRIPTION
Reverts llvm/llvm-project#92660

It needs more discussion.