### PR TITLE
[flang][OpenMP] Fix privatization when critical is present

### DIFF
--- a/flang/lib/Lower/OpenMP/DataSharingProcessor.cpp
+++ b/flang/lib/Lower/OpenMP/DataSharingProcessor.cpp
@@ -262,15 +262,6 @@ void DataSharingProcessor::insertLastPrivateCompare(mlir::Operation *op) {
   }
 }
 
-static bool mayHavePrivatizations(const lower::pft::Evaluation &eval) {
-  if (const parser::OpenMPConstruct *construct =
-          eval.getIf<parser::OpenMPConstruct>()) {
-    if (std::holds_alternative<parser::OpenMPCriticalConstruct>(construct->u))
-      return false;
-  }
-  return true;
-}
-
 static const parser::CharBlock *
 getSource(const semantics::SemanticsContext &semaCtx,
           const lower::pft::Evaluation &eval) {
@@ -314,7 +305,7 @@ void DataSharingProcessor::collectSymbolsInNestedRegions(
     llvm::SetVector<const semantics::Symbol *> &symbolsInNestedRegions) {
   for (lower::pft::Evaluation &nestedEval : eval.getNestedEvaluations()) {
     if (nestedEval.hasNestedEvaluations()) {
-      if (nestedEval.isConstruct() || !mayHavePrivatizations(nestedEval))
+      if (nestedEval.isConstruct())
         // Recursively look for OpenMP constructs within `nestedEval`'s region
         collectSymbolsInNestedRegions(nestedEval, flag, symbolsInNestedRegions);
       else {

--- a/flang/lib/Lower/OpenMP/DataSharingProcessor.h
+++ b/flang/lib/Lower/OpenMP/DataSharingProcessor.h
@@ -44,7 +44,9 @@ private:
     void Post(const T &) {}
 
     bool Pre(const parser::OpenMPConstruct &omp) {
-      currentConstruct = &omp;
+      // Skip constructs that may not have privatizations.
+      if (!std::holds_alternative<parser::OpenMPCriticalConstruct>(omp.u))
+        currentConstruct = &omp;
       return true;
     }
 

--- a/flang/test/Lower/OpenMP/critical.f90
+++ b/flang/test/Lower/OpenMP/critical.f90
@@ -51,3 +51,27 @@ subroutine predetermined_privatization()
   end do
   !$omp end parallel do
 end
+
+! https://github.com/llvm/llvm-project/issues/75767
+!CHECK-LABEL: func @_QPnested_privatization(
+subroutine nested_privatization()
+  integer :: i
+
+  !CHECK: %[[I:.*]] = fir.alloca i32 {bindc_name = "i", uniq_name = "_QFnested_privatizationEi"}
+  !CHECK: %[[I_DECL:.*]]:2 = hlfir.declare %[[I]] {uniq_name = "_QFnested_privatizationEi"} : (!fir.ref<i32>) -> (!fir.ref<i32>, !fir.ref<i32>)
+  !CHECK: omp.parallel {
+  !CHECK:   %[[PRIV_I:.*]] = fir.alloca i32 {bindc_name = "i", pinned, uniq_name = "_QFnested_privatizationEi"}
+  !CHECK:   %[[PRIV_I_DECL:.*]]:2 = hlfir.declare %[[PRIV_I]] {uniq_name = "_QFnested_privatizationEi"} : (!fir.ref<i32>) -> (!fir.ref<i32>, !fir.ref<i32>)
+  !CHECK:   %[[TEMP:.*]] = fir.load %[[I_DECL]]#0 : !fir.ref<i32>
+  !CHECK:   hlfir.assign %[[TEMP]] to %[[PRIV_I_DECL]]#0 temporary_lhs : i32, !fir.ref<i32>
+  !$omp parallel default(firstprivate)
+    !CHECK: omp.critical {
+    !$omp critical
+      !CHECK: %[[C200:.*]] = arith.constant 200 : i32
+      !CHECK: hlfir.assign %[[C200]] to %[[PRIV_I_DECL]]#0 : i32, !fir.ref<i32>
+      i = 200
+    !CHECK: }
+    !$omp end critical
+  !CHECK: }
+  !$omp end parallel
+end subroutine

--- a/flang/test/Lower/OpenMP/critical.f90
+++ b/flang/test/Lower/OpenMP/critical.f90
@@ -53,15 +53,15 @@ subroutine predetermined_privatization()
 end
 
 ! https://github.com/llvm/llvm-project/issues/75767
-!CHECK-LABEL: func @_QPnested_privatization(
-subroutine nested_privatization()
+!CHECK-LABEL: func @_QPparallel_critical_privatization(
+subroutine parallel_critical_privatization()
   integer :: i
 
-  !CHECK: %[[I:.*]] = fir.alloca i32 {bindc_name = "i", uniq_name = "_QFnested_privatizationEi"}
-  !CHECK: %[[I_DECL:.*]]:2 = hlfir.declare %[[I]] {uniq_name = "_QFnested_privatizationEi"} : (!fir.ref<i32>) -> (!fir.ref<i32>, !fir.ref<i32>)
+  !CHECK: %[[I:.*]] = fir.alloca i32 {bindc_name = "i", uniq_name = "_QFparallel_critical_privatizationEi"}
+  !CHECK: %[[I_DECL:.*]]:2 = hlfir.declare %[[I]] {uniq_name = "_QFparallel_critical_privatizationEi"} : (!fir.ref<i32>) -> (!fir.ref<i32>, !fir.ref<i32>)
   !CHECK: omp.parallel {
-  !CHECK:   %[[PRIV_I:.*]] = fir.alloca i32 {bindc_name = "i", pinned, uniq_name = "_QFnested_privatizationEi"}
-  !CHECK:   %[[PRIV_I_DECL:.*]]:2 = hlfir.declare %[[PRIV_I]] {uniq_name = "_QFnested_privatizationEi"} : (!fir.ref<i32>) -> (!fir.ref<i32>, !fir.ref<i32>)
+  !CHECK:   %[[PRIV_I:.*]] = fir.alloca i32 {bindc_name = "i", pinned, uniq_name = "_QFparallel_critical_privatizationEi"}
+  !CHECK:   %[[PRIV_I_DECL:.*]]:2 = hlfir.declare %[[PRIV_I]] {uniq_name = "_QFparallel_critical_privatizationEi"} : (!fir.ref<i32>) -> (!fir.ref<i32>, !fir.ref<i32>)
   !CHECK:   %[[TEMP:.*]] = fir.load %[[I_DECL]]#0 : !fir.ref<i32>
   !CHECK:   hlfir.assign %[[TEMP]] to %[[PRIV_I_DECL]]#0 temporary_lhs : i32, !fir.ref<i32>
   !$omp parallel default(firstprivate)


### PR DESCRIPTION
When a critical construct is present inside another construct where
privatizations may occur, such as a parallel construct, some
privatizations are skipped if the corresponding symbols are defined
inside the critical section only (see the example below).

This happens because, while critical constructs have a "body", they
don't have a separate scope (which makes sense, since no
privatizations can occur in them). Because of this, in semantics
phase, it's not possible to insert a new host association symbol,
but instead the symbol from the enclosing context is used directly.

This makes symbol collection in DataSharingProcessor consider the
new symbol to be defined by the critical construct, instead of by
the enclosing one, which causes the privatization to be skipped.

Example:
```
!$omp parallel default(firstprivate)
  !$omp critical
     i = 200
  !$omp end critical
!$omp end parallel
```

This patch fixes this by identifying constructs where
privatizations may not happen and skipping them during the
collection of nested symbols. Currently, this seems to happen only
with critical constructs, but others can be easily added to the
skip list, if needed.

Fixes https://github.com/llvm/llvm-project/issues/75767
