### PR TITLE
[lit] Skip xunit test on Windows only

### DIFF
--- a/llvm/utils/lit/tests/xunit-output.py
+++ b/llvm/utils/lit/tests/xunit-output.py
@@ -1,4 +1,4 @@
-# REQUIRES: shell
+# UNSUPPORTED: system-windows
 
 # Check xunit output
 # RUN: rm -rf %t.xunit.xml


### PR DESCRIPTION
This test works on Linux with lit's internal shell. It fails on Windows
because sh is not available.
