### PR TITLE
[JITLink][LoongArch] Handle R_LARCH_GOT_PC_{HI20,LO12} fixups

### DIFF
--- a/llvm/include/llvm/ExecutionEngine/JITLink/loongarch.h
+++ b/llvm/include/llvm/ExecutionEngine/JITLink/loongarch.h
@@ -224,7 +224,8 @@ inline Error applyFixup(LinkGraph &G, Block &B, const Edge &E) {
   case Delta64:
     *(little64_t *)FixupPtr = TargetAddress - FixupAddress + Addend;
     break;
-  case Page20: {
+  case Page20:
+  case RequestGOTAndTransformToPage20: {
     uint64_t Target = TargetAddress + Addend;
     uint64_t TargetPage =
         (Target + (Target & 0x800)) & ~static_cast<uint64_t>(0xfff);
@@ -239,7 +240,8 @@ inline Error applyFixup(LinkGraph &G, Block &B, const Edge &E) {
     *(little32_t *)FixupPtr = RawInstr | Imm31_12;
     break;
   }
-  case PageOffset12: {
+  case PageOffset12:
+  case RequestGOTAndTransformToPageOffset12: {
     uint64_t TargetOffset = (TargetAddress + Addend) & 0xfff;
 
     uint32_t RawInstr = *(ulittle32_t *)FixupPtr;


### PR DESCRIPTION
In default,
RequestGOTAndTransformToPage20/RequestGOTAndTransformToPageOffset12 is transformed to Page20/PageOffset12. Only the latter are later handled when applying fixups, the former are simply ignored.

This patch proposes to handle RequestGOTAndTransformTo* anyway when applying fixups to support custom configurations. This enables GOT entries from the input binary can be reused, BOLT is one such example.