### PR TITLE
[lldb] Support case-insensitive regex matches

### DIFF
--- a/lldb/include/lldb/Utility/RegularExpression.h
+++ b/lldb/include/lldb/Utility/RegularExpression.h
@@ -31,7 +31,13 @@ public:
   /// \param[in] string
   ///     An llvm::StringRef that represents the regular expression to compile.
   //      String is not referenced anymore after the object is constructed.
-  explicit RegularExpression(llvm::StringRef string);
+  //
+  /// \param[in] flags
+  ///     An llvm::Regex::RegexFlags that modifies the matching behavior. The
+  ///     default is NoFlags.
+  explicit RegularExpression(
+      llvm::StringRef string,
+      llvm::Regex::RegexFlags flags = llvm::Regex::NoFlags);
 
   ~RegularExpression() = default;
 

--- a/lldb/include/lldb/lldb-enumerations.h
+++ b/lldb/include/lldb/lldb-enumerations.h
@@ -1107,7 +1107,12 @@ enum MemberFunctionKind {
 };
 
 /// String matching algorithm used by SBTarget.
-enum MatchType { eMatchTypeNormal, eMatchTypeRegex, eMatchTypeStartsWith };
+enum MatchType {
+  eMatchTypeNormal,
+  eMatchTypeRegex,
+  eMatchTypeStartsWith,
+  eMatchTypeRegexInsensitive
+};
 
 /// Bitmask that describes details about a type.
 FLAGS_ENUM(TypeFlags){

--- a/lldb/source/API/SBTarget.cpp
+++ b/lldb/source/API/SBTarget.cpp
@@ -1789,6 +1789,11 @@ lldb::SBSymbolContextList SBTarget::FindGlobalFunctions(const char *name,
         target_sp->GetImages().FindFunctions(RegularExpression(name_ref),
                                              function_options, *sb_sc_list);
         break;
+      case eMatchTypeRegexInsensitive:
+        target_sp->GetImages().FindFunctions(
+            RegularExpression(name_ref, llvm::Regex::RegexFlags::IgnoreCase),
+            function_options, *sb_sc_list);
+        break;
       case eMatchTypeStartsWith:
         regexstr = llvm::Regex::escape(name) + ".*";
         target_sp->GetImages().FindFunctions(RegularExpression(regexstr),
@@ -1935,6 +1940,11 @@ SBValueList SBTarget::FindGlobalVariables(const char *name,
     case eMatchTypeRegex:
       target_sp->GetImages().FindGlobalVariables(RegularExpression(name_ref),
                                                  max_matches, variable_list);
+      break;
+    case eMatchTypeRegexInsensitive:
+      target_sp->GetImages().FindGlobalVariables(
+          RegularExpression(name_ref, llvm::Regex::IgnoreCase), max_matches,
+          variable_list);
       break;
     case eMatchTypeStartsWith:
       regexstr = "^" + llvm::Regex::escape(name) + ".*";

--- a/lldb/source/Utility/RegularExpression.cpp
+++ b/lldb/source/Utility/RegularExpression.cpp
@@ -12,10 +12,11 @@
 
 using namespace lldb_private;
 
-RegularExpression::RegularExpression(llvm::StringRef str)
+RegularExpression::RegularExpression(llvm::StringRef str,
+                                     llvm::Regex::RegexFlags flags)
     : m_regex_text(std::string(str)),
       // m_regex does not reference str anymore after it is constructed.
-      m_regex(llvm::Regex(str)) {}
+      m_regex(llvm::Regex(str, flags)) {}
 
 RegularExpression::RegularExpression(const RegularExpression &rhs)
     : RegularExpression(rhs.GetText()) {}

--- a/lldb/test/API/lang/cpp/class_static/TestStaticVariables.py
+++ b/lldb/test/API/lang/cpp/class_static/TestStaticVariables.py
@@ -2,7 +2,6 @@
 Test display and Python APIs on file and class static variables.
 """
 
-
 import lldb
 from lldbsuite.test.decorators import *
 from lldbsuite.test.lldbtest import *
@@ -264,7 +263,9 @@ class StaticVariableTestCase(TestBase):
         self.assertTrue(found_aa, "Regex search found AA::g_points")
 
         # Regex lowercase should find both as well.
-        val_list = target.FindGlobalVariables("a::g_points", 10, lldb.eMatchTypeRegexInsensitive)
+        val_list = target.FindGlobalVariables(
+            "a::g_points", 10, lldb.eMatchTypeRegexInsensitive
+        )
         self.assertEqual(val_list.GetSize(), 2, "Found A & AA")
 
         # Normal search for full name should find one, but it looks like we don't match

--- a/lldb/test/API/lang/cpp/class_static/TestStaticVariables.py
+++ b/lldb/test/API/lang/cpp/class_static/TestStaticVariables.py
@@ -263,6 +263,10 @@ class StaticVariableTestCase(TestBase):
         self.assertTrue(found_a, "Regex search found A::g_points")
         self.assertTrue(found_aa, "Regex search found AA::g_points")
 
+        # Regex lowercase should find both as well.
+        val_list = target.FindGlobalVariables("a::g_points", 10, lldb.eMatchTypeRegexInsensitive)
+        self.assertEqual(val_list.GetSize(), 2, "Found A & AA")
+
         # Normal search for full name should find one, but it looks like we don't match
         # on identifier boundaries here yet:
         val_list = target.FindGlobalVariables("A::g_points", 10, lldb.eMatchTypeNormal)


### PR DESCRIPTION
Support case-insensitive regex matches for `SBTarget::FindGlobalFunctions` and `SBTarget::FindGlobalVariables`.