### PR TITLE
[AMDGPU] Add IsSingle to a few Interp instructions

### DIFF
--- a/llvm/lib/Target/AMDGPU/VOP3Instructions.td
+++ b/llvm/lib/Target/AMDGPU/VOP3Instructions.td
@@ -105,7 +105,7 @@ class getInterp16Ins <bit HasSrc2, bit HasOMod,
 }
 
 class VOP3_INTERP16 <list<ValueType> ArgVT> : VOPProfile<ArgVT> {
-
+  let IsSingle = 1;
   let HasOMod = !ne(DstVT.Value, f16.Value);
   let HasHigh = 1;
 


### PR DESCRIPTION
A _e64 suffix should not be printed since these instructions only have one legal encoding length. The absence of the IsSingle flag is hidden by how the string is printed. We could fix it for GFX10 as well, but we shouldn't change the asm output to omit _e64 at this point.
NFC.