### PR TITLE
[mlir][spirv] Remove debug option from the `RUN` command in `vector-deinterleave.mlir`

### DIFF
--- a/mlir/test/mlir-vulkan-runner/vector-deinterleave.mlir
+++ b/mlir/test/mlir-vulkan-runner/vector-deinterleave.mlir
@@ -1,6 +1,6 @@
 // RUN: mlir-vulkan-runner %s \
 // RUN:  --shared-libs=%vulkan-runtime-wrappers,%mlir_runner_utils \
-// RUN:  --entry-point-result=void --debug-only=dialect-conversion | FileCheck %s
+// RUN:  --entry-point-result=void | FileCheck %s
 
 // CHECK: [0, 2]
 // CHECK: [1, 3]


### PR DESCRIPTION
This PR is based on #95800. It removes a debug option from the `RUN` command in `vector-deinterleave.mlir`.