### PR TITLE
[RISCV] Add .insn alias for addresses without the leading immediate.

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVInstrInfo.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfo.td
@@ -1140,6 +1140,9 @@ def : InstAlias<".insn_i $opcode, $funct3, $rd, $rs1, $imm12",
 def : InstAlias<".insn_i $opcode, $funct3, $rd, ${imm12}(${rs1})",
                 (InsnI_Mem AnyReg:$rd, uimm7_opcode:$opcode, uimm3:$funct3,
                            AnyReg:$rs1, simm12:$imm12)>;
+def : InstAlias<".insn_i $opcode, $funct3, $rd, (${rs1})",
+                (InsnI_Mem AnyReg:$rd, uimm7_opcode:$opcode, uimm3:$funct3,
+                           AnyReg:$rs1, 0)>;
 def : InstAlias<".insn_b $opcode, $funct3, $rs1, $rs2, $imm12",
                 (InsnB uimm7_opcode:$opcode, uimm3:$funct3, AnyReg:$rs1,
                        AnyReg:$rs2, simm13_lsb0:$imm12)>;
@@ -1157,6 +1160,9 @@ def : InstAlias<".insn_uj $opcode, $rd, $imm20",
 def : InstAlias<".insn_s $opcode, $funct3, $rs2, ${imm12}(${rs1})",
                 (InsnS uimm7_opcode:$opcode, uimm3:$funct3, AnyReg:$rs2,
                        AnyReg:$rs1, simm12:$imm12)>;
+def : InstAlias<".insn_s $opcode, $funct3, $rs2, (${rs1})",
+                (InsnS uimm7_opcode:$opcode, uimm3:$funct3, AnyReg:$rs2,
+                       AnyReg:$rs1, 0)>;
 }
 
 //===----------------------------------------------------------------------===//

--- a/llvm/lib/Target/RISCV/RISCVInstrInfoC.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoC.td
@@ -823,9 +823,15 @@ def : InstAlias<".insn_css $opcode, $funct3, $rs2, $imm6",
 def : InstAlias<".insn_cl $opcode, $funct3, $rd, ${imm5}(${rs1})",
                 (InsnCL AnyRegC:$rd, uimm2_opcode:$opcode, uimm3:$funct3,
                         AnyRegC:$rs1, uimm5:$imm5)>;
+def : InstAlias<".insn_cl $opcode, $funct3, $rd, (${rs1})",
+                (InsnCL AnyRegC:$rd, uimm2_opcode:$opcode, uimm3:$funct3,
+                        AnyRegC:$rs1, 0)>;
 def : InstAlias<".insn_cs $opcode, $funct3, $rs2, ${imm5}(${rs1})",
                 (InsnCS uimm2_opcode:$opcode, uimm3:$funct3, AnyRegC:$rs2,
                         AnyRegC:$rs1, uimm5:$imm5)>;
+def : InstAlias<".insn_cs $opcode, $funct3, $rs2, (${rs1})",
+                (InsnCS uimm2_opcode:$opcode, uimm3:$funct3, AnyRegC:$rs2,
+                        AnyRegC:$rs1, 0)>;
 def : InstAlias<".insn_ca $opcode, $funct6, $funct2, $rd, $rs2",
                 (InsnCA AnyRegC:$rd, uimm2_opcode:$opcode, uimm6:$funct6,
                         uimm2:$funct2, AnyRegC:$rs2)>;

--- a/llvm/test/MC/RISCV/insn.s
+++ b/llvm/test/MC/RISCV/insn.s
@@ -38,6 +38,15 @@ target:
 # CHECK-OBJ: jalr a0, 0xa(a1)
 .insn i  JALR,  0, a0, 10(a1)
 
+# CHECK-ASM: .insn i 103, 0, a0, 0(a1)
+# CHECK-ASM: encoding: [0x67,0x85,0x05,0x00]
+# CHECK-OBJ: jalr a0, 0x0(a1)
+.insn i  0x67,  0, a0, (a1)
+# CHECK-ASM: .insn i 103, 0, a0, 0(a1)
+# CHECK-ASM: encoding: [0x67,0x85,0x05,0x00]
+# CHECK-OBJ: jalr a0, 0x0(a1)
+.insn i  JALR,  0, a0, (a1)
+
 # CHECK-ASM: .insn i 3, 0, a0, 4(a1)
 # CHECK-ASM: encoding: [0x03,0x85,0x45,0x00]
 # CHECK-OBJ: lb a0, 0x4(a1)
@@ -46,6 +55,15 @@ target:
 # CHECK-ASM: encoding: [0x03,0x85,0x45,0x00]
 # CHECK-OBJ: lb a0, 0x4(a1)
 .insn i   LOAD,  0, a0, 4(a1)
+
+# CHECK-ASM: .insn i 3, 0, a0, 0(a1)
+# CHECK-ASM: encoding: [0x03,0x85,0x05,0x00]
+# CHECK-OBJ: lb a0, 0x0(a1)
+.insn i   0x3,  0, a0, (a1)
+# CHECK-ASM: .insn i 3, 0, a0, 0(a1)
+# CHECK-ASM: encoding: [0x03,0x85,0x05,0x00]
+# CHECK-OBJ: lb a0, 0x0(a1)
+.insn i   LOAD,  0, a0, (a1)
 
 # CHECK-ASM: .insn b 99, 0, a0, a1, target
 # CHECK-ASM: [0x63'A',A,0xb5'A',A]
@@ -73,6 +91,15 @@ target:
 # CHECK-ASM: encoding: [0x23,0x82,0xa5,0x00]
 # CHECK-OBJ: sb a0, 0x4(a1)
 .insn s  STORE,  0, a0, 4(a1)
+
+# CHECK-ASM: .insn s 35, 0, a0, 0(a1)
+# CHECK-ASM: encoding: [0x23,0x80,0xa5,0x00]
+# CHECK-OBJ: sb a0, 0x0(a1)
+.insn s  0x23,  0, a0, (a1)
+# CHECK-ASM: .insn s 35, 0, a0, 0(a1)
+# CHECK-ASM: encoding: [0x23,0x80,0xa5,0x00]
+# CHECK-OBJ: sb a0, 0x0(a1)
+.insn s  STORE,  0, a0, (a1)
 
 # CHECK-ASM: .insn u 55, a0, 4095
 # CHECK-ASM: encoding: [0x37,0xf5,0xff,0x00]

--- a/llvm/test/MC/RISCV/insn_c.s
+++ b/llvm/test/MC/RISCV/insn_c.s
@@ -51,10 +51,20 @@ target:
 # CHECK-OBJ: c.lw a0, 0x58(a1)
 .insn cl  0, 2, a0, 13(a1)
 
+# CHECK-ASM: .insn cl  0, 2, a0, 0
+# CHECK-ASM: encoding: [0x88,0x41]
+# CHECK-OBJ: c.lw a0, 0x0(a1)
+.insn cl  0, 2, a0, 0(a1)
+
 # CHECK-ASM: .insn cs  0, 6, a0, 13
 # CHECK-ASM: encoding: [0xa8,0xcd]
 # CHECK-OBJ: c.sw a0, 0x58(a1)
 .insn cs  0, 6, a0, 13(a1)
+
+# CHECK-ASM: .insn cs  0, 6, a0, 0
+# CHECK-ASM: encoding: [0x88,0xc1]
+# CHECK-OBJ: c.sw a0, 0x0(a1)
+.insn cs  0, 6, a0, (a1)
 
 # CHECK-ASM: .insn ca  1, 35, 0, a0, a1
 # CHECK-ASM: encoding: [0x0d,0x8d]


### PR DESCRIPTION
Most other instructions accept addresses that start with a '(' without an immediate before it. The .insn cases were missing. This is also supported by binutils.