### PR TITLE
[lldb] Disable TestPtyServer API test when remote testing

### DIFF
--- a/lldb/test/API/tools/lldb-server/TestPtyServer.py
+++ b/lldb/test/API/tools/lldb-server/TestPtyServer.py
@@ -7,6 +7,7 @@ from lldbgdbserverutils import *
 import xml.etree.ElementTree as ET
 
 
+@skipIfRemote
 @skipIf(hostoslist=["windows"])
 class PtyServerTestCase(gdbremote_testcase.GdbRemoteTestCaseBase):
     def setUp(self):


### PR DESCRIPTION
The local PTY is not available for the remotely executed lldb-server to pass the test. Also, in general, we cannot execute the local lldb-server instance because it could be compiled for the different system/cpu target.