### PR TITLE
[InlineCost] Use a const reference (NFC)

### DIFF
--- a/llvm/lib/Analysis/InlineCost.cpp
+++ b/llvm/lib/Analysis/InlineCost.cpp
@@ -2887,7 +2887,7 @@ static bool functionsHaveCompatibleAttributes(
   // caches the most recently created TLI in the TargetLibraryInfoWrapperPass
   // object, and always returns the same object (which is overwritten on each
   // GetTLI call). Therefore we copy the first result.
-  auto CalleeTLI = GetTLI(*Callee);
+  const auto &CalleeTLI = GetTLI(*Callee);
   return (IgnoreTTIInlineCompatible ||
           TTI.areInlineCompatible(Caller, Callee)) &&
          GetTLI(*Caller).areInlineCompatible(CalleeTLI,


### PR DESCRIPTION
The use of a const reference here saves 0.18% of heap allocations
during the compilation of a large preprocessed file, namely
X86ISelLowering.cpp, for the X86 target.

Note that GetTLI returns a const reference, so we don't have to worry
about a dangling reference.