### PR TITLE
[lldb] Remove redundant condition in watch mask check (NFC)

### DIFF
--- a/lldb/source/Plugins/Process/Linux/NativeRegisterContextLinux_arm.cpp
+++ b/lldb/source/Plugins/Process/Linux/NativeRegisterContextLinux_arm.cpp
@@ -506,7 +506,7 @@ uint32_t NativeRegisterContextLinux_arm::SetHardwareWatchpoint(
       return LLDB_INVALID_INDEX32;
     else if (watch_mask <= 0x02)
       size = 2;
-    else if (watch_mask <= 0x04)
+    else
       size = 4;
 
     addr = addr & (~0x03);


### PR DESCRIPTION
This issue is reported by cppcheck as a pointless test in the watch mask check. The `else if` condition is opposite to the previous `if` condition, making the expression always true.

Caught by cppcheck -
lldb/source/Plugins/Process/Linux/NativeRegisterContextLinux_arm.cpp:509:25: style: Expression is always true because 'else if' condition is opposite to previous condition at line 505. [multiCondition]

Fix #91223