### PR TITLE
[lldb] Remove SupportFile::Update and use the original Checksum

### DIFF
--- a/lldb/include/lldb/Utility/SupportFile.h
+++ b/lldb/include/lldb/Utility/SupportFile.h
@@ -49,9 +49,6 @@ public:
   /// Materialize the file to disk and return the path to that temporary file.
   virtual const FileSpec &Materialize() { return m_file_spec; }
 
-  /// Change the file name.
-  void Update(const FileSpec &file_spec) { m_file_spec = file_spec; }
-
 protected:
   FileSpec m_file_spec;
   Checksum m_checksum;

--- a/lldb/source/Symbol/LineEntry.cpp
+++ b/lldb/source/Symbol/LineEntry.cpp
@@ -244,7 +244,9 @@ void LineEntry::ApplyFileMappings(lldb::TargetSP target_sp) {
   if (target_sp) {
     // Apply any file remappings to our file.
     if (auto new_file_spec = target_sp->GetSourcePathMap().FindFile(
-            original_file_sp->GetSpecOnly()))
-      file_sp->Update(*new_file_spec);
+            original_file_sp->GetSpecOnly())) {
+      file_sp = std::make_shared<SupportFile>(*new_file_spec,
+                                              original_file_sp->GetChecksum());
+    }
   }
 }


### PR DESCRIPTION
When Jason was looking into the issue caused by #95606 he suggested using the Checksum from the original file in LineEntry. I like the idea because it makes sense semantically, but also allows us to get rid of the Update method and ensures we make a new copy, in case someone else is holding onto the old SupportFile.