### PR TITLE
[clang][Parser] "Better" error messages for invalid template template

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -580,6 +580,8 @@ Improvements to Clang's diagnostics
 - Clang no longer emits a "declared here" note for a builtin function that has no declaration in source.
   Fixes #GH93369.
 
+- Clang now suggests a fix-it to correct ``template`` in a template-template parameter with a missing ``<`` to ``typename``
+
 Improvements to Clang's time-trace
 ----------------------------------
 

--- a/clang/lib/Parse/ParseTemplate.cpp
+++ b/clang/lib/Parse/ParseTemplate.cpp
@@ -788,14 +788,14 @@ NamedDecl *Parser::ParseTemplateTemplateParameter(unsigned Depth,
   assert(Tok.is(tok::kw_template) && "Expected 'template' keyword");
 
   if (Token ahead = GetLookAheadToken(1); ahead.isNot(tok::less)) {
-    // Maybe they intended `typename` instead of `template` (given thats more common)
-    // Error early, to add a fixit hint
+    // Maybe they intended `typename` instead of `template` (given thats more
+    // common) Error early, to add a fixit hint
 
     Diag(ahead.getLocation(), diag::err_expected_less_after) << "template";
-    
+
     Diag(Tok.getLocation(), diag::note_meant_to_use_typename)
-      << FixItHint::CreateReplacement(CharSourceRange::getTokenRange(Tok.getLocation()),
-                                      "typename");
+        << FixItHint::CreateReplacement(
+               CharSourceRange::getTokenRange(Tok.getLocation()), "typename");
 
     Tok.setKind(tok::kw_typename);
     return ParseTypeParameter(Depth, Position);

--- a/clang/lib/Parse/ParseTemplate.cpp
+++ b/clang/lib/Parse/ParseTemplate.cpp
@@ -787,10 +787,7 @@ NamedDecl *Parser::ParseTemplateTemplateParameter(unsigned Depth,
                                                   unsigned Position) {
   assert(Tok.is(tok::kw_template) && "Expected 'template' keyword");
 
-  if (Token ahead = GetLookAheadToken(1);
-      ahead.isOneOf(tok::identifier, tok::ellipsis,
-                    tok::equal, tok::comma,
-                    tok::greater, tok::greatergreater, tok::greatergreatergreater)) {
+  if (Token ahead = GetLookAheadToken(1); ahead.isNot(tok::less)) {
     // Maybe they intended `typename` instead of `template` (given thats more common)
     // Error early, to add a fixit hint
 

--- a/clang/lib/Parse/ParseTemplate.cpp
+++ b/clang/lib/Parse/ParseTemplate.cpp
@@ -787,11 +787,11 @@ NamedDecl *Parser::ParseTemplateTemplateParameter(unsigned Depth,
                                                   unsigned Position) {
   assert(Tok.is(tok::kw_template) && "Expected 'template' keyword");
 
-  if (Token ahead = GetLookAheadToken(1); ahead.isNot(tok::less)) {
-    // Maybe they intended `typename` instead of `template` (given thats more
-    // common) Error early, to add a fixit hint
+  if (Token Next = NextToken(); Next.isNot(tok::less)) {
+    // `template` may have been a typo for `typename`, given that the
+    // latter is more common.
 
-    Diag(ahead.getLocation(), diag::err_expected_less_after) << "template";
+    Diag(Next.getLocation(), diag::err_expected_less_after) << "template";
 
     Diag(Tok.getLocation(), diag::note_meant_to_use_typename)
         << FixItHint::CreateReplacement(

--- a/clang/test/CXX/drs/cwg1xx.cpp
+++ b/clang/test/CXX/drs/cwg1xx.cpp
@@ -1145,8 +1145,10 @@ namespace cwg181 { // cwg181: yes
   namespace X {
     template <template X<class T> > struct A { };
     // expected-error@-1 +{{}}
+    //  expected-note@-2 {{did you mean to use 'typename'?}}
     template <template X<class T> > void f(A<X>) { }
     // expected-error@-1 +{{}}
+    //  expected-note@-2 {{did you mean to use 'typename'?}}
   }
 
   namespace Y {

--- a/clang/test/CXX/drs/cwg1xx.cpp
+++ b/clang/test/CXX/drs/cwg1xx.cpp
@@ -1145,10 +1145,10 @@ namespace cwg181 { // cwg181: yes
   namespace X {
     template <template X<class T> > struct A { };
     // expected-error@-1 +{{}}
-    //  expected-note@-2 {{did you mean to use 'typename'?}}
+    //   expected-note@-2 {{did you mean to use 'typename'?}}
     template <template X<class T> > void f(A<X>) { }
     // expected-error@-1 +{{}}
-    //  expected-note@-2 {{did you mean to use 'typename'?}}
+    //   expected-note@-2 {{did you mean to use 'typename'?}}
   }
 
   namespace Y {

--- a/clang/test/Parser/cxx-template-decl.cpp
+++ b/clang/test/Parser/cxx-template-decl.cpp
@@ -22,7 +22,7 @@ template<template<int+>> struct x3; // expected-error {{expected ',' or '>' in t
                                          cpp14-error {{template template parameter requires 'class' after the parameter list}} \
                                          cpp17-error {{template template parameter requires 'class' or 'typename' after the parameter list}}
 template <template X> struct Err1; // expected-error {{expected '<' after 'template'}} \
-// expected-error{{extraneous}}
+// expected-note{{did you mean to use 'typename'?}}
 template <template <typename> > struct Err2;       // cpp14-error {{template template parameter requires 'class' after the parameter list}}
 // cpp17-error@-1{{template template parameter requires 'class' or 'typename' after the parameter list}}
 template <template <typename> Foo> struct Err3;    // cpp14-error {{template template parameter requires 'class' after the parameter list}}


### PR DESCRIPTION
For the somewhat easy mistake of `template<template A> ...` clang outputs a partially cryptic error

This patch changes this to assume the programmer intended `typename` in cases where `template` is illegal, and emit diagnostics (and forward parsing) accordingly

This mirrors the behaviour of `typedef` handling, so I feel its a reasonable qol change

Apologies if I missed any broken tests. Currently my local setup is messed up and fails on 100-200 tests eroniously, so I did my best to search through the errors and find the ones that needed updating