### PR TITLE
[lldb] Fix the semantics of SupportFile equivalence

### DIFF
--- a/lldb/include/lldb/Utility/SupportFile.h
+++ b/lldb/include/lldb/Utility/SupportFile.h
@@ -30,8 +30,12 @@ public:
 
   virtual ~SupportFile() = default;
 
+  /// Return true if both SupportFiles have the same FileSpec and, if both have
+  /// a valid Checksum, the Checksum is the same.
   bool operator==(const SupportFile &other) const {
-    return m_file_spec == other.m_file_spec && m_checksum == other.m_checksum;
+    if (m_checksum && other.m_checksum)
+      return m_file_spec == other.m_file_spec && m_checksum == other.m_checksum;
+    return m_file_spec == other.m_file_spec;
   }
 
   bool operator!=(const SupportFile &other) const { return !(*this == other); }


### PR DESCRIPTION
Currently, two SupportFiles with the same FileSpec are considered different if one of them has a Checksum and the other doesn't. However, this is overly strict. It's totally valid to mix LineTables that do and do not contain Checksums. This patch makes it so that the Checksum is only compared if both SupportFiles have a valid Checksum.