### PR TITLE
[Xtensa] Fix register asm parsing.

### DIFF
--- a/llvm/lib/Target/Xtensa/AsmParser/XtensaAsmParser.cpp
+++ b/llvm/lib/Target/Xtensa/AsmParser/XtensaAsmParser.cpp
@@ -572,7 +572,7 @@ ParseStatus XtensaAsmParser::parseRegister(OperandVector &Operands,
   case AsmToken::Integer:
     if (!SR)
       return ParseStatus::NoMatch;
-    RegName = StringRef(std::to_string(getLexer().getTok().getIntVal()));
+    RegName = getLexer().getTok().getString();
     RegNo = MatchRegisterName(RegName);
     if (RegNo == 0)
       RegNo = MatchRegisterAltName(RegName);

--- a/llvm/test/MC/Xtensa/Core/registers.s
+++ b/llvm/test/MC/Xtensa/Core/registers.s
@@ -1,0 +1,14 @@
+# RUN: llvm-mc %s -triple=xtensa -show-encoding \
+# RUN:     | FileCheck -check-prefixes=CHECK,CHECK-INST %s
+
+
+.align	4
+LBL0:
+
+#############################################################
+## Check special registers parsing
+#############################################################
+
+# CHECK-INST: xsr a8, sar
+# CHECK: encoding: [0x80,0x03,0x61]
+xsr a8, 3


### PR DESCRIPTION
Fix passing temporary string object as argument to the StringRef constructor in "parseRegister" function, because it causes errors in the test "llvm/test/MC/Xtensa/Core/processor-control.s".