### PR TITLE
[clang] require arg list in type specifiers using template kw

### DIFF
--- a/clang/lib/Parse/Parser.cpp
+++ b/clang/lib/Parse/Parser.cpp
@@ -2060,9 +2060,19 @@ bool Parser::TryAnnotateTypeOrScopeToken(
       return true;
     }
 
+    bool TemplateKWPresent = false;
+    if (Tok.is(tok::kw_template)) {
+      ConsumeToken();
+      TemplateKWPresent = true;
+    }
+
     TypeResult Ty;
     if (Tok.is(tok::identifier)) {
-      // FIXME: check whether the next token is '<', first!
+      if (TemplateKWPresent && NextToken().isNot(tok::less)) {
+        Diag(Tok.getLocation(),
+             diag::missing_template_arg_list_after_template_kw);
+        return true;
+      }
       Ty = Actions.ActOnTypenameType(getCurScope(), TypenameLoc, SS,
                                      *Tok.getIdentifierInfo(),
                                      Tok.getLocation());

--- a/clang/test/Parser/cxx2a-concepts-requires-expr.cpp
+++ b/clang/test/Parser/cxx2a-concepts-requires-expr.cpp
@@ -83,7 +83,7 @@ bool r23 = requires { typename identity<T>::temp<T>; };
 template<typename T>
 bool r24 = requires {
     typename identity<T>::template temp<T>;
-    typename identity<T>::template temp; // expected-error{{expected an identifier or template-id after '::'}}
+    typename identity<T>::template temp; // expected-error{{template argument list is expected after a name prefixed by the template keyword}}
 };
 
 bool r25 = requires { ; };


### PR DESCRIPTION
Require a template argument list after a name prefixed by the template keyword in nested name specifiers. Addresses [CWG 96](https://www.open-std.org/jtc1/sc22/wg21/docs/cwg_defects.html#96) which was superseded by [P1787](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2020/p1787r6.html).

Followup to #80801.