### PR TITLE
[libc][math][c23] Temporarily disable fmodf16 on AArch64

### DIFF
--- a/libc/config/linux/aarch64/entrypoints.txt
+++ b/libc/config/linux/aarch64/entrypoints.txt
@@ -515,7 +515,6 @@ if(LIBC_TYPES_HAS_FLOAT16)
     libc.src.math.fminimum_magf16
     libc.src.math.fminimum_mag_numf16
     libc.src.math.fminimum_numf16
-    libc.src.math.fmodf16
     libc.src.math.fromfpf16
     libc.src.math.fromfpxf16
     libc.src.math.llrintf16


### PR DESCRIPTION
See Buildbot failure: https://lab.llvm.org/buildbot/#/builders/138/builds/67337.
