### PR TITLE
[TargetParser][AArch64] Believe runtime feature detection

### DIFF
--- a/llvm/lib/TargetParser/Host.cpp
+++ b/llvm/lib/TargetParser/Host.cpp
@@ -1941,9 +1941,10 @@ const StringMap<bool> sys::getHostCPUFeatures() {
   }
 
 #if defined(__aarch64__)
-  // If we have all crypto bits we can add the feature
-  if (crypto == (CAP_AES | CAP_PMULL | CAP_SHA1 | CAP_SHA2))
-    Features["crypto"] = true;
+  // LLVM has decided some AArch64 CPUs have all the instructions they _may_
+  // have, as opposed to all the instructions they _must_ have, so allow runtime
+  // information to correct us on that.
+  Features["crypto"] = (crypto == (CAP_AES | CAP_PMULL | CAP_SHA1 | CAP_SHA2));
 #endif
 
   return Features;
@@ -1952,12 +1953,13 @@ const StringMap<bool> sys::getHostCPUFeatures() {
 const StringMap<bool> sys::getHostCPUFeatures() {
   StringMap<bool> Features;
 
-  if (IsProcessorFeaturePresent(PF_ARM_NEON_INSTRUCTIONS_AVAILABLE))
-    Features["neon"] = true;
-  if (IsProcessorFeaturePresent(PF_ARM_V8_CRC32_INSTRUCTIONS_AVAILABLE))
-    Features["crc"] = true;
-  if (IsProcessorFeaturePresent(PF_ARM_V8_CRYPTO_INSTRUCTIONS_AVAILABLE))
-    Features["crypto"] = true;
+  // If we're asking the OS at runtime, believe what the OS says
+  Features["neon"] =
+      IsProcessorFeaturePresent(PF_ARM_NEON_INSTRUCTIONS_AVAILABLE);
+  Features["crc"] =
+      IsProcessorFeaturePresent(PF_ARM_V8_CRC32_INSTRUCTIONS_AVAILABLE);
+  Features["crypto"] =
+      IsProcessorFeaturePresent(PF_ARM_V8_CRYPTO_INSTRUCTIONS_AVAILABLE);
 
   return Features;
 }


### PR DESCRIPTION
In https://github.com/llvm/llvm-project/issues/90365 it was reported that TargetParser arrives at the wrong conclusion regarding what features are enabled when attempting to detect "native" features on the Raspberry Pi 4, because it (correctly) detects it as a Cortex-A72, but LLVM (incorrectly) believes all Cortex-A72s have crypto enabled. Attempt to help ourselves by allowing runtime information derived from the host to contradict whatever we believe is "true" about the architecture.