### PR TITLE
[test] Don't generate `regalloc-amdgpu.s` in #94426

### DIFF
--- a/llvm/test/tools/llc/new-pm/regalloc-amdgpu.mir
+++ b/llvm/test/tools/llc/new-pm/regalloc-amdgpu.mir
@@ -1,6 +1,6 @@
 # REQUIRES: amdgpu-registered-target
 # RUN: llc -mtriple=amdgcn --passes='regallocfast<filter=sgpr>' --print-pipeline-passes %s | FileCheck %s --check-prefix=PASS
-# RUN: not llc -mtriple=amdgcn --passes='regallocfast<filter=bad-filter>' --print-pipeline-passes %s 2>&1 | FileCheck %s --check-prefix=BAD-FILTER
+# RUN: not llc -mtriple=amdgcn --passes='regallocfast<filter=bad-filter>' --print-pipeline-passes --filetype=null %s 2>&1 | FileCheck %s --check-prefix=BAD-FILTER
 
 # PASS: regallocfast<filter=sgpr>
 # BAD-FILTER: invalid regallocfast register filter 'bad-filter'


### PR DESCRIPTION
The test will generate an empty `regalloc-amdgpu.s` file in test, which causes an unresolved test.