### PR TITLE
[clang-doc][cmake] Copy assets to build directory

### DIFF
--- a/clang-tools-extra/clang-doc/tool/CMakeLists.txt
+++ b/clang-tools-extra/clang-doc/tool/CMakeLists.txt
@@ -18,18 +18,43 @@ target_link_libraries(clang-doc
   clangDoc
   )
 
-install(FILES ../assets/clang-doc-default-stylesheet.css
-  DESTINATION "${CMAKE_INSTALL_DATADIR}/clang"
-  COMPONENT clang-doc)
 
-install(FILES ../assets/index.js
-  DESTINATION "${CMAKE_INSTALL_DATADIR}/clang"
-  COMPONENT clang-doc)
+set(assets
+  index.js
+  clang-doc-default-stylesheet.css
+)
+
+set(asset_dir "${CMAKE_CURRENT_SOURCE_DIR}/../assets")
+set(resource_dir "${CMAKE_BINARY_DIR}/share/clang")
+set(out_files)
+
+function(copy_files_to_dst src_dir dst_dir file msg)
+  set(src "${src_dir}/${file}")
+  set(dst "${dst_dir}/${file}")
+  # set a default message if one isn't supplied
+  if("${msg}" STREQUAL "")
+    set(msg "Copying ${file} to ${dst_dir}")
+  endif()
+
+  add_custom_command(OUTPUT ${dst}
+    DEPENDS ${src}
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different ${src} ${dst}
+    COMMENT "${msg}"
+  )
+  list(APPEND out_files ${dst})
+  set(out_files ${out_files} PARENT_SCOPE)
+endfunction(copy_files_to_dst)
+
+foreach(f ${assets})
+  install(FILES ${asset_dir}/${f}
+    DESTINATION "${CMAKE_INSTALL_DATADIR}/clang"
+    COMPONENT clang-doc)
+  copy_files_to_dst(${asset_dir} ${resource_dir} ${f} "")
+endforeach(f)
 
 add_custom_target(copy-clang-doc-assets
-  COMMAND ${CMAKE_COMMAND} -E copy_directory_if_different "${CMAKE_CURRENT_SOURCE_DIR}/../assets" "${CMAKE_BINARY_DIR}/share/clang"
-  DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/../assets"
+  DEPENDS ${out_files}
   COMMENT "Copying Clang-Doc Assets"
-  )
+)
 set_target_properties(copy-clang-doc-assets PROPERTIES FOLDER "Clang-Doc/Assets")
 add_dependencies(clang-doc copy-clang-doc-assets)

--- a/clang-tools-extra/clang-doc/tool/CMakeLists.txt
+++ b/clang-tools-extra/clang-doc/tool/CMakeLists.txt
@@ -25,3 +25,11 @@ install(FILES ../assets/clang-doc-default-stylesheet.css
 install(FILES ../assets/index.js
   DESTINATION "${CMAKE_INSTALL_DATADIR}/clang"
   COMPONENT clang-doc)
+
+add_custom_target(copy-clang-doc-assets
+  COMMAND ${CMAKE_COMMAND} -E copy_directory_if_different "${CMAKE_CURRENT_SOURCE_DIR}/../assets" "${CMAKE_BINARY_DIR}/share/clang"
+  DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/../assets"
+  COMMENT "Copying Clang-Doc Assets"
+  )
+set_target_properties(copy-clang-doc-assets PROPERTIES FOLDER "Clang-Doc/Assets")
+add_dependencies(clang-doc copy-clang-doc-assets)

--- a/clang-tools-extra/clang-doc/tool/CMakeLists.txt
+++ b/clang-tools-extra/clang-doc/tool/CMakeLists.txt
@@ -28,18 +28,13 @@ set(asset_dir "${CMAKE_CURRENT_SOURCE_DIR}/../assets")
 set(resource_dir "${CMAKE_BINARY_DIR}/share/clang")
 set(out_files)
 
-function(copy_files_to_dst src_dir dst_dir file msg)
+function(copy_files_to_dst src_dir dst_dir file)
   set(src "${src_dir}/${file}")
   set(dst "${dst_dir}/${file}")
-  # set a default message if one isn't supplied
-  if("${msg}" STREQUAL "")
-    set(msg "Copying ${file} to ${dst_dir}")
-  endif()
-
   add_custom_command(OUTPUT ${dst}
     DEPENDS ${src}
     COMMAND ${CMAKE_COMMAND} -E copy_if_different ${src} ${dst}
-    COMMENT "${msg}"
+    COMMENT "Copying ${file} to ${dst_dir}"
   )
   list(APPEND out_files ${dst})
   set(out_files ${out_files} PARENT_SCOPE)
@@ -49,7 +44,7 @@ foreach(f ${assets})
   install(FILES ${asset_dir}/${f}
     DESTINATION "${CMAKE_INSTALL_DATADIR}/clang"
     COMPONENT clang-doc)
-  copy_files_to_dst(${asset_dir} ${resource_dir} ${f} "")
+  copy_files_to_dst(${asset_dir} ${resource_dir} ${f})
 endforeach(f)
 
 add_custom_target(copy-clang-doc-assets


### PR DESCRIPTION
While we copy the asset files, like index.js, into the correct location in the install step, tests do not have access to those resources in the build directory.

This patch copies the contents of the clang-doc/assets directory into the build folder, so that they can be used in testing.

Pull Request: https://github.com/llvm/llvm-project/pull/95185