### PR TITLE
[Clang][AArch64] Use 'uint64_t*' for _arm_get_sme_state builtin.

### DIFF
--- a/clang/include/clang/Basic/BuiltinsAArch64.def
+++ b/clang/include/clang/Basic/BuiltinsAArch64.def
@@ -72,7 +72,7 @@ TARGET_BUILTIN(__builtin_arm_stg, "vv*", "t", "mte")
 TARGET_BUILTIN(__builtin_arm_subp, "Uiv*v*", "t", "mte")
 
 // SME state function
-BUILTIN(__builtin_arm_get_sme_state, "vULi*ULi*", "n")
+BUILTIN(__builtin_arm_get_sme_state, "vWUi*WUi*", "n")
 
 // Memory Operations
 TARGET_BUILTIN(__builtin_arm_mops_memset_tag, "v*v*iz", "", "mte,mops")

--- a/clang/test/CodeGen/aarch64-sme-intrinsics/acle_sme_state_builtin.c
+++ b/clang/test/CodeGen/aarch64-sme-intrinsics/acle_sme_state_builtin.c
@@ -1,0 +1,14 @@
+// REQUIRES: aarch64-registered-target
+// RUN: %clang_cc1 -triple aarch64-linux -S -disable-O0-optnone -Werror -Wall -o /dev/null %s
+// RUN: %clang_cc1 -triple aarch64-windows -S -disable-O0-optnone -Werror -Wall -o /dev/null %s
+// RUN: %clang_cc1 -triple aarch64-darwin -S -disable-O0-optnone -Werror -Wall -o /dev/null %s
+
+#include <stdint.h>
+
+// Ensure that the builtin is defined to take a uint64_t * rather than relying
+// on the size of 'unsigned long' which may have different meanings on different
+// targets depending on LP64/LLP64.
+void test_sme_state_builtin(uint64_t *a,
+                            uint64_t *b) __arm_streaming_compatible {
+  __builtin_arm_get_sme_state(a, b);
+}


### PR DESCRIPTION
Depending on the platform, the parameter for __arm_get_sme_state requires a `unsigned long long*` instead of a `unsigned long*`.

From ASTContext.cpp:

  case 'W':
    // This modifier represents int64 type.