### PR TITLE
[Transforms] Migrate to a new version of getValueProfDataFromInst

### DIFF
--- a/llvm/lib/Transforms/Instrumentation/PGOMemOPSizeOpt.cpp
+++ b/llvm/lib/Transforms/Instrumentation/PGOMemOPSizeOpt.cpp
@@ -247,7 +247,8 @@ bool MemOPSizeOpt::perform(MemOp MO) {
   if (!MemOPOptMemcmpBcmp && (MO.isMemcmp(TLI) || MO.isBcmp(TLI)))
     return false;
 
-  uint32_t NumVals, MaxNumVals = INSTR_PROF_NUM_BUCKETS;
+  uint32_t NumVals = INSTR_PROF_NUM_BUCKETS;
+  uint32_t MaxNumVals = INSTR_PROF_NUM_BUCKETS;
   uint64_t TotalCount;
   auto ValueDataArray = getValueProfDataFromInst(
       *MO.I, IPVK_MemOPSize, MaxNumVals, NumVals, TotalCount);

--- a/llvm/lib/Transforms/Instrumentation/PGOMemOPSizeOpt.cpp
+++ b/llvm/lib/Transforms/Instrumentation/PGOMemOPSizeOpt.cpp
@@ -177,10 +177,7 @@ public:
   MemOPSizeOpt(Function &Func, BlockFrequencyInfo &BFI,
                OptimizationRemarkEmitter &ORE, DominatorTree *DT,
                TargetLibraryInfo &TLI)
-      : Func(Func), BFI(BFI), ORE(ORE), DT(DT), TLI(TLI), Changed(false) {
-    ValueDataArray =
-        std::make_unique<InstrProfValueData[]>(INSTR_PROF_NUM_BUCKETS);
-  }
+      : Func(Func), BFI(BFI), ORE(ORE), DT(DT), TLI(TLI), Changed(false) {}
   bool isChanged() const { return Changed; }
   void perform() {
     WorkList.clear();
@@ -222,8 +219,6 @@ private:
   TargetLibraryInfo &TLI;
   bool Changed;
   std::vector<MemOp> WorkList;
-  // The space to read the profile annotation.
-  std::unique_ptr<InstrProfValueData[]> ValueDataArray;
   bool perform(MemOp MO);
 };
 
@@ -254,8 +249,9 @@ bool MemOPSizeOpt::perform(MemOp MO) {
 
   uint32_t NumVals, MaxNumVals = INSTR_PROF_NUM_BUCKETS;
   uint64_t TotalCount;
-  if (!getValueProfDataFromInst(*MO.I, IPVK_MemOPSize, MaxNumVals,
-                                ValueDataArray.get(), NumVals, TotalCount))
+  auto ValueDataArray = getValueProfDataFromInst(
+      *MO.I, IPVK_MemOPSize, MaxNumVals, NumVals, TotalCount);
+  if (!ValueDataArray)
     return false;
 
   uint64_t ActualCount = TotalCount;


### PR DESCRIPTION
Note that the version of getValueProfDataFromInst that returns bool
has been "deprecated" since:

  commit 1e15371dd8843dfc52b9435afaa133997c1773d8
  Author: Mingming Liu <mingmingl@google.com>
  Date:   Mon Apr 1 15:14:49 2024 -0700