### PR TITLE
[ProfileData] Simplify InstrProfValueSiteRecord (NFC)

### DIFF
--- a/llvm/include/llvm/ProfileData/InstrProf.h
+++ b/llvm/include/llvm/ProfileData/InstrProf.h
@@ -797,7 +797,7 @@ struct InstrProfValueSiteRecord {
   /// Value profiling data pairs at a given value site.
   std::list<InstrProfValueData> ValueData;
 
-  InstrProfValueSiteRecord() { ValueData.clear(); }
+  InstrProfValueSiteRecord() = default;
   template <class InputIterator>
   InstrProfValueSiteRecord(InputIterator F, InputIterator L)
       : ValueData(F, L) {}


### PR DESCRIPTION
std::list default-constructs itself as an empty list, so we don't need
to call ValueData.clear() in the constructor.