### PR TITLE
[clang-format] Don't count template template parameter as declaration

### DIFF
--- a/clang/lib/Format/TokenAnnotator.cpp
+++ b/clang/lib/Format/TokenAnnotator.cpp
@@ -1266,23 +1266,22 @@ private:
   }
 
   bool parseTemplateDeclaration() {
-    if (CurrentToken && CurrentToken->is(tok::less)) {
-      CurrentToken->setType(TT_TemplateOpener);
-      next();
-      TemplateDeclarationDepth++;
-      if (!parseAngle()) {
-        TemplateDeclarationDepth--;
-        return false;
-      }
-      TemplateDeclarationDepth--;
-      if (CurrentToken &&
-          (TemplateDeclarationDepth == 0 ||
-           !CurrentToken->isOneOf(tok::kw_typename, tok::kw_class))) {
-        CurrentToken->Previous->ClosesTemplateDeclaration = true;
-      }
-      return true;
-    }
-    return false;
+    if (!CurrentToken || CurrentToken->isNot(tok::less))
+      return false;
+
+    CurrentToken->setType(TT_TemplateOpener);
+    next();
+
+    TemplateDeclarationDepth++;
+    const bool WellFormed = parseAngle();
+    TemplateDeclarationDepth--;
+    if (!WellFormed)
+      return false;
+
+    if (CurrentToken && TemplateDeclarationDepth == 0)
+      CurrentToken->Previous->ClosesTemplateDeclaration = true;
+
+    return true;
   }
 
   bool consumeToken() {

--- a/clang/lib/Format/TokenAnnotator.cpp
+++ b/clang/lib/Format/TokenAnnotator.cpp
@@ -1276,8 +1276,8 @@ private:
       }
       TemplateDeclarationDepth--;
       if (CurrentToken &&
-          !(TemplateDeclarationDepth > 0 &&
-            CurrentToken->isOneOf(tok::kw_typename, tok::kw_class))) {
+          (TemplateDeclarationDepth == 0 ||
+            !CurrentToken->isOneOf(tok::kw_typename, tok::kw_class))) {
         CurrentToken->Previous->ClosesTemplateDeclaration = true;
       }
       return true;

--- a/clang/lib/Format/TokenAnnotator.cpp
+++ b/clang/lib/Format/TokenAnnotator.cpp
@@ -1277,7 +1277,7 @@ private:
       TemplateDeclarationDepth--;
       if (CurrentToken &&
           (TemplateDeclarationDepth == 0 ||
-            !CurrentToken->isOneOf(tok::kw_typename, tok::kw_class))) {
+           !CurrentToken->isOneOf(tok::kw_typename, tok::kw_class))) {
         CurrentToken->Previous->ClosesTemplateDeclaration = true;
       }
       return true;

--- a/clang/unittests/Format/TokenAnnotatorTest.cpp
+++ b/clang/unittests/Format/TokenAnnotatorTest.cpp
@@ -584,6 +584,23 @@ TEST_F(TokenAnnotatorTest, UnderstandsNonTemplateAngleBrackets) {
   EXPECT_TOKEN(Tokens[20], tok::greater, TT_BinaryOperator);
 }
 
+TEST_F(TokenAnnotatorTest, UnderstandsTemplateTemplateParameters) {
+  auto Tokens = annotate("template <template <typename...> typename X,\n"
+                         "          template <typename...> typename Y,\n"
+                         "          typename... T>\n"
+                         "class A {};");
+  ASSERT_EQ(Tokens.size(), 28u) << Tokens;
+  EXPECT_TOKEN(Tokens[1], tok::less, TT_TemplateOpener);
+  EXPECT_TOKEN(Tokens[3], tok::less, TT_TemplateOpener);
+  EXPECT_TOKEN(Tokens[6], tok::greater, TT_TemplateCloser);
+  EXPECT_EQ(Tokens[6]->ClosesTemplateDeclaration, 0u);
+  EXPECT_TOKEN(Tokens[11], tok::less, TT_TemplateOpener);
+  EXPECT_TOKEN(Tokens[14], tok::greater, TT_TemplateCloser);
+  EXPECT_EQ(Tokens[14]->ClosesTemplateDeclaration, 0u);
+  EXPECT_TOKEN(Tokens[21], tok::greater, TT_TemplateCloser);
+  EXPECT_EQ(Tokens[21]->ClosesTemplateDeclaration, 1u);
+}
+
 TEST_F(TokenAnnotatorTest, UnderstandsWhitespaceSensitiveMacros) {
   FormatStyle Style = getLLVMStyle();
   Style.WhitespaceSensitiveMacros.push_back("FOO");

--- a/clang/unittests/Format/TokenAnnotatorTest.cpp
+++ b/clang/unittests/Format/TokenAnnotatorTest.cpp
@@ -586,19 +586,19 @@ TEST_F(TokenAnnotatorTest, UnderstandsNonTemplateAngleBrackets) {
 
 TEST_F(TokenAnnotatorTest, UnderstandsTemplateTemplateParameters) {
   auto Tokens = annotate("template <template <typename...> typename X,\n"
-                         "          template <typename...> typename Y,\n"
+                         "          template <typename...> class Y,\n"
                          "          typename... T>\n"
                          "class A {};");
   ASSERT_EQ(Tokens.size(), 28u) << Tokens;
   EXPECT_TOKEN(Tokens[1], tok::less, TT_TemplateOpener);
   EXPECT_TOKEN(Tokens[3], tok::less, TT_TemplateOpener);
   EXPECT_TOKEN(Tokens[6], tok::greater, TT_TemplateCloser);
-  EXPECT_EQ(Tokens[6]->ClosesTemplateDeclaration, 0u);
+  EXPECT_FALSE(Tokens[6]->ClosesTemplateDeclaration);
   EXPECT_TOKEN(Tokens[11], tok::less, TT_TemplateOpener);
   EXPECT_TOKEN(Tokens[14], tok::greater, TT_TemplateCloser);
-  EXPECT_EQ(Tokens[14]->ClosesTemplateDeclaration, 0u);
+  EXPECT_FALSE(Tokens[14]->ClosesTemplateDeclaration);
   EXPECT_TOKEN(Tokens[21], tok::greater, TT_TemplateCloser);
-  EXPECT_EQ(Tokens[21]->ClosesTemplateDeclaration, 1u);
+  EXPECT_TRUE(Tokens[21]->ClosesTemplateDeclaration);
 }
 
 TEST_F(TokenAnnotatorTest, UnderstandsWhitespaceSensitiveMacros) {


### PR DESCRIPTION
In ContinuationIndenter::mustBreak, a break is required between a template declaration and the function/class declaration it applies to, if the template declaration spans multiple lines.

However, this also includes template template parameters, which can cause extra erroneous line breaks in some declarations.

This patch makes template template parameters not be counted as template declarations.

Fixes https://github.com/llvm/llvm-project/issues/93793
Fixes https://github.com/llvm/llvm-project/issues/48746