### PR TITLE
[libcxx][test][AIX] address more platform differences in locale tests

### DIFF
--- a/libcxx/test/std/localization/locale.categories/category.monetary/locale.money.get/locale.money.get.members/get_long_double_fr_FR.pass.cpp
+++ b/libcxx/test/std/localization/locale.categories/category.monetary/locale.money.get/locale.money.get.members/get_long_double_fr_FR.pass.cpp
@@ -11,8 +11,6 @@
 // NetBSD does not support LC_MONETARY at the moment
 // XFAIL: netbsd
 
-// XFAIL: LIBCXX-AIX-FIXME
-
 // REQUIRES: locale.fr_FR.UTF-8
 
 // <locale>
@@ -31,6 +29,13 @@
 #include "locale_helpers.h"
 #include "platform_support.h" // locale name macros
 #include "test_macros.h"
+
+#ifdef _AIX
+// the AIX libc expects U202F as LC_MONETARY thousands_sep
+#define THOUSANDS_SEP L"\u202F"
+#else
+#define THOUSANDS_SEP L" "
+#endif
 
 typedef std::money_get<char, cpp17_input_iterator<const char*> > Fn;
 
@@ -432,7 +437,7 @@ int main(int, char**)
             assert(ex == -1);
         }
         {   // positive
-            std::wstring v = convert_thousands_sep(L"1 234 567,89 ");
+            std::wstring v = convert_thousands_sep(L"1" THOUSANDS_SEP "234" THOUSANDS_SEP "567,89 ");
             typedef cpp17_input_iterator<const wchar_t*> I;
             long double ex;
             std::ios_base::iostate err = std::ios_base::goodbit;
@@ -443,7 +448,7 @@ int main(int, char**)
             assert(ex == 123456789);
         }
         {   // negative
-            std::wstring v = convert_thousands_sep(L"-1 234 567,89");
+            std::wstring v = convert_thousands_sep(L"-1" THOUSANDS_SEP "234" THOUSANDS_SEP "567,89");
             typedef cpp17_input_iterator<const wchar_t*> I;
             long double ex;
             std::ios_base::iostate err = std::ios_base::goodbit;
@@ -512,7 +517,7 @@ int main(int, char**)
             assert(ex == -1);
         }
         {   // positive, showbase
-            std::wstring v = convert_thousands_sep(L"1 234 567,89 \u20ac");  // EURO SIGN
+            std::wstring v = convert_thousands_sep(L"1" THOUSANDS_SEP "234" THOUSANDS_SEP "567,89 \u20ac");  // EURO SIGN
             typedef cpp17_input_iterator<const wchar_t*> I;
             long double ex;
             std::ios_base::iostate err = std::ios_base::goodbit;
@@ -523,7 +528,7 @@ int main(int, char**)
             assert(ex == 123456789);
         }
         {   // positive, showbase
-            std::wstring v = convert_thousands_sep(L"1 234 567,89 \u20ac");  // EURO SIGN
+            std::wstring v = convert_thousands_sep(L"1" THOUSANDS_SEP "234" THOUSANDS_SEP "567,89 \u20ac");  // EURO SIGN
             std::showbase(ios);
             typedef cpp17_input_iterator<const wchar_t*> I;
             long double ex;
@@ -536,7 +541,7 @@ int main(int, char**)
             std::noshowbase(ios);
         }
         {   // negative, showbase
-            std::wstring v = convert_thousands_sep(L"-1 234 567,89 \u20ac");  // EURO SIGN
+            std::wstring v = convert_thousands_sep(L"-1" THOUSANDS_SEP "234" THOUSANDS_SEP "567,89 \u20ac");  // EURO SIGN
             std::showbase(ios);
             typedef cpp17_input_iterator<const wchar_t*> I;
             long double ex;
@@ -549,7 +554,7 @@ int main(int, char**)
             std::noshowbase(ios);
         }
         {   // negative, showbase
-            std::wstring v = convert_thousands_sep(L"1 234 567,89 EUR -");
+            std::wstring v = convert_thousands_sep(L"1" THOUSANDS_SEP "234" THOUSANDS_SEP "567,89 EUR -");
             std::showbase(ios);
             typedef cpp17_input_iterator<const wchar_t*> I;
             long double ex;
@@ -561,7 +566,7 @@ int main(int, char**)
             std::noshowbase(ios);
         }
         {   // negative, showbase
-            std::wstring v = convert_thousands_sep(L"1 234 567,89 EUR -");
+            std::wstring v = convert_thousands_sep(L"1" THOUSANDS_SEP "234" THOUSANDS_SEP "567,89 EUR -");
             typedef cpp17_input_iterator<const wchar_t*> I;
             long double ex;
             std::ios_base::iostate err = std::ios_base::goodbit;
@@ -598,7 +603,7 @@ int main(int, char**)
             assert(ex == -1);
         }
         {   // positive
-            std::wstring v = convert_thousands_sep(L"1 234 567,89 ");
+            std::wstring v = convert_thousands_sep(L"1" THOUSANDS_SEP "234" THOUSANDS_SEP "567,89 ");
             typedef cpp17_input_iterator<const wchar_t*> I;
             long double ex;
             std::ios_base::iostate err = std::ios_base::goodbit;
@@ -609,7 +614,7 @@ int main(int, char**)
             assert(ex == 123456789);
         }
         {   // negative
-            std::wstring v = convert_thousands_sep(L"-1 234 567,89");
+            std::wstring v = convert_thousands_sep(L"-1" THOUSANDS_SEP "234" THOUSANDS_SEP "567,89");
             typedef cpp17_input_iterator<const wchar_t*> I;
             long double ex;
             std::ios_base::iostate err = std::ios_base::goodbit;
@@ -678,7 +683,7 @@ int main(int, char**)
             assert(ex == -1);
         }
         {   // positive, showbase
-            std::wstring v = convert_thousands_sep(L"1 234 567,89 EUR");
+            std::wstring v = convert_thousands_sep(L"1" THOUSANDS_SEP "234" THOUSANDS_SEP "567,89 EUR");
             typedef cpp17_input_iterator<const wchar_t*> I;
             long double ex;
             std::ios_base::iostate err = std::ios_base::goodbit;
@@ -689,7 +694,7 @@ int main(int, char**)
             assert(ex == 123456789);
         }
         {   // positive, showbase
-            std::wstring v = convert_thousands_sep(L"1 234 567,89 EUR");
+            std::wstring v = convert_thousands_sep(L"1" THOUSANDS_SEP "234" THOUSANDS_SEP "567,89 EUR");
             std::showbase(ios);
             typedef cpp17_input_iterator<const wchar_t*> I;
             long double ex;
@@ -702,7 +707,7 @@ int main(int, char**)
             std::noshowbase(ios);
         }
         {   // negative, showbase
-            std::wstring v = convert_thousands_sep(L"-1 234 567,89 EUR");
+            std::wstring v = convert_thousands_sep(L"-1" THOUSANDS_SEP "234" THOUSANDS_SEP "567,89 EUR");
             std::showbase(ios);
             typedef cpp17_input_iterator<const wchar_t*> I;
             long double ex;
@@ -715,7 +720,7 @@ int main(int, char**)
             std::noshowbase(ios);
         }
         {   // negative, showbase
-            std::wstring v = convert_thousands_sep(L"1 234 567,89 Eu-");
+            std::wstring v = convert_thousands_sep(L"1" THOUSANDS_SEP "234" THOUSANDS_SEP "567,89 Eu-");
             std::showbase(ios);
             typedef cpp17_input_iterator<const wchar_t*> I;
             long double ex;
@@ -727,7 +732,7 @@ int main(int, char**)
             std::noshowbase(ios);
         }
         {   // negative, showbase
-            std::wstring v = convert_thousands_sep(L"1 234 567,89 Eu-");
+            std::wstring v = convert_thousands_sep(L"1" THOUSANDS_SEP "234" THOUSANDS_SEP "567,89 Eu-");
             typedef cpp17_input_iterator<const wchar_t*> I;
             long double ex;
             std::ios_base::iostate err = std::ios_base::goodbit;

--- a/libcxx/test/std/localization/locale.categories/category.monetary/locale.money.get/locale.money.get.members/get_long_double_fr_FR.pass.cpp
+++ b/libcxx/test/std/localization/locale.categories/category.monetary/locale.money.get/locale.money.get.members/get_long_double_fr_FR.pass.cpp
@@ -32,9 +32,9 @@
 
 #ifdef _AIX
 // the AIX libc expects U202F as LC_MONETARY thousands_sep
-#define THOUSANDS_SEP L"\u202F"
+#  define THOUSANDS_SEP L"\u202F"
 #else
-#define THOUSANDS_SEP L" "
+#  define THOUSANDS_SEP L" "
 #endif
 
 typedef std::money_get<char, cpp17_input_iterator<const char*> > Fn;
@@ -437,26 +437,24 @@ int main(int, char**)
             assert(ex == -1);
         }
         {   // positive
-            std::wstring v = convert_thousands_sep(L"1" THOUSANDS_SEP "234" THOUSANDS_SEP "567,89 ");
-            typedef cpp17_input_iterator<const wchar_t*> I;
-            long double ex;
-            std::ios_base::iostate err = std::ios_base::goodbit;
-            I iter = f.get(I(v.data()), I(v.data() + v.size()),
-                                                false, ios, err, ex);
-            assert(base(iter) == v.data() + v.size());
-            assert(err == std::ios_base::eofbit);
-            assert(ex == 123456789);
+          std::wstring v = convert_thousands_sep(L"1" THOUSANDS_SEP "234" THOUSANDS_SEP "567,89 ");
+          typedef cpp17_input_iterator<const wchar_t*> I;
+          long double ex;
+          std::ios_base::iostate err = std::ios_base::goodbit;
+          I iter                     = f.get(I(v.data()), I(v.data() + v.size()), false, ios, err, ex);
+          assert(base(iter) == v.data() + v.size());
+          assert(err == std::ios_base::eofbit);
+          assert(ex == 123456789);
         }
         {   // negative
-            std::wstring v = convert_thousands_sep(L"-1" THOUSANDS_SEP "234" THOUSANDS_SEP "567,89");
-            typedef cpp17_input_iterator<const wchar_t*> I;
-            long double ex;
-            std::ios_base::iostate err = std::ios_base::goodbit;
-            I iter = f.get(I(v.data()), I(v.data() + v.size()),
-                                                false, ios, err, ex);
-            assert(base(iter) == v.data() + v.size());
-            assert(err == std::ios_base::eofbit);
-            assert(ex == -123456789);
+          std::wstring v = convert_thousands_sep(L"-1" THOUSANDS_SEP "234" THOUSANDS_SEP "567,89");
+          typedef cpp17_input_iterator<const wchar_t*> I;
+          long double ex;
+          std::ios_base::iostate err = std::ios_base::goodbit;
+          I iter                     = f.get(I(v.data()), I(v.data() + v.size()), false, ios, err, ex);
+          assert(base(iter) == v.data() + v.size());
+          assert(err == std::ios_base::eofbit);
+          assert(ex == -123456789);
         }
         {   // negative
             std::wstring v = L"-1234567,89";
@@ -517,64 +515,59 @@ int main(int, char**)
             assert(ex == -1);
         }
         {   // positive, showbase
-            std::wstring v = convert_thousands_sep(L"1" THOUSANDS_SEP "234" THOUSANDS_SEP "567,89 \u20ac");  // EURO SIGN
-            typedef cpp17_input_iterator<const wchar_t*> I;
-            long double ex;
-            std::ios_base::iostate err = std::ios_base::goodbit;
-            I iter = f.get(I(v.data()), I(v.data() + v.size()),
-                                                false, ios, err, ex);
-            assert(base(iter) == v.data() + v.size());
-            assert(err == std::ios_base::eofbit);
-            assert(ex == 123456789);
+          std::wstring v = convert_thousands_sep(L"1" THOUSANDS_SEP "234" THOUSANDS_SEP "567,89 \u20ac"); // EURO SIGN
+          typedef cpp17_input_iterator<const wchar_t*> I;
+          long double ex;
+          std::ios_base::iostate err = std::ios_base::goodbit;
+          I iter                     = f.get(I(v.data()), I(v.data() + v.size()), false, ios, err, ex);
+          assert(base(iter) == v.data() + v.size());
+          assert(err == std::ios_base::eofbit);
+          assert(ex == 123456789);
         }
         {   // positive, showbase
-            std::wstring v = convert_thousands_sep(L"1" THOUSANDS_SEP "234" THOUSANDS_SEP "567,89 \u20ac");  // EURO SIGN
-            std::showbase(ios);
-            typedef cpp17_input_iterator<const wchar_t*> I;
-            long double ex;
-            std::ios_base::iostate err = std::ios_base::goodbit;
-            I iter = f.get(I(v.data()), I(v.data() + v.size()),
-                                                false, ios, err, ex);
-            assert(base(iter) == v.data() + v.size());
-            assert(err == std::ios_base::eofbit);
-            assert(ex == 123456789);
-            std::noshowbase(ios);
+          std::wstring v = convert_thousands_sep(L"1" THOUSANDS_SEP "234" THOUSANDS_SEP "567,89 \u20ac"); // EURO SIGN
+          std::showbase(ios);
+          typedef cpp17_input_iterator<const wchar_t*> I;
+          long double ex;
+          std::ios_base::iostate err = std::ios_base::goodbit;
+          I iter                     = f.get(I(v.data()), I(v.data() + v.size()), false, ios, err, ex);
+          assert(base(iter) == v.data() + v.size());
+          assert(err == std::ios_base::eofbit);
+          assert(ex == 123456789);
+          std::noshowbase(ios);
         }
         {   // negative, showbase
-            std::wstring v = convert_thousands_sep(L"-1" THOUSANDS_SEP "234" THOUSANDS_SEP "567,89 \u20ac");  // EURO SIGN
-            std::showbase(ios);
-            typedef cpp17_input_iterator<const wchar_t*> I;
-            long double ex;
-            std::ios_base::iostate err = std::ios_base::goodbit;
-            I iter = f.get(I(v.data()), I(v.data() + v.size()),
-                                                false, ios, err, ex);
-            assert(base(iter) == v.data() + v.size());
-            assert(err == std::ios_base::eofbit);
-            assert(ex == -123456789);
-            std::noshowbase(ios);
+          std::wstring v = convert_thousands_sep(L"-1" THOUSANDS_SEP "234" THOUSANDS_SEP "567,89 \u20ac"); // EURO SIGN
+          std::showbase(ios);
+          typedef cpp17_input_iterator<const wchar_t*> I;
+          long double ex;
+          std::ios_base::iostate err = std::ios_base::goodbit;
+          I iter                     = f.get(I(v.data()), I(v.data() + v.size()), false, ios, err, ex);
+          assert(base(iter) == v.data() + v.size());
+          assert(err == std::ios_base::eofbit);
+          assert(ex == -123456789);
+          std::noshowbase(ios);
         }
         {   // negative, showbase
-            std::wstring v = convert_thousands_sep(L"1" THOUSANDS_SEP "234" THOUSANDS_SEP "567,89 EUR -");
-            std::showbase(ios);
-            typedef cpp17_input_iterator<const wchar_t*> I;
-            long double ex;
-            std::ios_base::iostate err = std::ios_base::goodbit;
-            I iter = f.get(I(v.data()), I(v.data() + v.size()),
-                                                false, ios, err, ex);
-            assert(base(iter) == v.data() + 13);
-            assert(err == std::ios_base::failbit);
-            std::noshowbase(ios);
+          std::wstring v = convert_thousands_sep(L"1" THOUSANDS_SEP "234" THOUSANDS_SEP "567,89 EUR -");
+          std::showbase(ios);
+          typedef cpp17_input_iterator<const wchar_t*> I;
+          long double ex;
+          std::ios_base::iostate err = std::ios_base::goodbit;
+          I iter                     = f.get(I(v.data()), I(v.data() + v.size()), false, ios, err, ex);
+          assert(base(iter) == v.data() + 13);
+          assert(err == std::ios_base::failbit);
+          std::noshowbase(ios);
         }
         {   // negative, showbase
-            std::wstring v = convert_thousands_sep(L"1" THOUSANDS_SEP "234" THOUSANDS_SEP "567,89 EUR -");
-            typedef cpp17_input_iterator<const wchar_t*> I;
-            long double ex;
-            std::ios_base::iostate err = std::ios_base::goodbit;
-            I iter = f.get(I(v.data()), I(v.data() + v.size()),
-                                                false, ios, err, ex);
-            assert(base(iter) == v.data() + 13);
-            assert(err == std::ios_base::goodbit);
-            assert(ex == 123456789);
+          std::wstring v = convert_thousands_sep(L"1" THOUSANDS_SEP "234" THOUSANDS_SEP "567,89 EUR -");
+          typedef cpp17_input_iterator<const wchar_t*> I;
+          long double ex;
+          std::ios_base::iostate err = std::ios_base::goodbit;
+          I iter                     = f.get(I(v.data()), I(v.data() + v.size()), false, ios, err, ex);
+          assert(base(iter) == v.data() + 13);
+          assert(err == std::ios_base::goodbit);
+          assert(ex == 123456789);
         }
     }
     {
@@ -603,26 +596,24 @@ int main(int, char**)
             assert(ex == -1);
         }
         {   // positive
-            std::wstring v = convert_thousands_sep(L"1" THOUSANDS_SEP "234" THOUSANDS_SEP "567,89 ");
-            typedef cpp17_input_iterator<const wchar_t*> I;
-            long double ex;
-            std::ios_base::iostate err = std::ios_base::goodbit;
-            I iter = f.get(I(v.data()), I(v.data() + v.size()),
-                                                true, ios, err, ex);
-            assert(base(iter) == v.data() + v.size());
-            assert(err == std::ios_base::eofbit);
-            assert(ex == 123456789);
+          std::wstring v = convert_thousands_sep(L"1" THOUSANDS_SEP "234" THOUSANDS_SEP "567,89 ");
+          typedef cpp17_input_iterator<const wchar_t*> I;
+          long double ex;
+          std::ios_base::iostate err = std::ios_base::goodbit;
+          I iter                     = f.get(I(v.data()), I(v.data() + v.size()), true, ios, err, ex);
+          assert(base(iter) == v.data() + v.size());
+          assert(err == std::ios_base::eofbit);
+          assert(ex == 123456789);
         }
         {   // negative
-            std::wstring v = convert_thousands_sep(L"-1" THOUSANDS_SEP "234" THOUSANDS_SEP "567,89");
-            typedef cpp17_input_iterator<const wchar_t*> I;
-            long double ex;
-            std::ios_base::iostate err = std::ios_base::goodbit;
-            I iter = f.get(I(v.data()), I(v.data() + v.size()),
-                                                true, ios, err, ex);
-            assert(base(iter) == v.data() + v.size());
-            assert(err == std::ios_base::eofbit);
-            assert(ex == -123456789);
+          std::wstring v = convert_thousands_sep(L"-1" THOUSANDS_SEP "234" THOUSANDS_SEP "567,89");
+          typedef cpp17_input_iterator<const wchar_t*> I;
+          long double ex;
+          std::ios_base::iostate err = std::ios_base::goodbit;
+          I iter                     = f.get(I(v.data()), I(v.data() + v.size()), true, ios, err, ex);
+          assert(base(iter) == v.data() + v.size());
+          assert(err == std::ios_base::eofbit);
+          assert(ex == -123456789);
         }
         {   // negative
             std::wstring v = L"-1234567,89";
@@ -683,64 +674,59 @@ int main(int, char**)
             assert(ex == -1);
         }
         {   // positive, showbase
-            std::wstring v = convert_thousands_sep(L"1" THOUSANDS_SEP "234" THOUSANDS_SEP "567,89 EUR");
-            typedef cpp17_input_iterator<const wchar_t*> I;
-            long double ex;
-            std::ios_base::iostate err = std::ios_base::goodbit;
-            I iter = f.get(I(v.data()), I(v.data() + v.size()),
-                                                true, ios, err, ex);
-            assert(base(iter) == v.data() + v.size());
-            assert(err == std::ios_base::eofbit);
-            assert(ex == 123456789);
+          std::wstring v = convert_thousands_sep(L"1" THOUSANDS_SEP "234" THOUSANDS_SEP "567,89 EUR");
+          typedef cpp17_input_iterator<const wchar_t*> I;
+          long double ex;
+          std::ios_base::iostate err = std::ios_base::goodbit;
+          I iter                     = f.get(I(v.data()), I(v.data() + v.size()), true, ios, err, ex);
+          assert(base(iter) == v.data() + v.size());
+          assert(err == std::ios_base::eofbit);
+          assert(ex == 123456789);
         }
         {   // positive, showbase
-            std::wstring v = convert_thousands_sep(L"1" THOUSANDS_SEP "234" THOUSANDS_SEP "567,89 EUR");
-            std::showbase(ios);
-            typedef cpp17_input_iterator<const wchar_t*> I;
-            long double ex;
-            std::ios_base::iostate err = std::ios_base::goodbit;
-            I iter = f.get(I(v.data()), I(v.data() + v.size()),
-                                                true, ios, err, ex);
-            assert(base(iter) == v.data() + v.size());
-            assert(err == std::ios_base::eofbit);
-            assert(ex == 123456789);
-            std::noshowbase(ios);
+          std::wstring v = convert_thousands_sep(L"1" THOUSANDS_SEP "234" THOUSANDS_SEP "567,89 EUR");
+          std::showbase(ios);
+          typedef cpp17_input_iterator<const wchar_t*> I;
+          long double ex;
+          std::ios_base::iostate err = std::ios_base::goodbit;
+          I iter                     = f.get(I(v.data()), I(v.data() + v.size()), true, ios, err, ex);
+          assert(base(iter) == v.data() + v.size());
+          assert(err == std::ios_base::eofbit);
+          assert(ex == 123456789);
+          std::noshowbase(ios);
         }
         {   // negative, showbase
-            std::wstring v = convert_thousands_sep(L"-1" THOUSANDS_SEP "234" THOUSANDS_SEP "567,89 EUR");
-            std::showbase(ios);
-            typedef cpp17_input_iterator<const wchar_t*> I;
-            long double ex;
-            std::ios_base::iostate err = std::ios_base::goodbit;
-            I iter = f.get(I(v.data()), I(v.data() + v.size()),
-                                                true, ios, err, ex);
-            assert(base(iter) == v.data() + v.size());
-            assert(err == std::ios_base::eofbit);
-            assert(ex == -123456789);
-            std::noshowbase(ios);
+          std::wstring v = convert_thousands_sep(L"-1" THOUSANDS_SEP "234" THOUSANDS_SEP "567,89 EUR");
+          std::showbase(ios);
+          typedef cpp17_input_iterator<const wchar_t*> I;
+          long double ex;
+          std::ios_base::iostate err = std::ios_base::goodbit;
+          I iter                     = f.get(I(v.data()), I(v.data() + v.size()), true, ios, err, ex);
+          assert(base(iter) == v.data() + v.size());
+          assert(err == std::ios_base::eofbit);
+          assert(ex == -123456789);
+          std::noshowbase(ios);
         }
         {   // negative, showbase
-            std::wstring v = convert_thousands_sep(L"1" THOUSANDS_SEP "234" THOUSANDS_SEP "567,89 Eu-");
-            std::showbase(ios);
-            typedef cpp17_input_iterator<const wchar_t*> I;
-            long double ex;
-            std::ios_base::iostate err = std::ios_base::goodbit;
-            I iter = f.get(I(v.data()), I(v.data() + v.size()),
-                                                true, ios, err, ex);
-            assert(base(iter) == v.data() + 14);
-            assert(err == std::ios_base::failbit);
-            std::noshowbase(ios);
+          std::wstring v = convert_thousands_sep(L"1" THOUSANDS_SEP "234" THOUSANDS_SEP "567,89 Eu-");
+          std::showbase(ios);
+          typedef cpp17_input_iterator<const wchar_t*> I;
+          long double ex;
+          std::ios_base::iostate err = std::ios_base::goodbit;
+          I iter                     = f.get(I(v.data()), I(v.data() + v.size()), true, ios, err, ex);
+          assert(base(iter) == v.data() + 14);
+          assert(err == std::ios_base::failbit);
+          std::noshowbase(ios);
         }
         {   // negative, showbase
-            std::wstring v = convert_thousands_sep(L"1" THOUSANDS_SEP "234" THOUSANDS_SEP "567,89 Eu-");
-            typedef cpp17_input_iterator<const wchar_t*> I;
-            long double ex;
-            std::ios_base::iostate err = std::ios_base::goodbit;
-            I iter = f.get(I(v.data()), I(v.data() + v.size()),
-                                                true, ios, err, ex);
-            assert(base(iter) == v.data() + 13);
-            assert(err == std::ios_base::goodbit);
-            assert(ex == 123456789);
+          std::wstring v = convert_thousands_sep(L"1" THOUSANDS_SEP "234" THOUSANDS_SEP "567,89 Eu-");
+          typedef cpp17_input_iterator<const wchar_t*> I;
+          long double ex;
+          std::ios_base::iostate err = std::ios_base::goodbit;
+          I iter                     = f.get(I(v.data()), I(v.data() + v.size()), true, ios, err, ex);
+          assert(base(iter) == v.data() + 13);
+          assert(err == std::ios_base::goodbit);
+          assert(ex == 123456789);
         }
     }
 #endif // TEST_HAS_NO_WIDE_CHARACTERS

--- a/libcxx/test/std/localization/locale.categories/category.monetary/locale.money.get/locale.money.get.members/get_long_double_zh_CN.pass.cpp
+++ b/libcxx/test/std/localization/locale.categories/category.monetary/locale.money.get/locale.money.get.members/get_long_double_zh_CN.pass.cpp
@@ -9,7 +9,6 @@
 // NetBSD does not support LC_MONETARY at the moment
 // XFAIL: netbsd
 
-// XFAIL: LIBCXX-AIX-FIXME
 // XFAIL: LIBCXX-FREEBSD-FIXME
 
 // REQUIRES: locale.zh_CN.UTF-8
@@ -156,7 +155,11 @@ int main(int, char**)
             std::noshowbase(ios);
         }
         {   // negative one, showbase
+#ifdef _AIX
+            std::string v = "-" + currency_symbol + "0.01";
+#else
             std::string v = currency_symbol + "-0.01";
+#endif
             typedef cpp17_input_iterator<const char*> I;
             long double ex;
             std::ios_base::iostate err = std::ios_base::goodbit;
@@ -167,7 +170,11 @@ int main(int, char**)
             assert(ex == -1);
         }
         {   // negative one, showbase
+#ifdef _AIX
+            std::string v = "-" + currency_symbol + "0.01";
+#else
             std::string v = currency_symbol + "-0.01";
+#endif
             std::showbase(ios);
             typedef cpp17_input_iterator<const char*> I;
             long double ex;
@@ -204,7 +211,11 @@ int main(int, char**)
             std::noshowbase(ios);
         }
         {   // negative, showbase
+#ifdef _AIX
+            std::string v = "-" + currency_symbol + "1,234,567.89";
+#else
             std::string v = currency_symbol + "-1,234,567.89";
+#endif
             std::showbase(ios);
             typedef cpp17_input_iterator<const char*> I;
             long double ex;
@@ -322,7 +333,7 @@ int main(int, char**)
             std::noshowbase(ios);
         }
         {   // negative one, showbase
-#ifdef TEST_HAS_GLIBC
+#if defined(TEST_HAS_GLIBC) || defined(_AIX)
             std::string v = "-" + currency_name + "0.01";
 #else
             std::string v = currency_name + "-0.01";
@@ -337,7 +348,7 @@ int main(int, char**)
             assert(ex == -1);
         }
         {   // negative one, showbase
-#ifdef TEST_HAS_GLIBC
+#if defined(TEST_HAS_GLIBC) || defined(_AIX)
             std::string v = "-" + currency_name + "0.01";
 #else
             std::string v = currency_name + "-0.01";
@@ -378,7 +389,7 @@ int main(int, char**)
             std::noshowbase(ios);
         }
         {   // negative, showbase
-#ifdef TEST_HAS_GLIBC
+#if defined(TEST_HAS_GLIBC) || defined(_AIX)
             std::string v = "-" + currency_name + "1,234,567.89";
 #else
             std::string v = currency_name + "-1,234,567.89";
@@ -507,7 +518,11 @@ int main(int, char**)
             std::noshowbase(ios);
         }
         {   // negative one, showbase
+#  ifdef _AIX
+            std::wstring v = L"-" + w_currency_symbol + L"0.01";
+#  else
             std::wstring v = w_currency_symbol + L"-0.01";
+#  endif
             typedef cpp17_input_iterator<const wchar_t*> I;
             long double ex;
             std::ios_base::iostate err = std::ios_base::goodbit;
@@ -518,7 +533,11 @@ int main(int, char**)
             assert(ex == -1);
         }
         {   // negative one, showbase
+#  ifdef _AIX
+            std::wstring v = L"-" + w_currency_symbol + L"0.01";
+#  else
             std::wstring v = w_currency_symbol + L"-0.01";
+#  endif
             std::showbase(ios);
             typedef cpp17_input_iterator<const wchar_t*> I;
             long double ex;
@@ -555,7 +574,11 @@ int main(int, char**)
             std::noshowbase(ios);
         }
         {   // negative, showbase
+#  ifdef _AIX
+            std::wstring v = L"-" + w_currency_symbol + L"1,234,567.89";
+#  else
             std::wstring v = w_currency_symbol + L"-1,234,567.89";
+#  endif
             std::showbase(ios);
             typedef cpp17_input_iterator<const wchar_t*> I;
             long double ex;
@@ -673,7 +696,7 @@ int main(int, char**)
             std::noshowbase(ios);
         }
         {   // negative one, showbase
-#ifdef TEST_HAS_GLIBC
+#if defined(TEST_HAS_GLIBC) || defined(_AIX)
             std::wstring v = L"-" + w_currency_name + L"0.01";
 #else
             std::wstring v = w_currency_name + L"-0.01";
@@ -688,7 +711,7 @@ int main(int, char**)
             assert(ex == -1);
         }
         {   // negative one, showbase
-#ifdef TEST_HAS_GLIBC
+#if defined(TEST_HAS_GLIBC) || defined(_AIX)
             std::wstring v = L"-" + w_currency_name + L"0.01";
 #else
             std::wstring v = w_currency_name + L"-0.01";
@@ -729,7 +752,7 @@ int main(int, char**)
             std::noshowbase(ios);
         }
         {   // negative, showbase
-#ifdef TEST_HAS_GLIBC
+#if defined(TEST_HAS_GLIBC) || defined(_AIX)
             std::wstring v = L"-" + w_currency_name + L"1,234,567.89";
 #else
             std::wstring v = w_currency_name + L"-1,234,567.89";

--- a/libcxx/test/std/localization/locale.categories/category.monetary/locale.money.get/locale.money.get.members/get_long_double_zh_CN.pass.cpp
+++ b/libcxx/test/std/localization/locale.categories/category.monetary/locale.money.get/locale.money.get.members/get_long_double_zh_CN.pass.cpp
@@ -156,35 +156,33 @@ int main(int, char**)
         }
         {   // negative one, showbase
 #ifdef _AIX
-            std::string v = "-" + currency_symbol + "0.01";
+          std::string v = "-" + currency_symbol + "0.01";
 #else
-            std::string v = currency_symbol + "-0.01";
+          std::string v = currency_symbol + "-0.01";
 #endif
-            typedef cpp17_input_iterator<const char*> I;
-            long double ex;
-            std::ios_base::iostate err = std::ios_base::goodbit;
-            I iter = f.get(I(v.data()), I(v.data() + v.size()),
-                                                false, ios, err, ex);
-            assert(base(iter) == v.data() + v.size());
-            assert(err == std::ios_base::eofbit);
-            assert(ex == -1);
+          typedef cpp17_input_iterator<const char*> I;
+          long double ex;
+          std::ios_base::iostate err = std::ios_base::goodbit;
+          I iter                     = f.get(I(v.data()), I(v.data() + v.size()), false, ios, err, ex);
+          assert(base(iter) == v.data() + v.size());
+          assert(err == std::ios_base::eofbit);
+          assert(ex == -1);
         }
         {   // negative one, showbase
 #ifdef _AIX
-            std::string v = "-" + currency_symbol + "0.01";
+          std::string v = "-" + currency_symbol + "0.01";
 #else
-            std::string v = currency_symbol + "-0.01";
+          std::string v = currency_symbol + "-0.01";
 #endif
-            std::showbase(ios);
-            typedef cpp17_input_iterator<const char*> I;
-            long double ex;
-            std::ios_base::iostate err = std::ios_base::goodbit;
-            I iter = f.get(I(v.data()), I(v.data() + v.size()),
-                                                false, ios, err, ex);
-            assert(base(iter) == v.data() + v.size());
-            assert(err == std::ios_base::eofbit);
-            assert(ex == -1);
-            std::noshowbase(ios);
+          std::showbase(ios);
+          typedef cpp17_input_iterator<const char*> I;
+          long double ex;
+          std::ios_base::iostate err = std::ios_base::goodbit;
+          I iter                     = f.get(I(v.data()), I(v.data() + v.size()), false, ios, err, ex);
+          assert(base(iter) == v.data() + v.size());
+          assert(err == std::ios_base::eofbit);
+          assert(ex == -1);
+          std::noshowbase(ios);
         }
         {   // positive, showbase
             std::string v = currency_symbol + "1,234,567.89";
@@ -212,20 +210,19 @@ int main(int, char**)
         }
         {   // negative, showbase
 #ifdef _AIX
-            std::string v = "-" + currency_symbol + "1,234,567.89";
+          std::string v = "-" + currency_symbol + "1,234,567.89";
 #else
-            std::string v = currency_symbol + "-1,234,567.89";
+          std::string v = currency_symbol + "-1,234,567.89";
 #endif
-            std::showbase(ios);
-            typedef cpp17_input_iterator<const char*> I;
-            long double ex;
-            std::ios_base::iostate err = std::ios_base::goodbit;
-            I iter = f.get(I(v.data()), I(v.data() + v.size()),
-                                                false, ios, err, ex);
-            assert(base(iter) == v.data() + v.size());
-            assert(err == std::ios_base::eofbit);
-            assert(ex == -123456789);
-            std::noshowbase(ios);
+          std::showbase(ios);
+          typedef cpp17_input_iterator<const char*> I;
+          long double ex;
+          std::ios_base::iostate err = std::ios_base::goodbit;
+          I iter                     = f.get(I(v.data()), I(v.data() + v.size()), false, ios, err, ex);
+          assert(base(iter) == v.data() + v.size());
+          assert(err == std::ios_base::eofbit);
+          assert(ex == -123456789);
+          std::noshowbase(ios);
         }
         {   // negative, showbase
             std::string v = "CNY -1,234,567.89";
@@ -334,7 +331,7 @@ int main(int, char**)
         }
         {   // negative one, showbase
 #if defined(TEST_HAS_GLIBC) || defined(_AIX)
-            std::string v = "-" + currency_name + "0.01";
+          std::string v = "-" + currency_name + "0.01";
 #else
             std::string v = currency_name + "-0.01";
 #endif
@@ -349,7 +346,7 @@ int main(int, char**)
         }
         {   // negative one, showbase
 #if defined(TEST_HAS_GLIBC) || defined(_AIX)
-            std::string v = "-" + currency_name + "0.01";
+          std::string v = "-" + currency_name + "0.01";
 #else
             std::string v = currency_name + "-0.01";
 #endif
@@ -390,7 +387,7 @@ int main(int, char**)
         }
         {   // negative, showbase
 #if defined(TEST_HAS_GLIBC) || defined(_AIX)
-            std::string v = "-" + currency_name + "1,234,567.89";
+          std::string v = "-" + currency_name + "1,234,567.89";
 #else
             std::string v = currency_name + "-1,234,567.89";
 #endif
@@ -519,35 +516,33 @@ int main(int, char**)
         }
         {   // negative one, showbase
 #  ifdef _AIX
-            std::wstring v = L"-" + w_currency_symbol + L"0.01";
+          std::wstring v = L"-" + w_currency_symbol + L"0.01";
 #  else
-            std::wstring v = w_currency_symbol + L"-0.01";
+          std::wstring v = w_currency_symbol + L"-0.01";
 #  endif
-            typedef cpp17_input_iterator<const wchar_t*> I;
-            long double ex;
-            std::ios_base::iostate err = std::ios_base::goodbit;
-            I iter = f.get(I(v.data()), I(v.data() + v.size()),
-                                                false, ios, err, ex);
-            assert(base(iter) == v.data() + v.size());
-            assert(err == std::ios_base::eofbit);
-            assert(ex == -1);
+          typedef cpp17_input_iterator<const wchar_t*> I;
+          long double ex;
+          std::ios_base::iostate err = std::ios_base::goodbit;
+          I iter                     = f.get(I(v.data()), I(v.data() + v.size()), false, ios, err, ex);
+          assert(base(iter) == v.data() + v.size());
+          assert(err == std::ios_base::eofbit);
+          assert(ex == -1);
         }
         {   // negative one, showbase
 #  ifdef _AIX
-            std::wstring v = L"-" + w_currency_symbol + L"0.01";
+          std::wstring v = L"-" + w_currency_symbol + L"0.01";
 #  else
-            std::wstring v = w_currency_symbol + L"-0.01";
+          std::wstring v = w_currency_symbol + L"-0.01";
 #  endif
-            std::showbase(ios);
-            typedef cpp17_input_iterator<const wchar_t*> I;
-            long double ex;
-            std::ios_base::iostate err = std::ios_base::goodbit;
-            I iter = f.get(I(v.data()), I(v.data() + v.size()),
-                                                false, ios, err, ex);
-            assert(base(iter) == v.data() + v.size());
-            assert(err == std::ios_base::eofbit);
-            assert(ex == -1);
-            std::noshowbase(ios);
+          std::showbase(ios);
+          typedef cpp17_input_iterator<const wchar_t*> I;
+          long double ex;
+          std::ios_base::iostate err = std::ios_base::goodbit;
+          I iter                     = f.get(I(v.data()), I(v.data() + v.size()), false, ios, err, ex);
+          assert(base(iter) == v.data() + v.size());
+          assert(err == std::ios_base::eofbit);
+          assert(ex == -1);
+          std::noshowbase(ios);
         }
         {   // positive, showbase
             std::wstring v = w_currency_symbol + L"1,234,567.89";
@@ -575,20 +570,19 @@ int main(int, char**)
         }
         {   // negative, showbase
 #  ifdef _AIX
-            std::wstring v = L"-" + w_currency_symbol + L"1,234,567.89";
+          std::wstring v = L"-" + w_currency_symbol + L"1,234,567.89";
 #  else
-            std::wstring v = w_currency_symbol + L"-1,234,567.89";
+          std::wstring v = w_currency_symbol + L"-1,234,567.89";
 #  endif
-            std::showbase(ios);
-            typedef cpp17_input_iterator<const wchar_t*> I;
-            long double ex;
-            std::ios_base::iostate err = std::ios_base::goodbit;
-            I iter = f.get(I(v.data()), I(v.data() + v.size()),
-                                                false, ios, err, ex);
-            assert(base(iter) == v.data() + v.size());
-            assert(err == std::ios_base::eofbit);
-            assert(ex == -123456789);
-            std::noshowbase(ios);
+          std::showbase(ios);
+          typedef cpp17_input_iterator<const wchar_t*> I;
+          long double ex;
+          std::ios_base::iostate err = std::ios_base::goodbit;
+          I iter                     = f.get(I(v.data()), I(v.data() + v.size()), false, ios, err, ex);
+          assert(base(iter) == v.data() + v.size());
+          assert(err == std::ios_base::eofbit);
+          assert(ex == -123456789);
+          std::noshowbase(ios);
         }
         {   // negative, showbase
             std::wstring v = L"CNY -1,234,567.89";
@@ -696,36 +690,34 @@ int main(int, char**)
             std::noshowbase(ios);
         }
         {   // negative one, showbase
-#if defined(TEST_HAS_GLIBC) || defined(_AIX)
-            std::wstring v = L"-" + w_currency_name + L"0.01";
-#else
-            std::wstring v = w_currency_name + L"-0.01";
-#endif
-            typedef cpp17_input_iterator<const wchar_t*> I;
-            long double ex;
-            std::ios_base::iostate err = std::ios_base::goodbit;
-            I iter = f.get(I(v.data()), I(v.data() + v.size()),
-                                                true, ios, err, ex);
-            assert(base(iter) == v.data() + v.size());
-            assert(err == std::ios_base::eofbit);
-            assert(ex == -1);
+#  if defined(TEST_HAS_GLIBC) || defined(_AIX)
+          std::wstring v = L"-" + w_currency_name + L"0.01";
+#  else
+          std::wstring v = w_currency_name + L"-0.01";
+#  endif
+          typedef cpp17_input_iterator<const wchar_t*> I;
+          long double ex;
+          std::ios_base::iostate err = std::ios_base::goodbit;
+          I iter                     = f.get(I(v.data()), I(v.data() + v.size()), true, ios, err, ex);
+          assert(base(iter) == v.data() + v.size());
+          assert(err == std::ios_base::eofbit);
+          assert(ex == -1);
         }
         {   // negative one, showbase
-#if defined(TEST_HAS_GLIBC) || defined(_AIX)
-            std::wstring v = L"-" + w_currency_name + L"0.01";
-#else
-            std::wstring v = w_currency_name + L"-0.01";
-#endif
-            std::showbase(ios);
-            typedef cpp17_input_iterator<const wchar_t*> I;
-            long double ex;
-            std::ios_base::iostate err = std::ios_base::goodbit;
-            I iter = f.get(I(v.data()), I(v.data() + v.size()),
-                                                true, ios, err, ex);
-            assert(base(iter) == v.data() + v.size());
-            assert(err == std::ios_base::eofbit);
-            assert(ex == -1);
-            std::noshowbase(ios);
+#  if defined(TEST_HAS_GLIBC) || defined(_AIX)
+          std::wstring v = L"-" + w_currency_name + L"0.01";
+#  else
+          std::wstring v = w_currency_name + L"-0.01";
+#  endif
+          std::showbase(ios);
+          typedef cpp17_input_iterator<const wchar_t*> I;
+          long double ex;
+          std::ios_base::iostate err = std::ios_base::goodbit;
+          I iter                     = f.get(I(v.data()), I(v.data() + v.size()), true, ios, err, ex);
+          assert(base(iter) == v.data() + v.size());
+          assert(err == std::ios_base::eofbit);
+          assert(ex == -1);
+          std::noshowbase(ios);
         }
         {   // positive, showbase
             std::wstring v = w_currency_name + L"1,234,567.89";
@@ -752,21 +744,20 @@ int main(int, char**)
             std::noshowbase(ios);
         }
         {   // negative, showbase
-#if defined(TEST_HAS_GLIBC) || defined(_AIX)
-            std::wstring v = L"-" + w_currency_name + L"1,234,567.89";
-#else
-            std::wstring v = w_currency_name + L"-1,234,567.89";
-#endif
-            std::showbase(ios);
-            typedef cpp17_input_iterator<const wchar_t*> I;
-            long double ex;
-            std::ios_base::iostate err = std::ios_base::goodbit;
-            I iter = f.get(I(v.data()), I(v.data() + v.size()),
-                                                true, ios, err, ex);
-            assert(base(iter) == v.data() + v.size());
-            assert(err == std::ios_base::eofbit);
-            assert(ex == -123456789);
-            std::noshowbase(ios);
+#  if defined(TEST_HAS_GLIBC) || defined(_AIX)
+          std::wstring v = L"-" + w_currency_name + L"1,234,567.89";
+#  else
+          std::wstring v = w_currency_name + L"-1,234,567.89";
+#  endif
+          std::showbase(ios);
+          typedef cpp17_input_iterator<const wchar_t*> I;
+          long double ex;
+          std::ios_base::iostate err = std::ios_base::goodbit;
+          I iter                     = f.get(I(v.data()), I(v.data() + v.size()), true, ios, err, ex);
+          assert(base(iter) == v.data() + v.size());
+          assert(err == std::ios_base::eofbit);
+          assert(ex == -123456789);
+          std::noshowbase(ios);
         }
         {   // negative, showbase
             std::wstring v = w_currency_symbol + L"-1,234,567.89";

--- a/libcxx/test/std/localization/locale.categories/category.monetary/locale.money.put/locale.money.put.members/put_long_double_fr_FR.pass.cpp
+++ b/libcxx/test/std/localization/locale.categories/category.monetary/locale.money.put/locale.money.put.members/put_long_double_fr_FR.pass.cpp
@@ -11,8 +11,6 @@
 // NetBSD does not support LC_MONETARY at the moment
 // XFAIL: netbsd
 
-// XFAIL: LIBCXX-AIX-FIXME
-
 // REQUIRES: locale.fr_FR.UTF-8
 
 // <locale>
@@ -31,6 +29,13 @@
 #include "locale_helpers.h"
 #include "platform_support.h" // locale name macros
 #include "test_macros.h"
+
+#ifdef _AIX
+// the AIX libc expects U202F as LC_MONETARY thousands_sep
+#define THOUSANDS_SEP L"\u202F"
+#else
+#define THOUSANDS_SEP L" "
+#endif
 
 typedef std::money_put<char, cpp17_output_iterator<char*> > Fn;
 
@@ -291,14 +296,14 @@ int main(int, char**)
         wchar_t str[100];
         cpp17_output_iterator<wchar_t*> iter = f.put(cpp17_output_iterator<wchar_t*>(str), false, ios, '*', v);
         std::wstring ex(str, base(iter));
-        assert(ex == convert_thousands_sep(L"1 234 567,89"));
+        assert(ex == convert_thousands_sep(L"1" THOUSANDS_SEP "234" THOUSANDS_SEP "567,89"));
     }
     {   // negative
         long double v = -123456789;
         wchar_t str[100];
         cpp17_output_iterator<wchar_t*> iter = f.put(cpp17_output_iterator<wchar_t*>(str), false, ios, '*', v);
         std::wstring ex(str, base(iter));
-        assert(ex == convert_thousands_sep(L"-1 234 567,89"));
+        assert(ex == convert_thousands_sep(L"-1" THOUSANDS_SEP "234" THOUSANDS_SEP "567,89"));
     }
     {   // zero, showbase
         long double v = 0;
@@ -322,7 +327,7 @@ int main(int, char**)
         wchar_t str[100];
         cpp17_output_iterator<wchar_t*> iter = f.put(cpp17_output_iterator<wchar_t*>(str), false, ios, '*', v);
         std::wstring ex(str, base(iter));
-        assert(ex == convert_thousands_sep(L"1 234 567,89 \u20ac"));
+        assert(ex == convert_thousands_sep(L"1" THOUSANDS_SEP "234" THOUSANDS_SEP "567,89 \u20ac"));
     }
     {   // negative, showbase
         long double v = -123456789;
@@ -330,7 +335,7 @@ int main(int, char**)
         wchar_t str[100];
         cpp17_output_iterator<wchar_t*> iter = f.put(cpp17_output_iterator<wchar_t*>(str), false, ios, '*', v);
         std::wstring ex(str, base(iter));
-        assert(ex == convert_thousands_sep(L"-1 234 567,89 \u20ac"));
+        assert(ex == convert_thousands_sep(L"-1" THOUSANDS_SEP "234" THOUSANDS_SEP "567,89 \u20ac"));
     }
     {   // negative, showbase, left
         long double v = -123456789;
@@ -340,7 +345,7 @@ int main(int, char**)
         wchar_t str[100];
         cpp17_output_iterator<wchar_t*> iter = f.put(cpp17_output_iterator<wchar_t*>(str), false, ios, ' ', v);
         std::wstring ex(str, base(iter));
-        assert(ex == convert_thousands_sep(L"-1 234 567,89 \u20ac     "));
+        assert(ex == convert_thousands_sep(L"-1" THOUSANDS_SEP "234" THOUSANDS_SEP "567,89 \u20ac     "));
         assert(ios.width() == 0);
     }
     {   // negative, showbase, internal
@@ -351,7 +356,7 @@ int main(int, char**)
         wchar_t str[100];
         cpp17_output_iterator<wchar_t*> iter = f.put(cpp17_output_iterator<wchar_t*>(str), false, ios, ' ', v);
         std::wstring ex(str, base(iter));
-        assert(ex == convert_thousands_sep(L"-1 234 567,89      \u20ac"));
+        assert(ex == convert_thousands_sep(L"-1" THOUSANDS_SEP "234" THOUSANDS_SEP "567,89      \u20ac"));
         assert(ios.width() == 0);
     }
     {   // negative, showbase, right
@@ -362,7 +367,7 @@ int main(int, char**)
         wchar_t str[100];
         cpp17_output_iterator<wchar_t*> iter = f.put(cpp17_output_iterator<wchar_t*>(str), false, ios, ' ', v);
         std::wstring ex(str, base(iter));
-        assert(ex == convert_thousands_sep(L"     -1 234 567,89 \u20ac"));
+        assert(ex == convert_thousands_sep(L"     -1" THOUSANDS_SEP "234" THOUSANDS_SEP "567,89 \u20ac"));
         assert(ios.width() == 0);
     }
 
@@ -388,14 +393,14 @@ int main(int, char**)
         wchar_t str[100];
         cpp17_output_iterator<wchar_t*> iter = f.put(cpp17_output_iterator<wchar_t*>(str), true, ios, '*', v);
         std::wstring ex(str, base(iter));
-        assert(ex == convert_thousands_sep(L"1 234 567,89"));
+        assert(ex == convert_thousands_sep(L"1" THOUSANDS_SEP "234" THOUSANDS_SEP "567,89"));
     }
     {   // negative
         long double v = -123456789;
         wchar_t str[100];
         cpp17_output_iterator<wchar_t*> iter = f.put(cpp17_output_iterator<wchar_t*>(str), true, ios, '*', v);
         std::wstring ex(str, base(iter));
-        assert(ex == convert_thousands_sep(L"-1 234 567,89"));
+        assert(ex == convert_thousands_sep(L"-1" THOUSANDS_SEP "234" THOUSANDS_SEP "567,89"));
     }
     {   // zero, showbase
         long double v = 0;
@@ -419,7 +424,7 @@ int main(int, char**)
         wchar_t str[100];
         cpp17_output_iterator<wchar_t*> iter = f.put(cpp17_output_iterator<wchar_t*>(str), true, ios, '*', v);
         std::wstring ex(str, base(iter));
-        assert(ex == convert_thousands_sep(L"1 234 567,89 EUR"));
+        assert(ex == convert_thousands_sep(L"1" THOUSANDS_SEP "234" THOUSANDS_SEP "567,89 EUR"));
     }
     {   // negative, showbase
         long double v = -123456789;
@@ -427,7 +432,7 @@ int main(int, char**)
         wchar_t str[100];
         cpp17_output_iterator<wchar_t*> iter = f.put(cpp17_output_iterator<wchar_t*>(str), true, ios, '*', v);
         std::wstring ex(str, base(iter));
-        assert(ex == convert_thousands_sep(L"-1 234 567,89 EUR"));
+        assert(ex == convert_thousands_sep(L"-1" THOUSANDS_SEP "234" THOUSANDS_SEP "567,89 EUR"));
     }
     {   // negative, showbase, left
         long double v = -123456789;
@@ -437,7 +442,7 @@ int main(int, char**)
         wchar_t str[100];
         cpp17_output_iterator<wchar_t*> iter = f.put(cpp17_output_iterator<wchar_t*>(str), true, ios, ' ', v);
         std::wstring ex(str, base(iter));
-        assert(ex == convert_thousands_sep(L"-1 234 567,89 EUR   "));
+        assert(ex == convert_thousands_sep(L"-1" THOUSANDS_SEP "234" THOUSANDS_SEP "567,89 EUR   "));
         assert(ios.width() == 0);
     }
     {   // negative, showbase, internal
@@ -448,7 +453,7 @@ int main(int, char**)
         wchar_t str[100];
         cpp17_output_iterator<wchar_t*> iter = f.put(cpp17_output_iterator<wchar_t*>(str), true, ios, ' ', v);
         std::wstring ex(str, base(iter));
-        assert(ex == convert_thousands_sep(L"-1 234 567,89    EUR"));
+        assert(ex == convert_thousands_sep(L"-1" THOUSANDS_SEP "234" THOUSANDS_SEP "567,89    EUR"));
         assert(ios.width() == 0);
     }
     {   // negative, showbase, right
@@ -459,7 +464,7 @@ int main(int, char**)
         wchar_t str[100];
         cpp17_output_iterator<wchar_t*> iter = f.put(cpp17_output_iterator<wchar_t*>(str), true, ios, ' ', v);
         std::wstring ex(str, base(iter));
-        assert(ex == convert_thousands_sep(L"   -1 234 567,89 EUR"));
+        assert(ex == convert_thousands_sep(L"   -1" THOUSANDS_SEP "234" THOUSANDS_SEP "567,89 EUR"));
         assert(ios.width() == 0);
     }
 }

--- a/libcxx/test/std/localization/locale.categories/category.monetary/locale.money.put/locale.money.put.members/put_long_double_fr_FR.pass.cpp
+++ b/libcxx/test/std/localization/locale.categories/category.monetary/locale.money.put/locale.money.put.members/put_long_double_fr_FR.pass.cpp
@@ -32,9 +32,9 @@
 
 #ifdef _AIX
 // the AIX libc expects U202F as LC_MONETARY thousands_sep
-#define THOUSANDS_SEP L"\u202F"
+#  define THOUSANDS_SEP L"\u202F"
 #else
-#define THOUSANDS_SEP L" "
+#  define THOUSANDS_SEP L" "
 #endif
 
 typedef std::money_put<char, cpp17_output_iterator<char*> > Fn;

--- a/libcxx/test/std/localization/locale.categories/category.monetary/locale.money.put/locale.money.put.members/put_long_double_zh_CN.pass.cpp
+++ b/libcxx/test/std/localization/locale.categories/category.monetary/locale.money.put/locale.money.put.members/put_long_double_zh_CN.pass.cpp
@@ -9,7 +9,6 @@
 // NetBSD does not support LC_MONETARY at the moment
 // XFAIL: netbsd
 
-// XFAIL: LIBCXX-AIX-FIXME
 // XFAIL: LIBCXX-FREEBSD-FIXME
 
 // REQUIRES: locale.zh_CN.UTF-8
@@ -120,7 +119,11 @@ int main(int, char**)
         char str[100];
         cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), false, ios, '*', v);
         std::string ex(str, base(iter));
+#ifdef _AIX
+        assert(ex == "-" + currency_symbol + "0.01");
+#else
         assert(ex == currency_symbol + "-0.01");
+#endif
     }
     {   // positive, showbase
         long double v = 123456789;
@@ -136,7 +139,11 @@ int main(int, char**)
         char str[100];
         cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), false, ios, '*', v);
         std::string ex(str, base(iter));
+#ifdef _AIX
+        assert(ex == "-" + currency_symbol + "1,234,567.89");
+#else
         assert(ex == currency_symbol + "-1,234,567.89");
+#endif
     }
     {   // negative, showbase, left
         long double v = -123456789;
@@ -146,7 +153,11 @@ int main(int, char**)
         char str[100];
         cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), false, ios, ' ', v);
         std::string ex(str, base(iter));
+#ifdef _AIX
+        assert(ex == "-" + currency_symbol + "1,234,567.89" + currency_symbol_padding);
+#else
         assert(ex == currency_symbol + "-1,234,567.89" + currency_symbol_padding);
+#endif
         assert(ios.width() == 0);
     }
     {   // negative, showbase, internal
@@ -157,7 +168,11 @@ int main(int, char**)
         char str[100];
         cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), false, ios, ' ', v);
         std::string ex(str, base(iter));
+#ifdef _AIX
+        assert(ex == "-" + currency_symbol + currency_symbol_padding + "1,234,567.89");
+#else
         assert(ex == currency_symbol + "-" + currency_symbol_padding + "1,234,567.89");
+#endif
         assert(ios.width() == 0);
     }
     {   // negative, showbase, right
@@ -168,7 +183,11 @@ int main(int, char**)
         char str[100];
         cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), false, ios, ' ', v);
         std::string ex(str, base(iter));
+#ifdef _AIX
+        assert(ex == currency_symbol_padding + "-" + currency_symbol + "1,234,567.89");
+#else
         assert(ex == currency_symbol_padding + currency_symbol + "-1,234,567.89");
+#endif
         assert(ios.width() == 0);
     }
 
@@ -217,7 +236,7 @@ int main(int, char**)
         char str[100];
         cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), true, ios, '*', v);
         std::string ex(str, base(iter));
-#ifdef TEST_HAS_GLIBC
+#if defined(TEST_HAS_GLIBC) || defined(_AIX)
         assert(ex == "-" + currency_name + "0.01");
 #else
         assert(ex == currency_name + "-0.01");
@@ -237,7 +256,7 @@ int main(int, char**)
         char str[100];
         cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), true, ios, '*', v);
         std::string ex(str, base(iter));
-#ifdef TEST_HAS_GLIBC
+#if defined(TEST_HAS_GLIBC) || defined(_AIX)
         assert(ex == "-" + currency_name + "1,234,567.89");
 #else
         assert(ex == currency_name + "-1,234,567.89");
@@ -251,7 +270,7 @@ int main(int, char**)
         char str[100];
         cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), true, ios, ' ', v);
         std::string ex(str, base(iter));
-#ifdef TEST_HAS_GLIBC
+#if defined(TEST_HAS_GLIBC) || defined(_AIX)
         assert(ex == "-" + currency_name + "1,234,567.89" + currency_name_padding);
 #else
         assert(ex == currency_name + "-1,234,567.89" + currency_name_padding);
@@ -266,7 +285,7 @@ int main(int, char**)
         char str[100];
         cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), true, ios, ' ', v);
         std::string ex(str, base(iter));
-#ifdef TEST_HAS_GLIBC
+#if defined(TEST_HAS_GLIBC) || defined(_AIX)
         assert(ex == "-" + currency_name + currency_name_padding + "1,234,567.89");
 #else
         assert(ex == currency_name + "-" + currency_name_padding + "1,234,567.89");
@@ -281,7 +300,7 @@ int main(int, char**)
         char str[100];
         cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), true, ios, ' ', v);
         std::string ex(str, base(iter));
-#ifdef TEST_HAS_GLIBC
+#if defined(TEST_HAS_GLIBC) || defined(_AIX)
         assert(ex == currency_name_padding + "-" + currency_name + "1,234,567.89");
 #else
         assert(ex == currency_name_padding + currency_name + "-1,234,567.89");
@@ -344,7 +363,11 @@ int main(int, char**)
         wchar_t str[100];
         cpp17_output_iterator<wchar_t*> iter = f.put(cpp17_output_iterator<wchar_t*>(str), false, ios, '*', v);
         std::wstring ex(str, base(iter));
+#ifdef _AIX
+        assert(ex == L"-" + currency_symbol + L"0.01");
+#else
         assert(ex == currency_symbol + L"-0.01");
+#endif
     }
     {   // positive, showbase
         long double v = 123456789;
@@ -360,7 +383,11 @@ int main(int, char**)
         wchar_t str[100];
         cpp17_output_iterator<wchar_t*> iter = f.put(cpp17_output_iterator<wchar_t*>(str), false, ios, '*', v);
         std::wstring ex(str, base(iter));
+#ifdef _AIX
+        assert(ex == L"-" + currency_symbol + L"1,234,567.89");
+#else
         assert(ex == currency_symbol + L"-1,234,567.89");
+#endif
     }
     {   // negative, showbase, left
         long double v = -123456789;
@@ -370,7 +397,11 @@ int main(int, char**)
         wchar_t str[100];
         cpp17_output_iterator<wchar_t*> iter = f.put(cpp17_output_iterator<wchar_t*>(str), false, ios, ' ', v);
         std::wstring ex(str, base(iter));
+#ifdef _AIX
+        assert(ex == L"-" + currency_symbol + L"1,234,567.89      ");
+#else
         assert(ex == currency_symbol + L"-1,234,567.89      ");
+#endif
         assert(ios.width() == 0);
     }
     {   // negative, showbase, internal
@@ -381,7 +412,11 @@ int main(int, char**)
         wchar_t str[100];
         cpp17_output_iterator<wchar_t*> iter = f.put(cpp17_output_iterator<wchar_t*>(str), false, ios, ' ', v);
         std::wstring ex(str, base(iter));
+#ifdef _AIX
+        assert(ex == L"-" + currency_symbol + L"      1,234,567.89");
+#else
         assert(ex == currency_symbol + L"-      1,234,567.89");
+#endif
         assert(ios.width() == 0);
     }
     {   // negative, showbase, right
@@ -392,7 +427,11 @@ int main(int, char**)
         wchar_t str[100];
         cpp17_output_iterator<wchar_t*> iter = f.put(cpp17_output_iterator<wchar_t*>(str), false, ios, ' ', v);
         std::wstring ex(str, base(iter));
+#ifdef _AIX
+        assert(ex == L"      -" + currency_symbol + L"1,234,567.89");
+#else
         assert(ex == L"      " + currency_symbol + L"-1,234,567.89");
+#endif
         assert(ios.width() == 0);
     }
 
@@ -441,7 +480,7 @@ int main(int, char**)
         wchar_t str[100];
         cpp17_output_iterator<wchar_t*> iter = f.put(cpp17_output_iterator<wchar_t*>(str), true, ios, '*', v);
         std::wstring ex(str, base(iter));
-#ifdef TEST_HAS_GLIBC
+#if defined(TEST_HAS_GLIBC) || defined(_AIX)
         assert(ex == L"-" + currency_name + L"0.01");
 #else
         assert(ex == currency_name + L"-0.01");
@@ -461,7 +500,7 @@ int main(int, char**)
         wchar_t str[100];
         cpp17_output_iterator<wchar_t*> iter = f.put(cpp17_output_iterator<wchar_t*>(str), true, ios, '*', v);
         std::wstring ex(str, base(iter));
-#ifdef TEST_HAS_GLIBC
+#if defined(TEST_HAS_GLIBC) || defined(_AIX)
         assert(ex == L"-" + currency_name + L"1,234,567.89");
 #else
         assert(ex == currency_name + L"-1,234,567.89");
@@ -475,7 +514,7 @@ int main(int, char**)
         wchar_t str[100];
         cpp17_output_iterator<wchar_t*> iter = f.put(cpp17_output_iterator<wchar_t*>(str), true, ios, ' ', v);
         std::wstring ex(str, base(iter));
-#ifdef TEST_HAS_GLIBC
+#if defined(TEST_HAS_GLIBC) || defined(_AIX)
         assert(ex == L"-" + currency_name + L"1,234,567.89" + currency_name_padding);
 #else
         assert(ex == currency_name + L"-1,234,567.89" + currency_name_padding);
@@ -490,7 +529,7 @@ int main(int, char**)
         wchar_t str[100];
         cpp17_output_iterator<wchar_t*> iter = f.put(cpp17_output_iterator<wchar_t*>(str), true, ios, ' ', v);
         std::wstring ex(str, base(iter));
-#ifdef TEST_HAS_GLIBC
+#if defined(TEST_HAS_GLIBC) || defined(_AIX)
         assert(ex == L"-" + currency_name + currency_name_padding + L"1,234,567.89");
 #else
         assert(ex == currency_name + L"-" + currency_name_padding + L"1,234,567.89");
@@ -505,7 +544,7 @@ int main(int, char**)
         wchar_t str[100];
         cpp17_output_iterator<wchar_t*> iter = f.put(cpp17_output_iterator<wchar_t*>(str), true, ios, ' ', v);
         std::wstring ex(str, base(iter));
-#ifdef TEST_HAS_GLIBC
+#if defined(TEST_HAS_GLIBC) || defined(_AIX)
         assert(ex == currency_name_padding + L"-" + currency_name + L"1,234,567.89");
 #else
         assert(ex == currency_name_padding + currency_name + L"-1,234,567.89");

--- a/libcxx/test/std/localization/locale.categories/category.monetary/locale.money.put/locale.money.put.members/put_long_double_zh_CN.pass.cpp
+++ b/libcxx/test/std/localization/locale.categories/category.monetary/locale.money.put/locale.money.put.members/put_long_double_zh_CN.pass.cpp
@@ -363,11 +363,11 @@ int main(int, char**)
         wchar_t str[100];
         cpp17_output_iterator<wchar_t*> iter = f.put(cpp17_output_iterator<wchar_t*>(str), false, ios, '*', v);
         std::wstring ex(str, base(iter));
-#ifdef _AIX
+#  ifdef _AIX
         assert(ex == L"-" + currency_symbol + L"0.01");
-#else
+#  else
         assert(ex == currency_symbol + L"-0.01");
-#endif
+#  endif
     }
     {   // positive, showbase
         long double v = 123456789;
@@ -383,11 +383,11 @@ int main(int, char**)
         wchar_t str[100];
         cpp17_output_iterator<wchar_t*> iter = f.put(cpp17_output_iterator<wchar_t*>(str), false, ios, '*', v);
         std::wstring ex(str, base(iter));
-#ifdef _AIX
+#  ifdef _AIX
         assert(ex == L"-" + currency_symbol + L"1,234,567.89");
-#else
+#  else
         assert(ex == currency_symbol + L"-1,234,567.89");
-#endif
+#  endif
     }
     {   // negative, showbase, left
         long double v = -123456789;
@@ -397,11 +397,11 @@ int main(int, char**)
         wchar_t str[100];
         cpp17_output_iterator<wchar_t*> iter = f.put(cpp17_output_iterator<wchar_t*>(str), false, ios, ' ', v);
         std::wstring ex(str, base(iter));
-#ifdef _AIX
+#  ifdef _AIX
         assert(ex == L"-" + currency_symbol + L"1,234,567.89      ");
-#else
+#  else
         assert(ex == currency_symbol + L"-1,234,567.89      ");
-#endif
+#  endif
         assert(ios.width() == 0);
     }
     {   // negative, showbase, internal
@@ -412,11 +412,11 @@ int main(int, char**)
         wchar_t str[100];
         cpp17_output_iterator<wchar_t*> iter = f.put(cpp17_output_iterator<wchar_t*>(str), false, ios, ' ', v);
         std::wstring ex(str, base(iter));
-#ifdef _AIX
+#  ifdef _AIX
         assert(ex == L"-" + currency_symbol + L"      1,234,567.89");
-#else
+#  else
         assert(ex == currency_symbol + L"-      1,234,567.89");
-#endif
+#  endif
         assert(ios.width() == 0);
     }
     {   // negative, showbase, right
@@ -427,11 +427,11 @@ int main(int, char**)
         wchar_t str[100];
         cpp17_output_iterator<wchar_t*> iter = f.put(cpp17_output_iterator<wchar_t*>(str), false, ios, ' ', v);
         std::wstring ex(str, base(iter));
-#ifdef _AIX
+#  ifdef _AIX
         assert(ex == L"      -" + currency_symbol + L"1,234,567.89");
-#else
+#  else
         assert(ex == L"      " + currency_symbol + L"-1,234,567.89");
-#endif
+#  endif
         assert(ios.width() == 0);
     }
 
@@ -480,7 +480,7 @@ int main(int, char**)
         wchar_t str[100];
         cpp17_output_iterator<wchar_t*> iter = f.put(cpp17_output_iterator<wchar_t*>(str), true, ios, '*', v);
         std::wstring ex(str, base(iter));
-#if defined(TEST_HAS_GLIBC) || defined(_AIX)
+#  if defined(TEST_HAS_GLIBC) || defined(_AIX)
         assert(ex == L"-" + currency_name + L"0.01");
 #else
         assert(ex == currency_name + L"-0.01");
@@ -500,7 +500,7 @@ int main(int, char**)
         wchar_t str[100];
         cpp17_output_iterator<wchar_t*> iter = f.put(cpp17_output_iterator<wchar_t*>(str), true, ios, '*', v);
         std::wstring ex(str, base(iter));
-#if defined(TEST_HAS_GLIBC) || defined(_AIX)
+#  if defined(TEST_HAS_GLIBC) || defined(_AIX)
         assert(ex == L"-" + currency_name + L"1,234,567.89");
 #else
         assert(ex == currency_name + L"-1,234,567.89");
@@ -514,7 +514,7 @@ int main(int, char**)
         wchar_t str[100];
         cpp17_output_iterator<wchar_t*> iter = f.put(cpp17_output_iterator<wchar_t*>(str), true, ios, ' ', v);
         std::wstring ex(str, base(iter));
-#if defined(TEST_HAS_GLIBC) || defined(_AIX)
+#  if defined(TEST_HAS_GLIBC) || defined(_AIX)
         assert(ex == L"-" + currency_name + L"1,234,567.89" + currency_name_padding);
 #else
         assert(ex == currency_name + L"-1,234,567.89" + currency_name_padding);
@@ -529,7 +529,7 @@ int main(int, char**)
         wchar_t str[100];
         cpp17_output_iterator<wchar_t*> iter = f.put(cpp17_output_iterator<wchar_t*>(str), true, ios, ' ', v);
         std::wstring ex(str, base(iter));
-#if defined(TEST_HAS_GLIBC) || defined(_AIX)
+#  if defined(TEST_HAS_GLIBC) || defined(_AIX)
         assert(ex == L"-" + currency_name + currency_name_padding + L"1,234,567.89");
 #else
         assert(ex == currency_name + L"-" + currency_name_padding + L"1,234,567.89");
@@ -544,7 +544,7 @@ int main(int, char**)
         wchar_t str[100];
         cpp17_output_iterator<wchar_t*> iter = f.put(cpp17_output_iterator<wchar_t*>(str), true, ios, ' ', v);
         std::wstring ex(str, base(iter));
-#if defined(TEST_HAS_GLIBC) || defined(_AIX)
+#  if defined(TEST_HAS_GLIBC) || defined(_AIX)
         assert(ex == currency_name_padding + L"-" + currency_name + L"1,234,567.89");
 #else
         assert(ex == currency_name_padding + currency_name + L"-1,234,567.89");


### PR DESCRIPTION
This is a follow on to https://github.com/llvm/llvm-project/pull/92312, where we address some more locale  platform differences. These are:

- for locale fr_FR AIX libc expects `U202F` as `LC_MONETARY` `thousands_sep`
- for locale zh_CN AIX libc `LC_MONETARY` has `n_sign_posn == 1`, indicating the `negative_sign` should come before the `currency_symbol` string