### PR TITLE
[LLD][ELF] ignore ".so" in search path when relocatable set

### DIFF
--- a/lld/ELF/DriverUtils.cpp
+++ b/lld/ELF/DriverUtils.cpp
@@ -234,7 +234,7 @@ std::optional<std::string> elf::findFromSearchPaths(StringRef path) {
 // search paths.
 std::optional<std::string> elf::searchLibraryBaseName(StringRef name) {
   for (StringRef dir : config->searchPaths) {
-    if (!config->isStatic)
+    if (!(config->isStatic || config->relocatable))
       if (std::optional<std::string> s = findFile(dir, "lib" + name + ".so"))
         return s;
     if (std::optional<std::string> s = findFile(dir, "lib" + name + ".a"))

--- a/lld/test/ELF/libsearch.s
+++ b/lld/test/ELF/libsearch.s
@@ -49,6 +49,12 @@
 // RUN: ld.lld -o %t3 %t.o -L%t.dir -lls
 // RUN: llvm-readobj --symbols %t3 | FileCheck --check-prefix=DYNAMIC %s
 
+// Should use static when dynamic exists in search path
+// RUN: ld.lld --relocatable -o %t3 %t.o -L%t.dir -lls
+// RUN: llvm-readelf -s -h %t3 | FileCheck --check-prefix=RELOCATABLE %s
+// RELOCATABLE: Type: REL (Relocatable file)
+// RELOCATABLE: [[#]] _static
+
 // Check for library search order
 // RUN: mkdir -p %t.dir2
 // RUN: cp %t.dir/libls.a %t.dir2


### PR DESCRIPTION
closes: https://github.com/llvm/llvm-project/issues/94958

fixes:
```
$ lld -r test.o -o test -L./libs -ltest
lld: error: attempted static link of dynamic object ./libs/libtest.so
```

when both libtest.a and libtest.so exist in the search path

test:
```
mkdir libs
echo void empty(void) { } > test.c
clang test.c -c
clang test.c --shared -o libs/libtest.so
ar rc libs/libtest.a test.o
lld -r test.o -o test -L./libs -ltest
```