### PR TITLE
[SDAG] Don't transfer !range metadata without noundef to SDAG

### DIFF
--- a/llvm/lib/CodeGen/SelectionDAG/SelectionDAGBuilder.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/SelectionDAGBuilder.cpp
@@ -4482,7 +4482,12 @@ static const MDNode *getRangeMetadata(const Instruction &I) {
   // transforms that are known not to be poison-safe, such as folding logical
   // and/or to bitwise and/or. For now, only transfer !range if !noundef is
   // also present.
-  if (!I.hasMetadata(LLVMContext::MD_noundef))
+  bool NoUndef = false;
+  if (const auto *CB = dyn_cast<CallBase>(&I)) {
+    NoUndef = CB->hasRetAttr(Attribute::NoUndef);
+  }
+  NoUndef = NoUndef || I.hasMetadata(LLVMContext::MD_noundef);
+  if (!NoUndef)
     return nullptr;
   return I.getMetadata(LLVMContext::MD_range);
 }

--- a/llvm/test/CodeGen/X86/legalize-vec-assertzext.ll
+++ b/llvm/test/CodeGen/X86/legalize-vec-assertzext.ll
@@ -34,6 +34,21 @@ define i64 @widen_assertzext(ptr %x) nounwind {
   ret i64 %d
 }
 
+define i64 @widen_assertzext_noundef_ret_attr(ptr %x) nounwind {
+; CHECK-LABEL: widen_assertzext_noundef_ret_attr:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    pushq %rax
+; CHECK-NEXT:    callq test2@PLT
+; CHECK-NEXT:    vextracti32x4 $3, %zmm0, %xmm0
+; CHECK-NEXT:    vmovq %xmm0, %rax
+; CHECK-NEXT:    popq %rcx
+; CHECK-NEXT:    vzeroupper
+; CHECK-NEXT:    retq
+  %e = call noundef <7 x i64> @test2(), !range !0
+  %d = extractelement <7 x i64> %e, i32 6
+  ret i64 %d
+}
+
 declare  <16 x i64> @test()
 declare  <7 x i64> @test2()
 !0 = !{ i64 0, i64 2 }

--- a/llvm/test/CodeGen/X86/legalize-vec-assertzext.ll
+++ b/llvm/test/CodeGen/X86/legalize-vec-assertzext.ll
@@ -39,6 +39,9 @@ define i64 @widen_assertzext_noundef_ret_attr(ptr %x) nounwind {
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    pushq %rax
 ; CHECK-NEXT:    callq test2@PLT
+; CHECK-NEXT:    movb $127, %al
+; CHECK-NEXT:    kmovw %eax, %k1
+; CHECK-NEXT:    vpexpandq %zmm0, %zmm0 {%k1} {z}
 ; CHECK-NEXT:    vextracti32x4 $3, %zmm0, %xmm0
 ; CHECK-NEXT:    vmovq %xmm0, %rax
 ; CHECK-NEXT:    popq %rcx


### PR DESCRIPTION
Same as https://github.com/llvm/llvm-project/commit/9deee6bffa9c331f46c68e5dd4cb4abf93dc0716 but for the noundef return attribute.

CC @nikic @arsenm