### PR TITLE
[flang] Disable Fortran free form line continuation in non-source lin…

### DIFF
--- a/flang/include/flang/Parser/token-sequence.h
+++ b/flang/include/flang/Parser/token-sequence.h
@@ -124,7 +124,7 @@ public:
   TokenSequence &RemoveRedundantBlanks(std::size_t firstChar = 0);
   TokenSequence &ClipComment(const Prescanner &, bool skipFirst = false);
   const TokenSequence &CheckBadFortranCharacters(
-      Messages &, const Prescanner &) const;
+      Messages &, const Prescanner &, bool allowAmpersand) const;
   const TokenSequence &CheckBadParentheses(Messages &) const;
   void Emit(CookedSource &) const;
   llvm::raw_ostream &Dump(llvm::raw_ostream &) const;

--- a/flang/lib/Parser/prescan.h
+++ b/flang/lib/Parser/prescan.h
@@ -94,6 +94,7 @@ private:
     LineClassification(Kind k, std::size_t po = 0, const char *s = nullptr)
         : kind{k}, payloadOffset{po}, sentinel{s} {}
     LineClassification(LineClassification &&) = default;
+    LineClassification &operator=(LineClassification &&) = default;
     Kind kind;
     std::size_t payloadOffset; // byte offset of content
     const char *sentinel; // if it's a compiler directive
@@ -117,6 +118,7 @@ private:
     parenthesisNesting_ = 0;
     continuationLines_ = 0;
     isPossibleMacroCall_ = false;
+    disableSourceContinuation_ = false;
   }
 
   Provenance GetProvenance(const char *sourceChar) const {
@@ -192,6 +194,8 @@ private:
   std::optional<LineClassification> IsFreeFormCompilerDirectiveLine(
       const char *) const;
   LineClassification ClassifyLine(const char *) const;
+  LineClassification ClassifyLine(
+      TokenSequence &, Provenance newlineProvenance) const;
   void SourceFormChange(std::string &&);
   bool CompilerDirectiveContinuation(TokenSequence &, const char *sentinel);
   bool SourceLineContinuation(TokenSequence &);
@@ -211,6 +215,7 @@ private:
   int continuationLines_{0};
   bool isPossibleMacroCall_{false};
   bool afterIncludeDirective_{false};
+  bool disableSourceContinuation_{false};
 
   Provenance startProvenance_;
   const char *start_{nullptr}; // beginning of current source file content

--- a/flang/lib/Parser/token-sequence.cpp
+++ b/flang/lib/Parser/token-sequence.cpp
@@ -347,7 +347,8 @@ ProvenanceRange TokenSequence::GetProvenanceRange() const {
 }
 
 const TokenSequence &TokenSequence::CheckBadFortranCharacters(
-    Messages &messages, const Prescanner &prescanner) const {
+    Messages &messages, const Prescanner &prescanner,
+    bool allowAmpersand) const {
   std::size_t tokens{SizeInTokens()};
   for (std::size_t j{0}; j < tokens; ++j) {
     CharBlock token{TokenAt(j)};
@@ -362,6 +363,8 @@ const TokenSequence &TokenSequence::CheckBadFortranCharacters(
           ++j;
           continue;
         }
+      } else if (ch == '&' && allowAmpersand) {
+        continue;
       }
       if (ch < ' ' || ch >= '\x7f') {
         messages.Say(GetTokenProvenanceRange(j),

--- a/flang/test/Preprocessing/directive-contin-with-pp.F90
+++ b/flang/test/Preprocessing/directive-contin-with-pp.F90
@@ -1,12 +1,17 @@
-! RUN: %flang -E %s 2>&1 | FileCheck %s
+! RUN: %flang -fc1 -fdebug-unparse -fopenmp %s 2>&1 | FileCheck %s
 
 #define DIR_START !dir$
 #define DIR_CONT !dir$&
 #define FIRST(x) DIR_START x
 #define NEXT(x) DIR_CONT x
 #define AMPER &
+#define COMMENT !
+#define OMP_START !$omp
+#define OMP_CONT !$omp&
 
-subroutine s(x1, x2, x3, x4, x5, x6, x7)
+module m
+ contains
+  subroutine s(x1, x2, x3, x4, x5, x6, x7)
 
 !dir$ ignore_tkr x1
 
@@ -24,18 +29,48 @@ FIRST(ignore_tkr &)
 FIRST(ignore_tkr &)
 NEXT(x6)
 
-FIRST(ignore_tkr &)
-NEXT(x7 &)
-NEXT(x8)
+COMMENT blah &
+COMMENT & more
+    stop 1
 
+OMP_START parallel &
+OMP_START do &
+OMP_START reduction(+:x)
+    do j1 = 1, n
+    end do
+
+OMP_START parallel &
+OMP_START & do &
+OMP_START & reduction(+:x)
+    do j2 = 1, n
+    end do
+
+OMP_START parallel &
+OMP_CONT do &
+OMP_CONT reduction(+:x)
+    do j3 = 1, n
+    end do
+  end
 end
 
-!CHECK: subroutine s(x1, x2, x3, x4, x5, x6, x7)
-!CHECK: !dir$ ignore_tkr x1
-!CHECK: !dir$ ignore_tkr x2
-!CHECK: !dir$ ignore_tkr x3
-!CHECK: !dir$ ignore_tkr  x4
-!CHECK: !dir$ ignore_tkr  x5
-!CHECK: !dir$ ignore_tkr  x6
-!CHECK: !dir$ ignore_tkr  x7  x8
-!CHECK: end
+!CHECK: MODULE m
+!CHECK: CONTAINS
+!CHECK:  SUBROUTINE s (x1, x2, x3, x4, x5, x6, x7)
+!CHECK:   !DIR$ IGNORE_TKR x1
+!CHECK:   !DIR$ IGNORE_TKR x2
+!CHECK:   !DIR$ IGNORE_TKR x3
+!CHECK:   !DIR$ IGNORE_TKR x4
+!CHECK:   !DIR$ IGNORE_TKR x5
+!CHECK:   !DIR$ IGNORE_TKR x6
+!CHECK:   STOP 1_4
+!CHECK: !$OMP PARALLEL DO  REDUCTION(+:x)
+!CHECK:   DO j1=1_4,n
+!CHECK:   END DO
+!CHECK: !$OMP PARALLEL DO  REDUCTION(+:x)
+!CHECK:   DO j2=1_4,n
+!CHECK:   END DO
+!CHECK: !$OMP PARALLEL DO  REDUCTION(+:x)
+!CHECK:   DO j3=1_4,n
+!CHECK:   END DO
+!CHECK:  END SUBROUTINE
+!CHECK: END MODULE


### PR DESCRIPTION
…e produced by keyword macro replacement

When later initial keyword macro replacement will yield a line that is not Fortran source, don't interpret "&" as a Fortran source line continuation marker during tokenization of the line.

Fixes https://github.com/llvm/llvm-project/issues/82579.