### PR TITLE
[BPF] Use ".L" local prefix label for basic blocks

### DIFF
--- a/llvm/lib/Target/BPF/MCTargetDesc/BPFMCAsmInfo.h
+++ b/llvm/lib/Target/BPF/MCTargetDesc/BPFMCAsmInfo.h
@@ -25,7 +25,7 @@ public:
       IsLittleEndian = false;
 
     InternalSymbolPrefix = ".L";
-    PrivateLabelPrefix = "L";
+    PrivateLabelPrefix = ".L";
     WeakRefDirective = "\t.weak\t";
 
     UsesELFSectionDirectiveForBSS = true;

--- a/llvm/test/CodeGen/BPF/cttz-ctlz.ll
+++ b/llvm/test/CodeGen/BPF/cttz-ctlz.ll
@@ -31,7 +31,7 @@ define i32 @cttz_i32(i32 %a) {
 ; CHECK-NEXT:    r2 = r1
 ; CHECK-NEXT:    r2 <<= 32
 ; CHECK-NEXT:    r2 >>= 32
-; CHECK-NEXT:    if r2 == 0 goto LBB1_2
+; CHECK-NEXT:    if r2 == 0 goto .LBB1_2
 ; CHECK-NEXT:  # %bb.1: # %cond.false
 ; CHECK-NEXT:    r2 = r1
 ; CHECK-NEXT:    r2 = -r2
@@ -43,7 +43,7 @@ define i32 @cttz_i32(i32 %a) {
 ; CHECK-NEXT:    r2 = {{\.?LCPI[0-9]+_[0-9]+}} ll
 ; CHECK-NEXT:    r2 += r1
 ; CHECK-NEXT:    r0 = *(u8 *)(r2 + 0)
-; CHECK-NEXT:  LBB1_2: # %cond.end
+; CHECK-NEXT:  .LBB1_2: # %cond.end
 ; CHECK-NEXT:    exit
     %ret = call i32 @llvm.cttz.i32(i32 %a, i1 0)
     ret i32 %ret
@@ -73,7 +73,7 @@ define i64 @cttz_i64(i64 %a) {
 ; CHECK-LABEL: cttz_i64:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    r0 = 64
-; CHECK-NEXT:    if r1 == 0 goto LBB3_2
+; CHECK-NEXT:    if r1 == 0 goto .LBB3_2
 ; CHECK-NEXT:  # %bb.1: # %cond.false
 ; CHECK-NEXT:    r2 = r1
 ; CHECK-NEXT:    r2 = -r2
@@ -84,7 +84,7 @@ define i64 @cttz_i64(i64 %a) {
 ; CHECK-NEXT:    r2 = {{\.?LCPI[0-9]+_[0-9]+}} ll
 ; CHECK-NEXT:    r2 += r1
 ; CHECK-NEXT:    r0 = *(u8 *)(r2 + 0)
-; CHECK-NEXT:  LBB3_2: # %cond.end
+; CHECK-NEXT:  .LBB3_2: # %cond.end
 ; CHECK-NEXT:    exit
     %ret = call i64 @llvm.cttz.i64(i64 %a, i1 0)
     ret i64 %ret
@@ -152,7 +152,7 @@ define i32 @ctlz_i32(i32 %a) {
 ; CHECK-NEXT:    r2 = r1
 ; CHECK-NEXT:    r2 <<= 32
 ; CHECK-NEXT:    r2 >>= 32
-; CHECK-NEXT:    if r2 == 0 goto LBB5_2
+; CHECK-NEXT:    if r2 == 0 goto .LBB5_2
 ; CHECK-NEXT:  # %bb.1: # %cond.false
 ; CHECK-NEXT:    r2 = 4294967294 ll
 ; CHECK-NEXT:    r3 = r1
@@ -197,7 +197,7 @@ define i32 @ctlz_i32(i32 %a) {
 ; CHECK-NEXT:    r1 = 4278190080 ll
 ; CHECK-NEXT:    r0 &= r1
 ; CHECK-NEXT:    r0 >>= 24
-; CHECK-NEXT:  LBB5_2: # %cond.end
+; CHECK-NEXT:  .LBB5_2: # %cond.end
 ; CHECK-NEXT:    exit
     %ret = call i32 @llvm.ctlz.i32(i32 %a, i1 0)
     ret i32 %ret
@@ -256,7 +256,7 @@ define i64 @ctlz_i64(i64 %a) {
 ; CHECK-LABEL: ctlz_i64:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    r0 = 64
-; CHECK-NEXT:    if r1 == 0 goto LBB7_2
+; CHECK-NEXT:    if r1 == 0 goto .LBB7_2
 ; CHECK-NEXT:  # %bb.1: # %cond.false
 ; CHECK-NEXT:    r2 = r1
 ; CHECK-NEXT:    r2 >>= 1
@@ -296,7 +296,7 @@ define i64 @ctlz_i64(i64 %a) {
 ; CHECK-NEXT:    r1 = 72340172838076673 ll
 ; CHECK-NEXT:    r0 *= r1
 ; CHECK-NEXT:    r0 >>= 56
-; CHECK-NEXT:  LBB7_2: # %cond.end
+; CHECK-NEXT:  .LBB7_2: # %cond.end
 ; CHECK-NEXT:    exit
     %ret = call i64 @llvm.ctlz.i64(i64 %a, i1 0)
     ret i64 %ret

--- a/llvm/test/CodeGen/BPF/gotol.ll
+++ b/llvm/test/CodeGen/BPF/gotol.ll
@@ -38,8 +38,8 @@ entry:
 ; case (3): conditional jmp followed by an unconditional jmp
 ; CHECK:        w0 = w2
 ; CHECK-NEXT:   if w1 < w2 goto
-; CHECK:        gotol LBB0_4    # encoding: [0x06'A',A,A,A,0x00,0x00,0x00,0x00]
-; CHECK-NEXT:                   # fixup A - offset: 0, value: LBB0_4, kind: FK_BPF_PCRel_4
+; CHECK:        gotol .LBB0_4   # encoding: [0x06'A',A,A,A,0x00,0x00,0x00,0x00]
+; CHECK-NEXT:                   # fixup A - offset: 0, value: .LBB0_4, kind: FK_BPF_PCRel_4
 
 begin:                                            ; preds = %next2, %next
   %s.0 = phi i32 [ %mul3, %next ], [ %mul7, %next2 ]
@@ -49,12 +49,12 @@ begin:                                            ; preds = %next2, %next
 
 ; case (2): conditional jmp
 ; CHECK:        w0 *= w1
-; CHECK-NEXT:   if w0 > w2 goto LBB0_7
-; CHECK:        goto LBB0_4
-; CHECK-LABEL:  LBB0_7:
+; CHECK-NEXT:   if w0 > w2 goto .LBB0_7
+; CHECK:        goto .LBB0_4
+; CHECK-LABEL:  .LBB0_7:
 ; CHECK:        gotol
 
-; CHECK-LABEL:  LBB0_4:
+; CHECK-LABEL:  .LBB0_4:
 
 if.then2:                                         ; preds = %begin
   %mul = mul i32 %div, %div

--- a/llvm/test/CodeGen/BPF/jump_table_blockaddr.ll
+++ b/llvm/test/CodeGen/BPF/jump_table_blockaddr.ll
@@ -62,21 +62,21 @@ llc -march=bpf -mcpu=v4 < test.ll \
 ; CHECK: 	r2 = *(u64 *)(r2 + 0)
 ; CHECK: 	r3 = BPF.JT.0.1 ll
 ; CHECK: 	r3 = *(u64 *)(r3 + 0)
-; CHECK: 	if w1 == 0 goto LBB0_2
+; CHECK: 	if w1 == 0 goto .LBB0_2
 ; CHECK: # %bb.1:                                # %entry
 ; CHECK: 	r3 = r2
-; CHECK: LBB0_2:                                 # %entry
+; CHECK: .LBB0_2:                                # %entry
 ; CHECK: 	*(u64 *)(r10 - 8) = r3
 ; CHECK: 	r1 = *(u64 *)(r10 - 8)
 ; CHECK: 	gotox r1
 ; CHECK: .Ltmp0:                                 # Block address taken
-; CHECK: LBB0_3:                                 # %l1
+; CHECK: .LBB0_3:                                # %l1
 ; CHECK: 	w0 = 3
-; CHECK: 	goto LBB0_5
+; CHECK: 	goto .LBB0_5
 ; CHECK: .Ltmp1:                                 # Block address taken
-; CHECK: LBB0_4:                                 # %l2
+; CHECK: .LBB0_4:                                # %l2
 ; CHECK: 	w0 = 2
-; CHECK: LBB0_5:                                 # %.split
+; CHECK: .LBB0_5:                                # %.split
 ; CHECK: 	exit
 ; CHECK: .Lfunc_end0:
 ; CHECK: 	.size	bar, .Lfunc_end0-bar
@@ -84,8 +84,8 @@ llc -march=bpf -mcpu=v4 < test.ll \
 ; CHECK: 	.cfi_endproc
 ; CHECK: 	.section	.jumptables,"",@progbits
 ; CHECK: BPF.JT.0.0:
-; CHECK: 	.quad	LBB0_3-.text
+; CHECK: 	.quad	.LBB0_3-.text
 ; CHECK: 	.size	BPF.JT.0.0, 8
 ; CHECK: BPF.JT.0.1:
-; CHECK: 	.quad	LBB0_4-.text
+; CHECK: 	.quad	.LBB0_4-.text
 ; CHECK: 	.size	BPF.JT.0.1, 8

--- a/llvm/test/CodeGen/BPF/jump_table_global_var.ll
+++ b/llvm/test/CodeGen/BPF/jump_table_global_var.ll
@@ -64,13 +64,13 @@ llc -march=bpf -mcpu=v4 < test.ll \
 ; CHECK: 	r1 = *(u64 *)(r2 + 0)
 ; CHECK: 	gotox r1
 ; CHECK: .Ltmp0:                                 # Block address taken
-; CHECK: LBB0_1:                                 # %l1
+; CHECK: .LBB0_1:                                # %l1
 ; CHECK: 	w0 = 4
-; CHECK: 	goto LBB0_3
+; CHECK: 	goto .LBB0_3
 ; CHECK: .Ltmp1:                                 # Block address taken
-; CHECK: LBB0_2:                                 # %l2
+; CHECK: .LBB0_2:                                # %l2
 ; CHECK: 	w0 = 3
-; CHECK: LBB0_3:                                 # %.split
+; CHECK: .LBB0_3:                                # %.split
 ; CHECK: 	exit
 ; CHECK: .Lfunc_end0:
 ; CHECK: 	.size	foo, .Lfunc_end0-foo
@@ -78,6 +78,6 @@ llc -march=bpf -mcpu=v4 < test.ll \
 ; CHECK: 	.cfi_endproc
 ; CHECK: 	.section	.jumptables,"",@progbits
 ; CHECK: BPF.JT.0.0:
-; CHECK: 	.quad	LBB0_1-.text
-; CHECK: 	.quad	LBB0_2-.text
+; CHECK: 	.quad	.LBB0_1-.text
+; CHECK: 	.quad	.LBB0_2-.text
 ; CHECK: 	.size	BPF.JT.0.0, 16

--- a/llvm/test/CodeGen/BPF/jump_table_switch_stmt.ll
+++ b/llvm/test/CodeGen/BPF/jump_table_switch_stmt.ll
@@ -66,7 +66,7 @@ llc -march=bpf -mcpu=v4 -bpf-min-jump-table-entries=3 < test.ll \
 ; CHECK: # %bb.0:                                # %entry
 ; CHECK:                                         # kill: def $w1 killed $w1 def $r1
 ; CHECK: 	w1 += -1
-; CHECK: 	if w1 > 29 goto LBB0_5
+; CHECK: 	if w1 > 29 goto .LBB0_5
 ; CHECK: # %bb.1:                                # %entry
 ; CHECK: 	w2 = 18
 ; CHECK: 	r1 <<= 3
@@ -76,15 +76,15 @@ llc -march=bpf -mcpu=v4 -bpf-min-jump-table-entries=3 < test.ll \
 ; CHECK: 	r1 = *(u64 *)(r4 + 0)
 ; CHECK: 	r3 += r1
 ; CHECK: 	gotox r3
-; CHECK: LBB0_2:                                 # %sw.bb1
+; CHECK: .LBB0_2:                                # %sw.bb1
 ; CHECK: 	w2 = 6
-; CHECK: 	goto LBB0_4
-; CHECK: LBB0_3:                                 # %sw.bb2
+; CHECK: 	goto .LBB0_4
+; CHECK: .LBB0_3:                                # %sw.bb2
 ; CHECK: 	w2 = 2
-; CHECK: LBB0_4:                                 # %sw.epilog.sink.split
+; CHECK: .LBB0_4:                                # %sw.epilog.sink.split
 ; CHECK: 	r1 = ret_user ll
 ; CHECK: 	*(u32 *)(r1 + 0) = w2
-; CHECK: LBB0_5:                                 # %sw.epilog
+; CHECK: .LBB0_5:                                # %sw.epilog
 ; CHECK: 	w0 = 0
 ; CHECK: 	exit
 ; CHECK: .Lfunc_end0:
@@ -93,34 +93,34 @@ llc -march=bpf -mcpu=v4 -bpf-min-jump-table-entries=3 < test.ll \
 ; CHECK: 	.cfi_endproc
 ; CHECK: 	.section	.jumptables,"",@progbits
 ; CHECK: BPF.JT.0.0:
-; CHECK: 	.quad	LBB0_4-.text
-; CHECK: 	.quad	LBB0_5-.text
-; CHECK: 	.quad	LBB0_5-.text
-; CHECK: 	.quad	LBB0_5-.text
-; CHECK: 	.quad	LBB0_5-.text
-; CHECK: 	.quad	LBB0_5-.text
-; CHECK: 	.quad	LBB0_5-.text
-; CHECK: 	.quad	LBB0_5-.text
-; CHECK: 	.quad	LBB0_5-.text
-; CHECK: 	.quad	LBB0_5-.text
-; CHECK: 	.quad	LBB0_5-.text
-; CHECK: 	.quad	LBB0_5-.text
-; CHECK: 	.quad	LBB0_5-.text
-; CHECK: 	.quad	LBB0_5-.text
-; CHECK: 	.quad	LBB0_5-.text
-; CHECK: 	.quad	LBB0_5-.text
-; CHECK: 	.quad	LBB0_5-.text
-; CHECK: 	.quad	LBB0_5-.text
-; CHECK: 	.quad	LBB0_5-.text
-; CHECK: 	.quad	LBB0_2-.text
-; CHECK: 	.quad	LBB0_5-.text
-; CHECK: 	.quad	LBB0_5-.text
-; CHECK: 	.quad	LBB0_5-.text
-; CHECK: 	.quad	LBB0_5-.text
-; CHECK: 	.quad	LBB0_5-.text
-; CHECK: 	.quad	LBB0_5-.text
-; CHECK: 	.quad	LBB0_5-.text
-; CHECK: 	.quad	LBB0_5-.text
-; CHECK: 	.quad	LBB0_5-.text
-; CHECK: 	.quad	LBB0_3-.text
+; CHECK: 	.quad	.LBB0_4-.text
+; CHECK: 	.quad	.LBB0_5-.text
+; CHECK: 	.quad	.LBB0_5-.text
+; CHECK: 	.quad	.LBB0_5-.text
+; CHECK: 	.quad	.LBB0_5-.text
+; CHECK: 	.quad	.LBB0_5-.text
+; CHECK: 	.quad	.LBB0_5-.text
+; CHECK: 	.quad	.LBB0_5-.text
+; CHECK: 	.quad	.LBB0_5-.text
+; CHECK: 	.quad	.LBB0_5-.text
+; CHECK: 	.quad	.LBB0_5-.text
+; CHECK: 	.quad	.LBB0_5-.text
+; CHECK: 	.quad	.LBB0_5-.text
+; CHECK: 	.quad	.LBB0_5-.text
+; CHECK: 	.quad	.LBB0_5-.text
+; CHECK: 	.quad	.LBB0_5-.text
+; CHECK: 	.quad	.LBB0_5-.text
+; CHECK: 	.quad	.LBB0_5-.text
+; CHECK: 	.quad	.LBB0_5-.text
+; CHECK: 	.quad	.LBB0_2-.text
+; CHECK: 	.quad	.LBB0_5-.text
+; CHECK: 	.quad	.LBB0_5-.text
+; CHECK: 	.quad	.LBB0_5-.text
+; CHECK: 	.quad	.LBB0_5-.text
+; CHECK: 	.quad	.LBB0_5-.text
+; CHECK: 	.quad	.LBB0_5-.text
+; CHECK: 	.quad	.LBB0_5-.text
+; CHECK: 	.quad	.LBB0_5-.text
+; CHECK: 	.quad	.LBB0_5-.text
+; CHECK: 	.quad	.LBB0_3-.text
 ; CHECK: 	.size	BPF.JT.0.0, 240

--- a/llvm/test/CodeGen/BPF/remove_truncate_9.ll
+++ b/llvm/test/CodeGen/BPF/remove_truncate_9.ll
@@ -15,10 +15,10 @@ define void @shl_lshr_same_bb(ptr %p) {
 ; CHECK-V2:       # %bb.0: # %entry
 ; CHECK-V2-NEXT:    r1 = *(u8 *)(r1 + 0)
 ; CHECK-V2-NEXT:    r5 = 1
-; CHECK-V2-NEXT:    if r1 == 0 goto LBB0_2
+; CHECK-V2-NEXT:    if r1 == 0 goto .LBB0_2
 ; CHECK-V2-NEXT:  # %bb.1: # %entry
 ; CHECK-V2-NEXT:    r5 = 0
-; CHECK-V2-NEXT:  LBB0_2: # %entry
+; CHECK-V2-NEXT:  .LBB0_2: # %entry
 ; CHECK-V2-NEXT:    r3 = r1
 ; CHECK-V2-NEXT:    r3 <<= 56
 ; CHECK-V2-NEXT:    r2 = r1
@@ -30,10 +30,10 @@ define void @shl_lshr_same_bb(ptr %p) {
 ; CHECK-V4:       # %bb.0: # %entry
 ; CHECK-V4-NEXT:    w1 = *(u8 *)(r1 + 0)
 ; CHECK-V4-NEXT:    w5 = 1
-; CHECK-V4-NEXT:    if w1 == 0 goto LBB0_2
+; CHECK-V4-NEXT:    if w1 == 0 goto .LBB0_2
 ; CHECK-V4-NEXT:  # %bb.1: # %entry
 ; CHECK-V4-NEXT:    w5 = 0
-; CHECK-V4-NEXT:  LBB0_2: # %entry
+; CHECK-V4-NEXT:  .LBB0_2: # %entry
 ; CHECK-V4-NEXT:    r3 = r1
 ; CHECK-V4-NEXT:    r3 <<= 56
 ; CHECK-V4-NEXT:    r2 = r1
@@ -57,10 +57,10 @@ define void @shl_lshr_diff_bb(ptr %p) {
 ; CHECK-V2:       # %bb.0: # %entry
 ; CHECK-V2-NEXT:    r1 = *(u16 *)(r1 + 0)
 ; CHECK-V2-NEXT:    r5 = 1
-; CHECK-V2-NEXT:    if r1 == 0 goto LBB1_2
+; CHECK-V2-NEXT:    if r1 == 0 goto .LBB1_2
 ; CHECK-V2-NEXT:  # %bb.1: # %entry
 ; CHECK-V2-NEXT:    r5 = 0
-; CHECK-V2-NEXT:  LBB1_2: # %entry
+; CHECK-V2-NEXT:  .LBB1_2: # %entry
 ; CHECK-V2-NEXT:    r3 = r1
 ; CHECK-V2-NEXT:    r3 <<= 48
 ; CHECK-V2-NEXT:    r2 = r1
@@ -72,10 +72,10 @@ define void @shl_lshr_diff_bb(ptr %p) {
 ; CHECK-V4:       # %bb.0: # %entry
 ; CHECK-V4-NEXT:    w1 = *(u16 *)(r1 + 0)
 ; CHECK-V4-NEXT:    w5 = 1
-; CHECK-V4-NEXT:    if w1 == 0 goto LBB1_2
+; CHECK-V4-NEXT:    if w1 == 0 goto .LBB1_2
 ; CHECK-V4-NEXT:  # %bb.1: # %entry
 ; CHECK-V4-NEXT:    w5 = 0
-; CHECK-V4-NEXT:  LBB1_2: # %entry
+; CHECK-V4-NEXT:  .LBB1_2: # %entry
 ; CHECK-V4-NEXT:    r3 = r1
 ; CHECK-V4-NEXT:    r3 <<= 48
 ; CHECK-V4-NEXT:    r2 = r1
@@ -105,10 +105,10 @@ define void @load_zext_same_bb(ptr %p) {
 ; CHECK-V2:       # %bb.0: # %entry
 ; CHECK-V2-NEXT:    r1 = *(u8 *)(r1 + 0)
 ; CHECK-V2-NEXT:    r2 = 1
-; CHECK-V2-NEXT:    if r1 == 0 goto LBB2_2
+; CHECK-V2-NEXT:    if r1 == 0 goto .LBB2_2
 ; CHECK-V2-NEXT:  # %bb.1: # %entry
 ; CHECK-V2-NEXT:    r2 = 0
-; CHECK-V2-NEXT:  LBB2_2: # %entry
+; CHECK-V2-NEXT:  .LBB2_2: # %entry
 ; CHECK-V2-NEXT:    call sink3
 ; CHECK-V2-NEXT:    exit
 ;
@@ -116,10 +116,10 @@ define void @load_zext_same_bb(ptr %p) {
 ; CHECK-V4:       # %bb.0: # %entry
 ; CHECK-V4-NEXT:    w1 = *(u8 *)(r1 + 0)
 ; CHECK-V4-NEXT:    w2 = 1
-; CHECK-V4-NEXT:    if w1 == 0 goto LBB2_2
+; CHECK-V4-NEXT:    if w1 == 0 goto .LBB2_2
 ; CHECK-V4-NEXT:  # %bb.1: # %entry
 ; CHECK-V4-NEXT:    w2 = 0
-; CHECK-V4-NEXT:  LBB2_2: # %entry
+; CHECK-V4-NEXT:  .LBB2_2: # %entry
 ; CHECK-V4-NEXT:    call sink3
 ; CHECK-V4-NEXT:    exit
 entry:
@@ -135,10 +135,10 @@ define void @load_zext_diff_bb(ptr %p) {
 ; CHECK-V2:       # %bb.0: # %entry
 ; CHECK-V2-NEXT:    r1 = *(u8 *)(r1 + 0)
 ; CHECK-V2-NEXT:    r2 = 1
-; CHECK-V2-NEXT:    if r1 == 0 goto LBB3_2
+; CHECK-V2-NEXT:    if r1 == 0 goto .LBB3_2
 ; CHECK-V2-NEXT:  # %bb.1: # %next
 ; CHECK-V2-NEXT:    r2 = 0
-; CHECK-V2-NEXT:  LBB3_2: # %next
+; CHECK-V2-NEXT:  .LBB3_2: # %next
 ; CHECK-V2-NEXT:    call sink3
 ; CHECK-V2-NEXT:    exit
 ;
@@ -146,10 +146,10 @@ define void @load_zext_diff_bb(ptr %p) {
 ; CHECK-V4:       # %bb.0: # %entry
 ; CHECK-V4-NEXT:    w1 = *(u8 *)(r1 + 0)
 ; CHECK-V4-NEXT:    w2 = 1
-; CHECK-V4-NEXT:    if w1 == 0 goto LBB3_2
+; CHECK-V4-NEXT:    if w1 == 0 goto .LBB3_2
 ; CHECK-V4-NEXT:  # %bb.1: # %next
 ; CHECK-V4-NEXT:    w2 = 0
-; CHECK-V4-NEXT:  LBB3_2: # %next
+; CHECK-V4-NEXT:  .LBB3_2: # %next
 ; CHECK-V4-NEXT:    call sink3
 ; CHECK-V4-NEXT:    exit
 entry:
@@ -167,10 +167,10 @@ define void @load_zext_diff_bb_2(ptr %p) {
 ; CHECK-V2:       # %bb.0: # %entry
 ; CHECK-V2-NEXT:    r1 = *(u32 *)(r1 + 0)
 ; CHECK-V2-NEXT:    r2 = 1
-; CHECK-V2-NEXT:    if r1 == 0 goto LBB4_2
+; CHECK-V2-NEXT:    if r1 == 0 goto .LBB4_2
 ; CHECK-V2-NEXT:  # %bb.1: # %next
 ; CHECK-V2-NEXT:    r2 = 0
-; CHECK-V2-NEXT:  LBB4_2: # %next
+; CHECK-V2-NEXT:  .LBB4_2: # %next
 ; CHECK-V2-NEXT:    call sink4
 ; CHECK-V2-NEXT:    exit
 ;
@@ -178,10 +178,10 @@ define void @load_zext_diff_bb_2(ptr %p) {
 ; CHECK-V4:       # %bb.0: # %entry
 ; CHECK-V4-NEXT:    w1 = *(u32 *)(r1 + 0)
 ; CHECK-V4-NEXT:    w2 = 1
-; CHECK-V4-NEXT:    if w1 == 0 goto LBB4_2
+; CHECK-V4-NEXT:    if w1 == 0 goto .LBB4_2
 ; CHECK-V4-NEXT:  # %bb.1: # %next
 ; CHECK-V4-NEXT:    w2 = 0
-; CHECK-V4-NEXT:  LBB4_2: # %next
+; CHECK-V4-NEXT:  .LBB4_2: # %next
 ; CHECK-V4-NEXT:    call sink4
 ; CHECK-V4-NEXT:    exit
 entry:

--- a/llvm/test/CodeGen/BPF/sanity.ll
+++ b/llvm/test/CodeGen/BPF/sanity.ll
@@ -76,10 +76,10 @@ define signext i8 @foo_cmp(i8 signext %a, i8 signext %b) #0 {
 ; CHECK-LABEL: foo_cmp:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    r0 = r1
-; CHECK-NEXT:    if r2 s> r0 goto LBB5_2
+; CHECK-NEXT:    if r2 s> r0 goto .LBB5_2
 ; CHECK-NEXT:  # %bb.1:
 ; CHECK-NEXT:    r0 = r2
-; CHECK-NEXT:  LBB5_2:
+; CHECK-NEXT:  .LBB5_2:
 ; CHECK-NEXT:    exit
   %1 = icmp slt i8 %a, %b
   %a.b = select i1 %1, i8 %a, i8 %b
@@ -91,18 +91,18 @@ define i32 @foo_muldiv(i8 signext %a, i16 signext %b, i32 %c, i64 %d) #0 {
 ; CHECK-LABEL: foo_muldiv:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    r0 = r2
-; CHECK-NEXT:    if r1 == 0 goto LBB6_2
+; CHECK-NEXT:    if r1 == 0 goto .LBB6_2
 ; CHECK-NEXT:  # %bb.1:
 ; CHECK-NEXT:    r0 *= r3
-; CHECK-NEXT:    goto LBB6_3
-; CHECK-NEXT:  LBB6_2:
+; CHECK-NEXT:    goto .LBB6_3
+; CHECK-NEXT:  .LBB6_2:
 ; CHECK-NEXT:    r3 <<= 32
 ; CHECK-NEXT:    r3 >>= 32
 ; CHECK-NEXT:    r4 <<= 32
 ; CHECK-NEXT:    r4 >>= 32
 ; CHECK-NEXT:    r4 /= r3
 ; CHECK-NEXT:    r0 = r4
-; CHECK-NEXT:  LBB6_3:
+; CHECK-NEXT:  .LBB6_3:
 ; CHECK-NEXT:    exit
   %1 = icmp eq i8 %a, 0
   br i1 %1, label %5, label %2


### PR DESCRIPTION
Previously, PrivateLabelPrefix was default-initialized to "L", so basic block labels were added to the symbol table. This seems like an oversight, so use ".L" for all private labels.

---

I'm not sure whether this is correct. But there's no documentation anywhere that states something else and MCAsmInfo.h documentation states that PrivateLabelPrefix "Defaults to the same as PrivateGlobalPrefix," so this really seems like an oversight. Also, BPF is the only target where private label and global prefixes differ.