### PR TITLE
[libc][math][c23] Temporarily disable modff16 on AArch64

### DIFF
--- a/libc/config/linux/aarch64/entrypoints.txt
+++ b/libc/config/linux/aarch64/entrypoints.txt
@@ -526,7 +526,7 @@ if(LIBC_TYPES_HAS_FLOAT16)
     libc.src.math.logbf16
     libc.src.math.lrintf16
     libc.src.math.lroundf16
-    libc.src.math.modff16
+    # libc.src.math.modff16
     libc.src.math.nanf16
     libc.src.math.nearbyintf16
     libc.src.math.nextafterf16


### PR DESCRIPTION
See Buildbot failure: https://lab.llvm.org/buildbot/#/builders/138/builds/67428.
