### PR TITLE
Clang-format coroutine files ahead of refactoring

### DIFF
--- a/llvm/lib/Transforms/Coroutines/CoroCleanup.cpp
+++ b/llvm/lib/Transforms/Coroutines/CoroCleanup.cpp
@@ -8,10 +8,10 @@
 
 #include "llvm/Transforms/Coroutines/CoroCleanup.h"
 #include "CoroInternal.h"
+#include "llvm/IR/Function.h"
 #include "llvm/IR/IRBuilder.h"
 #include "llvm/IR/InstIterator.h"
 #include "llvm/IR/PassManager.h"
-#include "llvm/IR/Function.h"
 #include "llvm/Transforms/Scalar/SimplifyCFG.h"
 
 using namespace llvm;
@@ -25,7 +25,7 @@ struct Lowerer : coro::LowererBase {
   Lowerer(Module &M) : LowererBase(M), Builder(Context) {}
   bool lower(Function &F);
 };
-}
+} // namespace
 
 static void lowerSubFn(IRBuilder<> &Builder, CoroSubFnInst *SubFn) {
   Builder.SetInsertPoint(SubFn);
@@ -114,8 +114,7 @@ static bool declaresCoroCleanupIntrinsics(const Module &M) {
           "llvm.coro.async.size.replace", "llvm.coro.async.resume"});
 }
 
-PreservedAnalyses CoroCleanupPass::run(Module &M,
-                                       ModuleAnalysisManager &MAM) {
+PreservedAnalyses CoroCleanupPass::run(Module &M, ModuleAnalysisManager &MAM) {
   if (!declaresCoroCleanupIntrinsics(M))
     return PreservedAnalyses::all();
 

--- a/llvm/lib/Transforms/Coroutines/CoroElide.cpp
+++ b/llvm/lib/Transforms/Coroutines/CoroElide.cpp
@@ -430,19 +430,18 @@ bool CoroIdElider::attemptElide() {
     NumOfCoroElided++;
 
 #ifndef NDEBUG
-      if (!CoroElideInfoOutputFilename.empty())
-        *getOrCreateLogFile() << "Elide " << CalleeCoroutineName << " in "
-                              << FEI.ContainingFunction->getName() << "\n";
+    if (!CoroElideInfoOutputFilename.empty())
+      *getOrCreateLogFile() << "Elide " << CalleeCoroutineName << " in "
+                            << FEI.ContainingFunction->getName() << "\n";
 #endif
 
-      ORE.emit([&]() {
-        return OptimizationRemark(DEBUG_TYPE, "CoroElide", CoroId)
-               << "'" << ore::NV("callee", CalleeCoroutineName)
-               << "' elided in '" << ore::NV("caller", CallerFunctionName)
-               << "' (frame_size="
-               << ore::NV("frame_size", FrameSizeAndAlign->first) << ", align="
-               << ore::NV("align", FrameSizeAndAlign->second.value()) << ")";
-      });
+    ORE.emit([&]() {
+      return OptimizationRemark(DEBUG_TYPE, "CoroElide", CoroId)
+             << "'" << ore::NV("callee", CalleeCoroutineName) << "' elided in '"
+             << ore::NV("caller", CallerFunctionName) << "' (frame_size="
+             << ore::NV("frame_size", FrameSizeAndAlign->first) << ", align="
+             << ore::NV("align", FrameSizeAndAlign->second.value()) << ")";
+    });
   } else {
     ORE.emit([&]() {
       auto Remark = OptimizationRemarkMissed(DEBUG_TYPE, "CoroElide", CoroId)

--- a/llvm/lib/Transforms/Coroutines/CoroFrame.cpp
+++ b/llvm/lib/Transforms/Coroutines/CoroFrame.cpp
@@ -869,7 +869,8 @@ void FrameTypeBuilder::addFieldForAllocas(const Function &F,
     SWI->setDefaultDest(DestBB);
   }
   // This Debug Info could tell us which allocas are merged into one slot.
-  LLVM_DEBUG(for (auto &AllocaSet : NonOverlapedAllocas) {
+  LLVM_DEBUG(for (auto &AllocaSet
+                  : NonOverlapedAllocas) {
     if (AllocaSet.size() > 1) {
       dbgs() << "In Function:" << F.getName() << "\n";
       dbgs() << "Find Union Set "

--- a/llvm/lib/Transforms/Coroutines/CoroInstr.h
+++ b/llvm/lib/Transforms/Coroutines/CoroInstr.h
@@ -246,9 +246,7 @@ public:
     return cast<ConstantInt>(getArgOperand(AlignArg))->getAlignValue();
   }
 
-  Value *getStorage() const {
-    return getArgOperand(StorageArg);
-  }
+  Value *getStorage() const { return getArgOperand(StorageArg); }
 
   /// Return the prototype for the continuation function.  The type,
   /// attributes, and calling convention of the continuation function(s)
@@ -270,8 +268,8 @@ public:
   // Methods to support type inquiry through isa, cast, and dyn_cast:
   static bool classof(const IntrinsicInst *I) {
     auto ID = I->getIntrinsicID();
-    return ID == Intrinsic::coro_id_retcon
-        || ID == Intrinsic::coro_id_retcon_once;
+    return ID == Intrinsic::coro_id_retcon ||
+           ID == Intrinsic::coro_id_retcon_once;
   }
   static bool classof(const Value *V) {
     return isa<IntrinsicInst>(V) && classof(cast<IntrinsicInst>(V));
@@ -279,8 +277,7 @@ public:
 };
 
 /// This represents the llvm.coro.id.retcon instruction.
-class LLVM_LIBRARY_VISIBILITY CoroIdRetconInst
-    : public AnyCoroIdRetconInst {
+class LLVM_LIBRARY_VISIBILITY CoroIdRetconInst : public AnyCoroIdRetconInst {
 public:
   // Methods to support type inquiry through isa, cast, and dyn_cast:
   static bool classof(const IntrinsicInst *I) {
@@ -594,7 +591,8 @@ public:
 };
 
 /// This represents the llvm.coro.suspend.retcon instruction.
-class LLVM_LIBRARY_VISIBILITY CoroSuspendRetconInst : public AnyCoroSuspendInst {
+class LLVM_LIBRARY_VISIBILITY CoroSuspendRetconInst
+    : public AnyCoroSuspendInst {
 public:
   op_iterator value_begin() { return arg_begin(); }
   const_op_iterator value_begin() const { return arg_begin(); }
@@ -738,10 +736,9 @@ public:
 /// This represents the llvm.coro.alloca.alloc instruction.
 class LLVM_LIBRARY_VISIBILITY CoroAllocaAllocInst : public IntrinsicInst {
   enum { SizeArg, AlignArg };
+
 public:
-  Value *getSize() const {
-    return getArgOperand(SizeArg);
-  }
+  Value *getSize() const { return getArgOperand(SizeArg); }
   Align getAlignment() const {
     return cast<ConstantInt>(getArgOperand(AlignArg))->getAlignValue();
   }
@@ -758,6 +755,7 @@ public:
 /// This represents the llvm.coro.alloca.get instruction.
 class LLVM_LIBRARY_VISIBILITY CoroAllocaGetInst : public IntrinsicInst {
   enum { AllocArg };
+
 public:
   CoroAllocaAllocInst *getAlloc() const {
     return cast<CoroAllocaAllocInst>(getArgOperand(AllocArg));
@@ -775,6 +773,7 @@ public:
 /// This represents the llvm.coro.alloca.free instruction.
 class LLVM_LIBRARY_VISIBILITY CoroAllocaFreeInst : public IntrinsicInst {
   enum { AllocArg };
+
 public:
   CoroAllocaAllocInst *getAlloc() const {
     return cast<CoroAllocaAllocInst>(getArgOperand(AllocArg));

--- a/llvm/lib/Transforms/Coroutines/CoroInternal.h
+++ b/llvm/lib/Transforms/Coroutines/CoroInternal.h
@@ -83,7 +83,7 @@ struct LLVM_LIBRARY_VISIBILITY Shape {
   SmallVector<CoroSizeInst *, 2> CoroSizes;
   SmallVector<CoroAlignInst *, 2> CoroAligns;
   SmallVector<AnyCoroSuspendInst *, 4> CoroSuspends;
-  SmallVector<CallInst*, 2> SwiftErrorOps;
+  SmallVector<CallInst *, 2> SwiftErrorOps;
   SmallVector<CoroAwaitSuspendInst *, 4> CoroAwaitSuspends;
   SmallVector<CallInst *, 2> SymmetricTransfers;
 
@@ -157,8 +157,7 @@ struct LLVM_LIBRARY_VISIBILITY Shape {
   }
 
   AnyCoroIdRetconInst *getRetconCoroId() const {
-    assert(ABI == coro::ABI::Retcon ||
-           ABI == coro::ABI::RetconOnce);
+    assert(ABI == coro::ABI::Retcon || ABI == coro::ABI::RetconOnce);
     return cast<AnyCoroIdRetconInst>(CoroBegin->getId());
   }
 
@@ -183,8 +182,8 @@ struct LLVM_LIBRARY_VISIBILITY Shape {
 
   PointerType *getSwitchResumePointerType() const {
     assert(ABI == coro::ABI::Switch);
-  assert(FrameTy && "frame type not assigned");
-  return cast<PointerType>(FrameTy->getElementType(SwitchFieldIndex::Resume));
+    assert(FrameTy && "frame type not assigned");
+    return cast<PointerType>(FrameTy->getElementType(SwitchFieldIndex::Resume));
   }
 
   FunctionType *getResumeFunctionType() const {
@@ -204,22 +203,20 @@ struct LLVM_LIBRARY_VISIBILITY Shape {
     llvm_unreachable("Unknown coro::ABI enum");
   }
 
-  ArrayRef<Type*> getRetconResultTypes() const {
-    assert(ABI == coro::ABI::Retcon ||
-           ABI == coro::ABI::RetconOnce);
+  ArrayRef<Type *> getRetconResultTypes() const {
+    assert(ABI == coro::ABI::Retcon || ABI == coro::ABI::RetconOnce);
     auto FTy = CoroBegin->getFunction()->getFunctionType();
 
     // The safety of all this is checked by checkWFRetconPrototype.
     if (auto STy = dyn_cast<StructType>(FTy->getReturnType())) {
       return STy->elements().slice(1);
     } else {
-      return ArrayRef<Type*>();
+      return ArrayRef<Type *>();
     }
   }
 
-  ArrayRef<Type*> getRetconResumeTypes() const {
-    assert(ABI == coro::ABI::Retcon ||
-           ABI == coro::ABI::RetconOnce);
+  ArrayRef<Type *> getRetconResumeTypes() const {
+    assert(ABI == coro::ABI::Retcon || ABI == coro::ABI::RetconOnce);
 
     // The safety of all this is checked by checkWFRetconPrototype.
     auto FTy = RetconLowering.ResumePrototype->getFunctionType();


### PR DESCRIPTION
To clean things up before refactoring apply clang-format changes to the coroutine sources. The files in lib/Transforms/Coroutines deviated from clang-format in a number of places.