### PR TITLE
[libc] Fix definition of `UINT_MAX` in limits.h

### DIFF
--- a/libc/include/llvm-libc-macros/limits-macros.h
+++ b/libc/include/llvm-libc-macros/limits-macros.h
@@ -148,7 +148,7 @@
 #endif // INT_MAX
 
 #ifndef UINT_MAX
-#define UINT_MAX (~0U)
+#define UINT_MAX (INT_MAX * 2U + 1U)
 #endif // UINT_MAX
 
 #ifndef LONG_MAX
@@ -160,7 +160,7 @@
 #endif // LONG_MAX
 
 #ifndef ULONG_MAX
-#define ULONG_MAX (~0UL)
+#define ULONG_MAX (LONG_MAX * 2UL + 1UL)
 #endif // ULONG_MAX
 
 #ifndef LLONG_MAX
@@ -172,7 +172,7 @@
 #endif // LLONG_MAX
 
 #ifndef ULLONG_MAX
-#define ULLONG_MAX (~0ULL)
+#define ULLONG_MAX (LLONG_MAX * 2ULL + 1ULL)
 #endif // ULLONG_MAX
 
 // *_MIN macros


### PR DESCRIPTION
Summary:
Currently we use `(~0U)` for this definition, however the ~ operator
returns a different sign, meaning that preprocessor checks against this
value will fail. See https://godbolt.org/z/TrjaY1d8q where the
preprocessor thinks that it's not `0xffffffff` while the static
assertion thinks it is. This is because the latter does implicit
conversion but the preprocessor does not. This is now consistent with
other headers.
