### PR TITLE
[libc++] guard gcc diagnostic push in `bitset`

### DIFF
--- a/libcxx/include/bitset
+++ b/libcxx/include/bitset
@@ -375,11 +375,15 @@ template <size_t _N_words, size_t _Size>
 _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX23 unsigned long long
 __bitset<_N_words, _Size>::to_ullong(true_type, true_type) const {
   unsigned long long __r = __first_[0];
+#if defined(_LIBCPP_COMPILER_GCC)
   _LIBCPP_DIAGNOSTIC_PUSH
   _LIBCPP_GCC_DIAGNOSTIC_IGNORED("-Wshift-count-overflow")
+#endif
   for (size_t __i = 1; __i < sizeof(unsigned long long) / sizeof(__storage_type); ++__i)
     __r |= static_cast<unsigned long long>(__first_[__i]) << (sizeof(__storage_type) * CHAR_BIT);
+#if defined(_LIBCPP_COMPILER_GCC)
   _LIBCPP_DIAGNOSTIC_POP
+#endif
   return __r;
 }
 


### PR DESCRIPTION
context: https://github.com/llvm/llvm-project/pull/92663/files#r1623238031

I'm not sure if it needs fixing. Please let me know if I'm doing something wrong.