### PR TITLE
[analyzer] Check the correct first and last elements in cstring.UninitializedRead

### DIFF
--- a/clang/include/clang/StaticAnalyzer/Core/PathSensitive/MemRegion.h
+++ b/clang/include/clang/StaticAnalyzer/Core/PathSensitive/MemRegion.h
@@ -34,6 +34,7 @@
 #include "llvm/ADT/iterator_range.h"
 #include "llvm/Support/Allocator.h"
 #include "llvm/Support/Casting.h"
+#include "llvm/Support/ErrorHandling.h"
 #include <cassert>
 #include <cstdint>
 #include <limits>
@@ -99,6 +100,8 @@ public:
 #define REGION(Id, Parent) Id ## Kind,
 #define REGION_RANGE(Id, First, Last) BEGIN_##Id = First, END_##Id = Last,
 #include "clang/StaticAnalyzer/Core/PathSensitive/Regions.def"
+#undef REGION
+#undef REGION_RANGE
   };
 
 private:
@@ -170,6 +173,17 @@ public:
   virtual void printPrettyAsExpr(raw_ostream &os) const;
 
   Kind getKind() const { return kind; }
+
+  StringRef getKindStr() const {
+    switch (getKind()) {
+#define REGION(Id, Parent)                                                     \
+  case Id##Kind:                                                               \
+    return #Id;
+#include "clang/StaticAnalyzer/Core/PathSensitive/Regions.def"
+#undef REGION
+    }
+    llvm_unreachable("Unkown kind!");
+  }
 
   template<typename RegionTy> const RegionTy* getAs() const;
   template <typename RegionTy>

--- a/clang/include/clang/StaticAnalyzer/Core/PathSensitive/MemRegion.h
+++ b/clang/include/clang/StaticAnalyzer/Core/PathSensitive/MemRegion.h
@@ -174,16 +174,7 @@ public:
 
   Kind getKind() const { return kind; }
 
-  StringRef getKindStr() const {
-    switch (getKind()) {
-#define REGION(Id, Parent)                                                     \
-  case Id##Kind:                                                               \
-    return #Id;
-#include "clang/StaticAnalyzer/Core/PathSensitive/Regions.def"
-#undef REGION
-    }
-    llvm_unreachable("Unkown kind!");
-  }
+  StringRef getKindStr() const;
 
   template<typename RegionTy> const RegionTy* getAs() const;
   template <typename RegionTy>

--- a/clang/lib/StaticAnalyzer/Checkers/CStringChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/CStringChecker.cpp
@@ -439,9 +439,6 @@ static const TypedValueRegion *getOriginRegion(const ElementRegion *ER) {
       return nullptr;
     Ret = sym2->getOriginRegion();
   }
-  if (const auto *Elem = MR->getAs<ElementRegion>()) {
-    Ret = Elem->getBaseRegion();
-  }
   return dyn_cast_or_null<TypedValueRegion>(Ret);
 }
 
@@ -460,10 +457,7 @@ ProgramStateRef CStringChecker::checkInit(CheckerContext &C,
     return nullptr;
 
   const MemRegion *R = Element.getAsRegion();
-  if (!R)
-    return State;
-
-  const auto *ER = dyn_cast<ElementRegion>(R);
+  const auto *ER = dyn_cast_or_null<ElementRegion>(R);
   if (!ER)
     return State;
 
@@ -552,11 +546,11 @@ ProgramStateRef CStringChecker::checkInit(CheckerContext &C,
     }
     llvm::SmallString<258> Buf;
     llvm::raw_svector_ostream OS(Buf);
-    OS << "The last element of the ";
-    printIdxWithOrdinalSuffix(OS, Buffer.ArgumentIndex + 1);
-    OS << " argument to access (the ";
+    OS << "The last (";
     printIdxWithOrdinalSuffix(OS, IdxInt->getExtValue() + 1);
-    OS << ") is undefined";
+    OS << ") element to access in the ";
+    printIdxWithOrdinalSuffix(OS, Buffer.ArgumentIndex + 1);
+    OS << " argument is undefined";
     emitUninitializedReadBug(C, State, Buffer.Expression, OS.str());
     return nullptr;
   }

--- a/clang/lib/StaticAnalyzer/Checkers/CStringChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/CStringChecker.cpp
@@ -427,21 +427,6 @@ static std::optional<NonLoc> getIndex(ProgramStateRef State,
   return Offset.castAs<NonLoc>();
 }
 
-// Try to get hold of the origin region (e.g. the actual array region from an
-// element region).
-static const TypedValueRegion *getOriginRegion(const ElementRegion *ER) {
-  const MemRegion *MR = ER->getSuperRegion();
-  const MemRegion *Ret = MR;
-  assert(MR);
-  if (const auto *sym = MR->getAs<SymbolicRegion>()) {
-    SymbolRef sym2 = sym->getSymbol();
-    if (!sym2)
-      return nullptr;
-    Ret = sym2->getOriginRegion();
-  }
-  return dyn_cast_or_null<TypedValueRegion>(Ret);
-}
-
 // Basically 1 -> 1st, 12 -> 12th, etc.
 static void printIdxWithOrdinalSuffix(llvm::raw_ostream &Os, unsigned Idx) {
   Os << Idx << llvm::getOrdinalSuffix(Idx);
@@ -461,7 +446,7 @@ ProgramStateRef CStringChecker::checkInit(CheckerContext &C,
   if (!ER)
     return State;
 
-  const TypedValueRegion *Orig = getOriginRegion(ER);
+  const auto *Orig = ER->getSuperRegion()->getAs<TypedValueRegion>();
   if (!Orig)
     return State;
 

--- a/clang/lib/StaticAnalyzer/Checkers/CStringChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/CStringChecker.cpp
@@ -359,12 +359,12 @@ REGISTER_MAP_WITH_PROGRAMSTATE(CStringLength, const MemRegion *, SVal)
 // Individual checks and utility methods.
 //===----------------------------------------------------------------------===//
 
-std::pair<ProgramStateRef , ProgramStateRef >
+std::pair<ProgramStateRef, ProgramStateRef>
 CStringChecker::assumeZero(CheckerContext &C, ProgramStateRef State, SVal V,
                            QualType Ty) {
   std::optional<DefinedSVal> val = V.getAs<DefinedSVal>();
   if (!val)
-    return std::pair<ProgramStateRef , ProgramStateRef >(State, State);
+    return std::pair<ProgramStateRef, ProgramStateRef>(State, State);
 
   SValBuilder &svalBuilder = C.getSValBuilder();
   DefinedOrUnknownSVal zero = svalBuilder.makeZeroVal(Ty);

--- a/clang/lib/StaticAnalyzer/Core/MemRegion.cpp
+++ b/clang/lib/StaticAnalyzer/Core/MemRegion.cpp
@@ -630,6 +630,17 @@ bool MemRegion::canPrintPrettyAsExpr() const {
   return false;
 }
 
+StringRef MemRegion::getKindStr() const {
+  switch (getKind()) {
+#define REGION(Id, Parent)                                                     \
+  case Id##Kind:                                                               \
+    return #Id;
+#include "clang/StaticAnalyzer/Core/PathSensitive/Regions.def"
+#undef REGION
+  }
+  llvm_unreachable("Unkown kind!");
+}
+
 void MemRegion::printPretty(raw_ostream &os) const {
   assert(canPrintPretty() && "This region cannot be printed pretty.");
   os << "'";

--- a/clang/test/Analysis/bstring_UninitRead.c
+++ b/clang/test/Analysis/bstring_UninitRead.c
@@ -1,12 +1,11 @@
 // RUN: %clang_analyze_cc1 -verify %s \
 // RUN: -analyzer-checker=core,alpha.unix.cstring
 
-
-// This file is generally for the alpha.unix.cstring.UninitializedRead Checker, the reason for putting it into
-// the separate file because the checker is break the some existing test cases in bstring.c file , so we don't 
-// wanna mess up with some existing test case so it's better to create separate file for it, this file also include 
-// the broken test for the reference in future about the broken tests.
-
+//===----------------------------------------------------------------------===//
+// mempcpy() using character array. This is the easiest case, as memcpy
+// intepretrs the dst and src buffers as character arrays (regardless of their
+// actual type).
+//===----------------------------------------------------------------------===//
 
 typedef typeof(sizeof(int)) size_t;
 
@@ -14,14 +13,14 @@ void clang_analyzer_eval(int);
 
 void *memcpy(void *restrict s1, const void *restrict s2, size_t n);
 
-void top(char *dst) {
+void memcpy_array_fully_uninit(char *dst) {
   char buf[10];
   memcpy(dst, buf, 10); // expected-warning{{The first element of the 2nd argument is undefined}}
                         // expected-note@-1{{Other elements might also be undefined}}
   (void)buf;
 }
 
-void top2(char *dst) {
+void memcpy_array_partially_uninit(char *dst) {
   char buf[10];
   buf[0] = 'i';
   memcpy(dst, buf, 10); // expected-warning{{The last element of the 2nd argument to access (the 10th) is undefined}}
@@ -29,14 +28,14 @@ void top2(char *dst) {
   (void)buf;
 }
 
-void top3(char *dst) {
+void memcpy_array_only_init_portion(char *dst) {
   char buf[10];
   buf[0] = 'i';
   memcpy(dst, buf, 1);
   (void)buf;
 }
 
-void top4(char *dst) {
+void memcpy_array_partially_init_error(char *dst) {
   char buf[10];
   buf[0] = 'i';
   memcpy(dst, buf, 2); // expected-warning{{The last element of the 2nd argument to access (the 2nd) is undefined}}
@@ -44,28 +43,36 @@ void top4(char *dst) {
   (void)buf;
 }
 
-//===----------------------------------------------------------------------===
-// mempcpy()
-//===----------------------------------------------------------------------===
+//===----------------------------------------------------------------------===//
+// mempcpy() using non-character arrays.
+//===----------------------------------------------------------------------===//
 
 void *mempcpy(void *restrict s1, const void *restrict s2, size_t n);
 
-void mempcpy13() {
+void memcpy_int_array_fully_init() {
   int src[] = {1, 2, 3, 4};
   int dst[5] = {0};
   int *p;
 
   p = mempcpy(dst, src, 4 * sizeof(int));
-  clang_analyzer_eval(p == &dst[4]); // no-warning (above is fatal)
+  clang_analyzer_eval(p == &dst[4]);
 }
+
+void memcpy_int_array_fully_init2(int *dest) {
+  int t[] = {1, 2, 3};
+  memcpy(dest, t, sizeof(t));
+}
+
+//===----------------------------------------------------------------------===//
+// mempcpy() using nonarrays.
+//===----------------------------------------------------------------------===//
 
 struct st {
   int i;
   int j;
 };
 
-
-void mempcpy15() {
+void mempcpy_struct_partially_uninit() {
   struct st s1 = {0};
   struct st s2;
   struct st *p1;
@@ -73,23 +80,20 @@ void mempcpy15() {
 
   p1 = (&s2) + 1;
 
+  // FIXME: Maybe ask UninitializedObjectChecker whether s1 is fully
+  // initialized?
   p2 = mempcpy(&s2, &s1, sizeof(struct st));
 
-  clang_analyzer_eval(p1 == p2); // no-warning (above is fatal)
+  clang_analyzer_eval(p1 == p2);
 }
 
-void mempcpy16() {
+void mempcpy_struct_fully_uninit() {
   struct st s1;
   struct st s2;
 
   // FIXME: Maybe ask UninitializedObjectChecker whether s1 is fully
   // initialized?
   mempcpy(&s2, &s1, sizeof(struct st));
-}
-
-void initialized(int *dest) {
-  int t[] = {1, 2, 3};
-  memcpy(dest, t, sizeof(t));
 }
 
 // Creduced crash.

--- a/clang/test/Analysis/bstring_UninitRead.c
+++ b/clang/test/Analysis/bstring_UninitRead.c
@@ -23,7 +23,7 @@ void memcpy_array_fully_uninit(char *dst) {
 void memcpy_array_partially_uninit(char *dst) {
   char buf[10];
   buf[0] = 'i';
-  memcpy(dst, buf, 10); // expected-warning{{The last (10th) element to access in the 2nd argument is undefined}}
+  memcpy(dst, buf, 10); // expected-warning{{The last accessed element (at index 9) in the 2nd argument is undefined}}
                         // expected-note@-1{{Other elements might also be undefined}}
   (void)buf;
 }
@@ -38,7 +38,7 @@ void memcpy_array_only_init_portion(char *dst) {
 void memcpy_array_partially_init_error(char *dst) {
   char buf[10];
   buf[0] = 'i';
-  memcpy(dst, buf, 2); // expected-warning{{The last (2nd) element to access in the 2nd argument is undefined}}
+  memcpy(dst, buf, 2); // expected-warning{{The last accessed element (at index 1) in the 2nd argument is undefined}}
                       // expected-note@-1{{Other elements might also be undefined}}
   (void)buf;
 }

--- a/clang/test/Analysis/bstring_UninitRead.c
+++ b/clang/test/Analysis/bstring_UninitRead.c
@@ -23,7 +23,7 @@ void memcpy_array_fully_uninit(char *dst) {
 void memcpy_array_partially_uninit(char *dst) {
   char buf[10];
   buf[0] = 'i';
-  memcpy(dst, buf, 10); // expected-warning{{The last element of the 2nd argument to access (the 10th) is undefined}}
+  memcpy(dst, buf, 10); // expected-warning{{The last (10th) element to access in the 2nd argument is undefined}}
                         // expected-note@-1{{Other elements might also be undefined}}
   (void)buf;
 }
@@ -38,8 +38,23 @@ void memcpy_array_only_init_portion(char *dst) {
 void memcpy_array_partially_init_error(char *dst) {
   char buf[10];
   buf[0] = 'i';
-  memcpy(dst, buf, 2); // expected-warning{{The last element of the 2nd argument to access (the 2nd) is undefined}}
-                        // expected-note@-1{{Other elements might also be undefined}}
+  memcpy(dst, buf, 2); // expected-warning{{The last (2nd) element to access in the 2nd argument is undefined}}
+                      // expected-note@-1{{Other elements might also be undefined}}
+  (void)buf;
+}
+
+// The interesting case here is that the portion we're copying is initialized,
+// but not the whole matrix. We need to be careful to extract buf[1], and not
+// buf when trying to peel region layers off from the source argument.
+void memcpy_array_from_matrix(char *dst) {
+  char buf[2][2];
+  buf[1][0] = 'i';
+  buf[1][1] = 'j';
+  // FIXME: This is a FP -- we mistakenly retrieve the first element of buf,
+  // instead of the first element of buf[1]. getLValueElement simply peels off
+  // another ElementRegion layer, when in this case it really shouldn't.
+  memcpy(dst, buf[1], 2); // expected-warning{{The first element of the 2nd argument is undefined}}
+                          // expected-note@-1{{Other elements might also be undefined}}
   (void)buf;
 }
 
@@ -96,8 +111,8 @@ void mempcpy_struct_fully_uninit() {
   mempcpy(&s2, &s1, sizeof(struct st));
 }
 
-// Creduced crash.
-
+// Creduced crash. In this case, an symbolicregion is wrapped in an
+// elementregion for the src argument.
 void *ga_copy_strings_from_0;
 void *memmove();
 void alloc();

--- a/clang/test/Analysis/bstring_UninitRead.c
+++ b/clang/test/Analysis/bstring_UninitRead.c
@@ -122,3 +122,11 @@ void ga_copy_strings() {
     memmove(alloc, ((char **)ga_copy_strings_from_0)[i], 1);
 }
 
+// Creduced crash. In this case, retrieving the Loc for the first element failed.
+char mov_mdhd_language_map[][4] = {};
+int ff_mov_lang_to_iso639_code;
+char *ff_mov_lang_to_iso639_to;
+void ff_mov_lang_to_iso639() {
+  memcpy(ff_mov_lang_to_iso639_to,
+         mov_mdhd_language_map[ff_mov_lang_to_iso639_code], 4);
+}


### PR DESCRIPTION
I intend to fix this checker up so that we can move it out of alpha. I made a bunch of analyses, and found many similar false positives:

```c++
int t[] = {1,2,3};
memcpy(dst, t, sizeof(t) / sizeof(t[0])); // warn
```

The problem here is the way CStringChecker checks whether the destination and source buffers are initialized: heuristically, it only checks the first and last element. This is fine, however, it retrieves these elements as characters, even if the underlaying object is not a character array. Reading the last byte of an integer is undefined, so the checker emits a bug here.

A quick search tells you the rationale: "Both objects are reinterpreted as arrays of unsigned char.". But the static analyzer right now can't check byte-by-byte if a memory region is _initialized_, it can only check if its a well-defined character or not.

In this patch, I pry the original array out of the arguments to memcpy (and similar functions), and retrieve the actual first and last elements according to the array's actual element type.

Currently, my improvements reduced the number of reports to 29 on these projects: memcached,tmux,curl,twin,vim,openssl,sqlite,ffmpeg,postgres

https://codechecker-demo.eastus.cloudapp.azure.com/Default/reports?detection-status=New&detection-status=Reopened&detection-status=Unresolved&is-unique=on&run=%2acstring_uninit_upper_bound_patched&newcheck=%2acstring_uninit_upper_bounds_patched&diff-type=New&checker-name=alpha.unix.cstring.UninitializedRead&items-per-page=100

Before my patch, there were 87.

https://codechecker-demo.eastus.cloudapp.azure.com/Default/reports?detection-status=New&detection-status=Reopened&detection-status=Unresolved&is-unique=on&run=%2acstring_uninit_baseline&newcheck=%2acstring_uninit_upper_bounds_patched&diff-type=New&checker-name=alpha.unix.cstring.UninitializedRead&items-per-page=100
