### PR TITLE
[gold] Don't pass StringRef to message()

### DIFF
--- a/llvm/tools/gold/gold-plugin.cpp
+++ b/llvm/tools/gold/gold-plugin.cpp
@@ -307,7 +307,8 @@ namespace options {
     } else if (opt.consume_front("opt-remarks-hotness-threshold=")) {
       auto ResultOrErr = remarks::parseHotnessThresholdOption(opt);
       if (!ResultOrErr)
-        message(LDPL_FATAL, "Invalid remarks hotness threshold: %s", opt);
+        message(LDPL_FATAL, "Invalid remarks hotness threshold: %s",
+                opt.data());
       else
         RemarksHotnessThreshold = *ResultOrErr;
     } else if (opt.consume_front("opt-remarks-format=")) {
@@ -319,7 +320,7 @@ namespace options {
     } else if (opt.consume_front("time-trace-granularity=")) {
       unsigned Granularity;
       if (opt.getAsInteger(10, Granularity))
-        message(LDPL_FATAL, "Invalid time trace granularity: %s", opt);
+        message(LDPL_FATAL, "Invalid time trace granularity: %s", opt.data());
       else
         time_trace_granularity = Granularity;
     } else {


### PR DESCRIPTION
This is a printf style variadic function. If using a "%s" format, we should pass "const char *" rather than "StringRef".

The use of data() here is safe because we know that the StringRef was originally derived from a null-terminated string.