### PR TITLE
[JITLink] Add x86_64::Delta8 edge kind, ELF::R_X86_64_PC8 support

### DIFF
--- a/llvm/include/llvm/ExecutionEngine/JITLink/x86_64.h
+++ b/llvm/include/llvm/ExecutionEngine/JITLink/x86_64.h
@@ -95,6 +95,19 @@ enum EdgeKind_x86_64 : Edge::Kind {
   ///
   Delta32,
 
+  /// An 8-bit delta.
+  ///
+  /// Delta from the fixup to the target.
+  ///
+  /// Fixup expression:
+  ///   Fixup <- Target - Fixup + Addend : int64
+  ///
+  /// Errors:
+  ///   - The result of the fixup expression must fit into an int8, otherwise
+  ///     an out-of-range error will be returned.
+  ///
+  Delta8,
+
   /// A 64-bit negative delta.
   ///
   /// Delta from target back to the fixup.
@@ -467,6 +480,15 @@ inline Error applyFixup(LinkGraph &G, Block &B, const Edge &E,
   case Delta32: {
     int64_t Value = E.getTarget().getAddress() - FixupAddress + E.getAddend();
     if (LLVM_LIKELY(isInt<32>(Value)))
+      *(little32_t *)FixupPtr = Value;
+    else
+      return makeTargetOutOfRangeError(G, B, E);
+    break;
+  }
+
+  case Delta8: {
+    int64_t Value = E.getTarget().getAddress() - FixupAddress + E.getAddend();
+    if (LLVM_LIKELY(isInt<8>(Value)))
       *(little32_t *)FixupPtr = Value;
     else
       return makeTargetOutOfRangeError(G, B, E);

--- a/llvm/include/llvm/ExecutionEngine/JITLink/x86_64.h
+++ b/llvm/include/llvm/ExecutionEngine/JITLink/x86_64.h
@@ -87,7 +87,7 @@ enum EdgeKind_x86_64 : Edge::Kind {
   /// Delta from the fixup to the target.
   ///
   /// Fixup expression:
-  ///   Fixup <- Target - Fixup + Addend : int64
+  ///   Fixup <- Target - Fixup + Addend : int32
   ///
   /// Errors:
   ///   - The result of the fixup expression must fit into an int32, otherwise
@@ -100,7 +100,7 @@ enum EdgeKind_x86_64 : Edge::Kind {
   /// Delta from the fixup to the target.
   ///
   /// Fixup expression:
-  ///   Fixup <- Target - Fixup + Addend : int64
+  ///   Fixup <- Target - Fixup + Addend : int8
   ///
   /// Errors:
   ///   - The result of the fixup expression must fit into an int8, otherwise

--- a/llvm/include/llvm/ExecutionEngine/JITLink/x86_64.h
+++ b/llvm/include/llvm/ExecutionEngine/JITLink/x86_64.h
@@ -489,7 +489,7 @@ inline Error applyFixup(LinkGraph &G, Block &B, const Edge &E,
   case Delta8: {
     int64_t Value = E.getTarget().getAddress() - FixupAddress + E.getAddend();
     if (LLVM_LIKELY(isInt<8>(Value)))
-      *(little32_t *)FixupPtr = Value;
+      *FixupPtr = Value;
     else
       return makeTargetOutOfRangeError(G, B, E);
     break;

--- a/llvm/lib/ExecutionEngine/JITLink/ELF_x86_64.cpp
+++ b/llvm/lib/ExecutionEngine/JITLink/ELF_x86_64.cpp
@@ -153,6 +153,9 @@ private:
     Edge::Kind Kind = Edge::Invalid;
 
     switch (ELFReloc) {
+    case ELF::R_X86_64_PC8:
+      Kind = x86_64::Delta8;
+      break;
     case ELF::R_X86_64_PC32:
     case ELF::R_X86_64_GOTPC32:
       Kind = x86_64::Delta32;

--- a/llvm/lib/ExecutionEngine/JITLink/x86_64.cpp
+++ b/llvm/lib/ExecutionEngine/JITLink/x86_64.cpp
@@ -34,6 +34,8 @@ const char *getEdgeKindName(Edge::Kind K) {
     return "Delta64";
   case Delta32:
     return "Delta32";
+  case Delta8:
+    return "Delta8";
   case NegDelta64:
     return "NegDelta64";
   case NegDelta32:

--- a/llvm/test/ExecutionEngine/JITLink/x86-64/ELF_R_X86_64_PC8.s
+++ b/llvm/test/ExecutionEngine/JITLink/x86-64/ELF_R_X86_64_PC8.s
@@ -1,0 +1,19 @@
+# RUN: llvm-mc -triple=x86_64-unknown-linux -position-independent \
+# RUN:     -filetype=obj -o %t.o %s
+# RUN: llvm-jitlink -noexec %t.o
+#
+# Check R_X86_64_PC8 handling.
+
+	.text
+	.globl	main
+	.type	main,@function
+main:
+	xorl	%eax, %eax
+	retq
+	.size	main, .-main
+
+	.type	P,@object
+	.globl	P
+P:
+	.byte main-. # Generate R_X86_64_PC8 relocation.
+  .size P, .-P


### PR DESCRIPTION
Add support for ELF::R_X86_64_PC8 relocation via new x86_64::Delta8 edge kind.