### PR TITLE
[Flang][OpenMP] Fix type in getBaseObject causing crashes in certain scenarios

### DIFF
--- a/flang/lib/Lower/OpenMP/Clauses.cpp
+++ b/flang/lib/Lower/OpenMP/Clauses.cpp
@@ -153,7 +153,7 @@ Object makeObject(const parser::OmpObject &object,
 std::optional<Object> getBaseObject(const Object &object,
                                     semantics::SemanticsContext &semaCtx) {
   // If it's just the symbol, then there is no base.
-  if (!object.id())
+  if (!object.ref())
     return std::nullopt;
 
   auto maybeRef = evaluate::ExtractDataRef(*object.ref());


### PR DESCRIPTION
This typo would unfortunately cause code like the following to ICE, where common block symbols/names are used in a map clause:

subroutine sb()
  implicit none
  integer:: b, c
  common /var/ b, c

!$omp target map(tofrom: /var/)
   b = 1
   c = 2
!$omp end target
end subroutine