### PR TITLE
[Clang] fix access checking inside return-type-requirement of compound requirements

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -914,6 +914,7 @@ Bug Fixes to C++ Support
 - Clang now diagnoses explicit specializations with storage class specifiers in all contexts.
 - Fix an assertion failure caused by parsing a lambda used as a default argument for the value of a
   forward-declared class. (#GH93512).
+- Fixed a bug in access checking inside return-type-requirement of compound requirements. (#GH93788).
 
 Bug Fixes to AST Handling
 ^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/clang/lib/Sema/SemaTemplateInstantiate.cpp
+++ b/clang/lib/Sema/SemaTemplateInstantiate.cpp
@@ -2735,7 +2735,7 @@ TemplateInstantiator::TransformExprRequirement(concepts::ExprRequirement *Req) {
     if (TPLInst.isInvalid())
       return nullptr;
     TemplateParameterList *TPL = TransformTemplateParameterList(OrigTPL);
-    if (!TPL)
+    if (!TPL || Trap.hasErrorOccurred())
       TransRetReq.emplace(createSubstDiag(SemaRef, Info,
           [&] (llvm::raw_ostream& OS) {
               RetReq.getTypeConstraint()->getImmediatelyDeclaredConstraint()

--- a/clang/test/CXX/expr/expr.prim/expr.prim.req/compound-requirement.cpp
+++ b/clang/test/CXX/expr/expr.prim/expr.prim.req/compound-requirement.cpp
@@ -189,3 +189,39 @@ namespace std_example {
   template<C5 T> struct C5_check {}; // expected-note{{because 'short' does not satisfy 'C5'}}
   using c5 = C5_check<short>; // expected-error{{constraints not satisfied for class template 'C5_check' [with T = short]}}
 }
+
+namespace access_checks {
+namespace in_return_type_requirement {
+
+// https://github.com/llvm/llvm-project/issues/93788
+template <typename From, typename To>
+concept is_assignable = requires(From from, To to) {
+  from = to;
+};
+
+template <typename T>
+class trait {
+ public:
+  using public_type = int;
+ private:
+  using private_type = int;
+};
+
+template <typename T>
+concept has_field = requires(T t) {
+  { t.field } -> is_assignable<typename trait<T>::private_type>;  // expected-note {{'private_type' is a private member}}
+};
+template <typename T>
+concept has_field2 = requires(T t) {
+  { t.field } -> is_assignable<typename trait<T>::public_type>;
+};
+
+struct A {
+  int field;
+};
+static_assert(has_field<A>); // expected-error {{static assertion failed}} \
+                             // expected-note {{because 'A' does not satisfy 'has_field'}}
+static_assert(has_field2<A>);
+
+}  // namespace access_checks
+}  // namespace in_return_type_requirement


### PR DESCRIPTION
fixes https://github.com/llvm/llvm-project/issues/93788 .