### PR TITLE
[lldb/crashlog] Add `--no-parallel-image-loading` hidden flag

### DIFF
--- a/lldb/examples/python/crashlog.py
+++ b/lldb/examples/python/crashlog.py
@@ -555,11 +555,15 @@ class CrashLog(symbolication.Symbolicator):
 
         futures = []
         with tempfile.TemporaryDirectory() as obj_dir:
-            with concurrent.futures.ThreadPoolExecutor() as executor:
 
-                def add_module(image, target, obj_dir):
-                    return image, image.add_module(target, obj_dir)
+            def add_module(image, target, obj_dir):
+                return image, image.add_module(target, obj_dir)
 
+            max_worker = None
+            if options.no_parallel_image_loading:
+                max_worker = 1
+
+            with concurrent.futures.ThreadPoolExecutor(max_worker) as executor:
                 for image in images_to_load:
                     if image not in loaded_images:
                         if image.uuid == uuid.UUID(int=0):
@@ -1528,6 +1532,7 @@ def load_crashlog_in_scripted_process(debugger, crashlog_path, options, result):
                 "file_path": crashlog_path,
                 "load_all_images": options.load_all_images,
                 "crashed_only": options.crashed_only,
+                "no_parallel_image_loading": options.no_parallel_image_loading,
             }
         )
     )
@@ -1718,6 +1723,13 @@ def CreateSymbolicateCrashLogOptions(
         action="store_true",
         dest="source_all",
         help="show source for all threads, not just the crashed thread",
+        default=False,
+    )
+    arg_parser.add_argument(
+        "--no-parallel-image-loading",
+        dest="no_parallel_image_loading",
+        action="store_true",
+        help=argparse.SUPPRESS,
         default=False,
     )
     if add_interactive_options:

--- a/lldb/examples/python/crashlog_scripted_process.py
+++ b/lldb/examples/python/crashlog_scripted_process.py
@@ -53,6 +53,7 @@ class CrashLogScriptedProcess(ScriptedProcess):
     class CrashLogOptions:
         load_all_images = False
         crashed_only = True
+        no_parallel_image_loading = False
 
     def __init__(self, exe_ctx: lldb.SBExecutionContext, args: lldb.SBStructuredData):
         super().__init__(exe_ctx, args)
@@ -83,6 +84,13 @@ class CrashLogScriptedProcess(ScriptedProcess):
         if crashed_only and crashed_only.IsValid():
             if crashed_only.GetType() == lldb.eStructuredDataTypeBoolean:
                 self.options.crashed_only = crashed_only.GetBooleanValue()
+
+        no_parallel_image_loading = args.GetValueForKey("no_parallel_image_loading")
+        if no_parallel_image_loading and no_parallel_image_loading.IsValid():
+            if no_parallel_image_loading.GetType() == lldb.eStructuredDataTypeBoolean:
+                self.options.no_parallel_image_loading = (
+                    no_parallel_image_loading.GetBooleanValue()
+                )
 
         self.pid = super().get_process_id()
         self.crashed_thread_idx = 0


### PR DESCRIPTION
This patch adds the `--no-parallel-image-loading` to the crashlog command. By default, image loading will happen in parallel in the crashlog script however, sometimes, when running tests or debugging the crashlog script itself, it's better to load the images sequentially.

As its name suggests, this flag will disable the default image loading behaviour to load all the images sequencially in the main thread.