### PR TITLE
[flang] Catch NULL(MOLD=assumed-rank)

### DIFF
--- a/flang/lib/Evaluate/intrinsics.cpp
+++ b/flang/lib/Evaluate/intrinsics.cpp
@@ -2691,6 +2691,10 @@ SpecificCall IntrinsicProcTable::Implementation::HandleNull(
       mold = nullptr;
     }
     if (mold) {
+      if (IsAssumedRank(*arguments[0])) {
+        context.messages().Say(arguments[0]->sourceLocation(),
+            "MOLD= argument to NULL() must not be assumed-rank"_err_en_US);
+      }
       bool isProcPtrTarget{
           IsProcedurePointerTarget(*mold) && !IsNullObjectPointer(*mold)};
       if (isProcPtrTarget || IsAllocatableOrPointerObject(*mold)) {

--- a/flang/test/Semantics/null01.f90
+++ b/flang/test/Semantics/null01.f90
@@ -151,10 +151,16 @@ module m
   subroutine s2(x)
     type(pdt(*)), pointer, intent(in) :: x
   end
-  subroutine test
+  subroutine s3(ar)
+    real, pointer :: ar(..)
+  end
+  subroutine test(ar)
+    real, pointer :: ar(..)
     !ERROR: Actual argument associated with dummy argument 'x=' is a NULL() pointer without a MOLD= to provide a character length
     call s1(null())
     !ERROR: Actual argument associated with dummy argument 'x=' is a NULL() pointer without a MOLD= to provide a value for the assumed type parameter 'n'
     call s2(null())
+    !ERROR: MOLD= argument to NULL() must not be assumed-rank
+    call s3(null(ar))
   end
 end


### PR DESCRIPTION
An assumed-rank dummy argument is not an acceptable MOLD argument to NULL(), whose result must have a known rank at compilation time.