### PR TITLE
[KnownBits] Speed up conflict handling in ForeachKnownBits in unit test.

### DIFF
--- a/llvm/unittests/Support/KnownBitsTest.h
+++ b/llvm/unittests/Support/KnownBitsTest.h
@@ -38,6 +38,12 @@ void ForeachNumInKnownBits(const KnownBits &Known, FnTy Fn) {
   unsigned Max = 1u << Bits;
   unsigned Zero = Known.Zero.getZExtValue();
   unsigned One = Known.One.getZExtValue();
+
+  if (Zero & One) {
+    // Known has a conflict. No values will satisfy it.
+    return;
+  }
+
   for (unsigned N = 0; N < Max; ++N) {
     if ((N & Zero) == 0 && (~N & One) == 0)
       Fn(APInt(Bits, N));


### PR DESCRIPTION
Exit early if known bits have a conflict. This gives me a ~15% speed up
when running this in my Release+Asserts build:

$ unittests/Support/SupportTests --gtest_filter=KnownBitsTest.*Exhaustive
