### PR TITLE
[llvm-readobj][COFF] Add `--coff-output-style` flag

### DIFF
--- a/llvm/docs/CommandGuide/llvm-readobj.rst
+++ b/llvm/docs/CommandGuide/llvm-readobj.rst
@@ -347,9 +347,20 @@ The following options are implemented only for the PE/COFF file format.
 
  Display the load config.
 
+.. option:: --coff-output-style=<value>
+
+ Format COFF information in the specified style. Valid options are ``LLVM``,
+ and ``JSON``. ``LLVM`` output (the default) is an expanded and
+ structured format. ``JSON`` is JSON formatted output intended for machine consumption.
+
 .. option:: --coff-resources
 
  Display the .rsrc section.
+
+.. option:: --pretty-print
+
+ When used with :option:`--coff-output-style`, JSON output will be formatted in
+ a more readable format.
 
 XCOFF SPECIFIC OPTIONS
 ----------------------

--- a/llvm/docs/ReleaseNotes.rst
+++ b/llvm/docs/ReleaseNotes.rst
@@ -341,6 +341,9 @@ Changes to the LLVM tools
   jumping in reverse direction with shift+L/R/B). (`#95662
   <https://github.com/llvm/llvm-project/pull/95662>`).
 
+* llvm-readobj now supports ``--coff-output-style=<value>``. Valid options are ``LLVM``,
+  and ``JSON``. (`#95074 <https://github.com/llvm/llvm-project/pull/95074>`)
+
 Changes to LLDB
 ---------------------------------
 

--- a/llvm/test/tools/llvm-readobj/COFF/output-style.test
+++ b/llvm/test/tools/llvm-readobj/COFF/output-style.test
@@ -1,0 +1,4 @@
+## Error for an unknown output style.
+RUN: not llvm-readobj --coff-output-style=unknown 2>&1 | FileCheck %s
+
+CHECK: error: --coff-output-style value should be either 'LLVM' or 'JSON', but was 'unknown'

--- a/llvm/tools/llvm-readobj/Opts.td
+++ b/llvm/tools/llvm-readobj/Opts.td
@@ -87,6 +87,7 @@ def coff_imports : FF<"coff-imports", "Display import table">, Group<grp_coff>;
 def coff_load_config : FF<"coff-load-config", "Display load config">, Group<grp_coff>;
 def coff_resources : FF<"coff-resources", "Display .rsrc section">, Group<grp_coff>;
 def coff_tls_directory : FF<"coff-tls-directory", "Display TLS directory">, Group<grp_coff>;
+defm coff_output_style: Eq<"coff-output-style", "Specify COFF dump style: LLVM, JSON">, Group<grp_coff>;
 
 // XCOFF specific options.
 def grp_xcoff : OptionGroup<"kind">, HelpText<"OPTIONS (XCOFF specific)">;

--- a/llvm/tools/llvm-readobj/llvm-readobj.cpp
+++ b/llvm/tools/llvm-readobj/llvm-readobj.cpp
@@ -309,6 +309,18 @@ static void parseOptions(const opt::InputArgList &Args) {
   opts::COFFLoadConfig = Args.hasArg(OPT_coff_load_config);
   opts::COFFResources = Args.hasArg(OPT_coff_resources);
   opts::COFFTLSDirectory = Args.hasArg(OPT_coff_tls_directory);
+  if (Arg *A = Args.getLastArg(OPT_coff_output_style_EQ)) {
+    std::string OutputStyleChoice = A->getValue();
+    opts::Output = StringSwitch<opts::OutputStyleTy>(OutputStyleChoice)
+                       .Case("LLVM", opts::OutputStyleTy::LLVM)
+                       .Case("JSON", opts::OutputStyleTy::JSON)
+                       .Default(opts::OutputStyleTy::UNKNOWN);
+    if (opts::Output == opts::OutputStyleTy::UNKNOWN) {
+      error("--coff-output-style value should be either 'LLVM' or "
+            "'JSON', but was '" +
+            OutputStyleChoice + "'");
+    }
+  }
 
   // XCOFF specific options.
   opts::XCOFFAuxiliaryHeader = Args.hasArg(OPT_auxiliary_header);


### PR DESCRIPTION
## Description

This PR introduces the `--coff-output-style` in the same vein as the `--elf-output-style`. Subsequent PRs, will begin to start adding the `COFFJSONDumper` functionality to make this work.