### PR TITLE
[Analysis] Migrate to a new version of getValueProfDataFromInst

### DIFF
--- a/llvm/lib/Analysis/IndirectCallPromotionAnalysis.cpp
+++ b/llvm/lib/Analysis/IndirectCallPromotionAnalysis.cpp
@@ -91,13 +91,13 @@ ArrayRef<InstrProfValueData>
 ICallPromotionAnalysis::getPromotionCandidatesForInstruction(
     const Instruction *I, uint32_t &NumVals, uint64_t &TotalCount,
     uint32_t &NumCandidates) {
-  bool Res =
-      getValueProfDataFromInst(*I, IPVK_IndirectCallTarget, MaxNumPromotions,
-                               ValueDataArray.get(), NumVals, TotalCount);
+  auto Res = getValueProfDataFromInst(*I, IPVK_IndirectCallTarget,
+                                      MaxNumPromotions, NumVals, TotalCount);
   if (!Res) {
     NumCandidates = 0;
     return ArrayRef<InstrProfValueData>();
   }
+  ValueDataArray = std::move(Res);
   NumCandidates = getProfitablePromotionCandidates(I, NumVals, TotalCount);
   return ArrayRef<InstrProfValueData>(ValueDataArray.get(), NumVals);
 }


### PR DESCRIPTION
Note that the version of getValueProfDataFromInst that returns bool
has been "deprecated" since:

  commit 1e15371dd8843dfc52b9435afaa133997c1773d8
  Author: Mingming Liu <mingmingl@google.com>
  Date:   Mon Apr 1 15:14:49 2024 -0700