### PR TITLE
[ProfileData] Remove swapToHostOrder

### DIFF
--- a/llvm/include/llvm/Support/Endian.h
+++ b/llvm/include/llvm/Support/Endian.h
@@ -72,7 +72,8 @@ template <typename value_type, endianness endian, std::size_t alignment>
 
 /// Read a value of a particular endianness from a buffer, and increment the
 /// buffer past that value.
-template <typename value_type, std::size_t alignment, typename CharT>
+template <typename value_type, std::size_t alignment = unaligned,
+          typename CharT>
 [[nodiscard]] inline value_type readNext(const CharT *&memory,
                                          endianness endian) {
   value_type ret = read<value_type, alignment>(memory, endian);

--- a/llvm/lib/ProfileData/InstrProf.cpp
+++ b/llvm/lib/ProfileData/InstrProf.cpp
@@ -1176,16 +1176,6 @@ void ValueProfData::deserializeTo(InstrProfRecord &Record,
   }
 }
 
-template <class T>
-static T swapToHostOrder(const unsigned char *&D, llvm::endianness Orig) {
-  using namespace support;
-
-  if (Orig == llvm::endianness::little)
-    return endian::readNext<T, llvm::endianness::little>(D);
-  else
-    return endian::readNext<T, llvm::endianness::big>(D);
-}
-
 static std::unique_ptr<ValueProfData> allocValueProfData(uint32_t TotalSize) {
   return std::unique_ptr<ValueProfData>(new (::operator new(TotalSize))
                                             ValueProfData());
@@ -1224,7 +1214,8 @@ ValueProfData::getValueProfData(const unsigned char *D,
     return make_error<InstrProfError>(instrprof_error::truncated);
 
   const unsigned char *Header = D;
-  uint32_t TotalSize = swapToHostOrder<uint32_t>(Header, Endianness);
+  uint32_t TotalSize = endian::readNext<uint32_t>(Header, Endianness);
+
   if (D + TotalSize > BufferEnd)
     return make_error<InstrProfError>(instrprof_error::too_large);
 


### PR DESCRIPTION
This patch removes swapToHostOrder in favor of
llvm::support::endian::readNext as swapToHostOrder is too thin a
wrapper around readNext.

Note that there are two variants of readNext:

- readNext<type, endian, align>(ptr)
- readNext<type, align>(ptr, endian)

swapToHostOrder uses the former, but this patch switches to the latter.

While we are at it, this patch teaches readNext to default to
unaligned just as I did in:

  commit 568368a43e5b4adb3c5d105a0eff3e0c13c0af8c
  Author: Kazu Hirata <kazu@google.com>
  Date:   Mon Apr 15 19:05:30 2024 -0700