### PR TITLE
[llvm-exegesis] Only link/initialize supported targets (NFC)

### DIFF
--- a/llvm/tools/llvm-exegesis/CMakeLists.txt
+++ b/llvm/tools/llvm-exegesis/CMakeLists.txt
@@ -1,15 +1,22 @@
+# Has side effect of defining LLVM_EXEGESIS_TARGETS
+add_subdirectory(lib)
+
 set(LLVM_LINK_COMPONENTS
-  AllTargetsAsmParsers
-  AllTargetsCodeGens
-  AllTargetsDescs
-  AllTargetsDisassemblers
-  AllTargetsInfos
   CodeGenTypes
   MC
   MCParser
   Support
   TargetParser
   )
+
+foreach(t ${LLVM_EXEGESIS_TARGETS})
+  string(STRIP ${t} t)
+  list(APPEND LLVM_LINK_COMPONTENTS "LLVM${t}AsmParser")
+  list(APPEND LLVM_LINK_COMPONTENTS "LLVM${t}CodeGen")
+  list(APPEND LLVM_LINK_COMPONTENTS "LLVM${t}Desc")
+  list(APPEND LLVM_LINK_COMPONTENTS "LLVM${t}Disassembler")
+  list(APPEND LLVM_LINK_COMPONTENTS "LLVM${t}Info")
+endforeach()
 
 add_llvm_tool(llvm-exegesis
   DISABLE_LLVM_LINK_LLVM_DYLIB
@@ -18,9 +25,6 @@ add_llvm_tool(llvm-exegesis
   DEPENDS
   intrinsics_gen
   )
-
-# Has side effect of defining LLVM_EXEGESIS_TARGETS
-add_subdirectory(lib)
 
 # Link all enabled exegesis targets
 set(libs)

--- a/llvm/tools/llvm-exegesis/llvm-exegesis.cpp
+++ b/llvm/tools/llvm-exegesis/llvm-exegesis.cpp
@@ -470,9 +470,11 @@ void benchmarkMain() {
 #endif
   }
 
-  InitializeAllAsmPrinters();
-  InitializeAllAsmParsers();
   InitializeAllExegesisTargets();
+#define LLVM_EXEGESIS(TargetName) \
+  LLVMInitialize##TargetName##AsmPrinter(); \
+  LLVMInitialize##TargetName##AsmParser();
+#include "llvm/Config/TargetExegesis.def"
 
   const LLVMState State =
       ExitOnErr(LLVMState::Create(TripleName, MCPU, "", UseDummyPerfCounters));
@@ -621,9 +623,11 @@ static void analysisMain() {
         "and --analysis-inconsistencies-output-file must be specified");
   }
 
-  InitializeAllAsmPrinters();
-  InitializeAllDisassemblers();
   InitializeAllExegesisTargets();
+#define LLVM_EXEGESIS(TargetName) \
+  LLVMInitialize##TargetName##AsmPrinter(); \
+  LLVMInitialize##TargetName##Disassembler();
+#include "llvm/Config/TargetExegesis.def"
 
   auto MemoryBuffer = ExitOnFileError(
       BenchmarkFile,
@@ -690,9 +694,11 @@ int main(int Argc, char **Argv) {
   InitLLVM X(Argc, Argv);
 
   // Initialize targets so we can print them when flag --version is specified.
-  InitializeAllTargetInfos();
-  InitializeAllTargets();
-  InitializeAllTargetMCs();
+#define LLVM_EXEGESIS(TargetName) \
+  LLVMInitialize##TargetName##Target(); \
+  LLVMInitialize##TargetName##TargetInfo(); \
+  LLVMInitialize##TargetName##TargetMC();
+#include "llvm/Config/TargetExegesis.def"
 
   // Register the Target and CPU printer for --version.
   cl::AddExtraVersionPrinter(sys::printDefaultTargetAndDetectedCPU);

--- a/llvm/tools/llvm-exegesis/llvm-exegesis.cpp
+++ b/llvm/tools/llvm-exegesis/llvm-exegesis.cpp
@@ -471,8 +471,8 @@ void benchmarkMain() {
   }
 
   InitializeAllExegesisTargets();
-#define LLVM_EXEGESIS(TargetName) \
-  LLVMInitialize##TargetName##AsmPrinter(); \
+#define LLVM_EXEGESIS(TargetName)                                              \
+  LLVMInitialize##TargetName##AsmPrinter();                                    \
   LLVMInitialize##TargetName##AsmParser();
 #include "llvm/Config/TargetExegesis.def"
 
@@ -624,8 +624,8 @@ static void analysisMain() {
   }
 
   InitializeAllExegesisTargets();
-#define LLVM_EXEGESIS(TargetName) \
-  LLVMInitialize##TargetName##AsmPrinter(); \
+#define LLVM_EXEGESIS(TargetName)                                              \
+  LLVMInitialize##TargetName##AsmPrinter();                                    \
   LLVMInitialize##TargetName##Disassembler();
 #include "llvm/Config/TargetExegesis.def"
 
@@ -694,9 +694,9 @@ int main(int Argc, char **Argv) {
   InitLLVM X(Argc, Argv);
 
   // Initialize targets so we can print them when flag --version is specified.
-#define LLVM_EXEGESIS(TargetName) \
-  LLVMInitialize##TargetName##Target(); \
-  LLVMInitialize##TargetName##TargetInfo(); \
+#define LLVM_EXEGESIS(TargetName)                                              \
+  LLVMInitialize##TargetName##Target();                                        \
+  LLVMInitialize##TargetName##TargetInfo();                                    \
   LLVMInitialize##TargetName##TargetMC();
 #include "llvm/Config/TargetExegesis.def"
 


### PR DESCRIPTION
llvm-exegesis currently links and initializes all targets, even though most of them are not supported by llvm-exegesis. This is particularly unfortunate because llvm-exegesis does not support the LLVM dylib, so llvm-exegesis essentially ends up doing a complete relink of all of LLVM, which is not fun if you use LTO.

Instead, only link and initialize the targets that are part of LLVM_EXEGESIS_TARGETS.