### PR TITLE
[KnownBits] Speed up ForeachKnownBits in unit test. NFC.

### DIFF
--- a/llvm/unittests/Support/KnownBitsTest.h
+++ b/llvm/unittests/Support/KnownBitsTest.h
@@ -34,13 +34,13 @@ template <typename FnTy> void ForeachKnownBits(unsigned Bits, FnTy Fn) {
 template <typename FnTy>
 void ForeachNumInKnownBits(const KnownBits &Known, FnTy Fn) {
   unsigned Bits = Known.getBitWidth();
-  unsigned Max = 1 << Bits;
+  assert(Bits < 32);
+  unsigned Max = 1u << Bits;
+  unsigned Zero = Known.Zero.getZExtValue();
+  unsigned One = Known.One.getZExtValue();
   for (unsigned N = 0; N < Max; ++N) {
-    APInt Num(Bits, N);
-    if ((Num & Known.Zero) != 0 || (~Num & Known.One) != 0)
-      continue;
-
-    Fn(Num);
+    if ((N & Zero) == 0 && (~N & One) == 0)
+      Fn(APInt(Bits, N));
   }
 }
 


### PR DESCRIPTION
Use fast unsigned arithmetic before constructing an APInt. This gives
me a ~2x speed up when running this in my Release+Asserts build:

$ unittests/Support/SupportTests --gtest_filter=KnownBitsTest.*Exhaustive
