### PR TITLE
[flang] Change argument to const reference

### DIFF
--- a/flang/lib/Semantics/scope.cpp
+++ b/flang/lib/Semantics/scope.cpp
@@ -56,7 +56,7 @@ Scope &Scope::MakeScope(Kind kind, Symbol *symbol) {
 
 template <typename T>
 static std::vector<common::Reference<T>> GetSortedSymbols(
-    std::map<SourceName, MutableSymbolRef> symbols) {
+    const std::map<SourceName, MutableSymbolRef> &symbols) {
   std::vector<common::Reference<T>> result;
   result.reserve(symbols.size());
   for (auto &pair : symbols) {


### PR DESCRIPTION
cppcheck recommends that a std::map being passed by value be changed to a const reference.

Fixes https://github.com/llvm/llvm-project/issues/94932.