### PR TITLE
[libcxx] [ci] Don't install wget in the Windows jobs

### DIFF
--- a/.github/workflows/libcxx-build-and-test.yaml
+++ b/.github/workflows/libcxx-build-and-test.yaml
@@ -209,7 +209,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install dependencies
         run: |
-          choco install -y ninja wget
+          choco install -y ninja
           pip install psutil
       - name: Install a current LLVM
         if: ${{ matrix.mingw != true }}


### PR DESCRIPTION
Nothing uses wget - only curl is used, and that's available out of the box.