### PR TITLE
[libc] Fixed NamedType usage in Fenv HeaderSpec Types

### DIFF
--- a/libc/spec/stdc.td
+++ b/libc/spec/stdc.td
@@ -134,8 +134,8 @@ def StdC : StandardSpec<"stdc"> {
           Macro<"FE_DFL_ENV">
       ],
       [
-          NamedType<"fenv_t">,
-          NamedType<"fexcept_t">,
+          FEnvT,
+          FExceptT,
       ], // Types
       [], // Enumerations
       [


### PR DESCRIPTION
Issue: NamedType<"fenv_t"> and NamedType<"fexcept_t"> were used in Fenv HeaderSpec Types section instead of the actual NamedType
Fixed: Changed to FEnvT and FExceptT