### PR TITLE
[CodeGen] Remove IsVolatile from DominatingValue<RValue>::save_type

### DIFF
--- a/clang/lib/CodeGen/CGCleanup.cpp
+++ b/clang/lib/CodeGen/CGCleanup.cpp
@@ -48,10 +48,10 @@ DominatingValue<RValue>::saved_type::save(CodeGenFunction &CGF, RValue rv) {
 
   assert(rv.isAggregate());
   Address V = rv.getAggregateAddress();
-  return saved_type(
-      DominatingValue<Address>::save(CGF, V), rv.isVolatileQualified(),
-      DominatingValue<Address>::needsSaving(V) ? AggregateAddress
-                                               : AggregateLiteral);
+  return saved_type(DominatingValue<Address>::save(CGF, V),
+                    DominatingValue<Address>::needsSaving(V)
+                        ? AggregateAddress
+                        : AggregateLiteral);
 }
 
 /// Given a saved r-value produced by SaveRValue, perform the code
@@ -65,7 +65,7 @@ RValue DominatingValue<RValue>::saved_type::restore(CodeGenFunction &CGF) {
   case AggregateLiteral:
   case AggregateAddress:
     return RValue::getAggregate(
-        DominatingValue<Address>::restore(CGF, AggregateAddr), IsVolatile);
+        DominatingValue<Address>::restore(CGF, AggregateAddr));
   case ComplexAddress: {
     llvm::Value *real = DominatingLLVMValue::restore(CGF, Vals.first);
     llvm::Value *imag = DominatingLLVMValue::restore(CGF, Vals.second);

--- a/clang/lib/CodeGen/CodeGenFunction.h
+++ b/clang/lib/CodeGen/CodeGenFunction.h
@@ -221,7 +221,6 @@ template <> struct DominatingValue<RValue> {
     };
     LLVM_PREFERRED_TYPE(Kind)
     unsigned K : 3;
-    unsigned IsVolatile : 1;
 
     saved_type(DominatingLLVMValue::saved_type Val1, unsigned K)
         : Vals{Val1, DominatingLLVMValue::saved_type()}, K(K) {}
@@ -230,8 +229,7 @@ template <> struct DominatingValue<RValue> {
                DominatingLLVMValue::saved_type Val2)
         : Vals{Val1, Val2}, K(ComplexAddress) {}
 
-    saved_type(DominatingValue<Address>::saved_type AggregateAddr,
-               bool IsVolatile, unsigned K)
+    saved_type(DominatingValue<Address>::saved_type AggregateAddr, unsigned K)
         : AggregateAddr(AggregateAddr), K(K) {}
 
   public:


### PR DESCRIPTION
Prior to 84780af4b02cb3b86e4cb724f996bf8e02f2f2e7, the class didn't have any information about whether the saved value was volatile.

This is NFC as far as I can tell.