### PR TITLE
[BranchFolder] Fix missing debug info with tail merging

### DIFF
--- a/llvm/lib/CodeGen/BranchFolding.h
+++ b/llvm/lib/CodeGen/BranchFolding.h
@@ -50,10 +50,11 @@ class TargetRegisterInfo;
     class MergePotentialsElt {
       unsigned Hash;
       MachineBasicBlock *Block;
+      DebugLoc BranchDebugLoc;
 
     public:
-      MergePotentialsElt(unsigned h, MachineBasicBlock *b)
-        : Hash(h), Block(b) {}
+      MergePotentialsElt(unsigned h, MachineBasicBlock *b, DebugLoc bdl)
+          : Hash(h), Block(b), BranchDebugLoc(std::move(bdl)) {}
 
       unsigned getHash() const { return Hash; }
       MachineBasicBlock *getBlock() const { return Block; }
@@ -61,6 +62,8 @@ class TargetRegisterInfo;
       void setBlock(MachineBasicBlock *MBB) {
         Block = MBB;
       }
+
+      const DebugLoc &getBranchDebugLoc() { return BranchDebugLoc; }
 
       bool operator<(const MergePotentialsElt &) const;
     };
@@ -162,8 +165,9 @@ class TargetRegisterInfo;
 
     /// Remove all blocks with hash CurHash from MergePotentials, restoring
     /// branches at ends of blocks as appropriate.
-    void RemoveBlocksWithHash(unsigned CurHash, MachineBasicBlock* SuccBB,
-                                                MachineBasicBlock* PredBB);
+    void RemoveBlocksWithHash(unsigned CurHash, MachineBasicBlock *SuccBB,
+                              MachineBasicBlock *PredBB,
+                              const DebugLoc &BranchDL);
 
     /// None of the blocks to be tail-merged consist only of the common tail.
     /// Create a block that does by splitting one.

--- a/llvm/test/CodeGen/MIR/X86/tail-merging-preserve-debugloc.mir
+++ b/llvm/test/CodeGen/MIR/X86/tail-merging-preserve-debugloc.mir
@@ -1,0 +1,99 @@
+# RUN: llc -o - %s -mtriple=x86_64-unknown-linux-gnu --run-pass=branch-folder -enable-tail-merge | FileCheck %s
+#
+# Generated with
+#
+# bin/llc -stop-before=branch-folder test.ll
+# 
+# target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
+# target triple = "x86_64-grtev4-linux-gnu"
+#
+# define i32 @main(i1 %0) {
+# entry:
+#   br i1 %0, label %1, label %2
+#
+# 1:                                                ; preds = %entry
+#   store i64 1, ptr null, align 1
+#   br label %3, !dbg !3
+#
+# 2:                                                ; preds = %entry
+#   store i64 0, ptr null, align 1
+#   br label %3
+#
+# 3:                                                ; preds = %2, %1
+#   ret i32 0
+# }
+#
+# !llvm.dbg.cu = !{!0}
+# !llvm.module.flags = !{!2}
+# 
+# !0 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus_14, file: !1, producer: "", isOptimized: true, runtimeVersion: 0, emissionKind: LineTablesOnly, nameTableKind: None)
+# !1 = !DIFile(filename: "foo.c", directory: "/tmp", checksumkind: CSK_MD5, checksum: "2d07c91bb9d9c2fa4eee31a1aeed20e3")
+# !2 = !{i32 2, !"Debug Info Version", i32 3}
+# !3 = !DILocation(line: 17, column: 3, scope: !4)
+# !4 = distinct !DISubprogram(name: "main", scope: !1, file: !1, line: 6, type: !5, scopeLine: 6, flags: DIFlagPrototyped | DIFlagAllCallsDescribed, spFlags: DISPFlagDefinition | DISPFlagOptimized, unit: !0)
+# !5 = !DISubroutineType(types: !6)
+# !6 = !{}
+--- |
+  
+  ; ModuleID = '../llvm/test/CodeGen/X86/tail-merging-preserve-debugloc.ll'
+  source_filename = "../llvm/test/CodeGen/X86/tail-merging-preserve-debugloc.ll"
+  target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
+  target triple = "x86_64-grtev4-linux-gnu"
+
+  define i32 @main(i1 %0) {
+  entry:
+    br i1 %0, label %1, label %2
+
+  1:                                                ; preds = %entry
+    store i64 1, ptr null, align 1
+    br label %3, !dbg !3
+
+  2:                                                ; preds = %entry
+    store i64 0, ptr null, align 1
+    br label %3
+
+  3:                                                ; preds = %2, %1
+    ret i32 0
+  }
+
+  !llvm.dbg.cu = !{!0}
+  !llvm.module.flags = !{!2}
+
+  !0 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus_14, file: !1, isOptimized: true, runtimeVersion: 0, emissionKind: LineTablesOnly, nameTableKind: None)
+  !1 = !DIFile(filename: "foo.c", directory: "/tmp", checksumkind: CSK_MD5, checksum: "2d07c91bb9d9c2fa4eee31a1aeed20e3")
+  !2 = !{i32 2, !"Debug Info Version", i32 3}
+  !3 = !DILocation(line: 17, column: 3, scope: !4)
+  !4 = distinct !DISubprogram(name: "main", scope: !1, file: !1, line: 6, type: !5, scopeLine: 6, flags: DIFlagPrototyped | DIFlagAllCallsDescribed, spFlags: DISPFlagDefinition | DISPFlagOptimized, unit: !0)
+  !5 = !DISubroutineType(types: !6)
+  !6 = !{}
+
+...
+---
+name:            main
+body:             |
+  bb.0.entry:
+    successors: %bb.1(0x40000000), %bb.2(0x40000000)
+    liveins: $edi
+
+    TEST8ri renamable $dil, 1, implicit-def $eflags, implicit killed $edi
+    JCC_1 %bb.2, 4, implicit killed $eflags
+    JMP_1 %bb.1
+
+  bb.1 (%ir-block.1):
+    successors: %bb.3(0x80000000)
+
+    MOV64mi32 $noreg, 1, $noreg, 0, $noreg, 1 :: (store (s64) into `ptr null`, align 1)
+    JMP_1 %bb.3, debug-location !3
+
+  bb.2 (%ir-block.2):
+    successors: %bb.3(0x80000000)
+
+    MOV64mi32 $noreg, 1, $noreg, 0, $noreg, 0 :: (store (s64) into `ptr null`, align 1)
+
+  bb.3 (%ir-block.3):
+    $eax = MOV32r0 implicit-def dead $eflags
+    RET 0, killed $eax
+
+...
+# CHECK: [[DEBUGNUM:!.*]] = !DILocation(line: 17, column: 3,
+# CHECK: JMP_1 %bb.3, debug-location [[DEBUGNUM]]

--- a/llvm/test/DebugInfo/COFF/local-variables.ll
+++ b/llvm/test/DebugInfo/COFF/local-variables.ll
@@ -45,6 +45,8 @@
 ; ASM:         .cv_loc 1 1 5 3                 # t.cpp:5:3
 ; ASM:         callq   capture
 ; ASM:         leaq    40(%rsp), %rcx
+; ASM: [[end_inline_1:\.Ltmp.*]]:
+; ASM:         .cv_loc 0 1 11 5                # t.cpp:11:5
 ; ASM:         jmp     .LBB0_3
 ; ASM: [[else_start:\.Ltmp.*]]:
 ; ASM: .LBB0_2:                                # %if.else
@@ -87,7 +89,7 @@
 ; ASM: .long   116                     # TypeIndex
 ; ASM: .short  0                       # Flags
 ; ASM: .asciz  "v"
-; ASM: .cv_def_range    [[inline_site1]] [[else_start]], frame_ptr_rel, 44
+; ASM: .cv_def_range    [[inline_site1]] [[end_inline_1]], frame_ptr_rel, 44
 ; ASM: .short  4430                    # Record kind: S_INLINESITE_END
 ; ASM: .short  4429                    # Record kind: S_INLINESITE
 ; ASM: .short  4414                    # Record kind: S_LOCAL
@@ -154,7 +156,7 @@
 ; OBJ:        ChangeLineOffset: 1
 ; OBJ:        ChangeCodeOffset: 0x14
 ; OBJ:        ChangeCodeOffsetAndLineOffset: {CodeOffset: 0xD, LineOffset: 1}
-; OBJ:        ChangeCodeLength: 0xC
+; OBJ:        ChangeCodeLength: 0xA
 ; OBJ:      ]
 ; OBJ:    }
 ; OBJ:    LocalSym {
@@ -168,7 +170,7 @@
 ; OBJ:      LocalVariableAddrRange {
 ; OBJ:        OffsetStart: .text+0x14
 ; OBJ:        ISectStart: 0x0
-; OBJ:        Range: 0x19
+; OBJ:        Range: 0x17
 ; OBJ:      }
 ; OBJ:    }
 ; OBJ:    InlineSiteEnd {


### PR DESCRIPTION
`BranchFolder::TryTailMergeBlocks(...)` removes unconditional branch instructions and then recreates them. However, this process loses debug source location information from the previous branch instruction, even if tail merging doesn't change IR. This patch preserves the debug information from the removed instruction and inserts them into the recreated instruction.

Fixes #94050