### PR TITLE
[libc] Remove unnecessary include from putchar.h

### DIFF
--- a/libc/src/stdio/putchar.h
+++ b/libc/src/stdio/putchar.h
@@ -9,8 +9,6 @@
 #ifndef LLVM_LIBC_SRC_STDIO_PUTCHAR_H
 #define LLVM_LIBC_SRC_STDIO_PUTCHAR_H
 
-#include <stdio.h>
-
 namespace LIBC_NAMESPACE {
 
 int putchar(int c);


### PR DESCRIPTION
The putchar header was including the public stdio.h. It doesn't need to
do that and it was causing build failures for downstream baremetal users
so this patch fixes it.