### PR TITLE
[VPlan] Treat Div/Rem as not Predicated if divisor is invariant

### DIFF
--- a/llvm/lib/Transforms/Vectorize/LoopVectorize.cpp
+++ b/llvm/lib/Transforms/Vectorize/LoopVectorize.cpp
@@ -3863,7 +3863,8 @@ bool LoopVectorizationCostModel::isPredicatedInst(Instruction *I) const {
   case Instruction::URem:
     // TODO: We can use the loop-preheader as context point here and get
     // context sensitive reasoning
-    return !isSafeToSpeculativelyExecute(I);
+    return !isSafeToSpeculativelyExecute(I) &&
+           !Legal->isInvariant(I->getOperand(1));
   case Instruction::Call:
     return Legal->isMaskRequired(I);
   }


### PR DESCRIPTION
It tries to fix https://github.com/llvm/llvm-project/issues/94328

From what I understand so far, as recorded in the issue, I think
we can treat Div/Rem as not Predicated if divisor is invariant.