### PR TITLE
[InstCombine] Propagate flags when folding consecutative shifts

### DIFF
--- a/llvm/test/Transforms/InstCombine/shift.ll
+++ b/llvm/test/Transforms/InstCombine/shift.ll
@@ -2242,7 +2242,7 @@ define i129 @shift_zext_not_nneg(i8 %arg) {
 
 define i8 @src_shl_nsw(i8 %x) {
 ; CHECK-LABEL: @src_shl_nsw(
-; CHECK-NEXT:    [[R:%.*]] = shl i8 32, [[X:%.*]]
+; CHECK-NEXT:    [[R:%.*]] = shl nsw i8 32, [[X:%.*]]
 ; CHECK-NEXT:    ret i8 [[R]]
 ;
   %sh = shl nsw i8 1, %x
@@ -2262,7 +2262,7 @@ define i8 @src_shl_nsw_fail(i8 %x) {
 
 define i8 @src_shl_nuw(i8 %x) {
 ; CHECK-LABEL: @src_shl_nuw(
-; CHECK-NEXT:    [[R:%.*]] = shl i8 12, [[X:%.*]]
+; CHECK-NEXT:    [[R:%.*]] = shl nuw i8 12, [[X:%.*]]
 ; CHECK-NEXT:    ret i8 [[R]]
 ;
   %sh = shl nuw i8 3, %x
@@ -2282,7 +2282,7 @@ define i8 @src_shl_nuw_fail(i8 %x) {
 
 define i8 @src_lshr_exact(i8 %x) {
 ; CHECK-LABEL: @src_lshr_exact(
-; CHECK-NEXT:    [[R:%.*]] = lshr i8 48, [[X:%.*]]
+; CHECK-NEXT:    [[R:%.*]] = lshr exact i8 48, [[X:%.*]]
 ; CHECK-NEXT:    ret i8 [[R]]
 ;
   %sh = lshr exact i8 96, %x
@@ -2302,7 +2302,7 @@ define i8 @src_lshr_exact_fail(i8 %x) {
 
 define i8 @src_ashr_exact(i8 %x) {
 ; CHECK-LABEL: @src_ashr_exact(
-; CHECK-NEXT:    [[R:%.*]] = lshr i8 8, [[X:%.*]]
+; CHECK-NEXT:    [[R:%.*]] = lshr exact i8 8, [[X:%.*]]
 ; CHECK-NEXT:    ret i8 [[R]]
 ;
   %sh = ashr exact i8 32, %x

--- a/llvm/test/Transforms/InstCombine/shift.ll
+++ b/llvm/test/Transforms/InstCombine/shift.ll
@@ -2240,4 +2240,84 @@ define i129 @shift_zext_not_nneg(i8 %arg) {
   ret i129 %shl
 }
 
+define i8 @src_shl_nsw(i8 %x) {
+; CHECK-LABEL: @src_shl_nsw(
+; CHECK-NEXT:    [[R:%.*]] = shl i8 32, [[X:%.*]]
+; CHECK-NEXT:    ret i8 [[R]]
+;
+  %sh = shl nsw i8 1, %x
+  %r = shl nsw i8 %sh, 5
+  ret i8 %r
+}
+
+define i8 @src_shl_nsw_fail(i8 %x) {
+; CHECK-LABEL: @src_shl_nsw_fail(
+; CHECK-NEXT:    [[R:%.*]] = shl i8 32, [[X:%.*]]
+; CHECK-NEXT:    ret i8 [[R]]
+;
+  %sh = shl nsw i8 1, %x
+  %r = shl i8 %sh, 5
+  ret i8 %r
+}
+
+define i8 @src_shl_nuw(i8 %x) {
+; CHECK-LABEL: @src_shl_nuw(
+; CHECK-NEXT:    [[R:%.*]] = shl i8 12, [[X:%.*]]
+; CHECK-NEXT:    ret i8 [[R]]
+;
+  %sh = shl nuw i8 3, %x
+  %r = shl nuw i8 %sh, 2
+  ret i8 %r
+}
+
+define i8 @src_shl_nuw_fail(i8 %x) {
+; CHECK-LABEL: @src_shl_nuw_fail(
+; CHECK-NEXT:    [[R:%.*]] = shl i8 12, [[X:%.*]]
+; CHECK-NEXT:    ret i8 [[R]]
+;
+  %sh = shl i8 3, %x
+  %r = shl nuw i8 %sh, 2
+  ret i8 %r
+}
+
+define i8 @src_lshr_exact(i8 %x) {
+; CHECK-LABEL: @src_lshr_exact(
+; CHECK-NEXT:    [[R:%.*]] = lshr i8 48, [[X:%.*]]
+; CHECK-NEXT:    ret i8 [[R]]
+;
+  %sh = lshr exact i8 96, %x
+  %r = lshr exact i8 %sh, 1
+  ret i8 %r
+}
+
+define i8 @src_lshr_exact_fail(i8 %x) {
+; CHECK-LABEL: @src_lshr_exact_fail(
+; CHECK-NEXT:    [[R:%.*]] = lshr i8 48, [[X:%.*]]
+; CHECK-NEXT:    ret i8 [[R]]
+;
+  %sh = lshr exact i8 96, %x
+  %r = lshr i8 %sh, 1
+  ret i8 %r
+}
+
+define i8 @src_ashr_exact(i8 %x) {
+; CHECK-LABEL: @src_ashr_exact(
+; CHECK-NEXT:    [[R:%.*]] = lshr i8 8, [[X:%.*]]
+; CHECK-NEXT:    ret i8 [[R]]
+;
+  %sh = ashr exact i8 32, %x
+  %r = ashr exact i8 %sh, 2
+  ret i8 %r
+}
+
+define i8 @src_ashr_exact_fail(i8 %x) {
+; CHECK-LABEL: @src_ashr_exact_fail(
+; CHECK-NEXT:    [[R:%.*]] = lshr i8 8, [[X:%.*]]
+; CHECK-NEXT:    ret i8 [[R]]
+;
+  %sh = ashr i8 32, %x
+  %r = ashr exact i8 %sh, 2
+  ret i8 %r
+}
+
 declare i16 @llvm.umax.i16(i16, i16)


### PR DESCRIPTION
- **[InstCombine] Add tests for propagating flags when folding consecutative shifts; NFC**
- **[InstCombine] Propagate flags when folding consecutative shifts**

When we fold `(shift (shift C0, x), C1)` we can propagate flags that
are common to both shifts.

Proofs: https://alive2.llvm.org/ce/z/LkEzXD