### PR TITLE
Workaround -Wglobal-constructor warning.

### DIFF
--- a/llvm/lib/Support/CodeGenCoverage.cpp
+++ b/llvm/lib/Support/CodeGenCoverage.cpp
@@ -21,8 +21,6 @@
 
 using namespace llvm;
 
-static sys::SmartMutex<true> OutputMutex;
-
 CodeGenCoverage::CodeGenCoverage() = default;
 
 void CodeGenCoverage::setCovered(uint64_t RuleID) {
@@ -79,6 +77,7 @@ bool CodeGenCoverage::parse(MemoryBuffer &Buffer, StringRef BackendName) {
 bool CodeGenCoverage::emit(StringRef CoveragePrefix,
                            StringRef BackendName) const {
   if (!CoveragePrefix.empty() && !RuleCoverage.empty()) {
+    static sys::SmartMutex<true> OutputMutex;
     sys::SmartScopedLock<true> Lock(OutputMutex);
 
     // We can handle locking within a process easily enough but we don't want to


### PR DESCRIPTION
This line was tripping the -Wglobal-constructor warning which was causing a build failure when -Werror was turned on.