### PR TITLE
[libc++][TZDB] Disables a failing test.

### DIFF
--- a/libcxx/test/std/time/time.zone/time.zone.timezone/time.zone.members/get_info.local_time.pass.cpp
+++ b/libcxx/test/std/time/time.zone/time.zone.timezone/time.zone.members/get_info.local_time.pass.cpp
@@ -13,6 +13,9 @@
 // XFAIL: libcpp-has-no-experimental-tzdb
 // XFAIL: availability-tzdb-missing
 
+// TODO TZDB Investigate why this fails.
+// UNSUPPORTED: target={{.*}}
+
 // <chrono>
 
 // class time_zone;


### PR DESCRIPTION
The test fails depending on the timezone database used. Disable it for now so it can be properly investigated later.