### PR TITLE
ConstantFold logl calls

### DIFF
--- a/llvm/lib/Analysis/ConstantFolding.cpp
+++ b/llvm/lib/Analysis/ConstantFolding.cpp
@@ -1734,6 +1734,14 @@ Constant *GetConstantFoldFPValue(double V, Type *Ty) {
   llvm_unreachable("Can only constant fold half/float/double");
 }
 
+#if defined(HAS_IEE754_FLOAT128)
+Constant *GetConstantFoldFPValue128(__float128 V, Type *Ty) {
+  if (Ty->isFP128Ty())
+    return ConstantFP::get(Ty, V);
+  llvm_unreachable("Can only constant fold fp128");
+}
+#endif
+
 /// Clear the floating-point exception state.
 inline void llvm_fenv_clearexcept() {
 #if defined(HAVE_FENV_H) && HAVE_DECL_FE_ALL_EXCEPT
@@ -1765,6 +1773,20 @@ Constant *ConstantFoldFP(double (*NativeFP)(double), const APFloat &V,
 
   return GetConstantFoldFPValue(Result, Ty);
 }
+
+#if defined(HAS_IEE754_FLOAT128)
+Constant *ConstantFoldFP128(long double (*NativeFP)(long double),
+                            const APFloat &V, Type *Ty) {
+  llvm_fenv_clearexcept();
+  __float128 Result = NativeFP(V.convertToQuad());
+  if (llvm_fenv_testexcept()) {
+    llvm_fenv_clearexcept();
+    return nullptr;
+  }
+
+  return GetConstantFoldFPValue128(Result, Ty);
+}
+#endif
 
 Constant *ConstantFoldBinaryFP(double (*NativeFP)(double, double),
                                const APFloat &V, const APFloat &W, Type *Ty) {
@@ -2085,18 +2107,16 @@ static Constant *ConstantFoldScalarCall1(StringRef Name,
     if (IntrinsicID == Intrinsic::canonicalize)
       return constantFoldCanonicalize(Ty, Call, U);
 
-      // Try to handle special fp128 cases before bailing
 #if defined(HAS_IEE754_FLOAT128) && defined(HAS_LOGF128)
     if (Ty->isFP128Ty()) {
-      const APFloat &Fp128APF = Op->getValueAPF();
       if (IntrinsicID == Intrinsic::log)
-        return ConstantFP::get(Ty, logf128(Fp128APF.convertToQuad()));
-    }
+        return ConstantFoldFP128(logf128, Op->getValueAPF(), Ty);
 
-    LibFunc Fp128Func = NotLibFunc;
-    if (Ty->isFP128Ty() && TLI->getLibFunc(Name, Fp128Func) &&
-        TLI->has(Fp128Func) && Fp128Func == LibFunc_logl)
-      return ConstantFP::get(Ty, logf128(Op->getValueAPF().convertToQuad()));
+      LibFunc Fp128Func = NotLibFunc;
+      if (TLI->getLibFunc(Name, Fp128Func) && TLI->has(Fp128Func) &&
+          Fp128Func == LibFunc_logl)
+        return ConstantFoldFP128(logf128, Op->getValueAPF(), Ty);
+    }
 #endif
 
     if (!Ty->isHalfTy() && !Ty->isFloatTy() && !Ty->isDoubleTy())

--- a/llvm/lib/Analysis/ConstantFolding.cpp
+++ b/llvm/lib/Analysis/ConstantFolding.cpp
@@ -2095,8 +2095,7 @@ static Constant *ConstantFoldScalarCall1(StringRef Name,
 
     LibFunc Fp128Func = NotLibFunc;
     if (Ty->isFP128Ty() && TLI->getLibFunc(Name, Fp128Func) &&
-        TLI->has(Fp128Func) && Fp128Func == LibFunc_logl &&
-        !Op->getValueAPF().isNegative() && !Op->getValueAPF().isZero())
+        TLI->has(Fp128Func) && Fp128Func == LibFunc_logl)
       return ConstantFP::get(Ty, logf128(Op->getValueAPF().convertToQuad()));
 #endif
 

--- a/llvm/lib/Analysis/ConstantFolding.cpp
+++ b/llvm/lib/Analysis/ConstantFolding.cpp
@@ -2109,8 +2109,10 @@ static Constant *ConstantFoldScalarCall1(StringRef Name,
 
 #if defined(HAS_IEE754_FLOAT128) && defined(HAS_LOGF128)
     if (Ty->isFP128Ty()) {
-      if (IntrinsicID == Intrinsic::log)
-        return ConstantFoldFP128(logf128, Op->getValueAPF(), Ty);
+      if (IntrinsicID == Intrinsic::log) {
+        __float128 Result = logf128(Op->getValueAPF().convertToQuad());
+        return GetConstantFoldFPValue128(Result, Ty);
+      }
 
       LibFunc Fp128Func = NotLibFunc;
       if (TLI->getLibFunc(Name, Fp128Func) && TLI->has(Fp128Func) &&

--- a/llvm/test/Transforms/InstSimplify/ConstProp/logf128.ll
+++ b/llvm/test/Transforms/InstSimplify/ConstProp/logf128.ll
@@ -3,6 +3,7 @@
 
 ; REQUIRES: has_logf128
 declare fp128 @llvm.log.f128(fp128)
+declare fp128 @logl(fp128)
 
 define fp128 @log_e_64(){
 ; CHECK-LABEL: define fp128 @log_e_64() {
@@ -123,4 +124,13 @@ define <2 x fp128> @log_e_negative_2_vector(){
 ;
   %A = call <2 x fp128> @llvm.log.v2f128(<2 x fp128> <fp128 0xL0000000000000000C000000000000000, fp128 0xL0000000000000000C000000000000001>)
   ret <2 x fp128> %A
+}
+
+define fp128 @logl_e_64(){
+; CHECK-LABEL: define fp128 @logl_e_64() {
+; CHECK-NEXT:    %A = call fp128 @logl(fp128 noundef 0xL00000000000000004005000000000000)
+; CHECK-NEXT:    ret fp128 0xL300000000000000040010A2B23F3BAB7
+;
+  %A = call fp128 @logl(fp128 noundef 0xL00000000000000004005000000000000)
+  ret fp128 %A
 }

--- a/llvm/test/Transforms/InstSimplify/ConstProp/logf128.ll
+++ b/llvm/test/Transforms/InstSimplify/ConstProp/logf128.ll
@@ -128,9 +128,46 @@ define <2 x fp128> @log_e_negative_2_vector(){
 
 define fp128 @logl_e_64(){
 ; CHECK-LABEL: define fp128 @logl_e_64() {
-; CHECK-NEXT:    %A = call fp128 @logl(fp128 noundef 0xL00000000000000004005000000000000)
+; CHECK-NEXT:    [[A:%.*]] = call fp128 @logl(fp128 noundef 0xL00000000000000004005000000000000)
 ; CHECK-NEXT:    ret fp128 0xL300000000000000040010A2B23F3BAB7
 ;
   %A = call fp128 @logl(fp128 noundef 0xL00000000000000004005000000000000)
+  ret fp128 %A
+}
+
+define fp128 @logl_e_0(){
+; CHECK-LABEL: define fp128 @logl_e_0() {
+; CHECK-NEXT:    [[A:%.*]] = call fp128 @logl(fp128 noundef 0xL00000000000000000000000000000000)
+; CHECK-NEXT:    ret fp128 0xL0000000000000000FFFF000000000000
+;
+  %A = call fp128 @logl(fp128 noundef 0xL00000000000000000000000000000000)
+  ret fp128 %A
+}
+
+define fp128 @logl_e_infinity(){
+; CHECK-LABEL: define fp128 @logl_e_infinity() {
+; CHECK-NEXT:    [[A:%.*]] = call fp128 @logl(fp128 noundef 0xL00000000000000007FFF000000000000)
+; CHECK-NEXT:    ret fp128 0xL00000000000000007FFF000000000000
+;
+  %A = call fp128 @logl(fp128 noundef 0xL00000000000000007FFF000000000000)
+  ret fp128 %A
+}
+
+define fp128 @logl_e_nan(){
+; CHECK-LABEL: define fp128 @logl_e_nan() {
+; CHECK-NEXT:    [[A:%.*]] = call fp128 @logl(fp128 noundef 0xL00000000000000007FFF000000000001)
+; CHECK-NEXT:    ret fp128 0xL00000000000000007FFF800000000001
+;
+  %A = call fp128 @logl(fp128 noundef 0xL00000000000000007FFF000000000001)
+  ret fp128 %A
+}
+
+
+define fp128 @logl_e_negative_2(){
+; CHECK-LABEL: define fp128 @logl_e_negative_2() {
+; CHECK-NEXT:    [[A:%.*]] = call fp128 @logl(fp128 noundef 0xL0000000000000000C000000000000000)
+; CHECK-NEXT:    ret fp128 0xL00000000000000007FFF800000000000
+;
+  %A = call fp128 @logl(fp128 noundef 0xL0000000000000000C000000000000000)
   ret fp128 %A
 }

--- a/llvm/test/Transforms/InstSimplify/ConstProp/logf128.ll
+++ b/llvm/test/Transforms/InstSimplify/ConstProp/logf128.ll
@@ -72,7 +72,8 @@ define fp128 @log_e_smallest_number_larger_than_one(){
 
 define fp128 @log_e_negative_2(){
 ; CHECK-LABEL: define fp128 @log_e_negative_2() {
-; CHECK-NEXT:    ret fp128 0xL00000000000000007FFF800000000000
+; CHECK-NEXT:    [[A:%.*]] = call fp128 @llvm.log.f128(fp128 noundef 0xL0000000000000000C000000000000000)
+; CHECK-NEXT:    ret fp128 [[A]]
 ;
   %A = call fp128 @llvm.log.f128(fp128 noundef 0xL0000000000000000C000000000000000)
   ret fp128 %A
@@ -80,7 +81,8 @@ define fp128 @log_e_negative_2(){
 
 define fp128 @log_e_0(){
 ; CHECK-LABEL: define fp128 @log_e_0() {
-; CHECK-NEXT:    ret fp128 0xL0000000000000000FFFF000000000000
+; CHECK-NEXT:    [[A:%.*]] = call fp128 @llvm.log.f128(fp128 noundef 0xL00000000000000000000000000000000)
+; CHECK-NEXT:    ret fp128 [[A]]
 ;
   %A = call fp128 @llvm.log.f128(fp128 noundef 0xL00000000000000000000000000000000)
   ret fp128 %A
@@ -88,7 +90,8 @@ define fp128 @log_e_0(){
 
 define fp128 @log_e_negative_0(){
 ; CHECK-LABEL: define fp128 @log_e_negative_0() {
-; CHECK-NEXT:    ret fp128 0xL0000000000000000FFFF000000000000
+; CHECK-NEXT:    [[A:%.*]] = call fp128 @llvm.log.f128(fp128 noundef 0xL00000000000000008000000000000000)
+; CHECK-NEXT:    ret fp128 [[A]]
 ;
   %A = call fp128 @llvm.log.f128(fp128 noundef 0xL00000000000000008000000000000000)
   ret fp128 %A
@@ -104,7 +107,8 @@ define fp128 @log_e_infinity(){
 
 define fp128 @log_e_negative_infinity(){
 ; CHECK-LABEL: define fp128 @log_e_negative_infinity() {
-; CHECK-NEXT:    ret fp128 0xL00000000000000007FFF800000000000
+; CHECK-NEXT:    [[A:%.*]] = call fp128 @llvm.log.f128(fp128 noundef 0xL0000000000000000FFFF000000000000)
+; CHECK-NEXT:    ret fp128 [[A]]
 ;
   %A = call fp128 @llvm.log.f128(fp128 noundef 0xL0000000000000000FFFF000000000000)
   ret fp128 %A
@@ -112,7 +116,8 @@ define fp128 @log_e_negative_infinity(){
 
 define fp128 @log_e_nan(){
 ; CHECK-LABEL: define fp128 @log_e_nan() {
-; CHECK-NEXT:    ret fp128 0xL00000000000000007FFF800000000001
+; CHECK-NEXT:    [[A:%.*]] = call fp128 @llvm.log.f128(fp128 noundef 0xL00000000000000007FFF000000000001)
+; CHECK-NEXT:    ret fp128 [[A]]
 ;
   %A = call fp128 @llvm.log.f128(fp128 noundef 0xL00000000000000007FFF000000000001)
   ret fp128 %A
@@ -120,7 +125,8 @@ define fp128 @log_e_nan(){
 
 define <2 x fp128> @log_e_negative_2_vector(){
 ; CHECK-LABEL: define <2 x fp128> @log_e_negative_2_vector() {
-; CHECK-NEXT:    ret <2 x fp128> <fp128 0xL00000000000000007FFF800000000000, fp128 0xL00000000000000007FFF800000000000>
+; CHECK-NEXT:    [[A:%.*]] = call <2 x fp128> @llvm.log.v2f128(<2 x fp128> <fp128 0xL0000000000000000C000000000000000, fp128 0xL0000000000000000C000000000000001>)
+; CHECK-NEXT:    ret <2 x fp128> [[A]]
 ;
   %A = call <2 x fp128> @llvm.log.v2f128(<2 x fp128> <fp128 0xL0000000000000000C000000000000000, fp128 0xL0000000000000000C000000000000001>)
   ret <2 x fp128> %A
@@ -138,7 +144,7 @@ define fp128 @logl_e_64(){
 define fp128 @logl_e_0(){
 ; CHECK-LABEL: define fp128 @logl_e_0() {
 ; CHECK-NEXT:    [[A:%.*]] = call fp128 @logl(fp128 noundef 0xL00000000000000000000000000000000)
-; CHECK-NEXT:    ret fp128 0xL0000000000000000FFFF000000000000
+; CHECK-NEXT:    ret fp128 [[A]]
 ;
   %A = call fp128 @logl(fp128 noundef 0xL00000000000000000000000000000000)
   ret fp128 %A
@@ -156,7 +162,7 @@ define fp128 @logl_e_infinity(){
 define fp128 @logl_e_nan(){
 ; CHECK-LABEL: define fp128 @logl_e_nan() {
 ; CHECK-NEXT:    [[A:%.*]] = call fp128 @logl(fp128 noundef 0xL00000000000000007FFF000000000001)
-; CHECK-NEXT:    ret fp128 0xL00000000000000007FFF800000000001
+; CHECK-NEXT:    ret fp128 [[A]]
 ;
   %A = call fp128 @logl(fp128 noundef 0xL00000000000000007FFF000000000001)
   ret fp128 %A
@@ -166,7 +172,7 @@ define fp128 @logl_e_nan(){
 define fp128 @logl_e_negative_2(){
 ; CHECK-LABEL: define fp128 @logl_e_negative_2() {
 ; CHECK-NEXT:    [[A:%.*]] = call fp128 @logl(fp128 noundef 0xL0000000000000000C000000000000000)
-; CHECK-NEXT:    ret fp128 0xL00000000000000007FFF800000000000
+; CHECK-NEXT:    ret fp128 [[A]]
 ;
   %A = call fp128 @logl(fp128 noundef 0xL0000000000000000C000000000000000)
   ret fp128 %A

--- a/llvm/test/Transforms/InstSimplify/ConstProp/logf128.ll
+++ b/llvm/test/Transforms/InstSimplify/ConstProp/logf128.ll
@@ -72,8 +72,7 @@ define fp128 @log_e_smallest_number_larger_than_one(){
 
 define fp128 @log_e_negative_2(){
 ; CHECK-LABEL: define fp128 @log_e_negative_2() {
-; CHECK-NEXT:    [[A:%.*]] = call fp128 @llvm.log.f128(fp128 noundef 0xL0000000000000000C000000000000000)
-; CHECK-NEXT:    ret fp128 [[A]]
+; CHECK-NEXT:    ret fp128 0xL00000000000000007FFF800000000000
 ;
   %A = call fp128 @llvm.log.f128(fp128 noundef 0xL0000000000000000C000000000000000)
   ret fp128 %A
@@ -81,8 +80,7 @@ define fp128 @log_e_negative_2(){
 
 define fp128 @log_e_0(){
 ; CHECK-LABEL: define fp128 @log_e_0() {
-; CHECK-NEXT:    [[A:%.*]] = call fp128 @llvm.log.f128(fp128 noundef 0xL00000000000000000000000000000000)
-; CHECK-NEXT:    ret fp128 [[A]]
+; CHECK-NEXT:    ret fp128 0xL0000000000000000FFFF000000000000
 ;
   %A = call fp128 @llvm.log.f128(fp128 noundef 0xL00000000000000000000000000000000)
   ret fp128 %A
@@ -90,8 +88,7 @@ define fp128 @log_e_0(){
 
 define fp128 @log_e_negative_0(){
 ; CHECK-LABEL: define fp128 @log_e_negative_0() {
-; CHECK-NEXT:    [[A:%.*]] = call fp128 @llvm.log.f128(fp128 noundef 0xL00000000000000008000000000000000)
-; CHECK-NEXT:    ret fp128 [[A]]
+; CHECK-NEXT:    ret fp128 0xL0000000000000000FFFF000000000000
 ;
   %A = call fp128 @llvm.log.f128(fp128 noundef 0xL00000000000000008000000000000000)
   ret fp128 %A
@@ -107,8 +104,7 @@ define fp128 @log_e_infinity(){
 
 define fp128 @log_e_negative_infinity(){
 ; CHECK-LABEL: define fp128 @log_e_negative_infinity() {
-; CHECK-NEXT:    [[A:%.*]] = call fp128 @llvm.log.f128(fp128 noundef 0xL0000000000000000FFFF000000000000)
-; CHECK-NEXT:    ret fp128 [[A]]
+; CHECK-NEXT:    ret fp128 0xL00000000000000007FFF800000000000
 ;
   %A = call fp128 @llvm.log.f128(fp128 noundef 0xL0000000000000000FFFF000000000000)
   ret fp128 %A
@@ -116,8 +112,7 @@ define fp128 @log_e_negative_infinity(){
 
 define fp128 @log_e_nan(){
 ; CHECK-LABEL: define fp128 @log_e_nan() {
-; CHECK-NEXT:    [[A:%.*]] = call fp128 @llvm.log.f128(fp128 noundef 0xL00000000000000007FFF000000000001)
-; CHECK-NEXT:    ret fp128 [[A]]
+; CHECK-NEXT:    ret fp128 0xL00000000000000007FFF800000000001
 ;
   %A = call fp128 @llvm.log.f128(fp128 noundef 0xL00000000000000007FFF000000000001)
   ret fp128 %A
@@ -125,8 +120,7 @@ define fp128 @log_e_nan(){
 
 define <2 x fp128> @log_e_negative_2_vector(){
 ; CHECK-LABEL: define <2 x fp128> @log_e_negative_2_vector() {
-; CHECK-NEXT:    [[A:%.*]] = call <2 x fp128> @llvm.log.v2f128(<2 x fp128> <fp128 0xL0000000000000000C000000000000000, fp128 0xL0000000000000000C000000000000001>)
-; CHECK-NEXT:    ret <2 x fp128> [[A]]
+; CHECK-NEXT:    ret <2 x fp128> <fp128 0xL00000000000000007FFF800000000000, fp128 0xL00000000000000007FFF800000000000>
 ;
   %A = call <2 x fp128> @llvm.log.v2f128(<2 x fp128> <fp128 0xL0000000000000000C000000000000000, fp128 0xL0000000000000000C000000000000001>)
   ret <2 x fp128> %A


### PR DESCRIPTION
This is a follow up patch from #90611 which folds logl calls in the same manner as log.f128 calls. logl suffers from the same problem as logf128 of having slow calls to fp128 log functions which can be constant folded. However, logl is emitted with -fmath-errno and log.f128 is emitted by -fno-math-errno by certain intrinsics.