### PR TITLE
[libc][stdlib] Fix UB in freelist

### DIFF
--- a/libc/src/stdlib/CMakeLists.txt
+++ b/libc/src/stdlib/CMakeLists.txt
@@ -398,8 +398,9 @@ else()
       freelist.h
     DEPENDS
       libc.src.__support.fixedvector
-      libc.src.__support.CPP.cstddef
       libc.src.__support.CPP.array
+      libc.src.__support.CPP.cstddef
+      libc.src.__support.CPP.new
       libc.src.__support.CPP.span
   )
   add_header_library(


### PR DESCRIPTION
Some of the freelist code uses type punning which is UB in C++, namely because we read from a union member that is not the active union member. For cases we used this, we should either use memcpy for storing or reinterpret_cast<cpp::byte*> for comparing.