### PR TITLE
[ObjC][CodeGen] Assume a for-in loop is in bounds and cannot overflow

### DIFF
--- a/clang/lib/CodeGen/CGObjC.cpp
+++ b/clang/lib/CodeGen/CGObjC.cpp
@@ -1952,7 +1952,7 @@ void CodeGenFunction::EmitObjCForCollectionStmt(const ObjCForCollectionStmt &S){
     Builder.CreateLoad(StateItemsPtr, "stateitems");
 
   // Fetch the value at the current index from the buffer.
-  llvm::Value *CurrentItemPtr = Builder.CreateGEP(
+  llvm::Value *CurrentItemPtr = Builder.CreateInBoundsGEP(
       ObjCIdType, EnumStateItems, index, "currentitem.ptr");
   llvm::Value *CurrentItem =
     Builder.CreateAlignedLoad(ObjCIdType, CurrentItemPtr, getPointerAlign());
@@ -2028,7 +2028,7 @@ void CodeGenFunction::EmitObjCForCollectionStmt(const ObjCForCollectionStmt &S){
 
   // First we check in the local buffer.
   llvm::Value *indexPlusOne =
-      Builder.CreateAdd(index, llvm::ConstantInt::get(NSUIntegerTy, 1));
+      Builder.CreateNUWAdd(index, llvm::ConstantInt::get(NSUIntegerTy, 1));
 
   // If we haven't overrun the buffer yet, we can continue.
   // Set the branch weights based on the simplifying assumption that this is

--- a/clang/test/CodeGenObjC/arc-foreach.m
+++ b/clang/test/CodeGenObjC/arc-foreach.m
@@ -53,7 +53,7 @@ void test0(NSArray *array) {
 
 // CHECK-LP64:      [[T0:%.*]] = getelementptr inbounds [[STATE_T]], ptr [[STATE]], i32 0, i32 1
 // CHECK-LP64-NEXT: [[T1:%.*]] = load ptr, ptr [[T0]]
-// CHECK-LP64-NEXT: [[T2:%.*]] = getelementptr ptr, ptr [[T1]], i64
+// CHECK-LP64-NEXT: [[T2:%.*]] = getelementptr inbounds ptr, ptr [[T1]], i64
 // CHECK-LP64-NEXT: [[T3:%.*]] = load ptr, ptr [[T2]]
 // CHECK-LP64-NEXT: store ptr [[T3]], ptr [[X]]
 
@@ -100,7 +100,7 @@ void test1(NSArray *array) {
 
 // CHECK-LP64:      [[T0:%.*]] = getelementptr inbounds [[STATE_T]], ptr [[STATE]], i32 0, i32 1
 // CHECK-LP64-NEXT: [[T1:%.*]] = load ptr, ptr [[T0]]
-// CHECK-LP64-NEXT: [[T2:%.*]] = getelementptr ptr, ptr [[T1]], i64
+// CHECK-LP64-NEXT: [[T2:%.*]] = getelementptr inbounds ptr, ptr [[T1]], i64
 // CHECK-LP64-NEXT: [[T3:%.*]] = load ptr, ptr [[T2]]
 // CHECK-LP64-NEXT: call ptr @llvm.objc.initWeak(ptr [[X]], ptr [[T3]])
 


### PR DESCRIPTION
When accessing data in the buffer, we know we won't overrun the buffer, so we know it is inbounds. In addition, we know that the addition to increase the index is also NUW because the buffer's end has to be unsigned-greater-than 0, which becomes untrue if the bounds ever has an unsigned wrap.