### PR TITLE
[libc][math] Temporarily disable nexttowardf16 on aarch64 due to clang-11 bug.

### DIFF
--- a/libc/config/linux/aarch64/entrypoints.txt
+++ b/libc/config/linux/aarch64/entrypoints.txt
@@ -516,7 +516,10 @@ if(LIBC_TYPES_HAS_FLOAT16)
     libc.src.math.nearbyintf16
     libc.src.math.nextafterf16
     libc.src.math.nextdownf16
-    libc.src.math.nexttowardf16
+    # Temporarily disable nexttowardf16 on aarch64 because the conversion
+    # between _Float16 and long double will crash clang-11.  This is fixed in
+    # clang-12 and after: https://godbolt.org/z/8ceT9454c
+    # libc.src.math.nexttowardf16
     libc.src.math.nextupf16
     libc.src.math.rintf16
     libc.src.math.roundf16


### PR DESCRIPTION
The conversion between _Float16 and long double will crash clang-11 on aarch64. This is fixed in clang-12: https://godbolt.org/z/8ceT9454c