### PR TITLE
[NFC][mlir][gpu] Fully-qualify all namespaces in the GPU compilation interfaces

### DIFF
--- a/mlir/include/mlir/Dialect/GPU/IR/CompilationAttrInterfaces.td
+++ b/mlir/include/mlir/Dialect/GPU/IR/CompilationAttrInterfaces.td
@@ -37,17 +37,18 @@ def GPUTargetAttrInterface : AttrInterface<"TargetAttrInterface"> {
         is meant to be used for passing additional options that are not in the
         attribute.
       }],
-      "std::optional<SmallVector<char, 0>>", "serializeToObject",
-      (ins "Operation*":$module, "const gpu::TargetOptions&":$options)>,
+      "std::optional<::mlir::SmallVector<char, 0>>", "serializeToObject",
+      (ins "::mlir::Operation*":$module,
+           "const ::mlir::gpu::TargetOptions&":$options)>,
     InterfaceMethod<[{
         Creates a GPU object attribute from a binary string.
 
         The `object` parameter is a binary string. The `options` parameter is
         meant to be used for passing additional options that are not in the
         attribute.
-      }], "Attribute", "createObject",
-        (ins "const SmallVector<char, 0>&":$object,
-             "const gpu::TargetOptions&":$options)>
+      }], "::mlir::Attribute", "createObject",
+        (ins "const ::llvm::SmallVector<char, 0>&":$object,
+             "const ::mlir::gpu::TargetOptions&":$options)>
   ];
 }
 
@@ -112,9 +113,10 @@ def OffloadingLLVMTranslationAttrInterface :
         The first argument has to be a GPU binary operation.
         If the function fails at any point, it must return `failure`.
       }],
-      "LogicalResult", "embedBinary",
-      (ins "Operation*":$binaryOp, "llvm::IRBuilderBase&":$hostBuilder,
-           "LLVM::ModuleTranslation&":$hostModuleTranslation)
+      "::mlir::LogicalResult", "embedBinary",
+      (ins "::mlir::Operation*":$binaryOp,
+           "::llvm::IRBuilderBase&":$hostBuilder,
+           "::mlir::LLVM::ModuleTranslation&":$hostModuleTranslation)
     >,
     InterfaceMethod<[{
         Translates a `gpu.launch_func` op into a sequence of LLVM IR
@@ -128,10 +130,10 @@ def OffloadingLLVMTranslationAttrInterface :
         respectively. If the function fails at any point, it must return
         `failure`.
       }],
-      "LogicalResult", "launchKernel",
-      (ins "Operation*":$launchFunc, "Operation*":$binaryOp,
-           "llvm::IRBuilderBase&":$hostBuilder,
-           "LLVM::ModuleTranslation&":$hostModuleTranslation)
+      "::mlir::LogicalResult", "launchKernel",
+      (ins "::mlir::Operation*":$launchFunc, "::mlir::Operation*":$binaryOp,
+           "::llvm::IRBuilderBase&":$hostBuilder,
+           "::mlir::LLVM::ModuleTranslation&":$hostModuleTranslation)
     >
   ];
 }


### PR DESCRIPTION
Fully qualify all namespaces appearing in `GPUTargetAttrInterface` and `OffloadingLLVMTranslationAttrInterface`. If they're not fully qualified then out-of-tree dialects might encounter name resolution errors.