### PR TITLE
[clang] Clean up macOS version flags

### DIFF
--- a/clang/docs/CommandGuide/clang.rst
+++ b/clang/docs/CommandGuide/clang.rst
@@ -362,7 +362,7 @@ number of cross compilers, or may only support a native target.
 
   Specify the architecture to build for (all platforms).
 
-.. option:: -mmacosx-version-min=<version>
+.. option:: -mmacos-version-min=<version>
 
   When building for macOS, specify the minimum version supported by your
   application.
@@ -723,7 +723,7 @@ ENVIRONMENT
 
 .. envvar:: MACOSX_DEPLOYMENT_TARGET
 
-  If :option:`-mmacosx-version-min` is unspecified, the default deployment
+  If :option:`-mmacos-version-min` is unspecified, the default deployment
   target is read from this environment variable. This option only affects
   Darwin targets.
 

--- a/clang/docs/LanguageExtensions.rst
+++ b/clang/docs/LanguageExtensions.rst
@@ -2063,7 +2063,7 @@ Objective-C @available
 ----------------------
 
 It is possible to use the newest SDK but still build a program that can run on
-older versions of macOS and iOS by passing ``-mmacosx-version-min=`` /
+older versions of macOS and iOS by passing ``-mmacos-version-min=`` /
 ``-miphoneos-version-min=``.
 
 Before LLVM 5.0, when calling a function that exists only in the OS that's
@@ -2084,7 +2084,7 @@ When a method that's introduced in the OS newer than the target OS is called, a
 
   void my_fun(NSSomeClass* var) {
     // If fancyNewMethod was added in e.g. macOS 10.12, but the code is
-    // built with -mmacosx-version-min=10.11, then this unconditional call
+    // built with -mmacos-version-min=10.11, then this unconditional call
     // will emit a -Wunguarded-availability warning:
     [var fancyNewMethod];
   }

--- a/clang/include/clang/Driver/ToolChain.h
+++ b/clang/include/clang/Driver/ToolChain.h
@@ -639,7 +639,7 @@ public:
 
   /// ComputeEffectiveClangTriple - Return the Clang triple to use for this
   /// target, which may take into account the command line arguments. For
-  /// example, on Darwin the -mmacosx-version-min= command line argument (which
+  /// example, on Darwin the -mmacos-version-min= command line argument (which
   /// sets the deployment target) determines the version in the triple passed to
   /// Clang.
   virtual std::string ComputeEffectiveClangTriple(

--- a/clang/test/Coverage/targets.c
+++ b/clang/test/Coverage/targets.c
@@ -14,4 +14,4 @@
 // RUN: %clang_cc1 -debug-info-kind=limited -triple x86_64-unknown-unknown -emit-llvm -o %t %s
 
 // clang 1.0 fails to compile Python 2.6
-// RUN: %clang -target x86_64-apple-darwin9 -### -S %s -mmacosx-version-min=10.4
+// RUN: %clang -target x86_64-apple-darwin9 -### -S %s -mmacos-version-min=10.4

--- a/clang/test/Driver/arc.c
+++ b/clang/test/Driver/arc.c
@@ -3,7 +3,7 @@
 // RUN: not %clang -x objective-c++ -target i386-apple-darwin10 -stdlib=libstdc++ -m32 -fobjc-arc %s -fsyntax-only 2>&1 | FileCheck %s
 // RUN: not %clang -x c -target i386-apple-darwin10 -stdlib=libstdc++ -m32 -fobjc-arc %s -fsyntax-only 2>&1 | FileCheck -check-prefix NOTOBJC %s
 // RUN: not %clang -x c++ -target i386-apple-darwin10 -stdlib=libstdc++ -m32 -fobjc-arc %s -fsyntax-only 2>&1 | FileCheck -check-prefix NOTOBJC %s
-// RUN: not %clang -x objective-c -target x86_64-apple-darwin11 -mmacosx-version-min=10.5 -fobjc-arc %s -fsyntax-only 2>&1 | FileCheck -check-prefix NOTSUPPORTED %s
+// RUN: not %clang -x objective-c -target x86_64-apple-darwin11 -mmacos-version-min=10.5 -fobjc-arc %s -fsyntax-only 2>&1 | FileCheck -check-prefix NOTSUPPORTED %s
 
 // Just to test clang is working.
 # foo

--- a/clang/test/Driver/arclite-link.c
+++ b/clang/test/Driver/arclite-link.c
@@ -1,9 +1,9 @@
 // RUN: touch %t.o
 // RUN: mkdir -p %t.tmpdir/Xcode.app/Contents/Developers/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.14.sdk
-// RUN: not %clang -### -target x86_64-apple-darwin10 -fobjc-link-runtime -lfoo -mmacosx-version-min=10.10 %t.o \
+// RUN: not %clang -### -target x86_64-apple-darwin10 -fobjc-link-runtime -lfoo -mmacos-version-min=10.10 %t.o \
 // RUN: -isysroot %t.tmpdir/Xcode.app/Contents/Developers/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.14.sdk 2>&1 | FileCheck -check-prefix=CHECK-ARCLITE-OSX %s
-// RUN: %clang -### -target x86_64-apple-darwin10 -fobjc-link-runtime -mmacosx-version-min=10.11 %t.o 2>&1 | FileCheck -check-prefix=CHECK-NOARCLITE %s
-// RUN: %clang -### -target i386-apple-darwin10 -fobjc-link-runtime -mmacosx-version-min=10.7 %t.o 2>&1 | FileCheck -check-prefix=CHECK-NOARCLITE %s
+// RUN: %clang -### -target x86_64-apple-darwin10 -fobjc-link-runtime -mmacos-version-min=10.11 %t.o 2>&1 | FileCheck -check-prefix=CHECK-NOARCLITE %s
+// RUN: %clang -### -target i386-apple-darwin10 -fobjc-link-runtime -mmacos-version-min=10.7 %t.o 2>&1 | FileCheck -check-prefix=CHECK-NOARCLITE %s
 // RUN: %clang -### -target x86_64-apple-darwin10 -fobjc-link-runtime -nostdlib %t.o 2>&1 | FileCheck -check-prefix=CHECK-NOSTDLIB %s
 
 // CHECK-ARCLITE-OSX: .tmpdir/Xcode.app/{{.*}}libarclite_macosx.a';
@@ -16,7 +16,7 @@
 // CHECK-NOARCLITE-NOT: libarclite
 // CHECK-NOSTDLIB-NOT: -lobjc
 
-// RUN: not %clang -### -target x86_64-apple-darwin10 -fobjc-link-runtime -fobjc-arc -mmacosx-version-min=10.10 %s 2>&1 | FileCheck -check-prefix=CHECK-UNUSED %s
+// RUN: not %clang -### -target x86_64-apple-darwin10 -fobjc-link-runtime -fobjc-arc -mmacos-version-min=10.10 %s 2>&1 | FileCheck -check-prefix=CHECK-UNUSED %s
 
 // CHECK-UNUSED-NOT: warning: argument unused during compilation: '-fobjc-link-runtime'
 

--- a/clang/test/Driver/darwin-objc-defaults.m
+++ b/clang/test/Driver/darwin-objc-defaults.m
@@ -3,7 +3,7 @@
 // i386
 
 // RUN: %clang -target x86_64-apple-darwin10 -S -### %s \
-// RUN:   -arch i386 -mmacosx-version-min=10.5 2> %t
+// RUN:   -arch i386 -mmacos-version-min=10.5 2> %t
 // RUN: FileCheck --check-prefix CHECK-CHECK-I386_OSX10_5 < %t %s
 
 // CHECK-CHECK-I386_OSX10_5: "-cc1"
@@ -12,7 +12,7 @@
 // CHECK-CHECK-I386_OSX10_5: darwin-objc-defaults
 
 // RUN: %clang -target x86_64-apple-darwin10 -S -### %s \
-// RUN:   -arch i386 -mmacosx-version-min=10.6 2> %t
+// RUN:   -arch i386 -mmacos-version-min=10.6 2> %t
 // RUN: FileCheck --check-prefix CHECK-CHECK-I386_OSX10_6 < %t %s
 
 // CHECK-CHECK-I386_OSX10_6: "-cc1"
@@ -32,14 +32,14 @@
 // x86_64
 
 // RUN: %clang -target x86_64-apple-darwin10 -S -### %s \
-// RUN:   -arch x86_64 -mmacosx-version-min=10.4 2> %t
+// RUN:   -arch x86_64 -mmacos-version-min=10.4 2> %t
 // RUN: FileCheck --check-prefix CHECK-CHECK-X86_64_OSX10_4 < %t %s
 
 // CHECK-CHECK-X86_64_OSX10_4: "-cc1"
 // CHECK-CHECK-X86_64_OSX10_4: -fobjc-dispatch-method=non-legacy
 
 // RUN: %clang -target x86_64-apple-darwin10 -S -### %s \
-// RUN:   -arch x86_64 -mmacosx-version-min=10.5 2> %t
+// RUN:   -arch x86_64 -mmacos-version-min=10.5 2> %t
 // RUN: FileCheck --check-prefix CHECK-CHECK-X86_64_OSX10_5 < %t %s
 
 
@@ -49,7 +49,7 @@
 // CHECK-CHECK-X86_64_OSX10_5: darwin-objc-defaults
 
 // RUN: %clang -target x86_64-apple-darwin10 -S -### %s \
-// RUN:   -arch x86_64 -mmacosx-version-min=10.6 2> %t
+// RUN:   -arch x86_64 -mmacos-version-min=10.6 2> %t
 // RUN: FileCheck --check-prefix CHECK-CHECK-X86_64_OSX10_6 < %t %s
 
 // CHECK-CHECK-X86_64_OSX10_6: "-cc1"
@@ -67,7 +67,7 @@
 // armv7
 
 // RUN: %clang -target x86_64-apple-darwin10 -S -### %s \
-// RUN:   -arch armv7 -mmacosx-version-min=10.5 2> %t
+// RUN:   -arch armv7 -mmacos-version-min=10.5 2> %t
 // RUN: FileCheck --check-prefix CHECK-CHECK-ARMV7_OSX10_5 < %t %s
 
 // CHECK-CHECK-ARMV7_OSX10_5: "-cc1"
@@ -76,7 +76,7 @@
 // CHECK-CHECK-ARMV7_OSX10_5: darwin-objc-defaults
 
 // RUN: %clang -target x86_64-apple-darwin10 -S -### %s	\
-// RUN:   -arch armv7 -mmacosx-version-min=10.6 2> %t
+// RUN:   -arch armv7 -mmacos-version-min=10.6 2> %t
 // RUN: FileCheck --check-prefix CHECK-CHECK-ARMV7_OSX10_6 < %t %s
 
 // CHECK-CHECK-ARMV7_OSX10_6: "-cc1"

--- a/clang/test/Driver/darwin-stdlib-dont-pass-in-c.c
+++ b/clang/test/Driver/darwin-stdlib-dont-pass-in-c.c
@@ -1,7 +1,7 @@
 // This test ensures that the Driver doesn't pass -stdlib= down to CC1 when compiling C code.
 
 // RUN: %clang -target x86_64-apple-darwin -ccc-install-dir %S/Inputs/darwin_toolchain_tree/bin/ -arch arm64 -miphoneos-version-min=7.0 %s -### 2>&1 | FileCheck %s
-// RUN: %clang -target x86_64-apple-darwin -ccc-install-dir %S/Inputs/darwin_toolchain_tree/bin/ -mmacosx-version-min=10.9 %s -### 2>&1 | FileCheck %s
+// RUN: %clang -target x86_64-apple-darwin -ccc-install-dir %S/Inputs/darwin_toolchain_tree/bin/ -mmacos-version-min=10.9 %s -### 2>&1 | FileCheck %s
 // RUN: %clang -target x86_64-apple-darwin -ccc-install-dir %S/Inputs/darwin_toolchain_tree/bin/ -arch armv7s -miphoneos-version-min=7.0 %s -### 2>&1 | FileCheck %s
 // RUN: %clang -target x86_64-apple-darwin -ccc-install-dir %S/Inputs/darwin_toolchain_tree/bin/ -arch armv7k %s -### 2>&1 | FileCheck %s
 

--- a/clang/test/Driver/darwin-stdlib.cpp
+++ b/clang/test/Driver/darwin-stdlib.cpp
@@ -1,7 +1,7 @@
 // Make sure that the Driver passes down -stdlib=libc++ to CC1 when specified explicitly.
 //
 // RUN: %clang -target x86_64-apple-darwin -ccc-install-dir %S/Inputs/darwin_toolchain_tree/bin/ -arch arm64  -miphoneos-version-min=7.0 -stdlib=libc++ %s -### 2>&1 | FileCheck --check-prefix=CHECK-LIBCXX %s
-// RUN: %clang -target x86_64-apple-darwin -ccc-install-dir %S/Inputs/darwin_toolchain_tree/bin/              -mmacosx-version-min=10.9  -stdlib=libc++ %s -### 2>&1 | FileCheck --check-prefix=CHECK-LIBCXX %s
+// RUN: %clang -target x86_64-apple-darwin -ccc-install-dir %S/Inputs/darwin_toolchain_tree/bin/              -mmacos-version-min=10.9  -stdlib=libc++ %s -### 2>&1 | FileCheck --check-prefix=CHECK-LIBCXX %s
 // RUN: %clang -target x86_64-apple-darwin -ccc-install-dir %S/Inputs/darwin_toolchain_tree/bin/ -arch armv7s -miphoneos-version-min=7.0 -stdlib=libc++ %s -### 2>&1 | FileCheck --check-prefix=CHECK-LIBCXX %s
 // RUN: %clang -target x86_64-apple-darwin -ccc-install-dir %S/Inputs/darwin_toolchain_tree/bin/ -arch armv7k                            -stdlib=libc++ %s -### 2>&1 | FileCheck --check-prefix=CHECK-LIBCXX %s
 // CHECK-LIBCXX: "-stdlib=libc++"
@@ -12,7 +12,7 @@
 // Driver behavior for now.
 //
 // RUN: %clang -target x86_64-apple-darwin -ccc-install-dir %S/Inputs/darwin_toolchain_tree/bin/ -arch arm64  -miphoneos-version-min=7.0 -stdlib=libstdc++ %s -### 2>&1 | FileCheck --check-prefix=CHECK-LIBSTDCXX %s
-// RUN: %clang -target x86_64-apple-darwin -ccc-install-dir %S/Inputs/darwin_toolchain_tree/bin/              -mmacosx-version-min=10.9  -stdlib=libstdc++ %s -### 2>&1 | FileCheck --check-prefix=CHECK-LIBSTDCXX %s
+// RUN: %clang -target x86_64-apple-darwin -ccc-install-dir %S/Inputs/darwin_toolchain_tree/bin/              -mmacos-version-min=10.9  -stdlib=libstdc++ %s -### 2>&1 | FileCheck --check-prefix=CHECK-LIBSTDCXX %s
 // RUN: %clang -target x86_64-apple-darwin -ccc-install-dir %S/Inputs/darwin_toolchain_tree/bin/ -arch armv7s -miphoneos-version-min=7.0 -stdlib=libstdc++ %s -### 2>&1 | FileCheck --check-prefix=CHECK-LIBSTDCXX %s
 // RUN: %clang -target x86_64-apple-darwin -ccc-install-dir %S/Inputs/darwin_toolchain_tree/bin/ -arch armv7k                            -stdlib=libstdc++ %s -### 2>&1 | FileCheck --check-prefix=CHECK-LIBSTDCXX %s
 // CHECK-LIBSTDCXX: "-stdlib=libstdc++"
@@ -23,7 +23,7 @@
 // going to be libc++.
 //
 // RUN: %clang -target x86_64-apple-darwin -ccc-install-dir %S/Inputs/darwin_toolchain_tree/bin/ -arch arm64  -miphoneos-version-min=7.0 %s -### 2>&1 | FileCheck --check-prefix=CHECK-NONE %s
-// RUN: %clang -target x86_64-apple-darwin -ccc-install-dir %S/Inputs/darwin_toolchain_tree/bin/              -mmacosx-version-min=10.9  %s -### 2>&1 | FileCheck --check-prefix=CHECK-NONE %s
+// RUN: %clang -target x86_64-apple-darwin -ccc-install-dir %S/Inputs/darwin_toolchain_tree/bin/              -mmacos-version-min=10.9  %s -### 2>&1 | FileCheck --check-prefix=CHECK-NONE %s
 // RUN: %clang -target x86_64-apple-darwin -ccc-install-dir %S/Inputs/darwin_toolchain_tree/bin/ -arch armv7s -miphoneos-version-min=7.0 %s -### 2>&1 | FileCheck --check-prefix=CHECK-NONE %s
 // RUN: %clang -target x86_64-apple-darwin -ccc-install-dir %S/Inputs/darwin_toolchain_tree/bin/ -arch armv7k                            %s -### 2>&1 | FileCheck --check-prefix=CHECK-NONE %s
 // CHECK-NONE-NOT: "-stdlib="

--- a/clang/test/Driver/darwin-version.c
+++ b/clang/test/Driver/darwin-version.c
@@ -62,27 +62,27 @@
 
 // RUN: %clang -target i686-apple-darwin8 -c %s -### 2>&1 | \
 // RUN:   FileCheck --check-prefix=CHECK-VERSION-OSX4 %s
-// RUN: %clang -target i686-apple-darwin9 -mmacosx-version-min=10.4 -c %s -### 2>&1 | \
+// RUN: %clang -target i686-apple-darwin9 -mmacos-version-min=10.4 -c %s -### 2>&1 | \
 // RUN:   FileCheck --check-prefix=CHECK-VERSION-OSX4 %s
 // CHECK-VERSION-OSX4: "i686-apple-macosx10.4.0"
 // RUN: %clang -target i686-apple-darwin9 -c %s -### 2>&1 | \
 // RUN:   FileCheck --check-prefix=CHECK-VERSION-OSX5 %s
-// RUN: %clang -target i686-apple-darwin9 -mmacosx-version-min=10.5 -c %s -### 2>&1 | \
+// RUN: %clang -target i686-apple-darwin9 -mmacos-version-min=10.5 -c %s -### 2>&1 | \
 // RUN:   FileCheck --check-prefix=CHECK-VERSION-OSX5 %s
 // CHECK-VERSION-OSX5: "i686-apple-macosx10.5.0"
 // RUN: %clang -target i686-apple-darwin10 -c %s -### 2>&1 | \
 // RUN:   FileCheck --check-prefix=CHECK-VERSION-OSX6 %s
-// RUN: %clang -target i686-apple-darwin9 -mmacosx-version-min=10.6 -c %s -### 2>&1 | \
+// RUN: %clang -target i686-apple-darwin9 -mmacos-version-min=10.6 -c %s -### 2>&1 | \
 // RUN:   FileCheck --check-prefix=CHECK-VERSION-OSX6 %s
 // CHECK-VERSION-OSX6: "i686-apple-macosx10.6.0"
 // RUN: %clang -target x86_64-apple-darwin14 -c %s -### 2>&1 | \
 // RUN:   FileCheck --check-prefix=CHECK-VERSION-OSX10 %s
-// RUN: %clang -target x86_64-apple-darwin -mmacosx-version-min=10.10 -c %s -### 2>&1 | \
+// RUN: %clang -target x86_64-apple-darwin -mmacos-version-min=10.10 -c %s -### 2>&1 | \
 // RUN:   FileCheck --check-prefix=CHECK-VERSION-OSX10 %s
 // RUN: %clang -target x86_64-apple-darwin -mmacos-version-min=10.10 -c %s -### 2>&1 | \
 // RUN:   FileCheck --check-prefix=CHECK-VERSION-OSX10 %s
 // CHECK-VERSION-OSX10: "x86_64-apple-macosx10.10.0"
-// RUN: not %clang -target x86_64-apple-darwin -mmacosx-version-min= -c %s -### 2>&1 | \
+// RUN: not %clang -target x86_64-apple-darwin -mmacos-version-min= -c %s -### 2>&1 | \
 // RUN:   FileCheck --check-prefix=CHECK-VERSION-MISSING %s
 // RUN: not %clang -target x86_64-apple-darwin -mmacos-version-min= -c %s -### 2>&1 | \
 // RUN:   FileCheck --check-prefix=CHECK-VERSION-MISSING %s

--- a/clang/test/Driver/darwin-xarch.c
+++ b/clang/test/Driver/darwin-xarch.c
@@ -1,6 +1,6 @@
 // RUN: %clang --target=x86_64-apple-darwin10 -### \
-// RUN:   -arch i386 -Xarch_i386 -mmacosx-version-min=10.4 \
-// RUN:   -arch x86_64 -Xarch_x86_64 -mmacosx-version-min=10.5 \
+// RUN:   -arch i386 -Xarch_i386 -mmacos-version-min=10.4 \
+// RUN:   -arch x86_64 -Xarch_x86_64 -mmacos-version-min=10.5 \
 // RUN:   -c %s 2> %t
 // RUN: FileCheck --check-prefix=CHECK-COMPILE < %t %s
 //

--- a/clang/test/Driver/fsanitize.c
+++ b/clang/test/Driver/fsanitize.c
@@ -545,7 +545,7 @@
 // RUN: %clang --target=riscv64-pc-freebsd -fsanitize=function %s -### 2>&1 | FileCheck %s --check-prefix=CHECK-FUNCTION
 // CHECK-FUNCTION: -cc1{{.*}}"-fsanitize=function" "-fsanitize-recover=function"
 
-// RUN: not %clang --target=x86_64-apple-darwin10 -mmacosx-version-min=10.8 -fsanitize=vptr %s -### 2>&1 | FileCheck %s --check-prefix=CHECK-VPTR-DARWIN-OLD
+// RUN: not %clang --target=x86_64-apple-darwin10 -mmacos-version-min=10.8 -fsanitize=vptr %s -### 2>&1 | FileCheck %s --check-prefix=CHECK-VPTR-DARWIN-OLD
 // CHECK-VPTR-DARWIN-OLD: unsupported option '-fsanitize=vptr' for target 'x86_64-apple-darwin10'
 
 // RUN: not %clang --target=arm-apple-ios4 -fsanitize=vptr %s -### 2>&1 | FileCheck %s --check-prefix=CHECK-VPTR-IOS-OLD
@@ -557,7 +557,7 @@
 // RUN: %clang --target=x86_64-apple-darwin15.0.0-simulator -fsanitize=vptr %s -### 2>&1
 // OK
 
-// RUN: %clang --target=x86_64-apple-darwin10 -mmacosx-version-min=10.9 -fsanitize=alignment,vptr %s -### 2>&1 | FileCheck %s --check-prefix=CHECK-VPTR-DARWIN-NEW
+// RUN: %clang --target=x86_64-apple-darwin10 -mmacos-version-min=10.9 -fsanitize=alignment,vptr %s -### 2>&1 | FileCheck %s --check-prefix=CHECK-VPTR-DARWIN-NEW
 // CHECK-VPTR-DARWIN-NEW: -fsanitize=alignment,vptr
 
 // RUN: %clang --target=armv7-apple-ios7 -miphoneos-version-min=7.0 -fsanitize=address %s -### 2>&1 | FileCheck %s --check-prefix=CHECK-ASAN-IOS
@@ -643,7 +643,7 @@
 // RUN: not %clang --target=x86_64-linux-gnu -fsanitize-trap=hwaddress -c %s -### 2>&1 | FileCheck %s --check-prefix=CHECK-HWASAN-TRAP
 // CHECK-HWASAN-TRAP: error: unsupported argument 'hwaddress' to option '-fsanitize-trap='
 
-// RUN: not %clang --target=x86_64-apple-darwin10 -mmacosx-version-min=10.7 -flto -fsanitize=cfi-vcall -fno-sanitize-trap=cfi -c %s -### 2>&1 | FileCheck %s --check-prefix=CHECK-CFI-NOTRAP-OLD-MACOS
+// RUN: not %clang --target=x86_64-apple-darwin10 -mmacos-version-min=10.7 -flto -fsanitize=cfi-vcall -fno-sanitize-trap=cfi -c %s -### 2>&1 | FileCheck %s --check-prefix=CHECK-CFI-NOTRAP-OLD-MACOS
 // CHECK-CFI-NOTRAP-OLD-MACOS: error: unsupported option '-fno-sanitize-trap=cfi-vcall' for target 'x86_64-apple-darwin10'
 
 // RUN: %clang --target=x86_64-pc-win32 -flto -fsanitize=cfi-vcall -fno-sanitize-trap=cfi -c -resource-dir=%S/Inputs/resource_dir %s -### 2>&1 | FileCheck %s --check-prefix=CHECK-CFI-NOTRAP-WIN

--- a/clang/test/Driver/macos-apple-silicon-slice-link-libs-darwin-only.cpp
+++ b/clang/test/Driver/macos-apple-silicon-slice-link-libs-darwin-only.cpp
@@ -1,5 +1,5 @@
-// RUN: %clang -### -target arm64-apple-darwin -arch arm64 -mmacosx-version-min=10.7 %s 2>&1 | FileCheck -check-prefix=ARM64-10_7 %s
-// RUN: %clang -### -target x86_64-apple-darwin10 -arch x86_64 -mmacosx-version-min=10.7 %s 2>&1 | FileCheck -check-prefix=x86_64-10_7 %s
+// RUN: %clang -### -target arm64-apple-darwin -arch arm64 -mmacos-version-min=10.7 %s 2>&1 | FileCheck -check-prefix=ARM64-10_7 %s
+// RUN: %clang -### -target x86_64-apple-darwin10 -arch x86_64 -mmacos-version-min=10.7 %s 2>&1 | FileCheck -check-prefix=x86_64-10_7 %s
 // REQUIRES: system-darwin
 
 // ARM64-10_7-NOT: -lcrt1.10.6.o

--- a/clang/test/Driver/sanitizer-ld.c
+++ b/clang/test/Driver/sanitizer-ld.c
@@ -688,7 +688,7 @@
 // CHECK-CFI-CROSS-DSO-DIAG-ANDROID: "--export-dynamic-symbol=__cfi_check"
 
 // RUN: %clangxx -fsanitize=address -### %s 2>&1 \
-// RUN:     -mmacosx-version-min=10.6 \
+// RUN:     -mmacos-version-min=10.6 \
 // RUN:     --target=x86_64-apple-darwin13.4.0 -fuse-ld=ld -stdlib=platform \
 // RUN:     -resource-dir=%S/Inputs/resource_dir \
 // RUN:     --sysroot=%S/Inputs/basic_linux_tree \
@@ -698,7 +698,7 @@
 // CHECK-ASAN-DARWIN106-CXX-NOT: -lc++abi
 
 // RUN: %clangxx -fsanitize=leak -### %s 2>&1 \
-// RUN:     -mmacosx-version-min=10.6 \
+// RUN:     -mmacos-version-min=10.6 \
 // RUN:     --target=x86_64-apple-darwin13.4.0 -fuse-ld=ld -stdlib=platform \
 // RUN:     -resource-dir=%S/Inputs/resource_dir \
 // RUN:     --sysroot=%S/Inputs/basic_linux_tree \

--- a/clang/test/Driver/stack-protector.c
+++ b/clang/test/Driver/stack-protector.c
@@ -43,15 +43,15 @@
 // RUN: %clang -target arm64-apple-ios8.0.0 -### %s 2>&1 | FileCheck %s -check-prefix=SSP_IOS
 // RUN: %clang -ffreestanding -target arm64-apple-ios8.0.0 -### %s 2>&1 | FileCheck %s -check-prefix=SSP_IOS
 // SSP_IOS: "-stack-protector" "1"
-// RUN: %clang -target x86_64-apple-darwin10 -mmacosx-version-min=10.6 -### %s 2>&1 | FileCheck %s -check-prefix=SSP_MACOSX
-// RUN: %clang -ffreestanding -target x86_64-apple-darwin10 -mmacosx-version-min=10.6 -### %s 2>&1 | FileCheck %s -check-prefix=SSP_MACOSX
+// RUN: %clang -target x86_64-apple-darwin10 -mmacos-version-min=10.6 -### %s 2>&1 | FileCheck %s -check-prefix=SSP_MACOSX
+// RUN: %clang -ffreestanding -target x86_64-apple-darwin10 -mmacos-version-min=10.6 -### %s 2>&1 | FileCheck %s -check-prefix=SSP_MACOSX
 // SSP_MACOSX: "-stack-protector" "1"
-// RUN: %clang -target x86_64-apple-darwin10 -mmacosx-version-min=10.5 -### %s 2>&1 | FileCheck %s -check-prefix=SSP_MACOSX_10_5
-// RUN: %clang -ffreestanding -target x86_64-apple-darwin10 -mmacosx-version-min=10.5 -### %s 2>&1 | FileCheck %s -check-prefix=SSP_MACOSX_10_5
+// RUN: %clang -target x86_64-apple-darwin10 -mmacos-version-min=10.5 -### %s 2>&1 | FileCheck %s -check-prefix=SSP_MACOSX_10_5
+// RUN: %clang -ffreestanding -target x86_64-apple-darwin10 -mmacos-version-min=10.5 -### %s 2>&1 | FileCheck %s -check-prefix=SSP_MACOSX_10_5
 // SSP_MACOSX_10_5: "-stack-protector" "1"
-// RUN: %clang -target x86_64-apple-darwin10 -mmacosx-version-min=10.5 -mkernel -### %s 2>&1 | FileCheck %s -check-prefix=SSP_MACOSX_KERNEL
+// RUN: %clang -target x86_64-apple-darwin10 -mmacos-version-min=10.5 -mkernel -### %s 2>&1 | FileCheck %s -check-prefix=SSP_MACOSX_KERNEL
 // SSP_MACOSX_KERNEL-NOT: "-stack-protector"
-// RUN: %clang -target x86_64-apple-darwin10 -mmacosx-version-min=10.6 -### %s 2>&1 | FileCheck %s -check-prefix=SSP_MACOSX_10_6_KERNEL
-// RUN: %clang -ffreestanding -target x86_64-apple-darwin10 -mmacosx-version-min=10.6 -### %s 2>&1 | FileCheck %s -check-prefix=SSP_MACOSX_10_6_KERNEL
+// RUN: %clang -target x86_64-apple-darwin10 -mmacos-version-min=10.6 -### %s 2>&1 | FileCheck %s -check-prefix=SSP_MACOSX_10_6_KERNEL
+// RUN: %clang -ffreestanding -target x86_64-apple-darwin10 -mmacos-version-min=10.6 -### %s 2>&1 | FileCheck %s -check-prefix=SSP_MACOSX_10_6_KERNEL
 // SSP_MACOSX_10_6_KERNEL: "-stack-protector" "1"
 

--- a/clang/test/Index/TestClassForwardDecl.m
+++ b/clang/test/Index/TestClassForwardDecl.m
@@ -1,4 +1,4 @@
-// RUN: c-index-test -write-pch %t.ast -arch x86_64 -mmacosx-version-min=10.6 %s
+// RUN: c-index-test -write-pch %t.ast -arch x86_64 -mmacos-version-min=10.6 %s
 // RUN: c-index-test -test-file-scan %t.ast %s | FileCheck -check-prefix=CHECK-scan %s
 // RUN: c-index-test -test-load-tu %t.ast local | FileCheck -check-prefix=CHECK-load %s
 // REQUIRES: x86-registered-target

--- a/clang/test/Index/c-index-api-loadTU-test.m
+++ b/clang/test/Index/c-index-api-loadTU-test.m
@@ -1,4 +1,4 @@
-// RUN: c-index-test -write-pch %t.ast -arch x86_64 -mmacosx-version-min=10.6 -fblocks -x objective-c %s
+// RUN: c-index-test -write-pch %t.ast -arch x86_64 -mmacos-version-min=10.6 -fblocks -x objective-c %s
 // RUN: c-index-test -test-load-tu %t.ast all > %t 2>&1 && FileCheck --input-file=%t %s
 // REQUIRES: x86-registered-target
 @interface Foo 

--- a/clang/test/Index/c-index-getCursor-test.m
+++ b/clang/test/Index/c-index-getCursor-test.m
@@ -1,4 +1,4 @@
-// RUN: c-index-test -write-pch %t.ast -arch x86_64 -mmacosx-version-min=10.6 -fblocks -x objective-c %s
+// RUN: c-index-test -write-pch %t.ast -arch x86_64 -mmacos-version-min=10.6 -fblocks -x objective-c %s
 // RUN: c-index-test -test-file-scan %t.ast %s > %t 2>&1 && FileCheck --input-file=%t %s
 @interface Foo 
 {

--- a/clang/tools/scan-build/libexec/ccc-analyzer
+++ b/clang/tools/scan-build/libexec/ccc-analyzer
@@ -389,6 +389,7 @@ my %CompilerLinkerOptionMap = (
   '-target' => 1,
   '-v' => 0,
   '-mmacosx-version-min' => 0, # This is really a 1 argument, but always has '='
+  '-mmacos-version-min' => 0, # This is really a 1 argument, but always has '='
   '-miphoneos-version-min' => 0, # This is really a 1 argument, but always has '='
   '--target' => 0
 );


### PR DESCRIPTION
The -mmacos-version-min flag is preferred over -mmacosx-version-min. This patch updates the tests and documentation to make this clear and also adds the missing logic to scan build to handle the new flag.

Fixes #86376.