### PR TITLE
[clang-tidy]fix false positives of the result of std::move() is used as rvalue for performance-move-const-arg

### DIFF
--- a/clang-tools-extra/clang-tidy/performance/MoveConstArgCheck.cpp
+++ b/clang-tools-extra/clang-tidy/performance/MoveConstArgCheck.cpp
@@ -44,7 +44,13 @@ void MoveConstArgCheck::registerMatchers(MatchFinder *Finder) {
                unless(isInTemplateInstantiation()))
           .bind("call-move");
 
-  Finder->addMatcher(MoveCallMatcher, this);
+  Finder->addMatcher(
+      expr(anyOf(
+          castExpr(hasSourceExpression(MoveCallMatcher)),
+          cxxConstructExpr(hasDeclaration(cxxConstructorDecl(anyOf(
+                               isCopyConstructor(), isMoveConstructor()))),
+                           hasArgument(0, MoveCallMatcher)))),
+      this);
 
   auto ConstTypeParmMatcher =
       qualType(references(isConstQualified())).bind("invocation-parm-type");

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -387,6 +387,10 @@ Changes in existing checks
 - Improved :doc:`modernize-use-using <clang-tidy/checks/modernize/use-using>`
   check by adding support for detection of typedefs declared on function level.
 
+- Improved :doc:`performance-move-const-arg
+  <clang-tidy/checks/performance/move-const-arg>` check ignoring the result
+  of ``std::move()`` is used as rvalue.
+
 - Improved :doc:`performance-unnecessary-copy-initialization
   <clang-tidy/checks/performance/unnecessary-copy-initialization>` check by
   detecting more cases of constant access. In particular, pointers can be

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -388,8 +388,8 @@ Changes in existing checks
   check by adding support for detection of typedefs declared on function level.
 
 - Improved :doc:`performance-move-const-arg
-  <clang-tidy/checks/performance/move-const-arg>` check ignoring the result
-  of ``std::move()`` is used as rvalue.
+  <clang-tidy/checks/performance/move-const-arg>` check by ignoring
+  ``std::move()`` calls when their target is used as an rvalue.
 
 - Improved :doc:`performance-unnecessary-copy-initialization
   <clang-tidy/checks/performance/unnecessary-copy-initialization>` check by

--- a/clang-tools-extra/test/clang-tidy/checkers/performance/move-const-arg.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/performance/move-const-arg.cpp
@@ -114,14 +114,18 @@ void f8() {
 int f9() { return M2(1); }
 
 template <typename T>
-T f10(const int x10) {
+T f_unknown_target(const int x10) {
   return std::move(x10);
-  // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: std::move of the const variable 'x10' of the trivially-copyable type 'const int' has no effect; remove std::move() [performance-move-const-arg]
-  // CHECK-FIXES: return x10;
 }
+
 void f11() {
-  f10<int>(1);
-  f10<double>(1);
+  f_unknown_target<int>(1);
+  f_unknown_target<double>(1);
+}
+
+A&& f_return_right_ref() {
+  static A a{};
+  return std::move(a);
 }
 
 class NoMoveSemantics {


### PR DESCRIPTION
Fixes: #86404
