### PR TITLE
[Clang] Remove unreachable code in verilogGroupDecl (NFC)

### DIFF
--- a/clang/lib/Format/TokenAnnotator.cpp
+++ b/clang/lib/Format/TokenAnnotator.cpp
@@ -3369,11 +3369,19 @@ private:
       FormatToken *Next = Tok->getNextNonComment();
 
       if (Tok->is(tok::hash)) {
-        // Start of a macro expansion.
-        First = Tok;
-        Tok = Next;
-        if (Tok)
-          Tok = Tok->getNextNonComment();
+
+        if (Next && Next->is(tok::l_paren)) {
+          // Handle parameterized macro.
+          Next = Next->MatchingParen;
+          if (Next)
+            Tok = Next->getNextNonComment();
+        } else {
+          // Start of a macro expansion.
+          First = Tok;
+          Tok = Next;
+          if (Tok)
+            Tok = Tok->getNextNonComment();
+        }
       } else if (Tok->is(tok::hashhash)) {
         // Concatenation. Skip.
         Tok = Next;
@@ -3410,11 +3418,6 @@ private:
         } else {
           break;
         }
-      } else if (Tok->is(tok::hash)) {
-        if (Next->is(tok::l_paren))
-          Next = Next->MatchingParen;
-        if (Next)
-          Tok = Next->getNextNonComment();
       } else {
         break;
       }

--- a/clang/lib/Format/TokenAnnotator.cpp
+++ b/clang/lib/Format/TokenAnnotator.cpp
@@ -3369,13 +3369,6 @@ private:
       FormatToken *Next = Tok->getNextNonComment();
 
       if (Tok->is(tok::hash)) {
-
-        if (Next && Next->is(tok::l_paren)) {
-          // Handle parameterized macro.
-          Next = Next->MatchingParen;
-          if (Next)
-            Tok = Next->getNextNonComment();
-        } else {
           // Start of a macro expansion.
           First = Tok;
           Tok = Next;

--- a/clang/lib/Format/TokenAnnotator.cpp
+++ b/clang/lib/Format/TokenAnnotator.cpp
@@ -3374,7 +3374,6 @@ private:
         Tok = Next;
         if (Tok)
           Tok = Tok->getNextNonComment();
-      }
       } else if (Tok->is(tok::hashhash)) {
         // Concatenation. Skip.
         Tok = Next;

--- a/clang/lib/Format/TokenAnnotator.cpp
+++ b/clang/lib/Format/TokenAnnotator.cpp
@@ -3369,12 +3369,12 @@ private:
       FormatToken *Next = Tok->getNextNonComment();
 
       if (Tok->is(tok::hash)) {
-          // Start of a macro expansion.
-          First = Tok;
-          Tok = Next;
-          if (Tok)
-            Tok = Tok->getNextNonComment();
-        }
+        // Start of a macro expansion.
+        First = Tok;
+        Tok = Next;
+        if (Tok)
+          Tok = Tok->getNextNonComment();
+      }
       } else if (Tok->is(tok::hashhash)) {
         // Concatenation. Skip.
         Tok = Next;


### PR DESCRIPTION
This is described in https://pvs-studio.com/en/blog/posts/cpp/1126/ so caught by the PVS Studio analyzer.

Warning message  -
The use of 'if (A) {...} else if (A) {...}' pattern was detected

There were two same 'if' conditions (Tok->is(tok::hash) but different execution blocks leading to unreachable code for the second 'if-else' condition.