### PR TITLE
[CodeGenTypes] Speed up getVectorElementType and getVectorMinNumElements

### DIFF
--- a/llvm/include/llvm/CodeGenTypes/MachineValueType.h
+++ b/llvm/include/llvm/CodeGenTypes/MachineValueType.h
@@ -38,7 +38,7 @@ namespace llvm {
       // are considered extended value types.
       INVALID_SIMPLE_VALUE_TYPE = 0,
 
-#define GET_VT_ATTR(Ty, n, sz, Any, Int, FP, Vec, Sc) Ty = n,
+#define GET_VT_ATTR(Ty, n, sz, Any, Int, FP, Vec, Sc, NElem, EltTy) Ty = n,
 #define GET_VT_RANGES
 #include "llvm/CodeGen/GenVT.inc"
 #undef GET_VT_ATTR
@@ -171,9 +171,9 @@ namespace llvm {
     /// Return true if this is an overloaded type for TableGen.
     bool isOverloaded() const {
       switch (SimpleTy) {
-#define GET_VT_ATTR(Ty, n, sz, Any, Int, FP, Vec, Sc)                          \
-  case Ty:                                                                     \
-    return Any;
+#define GET_VT_ATTR(Ty, n, sz, Any, Int, FP, Vec, Sc, NElem, EltTy)          \
+    case Ty:                                                                   \
+      return Any;
 #include "llvm/CodeGen/GenVT.inc"
 #undef GET_VT_ATTR
       default:
@@ -252,30 +252,28 @@ namespace llvm {
     }
 
     MVT getVectorElementType() const {
-      switch (SimpleTy) {
-      default:
-        llvm_unreachable("Not a vector MVT!");
-
-#define GET_VT_VECATTR(Ty, Sc, nElem, ElTy, ElSz)                              \
-  case Ty:                                                                     \
-    return ElTy;
+      assert(SimpleTy >= FIRST_VALUETYPE && SimpleTy <= LAST_VALUETYPE);
+      static constexpr SimpleValueType EltTyTable[] = {
+#define GET_VT_ATTR(Ty, N, Sz, Any, Int, FP, Vec, Sc, NElem, EltTy) EltTy,
 #include "llvm/CodeGen/GenVT.inc"
-#undef GET_VT_VECATTR
-      }
+#undef GET_VT_ATTR
+      };
+      SimpleValueType VT = EltTyTable[SimpleTy - FIRST_VALUETYPE];
+      assert(VT != INVALID_SIMPLE_VALUE_TYPE && "Not a vector MVT!");
+      return VT;
     }
 
     /// Given a vector type, return the minimum number of elements it contains.
     unsigned getVectorMinNumElements() const {
-      switch (SimpleTy) {
-      default:
-        llvm_unreachable("Not a vector MVT!");
-
-#define GET_VT_VECATTR(Ty, Sc, nElem, ElTy, ElSz)                              \
-  case Ty:                                                                     \
-    return nElem;
+      assert(SimpleTy >= FIRST_VALUETYPE && SimpleTy <= LAST_VALUETYPE);
+      static constexpr uint16_t NElemTable[] = {
+#define GET_VT_ATTR(Ty, N, Sz, Any, Int, FP, Vec, Sc, NElem, EltTy) NElem,
 #include "llvm/CodeGen/GenVT.inc"
-#undef GET_VT_VECATTR
-      }
+#undef GET_VT_ATTR
+      };
+      unsigned NElem = NElemTable[SimpleTy - FIRST_VALUETYPE];
+      assert(NElem != 0 && "Not a vector MVT!");
+      return NElem;
     }
 
     ElementCount getVectorElementCount() const {
@@ -298,8 +296,8 @@ namespace llvm {
     /// base size.
     TypeSize getSizeInBits() const {
       static constexpr TypeSize SizeTable[] = {
-#define GET_VT_ATTR(Ty, N, Sz, Any, Int, FP, Vec, Sc)                          \
-  TypeSize(Sz, Sc || Ty == aarch64svcount /* FIXME: Not in the td. */),
+#define GET_VT_ATTR(Ty, N, Sz, Any, Int, FP, Vec, Sc, NElem, EltTy)          \
+    TypeSize(Sz, Sc || Ty == aarch64svcount /* FIXME: Not in the td. */),
 #include "llvm/CodeGen/GenVT.inc"
 #undef GET_VT_ATTR
       };
@@ -420,9 +418,9 @@ namespace llvm {
     }
 
     static MVT getFloatingPointVT(unsigned BitWidth) {
-#define GET_VT_ATTR(Ty, n, sz, Any, Int, FP, Vec, Sc)                          \
-  if (FP == 3 && sz == BitWidth)                                               \
-    return Ty;
+#define GET_VT_ATTR(Ty, n, sz, Any, Int, FP, Vec, Sc, NElem, EltTy)          \
+    if (FP == 3 && sz == BitWidth)                                             \
+      return Ty;
 #include "llvm/CodeGen/GenVT.inc"
 #undef GET_VT_ATTR
 
@@ -430,9 +428,9 @@ namespace llvm {
     }
 
     static MVT getIntegerVT(unsigned BitWidth) {
-#define GET_VT_ATTR(Ty, n, sz, Any, Int, FP, Vec, Sc)                          \
-  if (Int == 3 && sz == BitWidth)                                              \
-    return Ty;
+#define GET_VT_ATTR(Ty, n, sz, Any, Int, FP, Vec, Sc, NElem, EltTy)          \
+    if (Int == 3 && sz == BitWidth)                                            \
+      return Ty;
 #include "llvm/CodeGen/GenVT.inc"
 #undef GET_VT_ATTR
 

--- a/llvm/utils/TableGen/Common/CodeGenTarget.cpp
+++ b/llvm/utils/TableGen/Common/CodeGenTarget.cpp
@@ -63,7 +63,7 @@ StringRef llvm::getName(MVT::SimpleValueType T) {
 StringRef llvm::getEnumName(MVT::SimpleValueType T) {
   // clang-format off
   switch (T) {
-#define GET_VT_ATTR(Ty, N, Sz, Any, Int, FP, Vec, Sc)                          \
+#define GET_VT_ATTR(Ty, N, Sz, Any, Int, FP, Vec, Sc, NElem, EltTy)   \
   case MVT::Ty: return "MVT::" # Ty;
 #include "llvm/CodeGen/GenVT.inc"
   default: llvm_unreachable("ILLEGAL VALUE TYPE!");

--- a/llvm/utils/TableGen/VTEmitter.cpp
+++ b/llvm/utils/TableGen/VTEmitter.cpp
@@ -73,6 +73,9 @@ void VTEmitter::run(raw_ostream &OS) {
     bool IsVector = VT->getValueAsBit("isVector");
     bool IsScalable = VT->getValueAsBit("isScalable");
     bool IsNormalValueType =  VT->getValueAsBit("isNormalValueType");
+    int64_t NElem = IsVector ? VT->getValueAsInt("nElem") : 0;
+    StringRef EltName = IsVector ? VT->getValueAsDef("ElementType")->getName()
+                                 : "INVALID_SIMPLE_VALUE_TYPE";
 
     UpdateVTRange("INTEGER_FIXEDLEN_VECTOR_VALUETYPE", Name,
                   IsInteger && IsVector && !IsScalable);
@@ -97,7 +100,9 @@ void VTEmitter::run(raw_ostream &OS) {
        << (IsInteger ? Name[0] == 'i' ? 3 : 1 : 0) << ", "
        << (IsFP ? Name[0] == 'f' ? 3 : 1 : 0) << ", "
        << IsVector << ", "
-       << IsScalable << ")\n";
+       << IsScalable << ", "
+       << NElem << ", "
+       << EltName << ")\n";
     // clang-format on
   }
   OS << "#endif\n\n";


### PR DESCRIPTION
Implement MVT::getVectorElementType and MVT::getVectorMinNumElements with table lookup instead of switch.

This speeds up "check-llvm-codegen-amdgpu" by about 7% in my Release build.