### PR TITLE
[libc][math][c23] Temporarily disable float16 on 32-bit Arm

### DIFF
--- a/libc/include/llvm-libc-macros/float16-macros.h
+++ b/libc/include/llvm-libc-macros/float16-macros.h
@@ -11,7 +11,7 @@
 
 #if defined(__FLT16_MANT_DIG__) &&                                             \
     (!defined(__GNUC__) || __GNUC__ >= 13 || defined(__clang__)) &&            \
-    !defined(__riscv)
+    !defined(__arm__) && !defined(_M_ARM) && !defined(__riscv)
 #define LIBC_TYPES_HAS_FLOAT16
 #endif
 


### PR DESCRIPTION
See Buildbot failure: https://lab.llvm.org/buildbot/#/builders/229/builds/27009.