### PR TITLE
Reapply "[libc] printf, putchar and vprintf in bareemetal entrypoints…

### DIFF
--- a/libc/config/baremetal/arm/entrypoints.txt
+++ b/libc/config/baremetal/arm/entrypoints.txt
@@ -80,8 +80,11 @@ set(TARGET_LIBC_ENTRYPOINTS
 
     # stdio.h entrypoints
     libc.src.stdio.remove
+    libc.src.stdio.printf
+    libc.src.stdio.putchar
     libc.src.stdio.sprintf
     libc.src.stdio.snprintf
+    libc.src.stdio.vprintf
     libc.src.stdio.vsprintf
     libc.src.stdio.vsnprintf
 

--- a/libc/config/baremetal/riscv/entrypoints.txt
+++ b/libc/config/baremetal/riscv/entrypoints.txt
@@ -80,8 +80,11 @@ set(TARGET_LIBC_ENTRYPOINTS
 
     # stdio.h entrypoints
     libc.src.stdio.remove
+    libc.src.stdio.printf
+    libc.src.stdio.putchar
     libc.src.stdio.sprintf
     libc.src.stdio.snprintf
+    libc.src.stdio.vprintf
     libc.src.stdio.vsprintf
     libc.src.stdio.vsnprintf
 


### PR DESCRIPTION
This reverts commit eca988aa4420f33810f9830c80ff9f149b7928ff. The underlying libc issue was fixed by PR#95576.

The original PR is #95436 , which adds printf, putchar and vprintf in bareemetal entrypoints