### PR TITLE
[clang] Fix missing installed header

### DIFF
--- a/clang/lib/Headers/CMakeLists.txt
+++ b/clang/lib/Headers/CMakeLists.txt
@@ -318,8 +318,10 @@ set(ppc_wrapper_files
 set(openmp_wrapper_files
   openmp_wrappers/math.h
   openmp_wrappers/cmath
-  openmp_wrappers/complex.h
+  # Due to a bug in CMake, `complex` must be before `complex.h`
+  # See: https://gitlab.kitware.com/cmake/cmake/-/issues/26058
   openmp_wrappers/complex
+  openmp_wrappers/complex.h
   openmp_wrappers/__clang_openmp_device_functions.h
   openmp_wrappers/complex_cmath.h
   openmp_wrappers/new


### PR DESCRIPTION
Since commit 8d468c132eed7ffe34d601b224220efd51655eb3, the header `openmp_wrappers/complex` is hidden behind `openmp_wrappers/complex.h` due to a bug in CMake[^1], so is not actually installed.

To test the issue, you can ask `ninja` to generate the file on your build:

```
$ ninja lib/clang/19/include/openmp_wrappers/complex.h
[199/199] Copying clang's openmp_wrappers/complex.h...
$ ninja lib/clang/19/include/openmp_wrappers/complex
ninja: error: unknown target 'lib/clang/19/include/openmp_wrappers/complex', did you mean 'lib/clang/19/include/openmp_wrappers/complex.h'? 
```

Re-ordering the entries workarounds the issue. The other option is to revert the cited commit, but I'm not sure which approach is preferred.

CC @etcwilde @jdoerfert 

[^1]: [Here](https://gitlab.kitware.com/cmake/cmake/-/issues/26058) is the CMake report on the issue.