### PR TITLE
[clang][include-cleaner]skip stdlib recogntion only when there are defintion with body in main file.

### DIFF
--- a/clang-tools-extra/include-cleaner/unittests/FindHeadersTest.cpp
+++ b/clang-tools-extra/include-cleaner/unittests/FindHeadersTest.cpp
@@ -631,12 +631,9 @@ TEST_F(HeadersForSymbolTest, StandardHeaders) {
 TEST_F(HeadersForSymbolTest, NonStandardHeaders) {
   Inputs.Code = "void assert() {}";
   buildAST();
-  EXPECT_THAT(
-      headersFor("assert"),
-      // Respect the ordering from the stdlib mapping.
-      UnorderedElementsAre(physicalHeader("input.mm"),
-                           tooling::stdlib::Header::named("<cassert>"),
-                           tooling::stdlib::Header::named("<assert.h>")));
+  EXPECT_THAT(headersFor("assert"),
+              // Respect the ordering from the stdlib mapping.
+              UnorderedElementsAre(physicalHeader("input.mm")));
 }
 
 TEST_F(HeadersForSymbolTest, ExporterNoNameMatch) {


### PR DESCRIPTION
When a definition is being located, standard library function recognition is skipped if the function has a definition with body in the main file
