### PR TITLE
[CodeGen] Do not include $noreg in any regmask operands. NFCI.

### DIFF
--- a/llvm/lib/CodeGen/MachineLICM.cpp
+++ b/llvm/lib/CodeGen/MachineLICM.cpp
@@ -440,8 +440,7 @@ static void applyBitsNotInRegMaskToRegUnitsMask(const TargetRegisterInfo &TRI,
         break;
 
       // Check if we have a valid PhysReg that is set in the mask.
-      // FIXME: We shouldn't have to check for PhysReg.
-      if (PhysReg && ((Word >> Bit) & 1)) {
+      if ((Word >> Bit) & 1) {
         for (MCRegUnitIterator RUI(PhysReg, &TRI); RUI.isValid(); ++RUI)
           ClobberedRUs.reset(*RUI);
       }

--- a/llvm/lib/CodeGen/RegUsageInfoCollector.cpp
+++ b/llvm/lib/CodeGen/RegUsageInfoCollector.cpp
@@ -142,6 +142,9 @@ bool RegUsageInfoCollector::runOnMachineFunction(MachineFunction &MF) {
     RegMask[Reg / 32] &= ~(1u << Reg % 32);
   };
 
+  // Don't include $noreg in any regmasks.
+  SetRegAsDefined(MCRegister::NoRegister);
+
   // Some targets can clobber registers "inside" a call, typically in
   // linker-generated code.
   for (const MCPhysReg Reg : TRI->getIntraCallClobberedRegs(&MF))


### PR DESCRIPTION
Saying that a call preserves $noreg seems weird and required a
workaround in MachineLICM.
