### PR TITLE
[flang] Adjust new warnings for extensions

### DIFF
--- a/flang/lib/Semantics/check-declarations.cpp
+++ b/flang/lib/Semantics/check-declarations.cpp
@@ -731,14 +731,13 @@ void CheckHelper::CheckObjectEntity(
         }
       } else if (!IsIntentInOut(symbol)) { // C1586
         messages_.Say(
-            "non-POINTER dummy argument of pure %s must have INTENT() or VALUE attribute"_warn_en_US,
+            "non-POINTER dummy argument of pure %s must have INTENT() or VALUE attribute"_err_en_US,
             what);
         ok = false;
       }
-      if (ok && InFunction()) {
+      if (ok && InFunction() && !InModuleFile() && !InElemental()) {
         if (context_.IsEnabled(common::LanguageFeature::RelaxedPureDummy)) {
-          if (context_.ShouldWarn(common::LanguageFeature::RelaxedPureDummy) &&
-              !InModuleFile() && !InElemental()) {
+          if (context_.ShouldWarn(common::LanguageFeature::RelaxedPureDummy)) {
             messages_.Say(
                 "non-POINTER dummy argument of pure function should be INTENT(IN) or VALUE"_warn_en_US);
           }

--- a/flang/test/Semantics/call10.f90
+++ b/flang/test/Semantics/call10.f90
@@ -53,7 +53,7 @@ module m
     real, value :: a ! ok
   end function
   pure real function f03(a) ! C1583
-    !ERROR: non-POINTER dummy argument of pure function must have INTENT() or VALUE attribute
+    !WARNING: non-POINTER dummy argument of pure function must have INTENT() or VALUE attribute
     real :: a
   end function
   pure real function f03a(a)
@@ -83,7 +83,7 @@ module m
   end function
 
   pure subroutine s01(a) ! C1586
-    !ERROR: non-POINTER dummy argument of pure subroutine must have INTENT() or VALUE attribute
+    !WARNING: non-POINTER dummy argument of pure subroutine must have INTENT() or VALUE attribute
     real :: a
   end subroutine
   pure subroutine s01a(a)


### PR DESCRIPTION
Prevent messages from module files, respect the language feature flags when enabling the relaxed PURE dummy argument checking, and check that the new warnings are enabled.