### PR TITLE
MCInst: decrease inline element count to 6. NFC

### DIFF
--- a/llvm/include/llvm/MC/MCInst.h
+++ b/llvm/include/llvm/MC/MCInst.h
@@ -189,7 +189,7 @@ class MCInst {
   unsigned Flags = 0;
 
   SMLoc Loc;
-  SmallVector<MCOperand, 10> Operands;
+  SmallVector<MCOperand, 6> Operands;
 
 public:
   MCInst() = default;


### PR DESCRIPTION
MCInst is primarily used in local variables and MCRelaxableFragment
(mostly JMP/JCC for x86). Reducing the inline element count can make
MCRelaxableFragment smaller, potentially leading to a lower peak RSS.

When compiling sqlite3.c, x86-64 has the largest maximum numOperands.

aarch64: 5; ppc64: 6; riscv64: 3; s390x: 6; x86-64: 8

Here is the frequency table for x86-64:

max getNumOperands: 8
0: 676
1: 37892
2: 84046
3: 26767
4: 1640
5: 1222
6: 80794
7: 768
8: 22
