### PR TITLE
[clang-format] Fix a bug in indenting lambda trailing arrows

### DIFF
--- a/clang/lib/Format/ContinuationIndenter.cpp
+++ b/clang/lib/Format/ContinuationIndenter.cpp
@@ -1457,6 +1457,11 @@ unsigned ContinuationIndenter::getNewLineColumn(const LineState &State) {
       !Current.isOneOf(tok::colon, tok::comment)) {
     return ContinuationIndent;
   }
+  if (Style.isCpp() && Current.is(tok::arrow) &&
+      Previous.isOneOf(tok::kw_noexcept, tok::kw_mutable, tok::kw_constexpr,
+                       tok::kw_consteval, tok::kw_static)) {
+    return ContinuationIndent;
+  }
   if (Current.is(TT_ProtoExtensionLSquare))
     return CurrentState.Indent;
   if (Current.isBinaryOperator() && CurrentState.UnindentOperator) {

--- a/clang/lib/Format/ContinuationIndenter.cpp
+++ b/clang/lib/Format/ContinuationIndenter.cpp
@@ -1457,7 +1457,7 @@ unsigned ContinuationIndenter::getNewLineColumn(const LineState &State) {
       !Current.isOneOf(tok::colon, tok::comment)) {
     return ContinuationIndent;
   }
-  if (Style.isCpp() && Current.is(tok::arrow) &&
+  if (Style.isCpp() && Current.is(TT_TrailingReturnArrow) &&
       Previous.isOneOf(tok::kw_noexcept, tok::kw_mutable, tok::kw_constexpr,
                        tok::kw_consteval, tok::kw_static)) {
     return ContinuationIndent;

--- a/clang/lib/Format/ContinuationIndenter.cpp
+++ b/clang/lib/Format/ContinuationIndenter.cpp
@@ -1257,6 +1257,11 @@ unsigned ContinuationIndenter::getNewLineColumn(const LineState &State) {
     }
     return CurrentState.Indent;
   }
+  if (Current.is(TT_TrailingReturnArrow) &&
+      Previous.isOneOf(tok::kw_noexcept, tok::kw_mutable, tok::kw_constexpr,
+                       tok::kw_consteval, tok::kw_static, TT_AttributeSquare)) {
+    return ContinuationIndent;
+  }
   if ((Current.isOneOf(tok::r_brace, tok::r_square) ||
        (Current.is(tok::greater) && (Style.isProto() || Style.isTableGen()))) &&
       State.Stack.size() > 1) {
@@ -1455,11 +1460,6 @@ unsigned ContinuationIndenter::getNewLineColumn(const LineState &State) {
       Previous.isNot(TT_TableGenDAGArgOperatorToBreak) &&
       !Current.isBinaryOperator() &&
       !Current.isOneOf(tok::colon, tok::comment)) {
-    return ContinuationIndent;
-  }
-  if (Current.is(TT_TrailingReturnArrow) &&
-      Previous.isOneOf(tok::kw_noexcept, tok::kw_mutable, tok::kw_constexpr,
-                       tok::kw_consteval, tok::kw_static)) {
     return ContinuationIndent;
   }
   if (Current.is(TT_ProtoExtensionLSquare))

--- a/clang/lib/Format/ContinuationIndenter.cpp
+++ b/clang/lib/Format/ContinuationIndenter.cpp
@@ -1457,7 +1457,7 @@ unsigned ContinuationIndenter::getNewLineColumn(const LineState &State) {
       !Current.isOneOf(tok::colon, tok::comment)) {
     return ContinuationIndent;
   }
-  if (Style.isCpp() && Current.is(TT_TrailingReturnArrow) &&
+  if (Current.is(TT_TrailingReturnArrow) &&
       Previous.isOneOf(tok::kw_noexcept, tok::kw_mutable, tok::kw_constexpr,
                        tok::kw_consteval, tok::kw_static)) {
     return ContinuationIndent;

--- a/clang/unittests/Format/FormatTest.cpp
+++ b/clang/unittests/Format/FormatTest.cpp
@@ -22858,6 +22858,31 @@ TEST_F(FormatTest, FormatsLambdas) {
       "      //\n"
       "    });");
 
+  verifyFormat("int main() {\n"
+               "  very_long_function_name_yes_it_is_really_long(\n"
+               "      [](auto n)\n"
+               "          -> std::unordered_map<very_long_type_name_A, "
+               "very_long_type_name_B> {\n"
+               "        really_do_something();\n"
+               "      });\n"
+               "}");
+  verifyFormat("int main() {\n"
+               "  very_long_function_name_yes_it_is_really_long(\n"
+               "      [](auto n) noexcept\n"
+               "          -> std::unordered_map<very_long_type_name_A, "
+               "very_long_type_name_B> {\n"
+               "        really_do_something();\n"
+               "      });\n"
+               "}");
+  verifyFormat("int main() {\n"
+               "  very_long_function_name_yes_it_is_really_long(\n"
+               "      [](auto n) constexpr\n"
+               "          -> std::unordered_map<very_long_type_name_A, "
+               "very_long_type_name_B> {\n"
+               "        really_do_something();\n"
+               "      });\n"
+               "}");
+
   FormatStyle DoNotMerge = getLLVMStyle();
   DoNotMerge.AllowShortLambdasOnASingleLine = FormatStyle::SLS_None;
   verifyFormat("auto c = []() {\n"

--- a/clang/unittests/Format/FormatTest.cpp
+++ b/clang/unittests/Format/FormatTest.cpp
@@ -22861,27 +22861,30 @@ TEST_F(FormatTest, FormatsLambdas) {
   verifyFormat("int main() {\n"
                "  very_long_function_name_yes_it_is_really_long(\n"
                "      [](auto n)\n"
-               "          -> std::unordered_map<very_long_type_name_A, "
-               "very_long_type_name_B> {\n"
+               "          -> std::unordered_map<very_long_type_name_A,\n"
+               "                                very_long_type_name_B> {\n"
                "        really_do_something();\n"
                "      });\n"
-               "}");
+               "}",
+               getLLVMStyleWithColumns(60));
   verifyFormat("int main() {\n"
                "  very_long_function_name_yes_it_is_really_long(\n"
                "      [](auto n) noexcept\n"
-               "          -> std::unordered_map<very_long_type_name_A, "
-               "very_long_type_name_B> {\n"
+               "          -> std::unordered_map<very_long_type_name_A,\n"
+               "                                very_long_type_name_B> {\n"
                "        really_do_something();\n"
                "      });\n"
-               "}");
+               "}",
+               getLLVMStyleWithColumns(60));
   verifyFormat("int main() {\n"
                "  very_long_function_name_yes_it_is_really_long(\n"
                "      [](auto n) constexpr\n"
-               "          -> std::unordered_map<very_long_type_name_A, "
-               "very_long_type_name_B> {\n"
+               "          -> std::unordered_map<very_long_type_name_A,\n"
+               "                                very_long_type_name_B> {\n"
                "        really_do_something();\n"
                "      });\n"
-               "}");
+               "}",
+               getLLVMStyleWithColumns(60));
 
   FormatStyle DoNotMerge = getLLVMStyle();
   DoNotMerge.AllowShortLambdasOnASingleLine = FormatStyle::SLS_None;

--- a/clang/unittests/Format/FormatTest.cpp
+++ b/clang/unittests/Format/FormatTest.cpp
@@ -22858,6 +22858,8 @@ TEST_F(FormatTest, FormatsLambdas) {
       "      //\n"
       "    });");
 
+  FormatStyle LLVMStyle = getLLVMStyleWithColumns(60);
+
   verifyFormat("int main() {\n"
                "  very_long_function_name_yes_it_is_really_long(\n"
                "      [](auto n)\n"
@@ -22866,7 +22868,7 @@ TEST_F(FormatTest, FormatsLambdas) {
                "        really_do_something();\n"
                "      });\n"
                "}",
-               getLLVMStyleWithColumns(60));
+               LLVMStyle);
   verifyFormat("int main() {\n"
                "  very_long_function_name_yes_it_is_really_long(\n"
                "      [](auto n) noexcept\n"
@@ -22875,7 +22877,7 @@ TEST_F(FormatTest, FormatsLambdas) {
                "        really_do_something();\n"
                "      });\n"
                "}",
-               getLLVMStyleWithColumns(60));
+               LLVMStyle);
   verifyFormat("int main() {\n"
                "  very_long_function_name_yes_it_is_really_long(\n"
                "      [](auto n) constexpr\n"
@@ -22884,7 +22886,7 @@ TEST_F(FormatTest, FormatsLambdas) {
                "        really_do_something();\n"
                "      });\n"
                "}",
-               getLLVMStyleWithColumns(60));
+               LLVMStyle);
 
   FormatStyle DoNotMerge = getLLVMStyle();
   DoNotMerge.AllowShortLambdasOnASingleLine = FormatStyle::SLS_None;

--- a/clang/unittests/Format/FormatTest.cpp
+++ b/clang/unittests/Format/FormatTest.cpp
@@ -22859,33 +22859,19 @@ TEST_F(FormatTest, FormatsLambdas) {
       "    });");
 
   FormatStyle LLVMStyle = getLLVMStyleWithColumns(60);
-
-  verifyFormat("int main() {\n"
-               "  very_long_function_name_yes_it_is_really_long(\n"
-               "      [](auto n)\n"
-               "          -> std::unordered_map<very_long_type_name_A,\n"
-               "                                very_long_type_name_B> {\n"
-               "        really_do_something();\n"
-               "      });\n"
-               "}",
+  verifyFormat("very_long_function_name_yes_it_is_really_long(\n"
+               "    [](auto n) noexcept [[back_attr]]\n"
+               "        -> std::unordered_map<very_long_type_name_A,\n"
+               "                              very_long_type_name_B> {\n"
+               "      really_do_something();\n"
+               "    });",
                LLVMStyle);
-  verifyFormat("int main() {\n"
-               "  very_long_function_name_yes_it_is_really_long(\n"
-               "      [](auto n) noexcept\n"
-               "          -> std::unordered_map<very_long_type_name_A,\n"
-               "                                very_long_type_name_B> {\n"
-               "        really_do_something();\n"
-               "      });\n"
-               "}",
-               LLVMStyle);
-  verifyFormat("int main() {\n"
-               "  very_long_function_name_yes_it_is_really_long(\n"
-               "      [](auto n) constexpr\n"
-               "          -> std::unordered_map<very_long_type_name_A,\n"
-               "                                very_long_type_name_B> {\n"
-               "        really_do_something();\n"
-               "      });\n"
-               "}",
+  verifyFormat("very_long_function_name_yes_it_is_really_long(\n"
+               "    [](auto n) constexpr\n"
+               "        -> std::unordered_map<very_long_type_name_A,\n"
+               "                              very_long_type_name_B> {\n"
+               "      really_do_something();\n"
+               "    });",
                LLVMStyle);
 
   FormatStyle DoNotMerge = getLLVMStyle();


### PR DESCRIPTION
Closes #94181