### PR TITLE
[lldb] Fix string truncation method when substring is the prefix of string (NFC)

### DIFF
--- a/lldb/source/Plugins/Platform/Android/PlatformAndroid.cpp
+++ b/lldb/source/Plugins/Platform/Android/PlatformAndroid.cpp
@@ -287,7 +287,7 @@ Status PlatformAndroid::DownloadModuleSlice(const FileSpec &src_file_spec,
   static constexpr llvm::StringLiteral k_zip_separator("!/");
   size_t pos = source_file.find(k_zip_separator);
   if (pos != std::string::npos)
-    source_file = source_file.resize(pos);
+    source_file.resize(pos);
 
   Status error;
   AdbClientUP adb(GetAdbClient(error));

--- a/lldb/source/Plugins/Platform/Android/PlatformAndroid.cpp
+++ b/lldb/source/Plugins/Platform/Android/PlatformAndroid.cpp
@@ -287,7 +287,7 @@ Status PlatformAndroid::DownloadModuleSlice(const FileSpec &src_file_spec,
   static constexpr llvm::StringLiteral k_zip_separator("!/");
   size_t pos = source_file.find(k_zip_separator);
   if (pos != std::string::npos)
-    source_file = source_file.resize(0, pos);
+    source_file = source_file.resize(pos);
 
   Status error;
   AdbClientUP adb(GetAdbClient(error));

--- a/lldb/source/Plugins/Platform/Android/PlatformAndroid.cpp
+++ b/lldb/source/Plugins/Platform/Android/PlatformAndroid.cpp
@@ -287,7 +287,7 @@ Status PlatformAndroid::DownloadModuleSlice(const FileSpec &src_file_spec,
   static constexpr llvm::StringLiteral k_zip_separator("!/");
   size_t pos = source_file.find(k_zip_separator);
   if (pos != std::string::npos)
-    source_file = source_file.substr(0, pos);
+    source_file = source_file.resize(0, pos);
 
   Status error;
   AdbClientUP adb(GetAdbClient(error));


### PR DESCRIPTION
Correct the method used to truncate the source_file string when substring is a prefix. The previous method used substr, which was changed to resize for clarity and efficiency.

Caught by cppcheck - 
lldb/source/Plugins/Platform/Android/PlatformAndroid.cpp:290:19: performance: Ineffective call of function 'substr' because a prefix of the string is assigned to itself. Use resize() or pop_back() instead. [uselessCallsSubstr]

Source code - 
source_file = source_file.substr(0, pos);

Fix #91211