### PR TITLE
[Driver] Rearrange some Apple version testing

### DIFF
--- a/clang/test/Driver/apple-os-triples.c
+++ b/clang/test/Driver/apple-os-triples.c
@@ -1,0 +1,31 @@
+// Test triple manipulations.
+
+// RUN: %clang -### -c %s \
+// RUN:     -target i386-apple-darwin10 -mappletvsimulator-version-min=9.0 -arch x86_64 2>&1 | \
+// RUN:     FileCheck %s -DARCH=x86_64 -DOS=tvos9.0.0-simulator
+// RUN: %clang -### -c %s \
+// RUN:     -target armv7s-apple-darwin10 -mappletvos-version-min=9.0 -arch arm64 2>&1 | \
+// RUN:     FileCheck %s -DARCH=arm64 -DOS=tvos9.0.0
+// RUN: env TVOS_DEPLOYMENT_TARGET=9.0 %clang -### -c %s \
+// RUN:     -isysroot SDKs/MacOSX10.9.sdk -target i386-apple-darwin10  -arch x86_64 2>&1 | \
+// RUN:     FileCheck %s -DARCH=x86_64 -DOS=tvos9.0.0
+
+// RUN: %clang -### -c %s \
+// RUN:     -target x86_64-apple-driverkit19.0 2>&1 | \
+// RUN:     FileCheck %s -DARCH=x86_64 -DOS=driverkit19.0.0
+
+// RUN: %clang -### -c %s \
+// RUN:     -target i386-apple-darwin10 -miphonesimulator-version-min=7.0 -arch i386 2>&1 | \
+// RUN:     FileCheck %s -DARCH=i386 -DOS=ios7.0.0-simulator
+// RUN: %clang -### -c %s \
+// RUN:     -target armv7s-apple-darwin10 -miphoneos-version-min=7.0 -arch armv7s 2>&1 | \
+// RUN:     FileCheck %s -DARCH=thumbv7s -DOS=ios7.0.0
+
+// RUN: %clang -### -c %s \
+// RUN:     -target i386-apple-darwin10 -mwatchsimulator-version-min=2.0 -arch i386 2>&1 | \
+// RUN:     FileCheck %s -DARCH=i386 -DOS=watchos2.0.0-simulator
+// RUN: %clang -### -c %s \
+// RUN:     -target armv7s-apple-darwin10 -mwatchos-version-min=2.0 -arch armv7k 2>&1 | \
+// RUN:     FileCheck %s -DARCH=thumbv7k -DOS=watchos2.0.0
+
+// CHECK: "-cc1" "-triple" "[[ARCH]]-apple-[[OS]]"

--- a/clang/test/Driver/apple-os-triples.c
+++ b/clang/test/Driver/apple-os-triples.c
@@ -1,31 +1,31 @@
 // Test triple manipulations.
 
 // RUN: %clang -### -c %s \
-// RUN:     -target i386-apple-darwin10 -mappletvsimulator-version-min=9.0 -arch x86_64 2>&1 | \
-// RUN:     FileCheck %s -DARCH=x86_64 -DOS=tvos9.0.0-simulator
+// RUN:   --target=i386-apple-darwin10 -mappletvsimulator-version-min=9.0 -arch x86_64 2>&1 | \
+// RUN:   FileCheck %s -DARCH=x86_64 -DOS=tvos9.0.0-simulator
 // RUN: %clang -### -c %s \
-// RUN:     -target armv7s-apple-darwin10 -mappletvos-version-min=9.0 -arch arm64 2>&1 | \
-// RUN:     FileCheck %s -DARCH=arm64 -DOS=tvos9.0.0
+// RUN:   --target=armv7s-apple-darwin10 -mappletvos-version-min=9.0 -arch arm64 2>&1 | \
+// RUN:   FileCheck %s -DARCH=arm64 -DOS=tvos9.0.0
 // RUN: env TVOS_DEPLOYMENT_TARGET=9.0 %clang -### -c %s \
-// RUN:     -isysroot SDKs/MacOSX10.9.sdk -target i386-apple-darwin10  -arch x86_64 2>&1 | \
-// RUN:     FileCheck %s -DARCH=x86_64 -DOS=tvos9.0.0
+// RUN:   -isysroot SDKs/MacOSX10.9.sdk -target i386-apple-darwin10  -arch x86_64 2>&1 | \
+// RUN:   FileCheck %s -DARCH=x86_64 -DOS=tvos9.0.0
 
 // RUN: %clang -### -c %s \
-// RUN:     -target x86_64-apple-driverkit19.0 2>&1 | \
-// RUN:     FileCheck %s -DARCH=x86_64 -DOS=driverkit19.0.0
+// RUN:   --target=x86_64-apple-driverkit19.0 2>&1 | \
+// RUN:   FileCheck %s -DARCH=x86_64 -DOS=driverkit19.0.0
 
 // RUN: %clang -### -c %s \
-// RUN:     -target i386-apple-darwin10 -miphonesimulator-version-min=7.0 -arch i386 2>&1 | \
-// RUN:     FileCheck %s -DARCH=i386 -DOS=ios7.0.0-simulator
+// RUN:   --target=i386-apple-darwin10 -miphonesimulator-version-min=7.0 -arch i386 2>&1 | \
+// RUN:   FileCheck %s -DARCH=i386 -DOS=ios7.0.0-simulator
 // RUN: %clang -### -c %s \
-// RUN:     -target armv7s-apple-darwin10 -miphoneos-version-min=7.0 -arch armv7s 2>&1 | \
-// RUN:     FileCheck %s -DARCH=thumbv7s -DOS=ios7.0.0
+// RUN:   --target=armv7s-apple-darwin10 -miphoneos-version-min=7.0 -arch armv7s 2>&1 | \
+// RUN:   FileCheck %s -DARCH=thumbv7s -DOS=ios7.0.0
 
 // RUN: %clang -### -c %s \
-// RUN:     -target i386-apple-darwin10 -mwatchsimulator-version-min=2.0 -arch i386 2>&1 | \
-// RUN:     FileCheck %s -DARCH=i386 -DOS=watchos2.0.0-simulator
+// RUN:   --target=i386-apple-darwin10 -mwatchsimulator-version-min=2.0 -arch i386 2>&1 | \
+// RUN:   FileCheck %s -DARCH=i386 -DOS=watchos2.0.0-simulator
 // RUN: %clang -### -c %s \
-// RUN:     -target armv7s-apple-darwin10 -mwatchos-version-min=2.0 -arch armv7k 2>&1 | \
-// RUN:     FileCheck %s -DARCH=thumbv7k -DOS=watchos2.0.0
+// RUN:   --target=armv7s-apple-darwin10 -mwatchos-version-min=2.0 -arch armv7k 2>&1 | \
+// RUN:   FileCheck %s -DARCH=thumbv7k -DOS=watchos2.0.0
 
 // CHECK: "-cc1" "-triple" "[[ARCH]]-apple-[[OS]]"

--- a/clang/test/Driver/appletvos-version-min.c
+++ b/clang/test/Driver/appletvos-version-min.c
@@ -1,8 +1,0 @@
-// REQUIRES: x86-registered-target
-// REQUIRES: aarch64-registered-target
-// RUN: %clang -target i386-apple-darwin10 -mappletvsimulator-version-min=9.0 -arch x86_64 -S -o - %s | FileCheck %s
-// RUN: %clang -target armv7s-apple-darwin10 -mappletvos-version-min=9.0 -arch arm64 -S -o - %s | FileCheck %s
-// RUN: env TVOS_DEPLOYMENT_TARGET=9.0 %clang -isysroot SDKs/MacOSX10.9.sdk -target i386-apple-darwin10  -arch x86_64 -S -o - %s | FileCheck %s
-
-int main() { return 0; }
-// CHECK: .tvos_version_min 9, 0

--- a/clang/test/Driver/driverkit-version-min.c
+++ b/clang/test/Driver/driverkit-version-min.c
@@ -1,5 +1,0 @@
-// REQUIRES: x86-registered-target
-// RUN: %clang -target x86_64-apple-driverkit19.0 -S -o - %s | FileCheck %s
-
-int main() { return 0; }
-// CHECK: .build_version driverkit, 19, 0

--- a/clang/test/Driver/ios-version-min.c
+++ b/clang/test/Driver/ios-version-min.c
@@ -1,7 +1,0 @@
-// REQUIRES: x86-registered-target
-// REQUIRES: arm-registered-target
-// RUN: %clang -target i386-apple-darwin10 -miphonesimulator-version-min=7.0 -arch i386 -S -o - %s | FileCheck %s
-// RUN: %clang -target armv7s-apple-darwin10 -miphoneos-version-min=7.0 -arch armv7s -S -o - %s | FileCheck %s
-
-int main() { return 0; }
-// CHECK: .ios_version_min 7, 0

--- a/clang/test/Driver/watchos-version-min.c
+++ b/clang/test/Driver/watchos-version-min.c
@@ -1,7 +1,0 @@
-// REQUIRES: x86-registered-target
-// REQUIRES: arm-registered-target
-// RUN: %clang -target i386-apple-darwin10 -mwatchsimulator-version-min=2.0 -arch i386 -S -o - %s | FileCheck %s
-// RUN: %clang -target armv7s-apple-darwin10 -mwatchos-version-min=2.0 -arch armv7k -S -o - %s | FileCheck %s
-
-int main() { return 0; }
-// CHECK: .watchos_version_min 2, 0

--- a/llvm/test/CodeGen/ARM/apple-version-min.ll
+++ b/llvm/test/CodeGen/ARM/apple-version-min.ll
@@ -1,0 +1,9 @@
+; Test emitting version_min directives.
+
+; RUN: llc %s -filetype=asm -o - --mtriple arm64-apple-tvos9.0.0 | FileCheck %s --check-prefix=TVOS
+; RUN: llc %s -filetype=asm -o - --mtriple thumbv7s-apple-ios7.0.0 | FileCheck %s --check-prefix=IOS
+; RUN: llc %s -filetype=asm -o - --mtriple thumbv7k-apple-watchos2.0.0 | FileCheck %s --check-prefix=WATCHOS
+
+; TVOS: .tvos_version_min 9, 0
+; IOS: .ios_version_min 7, 0
+; WATCHOS: .watchos_version_min 2, 0

--- a/llvm/test/CodeGen/X86/apple-version-min.ll
+++ b/llvm/test/CodeGen/X86/apple-version-min.ll
@@ -1,0 +1,12 @@
+; Test emitting version_min directives.
+
+; RUN: llc %s -filetype=asm -o - --mtriple x86_64-apple-tvos9.0.0-simulator | FileCheck %s --check-prefix=TVOS
+; RUN: llc %s -filetype=asm -o - --mtriple x86_64-apple-tvos9.0.0 | FileCheck %s --check-prefix=TVOS
+; RUN: llc %s -filetype=asm -o - --mtriple x86_64-apple-driverkit19.0.0 | FileCheck %s --check-prefix=DRIVERKIT
+; RUN: llc %s -filetype=asm -o - --mtriple i386-apple-ios7.0.0-simulator | FileCheck %s --check-prefix=IOS
+; RUN: llc %s -filetype=asm -o - --mtriple i386-apple-watchos2.0.0-simulator | FileCheck %s --check-prefix=WATCHOS
+
+; TVOS: .tvos_version_min 9, 0
+; DRIVERKIT: .build_version driverkit, 19, 0
+; IOS: .ios_version_min 7, 0
+; WATCHOS: .watchos_version_min 2, 0


### PR DESCRIPTION
There were four tests in Driver that actually tested bits of Driver and bits of CodeGen, and therefore had target restrictions. Rework those four tests into one Driver test (with no target restrictions) and two target-specific CodeGen tests.