### PR TITLE
[PowerPC] Alignment of toc-data symbol should not be increased during optimizations

### DIFF
--- a/llvm/docs/LangRef.rst
+++ b/llvm/docs/LangRef.rst
@@ -814,7 +814,7 @@ not GEPs.
 
 Globals with ``toc-data`` attribute set are stored in TOC of XCOFF. Their
 alignments are not larger than that of a TOC entry. Optimizations should not
-increase their alignments to prevent TOC overflow.
+increase their alignments to mitigate TOC overflow.
 
 Syntax::
 

--- a/llvm/docs/LangRef.rst
+++ b/llvm/docs/LangRef.rst
@@ -812,6 +812,10 @@ doesn't). These kinds of structs (we may call them homogeneous scalable vector
 structs) are considered sized and can be used in loads, stores, allocas, but
 not GEPs.
 
+Globals with ``toc-data`` attribute set are stored in TOC of XCOFF. Their
+alignments are not larger than that of a TOC entry. Optimizations should not
+increase their alignments to prevent TOC overflow.
+
 Syntax::
 
       @<GlobalVarName> = [Linkage] [PreemptionSpecifier] [Visibility]

--- a/llvm/lib/IR/Globals.cpp
+++ b/llvm/lib/IR/Globals.cpp
@@ -341,7 +341,6 @@ bool GlobalObject::canIncreaseAlignment() const {
     if (const GlobalVariable *GV = dyn_cast<GlobalVariable>(this))
       // GV with toc-data attribute is defined in a TOC entry which 
       // has a fixed alignment and cannot be arbitrarily increased.
-      // Its alignment should be the same as toc entry.
       return !GV->hasAttribute("toc-data");
 
   return true;

--- a/llvm/lib/IR/Globals.cpp
+++ b/llvm/lib/IR/Globals.cpp
@@ -339,7 +339,8 @@ bool GlobalObject::canIncreaseAlignment() const {
       (!Parent || Triple(Parent->getTargetTriple()).isOSBinFormatXCOFF());
   if (isXCOFF)
     if (const GlobalVariable *GV = dyn_cast<GlobalVariable>(this))
-      // GV with toc-data attribute is put in the region same as toc entry.
+      // GV with toc-data attribute is defined in a TOC entry which 
+      // has a fixed alignment and cannot be arbitrarily increased.
       // Its alignment should be the same as toc entry.
       return !GV->hasAttribute("toc-data");
 

--- a/llvm/lib/IR/Globals.cpp
+++ b/llvm/lib/IR/Globals.cpp
@@ -339,8 +339,8 @@ bool GlobalObject::canIncreaseAlignment() const {
       (!Parent || Triple(Parent->getTargetTriple()).isOSBinFormatXCOFF());
   if (isXCOFF)
     if (const GlobalVariable *GV = dyn_cast<GlobalVariable>(this))
-      // GV with toc-data attribute is defined in a TOC entry which 
-      // has a fixed alignment and cannot be arbitrarily increased.
+      // GV with toc-data attribute is defined in a TOC entry which has a fixed
+      // alignment and cannot be arbitrarily increased.
       return !GV->hasAttribute("toc-data");
 
   return true;

--- a/llvm/lib/IR/Globals.cpp
+++ b/llvm/lib/IR/Globals.cpp
@@ -335,6 +335,14 @@ bool GlobalObject::canIncreaseAlignment() const {
   if (isELF && !isDSOLocal())
     return false;
 
+  bool isXCOFF =
+      (!Parent || Triple(Parent->getTargetTriple()).isOSBinFormatXCOFF());
+  if (isXCOFF)
+    if (const GlobalVariable *GV = dyn_cast<GlobalVariable>(this))
+      // GV with toc-data attribute is put in the region same as toc entry.
+      // Its alignment should be the same as toc entry.
+      return !GV->hasAttribute("toc-data");
+
   return true;
 }
 

--- a/llvm/lib/IR/Globals.cpp
+++ b/llvm/lib/IR/Globals.cpp
@@ -335,12 +335,13 @@ bool GlobalObject::canIncreaseAlignment() const {
   if (isELF && !isDSOLocal())
     return false;
 
+  // GV with toc-data attribute is defined in a TOC entry. To mitigate TOC
+  // overflow, the alignment of such symbol should not be increased. Otherwise,
+  // padding is needed thus more TOC entries are wasted.
   bool isXCOFF =
       (!Parent || Triple(Parent->getTargetTriple()).isOSBinFormatXCOFF());
   if (isXCOFF)
     if (const GlobalVariable *GV = dyn_cast<GlobalVariable>(this))
-      // GV with toc-data attribute is defined in a TOC entry which has a fixed
-      // alignment and cannot be arbitrarily increased.
       return !GV->hasAttribute("toc-data");
 
   return true;

--- a/llvm/lib/IR/Globals.cpp
+++ b/llvm/lib/IR/Globals.cpp
@@ -342,7 +342,8 @@ bool GlobalObject::canIncreaseAlignment() const {
       (!Parent || Triple(Parent->getTargetTriple()).isOSBinFormatXCOFF());
   if (isXCOFF)
     if (const GlobalVariable *GV = dyn_cast<GlobalVariable>(this))
-      return !GV->hasAttribute("toc-data");
+      if (GV->hasAttribute("toc-data"))
+        return false;
 
   return true;
 }

--- a/llvm/test/CodeGen/PowerPC/tocdata-firm-alignment.ll
+++ b/llvm/test/CodeGen/PowerPC/tocdata-firm-alignment.ll
@@ -5,7 +5,7 @@ target triple = "powerpc-ibm-aix7.2.0.0"
 
 %struct.widget = type { i8, i8, i8 }
 
-; CHECK: @global = {{.*}}constant %struct.widget { i8 4, i8 0, i8 0 }, align 8 #0
+; CHECK: @global = {{.*}}constant %struct.widget { i8 4, i8 0, i8 0 }, align 4 #0
 @global = constant %struct.widget { i8 4, i8 0, i8 0 }, align 4 #0
 
 define void @baz() #1 {


### PR DESCRIPTION
Currently, the alignment of toc-data symbol might be changed during instcombine
```
IC: Visiting:   %global = alloca %struct.widget, align 8                                                                                         
Found alloca equal to global:   %global = alloca %struct.widget, align 8                                                                         
  memcpy =   call void @llvm.memcpy.p0.p0.i64(ptr nonnull align 1 %global, ptr align 1 @global, i64 3, i1 false)
```
The `alloca` is created with `PrefAlign` which is 8 and after IC, the alignment of `@global` is enforced into `8`, same as the `alloca`. This is not expected, since toc-data symbol has the same alignment as toc entry and should not be increased during optimizations.