### PR TITLE
[Bazel] Generate LLVM_HAS_XYZ_TARGET macros in llvm config

### DIFF
--- a/utils/bazel/llvm-project-overlay/llvm/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/llvm/BUILD.bazel
@@ -164,6 +164,10 @@ td_library(
     includes = ["include"],
 )
 
+llvm_config_target_defines = [
+  "LLVM_HAS_{}_TARGET=1".format(t) for t in llvm_targets
+]
+
 cc_library(
     name = "config",
     hdrs = [
@@ -171,7 +175,7 @@ cc_library(
         "include/llvm/Config/llvm-config.h",
     ],
     copts = llvm_copts,
-    defines = llvm_config_defines,
+    defines = llvm_config_defines + llvm_config_target_defines,
     includes = ["include"],
     textual_hdrs = [
         "include/llvm/Config/AsmParsers.def",


### PR DESCRIPTION
Otherwise code that depends on those targets being enabled might not get compiled correctly even if the targets are explicitly included in the configuration (in my case NVVM target for MLIR).