### PR TITLE
[clang] always use resolved arguments for default argument deduction

### DIFF
--- a/clang/lib/Sema/SemaTemplateDeduction.cpp
+++ b/clang/lib/Sema/SemaTemplateDeduction.cpp
@@ -712,19 +712,18 @@ DeduceTemplateSpecArguments(Sema &S, TemplateParameterList *TemplateParams,
     if (const auto *TD = TNA.getAsTemplateDecl(); TD && TD->isTypeAlias())
       return TemplateDeductionResult::Success;
 
-    // Perform template argument deduction for the template name.
-    if (auto Result =
-            DeduceTemplateArguments(S, TemplateParams, TNP, TNA, Info,
-                                    SA->template_arguments(), Deduced);
-        Result != TemplateDeductionResult::Success)
-      return Result;
-
     // FIXME: To preserve sugar, the TST needs to carry sugared resolved
     // arguments.
     ArrayRef<TemplateArgument> AResolved =
         SA->getCanonicalTypeInternal()
             ->castAs<TemplateSpecializationType>()
             ->template_arguments();
+
+    // Perform template argument deduction for the template name.
+    if (auto Result = DeduceTemplateArguments(S, TemplateParams, TNP, TNA, Info,
+                                              AResolved, Deduced);
+        Result != TemplateDeductionResult::Success)
+      return Result;
 
     // Perform template argument deduction on each template
     // argument. Ignore any missing/extra arguments, since they could be

--- a/clang/test/SemaTemplate/cwg2398.cpp
+++ b/clang/test/SemaTemplate/cwg2398.cpp
@@ -201,3 +201,19 @@ namespace consistency {
     // new-error@-1 {{ambiguous partial specializations}}
   } // namespace t2
 } // namespace consistency
+
+namespace regression1 {
+  template <typename T, typename Y> struct map {};
+  template <typename T> class foo {};
+
+  template <template <typename...> class MapType, typename Value>
+  Value bar(MapType<int, Value> map);
+
+  template <template <typename...> class MapType, typename Value>
+  Value bar(MapType<int, foo<Value>> map);
+
+  void aux() {
+    map<int, foo<int>> input;
+    bar(input);
+  }
+} // namespace regression1


### PR DESCRIPTION
This fixes a regression introduced with the changes in https://github.com/llvm/llvm-project/pull/93433 around preservation of TemplateName sugar in template type deduction.

Since the argument side TST is non-canonical, we have to extract the arguments from it's canonical type.
This was done for the deduction of the TST arguments, but we missed it for the default arguments used in the deduction of the TST name.