### PR TITLE
[Support] Add llvm::xxh3_128bits

### DIFF
--- a/llvm/include/llvm/Support/xxhash.h
+++ b/llvm/include/llvm/Support/xxhash.h
@@ -42,6 +42,7 @@
 #include "llvm/ADT/StringRef.h"
 
 namespace llvm {
+
 uint64_t xxHash64(llvm::StringRef Data);
 uint64_t xxHash64(llvm::ArrayRef<uint8_t> Data);
 
@@ -49,6 +50,30 @@ uint64_t xxh3_64bits(ArrayRef<uint8_t> data);
 inline uint64_t xxh3_64bits(StringRef data) {
   return xxh3_64bits(ArrayRef(data.bytes_begin(), data.size()));
 }
-}
+
+/*-**********************************************************************
+ *  XXH3 128-bit variant
+ ************************************************************************/
+
+/*!
+ * @brief The return value from 128-bit hashes.
+ *
+ * Stored in little endian order, although the fields themselves are in native
+ * endianness.
+ */
+struct XXH128_hash_t {
+  uint64_t low64;  /*!< `value & 0xFFFFFFFFFFFFFFFF` */
+  uint64_t high64; /*!< `value >> 64` */
+
+  /// Convenience equality check operator.
+  bool operator==(const XXH128_hash_t rhs) const {
+    return low64 == rhs.low64 && high64 == rhs.high64;
+  }
+};
+
+/// XXH3's 128-bit variant.
+XXH128_hash_t xxh3_128bits(ArrayRef<uint8_t> data);
+
+} // namespace llvm
 
 #endif

--- a/llvm/unittests/Support/xxhashTest.cpp
+++ b/llvm/unittests/Support/xxhashTest.cpp
@@ -11,6 +11,26 @@
 
 using namespace llvm;
 
+/* use #define to make them constant, required for initialization */
+#define PRIME32 2654435761U
+#define PRIME64 11400714785074694797ULL
+
+/*
+ * Fills a test buffer with pseudorandom data.
+ *
+ * This is used in the sanity check - its values must not be changed.
+ */
+static void fillTestBuffer(uint8_t *buffer, size_t len) {
+  uint64_t byteGen = PRIME32;
+
+  assert(buffer != NULL);
+
+  for (size_t i = 0; i < len; i++) {
+    buffer[i] = (uint8_t)(byteGen >> 56);
+    byteGen *= PRIME64;
+  }
+}
+
 TEST(xxhashTest, Basic) {
   EXPECT_EQ(0xef46db3751d8e999U, xxHash64(StringRef()));
   EXPECT_EQ(0x33bf00a859c4ba3fU, xxHash64("foo"));
@@ -59,5 +79,54 @@ TEST(xxhashTest, xxh3) {
   F(2049, 0x3ba6afa0249fef9a);
   F(2240, 0xd61d4d2a94e926a8);
   F(2243, 0x0979f786a24edde7);
+#undef F
+}
+
+TEST(xxhashTest, xxh3_128bits) {
+#define SANITY_BUFFER_SIZE 2367
+  uint8_t sanityBuffer[SANITY_BUFFER_SIZE];
+
+  fillTestBuffer(sanityBuffer, sizeof(sanityBuffer));
+
+#define F(len, expected)                                                       \
+  EXPECT_EQ(XXH128_hash_t(expected),                                           \
+            xxh3_128bits(ArrayRef(sanityBuffer, size_t(len))))
+
+  F(0, (XXH128_hash_t{0x6001C324468D497FULL,
+                      0x99AA06D3014798D8ULL})); /* empty string */
+  F(1, (XXH128_hash_t{0xC44BDFF4074EECDBULL,
+                      0xA6CD5E9392000F6AULL})); /*  1 -  3 */
+  F(6, (XXH128_hash_t{0x3E7039BDDA43CFC6ULL,
+                      0x082AFE0B8162D12AULL})); /*  4 -  8 */
+  F(12, (XXH128_hash_t{0x061A192713F69AD9ULL,
+                       0x6E3EFD8FC7802B18ULL})); /*  9 - 16 */
+  F(24, (XXH128_hash_t{0x1E7044D28B1B901DULL,
+                       0x0CE966E4678D3761ULL})); /* 17 - 32 */
+  F(48, (XXH128_hash_t{0xF942219AED80F67BULL,
+                       0xA002AC4E5478227EULL})); /* 33 - 64 */
+  F(81, (XXH128_hash_t{0x5E8BAFB9F95FB803ULL,
+                       0x4952F58181AB0042ULL})); /* 65 - 96 */
+  F(222, (XXH128_hash_t{0xF1AEBD597CEC6B3AULL,
+                        0x337E09641B948717ULL})); /* 129-240 */
+  F(403,
+    (XXH128_hash_t{
+        0xCDEB804D65C6DEA4ULL,
+        0x1B6DE21E332DD73DULL})); /* one block, last stripe is overlapping */
+  F(512,
+    (XXH128_hash_t{
+        0x617E49599013CB6BULL,
+        0x18D2D110DCC9BCA1ULL})); /* one block, finishing at stripe boundary */
+  F(2048,
+    (XXH128_hash_t{
+        0xDD59E2C3A5F038E0ULL,
+        0xF736557FD47073A5ULL})); /* 2 blocks, finishing at block boundary */
+  F(2240,
+    (XXH128_hash_t{
+        0x6E73A90539CF2948ULL,
+        0xCCB134FBFA7CE49DULL})); /* 3 blocks, finishing at stripe boundary */
+  F(2367,
+    (XXH128_hash_t{
+        0xCB37AEB9E5D361EDULL,
+        0xE89C0F6FF369B427ULL})); /* 3 blocks, last stripe is overlapping */
 #undef F
 }


### PR DESCRIPTION
Add a 128-bit xxhash function, following the existing `llvm::xxh3_64bits` and `llvm::xxHash` implementations. Previously, 48e93f57f1ee914ca29aa31bf2ccd916565a3610 added support for `llvm::xxh3_64bits`, which closely follows the upstream implementation at https://github.com/Cyan4973/xxHash, with simplifications from Devin Hussey's xxhash-clean.
However, it is desirable to have a larger 128-bit hash key for use cases such as filesystem checksums where chance of collision needs to be negligible.

So to that end this also ports over the 128-bit xxh3_128bits as `llvm::xxh3_128bits`.

Testing:
- Add a test based on xsum_sanity_check.c in upstream xxhash.

CC: @MaskRay @Mogball 