### PR TITLE
[lldb] Stop testing LLDB on Clang changes in pre-commit CI

### DIFF
--- a/.ci/generate-buildkite-pipeline-premerge
+++ b/.ci/generate-buildkite-pipeline-premerge
@@ -74,7 +74,8 @@ function compute-projects-to-test() {
       fi
     ;;
     clang)
-      for p in clang-tools-extra compiler-rt lldb cross-project-tests; do
+      # lldb is temporarily removed to alleviate Linux pre-commit CI waiting times
+      for p in clang-tools-extra compiler-rt cross-project-tests; do
         echo $p
       done
     ;;


### PR DESCRIPTION
This is a temporary measure to alleviate Linux pre-commit CI waiting times that started snowballing [recently](https://discourse.llvm.org/t/long-wait-for-linux-presubmit-testing/79547/5).
My [initial estimate](https://github.com/llvm/llvm-project/pull/94208#issuecomment-2155972973) of 4 additional minutes spent per built seems to be in the right ballpark, but looks like that was the last straw to break camel's back. It seems that CI load got past the tipping point, and now it's not able to burn through the queue over the night on workdays.

I don't intend to overthrow the consensus we reached in #94208, but it shouldn't come at the expense of the whole LLVM community. I'll enable this back as soon as we have news that we got more capacity for Linux pre-commit CI.