### PR TITLE
[bazel][windows] Add ntdll linkopt for Support

### DIFF
--- a/utils/bazel/llvm-project-overlay/llvm/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/llvm/BUILD.bazel
@@ -287,6 +287,7 @@ cc_library(
     linkopts = select({
         "@platforms//os:windows": [
             "ws2_32.lib",
+            "ntdll.lib",
         ],
         "@platforms//os:freebsd": [
             "-pthread",


### PR DESCRIPTION
Mirror the cmake change in cb7690af09b95bb944baf1b5a9ffb18f86c12130

```
lld-link: error: undefined symbol: __declspec(dllimport) RtlGetLastNtStatus
>>> referenced by Support.lib(ErrorHandling.obj):(class std::error_code __cdecl llvm::mapLastWindowsError(void))
```