### PR TITLE
[libc++][test][AIX] Only XFAIL atomic tests for before clang 19

### DIFF
--- a/libcxx/test/std/atomics/atomics.types.generic/atomics.types.float/fetch_add.pass.cpp
+++ b/libcxx/test/std/atomics/atomics.types.generic/atomics.types.float/fetch_add.pass.cpp
@@ -6,8 +6,11 @@
 //
 //===----------------------------------------------------------------------===//
 // UNSUPPORTED: c++03, c++11, c++14, c++17
-// UNSUPPORTED: LIBCXX-AIX-FIXME
 // XFAIL: !has-64-bit-atomics
+
+// Older versions of clang have a bug with atomic builtins affecting double and long double.
+// Fixed by 5fdd0948.
+// XFAIL: target=powerpc-ibm-{{.*}} && (clang-17 || clang-18)
 
 // https://github.com/llvm/llvm-project/issues/72893
 // XFAIL: target={{x86_64-.*}} && tsan

--- a/libcxx/test/std/atomics/atomics.types.generic/atomics.types.float/fetch_sub.pass.cpp
+++ b/libcxx/test/std/atomics/atomics.types.generic/atomics.types.float/fetch_sub.pass.cpp
@@ -6,8 +6,11 @@
 //
 //===----------------------------------------------------------------------===//
 // UNSUPPORTED: c++03, c++11, c++14, c++17
-// UNSUPPORTED: LIBCXX-AIX-FIXME
 // XFAIL: !has-64-bit-atomics
+
+// Older versions of clang have a bug with atomic builtins affecting double and long double.
+// Fixed by 5fdd0948.
+// XFAIL: target=powerpc-ibm-{{.*}} && (clang-17 || clang-18)
 
 // https://github.com/llvm/llvm-project/issues/72893
 // XFAIL: target={{x86_64-.*}} && tsan

--- a/libcxx/test/std/atomics/atomics.types.generic/atomics.types.float/operator.minus_equals.pass.cpp
+++ b/libcxx/test/std/atomics/atomics.types.generic/atomics.types.float/operator.minus_equals.pass.cpp
@@ -6,8 +6,11 @@
 //
 //===----------------------------------------------------------------------===//
 // UNSUPPORTED: c++03, c++11, c++14, c++17
-// UNSUPPORTED: LIBCXX-AIX-FIXME
 // XFAIL: !has-64-bit-atomics
+
+// Older versions of clang have a bug with atomic builtins affecting double and long double.
+// Fixed by 5fdd0948.
+// XFAIL: target=powerpc-ibm-{{.*}} && (clang-17 || clang-18)
 
 // floating-point-type operator-=(floating-point-type) volatile noexcept;
 // floating-point-type operator-=(floating-point-type) noexcept;

--- a/libcxx/test/std/atomics/atomics.types.generic/atomics.types.float/operator.plus_equals.pass.cpp
+++ b/libcxx/test/std/atomics/atomics.types.generic/atomics.types.float/operator.plus_equals.pass.cpp
@@ -6,8 +6,11 @@
 //
 //===----------------------------------------------------------------------===//
 // UNSUPPORTED: c++03, c++11, c++14, c++17
-// UNSUPPORTED: LIBCXX-AIX-FIXME
 // XFAIL: !has-64-bit-atomics
+
+// Older versions of clang have a bug with atomic builtins affecting double and long double.
+// Fixed by 5fdd0948.
+// XFAIL: target=powerpc-ibm-{{.*}} && (clang-17 || clang-18)
 
 // floating-point-type operator+=(floating-point-type) volatile noexcept;
 // floating-point-type operator+=(floating-point-type) noexcept;


### PR DESCRIPTION
These tests pass on 64-bit. They were fixed by 5fdd094837c6d8437803ebf3ccc91c3d494a2ac8 on 32-bit. So XFAIL only for 32-bit before clang 19.