### PR TITLE
[libc][fcntl] fix -Wshorten-64-to-32 for 32b ARM

### DIFF
--- a/libc/src/__support/OSUtil/linux/fcntl.cpp
+++ b/libc/src/__support/OSUtil/linux/fcntl.cpp
@@ -60,8 +60,8 @@ int fcntl(int fd, int cmd, void *arg) {
     // Now copy back into flk, in case flk64 got modified
     flk->l_type = flk64.l_type;
     flk->l_whence = flk64.l_whence;
-    flk->l_start = flk64.l_start;
-    flk->l_len = flk64.l_len;
+    flk->l_start = static_cast<decltype(flk->l_start)>(flk64.l_start);
+    flk->l_len = static_cast<decltype(flk->l_len)>(flk64.l_len);
     flk->l_pid = flk64.l_pid;
     return retVal;
   }


### PR DESCRIPTION
Fixes:

    llvm-project/libc/src/__support/OSUtil/linux/fcntl.cpp:63:26: error:
    implicit conversion loses integer precision: '__off64_t' (aka 'long long')
    to '__off_t' (aka 'long') [-Werror,-Wshorten-64-to-32]
        flk->l_start = flk64.l_start;
                     ~ ~~~~~~^~~~~~~
    llvm-project/libc/src/__support/OSUtil/linux/fcntl.cpp:64:24: error:
    implicit conversion loses integer precision: '__off64_t' (aka 'long long')
    to '__off_t' (aka 'long') [-Werror,-Wshorten-64-to-32]
        flk->l_len = flk64.l_len;
                   ~ ~~~~~~^~~~~

We already have an overflow check, just need the cast to be explicit. This
warning was observed on the 32b ARM build in overlay mode.