### PR TITLE
[mlir][spirv] Implement SPIR-V lowering for `vector.deinterleave`

### DIFF
--- a/mlir/lib/Conversion/VectorToSPIRV/VectorToSPIRV.cpp
+++ b/mlir/lib/Conversion/VectorToSPIRV/VectorToSPIRV.cpp
@@ -633,7 +633,6 @@ struct VectorDeinterleaveOpConvert final
       return rewriter.notifyMatchFailure(deinterleaveOp,
                                          "unsupported result vector type");
 
-    // Get location.
     Location loc = deinterleaveOp->getLoc();
 
     // Deinterleave the indices.

--- a/mlir/lib/Conversion/VectorToSPIRV/VectorToSPIRV.cpp
+++ b/mlir/lib/Conversion/VectorToSPIRV/VectorToSPIRV.cpp
@@ -643,7 +643,7 @@ struct VectorDeinterleaveOpConvert final
     // We cannot use `spirv::VectorShuffleOp` directly in this case, and need to
     // use `spirv::CompositeExtractOp`.
     if (n == 2) {
-      spirv::CompositeExtractOp compositeExtractZero =
+      auto elem0 =
           rewriter.create<spirv::CompositeExtractOp>(
               loc, newResultType, adaptor.getSource(),
               rewriter.getI32ArrayAttr({0}));

--- a/mlir/lib/Conversion/VectorToSPIRV/VectorToSPIRV.cpp
+++ b/mlir/lib/Conversion/VectorToSPIRV/VectorToSPIRV.cpp
@@ -677,7 +677,6 @@ struct VectorDeinterleaveOpConvert final
         loc, newResultType, adaptor.getSource(), adaptor.getSource(),
         rewriter.getI32ArrayAttr(indicesOdd));
 
-    // Replace deinterleaveOp with SPIR-V shuffles.
     rewriter.replaceOp(deinterleaveOp, {shuffleEven, shuffleOdd});
     return success();
   }

--- a/mlir/lib/Conversion/VectorToSPIRV/VectorToSPIRV.cpp
+++ b/mlir/lib/Conversion/VectorToSPIRV/VectorToSPIRV.cpp
@@ -653,8 +653,7 @@ struct VectorDeinterleaveOpConvert final
               loc, newResultType, adaptor.getSource(),
               rewriter.getI32ArrayAttr({1}));
 
-      rewriter.replaceOp(deinterleaveOp,
-                         {compositeExtractZero, compositeExtractOne});
+      rewriter.replaceOp(deinterleaveOp, {elem0, elem1});
       return success();
     }
 

--- a/mlir/lib/Conversion/VectorToSPIRV/VectorToSPIRV.cpp
+++ b/mlir/lib/Conversion/VectorToSPIRV/VectorToSPIRV.cpp
@@ -679,7 +679,6 @@ struct VectorDeinterleaveOpConvert final
 
     // Replace deinterleaveOp with SPIR-V shuffles.
     rewriter.replaceOp(deinterleaveOp, {shuffleEven, shuffleOdd});
-
     return success();
   }
 };

--- a/mlir/lib/Conversion/VectorToSPIRV/VectorToSPIRV.cpp
+++ b/mlir/lib/Conversion/VectorToSPIRV/VectorToSPIRV.cpp
@@ -648,7 +648,7 @@ struct VectorDeinterleaveOpConvert final
               loc, newResultType, adaptor.getSource(),
               rewriter.getI32ArrayAttr({0}));
 
-      spirv::CompositeExtractOp compositeExtractOne =
+      auto elem1 =
           rewriter.create<spirv::CompositeExtractOp>(
               loc, newResultType, adaptor.getSource(),
               rewriter.getI32ArrayAttr({1}));

--- a/mlir/lib/Conversion/VectorToSPIRV/VectorToSPIRV.cpp
+++ b/mlir/lib/Conversion/VectorToSPIRV/VectorToSPIRV.cpp
@@ -659,7 +659,7 @@ struct VectorDeinterleaveOpConvert final
     auto indicesEven =
         llvm::map_to_vector(seqEven, [](int i) { return i * 2; });
 
-    // Indices for `res2`.
+    // Indices for `shuffleOdd` (result 1).
     auto seqOdd = llvm::seq<int64_t>(n / 2);
     auto indicesOdd =
         llvm::map_to_vector(seqOdd, [](int i) { return i * 2 + 1; });

--- a/mlir/lib/Conversion/VectorToSPIRV/VectorToSPIRV.cpp
+++ b/mlir/lib/Conversion/VectorToSPIRV/VectorToSPIRV.cpp
@@ -654,7 +654,7 @@ struct VectorDeinterleaveOpConvert final
       return success();
     }
 
-    // Indices for `res1`.
+    // Indices for `shuffleEven` (result 0).
     auto seqEven = llvm::seq<int64_t>(n / 2);
     auto indicesEven =
         llvm::map_to_vector(seqEven, [](int i) { return i * 2; });

--- a/mlir/lib/Conversion/VectorToSPIRV/VectorToSPIRV.cpp
+++ b/mlir/lib/Conversion/VectorToSPIRV/VectorToSPIRV.cpp
@@ -665,12 +665,11 @@ struct VectorDeinterleaveOpConvert final
         llvm::map_to_vector(seqOdd, [](int i) { return i * 2 + 1; });
 
     // Create two SPIR-V shuffles.
-    spirv::VectorShuffleOp shuffleEven =
-        rewriter.create<spirv::VectorShuffleOp>(
-            loc, newResultType, sourceVector, sourceVector,
-            rewriter.getI32ArrayAttr(indicesEven));
+    auto shuffleEven = rewriter.create<spirv::VectorShuffleOp>(
+        loc, newResultType, sourceVector, sourceVector,
+        rewriter.getI32ArrayAttr(indicesEven));
 
-    spirv::VectorShuffleOp shuffleOdd = rewriter.create<spirv::VectorShuffleOp>(
+    auto shuffleOdd = rewriter.create<spirv::VectorShuffleOp>(
         loc, newResultType, sourceVector, sourceVector,
         rewriter.getI32ArrayAttr(indicesOdd));
 

--- a/mlir/test/Conversion/VectorToSPIRV/vector-to-spirv.mlir
+++ b/mlir/test/Conversion/VectorToSPIRV/vector-to-spirv.mlir
@@ -507,6 +507,56 @@ func.func @interleave_size1(%a: vector<1xf32>, %b: vector<1xf32>) -> vector<2xf3
 
 // -----
 
+// CHECK-LABEL: func @deinterleave_return0
+// CHECK-SAME: (%[[ARG0:.+]]: vector<4xf32>)
+//       CHECK: %[[SHUFFLE0:.*]] = spirv.VectorShuffle [0 : i32, 2 : i32] %[[ARG0]], %[[ARG0]] : vector<4xf32>, vector<4xf32> -> vector<2xf32>
+//       CHECK: %[[SHUFFLE1:.*]] = spirv.VectorShuffle [1 : i32, 3 : i32] %[[ARG0]], %[[ARG0]] : vector<4xf32>, vector<4xf32> -> vector<2xf32>
+//       CHECK: return %[[SHUFFLE0]]
+func.func @deinterleave_return0(%a: vector<4xf32>) -> vector<2xf32> {
+  %0, %1 = vector.deinterleave %a : vector<4xf32> -> vector<2xf32>
+  return %0 : vector<2xf32>
+}
+
+// -----
+
+// CHECK-LABEL: func @deinterleave_return1
+// CHECK-SAME: (%[[ARG0:.+]]: vector<4xf32>)
+//       CHECK: %[[SHUFFLE0:.*]] = spirv.VectorShuffle [0 : i32, 2 : i32] %[[ARG0]], %[[ARG0]] : vector<4xf32>, vector<4xf32> -> vector<2xf32>
+//       CHECK: %[[SHUFFLE1:.*]] = spirv.VectorShuffle [1 : i32, 3 : i32] %[[ARG0]], %[[ARG0]] : vector<4xf32>, vector<4xf32> -> vector<2xf32>
+//       CHECK: return %[[SHUFFLE1]]
+func.func @deinterleave_return1(%a: vector<4xf32>) -> vector<2xf32> {
+  %0, %1 = vector.deinterleave %a : vector<4xf32> -> vector<2xf32>
+  return %1 : vector<2xf32>
+}
+
+// -----
+
+// CHECK-LABEL: func @deinterleave_scalar_return0
+// CHECK-SAME: (%[[ARG0:.+]]: vector<2xf32>)
+//       CHECK: %[[EXTRACT0:.*]] = spirv.CompositeExtract %[[ARG0]][0 : i32] : vector<2xf32>
+//       CHECK: %[[EXTRACT1:.*]] = spirv.CompositeExtract %[[ARG0]][1 : i32] : vector<2xf32>
+//       CHECK: %[[RES:.*]] = builtin.unrealized_conversion_cast %[[EXTRACT0]] : f32 to vector<1xf32>
+//       CHECK: return %[[RES]]
+func.func @deinterleave_scalar_return0(%a: vector<2xf32>) -> vector<1xf32> {
+  %0, %1 = vector.deinterleave %a: vector<2xf32> -> vector<1xf32>
+  return %0 : vector<1xf32>
+}
+
+// -----
+
+// CHECK-LABEL: func @deinterleave_scalar_return1
+// CHECK-SAME: (%[[ARG0:.+]]: vector<2xf32>)
+//       CHECK: %[[EXTRACT0:.*]] = spirv.CompositeExtract %[[ARG0]][0 : i32] : vector<2xf32>
+//       CHECK: %[[EXTRACT1:.*]] = spirv.CompositeExtract %[[ARG0]][1 : i32] : vector<2xf32>
+//       CHECK: %[[RES:.*]] = builtin.unrealized_conversion_cast %[[EXTRACT1]] : f32 to vector<1xf32>
+//       CHECK: return %[[RES]]
+func.func @deinterleave_scalar_return1(%a: vector<2xf32>) -> vector<1xf32> {
+  %0, %1 = vector.deinterleave %a: vector<2xf32> -> vector<1xf32>
+  return %1 : vector<1xf32>
+}
+
+// -----
+
 // CHECK-LABEL: func @reduction_add
 //  CHECK-SAME: (%[[V:.+]]: vector<4xi32>)
 //       CHECK:   %[[S0:.+]] = spirv.CompositeExtract %[[V]][0 : i32] : vector<4xi32>

--- a/mlir/test/Conversion/VectorToSPIRV/vector-to-spirv.mlir
+++ b/mlir/test/Conversion/VectorToSPIRV/vector-to-spirv.mlir
@@ -507,52 +507,28 @@ func.func @interleave_size1(%a: vector<1xf32>, %b: vector<1xf32>) -> vector<2xf3
 
 // -----
 
-// CHECK-LABEL: func @deinterleave_return0
+// CHECK-LABEL: func @deinterleave
 // CHECK-SAME: (%[[ARG0:.+]]: vector<4xf32>)
 //       CHECK: %[[SHUFFLE0:.*]] = spirv.VectorShuffle [0 : i32, 2 : i32] %[[ARG0]], %[[ARG0]] : vector<4xf32>, vector<4xf32> -> vector<2xf32>
 //       CHECK: %[[SHUFFLE1:.*]] = spirv.VectorShuffle [1 : i32, 3 : i32] %[[ARG0]], %[[ARG0]] : vector<4xf32>, vector<4xf32> -> vector<2xf32>
-//       CHECK: return %[[SHUFFLE0]]
-func.func @deinterleave_return0(%a: vector<4xf32>) -> vector<2xf32> {
+//       CHECK: return %[[SHUFFLE0]], %[[SHUFFLE1]]
+func.func @deinterleave(%a: vector<4xf32>) -> (vector<2xf32>, vector<2xf32>) {
   %0, %1 = vector.deinterleave %a : vector<4xf32> -> vector<2xf32>
-  return %0 : vector<2xf32>
+  return %0, %1 : vector<2xf32>, vector<2xf32>
 }
 
 // -----
 
-// CHECK-LABEL: func @deinterleave_return1
-// CHECK-SAME: (%[[ARG0:.+]]: vector<4xf32>)
-//       CHECK: %[[SHUFFLE0:.*]] = spirv.VectorShuffle [0 : i32, 2 : i32] %[[ARG0]], %[[ARG0]] : vector<4xf32>, vector<4xf32> -> vector<2xf32>
-//       CHECK: %[[SHUFFLE1:.*]] = spirv.VectorShuffle [1 : i32, 3 : i32] %[[ARG0]], %[[ARG0]] : vector<4xf32>, vector<4xf32> -> vector<2xf32>
-//       CHECK: return %[[SHUFFLE1]]
-func.func @deinterleave_return1(%a: vector<4xf32>) -> vector<2xf32> {
-  %0, %1 = vector.deinterleave %a : vector<4xf32> -> vector<2xf32>
-  return %1 : vector<2xf32>
-}
-
-// -----
-
-// CHECK-LABEL: func @deinterleave_scalar_return0
+// CHECK-LABEL: func @deinterleave_scalar
 // CHECK-SAME: (%[[ARG0:.+]]: vector<2xf32>)
 //       CHECK: %[[EXTRACT0:.*]] = spirv.CompositeExtract %[[ARG0]][0 : i32] : vector<2xf32>
 //       CHECK: %[[EXTRACT1:.*]] = spirv.CompositeExtract %[[ARG0]][1 : i32] : vector<2xf32>
-//       CHECK: %[[RES:.*]] = builtin.unrealized_conversion_cast %[[EXTRACT0]] : f32 to vector<1xf32>
-//       CHECK: return %[[RES]]
-func.func @deinterleave_scalar_return0(%a: vector<2xf32>) -> vector<1xf32> {
+//       CHECK: %[[CAST0:.*]] = builtin.unrealized_conversion_cast %[[EXTRACT0]] : f32 to vector<1xf32>
+//       CHECK: %[[CAST1:.*]] = builtin.unrealized_conversion_cast %[[EXTRACT1]] : f32 to vector<1xf32>
+//       CHECK: return %[[CAST0]], %[[CAST1]]
+func.func @deinterleave_scalar(%a: vector<2xf32>) -> (vector<1xf32>, vector<1xf32>) {
   %0, %1 = vector.deinterleave %a: vector<2xf32> -> vector<1xf32>
-  return %0 : vector<1xf32>
-}
-
-// -----
-
-// CHECK-LABEL: func @deinterleave_scalar_return1
-// CHECK-SAME: (%[[ARG0:.+]]: vector<2xf32>)
-//       CHECK: %[[EXTRACT0:.*]] = spirv.CompositeExtract %[[ARG0]][0 : i32] : vector<2xf32>
-//       CHECK: %[[EXTRACT1:.*]] = spirv.CompositeExtract %[[ARG0]][1 : i32] : vector<2xf32>
-//       CHECK: %[[RES:.*]] = builtin.unrealized_conversion_cast %[[EXTRACT1]] : f32 to vector<1xf32>
-//       CHECK: return %[[RES]]
-func.func @deinterleave_scalar_return1(%a: vector<2xf32>) -> vector<1xf32> {
-  %0, %1 = vector.deinterleave %a: vector<2xf32> -> vector<1xf32>
-  return %1 : vector<1xf32>
+  return %0, %1 : vector<1xf32>, vector<1xf32>
 }
 
 // -----


### PR DESCRIPTION
1. Added a conversion for `vector.deinterleave` to the `VectorToSPIRV` pass.
2. Added LIT tests for the new conversion.