### PR TITLE
[clangd] Make it possible to enable misc-const-correctness clang-tidy check

### DIFF
--- a/clang-tools-extra/clangd/TidyProvider.cpp
+++ b/clang-tools-extra/clangd/TidyProvider.cpp
@@ -221,13 +221,7 @@ TidyProvider disableUnusableChecks(llvm::ArrayRef<std::string> ExtraBadChecks) {
       "-hicpp-invalid-access-moved",
       // Check uses dataflow analysis, which might hang/crash unexpectedly on
       // incomplete code.
-      "-bugprone-unchecked-optional-access",
-
-      // ----- Performance problems -----
-
-      // This check runs expensive analysis for each variable.
-      // It has been observed to increase reparse time by 10x.
-      "-misc-const-correctness");
+      "-bugprone-unchecked-optional-access");
 
   size_t Size = BadChecks.size();
   for (const std::string &Str : ExtraBadChecks) {


### PR DESCRIPTION
Before this PR, it wasn't possible to enable misc-const-correctness: disableUnusableChecks() forcefully disabled it because the check is slow.  It was implemented this way before clangd got the FastCheckFilter feature.  As the default setting of FastCheckFilter also disables misc-const-correctness, it makes sense to remove misc-const-correctness from disableUnusableChecks()'s list, to make it possible to enable misc-const-correctness by setting FastCheckFilter to None.  Fixes https://github.com/llvm/llvm-project/issues/89758.