### PR TITLE
[TableGen] Check for duplicate register tuple definitions.

### DIFF
--- a/llvm/test/TableGen/check-duplicate-tuple-regs.td
+++ b/llvm/test/TableGen/check-duplicate-tuple-regs.td
@@ -1,0 +1,10 @@
+// RUN: not llvm-tblgen -gen-register-info -I %p/../../include -I %p/Common %s 2>&1 | FileCheck %s
+
+include "reg-with-subregs-common.td"
+
+// CHECK: error: Register tuple redefines register 'R0_R1_R2_R3'
+def GPR128_Aligned : RegisterTuples<[sub0, sub1, sub2, sub3],
+                                    [(decimate (shl GPR32, 0), 4),
+                                     (decimate (shl GPR32, 1), 4),
+                                     (decimate (shl GPR32, 2), 4),
+                                     (decimate (shl GPR32, 3), 4)]>;

--- a/llvm/utils/TableGen/Common/CodeGenRegisters.cpp
+++ b/llvm/utils/TableGen/Common/CodeGenRegisters.cpp
@@ -22,6 +22,7 @@
 #include "llvm/ADT/SmallSet.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
+#include "llvm/ADT/StringSet.h"
 #include "llvm/ADT/Twine.h"
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/raw_ostream.h"
@@ -618,6 +619,9 @@ struct TupleExpander : SetTheory::Expander {
   // the synthesized definitions for their lifetime.
   std::vector<std::unique_ptr<Record>> &SynthDefs;
 
+  // Track all synthesized tuple names in order to detect duplicate definitions.
+  llvm::StringSet<> TupleNames;
+
   TupleExpander(std::vector<std::unique_ptr<Record>> &SynthDefs)
       : SynthDefs(SynthDefs) {}
 
@@ -683,6 +687,12 @@ struct TupleExpander : SetTheory::Expander {
           std::make_unique<Record>(Name, Def->getLoc(), Def->getRecords()));
       Record *NewReg = SynthDefs.back().get();
       Elts.insert(NewReg);
+
+      // Detect duplicates among synthesized registers.
+      const auto Res = TupleNames.insert(NewReg->getName());
+      if (!Res.second)
+        PrintFatalError(Def->getLoc(),
+                        "Register tuple redefines register '" + Name + "'.");
 
       // Copy Proto super-classes.
       ArrayRef<std::pair<Record *, SMRange>> Supers = Proto->getSuperClasses();


### PR DESCRIPTION
Currently TableGen does not directly detect duplicate synthesized registers as can happen in this example:

def GPR128 : RegisterTuples<[sub0, sub1, sub2, sub3],
                            [(decimate (shl GPR32, 0), 1),
                             (decimate (shl GPR32, 1), 1),
                             (decimate (shl GPR32, 2), 1),
                             (decimate (shl GPR32, 3), 1)]>;

def GPR128_Aligned : RegisterTuples<[sub0, sub1, sub2, sub3],
                                    [(decimate (shl GPR32, 0), 4),
                                     (decimate (shl GPR32, 1), 4),
                                     (decimate (shl GPR32, 2), 4),
                                     (decimate (shl GPR32, 3), 4)]>;

TableGen does fail, but with an unrelated and difficult to understand error that happens downstream of tuple expansion:
"error: No SubRegIndex for R0_R1_R2_R3 in R0_R1_R2_R3".

This patch detects the problem directly during expansion and emits an error pointing the user to the actual issue:
"error: Register tuple redefines register 'R0_R1_R2_R3'".