### PR TITLE
[libcxx] [ci] Simplify the mingw x86_64 configs

### DIFF
--- a/libcxx/utils/ci/run-buildbot
+++ b/libcxx/utils/ci/run-buildbot
@@ -703,22 +703,13 @@ clang-cl-static-crt)
 ;;
 mingw-dll)
     clean
-    # Explicitly specify the compiler with a triple prefix. The CI
-    # environment has got two installations of Clang; the default one
-    # defaults to MSVC mode, while there's an installation of llvm-mingw
-    # further back in PATH. By calling the compiler with an explicit
-    # triple prefix, we use the one that is bundled with a mingw sysroot.
     generate-cmake \
-          -DCMAKE_C_COMPILER=x86_64-w64-mingw32-clang \
-          -DCMAKE_CXX_COMPILER=x86_64-w64-mingw32-clang++ \
           -C "${MONOREPO_ROOT}/libcxx/cmake/caches/MinGW.cmake"
     check-runtimes
 ;;
 mingw-static)
     clean
     generate-cmake \
-          -DCMAKE_C_COMPILER=x86_64-w64-mingw32-clang \
-          -DCMAKE_CXX_COMPILER=x86_64-w64-mingw32-clang++ \
           -C "${MONOREPO_ROOT}/libcxx/cmake/caches/MinGW.cmake" \
           -DLIBCXX_ENABLE_SHARED=OFF \
           -DLIBUNWIND_ENABLE_SHARED=OFF


### PR DESCRIPTION
Since switching the Windows CI environment over to GitHub Actions runners, the mingw tests run in a setup where the default compiler binary is a mingw-targeting compiler, so we don't need to specify a custom executable name.

For the i686 tests, we still specify a custom compiler name, in order to target i686 instead of x86_64.