### PR TITLE
[lld-macho] Add swift support to ObjC category merger

### DIFF
--- a/lld/MachO/ObjC.cpp
+++ b/lld/MachO/ObjC.cpp
@@ -675,20 +675,18 @@ void ObjcCategoryMerger::parseProtocolListInfo(const ConcatInputSection *isec,
   ptrList.structCount += protocolCount;
   ptrList.structSize = target->wordSize;
 
-  uint32_t expectedListSize =
+  [[maybe_unused]] uint32_t expectedListSize =
       (protocolCount * target->wordSize) +
       /*header(count)*/ protocolListHeaderLayout.totalSize +
       /*extra null value*/ target->wordSize;
 
-  // On Swift, the protocol list does not have the extra (unecessary) null value
-  uint32_t expectedListSizeSwift = expectedListSize - target->wordSize;
+  // On Swift, the protocol list does not have the extra (unnecessary) null
+  [[maybe_unused]] uint32_t expectedListSizeSwift =
+      expectedListSize - target->wordSize;
 
   assert((expectedListSize == ptrListSym->isec()->data.size() ||
           expectedListSizeSwift == ptrListSym->isec()->data.size()) &&
          "Protocol list does not match expected size");
-
-  // Suppress unsuded var warning
-  (void)expectedListSize, (void)expectedListSizeSwift;
 
   uint32_t off = protocolListHeaderLayout.totalSize;
   for (uint32_t inx = 0; inx < protocolCount; ++inx) {

--- a/lld/MachO/ObjC.cpp
+++ b/lld/MachO/ObjC.cpp
@@ -1274,9 +1274,7 @@ void ObjcCategoryMerger::eraseMergedCategories() {
 
       eraseISec(catInfo.catBodyIsec);
 
-      // We can't erase 'catLayout.nameOffset' because for Swift categories, the
-      // name will be referenced in __METACLASS_DATA_.
-      // TODO: handle the above smarter
+      tryEraseDefinedAtIsecOffset(catInfo.catBodyIsec, catLayout.nameOffset);
       tryEraseDefinedAtIsecOffset(catInfo.catBodyIsec,
                                   catLayout.instanceMethodsOffset);
       tryEraseDefinedAtIsecOffset(catInfo.catBodyIsec,

--- a/lld/MachO/ObjC.h
+++ b/lld/MachO/ObjC.h
@@ -32,6 +32,8 @@ constexpr const char categoryInstanceMethods[] =
 constexpr const char categoryClassMethods[] =
     "__OBJC_$_CATEGORY_CLASS_METHODS_";
 constexpr const char categoryProtocols[] = "__OBJC_CATEGORY_PROTOCOLS_$_";
+
+constexpr const char swift_objc_category[] = "__CATEGORY_";
 } // namespace symbol_names
 
 // Check for duplicate method names within related categories / classes.


### PR DESCRIPTION
Currently ObjC category merger only supports categories defined in ObjC. But swift supports generating ObjC categories also. This change adds supports for the later categories. 