### PR TITLE
[flang] Change vector always errors to warnings

### DIFF
--- a/flang/lib/Lower/Bridge.cpp
+++ b/flang/lib/Lower/Bridge.cpp
@@ -2607,9 +2607,6 @@ private:
 
     if (e->isA<Fortran::parser::NonLabelDoStmt>())
       e->dirs.push_back(&dir);
-    else
-      fir::emitFatalError(toLocation(),
-                          "loop directive must appear before a loop");
   }
 
   void genFIR(const Fortran::parser::CompilerDirective &dir) {

--- a/flang/lib/Semantics/canonicalize-directives.cpp
+++ b/flang/lib/Semantics/canonicalize-directives.cpp
@@ -104,7 +104,7 @@ void CanonicalizationOfDirectives::CheckLoopDirective(
     std::string s{parser::ToUpperCaseLetters(dir.source.ToString())};
     s.pop_back(); // Remove trailing newline from source string
     messages_.Say(
-        dir.source, "A DO loop must follow the %s directive"_err_en_US, s);
+        dir.source, "A DO loop must follow the %s directive"_warn_en_US, s);
   }
 }
 

--- a/flang/test/Semantics/loop-directives.f90
+++ b/flang/test/Semantics/loop-directives.f90
@@ -1,19 +1,19 @@
-! RUN: %python %S/test_errors.py %s %flang
+! RUN: %python %S/test_errors.py %s %flang_fc1 -Werror
 
 subroutine empty
-  ! ERROR: A DO loop must follow the VECTOR ALWAYS directive
+  ! WARNING: A DO loop must follow the VECTOR ALWAYS directive
   !dir$ vector always
 end subroutine empty
 
 subroutine non_do
-  ! ERROR: A DO loop must follow the VECTOR ALWAYS directive
+  ! WARNING: A DO loop must follow the VECTOR ALWAYS directive
   !dir$ vector always
   a = 1
 end subroutine non_do
 
 subroutine execution_part
   do i=1,10
-  ! ERROR: A DO loop must follow the VECTOR ALWAYS directive
+  ! WARNING: A DO loop must follow the VECTOR ALWAYS directive
   !dir$ vector always
   end do
 end subroutine execution_part


### PR DESCRIPTION
This patch changes the error when !dir$ vector always doesn't appear before a
loop into a warning. It also removes the error while lowering when the vector
always directive has appeared, simply ignoring the directive instead.

Currently no warning is issued when the directive appears in the middle of the
specification part. This should be added in a future patch.

Fixes #95780 
