### PR TITLE
[llvm][ScheduleDAG] Set a fixed size for Sched::Preference

### DIFF
--- a/llvm/include/llvm/CodeGen/TargetLowering.h
+++ b/llvm/include/llvm/CodeGen/TargetLowering.h
@@ -96,7 +96,7 @@ class Value;
 
 namespace Sched {
 
-enum Preference {
+enum Preference : uint8_t {
   None,        // No preference
   Source,      // Follow source order.
   RegPressure, // Scheduling for lowest register pressure.


### PR DESCRIPTION
This trims off 8 bytes from llvm::SUnit:
```
--- before	2024-06-05 12:13:00
+++ after	2024-06-05 12:12:58
@@ -1,65 +1,65 @@
 *** Dumping AST Record Layout
          0 | class llvm::SUnit
          0 |   SDNode * Node
          8 |   MachineInstr * Instr
         16 |   SUnit * OrigNode
         24 |   const MCSchedClassDesc * SchedClass
         32 |   class llvm::SmallVector<class llvm::SDep, 4> Preds
         32 |     class llvm::SmallVectorImpl<class llvm::SDep> (base)
         32 |       class llvm::SmallVectorTemplateBase<class llvm::SDep> (base)
         32 |         class llvm::SmallVectorTemplateCommon<class llvm::SDep> (base)
         32 |           class llvm::SmallVectorBase<uint32_t> (base)
         32 |             void * BeginX
         40 |             unsigned int Size
         44 |             unsigned int Capacity
         48 |     struct llvm::SmallVectorStorage<class llvm::SDep, 4> (base)
         48 |       char[64] InlineElts
        112 |   class llvm::SmallVector<class llvm::SDep, 4> Succs
        112 |     class llvm::SmallVectorImpl<class llvm::SDep> (base)
        112 |       class llvm::SmallVectorTemplateBase<class llvm::SDep> (base)
        112 |         class llvm::SmallVectorTemplateCommon<class llvm::SDep> (base)
        112 |           class llvm::SmallVectorBase<uint32_t> (base)
        112 |             void * BeginX
        120 |             unsigned int Size
        124 |             unsigned int Capacity
        128 |     struct llvm::SmallVectorStorage<class llvm::SDep, 4> (base)
        128 |       char[64] InlineElts
        192 |   unsigned int NodeNum
        196 |   unsigned int NodeQueueId
        200 |   unsigned int NumPreds
        204 |   unsigned int NumSuccs
        208 |   unsigned int NumPredsLeft
        212 |   unsigned int NumSuccsLeft
        216 |   unsigned int WeakPredsLeft
        220 |   unsigned int WeakSuccsLeft
        224 |   unsigned short NumRegDefsLeft
        226 |   unsigned short Latency
    228:0-0 |   _Bool isVRegCycle
    228:1-1 |   _Bool isCall
    228:2-2 |   _Bool isCallOp
    228:3-3 |   _Bool isTwoAddress
    228:4-4 |   _Bool isCommutable
    228:5-5 |   _Bool hasPhysRegUses
    228:6-6 |   _Bool hasPhysRegDefs
    228:7-7 |   _Bool hasPhysRegClobbers
    229:0-0 |   _Bool isPending
    229:1-1 |   _Bool isAvailable
    229:2-2 |   _Bool isScheduled
    229:3-3 |   _Bool isScheduleHigh
    229:4-4 |   _Bool isScheduleLow
    229:5-5 |   _Bool isCloned
    229:6-6 |   _Bool isUnbuffered
    229:7-7 |   _Bool hasReservedResource
-       232 |   Sched::Preference SchedulingPref
-   236:0-0 |   _Bool isDepthCurrent
-   236:1-1 |   _Bool isHeightCurrent
-       240 |   unsigned int Depth
-       244 |   unsigned int Height
-       248 |   unsigned int TopReadyCycle
-       252 |   unsigned int BotReadyCycle
-       256 |   const TargetRegisterClass * CopyDstRC
-       264 |   const TargetRegisterClass * CopySrcRC
-           | [sizeof=272, dsize=272, align=8,
-           |  nvsize=272, nvalign=8]
+       230 |   Sched::Preference SchedulingPref
+   231:0-0 |   _Bool isDepthCurrent
+   231:1-1 |   _Bool isHeightCurrent
+       232 |   unsigned int Depth
+       236 |   unsigned int Height
+       240 |   unsigned int TopReadyCycle
+       244 |   unsigned int BotReadyCycle
+       248 |   const TargetRegisterClass * CopyDstRC
+       256 |   const TargetRegisterClass * CopySrcRC
+           | [sizeof=264, dsize=264, align=8,
+           |  nvsize=264, nvalign=8]
```