### PR TITLE
[memprof] Use std::unique_ptr instead of std::optional

### DIFF
--- a/llvm/lib/ProfileData/MemProfReader.cpp
+++ b/llvm/lib/ProfileData/MemProfReader.cpp
@@ -690,7 +690,7 @@ Error RawMemProfReader::readNextRecord(
       return F;
     auto Iter = this->GuidToSymbolName.find(F.Function);
     assert(Iter != this->GuidToSymbolName.end());
-    F.SymbolName = Iter->getSecond();
+    F.SymbolName = std::make_unique<std::string>(Iter->getSecond());
     return F;
   };
   return MemProfReader::readNextRecord(GuidRecord, IdToFrameCallback);


### PR DESCRIPTION
Changing the type of Frame::SymbolName from std::optional<std::string>
to std::unique<std::string> reduces sizeof(Frame) from 64 to 32.

The smaller type reduces the cycle and instruction counts by 23% and
4.4%, respectively, with "llvm-profdata show" modified to deserialize
all MemProfRecords in a MemProf V2 profile.  The peak memory usage is
cut down nearly by half.