### PR TITLE
Revert "[clang][NFC] Add a test for CWG2685"

### DIFF
--- a/clang/test/CXX/drs/cwg26xx.cpp
+++ b/clang/test/CXX/drs/cwg26xx.cpp
@@ -225,15 +225,6 @@ void m() {
 }
 
 #if __cplusplus >= 202302L
-
-namespace cwg2685 { // cwg2685: 17
-template <class T>
-struct A {
-  T ar[4];
-};
-A a = { "foo" };
-}
-
 namespace cwg2687 { // cwg2687: 18
 struct S{
     void f(int);

--- a/clang/www/cxx_dr_status.html
+++ b/clang/www/cxx_dr_status.html
@@ -15918,7 +15918,7 @@ and <I>POD class</I></td>
     <td><a href="https://cplusplus.github.io/CWG/issues/2685.html">2685</a></td>
     <td>C++23</td>
     <td>Aggregate CTAD, string, and brace elision</td>
-    <td class="full" align="center">Clang 17</td>
+    <td class="unknown" align="center">Unknown</td>
   </tr>
   <tr class="open" id="2686">
     <td><a href="https://cplusplus.github.io/CWG/issues/2686.html">2686</a></td>


### PR DESCRIPTION
I was wrong: The purpose of CWG2685 is to avoid brace elision on string literals and we should be rejecting the case.

Reverts llvm/llvm-project#95206
