### PR TITLE
[libc++] Workaround clang bug in __has_unique_object_representations

### DIFF
--- a/libcxx/include/__type_traits/has_unique_object_representation.h
+++ b/libcxx/include/__type_traits/has_unique_object_representation.h
@@ -11,6 +11,7 @@
 
 #include <__config>
 #include <__type_traits/integral_constant.h>
+#include <__type_traits/remove_all_extents.h>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
 #  pragma GCC system_header
@@ -22,7 +23,12 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _Tp>
 struct _LIBCPP_TEMPLATE_VIS has_unique_object_representations
-    : public integral_constant<bool, __has_unique_object_representations(_Tp)> {};
+    // TODO: We work around a Clang bug in __has_unique_object_representations by instantiating the
+    //       builtin on the non-array type first and discarding that. This is issue #95311.
+    //       This workaround can be removed once the bug has been fixed in all supported Clangs.
+    : public integral_constant<bool,
+                               ((void)__has_unique_object_representations(remove_all_extents_t<_Tp>),
+                                __has_unique_object_representations(_Tp))> {};
 
 template <class _Tp>
 inline constexpr bool has_unique_object_representations_v = __has_unique_object_representations(_Tp);

--- a/libcxx/include/__type_traits/has_unique_object_representation.h
+++ b/libcxx/include/__type_traits/has_unique_object_representation.h
@@ -23,12 +23,12 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _Tp>
 struct _LIBCPP_TEMPLATE_VIS has_unique_object_representations
-    // TODO: We work around a Clang bug in __has_unique_object_representations by instantiating the
-    //       builtin on the non-array type first and discarding that. This is issue #95311.
-    //       This workaround can be removed once the bug has been fixed in all supported Clangs.
-    : public integral_constant<bool,
-                               ((void)__has_unique_object_representations(remove_all_extents_t<_Tp>),
-                                __has_unique_object_representations(_Tp))> {};
+    // TODO: We work around a Clang and GCC bug in __has_unique_object_representations by using remove_all_extents
+    //       even though it should not be necessary. This was reported to the compilers:
+    //         - Clang: https://github.com/llvm/llvm-project/issues/95311
+    //         - GCC: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=115476
+    //       remove_all_extents_t can be removed once all the compilers we support have fixed this bug.
+    : public integral_constant<bool, __has_unique_object_representations(remove_all_extents_t<_Tp>)> {};
 
 template <class _Tp>
 inline constexpr bool has_unique_object_representations_v = __has_unique_object_representations(_Tp);

--- a/libcxx/test/std/utilities/meta/meta.unary/meta.unary.prop/has_unique_object_representations.compile.pass.cpp
+++ b/libcxx/test/std/utilities/meta/meta.unary/meta.unary.prop/has_unique_object_representations.compile.pass.cpp
@@ -67,7 +67,7 @@ class NTTP_ClassType_WithoutPadding {
   int x;
 };
 
-int main(int, char**) {
+void test() {
   test<false, void>();
   test<false, Empty>();
   test<false, EmptyUnion>();
@@ -103,6 +103,4 @@ int main(int, char**) {
     test<true, NTTP_ClassType_WithoutPadding<0>[][3]>();
     test<true, NTTP_ClassType_WithoutPadding<0>>();
   }
-
-  return 0;
 }


### PR DESCRIPTION
Clang currently has a bug in the __has_unique_object_representations builtin where it doesn't provide consistent answers based on the order of instantiation of templates. This was reported as #95311.

This patch adds a workaround in libc++ to avoid breaking users until Clang has been fixed. It also revamps the tests a bit.