### PR TITLE
[libc] Fix build breaks caused by f16sqrtf changes

### DIFF
--- a/libc/test/src/math/smoke/CMakeLists.txt
+++ b/libc/test/src/math/smoke/CMakeLists.txt
@@ -2597,6 +2597,9 @@ add_fp_unittest(
   HDRS
     SqrtTest.h
   DEPENDS
+    # The dependency on sqrtf128 is used to disable the test when float128
+    # support is not available.
+    libc.src.math.sqrtf128
     libc.src.__support.FPUtil.generic.sqrt
   COMPILE_OPTIONS
     -O3

--- a/libc/test/src/stdfix/ISqrtTest.h
+++ b/libc/test/src/stdfix/ISqrtTest.h
@@ -55,7 +55,7 @@ public:
       x_d += 1.0;
       ++x;
       OutType result = func(x);
-      double expected = LIBC_NAMESPACE::fputil::sqrt(x_d);
+      double expected = LIBC_NAMESPACE::fputil::sqrt<double>(x_d);
       testSpecificInput(x, result, expected, ERR);
     }
   }

--- a/libc/test/src/stdfix/SqrtTest.h
+++ b/libc/test/src/stdfix/SqrtTest.h
@@ -49,7 +49,8 @@ public:
       T v = LIBC_NAMESPACE::cpp::bit_cast<T>(x);
       double v_d = static_cast<double>(v);
       double errors = LIBC_NAMESPACE::fputil::abs(
-          static_cast<double>(func(v)) - LIBC_NAMESPACE::fputil::sqrt(v_d));
+          static_cast<double>(func(v)) -
+          LIBC_NAMESPACE::fputil::sqrt<double>(v_d));
       if (errors > ERR) {
         // Print out the failure input and output.
         EXPECT_EQ(v, zero);


### PR DESCRIPTION
See Buildbot failures:

- https://lab.llvm.org/buildbot/#/builders/78/builds/13
- https://lab.llvm.org/buildbot/#/builders/182/builds/7
