### PR TITLE
[lldb] Remove dead code block (NFC)

### DIFF
--- a/lldb/source/Utility/Scalar.cpp
+++ b/lldb/source/Utility/Scalar.cpp
@@ -753,9 +753,7 @@ bool Scalar::SignExtend(uint32_t sign_bit_pos) {
       return false;
 
     case Scalar::e_int:
-      if (max_bit_pos == sign_bit_pos)
-        return true;
-      else if (sign_bit_pos < (max_bit_pos - 1)) {
+      if (sign_bit_pos < (max_bit_pos - 1)) {
         llvm::APInt sign_bit = llvm::APInt::getSignMask(sign_bit_pos + 1);
         llvm::APInt bitwize_and = m_integer & sign_bit;
         if (bitwize_and.getBoolValue()) {


### PR DESCRIPTION
The check that max_bit_pos == sign_bit_pos conflicts with the check that sign_bit_pos < max_bit_pos in the block surrounding it.

Originally found by cppcheck - 
lldb/source/Utility/Scalar.cpp:756:23: warning: Opposite inner 'if' condition leads to a dead code block. [oppositeInnerCondition]

Fixes #85985