### PR TITLE
Update ModuleSummaryIndexBitcodeReader::makeCallList reserve amount

### DIFF
--- a/llvm/lib/Bitcode/Reader/BitcodeReader.cpp
+++ b/llvm/lib/Bitcode/Reader/BitcodeReader.cpp
@@ -7333,12 +7333,10 @@ ModuleSummaryIndexBitcodeReader::makeCallList(ArrayRef<uint64_t> Record,
                                               bool HasProfile, bool HasRelBF) {
   std::vector<FunctionSummary::EdgeTy> Ret;
   // In the case of new profile formats, there are two Record entries per
-  // Edge. Otherwise, conservatively reserve up to Record.size and later
-  // shrink_to_fit when we are done (and shrink_to_fit for the exact
-  // case should be a no-op).
-  if (!IsOldProfileFormat && (HasProfile || HasRelBF)) {
+  // Edge. Otherwise, conservatively reserve up to Record.size.
+  if (!IsOldProfileFormat && (HasProfile || HasRelBF))
     Ret.reserve(Record.size() / 2);
-  } else
+  else
     Ret.reserve(Record.size());
 
   for (unsigned I = 0, E = Record.size(); I != E; ++I) {
@@ -7358,8 +7356,6 @@ ModuleSummaryIndexBitcodeReader::makeCallList(ArrayRef<uint64_t> Record,
     Ret.push_back(FunctionSummary::EdgeTy{
         Callee, CalleeInfo(Hotness, HasTailCall, RelBF)});
   }
-
-  Ret.shrink_to_fit();
   return Ret;
 }
 

--- a/llvm/lib/Bitcode/Reader/BitcodeReader.cpp
+++ b/llvm/lib/Bitcode/Reader/BitcodeReader.cpp
@@ -7332,12 +7332,11 @@ ModuleSummaryIndexBitcodeReader::makeCallList(ArrayRef<uint64_t> Record,
                                               bool IsOldProfileFormat,
                                               bool HasProfile, bool HasRelBF) {
   std::vector<FunctionSummary::EdgeTy> Ret;
-  if (IsOldProfileFormat) {
-    if (HasProfile)
-      Ret.reserve(Record.size() / 3);
-    else
-      Ret.reserve(Record.size() / 2);
-  } else if (HasProfile || HasRelBF) {
+  // In the case of new profile formats, there are two Record entries per
+  // Edge. Otherwise, conservatively reserve up to Record.size and later
+  // shrink_to_fit when we are done (and shrink_to_fit for the exact
+  // case should be a no-op).
+  if (!IsOldProfileFormat && (HasProfile || HasRelBF)) {
     Ret.reserve(Record.size() / 2);
   } else
     Ret.reserve(Record.size());
@@ -7359,6 +7358,8 @@ ModuleSummaryIndexBitcodeReader::makeCallList(ArrayRef<uint64_t> Record,
     Ret.push_back(FunctionSummary::EdgeTy{
         Callee, CalleeInfo(Hotness, HasTailCall, RelBF)});
   }
+
+  Ret.shrink_to_fit();
   return Ret;
 }
 

--- a/llvm/lib/Bitcode/Reader/BitcodeReader.cpp
+++ b/llvm/lib/Bitcode/Reader/BitcodeReader.cpp
@@ -7332,7 +7332,16 @@ ModuleSummaryIndexBitcodeReader::makeCallList(ArrayRef<uint64_t> Record,
                                               bool IsOldProfileFormat,
                                               bool HasProfile, bool HasRelBF) {
   std::vector<FunctionSummary::EdgeTy> Ret;
-  Ret.reserve(Record.size());
+  if (IsOldProfileFormat) {
+    if (HasProfile)
+      Ret.reserve(Record.size() / 3);
+    else
+      Ret.reserve(Record.size() / 2);
+  } else if (HasProfile || HasRelBF) {
+    Ret.reserve(Record.size() / 2);
+  } else
+    Ret.reserve(Record.size());
+
   for (unsigned I = 0, E = Record.size(); I != E; ++I) {
     CalleeInfo::HotnessType Hotness = CalleeInfo::HotnessType::Unknown;
     bool HasTailCall = false;


### PR DESCRIPTION
Tighten the reserve() to `Record.size() / 2` instead of `Record.size()` in the HasProfile/HasRelBF cases. For the uncommon old profile format cases we leave it as is, but those should be rare and not worth optimizing.
This reduces peak memory during ThinLTO indexing by ~3% in one example.

Alternatively, we could make the branching for reserve more complex and try to cover every case.