### PR TITLE
[libc++][TZDB] Adds basics of zoned_time class.

### DIFF
--- a/libcxx/docs/Status/Cxx20Issues.csv
+++ b/libcxx/docs/Status/Cxx20Issues.csv
@@ -165,7 +165,7 @@
 "`3225 <https://wg21.link/LWG3225>`__","``zoned_time``\  converting constructor shall not be ``noexcept``\ ","Belfast","","","|chrono|"
 "`3190 <https://wg21.link/LWG3190>`__","``std::allocator::allocate``\  sometimes returns too little storage","Belfast","|Complete|","14.0"
 "`3218 <https://wg21.link/LWG3218>`__","Modifier for ``%d``\  parse flag does not match POSIX and ``format``\  specification","Belfast","","","|chrono| |format|"
-"`3224 <https://wg21.link/LWG3224>`__","``zoned_time``\  constructor from ``TimeZonePtr``\  does not specify initialization of ``tp_``\ ","Belfast","","","|chrono|"
+"`3224 <https://wg21.link/LWG3224>`__","``zoned_time``\  constructor from ``TimeZonePtr``\  does not specify initialization of ``tp_``\ ","Belfast","|Complete|","19.0","|chrono|"
 "`3230 <https://wg21.link/LWG3230>`__","Format specifier ``%y/%Y``\  is missing locale alternative versions","Belfast","|Complete|","16.0","|chrono| |format|"
 "`3232 <https://wg21.link/LWG3232>`__","Inconsistency in ``zoned_time``\  deduction guides","Belfast","","","|chrono|"
 "`3222 <https://wg21.link/LWG3222>`__","P0574R1 introduced preconditions on non-existent parameters","Belfast","",""

--- a/libcxx/include/__chrono/zoned_time.h
+++ b/libcxx/include/__chrono/zoned_time.h
@@ -16,14 +16,21 @@
 // Enable the contents of the header only when libc++ was built with experimental features enabled.
 #if !defined(_LIBCPP_HAS_NO_EXPERIMENTAL_TZDB)
 
+#  include <__chrono/duration.h>
+#  include <__chrono/system_clock.h>
 #  include <__chrono/time_zone.h>
 #  include <__chrono/tzdb_list.h>
 #  include <__config>
 #  include <__fwd/string_view.h>
+#  include <__type_traits/common_type.h>
+#  include <__utility/move.h>
 
 #  if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
 #    pragma GCC system_header
 #  endif
+
+_LIBCPP_PUSH_MACROS
+#  include <__undef_macros>
 
 _LIBCPP_BEGIN_NAMESPACE_STD
 
@@ -43,12 +50,56 @@ struct zoned_traits<const time_zone*> {
   }
 };
 
+template <class _Duration, class _TimeZonePtr = const time_zone*>
+class zoned_time {
+  // [time.zone.zonedtime.ctor]/2
+  static_assert(__is_duration<_Duration>::value,
+                "the program is ill-formed since _Duration is not a specialization of std::chrono::duration");
+
+  using __traits = zoned_traits<_TimeZonePtr>;
+
+public:
+  using duration = common_type_t<_Duration, seconds>;
+
+  _LIBCPP_HIDE_FROM_ABI zoned_time()
+    requires requires { __traits::default_zone(); }
+      : __zone_{__traits::default_zone()}, __tp_{} {}
+
+  _LIBCPP_HIDE_FROM_ABI zoned_time(const zoned_time&)            = default;
+  _LIBCPP_HIDE_FROM_ABI zoned_time& operator=(const zoned_time&) = default;
+
+  _LIBCPP_HIDE_FROM_ABI zoned_time(const sys_time<_Duration>& __tp)
+    requires requires { __traits::default_zone(); }
+      : __zone_{__traits::default_zone()}, __tp_{__tp} {}
+
+  _LIBCPP_HIDE_FROM_ABI explicit zoned_time(_TimeZonePtr __zone) : __zone_{std::move(__zone)}, __tp_{} {}
+
+  _LIBCPP_HIDE_FROM_ABI explicit zoned_time(string_view __name)
+    requires(requires { __traits::locate_zone(string_view{}); } &&
+             // The wording uses the constraint
+             //   constructible_from<zoned_time, decltype(__traits::locate_zone(string_view{}))>
+             // Using this constraint in the code causes the compiler to give an
+             // error the constraint depends on itself. To avoid that issue use
+             // the fact it is possible to create this object from a _TimeZonePtr.
+             constructible_from<_TimeZonePtr, decltype(__traits::locate_zone(string_view{}))>)
+      : __zone_{__traits::locate_zone(__name)}, __tp_{} {}
+
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI _TimeZonePtr get_time_zone() const { return __zone_; }
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI sys_time<duration> get_sys_time() const { return __tp_; }
+
+private:
+  _TimeZonePtr __zone_;
+  sys_time<duration> __tp_;
+};
+
 } // namespace chrono
 
 #  endif // _LIBCPP_STD_VER >= 20 && !defined(_LIBCPP_HAS_NO_TIME_ZONE_DATABASE) && !defined(_LIBCPP_HAS_NO_FILESYSTEM)
          // && !defined(_LIBCPP_HAS_NO_LOCALIZATION)
 
 _LIBCPP_END_NAMESPACE_STD
+
+_LIBCPP_POP_MACROS
 
 #endif // !defined(_LIBCPP_HAS_NO_EXPERIMENTAL_TZDB)
 

--- a/libcxx/include/chrono
+++ b/libcxx/include/chrono
@@ -789,6 +789,10 @@ strong_ordering operator<=>(const time_zone& x, const time_zone& y) noexcept;   
 // [time.zone.zonedtraits], class template zoned_traits
 template<class T> struct zoned_traits;                                           // C++20
 
+// [time.zone.zonedtime], class template zoned_time
+template<class Duration, class TimeZonePtr = const time_zone*>                   // C++20
+class zoned_time;
+
 // [time.zone.leap], leap second support
 class leap_second {                                                              // C++20
 public:

--- a/libcxx/modules/std/chrono.inc
+++ b/libcxx/modules/std/chrono.inc
@@ -230,10 +230,10 @@ export namespace std {
     // [time.zone.zonedtraits], class template zoned_traits
     using std::chrono::zoned_traits;
 
-#    if 0
     // [time.zone.zonedtime], class template zoned_time
     using std::chrono::zoned_time;
 
+#    if 0
     using std::chrono::zoned_seconds;
 #    endif // if 0
 

--- a/libcxx/test/libcxx/diagnostics/chrono.nodiscard.verify.cpp
+++ b/libcxx/test/libcxx/diagnostics/chrono.nodiscard.verify.cpp
@@ -78,4 +78,10 @@ void test() {
     t::default_zone();  // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
     t::locate_zone(""); // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
   }
+
+  {
+    std::chrono::zoned_time<std::chrono::seconds> zt;
+    zt.get_time_zone(); // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+    zt.get_sys_time();  // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+  }
 }

--- a/libcxx/test/std/time/time.zone/time.zone.zonedtime/copy.assign.pass.cpp
+++ b/libcxx/test/std/time/time.zone/time.zone.zonedtime/copy.assign.pass.cpp
@@ -1,0 +1,39 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: c++03, c++11, c++14, c++17
+// UNSUPPORTED: no-filesystem, no-localization, no-tzdb
+
+// XFAIL: libcpp-has-no-experimental-tzdb
+// XFAIL: availability-tzdb-missing
+
+// <chrono>
+
+// template<class Duration, class TimeZonePtr = const time_zone*>
+// class zoned_time;
+//
+// zoned_time& operator=(const zoned_time&) = default;
+
+#include <cassert>
+#include <chrono>
+#include <concepts>
+
+int main(int, char**) {
+  std::chrono::zoned_time<std::chrono::seconds> zt{std::chrono::sys_seconds{std::chrono::seconds{42}}};
+  assert(zt.get_time_zone() == std::chrono::locate_zone("UTC"));
+  assert(zt.get_sys_time() == std::chrono::sys_seconds{std::chrono::seconds{42}});
+
+  std::chrono::zoned_time<std::chrono::seconds> copy;
+  copy                                                                               = zt;
+  std::same_as<std::chrono::zoned_time<std::chrono::seconds>&> decltype(auto) result = (copy = zt);
+  assert(&result == &copy);
+  assert(copy.get_time_zone() == std::chrono::locate_zone("UTC"));
+  assert(copy.get_sys_time() == std::chrono::sys_seconds{std::chrono::seconds{42}});
+
+  return 0;
+}

--- a/libcxx/test/std/time/time.zone/time.zone.zonedtime/copy.ctor.pass.cpp
+++ b/libcxx/test/std/time/time.zone/time.zone.zonedtime/copy.ctor.pass.cpp
@@ -1,0 +1,43 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: c++03, c++11, c++14, c++17
+// UNSUPPORTED: no-filesystem, no-localization, no-tzdb
+
+// XFAIL: libcpp-has-no-experimental-tzdb
+// XFAIL: availability-tzdb-missing
+
+// <chrono>
+
+// template<class Duration, class TimeZonePtr = const time_zone*>
+// class zoned_time;
+//
+// zoned_time(const zoned_time&) = default;
+
+#include <cassert>
+#include <chrono>
+
+int main(int, char**) {
+  std::chrono::zoned_time<std::chrono::seconds> zt{std::chrono::sys_seconds{std::chrono::seconds{42}}};
+  assert(zt.get_time_zone() == std::chrono::locate_zone("UTC"));
+  assert(zt.get_sys_time() == std::chrono::sys_seconds{std::chrono::seconds{42}});
+
+  {
+    std::chrono::zoned_time<std::chrono::seconds> copy{zt};
+    assert(copy.get_time_zone() == std::chrono::locate_zone("UTC"));
+    assert(copy.get_sys_time() == std::chrono::sys_seconds{std::chrono::seconds{42}});
+  }
+
+  {
+    std::chrono::zoned_time<std::chrono::seconds> copy = zt;
+    assert(copy.get_time_zone() == std::chrono::locate_zone("UTC"));
+    assert(copy.get_sys_time() == std::chrono::sys_seconds{std::chrono::seconds{42}});
+  }
+
+  return 0;
+}

--- a/libcxx/test/std/time/time.zone/time.zone.zonedtime/test_offset_time_zone.h
+++ b/libcxx/test/std/time/time.zone/time.zone.zonedtime/test_offset_time_zone.h
@@ -1,0 +1,68 @@
+// -*- C++ -*-
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef TEST_STD_TIME_TIME_ZONE_TIME_ZONE_ZONEDTIME_TEST_OFFSET_TIME_ZONE_H
+#define TEST_STD_TIME_TIME_ZONE_TIME_ZONE_ZONEDTIME_TEST_OFFSET_TIME_ZONE_H
+
+#include <cassert>
+#include <charconv>
+#include <chrono>
+#include <string_view>
+
+enum class offset_time_zone_flags {
+  none             = 0,
+  has_default_zone = 1,
+  has_locate_zone  = 2,
+  both             = has_default_zone | has_locate_zone
+};
+
+// The enforcement of the flags is done in the zoned_traits
+template <offset_time_zone_flags flags = offset_time_zone_flags::both>
+class offset_time_zone {
+public:
+  offset_time_zone() : offset_{std::chrono::seconds{0}} {}
+  explicit offset_time_zone(std::string_view name) {
+    int count;
+    const char* begin             = name.data();
+    const char* end               = begin + name.size();
+    std::from_chars_result result = std::from_chars(begin, end, count);
+    assert(result == std::from_chars_result(end, std::errc{}));
+
+    offset_ = std::chrono::seconds(count);
+  }
+
+  std::chrono::seconds offset() const { return offset_; }
+
+private:
+  std::chrono::seconds offset_;
+};
+
+template <>
+struct std::chrono::zoned_traits<offset_time_zone<offset_time_zone_flags::has_default_zone>> {
+  using type = offset_time_zone<offset_time_zone_flags::has_default_zone>;
+
+  static type default_zone() { return {}; }
+};
+
+template <>
+struct std::chrono::zoned_traits<offset_time_zone<offset_time_zone_flags::has_locate_zone>> {
+  using type = offset_time_zone<offset_time_zone_flags::has_locate_zone>;
+
+  static type locate_zone(std::string_view name) { return type{name}; }
+};
+
+template <>
+struct std::chrono::zoned_traits<offset_time_zone<offset_time_zone_flags::both>> {
+  using type = offset_time_zone<offset_time_zone_flags::both>;
+
+  static type default_zone() { return {}; }
+  static type locate_zone(std::string_view name) { return type{name}; }
+};
+
+#endif // TEST_STD_TIME_TIME_ZONE_TIME_ZONE_ZONEDTIME_TEST_OFFSET_TIME_ZONE_H

--- a/libcxx/test/std/time/time.zone/time.zone.zonedtime/time.zone.zonedtime.ctor/default.pass.cpp
+++ b/libcxx/test/std/time/time.zone/time.zone.zonedtime/time.zone.zonedtime.ctor/default.pass.cpp
@@ -1,0 +1,66 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: c++03, c++11, c++14, c++17
+// UNSUPPORTED: no-filesystem, no-localization, no-tzdb
+
+// XFAIL: libcpp-has-no-experimental-tzdb
+// XFAIL: availability-tzdb-missing
+
+// <chrono>
+
+// template<class Duration, class TimeZonePtr = const time_zone*>
+// class zoned_time;
+//
+// zoned_time();
+
+#include <chrono>
+#include <concepts>
+#include <type_traits>
+
+#include "../test_offset_time_zone.h"
+
+// Verify the results of the default constructed object,
+// and whether the constructor's constraints are satisfied.
+int main(int, char**) {
+  {
+    static_assert(std::default_initializable<std::chrono::zoned_time<std::chrono::seconds>>);
+    std::chrono::zoned_time<std::chrono::seconds> zt;
+    assert(zt.get_time_zone() == std::chrono::locate_zone("UTC"));
+    assert(zt.get_sys_time() == std::chrono::sys_seconds{});
+  }
+
+  static_assert(!std::default_initializable<
+                std::chrono::zoned_time<std::chrono::seconds, offset_time_zone<offset_time_zone_flags::none>>>);
+
+  {
+    using type = offset_time_zone<offset_time_zone_flags::has_default_zone>;
+    static_assert(std::default_initializable<std::chrono::zoned_time<std::chrono::seconds, type>>);
+
+    std::chrono::zoned_time<std::chrono::seconds, type> zt;
+
+    assert(zt.get_time_zone().offset() == std::chrono::seconds{0});
+    assert(zt.get_sys_time() == std::chrono::sys_seconds{});
+  }
+
+  static_assert(
+      !std::default_initializable<
+          std::chrono::zoned_time<std::chrono::seconds, offset_time_zone<offset_time_zone_flags::has_locate_zone>>>);
+
+  {
+    using type = offset_time_zone<offset_time_zone_flags::both>;
+    static_assert(std::default_initializable<std::chrono::zoned_time<std::chrono::seconds, type>>);
+
+    std::chrono::zoned_time<std::chrono::seconds, type> zt;
+
+    assert(zt.get_time_zone().offset() == std::chrono::seconds{0});
+    assert(zt.get_sys_time() == std::chrono::sys_seconds{});
+  }
+
+  return 0;
+}

--- a/libcxx/test/std/time/time.zone/time.zone.zonedtime/time.zone.zonedtime.ctor/string_view.pass.cpp
+++ b/libcxx/test/std/time/time.zone/time.zone.zonedtime/time.zone.zonedtime.ctor/string_view.pass.cpp
@@ -1,0 +1,77 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: c++03, c++11, c++14, c++17
+// UNSUPPORTED: no-filesystem, no-localization, no-tzdb
+
+// XFAIL: libcpp-has-no-experimental-tzdb
+// XFAIL: availability-tzdb-missing
+
+// <chrono>
+
+// template<class Duration, class TimeZonePtr = const time_zone*>
+// class zoned_time;
+//
+// explicit zoned_time(string_view name);
+
+#include <chrono>
+#include <concepts>
+
+#include "../test_offset_time_zone.h"
+
+// Verify the results of the constructed object.
+int main(int, char**) {
+  {
+    using ptr = const std::chrono::time_zone*;
+    static_assert(std::constructible_from<std::chrono::zoned_time<std::chrono::seconds, ptr>, std::string_view>);
+    static_assert(!std::convertible_to<std::string_view, std::chrono::zoned_time<std::chrono::seconds, ptr>>);
+
+    std::chrono::zoned_time<std::chrono::seconds> zt{"UTC"};
+
+    assert(zt.get_time_zone() == std::chrono::locate_zone("UTC"));
+    assert(zt.get_sys_time() == std::chrono::sys_seconds{});
+  }
+
+  {
+    using ptr = offset_time_zone<offset_time_zone_flags::none>;
+    static_assert(!std::constructible_from<std::chrono::zoned_time<std::chrono::seconds, ptr>, std::string_view>);
+    static_assert(!std::convertible_to<std::string_view, std::chrono::zoned_time<std::chrono::seconds, ptr>>);
+  }
+
+  {
+    using ptr = offset_time_zone<offset_time_zone_flags::has_default_zone>;
+    static_assert(!std::constructible_from<std::chrono::zoned_time<std::chrono::seconds, ptr>, std::string_view>);
+    static_assert(!std::convertible_to<std::string_view, std::chrono::zoned_time<std::chrono::seconds, ptr>>);
+  }
+
+  {
+    using ptr = offset_time_zone<offset_time_zone_flags::has_locate_zone>;
+    static_assert(std::constructible_from<std::chrono::zoned_time<std::chrono::seconds, ptr>, std::string_view>);
+    static_assert(!std::convertible_to<std::string_view, std::chrono::zoned_time<std::chrono::seconds, ptr>>);
+
+    ptr tz;
+    std::chrono::zoned_time<std::chrono::seconds, ptr> zt{"42"};
+
+    assert(zt.get_time_zone().offset() == std::chrono::seconds{42});
+    assert(zt.get_sys_time() == std::chrono::sys_seconds{});
+  }
+
+  {
+    using ptr = offset_time_zone<offset_time_zone_flags::both>;
+    static_assert(std::constructible_from<std::chrono::zoned_time<std::chrono::seconds, ptr>, std::string_view>);
+    static_assert(!std::convertible_to<std::string_view, std::chrono::zoned_time<std::chrono::seconds, ptr>>);
+
+    ptr tz;
+    std::chrono::zoned_time<std::chrono::seconds, ptr> zt{"42"};
+
+    assert(zt.get_time_zone().offset() == std::chrono::seconds{42});
+    assert(zt.get_sys_time() == std::chrono::sys_seconds{});
+  }
+
+  return 0;
+}

--- a/libcxx/test/std/time/time.zone/time.zone.zonedtime/time.zone.zonedtime.ctor/sys_time.pass.cpp
+++ b/libcxx/test/std/time/time.zone/time.zone.zonedtime/time.zone.zonedtime.ctor/sys_time.pass.cpp
@@ -1,0 +1,138 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: c++03, c++11, c++14, c++17
+// UNSUPPORTED: no-filesystem, no-localization, no-tzdb
+
+// XFAIL: libcpp-has-no-experimental-tzdb
+// XFAIL: availability-tzdb-missing
+
+// <chrono>
+
+// template<class Duration, class TimeZonePtr = const time_zone*>
+// class zoned_time;
+//
+// zoned_time(const sys_time<Duration>& st);
+
+#include <chrono>
+#include <concepts>
+#include <type_traits>
+
+#include "../test_offset_time_zone.h"
+
+static void test_construction() {
+  static_assert(std::constructible_from<std::chrono::zoned_time<std::chrono::seconds>, std::chrono::sys_seconds>);
+  std::chrono::zoned_time<std::chrono::seconds> zt{std::chrono::sys_seconds{std::chrono::seconds{42}}};
+  assert(zt.get_time_zone() == std::chrono::locate_zone("UTC"));
+  assert(zt.get_sys_time() == std::chrono::sys_seconds{std::chrono::seconds{42}});
+}
+
+static void test_conversion() {
+  static_assert(std::convertible_to<std::chrono::sys_seconds, std::chrono::zoned_time<std::chrono::seconds>>);
+  std::chrono::zoned_time<std::chrono::seconds> zt = std::chrono::sys_seconds{std::chrono::seconds{42}};
+  assert(zt.get_time_zone() == std::chrono::locate_zone("UTC"));
+  assert(zt.get_sys_time() == std::chrono::sys_seconds{std::chrono::seconds{42}});
+}
+
+static void test_duration_conversion() {
+  {
+    using duration   = std::chrono::nanoseconds;
+    using time_point = std::chrono::sys_time<duration>;
+    std::chrono::zoned_time<duration> zt{time_point{duration{42}}};
+    assert(zt.get_sys_time() == time_point{duration{42}});
+  }
+  {
+    using duration   = std::chrono::microseconds;
+    using time_point = std::chrono::sys_time<duration>;
+    std::chrono::zoned_time<duration> zt{time_point{duration{42}}};
+    assert(zt.get_sys_time() == time_point{duration{42}});
+  }
+  {
+    using duration   = std::chrono::milliseconds;
+    using time_point = std::chrono::sys_time<duration>;
+    std::chrono::zoned_time<duration> zt{time_point{duration{42}}};
+    assert(zt.get_sys_time() == time_point{duration{42}});
+  }
+  {
+    using duration   = std::chrono::seconds;
+    using time_point = std::chrono::sys_time<duration>;
+    std::chrono::zoned_time<duration> zt{time_point{duration{42}}};
+    assert(zt.get_sys_time() == time_point{duration{42}});
+  }
+  {
+    using duration   = std::chrono::days;
+    using time_point = std::chrono::sys_time<duration>;
+    std::chrono::zoned_time<duration> zt{time_point{duration{42}}};
+    assert(zt.get_sys_time() == std::chrono::sys_seconds{std::chrono::days{42}});
+  }
+  {
+    using duration   = std::chrono::weeks;
+    using time_point = std::chrono::sys_time<duration>;
+    std::chrono::zoned_time<duration> zt{time_point{duration{42}}};
+    assert(zt.get_sys_time() == std::chrono::sys_seconds{std::chrono::weeks{42}});
+  }
+  {
+    using duration   = std::chrono::months;
+    using time_point = std::chrono::sys_time<duration>;
+    std::chrono::zoned_time<duration> zt{time_point{duration{42}}};
+    assert(zt.get_sys_time() == std::chrono::sys_seconds{std::chrono::months{42}});
+  }
+  {
+    using duration   = std::chrono::years;
+    using time_point = std::chrono::sys_time<duration>;
+    std::chrono::zoned_time<duration> zt{time_point{duration{42}}};
+    assert(zt.get_sys_time() == std::chrono::sys_seconds{std::chrono::years{42}});
+  }
+}
+
+static void test_duration_constraints() {
+  static_assert(!std::constructible_from<
+                std::chrono::zoned_time<std::chrono::seconds, offset_time_zone<offset_time_zone_flags::none>>,
+                std::chrono::sys_seconds>);
+
+  {
+    using type = offset_time_zone<offset_time_zone_flags::has_default_zone>;
+    static_assert(
+        std::constructible_from<std::chrono::zoned_time<std::chrono::seconds, type>, std::chrono::sys_seconds>);
+
+    std::chrono::zoned_time<std::chrono::seconds, type> zt = std::chrono::sys_seconds{std::chrono::seconds{42}};
+
+    assert(zt.get_time_zone().offset() == std::chrono::seconds{0});
+    assert(zt.get_sys_time() == std::chrono::sys_seconds{std::chrono::seconds{42}});
+  }
+
+  static_assert(
+      !std::constructible_from<
+          std::chrono::zoned_time<std::chrono::seconds, offset_time_zone<offset_time_zone_flags::has_locate_zone>>,
+          std::chrono::sys_seconds>);
+
+  {
+    using type = offset_time_zone<offset_time_zone_flags::both>;
+    static_assert(
+        std::constructible_from<std::chrono::zoned_time<std::chrono::seconds, type>, std::chrono::sys_seconds>);
+
+    std::chrono::zoned_time<std::chrono::seconds, type> zt = std::chrono::sys_seconds{std::chrono::seconds{42}};
+
+    assert(zt.get_time_zone().offset() == std::chrono::seconds{0});
+    assert(zt.get_sys_time() == std::chrono::sys_seconds{std::chrono::seconds{42}});
+  }
+}
+
+// Verify:
+// - the results of the constructed object,
+// - conversion construction is possible,
+// - Duration is converted to zoned_time<>::duration, and
+// - whether the constructor's constraints are satisfied.
+int main(int, char**) {
+  test_construction();
+  test_conversion();
+  test_duration_conversion();
+  test_duration_constraints();
+
+  return 0;
+}

--- a/libcxx/test/std/time/time.zone/time.zone.zonedtime/time.zone.zonedtime.ctor/time_zone_pointer.pass.cpp
+++ b/libcxx/test/std/time/time.zone/time.zone.zonedtime/time.zone.zonedtime.ctor/time_zone_pointer.pass.cpp
@@ -1,0 +1,87 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: c++03, c++11, c++14, c++17
+// UNSUPPORTED: no-filesystem, no-localization, no-tzdb
+
+// XFAIL: libcpp-has-no-experimental-tzdb
+// XFAIL: availability-tzdb-missing
+
+// <chrono>
+
+// template<class Duration, class TimeZonePtr = const time_zone*>
+// class zoned_time;
+//
+// explicit zoned_time(TimeZonePtr z);
+
+#include <chrono>
+#include <concepts>
+
+#include "../test_offset_time_zone.h"
+
+// Verify the results of the constructed object.
+int main(int, char**) {
+  {
+    using ptr = const std::chrono::time_zone*;
+    static_assert(std::constructible_from<std::chrono::zoned_time<std::chrono::seconds, ptr>, ptr>);
+    static_assert(!std::convertible_to<ptr, std::chrono::zoned_time<std::chrono::seconds, ptr>>);
+
+    ptr tz = std::chrono::locate_zone("UTC");
+    std::chrono::zoned_time<std::chrono::seconds> zt{tz};
+
+    assert(zt.get_time_zone() == tz);
+    assert(zt.get_sys_time() == std::chrono::sys_seconds{});
+  }
+
+  {
+    using ptr = offset_time_zone<offset_time_zone_flags::none>;
+    static_assert(std::constructible_from<std::chrono::zoned_time<std::chrono::seconds, ptr>, ptr>);
+    static_assert(!std::convertible_to<ptr, std::chrono::zoned_time<std::chrono::seconds, ptr>>);
+
+    ptr tz;
+    std::chrono::zoned_time<std::chrono::seconds, ptr> zt{tz};
+
+    assert(zt.get_time_zone().offset() == tz.offset());
+    assert(zt.get_sys_time() == std::chrono::sys_seconds{});
+  }
+  {
+    using ptr = offset_time_zone<offset_time_zone_flags::has_default_zone>;
+    static_assert(std::constructible_from<std::chrono::zoned_time<std::chrono::seconds, ptr>, ptr>);
+    static_assert(!std::convertible_to<ptr, std::chrono::zoned_time<std::chrono::seconds, ptr>>);
+
+    ptr tz;
+    std::chrono::zoned_time<std::chrono::seconds, ptr> zt{tz};
+
+    assert(zt.get_time_zone().offset() == tz.offset());
+    assert(zt.get_sys_time() == std::chrono::sys_seconds{});
+  }
+  {
+    using ptr = offset_time_zone<offset_time_zone_flags::has_locate_zone>;
+    static_assert(std::constructible_from<std::chrono::zoned_time<std::chrono::seconds, ptr>, ptr>);
+    static_assert(!std::convertible_to<ptr, std::chrono::zoned_time<std::chrono::seconds, ptr>>);
+
+    ptr tz;
+    std::chrono::zoned_time<std::chrono::seconds, ptr> zt{tz};
+
+    assert(zt.get_time_zone().offset() == tz.offset());
+    assert(zt.get_sys_time() == std::chrono::sys_seconds{});
+  }
+  {
+    using ptr = offset_time_zone<offset_time_zone_flags::both>;
+    static_assert(std::constructible_from<std::chrono::zoned_time<std::chrono::seconds, ptr>, ptr>);
+    static_assert(!std::convertible_to<ptr, std::chrono::zoned_time<std::chrono::seconds, ptr>>);
+
+    ptr tz;
+    std::chrono::zoned_time<std::chrono::seconds, ptr> zt{tz};
+
+    assert(zt.get_time_zone().offset() == tz.offset());
+    assert(zt.get_sys_time() == std::chrono::sys_seconds{});
+  }
+
+  return 0;
+}

--- a/libcxx/test/std/time/time.zone/time.zone.zonedtime/time.zone.zonedtime.members/get_sys_time.pass.cpp
+++ b/libcxx/test/std/time/time.zone/time.zone.zonedtime/time.zone.zonedtime.members/get_sys_time.pass.cpp
@@ -1,0 +1,121 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: c++03, c++11, c++14, c++17
+// UNSUPPORTED: no-filesystem, no-localization, no-tzdb
+
+// XFAIL: libcpp-has-no-experimental-tzdb
+// XFAIL: availability-tzdb-missing
+
+// <chrono>
+
+// template<class Duration, class TimeZonePtr = const time_zone*>
+// class zoned_time;
+//
+// sys_time<duration> get_sys_time() const;
+
+#include <chrono>
+#include <concepts>
+
+#include "../test_offset_time_zone.h"
+
+static void test_const_member() {
+  {
+    using duration   = std::chrono::nanoseconds;
+    using time_point = std::chrono::sys_time<duration>;
+    std::chrono::zoned_time<duration> zt{time_point{duration{42}}};
+
+    std::same_as<time_point> decltype(auto) time = zt.get_sys_time();
+    assert(time == time_point{duration{42}});
+  }
+  {
+    using duration   = std::chrono::nanoseconds;
+    using time_point = std::chrono::sys_time<duration>;
+    const std::chrono::zoned_time<duration> zt{time_point{duration{42}}};
+
+    std::same_as<time_point> decltype(auto) time = zt.get_sys_time();
+    assert(time == time_point{duration{42}});
+  }
+}
+
+static void test_duration_conversion() {
+  // common_type_t<duration, seconds> -> duration
+  {
+    using duration   = std::chrono::nanoseconds;
+    using time_point = std::chrono::sys_time<duration>;
+    std::chrono::zoned_time<duration> zt{time_point{duration{42}}};
+
+    std::same_as<time_point> decltype(auto) time = zt.get_sys_time();
+    assert(time == time_point{duration{42}});
+  }
+  {
+    using duration   = std::chrono::microseconds;
+    using time_point = std::chrono::sys_time<duration>;
+    std::chrono::zoned_time<duration> zt{time_point{duration{42}}};
+
+    std::same_as<time_point> decltype(auto) time = zt.get_sys_time();
+    assert(time == time_point{duration{42}});
+  }
+  {
+    using duration   = std::chrono::milliseconds;
+    using time_point = std::chrono::sys_time<duration>;
+    std::chrono::zoned_time<duration> zt{time_point{duration{42}}};
+
+    std::same_as<time_point> decltype(auto) time = zt.get_sys_time();
+    assert(time == time_point{duration{42}});
+  }
+  // common_type_t<seconds, seconds> -> seconds
+  {
+    using duration   = std::chrono::seconds;
+    using time_point = std::chrono::sys_time<duration>;
+    std::chrono::zoned_time<duration> zt{time_point{duration{42}}};
+
+    std::same_as<time_point> decltype(auto) time = zt.get_sys_time();
+    assert(time == time_point{duration{42}});
+  }
+  // common_type_t<duration, seconds> -> seconds
+  {
+    using duration   = std::chrono::days;
+    using time_point = std::chrono::sys_time<duration>;
+    std::chrono::zoned_time<duration> zt{time_point{duration{42}}};
+
+    std::same_as<std::chrono::sys_seconds> decltype(auto) time = zt.get_sys_time();
+    assert(time == time_point{duration{42}});
+  }
+  {
+    using duration   = std::chrono::weeks;
+    using time_point = std::chrono::sys_time<duration>;
+    std::chrono::zoned_time<duration> zt{time_point{duration{42}}};
+
+    std::same_as<std::chrono::sys_seconds> decltype(auto) time = zt.get_sys_time();
+    assert(time == time_point{duration{42}});
+  }
+  {
+    using duration   = std::chrono::months;
+    using time_point = std::chrono::sys_time<duration>;
+    std::chrono::zoned_time<duration> zt{time_point{duration{42}}};
+
+    std::same_as<std::chrono::sys_seconds> decltype(auto) time = zt.get_sys_time();
+    assert(time == time_point{duration{42}});
+  }
+  {
+    using duration   = std::chrono::years;
+    using time_point = std::chrono::sys_time<duration>;
+    std::chrono::zoned_time<duration> zt{time_point{duration{42}}};
+
+    std::same_as<std::chrono::sys_seconds> decltype(auto) time = zt.get_sys_time();
+    assert(time == time_point{duration{42}});
+  }
+}
+
+int main(int, char**) {
+  test_const_member();
+  test_duration_conversion();
+
+  return 0;
+}

--- a/libcxx/test/std/time/time.zone/time.zone.zonedtime/time.zone.zonedtime.members/get_time_zone.pass.cpp
+++ b/libcxx/test/std/time/time.zone/time.zone.zonedtime/time.zone.zonedtime.members/get_time_zone.pass.cpp
@@ -1,0 +1,53 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: c++03, c++11, c++14, c++17
+// UNSUPPORTED: no-filesystem, no-localization, no-tzdb
+
+// XFAIL: libcpp-has-no-experimental-tzdb
+// XFAIL: availability-tzdb-missing
+
+// <chrono>
+
+// template<class Duration, class TimeZonePtr = const time_zone*>
+// class zoned_time;
+//
+// TimeZonePtr get_time_zone() const;
+
+#include <chrono>
+#include <concepts>
+
+#include "../test_offset_time_zone.h"
+
+int main(int, char**) {
+  {
+    const std::chrono::time_zone* tz = std::chrono::locate_zone("UTC");
+    std::chrono::zoned_time<std::chrono::seconds> zt{tz};
+
+    std::same_as<const std::chrono::time_zone*> decltype(auto) ptr = zt.get_time_zone();
+    assert(ptr = tz);
+  }
+
+  {
+    int tz = 0;
+    std::chrono::zoned_time<std::chrono::seconds, int*> zt{&tz};
+
+    std::same_as<int*> decltype(auto) ptr = zt.get_time_zone();
+    assert(ptr = &tz);
+  }
+
+  {
+    int tz = 0;
+    const std::chrono::zoned_time<std::chrono::seconds, int*> zt{&tz};
+
+    std::same_as<int*> decltype(auto) ptr = zt.get_time_zone();
+    assert(ptr = &tz);
+  }
+
+  return 0;
+}

--- a/libcxx/test/std/time/time.zone/time.zone.zonedtime/types.compile.pass.cpp
+++ b/libcxx/test/std/time/time.zone/time.zone.zonedtime/types.compile.pass.cpp
@@ -1,0 +1,63 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: c++03, c++11, c++14, c++17
+// UNSUPPORTED: no-filesystem, no-localization, no-tzdb
+
+// XFAIL: libcpp-has-no-experimental-tzdb
+// XFAIL: availability-tzdb-missing
+
+// <chrono>
+
+//  template<class Duration, class TimeZonePtr = const time_zone*>
+//  class zoned_time {
+//  public:
+//    using duration = common_type_t<Duration, seconds>;
+//  ...
+//    zoned_time(const zoned_time&) = default;
+//    zoned_time& operator=(const zoned_time&) = default;
+//
+//  };
+
+#include <chrono>
+#include <concepts>
+#include <type_traits>
+#include <memory>
+
+// Test the default template argument
+static_assert(std::same_as<std::chrono::zoned_time<std::chrono::days>,
+                           std::chrono::zoned_time<std::chrono::days, const std::chrono::time_zone*>>);
+
+// Test duration
+static_assert(std::same_as<std::chrono::zoned_time<std::chrono::nanoseconds>::duration, std::chrono::nanoseconds>);
+static_assert(std::same_as<std::chrono::zoned_time<std::chrono::microseconds>::duration, std::chrono::microseconds>);
+static_assert(std::same_as<std::chrono::zoned_time<std::chrono::milliseconds>::duration, std::chrono::milliseconds>);
+static_assert(std::same_as<std::chrono::zoned_time<std::chrono::seconds>::duration, std::chrono::seconds>);
+static_assert(std::same_as<std::chrono::zoned_time<std::chrono::days>::duration, std::chrono::seconds>);
+static_assert(std::same_as<std::chrono::zoned_time<std::chrono::weeks>::duration, std::chrono::seconds>);
+static_assert(std::same_as<std::chrono::zoned_time<std::chrono::months>::duration, std::chrono::seconds>);
+static_assert(std::same_as<std::chrono::zoned_time<std::chrono::years>::duration, std::chrono::seconds>);
+
+// Tests defaulted copy construct/assign and move construct/assign
+static_assert(std::is_copy_constructible_v<std::chrono::zoned_time<std::chrono::days>>);
+static_assert(std::is_move_constructible_v<std::chrono::zoned_time<std::chrono::days>>);
+static_assert(std::is_copy_assignable_v<std::chrono::zoned_time<std::chrono::days>>);
+static_assert(std::is_move_assignable_v<std::chrono::zoned_time<std::chrono::days>>);
+
+// There are no requirements for TimeZonePtr, so test with a non-pointer type.
+static_assert(std::is_copy_constructible_v<std::chrono::zoned_time<std::chrono::days, int>>);
+static_assert(std::is_move_constructible_v<std::chrono::zoned_time<std::chrono::days, int>>);
+static_assert(std::is_copy_assignable_v<std::chrono::zoned_time<std::chrono::days, int>>);
+static_assert(std::is_move_assignable_v<std::chrono::zoned_time<std::chrono::days, int>>);
+
+// Test with a move only type, since the copy constructor is defined, no move
+// constuctor is generated.
+static_assert(!std::is_copy_constructible_v<std::chrono::zoned_time< std::chrono::days, std::unique_ptr<int>>>);
+static_assert(!std::is_move_constructible_v<std::chrono::zoned_time< std::chrono::days, std::unique_ptr<int>>>);
+static_assert(!std::is_copy_assignable_v<std::chrono::zoned_time< std::chrono::days, std::unique_ptr<int>>>);
+static_assert(!std::is_move_assignable_v<std::chrono::zoned_time< std::chrono::days, std::unique_ptr<int>>>);

--- a/libcxx/test/std/time/time.zone/time.zone.zonedtime/types.verify.cpp
+++ b/libcxx/test/std/time/time.zone/time.zone.zonedtime/types.verify.cpp
@@ -1,0 +1,24 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: c++03, c++11, c++14, c++17
+// UNSUPPORTED: no-filesystem, no-localization, no-tzdb
+
+// XFAIL: libcpp-has-no-experimental-tzdb
+// XFAIL: availability-tzdb-missing
+
+// <chrono>
+
+// template<class Duration, class TimeZonePtr = const time_zone*>
+//
+// If Duration is not a specialization of chrono::duration, the program is ill-formed.
+
+#include <chrono>
+
+std::chrono::zoned_time<int>
+    v; // expected-error@*:* {{the program is ill-formed since _Duration is not a specialization of std::chrono::duration}}


### PR DESCRIPTION
This implements the class, its non-templated constructors and its getters to verify the construction.

Completes
- LWG3224 zoned_time constructor from TimeZonePtr does not specify initialization of tp_

Implements parts of:
- P0355 Extending chrono to Calendars and Time Zones