### PR TITLE
[clang-tidy] ignoring macro with hash preprocessing token in cppcoreguidelines-macro-usage

### DIFF
--- a/clang-tools-extra/clang-tidy/cppcoreguidelines/MacroUsageCheck.cpp
+++ b/clang-tools-extra/clang-tidy/cppcoreguidelines/MacroUsageCheck.cpp
@@ -7,12 +7,12 @@
 //===----------------------------------------------------------------------===//
 
 #include "MacroUsageCheck.h"
+#include "clang/Basic/TokenKinds.h"
 #include "clang/Frontend/CompilerInstance.h"
 #include "clang/Lex/PPCallbacks.h"
 #include "clang/Lex/Preprocessor.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/Support/Regex.h"
-#include <algorithm>
 #include <cctype>
 #include <functional>
 
@@ -37,7 +37,10 @@ public:
                     const MacroDirective *MD) override {
     if (SM.isWrittenInBuiltinFile(MD->getLocation()) ||
         MD->getMacroInfo()->isUsedForHeaderGuard() ||
-        MD->getMacroInfo()->getNumTokens() == 0)
+        MD->getMacroInfo()->tokens_empty() ||
+        llvm::any_of(MD->getMacroInfo()->tokens(), [](const Token &T) {
+          return T.isOneOf(tok::TokenKind::hash, tok::TokenKind::hashhash);
+        }))
       return;
 
     if (IgnoreCommandLineMacros &&

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -266,6 +266,10 @@ Changes in existing checks
   <clang-tidy/checks/bugprone/use-after-move>` check to also handle
   calls to ``std::forward``.
 
+- Improved :doc:`cppcoreguidelines-macro-usage
+  <clang-tidy/checks/cppcoreguidelines/macro-usage>` check by ignoring macro with
+  hash preprocessing token.
+
 - Improved :doc:`cppcoreguidelines-missing-std-forward
   <clang-tidy/checks/cppcoreguidelines/missing-std-forward>` check by no longer
   giving false positives for deleted functions, by fixing false negatives when only

--- a/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/macro-usage.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/macro-usage.rst
@@ -17,6 +17,7 @@ Examples:
   #define C 0
   #define F1(x, y) ((a) > (b) ? (a) : (b))
   #define F2(...) (__VA_ARGS__)
+  #define F3(x, y) x##y
   #define COMMA ,
   #define NORETURN [[noreturn]]
   #define DEPRECATED attribute((deprecated))

--- a/clang-tools-extra/test/clang-tidy/checkers/cppcoreguidelines/macro-usage.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/cppcoreguidelines/macro-usage.cpp
@@ -31,6 +31,10 @@
 // CHECK-MESSAGES: [[@LINE-1]]:9: warning: variadic macro 'PROBLEMATIC_VARIADIC2' used; consider using a 'constexpr' variadic template function
 
 // These are all examples of common macros that shouldn't have constexpr suggestions.
+#define CONCAT_NAME(a, b) a##b
+
+#define CONCAT_STR(a, b) #a #b
+
 #define COMMA ,
 
 #define NORETURN [[noreturn]]


### PR DESCRIPTION
`#` and `##` preprocessing tokens cannot be replaced by constexpr function. It should be ignored in check.