### PR TITLE
[clang][NVPTX] Define macro indicating the PTX version

### DIFF
--- a/clang/lib/Basic/Targets/NVPTX.cpp
+++ b/clang/lib/Basic/Targets/NVPTX.cpp
@@ -173,6 +173,7 @@ void NVPTXTargetInfo::getTargetDefines(const LangOptions &Opts,
                                        MacroBuilder &Builder) const {
   Builder.defineMacro("__PTX__");
   Builder.defineMacro("__NVPTX__");
+  Builder.defineMacro("__PTX_VERSION__", Twine(PTXVersion));
 
   // Skip setting architecture dependent macros if undefined.
   if (GPU == CudaArch::UNUSED && !HostTarget)

--- a/clang/test/Preprocessor/cuda-ptx-versioning.cu
+++ b/clang/test/Preprocessor/cuda-ptx-versioning.cu
@@ -1,0 +1,11 @@
+// RUN: %clang_cc1 %s -E -dM -o - -x cuda -fcuda-is-device -triple nvptx64 \
+// RUN: | FileCheck -match-full-lines %s --check-prefix=CHECK-CUDA32
+// CHECK-CUDA32: #define __PTX_VERSION__ 32
+
+// RUN: %clang_cc1 %s -E -dM -o - -x cuda -fcuda-is-device -triple nvptx64 -target-feature +ptx78 \
+// RUN:  -target-cpu sm_90 | FileCheck -match-full-lines %s --check-prefix=CHECK-CUDA78
+// CHECK-CUDA78: #define __PTX_VERSION__ 78
+
+// RUN: %clang_cc1 %s -E -dM -o - -x cuda -fcuda-is-device -triple nvptx64 -target-feature +ptx80 \
+// RUN:  -target-cpu sm_80 | FileCheck -match-full-lines %s --check-prefix=CHECK-CUDA80
+// CHECK-CUDA80: #define __PTX_VERSION__ 80


### PR DESCRIPTION
Define __PTX_VERSION__ macro to indicate the used PTX version.

Usually each new PTX version brings a new sm version and the associated instructions. However, some of these instructions can also be made available to older sm. This allows applications to check more accurately for available instructions.