### PR TITLE
[compiler-rt] Remove redundant checks.

### DIFF
--- a/compiler-rt/lib/asan/asan_suppressions.cpp
+++ b/compiler-rt/lib/asan/asan_suppressions.cpp
@@ -39,8 +39,7 @@ void InitializeSuppressions() {
   suppression_ctx = new (suppression_placeholder)
       SuppressionContext(kSuppressionTypes, ARRAY_SIZE(kSuppressionTypes));
   suppression_ctx->ParseFromFile(flags()->suppressions);
-  if (&__asan_default_suppressions)
-    suppression_ctx->Parse(__asan_default_suppressions());
+  suppression_ctx->Parse(__asan_default_suppressions());
 }
 
 bool IsInterceptorSuppressed(const char *interceptor_name) {

--- a/compiler-rt/lib/sanitizer_common/sancov_flags.cpp
+++ b/compiler-rt/lib/sanitizer_common/sancov_flags.cpp
@@ -37,10 +37,6 @@ static void RegisterSancovFlags(FlagParser *parser, SancovFlags *f) {
 #undef SANCOV_FLAG
 }
 
-static const char *MaybeCallSancovDefaultOptions() {
-  return (&__sancov_default_options) ? __sancov_default_options() : "";
-}
-
 void InitializeSancovFlags() {
   SancovFlags *f = sancov_flags();
   f->SetDefaults();
@@ -48,7 +44,7 @@ void InitializeSancovFlags() {
   FlagParser parser;
   RegisterSancovFlags(&parser, f);
 
-  parser.ParseString(MaybeCallSancovDefaultOptions());
+  parser.ParseString(__sancov_default_options());
   parser.ParseStringFromEnv("SANCOV_OPTIONS");
 
   ReportUnrecognizedFlags();


### PR DESCRIPTION
Since `__sancov_default_options` and `__asan_default_suppressions` are weak definitions, not weak references (declarations) the checks of equality of addresses of these symbols to zero is not needed. So we can completely remove `MaybeCallSancovDefaultOptions` and use `__sancov_default_options` instead directly. gcc-14 emits `-Waddress` warning to such checks.