### PR TITLE
[Flang][OpenMP] NFC: Check omp.loop_nest in compound construct lowering

### DIFF
--- a/flang/test/Lower/OpenMP/if-clause.f90
+++ b/flang/test/Lower/OpenMP/if-clause.f90
@@ -30,6 +30,7 @@ program main
   ! CHECK:      omp.wsloop
   ! CHECK-NOT:  if({{.*}})
   ! CHECK-SAME: {
+  ! CHECK-NEXT: omp.loop_nest
   !$omp do simd
   do i = 1, 10
   end do
@@ -38,6 +39,7 @@ program main
   ! CHECK:      omp.wsloop
   ! CHECK-NOT:  if({{.*}})
   ! CHECK-SAME: {
+  ! CHECK-NEXT: omp.loop_nest
   !$omp do simd if(.true.)
   do i = 1, 10
   end do
@@ -46,6 +48,7 @@ program main
   ! CHECK:      omp.wsloop
   ! CHECK-NOT:  if({{.*}})
   ! CHECK-SAME: {
+  ! CHECK-NEXT: omp.loop_nest
   !$omp do simd if(simd: .true.)
   do i = 1, 10
   end do
@@ -79,6 +82,10 @@ program main
   ! CHECK:      omp.parallel
   ! CHECK-NOT:  if({{.*}})
   ! CHECK-SAME: {
+  ! CHECK:      omp.wsloop
+  ! CHECK-NOT:  if({{.*}})
+  ! CHECK-SAME: {
+  ! CHECK-NEXT: omp.loop_nest
   !$omp parallel do
   do i = 1, 10
   end do
@@ -86,6 +93,10 @@ program main
 
   ! CHECK:      omp.parallel
   ! CHECK-SAME: if({{.*}})
+  ! CHECK:      omp.wsloop
+  ! CHECK-NOT:  if({{.*}})
+  ! CHECK-SAME: {
+  ! CHECK-NEXT: omp.loop_nest
   !$omp parallel do if(.true.)
   do i = 1, 10
   end do
@@ -93,6 +104,10 @@ program main
 
   ! CHECK:      omp.parallel
   ! CHECK-SAME: if({{.*}})
+  ! CHECK:      omp.wsloop
+  ! CHECK-NOT:  if({{.*}})
+  ! CHECK-SAME: {
+  ! CHECK-NEXT: omp.loop_nest
   !$omp parallel do if(parallel: .true.)
   do i = 1, 10
   end do
@@ -107,6 +122,7 @@ program main
   ! CHECK:      omp.wsloop
   ! CHECK-NOT:  if({{.*}})
   ! CHECK-SAME: {
+  ! CHECK-NEXT: omp.loop_nest
   !$omp parallel do simd
   do i = 1, 10
   end do
@@ -117,6 +133,7 @@ program main
   ! CHECK:      omp.wsloop
   ! CHECK-NOT:  if({{.*}})
   ! CHECK-SAME: {
+  ! CHECK-NEXT: omp.loop_nest
   !$omp parallel do simd if(.true.)
   do i = 1, 10
   end do
@@ -127,6 +144,7 @@ program main
   ! CHECK:      omp.wsloop
   ! CHECK-NOT:  if({{.*}})
   ! CHECK-SAME: {
+  ! CHECK-NEXT: omp.loop_nest
   !$omp parallel do simd if(parallel: .true.) if(simd: .false.)
   do i = 1, 10
   end do
@@ -137,6 +155,7 @@ program main
   ! CHECK:      omp.wsloop
   ! CHECK-NOT:  if({{.*}})
   ! CHECK-SAME: {
+  ! CHECK-NEXT: omp.loop_nest
   !$omp parallel do simd if(parallel: .true.)
   do i = 1, 10
   end do
@@ -148,6 +167,7 @@ program main
   ! CHECK:      omp.wsloop
   ! CHECK-NOT:  if({{.*}})
   ! CHECK-SAME: {
+  ! CHECK-NEXT: omp.loop_nest
   !$omp parallel do simd if(simd: .true.)
   do i = 1, 10
   end do
@@ -159,6 +179,7 @@ program main
   ! CHECK:      omp.simd
   ! CHECK-NOT:  if({{.*}})
   ! CHECK-SAME: {
+  ! CHECK-NEXT: omp.loop_nest
   !$omp simd
   do i = 1, 10
   end do
@@ -166,6 +187,7 @@ program main
 
   ! CHECK:      omp.simd
   ! CHECK-SAME: if({{.*}})
+  ! CHECK-NEXT: omp.loop_nest
   !$omp simd if(.true.)
   do i = 1, 10
   end do
@@ -173,6 +195,7 @@ program main
 
   ! CHECK:      omp.simd
   ! CHECK-SAME: if({{.*}})
+  ! CHECK-NEXT: omp.loop_nest
   !$omp simd if(simd: .true.)
   do i = 1, 10
   end do
@@ -257,6 +280,10 @@ program main
   ! CHECK:      omp.parallel
   ! CHECK-NOT:  if({{.*}})
   ! CHECK-SAME: {
+  ! CHECK:      omp.wsloop
+  ! CHECK-NOT:  if({{.*}})
+  ! CHECK-SAME: {
+  ! CHECK-NEXT: omp.loop_nest
   !$omp target parallel do
   do i = 1, 10
   end do
@@ -266,6 +293,10 @@ program main
   ! CHECK-SAME: if({{.*}})
   ! CHECK:      omp.parallel
   ! CHECK-SAME: if({{.*}})
+  ! CHECK:      omp.wsloop
+  ! CHECK-NOT:  if({{.*}})
+  ! CHECK-SAME: {
+  ! CHECK-NEXT: omp.loop_nest
   !$omp target parallel do if(.true.)
   do i = 1, 10
   end do
@@ -275,6 +306,10 @@ program main
   ! CHECK-SAME: if({{.*}})
   ! CHECK:      omp.parallel
   ! CHECK-SAME: if({{.*}})
+  ! CHECK:      omp.wsloop
+  ! CHECK-NOT:  if({{.*}})
+  ! CHECK-SAME: {
+  ! CHECK-NEXT: omp.loop_nest
   !$omp target parallel do if(target: .true.) if(parallel: .false.)
   do i = 1, 10
   end do
@@ -285,6 +320,10 @@ program main
   ! CHECK:      omp.parallel
   ! CHECK-NOT:  if({{.*}})
   ! CHECK-SAME: {
+  ! CHECK:      omp.wsloop
+  ! CHECK-NOT:  if({{.*}})
+  ! CHECK-SAME: {
+  ! CHECK-NEXT: omp.loop_nest
   !$omp target parallel do if(target: .true.)
   do i = 1, 10
   end do
@@ -295,6 +334,10 @@ program main
   ! CHECK-SAME: {
   ! CHECK:      omp.parallel
   ! CHECK-SAME: if({{.*}})
+  ! CHECK:      omp.wsloop
+  ! CHECK-NOT:  if({{.*}})
+  ! CHECK-SAME: {
+  ! CHECK-NEXT: omp.loop_nest
   !$omp target parallel do if(parallel: .true.)
   do i = 1, 10
   end do
@@ -312,6 +355,7 @@ program main
   ! CHECK:      omp.wsloop
   ! CHECK-NOT:  if({{.*}})
   ! CHECK-SAME: {
+  ! CHECK-NEXT: omp.loop_nest
   !$omp target parallel do simd
   do i = 1, 10
   end do
@@ -324,6 +368,7 @@ program main
   ! CHECK:      omp.wsloop
   ! CHECK-NOT:  if({{.*}})
   ! CHECK-SAME: {
+  ! CHECK-NEXT: omp.loop_nest
   !$omp target parallel do simd if(.true.)
   do i = 1, 10
   end do
@@ -336,6 +381,7 @@ program main
   ! CHECK:      omp.wsloop
   ! CHECK-NOT:  if({{.*}})
   ! CHECK-SAME: {
+  ! CHECK-NEXT: omp.loop_nest
   !$omp target parallel do simd if(target: .true.) if(parallel: .false.) &
   !$omp&                        if(simd: .true.)
   do i = 1, 10
@@ -350,6 +396,7 @@ program main
   ! CHECK:      omp.wsloop
   ! CHECK-NOT:  if({{.*}})
   ! CHECK-SAME: {
+  ! CHECK-NEXT: omp.loop_nest
   !$omp target parallel do simd if(target: .true.)
   do i = 1, 10
   end do
@@ -363,6 +410,7 @@ program main
   ! CHECK:      omp.wsloop
   ! CHECK-NOT:  if({{.*}})
   ! CHECK-SAME: {
+  ! CHECK-NEXT: omp.loop_nest
   !$omp target parallel do simd if(parallel: .true.) if(simd: .false.)
   do i = 1, 10
   end do
@@ -424,6 +472,7 @@ program main
   ! CHECK:      omp.simd
   ! CHECK-NOT:  if({{.*}})
   ! CHECK-SAME: {
+  ! CHECK-NEXT: omp.loop_nest
   !$omp target simd
   do i = 1, 10
   end do
@@ -433,6 +482,7 @@ program main
   ! CHECK-SAME: if({{.*}})
   ! CHECK:      omp.simd
   ! CHECK-SAME: if({{.*}})
+  ! CHECK-NEXT: omp.loop_nest
   !$omp target simd if(.true.)
   do i = 1, 10
   end do
@@ -442,6 +492,7 @@ program main
   ! CHECK-SAME: if({{.*}})
   ! CHECK:      omp.simd
   ! CHECK-SAME: if({{.*}})
+  ! CHECK-NEXT: omp.loop_nest
   !$omp target simd if(target: .true.) if(simd: .false.)
   do i = 1, 10
   end do
@@ -452,6 +503,7 @@ program main
   ! CHECK:      omp.simd
   ! CHECK-NOT:  if({{.*}})
   ! CHECK-SAME: {
+  ! CHECK-NEXT: omp.loop_nest
   !$omp target simd if(target: .true.)
   do i = 1, 10
   end do
@@ -462,6 +514,7 @@ program main
   ! CHECK-SAME: {
   ! CHECK:      omp.simd
   ! CHECK-SAME: if({{.*}})
+  ! CHECK-NEXT: omp.loop_nest
   !$omp target simd if(simd: .true.)
   do i = 1, 10
   end do
@@ -479,6 +532,7 @@ program main
   ! CHECK:      omp.distribute
   ! CHECK-NOT:  if({{.*}})
   ! CHECK-SAME: {
+  ! CHECK-NEXT: omp.loop_nest
   !$omp target teams distribute
   do i = 1, 10
   end do
@@ -491,6 +545,7 @@ program main
   ! CHECK:      omp.distribute
   ! CHECK-NOT:  if({{.*}})
   ! CHECK-SAME: {
+  ! CHECK-NEXT: omp.loop_nest
   !$omp target teams distribute if(.true.)
   do i = 1, 10
   end do
@@ -503,6 +558,7 @@ program main
   ! CHECK:      omp.distribute
   ! CHECK-NOT:  if({{.*}})
   ! CHECK-SAME: {
+  ! CHECK-NEXT: omp.loop_nest
   !$omp target teams distribute if(target: .true.) if(teams: .false.)
   do i = 1, 10
   end do
@@ -516,6 +572,7 @@ program main
   ! CHECK:      omp.distribute
   ! CHECK-NOT:  if({{.*}})
   ! CHECK-SAME: {
+  ! CHECK-NEXT: omp.loop_nest
   !$omp target teams distribute if(target: .true.)
   do i = 1, 10
   end do
@@ -529,6 +586,7 @@ program main
   ! CHECK:      omp.distribute
   ! CHECK-NOT:  if({{.*}})
   ! CHECK-SAME: {
+  ! CHECK-NEXT: omp.loop_nest
   !$omp target teams distribute if(teams: .true.)
   do i = 1, 10
   end do
@@ -609,6 +667,7 @@ program main
   ! CHECK:      omp.distribute
   ! CHECK-NOT:  if({{.*}})
   ! CHECK-SAME: {
+  ! CHECK-NEXT: omp.loop_nest
   !$omp teams distribute
   do i = 1, 10
   end do
@@ -619,6 +678,7 @@ program main
   ! CHECK:      omp.distribute
   ! CHECK-NOT:  if({{.*}})
   ! CHECK-SAME: {
+  ! CHECK-NEXT: omp.loop_nest
   !$omp teams distribute if(.true.)
   do i = 1, 10
   end do
@@ -629,6 +689,7 @@ program main
   ! CHECK:      omp.distribute
   ! CHECK-NOT:  if({{.*}})
   ! CHECK-SAME: {
+  ! CHECK-NEXT: omp.loop_nest
   !$omp teams distribute if(teams: .true.)
   do i = 1, 10
   end do

--- a/flang/test/Lower/OpenMP/loop-compound.f90
+++ b/flang/test/Lower/OpenMP/loop-compound.f90
@@ -1,4 +1,5 @@
-! This test checks lowering of OpenMP combined loop constructs.
+! This test checks lowering of OpenMP compound (combined and composite) loop
+! constructs.
 
 ! RUN: bbc -fopenmp -emit-hlfir %s -o - | FileCheck %s
 ! RUN: %flang_fc1 -fopenmp -emit-hlfir %s -o - | FileCheck %s
@@ -22,6 +23,7 @@ program main
   ! DO SIMD
   ! ----------------------------------------------------------------------------
   ! CHECK: omp.wsloop
+  ! CHECK-NEXT: omp.loop_nest
   !$omp do simd
   do i = 1, 10
   end do
@@ -32,6 +34,7 @@ program main
   ! ----------------------------------------------------------------------------
   ! CHECK: omp.parallel
   ! CHECK: omp.wsloop
+  ! CHECK-NEXT: omp.loop_nest
   !$omp parallel do simd
   do i = 1, 10
   end do
@@ -42,6 +45,7 @@ program main
   ! ----------------------------------------------------------------------------
   ! CHECK: omp.parallel
   ! CHECK: omp.wsloop
+  ! CHECK-NEXT: omp.loop_nest
   !$omp parallel do
   do i = 1, 10
   end do
@@ -53,6 +57,7 @@ program main
   ! CHECK: omp.target
   ! CHECK: omp.parallel
   ! CHECK: omp.wsloop
+  ! CHECK-NEXT: omp.loop_nest
   !$omp target parallel do simd
   do i = 1, 10
   end do
@@ -64,6 +69,7 @@ program main
   ! CHECK: omp.target
   ! CHECK: omp.parallel
   ! CHECK: omp.wsloop
+  ! CHECK-NEXT: omp.loop_nest
   !$omp target parallel do
   do i = 1, 10
   end do
@@ -74,6 +80,7 @@ program main
   ! ----------------------------------------------------------------------------
   ! CHECK: omp.target
   ! CHECK: omp.simd
+  ! CHECK-NEXT: omp.loop_nest
   !$omp target simd
   do i = 1, 10
   end do
@@ -86,6 +93,7 @@ program main
   ! CHECK: omp.target
   ! CHECK: omp.teams
   ! CHECK: omp.distribute
+  ! CHECK-NEXT: omp.loop_nest
   !$omp target teams distribute
   do i = 1, 10
   end do
@@ -97,6 +105,7 @@ program main
 
   ! CHECK: omp.teams
   ! CHECK: omp.distribute
+  ! CHECK-NEXT: omp.loop_nest
   !$omp teams distribute
   do i = 1, 10
   end do


### PR DESCRIPTION
This patch updates tests containing compound loop constructs to also check for the `omp.loop_nest` operation. The "loop-combined.f90" test file is renamed to "loop-compound.f90" as well, to better indicate the types of constructs that are checked in it.