### PR TITLE
[clang-tidy] Extend modernize-use-designated-initializers with new options

### DIFF
--- a/clang-tools-extra/clang-tidy/modernize/UseDesignatedInitializersCheck.cpp
+++ b/clang-tools-extra/clang-tidy/modernize/UseDesignatedInitializersCheck.cpp
@@ -32,6 +32,14 @@ static constexpr bool RestrictToPODTypesDefault = false;
 static constexpr char IgnoreMacrosName[] = "IgnoreMacros";
 static constexpr bool IgnoreMacrosDefault = true;
 
+static constexpr char StrictCStandardComplianceName[] =
+    "StrictCStandardCompliance";
+static constexpr bool StrictCStandardComplianceDefault = true;
+
+static constexpr char StrictCppStandardComplianceName[] =
+    "StrictCppStandardCompliance";
+static constexpr bool StrictCppStandardComplianceDefault = true;
+
 namespace {
 
 struct Designators {
@@ -97,7 +105,12 @@ UseDesignatedInitializersCheck::UseDesignatedInitializersCheck(
       RestrictToPODTypes(
           Options.get(RestrictToPODTypesName, RestrictToPODTypesDefault)),
       IgnoreMacros(
-          Options.getLocalOrGlobal(IgnoreMacrosName, IgnoreMacrosDefault)) {}
+          Options.getLocalOrGlobal(IgnoreMacrosName, IgnoreMacrosDefault)),
+      StrictCStandardCompliance(Options.get(StrictCStandardComplianceName,
+                                            StrictCStandardComplianceDefault)),
+      StrictCppStandardCompliance(
+          Options.get(StrictCppStandardComplianceName,
+                      StrictCppStandardComplianceDefault)) {}
 
 void UseDesignatedInitializersCheck::registerMatchers(MatchFinder *Finder) {
   const auto HasBaseWithFields =
@@ -179,6 +192,9 @@ void UseDesignatedInitializersCheck::storeOptions(
                 IgnoreSingleElementAggregates);
   Options.store(Opts, RestrictToPODTypesName, RestrictToPODTypes);
   Options.store(Opts, IgnoreMacrosName, IgnoreMacros);
+  Options.store(Opts, StrictCStandardComplianceName, StrictCStandardCompliance);
+  Options.store(Opts, StrictCppStandardComplianceName,
+                StrictCppStandardCompliance);
 }
 
 } // namespace clang::tidy::modernize

--- a/clang-tools-extra/clang-tidy/modernize/UseDesignatedInitializersCheck.h
+++ b/clang-tools-extra/clang-tidy/modernize/UseDesignatedInitializersCheck.h
@@ -29,10 +29,19 @@ public:
     return TK_IgnoreUnlessSpelledInSource;
   }
 
+  bool isLanguageVersionSupported(const LangOptions &LangOpts) const override {
+    return LangOpts.CPlusPlus20 || LangOpts.C99 ||
+           (LangOpts.CPlusPlus && !StrictCppStandardCompliance) ||
+           (!LangOpts.CPlusPlus && !LangOpts.ObjC &&
+            !StrictCStandardCompliance);
+  }
+
 private:
   bool IgnoreSingleElementAggregates;
   bool RestrictToPODTypes;
   bool IgnoreMacros;
+  bool StrictCStandardCompliance;
+  bool StrictCppStandardCompliance;
 };
 
 } // namespace clang::tidy::modernize

--- a/clang-tools-extra/docs/clang-tidy/checks/modernize/use-designated-initializers.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/modernize/use-designated-initializers.rst
@@ -37,7 +37,7 @@ declaration of ``S``.
 
 Even when compiling in a language version older than C++20, depending on your
 compiler, designated initializers are potentially supported. Therefore, the
-check is not restricted to C++20 and newer versions. Check out the options
+check is by default restricted to C99/C++20 and above. Check out the options
 ``-Wc99-designator`` to get support for mixed designators in initializer list in
 C and ``-Wc++20-designator`` for support of designated initializers in older C++
 language modes.
@@ -60,3 +60,13 @@ Options
     The value `true` specifies that only Plain Old Data (POD) types shall be
     checked. This makes the check applicable to even older C++ standards. The
     default value is `false`.
+
+.. option:: StrictCStandardCompliance
+
+   When set to `false`, the check will not restrict itself to C99 and above.
+   The default value is `true`.
+
+.. option:: StrictCppStandardCompliance
+
+   When set to `false`, the check will not restrict itself to C++20 and above.
+   The default value is `true`.

--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/use-designated-initializers.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/use-designated-initializers.cpp
@@ -1,13 +1,13 @@
-// RUN: %check_clang_tidy -std=c++17 %s modernize-use-designated-initializers %t \
+// RUN: %check_clang_tidy -std=c++20 %s modernize-use-designated-initializers %t \
 // RUN:     -- \
 // RUN:     -- -fno-delayed-template-parsing
-// RUN: %check_clang_tidy -check-suffixes=,SINGLE-ELEMENT -std=c++17 %s modernize-use-designated-initializers %t \
+// RUN: %check_clang_tidy -check-suffixes=,SINGLE-ELEMENT -std=c++20 %s modernize-use-designated-initializers %t \
 // RUN:     -- -config="{CheckOptions: {modernize-use-designated-initializers.IgnoreSingleElementAggregates: false}}" \
 // RUN:     -- -fno-delayed-template-parsing
-// RUN: %check_clang_tidy -check-suffixes=POD -std=c++17 %s modernize-use-designated-initializers %t \
+// RUN: %check_clang_tidy -check-suffixes=POD -std=c++20 %s modernize-use-designated-initializers %t \
 // RUN:     -- -config="{CheckOptions: {modernize-use-designated-initializers.RestrictToPODTypes: true}}" \
 // RUN:     -- -fno-delayed-template-parsing
-// RUN: %check_clang_tidy -check-suffixes=,MACROS -std=c++17 %s modernize-use-designated-initializers %t \
+// RUN: %check_clang_tidy -check-suffixes=,MACROS -std=c++20 %s modernize-use-designated-initializers %t \
 // RUN:     -- -config="{CheckOptions: {modernize-use-designated-initializers.IgnoreMacros: false}}" \
 // RUN:     -- -fno-delayed-template-parsing
 


### PR DESCRIPTION
Add StrictCStandardCompliance and StrictCppStandardCompliance options that default to true.

Closes #83732