### PR TITLE
[clang-tidy] Remove redundant LINK_LIBS

### DIFF
--- a/clang-tools-extra/clang-tidy/misc/CMakeLists.txt
+++ b/clang-tools-extra/clang-tidy/misc/CMakeLists.txt
@@ -43,7 +43,6 @@ add_clang_library(clangTidyMiscModule
   UseAnonymousNamespaceCheck.cpp
 
   LINK_LIBS
-  clangAnalysis
   clangTidy
   clangTidyUtils
 


### PR DESCRIPTION
clangAnalysis is already being pulled in via clang_target_link_libraries(). Also listing it in LINK_LIBS means that we'll link both against the static libraries and the shared libclang-cpp.so library if CLANG_LINK_CLANG_DYLIB is enabled, and waste time on unnecessary LTO.