### PR TITLE
[Clang] Initialize AtLeastAsSpecialized to prevent undefined behavior in Sema::isTemplateTemplateParameterAtLeastAsSpecializedAs()

### DIFF
--- a/clang/lib/Sema/SemaTemplateDeduction.cpp
+++ b/clang/lib/Sema/SemaTemplateDeduction.cpp
@@ -6447,7 +6447,7 @@ bool Sema::isTemplateTemplateParameterAtLeastAsSpecializedAs(
   if (Inst.isInvalid())
     return false;
 
-  bool AtLeastAsSpecialized;
+  bool AtLeastAsSpecialized = false;
   runWithSufficientStackSpace(Info.getLocation(), [&] {
     AtLeastAsSpecialized =
         ::FinishTemplateArgumentDeduction(


### PR DESCRIPTION
This patch fixes a static analyzer bug where the `boolean` variable `AtLeastAsSpecialized` was used uninitialized. The variable is now explicitly initialized to `false` before its potential modification within a `lambda function` to ensure that it always holds a valid value when returned, preventing undefined behavior due to uninitialized variable usage in `Sema::isTemplateTemplateParameterAtLeastAsSpecializedAs()`.