### PR TITLE
[libc++] Add default copy ctor to "__chrono/exception.h"

### DIFF
--- a/libcxx/include/__chrono/exception.h
+++ b/libcxx/include/__chrono/exception.h
@@ -48,6 +48,9 @@ public:
                             "creating an nonexistent_local_time from a local_info that is not non-existent");
   }
 
+  nonexistent_local_time(const nonexistent_local_time&)            = default;
+  nonexistent_local_time& operator=(const nonexistent_local_time&) = default;
+
   _LIBCPP_AVAILABILITY_TZDB _LIBCPP_EXPORTED_FROM_ABI ~nonexistent_local_time() override; // exported as key function
 
 private:
@@ -88,6 +91,9 @@ public:
     _LIBCPP_ASSERT_PEDANTIC(__info.result == local_info::ambiguous,
                             "creating an ambiguous_local_time from a local_info that is not ambiguous");
   }
+
+  ambiguous_local_time(const ambiguous_local_time&)            = default;
+  ambiguous_local_time& operator=(const ambiguous_local_time&) = default;
 
   _LIBCPP_AVAILABILITY_TZDB _LIBCPP_EXPORTED_FROM_ABI ~ambiguous_local_time() override; // exported as key function
 

--- a/libcxx/include/__chrono/exception.h
+++ b/libcxx/include/__chrono/exception.h
@@ -48,8 +48,8 @@ public:
                             "creating an nonexistent_local_time from a local_info that is not non-existent");
   }
 
-  nonexistent_local_time(const nonexistent_local_time&)            = default;
-  nonexistent_local_time& operator=(const nonexistent_local_time&) = default;
+  _LIBCPP_HIDE_FROM_ABI nonexistent_local_time(const nonexistent_local_time&)            = default;
+  _LIBCPP_HIDE_FROM_ABI nonexistent_local_time& operator=(const nonexistent_local_time&) = default;
 
   _LIBCPP_AVAILABILITY_TZDB _LIBCPP_EXPORTED_FROM_ABI ~nonexistent_local_time() override; // exported as key function
 
@@ -92,8 +92,8 @@ public:
                             "creating an ambiguous_local_time from a local_info that is not ambiguous");
   }
 
-  ambiguous_local_time(const ambiguous_local_time&)            = default;
-  ambiguous_local_time& operator=(const ambiguous_local_time&) = default;
+  _LIBCPP_HIDE_FROM_ABI ambiguous_local_time(const ambiguous_local_time&)            = default;
+  _LIBCPP_HIDE_FROM_ABI ambiguous_local_time& operator=(const ambiguous_local_time&) = default;
 
   _LIBCPP_AVAILABILITY_TZDB _LIBCPP_EXPORTED_FROM_ABI ~ambiguous_local_time() override; // exported as key function
 


### PR DESCRIPTION
After PR#90394, "__chrono/exception.h" will trigger "deprecated-copy-with-user-provided-dtor" warning on Windows x64 runtime testing with ToT Clang. This patch addresses this issue by explicitly adding those default copy ctors.

It is a bit weird that the same warning will not happen when testing on Linux x64 under the same condition, despite the warning flag was enabled (with `-Wdeprecated-copy -Wdeprecated-copy-dtor`). It might be a bug.