### PR TITLE
[bazel] Implement tblgen as a bazel rule

### DIFF
--- a/utils/bazel/llvm-project-overlay/llvm/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/llvm/BUILD.bazel
@@ -2343,11 +2343,11 @@ gentbl(
         tblgen = ":llvm-tblgen",
         # MSVC isn't happy with long string literals, while other compilers
         # which support them get significant compile time improvements with
-        # them enabled. Ideally this flag would only be enabled on Windows via
-        # a select() on `@platforms//os:windows,`, but that would
-        # require refactoring gentbl from a macro into a rule.
-        # TODO(#92): Refactor gentbl to support this use
-        tblgen_args = "--long-string-literals=0",
+        # them enabled.
+        tblgen_args = select({
+            "@platforms//os:windows": "--long-string-literals=0",
+            "//conditions:default": "",
+        }),
         td_file = "lib/Target/" + target["name"] + "/" + target["short_name"] + ".td",
         td_srcs = [
             ":common_target_td_sources",


### PR DESCRIPTION
Currently one might invoke `llvm-tblgen` in Bazel by using `gentbl` macro. But bazel macros do not allow you to use `select` statements with them. For example,  one might use different `tblgen_args` on different OS, or depending on command line options. So, in this PR I implemented tblgen as a rule instead of a macro.

```
tblgen_args = select({
          "@platforms//os:windows": "--long-string-literals=0",
          "//conditions:default": "",
      }),
```