### PR TITLE
[Clang] Fix potential null pointer dereferences in retain cycle detection

### DIFF
--- a/clang/lib/Sema/SemaObjC.cpp
+++ b/clang/lib/Sema/SemaObjC.cpp
@@ -849,7 +849,7 @@ static bool findRetainCycleOwner(Sema &S, Expr *e, RetainCycleOwner &owner) {
       owner.Indirect = true;
       if (pre->isSuperReceiver()) {
         if (const auto *CurMethodDecl = S.getCurMethodDecl()) {
-          owner.Variable = CurMethodDecl()->getSelfDecl();
+          owner.Variable = CurMethodDecl->getSelfDecl();
           if (!owner.Variable)
             return false;
           owner.Loc = pre->getLocation();

--- a/clang/lib/Sema/SemaObjC.cpp
+++ b/clang/lib/Sema/SemaObjC.cpp
@@ -1173,9 +1173,13 @@ void SemaObjC::checkRetainCycles(ObjCMessageExpr *msg) {
       return;
   } else {
     assert(msg->getReceiverKind() == ObjCMessageExpr::SuperInstance);
-    owner.Variable = SemaRef.getCurMethodDecl()->getSelfDecl();
-    owner.Loc = msg->getSuperLoc();
-    owner.Range = msg->getSuperLoc();
+    if (const auto *CurMethodDecl = SemaRef.getCurMethodDecl()) {
+      owner.Variable = CurMethodDecl->getSelfDecl();
+      owner.Loc = msg->getSuperLoc();
+      owner.Range = msg->getSuperLoc();
+    } else {
+      return;
+    }
   }
 
   // Check whether the receiver is captured by any of the arguments.

--- a/clang/lib/Sema/SemaObjC.cpp
+++ b/clang/lib/Sema/SemaObjC.cpp
@@ -848,12 +848,16 @@ static bool findRetainCycleOwner(Sema &S, Expr *e, RetainCycleOwner &owner) {
 
       owner.Indirect = true;
       if (pre->isSuperReceiver()) {
-        owner.Variable = S.getCurMethodDecl()->getSelfDecl();
-        if (!owner.Variable)
+        if (const auto *CurMethodDecl = S.getCurMethodDecl()) {
+          owner.Variable = CurMethodDecl()->getSelfDecl();
+          if (!owner.Variable)
+            return false;
+          owner.Loc = pre->getLocation();
+          owner.Range = pre->getSourceRange();
+          return true;
+        } else {
           return false;
-        owner.Loc = pre->getLocation();
-        owner.Range = pre->getSourceRange();
-        return true;
+        }
       }
       e = const_cast<Expr *>(
           cast<OpaqueValueExpr>(pre->getBase())->getSourceExpr());


### PR DESCRIPTION
This patch resolves a static analyzer bugs where `S.getCurMethodDecl()` or `SemaRef.getCurMethodDecl()` could return `nullptr` when calling `getSelfDecl(()` and was being dereferenced without a null check. The fix introduces a check for a non-null return value before accessing `getSelfDecl()` to ensure safe dereferencing.

This change prevents undefined behavior in scenarios where the current method declaration is not available, thus enhancing the robustness of the retain cycle detection logic.