### PR TITLE
[Clang] Remove some dead code in getNumTeamsExprForTargetDirective

### DIFF
--- a/clang/lib/CodeGen/CGOpenMPRuntime.cpp
+++ b/clang/lib/CodeGen/CGOpenMPRuntime.cpp
@@ -6032,11 +6032,8 @@ const Expr *CGOpenMPRuntime::getNumTeamsExprForTargetDirective(
         MinTeamsVal = MaxTeamsVal = 0;
         return nullptr;
       }
-      if (isOpenMPParallelDirective(NestedDir->getDirectiveKind()) ||
-          isOpenMPSimdDirective(NestedDir->getDirectiveKind())) {
-        MinTeamsVal = MaxTeamsVal = 1;
-        return nullptr;
-      }
+      MinTeamsVal = MaxTeamsVal = 1;
+      return nullptr;
     }
     // A value of -1 is used to check if we need to emit no teams region
     MinTeamsVal = MaxTeamsVal = -1;

--- a/clang/lib/CodeGen/CGOpenMPRuntime.cpp
+++ b/clang/lib/CodeGen/CGOpenMPRuntime.cpp
@@ -6037,8 +6037,6 @@ const Expr *CGOpenMPRuntime::getNumTeamsExprForTargetDirective(
         MinTeamsVal = MaxTeamsVal = 1;
         return nullptr;
       }
-      MinTeamsVal = MaxTeamsVal = 1;
-      return nullptr;
     }
     // A value of -1 is used to check if we need to emit no teams region
     MinTeamsVal = MaxTeamsVal = -1;


### PR DESCRIPTION
This was reported in https://pvs-studio.com/en/blog/posts/cpp/1126/, fragment N9.

V523 The 'then' statement is equivalent to the subsequent code fragment. CGOpenMPRuntime.cpp:6040, 6036