### PR TITLE
[libc++][test] Adjust expected hexfloat format

### DIFF
--- a/libcxx/test/std/localization/locale.categories/category.numeric/locale.nm.put/facet.num.put.members/put_double.hex.pass.cpp
+++ b/libcxx/test/std/localization/locale.categories/category.numeric/locale.nm.put/facet.num.put.members/put_double.hex.pass.cpp
@@ -28,12 +28,14 @@
 #  define SP_LC_SUFFIX ".0"
 #  define SP_LG_SUFFIX ";0"
 #  define PADDING "****************"
+#  define SP_PADDING "****************"
 #else
 #  define LC_SUFFIX ""
 #  define LG_SUFFIX ""
 #  define SP_LC_SUFFIX "."
 #  define SP_LG_SUFFIX ";"
-#  define PADDING "*****************"
+#  define PADDING "******************"
+#  define SP_PADDING "*****************"
 #endif
 
 typedef std::num_put<char, cpp17_output_iterator<char*> > F;
@@ -163,7 +165,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0x0" SP_LC_SUFFIX "p+0" PADDING);
+                                    assert(ex == "-0x0" SP_LC_SUFFIX "p+0" SP_PADDING);
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -171,7 +173,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == PADDING "-0x0" SP_LC_SUFFIX "p+0");
+                                    assert(ex == SP_PADDING "-0x0" SP_LC_SUFFIX "p+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -179,7 +181,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-" PADDING "0x0" SP_LC_SUFFIX "p+0");
+                                    assert(ex == "-" SP_PADDING "0x0" SP_LC_SUFFIX "p+0");
                                     assert(ios.width() == 0);
                                 }
                             }
@@ -197,7 +199,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0x0" SP_LG_SUFFIX "p+0" PADDING);
+                                    assert(ex == "-0x0" SP_LG_SUFFIX "p+0" SP_PADDING);
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -205,7 +207,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == PADDING "-0x0" SP_LG_SUFFIX "p+0");
+                                    assert(ex == SP_PADDING "-0x0" SP_LG_SUFFIX "p+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -213,7 +215,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-" PADDING "0x0" SP_LG_SUFFIX "p+0");
+                                    assert(ex == "-" SP_PADDING "0x0" SP_LG_SUFFIX "p+0");
                                     assert(ios.width() == 0);
                                 }
                             }
@@ -308,7 +310,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0x0" SP_LC_SUFFIX "p+0" PADDING);
+                                    assert(ex == "-0x0" SP_LC_SUFFIX "p+0" SP_PADDING);
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -316,7 +318,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == PADDING "-0x0" SP_LC_SUFFIX "p+0");
+                                    assert(ex == SP_PADDING "-0x0" SP_LC_SUFFIX "p+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -324,7 +326,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-" PADDING "0x0" SP_LC_SUFFIX "p+0");
+                                    assert(ex == "-" SP_PADDING "0x0" SP_LC_SUFFIX "p+0");
                                     assert(ios.width() == 0);
                                 }
                             }
@@ -342,7 +344,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0x0" SP_LG_SUFFIX "p+0" PADDING);
+                                    assert(ex == "-0x0" SP_LG_SUFFIX "p+0" SP_PADDING);
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -350,7 +352,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == PADDING "-0x0" SP_LG_SUFFIX "p+0");
+                                    assert(ex == SP_PADDING "-0x0" SP_LG_SUFFIX "p+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -358,7 +360,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-" PADDING "0x0" SP_LG_SUFFIX "p+0");
+                                    assert(ex == "-" SP_PADDING "0x0" SP_LG_SUFFIX "p+0");
                                     assert(ios.width() == 0);
                                 }
                             }
@@ -456,7 +458,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0X0" SP_LC_SUFFIX "P+0" PADDING);
+                                    assert(ex == "-0X0" SP_LC_SUFFIX "P+0" SP_PADDING);
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -464,7 +466,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == PADDING "-0X0" SP_LC_SUFFIX "P+0");
+                                    assert(ex == SP_PADDING "-0X0" SP_LC_SUFFIX "P+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -472,7 +474,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-" PADDING "0X0" SP_LC_SUFFIX "P+0");
+                                    assert(ex == "-" SP_PADDING "0X0" SP_LC_SUFFIX "P+0");
                                     assert(ios.width() == 0);
                                 }
                             }
@@ -490,7 +492,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0X0" SP_LG_SUFFIX "P+0" PADDING);
+                                    assert(ex == "-0X0" SP_LG_SUFFIX "P+0" SP_PADDING);
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -498,7 +500,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == PADDING "-0X0" SP_LG_SUFFIX "P+0");
+                                    assert(ex == SP_PADDING "-0X0" SP_LG_SUFFIX "P+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -506,7 +508,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-" PADDING "0X0" SP_LG_SUFFIX "P+0");
+                                    assert(ex == "-" SP_PADDING "0X0" SP_LG_SUFFIX "P+0");
                                     assert(ios.width() == 0);
                                 }
                             }
@@ -601,7 +603,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0X0" SP_LC_SUFFIX "P+0" PADDING);
+                                    assert(ex == "-0X0" SP_LC_SUFFIX "P+0" SP_PADDING);
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -609,7 +611,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == PADDING "-0X0" SP_LC_SUFFIX "P+0");
+                                    assert(ex == SP_PADDING "-0X0" SP_LC_SUFFIX "P+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -617,7 +619,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-" PADDING "0X0" SP_LC_SUFFIX "P+0");
+                                    assert(ex == "-" SP_PADDING "0X0" SP_LC_SUFFIX "P+0");
                                     assert(ios.width() == 0);
                                 }
                             }
@@ -635,7 +637,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0X0" SP_LG_SUFFIX "P+0" PADDING);
+                                    assert(ex == "-0X0" SP_LG_SUFFIX "P+0" SP_PADDING);
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -643,7 +645,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == PADDING "-0X0" SP_LG_SUFFIX "P+0");
+                                    assert(ex == SP_PADDING "-0X0" SP_LG_SUFFIX "P+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -651,7 +653,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-" PADDING "0X0" SP_LG_SUFFIX "P+0");
+                                    assert(ex == "-" SP_PADDING "0X0" SP_LG_SUFFIX "P+0");
                                     assert(ios.width() == 0);
                                 }
                             }
@@ -752,7 +754,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0x0" SP_LC_SUFFIX "p+0" PADDING);
+                                    assert(ex == "-0x0" SP_LC_SUFFIX "p+0" SP_PADDING);
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -760,7 +762,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == PADDING "-0x0" SP_LC_SUFFIX "p+0");
+                                    assert(ex == SP_PADDING "-0x0" SP_LC_SUFFIX "p+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -768,7 +770,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-" PADDING "0x0" SP_LC_SUFFIX "p+0");
+                                    assert(ex == "-" SP_PADDING "0x0" SP_LC_SUFFIX "p+0");
                                     assert(ios.width() == 0);
                                 }
                             }
@@ -786,7 +788,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0x0" SP_LG_SUFFIX "p+0" PADDING);
+                                    assert(ex == "-0x0" SP_LG_SUFFIX "p+0" SP_PADDING);
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -794,7 +796,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == PADDING "-0x0" SP_LG_SUFFIX "p+0");
+                                    assert(ex == SP_PADDING "-0x0" SP_LG_SUFFIX "p+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -802,7 +804,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-" PADDING "0x0" SP_LG_SUFFIX "p+0");
+                                    assert(ex == "-" SP_PADDING "0x0" SP_LG_SUFFIX "p+0");
                                     assert(ios.width() == 0);
                                 }
                             }
@@ -897,7 +899,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0x0" SP_LC_SUFFIX "p+0" PADDING);
+                                    assert(ex == "-0x0" SP_LC_SUFFIX "p+0" SP_PADDING);
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -905,7 +907,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == PADDING "-0x0" SP_LC_SUFFIX "p+0");
+                                    assert(ex == SP_PADDING "-0x0" SP_LC_SUFFIX "p+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -913,7 +915,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-" PADDING "0x0" SP_LC_SUFFIX "p+0");
+                                    assert(ex == "-" SP_PADDING "0x0" SP_LC_SUFFIX "p+0");
                                     assert(ios.width() == 0);
                                 }
                             }
@@ -931,7 +933,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0x0" SP_LG_SUFFIX "p+0" PADDING);
+                                    assert(ex == "-0x0" SP_LG_SUFFIX "p+0" SP_PADDING);
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -939,7 +941,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == PADDING "-0x0" SP_LG_SUFFIX "p+0");
+                                    assert(ex == SP_PADDING "-0x0" SP_LG_SUFFIX "p+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -947,7 +949,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-" PADDING "0x0" SP_LG_SUFFIX "p+0");
+                                    assert(ex == "-" SP_PADDING "0x0" SP_LG_SUFFIX "p+0");
                                     assert(ios.width() == 0);
                                 }
                             }
@@ -1045,7 +1047,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0X0" SP_LC_SUFFIX "P+0" PADDING);
+                                    assert(ex == "-0X0" SP_LC_SUFFIX "P+0" SP_PADDING);
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -1053,7 +1055,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == PADDING "-0X0" SP_LC_SUFFIX "P+0");
+                                    assert(ex == SP_PADDING "-0X0" SP_LC_SUFFIX "P+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -1061,7 +1063,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-" PADDING "0X0" SP_LC_SUFFIX "P+0");
+                                    assert(ex == "-" SP_PADDING "0X0" SP_LC_SUFFIX "P+0");
                                     assert(ios.width() == 0);
                                 }
                             }
@@ -1079,7 +1081,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0X0" SP_LG_SUFFIX "P+0" PADDING);
+                                    assert(ex == "-0X0" SP_LG_SUFFIX "P+0" SP_PADDING);
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -1087,7 +1089,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == PADDING "-0X0" SP_LG_SUFFIX "P+0");
+                                    assert(ex == SP_PADDING "-0X0" SP_LG_SUFFIX "P+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -1095,7 +1097,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-" PADDING "0X0" SP_LG_SUFFIX "P+0");
+                                    assert(ex == "-" SP_PADDING "0X0" SP_LG_SUFFIX "P+0");
                                     assert(ios.width() == 0);
                                 }
                             }
@@ -1190,7 +1192,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0X0" SP_LC_SUFFIX "P+0" PADDING);
+                                    assert(ex == "-0X0" SP_LC_SUFFIX "P+0" SP_PADDING);
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -1198,7 +1200,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == PADDING "-0X0" SP_LC_SUFFIX "P+0");
+                                    assert(ex == SP_PADDING "-0X0" SP_LC_SUFFIX "P+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -1206,7 +1208,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-" PADDING "0X0" SP_LC_SUFFIX "P+0");
+                                    assert(ex == "-" SP_PADDING "0X0" SP_LC_SUFFIX "P+0");
                                     assert(ios.width() == 0);
                                 }
                             }
@@ -1224,7 +1226,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0X0" SP_LG_SUFFIX "P+0" PADDING);
+                                    assert(ex == "-0X0" SP_LG_SUFFIX "P+0" SP_PADDING);
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -1232,7 +1234,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == PADDING "-0X0" SP_LG_SUFFIX "P+0");
+                                    assert(ex == SP_PADDING "-0X0" SP_LG_SUFFIX "P+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -1240,7 +1242,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-" PADDING "0X0" SP_LG_SUFFIX "P+0");
+                                    assert(ex == "-" SP_PADDING "0X0" SP_LG_SUFFIX "P+0");
                                     assert(ios.width() == 0);
                                 }
                             }
@@ -1341,7 +1343,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0x0" SP_LC_SUFFIX "p+0" PADDING);
+                                    assert(ex == "-0x0" SP_LC_SUFFIX "p+0" SP_PADDING);
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -1349,7 +1351,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == PADDING "-0x0" SP_LC_SUFFIX "p+0");
+                                    assert(ex == SP_PADDING "-0x0" SP_LC_SUFFIX "p+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -1357,7 +1359,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-" PADDING "0x0" SP_LC_SUFFIX "p+0");
+                                    assert(ex == "-" SP_PADDING "0x0" SP_LC_SUFFIX "p+0");
                                     assert(ios.width() == 0);
                                 }
                             }
@@ -1375,7 +1377,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0x0" SP_LG_SUFFIX "p+0" PADDING);
+                                    assert(ex == "-0x0" SP_LG_SUFFIX "p+0" SP_PADDING);
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -1383,7 +1385,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == PADDING "-0x0" SP_LG_SUFFIX "p+0");
+                                    assert(ex == SP_PADDING "-0x0" SP_LG_SUFFIX "p+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -1391,7 +1393,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-" PADDING "0x0" SP_LG_SUFFIX "p+0");
+                                    assert(ex == "-" SP_PADDING "0x0" SP_LG_SUFFIX "p+0");
                                     assert(ios.width() == 0);
                                 }
                             }
@@ -1486,7 +1488,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0x0" SP_LC_SUFFIX "p+0" PADDING);
+                                    assert(ex == "-0x0" SP_LC_SUFFIX "p+0" SP_PADDING);
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -1494,7 +1496,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == PADDING "-0x0" SP_LC_SUFFIX "p+0");
+                                    assert(ex == SP_PADDING "-0x0" SP_LC_SUFFIX "p+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -1502,7 +1504,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-" PADDING "0x0" SP_LC_SUFFIX "p+0");
+                                    assert(ex == "-" SP_PADDING "0x0" SP_LC_SUFFIX "p+0");
                                     assert(ios.width() == 0);
                                 }
                             }
@@ -1520,7 +1522,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0x0" SP_LG_SUFFIX "p+0" PADDING);
+                                    assert(ex == "-0x0" SP_LG_SUFFIX "p+0" SP_PADDING);
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -1528,7 +1530,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == PADDING "-0x0" SP_LG_SUFFIX "p+0");
+                                    assert(ex == SP_PADDING "-0x0" SP_LG_SUFFIX "p+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -1536,7 +1538,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-" PADDING "0x0" SP_LG_SUFFIX "p+0");
+                                    assert(ex == "-" SP_PADDING "0x0" SP_LG_SUFFIX "p+0");
                                     assert(ios.width() == 0);
                                 }
                             }
@@ -1634,7 +1636,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0X0" SP_LC_SUFFIX "P+0" PADDING);
+                                    assert(ex == "-0X0" SP_LC_SUFFIX "P+0" SP_PADDING);
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -1642,7 +1644,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == PADDING "-0X0" SP_LC_SUFFIX "P+0");
+                                    assert(ex == SP_PADDING "-0X0" SP_LC_SUFFIX "P+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -1650,7 +1652,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-" PADDING "0X0" SP_LC_SUFFIX "P+0");
+                                    assert(ex == "-" SP_PADDING "0X0" SP_LC_SUFFIX "P+0");
                                     assert(ios.width() == 0);
                                 }
                             }
@@ -1668,7 +1670,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0X0" SP_LG_SUFFIX "P+0" PADDING);
+                                    assert(ex == "-0X0" SP_LG_SUFFIX "P+0" SP_PADDING);
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -1676,7 +1678,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == PADDING "-0X0" SP_LG_SUFFIX "P+0");
+                                    assert(ex == SP_PADDING "-0X0" SP_LG_SUFFIX "P+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -1684,7 +1686,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-" PADDING "0X0" SP_LG_SUFFIX "P+0");
+                                    assert(ex == "-" SP_PADDING "0X0" SP_LG_SUFFIX "P+0");
                                     assert(ios.width() == 0);
                                 }
                             }
@@ -1779,7 +1781,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0X0" SP_LC_SUFFIX "P+0" PADDING);
+                                    assert(ex == "-0X0" SP_LC_SUFFIX "P+0" SP_PADDING);
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -1787,7 +1789,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == PADDING "-0X0" SP_LC_SUFFIX "P+0");
+                                    assert(ex == SP_PADDING "-0X0" SP_LC_SUFFIX "P+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -1795,7 +1797,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-" PADDING "0X0" SP_LC_SUFFIX "P+0");
+                                    assert(ex == "-" SP_PADDING "0X0" SP_LC_SUFFIX "P+0");
                                     assert(ios.width() == 0);
                                 }
                             }
@@ -1813,7 +1815,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0X0" SP_LG_SUFFIX "P+0" PADDING);
+                                    assert(ex == "-0X0" SP_LG_SUFFIX "P+0" SP_PADDING);
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -1821,7 +1823,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == PADDING "-0X0" SP_LG_SUFFIX "P+0");
+                                    assert(ex == SP_PADDING "-0X0" SP_LG_SUFFIX "P+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -1829,7 +1831,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-" PADDING "0X0" SP_LG_SUFFIX "P+0");
+                                    assert(ex == "-" SP_PADDING "0X0" SP_LG_SUFFIX "P+0");
                                     assert(ios.width() == 0);
                                 }
                             }

--- a/libcxx/test/std/localization/locale.categories/category.numeric/locale.nm.put/facet.num.put.members/put_double.hex.pass.cpp
+++ b/libcxx/test/std/localization/locale.categories/category.numeric/locale.nm.put/facet.num.put.members/put_double.hex.pass.cpp
@@ -23,17 +23,17 @@
 #include "test_iterators.h"
 
 #ifdef _AIX
-#define LC_SUFFIX ".0"
-#define LG_SUFFIX ";0"
-#define SP_LC_SUFFIX ".0"
-#define SP_LG_SUFFIX ";0"
-#define PADDING "****************"
+#  define LC_SUFFIX ".0"
+#  define LG_SUFFIX ";0"
+#  define SP_LC_SUFFIX ".0"
+#  define SP_LG_SUFFIX ";0"
+#  define PADDING "****************"
 #else
-#define LC_SUFFIX ""
-#define LG_SUFFIX ""
-#define SP_LC_SUFFIX "."
-#define SP_LC_SUFFIX ";"
-#define PADDING "*****************"
+#  define LC_SUFFIX ""
+#  define LG_SUFFIX ""
+#  define SP_LC_SUFFIX "."
+#  define SP_LG_SUFFIX ";"
+#  define PADDING "*****************"
 #endif
 
 typedef std::num_put<char, cpp17_output_iterator<char*> > F;

--- a/libcxx/test/std/localization/locale.categories/category.numeric/locale.nm.put/facet.num.put.members/put_double.hex.pass.cpp
+++ b/libcxx/test/std/localization/locale.categories/category.numeric/locale.nm.put/facet.num.put.members/put_double.hex.pass.cpp
@@ -14,8 +14,6 @@
 
 // XFAIL: win32-broken-printf-a-precision
 
-// XFAIL: LIBCXX-AIX-FIXME
-
 #include <locale>
 #include <ios>
 #include <cassert>
@@ -23,6 +21,20 @@
 #include <cmath>
 #include "test_macros.h"
 #include "test_iterators.h"
+
+#ifdef _AIX
+#define LC_SUFFIX ".0"
+#define LG_SUFFIX ";0"
+#define SP_LC_SUFFIX ".0"
+#define SP_LG_SUFFIX ";0"
+#define PADDING "****************"
+#else
+#define LC_SUFFIX ""
+#define LG_SUFFIX ""
+#define SP_LC_SUFFIX "."
+#define SP_LC_SUFFIX ";"
+#define PADDING "*****************"
+#endif
 
 typedef std::num_put<char, cpp17_output_iterator<char*> > F;
 
@@ -72,7 +84,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0x0p+0");
+                                    assert(ex == "-0x0" LC_SUFFIX "p+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -80,7 +92,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0x0p+0******************");
+                                    assert(ex == "-0x0" LC_SUFFIX "p+0" PADDING);
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -88,7 +100,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "******************-0x0p+0");
+                                    assert(ex == PADDING "-0x0" LC_SUFFIX "p+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -96,7 +108,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-******************0x0p+0");
+                                    assert(ex == "-" PADDING "0x0" LC_SUFFIX "p+0");
                                     assert(ios.width() == 0);
                                 }
                             }
@@ -106,7 +118,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0x0p+0");
+                                    assert(ex == "-0x0" LG_SUFFIX "p+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -114,7 +126,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0x0p+0******************");
+                                    assert(ex == "-0x0" LG_SUFFIX "p+0" PADDING);
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -122,7 +134,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "******************-0x0p+0");
+                                    assert(ex == PADDING "-0x0" LG_SUFFIX "p+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -130,7 +142,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-******************0x0p+0");
+                                    assert(ex == "-" PADDING "0x0" LG_SUFFIX "p+0");
                                     assert(ios.width() == 0);
                                 }
                             }
@@ -143,7 +155,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0x0.p+0");
+                                    assert(ex == "-0x0" SP_LC_SUFFIX "p+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -151,7 +163,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0x0.p+0*****************");
+                                    assert(ex == "-0x0" SP_LC_SUFFIX "p+0" PADDING);
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -159,7 +171,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "*****************-0x0.p+0");
+                                    assert(ex == PADDING "-0x0" SP_LC_SUFFIX "p+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -167,7 +179,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-*****************0x0.p+0");
+                                    assert(ex == "-" PADDING "0x0" SP_LC_SUFFIX "p+0");
                                     assert(ios.width() == 0);
                                 }
                             }
@@ -177,7 +189,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0x0;p+0");
+                                    assert(ex == "-0x0" SP_LG_SUFFIX "p+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -185,7 +197,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0x0;p+0*****************");
+                                    assert(ex == "-0x0" SP_LG_SUFFIX "p+0" PADDING);
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -193,7 +205,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "*****************-0x0;p+0");
+                                    assert(ex == PADDING "-0x0" SP_LG_SUFFIX "p+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -201,7 +213,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-*****************0x0;p+0");
+                                    assert(ex == "-" PADDING "0x0" SP_LG_SUFFIX "p+0");
                                     assert(ios.width() == 0);
                                 }
                             }
@@ -217,7 +229,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0x0p+0");
+                                    assert(ex == "-0x0" LC_SUFFIX "p+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -225,7 +237,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0x0p+0******************");
+                                    assert(ex == "-0x0" LC_SUFFIX "p+0" PADDING);
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -233,7 +245,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "******************-0x0p+0");
+                                    assert(ex == PADDING "-0x0" LC_SUFFIX "p+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -241,7 +253,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-******************0x0p+0");
+                                    assert(ex == "-" PADDING "0x0" LC_SUFFIX "p+0");
                                     assert(ios.width() == 0);
                                 }
                             }
@@ -251,7 +263,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0x0p+0");
+                                    assert(ex == "-0x0" LG_SUFFIX "p+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -259,7 +271,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0x0p+0******************");
+                                    assert(ex == "-0x0" LG_SUFFIX "p+0" PADDING);
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -267,7 +279,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "******************-0x0p+0");
+                                    assert(ex == PADDING "-0x0" LG_SUFFIX "p+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -275,7 +287,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-******************0x0p+0");
+                                    assert(ex == "-" PADDING "0x0" LG_SUFFIX "p+0");
                                     assert(ios.width() == 0);
                                 }
                             }
@@ -288,7 +300,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0x0.p+0");
+                                    assert(ex == "-0x0" SP_LC_SUFFIX "p+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -296,7 +308,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0x0.p+0*****************");
+                                    assert(ex == "-0x0" SP_LC_SUFFIX "p+0" PADDING);
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -304,7 +316,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "*****************-0x0.p+0");
+                                    assert(ex == PADDING "-0x0" SP_LC_SUFFIX "p+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -312,7 +324,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-*****************0x0.p+0");
+                                    assert(ex == "-" PADDING "0x0" SP_LC_SUFFIX "p+0");
                                     assert(ios.width() == 0);
                                 }
                             }
@@ -322,7 +334,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0x0;p+0");
+                                    assert(ex == "-0x0" SP_LG_SUFFIX "p+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -330,7 +342,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0x0;p+0*****************");
+                                    assert(ex == "-0x0" SP_LG_SUFFIX "p+0" PADDING);
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -338,7 +350,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "*****************-0x0;p+0");
+                                    assert(ex == PADDING "-0x0" SP_LG_SUFFIX "p+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -346,7 +358,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-*****************0x0;p+0");
+                                    assert(ex == "-" PADDING "0x0" SP_LG_SUFFIX "p+0");
                                     assert(ios.width() == 0);
                                 }
                             }
@@ -365,7 +377,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0X0P+0");
+                                    assert(ex == "-0X0" LC_SUFFIX "P+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -373,7 +385,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0X0P+0******************");
+                                    assert(ex == "-0X0" LC_SUFFIX "P+0" PADDING);
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -381,7 +393,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "******************-0X0P+0");
+                                    assert(ex == PADDING "-0X0" LC_SUFFIX "P+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -389,7 +401,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-******************0X0P+0");
+                                    assert(ex == "-" PADDING "0X0" LC_SUFFIX "P+0");
                                     assert(ios.width() == 0);
                                 }
                             }
@@ -399,7 +411,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0X0P+0");
+                                    assert(ex == "-0X0" LG_SUFFIX "P+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -407,7 +419,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0X0P+0******************");
+                                    assert(ex == "-0X0" LG_SUFFIX "P+0" PADDING);
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -415,7 +427,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "******************-0X0P+0");
+                                    assert(ex == PADDING "-0X0" LG_SUFFIX "P+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -423,7 +435,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-******************0X0P+0");
+                                    assert(ex == "-" PADDING "0X0" LG_SUFFIX "P+0");
                                     assert(ios.width() == 0);
                                 }
                             }
@@ -436,7 +448,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0X0.P+0");
+                                    assert(ex == "-0X0" SP_LC_SUFFIX "P+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -444,7 +456,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0X0.P+0*****************");
+                                    assert(ex == "-0X0" SP_LC_SUFFIX "P+0" PADDING);
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -452,7 +464,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "*****************-0X0.P+0");
+                                    assert(ex == PADDING "-0X0" SP_LC_SUFFIX "P+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -460,7 +472,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-*****************0X0.P+0");
+                                    assert(ex == "-" PADDING "0X0" SP_LC_SUFFIX "P+0");
                                     assert(ios.width() == 0);
                                 }
                             }
@@ -470,7 +482,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0X0;P+0");
+                                    assert(ex == "-0X0" SP_LG_SUFFIX "P+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -478,7 +490,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0X0;P+0*****************");
+                                    assert(ex == "-0X0" SP_LG_SUFFIX "P+0" PADDING);
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -486,7 +498,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "*****************-0X0;P+0");
+                                    assert(ex == PADDING "-0X0" SP_LG_SUFFIX "P+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -494,7 +506,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-*****************0X0;P+0");
+                                    assert(ex == "-" PADDING "0X0" SP_LG_SUFFIX "P+0");
                                     assert(ios.width() == 0);
                                 }
                             }
@@ -510,7 +522,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0X0P+0");
+                                    assert(ex == "-0X0" LC_SUFFIX "P+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -518,7 +530,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0X0P+0******************");
+                                    assert(ex == "-0X0" LC_SUFFIX "P+0" PADDING);
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -526,7 +538,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "******************-0X0P+0");
+                                    assert(ex == PADDING "-0X0" LC_SUFFIX "P+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -534,7 +546,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-******************0X0P+0");
+                                    assert(ex == "-" PADDING "0X0" LC_SUFFIX "P+0");
                                     assert(ios.width() == 0);
                                 }
                             }
@@ -544,7 +556,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0X0P+0");
+                                    assert(ex == "-0X0" LG_SUFFIX "P+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -552,7 +564,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0X0P+0******************");
+                                    assert(ex == "-0X0" LG_SUFFIX "P+0" PADDING);
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -560,7 +572,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "******************-0X0P+0");
+                                    assert(ex == PADDING "-0X0" LG_SUFFIX "P+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -568,7 +580,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-******************0X0P+0");
+                                    assert(ex == "-" PADDING "0X0" LG_SUFFIX "P+0");
                                     assert(ios.width() == 0);
                                 }
                             }
@@ -581,7 +593,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0X0.P+0");
+                                    assert(ex == "-0X0" SP_LC_SUFFIX "P+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -589,7 +601,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0X0.P+0*****************");
+                                    assert(ex == "-0X0" SP_LC_SUFFIX "P+0" PADDING);
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -597,7 +609,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "*****************-0X0.P+0");
+                                    assert(ex == PADDING "-0X0" SP_LC_SUFFIX "P+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -605,7 +617,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-*****************0X0.P+0");
+                                    assert(ex == "-" PADDING "0X0" SP_LC_SUFFIX "P+0");
                                     assert(ios.width() == 0);
                                 }
                             }
@@ -615,7 +627,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0X0;P+0");
+                                    assert(ex == "-0X0" SP_LG_SUFFIX "P+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -623,7 +635,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0X0;P+0*****************");
+                                    assert(ex == "-0X0" SP_LG_SUFFIX "P+0" PADDING);
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -631,7 +643,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "*****************-0X0;P+0");
+                                    assert(ex == PADDING "-0X0" SP_LG_SUFFIX "P+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -639,7 +651,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-*****************0X0;P+0");
+                                    assert(ex == "-" PADDING "0X0" SP_LG_SUFFIX "P+0");
                                     assert(ios.width() == 0);
                                 }
                             }
@@ -661,7 +673,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0x0p+0");
+                                    assert(ex == "-0x0" LC_SUFFIX "p+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -669,7 +681,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0x0p+0******************");
+                                    assert(ex == "-0x0" LC_SUFFIX "p+0" PADDING);
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -677,7 +689,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "******************-0x0p+0");
+                                    assert(ex == PADDING "-0x0" LC_SUFFIX "p+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -685,7 +697,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-******************0x0p+0");
+                                    assert(ex == "-" PADDING "0x0" LC_SUFFIX "p+0");
                                     assert(ios.width() == 0);
                                 }
                             }
@@ -695,7 +707,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0x0p+0");
+                                    assert(ex == "-0x0" LG_SUFFIX "p+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -703,7 +715,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0x0p+0******************");
+                                    assert(ex == "-0x0" LG_SUFFIX "p+0" PADDING);
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -711,7 +723,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "******************-0x0p+0");
+                                    assert(ex == PADDING "-0x0" LG_SUFFIX "p+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -719,7 +731,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-******************0x0p+0");
+                                    assert(ex == "-" PADDING "0x0" LG_SUFFIX "p+0");
                                     assert(ios.width() == 0);
                                 }
                             }
@@ -732,7 +744,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0x0.p+0");
+                                    assert(ex == "-0x0" SP_LC_SUFFIX "p+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -740,7 +752,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0x0.p+0*****************");
+                                    assert(ex == "-0x0" SP_LC_SUFFIX "p+0" PADDING);
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -748,7 +760,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "*****************-0x0.p+0");
+                                    assert(ex == PADDING "-0x0" SP_LC_SUFFIX "p+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -756,7 +768,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-*****************0x0.p+0");
+                                    assert(ex == "-" PADDING "0x0" SP_LC_SUFFIX "p+0");
                                     assert(ios.width() == 0);
                                 }
                             }
@@ -766,7 +778,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0x0;p+0");
+                                    assert(ex == "-0x0" SP_LG_SUFFIX "p+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -774,7 +786,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0x0;p+0*****************");
+                                    assert(ex == "-0x0" SP_LG_SUFFIX "p+0" PADDING);
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -782,7 +794,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "*****************-0x0;p+0");
+                                    assert(ex == PADDING "-0x0" SP_LG_SUFFIX "p+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -790,7 +802,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-*****************0x0;p+0");
+                                    assert(ex == "-" PADDING "0x0" SP_LG_SUFFIX "p+0");
                                     assert(ios.width() == 0);
                                 }
                             }
@@ -806,7 +818,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0x0p+0");
+                                    assert(ex == "-0x0" LC_SUFFIX "p+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -814,7 +826,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0x0p+0******************");
+                                    assert(ex == "-0x0" LC_SUFFIX "p+0" PADDING);
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -822,7 +834,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "******************-0x0p+0");
+                                    assert(ex == PADDING "-0x0" LC_SUFFIX "p+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -830,7 +842,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-******************0x0p+0");
+                                    assert(ex == "-" PADDING "0x0" LC_SUFFIX "p+0");
                                     assert(ios.width() == 0);
                                 }
                             }
@@ -840,7 +852,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0x0p+0");
+                                    assert(ex == "-0x0" LG_SUFFIX "p+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -848,7 +860,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0x0p+0******************");
+                                    assert(ex == "-0x0" LG_SUFFIX "p+0" PADDING);
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -856,7 +868,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "******************-0x0p+0");
+                                    assert(ex == PADDING "-0x0" LG_SUFFIX "p+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -864,7 +876,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-******************0x0p+0");
+                                    assert(ex == "-" PADDING "0x0" LG_SUFFIX "p+0");
                                     assert(ios.width() == 0);
                                 }
                             }
@@ -877,7 +889,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0x0.p+0");
+                                    assert(ex == "-0x0" SP_LC_SUFFIX "p+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -885,7 +897,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0x0.p+0*****************");
+                                    assert(ex == "-0x0" SP_LC_SUFFIX "p+0" PADDING);
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -893,7 +905,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "*****************-0x0.p+0");
+                                    assert(ex == PADDING "-0x0" SP_LC_SUFFIX "p+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -901,7 +913,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-*****************0x0.p+0");
+                                    assert(ex == "-" PADDING "0x0" SP_LC_SUFFIX "p+0");
                                     assert(ios.width() == 0);
                                 }
                             }
@@ -911,7 +923,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0x0;p+0");
+                                    assert(ex == "-0x0" SP_LG_SUFFIX "p+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -919,7 +931,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0x0;p+0*****************");
+                                    assert(ex == "-0x0" SP_LG_SUFFIX "p+0" PADDING);
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -927,7 +939,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "*****************-0x0;p+0");
+                                    assert(ex == PADDING "-0x0" SP_LG_SUFFIX "p+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -935,7 +947,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-*****************0x0;p+0");
+                                    assert(ex == "-" PADDING "0x0" SP_LG_SUFFIX "p+0");
                                     assert(ios.width() == 0);
                                 }
                             }
@@ -954,7 +966,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0X0P+0");
+                                    assert(ex == "-0X0" LC_SUFFIX "P+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -962,7 +974,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0X0P+0******************");
+                                    assert(ex == "-0X0" LC_SUFFIX "P+0" PADDING);
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -970,7 +982,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "******************-0X0P+0");
+                                    assert(ex == PADDING "-0X0" LC_SUFFIX "P+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -978,7 +990,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-******************0X0P+0");
+                                    assert(ex == "-" PADDING "0X0" LC_SUFFIX "P+0");
                                     assert(ios.width() == 0);
                                 }
                             }
@@ -988,7 +1000,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0X0P+0");
+                                    assert(ex == "-0X0" LG_SUFFIX "P+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -996,7 +1008,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0X0P+0******************");
+                                    assert(ex == "-0X0" LG_SUFFIX "P+0" PADDING);
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -1004,7 +1016,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "******************-0X0P+0");
+                                    assert(ex == PADDING "-0X0" LG_SUFFIX "P+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -1012,7 +1024,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-******************0X0P+0");
+                                    assert(ex == "-" PADDING "0X0" LG_SUFFIX "P+0");
                                     assert(ios.width() == 0);
                                 }
                             }
@@ -1025,7 +1037,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0X0.P+0");
+                                    assert(ex == "-0X0" SP_LC_SUFFIX "P+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -1033,7 +1045,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0X0.P+0*****************");
+                                    assert(ex == "-0X0" SP_LC_SUFFIX "P+0" PADDING);
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -1041,7 +1053,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "*****************-0X0.P+0");
+                                    assert(ex == PADDING "-0X0" SP_LC_SUFFIX "P+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -1049,7 +1061,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-*****************0X0.P+0");
+                                    assert(ex == "-" PADDING "0X0" SP_LC_SUFFIX "P+0");
                                     assert(ios.width() == 0);
                                 }
                             }
@@ -1059,7 +1071,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0X0;P+0");
+                                    assert(ex == "-0X0" SP_LG_SUFFIX "P+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -1067,7 +1079,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0X0;P+0*****************");
+                                    assert(ex == "-0X0" SP_LG_SUFFIX "P+0" PADDING);
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -1075,7 +1087,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "*****************-0X0;P+0");
+                                    assert(ex == PADDING "-0X0" SP_LG_SUFFIX "P+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -1083,7 +1095,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-*****************0X0;P+0");
+                                    assert(ex == "-" PADDING "0X0" SP_LG_SUFFIX "P+0");
                                     assert(ios.width() == 0);
                                 }
                             }
@@ -1099,7 +1111,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0X0P+0");
+                                    assert(ex == "-0X0" LC_SUFFIX "P+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -1107,7 +1119,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0X0P+0******************");
+                                    assert(ex == "-0X0" LC_SUFFIX "P+0" PADDING);
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -1115,7 +1127,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "******************-0X0P+0");
+                                    assert(ex == PADDING "-0X0" LC_SUFFIX "P+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -1123,7 +1135,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-******************0X0P+0");
+                                    assert(ex == "-" PADDING "0X0" LC_SUFFIX "P+0");
                                     assert(ios.width() == 0);
                                 }
                             }
@@ -1133,7 +1145,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0X0P+0");
+                                    assert(ex == "-0X0" LG_SUFFIX "P+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -1141,7 +1153,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0X0P+0******************");
+                                    assert(ex == "-0X0" LG_SUFFIX "P+0" PADDING);
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -1149,7 +1161,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "******************-0X0P+0");
+                                    assert(ex == PADDING "-0X0" LG_SUFFIX "P+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -1157,7 +1169,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-******************0X0P+0");
+                                    assert(ex == "-" PADDING "0X0" LG_SUFFIX "P+0");
                                     assert(ios.width() == 0);
                                 }
                             }
@@ -1170,7 +1182,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0X0.P+0");
+                                    assert(ex == "-0X0" SP_LC_SUFFIX "P+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -1178,7 +1190,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0X0.P+0*****************");
+                                    assert(ex == "-0X0" SP_LC_SUFFIX "P+0" PADDING);
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -1186,7 +1198,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "*****************-0X0.P+0");
+                                    assert(ex == PADDING "-0X0" SP_LC_SUFFIX "P+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -1194,7 +1206,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-*****************0X0.P+0");
+                                    assert(ex == "-" PADDING "0X0" SP_LC_SUFFIX "P+0");
                                     assert(ios.width() == 0);
                                 }
                             }
@@ -1204,7 +1216,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0X0;P+0");
+                                    assert(ex == "-0X0" SP_LG_SUFFIX "P+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -1212,7 +1224,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0X0;P+0*****************");
+                                    assert(ex == "-0X0" SP_LG_SUFFIX "P+0" PADDING);
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -1220,7 +1232,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "*****************-0X0;P+0");
+                                    assert(ex == PADDING "-0X0" SP_LG_SUFFIX "P+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -1228,7 +1240,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-*****************0X0;P+0");
+                                    assert(ex == "-" PADDING "0X0" SP_LG_SUFFIX "P+0");
                                     assert(ios.width() == 0);
                                 }
                             }
@@ -1250,7 +1262,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0x0p+0");
+                                    assert(ex == "-0x0" LC_SUFFIX "p+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -1258,7 +1270,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0x0p+0******************");
+                                    assert(ex == "-0x0" LC_SUFFIX "p+0" PADDING);
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -1266,7 +1278,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "******************-0x0p+0");
+                                    assert(ex == PADDING "-0x0" LC_SUFFIX "p+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -1274,7 +1286,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-******************0x0p+0");
+                                    assert(ex == "-" PADDING "0x0" LC_SUFFIX "p+0");
                                     assert(ios.width() == 0);
                                 }
                             }
@@ -1284,7 +1296,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0x0p+0");
+                                    assert(ex == "-0x0" LG_SUFFIX "p+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -1292,7 +1304,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0x0p+0******************");
+                                    assert(ex == "-0x0" LG_SUFFIX "p+0" PADDING);
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -1300,7 +1312,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "******************-0x0p+0");
+                                    assert(ex == PADDING "-0x0" LG_SUFFIX "p+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -1308,7 +1320,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-******************0x0p+0");
+                                    assert(ex == "-" PADDING "0x0" LG_SUFFIX "p+0");
                                     assert(ios.width() == 0);
                                 }
                             }
@@ -1321,7 +1333,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0x0.p+0");
+                                    assert(ex == "-0x0" SP_LC_SUFFIX "p+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -1329,7 +1341,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0x0.p+0*****************");
+                                    assert(ex == "-0x0" SP_LC_SUFFIX "p+0" PADDING);
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -1337,7 +1349,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "*****************-0x0.p+0");
+                                    assert(ex == PADDING "-0x0" SP_LC_SUFFIX "p+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -1345,7 +1357,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-*****************0x0.p+0");
+                                    assert(ex == "-" PADDING "0x0" SP_LC_SUFFIX "p+0");
                                     assert(ios.width() == 0);
                                 }
                             }
@@ -1355,7 +1367,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0x0;p+0");
+                                    assert(ex == "-0x0" SP_LG_SUFFIX "p+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -1363,7 +1375,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0x0;p+0*****************");
+                                    assert(ex == "-0x0" SP_LG_SUFFIX "p+0" PADDING);
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -1371,7 +1383,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "*****************-0x0;p+0");
+                                    assert(ex == PADDING "-0x0" SP_LG_SUFFIX "p+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -1379,7 +1391,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-*****************0x0;p+0");
+                                    assert(ex == "-" PADDING "0x0" SP_LG_SUFFIX "p+0");
                                     assert(ios.width() == 0);
                                 }
                             }
@@ -1395,7 +1407,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0x0p+0");
+                                    assert(ex == "-0x0" LC_SUFFIX "p+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -1403,7 +1415,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0x0p+0******************");
+                                    assert(ex == "-0x0" LC_SUFFIX "p+0" PADDING);
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -1411,7 +1423,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "******************-0x0p+0");
+                                    assert(ex == PADDING "-0x0" LC_SUFFIX "p+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -1419,7 +1431,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-******************0x0p+0");
+                                    assert(ex == "-" PADDING "0x0" LC_SUFFIX "p+0");
                                     assert(ios.width() == 0);
                                 }
                             }
@@ -1429,7 +1441,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0x0p+0");
+                                    assert(ex == "-0x0" LG_SUFFIX "p+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -1437,7 +1449,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0x0p+0******************");
+                                    assert(ex == "-0x0" LG_SUFFIX "p+0" PADDING);
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -1445,7 +1457,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "******************-0x0p+0");
+                                    assert(ex == PADDING "-0x0" LG_SUFFIX "p+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -1453,7 +1465,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-******************0x0p+0");
+                                    assert(ex == "-" PADDING "0x0" LG_SUFFIX "p+0");
                                     assert(ios.width() == 0);
                                 }
                             }
@@ -1466,7 +1478,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0x0.p+0");
+                                    assert(ex == "-0x0" SP_LC_SUFFIX "p+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -1474,7 +1486,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0x0.p+0*****************");
+                                    assert(ex == "-0x0" SP_LC_SUFFIX "p+0" PADDING);
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -1482,7 +1494,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "*****************-0x0.p+0");
+                                    assert(ex == PADDING "-0x0" SP_LC_SUFFIX "p+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -1490,7 +1502,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-*****************0x0.p+0");
+                                    assert(ex == "-" PADDING "0x0" SP_LC_SUFFIX "p+0");
                                     assert(ios.width() == 0);
                                 }
                             }
@@ -1500,7 +1512,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0x0;p+0");
+                                    assert(ex == "-0x0" SP_LG_SUFFIX "p+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -1508,7 +1520,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0x0;p+0*****************");
+                                    assert(ex == "-0x0" SP_LG_SUFFIX "p+0" PADDING);
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -1516,7 +1528,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "*****************-0x0;p+0");
+                                    assert(ex == PADDING "-0x0" SP_LG_SUFFIX "p+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -1524,7 +1536,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-*****************0x0;p+0");
+                                    assert(ex == "-" PADDING "0x0" SP_LG_SUFFIX "p+0");
                                     assert(ios.width() == 0);
                                 }
                             }
@@ -1543,7 +1555,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0X0P+0");
+                                    assert(ex == "-0X0" LC_SUFFIX "P+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -1551,7 +1563,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0X0P+0******************");
+                                    assert(ex == "-0X0" LC_SUFFIX "P+0" PADDING);
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -1559,7 +1571,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "******************-0X0P+0");
+                                    assert(ex == PADDING "-0X0" LC_SUFFIX "P+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -1567,7 +1579,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-******************0X0P+0");
+                                    assert(ex == "-" PADDING "0X0" LC_SUFFIX "P+0");
                                     assert(ios.width() == 0);
                                 }
                             }
@@ -1577,7 +1589,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0X0P+0");
+                                    assert(ex == "-0X0" LG_SUFFIX "P+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -1585,7 +1597,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0X0P+0******************");
+                                    assert(ex == "-0X0" LG_SUFFIX "P+0" PADDING);
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -1593,7 +1605,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "******************-0X0P+0");
+                                    assert(ex == PADDING "-0X0" LG_SUFFIX "P+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -1601,7 +1613,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-******************0X0P+0");
+                                    assert(ex == "-" PADDING "0X0" LG_SUFFIX "P+0");
                                     assert(ios.width() == 0);
                                 }
                             }
@@ -1614,7 +1626,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0X0.P+0");
+                                    assert(ex == "-0X0" SP_LC_SUFFIX "P+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -1622,7 +1634,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0X0.P+0*****************");
+                                    assert(ex == "-0X0" SP_LC_SUFFIX "P+0" PADDING);
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -1630,7 +1642,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "*****************-0X0.P+0");
+                                    assert(ex == PADDING "-0X0" SP_LC_SUFFIX "P+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -1638,7 +1650,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-*****************0X0.P+0");
+                                    assert(ex == "-" PADDING "0X0" SP_LC_SUFFIX "P+0");
                                     assert(ios.width() == 0);
                                 }
                             }
@@ -1648,7 +1660,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0X0;P+0");
+                                    assert(ex == "-0X0" SP_LG_SUFFIX "P+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -1656,7 +1668,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0X0;P+0*****************");
+                                    assert(ex == "-0X0" SP_LG_SUFFIX "P+0" PADDING);
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -1664,7 +1676,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "*****************-0X0;P+0");
+                                    assert(ex == PADDING "-0X0" SP_LG_SUFFIX "P+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -1672,7 +1684,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-*****************0X0;P+0");
+                                    assert(ex == "-" PADDING "0X0" SP_LG_SUFFIX "P+0");
                                     assert(ios.width() == 0);
                                 }
                             }
@@ -1688,7 +1700,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0X0P+0");
+                                    assert(ex == "-0X0" LC_SUFFIX "P+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -1696,7 +1708,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0X0P+0******************");
+                                    assert(ex == "-0X0" LC_SUFFIX "P+0" PADDING);
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -1704,7 +1716,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "******************-0X0P+0");
+                                    assert(ex == PADDING "-0X0" LC_SUFFIX "P+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -1712,7 +1724,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-******************0X0P+0");
+                                    assert(ex == "-" PADDING "0X0" LC_SUFFIX "P+0");
                                     assert(ios.width() == 0);
                                 }
                             }
@@ -1722,7 +1734,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0X0P+0");
+                                    assert(ex == "-0X0" LG_SUFFIX "P+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -1730,7 +1742,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0X0P+0******************");
+                                    assert(ex == "-0X0" LG_SUFFIX "P+0" PADDING);
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -1738,7 +1750,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "******************-0X0P+0");
+                                    assert(ex == PADDING "-0X0" LG_SUFFIX "P+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -1746,7 +1758,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-******************0X0P+0");
+                                    assert(ex == "-" PADDING "0X0" LG_SUFFIX "P+0");
                                     assert(ios.width() == 0);
                                 }
                             }
@@ -1759,7 +1771,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0X0.P+0");
+                                    assert(ex == "-0X0" SP_LC_SUFFIX "P+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -1767,7 +1779,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0X0.P+0*****************");
+                                    assert(ex == "-0X0" SP_LC_SUFFIX "P+0" PADDING);
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -1775,7 +1787,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "*****************-0X0.P+0");
+                                    assert(ex == PADDING "-0X0" SP_LC_SUFFIX "P+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -1783,7 +1795,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-*****************0X0.P+0");
+                                    assert(ex == "-" PADDING "0X0" SP_LC_SUFFIX "P+0");
                                     assert(ios.width() == 0);
                                 }
                             }
@@ -1793,7 +1805,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0X0;P+0");
+                                    assert(ex == "-0X0" SP_LG_SUFFIX "P+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -1801,7 +1813,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0X0;P+0*****************");
+                                    assert(ex == "-0X0" SP_LG_SUFFIX "P+0" PADDING);
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -1809,7 +1821,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "*****************-0X0;P+0");
+                                    assert(ex == PADDING "-0X0" SP_LG_SUFFIX "P+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -1817,7 +1829,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-*****************0X0;P+0");
+                                    assert(ex == "-" PADDING "0X0" SP_LG_SUFFIX "P+0");
                                     assert(ios.width() == 0);
                                 }
                             }

--- a/libcxx/test/std/localization/locale.categories/category.numeric/locale.nm.put/facet.num.put.members/put_long_double.hex.pass.cpp
+++ b/libcxx/test/std/localization/locale.categories/category.numeric/locale.nm.put/facet.num.put.members/put_long_double.hex.pass.cpp
@@ -28,12 +28,14 @@
 #  define SP_LC_SUFFIX ".0"
 #  define SP_LG_SUFFIX ";0"
 #  define PADDING "****************"
+#  define SP_PADDING "****************"
 #else
 #  define LC_SUFFIX ""
 #  define LG_SUFFIX ""
 #  define SP_LC_SUFFIX "."
 #  define SP_LG_SUFFIX ";"
-#  define PADDING "*****************"
+#  define PADDING "******************"
+#  define SP_PADDING "*****************"
 #endif
 
 typedef std::num_put<char, cpp17_output_iterator<char*> > F;
@@ -163,7 +165,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0x0" SP_LC_SUFFIX "p+0" PADDING);
+                                    assert(ex == "-0x0" SP_LC_SUFFIX "p+0" SP_PADDING);
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -171,7 +173,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == PADDING "-0x0" SP_LC_SUFFIX "p+0");
+                                    assert(ex == SP_PADDING "-0x0" SP_LC_SUFFIX "p+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -179,7 +181,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-" PADDING "0x0" SP_LC_SUFFIX "p+0");
+                                    assert(ex == "-" SP_PADDING "0x0" SP_LC_SUFFIX "p+0");
                                     assert(ios.width() == 0);
                                 }
                             }
@@ -197,7 +199,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0x0" SP_LG_SUFFIX "p+0" PADDING);
+                                    assert(ex == "-0x0" SP_LG_SUFFIX "p+0" SP_PADDING);
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -205,7 +207,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == PADDING "-0x0" SP_LG_SUFFIX "p+0");
+                                    assert(ex == SP_PADDING "-0x0" SP_LG_SUFFIX "p+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -213,7 +215,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-" PADDING "0x0" SP_LG_SUFFIX "p+0");
+                                    assert(ex == "-" SP_PADDING "0x0" SP_LG_SUFFIX "p+0");
                                     assert(ios.width() == 0);
                                 }
                             }
@@ -308,7 +310,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0x0" SP_LC_SUFFIX "p+0" PADDING);
+                                    assert(ex == "-0x0" SP_LC_SUFFIX "p+0" SP_PADDING);
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -316,7 +318,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == PADDING "-0x0" SP_LC_SUFFIX "p+0");
+                                    assert(ex == SP_PADDING "-0x0" SP_LC_SUFFIX "p+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -324,7 +326,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-" PADDING "0x0" SP_LC_SUFFIX "p+0");
+                                    assert(ex == "-" SP_PADDING "0x0" SP_LC_SUFFIX "p+0");
                                     assert(ios.width() == 0);
                                 }
                             }
@@ -342,7 +344,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0x0" SP_LG_SUFFIX "p+0" PADDING);
+                                    assert(ex == "-0x0" SP_LG_SUFFIX "p+0" SP_PADDING);
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -350,7 +352,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == PADDING "-0x0" SP_LG_SUFFIX "p+0");
+                                    assert(ex == SP_PADDING "-0x0" SP_LG_SUFFIX "p+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -358,7 +360,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-" PADDING "0x0" SP_LG_SUFFIX "p+0");
+                                    assert(ex == "-" SP_PADDING "0x0" SP_LG_SUFFIX "p+0");
                                     assert(ios.width() == 0);
                                 }
                             }
@@ -456,7 +458,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0X0" SP_LC_SUFFIX "P+0" PADDING);
+                                    assert(ex == "-0X0" SP_LC_SUFFIX "P+0" SP_PADDING);
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -464,7 +466,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == PADDING "-0X0" SP_LC_SUFFIX "P+0");
+                                    assert(ex == SP_PADDING "-0X0" SP_LC_SUFFIX "P+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -472,7 +474,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-" PADDING "0X0" SP_LC_SUFFIX "P+0");
+                                    assert(ex == "-" SP_PADDING "0X0" SP_LC_SUFFIX "P+0");
                                     assert(ios.width() == 0);
                                 }
                             }
@@ -490,7 +492,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0X0" SP_LG_SUFFIX "P+0" PADDING);
+                                    assert(ex == "-0X0" SP_LG_SUFFIX "P+0" SP_PADDING);
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -498,7 +500,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == PADDING "-0X0" SP_LG_SUFFIX "P+0");
+                                    assert(ex == SP_PADDING "-0X0" SP_LG_SUFFIX "P+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -506,7 +508,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-" PADDING "0X0" SP_LG_SUFFIX "P+0");
+                                    assert(ex == "-" SP_PADDING "0X0" SP_LG_SUFFIX "P+0");
                                     assert(ios.width() == 0);
                                 }
                             }
@@ -601,7 +603,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0X0" SP_LC_SUFFIX "P+0" PADDING);
+                                    assert(ex == "-0X0" SP_LC_SUFFIX "P+0" SP_PADDING);
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -609,7 +611,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == PADDING "-0X0" SP_LC_SUFFIX "P+0");
+                                    assert(ex == SP_PADDING "-0X0" SP_LC_SUFFIX "P+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -617,7 +619,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-" PADDING "0X0" SP_LC_SUFFIX "P+0");
+                                    assert(ex == "-" SP_PADDING "0X0" SP_LC_SUFFIX "P+0");
                                     assert(ios.width() == 0);
                                 }
                             }
@@ -635,7 +637,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0X0" SP_LG_SUFFIX "P+0" PADDING);
+                                    assert(ex == "-0X0" SP_LG_SUFFIX "P+0" SP_PADDING);
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -643,7 +645,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == PADDING "-0X0" SP_LG_SUFFIX "P+0");
+                                    assert(ex == SP_PADDING "-0X0" SP_LG_SUFFIX "P+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -651,7 +653,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-" PADDING "0X0" SP_LG_SUFFIX "P+0");
+                                    assert(ex == "-" SP_PADDING "0X0" SP_LG_SUFFIX "P+0");
                                     assert(ios.width() == 0);
                                 }
                             }
@@ -752,7 +754,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0x0" SP_LC_SUFFIX "p+0" PADDING);
+                                    assert(ex == "-0x0" SP_LC_SUFFIX "p+0" SP_PADDING);
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -760,7 +762,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == PADDING "-0x0" SP_LC_SUFFIX "p+0");
+                                    assert(ex == SP_PADDING "-0x0" SP_LC_SUFFIX "p+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -768,7 +770,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-" PADDING "0x0" SP_LC_SUFFIX "p+0");
+                                    assert(ex == "-" SP_PADDING "0x0" SP_LC_SUFFIX "p+0");
                                     assert(ios.width() == 0);
                                 }
                             }
@@ -786,7 +788,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0x0" SP_LG_SUFFIX "p+0" PADDING);
+                                    assert(ex == "-0x0" SP_LG_SUFFIX "p+0" SP_PADDING);
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -794,7 +796,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == PADDING "-0x0" SP_LG_SUFFIX "p+0");
+                                    assert(ex == SP_PADDING "-0x0" SP_LG_SUFFIX "p+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -802,7 +804,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-" PADDING "0x0" SP_LG_SUFFIX "p+0");
+                                    assert(ex == "-" SP_PADDING "0x0" SP_LG_SUFFIX "p+0");
                                     assert(ios.width() == 0);
                                 }
                             }
@@ -897,7 +899,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0x0" SP_LC_SUFFIX "p+0" PADDING);
+                                    assert(ex == "-0x0" SP_LC_SUFFIX "p+0" SP_PADDING);
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -905,7 +907,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == PADDING "-0x0" SP_LC_SUFFIX "p+0");
+                                    assert(ex == SP_PADDING "-0x0" SP_LC_SUFFIX "p+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -913,7 +915,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-" PADDING "0x0" SP_LC_SUFFIX "p+0");
+                                    assert(ex == "-" SP_PADDING "0x0" SP_LC_SUFFIX "p+0");
                                     assert(ios.width() == 0);
                                 }
                             }
@@ -931,7 +933,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0x0" SP_LG_SUFFIX "p+0" PADDING);
+                                    assert(ex == "-0x0" SP_LG_SUFFIX "p+0" SP_PADDING);
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -939,7 +941,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == PADDING "-0x0" SP_LG_SUFFIX "p+0");
+                                    assert(ex == SP_PADDING "-0x0" SP_LG_SUFFIX "p+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -947,7 +949,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-" PADDING "0x0" SP_LG_SUFFIX "p+0");
+                                    assert(ex == "-" SP_PADDING "0x0" SP_LG_SUFFIX "p+0");
                                     assert(ios.width() == 0);
                                 }
                             }
@@ -1045,7 +1047,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0X0" SP_LC_SUFFIX "P+0" PADDING);
+                                    assert(ex == "-0X0" SP_LC_SUFFIX "P+0" SP_PADDING);
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -1053,7 +1055,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == PADDING "-0X0" SP_LC_SUFFIX "P+0");
+                                    assert(ex == SP_PADDING "-0X0" SP_LC_SUFFIX "P+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -1061,7 +1063,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-" PADDING "0X0" SP_LC_SUFFIX "P+0");
+                                    assert(ex == "-" SP_PADDING "0X0" SP_LC_SUFFIX "P+0");
                                     assert(ios.width() == 0);
                                 }
                             }
@@ -1079,7 +1081,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0X0" SP_LG_SUFFIX "P+0" PADDING);
+                                    assert(ex == "-0X0" SP_LG_SUFFIX "P+0" SP_PADDING);
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -1087,7 +1089,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == PADDING "-0X0" SP_LG_SUFFIX "P+0");
+                                    assert(ex == SP_PADDING "-0X0" SP_LG_SUFFIX "P+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -1095,7 +1097,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-" PADDING "0X0" SP_LG_SUFFIX "P+0");
+                                    assert(ex == "-" SP_PADDING "0X0" SP_LG_SUFFIX "P+0");
                                     assert(ios.width() == 0);
                                 }
                             }
@@ -1190,7 +1192,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0X0" SP_LC_SUFFIX "P+0" PADDING);
+                                    assert(ex == "-0X0" SP_LC_SUFFIX "P+0" SP_PADDING);
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -1198,7 +1200,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == PADDING "-0X0" SP_LC_SUFFIX "P+0");
+                                    assert(ex == SP_PADDING "-0X0" SP_LC_SUFFIX "P+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -1206,7 +1208,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-" PADDING "0X0" SP_LC_SUFFIX "P+0");
+                                    assert(ex == "-" SP_PADDING "0X0" SP_LC_SUFFIX "P+0");
                                     assert(ios.width() == 0);
                                 }
                             }
@@ -1224,7 +1226,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0X0" SP_LG_SUFFIX "P+0" PADDING);
+                                    assert(ex == "-0X0" SP_LG_SUFFIX "P+0" SP_PADDING);
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -1232,7 +1234,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == PADDING "-0X0" SP_LG_SUFFIX "P+0");
+                                    assert(ex == SP_PADDING "-0X0" SP_LG_SUFFIX "P+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -1240,7 +1242,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-" PADDING "0X0" SP_LG_SUFFIX "P+0");
+                                    assert(ex == "-" SP_PADDING "0X0" SP_LG_SUFFIX "P+0");
                                     assert(ios.width() == 0);
                                 }
                             }
@@ -1341,7 +1343,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0x0" SP_LC_SUFFIX "p+0" PADDING);
+                                    assert(ex == "-0x0" SP_LC_SUFFIX "p+0" SP_PADDING);
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -1349,7 +1351,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == PADDING "-0x0" SP_LC_SUFFIX "p+0");
+                                    assert(ex == SP_PADDING "-0x0" SP_LC_SUFFIX "p+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -1357,7 +1359,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-" PADDING "0x0" SP_LC_SUFFIX "p+0");
+                                    assert(ex == "-" SP_PADDING "0x0" SP_LC_SUFFIX "p+0");
                                     assert(ios.width() == 0);
                                 }
                             }
@@ -1375,7 +1377,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0x0" SP_LG_SUFFIX "p+0" PADDING);
+                                    assert(ex == "-0x0" SP_LG_SUFFIX "p+0" SP_PADDING);
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -1383,7 +1385,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == PADDING "-0x0" SP_LG_SUFFIX "p+0");
+                                    assert(ex == SP_PADDING "-0x0" SP_LG_SUFFIX "p+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -1391,7 +1393,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-" PADDING "0x0" SP_LG_SUFFIX "p+0");
+                                    assert(ex == "-" SP_PADDING "0x0" SP_LG_SUFFIX "p+0");
                                     assert(ios.width() == 0);
                                 }
                             }
@@ -1486,7 +1488,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0x0" SP_LC_SUFFIX "p+0" PADDING);
+                                    assert(ex == "-0x0" SP_LC_SUFFIX "p+0" SP_PADDING);
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -1494,7 +1496,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == PADDING "-0x0" SP_LC_SUFFIX "p+0");
+                                    assert(ex == SP_PADDING "-0x0" SP_LC_SUFFIX "p+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -1502,7 +1504,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-" PADDING "0x0" SP_LC_SUFFIX "p+0");
+                                    assert(ex == "-" SP_PADDING "0x0" SP_LC_SUFFIX "p+0");
                                     assert(ios.width() == 0);
                                 }
                             }
@@ -1520,7 +1522,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0x0" SP_LG_SUFFIX "p+0" PADDING);
+                                    assert(ex == "-0x0" SP_LG_SUFFIX "p+0" SP_PADDING);
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -1528,7 +1530,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == PADDING "-0x0" SP_LG_SUFFIX "p+0");
+                                    assert(ex == SP_PADDING "-0x0" SP_LG_SUFFIX "p+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -1536,7 +1538,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-" PADDING "0x0" SP_LG_SUFFIX "p+0");
+                                    assert(ex == "-" SP_PADDING "0x0" SP_LG_SUFFIX "p+0");
                                     assert(ios.width() == 0);
                                 }
                             }
@@ -1634,7 +1636,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0X0" SP_LC_SUFFIX "P+0" PADDING);
+                                    assert(ex == "-0X0" SP_LC_SUFFIX "P+0" SP_PADDING);
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -1642,7 +1644,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == PADDING "-0X0" SP_LC_SUFFIX "P+0");
+                                    assert(ex == SP_PADDING "-0X0" SP_LC_SUFFIX "P+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -1650,7 +1652,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-" PADDING "0X0" SP_LC_SUFFIX "P+0");
+                                    assert(ex == "-" SP_PADDING "0X0" SP_LC_SUFFIX "P+0");
                                     assert(ios.width() == 0);
                                 }
                             }
@@ -1668,7 +1670,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0X0" SP_LG_SUFFIX "P+0" PADDING);
+                                    assert(ex == "-0X0" SP_LG_SUFFIX "P+0" SP_PADDING);
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -1676,7 +1678,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == PADDING "-0X0" SP_LG_SUFFIX "P+0");
+                                    assert(ex == SP_PADDING "-0X0" SP_LG_SUFFIX "P+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -1684,7 +1686,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-" PADDING "0X0" SP_LG_SUFFIX "P+0");
+                                    assert(ex == "-" SP_PADDING "0X0" SP_LG_SUFFIX "P+0");
                                     assert(ios.width() == 0);
                                 }
                             }
@@ -1779,7 +1781,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0X0" SP_LC_SUFFIX "P+0" PADDING);
+                                    assert(ex == "-0X0" SP_LC_SUFFIX "P+0" SP_PADDING);
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -1787,7 +1789,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == PADDING "-0X0" SP_LC_SUFFIX "P+0");
+                                    assert(ex == SP_PADDING "-0X0" SP_LC_SUFFIX "P+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -1795,7 +1797,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-" PADDING "0X0" SP_LC_SUFFIX "P+0");
+                                    assert(ex == "-" SP_PADDING "0X0" SP_LC_SUFFIX "P+0");
                                     assert(ios.width() == 0);
                                 }
                             }
@@ -1813,7 +1815,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0X0" SP_LG_SUFFIX "P+0" PADDING);
+                                    assert(ex == "-0X0" SP_LG_SUFFIX "P+0" SP_PADDING);
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -1821,7 +1823,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == PADDING "-0X0" SP_LG_SUFFIX "P+0");
+                                    assert(ex == SP_PADDING "-0X0" SP_LG_SUFFIX "P+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -1829,7 +1831,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-" PADDING "0X0" SP_LG_SUFFIX "P+0");
+                                    assert(ex == "-" SP_PADDING "0X0" SP_LG_SUFFIX "P+0");
                                     assert(ios.width() == 0);
                                 }
                             }

--- a/libcxx/test/std/localization/locale.categories/category.numeric/locale.nm.put/facet.num.put.members/put_long_double.hex.pass.cpp
+++ b/libcxx/test/std/localization/locale.categories/category.numeric/locale.nm.put/facet.num.put.members/put_long_double.hex.pass.cpp
@@ -23,17 +23,17 @@
 #include "test_iterators.h"
 
 #ifdef _AIX
-#define LC_SUFFIX ".0"
-#define LG_SUFFIX ";0"
-#define SP_LC_SUFFIX ".0"
-#define SP_LG_SUFFIX ";0"
-#define PADDING "****************"
+#  define LC_SUFFIX ".0"
+#  define LG_SUFFIX ";0"
+#  define SP_LC_SUFFIX ".0"
+#  define SP_LG_SUFFIX ";0"
+#  define PADDING "****************"
 #else
-#define LC_SUFFIX ""
-#define LG_SUFFIX ""
-#define SP_LC_SUFFIX "."
-#define SP_LC_SUFFIX ";"
-#define PADDING "*****************"
+#  define LC_SUFFIX ""
+#  define LG_SUFFIX ""
+#  define SP_LC_SUFFIX "."
+#  define SP_LG_SUFFIX ";"
+#  define PADDING "*****************"
 #endif
 
 typedef std::num_put<char, cpp17_output_iterator<char*> > F;

--- a/libcxx/test/std/localization/locale.categories/category.numeric/locale.nm.put/facet.num.put.members/put_long_double.hex.pass.cpp
+++ b/libcxx/test/std/localization/locale.categories/category.numeric/locale.nm.put/facet.num.put.members/put_long_double.hex.pass.cpp
@@ -14,8 +14,6 @@
 
 // XFAIL: win32-broken-printf-a-precision
 
-// XFAIL: LIBCXX-AIX-FIXME
-
 #include <locale>
 #include <ios>
 #include <cassert>
@@ -23,6 +21,20 @@
 #include <cmath>
 #include "test_macros.h"
 #include "test_iterators.h"
+
+#ifdef _AIX
+#define LC_SUFFIX ".0"
+#define LG_SUFFIX ";0"
+#define SP_LC_SUFFIX ".0"
+#define SP_LG_SUFFIX ";0"
+#define PADDING "****************"
+#else
+#define LC_SUFFIX ""
+#define LG_SUFFIX ""
+#define SP_LC_SUFFIX "."
+#define SP_LC_SUFFIX ";"
+#define PADDING "*****************"
+#endif
 
 typedef std::num_put<char, cpp17_output_iterator<char*> > F;
 
@@ -72,7 +84,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0x0p+0");
+                                    assert(ex == "-0x0" LC_SUFFIX "p+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -80,7 +92,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0x0p+0******************");
+                                    assert(ex == "-0x0" LC_SUFFIX "p+0" PADDING);
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -88,7 +100,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "******************-0x0p+0");
+                                    assert(ex == PADDING "-0x0" LC_SUFFIX "p+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -96,7 +108,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-******************0x0p+0");
+                                    assert(ex == "-" PADDING "0x0" LC_SUFFIX "p+0");
                                     assert(ios.width() == 0);
                                 }
                             }
@@ -106,7 +118,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0x0p+0");
+                                    assert(ex == "-0x0" LG_SUFFIX "p+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -114,7 +126,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0x0p+0******************");
+                                    assert(ex == "-0x0" LG_SUFFIX "p+0" PADDING);
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -122,7 +134,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "******************-0x0p+0");
+                                    assert(ex == PADDING "-0x0" LG_SUFFIX "p+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -130,7 +142,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-******************0x0p+0");
+                                    assert(ex == "-" PADDING "0x0" LG_SUFFIX "p+0");
                                     assert(ios.width() == 0);
                                 }
                             }
@@ -143,7 +155,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0x0.p+0");
+                                    assert(ex == "-0x0" SP_LC_SUFFIX "p+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -151,7 +163,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0x0.p+0*****************");
+                                    assert(ex == "-0x0" SP_LC_SUFFIX "p+0" PADDING);
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -159,7 +171,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "*****************-0x0.p+0");
+                                    assert(ex == PADDING "-0x0" SP_LC_SUFFIX "p+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -167,7 +179,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-*****************0x0.p+0");
+                                    assert(ex == "-" PADDING "0x0" SP_LC_SUFFIX "p+0");
                                     assert(ios.width() == 0);
                                 }
                             }
@@ -177,7 +189,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0x0;p+0");
+                                    assert(ex == "-0x0" SP_LG_SUFFIX "p+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -185,7 +197,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0x0;p+0*****************");
+                                    assert(ex == "-0x0" SP_LG_SUFFIX "p+0" PADDING);
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -193,7 +205,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "*****************-0x0;p+0");
+                                    assert(ex == PADDING "-0x0" SP_LG_SUFFIX "p+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -201,7 +213,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-*****************0x0;p+0");
+                                    assert(ex == "-" PADDING "0x0" SP_LG_SUFFIX "p+0");
                                     assert(ios.width() == 0);
                                 }
                             }
@@ -217,7 +229,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0x0p+0");
+                                    assert(ex == "-0x0" LC_SUFFIX "p+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -225,7 +237,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0x0p+0******************");
+                                    assert(ex == "-0x0" LC_SUFFIX "p+0" PADDING);
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -233,7 +245,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "******************-0x0p+0");
+                                    assert(ex == PADDING "-0x0" LC_SUFFIX "p+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -241,7 +253,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-******************0x0p+0");
+                                    assert(ex == "-" PADDING "0x0" LC_SUFFIX "p+0");
                                     assert(ios.width() == 0);
                                 }
                             }
@@ -251,7 +263,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0x0p+0");
+                                    assert(ex == "-0x0" LG_SUFFIX "p+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -259,7 +271,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0x0p+0******************");
+                                    assert(ex == "-0x0" LG_SUFFIX "p+0" PADDING);
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -267,7 +279,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "******************-0x0p+0");
+                                    assert(ex == PADDING "-0x0" LG_SUFFIX "p+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -275,7 +287,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-******************0x0p+0");
+                                    assert(ex == "-" PADDING "0x0" LG_SUFFIX "p+0");
                                     assert(ios.width() == 0);
                                 }
                             }
@@ -288,7 +300,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0x0.p+0");
+                                    assert(ex == "-0x0" SP_LC_SUFFIX "p+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -296,7 +308,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0x0.p+0*****************");
+                                    assert(ex == "-0x0" SP_LC_SUFFIX "p+0" PADDING);
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -304,7 +316,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "*****************-0x0.p+0");
+                                    assert(ex == PADDING "-0x0" SP_LC_SUFFIX "p+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -312,7 +324,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-*****************0x0.p+0");
+                                    assert(ex == "-" PADDING "0x0" SP_LC_SUFFIX "p+0");
                                     assert(ios.width() == 0);
                                 }
                             }
@@ -322,7 +334,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0x0;p+0");
+                                    assert(ex == "-0x0" SP_LG_SUFFIX "p+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -330,7 +342,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0x0;p+0*****************");
+                                    assert(ex == "-0x0" SP_LG_SUFFIX "p+0" PADDING);
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -338,7 +350,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "*****************-0x0;p+0");
+                                    assert(ex == PADDING "-0x0" SP_LG_SUFFIX "p+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -346,7 +358,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-*****************0x0;p+0");
+                                    assert(ex == "-" PADDING "0x0" SP_LG_SUFFIX "p+0");
                                     assert(ios.width() == 0);
                                 }
                             }
@@ -365,7 +377,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0X0P+0");
+                                    assert(ex == "-0X0" LC_SUFFIX "P+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -373,7 +385,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0X0P+0******************");
+                                    assert(ex == "-0X0" LC_SUFFIX "P+0" PADDING);
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -381,7 +393,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "******************-0X0P+0");
+                                    assert(ex == PADDING "-0X0" LC_SUFFIX "P+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -389,7 +401,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-******************0X0P+0");
+                                    assert(ex == "-" PADDING "0X0" LC_SUFFIX "P+0");
                                     assert(ios.width() == 0);
                                 }
                             }
@@ -399,7 +411,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0X0P+0");
+                                    assert(ex == "-0X0" LG_SUFFIX "P+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -407,7 +419,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0X0P+0******************");
+                                    assert(ex == "-0X0" LG_SUFFIX "P+0" PADDING);
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -415,7 +427,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "******************-0X0P+0");
+                                    assert(ex == PADDING "-0X0" LG_SUFFIX "P+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -423,7 +435,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-******************0X0P+0");
+                                    assert(ex == "-" PADDING "0X0" LG_SUFFIX "P+0");
                                     assert(ios.width() == 0);
                                 }
                             }
@@ -436,7 +448,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0X0.P+0");
+                                    assert(ex == "-0X0" SP_LC_SUFFIX "P+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -444,7 +456,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0X0.P+0*****************");
+                                    assert(ex == "-0X0" SP_LC_SUFFIX "P+0" PADDING);
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -452,7 +464,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "*****************-0X0.P+0");
+                                    assert(ex == PADDING "-0X0" SP_LC_SUFFIX "P+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -460,7 +472,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-*****************0X0.P+0");
+                                    assert(ex == "-" PADDING "0X0" SP_LC_SUFFIX "P+0");
                                     assert(ios.width() == 0);
                                 }
                             }
@@ -470,7 +482,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0X0;P+0");
+                                    assert(ex == "-0X0" SP_LG_SUFFIX "P+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -478,7 +490,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0X0;P+0*****************");
+                                    assert(ex == "-0X0" SP_LG_SUFFIX "P+0" PADDING);
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -486,7 +498,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "*****************-0X0;P+0");
+                                    assert(ex == PADDING "-0X0" SP_LG_SUFFIX "P+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -494,7 +506,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-*****************0X0;P+0");
+                                    assert(ex == "-" PADDING "0X0" SP_LG_SUFFIX "P+0");
                                     assert(ios.width() == 0);
                                 }
                             }
@@ -510,7 +522,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0X0P+0");
+                                    assert(ex == "-0X0" LC_SUFFIX "P+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -518,7 +530,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0X0P+0******************");
+                                    assert(ex == "-0X0" LC_SUFFIX "P+0" PADDING);
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -526,7 +538,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "******************-0X0P+0");
+                                    assert(ex == PADDING "-0X0" LC_SUFFIX "P+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -534,7 +546,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-******************0X0P+0");
+                                    assert(ex == "-" PADDING "0X0" LC_SUFFIX "P+0");
                                     assert(ios.width() == 0);
                                 }
                             }
@@ -544,7 +556,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0X0P+0");
+                                    assert(ex == "-0X0" LG_SUFFIX "P+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -552,7 +564,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0X0P+0******************");
+                                    assert(ex == "-0X0" LG_SUFFIX "P+0" PADDING);
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -560,7 +572,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "******************-0X0P+0");
+                                    assert(ex == PADDING "-0X0" LG_SUFFIX "P+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -568,7 +580,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-******************0X0P+0");
+                                    assert(ex == "-" PADDING "0X0" LG_SUFFIX "P+0");
                                     assert(ios.width() == 0);
                                 }
                             }
@@ -581,7 +593,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0X0.P+0");
+                                    assert(ex == "-0X0" SP_LC_SUFFIX "P+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -589,7 +601,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0X0.P+0*****************");
+                                    assert(ex == "-0X0" SP_LC_SUFFIX "P+0" PADDING);
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -597,7 +609,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "*****************-0X0.P+0");
+                                    assert(ex == PADDING "-0X0" SP_LC_SUFFIX "P+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -605,7 +617,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-*****************0X0.P+0");
+                                    assert(ex == "-" PADDING "0X0" SP_LC_SUFFIX "P+0");
                                     assert(ios.width() == 0);
                                 }
                             }
@@ -615,7 +627,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0X0;P+0");
+                                    assert(ex == "-0X0" SP_LG_SUFFIX "P+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -623,7 +635,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0X0;P+0*****************");
+                                    assert(ex == "-0X0" SP_LG_SUFFIX "P+0" PADDING);
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -631,7 +643,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "*****************-0X0;P+0");
+                                    assert(ex == PADDING "-0X0" SP_LG_SUFFIX "P+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -639,7 +651,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-*****************0X0;P+0");
+                                    assert(ex == "-" PADDING "0X0" SP_LG_SUFFIX "P+0");
                                     assert(ios.width() == 0);
                                 }
                             }
@@ -661,7 +673,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0x0p+0");
+                                    assert(ex == "-0x0" LC_SUFFIX "p+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -669,7 +681,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0x0p+0******************");
+                                    assert(ex == "-0x0" LC_SUFFIX "p+0" PADDING);
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -677,7 +689,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "******************-0x0p+0");
+                                    assert(ex == PADDING "-0x0" LC_SUFFIX "p+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -685,7 +697,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-******************0x0p+0");
+                                    assert(ex == "-" PADDING "0x0" LC_SUFFIX "p+0");
                                     assert(ios.width() == 0);
                                 }
                             }
@@ -695,7 +707,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0x0p+0");
+                                    assert(ex == "-0x0" LG_SUFFIX "p+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -703,7 +715,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0x0p+0******************");
+                                    assert(ex == "-0x0" LG_SUFFIX "p+0" PADDING);
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -711,7 +723,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "******************-0x0p+0");
+                                    assert(ex == PADDING "-0x0" LG_SUFFIX "p+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -719,7 +731,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-******************0x0p+0");
+                                    assert(ex == "-" PADDING "0x0" LG_SUFFIX "p+0");
                                     assert(ios.width() == 0);
                                 }
                             }
@@ -732,7 +744,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0x0.p+0");
+                                    assert(ex == "-0x0" SP_LC_SUFFIX "p+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -740,7 +752,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0x0.p+0*****************");
+                                    assert(ex == "-0x0" SP_LC_SUFFIX "p+0" PADDING);
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -748,7 +760,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "*****************-0x0.p+0");
+                                    assert(ex == PADDING "-0x0" SP_LC_SUFFIX "p+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -756,7 +768,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-*****************0x0.p+0");
+                                    assert(ex == "-" PADDING "0x0" SP_LC_SUFFIX "p+0");
                                     assert(ios.width() == 0);
                                 }
                             }
@@ -766,7 +778,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0x0;p+0");
+                                    assert(ex == "-0x0" SP_LG_SUFFIX "p+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -774,7 +786,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0x0;p+0*****************");
+                                    assert(ex == "-0x0" SP_LG_SUFFIX "p+0" PADDING);
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -782,7 +794,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "*****************-0x0;p+0");
+                                    assert(ex == PADDING "-0x0" SP_LG_SUFFIX "p+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -790,7 +802,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-*****************0x0;p+0");
+                                    assert(ex == "-" PADDING "0x0" SP_LG_SUFFIX "p+0");
                                     assert(ios.width() == 0);
                                 }
                             }
@@ -806,7 +818,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0x0p+0");
+                                    assert(ex == "-0x0" LC_SUFFIX "p+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -814,7 +826,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0x0p+0******************");
+                                    assert(ex == "-0x0" LC_SUFFIX "p+0" PADDING);
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -822,7 +834,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "******************-0x0p+0");
+                                    assert(ex == PADDING "-0x0" LC_SUFFIX "p+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -830,7 +842,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-******************0x0p+0");
+                                    assert(ex == "-" PADDING "0x0" LC_SUFFIX "p+0");
                                     assert(ios.width() == 0);
                                 }
                             }
@@ -840,7 +852,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0x0p+0");
+                                    assert(ex == "-0x0" LG_SUFFIX "p+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -848,7 +860,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0x0p+0******************");
+                                    assert(ex == "-0x0" LG_SUFFIX "p+0" PADDING);
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -856,7 +868,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "******************-0x0p+0");
+                                    assert(ex == PADDING "-0x0" LG_SUFFIX "p+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -864,7 +876,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-******************0x0p+0");
+                                    assert(ex == "-" PADDING "0x0" LG_SUFFIX "p+0");
                                     assert(ios.width() == 0);
                                 }
                             }
@@ -877,7 +889,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0x0.p+0");
+                                    assert(ex == "-0x0" SP_LC_SUFFIX "p+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -885,7 +897,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0x0.p+0*****************");
+                                    assert(ex == "-0x0" SP_LC_SUFFIX "p+0" PADDING);
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -893,7 +905,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "*****************-0x0.p+0");
+                                    assert(ex == PADDING "-0x0" SP_LC_SUFFIX "p+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -901,7 +913,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-*****************0x0.p+0");
+                                    assert(ex == "-" PADDING "0x0" SP_LC_SUFFIX "p+0");
                                     assert(ios.width() == 0);
                                 }
                             }
@@ -911,7 +923,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0x0;p+0");
+                                    assert(ex == "-0x0" SP_LG_SUFFIX "p+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -919,7 +931,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0x0;p+0*****************");
+                                    assert(ex == "-0x0" SP_LG_SUFFIX "p+0" PADDING);
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -927,7 +939,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "*****************-0x0;p+0");
+                                    assert(ex == PADDING "-0x0" SP_LG_SUFFIX "p+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -935,7 +947,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-*****************0x0;p+0");
+                                    assert(ex == "-" PADDING "0x0" SP_LG_SUFFIX "p+0");
                                     assert(ios.width() == 0);
                                 }
                             }
@@ -954,7 +966,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0X0P+0");
+                                    assert(ex == "-0X0" LC_SUFFIX "P+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -962,7 +974,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0X0P+0******************");
+                                    assert(ex == "-0X0" LC_SUFFIX "P+0" PADDING);
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -970,7 +982,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "******************-0X0P+0");
+                                    assert(ex == PADDING "-0X0" LC_SUFFIX "P+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -978,7 +990,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-******************0X0P+0");
+                                    assert(ex == "-" PADDING "0X0" LC_SUFFIX "P+0");
                                     assert(ios.width() == 0);
                                 }
                             }
@@ -988,7 +1000,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0X0P+0");
+                                    assert(ex == "-0X0" LG_SUFFIX "P+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -996,7 +1008,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0X0P+0******************");
+                                    assert(ex == "-0X0" LG_SUFFIX "P+0" PADDING);
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -1004,7 +1016,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "******************-0X0P+0");
+                                    assert(ex == PADDING "-0X0" LG_SUFFIX "P+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -1012,7 +1024,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-******************0X0P+0");
+                                    assert(ex == "-" PADDING "0X0" LG_SUFFIX "P+0");
                                     assert(ios.width() == 0);
                                 }
                             }
@@ -1025,7 +1037,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0X0.P+0");
+                                    assert(ex == "-0X0" SP_LC_SUFFIX "P+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -1033,7 +1045,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0X0.P+0*****************");
+                                    assert(ex == "-0X0" SP_LC_SUFFIX "P+0" PADDING);
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -1041,7 +1053,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "*****************-0X0.P+0");
+                                    assert(ex == PADDING "-0X0" SP_LC_SUFFIX "P+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -1049,7 +1061,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-*****************0X0.P+0");
+                                    assert(ex == "-" PADDING "0X0" SP_LC_SUFFIX "P+0");
                                     assert(ios.width() == 0);
                                 }
                             }
@@ -1059,7 +1071,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0X0;P+0");
+                                    assert(ex == "-0X0" SP_LG_SUFFIX "P+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -1067,7 +1079,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0X0;P+0*****************");
+                                    assert(ex == "-0X0" SP_LG_SUFFIX "P+0" PADDING);
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -1075,7 +1087,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "*****************-0X0;P+0");
+                                    assert(ex == PADDING "-0X0" SP_LG_SUFFIX "P+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -1083,7 +1095,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-*****************0X0;P+0");
+                                    assert(ex == "-" PADDING "0X0" SP_LG_SUFFIX "P+0");
                                     assert(ios.width() == 0);
                                 }
                             }
@@ -1099,7 +1111,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0X0P+0");
+                                    assert(ex == "-0X0" LC_SUFFIX "P+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -1107,7 +1119,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0X0P+0******************");
+                                    assert(ex == "-0X0" LC_SUFFIX "P+0" PADDING);
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -1115,7 +1127,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "******************-0X0P+0");
+                                    assert(ex == PADDING "-0X0" LC_SUFFIX "P+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -1123,7 +1135,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-******************0X0P+0");
+                                    assert(ex == "-" PADDING "0X0" LC_SUFFIX "P+0");
                                     assert(ios.width() == 0);
                                 }
                             }
@@ -1133,7 +1145,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0X0P+0");
+                                    assert(ex == "-0X0" LG_SUFFIX "P+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -1141,7 +1153,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0X0P+0******************");
+                                    assert(ex == "-0X0" LG_SUFFIX "P+0" PADDING);
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -1149,7 +1161,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "******************-0X0P+0");
+                                    assert(ex == PADDING "-0X0" LG_SUFFIX "P+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -1157,7 +1169,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-******************0X0P+0");
+                                    assert(ex == "-" PADDING "0X0" LG_SUFFIX "P+0");
                                     assert(ios.width() == 0);
                                 }
                             }
@@ -1170,7 +1182,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0X0.P+0");
+                                    assert(ex == "-0X0" SP_LC_SUFFIX "P+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -1178,7 +1190,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0X0.P+0*****************");
+                                    assert(ex == "-0X0" SP_LC_SUFFIX "P+0" PADDING);
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -1186,7 +1198,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "*****************-0X0.P+0");
+                                    assert(ex == PADDING "-0X0" SP_LC_SUFFIX "P+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -1194,7 +1206,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-*****************0X0.P+0");
+                                    assert(ex == "-" PADDING "0X0" SP_LC_SUFFIX "P+0");
                                     assert(ios.width() == 0);
                                 }
                             }
@@ -1204,7 +1216,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0X0;P+0");
+                                    assert(ex == "-0X0" SP_LG_SUFFIX "P+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -1212,7 +1224,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0X0;P+0*****************");
+                                    assert(ex == "-0X0" SP_LG_SUFFIX "P+0" PADDING);
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -1220,7 +1232,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "*****************-0X0;P+0");
+                                    assert(ex == PADDING "-0X0" SP_LG_SUFFIX "P+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -1228,7 +1240,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-*****************0X0;P+0");
+                                    assert(ex == "-" PADDING "0X0" SP_LG_SUFFIX "P+0");
                                     assert(ios.width() == 0);
                                 }
                             }
@@ -1250,7 +1262,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0x0p+0");
+                                    assert(ex == "-0x0" LC_SUFFIX "p+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -1258,7 +1270,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0x0p+0******************");
+                                    assert(ex == "-0x0" LC_SUFFIX "p+0" PADDING);
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -1266,7 +1278,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "******************-0x0p+0");
+                                    assert(ex == PADDING "-0x0" LC_SUFFIX "p+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -1274,7 +1286,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-******************0x0p+0");
+                                    assert(ex == "-" PADDING "0x0" LC_SUFFIX "p+0");
                                     assert(ios.width() == 0);
                                 }
                             }
@@ -1284,7 +1296,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0x0p+0");
+                                    assert(ex == "-0x0" LG_SUFFIX "p+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -1292,7 +1304,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0x0p+0******************");
+                                    assert(ex == "-0x0" LG_SUFFIX "p+0" PADDING);
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -1300,7 +1312,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "******************-0x0p+0");
+                                    assert(ex == PADDING "-0x0" LG_SUFFIX "p+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -1308,7 +1320,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-******************0x0p+0");
+                                    assert(ex == "-" PADDING "0x0" LG_SUFFIX "p+0");
                                     assert(ios.width() == 0);
                                 }
                             }
@@ -1321,7 +1333,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0x0.p+0");
+                                    assert(ex == "-0x0" SP_LC_SUFFIX "p+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -1329,7 +1341,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0x0.p+0*****************");
+                                    assert(ex == "-0x0" SP_LC_SUFFIX "p+0" PADDING);
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -1337,7 +1349,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "*****************-0x0.p+0");
+                                    assert(ex == PADDING "-0x0" SP_LC_SUFFIX "p+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -1345,7 +1357,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-*****************0x0.p+0");
+                                    assert(ex == "-" PADDING "0x0" SP_LC_SUFFIX "p+0");
                                     assert(ios.width() == 0);
                                 }
                             }
@@ -1355,7 +1367,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0x0;p+0");
+                                    assert(ex == "-0x0" SP_LG_SUFFIX "p+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -1363,7 +1375,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0x0;p+0*****************");
+                                    assert(ex == "-0x0" SP_LG_SUFFIX "p+0" PADDING);
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -1371,7 +1383,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "*****************-0x0;p+0");
+                                    assert(ex == PADDING "-0x0" SP_LG_SUFFIX "p+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -1379,7 +1391,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-*****************0x0;p+0");
+                                    assert(ex == "-" PADDING "0x0" SP_LG_SUFFIX "p+0");
                                     assert(ios.width() == 0);
                                 }
                             }
@@ -1395,7 +1407,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0x0p+0");
+                                    assert(ex == "-0x0" LC_SUFFIX "p+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -1403,7 +1415,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0x0p+0******************");
+                                    assert(ex == "-0x0" LC_SUFFIX "p+0" PADDING);
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -1411,7 +1423,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "******************-0x0p+0");
+                                    assert(ex == PADDING "-0x0" LC_SUFFIX "p+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -1419,7 +1431,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-******************0x0p+0");
+                                    assert(ex == "-" PADDING "0x0" LC_SUFFIX "p+0");
                                     assert(ios.width() == 0);
                                 }
                             }
@@ -1429,7 +1441,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0x0p+0");
+                                    assert(ex == "-0x0" LG_SUFFIX "p+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -1437,7 +1449,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0x0p+0******************");
+                                    assert(ex == "-0x0" LG_SUFFIX "p+0" PADDING);
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -1445,7 +1457,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "******************-0x0p+0");
+                                    assert(ex == PADDING "-0x0" LG_SUFFIX "p+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -1453,7 +1465,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-******************0x0p+0");
+                                    assert(ex == "-" PADDING "0x0" LG_SUFFIX "p+0");
                                     assert(ios.width() == 0);
                                 }
                             }
@@ -1466,7 +1478,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0x0.p+0");
+                                    assert(ex == "-0x0" SP_LC_SUFFIX "p+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -1474,7 +1486,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0x0.p+0*****************");
+                                    assert(ex == "-0x0" SP_LC_SUFFIX "p+0" PADDING);
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -1482,7 +1494,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "*****************-0x0.p+0");
+                                    assert(ex == PADDING "-0x0" SP_LC_SUFFIX "p+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -1490,7 +1502,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-*****************0x0.p+0");
+                                    assert(ex == "-" PADDING "0x0" SP_LC_SUFFIX "p+0");
                                     assert(ios.width() == 0);
                                 }
                             }
@@ -1500,7 +1512,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0x0;p+0");
+                                    assert(ex == "-0x0" SP_LG_SUFFIX "p+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -1508,7 +1520,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0x0;p+0*****************");
+                                    assert(ex == "-0x0" SP_LG_SUFFIX "p+0" PADDING);
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -1516,7 +1528,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "*****************-0x0;p+0");
+                                    assert(ex == PADDING "-0x0" SP_LG_SUFFIX "p+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -1524,7 +1536,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-*****************0x0;p+0");
+                                    assert(ex == "-" PADDING "0x0" SP_LG_SUFFIX "p+0");
                                     assert(ios.width() == 0);
                                 }
                             }
@@ -1543,7 +1555,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0X0P+0");
+                                    assert(ex == "-0X0" LC_SUFFIX "P+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -1551,7 +1563,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0X0P+0******************");
+                                    assert(ex == "-0X0" LC_SUFFIX "P+0" PADDING);
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -1559,7 +1571,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "******************-0X0P+0");
+                                    assert(ex == PADDING "-0X0" LC_SUFFIX "P+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -1567,7 +1579,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-******************0X0P+0");
+                                    assert(ex == "-" PADDING "0X0" LC_SUFFIX "P+0");
                                     assert(ios.width() == 0);
                                 }
                             }
@@ -1577,7 +1589,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0X0P+0");
+                                    assert(ex == "-0X0" LG_SUFFIX "P+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -1585,7 +1597,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0X0P+0******************");
+                                    assert(ex == "-0X0" LG_SUFFIX "P+0" PADDING);
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -1593,7 +1605,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "******************-0X0P+0");
+                                    assert(ex == PADDING "-0X0" LG_SUFFIX "P+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -1601,7 +1613,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-******************0X0P+0");
+                                    assert(ex == "-" PADDING "0X0" LG_SUFFIX "P+0");
                                     assert(ios.width() == 0);
                                 }
                             }
@@ -1614,7 +1626,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0X0.P+0");
+                                    assert(ex == "-0X0" SP_LC_SUFFIX "P+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -1622,7 +1634,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0X0.P+0*****************");
+                                    assert(ex == "-0X0" SP_LC_SUFFIX "P+0" PADDING);
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -1630,7 +1642,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "*****************-0X0.P+0");
+                                    assert(ex == PADDING "-0X0" SP_LC_SUFFIX "P+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -1638,7 +1650,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-*****************0X0.P+0");
+                                    assert(ex == "-" PADDING "0X0" SP_LC_SUFFIX "P+0");
                                     assert(ios.width() == 0);
                                 }
                             }
@@ -1648,7 +1660,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0X0;P+0");
+                                    assert(ex == "-0X0" SP_LG_SUFFIX "P+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -1656,7 +1668,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0X0;P+0*****************");
+                                    assert(ex == "-0X0" SP_LG_SUFFIX "P+0" PADDING);
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -1664,7 +1676,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "*****************-0X0;P+0");
+                                    assert(ex == PADDING "-0X0" SP_LG_SUFFIX "P+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -1672,7 +1684,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-*****************0X0;P+0");
+                                    assert(ex == "-" PADDING "0X0" SP_LG_SUFFIX "P+0");
                                     assert(ios.width() == 0);
                                 }
                             }
@@ -1688,7 +1700,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0X0P+0");
+                                    assert(ex == "-0X0" LC_SUFFIX "P+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -1696,7 +1708,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0X0P+0******************");
+                                    assert(ex == "-0X0" LC_SUFFIX "P+0" PADDING);
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -1704,7 +1716,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "******************-0X0P+0");
+                                    assert(ex == PADDING "-0X0" LC_SUFFIX "P+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -1712,7 +1724,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-******************0X0P+0");
+                                    assert(ex == "-" PADDING "0X0" LC_SUFFIX "P+0");
                                     assert(ios.width() == 0);
                                 }
                             }
@@ -1722,7 +1734,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0X0P+0");
+                                    assert(ex == "-0X0" LG_SUFFIX "P+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -1730,7 +1742,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0X0P+0******************");
+                                    assert(ex == "-0X0" LG_SUFFIX "P+0" PADDING);
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -1738,7 +1750,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "******************-0X0P+0");
+                                    assert(ex == PADDING "-0X0" LG_SUFFIX "P+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -1746,7 +1758,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-******************0X0P+0");
+                                    assert(ex == "-" PADDING "0X0" LG_SUFFIX "P+0");
                                     assert(ios.width() == 0);
                                 }
                             }
@@ -1759,7 +1771,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0X0.P+0");
+                                    assert(ex == "-0X0" SP_LC_SUFFIX "P+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -1767,7 +1779,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0X0.P+0*****************");
+                                    assert(ex == "-0X0" SP_LC_SUFFIX "P+0" PADDING);
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -1775,7 +1787,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "*****************-0X0.P+0");
+                                    assert(ex == PADDING "-0X0" SP_LC_SUFFIX "P+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -1783,7 +1795,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-*****************0X0.P+0");
+                                    assert(ex == "-" PADDING "0X0" SP_LC_SUFFIX "P+0");
                                     assert(ios.width() == 0);
                                 }
                             }
@@ -1793,7 +1805,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0X0;P+0");
+                                    assert(ex == "-0X0" SP_LG_SUFFIX "P+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -1801,7 +1813,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-0X0;P+0*****************");
+                                    assert(ex == "-0X0" SP_LG_SUFFIX "P+0" PADDING);
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -1809,7 +1821,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "*****************-0X0;P+0");
+                                    assert(ex == PADDING "-0X0" SP_LG_SUFFIX "P+0");
                                     assert(ios.width() == 0);
                                 }
                                 ios.width(25);
@@ -1817,7 +1829,7 @@ void test1()
                                 {
                                     cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', v);
                                     std::string ex(str, base(iter));
-                                    assert(ex == "-*****************0X0;P+0");
+                                    assert(ex == "-" PADDING "0X0" SP_LG_SUFFIX "P+0");
                                     assert(ios.width() == 0);
                                 }
                             }


### PR DESCRIPTION
The test expects a hex float format of `0x0p+0`, but AIX prints `0x0.0p+0`. This change adjusts the test to accept both. 