### PR TITLE
[libc++][NFC] Remove unnecessary parens in static_asserts

### DIFF
--- a/libcxx/include/__atomic/memory_order.h
+++ b/libcxx/include/__atomic/memory_order.h
@@ -37,7 +37,7 @@ enum class memory_order : __memory_order_underlying_t {
   seq_cst = __mo_seq_cst
 };
 
-static_assert((is_same<underlying_type<memory_order>::type, __memory_order_underlying_t>::value),
+static_assert(is_same<underlying_type<memory_order>::type, __memory_order_underlying_t>::value,
               "unexpected underlying type for std::memory_order");
 
 inline constexpr auto memory_order_relaxed = memory_order::relaxed;

--- a/libcxx/include/__hash_table
+++ b/libcxx/include/__hash_table
@@ -240,9 +240,9 @@ public:
 
 private:
   static_assert(!is_const<__node_type>::value, "_NodePtr should never be a pointer to const");
-  static_assert((is_same<typename pointer_traits<_VoidPtr>::element_type, void>::value),
+  static_assert(is_same<typename pointer_traits<_VoidPtr>::element_type, void>::value,
                 "_VoidPtr does not point to unqualified void type");
-  static_assert((is_same<__rebind_pointer_t<_VoidPtr, __node_type>, _NodePtr>::value),
+  static_assert(is_same<__rebind_pointer_t<_VoidPtr, __node_type>, _NodePtr>::value,
                 "_VoidPtr does not rebind to _NodePtr.");
 };
 
@@ -700,11 +700,11 @@ private:
   // check for sane allocator pointer rebinding semantics. Rebinding the
   // allocator for a new pointer type should be exactly the same as rebinding
   // the pointer using 'pointer_traits'.
-  static_assert((is_same<__node_pointer, typename __node_traits::pointer>::value),
+  static_assert(is_same<__node_pointer, typename __node_traits::pointer>::value,
                 "Allocator does not rebind pointers in a sane manner.");
   typedef __rebind_alloc<__node_traits, __first_node> __node_base_allocator;
   typedef allocator_traits<__node_base_allocator> __node_base_traits;
-  static_assert((is_same<__node_base_pointer, typename __node_base_traits::pointer>::value),
+  static_assert(is_same<__node_base_pointer, typename __node_base_traits::pointer>::value,
                 "Allocator does not rebind pointers in a sane manner.");
 
 private:
@@ -1101,8 +1101,8 @@ __hash_table<_Tp, _Hash, _Equal, _Alloc>::__hash_table(__hash_table&& __u, const
 template <class _Tp, class _Hash, class _Equal, class _Alloc>
 __hash_table<_Tp, _Hash, _Equal, _Alloc>::~__hash_table() {
 #if defined(_LIBCPP_CXX03_LANG)
-  static_assert((is_copy_constructible<key_equal>::value), "Predicate must be copy-constructible.");
-  static_assert((is_copy_constructible<hasher>::value), "Hasher must be copy-constructible.");
+  static_assert(is_copy_constructible<key_equal>::value, "Predicate must be copy-constructible.");
+  static_assert(is_copy_constructible<hasher>::value, "Hasher must be copy-constructible.");
 #endif
 
   __deallocate_node(__p1_.first().__next_);
@@ -1228,7 +1228,7 @@ template <class _InputIterator>
 void __hash_table<_Tp, _Hash, _Equal, _Alloc>::__assign_unique(_InputIterator __first, _InputIterator __last) {
   typedef iterator_traits<_InputIterator> _ITraits;
   typedef typename _ITraits::value_type _ItValueType;
-  static_assert((is_same<_ItValueType, __container_value_type>::value),
+  static_assert(is_same<_ItValueType, __container_value_type>::value,
                 "__assign_unique may only be called with the containers value type");
 
   if (bucket_count() != 0) {

--- a/libcxx/include/__math/exponential_functions.h
+++ b/libcxx/include/__math/exponential_functions.h
@@ -160,7 +160,7 @@ inline _LIBCPP_HIDE_FROM_ABI long double pow(long double __x, long double __y) _
 template <class _A1, class _A2, __enable_if_t<is_arithmetic<_A1>::value && is_arithmetic<_A2>::value, int> = 0>
 inline _LIBCPP_HIDE_FROM_ABI typename __promote<_A1, _A2>::type pow(_A1 __x, _A2 __y) _NOEXCEPT {
   using __result_type = typename __promote<_A1, _A2>::type;
-  static_assert((!(_IsSame<_A1, __result_type>::value && _IsSame<_A2, __result_type>::value)), "");
+  static_assert(!(_IsSame<_A1, __result_type>::value && _IsSame<_A2, __result_type>::value), "");
   return __math::pow((__result_type)__x, (__result_type)__y);
 }
 

--- a/libcxx/include/__math/fdim.h
+++ b/libcxx/include/__math/fdim.h
@@ -37,7 +37,7 @@ inline _LIBCPP_HIDE_FROM_ABI long double fdim(long double __x, long double __y) 
 template <class _A1, class _A2, __enable_if_t<is_arithmetic<_A1>::value && is_arithmetic<_A2>::value, int> = 0>
 inline _LIBCPP_HIDE_FROM_ABI typename __promote<_A1, _A2>::type fdim(_A1 __x, _A2 __y) _NOEXCEPT {
   using __result_type = typename __promote<_A1, _A2>::type;
-  static_assert((!(_IsSame<_A1, __result_type>::value && _IsSame<_A2, __result_type>::value)), "");
+  static_assert(!(_IsSame<_A1, __result_type>::value && _IsSame<_A2, __result_type>::value), "");
   return __math::fdim((__result_type)__x, (__result_type)__y);
 }
 

--- a/libcxx/include/__math/fma.h
+++ b/libcxx/include/__math/fma.h
@@ -42,9 +42,9 @@ template <class _A1,
           __enable_if_t<is_arithmetic<_A1>::value && is_arithmetic<_A2>::value && is_arithmetic<_A3>::value, int> = 0>
 inline _LIBCPP_HIDE_FROM_ABI typename __promote<_A1, _A2, _A3>::type fma(_A1 __x, _A2 __y, _A3 __z) _NOEXCEPT {
   using __result_type = typename __promote<_A1, _A2, _A3>::type;
-  static_assert((!(_IsSame<_A1, __result_type>::value && _IsSame<_A2, __result_type>::value &&
-                   _IsSame<_A3, __result_type>::value)),
-                "");
+  static_assert(
+      !(_IsSame<_A1, __result_type>::value && _IsSame<_A2, __result_type>::value && _IsSame<_A3, __result_type>::value),
+      "");
   return __builtin_fma((__result_type)__x, (__result_type)__y, (__result_type)__z);
 }
 

--- a/libcxx/include/__math/hypot.h
+++ b/libcxx/include/__math/hypot.h
@@ -37,7 +37,7 @@ inline _LIBCPP_HIDE_FROM_ABI long double hypot(long double __x, long double __y)
 template <class _A1, class _A2, __enable_if_t<is_arithmetic<_A1>::value && is_arithmetic<_A2>::value, int> = 0>
 inline _LIBCPP_HIDE_FROM_ABI typename __promote<_A1, _A2>::type hypot(_A1 __x, _A2 __y) _NOEXCEPT {
   using __result_type = typename __promote<_A1, _A2>::type;
-  static_assert((!(_IsSame<_A1, __result_type>::value && _IsSame<_A2, __result_type>::value)), "");
+  static_assert(!(_IsSame<_A1, __result_type>::value && _IsSame<_A2, __result_type>::value), "");
   return __math::hypot((__result_type)__x, (__result_type)__y);
 }
 

--- a/libcxx/include/__math/inverse_trigonometric_functions.h
+++ b/libcxx/include/__math/inverse_trigonometric_functions.h
@@ -88,7 +88,7 @@ inline _LIBCPP_HIDE_FROM_ABI long double atan2(long double __y, long double __x)
 template <class _A1, class _A2, __enable_if_t<is_arithmetic<_A1>::value && is_arithmetic<_A2>::value, int> = 0>
 inline _LIBCPP_HIDE_FROM_ABI typename __promote<_A1, _A2>::type atan2(_A1 __y, _A2 __x) _NOEXCEPT {
   using __result_type = typename __promote<_A1, _A2>::type;
-  static_assert((!(_IsSame<_A1, __result_type>::value && _IsSame<_A2, __result_type>::value)), "");
+  static_assert(!(_IsSame<_A1, __result_type>::value && _IsSame<_A2, __result_type>::value), "");
   return __math::atan2((__result_type)__y, (__result_type)__x);
 }
 

--- a/libcxx/include/__math/min_max.h
+++ b/libcxx/include/__math/min_max.h
@@ -41,7 +41,7 @@ _LIBCPP_NODISCARD inline _LIBCPP_HIDE_FROM_ABI long double fmax(long double __x,
 template <class _A1, class _A2, __enable_if_t<is_arithmetic<_A1>::value && is_arithmetic<_A2>::value, int> = 0>
 _LIBCPP_NODISCARD inline _LIBCPP_HIDE_FROM_ABI typename __promote<_A1, _A2>::type fmax(_A1 __x, _A2 __y) _NOEXCEPT {
   using __result_type = typename __promote<_A1, _A2>::type;
-  static_assert((!(_IsSame<_A1, __result_type>::value && _IsSame<_A2, __result_type>::value)), "");
+  static_assert(!(_IsSame<_A1, __result_type>::value && _IsSame<_A2, __result_type>::value), "");
   return __math::fmax((__result_type)__x, (__result_type)__y);
 }
 
@@ -63,7 +63,7 @@ _LIBCPP_NODISCARD inline _LIBCPP_HIDE_FROM_ABI long double fmin(long double __x,
 template <class _A1, class _A2, __enable_if_t<is_arithmetic<_A1>::value && is_arithmetic<_A2>::value, int> = 0>
 _LIBCPP_NODISCARD inline _LIBCPP_HIDE_FROM_ABI typename __promote<_A1, _A2>::type fmin(_A1 __x, _A2 __y) _NOEXCEPT {
   using __result_type = typename __promote<_A1, _A2>::type;
-  static_assert((!(_IsSame<_A1, __result_type>::value && _IsSame<_A2, __result_type>::value)), "");
+  static_assert(!(_IsSame<_A1, __result_type>::value && _IsSame<_A2, __result_type>::value), "");
   return __math::fmin((__result_type)__x, (__result_type)__y);
 }
 

--- a/libcxx/include/__math/modulo.h
+++ b/libcxx/include/__math/modulo.h
@@ -39,7 +39,7 @@ inline _LIBCPP_HIDE_FROM_ABI long double fmod(long double __x, long double __y) 
 template <class _A1, class _A2, __enable_if_t<is_arithmetic<_A1>::value && is_arithmetic<_A2>::value, int> = 0>
 inline _LIBCPP_HIDE_FROM_ABI typename __promote<_A1, _A2>::type fmod(_A1 __x, _A2 __y) _NOEXCEPT {
   using __result_type = typename __promote<_A1, _A2>::type;
-  static_assert((!(_IsSame<_A1, __result_type>::value && _IsSame<_A2, __result_type>::value)), "");
+  static_assert(!(_IsSame<_A1, __result_type>::value && _IsSame<_A2, __result_type>::value), "");
   return __math::fmod((__result_type)__x, (__result_type)__y);
 }
 

--- a/libcxx/include/__math/remainder.h
+++ b/libcxx/include/__math/remainder.h
@@ -40,7 +40,7 @@ inline _LIBCPP_HIDE_FROM_ABI long double remainder(long double __x, long double 
 template <class _A1, class _A2, __enable_if_t<is_arithmetic<_A1>::value && is_arithmetic<_A2>::value, int> = 0>
 inline _LIBCPP_HIDE_FROM_ABI typename __promote<_A1, _A2>::type remainder(_A1 __x, _A2 __y) _NOEXCEPT {
   using __result_type = typename __promote<_A1, _A2>::type;
-  static_assert((!(_IsSame<_A1, __result_type>::value && _IsSame<_A2, __result_type>::value)), "");
+  static_assert(!(_IsSame<_A1, __result_type>::value && _IsSame<_A2, __result_type>::value), "");
   return __math::remainder((__result_type)__x, (__result_type)__y);
 }
 
@@ -62,7 +62,7 @@ inline _LIBCPP_HIDE_FROM_ABI long double remquo(long double __x, long double __y
 template <class _A1, class _A2, __enable_if_t<is_arithmetic<_A1>::value && is_arithmetic<_A2>::value, int> = 0>
 inline _LIBCPP_HIDE_FROM_ABI typename __promote<_A1, _A2>::type remquo(_A1 __x, _A2 __y, int* __z) _NOEXCEPT {
   using __result_type = typename __promote<_A1, _A2>::type;
-  static_assert((!(_IsSame<_A1, __result_type>::value && _IsSame<_A2, __result_type>::value)), "");
+  static_assert(!(_IsSame<_A1, __result_type>::value && _IsSame<_A2, __result_type>::value), "");
   return __math::remquo((__result_type)__x, (__result_type)__y, __z);
 }
 

--- a/libcxx/include/__math/rounding_functions.h
+++ b/libcxx/include/__math/rounding_functions.h
@@ -160,7 +160,7 @@ inline _LIBCPP_HIDE_FROM_ABI long double nextafter(long double __x, long double 
 template <class _A1, class _A2, __enable_if_t<is_arithmetic<_A1>::value && is_arithmetic<_A2>::value, int> = 0>
 inline _LIBCPP_HIDE_FROM_ABI typename __promote<_A1, _A2>::type nextafter(_A1 __x, _A2 __y) _NOEXCEPT {
   using __result_type = typename __promote<_A1, _A2>::type;
-  static_assert((!(_IsSame<_A1, __result_type>::value && _IsSame<_A2, __result_type>::value)), "");
+  static_assert(!(_IsSame<_A1, __result_type>::value && _IsSame<_A2, __result_type>::value), "");
   return __math::nextafter((__result_type)__x, (__result_type)__y);
 }
 

--- a/libcxx/include/__mdspan/extents.h
+++ b/libcxx/include/__mdspan/extents.h
@@ -165,7 +165,7 @@ public:
   template <class... _DynVals>
     requires(sizeof...(_DynVals) != __size_dynamic_)
   _LIBCPP_HIDE_FROM_ABI constexpr __maybe_static_array(_DynVals... __vals) {
-    static_assert((sizeof...(_DynVals) == __size_), "Invalid number of values.");
+    static_assert(sizeof...(_DynVals) == __size_, "Invalid number of values.");
     _TDynamic __values[__size_] = {static_cast<_TDynamic>(__vals)...};
     for (size_t __i = 0; __i < __size_; __i++) {
       _TStatic __static_val = _StaticValues::__get(__i);
@@ -185,7 +185,7 @@ public:
   template <class _Tp, size_t _Size>
     requires(_Size != __size_dynamic_)
   _LIBCPP_HIDE_FROM_ABI constexpr __maybe_static_array(const span<_Tp, _Size>& __vals) {
-    static_assert((_Size == __size_) || (__size_ == dynamic_extent));
+    static_assert(_Size == __size_ || __size_ == dynamic_extent);
     for (size_t __i = 0; __i < __size_; __i++) {
       _TStatic __static_val = _StaticValues::__get(__i);
       if (__static_val == _DynTag) {

--- a/libcxx/include/__mdspan/layout_left.h
+++ b/libcxx/include/__mdspan/layout_left.h
@@ -67,7 +67,7 @@ private:
     return true;
   }
 
-  static_assert((extents_type::rank_dynamic() > 0) || __required_span_size_is_representable(extents_type()),
+  static_assert(extents_type::rank_dynamic() > 0 || __required_span_size_is_representable(extents_type()),
                 "layout_left::mapping product of static extents must be representable as index_type.");
 
 public:

--- a/libcxx/include/__mdspan/layout_right.h
+++ b/libcxx/include/__mdspan/layout_right.h
@@ -66,7 +66,7 @@ private:
     return true;
   }
 
-  static_assert((extents_type::rank_dynamic() > 0) || __required_span_size_is_representable(extents_type()),
+  static_assert(extents_type::rank_dynamic() > 0 || __required_span_size_is_representable(extents_type()),
                 "layout_right::mapping product of static extents must be representable as index_type.");
 
 public:

--- a/libcxx/include/__mdspan/layout_stride.h
+++ b/libcxx/include/__mdspan/layout_stride.h
@@ -149,7 +149,7 @@ private:
     }
   }
 
-  static_assert((extents_type::rank_dynamic() > 0) || __required_span_size_is_representable(extents_type()),
+  static_assert(extents_type::rank_dynamic() > 0 || __required_span_size_is_representable(extents_type()),
                 "layout_stride::mapping product of static extents must be representable as index_type.");
 
 public:

--- a/libcxx/include/__numeric/gcd_lcm.h
+++ b/libcxx/include/__numeric/gcd_lcm.h
@@ -53,7 +53,7 @@ struct __ct_abs<_Result, _Source, false> {
 
 template <class _Tp>
 _LIBCPP_CONSTEXPR _LIBCPP_HIDDEN _Tp __gcd(_Tp __a, _Tp __b) {
-  static_assert((!is_signed<_Tp>::value), "");
+  static_assert(!is_signed<_Tp>::value, "");
 
   // From: https://lemire.me/blog/2013/12/26/fastest-way-to-compute-the-greatest-common-divisor
   //
@@ -97,9 +97,9 @@ _LIBCPP_CONSTEXPR _LIBCPP_HIDDEN _Tp __gcd(_Tp __a, _Tp __b) {
 
 template <class _Tp, class _Up>
 _LIBCPP_CONSTEXPR _LIBCPP_HIDE_FROM_ABI common_type_t<_Tp, _Up> gcd(_Tp __m, _Up __n) {
-  static_assert((is_integral<_Tp>::value && is_integral<_Up>::value), "Arguments to gcd must be integer types");
-  static_assert((!is_same<__remove_cv_t<_Tp>, bool>::value), "First argument to gcd cannot be bool");
-  static_assert((!is_same<__remove_cv_t<_Up>, bool>::value), "Second argument to gcd cannot be bool");
+  static_assert(is_integral<_Tp>::value && is_integral<_Up>::value, "Arguments to gcd must be integer types");
+  static_assert(!is_same<__remove_cv_t<_Tp>, bool>::value, "First argument to gcd cannot be bool");
+  static_assert(!is_same<__remove_cv_t<_Up>, bool>::value, "Second argument to gcd cannot be bool");
   using _Rp = common_type_t<_Tp, _Up>;
   using _Wp = make_unsigned_t<_Rp>;
   return static_cast<_Rp>(
@@ -108,9 +108,9 @@ _LIBCPP_CONSTEXPR _LIBCPP_HIDE_FROM_ABI common_type_t<_Tp, _Up> gcd(_Tp __m, _Up
 
 template <class _Tp, class _Up>
 _LIBCPP_CONSTEXPR _LIBCPP_HIDE_FROM_ABI common_type_t<_Tp, _Up> lcm(_Tp __m, _Up __n) {
-  static_assert((is_integral<_Tp>::value && is_integral<_Up>::value), "Arguments to lcm must be integer types");
-  static_assert((!is_same<__remove_cv_t<_Tp>, bool>::value), "First argument to lcm cannot be bool");
-  static_assert((!is_same<__remove_cv_t<_Up>, bool>::value), "Second argument to lcm cannot be bool");
+  static_assert(is_integral<_Tp>::value && is_integral<_Up>::value, "Arguments to lcm must be integer types");
+  static_assert(!is_same<__remove_cv_t<_Tp>, bool>::value, "First argument to lcm cannot be bool");
+  static_assert(!is_same<__remove_cv_t<_Up>, bool>::value, "Second argument to lcm cannot be bool");
   if (__m == 0 || __n == 0)
     return 0;
 

--- a/libcxx/include/__thread/thread.h
+++ b/libcxx/include/__thread/thread.h
@@ -65,7 +65,7 @@ class __thread_specific_ptr {
 
   // Only __thread_local_data() may construct a __thread_specific_ptr
   // and only with _Tp == __thread_struct.
-  static_assert((is_same<_Tp, __thread_struct>::value), "");
+  static_assert(is_same<_Tp, __thread_struct>::value, "");
   __thread_specific_ptr();
   friend _LIBCPP_EXPORTED_FROM_ABI __thread_specific_ptr<__thread_struct>& __thread_local_data();
 

--- a/libcxx/include/__tree
+++ b/libcxx/include/__tree
@@ -574,7 +574,7 @@ struct __tree_node_base_types {
 #endif
 
 private:
-  static_assert((is_same<typename pointer_traits<_VoidPtr>::element_type, void>::value),
+  static_assert(is_same<typename pointer_traits<_VoidPtr>::element_type, void>::value,
                 "_VoidPtr does not point to unqualified void type");
 };
 
@@ -614,7 +614,7 @@ public:
 
 private:
   static_assert(!is_const<__node_type>::value, "_NodePtr should never be a pointer to const");
-  static_assert((is_same<__rebind_pointer_t<_VoidPtr, __node_type>, _NodePtr>::value),
+  static_assert(is_same<__rebind_pointer_t<_VoidPtr, __node_type>, _NodePtr>::value,
                 "_VoidPtr does not rebind to _NodePtr.");
 };
 
@@ -925,11 +925,11 @@ private:
   // check for sane allocator pointer rebinding semantics. Rebinding the
   // allocator for a new pointer type should be exactly the same as rebinding
   // the pointer using 'pointer_traits'.
-  static_assert((is_same<__node_pointer, typename __node_traits::pointer>::value),
+  static_assert(is_same<__node_pointer, typename __node_traits::pointer>::value,
                 "Allocator does not rebind pointers in a sane manner.");
   typedef __rebind_alloc<__node_traits, __node_base> __node_base_allocator;
   typedef allocator_traits<__node_base_allocator> __node_base_traits;
-  static_assert((is_same<__node_base_pointer, typename __node_base_traits::pointer>::value),
+  static_assert(is_same<__node_base_pointer, typename __node_base_traits::pointer>::value,
                 "Allocator does not rebind pointers in a sane manner.");
 
 private:
@@ -1401,7 +1401,7 @@ template <class _ForwardIterator>
 void __tree<_Tp, _Compare, _Allocator>::__assign_unique(_ForwardIterator __first, _ForwardIterator __last) {
   typedef iterator_traits<_ForwardIterator> _ITraits;
   typedef typename _ITraits::value_type _ItValueType;
-  static_assert((is_same<_ItValueType, __container_value_type>::value),
+  static_assert(is_same<_ItValueType, __container_value_type>::value,
                 "__assign_unique may only be called with the containers value type");
   static_assert(
       __has_forward_iterator_category<_ForwardIterator>::value, "__assign_unique requires a forward iterator");
@@ -1531,7 +1531,7 @@ __tree<_Tp, _Compare, _Allocator>& __tree<_Tp, _Compare, _Allocator>::operator=(
 
 template <class _Tp, class _Compare, class _Allocator>
 __tree<_Tp, _Compare, _Allocator>::~__tree() {
-  static_assert((is_copy_constructible<value_compare>::value), "Comparator must be copy-constructible.");
+  static_assert(is_copy_constructible<value_compare>::value, "Comparator must be copy-constructible.");
   destroy(__root());
 }
 

--- a/libcxx/include/cmath
+++ b/libcxx/include/cmath
@@ -561,9 +561,9 @@ inline _LIBCPP_HIDE_FROM_ABI
                           __promote<_A1, _A2, _A3> >::type
     hypot(_A1 __lcpp_x, _A2 __lcpp_y, _A3 __lcpp_z) _NOEXCEPT {
   typedef typename __promote<_A1, _A2, _A3>::type __result_type;
-  static_assert((!(is_same<_A1, __result_type>::value && is_same<_A2, __result_type>::value &&
-                   is_same<_A3, __result_type>::value)),
-                "");
+  static_assert(
+      !(is_same<_A1, __result_type>::value && is_same<_A2, __result_type>::value && is_same<_A3, __result_type>::value),
+      "");
   return std::hypot((__result_type)__lcpp_x, (__result_type)__lcpp_y, (__result_type)__lcpp_z);
 }
 #endif
@@ -629,7 +629,7 @@ template <class _A1,
 _LIBCPP_CONSTEXPR inline _LIBCPP_HIDE_FROM_ABI typename __promote<_A1, _A2>::type
 __constexpr_copysign(_A1 __x, _A2 __y) _NOEXCEPT {
   typedef typename std::__promote<_A1, _A2>::type __result_type;
-  static_assert((!(std::_IsSame<_A1, __result_type>::value && std::_IsSame<_A2, __result_type>::value)), "");
+  static_assert(!(std::_IsSame<_A1, __result_type>::value && std::_IsSame<_A2, __result_type>::value), "");
   return __builtin_copysign((__result_type)__x, (__result_type)__y);
 }
 

--- a/libcxx/include/deque
+++ b/libcxx/include/deque
@@ -448,7 +448,7 @@ public:
 
   using value_type = _Tp;
 
-  static_assert((is_same<typename _Allocator::value_type, value_type>::value),
+  static_assert(is_same<typename _Allocator::value_type, value_type>::value,
                 "Allocator::value_type must be same type as value_type");
 
   using allocator_type = _Allocator;

--- a/libcxx/include/forward_list
+++ b/libcxx/include/forward_list
@@ -407,7 +407,7 @@ public:
 
 template <class _NodeConstPtr>
 class _LIBCPP_TEMPLATE_VIS __forward_list_const_iterator {
-  static_assert((!is_const<typename pointer_traits<_NodeConstPtr>::element_type>::value), "");
+  static_assert(!is_const<typename pointer_traits<_NodeConstPtr>::element_type>::value, "");
   typedef _NodeConstPtr _NodePtr;
 
   typedef __forward_node_traits<_NodePtr> __traits;
@@ -657,9 +657,8 @@ public:
                 "[allocator.requirements] states that rebinding an allocator to the same type should result in the "
                 "original allocator");
 
-  static_assert((!is_same<allocator_type, __node_allocator>::value),
-                "internal allocator type must differ from user-specified "
-                "type; otherwise overload resolution breaks");
+  static_assert(!is_same<allocator_type, __node_allocator>::value,
+                "internal allocator type must differ from user-specified type; otherwise overload resolution breaks");
 
   typedef value_type& reference;
   typedef const value_type& const_reference;

--- a/libcxx/include/ios
+++ b/libcxx/include/ios
@@ -532,7 +532,7 @@ public:
   typedef typename traits_type::pos_type pos_type;
   typedef typename traits_type::off_type off_type;
 
-  static_assert((is_same<_CharT, typename traits_type::char_type>::value),
+  static_assert(is_same<_CharT, typename traits_type::char_type>::value,
                 "traits_type::char_type must be the same type as CharT");
 
 #ifdef _LIBCPP_CXX03_LANG

--- a/libcxx/include/list
+++ b/libcxx/include/list
@@ -493,9 +493,8 @@ protected:
 
   typedef __rebind_alloc<__alloc_traits, __node_base> __node_base_allocator;
   typedef typename allocator_traits<__node_base_allocator>::pointer __node_base_pointer;
-  static_assert((!is_same<allocator_type, __node_allocator>::value),
-                "internal allocator type must differ from user-specified "
-                "type; otherwise overload resolution breaks");
+  static_assert(!is_same<allocator_type, __node_allocator>::value,
+                "internal allocator type must differ from user-specified type; otherwise overload resolution breaks");
 
   __node_base __end_;
   __compressed_pair<size_type, __node_allocator> __size_alloc_;
@@ -674,7 +673,7 @@ class _LIBCPP_TEMPLATE_VIS list : private __list_imp<_Tp, _Alloc> {
 public:
   typedef _Tp value_type;
   typedef _Alloc allocator_type;
-  static_assert((is_same<value_type, typename allocator_type::value_type>::value),
+  static_assert(is_same<value_type, typename allocator_type::value_type>::value,
                 "Allocator::value_type must be same type as value_type");
   typedef value_type& reference;
   typedef const value_type& const_reference;

--- a/libcxx/include/map
+++ b/libcxx/include/map
@@ -974,7 +974,7 @@ public:
   typedef value_type& reference;
   typedef const value_type& const_reference;
 
-  static_assert((is_same<typename allocator_type::value_type, value_type>::value),
+  static_assert(is_same<typename allocator_type::value_type, value_type>::value,
                 "Allocator::value_type must be same type as value_type");
 
   class _LIBCPP_TEMPLATE_VIS value_compare : public __binary_function<value_type, value_type, bool> {
@@ -1659,7 +1659,7 @@ public:
   typedef value_type& reference;
   typedef const value_type& const_reference;
 
-  static_assert((is_same<typename allocator_type::value_type, value_type>::value),
+  static_assert(is_same<typename allocator_type::value_type, value_type>::value,
                 "Allocator::value_type must be same type as value_type");
 
   class _LIBCPP_TEMPLATE_VIS value_compare : public __binary_function<value_type, value_type, bool> {

--- a/libcxx/include/queue
+++ b/libcxx/include/queue
@@ -303,7 +303,7 @@ public:
   typedef typename container_type::reference reference;
   typedef typename container_type::const_reference const_reference;
   typedef typename container_type::size_type size_type;
-  static_assert((is_same<_Tp, value_type>::value), "");
+  static_assert(is_same<_Tp, value_type>::value, "");
 
 protected:
   container_type c;
@@ -519,7 +519,7 @@ public:
   typedef typename container_type::reference reference;
   typedef typename container_type::const_reference const_reference;
   typedef typename container_type::size_type size_type;
-  static_assert((is_same<_Tp, value_type>::value), "");
+  static_assert(is_same<_Tp, value_type>::value, "");
 
 protected:
   container_type c;

--- a/libcxx/include/set
+++ b/libcxx/include/set
@@ -571,7 +571,7 @@ public:
   typedef value_type& reference;
   typedef const value_type& const_reference;
 
-  static_assert((is_same<typename allocator_type::value_type, value_type>::value),
+  static_assert(is_same<typename allocator_type::value_type, value_type>::value,
                 "Allocator::value_type must be same type as value_type");
 
 private:
@@ -1028,7 +1028,7 @@ public:
   typedef value_type& reference;
   typedef const value_type& const_reference;
 
-  static_assert((is_same<typename allocator_type::value_type, value_type>::value),
+  static_assert(is_same<typename allocator_type::value_type, value_type>::value,
                 "Allocator::value_type must be same type as value_type");
 
 private:

--- a/libcxx/include/stack
+++ b/libcxx/include/stack
@@ -157,7 +157,7 @@ public:
   typedef typename container_type::reference reference;
   typedef typename container_type::const_reference const_reference;
   typedef typename container_type::size_type size_type;
-  static_assert((is_same<_Tp, value_type>::value), "");
+  static_assert(is_same<_Tp, value_type>::value, "");
 
 protected:
   container_type c;

--- a/libcxx/include/streambuf
+++ b/libcxx/include/streambuf
@@ -137,7 +137,7 @@ public:
   typedef typename traits_type::pos_type pos_type;
   typedef typename traits_type::off_type off_type;
 
-  static_assert((is_same<_CharT, typename traits_type::char_type>::value),
+  static_assert(is_same<_CharT, typename traits_type::char_type>::value,
                 "traits_type::char_type must be the same type as CharT");
 
   virtual ~basic_streambuf();

--- a/libcxx/include/string
+++ b/libcxx/include/string
@@ -774,12 +774,12 @@ public:
 #define _LIBCPP_ASAN_VOLATILE_WRAPPER(PTR) PTR
 #endif
 
-  static_assert((!is_array<value_type>::value), "Character type of basic_string must not be an array");
-  static_assert((is_standard_layout<value_type>::value), "Character type of basic_string must be standard-layout");
-  static_assert((is_trivial<value_type>::value), "Character type of basic_string must be trivial");
-  static_assert((is_same<_CharT, typename traits_type::char_type>::value),
+  static_assert(!is_array<value_type>::value, "Character type of basic_string must not be an array");
+  static_assert(is_standard_layout<value_type>::value, "Character type of basic_string must be standard-layout");
+  static_assert(is_trivial<value_type>::value, "Character type of basic_string must be trivial");
+  static_assert(is_same<_CharT, typename traits_type::char_type>::value,
                 "traits_type::char_type must be the same type as CharT");
-  static_assert((is_same<typename allocator_type::value_type, value_type>::value),
+  static_assert(is_same<typename allocator_type::value_type, value_type>::value,
                 "Allocator::value_type must be same type as value_type");
 
   static_assert(is_same<allocator_type, __rebind_alloc<__alloc_traits, value_type> >::value,

--- a/libcxx/include/string_view
+++ b/libcxx/include/string_view
@@ -293,10 +293,10 @@ public:
   using difference_type                         = ptrdiff_t;
   static _LIBCPP_CONSTEXPR const size_type npos = -1; // size_type(-1);
 
-  static_assert((!is_array<value_type>::value), "Character type of basic_string_view must not be an array");
-  static_assert((is_standard_layout<value_type>::value), "Character type of basic_string_view must be standard-layout");
-  static_assert((is_trivial<value_type>::value), "Character type of basic_string_view must be trivial");
-  static_assert((is_same<_CharT, typename traits_type::char_type>::value),
+  static_assert(!is_array<value_type>::value, "Character type of basic_string_view must not be an array");
+  static_assert(is_standard_layout<value_type>::value, "Character type of basic_string_view must be standard-layout");
+  static_assert(is_trivial<value_type>::value, "Character type of basic_string_view must be trivial");
+  static_assert(is_same<_CharT, typename traits_type::char_type>::value,
                 "traits_type::char_type must be the same type as CharT");
 
   // [string.view.cons], construct/copy

--- a/libcxx/include/unordered_map
+++ b/libcxx/include/unordered_map
@@ -1036,7 +1036,7 @@ public:
   typedef pair<const key_type, mapped_type> value_type;
   typedef value_type& reference;
   typedef const value_type& const_reference;
-  static_assert((is_same<value_type, typename allocator_type::value_type>::value),
+  static_assert(is_same<value_type, typename allocator_type::value_type>::value,
                 "Allocator::value_type must be same type as value_type");
 
 private:
@@ -1063,8 +1063,8 @@ private:
                 "[allocator.requirements] states that rebinding an allocator to the same type should result in the "
                 "original allocator");
 
-  static_assert((is_same<typename __table::__container_value_type, value_type>::value), "");
-  static_assert((is_same<typename __table::__node_value_type, __value_type>::value), "");
+  static_assert(is_same<typename __table::__container_value_type, value_type>::value, "");
+  static_assert(is_same<typename __table::__node_value_type, __value_type>::value, "");
 
 public:
   typedef typename __alloc_traits::pointer pointer;
@@ -1843,7 +1843,7 @@ public:
   typedef pair<const key_type, mapped_type> value_type;
   typedef value_type& reference;
   typedef const value_type& const_reference;
-  static_assert((is_same<value_type, typename allocator_type::value_type>::value),
+  static_assert(is_same<value_type, typename allocator_type::value_type>::value,
                 "Allocator::value_type must be same type as value_type");
 
 private:
@@ -1863,7 +1863,7 @@ private:
   typedef __hash_map_node_destructor<__node_allocator> _Dp;
   typedef unique_ptr<__node, _Dp> __node_holder;
   typedef allocator_traits<allocator_type> __alloc_traits;
-  static_assert((is_same<typename __node_traits::size_type, typename __alloc_traits::size_type>::value),
+  static_assert(is_same<typename __node_traits::size_type, typename __alloc_traits::size_type>::value,
                 "Allocator uses different size_type for different types");
 
   static_assert(is_same<allocator_type, __rebind_alloc<__alloc_traits, value_type> >::value,

--- a/libcxx/include/unordered_set
+++ b/libcxx/include/unordered_set
@@ -588,7 +588,7 @@ public:
   typedef __type_identity_t<_Alloc> allocator_type;
   typedef value_type& reference;
   typedef const value_type& const_reference;
-  static_assert((is_same<value_type, typename allocator_type::value_type>::value),
+  static_assert(is_same<value_type, typename allocator_type::value_type>::value,
                 "Allocator::value_type must be same type as value_type");
 
   static_assert(is_same<allocator_type, __rebind_alloc<allocator_traits<allocator_type>, value_type> >::value,
@@ -1186,7 +1186,7 @@ public:
   typedef __type_identity_t<_Alloc> allocator_type;
   typedef value_type& reference;
   typedef const value_type& const_reference;
-  static_assert((is_same<value_type, typename allocator_type::value_type>::value),
+  static_assert(is_same<value_type, typename allocator_type::value_type>::value,
                 "Allocator::value_type must be same type as value_type");
 
 private:

--- a/libcxx/include/vector
+++ b/libcxx/include/vector
@@ -415,7 +415,7 @@ public:
       vector,
       void>;
 
-  static_assert((is_same<typename allocator_type::value_type, value_type>::value),
+  static_assert(is_same<typename allocator_type::value_type, value_type>::value,
                 "Allocator::value_type must be same type as value_type");
 
   static_assert(is_same<allocator_type, __rebind_alloc<__alloc_traits, value_type> >::value,


### PR DESCRIPTION
These were required a long time ago due to `static_assert` not actually being available in C++03. Now `static_assert` is simply mapped to `_Static_assert` in C++03, making the additional parens unnecessary.
