### PR TITLE
[clang] Move 'alpha.cplusplus.MisusedMovedObject' to 'cplusplus.Move' in documentation (NFC)

### DIFF
--- a/clang/docs/analyzer/checkers.rst
+++ b/clang/docs/analyzer/checkers.rst
@@ -416,6 +416,25 @@ around, such as ``std::string_view``.
    // note: inner buffer of 'std::string' deallocated by call to destructor
  }
 
+.. _cplusplus-Move:
+
+cplusplus.Move (C++)
+""""""""""""""""""""
+Method calls on a moved-from object and copying a moved-from object will be reported.
+
+
+.. code-block:: cpp
+
+  struct A {
+   void foo() {}
+ };
+
+ void f() {
+   A a;
+   A b = std::move(a); // note: 'a' became 'moved-from' here
+   a.foo();            // warn: method call on a 'moved-from' object 'a'
+ }
+
 .. _cplusplus-NewDelete:
 
 cplusplus.NewDelete (C++)
@@ -2597,25 +2616,6 @@ Check for use of iterators of different containers where iterators of the same c
                                                    //       used where the same
                                                    //       container is
                                                    //       expected
- }
-
-.. _alpha-cplusplus-MisusedMovedObject:
-
-alpha.cplusplus.MisusedMovedObject (C++)
-""""""""""""""""""""""""""""""""""""""""
-Method calls on a moved-from object and copying a moved-from object will be reported.
-
-
-.. code-block:: cpp
-
-  struct A {
-   void foo() {}
- };
-
- void f() {
-   A a;
-   A b = std::move(a); // note: 'a' became 'moved-from' here
-   a.foo();            // warn: method call on a 'moved-from' object 'a'
  }
 
 .. _alpha-cplusplus-SmartPtr:


### PR DESCRIPTION
The checker was renamed at some time ago but the documentation was not updated. The section is now just moved and renamed. The documentation is still very simple and needs improvement.