### PR TITLE
[clang][NFC] Add a test for CWG2685

### DIFF
--- a/clang/test/CXX/drs/cwg26xx.cpp
+++ b/clang/test/CXX/drs/cwg26xx.cpp
@@ -225,6 +225,15 @@ void m() {
 }
 
 #if __cplusplus >= 202302L
+
+namespace cwg2685 { // cwg2685: 17
+template <class T>
+struct A {
+  T ar[4];
+};
+A a = { "foo" };
+}
+
 namespace cwg2687 { // cwg2687: 18
 struct S{
     void f(int);

--- a/clang/www/cxx_dr_status.html
+++ b/clang/www/cxx_dr_status.html
@@ -12670,7 +12670,7 @@ and <I>POD class</I></td>
   </tr>
   <tr class="open" id="2144">
     <td><a href="https://cplusplus.github.io/CWG/issues/2144.html">2144</a></td>
-    <td>drafting</td>
+    <td>tentatively ready</td>
     <td>Function/variable declaration ambiguity</td>
     <td align="center">Not resolved</td>
   </tr>
@@ -15918,7 +15918,7 @@ and <I>POD class</I></td>
     <td><a href="https://cplusplus.github.io/CWG/issues/2685.html">2685</a></td>
     <td>C++23</td>
     <td>Aggregate CTAD, string, and brace elision</td>
-    <td class="unknown" align="center">Unknown</td>
+    <td class="full" align="center">Clang 17</td>
   </tr>
   <tr class="open" id="2686">
     <td><a href="https://cplusplus.github.io/CWG/issues/2686.html">2686</a></td>
@@ -17081,7 +17081,7 @@ objects</td>
   </tr>
   <tr class="open" id="2879">
     <td><a href="https://cplusplus.github.io/CWG/issues/2879.html">2879</a></td>
-    <td>open</td>
+    <td>drafting</td>
     <td>Undesired outcomes with <TT>const_cast</TT></td>
     <td align="center">Not resolved</td>
   </tr>
@@ -17099,13 +17099,13 @@ objects</td>
   </tr>
   <tr class="open" id="2882">
     <td><a href="https://cplusplus.github.io/CWG/issues/2882.html">2882</a></td>
-    <td>open</td>
+    <td>tentatively ready</td>
     <td>Unclear treatment of conversion to <TT>void</TT></td>
     <td align="center">Not resolved</td>
   </tr>
   <tr class="open" id="2883">
     <td><a href="https://cplusplus.github.io/CWG/issues/2883.html">2883</a></td>
-    <td>open</td>
+    <td>tentatively ready</td>
     <td>Definition of "odr-usable" ignores lambda scopes</td>
     <td align="center">Not resolved</td>
   </tr>
@@ -17117,25 +17117,25 @@ objects</td>
   </tr>
   <tr class="open" id="2885">
     <td><a href="https://cplusplus.github.io/CWG/issues/2885.html">2885</a></td>
-    <td>review</td>
+    <td>tentatively ready</td>
     <td>Non-eligible trivial default constructors</td>
     <td align="center">Not resolved</td>
   </tr>
   <tr class="open" id="2886">
     <td><a href="https://cplusplus.github.io/CWG/issues/2886.html">2886</a></td>
-    <td>open</td>
+    <td>tentatively ready</td>
     <td>Temporaries and trivial potentially-throwing special member functions</td>
     <td align="center">Not resolved</td>
   </tr>
   <tr class="open" id="2887">
     <td><a href="https://cplusplus.github.io/CWG/issues/2887.html">2887</a></td>
-    <td>open</td>
+    <td>tentatively ready</td>
     <td>Missing compatibility entries for xvalues</td>
     <td align="center">Not resolved</td>
   </tr>
   <tr class="open" id="2888">
     <td><a href="https://cplusplus.github.io/CWG/issues/2888.html">2888</a></td>
-    <td>open</td>
+    <td>review</td>
     <td>Missing cases for reference and array types for argument-dependent lookup</td>
     <td align="center">Not resolved</td>
   </tr>
@@ -17153,8 +17153,50 @@ objects</td>
   </tr>
   <tr class="open" id="2891">
     <td><a href="https://cplusplus.github.io/CWG/issues/2891.html">2891</a></td>
-    <td>review</td>
+    <td>tentatively ready</td>
     <td>Normative status of implementation limits</td>
+    <td align="center">Not resolved</td>
+  </tr>
+  <tr class="open" id="2892">
+    <td><a href="https://cplusplus.github.io/CWG/issues/2892.html">2892</a></td>
+    <td>tentatively ready</td>
+    <td>Unclear usual arithmetic conversions</td>
+    <td align="center">Not resolved</td>
+  </tr>
+  <tr class="open" id="2893">
+    <td><a href="https://cplusplus.github.io/CWG/issues/2893.html">2893</a></td>
+    <td>open</td>
+    <td>Instantiations in discarded <TT>if constexpr</TT> substatements</td>
+    <td align="center">Not resolved</td>
+  </tr>
+  <tr class="open" id="2894">
+    <td><a href="https://cplusplus.github.io/CWG/issues/2894.html">2894</a></td>
+    <td>open</td>
+    <td>Functional casts create prvalues of reference type</td>
+    <td align="center">Not resolved</td>
+  </tr>
+  <tr class="open" id="2895">
+    <td><a href="https://cplusplus.github.io/CWG/issues/2895.html">2895</a></td>
+    <td>open</td>
+    <td>Initialization should ignore the destination type's cv-qualification</td>
+    <td align="center">Not resolved</td>
+  </tr>
+  <tr class="open" id="2896">
+    <td><a href="https://cplusplus.github.io/CWG/issues/2896.html">2896</a></td>
+    <td>open</td>
+    <td>Template argument deduction involving exception specifications</td>
+    <td align="center">Not resolved</td>
+  </tr>
+  <tr class="open" id="2897">
+    <td><a href="https://cplusplus.github.io/CWG/issues/2897.html">2897</a></td>
+    <td>open</td>
+    <td>Copying potentially-overlapping union subobjects</td>
+    <td align="center">Not resolved</td>
+  </tr>
+  <tr class="open" id="2898">
+    <td><a href="https://cplusplus.github.io/CWG/issues/2898.html">2898</a></td>
+    <td>open</td>
+    <td>Clarify implicit conversion sequence from <I>cv</I> <TT>T</TT> to <TT>T</TT></td>
     <td align="center">Not resolved</td>
   </tr></table>
 


### PR DESCRIPTION
I believe it has been implemented since D139837 "Implements CTAD for aggregates P1816R0 and P2082R1", so this just claims we have already supported it.

Plus an update on the dr status page.