### PR TITLE
[PowerPC][XCOFF] Handle non-zero addend in relocation to external toc-data symbol

### DIFF
--- a/llvm/lib/MC/XCOFFObjectWriter.cpp
+++ b/llvm/lib/MC/XCOFFObjectWriter.cpp
@@ -729,10 +729,9 @@ void XCOFFObjectWriter::recordRelocation(MCAssembler &Asm,
     // For non toc-data external symbols, R_TOC type relocation will relocate to
     // data symbols that have XCOFF::XTY_SD type csect. For toc-data external
     // symbols, R_TOC type relocation will relocate to data symbols that have
-    // XCOFF_ER type csect. For XCOFF_ER kind symbols, there will be no TOC
-    // entry for them, so the FixedValue should always be 0.
+    // XCOFF_ER type csect.
     if (SymASec->getCSectType() == XCOFF::XTY_ER) {
-      FixedValue = 0;
+      FixedValue = Target.getConstant();
     } else {
       // The FixedValue should be the TOC entry offset from the TOC-base plus
       // any constant offset value.

--- a/llvm/test/CodeGen/PowerPC/tocdata-non-zero-addend.mir
+++ b/llvm/test/CodeGen/PowerPC/tocdata-non-zero-addend.mir
@@ -4,7 +4,7 @@
 # CHECK: lbz 3, 2(2)
 # CHECK-NEXT: R_TOC        x
 # CHECK-LABEL: .read_y
-# CHECK: lbz 3, 0(2)
+# CHECK: lbz 3, 1(2)
 # CHECK-NEXT: R_TOC        y
 
 --- |


### PR DESCRIPTION
There are situations that the addend of toc-data relocation is not zero. We should fix it for IAS.