### PR TITLE
[gtest] Enable zos for death test support

### DIFF
--- a/third-party/unittest/googletest/include/gtest/internal/gtest-port.h
+++ b/third-party/unittest/googletest/include/gtest/internal/gtest-port.h
@@ -652,7 +652,7 @@ typedef struct _RTL_CRITICAL_SECTION GTEST_CRITICAL_SECTION;
 // Determines whether to support death tests.
 // pops up a dialog window that cannot be suppressed programmatically.
 #if (defined(GTEST_OS_LINUX) || defined(GTEST_OS_CYGWIN) ||           \
-     defined(GTEST_OS_SOLARIS) ||                                     \
+     defined(GTEST_OS_SOLARIS) || defined(GTEST_OS_ZOS) ||            \
      (defined(GTEST_OS_MAC) && !defined(GTEST_OS_IOS)) ||             \
      (defined(GTEST_OS_WINDOWS_DESKTOP) && _MSC_VER) ||               \
      defined(GTEST_OS_WINDOWS_MINGW) || defined(GTEST_OS_AIX) ||      \


### PR DESCRIPTION
This patch implements the following change to enable zos for death test support. https://github.com/google/googletest/pull/4527