### PR TITLE
[libc++][NFC] Remove some dead code in string

### DIFF
--- a/libcxx/include/string
+++ b/libcxx/include/string
@@ -868,23 +868,9 @@ private:
 
   static_assert(sizeof(__short) == (sizeof(value_type) * (__min_cap + 1)), "__short has an unexpected size.");
 
-  union __ulx {
-    __long __lx;
-    __short __lxx;
-  };
-
-  enum { __n_words = sizeof(__ulx) / sizeof(size_type) };
-
-  struct __raw {
-    size_type __words[__n_words];
-  };
-
-  struct __rep {
-    union {
-      __short __s;
-      __long __l;
-      __raw __r;
-    };
+  union __rep {
+    __short __s;
+    __long __l;
   };
 
   __compressed_pair<__rep, allocator_type> __r_;


### PR DESCRIPTION
It looks like the last references got removed in c747bd0e2339.
It removed a __zero() function, which was probably created at
some point in the ancient past to optimize copying the string 
representation. The __zero() function got simplified to an 
assignment as part of making string constexpr, rendering this 
code unnecessary.