### PR TITLE
[GitHub][workflows] Use latest clang-format version 18.1.7

### DIFF
--- a/.github/workflows/pr-code-format.yml
+++ b/.github/workflows/pr-code-format.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Install clang-format
         uses: aminya/setup-cpp@v1
         with:
-          clangformat: 18.1.1
+          clangformat: 18.1.7
 
       - name: Setup Python env
         uses: actions/setup-python@v5


### PR DESCRIPTION
Since clang-format 18.1.4, there have been a number of commits that fixed various kinds of issues:

- Bug
3ceccbdb1995

- Regression
6dbaa89433f7
51ff7f38b633
35fea1032741
7699b341b763
768118d1ad38
8c0fe0d65ed8

- Crash
f1491c7460e7

- Invalid code generation
0abb89a80f5c