### PR TITLE
[IR] Mark shl constant expression as undesirable

### DIFF
--- a/llvm/lib/IR/Constants.cpp
+++ b/llvm/lib/IR/Constants.cpp
@@ -2324,11 +2324,11 @@ bool ConstantExpr::isDesirableBinOp(unsigned Opcode) {
   case Instruction::Or:
   case Instruction::LShr:
   case Instruction::AShr:
+  case Instruction::Shl:
     return false;
   case Instruction::Add:
   case Instruction::Sub:
   case Instruction::Mul:
-  case Instruction::Shl:
   case Instruction::Xor:
     return true;
   default:

--- a/llvm/test/CodeGen/AArch64/stack-tagging-initializer-merge.ll
+++ b/llvm/test/CodeGen/AArch64/stack-tagging-initializer-merge.ll
@@ -304,8 +304,9 @@ define void @InitVectorSplit() sanitize_memtag {
 ; CHECK-NEXT:    [[TX:%.*]] = call ptr @llvm.aarch64.tagp.p0(ptr [[X]], ptr [[BASETAG]], i64 0)
 ; CHECK-NEXT:    call void @llvm.lifetime.start.p0(i64 16, ptr nonnull [[X]])
 ; CHECK-NEXT:    [[TMP0:%.*]] = getelementptr i32, ptr [[TX]], i32 1
+; CHECK-NEXT:    [[TMP1:%.*]] = shl i64 bitcast (<2 x i32> <i32 1, i32 2> to i64), 32
 ; CHECK-NEXT:    [[LSHR:%.*]] = lshr i64 bitcast (<2 x i32> <i32 1, i32 2> to i64), 32
-; CHECK-NEXT:    call void @llvm.aarch64.stgp(ptr [[TX]], i64 shl (i64 bitcast (<2 x i32> <i32 1, i32 2> to i64), i64 32), i64 [[LSHR]])
+; CHECK-NEXT:    call void @llvm.aarch64.stgp(ptr [[TX]], i64 [[TMP1]], i64 [[LSHR]])
 ; CHECK-NEXT:    call void @use(ptr nonnull [[TX]])
 ; CHECK-NEXT:    call void @llvm.aarch64.settag(ptr [[X]], i64 16)
 ; CHECK-NEXT:    call void @llvm.lifetime.end.p0(i64 16, ptr nonnull [[X]])

--- a/llvm/test/CodeGen/AMDGPU/lower-buffer-fat-pointers-constants.ll
+++ b/llvm/test/CodeGen/AMDGPU/lower-buffer-fat-pointers-constants.ll
@@ -143,8 +143,9 @@ define ptr addrspace(7) @gep_p7_from_p7() {
 define i160 @ptrtoint() {
 ; CHECK-LABEL: define i160 @ptrtoint
 ; CHECK-SAME: () #[[ATTR0]] {
-; CHECK-NEXT:    [[TMP1:%.*]] = or i160 shl nuw (i160 ptrtoint (ptr addrspace(8) @buf to i160), i160 32), 12
-; CHECK-NEXT:    ret i160 [[TMP1]]
+; CHECK-NEXT:    [[TMP1:%.*]] = shl nuw i160 ptrtoint (ptr addrspace(8) @buf to i160), 32
+; CHECK-NEXT:    [[TMP2:%.*]] = or i160 [[TMP1]], 12
+; CHECK-NEXT:    ret i160 [[TMP2]]
 ;
   ret i160 ptrtoint(
   ptr addrspace(7) getelementptr(
@@ -155,8 +156,9 @@ define i160 @ptrtoint() {
 define i256 @ptrtoint_long() {
 ; CHECK-LABEL: define i256 @ptrtoint_long
 ; CHECK-SAME: () #[[ATTR0]] {
-; CHECK-NEXT:    [[TMP1:%.*]] = or i256 shl nuw nsw (i256 ptrtoint (ptr addrspace(8) @buf to i256), i256 32), 12
-; CHECK-NEXT:    ret i256 [[TMP1]]
+; CHECK-NEXT:    [[TMP1:%.*]] = shl nuw nsw i256 ptrtoint (ptr addrspace(8) @buf to i256), 32
+; CHECK-NEXT:    [[TMP2:%.*]] = or i256 [[TMP1]], 12
+; CHECK-NEXT:    ret i256 [[TMP2]]
 ;
   ret i256 ptrtoint(
   ptr addrspace(7) getelementptr(
@@ -167,8 +169,9 @@ define i256 @ptrtoint_long() {
 define i64 @ptrtoint_short() {
 ; CHECK-LABEL: define i64 @ptrtoint_short
 ; CHECK-SAME: () #[[ATTR0]] {
-; CHECK-NEXT:    [[TMP1:%.*]] = or i64 shl (i64 ptrtoint (ptr addrspace(8) @buf to i64), i64 32), 12
-; CHECK-NEXT:    ret i64 [[TMP1]]
+; CHECK-NEXT:    [[TMP1:%.*]] = shl i64 ptrtoint (ptr addrspace(8) @buf to i64), 32
+; CHECK-NEXT:    [[TMP2:%.*]] = or i64 [[TMP1]], 12
+; CHECK-NEXT:    ret i64 [[TMP2]]
 ;
   ret i64 ptrtoint(
   ptr addrspace(7) getelementptr(


### PR DESCRIPTION
Mark shl constant expressions undesirable, so that they are no longer automatically created by IRBuilder, constant folding, etc.

This is in preparation for removing them entirely.