### PR TITLE
[libc++] Guard transitive include of `<locale>` with availability macro

### DIFF
--- a/libcxx/include/vector
+++ b/libcxx/include/vector
@@ -2974,7 +2974,9 @@ _LIBCPP_POP_MACROS
 #  include <concepts>
 #  include <cstdlib>
 #  include <iosfwd>
+#if !defined(_LIBCPP_HAS_NO_LOCALIZATION)
 #  include <locale>
+#endif
 #  include <tuple>
 #  include <type_traits>
 #  include <typeinfo>


### PR DESCRIPTION
This is a follow-up to https://github.com/llvm/llvm-project/pull/80282.
The transitive includes of `<locale>` in `<vector>` were all guarded by
the availability macro -- the new include should also be guarded,
otherwise any users who compile with localization disabled will start
getting errors trying to include `<vector>`.
