### PR TITLE
[lldb] Fix TestModuleLoadedNotifys API test to work correctly on most of Linux targets

### DIFF
--- a/lldb/test/API/functionalities/target-new-solib-notifications/Makefile
+++ b/lldb/test/API/functionalities/target-new-solib-notifications/Makefile
@@ -1,5 +1,5 @@
 CXX_SOURCES := main.cpp
-LD_EXTRAS := -L. -lloadunload_d -lloadunload_c -lloadunload_a -lloadunload_b
+LD_EXTRAS := -L. -l_d -l_c -l_a -l_b
 
 a.out: lib_b lib_a lib_c lib_d
 
@@ -7,17 +7,17 @@ include Makefile.rules
 
 lib_a: lib_b
 	$(MAKE) -f $(MAKEFILE_RULES) \
-		DYLIB_ONLY=YES DYLIB_CXX_SOURCES=a.cpp DYLIB_NAME=loadunload_a \
-		LD_EXTRAS="-L. -lloadunload_b"
+		DYLIB_ONLY=YES DYLIB_CXX_SOURCES=a.cpp DYLIB_NAME=_a \
+		LD_EXTRAS="-L. -l_b"
 
 lib_b:
 	$(MAKE) -f $(MAKEFILE_RULES) \
-		DYLIB_ONLY=YES DYLIB_CXX_SOURCES=b.cpp DYLIB_NAME=loadunload_b
+		DYLIB_ONLY=YES DYLIB_CXX_SOURCES=b.cpp DYLIB_NAME=_b
 
 lib_c:
 	$(MAKE) -f $(MAKEFILE_RULES) \
-		DYLIB_ONLY=YES DYLIB_CXX_SOURCES=c.cpp DYLIB_NAME=loadunload_c
+		DYLIB_ONLY=YES DYLIB_CXX_SOURCES=c.cpp DYLIB_NAME=_c
 
 lib_d:
 	$(MAKE) -f $(MAKEFILE_RULES) \
-		DYLIB_ONLY=YES DYLIB_CXX_SOURCES=d.cpp DYLIB_NAME=loadunload_d
+		DYLIB_ONLY=YES DYLIB_CXX_SOURCES=d.cpp DYLIB_NAME=_d

--- a/lldb/test/API/functionalities/target-new-solib-notifications/Makefile
+++ b/lldb/test/API/functionalities/target-new-solib-notifications/Makefile
@@ -1,3 +1,23 @@
 CXX_SOURCES := main.cpp
+LD_EXTRAS := -L. -lloadunload_d -lloadunload_c -lloadunload_a -lloadunload_b
+
+a.out: lib_b lib_a lib_c lib_d
 
 include Makefile.rules
+
+lib_a: lib_b
+	$(MAKE) -f $(MAKEFILE_RULES) \
+		DYLIB_ONLY=YES DYLIB_CXX_SOURCES=a.cpp DYLIB_NAME=loadunload_a \
+		LD_EXTRAS="-L. -lloadunload_b"
+
+lib_b:
+	$(MAKE) -f $(MAKEFILE_RULES) \
+		DYLIB_ONLY=YES DYLIB_CXX_SOURCES=b.cpp DYLIB_NAME=loadunload_b
+
+lib_c:
+	$(MAKE) -f $(MAKEFILE_RULES) \
+		DYLIB_ONLY=YES DYLIB_CXX_SOURCES=c.cpp DYLIB_NAME=loadunload_c
+
+lib_d:
+	$(MAKE) -f $(MAKEFILE_RULES) \
+		DYLIB_ONLY=YES DYLIB_CXX_SOURCES=d.cpp DYLIB_NAME=loadunload_d

--- a/lldb/test/API/functionalities/target-new-solib-notifications/TestModuleLoadedNotifys.py
+++ b/lldb/test/API/functionalities/target-new-solib-notifications/TestModuleLoadedNotifys.py
@@ -117,7 +117,7 @@ class ModuleLoadedNotifysTestCase(TestBase):
         # program: a.out and dyld, and then all the rest of the system libraries.
         # On Linux we get events for ld.so, [vdso], the binary and then all libraries.
 
-        avg_solibs_added_per_event = round(
-            10.0 * float(total_solibs_added) / float(total_modules_added_events)
+        avg_solibs_added_per_event = float(total_solibs_added) / float(
+            total_modules_added_events
         )
-        self.assertGreater(avg_solibs_added_per_event, 10)
+        self.assertGreater(round(10.0 * avg_solibs_added_per_event), 10)

--- a/lldb/test/API/functionalities/target-new-solib-notifications/TestModuleLoadedNotifys.py
+++ b/lldb/test/API/functionalities/target-new-solib-notifications/TestModuleLoadedNotifys.py
@@ -118,6 +118,6 @@ class ModuleLoadedNotifysTestCase(TestBase):
         # On Linux we get events for ld.so, [vdso], the binary and then all libraries.
 
         avg_solibs_added_per_event = round(
-            float(total_solibs_added) / float(total_modules_added_events)
+            10.0 * float(total_solibs_added) / float(total_modules_added_events)
         )
-        self.assertGreater(avg_solibs_added_per_event, 1)
+        self.assertGreater(avg_solibs_added_per_event, 10)

--- a/lldb/test/API/functionalities/target-new-solib-notifications/TestModuleLoadedNotifys.py
+++ b/lldb/test/API/functionalities/target-new-solib-notifications/TestModuleLoadedNotifys.py
@@ -40,15 +40,11 @@ class ModuleLoadedNotifysTestCase(TestBase):
     def test_launch_notifications(self):
         """Test that lldb broadcasts newly loaded libraries in batches."""
 
-        ext = "so"
-        if self.platformIsDarwin():
-            ext = "dylib"
-
         expected_solibs = [
-            "libloadunload_a." + ext,
-            "libloadunload_b." + ext,
-            "libloadunload_c." + ext,
-            "libloadunload_d." + ext,
+            "lib_a." + self.platformContext.shlib_extension,
+            "lib_b." + self.platformContext.shlib_extension,
+            "lib_c." + self.platformContext.shlib_extension,
+            "lib_d." + self.platformContext.shlib_extension,
         ]
 
         self.build()
@@ -154,7 +150,4 @@ class ModuleLoadedNotifysTestCase(TestBase):
         # On Linux we get events for ld.so, [vdso], the binary and then all libraries,
         # but the different configurations could load a different number of .so modules
         # per event.
-        self.assertGreaterEqual(
-            len(set(max_solib_chunk_per_event).intersection(expected_solibs)),
-            len(expected_solibs),
-        )
+        self.assertLessEqual(set(expected_solibs), set(max_solib_chunk_per_event))

--- a/lldb/test/API/functionalities/target-new-solib-notifications/TestModuleLoadedNotifys.py
+++ b/lldb/test/API/functionalities/target-new-solib-notifications/TestModuleLoadedNotifys.py
@@ -9,22 +9,51 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
+@skipUnlessPlatform(["linux"] + lldbplatformutil.getDarwinOSTriples())
 class ModuleLoadedNotifysTestCase(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
 
     # At least DynamicLoaderDarwin and DynamicLoaderPOSIXDYLD should batch up
     # notifications about newly added/removed libraries.  Other DynamicLoaders may
     # not be written this way.
-    @skipUnlessPlatform(["linux"] + lldbplatformutil.getDarwinOSTriples())
     def setUp(self):
         # Call super's setUp().
         TestBase.setUp(self)
         # Find the line number to break inside main().
         self.line = line_number("main.cpp", "// breakpoint")
 
+    def setup_test(self, solibs):
+        if lldb.remote_platform:
+            path = lldb.remote_platform.GetWorkingDirectory()
+            for f in solibs:
+                lldbutil.install_to_target(self, self.getBuildArtifact(f))
+        else:
+            path = self.getBuildDir()
+            if self.dylibPath in os.environ:
+                sep = self.platformContext.shlib_path_separator
+                path = os.environ[self.dylibPath] + sep + path
+        self.runCmd(
+            "settings append target.env-vars '{}={}'".format(self.dylibPath, path)
+        )
+        self.default_path = path
+
     def test_launch_notifications(self):
         """Test that lldb broadcasts newly loaded libraries in batches."""
+
+        ext = "so"
+        if self.platformIsDarwin():
+            ext = "dylib"
+
+        expected_solibs = [
+            "libloadunload_a." + ext,
+            "libloadunload_b." + ext,
+            "libloadunload_c." + ext,
+            "libloadunload_d." + ext,
+        ]
+
         self.build()
+        self.setup_test(expected_solibs)
+
         exe = self.getBuildArtifact("a.out")
         self.dbg.SetAsync(False)
 
@@ -70,6 +99,8 @@ class ModuleLoadedNotifysTestCase(TestBase):
         total_modules_added_events = 0
         total_modules_removed_events = 0
         already_loaded_modules = []
+        max_solibs_per_event = 0
+        max_solib_chunk_per_event = []
         while listener.GetNextEvent(event):
             if lldb.SBTarget.EventIsTargetEvent(event):
                 if event.GetType() == lldb.SBTarget.eBroadcastBitModulesLoaded:
@@ -91,11 +122,16 @@ class ModuleLoadedNotifysTestCase(TestBase):
                                 "{} is already loaded".format(module),
                             )
                         already_loaded_modules.append(module)
-                        if self.TraceOn():
-                            added_files.append(module.GetFileSpec().GetFilename())
+                        added_files.append(module.GetFileSpec().GetFilename())
                     if self.TraceOn():
                         # print all of the binaries that have been added
                         print("Loaded files: %s" % (", ".join(added_files)))
+
+                    # We will check the latest biggest chunk of loaded solibs.
+                    # We expect all of our solibs in the last chunk of loaded modules.
+                    if solib_count >= max_solibs_per_event:
+                        max_solib_chunk_per_event = added_files.copy()
+                        max_solibs_per_event = solib_count
 
                 if event.GetType() == lldb.SBTarget.eBroadcastBitModulesUnloaded:
                     solib_count = lldb.SBTarget.GetNumModulesFromEvent(event)
@@ -115,9 +151,10 @@ class ModuleLoadedNotifysTestCase(TestBase):
         # binaries in batches.  Check that we got back more than 1 solib per event.
         # In practice on Darwin today, we get back two events for a do-nothing c
         # program: a.out and dyld, and then all the rest of the system libraries.
-        # On Linux we get events for ld.so, [vdso], the binary and then all libraries.
-
-        avg_solibs_added_per_event = float(total_solibs_added) / float(
-            total_modules_added_events
+        # On Linux we get events for ld.so, [vdso], the binary and then all libraries,
+        # but the different configurations could load a different number of .so modules
+        # per event.
+        self.assertGreaterEqual(
+            len(set(max_solib_chunk_per_event).intersection(expected_solibs)),
+            len(expected_solibs),
         )
-        self.assertGreater(round(10.0 * avg_solibs_added_per_event), 10)

--- a/lldb/test/API/functionalities/target-new-solib-notifications/a.cpp
+++ b/lldb/test/API/functionalities/target-new-solib-notifications/a.cpp
@@ -1,7 +1,3 @@
 extern "C" int b_function();
 
-int a_init() { return 234; }
-
-int a_global = a_init();
-
 extern "C" int a_function() { return b_function(); }

--- a/lldb/test/API/functionalities/target-new-solib-notifications/a.cpp
+++ b/lldb/test/API/functionalities/target-new-solib-notifications/a.cpp
@@ -1,0 +1,7 @@
+extern "C" int b_function();
+
+int a_init() { return 234; }
+
+int a_global = a_init();
+
+extern "C" int a_function() { return b_function(); }

--- a/lldb/test/API/functionalities/target-new-solib-notifications/b.cpp
+++ b/lldb/test/API/functionalities/target-new-solib-notifications/b.cpp
@@ -1,5 +1,1 @@
-int b_init() { return 345; }
-
-int b_global = b_init();
-
 extern "C" int b_function() { return 500; }

--- a/lldb/test/API/functionalities/target-new-solib-notifications/b.cpp
+++ b/lldb/test/API/functionalities/target-new-solib-notifications/b.cpp
@@ -1,0 +1,5 @@
+int b_init() { return 345; }
+
+int b_global = b_init();
+
+extern "C" int b_function() { return 500; }

--- a/lldb/test/API/functionalities/target-new-solib-notifications/c.cpp
+++ b/lldb/test/API/functionalities/target-new-solib-notifications/c.cpp
@@ -1,0 +1,1 @@
+extern "C" int c_function() { return 600; }

--- a/lldb/test/API/functionalities/target-new-solib-notifications/d.cpp
+++ b/lldb/test/API/functionalities/target-new-solib-notifications/d.cpp
@@ -1,0 +1,5 @@
+int d_init() { return 123; }
+
+int d_global = d_init();
+
+extern "C" int d_function() { return 700; }

--- a/lldb/test/API/functionalities/target-new-solib-notifications/d.cpp
+++ b/lldb/test/API/functionalities/target-new-solib-notifications/d.cpp
@@ -1,5 +1,1 @@
-int d_init() { return 123; }
-
-int d_global = d_init();
-
 extern "C" int d_function() { return 700; }

--- a/lldb/test/API/functionalities/target-new-solib-notifications/main.cpp
+++ b/lldb/test/API/functionalities/target-new-solib-notifications/main.cpp
@@ -1,6 +1,16 @@
 #include <stdio.h>
-int main ()
-{
+
+extern "C" int a_function();
+extern "C" int c_function();
+extern "C" int b_function();
+extern "C" int d_function();
+
+int main() {
+  a_function();
+  b_function();
+  c_function();
+  d_function();
+
   puts("running"); // breakpoint here
   return 0;
 }


### PR DESCRIPTION
The different build configuration and target Linux system can load a different number of .so libraries (2 and more). As example, Linux x86_64 host shows the following loaded modules:
```
Loaded files: ld-linux-x86-64.so.2
Loaded files: [vdso]
Loaded files: a.out
Loaded files: libstdc++.so.6, libm.so.6, libgcc_s.so.1, libc.so.6
```
avg_solibs_added_per_event = 1.75

But Linux Aarch64 (remote target) with statically linked C++ library (clang) shows:
```
Loaded files: ld-2.31.so
Loaded files: [vdso]
Loaded files: a.out
Loaded files: libm.so.6, libc.so.6
```
avg_solibs_added_per_event = 1.25

Increase precision by 1 digit to fix the test.