### PR TITLE
[BoundsSafety][doc] Make it clear that the feature is work-in-progress

### DIFF
--- a/clang/docs/BoundsSafety.rst
+++ b/clang/docs/BoundsSafety.rst
@@ -9,7 +9,7 @@ Overview
 ========
 
 **NOTE:** This is a design document and the feature is not available for users yet.
-Please find :doc:`BoundsSafetyImplPlans` for more details.
+Please see :doc:`BoundsSafetyImplPlans` for more details.
 
 ``-fbounds-safety`` is a C extension to enforce bounds safety to prevent
 out-of-bounds (OOB) memory accesses, which remain a major source of security

--- a/clang/docs/BoundsSafety.rst
+++ b/clang/docs/BoundsSafety.rst
@@ -8,6 +8,9 @@
 Overview
 ========
 
+**NOTE:** This is a design document and the feature is not available for users yet.
+Please find :doc:`BoundsSafetyImplPlans` for more details.
+
 ``-fbounds-safety`` is a C extension to enforce bounds safety to prevent
 out-of-bounds (OOB) memory accesses, which remain a major source of security
 vulnerabilities in C. ``-fbounds-safety`` aims to eliminate this class of bugs
@@ -55,9 +58,7 @@ adopt, offering these properties that make it widely adoptable in practice:
 * It has a relatively low adoption cost.
 
 This document discusses the key designs of ``-fbounds-safety``. The document is
-subject to be actively updated with a more detailed specification. The
-implementation plan can be found in :doc:`BoundsSafetyImplPlans`.
-
+subject to be actively updated with a more detailed specification.
 
 Programming Model
 =================


### PR DESCRIPTION
The `-fbounds-safety` feature is not available yet and the implementation is still in progress, which will be guarded by `-fexperimental-bounds-safety`. To avoid the confusion, we're making it more explicit that the feature is not available yet and the document only describes the model.