### PR TITLE
[OpenMP][libomp] Fix tasking debug assert

### DIFF
--- a/openmp/runtime/src/kmp_tasking.cpp
+++ b/openmp/runtime/src/kmp_tasking.cpp
@@ -3245,7 +3245,7 @@ static kmp_task_t *__kmp_steal_task(kmp_int32 victim_tid, kmp_int32 gtid,
   threads_data = task_team->tt.tt_threads_data;
   KMP_DEBUG_ASSERT(threads_data != NULL); // Caller should check this condition
   KMP_DEBUG_ASSERT(victim_tid >= 0);
-  KMP_DEBUG_ASSERT(victim_tid < task_team->tt.tt_nproc);
+  KMP_DEBUG_ASSERT(victim_tid < task_team->tt.tt_max_threads);
 
   victim_td = &threads_data[victim_tid];
   victim_thr = victim_td->td.td_thr;

--- a/openmp/runtime/test/tasking/issue-94260-1.cpp
+++ b/openmp/runtime/test/tasking/issue-94260-1.cpp
@@ -1,0 +1,66 @@
+// RUN: %libomp-cxx-compile-and-run
+
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <omp.h>
+
+// The number of times to run each test
+#define NTIMES 2
+
+// Every thread creates a single "increment" task
+void test_tasks() {
+  for (int i = 0; i < 100; ++i)
+#pragma omp task
+  {
+    int tid = omp_get_thread_num();
+  }
+}
+
+// Testing single level of parallelism with increment tasks
+void test_base(int nthreads) {
+#ifdef VERBOSE
+#pragma omp master
+  printf("    test_base(%d)\n", nthreads);
+#endif
+#pragma omp parallel num_threads(nthreads)
+  { test_tasks(); }
+}
+
+// Testing nested parallel with increment tasks
+// first = nthreads of outer parallel
+// second = nthreads of nested parallel
+void test_nest(int first, int second) {
+#ifdef VERBOSE
+#pragma omp master
+  printf("   test_nest(%d, %d)\n", first, second);
+#endif
+#pragma omp parallel num_threads(first)
+  {
+    for (int i = 0; i < 100; ++i)
+#pragma omp task
+    {
+      int tid = omp_get_thread_num();
+    }
+    test_base(second);
+  }
+}
+
+template <typename... Args>
+void run_ntimes(int n, void (*func)(Args...), Args... args) {
+  for (int i = 0; i < n; ++i) {
+    func(args...);
+  }
+}
+
+int main() {
+  omp_set_max_active_levels(5);
+
+  for (int i = 0; i < 100; ++i) {
+    run_ntimes(NTIMES, test_nest, 4, 3);
+    run_ntimes(NTIMES, test_nest, 2, 1);
+  }
+
+  printf("PASS\n");
+  return EXIT_SUCCESS;
+}

--- a/openmp/runtime/test/tasking/issue-94260-2.c
+++ b/openmp/runtime/test/tasking/issue-94260-2.c
@@ -1,0 +1,51 @@
+// RUN: %libomp-compile-and-run
+
+#include <stdio.h>
+#include <omp.h>
+
+int test_omp_parallel_num_threads() {
+  int num_failed;
+  int threads;
+  int nthreads;
+  int max_threads = 0;
+
+  num_failed = 0;
+#pragma omp task
+  {}
+
+/* first we check how many threads are available */
+#pragma omp parallel
+  {
+#pragma omp task
+    {}
+#pragma omp master
+    max_threads = omp_get_num_threads();
+  }
+
+  /* we increase the number of threads from one to maximum:*/
+  for (threads = 1; threads <= max_threads; threads++) {
+    nthreads = 0;
+#pragma omp parallel reduction(+ : num_failed) num_threads(threads)
+    {
+#pragma omp task
+      {}
+      num_failed = num_failed + !(threads == omp_get_num_threads());
+#pragma omp atomic
+      nthreads += 1;
+    }
+    num_failed = num_failed + !(nthreads == threads);
+  }
+  return (!num_failed);
+}
+
+int main() {
+  int i;
+  int num_failed = 0;
+
+  for (i = 0; i < 100; i++) {
+    if (!test_omp_parallel_num_threads()) {
+      num_failed++;
+    }
+  }
+  return num_failed;
+}


### PR DESCRIPTION
The debug assert is meant to check that the index is a valid which means the runtime needs to check against the size of the array instead of the number of threads. A free()-ed thread put back in the thread pool may index into anywhere inside the task team's available array from 0 to tt_max_threads potentially.

Fixes: #94260