### PR TITLE
DenseMap: support enum class keys

### DIFF
--- a/llvm/include/llvm/ADT/DenseMapInfo.h
+++ b/llvm/include/llvm/ADT/DenseMapInfo.h
@@ -297,6 +297,27 @@ template <typename... Ts> struct DenseMapInfo<std::tuple<Ts...>> {
   }
 };
 
+// Provide DenseMapInfo for enum classes.
+template <typename Enum>
+struct DenseMapInfo<Enum, std::enable_if_t<std::is_enum_v<Enum>>> {
+  using UnderlyingType = std::underlying_type_t<Enum>;
+  using Info = DenseMapInfo<UnderlyingType>;
+
+  static Enum getEmptyKey() { return static_cast<Enum>(Info::getEmptyKey()); }
+
+  static Enum getTombstoneKey() {
+    return static_cast<Enum>(Info::getTombstoneKey());
+  }
+
+  static unsigned getHashValue(const Enum &Val) {
+    return Info::getHashValue(static_cast<UnderlyingType>(Val));
+  }
+
+  static bool isEqual(const Enum &LHS, const Enum &RHS) {
+    return Info::isEqual(static_cast<UnderlyingType>(LHS),
+                         static_cast<UnderlyingType>(RHS));
+  }
+};
 } // end namespace llvm
 
 #endif // LLVM_ADT_DENSEMAPINFO_H

--- a/llvm/include/llvm/ADT/DenseMapInfo.h
+++ b/llvm/include/llvm/ADT/DenseMapInfo.h
@@ -313,10 +313,7 @@ struct DenseMapInfo<Enum, std::enable_if_t<std::is_enum_v<Enum>>> {
     return Info::getHashValue(static_cast<UnderlyingType>(Val));
   }
 
-  static bool isEqual(const Enum &LHS, const Enum &RHS) {
-    return Info::isEqual(static_cast<UnderlyingType>(LHS),
-                         static_cast<UnderlyingType>(RHS));
-  }
+  static bool isEqual(const Enum &LHS, const Enum &RHS) { return LHS == RHS; }
 };
 } // end namespace llvm
 

--- a/llvm/unittests/ADT/DenseMapTest.cpp
+++ b/llvm/unittests/ADT/DenseMapTest.cpp
@@ -21,7 +21,6 @@
 using namespace llvm;
 
 namespace {
-
 uint32_t getTestKey(int i, uint32_t *) { return i; }
 uint32_t getTestValue(int i, uint32_t *) { return 42 + i; }
 
@@ -34,6 +33,14 @@ uint32_t *getTestValue(int i, uint32_t **) {
   static uint32_t dummy_arr1[8192];
   assert(i < 8192 && "Only support 8192 dummy keys.");
   return &dummy_arr1[i];
+}
+
+enum class EnumClass { Val };
+
+EnumClass getTestKey(int i, EnumClass *) {
+  // We can't possibly support 100 values for the swap test, so just return an
+  // invalid EnumClass for testing.
+  return static_cast<EnumClass>(i);
 }
 
 /// A test class that tries to check that construction and destruction
@@ -104,14 +111,19 @@ template <typename T>
 typename T::mapped_type *const DenseMapTest<T>::dummy_value_ptr = nullptr;
 
 // Register these types for testing.
+// clang-format off
 typedef ::testing::Types<DenseMap<uint32_t, uint32_t>,
                          DenseMap<uint32_t *, uint32_t *>,
                          DenseMap<CtorTester, CtorTester, CtorTesterMapInfo>,
+                         DenseMap<EnumClass, uint32_t>,
                          SmallDenseMap<uint32_t, uint32_t>,
                          SmallDenseMap<uint32_t *, uint32_t *>,
                          SmallDenseMap<CtorTester, CtorTester, 4,
-                                       CtorTesterMapInfo>
+                                       CtorTesterMapInfo>,
+                         SmallDenseMap<EnumClass, uint32_t>
                          > DenseMapTestTypes;
+// clang-format on
+
 TYPED_TEST_SUITE(DenseMapTest, DenseMapTestTypes, );
 
 // Empty map tests

--- a/llvm/unittests/ADT/MapVectorTest.cpp
+++ b/llvm/unittests/ADT/MapVectorTest.cpp
@@ -267,30 +267,6 @@ TEST(MapVectorTest, NonCopyable) {
   ASSERT_EQ(*MV.find(2)->second, 2);
 }
 
-TEST(MapVectorTest, EnumClassKey) {
-  enum class EC1 { ValA, ValB };
-  enum class EC2 { ValA, ValB };
-  MapVector<EC1, int> MV1;
-  MapVector<EC2, int> MV2;
-
-  ASSERT_TRUE(MV1.empty());
-  ASSERT_TRUE(MV2.empty());
-  MV1.insert({EC1::ValA, 13});
-  MV1.insert({EC1::ValB, 7});
-  MV2.insert({EC2::ValA, 42});
-  MV2.insert({EC2::ValB, 43});
-
-  ASSERT_EQ(MV1.count(EC1::ValA), 1u);
-  ASSERT_EQ(MV2.count(EC2::ValA), 1u);
-  ASSERT_EQ(MV2[EC2::ValB], 43);
-  ASSERT_NE(DenseMapInfo<EC1>::getHashValue(EC1::ValA),
-            DenseMapInfo<EC1>::getHashValue(EC1::ValB));
-  ASSERT_NE(EC2::ValA, DenseMapInfo<EC2>::getTombstoneKey());
-  ASSERT_NE(EC2::ValB, DenseMapInfo<EC2>::getTombstoneKey());
-  ASSERT_NE(EC2::ValA, DenseMapInfo<EC2>::getEmptyKey());
-  ASSERT_NE(EC2::ValB, DenseMapInfo<EC2>::getEmptyKey());
-}
-
 template <class IntType> struct MapVectorMappedTypeTest : ::testing::Test {
   using int_type = IntType;
 };

--- a/llvm/unittests/ADT/MapVectorTest.cpp
+++ b/llvm/unittests/ADT/MapVectorTest.cpp
@@ -267,6 +267,30 @@ TEST(MapVectorTest, NonCopyable) {
   ASSERT_EQ(*MV.find(2)->second, 2);
 }
 
+TEST(MapVectorTest, EnumClassKey) {
+  enum class EC1 { ValA, ValB };
+  enum class EC2 { ValA, ValB };
+  MapVector<EC1, int> MV1;
+  MapVector<EC2, int> MV2;
+
+  ASSERT_TRUE(MV1.empty());
+  ASSERT_TRUE(MV2.empty());
+  MV1.insert({EC1::ValA, 13});
+  MV1.insert({EC1::ValB, 7});
+  MV2.insert({EC2::ValA, 42});
+  MV2.insert({EC2::ValB, 43});
+
+  ASSERT_EQ(MV1.count(EC1::ValA), 1u);
+  ASSERT_EQ(MV2.count(EC2::ValA), 1u);
+  ASSERT_EQ(MV2[EC2::ValB], 43);
+  ASSERT_NE(DenseMapInfo<EC1>::getHashValue(EC1::ValA),
+            DenseMapInfo<EC1>::getHashValue(EC1::ValB));
+  ASSERT_NE(EC2::ValA, DenseMapInfo<EC2>::getTombstoneKey());
+  ASSERT_NE(EC2::ValB, DenseMapInfo<EC2>::getTombstoneKey());
+  ASSERT_NE(EC2::ValA, DenseMapInfo<EC2>::getEmptyKey());
+  ASSERT_NE(EC2::ValB, DenseMapInfo<EC2>::getEmptyKey());
+}
+
 template <class IntType> struct MapVectorMappedTypeTest : ::testing::Test {
   using int_type = IntType;
 };


### PR DESCRIPTION
Implemented using std::underlying_type.