### PR TITLE
[clang][OpenMP] Fix teams nesting of region check

### DIFF
--- a/clang/lib/Sema/SemaOpenMP.cpp
+++ b/clang/lib/Sema/SemaOpenMP.cpp
@@ -13434,10 +13434,14 @@ StmtResult SemaOpenMP::ActOnOpenMPTargetDirective(ArrayRef<OMPClause *> Clauses,
       auto I = CS->body_begin();
       while (I != CS->body_end()) {
         const auto *OED = dyn_cast<OMPExecutableDirective>(*I);
-        if (!OED || !isOpenMPTeamsDirective(OED->getDirectiveKind()) ||
-            OMPTeamsFound) {
-
+        bool IsTeams = OED && isOpenMPTeamsDirective(OED->getDirectiveKind());
+        if (!IsTeams || I != CS->body_begin()) {
           OMPTeamsFound = false;
+          if (IsTeams && I != CS->body_begin()) {
+            // This is the two teams case. Since the InnerTeamsRegionLoc will
+            // point to this second one reset the iterator to the other teams.
+            --I;
+          }
           break;
         }
         ++I;

--- a/clang/test/OpenMP/Inputs/nesting_of_regions.cpp
+++ b/clang/test/OpenMP/Inputs/nesting_of_regions.cpp
@@ -4882,6 +4882,12 @@ void foo() {
   }
 #pragma omp target // expected-error {{target construct with nested teams region contains statements outside of the teams construct}}
   {
+#pragma omp teams  // expected-note {{nested teams construct here}}
+    ++a;
+    ++a;           // expected-note {{statement outside teams construct here}}
+  }
+#pragma omp target // expected-error {{target construct with nested teams region contains statements outside of the teams construct}}
+  {
     while (0)      // expected-note {{statement outside teams construct here}}
 #pragma omp teams  // expected-note {{nested teams construct here}}
     ++a;
@@ -14132,6 +14138,12 @@ void foo() {
     ++a;          // expected-note {{statement outside teams construct here}}
 #pragma omp teams // expected-note {{nested teams construct here}}
     ++a;
+  }
+#pragma omp target // expected-error {{target construct with nested teams region contains statements outside of the teams construct}}
+  {
+#pragma omp teams // expected-note {{nested teams construct here}}
+    ++a;
+    ++a;          // expected-note {{statement outside teams construct here}}
   }
 #pragma omp target
   {


### PR DESCRIPTION
The static verifier flagged dead code in the check since the loop will only execute once and never reach the iterator increment.

The loop needs to iterate twice to correctly diagnose when a statement is after the teams.

Since there are two iterations again, reset the iterator to the first teams directive when the double teams case is seen so the diagnostic can report both locations.