### PR TITLE
[TargetLibraryInfo] Use std::move (NFC)

### DIFF
--- a/llvm/include/llvm/Analysis/TargetLibraryInfo.h
+++ b/llvm/include/llvm/Analysis/TargetLibraryInfo.h
@@ -316,7 +316,8 @@ public:
   // Provide value semantics.
   TargetLibraryInfo(const TargetLibraryInfo &TLI) = default;
   TargetLibraryInfo(TargetLibraryInfo &&TLI)
-      : Impl(TLI.Impl), OverrideAsUnavailable(TLI.OverrideAsUnavailable) {}
+      : Impl(TLI.Impl),
+        OverrideAsUnavailable(std::move(TLI.OverrideAsUnavailable)) {}
   TargetLibraryInfo &operator=(const TargetLibraryInfo &TLI) = default;
   TargetLibraryInfo &operator=(TargetLibraryInfo &&TLI) {
     Impl = TLI.Impl;

--- a/llvm/include/llvm/Analysis/TargetLibraryInfo.h
+++ b/llvm/include/llvm/Analysis/TargetLibraryInfo.h
@@ -321,7 +321,7 @@ public:
   TargetLibraryInfo &operator=(const TargetLibraryInfo &TLI) = default;
   TargetLibraryInfo &operator=(TargetLibraryInfo &&TLI) {
     Impl = TLI.Impl;
-    OverrideAsUnavailable = TLI.OverrideAsUnavailable;
+    OverrideAsUnavailable = std::move(TLI.OverrideAsUnavailable);
     return *this;
   }
 


### PR DESCRIPTION
The std::move here saves 0.11% of heap allocations during the
compilation of a large preprocessed file, namely X86ISelLowering.cpp,
for the X86 target.