### PR TITLE
lld: add support for NOCROSSREFS(_TO)

### DIFF
--- a/lld/ELF/LinkerScript.cpp
+++ b/lld/ELF/LinkerScript.cpp
@@ -1714,3 +1714,14 @@ bool LinkerScript::shouldAddProvideSym(StringRef symName) {
   Symbol *sym = symtab.find(symName);
   return sym && !sym->isDefined() && !sym->isCommon();
 }
+
+bool NoCrossRefList::matchesRefToSection(const OutputSection *section) const {
+  if (toSection)
+    return toSection.value() == section->name;
+
+  return llvm::is_contained(outputSections, section->name);
+}
+
+bool NoCrossRefList::matchesRefFromSection(const OutputSection *section) const {
+  return llvm::is_contained(outputSections, section->name);
+}

--- a/lld/ELF/LinkerScript.h
+++ b/lld/ELF/LinkerScript.h
@@ -256,6 +256,19 @@ struct InsertCommand {
   StringRef where;
 };
 
+struct NoCrossRefList {
+  SmallVector<StringRef, 2> outputSections;
+
+  // See documentation for NOCROSSREFS and NOCROSSREFS_TO. When toSection is
+  // NONE outputSections are output section names that must not have any cross
+  // references between them. Otherwise, toSection is tosection name and
+  // outputSections are fromsections.
+  std::optional<StringRef> toSection;
+
+  bool matchesRefFromSection(const OutputSection *section) const;
+  bool matchesRefToSection(const OutputSection *section) const;
+};
+
 struct PhdrsCommand {
   StringRef name;
   unsigned type = llvm::ELF::PT_NULL;
@@ -393,6 +406,9 @@ public:
 
   // OutputSections specified by OVERWRITE_SECTIONS.
   SmallVector<OutputDesc *, 0> overwriteSections;
+
+  // OutputSections names specified by NOCROSSREFS(_TO).
+  SmallVector<NoCrossRefList, 0> noCrossRefLists;
 
   // Sections that will be warned/errored by --orphan-handling.
   SmallVector<const InputSectionBase *, 0> orphanSections;

--- a/lld/ELF/Relocations.h
+++ b/lld/ELF/Relocations.h
@@ -141,6 +141,7 @@ struct JumpInstrMod {
 // the diagnostics.
 template <class ELFT> void scanRelocations();
 void reportUndefinedSymbols();
+void checkNoCrossRefs();
 void postScanRelocations();
 void addGotEntry(Symbol &sym);
 

--- a/lld/ELF/Writer.cpp
+++ b/lld/ELF/Writer.cpp
@@ -309,6 +309,9 @@ template <class ELFT> void Writer<ELFT>::run() {
   finalizeSections();
   checkExecuteOnly();
 
+  if (script->noCrossRefLists.size())
+    checkNoCrossRefs();
+
   // If --compressed-debug-sections is specified, compress .debug_* sections.
   // Do it right now because it changes the size of output sections.
   for (OutputSection *sec : outputSections)

--- a/lld/test/ELF/linkerscript/nocrossrefs.test
+++ b/lld/test/ELF/linkerscript/nocrossrefs.test
@@ -1,0 +1,179 @@
+# REQUIRES: x86
+# RUN: rm -rf %t && split-file %s %t && cd %t
+
+# RUN: llvm-mc --triple=x86_64-unknown-linux -filetype=obj -o main.o main.s
+# RUN: not ld.lld main.o -o main --script script1.ld 2>&1 | FileCheck -check-prefix=ERR %s
+# ERR: {{.*}} error: main.o:(.text+0x6): prohibited cross reference from .text to in .text1
+
+#--- script1.ld
+NOCROSSREFS(.text .text1);
+SECTIONS {
+	.text  : { *(.text) }
+	.text1 : { *(.text1) }
+	.text2 : { *(.text2) }
+}
+
+# RUN: llvm-mc --triple=x86_64-unknown-linux -filetype=obj -o main.o main.s
+# RUN: not ld.lld main.o -o main --script script2.ld 2>&1 | FileCheck -check-prefix=ERR1 %s
+# ERR1: {{.*}} error: main.o:(.text+0x6): prohibited cross reference from .text to in .text1
+
+#--- script2.ld
+NOCROSSREFS_TO(.text1 .text);
+SECTIONS {
+	.text  : { *(.text) }
+	.text1 : { *(.text1) }
+	.text2 : { *(.text2) }
+}
+
+# RUN: llvm-mc --triple=x86_64-unknown-linux -filetype=obj -o main.o main.s
+# RUN: not ld.lld main.o -o main --script script3.ld 2>&1 | FileCheck -check-prefix=ERR2 %s
+# ERR2: {{.*}} error: main.o:(.text+0x6): prohibited cross reference from .text to in .text1
+
+#--- script3.ld
+NOCROSSREFS(.text1 .text .text2);
+SECTIONS {
+	.text  : { *(.text) }
+	.text1 : { *(.text1) }
+	.text2 : { *(.text2) }
+}
+
+# RUN: llvm-mc --triple=x86_64-unknown-linux -filetype=obj -o main.o main.s
+# RUN: ld.lld main.o -o main --script script4.ld 2>&1
+
+#--- script4.ld
+NOCROSSREFS_TO(.text .text1);
+SECTIONS {
+	.text  : { *(.text) }
+	.text1 : { *(.text1) }
+	.text2 : { *(.text2) }
+}
+
+# RUN: llvm-mc --triple=x86_64-unknown-linux -filetype=obj -o main.o main.s
+# RUN: ld.lld main.o -o main --script script5.ld 2>&1
+
+#--- script5.ld
+NOCROSSREFS_TO();
+SECTIONS {
+	.text  : { *(.text) }
+	.text1 : { *(.text1) }
+	.text2 : { *(.text2) }
+}
+
+# RUN: llvm-mc --triple=x86_64-unknown-linux -filetype=obj -o main.o main.s
+# RUN: ld.lld main.o -o main --script script6.ld 2>&1
+
+#--- script6.ld
+NOCROSSREFS();
+SECTIONS {
+	.text  : { *(.text) }
+	.text1 : { *(.text1) }
+	.text2 : { *(.text2) }
+}
+
+# RUN: llvm-mc --triple=x86_64-unknown-linux -filetype=obj -o main.o main.s
+# RUN: ld.lld main.o -o main --script script7.ld 2>&1
+
+#--- script7.ld
+NOCROSSREFS(.text);
+SECTIONS {
+	.text  : { *(.text) }
+	.text1 : { *(.text1) }
+	.text2 : { *(.text2) }
+}
+
+# RUN: llvm-mc --triple=x86_64-unknown-linux -filetype=obj -o main.o main.s
+# RUN: ld.lld main.o -o main --script script8.ld 2>&1
+
+#--- script8.ld
+NOCROSSREFS_TO(.text);
+SECTIONS {
+	.text  : { *(.text) }
+	.text1 : { *(.text1) }
+	.text2 : { *(.text2) }
+}
+
+# RUN: llvm-mc --triple=x86_64-unknown-linux -filetype=obj -o main.o main.s
+# RUN: ld.lld main.o -o main --script script9.ld 2>&1
+
+#--- script9.ld
+NOCROSSREFS_TO(.text2 .text);
+SECTIONS {
+	.text  : { *(.text) }
+	.text1 : { *(.text1) }
+	.text2 : { *(.text2) }
+}
+
+# RUN: llvm-mc --triple=x86_64-unknown-linux -filetype=obj -o main.o main.s
+# RUN: ld.lld main.o -o main --script script10.ld 2>&1
+
+#--- script10.ld
+NOCROSSREFS(.text .text2);
+SECTIONS {
+	.text  : { *(.text) }
+	.text1 : { *(.text1) }
+	.text2 : { *(.text2) }
+}
+
+# RUN: llvm-mc --triple=x86_64-unknown-linux -filetype=obj -o main.o main.s
+# RUN: ld.lld main.o -o main --script script11.ld 2>&1
+
+#--- script11.ld
+NOCROSSREFS(.text .text2);
+SECTIONS {
+	foo = ABSOLUTE(.);
+	.text  : { *(.text) }
+	.text1 : { *(.text1) }
+	.text2 : { *(.text2) }
+}
+
+# RUN: llvm-mc --triple=x86_64-unknown-linux -filetype=obj -o main.o main.s
+# RUN: ld.lld main.o -o main --script script12.ld 2>&1
+
+#--- script12.ld
+NOCROSSREFS(.text .text2);
+SECTIONS {
+	foo = ABSOLUTE(.);
+	.text  : { *(.text) }
+	.text1 : { *(.text1) }
+	.text2 : { *(.text2) }
+	.bss   : { *(.unused) }
+}
+
+# RUN: llvm-mc --triple=x86_64-unknown-linux -filetype=obj -o main.o main.s
+# RUN: not ld.lld main.o -o main --script script13.ld 2>&1 | FileCheck -check-prefix=ERR3 %s
+# ERR3: {{.*}} error: main.o:(.text+0x5): prohibited cross reference from .text to unused in .bss
+
+#--- script13.ld
+NOCROSSREFS(.text .bss);
+SECTIONS {
+	foo = ABSOLUTE(.);
+	.text  : { *(.text) }
+	.text1 : { *(.text1) }
+	.text2 : { *(.text2) }
+	.bss   : { *(.unused) }
+}
+
+#--- main.s
+.global _start
+_start:
+	call test
+
+	.type	unused,@object
+	.comm	unused,4,4
+
+	.section	.noalloc,"",@progbits
+	.quad	unused
+
+.section .text
+test:
+	.reloc ., R_X86_64_32, unused
+	call test1
+
+.section .text2
+test2:
+	.reloc ., R_X86_64_32, foo
+	nop
+
+.section .text1
+test1:
+	nop


### PR DESCRIPTION
Patch introduces supprot for NOCROSSREFS_(TO) linker script commands. These commands specify which cross-section references should be threated as errors. See more in ld documenmtation [0]

Implementation is straightforward -- traverse all relocations in all object files and report an error if there is prohibited one.

[0] https://sourceware.org/binutils/docs/ld/Miscellaneous-Commands.html

Closes: #41825