### PR TITLE
[AIX] use LIBPATH on AIX instead of LD_LIBRARY_PATH

### DIFF
--- a/llvm/utils/lit/lit/llvm/config.py
+++ b/llvm/utils/lit/lit/llvm/config.py
@@ -588,7 +588,10 @@ class LLVMConfig(object):
             if getattr(self.config, pp, None)
         ]
 
-        self.with_environment("LD_LIBRARY_PATH", lib_paths, append_path=True)
+        if sys.platform.startswith("aix"):
+            self.with_environment("LIBPATH", lib_paths, append_path=True)
+        else:
+            self.with_environment("LD_LIBRARY_PATH", lib_paths, append_path=True)
 
         shl = getattr(self.config, "llvm_shlib_dir", None)
         pext = getattr(self.config, "llvm_plugin_ext", None)

--- a/llvm/utils/lit/lit/llvm/config.py
+++ b/llvm/utils/lit/lit/llvm/config.py
@@ -588,7 +588,7 @@ class LLVMConfig(object):
             if getattr(self.config, pp, None)
         ]
 
-        if sys.platform.startswith("aix"):
+        if platform.system() == "AIX":
             self.with_environment("LIBPATH", lib_paths, append_path=True)
         else:
             self.with_environment("LD_LIBRARY_PATH", lib_paths, append_path=True)


### PR DESCRIPTION
LD_LIBRARY_PATH will become invalid when LIBPATH is also set on AIX.

See below example on AIX:
```
$ldd a.out
a.out needs:
	 /usr/lib/libc.a(shr.o)
Cannot find libtest.a
	 /unix
	 /usr/lib/libcrypt.a(shr.o)

$./a.out
Could not load program ./a.out:
	Dependent module libtest.a could not be loaded.
Could not load module libtest.a.
System error: No such file or directory

$export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/tmp
$./a.out ; echo $?
10

$export LIBPATH=./
$./a.out ; echo $?  >>>>>> Now LD_LIBRARY_PATH is not used by system loader
Could not load program ./a.out:
	Dependent module libtest.a could not be loaded.
Could not load module libtest.a.
System error: No such file or directory
```

This breaks many AIX LIT cases on our downstream buildbots which sets LIBPATH.