### PR TITLE
[lldb] Fix inconsistencies in DWARFExpression errors

### DIFF
--- a/lldb/source/Expression/DWARFExpression.cpp
+++ b/lldb/source/Expression/DWARFExpression.cpp
@@ -973,7 +973,7 @@ llvm::Expected<Value> DWARFExpression::Evaluate(
     case DW_OP_deref: {
       if (stack.empty())
         return llvm::createStringError(
-            "Expression stack empty for DW_OP_deref.");
+            "expression stack empty for DW_OP_deref");
       Value::ValueType value_type = stack.back().GetValueType();
       switch (value_type) {
       case Value::ValueType::HostAddress: {
@@ -1023,16 +1023,16 @@ llvm::Expected<Value> DWARFExpression::Evaluate(
                   pointer_addr, error.AsCString());
             }
           } else {
-            return llvm::createStringError("NULL process for DW_OP_deref.\n");
+            return llvm::createStringError("NULL process for DW_OP_deref");
           }
         } else {
           return llvm::createStringError(
-              "NULL execution context for DW_OP_deref.\n");
+              "NULL execution context for DW_OP_deref");
         }
         break;
 
       case Value::ValueType::Invalid:
-        return llvm::createStringError("Invalid value type for DW_OP_deref.\n");
+        return llvm::createStringError("invalid value type for DW_OP_deref");
       }
 
     } break;
@@ -1052,7 +1052,7 @@ llvm::Expected<Value> DWARFExpression::Evaluate(
     case DW_OP_deref_size: {
       if (stack.empty()) {
         return llvm::createStringError(
-            "Expression stack empty for DW_OP_deref_size.");
+            "expression stack empty for DW_OP_deref_size");
       }
       uint8_t size = opcodes.GetU8(&offset);
       if (size > 8) {
@@ -1164,18 +1164,17 @@ llvm::Expected<Value> DWARFExpression::Evaluate(
             }
           } else {
 
-            return llvm::createStringError(
-                "NULL process for DW_OP_deref_size.\n");
+            return llvm::createStringError("NULL process for DW_OP_deref_size");
           }
         } else {
           return llvm::createStringError(
-              "NULL execution context for DW_OP_deref_size.\n");
+              "NULL execution context for DW_OP_deref_size");
         }
         break;
 
       case Value::ValueType::Invalid:
 
-        return llvm::createStringError("Invalid value for DW_OP_deref_size.\n");
+        return llvm::createStringError("invalid value for DW_OP_deref_size");
       }
 
     } break;
@@ -1196,9 +1195,7 @@ llvm::Expected<Value> DWARFExpression::Evaluate(
     // extended to the size of an address on the target machine before being
     // pushed on the expression stack.
     case DW_OP_xderef_size:
-
-      return llvm::createStringError(
-          "Unimplemented opcode: DW_OP_xderef_size.");
+      return llvm::createStringError("unimplemented opcode: DW_OP_xderef_size");
     // OPCODE: DW_OP_xderef
     // OPERANDS: none
     // DESCRIPTION: Provides an extended dereference mechanism. The entry at
@@ -1210,7 +1207,7 @@ llvm::Expected<Value> DWARFExpression::Evaluate(
     // retrieved from the dereferenced address is the size of an address on the
     // target machine.
     case DW_OP_xderef:
-      return llvm::createStringError("Unimplemented opcode: DW_OP_xderef.");
+      return llvm::createStringError("unimplemented opcode: DW_OP_xderef");
 
     // All DW_OP_constXXX opcodes have a single operand as noted below:
     //
@@ -1263,7 +1260,7 @@ llvm::Expected<Value> DWARFExpression::Evaluate(
     // DESCRIPTION: duplicates the value at the top of the stack
     case DW_OP_dup:
       if (stack.empty()) {
-        return llvm::createStringError("Expression stack empty for DW_OP_dup.");
+        return llvm::createStringError("expression stack empty for DW_OP_dup");
       } else
         stack.push_back(stack.back());
       break;
@@ -1273,8 +1270,7 @@ llvm::Expected<Value> DWARFExpression::Evaluate(
     // DESCRIPTION: pops the value at the top of the stack
     case DW_OP_drop:
       if (stack.empty()) {
-        return llvm::createStringError(
-            "Expression stack empty for DW_OP_drop.");
+        return llvm::createStringError("expression stack empty for DW_OP_drop");
       } else
         stack.pop_back();
       break;
@@ -1286,7 +1282,7 @@ llvm::Expected<Value> DWARFExpression::Evaluate(
     case DW_OP_over:
       if (stack.size() < 2) {
         return llvm::createStringError(
-            "Expression stack needs at least 2 items for DW_OP_over.");
+            "expression stack needs at least 2 items for DW_OP_over");
       } else
         stack.push_back(stack[stack.size() - 2]);
       break;
@@ -1313,7 +1309,7 @@ llvm::Expected<Value> DWARFExpression::Evaluate(
     case DW_OP_swap:
       if (stack.size() < 2) {
         return llvm::createStringError(
-            "Expression stack needs at least 2 items for DW_OP_swap.");
+            "expression stack needs at least 2 items for DW_OP_swap");
       } else {
         tmp = stack.back();
         stack.back() = stack[stack.size() - 2];
@@ -1330,7 +1326,7 @@ llvm::Expected<Value> DWARFExpression::Evaluate(
     case DW_OP_rot:
       if (stack.size() < 3) {
         return llvm::createStringError(
-            "Expression stack needs at least 3 items for DW_OP_rot.");
+            "expression stack needs at least 3 items for DW_OP_rot");
       } else {
         size_t last_idx = stack.size() - 1;
         Value old_top = stack[last_idx];
@@ -1348,10 +1344,10 @@ llvm::Expected<Value> DWARFExpression::Evaluate(
     case DW_OP_abs:
       if (stack.empty()) {
         return llvm::createStringError(
-            "Expression stack needs at least 1 item for DW_OP_abs.");
+            "expression stack needs at least 1 item for DW_OP_abs");
       } else if (!stack.back().ResolveValue(exe_ctx).AbsoluteValue()) {
         return llvm::createStringError(
-            "Failed to take the absolute value of the first stack item.");
+            "failed to take the absolute value of the first stack item");
       }
       break;
 
@@ -1362,7 +1358,7 @@ llvm::Expected<Value> DWARFExpression::Evaluate(
     case DW_OP_and:
       if (stack.size() < 2) {
         return llvm::createStringError(
-            "Expression stack needs at least 2 items for DW_OP_and.");
+            "expression stack needs at least 2 items for DW_OP_and");
       } else {
         tmp = stack.back();
         stack.pop_back();
@@ -1379,23 +1375,22 @@ llvm::Expected<Value> DWARFExpression::Evaluate(
     case DW_OP_div:
       if (stack.size() < 2) {
         return llvm::createStringError(
-            "Expression stack needs at least 2 items for DW_OP_div.");
+            "expression stack needs at least 2 items for DW_OP_div");
       } else {
         tmp = stack.back();
-        if (tmp.ResolveValue(exe_ctx).IsZero()) {
-          return llvm::createStringError("Divide by zero.");
-        } else {
-          stack.pop_back();
-          Scalar divisor, dividend;
-          divisor = tmp.ResolveValue(exe_ctx);
-          dividend = stack.back().ResolveValue(exe_ctx);
-          divisor.MakeSigned();
-          dividend.MakeSigned();
-          stack.back() = dividend / divisor;
-          if (!stack.back().ResolveValue(exe_ctx).IsValid()) {
-            return llvm::createStringError("Divide failed.");
-          }
-        }
+        if (tmp.ResolveValue(exe_ctx).IsZero())
+          return llvm::createStringError("divide by zero");
+
+        stack.pop_back();
+        Scalar divisor, dividend;
+        divisor = tmp.ResolveValue(exe_ctx);
+        dividend = stack.back().ResolveValue(exe_ctx);
+        divisor.MakeSigned();
+        dividend.MakeSigned();
+        stack.back() = dividend / divisor;
+
+        if (!stack.back().ResolveValue(exe_ctx).IsValid())
+          return llvm::createStringError("divide failed");
       }
       break;
 
@@ -1406,7 +1401,7 @@ llvm::Expected<Value> DWARFExpression::Evaluate(
     case DW_OP_minus:
       if (stack.size() < 2) {
         return llvm::createStringError(
-            "Expression stack needs at least 2 items for DW_OP_minus.");
+            "expression stack needs at least 2 items for DW_OP_minus");
       } else {
         tmp = stack.back();
         stack.pop_back();
@@ -1423,7 +1418,7 @@ llvm::Expected<Value> DWARFExpression::Evaluate(
     case DW_OP_mod:
       if (stack.size() < 2) {
         return llvm::createStringError(
-            "Expression stack needs at least 2 items for DW_OP_mod.");
+            "expression stack needs at least 2 items for DW_OP_mod");
       } else {
         tmp = stack.back();
         stack.pop_back();
@@ -1439,7 +1434,7 @@ llvm::Expected<Value> DWARFExpression::Evaluate(
     case DW_OP_mul:
       if (stack.size() < 2) {
         return llvm::createStringError(
-            "Expression stack needs at least 2 items for DW_OP_mul.");
+            "expression stack needs at least 2 items for DW_OP_mul");
       } else {
         tmp = stack.back();
         stack.pop_back();
@@ -1454,10 +1449,10 @@ llvm::Expected<Value> DWARFExpression::Evaluate(
     case DW_OP_neg:
       if (stack.empty()) {
         return llvm::createStringError(
-            "Expression stack needs at least 1 item for DW_OP_neg.");
+            "expression stack needs at least 1 item for DW_OP_neg");
       } else {
         if (!stack.back().ResolveValue(exe_ctx).UnaryNegate())
-          return llvm::createStringError("Unary negate failed.");
+          return llvm::createStringError("unary negate failed");
       }
       break;
 
@@ -1468,10 +1463,10 @@ llvm::Expected<Value> DWARFExpression::Evaluate(
     case DW_OP_not:
       if (stack.empty()) {
         return llvm::createStringError(
-            "Expression stack needs at least 1 item for DW_OP_not.");
+            "expression stack needs at least 1 item for DW_OP_not");
       } else {
         if (!stack.back().ResolveValue(exe_ctx).OnesComplement()) {
-          return llvm::createStringError("Logical NOT failed.");
+          return llvm::createStringError("logical NOT failed");
         }
       }
       break;
@@ -1483,7 +1478,7 @@ llvm::Expected<Value> DWARFExpression::Evaluate(
     case DW_OP_or:
       if (stack.size() < 2) {
         return llvm::createStringError(
-            "Expression stack needs at least 2 items for DW_OP_or.");
+            "expression stack needs at least 2 items for DW_OP_or");
       } else {
         tmp = stack.back();
         stack.pop_back();
@@ -1499,7 +1494,7 @@ llvm::Expected<Value> DWARFExpression::Evaluate(
     case DW_OP_plus:
       if (stack.size() < 2) {
         return llvm::createStringError(
-            "Expression stack needs at least 2 items for DW_OP_plus.");
+            "expression stack needs at least 2 items for DW_OP_plus");
       } else {
         tmp = stack.back();
         stack.pop_back();
@@ -1514,15 +1509,13 @@ llvm::Expected<Value> DWARFExpression::Evaluate(
     case DW_OP_plus_uconst:
       if (stack.empty()) {
         return llvm::createStringError(
-            "Expression stack needs at least 1 item for DW_OP_plus_uconst.");
+            "expression stack needs at least 1 item for DW_OP_plus_uconst");
       } else {
         const uint64_t uconst_value = opcodes.GetULEB128(&offset);
         // Implicit conversion from a UINT to a Scalar...
         stack.back().GetScalar() += uconst_value;
-        if (!stack.back().GetScalar().IsValid()) {
-
-          return llvm::createStringError("DW_OP_plus_uconst failed.");
-        }
+        if (!stack.back().GetScalar().IsValid())
+          return llvm::createStringError("DW_OP_plus_uconst failed");
       }
       break;
 
@@ -1534,7 +1527,7 @@ llvm::Expected<Value> DWARFExpression::Evaluate(
     case DW_OP_shl:
       if (stack.size() < 2) {
         return llvm::createStringError(
-            "Expression stack needs at least 2 items for DW_OP_shl.");
+            "expression stack needs at least 2 items for DW_OP_shl");
       } else {
         tmp = stack.back();
         stack.pop_back();
@@ -1550,13 +1543,13 @@ llvm::Expected<Value> DWARFExpression::Evaluate(
     case DW_OP_shr:
       if (stack.size() < 2) {
         return llvm::createStringError(
-            "Expression stack needs at least 2 items for DW_OP_shr.");
+            "expression stack needs at least 2 items for DW_OP_shr");
       } else {
         tmp = stack.back();
         stack.pop_back();
         if (!stack.back().ResolveValue(exe_ctx).ShiftRightLogical(
                 tmp.ResolveValue(exe_ctx))) {
-          return llvm::createStringError("DW_OP_shr failed.");
+          return llvm::createStringError("DW_OP_shr failed");
         }
       }
       break;
@@ -1570,7 +1563,7 @@ llvm::Expected<Value> DWARFExpression::Evaluate(
     case DW_OP_shra:
       if (stack.size() < 2) {
         return llvm::createStringError(
-            "Expression stack needs at least 2 items for DW_OP_shra.");
+            "expression stack needs at least 2 items for DW_OP_shra");
       } else {
         tmp = stack.back();
         stack.pop_back();
@@ -1585,7 +1578,7 @@ llvm::Expected<Value> DWARFExpression::Evaluate(
     case DW_OP_xor:
       if (stack.size() < 2) {
         return llvm::createStringError(
-            "Expression stack needs at least 2 items for DW_OP_xor.");
+            "expression stack needs at least 2 items for DW_OP_xor");
       } else {
         tmp = stack.back();
         stack.pop_back();
@@ -1625,7 +1618,7 @@ llvm::Expected<Value> DWARFExpression::Evaluate(
     case DW_OP_bra:
       if (stack.empty()) {
         return llvm::createStringError(
-            "Expression stack needs at least 1 item for DW_OP_bra.");
+            "expression stack needs at least 1 item for DW_OP_bra");
       } else {
         tmp = stack.back();
         stack.pop_back();
@@ -1657,7 +1650,7 @@ llvm::Expected<Value> DWARFExpression::Evaluate(
     case DW_OP_eq:
       if (stack.size() < 2) {
         return llvm::createStringError(
-            "Expression stack needs at least 2 items for DW_OP_eq.");
+            "expression stack needs at least 2 items for DW_OP_eq");
       } else {
         tmp = stack.back();
         stack.pop_back();
@@ -1676,7 +1669,7 @@ llvm::Expected<Value> DWARFExpression::Evaluate(
     case DW_OP_ge:
       if (stack.size() < 2) {
         return llvm::createStringError(
-            "Expression stack needs at least 2 items for DW_OP_ge.");
+            "expression stack needs at least 2 items for DW_OP_ge");
       } else {
         tmp = stack.back();
         stack.pop_back();
@@ -1695,7 +1688,7 @@ llvm::Expected<Value> DWARFExpression::Evaluate(
     case DW_OP_gt:
       if (stack.size() < 2) {
         return llvm::createStringError(
-            "Expression stack needs at least 2 items for DW_OP_gt.");
+            "expression stack needs at least 2 items for DW_OP_gt");
       } else {
         tmp = stack.back();
         stack.pop_back();
@@ -1714,7 +1707,7 @@ llvm::Expected<Value> DWARFExpression::Evaluate(
     case DW_OP_le:
       if (stack.size() < 2) {
         return llvm::createStringError(
-            "Expression stack needs at least 2 items for DW_OP_le.");
+            "expression stack needs at least 2 items for DW_OP_le");
       } else {
         tmp = stack.back();
         stack.pop_back();
@@ -1733,7 +1726,7 @@ llvm::Expected<Value> DWARFExpression::Evaluate(
     case DW_OP_lt:
       if (stack.size() < 2) {
         return llvm::createStringError(
-            "Expression stack needs at least 2 items for DW_OP_lt.");
+            "expression stack needs at least 2 items for DW_OP_lt");
       } else {
         tmp = stack.back();
         stack.pop_back();
@@ -1752,7 +1745,7 @@ llvm::Expected<Value> DWARFExpression::Evaluate(
     case DW_OP_ne:
       if (stack.size() < 2) {
         return llvm::createStringError(
-            "Expression stack needs at least 2 items for DW_OP_ne.");
+            "expression stack needs at least 2 items for DW_OP_ne");
       } else {
         tmp = stack.back();
         stack.pop_back();
@@ -1944,11 +1937,11 @@ llvm::Expected<Value> DWARFExpression::Evaluate(
             return fb_err.ToError();
         } else {
           return llvm::createStringError(
-              "Invalid stack frame in context for DW_OP_fbreg opcode.");
+              "invalid stack frame in context for DW_OP_fbreg opcode");
         }
       } else {
         return llvm::createStringError(
-            "NULL execution context for DW_OP_fbreg.\n");
+            "NULL execution context for DW_OP_fbreg");
       }
 
       break;
@@ -2098,7 +2091,7 @@ llvm::Expected<Value> DWARFExpression::Evaluate(
         // Reset for the next piece.
         dwarf4_location_description_kind = Memory;
         return llvm::createStringError(
-            "Expression stack needs at least 1 item for DW_OP_bit_piece.");
+            "expression stack needs at least 1 item for DW_OP_bit_piece");
       } else {
         UpdateValueTypeFromLocationDescription(
             log, dwarf_cu, dwarf4_location_description_kind, &stack.back());
@@ -2109,7 +2102,7 @@ llvm::Expected<Value> DWARFExpression::Evaluate(
         switch (stack.back().GetValueType()) {
         case Value::ValueType::Invalid:
           return llvm::createStringError(
-              "unable to extract bit value from invalid value.");
+              "unable to extract bit value from invalid value");
         case Value::ValueType::Scalar: {
           if (!stack.back().GetScalar().ExtractBitfield(piece_bit_size,
                                                         piece_bit_offset)) {
@@ -2147,7 +2140,7 @@ llvm::Expected<Value> DWARFExpression::Evaluate(
 
       if (!data) {
         LLDB_LOG(log, "Evaluate_DW_OP_implicit_value: could not be read data");
-        return llvm::createStringError("Could not evaluate %s.",
+        return llvm::createStringError("could not evaluate %s",
                                        DW_OP_value_to_name(op));
       }
 
@@ -2198,7 +2191,7 @@ llvm::Expected<Value> DWARFExpression::Evaluate(
     // the stack by the called expression may be used as return values by prior
     // agreement between the calling and called expressions.
     case DW_OP_call2:
-      return llvm::createStringError("Unimplemented opcode DW_OP_call2.");
+      return llvm::createStringError("unimplemented opcode DW_OP_call2");
     // OPCODE: DW_OP_call4
     // OPERANDS: 1
     //      uint32_t compile unit relative offset of a DIE
@@ -2219,8 +2212,7 @@ llvm::Expected<Value> DWARFExpression::Evaluate(
     // the stack by the called expression may be used as return values by prior
     // agreement between the calling and called expressions.
     case DW_OP_call4:
-
-      return llvm::createStringError("Unimplemented opcode DW_OP_call4.");
+      return llvm::createStringError("unimplemented opcode DW_OP_call4");
 
     // OPCODE: DW_OP_stack_value
     // OPERANDS: None
@@ -2229,10 +2221,9 @@ llvm::Expected<Value> DWARFExpression::Evaluate(
     // value to be used.  This is the actual object value and not the location.
     case DW_OP_stack_value:
       dwarf4_location_description_kind = Implicit;
-      if (stack.empty()) {
+      if (stack.empty())
         return llvm::createStringError(
-            "Expression stack needs at least 1 item for DW_OP_stack_value.");
-      }
+            "expression stack needs at least 1 item for DW_OP_stack_value");
       stack.back().SetValueType(Value::ValueType::Scalar);
       break;
 
@@ -2246,7 +2237,7 @@ llvm::Expected<Value> DWARFExpression::Evaluate(
     case DW_OP_convert: {
       if (stack.size() < 1) {
         return llvm::createStringError(
-            "Expression stack needs at least 1 item for DW_OP_convert.");
+            "expression stack needs at least 1 item for DW_OP_convert");
       }
       const uint64_t die_offset = opcodes.GetULEB128(&offset);
       uint64_t bit_size;
@@ -2256,7 +2247,7 @@ llvm::Expected<Value> DWARFExpression::Evaluate(
         // machine and an unspecified signedness. Scalar has no
         // "unspecified signedness", so we use unsigned types.
         if (!module_sp)
-          return llvm::createStringError("No module");
+          return llvm::createStringError("no module");
         sign = false;
         bit_size = module_sp->GetArchitecture().GetAddressByteSize() * 8;
         if (!bit_size)
@@ -2269,7 +2260,7 @@ llvm::Expected<Value> DWARFExpression::Evaluate(
         DWARFDIE die = const_cast<DWARFUnit *>(dwarf_cu)->GetDIE(abs_die_offset);
         if (!die)
           return llvm::createStringError(
-              "Cannot resolve DW_OP_convert type DIE");
+              "cannot resolve DW_OP_convert type DIE");
         uint64_t encoding =
             die.GetAttributeValueAsUnsigned(DW_AT_encoding, DW_ATE_hi_user);
         bit_size = die.GetAttributeValueAsUnsigned(DW_AT_byte_size, 0) * 8;
@@ -2277,7 +2268,7 @@ llvm::Expected<Value> DWARFExpression::Evaluate(
           bit_size = die.GetAttributeValueAsUnsigned(DW_AT_bit_size, 0);
         if (!bit_size)
           return llvm::createStringError(
-              "Unsupported type size in DW_OP_convert");
+              "unsupported type size in DW_OP_convert");
         switch (encoding) {
         case DW_ATE_signed:
         case DW_ATE_signed_char:
@@ -2289,7 +2280,7 @@ llvm::Expected<Value> DWARFExpression::Evaluate(
           break;
         default:
           return llvm::createStringError(
-              "Unsupported encoding in DW_OP_convert");
+              "unsupported encoding in DW_OP_convert");
         }
       }
       Scalar &top = stack.back().ResolveValue(exe_ctx);
@@ -2313,13 +2304,13 @@ llvm::Expected<Value> DWARFExpression::Evaluate(
           stack.back().SetValueType(Value::ValueType::LoadAddress);
         } else {
           return llvm::createStringError(
-              "Stack frame does not include a canonical "
+              "stack frame does not include a canonical "
               "frame address for DW_OP_call_frame_cfa "
-              "opcode.");
+              "opcode");
         }
       } else {
-        return llvm::createStringError("Invalid stack frame in context for "
-                                       "DW_OP_call_frame_cfa opcode.");
+        return llvm::createStringError("unvalid stack frame in context for "
+                                       "DW_OP_call_frame_cfa opcode");
       }
       break;
 
@@ -2334,18 +2325,18 @@ llvm::Expected<Value> DWARFExpression::Evaluate(
       if (stack.size() < 1) {
         if (op == DW_OP_form_tls_address)
           return llvm::createStringError(
-              "DW_OP_form_tls_address needs an argument.");
+              "DW_OP_form_tls_address needs an argument");
         else
           return llvm::createStringError(
-              "DW_OP_GNU_push_tls_address needs an argument.");
+              "DW_OP_GNU_push_tls_address needs an argument");
       }
 
       if (!exe_ctx || !module_sp)
-        return llvm::createStringError("No context to evaluate TLS within.");
+        return llvm::createStringError("no context to evaluate TLS within");
 
       Thread *thread = exe_ctx->GetThreadPtr();
       if (!thread)
-        return llvm::createStringError("No thread to evaluate TLS within.");
+        return llvm::createStringError("no thread to evaluate TLS within");
 
       // Lookup the TLS block address for this thread and module.
       const addr_t tls_file_addr =
@@ -2355,7 +2346,7 @@ llvm::Expected<Value> DWARFExpression::Evaluate(
 
       if (tls_load_addr == LLDB_INVALID_ADDRESS)
         return llvm::createStringError(
-            "No TLS data currently exists for this thread.");
+            "no TLS data currently exists for this thread");
 
       stack.back().GetScalar() = tls_load_addr;
       stack.back().SetValueType(Value::ValueType::LoadAddress);
@@ -2430,7 +2421,7 @@ llvm::Expected<Value> DWARFExpression::Evaluate(
     if (pieces.GetBuffer().GetByteSize())
       return pieces;
 
-    return llvm::createStringError("Stack empty after evaluation.");
+    return llvm::createStringError("stack empty after evaluation");
   }
 
   UpdateValueTypeFromLocationDescription(


### PR DESCRIPTION
This patch make all errors start with a lowercase letter and removes trailing periods and newlines. This fixes inconsistencies between error messages and facilitate concatenating them.