### PR TITLE
Reland "[NFC][AMDGPU] Do not flush after printing every instruction"

### DIFF
--- a/llvm/lib/Target/AMDGPU/MCTargetDesc/AMDGPUInstPrinter.cpp
+++ b/llvm/lib/Target/AMDGPU/MCTargetDesc/AMDGPUInstPrinter.cpp
@@ -43,7 +43,6 @@ void AMDGPUInstPrinter::printRegName(raw_ostream &OS, MCRegister Reg) const {
 void AMDGPUInstPrinter::printInst(const MCInst *MI, uint64_t Address,
                                   StringRef Annot, const MCSubtargetInfo &STI,
                                   raw_ostream &OS) {
-  OS.flush();
   printInstruction(MI, Address, STI, OS);
   printAnnotation(OS, Annot);
 }

--- a/llvm/lib/Target/AMDGPU/MCTargetDesc/R600InstPrinter.cpp
+++ b/llvm/lib/Target/AMDGPU/MCTargetDesc/R600InstPrinter.cpp
@@ -21,7 +21,6 @@ using namespace llvm;
 void R600InstPrinter::printInst(const MCInst *MI, uint64_t Address,
                                 StringRef Annot, const MCSubtargetInfo &STI,
                                 raw_ostream &O) {
-  O.flush();
   printInstruction(MI, Address, O);
   printAnnotation(O, Annot);
 }

--- a/llvm/test/MC/AMDGPU/hsa-sym-expr-failure.s
+++ b/llvm/test/MC/AMDGPU/hsa-sym-expr-failure.s
@@ -4,10 +4,8 @@
 // they don't depend on yet-unknown symbolic values.
 
 .text
-// ASM: .text
 
 .amdhsa_code_object_version 4
-// ASM: .amdhsa_code_object_version 4
 
 .p2align 8
 .type user_sgpr_count,@function
@@ -19,11 +17,10 @@ user_sgpr_count:
   .amdhsa_next_free_vgpr 0
   .amdhsa_next_free_sgpr 0
   .amdhsa_accum_offset 4
+// ASM: :[[@LINE+1]]:{{[0-9]+}}: error: directive should have resolvable expression
   .amdhsa_user_sgpr_count defined_boolean
 .end_amdhsa_kernel
 
-// ASM: error: directive should have resolvable expression
-// ASM-NEXT:   .amdhsa_user_sgpr_count
 
 .p2align 8
 .type user_sgpr_private_segment_buffer,@function
@@ -34,11 +31,9 @@ user_sgpr_private_segment_buffer:
   .amdhsa_next_free_vgpr 0
   .amdhsa_next_free_sgpr 0
   .amdhsa_accum_offset 4
+// ASM: :[[@LINE+1]]:{{[0-9]+}}: error: directive should have resolvable expression
   .amdhsa_user_sgpr_private_segment_buffer defined_boolean
 .end_amdhsa_kernel
-
-// ASM: error: directive should have resolvable expression
-// ASM-NEXT:   .amdhsa_user_sgpr_private_segment_buffer
 
 .p2align 8
 .type user_sgpr_kernarg_preload_length,@function
@@ -49,11 +44,9 @@ user_sgpr_kernarg_preload_length:
   .amdhsa_next_free_vgpr 0
   .amdhsa_next_free_sgpr 0
   .amdhsa_accum_offset 4
+// ASM: :[[@LINE+1]]:{{[0-9]+}}: error: directive should have resolvable expression
   .amdhsa_user_sgpr_kernarg_preload_length defined_boolean
 .end_amdhsa_kernel
-
-// ASM: error: directive should have resolvable expression
-// ASM-NEXT:   .amdhsa_user_sgpr_kernarg_preload_length defined_boolean
 
 .p2align 8
 .type user_sgpr_kernarg_preload_offset,@function
@@ -64,11 +57,9 @@ user_sgpr_kernarg_preload_offset:
   .amdhsa_next_free_vgpr 0
   .amdhsa_next_free_sgpr 0
   .amdhsa_accum_offset 4
+// ASM: :[[@LINE+1]]:{{[0-9]+}}: error: directive should have resolvable expression
   .amdhsa_user_sgpr_kernarg_preload_offset defined_boolean
 .end_amdhsa_kernel
-
-// ASM: error: directive should have resolvable expression
-// ASM-NEXT:   .amdhsa_user_sgpr_kernarg_preload_offset defined_boolean
 
 .p2align 8
 .type user_sgpr_dispatch_ptr,@function
@@ -80,11 +71,9 @@ user_sgpr_dispatch_ptr:
   .amdhsa_next_free_vgpr 0
   .amdhsa_next_free_sgpr 0
   .amdhsa_accum_offset 4
+// ASM: :[[@LINE+1]]:{{[0-9]+}}: error: directive should have resolvable expression
   .amdhsa_user_sgpr_dispatch_ptr defined_boolean
 .end_amdhsa_kernel
-
-// ASM: error: directive should have resolvable expression
-// ASM-NEXT:   .amdhsa_user_sgpr_dispatch_ptr
 
 .p2align 8
 .type user_sgpr_queue_ptr,@function
@@ -96,11 +85,9 @@ user_sgpr_queue_ptr:
   .amdhsa_next_free_vgpr 0
   .amdhsa_next_free_sgpr 0
   .amdhsa_accum_offset 4
+// ASM: :[[@LINE+1]]:{{[0-9]+}}: error: directive should have resolvable expression
   .amdhsa_user_sgpr_queue_ptr defined_boolean
 .end_amdhsa_kernel
-
-// ASM: error: directive should have resolvable expression
-// ASM-NEXT:   .amdhsa_user_sgpr_queue_ptr
 
 .p2align 8
 .type user_sgpr_kernarg_segment_ptr,@function
@@ -112,11 +99,9 @@ user_sgpr_kernarg_segment_ptr:
   .amdhsa_next_free_vgpr 0
   .amdhsa_next_free_sgpr 0
   .amdhsa_accum_offset 4
+// ASM: :[[@LINE+1]]:{{[0-9]+}}: error: directive should have resolvable expression
   .amdhsa_user_sgpr_kernarg_segment_ptr defined_boolean
 .end_amdhsa_kernel
-
-// ASM: error: directive should have resolvable expression
-// ASM-NEXT:   .amdhsa_user_sgpr_kernarg_segment_ptr
 
 .p2align 8
 .type user_sgpr_dispatch_id,@function
@@ -128,11 +113,9 @@ user_sgpr_dispatch_id:
   .amdhsa_next_free_vgpr 0
   .amdhsa_next_free_sgpr 0
   .amdhsa_accum_offset 4
+// ASM: :[[@LINE+1]]:{{[0-9]+}}: error: directive should have resolvable expression
   .amdhsa_user_sgpr_dispatch_id defined_boolean
 .end_amdhsa_kernel
-
-// ASM: error: directive should have resolvable expression
-// ASM-NEXT:   .amdhsa_user_sgpr_dispatch_id
 
 .p2align 8
 .type user_sgpr_flat_scratch_init,@function
@@ -144,11 +127,9 @@ user_sgpr_flat_scratch_init:
   .amdhsa_next_free_vgpr 0
   .amdhsa_next_free_sgpr 0
   .amdhsa_accum_offset 4
+// ASM: :[[@LINE+1]]:{{[0-9]+}}: error: directive should have resolvable expression
   .amdhsa_user_sgpr_flat_scratch_init defined_boolean
 .end_amdhsa_kernel
-
-// ASM: error: directive should have resolvable expression
-// ASM-NEXT:   .amdhsa_user_sgpr_flat_scratch_init
 
 .p2align 8
 .type user_sgpr_private_segment_size,@function
@@ -160,11 +141,9 @@ user_sgpr_private_segment_size:
   .amdhsa_next_free_vgpr 0
   .amdhsa_next_free_sgpr 0
   .amdhsa_accum_offset 4
+// ASM: :[[@LINE+1]]:{{[0-9]+}}: error: directive should have resolvable expression
   .amdhsa_user_sgpr_private_segment_size defined_boolean
 .end_amdhsa_kernel
-
-// ASM: error: directive should have resolvable expression
-// ASM-NEXT:   .amdhsa_user_sgpr_private_segment_size
 
 .p2align 8
 .type wavefront_size32,@function
@@ -176,11 +155,9 @@ wavefront_size32:
   .amdhsa_next_free_vgpr 0
   .amdhsa_next_free_sgpr 0
   .amdhsa_accum_offset 4
+// ASM: :[[@LINE+1]]:{{[0-9]+}}: error: directive should have resolvable expression
   .amdhsa_wavefront_size32 defined_boolean
 .end_amdhsa_kernel
-
-// ASM: error: directive should have resolvable expression
-// ASM-NEXT:   .amdhsa_wavefront_size32
 
 .p2align 8
 .type next_free_vgpr,@function
@@ -189,13 +166,11 @@ next_free_vgpr:
 
 .p2align 6
 .amdhsa_kernel next_free_vgpr
+// ASM: :[[@LINE+1]]:{{[0-9]+}}: error: directive should have resolvable expression
   .amdhsa_next_free_vgpr defined_boolean
   .amdhsa_next_free_sgpr 0
   .amdhsa_accum_offset 4
 .end_amdhsa_kernel
-
-// ASM: error: directive should have resolvable expression
-// ASM-NEXT:   .amdhsa_next_free_vgpr
 
 .p2align 8
 .type next_free_sgpr,@function
@@ -205,12 +180,10 @@ next_free_sgpr:
 .p2align 6
 .amdhsa_kernel next_free_sgpr
   .amdhsa_next_free_vgpr 0
+// ASM: :[[@LINE+1]]:{{[0-9]+}}: error: directive should have resolvable expression
   .amdhsa_next_free_sgpr defined_boolean
   .amdhsa_accum_offset 4
 .end_amdhsa_kernel
-
-// ASM: error: directive should have resolvable expression
-// ASM-NEXT:   .amdhsa_next_free_sgpr
 
 .p2align 8
 .type accum_offset,@function
@@ -221,11 +194,9 @@ accum_offset:
 .amdhsa_kernel accum_offset
   .amdhsa_next_free_vgpr 0
   .amdhsa_next_free_sgpr 0
+// ASM: :[[@LINE+1]]:{{[0-9]+}}: error: directive should have resolvable expression
   .amdhsa_accum_offset defined_boolean
 .end_amdhsa_kernel
-
-// ASM: error: directive should have resolvable expression
-// ASM-NEXT:   .amdhsa_accum_offset
 
 .p2align 8
 .type reserve_vcc,@function
@@ -237,11 +208,9 @@ reserve_vcc:
   .amdhsa_next_free_vgpr 0
   .amdhsa_next_free_sgpr 0
   .amdhsa_accum_offset 4
+// ASM: :[[@LINE+1]]:{{[0-9]+}}: error: directive should have resolvable expression
   .amdhsa_reserve_vcc defined_boolean
 .end_amdhsa_kernel
-
-// ASM: error: directive should have resolvable expression
-// ASM-NEXT:   .amdhsa_reserve_vcc
 
 .p2align 8
 .type reserve_flat_scratch,@function
@@ -253,11 +222,9 @@ reserve_flat_scratch:
   .amdhsa_next_free_vgpr 0
   .amdhsa_next_free_sgpr 0
   .amdhsa_accum_offset 4
+// ASM: :[[@LINE+1]]:{{[0-9]+}}: error: directive should have resolvable expression
   .amdhsa_reserve_flat_scratch defined_boolean
 .end_amdhsa_kernel
-
-// ASM: error: directive should have resolvable expression
-// ASM-NEXT:   .amdhsa_reserve_flat_scratch
 
 .p2align 8
 .type shared_vgpr_count,@function
@@ -269,13 +236,8 @@ shared_vgpr_count:
   .amdhsa_next_free_vgpr 0
   .amdhsa_next_free_sgpr 0
   .amdhsa_accum_offset 4
+// ASM: :[[@LINE+1]]:{{[0-9]+}}: error: directive should have resolvable expression
   .amdhsa_shared_vgpr_count defined_boolean
 .end_amdhsa_kernel
 
-// ASM: error: directive should have resolvable expression
-// ASM-NEXT:   .amdhsa_shared_vgpr_count
-
 .set defined_boolean, 1
-
-// ASM:       .set defined_boolean, 1
-// ASM-NEXT:  .no_dead_strip defined_boolean


### PR DESCRIPTION
Reland of #95237 with fix to failing test. The test relied on stderr/stdout output being interleaved in a specific order.

It's very expensive and doesn't achieve anything.

I one test I did, it saves almost 10s on a 2m23s build, bringing it down to 2m15s using a downstream branch.