### PR TITLE
MathExtras: rewrite some methods to never overflow

### DIFF
--- a/llvm/include/llvm/Support/MathExtras.h
+++ b/llvm/include/llvm/Support/MathExtras.h
@@ -472,9 +472,8 @@ inline int64_t mod(int64_t Numerator, int64_t Denominator) {
 inline uint64_t divideNearest(uint64_t Numerator, uint64_t Denominator) {
   uint64_t Mod = Numerator % Denominator;
   uint64_t HalfDenomFloor = Denominator / 2;
-  return (Numerator / Denominator) +
-         (Mod > HalfDenomFloor ||
-          ((Mod == HalfDenomFloor) & ~(Denominator & 1)));
+  uint64_t TieBreaker = ((Mod == HalfDenomFloor) & ~(Denominator & 1));
+  return (Numerator / Denominator) + (Mod > HalfDenomFloor || TieBreaker);
 }
 
 /// Returns the largest uint64_t less than or equal to \p Value and is

--- a/llvm/include/llvm/Support/MathExtras.h
+++ b/llvm/include/llvm/Support/MathExtras.h
@@ -429,6 +429,7 @@ template <uint64_t Align> constexpr inline uint64_t alignTo(uint64_t Value) {
 /// Returns the integer ceil(Numerator / Denominator). Unsigned version.
 /// Guaranteed to never overflow.
 inline uint64_t divideCeil(uint64_t Numerator, uint64_t Denominator) {
+  assert(Denominator && "Division by zero");
   uint64_t Bias = (Numerator != 0);
   return (Numerator - Bias) / Denominator + Bias;
 }
@@ -456,7 +457,7 @@ inline int64_t divideFloorSigned(int64_t Numerator, int64_t Denominator) {
   int64_t Bias = Denominator >= 0 ? -1 : 1;
   bool SameSign = (Numerator >= 0) == (Denominator >= 0);
   return SameSign ? Numerator / Denominator
-                  : -((Bias - Numerator) / Denominator) - 1;
+                  : (Numerator - Bias) / Denominator - 1;
 }
 
 /// Returns the remainder of the Euclidean division of LHS by RHS. Result is
@@ -470,10 +471,9 @@ inline int64_t mod(int64_t Numerator, int64_t Denominator) {
 /// Returns (Numerator / Denominator) rounded by round-half-up. Guaranteed to
 /// never overflow.
 inline uint64_t divideNearest(uint64_t Numerator, uint64_t Denominator) {
+  assert(Denominator && "Division by zero");
   uint64_t Mod = Numerator % Denominator;
-  uint64_t HalfDenomFloor = Denominator / 2;
-  uint64_t TieBreaker = ((Mod == HalfDenomFloor) & ~(Denominator & 1));
-  return (Numerator / Denominator) + (Mod > HalfDenomFloor || TieBreaker);
+  return (Numerator / Denominator) + (Mod > (Denominator - 1) / 2);
 }
 
 /// Returns the largest uint64_t less than or equal to \p Value and is

--- a/llvm/include/llvm/Support/MathExtras.h
+++ b/llvm/include/llvm/Support/MathExtras.h
@@ -440,8 +440,8 @@ inline int64_t divideCeilSigned(int64_t Numerator, int64_t Denominator) {
   if (!Numerator)
     return 0;
   // C's integer division rounds towards 0.
-  int64_t Bias = (Denominator > 0 ? 1 : -1);
-  bool SameSign = (Numerator > 0) == (Denominator > 0);
+  int64_t Bias = (Denominator >= 0 ? 1 : -1);
+  bool SameSign = (Numerator >= 0) == (Denominator >= 0);
   return SameSign ? (Numerator - Bias) / Denominator + 1
                   : Numerator / Denominator;
 }
@@ -453,8 +453,8 @@ inline int64_t divideFloorSigned(int64_t Numerator, int64_t Denominator) {
   if (!Numerator)
     return 0;
   // C's integer division rounds towards 0.
-  int64_t Bias = Denominator > 0 ? 1 : -1;
-  bool SameSign = (Numerator > 0) == (Denominator > 0);
+  int64_t Bias = Denominator >= 0 ? 1 : -1;
+  bool SameSign = (Numerator >= 0) == (Denominator >= 0);
   return SameSign ? Numerator / Denominator
                   : -((-Numerator - Bias) / Denominator) - 1;
 }

--- a/llvm/include/llvm/Support/MathExtras.h
+++ b/llvm/include/llvm/Support/MathExtras.h
@@ -453,10 +453,10 @@ inline int64_t divideFloorSigned(int64_t Numerator, int64_t Denominator) {
   if (!Numerator)
     return 0;
   // C's integer division rounds towards 0.
-  int64_t Bias = Denominator >= 0 ? 1 : -1;
+  int64_t Bias = Denominator >= 0 ? -1 : 1;
   bool SameSign = (Numerator >= 0) == (Denominator >= 0);
   return SameSign ? Numerator / Denominator
-                  : -((-Numerator - Bias) / Denominator) - 1;
+                  : -((Bias - Numerator) / Denominator) - 1;
 }
 
 /// Returns the remainder of the Euclidean division of LHS by RHS. Result is
@@ -467,11 +467,14 @@ inline int64_t mod(int64_t Numerator, int64_t Denominator) {
   return Mod < 0 ? Mod + Denominator : Mod;
 }
 
-/// Returns (Numerator / Denominator) rounded by round-half-up. Guranteed to
+/// Returns (Numerator / Denominator) rounded by round-half-up. Guaranteed to
 /// never overflow.
 inline uint64_t divideNearest(uint64_t Numerator, uint64_t Denominator) {
+  uint64_t Mod = Numerator % Denominator;
+  uint64_t HalfDenomFloor = Denominator / 2;
   return (Numerator / Denominator) +
-         (Denominator == 1 ? 0 : Numerator % Denominator >= Denominator / 2);
+         (Mod > HalfDenomFloor ||
+          ((Mod == HalfDenomFloor) & ~(Denominator & 1)));
 }
 
 /// Returns the largest uint64_t less than or equal to \p Value and is

--- a/llvm/unittests/Support/MathExtrasTest.cpp
+++ b/llvm/unittests/Support/MathExtrasTest.cpp
@@ -459,15 +459,30 @@ TEST(MathExtras, DivideNearest) {
   EXPECT_EQ(divideNearest(14, 3), 5u);
   EXPECT_EQ(divideNearest(15, 3), 5u);
   EXPECT_EQ(divideNearest(0, 3), 0u);
+  EXPECT_EQ(divideNearest(5, 4), 1u);
+  EXPECT_EQ(divideNearest(6, 4), 2u);
+  EXPECT_EQ(divideNearest(3, 1), 3u);
   EXPECT_EQ(divideNearest(std::numeric_limits<uint32_t>::max(), 2),
-            2147483648u);
+            std::numeric_limits<uint32_t>::max() / 2 + 1);
+  EXPECT_EQ(divideNearest(std::numeric_limits<uint64_t>::max(), 2),
+            std::numeric_limits<uint64_t>::max() / 2 + 1);
+  EXPECT_EQ(divideNearest(std::numeric_limits<uint64_t>::max(), 1),
+            std::numeric_limits<uint64_t>::max());
 }
 
 TEST(MathExtras, DivideCeil) {
   EXPECT_EQ(divideCeil(14, 3), 5u);
   EXPECT_EQ(divideCeil(15, 3), 5u);
   EXPECT_EQ(divideCeil(0, 3), 0u);
-  EXPECT_EQ(divideCeil(std::numeric_limits<uint32_t>::max(), 2), 2147483648u);
+  EXPECT_EQ(divideCeil(5, 4), 2u);
+  EXPECT_EQ(divideCeil(6, 4), 2u);
+  EXPECT_EQ(divideCeil(3, 1), 3u);
+  EXPECT_EQ(divideCeil(std::numeric_limits<uint32_t>::max(), 2),
+            std::numeric_limits<uint32_t>::max() / 2 + 1);
+  EXPECT_EQ(divideCeil(std::numeric_limits<uint64_t>::max(), 2),
+            std::numeric_limits<uint64_t>::max() / 2 + 1);
+  EXPECT_EQ(divideCeil(std::numeric_limits<uint64_t>::max(), 1),
+            std::numeric_limits<uint64_t>::max());
 
   EXPECT_EQ(divideCeilSigned(14, 3), 5);
   EXPECT_EQ(divideCeilSigned(15, 3), 5);
@@ -479,8 +494,12 @@ TEST(MathExtras, DivideCeil) {
   EXPECT_EQ(divideCeilSigned(0, -3), 0);
   EXPECT_EQ(divideCeilSigned(std::numeric_limits<int32_t>::max(), 2),
             std::numeric_limits<int32_t>::max() / 2 + 1);
+  EXPECT_EQ(divideCeilSigned(std::numeric_limits<int64_t>::max(), 2),
+            std::numeric_limits<int64_t>::max() / 2 + 1);
   EXPECT_EQ(divideCeilSigned(std::numeric_limits<int32_t>::max(), -2),
             std::numeric_limits<int32_t>::min() / 2 + 1);
+  EXPECT_EQ(divideCeilSigned(std::numeric_limits<int64_t>::max(), -2),
+            std::numeric_limits<int64_t>::min() / 2 + 1);
 }
 
 TEST(MathExtras, DivideFloorSigned) {
@@ -494,8 +513,12 @@ TEST(MathExtras, DivideFloorSigned) {
   EXPECT_EQ(divideFloorSigned(0, -3), 0);
   EXPECT_EQ(divideFloorSigned(std::numeric_limits<int32_t>::max(), 2),
             std::numeric_limits<int32_t>::max() / 2);
+  EXPECT_EQ(divideFloorSigned(std::numeric_limits<int64_t>::max(), 2),
+            std::numeric_limits<int64_t>::max() / 2);
   EXPECT_EQ(divideFloorSigned(std::numeric_limits<int32_t>::max(), -2),
             std::numeric_limits<int32_t>::min() / 2);
+  EXPECT_EQ(divideFloorSigned(std::numeric_limits<int64_t>::max(), -2),
+            std::numeric_limits<int64_t>::min() / 2);
 }
 
 TEST(MathExtras, Mod) {

--- a/llvm/unittests/Support/MathExtrasTest.cpp
+++ b/llvm/unittests/Support/MathExtrasTest.cpp
@@ -462,12 +462,17 @@ TEST(MathExtras, DivideNearest) {
   EXPECT_EQ(divideNearest(5, 4), 1u);
   EXPECT_EQ(divideNearest(6, 4), 2u);
   EXPECT_EQ(divideNearest(3, 1), 3u);
+  EXPECT_EQ(divideNearest(3, 6), 1u);
+  EXPECT_EQ(divideNearest(3, 7), 0u);
   EXPECT_EQ(divideNearest(std::numeric_limits<uint32_t>::max(), 2),
             std::numeric_limits<uint32_t>::max() / 2 + 1);
   EXPECT_EQ(divideNearest(std::numeric_limits<uint64_t>::max(), 2),
             std::numeric_limits<uint64_t>::max() / 2 + 1);
   EXPECT_EQ(divideNearest(std::numeric_limits<uint64_t>::max(), 1),
             std::numeric_limits<uint64_t>::max());
+  EXPECT_EQ(divideNearest(std::numeric_limits<uint64_t>::max() - 1,
+                          std::numeric_limits<uint64_t>::max()),
+            1u);
 }
 
 TEST(MathExtras, DivideCeil) {
@@ -477,6 +482,8 @@ TEST(MathExtras, DivideCeil) {
   EXPECT_EQ(divideCeil(5, 4), 2u);
   EXPECT_EQ(divideCeil(6, 4), 2u);
   EXPECT_EQ(divideCeil(3, 1), 3u);
+  EXPECT_EQ(divideCeil(3, 6), 1u);
+  EXPECT_EQ(divideCeil(3, 7), 1u);
   EXPECT_EQ(divideCeil(std::numeric_limits<uint32_t>::max(), 2),
             std::numeric_limits<uint32_t>::max() / 2 + 1);
   EXPECT_EQ(divideCeil(std::numeric_limits<uint64_t>::max(), 2),
@@ -500,6 +507,8 @@ TEST(MathExtras, DivideCeil) {
             std::numeric_limits<int32_t>::min() / 2 + 1);
   EXPECT_EQ(divideCeilSigned(std::numeric_limits<int64_t>::max(), -2),
             std::numeric_limits<int64_t>::min() / 2 + 1);
+  EXPECT_EQ(divideCeilSigned(std::numeric_limits<int64_t>::min(), 1),
+            std::numeric_limits<int64_t>::min());
 }
 
 TEST(MathExtras, DivideFloorSigned) {
@@ -519,6 +528,8 @@ TEST(MathExtras, DivideFloorSigned) {
             std::numeric_limits<int32_t>::min() / 2);
   EXPECT_EQ(divideFloorSigned(std::numeric_limits<int64_t>::max(), -2),
             std::numeric_limits<int64_t>::min() / 2);
+  EXPECT_EQ(divideFloorSigned(std::numeric_limits<int64_t>::min(), 1),
+            std::numeric_limits<int64_t>::min());
 }
 
 TEST(MathExtras, Mod) {


### PR DESCRIPTION
Rewrite divideCeil, divideNearest, divideFloorSigned, and divideCeilSigned to never overflow.