### PR TITLE
[Clang] Fix a variable shadowing in MapLattice (NFC)

### DIFF
--- a/clang/include/clang/Analysis/FlowSensitive/MapLattice.h
+++ b/clang/include/clang/Analysis/FlowSensitive/MapLattice.h
@@ -49,7 +49,7 @@ public:
 
   MapLattice() = default;
 
-  explicit MapLattice(Container C) { C = std::move(C); }
+  explicit MapLattice(Container C) : C { std::move(C) } {};
 
   // The `bottom` element is the empty map.
   static MapLattice bottom() { return MapLattice(); }

--- a/clang/include/clang/Analysis/FlowSensitive/MapLattice.h
+++ b/clang/include/clang/Analysis/FlowSensitive/MapLattice.h
@@ -49,7 +49,7 @@ public:
 
   MapLattice() = default;
 
-  explicit MapLattice(Container C) : C { std::move(C) } {};
+  explicit MapLattice(Container C) : C{std::move(C)} {};
 
   // The `bottom` element is the empty map.
   static MapLattice bottom() { return MapLattice(); }


### PR DESCRIPTION
Reported in https://pvs-studio.com/en/blog/posts/cpp/1126/, fragment N10.

The PVS-Studio warning:
V570 The 'C' variable is assigned to itself. MapLattice.h:52