### PR TITLE
[SDPatternMatch] Only match ISD::SIGN_EXTEND in m_SExt

### DIFF
--- a/llvm/include/llvm/CodeGen/SDPatternMatch.h
+++ b/llvm/include/llvm/CodeGen/SDPatternMatch.h
@@ -642,8 +642,7 @@ template <typename Opnd> inline UnaryOpc_match<Opnd> m_ZExt(const Opnd &Op) {
 }
 
 template <typename Opnd> inline auto m_SExt(const Opnd &Op) {
-  return m_AnyOf(UnaryOpc_match<Opnd>(ISD::SIGN_EXTEND, Op),
-                 m_Node(ISD::SIGN_EXTEND_INREG, Op, m_Value()));
+  return UnaryOpc_match<Opnd>(ISD::SIGN_EXTEND, Op);
 }
 
 template <typename Opnd> inline UnaryOpc_match<Opnd> m_AnyExt(const Opnd &Op) {

--- a/llvm/unittests/CodeGen/SelectionDAGPatternMatchTest.cpp
+++ b/llvm/unittests/CodeGen/SelectionDAGPatternMatchTest.cpp
@@ -269,8 +269,6 @@ TEST_F(SelectionDAGPatternMatchTest, optionalResizing) {
   SDValue Op64 = DAG->getCopyFromReg(DAG->getEntryNode(), DL, 1, Int64VT);
   SDValue ZExt = DAG->getNode(ISD::ZERO_EXTEND, DL, Int64VT, Op32);
   SDValue SExt = DAG->getNode(ISD::SIGN_EXTEND, DL, Int64VT, Op32);
-  SDValue SExtInReg = DAG->getNode(ISD::SIGN_EXTEND_INREG, DL, Int64VT, Op64,
-                                   DAG->getValueType(Int32VT));
   SDValue AExt = DAG->getNode(ISD::ANY_EXTEND, DL, Int64VT, Op32);
   SDValue Trunc = DAG->getNode(ISD::TRUNCATE, DL, Int32VT, Op64);
 
@@ -284,8 +282,6 @@ TEST_F(SelectionDAGPatternMatchTest, optionalResizing) {
   EXPECT_TRUE(A == Op64);
   EXPECT_TRUE(sd_match(SExt, m_SExtOrSelf(m_Value(A))));
   EXPECT_TRUE(A == Op32);
-  EXPECT_TRUE(sd_match(SExtInReg, m_SExtOrSelf(m_Value(A))));
-  EXPECT_TRUE(A == Op64);
   EXPECT_TRUE(sd_match(Op32, m_AExtOrSelf(m_Value(A))));
   EXPECT_TRUE(A == Op32);
   EXPECT_TRUE(sd_match(AExt, m_AExtOrSelf(m_Value(A))));


### PR DESCRIPTION
Context: https://github.com/llvm/llvm-project/pull/95365#discussion_r1638236603

The current implementation of `m_SExt` matches both `ISD::SIGN_EXTEND` and `ISD::SIGN_EXTEND_INREG`. However, in cases where we specifically need to match _only_ `ISD::SIGN_EXTEND`, such as in the SelectionDAG graph below, this can lead to issues and unintended combinations.

```
SelectionDAG has 13 nodes:
  t0: ch,glue = EntryToken
          t2: v2i32,ch = CopyFromReg t0, Register:v2i32 %0
        t21: v2i32 = sign_extend_inreg t2, ValueType:ch:v2i8
          t4: v2i32,ch = CopyFromReg t0, Register:v2i32 %1
        t22: v2i32 = sign_extend_inreg t4, ValueType:ch:v2i8
      t23: v2i32 = avgfloors t21, t22
    t24: v2i32 = sign_extend_inreg t23, ValueType:ch:v2i8
  t15: ch,glue = CopyToReg t0, Register:v2i32 $d0, t24
  t16: ch = AArch64ISD::RET_GLUE t15, Register:v2i32 $d0, t15:1
```