### PR TITLE
[workflows] Fix release note request workflow

### DIFF
--- a/.github/workflows/issue-write.yml
+++ b/.github/workflows/issue-write.yml
@@ -5,6 +5,7 @@ on:
     workflows:
       - "Check code formatting"
       - "Check for private emails used in PRs"
+      - "PR Request Release Note"
     types:
       - completed
 
@@ -92,7 +93,11 @@ jobs:
 
             var pr_number = 0;
             gql_result.repository.ref.associatedPullRequests.nodes.forEach((pr) => {
-              if (pr.baseRepository.owner.login = context.repo.owner && pr.state == 'OPEN') {
+
+              // The largest PR number is the one we care about.  The only way
+              // to have more than one associated pull requests is if all the
+              // old pull requests are in the closed state.
+              if (pr.baseRepository.owner.login = context.repo.owner && pr.number > pr_number) {
                 pr_number = pr.number;
               }
             });

--- a/.github/workflows/pr-request-release-note.yml
+++ b/.github/workflows/pr-request-release-note.yml
@@ -2,7 +2,6 @@ name: PR Request Release Note
 
 permissions:
   contents: read
-  pull-requests: write
 
 on:
   pull_request:
@@ -41,3 +40,10 @@ jobs:
             --token "$GITHUB_TOKEN" \
             request-release-note \
             --pr-number ${{ github.event.pull_request.number}}
+
+      - uses: actions/upload-artifact@26f96dfa697d77e81fd5907df203aa23a56210a8 #v4.3.0
+        if: always()
+        with:
+          name: workflow-args
+          path: |
+            comments

--- a/llvm/utils/git/github-automation.py
+++ b/llvm/utils/git/github-automation.py
@@ -11,6 +11,7 @@
 import argparse
 from git import Repo  # type: ignore
 import html
+import json
 import github
 import os
 import re
@@ -653,7 +654,15 @@ def request_release_note(token: str, repo_name: str, pr_number: int):
         mention = f"@{submitter}"
 
     comment = f"{mention} (or anyone else). If you would like to add a note about this fix in the release notes (completely optional). Please reply to this comment with a one or two sentence description of the fix.  When you are done, please add the release:note label to this PR. "
-    pr.as_issue().create_comment(comment)
+    try:
+        pr.as_issue().create_comment(comment)
+    except:
+        # Failed to create comment so emit file instead
+        with open("comments", "w") as file:
+            data = [
+                {"body" : comment}
+            ]
+            json.dump(data, file)
 
 
 parser = argparse.ArgumentParser()

--- a/llvm/utils/git/github-automation.py
+++ b/llvm/utils/git/github-automation.py
@@ -659,7 +659,7 @@ def request_release_note(token: str, repo_name: str, pr_number: int):
     except:
         # Failed to create comment so emit file instead
         with open("comments", "w") as file:
-            data = [{"body" : comment}]
+            data = [{"body": comment}]
             json.dump(data, file)
 
 

--- a/llvm/utils/git/github-automation.py
+++ b/llvm/utils/git/github-automation.py
@@ -659,9 +659,7 @@ def request_release_note(token: str, repo_name: str, pr_number: int):
     except:
         # Failed to create comment so emit file instead
         with open("comments", "w") as file:
-            data = [
-                {"body" : comment}
-            ]
+            data = [{"body" : comment}]
             json.dump(data, file)
 
 


### PR DESCRIPTION
We need to use the issue-write workflow to write the comments, because pull_request targets don't have permissions to write comments.