### PR TITLE
[Clang][Sema][TemplateDeduction] Skip pack expansion type at the end of default template argument list if unneeded

### DIFF
--- a/clang/lib/Sema/SemaTemplateDeduction.cpp
+++ b/clang/lib/Sema/SemaTemplateDeduction.cpp
@@ -593,9 +593,15 @@ DeduceTemplateArguments(Sema &S, TemplateParameterList *TemplateParams,
 
       TemplateParameterList *As = TempArg->getTemplateParameters();
       if (DefaultArguments.size() != 0) {
-        assert(DefaultArguments.size() <= As->size());
+        if ((DefaultArguments.size() > As->size()) &&
+            (DefaultArguments.size() != As->size() + 1 ||
+             DefaultArguments.back().getKind() != TemplateArgument::Type ||
+             !isa<PackExpansionType>(DefaultArguments.back().getAsType()))) {
+          return TemplateDeductionResult::TooFewArguments;
+        }
         SmallVector<NamedDecl *, 4> Params(As->size());
-        for (unsigned I = 0; I < DefaultArguments.size(); ++I)
+        for (unsigned I = 0;
+             I < std::min((size_t)As->size(), DefaultArguments.size()); ++I)
           Params[I] = getTemplateParameterWithDefault(S, As->getParam(I),
                                                       DefaultArguments[I]);
         for (unsigned I = DefaultArguments.size(); I < As->size(); ++I)


### PR DESCRIPTION
If default argument list has one more element than actual argument list and the last default argument is a pack expansion, we can ignore it.  This is to fix a failed assertion:

clang: llvm-project/clang/lib/Sema/SemaTemplateDeduction.cpp:596: TemplateDeductionResult DeduceTemplateArguments(Sema &, TemplateParameterList *, TemplateName, TemplateName, TemplateDeductionInfo &, ArrayRef<TemplateArgument>, SmallVectorImpl<DeducedTemplateArgument> &): Assertion `DefaultArguments.size() <= As->size()' failed.