### PR TITLE
Revert "[MC] Make ELFUniquingMap a StringMap"

### DIFF
--- a/llvm/lib/MC/MCContext.cpp
+++ b/llvm/lib/MC/MCContext.cpp
@@ -44,7 +44,6 @@
 #include "llvm/MC/SectionKind.h"
 #include "llvm/Support/Casting.h"
 #include "llvm/Support/CommandLine.h"
-#include "llvm/Support/EndianStream.h"
 #include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/MemoryBuffer.h"
 #include "llvm/Support/Path.h"
@@ -549,42 +548,16 @@ MCSectionELF *MCContext::getELFSection(const Twine &Section, unsigned Type,
   if (GroupSym)
     Group = GroupSym->getName();
   assert(!(LinkedToSym && LinkedToSym->getName().empty()));
+  // Do the lookup, if we have a hit, return it.
+  auto IterBool = ELFUniquingMap.insert(std::make_pair(
+      ELFSectionKey{Section.str(), Group,
+                    LinkedToSym ? LinkedToSym->getName() : "", UniqueID},
+      nullptr));
+  auto &Entry = *IterBool.first;
+  if (!IterBool.second)
+    return Entry.second;
 
-  // Sections are differentiated by the quadruple (section_name, group_name,
-  // unique_id, link_to_symbol_name). Sections sharing the same quadruple are
-  // combined into one section. As an optimization, non-unique sections without
-  // group or linked-to symbol have a shorter unique-ing key.
-  std::pair<StringMap<MCSectionELF *>::iterator, bool> EntryNewPair;
-  // Length of the section name, which are the first SectionLen bytes of the key
-  unsigned SectionLen;
-  if (GroupSym || LinkedToSym || UniqueID != MCSection::NonUniqueID) {
-    SmallString<128> Buffer;
-    Section.toVector(Buffer);
-    SectionLen = Buffer.size();
-    Buffer.push_back(0); // separator which cannot occur in the name
-    if (GroupSym)
-      Buffer.append(GroupSym->getName());
-    Buffer.push_back(0); // separator which cannot occur in the name
-    if (LinkedToSym)
-      Buffer.append(LinkedToSym->getName());
-    support::endian::write(Buffer, UniqueID, endianness::native);
-    StringRef UniqueMapKey = StringRef(Buffer);
-    EntryNewPair = ELFUniquingMap.insert(std::make_pair(UniqueMapKey, nullptr));
-  } else if (!Section.isSingleStringRef()) {
-    SmallString<128> Buffer;
-    SectionLen = Buffer.size();
-    StringRef UniqueMapKey = Section.toStringRef(Buffer);
-    EntryNewPair = ELFUniquingMap.insert(std::make_pair(UniqueMapKey, nullptr));
-  } else {
-    SectionLen = Section.getSingleStringRef().size();
-    StringRef UniqueMapKey = Section.getSingleStringRef();
-    EntryNewPair = ELFUniquingMap.insert(std::make_pair(UniqueMapKey, nullptr));
-  }
-
-  if (!EntryNewPair.second)
-    return EntryNewPair.first->second;
-
-  StringRef CachedName = EntryNewPair.first->getKey().take_front(SectionLen);
+  StringRef CachedName = Entry.first.SectionName;
 
   SectionKind Kind;
   if (Flags & ELF::SHF_ARM_PURECODE)
@@ -628,7 +601,7 @@ MCSectionELF *MCContext::getELFSection(const Twine &Section, unsigned Type,
   MCSectionELF *Result =
       createELFSectionImpl(CachedName, Type, Flags, Kind, EntrySize, GroupSym,
                            IsComdat, UniqueID, LinkedToSym);
-  EntryNewPair.first->second = Result;
+  Entry.second = Result;
 
   recordELFMergeableSectionInfo(Result->getName(), Result->getFlags(),
                                 Result->getUniqueID(), Result->getEntrySize());


### PR DESCRIPTION
Reverts llvm/llvm-project#95006

Seems like there's some bug where the section name is empty in the `if (!Section.isSingleStringRef())`. Revert for now to get builds back to green.