### PR TITLE
[clang] Add fixit for using declaration with a (qualified) namespace

### DIFF
--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -607,6 +607,8 @@ def note_using_decl_class_member_workaround : Note<
   "a const variable|a constexpr variable}0 instead">;
 def err_using_decl_can_not_refer_to_namespace : Error<
   "using declaration cannot refer to a namespace">;
+def note_namespace_using_decl : Note<
+  "did you mean 'using namespace'?">;
 def warn_cxx17_compat_using_decl_scoped_enumerator: Warning<
   "using declaration naming a scoped enumerator is incompatible with "
   "C++ standards before C++20">, InGroup<CXXPre20Compat>, DefaultIgnore;

--- a/clang/lib/Sema/SemaDeclCXX.cpp
+++ b/clang/lib/Sema/SemaDeclCXX.cpp
@@ -13079,10 +13079,10 @@ NamedDecl *Sema::BuildUsingDeclaration(
   // A using-declaration shall not name a namespace.
   if (R.getAsSingle<NamespaceDecl>()) {
     Diag(IdentLoc, diag::err_using_decl_can_not_refer_to_namespace)
-      << SS.getRange();
+        << SS.getRange();
     // Suggest using 'using namespace ...' instead.
     Diag(SS.getBeginLoc(), diag::note_namespace_using_decl)
-      << FixItHint::CreateInsertion(SS.getBeginLoc(), "namespace ");
+        << FixItHint::CreateInsertion(SS.getBeginLoc(), "namespace ");
     return BuildInvalid();
   }
 

--- a/clang/lib/Sema/SemaDeclCXX.cpp
+++ b/clang/lib/Sema/SemaDeclCXX.cpp
@@ -13080,6 +13080,9 @@ NamedDecl *Sema::BuildUsingDeclaration(
   if (R.getAsSingle<NamespaceDecl>()) {
     Diag(IdentLoc, diag::err_using_decl_can_not_refer_to_namespace)
       << SS.getRange();
+    // Suggest using 'using namespace ...' instead.
+    Diag(SS.getBeginLoc(), diag::note_namespace_using_decl)
+      << FixItHint::CreateInsertion(SS.getBeginLoc(), "namespace ");
     return BuildInvalid();
   }
 

--- a/clang/test/CXX/dcl.dcl/basic.namespace/namespace.udecl/p6-cxx11.cpp
+++ b/clang/test/CXX/dcl.dcl/basic.namespace/namespace.udecl/p6-cxx11.cpp
@@ -1,7 +1,10 @@
 // RUN: %clang_cc1 -fsyntax-only -verify %s
+// RUN: not %clang_cc1 -fsyntax-only -fdiagnostics-parseable-fixits %s 2>&1 | FileCheck %s
 
 namespace A {
   namespace B { }
 }
 
+// CHECK: fix-it:"{{.*}}":{[[@LINE+1]]:7-[[@LINE+1]]:7}:"namespace "
 using A::B; // expected-error{{using declaration cannot refer to a namespace}}
+            // expected-note@-1 {{did you mean 'using namespace'?}}

--- a/clang/test/CXX/drs/cwg4xx.cpp
+++ b/clang/test/CXX/drs/cwg4xx.cpp
@@ -941,8 +941,10 @@ namespace cwg460 { // cwg460: yes
     // expected-error@-1 {{using declaration requires a qualified name}}
     using cwg460::X;
     // expected-error@-1 {{using declaration cannot refer to a namespace}}
+    // expected-note@-2 {{did you mean 'using namespace'?}}
     using X::Q;
     // expected-error@-1 {{using declaration cannot refer to a namespace}}
+    // expected-note@-2 {{did you mean 'using namespace'?}}
   }
 }
 


### PR DESCRIPTION
For `using std::literals`, we now output:

    error: using declaration cannot refer to a namespace
        4 |   using std::literals;
          |         ~~~~~^
    note: did you mean 'using namespace'?
        4 |   using std::literals;
          |         ^
          |         namespace

Previously, we didn't have the note.

This only fires for qualified namespaces. Just `using std;` doesn't trigger this, since using declarations without cxx scope specifier are rejected earlier. Making that work is an exercise for future selves :)