### PR TITLE
[Clang][NFC] Avoid opening namespace std

### DIFF
--- a/clang/include/clang/Format/Format.h
+++ b/clang/include/clang/Format/Format.h
@@ -5430,9 +5430,7 @@ bool isClangFormatOff(StringRef Comment);
 } // end namespace format
 } // end namespace clang
 
-namespace std {
 template <>
-struct is_error_code_enum<clang::format::ParseError> : std::true_type {};
-} // namespace std
+struct std::is_error_code_enum<clang::format::ParseError> : std::true_type {};
 
 #endif // LLVM_CLANG_FORMAT_FORMAT_H

--- a/clang/include/clang/Frontend/PrecompiledPreamble.h
+++ b/clang/include/clang/Frontend/PrecompiledPreamble.h
@@ -256,9 +256,7 @@ public:
 std::error_code make_error_code(BuildPreambleError Error);
 } // namespace clang
 
-namespace std {
 template <>
-struct is_error_code_enum<clang::BuildPreambleError> : std::true_type {};
-} // namespace std
+struct std::is_error_code_enum<clang::BuildPreambleError> : std::true_type {};
 
 #endif

--- a/clang/include/clang/Frontend/SerializedDiagnosticReader.h
+++ b/clang/include/clang/Frontend/SerializedDiagnosticReader.h
@@ -128,11 +128,8 @@ protected:
 } // namespace serialized_diags
 } // namespace clang
 
-namespace std {
-
 template <>
-struct is_error_code_enum<clang::serialized_diags::SDError> : std::true_type {};
-
-} // namespace std
+struct std::is_error_code_enum<clang::serialized_diags::SDError>
+    : std::true_type {};
 
 #endif // LLVM_CLANG_FRONTEND_SERIALIZEDDIAGNOSTICREADER_H

--- a/clang/lib/StaticAnalyzer/Checkers/BlockInCriticalSectionChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/BlockInCriticalSectionChecker.cpp
@@ -202,13 +202,12 @@ public:
 
 REGISTER_LIST_WITH_PROGRAMSTATE(ActiveCritSections, CritSectionMarker)
 
-namespace std {
 // Iterator traits for ImmutableList data structure
 // that enable the use of STL algorithms.
 // TODO: Move these to llvm::ImmutableList when overhauling immutable data
 // structures for proper iterator concept support.
 template <>
-struct iterator_traits<
+struct std::iterator_traits<
     typename llvm::ImmutableList<CritSectionMarker>::iterator> {
   using iterator_category = std::forward_iterator_tag;
   using value_type = CritSectionMarker;
@@ -216,7 +215,6 @@ struct iterator_traits<
   using reference = CritSectionMarker &;
   using pointer = CritSectionMarker *;
 };
-} // namespace std
 
 std::optional<MutexDescriptor>
 BlockInCriticalSectionChecker::checkDescriptorMatch(const CallEvent &Call,


### PR DESCRIPTION
Never opening `namespace std` avoids even the possibility of introducing new symbols as well as making the code a bit shorter by removing unnecessary boiler plate.

