### PR TITLE
[Clang] [Sema] Ensure noexcept(typeid(E)) checks if E throws when needed

### DIFF
--- a/clang/lib/Sema/SemaExceptionSpec.cpp
+++ b/clang/lib/Sema/SemaExceptionSpec.cpp
@@ -1111,12 +1111,16 @@ static CanThrowResult canDynamicCastThrow(const CXXDynamicCastExpr *DC) {
 }
 
 static CanThrowResult canTypeidThrow(Sema &S, const CXXTypeidExpr *DC) {
-  // Operand is not evaluated, cannot possibly throw.
-  if (!DC->isPotentiallyEvaluated())
+  // A typeid of a type is a constant and does not throw.
+  if (DC->isTypeOperand())
     return CT_Cannot;
 
   if (DC->isValueDependent())
     return CT_Dependent;
+
+  // If this operand is not evaluated it cannot possibly throw.
+  if (!DC->isPotentiallyEvaluated())
+    return CT_Cannot;
 
   // Can throw std::bad_typeid if a nullptr is dereferenced.
   if (DC->hasNullCheck())

--- a/clang/lib/Sema/SemaExceptionSpec.cpp
+++ b/clang/lib/Sema/SemaExceptionSpec.cpp
@@ -1111,14 +1111,14 @@ static CanThrowResult canDynamicCastThrow(const CXXDynamicCastExpr *DC) {
 }
 
 static CanThrowResult canTypeidThrow(Sema &S, const CXXTypeidExpr *DC) {
-  // Operand is not evaluated, cannot possibly throw
+  // Operand is not evaluated, cannot possibly throw.
   if (!DC->isPotentiallyEvaluated())
     return CT_Cannot;
 
   if (DC->isValueDependent())
     return CT_Dependent;
 
-  // Can throw std::bad_typeid if a nullptr is dereferenced
+  // Can throw std::bad_typeid if a nullptr is dereferenced.
   if (DC->hasNullCheck())
     return CT_Can;
 

--- a/clang/test/SemaCXX/cxx0x-noexcept-expression.cpp
+++ b/clang/test/SemaCXX/cxx0x-noexcept-expression.cpp
@@ -124,31 +124,36 @@ struct X {
 template<typename T>
 void f1() {
   X<noexcept(typeid(*T{}))> dependent;
-  dependent.f<void>();
+  // `dependent` should be type-dependent because the noexcept-expression should be value-dependent
+  // (it is true if T is int*, false if T is Polymorphic<false, false>* for example)
+  dependent.f<void>();  // This should need to be `.template f` to parse as a template
   // expected-error@-1 {{use 'template' keyword to treat 'f' as a dependent template name}}
 }
 template<typename... T>
 void f2() {
   X<noexcept(typeid(*((static_cast<Polymorphic<false, false>*>(nullptr) && ... && T{}))))> dependent;
+  // X<true> when T...[0] is a type with some operator&& which returns int*
+  // X<false> when sizeof...(T) == 0
   dependent.f<void>();
   // expected-error@-1 {{use 'template' keyword to treat 'f' as a dependent template name}}
 }
 template<typename T>
 void f3() {
   X<noexcept(typeid(*static_cast<T*>(nullptr)))> dependent;
+  // X<true> when T is int, X<false> when T is Polymorphic<false, false>
   dependent.f<void>();
   // expected-error@-1 {{use 'template' keyword to treat 'f' as a dependent template name}}
 }
 template<typename T>
 void f4() {
   X<noexcept(typeid(T))> not_dependent;
-  not_dependent.non_existant();
-  // expected-error@-1 {{no member named 'non_existant' in 'typeid_::X<true>'}}
+  not_dependent.non_existent();
+  // expected-error@-1 {{no member named 'non_existent' in 'typeid_::X<true>'}}
 }
 template<typename T>
 void f5() {
   X<noexcept(typeid(sizeof(sizeof(T))))> not_dependent;
-  not_dependent.non_existant();
-  // expected-error@-1 {{no member named 'non_existant' in 'typeid_::X<true>'}}
+  not_dependent.non_existent();
+  // expected-error@-1 {{no member named 'non_existent' in 'typeid_::X<true>'}}
 }
 } // namespace typeid_


### PR DESCRIPTION
3ad31e12ccfc7db25f3cbedc4ee966e7099ac78f changed it so that not all potentially-evaluated `typeid`s were marked as potentially-throwing, but I forgot to check the subexpression if the null check of the `typeid` didn't potentially-throw. This adds that check.