### PR TITLE
[PPC] Add DwarfRegAlias for VSRPair

### DIFF
--- a/llvm/lib/CodeGen/StackMaps.cpp
+++ b/llvm/lib/CodeGen/StackMaps.cpp
@@ -191,21 +191,13 @@ unsigned StackMaps::getNextMetaArgIdx(const MachineInstr *MI, unsigned CurIdx) {
   return CurIdx;
 }
 
-/// Go up the super-register and sub-register chain until we hit a valid dwarf
-/// register number.
+/// Go up the super-register chain until we hit a valid dwarf register number.
 static unsigned getDwarfRegNum(unsigned Reg, const TargetRegisterInfo *TRI) {
   int RegNum;
   for (MCPhysReg SR : TRI->superregs_inclusive(Reg)) {
     RegNum = TRI->getDwarfRegNum(SR, false);
     if (RegNum >= 0)
       break;
-  }
-  if (RegNum < 0) {
-    for (MCPhysReg SR : TRI->subregs_inclusive(Reg)) {
-      RegNum = TRI->getDwarfRegNum(SR, false);
-      if (RegNum >= 0)
-        break;
-    }
   }
 
   assert(RegNum >= 0 && isUInt<16>(RegNum) && "Invalid Dwarf register number.");

--- a/llvm/lib/CodeGen/StackMaps.cpp
+++ b/llvm/lib/CodeGen/StackMaps.cpp
@@ -191,13 +191,21 @@ unsigned StackMaps::getNextMetaArgIdx(const MachineInstr *MI, unsigned CurIdx) {
   return CurIdx;
 }
 
-/// Go up the super-register chain until we hit a valid dwarf register number.
+/// Go up the super-register and sub-register chain until we hit a valid dwarf
+/// register number.
 static unsigned getDwarfRegNum(unsigned Reg, const TargetRegisterInfo *TRI) {
   int RegNum;
   for (MCPhysReg SR : TRI->superregs_inclusive(Reg)) {
     RegNum = TRI->getDwarfRegNum(SR, false);
     if (RegNum >= 0)
       break;
+  }
+  if (RegNum < 0) {
+    for (MCPhysReg SR : TRI->subregs_inclusive(Reg)) {
+      RegNum = TRI->getDwarfRegNum(SR, false);
+      if (RegNum >= 0)
+        break;
+    }
   }
 
   assert(RegNum >= 0 && isUInt<16>(RegNum) && "Invalid Dwarf register number.");

--- a/llvm/lib/Target/PowerPC/PPCRegisterInfo.td
+++ b/llvm/lib/Target/PowerPC/PPCRegisterInfo.td
@@ -199,7 +199,7 @@ let SubRegIndices = [sub_vsx0, sub_vsx1] in {
     def VSRp#!add(!srl(Index, 1), 16) :
       VSRPair<!add(!srl(Index, 1), 16), "vsp"#!add(Index, 32),
               [!cast<VR>("V"#Index), !cast<VR>("V"#!add(Index, 1))]>,
-      DwarfRegNum<[-1, -1]>;
+              DwarfRegAlias<!cast<VR>("V"#Index)>;
   }
 }
 

--- a/llvm/test/CodeGen/PowerPC/ppc64-anyregcc.ll
+++ b/llvm/test/CodeGen/PowerPC/ppc64-anyregcc.ll
@@ -1,3 +1,4 @@
+; RUN: llc -verify-machineinstrs < %s | FileCheck %s
 ; RUN: llc -mcpu=pwr10 -verify-machineinstrs < %s | FileCheck %s
 target datalayout = "E-m:e-i64:64-n32:64"
 target triple = "powerpc64-unknown-linux-gnu"

--- a/llvm/test/CodeGen/PowerPC/ppc64-anyregcc.ll
+++ b/llvm/test/CodeGen/PowerPC/ppc64-anyregcc.ll
@@ -1,4 +1,4 @@
-; RUN: llc -verify-machineinstrs < %s | FileCheck %s
+; RUN: llc -mcpu=pwr10 -verify-machineinstrs < %s | FileCheck %s
 target datalayout = "E-m:e-i64:64-n32:64"
 target triple = "powerpc64-unknown-linux-gnu"
 


### PR DESCRIPTION
Add DwarfRegAlias for VSRPair as it shares dwarfRegNum with the VR registers.