### PR TITLE
[clang-format][NFC] Add CMake target clang-format-check-format

### DIFF
--- a/clang/lib/Format/CMakeLists.txt
+++ b/clang/lib/Format/CMakeLists.txt
@@ -29,3 +29,27 @@ add_clang_library(clangFormat
   clangToolingCore
   clangToolingInclusions
   )
+
+file(GLOB_RECURSE files
+  *.cpp
+  *.h
+  ../../include/clang/Format/*.h
+  ../../tools/clang-format/*.cpp
+  ../../unittests/Format/*.cpp
+  ../../unittests/Format/*.h
+  )
+
+set(check_format_depends)
+set(i 0)
+foreach (file IN LISTS files)
+  add_custom_command(OUTPUT clang-format-check-format${i}
+    COMMAND clang-format ${file} | diff -u ${file} -
+    VERBATIM
+    COMMENT "Checking format of ${file}..."
+  )
+  list(APPEND check_format_depends "clang-format-check-format${i}")
+
+  math(EXPR i ${i}+1)
+endforeach ()
+
+add_custom_target(clang-format-check-format DEPENDS ${check_format_depends})


### PR DESCRIPTION
Adapted from polly-check-format.