### PR TITLE
[clang] SourceLocIdentKind::Function should not be dependent

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -846,6 +846,7 @@ Bug Fixes to C++ Support
 - Fix a crash caused by improper use of ``__array_extent``. (#GH80474)
 - Fixed several bugs in capturing variables within unevaluated contexts. (#GH63845), (#GH67260), (#GH69307),
   (#GH88081), (#GH89496), (#GH90669) and (#GH91633).
+- Fix a crash when SourceLocExpr instantiated in a dependent context. (GH80210).
 
 Bug Fixes to AST Handling
 ^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/clang/include/clang/AST/Expr.h
+++ b/clang/include/clang/AST/Expr.h
@@ -4786,8 +4786,6 @@ public:
 
   static bool MayBeDependent(SourceLocIdentKind Kind) {
     switch (Kind) {
-    case SourceLocIdentKind::Function:
-    case SourceLocIdentKind::FuncSig:
     case SourceLocIdentKind::SourceLocStruct:
       return true;
     default:

--- a/clang/test/CodeGenCXX/PR80210.cpp
+++ b/clang/test/CodeGenCXX/PR80210.cpp
@@ -1,0 +1,34 @@
+// RUN: %clang_cc1 -std=c++20 %s -emit-llvm -o /dev/null -verify -triple %itanium_abi_triple
+// RUN: %clang_cc1 -std=c++20 %s -emit-llvm -o /dev/null -verify -triple %ms_abi_triple
+
+// expected-no-diagnostics
+
+struct BasicPersistent;
+template <typename> BasicPersistent &&__declval(int);
+template <typename _Tp> auto declval() -> decltype(__declval<_Tp>(0));
+template <typename _Tp> _Tp forward;
+template <typename _Tp, typename... _Args>
+auto construct_at(_Tp *, _Args...) -> decltype(new _Tp(declval<_Args>()...)) {return 0;}
+template <typename> struct allocator;
+template <typename> struct allocator_traits;
+template <typename _Tp> struct allocator_traits<allocator<_Tp>> {
+  using pointer = _Tp *;
+  template <typename _Up, typename... _Args>
+  static void construct(_Up __p, _Args...) {
+    construct_at(__p, forward<_Args>...);
+  }
+};
+struct __alloc_traits : allocator_traits<allocator<BasicPersistent>> {
+} push_back___x;
+__alloc_traits::pointer _M_impl_0;
+template <typename... _Args> void emplace_back(_Args...) {
+  __alloc_traits::construct(_M_impl_0, forward<_Args>...);
+}
+struct SourceLocation {
+  static SourceLocation Current(const char * = __builtin_FUNCTION());
+};
+struct BasicPersistent {
+  BasicPersistent(BasicPersistent &&,
+                  SourceLocation = SourceLocation::Current());
+};
+void CFXJSE_EngineAddObjectToUpArray() { emplace_back(push_back___x); }


### PR DESCRIPTION
Consider the testcase, return type of `construct_at` is
```cpp
DecltypeType 0x55555570d8c0 'decltype(new struct BasicPersistent(declval<struct __alloc_traits>()))' sugar dependent
|-CXXNewExpr 0x55555570d880 'struct BasicPersistent *' Function 0x55555570ace0 'operator new' 'void *(unsigned long)'
| `-CXXConstructExpr 0x55555570d848 'struct BasicPersistent' 'void (BasicPersistent &&, SourceLocation)'
|   |-CallExpr 0x55555570aae8 'BasicPersistent':'struct BasicPersistent' xvalue
|   | `-ImplicitCastExpr 0x55555570aad0 'auto (*)(void) -> decltype(__declval<struct __alloc_traits>(0))' <FunctionToPointerDecay>
|   |   `-DeclRefExpr 0x55555570aa18 'auto (void) -> decltype(__declval<struct __alloc_traits>(0))' lvalue Function 0x55555570a908 'declval' 'auto (void) -> decltype(__declval<struct __alloc_traits>(0))' (FunctionTemplate 0x5555556d0548 'declval') non_odr_use_unevaluated
|   `-CXXDefaultArgExpr 0x55555570d820 'SourceLocation':'struct SourceLocation' has rewritten init
|     `-CallExpr 0x55555570d7b0 'SourceLocation':'struct SourceLocation'
|       |-ImplicitCastExpr 0x55555570d798 'SourceLocation (*)(const char *)' <FunctionToPointerDecay>
|       | `-DeclRefExpr 0x5555556fe5c8 'SourceLocation (const char *)' lvalue CXXMethod 0x5555556fdb28 'Current' 'SourceLocation (const char *)'
|       |   `-NestedNameSpecifier TypeSpec 'struct SourceLocation'
|       `-CXXDefaultArgExpr 0x55555570d7f8 'const char *' has rewritten init
|         `-SourceLocExpr 0x55555570d7d8 'const char *'
`-PointerType 0x555555704800 'struct BasicPersistent *'
  `-SubstTemplateTypeParmType 0x5555557047d0 'struct BasicPersistent' sugar typename depth 0 index 0 _Tp
    |-FunctionTemplate 0x5555556ee048 'construct_at'
    `-RecordType 0x5555556cfd10 'struct BasicPersistent'
      `-CXXRecord 0x5555556fdc98 'BasicPersistent'
```
when in the process of instantiation. This type is dependent due to the dependency of `SourceLocExpr` which leads to the crash(only crash in codegen stage and `clang-check -ast-dump` is OK). `SourceLocExpr` is created in a dependent context when transforming the return type of `construct_at` because its context(`Sema.CurContext`) is a dependent `FunctionDecl`. But `SourceLocExpr` should not be dependent when we finish the transformation.  Removing `SourceLocIdentKind::Function` makes `SourceLocExpr` independent.
attempt to fix https://github.com/llvm/llvm-project/issues/80210