### PR TITLE
[lldb] Gracefully down TestCoroutineHandle test in case the 'coroutine' feature is missing

### DIFF
--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/coroutine_handle/Makefile
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/coroutine_handle/Makefile
@@ -1,4 +1,12 @@
 CXX_SOURCES := main.cpp
 CFLAGS_EXTRAS := -std=c++20
 
+ifeq "1" "$(USE_LIBSTDCPP)"
+  CFLAGS_EXTRAS += -DUSE_LIBSTDCPP
+endif
+
+ifeq "1" "$(USE_LIBCPP)"
+  CFLAGS_EXTRAS += -DUSE_LIBCPP
+endif
+
 include Makefile.rules


### PR DESCRIPTION
Do not let the compiler gets failed in case the target platform does not support the 'coroutine' C++ features. Just compile without it and let lldb know about missed/unsupported feature.