### PR TITLE
[LLD] Add CLASS syntax to SECTIONS

### DIFF
--- a/lld/ELF/InputSection.cpp
+++ b/lld/ELF/InputSection.cpp
@@ -194,6 +194,8 @@ uint64_t SectionBase::getOffset(uint64_t offset) const {
     // For output sections we treat offset -1 as the end of the section.
     return offset == uint64_t(-1) ? os->size : offset;
   }
+  case Class:
+    llvm_unreachable("section classes do not have offsets");
   case Regular:
   case Synthetic:
   case Spill:

--- a/lld/ELF/InputSection.h
+++ b/lld/ELF/InputSection.h
@@ -61,7 +61,7 @@ template <class ELFT> struct RelsOrRelas {
 // sections.
 class SectionBase {
 public:
-  enum Kind { Regular, Synthetic, Spill, EHFrame, Merge, Output };
+  enum Kind { Regular, Synthetic, Spill, EHFrame, Merge, Output, Class };
 
   Kind kind() const { return (Kind)sectionKind; }
 
@@ -148,7 +148,9 @@ public:
                    uint32_t addralign, ArrayRef<uint8_t> data, StringRef name,
                    Kind sectionKind);
 
-  static bool classof(const SectionBase *s) { return s->kind() != Output; }
+  static bool classof(const SectionBase *s) {
+    return s->kind() != Output && s->kind() != Class;
+  }
 
   // The file which contains this section. Its dynamic type is usually
   // ObjFile<ELFT>, but may be an InputFile of InternalKind (for a synthetic

--- a/lld/ELF/LinkerScript.cpp
+++ b/lld/ELF/LinkerScript.cpp
@@ -808,13 +808,18 @@ void LinkerScript::processSectionCommands() {
 
   // Input sections cannot have a section class parent past this point; they
   // must have been assigned to an output section.
-  for (const auto &[_, sc] : sectionClasses)
-    for (InputSectionDescription *isd : sc->sc.commands)
-      for (InputSectionBase *sec : isd->sectionBases)
-        if (sec->parent && isa<SectionClass>(sec->parent))
-          errorOrWarn("section '" + sec->name + "' assigned to class '" +
-                      sec->parent->name +
-                      "' but unreferenced by any output section");
+  for (const auto &[_, sc] : sectionClasses) {
+    for (InputSectionDescription *isd : sc->sc.commands) {
+      for (InputSectionBase *sec : isd->sectionBases) {
+        if (sec->parent && isa<SectionClass>(sec->parent)) {
+          errorOrWarn("section class '" + sec->parent->name +
+                      "' is unreferenced");
+          goto nextClass;
+        }
+      }
+    }
+  nextClass:;
+  }
 }
 
 void LinkerScript::processSymbolAssignments() {

--- a/lld/ELF/LinkerScript.cpp
+++ b/lld/ELF/LinkerScript.cpp
@@ -602,7 +602,8 @@ LinkerScript::computeInputSections(const InputSectionDescription *cmd,
       return ret;
     }
     if (!scd->sc.assigned) {
-      error("section class '" + cmd->className + "' used before assigned");
+      error("section class '" + cmd->className + "' referenced by '" +
+            outCmd.name + "' before class definition");
       return ret;
     }
 
@@ -806,7 +807,7 @@ void LinkerScript::processSectionCommands() {
       for (InputSectionBase *sec : isd->sectionBases)
         if (sec->parent && isa<SectionClass>(sec->parent))
           error("section '" + sec->name + "' assigned to class '" +
-                sec->parent->name + "' but to no output section");
+                sec->parent->name + "' but unreferenced by any output section");
 }
 
 void LinkerScript::processSymbolAssignments() {

--- a/lld/ELF/LinkerScript.cpp
+++ b/lld/ELF/LinkerScript.cpp
@@ -609,7 +609,8 @@ LinkerScript::computeInputSections(const InputSectionDescription *cmd,
           continue;
         bool isSpill = sec->parent && isa<OutputSection>(sec->parent);
         if (!sec->parent || (isSpill && outCmd.name == "/DISCARD/")) {
-          errorOrWarn("section '" + sec->name + "' cannot spill from/to /DISCARD/");
+          errorOrWarn("section '" + sec->name +
+                      "' cannot spill from/to /DISCARD/");
           continue;
         }
         if (isSpill)

--- a/lld/ELF/LinkerScript.h
+++ b/lld/ELF/LinkerScript.h
@@ -201,11 +201,11 @@ class InputSectionDescription : public SectionCommand {
 
 public:
   InputSectionDescription(StringRef filePattern, uint64_t withFlags = 0,
-                          uint64_t withoutFlags = 0, StringRef className = {})
+                          uint64_t withoutFlags = 0, StringRef classRef = {})
       : SectionCommand(InputSectionKind), filePat(filePattern),
-        withFlags(withFlags), withoutFlags(withoutFlags), className(className) {
-    assert((filePattern.empty() || className.empty()) &&
-           "file pattern and class name are mutually exclusive");
+        withFlags(withFlags), withoutFlags(withoutFlags), classRef(classRef) {
+    assert((filePattern.empty() || classRef.empty()) &&
+           "file pattern and class reference are mutually exclusive");
   }
 
   static bool classof(const SectionCommand *c) {
@@ -237,7 +237,7 @@ public:
 
   // If present, input section matching uses class membership instead of file
   // and section patterns (mutually exclusive).
-  StringRef className;
+  StringRef classRef;
 };
 
 // Represents BYTE(), SHORT(), LONG(), or QUAD().

--- a/lld/ELF/LinkerScript.h
+++ b/lld/ELF/LinkerScript.h
@@ -81,7 +81,7 @@ enum SectionsCommandKind {
   OutputSectionKind,
   InputSectionKind,
   ByteKind, // BYTE(expr), SHORT(expr), LONG(expr) or QUAD(expr)
-  ClassKind,
+  ClassKind, // CLASS(class_name)
 };
 
 struct SectionCommand {
@@ -203,7 +203,7 @@ public:
   InputSectionDescription(StringRef filePattern, uint64_t withFlags = 0,
                           uint64_t withoutFlags = 0, StringRef classRef = {})
       : SectionCommand(InputSectionKind), filePat(filePattern),
-        withFlags(withFlags), withoutFlags(withoutFlags), classRef(classRef) {
+        classRef(classRef), withFlags(withFlags), withoutFlags(withoutFlags) {
     assert((filePattern.empty() || classRef.empty()) &&
            "file pattern and class reference are mutually exclusive");
   }
@@ -217,6 +217,10 @@ public:
   // Input sections that matches at least one of SectionPatterns
   // will be associated with this InputSectionDescription.
   SmallVector<SectionPattern, 0> sectionPatterns;
+
+  // If present, input section matching uses class membership instead of file
+  // and section patterns (mutually exclusive).
+  StringRef classRef;
 
   // Includes InputSections and MergeInputSections. Used temporarily during
   // assignment of input sections to output sections.
@@ -234,10 +238,6 @@ public:
   // SectionPatterns can be filtered with the INPUT_SECTION_FLAGS command.
   uint64_t withFlags;
   uint64_t withoutFlags;
-
-  // If present, input section matching uses class membership instead of file
-  // and section patterns (mutually exclusive).
-  StringRef classRef;
 };
 
 // Represents BYTE(), SHORT(), LONG(), or QUAD().
@@ -442,7 +442,7 @@ public:
   // Named lists of input sections that can be collectively referenced in output
   // section descriptions. Multiple references allow for sections to spill from
   // one output section to another.
-  llvm::StringMap<SectionClassDesc *> sectionClasses;
+  llvm::DenseMap<llvm::CachedHashStringRef, SectionClassDesc *> sectionClasses;
 };
 
 struct ScriptWrapper {

--- a/lld/ELF/LinkerScript.h
+++ b/lld/ELF/LinkerScript.h
@@ -80,7 +80,7 @@ enum SectionsCommandKind {
   AssignmentKind, // . = expr or <sym> = expr
   OutputSectionKind,
   InputSectionKind,
-  ByteKind, // BYTE(expr), SHORT(expr), LONG(expr) or QUAD(expr)
+  ByteKind,  // BYTE(expr), SHORT(expr), LONG(expr) or QUAD(expr)
   ClassKind, // CLASS(class_name)
 };
 

--- a/lld/ELF/MapFile.cpp
+++ b/lld/ELF/MapFile.cpp
@@ -167,6 +167,8 @@ static void writeMapFile(raw_fd_ostream &os) {
       os << assign->commandString << '\n';
       continue;
     }
+    if (isa<SectionClassDesc>(cmd))
+      continue;
 
     osec = &cast<OutputDesc>(cmd)->osec;
     writeHeader(os, osec->addr, osec->getLMA(), osec->size, osec->addralign);

--- a/lld/ELF/OutputSections.h
+++ b/lld/ELF/OutputSections.h
@@ -143,6 +143,25 @@ struct OutputDesc final : SectionCommand {
   }
 };
 
+// A list of input sections that can be referenced in output descriptions.
+// Multiple references allow sections to spill from one output section to the
+// next.
+struct SectionClass final : public SectionBase {
+  SmallVector<InputSectionDescription *, 0> commands;
+  bool assigned = false;
+
+  SectionClass(StringRef name) : SectionBase(Class, name, 0, 0, 0, 0, 0, 0) {}
+  static bool classof(const SectionBase *s) { return s->kind() == Class; }
+};
+
+struct SectionClassDesc : SectionCommand {
+  SectionClass sc;
+
+  SectionClassDesc(StringRef name) : SectionCommand(ClassKind), sc(name) {}
+
+  static bool classof(const SectionCommand *c) { return c->kind == ClassKind; }
+};
+
 int getPriority(StringRef s);
 
 InputSection *getFirstInputSection(const OutputSection *os);

--- a/lld/ELF/OutputSections.h
+++ b/lld/ELF/OutputSections.h
@@ -143,9 +143,9 @@ struct OutputDesc final : SectionCommand {
   }
 };
 
-// A list of input sections that can be referenced in output descriptions.
-// Multiple references allow sections to spill from one output section to the
-// next.
+// This represents a CLASS(class_name) { ... } that can be referenced by output
+// section descriptions. If referenced more than once, the sections can be
+// spilled to the next reference like --enable-non-contiguous-regions.
 struct SectionClass final : public SectionBase {
   SmallVector<InputSectionDescription *, 0> commands;
   bool assigned = false;

--- a/lld/ELF/ScriptParser.cpp
+++ b/lld/ELF/ScriptParser.cpp
@@ -608,7 +608,6 @@ SmallVector<SectionCommand *, 0> ScriptParser::readOverlay() {
 }
 
 SectionClassDesc *ScriptParser::readSectionClassDescription() {
-  std::string loc = getCurrentLocation();
   StringRef name = readSectionClassName();
   SectionClassDesc *desc = make<SectionClassDesc>(name);
   if (!script->sectionClasses.insert({name, desc}).second)
@@ -616,9 +615,9 @@ SectionClassDesc *ScriptParser::readSectionClassDescription() {
   expect("{");
   while (!errorCount() && !consume("}")) {
     StringRef tok = next();
-    if (tok == "(" || tok == ")")
+    if (tok == "(" || tok == ")") {
       setError("expected filename pattern");
-    else if (peek() == "(") {
+    } else if (peek() == "(") {
       InputSectionDescription *isd = readInputSectionDescription(tok);
       if (!isd->classRef.empty())
         setError("section class '" + name + "' references class '" +

--- a/lld/ELF/ScriptParser.cpp
+++ b/lld/ELF/ScriptParser.cpp
@@ -613,8 +613,7 @@ SectionClassDesc *ScriptParser::readSectionClassDescription() {
   if (!script->sectionClasses.insert({CachedHashStringRef(name), desc}).second)
     setError("section class '" + name + "' already defined");
   expect("{");
-  while (!errorCount() && !consume("}")) {
-    StringRef tok = next();
+  while (auto tok = till("}")) {
     if (tok == "(" || tok == ")") {
       setError("expected filename pattern");
     } else if (peek() == "(") {

--- a/lld/ELF/ScriptParser.cpp
+++ b/lld/ELF/ScriptParser.cpp
@@ -610,7 +610,7 @@ SmallVector<SectionCommand *, 0> ScriptParser::readOverlay() {
 SectionClassDesc *ScriptParser::readSectionClassDescription() {
   StringRef name = readSectionClassName();
   SectionClassDesc *desc = make<SectionClassDesc>(name);
-  if (!script->sectionClasses.insert({name, desc}).second)
+  if (!script->sectionClasses.insert({CachedHashStringRef(name), desc}).second)
     setError("section class '" + name + "' already defined");
   expect("{");
   while (!errorCount() && !consume("}")) {
@@ -630,7 +630,7 @@ SectionClassDesc *ScriptParser::readSectionClassDescription() {
 
 StringRef ScriptParser::readSectionClassName() {
   expect("(");
-  StringRef name = next();
+  StringRef name = unquote(next());
   expect(")");
   return name;
 }

--- a/lld/ELF/ScriptParser.cpp
+++ b/lld/ELF/ScriptParser.cpp
@@ -998,7 +998,7 @@ OutputDesc *ScriptParser::readOverlaySectionDescription() {
     }
     if (tok == "CLASS")
       osd->osec.commands.push_back(make<InputSectionDescription>(
-          StringRef{}, withFlags, withoutFlags, next()));
+          StringRef{}, withFlags, withoutFlags, readSectionClassName()));
     else
       osd->osec.commands.push_back(
           readInputSectionRules(tok, withFlags, withoutFlags));

--- a/lld/ELF/ScriptParser.cpp
+++ b/lld/ELF/ScriptParser.cpp
@@ -87,6 +87,8 @@ private:
   OutputDesc *readOverlaySectionDescription();
   OutputDesc *readOutputSectionDescription(StringRef outSec);
   SmallVector<SectionCommand *, 0> readOverlay();
+  SectionClassDesc *readSectionClassDescription();
+  StringRef readSectionClassName();
   SmallVector<StringRef, 0> readOutputSectionPhdrs();
   std::pair<uint64_t, uint64_t> readInputSectionFlags();
   InputSectionDescription *readInputSectionDescription(StringRef tok);
@@ -605,6 +607,35 @@ SmallVector<SectionCommand *, 0> ScriptParser::readOverlay() {
   return v;
 }
 
+SectionClassDesc *ScriptParser::readSectionClassDescription() {
+  std::string loc = getCurrentLocation();
+  StringRef name = readSectionClassName();
+  SectionClassDesc *desc = make<SectionClassDesc>(name);
+  if (!script->sectionClasses.insert({name, desc}).second)
+    setError("section class '" + name + "' already defined");
+  expect("{");
+  while (!errorCount() && !consume("}")) {
+    StringRef tok = next();
+    if (tok == "(" || tok == ")")
+      setError("expected filename pattern");
+    else if (peek() == "(") {
+      InputSectionDescription *isd = readInputSectionDescription(tok);
+      if (!isd->className.empty())
+        setError("section class '" + name + "' references class '" +
+                 isd->className + "'");
+      desc->sc.commands.push_back(isd);
+    }
+  }
+  return desc;
+}
+
+StringRef ScriptParser::readSectionClassName() {
+  expect("(");
+  StringRef name = next();
+  expect(")");
+  return name;
+}
+
 void ScriptParser::readOverwriteSections() {
   expect("{");
   while (auto tok = till("}"))
@@ -619,7 +650,12 @@ void ScriptParser::readSections() {
       for (SectionCommand *cmd : readOverlay())
         v.push_back(cmd);
       continue;
-    } else if (tok == "INCLUDE") {
+    }
+    if (tok == "CLASS") {
+      v.push_back(readSectionClassDescription());
+      continue;
+    }
+    if (tok == "INCLUDE") {
       readInclude();
       continue;
     }
@@ -822,8 +858,14 @@ ScriptParser::readInputSectionDescription(StringRef tok) {
     expect("(");
     if (consume("INPUT_SECTION_FLAGS"))
       std::tie(withFlags, withoutFlags) = readInputSectionFlags();
-    InputSectionDescription *cmd =
-        readInputSectionRules(next(), withFlags, withoutFlags);
+
+    tok = next();
+    InputSectionDescription *cmd;
+    if (tok == "CLASS")
+      cmd = make<InputSectionDescription>(StringRef{}, withFlags, withoutFlags,
+                                          readSectionClassName());
+    else
+      cmd = readInputSectionRules(tok, withFlags, withoutFlags);
     expect(")");
     script->keptSections.push_back(cmd);
     return cmd;
@@ -832,6 +874,9 @@ ScriptParser::readInputSectionDescription(StringRef tok) {
     std::tie(withFlags, withoutFlags) = readInputSectionFlags();
     tok = next();
   }
+  if (tok == "CLASS")
+    return make<InputSectionDescription>(StringRef{}, withFlags, withoutFlags,
+                                         readSectionClassName());
   return readInputSectionRules(tok, withFlags, withoutFlags);
 }
 
@@ -951,8 +996,12 @@ OutputDesc *ScriptParser::readOverlaySectionDescription() {
       std::tie(withFlags, withoutFlags) = readInputSectionFlags();
       tok = till("");
     }
-    osd->osec.commands.push_back(
-        readInputSectionRules(tok, withFlags, withoutFlags));
+    if (tok == "CLASS")
+      osd->osec.commands.push_back(make<InputSectionDescription>(
+          StringRef{}, withFlags, withoutFlags, next()));
+    else
+      osd->osec.commands.push_back(
+          readInputSectionRules(tok, withFlags, withoutFlags));
   }
   osd->osec.phdrs = readOutputSectionPhdrs();
   return osd;

--- a/lld/ELF/ScriptParser.cpp
+++ b/lld/ELF/ScriptParser.cpp
@@ -620,9 +620,9 @@ SectionClassDesc *ScriptParser::readSectionClassDescription() {
       setError("expected filename pattern");
     else if (peek() == "(") {
       InputSectionDescription *isd = readInputSectionDescription(tok);
-      if (!isd->className.empty())
+      if (!isd->classRef.empty())
         setError("section class '" + name + "' references class '" +
-                 isd->className + "'");
+                 isd->classRef + "'");
       desc->sc.commands.push_back(isd);
     }
   }

--- a/lld/docs/ELF/linker_script.rst
+++ b/lld/docs/ELF/linker_script.rst
@@ -198,13 +198,52 @@ the current location to a max-page-size boundary, ensuring that the next
 LLD will insert ``.relro_padding`` immediately before the symbol assignment
 using ``DATA_SEGMENT_RELRO_END``.
 
+Section Classes
+~~~~~~~~~~~~~~~
+
+``SECTIONS`` commands can define classes of input sections:
+
+::
+
+  SECTIONS {
+    CLASS(class_name) {
+      input-section-description
+      input-section-description
+      ...
+    }
+  }
+
+Input section descriptions can refer to a class using ``CLASS(class_name)``
+instead of the usual filename and section name patterns. For example:
+
+::
+
+  SECTIONS {
+    CLASS(c) { *(.rodata.earlier) }
+    .rodata { *(.rodata) CLASS(c) (*.rodata.later) }
+  }
+
+Input sections that are assigned to a class cannot be matched by later
+wildcards, just as if they had been assigned to an earlier output section. If a
+class is referenced in multiple output sections, when a memory region would
+overflow, the linker spills input sections from a reference to later references
+rather than failing the link.
+
+Classes cannot reference other classes; an input section is assigned to at most
+one class.
+
+Sections cannot be specified to possibly spill into or out of
+``INSERT [AFTER|BEFORE]``, ``OVERWRITE_SECTIONS``, or ``/DISCARD/``.
+
 Non-contiguous regions
 ~~~~~~~~~~~~~~~~~~~~~~
 
-The flag ``--enable-non-contiguous-regions`` allows input sections to spill to
-later matches rather than causing the link to fail by overflowing a memory
-region. Unlike GNU ld, ``/DISCARD/`` only matches previously-unmatched sections
-(i.e., the flag does not affect it). Also, if a section fails to fit at any of
-its matches, the link fails instead of discarding the section. Accordingly, the
-GNU flag ``--enable-non-contiguous-regions-warnings`` is not implemented, as it
-exists to warn about such occurrences.
+The flag ``--enable-non-contiguous-regions`` provides a version of the above
+spilling functionality that is more compatible with GNU LD. It allows input
+sections to spill to later wildcard matches. (This globally changes the
+behavior of wildcards.) Unlike GNU ld, ``/DISCARD/`` only matches
+previously-unmatched sections (i.e., the flag does not affect it). Also, if a
+section fails to fit at any of its matches, the link fails instead of
+discarding the section. Accordingly, the GNU flag
+``--enable-non-contiguous-regions-warnings`` is not implemented, as it exists
+to warn about such occurrences.

--- a/lld/docs/ELF/linker_script.rst
+++ b/lld/docs/ELF/linker_script.rst
@@ -201,7 +201,8 @@ using ``DATA_SEGMENT_RELRO_END``.
 Section Classes
 ~~~~~~~~~~~~~~~
 
-``SECTIONS`` commands can define classes of input sections:
+The ``CLASS`` keyword inside a ``SECTIONS`` command defines classes of input
+sections:
 
 ::
 
@@ -213,7 +214,7 @@ Section Classes
     }
   }
 
-Input section descriptions can refer to a class using ``CLASS(class_name)``
+Input section descriptions refer to a class using ``CLASS(class_name)``
 instead of the usual filename and section name patterns. For example:
 
 ::
@@ -223,11 +224,11 @@ instead of the usual filename and section name patterns. For example:
     .rodata { *(.rodata) CLASS(c) (*.rodata.later) }
   }
 
-Input sections that are assigned to a class cannot be matched by later
-wildcards, just as if they had been assigned to an earlier output section. If a
-class is referenced in multiple output sections, when a memory region would
-overflow, the linker spills input sections from a reference to later references
-rather than failing the link.
+Input sections that are assigned to a class are not matched by later patterns,
+just as if they had been assigned to an earlier output section. If a class is
+referenced in multiple output sections, when a memory region would overflow,
+the linker spills input sections from a reference to later references rather
+than failing the link.
 
 Classes cannot reference other classes; an input section is assigned to at most
 one class.
@@ -240,10 +241,9 @@ Non-contiguous regions
 
 The flag ``--enable-non-contiguous-regions`` provides a version of the above
 spilling functionality that is more compatible with GNU LD. It allows input
-sections to spill to later wildcard matches. (This globally changes the
-behavior of wildcards.) Unlike GNU ld, ``/DISCARD/`` only matches
-previously-unmatched sections (i.e., the flag does not affect it). Also, if a
-section fails to fit at any of its matches, the link fails instead of
-discarding the section. Accordingly, the GNU flag
-``--enable-non-contiguous-regions-warnings`` is not implemented, as it exists
-to warn about such occurrences.
+sections to spill to later pattern matches. (This globally changes the behavior
+of patterns.) Unlike GNU ld, ``/DISCARD/`` only matches previously-unmatched
+sections (i.e., the flag does not affect it). Also, if a section fails to fit
+at any of its matches, the link fails instead of discarding the section.
+Accordingly, the GNU flag ``--enable-non-contiguous-regions-warnings`` is not
+implemented, as it exists to warn about such occurrences.

--- a/lld/docs/ReleaseNotes.rst
+++ b/lld/docs/ReleaseNotes.rst
@@ -34,8 +34,8 @@ ELF Improvements
   regions by automatically spilling to later class references if a region would
   overflow. This reduces the toil of manually packing regions (typical for
   embedded). It also makes full LTO feasible in such cases, since IR merging
-  currently prevents the linker script from referring to input files. (TODO: PR
-  Reference)
+  currently prevents the linker script from referring to input files.
+  (`#95323 <https://github.com/llvm/llvm-project/pull/95323>`_)
 
 Breaking changes
 ----------------

--- a/lld/docs/ReleaseNotes.rst
+++ b/lld/docs/ReleaseNotes.rst
@@ -29,6 +29,13 @@ ELF Improvements
 * ``-z nosectionheader`` has been implemented to omit the section header table.
   The operation is similar to ``llvm-objcopy --strip-sections``.
   (`#101286 <https://github.com/llvm/llvm-project/pull/101286>`_)
+* Section ``CLASS`` syntax allows binding input section to named classes. This
+  allows the linker to automatically pack the input sections into memory
+  regions by automatically spilling to later class references if a region would
+  overflow. This reduces the toil of manually packing regions (typical for
+  embedded). It also makes full LTO feasible in such cases, since IR merging
+  currently prevents the linker script from referring to input files. (TODO: PR
+  Reference)
 
 Breaking changes
 ----------------

--- a/lld/docs/ReleaseNotes.rst
+++ b/lld/docs/ReleaseNotes.rst
@@ -29,12 +29,11 @@ ELF Improvements
 * ``-z nosectionheader`` has been implemented to omit the section header table.
   The operation is similar to ``llvm-objcopy --strip-sections``.
   (`#101286 <https://github.com/llvm/llvm-project/pull/101286>`_)
-* Section ``CLASS`` syntax allows binding input section to named classes. This
-  allows the linker to automatically pack the input sections into memory
-  regions by automatically spilling to later class references if a region would
-  overflow. This reduces the toil of manually packing regions (typical for
-  embedded). It also makes full LTO feasible in such cases, since IR merging
-  currently prevents the linker script from referring to input files.
+* Section ``CLASS`` linker script syntax binds input sections to named classes,
+  which are referenced later one or more times. This provides access to the
+  automatic spilling mechanism of `--enable-non-contiguous-regions` without
+  globally changing the semantics of section matching. It also independently
+  increases the expressive power of linker scripts.
   (`#95323 <https://github.com/llvm/llvm-project/pull/95323>`_)
 
 Breaking changes

--- a/lld/test/ELF/linkerscript/section-class.test
+++ b/lld/test/ELF/linkerscript/section-class.test
@@ -1,0 +1,379 @@
+# REQUIRES: x86
+
+# RUN: rm -rf %t && split-file %s %t && cd %t
+
+# RUN: llvm-mc -n -filetype=obj -triple=x86_64 matching.s -o matching.o
+
+## CLASS definitions match sections in linker script order. The sections may be
+## placed in a different order. Classes may derive from one another, and class
+## references may be restricted by INPUT_SECTION_FLAGS.
+
+# RUN: ld.lld -T matching.ld matching.o -o matching
+# RUN: llvm-readobj -x .rodata matching | FileCheck %s --check-prefix=MATCHING
+
+# MATCHING: 02030104
+
+
+## An error is reported when a section class has more than one description.
+
+# RUN: not ld.lld -T already-defined.ld matching.o 2>&1 | \
+# RUN:   FileCheck %s --check-prefix=ALREADY-DEFINED --implicit-check-not=error:
+
+# ALREADY-DEFINED: error: already-defined.ld:3: section class 'a' already defined
+
+
+## An error is reported when a filename pattern is missing in a section class
+## description.
+
+# RUN: not ld.lld -T missing-filename-pattern.ld matching.o 2>&1 | \
+# RUN:   FileCheck %s --check-prefix=MISSING-FILENAME-PATTERN --implicit-check-not=error:
+
+# MISSING-FILENAME-PATTERN: error: missing-filename-pattern.ld:2: expected filename pattern
+
+
+## An error is reported when the content of section classes is demanded before
+## input sections have been assigned to them.
+
+# RUN: not ld.lld -T used-before-assigned.ld matching.o 2>&1 | \
+# RUN:   FileCheck %s --check-prefix=USED-BEFORE-ASSIGNED
+
+# USED-BEFORE-ASSIGNED: error: section class 'a' used before assigned
+
+
+## An error is reported when an input section is bound to a section class but
+## is not referenced by at least one output section.
+
+# RUN: not ld.lld -T unreferenced.ld matching.o 2>&1 | \
+# RUN:   FileCheck %s --check-prefix=UNREFERENCED
+
+# UNREFERENCED: error: section '.rodata.a' assigned to class 'a' but to no output section
+
+
+## An error is reported when one section class references another.
+
+# RUN: not ld.lld -T class-references-class.ld matching.o 2>&1 | \
+# RUN:   FileCheck %s --check-prefix=CLASS-REFERENCES-CLASS --implicit-check-not=error:
+
+# CLASS-REFERENCES-CLASS: error: class-references-class.ld:3: section class 'b' references class 'a'
+
+
+# RUN: llvm-mc -n -filetype=obj -triple=x86_64 spill.s -o spill.o
+
+
+## An input section in a class spills to a later class ref when the region of
+## its first ref would overflow. The spill uses the alignment of the later ref.
+
+# RUN: ld.lld -T spill.ld spill.o -o spill
+# RUN: llvm-readelf -S spill | FileCheck %s --check-prefix=SPILL
+
+# SPILL:      Name          Type     Address          Off    Size
+# SPILL:      .first_chance PROGBITS 0000000000000000 001000 000001
+# SPILL-NEXT: .last_chance  PROGBITS 0000000000000008 001008 000002
+
+
+## A spill off the end still fails the link.
+
+# RUN: not ld.lld -T spill-fail.ld spill.o 2>&1 |\
+# RUN:   FileCheck %s --check-prefix=SPILL-FAIL --implicit-check-not=error:
+
+# SPILL-FAIL: error: section '.last_chance' will not fit in region 'b': overflowed by 2 bytes
+
+
+## The above spill still occurs when the LMA would overflow, even though the
+## VMA would fit.
+
+# RUN: ld.lld -T spill-lma.ld spill.o -o spill-lma
+# RUN: llvm-readelf -S spill-lma | FileCheck %s --check-prefix=SPILL-LMA
+
+# SPILL-LMA:      Name          Type     Address          Off    Size
+# SPILL-LMA:      .first_chance PROGBITS 0000000000000000 001000 000001
+# SPILL-LMA-NEXT: .last_chance  PROGBITS 0000000000000003 001003 000002
+
+
+## A spill occurs to an additional class ref after the first.
+
+# RUN: ld.lld -T spill-later.ld spill.o -o spill-later
+# RUN: llvm-readelf -S spill-later | FileCheck %s --check-prefix=SPILL-LATER
+
+# SPILL-LATER:      Name            Type     Address          Off    Size
+# SPILL-LATER:      .first_chance   PROGBITS 0000000000000000 001000 000001
+# SPILL-LATER-NEXT: .second_chance  PROGBITS 0000000000000002 001001 000000
+# SPILL-LATER-NEXT: .last_chance    PROGBITS 0000000000000003 001003 000002
+
+
+## A later overflow causes an earlier section to spill.
+
+# RUN: ld.lld -T spill-earlier.ld spill.o -o spill-earlier
+# RUN: llvm-readelf -S spill-earlier | FileCheck %s --check-prefix=SPILL-EARLIER
+
+# SPILL-EARLIER:      Name          Type     Address          Off    Size
+# SPILL-EARLIER:      .first_chance PROGBITS 0000000000000000 001000 000002
+# SPILL-EARLIER-NEXT: .last_chance  PROGBITS 0000000000000002 001002 000001
+
+
+## SHF_MERGEd sections are spilled according to the class refs of the first
+## merged input section (the one giving the resulting section its name).
+
+# RUN: llvm-mc -n -filetype=obj -triple=x86_64 merge.s -o merge.o
+# RUN: ld.lld -T spill-merge.ld merge.o -o spill-merge
+# RUN: llvm-readelf -S spill-merge | FileCheck %s --check-prefix=SPILL-MERGE
+
+# SPILL-MERGE:      Name          Type     Address          Off    Size
+# SPILL-MERGE:      .first  PROGBITS 0000000000000000 000190 000000
+# SPILL-MERGE-NEXT: .second PROGBITS 0000000000000001 001001 000002
+# SPILL-MERGE-NEXT: .third  PROGBITS 0000000000000003 001003 000000
+
+
+## SHF_LINK_ORDER is reordered when spilling changes relative section order.
+
+# RUN: llvm-mc -n -filetype=obj -triple=x86_64 link-order.s -o link-order.o
+# RUN: ld.lld -T link-order.ld link-order.o -o link-order
+# RUN: llvm-readobj -x .order link-order | FileCheck %s --check-prefix=LINK-ORDER
+
+# LINK-ORDER: 020301
+
+
+## An error is reported when a section might spill from INSERT.
+
+# RUN: not ld.lld -T from-insert.ld spill.o 2>&1 |\
+# RUN:   FileCheck %s --check-prefix=FROM-INSERT
+
+# FROM-INSERT: error: section '.two_byte_section' cannot spill from/to INSERT section '.b'
+
+
+## An error is reported when a section might spill to INSERT.
+
+# RUN: not ld.lld -T to-insert.ld spill.o 2>&1 |\
+# RUN:   FileCheck %s --check-prefix=TO-INSERT
+
+# TO-INSERT: error: section '.two_byte_section' cannot spill from/to INSERT section '.b'
+
+
+## An error is reported when a section might spill from /DISCARD/.
+
+# RUN: not ld.lld -T from-discard.ld spill.o 2>&1 |\
+# RUN:   FileCheck %s --check-prefix=FROM-DISCARD
+
+# FROM-DISCARD: error: section '.two_byte_section' cannot spill from/to /DISCARD/
+
+
+## An error is reported when a section might spill to /DISCARD/.
+
+# RUN: not ld.lld -T to-discard.ld spill.o 2>&1 |\
+# RUN:   FileCheck %s --check-prefix=TO-DISCARD
+
+# TO-DISCARD: error: section '.two_byte_section' cannot spill from/to /DISCARD/
+
+#--- matching.s
+.section .rodata.a,"a",@progbits
+.byte 1
+
+.section .rodata.b,"a",@progbits
+.byte 2
+
+.section .rodata.c,"ax",@progbits
+.byte 3
+
+.section .rodata.d,"a",@progbits
+.byte 4
+
+#--- matching.ld
+MEMORY {
+ m : ORIGIN = 0, LENGTH = 4
+}
+
+SECTIONS {
+  CLASS(a) { *(.rodata.a) }
+  CLASS(cd) { *(.rodata.c) *(.rodata.d) }
+  .rodata : {
+    *(.rodata.*)
+    INPUT_SECTION_FLAGS(SHF_EXECINSTR) CLASS(cd)
+    CLASS(a)
+    CLASS(cd)
+  } >m
+}
+
+#--- already-defined.ld
+SECTIONS {
+  CLASS(a) { *(.rodata.a) }
+  CLASS(a) { *(.rodata.b) }
+}
+
+#--- missing-filename-pattern.ld
+SECTIONS {
+  CLASS(a) { (.rodata.a) }
+}
+
+#--- used-before-assigned.ld
+SECTIONS {
+  .rodata : { CLASS(a) }
+  CLASS(a) { *(.rodata.a) }
+}
+
+#--- unreferenced.ld
+SECTIONS {
+  CLASS(a) { *(.rodata.*) }
+}
+
+#--- class-references-class.ld
+SECTIONS {
+  CLASS(a) { *(.rodata.a) }
+  CLASS(b) { CLASS(a) }
+}
+
+#--- spill.s
+.section .one_byte_section,"a",@progbits
+.fill 1
+
+.section .two_byte_section,"a",@progbits
+.fill 2
+
+#--- spill.ld
+MEMORY {
+  a : ORIGIN = 0, LENGTH = 2
+  b : ORIGIN = 2, LENGTH = 16
+}
+
+SECTIONS {
+  CLASS(c) { *(.two_byte_section) }
+  .first_chance : SUBALIGN(1) { *(.one_byte_section) CLASS(c) } >a
+  .last_chance : SUBALIGN(8) { CLASS (c) } >b
+}
+
+#--- spill-fail.ld
+MEMORY {
+  a : ORIGIN = 0, LENGTH = 1
+  b : ORIGIN = 2, LENGTH = 0
+}
+
+SECTIONS {
+  CLASS(c) { *(.two_byte_section) }
+  .first_chance : { *(.one_byte_section) CLASS(c) } >a
+  .last_chance : { CLASS(c) } >b
+}
+
+#--- spill-lma.ld
+MEMORY {
+  vma_a : ORIGIN = 0, LENGTH = 3
+  vma_b : ORIGIN = 3, LENGTH = 3
+  lma_a : ORIGIN = 6, LENGTH = 2
+  lma_b : ORIGIN = 8, LENGTH = 2
+}
+
+SECTIONS {
+  CLASS(c) { *(.two_byte_section) }
+  .first_chance : { *(.one_byte_section) CLASS(c) } >vma_a AT>lma_a
+  .last_chance : { CLASS(c) } >vma_b AT>lma_b
+}
+
+#--- spill-later.ld
+MEMORY {
+  a : ORIGIN = 0, LENGTH = 2
+  b : ORIGIN = 2, LENGTH = 1
+  c : ORIGIN = 3, LENGTH = 2
+}
+
+SECTIONS {
+  CLASS(c) { *(.two_byte_section) }
+  .first_chance : { *(.one_byte_section) CLASS(c) } >a
+  .second_chance : { CLASS(c) } >b
+  .last_chance : { CLASS(c) } >c
+}
+
+#--- spill-earlier.ld
+MEMORY {
+  a : ORIGIN = 0, LENGTH = 2
+  b : ORIGIN = 2, LENGTH = 1
+}
+
+SECTIONS {
+  CLASS(c) { *(.one_byte_section) }
+  .first_chance : { CLASS(c) *(.two_byte_section) } >a
+  .last_chance : { CLASS(c) } >b
+}
+
+#--- merge.s
+.section .a,"aM",@progbits,1
+.byte 0x12, 0x34
+
+.section .b,"aM",@progbits,1
+.byte 0x12
+
+#--- spill-merge.ld
+MEMORY {
+  a : ORIGIN = 0, LENGTH = 1
+  b : ORIGIN = 1, LENGTH = 2
+  c : ORIGIN = 3, LENGTH = 2
+}
+
+SECTIONS {
+  CLASS(a) { *(.a) }
+  CLASS(b) { *(.b) }
+  .first : { CLASS(a) CLASS(b) } >a
+  .second : { CLASS(a) } >b
+  .third : { CLASS(b) } >c
+}
+
+#--- link-order.s
+.section .a,"a",@progbits
+.fill 1
+
+.section .b,"a",@progbits
+.fill 1
+
+.section .c,"a",@progbits
+.fill 1
+
+.section .link_order.a,"ao",@progbits,.a
+.byte 1
+
+.section .link_order.b,"ao",@progbits,.b
+.byte 2
+
+.section .link_order.c,"ao",@progbits,.c
+.byte 3
+
+#--- link-order.ld
+MEMORY {
+  order : ORIGIN = 0, LENGTH = 3
+  potential_a : ORIGIN = 3, LENGTH = 0
+  bc : ORIGIN = 3, LENGTH = 2
+  actual_a : ORIGIN = 5, LENGTH = 1
+}
+
+SECTIONS {
+  CLASS(a) { *(.a) }
+  .order :  { *(.link_order.*) } > order
+  .potential_a : { CLASS(a) } >potential_a
+  .bc : { *(.b) *(.c) } >bc
+  .actual_a : { CLASS(a) } >actual_a
+}
+
+#--- from-insert.ld
+SECTIONS {
+  CLASS(class) { *(.two_byte_section) }
+  .a : { *(.one_byte_section) }
+}
+SECTIONS { .b : { CLASS(class) } } INSERT AFTER .a;
+SECTIONS { .c : { CLASS(class) } }
+
+#--- to-insert.ld
+SECTIONS {
+  CLASS(class) { *(.two_byte_section) }
+  .a : { CLASS(class) *(.one_byte_section) }
+}
+SECTIONS { .b : { CLASS(class) } } INSERT AFTER .a;
+
+#--- from-discard.ld
+SECTIONS {
+  CLASS(class) { *(.two_byte_section) }
+  /DISCARD/ : { CLASS(class) }
+  .c : { CLASS(class) }
+}
+
+#--- to-discard.ld
+SECTIONS {
+  CLASS(class) { *(.two_byte_section) }
+  .a : { CLASS(class) }
+  /DISCARD/ : { CLASS(class) }
+}

--- a/lld/test/ELF/linkerscript/section-class.test
+++ b/lld/test/ELF/linkerscript/section-class.test
@@ -12,7 +12,7 @@
 # RUN: llvm-readobj -x .rodata -x .rodata.d matching | FileCheck %s --check-prefix=MATCHING
 
 # MATCHING:      .rodata
-# MATCHING-NEXT: 020301
+# MATCHING-NEXT: 020301cc 0605
 # MATCHING:      .rodata.d
 # MATCHING-NEXT: 04
 
@@ -32,6 +32,14 @@
 # RUN:   FileCheck %s --check-prefix=MISSING-FILENAME-PATTERN --implicit-check-not=error:
 
 # MISSING-FILENAME-PATTERN: error: missing-filename-pattern.ld:2: expected filename pattern
+
+
+## An error is reported when more than one class is mentioned in a reference.
+
+# RUN: not ld.lld -T multiple-class-names.ld matching.o 2>&1 | \
+# RUN:   FileCheck %s --check-prefix=MULTIPLE-CLASS-NAMES --implicit-check-not=error:
+
+# MULTIPLE-CLASS-NAMES: error: multiple-class-names.ld:4: ) expected, but got b
 
 
 ## An error is reported when the content of section classes is demanded before
@@ -113,6 +121,19 @@
 # SPILL-EARLIER-NEXT: .last_chance  PROGBITS 0000000000000002 001002 000001
 
 
+## Class definitions do not preclude additional matches when used with
+## --enable-non-contiguous-regions, and additional matches in class
+## definitions become spills at class references.
+
+# RUN: ld.lld -T enable-non-contiguous-regions.ld spill.o -o enable-non-contiguous-regions --enable-non-contiguous-regions
+# RUN: llvm-readelf -S enable-non-contiguous-regions | FileCheck %s --check-prefix=ENABLE-NON-CONTIGUOUS-REGIONS
+
+# ENABLE-NON-CONTIGUOUS-REGIONS:      Name          Type     Address          Off    Size
+# ENABLE-NON-CONTIGUOUS-REGIONS:      .first_chance     PROGBITS 0000000000000000 000190 000000
+# ENABLE-NON-CONTIGUOUS-REGIONS-NEXT: .last_chance      PROGBITS 0000000000000001 001001 000002
+# ENABLE-NON-CONTIGUOUS-REGIONS-NEXT: .one_byte_section PROGBITS 0000000000000003 001003 000001
+
+
 ## SHF_MERGEd sections are spilled according to the class refs of the first
 ## merged input section (the one giving the resulting section its name).
 
@@ -179,14 +200,23 @@
 .section .rodata.d,"a",@progbits
 .byte 4
 
+.section .rodata.e,"a",@progbits
+.byte 5
+
+.section .rodata.f,"a",@progbits
+.balign 2
+.byte 6
+
 #--- matching.ld
 SECTIONS {
   CLASS(a) { *(.rodata.a) }
   CLASS(cd) { *(.rodata.c) *(.rodata.d) }
+  CLASS(ef) { *(SORT_BY_ALIGNMENT(.rodata.e .rodata.f)) }
   .rodata : {
     *(.rodata.*)
     INPUT_SECTION_FLAGS(SHF_EXECINSTR) CLASS(cd)
     CLASS(a)
+    CLASS(ef)
   }
   OVERLAY : { .rodata.d { INPUT_SECTION_FLAGS(!SHF_EXECINSTR) CLASS(cd) } }
 }
@@ -200,6 +230,13 @@ SECTIONS {
 #--- missing-filename-pattern.ld
 SECTIONS {
   CLASS(a) { (.rodata.a) }
+}
+
+#--- multiple-class-names.ld
+SECTIONS {
+  CLASS(a) { *(.rodata.a) }
+  CLASS(b) { *(.rodata.b) }
+  .rodata : { CLASS(a b) }
 }
 
 #--- referenced-before-defined.ld
@@ -288,6 +325,25 @@ SECTIONS {
   CLASS(c) { *(.one_byte_section) }
   .first_chance : { CLASS(c) *(.two_byte_section) } >a
   .last_chance : { CLASS(c) } >b
+}
+
+#--- enable-non-contiguous-regions.ld
+MEMORY {
+  a : ORIGIN = 0, LENGTH = 1
+  b : ORIGIN = 1, LENGTH = 2
+  c : ORIGIN = 3, LENGTH = 1
+}
+
+SECTIONS {
+  .first_chance : { *(.two_byte_section) } >a
+  /* An additional match in a class defers a spill. */
+  CLASS(two) { *(.two_byte_section) }
+  /* A class references actualizes deferred spills. */
+  .last_chance : { CLASS(two) } >b
+
+  /* Section classes do not preclude other matches. */
+  CLASS(one) { *(.one_byte_section) }
+  .one_byte_section : { *(.one_byte_section) } >c
 }
 
 #--- merge.s

--- a/lld/test/ELF/linkerscript/section-class.test
+++ b/lld/test/ELF/linkerscript/section-class.test
@@ -9,9 +9,12 @@
 ## references may be restricted by INPUT_SECTION_FLAGS.
 
 # RUN: ld.lld -T matching.ld matching.o -o matching
-# RUN: llvm-readobj -x .rodata matching | FileCheck %s --check-prefix=MATCHING
+# RUN: llvm-readobj -x .rodata -x .rodata.d matching | FileCheck %s --check-prefix=MATCHING
 
-# MATCHING: 02030104
+# MATCHING:      .rodata
+# MATCHING-NEXT: 020301
+# MATCHING:      .rodata.d
+# MATCHING-NEXT: 04
 
 
 ## An error is reported when a section class has more than one description.
@@ -32,13 +35,12 @@
 
 
 ## An error is reported when the content of section classes is demanded before
-## input sections have been assigned to them.
+## its definition is processed.
 
-# RUN: not ld.lld -T used-before-assigned.ld matching.o 2>&1 | \
-# RUN:   FileCheck %s --check-prefix=USED-BEFORE-ASSIGNED
+# RUN: not ld.lld -T referenced-before-defined.ld matching.o 2>&1 | \
+# RUN:   FileCheck %s --check-prefix=REFERENCED-BEFORE-DEFINED
 
-# USED-BEFORE-ASSIGNED: error: section class 'a' used before assigned
-
+# REFERENCED-BEFORE-DEFINED: error: section class 'a' referenced by '.rodata' before class definition
 
 ## An error is reported when an input section is bound to a section class but
 ## is not referenced by at least one output section.
@@ -46,7 +48,7 @@
 # RUN: not ld.lld -T unreferenced.ld matching.o 2>&1 | \
 # RUN:   FileCheck %s --check-prefix=UNREFERENCED
 
-# UNREFERENCED: error: section '.rodata.a' assigned to class 'a' but to no output section
+# UNREFERENCED: error: section '.rodata.a' assigned to class 'a' but unreferenced by any output section
 
 
 ## An error is reported when one section class references another.
@@ -178,10 +180,6 @@
 .byte 4
 
 #--- matching.ld
-MEMORY {
- m : ORIGIN = 0, LENGTH = 4
-}
-
 SECTIONS {
   CLASS(a) { *(.rodata.a) }
   CLASS(cd) { *(.rodata.c) *(.rodata.d) }
@@ -189,8 +187,8 @@ SECTIONS {
     *(.rodata.*)
     INPUT_SECTION_FLAGS(SHF_EXECINSTR) CLASS(cd)
     CLASS(a)
-    CLASS(cd)
-  } >m
+  }
+  OVERLAY : { .rodata.d { INPUT_SECTION_FLAGS(!SHF_EXECINSTR) CLASS(cd) } }
 }
 
 #--- already-defined.ld
@@ -204,7 +202,7 @@ SECTIONS {
   CLASS(a) { (.rodata.a) }
 }
 
-#--- used-before-assigned.ld
+#--- referenced-before-defined.ld
 SECTIONS {
   .rodata : { CLASS(a) }
   CLASS(a) { *(.rodata.a) }

--- a/lld/test/ELF/linkerscript/section-class.test
+++ b/lld/test/ELF/linkerscript/section-class.test
@@ -32,7 +32,7 @@
 
 #--- matching.lds
 ## CLASS definitions match sections in linker script order. The sections may be
-## placed in a different order. Classes may derive from one another. Class # #
+## placed in a different order. Classes may derive from one another. Class
 ## references can be restricted by INPUT_SECTION_FLAGS. Classes can be referenced
 ## in /DISCARD/ and INSERT.
 SECTIONS {
@@ -40,30 +40,29 @@ SECTIONS {
   CLASS(cd) { *(.rodata.c) *(.rodata.d) }
   CLASS(ef) { *(SORT_BY_ALIGNMENT(.rodata.e .rodata.f)) }
   CLASS(g) { *(.rodata.g) }
-  CLASS(h) { *(.rodata.h) }
+  CLASS("h)") { *(.rodata.h) }
   .rodata : {
     *(.rodata.*)
     INPUT_SECTION_FLAGS(SHF_EXECINSTR) CLASS( cd)
-    CLASS(a)
-    CLASS(ef )
+    CLASS(a)CLASS(ef )
   }
   OVERLAY : { .rodata.d { INPUT_SECTION_FLAGS(!SHF_EXECINSTR) CLASS(cd) } }
   /DISCARD/ : { CLASS(g) }
 }
 
 SECTIONS {
-  .rodata.h : { CLASS(h) }
+  .rodata.h : { CLASS("h)") }
 } INSERT AFTER .rodata;
 
 # RUN: ld.lld -T matching.lds matching.o -o matching
-# RUN: llvm-readobj -x .rodata -x .rodata.d -x .rodata.h matching |\
+# RUN: llvm-objdump -s matching |\
 # RUN:   FileCheck %s --check-prefix=MATCHING
 # MATCHING:      .rodata
-# MATCHING-NEXT: 020301cc 0605
+# MATCHING-NEXT: 020301cc 0605 ......{{$}}
 # MATCHING:      .rodata.h
-# MATCHING-NEXT: 08
+# MATCHING-NEXT: 08 .{{$}}
 # MATCHING:      .rodata.d
-# MATCHING-NEXT: 04
+# MATCHING-NEXT: 04 .{{$}}
 
 #--- already-defined.lds
 ## A section class has more than one description.
@@ -79,16 +78,23 @@ SECTIONS {
 
 # ALREADY-DEFINED: error: already-defined.lds:4: section class 'a' already defined
 
-#--- missing-filename-pattern.lds
+#--- missing-filename-pattern-1.lds
 ## A filename pattern is missing in a section class description.
 SECTIONS {
   CLASS(a) { (.rodata.a) }
 }
+#--- missing-filename-pattern-2.lds
+## A filename pattern is missing in a section class description.
+SECTIONS {
+  CLASS(a) { .rodata.a) }
+}
 
-# RUN: not ld.lld -T missing-filename-pattern.lds matching.o 2>&1 | \
+# RUN: not ld.lld -T missing-filename-pattern-1.lds matching.o 2>&1 | \
+# RUN:   FileCheck %s --check-prefix=MISSING-FILENAME-PATTERN --implicit-check-not=error:
+# RUN: not ld.lld -T missing-filename-pattern-2.lds matching.o 2>&1 | \
 # RUN:   FileCheck %s --check-prefix=MISSING-FILENAME-PATTERN --implicit-check-not=error:
 
-# MISSING-FILENAME-PATTERN: error: missing-filename-pattern.lds:3: expected filename pattern
+# MISSING-FILENAME-PATTERN: error: missing-filename-pattern-{{[1-2]}}.lds:3: expected filename pattern
 
 #--- multiple-class-names.lds
 ## More than one class is mentioned in a reference.
@@ -102,6 +108,17 @@ SECTIONS {
 # RUN:   FileCheck %s --check-prefix=MULTIPLE-CLASS-NAMES --implicit-check-not=error:
 
 # MULTIPLE-CLASS-NAMES: error: multiple-class-names.lds:5: ) expected, but got b
+
+#--- undefined.lds
+## A section class is referenced but never defined
+SECTIONS {
+  .rodata : { CLASS(a) }
+}
+
+# RUN: not ld.lld -T undefined.lds matching.o 2>&1 | \
+# RUN:   FileCheck %s --check-prefix=UNDEFINED --implicit-check-not=error:
+
+# UNDEFINED: error: undefined section class 'a'
 
 #--- referenced-before-defined.lds
 ## The content of section classes is demanded before its definition is processed.
@@ -119,8 +136,7 @@ SECTIONS {
 # REFERENCED-BEFORE-DEFINED-WARN: warning: section class 'a' referenced by '.rodata' before class definition
 
 #--- unreferenced.lds
-## An input section is bound to a section class but is not referenced by at
-## least one output section.
+## An input section is bound to a section class but is not referenced.
 SECTIONS {
   CLASS(a) { *(.rodata.*) }
 }
@@ -362,9 +378,9 @@ SECTIONS {
 }
 
 # RUN: ld.lld -T link-order.lds link-order.o -o link-order
-# RUN: llvm-readobj -x .order link-order | FileCheck %s --check-prefix=LINK-ORDER
+# RUN: llvm-objdump -s link-order | FileCheck %s --check-prefix=LINK-ORDER
 
-# LINK-ORDER: 020301
+# LINK-ORDER: 020301 ...{{$}}
 
 #--- from-insert.lds
 ## A section might spill from INSERT.

--- a/lld/test/ELF/linkerscript/section-class.test
+++ b/lld/test/ELF/linkerscript/section-class.test
@@ -142,12 +142,12 @@ SECTIONS {
 }
 
 # RUN: not ld.lld -T unreferenced.lds matching.o 2>&1 | \
-# RUN:   FileCheck %s --check-prefix=UNREFERENCED
+# RUN:   FileCheck %s --check-prefix=UNREFERENCED -implicit-check-not=error:
 # RUN: ld.lld -T unreferenced.lds matching.o -o out --noinhibit-exec 2>&1 | \
-# RUN:   FileCheck %s --check-prefix=UNREFERENCED-WARN
+# RUN:   FileCheck %s --check-prefix=UNREFERENCED-WARN -implicit-check-not=error:
 
-# UNREFERENCED: error: section '.rodata.a' assigned to class 'a' but unreferenced by any output section
-# UNREFERENCED-WARN: warning: section '.rodata.a' assigned to class 'a' but unreferenced by any output section
+# UNREFERENCED: error: section class 'a' is unreferenced
+# UNREFERENCED-WARN: warning: section class 'a' is unreferenced
 
 #--- class-references-class.lds
 ## One section class references another.

--- a/lld/test/ELF/linkerscript/section-class.test
+++ b/lld/test/ELF/linkerscript/section-class.test
@@ -2,191 +2,6 @@
 
 # RUN: rm -rf %t && split-file %s %t && cd %t
 
-# RUN: llvm-mc -n -filetype=obj -triple=x86_64 matching.s -o matching.o
-
-## CLASS definitions match sections in linker script order. The sections may be
-## placed in a different order. Classes may derive from one another, and class
-## references may be restricted by INPUT_SECTION_FLAGS.
-
-# RUN: ld.lld -T matching.ld matching.o -o matching
-# RUN: llvm-readobj -x .rodata -x .rodata.d matching | FileCheck %s --check-prefix=MATCHING
-
-# MATCHING:      .rodata
-# MATCHING-NEXT: 020301cc 0605
-# MATCHING:      .rodata.d
-# MATCHING-NEXT: 04
-
-
-## An error is reported when a section class has more than one description.
-
-# RUN: not ld.lld -T already-defined.ld matching.o 2>&1 | \
-# RUN:   FileCheck %s --check-prefix=ALREADY-DEFINED --implicit-check-not=error:
-
-# ALREADY-DEFINED: error: already-defined.ld:3: section class 'a' already defined
-
-
-## An error is reported when a filename pattern is missing in a section class
-## description.
-
-# RUN: not ld.lld -T missing-filename-pattern.ld matching.o 2>&1 | \
-# RUN:   FileCheck %s --check-prefix=MISSING-FILENAME-PATTERN --implicit-check-not=error:
-
-# MISSING-FILENAME-PATTERN: error: missing-filename-pattern.ld:2: expected filename pattern
-
-
-## An error is reported when more than one class is mentioned in a reference.
-
-# RUN: not ld.lld -T multiple-class-names.ld matching.o 2>&1 | \
-# RUN:   FileCheck %s --check-prefix=MULTIPLE-CLASS-NAMES --implicit-check-not=error:
-
-# MULTIPLE-CLASS-NAMES: error: multiple-class-names.ld:4: ) expected, but got b
-
-
-## An error is reported when the content of section classes is demanded before
-## its definition is processed.
-
-# RUN: not ld.lld -T referenced-before-defined.ld matching.o 2>&1 | \
-# RUN:   FileCheck %s --check-prefix=REFERENCED-BEFORE-DEFINED
-
-# REFERENCED-BEFORE-DEFINED: error: section class 'a' referenced by '.rodata' before class definition
-
-## An error is reported when an input section is bound to a section class but
-## is not referenced by at least one output section.
-
-# RUN: not ld.lld -T unreferenced.ld matching.o 2>&1 | \
-# RUN:   FileCheck %s --check-prefix=UNREFERENCED
-
-# UNREFERENCED: error: section '.rodata.a' assigned to class 'a' but unreferenced by any output section
-
-
-## An error is reported when one section class references another.
-
-# RUN: not ld.lld -T class-references-class.ld matching.o 2>&1 | \
-# RUN:   FileCheck %s --check-prefix=CLASS-REFERENCES-CLASS --implicit-check-not=error:
-
-# CLASS-REFERENCES-CLASS: error: class-references-class.ld:3: section class 'b' references class 'a'
-
-
-# RUN: llvm-mc -n -filetype=obj -triple=x86_64 spill.s -o spill.o
-
-
-## An input section in a class spills to a later class ref when the region of
-## its first ref would overflow. The spill uses the alignment of the later ref.
-
-# RUN: ld.lld -T spill.ld spill.o -o spill
-# RUN: llvm-readelf -S spill | FileCheck %s --check-prefix=SPILL
-
-# SPILL:      Name          Type     Address          Off    Size
-# SPILL:      .first_chance PROGBITS 0000000000000000 001000 000001
-# SPILL-NEXT: .last_chance  PROGBITS 0000000000000008 001008 000002
-
-
-## A spill off the end still fails the link.
-
-# RUN: not ld.lld -T spill-fail.ld spill.o 2>&1 |\
-# RUN:   FileCheck %s --check-prefix=SPILL-FAIL --implicit-check-not=error:
-
-# SPILL-FAIL: error: section '.last_chance' will not fit in region 'b': overflowed by 2 bytes
-
-
-## The above spill still occurs when the LMA would overflow, even though the
-## VMA would fit.
-
-# RUN: ld.lld -T spill-lma.ld spill.o -o spill-lma
-# RUN: llvm-readelf -S spill-lma | FileCheck %s --check-prefix=SPILL-LMA
-
-# SPILL-LMA:      Name          Type     Address          Off    Size
-# SPILL-LMA:      .first_chance PROGBITS 0000000000000000 001000 000001
-# SPILL-LMA-NEXT: .last_chance  PROGBITS 0000000000000003 001003 000002
-
-
-## A spill occurs to an additional class ref after the first.
-
-# RUN: ld.lld -T spill-later.ld spill.o -o spill-later
-# RUN: llvm-readelf -S spill-later | FileCheck %s --check-prefix=SPILL-LATER
-
-# SPILL-LATER:      Name            Type     Address          Off    Size
-# SPILL-LATER:      .first_chance   PROGBITS 0000000000000000 001000 000001
-# SPILL-LATER-NEXT: .second_chance  PROGBITS 0000000000000002 001001 000000
-# SPILL-LATER-NEXT: .last_chance    PROGBITS 0000000000000003 001003 000002
-
-
-## A later overflow causes an earlier section to spill.
-
-# RUN: ld.lld -T spill-earlier.ld spill.o -o spill-earlier
-# RUN: llvm-readelf -S spill-earlier | FileCheck %s --check-prefix=SPILL-EARLIER
-
-# SPILL-EARLIER:      Name          Type     Address          Off    Size
-# SPILL-EARLIER:      .first_chance PROGBITS 0000000000000000 001000 000002
-# SPILL-EARLIER-NEXT: .last_chance  PROGBITS 0000000000000002 001002 000001
-
-
-## Class definitions do not preclude additional matches when used with
-## --enable-non-contiguous-regions, and additional matches in class
-## definitions become spills at class references.
-
-# RUN: ld.lld -T enable-non-contiguous-regions.ld spill.o -o enable-non-contiguous-regions --enable-non-contiguous-regions
-# RUN: llvm-readelf -S enable-non-contiguous-regions | FileCheck %s --check-prefix=ENABLE-NON-CONTIGUOUS-REGIONS
-
-# ENABLE-NON-CONTIGUOUS-REGIONS:      Name          Type     Address          Off    Size
-# ENABLE-NON-CONTIGUOUS-REGIONS:      .first_chance     PROGBITS 0000000000000000 000190 000000
-# ENABLE-NON-CONTIGUOUS-REGIONS-NEXT: .last_chance      PROGBITS 0000000000000001 001001 000002
-# ENABLE-NON-CONTIGUOUS-REGIONS-NEXT: .one_byte_section PROGBITS 0000000000000003 001003 000001
-
-
-## SHF_MERGEd sections are spilled according to the class refs of the first
-## merged input section (the one giving the resulting section its name).
-
-# RUN: llvm-mc -n -filetype=obj -triple=x86_64 merge.s -o merge.o
-# RUN: ld.lld -T spill-merge.ld merge.o -o spill-merge
-# RUN: llvm-readelf -S spill-merge | FileCheck %s --check-prefix=SPILL-MERGE
-
-# SPILL-MERGE:      Name          Type     Address          Off    Size
-# SPILL-MERGE:      .first  PROGBITS 0000000000000000 000190 000000
-# SPILL-MERGE-NEXT: .second PROGBITS 0000000000000001 001001 000002
-# SPILL-MERGE-NEXT: .third  PROGBITS 0000000000000003 001003 000000
-
-
-## SHF_LINK_ORDER is reordered when spilling changes relative section order.
-
-# RUN: llvm-mc -n -filetype=obj -triple=x86_64 link-order.s -o link-order.o
-# RUN: ld.lld -T link-order.ld link-order.o -o link-order
-# RUN: llvm-readobj -x .order link-order | FileCheck %s --check-prefix=LINK-ORDER
-
-# LINK-ORDER: 020301
-
-
-## An error is reported when a section might spill from INSERT.
-
-# RUN: not ld.lld -T from-insert.ld spill.o 2>&1 |\
-# RUN:   FileCheck %s --check-prefix=FROM-INSERT
-
-# FROM-INSERT: error: section '.two_byte_section' cannot spill from/to INSERT section '.b'
-
-
-## An error is reported when a section might spill to INSERT.
-
-# RUN: not ld.lld -T to-insert.ld spill.o 2>&1 |\
-# RUN:   FileCheck %s --check-prefix=TO-INSERT
-
-# TO-INSERT: error: section '.two_byte_section' cannot spill from/to INSERT section '.b'
-
-
-## An error is reported when a section might spill from /DISCARD/.
-
-# RUN: not ld.lld -T from-discard.ld spill.o 2>&1 |\
-# RUN:   FileCheck %s --check-prefix=FROM-DISCARD
-
-# FROM-DISCARD: error: section '.two_byte_section' cannot spill from/to /DISCARD/
-
-
-## An error is reported when a section might spill to /DISCARD/.
-
-# RUN: not ld.lld -T to-discard.ld spill.o 2>&1 |\
-# RUN:   FileCheck %s --check-prefix=TO-DISCARD
-
-# TO-DISCARD: error: section '.two_byte_section' cannot spill from/to /DISCARD/
-
 #--- matching.s
 .section .rodata.a,"a",@progbits
 .byte 1
@@ -207,11 +22,25 @@
 .balign 2
 .byte 6
 
-#--- matching.ld
+.section .rodata.g,"a",@progbits
+.byte 7
+
+.section .rodata.h,"a",@progbits
+.byte 8
+
+# RUN: llvm-mc -n -filetype=obj -triple=x86_64 matching.s -o matching.o
+
+#--- matching.lds
+## CLASS definitions match sections in linker script order. The sections may be
+## placed in a different order. Classes may derive from one another. Class # #
+## references can be restricted by INPUT_SECTION_FLAGS. Classes can be referenced
+## in /DISCARD/ and INSERT.
 SECTIONS {
   CLASS(a) { *(.rodata.a) }
   CLASS(cd) { *(.rodata.c) *(.rodata.d) }
   CLASS(ef) { *(SORT_BY_ALIGNMENT(.rodata.e .rodata.f)) }
+  CLASS(g) { *(.rodata.g) }
+  CLASS(h) { *(.rodata.h) }
   .rodata : {
     *(.rodata.*)
     INPUT_SECTION_FLAGS(SHF_EXECINSTR) CLASS(cd)
@@ -219,42 +48,102 @@ SECTIONS {
     CLASS(ef)
   }
   OVERLAY : { .rodata.d { INPUT_SECTION_FLAGS(!SHF_EXECINSTR) CLASS(cd) } }
+  /DISCARD/ : { CLASS(g) }
 }
 
-#--- already-defined.ld
+SECTIONS {
+  .rodata.h : { CLASS(h) }
+} INSERT AFTER .rodata;
+
+# RUN: ld.lld -T matching.lds matching.o -o matching
+# RUN: llvm-readobj -x .rodata -x .rodata.d -x .rodata.h matching |\
+# RUN:   FileCheck %s --check-prefix=MATCHING
+# MATCHING:      .rodata
+# MATCHING-NEXT: 020301cc 0605
+# MATCHING:      .rodata.h
+# MATCHING-NEXT: 08
+# MATCHING:      .rodata.d
+# MATCHING-NEXT: 04
+
+#--- already-defined.lds
+## A section class has more than one description.
 SECTIONS {
   CLASS(a) { *(.rodata.a) }
   CLASS(a) { *(.rodata.b) }
+  CLASS(b) { *(.rodata.c) }
+  CLASS(b) { *(.rodata.d) }
 }
 
-#--- missing-filename-pattern.ld
+# RUN: not ld.lld -T already-defined.lds matching.o 2>&1 | \
+# RUN:   FileCheck %s --check-prefix=ALREADY-DEFINED --implicit-check-not=error:
+
+# ALREADY-DEFINED: error: already-defined.lds:4: section class 'a' already defined
+
+#--- missing-filename-pattern.lds
+## A filename pattern is missing in a section class description.
 SECTIONS {
   CLASS(a) { (.rodata.a) }
 }
 
-#--- multiple-class-names.ld
+# RUN: not ld.lld -T missing-filename-pattern.lds matching.o 2>&1 | \
+# RUN:   FileCheck %s --check-prefix=MISSING-FILENAME-PATTERN --implicit-check-not=error:
+
+# MISSING-FILENAME-PATTERN: error: missing-filename-pattern.lds:3: expected filename pattern
+
+#--- multiple-class-names.lds
+## More than one class is mentioned in a reference.
 SECTIONS {
   CLASS(a) { *(.rodata.a) }
   CLASS(b) { *(.rodata.b) }
   .rodata : { CLASS(a b) }
 }
 
-#--- referenced-before-defined.ld
+# RUN: not ld.lld -T multiple-class-names.lds matching.o 2>&1 | \
+# RUN:   FileCheck %s --check-prefix=MULTIPLE-CLASS-NAMES --implicit-check-not=error:
+
+# MULTIPLE-CLASS-NAMES: error: multiple-class-names.lds:5: ) expected, but got b
+
+#--- referenced-before-defined.lds
+## The content of section classes is demanded before its definition is processed.
 SECTIONS {
   .rodata : { CLASS(a) }
   CLASS(a) { *(.rodata.a) }
 }
 
-#--- unreferenced.ld
+# RUN: not ld.lld -T referenced-before-defined.lds matching.o 2>&1 | \
+# RUN:   FileCheck %s --check-prefix=REFERENCED-BEFORE-DEFINED
+# RUN: ld.lld -T referenced-before-defined.lds matching.o -o out --noinhibit-exec 2>&1 | \
+# RUN:   FileCheck %s --check-prefix=REFERENCED-BEFORE-DEFINED-WARN
+
+# REFERENCED-BEFORE-DEFINED: error: section class 'a' referenced by '.rodata' before class definition
+# REFERENCED-BEFORE-DEFINED-WARN: warning: section class 'a' referenced by '.rodata' before class definition
+
+#--- unreferenced.lds
+## An input section is bound to a section class but is not referenced by at
+## least one output section.
 SECTIONS {
   CLASS(a) { *(.rodata.*) }
 }
 
-#--- class-references-class.ld
+# RUN: not ld.lld -T unreferenced.lds matching.o 2>&1 | \
+# RUN:   FileCheck %s --check-prefix=UNREFERENCED
+# RUN: ld.lld -T unreferenced.lds matching.o -o out --noinhibit-exec 2>&1 | \
+# RUN:   FileCheck %s --check-prefix=UNREFERENCED-WARN
+
+# UNREFERENCED: error: section '.rodata.a' assigned to class 'a' but unreferenced by any output section
+# UNREFERENCED-WARN: warning: section '.rodata.a' assigned to class 'a' but unreferenced by any output section
+
+#--- class-references-class.lds
+## One section class references another.
 SECTIONS {
   CLASS(a) { *(.rodata.a) }
   CLASS(b) { CLASS(a) }
 }
+
+# RUN: not ld.lld -T class-references-class.lds matching.o 2>&1 | \
+# RUN:   FileCheck %s --check-prefix=CLASS-REFERENCES-CLASS --implicit-check-not=error:
+
+# CLASS-REFERENCES-CLASS: error: class-references-class.lds:4: section class 'b' references class 'a'
 
 #--- spill.s
 .section .one_byte_section,"a",@progbits
@@ -263,7 +152,11 @@ SECTIONS {
 .section .two_byte_section,"a",@progbits
 .fill 2
 
-#--- spill.ld
+# RUN: llvm-mc -n -filetype=obj -triple=x86_64 spill.s -o spill.o
+
+#--- spill.lds
+## An input section in a class spills to a later class ref when the region of
+## its first ref would overflow. The spill uses the alignment of the later ref.
 MEMORY {
   a : ORIGIN = 0, LENGTH = 2
   b : ORIGIN = 2, LENGTH = 16
@@ -275,7 +168,15 @@ SECTIONS {
   .last_chance : SUBALIGN(8) { CLASS (c) } >b
 }
 
-#--- spill-fail.ld
+# RUN: ld.lld -T spill.lds spill.o -o spill
+# RUN: llvm-readelf -S spill | FileCheck %s --check-prefix=SPILL
+
+# SPILL:      Name          Type     Address          Off    Size
+# SPILL:      .first_chance PROGBITS 0000000000000000 001000 000001
+# SPILL-NEXT: .last_chance  PROGBITS 0000000000000008 001008 000002
+
+#--- spill-fail.lds
+## A spill off the end still fails the link.
 MEMORY {
   a : ORIGIN = 0, LENGTH = 1
   b : ORIGIN = 2, LENGTH = 0
@@ -287,7 +188,14 @@ SECTIONS {
   .last_chance : { CLASS(c) } >b
 }
 
-#--- spill-lma.ld
+# RUN: not ld.lld -T spill-fail.lds spill.o 2>&1 |\
+# RUN:   FileCheck %s --check-prefix=SPILL-FAIL --implicit-check-not=error:
+
+# SPILL-FAIL: error: section '.last_chance' will not fit in region 'b': overflowed by 2 bytes
+
+#--- spill-lma.lds
+## The above spill still occurs when the LMA would overflow, even though the
+## VMA would fit.
 MEMORY {
   vma_a : ORIGIN = 0, LENGTH = 3
   vma_b : ORIGIN = 3, LENGTH = 3
@@ -301,7 +209,15 @@ SECTIONS {
   .last_chance : { CLASS(c) } >vma_b AT>lma_b
 }
 
-#--- spill-later.ld
+# RUN: ld.lld -T spill-lma.lds spill.o -o spill-lma
+# RUN: llvm-readelf -S spill-lma | FileCheck %s --check-prefix=SPILL-LMA
+
+# SPILL-LMA:      Name          Type     Address          Off    Size
+# SPILL-LMA:      .first_chance PROGBITS 0000000000000000 001000 000001
+# SPILL-LMA-NEXT: .last_chance  PROGBITS 0000000000000003 001003 000002
+
+#--- spill-later.lds
+## A spill occurs to an additional class ref after the first.
 MEMORY {
   a : ORIGIN = 0, LENGTH = 2
   b : ORIGIN = 2, LENGTH = 1
@@ -315,7 +231,16 @@ SECTIONS {
   .last_chance : { CLASS(c) } >c
 }
 
-#--- spill-earlier.ld
+# RUN: ld.lld -T spill-later.lds spill.o -o spill-later
+# RUN: llvm-readelf -S spill-later | FileCheck %s --check-prefix=SPILL-LATER
+
+# SPILL-LATER:      Name            Type     Address          Off    Size
+# SPILL-LATER:      .first_chance   PROGBITS 0000000000000000 001000 000001
+# SPILL-LATER-NEXT: .second_chance  PROGBITS 0000000000000002 001001 000000
+# SPILL-LATER-NEXT: .last_chance    PROGBITS 0000000000000003 001003 000002
+
+#--- spill-earlier.lds
+## A later overflow causes an earlier section to spill.
 MEMORY {
   a : ORIGIN = 0, LENGTH = 2
   b : ORIGIN = 2, LENGTH = 1
@@ -327,7 +252,17 @@ SECTIONS {
   .last_chance : { CLASS(c) } >b
 }
 
-#--- enable-non-contiguous-regions.ld
+# RUN: ld.lld -T spill-earlier.lds spill.o -o spill-earlier
+# RUN: llvm-readelf -S spill-earlier | FileCheck %s --check-prefix=SPILL-EARLIER
+
+# SPILL-EARLIER:      Name          Type     Address          Off    Size
+# SPILL-EARLIER:      .first_chance PROGBITS 0000000000000000 001000 000002
+# SPILL-EARLIER-NEXT: .last_chance  PROGBITS 0000000000000002 001002 000001
+
+#--- enable-non-contiguous-regions.lds
+## Class definitions do not preclude additional matches when used with
+## --enable-non-contiguous-regions, and additional matches in class
+## definitions become spills at class references.
 MEMORY {
   a : ORIGIN = 0, LENGTH = 1
   b : ORIGIN = 1, LENGTH = 2
@@ -346,6 +281,14 @@ SECTIONS {
   .one_byte_section : { *(.one_byte_section) } >c
 }
 
+# RUN: ld.lld -T enable-non-contiguous-regions.lds spill.o -o enable-non-contiguous-regions --enable-non-contiguous-regions
+# RUN: llvm-readelf -S enable-non-contiguous-regions | FileCheck %s --check-prefix=ENABLE-NON-CONTIGUOUS-REGIONS
+
+# ENABLE-NON-CONTIGUOUS-REGIONS:      Name          Type     Address          Off    Size
+# ENABLE-NON-CONTIGUOUS-REGIONS:      .first_chance     PROGBITS 0000000000000000 000190 000000
+# ENABLE-NON-CONTIGUOUS-REGIONS-NEXT: .last_chance      PROGBITS 0000000000000001 001001 000002
+# ENABLE-NON-CONTIGUOUS-REGIONS-NEXT: .one_byte_section PROGBITS 0000000000000003 001003 000001
+
 #--- merge.s
 .section .a,"aM",@progbits,1
 .byte 0x12, 0x34
@@ -353,7 +296,11 @@ SECTIONS {
 .section .b,"aM",@progbits,1
 .byte 0x12
 
-#--- spill-merge.ld
+# RUN: llvm-mc -n -filetype=obj -triple=x86_64 merge.s -o merge.o
+
+#--- spill-merge.lds
+## SHF_MERGE sections are spilled according to the class refs of the first
+## merged input section (the one giving the resulting section its name).
 MEMORY {
   a : ORIGIN = 0, LENGTH = 1
   b : ORIGIN = 1, LENGTH = 2
@@ -367,6 +314,14 @@ SECTIONS {
   .second : { CLASS(a) } >b
   .third : { CLASS(b) } >c
 }
+
+# RUN: ld.lld -T spill-merge.lds merge.o -o spill-merge
+# RUN: llvm-readelf -S spill-merge | FileCheck %s --check-prefix=SPILL-MERGE
+
+# SPILL-MERGE:      Name          Type     Address          Off    Size
+# SPILL-MERGE:      .first  PROGBITS 0000000000000000 000190 000000
+# SPILL-MERGE-NEXT: .second PROGBITS 0000000000000001 001001 000002
+# SPILL-MERGE-NEXT: .third  PROGBITS 0000000000000003 001003 000000
 
 #--- link-order.s
 .section .a,"a",@progbits
@@ -387,7 +342,10 @@ SECTIONS {
 .section .link_order.c,"ao",@progbits,.c
 .byte 3
 
-#--- link-order.ld
+# RUN: llvm-mc -n -filetype=obj -triple=x86_64 link-order.s -o link-order.o
+
+#--- link-order.lds
+## SHF_LINK_ORDER is reordered when spilling changes relative section order.
 MEMORY {
   order : ORIGIN = 0, LENGTH = 3
   potential_a : ORIGIN = 3, LENGTH = 0
@@ -403,7 +361,13 @@ SECTIONS {
   .actual_a : { CLASS(a) } >actual_a
 }
 
-#--- from-insert.ld
+# RUN: ld.lld -T link-order.lds link-order.o -o link-order
+# RUN: llvm-readobj -x .order link-order | FileCheck %s --check-prefix=LINK-ORDER
+
+# LINK-ORDER: 020301
+
+#--- from-insert.lds
+## A section might spill from INSERT.
 SECTIONS {
   CLASS(class) { *(.two_byte_section) }
   .a : { *(.one_byte_section) }
@@ -411,23 +375,58 @@ SECTIONS {
 SECTIONS { .b : { CLASS(class) } } INSERT AFTER .a;
 SECTIONS { .c : { CLASS(class) } }
 
-#--- to-insert.ld
+# RUN: not ld.lld -T from-insert.lds spill.o 2>&1 |\
+# RUN:   FileCheck %s --check-prefix=FROM-INSERT
+# RUN: ld.lld -T from-insert.lds spill.o -o out --noinhibit-exec 2>&1 |\
+# RUN:   FileCheck %s --check-prefix=FROM-INSERT-WARN
+
+# FROM-INSERT: error: section '.two_byte_section' cannot spill from/to INSERT section '.b'
+# FROM-INSERT-WARN: warning: section '.two_byte_section' cannot spill from/to INSERT section '.b'
+
+#--- to-insert.lds
+## A section might spill to INSERT.
 SECTIONS {
   CLASS(class) { *(.two_byte_section) }
   .a : { CLASS(class) *(.one_byte_section) }
 }
 SECTIONS { .b : { CLASS(class) } } INSERT AFTER .a;
 
-#--- from-discard.ld
+# RUN: not ld.lld -T to-insert.lds spill.o 2>&1 |\
+# RUN:   FileCheck %s --check-prefix=TO-INSERT
+# RUN:  ld.lld -T to-insert.lds spill.o -o out --noinhibit-exec 2>&1 |\
+# RUN:   FileCheck %s --check-prefix=TO-INSERT-WARN
+
+# TO-INSERT: error: section '.two_byte_section' cannot spill from/to INSERT section '.b'
+# TO-INSERT-WARN: warning: section '.two_byte_section' cannot spill from/to INSERT section '.b'
+
+#--- from-discard.lds
+## A section might spill from /DISCARD/.
 SECTIONS {
   CLASS(class) { *(.two_byte_section) }
   /DISCARD/ : { CLASS(class) }
   .c : { CLASS(class) }
 }
 
-#--- to-discard.ld
+# RUN: not ld.lld -T from-discard.lds spill.o 2>&1 |\
+# RUN:   FileCheck %s --check-prefix=FROM-DISCARD
+# RUN: ld.lld -T from-discard.lds spill.o -o out --noinhibit-exec 2>&1 |\
+# RUN:   FileCheck %s --check-prefix=FROM-DISCARD-WARN
+
+# FROM-DISCARD: error: section '.two_byte_section' cannot spill from/to /DISCARD/
+# FROM-DISCARD-WARN: warning: section '.two_byte_section' cannot spill from/to /DISCARD/
+
+#--- to-discard.lds
+## A section might spill to /DISCARD/.
 SECTIONS {
   CLASS(class) { *(.two_byte_section) }
   .a : { CLASS(class) }
   /DISCARD/ : { CLASS(class) }
 }
+
+# RUN: not ld.lld -T to-discard.lds spill.o 2>&1 |\
+# RUN:   FileCheck %s --check-prefix=TO-DISCARD
+# RUN: ld.lld -T to-discard.lds spill.o -o out --noinhibit-exec 2>&1 |\
+# RUN:   FileCheck %s --check-prefix=TO-DISCARD-WARN
+
+# TO-DISCARD: error: section '.two_byte_section' cannot spill from/to /DISCARD/
+# TO-DISCARD-WARN: warning: section '.two_byte_section' cannot spill from/to /DISCARD/

--- a/lld/test/ELF/linkerscript/section-class.test
+++ b/lld/test/ELF/linkerscript/section-class.test
@@ -43,9 +43,9 @@ SECTIONS {
   CLASS(h) { *(.rodata.h) }
   .rodata : {
     *(.rodata.*)
-    INPUT_SECTION_FLAGS(SHF_EXECINSTR) CLASS(cd)
+    INPUT_SECTION_FLAGS(SHF_EXECINSTR) CLASS( cd)
     CLASS(a)
-    CLASS(ef)
+    CLASS(ef )
   }
   OVERLAY : { .rodata.d { INPUT_SECTION_FLAGS(!SHF_EXECINSTR) CLASS(cd) } }
   /DISCARD/ : { CLASS(g) }


### PR DESCRIPTION
This allows the input section matching algorithm to be separated from output section descriptions. This allows a group of sections to be assigned to multiple output sections, providing an explicit version of --enable-non-contiguous-regions's spilling that doesn't require altering global linker script matching behavior with a flag. It also makes the linker script language more expressive even if spilling is not intended, since input section matching can be done in a different order than sections are placed in an output section.

The implementation reuses the backend mechanism provided by --enable-non-contiguous-regions, so it has roughly similar semantics and limitations. In particular, sections cannot be spilled into or out of INSERT, OVERWRITE_SECTIONS, or /DISCARD/. The former two aren't intrinsic, so it may be possible to relax those restrictions later.