### PR TITLE
[libc++] Use __is_nothrow_destructible

### DIFF
--- a/libcxx/include/__type_traits/is_nothrow_destructible.h
+++ b/libcxx/include/__type_traits/is_nothrow_destructible.h
@@ -12,9 +12,6 @@
 #include <__config>
 #include <__type_traits/integral_constant.h>
 #include <__type_traits/is_destructible.h>
-#include <__type_traits/is_reference.h>
-#include <__type_traits/is_scalar.h>
-#include <__type_traits/remove_all_extents.h>
 #include <__utility/declval.h>
 #include <cstddef>
 
@@ -24,7 +21,12 @@
 
 _LIBCPP_BEGIN_NAMESPACE_STD
 
-#if !defined(_LIBCPP_CXX03_LANG)
+#if __has_builtin(__is_nothrow_destructible)
+
+template <class _Tp>
+struct _LIBCPP_TEMPLATE_VIS is_nothrow_destructible : integral_constant<bool, __is_nothrow_destructible(_Tp)> {};
+
+#else
 
 template <bool, class _Tp>
 struct __libcpp_is_nothrow_destructible;
@@ -49,20 +51,7 @@ struct _LIBCPP_TEMPLATE_VIS is_nothrow_destructible<_Tp&> : public true_type {};
 template <class _Tp>
 struct _LIBCPP_TEMPLATE_VIS is_nothrow_destructible<_Tp&&> : public true_type {};
 
-#else
-
-template <class _Tp>
-struct __libcpp_nothrow_destructor : public integral_constant<bool, is_scalar<_Tp>::value || is_reference<_Tp>::value> {
-};
-
-template <class _Tp>
-struct _LIBCPP_TEMPLATE_VIS is_nothrow_destructible : public __libcpp_nothrow_destructor<__remove_all_extents_t<_Tp> > {
-};
-
-template <class _Tp>
-struct _LIBCPP_TEMPLATE_VIS is_nothrow_destructible<_Tp[]> : public false_type {};
-
-#endif
+#endif // __has_builtin(__is_nothrow_destructible)
 
 #if _LIBCPP_STD_VER >= 17
 template <class _Tp>

--- a/libcxx/test/std/utilities/meta/meta.unary/meta.unary.prop/is_nothrow_destructible.pass.cpp
+++ b/libcxx/test/std/utilities/meta/meta.unary/meta.unary.prop/is_nothrow_destructible.pass.cpp
@@ -56,6 +56,10 @@ struct PurePublicDestructor              { public:    virtual ~PurePublicDestruc
 struct PureProtectedDestructor           { protected: virtual ~PureProtectedDestructor() = 0; };
 struct PurePrivateDestructor             { private:   virtual ~PurePrivateDestructor() = 0; };
 
+struct ExplicitlyNoThrowDestructor {
+    ~ExplicitlyNoThrowDestructor() TEST_NOEXCEPT {}
+};
+
 class Empty
 {
 };
@@ -92,11 +96,12 @@ int main(int, char**)
     test_is_nothrow_destructible<PublicDestructor>();
     test_is_nothrow_destructible<VirtualPublicDestructor>();
     test_is_nothrow_destructible<PurePublicDestructor>();
+#endif
+    test_is_nothrow_destructible<ExplicitlyNoThrowDestructor>();
     test_is_nothrow_destructible<bit_zero>();
     test_is_nothrow_destructible<Abstract>();
     test_is_nothrow_destructible<Empty>();
     test_is_nothrow_destructible<Union>();
-#endif
     // requires access control
     test_is_not_nothrow_destructible<ProtectedDestructor>();
     test_is_not_nothrow_destructible<PrivateDestructor>();


### PR DESCRIPTION
This changes the behaviour in C++03 mode because we'll now use the builtin on Clang, but I don't think that's much of a problem.
