### PR TITLE
[clang-interp] Use -fno-sized-deallocation in two tests

### DIFF
--- a/clang/test/Interpreter/inline-virtual.cpp
+++ b/clang/test/Interpreter/inline-virtual.cpp
@@ -3,8 +3,10 @@
 //
 // We disable RTTI to avoid problems on Windows for non-RTTI builds of LLVM
 // where the JIT cannot find ??_7type_info@@6B@.
-// RUN: cat %s | clang-repl -Xcc -fno-rtti | FileCheck %s
-// RUN: cat %s | clang-repl -Xcc -fno-rtti -Xcc -O2 | FileCheck %s
+// RUN: cat %s | clang-repl -Xcc -fno-rtti -Xcc -fno-sized-deallocation \
+// RUN:     | FileCheck %s
+// RUN: cat %s | clang-repl -Xcc -fno-rtti -Xcc -fno-sized-deallocation \
+// RUN:     -Xcc -O2 | FileCheck %s
 
 extern "C" int printf(const char *, ...);
 

--- a/clang/unittests/Interpreter/InterpreterTest.cpp
+++ b/clang/unittests/Interpreter/InterpreterTest.cpp
@@ -286,7 +286,8 @@ TEST_F(InterpreterTest, InstantiateTemplate) {
 // https://github.com/llvm/llvm-project/issues/94994.
 #ifndef __arm__
 TEST_F(InterpreterTest, Value) {
-  std::unique_ptr<Interpreter> Interp = createInterpreter();
+  std::vector<const char *> Args = {"-fno-sized-deallocation"};
+  std::unique_ptr<Interpreter> Interp = createInterpreter(Args);
 
   Value V1;
   llvm::cantFail(Interp->ParseAndExecute("int x = 42;"));


### PR DESCRIPTION
At least on my Windows machine, these two tests fail due to not being able to look up `??3@YAXPEAX_K@Z` (which is
`void __cdecl operator delete(void *, unsigned __int64)` in demangled) after 130e93cc26ca. Since they don't test anything related to sized deallocation, just disable sized allocation for them.

Possibly fixes #95451.