### PR TITLE
[docs] Fix benchmarking tips

### DIFF
--- a/llvm/docs/Benchmarking.rst
+++ b/llvm/docs/Benchmarking.rst
@@ -49,7 +49,7 @@ Linux
 
    for i in /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor
    do
-     echo performance > /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor
+     echo performance > $i
    done
 
 * Use https://github.com/lpechacek/cpuset to reserve cpus for just the


### PR DESCRIPTION
This PR fixes an incorrect line for setting scaling_governer in benchmarking tips.