### PR TITLE
[test][OpenMP] Avoid writing to a potentially write-protected dir

### DIFF
--- a/clang/test/OpenMP/error_unsupport_feature.c
+++ b/clang/test/OpenMP/error_unsupport_feature.c
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -fsyntax-only -verify -fopenmp %s
+// RUN: %clang_cc1 -emit-llvm-only -verify -fopenmp %s
 
 int main () {
   int r = 0;

--- a/clang/test/OpenMP/error_unsupport_feature.c
+++ b/clang/test/OpenMP/error_unsupport_feature.c
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -emit-llvm -verify -fopenmp %s
+// RUN: %clang_cc1 -fsyntax-only -verify -fopenmp %s
 
 int main () {
   int r = 0;


### PR DESCRIPTION
The test clang/test/OpenMP/error_unsupport_feature.c don't check the output written to the current directory. The current directory may be write protected e.g. in a sandboxed environment.

This patch replace the -emit-llvm option with  -emit-llvm-only as it don't care about the outputed llvm IR.