### PR TITLE
[ADT] Update hash function of uint64_t for DenseMap

### DIFF
--- a/llvm/include/llvm/ADT/DenseMapInfo.h
+++ b/llvm/include/llvm/ADT/DenseMapInfo.h
@@ -137,7 +137,12 @@ template<> struct DenseMapInfo<unsigned long> {
   static inline unsigned long getTombstoneKey() { return ~0UL - 1L; }
 
   static unsigned getHashValue(const unsigned long& Val) {
-    return (unsigned)(Val * 37UL);
+    if constexpr (sizeof(Val) == 4)
+      return DenseMapInfo<unsigned>::getHashValue(Val);
+    else
+      return detail::combineHashValue(
+          DenseMapInfo<unsigned>::getHashValue(Val),
+          DenseMapInfo<unsigned>::getHashValue(Val >> 32));
   }
 
   static bool isEqual(const unsigned long& LHS, const unsigned long& RHS) {
@@ -151,8 +156,9 @@ template<> struct DenseMapInfo<unsigned long long> {
   static inline unsigned long long getTombstoneKey() { return ~0ULL - 1ULL; }
 
   static unsigned getHashValue(const unsigned long long& Val) {
-    return DenseMapInfo<unsigned>::getHashValue(Val) ^
-           DenseMapInfo<unsigned>::getHashValue(Val >> 32);
+    return detail::combineHashValue(
+        DenseMapInfo<unsigned>::getHashValue(Val),
+        DenseMapInfo<unsigned>::getHashValue(Val >> 32));
   }
 
   static bool isEqual(const unsigned long long& LHS,

--- a/llvm/include/llvm/ADT/DenseMapInfo.h
+++ b/llvm/include/llvm/ADT/DenseMapInfo.h
@@ -151,7 +151,7 @@ template<> struct DenseMapInfo<unsigned long long> {
   static inline unsigned long long getTombstoneKey() { return ~0ULL - 1ULL; }
 
   static unsigned getHashValue(const unsigned long long& Val) {
-    return (unsigned)(Val * 37ULL);
+    return DenseMapInfo<unsigned>(Val) ^ DenseMapInfo<unsigned>(Val >> 32);
   }
 
   static bool isEqual(const unsigned long long& LHS,

--- a/llvm/include/llvm/ADT/DenseMapInfo.h
+++ b/llvm/include/llvm/ADT/DenseMapInfo.h
@@ -151,7 +151,8 @@ template<> struct DenseMapInfo<unsigned long long> {
   static inline unsigned long long getTombstoneKey() { return ~0ULL - 1ULL; }
 
   static unsigned getHashValue(const unsigned long long& Val) {
-    return DenseMapInfo<unsigned>(Val) ^ DenseMapInfo<unsigned>(Val >> 32);
+    return DenseMapInfo<unsigned>::getHashValue(Val) ^
+           DenseMapInfo<unsigned>::getHashValue(Val >> 32);
   }
 
   static bool isEqual(const unsigned long long& LHS,

--- a/llvm/include/llvm/ADT/DenseMapInfo.h
+++ b/llvm/include/llvm/ADT/DenseMapInfo.h
@@ -140,9 +140,7 @@ template<> struct DenseMapInfo<unsigned long> {
     if constexpr (sizeof(Val) == 4)
       return DenseMapInfo<unsigned>::getHashValue(Val);
     else
-      return detail::combineHashValue(
-          DenseMapInfo<unsigned>::getHashValue(Val),
-          DenseMapInfo<unsigned>::getHashValue(Val >> 32));
+      return detail::combineHashValue(Val >> 32, Val);
   }
 
   static bool isEqual(const unsigned long& LHS, const unsigned long& RHS) {
@@ -156,9 +154,7 @@ template<> struct DenseMapInfo<unsigned long long> {
   static inline unsigned long long getTombstoneKey() { return ~0ULL - 1ULL; }
 
   static unsigned getHashValue(const unsigned long long& Val) {
-    return detail::combineHashValue(
-        DenseMapInfo<unsigned>::getHashValue(Val),
-        DenseMapInfo<unsigned>::getHashValue(Val >> 32));
+    return detail::combineHashValue(Val >> 32, Val);
   }
 
   static bool isEqual(const unsigned long long& LHS,


### PR DESCRIPTION
(Background: See the comment:
https://github.com/llvm/llvm-project/pull/92083#issuecomment-2168121729)

It looks like the hash function for 64bits integers are not very good:

```
  static unsigned getHashValue(const unsigned long long& Val) {
    return (unsigned)(Val * 37ULL);
  }
```

Since the result is truncated to 32 bits. It looks like the higher 32 bits won't contribute to the result. So that `0x1'00000001` will have the the same results to `0x2'00000001`, `0x3'00000001`, ...

Then we may meet a lot collisions in such cases. I feel it should generally good to include higher 32 bits for hashing functions.

Not sure who's the appropriate reviewer, adding some people by impressions.