### PR TITLE
[compiler-rt] Remove 'memprof_meminfoblock.h' from MEMPROF_HEADERS (NFC)

### DIFF
--- a/compiler-rt/lib/memprof/CMakeLists.txt
+++ b/compiler-rt/lib/memprof/CMakeLists.txt
@@ -37,7 +37,6 @@ SET(MEMPROF_HEADERS
   memprof_interface_internal.h
   memprof_internal.h
   memprof_mapping.h
-  memprof_meminfoblock.h
   memprof_mibmap.h
   memprof_rawprofile.h
   memprof_stack.h


### PR DESCRIPTION
Commit 8306968b592d942cc49bde2e387061e673a9fbb7 deleted file `compiler-rt/lib/memprof/memprof_meminfoblock.h`, but didn't remove it from MEMPROF_HEADERS in `compiler-rt/lib/memprof/CMakeLists.txt`.

Remove unneeded leftover line in `compiler-rt/lib/memprof/CMakeLists.txt`.

p.s.
GH #54777 reported a llvm14 build failure due to the existence of the leftover line, but I'm unable to reproduce the build failure with llvm19 trunk.