### PR TITLE
[lldb] Adjust the for loop condition to prevent unintended increments in ExpandRLE (NFC)

### DIFF
--- a/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunication.cpp
+++ b/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunication.cpp
@@ -1298,7 +1298,7 @@ std::string GDBRemoteCommunication::ExpandRLE(std::string packet) {
   std::string decoded;
   decoded.reserve(packet.size());
   for (std::string::const_iterator c = packet.begin(); c != packet.end();) {
-    if (*c == '*') {
+    if (*c == '*' && std::next(c) != packet.end()) {
       // '*' indicates RLE. Next character will give us the repeat count and
       // previous character is what is to be repeated.
       char char_to_repeat = decoded.back();

--- a/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunication.cpp
+++ b/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunication.cpp
@@ -1297,7 +1297,7 @@ std::string GDBRemoteCommunication::ExpandRLE(std::string packet) {
   // Reserve enough byte for the most common case (no RLE used).
   std::string decoded;
   decoded.reserve(packet.size());
-  for (std::string::const_iterator c = packet.begin(); c != packet.end(); ++c) {
+  for (std::string::const_iterator c = packet.begin(); c != packet.end();) {
     if (*c == '*') {
       // '*' indicates RLE. Next character will give us the repeat count and
       // previous character is what is to be repeated.
@@ -1316,6 +1316,7 @@ std::string GDBRemoteCommunication::ExpandRLE(std::string packet) {
     } else {
       decoded.push_back(*c);
     }
+    c++;
   }
   return decoded;
 }


### PR DESCRIPTION
This PR address the issue reported by static analyser cppcheck regarding missing bounds check for extra iterator increment in a loop. This could lead to accessing out-of-bounds memory. 
To fix this we check next of `c` there is alteast one element left.

Caught by cppcheck -
lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunication.cpp:1300:75: warning: Missing bounds check for extra iterator increment in loop. [StlMissingComparison]

Fix #91225