### PR TITLE
[Serialization] Use specialized decl hash function for GlobalDeclID

### DIFF
--- a/clang/include/clang/AST/DeclID.h
+++ b/clang/include/clang/AST/DeclID.h
@@ -230,7 +230,11 @@ template <> struct DenseMapInfo<clang::GlobalDeclID> {
   }
 
   static unsigned getHashValue(const GlobalDeclID &Key) {
-    return DenseMapInfo<DeclID>::getHashValue(Key.get());
+    // Our default hash algorithm for 64 bits integer may not be very good.
+    // In GlobalDeclID's case, it is pretty common that the lower 32 bits can
+    // be same.
+    return DenseMapInfo<uint32_t>::getHashValue(Key.getModuleFileIndex()) ^
+           DenseMapInfo<uint32_t>::getHashValue(Key.getLocalDeclIndex());
   }
 
   static bool isEqual(const GlobalDeclID &L, const GlobalDeclID &R) {

--- a/clang/include/clang/AST/DeclID.h
+++ b/clang/include/clang/AST/DeclID.h
@@ -17,6 +17,7 @@
 #define LLVM_CLANG_AST_DECLID_H
 
 #include "llvm/ADT/DenseMapInfo.h"
+#include "llvm/ADT/Hashing.h"
 #include "llvm/ADT/iterator.h"
 
 #include <climits>
@@ -233,8 +234,8 @@ template <> struct DenseMapInfo<clang::GlobalDeclID> {
     // Our default hash algorithm for 64 bits integer may not be very good.
     // In GlobalDeclID's case, it is pretty common that the lower 32 bits can
     // be same.
-    return DenseMapInfo<uint32_t>::getHashValue(Key.getModuleFileIndex()) ^
-           DenseMapInfo<uint32_t>::getHashValue(Key.getLocalDeclIndex());
+    // FIXME: Remove this when we fix the underlying issue.
+    return llvm::hash_value(Key.get());
   }
 
   static bool isEqual(const GlobalDeclID &L, const GlobalDeclID &R) {


### PR DESCRIPTION
See the comment:
https://github.com/llvm/llvm-project/pull/92083#issuecomment-2168121729

After the patch, https://github.com/llvm/llvm-project/pull/92083, the lower 32 bits of DeclID can be the same commonly. This may produce many collisions. It will be best to change the default hash implementation for uint64_t. But sent this one as a quick workaround.

Feel free to update this if you prefer other hash functions.