### PR TITLE
[llvm][transforms] Add a new algorithm to SplitModule

### DIFF
--- a/llvm/include/llvm/Transforms/Utils/SplitModule.h
+++ b/llvm/include/llvm/Transforms/Utils/SplitModule.h
@@ -35,7 +35,7 @@ class Module;
 void SplitModule(
     Module &M, unsigned N,
     function_ref<void(std::unique_ptr<Module> MPart)> ModuleCallback,
-    bool PreserveLocals = false);
+    bool PreserveLocals = false, bool TryToAvoidEmptyModules = false);
 
 } // end namespace llvm
 

--- a/llvm/include/llvm/Transforms/Utils/SplitModule.h
+++ b/llvm/include/llvm/Transforms/Utils/SplitModule.h
@@ -24,6 +24,9 @@ class Module;
 
 /// Splits the module M into N linkable partitions. The function ModuleCallback
 /// is called N times passing each individual partition as the MPart argument.
+/// PreserveLocals: Split without externalizing locals.
+/// TryToAvoidEmptyModules: Try to avoid generating empty modules by
+/// modifying the distribution of functions.
 ///
 /// FIXME: This function does not deal with the somewhat subtle symbol
 /// visibility issues around module splitting, including (but not limited to):

--- a/llvm/include/llvm/Transforms/Utils/SplitModule.h
+++ b/llvm/include/llvm/Transforms/Utils/SplitModule.h
@@ -25,8 +25,8 @@ class Module;
 /// Splits the module M into N linkable partitions. The function ModuleCallback
 /// is called N times passing each individual partition as the MPart argument.
 /// PreserveLocals: Split without externalizing locals.
-/// TryToAvoidEmptyModules: Try to avoid generating empty modules by
-/// modifying the distribution of functions.
+/// RoundRobin: Use round-robin distribution of functions to modules instead
+/// of the default name-hash-based one.
 ///
 /// FIXME: This function does not deal with the somewhat subtle symbol
 /// visibility issues around module splitting, including (but not limited to):
@@ -38,7 +38,7 @@ class Module;
 void SplitModule(
     Module &M, unsigned N,
     function_ref<void(std::unique_ptr<Module> MPart)> ModuleCallback,
-    bool PreserveLocals = false, bool TryToAvoidEmptyModules = false);
+    bool PreserveLocals = false, bool RoundRobin = false);
 
 } // end namespace llvm
 

--- a/llvm/lib/Transforms/Utils/SplitModule.cpp
+++ b/llvm/lib/Transforms/Utils/SplitModule.cpp
@@ -294,12 +294,14 @@ void llvm::SplitModule(
       if (!NonEmptyModules.contains(I))
         EmptyModules.push_back(I);
     }
-    auto NextEmptyModuleIt = EmptyModules.begin();
-    for (const auto F : UnmappedFunctions) {
-      if (NextEmptyModuleIt == EmptyModules.end())
-        break;
-      ClusterIDMap.insert({F, *NextEmptyModuleIt});
-      ++NextEmptyModuleIt;
+    if (!EmptyModules.empty()) {
+      auto NextEmptyModuleIt = EmptyModules.begin();
+      for (const auto F : UnmappedFunctions) {
+        if (NextEmptyModuleIt == EmptyModules.end())
+          break;
+        ClusterIDMap.insert({F, *NextEmptyModuleIt});
+        ++NextEmptyModuleIt;
+      }
     }
   }
 

--- a/llvm/test/tools/llvm-split/avoid-empty-modules.ll
+++ b/llvm/test/tools/llvm-split/avoid-empty-modules.ll
@@ -1,0 +1,23 @@
+; RUN: llvm-split -o %t %s -j 2 -avoid-empty-modules
+; RUN: llvm-dis -o - %t0 | FileCheck --check-prefix=CHECK0 %s
+; RUN: llvm-dis -o - %t1 | FileCheck --check-prefix=CHECK1 %s
+
+; CHECK0-NOT: define
+; CHECK0: declare extern_weak void @e
+; CHECK0: define void @A
+; CHECK0-NOT: define
+
+; CHECK1-NOT: define
+; CHECK1: declare extern_weak void @e
+; CHECK1: define void @C
+; CHECK1-NOT: define
+
+declare extern_weak void @e(...)
+
+define void @A() {
+  ret void
+}
+
+define void @C() {
+  ret void
+}

--- a/llvm/test/tools/llvm-split/name-hash-based-distribution.ll
+++ b/llvm/test/tools/llvm-split/name-hash-based-distribution.ll
@@ -1,0 +1,17 @@
+; RUN: llvm-split -o %t %s -j 2
+; RUN: llvm-dis -o - %t0 | FileCheck --check-prefix=CHECK0 %s
+; RUN: llvm-dis -o - %t1 | FileCheck --check-prefix=CHECK1 %s
+
+; CHECK0-NOT: define
+
+; CHECK1-NOT: declare
+; CHECK1: define void @A
+; CHECK1: define void @C
+
+define void @A() {
+  ret void
+}
+
+define void @C() {
+  ret void
+}

--- a/llvm/test/tools/llvm-split/name-hash-based-distribution.ll
+++ b/llvm/test/tools/llvm-split/name-hash-based-distribution.ll
@@ -3,15 +3,27 @@
 ; RUN: llvm-dis -o - %t1 | FileCheck --check-prefix=CHECK1 %s
 
 ; CHECK0-NOT: define
+; CHECK0: define void @D
+; CHECK0-NOT: define
 
-; CHECK1-NOT: declare
+; CHECK1-NOT: define
 ; CHECK1: define void @A
+; CHECK1: define void @B
 ; CHECK1: define void @C
+; CHECK1-NOT: define
 
 define void @A() {
   ret void
 }
 
+define void @B() {
+  ret void
+}
+
 define void @C() {
+  ret void
+}
+
+define void @D() {
   ret void
 }

--- a/llvm/test/tools/llvm-split/round-robin.ll
+++ b/llvm/test/tools/llvm-split/round-robin.ll
@@ -1,15 +1,17 @@
-; RUN: llvm-split -o %t %s -j 2 -avoid-empty-modules
+; RUN: llvm-split -o %t %s -j 2 -round-robin
 ; RUN: llvm-dis -o - %t0 | FileCheck --check-prefix=CHECK0 %s
 ; RUN: llvm-dis -o - %t1 | FileCheck --check-prefix=CHECK1 %s
 
 ; CHECK0-NOT: define
 ; CHECK0: declare extern_weak void @e
 ; CHECK0: define void @A
+; CHECK0: define void @C
 ; CHECK0-NOT: define
 
 ; CHECK1-NOT: define
 ; CHECK1: declare extern_weak void @e
-; CHECK1: define void @C
+; CHECK1: define void @B
+; CHECK1: define void @D
 ; CHECK1-NOT: define
 
 declare extern_weak void @e(...)
@@ -18,6 +20,14 @@ define void @A() {
   ret void
 }
 
+define void @B() {
+  ret void
+}
+
 define void @C() {
+  ret void
+}
+
+define void @D() {
   ret void
 }

--- a/llvm/tools/llvm-split/llvm-split.cpp
+++ b/llvm/tools/llvm-split/llvm-split.cpp
@@ -53,6 +53,12 @@ static cl::opt<bool>
                    cl::desc("Split without externalizing locals"),
                    cl::cat(SplitCategory));
 
+static cl::opt<bool>
+    TryToAvoidEmptyModules("avoid-empty-modules", cl::Prefix, cl::init(false),
+                           cl::desc("Try to avoid generating empty modules by "
+                                    "modifying the distribution of functions"),
+                           cl::cat(SplitCategory));
+
 static cl::opt<std::string>
     MTriple("mtriple",
             cl::desc("Target triple. When present, a TargetMachine is created "
@@ -122,6 +128,9 @@ int main(int argc, char **argv) {
       errs() << "warning: -preserve-locals has no effect when using "
                 "TargetMachine::splitModule\n";
     }
+    if (TryToAvoidEmptyModules)
+      errs() << "warning: -avoid-empty-modules has no effect when using "
+                "TargetMachine::splitModule\n";
 
     if (TM->splitModule(*M, NumOutputs, HandleModulePart))
       return 0;
@@ -131,6 +140,7 @@ int main(int argc, char **argv) {
               "splitModule implementation\n";
   }
 
-  SplitModule(*M, NumOutputs, HandleModulePart, PreserveLocals);
+  SplitModule(*M, NumOutputs, HandleModulePart, PreserveLocals,
+              TryToAvoidEmptyModules);
   return 0;
 }

--- a/llvm/tools/llvm-split/llvm-split.cpp
+++ b/llvm/tools/llvm-split/llvm-split.cpp
@@ -54,10 +54,10 @@ static cl::opt<bool>
                    cl::cat(SplitCategory));
 
 static cl::opt<bool>
-    TryToAvoidEmptyModules("avoid-empty-modules", cl::Prefix, cl::init(false),
-                           cl::desc("Try to avoid generating empty modules by "
-                                    "modifying the distribution of functions"),
-                           cl::cat(SplitCategory));
+    RoundRobin("round-robin", cl::Prefix, cl::init(false),
+               cl::desc("Use round-robin distribution of functions to "
+                        "modules instead of the default name-hash-based one"),
+               cl::cat(SplitCategory));
 
 static cl::opt<std::string>
     MTriple("mtriple",
@@ -128,8 +128,8 @@ int main(int argc, char **argv) {
       errs() << "warning: -preserve-locals has no effect when using "
                 "TargetMachine::splitModule\n";
     }
-    if (TryToAvoidEmptyModules)
-      errs() << "warning: -avoid-empty-modules has no effect when using "
+    if (RoundRobin)
+      errs() << "warning: -round-robin has no effect when using "
                 "TargetMachine::splitModule\n";
 
     if (TM->splitModule(*M, NumOutputs, HandleModulePart))
@@ -140,7 +140,6 @@ int main(int argc, char **argv) {
               "splitModule implementation\n";
   }
 
-  SplitModule(*M, NumOutputs, HandleModulePart, PreserveLocals,
-              TryToAvoidEmptyModules);
+  SplitModule(*M, NumOutputs, HandleModulePart, PreserveLocals, RoundRobin);
   return 0;
 }


### PR DESCRIPTION
The new round-robin algorithm overrides the hash-based distribution of functions to modules. It achieves a more even number of functions per module when the number of functions is close to the number of requested modules. It's not in use by default and is available under a new flag.