### PR TITLE
[libc] Add baremetal putchar

### DIFF
--- a/libc/src/stdio/baremetal/CMakeLists.txt
+++ b/libc/src/stdio/baremetal/CMakeLists.txt
@@ -18,4 +18,16 @@ add_entrypoint_object(
     libc.src.stdio.printf_core.printf_main
     libc.src.stdio.printf_core.writer
     libc.src.__support.arg_list
+    libc.src.__support.OSUtil.osutil
+)
+
+add_entrypoint_object(
+  putchar
+  SRCS
+    putchar.cpp
+  HDRS
+    ../putchar.h
+  DEPENDS
+    libc.src.__support.OSUtil.osutil
+    libc.src.__support.CPP.string_view
 )

--- a/libc/src/stdio/baremetal/printf.cpp
+++ b/libc/src/stdio/baremetal/printf.cpp
@@ -7,6 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "src/stdio/printf.h"
+#include "src/__support/OSUtil/io.h"
 #include "src/__support/arg_list.h"
 #include "src/stdio/printf_core/core_structs.h"
 #include "src/stdio/printf_core/printf_main.h"
@@ -14,19 +15,12 @@
 
 #include <stdarg.h>
 
-// TODO(https://github.com/llvm/llvm-project/issues/94685) unify baremetal hooks
-
-// This is intended to be provided by the vendor.
-extern "C" size_t __llvm_libc_raw_write(const char *s, size_t size);
-
 namespace LIBC_NAMESPACE {
 
 namespace {
 
 LIBC_INLINE int raw_write_hook(cpp::string_view new_str, void *) {
-  size_t written = __llvm_libc_raw_write(new_str.data(), new_str.size());
-  if (written != new_str.size())
-    return printf_core::FILE_WRITE_ERROR;
+  write_to_stderr(new_str);
   return printf_core::WRITE_OK;
 }
 

--- a/libc/src/stdio/baremetal/putchar.cpp
+++ b/libc/src/stdio/baremetal/putchar.cpp
@@ -1,0 +1,23 @@
+//===-- Baremetal Implementation of putchar -------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "src/stdio/putchar.h"
+#include "src/__support/CPP/string_view.h"
+#include "src/__support/OSUtil/io.h"
+
+namespace LIBC_NAMESPACE {
+
+LLVM_LIBC_FUNCTION(int, putchar, (int c)) {
+  char uc = static_cast<char>(c);
+
+  write_to_stderr(cpp::string_view(&uc, 1));
+
+  return 0;
+}
+
+} // namespace LIBC_NAMESPACE


### PR DESCRIPTION
In #94685 I discussed my ideas for cleaner baremetal output writing.
This patch is not that. This patch just uses `write_to_stderr` for
outputting from putchar and printf on baremetal. I'm still planning to
create a proper design for writing to stdout and stderr on various
platforms, but that will be a followup patch.
