### PR TITLE
[NFC][CGSCC] Remove RCWorklist from CGSCCUpdateResult

### DIFF
--- a/llvm/include/llvm/Analysis/CGSCCPassManager.h
+++ b/llvm/include/llvm/Analysis/CGSCCPassManager.h
@@ -230,17 +230,6 @@ using ModuleAnalysisManagerCGSCCProxy =
 /// Passes which do not change the call graph structure in any way can just
 /// ignore this argument to their run method.
 struct CGSCCUpdateResult {
-  /// Worklist of the RefSCCs queued for processing.
-  ///
-  /// When a pass refines the graph and creates new RefSCCs or causes them to
-  /// have a different shape or set of component SCCs it should add the RefSCCs
-  /// to this worklist so that we visit them in the refined form.
-  ///
-  /// This worklist is in reverse post-order, as we pop off the back in order
-  /// to observe RefSCCs in post-order. When adding RefSCCs, clients should add
-  /// them in reverse post-order.
-  SmallPriorityWorklist<LazyCallGraph::RefSCC *, 1> &RCWorklist;
-
   /// Worklist of the SCCs queued for processing.
   ///
   /// When a pass refines the graph and creates new SCCs or causes them to have

--- a/llvm/lib/Analysis/CGSCCPassManager.cpp
+++ b/llvm/lib/Analysis/CGSCCPassManager.cpp
@@ -160,10 +160,14 @@ ModuleToPostOrderCGSCCPassAdaptor::run(Module &M, ModuleAnalysisManager &AM) {
 
   SmallVector<Function *, 4> DeadFunctions;
 
-  CGSCCUpdateResult UR = {
-      RCWorklist,           CWorklist,     InvalidRefSCCSet,
-      InvalidSCCSet,        nullptr,       PreservedAnalyses::all(),
-      InlinedInternalEdges, DeadFunctions, {}};
+  CGSCCUpdateResult UR = {CWorklist,
+                          InvalidRefSCCSet,
+                          InvalidSCCSet,
+                          nullptr,
+                          PreservedAnalyses::all(),
+                          InlinedInternalEdges,
+                          DeadFunctions,
+                          {}};
 
   // Request PassInstrumentation from analysis manager, will use it to run
   // instrumenting callbacks for the passes later.


### PR DESCRIPTION
After #94815, this is only used within ModuleToPostOrderCGSCCPassAdaptor::run(), so keep it local to that function.