### PR TITLE
[lldb][ConstString] Prevent GetString from constructing a std::string with a nullptr

### DIFF
--- a/lldb/include/lldb/Utility/ConstString.h
+++ b/lldb/include/lldb/Utility/ConstString.h
@@ -199,7 +199,9 @@ public:
   }
 
   /// Get the string value as a std::string
-  std::string GetString() const { return std::string(m_string, GetLength()); }
+  std::string GetString() const {
+    return std::string(AsCString(""), GetLength());
+  }
 
   /// Get the string value as a C string.
   ///

--- a/lldb/unittests/Utility/ConstStringTest.cpp
+++ b/lldb/unittests/Utility/ConstStringTest.cpp
@@ -88,6 +88,7 @@ TEST(ConstStringTest, NullAndEmptyStates) {
   EXPECT_TRUE(!null);
   EXPECT_TRUE(null.IsEmpty());
   EXPECT_TRUE(null.IsNull());
+  EXPECT_TRUE(null.GetString().empty());
 }
 
 TEST(ConstStringTest, CompareConstString) {


### PR DESCRIPTION
This patch prevents passing a `nullptr` to the `std::string` constructor in `GetString`. This prevents UB arising from calling `GetString` on a default-constructed `ConstString`.