### PR TITLE
[libc] Remove unnecessary check in printf floats

### DIFF
--- a/libc/src/stdio/printf_core/float_dec_converter.h
+++ b/libc/src/stdio/printf_core/float_dec_converter.h
@@ -502,25 +502,22 @@ LIBC_INLINE int convert_float_decimal_typed(Writer *writer,
 
   const size_t positive_blocks = float_converter.get_positive_blocks();
 
-  if (positive_blocks >= 0) {
-    // This loop iterates through the number a block at a time until it finds a
-    // block that is not zero or it hits the decimal point. This is because all
-    // zero blocks before the first nonzero digit or the decimal point are
-    // ignored (no leading zeroes, at least at this stage).
-    int32_t i = static_cast<int32_t>(positive_blocks) - 1;
-    for (; i >= 0; --i) {
-      BlockInt digits = float_converter.get_positive_block(i);
-      if (nonzero) {
-        RET_IF_RESULT_NEGATIVE(float_writer.write_middle_block(digits));
-      } else if (digits != 0) {
-        size_t blocks_before_decimal = i;
-        float_writer.init((blocks_before_decimal * BLOCK_SIZE) +
-                              (has_decimal_point ? 1 : 0) + precision,
-                          blocks_before_decimal * BLOCK_SIZE);
-        float_writer.write_first_block(digits);
+  // This loop iterates through the number a block at a time until it finds a
+  // block that is not zero or it hits the decimal point. This is because all
+  // zero blocks before the first nonzero digit or the decimal point are
+  // ignored (no leading zeroes, at least at this stage).
+  for (int32_t i = static_cast<int32_t>(positive_blocks) - 1; i >= 0; --i) {
+    BlockInt digits = float_converter.get_positive_block(i);
+    if (nonzero) {
+      RET_IF_RESULT_NEGATIVE(float_writer.write_middle_block(digits));
+    } else if (digits != 0) {
+      size_t blocks_before_decimal = i;
+      float_writer.init((blocks_before_decimal * BLOCK_SIZE) +
+                            (has_decimal_point ? 1 : 0) + precision,
+                        blocks_before_decimal * BLOCK_SIZE);
+      float_writer.write_first_block(digits);
 
-        nonzero = true;
-      }
+      nonzero = true;
     }
   }
 


### PR DESCRIPTION
Fixes https://github.com/llvm/llvm-project/issues/95638

The check was `if(unsigned_num >= 0)` which will always be true. The
intent was to check for zero, but the `for` loop inside the `if` was
already doing that.