### PR TITLE
[Analysis] Clean up getPromotionCandidatesForInstruction (NFC)

### DIFF
--- a/llvm/include/llvm/Analysis/IndirectCallPromotionAnalysis.h
+++ b/llvm/include/llvm/Analysis/IndirectCallPromotionAnalysis.h
@@ -57,10 +57,8 @@ public:
   ///
   /// The returned array space is owned by this class, and overwritten on
   /// subsequent calls.
-  ArrayRef<InstrProfValueData>
-  getPromotionCandidatesForInstruction(const Instruction *I, uint32_t &NumVals,
-                                       uint64_t &TotalCount,
-                                       uint32_t &NumCandidates);
+  ArrayRef<InstrProfValueData> getPromotionCandidatesForInstruction(
+      const Instruction *I, uint64_t &TotalCount, uint32_t &NumCandidates);
 };
 
 } // end namespace llvm

--- a/llvm/lib/Analysis/IndirectCallPromotionAnalysis.cpp
+++ b/llvm/lib/Analysis/IndirectCallPromotionAnalysis.cpp
@@ -89,8 +89,8 @@ uint32_t ICallPromotionAnalysis::getProfitablePromotionCandidates(
 
 ArrayRef<InstrProfValueData>
 ICallPromotionAnalysis::getPromotionCandidatesForInstruction(
-    const Instruction *I, uint32_t &NumVals, uint64_t &TotalCount,
-    uint32_t &NumCandidates) {
+    const Instruction *I, uint64_t &TotalCount, uint32_t &NumCandidates) {
+  uint32_t NumVals;
   auto Res = getValueProfDataFromInst(*I, IPVK_IndirectCallTarget,
                                       MaxNumPromotions, NumVals, TotalCount);
   if (!Res) {

--- a/llvm/lib/Analysis/ModuleSummaryAnalysis.cpp
+++ b/llvm/lib/Analysis/ModuleSummaryAnalysis.cpp
@@ -483,11 +483,11 @@ static void computeFunctionSummary(
           }
         }
 
-        uint32_t NumVals, NumCandidates;
+        uint32_t NumCandidates;
         uint64_t TotalCount;
         auto CandidateProfileData =
-            ICallAnalysis.getPromotionCandidatesForInstruction(
-                &I, NumVals, TotalCount, NumCandidates);
+            ICallAnalysis.getPromotionCandidatesForInstruction(&I, TotalCount,
+                                                               NumCandidates);
         for (const auto &Candidate : CandidateProfileData)
           CallGraphEdges[Index.getOrInsertValueInfo(Candidate.Value)]
               .updateHotness(getHotness(Candidate.Count, PSI));

--- a/llvm/lib/Transforms/Instrumentation/IndirectCallPromotion.cpp
+++ b/llvm/lib/Transforms/Instrumentation/IndirectCallPromotion.cpp
@@ -315,10 +315,10 @@ bool IndirectCallPromoter::processFunction(ProfileSummaryInfo *PSI) {
   bool Changed = false;
   ICallPromotionAnalysis ICallAnalysis;
   for (auto *CB : findIndirectCalls(F)) {
-    uint32_t NumVals, NumCandidates;
+    uint32_t NumCandidates;
     uint64_t TotalCount;
     auto ICallProfDataRef = ICallAnalysis.getPromotionCandidatesForInstruction(
-        CB, NumVals, TotalCount, NumCandidates);
+        CB, TotalCount, NumCandidates);
     if (!NumCandidates ||
         (PSI && PSI->hasProfileSummary() && !PSI->isHotCount(TotalCount)))
       continue;


### PR DESCRIPTION
Callers of getPromotionCandidatesForInstruction pass NumVals as an out
parameter for the number of value-count pairs of the value profiling
data, but nobody uses the out parameter.

This patch removes the parameter and updates the callers.  Note that
the number of value-count pairs is still available via
getPromotionCandidatesForInstruction(...).size().