### PR TITLE
[flang] Allow interoperable object to have interoperable derived type…

### DIFF
--- a/flang/test/Semantics/declarations02.f90
+++ b/flang/test/Semantics/declarations02.f90
@@ -1,4 +1,4 @@
-! RUN: %python %S/test_errors.py %s %flang_fc1
+! RUN: %python %S/test_errors.py %s %flang_fc1 -pedantic
 
 module m
   !ERROR: 'x1' may not have both the BIND(C) and PARAMETER attributes
@@ -32,14 +32,14 @@ module m
   end type
 
   !ERROR: 't1' may not have both the BIND(C) and PARAMETER attributes
-  !ERROR: The derived type of a BIND(C) object must also be BIND(C)
+  !WARNING: The derived type of an interoperable object should be BIND(C)
   type(my_type1), bind(c), parameter :: t1 = my_type1(1)
   !ERROR: 't2' may not have both the BIND(C) and PARAMETER attributes
   type(my_type2), bind(c), parameter :: t2 = my_type2(1)
 
   type(my_type2), parameter :: t3 = my_type2(1) ! no error
   !ERROR: 't4' may not have both the BIND(C) and PARAMETER attributes
-  !ERROR: The derived type of a BIND(C) object must also be BIND(C)
+  !WARNING: The derived type of an interoperable object should be BIND(C)
   type(my_type1), parameter :: t4 = my_type1(1)
   !ERROR: 't5' may not have both the BIND(C) and PARAMETER attributes
   type(my_type2), parameter :: t5 = my_type2(1)


### PR DESCRIPTION
… that's not BIND(C)

An interoperable BIND(C) object with a derived type should have a BIND(C) derived type, but will now work with a derived type that satisfies all of the requirements of a BIND(C) derived type.