### PR TITLE
[lld] Remove const qualifier on symbolKind (NFC)

### DIFF
--- a/lld/COFF/Symbols.h
+++ b/lld/COFF/Symbols.h
@@ -106,7 +106,7 @@ protected:
            "If the name is empty, the Symbol must be a DefinedCOFF.");
   }
 
-  const unsigned symbolKind : 8;
+  unsigned symbolKind : 8;
   unsigned isExternal : 1;
 
 public:


### PR DESCRIPTION
The symbol including this member is being overwritten here: https://github.com/llvm/llvm-project/blob/2117677e304d334326f6591f3c75fb2f34dc4bcb/lld/COFF/SymbolTable.cpp#L496-L509 I don't think that's compatible with this `const` qualifier.