### PR TITLE
[CodeGen][SDAG] Remove CombinedNodes SmallPtrSet

### DIFF
--- a/llvm/include/llvm/CodeGen/SelectionDAGNodes.h
+++ b/llvm/include/llvm/CodeGen/SelectionDAGNodes.h
@@ -649,7 +649,9 @@ private:
   /// Return a pointer to the specified value type.
   static const EVT *getValueTypeList(EVT VT);
 
-  /// Index in worklist of DAGCombiner, or -1.
+  /// Index in worklist of DAGCombiner, or negative if the node is not in the
+  /// worklist. -1 = not in worklist; -2 = not in worklist, but has already been
+  /// combined at least once.
   int CombinerWorklistIndex = -1;
 
   uint32_t CFIType = 0;


### PR DESCRIPTION
This "small" set grows quite large and it's more performant to store whether a node has been combined before in the node itself.

As this information is only relevant for nodes that are currently not in the worklist, add a second state to the CombinerWorklistIndex (-2) to indicate that a node is currently not in a worklist, but was combined before.

This brings a substantial performance improvement, see [here](http://llvm-compile-time-tracker.com/compare.php?from=6150e84cfc87d118f8cd2794e40dd021c8779e9d&to=eb6eecb3fbefe62622014e47453f816ec1a621c6&stat=instructions:u).