### PR TITLE
[Clang] Swap range metadata to attribute for intrinsics.

### DIFF
--- a/clang/lib/CodeGen/CGBuiltin.cpp
+++ b/clang/lib/CodeGen/CGBuiltin.cpp
@@ -734,17 +734,15 @@ static llvm::Value *EmitOverflowIntrinsic(CodeGenFunction &CGF,
   return CGF.Builder.CreateExtractValue(Tmp, 0);
 }
 
-static Value *emitRangedBuiltin(CodeGenFunction &CGF,
-                                unsigned IntrinsicID,
+static Value *emitRangedBuiltin(CodeGenFunction &CGF, unsigned IntrinsicID,
                                 int low, int high) {
-    llvm::MDBuilder MDHelper(CGF.getLLVMContext());
-    llvm::MDNode *RNode = MDHelper.createRange(APInt(32, low), APInt(32, high));
-    Function *F = CGF.CGM.getIntrinsic(IntrinsicID, {});
-    llvm::Instruction *Call = CGF.Builder.CreateCall(F);
-    Call->setMetadata(llvm::LLVMContext::MD_range, RNode);
-    Call->setMetadata(llvm::LLVMContext::MD_noundef,
-                      llvm::MDNode::get(CGF.getLLVMContext(), std::nullopt));
-    return Call;
+  Function *F = CGF.CGM.getIntrinsic(IntrinsicID, {});
+  llvm::CallInst *Call = CGF.Builder.CreateCall(F);
+  llvm::ConstantRange CR(APInt(32, low), APInt(32, high));
+  Call->addRangeRetAttr(CR);
+  Call->setMetadata(llvm::LLVMContext::MD_noundef,
+                    llvm::MDNode::get(CGF.getLLVMContext(), std::nullopt));
+  return Call;
 }
 
 namespace {

--- a/clang/lib/CodeGen/CGBuiltin.cpp
+++ b/clang/lib/CodeGen/CGBuiltin.cpp
@@ -740,8 +740,7 @@ static Value *emitRangedBuiltin(CodeGenFunction &CGF, unsigned IntrinsicID,
   llvm::CallInst *Call = CGF.Builder.CreateCall(F);
   llvm::ConstantRange CR(APInt(32, low), APInt(32, high));
   Call->addRangeRetAttr(CR);
-  Call->setMetadata(llvm::LLVMContext::MD_noundef,
-                    llvm::MDNode::get(CGF.getLLVMContext(), std::nullopt));
+  Call->addRetAttr(llvm::Attribute::AttrKind::NoUndef);
   return Call;
 }
 

--- a/clang/test/CodeGenOpenCL/builtins-amdgcn.cl
+++ b/clang/test/CodeGenOpenCL/builtins-amdgcn.cl
@@ -605,9 +605,9 @@ void test_s_getreg(volatile global uint *out)
 }
 
 // CHECK-LABEL: @test_get_local_id(
-// CHECK: tail call{{.*}} i32 @llvm.amdgcn.workitem.id.x(), !range [[$WI_RANGE:![0-9]*]], !noundef
-// CHECK: tail call{{.*}} i32 @llvm.amdgcn.workitem.id.y(), !range [[$WI_RANGE]], !noundef
-// CHECK: tail call{{.*}} i32 @llvm.amdgcn.workitem.id.z(), !range [[$WI_RANGE]], !noundef
+// CHECK: tail call range(i32 0, 1024){{.*}} i32 @llvm.amdgcn.workitem.id.x(), !noundef
+// CHECK: tail call range(i32 0, 1024){{.*}} i32 @llvm.amdgcn.workitem.id.y(), !noundef
+// CHECK: tail call range(i32 0, 1024{{.*}}) i32 @llvm.amdgcn.workitem.id.z(), !noundef
 void test_get_local_id(int d, global int *out)
 {
 	switch (d) {
@@ -891,6 +891,5 @@ void test_set_fpenv(unsigned long env) {
   __builtin_amdgcn_set_fpenv(env);
 }
 
-// CHECK-DAG: [[$WI_RANGE]] = !{i32 0, i32 1024}
 // CHECK-DAG: [[$WS_RANGE]] = !{i16 1, i16 1025}
 // CHECK-DAG: attributes #[[$NOUNWIND_READONLY]] = { convergent mustprogress nocallback nofree nounwind willreturn memory(none) }

--- a/clang/test/CodeGenOpenCL/builtins-amdgcn.cl
+++ b/clang/test/CodeGenOpenCL/builtins-amdgcn.cl
@@ -605,9 +605,9 @@ void test_s_getreg(volatile global uint *out)
 }
 
 // CHECK-LABEL: @test_get_local_id(
-// CHECK: tail call range(i32 0, 1024){{.*}} i32 @llvm.amdgcn.workitem.id.x(), !noundef
-// CHECK: tail call range(i32 0, 1024){{.*}} i32 @llvm.amdgcn.workitem.id.y(), !noundef
-// CHECK: tail call range(i32 0, 1024{{.*}}) i32 @llvm.amdgcn.workitem.id.z(), !noundef
+// CHECK: tail call noundef range(i32 0, 1024){{.*}} i32 @llvm.amdgcn.workitem.id.x()
+// CHECK: tail call noundef range(i32 0, 1024){{.*}} i32 @llvm.amdgcn.workitem.id.y()
+// CHECK: tail call noundef range(i32 0, 1024){{.*}} i32 @llvm.amdgcn.workitem.id.z()
 void test_get_local_id(int d, global int *out)
 {
 	switch (d) {

--- a/clang/test/CodeGenOpenCL/builtins-r600.cl
+++ b/clang/test/CodeGenOpenCL/builtins-r600.cl
@@ -39,9 +39,9 @@ void test_get_group_id(int d, global int *out)
 }
 
 // CHECK-LABEL: @test_get_local_id(
-// CHECK: tail call i32 @llvm.r600.read.tidig.x(), !range [[WI_RANGE:![0-9]*]]
-// CHECK: tail call i32 @llvm.r600.read.tidig.y(), !range [[WI_RANGE]]
-// CHECK: tail call i32 @llvm.r600.read.tidig.z(), !range [[WI_RANGE]]
+// CHECK: tail call range(i32 0, 1024) i32 @llvm.r600.read.tidig.x()
+// CHECK: tail call range(i32 0, 1024) i32 @llvm.r600.read.tidig.y()
+// CHECK: tail call range(i32 0, 1024) i32 @llvm.r600.read.tidig.z()
 void test_get_local_id(int d, global int *out)
 {
 	switch (d) {
@@ -52,4 +52,3 @@ void test_get_local_id(int d, global int *out)
 	}
 }
 
-// CHECK-DAG: [[WI_RANGE]] = !{i32 0, i32 1024}

--- a/clang/test/CodeGenOpenCL/builtins-r600.cl
+++ b/clang/test/CodeGenOpenCL/builtins-r600.cl
@@ -39,9 +39,9 @@ void test_get_group_id(int d, global int *out)
 }
 
 // CHECK-LABEL: @test_get_local_id(
-// CHECK: tail call range(i32 0, 1024) i32 @llvm.r600.read.tidig.x()
-// CHECK: tail call range(i32 0, 1024) i32 @llvm.r600.read.tidig.y()
-// CHECK: tail call range(i32 0, 1024) i32 @llvm.r600.read.tidig.z()
+// CHECK: tail call noundef range(i32 0, 1024) i32 @llvm.r600.read.tidig.x()
+// CHECK: tail call noundef range(i32 0, 1024) i32 @llvm.r600.read.tidig.y()
+// CHECK: tail call noundef range(i32 0, 1024) i32 @llvm.r600.read.tidig.z()
 void test_get_local_id(int d, global int *out)
 {
 	switch (d) {


### PR DESCRIPTION
Continues to swap out range metadata to range attribute for calls to be able to deprecate range metadata on calls in the future