### PR TITLE
[clang-tidy] Ignore non-math operators in readability-math-missing-parentheses

### DIFF
--- a/clang-tools-extra/clang-tidy/readability/MathMissingParenthesesCheck.cpp
+++ b/clang-tools-extra/clang-tidy/readability/MathMissingParenthesesCheck.cpp
@@ -57,7 +57,8 @@ static void addParantheses(const BinaryOperator *BinOp,
   int Precedence1 = getPrecedence(BinOp);
   int Precedence2 = getPrecedence(ParentBinOp);
 
-  if (ParentBinOp != nullptr && Precedence1 != Precedence2) {
+  if (ParentBinOp != nullptr && Precedence1 != Precedence2 && Precedence1 > 0 &&
+      Precedence2 > 0) {
     const clang::SourceLocation StartLoc = BinOp->getBeginLoc();
     const clang::SourceLocation EndLoc =
         clang::Lexer::getLocForEndOfToken(BinOp->getEndLoc(), 0, SM, LangOpts);

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/math-missing-parentheses.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/math-missing-parentheses.cpp
@@ -140,3 +140,20 @@ void f(){
     //CHECK-MESSAGES: :[[@LINE+1]]:13: warning: '*' has higher precedence than '+'; add parentheses to explicitly specify the order of operations [readability-math-missing-parentheses]
     int v = FUN5(0 + 1);
 }
+
+namespace PR92516 {
+  void f(int i) {
+    int j, k;
+    for (j = i + 1, k = 0; j < 1; ++j) {}
+  }
+
+  void f2(int i) {
+    int j;
+    for (j = i + 1; j < 1; ++j) {}
+  }
+
+  void f3(int i) {
+    int j;
+    for (j = i + 1, 2; j < 1; ++j) {}
+  }
+}


### PR DESCRIPTION
Do not emit warnings for non-math operators.

Closes #92516