### PR TITLE
[clangd] Use clang_target_link_libraries() for clang libs

### DIFF
--- a/clang-tools-extra/clangd/index/remote/CMakeLists.txt
+++ b/clang-tools-extra/clangd/index/remote/CMakeLists.txt
@@ -26,13 +26,17 @@ if (CLANGD_ENABLE_REMOTE)
     clangdRemoteIndexProto
     clangdRemoteIndexServiceProto
     clangdRemoteMarshalling
-    clangBasic
     clangDaemon
     clangdSupport
 
     DEPENDS
     clangdRemoteIndexProto
     clangdRemoteIndexServiceProto
+    )
+
+  clang_target_link_libraries(clangdRemoteIndex
+    PRIVATE
+    clangBasic
     )
 
   add_subdirectory(marshalling)

--- a/clang-tools-extra/pseudo/lib/CMakeLists.txt
+++ b/clang-tools-extra/pseudo/lib/CMakeLists.txt
@@ -14,8 +14,6 @@ add_clang_library(clangPseudo
   Token.cpp
 
   LINK_LIBS
-  clangBasic
-  clangLex
   clangPseudoGrammar
 
   DEPENDS
@@ -24,4 +22,10 @@ add_clang_library(clangPseudo
 
   target_include_directories(clangPseudo INTERFACE
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include>
+  )
+
+clang_target_link_libraries(clangPseudo
+  PRIVATE
+  clangBasic
+  clangLex
   )

--- a/clang-tools-extra/pseudo/lib/cxx/CMakeLists.txt
+++ b/clang-tools-extra/pseudo/lib/cxx/CMakeLists.txt
@@ -9,7 +9,11 @@ add_clang_library(clangPseudoCXX
   cxx_gen
 
   LINK_LIBS
-  clangBasic
   clangPseudo
   clangPseudoGrammar
+  )
+
+clang_target_link_libraries(clangPseudoCXX
+  PRIVATE
+  clangBasic
   )


### PR DESCRIPTION
Use clang_target_link_libraries() instead of LINK_LIBS when linking clang libraries. This ensures that in CLANG_LINK_CLANG_DYLIB mode we link against libclang-cpp.so (instead of linking against both it and the static libraries).

Most places were already doing this correctly, there were just a handful of leftovers.