### PR TITLE
[TargetLibraryInfo] Use the default move constructor/assignment operator

### DIFF
--- a/llvm/include/llvm/Analysis/TargetLibraryInfo.h
+++ b/llvm/include/llvm/Analysis/TargetLibraryInfo.h
@@ -315,15 +315,9 @@ public:
 
   // Provide value semantics.
   TargetLibraryInfo(const TargetLibraryInfo &TLI) = default;
-  TargetLibraryInfo(TargetLibraryInfo &&TLI)
-      : Impl(TLI.Impl),
-        OverrideAsUnavailable(std::move(TLI.OverrideAsUnavailable)) {}
+  TargetLibraryInfo(TargetLibraryInfo &&TLI) = default;
   TargetLibraryInfo &operator=(const TargetLibraryInfo &TLI) = default;
-  TargetLibraryInfo &operator=(TargetLibraryInfo &&TLI) {
-    Impl = TLI.Impl;
-    OverrideAsUnavailable = std::move(TLI.OverrideAsUnavailable);
-    return *this;
-  }
+  TargetLibraryInfo &operator=(TargetLibraryInfo &&TLI) = default;
 
   /// Determine whether a callee with the given TLI can be inlined into
   /// caller with this TLI, based on 'nobuiltin' attributes. When requested,


### PR DESCRIPTION
  commit ecea8371ff03c15fb3dc27ee4108b98335fd2d63
  Author: Kazu Hirata <kazu@google.com>
  Date:   Sat Jun 15 14:02:42 2024 -0700

added std::move to the move constructor and assignment operator, but
we can just use = default to have the compiler to generate them.

As expected, the number of heap allocations is virtually unchanged.