### PR TITLE
[lldb][ObjC] Don't query objective-c runtime for decls in C++ contexts

### DIFF
--- a/lldb/source/Plugins/ExpressionParser/Clang/ClangASTSource.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Clang/ClangASTSource.cpp
@@ -637,7 +637,7 @@ void ClangASTSource::FindExternalVisibleDecls(
     FindDeclInModules(context, name);
   }
 
-  if (!context.m_found_type) {
+  if (!context.m_found_type && m_ast_context->getLangOpts().ObjC) {
     FindDeclInObjCRuntime(context, name);
   }
 }

--- a/lldb/test/API/lang/objcxx/objc-from-cpp-frames-without-debuginfo/TestObjCFromCppFramesWithoutDebugInfo.py
+++ b/lldb/test/API/lang/objcxx/objc-from-cpp-frames-without-debuginfo/TestObjCFromCppFramesWithoutDebugInfo.py
@@ -15,4 +15,9 @@ class TestObjCFromCppFramesWithoutDebugInfo(TestBase):
         (_, process, _, _) = lldbutil.run_to_name_breakpoint(self, "main")
 
         self.assertState(process.GetState(), lldb.eStateStopped)
+
+        # Tests that we can use builtin Objective-C identifiers.
         self.expect("expr id", error=False)
+
+        # Tests that we can lookup Objective-C decls in the ObjC runtime plugin.
+        self.expect_expr("NSString *c; c == nullptr", result_value="true", result_type="bool")

--- a/lldb/test/API/lang/objcxx/objc-from-cpp-frames-without-debuginfo/TestObjCFromCppFramesWithoutDebugInfo.py
+++ b/lldb/test/API/lang/objcxx/objc-from-cpp-frames-without-debuginfo/TestObjCFromCppFramesWithoutDebugInfo.py
@@ -20,4 +20,6 @@ class TestObjCFromCppFramesWithoutDebugInfo(TestBase):
         self.expect("expr id", error=False)
 
         # Tests that we can lookup Objective-C decls in the ObjC runtime plugin.
-        self.expect_expr("NSString *c; c == nullptr", result_value="true", result_type="bool")
+        self.expect_expr(
+            "NSString *c; c == nullptr", result_value="true", result_type="bool"
+        )

--- a/lldb/test/Shell/Expr/TestObjCInCXXContext.test
+++ b/lldb/test/Shell/Expr/TestObjCInCXXContext.test
@@ -1,0 +1,21 @@
+// UNSUPPORTED: system-linux, system-windows
+
+// Tests that we don't consult the the Objective-C runtime
+// plugin when in a purely C++ context.
+//
+// RUN: %clangxx_host %p/Inputs/objc-cast.cpp -g -o %t
+// RUN: %lldb %t \
+// RUN:   -o "b main" -o run \
+// RUN:   -o "expression --language objective-c -- NSString * a; a" \
+// RUN:   -o "expression --language objective-c++ -- NSString * b; b" \
+// RUN:   -o "expression NSString" \
+// RUN:   2>&1 | FileCheck %s
+
+// CHECK:      (lldb) expression --language objective-c -- NSString * a; a
+// CHECK-NEXT: (NSString *){{.*}}= nil
+
+// CHECK:      (lldb) expression --language objective-c++ -- NSString * b; b
+// CHECK-NEXT: (NSString *){{.*}}= nil
+
+// CHECK:      (lldb) expression NSString
+// CHECK-NEXT: error:{{.*}} use of undeclared identifier 'NSString'


### PR DESCRIPTION
When LLDB isn't able to find a `clang::Decl` in response to a `FindExternalVisibleDeclsByName`, it will fall-back to looking into the Objective-C runtime for that decl. This ends up doing a lot of work which isn't necessary when we're debugging a C++ program. This patch makes the ObjC lookup conditional on the language that the ExpressionParser deduced (which can be explicitly set using the `expr --language` option or is set implicitly if we're stopped in an ObjC frame or a C++ frame without debug-info).

rdar://96236519