### PR TITLE
[clang-format] Handle Verilog delay control

### DIFF
--- a/clang/lib/Format/TokenAnnotator.cpp
+++ b/clang/lib/Format/TokenAnnotator.cpp
@@ -3414,7 +3414,8 @@ private:
         } else {
           break;
         }
-      } else if (Tok->is(tok::hash)) {
+      } else if (Tok->is(Keywords.kw_verilogHash)) {
+        // Delay control.
         if (Next->is(tok::l_paren))
           Next = Next->MatchingParen;
         if (Next)

--- a/clang/unittests/Format/FormatTestVerilog.cpp
+++ b/clang/unittests/Format/FormatTestVerilog.cpp
@@ -391,6 +391,15 @@ TEST_F(FormatTestVerilog, Declaration) {
   verifyFormat("wire mynet, mynet1;");
   verifyFormat("wire mynet, //\n"
                "     mynet1;");
+  verifyFormat("wire #0 mynet, mynet1;");
+  verifyFormat("wire logic #0 mynet, mynet1;");
+  verifyFormat("wire #(1, 2, 3) mynet, mynet1;");
+  verifyFormat("wire #0 mynet, //\n"
+               "        mynet1;");
+  verifyFormat("wire logic #0 mynet, //\n"
+               "              mynet1;");
+  verifyFormat("wire #(1, 2, 3) mynet, //\n"
+               "                mynet1;");
   verifyFormat("wire mynet = enable;");
   verifyFormat("wire mynet = enable, mynet1;");
   verifyFormat("wire mynet = enable, //\n"


### PR DESCRIPTION
I made a mistake when I tried to make the code handle the backtick character like the hash character.  The code did not recognize the delay control structure.  It caused net names in the declaration to be aligned to the type name instead of the first net name.

new

```Verilog
wire logic #0 mynet, //
              mynet1;
```

old

```Verilog
wire logic #0 mynet, //
     mynet1;
```