### PR TITLE
[lldb] Remove redundant c_str() calls in stream output (NFC)

### DIFF
--- a/lldb/tools/debugserver/source/JSON.cpp
+++ b/lldb/tools/debugserver/source/JSON.cpp
@@ -43,7 +43,7 @@ JSONString::JSONString(const std::string &s)
     : JSONValue(JSONValue::Kind::String), m_data(s) {}
 
 void JSONString::Write(std::ostream &s) {
-  s << "\"" << json_string_quote_metachars(m_data).c_str() << "\"";
+  s << "\"" << json_string_quote_metachars(m_data) << "\"";
 }
 
 uint64_t JSONNumber::GetAsUnsigned() const {
@@ -395,7 +395,7 @@ JSONParser::Token JSONParser::GetToken(std::string &value) {
           } else {
             error << "error: got exponent character but no exponent digits at "
                      "offset in float value \""
-                  << value.c_str() << "\"";
+                  << value << "\"";
             value = error.str();
             return Token::Status;
           }
@@ -405,8 +405,7 @@ JSONParser::Token JSONParser::GetToken(std::string &value) {
           if (got_frac_digits) {
             return Token::Float;
           } else {
-            error << "error: no digits after decimal point \"" << value.c_str()
-                  << "\"";
+            error << "error: no digits after decimal point \"" << value << "\"";
             value = error.str();
             return Token::Status;
           }
@@ -417,7 +416,7 @@ JSONParser::Token JSONParser::GetToken(std::string &value) {
           // We need at least some integer digits to make an integer
           return Token::Integer;
         } else {
-          error << "error: no digits negate sign \"" << value.c_str() << "\"";
+          error << "error: no digits negate sign \"" << value << "\"";
           value = error.str();
           return Token::Status;
         }


### PR DESCRIPTION
Passing the result of c_str() to a stream is slow and redundant. This change removes unnecessary c_str() calls and uses the string object directly.

Caught by cppcheck -
lldb/tools/debugserver/source/JSON.cpp:398:19: performance: Passing the result of c_str() to a stream is slow and redundant. [stlcstrStream] 
lldb/tools/debugserver/source/JSON.cpp:408:64: performance: Passing the result of c_str() to a stream is slow and redundant. [stlcstrStream] 
lldb/tools/debugserver/source/JSON.cpp:420:54: performance: Passing the result of c_str() to a stream is slow and redundant. [stlcstrStream] 
lldb/tools/debugserver/source/JSON.cpp:46:13: performance: Passing the result of c_str() to a stream is slow and redundant. [stlcstrStream]

Fix #91212