### PR TITLE
[LoongArch] Add a pass to rewrite rd to r0 for non-computational instrs whose return values are unused

### DIFF
--- a/llvm/lib/Target/LoongArch/CMakeLists.txt
+++ b/llvm/lib/Target/LoongArch/CMakeLists.txt
@@ -16,6 +16,7 @@ add_public_tablegen_target(LoongArchCommonTableGen)
 
 add_llvm_target(LoongArchCodeGen
   LoongArchAsmPrinter.cpp
+  LoongArchDeadRegisterDefinitions.cpp
   LoongArchExpandAtomicPseudoInsts.cpp
   LoongArchExpandPseudoInsts.cpp
   LoongArchFrameLowering.cpp

--- a/llvm/lib/Target/LoongArch/LoongArch.h
+++ b/llvm/lib/Target/LoongArch/LoongArch.h
@@ -33,12 +33,14 @@ bool lowerLoongArchMachineOperandToMCOperand(const MachineOperand &MO,
                                              MCOperand &MCOp,
                                              const AsmPrinter &AP);
 
+FunctionPass *createLoongArchDeadRegisterDefinitionsPass();
 FunctionPass *createLoongArchExpandAtomicPseudoPass();
 FunctionPass *createLoongArchISelDag(LoongArchTargetMachine &TM);
 FunctionPass *createLoongArchOptWInstrsPass();
 FunctionPass *createLoongArchPreRAExpandPseudoPass();
 FunctionPass *createLoongArchExpandPseudoPass();
 void initializeLoongArchDAGToDAGISelLegacyPass(PassRegistry &);
+void initializeLoongArchDeadRegisterDefinitionsPass(PassRegistry &);
 void initializeLoongArchExpandAtomicPseudoPass(PassRegistry &);
 void initializeLoongArchOptWInstrsPass(PassRegistry &);
 void initializeLoongArchPreRAExpandPseudoPass(PassRegistry &);

--- a/llvm/lib/Target/LoongArch/LoongArchDeadRegisterDefinitions.cpp
+++ b/llvm/lib/Target/LoongArch/LoongArchDeadRegisterDefinitions.cpp
@@ -1,0 +1,108 @@
+//=== LoongArchDeadRegisterDefinitions.cpp - Replace dead defs w/ zero reg ===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===---------------------------------------------------------------------===//
+//
+// This pass rewrites Rd to r0 for instrs whose return values are unused.
+//
+//===---------------------------------------------------------------------===//
+
+#include "LoongArch.h"
+#include "LoongArchInstrInfo.h"
+#include "LoongArchSubtarget.h"
+#include "llvm/ADT/Statistic.h"
+#include "llvm/CodeGen/LiveDebugVariables.h"
+#include "llvm/CodeGen/LiveIntervals.h"
+#include "llvm/CodeGen/LiveStacks.h"
+#include "llvm/CodeGen/MachineFunctionPass.h"
+#include "llvm/CodeGen/MachineRegisterInfo.h"
+
+using namespace llvm;
+#define DEBUG_TYPE "loongarch-dead-defs"
+#define LoongArch_DEAD_REG_DEF_NAME "LoongArch Dead register definitions"
+
+STATISTIC(NumDeadDefsReplaced, "Number of dead definitions replaced");
+
+namespace {
+class LoongArchDeadRegisterDefinitions : public MachineFunctionPass {
+public:
+  static char ID;
+
+  LoongArchDeadRegisterDefinitions() : MachineFunctionPass(ID) {}
+  bool runOnMachineFunction(MachineFunction &MF) override;
+  void getAnalysisUsage(AnalysisUsage &AU) const override {
+    AU.setPreservesCFG();
+    AU.addRequired<LiveIntervals>();
+    AU.addPreserved<LiveIntervals>();
+    AU.addRequired<LiveIntervals>();
+    AU.addPreserved<SlotIndexes>();
+    AU.addPreserved<LiveDebugVariables>();
+    AU.addPreserved<LiveStacks>();
+    MachineFunctionPass::getAnalysisUsage(AU);
+  }
+
+  StringRef getPassName() const override { return LoongArch_DEAD_REG_DEF_NAME; }
+};
+} // end anonymous namespace
+
+char LoongArchDeadRegisterDefinitions::ID = 0;
+INITIALIZE_PASS(LoongArchDeadRegisterDefinitions, DEBUG_TYPE,
+                LoongArch_DEAD_REG_DEF_NAME, false, false)
+
+FunctionPass *llvm::createLoongArchDeadRegisterDefinitionsPass() {
+  return new LoongArchDeadRegisterDefinitions();
+}
+
+bool LoongArchDeadRegisterDefinitions::runOnMachineFunction(
+    MachineFunction &MF) {
+  if (skipFunction(MF.getFunction()))
+    return false;
+
+  const TargetInstrInfo *TII = MF.getSubtarget().getInstrInfo();
+  const TargetRegisterInfo *TRI = MF.getSubtarget().getRegisterInfo();
+  LiveIntervals &LIS = getAnalysis<LiveIntervals>();
+  LLVM_DEBUG(dbgs() << "***** LoongArchDeadRegisterDefinitions *****\n");
+
+  bool MadeChange = false;
+  for (MachineBasicBlock &MBB : MF) {
+    for (MachineInstr &MI : MBB) {
+      // We only handle non-computational instructions.
+      const MCInstrDesc &Desc = MI.getDesc();
+      if (!Desc.mayLoad() && !Desc.mayStore() &&
+          !Desc.hasUnmodeledSideEffects())
+        continue;
+      for (int I = 0, E = Desc.getNumDefs(); I != E; ++I) {
+        MachineOperand &MO = MI.getOperand(I);
+        if (!MO.isReg() || !MO.isDef() || MO.isEarlyClobber())
+          continue;
+        // Be careful not to change the register if it's a tied operand.
+        if (MI.isRegTiedToUseOperand(I)) {
+          LLVM_DEBUG(dbgs() << "    Ignoring, def is tied operand.\n");
+          continue;
+        }
+        Register Reg = MO.getReg();
+        if (!Reg.isVirtual() || !MO.isDead())
+          continue;
+        LLVM_DEBUG(dbgs() << "    Dead def operand #" << I << " in:\n      ";
+                   MI.print(dbgs()));
+        const TargetRegisterClass *RC = TII->getRegClass(Desc, I, TRI, MF);
+        if (!(RC && RC->contains(LoongArch::R0))) {
+          LLVM_DEBUG(dbgs() << "    Ignoring, register is not a GPR.\n");
+          continue;
+        }
+        assert(LIS.hasInterval(Reg));
+        LIS.removeInterval(Reg);
+        MO.setReg(LoongArch::R0);
+        LLVM_DEBUG(dbgs() << "    Replacing with zero register. New:\n      ";
+                   MI.print(dbgs()));
+        ++NumDeadDefsReplaced;
+        MadeChange = true;
+      }
+    }
+  }
+
+  return MadeChange;
+}

--- a/llvm/lib/Target/LoongArch/LoongArchTargetMachine.cpp
+++ b/llvm/lib/Target/LoongArch/LoongArchTargetMachine.cpp
@@ -34,10 +34,18 @@ extern "C" LLVM_EXTERNAL_VISIBILITY void LLVMInitializeLoongArchTarget() {
   RegisterTargetMachine<LoongArchTargetMachine> X(getTheLoongArch32Target());
   RegisterTargetMachine<LoongArchTargetMachine> Y(getTheLoongArch64Target());
   auto *PR = PassRegistry::getPassRegistry();
+  initializeLoongArchDeadRegisterDefinitionsPass(*PR);
   initializeLoongArchOptWInstrsPass(*PR);
   initializeLoongArchPreRAExpandPseudoPass(*PR);
   initializeLoongArchDAGToDAGISelLegacyPass(*PR);
 }
+
+static cl::opt<bool> EnableLoongArchDeadRegisterElimination(
+    "loongarch-enable-dead-defs", cl::Hidden,
+    cl::desc("Enable the pass that removes dead"
+             " definitons and replaces stores to"
+             " them with stores to r0"),
+    cl::init(true));
 
 static cl::opt<bool>
     EnableLoopDataPrefetch("loongarch-enable-loop-data-prefetch", cl::Hidden,
@@ -148,6 +156,8 @@ public:
   void addPreEmitPass2() override;
   void addMachineSSAOptimization() override;
   void addPreRegAlloc() override;
+  bool addRegAssignAndRewriteFast() override;
+  bool addRegAssignAndRewriteOptimized() override;
 };
 } // end namespace
 
@@ -199,4 +209,18 @@ void LoongArchPassConfig::addMachineSSAOptimization() {
 
 void LoongArchPassConfig::addPreRegAlloc() {
   addPass(createLoongArchPreRAExpandPseudoPass());
+}
+
+bool LoongArchPassConfig::addRegAssignAndRewriteFast() {
+  if (TM->getOptLevel() != CodeGenOptLevel::None &&
+      EnableLoongArchDeadRegisterElimination)
+    addPass(createLoongArchDeadRegisterDefinitionsPass());
+  return TargetPassConfig::addRegAssignAndRewriteFast();
+}
+
+bool LoongArchPassConfig::addRegAssignAndRewriteOptimized() {
+  if (TM->getOptLevel() != CodeGenOptLevel::None &&
+      EnableLoongArchDeadRegisterElimination)
+    addPass(createLoongArchDeadRegisterDefinitionsPass());
+  return TargetPassConfig::addRegAssignAndRewriteOptimized();
 }

--- a/llvm/test/CodeGen/LoongArch/global-address.ll
+++ b/llvm/test/CodeGen/LoongArch/global-address.ll
@@ -14,40 +14,40 @@ define void @foo() nounwind {
 ; LA32NOPIC:       # %bb.0:
 ; LA32NOPIC-NEXT:    pcalau12i $a0, %got_pc_hi20(G)
 ; LA32NOPIC-NEXT:    ld.w $a0, $a0, %got_pc_lo12(G)
-; LA32NOPIC-NEXT:    ld.w $a0, $a0, 0
+; LA32NOPIC-NEXT:    ld.w $zero, $a0, 0
 ; LA32NOPIC-NEXT:    pcalau12i $a0, %pc_hi20(g)
 ; LA32NOPIC-NEXT:    addi.w $a0, $a0, %pc_lo12(g)
-; LA32NOPIC-NEXT:    ld.w $a0, $a0, 0
+; LA32NOPIC-NEXT:    ld.w $zero, $a0, 0
 ; LA32NOPIC-NEXT:    ret
 ;
 ; LA32PIC-LABEL: foo:
 ; LA32PIC:       # %bb.0:
 ; LA32PIC-NEXT:    pcalau12i $a0, %got_pc_hi20(G)
 ; LA32PIC-NEXT:    ld.w $a0, $a0, %got_pc_lo12(G)
-; LA32PIC-NEXT:    ld.w $a0, $a0, 0
+; LA32PIC-NEXT:    ld.w $zero, $a0, 0
 ; LA32PIC-NEXT:    pcalau12i $a0, %pc_hi20(.Lg$local)
 ; LA32PIC-NEXT:    addi.w $a0, $a0, %pc_lo12(.Lg$local)
-; LA32PIC-NEXT:    ld.w $a0, $a0, 0
+; LA32PIC-NEXT:    ld.w $zero, $a0, 0
 ; LA32PIC-NEXT:    ret
 ;
 ; LA64NOPIC-LABEL: foo:
 ; LA64NOPIC:       # %bb.0:
 ; LA64NOPIC-NEXT:    pcalau12i $a0, %got_pc_hi20(G)
 ; LA64NOPIC-NEXT:    ld.d $a0, $a0, %got_pc_lo12(G)
-; LA64NOPIC-NEXT:    ld.w $a0, $a0, 0
+; LA64NOPIC-NEXT:    ld.w $zero, $a0, 0
 ; LA64NOPIC-NEXT:    pcalau12i $a0, %pc_hi20(g)
 ; LA64NOPIC-NEXT:    addi.d $a0, $a0, %pc_lo12(g)
-; LA64NOPIC-NEXT:    ld.w $a0, $a0, 0
+; LA64NOPIC-NEXT:    ld.w $zero, $a0, 0
 ; LA64NOPIC-NEXT:    ret
 ;
 ; LA64PIC-LABEL: foo:
 ; LA64PIC:       # %bb.0:
 ; LA64PIC-NEXT:    pcalau12i $a0, %got_pc_hi20(G)
 ; LA64PIC-NEXT:    ld.d $a0, $a0, %got_pc_lo12(G)
-; LA64PIC-NEXT:    ld.w $a0, $a0, 0
+; LA64PIC-NEXT:    ld.w $zero, $a0, 0
 ; LA64PIC-NEXT:    pcalau12i $a0, %pc_hi20(.Lg$local)
 ; LA64PIC-NEXT:    addi.d $a0, $a0, %pc_lo12(.Lg$local)
-; LA64PIC-NEXT:    ld.w $a0, $a0, 0
+; LA64PIC-NEXT:    ld.w $zero, $a0, 0
 ; LA64PIC-NEXT:    ret
 ;
 ; LA64LARGENOPIC-LABEL: foo:
@@ -57,13 +57,13 @@ define void @foo() nounwind {
 ; LA64LARGENOPIC-NEXT:    lu32i.d $t8, %got64_pc_lo20(G)
 ; LA64LARGENOPIC-NEXT:    lu52i.d $t8, $t8, %got64_pc_hi12(G)
 ; LA64LARGENOPIC-NEXT:    ldx.d $a0, $t8, $a0
-; LA64LARGENOPIC-NEXT:    ld.w $a0, $a0, 0
+; LA64LARGENOPIC-NEXT:    ld.w $zero, $a0, 0
 ; LA64LARGENOPIC-NEXT:    pcalau12i $a0, %pc_hi20(g)
 ; LA64LARGENOPIC-NEXT:    addi.d $t8, $zero, %pc_lo12(g)
 ; LA64LARGENOPIC-NEXT:    lu32i.d $t8, %pc64_lo20(g)
 ; LA64LARGENOPIC-NEXT:    lu52i.d $t8, $t8, %pc64_hi12(g)
 ; LA64LARGENOPIC-NEXT:    add.d $a0, $t8, $a0
-; LA64LARGENOPIC-NEXT:    ld.w $a0, $a0, 0
+; LA64LARGENOPIC-NEXT:    ld.w $zero, $a0, 0
 ; LA64LARGENOPIC-NEXT:    ret
 ;
 ; LA64LARGEPIC-LABEL: foo:
@@ -73,13 +73,13 @@ define void @foo() nounwind {
 ; LA64LARGEPIC-NEXT:    lu32i.d $t8, %got64_pc_lo20(G)
 ; LA64LARGEPIC-NEXT:    lu52i.d $t8, $t8, %got64_pc_hi12(G)
 ; LA64LARGEPIC-NEXT:    ldx.d $a0, $t8, $a0
-; LA64LARGEPIC-NEXT:    ld.w $a0, $a0, 0
+; LA64LARGEPIC-NEXT:    ld.w $zero, $a0, 0
 ; LA64LARGEPIC-NEXT:    pcalau12i $a0, %pc_hi20(.Lg$local)
 ; LA64LARGEPIC-NEXT:    addi.d $t8, $zero, %pc_lo12(.Lg$local)
 ; LA64LARGEPIC-NEXT:    lu32i.d $t8, %pc64_lo20(.Lg$local)
 ; LA64LARGEPIC-NEXT:    lu52i.d $t8, $t8, %pc64_hi12(.Lg$local)
 ; LA64LARGEPIC-NEXT:    add.d $a0, $t8, $a0
-; LA64LARGEPIC-NEXT:    ld.w $a0, $a0, 0
+; LA64LARGEPIC-NEXT:    ld.w $zero, $a0, 0
 ; LA64LARGEPIC-NEXT:    ret
   %V = load volatile i32, ptr @G
   %v = load volatile i32, ptr @g

--- a/llvm/test/CodeGen/LoongArch/intrinsic-la64.ll
+++ b/llvm/test/CodeGen/LoongArch/intrinsic-la64.ll
@@ -178,7 +178,7 @@ entry:
 define void @csrrd_d_noret() {
 ; CHECK-LABEL: csrrd_d_noret:
 ; CHECK:       # %bb.0: # %entry
-; CHECK-NEXT:    csrrd $a0, 1
+; CHECK-NEXT:    csrrd $zero, 1
 ; CHECK-NEXT:    ret
 entry:
   %0 = tail call i64 @llvm.loongarch.csrrd.d(i32 1)
@@ -240,7 +240,7 @@ entry:
 define void @iocsrrd_d_noret(i32 %a) {
 ; CHECK-LABEL: iocsrrd_d_noret:
 ; CHECK:       # %bb.0: # %entry
-; CHECK-NEXT:    iocsrrd.d $a0, $a0
+; CHECK-NEXT:    iocsrrd.d $zero, $a0
 ; CHECK-NEXT:    ret
 entry:
   %0 = tail call i64 @llvm.loongarch.iocsrrd.d(i32 %a)
@@ -290,7 +290,7 @@ entry:
 define void @lddir_d_noret(i64 %a) {
 ; CHECK-LABEL: lddir_d_noret:
 ; CHECK:       # %bb.0: # %entry
-; CHECK-NEXT:    lddir $a0, $a0, 1
+; CHECK-NEXT:    lddir $zero, $a0, 1
 ; CHECK-NEXT:    ret
 entry:
   %0 = tail call i64 @llvm.loongarch.lddir.d(i64 %a, i64 1)

--- a/llvm/test/CodeGen/LoongArch/intrinsic.ll
+++ b/llvm/test/CodeGen/LoongArch/intrinsic.ll
@@ -73,7 +73,7 @@ entry:
 define void @movfcsr2gr_noret() nounwind {
 ; CHECK-LABEL: movfcsr2gr_noret:
 ; CHECK:       # %bb.0: # %entry
-; CHECK-NEXT:    movfcsr2gr $a0, $fcsr1
+; CHECK-NEXT:    movfcsr2gr $zero, $fcsr1
 ; CHECK-NEXT:    ret
 entry:
   %res = call i32 @llvm.loongarch.movfcsr2gr(i32 1)
@@ -103,7 +103,7 @@ entry:
 define void @csrrd_w_noret() {
 ; CHECK-LABEL: csrrd_w_noret:
 ; CHECK:       # %bb.0: # %entry
-; CHECK-NEXT:    csrrd $a0, 1
+; CHECK-NEXT:    csrrd $zero, 1
 ; CHECK-NEXT:    ret
 entry:
   %0 = tail call i32 @llvm.loongarch.csrrd.w(i32 1)
@@ -185,7 +185,7 @@ entry:
 define void @iocsrrd_b_noret(i32 %a) {
 ; CHECK-LABEL: iocsrrd_b_noret:
 ; CHECK:       # %bb.0: # %entry
-; CHECK-NEXT:    iocsrrd.b $a0, $a0
+; CHECK-NEXT:    iocsrrd.b $zero, $a0
 ; CHECK-NEXT:    ret
 entry:
   %0 = tail call i32 @llvm.loongarch.iocsrrd.b(i32 %a)
@@ -195,7 +195,7 @@ entry:
 define void @iocsrrd_h_noret(i32 %a) {
 ; CHECK-LABEL: iocsrrd_h_noret:
 ; CHECK:       # %bb.0: # %entry
-; CHECK-NEXT:    iocsrrd.h $a0, $a0
+; CHECK-NEXT:    iocsrrd.h $zero, $a0
 ; CHECK-NEXT:    ret
 entry:
   %0 = tail call i32 @llvm.loongarch.iocsrrd.h(i32 %a)
@@ -205,7 +205,7 @@ entry:
 define void @iocsrrd_w_noret(i32 %a) {
 ; CHECK-LABEL: iocsrrd_w_noret:
 ; CHECK:       # %bb.0: # %entry
-; CHECK-NEXT:    iocsrrd.w $a0, $a0
+; CHECK-NEXT:    iocsrrd.w $zero, $a0
 ; CHECK-NEXT:    ret
 entry:
   %0 = tail call i32 @llvm.loongarch.iocsrrd.w(i32 %a)

--- a/llvm/test/CodeGen/LoongArch/ir-instruction/br.ll
+++ b/llvm/test/CodeGen/LoongArch/ir-instruction/br.ll
@@ -21,7 +21,7 @@ define void @foo_br_eq(i32 %a, ptr %b) nounwind {
 ; LA32-NEXT:    ld.w $a2, $a1, 0
 ; LA32-NEXT:    beq $a2, $a0, .LBB1_2
 ; LA32-NEXT:  # %bb.1: # %test
-; LA32-NEXT:    ld.w $a0, $a1, 0
+; LA32-NEXT:    ld.w $zero, $a1, 0
 ; LA32-NEXT:  .LBB1_2: # %end
 ; LA32-NEXT:    ret
 ;
@@ -31,7 +31,7 @@ define void @foo_br_eq(i32 %a, ptr %b) nounwind {
 ; LA64-NEXT:    addi.w $a0, $a0, 0
 ; LA64-NEXT:    beq $a2, $a0, .LBB1_2
 ; LA64-NEXT:  # %bb.1: # %test
-; LA64-NEXT:    ld.w $a0, $a1, 0
+; LA64-NEXT:    ld.w $zero, $a1, 0
 ; LA64-NEXT:  .LBB1_2: # %end
 ; LA64-NEXT:    ret
   %val = load volatile i32, ptr %b
@@ -51,7 +51,7 @@ define void @foo_br_ne(i32 %a, ptr %b) nounwind {
 ; LA32-NEXT:    ld.w $a2, $a1, 0
 ; LA32-NEXT:    bne $a2, $a0, .LBB2_2
 ; LA32-NEXT:  # %bb.1: # %test
-; LA32-NEXT:    ld.w $a0, $a1, 0
+; LA32-NEXT:    ld.w $zero, $a1, 0
 ; LA32-NEXT:  .LBB2_2: # %end
 ; LA32-NEXT:    ret
 ;
@@ -61,7 +61,7 @@ define void @foo_br_ne(i32 %a, ptr %b) nounwind {
 ; LA64-NEXT:    addi.w $a0, $a0, 0
 ; LA64-NEXT:    bne $a2, $a0, .LBB2_2
 ; LA64-NEXT:  # %bb.1: # %test
-; LA64-NEXT:    ld.w $a0, $a1, 0
+; LA64-NEXT:    ld.w $zero, $a1, 0
 ; LA64-NEXT:  .LBB2_2: # %end
 ; LA64-NEXT:    ret
   %val = load volatile i32, ptr %b
@@ -81,7 +81,7 @@ define void @foo_br_slt(i32 %a, ptr %b) nounwind {
 ; LA32-NEXT:    ld.w $a2, $a1, 0
 ; LA32-NEXT:    blt $a2, $a0, .LBB3_2
 ; LA32-NEXT:  # %bb.1: # %test
-; LA32-NEXT:    ld.w $a0, $a1, 0
+; LA32-NEXT:    ld.w $zero, $a1, 0
 ; LA32-NEXT:  .LBB3_2: # %end
 ; LA32-NEXT:    ret
 ;
@@ -91,7 +91,7 @@ define void @foo_br_slt(i32 %a, ptr %b) nounwind {
 ; LA64-NEXT:    addi.w $a0, $a0, 0
 ; LA64-NEXT:    blt $a2, $a0, .LBB3_2
 ; LA64-NEXT:  # %bb.1: # %test
-; LA64-NEXT:    ld.w $a0, $a1, 0
+; LA64-NEXT:    ld.w $zero, $a1, 0
 ; LA64-NEXT:  .LBB3_2: # %end
 ; LA64-NEXT:    ret
   %val = load volatile i32, ptr %b
@@ -111,7 +111,7 @@ define void @foo_br_sge(i32 %a, ptr %b) nounwind {
 ; LA32-NEXT:    ld.w $a2, $a1, 0
 ; LA32-NEXT:    bge $a2, $a0, .LBB4_2
 ; LA32-NEXT:  # %bb.1: # %test
-; LA32-NEXT:    ld.w $a0, $a1, 0
+; LA32-NEXT:    ld.w $zero, $a1, 0
 ; LA32-NEXT:  .LBB4_2: # %end
 ; LA32-NEXT:    ret
 ;
@@ -121,7 +121,7 @@ define void @foo_br_sge(i32 %a, ptr %b) nounwind {
 ; LA64-NEXT:    addi.w $a0, $a0, 0
 ; LA64-NEXT:    bge $a2, $a0, .LBB4_2
 ; LA64-NEXT:  # %bb.1: # %test
-; LA64-NEXT:    ld.w $a0, $a1, 0
+; LA64-NEXT:    ld.w $zero, $a1, 0
 ; LA64-NEXT:  .LBB4_2: # %end
 ; LA64-NEXT:    ret
   %val = load volatile i32, ptr %b
@@ -141,7 +141,7 @@ define void @foo_br_ult(i32 %a, ptr %b) nounwind {
 ; LA32-NEXT:    ld.w $a2, $a1, 0
 ; LA32-NEXT:    bltu $a2, $a0, .LBB5_2
 ; LA32-NEXT:  # %bb.1: # %test
-; LA32-NEXT:    ld.w $a0, $a1, 0
+; LA32-NEXT:    ld.w $zero, $a1, 0
 ; LA32-NEXT:  .LBB5_2: # %end
 ; LA32-NEXT:    ret
 ;
@@ -151,7 +151,7 @@ define void @foo_br_ult(i32 %a, ptr %b) nounwind {
 ; LA64-NEXT:    addi.w $a0, $a0, 0
 ; LA64-NEXT:    bltu $a2, $a0, .LBB5_2
 ; LA64-NEXT:  # %bb.1: # %test
-; LA64-NEXT:    ld.w $a0, $a1, 0
+; LA64-NEXT:    ld.w $zero, $a1, 0
 ; LA64-NEXT:  .LBB5_2: # %end
 ; LA64-NEXT:    ret
   %val = load volatile i32, ptr %b
@@ -171,7 +171,7 @@ define void @foo_br_uge(i32 %a, ptr %b) nounwind {
 ; LA32-NEXT:    ld.w $a2, $a1, 0
 ; LA32-NEXT:    bgeu $a2, $a0, .LBB6_2
 ; LA32-NEXT:  # %bb.1: # %test
-; LA32-NEXT:    ld.w $a0, $a1, 0
+; LA32-NEXT:    ld.w $zero, $a1, 0
 ; LA32-NEXT:  .LBB6_2: # %end
 ; LA32-NEXT:    ret
 ;
@@ -181,7 +181,7 @@ define void @foo_br_uge(i32 %a, ptr %b) nounwind {
 ; LA64-NEXT:    addi.w $a0, $a0, 0
 ; LA64-NEXT:    bgeu $a2, $a0, .LBB6_2
 ; LA64-NEXT:  # %bb.1: # %test
-; LA64-NEXT:    ld.w $a0, $a1, 0
+; LA64-NEXT:    ld.w $zero, $a1, 0
 ; LA64-NEXT:  .LBB6_2: # %end
 ; LA64-NEXT:    ret
   %val = load volatile i32, ptr %b
@@ -202,7 +202,7 @@ define void @foo_br_sgt(i32 %a, ptr %b) nounwind {
 ; LA32-NEXT:    ld.w $a2, $a1, 0
 ; LA32-NEXT:    blt $a0, $a2, .LBB7_2
 ; LA32-NEXT:  # %bb.1: # %test
-; LA32-NEXT:    ld.w $a0, $a1, 0
+; LA32-NEXT:    ld.w $zero, $a1, 0
 ; LA32-NEXT:  .LBB7_2: # %end
 ; LA32-NEXT:    ret
 ;
@@ -212,7 +212,7 @@ define void @foo_br_sgt(i32 %a, ptr %b) nounwind {
 ; LA64-NEXT:    addi.w $a0, $a0, 0
 ; LA64-NEXT:    blt $a0, $a2, .LBB7_2
 ; LA64-NEXT:  # %bb.1: # %test
-; LA64-NEXT:    ld.w $a0, $a1, 0
+; LA64-NEXT:    ld.w $zero, $a1, 0
 ; LA64-NEXT:  .LBB7_2: # %end
 ; LA64-NEXT:    ret
   %val = load volatile i32, ptr %b
@@ -232,7 +232,7 @@ define void @foo_br_sle(i32 %a, ptr %b) nounwind {
 ; LA32-NEXT:    ld.w $a2, $a1, 0
 ; LA32-NEXT:    bge $a0, $a2, .LBB8_2
 ; LA32-NEXT:  # %bb.1: # %test
-; LA32-NEXT:    ld.w $a0, $a1, 0
+; LA32-NEXT:    ld.w $zero, $a1, 0
 ; LA32-NEXT:  .LBB8_2: # %end
 ; LA32-NEXT:    ret
 ;
@@ -242,7 +242,7 @@ define void @foo_br_sle(i32 %a, ptr %b) nounwind {
 ; LA64-NEXT:    addi.w $a0, $a0, 0
 ; LA64-NEXT:    bge $a0, $a2, .LBB8_2
 ; LA64-NEXT:  # %bb.1: # %test
-; LA64-NEXT:    ld.w $a0, $a1, 0
+; LA64-NEXT:    ld.w $zero, $a1, 0
 ; LA64-NEXT:  .LBB8_2: # %end
 ; LA64-NEXT:    ret
   %val = load volatile i32, ptr %b
@@ -262,7 +262,7 @@ define void @foo_br_ugt(i32 %a, ptr %b) nounwind {
 ; LA32-NEXT:    ld.w $a2, $a1, 0
 ; LA32-NEXT:    bltu $a0, $a2, .LBB9_2
 ; LA32-NEXT:  # %bb.1: # %test
-; LA32-NEXT:    ld.w $a0, $a1, 0
+; LA32-NEXT:    ld.w $zero, $a1, 0
 ; LA32-NEXT:  .LBB9_2: # %end
 ; LA32-NEXT:    ret
 ;
@@ -272,7 +272,7 @@ define void @foo_br_ugt(i32 %a, ptr %b) nounwind {
 ; LA64-NEXT:    addi.w $a0, $a0, 0
 ; LA64-NEXT:    bltu $a0, $a2, .LBB9_2
 ; LA64-NEXT:  # %bb.1: # %test
-; LA64-NEXT:    ld.w $a0, $a1, 0
+; LA64-NEXT:    ld.w $zero, $a1, 0
 ; LA64-NEXT:  .LBB9_2: # %end
 ; LA64-NEXT:    ret
   %val = load volatile i32, ptr %b
@@ -292,7 +292,7 @@ define void @foo_br_ule(i32 %a, ptr %b) nounwind {
 ; LA32-NEXT:    ld.w $a2, $a1, 0
 ; LA32-NEXT:    bgeu $a0, $a2, .LBB10_2
 ; LA32-NEXT:  # %bb.1: # %test
-; LA32-NEXT:    ld.w $a0, $a1, 0
+; LA32-NEXT:    ld.w $zero, $a1, 0
 ; LA32-NEXT:  .LBB10_2: # %end
 ; LA32-NEXT:    ret
 ;
@@ -302,7 +302,7 @@ define void @foo_br_ule(i32 %a, ptr %b) nounwind {
 ; LA64-NEXT:    addi.w $a0, $a0, 0
 ; LA64-NEXT:    bgeu $a0, $a2, .LBB10_2
 ; LA64-NEXT:  # %bb.1: # %test
-; LA64-NEXT:    ld.w $a0, $a1, 0
+; LA64-NEXT:    ld.w $zero, $a1, 0
 ; LA64-NEXT:  .LBB10_2: # %end
 ; LA64-NEXT:    ret
   %val = load volatile i32, ptr %b
@@ -321,11 +321,11 @@ end:
 define void @foo_br_cc(ptr %a, i1 %cc) nounwind {
 ; ALL-LABEL: foo_br_cc:
 ; ALL:       # %bb.0:
-; ALL-NEXT:    ld.w $a2, $a0, 0
+; ALL-NEXT:    ld.w $zero, $a0, 0
 ; ALL-NEXT:    andi $a1, $a1, 1
 ; ALL-NEXT:    bnez $a1, .LBB11_2
 ; ALL-NEXT:  # %bb.1: # %test
-; ALL-NEXT:    ld.w $a0, $a0, 0
+; ALL-NEXT:    ld.w $zero, $a0, 0
 ; ALL-NEXT:  .LBB11_2: # %end
 ; ALL-NEXT:    ret
   %val = load volatile i32, ptr %a

--- a/llvm/test/CodeGen/LoongArch/ir-instruction/load-store.ll
+++ b/llvm/test/CodeGen/LoongArch/ir-instruction/load-store.ll
@@ -57,7 +57,7 @@ define i32 @load_store_global_array(i32 %a) nounwind {
 ; LA32NOPIC-NEXT:    addi.w $a2, $a1, %pc_lo12(arr)
 ; LA32NOPIC-NEXT:    ld.w $a1, $a2, 0
 ; LA32NOPIC-NEXT:    st.w $a0, $a2, 0
-; LA32NOPIC-NEXT:    ld.w $a3, $a2, 36
+; LA32NOPIC-NEXT:    ld.w $zero, $a2, 36
 ; LA32NOPIC-NEXT:    st.w $a0, $a2, 36
 ; LA32NOPIC-NEXT:    move $a0, $a1
 ; LA32NOPIC-NEXT:    ret
@@ -68,7 +68,7 @@ define i32 @load_store_global_array(i32 %a) nounwind {
 ; LA32PIC-NEXT:    addi.w $a2, $a1, %pc_lo12(.Larr$local)
 ; LA32PIC-NEXT:    ld.w $a1, $a2, 0
 ; LA32PIC-NEXT:    st.w $a0, $a2, 0
-; LA32PIC-NEXT:    ld.w $a3, $a2, 36
+; LA32PIC-NEXT:    ld.w $zero, $a2, 36
 ; LA32PIC-NEXT:    st.w $a0, $a2, 36
 ; LA32PIC-NEXT:    move $a0, $a1
 ; LA32PIC-NEXT:    ret
@@ -79,7 +79,7 @@ define i32 @load_store_global_array(i32 %a) nounwind {
 ; LA64NOPIC-NEXT:    addi.d $a2, $a1, %pc_lo12(arr)
 ; LA64NOPIC-NEXT:    ld.w $a1, $a2, 0
 ; LA64NOPIC-NEXT:    st.w $a0, $a2, 0
-; LA64NOPIC-NEXT:    ld.w $a3, $a2, 36
+; LA64NOPIC-NEXT:    ld.w $zero, $a2, 36
 ; LA64NOPIC-NEXT:    st.w $a0, $a2, 36
 ; LA64NOPIC-NEXT:    move $a0, $a1
 ; LA64NOPIC-NEXT:    ret
@@ -90,7 +90,7 @@ define i32 @load_store_global_array(i32 %a) nounwind {
 ; LA64PIC-NEXT:    addi.d $a2, $a1, %pc_lo12(.Larr$local)
 ; LA64PIC-NEXT:    ld.w $a1, $a2, 0
 ; LA64PIC-NEXT:    st.w $a0, $a2, 0
-; LA64PIC-NEXT:    ld.w $a3, $a2, 36
+; LA64PIC-NEXT:    ld.w $zero, $a2, 36
 ; LA64PIC-NEXT:    st.w $a0, $a2, 36
 ; LA64PIC-NEXT:    move $a0, $a1
 ; LA64PIC-NEXT:    ret
@@ -108,7 +108,7 @@ define i64 @ld_b(ptr %a) nounwind {
 ; LA32NOPIC-LABEL: ld_b:
 ; LA32NOPIC:       # %bb.0:
 ; LA32NOPIC-NEXT:    ld.b $a2, $a0, 1
-; LA32NOPIC-NEXT:    ld.b $a0, $a0, 0
+; LA32NOPIC-NEXT:    ld.b $zero, $a0, 0
 ; LA32NOPIC-NEXT:    srai.w $a1, $a2, 31
 ; LA32NOPIC-NEXT:    move $a0, $a2
 ; LA32NOPIC-NEXT:    ret
@@ -116,7 +116,7 @@ define i64 @ld_b(ptr %a) nounwind {
 ; LA32PIC-LABEL: ld_b:
 ; LA32PIC:       # %bb.0:
 ; LA32PIC-NEXT:    ld.b $a2, $a0, 1
-; LA32PIC-NEXT:    ld.b $a0, $a0, 0
+; LA32PIC-NEXT:    ld.b $zero, $a0, 0
 ; LA32PIC-NEXT:    srai.w $a1, $a2, 31
 ; LA32PIC-NEXT:    move $a0, $a2
 ; LA32PIC-NEXT:    ret
@@ -124,14 +124,14 @@ define i64 @ld_b(ptr %a) nounwind {
 ; LA64NOPIC-LABEL: ld_b:
 ; LA64NOPIC:       # %bb.0:
 ; LA64NOPIC-NEXT:    ld.b $a1, $a0, 1
-; LA64NOPIC-NEXT:    ld.b $a0, $a0, 0
+; LA64NOPIC-NEXT:    ld.b $zero, $a0, 0
 ; LA64NOPIC-NEXT:    move $a0, $a1
 ; LA64NOPIC-NEXT:    ret
 ;
 ; LA64PIC-LABEL: ld_b:
 ; LA64PIC:       # %bb.0:
 ; LA64PIC-NEXT:    ld.b $a1, $a0, 1
-; LA64PIC-NEXT:    ld.b $a0, $a0, 0
+; LA64PIC-NEXT:    ld.b $zero, $a0, 0
 ; LA64PIC-NEXT:    move $a0, $a1
 ; LA64PIC-NEXT:    ret
   %1 = getelementptr i8, ptr %a, i64 1
@@ -145,7 +145,7 @@ define i64 @ld_h(ptr %a) nounwind {
 ; LA32NOPIC-LABEL: ld_h:
 ; LA32NOPIC:       # %bb.0:
 ; LA32NOPIC-NEXT:    ld.h $a2, $a0, 4
-; LA32NOPIC-NEXT:    ld.h $a0, $a0, 0
+; LA32NOPIC-NEXT:    ld.h $zero, $a0, 0
 ; LA32NOPIC-NEXT:    srai.w $a1, $a2, 31
 ; LA32NOPIC-NEXT:    move $a0, $a2
 ; LA32NOPIC-NEXT:    ret
@@ -153,7 +153,7 @@ define i64 @ld_h(ptr %a) nounwind {
 ; LA32PIC-LABEL: ld_h:
 ; LA32PIC:       # %bb.0:
 ; LA32PIC-NEXT:    ld.h $a2, $a0, 4
-; LA32PIC-NEXT:    ld.h $a0, $a0, 0
+; LA32PIC-NEXT:    ld.h $zero, $a0, 0
 ; LA32PIC-NEXT:    srai.w $a1, $a2, 31
 ; LA32PIC-NEXT:    move $a0, $a2
 ; LA32PIC-NEXT:    ret
@@ -161,14 +161,14 @@ define i64 @ld_h(ptr %a) nounwind {
 ; LA64NOPIC-LABEL: ld_h:
 ; LA64NOPIC:       # %bb.0:
 ; LA64NOPIC-NEXT:    ld.h $a1, $a0, 4
-; LA64NOPIC-NEXT:    ld.h $a0, $a0, 0
+; LA64NOPIC-NEXT:    ld.h $zero, $a0, 0
 ; LA64NOPIC-NEXT:    move $a0, $a1
 ; LA64NOPIC-NEXT:    ret
 ;
 ; LA64PIC-LABEL: ld_h:
 ; LA64PIC:       # %bb.0:
 ; LA64PIC-NEXT:    ld.h $a1, $a0, 4
-; LA64PIC-NEXT:    ld.h $a0, $a0, 0
+; LA64PIC-NEXT:    ld.h $zero, $a0, 0
 ; LA64PIC-NEXT:    move $a0, $a1
 ; LA64PIC-NEXT:    ret
   %1 = getelementptr i16, ptr %a, i64 2
@@ -182,7 +182,7 @@ define i64 @ld_w(ptr %a) nounwind {
 ; LA32NOPIC-LABEL: ld_w:
 ; LA32NOPIC:       # %bb.0:
 ; LA32NOPIC-NEXT:    ld.w $a2, $a0, 12
-; LA32NOPIC-NEXT:    ld.w $a0, $a0, 0
+; LA32NOPIC-NEXT:    ld.w $zero, $a0, 0
 ; LA32NOPIC-NEXT:    srai.w $a1, $a2, 31
 ; LA32NOPIC-NEXT:    move $a0, $a2
 ; LA32NOPIC-NEXT:    ret
@@ -190,7 +190,7 @@ define i64 @ld_w(ptr %a) nounwind {
 ; LA32PIC-LABEL: ld_w:
 ; LA32PIC:       # %bb.0:
 ; LA32PIC-NEXT:    ld.w $a2, $a0, 12
-; LA32PIC-NEXT:    ld.w $a0, $a0, 0
+; LA32PIC-NEXT:    ld.w $zero, $a0, 0
 ; LA32PIC-NEXT:    srai.w $a1, $a2, 31
 ; LA32PIC-NEXT:    move $a0, $a2
 ; LA32PIC-NEXT:    ret
@@ -198,14 +198,14 @@ define i64 @ld_w(ptr %a) nounwind {
 ; LA64NOPIC-LABEL: ld_w:
 ; LA64NOPIC:       # %bb.0:
 ; LA64NOPIC-NEXT:    ld.w $a1, $a0, 12
-; LA64NOPIC-NEXT:    ld.w $a0, $a0, 0
+; LA64NOPIC-NEXT:    ld.w $zero, $a0, 0
 ; LA64NOPIC-NEXT:    move $a0, $a1
 ; LA64NOPIC-NEXT:    ret
 ;
 ; LA64PIC-LABEL: ld_w:
 ; LA64PIC:       # %bb.0:
 ; LA64PIC-NEXT:    ld.w $a1, $a0, 12
-; LA64PIC-NEXT:    ld.w $a0, $a0, 0
+; LA64PIC-NEXT:    ld.w $zero, $a0, 0
 ; LA64PIC-NEXT:    move $a0, $a1
 ; LA64PIC-NEXT:    ret
   %1 = getelementptr i32, ptr %a, i64 3
@@ -220,8 +220,8 @@ define i64 @ld_d(ptr %a) nounwind {
 ; LA32NOPIC:       # %bb.0:
 ; LA32NOPIC-NEXT:    ld.w $a1, $a0, 28
 ; LA32NOPIC-NEXT:    ld.w $a2, $a0, 24
-; LA32NOPIC-NEXT:    ld.w $a3, $a0, 4
-; LA32NOPIC-NEXT:    ld.w $a0, $a0, 0
+; LA32NOPIC-NEXT:    ld.w $zero, $a0, 4
+; LA32NOPIC-NEXT:    ld.w $zero, $a0, 0
 ; LA32NOPIC-NEXT:    move $a0, $a2
 ; LA32NOPIC-NEXT:    ret
 ;
@@ -229,22 +229,22 @@ define i64 @ld_d(ptr %a) nounwind {
 ; LA32PIC:       # %bb.0:
 ; LA32PIC-NEXT:    ld.w $a1, $a0, 28
 ; LA32PIC-NEXT:    ld.w $a2, $a0, 24
-; LA32PIC-NEXT:    ld.w $a3, $a0, 4
-; LA32PIC-NEXT:    ld.w $a0, $a0, 0
+; LA32PIC-NEXT:    ld.w $zero, $a0, 4
+; LA32PIC-NEXT:    ld.w $zero, $a0, 0
 ; LA32PIC-NEXT:    move $a0, $a2
 ; LA32PIC-NEXT:    ret
 ;
 ; LA64NOPIC-LABEL: ld_d:
 ; LA64NOPIC:       # %bb.0:
 ; LA64NOPIC-NEXT:    ld.d $a1, $a0, 24
-; LA64NOPIC-NEXT:    ld.d $a0, $a0, 0
+; LA64NOPIC-NEXT:    ld.d $zero, $a0, 0
 ; LA64NOPIC-NEXT:    move $a0, $a1
 ; LA64NOPIC-NEXT:    ret
 ;
 ; LA64PIC-LABEL: ld_d:
 ; LA64PIC:       # %bb.0:
 ; LA64PIC-NEXT:    ld.d $a1, $a0, 24
-; LA64PIC-NEXT:    ld.d $a0, $a0, 0
+; LA64PIC-NEXT:    ld.d $zero, $a0, 0
 ; LA64PIC-NEXT:    move $a0, $a1
 ; LA64PIC-NEXT:    ret
   %1 = getelementptr i64, ptr %a, i64 3
@@ -375,7 +375,7 @@ define i64 @ldx_b(ptr %a, i64 %idx) nounwind {
 ; LA32NOPIC:       # %bb.0:
 ; LA32NOPIC-NEXT:    add.w $a1, $a0, $a1
 ; LA32NOPIC-NEXT:    ld.b $a2, $a1, 0
-; LA32NOPIC-NEXT:    ld.b $a0, $a0, 0
+; LA32NOPIC-NEXT:    ld.b $zero, $a0, 0
 ; LA32NOPIC-NEXT:    srai.w $a1, $a2, 31
 ; LA32NOPIC-NEXT:    move $a0, $a2
 ; LA32NOPIC-NEXT:    ret
@@ -384,7 +384,7 @@ define i64 @ldx_b(ptr %a, i64 %idx) nounwind {
 ; LA32PIC:       # %bb.0:
 ; LA32PIC-NEXT:    add.w $a1, $a0, $a1
 ; LA32PIC-NEXT:    ld.b $a2, $a1, 0
-; LA32PIC-NEXT:    ld.b $a0, $a0, 0
+; LA32PIC-NEXT:    ld.b $zero, $a0, 0
 ; LA32PIC-NEXT:    srai.w $a1, $a2, 31
 ; LA32PIC-NEXT:    move $a0, $a2
 ; LA32PIC-NEXT:    ret
@@ -392,14 +392,14 @@ define i64 @ldx_b(ptr %a, i64 %idx) nounwind {
 ; LA64NOPIC-LABEL: ldx_b:
 ; LA64NOPIC:       # %bb.0:
 ; LA64NOPIC-NEXT:    ldx.b $a1, $a0, $a1
-; LA64NOPIC-NEXT:    ld.b $a0, $a0, 0
+; LA64NOPIC-NEXT:    ld.b $zero, $a0, 0
 ; LA64NOPIC-NEXT:    move $a0, $a1
 ; LA64NOPIC-NEXT:    ret
 ;
 ; LA64PIC-LABEL: ldx_b:
 ; LA64PIC:       # %bb.0:
 ; LA64PIC-NEXT:    ldx.b $a1, $a0, $a1
-; LA64PIC-NEXT:    ld.b $a0, $a0, 0
+; LA64PIC-NEXT:    ld.b $zero, $a0, 0
 ; LA64PIC-NEXT:    move $a0, $a1
 ; LA64PIC-NEXT:    ret
   %1 = getelementptr i8, ptr %a, i64 %idx
@@ -414,7 +414,7 @@ define i64 @ldx_h(ptr %a, i64 %idx) nounwind {
 ; LA32NOPIC:       # %bb.0:
 ; LA32NOPIC-NEXT:    alsl.w $a1, $a1, $a0, 1
 ; LA32NOPIC-NEXT:    ld.h $a2, $a1, 0
-; LA32NOPIC-NEXT:    ld.h $a0, $a0, 0
+; LA32NOPIC-NEXT:    ld.h $zero, $a0, 0
 ; LA32NOPIC-NEXT:    srai.w $a1, $a2, 31
 ; LA32NOPIC-NEXT:    move $a0, $a2
 ; LA32NOPIC-NEXT:    ret
@@ -423,7 +423,7 @@ define i64 @ldx_h(ptr %a, i64 %idx) nounwind {
 ; LA32PIC:       # %bb.0:
 ; LA32PIC-NEXT:    alsl.w $a1, $a1, $a0, 1
 ; LA32PIC-NEXT:    ld.h $a2, $a1, 0
-; LA32PIC-NEXT:    ld.h $a0, $a0, 0
+; LA32PIC-NEXT:    ld.h $zero, $a0, 0
 ; LA32PIC-NEXT:    srai.w $a1, $a2, 31
 ; LA32PIC-NEXT:    move $a0, $a2
 ; LA32PIC-NEXT:    ret
@@ -432,7 +432,7 @@ define i64 @ldx_h(ptr %a, i64 %idx) nounwind {
 ; LA64NOPIC:       # %bb.0:
 ; LA64NOPIC-NEXT:    slli.d $a1, $a1, 1
 ; LA64NOPIC-NEXT:    ldx.h $a1, $a0, $a1
-; LA64NOPIC-NEXT:    ld.h $a0, $a0, 0
+; LA64NOPIC-NEXT:    ld.h $zero, $a0, 0
 ; LA64NOPIC-NEXT:    move $a0, $a1
 ; LA64NOPIC-NEXT:    ret
 ;
@@ -440,7 +440,7 @@ define i64 @ldx_h(ptr %a, i64 %idx) nounwind {
 ; LA64PIC:       # %bb.0:
 ; LA64PIC-NEXT:    slli.d $a1, $a1, 1
 ; LA64PIC-NEXT:    ldx.h $a1, $a0, $a1
-; LA64PIC-NEXT:    ld.h $a0, $a0, 0
+; LA64PIC-NEXT:    ld.h $zero, $a0, 0
 ; LA64PIC-NEXT:    move $a0, $a1
 ; LA64PIC-NEXT:    ret
   %1 = getelementptr i16, ptr %a, i64 %idx
@@ -455,7 +455,7 @@ define i64 @ldx_w(ptr %a, i64 %idx) nounwind {
 ; LA32NOPIC:       # %bb.0:
 ; LA32NOPIC-NEXT:    alsl.w $a1, $a1, $a0, 2
 ; LA32NOPIC-NEXT:    ld.w $a2, $a1, 0
-; LA32NOPIC-NEXT:    ld.w $a0, $a0, 0
+; LA32NOPIC-NEXT:    ld.w $zero, $a0, 0
 ; LA32NOPIC-NEXT:    srai.w $a1, $a2, 31
 ; LA32NOPIC-NEXT:    move $a0, $a2
 ; LA32NOPIC-NEXT:    ret
@@ -464,7 +464,7 @@ define i64 @ldx_w(ptr %a, i64 %idx) nounwind {
 ; LA32PIC:       # %bb.0:
 ; LA32PIC-NEXT:    alsl.w $a1, $a1, $a0, 2
 ; LA32PIC-NEXT:    ld.w $a2, $a1, 0
-; LA32PIC-NEXT:    ld.w $a0, $a0, 0
+; LA32PIC-NEXT:    ld.w $zero, $a0, 0
 ; LA32PIC-NEXT:    srai.w $a1, $a2, 31
 ; LA32PIC-NEXT:    move $a0, $a2
 ; LA32PIC-NEXT:    ret
@@ -473,7 +473,7 @@ define i64 @ldx_w(ptr %a, i64 %idx) nounwind {
 ; LA64NOPIC:       # %bb.0:
 ; LA64NOPIC-NEXT:    slli.d $a1, $a1, 2
 ; LA64NOPIC-NEXT:    ldx.w $a1, $a0, $a1
-; LA64NOPIC-NEXT:    ld.w $a0, $a0, 0
+; LA64NOPIC-NEXT:    ld.w $zero, $a0, 0
 ; LA64NOPIC-NEXT:    move $a0, $a1
 ; LA64NOPIC-NEXT:    ret
 ;
@@ -481,7 +481,7 @@ define i64 @ldx_w(ptr %a, i64 %idx) nounwind {
 ; LA64PIC:       # %bb.0:
 ; LA64PIC-NEXT:    slli.d $a1, $a1, 2
 ; LA64PIC-NEXT:    ldx.w $a1, $a0, $a1
-; LA64PIC-NEXT:    ld.w $a0, $a0, 0
+; LA64PIC-NEXT:    ld.w $zero, $a0, 0
 ; LA64PIC-NEXT:    move $a0, $a1
 ; LA64PIC-NEXT:    ret
   %1 = getelementptr i32, ptr %a, i64 %idx
@@ -497,8 +497,8 @@ define i64 @ldx_d(ptr %a, i64 %idx) nounwind {
 ; LA32NOPIC-NEXT:    alsl.w $a1, $a1, $a0, 3
 ; LA32NOPIC-NEXT:    ld.w $a2, $a1, 0
 ; LA32NOPIC-NEXT:    ld.w $a1, $a1, 4
-; LA32NOPIC-NEXT:    ld.w $a3, $a0, 0
-; LA32NOPIC-NEXT:    ld.w $a0, $a0, 4
+; LA32NOPIC-NEXT:    ld.w $zero, $a0, 0
+; LA32NOPIC-NEXT:    ld.w $zero, $a0, 4
 ; LA32NOPIC-NEXT:    move $a0, $a2
 ; LA32NOPIC-NEXT:    ret
 ;
@@ -507,8 +507,8 @@ define i64 @ldx_d(ptr %a, i64 %idx) nounwind {
 ; LA32PIC-NEXT:    alsl.w $a1, $a1, $a0, 3
 ; LA32PIC-NEXT:    ld.w $a2, $a1, 0
 ; LA32PIC-NEXT:    ld.w $a1, $a1, 4
-; LA32PIC-NEXT:    ld.w $a3, $a0, 0
-; LA32PIC-NEXT:    ld.w $a0, $a0, 4
+; LA32PIC-NEXT:    ld.w $zero, $a0, 0
+; LA32PIC-NEXT:    ld.w $zero, $a0, 4
 ; LA32PIC-NEXT:    move $a0, $a2
 ; LA32PIC-NEXT:    ret
 ;
@@ -516,7 +516,7 @@ define i64 @ldx_d(ptr %a, i64 %idx) nounwind {
 ; LA64NOPIC:       # %bb.0:
 ; LA64NOPIC-NEXT:    slli.d $a1, $a1, 3
 ; LA64NOPIC-NEXT:    ldx.d $a1, $a0, $a1
-; LA64NOPIC-NEXT:    ld.d $a0, $a0, 0
+; LA64NOPIC-NEXT:    ld.d $zero, $a0, 0
 ; LA64NOPIC-NEXT:    move $a0, $a1
 ; LA64NOPIC-NEXT:    ret
 ;
@@ -524,7 +524,7 @@ define i64 @ldx_d(ptr %a, i64 %idx) nounwind {
 ; LA64PIC:       # %bb.0:
 ; LA64PIC-NEXT:    slli.d $a1, $a1, 3
 ; LA64PIC-NEXT:    ldx.d $a1, $a0, $a1
-; LA64PIC-NEXT:    ld.d $a0, $a0, 0
+; LA64PIC-NEXT:    ld.d $zero, $a0, 0
 ; LA64PIC-NEXT:    move $a0, $a1
 ; LA64PIC-NEXT:    ret
   %1 = getelementptr i64, ptr %a, i64 %idx
@@ -855,7 +855,7 @@ define i64 @load_sext_zext_anyext_i1(ptr %a) nounwind {
 ; LA32NOPIC-NEXT:    ld.bu $a1, $a0, 1
 ; LA32NOPIC-NEXT:    ld.bu $a3, $a0, 2
 ; LA32NOPIC-NEXT:    sub.w $a2, $a3, $a1
-; LA32NOPIC-NEXT:    ld.b $a0, $a0, 0
+; LA32NOPIC-NEXT:    ld.b $zero, $a0, 0
 ; LA32NOPIC-NEXT:    sltu $a0, $a3, $a1
 ; LA32NOPIC-NEXT:    sub.w $a1, $zero, $a0
 ; LA32NOPIC-NEXT:    move $a0, $a2
@@ -866,7 +866,7 @@ define i64 @load_sext_zext_anyext_i1(ptr %a) nounwind {
 ; LA32PIC-NEXT:    ld.bu $a1, $a0, 1
 ; LA32PIC-NEXT:    ld.bu $a3, $a0, 2
 ; LA32PIC-NEXT:    sub.w $a2, $a3, $a1
-; LA32PIC-NEXT:    ld.b $a0, $a0, 0
+; LA32PIC-NEXT:    ld.b $zero, $a0, 0
 ; LA32PIC-NEXT:    sltu $a0, $a3, $a1
 ; LA32PIC-NEXT:    sub.w $a1, $zero, $a0
 ; LA32PIC-NEXT:    move $a0, $a2
@@ -876,7 +876,7 @@ define i64 @load_sext_zext_anyext_i1(ptr %a) nounwind {
 ; LA64NOPIC:       # %bb.0:
 ; LA64NOPIC-NEXT:    ld.bu $a1, $a0, 1
 ; LA64NOPIC-NEXT:    ld.bu $a2, $a0, 2
-; LA64NOPIC-NEXT:    ld.b $a0, $a0, 0
+; LA64NOPIC-NEXT:    ld.b $zero, $a0, 0
 ; LA64NOPIC-NEXT:    sub.d $a0, $a2, $a1
 ; LA64NOPIC-NEXT:    ret
 ;
@@ -884,7 +884,7 @@ define i64 @load_sext_zext_anyext_i1(ptr %a) nounwind {
 ; LA64PIC:       # %bb.0:
 ; LA64PIC-NEXT:    ld.bu $a1, $a0, 1
 ; LA64PIC-NEXT:    ld.bu $a2, $a0, 2
-; LA64PIC-NEXT:    ld.b $a0, $a0, 0
+; LA64PIC-NEXT:    ld.b $zero, $a0, 0
 ; LA64PIC-NEXT:    sub.d $a0, $a2, $a1
 ; LA64PIC-NEXT:    ret
   ;; sextload i1
@@ -906,7 +906,7 @@ define i16 @load_sext_zext_anyext_i1_i16(ptr %a) nounwind {
 ; LA32NOPIC:       # %bb.0:
 ; LA32NOPIC-NEXT:    ld.bu $a1, $a0, 1
 ; LA32NOPIC-NEXT:    ld.bu $a2, $a0, 2
-; LA32NOPIC-NEXT:    ld.b $a0, $a0, 0
+; LA32NOPIC-NEXT:    ld.b $zero, $a0, 0
 ; LA32NOPIC-NEXT:    sub.w $a0, $a2, $a1
 ; LA32NOPIC-NEXT:    ret
 ;
@@ -914,7 +914,7 @@ define i16 @load_sext_zext_anyext_i1_i16(ptr %a) nounwind {
 ; LA32PIC:       # %bb.0:
 ; LA32PIC-NEXT:    ld.bu $a1, $a0, 1
 ; LA32PIC-NEXT:    ld.bu $a2, $a0, 2
-; LA32PIC-NEXT:    ld.b $a0, $a0, 0
+; LA32PIC-NEXT:    ld.b $zero, $a0, 0
 ; LA32PIC-NEXT:    sub.w $a0, $a2, $a1
 ; LA32PIC-NEXT:    ret
 ;
@@ -922,7 +922,7 @@ define i16 @load_sext_zext_anyext_i1_i16(ptr %a) nounwind {
 ; LA64NOPIC:       # %bb.0:
 ; LA64NOPIC-NEXT:    ld.bu $a1, $a0, 1
 ; LA64NOPIC-NEXT:    ld.bu $a2, $a0, 2
-; LA64NOPIC-NEXT:    ld.b $a0, $a0, 0
+; LA64NOPIC-NEXT:    ld.b $zero, $a0, 0
 ; LA64NOPIC-NEXT:    sub.d $a0, $a2, $a1
 ; LA64NOPIC-NEXT:    ret
 ;
@@ -930,7 +930,7 @@ define i16 @load_sext_zext_anyext_i1_i16(ptr %a) nounwind {
 ; LA64PIC:       # %bb.0:
 ; LA64PIC-NEXT:    ld.bu $a1, $a0, 1
 ; LA64PIC-NEXT:    ld.bu $a2, $a0, 2
-; LA64PIC-NEXT:    ld.b $a0, $a0, 0
+; LA64PIC-NEXT:    ld.b $zero, $a0, 0
 ; LA64PIC-NEXT:    sub.d $a0, $a2, $a1
 ; LA64PIC-NEXT:    ret
   ;; sextload i1

--- a/llvm/test/CodeGen/LoongArch/psabi-restricted-scheduling.ll
+++ b/llvm/test/CodeGen/LoongArch/psabi-restricted-scheduling.ll
@@ -27,22 +27,22 @@ define void @foo() nounwind {
 ; MEDIUM_NO_SCH-NEXT:    st.d $ra, $sp, 8 # 8-byte Folded Spill
 ; MEDIUM_NO_SCH-NEXT:    pcalau12i $a0, %got_pc_hi20(G)
 ; MEDIUM_NO_SCH-NEXT:    ld.d $a0, $a0, %got_pc_lo12(G)
-; MEDIUM_NO_SCH-NEXT:    ld.d $a0, $a0, 0
+; MEDIUM_NO_SCH-NEXT:    ld.d $zero, $a0, 0
 ; MEDIUM_NO_SCH-NEXT:    pcalau12i $a0, %pc_hi20(g)
 ; MEDIUM_NO_SCH-NEXT:    addi.d $a0, $a0, %pc_lo12(g)
-; MEDIUM_NO_SCH-NEXT:    ld.d $a0, $a0, 0
+; MEDIUM_NO_SCH-NEXT:    ld.d $zero, $a0, 0
 ; MEDIUM_NO_SCH-NEXT:    ori $a0, $zero, 1
 ; MEDIUM_NO_SCH-NEXT:    pcaddu18i $ra, %call36(bar)
 ; MEDIUM_NO_SCH-NEXT:    jirl $ra, $ra, 0
 ; MEDIUM_NO_SCH-NEXT:    pcalau12i $a0, %ie_pc_hi20(gd)
 ; MEDIUM_NO_SCH-NEXT:    ld.d $a0, $a0, %ie_pc_lo12(gd)
-; MEDIUM_NO_SCH-NEXT:    ldx.d $a0, $a0, $tp
+; MEDIUM_NO_SCH-NEXT:    ldx.d $zero, $a0, $tp
 ; MEDIUM_NO_SCH-NEXT:    pcalau12i $a0, %ie_pc_hi20(ld)
 ; MEDIUM_NO_SCH-NEXT:    ld.d $a0, $a0, %ie_pc_lo12(ld)
-; MEDIUM_NO_SCH-NEXT:    ldx.d $a0, $a0, $tp
+; MEDIUM_NO_SCH-NEXT:    ldx.d $zero, $a0, $tp
 ; MEDIUM_NO_SCH-NEXT:    pcalau12i $a0, %ie_pc_hi20(ie)
 ; MEDIUM_NO_SCH-NEXT:    ld.d $a0, $a0, %ie_pc_lo12(ie)
-; MEDIUM_NO_SCH-NEXT:    ldx.d $a0, $a0, $tp
+; MEDIUM_NO_SCH-NEXT:    ldx.d $zero, $a0, $tp
 ; MEDIUM_NO_SCH-NEXT:    ld.d $ra, $sp, 8 # 8-byte Folded Reload
 ; MEDIUM_NO_SCH-NEXT:    addi.d $sp, $sp, 16
 ; MEDIUM_NO_SCH-NEXT:    ret
@@ -53,22 +53,22 @@ define void @foo() nounwind {
 ; MEDIUM_SCH-NEXT:    st.d $ra, $sp, 8 # 8-byte Folded Spill
 ; MEDIUM_SCH-NEXT:    pcalau12i $a0, %got_pc_hi20(G)
 ; MEDIUM_SCH-NEXT:    ld.d $a0, $a0, %got_pc_lo12(G)
-; MEDIUM_SCH-NEXT:    ld.d $a0, $a0, 0
+; MEDIUM_SCH-NEXT:    ld.d $zero, $a0, 0
 ; MEDIUM_SCH-NEXT:    pcalau12i $a0, %pc_hi20(g)
 ; MEDIUM_SCH-NEXT:    addi.d $a0, $a0, %pc_lo12(g)
-; MEDIUM_SCH-NEXT:    ld.d $a0, $a0, 0
+; MEDIUM_SCH-NEXT:    ld.d $zero, $a0, 0
 ; MEDIUM_SCH-NEXT:    ori $a0, $zero, 1
 ; MEDIUM_SCH-NEXT:    pcaddu18i $ra, %call36(bar)
 ; MEDIUM_SCH-NEXT:    jirl $ra, $ra, 0
 ; MEDIUM_SCH-NEXT:    pcalau12i $a0, %ie_pc_hi20(gd)
 ; MEDIUM_SCH-NEXT:    ld.d $a0, $a0, %ie_pc_lo12(gd)
-; MEDIUM_SCH-NEXT:    ldx.d $a0, $a0, $tp
+; MEDIUM_SCH-NEXT:    ldx.d $zero, $a0, $tp
 ; MEDIUM_SCH-NEXT:    pcalau12i $a0, %ie_pc_hi20(ld)
 ; MEDIUM_SCH-NEXT:    ld.d $a0, $a0, %ie_pc_lo12(ld)
-; MEDIUM_SCH-NEXT:    ldx.d $a0, $a0, $tp
+; MEDIUM_SCH-NEXT:    ldx.d $zero, $a0, $tp
 ; MEDIUM_SCH-NEXT:    pcalau12i $a0, %ie_pc_hi20(ie)
 ; MEDIUM_SCH-NEXT:    ld.d $a0, $a0, %ie_pc_lo12(ie)
-; MEDIUM_SCH-NEXT:    ldx.d $a0, $a0, $tp
+; MEDIUM_SCH-NEXT:    ldx.d $zero, $a0, $tp
 ; MEDIUM_SCH-NEXT:    ld.d $ra, $sp, 8 # 8-byte Folded Reload
 ; MEDIUM_SCH-NEXT:    addi.d $sp, $sp, 16
 ; MEDIUM_SCH-NEXT:    ret
@@ -82,13 +82,13 @@ define void @foo() nounwind {
 ; LARGE_NO_SCH-NEXT:    lu32i.d $t8, %got64_pc_lo20(G)
 ; LARGE_NO_SCH-NEXT:    lu52i.d $t8, $t8, %got64_pc_hi12(G)
 ; LARGE_NO_SCH-NEXT:    ldx.d $a0, $t8, $a0
-; LARGE_NO_SCH-NEXT:    ld.d $a0, $a0, 0
+; LARGE_NO_SCH-NEXT:    ld.d $zero, $a0, 0
 ; LARGE_NO_SCH-NEXT:    pcalau12i $a0, %pc_hi20(g)
 ; LARGE_NO_SCH-NEXT:    addi.d $t8, $zero, %pc_lo12(g)
 ; LARGE_NO_SCH-NEXT:    lu32i.d $t8, %pc64_lo20(g)
 ; LARGE_NO_SCH-NEXT:    lu52i.d $t8, $t8, %pc64_hi12(g)
 ; LARGE_NO_SCH-NEXT:    add.d $a0, $t8, $a0
-; LARGE_NO_SCH-NEXT:    ld.d $a0, $a0, 0
+; LARGE_NO_SCH-NEXT:    ld.d $zero, $a0, 0
 ; LARGE_NO_SCH-NEXT:    ori $a0, $zero, 1
 ; LARGE_NO_SCH-NEXT:    pcalau12i $ra, %got_pc_hi20(bar)
 ; LARGE_NO_SCH-NEXT:    addi.d $t8, $zero, %got_pc_lo12(bar)
@@ -101,19 +101,19 @@ define void @foo() nounwind {
 ; LARGE_NO_SCH-NEXT:    lu32i.d $t8, %ie64_pc_lo20(gd)
 ; LARGE_NO_SCH-NEXT:    lu52i.d $t8, $t8, %ie64_pc_hi12(gd)
 ; LARGE_NO_SCH-NEXT:    ldx.d $a0, $t8, $a0
-; LARGE_NO_SCH-NEXT:    ldx.d $a0, $a0, $tp
+; LARGE_NO_SCH-NEXT:    ldx.d $zero, $a0, $tp
 ; LARGE_NO_SCH-NEXT:    pcalau12i $a0, %ie_pc_hi20(ld)
 ; LARGE_NO_SCH-NEXT:    addi.d $t8, $zero, %ie_pc_lo12(ld)
 ; LARGE_NO_SCH-NEXT:    lu32i.d $t8, %ie64_pc_lo20(ld)
 ; LARGE_NO_SCH-NEXT:    lu52i.d $t8, $t8, %ie64_pc_hi12(ld)
 ; LARGE_NO_SCH-NEXT:    ldx.d $a0, $t8, $a0
-; LARGE_NO_SCH-NEXT:    ldx.d $a0, $a0, $tp
+; LARGE_NO_SCH-NEXT:    ldx.d $zero, $a0, $tp
 ; LARGE_NO_SCH-NEXT:    pcalau12i $a0, %ie_pc_hi20(ie)
 ; LARGE_NO_SCH-NEXT:    addi.d $t8, $zero, %ie_pc_lo12(ie)
 ; LARGE_NO_SCH-NEXT:    lu32i.d $t8, %ie64_pc_lo20(ie)
 ; LARGE_NO_SCH-NEXT:    lu52i.d $t8, $t8, %ie64_pc_hi12(ie)
 ; LARGE_NO_SCH-NEXT:    ldx.d $a0, $t8, $a0
-; LARGE_NO_SCH-NEXT:    ldx.d $a0, $a0, $tp
+; LARGE_NO_SCH-NEXT:    ldx.d $zero, $a0, $tp
 ; LARGE_NO_SCH-NEXT:    ld.d $ra, $sp, 8 # 8-byte Folded Reload
 ; LARGE_NO_SCH-NEXT:    addi.d $sp, $sp, 16
 ; LARGE_NO_SCH-NEXT:    ret
@@ -127,13 +127,13 @@ define void @foo() nounwind {
 ; LARGE_SCH-NEXT:    lu32i.d $t8, %got64_pc_lo20(G)
 ; LARGE_SCH-NEXT:    lu52i.d $t8, $t8, %got64_pc_hi12(G)
 ; LARGE_SCH-NEXT:    ldx.d $a0, $t8, $a0
-; LARGE_SCH-NEXT:    ld.d $a0, $a0, 0
+; LARGE_SCH-NEXT:    ld.d $zero, $a0, 0
 ; LARGE_SCH-NEXT:    pcalau12i $a0, %pc_hi20(g)
 ; LARGE_SCH-NEXT:    addi.d $t8, $zero, %pc_lo12(g)
 ; LARGE_SCH-NEXT:    lu32i.d $t8, %pc64_lo20(g)
 ; LARGE_SCH-NEXT:    lu52i.d $t8, $t8, %pc64_hi12(g)
 ; LARGE_SCH-NEXT:    add.d $a0, $t8, $a0
-; LARGE_SCH-NEXT:    ld.d $a0, $a0, 0
+; LARGE_SCH-NEXT:    ld.d $zero, $a0, 0
 ; LARGE_SCH-NEXT:    ori $a0, $zero, 1
 ; LARGE_SCH-NEXT:    pcalau12i $ra, %got_pc_hi20(bar)
 ; LARGE_SCH-NEXT:    addi.d $t8, $zero, %got_pc_lo12(bar)
@@ -146,19 +146,19 @@ define void @foo() nounwind {
 ; LARGE_SCH-NEXT:    lu32i.d $t8, %ie64_pc_lo20(gd)
 ; LARGE_SCH-NEXT:    lu52i.d $t8, $t8, %ie64_pc_hi12(gd)
 ; LARGE_SCH-NEXT:    ldx.d $a0, $t8, $a0
-; LARGE_SCH-NEXT:    ldx.d $a0, $a0, $tp
+; LARGE_SCH-NEXT:    ldx.d $zero, $a0, $tp
 ; LARGE_SCH-NEXT:    pcalau12i $a0, %ie_pc_hi20(ld)
 ; LARGE_SCH-NEXT:    addi.d $t8, $zero, %ie_pc_lo12(ld)
 ; LARGE_SCH-NEXT:    lu32i.d $t8, %ie64_pc_lo20(ld)
 ; LARGE_SCH-NEXT:    lu52i.d $t8, $t8, %ie64_pc_hi12(ld)
 ; LARGE_SCH-NEXT:    ldx.d $a0, $t8, $a0
-; LARGE_SCH-NEXT:    ldx.d $a0, $a0, $tp
+; LARGE_SCH-NEXT:    ldx.d $zero, $a0, $tp
 ; LARGE_SCH-NEXT:    pcalau12i $a0, %ie_pc_hi20(ie)
 ; LARGE_SCH-NEXT:    addi.d $t8, $zero, %ie_pc_lo12(ie)
 ; LARGE_SCH-NEXT:    lu32i.d $t8, %ie64_pc_lo20(ie)
 ; LARGE_SCH-NEXT:    lu52i.d $t8, $t8, %ie64_pc_hi12(ie)
 ; LARGE_SCH-NEXT:    ldx.d $a0, $t8, $a0
-; LARGE_SCH-NEXT:    ldx.d $a0, $a0, $tp
+; LARGE_SCH-NEXT:    ldx.d $zero, $a0, $tp
 ; LARGE_SCH-NEXT:    ld.d $ra, $sp, 8 # 8-byte Folded Reload
 ; LARGE_SCH-NEXT:    addi.d $sp, $sp, 16
 ; LARGE_SCH-NEXT:    ret

--- a/llvm/utils/gn/secondary/llvm/lib/Target/LoongArch/BUILD.gn
+++ b/llvm/utils/gn/secondary/llvm/lib/Target/LoongArch/BUILD.gn
@@ -34,6 +34,7 @@ static_library("LLVMLoongArchCodeGen") {
   include_dirs = [ "." ]
   sources = [
     "LoongArchAsmPrinter.cpp",
+    "LoongArchDeadRegisterDefinitions.cpp",
     "LoongArchExpandAtomicPseudoInsts.cpp",
     "LoongArchExpandPseudoInsts.cpp",
     "LoongArchFrameLowering.cpp",


### PR DESCRIPTION
This patch adds a peephole pass `LoongArchDeadRegisterDefinitions`. It rewrites `rd` to `r0` when `rd` is marked as dead. It may improve the register allocation and reduce pipeline hazards on CPUs without register renaming and OOO.