### PR TITLE
[asan] Attempt to fix tests broken by #94307.

### DIFF
--- a/compiler-rt/test/asan/TestCases/strcpy-overlap.cpp
+++ b/compiler-rt/test/asan/TestCases/strcpy-overlap.cpp
@@ -36,7 +36,7 @@ __attribute__((noinline)) void bad_function() {
   char buffer[] = "hello";
   // CHECK: strcpy-param-overlap: memory ranges
   // CHECK: [{{0x.*,[ ]*0x.*}}) and [{{0x.*,[ ]*0x.*}}) overlap
-  // CHECK: {{#[0-9]+ 0x.* in .*strcpy .*.cpp}}
+  // CHECK: {{#[0-9]+ 0x.* in .*strcpy.* .*.cpp}}
   // CHECK: {{#[0-9]+ 0x.* in bad_function.*strcpy-overlap.cpp:}}[[@LINE+2]]
   // CHECK: {{#[0-9]+ 0x.* in main .*strcpy-overlap.cpp:}}[[@LINE+5]]
   strcpy(buffer, buffer + 1); // BOOM

--- a/compiler-rt/test/asan/TestCases/strdup_oob_test.cpp
+++ b/compiler-rt/test/asan/TestCases/strdup_oob_test.cpp
@@ -23,7 +23,7 @@ int main(int argc, char **argv) {
   // CHECK: AddressSanitizer: heap-buffer-overflow
   // CHECK: #0 {{.*}}main {{.*}}strdup_oob_test.cpp:[[@LINE-2]]
   // CHECK-LABEL: allocated by thread T{{.*}} here:
-  // CHECK: #{{[0-9]}}+ {{.*}}strdup
+  // CHECK: #{{[0-9]+}} {{.*}}strdup
   // CHECK: #{{.*}}main {{.*}}strdup_oob_test.cpp:[[@LINE-6]]
   // CHECK-LABEL: SUMMARY
   // CHECK: strdup_oob_test.cpp:[[@LINE-7]]

--- a/compiler-rt/test/asan/TestCases/use-after-free-right.cpp
+++ b/compiler-rt/test/asan/TestCases/use-after-free-right.cpp
@@ -18,7 +18,7 @@ int main() {
   // CHECK: {{    #[0-9]+ 0x.* in main .*use-after-free-right.cpp:}}[[@LINE-4]]
   // CHECK: {{0x.* is located 0 bytes inside of 1-byte region .0x.*,0x.*}}
   // CHECK: {{freed by thread T0 here:}}
-  // CHECK: {{    #[0-9]+ 0x.* in .*free .*.cpp}}
+  // CHECK: {{    #[0-9]+ 0x.* in .*free.* .*.cpp}}
   // CHECK: {{    #[0-9]+ 0x.* in main .*use-after-free-right.cpp:}}[[@LINE-9]]
 
   // CHECK: {{previously allocated by thread T0 here:}}


### PR DESCRIPTION
Change #94307 attempted to make the checks in several tests more flexible, but in one case it introduced a bug which broke one test, and in two other cases, caused a passing test to now fail. I am repeating my analysis here, but I originally made these comments on #94307. Since this is failing on our internal builder and at least one upstream build bot, I am attempting to fix this change in order to unblock us and get the bot back to green.

strdup_oob_test.cpp:
This test had `#{{[01]}}` replaced with `#{{[0-9]}}+` in order to have it match more than just `#0` or `#1`. The problem was the `+` for the regex was mistakenly placed outside of the regex expression, causing it to only match the literal strings `#0+`, `#1+`, `#2+`, etc. This fixes the issue by putting the `+` character back in the regex where it was likely intended to be.

strcpy-overlap.cpp and use-after-free-right.cpp:
These cases both failed on our internal builder for similar reasons. For strcpy-overlap.cpp, the CHECK line was changed from `{{#0 0x.* in .*strcpy}}` to `{{#[0-9]+ 0x.* in .*strcpy .*.cpp}}`. This caused our builder to fail because the line that was previously being matched looked like this:
```
#0 0x55ec8a9ad17c in strcpy.part.0 /home/jenkins/compiler-rt/lib/asan/asan_interceptors.cpp:566:5
```
Instead of just `strcpy `, we have `strcpy.part.0 `. Since there isn't a space immediately following the `strcpy` text, the matching failed causing the test to fail.

The test use-after-free-right.cpp had a similar failure. The regex was changed from `{{    #0 0x.* in .*free}}` to `{{    #[0-9]+ 0x.* in .*free .*.cpp}}`. In this case, our builder was generating the following output that previously matched, but no longer did after this change due to no space immediately following the `free` text:
```
#0 0x55e55ffaf717 in cfree.part.0 /home/jenkins/compiler-rt/lib/asan/asan_malloc_linux.cpp:52:3
```
The fix for both of these tests is to change the regex to accept zero or more characters after `strcpy` and `free` respectively so that they match both cases.