### PR TITLE
[libc++] Use enable_if_t to constrain make_unique{,_for_overwrite}

### DIFF
--- a/libcxx/include/__memory/shared_ptr.h
+++ b/libcxx/include/__memory/shared_ptr.h
@@ -957,7 +957,7 @@ private:
 template <class _Array, class _Alloc, class... _Arg>
 _LIBCPP_HIDE_FROM_ABI shared_ptr<_Array>
 __allocate_shared_unbounded_array(const _Alloc& __a, size_t __n, _Arg&&... __arg) {
-  static_assert(__libcpp_is_unbounded_array<_Array>::value);
+  static_assert(__is_unbounded_array_v<_Array>);
   // We compute the number of bytes necessary to hold the control block and the
   // array elements. Then, we allocate an array of properly-aligned dummy structs
   // large enough to hold the control block and array. This allows shifting the
@@ -1034,7 +1034,7 @@ private:
 
 template <class _Array, class _Alloc, class... _Arg>
 _LIBCPP_HIDE_FROM_ABI shared_ptr<_Array> __allocate_shared_bounded_array(const _Alloc& __a, _Arg&&... __arg) {
-  static_assert(__libcpp_is_bounded_array<_Array>::value);
+  static_assert(__is_bounded_array_v<_Array>);
   using _ControlBlock      = __bounded_array_control_block<_Array, _Alloc>;
   using _ControlBlockAlloc = __allocator_traits_rebind_t<_Alloc, _ControlBlock>;
 

--- a/libcxx/include/__memory/uninitialized_algorithms.h
+++ b/libcxx/include/__memory/uninitialized_algorithms.h
@@ -375,7 +375,7 @@ __allocator_destroy_multidimensional(_Alloc& __alloc, _BidirIter __first, _Bidir
     return;
 
   if constexpr (is_array_v<_ValueType>) {
-    static_assert(!__libcpp_is_unbounded_array<_ValueType>::value,
+    static_assert(!__is_unbounded_array_v<_ValueType>,
                   "arrays of unbounded arrays don't exist, but if they did we would mess up here");
 
     using _Element = remove_extent_t<_ValueType>;

--- a/libcxx/include/__memory/unique_ptr.h
+++ b/libcxx/include/__memory/unique_ptr.h
@@ -30,6 +30,7 @@
 #include <__type_traits/integral_constant.h>
 #include <__type_traits/is_array.h>
 #include <__type_traits/is_assignable.h>
+#include <__type_traits/is_bounded_array.h>
 #include <__type_traits/is_constant_evaluated.h>
 #include <__type_traits/is_constructible.h>
 #include <__type_traits/is_convertible.h>
@@ -39,6 +40,7 @@
 #include <__type_traits/is_same.h>
 #include <__type_traits/is_swappable.h>
 #include <__type_traits/is_trivially_relocatable.h>
+#include <__type_traits/is_unbounded_array.h>
 #include <__type_traits/is_void.h>
 #include <__type_traits/remove_extent.h>
 #include <__type_traits/type_identity.h>
@@ -757,55 +759,36 @@ operator<=>(const unique_ptr<_T1, _D1>& __x, nullptr_t) {
 
 #if _LIBCPP_STD_VER >= 14
 
-template <class _Tp>
-struct __unique_if {
-  typedef unique_ptr<_Tp> __unique_single;
-};
-
-template <class _Tp>
-struct __unique_if<_Tp[]> {
-  typedef unique_ptr<_Tp[]> __unique_array_unknown_bound;
-};
-
-template <class _Tp, size_t _Np>
-struct __unique_if<_Tp[_Np]> {
-  typedef void __unique_array_known_bound;
-};
-
-template <class _Tp, class... _Args>
-inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX23 typename __unique_if<_Tp>::__unique_single
-make_unique(_Args&&... __args) {
+template <class _Tp, class... _Args, enable_if_t<!is_array<_Tp>::value, int> = 0>
+inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX23 unique_ptr<_Tp> make_unique(_Args&&... __args) {
   return unique_ptr<_Tp>(new _Tp(std::forward<_Args>(__args)...));
 }
 
-template <class _Tp>
-inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX23 typename __unique_if<_Tp>::__unique_array_unknown_bound
-make_unique(size_t __n) {
+template <class _Tp, enable_if_t<__is_unbounded_array_v<_Tp>, int> = 0>
+inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX23 unique_ptr<_Tp> make_unique(size_t __n) {
   typedef __remove_extent_t<_Tp> _Up;
   return unique_ptr<_Tp>(__private_constructor_tag(), new _Up[__n](), __n);
 }
 
-template <class _Tp, class... _Args>
-typename __unique_if<_Tp>::__unique_array_known_bound make_unique(_Args&&...) = delete;
+template <class _Tp, class... _Args, enable_if_t<__is_bounded_array_v<_Tp>, int> = 0>
+void make_unique(_Args&&...) = delete;
 
 #endif // _LIBCPP_STD_VER >= 14
 
 #if _LIBCPP_STD_VER >= 20
 
-template <class _Tp>
-_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX23 typename __unique_if<_Tp>::__unique_single
-make_unique_for_overwrite() {
+template <class _Tp, enable_if_t<!is_array_v<_Tp>, int> = 0>
+_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX23 unique_ptr<_Tp> make_unique_for_overwrite() {
   return unique_ptr<_Tp>(new _Tp);
 }
 
-template <class _Tp>
-_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX23 typename __unique_if<_Tp>::__unique_array_unknown_bound
-make_unique_for_overwrite(size_t __n) {
+template <class _Tp, enable_if_t<is_unbounded_array_v<_Tp>, int> = 0>
+_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX23 unique_ptr<_Tp> make_unique_for_overwrite(size_t __n) {
   return unique_ptr<_Tp>(__private_constructor_tag(), new __remove_extent_t<_Tp>[__n], __n);
 }
 
-template <class _Tp, class... _Args>
-typename __unique_if<_Tp>::__unique_array_known_bound make_unique_for_overwrite(_Args&&...) = delete;
+template <class _Tp, class... _Args, enable_if_t<is_bounded_array_v<_Tp>, int> = 0>
+void make_unique_for_overwrite(_Args&&...) = delete;
 
 #endif // _LIBCPP_STD_VER >= 20
 

--- a/libcxx/include/__type_traits/is_bounded_array.h
+++ b/libcxx/include/__type_traits/is_bounded_array.h
@@ -20,9 +20,9 @@
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class>
-struct _LIBCPP_TEMPLATE_VIS __libcpp_is_bounded_array : false_type {};
+inline const bool __is_bounded_array_v = false;
 template <class _Tp, size_t _Np>
-struct _LIBCPP_TEMPLATE_VIS __libcpp_is_bounded_array<_Tp[_Np]> : true_type {};
+inline const bool __is_bounded_array_v<_Tp[_Np]> = true;
 
 #if _LIBCPP_STD_VER >= 20
 

--- a/libcxx/include/__type_traits/is_unbounded_array.h
+++ b/libcxx/include/__type_traits/is_unbounded_array.h
@@ -19,9 +19,9 @@
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class>
-struct _LIBCPP_TEMPLATE_VIS __libcpp_is_unbounded_array : false_type {};
+inline const bool __is_unbounded_array_v = false;
 template <class _Tp>
-struct _LIBCPP_TEMPLATE_VIS __libcpp_is_unbounded_array<_Tp[]> : true_type {};
+inline const bool __is_unbounded_array_v<_Tp[]> = true;
 
 #if _LIBCPP_STD_VER >= 20
 


### PR DESCRIPTION
This improves the diagnostics a bit by using `enable_if_t` which clang is aware of, instead of a custom SFINAE class, as well as writing the functions in a more canonical style.

As a drive-by this also makes `__is_{,un}bounded_array` variable templates instead of class templates.
