### PR TITLE
[ObjCARC] Add variations of intrinsics that do not touch reference counts

### DIFF
--- a/llvm/lib/Analysis/ObjCARCInstKind.cpp
+++ b/llvm/lib/Analysis/ObjCARCInstKind.cpp
@@ -201,8 +201,13 @@ static bool isUseOnlyIntrinsic(unsigned ID) {
   // TODO: Expand this into a covered switch. There is a lot more here.
   switch (ID) {
   case Intrinsic::memcpy:
+  case Intrinsic::memcpy_element_unordered_atomic:
+  case Intrinsic::memcpy_inline:
   case Intrinsic::memmove:
+  case Intrinsic::memmove_element_unordered_atomic:
   case Intrinsic::memset:
+  case Intrinsic::memset_element_unordered_atomic:
+  case Intrinsic::memset_inline:
     return true;
   default:
     return false;


### PR DESCRIPTION
memset, memmove, and memcpy have variations that are not covered by the switch case but should be. They do not touch the retain count either.