### PR TITLE
[Orc][RuntimeDyld] Return after handling error

### DIFF
--- a/llvm/lib/ExecutionEngine/RuntimeDyld/RuntimeDyld.cpp
+++ b/llvm/lib/ExecutionEngine/RuntimeDyld/RuntimeDyld.cpp
@@ -1466,8 +1466,10 @@ void jitLinkForORC(
     return;
   }
 
-  if (auto Err = OnLoaded(*O.getBinary(), *Info, RTDyld.getSymbolTable()))
+  if (auto Err = OnLoaded(*O.getBinary(), *Info, RTDyld.getSymbolTable())) {
     OnEmitted(std::move(O), std::move(Info), std::move(Err));
+    return;
+  }
 
   RuntimeDyldImpl::finalizeAsync(std::move(RTDyld.Dyld), std::move(OnEmitted),
                                  std::move(O), std::move(Info));


### PR DESCRIPTION
If OnLoaded failed, return after passing the error to OnEmitted instead of also calling finalizeAsync (which would use values that have already been moved and perform another call to OnEmitted).