### PR TITLE
[Clang] Forward -rpath flag to the correct format in CPU offloading

### DIFF
--- a/clang/test/Driver/linker-wrapper.c
+++ b/clang/test/Driver/linker-wrapper.c
@@ -57,6 +57,7 @@ __attribute__((visibility("protected"), used)) int x;
 // RUN: llvm-ar rcs %t.a %t.o
 // RUN: clang-linker-wrapper --host-triple=x86_64-unknown-linux-gnu --dry-run \
 // RUN:   --linker-path=/usr/bin/ld.lld --whole-archive %t.a --no-whole-archive \
+// RUN:   -rpath %S/Inputs/linker-wrapper
 // RUN:   %t.o -o a.out 2>&1 | FileCheck %s --check-prefix=CPU-LINK
 
 // CPU-LINK: clang{{.*}} -o {{.*}}.img --target=x86_64-unknown-linux-gnu -march=native -O2 -Wl,--no-undefined {{.*}}.o {{.*}}.o -Wl,-Bsymbolic -shared -Wl,--whole-archive {{.*}}.a -Wl,--no-whole-archive

--- a/clang/tools/clang-linker-wrapper/ClangLinkerWrapper.cpp
+++ b/clang/tools/clang-linker-wrapper/ClangLinkerWrapper.cpp
@@ -500,6 +500,9 @@ Expected<StringRef> clang(ArrayRef<StringRef> InputFiles, const ArgList &Args) {
         LinkerArgs.push_back(Args.MakeArgString("-Wl,--whole-archive"));
       else if (Arg->getOption().matches(OPT_no_whole_archive))
         LinkerArgs.push_back(Args.MakeArgString("-Wl,--no-whole-archive"));
+      else if (Arg->getOption().matches(OPT_rpath))
+        LinkerArgs.push_back(
+            Args.MakeArgString("-Wl,-rpath," + Twine(Arg->getValue())));
       else
         Arg->render(Args, LinkerArgs);
     }


### PR DESCRIPTION
`clang-linker-wrapper` gets flags in linker format. In CPU offloading we need to format some of them as compiler flags, like it is already done with `--no-whole-archine`. This patch does the same with `-rpath`