### PR TITLE
[X86] Replace hasVirtualTileReg with AMXProgModel

### DIFF
--- a/llvm/lib/Target/X86/X86FastTileConfig.cpp
+++ b/llvm/lib/Target/X86/X86FastTileConfig.cpp
@@ -161,9 +161,6 @@ bool X86FastTileConfig::configBasicBlock(MachineBasicBlock &MBB) {
     }
   }
 
-  if (Change)
-    X86FI->setHasVirtualTileReg(true);
-
   return Change;
 }
 

--- a/llvm/lib/Target/X86/X86FrameLowering.cpp
+++ b/llvm/lib/Target/X86/X86FrameLowering.cpp
@@ -2594,7 +2594,7 @@ void X86FrameLowering::emitEpilogue(MachineFunction &MF,
   }
 
   // Emit tilerelease for AMX kernel.
-  if (X86FI->hasVirtualTileReg())
+  if (X86FI->getAMXProgModel() == AMXProgModelEnum::ManagedRA)
     BuildMI(MBB, Terminator, DL, TII.get(X86::TILERELEASE));
 }
 

--- a/llvm/lib/Target/X86/X86MachineFunctionInfo.h
+++ b/llvm/lib/Target/X86/X86MachineFunctionInfo.h
@@ -119,10 +119,6 @@ class X86MachineFunctionInfo : public MachineFunctionInfo {
   /// other tools to detect the extended record.
   bool HasSwiftAsyncContext = false;
 
-  /// True if this function has tile virtual register. This is used to
-  /// determine if we should insert tilerelease in frame lowering.
-  bool HasVirtualTileReg = false;
-
   /// Ajust stack for push2/pop2
   bool PadForPush2Pop2 = false;
 
@@ -249,9 +245,6 @@ public:
 
   bool hasSwiftAsyncContext() const { return HasSwiftAsyncContext; }
   void setHasSwiftAsyncContext(bool v) { HasSwiftAsyncContext = v; }
-
-  bool hasVirtualTileReg() const { return HasVirtualTileReg; }
-  void setHasVirtualTileReg(bool v) { HasVirtualTileReg = v; }
 
   bool padForPush2Pop2() const { return PadForPush2Pop2; }
   void setPadForPush2Pop2(bool V) { PadForPush2Pop2 = V; }

--- a/llvm/lib/Target/X86/X86PreTileConfig.cpp
+++ b/llvm/lib/Target/X86/X86PreTileConfig.cpp
@@ -301,7 +301,6 @@ bool X86PreTileConfig::runOnMachineFunction(MachineFunction &MF) {
   // There's no AMX instruction if we didn't find a tile config live in point.
   if (CfgNeedInsert.empty())
     return false;
-  X86FI->setHasVirtualTileReg(true);
 
   // Avoid to insert ldtilecfg before any shape defs.
   SmallVector<MachineBasicBlock *, 8> WorkList;


### PR DESCRIPTION
Cleanup after AMXProgModel introduction. AMXProgModel is ManagedRA
whenever virtual tile registers exist at some point.
