### PR TITLE
[LVI] Remove unused get of Range metadata.

### DIFF
--- a/llvm/lib/Analysis/LazyValueInfo.cpp
+++ b/llvm/lib/Analysis/LazyValueInfo.cpp
@@ -1116,9 +1116,6 @@ LazyValueInfoImpl::getValueFromSimpleICmpCondition(CmpInst::Predicate Pred,
     if (!R)
       return std::nullopt;
     RHSRange = toConstantRange(*R, RHS->getType());
-  } else if (Instruction *I = dyn_cast<Instruction>(RHS)) {
-    if (auto *Ranges = I->getMetadata(LLVMContext::MD_range))
-      RHSRange = getConstantRangeFromMetadata(*Ranges);
   }
 
   ConstantRange TrueValues =


### PR DESCRIPTION
There is no test for this code and it also do not change the result of https://github.com/dtcxzyw/llvm-opt-benchmark when I run it locally. 
I have not been able to make a test for this and do not know how to handle the range attribute for this so maybe it shall be removed?

CC @nikic 