### PR TITLE
[lldb] Fix incorrect logical operator in 'if' condition check (NFC)

### DIFF
--- a/lldb/source/Plugins/ScriptInterpreter/Python/Interfaces/ScriptedPythonInterface.h
+++ b/lldb/source/Plugins/ScriptInterpreter/Python/Interfaces/ScriptedPythonInterface.h
@@ -85,7 +85,7 @@ public:
     bool has_class_name = !class_name.empty();
     bool has_interpreter_dict =
         !(llvm::StringRef(m_interpreter.GetDictionaryName()).empty());
-    if (!has_class_name && !has_interpreter_dict && !script_obj) {
+    if (!has_class_name || !has_interpreter_dict || !script_obj) {
       if (!has_class_name)
         return create_error("Missing script class name.");
       else if (!has_interpreter_dict)

--- a/lldb/source/Plugins/ScriptInterpreter/Python/Interfaces/ScriptedPythonInterface.h
+++ b/lldb/source/Plugins/ScriptInterpreter/Python/Interfaces/ScriptedPythonInterface.h
@@ -86,17 +86,14 @@ public:
     bool has_interpreter_dict =
         !(llvm::StringRef(m_interpreter.GetDictionaryName()).empty());
 
-    if (!has_class_name) {
+    if (!has_class_name)
       return create_error("Missing script class name.");
-    }
 
-    if (!has_interpreter_dict) {
+    if (!has_interpreter_dict)
       return create_error("Invalid script interpreter dictionary.");
-    }
 
-    if (!script_obj) {
+    if (!script_obj)
       return create_error("Missing scripting object.");
-    }
 
     Locker py_lock(&m_interpreter, Locker::AcquireLock | Locker::NoSTDIN,
                    Locker::FreeLock);

--- a/lldb/source/Plugins/ScriptInterpreter/Python/Interfaces/ScriptedPythonInterface.h
+++ b/lldb/source/Plugins/ScriptInterpreter/Python/Interfaces/ScriptedPythonInterface.h
@@ -85,13 +85,17 @@ public:
     bool has_class_name = !class_name.empty();
     bool has_interpreter_dict =
         !(llvm::StringRef(m_interpreter.GetDictionaryName()).empty());
-    if (!has_class_name || !has_interpreter_dict || !script_obj) {
-      if (!has_class_name)
-        return create_error("Missing script class name.");
-      else if (!has_interpreter_dict)
-        return create_error("Invalid script interpreter dictionary.");
-      else
-        return create_error("Missing scripting object.");
+
+    if (!has_class_name) {
+      return create_error("Missing script class name.");
+    }
+
+    if (!has_interpreter_dict) {
+      return create_error("Invalid script interpreter dictionary.");
+    }
+
+    if (!script_obj) {
+      return create_error("Missing scripting object.");
     }
 
     Locker py_lock(&m_interpreter, Locker::AcquireLock | Locker::NoSTDIN,


### PR DESCRIPTION
The condition checking for missing class name, interpreter dictionary, and script object incorrectly used logical AND (&&), which could never be true to enter the 'if' block. 

This commit uses separate if conditions for each class name, interpreter dictionary, and script object.

Cought by cppcheck -
lldb/source/Plugins/ScriptInterpreter/Python/Interfaces/ScriptedPythonInterface.h:89:11: warning: Identical inner 'if' condition is always true. [identicalInnerCondition]
lldb/source/Plugins/ScriptInterpreter/Python/Interfaces/ScriptedPythonInterface.h:91:16: warning: Identical inner 'if' condition is always true. [identicalInnerCondition]

Fix #89195