### PR TITLE
[libc++][NFC] Run clang-format on libcxx/include again

### DIFF
--- a/libcxx/include/__algorithm/comp_ref_type.h
+++ b/libcxx/include/__algorithm/comp_ref_type.h
@@ -41,9 +41,9 @@ struct __debug_less {
   }
 
   template <class _LHS, class _RHS>
-  _LIBCPP_CONSTEXPR_SINCE_CXX14 inline _LIBCPP_HIDE_FROM_ABI decltype((void)std::declval<_Compare&>()(
-      std::declval<_LHS&>(), std::declval<_RHS&>()))
-  __do_compare_assert(int, _LHS& __l, _RHS& __r) {
+  _LIBCPP_CONSTEXPR_SINCE_CXX14 inline
+      _LIBCPP_HIDE_FROM_ABI decltype((void)std::declval<_Compare&>()(std::declval<_LHS&>(), std::declval<_RHS&>()))
+      __do_compare_assert(int, _LHS& __l, _RHS& __r) {
     _LIBCPP_ASSERT_SEMANTIC_REQUIREMENT(!__comp_(__l, __r), "Comparator does not induce a strict weak ordering");
     (void)__l;
     (void)__r;

--- a/libcxx/include/__algorithm/make_projected.h
+++ b/libcxx/include/__algorithm/make_projected.h
@@ -36,8 +36,8 @@ struct _ProjectedPred {
       : __pred(__pred_arg), __proj(__proj_arg) {}
 
   template <class _Tp>
-  typename __invoke_of<_Pred&, decltype(std::__invoke(std::declval<_Proj&>(), std::declval<_Tp>())) >::
-      type _LIBCPP_CONSTEXPR _LIBCPP_HIDE_FROM_ABI
+  typename __invoke_of<_Pred&, decltype(std::__invoke(std::declval<_Proj&>(), std::declval<_Tp>()))>::type
+      _LIBCPP_CONSTEXPR _LIBCPP_HIDE_FROM_ABI
       operator()(_Tp&& __v) const {
     return std::__invoke(__pred, std::__invoke(__proj, std::forward<_Tp>(__v)));
   }
@@ -45,8 +45,8 @@ struct _ProjectedPred {
   template <class _T1, class _T2>
   typename __invoke_of<_Pred&,
                        decltype(std::__invoke(std::declval<_Proj&>(), std::declval<_T1>())),
-                       decltype(std::__invoke(std::declval<_Proj&>(),
-                                              std::declval<_T2>())) >::type _LIBCPP_CONSTEXPR _LIBCPP_HIDE_FROM_ABI
+                       decltype(std::__invoke(std::declval<_Proj&>(), std::declval<_T2>()))>::type _LIBCPP_CONSTEXPR
+  _LIBCPP_HIDE_FROM_ABI
   operator()(_T1&& __lhs, _T2&& __rhs) const {
     return std::__invoke(
         __pred, std::__invoke(__proj, std::forward<_T1>(__lhs)), std::__invoke(__proj, std::forward<_T2>(__rhs)));

--- a/libcxx/include/__atomic/atomic_init.h
+++ b/libcxx/include/__atomic/atomic_init.h
@@ -15,10 +15,8 @@
 #  pragma GCC system_header
 #endif
 
-#define ATOMIC_FLAG_INIT                                                                                               \
-  { false }
-#define ATOMIC_VAR_INIT(__v)                                                                                           \
-  { __v }
+#define ATOMIC_FLAG_INIT {false}
+#define ATOMIC_VAR_INIT(__v) {__v}
 
 #if _LIBCPP_STD_VER >= 20 && !defined(_LIBCPP_DISABLE_DEPRECATION_WARNINGS)
 #  pragma clang deprecated(ATOMIC_VAR_INIT)

--- a/libcxx/include/__bit_reference
+++ b/libcxx/include/__bit_reference
@@ -95,8 +95,8 @@ public:
   }
 
 private:
-  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 explicit __bit_reference(
-      __storage_pointer __s, __storage_type __m) _NOEXCEPT
+  _LIBCPP_HIDE_FROM_ABI
+  _LIBCPP_CONSTEXPR_SINCE_CXX20 explicit __bit_reference(__storage_pointer __s, __storage_type __m) _NOEXCEPT
       : __seg_(__s),
         __mask_(__m) {}
 };
@@ -149,7 +149,7 @@ public:
   using __container = typename _Cp::__self;
 
   _LIBCPP_HIDE_FROM_ABI __bit_const_reference(const __bit_const_reference&) = default;
-  __bit_const_reference& operator=(const __bit_const_reference&) = delete;
+  __bit_const_reference& operator=(const __bit_const_reference&)            = delete;
 
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 __bit_const_reference(const __bit_reference<_Cp>& __x) _NOEXCEPT
       : __seg_(__x.__seg_),
@@ -164,8 +164,8 @@ public:
   }
 
 private:
-  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR explicit __bit_const_reference(
-      __storage_pointer __s, __storage_type __m) _NOEXCEPT
+  _LIBCPP_HIDE_FROM_ABI
+  _LIBCPP_CONSTEXPR explicit __bit_const_reference(__storage_pointer __s, __storage_type __m) _NOEXCEPT
       : __seg_(__s),
         __mask_(__m) {}
 };
@@ -939,8 +939,8 @@ public:
   }
 
 private:
-  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 explicit __bit_iterator(
-      __storage_pointer __s, unsigned __ctz) _NOEXCEPT
+  _LIBCPP_HIDE_FROM_ABI
+  _LIBCPP_CONSTEXPR_SINCE_CXX20 explicit __bit_iterator(__storage_pointer __s, unsigned __ctz) _NOEXCEPT
       : __seg_(__s),
         __ctz_(__ctz) {}
 
@@ -999,8 +999,8 @@ private:
   _LIBCPP_CONSTEXPR_SINCE_CXX20 friend __bit_iterator<_Dp, _IC>
       __find_bool(__bit_iterator<_Dp, _IC>, typename _Dp::size_type);
   template <bool _ToCount, class _Dp, bool _IC>
-  friend typename __bit_iterator<_Dp, _IC>::difference_type _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20
-      __count_bool(__bit_iterator<_Dp, _IC>, typename _Dp::size_type);
+  friend typename __bit_iterator<_Dp, _IC>::difference_type _LIBCPP_HIDE_FROM_ABI
+  _LIBCPP_CONSTEXPR_SINCE_CXX20 __count_bool(__bit_iterator<_Dp, _IC>, typename _Dp::size_type);
 };
 
 _LIBCPP_END_NAMESPACE_STD

--- a/libcxx/include/__chrono/duration.h
+++ b/libcxx/include/__chrono/duration.h
@@ -391,8 +391,8 @@ operator<=>(const duration<_Rep1, _Period1>& __lhs, const duration<_Rep2, _Perio
 
 template <class _Rep1, class _Period1, class _Rep2, class _Period2>
 inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR
-    typename common_type<duration<_Rep1, _Period1>, duration<_Rep2, _Period2> >::type
-    operator+(const duration<_Rep1, _Period1>& __lhs, const duration<_Rep2, _Period2>& __rhs) {
+typename common_type<duration<_Rep1, _Period1>, duration<_Rep2, _Period2> >::type
+operator+(const duration<_Rep1, _Period1>& __lhs, const duration<_Rep2, _Period2>& __rhs) {
   typedef typename common_type<duration<_Rep1, _Period1>, duration<_Rep2, _Period2> >::type _Cd;
   return _Cd(_Cd(__lhs).count() + _Cd(__rhs).count());
 }
@@ -401,8 +401,8 @@ inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR
 
 template <class _Rep1, class _Period1, class _Rep2, class _Period2>
 inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR
-    typename common_type<duration<_Rep1, _Period1>, duration<_Rep2, _Period2> >::type
-    operator-(const duration<_Rep1, _Period1>& __lhs, const duration<_Rep2, _Period2>& __rhs) {
+typename common_type<duration<_Rep1, _Period1>, duration<_Rep2, _Period2> >::type
+operator-(const duration<_Rep1, _Period1>& __lhs, const duration<_Rep2, _Period2>& __rhs) {
   typedef typename common_type<duration<_Rep1, _Period1>, duration<_Rep2, _Period2> >::type _Cd;
   return _Cd(_Cd(__lhs).count() - _Cd(__rhs).count());
 }
@@ -468,8 +468,8 @@ operator%(const duration<_Rep1, _Period>& __d, const _Rep2& __s) {
 
 template <class _Rep1, class _Period1, class _Rep2, class _Period2>
 inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR
-    typename common_type<duration<_Rep1, _Period1>, duration<_Rep2, _Period2> >::type
-    operator%(const duration<_Rep1, _Period1>& __lhs, const duration<_Rep2, _Period2>& __rhs) {
+typename common_type<duration<_Rep1, _Period1>, duration<_Rep2, _Period2> >::type
+operator%(const duration<_Rep1, _Period1>& __lhs, const duration<_Rep2, _Period2>& __rhs) {
   typedef typename common_type<_Rep1, _Rep2>::type _Cr;
   typedef typename common_type<duration<_Rep1, _Period1>, duration<_Rep2, _Period2> >::type _Cd;
   return _Cd(static_cast<_Cr>(_Cd(__lhs).count()) % static_cast<_Cr>(_Cd(__rhs).count()));

--- a/libcxx/include/__chrono/time_point.h
+++ b/libcxx/include/__chrono/time_point.h
@@ -78,7 +78,7 @@ public:
 
 template <class _Clock, class _Duration1, class _Duration2>
 struct _LIBCPP_TEMPLATE_VIS
-    common_type<chrono::time_point<_Clock, _Duration1>, chrono::time_point<_Clock, _Duration2> > {
+common_type<chrono::time_point<_Clock, _Duration1>, chrono::time_point<_Clock, _Duration2> > {
   typedef chrono::time_point<_Clock, typename common_type<_Duration1, _Duration2>::type> type;
 };
 
@@ -180,9 +180,9 @@ operator<=>(const time_point<_Clock, _Duration1>& __lhs, const time_point<_Clock
 // time_point operator+(time_point x, duration y);
 
 template <class _Clock, class _Duration1, class _Rep2, class _Period2>
-inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14
-    time_point<_Clock, typename common_type<_Duration1, duration<_Rep2, _Period2> >::type>
-    operator+(const time_point<_Clock, _Duration1>& __lhs, const duration<_Rep2, _Period2>& __rhs) {
+inline _LIBCPP_HIDE_FROM_ABI
+_LIBCPP_CONSTEXPR_SINCE_CXX14 time_point<_Clock, typename common_type<_Duration1, duration<_Rep2, _Period2> >::type>
+operator+(const time_point<_Clock, _Duration1>& __lhs, const duration<_Rep2, _Period2>& __rhs) {
   typedef time_point<_Clock, typename common_type<_Duration1, duration<_Rep2, _Period2> >::type> _Tr;
   return _Tr(__lhs.time_since_epoch() + __rhs);
 }
@@ -190,18 +190,18 @@ inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14
 // time_point operator+(duration x, time_point y);
 
 template <class _Rep1, class _Period1, class _Clock, class _Duration2>
-inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14
-    time_point<_Clock, typename common_type<duration<_Rep1, _Period1>, _Duration2>::type>
-    operator+(const duration<_Rep1, _Period1>& __lhs, const time_point<_Clock, _Duration2>& __rhs) {
+inline _LIBCPP_HIDE_FROM_ABI
+_LIBCPP_CONSTEXPR_SINCE_CXX14 time_point<_Clock, typename common_type<duration<_Rep1, _Period1>, _Duration2>::type>
+operator+(const duration<_Rep1, _Period1>& __lhs, const time_point<_Clock, _Duration2>& __rhs) {
   return __rhs + __lhs;
 }
 
 // time_point operator-(time_point x, duration y);
 
 template <class _Clock, class _Duration1, class _Rep2, class _Period2>
-inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14
-    time_point<_Clock, typename common_type<_Duration1, duration<_Rep2, _Period2> >::type>
-    operator-(const time_point<_Clock, _Duration1>& __lhs, const duration<_Rep2, _Period2>& __rhs) {
+inline _LIBCPP_HIDE_FROM_ABI
+_LIBCPP_CONSTEXPR_SINCE_CXX14 time_point<_Clock, typename common_type<_Duration1, duration<_Rep2, _Period2> >::type>
+operator-(const time_point<_Clock, _Duration1>& __lhs, const duration<_Rep2, _Period2>& __rhs) {
   typedef time_point<_Clock, typename common_type<_Duration1, duration<_Rep2, _Period2> >::type> _Ret;
   return _Ret(__lhs.time_since_epoch() - __rhs);
 }

--- a/libcxx/include/__config
+++ b/libcxx/include/__config
@@ -566,7 +566,7 @@ typedef __char32_t char32_t;
 #  ifndef _LIBCPP_NO_ABI_TAG
 #    define _LIBCPP_HIDE_FROM_ABI                                                                                      \
       _LIBCPP_HIDDEN _LIBCPP_EXCLUDE_FROM_EXPLICIT_INSTANTIATION                                                       \
-          __attribute__((__abi_tag__(_LIBCPP_TOSTRING(_LIBCPP_ODR_SIGNATURE))))
+      __attribute__((__abi_tag__(_LIBCPP_TOSTRING(_LIBCPP_ODR_SIGNATURE))))
 #  else
 #    define _LIBCPP_HIDE_FROM_ABI _LIBCPP_HIDDEN _LIBCPP_EXCLUDE_FROM_EXPLICIT_INSTANTIATION
 #  endif
@@ -583,11 +583,11 @@ typedef __char32_t char32_t;
 #  endif
 
 // TODO: Remove this workaround once we drop support for Clang 16
-#if __has_warning("-Wc++23-extensions")
-#  define _LIBCPP_CLANG_DIAGNOSTIC_IGNORED_CXX23_EXTENSION _LIBCPP_CLANG_DIAGNOSTIC_IGNORED("-Wc++23-extensions")
-#else
-#  define _LIBCPP_CLANG_DIAGNOSTIC_IGNORED_CXX23_EXTENSION _LIBCPP_CLANG_DIAGNOSTIC_IGNORED("-Wc++2b-extensions")
-#endif
+#  if __has_warning("-Wc++23-extensions")
+#    define _LIBCPP_CLANG_DIAGNOSTIC_IGNORED_CXX23_EXTENSION _LIBCPP_CLANG_DIAGNOSTIC_IGNORED("-Wc++23-extensions")
+#  else
+#    define _LIBCPP_CLANG_DIAGNOSTIC_IGNORED_CXX23_EXTENSION _LIBCPP_CLANG_DIAGNOSTIC_IGNORED("-Wc++2b-extensions")
+#  endif
 
 // Clang modules take a significant compile time hit when pushing and popping diagnostics.
 // Since all the headers are marked as system headers in the modulemap, we can simply disable this

--- a/libcxx/include/__configuration/abi.h
+++ b/libcxx/include/__configuration/abi.h
@@ -90,7 +90,7 @@
 #  define _LIBCPP_ABI_USE_WRAP_ITER_IN_STD_ARRAY
 #  define _LIBCPP_ABI_USE_WRAP_ITER_IN_STD_STRING_VIEW
 // Dont' add an inline namespace for `std::filesystem`
-#    define _LIBCPP_ABI_NO_FILESYSTEM_INLINE_NAMESPACE
+#  define _LIBCPP_ABI_NO_FILESYSTEM_INLINE_NAMESPACE
 #elif _LIBCPP_ABI_VERSION == 1
 #  if !(defined(_LIBCPP_OBJECT_FORMAT_COFF) || defined(_LIBCPP_OBJECT_FORMAT_XCOFF))
 // Enable compiling copies of now inline methods into the dylib to support

--- a/libcxx/include/__exception/exception_ptr.h
+++ b/libcxx/include/__exception/exception_ptr.h
@@ -99,15 +99,16 @@ _LIBCPP_HIDE_FROM_ABI exception_ptr make_exception_ptr(_Ep __e) _NOEXCEPT {
   void* __ex = __cxxabiv1::__cxa_allocate_exception(sizeof(_Ep));
 #      ifdef __wasm__
   // In Wasm, a destructor returns its argument
-  (void)__cxxabiv1::__cxa_init_primary_exception(__ex, const_cast<std::type_info*>(&typeid(_Ep)), [](void* __p) -> void* {
+  (void)__cxxabiv1::__cxa_init_primary_exception(
+      __ex, const_cast<std::type_info*>(&typeid(_Ep)), [](void* __p) -> void* {
 #      else
   (void)__cxxabiv1::__cxa_init_primary_exception(__ex, const_cast<std::type_info*>(&typeid(_Ep)), [](void* __p) {
 #      endif
-    std::__destroy_at(static_cast<_Ep2*>(__p));
+        std::__destroy_at(static_cast<_Ep2*>(__p));
 #      ifdef __wasm__
-    return __p;
+        return __p;
 #      endif
-  });
+      });
 
   try {
     ::new (__ex) _Ep2(__e);

--- a/libcxx/include/__format/formatter_output.h
+++ b/libcxx/include/__format/formatter_output.h
@@ -100,8 +100,8 @@ __padding_size(size_t __size, size_t __width, __format_spec::__alignment __align
 ///
 /// This uses a "mass output function" of __format::__output_buffer when possible.
 template <__fmt_char_type _CharT, __fmt_char_type _OutCharT = _CharT>
-_LIBCPP_HIDE_FROM_ABI auto __copy(basic_string_view<_CharT> __str, output_iterator<const _OutCharT&> auto __out_it)
-    -> decltype(__out_it) {
+_LIBCPP_HIDE_FROM_ABI auto
+__copy(basic_string_view<_CharT> __str, output_iterator<const _OutCharT&> auto __out_it) -> decltype(__out_it) {
   if constexpr (std::same_as<decltype(__out_it), std::back_insert_iterator<__format::__output_buffer<_OutCharT>>>) {
     __out_it.__get_container()->__copy(__str);
     return __out_it;
@@ -116,16 +116,16 @@ _LIBCPP_HIDE_FROM_ABI auto __copy(basic_string_view<_CharT> __str, output_iterat
 template <contiguous_iterator _Iterator,
           __fmt_char_type _CharT    = typename iterator_traits<_Iterator>::value_type,
           __fmt_char_type _OutCharT = _CharT>
-_LIBCPP_HIDE_FROM_ABI auto __copy(_Iterator __first, _Iterator __last, output_iterator<const _OutCharT&> auto __out_it)
-    -> decltype(__out_it) {
+_LIBCPP_HIDE_FROM_ABI auto
+__copy(_Iterator __first, _Iterator __last, output_iterator<const _OutCharT&> auto __out_it) -> decltype(__out_it) {
   return __formatter::__copy(basic_string_view{__first, __last}, std::move(__out_it));
 }
 
 template <contiguous_iterator _Iterator,
           __fmt_char_type _CharT    = typename iterator_traits<_Iterator>::value_type,
           __fmt_char_type _OutCharT = _CharT>
-_LIBCPP_HIDE_FROM_ABI auto __copy(_Iterator __first, size_t __n, output_iterator<const _OutCharT&> auto __out_it)
-    -> decltype(__out_it) {
+_LIBCPP_HIDE_FROM_ABI auto
+__copy(_Iterator __first, size_t __n, output_iterator<const _OutCharT&> auto __out_it) -> decltype(__out_it) {
   return __formatter::__copy(basic_string_view{std::to_address(__first), __n}, std::move(__out_it));
 }
 
@@ -136,9 +136,11 @@ template <contiguous_iterator _Iterator,
           __fmt_char_type _CharT    = typename iterator_traits<_Iterator>::value_type,
           __fmt_char_type _OutCharT = _CharT,
           class _UnaryOperation>
-_LIBCPP_HIDE_FROM_ABI auto __transform(
-    _Iterator __first, _Iterator __last, output_iterator<const _OutCharT&> auto __out_it, _UnaryOperation __operation)
-    -> decltype(__out_it) {
+_LIBCPP_HIDE_FROM_ABI auto
+__transform(_Iterator __first,
+            _Iterator __last,
+            output_iterator<const _OutCharT&> auto __out_it,
+            _UnaryOperation __operation) -> decltype(__out_it) {
   if constexpr (std::same_as<decltype(__out_it), std::back_insert_iterator<__format::__output_buffer<_OutCharT>>>) {
     __out_it.__get_container()->__transform(__first, __last, std::move(__operation));
     return __out_it;

--- a/libcxx/include/__functional/bind.h
+++ b/libcxx/include/__functional/bind.h
@@ -105,8 +105,8 @@ struct __mu_return2<true, _Ti, _Uj> {
 
 template <class _Ti, class _Uj, __enable_if_t<0 < is_placeholder<_Ti>::value, int> = 0>
 inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20
-    typename __mu_return2<0 < is_placeholder<_Ti>::value, _Ti, _Uj>::type
-    __mu(_Ti&, _Uj& __uj) {
+typename __mu_return2<0 < is_placeholder<_Ti>::value, _Ti, _Uj>::type
+__mu(_Ti&, _Uj& __uj) {
   const size_t __indx = is_placeholder<_Ti>::value - 1;
   return std::forward<typename tuple_element<__indx, _Uj>::type>(std::get<__indx>(__uj));
 }
@@ -225,8 +225,8 @@ public:
 
   template <class... _Args>
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20
-      typename __bind_return<const _Fd, const _Td, tuple<_Args&&...> >::type
-      operator()(_Args&&... __args) const {
+  typename __bind_return<const _Fd, const _Td, tuple<_Args&&...> >::type
+  operator()(_Args&&... __args) const {
     return std::__apply_functor(__f_, __bound_args_, __indices(), tuple<_Args&&...>(std::forward<_Args>(__args)...));
   }
 };

--- a/libcxx/include/__functional/bind_back.h
+++ b/libcxx/include/__functional/bind_back.h
@@ -52,7 +52,7 @@ struct __bind_back_t : __perfect_forward<__bind_back_op<tuple_size_v<_BoundArgs>
 
 template <class _Fn, class... _Args>
   requires is_constructible_v<decay_t<_Fn>, _Fn> && is_move_constructible_v<decay_t<_Fn>> &&
-           (is_constructible_v<decay_t<_Args>, _Args> && ...) && (is_move_constructible_v<decay_t<_Args>> && ...)
+               (is_constructible_v<decay_t<_Args>, _Args> && ...) && (is_move_constructible_v<decay_t<_Args>> && ...)
 _LIBCPP_HIDE_FROM_ABI constexpr auto __bind_back(_Fn&& __f, _Args&&... __args) noexcept(
     noexcept(__bind_back_t<decay_t<_Fn>, tuple<decay_t<_Args>...>>(
         std::forward<_Fn>(__f), std::forward_as_tuple(std::forward<_Args>(__args)...))))

--- a/libcxx/include/__functional/bind_front.h
+++ b/libcxx/include/__functional/bind_front.h
@@ -29,9 +29,8 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 
 struct __bind_front_op {
   template <class... _Args>
-  _LIBCPP_HIDE_FROM_ABI constexpr auto operator()(_Args&&... __args) const
-      noexcept(noexcept(std::invoke(std::forward<_Args>(__args)...)))
-          -> decltype(std::invoke(std::forward<_Args>(__args)...)) {
+  _LIBCPP_HIDE_FROM_ABI constexpr auto operator()(_Args&&... __args) const noexcept(
+      noexcept(std::invoke(std::forward<_Args>(__args)...))) -> decltype(std::invoke(std::forward<_Args>(__args)...)) {
     return std::invoke(std::forward<_Args>(__args)...);
   }
 };

--- a/libcxx/include/__functional/mem_fn.h
+++ b/libcxx/include/__functional/mem_fn.h
@@ -38,8 +38,8 @@ public:
   template <class... _ArgTypes>
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20
 
-      typename __invoke_return<type, _ArgTypes...>::type
-      operator()(_ArgTypes&&... __args) const {
+  typename __invoke_return<type, _ArgTypes...>::type
+  operator()(_ArgTypes&&... __args) const {
     return std::__invoke(__f_, std::forward<_ArgTypes>(__args)...);
   }
 };

--- a/libcxx/include/__functional/mem_fun_ref.h
+++ b/libcxx/include/__functional/mem_fun_ref.h
@@ -89,8 +89,8 @@ public:
 };
 
 template <class _Sp, class _Tp, class _Ap>
-class _LIBCPP_TEMPLATE_VIS _LIBCPP_DEPRECATED_IN_CXX11 const_mem_fun1_t
-    : public __binary_function<const _Tp*, _Ap, _Sp> {
+class _LIBCPP_TEMPLATE_VIS
+_LIBCPP_DEPRECATED_IN_CXX11 const_mem_fun1_t : public __binary_function<const _Tp*, _Ap, _Sp> {
   _Sp (_Tp::*__p_)(_Ap) const;
 
 public:

--- a/libcxx/include/__functional/operations.h
+++ b/libcxx/include/__functional/operations.h
@@ -50,8 +50,8 @@ template <>
 struct _LIBCPP_TEMPLATE_VIS plus<void> {
   template <class _T1, class _T2>
   _LIBCPP_CONSTEXPR_SINCE_CXX14 _LIBCPP_HIDE_FROM_ABI auto operator()(_T1&& __t, _T2&& __u) const
-      noexcept(noexcept(std::forward<_T1>(__t) + std::forward<_T2>(__u)))
-          -> decltype(std::forward<_T1>(__t) + std::forward<_T2>(__u)) {
+      noexcept(noexcept(std::forward<_T1>(__t) + std::forward<_T2>(__u))) //
+      -> decltype(std::forward<_T1>(__t) + std::forward<_T2>(__u)) {
     return std::forward<_T1>(__t) + std::forward<_T2>(__u);
   }
   typedef void is_transparent;
@@ -76,8 +76,8 @@ template <>
 struct _LIBCPP_TEMPLATE_VIS minus<void> {
   template <class _T1, class _T2>
   _LIBCPP_CONSTEXPR_SINCE_CXX14 _LIBCPP_HIDE_FROM_ABI auto operator()(_T1&& __t, _T2&& __u) const
-      noexcept(noexcept(std::forward<_T1>(__t) - std::forward<_T2>(__u)))
-          -> decltype(std::forward<_T1>(__t) - std::forward<_T2>(__u)) {
+      noexcept(noexcept(std::forward<_T1>(__t) - std::forward<_T2>(__u))) //
+      -> decltype(std::forward<_T1>(__t) - std::forward<_T2>(__u)) {
     return std::forward<_T1>(__t) - std::forward<_T2>(__u);
   }
   typedef void is_transparent;
@@ -102,8 +102,8 @@ template <>
 struct _LIBCPP_TEMPLATE_VIS multiplies<void> {
   template <class _T1, class _T2>
   _LIBCPP_CONSTEXPR_SINCE_CXX14 _LIBCPP_HIDE_FROM_ABI auto operator()(_T1&& __t, _T2&& __u) const
-      noexcept(noexcept(std::forward<_T1>(__t) * std::forward<_T2>(__u)))
-          -> decltype(std::forward<_T1>(__t) * std::forward<_T2>(__u)) {
+      noexcept(noexcept(std::forward<_T1>(__t) * std::forward<_T2>(__u))) //
+      -> decltype(std::forward<_T1>(__t) * std::forward<_T2>(__u)) {
     return std::forward<_T1>(__t) * std::forward<_T2>(__u);
   }
   typedef void is_transparent;
@@ -128,8 +128,8 @@ template <>
 struct _LIBCPP_TEMPLATE_VIS divides<void> {
   template <class _T1, class _T2>
   _LIBCPP_CONSTEXPR_SINCE_CXX14 _LIBCPP_HIDE_FROM_ABI auto operator()(_T1&& __t, _T2&& __u) const
-      noexcept(noexcept(std::forward<_T1>(__t) / std::forward<_T2>(__u)))
-          -> decltype(std::forward<_T1>(__t) / std::forward<_T2>(__u)) {
+      noexcept(noexcept(std::forward<_T1>(__t) / std::forward<_T2>(__u))) //
+      -> decltype(std::forward<_T1>(__t) / std::forward<_T2>(__u)) {
     return std::forward<_T1>(__t) / std::forward<_T2>(__u);
   }
   typedef void is_transparent;
@@ -154,8 +154,8 @@ template <>
 struct _LIBCPP_TEMPLATE_VIS modulus<void> {
   template <class _T1, class _T2>
   _LIBCPP_CONSTEXPR_SINCE_CXX14 _LIBCPP_HIDE_FROM_ABI auto operator()(_T1&& __t, _T2&& __u) const
-      noexcept(noexcept(std::forward<_T1>(__t) % std::forward<_T2>(__u)))
-          -> decltype(std::forward<_T1>(__t) % std::forward<_T2>(__u)) {
+      noexcept(noexcept(std::forward<_T1>(__t) % std::forward<_T2>(__u))) //
+      -> decltype(std::forward<_T1>(__t) % std::forward<_T2>(__u)) {
     return std::forward<_T1>(__t) % std::forward<_T2>(__u);
   }
   typedef void is_transparent;
@@ -178,7 +178,8 @@ template <>
 struct _LIBCPP_TEMPLATE_VIS negate<void> {
   template <class _Tp>
   _LIBCPP_CONSTEXPR_SINCE_CXX14 _LIBCPP_HIDE_FROM_ABI auto operator()(_Tp&& __x) const
-      noexcept(noexcept(-std::forward<_Tp>(__x))) -> decltype(-std::forward<_Tp>(__x)) {
+      noexcept(noexcept(-std::forward<_Tp>(__x))) //
+      -> decltype(-std::forward<_Tp>(__x)) {
     return -std::forward<_Tp>(__x);
   }
   typedef void is_transparent;
@@ -205,8 +206,8 @@ template <>
 struct _LIBCPP_TEMPLATE_VIS bit_and<void> {
   template <class _T1, class _T2>
   _LIBCPP_CONSTEXPR_SINCE_CXX14 _LIBCPP_HIDE_FROM_ABI auto operator()(_T1&& __t, _T2&& __u) const
-      noexcept(noexcept(std::forward<_T1>(__t) & std::forward<_T2>(__u)))
-          -> decltype(std::forward<_T1>(__t) & std::forward<_T2>(__u)) {
+      noexcept(noexcept(std::forward<_T1>(__t) &
+                        std::forward<_T2>(__u))) -> decltype(std::forward<_T1>(__t) & std::forward<_T2>(__u)) {
     return std::forward<_T1>(__t) & std::forward<_T2>(__u);
   }
   typedef void is_transparent;
@@ -224,7 +225,8 @@ template <>
 struct _LIBCPP_TEMPLATE_VIS bit_not<void> {
   template <class _Tp>
   _LIBCPP_CONSTEXPR_SINCE_CXX14 _LIBCPP_HIDE_FROM_ABI auto operator()(_Tp&& __x) const
-      noexcept(noexcept(~std::forward<_Tp>(__x))) -> decltype(~std::forward<_Tp>(__x)) {
+      noexcept(noexcept(~std::forward<_Tp>(__x))) //
+      -> decltype(~std::forward<_Tp>(__x)) {
     return ~std::forward<_Tp>(__x);
   }
   typedef void is_transparent;
@@ -249,8 +251,8 @@ template <>
 struct _LIBCPP_TEMPLATE_VIS bit_or<void> {
   template <class _T1, class _T2>
   _LIBCPP_CONSTEXPR_SINCE_CXX14 _LIBCPP_HIDE_FROM_ABI auto operator()(_T1&& __t, _T2&& __u) const
-      noexcept(noexcept(std::forward<_T1>(__t) | std::forward<_T2>(__u)))
-          -> decltype(std::forward<_T1>(__t) | std::forward<_T2>(__u)) {
+      noexcept(noexcept(std::forward<_T1>(__t) | std::forward<_T2>(__u))) //
+      -> decltype(std::forward<_T1>(__t) | std::forward<_T2>(__u)) {
     return std::forward<_T1>(__t) | std::forward<_T2>(__u);
   }
   typedef void is_transparent;
@@ -275,8 +277,8 @@ template <>
 struct _LIBCPP_TEMPLATE_VIS bit_xor<void> {
   template <class _T1, class _T2>
   _LIBCPP_CONSTEXPR_SINCE_CXX14 _LIBCPP_HIDE_FROM_ABI auto operator()(_T1&& __t, _T2&& __u) const
-      noexcept(noexcept(std::forward<_T1>(__t) ^ std::forward<_T2>(__u)))
-          -> decltype(std::forward<_T1>(__t) ^ std::forward<_T2>(__u)) {
+      noexcept(noexcept(std::forward<_T1>(__t) ^ std::forward<_T2>(__u))) //
+      -> decltype(std::forward<_T1>(__t) ^ std::forward<_T2>(__u)) {
     return std::forward<_T1>(__t) ^ std::forward<_T2>(__u);
   }
   typedef void is_transparent;
@@ -303,8 +305,8 @@ template <>
 struct _LIBCPP_TEMPLATE_VIS equal_to<void> {
   template <class _T1, class _T2>
   _LIBCPP_CONSTEXPR_SINCE_CXX14 _LIBCPP_HIDE_FROM_ABI auto operator()(_T1&& __t, _T2&& __u) const
-      noexcept(noexcept(std::forward<_T1>(__t) == std::forward<_T2>(__u)))
-          -> decltype(std::forward<_T1>(__t) == std::forward<_T2>(__u)) {
+      noexcept(noexcept(std::forward<_T1>(__t) == std::forward<_T2>(__u))) //
+      -> decltype(std::forward<_T1>(__t) == std::forward<_T2>(__u)) {
     return std::forward<_T1>(__t) == std::forward<_T2>(__u);
   }
   typedef void is_transparent;
@@ -338,8 +340,8 @@ template <>
 struct _LIBCPP_TEMPLATE_VIS not_equal_to<void> {
   template <class _T1, class _T2>
   _LIBCPP_CONSTEXPR_SINCE_CXX14 _LIBCPP_HIDE_FROM_ABI auto operator()(_T1&& __t, _T2&& __u) const
-      noexcept(noexcept(std::forward<_T1>(__t) != std::forward<_T2>(__u)))
-          -> decltype(std::forward<_T1>(__t) != std::forward<_T2>(__u)) {
+      noexcept(noexcept(std::forward<_T1>(__t) != std::forward<_T2>(__u))) //
+      -> decltype(std::forward<_T1>(__t) != std::forward<_T2>(__u)) {
     return std::forward<_T1>(__t) != std::forward<_T2>(__u);
   }
   typedef void is_transparent;
@@ -367,8 +369,8 @@ template <>
 struct _LIBCPP_TEMPLATE_VIS less<void> {
   template <class _T1, class _T2>
   _LIBCPP_CONSTEXPR_SINCE_CXX14 _LIBCPP_HIDE_FROM_ABI auto operator()(_T1&& __t, _T2&& __u) const
-      noexcept(noexcept(std::forward<_T1>(__t) < std::forward<_T2>(__u)))
-          -> decltype(std::forward<_T1>(__t) < std::forward<_T2>(__u)) {
+      noexcept(noexcept(std::forward<_T1>(__t) < std::forward<_T2>(__u))) //
+      -> decltype(std::forward<_T1>(__t) < std::forward<_T2>(__u)) {
     return std::forward<_T1>(__t) < std::forward<_T2>(__u);
   }
   typedef void is_transparent;
@@ -396,8 +398,8 @@ template <>
 struct _LIBCPP_TEMPLATE_VIS less_equal<void> {
   template <class _T1, class _T2>
   _LIBCPP_CONSTEXPR_SINCE_CXX14 _LIBCPP_HIDE_FROM_ABI auto operator()(_T1&& __t, _T2&& __u) const
-      noexcept(noexcept(std::forward<_T1>(__t) <= std::forward<_T2>(__u)))
-          -> decltype(std::forward<_T1>(__t) <= std::forward<_T2>(__u)) {
+      noexcept(noexcept(std::forward<_T1>(__t) <= std::forward<_T2>(__u))) //
+      -> decltype(std::forward<_T1>(__t) <= std::forward<_T2>(__u)) {
     return std::forward<_T1>(__t) <= std::forward<_T2>(__u);
   }
   typedef void is_transparent;
@@ -422,8 +424,8 @@ template <>
 struct _LIBCPP_TEMPLATE_VIS greater_equal<void> {
   template <class _T1, class _T2>
   _LIBCPP_CONSTEXPR_SINCE_CXX14 _LIBCPP_HIDE_FROM_ABI auto operator()(_T1&& __t, _T2&& __u) const
-      noexcept(noexcept(std::forward<_T1>(__t) >= std::forward<_T2>(__u)))
-          -> decltype(std::forward<_T1>(__t) >= std::forward<_T2>(__u)) {
+      noexcept(noexcept(std::forward<_T1>(__t) >=
+                        std::forward<_T2>(__u))) -> decltype(std::forward<_T1>(__t) >= std::forward<_T2>(__u)) {
     return std::forward<_T1>(__t) >= std::forward<_T2>(__u);
   }
   typedef void is_transparent;
@@ -448,8 +450,8 @@ template <>
 struct _LIBCPP_TEMPLATE_VIS greater<void> {
   template <class _T1, class _T2>
   _LIBCPP_CONSTEXPR_SINCE_CXX14 _LIBCPP_HIDE_FROM_ABI auto operator()(_T1&& __t, _T2&& __u) const
-      noexcept(noexcept(std::forward<_T1>(__t) > std::forward<_T2>(__u)))
-          -> decltype(std::forward<_T1>(__t) > std::forward<_T2>(__u)) {
+      noexcept(noexcept(std::forward<_T1>(__t) > std::forward<_T2>(__u))) //
+      -> decltype(std::forward<_T1>(__t) > std::forward<_T2>(__u)) {
     return std::forward<_T1>(__t) > std::forward<_T2>(__u);
   }
   typedef void is_transparent;
@@ -476,8 +478,8 @@ template <>
 struct _LIBCPP_TEMPLATE_VIS logical_and<void> {
   template <class _T1, class _T2>
   _LIBCPP_CONSTEXPR_SINCE_CXX14 _LIBCPP_HIDE_FROM_ABI auto operator()(_T1&& __t, _T2&& __u) const
-      noexcept(noexcept(std::forward<_T1>(__t) && std::forward<_T2>(__u)))
-          -> decltype(std::forward<_T1>(__t) && std::forward<_T2>(__u)) {
+      noexcept(noexcept(std::forward<_T1>(__t) && std::forward<_T2>(__u))) //
+      -> decltype(std::forward<_T1>(__t) && std::forward<_T2>(__u)) {
     return std::forward<_T1>(__t) && std::forward<_T2>(__u);
   }
   typedef void is_transparent;
@@ -500,7 +502,8 @@ template <>
 struct _LIBCPP_TEMPLATE_VIS logical_not<void> {
   template <class _Tp>
   _LIBCPP_CONSTEXPR_SINCE_CXX14 _LIBCPP_HIDE_FROM_ABI auto operator()(_Tp&& __x) const
-      noexcept(noexcept(!std::forward<_Tp>(__x))) -> decltype(!std::forward<_Tp>(__x)) {
+      noexcept(noexcept(!std::forward<_Tp>(__x))) //
+      -> decltype(!std::forward<_Tp>(__x)) {
     return !std::forward<_Tp>(__x);
   }
   typedef void is_transparent;
@@ -525,8 +528,8 @@ template <>
 struct _LIBCPP_TEMPLATE_VIS logical_or<void> {
   template <class _T1, class _T2>
   _LIBCPP_CONSTEXPR_SINCE_CXX14 _LIBCPP_HIDE_FROM_ABI auto operator()(_T1&& __t, _T2&& __u) const
-      noexcept(noexcept(std::forward<_T1>(__t) || std::forward<_T2>(__u)))
-          -> decltype(std::forward<_T1>(__t) || std::forward<_T2>(__u)) {
+      noexcept(noexcept(std::forward<_T1>(__t) || std::forward<_T2>(__u))) //
+      -> decltype(std::forward<_T1>(__t) || std::forward<_T2>(__u)) {
     return std::forward<_T1>(__t) || std::forward<_T2>(__u);
   }
   typedef void is_transparent;

--- a/libcxx/include/__functional/pointer_to_binary_function.h
+++ b/libcxx/include/__functional/pointer_to_binary_function.h
@@ -22,8 +22,8 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 #if _LIBCPP_STD_VER <= 14 || defined(_LIBCPP_ENABLE_CXX17_REMOVED_BINDERS)
 
 template <class _Arg1, class _Arg2, class _Result>
-class _LIBCPP_TEMPLATE_VIS _LIBCPP_DEPRECATED_IN_CXX11 pointer_to_binary_function
-    : public __binary_function<_Arg1, _Arg2, _Result> {
+class _LIBCPP_TEMPLATE_VIS
+_LIBCPP_DEPRECATED_IN_CXX11 pointer_to_binary_function : public __binary_function<_Arg1, _Arg2, _Result> {
   _Result (*__f_)(_Arg1, _Arg2);
 
 public:

--- a/libcxx/include/__functional/pointer_to_unary_function.h
+++ b/libcxx/include/__functional/pointer_to_unary_function.h
@@ -22,8 +22,8 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 #if _LIBCPP_STD_VER <= 14 || defined(_LIBCPP_ENABLE_CXX17_REMOVED_BINDERS)
 
 template <class _Arg, class _Result>
-class _LIBCPP_TEMPLATE_VIS _LIBCPP_DEPRECATED_IN_CXX11 pointer_to_unary_function
-    : public __unary_function<_Arg, _Result> {
+class _LIBCPP_TEMPLATE_VIS
+_LIBCPP_DEPRECATED_IN_CXX11 pointer_to_unary_function : public __unary_function<_Arg, _Result> {
   _Result (*__f_)(_Arg);
 
 public:

--- a/libcxx/include/__functional/unary_negate.h
+++ b/libcxx/include/__functional/unary_negate.h
@@ -22,8 +22,8 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 #if _LIBCPP_STD_VER <= 17 || defined(_LIBCPP_ENABLE_CXX20_REMOVED_NEGATORS)
 
 template <class _Predicate>
-class _LIBCPP_TEMPLATE_VIS _LIBCPP_DEPRECATED_IN_CXX17 unary_negate
-    : public __unary_function<typename _Predicate::argument_type, bool> {
+class _LIBCPP_TEMPLATE_VIS
+_LIBCPP_DEPRECATED_IN_CXX17 unary_negate : public __unary_function<typename _Predicate::argument_type, bool> {
   _Predicate __pred_;
 
 public:

--- a/libcxx/include/__iterator/access.h
+++ b/libcxx/include/__iterator/access.h
@@ -54,8 +54,8 @@ _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX17 auto end(const _Cp& __c) -> 
 #  if _LIBCPP_STD_VER >= 14
 
 template <class _Cp>
-_LIBCPP_HIDE_FROM_ABI constexpr auto cbegin(const _Cp& __c) noexcept(noexcept(std::begin(__c)))
-    -> decltype(std::begin(__c)) {
+_LIBCPP_HIDE_FROM_ABI constexpr auto
+cbegin(const _Cp& __c) noexcept(noexcept(std::begin(__c))) -> decltype(std::begin(__c)) {
   return std::begin(__c);
 }
 

--- a/libcxx/include/__iterator/bounded_iter.h
+++ b/libcxx/include/__iterator/bounded_iter.h
@@ -84,8 +84,8 @@ private:
   //
   // Since it is non-standard for iterators to have this constructor, __bounded_iter must
   // be created via `std::__make_bounded_iter`.
-  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 explicit __bounded_iter(
-      _Iterator __current, _Iterator __begin, _Iterator __end)
+  _LIBCPP_HIDE_FROM_ABI
+  _LIBCPP_CONSTEXPR_SINCE_CXX14 explicit __bounded_iter(_Iterator __current, _Iterator __begin, _Iterator __end)
       : __current_(__current), __begin_(__begin), __end_(__end) {
     _LIBCPP_ASSERT_INTERNAL(
         __begin <= __current, "__bounded_iter(current, begin, end): current and begin are inconsistent");

--- a/libcxx/include/__iterator/cpp17_iterator_concepts.h
+++ b/libcxx/include/__iterator/cpp17_iterator_concepts.h
@@ -68,7 +68,7 @@ concept __cpp17_default_constructible = is_default_constructible_v<_Tp>;
 template <class _Iter>
 concept __cpp17_iterator =
     __cpp17_copy_constructible<_Iter> && __cpp17_copy_assignable<_Iter> && __cpp17_destructible<_Iter> &&
-    (is_signed_v<__iter_diff_t<_Iter>> || is_void_v<__iter_diff_t<_Iter>>)&&requires(_Iter __iter) {
+    (is_signed_v<__iter_diff_t<_Iter>> || is_void_v<__iter_diff_t<_Iter>>) && requires(_Iter __iter) {
       { *__iter };
       { ++__iter } -> same_as<_Iter&>;
     };

--- a/libcxx/include/__iterator/iter_swap.h
+++ b/libcxx/include/__iterator/iter_swap.h
@@ -42,7 +42,7 @@ void iter_swap(_I1, _I2) = delete;
 
 template <class _T1, class _T2>
 concept __unqualified_iter_swap =
-    (__class_or_enum<remove_cvref_t<_T1>> || __class_or_enum<remove_cvref_t<_T2>>)&&requires(_T1&& __x, _T2&& __y) {
+    (__class_or_enum<remove_cvref_t<_T1>> || __class_or_enum<remove_cvref_t<_T2>>) && requires(_T1&& __x, _T2&& __y) {
       // NOLINTNEXTLINE(libcpp-robust-against-adl) iter_swap ADL calls should only be made through ranges::iter_swap
       iter_swap(std::forward<_T1>(__x), std::forward<_T2>(__y));
     };

--- a/libcxx/include/__iterator/move_iterator.h
+++ b/libcxx/include/__iterator/move_iterator.h
@@ -292,8 +292,8 @@ operator>=(const move_iterator<_Iter1>& __x, const move_iterator<_Iter2>& __y) {
 #if _LIBCPP_STD_VER >= 20
 template <class _Iter1, three_way_comparable_with<_Iter1> _Iter2>
 inline _LIBCPP_HIDE_FROM_ABI constexpr auto
-operator<=>(const move_iterator<_Iter1>& __x, const move_iterator<_Iter2>& __y)
-    -> compare_three_way_result_t<_Iter1, _Iter2> {
+operator<=>(const move_iterator<_Iter1>& __x,
+            const move_iterator<_Iter2>& __y) -> compare_three_way_result_t<_Iter1, _Iter2> {
   return __x.base() <=> __y.base();
 }
 #endif // _LIBCPP_STD_VER >= 20

--- a/libcxx/include/__iterator/reverse_iterator.h
+++ b/libcxx/include/__iterator/reverse_iterator.h
@@ -184,7 +184,7 @@ public:
 
 #if _LIBCPP_STD_VER >= 20
   _LIBCPP_HIDE_FROM_ABI friend constexpr iter_rvalue_reference_t<_Iter> iter_move(const reverse_iterator& __i) noexcept(
-      is_nothrow_copy_constructible_v<_Iter>&& noexcept(ranges::iter_move(--std::declval<_Iter&>()))) {
+      is_nothrow_copy_constructible_v<_Iter> && noexcept(ranges::iter_move(--std::declval<_Iter&>()))) {
     auto __tmp = __i.base();
     return ranges::iter_move(--__tmp);
   }
@@ -192,9 +192,8 @@ public:
   template <indirectly_swappable<_Iter> _Iter2>
   _LIBCPP_HIDE_FROM_ABI friend constexpr void
   iter_swap(const reverse_iterator& __x, const reverse_iterator<_Iter2>& __y) noexcept(
-      is_nothrow_copy_constructible_v<_Iter> &&
-      is_nothrow_copy_constructible_v<_Iter2>&& noexcept(
-          ranges::iter_swap(--std::declval<_Iter&>(), --std::declval<_Iter2&>()))) {
+      is_nothrow_copy_constructible_v<_Iter> && is_nothrow_copy_constructible_v<_Iter2> &&
+      noexcept(ranges::iter_swap(--std::declval<_Iter&>(), --std::declval<_Iter2&>()))) {
     auto __xtmp = __x.base();
     auto __ytmp = __y.base();
     ranges::iter_swap(--__xtmp, --__ytmp);
@@ -285,8 +284,8 @@ operator<=>(const reverse_iterator<_Iter1>& __x, const reverse_iterator<_Iter2>&
 #ifndef _LIBCPP_CXX03_LANG
 template <class _Iter1, class _Iter2>
 inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX17 auto
-operator-(const reverse_iterator<_Iter1>& __x, const reverse_iterator<_Iter2>& __y)
-    -> decltype(__y.base() - __x.base()) {
+operator-(const reverse_iterator<_Iter1>& __x,
+          const reverse_iterator<_Iter2>& __y) -> decltype(__y.base() - __x.base()) {
   return __y.base() - __x.base();
 }
 #else

--- a/libcxx/include/__iterator/wrap_iter.h
+++ b/libcxx/include/__iterator/wrap_iter.h
@@ -186,8 +186,8 @@ _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14
     operator-(const __wrap_iter<_Iter1>& __x,
               const __wrap_iter<_Iter2>& __y) _NOEXCEPT->decltype(__x.base() - __y.base())
 #else
-    typename __wrap_iter<_Iter1>::difference_type
-    operator-(const __wrap_iter<_Iter1>& __x, const __wrap_iter<_Iter2>& __y) _NOEXCEPT
+typename __wrap_iter<_Iter1>::difference_type
+operator-(const __wrap_iter<_Iter1>& __x, const __wrap_iter<_Iter2>& __y) _NOEXCEPT
 #endif // C++03
 {
   return __x.base() - __y.base();

--- a/libcxx/include/__mdspan/mdspan.h
+++ b/libcxx/include/__mdspan/mdspan.h
@@ -274,8 +274,8 @@ explicit mdspan(_ElementType*,
 #  else
 template <class _ElementType, class... _OtherIndexTypes>
   requires((is_convertible_v<_OtherIndexTypes, size_t> && ...) && (sizeof...(_OtherIndexTypes) > 0))
-explicit mdspan(_ElementType*, _OtherIndexTypes...)
-    -> mdspan<_ElementType, dextents<size_t, sizeof...(_OtherIndexTypes)>>;
+explicit mdspan(_ElementType*,
+                _OtherIndexTypes...) -> mdspan<_ElementType, dextents<size_t, sizeof...(_OtherIndexTypes)>>;
 #  endif
 
 template <class _Pointer>

--- a/libcxx/include/__memory/allocate_at_least.h
+++ b/libcxx/include/__memory/allocate_at_least.h
@@ -35,9 +35,9 @@ struct __allocation_result {
 };
 
 template <class _Alloc>
-_LIBCPP_NODISCARD _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR
-    __allocation_result<typename allocator_traits<_Alloc>::pointer>
-    __allocate_at_least(_Alloc& __alloc, size_t __n) {
+_LIBCPP_NODISCARD _LIBCPP_HIDE_FROM_ABI
+_LIBCPP_CONSTEXPR __allocation_result<typename allocator_traits<_Alloc>::pointer>
+__allocate_at_least(_Alloc& __alloc, size_t __n) {
   return {__alloc.allocate(__n), __n};
 }
 

--- a/libcxx/include/__memory/pointer_traits.h
+++ b/libcxx/include/__memory/pointer_traits.h
@@ -202,16 +202,16 @@ struct _IsFancyPointer {
 
 // enable_if is needed here to avoid instantiating checks for fancy pointers on raw pointers
 template <class _Pointer, __enable_if_t< _And<is_class<_Pointer>, _IsFancyPointer<_Pointer> >::value, int> = 0>
-_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR
-    __decay_t<decltype(__to_address_helper<_Pointer>::__call(std::declval<const _Pointer&>()))>
-    __to_address(const _Pointer& __p) _NOEXCEPT {
+_LIBCPP_HIDE_FROM_ABI
+_LIBCPP_CONSTEXPR __decay_t<decltype(__to_address_helper<_Pointer>::__call(std::declval<const _Pointer&>()))>
+__to_address(const _Pointer& __p) _NOEXCEPT {
   return __to_address_helper<_Pointer>::__call(__p);
 }
 
 template <class _Pointer, class>
 struct __to_address_helper {
-  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR static decltype(std::__to_address(
-      std::declval<const _Pointer&>().operator->()))
+  _LIBCPP_HIDE_FROM_ABI
+  _LIBCPP_CONSTEXPR static decltype(std::__to_address(std::declval<const _Pointer&>().operator->()))
   __call(const _Pointer& __p) _NOEXCEPT {
     return std::__to_address(__p.operator->());
   }
@@ -220,8 +220,8 @@ struct __to_address_helper {
 template <class _Pointer>
 struct __to_address_helper<_Pointer,
                            decltype((void)pointer_traits<_Pointer>::to_address(std::declval<const _Pointer&>()))> {
-  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR static decltype(pointer_traits<_Pointer>::to_address(
-      std::declval<const _Pointer&>()))
+  _LIBCPP_HIDE_FROM_ABI
+  _LIBCPP_CONSTEXPR static decltype(pointer_traits<_Pointer>::to_address(std::declval<const _Pointer&>()))
   __call(const _Pointer& __p) _NOEXCEPT {
     return pointer_traits<_Pointer>::to_address(__p);
   }
@@ -234,8 +234,8 @@ inline _LIBCPP_HIDE_FROM_ABI constexpr auto to_address(_Tp* __p) noexcept {
 }
 
 template <class _Pointer>
-inline _LIBCPP_HIDE_FROM_ABI constexpr auto to_address(const _Pointer& __p) noexcept
-    -> decltype(std::__to_address(__p)) {
+inline _LIBCPP_HIDE_FROM_ABI constexpr auto
+to_address(const _Pointer& __p) noexcept -> decltype(std::__to_address(__p)) {
   return std::__to_address(__p);
 }
 #endif

--- a/libcxx/include/__memory/unique_ptr.h
+++ b/libcxx/include/__memory/unique_ptr.h
@@ -183,8 +183,8 @@ public:
       : __ptr_(__value_init_tag(), __value_init_tag()) {}
 
   template <bool _Dummy = true, class = _EnableIfDeleterDefaultConstructible<_Dummy> >
-  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX23 explicit unique_ptr(pointer __p) _NOEXCEPT
-      : __ptr_(__p, __value_init_tag()) {}
+  _LIBCPP_HIDE_FROM_ABI
+  _LIBCPP_CONSTEXPR_SINCE_CXX23 explicit unique_ptr(pointer __p) _NOEXCEPT : __ptr_(__p, __value_init_tag()) {}
 
   template <bool _Dummy = true, class = _EnableIfDeleterConstructible<_LValRefType<_Dummy> > >
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX23 unique_ptr(pointer __p, _LValRefType<_Dummy> __d) _NOEXCEPT
@@ -359,8 +359,8 @@ public:
             bool _Dummy = true,
             class       = _EnableIfDeleterDefaultConstructible<_Dummy>,
             class       = _EnableIfPointerConvertible<_Pp> >
-  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX23 explicit unique_ptr(_Pp __p) _NOEXCEPT
-      : __ptr_(__p, __value_init_tag()) {}
+  _LIBCPP_HIDE_FROM_ABI
+  _LIBCPP_CONSTEXPR_SINCE_CXX23 explicit unique_ptr(_Pp __p) _NOEXCEPT : __ptr_(__p, __value_init_tag()) {}
 
   template <class _Pp,
             bool _Dummy = true,
@@ -517,8 +517,8 @@ inline _LIBCPP_HIDE_FROM_ABI bool operator>=(const unique_ptr<_T1, _D1>& __x, co
 template <class _T1, class _D1, class _T2, class _D2>
   requires three_way_comparable_with<typename unique_ptr<_T1, _D1>::pointer, typename unique_ptr<_T2, _D2>::pointer>
 _LIBCPP_HIDE_FROM_ABI
-    compare_three_way_result_t<typename unique_ptr<_T1, _D1>::pointer, typename unique_ptr<_T2, _D2>::pointer>
-    operator<=>(const unique_ptr<_T1, _D1>& __x, const unique_ptr<_T2, _D2>& __y) {
+compare_three_way_result_t<typename unique_ptr<_T1, _D1>::pointer, typename unique_ptr<_T2, _D2>::pointer>
+operator<=>(const unique_ptr<_T1, _D1>& __x, const unique_ptr<_T2, _D2>& __y) {
   return compare_three_way()(__x.get(), __y.get());
 }
 #endif

--- a/libcxx/include/__ranges/access.h
+++ b/libcxx/include/__ranges/access.h
@@ -191,9 +191,8 @@ struct __fn {
 
   template <class _Tp>
     requires is_rvalue_reference_v<_Tp&&>
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr auto operator()(_Tp&& __t) const
-      noexcept(noexcept(ranges::end(static_cast<const _Tp&&>(__t))))
-          -> decltype(ranges::end(static_cast<const _Tp&&>(__t))) {
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr auto operator()(_Tp&& __t) const noexcept(
+      noexcept(ranges::end(static_cast<const _Tp&&>(__t)))) -> decltype(ranges::end(static_cast<const _Tp&&>(__t))) {
     return ranges::end(static_cast<const _Tp&&>(__t));
   }
 };

--- a/libcxx/include/__ranges/all.h
+++ b/libcxx/include/__ranges/all.h
@@ -39,9 +39,8 @@ namespace __all {
 struct __fn : __range_adaptor_closure<__fn> {
   template <class _Tp>
     requires ranges::view<decay_t<_Tp>>
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr auto operator()(_Tp&& __t) const
-      noexcept(noexcept(_LIBCPP_AUTO_CAST(std::forward<_Tp>(__t))))
-          -> decltype(_LIBCPP_AUTO_CAST(std::forward<_Tp>(__t))) {
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr auto operator()(_Tp&& __t) const noexcept(
+      noexcept(_LIBCPP_AUTO_CAST(std::forward<_Tp>(__t)))) -> decltype(_LIBCPP_AUTO_CAST(std::forward<_Tp>(__t))) {
     return _LIBCPP_AUTO_CAST(std::forward<_Tp>(__t));
   }
 

--- a/libcxx/include/__ranges/common_view.h
+++ b/libcxx/include/__ranges/common_view.h
@@ -114,16 +114,14 @@ namespace __common {
 struct __fn : __range_adaptor_closure<__fn> {
   template <class _Range>
     requires common_range<_Range>
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr auto operator()(_Range&& __range) const
-      noexcept(noexcept(views::all(std::forward<_Range>(__range))))
-          -> decltype(views::all(std::forward<_Range>(__range))) {
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr auto operator()(_Range&& __range) const noexcept(
+      noexcept(views::all(std::forward<_Range>(__range)))) -> decltype(views::all(std::forward<_Range>(__range))) {
     return views::all(std::forward<_Range>(__range));
   }
 
   template <class _Range>
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr auto operator()(_Range&& __range) const
-      noexcept(noexcept(common_view{std::forward<_Range>(__range)}))
-          -> decltype(common_view{std::forward<_Range>(__range)}) {
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr auto operator()(_Range&& __range) const noexcept(noexcept(common_view{
+      std::forward<_Range>(__range)})) -> decltype(common_view{std::forward<_Range>(__range)}) {
     return common_view{std::forward<_Range>(__range)};
   }
 };

--- a/libcxx/include/__ranges/counted.h
+++ b/libcxx/include/__ranges/counted.h
@@ -51,9 +51,8 @@ struct __fn {
   }
 
   template <random_access_iterator _It>
-  _LIBCPP_HIDE_FROM_ABI static constexpr auto
-  __go(_It __it, iter_difference_t<_It> __count) noexcept(noexcept(subrange(__it, __it + __count)))
-      -> decltype(subrange(__it, __it + __count)) {
+  _LIBCPP_HIDE_FROM_ABI static constexpr auto __go(_It __it, iter_difference_t<_It> __count) noexcept(
+      noexcept(subrange(__it, __it + __count))) -> decltype(subrange(__it, __it + __count)) {
     return subrange(__it, __it + __count);
   }
 

--- a/libcxx/include/__ranges/data.h
+++ b/libcxx/include/__ranges/data.h
@@ -83,9 +83,8 @@ struct __fn {
 
   template <class _Tp>
     requires is_rvalue_reference_v<_Tp&&>
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr auto operator()(_Tp&& __t) const
-      noexcept(noexcept(ranges::data(static_cast<const _Tp&&>(__t))))
-          -> decltype(ranges::data(static_cast<const _Tp&&>(__t))) {
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr auto operator()(_Tp&& __t) const noexcept(
+      noexcept(ranges::data(static_cast<const _Tp&&>(__t)))) -> decltype(ranges::data(static_cast<const _Tp&&>(__t))) {
     return ranges::data(static_cast<const _Tp&&>(__t));
   }
 };

--- a/libcxx/include/__ranges/drop_view.h
+++ b/libcxx/include/__ranges/drop_view.h
@@ -289,14 +289,14 @@ struct __fn {
   template <class _Range, convertible_to<range_difference_t<_Range>> _Np, class _RawRange = remove_cvref_t<_Range>>
   // Note: without specifically excluding the other cases, GCC sees this overload as ambiguous with the other
   // overloads.
-    requires(
-        !(__is_empty_view<_RawRange> ||
+    requires(!(__is_empty_view<_RawRange> ||
 #  if _LIBCPP_STD_VER >= 23
-          __is_repeat_specialization<_RawRange> ||
+               __is_repeat_specialization<_RawRange> ||
 #  endif
-          (__is_subrange_specialization_with_store_size<_RawRange> && sized_range<_RawRange> &&
-           random_access_range<_RawRange>) ||
-          (__is_passthrough_specialization<_RawRange> && sized_range<_RawRange> && random_access_range<_RawRange>)))
+               (__is_subrange_specialization_with_store_size<_RawRange> && sized_range<_RawRange> &&
+                random_access_range<_RawRange>) ||
+               (__is_passthrough_specialization<_RawRange> && sized_range<_RawRange> &&
+                random_access_range<_RawRange>)))
   [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr auto operator()(_Range&& __range, _Np&& __n) const
       noexcept(noexcept(drop_view(std::forward<_Range>(__range), std::forward<_Np>(__n))))
           -> decltype(drop_view(std::forward<_Range>(__range), std::forward<_Np>(__n))) {

--- a/libcxx/include/__ranges/lazy_split_view.h
+++ b/libcxx/include/__ranges/lazy_split_view.h
@@ -403,8 +403,8 @@ template <class _Range, class _Pattern>
 lazy_split_view(_Range&&, _Pattern&&) -> lazy_split_view<views::all_t<_Range>, views::all_t<_Pattern>>;
 
 template <input_range _Range>
-lazy_split_view(_Range&&, range_value_t<_Range>)
-    -> lazy_split_view<views::all_t<_Range>, single_view<range_value_t<_Range>>>;
+lazy_split_view(_Range&&,
+                range_value_t<_Range>) -> lazy_split_view<views::all_t<_Range>, single_view<range_value_t<_Range>>>;
 
 namespace views {
 namespace __lazy_split_view {

--- a/libcxx/include/__ranges/rend.h
+++ b/libcxx/include/__ranges/rend.h
@@ -104,9 +104,8 @@ struct __fn {
 
   template <class _Tp>
     requires is_rvalue_reference_v<_Tp&&>
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr auto operator()(_Tp&& __t) const
-      noexcept(noexcept(ranges::rend(static_cast<const _Tp&&>(__t))))
-          -> decltype(ranges::rend(static_cast<const _Tp&&>(__t))) {
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr auto operator()(_Tp&& __t) const noexcept(
+      noexcept(ranges::rend(static_cast<const _Tp&&>(__t)))) -> decltype(ranges::rend(static_cast<const _Tp&&>(__t))) {
     return ranges::rend(static_cast<const _Tp&&>(__t));
   }
 };

--- a/libcxx/include/__ranges/reverse_view.h
+++ b/libcxx/include/__ranges/reverse_view.h
@@ -181,9 +181,8 @@ struct __fn : __range_adaptor_closure<__fn> {
   template <class _Range>
     requires(!__is_reverse_view<remove_cvref_t<_Range>> && !__is_sized_reverse_subrange<remove_cvref_t<_Range>> &&
              !__is_unsized_reverse_subrange<remove_cvref_t<_Range>>)
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr auto operator()(_Range&& __range) const
-      noexcept(noexcept(reverse_view{std::forward<_Range>(__range)}))
-          -> decltype(reverse_view{std::forward<_Range>(__range)}) {
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr auto operator()(_Range&& __range) const noexcept(noexcept(reverse_view{
+      std::forward<_Range>(__range)})) -> decltype(reverse_view{std::forward<_Range>(__range)}) {
     return reverse_view{std::forward<_Range>(__range)};
   }
 };

--- a/libcxx/include/__ranges/subrange.h
+++ b/libcxx/include/__ranges/subrange.h
@@ -200,12 +200,11 @@ template <input_or_output_iterator _Iter, sentinel_for<_Iter> _Sent>
 subrange(_Iter, _Sent, make_unsigned_t<iter_difference_t<_Iter>>) -> subrange<_Iter, _Sent, subrange_kind::sized>;
 
 template <borrowed_range _Range>
-subrange(_Range&&)
-    -> subrange<iterator_t<_Range>,
-                sentinel_t<_Range>,
-                (sized_range<_Range> || sized_sentinel_for<sentinel_t<_Range>, iterator_t<_Range>>)
-                    ? subrange_kind::sized
-                    : subrange_kind::unsized>;
+subrange(_Range&&) -> subrange<iterator_t<_Range>,
+                               sentinel_t<_Range>,
+                               (sized_range<_Range> || sized_sentinel_for<sentinel_t<_Range>, iterator_t<_Range>>)
+                                   ? subrange_kind::sized
+                                   : subrange_kind::unsized>;
 
 template <borrowed_range _Range>
 subrange(_Range&&, make_unsigned_t<range_difference_t<_Range>>)

--- a/libcxx/include/__split_buffer
+++ b/libcxx/include/__split_buffer
@@ -211,8 +211,8 @@ private:
   _LIBCPP_CONSTEXPR_SINCE_CXX20 _LIBCPP_HIDE_FROM_ABI void __move_assign_alloc(__split_buffer&, false_type) _NOEXCEPT {}
 
   struct _ConstructTransaction {
-    _LIBCPP_CONSTEXPR_SINCE_CXX20 _LIBCPP_HIDE_FROM_ABI explicit _ConstructTransaction(
-        pointer* __p, size_type __n) _NOEXCEPT
+    _LIBCPP_CONSTEXPR_SINCE_CXX20
+    _LIBCPP_HIDE_FROM_ABI explicit _ConstructTransaction(pointer* __p, size_type __n) _NOEXCEPT
         : __pos_(*__p),
           __end_(*__p + __n),
           __dest_(__p) {}

--- a/libcxx/include/__tuple/sfinae_helpers.h
+++ b/libcxx/include/__tuple/sfinae_helpers.h
@@ -35,8 +35,8 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 
 struct __tuple_sfinae_base {
   template <template <class, class...> class _Trait, class... _LArgs, class... _RArgs>
-  static auto __do_test(__tuple_types<_LArgs...>, __tuple_types<_RArgs...>)
-      -> __all<__enable_if_t<_Trait<_LArgs, _RArgs>::value, bool>{true}...>;
+  static auto __do_test(__tuple_types<_LArgs...>,
+                        __tuple_types<_RArgs...>) -> __all<__enable_if_t<_Trait<_LArgs, _RArgs>::value, bool>{true}...>;
   template <template <class...> class>
   static auto __do_test(...) -> false_type;
 

--- a/libcxx/include/__tuple/tuple_size.h
+++ b/libcxx/include/__tuple/tuple_size.h
@@ -43,7 +43,7 @@ struct _LIBCPP_TEMPLATE_VIS tuple_size<__enable_if_tuple_size_imp< volatile _Tp,
 
 template <class _Tp>
 struct _LIBCPP_TEMPLATE_VIS
-    tuple_size<__enable_if_tuple_size_imp<const volatile _Tp, integral_constant<size_t, sizeof(tuple_size<_Tp>)>>>
+tuple_size<__enable_if_tuple_size_imp<const volatile _Tp, integral_constant<size_t, sizeof(tuple_size<_Tp>)>>>
     : public integral_constant<size_t, tuple_size<_Tp>::value> {};
 
 #else

--- a/libcxx/include/__type_traits/invoke.h
+++ b/libcxx/include/__type_traits/invoke.h
@@ -163,8 +163,8 @@ struct __invokable_r {
   using _Result = decltype(__try_call<_Fp, _Args...>(0));
 
   using type              = __conditional_t<_IsNotSame<_Result, __nat>::value,
-                               __conditional_t<is_void<_Ret>::value, true_type, __is_core_convertible<_Result, _Ret> >,
-                               false_type>;
+                                            __conditional_t<is_void<_Ret>::value, true_type, __is_core_convertible<_Result, _Ret> >,
+                                            false_type>;
   static const bool value = type::value;
 };
 template <class _Fp, class... _Args>

--- a/libcxx/include/__type_traits/is_literal_type.h
+++ b/libcxx/include/__type_traits/is_literal_type.h
@@ -20,8 +20,8 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 
 #if _LIBCPP_STD_VER <= 17 || defined(_LIBCPP_ENABLE_CXX20_REMOVED_TYPE_TRAITS)
 template <class _Tp>
-struct _LIBCPP_TEMPLATE_VIS _LIBCPP_DEPRECATED_IN_CXX17 is_literal_type
-    : public integral_constant<bool, __is_literal_type(_Tp)> {};
+struct _LIBCPP_TEMPLATE_VIS
+_LIBCPP_DEPRECATED_IN_CXX17 is_literal_type : public integral_constant<bool, __is_literal_type(_Tp)> {};
 
 #  if _LIBCPP_STD_VER >= 17
 template <class _Tp>

--- a/libcxx/include/__utility/exception_guard.h
+++ b/libcxx/include/__utility/exception_guard.h
@@ -96,8 +96,8 @@ _LIBCPP_CTAD_SUPPORTED_FOR_TYPE(__exception_guard_exceptions);
 template <class _Rollback>
 struct __exception_guard_noexceptions {
   __exception_guard_noexceptions() = delete;
-  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20
-      _LIBCPP_NODEBUG explicit __exception_guard_noexceptions(_Rollback) {}
+  _LIBCPP_HIDE_FROM_ABI
+  _LIBCPP_CONSTEXPR_SINCE_CXX20 _LIBCPP_NODEBUG explicit __exception_guard_noexceptions(_Rollback) {}
 
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 _LIBCPP_NODEBUG
   __exception_guard_noexceptions(__exception_guard_noexceptions&& __other)

--- a/libcxx/include/__utility/forward_like.h
+++ b/libcxx/include/__utility/forward_like.h
@@ -34,8 +34,8 @@ template <class _Ap, class _Bp>
 using _ForwardLike = _OverrideRef<_Ap&&, _CopyConst<remove_reference_t<_Ap>, remove_reference_t<_Bp>>>;
 
 template <class _Tp, class _Up>
-[[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr auto forward_like(_LIBCPP_LIFETIMEBOUND _Up&& __ux) noexcept
-    -> _ForwardLike<_Tp, _Up> {
+[[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr auto
+forward_like(_LIBCPP_LIFETIMEBOUND _Up&& __ux) noexcept -> _ForwardLike<_Tp, _Up> {
   return static_cast<_ForwardLike<_Tp, _Up>>(__ux);
 }
 

--- a/libcxx/include/__utility/is_pointer_in_range.h
+++ b/libcxx/include/__utility/is_pointer_in_range.h
@@ -33,8 +33,8 @@ struct __is_less_than_comparable<_Tp, _Up, __void_t<decltype(std::declval<_Tp>()
 };
 
 template <class _Tp, class _Up, __enable_if_t<__is_less_than_comparable<const _Tp*, const _Up*>::value, int> = 0>
-_LIBCPP_CONSTEXPR_SINCE_CXX14 _LIBCPP_HIDE_FROM_ABI _LIBCPP_NO_SANITIZE("address") bool __is_pointer_in_range(
-    const _Tp* __begin, const _Tp* __end, const _Up* __ptr) {
+_LIBCPP_CONSTEXPR_SINCE_CXX14 _LIBCPP_HIDE_FROM_ABI _LIBCPP_NO_SANITIZE("address") bool
+__is_pointer_in_range(const _Tp* __begin, const _Tp* __end, const _Up* __ptr) {
   _LIBCPP_ASSERT_VALID_INPUT_RANGE(std::__is_valid_range(__begin, __end), "[__begin, __end) is not a valid range");
 
   if (__libcpp_is_constant_evaluated()) {
@@ -48,8 +48,8 @@ _LIBCPP_CONSTEXPR_SINCE_CXX14 _LIBCPP_HIDE_FROM_ABI _LIBCPP_NO_SANITIZE("address
 }
 
 template <class _Tp, class _Up, __enable_if_t<!__is_less_than_comparable<const _Tp*, const _Up*>::value, int> = 0>
-_LIBCPP_CONSTEXPR_SINCE_CXX14 _LIBCPP_HIDE_FROM_ABI _LIBCPP_NO_SANITIZE("address") bool __is_pointer_in_range(
-    const _Tp* __begin, const _Tp* __end, const _Up* __ptr) {
+_LIBCPP_CONSTEXPR_SINCE_CXX14 _LIBCPP_HIDE_FROM_ABI _LIBCPP_NO_SANITIZE("address") bool
+__is_pointer_in_range(const _Tp* __begin, const _Tp* __end, const _Up* __ptr) {
   if (__libcpp_is_constant_evaluated())
     return false;
 

--- a/libcxx/include/__verbose_abort
+++ b/libcxx/include/__verbose_abort
@@ -21,7 +21,7 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 // This function should never be called directly from the code -- it should only be called through
 // the _LIBCPP_VERBOSE_ABORT macro.
 _LIBCPP_NORETURN _LIBCPP_AVAILABILITY_VERBOSE_ABORT _LIBCPP_OVERRIDABLE_FUNC_VIS
-    _LIBCPP_ATTRIBUTE_FORMAT(__printf__, 1, 2) void __libcpp_verbose_abort(const char* __format, ...);
+_LIBCPP_ATTRIBUTE_FORMAT(__printf__, 1, 2) void __libcpp_verbose_abort(const char* __format, ...);
 
 // _LIBCPP_VERBOSE_ABORT(format, args...)
 //

--- a/libcxx/include/any
+++ b/libcxx/include/any
@@ -205,7 +205,7 @@ public:
   template < class _ValueType,
              class _Tp = decay_t<_ValueType>,
              class     = enable_if_t< !is_same<_Tp, any>::value && !__is_inplace_type<_ValueType>::value &&
-                                  is_copy_constructible<_Tp>::value> >
+                                      is_copy_constructible<_Tp>::value> >
   _LIBCPP_HIDE_FROM_ABI any(_ValueType&& __value);
 
   template <class _ValueType,
@@ -219,7 +219,7 @@ public:
             class... _Args,
             class _Tp = decay_t<_ValueType>,
             class     = enable_if_t< is_constructible<_Tp, initializer_list<_Up>&, _Args...>::value &&
-                                 is_copy_constructible<_Tp>::value> >
+                                     is_copy_constructible<_Tp>::value> >
   _LIBCPP_HIDE_FROM_ABI explicit any(in_place_type_t<_ValueType>, initializer_list<_Up>, _Args&&... __args);
 
   _LIBCPP_HIDE_FROM_ABI ~any() { this->reset(); }
@@ -251,7 +251,7 @@ public:
             class... _Args,
             class _Tp = decay_t<_ValueType>,
             class     = enable_if_t< is_constructible<_Tp, initializer_list<_Up>&, _Args...>::value &&
-                                 is_copy_constructible<_Tp>::value> >
+                                     is_copy_constructible<_Tp>::value> >
   _LIBCPP_HIDE_FROM_ABI _Tp& emplace(initializer_list<_Up>, _Args&&...);
 
   // 6.3.3 any modifiers

--- a/libcxx/include/array
+++ b/libcxx/include/array
@@ -232,9 +232,7 @@ struct _LIBCPP_TEMPLATE_VIS array {
   // capacity:
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR size_type size() const _NOEXCEPT { return _Size; }
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR size_type max_size() const _NOEXCEPT { return _Size; }
-  _LIBCPP_NODISCARD _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR bool empty() const _NOEXCEPT {
-    return _Size == 0;
-  }
+  _LIBCPP_NODISCARD _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR bool empty() const _NOEXCEPT { return _Size == 0; }
 
   // element access:
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX17 reference operator[](size_type __n) _NOEXCEPT {

--- a/libcxx/include/barrier
+++ b/libcxx/include/barrier
@@ -264,8 +264,8 @@ public:
 
   static _LIBCPP_HIDE_FROM_ABI constexpr ptrdiff_t max() noexcept { return __barrier_base<_CompletionF>::max(); }
 
-  _LIBCPP_AVAILABILITY_SYNC _LIBCPP_HIDE_FROM_ABI explicit barrier(
-      ptrdiff_t __count, _CompletionF __completion = _CompletionF())
+  _LIBCPP_AVAILABILITY_SYNC
+      _LIBCPP_HIDE_FROM_ABI explicit barrier(ptrdiff_t __count, _CompletionF __completion = _CompletionF())
       : __b_(__count, std::move(__completion)) {
     _LIBCPP_ASSERT_ARGUMENT_WITHIN_DOMAIN(
         __count >= 0,

--- a/libcxx/include/cmath
+++ b/libcxx/include/cmath
@@ -557,9 +557,9 @@ inline _LIBCPP_HIDE_FROM_ABI long double hypot(long double __x, long double __y,
 
 template <class _A1, class _A2, class _A3>
 inline _LIBCPP_HIDE_FROM_ABI
-    typename enable_if_t< is_arithmetic<_A1>::value && is_arithmetic<_A2>::value && is_arithmetic<_A3>::value,
-                          __promote<_A1, _A2, _A3> >::type
-    hypot(_A1 __lcpp_x, _A2 __lcpp_y, _A3 __lcpp_z) _NOEXCEPT {
+typename enable_if_t< is_arithmetic<_A1>::value && is_arithmetic<_A2>::value && is_arithmetic<_A3>::value,
+                      __promote<_A1, _A2, _A3> >::type
+hypot(_A1 __lcpp_x, _A2 __lcpp_y, _A3 __lcpp_z) _NOEXCEPT {
   typedef typename __promote<_A1, _A2, _A3>::type __result_type;
   static_assert(
       !(is_same<_A1, __result_type>::value && is_same<_A2, __result_type>::value && is_same<_A3, __result_type>::value),

--- a/libcxx/include/codecvt
+++ b/libcxx/include/codecvt
@@ -433,8 +433,8 @@ protected:
 
 _LIBCPP_SUPPRESS_DEPRECATED_PUSH
 template <class _Elem, unsigned long _Maxcode = 0x10ffff, codecvt_mode _Mode = (codecvt_mode)0>
-class _LIBCPP_TEMPLATE_VIS _LIBCPP_DEPRECATED_IN_CXX17 codecvt_utf16
-    : public __codecvt_utf16<_Elem, _Mode & little_endian> {
+class _LIBCPP_TEMPLATE_VIS
+_LIBCPP_DEPRECATED_IN_CXX17 codecvt_utf16 : public __codecvt_utf16<_Elem, _Mode & little_endian> {
 public:
   _LIBCPP_HIDE_FROM_ABI explicit codecvt_utf16(size_t __refs = 0)
       : __codecvt_utf16<_Elem, _Mode & little_endian>(__refs, _Maxcode, _Mode) {}

--- a/libcxx/include/coroutine
+++ b/libcxx/include/coroutine
@@ -41,10 +41,10 @@ struct suspend_always;
 #include <__config>
 
 #if _LIBCPP_STD_VER >= 20
-#include <__coroutine/coroutine_handle.h>
-#include <__coroutine/coroutine_traits.h>
-#include <__coroutine/noop_coroutine_handle.h>
-#include <__coroutine/trivial_awaitables.h>
+#  include <__coroutine/coroutine_handle.h>
+#  include <__coroutine/coroutine_traits.h>
+#  include <__coroutine/noop_coroutine_handle.h>
+#  include <__coroutine/trivial_awaitables.h>
 #endif // _LIBCPP_STD_VER >= 20
 
 #include <version>

--- a/libcxx/include/fstream
+++ b/libcxx/include/fstream
@@ -1103,8 +1103,8 @@ public:
   _LIBCPP_HIDE_FROM_ABI explicit basic_ifstream(const string& __s, ios_base::openmode __mode = ios_base::in);
 #  if _LIBCPP_STD_VER >= 17
   template <class _Tp, class = enable_if_t<is_same_v<_Tp, filesystem::path>>>
-  _LIBCPP_AVAILABILITY_FILESYSTEM_LIBRARY _LIBCPP_HIDE_FROM_ABI explicit basic_ifstream(
-      const _Tp& __p, ios_base::openmode __mode = ios_base::in)
+  _LIBCPP_AVAILABILITY_FILESYSTEM_LIBRARY
+      _LIBCPP_HIDE_FROM_ABI explicit basic_ifstream(const _Tp& __p, ios_base::openmode __mode = ios_base::in)
       : basic_ifstream(__p.c_str(), __mode) {}
 #  endif // _LIBCPP_STD_VER >= 17
   _LIBCPP_HIDE_FROM_ABI basic_ifstream(basic_ifstream&& __rhs);
@@ -1258,8 +1258,8 @@ public:
 
 #  if _LIBCPP_STD_VER >= 17
   template <class _Tp, class = enable_if_t<is_same_v<_Tp, filesystem::path>>>
-  _LIBCPP_AVAILABILITY_FILESYSTEM_LIBRARY _LIBCPP_HIDE_FROM_ABI explicit basic_ofstream(
-      const _Tp& __p, ios_base::openmode __mode = ios_base::out)
+  _LIBCPP_AVAILABILITY_FILESYSTEM_LIBRARY
+      _LIBCPP_HIDE_FROM_ABI explicit basic_ofstream(const _Tp& __p, ios_base::openmode __mode = ios_base::out)
       : basic_ofstream(__p.c_str(), __mode) {}
 #  endif // _LIBCPP_STD_VER >= 17
 

--- a/libcxx/include/limits
+++ b/libcxx/include/limits
@@ -314,10 +314,18 @@ protected:
   static _LIBCPP_CONSTEXPR const bool has_signaling_NaN                                    = true;
   static _LIBCPP_DEPRECATED_IN_CXX23 _LIBCPP_CONSTEXPR const float_denorm_style has_denorm = denorm_present;
   static _LIBCPP_DEPRECATED_IN_CXX23 _LIBCPP_CONSTEXPR const bool has_denorm_loss          = false;
-  _LIBCPP_NODISCARD _LIBCPP_HIDE_FROM_ABI static _LIBCPP_CONSTEXPR type infinity() _NOEXCEPT { return __builtin_huge_valf(); }
-  _LIBCPP_NODISCARD _LIBCPP_HIDE_FROM_ABI static _LIBCPP_CONSTEXPR type quiet_NaN() _NOEXCEPT { return __builtin_nanf(""); }
-  _LIBCPP_NODISCARD _LIBCPP_HIDE_FROM_ABI static _LIBCPP_CONSTEXPR type signaling_NaN() _NOEXCEPT { return __builtin_nansf(""); }
-  _LIBCPP_NODISCARD _LIBCPP_HIDE_FROM_ABI static _LIBCPP_CONSTEXPR type denorm_min() _NOEXCEPT { return __FLT_DENORM_MIN__; }
+  _LIBCPP_NODISCARD _LIBCPP_HIDE_FROM_ABI static _LIBCPP_CONSTEXPR type infinity() _NOEXCEPT {
+    return __builtin_huge_valf();
+  }
+  _LIBCPP_NODISCARD _LIBCPP_HIDE_FROM_ABI static _LIBCPP_CONSTEXPR type quiet_NaN() _NOEXCEPT {
+    return __builtin_nanf("");
+  }
+  _LIBCPP_NODISCARD _LIBCPP_HIDE_FROM_ABI static _LIBCPP_CONSTEXPR type signaling_NaN() _NOEXCEPT {
+    return __builtin_nansf("");
+  }
+  _LIBCPP_NODISCARD _LIBCPP_HIDE_FROM_ABI static _LIBCPP_CONSTEXPR type denorm_min() _NOEXCEPT {
+    return __FLT_DENORM_MIN__;
+  }
 
   static _LIBCPP_CONSTEXPR const bool is_iec559  = true;
   static _LIBCPP_CONSTEXPR const bool is_bounded = true;
@@ -363,10 +371,18 @@ protected:
   static _LIBCPP_CONSTEXPR const bool has_signaling_NaN                                    = true;
   static _LIBCPP_DEPRECATED_IN_CXX23 _LIBCPP_CONSTEXPR const float_denorm_style has_denorm = denorm_present;
   static _LIBCPP_DEPRECATED_IN_CXX23 _LIBCPP_CONSTEXPR const bool has_denorm_loss          = false;
-  _LIBCPP_NODISCARD _LIBCPP_HIDE_FROM_ABI static _LIBCPP_CONSTEXPR type infinity() _NOEXCEPT { return __builtin_huge_val(); }
-  _LIBCPP_NODISCARD _LIBCPP_HIDE_FROM_ABI static _LIBCPP_CONSTEXPR type quiet_NaN() _NOEXCEPT { return __builtin_nan(""); }
-  _LIBCPP_NODISCARD _LIBCPP_HIDE_FROM_ABI static _LIBCPP_CONSTEXPR type signaling_NaN() _NOEXCEPT { return __builtin_nans(""); }
-  _LIBCPP_NODISCARD _LIBCPP_HIDE_FROM_ABI static _LIBCPP_CONSTEXPR type denorm_min() _NOEXCEPT { return __DBL_DENORM_MIN__; }
+  _LIBCPP_NODISCARD _LIBCPP_HIDE_FROM_ABI static _LIBCPP_CONSTEXPR type infinity() _NOEXCEPT {
+    return __builtin_huge_val();
+  }
+  _LIBCPP_NODISCARD _LIBCPP_HIDE_FROM_ABI static _LIBCPP_CONSTEXPR type quiet_NaN() _NOEXCEPT {
+    return __builtin_nan("");
+  }
+  _LIBCPP_NODISCARD _LIBCPP_HIDE_FROM_ABI static _LIBCPP_CONSTEXPR type signaling_NaN() _NOEXCEPT {
+    return __builtin_nans("");
+  }
+  _LIBCPP_NODISCARD _LIBCPP_HIDE_FROM_ABI static _LIBCPP_CONSTEXPR type denorm_min() _NOEXCEPT {
+    return __DBL_DENORM_MIN__;
+  }
 
   static _LIBCPP_CONSTEXPR const bool is_iec559  = true;
   static _LIBCPP_CONSTEXPR const bool is_bounded = true;
@@ -412,10 +428,18 @@ protected:
   static _LIBCPP_CONSTEXPR const bool has_signaling_NaN                                    = true;
   static _LIBCPP_DEPRECATED_IN_CXX23 _LIBCPP_CONSTEXPR const float_denorm_style has_denorm = denorm_present;
   static _LIBCPP_DEPRECATED_IN_CXX23 _LIBCPP_CONSTEXPR const bool has_denorm_loss          = false;
-  _LIBCPP_NODISCARD _LIBCPP_HIDE_FROM_ABI static _LIBCPP_CONSTEXPR type infinity() _NOEXCEPT { return __builtin_huge_vall(); }
-  _LIBCPP_NODISCARD _LIBCPP_HIDE_FROM_ABI static _LIBCPP_CONSTEXPR type quiet_NaN() _NOEXCEPT { return __builtin_nanl(""); }
-  _LIBCPP_NODISCARD _LIBCPP_HIDE_FROM_ABI static _LIBCPP_CONSTEXPR type signaling_NaN() _NOEXCEPT { return __builtin_nansl(""); }
-  _LIBCPP_NODISCARD _LIBCPP_HIDE_FROM_ABI static _LIBCPP_CONSTEXPR type denorm_min() _NOEXCEPT { return __LDBL_DENORM_MIN__; }
+  _LIBCPP_NODISCARD _LIBCPP_HIDE_FROM_ABI static _LIBCPP_CONSTEXPR type infinity() _NOEXCEPT {
+    return __builtin_huge_vall();
+  }
+  _LIBCPP_NODISCARD _LIBCPP_HIDE_FROM_ABI static _LIBCPP_CONSTEXPR type quiet_NaN() _NOEXCEPT {
+    return __builtin_nanl("");
+  }
+  _LIBCPP_NODISCARD _LIBCPP_HIDE_FROM_ABI static _LIBCPP_CONSTEXPR type signaling_NaN() _NOEXCEPT {
+    return __builtin_nansl("");
+  }
+  _LIBCPP_NODISCARD _LIBCPP_HIDE_FROM_ABI static _LIBCPP_CONSTEXPR type denorm_min() _NOEXCEPT {
+    return __LDBL_DENORM_MIN__;
+  }
 
 #if defined(__powerpc__) && defined(__LONG_DOUBLE_IBM128__)
   static _LIBCPP_CONSTEXPR const bool is_iec559 = false;
@@ -452,8 +476,12 @@ public:
   static _LIBCPP_CONSTEXPR const bool is_integer  = __base::is_integer;
   static _LIBCPP_CONSTEXPR const bool is_exact    = __base::is_exact;
   static _LIBCPP_CONSTEXPR const int radix        = __base::radix;
-  _LIBCPP_NODISCARD _LIBCPP_HIDE_FROM_ABI static _LIBCPP_CONSTEXPR type epsilon() _NOEXCEPT { return __base::epsilon(); }
-  _LIBCPP_NODISCARD _LIBCPP_HIDE_FROM_ABI static _LIBCPP_CONSTEXPR type round_error() _NOEXCEPT { return __base::round_error(); }
+  _LIBCPP_NODISCARD _LIBCPP_HIDE_FROM_ABI static _LIBCPP_CONSTEXPR type epsilon() _NOEXCEPT {
+    return __base::epsilon();
+  }
+  _LIBCPP_NODISCARD _LIBCPP_HIDE_FROM_ABI static _LIBCPP_CONSTEXPR type round_error() _NOEXCEPT {
+    return __base::round_error();
+  }
 
   static _LIBCPP_CONSTEXPR const int min_exponent   = __base::min_exponent;
   static _LIBCPP_CONSTEXPR const int min_exponent10 = __base::min_exponent10;
@@ -467,10 +495,18 @@ public:
   static _LIBCPP_DEPRECATED_IN_CXX23 _LIBCPP_CONSTEXPR const float_denorm_style has_denorm = __base::has_denorm;
   static _LIBCPP_DEPRECATED_IN_CXX23 _LIBCPP_CONSTEXPR const bool has_denorm_loss          = __base::has_denorm_loss;
   _LIBCPP_SUPPRESS_DEPRECATED_POP
-  _LIBCPP_NODISCARD _LIBCPP_HIDE_FROM_ABI static _LIBCPP_CONSTEXPR type infinity() _NOEXCEPT { return __base::infinity(); }
-  _LIBCPP_NODISCARD _LIBCPP_HIDE_FROM_ABI static _LIBCPP_CONSTEXPR type quiet_NaN() _NOEXCEPT { return __base::quiet_NaN(); }
-  _LIBCPP_NODISCARD _LIBCPP_HIDE_FROM_ABI static _LIBCPP_CONSTEXPR type signaling_NaN() _NOEXCEPT { return __base::signaling_NaN(); }
-  _LIBCPP_NODISCARD _LIBCPP_HIDE_FROM_ABI static _LIBCPP_CONSTEXPR type denorm_min() _NOEXCEPT { return __base::denorm_min(); }
+  _LIBCPP_NODISCARD _LIBCPP_HIDE_FROM_ABI static _LIBCPP_CONSTEXPR type infinity() _NOEXCEPT {
+    return __base::infinity();
+  }
+  _LIBCPP_NODISCARD _LIBCPP_HIDE_FROM_ABI static _LIBCPP_CONSTEXPR type quiet_NaN() _NOEXCEPT {
+    return __base::quiet_NaN();
+  }
+  _LIBCPP_NODISCARD _LIBCPP_HIDE_FROM_ABI static _LIBCPP_CONSTEXPR type signaling_NaN() _NOEXCEPT {
+    return __base::signaling_NaN();
+  }
+  _LIBCPP_NODISCARD _LIBCPP_HIDE_FROM_ABI static _LIBCPP_CONSTEXPR type denorm_min() _NOEXCEPT {
+    return __base::denorm_min();
+  }
 
   static _LIBCPP_CONSTEXPR const bool is_iec559  = __base::is_iec559;
   static _LIBCPP_CONSTEXPR const bool is_bounded = __base::is_bounded;

--- a/libcxx/include/locale
+++ b/libcxx/include/locale
@@ -3149,22 +3149,22 @@ private:
   size_t __cvtcount_;
 
 public:
-#ifndef _LIBCPP_CXX03_LANG
+#  ifndef _LIBCPP_CXX03_LANG
   _LIBCPP_HIDE_FROM_ABI wstring_convert() : wstring_convert(new _Codecvt) {}
   _LIBCPP_HIDE_FROM_ABI explicit wstring_convert(_Codecvt* __pcvt);
-#else
+#  else
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_EXPLICIT_SINCE_CXX14 wstring_convert(_Codecvt* __pcvt = new _Codecvt);
-#endif
+#  endif
 
   _LIBCPP_HIDE_FROM_ABI wstring_convert(_Codecvt* __pcvt, state_type __state);
   _LIBCPP_EXPLICIT_SINCE_CXX14 _LIBCPP_HIDE_FROM_ABI
   wstring_convert(const byte_string& __byte_err, const wide_string& __wide_err = wide_string());
-#ifndef _LIBCPP_CXX03_LANG
+#  ifndef _LIBCPP_CXX03_LANG
   _LIBCPP_HIDE_FROM_ABI wstring_convert(wstring_convert&& __wc);
-#endif
+#  endif
   _LIBCPP_HIDE_FROM_ABI ~wstring_convert();
 
-  wstring_convert(const wstring_convert& __wc) = delete;
+  wstring_convert(const wstring_convert& __wc)            = delete;
   wstring_convert& operator=(const wstring_convert& __wc) = delete;
 
   _LIBCPP_HIDE_FROM_ABI wide_string from_bytes(char __byte) { return from_bytes(&__byte, &__byte + 1); }
@@ -3206,7 +3206,7 @@ wstring_convert<_Codecvt, _Elem, _WideAlloc, _ByteAlloc>::wstring_convert(
   __cvtptr_ = new _Codecvt;
 }
 
-#ifndef _LIBCPP_CXX03_LANG
+#  ifndef _LIBCPP_CXX03_LANG
 
 template <class _Codecvt, class _Elem, class _WideAlloc, class _ByteAlloc>
 inline wstring_convert<_Codecvt, _Elem, _WideAlloc, _ByteAlloc>::wstring_convert(wstring_convert&& __wc)
@@ -3218,7 +3218,7 @@ inline wstring_convert<_Codecvt, _Elem, _WideAlloc, _ByteAlloc>::wstring_convert
   __wc.__cvtptr_ = nullptr;
 }
 
-#endif // _LIBCPP_CXX03_LANG
+#  endif // _LIBCPP_CXX03_LANG
 
 _LIBCPP_SUPPRESS_DEPRECATED_PUSH
 template <class _Codecvt, class _Elem, class _WideAlloc, class _ByteAlloc>
@@ -3372,14 +3372,14 @@ private:
   bool __always_noconv_;
 
 public:
-#ifndef _LIBCPP_CXX03_LANG
+#  ifndef _LIBCPP_CXX03_LANG
   _LIBCPP_HIDE_FROM_ABI wbuffer_convert() : wbuffer_convert(nullptr) {}
   explicit _LIBCPP_HIDE_FROM_ABI
   wbuffer_convert(streambuf* __bytebuf, _Codecvt* __pcvt = new _Codecvt, state_type __state = state_type());
-#else
+#  else
   _LIBCPP_EXPLICIT_SINCE_CXX14 _LIBCPP_HIDE_FROM_ABI
   wbuffer_convert(streambuf* __bytebuf = nullptr, _Codecvt* __pcvt = new _Codecvt, state_type __state = state_type());
-#endif
+#  endif
 
   _LIBCPP_HIDE_FROM_ABI ~wbuffer_convert();
 

--- a/libcxx/include/map
+++ b/libcxx/include/map
@@ -1357,9 +1357,7 @@ public:
   }
 #endif
 
-  _LIBCPP_HIDE_FROM_ABI void swap(map& __m) _NOEXCEPT_(__is_nothrow_swappable_v<__base>) {
-    __tree_.swap(__m.__tree_);
-  }
+  _LIBCPP_HIDE_FROM_ABI void swap(map& __m) _NOEXCEPT_(__is_nothrow_swappable_v<__base>) { __tree_.swap(__m.__tree_); }
 
   _LIBCPP_HIDE_FROM_ABI iterator find(const key_type& __k) { return __tree_.find(__k); }
   _LIBCPP_HIDE_FROM_ABI const_iterator find(const key_type& __k) const { return __tree_.find(__k); }
@@ -1475,8 +1473,9 @@ template <class _Key,
           class _Allocator = allocator<pair<const _Key, _Tp>>,
           class            = enable_if_t<!__is_allocator<_Compare>::value, void>,
           class            = enable_if_t<__is_allocator<_Allocator>::value, void>>
-map(initializer_list<pair<_Key, _Tp>>, _Compare = _Compare(), _Allocator = _Allocator())
-    -> map<remove_const_t<_Key>, _Tp, _Compare, _Allocator>;
+map(initializer_list<pair<_Key, _Tp>>,
+    _Compare   = _Compare(),
+    _Allocator = _Allocator()) -> map<remove_const_t<_Key>, _Tp, _Compare, _Allocator>;
 
 template <class _InputIterator,
           class _Allocator,
@@ -1495,8 +1494,8 @@ map(from_range_t, _Range&&, _Allocator)
 #  endif
 
 template <class _Key, class _Tp, class _Allocator, class = enable_if_t<__is_allocator<_Allocator>::value, void>>
-map(initializer_list<pair<_Key, _Tp>>, _Allocator)
-    -> map<remove_const_t<_Key>, _Tp, less<remove_const_t<_Key>>, _Allocator>;
+map(initializer_list<pair<_Key, _Tp>>,
+    _Allocator) -> map<remove_const_t<_Key>, _Tp, less<remove_const_t<_Key>>, _Allocator>;
 #endif
 
 #ifndef _LIBCPP_CXX03_LANG
@@ -2061,8 +2060,9 @@ template <class _Key,
           class _Allocator = allocator<pair<const _Key, _Tp>>,
           class            = enable_if_t<!__is_allocator<_Compare>::value, void>,
           class            = enable_if_t<__is_allocator<_Allocator>::value, void>>
-multimap(initializer_list<pair<_Key, _Tp>>, _Compare = _Compare(), _Allocator = _Allocator())
-    -> multimap<remove_const_t<_Key>, _Tp, _Compare, _Allocator>;
+multimap(initializer_list<pair<_Key, _Tp>>,
+         _Compare   = _Compare(),
+         _Allocator = _Allocator()) -> multimap<remove_const_t<_Key>, _Tp, _Compare, _Allocator>;
 
 template <class _InputIterator,
           class _Allocator,
@@ -2081,8 +2081,8 @@ multimap(from_range_t, _Range&&, _Allocator)
 #  endif
 
 template <class _Key, class _Tp, class _Allocator, class = enable_if_t<__is_allocator<_Allocator>::value, void>>
-multimap(initializer_list<pair<_Key, _Tp>>, _Allocator)
-    -> multimap<remove_const_t<_Key>, _Tp, less<remove_const_t<_Key>>, _Allocator>;
+multimap(initializer_list<pair<_Key, _Tp>>,
+         _Allocator) -> multimap<remove_const_t<_Key>, _Tp, less<remove_const_t<_Key>>, _Allocator>;
 #endif
 
 #ifndef _LIBCPP_CXX03_LANG

--- a/libcxx/include/mutex
+++ b/libcxx/include/mutex
@@ -445,8 +445,8 @@ private:
   mutex_type& __m_;
 
 public:
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI explicit scoped_lock(mutex_type& __m)
-      _LIBCPP_THREAD_SAFETY_ANNOTATION(acquire_capability(__m))
+  [[nodiscard]]
+  _LIBCPP_HIDE_FROM_ABI explicit scoped_lock(mutex_type& __m) _LIBCPP_THREAD_SAFETY_ANNOTATION(acquire_capability(__m))
       : __m_(__m) {
     __m_.lock();
   }

--- a/libcxx/include/new
+++ b/libcxx/include/new
@@ -204,8 +204,8 @@ inline constexpr destroying_delete_t destroying_delete{};
 #if !defined(_LIBCPP_ABI_VCRUNTIME)
 
 _LIBCPP_NODISCARD _LIBCPP_OVERRIDABLE_FUNC_VIS void* operator new(std::size_t __sz) _THROW_BAD_ALLOC;
-_LIBCPP_NODISCARD _LIBCPP_OVERRIDABLE_FUNC_VIS void*
-operator new(std::size_t __sz, const std::nothrow_t&) _NOEXCEPT _LIBCPP_NOALIAS;
+_LIBCPP_NODISCARD _LIBCPP_OVERRIDABLE_FUNC_VIS void* operator new(std::size_t __sz, const std::nothrow_t&) _NOEXCEPT
+    _LIBCPP_NOALIAS;
 _LIBCPP_OVERRIDABLE_FUNC_VIS void operator delete(void* __p) _NOEXCEPT;
 _LIBCPP_OVERRIDABLE_FUNC_VIS void operator delete(void* __p, const std::nothrow_t&) _NOEXCEPT;
 #  ifndef _LIBCPP_HAS_NO_LIBRARY_SIZED_DEALLOCATION
@@ -213,8 +213,8 @@ _LIBCPP_OVERRIDABLE_FUNC_VIS void operator delete(void* __p, std::size_t __sz) _
 #  endif
 
 _LIBCPP_NODISCARD _LIBCPP_OVERRIDABLE_FUNC_VIS void* operator new[](std::size_t __sz) _THROW_BAD_ALLOC;
-_LIBCPP_NODISCARD _LIBCPP_OVERRIDABLE_FUNC_VIS void*
-operator new[](std::size_t __sz, const std::nothrow_t&) _NOEXCEPT _LIBCPP_NOALIAS;
+_LIBCPP_NODISCARD _LIBCPP_OVERRIDABLE_FUNC_VIS void* operator new[](std::size_t __sz, const std::nothrow_t&) _NOEXCEPT
+    _LIBCPP_NOALIAS;
 _LIBCPP_OVERRIDABLE_FUNC_VIS void operator delete[](void* __p) _NOEXCEPT;
 _LIBCPP_OVERRIDABLE_FUNC_VIS void operator delete[](void* __p, const std::nothrow_t&) _NOEXCEPT;
 #  ifndef _LIBCPP_HAS_NO_LIBRARY_SIZED_DEALLOCATION
@@ -222,8 +222,7 @@ _LIBCPP_OVERRIDABLE_FUNC_VIS void operator delete[](void* __p, std::size_t __sz)
 #  endif
 
 #  ifndef _LIBCPP_HAS_NO_LIBRARY_ALIGNED_ALLOCATION
-_LIBCPP_NODISCARD _LIBCPP_OVERRIDABLE_FUNC_VIS void*
-operator new(std::size_t __sz, std::align_val_t) _THROW_BAD_ALLOC;
+_LIBCPP_NODISCARD _LIBCPP_OVERRIDABLE_FUNC_VIS void* operator new(std::size_t __sz, std::align_val_t) _THROW_BAD_ALLOC;
 _LIBCPP_NODISCARD _LIBCPP_OVERRIDABLE_FUNC_VIS void*
 operator new(std::size_t __sz, std::align_val_t, const std::nothrow_t&) _NOEXCEPT _LIBCPP_NOALIAS;
 _LIBCPP_OVERRIDABLE_FUNC_VIS void operator delete(void* __p, std::align_val_t) _NOEXCEPT;
@@ -243,12 +242,8 @@ _LIBCPP_OVERRIDABLE_FUNC_VIS void operator delete[](void* __p, std::size_t __sz,
 #    endif
 #  endif
 
-_LIBCPP_NODISCARD inline _LIBCPP_HIDE_FROM_ABI void* operator new(std::size_t, void* __p) _NOEXCEPT {
-  return __p;
-}
-_LIBCPP_NODISCARD inline _LIBCPP_HIDE_FROM_ABI void* operator new[](std::size_t, void* __p) _NOEXCEPT {
-  return __p;
-}
+_LIBCPP_NODISCARD inline _LIBCPP_HIDE_FROM_ABI void* operator new(std::size_t, void* __p) _NOEXCEPT { return __p; }
+_LIBCPP_NODISCARD inline _LIBCPP_HIDE_FROM_ABI void* operator new[](std::size_t, void* __p) _NOEXCEPT { return __p; }
 inline _LIBCPP_HIDE_FROM_ABI void operator delete(void*, void*) _NOEXCEPT {}
 inline _LIBCPP_HIDE_FROM_ABI void operator delete[](void*, void*) _NOEXCEPT {}
 

--- a/libcxx/include/optional
+++ b/libcxx/include/optional
@@ -724,9 +724,9 @@ public:
   template <
       class _Up = value_type,
       class     = enable_if_t< _And< _IsNotSame<__remove_cvref_t<_Up>, optional>,
-                                 _Or< _IsNotSame<__remove_cvref_t<_Up>, value_type>, _Not<is_scalar<value_type>> >,
-                                 is_constructible<value_type, _Up>,
-                                 is_assignable<value_type&, _Up> >::value> >
+                                     _Or< _IsNotSame<__remove_cvref_t<_Up>, value_type>, _Not<is_scalar<value_type>> >,
+                                     is_constructible<value_type, _Up>,
+                                     is_assignable<value_type&, _Up> >::value> >
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 optional& operator=(_Up&& __v) {
     if (this->has_value())
       this->__get() = std::forward<_Up>(__v);
@@ -1242,9 +1242,9 @@ operator<=>(const optional<_Tp>& __x, const _Up& __v) {
 #  endif // _LIBCPP_STD_VER >= 20
 
 template <class _Tp>
-inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20
-    enable_if_t< is_move_constructible_v<_Tp> && is_swappable_v<_Tp>, void >
-    swap(optional<_Tp>& __x, optional<_Tp>& __y) noexcept(noexcept(__x.swap(__y))) {
+inline _LIBCPP_HIDE_FROM_ABI
+_LIBCPP_CONSTEXPR_SINCE_CXX20 enable_if_t< is_move_constructible_v<_Tp> && is_swappable_v<_Tp>, void >
+swap(optional<_Tp>& __x, optional<_Tp>& __y) noexcept(noexcept(__x.swap(__y))) {
   __x.swap(__y);
 }
 

--- a/libcxx/include/print
+++ b/libcxx/include/print
@@ -358,10 +358,14 @@ _LIBCPP_HIDE_FROM_ABI void println(FILE* __stream, format_string<_Args...> __fmt
 }
 
 template <class = void> // TODO PRINT template or availability markup fires too eagerly (http://llvm.org/PR61563).
-_LIBCPP_HIDE_FROM_ABI inline void println(FILE* __stream) { std::print(__stream, "\n"); }
+_LIBCPP_HIDE_FROM_ABI inline void println(FILE* __stream) {
+  std::print(__stream, "\n");
+}
 
 template <class = void> // TODO PRINT template or availability markup fires too eagerly (http://llvm.org/PR61563).
-_LIBCPP_HIDE_FROM_ABI inline void println() { println(stdout); }
+_LIBCPP_HIDE_FROM_ABI inline void println() {
+  println(stdout);
+}
 
 template <class... _Args>
 _LIBCPP_HIDE_FROM_ABI void println(format_string<_Args...> __fmt, _Args&&... __args) {

--- a/libcxx/include/queue
+++ b/libcxx/include/queue
@@ -398,13 +398,13 @@ public:
   template <class... _Args>
   _LIBCPP_HIDE_FROM_ABI
 #  if _LIBCPP_STD_VER >= 17
-      decltype(auto)
-      emplace(_Args&&... __args) {
+  decltype(auto)
+  emplace(_Args&&... __args) {
     return c.emplace_back(std::forward<_Args>(__args)...);
   }
 #  else
-      void
-      emplace(_Args&&... __args) {
+  void
+  emplace(_Args&&... __args) {
     c.emplace_back(std::forward<_Args>(__args)...);
   }
 #  endif

--- a/libcxx/include/regex
+++ b/libcxx/include/regex
@@ -1956,7 +1956,7 @@ public:
 
   _LIBCPP_HIDE_FROM_ABI __match_char(_CharT __c, __node<_CharT>* __s) : base(__s), __c_(__c) {}
 
-  __match_char(const __match_char&) = delete;
+  __match_char(const __match_char&)            = delete;
   __match_char& operator=(const __match_char&) = delete;
 
   _LIBCPP_HIDE_FROM_ABI_VIRTUAL virtual void __exec(__state&) const;
@@ -1989,7 +1989,7 @@ public:
   _LIBCPP_HIDE_FROM_ABI __match_char_icase(const _Traits& __traits, _CharT __c, __node<_CharT>* __s)
       : base(__s), __traits_(__traits), __c_(__traits.translate_nocase(__c)) {}
 
-  __match_char_icase(const __match_char_icase&) = delete;
+  __match_char_icase(const __match_char_icase&)            = delete;
   __match_char_icase& operator=(const __match_char_icase&) = delete;
 
   _LIBCPP_HIDE_FROM_ABI_VIRTUAL virtual void __exec(__state&) const;
@@ -2705,7 +2705,7 @@ public:
   __lookahead(const basic_regex<_CharT, _Traits>& __exp, bool __invert, __node<_CharT>* __s, unsigned __mexp)
       : base(__s), __exp_(__exp), __mexp_(__mexp), __invert_(__invert) {}
 
-  __lookahead(const __lookahead&) = delete;
+  __lookahead(const __lookahead&)            = delete;
   __lookahead& operator=(const __lookahead&) = delete;
 
   _LIBCPP_HIDE_FROM_ABI_VIRTUAL virtual void __exec(__state&) const;
@@ -5434,8 +5434,8 @@ regex_iterator<_BidirectionalIterator, _CharT, _Traits>::operator++() {
     // equal to the previous value of `match[0].second`... It is unspecified how the implementation makes these
     // adjustments." The adjustment is necessary if we incremented `__start` above (the branch that deals with
     // zero-length matches).
-    auto& __prefix = __match_.__prefix_;
-    __prefix.first = __prefix_start;
+    auto& __prefix   = __match_.__prefix_;
+    __prefix.first   = __prefix_start;
     __prefix.matched = __prefix.first != __prefix.second;
   }
 

--- a/libcxx/include/scoped_allocator
+++ b/libcxx/include/scoped_allocator
@@ -313,7 +313,7 @@ false_type __has_outer_allocator_test(const volatile _Alloc& __a);
 
 template <class _Alloc>
 struct __has_outer_allocator
-    : public common_type< decltype(std::__has_outer_allocator_test(std::declval<_Alloc&>())) >::type {};
+    : public common_type< decltype(std::__has_outer_allocator_test(std::declval<_Alloc&>()))>::type {};
 
 template <class _Alloc, bool = __has_outer_allocator<_Alloc>::value>
 struct __outermost {

--- a/libcxx/include/set
+++ b/libcxx/include/set
@@ -924,13 +924,15 @@ template <class _InputIterator,
           class _Allocator,
           class = enable_if_t<__has_input_iterator_category<_InputIterator>::value, void>,
           class = enable_if_t<__is_allocator<_Allocator>::value, void>>
-set(_InputIterator, _InputIterator, _Allocator)
-    -> set<__iter_value_type<_InputIterator>, less<__iter_value_type<_InputIterator>>, _Allocator>;
+set(_InputIterator,
+    _InputIterator,
+    _Allocator) -> set<__iter_value_type<_InputIterator>, less<__iter_value_type<_InputIterator>>, _Allocator>;
 
 #  if _LIBCPP_STD_VER >= 23
 template <ranges::input_range _Range, class _Allocator, class = enable_if_t<__is_allocator<_Allocator>::value, void>>
-set(from_range_t, _Range&&, _Allocator)
-    -> set<ranges::range_value_t<_Range>, less<ranges::range_value_t<_Range>>, _Allocator>;
+set(from_range_t,
+    _Range&&,
+    _Allocator) -> set<ranges::range_value_t<_Range>, less<ranges::range_value_t<_Range>>, _Allocator>;
 #  endif
 
 template <class _Key, class _Allocator, class = enable_if_t<__is_allocator<_Allocator>::value, void>>
@@ -1376,8 +1378,9 @@ template <class _Key,
           class _Allocator = allocator<_Key>,
           class            = enable_if_t<__is_allocator<_Allocator>::value, void>,
           class            = enable_if_t<!__is_allocator<_Compare>::value, void>>
-multiset(initializer_list<_Key>, _Compare = _Compare(), _Allocator = _Allocator())
-    -> multiset<_Key, _Compare, _Allocator>;
+multiset(initializer_list<_Key>,
+         _Compare   = _Compare(),
+         _Allocator = _Allocator()) -> multiset<_Key, _Compare, _Allocator>;
 
 template <class _InputIterator,
           class _Allocator,
@@ -1388,8 +1391,9 @@ multiset(_InputIterator, _InputIterator, _Allocator)
 
 #  if _LIBCPP_STD_VER >= 23
 template <ranges::input_range _Range, class _Allocator, class = enable_if_t<__is_allocator<_Allocator>::value, void>>
-multiset(from_range_t, _Range&&, _Allocator)
-    -> multiset<ranges::range_value_t<_Range>, less<ranges::range_value_t<_Range>>, _Allocator>;
+multiset(from_range_t,
+         _Range&&,
+         _Allocator) -> multiset<ranges::range_value_t<_Range>, less<ranges::range_value_t<_Range>>, _Allocator>;
 #  endif
 
 template <class _Key, class _Allocator, class = enable_if_t<__is_allocator<_Allocator>::value, void>>

--- a/libcxx/include/shared_mutex
+++ b/libcxx/include/shared_mutex
@@ -220,8 +220,8 @@ public:
 };
 #  endif
 
-class _LIBCPP_EXPORTED_FROM_ABI _LIBCPP_THREAD_SAFETY_ANNOTATION(__capability__("shared_timed_mutex"))
-    shared_timed_mutex {
+class _LIBCPP_EXPORTED_FROM_ABI
+_LIBCPP_THREAD_SAFETY_ANNOTATION(__capability__("shared_timed_mutex")) shared_timed_mutex {
   __shared_mutex_base __base_;
 
 public:

--- a/libcxx/include/span
+++ b/libcxx/include/span
@@ -206,12 +206,12 @@ struct __is_std_span<span<_Tp, _Sz>> : true_type {};
 
 template <class _Range, class _ElementType>
 concept __span_compatible_range =
-    ranges::contiguous_range<_Range> &&                            //
-    ranges::sized_range<_Range> &&                                 //
-    (ranges::borrowed_range<_Range> || is_const_v<_ElementType>)&& //
-    !__is_std_span<remove_cvref_t<_Range>>::value &&               //
-    !__is_std_array<remove_cvref_t<_Range>>::value &&              //
-    !is_array_v<remove_cvref_t<_Range>> &&                         //
+    ranges::contiguous_range<_Range> &&                             //
+    ranges::sized_range<_Range> &&                                  //
+    (ranges::borrowed_range<_Range> || is_const_v<_ElementType>) && //
+    !__is_std_span<remove_cvref_t<_Range>>::value &&                //
+    !__is_std_array<remove_cvref_t<_Range>>::value &&               //
+    !is_array_v<remove_cvref_t<_Range>> &&                          //
     is_convertible_v<remove_reference_t<ranges::range_reference_t<_Range>> (*)[], _ElementType (*)[]>;
 
 template <class _From, class _To>
@@ -326,8 +326,8 @@ public:
   }
 
   template <size_t _Offset, size_t _Count = dynamic_extent>
-  _LIBCPP_HIDE_FROM_ABI constexpr auto subspan() const noexcept
-      -> span<element_type, _Count != dynamic_extent ? _Count : _Extent - _Offset> {
+  _LIBCPP_HIDE_FROM_ABI constexpr auto
+  subspan() const noexcept -> span<element_type, _Count != dynamic_extent ? _Count : _Extent - _Offset> {
     static_assert(_Offset <= _Extent, "span<T, N>::subspan<Offset, Count>(): Offset out of range");
     static_assert(_Count == dynamic_extent || _Count <= _Extent - _Offset,
                   "span<T, N>::subspan<Offset, Count>(): Offset + Count out of range");

--- a/libcxx/include/stack
+++ b/libcxx/include/stack
@@ -219,7 +219,7 @@ public:
   template <class _InputIterator,
             class _Alloc,
             __enable_if_t<__has_input_iterator_category<_InputIterator>::value, int> = 0,
-            __enable_if_t<uses_allocator<container_type, _Alloc>::value, int> = 0>
+            __enable_if_t<uses_allocator<container_type, _Alloc>::value, int>        = 0>
   _LIBCPP_HIDE_FROM_ABI stack(_InputIterator __first, _InputIterator __last, const _Alloc& __alloc)
       : c(__first, __last, __alloc) {}
 
@@ -254,13 +254,13 @@ public:
   template <class... _Args>
   _LIBCPP_HIDE_FROM_ABI
 #  if _LIBCPP_STD_VER >= 17
-      decltype(auto)
-      emplace(_Args&&... __args) {
+  decltype(auto)
+  emplace(_Args&&... __args) {
     return c.emplace_back(std::forward<_Args>(__args)...);
   }
 #  else
-      void
-      emplace(_Args&&... __args) {
+  void
+  emplace(_Args&&... __args) {
     c.emplace_back(std::forward<_Args>(__args)...);
   }
 #  endif
@@ -303,13 +303,15 @@ stack(from_range_t, _Range&&) -> stack<ranges::range_value_t<_Range>>;
 template <class _InputIterator,
           class _Alloc,
           __enable_if_t<__has_input_iterator_category<_InputIterator>::value, int> = 0,
-          __enable_if_t<__is_allocator<_Alloc>::value, int> = 0>
-stack(_InputIterator, _InputIterator, _Alloc)
-    -> stack<__iter_value_type<_InputIterator>, deque<__iter_value_type<_InputIterator>, _Alloc>>;
+          __enable_if_t<__is_allocator<_Alloc>::value, int>                        = 0>
+stack(_InputIterator,
+      _InputIterator,
+      _Alloc) -> stack<__iter_value_type<_InputIterator>, deque<__iter_value_type<_InputIterator>, _Alloc>>;
 
 template <ranges::input_range _Range, class _Alloc, __enable_if_t<__is_allocator<_Alloc>::value, int> = 0>
-stack(from_range_t, _Range&&, _Alloc)
-    -> stack<ranges::range_value_t<_Range>, deque<ranges::range_value_t<_Range>, _Alloc>>;
+stack(from_range_t,
+      _Range&&,
+      _Alloc) -> stack<ranges::range_value_t<_Range>, deque<ranges::range_value_t<_Range>, _Alloc>>;
 
 #endif
 

--- a/libcxx/include/string
+++ b/libcxx/include/string
@@ -750,28 +750,27 @@ public:
       void>;
 #endif
 #if !defined(_LIBCPP_HAS_NO_ASAN) && defined(_LIBCPP_INSTRUMENTED_WITH_ASAN)
-  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20
-  pointer __asan_volatile_wrapper(pointer const &__ptr) const {
+  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 pointer __asan_volatile_wrapper(pointer const& __ptr) const {
     if (__libcpp_is_constant_evaluated())
       return __ptr;
 
     pointer volatile __copy_ptr = __ptr;
 
-    return const_cast<pointer &>(__copy_ptr);
+    return const_cast<pointer&>(__copy_ptr);
   }
 
-  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20
-  const_pointer __asan_volatile_wrapper(const_pointer const &__ptr) const {
+  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 const_pointer
+  __asan_volatile_wrapper(const_pointer const& __ptr) const {
     if (__libcpp_is_constant_evaluated())
       return __ptr;
 
     const_pointer volatile __copy_ptr = __ptr;
 
-    return const_cast<const_pointer &>(__copy_ptr);
+    return const_cast<const_pointer&>(__copy_ptr);
   }
-#define _LIBCPP_ASAN_VOLATILE_WRAPPER(PTR) __asan_volatile_wrapper(PTR)
+#  define _LIBCPP_ASAN_VOLATILE_WRAPPER(PTR) __asan_volatile_wrapper(PTR)
 #else
-#define _LIBCPP_ASAN_VOLATILE_WRAPPER(PTR) PTR
+#  define _LIBCPP_ASAN_VOLATILE_WRAPPER(PTR) PTR
 #endif
 
   static_assert(!is_array<value_type>::value, "Character type of basic_string must not be an array");
@@ -1094,8 +1093,8 @@ public:
             __enable_if_t<__can_be_converted_to_string_view<_CharT, _Traits, _Tp>::value &&
                               !__is_same_uncvref<_Tp, basic_string>::value,
                           int> = 0>
-  _LIBCPP_METHOD_TEMPLATE_IMPLICIT_INSTANTIATION_VIS _LIBCPP_CONSTEXPR_SINCE_CXX20 explicit basic_string(
-      const _Tp& __t, const allocator_type& __a)
+  _LIBCPP_METHOD_TEMPLATE_IMPLICIT_INSTANTIATION_VIS
+  _LIBCPP_CONSTEXPR_SINCE_CXX20 explicit basic_string(const _Tp& __t, const allocator_type& __a)
       : __r_(__default_init_tag(), __a) {
     __self_view __sv = __t;
     __init(__sv.data(), __sv.size());
@@ -1327,8 +1326,8 @@ public:
                           int> = 0>
   _LIBCPP_METHOD_TEMPLATE_IMPLICIT_INSTANTIATION_VIS _LIBCPP_CONSTEXPR_SINCE_CXX20
 
-      basic_string&
-      append(const _Tp& __t, size_type __pos, size_type __n = npos);
+  basic_string&
+  append(const _Tp& __t, size_type __pos, size_type __n = npos);
 
   _LIBCPP_CONSTEXPR_SINCE_CXX20 basic_string& append(const value_type* __s, size_type __n);
   _LIBCPP_CONSTEXPR_SINCE_CXX20 basic_string& append(const value_type* __s);
@@ -1910,10 +1909,12 @@ private:
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 const_pointer __get_long_pointer() const _NOEXCEPT {
     return _LIBCPP_ASAN_VOLATILE_WRAPPER(__r_.first().__l.__data_);
   }
-  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 _LIBCPP_STRING_INTERNAL_MEMORY_ACCESS pointer __get_short_pointer() _NOEXCEPT {
+  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 _LIBCPP_STRING_INTERNAL_MEMORY_ACCESS pointer
+  __get_short_pointer() _NOEXCEPT {
     return _LIBCPP_ASAN_VOLATILE_WRAPPER(pointer_traits<pointer>::pointer_to(__r_.first().__s.__data_[0]));
   }
-  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 _LIBCPP_STRING_INTERNAL_MEMORY_ACCESS const_pointer __get_short_pointer() const _NOEXCEPT {
+  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 _LIBCPP_STRING_INTERNAL_MEMORY_ACCESS const_pointer
+  __get_short_pointer() const _NOEXCEPT {
     return _LIBCPP_ASAN_VOLATILE_WRAPPER(pointer_traits<const_pointer>::pointer_to(__r_.first().__s.__data_[0]));
   }
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 pointer __get_pointer() _NOEXCEPT {
@@ -2009,15 +2010,15 @@ private:
 
   _LIBCPP_CONSTEXPR_SINCE_CXX20
 #if _LIBCPP_ABI_VERSION >= 2 //  We want to use the function in the dylib in ABIv1
-      _LIBCPP_HIDE_FROM_ABI
+  _LIBCPP_HIDE_FROM_ABI
 #endif
-          _LIBCPP_DEPRECATED_("use __grow_by_without_replace") void __grow_by(
-              size_type __old_cap,
-              size_type __delta_cap,
-              size_type __old_sz,
-              size_type __n_copy,
-              size_type __n_del,
-              size_type __n_add = 0);
+  _LIBCPP_DEPRECATED_("use __grow_by_without_replace") void __grow_by(
+      size_type __old_cap,
+      size_type __delta_cap,
+      size_type __old_sz,
+      size_type __n_copy,
+      size_type __n_del,
+      size_type __n_add = 0);
   _LIBCPP_CONSTEXPR_SINCE_CXX20 _LIBCPP_HIDE_FROM_ABI void __grow_by_without_replace(
       size_type __old_cap,
       size_type __delta_cap,
@@ -2183,8 +2184,8 @@ template <class _CharT,
           class _Traits,
           class _Allocator = allocator<_CharT>,
           class            = enable_if_t<__is_allocator<_Allocator>::value> >
-explicit basic_string(basic_string_view<_CharT, _Traits>, const _Allocator& = _Allocator())
-    -> basic_string<_CharT, _Traits, _Allocator>;
+explicit basic_string(basic_string_view<_CharT, _Traits>,
+                      const _Allocator& = _Allocator()) -> basic_string<_CharT, _Traits, _Allocator>;
 
 template <class _CharT,
           class _Traits,
@@ -2419,15 +2420,15 @@ _LIBCPP_CONSTEXPR_SINCE_CXX20 void basic_string<_CharT, _Traits, _Allocator>::__
 template <class _CharT, class _Traits, class _Allocator>
 void _LIBCPP_CONSTEXPR_SINCE_CXX20
 #if _LIBCPP_ABI_VERSION >= 2 // We want to use the function in the dylib in ABIv1
-    _LIBCPP_HIDE_FROM_ABI
+_LIBCPP_HIDE_FROM_ABI
 #endif
-    _LIBCPP_DEPRECATED_("use __grow_by_without_replace") basic_string<_CharT, _Traits, _Allocator>::__grow_by(
-        size_type __old_cap,
-        size_type __delta_cap,
-        size_type __old_sz,
-        size_type __n_copy,
-        size_type __n_del,
-        size_type __n_add) {
+_LIBCPP_DEPRECATED_("use __grow_by_without_replace") basic_string<_CharT, _Traits, _Allocator>::__grow_by(
+    size_type __old_cap,
+    size_type __delta_cap,
+    size_type __old_sz,
+    size_type __n_copy,
+    size_type __n_del,
+    size_type __n_add) {
   size_type __ms = max_size();
   if (__delta_cap > __ms - __old_cap)
     __throw_length_error();

--- a/libcxx/include/string_view
+++ b/libcxx/include/string_view
@@ -394,9 +394,7 @@ public:
     return numeric_limits<size_type>::max() / sizeof(value_type);
   }
 
-  _LIBCPP_NODISCARD _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR bool empty() const _NOEXCEPT {
-    return __size_ == 0;
-  }
+  _LIBCPP_NODISCARD _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR bool empty() const _NOEXCEPT { return __size_ == 0; }
 
   // [string.view.access], element access
   _LIBCPP_CONSTEXPR _LIBCPP_HIDE_FROM_ABI const_reference operator[](size_type __pos) const _NOEXCEPT {

--- a/libcxx/include/strstream
+++ b/libcxx/include/strstream
@@ -141,18 +141,18 @@ private:
 #if _LIBCPP_STD_VER < 26 || defined(_LIBCPP_ENABLE_CXX26_REMOVED_STRSTREAM) || defined(_LIBCPP_BUILDING_LIBRARY)
 
 _LIBCPP_PUSH_MACROS
-#include <__undef_macros>
+#  include <__undef_macros>
 
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 class _LIBCPP_DEPRECATED _LIBCPP_EXPORTED_FROM_ABI strstreambuf : public streambuf {
 public:
-#ifndef _LIBCPP_CXX03_LANG
+#  ifndef _LIBCPP_CXX03_LANG
   _LIBCPP_HIDE_FROM_ABI strstreambuf() : strstreambuf(0) {}
   explicit strstreambuf(streamsize __alsize);
-#else
+#  else
   explicit strstreambuf(streamsize __alsize = 0);
-#endif
+#  endif
   strstreambuf(void* (*__palloc)(size_t), void (*__pfree)(void*));
   strstreambuf(char* __gnext, streamsize __n, char* __pbeg = nullptr);
   strstreambuf(const char* __gnext, streamsize __n);
@@ -162,10 +162,10 @@ public:
   strstreambuf(unsigned char* __gnext, streamsize __n, unsigned char* __pbeg = nullptr);
   strstreambuf(const unsigned char* __gnext, streamsize __n);
 
-#ifndef _LIBCPP_CXX03_LANG
+#  ifndef _LIBCPP_CXX03_LANG
   _LIBCPP_HIDE_FROM_ABI strstreambuf(strstreambuf&& __rhs);
   _LIBCPP_HIDE_FROM_ABI strstreambuf& operator=(strstreambuf&& __rhs);
-#endif // _LIBCPP_CXX03_LANG
+#  endif // _LIBCPP_CXX03_LANG
 
   ~strstreambuf() override;
 
@@ -199,7 +199,7 @@ private:
   void __init(char* __gnext, streamsize __n, char* __pbeg);
 };
 
-#ifndef _LIBCPP_CXX03_LANG
+#  ifndef _LIBCPP_CXX03_LANG
 
 inline _LIBCPP_HIDE_FROM_ABI strstreambuf::strstreambuf(strstreambuf&& __rhs)
     : streambuf(__rhs),
@@ -228,7 +228,7 @@ inline _LIBCPP_HIDE_FROM_ABI strstreambuf& strstreambuf::operator=(strstreambuf&
   return *this;
 }
 
-#endif // _LIBCPP_CXX03_LANG
+#  endif // _LIBCPP_CXX03_LANG
 
 class _LIBCPP_DEPRECATED _LIBCPP_EXPORTED_FROM_ABI istrstream : public istream {
 public:
@@ -237,7 +237,7 @@ public:
   _LIBCPP_HIDE_FROM_ABI istrstream(const char* __s, streamsize __n) : istream(&__sb_), __sb_(__s, __n) {}
   _LIBCPP_HIDE_FROM_ABI istrstream(char* __s, streamsize __n) : istream(&__sb_), __sb_(__s, __n) {}
 
-#ifndef _LIBCPP_CXX03_LANG
+#  ifndef _LIBCPP_CXX03_LANG
   _LIBCPP_HIDE_FROM_ABI istrstream(istrstream&& __rhs) // extension
       : istream(std::move(static_cast<istream&>(__rhs))), __sb_(std::move(__rhs.__sb_)) {
     istream::set_rdbuf(&__sb_);
@@ -248,7 +248,7 @@ public:
     istream::operator=(std::move(__rhs));
     return *this;
   }
-#endif // _LIBCPP_CXX03_LANG
+#  endif // _LIBCPP_CXX03_LANG
 
   ~istrstream() override;
 
@@ -270,7 +270,7 @@ public:
   _LIBCPP_HIDE_FROM_ABI ostrstream(char* __s, int __n, ios_base::openmode __mode = ios_base::out)
       : ostream(&__sb_), __sb_(__s, __n, __s + (__mode & ios::app ? std::strlen(__s) : 0)) {}
 
-#ifndef _LIBCPP_CXX03_LANG
+#  ifndef _LIBCPP_CXX03_LANG
   _LIBCPP_HIDE_FROM_ABI ostrstream(ostrstream&& __rhs) // extension
       : ostream(std::move(static_cast<ostream&>(__rhs))), __sb_(std::move(__rhs.__sb_)) {
     ostream::set_rdbuf(&__sb_);
@@ -281,7 +281,7 @@ public:
     ostream::operator=(std::move(__rhs));
     return *this;
   }
-#endif // _LIBCPP_CXX03_LANG
+#  endif // _LIBCPP_CXX03_LANG
 
   ~ostrstream() override;
 
@@ -312,7 +312,7 @@ public:
   _LIBCPP_HIDE_FROM_ABI strstream(char* __s, int __n, ios_base::openmode __mode = ios_base::in | ios_base::out)
       : iostream(&__sb_), __sb_(__s, __n, __s + (__mode & ios::app ? std::strlen(__s) : 0)) {}
 
-#ifndef _LIBCPP_CXX03_LANG
+#  ifndef _LIBCPP_CXX03_LANG
   _LIBCPP_HIDE_FROM_ABI strstream(strstream&& __rhs) // extension
       : iostream(std::move(static_cast<iostream&>(__rhs))), __sb_(std::move(__rhs.__sb_)) {
     iostream::set_rdbuf(&__sb_);
@@ -323,7 +323,7 @@ public:
     iostream::operator=(std::move(__rhs));
     return *this;
   }
-#endif // _LIBCPP_CXX03_LANG
+#  endif // _LIBCPP_CXX03_LANG
 
   ~strstream() override;
 

--- a/libcxx/include/tuple
+++ b/libcxx/include/tuple
@@ -279,8 +279,7 @@ class __tuple_leaf;
 
 template <size_t _Ip, class _Hp, bool _Ep>
 inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 void
-swap(__tuple_leaf<_Ip, _Hp, _Ep>& __x, __tuple_leaf<_Ip, _Hp, _Ep>& __y)
-    _NOEXCEPT_(__is_nothrow_swappable_v<_Hp>) {
+swap(__tuple_leaf<_Ip, _Hp, _Ep>& __x, __tuple_leaf<_Ip, _Hp, _Ep>& __y) _NOEXCEPT_(__is_nothrow_swappable_v<_Hp>) {
   swap(__x.get(), __y.get());
 }
 
@@ -327,9 +326,9 @@ public:
     static_assert(!is_reference<_Hp>::value, "Attempted to default construct a reference element in a tuple");
   }
 
-  template <class _Tp,
-            __enable_if_t<_And<_IsNotSame<__remove_cvref_t<_Tp>, __tuple_leaf>, is_constructible<_Hp, _Tp> >::value,
-                           int> = 0>
+  template <
+      class _Tp,
+      __enable_if_t<_And<_IsNotSame<__remove_cvref_t<_Tp>, __tuple_leaf>, is_constructible<_Hp, _Tp> >::value, int> = 0>
   _LIBCPP_HIDE_FROM_ABI
   _LIBCPP_CONSTEXPR_SINCE_CXX14 explicit __tuple_leaf(_Tp&& __t) _NOEXCEPT_(is_nothrow_constructible<_Hp, _Tp>::value)
       : __value_(std::forward<_Tp>(__t)) {
@@ -338,23 +337,23 @@ public:
   }
 
   template <class _Tp, class _Alloc>
-  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 explicit __tuple_leaf(
-      integral_constant<int, 0>, const _Alloc&, _Tp&& __t)
+  _LIBCPP_HIDE_FROM_ABI
+  _LIBCPP_CONSTEXPR_SINCE_CXX14 explicit __tuple_leaf(integral_constant<int, 0>, const _Alloc&, _Tp&& __t)
       : __value_(std::forward<_Tp>(__t)) {
     static_assert(__can_bind_reference<_Tp&&>(),
                   "Attempted construction of reference element binds to a temporary whose lifetime has ended");
   }
 
   template <class _Tp, class _Alloc>
-  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 explicit __tuple_leaf(
-      integral_constant<int, 1>, const _Alloc& __a, _Tp&& __t)
+  _LIBCPP_HIDE_FROM_ABI
+  _LIBCPP_CONSTEXPR_SINCE_CXX14 explicit __tuple_leaf(integral_constant<int, 1>, const _Alloc& __a, _Tp&& __t)
       : __value_(allocator_arg_t(), __a, std::forward<_Tp>(__t)) {
     static_assert(!is_reference<_Hp>::value, "Attempted to uses-allocator construct a reference element in a tuple");
   }
 
   template <class _Tp, class _Alloc>
-  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 explicit __tuple_leaf(
-      integral_constant<int, 2>, const _Alloc& __a, _Tp&& __t)
+  _LIBCPP_HIDE_FROM_ABI
+  _LIBCPP_CONSTEXPR_SINCE_CXX14 explicit __tuple_leaf(integral_constant<int, 2>, const _Alloc& __a, _Tp&& __t)
       : __value_(std::forward<_Tp>(__t), __a) {
     static_assert(!is_reference<_Hp>::value, "Attempted to uses-allocator construct a reference element in a tuple");
   }
@@ -565,9 +564,9 @@ public:
   // tuple(const T&...) constructors (including allocator_arg_t variants)
   template <template <class...> class _And = _And,
             __enable_if_t< _And< _BoolConstant<sizeof...(_Tp) >= 1>, is_copy_constructible<_Tp>... >::value, int> = 0>
-  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 explicit(
-      _Not<_Lazy<_And, is_convertible<const _Tp&, _Tp>...> >::value) tuple(const _Tp&... __t)
-      _NOEXCEPT_(_And<is_nothrow_copy_constructible<_Tp>...>::value)
+  _LIBCPP_HIDE_FROM_ABI
+  _LIBCPP_CONSTEXPR_SINCE_CXX14 explicit(_Not<_Lazy<_And, is_convertible<const _Tp&, _Tp>...> >::value)
+      tuple(const _Tp&... __t) _NOEXCEPT_(_And<is_nothrow_copy_constructible<_Tp>...>::value)
       : __base_(typename __make_tuple_indices<sizeof...(_Tp)>::type(),
                 typename __make_tuple_types<tuple, sizeof...(_Tp)>::type(),
                 typename __make_tuple_indices<0>::type(),
@@ -577,8 +576,8 @@ public:
   template <class _Alloc,
             template <class...> class _And = _And,
             __enable_if_t< _And< _BoolConstant<sizeof...(_Tp) >= 1>, is_copy_constructible<_Tp>... >::value, int> = 0>
-  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 explicit(
-      _Not<_Lazy<_And, is_convertible<const _Tp&, _Tp>...> >::value)
+  _LIBCPP_HIDE_FROM_ABI
+  _LIBCPP_CONSTEXPR_SINCE_CXX20 explicit(_Not<_Lazy<_And, is_convertible<const _Tp&, _Tp>...> >::value)
       tuple(allocator_arg_t, const _Alloc& __a, const _Tp&... __t)
       : __base_(allocator_arg_t(),
                 __a,
@@ -669,16 +668,16 @@ public:
                         _Not<is_constructible<_Tp, _OtherTuple> >... > > > {};
 
   template <class... _Up, __enable_if_t< _And< _EnableCtorFromUTypesTuple<const tuple<_Up...>&> >::value, int> = 0>
-  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 explicit(
-      _Not<_Lazy<_And, is_convertible<const _Up&, _Tp>...> >::value) tuple(const tuple<_Up...>& __t)
-      _NOEXCEPT_(_And<is_nothrow_constructible<_Tp, const _Up&>...>::value)
+  _LIBCPP_HIDE_FROM_ABI
+  _LIBCPP_CONSTEXPR_SINCE_CXX14 explicit(_Not<_Lazy<_And, is_convertible<const _Up&, _Tp>...> >::value)
+      tuple(const tuple<_Up...>& __t) _NOEXCEPT_(_And<is_nothrow_constructible<_Tp, const _Up&>...>::value)
       : __base_(__t) {}
 
   template <class... _Up,
             class _Alloc,
             __enable_if_t< _And< _EnableCtorFromUTypesTuple<const tuple<_Up...>&> >::value, int> = 0>
-  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 explicit(
-      _Not<_Lazy<_And, is_convertible<const _Up&, _Tp>...> >::value)
+  _LIBCPP_HIDE_FROM_ABI
+  _LIBCPP_CONSTEXPR_SINCE_CXX20 explicit(_Not<_Lazy<_And, is_convertible<const _Up&, _Tp>...> >::value)
       tuple(allocator_arg_t, const _Alloc& __a, const tuple<_Up...>& __t)
       : __base_(allocator_arg_t(), __a, __t) {}
 
@@ -753,9 +752,9 @@ public:
             class _Up2,
             template <class...> class _And                                                   = _And,
             __enable_if_t< _And< _EnableCtorFromPair<const pair<_Up1, _Up2>&> >::value, int> = 0>
-  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 explicit(
-      _Not<_BothImplicitlyConvertible<const pair<_Up1, _Up2>&> >::value) tuple(const pair<_Up1, _Up2>& __p)
-      _NOEXCEPT_(_NothrowConstructibleFromPair<const pair<_Up1, _Up2>&>::value)
+  _LIBCPP_HIDE_FROM_ABI
+  _LIBCPP_CONSTEXPR_SINCE_CXX14 explicit(_Not<_BothImplicitlyConvertible<const pair<_Up1, _Up2>&> >::value)
+      tuple(const pair<_Up1, _Up2>& __p) _NOEXCEPT_(_NothrowConstructibleFromPair<const pair<_Up1, _Up2>&>::value)
       : __base_(__p) {}
 
   template <class _Alloc,
@@ -763,8 +762,8 @@ public:
             class _Up2,
             template <class...> class _And                                                   = _And,
             __enable_if_t< _And< _EnableCtorFromPair<const pair<_Up1, _Up2>&> >::value, int> = 0>
-  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 explicit(
-      _Not<_BothImplicitlyConvertible<const pair<_Up1, _Up2>&> >::value)
+  _LIBCPP_HIDE_FROM_ABI
+  _LIBCPP_CONSTEXPR_SINCE_CXX20 explicit(_Not<_BothImplicitlyConvertible<const pair<_Up1, _Up2>&> >::value)
       tuple(allocator_arg_t, const _Alloc& __a, const pair<_Up1, _Up2>& __p)
       : __base_(allocator_arg_t(), __a, __p) {}
 
@@ -791,9 +790,9 @@ public:
             class _Up2,
             template <class...> class _And                                              = _And,
             __enable_if_t< _And< _EnableCtorFromPair<pair<_Up1, _Up2>&&> >::value, int> = 0>
-  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 explicit(
-      _Not<_BothImplicitlyConvertible<pair<_Up1, _Up2>&&> >::value) tuple(pair<_Up1, _Up2>&& __p)
-      _NOEXCEPT_(_NothrowConstructibleFromPair<pair<_Up1, _Up2>&&>::value)
+  _LIBCPP_HIDE_FROM_ABI
+  _LIBCPP_CONSTEXPR_SINCE_CXX14 explicit(_Not<_BothImplicitlyConvertible<pair<_Up1, _Up2>&&> >::value)
+      tuple(pair<_Up1, _Up2>&& __p) _NOEXCEPT_(_NothrowConstructibleFromPair<pair<_Up1, _Up2>&&>::value)
       : __base_(std::move(__p)) {}
 
   template <class _Alloc,
@@ -801,8 +800,8 @@ public:
             class _Up2,
             template <class...> class _And                                              = _And,
             __enable_if_t< _And< _EnableCtorFromPair<pair<_Up1, _Up2>&&> >::value, int> = 0>
-  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 explicit(
-      _Not<_BothImplicitlyConvertible<pair<_Up1, _Up2>&&> >::value)
+  _LIBCPP_HIDE_FROM_ABI
+  _LIBCPP_CONSTEXPR_SINCE_CXX20 explicit(_Not<_BothImplicitlyConvertible<pair<_Up1, _Up2>&&> >::value)
       tuple(allocator_arg_t, const _Alloc& __a, pair<_Up1, _Up2>&& __p)
       : __base_(allocator_arg_t(), __a, std::move(__p)) {}
 
@@ -1315,8 +1314,8 @@ template <class... _Types, size_t... _I0, size_t... _J0>
 struct __tuple_cat<tuple<_Types...>, __tuple_indices<_I0...>, __tuple_indices<_J0...> > {
   template <class _Tuple0>
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14
-      typename __tuple_cat_return_ref<tuple<_Types...>&&, _Tuple0&&>::type
-      operator()(tuple<_Types...> __t, _Tuple0&& __t0) {
+  typename __tuple_cat_return_ref<tuple<_Types...>&&, _Tuple0&&>::type
+  operator()(tuple<_Types...> __t, _Tuple0&& __t0) {
     (void)__t; // avoid unused parameter warning on GCC when _I0 is empty
     return std::forward_as_tuple(
         std::forward<_Types>(std::get<_I0>(__t))..., std::get<_J0>(std::forward<_Tuple0>(__t0))...);
@@ -1324,8 +1323,8 @@ struct __tuple_cat<tuple<_Types...>, __tuple_indices<_I0...>, __tuple_indices<_J
 
   template <class _Tuple0, class _Tuple1, class... _Tuples>
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14
-      typename __tuple_cat_return_ref<tuple<_Types...>&&, _Tuple0&&, _Tuple1&&, _Tuples&&...>::type
-      operator()(tuple<_Types...> __t, _Tuple0&& __t0, _Tuple1&& __t1, _Tuples&&... __tpls) {
+  typename __tuple_cat_return_ref<tuple<_Types...>&&, _Tuple0&&, _Tuple1&&, _Tuples&&...>::type
+  operator()(tuple<_Types...> __t, _Tuple0&& __t0, _Tuple1&& __t1, _Tuples&&... __tpls) {
     (void)__t; // avoid unused parameter warning on GCC when _I0 is empty
     typedef _LIBCPP_NODEBUG __libcpp_remove_reference_t<_Tuple0> _T0;
     typedef _LIBCPP_NODEBUG __libcpp_remove_reference_t<_Tuple1> _T1;

--- a/libcxx/include/unordered_map
+++ b/libcxx/include/unordered_map
@@ -1415,13 +1415,11 @@ public:
     return __table_.__equal_range_unique(__k);
   }
 #if _LIBCPP_STD_VER >= 20
-  template <class _K2,
-            enable_if_t<__is_transparent_v<hasher, _K2> && __is_transparent_v<key_equal, _K2>>* = nullptr>
+  template <class _K2, enable_if_t<__is_transparent_v<hasher, _K2> && __is_transparent_v<key_equal, _K2>>* = nullptr>
   _LIBCPP_HIDE_FROM_ABI pair<iterator, iterator> equal_range(const _K2& __k) {
     return __table_.__equal_range_unique(__k);
   }
-  template <class _K2,
-            enable_if_t<__is_transparent_v<hasher, _K2> && __is_transparent_v<key_equal, _K2>>* = nullptr>
+  template <class _K2, enable_if_t<__is_transparent_v<hasher, _K2> && __is_transparent_v<key_equal, _K2>>* = nullptr>
   _LIBCPP_HIDE_FROM_ABI pair<const_iterator, const_iterator> equal_range(const _K2& __k) const {
     return __table_.__equal_range_unique(__k);
   }
@@ -2162,13 +2160,11 @@ public:
     return __table_.__equal_range_multi(__k);
   }
 #if _LIBCPP_STD_VER >= 20
-  template <class _K2,
-            enable_if_t<__is_transparent_v<hasher, _K2> && __is_transparent_v<key_equal, _K2>>* = nullptr>
+  template <class _K2, enable_if_t<__is_transparent_v<hasher, _K2> && __is_transparent_v<key_equal, _K2>>* = nullptr>
   _LIBCPP_HIDE_FROM_ABI pair<iterator, iterator> equal_range(const _K2& __k) {
     return __table_.__equal_range_multi(__k);
   }
-  template <class _K2,
-            enable_if_t<__is_transparent_v<hasher, _K2> && __is_transparent_v<key_equal, _K2>>* = nullptr>
+  template <class _K2, enable_if_t<__is_transparent_v<hasher, _K2> && __is_transparent_v<key_equal, _K2>>* = nullptr>
   _LIBCPP_HIDE_FROM_ABI pair<const_iterator, const_iterator> equal_range(const _K2& __k) const {
     return __table_.__equal_range_multi(__k);
   }
@@ -2243,12 +2239,12 @@ template <class _Key,
           class            = enable_if_t<!is_integral<_Hash>::value>,
           class            = enable_if_t<!__is_allocator<_Pred>::value>,
           class            = enable_if_t<__is_allocator<_Allocator>::value>>
-unordered_multimap(initializer_list<pair<_Key, _Tp>>,
-                   typename allocator_traits<_Allocator>::size_type = 0,
-                   _Hash                                            = _Hash(),
-                   _Pred                                            = _Pred(),
-                   _Allocator                                       = _Allocator())
-    -> unordered_multimap<remove_const_t<_Key>, _Tp, _Hash, _Pred, _Allocator>;
+unordered_multimap(
+    initializer_list<pair<_Key, _Tp>>,
+    typename allocator_traits<_Allocator>::size_type = 0,
+    _Hash                                            = _Hash(),
+    _Pred                                            = _Pred(),
+    _Allocator = _Allocator()) -> unordered_multimap<remove_const_t<_Key>, _Tp, _Hash, _Pred, _Allocator>;
 
 template <class _InputIterator,
           class _Allocator,

--- a/libcxx/include/unordered_set
+++ b/libcxx/include/unordered_set
@@ -928,13 +928,13 @@ template <ranges::input_range _Range,
           class            = enable_if_t<!is_integral<_Hash>::value>,
           class            = enable_if_t<!__is_allocator<_Pred>::value>,
           class            = enable_if_t<__is_allocator<_Allocator>::value>>
-unordered_set(from_range_t,
-              _Range&&,
-              typename allocator_traits<_Allocator>::size_type = 0,
-              _Hash                                            = _Hash(),
-              _Pred                                            = _Pred(),
-              _Allocator                                       = _Allocator())
-    -> unordered_set<ranges::range_value_t<_Range>, _Hash, _Pred, _Allocator>; // C++23
+unordered_set(
+    from_range_t,
+    _Range&&,
+    typename allocator_traits<_Allocator>::size_type = 0,
+    _Hash                                            = _Hash(),
+    _Pred                                            = _Pred(),
+    _Allocator = _Allocator()) -> unordered_set<ranges::range_value_t<_Range>, _Hash, _Pred, _Allocator>; // C++23
 #  endif
 
 template <class _Tp,

--- a/libcxx/include/valarray
+++ b/libcxx/include/valarray
@@ -2667,8 +2667,8 @@ operator*(const _Expr1& __x, const _Expr2& __y) {
 
 template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> = 0>
 inline _LIBCPP_HIDE_FROM_ABI
-    __val_expr<_BinaryOp<multiplies<typename _Expr::value_type>, _Expr, __scalar_expr<typename _Expr::value_type> > >
-    operator*(const _Expr& __x, const typename _Expr::value_type& __y) {
+__val_expr<_BinaryOp<multiplies<typename _Expr::value_type>, _Expr, __scalar_expr<typename _Expr::value_type> > >
+operator*(const _Expr& __x, const typename _Expr::value_type& __y) {
   typedef typename _Expr::value_type value_type;
   typedef _BinaryOp<multiplies<value_type>, _Expr, __scalar_expr<value_type> > _Op;
   return __val_expr<_Op>(_Op(multiplies<value_type>(), __x, __scalar_expr<value_type>(__y, __x.size())));
@@ -2676,8 +2676,8 @@ inline _LIBCPP_HIDE_FROM_ABI
 
 template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> = 0>
 inline _LIBCPP_HIDE_FROM_ABI
-    __val_expr<_BinaryOp<multiplies<typename _Expr::value_type>, __scalar_expr<typename _Expr::value_type>, _Expr> >
-    operator*(const typename _Expr::value_type& __x, const _Expr& __y) {
+__val_expr<_BinaryOp<multiplies<typename _Expr::value_type>, __scalar_expr<typename _Expr::value_type>, _Expr> >
+operator*(const typename _Expr::value_type& __x, const _Expr& __y) {
   typedef typename _Expr::value_type value_type;
   typedef _BinaryOp<multiplies<value_type>, __scalar_expr<value_type>, _Expr> _Op;
   return __val_expr<_Op>(_Op(multiplies<value_type>(), __scalar_expr<value_type>(__x, __y.size()), __y));
@@ -2695,8 +2695,8 @@ operator/(const _Expr1& __x, const _Expr2& __y) {
 
 template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> = 0>
 inline _LIBCPP_HIDE_FROM_ABI
-    __val_expr<_BinaryOp<divides<typename _Expr::value_type>, _Expr, __scalar_expr<typename _Expr::value_type> > >
-    operator/(const _Expr& __x, const typename _Expr::value_type& __y) {
+__val_expr<_BinaryOp<divides<typename _Expr::value_type>, _Expr, __scalar_expr<typename _Expr::value_type> > >
+operator/(const _Expr& __x, const typename _Expr::value_type& __y) {
   typedef typename _Expr::value_type value_type;
   typedef _BinaryOp<divides<value_type>, _Expr, __scalar_expr<value_type> > _Op;
   return __val_expr<_Op>(_Op(divides<value_type>(), __x, __scalar_expr<value_type>(__y, __x.size())));
@@ -2704,8 +2704,8 @@ inline _LIBCPP_HIDE_FROM_ABI
 
 template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> = 0>
 inline _LIBCPP_HIDE_FROM_ABI
-    __val_expr<_BinaryOp<divides<typename _Expr::value_type>, __scalar_expr<typename _Expr::value_type>, _Expr> >
-    operator/(const typename _Expr::value_type& __x, const _Expr& __y) {
+__val_expr<_BinaryOp<divides<typename _Expr::value_type>, __scalar_expr<typename _Expr::value_type>, _Expr> >
+operator/(const typename _Expr::value_type& __x, const _Expr& __y) {
   typedef typename _Expr::value_type value_type;
   typedef _BinaryOp<divides<value_type>, __scalar_expr<value_type>, _Expr> _Op;
   return __val_expr<_Op>(_Op(divides<value_type>(), __scalar_expr<value_type>(__x, __y.size()), __y));
@@ -2723,8 +2723,8 @@ operator%(const _Expr1& __x, const _Expr2& __y) {
 
 template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> = 0>
 inline _LIBCPP_HIDE_FROM_ABI
-    __val_expr<_BinaryOp<modulus<typename _Expr::value_type>, _Expr, __scalar_expr<typename _Expr::value_type> > >
-    operator%(const _Expr& __x, const typename _Expr::value_type& __y) {
+__val_expr<_BinaryOp<modulus<typename _Expr::value_type>, _Expr, __scalar_expr<typename _Expr::value_type> > >
+operator%(const _Expr& __x, const typename _Expr::value_type& __y) {
   typedef typename _Expr::value_type value_type;
   typedef _BinaryOp<modulus<value_type>, _Expr, __scalar_expr<value_type> > _Op;
   return __val_expr<_Op>(_Op(modulus<value_type>(), __x, __scalar_expr<value_type>(__y, __x.size())));
@@ -2732,8 +2732,8 @@ inline _LIBCPP_HIDE_FROM_ABI
 
 template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> = 0>
 inline _LIBCPP_HIDE_FROM_ABI
-    __val_expr<_BinaryOp<modulus<typename _Expr::value_type>, __scalar_expr<typename _Expr::value_type>, _Expr> >
-    operator%(const typename _Expr::value_type& __x, const _Expr& __y) {
+__val_expr<_BinaryOp<modulus<typename _Expr::value_type>, __scalar_expr<typename _Expr::value_type>, _Expr> >
+operator%(const typename _Expr::value_type& __x, const _Expr& __y) {
   typedef typename _Expr::value_type value_type;
   typedef _BinaryOp<modulus<value_type>, __scalar_expr<value_type>, _Expr> _Op;
   return __val_expr<_Op>(_Op(modulus<value_type>(), __scalar_expr<value_type>(__x, __y.size()), __y));
@@ -2751,8 +2751,8 @@ operator+(const _Expr1& __x, const _Expr2& __y) {
 
 template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> = 0>
 inline _LIBCPP_HIDE_FROM_ABI
-    __val_expr<_BinaryOp<plus<typename _Expr::value_type>, _Expr, __scalar_expr<typename _Expr::value_type> > >
-    operator+(const _Expr& __x, const typename _Expr::value_type& __y) {
+__val_expr<_BinaryOp<plus<typename _Expr::value_type>, _Expr, __scalar_expr<typename _Expr::value_type> > >
+operator+(const _Expr& __x, const typename _Expr::value_type& __y) {
   typedef typename _Expr::value_type value_type;
   typedef _BinaryOp<plus<value_type>, _Expr, __scalar_expr<value_type> > _Op;
   return __val_expr<_Op>(_Op(plus<value_type>(), __x, __scalar_expr<value_type>(__y, __x.size())));
@@ -2760,8 +2760,8 @@ inline _LIBCPP_HIDE_FROM_ABI
 
 template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> = 0>
 inline _LIBCPP_HIDE_FROM_ABI
-    __val_expr<_BinaryOp<plus<typename _Expr::value_type>, __scalar_expr<typename _Expr::value_type>, _Expr> >
-    operator+(const typename _Expr::value_type& __x, const _Expr& __y) {
+__val_expr<_BinaryOp<plus<typename _Expr::value_type>, __scalar_expr<typename _Expr::value_type>, _Expr> >
+operator+(const typename _Expr::value_type& __x, const _Expr& __y) {
   typedef typename _Expr::value_type value_type;
   typedef _BinaryOp<plus<value_type>, __scalar_expr<value_type>, _Expr> _Op;
   return __val_expr<_Op>(_Op(plus<value_type>(), __scalar_expr<value_type>(__x, __y.size()), __y));
@@ -2779,8 +2779,8 @@ operator-(const _Expr1& __x, const _Expr2& __y) {
 
 template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> = 0>
 inline _LIBCPP_HIDE_FROM_ABI
-    __val_expr<_BinaryOp<minus<typename _Expr::value_type>, _Expr, __scalar_expr<typename _Expr::value_type> > >
-    operator-(const _Expr& __x, const typename _Expr::value_type& __y) {
+__val_expr<_BinaryOp<minus<typename _Expr::value_type>, _Expr, __scalar_expr<typename _Expr::value_type> > >
+operator-(const _Expr& __x, const typename _Expr::value_type& __y) {
   typedef typename _Expr::value_type value_type;
   typedef _BinaryOp<minus<value_type>, _Expr, __scalar_expr<value_type> > _Op;
   return __val_expr<_Op>(_Op(minus<value_type>(), __x, __scalar_expr<value_type>(__y, __x.size())));
@@ -2788,8 +2788,8 @@ inline _LIBCPP_HIDE_FROM_ABI
 
 template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> = 0>
 inline _LIBCPP_HIDE_FROM_ABI
-    __val_expr<_BinaryOp<minus<typename _Expr::value_type>, __scalar_expr<typename _Expr::value_type>, _Expr> >
-    operator-(const typename _Expr::value_type& __x, const _Expr& __y) {
+__val_expr<_BinaryOp<minus<typename _Expr::value_type>, __scalar_expr<typename _Expr::value_type>, _Expr> >
+operator-(const typename _Expr::value_type& __x, const _Expr& __y) {
   typedef typename _Expr::value_type value_type;
   typedef _BinaryOp<minus<value_type>, __scalar_expr<value_type>, _Expr> _Op;
   return __val_expr<_Op>(_Op(minus<value_type>(), __scalar_expr<value_type>(__x, __y.size()), __y));
@@ -2807,8 +2807,8 @@ operator^(const _Expr1& __x, const _Expr2& __y) {
 
 template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> = 0>
 inline _LIBCPP_HIDE_FROM_ABI
-    __val_expr<_BinaryOp<bit_xor<typename _Expr::value_type>, _Expr, __scalar_expr<typename _Expr::value_type> > >
-    operator^(const _Expr& __x, const typename _Expr::value_type& __y) {
+__val_expr<_BinaryOp<bit_xor<typename _Expr::value_type>, _Expr, __scalar_expr<typename _Expr::value_type> > >
+operator^(const _Expr& __x, const typename _Expr::value_type& __y) {
   typedef typename _Expr::value_type value_type;
   typedef _BinaryOp<bit_xor<value_type>, _Expr, __scalar_expr<value_type> > _Op;
   return __val_expr<_Op>(_Op(bit_xor<value_type>(), __x, __scalar_expr<value_type>(__y, __x.size())));
@@ -2816,8 +2816,8 @@ inline _LIBCPP_HIDE_FROM_ABI
 
 template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> = 0>
 inline _LIBCPP_HIDE_FROM_ABI
-    __val_expr<_BinaryOp<bit_xor<typename _Expr::value_type>, __scalar_expr<typename _Expr::value_type>, _Expr> >
-    operator^(const typename _Expr::value_type& __x, const _Expr& __y) {
+__val_expr<_BinaryOp<bit_xor<typename _Expr::value_type>, __scalar_expr<typename _Expr::value_type>, _Expr> >
+operator^(const typename _Expr::value_type& __x, const _Expr& __y) {
   typedef typename _Expr::value_type value_type;
   typedef _BinaryOp<bit_xor<value_type>, __scalar_expr<value_type>, _Expr> _Op;
   return __val_expr<_Op>(_Op(bit_xor<value_type>(), __scalar_expr<value_type>(__x, __y.size()), __y));
@@ -2835,8 +2835,8 @@ operator&(const _Expr1& __x, const _Expr2& __y) {
 
 template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> = 0>
 inline _LIBCPP_HIDE_FROM_ABI
-    __val_expr<_BinaryOp<bit_and<typename _Expr::value_type>, _Expr, __scalar_expr<typename _Expr::value_type> > >
-    operator&(const _Expr& __x, const typename _Expr::value_type& __y) {
+__val_expr<_BinaryOp<bit_and<typename _Expr::value_type>, _Expr, __scalar_expr<typename _Expr::value_type> > >
+operator&(const _Expr& __x, const typename _Expr::value_type& __y) {
   typedef typename _Expr::value_type value_type;
   typedef _BinaryOp<bit_and<value_type>, _Expr, __scalar_expr<value_type> > _Op;
   return __val_expr<_Op>(_Op(bit_and<value_type>(), __x, __scalar_expr<value_type>(__y, __x.size())));
@@ -2844,8 +2844,8 @@ inline _LIBCPP_HIDE_FROM_ABI
 
 template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> = 0>
 inline _LIBCPP_HIDE_FROM_ABI
-    __val_expr<_BinaryOp<bit_and<typename _Expr::value_type>, __scalar_expr<typename _Expr::value_type>, _Expr> >
-    operator&(const typename _Expr::value_type& __x, const _Expr& __y) {
+__val_expr<_BinaryOp<bit_and<typename _Expr::value_type>, __scalar_expr<typename _Expr::value_type>, _Expr> >
+operator&(const typename _Expr::value_type& __x, const _Expr& __y) {
   typedef typename _Expr::value_type value_type;
   typedef _BinaryOp<bit_and<value_type>, __scalar_expr<value_type>, _Expr> _Op;
   return __val_expr<_Op>(_Op(bit_and<value_type>(), __scalar_expr<value_type>(__x, __y.size()), __y));
@@ -2863,8 +2863,8 @@ operator|(const _Expr1& __x, const _Expr2& __y) {
 
 template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> = 0>
 inline _LIBCPP_HIDE_FROM_ABI
-    __val_expr<_BinaryOp<bit_or<typename _Expr::value_type>, _Expr, __scalar_expr<typename _Expr::value_type> > >
-    operator|(const _Expr& __x, const typename _Expr::value_type& __y) {
+__val_expr<_BinaryOp<bit_or<typename _Expr::value_type>, _Expr, __scalar_expr<typename _Expr::value_type> > >
+operator|(const _Expr& __x, const typename _Expr::value_type& __y) {
   typedef typename _Expr::value_type value_type;
   typedef _BinaryOp<bit_or<value_type>, _Expr, __scalar_expr<value_type> > _Op;
   return __val_expr<_Op>(_Op(bit_or<value_type>(), __x, __scalar_expr<value_type>(__y, __x.size())));
@@ -2872,8 +2872,8 @@ inline _LIBCPP_HIDE_FROM_ABI
 
 template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> = 0>
 inline _LIBCPP_HIDE_FROM_ABI
-    __val_expr<_BinaryOp<bit_or<typename _Expr::value_type>, __scalar_expr<typename _Expr::value_type>, _Expr> >
-    operator|(const typename _Expr::value_type& __x, const _Expr& __y) {
+__val_expr<_BinaryOp<bit_or<typename _Expr::value_type>, __scalar_expr<typename _Expr::value_type>, _Expr> >
+operator|(const typename _Expr::value_type& __x, const _Expr& __y) {
   typedef typename _Expr::value_type value_type;
   typedef _BinaryOp<bit_or<value_type>, __scalar_expr<value_type>, _Expr> _Op;
   return __val_expr<_Op>(_Op(bit_or<value_type>(), __scalar_expr<value_type>(__x, __y.size()), __y));
@@ -2890,8 +2890,8 @@ operator<<(const _Expr1& __x, const _Expr2& __y) {
 }
 
 template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> = 0>
-inline _LIBCPP_HIDE_FROM_ABI __val_expr<
-    _BinaryOp<__bit_shift_left<typename _Expr::value_type>, _Expr, __scalar_expr<typename _Expr::value_type> > >
+inline _LIBCPP_HIDE_FROM_ABI
+__val_expr< _BinaryOp<__bit_shift_left<typename _Expr::value_type>, _Expr, __scalar_expr<typename _Expr::value_type> > >
 operator<<(const _Expr& __x, const typename _Expr::value_type& __y) {
   typedef typename _Expr::value_type value_type;
   typedef _BinaryOp<__bit_shift_left<value_type>, _Expr, __scalar_expr<value_type> > _Op;
@@ -2899,8 +2899,8 @@ operator<<(const _Expr& __x, const typename _Expr::value_type& __y) {
 }
 
 template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> = 0>
-inline _LIBCPP_HIDE_FROM_ABI __val_expr<
-    _BinaryOp<__bit_shift_left<typename _Expr::value_type>, __scalar_expr<typename _Expr::value_type>, _Expr> >
+inline _LIBCPP_HIDE_FROM_ABI
+__val_expr< _BinaryOp<__bit_shift_left<typename _Expr::value_type>, __scalar_expr<typename _Expr::value_type>, _Expr> >
 operator<<(const typename _Expr::value_type& __x, const _Expr& __y) {
   typedef typename _Expr::value_type value_type;
   typedef _BinaryOp<__bit_shift_left<value_type>, __scalar_expr<value_type>, _Expr> _Op;
@@ -2927,8 +2927,8 @@ operator>>(const _Expr& __x, const typename _Expr::value_type& __y) {
 }
 
 template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> = 0>
-inline _LIBCPP_HIDE_FROM_ABI __val_expr<
-    _BinaryOp<__bit_shift_right<typename _Expr::value_type>, __scalar_expr<typename _Expr::value_type>, _Expr> >
+inline _LIBCPP_HIDE_FROM_ABI
+__val_expr< _BinaryOp<__bit_shift_right<typename _Expr::value_type>, __scalar_expr<typename _Expr::value_type>, _Expr> >
 operator>>(const typename _Expr::value_type& __x, const _Expr& __y) {
   typedef typename _Expr::value_type value_type;
   typedef _BinaryOp<__bit_shift_right<value_type>, __scalar_expr<value_type>, _Expr> _Op;
@@ -2947,8 +2947,8 @@ operator&&(const _Expr1& __x, const _Expr2& __y) {
 
 template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> = 0>
 inline _LIBCPP_HIDE_FROM_ABI
-    __val_expr<_BinaryOp<logical_and<typename _Expr::value_type>, _Expr, __scalar_expr<typename _Expr::value_type> > >
-    operator&&(const _Expr& __x, const typename _Expr::value_type& __y) {
+__val_expr<_BinaryOp<logical_and<typename _Expr::value_type>, _Expr, __scalar_expr<typename _Expr::value_type> > >
+operator&&(const _Expr& __x, const typename _Expr::value_type& __y) {
   typedef typename _Expr::value_type value_type;
   typedef _BinaryOp<logical_and<value_type>, _Expr, __scalar_expr<value_type> > _Op;
   return __val_expr<_Op>(_Op(logical_and<value_type>(), __x, __scalar_expr<value_type>(__y, __x.size())));
@@ -2956,8 +2956,8 @@ inline _LIBCPP_HIDE_FROM_ABI
 
 template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> = 0>
 inline _LIBCPP_HIDE_FROM_ABI
-    __val_expr<_BinaryOp<logical_and<typename _Expr::value_type>, __scalar_expr<typename _Expr::value_type>, _Expr> >
-    operator&&(const typename _Expr::value_type& __x, const _Expr& __y) {
+__val_expr<_BinaryOp<logical_and<typename _Expr::value_type>, __scalar_expr<typename _Expr::value_type>, _Expr> >
+operator&&(const typename _Expr::value_type& __x, const _Expr& __y) {
   typedef typename _Expr::value_type value_type;
   typedef _BinaryOp<logical_and<value_type>, __scalar_expr<value_type>, _Expr> _Op;
   return __val_expr<_Op>(_Op(logical_and<value_type>(), __scalar_expr<value_type>(__x, __y.size()), __y));
@@ -2975,8 +2975,8 @@ operator||(const _Expr1& __x, const _Expr2& __y) {
 
 template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> = 0>
 inline _LIBCPP_HIDE_FROM_ABI
-    __val_expr<_BinaryOp<logical_or<typename _Expr::value_type>, _Expr, __scalar_expr<typename _Expr::value_type> > >
-    operator||(const _Expr& __x, const typename _Expr::value_type& __y) {
+__val_expr<_BinaryOp<logical_or<typename _Expr::value_type>, _Expr, __scalar_expr<typename _Expr::value_type> > >
+operator||(const _Expr& __x, const typename _Expr::value_type& __y) {
   typedef typename _Expr::value_type value_type;
   typedef _BinaryOp<logical_or<value_type>, _Expr, __scalar_expr<value_type> > _Op;
   return __val_expr<_Op>(_Op(logical_or<value_type>(), __x, __scalar_expr<value_type>(__y, __x.size())));
@@ -2984,8 +2984,8 @@ inline _LIBCPP_HIDE_FROM_ABI
 
 template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> = 0>
 inline _LIBCPP_HIDE_FROM_ABI
-    __val_expr<_BinaryOp<logical_or<typename _Expr::value_type>, __scalar_expr<typename _Expr::value_type>, _Expr> >
-    operator||(const typename _Expr::value_type& __x, const _Expr& __y) {
+__val_expr<_BinaryOp<logical_or<typename _Expr::value_type>, __scalar_expr<typename _Expr::value_type>, _Expr> >
+operator||(const typename _Expr::value_type& __x, const _Expr& __y) {
   typedef typename _Expr::value_type value_type;
   typedef _BinaryOp<logical_or<value_type>, __scalar_expr<value_type>, _Expr> _Op;
   return __val_expr<_Op>(_Op(logical_or<value_type>(), __scalar_expr<value_type>(__x, __y.size()), __y));
@@ -3003,8 +3003,8 @@ operator==(const _Expr1& __x, const _Expr2& __y) {
 
 template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> = 0>
 inline _LIBCPP_HIDE_FROM_ABI
-    __val_expr<_BinaryOp<equal_to<typename _Expr::value_type>, _Expr, __scalar_expr<typename _Expr::value_type> > >
-    operator==(const _Expr& __x, const typename _Expr::value_type& __y) {
+__val_expr<_BinaryOp<equal_to<typename _Expr::value_type>, _Expr, __scalar_expr<typename _Expr::value_type> > >
+operator==(const _Expr& __x, const typename _Expr::value_type& __y) {
   typedef typename _Expr::value_type value_type;
   typedef _BinaryOp<equal_to<value_type>, _Expr, __scalar_expr<value_type> > _Op;
   return __val_expr<_Op>(_Op(equal_to<value_type>(), __x, __scalar_expr<value_type>(__y, __x.size())));
@@ -3012,8 +3012,8 @@ inline _LIBCPP_HIDE_FROM_ABI
 
 template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> = 0>
 inline _LIBCPP_HIDE_FROM_ABI
-    __val_expr<_BinaryOp<equal_to<typename _Expr::value_type>, __scalar_expr<typename _Expr::value_type>, _Expr> >
-    operator==(const typename _Expr::value_type& __x, const _Expr& __y) {
+__val_expr<_BinaryOp<equal_to<typename _Expr::value_type>, __scalar_expr<typename _Expr::value_type>, _Expr> >
+operator==(const typename _Expr::value_type& __x, const _Expr& __y) {
   typedef typename _Expr::value_type value_type;
   typedef _BinaryOp<equal_to<value_type>, __scalar_expr<value_type>, _Expr> _Op;
   return __val_expr<_Op>(_Op(equal_to<value_type>(), __scalar_expr<value_type>(__x, __y.size()), __y));
@@ -3031,8 +3031,8 @@ operator!=(const _Expr1& __x, const _Expr2& __y) {
 
 template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> = 0>
 inline _LIBCPP_HIDE_FROM_ABI
-    __val_expr<_BinaryOp<not_equal_to<typename _Expr::value_type>, _Expr, __scalar_expr<typename _Expr::value_type> > >
-    operator!=(const _Expr& __x, const typename _Expr::value_type& __y) {
+__val_expr<_BinaryOp<not_equal_to<typename _Expr::value_type>, _Expr, __scalar_expr<typename _Expr::value_type> > >
+operator!=(const _Expr& __x, const typename _Expr::value_type& __y) {
   typedef typename _Expr::value_type value_type;
   typedef _BinaryOp<not_equal_to<value_type>, _Expr, __scalar_expr<value_type> > _Op;
   return __val_expr<_Op>(_Op(not_equal_to<value_type>(), __x, __scalar_expr<value_type>(__y, __x.size())));
@@ -3040,8 +3040,8 @@ inline _LIBCPP_HIDE_FROM_ABI
 
 template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> = 0>
 inline _LIBCPP_HIDE_FROM_ABI
-    __val_expr<_BinaryOp<not_equal_to<typename _Expr::value_type>, __scalar_expr<typename _Expr::value_type>, _Expr> >
-    operator!=(const typename _Expr::value_type& __x, const _Expr& __y) {
+__val_expr<_BinaryOp<not_equal_to<typename _Expr::value_type>, __scalar_expr<typename _Expr::value_type>, _Expr> >
+operator!=(const typename _Expr::value_type& __x, const _Expr& __y) {
   typedef typename _Expr::value_type value_type;
   typedef _BinaryOp<not_equal_to<value_type>, __scalar_expr<value_type>, _Expr> _Op;
   return __val_expr<_Op>(_Op(not_equal_to<value_type>(), __scalar_expr<value_type>(__x, __y.size()), __y));
@@ -3059,8 +3059,8 @@ operator<(const _Expr1& __x, const _Expr2& __y) {
 
 template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> = 0>
 inline _LIBCPP_HIDE_FROM_ABI
-    __val_expr<_BinaryOp<less<typename _Expr::value_type>, _Expr, __scalar_expr<typename _Expr::value_type> > >
-    operator<(const _Expr& __x, const typename _Expr::value_type& __y) {
+__val_expr<_BinaryOp<less<typename _Expr::value_type>, _Expr, __scalar_expr<typename _Expr::value_type> > >
+operator<(const _Expr& __x, const typename _Expr::value_type& __y) {
   typedef typename _Expr::value_type value_type;
   typedef _BinaryOp<less<value_type>, _Expr, __scalar_expr<value_type> > _Op;
   return __val_expr<_Op>(_Op(less<value_type>(), __x, __scalar_expr<value_type>(__y, __x.size())));
@@ -3068,8 +3068,8 @@ inline _LIBCPP_HIDE_FROM_ABI
 
 template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> = 0>
 inline _LIBCPP_HIDE_FROM_ABI
-    __val_expr<_BinaryOp<less<typename _Expr::value_type>, __scalar_expr<typename _Expr::value_type>, _Expr> >
-    operator<(const typename _Expr::value_type& __x, const _Expr& __y) {
+__val_expr<_BinaryOp<less<typename _Expr::value_type>, __scalar_expr<typename _Expr::value_type>, _Expr> >
+operator<(const typename _Expr::value_type& __x, const _Expr& __y) {
   typedef typename _Expr::value_type value_type;
   typedef _BinaryOp<less<value_type>, __scalar_expr<value_type>, _Expr> _Op;
   return __val_expr<_Op>(_Op(less<value_type>(), __scalar_expr<value_type>(__x, __y.size()), __y));
@@ -3087,8 +3087,8 @@ operator>(const _Expr1& __x, const _Expr2& __y) {
 
 template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> = 0>
 inline _LIBCPP_HIDE_FROM_ABI
-    __val_expr<_BinaryOp<greater<typename _Expr::value_type>, _Expr, __scalar_expr<typename _Expr::value_type> > >
-    operator>(const _Expr& __x, const typename _Expr::value_type& __y) {
+__val_expr<_BinaryOp<greater<typename _Expr::value_type>, _Expr, __scalar_expr<typename _Expr::value_type> > >
+operator>(const _Expr& __x, const typename _Expr::value_type& __y) {
   typedef typename _Expr::value_type value_type;
   typedef _BinaryOp<greater<value_type>, _Expr, __scalar_expr<value_type> > _Op;
   return __val_expr<_Op>(_Op(greater<value_type>(), __x, __scalar_expr<value_type>(__y, __x.size())));
@@ -3096,8 +3096,8 @@ inline _LIBCPP_HIDE_FROM_ABI
 
 template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> = 0>
 inline _LIBCPP_HIDE_FROM_ABI
-    __val_expr<_BinaryOp<greater<typename _Expr::value_type>, __scalar_expr<typename _Expr::value_type>, _Expr> >
-    operator>(const typename _Expr::value_type& __x, const _Expr& __y) {
+__val_expr<_BinaryOp<greater<typename _Expr::value_type>, __scalar_expr<typename _Expr::value_type>, _Expr> >
+operator>(const typename _Expr::value_type& __x, const _Expr& __y) {
   typedef typename _Expr::value_type value_type;
   typedef _BinaryOp<greater<value_type>, __scalar_expr<value_type>, _Expr> _Op;
   return __val_expr<_Op>(_Op(greater<value_type>(), __scalar_expr<value_type>(__x, __y.size()), __y));
@@ -3115,8 +3115,8 @@ operator<=(const _Expr1& __x, const _Expr2& __y) {
 
 template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> = 0>
 inline _LIBCPP_HIDE_FROM_ABI
-    __val_expr<_BinaryOp<less_equal<typename _Expr::value_type>, _Expr, __scalar_expr<typename _Expr::value_type> > >
-    operator<=(const _Expr& __x, const typename _Expr::value_type& __y) {
+__val_expr<_BinaryOp<less_equal<typename _Expr::value_type>, _Expr, __scalar_expr<typename _Expr::value_type> > >
+operator<=(const _Expr& __x, const typename _Expr::value_type& __y) {
   typedef typename _Expr::value_type value_type;
   typedef _BinaryOp<less_equal<value_type>, _Expr, __scalar_expr<value_type> > _Op;
   return __val_expr<_Op>(_Op(less_equal<value_type>(), __x, __scalar_expr<value_type>(__y, __x.size())));
@@ -3124,8 +3124,8 @@ inline _LIBCPP_HIDE_FROM_ABI
 
 template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> = 0>
 inline _LIBCPP_HIDE_FROM_ABI
-    __val_expr<_BinaryOp<less_equal<typename _Expr::value_type>, __scalar_expr<typename _Expr::value_type>, _Expr> >
-    operator<=(const typename _Expr::value_type& __x, const _Expr& __y) {
+__val_expr<_BinaryOp<less_equal<typename _Expr::value_type>, __scalar_expr<typename _Expr::value_type>, _Expr> >
+operator<=(const typename _Expr::value_type& __x, const _Expr& __y) {
   typedef typename _Expr::value_type value_type;
   typedef _BinaryOp<less_equal<value_type>, __scalar_expr<value_type>, _Expr> _Op;
   return __val_expr<_Op>(_Op(less_equal<value_type>(), __scalar_expr<value_type>(__x, __y.size()), __y));
@@ -3143,8 +3143,8 @@ operator>=(const _Expr1& __x, const _Expr2& __y) {
 
 template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> = 0>
 inline _LIBCPP_HIDE_FROM_ABI
-    __val_expr<_BinaryOp<greater_equal<typename _Expr::value_type>, _Expr, __scalar_expr<typename _Expr::value_type> > >
-    operator>=(const _Expr& __x, const typename _Expr::value_type& __y) {
+__val_expr<_BinaryOp<greater_equal<typename _Expr::value_type>, _Expr, __scalar_expr<typename _Expr::value_type> > >
+operator>=(const _Expr& __x, const typename _Expr::value_type& __y) {
   typedef typename _Expr::value_type value_type;
   typedef _BinaryOp<greater_equal<value_type>, _Expr, __scalar_expr<value_type> > _Op;
   return __val_expr<_Op>(_Op(greater_equal<value_type>(), __x, __scalar_expr<value_type>(__y, __x.size())));
@@ -3152,8 +3152,8 @@ inline _LIBCPP_HIDE_FROM_ABI
 
 template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> = 0>
 inline _LIBCPP_HIDE_FROM_ABI
-    __val_expr<_BinaryOp<greater_equal<typename _Expr::value_type>, __scalar_expr<typename _Expr::value_type>, _Expr> >
-    operator>=(const typename _Expr::value_type& __x, const _Expr& __y) {
+__val_expr<_BinaryOp<greater_equal<typename _Expr::value_type>, __scalar_expr<typename _Expr::value_type>, _Expr> >
+operator>=(const typename _Expr::value_type& __x, const _Expr& __y) {
   typedef typename _Expr::value_type value_type;
   typedef _BinaryOp<greater_equal<value_type>, __scalar_expr<value_type>, _Expr> _Op;
   return __val_expr<_Op>(_Op(greater_equal<value_type>(), __scalar_expr<value_type>(__x, __y.size()), __y));
@@ -3203,8 +3203,8 @@ atan2(const _Expr1& __x, const _Expr2& __y) {
 
 template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> = 0>
 inline _LIBCPP_HIDE_FROM_ABI
-    __val_expr<_BinaryOp<__atan2_expr<typename _Expr::value_type>, _Expr, __scalar_expr<typename _Expr::value_type> > >
-    atan2(const _Expr& __x, const typename _Expr::value_type& __y) {
+__val_expr<_BinaryOp<__atan2_expr<typename _Expr::value_type>, _Expr, __scalar_expr<typename _Expr::value_type> > >
+atan2(const _Expr& __x, const typename _Expr::value_type& __y) {
   typedef typename _Expr::value_type value_type;
   typedef _BinaryOp<__atan2_expr<value_type>, _Expr, __scalar_expr<value_type> > _Op;
   return __val_expr<_Op>(_Op(__atan2_expr<value_type>(), __x, __scalar_expr<value_type>(__y, __x.size())));
@@ -3212,8 +3212,8 @@ inline _LIBCPP_HIDE_FROM_ABI
 
 template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> = 0>
 inline _LIBCPP_HIDE_FROM_ABI
-    __val_expr<_BinaryOp<__atan2_expr<typename _Expr::value_type>, __scalar_expr<typename _Expr::value_type>, _Expr> >
-    atan2(const typename _Expr::value_type& __x, const _Expr& __y) {
+__val_expr<_BinaryOp<__atan2_expr<typename _Expr::value_type>, __scalar_expr<typename _Expr::value_type>, _Expr> >
+atan2(const typename _Expr::value_type& __x, const _Expr& __y) {
   typedef typename _Expr::value_type value_type;
   typedef _BinaryOp<__atan2_expr<value_type>, __scalar_expr<value_type>, _Expr> _Op;
   return __val_expr<_Op>(_Op(__atan2_expr<value_type>(), __scalar_expr<value_type>(__x, __y.size()), __y));
@@ -3271,8 +3271,8 @@ pow(const _Expr1& __x, const _Expr2& __y) {
 
 template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> = 0>
 inline _LIBCPP_HIDE_FROM_ABI
-    __val_expr<_BinaryOp<__pow_expr<typename _Expr::value_type>, _Expr, __scalar_expr<typename _Expr::value_type> > >
-    pow(const _Expr& __x, const typename _Expr::value_type& __y) {
+__val_expr<_BinaryOp<__pow_expr<typename _Expr::value_type>, _Expr, __scalar_expr<typename _Expr::value_type> > >
+pow(const _Expr& __x, const typename _Expr::value_type& __y) {
   typedef typename _Expr::value_type value_type;
   typedef _BinaryOp<__pow_expr<value_type>, _Expr, __scalar_expr<value_type> > _Op;
   return __val_expr<_Op>(_Op(__pow_expr<value_type>(), __x, __scalar_expr<value_type>(__y, __x.size())));
@@ -3280,8 +3280,8 @@ inline _LIBCPP_HIDE_FROM_ABI
 
 template <class _Expr, __enable_if_t<__is_val_expr<_Expr>::value, int> = 0>
 inline _LIBCPP_HIDE_FROM_ABI
-    __val_expr<_BinaryOp<__pow_expr<typename _Expr::value_type>, __scalar_expr<typename _Expr::value_type>, _Expr> >
-    pow(const typename _Expr::value_type& __x, const _Expr& __y) {
+__val_expr<_BinaryOp<__pow_expr<typename _Expr::value_type>, __scalar_expr<typename _Expr::value_type>, _Expr> >
+pow(const typename _Expr::value_type& __x, const _Expr& __y) {
   typedef typename _Expr::value_type value_type;
   typedef _BinaryOp<__pow_expr<value_type>, __scalar_expr<value_type>, _Expr> _Op;
   return __val_expr<_Op>(_Op(__pow_expr<value_type>(), __scalar_expr<value_type>(__x, __y.size()), __y));

--- a/libcxx/include/variant
+++ b/libcxx/include/variant
@@ -1358,8 +1358,8 @@ _LIBCPP_HIDE_FROM_ABI _LIBCPP_AVAILABILITY_THROW_BAD_VARIANT_ACCESS constexpr au
 
 template <size_t _Ip, class... _Types>
 _LIBCPP_HIDE_FROM_ABI
-    _LIBCPP_AVAILABILITY_THROW_BAD_VARIANT_ACCESS constexpr variant_alternative_t<_Ip, variant<_Types...>>&
-    get(variant<_Types...>& __v) {
+_LIBCPP_AVAILABILITY_THROW_BAD_VARIANT_ACCESS constexpr variant_alternative_t<_Ip, variant<_Types...>>&
+get(variant<_Types...>& __v) {
   static_assert(_Ip < sizeof...(_Types));
   static_assert(!is_void_v<variant_alternative_t<_Ip, variant<_Types...>>>);
   return std::__generic_get<_Ip>(__v);
@@ -1367,8 +1367,8 @@ _LIBCPP_HIDE_FROM_ABI
 
 template <size_t _Ip, class... _Types>
 _LIBCPP_HIDE_FROM_ABI
-    _LIBCPP_AVAILABILITY_THROW_BAD_VARIANT_ACCESS constexpr variant_alternative_t<_Ip, variant<_Types...>>&&
-    get(variant<_Types...>&& __v) {
+_LIBCPP_AVAILABILITY_THROW_BAD_VARIANT_ACCESS constexpr variant_alternative_t<_Ip, variant<_Types...>>&&
+get(variant<_Types...>&& __v) {
   static_assert(_Ip < sizeof...(_Types));
   static_assert(!is_void_v<variant_alternative_t<_Ip, variant<_Types...>>>);
   return std::__generic_get<_Ip>(std::move(__v));
@@ -1376,8 +1376,8 @@ _LIBCPP_HIDE_FROM_ABI
 
 template <size_t _Ip, class... _Types>
 _LIBCPP_HIDE_FROM_ABI
-    _LIBCPP_AVAILABILITY_THROW_BAD_VARIANT_ACCESS constexpr const variant_alternative_t<_Ip, variant<_Types...>>&
-    get(const variant<_Types...>& __v) {
+_LIBCPP_AVAILABILITY_THROW_BAD_VARIANT_ACCESS constexpr const variant_alternative_t<_Ip, variant<_Types...>>&
+get(const variant<_Types...>& __v) {
   static_assert(_Ip < sizeof...(_Types));
   static_assert(!is_void_v<variant_alternative_t<_Ip, variant<_Types...>>>);
   return std::__generic_get<_Ip>(__v);
@@ -1385,8 +1385,8 @@ _LIBCPP_HIDE_FROM_ABI
 
 template <size_t _Ip, class... _Types>
 _LIBCPP_HIDE_FROM_ABI
-    _LIBCPP_AVAILABILITY_THROW_BAD_VARIANT_ACCESS constexpr const variant_alternative_t<_Ip, variant<_Types...>>&&
-    get(const variant<_Types...>&& __v) {
+_LIBCPP_AVAILABILITY_THROW_BAD_VARIANT_ACCESS constexpr const variant_alternative_t<_Ip, variant<_Types...>>&&
+get(const variant<_Types...>&& __v) {
   static_assert(_Ip < sizeof...(_Types));
   static_assert(!is_void_v<variant_alternative_t<_Ip, variant<_Types...>>>);
   return std::__generic_get<_Ip>(std::move(__v));
@@ -1588,8 +1588,8 @@ visit(_Visitor&& __visitor, _Vs&&... __vs) {
 
 template <class... _Types>
 _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 auto
-swap(variant<_Types...>& __lhs, variant<_Types...>& __rhs) noexcept(noexcept(__lhs.swap(__rhs)))
-    -> decltype(__lhs.swap(__rhs)) {
+swap(variant<_Types...>& __lhs,
+     variant<_Types...>& __rhs) noexcept(noexcept(__lhs.swap(__rhs))) -> decltype(__lhs.swap(__rhs)) {
   return __lhs.swap(__rhs);
 }
 

--- a/libcxx/include/vector
+++ b/libcxx/include/vector
@@ -676,11 +676,11 @@ public:
   template <class... _Args>
   _LIBCPP_CONSTEXPR_SINCE_CXX20 _LIBCPP_HIDE_FROM_ABI
 #if _LIBCPP_STD_VER >= 17
-      reference
-      emplace_back(_Args&&... __args);
+  reference
+  emplace_back(_Args&&... __args);
 #else
-      void
-      emplace_back(_Args&&... __args);
+  void
+  emplace_back(_Args&&... __args);
 #endif
 
 #if _LIBCPP_STD_VER >= 23
@@ -2983,9 +2983,9 @@ _LIBCPP_POP_MACROS
 #  include <concepts>
 #  include <cstdlib>
 #  include <iosfwd>
-#if !defined(_LIBCPP_HAS_NO_LOCALIZATION)
-#  include <locale>
-#endif
+#  if !defined(_LIBCPP_HAS_NO_LOCALIZATION)
+#    include <locale>
+#  endif
 #  include <tuple>
 #  include <type_traits>
 #  include <typeinfo>


### PR DESCRIPTION
As time went by, a few files have become mis-formatted w.r.t. clang-format. This was made worse by the fact that formatting was not being enforced in extensionless headers. This commit simply brings all of libcxx/include in-line with clang-format again.

We might have to do this from time to time as we update our clang-format version, but frankly this is really low effort now that we've formatted everything once.