### PR TITLE
[clang] Don't use -Wno-nested-anon-types on GCC

### DIFF
--- a/clang/CMakeLists.txt
+++ b/clang/CMakeLists.txt
@@ -350,7 +350,9 @@ if (LLVM_COMPILER_IS_GCC_COMPATIBLE)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pedantic -Wno-long-long")
   endif ()
 
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-nested-anon-types" )
+  if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-nested-anon-types" )
+  endif ()
 endif ()
 
 # Determine HOST_LINK_VERSION on Darwin.


### PR DESCRIPTION
GCC usually doesn't warn about unrecognized -Wno-<foo> options, if no diagnostics are printed. However if some diagnostics are printed, it also mentions that there were unrecognized -Wno-<foo> options.

Before 4feae05c6abda364a9295aecfa600d7d4e7dfeb6, we checked for whether -Wnested-anon-types was supported, and added the -Wno-<foo> form if the positive form of the option was supported.

As of GCC 14, -Wnested-anon-types isn't supported, thus limit the use of the option to actual Clang (and still only while using the GCC compatible driver).

This avoids unnecessary mentions about unrecognized -Wno-<foo> options when building with GCC.