### PR TITLE
[clang] Emitting a warning if optimizations are enabled with sanitizers

### DIFF
--- a/clang/include/clang/Basic/DiagnosticDriverKinds.td
+++ b/clang/include/clang/Basic/DiagnosticDriverKinds.td
@@ -477,6 +477,8 @@ def warn_drv_disabling_vptr_no_rtti_default : Warning<
 def warn_drv_object_size_disabled_O0 : Warning<
   "the object size sanitizer has no effect at -O0, but is explicitly enabled: %0">,
   InGroup<InvalidCommandLineArgument>, DefaultWarnNoWerror;
+def warn_sanitizer_with_optimization : Warning<
+  "enabling optimizations with sanitizers may potentially reduce effectiveness">;
 def warn_ignoring_verify_debuginfo_preserve_export : Warning<
   "ignoring -fverify-debuginfo-preserve-export=%0 because "
   "-fverify-debuginfo-preserve wasn't enabled">,

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -6208,6 +6208,12 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
     PScpu::addProfileRTArgs(TC, Args, CmdArgs);
     PScpu::addSanitizerArgs(TC, Args, CmdArgs);
   }
+  
+  // Emit a warning if optimizations are enabled with sanitizers
+  if (Args.hasArg(options::OPT_fsanitize_EQ) &&
+      (Args.hasArg(options::OPT_Ofast) || Args.hasArg(options::OPT_O))) {
+    D.Diag(diag::warn_sanitizer_with_optimization);
+  }
 
   // Pass options for controlling the default header search paths.
   if (Args.hasArg(options::OPT_nostdinc)) {

--- a/clang/test/Driver/fsanitize.c
+++ b/clang/test/Driver/fsanitize.c
@@ -1038,3 +1038,10 @@
 // RUN: not %clang --target=aarch64-none-elf -fsanitize=dataflow %s -### 2>&1 | FileCheck %s -check-prefix=UNSUPPORTED-BAREMETAL
 // RUN: not %clang --target=arm-arm-none-eabi -fsanitize=shadow-call-stack %s -### 2>&1 | FileCheck %s -check-prefix=UNSUPPORTED-BAREMETAL
 // UNSUPPORTED-BAREMETAL: unsupported option '-fsanitize={{.*}}' for target
+
+// RUN: %clang -O0 -O1 -fsanitize=address %s -### 2>&1 | FileCheck %s -check-prefix=CHECK-SAN-OPT-WARN
+// RUN: %clang -Ofast -fsanitize=address %s -### 2>&1 | FileCheck %s -check-prefix=CHECK-SAN-OPT-WARN
+// RUN: %clang -O3 -fsanitize=address %s -### 2>&1 | FileCheck %s -check-prefix=CHECK-SAN-OPT-WARN
+// RUN: %clang -O2 -fsanitize=thread %s -### 2>&1 | FileCheck %s -check-prefix=CHECK-SAN-OPT-WARN
+// RUN: %clang -O1 -fsanitize=thread %s -### 2>&1 | FileCheck %s -check-prefix=CHECK-SAN-OPT-WARN
+// CHECK-SAN-OPT-WARN: warning: enabling optimizations with sanitizers may potentially reduce effectiveness


### PR DESCRIPTION
Sanitizers achieve better accuracy with lower optimization levels, and it is generally recommended to use `-O0` (the default optimization level) when using sanitizers for the most accurate results. However, many users might not be aware of this recommendation.

To ensure transparency, we should issue a warning when optimization levels other than `-O0` are enabled alongside sanitizers. This warning will inform users that higher optimization levels can reduce the effectiveness of sanitizers, thereby making them aware of the potential impact on the accuracy of sanitizer.

