### PR TITLE
[compiler-rt] Allow using a compiler without `stdio` and `printf`

### DIFF
--- a/compiler-rt/cmake/config-ix.cmake
+++ b/compiler-rt/cmake/config-ix.cmake
@@ -223,7 +223,7 @@ set(COMPILER_RT_SUPPORTED_ARCH)
 # runtime libraries supported by our current compilers cross-compiling
 # abilities.
 set(SIMPLE_SOURCE ${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/simple.cc)
-file(WRITE ${SIMPLE_SOURCE} "#include <stdlib.h>\n#include <stdio.h>\nint main(void) { printf(\"hello, world\"); }\n")
+file(WRITE ${SIMPLE_SOURCE} "#include <stdint.h>\nint main(void) { return 0; }\n")
 
 # Detect whether the current target platform is 32-bit or 64-bit, and setup
 # the correct commandline flags needed to attempt to target 32-bit and 64-bit.


### PR DESCRIPTION
Summary:
Part of attempts to get `compiler-rt` working for NVPTX and AMDGPU
targets. We only wish to build the builtins, which are unhosted.
Currently the build system rejects any compiler that isn't hosted due to
the check requiring `printf`. SImply make it return zero instead.
