### PR TITLE
[clang][LoongArch] Enable -fasynchronous-unwind-tables by default on Linux

### DIFF
--- a/clang/lib/Driver/ToolChains/Gnu.cpp
+++ b/clang/lib/Driver/ToolChains/Gnu.cpp
@@ -3087,6 +3087,8 @@ Generic_GCC::getDefaultUnwindTableLevel(const ArgList &Args) const {
   switch (getArch()) {
   case llvm::Triple::aarch64:
   case llvm::Triple::aarch64_be:
+  case llvm::Triple::loongarch32:
+  case llvm::Triple::loongarch64:
   case llvm::Triple::ppc:
   case llvm::Triple::ppcle:
   case llvm::Triple::ppc64:

--- a/clang/test/Driver/loongarch-features.c
+++ b/clang/test/Driver/loongarch-features.c
@@ -1,0 +1,7 @@
+// RUN: %clang --target=loongarch64-linux -### %s -fsyntax-only 2>&1 \
+// RUN:   | FileCheck %s -check-prefix=DEFAULT-LINUX
+
+// DEFAULT-LINUX: "-funwind-tables=2"
+// DEFAULT-LINUX-SAME: "-target-feature" "+f"
+// DEFAULT-LINUX-SAME: "-target-feature" "+d"
+// DEFAULT-LINUX-SAME: "-target-feature" "+ual"


### PR DESCRIPTION
This could improve user experience for stack unwinding, and also this is
enabled by default by LoongArch GCC.

Similar to commit be437f3bb8b657f4d2de4603734f24daa624d204
