### PR TITLE
[hexagon] Add {con,de}structive interference size defn

### DIFF
--- a/clang/lib/Basic/Targets/Hexagon.cpp
+++ b/clang/lib/Basic/Targets/Hexagon.cpp
@@ -238,6 +238,18 @@ static constexpr CPUSuffix Suffixes[] = {
     {{"hexagonv73"}, {"73"}},
 };
 
+std::optional<unsigned> HexagonTargetInfo::getHexagonCPURev(StringRef Name) {
+  StringRef Arch = Name;
+  Arch.consume_front("hexagonv");
+  Arch.consume_back("t");
+
+  unsigned Val;
+  if (!Arch.getAsInteger(0, Val))
+    return Val;
+
+  return std::nullopt;
+}
+
 const char *HexagonTargetInfo::getHexagonCPUSuffix(StringRef Name) {
   const CPUSuffix *Item = llvm::find_if(
       Suffixes, [Name](const CPUSuffix &S) { return S.Name == Name; });

--- a/clang/lib/Basic/Targets/Hexagon.h
+++ b/clang/lib/Basic/Targets/Hexagon.h
@@ -17,6 +17,7 @@
 #include "clang/Basic/TargetOptions.h"
 #include "llvm/Support/Compiler.h"
 #include "llvm/TargetParser/Triple.h"
+#include <optional>
 
 namespace clang {
 namespace targets {
@@ -115,6 +116,7 @@ public:
   std::string_view getClobbers() const override { return ""; }
 
   static const char *getHexagonCPUSuffix(StringRef Name);
+  static std::optional<unsigned> getHexagonCPURev(StringRef Name);
 
   bool isValidCPUName(StringRef Name) const override {
     return getHexagonCPUSuffix(Name);
@@ -139,6 +141,14 @@ public:
   }
 
   bool hasBitIntType() const override { return true; }
+
+  std::pair<unsigned, unsigned> hardwareInterferenceSizes() const override {
+    std::optional<unsigned> Rev = getHexagonCPURev(CPU);
+
+    // V73 and later have 64-byte cache lines.
+    unsigned CacheLineSizeBytes = Rev >= 73 ? 64 : 32;
+    return std::make_pair(CacheLineSizeBytes, CacheLineSizeBytes);
+  }
 };
 } // namespace targets
 } // namespace clang

--- a/clang/test/Preprocessor/hexagon-predefines.c
+++ b/clang/test/Preprocessor/hexagon-predefines.c
@@ -169,3 +169,20 @@
 // CHECK-ATOMIC: #define __CLANG_ATOMIC_POINTER_LOCK_FREE 2
 // CHECK-ATOMIC: #define __CLANG_ATOMIC_SHORT_LOCK_FREE 2
 // CHECK-ATOMIC: #define __CLANG_ATOMIC_WCHAR_T_LOCK_FREE 2
+
+// RUN: %clang_cc1 -E -dM -triple hexagon-unknown-linux-musl \
+// RUN: -target-cpu hexagonv67 | FileCheck \
+// RUN: %s -check-prefix CHECK-INTERFERENCE
+// RUN: %clang_cc1 -E -dM -triple hexagon-unknown-none-elf \
+// RUN: -target-cpu hexagonv67 | FileCheck \
+// RUN: %s -check-prefix CHECK-INTERFERENCE
+// RUN: %clang_cc1 -E -dM -triple hexagon-unknown-none-elf \
+// RUN: -target-cpu hexagonv71t | FileCheck \
+// RUN: %s -check-prefix CHECK-INTERFERENCE
+// CHECK-INTERFERENCE: #define __GCC_CONSTRUCTIVE_SIZE 32
+// CHECK-INTERFERENCE: #define __GCC_DESTRUCTIVE_SIZE 32
+// RUN: %clang_cc1 -E -dM -triple hexagon-unknown-none-elf \
+// RUN: -target-cpu hexagonv73 | FileCheck \
+// RUN: %s -check-prefix CHECK-INTERFERENCE-73
+// CHECK-INTERFERENCE-73: #define __GCC_CONSTRUCTIVE_SIZE 64
+// CHECK-INTERFERENCE-73: #define __GCC_DESTRUCTIVE_SIZE 64


### PR DESCRIPTION
This support was originally added in 72c373bfdc98 ([C++17] Support __GCC_[CON|DE]STRUCTIVE_SIZE (#89446), 2024-04-26).  We're overriding the values for Hexagon here.