### PR TITLE
[NFC][NVPTX][test] Update test for `fneg half`

### DIFF
--- a/llvm/test/CodeGen/NVPTX/f16-instructions.ll
+++ b/llvm/test/CodeGen/NVPTX/f16-instructions.ll
@@ -131,8 +131,8 @@ define half @test_fsub(half %a, half %b) #0 {
   ret half %r
 }
 
-; CHECK-LABEL: test_fneg(
-; CHECK-DAG:  ld.param.b16    [[A:%rs[0-9]+]], [test_fneg_param_0];
+; CHECK-LABEL: test_old_fneg(
+; CHECK-DAG:  ld.param.b16    [[A:%rs[0-9]+]], [test_old_fneg_param_0];
 ; CHECK-F16-NOFTZ-NEXT:   mov.b16        [[Z:%rs[0-9]+]], 0x0000
 ; CHECK-F16-NOFTZ-NEXT:   sub.rn.f16     [[R:%rs[0-9]+]], [[Z]], [[A]];
 ; CHECK-F16-FTZ-NEXT:   mov.b16        [[Z:%rs[0-9]+]], 0x0000
@@ -143,8 +143,18 @@ define half @test_fsub(half %a, half %b) #0 {
 ; CHECK-NOF16-NEXT: cvt.rn.f16.f32 [[R:%rs[0-9]+]], [[R32]]
 ; CHECK-NEXT: st.param.b16    [func_retval0+0], [[R]];
 ; CHECK-NEXT: ret;
-define half @test_fneg(half %a) #0 {
+define half @test_old_fneg(half %a) #0 {
   %r = fsub half 0.0, %a
+  ret half %r
+}
+
+; CHECK-LABEL: test_fneg(
+; CHECK-DAG:  ld.param.b16    [[A:%rs[0-9]+]], [test_fneg_param_0];
+; CHECK-NEXT: xor.b16    [[R:%rs[0-9]+]], [[A]], -32768;
+; CHECK-NEXT: st.param.b16    [func_retval0+0], [[R]];
+; CHECK-NEXT: ret;
+define half @test_fneg(half %a) #0 {
+  %r = fneg half %a
   ret half %r
 }
 

--- a/llvm/test/CodeGen/NVPTX/f16-instructions.ll
+++ b/llvm/test/CodeGen/NVPTX/f16-instructions.ll
@@ -149,8 +149,10 @@ define half @test_old_fneg(half %a) #0 {
 }
 
 ; CHECK-LABEL: test_fneg(
-; CHECK-DAG:  ld.param.b16    [[A:%rs[0-9]+]], [test_fneg_param_0];
-; CHECK-NEXT: xor.b16    [[R:%rs[0-9]+]], [[A]], -32768;
+; CHECK:  ld.param.b16    [[A:%rs[0-9]+]], [test_fneg_param_0];
+; CHECK-F16-NOFTZ-NEXT:   neg.f16     [[R:%rs[0-9]+]], [[A]];
+; CHECK-F16-FTZ-NEXT:   neg.ftz.f16     [[R:%rs[0-9]+]], [[A]];
+; CHECK-NOF16-NEXT:  xor.b16    [[R:%rs[0-9]+]], [[A]], -32768;
 ; CHECK-NEXT: st.param.b16    [func_retval0+0], [[R]];
 ; CHECK-NEXT: ret;
 define half @test_fneg(half %a) #0 {


### PR DESCRIPTION
`test_fneg` function uses `fsub half 0.0, %x`. Add a test that uses the `fneg` instruction directly.