### PR TITLE
[NFC][libc++][test][AIX] fix SIMD test XFAIL for clang before 19

### DIFF
--- a/libcxx/test/std/experimental/simd/simd.class/simd_copy.pass.cpp
+++ b/libcxx/test/std/experimental/simd/simd.class/simd_copy.pass.cpp
@@ -8,9 +8,9 @@
 
 // UNSUPPORTED: c++03, c++11, c++14
 
-// FIXME: Fatal error with following targets (remove XFAIL when fixed):
+// Older versions of clang may encounter a backend error (see 0295c2ad):
 //   Pass-by-value arguments with alignment greater than register width are not supported.
-// XFAIL: target=powerpc{{.*}}-ibm-aix7.2.5.7
+// XFAIL: target=powerpc{{.*}}-ibm-{{.*}} && (clang-17 || clang-18)
 
 // <experimental/simd>
 //


### PR DESCRIPTION
058e4454 added an XFAIL for this test on AIX because of a backend limitation. That backend limitation
has been resolved by 0295c2ad and will be available for clang 19, so we should update the test to
limit the XFAIL to clang versions before that.