### PR TITLE
[compiler-rt][RISC-V] Save/Restore for E goes with ABI

### DIFF
--- a/compiler-rt/lib/builtins/riscv/restore.S
+++ b/compiler-rt/lib/builtins/riscv/restore.S
@@ -22,7 +22,7 @@
 
 #if __riscv_xlen == 32
 
-#ifndef __riscv_32e
+#ifndef __riscv_abi_rve
 
   .globl  __riscv_restore_12
   .type   __riscv_restore_12,@function
@@ -109,7 +109,7 @@ __riscv_restore_0:
 
 #elif __riscv_xlen == 64
 
-#ifndef __riscv_64e
+#ifndef __riscv_abi_rve
 
   .globl  __riscv_restore_12
   .type   __riscv_restore_12,@function

--- a/compiler-rt/lib/builtins/riscv/save.S
+++ b/compiler-rt/lib/builtins/riscv/save.S
@@ -18,7 +18,7 @@
 
 #if __riscv_xlen == 32
 
-#ifndef __riscv_32e
+#ifndef __riscv_abi_rve
 
   .globl  __riscv_save_12
   .type   __riscv_save_12,@function
@@ -115,7 +115,7 @@ __riscv_save_0:
 
 #elif __riscv_xlen == 64
 
-#ifndef __riscv_64e
+#ifndef __riscv_abi_rve
 
   .globl  __riscv_save_12
   .type   __riscv_save_12,@function


### PR DESCRIPTION
When compiling for the ILP32E/LP64E ABIs, even on a RISC-V machine with
    `i`, we should be using the ILP32E/LP64E save/restore routines, so use
    the right preprocessor macro.

---

Previous Description Below:

This makes two significant changes, which I believe are both bugfixes.

- When compiling for the ILP32E/LP64E ABIs, even on a RISC-V machine with `i`, we should be using the ILP32E/LP64E save/restore routines, so use the right preprocessor macro.
- Saves/restores registers in batches that match the stack alignment for the ILP32E/LP64E ABIs, rather than the larger batches of the conventional ABIs. The implementations of the save routines are not tail-shared, to reduce the number of instructions. I think this also helps code size but I need to check this again.

I would expect (but haven't measured) that the majority of functions compiled for the ILP32E/LP64E ABIs will in fact use both callee-saved registers, and therefore there are still savings to be had, but I think those can come later, with more data (especially if those changes are just to the instruction sequences we use to save the registers, rather than the number and alignment of how this is done).

From what I can tell, this matches the CFI information that both clang and GCC emit: https://godbolt.org/z/ozY3z8Yx5