### PR TITLE
[compiler-rt] [profile] Add value profile in profile data without-libc

### DIFF
--- a/compiler-rt/lib/profile/InstrProfiling.h
+++ b/compiler-rt/lib/profile/InstrProfiling.h
@@ -93,9 +93,22 @@ void __llvm_profile_set_page_size(unsigned PageSize);
 uint8_t __llvm_profile_get_num_padding_bytes(uint64_t SizeInBytes);
 
 /*!
+ * \brief Get all required size for profile buffer.
+ */
+uint64_t __llvm_profile_get_all_size_for_buffer(void);
+
+/*!
  * \brief Get required size for profile buffer.
  */
 uint64_t __llvm_profile_get_size_for_buffer(void);
+
+/*!
+ * \brief Write all instrumentation data to the given buffer.
+ *
+ * \pre \c Buffer is the start of a buffer at least as big as \a
+ * __llvm_profile_get_all_size_for_buffer().
+ */
+int __llvm_profile_write_all_buffer(char *Buffer);
 
 /*!
  * \brief Write instrumentation data to the given buffer.

--- a/compiler-rt/lib/profile/InstrProfilingBuffer.c
+++ b/compiler-rt/lib/profile/InstrProfilingBuffer.c
@@ -234,6 +234,27 @@ void initBufferWriter(ProfDataWriter *BufferWriter, char *Buffer) {
   BufferWriter->WriterCtx = Buffer;
 }
 
+/// Write all profile data size including value profile.
+COMPILER_RT_VISIBILITY int __llvm_profile_write_all_buffer(char *Buffer) {
+  ProfDataWriter BufferWriter;
+  initBufferWriter(&BufferWriter, Buffer);
+  return lprofWriteData(&BufferWriter, lprofGetVPDataReader(), 0);
+}
+
+/// Get all value profile data size. In this implementation,
+/// value profile data size is calculated with each function.
+COMPILER_RT_VISIBILITY
+uint64_t __llvm_profile_get_all_size_for_buffer(void) {
+  const __llvm_profile_data *DI = 0;
+  const __llvm_profile_data *DataBegin = __llvm_profile_begin_data();
+  const __llvm_profile_data *DataEnd = __llvm_profile_end_data();
+  uint64_t TotalSize = 0;
+  for (DI = DataBegin; DI < DataEnd; DI++) {
+    TotalSize += lprofgetValueProfDataSize(lprofGetVPDataReader(), DI);
+  }
+  return __llvm_profile_get_size_for_buffer() + TotalSize;
+}
+
 COMPILER_RT_VISIBILITY int __llvm_profile_write_buffer(char *Buffer) {
   ProfDataWriter BufferWriter;
   initBufferWriter(&BufferWriter, Buffer);

--- a/compiler-rt/lib/profile/InstrProfilingInternal.h
+++ b/compiler-rt/lib/profile/InstrProfilingInternal.h
@@ -148,6 +148,10 @@ typedef struct VPDataReaderType {
                                         uint32_t N);
 } VPDataReaderType;
 
+/* Get value profile data size including the header and padding. */
+uint64_t lprofgetValueProfDataSize(VPDataReaderType *VPDataReader,
+                                   const __llvm_profile_data *Data);
+
 /* Write profile data to destination. If SkipNameDataWrite is set to 1,
    the name data is already in destination, we just skip over it. */
 int lprofWriteData(ProfDataWriter *Writer, VPDataReaderType *VPDataReader,

--- a/compiler-rt/test/profile/instrprof-all-without-libc.c
+++ b/compiler-rt/test/profile/instrprof-all-without-libc.c
@@ -1,0 +1,89 @@
+// RUN: %clang_profgen -DCHECK_SYMBOLS -O3 -o %t.symbols %s
+// RUN: llvm-nm %t.symbols | FileCheck %s --check-prefix=CHECK-SYMBOLS
+// RUN: %clang_profgen -O3 -o %t %s
+// RUN: %run %t %t.profraw
+// RUN: llvm-profdata merge -o %t.profdata %t.profraw
+// RUN: %clang_profuse=%t.profdata -o - -S -emit-llvm %s | FileCheck %s
+
+// This usage of llvm-nm assumes executables have symbol tables. They do not in
+// an MSVC environment, so we can't make this test portable.
+// UNSUPPORTED: msvc
+
+#include <stdint.h>
+#include <stdlib.h>
+
+#ifndef CHECK_SYMBOLS
+#  include <stdio.h>
+#endif
+
+int __llvm_profile_runtime = 0;
+uint64_t __llvm_profile_get_all_size_for_buffer(void);
+int __llvm_profile_write_all_buffer(char *);
+int __llvm_profile_merge_from_buffer(const char *, uint64_t Size);
+
+int write_buffer(uint64_t, const char *);
+
+int add(int x, int y) { return x + y; }
+
+int sub(int x, int y) { return x - y; }
+
+int main(int argc, const char *argv[]) {
+  // CHECK-LABEL: define {{.*}} @main(
+  // CHECK: br i1 %{{.*}}, label %{{.*}}, label %{{.*}}, !prof ![[PD1:[0-9]+]]
+  if (argc < 2)
+    return 1;
+
+  const uint64_t MaxSize = 10000;
+  static char Buffer[MaxSize];
+
+  int (*fun)(int x, int y);
+
+  if (argc < 2)
+    fun = add;
+  else
+    fun = sub;
+
+  int result = (*fun)(2, 1);
+
+  uint64_t Size = __llvm_profile_get_all_size_for_buffer();
+  if (Size > MaxSize)
+    return result;
+  int Write = __llvm_profile_write_all_buffer(Buffer);
+  if (Write)
+    return Write;
+
+#ifdef CHECK_SYMBOLS
+  // Don't write it out.  Since we're checking the symbols, we don't have libc
+  // available.
+  // Call merge function to make sure it does not bring in libc deps:
+  __llvm_profile_merge_from_buffer(Buffer, Size);
+  return 0;
+#else
+  // Actually write it out so we can FileCheck the output.
+  FILE *File = fopen(argv[1], "w");
+  if (!File)
+    return result;
+  if (fwrite(Buffer, 1, Size, File) != Size)
+    return result;
+  return fclose(File);
+#endif
+}
+// CHECK: ![[PD1]] = !{!"branch_weights", i32 1, i32 2}
+
+// CHECK-SYMBOLS-NOT: {{ }}___cxx_global_var_init
+// CHECK-SYMBOLS-NOT: {{ }}___llvm_profile_register_write_file_atexit
+// CHECK-SYMBOLS-NOT: {{ }}___llvm_profile_set_filename
+// CHECK-SYMBOLS-NOT: {{ }}___llvm_profile_write_file
+// CHECK-SYMBOLS-NOT: {{ }}_fdopen
+// CHECK-SYMBOLS-NOT: {{ }}_fopen
+// CHECK-SYMBOLS-NOT: {{ }}_fwrite
+// CHECK-SYMBOLS-NOT: {{ }}_getenv
+// CHECK-SYMBOLS-NOT: {{ }}getenv
+// CHECK-SYMBOLS-NOT: {{ }}_malloc
+// CHECK-SYMBOLS-NOT: {{ }}malloc
+// CHECK-SYMBOLS-NOT: {{ }}_calloc
+// CHECK-SYMBOLS-NOT: {{ }}calloc
+// CHECK-SYMBOLS-NOT: {{ }}_free
+// CHECK-SYMBOLS-NOT: {{ }}free
+// CHECK-SYMBOLS-NOT: {{ }}_open
+// CHECK-SYMBOLS-NOT: {{ }}_getpagesize


### PR DESCRIPTION
Fix the 'truncated profile data' error: when the instrumented source code includes value profile instrumentation, the __llvm_profile_get_size_for_buffer does not include the size of value profile.