### PR TITLE
[libc][math][c23] Temporarily disable float16 on RISC-V

### DIFF
--- a/libc/include/llvm-libc-macros/float16-macros.h
+++ b/libc/include/llvm-libc-macros/float16-macros.h
@@ -10,7 +10,8 @@
 #define LLVM_LIBC_MACROS_FLOAT16_MACROS_H
 
 #if defined(__FLT16_MANT_DIG__) &&                                             \
-    (!defined(__GNUC__) || __GNUC__ >= 13 || defined(__clang__))
+    (!defined(__GNUC__) || __GNUC__ >= 13 || defined(__clang__)) &&            \
+    !defined(__riscv)
 #define LIBC_TYPES_HAS_FLOAT16
 #endif
 


### PR DESCRIPTION
See Buildbot failures:

- https://lab.llvm.org/buildbot/#/builders/257/builds/13450
- https://lab.llvm.org/buildbot/#/builders/256/builds/14531
