### PR TITLE
Revert "[X86] Add support for MS inp functions."

### DIFF
--- a/clang/lib/Headers/intrin.h
+++ b/clang/lib/Headers/intrin.h
@@ -329,25 +329,6 @@ static __inline__ void __DEFAULT_FN_ATTRS __stosq(unsigned __int64 *__dst,
 static __inline__ void __DEFAULT_FN_ATTRS __halt(void) {
   __asm__ volatile("hlt");
 }
-
-static inline int _inp(unsigned short port) {
-  int ret;
-  __asm__ volatile("inb %w1, %b0" : "=a"(ret) : "Nd"(port));
-  return ret;
-}
-
-static inline unsigned short _inpw(unsigned short port) {
-  unsigned short ret;
-  __asm__ volatile("inw %w1, %w0" : "=a"(ret) : "Nd"(port));
-  return ret;
-}
-
-static inline unsigned long _inpd(unsigned short port) {
-  unsigned long ret;
-  __asm__ volatile("inl %w1, %k0" : "=a"(ret) : "Nd"(port));
-  return ret;
-}
-
 #endif
 
 #if defined(__i386__) || defined(__x86_64__) || defined(__aarch64__)

--- a/clang/test/CodeGen/X86/ms-x86-intrinsics.c
+++ b/clang/test/CodeGen/X86/ms-x86-intrinsics.c
@@ -63,31 +63,6 @@ unsigned __int64 test__emulu(unsigned int a, unsigned int b) {
 // CHECK: [[RES:%[0-9]+]] = mul nuw i64 [[Y]], [[X]]
 // CHECK: ret i64 [[RES]]
 
-
-int test_inp(unsigned short port) {
-  return _inp(port);
-}
-// CHECK-LABEL: i32 @test_inp(i16 noundef
-// CHECK-SAME:  [[PORT:%.*]])
-// CHECK:       [[TMP0:%.*]] = tail call i32 asm sideeffect "inb ${1:w}, ${0:b}", "={ax},N{dx},~{dirflag},~{fpsr},~{flags}"(i16 [[PORT]])
-// CHECK-NEXT:  ret i32 [[TMP0]]
-
-unsigned short test_inpw(unsigned short port) {
-  return _inpw(port);
-}
-// CHECK-LABEL: i16 @test_inpw(i16 noundef
-// CHECK-SAME:  [[PORT:%.*]])
-// CHECK:       [[TMP0:%.*]] = tail call i16 asm sideeffect "inw ${1:w}, ${0:w}", "={ax},N{dx},~{dirflag},~{fpsr},~{flags}"(i16 [[PORT]])
-// CHECK-NEXT:  ret i16 [[TMP0]]
-
-unsigned long test_inpd(unsigned short port) {
-  return _inpd(port);
-}
-// CHECK-LABEL: i32 @test_inpd(i16 noundef
-// CHECK-SAME:  [[PORT:%.*]])
-// CHECK:       [[TMP0:%.*]] = tail call i32 asm sideeffect "inl ${1:w}, ${0:k}", "={ax},N{dx},~{dirflag},~{fpsr},~{flags}"(i16 [[PORT]])
-// CHECK-NEXT:  ret i32 [[TMP0]]
-
 #if defined(__x86_64__)
 
 char test__readgsbyte(unsigned long Offset) {


### PR DESCRIPTION
Reverts llvm/llvm-project#93804
Revert commit 089dfeee8a8761c35a3a56e75281275871dd53bc. The original request can be fulfilled with alternative __inbyte/__inword/__indword