### PR TITLE
[X86AsmParser] IntelExpression: End of Statement should check for valid end state

### DIFF
--- a/llvm/lib/Target/X86/AsmParser/X86AsmParser.cpp
+++ b/llvm/lib/Target/X86/AsmParser/X86AsmParser.cpp
@@ -473,7 +473,9 @@ private:
     unsigned getLength() const { return CurType.Length; }
     int64_t getImm() { return Imm + IC.execute(); }
     bool isValidEndState() const {
-      return State == IES_RBRAC || State == IES_INTEGER;
+      return State == IES_RBRAC || State == IES_RPAREN ||
+             State == IES_INTEGER || State == IES_REGISTER ||
+             State == IES_OFFSET;
     }
 
     // Is the intel expression appended after an operand index.
@@ -1896,9 +1898,6 @@ bool X86AsmParser::ParseIntelExpression(IntelExprStateMachine &SM, SMLoc &End) {
       return Error(Tok.getLoc(), "unknown token in expression");
     case AsmToken::Error:
       return Error(getLexer().getErrLoc(), getLexer().getErr());
-      break;
-    case AsmToken::EndOfStatement:
-      Done = true;
       break;
     case AsmToken::Real:
       // DotOperator: [ebx].0

--- a/llvm/test/MC/X86/intel-syntax-expr.s
+++ b/llvm/test/MC/X86/intel-syntax-expr.s
@@ -1,0 +1,8 @@
+// RUN: not llvm-mc -triple x86_64-unknown-unknown -x86-asm-syntax=intel %s 2>&1 | FileCheck %s
+
+// When the intel syntax is enabled, to parse an operand, X86AsmParser doesn't use the method parseExpression from AsmParser
+// but ParseIntelExpr which was not processing well an end of statement.
+
+// CHECK: LLVM ERROR: SmallVector unable to grow. Requested capacity (4294967296) is larger than maximum value for size type (4294967295)
+test:
+i-

--- a/llvm/test/MC/X86/intel-syntax-expr.s
+++ b/llvm/test/MC/X86/intel-syntax-expr.s
@@ -3,6 +3,6 @@
 // When the intel syntax is enabled, to parse an operand, X86AsmParser doesn't use the method parseExpression from AsmParser
 // but ParseIntelExpr which was not processing well an end of statement.
 
-// CHECK: LLVM ERROR: SmallVector unable to grow. Requested capacity (4294967296) is larger than maximum value for size type (4294967295)
+// CHECK: error: unknown token in expression
 test:
 i-


### PR DESCRIPTION
The following commit bfb7099eeb9b6f62510b1db0cb93a8c3cfa68236 added a special case for End of Statement that doesn't check if the state machine is rightfully in a state where ending is valid.

This PR suggest to revert this change to make `EndOfStatement` processed as any other tokens that are not consumable by the state machine.

Fixes https://github.com/llvm/llvm-project/issues/94446