### PR TITLE
[X86] Use 32-bit jump table entries on Windows

### DIFF
--- a/llvm/lib/Target/X86/X86ISelLoweringCall.cpp
+++ b/llvm/lib/Target/X86/X86ISelLoweringCall.cpp
@@ -418,7 +418,7 @@ unsigned X86TargetLowering::getJumpTableEncoding() const {
     return MachineJumpTableInfo::EK_Custom32;
   if (isPositionIndependent() &&
       getTargetMachine().getCodeModel() == CodeModel::Large &&
-      !Subtarget.isOSWindows())
+      !Subtarget.isTargetCOFF())
     return MachineJumpTableInfo::EK_LabelDifference64;
 
   // Otherwise, use the normal jump table encoding heuristics.

--- a/llvm/lib/Target/X86/X86ISelLoweringCall.cpp
+++ b/llvm/lib/Target/X86/X86ISelLoweringCall.cpp
@@ -417,7 +417,8 @@ unsigned X86TargetLowering::getJumpTableEncoding() const {
   if (isPositionIndependent() && Subtarget.isPICStyleGOT())
     return MachineJumpTableInfo::EK_Custom32;
   if (isPositionIndependent() &&
-      getTargetMachine().getCodeModel() == CodeModel::Large)
+      getTargetMachine().getCodeModel() == CodeModel::Large &&
+      !Subtarget.isOSWindows())
     return MachineJumpTableInfo::EK_LabelDifference64;
 
   // Otherwise, use the normal jump table encoding heuristics.

--- a/llvm/test/CodeGen/X86/win64-jumptable.ll
+++ b/llvm/test/CodeGen/X86/win64-jumptable.ll
@@ -1,6 +1,8 @@
-; RUN: llc < %s -relocation-model static | FileCheck %s
+; RUN: llc < %s -relocation-model=static | FileCheck %s
+; RUN: llc < %s -relocation-model=pic | FileCheck %s --check-prefix=PIC
+; RUN: llc < %s -relocation-model=pic -code-model=large | FileCheck %s --check-prefix=PIC
 
-; FIXME: Remove '-relocation-model static' when it is no longer necessary to
+; FIXME: Remove '-relocation-model=static' when it is no longer necessary to
 ; trigger the separate .rdata section.
 
 target datalayout = "e-m:w-i64:64-f80:128-n8:16:32:64-S128"
@@ -57,3 +59,9 @@ declare void @g(i32)
 ; It's important that we switch back to .text here, not .rdata.
 ; CHECK: .text
 ; CHECK: .seh_endproc
+
+; Windows PIC code should use 32-bit entries
+; PIC: .long .LBB0_2-.LJTI0_0
+; PIC: .long .LBB0_3-.LJTI0_0
+; PIC: .long .LBB0_4-.LJTI0_0
+; PIC: .long .LBB0_5-.LJTI0_0


### PR DESCRIPTION
Windows doesn't support relative 64-bit relocations.

Fixes #95622