### PR TITLE
[Serialization] Use 32 bit aligned decl id instead of unaligned decl id

### DIFF
--- a/clang/include/clang/Serialization/ASTBitCodes.h
+++ b/clang/include/clang/Serialization/ASTBitCodes.h
@@ -168,12 +168,16 @@ const unsigned int NUM_PREDEF_SUBMODULE_IDS = 1;
 /// because blobs in bitstream are 32-bit aligned). This structure is
 /// serialized "as is" to the AST file.
 class UnalignedUInt64 {
-  uint32_t BitLow = 0;
-  uint32_t BitHigh = 0;
+  uint32_t BitLow;
+  uint32_t BitHigh;
 
 public:
   UnalignedUInt64() = default;
   UnalignedUInt64(uint64_t BitOffset) { set(BitOffset); }
+
+  operator uint64_t() const {
+    return get();
+  }
 
   void set(uint64_t Offset) {
     BitLow = Offset;
@@ -255,11 +259,9 @@ public:
   }
 };
 
-// The unaligned decl ID used in the Blobs of bistreams.
-using unaligned_decl_id_t =
-    llvm::support::detail::packed_endian_specific_integral<
-        serialization::DeclID, llvm::endianness::native,
-        llvm::support::unaligned>;
+// The 32 bits aligned decl ID used in the Blobs of bistreams due the blobs
+// are 32 bits aligned.
+using SerializedDeclID = UnalignedUInt64;
 
 /// The number of predefined preprocessed entity IDs.
 const unsigned int NUM_PREDEF_PP_ENTITY_IDS = 1;
@@ -1986,9 +1988,9 @@ enum CleanupObjectKind { COK_Block, COK_CompoundLiteral };
 
 /// Describes the categories of an Objective-C class.
 struct ObjCCategoriesInfo {
-  // The ID of the definition. Use unaligned_decl_id_t to keep
+  // The ID of the definition. Use SerializedDeclID to keep
   // ObjCCategoriesInfo 32-bit aligned.
-  unaligned_decl_id_t DefinitionID;
+  SerializedDeclID DefinitionID;
 
   // Offset into the array of category lists.
   unsigned Offset;

--- a/clang/include/clang/Serialization/ASTReader.h
+++ b/clang/include/clang/Serialization/ASTReader.h
@@ -586,11 +586,11 @@ private:
 
   struct FileDeclsInfo {
     ModuleFile *Mod = nullptr;
-    ArrayRef<serialization::unaligned_decl_id_t> Decls;
+    ArrayRef<serialization::SerializedDeclID> Decls;
 
     FileDeclsInfo() = default;
     FileDeclsInfo(ModuleFile *Mod,
-                  ArrayRef<serialization::unaligned_decl_id_t> Decls)
+                  ArrayRef<serialization::SerializedDeclID> Decls)
         : Mod(Mod), Decls(Decls) {}
   };
 
@@ -599,7 +599,7 @@ private:
 
   /// An array of lexical contents of a declaration context, as a sequence of
   /// Decl::Kind, DeclID pairs.
-  using LexicalContents = ArrayRef<serialization::unaligned_decl_id_t>;
+  using LexicalContents = ArrayRef<serialization::SerializedDeclID>;
 
   /// Map from a DeclContext to its lexical contents.
   llvm::DenseMap<const DeclContext*, std::pair<ModuleFile*, LexicalContents>>
@@ -1482,7 +1482,7 @@ private:
 public:
   class ModuleDeclIterator
       : public llvm::iterator_adaptor_base<
-            ModuleDeclIterator, const serialization::unaligned_decl_id_t *,
+            ModuleDeclIterator, const serialization::SerializedDeclID *,
             std::random_access_iterator_tag, const Decl *, ptrdiff_t,
             const Decl *, const Decl *> {
     ASTReader *Reader = nullptr;
@@ -1492,7 +1492,7 @@ public:
     ModuleDeclIterator() : iterator_adaptor_base(nullptr) {}
 
     ModuleDeclIterator(ASTReader *Reader, ModuleFile *Mod,
-                       const serialization::unaligned_decl_id_t *Pos)
+                       const serialization::SerializedDeclID *Pos)
         : iterator_adaptor_base(Pos), Reader(Reader), Mod(Mod) {}
 
     value_type operator*() const {

--- a/clang/include/clang/Serialization/ModuleFile.h
+++ b/clang/include/clang/Serialization/ModuleFile.h
@@ -458,7 +458,7 @@ public:
   unsigned BaseDeclIndex = 0;
 
   /// Array of file-level DeclIDs sorted by file.
-  const serialization::unaligned_decl_id_t *FileSortedDecls = nullptr;
+  const serialization::SerializedDeclID *FileSortedDecls = nullptr;
   unsigned NumFileSortedDecls = 0;
 
   /// Array of category list location information within this


### PR DESCRIPTION
See the post commit message in
https://github.com/llvm/llvm-project/pull/92083.

I suspect the compile time regression in AArch64 is related to alignments.

I am not sure if this is the problem since I can't reproduce.