### PR TITLE
[lldb] [NFC] Rewrite TestRedefinitionsInInlines.py as an API test

### DIFF
--- a/lldb/test/API/lang/c/inlines/Makefile
+++ b/lldb/test/API/lang/c/inlines/Makefile
@@ -1,0 +1,3 @@
+C_SOURCES := main.c 
+
+include Makefile.rules

--- a/lldb/test/API/lang/c/inlines/TestRedefinitionsInInlines.py
+++ b/lldb/test/API/lang/c/inlines/TestRedefinitionsInInlines.py
@@ -1,14 +1,61 @@
-from lldbsuite.test import lldbinline
-from lldbsuite.test import decorators
+"""Test that inlined argument variables have their correct location in debuginfo"""
 
-lldbinline.MakeInlineTest(
-    __file__,
-    globals(),
-    [
-        decorators.expectedFailureAll(
-            compiler="clang",
-            compiler_version=["<", "3.5"],
-            bugnumber="llvm.org/pr27845",
+import lldb
+from lldbsuite.test.decorators import *
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test import lldbutil
+
+
+class TestRedefinitionsInInlines(TestBase):
+
+    # https://github.com/llvm/llvm-project/issues/28219
+    @skipIf(compiler="clang", compiler_version=["<", "3.5"])
+    def test(self):
+        self.source = "main.c"
+        self.build()
+        (target, process, thread, bp1) = lldbutil.run_to_source_breakpoint(
+            self, "first breakpoint", lldb.SBFileSpec(self.source, False)
         )
-    ],
-)
+
+        bp2 = target.BreakpointCreateBySourceRegex(
+            "second breakpoint", lldb.SBFileSpec(self.source, False)
+        )
+        bp3 = target.BreakpointCreateBySourceRegex(
+            "third breakpoint", lldb.SBFileSpec(self.source, False)
+        )
+
+        # When called from main(), test2 is passed in the value of 42 in 'b'
+        self.expect("expression b", DATA_TYPES_DISPLAYED_CORRECTLY, substrs=["42"])
+
+        process.Continue()
+
+        self.assertState(process.GetState(), lldb.eStateStopped)
+        thread = lldbutil.get_stopped_thread(process, lldb.eStopReasonBreakpoint)
+        self.assertIsNotNone(thread)
+        bp_id = thread.GetStopReasonDataAtIndex(0)
+        self.assertEqual(bp_id, bp2.GetID())
+
+        self.expect("expression b", DATA_TYPES_DISPLAYED_CORRECTLY, substrs=["42"])
+        self.expect("expression c", DATA_TYPES_DISPLAYED_CORRECTLY, substrs=["84"])
+
+        process.Continue()
+
+        # Now we're in test1(), and the first thing it does is call test2(24).  "Step in"
+        # and check that we have the value 24 as the argument.
+        self.assertState(process.GetState(), lldb.eStateStopped)
+        thread = lldbutil.get_stopped_thread(process, lldb.eStopReasonBreakpoint)
+        self.assertIsNotNone(thread)
+        bp_id = thread.GetStopReasonDataAtIndex(0)
+        self.assertEqual(bp_id, bp3.GetID())
+
+        frame = thread.GetFrameAtIndex(0)
+        self.assertTrue(frame.IsInlined())
+        self.assertEqual(frame.GetFunctionName(), "test1")
+
+        thread.StepInto()
+
+        frame = thread.GetFrameAtIndex(0)
+        self.assertTrue(frame.IsInlined())
+        self.assertEqual(frame.GetFunctionName(), "test2")
+
+        self.expect("expression b", DATA_TYPES_DISPLAYED_CORRECTLY, substrs=["24"])

--- a/lldb/test/API/lang/c/inlines/TestRedefinitionsInInlines.py
+++ b/lldb/test/API/lang/c/inlines/TestRedefinitionsInInlines.py
@@ -7,7 +7,6 @@ from lldbsuite.test import lldbutil
 
 
 class TestRedefinitionsInInlines(TestBase):
-
     # https://github.com/llvm/llvm-project/issues/28219
     @skipIf(compiler="clang", compiler_version=["<", "3.5"])
     def test(self):

--- a/lldb/test/API/lang/c/inlines/main.c
+++ b/lldb/test/API/lang/c/inlines/main.c
@@ -3,23 +3,22 @@
 inline void test1(int) __attribute__ ((always_inline));
 inline void test2(int) __attribute__ ((always_inline));
 
+// Called once from main with b==42 then called from test1 with b==24.
 void test2(int b) {
-    printf("test2(%d)\n", b); //% self.expect("expression b", DATA_TYPES_DISPLAYED_CORRECTLY, substrs = ["42"])
-    {
-      int c = b * 2;
-      printf("c=%d\n", c); //% self.expect("expression b", DATA_TYPES_DISPLAYED_CORRECTLY, substrs = ["42"])
-                           //% self.expect("expression c", DATA_TYPES_DISPLAYED_CORRECTLY, substrs = ["84"])
-    }
+  printf("test2(%d)\n", b); // first breakpoint
+  {
+    int c = b * 2;
+    printf("c=%d\n", c); // second breakpoint
+  }
 }
 
 void test1(int a) {
     printf("test1(%d)\n",  a);
-    test2(a+1);//% self.runCmd("step")
-               //% self.expect("expression b", DATA_TYPES_DISPLAYED_CORRECTLY, substrs = ["24"])
+    test2(a + 1); // third breakpoint
 }
 
-int main() {
-    test2(42);
-    test1(23);
-    return 0;
+int main(int argc) {
+  test2(42);
+  test1(23);
+  return 0;
 }


### PR DESCRIPTION
Rewrite an inline test as an API test, to be a little easier to debug, and add some additional checks that we're in the inlined test1, then step and we are now in the inlined test2 functions.