### PR TITLE
[clang-format] Handle AttributeMacro before access modifiers

### DIFF
--- a/clang/lib/Format/UnwrappedLineFormatter.cpp
+++ b/clang/lib/Format/UnwrappedLineFormatter.cpp
@@ -57,7 +57,10 @@ public:
   /// Update the indent state given that \p Line is going to be formatted
   /// next.
   void nextLine(const AnnotatedLine &Line) {
-    Offset = getIndentOffset(*Line.First);
+    const auto *Tok = Line.First;
+    if (Tok->is(TT_AttributeMacro) && Tok->Next)
+      Tok = Tok->Next;
+    Offset = getIndentOffset(*Tok);
     // Update the indent level cache size so that we can rely on it
     // having the right size in adjustToUnmodifiedline.
     if (Line.Level >= IndentForLevel.size())

--- a/clang/unittests/Format/FormatTest.cpp
+++ b/clang/unittests/Format/FormatTest.cpp
@@ -12912,6 +12912,15 @@ TEST_F(FormatTest, FormatsAccessModifiers) {
                "  int j;\n"
                "};",
                Style);
+  Style.AttributeMacros.push_back("FOO");
+  Style.AttributeMacros.push_back("BAR");
+  verifyFormat("struct foo {\n"
+               "FOO private:\n"
+               "  int i;\n"
+               "BAR private:\n"
+               "  int j;\n"
+               "};",
+               Style);
 
   FormatStyle NoEmptyLines = getLLVMStyle();
   NoEmptyLines.MaxEmptyLinesToKeep = 0;
@@ -26127,6 +26136,12 @@ TEST_F(FormatTest, IndentAccessModifiers) {
                Style);
   verifyFormat("class C {\n"
                "   public /**/:\n"
+               "      int i;\n"
+               "};",
+               Style);
+  Style.AttributeMacros.push_back("FOO");
+  verifyFormat("class C {\n"
+               "   FOO public:\n"
                "      int i;\n"
                "};",
                Style);


### PR DESCRIPTION
Closes #95094.