### PR TITLE
[lldb] Suppress unsupported language warning for assembly

### DIFF
--- a/lldb/source/Target/Process.cpp
+++ b/lldb/source/Target/Process.cpp
@@ -5924,7 +5924,9 @@ void Process::PrintWarningUnsupportedLanguage(const SymbolContext &sc) {
   if (!sc.module_sp)
     return;
   LanguageType language = sc.GetLanguage();
-  if (language == eLanguageTypeUnknown)
+  if (language == eLanguageTypeUnknown ||
+      language == lldb::eLanguageTypeAssembly ||
+      language == lldb::eLanguageTypeMipsAssembler)
     return;
   LanguageSet plugins =
       PluginManager::GetAllTypeSystemSupportedLanguagesForTypes();

--- a/lldb/test/Shell/Process/UnsupportedLanguage.test
+++ b/lldb/test/Shell/Process/UnsupportedLanguage.test
@@ -1,8 +1,17 @@
-Test warnings.
+Test unsupported language warning
+
 REQUIRES: shell
+
 RUN: %clang_host %S/Inputs/true.c -std=c99 -g -c -S -emit-llvm -o - \
 RUN:   | sed -e 's/DW_LANG_C99/DW_LANG_Mips_Assembler/g' >%t.ll
 RUN: %clang_host %t.ll -g -o %t.exe
-RUN: %lldb -o "b main" -o r -o q -b %t.exe 2>&1 | FileCheck %s
+RUN: %lldb -o "b main" -o r -o q -b %t.exe 2>&1 | FileCheck %s --check-prefix ASM
 
-CHECK: This version of LLDB has no plugin for the language "assembler"
+ASM-NOT: This version of LLDB has no plugin for the language "assembler"
+
+RUN: %clang_host %S/Inputs/true.c -std=c99 -g -c -S -emit-llvm -o - \
+RUN:   | sed -e 's/DW_LANG_C99/DW_LANG_Cobol74/g' >%t.ll
+RUN: %clang_host %t.ll -g -o %t.exe
+RUN: %lldb -o "b main" -o r -o q -b %t.exe 2>&1 | FileCheck %s --check-prefix COBOL
+
+COBOL-NOT: This version of LLDB has no plugin for the language "cobol"

--- a/lldb/test/Shell/Process/UnsupportedLanguage.test
+++ b/lldb/test/Shell/Process/UnsupportedLanguage.test
@@ -14,4 +14,4 @@ RUN:   | sed -e 's/DW_LANG_C99/DW_LANG_Cobol74/g' >%t.ll
 RUN: %clang_host %t.ll -g -o %t.exe
 RUN: %lldb -o "b main" -o r -o q -b %t.exe 2>&1 | FileCheck %s --check-prefix COBOL
 
-COBOL-NOT: This version of LLDB has no plugin for the language "cobol"
+COBOL: This version of LLDB has no plugin for the language "cobol74"


### PR DESCRIPTION
The following warning is technically correct, but pretty much useless, since there aren't any frame variables that we'd expect the debugger to understand.

> This version of LLDB has no plugin for the language "assembler".
> Inspection of frame variables will be limited.

This message is useful in the general case but should be suppressed for the "assembler" case.

rdar://92745462