### PR TITLE
[HLSL] Fix FileCheck annotation typos

### DIFF
--- a/clang/test/CodeGenHLSL/convergence/for.hlsl
+++ b/clang/test/CodeGenHLSL/convergence/for.hlsl
@@ -92,7 +92,7 @@ void test6() {
 // CHECK:   [[C1:%[a-zA-Z0-9]+]] = call spir_func noundef i1 @_Z4condv() [[A3]] [ "convergencectrl"(token [[T1]]) ]
 // CHECK:   br i1 [[C1]], label %if.then, label %if.end
 // CHECK: if.then:
-// CHECK    call spir_func void @_Z3foov() [[A3:#[0-9]+]] [ "convergencectrl"(token [[T1]]) ]
+// CHECK:   call spir_func void @_Z3foov() [[A3:#[0-9]+]] [ "convergencectrl"(token [[T1]]) ]
 // CHECK:   br label %for.end
 // CHECK: if.end:
 // CHECK:   br label %for.inc

--- a/clang/test/SemaHLSL/standard_conversion_sequences.hlsl
+++ b/clang/test/SemaHLSL/standard_conversion_sequences.hlsl
@@ -4,9 +4,8 @@
 void test() {
   
   // CHECK: VarDecl {{.*}} used f3 'vector<float, 3>':'float __attribute__((ext_vector_type(3)))' cinit
-  // CHECK-NEXt: ImplicitCastExpr {{.*}} 'vector<float, 3>':'float __attribute__((ext_vector_type(3)))' <VectorSplat>
-  // CHECK-NEXt: ImplicitCastExpr {{.*}} 'float' <FloatingCast>
-  // CHECK-NEXt: FloatingLiteral {{.*}} 'double' 1.000000e+00
+  // CHECK-NEXT: ImplicitCastExpr {{.*}} 'vector<float, 3>':'float __attribute__((ext_vector_type(3)))' <VectorSplat>
+  // CHECK-NEXT: FloatingLiteral {{.*}} 'float' 1.000000e+00
   vector<float,3> f3 = 1.0; // No warning for splatting to a vector from a literal.
 
 


### PR DESCRIPTION
These are the HLSL specific fixes from #93193. Thanks @klensy!