### PR TITLE
[LLDB] Remove the redundent increment of 'properties' variable

### DIFF
--- a/lldb/source/Commands/CommandObjectTarget.cpp
+++ b/lldb/source/Commands/CommandObjectTarget.cpp
@@ -97,7 +97,7 @@ static void DumpTargetInfo(uint32_t target_idx, Target *target,
 
   uint32_t properties = 0;
   if (target_arch.IsValid()) {
-    strm.Printf("%sarch=", properties > 0 ? ", " : " ( ");
+    strm.Printf(" ( arch=");
     target_arch.DumpTriple(strm.AsRawOstream());
     properties++;
   }

--- a/lldb/source/Commands/CommandObjectTarget.cpp
+++ b/lldb/source/Commands/CommandObjectTarget.cpp
@@ -97,7 +97,7 @@ static void DumpTargetInfo(uint32_t target_idx, Target *target,
 
   uint32_t properties = 0;
   if (target_arch.IsValid()) {
-    strm.Printf("%sarch=", properties++ > 0 ? ", " : " ( ");
+    strm.Printf("%sarch=", properties > 0 ? ", " : " ( ");
     target_arch.DumpTriple(strm.AsRawOstream());
     properties++;
   }


### PR DESCRIPTION
This is described in (N3) https://pvs-studio.com/en/blog/posts/cpp/1126/ 

Warning message -
V547 Expression 'properties ++ > 0' is always false. CommandObjectTarget.cpp:100

I could not understand it properly but the properties++ operation is performed twice when the target architecture is valid.
First increment seems unnecessary since it is always false '0>0'.