### PR TITLE
[test] Skip some tests on Windows only

### DIFF
--- a/llvm/test/DebugInfo/symbolize-gnu-debuglink-no-realpath.test
+++ b/llvm/test/DebugInfo/symbolize-gnu-debuglink-no-realpath.test
@@ -1,4 +1,6 @@
-# REQUIRES: shell
+# This test uses symlinks.
+UNSUPPORTED: system-windows
+
 # Ensure that no realpath assumptions are made about .gnu_debuglink paths.
 
 # Copy inputs to some other location with arbitrary names, with the original

--- a/llvm/test/Other/lit-unicode.txt
+++ b/llvm/test/Other/lit-unicode.txt
@@ -1,5 +1,5 @@
-FIXME: See if we can fix this in lit by using Unicode strings.
-REQUIRES: shell
+Windows echo does not have good Unicode support.
+UNSUPPORTED: system-windows
 
 RUN: echo "ようこそ" | FileCheck %s
 CHECK: {{^}}ようこそ{{$}}

--- a/llvm/test/tools/llvm-rc/windres-prefix.test
+++ b/llvm/test/tools/llvm-rc/windres-prefix.test
@@ -1,4 +1,5 @@
-; REQUIRES: shell
+; This test uses symlinks.
+; UNSUPPORTED: system-windows
 
 ; RUN: rm -rf %t && mkdir %t
 


### PR DESCRIPTION
These tests do not require bash. Skip them because they use features not
available on Windows. This is a follow up to #94595.
