### PR TITLE
[CodeGen][NewPM] Split `MachinePostDominators` into a concrete analysis result

### DIFF
--- a/llvm/include/llvm/CodeGen/MachinePostDominators.h
+++ b/llvm/include/llvm/CodeGen/MachinePostDominators.h
@@ -15,78 +15,63 @@
 #define LLVM_CODEGEN_MACHINEPOSTDOMINATORS_H
 
 #include "llvm/CodeGen/MachineDominators.h"
-#include "llvm/CodeGen/MachineFunctionPass.h"
-#include <memory>
 
 namespace llvm {
+
+extern template class DominatorTreeBase<MachineBasicBlock, true>; // PostDomTree
+
+namespace DomTreeBuilder {
+using MBBPostDomTree = PostDomTreeBase<MachineBasicBlock>;
+using MBBPostDomTreeGraphDiff = GraphDiff<MachineBasicBlock *, true>;
+
+extern template void Calculate<MBBPostDomTree>(MBBPostDomTree &DT);
+extern template void InsertEdge<MBBPostDomTree>(MBBPostDomTree &DT,
+                                                MachineBasicBlock *From,
+                                                MachineBasicBlock *To);
+extern template void DeleteEdge<MBBPostDomTree>(MBBPostDomTree &DT,
+                                                MachineBasicBlock *From,
+                                                MachineBasicBlock *To);
+extern template void ApplyUpdates<MBBPostDomTree>(MBBPostDomTree &DT,
+                                                  MBBPostDomTreeGraphDiff &,
+                                                  MBBPostDomTreeGraphDiff *);
+extern template bool
+Verify<MBBPostDomTree>(const MBBPostDomTree &DT,
+                       MBBPostDomTree::VerificationLevel VL);
+} // namespace DomTreeBuilder
 
 ///
 /// MachinePostDominatorTree - an analysis pass wrapper for DominatorTree
 /// used to compute the post-dominator tree for MachineFunctions.
 ///
-class MachinePostDominatorTree : public MachineFunctionPass {
-  using PostDomTreeT = PostDomTreeBase<MachineBasicBlock>;
-  std::unique_ptr<PostDomTreeT> PDT;
+class MachinePostDominatorTree : public PostDomTreeBase<MachineBasicBlock> {
+  using Base = PostDomTreeBase<MachineBasicBlock>;
 
 public:
-  static char ID;
+  MachinePostDominatorTree() = default;
 
-  MachinePostDominatorTree();
-
-  PostDomTreeT &getBase() {
-    if (!PDT)
-      PDT.reset(new PostDomTreeT());
-    return *PDT;
-  }
-
-  FunctionPass *createMachinePostDominatorTreePass();
-
-  MachineDomTreeNode *getRootNode() const { return PDT->getRootNode(); }
-
-  MachineDomTreeNode *operator[](MachineBasicBlock *BB) const {
-    return PDT->getNode(BB);
-  }
-
-  MachineDomTreeNode *getNode(MachineBasicBlock *BB) const {
-    return PDT->getNode(BB);
-  }
-
-  bool dominates(const MachineDomTreeNode *A,
-                 const MachineDomTreeNode *B) const {
-    return PDT->dominates(A, B);
-  }
-
-  bool dominates(const MachineBasicBlock *A, const MachineBasicBlock *B) const {
-    return PDT->dominates(A, B);
-  }
-
-  bool properlyDominates(const MachineDomTreeNode *A,
-                         const MachineDomTreeNode *B) const {
-    return PDT->properlyDominates(A, B);
-  }
-
-  bool properlyDominates(const MachineBasicBlock *A,
-                         const MachineBasicBlock *B) const {
-    return PDT->properlyDominates(A, B);
-  }
-
-  bool isVirtualRoot(const MachineDomTreeNode *Node) const {
-    return PDT->isVirtualRoot(Node);
-  }
-
-  MachineBasicBlock *findNearestCommonDominator(MachineBasicBlock *A,
-                                                MachineBasicBlock *B) const {
-    return PDT->findNearestCommonDominator(A, B);
-  }
+  /// Make findNearestCommonDominator(const NodeT *A, const NodeT *B) available.
+  using Base::findNearestCommonDominator;
 
   /// Returns the nearest common dominator of the given blocks.
   /// If that tree node is a virtual root, a nullptr will be returned.
   MachineBasicBlock *
   findNearestCommonDominator(ArrayRef<MachineBasicBlock *> Blocks) const;
+};
+
+class MachinePostDominatorTreeWrapperPass : public MachineFunctionPass {
+  std::optional<MachinePostDominatorTree> PDT;
+
+public:
+  static char ID;
+
+  MachinePostDominatorTreeWrapperPass();
+
+  MachinePostDominatorTree &getPostDomTree() { return *PDT; }
+  const MachinePostDominatorTree &getPostDomTree() const { return *PDT; }
 
   bool runOnMachineFunction(MachineFunction &MF) override;
   void getAnalysisUsage(AnalysisUsage &AU) const override;
-  void releaseMemory() override { PDT.reset(nullptr); }
+  void releaseMemory() override { PDT.reset(); }
   void verifyAnalysis() const override;
   void print(llvm::raw_ostream &OS, const Module *M = nullptr) const override;
 };

--- a/llvm/include/llvm/InitializePasses.h
+++ b/llvm/include/llvm/InitializePasses.h
@@ -200,7 +200,7 @@ void initializeMachineModuleInfoWrapperPassPass(PassRegistry &);
 void initializeMachineOptimizationRemarkEmitterPassPass(PassRegistry&);
 void initializeMachineOutlinerPass(PassRegistry&);
 void initializeMachinePipelinerPass(PassRegistry&);
-void initializeMachinePostDominatorTreePass(PassRegistry&);
+void initializeMachinePostDominatorTreeWrapperPassPass(PassRegistry &);
 void initializeMachineRegionInfoPassPass(PassRegistry&);
 void initializeMachineSanitizerBinaryMetadataPass(PassRegistry &);
 void initializeMachineSchedulerPass(PassRegistry&);

--- a/llvm/lib/CodeGen/CodeGen.cpp
+++ b/llvm/lib/CodeGen/CodeGen.cpp
@@ -91,7 +91,7 @@ void llvm::initializeCodeGen(PassRegistry &Registry) {
   initializeMachinePipelinerPass(Registry);
   initializeMachineSanitizerBinaryMetadataPass(Registry);
   initializeModuloScheduleTestPass(Registry);
-  initializeMachinePostDominatorTreePass(Registry);
+  initializeMachinePostDominatorTreeWrapperPassPass(Registry);
   initializeMachineRegionInfoPassPass(Registry);
   initializeMachineSchedulerPass(Registry);
   initializeMachineSinkingPass(Registry);

--- a/llvm/lib/CodeGen/MIRSampleProfile.cpp
+++ b/llvm/lib/CodeGen/MIRSampleProfile.cpp
@@ -71,7 +71,7 @@ INITIALIZE_PASS_BEGIN(MIRProfileLoaderPass, DEBUG_TYPE,
                       /* cfg = */ false, /* is_analysis = */ false)
 INITIALIZE_PASS_DEPENDENCY(MachineBlockFrequencyInfo)
 INITIALIZE_PASS_DEPENDENCY(MachineDominatorTreeWrapperPass)
-INITIALIZE_PASS_DEPENDENCY(MachinePostDominatorTree)
+INITIALIZE_PASS_DEPENDENCY(MachinePostDominatorTreeWrapperPass)
 INITIALIZE_PASS_DEPENDENCY(MachineLoopInfo)
 INITIALIZE_PASS_DEPENDENCY(MachineOptimizationRemarkEmitterPass)
 INITIALIZE_PASS_END(MIRProfileLoaderPass, DEBUG_TYPE, "Load MIR Sample Profile",
@@ -366,8 +366,9 @@ bool MIRProfileLoaderPass::runOnMachineFunction(MachineFunction &MF) {
   MBFI = &getAnalysis<MachineBlockFrequencyInfo>();
   MIRSampleLoader->setInitVals(
       &getAnalysis<MachineDominatorTreeWrapperPass>().getDomTree(),
-      &getAnalysis<MachinePostDominatorTree>(), &getAnalysis<MachineLoopInfo>(),
-      MBFI, &getAnalysis<MachineOptimizationRemarkEmitterPass>().getORE());
+      &getAnalysis<MachinePostDominatorTreeWrapperPass>().getPostDomTree(),
+      &getAnalysis<MachineLoopInfo>(), MBFI,
+      &getAnalysis<MachineOptimizationRemarkEmitterPass>().getORE());
 
   MF.RenumberBlocks();
   if (ViewBFIBefore && ViewBlockLayoutWithBFI != GVDT_None &&
@@ -401,7 +402,7 @@ void MIRProfileLoaderPass::getAnalysisUsage(AnalysisUsage &AU) const {
   AU.setPreservesAll();
   AU.addRequired<MachineBlockFrequencyInfo>();
   AU.addRequired<MachineDominatorTreeWrapperPass>();
-  AU.addRequired<MachinePostDominatorTree>();
+  AU.addRequired<MachinePostDominatorTreeWrapperPass>();
   AU.addRequiredTransitive<MachineLoopInfo>();
   AU.addRequired<MachineOptimizationRemarkEmitterPass>();
   MachineFunctionPass::getAnalysisUsage(AU);

--- a/llvm/lib/CodeGen/MachinePostDominators.cpp
+++ b/llvm/lib/CodeGen/MachinePostDominators.cpp
@@ -19,31 +19,46 @@ using namespace llvm;
 namespace llvm {
 template class DominatorTreeBase<MachineBasicBlock, true>; // PostDomTreeBase
 
+namespace DomTreeBuilder {
+
+template void Calculate<MBBPostDomTree>(MBBPostDomTree &DT);
+template void InsertEdge<MBBPostDomTree>(MBBPostDomTree &DT,
+                                         MachineBasicBlock *From,
+                                         MachineBasicBlock *To);
+template void DeleteEdge<MBBPostDomTree>(MBBPostDomTree &DT,
+                                         MachineBasicBlock *From,
+                                         MachineBasicBlock *To);
+template void ApplyUpdates<MBBPostDomTree>(MBBPostDomTree &DT,
+                                           MBBPostDomTreeGraphDiff &,
+                                           MBBPostDomTreeGraphDiff *);
+template bool Verify<MBBPostDomTree>(const MBBPostDomTree &DT,
+                                     MBBPostDomTree::VerificationLevel VL);
+
+} // namespace DomTreeBuilder
 extern bool VerifyMachineDomInfo;
 } // namespace llvm
 
-char MachinePostDominatorTree::ID = 0;
+char MachinePostDominatorTreeWrapperPass::ID = 0;
 
 //declare initializeMachinePostDominatorTreePass
-INITIALIZE_PASS(MachinePostDominatorTree, "machinepostdomtree",
+INITIALIZE_PASS(MachinePostDominatorTreeWrapperPass, "machinepostdomtree",
                 "MachinePostDominator Tree Construction", true, true)
 
-MachinePostDominatorTree::MachinePostDominatorTree()
-    : MachineFunctionPass(ID), PDT(nullptr) {
-  initializeMachinePostDominatorTreePass(*PassRegistry::getPassRegistry());
+MachinePostDominatorTreeWrapperPass::MachinePostDominatorTreeWrapperPass()
+    : MachineFunctionPass(ID), PDT() {
+  initializeMachinePostDominatorTreeWrapperPassPass(
+      *PassRegistry::getPassRegistry());
 }
 
-FunctionPass *MachinePostDominatorTree::createMachinePostDominatorTreePass() {
-  return new MachinePostDominatorTree();
-}
-
-bool MachinePostDominatorTree::runOnMachineFunction(MachineFunction &F) {
-  PDT = std::make_unique<PostDomTreeT>();
+bool MachinePostDominatorTreeWrapperPass::runOnMachineFunction(
+    MachineFunction &F) {
+  PDT = MachinePostDominatorTree();
   PDT->recalculate(F);
   return false;
 }
 
-void MachinePostDominatorTree::getAnalysisUsage(AnalysisUsage &AU) const {
+void MachinePostDominatorTreeWrapperPass::getAnalysisUsage(
+    AnalysisUsage &AU) const {
   AU.setPreservesAll();
   MachineFunctionPass::getAnalysisUsage(AU);
 }
@@ -54,26 +69,23 @@ MachineBasicBlock *MachinePostDominatorTree::findNearestCommonDominator(
 
   MachineBasicBlock *NCD = Blocks.front();
   for (MachineBasicBlock *BB : Blocks.drop_front()) {
-    NCD = PDT->findNearestCommonDominator(NCD, BB);
+    NCD = Base::findNearestCommonDominator(NCD, BB);
 
     // Stop when the root is reached.
-    if (PDT->isVirtualRoot(PDT->getNode(NCD)))
+    if (isVirtualRoot(getNode(NCD)))
       return nullptr;
   }
 
   return NCD;
 }
 
-void MachinePostDominatorTree::verifyAnalysis() const {
-  if (PDT && VerifyMachineDomInfo)
-    if (!PDT->verify(PostDomTreeT::VerificationLevel::Basic)) {
-      errs() << "MachinePostDominatorTree verification failed\n";
-
-      abort();
-    }
+void MachinePostDominatorTreeWrapperPass::verifyAnalysis() const {
+  if (VerifyMachineDomInfo && PDT &&
+      !PDT->verify(MachinePostDominatorTree::VerificationLevel::Basic))
+    report_fatal_error("MachinePostDominatorTree verification failed!");
 }
 
-void MachinePostDominatorTree::print(llvm::raw_ostream &OS,
-                                     const Module *M) const {
+void MachinePostDominatorTreeWrapperPass::print(llvm::raw_ostream &OS,
+                                                const Module *M) const {
   PDT->print(OS);
 }

--- a/llvm/lib/CodeGen/MachineRegionInfo.cpp
+++ b/llvm/lib/CodeGen/MachineRegionInfo.cpp
@@ -85,7 +85,8 @@ bool MachineRegionInfoPass::runOnMachineFunction(MachineFunction &F) {
   releaseMemory();
 
   auto DT = &getAnalysis<MachineDominatorTreeWrapperPass>().getDomTree();
-  auto PDT = &getAnalysis<MachinePostDominatorTree>();
+  auto PDT =
+      &getAnalysis<MachinePostDominatorTreeWrapperPass>().getPostDomTree();
   auto DF = &getAnalysis<MachineDominanceFrontier>();
 
   RI.recalculate(F, DT, PDT, DF);
@@ -110,7 +111,7 @@ void MachineRegionInfoPass::verifyAnalysis() const {
 void MachineRegionInfoPass::getAnalysisUsage(AnalysisUsage &AU) const {
   AU.setPreservesAll();
   AU.addRequired<MachineDominatorTreeWrapperPass>();
-  AU.addRequired<MachinePostDominatorTree>();
+  AU.addRequired<MachinePostDominatorTreeWrapperPass>();
   AU.addRequired<MachineDominanceFrontier>();
   MachineFunctionPass::getAnalysisUsage(AU);
 }
@@ -131,7 +132,7 @@ char &MachineRegionInfoPassID = MachineRegionInfoPass::ID;
 INITIALIZE_PASS_BEGIN(MachineRegionInfoPass, DEBUG_TYPE,
                       "Detect single entry single exit regions", true, true)
 INITIALIZE_PASS_DEPENDENCY(MachineDominatorTreeWrapperPass)
-INITIALIZE_PASS_DEPENDENCY(MachinePostDominatorTree)
+INITIALIZE_PASS_DEPENDENCY(MachinePostDominatorTreeWrapperPass)
 INITIALIZE_PASS_DEPENDENCY(MachineDominanceFrontier)
 INITIALIZE_PASS_END(MachineRegionInfoPass, DEBUG_TYPE,
                     "Detect single entry single exit regions", true, true)

--- a/llvm/lib/CodeGen/MachineSink.cpp
+++ b/llvm/lib/CodeGen/MachineSink.cpp
@@ -185,7 +185,7 @@ namespace {
       MachineFunctionPass::getAnalysisUsage(AU);
       AU.addRequired<AAResultsWrapperPass>();
       AU.addRequired<MachineDominatorTreeWrapperPass>();
-      AU.addRequired<MachinePostDominatorTree>();
+      AU.addRequired<MachinePostDominatorTreeWrapperPass>();
       AU.addRequired<MachineCycleInfoWrapperPass>();
       AU.addRequired<MachineBranchProbabilityInfo>();
       AU.addPreserved<MachineCycleInfoWrapperPass>();
@@ -709,7 +709,7 @@ bool MachineSinking::runOnMachineFunction(MachineFunction &MF) {
   TRI = STI->getRegisterInfo();
   MRI = &MF.getRegInfo();
   DT = &getAnalysis<MachineDominatorTreeWrapperPass>().getDomTree();
-  PDT = &getAnalysis<MachinePostDominatorTree>();
+  PDT = &getAnalysis<MachinePostDominatorTreeWrapperPass>().getPostDomTree();
   CI = &getAnalysis<MachineCycleInfoWrapperPass>().getCycleInfo();
   MBFI = UseBlockFreqInfo ? &getAnalysis<MachineBlockFrequencyInfo>() : nullptr;
   MBPI = &getAnalysis<MachineBranchProbabilityInfo>();

--- a/llvm/lib/CodeGen/ShrinkWrap.cpp
+++ b/llvm/lib/CodeGen/ShrinkWrap.cpp
@@ -226,7 +226,7 @@ class ShrinkWrap : public MachineFunctionPass {
   void init(MachineFunction &MF) {
     RCI.runOnMachineFunction(MF);
     MDT = &getAnalysis<MachineDominatorTreeWrapperPass>().getDomTree();
-    MPDT = &getAnalysis<MachinePostDominatorTree>();
+    MPDT = &getAnalysis<MachinePostDominatorTreeWrapperPass>().getPostDomTree();
     Save = nullptr;
     Restore = nullptr;
     MBFI = &getAnalysis<MachineBlockFrequencyInfo>();
@@ -263,7 +263,7 @@ public:
     AU.setPreservesAll();
     AU.addRequired<MachineBlockFrequencyInfo>();
     AU.addRequired<MachineDominatorTreeWrapperPass>();
-    AU.addRequired<MachinePostDominatorTree>();
+    AU.addRequired<MachinePostDominatorTreeWrapperPass>();
     AU.addRequired<MachineLoopInfo>();
     AU.addRequired<MachineOptimizationRemarkEmitterPass>();
     MachineFunctionPass::getAnalysisUsage(AU);
@@ -290,7 +290,7 @@ char &llvm::ShrinkWrapID = ShrinkWrap::ID;
 INITIALIZE_PASS_BEGIN(ShrinkWrap, DEBUG_TYPE, "Shrink Wrap Pass", false, false)
 INITIALIZE_PASS_DEPENDENCY(MachineBlockFrequencyInfo)
 INITIALIZE_PASS_DEPENDENCY(MachineDominatorTreeWrapperPass)
-INITIALIZE_PASS_DEPENDENCY(MachinePostDominatorTree)
+INITIALIZE_PASS_DEPENDENCY(MachinePostDominatorTreeWrapperPass)
 INITIALIZE_PASS_DEPENDENCY(MachineLoopInfo)
 INITIALIZE_PASS_DEPENDENCY(MachineOptimizationRemarkEmitterPass)
 INITIALIZE_PASS_END(ShrinkWrap, DEBUG_TYPE, "Shrink Wrap Pass", false, false)
@@ -671,7 +671,7 @@ bool ShrinkWrap::postShrinkWrapping(bool HasCandidate, MachineFunction &MF,
   Restore = NewRestore;
 
   MDT->recalculate(MF);
-  MPDT->runOnMachineFunction(MF);
+  MPDT->recalculate(MF);
 
   assert((MDT->dominates(Save, Restore) && MPDT->dominates(Restore, Save)) &&
          "Incorrect save or restore point due to dominance relations");

--- a/llvm/lib/Target/AMDGPU/AMDGPUGlobalISelDivergenceLowering.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUGlobalISelDivergenceLowering.cpp
@@ -47,7 +47,7 @@ public:
   void getAnalysisUsage(AnalysisUsage &AU) const override {
     AU.setPreservesCFG();
     AU.addRequired<MachineDominatorTreeWrapperPass>();
-    AU.addRequired<MachinePostDominatorTree>();
+    AU.addRequired<MachinePostDominatorTreeWrapperPass>();
     AU.addRequired<MachineUniformityAnalysisPass>();
     MachineFunctionPass::getAnalysisUsage(AU);
   }
@@ -193,7 +193,7 @@ void DivergenceLoweringHelper::constrainAsLaneMask(Incoming &In) {
 INITIALIZE_PASS_BEGIN(AMDGPUGlobalISelDivergenceLowering, DEBUG_TYPE,
                       "AMDGPU GlobalISel divergence lowering", false, false)
 INITIALIZE_PASS_DEPENDENCY(MachineDominatorTreeWrapperPass)
-INITIALIZE_PASS_DEPENDENCY(MachinePostDominatorTree)
+INITIALIZE_PASS_DEPENDENCY(MachinePostDominatorTreeWrapperPass)
 INITIALIZE_PASS_DEPENDENCY(MachineUniformityAnalysisPass)
 INITIALIZE_PASS_END(AMDGPUGlobalISelDivergenceLowering, DEBUG_TYPE,
                     "AMDGPU GlobalISel divergence lowering", false, false)
@@ -211,7 +211,8 @@ bool AMDGPUGlobalISelDivergenceLowering::runOnMachineFunction(
     MachineFunction &MF) {
   MachineDominatorTree &DT =
       getAnalysis<MachineDominatorTreeWrapperPass>().getDomTree();
-  MachinePostDominatorTree &PDT = getAnalysis<MachinePostDominatorTree>();
+  MachinePostDominatorTree &PDT =
+      getAnalysis<MachinePostDominatorTreeWrapperPass>().getPostDomTree();
   MachineUniformityInfo &MUI =
       getAnalysis<MachineUniformityAnalysisPass>().getUniformityInfo();
 

--- a/llvm/lib/Target/AMDGPU/R600MachineCFGStructurizer.cpp
+++ b/llvm/lib/Target/AMDGPU/R600MachineCFGStructurizer.cpp
@@ -114,7 +114,7 @@ public:
 
   void getAnalysisUsage(AnalysisUsage &AU) const override {
     AU.addRequired<MachineDominatorTreeWrapperPass>();
-    AU.addRequired<MachinePostDominatorTree>();
+    AU.addRequired<MachinePostDominatorTreeWrapperPass>();
     AU.addRequired<MachineLoopInfo>();
     MachineFunctionPass::getAnalysisUsage(AU);
   }
@@ -142,7 +142,7 @@ public:
     LLVM_DEBUG(dbgs() << "LoopInfo:\n"; PrintLoopinfo(*MLI););
     MDT = &getAnalysis<MachineDominatorTreeWrapperPass>().getDomTree();
     LLVM_DEBUG(MDT->print(dbgs()););
-    PDT = &getAnalysis<MachinePostDominatorTree>();
+    PDT = &getAnalysis<MachinePostDominatorTreeWrapperPass>().getPostDomTree();
     LLVM_DEBUG(PDT->print(dbgs()););
     prepare();
     run();
@@ -1630,7 +1630,7 @@ void R600MachineCFGStructurizer::retireBlock(MachineBasicBlock *MBB) {
 INITIALIZE_PASS_BEGIN(R600MachineCFGStructurizer, "amdgpustructurizer",
                       "AMDGPU CFG Structurizer", false, false)
 INITIALIZE_PASS_DEPENDENCY(MachineDominatorTreeWrapperPass)
-INITIALIZE_PASS_DEPENDENCY(MachinePostDominatorTree)
+INITIALIZE_PASS_DEPENDENCY(MachinePostDominatorTreeWrapperPass)
 INITIALIZE_PASS_DEPENDENCY(MachineLoopInfo)
 INITIALIZE_PASS_END(R600MachineCFGStructurizer, "amdgpustructurizer",
                       "AMDGPU CFG Structurizer", false, false)

--- a/llvm/lib/Target/AMDGPU/SIInsertWaitcnts.cpp
+++ b/llvm/lib/Target/AMDGPU/SIInsertWaitcnts.cpp
@@ -641,7 +641,7 @@ public:
   void getAnalysisUsage(AnalysisUsage &AU) const override {
     AU.setPreservesCFG();
     AU.addRequired<MachineLoopInfo>();
-    AU.addRequired<MachinePostDominatorTree>();
+    AU.addRequired<MachinePostDominatorTreeWrapperPass>();
     AU.addUsedIfAvailable<AAResultsWrapperPass>();
     AU.addPreserved<AAResultsWrapperPass>();
     MachineFunctionPass::getAnalysisUsage(AU);
@@ -1118,7 +1118,7 @@ bool WaitcntBrackets::counterOutOfOrder(InstCounterType T) const {
 INITIALIZE_PASS_BEGIN(SIInsertWaitcnts, DEBUG_TYPE, "SI Insert Waitcnts", false,
                       false)
 INITIALIZE_PASS_DEPENDENCY(MachineLoopInfo)
-INITIALIZE_PASS_DEPENDENCY(MachinePostDominatorTree)
+INITIALIZE_PASS_DEPENDENCY(MachinePostDominatorTreeWrapperPass)
 INITIALIZE_PASS_END(SIInsertWaitcnts, DEBUG_TYPE, "SI Insert Waitcnts", false,
                     false)
 
@@ -2398,7 +2398,7 @@ bool SIInsertWaitcnts::runOnMachineFunction(MachineFunction &MF) {
   MRI = &MF.getRegInfo();
   const SIMachineFunctionInfo *MFI = MF.getInfo<SIMachineFunctionInfo>();
   MLI = &getAnalysis<MachineLoopInfo>();
-  PDT = &getAnalysis<MachinePostDominatorTree>();
+  PDT = &getAnalysis<MachinePostDominatorTreeWrapperPass>().getPostDomTree();
   if (auto AAR = getAnalysisIfAvailable<AAResultsWrapperPass>())
     AA = &AAR->getAAResults();
 

--- a/llvm/lib/Target/AMDGPU/SILowerI1Copies.cpp
+++ b/llvm/lib/Target/AMDGPU/SILowerI1Copies.cpp
@@ -52,7 +52,7 @@ public:
   void getAnalysisUsage(AnalysisUsage &AU) const override {
     AU.setPreservesCFG();
     AU.addRequired<MachineDominatorTreeWrapperPass>();
-    AU.addRequired<MachinePostDominatorTree>();
+    AU.addRequired<MachinePostDominatorTreeWrapperPass>();
     MachineFunctionPass::getAnalysisUsage(AU);
   }
 };
@@ -400,7 +400,7 @@ private:
 INITIALIZE_PASS_BEGIN(SILowerI1Copies, DEBUG_TYPE, "SI Lower i1 Copies", false,
                       false)
 INITIALIZE_PASS_DEPENDENCY(MachineDominatorTreeWrapperPass)
-INITIALIZE_PASS_DEPENDENCY(MachinePostDominatorTree)
+INITIALIZE_PASS_DEPENDENCY(MachinePostDominatorTreeWrapperPass)
 INITIALIZE_PASS_END(SILowerI1Copies, DEBUG_TYPE, "SI Lower i1 Copies", false,
                     false)
 
@@ -447,7 +447,7 @@ bool SILowerI1Copies::runOnMachineFunction(MachineFunction &TheMF) {
 
   Vreg1LoweringHelper Helper(
       &TheMF, &getAnalysis<MachineDominatorTreeWrapperPass>().getDomTree(),
-      &getAnalysis<MachinePostDominatorTree>());
+      &getAnalysis<MachinePostDominatorTreeWrapperPass>().getPostDomTree());
 
   bool Changed = false;
   Changed |= Helper.lowerCopiesFromI1();

--- a/llvm/lib/Target/Hexagon/HexagonFrameLowering.cpp
+++ b/llvm/lib/Target/Hexagon/HexagonFrameLowering.cpp
@@ -415,7 +415,7 @@ void HexagonFrameLowering::findShrunkPrologEpilog(MachineFunction &MF,
   MachineDominatorTree MDT;
   MDT.calculate(MF);
   MachinePostDominatorTree MPT;
-  MPT.runOnMachineFunction(MF);
+  MPT.recalculate(MF);
 
   using UnsignedMap = DenseMap<unsigned, unsigned>;
   using RPOTType = ReversePostOrderTraversal<const MachineFunction *>;

--- a/llvm/lib/Target/PowerPC/PPCBranchCoalescing.cpp
+++ b/llvm/lib/Target/PowerPC/PPCBranchCoalescing.cpp
@@ -166,7 +166,7 @@ public:
 
   void getAnalysisUsage(AnalysisUsage &AU) const override {
     AU.addRequired<MachineDominatorTreeWrapperPass>();
-    AU.addRequired<MachinePostDominatorTree>();
+    AU.addRequired<MachinePostDominatorTreeWrapperPass>();
     MachineFunctionPass::getAnalysisUsage(AU);
   }
 
@@ -196,7 +196,7 @@ FunctionPass *llvm::createPPCBranchCoalescingPass() {
 INITIALIZE_PASS_BEGIN(PPCBranchCoalescing, DEBUG_TYPE,
                       "Branch Coalescing", false, false)
 INITIALIZE_PASS_DEPENDENCY(MachineDominatorTreeWrapperPass)
-INITIALIZE_PASS_DEPENDENCY(MachinePostDominatorTree)
+INITIALIZE_PASS_DEPENDENCY(MachinePostDominatorTreeWrapperPass)
 INITIALIZE_PASS_END(PPCBranchCoalescing, DEBUG_TYPE, "Branch Coalescing",
                     false, false)
 
@@ -215,7 +215,7 @@ void PPCBranchCoalescing::CoalescingCandidateInfo::clear() {
 
 void PPCBranchCoalescing::initialize(MachineFunction &MF) {
   MDT = &getAnalysis<MachineDominatorTreeWrapperPass>().getDomTree();
-  MPDT = &getAnalysis<MachinePostDominatorTree>();
+  MPDT = &getAnalysis<MachinePostDominatorTreeWrapperPass>().getPostDomTree();
   TII = MF.getSubtarget().getInstrInfo();
   MRI = &MF.getRegInfo();
 }

--- a/llvm/lib/Target/PowerPC/PPCMIPeephole.cpp
+++ b/llvm/lib/Target/PowerPC/PPCMIPeephole.cpp
@@ -157,11 +157,11 @@ public:
   void getAnalysisUsage(AnalysisUsage &AU) const override {
     AU.addRequired<LiveVariables>();
     AU.addRequired<MachineDominatorTreeWrapperPass>();
-    AU.addRequired<MachinePostDominatorTree>();
+    AU.addRequired<MachinePostDominatorTreeWrapperPass>();
     AU.addRequired<MachineBlockFrequencyInfo>();
     AU.addPreserved<LiveVariables>();
     AU.addPreserved<MachineDominatorTreeWrapperPass>();
-    AU.addPreserved<MachinePostDominatorTree>();
+    AU.addPreserved<MachinePostDominatorTreeWrapperPass>();
     AU.addPreserved<MachineBlockFrequencyInfo>();
     MachineFunctionPass::getAnalysisUsage(AU);
   }
@@ -201,7 +201,7 @@ void PPCMIPeephole::initialize(MachineFunction &MFParm) {
   MF = &MFParm;
   MRI = &MF->getRegInfo();
   MDT = &getAnalysis<MachineDominatorTreeWrapperPass>().getDomTree();
-  MPDT = &getAnalysis<MachinePostDominatorTree>();
+  MPDT = &getAnalysis<MachinePostDominatorTreeWrapperPass>().getPostDomTree();
   MBFI = &getAnalysis<MachineBlockFrequencyInfo>();
   LV = &getAnalysis<LiveVariables>();
   EntryFreq = MBFI->getEntryFreq();
@@ -2030,7 +2030,7 @@ INITIALIZE_PASS_BEGIN(PPCMIPeephole, DEBUG_TYPE,
                       "PowerPC MI Peephole Optimization", false, false)
 INITIALIZE_PASS_DEPENDENCY(MachineBlockFrequencyInfo)
 INITIALIZE_PASS_DEPENDENCY(MachineDominatorTreeWrapperPass)
-INITIALIZE_PASS_DEPENDENCY(MachinePostDominatorTree)
+INITIALIZE_PASS_DEPENDENCY(MachinePostDominatorTreeWrapperPass)
 INITIALIZE_PASS_DEPENDENCY(LiveVariables)
 INITIALIZE_PASS_END(PPCMIPeephole, DEBUG_TYPE,
                     "PowerPC MI Peephole Optimization", false, false)


### PR DESCRIPTION
`MachinePostDominators` of #94571.