### PR TITLE
Reapply PR/87550

### DIFF
--- a/lldb/include/lldb/API/SBDebugger.h
+++ b/lldb/include/lldb/API/SBDebugger.h
@@ -57,6 +57,8 @@ public:
 
   static const char *GetBroadcasterClass();
 
+  static bool SupportsLanguage(lldb::LanguageType language);
+
   lldb::SBBroadcaster GetBroadcaster();
 
   /// Get progress data from a SBEvent whose type is eBroadcastBitProgress.

--- a/lldb/include/lldb/Symbol/TypeSystem.h
+++ b/lldb/include/lldb/Symbol/TypeSystem.h
@@ -209,6 +209,7 @@ public:
   // TypeSystems can support more than one language
   virtual bool SupportsLanguage(lldb::LanguageType language) = 0;
 
+  static bool SupportsLanguageStatic(lldb::LanguageType language);
   // Type Completion
 
   virtual bool GetCompleteType(lldb::opaque_compiler_type_t type) = 0;

--- a/lldb/source/API/SBDebugger.cpp
+++ b/lldb/source/API/SBDebugger.cpp
@@ -1742,3 +1742,7 @@ bool SBDebugger::InterruptRequested()   {
     return m_opaque_sp->InterruptRequested();
   return false;
 }
+
+bool SBDebugger::SupportsLanguage(lldb::LanguageType language) {
+  return TypeSystem::SupportsLanguageStatic(language);
+}

--- a/lldb/source/Symbol/TypeSystem.cpp
+++ b/lldb/source/Symbol/TypeSystem.cpp
@@ -335,3 +335,14 @@ TypeSystemMap::GetTypeSystemForLanguage(lldb::LanguageType language,
   }
   return GetTypeSystemForLanguage(language);
 }
+
+bool TypeSystem::SupportsLanguageStatic(lldb::LanguageType language) {
+  if (language == eLanguageTypeUnknown)
+    return false;
+
+  LanguageSet languages =
+      PluginManager::GetAllTypeSystemSupportedLanguagesForTypes();
+  if (languages.Empty())
+    return false;
+  return languages[language];
+}

--- a/lldb/tools/lldb-dap/DAP.cpp
+++ b/lldb/tools/lldb-dap/DAP.cpp
@@ -60,19 +60,19 @@ DAP::~DAP() = default;
 
 void DAP::PopulateExceptionBreakpoints() {
   exception_breakpoints = {};
-  if (debugger.SupportsLanguage(lldb::eLanguageTypeC_plus_plus)) {
+  if (SBDebugger::SupportsLanguage(lldb::eLanguageTypeC_plus_plus)) {
     exception_breakpoints->emplace_back("cpp_catch", "C++ Catch",
                                         lldb::eLanguageTypeC_plus_plus);
     exception_breakpoints->emplace_back("cpp_throw", "C++ Throw",
                                         lldb::eLanguageTypeC_plus_plus);
   }
-  if (debugger.SupportsLanguage(lldb::eLanguageTypeObjC)) {
+  if (SBDebugger::SupportsLanguage(lldb::eLanguageTypeObjC)) {
     exception_breakpoints->emplace_back("objc_catch", "Objective-C Catch",
                                         lldb::eLanguageTypeObjC);
     exception_breakpoints->emplace_back("objc_throw", "Objective-C Throw",
                                         lldb::eLanguageTypeObjC);
   }
-  if (debugger.SupportsLanguage(lldb::eLanguageTypeSwift)) {
+  if (SBDebugger::SupportsLanguage(lldb::eLanguageTypeSwift)) {
     exception_breakpoints->emplace_back("swift_catch", "Swift Catch",
                                         lldb::eLanguageTypeSwift);
     exception_breakpoints->emplace_back("swift_throw", "Swift Throw",
@@ -81,8 +81,24 @@ void DAP::PopulateExceptionBreakpoints() {
 }
 
 ExceptionBreakpoint *DAP::GetExceptionBreakpoint(const std::string &filter) {
-  assert(exception_breakpoints.has_value() &&
-         "PopulateExceptionBreakpoints must be called first");
+  // PopulateExceptionBreakpoints() is called after g_dap.debugger is created
+  // in a request-initialize.
+  //
+  // But this GetExceptionBreakpoint() method may be called before attaching, in
+  // which case, we may not have populated the filter yet.
+  //
+  // We also cannot call PopulateExceptionBreakpoints() in DAP::DAP() because
+  // we need SBDebugger::Initialize() to have been called before this.
+  //
+  // So just checking the filter list and do lazy-populating seems easiest.
+  // Two other options include:
+  //  + call g_dap.PopulateExceptionBreakpoints() in lldb-dap.cpp::main()
+  //    right after the call to SBDebugger::Initialize()
+  //  + Just call PopulateExceptionBreakpoints() to get a fresh list  everytime
+  //    we query (a bit overkill since it's not likely to change?)
+  if (!exception_breakpoints.has_value)
+    PopulateExceptionBreakpoints();
+
   for (auto &bp : *exception_breakpoints) {
     if (bp.filter == filter)
       return &bp;
@@ -91,8 +107,10 @@ ExceptionBreakpoint *DAP::GetExceptionBreakpoint(const std::string &filter) {
 }
 
 ExceptionBreakpoint *DAP::GetExceptionBreakpoint(const lldb::break_id_t bp_id) {
-  assert(exception_breakpoints.has_value() &&
-         "PopulateExceptionBreakpoints must be called first");
+  // See comment in the other GetExceptionBreakpoint().
+  if (!exception_breakpoints.has_value)
+    PopulateExceptionBreakpoints();
+
   for (auto &bp : *exception_breakpoints) {
     if (bp.bp.GetID() == bp_id)
       return &bp;

--- a/lldb/tools/lldb-dap/DAP.cpp
+++ b/lldb/tools/lldb-dap/DAP.cpp
@@ -59,25 +59,29 @@ DAP::DAP()
 DAP::~DAP() = default;
 
 void DAP::PopulateExceptionBreakpoints() {
-  exception_breakpoints = {};
-  if (lldb::SBDebugger::SupportsLanguage(lldb::eLanguageTypeC_plus_plus)) {
-    exception_breakpoints->emplace_back("cpp_catch", "C++ Catch",
-                                        lldb::eLanguageTypeC_plus_plus);
-    exception_breakpoints->emplace_back("cpp_throw", "C++ Throw",
-                                        lldb::eLanguageTypeC_plus_plus);
-  }
-  if (lldb::SBDebugger::SupportsLanguage(lldb::eLanguageTypeObjC)) {
-    exception_breakpoints->emplace_back("objc_catch", "Objective-C Catch",
-                                        lldb::eLanguageTypeObjC);
-    exception_breakpoints->emplace_back("objc_throw", "Objective-C Throw",
-                                        lldb::eLanguageTypeObjC);
-  }
-  if (lldb::SBDebugger::SupportsLanguage(lldb::eLanguageTypeSwift)) {
-    exception_breakpoints->emplace_back("swift_catch", "Swift Catch",
-                                        lldb::eLanguageTypeSwift);
-    exception_breakpoints->emplace_back("swift_throw", "Swift Throw",
-                                        lldb::eLanguageTypeSwift);
-  }
+  if (exception_breakpoints.has_value())
+    return;
+  llvm::call_once(initExceptionBreakpoints, [this]() {
+    exception_breakpoints = {};
+    if (lldb::SBDebugger::SupportsLanguage(lldb::eLanguageTypeC_plus_plus)) {
+      exception_breakpoints->emplace_back("cpp_catch", "C++ Catch",
+                                          lldb::eLanguageTypeC_plus_plus);
+      exception_breakpoints->emplace_back("cpp_throw", "C++ Throw",
+                                          lldb::eLanguageTypeC_plus_plus);
+    }
+    if (lldb::SBDebugger::SupportsLanguage(lldb::eLanguageTypeObjC)) {
+      exception_breakpoints->emplace_back("objc_catch", "Objective-C Catch",
+                                          lldb::eLanguageTypeObjC);
+      exception_breakpoints->emplace_back("objc_throw", "Objective-C Throw",
+                                          lldb::eLanguageTypeObjC);
+    }
+    if (lldb::SBDebugger::SupportsLanguage(lldb::eLanguageTypeSwift)) {
+      exception_breakpoints->emplace_back("swift_catch", "Swift Catch",
+                                          lldb::eLanguageTypeSwift);
+      exception_breakpoints->emplace_back("swift_throw", "Swift Throw",
+                                          lldb::eLanguageTypeSwift);
+    }
+  });
 }
 
 ExceptionBreakpoint *DAP::GetExceptionBreakpoint(const std::string &filter) {
@@ -90,14 +94,15 @@ ExceptionBreakpoint *DAP::GetExceptionBreakpoint(const std::string &filter) {
   // We also cannot call PopulateExceptionBreakpoints() in DAP::DAP() because
   // we need SBDebugger::Initialize() to have been called before this.
   //
-  // So just checking the filter list and do lazy-populating seems easiest.
-  // Two other options include:
+  // So just calling PopulateExceptionBreakoints(),which does lazy-populating
+  // seems easiest. Two other options include:
   //  + call g_dap.PopulateExceptionBreakpoints() in lldb-dap.cpp::main()
   //    right after the call to SBDebugger::Initialize()
   //  + Just call PopulateExceptionBreakpoints() to get a fresh list  everytime
   //    we query (a bit overkill since it's not likely to change?)
-  if (!exception_breakpoints.has_value())
-    PopulateExceptionBreakpoints();
+  PopulateExceptionBreakpoints();
+  assert(exception_breakpoints.has_value() &&
+         "exception_breakpoints must have been populated");
 
   for (auto &bp : *exception_breakpoints) {
     if (bp.filter == filter)
@@ -108,8 +113,9 @@ ExceptionBreakpoint *DAP::GetExceptionBreakpoint(const std::string &filter) {
 
 ExceptionBreakpoint *DAP::GetExceptionBreakpoint(const lldb::break_id_t bp_id) {
   // See comment in the other GetExceptionBreakpoint().
-  if (!exception_breakpoints.has_value())
-    PopulateExceptionBreakpoints();
+  PopulateExceptionBreakpoints();
+  assert(exception_breakpoints.has_value() &&
+         "exception_breakpoints must have been populated");
 
   for (auto &bp : *exception_breakpoints) {
     if (bp.bp.GetID() == bp_id)

--- a/lldb/tools/lldb-dap/DAP.cpp
+++ b/lldb/tools/lldb-dap/DAP.cpp
@@ -96,7 +96,7 @@ ExceptionBreakpoint *DAP::GetExceptionBreakpoint(const std::string &filter) {
   //    right after the call to SBDebugger::Initialize()
   //  + Just call PopulateExceptionBreakpoints() to get a fresh list  everytime
   //    we query (a bit overkill since it's not likely to change?)
-  if (!exception_breakpoints.has_value)
+  if (!exception_breakpoints.has_value())
     PopulateExceptionBreakpoints();
 
   for (auto &bp : *exception_breakpoints) {
@@ -108,7 +108,7 @@ ExceptionBreakpoint *DAP::GetExceptionBreakpoint(const std::string &filter) {
 
 ExceptionBreakpoint *DAP::GetExceptionBreakpoint(const lldb::break_id_t bp_id) {
   // See comment in the other GetExceptionBreakpoint().
-  if (!exception_breakpoints.has_value)
+  if (!exception_breakpoints.has_value())
     PopulateExceptionBreakpoints();
 
   for (auto &bp : *exception_breakpoints) {

--- a/lldb/tools/lldb-dap/DAP.cpp
+++ b/lldb/tools/lldb-dap/DAP.cpp
@@ -60,19 +60,19 @@ DAP::~DAP() = default;
 
 void DAP::PopulateExceptionBreakpoints() {
   exception_breakpoints = {};
-  if (SBDebugger::SupportsLanguage(lldb::eLanguageTypeC_plus_plus)) {
+  if (lldb::SBDebugger::SupportsLanguage(lldb::eLanguageTypeC_plus_plus)) {
     exception_breakpoints->emplace_back("cpp_catch", "C++ Catch",
                                         lldb::eLanguageTypeC_plus_plus);
     exception_breakpoints->emplace_back("cpp_throw", "C++ Throw",
                                         lldb::eLanguageTypeC_plus_plus);
   }
-  if (SBDebugger::SupportsLanguage(lldb::eLanguageTypeObjC)) {
+  if (lldb::SBDebugger::SupportsLanguage(lldb::eLanguageTypeObjC)) {
     exception_breakpoints->emplace_back("objc_catch", "Objective-C Catch",
                                         lldb::eLanguageTypeObjC);
     exception_breakpoints->emplace_back("objc_throw", "Objective-C Throw",
                                         lldb::eLanguageTypeObjC);
   }
-  if (SBDebugger::SupportsLanguage(lldb::eLanguageTypeSwift)) {
+  if (lldb::SBDebugger::SupportsLanguage(lldb::eLanguageTypeSwift)) {
     exception_breakpoints->emplace_back("swift_catch", "Swift Catch",
                                         lldb::eLanguageTypeSwift);
     exception_breakpoints->emplace_back("swift_throw", "Swift Throw",

--- a/lldb/tools/lldb-dap/DAP.cpp
+++ b/lldb/tools/lldb-dap/DAP.cpp
@@ -59,8 +59,6 @@ DAP::DAP()
 DAP::~DAP() = default;
 
 void DAP::PopulateExceptionBreakpoints() {
-  if (exception_breakpoints.has_value())
-    return;
   llvm::call_once(initExceptionBreakpoints, [this]() {
     exception_breakpoints = {};
     if (lldb::SBDebugger::SupportsLanguage(lldb::eLanguageTypeC_plus_plus)) {

--- a/lldb/tools/lldb-dap/DAP.h
+++ b/lldb/tools/lldb-dap/DAP.h
@@ -156,7 +156,7 @@ struct DAP {
   std::unique_ptr<std::ofstream> log;
   llvm::StringMap<SourceBreakpointMap> source_breakpoints;
   FunctionBreakpointMap function_breakpoints;
-  std::vector<ExceptionBreakpoint> exception_breakpoints;
+  std::optional<std::vector<ExceptionBreakpoint>> exception_breakpoints;
   std::vector<std::string> init_commands;
   std::vector<std::string> pre_run_commands;
   std::vector<std::string> post_run_commands;
@@ -227,6 +227,8 @@ struct DAP {
   lldb::SBFrame GetLLDBFrame(const llvm::json::Object &arguments);
 
   llvm::json::Value CreateTopLevelScopes();
+
+  void PopulateExceptionBreakpoints();
 
   /// \return
   ///   Attempt to determine if an expression is a variable expression or

--- a/lldb/tools/lldb-dap/DAP.h
+++ b/lldb/tools/lldb-dap/DAP.h
@@ -157,6 +157,7 @@ struct DAP {
   llvm::StringMap<SourceBreakpointMap> source_breakpoints;
   FunctionBreakpointMap function_breakpoints;
   std::optional<std::vector<ExceptionBreakpoint>> exception_breakpoints;
+  llvm::once_flag initExceptionBreakpoints;
   std::vector<std::string> init_commands;
   std::vector<std::string> pre_run_commands;
   std::vector<std::string> post_run_commands;

--- a/lldb/tools/lldb-dap/lldb-dap.cpp
+++ b/lldb/tools/lldb-dap/lldb-dap.cpp
@@ -16,6 +16,7 @@
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
+#include <optional>
 #include <sys/stat.h>
 #include <sys/types.h>
 #if defined(_WIN32)
@@ -1586,6 +1587,7 @@ void request_initialize(const llvm::json::Object &request) {
   bool source_init_file = GetBoolean(arguments, "sourceInitFile", true);
 
   g_dap.debugger = lldb::SBDebugger::Create(source_init_file, log_cb, nullptr);
+  g_dap.PopulateExceptionBreakpoints();
   auto cmd = g_dap.debugger.GetCommandInterpreter().AddMultiwordCommand(
       "lldb-dap", "Commands for managing lldb-dap.");
   if (GetBoolean(arguments, "supportsStartDebuggingRequest", false)) {
@@ -1621,7 +1623,7 @@ void request_initialize(const llvm::json::Object &request) {
   body.try_emplace("supportsEvaluateForHovers", true);
   // Available filters or options for the setExceptionBreakpoints request.
   llvm::json::Array filters;
-  for (const auto &exc_bp : g_dap.exception_breakpoints) {
+  for (const auto &exc_bp : *g_dap.exception_breakpoints) {
     filters.emplace_back(CreateExceptionBreakpointFilter(exc_bp));
   }
   body.try_emplace("exceptionBreakpointFilters", std::move(filters));
@@ -2476,7 +2478,7 @@ void request_setExceptionBreakpoints(const llvm::json::Object &request) {
   // Keep a list of any exception breakpoint filter names that weren't set
   // so we can clear any exception breakpoints if needed.
   std::set<std::string> unset_filters;
-  for (const auto &bp : g_dap.exception_breakpoints)
+  for (const auto &bp : *g_dap.exception_breakpoints)
     unset_filters.insert(bp.filter);
 
   for (const auto &value : *filters) {


### PR DESCRIPTION
Re-apply https://github.com/llvm/llvm-project/pull/87550 with fixes.

Details:
Some tests in fuchsia failed because of the newly added assertion.
This was because `GetExceptionBreakpoint()` could be called before `g_dap.debugger` was initted.

The fix here is to just lazily populate the list in GetExceptionBreakpoint() rather than assuming it's already been initted.
(There is some nuisance here because we can't simply just populate it in DAP::DAP(), which is a global ctor and is called before `SBDebugger::Initialize()` is called. )