### PR TITLE
[Orc] Fix error handling

### DIFF
--- a/llvm/include/llvm/ExecutionEngine/Orc/Shared/WrapperFunctionUtils.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/Shared/WrapperFunctionUtils.h
@@ -503,8 +503,10 @@ public:
 
       SPSInputBuffer IB(R.data(), R.size());
       if (auto Err = detail::ResultDeserializer<SPSRetTagT, RetT>::deserialize(
-              RetVal, R.data(), R.size()))
+              RetVal, R.data(), R.size())) {
         SDR(std::move(Err), std::move(RetVal));
+        return;
+      }
 
       SDR(Error::success(), std::move(RetVal));
     };


### PR DESCRIPTION
I believe we should return after the SDR for the error case, instead of invoking it a second time with Error::success().

I have no idea how to test this (or if that's even possible), I just found this through a static analyser warning.