### PR TITLE
[libc] Fix scheduler test incorrectly guessing user privileges

### DIFF
--- a/libc/test/src/sched/param_and_scheduler_test.cpp
+++ b/libc/test/src/sched/param_and_scheduler_test.cpp
@@ -145,11 +145,9 @@ public:
   using LlvmLibcSchedTest = SchedTest;                                         \
   TEST_F(LlvmLibcSchedTest, Sched_##policy) { testSched(policy, can_set); }
 
-// Temporarily disabled as these tests are failing on Arch Linux where
-// scheduling policy setting succeeds without running as root.
-// // Root is required to set these policies.
-// LIST_SCHED_TESTS(SCHED_FIFO, LIBC_NAMESPACE::getuid() == 0)
-// LIST_SCHED_TESTS(SCHED_RR, LIBC_NAMESPACE::getuid() == 0)
+// Root is required to set these policies.
+LIST_SCHED_TESTS(SCHED_FIFO, LIBC_NAMESPACE::getuid() == 0)
+LIST_SCHED_TESTS(SCHED_RR, LIBC_NAMESPACE::getuid() == 0)
 
 // No root is required to set these policies.
 LIST_SCHED_TESTS(SCHED_OTHER, true)

--- a/libc/test/src/sched/param_and_scheduler_test.cpp
+++ b/libc/test/src/sched/param_and_scheduler_test.cpp
@@ -145,9 +145,11 @@ public:
   using LlvmLibcSchedTest = SchedTest;                                         \
   TEST_F(LlvmLibcSchedTest, Sched_##policy) { testSched(policy, can_set); }
 
-// Root is required to set these policies.
-LIST_SCHED_TESTS(SCHED_FIFO, LIBC_NAMESPACE::getuid() == 0)
-LIST_SCHED_TESTS(SCHED_RR, LIBC_NAMESPACE::getuid() == 0)
+// Temporarily disabled as these tests are failing on Arch Linux where
+// scheduling policy setting succeeds without running as root.
+// // Root is required to set these policies.
+// LIST_SCHED_TESTS(SCHED_FIFO, LIBC_NAMESPACE::getuid() == 0)
+// LIST_SCHED_TESTS(SCHED_RR, LIBC_NAMESPACE::getuid() == 0)
 
 // No root is required to set these policies.
 LIST_SCHED_TESTS(SCHED_OTHER, true)


### PR DESCRIPTION
Non-root users may be able to set real-time scheduling policies. Don't
expect failure to set real-time scheduling policies based on UID.
Instead, check that if it fails, it is either due to missing privileges,
or unsupported parameters if the scheduling policy is not mandated by
POSIX.

Fixes #95564.
