### PR TITLE
[scudo] Test secondary cache options only if enabled

### DIFF
--- a/compiler-rt/lib/scudo/standalone/tests/secondary_test.cpp
+++ b/compiler-rt/lib/scudo/standalone/tests/secondary_test.cpp
@@ -191,12 +191,13 @@ TEST_F(MapAllocatorTest, SecondaryIterate) {
 }
 
 TEST_F(MapAllocatorTest, SecondaryOptions) {
-  // Attempt to set a maximum number of entries higher than the array size.
-  EXPECT_TRUE(Allocator->setOption(scudo::Option::MaxCacheEntriesCount, 4096U));
-
-  // Attempt to set an invalid (negative) number of entries
-  EXPECT_FALSE(Allocator->setOption(scudo::Option::MaxCacheEntriesCount, -1));
+  // Test options that are only meaningful if the secondary cache is enabled.
   if (Allocator->canCache(0U)) {
+    // Attempt to set a maximum number of entries higher than the array size.
+    EXPECT_TRUE(
+        Allocator->setOption(scudo::Option::MaxCacheEntriesCount, 4096U));
+    // Attempt to set an invalid (negative) number of entries
+    EXPECT_FALSE(Allocator->setOption(scudo::Option::MaxCacheEntriesCount, -1));
     // Various valid combinations.
     EXPECT_TRUE(Allocator->setOption(scudo::Option::MaxCacheEntriesCount, 4U));
     EXPECT_TRUE(


### PR DESCRIPTION
Configs that use `MapAllocatorNoCache` for its secondary cache will return `false` if `setOption` is called with some [specific options](https://github.com/llvm/llvm-project/blob/main/compiler-rt/lib/scudo/standalone/secondary.h#L104), and this breaks with the `SecondaryOptions` test.

This change will gate testing all `setOption` expectations for cache options only if the allocator cache is enabled. This will unblock [github.com/llvm/llvm-project/pull/95595 ](https://github.com/llvm/llvm-project/pull/95595) from merging into Fuchsia.