### PR TITLE
[IR] Remove the possibility of ConstantExpr having fast-math flags.

### DIFF
--- a/llvm/include/llvm/IR/Operator.h
+++ b/llvm/include/llvm/IR/Operator.h
@@ -330,8 +330,6 @@ public:
     unsigned Opcode;
     if (auto *I = dyn_cast<Instruction>(V))
       Opcode = I->getOpcode();
-    else if (auto *CE = dyn_cast<ConstantExpr>(V))
-      Opcode = CE->getOpcode();
     else
       return false;
 


### PR DESCRIPTION
This possibility was added in https://reviews.llvm.org/D34303 to resolve some assertion failures with cases where FP math operations got constant-folded in constant expressions. However, at no point did the IR representation allow for expressing fast-math flags on constant expressions.

With the change of https://github.com/llvm/llvm-project/pull/93038, there are no longer any constant expressions capable of being FP math operators, and thus FPMathOperator can go back to being Instruction-only.