### PR TITLE
[clang-tidy] Improve bugprone-multi-level-implicit-pointer-conversion

### DIFF
--- a/clang-tools-extra/clang-tidy/bugprone/MultiLevelImplicitPointerConversionCheck.cpp
+++ b/clang-tools-extra/clang-tidy/bugprone/MultiLevelImplicitPointerConversionCheck.cpp
@@ -48,12 +48,21 @@ AST_MATCHER(ImplicitCastExpr, isMultiLevelPointerConversion) {
   return SourcePtrLevel != TargetPtrLevel;
 }
 
+AST_MATCHER(QualType, isPointerType) {
+  const QualType Type =
+      Node.getCanonicalType().getNonReferenceType().getUnqualifiedType();
+
+  return !Type.isNull() && Type->isPointerType();
+}
+
 } // namespace
 
 void MultiLevelImplicitPointerConversionCheck::registerMatchers(
     MatchFinder *Finder) {
   Finder->addMatcher(
-      implicitCastExpr(hasCastKind(CK_BitCast), isMultiLevelPointerConversion())
+      implicitCastExpr(hasCastKind(CK_BitCast), isMultiLevelPointerConversion(),
+                       unless(hasParent(explicitCastExpr(
+                           hasDestinationType(isPointerType())))))
           .bind("expr"),
       this);
 }

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -218,6 +218,10 @@ Changes in existing checks
   check by ignoring ``__func__`` macro in lambda captures, initializers of
   default parameters and nested function declarations.
 
+- Improved :doc:`bugprone-multi-level-implicit-pointer-conversion
+  <clang-tidy/checks/bugprone/multi-level-implicit-pointer-conversion>` check
+  by ignoring implicit pointer conversions that are part of a cast expression.
+
 - Improved :doc:`bugprone-non-zero-enum-to-bool-conversion
   <clang-tidy/checks/bugprone/non-zero-enum-to-bool-conversion>` check by
   eliminating false positives resulting from direct usage of bitwise operators

--- a/clang-tools-extra/test/clang-tidy/checkers/bugprone/multi-level-implicit-pointer-conversion.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/bugprone/multi-level-implicit-pointer-conversion.cpp
@@ -63,3 +63,15 @@ void test()
 
   takeSecondLevelVoidPtr(getSecondLevelVoidPtr());
 }
+
+namespace PR93959 {
+  void free(void*);
+
+  void test() {
+    char **p = nullptr;
+    free(p);
+    // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: multilevel pointer conversion from 'char **' to 'void *', please use explicit cast [bugprone-multi-level-implicit-pointer-conversion]
+    free((void *)p);
+    free(static_cast<void *>(p));
+  }
+}


### PR DESCRIPTION
Ignore implicit pointer conversions that are part of a cast expression

Closes #93959