### PR TITLE
Revert #95218 and fix the build

### DIFF
--- a/llvm/include/llvm/ADT/DynamicAPInt.h
+++ b/llvm/include/llvm/ADT/DynamicAPInt.h
@@ -203,18 +203,14 @@ public:
 
   friend hash_code hash_value(const DynamicAPInt &x); // NOLINT
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   raw_ostream &print(raw_ostream &OS) const;
   LLVM_DUMP_METHOD void dump() const;
-#endif
 };
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 inline raw_ostream &operator<<(raw_ostream &OS, const DynamicAPInt &X) {
   X.print(OS);
   return OS;
 }
-#endif
 
 /// Redeclarations of friend declaration above to
 /// make it discoverable by lookups.

--- a/llvm/include/llvm/ADT/SlowDynamicAPInt.h
+++ b/llvm/include/llvm/ADT/SlowDynamicAPInt.h
@@ -71,18 +71,14 @@ public:
 
   unsigned getBitWidth() const { return Val.getBitWidth(); }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   void print(raw_ostream &OS) const;
   LLVM_DUMP_METHOD void dump() const;
-#endif
 };
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 inline raw_ostream &operator<<(raw_ostream &OS, const SlowDynamicAPInt &X) {
   X.print(OS);
   return OS;
 }
-#endif
 
 /// Returns the remainder of dividing LHS by RHS.
 ///

--- a/llvm/lib/Support/DynamicAPInt.cpp
+++ b/llvm/lib/Support/DynamicAPInt.cpp
@@ -18,7 +18,6 @@ hash_code llvm::hash_value(const DynamicAPInt &X) {
   return detail::hash_value(X.getLarge());
 }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 raw_ostream &DynamicAPInt::print(raw_ostream &OS) const {
   if (isSmall())
     return OS << ValSmall;
@@ -26,4 +25,3 @@ raw_ostream &DynamicAPInt::print(raw_ostream &OS) const {
 }
 
 void DynamicAPInt::dump() const { print(dbgs()); }
-#endif

--- a/llvm/lib/Support/SlowDynamicAPInt.cpp
+++ b/llvm/lib/Support/SlowDynamicAPInt.cpp
@@ -281,8 +281,6 @@ SlowDynamicAPInt &SlowDynamicAPInt::operator--() {
 /// ---------------------------------------------------------------------------
 /// Printing.
 /// ---------------------------------------------------------------------------
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 void SlowDynamicAPInt::print(raw_ostream &OS) const { OS << Val; }
 
 void SlowDynamicAPInt::dump() const { print(dbgs()); }
-#endif

--- a/mlir/include/mlir/Analysis/Presburger/Fraction.h
+++ b/mlir/include/mlir/Analysis/Presburger/Fraction.h
@@ -52,23 +52,14 @@ struct Fraction {
     return num / den;
   }
 
-  /// The numerator and denominator, respectively. The denominator is always
-  /// positive.
-  DynamicAPInt num{0}, den{1};
-
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   llvm::raw_ostream &print(llvm::raw_ostream &os) const {
     return os << "(" << num << "/" << den << ")";
   }
-#endif
-};
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
-inline llvm::raw_ostream &operator<<(llvm::raw_ostream &os, const Fraction &x) {
-  x.print(os);
-  return os;
-}
-#endif
+  /// The numerator and denominator, respectively. The denominator is always
+  /// positive.
+  DynamicAPInt num{0}, den{1};
+};
 
 /// Three-way comparison between two fractions.
 /// Returns +1, 0, and -1 if the first fraction is greater than, equal to, or
@@ -165,6 +156,12 @@ inline Fraction &operator*=(Fraction &x, const Fraction &y) {
   x = x * y;
   return x;
 }
+
+inline llvm::raw_ostream &operator<<(llvm::raw_ostream &os, const Fraction &x) {
+  x.print(os);
+  return os;
+}
+
 } // namespace presburger
 } // namespace mlir
 


### PR DESCRIPTION
Fix the build failure arising from 76030dc (mlir/Presburger/MPInt: move into llvm/ADT) by reverting the failed fix-forward #95218, and removing the guards on the debug-print functions in DynamicAPInt.

-- 8< --
@nikic has suggested a trivial fix. Of course, I can always fold this into the re-land, if a revert is really desired.