### PR TITLE
[clang] NFCI: Make ASTContext optional in the AST text dumper again

### DIFF
--- a/clang/lib/AST/TextNodeDumper.cpp
+++ b/clang/lib/AST/TextNodeDumper.cpp
@@ -958,6 +958,9 @@ void TextNodeDumper::dumpTemplateArgument(const TemplateArgument &TA) {
   }
   OS << " '" << Str << "'";
 
+  if (!Context)
+    return;
+
   if (TemplateArgument CanonTA = Context->getCanonicalTemplateArgument(TA);
       !CanonTA.structurallyEquals(TA)) {
     llvm::SmallString<128> CanonStr;
@@ -1139,15 +1142,17 @@ void TextNodeDumper::dumpTemplateName(TemplateName TN, StringRef Label) {
       }
       OS << " '" << Str << "'";
 
-      if (TemplateName CanonTN = Context->getCanonicalTemplateName(TN);
-          CanonTN != TN) {
-        llvm::SmallString<128> CanonStr;
-        {
-          llvm::raw_svector_ostream SS(CanonStr);
-          CanonTN.print(SS, PrintPolicy);
+      if (Context) {
+        if (TemplateName CanonTN = Context->getCanonicalTemplateName(TN);
+            CanonTN != TN) {
+          llvm::SmallString<128> CanonStr;
+          {
+            llvm::raw_svector_ostream SS(CanonStr);
+            CanonTN.print(SS, PrintPolicy);
+          }
+          if (CanonStr != Str)
+            OS << ":'" << CanonStr << "'";
         }
-        if (CanonStr != Str)
-          OS << ":'" << CanonStr << "'";
       }
     }
     dumpBareTemplateName(TN);

--- a/clang/lib/AST/Type.cpp
+++ b/clang/lib/AST/Type.cpp
@@ -4444,7 +4444,6 @@ static CachedProperties computeCachedProperties(const Type *T) {
 #define NON_CANONICAL_UNLESS_DEPENDENT_TYPE(Class,Base) case Type::Class:
 #include "clang/AST/TypeNodes.inc"
     // Treat instantiation-dependent types as external.
-    if (!T->isInstantiationDependentType()) T->dump();
     assert(T->isInstantiationDependentType());
     return CachedProperties(Linkage::External, false);
 


### PR DESCRIPTION
Previous patches 3cabbf60393cc8d55fe635e35e89e5973162de33 and 1a2f3309765fdc143fdc3809211fb85d2e2ca341 broke the assumption that the AST Context was optional for the text node dumper.

While missing an ASTContext makes some helpful information unavailable, the pure `dump` overloads taking no parameters are quite convenient for quick debugging, so let's make that work again.