### PR TITLE
[MIPS] Fix error messages when rejecting certain assembly not supported by ISA

### DIFF
--- a/llvm/lib/Target/Mips/AsmParser/MipsAsmParser.cpp
+++ b/llvm/lib/Target/Mips/AsmParser/MipsAsmParser.cpp
@@ -6412,7 +6412,7 @@ bool MipsAsmParser::parseOperand(OperandVector &Operands, StringRef Mnemonic) {
   // custom parse the operand, or fallback to the general approach.
   // Setting the third parameter to true tells the parser to keep parsing even
   // if the operands are not supported with the current feature set. In this
-  // case, the instruction matcher will output a "instruction requires a CPU 
+  // case, the instruction matcher will output a "instruction requires a CPU
   // feature not currently enabled" error. If this were false, the parser would
   // stop here and output a less useful "invalid operand" error.
   ParseStatus Res = MatchOperandParserImpl(Operands, Mnemonic, true);

--- a/llvm/lib/Target/Mips/AsmParser/MipsAsmParser.cpp
+++ b/llvm/lib/Target/Mips/AsmParser/MipsAsmParser.cpp
@@ -6410,6 +6410,11 @@ bool MipsAsmParser::parseOperand(OperandVector &Operands, StringRef Mnemonic) {
 
   // Check if the current operand has a custom associated parser, if so, try to
   // custom parse the operand, or fallback to the general approach.
+  // Setting the third parameter to true tells the parser to keep parsing even
+  // if the operands are not supported with the current feature set. In this
+  // case, the instruction matcher will output a "instruction requires a CPU 
+  // feature not currently enabled" error. If this were false, the parser would
+  // stop here and output a less useful "invalid operand" error.
   ParseStatus Res = MatchOperandParserImpl(Operands, Mnemonic, true);
   if (Res.isSuccess())
     return false;

--- a/llvm/lib/Target/Mips/AsmParser/MipsAsmParser.cpp
+++ b/llvm/lib/Target/Mips/AsmParser/MipsAsmParser.cpp
@@ -6410,7 +6410,7 @@ bool MipsAsmParser::parseOperand(OperandVector &Operands, StringRef Mnemonic) {
 
   // Check if the current operand has a custom associated parser, if so, try to
   // custom parse the operand, or fallback to the general approach.
-  ParseStatus Res = MatchOperandParserImpl(Operands, Mnemonic);
+  ParseStatus Res = MatchOperandParserImpl(Operands, Mnemonic, true);
   if (Res.isSuccess())
     return false;
   // If there wasn't a custom match, try the generic matcher below. Otherwise,

--- a/llvm/test/MC/Mips/cnmips/invalid-wrong-error.s
+++ b/llvm/test/MC/Mips/cnmips/invalid-wrong-error.s
@@ -4,7 +4,7 @@
 # RUN: FileCheck %s < %t1
 
   .set  noat
-  lwc3  $4, 0($5)  # CHECK: :{{[0-9]+}}:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled 
-  swc3  $4, 0($5)  # CHECK: :{{[0-9]+}}:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled 
-  ldc3  $4, 0($5)  # CHECK: :{{[0-9]+}}:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled 
-  sdc3  $4, 0($5)  # CHECK: :{{[0-9]+}}:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled 
+  lwc3  $4, 0($5)  # CHECK: :[[#]]:[[#]]: error: instruction requires a CPU feature not currently enabled 
+  swc3  $4, 0($5)  # CHECK: :[[#]]:[[#]]: error: instruction requires a CPU feature not currently enabled 
+  ldc3  $4, 0($5)  # CHECK: :[[#]]:[[#]]: error: instruction requires a CPU feature not currently enabled 
+  sdc3  $4, 0($5)  # CHECK: :[[#]]:[[#]]: error: instruction requires a CPU feature not currently enabled 

--- a/llvm/test/MC/Mips/cnmips/invalid-wrong-error.s
+++ b/llvm/test/MC/Mips/cnmips/invalid-wrong-error.s
@@ -1,8 +1,10 @@
+# These were correctly rejected as not being supported but the wrong
+# error message was emitted.
 # RUN: not llvm-mc %s -triple=mips64-unknown-linux -show-encoding -mcpu=octeon 2>%t1
 # RUN: FileCheck %s < %t1
 
   .set  noat
-  lwc3  $4, 0($5)  # CHECK: :{{[0-9]+}}:{{[0-9]+}}: error: invalid operand for instruction
-  swc3  $4, 0($5)  # CHECK: :{{[0-9]+}}:{{[0-9]+}}: error: invalid operand for instruction
-  ldc3  $4, 0($5)  # CHECK: :{{[0-9]+}}:{{[0-9]+}}: error: invalid operand for instruction
-  sdc3  $4, 0($5)  # CHECK: :{{[0-9]+}}:{{[0-9]+}}: error: invalid operand for instruction
+  lwc3  $4, 0($5)  # CHECK: :{{[0-9]+}}:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled 
+  swc3  $4, 0($5)  # CHECK: :{{[0-9]+}}:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled 
+  ldc3  $4, 0($5)  # CHECK: :{{[0-9]+}}:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled 
+  sdc3  $4, 0($5)  # CHECK: :{{[0-9]+}}:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled 

--- a/llvm/test/MC/Mips/eva/invalid-noeva-wrong-error.s
+++ b/llvm/test/MC/Mips/eva/invalid-noeva-wrong-error.s
@@ -19,51 +19,51 @@
 # RUN: FileCheck %s < %t1
 
         .set noat
-        cachee    31, 255($7)          # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
-        cachee    0, -256($4)          # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
-        cachee    5, -140($4)          # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
-        lbe       $10,-256($25)        # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
-        lbe       $13,255($15)         # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
-        lbe       $11,146($14)         # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
-        lbue      $13,-256($v1)        # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
-        lbue      $13,255($v0)         # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
-        lbue      $13,-190($v1)        # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
-        lhe       $13,-256($s5)        # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
-        lhe       $12,255($s0)         # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
-        lhe       $13,81($s0)          # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
-        lhue      $s2,-256($v1)        # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
-        lhue      $s2,255($v1)         # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
-        lhue      $s6,-168($v0)        # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
-        lle       $v0,-256($s5)        # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
-        lle       $v1,255($s3)         # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
-        lle       $v1,-71($s6)         # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
-        lwe       $15,255($a2)         # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
-        lwe       $13,-256($a2)        # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
-        lwe       $15,-200($a1)        # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
-        lwle      $s6,255($15)         # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
-        lwle      $s7,-256($10)        # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
-        lwle      $s7,-176($13)        # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
-        lwre      $zero,255($gp)       # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
-        lwre      $zero,-256($gp)      # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
-        lwre      $zero,-176($gp)      # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
-        prefe     14, -256($2)         # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
-        prefe     11, 255($3)          # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
-        prefe     14, -37($3)          # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
-        sbe       $s1,255($11)         # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
-        sbe       $s1,-256($10)        # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
-        sbe       $s3,0($14)           # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
-        sce       $9,255($s2)          # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
-        sce       $12,-256($s5)        # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
-        sce       $13,-31($s7)         # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
-        she       $14,255($15)         # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
-        she       $14,-256($15)        # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
-        she       $9,235($11)          # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
-        swe       $ra,255($sp)         # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
-        swe       $ra,-256($sp)        # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
-        swe       $ra,-53($sp)         # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
-        swle      $9,255($s1)          # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
-        swle      $10,-256($s3)        # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
-        swle      $8,131($s5)          # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
-        swre      $s4,255($13)         # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
-        swre      $s4,-256($13)        # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
-        swre      $s2,86($14)          # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
+        cachee    31, 255($7)          # CHECK: :[[#@LINE]]:[[#]]: error: instruction requires a CPU feature not currently enabled
+        cachee    0, -256($4)          # CHECK: :[[#@LINE]]:[[#]]: error: instruction requires a CPU feature not currently enabled
+        cachee    5, -140($4)          # CHECK: :[[#@LINE]]:[[#]]: error: instruction requires a CPU feature not currently enabled
+        lbe       $10,-256($25)        # CHECK: :[[#@LINE]]:[[#]]: error: instruction requires a CPU feature not currently enabled
+        lbe       $13,255($15)         # CHECK: :[[#@LINE]]:[[#]]: error: instruction requires a CPU feature not currently enabled
+        lbe       $11,146($14)         # CHECK: :[[#@LINE]]:[[#]]: error: instruction requires a CPU feature not currently enabled
+        lbue      $13,-256($v1)        # CHECK: :[[#@LINE]]:[[#]]: error: instruction requires a CPU feature not currently enabled
+        lbue      $13,255($v0)         # CHECK: :[[#@LINE]]:[[#]]: error: instruction requires a CPU feature not currently enabled
+        lbue      $13,-190($v1)        # CHECK: :[[#@LINE]]:[[#]]: error: instruction requires a CPU feature not currently enabled
+        lhe       $13,-256($s5)        # CHECK: :[[#@LINE]]:[[#]]: error: instruction requires a CPU feature not currently enabled
+        lhe       $12,255($s0)         # CHECK: :[[#@LINE]]:[[#]]: error: instruction requires a CPU feature not currently enabled
+        lhe       $13,81($s0)          # CHECK: :[[#@LINE]]:[[#]]: error: instruction requires a CPU feature not currently enabled
+        lhue      $s2,-256($v1)        # CHECK: :[[#@LINE]]:[[#]]: error: instruction requires a CPU feature not currently enabled
+        lhue      $s2,255($v1)         # CHECK: :[[#@LINE]]:[[#]]: error: instruction requires a CPU feature not currently enabled
+        lhue      $s6,-168($v0)        # CHECK: :[[#@LINE]]:[[#]]: error: instruction requires a CPU feature not currently enabled
+        lle       $v0,-256($s5)        # CHECK: :[[#@LINE]]:[[#]]: error: instruction requires a CPU feature not currently enabled
+        lle       $v1,255($s3)         # CHECK: :[[#@LINE]]:[[#]]: error: instruction requires a CPU feature not currently enabled
+        lle       $v1,-71($s6)         # CHECK: :[[#@LINE]]:[[#]]: error: instruction requires a CPU feature not currently enabled
+        lwe       $15,255($a2)         # CHECK: :[[#@LINE]]:[[#]]: error: instruction requires a CPU feature not currently enabled
+        lwe       $13,-256($a2)        # CHECK: :[[#@LINE]]:[[#]]: error: instruction requires a CPU feature not currently enabled
+        lwe       $15,-200($a1)        # CHECK: :[[#@LINE]]:[[#]]: error: instruction requires a CPU feature not currently enabled
+        lwle      $s6,255($15)         # CHECK: :[[#@LINE]]:[[#]]: error: instruction requires a CPU feature not currently enabled
+        lwle      $s7,-256($10)        # CHECK: :[[#@LINE]]:[[#]]: error: instruction requires a CPU feature not currently enabled
+        lwle      $s7,-176($13)        # CHECK: :[[#@LINE]]:[[#]]: error: instruction requires a CPU feature not currently enabled
+        lwre      $zero,255($gp)       # CHECK: :[[#@LINE]]:[[#]]: error: instruction requires a CPU feature not currently enabled
+        lwre      $zero,-256($gp)      # CHECK: :[[#@LINE]]:[[#]]: error: instruction requires a CPU feature not currently enabled
+        lwre      $zero,-176($gp)      # CHECK: :[[#@LINE]]:[[#]]: error: instruction requires a CPU feature not currently enabled
+        prefe     14, -256($2)         # CHECK: :[[#@LINE]]:[[#]]: error: instruction requires a CPU feature not currently enabled
+        prefe     11, 255($3)          # CHECK: :[[#@LINE]]:[[#]]: error: instruction requires a CPU feature not currently enabled
+        prefe     14, -37($3)          # CHECK: :[[#@LINE]]:[[#]]: error: instruction requires a CPU feature not currently enabled
+        sbe       $s1,255($11)         # CHECK: :[[#@LINE]]:[[#]]: error: instruction requires a CPU feature not currently enabled
+        sbe       $s1,-256($10)        # CHECK: :[[#@LINE]]:[[#]]: error: instruction requires a CPU feature not currently enabled
+        sbe       $s3,0($14)           # CHECK: :[[#@LINE]]:[[#]]: error: instruction requires a CPU feature not currently enabled
+        sce       $9,255($s2)          # CHECK: :[[#@LINE]]:[[#]]: error: instruction requires a CPU feature not currently enabled
+        sce       $12,-256($s5)        # CHECK: :[[#@LINE]]:[[#]]: error: instruction requires a CPU feature not currently enabled
+        sce       $13,-31($s7)         # CHECK: :[[#@LINE]]:[[#]]: error: instruction requires a CPU feature not currently enabled
+        she       $14,255($15)         # CHECK: :[[#@LINE]]:[[#]]: error: instruction requires a CPU feature not currently enabled
+        she       $14,-256($15)        # CHECK: :[[#@LINE]]:[[#]]: error: instruction requires a CPU feature not currently enabled
+        she       $9,235($11)          # CHECK: :[[#@LINE]]:[[#]]: error: instruction requires a CPU feature not currently enabled
+        swe       $ra,255($sp)         # CHECK: :[[#@LINE]]:[[#]]: error: instruction requires a CPU feature not currently enabled
+        swe       $ra,-256($sp)        # CHECK: :[[#@LINE]]:[[#]]: error: instruction requires a CPU feature not currently enabled
+        swe       $ra,-53($sp)         # CHECK: :[[#@LINE]]:[[#]]: error: instruction requires a CPU feature not currently enabled
+        swle      $9,255($s1)          # CHECK: :[[#@LINE]]:[[#]]: error: instruction requires a CPU feature not currently enabled
+        swle      $10,-256($s3)        # CHECK: :[[#@LINE]]:[[#]]: error: instruction requires a CPU feature not currently enabled
+        swle      $8,131($s5)          # CHECK: :[[#@LINE]]:[[#]]: error: instruction requires a CPU feature not currently enabled
+        swre      $s4,255($13)         # CHECK: :[[#@LINE]]:[[#]]: error: instruction requires a CPU feature not currently enabled
+        swre      $s4,-256($13)        # CHECK: :[[#@LINE]]:[[#]]: error: instruction requires a CPU feature not currently enabled
+        swre      $s2,86($14)          # CHECK: :[[#@LINE]]:[[#]]: error: instruction requires a CPU feature not currently enabled

--- a/llvm/test/MC/Mips/eva/invalid-noeva-wrong-error.s
+++ b/llvm/test/MC/Mips/eva/invalid-noeva-wrong-error.s
@@ -1,5 +1,5 @@
-# invalid operand for instructions that are invalid without -mattr=+eva flag and
-# are correctly rejected but use the wrong error message at the moment.
+# Instructions that are invalid without -mattr=+eva flag. These were rejected
+# correctly but used to emit an incorrect error message.
 #
 # RUN: not llvm-mc %s -triple=mips64-unknown-linux -show-encoding -mcpu=mips32r2 2>%t1
 # RUN: FileCheck %s < %t1
@@ -19,51 +19,51 @@
 # RUN: FileCheck %s < %t1
 
         .set noat
-        cachee    31, 255($7)          # CHECK: :[[@LINE]]:23: error: invalid operand for instruction
-        cachee    0, -256($4)          # CHECK: :[[@LINE]]:22: error: invalid operand for instruction
-        cachee    5, -140($4)          # CHECK: :[[@LINE]]:22: error: invalid operand for instruction
-        lbe       $10,-256($25)        # CHECK: :[[@LINE]]:{{[0-9]+}}: error: invalid operand for instruction
-        lbe       $13,255($15)         # CHECK: :[[@LINE]]:{{[0-9]+}}: error: invalid operand for instruction
-        lbe       $11,146($14)         # CHECK: :[[@LINE]]:{{[0-9]+}}: error: invalid operand for instruction
-        lbue      $13,-256($v1)        # CHECK: :[[@LINE]]:{{[0-9]+}}: error: invalid operand for instruction
-        lbue      $13,255($v0)         # CHECK: :[[@LINE]]:{{[0-9]+}}: error: invalid operand for instruction
-        lbue      $13,-190($v1)        # CHECK: :[[@LINE]]:{{[0-9]+}}: error: invalid operand for instruction
-        lhe       $13,-256($s5)        # CHECK: :[[@LINE]]:{{[0-9]+}}: error: invalid operand for instruction
-        lhe       $12,255($s0)         # CHECK: :[[@LINE]]:{{[0-9]+}}: error: invalid operand for instruction
-        lhe       $13,81($s0)          # CHECK: :[[@LINE]]:{{[0-9]+}}: error: invalid operand for instruction
-        lhue      $s2,-256($v1)        # CHECK: :[[@LINE]]:{{[0-9]+}}: error: invalid operand for instruction
-        lhue      $s2,255($v1)         # CHECK: :[[@LINE]]:{{[0-9]+}}: error: invalid operand for instruction
-        lhue      $s6,-168($v0)        # CHECK: :[[@LINE]]:{{[0-9]+}}: error: invalid operand for instruction
-        lle       $v0,-256($s5)        # CHECK: :[[@LINE]]:{{[0-9]+}}: error: invalid operand for instruction
-        lle       $v1,255($s3)         # CHECK: :[[@LINE]]:{{[0-9]+}}: error: invalid operand for instruction
-        lle       $v1,-71($s6)         # CHECK: :[[@LINE]]:{{[0-9]+}}: error: invalid operand for instruction
-        lwe       $15,255($a2)         # CHECK: :[[@LINE]]:{{[0-9]+}}: error: invalid operand for instruction
-        lwe       $13,-256($a2)        # CHECK: :[[@LINE]]:{{[0-9]+}}: error: invalid operand for instruction
-        lwe       $15,-200($a1)        # CHECK: :[[@LINE]]:{{[0-9]+}}: error: invalid operand for instruction
-        lwle      $s6,255($15)         # CHECK: :[[@LINE]]:{{[0-9]+}}: error: invalid operand for instruction
-        lwle      $s7,-256($10)        # CHECK: :[[@LINE]]:{{[0-9]+}}: error: invalid operand for instruction
-        lwle      $s7,-176($13)        # CHECK: :[[@LINE]]:{{[0-9]+}}: error: invalid operand for instruction
-        lwre      $zero,255($gp)       # CHECK: :[[@LINE]]:{{[0-9]+}}: error: invalid operand for instruction
-        lwre      $zero,-256($gp)      # CHECK: :[[@LINE]]:{{[0-9]+}}: error: invalid operand for instruction
-        lwre      $zero,-176($gp)      # CHECK: :[[@LINE]]:{{[0-9]+}}: error: invalid operand for instruction
-        prefe     14, -256($2)         # CHECK: :[[@LINE]]:{{[0-9]+}}: error: invalid operand for instruction
-        prefe     11, 255($3)          # CHECK: :[[@LINE]]:{{[0-9]+}}: error: invalid operand for instruction
-        prefe     14, -37($3)          # CHECK: :[[@LINE]]:{{[0-9]+}}: error: invalid operand for instruction
-        sbe       $s1,255($11)         # CHECK: :[[@LINE]]:{{[0-9]+}}: error: invalid operand for instruction
-        sbe       $s1,-256($10)        # CHECK: :[[@LINE]]:{{[0-9]+}}: error: invalid operand for instruction
-        sbe       $s3,0($14)           # CHECK: :[[@LINE]]:{{[0-9]+}}: error: invalid operand for instruction
-        sce       $9,255($s2)          # CHECK: :[[@LINE]]:{{[0-9]+}}: error: invalid operand for instruction
-        sce       $12,-256($s5)        # CHECK: :[[@LINE]]:{{[0-9]+}}: error: invalid operand for instruction
-        sce       $13,-31($s7)         # CHECK: :[[@LINE]]:{{[0-9]+}}: error: invalid operand for instruction
-        she       $14,255($15)         # CHECK: :[[@LINE]]:{{[0-9]+}}: error: invalid operand for instruction
-        she       $14,-256($15)        # CHECK: :[[@LINE]]:{{[0-9]+}}: error: invalid operand for instruction
-        she       $9,235($11)          # CHECK: :[[@LINE]]:{{[0-9]+}}: error: invalid operand for instruction
-        swe       $ra,255($sp)         # CHECK: :[[@LINE]]:{{[0-9]+}}: error: invalid operand for instruction
-        swe       $ra,-256($sp)        # CHECK: :[[@LINE]]:{{[0-9]+}}: error: invalid operand for instruction
-        swe       $ra,-53($sp)         # CHECK: :[[@LINE]]:{{[0-9]+}}: error: invalid operand for instruction
-        swle      $9,255($s1)          # CHECK: :[[@LINE]]:{{[0-9]+}}: error: invalid operand for instruction
-        swle      $10,-256($s3)        # CHECK: :[[@LINE]]:{{[0-9]+}}: error: invalid operand for instruction
-        swle      $8,131($s5)          # CHECK: :[[@LINE]]:{{[0-9]+}}: error: invalid operand for instruction
-        swre      $s4,255($13)         # CHECK: :[[@LINE]]:{{[0-9]+}}: error: invalid operand for instruction
-        swre      $s4,-256($13)        # CHECK: :[[@LINE]]:{{[0-9]+}}: error: invalid operand for instruction
-        swre      $s2,86($14)          # CHECK: :[[@LINE]]:{{[0-9]+}}: error: invalid operand for instruction
+        cachee    31, 255($7)          # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
+        cachee    0, -256($4)          # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
+        cachee    5, -140($4)          # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
+        lbe       $10,-256($25)        # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
+        lbe       $13,255($15)         # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
+        lbe       $11,146($14)         # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
+        lbue      $13,-256($v1)        # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
+        lbue      $13,255($v0)         # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
+        lbue      $13,-190($v1)        # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
+        lhe       $13,-256($s5)        # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
+        lhe       $12,255($s0)         # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
+        lhe       $13,81($s0)          # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
+        lhue      $s2,-256($v1)        # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
+        lhue      $s2,255($v1)         # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
+        lhue      $s6,-168($v0)        # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
+        lle       $v0,-256($s5)        # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
+        lle       $v1,255($s3)         # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
+        lle       $v1,-71($s6)         # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
+        lwe       $15,255($a2)         # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
+        lwe       $13,-256($a2)        # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
+        lwe       $15,-200($a1)        # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
+        lwle      $s6,255($15)         # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
+        lwle      $s7,-256($10)        # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
+        lwle      $s7,-176($13)        # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
+        lwre      $zero,255($gp)       # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
+        lwre      $zero,-256($gp)      # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
+        lwre      $zero,-176($gp)      # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
+        prefe     14, -256($2)         # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
+        prefe     11, 255($3)          # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
+        prefe     14, -37($3)          # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
+        sbe       $s1,255($11)         # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
+        sbe       $s1,-256($10)        # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
+        sbe       $s3,0($14)           # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
+        sce       $9,255($s2)          # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
+        sce       $12,-256($s5)        # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
+        sce       $13,-31($s7)         # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
+        she       $14,255($15)         # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
+        she       $14,-256($15)        # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
+        she       $9,235($11)          # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
+        swe       $ra,255($sp)         # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
+        swe       $ra,-256($sp)        # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
+        swe       $ra,-53($sp)         # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
+        swle      $9,255($s1)          # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
+        swle      $10,-256($s3)        # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
+        swle      $8,131($s5)          # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
+        swre      $s4,255($13)         # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
+        swre      $s4,-256($13)        # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
+        swre      $s2,86($14)          # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled

--- a/llvm/test/MC/Mips/eva/invalid_R6.s
+++ b/llvm/test/MC/Mips/eva/invalid_R6.s
@@ -6,18 +6,18 @@
 # RUN: FileCheck %s < %t1
 
         .set noat
-        lwle      $s6,255($15)       # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled 
-        lwle      $s7,-256($10)      # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled 
-        lwle      $s7,-176($13)      # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled 
-        lwre      $zero,255($gp)     # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled 
-        lwre      $zero,-256($gp)    # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled 
-        lwre      $zero,-176($gp)    # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled 
-        swle      $9,255($s1)        # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled 
-        swle      $10,-256($s3)      # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled 
-        swle      $8,131($s5)        # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled 
-        swre      $s4,255($13)       # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled 
-        swre      $s4,-256($13)      # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled 
-        swre      $s2,86($14)        # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled 
+        lwle      $s6,255($15)       # CHECK: :[[#@LINE]]:[[#]]: error: instruction requires a CPU feature not currently enabled 
+        lwle      $s7,-256($10)      # CHECK: :[[#@LINE]]:[[#]]: error: instruction requires a CPU feature not currently enabled 
+        lwle      $s7,-176($13)      # CHECK: :[[#@LINE]]:[[#]]: error: instruction requires a CPU feature not currently enabled 
+        lwre      $zero,255($gp)     # CHECK: :[[#@LINE]]:[[#]]: error: instruction requires a CPU feature not currently enabled 
+        lwre      $zero,-256($gp)    # CHECK: :[[#@LINE]]:[[#]]: error: instruction requires a CPU feature not currently enabled 
+        lwre      $zero,-176($gp)    # CHECK: :[[#@LINE]]:[[#]]: error: instruction requires a CPU feature not currently enabled 
+        swle      $9,255($s1)        # CHECK: :[[#@LINE]]:[[#]]: error: instruction requires a CPU feature not currently enabled 
+        swle      $10,-256($s3)      # CHECK: :[[#@LINE]]:[[#]]: error: instruction requires a CPU feature not currently enabled 
+        swle      $8,131($s5)        # CHECK: :[[#@LINE]]:[[#]]: error: instruction requires a CPU feature not currently enabled 
+        swre      $s4,255($13)       # CHECK: :[[#@LINE]]:[[#]]: error: instruction requires a CPU feature not currently enabled 
+        swre      $s4,-256($13)      # CHECK: :[[#@LINE]]:[[#]]: error: instruction requires a CPU feature not currently enabled 
+        swre      $s2,86($14)        # CHECK: :[[#@LINE]]:[[#]]: error: instruction requires a CPU feature not currently enabled 
         lle       $33, 8($5)         # CHECK: :[[@LINE]]:19: error: invalid register number
         lle       $4, 8($33)         # CHECK: :[[@LINE]]:25: error: invalid register number
         lle       $4, 512($5)        # CHECK: :[[@LINE]]:23: error: expected memory with 9-bit signed offset

--- a/llvm/test/MC/Mips/eva/invalid_R6.s
+++ b/llvm/test/MC/Mips/eva/invalid_R6.s
@@ -6,18 +6,18 @@
 # RUN: FileCheck %s < %t1
 
         .set noat
-        lwle      $s6,255($15)       # CHECK: :[[@LINE]]:{{[0-9]+}}: error: invalid operand for instruction
-        lwle      $s7,-256($10)      # CHECK: :[[@LINE]]:{{[0-9]+}}: error: invalid operand for instruction
-        lwle      $s7,-176($13)      # CHECK: :[[@LINE]]:{{[0-9]+}}: error: invalid operand for instruction
-        lwre      $zero,255($gp)     # CHECK: :[[@LINE]]:{{[0-9]+}}: error: invalid operand for instruction
-        lwre      $zero,-256($gp)    # CHECK: :[[@LINE]]:{{[0-9]+}}: error: invalid operand for instruction
-        lwre      $zero,-176($gp)    # CHECK: :[[@LINE]]:{{[0-9]+}}: error: invalid operand for instruction
-        swle      $9,255($s1)        # CHECK: :[[@LINE]]:{{[0-9]+}}: error: invalid operand for instruction
-        swle      $10,-256($s3)      # CHECK: :[[@LINE]]:{{[0-9]+}}: error: invalid operand for instruction
-        swle      $8,131($s5)        # CHECK: :[[@LINE]]:{{[0-9]+}}: error: invalid operand for instruction
-        swre      $s4,255($13)       # CHECK: :[[@LINE]]:{{[0-9]+}}: error: invalid operand for instruction
-        swre      $s4,-256($13)      # CHECK: :[[@LINE]]:{{[0-9]+}}: error: invalid operand for instruction
-        swre      $s2,86($14)        # CHECK: :[[@LINE]]:{{[0-9]+}}: error: invalid operand for instruction
+        lwle      $s6,255($15)       # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled 
+        lwle      $s7,-256($10)      # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled 
+        lwle      $s7,-176($13)      # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled 
+        lwre      $zero,255($gp)     # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled 
+        lwre      $zero,-256($gp)    # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled 
+        lwre      $zero,-176($gp)    # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled 
+        swle      $9,255($s1)        # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled 
+        swle      $10,-256($s3)      # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled 
+        swle      $8,131($s5)        # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled 
+        swre      $s4,255($13)       # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled 
+        swre      $s4,-256($13)      # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled 
+        swre      $s2,86($14)        # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled 
         lle       $33, 8($5)         # CHECK: :[[@LINE]]:19: error: invalid register number
         lle       $4, 8($33)         # CHECK: :[[@LINE]]:25: error: invalid register number
         lle       $4, 512($5)        # CHECK: :[[@LINE]]:23: error: expected memory with 9-bit signed offset

--- a/llvm/test/MC/Mips/micromips32r6/invalid-wrong-error.s
+++ b/llvm/test/MC/Mips/micromips32r6/invalid-wrong-error.s
@@ -29,7 +29,7 @@
   sc $4, -513($5)          # CHECK: :[[@LINE]]:3: error: instruction requires a CPU feature not currently enabled
   ll $4, 512($5)           # CHECK: :[[@LINE]]:3: error: instruction requires a CPU feature not currently enabled
   ll $4, -513($5)          # CHECK: :[[@LINE]]:3: error: instruction requires a CPU feature not currently enabled
-  lwr $4, 1($5)            # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
-  lwl $4, 1($5)            # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
-  swr $4, 1($5)            # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
-  swl $4, 1($5)            # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
+  lwr $4, 1($5)            # CHECK: :[[#@LINE]]:[[#]]: error: instruction requires a CPU feature not currently enabled
+  lwl $4, 1($5)            # CHECK: :[[#@LINE]]:[[#]]: error: instruction requires a CPU feature not currently enabled
+  swr $4, 1($5)            # CHECK: :[[#@LINE]]:[[#]]: error: instruction requires a CPU feature not currently enabled
+  swl $4, 1($5)            # CHECK: :[[#@LINE]]:[[#]]: error: instruction requires a CPU feature not currently enabled

--- a/llvm/test/MC/Mips/micromips32r6/invalid-wrong-error.s
+++ b/llvm/test/MC/Mips/micromips32r6/invalid-wrong-error.s
@@ -1,4 +1,5 @@
-# Instructions that are correctly rejected but emit a wrong or misleading error.
+# Instructions that were correctly rejected but used to emit a wrong or 
+# misleading error.
 # RUN: not llvm-mc %s -triple=mips -show-encoding -mcpu=mips32r6 -mattr=micromips 2>%t1
 # RUN: FileCheck %s < %t1
 
@@ -28,7 +29,7 @@
   sc $4, -513($5)          # CHECK: :[[@LINE]]:3: error: instruction requires a CPU feature not currently enabled
   ll $4, 512($5)           # CHECK: :[[@LINE]]:3: error: instruction requires a CPU feature not currently enabled
   ll $4, -513($5)          # CHECK: :[[@LINE]]:3: error: instruction requires a CPU feature not currently enabled
-  lwr $4, 1($5)            # CHECK: :[[@LINE]]:11: error: invalid operand for instruction
-  lwl $4, 1($5)            # CHECK: :[[@LINE]]:11: error: invalid operand for instruction
-  swr $4, 1($5)            # CHECK: :[[@LINE]]:11: error: invalid operand for instruction
-  swl $4, 1($5)            # CHECK: :[[@LINE]]:11: error: invalid operand for instruction
+  lwr $4, 1($5)            # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
+  lwl $4, 1($5)            # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
+  swr $4, 1($5)            # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
+  swl $4, 1($5)            # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled

--- a/llvm/test/MC/Mips/mips1/invalid-mips2-wrong-error.s
+++ b/llvm/test/MC/Mips/mips1/invalid-mips2-wrong-error.s
@@ -6,11 +6,11 @@
 # RUN: FileCheck %s < %t1
 
 	.set noat
-        ldc2      $8,-21181($at)  # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled 
-        ldc2      $8,-1024($at)   # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled 
-        ldc3      $29,-28645($s1) # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled 
-        ll        $v0,-7321($s2)  # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled 
-        sc        $t7,18904($s3)  # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled 
-        sdc2      $20,23157($s2)  # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled 
-        sdc2      $20,-1024($s2)  # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled 
-        sdc3      $12,5835($t2)   # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled 
+        ldc2      $8,-21181($at)  # CHECK: :[[#@LINE]]:[[#]]: error: instruction requires a CPU feature not currently enabled 
+        ldc2      $8,-1024($at)   # CHECK: :[[#@LINE]]:[[#]]: error: instruction requires a CPU feature not currently enabled 
+        ldc3      $29,-28645($s1) # CHECK: :[[#@LINE]]:[[#]]: error: instruction requires a CPU feature not currently enabled 
+        ll        $v0,-7321($s2)  # CHECK: :[[#@LINE]]:[[#]]: error: instruction requires a CPU feature not currently enabled 
+        sc        $t7,18904($s3)  # CHECK: :[[#@LINE]]:[[#]]: error: instruction requires a CPU feature not currently enabled 
+        sdc2      $20,23157($s2)  # CHECK: :[[#@LINE]]:[[#]]: error: instruction requires a CPU feature not currently enabled 
+        sdc2      $20,-1024($s2)  # CHECK: :[[#@LINE]]:[[#]]: error: instruction requires a CPU feature not currently enabled 
+        sdc3      $12,5835($t2)   # CHECK: :[[#@LINE]]:[[#]]: error: instruction requires a CPU feature not currently enabled 

--- a/llvm/test/MC/Mips/mips1/invalid-mips2-wrong-error.s
+++ b/llvm/test/MC/Mips/mips1/invalid-mips2-wrong-error.s
@@ -1,16 +1,16 @@
-# Instructions that are invalid and are correctly rejected but use the wrong
-# error message at the moment.
+# Instructions that are invalid and are correctly rejected but used to emit
+# the wrong error message.
 #
 # RUN: not llvm-mc %s -triple=mips-unknown-linux -show-encoding -mcpu=mips1 \
 # RUN:     2>%t1
 # RUN: FileCheck %s < %t1
 
 	.set noat
-        ldc2      $8,-21181($at)  # CHECK: :[[@LINE]]:{{[0-9]+}}: error: invalid operand for instruction
-        ldc2      $8,-1024($at)   # CHECK: :[[@LINE]]:{{[0-9]+}}: error: invalid operand for instruction
-        ldc3      $29,-28645($s1) # CHECK: :[[@LINE]]:{{[0-9]+}}: error: invalid operand for instruction
-        ll        $v0,-7321($s2)  # CHECK: :[[@LINE]]:{{[0-9]+}}: error: invalid operand for instruction
-        sc        $t7,18904($s3)  # CHECK: :[[@LINE]]:{{[0-9]+}}: error: invalid operand for instruction
-        sdc2      $20,23157($s2)  # CHECK: :[[@LINE]]:{{[0-9]+}}: error: invalid operand for instruction
-        sdc2      $20,-1024($s2)  # CHECK: :[[@LINE]]:{{[0-9]+}}: error: invalid operand for instruction
-        sdc3      $12,5835($t2)   # CHECK: :[[@LINE]]:{{[0-9]+}}: error: invalid operand for instruction
+        ldc2      $8,-21181($at)  # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled 
+        ldc2      $8,-1024($at)   # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled 
+        ldc3      $29,-28645($s1) # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled 
+        ll        $v0,-7321($s2)  # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled 
+        sc        $t7,18904($s3)  # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled 
+        sdc2      $20,23157($s2)  # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled 
+        sdc2      $20,-1024($s2)  # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled 
+        sdc3      $12,5835($t2)   # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled 

--- a/llvm/test/MC/Mips/mips1/invalid-mips3-wrong-error.s
+++ b/llvm/test/MC/Mips/mips1/invalid-mips3-wrong-error.s
@@ -6,14 +6,14 @@
 # RUN: FileCheck %s < %t1
 
 	.set noat
-        ldc2      $8,-21181($at)    # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled 
-        ldc2      $20,-1024($s2)    # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled 
-        ldl       $24,-4167($24)    # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled 
-        ldr       $14,-30358($s4)   # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled 
-        ll        $v0,-7321($s2)    # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled 
-        sc        $15,18904($s3)    # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled 
-        scd       $15,-8243($sp)    # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled 
-        sdc2      $20,23157($s2)    # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled 
-        sdc2      $20,-1024($s2)    # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled 
-        sdl       $a3,-20961($s8)   # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled 
-        sdr       $11,-20423($12)   # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled 
+        ldc2      $8,-21181($at)    # CHECK: :[[#@LINE]]:[[#]]: error: instruction requires a CPU feature not currently enabled 
+        ldc2      $20,-1024($s2)    # CHECK: :[[#@LINE]]:[[#]]: error: instruction requires a CPU feature not currently enabled 
+        ldl       $24,-4167($24)    # CHECK: :[[#@LINE]]:[[#]]: error: instruction requires a CPU feature not currently enabled 
+        ldr       $14,-30358($s4)   # CHECK: :[[#@LINE]]:[[#]]: error: instruction requires a CPU feature not currently enabled 
+        ll        $v0,-7321($s2)    # CHECK: :[[#@LINE]]:[[#]]: error: instruction requires a CPU feature not currently enabled 
+        sc        $15,18904($s3)    # CHECK: :[[#@LINE]]:[[#]]: error: instruction requires a CPU feature not currently enabled 
+        scd       $15,-8243($sp)    # CHECK: :[[#@LINE]]:[[#]]: error: instruction requires a CPU feature not currently enabled 
+        sdc2      $20,23157($s2)    # CHECK: :[[#@LINE]]:[[#]]: error: instruction requires a CPU feature not currently enabled 
+        sdc2      $20,-1024($s2)    # CHECK: :[[#@LINE]]:[[#]]: error: instruction requires a CPU feature not currently enabled 
+        sdl       $a3,-20961($s8)   # CHECK: :[[#@LINE]]:[[#]]: error: instruction requires a CPU feature not currently enabled 
+        sdr       $11,-20423($12)   # CHECK: :[[#@LINE]]:[[#]]: error: instruction requires a CPU feature not currently enabled 

--- a/llvm/test/MC/Mips/mips1/invalid-mips3-wrong-error.s
+++ b/llvm/test/MC/Mips/mips1/invalid-mips3-wrong-error.s
@@ -1,19 +1,19 @@
-# Instructions that are invalid and are correctly rejected but use the wrong
-# error message at the moment.
+# Instructions that are invalid and are correctly rejected but used to emit
+# the wrong error message.
 #
 # RUN: not llvm-mc %s -triple=mips-unknown-linux -show-encoding -mcpu=mips1 \
 # RUN:     2>%t1
 # RUN: FileCheck %s < %t1
 
 	.set noat
-        ldc2      $8,-21181($at)    # CHECK: :[[@LINE]]:{{[0-9]+}}: error: invalid operand for instruction
-        ldc2      $20,-1024($s2)    # CHECK: :[[@LINE]]:{{[0-9]+}}: error: invalid operand for instruction
-        ldl       $24,-4167($24)    # CHECK: :[[@LINE]]:{{[0-9]+}}: error: invalid operand for instruction
-        ldr       $14,-30358($s4)   # CHECK: :[[@LINE]]:{{[0-9]+}}: error: invalid operand for instruction
-        ll        $v0,-7321($s2)    # CHECK: :[[@LINE]]:{{[0-9]+}}: error: invalid operand for instruction
-        sc        $15,18904($s3)    # CHECK: :[[@LINE]]:{{[0-9]+}}: error: invalid operand for instruction
-        scd       $15,-8243($sp)    # CHECK: :[[@LINE]]:{{[0-9]+}}: error: invalid operand for instruction
-        sdc2      $20,23157($s2)    # CHECK: :[[@LINE]]:{{[0-9]+}}: error: invalid operand for instruction
-        sdc2      $20,-1024($s2)    # CHECK: :[[@LINE]]:{{[0-9]+}}: error: invalid operand for instruction
-        sdl       $a3,-20961($s8)   # CHECK: :[[@LINE]]:{{[0-9]+}}: error: invalid operand for instruction
-        sdr       $11,-20423($12)   # CHECK: :[[@LINE]]:{{[0-9]+}}: error: invalid operand for instruction
+        ldc2      $8,-21181($at)    # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled 
+        ldc2      $20,-1024($s2)    # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled 
+        ldl       $24,-4167($24)    # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled 
+        ldr       $14,-30358($s4)   # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled 
+        ll        $v0,-7321($s2)    # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled 
+        sc        $15,18904($s3)    # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled 
+        scd       $15,-8243($sp)    # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled 
+        sdc2      $20,23157($s2)    # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled 
+        sdc2      $20,-1024($s2)    # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled 
+        sdl       $a3,-20961($s8)   # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled 
+        sdr       $11,-20423($12)   # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled 

--- a/llvm/test/MC/Mips/mips1/invalid-mips3.s
+++ b/llvm/test/MC/Mips/mips1/invalid-mips3.s
@@ -54,8 +54,8 @@
         floor.l.s $f12,$f5          # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
         floor.w.d $f14,$f11         # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
         floor.w.s $f8,$f9           # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
-        lld       $zero,-14736($ra) # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
-        lwu       $s3,-24086($v1)   # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
+        lld       $zero,-14736($ra) # CHECK: :[[#@LINE]]:[[#]]: error: instruction requires a CPU feature not currently enabled
+        lwu       $s3,-24086($v1)   # CHECK: :[[#@LINE]]:[[#]]: error: instruction requires a CPU feature not currently enabled
         round.l.d $f12,$f1          # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
         round.l.s $f25,$f5          # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
         round.w.d $f6,$f4           # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled

--- a/llvm/test/MC/Mips/mips1/invalid-mips3.s
+++ b/llvm/test/MC/Mips/mips1/invalid-mips3.s
@@ -54,8 +54,8 @@
         floor.l.s $f12,$f5          # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
         floor.w.d $f14,$f11         # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
         floor.w.s $f8,$f9           # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
-        lld       $zero,-14736($ra) # CHECK: :[[@LINE]]:{{[0-9]+}}: error: invalid operand for instruction
-        lwu       $s3,-24086($v1)   # CHECK: :[[@LINE]]:23: error: invalid operand for instruction
+        lld       $zero,-14736($ra) # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
+        lwu       $s3,-24086($v1)   # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
         round.l.d $f12,$f1          # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
         round.l.s $f25,$f5          # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
         round.w.d $f6,$f4           # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled

--- a/llvm/test/MC/Mips/mips1/invalid-mips4-wrong-error.s
+++ b/llvm/test/MC/Mips/mips1/invalid-mips4-wrong-error.s
@@ -8,14 +8,14 @@
 	.set noat
         bc1fl     $fcc7,27          # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
         bc1tl     $fcc7,27          # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
-        ldc2      $8,-21181($at)    # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled 
-        ldc2      $20,-1024($s2)    # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled 
-        ldl       $24,-4167($24)    # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled 
-        ldr       $14,-30358($s4)   # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled 
-        ll        $v0,-7321($s2)    # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled 
-        sc        $15,18904($s3)    # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled 
-        scd       $15,-8243($sp)    # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled 
-        sdc2      $20,23157($s2)    # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled 
-        sdc2      $20,-1024($s2)    # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled 
-        sdl       $a3,-20961($s8)   # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled 
-        sdr       $11,-20423($12)   # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled 
+        ldc2      $8,-21181($at)    # CHECK: :[[#@LINE]]:[[#]]: error: instruction requires a CPU feature not currently enabled 
+        ldc2      $20,-1024($s2)    # CHECK: :[[#@LINE]]:[[#]]: error: instruction requires a CPU feature not currently enabled 
+        ldl       $24,-4167($24)    # CHECK: :[[#@LINE]]:[[#]]: error: instruction requires a CPU feature not currently enabled 
+        ldr       $14,-30358($s4)   # CHECK: :[[#@LINE]]:[[#]]: error: instruction requires a CPU feature not currently enabled 
+        ll        $v0,-7321($s2)    # CHECK: :[[#@LINE]]:[[#]]: error: instruction requires a CPU feature not currently enabled 
+        sc        $15,18904($s3)    # CHECK: :[[#@LINE]]:[[#]]: error: instruction requires a CPU feature not currently enabled 
+        scd       $15,-8243($sp)    # CHECK: :[[#@LINE]]:[[#]]: error: instruction requires a CPU feature not currently enabled 
+        sdc2      $20,23157($s2)    # CHECK: :[[#@LINE]]:[[#]]: error: instruction requires a CPU feature not currently enabled 
+        sdc2      $20,-1024($s2)    # CHECK: :[[#@LINE]]:[[#]]: error: instruction requires a CPU feature not currently enabled 
+        sdl       $a3,-20961($s8)   # CHECK: :[[#@LINE]]:[[#]]: error: instruction requires a CPU feature not currently enabled 
+        sdr       $11,-20423($12)   # CHECK: :[[#@LINE]]:[[#]]: error: instruction requires a CPU feature not currently enabled 

--- a/llvm/test/MC/Mips/mips1/invalid-mips4-wrong-error.s
+++ b/llvm/test/MC/Mips/mips1/invalid-mips4-wrong-error.s
@@ -1,5 +1,5 @@
-# Instructions that are invalid and are correctly rejected but use the wrong
-# error message at the moment.
+# Instructions that are invalid and are correctly rejected but used to emit
+# the wrong error message.
 #
 # RUN: not llvm-mc %s -triple=mips-unknown-linux -show-encoding -mcpu=mips1 \
 # RUN:     2>%t1
@@ -8,14 +8,14 @@
 	.set noat
         bc1fl     $fcc7,27          # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
         bc1tl     $fcc7,27          # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
-        ldc2      $8,-21181($at)    # CHECK: :[[@LINE]]:{{[0-9]+}}: error: invalid operand for instruction
-        ldc2      $20,-1024($s2)    # CHECK: :[[@LINE]]:{{[0-9]+}}: error: invalid operand for instruction
-        ldl       $24,-4167($24)    # CHECK: :[[@LINE]]:{{[0-9]+}}: error: invalid operand for instruction
-        ldr       $14,-30358($s4)   # CHECK: :[[@LINE]]:{{[0-9]+}}: error: invalid operand for instruction
-        ll        $v0,-7321($s2)    # CHECK: :[[@LINE]]:{{[0-9]+}}: error: invalid operand for instruction
-        sc        $15,18904($s3)    # CHECK: :[[@LINE]]:{{[0-9]+}}: error: invalid operand for instruction
-        scd       $15,-8243($sp)    # CHECK: :[[@LINE]]:{{[0-9]+}}: error: invalid operand for instruction
-        sdc2      $20,23157($s2)    # CHECK: :[[@LINE]]:{{[0-9]+}}: error: invalid operand for instruction
-        sdc2      $20,-1024($s2)    # CHECK: :[[@LINE]]:{{[0-9]+}}: error: invalid operand for instruction
-        sdl       $a3,-20961($s8)   # CHECK: :[[@LINE]]:{{[0-9]+}}: error: invalid operand for instruction
-        sdr       $11,-20423($12)   # CHECK: :[[@LINE]]:{{[0-9]+}}: error: invalid operand for instruction
+        ldc2      $8,-21181($at)    # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled 
+        ldc2      $20,-1024($s2)    # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled 
+        ldl       $24,-4167($24)    # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled 
+        ldr       $14,-30358($s4)   # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled 
+        ll        $v0,-7321($s2)    # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled 
+        sc        $15,18904($s3)    # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled 
+        scd       $15,-8243($sp)    # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled 
+        sdc2      $20,23157($s2)    # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled 
+        sdc2      $20,-1024($s2)    # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled 
+        sdl       $a3,-20961($s8)   # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled 
+        sdr       $11,-20423($12)   # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled 

--- a/llvm/test/MC/Mips/mips1/invalid-mips4.s
+++ b/llvm/test/MC/Mips/mips1/invalid-mips4.s
@@ -69,8 +69,8 @@
         movz      $a1,$s6,$9        # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
         movz.d    $f12,$f29,$9      # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
         movz.s    $f25,$f7,$v1      # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
-        lld       $zero,-14736($ra) # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
-        lwu       $s3,-24086($v1)   # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
+        lld       $zero,-14736($ra) # CHECK: :[[#@LINE]]:[[#]]: error: instruction requires a CPU feature not currently enabled
+        lwu       $s3,-24086($v1)   # CHECK: :[[#@LINE]]:[[#]]: error: instruction requires a CPU feature not currently enabled
         round.l.d $f12,$f1          # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
         round.l.s $f25,$f5          # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
         round.w.d $f6,$f4           # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled

--- a/llvm/test/MC/Mips/mips1/invalid-mips4.s
+++ b/llvm/test/MC/Mips/mips1/invalid-mips4.s
@@ -69,8 +69,8 @@
         movz      $a1,$s6,$9        # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
         movz.d    $f12,$f29,$9      # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
         movz.s    $f25,$f7,$v1      # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
-        lld       $zero,-14736($ra) # CHECK: :[[@LINE]]:{{[0-9]+}}: error: invalid operand for instruction
-        lwu       $s3,-24086($v1)   # CHECK: :[[@LINE]]:23: error: invalid operand for instruction
+        lld       $zero,-14736($ra) # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
+        lwu       $s3,-24086($v1)   # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
         round.l.d $f12,$f1          # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
         round.l.s $f25,$f5          # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
         round.w.d $f6,$f4           # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled

--- a/llvm/test/MC/Mips/mips1/invalid-mips5.s
+++ b/llvm/test/MC/Mips/mips1/invalid-mips5.s
@@ -98,5 +98,5 @@
         sdxc1     $f11,$a2($t2)     # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
         suxc1     $f12,$k1($t1)     # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
         swxc1     $f19,$t0($k0)     # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
-        ldc1      $f11,16391($s0)   # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled 
-        sdc1      $f31,30574($t5)   # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled 
+        ldc1      $f11,16391($s0)   # CHECK: :[[#@LINE]]:[[#]]: error: instruction requires a CPU feature not currently enabled 
+        sdc1      $f31,30574($t5)   # CHECK: :[[#@LINE]]:[[#]]: error: instruction requires a CPU feature not currently enabled 

--- a/llvm/test/MC/Mips/mips1/invalid-mips5.s
+++ b/llvm/test/MC/Mips/mips1/invalid-mips5.s
@@ -98,5 +98,5 @@
         sdxc1     $f11,$a2($t2)     # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
         suxc1     $f12,$k1($t1)     # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
         swxc1     $f19,$t0($k0)     # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
-        ldc1      $f11,16391($s0)   # CHECK: :[[@LINE]]:{{[0-9]+}}: error: invalid operand for instruction
-        sdc1      $f31,30574($t5)   # CHECK: :[[@LINE]]:{{[0-9]+}}: error: invalid operand for instruction
+        ldc1      $f11,16391($s0)   # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled 
+        sdc1      $f31,30574($t5)   # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled 

--- a/llvm/test/MC/Mips/mips2/invalid-mips3-wrong-error.s
+++ b/llvm/test/MC/Mips/mips2/invalid-mips3-wrong-error.s
@@ -7,8 +7,8 @@
 
 	.set noat
         dmult     $s7,$a5           # CHECK: :[[@LINE]]:{{[0-9]+}}: error: invalid operand for instruction
-        ldl       $t8,-4167($t8)    # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
-        ldr       $t2,-30358($s4)   # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
-        scd       $t3,-8243($sp)    # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
-        sdl       $a3,-20961($s8)   # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
+        ldl       $t8,-4167($t8)    # CHECK: :[[#@LINE]]:[[#]]: error: instruction requires a CPU feature not currently enabled
+        ldr       $t2,-30358($s4)   # CHECK: :[[#@LINE]]:[[#]]: error: instruction requires a CPU feature not currently enabled
+        scd       $t3,-8243($sp)    # CHECK: :[[#@LINE]]:[[#]]: error: instruction requires a CPU feature not currently enabled
+        sdl       $a3,-20961($s8)   # CHECK: :[[#@LINE]]:[[#]]: error: instruction requires a CPU feature not currently enabled
         sdr       $a7,-20423($t0)   # CHECK: :[[@LINE]]:{{[0-9]+}}: error: invalid operand for instruction

--- a/llvm/test/MC/Mips/mips2/invalid-mips3-wrong-error.s
+++ b/llvm/test/MC/Mips/mips2/invalid-mips3-wrong-error.s
@@ -1,5 +1,5 @@
-# Instructions that are invalid and are correctly rejected but use the wrong
-# error message at the moment.
+# Instructions that are invalid and are correctly rejected but used to emit
+# the wrong error message.
 #
 # RUN: not llvm-mc %s -triple=mips-unknown-linux -show-encoding -mcpu=mips2 \
 # RUN:     2>%t1
@@ -7,8 +7,8 @@
 
 	.set noat
         dmult     $s7,$a5           # CHECK: :[[@LINE]]:{{[0-9]+}}: error: invalid operand for instruction
-        ldl       $t8,-4167($t8)    # CHECK: :[[@LINE]]:{{[0-9]+}}: error: invalid operand for instruction
-        ldr       $t2,-30358($s4)   # CHECK: :[[@LINE]]:{{[0-9]+}}: error: invalid operand for instruction
-        scd       $t3,-8243($sp)    # CHECK: :[[@LINE]]:{{[0-9]+}}: error: invalid operand for instruction
-        sdl       $a3,-20961($s8)   # CHECK: :[[@LINE]]:{{[0-9]+}}: error: invalid operand for instruction
+        ldl       $t8,-4167($t8)    # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
+        ldr       $t2,-30358($s4)   # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
+        scd       $t3,-8243($sp)    # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
+        sdl       $a3,-20961($s8)   # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
         sdr       $a7,-20423($t0)   # CHECK: :[[@LINE]]:{{[0-9]+}}: error: invalid operand for instruction

--- a/llvm/test/MC/Mips/mips2/invalid-mips3.s
+++ b/llvm/test/MC/Mips/mips2/invalid-mips3.s
@@ -43,15 +43,15 @@
         dsrl32     $s3,23            # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
         dsrl32     $s3,$6,23         # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
         dsrlv      $s3,$t2,$s4       # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
-        dsub       $a3,$s6,$a4       # CHECK: :[[@LINE]]:{{[0-9]+}}: error: unexpected token in argument list
+        dsub       $a3,$s6,$a4       # CHECK: :[[#@LINE]]:[[#]]: error: unexpected token in argument list
         dsubu      $a1,$a1,$k0       # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
         dsubu      $15,$11,5025      # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
         dsubu      $14,-4586         # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
         eret                         # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
         floor.l.d  $f26,$f7          # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
         floor.l.s  $f12,$f5          # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
-        lld        $zero,-14736($ra) # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
-        lwu        $s3,-24086($v1)   # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
+        lld        $zero,-14736($ra) # CHECK: :[[#@LINE]]:[[#]]: error: instruction requires a CPU feature not currently enabled
+        lwu        $s3,-24086($v1)   # CHECK: :[[#@LINE]]:[[#]]: error: instruction requires a CPU feature not currently enabled
         round.l.d  $f12,$f1          # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
         round.l.s  $f25,$f5          # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
         trunc.l.d   $f23,$f23        # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled

--- a/llvm/test/MC/Mips/mips2/invalid-mips3.s
+++ b/llvm/test/MC/Mips/mips2/invalid-mips3.s
@@ -43,15 +43,15 @@
         dsrl32     $s3,23            # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
         dsrl32     $s3,$6,23         # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
         dsrlv      $s3,$t2,$s4       # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
-        dsub       $a3,$s6,$a4       # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
+        dsub       $a3,$s6,$a4       # CHECK: :[[@LINE]]:{{[0-9]+}}: error: unexpected token in argument list
         dsubu      $a1,$a1,$k0       # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
         dsubu      $15,$11,5025      # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
         dsubu      $14,-4586         # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
         eret                         # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
         floor.l.d  $f26,$f7          # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
         floor.l.s  $f12,$f5          # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
-        lld        $zero,-14736($ra) # CHECK: :[[@LINE]]:{{[0-9]+}}: error: invalid operand for instruction
-        lwu        $s3,-24086($v1)   # CHECK: :[[@LINE]]:24: error: invalid operand for instruction
+        lld        $zero,-14736($ra) # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
+        lwu        $s3,-24086($v1)   # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
         round.l.d  $f12,$f1          # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
         round.l.s  $f25,$f5          # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
         trunc.l.d   $f23,$f23        # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled

--- a/llvm/test/MC/Mips/mips2/invalid-mips4-wrong-error.s
+++ b/llvm/test/MC/Mips/mips2/invalid-mips4-wrong-error.s
@@ -8,6 +8,6 @@
 	.set noat
         bc1fl     $fcc7,27        # CHECK: :[[@LINE]]:{{[0-9]+}}: error: non-zero fcc register doesn't exist in current ISA level
         bc1tl     $fcc7,27        # CHECK: :[[@LINE]]:{{[0-9]+}}: error: non-zero fcc register doesn't exist in current ISA level
-        scd       $15,-8243($sp)  # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
-        sdl       $a3,-20961($s8) # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
-        sdr       $11,-20423($12) # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
+        scd       $15,-8243($sp)  # CHECK: :[[#@LINE]]:[[#]]: error: instruction requires a CPU feature not currently enabled
+        sdl       $a3,-20961($s8) # CHECK: :[[#@LINE]]:[[#]]: error: instruction requires a CPU feature not currently enabled
+        sdr       $11,-20423($12) # CHECK: :[[#@LINE]]:[[#]]: error: instruction requires a CPU feature not currently enabled

--- a/llvm/test/MC/Mips/mips2/invalid-mips4-wrong-error.s
+++ b/llvm/test/MC/Mips/mips2/invalid-mips4-wrong-error.s
@@ -1,5 +1,5 @@
-# Instructions that are invalid and are correctly rejected but use the wrong
-# error message at the moment.
+# Instructions that are invalid and are correctly rejected but used to emit
+# the wrong error message.
 #
 # RUN: not llvm-mc %s -triple=mips-unknown-linux -show-encoding -mcpu=mips2 \
 # RUN:     2>%t1
@@ -8,6 +8,6 @@
 	.set noat
         bc1fl     $fcc7,27        # CHECK: :[[@LINE]]:{{[0-9]+}}: error: non-zero fcc register doesn't exist in current ISA level
         bc1tl     $fcc7,27        # CHECK: :[[@LINE]]:{{[0-9]+}}: error: non-zero fcc register doesn't exist in current ISA level
-        scd       $15,-8243($sp)  # CHECK: :[[@LINE]]:{{[0-9]+}}: error: invalid operand for instruction
-        sdl       $a3,-20961($s8) # CHECK: :[[@LINE]]:{{[0-9]+}}: error: invalid operand for instruction
-        sdr       $11,-20423($12) # CHECK: :[[@LINE]]:{{[0-9]+}}: error: invalid operand for instruction
+        scd       $15,-8243($sp)  # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
+        sdl       $a3,-20961($s8) # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
+        sdr       $11,-20423($12) # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled

--- a/llvm/test/MC/Mips/mips2/invalid-mips4.s
+++ b/llvm/test/MC/Mips/mips2/invalid-mips4.s
@@ -48,7 +48,7 @@
         floor.l.s $f12,$f5        # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
         ldxc1     $f8,$s7($15)    # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
         lwxc1     $f12,$s1($s8)   # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
-        lwu       $s3,-24086($v1) # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
+        lwu       $s3,-24086($v1) # CHECK: :[[#@LINE]]:[[#]]: error: instruction requires a CPU feature not currently enabled
         movf      $gp,$8,$fcc0    # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
         movf      $gp,$8,$fcc7    # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
         movf.d    $f6,$f11,$fcc0  # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled

--- a/llvm/test/MC/Mips/mips2/invalid-mips4.s
+++ b/llvm/test/MC/Mips/mips2/invalid-mips4.s
@@ -48,7 +48,7 @@
         floor.l.s $f12,$f5        # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
         ldxc1     $f8,$s7($15)    # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
         lwxc1     $f12,$s1($s8)   # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
-        lwu       $s3,-24086($v1) # CHECK: :[[@LINE]]:23: error: invalid operand for instruction
+        lwu       $s3,-24086($v1) # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
         movf      $gp,$8,$fcc0    # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
         movf      $gp,$8,$fcc7    # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
         movf.d    $f6,$f11,$fcc0  # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled

--- a/llvm/test/MC/Mips/mips32r6/invalid-mips1-wrong-error.s
+++ b/llvm/test/MC/Mips/mips32r6/invalid-mips1-wrong-error.s
@@ -7,14 +7,14 @@
 	.set noat
         bc2f      4                   # CHECK: :[[@LINE]]:{{[0-9]+}}: error: unknown instruction
         bc2t      4                   # CHECK: :[[@LINE]]:{{[0-9]+}}: error: unknown instruction
-        lwl       $s4,-4231($15)      # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
-        lwr       $zero,-19147($gp)   # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
-        swl       $15,13694($s3)      # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
-        swr       $s1,-26590($14)     # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
+        lwl       $s4,-4231($15)      # CHECK: :[[#@LINE]]:[[#]]: error: instruction requires a CPU feature not currently enabled
+        lwr       $zero,-19147($gp)   # CHECK: :[[#@LINE]]:[[#]]: error: instruction requires a CPU feature not currently enabled
+        swl       $15,13694($s3)      # CHECK: :[[#@LINE]]:[[#]]: error: instruction requires a CPU feature not currently enabled
+        swr       $s1,-26590($14)     # CHECK: :[[#@LINE]]:[[#]]: error: instruction requires a CPU feature not currently enabled
         lwle      $s4,-4231($15)      # CHECK: :[[@LINE]]:{{[0-9]+}}: error: invalid operand for instruction
         lwre      $zero,-19147($gp)   # CHECK: :[[@LINE]]:{{[0-9]+}}: error: invalid operand for instruction
         swle      $15,13694($s3)      # CHECK: :[[@LINE]]:{{[0-9]+}}: error: invalid operand for instruction
-        swre      $24, 5($3)          # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
+        swre      $24, 5($3)          # CHECK: :[[#@LINE]]:[[#]]: error: instruction requires a CPU feature not currently enabled
         swre      $s1,-26590($14)     # CHECK: :[[@LINE]]:{{[0-9]+}}: error: invalid operand for instruction
-        lwc3      $12, 4($4)          # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
-        swc3      $12, 4($4)          # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
+        lwc3      $12, 4($4)          # CHECK: :[[#@LINE]]:[[#]]: error: instruction requires a CPU feature not currently enabled
+        swc3      $12, 4($4)          # CHECK: :[[#@LINE]]:[[#]]: error: instruction requires a CPU feature not currently enabled

--- a/llvm/test/MC/Mips/mips32r6/invalid-mips1-wrong-error.s
+++ b/llvm/test/MC/Mips/mips32r6/invalid-mips1-wrong-error.s
@@ -7,14 +7,14 @@
 	.set noat
         bc2f      4                   # CHECK: :[[@LINE]]:{{[0-9]+}}: error: unknown instruction
         bc2t      4                   # CHECK: :[[@LINE]]:{{[0-9]+}}: error: unknown instruction
-        lwl       $s4,-4231($15)      # CHECK: :[[@LINE]]:{{[0-9]+}}: error: invalid operand for instruction
-        lwr       $zero,-19147($gp)   # CHECK: :[[@LINE]]:{{[0-9]+}}: error: invalid operand for instruction
-        swl       $15,13694($s3)      # CHECK: :[[@LINE]]:{{[0-9]+}}: error: invalid operand for instruction
-        swr       $s1,-26590($14)     # CHECK: :[[@LINE]]:{{[0-9]+}}: error: invalid operand for instruction
+        lwl       $s4,-4231($15)      # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
+        lwr       $zero,-19147($gp)   # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
+        swl       $15,13694($s3)      # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
+        swr       $s1,-26590($14)     # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
         lwle      $s4,-4231($15)      # CHECK: :[[@LINE]]:{{[0-9]+}}: error: invalid operand for instruction
         lwre      $zero,-19147($gp)   # CHECK: :[[@LINE]]:{{[0-9]+}}: error: invalid operand for instruction
         swle      $15,13694($s3)      # CHECK: :[[@LINE]]:{{[0-9]+}}: error: invalid operand for instruction
-        swre      $24, 5($3)          # CHECK: :[[@LINE]]:{{[0-9]+}}: error: invalid operand for instruction
+        swre      $24, 5($3)          # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
         swre      $s1,-26590($14)     # CHECK: :[[@LINE]]:{{[0-9]+}}: error: invalid operand for instruction
-        lwc3      $12, 4($4)          # CHECK: :[[@LINE]]:{{[0-9]+}}: error: invalid operand for instruction
-        swc3      $12, 4($4)          # CHECK: :[[@LINE]]:{{[0-9]+}}: error: invalid operand for instruction
+        lwc3      $12, 4($4)          # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
+        swc3      $12, 4($4)          # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled

--- a/llvm/test/MC/Mips/mips64r6/invalid-mips1-wrong-error.s
+++ b/llvm/test/MC/Mips/mips64r6/invalid-mips1-wrong-error.s
@@ -7,13 +7,13 @@
 	.set noat
         bc2f      4                   # CHECK: :[[@LINE]]:{{[0-9]+}}: error: unknown instruction
         bc2t      4                   # CHECK: :[[@LINE]]:{{[0-9]+}}: error: unknown instruction
-        lwl       $s4,-4231($15)      # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
-        lwr       $zero,-19147($gp)   # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
-        swl       $15,13694($s3)      # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
-        swr       $s1,-26590($14)     # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
+        lwl       $s4,-4231($15)      # CHECK: :[[#@LINE]]:[[#]]: error: instruction requires a CPU feature not currently enabled
+        lwr       $zero,-19147($gp)   # CHECK: :[[#@LINE]]:[[#]]: error: instruction requires a CPU feature not currently enabled
+        swl       $15,13694($s3)      # CHECK: :[[#@LINE]]:[[#]]: error: instruction requires a CPU feature not currently enabled
+        swr       $s1,-26590($14)     # CHECK: :[[#@LINE]]:[[#]]: error: instruction requires a CPU feature not currently enabled
         lwle      $s4,-4231($15)      # CHECK: :[[@LINE]]:{{[0-9]+}}: error: invalid operand for instruction
         lwre      $zero,-19147($gp)   # CHECK: :[[@LINE]]:{{[0-9]+}}: error: invalid operand for instruction
         swle      $15,13694($s3)      # CHECK: :[[@LINE]]:{{[0-9]+}}: error: invalid operand for instruction
         swre      $s1,-26590($14)     # CHECK: :[[@LINE]]:{{[0-9]+}}: error: invalid operand for instruction
-        lwc3      $12, 4($4)          # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
-        swc3      $12, 4($4)          # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
+        lwc3      $12, 4($4)          # CHECK: :[[#@LINE]]:[[#]]: error: instruction requires a CPU feature not currently enabled
+        swc3      $12, 4($4)          # CHECK: :[[#@LINE]]:[[#]]: error: instruction requires a CPU feature not currently enabled

--- a/llvm/test/MC/Mips/mips64r6/invalid-mips1-wrong-error.s
+++ b/llvm/test/MC/Mips/mips64r6/invalid-mips1-wrong-error.s
@@ -7,13 +7,13 @@
 	.set noat
         bc2f      4                   # CHECK: :[[@LINE]]:{{[0-9]+}}: error: unknown instruction
         bc2t      4                   # CHECK: :[[@LINE]]:{{[0-9]+}}: error: unknown instruction
-        lwl       $s4,-4231($15)      # CHECK: :[[@LINE]]:{{[0-9]+}}: error: invalid operand for instruction
-        lwr       $zero,-19147($gp)   # CHECK: :[[@LINE]]:{{[0-9]+}}: error: invalid operand for instruction
-        swl       $15,13694($s3)      # CHECK: :[[@LINE]]:{{[0-9]+}}: error: invalid operand for instruction
-        swr       $s1,-26590($14)     # CHECK: :[[@LINE]]:{{[0-9]+}}: error: invalid operand for instruction
+        lwl       $s4,-4231($15)      # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
+        lwr       $zero,-19147($gp)   # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
+        swl       $15,13694($s3)      # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
+        swr       $s1,-26590($14)     # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
         lwle      $s4,-4231($15)      # CHECK: :[[@LINE]]:{{[0-9]+}}: error: invalid operand for instruction
         lwre      $zero,-19147($gp)   # CHECK: :[[@LINE]]:{{[0-9]+}}: error: invalid operand for instruction
         swle      $15,13694($s3)      # CHECK: :[[@LINE]]:{{[0-9]+}}: error: invalid operand for instruction
         swre      $s1,-26590($14)     # CHECK: :[[@LINE]]:{{[0-9]+}}: error: invalid operand for instruction
-        lwc3      $12, 4($4)          # CHECK: :[[@LINE]]:{{[0-9]+}}: error: invalid operand for instruction
-        swc3      $12, 4($4)          # CHECK: :[[@LINE]]:{{[0-9]+}}: error: invalid operand for instruction
+        lwc3      $12, 4($4)          # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
+        swc3      $12, 4($4)          # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled

--- a/llvm/test/MC/Mips/mips64r6/invalid-mips3-wrong-error.s
+++ b/llvm/test/MC/Mips/mips64r6/invalid-mips3-wrong-error.s
@@ -5,18 +5,18 @@
 # RUN: FileCheck %s < %t1
 
 	.set noat
-        ldl       $s4,-4231($15)      # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
-        ldr       $zero,-19147($gp)   # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
-        sdl       $15,13694($s3)      # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
-        sdr       $s1,-26590($14)     # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
+        ldl       $s4,-4231($15)      # CHECK: :[[#@LINE]]:[[#]]: error: instruction requires a CPU feature not currently enabled
+        ldr       $zero,-19147($gp)   # CHECK: :[[#@LINE]]:[[#]]: error: instruction requires a CPU feature not currently enabled
+        sdl       $15,13694($s3)      # CHECK: :[[#@LINE]]:[[#]]: error: instruction requires a CPU feature not currently enabled
+        sdr       $s1,-26590($14)     # CHECK: :[[#@LINE]]:[[#]]: error: instruction requires a CPU feature not currently enabled
         ldle      $s4,-4231($15)      # CHECK: :[[@LINE]]:{{[0-9]+}}: error: unknown instruction
         ldre      $zero,-19147($gp)   # CHECK: :[[@LINE]]:{{[0-9]+}}: error: unknown instruction
         sdle      $15,13694($s3)      # CHECK: :[[@LINE]]:{{[0-9]+}}: error: unknown instruction
         sdre      $s1,-26590($14)     # CHECK: :[[@LINE]]:{{[0-9]+}}: error: unknown instruction
-        lwl       $s4,-4231($15)      # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
-        lwr       $zero,-19147($gp)   # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
-        swl       $15,13694($s3)      # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
-        swr       $s1,-26590($14)     # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
+        lwl       $s4,-4231($15)      # CHECK: :[[#@LINE]]:[[#]]: error: instruction requires a CPU feature not currently enabled
+        lwr       $zero,-19147($gp)   # CHECK: :[[#@LINE]]:[[#]]: error: instruction requires a CPU feature not currently enabled
+        swl       $15,13694($s3)      # CHECK: :[[#@LINE]]:[[#]]: error: instruction requires a CPU feature not currently enabled
+        swr       $s1,-26590($14)     # CHECK: :[[#@LINE]]:[[#]]: error: instruction requires a CPU feature not currently enabled
         lwle      $s4,-4231($15)      # CHECK: :[[@LINE]]:{{[0-9]+}}: error: invalid operand for instruction
         lwre      $zero,-19147($gp)   # CHECK: :[[@LINE]]:{{[0-9]+}}: error: invalid operand for instruction
         swle      $15,13694($s3)      # CHECK: :[[@LINE]]:{{[0-9]+}}: error: invalid operand for instruction

--- a/llvm/test/MC/Mips/mips64r6/invalid-mips3-wrong-error.s
+++ b/llvm/test/MC/Mips/mips64r6/invalid-mips3-wrong-error.s
@@ -5,18 +5,18 @@
 # RUN: FileCheck %s < %t1
 
 	.set noat
-        ldl       $s4,-4231($15)      # CHECK: :[[@LINE]]:{{[0-9]+}}: error: invalid operand for instruction
-        ldr       $zero,-19147($gp)   # CHECK: :[[@LINE]]:{{[0-9]+}}: error: invalid operand for instruction
-        sdl       $15,13694($s3)      # CHECK: :[[@LINE]]:{{[0-9]+}}: error: invalid operand for instruction
-        sdr       $s1,-26590($14)     # CHECK: :[[@LINE]]:{{[0-9]+}}: error: invalid operand for instruction
+        ldl       $s4,-4231($15)      # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
+        ldr       $zero,-19147($gp)   # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
+        sdl       $15,13694($s3)      # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
+        sdr       $s1,-26590($14)     # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
         ldle      $s4,-4231($15)      # CHECK: :[[@LINE]]:{{[0-9]+}}: error: unknown instruction
         ldre      $zero,-19147($gp)   # CHECK: :[[@LINE]]:{{[0-9]+}}: error: unknown instruction
         sdle      $15,13694($s3)      # CHECK: :[[@LINE]]:{{[0-9]+}}: error: unknown instruction
         sdre      $s1,-26590($14)     # CHECK: :[[@LINE]]:{{[0-9]+}}: error: unknown instruction
-        lwl       $s4,-4231($15)      # CHECK: :[[@LINE]]:{{[0-9]+}}: error: invalid operand for instruction
-        lwr       $zero,-19147($gp)   # CHECK: :[[@LINE]]:{{[0-9]+}}: error: invalid operand for instruction
-        swl       $15,13694($s3)      # CHECK: :[[@LINE]]:{{[0-9]+}}: error: invalid operand for instruction
-        swr       $s1,-26590($14)     # CHECK: :[[@LINE]]:{{[0-9]+}}: error: invalid operand for instruction
+        lwl       $s4,-4231($15)      # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
+        lwr       $zero,-19147($gp)   # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
+        swl       $15,13694($s3)      # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
+        swr       $s1,-26590($14)     # CHECK: :[[@LINE]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
         lwle      $s4,-4231($15)      # CHECK: :[[@LINE]]:{{[0-9]+}}: error: invalid operand for instruction
         lwre      $zero,-19147($gp)   # CHECK: :[[@LINE]]:{{[0-9]+}}: error: invalid operand for instruction
         swle      $15,13694($s3)      # CHECK: :[[@LINE]]:{{[0-9]+}}: error: invalid operand for instruction

--- a/llvm/test/MC/Mips/target-soft-float.s
+++ b/llvm/test/MC/Mips/target-soft-float.s
@@ -268,9 +268,9 @@ foo:
   floor.w.s  $f2, $f2
   # 32: :[[@LINE-1]]:3: error: instruction requires a CPU feature not currently enabled
   ldc1       $f2, 16($7)
-  # 32: :[[@LINE-1]]:3: error: instruction requires a CPU feature not currently enabled
+  # 32: :[[#@LINE-1]]:3: error: instruction requires a CPU feature not currently enabled
   lwc1       $f2, 16($7)
-  # 32: :[[@LINE-1]]:3: error: instruction requires a CPU feature not currently enabled
+  # 32: :[[#@LINE-1]]:3: error: instruction requires a CPU feature not currently enabled
   madd.s     $f2, $f2, $f2, $f2
   # 32: :[[@LINE-1]]:3: error: instruction requires a CPU feature not currently enabled
   mfc1       $7, $f2
@@ -310,7 +310,7 @@ foo:
   round.w.s  $f2, $f2
   # 32: :[[@LINE-1]]:3: error: instruction requires a CPU feature not currently enabled
   sdc1       $f2, 16($7)
-  # 32: :[[@LINE-1]]:3: error: instruction requires a CPU feature not currently enabled
+  # 32: :[[#@LINE-1]]:3: error: instruction requires a CPU feature not currently enabled
   sqrt.d     $f2, $f2
   # 32: :[[@LINE-1]]:3: error: instruction requires a CPU feature not currently enabled
   sqrt.s     $f2, $f2
@@ -320,7 +320,7 @@ foo:
   sub.s      $f2, $f2, $f2
   # 32: :[[@LINE-1]]:3: error: instruction requires a CPU feature not currently enabled
   swc1       $f2, 16($7)
-  # 32: :[[@LINE-1]]:3: error: instruction requires a CPU feature not currently enabled
+  # 32: :[[#@LINE-1]]:3: error: instruction requires a CPU feature not currently enabled
   trunc.w.d  $f2, $f2
   # 32: :[[@LINE-1]]:3: error: instruction requires a CPU feature not currently enabled
   trunc.w.s  $f2, $f2

--- a/llvm/test/MC/Mips/target-soft-float.s
+++ b/llvm/test/MC/Mips/target-soft-float.s
@@ -268,11 +268,9 @@ foo:
   floor.w.s  $f2, $f2
   # 32: :[[@LINE-1]]:3: error: instruction requires a CPU feature not currently enabled
   ldc1       $f2, 16($7)
-  # FIXME: LDC1 is correctly rejected but the wrong error message is emitted.
-  # 32: :[[@LINE-2]]:19: error: invalid operand for instruction
+  # 32: :[[@LINE-1]]:3: error: instruction requires a CPU feature not currently enabled
   lwc1       $f2, 16($7)
-  # FIXME: LWC1 is correctly rejected but the wrong error message is emitted.
-  # 32: :[[@LINE-2]]:19: error: invalid operand for instruction
+  # 32: :[[@LINE-1]]:3: error: instruction requires a CPU feature not currently enabled
   madd.s     $f2, $f2, $f2, $f2
   # 32: :[[@LINE-1]]:3: error: instruction requires a CPU feature not currently enabled
   mfc1       $7, $f2
@@ -312,8 +310,7 @@ foo:
   round.w.s  $f2, $f2
   # 32: :[[@LINE-1]]:3: error: instruction requires a CPU feature not currently enabled
   sdc1       $f2, 16($7)
-  # FIXME: SDC1 is correctly rejected but the wrong error message is emitted.
-  # 32: :[[@LINE-2]]:19: error: invalid operand for instruction
+  # 32: :[[@LINE-1]]:3: error: instruction requires a CPU feature not currently enabled
   sqrt.d     $f2, $f2
   # 32: :[[@LINE-1]]:3: error: instruction requires a CPU feature not currently enabled
   sqrt.s     $f2, $f2
@@ -323,8 +320,7 @@ foo:
   sub.s      $f2, $f2, $f2
   # 32: :[[@LINE-1]]:3: error: instruction requires a CPU feature not currently enabled
   swc1       $f2, 16($7)
-  # FIXME: SWC1 is correctly rejected but the wrong error message is emitted.
-  # 32: :[[@LINE-2]]:19: error: invalid operand for instruction
+  # 32: :[[@LINE-1]]:3: error: instruction requires a CPU feature not currently enabled
   trunc.w.d  $f2, $f2
   # 32: :[[@LINE-1]]:3: error: instruction requires a CPU feature not currently enabled
   trunc.w.s  $f2, $f2


### PR DESCRIPTION
… instructions.

This is a fix I stumbled upon while working on something else. I decided to break it out since it seems like a good "first issue" to submit. I updated the comments in the "wrong error" test files to indicate that the messages are no longer incorrect, but I left the names of the test files alone. I was not sure what to do with those, so I would appreciate thoughts or guidance.