### PR TITLE
Revert "[libc] fix aarch64 linux full build (#95358)"

### DIFF
--- a/libc/config/linux/aarch64/entrypoints.txt
+++ b/libc/config/linux/aarch64/entrypoints.txt
@@ -643,12 +643,6 @@ if(LLVM_LIBC_FULL_BUILD)
     libc.src.pthread.pthread_mutexattr_setrobust
     libc.src.pthread.pthread_mutexattr_settype
     libc.src.pthread.pthread_once
-    libc.src.pthread.pthread_rwlockattr_destroy
-    libc.src.pthread.pthread_rwlockattr_getkind_np
-    libc.src.pthread.pthread_rwlockattr_getpshared
-    libc.src.pthread.pthread_rwlockattr_init
-    libc.src.pthread.pthread_rwlockattr_setkind_np
-    libc.src.pthread.pthread_rwlockattr_setpshared
     libc.src.pthread.pthread_setspecific
 
     # sched.h entrypoints
@@ -759,7 +753,6 @@ if(LLVM_LIBC_FULL_BUILD)
     libc.src.unistd._exit
     libc.src.unistd.environ
     libc.src.unistd.execv
-    libc.src.unistd.fork
     libc.src.unistd.getopt
     libc.src.unistd.optarg
     libc.src.unistd.optind

--- a/libc/src/__support/threads/linux/CMakeLists.txt
+++ b/libc/src/__support/threads/linux/CMakeLists.txt
@@ -64,7 +64,6 @@ add_object_library(
     .futex_utils
     libc.config.linux.app_h
     libc.include.sys_syscall
-    libc.include.fcntl
     libc.src.errno.errno
     libc.src.__support.CPP.atomic
     libc.src.__support.CPP.stringstream

--- a/libc/test/IntegrationTest/test.cpp
+++ b/libc/test/IntegrationTest/test.cpp
@@ -79,10 +79,4 @@ void *realloc(void *ptr, size_t s) {
 // Integration tests are linked with -nostdlib. BFD linker expects
 // __dso_handle when -nostdlib is used.
 void *__dso_handle = nullptr;
-
-// On some platform (aarch64 fedora tested) full build integration test
-// objects need to link against libgcc, which may expect a __getauxval
-// function. For now, it is fine to provide a weak definition that always
-// returns false.
-[[gnu::weak]] bool __getauxval(uint64_t, uint64_t *) { return false; }
 } // extern "C"


### PR DESCRIPTION
This reverts commit ca05204f9aa258c5324d5675c7987c7e570168a0.

I misinterpreted `__getauxval` with `__getauxval2`. It should be the same as `getauxval` and we should be able to provide it in a more proper way.

I also found the GCC patch that actually cause this problem:
https://gcc.gnu.org/git/gitweb.cgi?p=gcc.git;h=1266778548e20de82983b6446f3cb685068cfb1e