### PR TITLE
Add an artifact containing the libc++ headers + libraries.

### DIFF
--- a/.github/workflows/libcxx-build-and-test.yaml
+++ b/.github/workflows/libcxx-build-and-test.yaml
@@ -82,6 +82,12 @@ jobs:
             **/CMakeError.log
             **/CMakeOutput.log
             **/crash_diagnostics/*
+      - uses: actions/upload-artifact@26f96dfa697d77e81fd5907df203aa23a56210a8 # v4.3.0
+        if: success() && matrix.config == 'generic-cxx26'
+        with:
+          name: libcxx-install
+          path: |
+            install/**
   stage2:
     if: github.repository_owner == 'llvm'
     runs-on: libcxx-runners-8-set

--- a/.github/workflows/libcxx-build-and-test.yaml
+++ b/.github/workflows/libcxx-build-and-test.yaml
@@ -87,7 +87,7 @@ jobs:
         with:
           name: libcxx-install
           path: |
-            install/**
+            build/generic-cxx26/install/**
   stage2:
     if: github.repository_owner == 'llvm'
     runs-on: libcxx-runners-8-set


### PR DESCRIPTION
This artifact is only added for the Clang C++26 configuration.
The idea is to use these artifacts in other bits of the workflows,
or in other tools outside of github (I'm imagining a compiler explorer
instance that allows comparing the libc++ in the pull request with
the head version)

To be more concrete, one use case is "testing as we ship". Currently
all of the workflows build the library using the same compiler
(and sometimes dialect?) that they test with. This isn't representative
to how libc++ is built and used in the wild. We should consider
if we want to build the library once, in a blessed configuration,
and then tests it against the battery of compilers & configurations
we support.

Right now, this is just an experiment.
