### PR TITLE
[MC] Reduce size of MCDataFragment by 8 bytes

### DIFF
--- a/llvm/include/llvm/MC/MCFragment.h
+++ b/llvm/include/llvm/MC/MCFragment.h
@@ -72,8 +72,8 @@ private:
   FragmentType Kind;
 
 protected:
-  bool HasInstructions;
-  bool LinkerRelaxable = false;
+  bool HasInstructions : 1;
+  bool LinkerRelaxable : 1;
 
   MCFragment(FragmentType Kind, bool HasInstructions,
              MCSection *Parent = nullptr);

--- a/llvm/lib/MC/MCFragment.cpp
+++ b/llvm/lib/MC/MCFragment.cpp
@@ -199,7 +199,8 @@ uint64_t llvm::computeBundlePadding(const MCAssembler &Assembler,
 
 MCFragment::MCFragment(FragmentType Kind, bool HasInstructions,
                        MCSection *Parent)
-    : Parent(Parent), Kind(Kind), HasInstructions(HasInstructions) {
+    : Parent(Parent), Kind(Kind), HasInstructions(HasInstructions),
+      LinkerRelaxable(false) {
   if (Parent && !isa<MCDummyFragment>(*this))
     Parent->addFragment(*this);
 }


### PR DESCRIPTION
Due to alignment, MCEncodedFragment was 1 byte over the 8 byte boundary, so folding to bools into bitfields in MCFragment gives a nice space reduction of MCDataFragment from 224 to 216 bytes.