### PR TITLE
[dfsan] Add test case for sscanf

### DIFF
--- a/compiler-rt/test/dfsan/sscanf.c
+++ b/compiler-rt/test/dfsan/sscanf.c
@@ -1,0 +1,19 @@
+// RUN: %clang_dfsan %s -o %t && %run %t
+// XFAIL: *
+
+#include <assert.h>
+#include <stdio.h>
+
+int main(int argc, char *argv[]) {
+  char buf[256] = "10000000000-100000000000 rw-p 00000000 00:00 0";
+  long rss = 0;
+  // This test exposes a bug in DFSan's sscanf, that leads to flakiness
+  // in release_shadow_space.c (see
+  // https://github.com/llvm/llvm-project/issues/91287)
+  if (sscanf(buf, "Garbage text before, %ld, Garbage text after", &rss) == 1) {
+    printf("Error: matched %ld\n", rss);
+    return 1;
+  }
+
+  return 0;
+}


### PR DESCRIPTION
This test case shows a limitation of DFSan's sscanf implementation (introduced in https://reviews.llvm.org/D153775): it simply ignores ordinary characters in the format string, instead of actually comparing them against the input. This may change the semantics of instrumented programs.

Importantly, this also means that DFSan's release_shadow_space.c test, which relies on sscanf to scrape the RSS from /proc/maps output, will incorrectly match lines that don't contain RSS information. As a result, it adding together numbers from irrelevant output (e.g., base addresses), resulting in test flakiness
(https://github.com/llvm/llvm-project/issues/91287).