### PR TITLE
[lldb/crashlog] Use environment variable to manually set dsymForUUIDBinary

### DIFF
--- a/lldb/examples/python/crashlog.py
+++ b/lldb/examples/python/crashlog.py
@@ -284,7 +284,9 @@ class CrashLog(symbolication.Symbolicator):
         """Class that represents a binary images in a darwin crash log"""
 
         dsymForUUIDBinary = "/usr/local/bin/dsymForUUID"
-        if not os.path.exists(dsymForUUIDBinary):
+        if "LLDB_APPLE_DSYMFORUUID_EXECUTABLE" in os.environ:
+            dsymForUUIDBinary = os.environ["LLDB_APPLE_DSYMFORUUID_EXECUTABLE"]
+        elif not os.path.exists(dsymForUUIDBinary):
             try:
                 dsymForUUIDBinary = (
                     subprocess.check_output("which dsymForUUID", shell=True)

--- a/lldb/test/Shell/ScriptInterpreter/Python/Crashlog/lit.local.cfg
+++ b/lldb/test/Shell/ScriptInterpreter/Python/Crashlog/lit.local.cfg
@@ -3,3 +3,5 @@ if 'system-darwin' not in config.available_features:
 
 if 'lldb-repro' in config.available_features:
   config.unsupported = True
+
+config.environment["LLDB_APPLE_DSYMFORUUID_EXECUTABLE"] = ""


### PR DESCRIPTION
In lldb, users can change the `dsymForUUID` binary using the `LLDB_APPLE_DSYMFORUUID_EXECUTABLE` environment variable.

This patch changes the crashlog to support the same behaviour as lldb and uses this environment variable to disable `dsymForUUID` lookups in crashlog test by having it be empty. Since CI bots shoudn't have access to images on build records, it doesn't make sense to make use of `dsymForUUID` in tests.

rdar://128953725