### PR TITLE
[libc++][test] Avoid `-Wunused-variable` warnings in mutex tests

### DIFF
--- a/libcxx/test/std/thread/thread.mutex/thread.mutex.requirements/thread.sharedtimedmutex.requirements/thread.sharedtimedmutex.class/default.pass.cpp
+++ b/libcxx/test/std/thread/thread.mutex/thread.mutex.requirements/thread.sharedtimedmutex.requirements/thread.sharedtimedmutex.class/default.pass.cpp
@@ -19,9 +19,9 @@
 
 #include "test_macros.h"
 
-int main(int, char**)
-{
-    std::shared_timed_mutex m;
+int main(int, char**) {
+  std::shared_timed_mutex m;
+  (void)m;
 
   return 0;
 }

--- a/libcxx/test/std/thread/thread.mutex/thread.mutex.requirements/thread.timedmutex.requirements/thread.timedmutex.class/default.pass.cpp
+++ b/libcxx/test/std/thread/thread.mutex/thread.mutex.requirements/thread.timedmutex.requirements/thread.timedmutex.class/default.pass.cpp
@@ -18,9 +18,9 @@
 
 #include "test_macros.h"
 
-int main(int, char**)
-{
-    std::timed_mutex m;
+int main(int, char**) {
+  std::timed_mutex m;
+  (void)m;
 
   return 0;
 }

--- a/libcxx/test/std/thread/thread.mutex/thread.mutex.requirements/thread.timedmutex.requirements/thread.timedmutex.recursive/default.pass.cpp
+++ b/libcxx/test/std/thread/thread.mutex/thread.mutex.requirements/thread.timedmutex.requirements/thread.timedmutex.recursive/default.pass.cpp
@@ -18,9 +18,9 @@
 
 #include "test_macros.h"
 
-int main(int, char**)
-{
-    std::recursive_timed_mutex m;
+int main(int, char**) {
+  std::recursive_timed_mutex m;
+  (void)m;
 
   return 0;
 }


### PR DESCRIPTION
After enhancing MSVC's STL to statically initialize our `condition_variable`, Clang began noticing that these mutex flavors were unused:

```
[...snipped...]\default.pass.cpp(23,22): error: unused variable 'm' [-Werror,-Wunused-variable]
   23 |     std::timed_mutex m;
      |                      ^

[...snipped...]\default.pass.cpp(23,32): error: unused variable 'm' [-Werror,-Wunused-variable]
   23 |     std::recursive_timed_mutex m;
      |                                ^

[...snipped...]\default.pass.cpp(24,29): error: unused variable 'm' [-Werror,-Wunused-variable]
   24 |     std::shared_timed_mutex m;
      |                             ^
```