### PR TITLE
[SPIRV] Silence unused variable warnings

### DIFF
--- a/llvm/lib/Target/SPIRV/Analysis/SPIRVConvergenceRegionAnalysis.cpp
+++ b/llvm/lib/Target/SPIRV/Analysis/SPIRVConvergenceRegionAnalysis.cpp
@@ -138,7 +138,7 @@ ConvergenceRegion::ConvergenceRegion(
     SmallPtrSet<BasicBlock *, 8> &&Blocks, SmallPtrSet<BasicBlock *, 2> &&Exits)
     : DT(DT), LI(LI), ConvergenceToken(ConvergenceToken), Entry(Entry),
       Exits(std::move(Exits)), Blocks(std::move(Blocks)) {
-  for (auto *BB : this->Exits)
+  for ([[maybe_unused]] auto *BB : this->Exits)
     assert(this->Blocks.count(BB) != 0);
   assert(this->Blocks.count(this->Entry) != 0);
 }

--- a/llvm/lib/Target/SPIRV/SPIRVBuiltins.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVBuiltins.cpp
@@ -2418,7 +2418,7 @@ Type *parseBuiltinCallArgumentBaseType(const StringRef DemangledCall,
   if (hasBuiltinTypePrefix(TypeStr)) {
     // OpenCL builtin types in demangled call strings have the following format:
     // e.g. ocl_image2d_ro
-    bool IsOCLBuiltinType = TypeStr.consume_front("ocl_");
+    [[maybe_unused]] bool IsOCLBuiltinType = TypeStr.consume_front("ocl_");
     assert(IsOCLBuiltinType && "Invalid OpenCL builtin prefix");
 
     // Check if this is pointer to a builtin type and not just pointer


### PR DESCRIPTION
This change marks a few variable declarations as [[maybe_unused]] to silence unused variable warnings.