### PR TITLE
[dexter] Correctly identify stop-reason while driving VisualStudio

### DIFF
--- a/cross-project-tests/debuginfo-tests/dexter/dex/debugger/visualstudio/VisualStudio.py
+++ b/cross-project-tests/debuginfo-tests/dexter/dex/debugger/visualstudio/VisualStudio.py
@@ -37,6 +37,7 @@ def _load_com_module():
 # properties we set through dexter currently.
 VSBreakpoint = namedtuple("VSBreakpoint", "path, line, col, cond")
 
+
 # Visual Studio events.
 # https://learn.microsoft.com/en-us/dotnet/api/envdte.dbgeventreason?view=visualstudiosdk-2022
 class DbgEvent(IntEnum):

--- a/cross-project-tests/debuginfo-tests/dexter/dex/debugger/visualstudio/VisualStudio.py
+++ b/cross-project-tests/debuginfo-tests/dexter/dex/debugger/visualstudio/VisualStudio.py
@@ -309,15 +309,15 @@ class VisualStudio(
 
     def _translate_stop_reason(self, reason):
         # https://learn.microsoft.com/en-us/dotnet/api/envdte.dbgeventreason?view=visualstudiosdk-2022
-        if reason == 1: # dbgEventReasonNone
+        if reason == 1:  # dbgEventReasonNone
             return None
-        if reason == 9: # dbgEventReasonBreakpoint
+        if reason == 9:  # dbgEventReasonBreakpoint
             return StopReason.BREAKPOINT
-        if reason == 8: # dbgEventReasonStep
+        if reason == 8:  # dbgEventReasonStep
             return StopReason.STEP
-        if reason == 6: # dbgEventReasonEndProgram
+        if reason == 6:  # dbgEventReasonEndProgram
             return StopReason.PROGRAM_EXIT
-        if reason == 11: # dbgEventReasonExceptionNotHandled
+        if reason == 11:  # dbgEventReasonExceptionNotHandled
             return StopReason.ERROR
         # Others:
         # dbgEventReasonNone = 1


### PR DESCRIPTION
Prior to this patch VisualStudio._get_step_info incorrectly identifies the reason the debugger has stopped. e.g., stepping through a program would be reported as a StopReason.Breakpoint rather than StopReason.Step.

Fix. No test added as there are no VisualStudio tests (tested locally).