### PR TITLE
mlir/Presburger: thoroughly guard debug-print

### DIFF
--- a/mlir/include/mlir/Analysis/FlatLinearValueConstraints.h
+++ b/mlir/include/mlir/Analysis/FlatLinearValueConstraints.h
@@ -218,10 +218,12 @@ protected:
       AffineMap map, std::vector<SmallVector<int64_t, 8>> *flattenedExprs,
       bool addConservativeSemiAffineBounds = false);
 
+#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   /// Prints the number of constraints, dimensions, symbols and locals in the
   /// FlatLinearConstraints. Also, prints for each variable whether there is
   /// an SSA Value attached to it.
   void printSpace(raw_ostream &os) const override;
+#endif
 };
 
 /// FlatLinearValueConstraints represents an extension of FlatLinearConstraints
@@ -432,10 +434,12 @@ public:
   void projectOut(Value val);
   using IntegerPolyhedron::projectOut;
 
+#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   /// Prints the number of constraints, dimensions, symbols and locals in the
   /// FlatAffineValueConstraints. Also, prints for each variable whether there
   /// is an SSA Value attached to it.
   void printSpace(raw_ostream &os) const override;
+#endif
 
   /// Align `map` with this constraint system based on `operands`. Each operand
   /// must already have a corresponding dim/symbol in this constraint system.

--- a/mlir/include/mlir/Analysis/Presburger/GeneratingFunction.h
+++ b/mlir/include/mlir/Analysis/Presburger/GeneratingFunction.h
@@ -90,6 +90,7 @@ public:
                               sumDenominators);
   }
 
+#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   llvm::raw_ostream &print(llvm::raw_ostream &os) const {
     for (unsigned i = 0, e = signs.size(); i < e; i++) {
       if (i == 0) {
@@ -124,6 +125,7 @@ public:
     }
     return os;
   }
+#endif
 
 private:
   unsigned numParam;

--- a/mlir/include/mlir/Analysis/Presburger/IntegerRelation.h
+++ b/mlir/include/mlir/Analysis/Presburger/IntegerRelation.h
@@ -748,8 +748,10 @@ public:
   // false.
   bool isFullDim();
 
+#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   void print(raw_ostream &os) const;
   void dump() const;
+#endif
 
 protected:
   /// Checks all rows of equality/inequality constraints for trivial
@@ -834,9 +836,11 @@ protected:
   /// is meant to be used within an assert internally.
   virtual bool hasConsistentState() const;
 
+#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   /// Prints the number of constraints, dimensions, symbols and locals in the
   /// IntegerRelation.
   virtual void printSpace(raw_ostream &os) const;
+#endif
 
   /// Removes variables in the column range [varStart, varLimit), and copies any
   /// remaining valid data into place, updates member variables, and resizes

--- a/mlir/include/mlir/Analysis/Presburger/Matrix.h
+++ b/mlir/include/mlir/Analysis/Presburger/Matrix.h
@@ -206,9 +206,11 @@ public:
   /// corresponding to 2.
   std::pair<Matrix<T>, Matrix<T>> splitByBitset(ArrayRef<int> indicator);
 
+#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   /// Print the matrix.
   void print(raw_ostream &os) const;
   void dump() const;
+#endif
 
   /// Return whether the Matrix is in a consistent state with all its
   /// invariants satisfied.

--- a/mlir/include/mlir/Analysis/Presburger/PWMAFunction.h
+++ b/mlir/include/mlir/Analysis/Presburger/PWMAFunction.h
@@ -109,8 +109,10 @@ public:
   /// Get this function as a relation.
   IntegerRelation getAsRelation() const;
 
+#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   void print(raw_ostream &os) const;
   void dump() const;
+#endif
 
 private:
   /// Assert that the MAF is consistent.
@@ -220,8 +222,10 @@ public:
   PWMAFunction unionLexMin(const PWMAFunction &func);
   PWMAFunction unionLexMax(const PWMAFunction &func);
 
+#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   void print(raw_ostream &os) const;
   void dump() const;
+#endif
 
 private:
   /// Return a function defined on the union of the domains of `this` and

--- a/mlir/include/mlir/Analysis/Presburger/PresburgerRelation.h
+++ b/mlir/include/mlir/Analysis/Presburger/PresburgerRelation.h
@@ -221,9 +221,11 @@ public:
   /// dimensional we mean that it is not flat along any dimension.
   bool isFullDim() const;
 
+#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   /// Print the set's internal state.
   void print(raw_ostream &os) const;
   void dump() const;
+#endif
 
 protected:
   /// Construct an empty PresburgerRelation with the specified number of

--- a/mlir/include/mlir/Analysis/Presburger/PresburgerSpace.h
+++ b/mlir/include/mlir/Analysis/Presburger/PresburgerSpace.h
@@ -99,8 +99,10 @@ public:
   bool operator==(const Identifier &other) const { return isEqual(other); }
   bool operator!=(const Identifier &other) const { return !isEqual(other); }
 
+#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   void print(llvm::raw_ostream &os) const;
   void dump() const;
+#endif
 
 private:
   /// The value of the identifier.
@@ -308,8 +310,10 @@ public:
   /// the same identifiers in the same order.
   void mergeAndAlignSymbols(PresburgerSpace &other);
 
+#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   void print(llvm::raw_ostream &os) const;
   void dump() const;
+#endif
 
 protected:
   PresburgerSpace(unsigned numDomain, unsigned numRange, unsigned numSymbols,

--- a/mlir/include/mlir/Analysis/Presburger/Simplex.h
+++ b/mlir/include/mlir/Analysis/Presburger/Simplex.h
@@ -208,9 +208,11 @@ public:
   /// Add all the constraints from the given IntegerRelation.
   void intersectIntegerRelation(const IntegerRelation &rel);
 
+#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   /// Print the tableau's internal state.
   void print(raw_ostream &os) const;
   void dump() const;
+#endif
 
 protected:
   /// Construct a SimplexBase with the specified number of variables and fixed
@@ -246,12 +248,14 @@ protected:
     bool restricted : 1;
     bool isSymbol : 1;
 
+#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
     void print(raw_ostream &os) const {
       os << (orientation == Orientation::Row ? "r" : "c");
       os << pos;
       if (restricted)
         os << " [>=0]";
     }
+#endif
   };
 
   struct Pivot {

--- a/mlir/include/mlir/Analysis/Presburger/Utils.h
+++ b/mlir/include/mlir/Analysis/Presburger/Utils.h
@@ -181,8 +181,10 @@ public:
   void
   removeDuplicateDivs(llvm::function_ref<bool(unsigned i, unsigned j)> merge);
 
+#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   void print(raw_ostream &os) const;
   void dump() const;
+#endif
 
 private:
   /// Each row of the Matrix represents a single division dividend. The

--- a/mlir/include/mlir/Interfaces/ValueBoundsOpInterface.h
+++ b/mlir/include/mlir/Interfaces/ValueBoundsOpInterface.h
@@ -301,9 +301,11 @@ public:
   /// Return an expression that represents a constant.
   AffineExpr getExpr(int64_t constant);
 
+#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   /// Debugging only: Dump the constraint set and the column-to-value/dim
   /// mapping to llvm::errs.
   void dump() const;
+#endif
 
 protected:
   /// Dimension identifier to indicate a value is index-typed. This is used for

--- a/mlir/lib/Analysis/FlatLinearValueConstraints.cpp
+++ b/mlir/lib/Analysis/FlatLinearValueConstraints.cpp
@@ -1194,6 +1194,7 @@ void FlatLinearValueConstraints::addBound(BoundType type, Value val,
   addBound(type, pos, value);
 }
 
+#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 void FlatLinearConstraints::printSpace(raw_ostream &os) const {
   IntegerPolyhedron::printSpace(os);
   os << "(";
@@ -1221,6 +1222,7 @@ void FlatLinearValueConstraints::printSpace(raw_ostream &os) const {
     os << "Local\t";
   os << "const)\n";
 }
+#endif
 
 void FlatLinearValueConstraints::projectOut(Value val) {
   unsigned pos;

--- a/mlir/lib/Analysis/Presburger/IntegerRelation.cpp
+++ b/mlir/lib/Analysis/Presburger/IntegerRelation.cpp
@@ -2500,11 +2500,6 @@ void IntegerRelation::applyDomain(const IntegerRelation &rel) {
 
 void IntegerRelation::applyRange(const IntegerRelation &rel) { compose(rel); }
 
-void IntegerRelation::printSpace(raw_ostream &os) const {
-  space.print(os);
-  os << getNumConstraints() << " constraints\n";
-}
-
 void IntegerRelation::removeTrivialEqualities() {
   for (int i = getNumEqualities() - 1; i >= 0; --i)
     if (rangeIsZero(getEquality(i)))
@@ -2589,6 +2584,12 @@ void IntegerRelation::mergeAndCompose(const IntegerRelation &other) {
   *this = result;
 }
 
+#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
+void IntegerRelation::printSpace(raw_ostream &os) const {
+  space.print(os);
+  os << getNumConstraints() << " constraints\n";
+}
+
 void IntegerRelation::print(raw_ostream &os) const {
   assert(hasConsistentState());
   printSpace(os);
@@ -2610,7 +2611,7 @@ void IntegerRelation::print(raw_ostream &os) const {
 }
 
 void IntegerRelation::dump() const { print(llvm::errs()); }
-
+#endif
 unsigned IntegerPolyhedron::insertVar(VarKind kind, unsigned pos,
                                       unsigned num) {
   assert((kind != VarKind::Domain || num == 0) &&

--- a/mlir/lib/Analysis/Presburger/Matrix.cpp
+++ b/mlir/lib/Analysis/Presburger/Matrix.cpp
@@ -397,6 +397,7 @@ Matrix<T> Matrix<T>::getSubMatrix(unsigned fromRow, unsigned toRow,
   return subMatrix;
 }
 
+#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 template <typename T>
 void Matrix<T>::print(raw_ostream &os) const {
   for (unsigned row = 0; row < nRows; ++row) {
@@ -405,6 +406,12 @@ void Matrix<T>::print(raw_ostream &os) const {
     os << '\n';
   }
 }
+
+template <typename T>
+void Matrix<T>::dump() const {
+  print(llvm::errs());
+}
+#endif
 
 /// We iterate over the `indicator` bitset, checking each bit. If a bit is 1,
 /// we append it to one matrix, and if it is zero, we append it to the other.
@@ -419,11 +426,6 @@ Matrix<T>::splitByBitset(ArrayRef<int> indicator) {
       rowsForZero.appendExtraRow(getRow(i));
   }
   return {rowsForOne, rowsForZero};
-}
-
-template <typename T>
-void Matrix<T>::dump() const {
-  print(llvm::errs());
 }
 
 template <typename T>

--- a/mlir/lib/Analysis/Presburger/PWMAFunction.cpp
+++ b/mlir/lib/Analysis/Presburger/PWMAFunction.cpp
@@ -58,6 +58,7 @@ PresburgerSet PWMAFunction::getDomain() const {
   return domain;
 }
 
+#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 void MultiAffineFunction::print(raw_ostream &os) const {
   space.print(os);
   os << "Division Representation:\n";
@@ -65,6 +66,7 @@ void MultiAffineFunction::print(raw_ostream &os) const {
   os << "Output:\n";
   output.print(os);
 }
+#endif
 
 SmallVector<DynamicAPInt, 8>
 MultiAffineFunction::valueAt(ArrayRef<DynamicAPInt> point) const {
@@ -299,6 +301,7 @@ void PWMAFunction::addPiece(const Piece &piece) {
   pieces.push_back(piece);
 }
 
+#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 void PWMAFunction::print(raw_ostream &os) const {
   space.print(os);
   os << getNumPieces() << " pieces:\n";
@@ -311,6 +314,7 @@ void PWMAFunction::print(raw_ostream &os) const {
 }
 
 void PWMAFunction::dump() const { print(llvm::errs()); }
+#endif
 
 PWMAFunction PWMAFunction::unionFunction(
     const PWMAFunction &func,

--- a/mlir/lib/Analysis/Presburger/PresburgerRelation.cpp
+++ b/mlir/lib/Analysis/Presburger/PresburgerRelation.cpp
@@ -1049,6 +1049,7 @@ bool PresburgerRelation::isFullDim() const {
   });
 }
 
+#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 void PresburgerRelation::print(raw_ostream &os) const {
   os << "Number of Disjuncts: " << getNumDisjuncts() << "\n";
   for (const IntegerRelation &disjunct : disjuncts) {
@@ -1058,6 +1059,7 @@ void PresburgerRelation::print(raw_ostream &os) const {
 }
 
 void PresburgerRelation::dump() const { print(llvm::errs()); }
+#endif
 
 PresburgerSet PresburgerSet::getUniverse(const PresburgerSpace &space) {
   PresburgerSet result(space);

--- a/mlir/lib/Analysis/Presburger/PresburgerSpace.cpp
+++ b/mlir/lib/Analysis/Presburger/PresburgerSpace.cpp
@@ -24,6 +24,7 @@ bool Identifier::isEqual(const Identifier &other) const {
   return value == other.value;
 }
 
+#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 void Identifier::print(llvm::raw_ostream &os) const {
   os << "Id<" << value << ">";
 }
@@ -32,6 +33,7 @@ void Identifier::dump() const {
   print(llvm::errs());
   llvm::errs() << "\n";
 }
+#endif
 
 PresburgerSpace PresburgerSpace::getDomainSpace() const {
   PresburgerSpace newSpace = *this;
@@ -324,6 +326,7 @@ void PresburgerSpace::mergeAndAlignSymbols(PresburgerSpace &other) {
   }
 }
 
+#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 void PresburgerSpace::print(llvm::raw_ostream &os) const {
   os << "Domain: " << getNumDomainVars() << ", "
      << "Range: " << getNumRangeVars() << ", "
@@ -356,3 +359,4 @@ void PresburgerSpace::dump() const {
   print(llvm::errs());
   llvm::errs() << "\n";
 }
+#endif

--- a/mlir/lib/Analysis/Presburger/Simplex.cpp
+++ b/mlir/lib/Analysis/Presburger/Simplex.cpp
@@ -2121,6 +2121,7 @@ bool Simplex::isFlatAlong(ArrayRef<DynamicAPInt> coeffs) {
   return *upOpt == *downOpt;
 }
 
+#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 void SimplexBase::print(raw_ostream &os) const {
   os << "rows = " << getNumRows() << ", columns = " << getNumColumns() << "\n";
   if (empty)
@@ -2157,6 +2158,7 @@ void SimplexBase::print(raw_ostream &os) const {
 }
 
 void SimplexBase::dump() const { print(llvm::errs()); }
+#endif
 
 bool Simplex::isRationalSubsetOf(const IntegerRelation &rel) {
   if (isEmpty())

--- a/mlir/lib/Analysis/Presburger/Utils.cpp
+++ b/mlir/lib/Analysis/Presburger/Utils.cpp
@@ -513,6 +513,7 @@ void DivisionRepr::insertDiv(unsigned pos, unsigned num) {
   denoms.insert(denoms.begin() + pos, num, DynamicAPInt(0));
 }
 
+#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 void DivisionRepr::print(raw_ostream &os) const {
   os << "Dividends:\n";
   dividends.print(os);
@@ -523,6 +524,7 @@ void DivisionRepr::print(raw_ostream &os) const {
 }
 
 void DivisionRepr::dump() const { print(llvm::errs()); }
+#endif
 
 SmallVector<DynamicAPInt, 8>
 presburger::getDynamicAPIntVec(ArrayRef<int64_t> range) {

--- a/mlir/lib/Interfaces/ValueBoundsOpInterface.cpp
+++ b/mlir/lib/Interfaces/ValueBoundsOpInterface.cpp
@@ -881,6 +881,7 @@ ValueBoundsConstraintSet::areEquivalentSlices(MLIRContext *ctx,
   return true;
 }
 
+#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 void ValueBoundsConstraintSet::dump() const {
   llvm::errs() << "==========\nColumns:\n";
   llvm::errs() << "(column\tdim\tvalue)\n";
@@ -909,6 +910,7 @@ void ValueBoundsConstraintSet::dump() const {
   cstr.dump();
   llvm::errs() << "==========\n";
 }
+#endif
 
 ValueBoundsConstraintSet::BoundBuilder &
 ValueBoundsConstraintSet::BoundBuilder::operator[](int64_t dim) {

--- a/mlir/unittests/Analysis/Presburger/IntegerPolyhedronTest.cpp
+++ b/mlir/unittests/Analysis/Presburger/IntegerPolyhedronTest.cpp
@@ -41,11 +41,13 @@ makeSetFromConstraints(unsigned ids, ArrayRef<SmallVector<int64_t, 4>> ineqs,
   return set;
 }
 
+#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 static void dump(ArrayRef<DynamicAPInt> vec) {
   for (const DynamicAPInt &x : vec)
     llvm::errs() << x << ' ';
   llvm::errs() << '\n';
 }
+#endif
 
 /// If fn is TestFunction::Sample (default):
 ///
@@ -69,16 +71,19 @@ static void checkSample(bool hasSample, const IntegerPolyhedron &poly,
 
     if (!hasSample) {
       EXPECT_FALSE(maybeSample.has_value());
+#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
       if (maybeSample.has_value()) {
         llvm::errs() << "findIntegerSample gave sample: ";
         dump(*maybeSample);
       }
-
+#endif
       EXPECT_TRUE(maybeLexMin.isEmpty());
+#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
       if (maybeLexMin.isBounded()) {
         llvm::errs() << "findIntegerLexMin gave sample: ";
         dump(*maybeLexMin);
       }
+#endif
     } else {
       ASSERT_TRUE(maybeSample.has_value());
       EXPECT_TRUE(poly.containsPoint(*maybeSample));

--- a/mlir/unittests/Analysis/Presburger/LinearTransformTest.cpp
+++ b/mlir/unittests/Analysis/Presburger/LinearTransformTest.cpp
@@ -28,10 +28,12 @@ void testColumnEchelonForm(const IntMatrix &m, unsigned expectedRank) {
     for (unsigned col = lastAllowedNonZeroCol + 1, nCols = m.getNumColumns();
          col < nCols; ++col) {
       EXPECT_EQ(rowVec[col], 0);
+#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
       if (rowVec[col] != 0) {
         llvm::errs() << "Failed at input matrix:\n";
         m.dump();
       }
+#endif
     }
     if (rowVec[lastAllowedNonZeroCol] != 0)
       lastAllowedNonZeroCol++;


### PR DESCRIPTION
Follow up on 638d968 (mlir/Presburger: guard dump function; fix buildbot) to implement a more thorough fix. Guard all debug-printing functions in Presburger with !NDEBUG || LLVM_ENABLE_DUMP. This fixes the build on one particular configuration: without assertions, and LLVM_ENABLE_DUMP explicitly turned off.