### PR TITLE
[llvm-profdata] Clean up traverseAllValueSites (NFC)

### DIFF
--- a/llvm/tools/llvm-profdata/llvm-profdata.cpp
+++ b/llvm/tools/llvm-profdata/llvm-profdata.cpp
@@ -2695,30 +2695,30 @@ static void traverseAllValueSites(const InstrProfRecord &Func, uint32_t VK,
   uint32_t NS = Func.getNumValueSites(VK);
   Stats.TotalNumValueSites += NS;
   for (size_t I = 0; I < NS; ++I) {
-    uint32_t NV = Func.getNumValueDataForSite(VK, I);
-    std::unique_ptr<InstrProfValueData[]> VD = Func.getValueForSite(VK, I);
+    auto VD = Func.getValueArrayForSite(VK, I);
+    if (VD.empty())
+      continue;
+    uint32_t NV = VD.size();
     Stats.TotalNumValues += NV;
-    if (NV) {
-      Stats.TotalNumValueSitesWithValueProfile++;
-      if (NV > Stats.ValueSitesHistogram.size())
-        Stats.ValueSitesHistogram.resize(NV, 0);
-      Stats.ValueSitesHistogram[NV - 1]++;
-    }
+    Stats.TotalNumValueSitesWithValueProfile++;
+    if (NV > Stats.ValueSitesHistogram.size())
+      Stats.ValueSitesHistogram.resize(NV, 0);
+    Stats.ValueSitesHistogram[NV - 1]++;
 
     uint64_t SiteSum = 0;
-    for (uint32_t V = 0; V < NV; V++)
-      SiteSum += VD[V].Count;
+    for (const auto &V : VD)
+      SiteSum += V.Count;
     if (SiteSum == 0)
       SiteSum = 1;
 
-    for (uint32_t V = 0; V < NV; V++) {
+    for (const auto &V : VD) {
       OS << "\t[ " << format("%2u", I) << ", ";
       if (Symtab == nullptr)
-        OS << format("%4" PRIu64, VD[V].Value);
+        OS << format("%4" PRIu64, V.Value);
       else
-        OS << Symtab->getFuncOrVarName(VD[V].Value);
-      OS << ", " << format("%10" PRId64, VD[V].Count) << " ] ("
-         << format("%.2f%%", (VD[V].Count * 100.0 / SiteSum)) << ")\n";
+        OS << Symtab->getFuncOrVarName(V.Value);
+      OS << ", " << format("%10" PRId64, V.Count) << " ] ("
+         << format("%.2f%%", (V.Count * 100.0 / SiteSum)) << ")\n";
     }
   }
 }

--- a/llvm/tools/llvm-profdata/llvm-profdata.cpp
+++ b/llvm/tools/llvm-profdata/llvm-profdata.cpp
@@ -2696,9 +2696,9 @@ static void traverseAllValueSites(const InstrProfRecord &Func, uint32_t VK,
   Stats.TotalNumValueSites += NS;
   for (size_t I = 0; I < NS; ++I) {
     auto VD = Func.getValueArrayForSite(VK, I);
-    if (VD.empty())
-      continue;
     uint32_t NV = VD.size();
+    if (NV == 0)
+      continue;
     Stats.TotalNumValues += NV;
     Stats.TotalNumValueSitesWithValueProfile++;
     if (NV > Stats.ValueSitesHistogram.size())


### PR DESCRIPTION
If NV == 0, nothing interesting happens after the "if" statement.  We
should just "continue" to the next value site.

While I am at it, this patch migrates a use of getValueForSite to
getValueArrayForSite.