### PR TITLE
[SPIRV] Fix warning in SPIRVMergeRegionExitTargets.cpp

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVMergeRegionExitTargets.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVMergeRegionExitTargets.cpp
@@ -100,7 +100,7 @@ public:
     }
 
     // TODO: add support for switch cases.
-    assert(false && "Unhandled terminator type.");
+    llvm_unreachable("Unhandled terminator type.");
   }
 
   /// Replaces |BB|'s branch targets present in |ToReplace| with |NewTarget|.


### PR DESCRIPTION
Fix warning in SPIRVMergeRegionExitTargets.cpp about "non-void function does not return a value in all control paths" by changing assert to llvm_unreachable.