### PR TITLE
[flang] Address missed cases for REDUCE change, fixes shared lib build

### DIFF
--- a/flang/runtime/complex-reduction.c
+++ b/flang/runtime/complex-reduction.c
@@ -157,23 +157,39 @@ ADAPT_REDUCTION(DotProductComplex16, CFloat128ComplexType, CppComplexFloat128,
 #endif
 
 /* REDUCE() */
-#define RARGS REDUCE_ARGS(float_Complex_t)
-ADAPT_REDUCTION(ReduceComplex4, float_Complex_t, CppComplexFloat, CMPLXF, RARGS,
-    REDUCE_ARG_NAMES)
+#define RARGS REDUCE_ARGS(float_Complex_t, float_Complex_t_ref_op)
+ADAPT_REDUCTION(ReduceComplex4Ref, float_Complex_t, CppComplexFloat, CMPLXF,
+    RARGS, REDUCE_ARG_NAMES)
 #undef RARGS
-#define RARGS REDUCE_ARGS(double_Complex_t)
-ADAPT_REDUCTION(ReduceComplex8, double_Complex_t, CppComplexDouble, CMPLX,
+#define RARGS REDUCE_ARGS(float_Complex_t, float_Complex_t_value_op)
+ADAPT_REDUCTION(ReduceComplex4Value, float_Complex_t, CppComplexFloat, CMPLXF,
+    RARGS, REDUCE_ARG_NAMES)
+#undef RARGS
+#define RARGS REDUCE_ARGS(double_Complex_t, double_Complex_t_ref_op)
+ADAPT_REDUCTION(ReduceComplex8Ref, double_Complex_t, CppComplexDouble, CMPLX,
+    RARGS, REDUCE_ARG_NAMES)
+#undef RARGS
+#define RARGS REDUCE_ARGS(double_Complex_t, double_Complex_t_value_op)
+ADAPT_REDUCTION(ReduceComplex8Value, double_Complex_t, CppComplexDouble, CMPLX,
     RARGS, REDUCE_ARG_NAMES)
 #undef RARGS
 #if LDBL_MANT_DIG == 64
-#define RARGS REDUCE_ARGS(long_double_Complex_t)
-ADAPT_REDUCTION(ReduceComplex10, long_double_Complex_t, CppComplexLongDouble,
+#define RARGS REDUCE_ARGS(long_double_Complex_t, long_double_Complex_t_ref_op)
+ADAPT_REDUCTION(ReduceComplex10Ref, long_double_Complex_t, CppComplexLongDouble,
     CMPLXL, RARGS, REDUCE_ARG_NAMES)
+#undef RARGS
+#define RARGS REDUCE_ARGS(long_double_Complex_t, long_double_Complex_t_value_op)
+ADAPT_REDUCTION(ReduceComplex10Value, long_double_Complex_t,
+    CppComplexLongDouble, CMPLXL, RARGS, REDUCE_ARG_NAMES)
 #undef RARGS
 #endif
 #if LDBL_MANT_DIG == 113 || HAS_FLOAT128
-#define RARGS REDUCE_ARGS(CFloat128ComplexType)
-ADAPT_REDUCTION(ReduceComplex16, CFloat128ComplexType, CppComplexFloat128,
+#define RARGS REDUCE_ARGS(CFloat128ComplexType, CFloat128ComplexType_ref_op)
+ADAPT_REDUCTION(ReduceComplex16Ref, CFloat128ComplexType, CppComplexFloat128,
+    CMPLXF128, RARGS, REDUCE_ARG_NAMES)
+#undef RARGS
+#define RARGS REDUCE_ARGS(CFloat128ComplexType, CFloat128ComplexType_value_op)
+ADAPT_REDUCTION(ReduceComplex16Value, CFloat128ComplexType, CppComplexFloat128,
     CMPLXF128, RARGS, REDUCE_ARG_NAMES)
 #undef RARGS
 #endif

--- a/flang/runtime/complex-reduction.h
+++ b/flang/runtime/complex-reduction.h
@@ -69,49 +69,91 @@ long_double_Complex_t RTNAME(DotProductComplex10)(DOT_PRODUCT_ARGS);
 CFloat128ComplexType RTNAME(DotProductComplex16)(DOT_PRODUCT_ARGS);
 #endif
 
-#define REDUCE_ARGS(T) \
-  T##_op operation, const struct CppDescriptor *x, \
-      const struct CppDescriptor *y, const char *source, int line, \
-      int dim /*=0*/, const struct CppDescriptor *mask /*=NULL*/, \
-      const T *identity /*=NULL*/, _Bool ordered /*=true*/
+#define REDUCE_ARGS(T, OP) \
+  OP operation, const struct CppDescriptor *x, const struct CppDescriptor *y, \
+      const char *source, int line, int dim /*=0*/, \
+      const struct CppDescriptor *mask /*=NULL*/, const T *identity /*=NULL*/, \
+      _Bool ordered /*=true*/
 #define REDUCE_ARG_NAMES \
   operation, x, y, source, line, dim, mask, identity, ordered
 
-typedef float_Complex_t (*float_Complex_t_op)(
+typedef float_Complex_t (*float_Complex_t_ref_op)(
     const float_Complex_t *, const float_Complex_t *);
-typedef double_Complex_t (*double_Complex_t_op)(
+typedef float_Complex_t (*float_Complex_t_value_op)(
+    float_Complex_t, float_Complex_t);
+typedef double_Complex_t (*double_Complex_t_ref_op)(
     const double_Complex_t *, const double_Complex_t *);
-typedef long_double_Complex_t (*long_double_Complex_t_op)(
+typedef double_Complex_t (*double_Complex_t_value_op)(
+    double_Complex_t, double_Complex_t);
+typedef long_double_Complex_t (*long_double_Complex_t_ref_op)(
     const long_double_Complex_t *, const long_double_Complex_t *);
+typedef long_double_Complex_t (*long_double_Complex_t_value_op)(
+    long_double_Complex_t, long_double_Complex_t);
 
-float_Complex_t RTNAME(ReduceComplex2)(REDUCE_ARGS(float_Complex_t));
-float_Complex_t RTNAME(ReduceComplex3)(REDUCE_ARGS(float_Complex_t));
-float_Complex_t RTNAME(ReduceComplex4)(REDUCE_ARGS(float_Complex_t));
-double_Complex_t RTNAME(ReduceComplex8)(REDUCE_ARGS(double_Complex_t));
-long_double_Complex_t RTNAME(ReduceComplex10)(
-    REDUCE_ARGS(long_double_Complex_t));
+float_Complex_t RTNAME(ReduceComplex2Ref)(
+    REDUCE_ARGS(float_Complex_t, float_Complex_t_ref_op));
+float_Complex_t RTNAME(ReduceComplex2Value)(
+    REDUCE_ARGS(float_Complex_t, float_Complex_t_value_op));
+float_Complex_t RTNAME(ReduceComplex3Ref)(
+    REDUCE_ARGS(float_Complex_t, float_Complex_t_ref_op));
+float_Complex_t RTNAME(ReduceComplex3Value)(
+    REDUCE_ARGS(float_Complex_t, float_Complex_t_value_op));
+float_Complex_t RTNAME(ReduceComplex4Ref)(
+    REDUCE_ARGS(float_Complex_t, float_Complex_t_ref_op));
+float_Complex_t RTNAME(ReduceComplex4Value)(
+    REDUCE_ARGS(float_Complex_t, float_Complex_t_value_op));
+double_Complex_t RTNAME(ReduceComplex8Ref)(
+    REDUCE_ARGS(double_Complex_t, double_Complex_t_ref_op));
+double_Complex_t RTNAME(ReduceComplex8Value)(
+    REDUCE_ARGS(double_Complex_t, double_Complex_t_value_op));
+long_double_Complex_t RTNAME(ReduceComplex10Ref)(
+    REDUCE_ARGS(long_double_Complex_t, long_double_Complex_t_ref_op));
+long_double_Complex_t RTNAME(ReduceComplex10Value)(
+    REDUCE_ARGS(long_double_Complex_t, long_double_Complex_t_value_op));
 #if LDBL_MANT_DIG == 113 || HAS_FLOAT128
-typedef CFloat128ComplexType (*CFloat128ComplexType_op)(
+typedef CFloat128ComplexType (*CFloat128ComplexType_ref_op)(
     const CFloat128ComplexType *, const CFloat128ComplexType *);
-CFloat128ComplexType RTNAME(ReduceComplex16)(REDUCE_ARGS(CFloat128ComplexType));
+typedef CFloat128ComplexType (*CFloat128ComplexType_value_op)(
+    CFloat128ComplexType, CFloat128ComplexType);
+CFloat128ComplexType RTNAME(ReduceComplex16Ref)(
+    REDUCE_ARGS(CFloat128ComplexType, CFloat128ComplexType_ref_op));
+CFloat128ComplexType RTNAME(ReduceComplex16Value)(
+    REDUCE_ARGS(CFloat128ComplexType, CFloat128ComplexType_value_op));
 #endif
 
-#define REDUCE_DIM_ARGS(T) \
-  struct CppDescriptor *result, T##_op operation, \
-      const struct CppDescriptor *x, const struct CppDescriptor *y, \
-      const char *source, int line, int dim, \
+#define REDUCE_DIM_ARGS(T, OP) \
+  struct CppDescriptor *result, OP operation, const struct CppDescriptor *x, \
+      const struct CppDescriptor *y, const char *source, int line, int dim, \
       const struct CppDescriptor *mask /*=NULL*/, const T *identity /*=NULL*/, \
       _Bool ordered /*=true*/
 #define REDUCE_DIM_ARG_NAMES \
   result, operation, x, y, source, line, dim, mask, identity, ordered
 
-void RTNAME(ReduceComplex2Dim)(REDUCE_DIM_ARGS(float_Complex_t));
-void RTNAME(ReduceComplex3Dim)(REDUCE_DIM_ARGS(float_Complex_t));
-void RTNAME(ReduceComplex4Dim)(REDUCE_DIM_ARGS(float_Complex_t));
-void RTNAME(ReduceComplex8Dim)(REDUCE_DIM_ARGS(double_Complex_t));
-void RTNAME(ReduceComplex10Dim)(REDUCE_DIM_ARGS(long_double_Complex_t));
+void RTNAME(ReduceComplex2DimRef)(
+    REDUCE_DIM_ARGS(float_Complex_t, float_Complex_t_ref_op));
+void RTNAME(ReduceComplex2DimValue)(
+    REDUCE_DIM_ARGS(float_Complex_t, float_Complex_t_value_op));
+void RTNAME(ReduceComplex3DimRef)(
+    REDUCE_DIM_ARGS(float_Complex_t, float_Complex_t_ref_op));
+void RTNAME(ReduceComplex3DimValue)(
+    REDUCE_DIM_ARGS(float_Complex_t, float_Complex_t_value_op));
+void RTNAME(ReduceComplex4DimRef)(
+    REDUCE_DIM_ARGS(float_Complex_t, float_Complex_t_ref_op));
+void RTNAME(ReduceComplex4DimValue)(
+    REDUCE_DIM_ARGS(float_Complex_t, float_Complex_t_value_op));
+void RTNAME(ReduceComplex8DimRef)(
+    REDUCE_DIM_ARGS(double_Complex_t, double_Complex_t_ref_op));
+void RTNAME(ReduceComplex8DimValue)(
+    REDUCE_DIM_ARGS(double_Complex_t, double_Complex_t_value_op));
+void RTNAME(ReduceComplex10DimRef)(
+    REDUCE_DIM_ARGS(long_double_Complex_t, long_double_Complex_t_ref_op));
+void RTNAME(ReduceComplex10DimValue)(
+    REDUCE_DIM_ARGS(long_double_Complex_t, long_double_Complex_t_value_op));
 #if LDBL_MANT_DIG == 113 || HAS_FLOAT128
-void RTNAME(ReduceComplex16Dim)(REDUCE_DIM_ARGS(CFloat128ComplexType));
+void RTNAME(ReduceComplex16DimRef)(
+    REDUCE_DIM_ARGS(CFloat128ComplexType, CFloat128ComplexType_ref_op));
+void RTNAME(ReduceComplex16DimValue)(
+    REDUCE_DIM_ARGS(CFloat128ComplexType, CFloat128ComplexType_value_op));
 #endif
 
 #endif // FORTRAN_RUNTIME_COMPLEX_REDUCTION_H_


### PR DESCRIPTION
My recent change that distinguishes pass-by-reference from pass-by-value reduction operation functions missed the "CppReduceComplex" cases, and also broke the shared library build-bots.  Fix.