### PR TITLE
[CodeGen] Use temp symbol for MBBs

### DIFF
--- a/llvm/include/llvm/MC/MCContext.h
+++ b/llvm/include/llvm/MC/MCContext.h
@@ -455,6 +455,12 @@ public:
   MCSymbol *createNamedTempSymbol();
   MCSymbol *createNamedTempSymbol(const Twine &Name);
 
+  /// Get or create a symbol for a basic block. For non-always-emit symbols,
+  /// this behaves like createTempSymbol, except that it uses the
+  /// PrivateLabelPrefix instead of the PrivateGlobalPrefix. When AlwaysEmit is
+  /// true, behaves like getOrCreateSymbol, prefixed with PrivateLabelPrefix.
+  MCSymbol *createBlockSymbol(const Twine &Name, bool AlwaysEmit = false);
+
   /// Create the definition of a directional local symbol for numbered label
   /// (used for "1:" definitions).
   MCSymbol *createDirectionalLocalSymbol(unsigned LocalLabelVal);

--- a/llvm/lib/CodeGen/MachineBasicBlock.cpp
+++ b/llvm/lib/CodeGen/MachineBasicBlock.cpp
@@ -80,10 +80,11 @@ MCSymbol *MachineBasicBlock::getSymbol() const {
       }
       CachedMCSymbol = Ctx.getOrCreateSymbol(MF->getName() + Suffix);
     } else {
-      const StringRef Prefix = Ctx.getAsmInfo()->getPrivateLabelPrefix();
-      CachedMCSymbol = Ctx.getOrCreateSymbol(Twine(Prefix) + "BB" +
-                                             Twine(MF->getFunctionNumber()) +
-                                             "_" + Twine(getNumber()));
+      // If the block occurs as label in inline assembly, parsing the assembly
+      // needs an actual label name => set AlwaysEmit in these cases.
+      CachedMCSymbol = Ctx.createBlockSymbol(
+          "BB" + Twine(MF->getFunctionNumber()) + "_" + Twine(getNumber()),
+          /*AlwaysEmit=*/hasLabelMustBeEmitted());
     }
   }
   return CachedMCSymbol;
@@ -104,10 +105,9 @@ MCSymbol *MachineBasicBlock::getEndSymbol() const {
   if (!CachedEndMCSymbol) {
     const MachineFunction *MF = getParent();
     MCContext &Ctx = MF->getContext();
-    auto Prefix = Ctx.getAsmInfo()->getPrivateLabelPrefix();
-    CachedEndMCSymbol = Ctx.getOrCreateSymbol(Twine(Prefix) + "BB_END" +
-                                              Twine(MF->getFunctionNumber()) +
-                                              "_" + Twine(getNumber()));
+    CachedEndMCSymbol = Ctx.createBlockSymbol(
+        "BB_END" + Twine(MF->getFunctionNumber()) + "_" + Twine(getNumber()),
+        /*AlwaysEmit=*/false);
   }
   return CachedEndMCSymbol;
 }

--- a/llvm/lib/MC/MCContext.cpp
+++ b/llvm/lib/MC/MCContext.cpp
@@ -318,6 +318,18 @@ MCSymbol *MCContext::createNamedTempSymbol(const Twine &Name) {
                                /*IsTemporary=*/!SaveTempLabels);
 }
 
+MCSymbol *MCContext::createBlockSymbol(const Twine &Name, bool AlwaysEmit) {
+  if (AlwaysEmit)
+    return getOrCreateSymbol(MAI->getPrivateLabelPrefix() + Name);
+
+  if (!UseNamesOnTempLabels)
+    return createSymbolImpl(nullptr, /*IsTemporary=*/true);
+
+  SmallString<128> NameSV;
+  raw_svector_ostream(NameSV) << MAI->getPrivateLabelPrefix() << Name;
+  return createSymbol(NameSV, false, /*IsTemporary=*/true);
+}
+
 MCSymbol *MCContext::createLinkerPrivateTempSymbol() {
   return createLinkerPrivateSymbol("tmp");
 }

--- a/llvm/lib/MC/MCContext.cpp
+++ b/llvm/lib/MC/MCContext.cpp
@@ -322,12 +322,11 @@ MCSymbol *MCContext::createBlockSymbol(const Twine &Name, bool AlwaysEmit) {
   if (AlwaysEmit)
     return getOrCreateSymbol(MAI->getPrivateLabelPrefix() + Name);
 
-  if (!UseNamesOnTempLabels)
-    return createSymbolImpl(nullptr, /*IsTemporary=*/true);
-
-  SmallString<128> NameSV;
-  raw_svector_ostream(NameSV) << MAI->getPrivateLabelPrefix() << Name;
-  return createSymbol(NameSV, false, /*IsTemporary=*/true);
+  bool IsTemporary = !SaveTempLabels;
+  if (IsTemporary && !UseNamesOnTempLabels)
+    return createSymbolImpl(nullptr, IsTemporary);
+  return createRenamableSymbol(MAI->getPrivateLabelPrefix() << Name,
+                               /*AlwaysAddSuffix=*/false, IsTemporary);
 }
 
 MCSymbol *MCContext::createLinkerPrivateTempSymbol() {

--- a/llvm/test/CodeGen/AArch64/branch-relax-cross-section.mir
+++ b/llvm/test/CodeGen/AArch64/branch-relax-cross-section.mir
@@ -473,8 +473,8 @@ body:             |
   ; INDIRECT-NEXT:    successors: %bb.1
   ; INDIRECT-NEXT:    liveins: $x16
   ; INDIRECT-NEXT:    {{ $}}
-  ; INDIRECT-NEXT:    $[[SCAVENGED_REGISTER:x[0-9]+]] = ADRP target-flags(aarch64-page) <mcsymbol .LBB5_1>
-  ; INDIRECT-NEXT:    $[[SCAVENGED_REGISTER]] = ADDXri $[[SCAVENGED_REGISTER]], target-flags(aarch64-pageoff, aarch64-nc) <mcsymbol .LBB5_1>, 0
+  ; INDIRECT-NEXT:    $[[SCAVENGED_REGISTER:x[0-9]+]] = ADRP target-flags(aarch64-page) <mcsymbol >
+  ; INDIRECT-NEXT:    $[[SCAVENGED_REGISTER]] = ADDXri $[[SCAVENGED_REGISTER]], target-flags(aarch64-pageoff, aarch64-nc) <mcsymbol >, 0
   ; INDIRECT-NEXT:    BR $[[SCAVENGED_REGISTER]]
 
   bb.0.entry:

--- a/llvm/test/CodeGen/BPF/objdump_cond_op.ll
+++ b/llvm/test/CodeGen/BPF/objdump_cond_op.ll
@@ -27,7 +27,7 @@ define i32 @test(i32, i32) local_unnamed_addr #0 {
   br label %13
 ; CHECK: r1 <<= 32
 ; CHECK: r1 >>= 32
-; CHECK: if r1 != 2 goto +6 <LBB0_2>
+; CHECK: if r1 != 2 goto +6 <test+0x48>
 
 ; <label>:8:                                      ; preds = %2
   %9 = icmp eq i32 %0, %1
@@ -38,32 +38,29 @@ define i32 @test(i32, i32) local_unnamed_addr #0 {
 ; CHECK: r0 = *(u32 *)(r1 + 0)
 ; CHECK: r0 *= r0
 ; CHECK: r0 <<= 1
-; CHECK: goto +7 <LBB0_4>
+; CHECK: goto +7 <test+0x80>
 
 ; <label>:11:                                     ; preds = %8
   %12 = shl nsw i32 %10, 2
   br label %13
 
-; CHECK-LABEL: <LBB0_2>:
 ; CHECK: r3 = 0 ll
 ; CHECK: r0 = *(u32 *)(r3 + 0)
 ; CHECK: r2 <<= 32
 ; CHECK: r2 >>= 32
-; CHECK: if r1 == r2 goto +4 <LBB0_5>
+; CHECK: if r1 == r2 goto +4 <test+0x98>
 ; CHECK: r0 <<= 2
 
 ; <label>:13:                                     ; preds = %4, %11
   %14 = phi i32 [ %12, %11 ], [ %7, %4 ]
   store i32 %14, ptr @gbl, align 4
   br label %15
-; CHECK-LABEL: <LBB0_4>:
 ; CHECK: r1 = 0 ll
 ; CHECK: *(u32 *)(r1 + 0) = r0
 
 ; <label>:15:                                     ; preds = %8, %13
   %16 = phi i32 [ %14, %13 ], [ %10, %8 ]
   ret i32 %16
-; CHECK-LABEL: <LBB0_5>:
 ; CHECK: exit
 }
 attributes #0 = { norecurse nounwind }

--- a/llvm/test/CodeGen/BPF/objdump_cond_op_2.ll
+++ b/llvm/test/CodeGen/BPF/objdump_cond_op_2.ll
@@ -14,8 +14,7 @@ define i32 @test(i32, i32) local_unnamed_addr #0 {
 
 ; <label>:4:                                      ; preds = %2
   br label %5
-; CHECK: if r4 s>= r3 goto +10 <LBB0_2>
-; CHECK-LABEL: <LBB0_1>:
+; CHECK: if r4 s>= r3 goto +10 <test+0x90>
 
 ; <label>:5:                                      ; preds = %4, %5
   %6 = phi i32 [ %9, %5 ], [ 0, %4 ]
@@ -27,12 +26,11 @@ define i32 @test(i32, i32) local_unnamed_addr #0 {
   %12 = icmp slt i32 %10, %11
   br i1 %12, label %5, label %13
 ; CHECK: r1 = r3
-; CHECK: if r2 s> r3 goto -10 <LBB0_1>
+; CHECK: if r2 s> r3 goto -10 <test+0x40>
 
 ; <label>:13:                                     ; preds = %5, %2
   %14 = phi i32 [ 0, %2 ], [ %9, %5 ]
   ret i32 %14
-; CHECK-LABEL: <LBB0_2>:
 ; CHECK: exit
 }
 attributes #0 = { norecurse nounwind readnone }


### PR DESCRIPTION
Internal label names never occur in the symbol table, so when using an object streamer, there's no point in constructing these names and then adding them to hash tables -- they are never visible in the output.

It's not possible to reuse createTempSymbol, because on BPF has a different prefix for globals and basic blocks right now.