### PR TITLE
[MLIR] Fix generic assembly syntax for ArrayAttr containing hex float

### DIFF
--- a/mlir/test/IR/array-of-attr.mlir
+++ b/mlir/test/IR/array-of-attr.mlir
@@ -12,3 +12,7 @@ test.array_of_attr_op
 // CHECK: test.array_of_attr_op
 // CHECK-SAME: a = [], b = [], c = []
 test.array_of_attr_op a = [], b = [], c = []
+
+// CHECK: "test.test_array_float"
+// CHECK-SAME: 1.000000e+00 : f32, 1.000000e+00, 0x7FF0000000000000 : f64
+"test.test_array_float"() {test.float_arr = [1.0 : f32, 1.0 : f64, 0x7FF0000000000000 : f64]} : () -> ()


### PR DESCRIPTION
When a float attribute is printed with Hex, we should not elide the type because it is parsed back as i64 otherwise.