### PR TITLE
[ROCDL] Add the global.atomic.fadd intrinsic in ROCDL

### DIFF
--- a/mlir/include/mlir/Dialect/LLVMIR/ROCDLOps.td
+++ b/mlir/include/mlir/Dialect/LLVMIR/ROCDLOps.td
@@ -165,7 +165,7 @@ def ROCDL_BallotOp :
   let summary = "Vote across thread group";
 
   let description = [{
-      Ballot provides a bit mask containing the 1-bit predicate value from each lane. 
+      Ballot provides a bit mask containing the 1-bit predicate value from each lane.
       The nth bit of the result contains the 1 bit contributed by the nth warp lane.
   }];
 
@@ -516,7 +516,7 @@ def ROCDL_RawBufferAtomicCmpSwap :
 }
 
 //===---------------------------------------------------------------------===//
-// MI-100 and MI-200 buffer atomic floating point add intrinsic
+// MI-100, MI-200 and MI-300 global/buffer atomic floating point add intrinsic
 
 def ROCDL_RawBufferAtomicFAddOp :
   ROCDL_Op<"raw.buffer.atomic.fadd">,
@@ -530,6 +530,19 @@ def ROCDL_RawBufferAtomicFAddOp :
       createIntrinsicCall(builder,
           llvm::Intrinsic::amdgcn_raw_buffer_atomic_fadd, {$vdata, $rsrc,
             $offset, $soffset, $aux}, {vdataType});
+  }];
+  let hasCustomAssemblyFormat = 1;
+}
+
+def ROCDL_GlobalAtomicFAddOp :
+  ROCDL_Op<"global.atomic.fadd">,
+  Arguments<(ins LLVM_Type:$ptr,
+                 LLVM_Type:$vdata)>{
+  string llvmBuilder = [{
+      auto vdataType = moduleTranslation.convertType(op.getVdata().getType());
+      auto ptrType = moduleTranslation.convertType(op.getPtr().getType());
+      createIntrinsicCall(builder,
+          llvm::Intrinsic::amdgcn_global_atomic_fadd, {$ptr, $vdata}, {vdataType, ptrType, vdataType});
   }];
   let hasCustomAssemblyFormat = 1;
 }

--- a/mlir/include/mlir/Dialect/LLVMIR/ROCDLOps.td
+++ b/mlir/include/mlir/Dialect/LLVMIR/ROCDLOps.td
@@ -165,7 +165,7 @@ def ROCDL_BallotOp :
   let summary = "Vote across thread group";
 
   let description = [{
-      Ballot provides a bit mask containing the 1-bit predicate value from each lane.
+      Ballot provides a bit mask containing the 1-bit predicate value from each lane. 
       The nth bit of the result contains the 1 bit contributed by the nth warp lane.
   }];
 

--- a/mlir/include/mlir/Dialect/LLVMIR/ROCDLOps.td
+++ b/mlir/include/mlir/Dialect/LLVMIR/ROCDLOps.td
@@ -535,17 +535,12 @@ def ROCDL_RawBufferAtomicFAddOp :
   let hasCustomAssemblyFormat = 1;
 }
 
-def ROCDL_GlobalAtomicFAddOp :
-  ROCDL_Op<"global.atomic.fadd">,
-  Arguments<(ins ROCDLGlobalPtr:$ptr,
-                 LLVM_Type:$vdata)>{
-  string llvmBuilder = [{
-      auto vdataType = moduleTranslation.convertType(op.getVdata().getType());
-      auto ptrType = moduleTranslation.convertType(op.getPtr().getType());
-      createIntrinsicCall(builder,
-          llvm::Intrinsic::amdgcn_global_atomic_fadd, {$ptr, $vdata}, {vdataType, ptrType, vdataType});
-  }];
-  let assemblyFormat = "operands attr-dict `:` type($vdata)";
+def ROCDL_GlobalAtomicFAddOp:
+  ROCDL_IntrOp<"global.atomic.fadd",
+    [0], [0, 1], [AllTypesMatch<["res", "vdata"]>], 1>,
+    Arguments<(ins ROCDLGlobalPtr:$ptr,
+                  LLVM_Type:$vdata)>{
+  let assemblyFormat = "operands attr-dict `:` type($res)";
 }
 
 //===---------------------------------------------------------------------===//

--- a/mlir/include/mlir/Dialect/LLVMIR/ROCDLOps.td
+++ b/mlir/include/mlir/Dialect/LLVMIR/ROCDLOps.td
@@ -342,6 +342,7 @@ def ROCDL_wmma_i32_16x16x16_iu4 : ROCDL_Wmma_IntrOp<"wmma.i32.16x16x16.iu4", [1]
 //===---------------------------------------------------------------------===//
 
 def ROCDLBufferRsrc : LLVM_PointerInAddressSpace<8>;
+def ROCDLGlobalPtr: LLVM_PointerInAddressSpace<1>;
 
 def ROCDL_MakeBufferRsrcOp :
   ROCDL_IntrOp<"make.buffer.rsrc", [], [0], [Pure], 1>,
@@ -516,7 +517,7 @@ def ROCDL_RawBufferAtomicCmpSwap :
 }
 
 //===---------------------------------------------------------------------===//
-// MI-100, MI-200 and MI-300 global/buffer atomic floating point add intrinsic
+// gfx9x global/buffer atomic floating point add intrinsics
 
 def ROCDL_RawBufferAtomicFAddOp :
   ROCDL_Op<"raw.buffer.atomic.fadd">,
@@ -536,7 +537,7 @@ def ROCDL_RawBufferAtomicFAddOp :
 
 def ROCDL_GlobalAtomicFAddOp :
   ROCDL_Op<"global.atomic.fadd">,
-  Arguments<(ins LLVM_Type:$ptr,
+  Arguments<(ins ROCDLGlobalPtr:$ptr,
                  LLVM_Type:$vdata)>{
   string llvmBuilder = [{
       auto vdataType = moduleTranslation.convertType(op.getVdata().getType());
@@ -544,7 +545,7 @@ def ROCDL_GlobalAtomicFAddOp :
       createIntrinsicCall(builder,
           llvm::Intrinsic::amdgcn_global_atomic_fadd, {$ptr, $vdata}, {vdataType, ptrType, vdataType});
   }];
-  let hasCustomAssemblyFormat = 1;
+  let assemblyFormat = "operands attr-dict `:` type($vdata)";
 }
 
 //===---------------------------------------------------------------------===//

--- a/mlir/lib/Dialect/LLVMIR/IR/ROCDLDialect.cpp
+++ b/mlir/lib/Dialect/LLVMIR/IR/ROCDLDialect.cpp
@@ -158,6 +158,26 @@ void RawBufferAtomicFAddOp::print(mlir::OpAsmPrinter &p) {
 }
 
 // <operation> ::=
+//     `llvm.amdgcn.global.atomic.fadd.* %vdata, %ptr
+ParseResult GlobalAtomicFAddOp::parse(OpAsmParser &parser,
+                                      OperationState &result) {
+  SmallVector<OpAsmParser::UnresolvedOperand, 5> ops;
+  Type type;
+  if (parser.parseOperandList(ops, 2) || parser.parseColonType(type))
+    return failure();
+
+  auto ptrType = LLVM::LLVMPointerType::get(parser.getContext());
+  if (parser.resolveOperands(ops, {ptrType, type}, parser.getNameLoc(),
+                             result.operands))
+    return failure();
+  return success();
+}
+
+void GlobalAtomicFAddOp::print(mlir::OpAsmPrinter &p) {
+  p << " " << getOperands() << " : " << getVdata().getType();
+}
+
+// <operation> ::=
 //     `llvm.amdgcn.raw.buffer.atomic.fmax.* %vdata, %rsrc,  %offset,
 //     %soffset, %aux : result_type`
 ParseResult RawBufferAtomicFMaxOp::parse(OpAsmParser &parser,

--- a/mlir/lib/Dialect/LLVMIR/IR/ROCDLDialect.cpp
+++ b/mlir/lib/Dialect/LLVMIR/IR/ROCDLDialect.cpp
@@ -158,26 +158,6 @@ void RawBufferAtomicFAddOp::print(mlir::OpAsmPrinter &p) {
 }
 
 // <operation> ::=
-//     `llvm.amdgcn.global.atomic.fadd.* %vdata, %ptr
-ParseResult GlobalAtomicFAddOp::parse(OpAsmParser &parser,
-                                      OperationState &result) {
-  SmallVector<OpAsmParser::UnresolvedOperand, 5> ops;
-  Type type;
-  if (parser.parseOperandList(ops, 2) || parser.parseColonType(type))
-    return failure();
-
-  auto ptrType = LLVM::LLVMPointerType::get(parser.getContext());
-  if (parser.resolveOperands(ops, {ptrType, type}, parser.getNameLoc(),
-                             result.operands))
-    return failure();
-  return success();
-}
-
-void GlobalAtomicFAddOp::print(mlir::OpAsmPrinter &p) {
-  p << " " << getOperands() << " : " << getVdata().getType();
-}
-
-// <operation> ::=
 //     `llvm.amdgcn.raw.buffer.atomic.fmax.* %vdata, %rsrc,  %offset,
 //     %soffset, %aux : result_type`
 ParseResult RawBufferAtomicFMaxOp::parse(OpAsmParser &parser,

--- a/mlir/test/Target/LLVMIR/rocdl.mlir
+++ b/mlir/test/Target/LLVMIR/rocdl.mlir
@@ -494,6 +494,15 @@ llvm.func @rocdl.raw.buffer.atomic.f32(%rsrc : vector<4xi32>,
   llvm.return
 }
 
+// CHECK-LABEL: rocdl.global.atomic
+llvm.func @rocdl.global.atomic(%vdata0 : f32, %vdata1 : vector<2xf16>, %ptr : !llvm.ptr) {
+  // CHECK: call float @llvm.amdgcn.global.atomic.fadd.f32.p0.f32(ptr %{{.*}}, float %{{.*}}
+  rocdl.global.atomic.fadd %ptr, %vdata0: f32
+  // CHECK: call <2 x half> @llvm.amdgcn.global.atomic.fadd.v2f16.p0.v2f16(ptr %{{.*}}, <2 x half> %{{.*}})
+  rocdl.global.atomic.fadd %ptr, %vdata1: vector<2xf16>
+  llvm.return
+}
+
 llvm.func @rocdl.raw.buffer.atomic.i32(%rsrc : vector<4xi32>,
                         %offset : i32, %soffset : i32,
                         %vdata1 : i32) {

--- a/mlir/test/Target/LLVMIR/rocdl.mlir
+++ b/mlir/test/Target/LLVMIR/rocdl.mlir
@@ -495,10 +495,10 @@ llvm.func @rocdl.raw.buffer.atomic.f32(%rsrc : vector<4xi32>,
 }
 
 // CHECK-LABEL: rocdl.global.atomic
-llvm.func @rocdl.global.atomic(%vdata0 : f32, %vdata1 : vector<2xf16>, %ptr : !llvm.ptr) {
-  // CHECK: call float @llvm.amdgcn.global.atomic.fadd.f32.p0.f32(ptr %{{.*}}, float %{{.*}}
+llvm.func @rocdl.global.atomic(%vdata0 : f32, %vdata1 : vector<2xf16>, %ptr : !llvm.ptr<1>) {
+  // CHECK: call float @llvm.amdgcn.global.atomic.fadd.f32.p1.f32(ptr addrspace(1) %{{.*}}, float %{{.*}}
   rocdl.global.atomic.fadd %ptr, %vdata0: f32
-  // CHECK: call <2 x half> @llvm.amdgcn.global.atomic.fadd.v2f16.p0.v2f16(ptr %{{.*}}, <2 x half> %{{.*}})
+  // CHECK: call <2 x half> @llvm.amdgcn.global.atomic.fadd.v2f16.p1.v2f16(ptr addrspace(1) %{{.*}}, <2 x half> %{{.*}})
   rocdl.global.atomic.fadd %ptr, %vdata1: vector<2xf16>
   llvm.return
 }


### PR DESCRIPTION
This PR adds the `global.atomic.fadd` intrinsic in ROCDL (which supports `f32` and `vector<2xf16>`)