### PR TITLE
[llvm-reduce] Remove DIGlobalVariableExpressions from DICompileUnit's globals

### DIFF
--- a/llvm/test/tools/llvm-reduce/remove-debug-info-nodes.ll
+++ b/llvm/test/tools/llvm-reduce/remove-debug-info-nodes.ll
@@ -2,7 +2,7 @@
 ; DICompileUnit and DISuprogram.
 ;
 ; RUN: llvm-reduce --delta-passes=di-metadata --abort-on-invalid-reduction --test FileCheck --test-arg --check-prefixes=CHECK-INTERESTINGNESS --test-arg %s --test-arg --input-file %s -o %t
-; RUN: FileCheck <%t --enable-var-scope %s
+; RUN: FileCheck <%t --enable-var-scope %s --implicit-check-not=DIGlobalVariableExpression
 
 ; CHECK-INTERESTINGNESS: define void @test() !dbg [[SUBPROG:![0-9]+]]
 ; CHECK-INTERESTINGNESS: !llvm.module.flags = !{
@@ -15,18 +15,15 @@
 ; CHECK-INTERESTINGNESS-DAG: [[SUBPROG]] = distinct !DISubprogram(name: "test",
 
 
-
 ; CHECK: define void @test() !dbg [[SUBPROG:![0-9]+]]
 ; CHECK: !llvm.module.flags = !{
 
 ; CHECK: !llvm.dbg.cu = !{[[CU:.+]]}
 
-; CHECK-DAG: [[CU]] = distinct !DICompileUnit(language: DW_LANG_C99,{{.*}}, retainedTypes: [[TYPES:![0-9]+]], globals: [[GLOBALS:![0-9]+]]
+; CHECK-DAG: [[CU]] = distinct !DICompileUnit(language: DW_LANG_C99,{{.*}}, retainedTypes: [[TYPES:![0-9]+]], globals: [[EMPTY:![0-9]+]]
 ; CHECK-DAG: [[EMPTY:![0-9]+]] = !{}
 ; CHECK-DAG: [[TYPES]] = !{[[T0:![0-9]+]]
 ; CHECK-DAG: [[T0]] = !DIBasicType(name: "unsigned int",
-; CHECK-DAG: [[GLOBALS]] = !{{{![0-9]+}}
-
 ; CHECK-DAG: [[SUBPROG]] = distinct !DISubprogram(name: "test", {{.*}}retainedNodes: [[EMPTY]])
 
 define void @test() !dbg !17 {

--- a/llvm/test/tools/llvm-reduce/remove-debug-info-nodes.ll
+++ b/llvm/test/tools/llvm-reduce/remove-debug-info-nodes.ll
@@ -15,13 +15,14 @@
 ; CHECK-INTERESTINGNESS-DAG: [[SUBPROG]] = distinct !DISubprogram(name: "test",
 
 
+
 ; CHECK: define void @test() !dbg [[SUBPROG:![0-9]+]]
 ; CHECK: !llvm.module.flags = !{
 
 ; CHECK: !llvm.dbg.cu = !{[[CU:.+]]}
 
 ; CHECK-DAG: [[CU]] = distinct !DICompileUnit(language: DW_LANG_C99,{{.*}}, retainedTypes: [[TYPES:![0-9]+]], globals: [[EMPTY:![0-9]+]]
-; CHECK-DAG: [[EMPTY:![0-9]+]] = !{}
+; CHECK-DAG: [[EMPTY]] = !{}
 ; CHECK-DAG: [[TYPES]] = !{[[T0:![0-9]+]]
 ; CHECK-DAG: [[T0]] = !DIBasicType(name: "unsigned int",
 ; CHECK-DAG: [[SUBPROG]] = distinct !DISubprogram(name: "test", {{.*}}retainedNodes: [[EMPTY]])

--- a/llvm/tools/llvm-reduce/deltas/ReduceDIMetadata.cpp
+++ b/llvm/tools/llvm-reduce/deltas/ReduceDIMetadata.cpp
@@ -65,12 +65,14 @@ void identifyUninterestingMDNodes(Oracle &O, MDNodeList &MDs) {
     SmallVector<Metadata *, 16> TN;
     for (size_t I = 0; I < Tup->getNumOperands(); ++I) {
       // Ignore any operands that are not DebugInfo metadata nodes.
-      if (isa_and_nonnull<DINode>(Tup->getOperand(I)))
-        // Don't add uninteresting operands to the tuple.
-        if (!O.shouldKeep())
-          continue;
-
-      TN.push_back(Tup->getOperand(I));
+      if (Metadata *Op = Tup->getOperand(I).get()) {
+        if (isa<DINode>(Op) || isa<DIGlobalVariableExpression>(Op)) {
+          // Don't add uninteresting operands to the tuple.
+          if (!O.shouldKeep())
+            continue;
+        }
+        TN.push_back(Op);
+      }
     }
     if (TN.size() != Tup->getNumOperands())
       DbgNode->replaceOperandWith(OpIdx, DbgNode->get(DbgNode->getContext(), TN));

--- a/llvm/tools/llvm-reduce/deltas/ReduceDIMetadata.cpp
+++ b/llvm/tools/llvm-reduce/deltas/ReduceDIMetadata.cpp
@@ -66,11 +66,10 @@ void identifyUninterestingMDNodes(Oracle &O, MDNodeList &MDs) {
     for (size_t I = 0; I < Tup->getNumOperands(); ++I) {
       // Ignore any operands that are not DebugInfo metadata nodes.
       if (Metadata *Op = Tup->getOperand(I).get()) {
-        if (isa<DINode>(Op) || isa<DIGlobalVariableExpression>(Op)) {
+        if (isa<DINode>(Op) || isa<DIGlobalVariableExpression>(Op))
           // Don't add uninteresting operands to the tuple.
           if (!O.shouldKeep())
             continue;
-        }
         TN.push_back(Op);
       }
     }


### PR DESCRIPTION
The 'metadata' delta pass will remove !dbg attachments from globals (which are DIGlobalVariableExpression nodes). The DIGlobalVariableExpressions don't get eliminated from the IR however if they are still referenced by the globals field in DICompileUnit.

Teach the 'di-metadata' pass to try removing global variable operands from metadata tuples as well as DINodes.