### PR TITLE
[clang] [test] Skip a test that sets PATH= on Windows

### DIFF
--- a/clang/test/Driver/spirv-toolchain.cl
+++ b/clang/test/Driver/spirv-toolchain.cl
@@ -80,10 +80,15 @@
 
 //-----------------------------------------------------------------------------
 // Check llvm-spirv-<LLVM_VERSION_MAJOR> is used if it is found in PATH.
+//
+// This test uses the PATH environment variable; on Windows, we may need to retain
+// the original path for the built Clang binary to be able to execute (as it is
+// used for locating dependent DLLs). Therefore, skip this test on system-windows.
+//
 // RUN: mkdir -p %t/versioned
 // RUN: touch %t/versioned/llvm-spirv-%llvm-version-major \
 // RUN:   && chmod +x %t/versioned/llvm-spirv-%llvm-version-major
-// RUN: env "PATH=%t/versioned" %clang -### --target=spirv64 -x cl -c %s 2>&1 \
-// RUN:   | FileCheck -DVERSION=%llvm-version-major --check-prefix=VERSIONED %s
+// RUN: %if !system-windows %{ env "PATH=%t/versioned" %clang -### --target=spirv64 -x cl -c %s 2>&1 \
+// RUN:   | FileCheck -DVERSION=%llvm-version-major --check-prefix=VERSIONED %s %}
 
 // VERSIONED: {{.*}}llvm-spirv-[[VERSION]]


### PR DESCRIPTION
The same has been done in a couple other existing tests, that also are skipped on Windows (e.g. ld-path.c). Some tests that really do want to test setting the path on Windows does it differently, see e.g. ps4-ps5-linker-win.c.

Since a65771fce4a2f25f16d4b3918ad6a11370637f7b, the spirv-toolchain.cl test does one test where PATH is set. Setting PATH does work in some build configurations - however, if built with e.g. llvm-mingw, the built Clang executable depends on libc++.dll (and libunwind.dll) which are found in PATH. If the PATH is overridden, the newly built Clang executable no longer can run.
