### PR TITLE
[libcxx] [ci] Update Clang for Windows jobs to 18.1.x

### DIFF
--- a/.github/workflows/libcxx-build-and-test.yaml
+++ b/.github/workflows/libcxx-build-and-test.yaml
@@ -214,11 +214,11 @@ jobs:
       - name: Install a current LLVM
         if: ${{ matrix.mingw != true }}
         run: |
-          choco install -y llvm --version=17.0.6
+          choco install -y llvm --version=18.1.6 --allow-downgrade
       - name: Install llvm-mingw
         if: ${{ matrix.mingw == true }}
         run: |
-          curl -LO https://github.com/mstorsjo/llvm-mingw/releases/download/20231128/llvm-mingw-20231128-ucrt-x86_64.zip
+          curl -LO https://github.com/mstorsjo/llvm-mingw/releases/download/20240606/llvm-mingw-20240606-ucrt-x86_64.zip
           powershell Expand-Archive llvm-mingw*.zip -DestinationPath .
           del llvm-mingw*.zip
           mv llvm-mingw* c:\llvm-mingw


### PR DESCRIPTION
Pick the latest version available in Chocolatey (18.1.6) and llvm-mingw (20240606, which includes LLVM 18.1.7).

Also add the flag "--allow-downgrade" when installing a specific version of LLVM. If the preinstalled version is higher than the requested one, Chocolatey would otherwise error out when requesting installing a lower version. This will avoid errors in the future, if the runner image comes preinstalled with a newer version of LLVM.

(This currently seems to happen with a recent version of the GitHub Actions runner image, version 20240610.1.0 has LLVM 18.1.6 already preinstalled, and will error out when trying to install the 17.0.6 version that we previously requested.)