### PR TITLE
[Instrumentation] Remove an extraneous ArrayRef (NFC)

### DIFF
--- a/llvm/lib/Transforms/Instrumentation/PGOMemOPSizeOpt.cpp
+++ b/llvm/lib/Transforms/Instrumentation/PGOMemOPSizeOpt.cpp
@@ -402,8 +402,7 @@ bool MemOPSizeOpt::perform(MemOp MO) {
   // If all promoted, we don't need the MD.prof metadata.
   if (SavedRemainCount > 0 || Version != NumVals) {
     // Otherwise we need update with the un-promoted records back.
-    ArrayRef<InstrProfValueData> RemVDs(RemainingVDs);
-    annotateValueSite(*Func.getParent(), *MO.I, RemVDs, SavedRemainCount,
+    annotateValueSite(*Func.getParent(), *MO.I, RemainingVDs, SavedRemainCount,
                       IPVK_MemOPSize, NumVals);
   }
 


### PR DESCRIPTION
We can implicitly convert RemainingVDs to an ArrayRef.  Note that
RemainingVDs is of type SmallVector<InstrProfValueData, 24>.