### PR TITLE
tidy

### DIFF
--- a/clang-tools-extra/clang-tidy/readability/ElseAfterReturnCheck.cpp
+++ b/clang-tools-extra/clang-tidy/readability/ElseAfterReturnCheck.cpp
@@ -231,7 +231,7 @@ static StringRef getControlFlowString(const Stmt &Stmt) {
     return "break";
   if (isa<CXXThrowExpr>(Stmt))
     return "throw";
-  llvm_unreachable("Unknown control flow interruptor");
+  llvm_unreachable("Unknown control flow interrupter");
 }
 
 void ElseAfterReturnCheck::check(const MatchFinder::MatchResult &Result) {
@@ -247,12 +247,12 @@ void ElseAfterReturnCheck::check(const MatchFinder::MatchResult &Result) {
     return;
 
   bool IsLastInScope = OuterScope->body_back() == If;
-  StringRef ControlFlowInterruptor = getControlFlowString(*Interrupt);
+  const StringRef ControlFlowInterrupter = getControlFlowString(*Interrupt);
 
   if (!IsLastInScope && containsDeclInScope(Else)) {
     if (WarnOnUnfixable) {
       // Warn, but don't attempt an autofix.
-      diag(ElseLoc, WarningMessage) << ControlFlowInterruptor;
+      diag(ElseLoc, WarningMessage) << ControlFlowInterrupter;
     }
     return;
   }
@@ -264,7 +264,7 @@ void ElseAfterReturnCheck::check(const MatchFinder::MatchResult &Result) {
       // If the if statement is the last statement of its enclosing statements
       // scope, we can pull the decl out of the if statement.
       DiagnosticBuilder Diag = diag(ElseLoc, WarningMessage)
-                               << ControlFlowInterruptor
+                               << ControlFlowInterrupter
                                << SourceRange(ElseLoc);
       if (checkInitDeclUsageInElse(If) != nullptr) {
         Diag << tooling::fixit::createReplacement(
@@ -288,7 +288,7 @@ void ElseAfterReturnCheck::check(const MatchFinder::MatchResult &Result) {
       removeElseAndBrackets(Diag, *Result.Context, Else, ElseLoc);
     } else if (WarnOnUnfixable) {
       // Warn, but don't attempt an autofix.
-      diag(ElseLoc, WarningMessage) << ControlFlowInterruptor;
+      diag(ElseLoc, WarningMessage) << ControlFlowInterrupter;
     }
     return;
   }
@@ -300,7 +300,7 @@ void ElseAfterReturnCheck::check(const MatchFinder::MatchResult &Result) {
       // If the if statement is the last statement of its enclosing statements
       // scope, we can pull the decl out of the if statement.
       DiagnosticBuilder Diag = diag(ElseLoc, WarningMessage)
-                               << ControlFlowInterruptor
+                               << ControlFlowInterrupter
                                << SourceRange(ElseLoc);
       Diag << tooling::fixit::createReplacement(
                   SourceRange(If->getIfLoc()),
@@ -312,13 +312,13 @@ void ElseAfterReturnCheck::check(const MatchFinder::MatchResult &Result) {
       removeElseAndBrackets(Diag, *Result.Context, Else, ElseLoc);
     } else if (WarnOnUnfixable) {
       // Warn, but don't attempt an autofix.
-      diag(ElseLoc, WarningMessage) << ControlFlowInterruptor;
+      diag(ElseLoc, WarningMessage) << ControlFlowInterrupter;
     }
     return;
   }
 
   DiagnosticBuilder Diag = diag(ElseLoc, WarningMessage)
-                           << ControlFlowInterruptor << SourceRange(ElseLoc);
+                           << ControlFlowInterrupter << SourceRange(ElseLoc);
   removeElseAndBrackets(Diag, *Result.Context, Else, ElseLoc);
 }
 


### PR DESCRIPTION
- **[MLIR] Translate DIStringType. (#94480)**
- **[clangd] Fix crash with null check for Token at Loc (#94528)**
- **[flang][Transforms][NFC] Remove boilerplate from vscale range pass (#94598)**
- **[PowerPC] modify the frameaddress case, NFC**
- **[PowerPC] return correct frame address for frameaddress intrinsic**
- **[ARM] Add NEON support for ISD::ABDS/ABDU nodes. (#94504)**
- **[CMake][Release] Use the TXZ cpack generator for binaries (#90138)**
- **[DebugInfo] Add DW_OP_LLVM_extract_bits (#93990)**
- **Add checks before hoisting out in loop pipelining  (#90872)**
- **[clang][Interp][NFC] Properly assign block pointer Pointee**
- **[clang][Interp] Fix refers_to_enclosing_variable_or_capture DREs**
- **[SimplifyCFG] Remove bogus UTC line from test (NFC)**
- **[SimplifyCFG] Regenerate switch to lookup tests (NFC)**
- **[mlir][vector] Add n-d deinterleave lowering (#94237)**
- **[ARM] r11 is reserved when using -mframe-chain=aapcs (#86951)**
- **[DAG] Always allow folding XOR patterns to ABS pre-legalization (#94601)**
- **fix(mlir/**.py): fix comparison to None (#94019)**
- **[ARM] Add support for Cortex-R52+ (#94633)**
- **[NFC][LoongArch] Update test for #94590**
- **[clang][test] Skip interpreter value test on Arm 32 bit**
- **[gn build] Port e622996eddfb**
- **[Flang] Handle the newly-added "Reserved" FramePointerKind for 1a5239251ead73ee57f4e2f7fc93433ac7cf18b1**
- **[clang][SPIR-V] Add support for AMDGCN flavoured SPIRV (#89796)**
- **[BOLT][NFC] Infailable fns return void (#92018)**
- **[CodeGen][SDAG] Remove CombinedNodes SmallPtrSet (#94609)**
- **[clang][Interp] Check ConstantExpr results for initialization**
- **[clang][Interp][NFC] Fix a const-correctness warning**
- **[clang][Interp] Limit lambda capture lazy visting to actual captures**
- **[serialization] no transitive decl change (#92083)**
- **[AMDGPU] Fix interaction between WQM and llvm.amdgcn.init.exec (#93680)**
- **[Frontend][OpenMP] Sort all the things in OMP.td, NFC (#94653)**
- **[flang][OpenMP] Lower `target .. private(..)` to `omp.private` ops (#94195)**
- **[libc] Correctly pass the C++ standard to NVPTX internal builds**
- **[mlir][linalg] Support lowering unpack with outer_dims_perm (#94477)**
- **[mlir] Add reshape propagation patterns for tensor.pad (#94489)**
- **[mlir] Fix bugs in expand_shape patterns after semantics changes (#94631)**
- **[ARM] Clean up neon_vabd.ll, vaba.ll and vabd.ll tests a bit. NFC**
- **[arm64] Add tan intrinsic lowering (#94545)**
- **[AArch64] Add addp from shuffles tests. NFC**
- **[Clang] Add timeout for GPU detection utilities (#94751)**
- **[RISCV] Codegen support for XCVmem extension (#76916)**
- **[MachineOutliner] Sort by Benefit to Cost Ratio (#90264)**
- **[memprof] Clean up IndexedMemProfReader (NFC) (#94710)**
- **[flang] lower SIZE and SIZEOF for assumed-ranks (#94684)**
- **[memprof] Use CallStackRadixTreeBuilder in the V3 format (#94708)**
- **[mlir][vector] Remove Emulated Sub-directory (#94742)**
- **[gn] port 33a6ce18373ff (check-clang obj2yaml dep)**
- **[gn] port cb7690af09b95 (ntdll dep)**
- **[KnownBits] Remove `hasConflict()` assertions (#94568)**
- **[libc++][test][AIX] Only XFAIL atomic tests for before clang 19 (#94646)**
- **[AArch64] Add patterns for add(uzp1(x,y), uzp2(x, y)) -> addp.**
- **[LV] Add test with dead load and vector pointer.**
- **[libc++][regex] Correctly adjust match prefix for zero-length matches. (#94550)**
- **Reapply PR/87550 (#94625)**
- **[libc++] Undeprecate shared_ptr atomic access APIs (#92920)**
- **[Reassociate] shifttest.ll - generate test checks to replace custom grep expression**
- **[flang][runtime] add SHAPE runtime interface (#94702)**
- **[flang][OpenMP] Add `--openmp-enable-delayed-privatization-staging` flag (#94749)**
- **[OpenMP] Fix passing target id features to AMDGPU offloading (#94765)**
- **Fixed grammatical error in "enum specifier" error msg #94443 (#94592)**
- **[clang] always use resolved arguments for default argument deduction (#94756)**
- **Check if LLD is built when checking if lto_supported (#92752)**
- **[mlir][vector][NFC] Make function name more meaningful in lit tests. (#94538)**
- **[SDISel][Builder] Fix the instantiation of <1 x bfloat|half> (#94591)**
- **[RISCV] Fold (vXi8 (trunc (vselect (setltu, X, 256), X, (sext (setgt X, 0))))) to vmax+vnclipu. (#94720)**
- **[RISCV] Add .insn alias for addresses without the leading immediate. (#94698)**
- **Revert "Reapply PR/87550 (#94625)"**
- **[AArch64] Add patterns for fadd(uzp1(x,y), uzp2(x, y)) -> faddp.**
- **[libc++][NFC] Fix typo**
- **[CGSCC] Verify that call graph is valid after iteration (#94692)**
- **Fix #pragma (packed, n) not emitting the alignment in debug info (#94673)**
- **[clang] Add fixit for using declaration with a (qualified) namespace (#94762)**
- **[libc] Add baremetal printf (#94078)**
- **[PseudoProbe] Make probe discriminator compatible with dwarf base discriminator (#94506)**
- **[Driver,test] Add -Wno-msvc-not-found to gcc-param.c**
- **[clang][driver] Enable '-flto' on bare-metal (#94738)**
- **[CMake] Fix building on Haiku (#94721)**
- **[SPIR-V] Improve type inference, addrspacecast and dependencies between SPIR-V entities and required capability/extensions (#94626)**
- **[bazel] Port #94078 (#94792)**
- **[RISCV][GISel] Do libcall for G_FPTOSI, G_FPTOUI when no D or F support (#94613)**
- **[llvm-dwarfdump] Add a null-check in `prettyPrintBaseTypeRef`. (#93156)**
- **[InstCombine] Add tests for folding `(icmp eq/ne (xor x, C0), C1)`; NFC**
- **[InstCombine] Fold `(icmp eq/ne (xor x, y), C1)` even if multiuse**
- **[OpenMP][Offload] - Ensure OPENMP_STANDALONE_BUILD is defined (#94801)**
- **InstCombine: Fix testing of pow libcall in errno case (#94772)**
- **[lldb] Encode operands and arity in Dwarf.def and use them in LLDB. (#94679)**
- **[AArch64][LoopIdiom] Generalize AArch64LoopIdiomTransform into LoopIdiomVectorize (#94081)**
- **[ELF] Implement --force-group-allocation**
- **[VectorCombine] Add tests for shuffleToIdentity of concats. NFC**
- **[bazel] Port #94081 (#94805)**
- **[BOLT][NFC] Unset UseAssemblerInfoForParsing for emission (#94778)**
- **[ProfileData] Add const to a few places (NFC) (#94803)**
- **[RISCV] Add TargetConstraintType=2 to vnclip pseudoinstructions. NFC**
- **[libc][math][c23] Add fmodf16 C23 math function (#94629)**
- **[clang-tidy] new check misc-use-internal-linkage (#90830)**
- **[libc][math][c23] Temporarily disable fmodf16 on AArch64 (#94813)**
- **[RISCV] Remove unused tablegen multiclasses. NFC**
- **Reland "[python] Bump Python minimum version to 3.8 (#78828)"**
- **[mlir][loops] Add getters for multi dim loop variables in `LoopLikeOpInterface` (#94516)**
- **[MemProf] Add matching statistics and tracing (#94814)**
- **[memprof] Fix a build error**
- **[RISCV] Remove unused tablegen multiclass. NFC**
- **[RISCV] Remove CarryIn and Constraint parameters from VPseudoTiedBinaryCarryIn. NFC**
- **[RISCV] Rename VPseudoBinaryCarryIn to VPseudoBinaryCarry. NFC**
- **Add AllowRepeats to SBCommandInterpreterRunOptions. (#94786)**
- **[memprof] Improve deserialization performance in V3 (#94787)**
- **[InstCombine] Preserve the nsw/nuw flags for (X | Op01C) + Op1C --> X + (Op01C + Op1C) (#94586)**
- **[lld] Discard SHT_LLVM_LTO sections in relocatable links (#92825)**
- **[ProfileData] Use default member initialization (NFC) (#94817)**
- **[ProfileData] Use DenseMap::lookup (NFC) (#94818)**
- **[gn build] Port 37e309f16354 (AArch64 loopvectorize)**
- **[memprof] Remove extraneous memprof:: (NFC) (#94825)**
- **[gn build] Port c4f83a004bf3**
- **[RISCV] Rename VPseudoVWALU_VV_VX_VI to VPseudoVWSLL. NFC**
- **[RISCV] Refactor VPseudoVROL and VPseudoVROR multiclasses to use inheritance. NFC**
- **[RISCV] Rename VPseudoBinaryNoMaskTU->VPseudoBinaryNoMaskPolicy. NFC**
- **[RISCV] Rename VPatBinarySwapped to VPatBinaryMSwapped. NFC**
- **[RISCV] Flatten VPatBinaryW_VI_VWSLL and VPatBinaryW_VX_VWSLL into VPatBinaryW_VV_VX_VI_VWSLL. NFC**
- **[workflows] Add post-commit job that periodically runs the clang static analyzer (#94106)**
- **[mlir] Handle the newly-added "Reserved" FramePointerKind for 1a5239251ead73ee57f4e2f7fc93433ac7cf18b1 (NFC)**
- **[dfsan] Fix release_shadow_space.c (#94770)**
- **[HLSL] Use llvm::Triple::EnvironmentType instead of HLSLShaderAttr::ShaderType (#93847)**
- **[CMake] Update CMake cache file for the ARM/Aarch64 cross toolchain builds. NFC. (#94835)**
- **[RISCV] Remove many ImmType parameters from tablegen classes. NFC**
- **[RISCV] Remove unused defaults for sew paramters in tablegen. NFC**
- **[lldb] Remove redundant c_str() calls in stream output (NFC) (#94839)**
- **Revert "[lld][AArch64][ELF][PAC] Support `.relr.auth.dyn` section" (#94843)**
- **[RISCV] Replace VPseudoBinaryFV_VV with VPseudoBinaryV_VV. NFC**
- **[RISCV] Remove unnecessary setting of parameter with same default value. NFC**
- **[Support] Do not use `llvm::size` in `getLoopPreheader` (#94540)**
- **[SystemZ] Fix handling of triples.**
- **[mlir][Transforms][NFC] `GreedyPatternRewriteDriver`: Use composition instead of inheritance (#92785)**
- **[clang] Report erroneous floating point results in _Complex math (#90588)**
- **[SDISel][Combine] Constant fold FP16_TO_FP (#94790)**
- **[compiler-rt] Replace deprecated aligned_storage with aligned byte array (#94171)**
- **lld/test: Make sure removing %t at first**
- **Enable LLDB tests in Linux pre-merge CI (#94208)**
- **[SimplifyCFG] Don't use a mask for lookup tables generated from switches with an unreachable default case (#94468)**
- **[llvm] Remove useless headers in example BrainF (#93701)**
- **[DAGCombine] Fix miscompilation caused by PR94008 (#94850)**
- **[Reassociate] Use uint64_t for repeat count (#94232)**
- **[X86] Support ATOMIC_LOAD_FP_BINOP_MI for other binops (#87524)**
- **[memprof] Make Version3 officially available (#94837)**
- **[ProfileData] Use a range-based for loop (NFC) (#94856)**
- **[memprof] Remove redundant virtual (NFC) (#94858)**
- **[libc++][NFC] Simplify the implementation of `__promote` (#81379)**
- **[RISCV][MC] Implicit 0-offset aliases for JR/JALR (#94688)**
- **[ProfileData] Use default member initialization (NFC) (#94860)**
- **[lldb] Use const reference for range variables to improve performance (NFC) (#94840)**
- **[libc][math][c23] fmul correcly rounded to all rounding modes (#91537)**
- **[libc][math][C23] Implemented remquof128 function (#94809)**
- **[VPlan] Check if only first part is used for all per-part VPInsts.**
- **[RISCV][GISel] Add calling convention support for half (#94110)**
- **[VPlan] Mark FirstOrderRecurrenceSplice as not having side-effects.**
- **[ProfileData] Simplify calls to readNext in readBinaryIdsInternal (NFC) (#94862)**
- **[mlir][nfc] Sort test passes registration (#94201)**
- **[InstCombine] Add tests for propagating flags when folding consecutative shifts; NFC**
- **[InstCombine] Propagate flags when folding consecutative shifts**
- **[clang][NFC] Update CWG issues list**
- **[MC] Simplify Sec.getFragmentList().insert(Sec.begin(), F). NFC**
- **[SPARC][IAS] Add GNU extension for `addc`**
- **[SPARC][IAS] Add support for %uhi and %ulo extensions**
- **[SPARC][IAS] Add aliases for %asr20-21 as defined in JPS1**
- **[clang][Interp][NFC] Refactor lvalue-to-rvalue conversion code**
- **[clang-tidy] Ignore non-math operators in readability-math-missing-parentheses (#94654)**
- **[mlir][Transforms][NFC] Improve dialect conversion documentation (#94736)**
- **[ARM] vector-store.ll - add big-endian test coverage**
- **[clang-tidy] Ignore implicit functions in readability-implicit-bool-conversion (#94512)**
- **[clang-tidy] Extend modernize-use-designated-initializers with new options (#94651)**
- **[clang-tidy] Improve bugprone-multi-level-implicit-pointer-conversion (#94524)**
- **[X86] Trim trailing whitespace to reduce diff in #94845**
- **[DAG] FoldConstantArithmetic - allow binop folding to work with differing bitcasted constants (#94863)**
- **[DAG] Fold fdiv X, c2 -> fmul X, 1/c2 without AllowReciprocal if exact (#93882)**
- **[VPlan] Handle more cases in VPInstruction::onlyFirstPartUsed.**
- **[clang][Interp] Implement ~ operator for complex values**
- **[clang][Interp] Handle __extension__ for complex values**
- **[clang][Interp] Reject compound assign operators pre-C++14**
- **[AMDGPU] Swap range metadata to attribute for workitem id. (#94871)**
- **[SPARC][IAS] Add named prefetch tag constants**
- **[SPARC][IAS] Add support for `prefetcha` instruction**
- **Use StringRef::starts_with (NFC) (#94886)**
- **[SPARC][IAS] Handle the case of non-4-byte aligned writeNopData**
- **[SPARC][IAS] Add movr(n)e alias for movr(n)z**
- **[libc++][TZDB] Implements time_zone get_info(local_time). (#89537)**
- **[Instrumentation] Remove an extraneous ArrayRef (NFC) (#94890)**
- **[clang] NFC: add new cwg2398 tests**
- **[ProfileData] Use ArrayRef instead of const std::vector<T> & (NFC) (#94878)**
- **[RISCV] Cleanup some Constraint parameters in RISCVInstrInfoVPseudos.td. NFC**
- **[InstCombine] Fix missing argument typo in `InstCombinerImpl::foldICmpShlConstant` (#94899)**
- **GlobalISel: Remove faulty assert in buildAtomicRMW op**
- **[NFC][mlir][gpu] Fully-qualify all namespaces in the GPU compilation interfaces (#94908)**
- **[Clang][OpenMP] throw compilation error instead of crash in Stmt::OMPScopeDirectiveClass case (#77535) (#84135)**
- **[ProfileData] Refactor VTableNamePtr and CompressedVTableNamesLen (NFC) (#94859)**
- **[libc++][TZDB] Implements time_zone::to_sys. (#90394)**
- **[NFC][mlir][gpu] Make sym_name an inherent attr in GPUModuleOp (#94918)**
- **MCInst: decrease inline element count to 6. NFC**
- **[RISCV] Remove unused tablegen classes. NFC**
- **[RISCV] Replace TU with Policy in tablegen class name. NFC**
- **[mlir][python] Fix attribute registration in ir.py (#94615)**
- **[ProfileData] Refactor BinaryIdsStart and BinaryIdsSize (NFC) (#94922)**
- **[MC,test] Reorganize relax-recompute-align.s & layout-interdependency.s**
- **[libc][math][c23] Add nanf16 C23 math function (#94767)**
- **[MC] Relax fragments eagerly**
- **[mlir][bufferization] Fix handling of indirect function calls (#94896)**
- **[MC] Remove the last MCFragment::getPrevNode use. NFC**
- **[libc++][TZDB] Implements time_zone::to_sys. (#90901)**
- **[clang][Interp] Disallow ptr-to-int casts on dummy pointers**
- **[lld] Remove const qualifier on symbolKind (NFC) (#94753)**
- **[CodeGen] Simplify codegen for array initialization (#93956)**
- **[TLI] ReplaceWithVecLib: drop Instruction support (#94365)**
- **[dexter] Correctly identify stop-reason while driving VisualStudio (#94754)**
- **[flang] add source to SHAPE API (#94781)**
- **Reapply [ConstantFold] Remove non-trivial gep-of-gep fold (#93823)**
- **[clang][Interp] Diagnose casts from void pointers**
- **[clang][analyzer] Improved PointerSubChecker (#93676)**
- **[RemoveDIs] C API: Add before-dbg-record versions of IRBuilder position funcs (#92417)**
- **[flang] lower SHAPE with assumed-rank arguments (#94812)**
- **[lldb] Fix redundant condition in compression type check (NFC) (#94841)**
- **[lldb] Remove redundant condition in watch mask check (NFC) (#94842)**
- **NFC fix typos from #92417**
- **[scudo] Apply filling when realloc shrinks and re-grows a block in-place (#93212)**
- **[flang][runtime] add LBOUND API for assumed-rank arrays (#94808)**
- **[lldb] Gracefully down TestCoroutineHandle test in case the 'coroutine' feature is missing (#94903)**
- **[KnownBits] Speed up ForeachKnownBits in unit test. NFC. (#94939)**
- **[AMDGPU] Remove unused checks left over from X86**
- **[clang-tidy] `doesNotMutateObject`: Handle calls to member functions … (#94362)**
- **[AMDGPU] Fix typos in GCN-PROMOTE check prefix**
- **[flang] use hlfir base when translating assumed-rank entity to fir::ExtendedValue (#94822)**
- **[flang][Transforms][NFC] reduce boilerplate in func attr pass (#94739)**
- **[Clang][C++23] update constexpr diagnostics for missing return statements per P2448 (#94123)**
- **[KnownBits] Speed up conflict handling in ForeachKnownBits in unit test. (#94943)**
- **[flang][OpenMP] Fix unused prefixes in function-filtering-2 test (#94330)**
- **[libc++][TZDB] Implements time_zone::to_local. (#91003)**
- **[AArch64] Add tests for extending mul. NFC**
- **[mlir][emitc] Remove copy from scf.for lowering (#94898)**
- **[Clang] Extend EmitPseudoVariable to support debug records (#94956)**
- **[mlir][ArmSME] Add option to only enable streaming mode for scalable code (#94759)**
- **[RFC][AMDGPU] Remove old llvm.amdgcn.buffer.* and tbuffer intrinsics (#93801)**
- **[AMDGPU] Support SIProgramInfo MCExpr for comments and remarks (#94350)**
- **Revert "[scudo] Apply filling when realloc shrinks and re-grows a block in-place (#93212)"**
- **[mlir][EmitC] Fix call ops with zero arguments in func to emitc conversion (#94936)**
- **[KnownBits] re-introduce RefinePosionToZero in unittest (#94848)**
- **Reapply#3 "[RemoveDIs] Load into new debug info format by default in LLVM (#89799)"**
- **[LV] Add extra X86 cost tests for any_of reduction and multi-exit loops.**
- **[Flang] Update test to not check for tail calls on debug intrinsics**
- **[Misc] Use `LLVM_ENABLE_ABI_BREAKING_CHECKS` correctly (#94212)**
- **[AMDGPU] Fix -Wunused-variable in AMDGPUAsmPrinter.cpp (NFC)**
- **[libc][math][c23] Add {frexp,ilogb,llogb,logb,modf}f16 C23 math functions (#94758)**
- **[LVI] Remove unused get of Range metadata (#94914)**
- **[libc][math][c23] Temporarily disable modff16 on AArch64 (#94972)**
- **[AArch64] Decouple feature dependency expansion. (#94279)**
- **[Frontend] Introduce `getDirectiveCategory` for ACC/OMP directives (#94689)**
- **[gn build] port 77116bd7d268**
- **[clang] NFCI: improve TemplateArgument and TemplateName dump methods (#94905)**
- **[libc++] Fix invalid escape sequences in Python comments (#94032)**
- **[AArch64] fix Windows buildbot failure**
- **[libc++][test] Avoid `-Wunused-variable` warnings in mutex tests (#94907)**
- **[libc] Add WordTypeSelector<16> specialization (#94979)**
- **[CUDA][HIP] warn incompatible redeclare (#77359)**
- **Revert 291b415c6c39156c82c7cdefd7a6a67657fb6927 : [Misc] Use `LLVM_ENABLE_ABI_BREAKING_CHECKS` correctly (#94212)**
- **Restore 'REQUIRES: shell' for some tests after 878deae**
- **Revert "[Misc] Use `LLVM_ENABLE_ABI_BREAKING_CHECKS` correctly" (#94982)**
- **[RemoveDIs] Update migration doc to explain how to handle textual IR updates (#91725)**
- **AMDGPU: Fix using useless cachepolicy argument in buffer atomic test**
- **AMDGPU: Simplify some tests by not using amdgpu_ps**
- **[libc][math][c23] Temporarily disable float16 on RISC-V (#94984)**
- **[libunwind] Tweak tests for musl support. (#85097)**
- **[bazel][libc]Fix test bazel for 6b21e17049**
- **AMDGPU: Do not assert on v6x16 buffer load intrinsics (#94966)**
- **[InstCombine] fold `ldexp(x, zext(i1 y))` to `fmul x, (select y, 2.0, 1.0)` (#94887)**
- **[test][OpenMP] Avoid writing to a potentially write-protected dir (#94931)**
- **[AMDGPU] Restore non-buffer atomic tests lost in #93801 (#94978)**
- **[lldb] Fix TestModuleLoadedNotifys API test to work correctly on most of Linux targets (#94672)**
- **[mlir][Arith] Generalize and improve -int-range-optimizations (#94712)**
- **[libc][math][c23] Add {remainder,remquo}f16 C23 math functions (#94773)**
- **[clang][OpenMP][NFC] Remove unnecessary nullptr check (#94680)**
- **[libc++][TZDB] Implements zoned_traits. (#91059)**
- **[clang][test] Update link for Arm clang-repl test disable**
- **[gn build] Port 151bd7cab4fc**
- **[OpenMP][NFC] Fix argument order of SourceLocations for allocate clause (#94777)**
- **[flang] Generate fir.do_loop reduce from DO CONCURRENT REDUCE clause (#94718)**
- **[mlir][Bazel] Fix for 4722911**
- **[flang] Fix copy creation in #94718**
- **[AArch64] set A14/M1 architecture version to v8.4-a (#92600)**
- **[clang-format] Fix a bug in indenting lambda trailing arrows (#94560)**
- **[RISCV] Remove stale comments. NFC (#94925)**
- **[RISCV] Use DefaultAttrsIntrinsic for some vector intrinsics. (#94819)**
- **SimplifyLibCalls: Don't require ldexp to emit intrinsic in exp2 combine (#92707)**
- **[lit] Skip xunit test on Windows only (#94980)**
- **[mlir][spirv] Fix typo in IndexToSPIRV tests directory name (#95005)**
- **[clang-repl] Always do export_executable_symbols_for_plugins(clang-repl)**
- **[GISel][RISCV] Anyextend before copying f16 -> i32/i64 (#94993)**
- **[X86] Add abs tests that check for MIN_SIGNED_INT cases**
- **[InstCombine] Regenerate some old bool math tests to use FileCheck and UTC scripts**
- **[AArch64] Push mul into extend operands (#94960)**
- **Document that llvm-lit needs to be run to collect static metrics (#94836)**
- **[ELF] Change build-id default to sha1 (#93943)**
- **[mlir][sparse] introduce `sparse_tensor.iterate` operation (#88955)**
- **[HWASan] skip libcxx test that times out with hwasan**
- **[BOLT][DWARF][NFC] Replace usages of GDBIndex functions (#94701)**
- **[lldb] Tighten ABI assert in `StopInfoMachException::DeterminePtrauthFailure` (NFC) (#95015)**
- **[InstCombine] Add tests for combining `(icmp eq/ne (and X, P2), (and X, -P2))`; NFC**
- **[InstCombine] Extend `(icmp eq/ne (and Z, X), (and Z, Y))` folds**
- **[clang-tidy] fix(clang-tools-extra/**.py): fix comparison to None (#94013)**
- **[mlir][bazel] fixes for e276cf0**
- **[llvm][IR] Extend BranchWeightMetadata to track provenance of weights (#86609)**
- **Workaround -Wglobal-constructor warning. (#94699)**
- **[NFC][msan] Regenerate tests with --scrub-attributes (#95022)**
- **[clang] Fix loss of `dllexport` for exported template specialization (#94664)**
- **[MC] Maintain MCRelaxAll after reset() (#94945)**
- **[MC][NFC] Make ELFUniquingMap a StringMap (#95006)**
- **[msan][NFC] Make mask in test more interesting (#94874)**
- **Revert "[MC] Make ELFUniquingMap a StringMap" (#95023)**
- **[clang-tidy] fix(clang-tools-extra/**.py): fix invalid escape sequences (#94028)**
- **[clang-tidy][DOC] Update doc for Clang Static Analyzer checks**
- **[BOLT] Fix a warning**
- **[MC] Don't evaluate name of unnamed symbols (#95021)**
- **[libc][math][c23] Temporarily disable float16 on 32-bit Arm (#95027)**
- **[LSR][AArch64] Optimize chain generation based on legal addressing modes (#94453)**
- **Reapply "[libc][math][c23] Add MPFR unit tests for {ceil,floor,round,roundeven,trunc}f16 (#94383)" (#94807)**
- **[mlir][Transforms] Dialect Conversion: Simplify block conversion API (#94866)**
- **[clang][cmake] Fixes for PGO builds when invoking ninja twice (#92591)**
- **[NFC][msan] Prepare function to extract main logic (#94880)**
- **[NFC][msan] Extract `handleSelectLikeInst` (#94881)**
- **[NFCI][metadata][LibCallsShrinkWrap] Use create{Unlikely,Likely}BranchWeights (#89465)**
- **[libc][stdlib] Add Block class (#94407)**
- **[mlir][sparse] fix missing cmake dependencies. (#95034)**
- **[VPlan] Generalize type inference for binary VPInstructions (NFC).**
- **[Clang][Comments] Add argument parsing for @throw @throws @exception (#84726)**
- **[flang] Lower REDUCE intrinsic with no DIM argument and rank 1 (#94652)**
- **[libc][math][c23] Add MPFR unit tests for {rint,lrint,llrint,lround,llround}f16 (#94473)**
- **[BOLT] Clean up DIEStreamer (NFC) (#95028)**
- **[NFC][libc][stdlib] LLVM_LIBC_SRC_STDLIB_LDIV_H -> LLVM_LIBC_SRC_STDL… (#95038)**
- **[libc][stdlib] Move LIBC_INLINE after template and before constexpr (#95037)**
- **[flang][NFC] Remove debug printing**
- **[NFCI][metadata][clang] Use create{Unlikely,Likely}BranchWeights (#89467)**
- **[Inliner][test] Fix incorrect REQUIRE line in `inline-switch-default.ll` (NFC) (#95009)**
- **[X86,MC] Remove two getPrevNode**
- **[memprof] Fix comment typos (NFC)**
- **Revert "[AArch64] Decouple feature dependency expansion. (#94279)" (#95056)**
- **[mlir] Sanitize identifiers with leading symbol. (#94795)**
- **[libc][stdlib] Add freelist class (#95041)**
- **[clang]  Reland Add tanf16 builtin and support for tan constrained intrinsic (#94559)**
- **[LLVM][IR][Sanitizers] Add sanitize_numerical_stability attribute (#95051)**
- **MCSection: Remove unused reverse iterators**
- **Reland "[X86] Assign AVX10_1 feature priority to align with gcc. (#94557)" (#94734)**
- **[mlir][gpu] Update LaunchFuncOp lowering in GPU to LLVM (#94991)**
- **[MC] Remove getFragmentList uses. NFC**
- **[clang] Replace X && isa<Y>(X) with isa_and_nonnull<Y>(X). NFC (#94987)**
- **[libc][stdlib] Change old unsigned short variables to size_t (#95065)**
- **[lldb] NFC add comments and test case for ObjectFileMachO delay-init (#95067)**
- **[flang] Lower REDUCE intrinsic with DIM argument (#94771)**
- **[PAC][AArch64] Lower ptrauth constants in data (#94240)**
- **[AMDGPU] Update tests for last-use in global/scratch/flat/buffer load… (#94975)**
- **[Clang][Sanitizers] Add numerical sanitizer (#93783)**
- **[clang] Don't use -Wno-nested-anon-types on GCC (#95029)**
- **Revert "[llvm][IR] Extend BranchWeightMetadata to track provenance of weights" (#95060)**
- **[RISCV] Add B extension (#76893)**
- **[clangd] Use clang_target_link_libraries() for clang libs (#94937)**
- **Explain partial byte extraction logic. (#92868)**
- **[RISCV][MC] Warn if SEW/LMUL may not be compatible**
- **[clang][dataflow] Handle `AtomicExpr` in `ResultObjectVisitor`. (#94963)**
- **Reland "[MC][NFC] Make ELFUniquingMap a StringMap (#95006)" (#95030)**
- **[clang][nullability] Don't return null fields from `getReferencedDecls()`. (#94983)**
- **[CodeGen] Preserved additional analyses in StackSlotColoring pass. (#93779)**
- **[flang] lower LBOUND for assumed-rank arrays (#94995)**
- **[flang][debug] Support assumed shape arrays. (#94644)**
- **[lldb] Add a test for lea_rsp_pattern_p to x86 unwinder (NFC) (#94852)**
- **[AArch64] Fix gcc "enumeral and non-enumeral type" warning**
- **[APFloat] Add APFloat support for FP6 data types (#94735)**
- **[AArch64] Disable red-zone when lowering Q-reg copy through memory. (#94962)**
- **MathExtras: MulOverflow: use builtin when available (NFC) (#95046)**
- **[NFC] Mitigate pointless copies (#95052)**
- **[StackSafety] Make lit tests compatible with lit's internal shell. NFC. (#94971)**
- **[clang][Interp] Refine diagnostics for casts from void***
- **[clang] Remove a redundant check in Mangle. NFC (#95071)**
- **[CostModel][X86] Adjust ABS scalar SizeLatency cost to 3uops**
- **[InstCombine] fold ldexp(x, sext(i1 y)) to fmul x, (select y, 0.5, 1.0) (#95073)**
- **[test] Fix documentation of %{fs-sep} et al (#95088)**
- **[X86] is_fpclass.ll - add NDD test coverage**
- **[X86] Add AMXProgModel to YAML serialization (#94988)**
- **[MC][X86] Avoid copying MCInst in emitInstrEnd (#94947)**
- **Revert new debug info format commits:**
- **[clang][Interp][test] Add test for void* diagnostics changes**
- **[X86] Pull out repeated SDLoc in various ADD/SUB/XOR folds. NFC.**
- **[InstCombine] Add #38139 test coverage**
- **[mlir][arith] Delete unnecessary error logs (#94970)**
- **Fix complex abs with nnan/ninf. (#95080)**
- **[clang][Interp][NFC] Remove unneeded opcode initializers**
- **[Driver] Rearrange some Apple version testing (#94514)**
- **[SPIR-V] Fix flakiness during switch generation. (#95001)**
- **[MLIR][Flang][DebugInfo] Set debug info format in MLIR->IR translation (#95098)**
- **[clang-tidy] Improve sizeof(pointer) handling in bugprone-sizeof-expression (#94356)**
- **[CodeGen][MachineLICM] Use RegUnits in HoistRegionPostRA (#94608)**
- ** [libc++] Fix endianness for algorithm mismatch (#93082)**
- **Revert "[MLIR][Flang][DebugInfo] Set debug info format in MLIR->IR translation (#95098)"**
- **[AMDGPU] Document amdgpu-as in AMDGPUUsage (#94335)**
- **AMDGPU: Add more tests for vector typed atomicrmw fadd**
- **Reapply "[MLIR][Flang][DebugInfo] Set debug info format in MLIR->IR translation (#95098)"**
- **[MLIR][Flang][DebugInfo] Convert debug format in MLIR translators**
- **[mlir][vector] Update tests for collapse 1/n (nfc) (#94490)**
- **[clang-tidy] fix false positives for the functions with the same name as standard library functions in misc-include-cleaner (#94923)**
- **[ConstantFolding] Preserve nowrap flags in gep of gep fold**
- **Fix test to have correct requirements (#95106)**
- **[clang][Interp] Support ObjCEncodeExprs**
- **[RemoveDIs] Update all docs to use debug records (#91768)**
- **[gold] Don't pass StringRef to message() (#95083)**
- **[CodeGen][NewPM] Split `MachineDominatorTree` into a concrete analysis result (#94571)**
- **[X86] early-ifcvt-remarks.ll - add codegen checks**
- **Updated the annotations of Python bindings (#92733)**
- **[bazel] Add missing dependency for 3cc2710e0dd53bb82742904fa13014018a1137ed**
- **[Offload][NFCI] Initialize the KernelArgsTy to default values (#95117)**
- **Revert#2 "[MLIR][Flang][DebugInfo] Set debug info format in MLIR->IR translation (#95098)"**
- **[lldb] Skip declaration DIEs in the debug_names index (#94744)**
- **[X86] early-ifcvt-remarks.ll - use i64 arithmetic to ensure ifcvt doesn't drop below threshold**
- **[X86] SimplifyDemandedBitsForTargetNode - add basic X86ISD::CMOV handling**
- **[Bazel] Layering fix for 65310f34d7edf7924ca4cbe7df836770669f70dc**
- **[mlir] Add bufferization option for parallel region check (#94645)**
- **[WASM] Fix for wasi libc build break add tan to RuntimeLibcallSignatureTable (#95082)**
- **[mlir] Add PDL C & Python usage (#94714)**
- **Restore 'REQUIRES: shell' for another test after 878deae**
- **[libc][math][c23] Add {totalorder,totalordermag}f16 C23 math functions (#95014)**
- **[X86] ICMP EQ/NE MIN_SIGNED_INT - avoid immediate argument by using NEG + SETO/SETNO (#94948)**
- **[NFC][clang-tidy] fix typo in readability-else-after-return**
