### PR TITLE
[clang-tidy]fix crashing when self include cycles for misc-header-include-cycle

### DIFF
--- a/clang-tools-extra/clang-tidy/misc/HeaderIncludeCycleCheck.cpp
+++ b/clang-tools-extra/clang-tidy/misc/HeaderIncludeCycleCheck.cpp
@@ -139,8 +139,10 @@ public:
 
     auto CurrentIt = Files.rbegin();
     do {
-      Check.diag(CurrentIt->Loc, "'%0' included from here", DiagnosticIDs::Note)
-          << CurrentIt->Name;
+      if (CurrentIt->Loc.isValid())
+        Check.diag(CurrentIt->Loc, "'%0' included from here",
+                   DiagnosticIDs::Note)
+            << CurrentIt->Name;
     } while (CurrentIt++ != It);
   }
 

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -317,6 +317,10 @@ Changes in existing checks
   Additionally, the option `UseHeaderFileExtensions` is removed, so that the
   check uses the `HeaderFileExtensions` option unconditionally.
 
+- Improved :doc:`misc-header-include-cycle
+  <clang-tidy/checks/misc/header-include-cycle>` check by avoiding crash for self
+  include cycles.
+
 - Improved :doc:`misc-unused-using-decls
   <clang-tidy/checks/misc/unused-using-decls>` check by replacing the local
   option `HeaderFileExtensions` by the global option of the same name.

--- a/clang-tools-extra/test/clang-tidy/checkers/misc/header-include-cycle.self.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/misc/header-include-cycle.self.cpp
@@ -1,0 +1,3 @@
+// RUN: not clang-tidy %s -checks='-*,misc-header-include-cycle'
+
+#include "header-include-cycle.self.cpp"


### PR DESCRIPTION
Fixes: #94634
