### PR TITLE
[llvm/IR] Fix module build issue following e57308b063bb (NFC)

### DIFF
--- a/llvm/include/llvm/IR/IRBuilderFolder.h
+++ b/llvm/include/llvm/IR/IRBuilderFolder.h
@@ -15,6 +15,7 @@
 #define LLVM_IR_IRBUILDERFOLDER_H
 
 #include "llvm/ADT/ArrayRef.h"
+#include "llvm/IR/GEPNoWrapFlags.h"
 #include "llvm/IR/InstrTypes.h"
 #include "llvm/IR/Instruction.h"
 


### PR DESCRIPTION
This patch fixes a build issue following e57308b063bb when enabling
module build.

With that change, we failed to build the LLVM_IR module since
GEPNoWrapFlags wasn't defined prior to using it.

This patch addressed that issue by including the missing header in
`llvm/IR/IRBuilderFolder.h` which uses the `GEPNoWrapFlags` type.
This should ensure that we can always build the `LLVM_IR` module.

Signed-off-by: Med Ismail Bennani <ismail@bennani.ma>