### PR TITLE
[libc][__support][bit] Switch popcount to Brian Kernighan’s Algorithm

### DIFF
--- a/libc/src/__support/CPP/bit.h
+++ b/libc/src/__support/CPP/bit.h
@@ -271,9 +271,10 @@ template <typename T>
 [[nodiscard]] LIBC_INLINE constexpr cpp::enable_if_t<cpp::is_unsigned_v<T>, int>
 popcount(T value) {
   int count = 0;
-  for (int i = 0; i != cpp::numeric_limits<T>::digits; ++i)
-    if ((value >> i) & 0x1)
-      ++count;
+  while (value) {
+    value &= value - 1;
+    ++count;
+  }
   return count;
 }
 #define ADD_SPECIALIZATION(TYPE, BUILTIN)                                      \


### PR DESCRIPTION
This swaps the algorithm used for popcount to Brian Kernighan’s Algorithm[1] when __builtin_popcount is not available.

The while loop runs once per set bit instead of once per digit as before which is slightly better on average.

[1] https://graphics.stanford.edu/~seander/bithacks.html#CountBitsSetKernighan