### PR TITLE
[CI][format] Explicitly pass extensions to git-clang-format

### DIFF
--- a/llvm/utils/git/code-format-helper.py
+++ b/llvm/utils/git/code-format-helper.py
@@ -216,6 +216,15 @@ class ClangFormatHelper(FormatHelper):
             cf_cmd.append(args.start_rev)
             cf_cmd.append(args.end_rev)
 
+        # Gather the extension of all modified files and pass them explicitly to git-clang-format.
+        # This prevents git-clang-format from applying its own filtering rules on top of ours.
+        extensions = set()
+        for file in cpp_files:
+            _, ext = os.path.splitext(file)
+            extensions.add(ext.strip(".")) # Exclude periods since git-clang-format takes extensions without them
+        cf_cmd.append("--extensions")
+        cf_cmd.append("'{}'".format(",".join(extensions)))
+
         cf_cmd.append("--")
         cf_cmd += cpp_files
 

--- a/llvm/utils/git/code-format-helper.py
+++ b/llvm/utils/git/code-format-helper.py
@@ -221,7 +221,9 @@ class ClangFormatHelper(FormatHelper):
         extensions = set()
         for file in cpp_files:
             _, ext = os.path.splitext(file)
-            extensions.add(ext.strip(".")) # Exclude periods since git-clang-format takes extensions without them
+            extensions.add(
+                ext.strip(".")
+            )  # Exclude periods since git-clang-format takes extensions without them
         cf_cmd.append("--extensions")
         cf_cmd.append("'{}'".format(",".join(extensions)))
 


### PR DESCRIPTION
This ensures that the CI script controls which file extensions are considered instead of letting git-clang-format apply its own filtering rules. In particular, this properly handles libc++ extension-less headers which were passed to git-clang-format, but then dropped by that tool as having an unrecognized extension.