### PR TITLE
[ProfileData] Remove getValueForSite and getNumValueDataForSite

### DIFF
--- a/llvm/include/llvm/ProfileData/InstrProf.h
+++ b/llvm/include/llvm/ProfileData/InstrProf.h
@@ -857,20 +857,6 @@ struct InstrProfRecord {
   inline ArrayRef<InstrProfValueData> getValueArrayForSite(uint32_t ValueKind,
                                                            uint32_t Site) const;
 
-  /// Return the number of value data collected for ValueKind at profiling
-  /// site: Site.
-  inline uint32_t getNumValueDataForSite(uint32_t ValueKind,
-                                         uint32_t Site) const;
-
-  /// Return the array of profiled values at \p Site.
-  inline std::unique_ptr<InstrProfValueData[]>
-  getValueForSite(uint32_t ValueKind, uint32_t Site) const;
-
-  /// Get the target value/counts of kind \p ValueKind collected at site
-  /// \p Site and store the result in array \p Dest.
-  inline void getValueForSite(InstrProfValueData Dest[], uint32_t ValueKind,
-                              uint32_t Site) const;
-
   /// Reserve space for NumValueSites sites.
   inline void reserveSites(uint32_t ValueKind, uint32_t NumValueSites);
 
@@ -1048,36 +1034,9 @@ uint32_t InstrProfRecord::getNumValueSites(uint32_t ValueKind) const {
   return getValueSitesForKind(ValueKind).size();
 }
 
-uint32_t InstrProfRecord::getNumValueDataForSite(uint32_t ValueKind,
-                                                 uint32_t Site) const {
-  return getValueSitesForKind(ValueKind)[Site].ValueData.size();
-}
-
 ArrayRef<InstrProfValueData>
 InstrProfRecord::getValueArrayForSite(uint32_t ValueKind, uint32_t Site) const {
   return getValueSitesForKind(ValueKind)[Site].ValueData;
-}
-
-std::unique_ptr<InstrProfValueData[]>
-InstrProfRecord::getValueForSite(uint32_t ValueKind, uint32_t Site) const {
-  uint32_t N = getNumValueDataForSite(ValueKind, Site);
-  if (N == 0)
-    return std::unique_ptr<InstrProfValueData[]>(nullptr);
-
-  auto VD = std::make_unique<InstrProfValueData[]>(N);
-  getValueForSite(VD.get(), ValueKind, Site);
-
-  return VD;
-}
-
-void InstrProfRecord::getValueForSite(InstrProfValueData Dest[],
-                                      uint32_t ValueKind, uint32_t Site) const {
-  uint32_t I = 0;
-  for (auto V : getValueSitesForKind(ValueKind)[Site].ValueData) {
-    Dest[I].Value = V.Value;
-    Dest[I].Count = V.Count;
-    I++;
-  }
 }
 
 void InstrProfRecord::reserveSites(uint32_t ValueKind, uint32_t NumValueSites) {


### PR DESCRIPTION
This patch removes getValueForSite and getNumValueDataForSite as I've
migrated all uses of them to getValueArrayForSite.