### PR TITLE
[clang][dataflow] Handle `AtomicExpr` in `ResultObjectVisitor`.

### DIFF
--- a/clang/lib/Analysis/FlowSensitive/DataflowEnvironment.cpp
+++ b/clang/lib/Analysis/FlowSensitive/DataflowEnvironment.cpp
@@ -415,7 +415,7 @@ public:
     // below them can initialize the same object (or part of it).
     if (isa<CXXConstructExpr>(E) || isa<CallExpr>(E) || isa<LambdaExpr>(E) ||
         isa<CXXDefaultArgExpr>(E) || isa<CXXDefaultInitExpr>(E) ||
-        isa<CXXStdInitializerListExpr>(E) ||
+        isa<CXXStdInitializerListExpr>(E) || isa<AtomicExpr>(E) ||
         // We treat `BuiltinBitCastExpr` as an "original initializer" too as
         // it may not even be casting from a record type -- and even if it is,
         // the two objects are in general of unrelated type.


### PR DESCRIPTION
This is one of the node kinds that should be considered an "original
initializer". The patch adds a test that was causing an assertion failure in
`assert(Children.size() == 1)` without the fix.
