### PR TITLE
[flang][NFC] Fix typo getFuncElementAttrName -> getFuncElementalAttrName

### DIFF
--- a/flang/include/flang/Optimizer/Dialect/FIROpsSupport.h
+++ b/flang/include/flang/Optimizer/Dialect/FIROpsSupport.h
@@ -152,7 +152,7 @@ static constexpr llvm::StringRef getFuncPureAttrName() {
   return "fir.func_pure";
 }
 
-static constexpr llvm::StringRef getFuncElementAttrName() {
+static constexpr llvm::StringRef getFuncElementalAttrName() {
   return "fir.func_elemental";
 }
 

--- a/flang/lib/Lower/CallInterface.cpp
+++ b/flang/lib/Lower/CallInterface.cpp
@@ -615,7 +615,7 @@ static void addSymbolAttribute(mlir::func::FuncOp func,
     func->setAttr(fir::getFuncPureAttrName(),
                   mlir::UnitAttr::get(&mlirContext));
   if (IsElementalProcedure(sym))
-    func->setAttr(fir::getFuncElementAttrName(),
+    func->setAttr(fir::getFuncElementalAttrName(),
                   mlir::UnitAttr::get(&mlirContext));
   if (sym.attrs().test(Fortran::semantics::Attr::RECURSIVE))
     func->setAttr(fir::getFuncRecursiveAttrName(),


### PR DESCRIPTION
Fix type in the getter for the attribute name