### PR TITLE
[LangRef] Add description of toc-data global variables

### DIFF
--- a/llvm/docs/LangRef.rst
+++ b/llvm/docs/LangRef.rst
@@ -812,6 +812,9 @@ doesn't). These kinds of structs (we may call them homogeneous scalable vector
 structs) are considered sized and can be used in loads, stores, allocas, but
 not GEPs.
 
+Globals with ``toc-data`` attribute set are stored in TOC of XCOFF. Their
+alignments are the same as that of a TOC entry.
+
 Syntax::
 
       @<GlobalVarName> = [Linkage] [PreemptionSpecifier] [Visibility]

--- a/llvm/docs/LangRef.rst
+++ b/llvm/docs/LangRef.rst
@@ -813,7 +813,8 @@ structs) are considered sized and can be used in loads, stores, allocas, but
 not GEPs.
 
 Globals with ``toc-data`` attribute set are stored in TOC of XCOFF. Their
-alignments are the same as that of a TOC entry.
+alignments are not larger than that of a TOC entry. Optimizations should not
+increase their alignments to prevent TOC overflow.
 
 Syntax::
 


### PR DESCRIPTION
Add description of `toc-data` global variable in LLVM Language Reference.

Addressed comment in https://github.com/llvm/llvm-project/pull/94593#pullrequestreview-2102796085.