### PR TITLE
[clang-format] Handle AttributeMacro before access modifiers

### DIFF
--- a/clang/lib/Format/TokenAnnotator.cpp
+++ b/clang/lib/Format/TokenAnnotator.cpp
@@ -1419,6 +1419,8 @@ private:
             Tok->setType(TT_CtorInitializerColon);
         } else {
           Tok->setType(TT_InheritanceColon);
+          if (Prev->isOneOf(tok::kw_public, tok::kw_private, tok::kw_protected))
+            Line.Type = LT_AccessModifier;
         }
       } else if (canBeObjCSelectorComponent(*Tok->Previous) && Tok->Next &&
                  (Tok->Next->isOneOf(tok::r_paren, tok::comma) ||
@@ -1970,7 +1972,6 @@ public:
       }
     }
 
-    bool SeenAccessModifier = false;
     bool KeywordVirtualFound = false;
     bool ImportStatement = false;
 
@@ -1979,9 +1980,7 @@ public:
       ImportStatement = true;
 
     while (CurrentToken) {
-      if (CurrentToken->isAccessSpecifier())
-        SeenAccessModifier = true;
-      else if (CurrentToken->is(tok::kw_virtual))
+      if (CurrentToken->is(tok::kw_virtual))
         KeywordVirtualFound = true;
       if (Style.isJavaScript()) {
         // export {...} from '...';
@@ -2001,7 +2000,7 @@ public:
       if (!consumeToken())
         return LT_Invalid;
     }
-    if (SeenAccessModifier)
+    if (Line.Type == LT_AccessModifier)
       return LT_AccessModifier;
     if (KeywordVirtualFound)
       return LT_VirtualFunctionDecl;

--- a/clang/lib/Format/TokenAnnotator.cpp
+++ b/clang/lib/Format/TokenAnnotator.cpp
@@ -1970,6 +1970,7 @@ public:
       }
     }
 
+    bool SeenAccessModifier = false;
     bool KeywordVirtualFound = false;
     bool ImportStatement = false;
 
@@ -1978,7 +1979,9 @@ public:
       ImportStatement = true;
 
     while (CurrentToken) {
-      if (CurrentToken->is(tok::kw_virtual))
+      if (CurrentToken->isAccessSpecifier())
+        SeenAccessModifier = true;
+      else if (CurrentToken->is(tok::kw_virtual))
         KeywordVirtualFound = true;
       if (Style.isJavaScript()) {
         // export {...} from '...';
@@ -1998,6 +2001,8 @@ public:
       if (!consumeToken())
         return LT_Invalid;
     }
+    if (SeenAccessModifier)
+      return LT_AccessModifier;
     if (KeywordVirtualFound)
       return LT_VirtualFunctionDecl;
     if (ImportStatement)

--- a/clang/lib/Format/TokenAnnotator.h
+++ b/clang/lib/Format/TokenAnnotator.h
@@ -22,6 +22,7 @@ namespace format {
 
 enum LineType {
   LT_Invalid,
+  LT_AccessModifier, // Contains public/protected/private followed by colon.
   LT_ImportStatement,
   LT_ObjCDecl, // An @interface, @implementation, or @protocol line.
   LT_ObjCMethodDecl,

--- a/clang/lib/Format/TokenAnnotator.h
+++ b/clang/lib/Format/TokenAnnotator.h
@@ -47,7 +47,7 @@ enum ScopeType {
 class AnnotatedLine {
 public:
   AnnotatedLine(const UnwrappedLine &Line)
-      : First(Line.Tokens.front().Tok), Level(Line.Level),
+      : First(Line.Tokens.front().Tok), Type(LT_Invalid), Level(Line.Level),
         PPLevel(Line.PPLevel),
         MatchingOpeningBlockLineIndex(Line.MatchingOpeningBlockLineIndex),
         MatchingClosingBlockLineIndex(Line.MatchingClosingBlockLineIndex),

--- a/clang/lib/Format/TokenAnnotator.h
+++ b/clang/lib/Format/TokenAnnotator.h
@@ -47,7 +47,7 @@ enum ScopeType {
 class AnnotatedLine {
 public:
   AnnotatedLine(const UnwrappedLine &Line)
-      : First(Line.Tokens.front().Tok), Type(LT_Invalid), Level(Line.Level),
+      : First(Line.Tokens.front().Tok), Type(LT_Other), Level(Line.Level),
         PPLevel(Line.PPLevel),
         MatchingOpeningBlockLineIndex(Line.MatchingOpeningBlockLineIndex),
         MatchingClosingBlockLineIndex(Line.MatchingClosingBlockLineIndex),

--- a/clang/lib/Format/TokenAnnotator.h
+++ b/clang/lib/Format/TokenAnnotator.h
@@ -22,7 +22,8 @@ namespace format {
 
 enum LineType {
   LT_Invalid,
-  LT_AccessModifier, // Contains public/protected/private followed by colon.
+  // Contains public/private/protected followed by TT_InheritanceColon.
+  LT_AccessModifier,
   LT_ImportStatement,
   LT_ObjCDecl, // An @interface, @implementation, or @protocol line.
   LT_ObjCMethodDecl,

--- a/clang/lib/Format/UnwrappedLineFormatter.cpp
+++ b/clang/lib/Format/UnwrappedLineFormatter.cpp
@@ -57,7 +57,7 @@ public:
   /// Update the indent state given that \p Line is going to be formatted
   /// next.
   void nextLine(const AnnotatedLine &Line) {
-    Offset = getIndentOffset(*Line.First);
+    Offset = getIndentOffset(Line);
     // Update the indent level cache size so that we can rely on it
     // having the right size in adjustToUnmodifiedline.
     if (Line.Level >= IndentForLevel.size())
@@ -111,42 +111,41 @@ private:
   ///
   /// For example, 'public:' labels in classes are offset by 1 or 2
   /// characters to the left from their level.
-  int getIndentOffset(const FormatToken &RootToken) {
+  int getIndentOffset(const AnnotatedLine &Line) {
     if (Style.Language == FormatStyle::LK_Java || Style.isJavaScript() ||
         Style.isCSharp()) {
       return 0;
     }
 
-    auto IsAccessModifier = [this, &RootToken]() {
-      if (RootToken.isAccessSpecifier(Style.isCpp())) {
+    auto IsAccessModifier = [&](const FormatToken &RootToken) {
+      if (Line.Type == LT_AccessModifier || RootToken.isObjCAccessSpecifier())
         return true;
-      } else if (RootToken.isObjCAccessSpecifier()) {
-        return true;
-      }
+
+      const auto *Next = RootToken.Next;
+
       // Handle Qt signals.
-      else if (RootToken.isOneOf(Keywords.kw_signals, Keywords.kw_qsignals) &&
-               RootToken.Next && RootToken.Next->is(tok::colon)) {
-        return true;
-      } else if (RootToken.Next &&
-                 RootToken.Next->isOneOf(Keywords.kw_slots,
-                                         Keywords.kw_qslots) &&
-                 RootToken.Next->Next && RootToken.Next->Next->is(tok::colon)) {
+      if (RootToken.isOneOf(Keywords.kw_signals, Keywords.kw_qsignals) &&
+          Next && Next->is(tok::colon)) {
         return true;
       }
+
+      if (Next && Next->isOneOf(Keywords.kw_slots, Keywords.kw_qslots) &&
+          Next->Next && Next->Next->is(tok::colon)) {
+        return true;
+      }
+
       // Handle malformed access specifier e.g. 'private' without trailing ':'.
-      else if (!RootToken.Next && RootToken.isAccessSpecifier(false)) {
-        return true;
-      }
-      return false;
+      return !Next && RootToken.isAccessSpecifier(false);
     };
 
-    if (IsAccessModifier()) {
+    if (IsAccessModifier(*Line.First)) {
       // The AccessModifierOffset may be overridden by IndentAccessModifiers,
       // in which case we take a negative value of the IndentWidth to simulate
       // the upper indent level.
       return Style.IndentAccessModifiers ? -Style.IndentWidth
                                          : Style.AccessModifierOffset;
     }
+
     return 0;
   }
 

--- a/clang/lib/Format/UnwrappedLineParser.cpp
+++ b/clang/lib/Format/UnwrappedLineParser.cpp
@@ -368,6 +368,8 @@ bool UnwrappedLineParser::parseLevel(const FormatToken *OpeningBrace,
   do {
     if (FormatTok->isAttribute()) {
       nextToken();
+      if (FormatTok->is(tok::l_paren))
+        parseParens();
       continue;
     }
     tok::TokenKind Kind = FormatTok->Tok.getKind();

--- a/clang/unittests/Format/FormatTest.cpp
+++ b/clang/unittests/Format/FormatTest.cpp
@@ -12912,6 +12912,15 @@ TEST_F(FormatTest, FormatsAccessModifiers) {
                "  int j;\n"
                "};",
                Style);
+  Style.AttributeMacros.push_back("FOO");
+  Style.AttributeMacros.push_back("BAR");
+  verifyFormat("struct foo {\n"
+               "FOO private:\n"
+               "  int i;\n"
+               "BAR private:\n"
+               "  int j;\n"
+               "};",
+               Style);
 
   FormatStyle NoEmptyLines = getLLVMStyle();
   NoEmptyLines.MaxEmptyLinesToKeep = 0;
@@ -26127,6 +26136,12 @@ TEST_F(FormatTest, IndentAccessModifiers) {
                Style);
   verifyFormat("class C {\n"
                "   public /**/:\n"
+               "      int i;\n"
+               "};",
+               Style);
+  Style.AttributeMacros.push_back("FOO");
+  verifyFormat("class C {\n"
+               "   FOO public:\n"
                "      int i;\n"
                "};",
                Style);

--- a/clang/unittests/Format/FormatTest.cpp
+++ b/clang/unittests/Format/FormatTest.cpp
@@ -12917,7 +12917,7 @@ TEST_F(FormatTest, FormatsAccessModifiers) {
   verifyFormat("struct foo {\n"
                "FOO private:\n"
                "  int i;\n"
-               "BAR private:\n"
+               "BAR(x) protected:\n"
                "  int j;\n"
                "};",
                Style);


### PR DESCRIPTION
Closes #95094.