### PR TITLE
[mlir][vector] Remove Emulated Sub-directory

### DIFF
--- a/mlir/test/Integration/Dialect/Vector/CPU/ArmSME/Emulated/lit.local.cfg
+++ b/mlir/test/Integration/Dialect/Vector/CPU/ArmSME/Emulated/lit.local.cfg
@@ -1,5 +1,0 @@
-# The tests in this folder assume full control of the hardware features, such as
-# the vector length, so must be run under an emulator.
-
-if not config.arm_emulator_executable:
-    config.unsupported = True

--- a/mlir/test/Integration/Dialect/Vector/CPU/ArmSME/test-setArmSVLBits.mlir
+++ b/mlir/test/Integration/Dialect/Vector/CPU/ArmSME/test-setArmSVLBits.mlir
@@ -1,3 +1,5 @@
+// REQUIRES: arm-emulator
+
 // DEFINE: %{entry_point} = main
 // DEFINE: %{compile} = mlir-opt %s \
 // DEFINE: --pass-pipeline="builtin.module(func.func(convert-arm-sme-to-llvm),test-lower-to-llvm)"

--- a/mlir/test/Integration/Dialect/Vector/CPU/ArmSVE/Emulated/lit.local.cfg
+++ b/mlir/test/Integration/Dialect/Vector/CPU/ArmSVE/Emulated/lit.local.cfg
@@ -1,5 +1,0 @@
-# The tests in this folder assume full control of the hardware features, such as
-# the vector length, so must be run under an emulator.
-
-if not config.arm_emulator_executable:
-    config.unsupported = True

--- a/mlir/test/Integration/Dialect/Vector/CPU/ArmSVE/test-scalable-deinterleave.mlir
+++ b/mlir/test/Integration/Dialect/Vector/CPU/ArmSVE/test-scalable-deinterleave.mlir
@@ -1,3 +1,5 @@
+// REQUIRES: arm-emulator
+
 // DEFINE: %{entry_point} = entry
 // DEFINE: %{compile} = mlir-opt %s -test-lower-to-llvm
 // DEFINE: %{run} = %mcr_aarch64_cmd -march=aarch64 -mattr=+sve \

--- a/mlir/test/Integration/Dialect/Vector/CPU/ArmSVE/test-setArmVLBits.mlir
+++ b/mlir/test/Integration/Dialect/Vector/CPU/ArmSVE/test-setArmVLBits.mlir
@@ -1,3 +1,5 @@
+// REQUIRES: arm-emulator
+
 // DEFINE: %{entry_point} = main
 // DEFINE: %{compile} = mlir-opt %s -test-lower-to-llvm
 // DEFINE: %{run} = %mcr_aarch64_cmd -march=aarch64 -mattr=+sve \

--- a/mlir/test/lit.cfg.py
+++ b/mlir/test/lit.cfg.py
@@ -250,3 +250,6 @@ if config.run_nvptx_tests:
 
 if config.run_rocm_tests:
     config.available_features.add("host-supports-amdgpu")
+
+if config.arm_emulator_executable:
+    config.available_features.add("arm-emulator")


### PR DESCRIPTION
The "Emulated" sub-directories under "ArmSVE" and
"ArmSME" have been removed. Associated tests
have been moved up a directory and now include
the "REQUIRES" constraint for the arm-emulator.