### PR TITLE
[HLSL][clang] Add elementwise builtins for trig intrinsics

### DIFF
--- a/clang/docs/LanguageExtensions.rst
+++ b/clang/docs/LanguageExtensions.rst
@@ -657,6 +657,12 @@ Unless specified otherwise operation(±0) = ±0 and operation(±infinity) = ±in
  T __builtin_elementwise_sin(T x)            return the sine of x interpreted as an angle in radians          floating point types
  T __builtin_elementwise_cos(T x)            return the cosine of x interpreted as an angle in radians        floating point types
  T __builtin_elementwise_tan(T x)            return the tangent of x interpreted as an angle in radians       floating point types
+ T __builtin_elementwise_asin(T x)           return the arcsine of x interpreted as an angle in radians       floating point types
+ T __builtin_elementwise_acos(T x)           return the arccosine of x interpreted as an angle in radians     floating point types
+ T __builtin_elementwise_atan(T x)           return the arctangent of x interpreted as an angle in radians    floating point types
+ T __builtin_elementwise_sinh(T x)           return the hyperbolic sine of angle x in radians                 floating point types
+ T __builtin_elementwise_cosh(T x)           return the hyperbolic cosine of angle x in radians               floating point types
+ T __builtin_elementwise_tanh(T x)           return the hyperbolic tangent of angle x in radians              floating point types
  T __builtin_elementwise_floor(T x)          return the largest integral value less than or equal to x        floating point types
  T __builtin_elementwise_log(T x)            return the natural logarithm of x                                floating point types
  T __builtin_elementwise_log2(T x)           return the base 2 logarithm of x                                 floating point types

--- a/clang/include/clang/Basic/Builtins.td
+++ b/clang/include/clang/Basic/Builtins.td
@@ -1218,6 +1218,24 @@ def ElementwiseAbs : Builtin {
   let Prototype = "void(...)";
 }
 
+def ElementwiseACos : Builtin {
+  let Spellings = ["__builtin_elementwise_acos"];
+  let Attributes = [NoThrow, Const, CustomTypeChecking];
+  let Prototype = "void(...)";
+}
+
+def ElementwiseASin : Builtin {
+  let Spellings = ["__builtin_elementwise_asin"];
+  let Attributes = [NoThrow, Const, CustomTypeChecking];
+  let Prototype = "void(...)";
+}
+
+def ElementwiseATan : Builtin {
+  let Spellings = ["__builtin_elementwise_atan"];
+  let Attributes = [NoThrow, Const, CustomTypeChecking];
+  let Prototype = "void(...)";
+}
+
 def ElementwiseBitreverse : Builtin {
   let Spellings = ["__builtin_elementwise_bitreverse"];
   let Attributes = [NoThrow, Const, CustomTypeChecking];
@@ -1244,6 +1262,12 @@ def ElementwiseCeil : Builtin {
 
 def ElementwiseCos : Builtin {
   let Spellings = ["__builtin_elementwise_cos"];
+  let Attributes = [NoThrow, Const, CustomTypeChecking];
+  let Prototype = "void(...)";
+}
+
+def ElementwiseCosh : Builtin {
+  let Spellings = ["__builtin_elementwise_cosh"];
   let Attributes = [NoThrow, Const, CustomTypeChecking];
   let Prototype = "void(...)";
 }
@@ -1320,6 +1344,12 @@ def ElementwiseSin : Builtin {
   let Prototype = "void(...)";
 }
 
+def ElementwiseSinh : Builtin {
+  let Spellings = ["__builtin_elementwise_sinh"];
+  let Attributes = [NoThrow, Const, CustomTypeChecking];
+  let Prototype = "void(...)";
+}
+
 def ElementwiseSqrt : Builtin {
   let Spellings = ["__builtin_elementwise_sqrt"];
   let Attributes = [NoThrow, Const, CustomTypeChecking];
@@ -1328,6 +1358,12 @@ def ElementwiseSqrt : Builtin {
 
 def ElementwiseTan : Builtin {
   let Spellings = ["__builtin_elementwise_tan"];
+  let Attributes = [NoThrow, Const, CustomTypeChecking];
+  let Prototype = "void(...)";
+}
+
+def ElementwiseTanh : Builtin {
+  let Spellings = ["__builtin_elementwise_tanh"];
   let Attributes = [NoThrow, Const, CustomTypeChecking];
   let Prototype = "void(...)";
 }

--- a/clang/lib/CodeGen/CGBuiltin.cpp
+++ b/clang/lib/CodeGen/CGBuiltin.cpp
@@ -3690,7 +3690,15 @@ RValue CodeGenFunction::EmitBuiltinExpr(const GlobalDecl GD, unsigned BuiltinID,
 
     return RValue::get(Result);
   }
-
+  case Builtin::BI__builtin_elementwise_acos:
+    return RValue::get(emitBuiltinWithOneOverloadedType<1>(
+        *this, E, llvm::Intrinsic::acos, "elt.acos"));
+  case Builtin::BI__builtin_elementwise_asin:
+    return RValue::get(emitBuiltinWithOneOverloadedType<1>(
+        *this, E, llvm::Intrinsic::asin, "elt.asin"));
+  case Builtin::BI__builtin_elementwise_atan:
+    return RValue::get(emitBuiltinWithOneOverloadedType<1>(
+        *this, E, llvm::Intrinsic::atan, "elt.atan"));
   case Builtin::BI__builtin_elementwise_ceil:
     return RValue::get(emitBuiltinWithOneOverloadedType<1>(
         *this, E, llvm::Intrinsic::ceil, "elt.ceil"));
@@ -3719,6 +3727,9 @@ RValue CodeGenFunction::EmitBuiltinExpr(const GlobalDecl GD, unsigned BuiltinID,
   case Builtin::BI__builtin_elementwise_cos:
     return RValue::get(emitBuiltinWithOneOverloadedType<1>(
         *this, E, llvm::Intrinsic::cos, "elt.cos"));
+  case Builtin::BI__builtin_elementwise_cosh:
+    return RValue::get(emitBuiltinWithOneOverloadedType<1>(
+        *this, E, llvm::Intrinsic::cosh, "elt.cosh"));
   case Builtin::BI__builtin_elementwise_floor:
     return RValue::get(emitBuiltinWithOneOverloadedType<1>(
         *this, E, llvm::Intrinsic::floor, "elt.floor"));
@@ -3737,9 +3748,15 @@ RValue CodeGenFunction::EmitBuiltinExpr(const GlobalDecl GD, unsigned BuiltinID,
   case Builtin::BI__builtin_elementwise_sin:
     return RValue::get(emitBuiltinWithOneOverloadedType<1>(
         *this, E, llvm::Intrinsic::sin, "elt.sin"));
+  case Builtin::BI__builtin_elementwise_sinh:
+    return RValue::get(emitBuiltinWithOneOverloadedType<1>(
+        *this, E, llvm::Intrinsic::sinh, "elt.sinh"));
   case Builtin::BI__builtin_elementwise_tan:
     return RValue::get(emitBuiltinWithOneOverloadedType<1>(
         *this, E, llvm::Intrinsic::tan, "elt.tan"));
+  case Builtin::BI__builtin_elementwise_tanh:
+    return RValue::get(emitBuiltinWithOneOverloadedType<1>(
+        *this, E, llvm::Intrinsic::tanh, "elt.tanh"));
   case Builtin::BI__builtin_elementwise_trunc:
     return RValue::get(emitBuiltinWithOneOverloadedType<1>(
         *this, E, llvm::Intrinsic::trunc, "elt.trunc"));

--- a/clang/lib/Headers/hlsl/hlsl_intrinsics.h
+++ b/clang/lib/Headers/hlsl/hlsl_intrinsics.h
@@ -108,6 +108,34 @@ _HLSL_BUILTIN_ALIAS(__builtin_elementwise_abs)
 double4 abs(double4);
 
 //===----------------------------------------------------------------------===//
+// acos builtins
+//===----------------------------------------------------------------------===//
+
+/// \fn T acos(T Val)
+/// \brief Returns the arccosine of the input value, \a Val.
+/// \param Val The input value.
+
+#ifdef __HLSL_ENABLE_16_BIT
+_HLSL_BUILTIN_ALIAS(__builtin_elementwise_acos)
+half acos(half);
+_HLSL_BUILTIN_ALIAS(__builtin_elementwise_acos)
+half2 acos(half2);
+_HLSL_BUILTIN_ALIAS(__builtin_elementwise_acos)
+half3 acos(half3);
+_HLSL_BUILTIN_ALIAS(__builtin_elementwise_acos)
+half4 acos(half4);
+#endif
+
+_HLSL_BUILTIN_ALIAS(__builtin_elementwise_acos)
+float acos(float);
+_HLSL_BUILTIN_ALIAS(__builtin_elementwise_acos)
+float2 acos(float2);
+_HLSL_BUILTIN_ALIAS(__builtin_elementwise_acos)
+float3 acos(float3);
+_HLSL_BUILTIN_ALIAS(__builtin_elementwise_acos)
+float4 acos(float4);
+
+//===----------------------------------------------------------------------===//
 // all builtins
 //===----------------------------------------------------------------------===//
 
@@ -332,6 +360,62 @@ _HLSL_BUILTIN_ALIAS(__builtin_hlsl_elementwise_any)
 bool any(double4);
 
 //===----------------------------------------------------------------------===//
+// asin builtins
+//===----------------------------------------------------------------------===//
+
+/// \fn T asin(T Val)
+/// \brief Returns the arcsine of the input value, \a Val.
+/// \param Val The input value.
+
+#ifdef __HLSL_ENABLE_16_BIT
+_HLSL_BUILTIN_ALIAS(__builtin_elementwise_asin)
+half asin(half);
+_HLSL_BUILTIN_ALIAS(__builtin_elementwise_asin)
+half2 asin(half2);
+_HLSL_BUILTIN_ALIAS(__builtin_elementwise_asin)
+half3 asin(half3);
+_HLSL_BUILTIN_ALIAS(__builtin_elementwise_asin)
+half4 asin(half4);
+#endif
+
+_HLSL_BUILTIN_ALIAS(__builtin_elementwise_asin)
+float asin(float);
+_HLSL_BUILTIN_ALIAS(__builtin_elementwise_asin)
+float2 asin(float2);
+_HLSL_BUILTIN_ALIAS(__builtin_elementwise_asin)
+float3 asin(float3);
+_HLSL_BUILTIN_ALIAS(__builtin_elementwise_asin)
+float4 asin(float4);
+
+//===----------------------------------------------------------------------===//
+// atan builtins
+//===----------------------------------------------------------------------===//
+
+/// \fn T atan(T Val)
+/// \brief Returns the arctangent of the input value, \a Val.
+/// \param Val The input value.
+
+#ifdef __HLSL_ENABLE_16_BIT
+_HLSL_BUILTIN_ALIAS(__builtin_elementwise_atan)
+half atan(half);
+_HLSL_BUILTIN_ALIAS(__builtin_elementwise_atan)
+half2 atan(half2);
+_HLSL_BUILTIN_ALIAS(__builtin_elementwise_atan)
+half3 atan(half3);
+_HLSL_BUILTIN_ALIAS(__builtin_elementwise_atan)
+half4 atan(half4);
+#endif
+
+_HLSL_BUILTIN_ALIAS(__builtin_elementwise_atan)
+float atan(float);
+_HLSL_BUILTIN_ALIAS(__builtin_elementwise_atan)
+float2 atan(float2);
+_HLSL_BUILTIN_ALIAS(__builtin_elementwise_atan)
+float3 atan(float3);
+_HLSL_BUILTIN_ALIAS(__builtin_elementwise_atan)
+float4 atan(float4);
+
+//===----------------------------------------------------------------------===//
 // ceil builtins
 //===----------------------------------------------------------------------===//
 
@@ -501,6 +585,34 @@ _HLSL_BUILTIN_ALIAS(__builtin_elementwise_cos)
 float3 cos(float3);
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_cos)
 float4 cos(float4);
+
+//===----------------------------------------------------------------------===//
+// cosh builtins
+//===----------------------------------------------------------------------===//
+
+/// \fn T cosh(T Val)
+/// \brief Returns the hyperbolic cosine of the input value, \a Val.
+/// \param Val The input value.
+
+#ifdef __HLSL_ENABLE_16_BIT
+_HLSL_BUILTIN_ALIAS(__builtin_elementwise_cosh)
+half cosh(half);
+_HLSL_BUILTIN_ALIAS(__builtin_elementwise_cosh)
+half2 cosh(half2);
+_HLSL_BUILTIN_ALIAS(__builtin_elementwise_cosh)
+half3 cosh(half3);
+_HLSL_BUILTIN_ALIAS(__builtin_elementwise_cosh)
+half4 cosh(half4);
+#endif
+
+_HLSL_BUILTIN_ALIAS(__builtin_elementwise_cosh)
+float cosh(float);
+_HLSL_BUILTIN_ALIAS(__builtin_elementwise_cosh)
+float2 cosh(float2);
+_HLSL_BUILTIN_ALIAS(__builtin_elementwise_cosh)
+float3 cosh(float3);
+_HLSL_BUILTIN_ALIAS(__builtin_elementwise_cosh)
+float4 cosh(float4);
 
 //===----------------------------------------------------------------------===//
 // dot product builtins
@@ -1419,6 +1531,34 @@ _HLSL_BUILTIN_ALIAS(__builtin_elementwise_sin)
 float4 sin(float4);
 
 //===----------------------------------------------------------------------===//
+// sinh builtins
+//===----------------------------------------------------------------------===//
+
+/// \fn T sinh(T Val)
+/// \brief Returns the hyperbolic sine of the input value, \a Val.
+/// \param Val The input value.
+
+#ifdef __HLSL_ENABLE_16_BIT
+_HLSL_BUILTIN_ALIAS(__builtin_elementwise_sinh)
+half sinh(half);
+_HLSL_BUILTIN_ALIAS(__builtin_elementwise_sinh)
+half2 sinh(half2);
+_HLSL_BUILTIN_ALIAS(__builtin_elementwise_sinh)
+half3 sinh(half3);
+_HLSL_BUILTIN_ALIAS(__builtin_elementwise_sinh)
+half4 sinh(half4);
+#endif
+
+_HLSL_BUILTIN_ALIAS(__builtin_elementwise_sinh)
+float sinh(float);
+_HLSL_BUILTIN_ALIAS(__builtin_elementwise_sinh)
+float2 sinh(float2);
+_HLSL_BUILTIN_ALIAS(__builtin_elementwise_sinh)
+float3 sinh(float3);
+_HLSL_BUILTIN_ALIAS(__builtin_elementwise_sinh)
+float4 sinh(float4);
+
+//===----------------------------------------------------------------------===//
 // sqrt builtins
 //===----------------------------------------------------------------------===//
 
@@ -1451,6 +1591,11 @@ float4 sqrt(float4);
 //===----------------------------------------------------------------------===//
 // tan builtins
 //===----------------------------------------------------------------------===//
+
+/// \fn T tan(T Val)
+/// \brief Returns the tangent of the input value, \a Val.
+/// \param Val The input value.
+
 #ifdef __HLSL_ENABLE_16_BIT
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_tan)
 half tan(half);
@@ -1470,6 +1615,34 @@ _HLSL_BUILTIN_ALIAS(__builtin_elementwise_tan)
 float3 tan(float3);
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_tan)
 float4 tan(float4);
+
+//===----------------------------------------------------------------------===//
+// tanh builtins
+//===----------------------------------------------------------------------===//
+
+/// \fn T tanh(T Val)
+/// \brief Returns the hyperbolic tangent of the input value, \a Val.
+/// \param Val The input value.
+
+#ifdef __HLSL_ENABLE_16_BIT
+_HLSL_BUILTIN_ALIAS(__builtin_elementwise_tanh)
+half tanh(half);
+_HLSL_BUILTIN_ALIAS(__builtin_elementwise_tanh)
+half2 tanh(half2);
+_HLSL_BUILTIN_ALIAS(__builtin_elementwise_tanh)
+half3 tanh(half3);
+_HLSL_BUILTIN_ALIAS(__builtin_elementwise_tanh)
+half4 tanh(half4);
+#endif
+
+_HLSL_BUILTIN_ALIAS(__builtin_elementwise_tanh)
+float tanh(float);
+_HLSL_BUILTIN_ALIAS(__builtin_elementwise_tanh)
+float2 tanh(float2);
+_HLSL_BUILTIN_ALIAS(__builtin_elementwise_tanh)
+float3 tanh(float3);
+_HLSL_BUILTIN_ALIAS(__builtin_elementwise_tanh)
+float4 tanh(float4);
 
 //===----------------------------------------------------------------------===//
 // trunc builtins

--- a/clang/lib/Sema/SemaChecking.cpp
+++ b/clang/lib/Sema/SemaChecking.cpp
@@ -3160,8 +3160,12 @@ Sema::CheckBuiltinFunctionCall(FunctionDecl *FDecl, unsigned BuiltinID,
 
   // These builtins restrict the element type to floating point
   // types only.
+  case Builtin::BI__builtin_elementwise_acos:
+  case Builtin::BI__builtin_elementwise_asin:
+  case Builtin::BI__builtin_elementwise_atan:
   case Builtin::BI__builtin_elementwise_ceil:
   case Builtin::BI__builtin_elementwise_cos:
+  case Builtin::BI__builtin_elementwise_cosh:
   case Builtin::BI__builtin_elementwise_exp:
   case Builtin::BI__builtin_elementwise_exp2:
   case Builtin::BI__builtin_elementwise_floor:
@@ -3173,8 +3177,10 @@ Sema::CheckBuiltinFunctionCall(FunctionDecl *FDecl, unsigned BuiltinID,
   case Builtin::BI__builtin_elementwise_rint:
   case Builtin::BI__builtin_elementwise_nearbyint:
   case Builtin::BI__builtin_elementwise_sin:
+  case Builtin::BI__builtin_elementwise_sinh:
   case Builtin::BI__builtin_elementwise_sqrt:
   case Builtin::BI__builtin_elementwise_tan:
+  case Builtin::BI__builtin_elementwise_tanh:
   case Builtin::BI__builtin_elementwise_trunc:
   case Builtin::BI__builtin_elementwise_canonicalize: {
     if (PrepareBuiltinElementwiseMathOneArgCall(TheCall))
@@ -3635,8 +3641,12 @@ bool Sema::CheckHLSLBuiltinFunctionCall(unsigned BuiltinID, CallExpr *TheCall) {
       return true;
     break;
   }
+  case Builtin::BI__builtin_elementwise_acos:
+  case Builtin::BI__builtin_elementwise_asin:
+  case Builtin::BI__builtin_elementwise_atan:
   case Builtin::BI__builtin_elementwise_ceil:
   case Builtin::BI__builtin_elementwise_cos:
+  case Builtin::BI__builtin_elementwise_cosh:
   case Builtin::BI__builtin_elementwise_exp:
   case Builtin::BI__builtin_elementwise_exp2:
   case Builtin::BI__builtin_elementwise_floor:
@@ -3646,8 +3656,10 @@ bool Sema::CheckHLSLBuiltinFunctionCall(unsigned BuiltinID, CallExpr *TheCall) {
   case Builtin::BI__builtin_elementwise_pow:
   case Builtin::BI__builtin_elementwise_roundeven:
   case Builtin::BI__builtin_elementwise_sin:
+  case Builtin::BI__builtin_elementwise_sinh:
   case Builtin::BI__builtin_elementwise_sqrt:
   case Builtin::BI__builtin_elementwise_tan:
+  case Builtin::BI__builtin_elementwise_tanh:
   case Builtin::BI__builtin_elementwise_trunc: {
     if (CheckFloatOrHalfRepresentations(this, TheCall))
       return true;

--- a/clang/test/CodeGen/builtins-elementwise-math.c
+++ b/clang/test/CodeGen/builtins-elementwise-math.c
@@ -375,6 +375,54 @@ void test_builtin_elementwise_ceil(float f1, float f2, double d1, double d2,
   vf2 = __builtin_elementwise_ceil(vf1);
 }
 
+void test_builtin_elementwise_acos(float f1, float f2, double d1, double d2,
+                                  float4 vf1, float4 vf2) {
+  // CHECK-LABEL: define void @test_builtin_elementwise_acos(
+  // CHECK:      [[F1:%.+]] = load float, ptr %f1.addr, align 4
+  // CHECK-NEXT:  call float @llvm.acos.f32(float [[F1]])
+  f2 = __builtin_elementwise_acos(f1);
+
+  // CHECK:      [[D1:%.+]] = load double, ptr %d1.addr, align 8
+  // CHECK-NEXT: call double @llvm.acos.f64(double [[D1]])
+  d2 = __builtin_elementwise_acos(d1);
+
+  // CHECK:      [[VF1:%.+]] = load <4 x float>, ptr %vf1.addr, align 16
+  // CHECK-NEXT: call <4 x float> @llvm.acos.v4f32(<4 x float> [[VF1]])
+  vf2 = __builtin_elementwise_acos(vf1);
+}
+
+void test_builtin_elementwise_asin(float f1, float f2, double d1, double d2,
+                                  float4 vf1, float4 vf2) {
+  // CHECK-LABEL: define void @test_builtin_elementwise_asin(
+  // CHECK:      [[F1:%.+]] = load float, ptr %f1.addr, align 4
+  // CHECK-NEXT:  call float @llvm.asin.f32(float [[F1]])
+  f2 = __builtin_elementwise_asin(f1);
+
+  // CHECK:      [[D1:%.+]] = load double, ptr %d1.addr, align 8
+  // CHECK-NEXT: call double @llvm.asin.f64(double [[D1]])
+  d2 = __builtin_elementwise_asin(d1);
+
+  // CHECK:      [[VF1:%.+]] = load <4 x float>, ptr %vf1.addr, align 16
+  // CHECK-NEXT: call <4 x float> @llvm.asin.v4f32(<4 x float> [[VF1]])
+  vf2 = __builtin_elementwise_asin(vf1);
+}
+
+void test_builtin_elementwise_atan(float f1, float f2, double d1, double d2,
+                                  float4 vf1, float4 vf2) {
+  // CHECK-LABEL: define void @test_builtin_elementwise_atan(
+  // CHECK:      [[F1:%.+]] = load float, ptr %f1.addr, align 4
+  // CHECK-NEXT:  call float @llvm.atan.f32(float [[F1]])
+  f2 = __builtin_elementwise_atan(f1);
+
+  // CHECK:      [[D1:%.+]] = load double, ptr %d1.addr, align 8
+  // CHECK-NEXT: call double @llvm.atan.f64(double [[D1]])
+  d2 = __builtin_elementwise_atan(d1);
+
+  // CHECK:      [[VF1:%.+]] = load <4 x float>, ptr %vf1.addr, align 16
+  // CHECK-NEXT: call <4 x float> @llvm.atan.v4f32(<4 x float> [[VF1]])
+  vf2 = __builtin_elementwise_atan(vf1);
+}
+
 void test_builtin_elementwise_cos(float f1, float f2, double d1, double d2,
                                   float4 vf1, float4 vf2) {
   // CHECK-LABEL: define void @test_builtin_elementwise_cos(
@@ -389,6 +437,22 @@ void test_builtin_elementwise_cos(float f1, float f2, double d1, double d2,
   // CHECK:      [[VF1:%.+]] = load <4 x float>, ptr %vf1.addr, align 16
   // CHECK-NEXT: call <4 x float> @llvm.cos.v4f32(<4 x float> [[VF1]])
   vf2 = __builtin_elementwise_cos(vf1);
+}
+
+void test_builtin_elementwise_cosh(float f1, float f2, double d1, double d2,
+                                  float4 vf1, float4 vf2) {
+  // CHECK-LABEL: define void @test_builtin_elementwise_cosh(
+  // CHECK:      [[F1:%.+]] = load float, ptr %f1.addr, align 4
+  // CHECK-NEXT:  call float @llvm.cosh.f32(float [[F1]])
+  f2 = __builtin_elementwise_cosh(f1);
+
+  // CHECK:      [[D1:%.+]] = load double, ptr %d1.addr, align 8
+  // CHECK-NEXT: call double @llvm.cosh.f64(double [[D1]])
+  d2 = __builtin_elementwise_cosh(d1);
+
+  // CHECK:      [[VF1:%.+]] = load <4 x float>, ptr %vf1.addr, align 16
+  // CHECK-NEXT: call <4 x float> @llvm.cosh.v4f32(<4 x float> [[VF1]])
+  vf2 = __builtin_elementwise_cosh(vf1);
 }
 
 void test_builtin_elementwise_exp(float f1, float f2, double d1, double d2,
@@ -588,6 +652,22 @@ void test_builtin_elementwise_sin(float f1, float f2, double d1, double d2,
   vf2 = __builtin_elementwise_sin(vf1);
 }
 
+void test_builtin_elementwise_sinh(float f1, float f2, double d1, double d2,
+                                  float4 vf1, float4 vf2) {
+  // CHECK-LABEL: define void @test_builtin_elementwise_sinh(
+  // CHECK:      [[F1:%.+]] = load float, ptr %f1.addr, align 4
+  // CHECK-NEXT:  call float @llvm.sinh.f32(float [[F1]])
+  f2 = __builtin_elementwise_sinh(f1);
+
+  // CHECK:      [[D1:%.+]] = load double, ptr %d1.addr, align 8
+  // CHECK-NEXT: call double @llvm.sinh.f64(double [[D1]])
+  d2 = __builtin_elementwise_sinh(d1);
+
+  // CHECK:      [[VF1:%.+]] = load <4 x float>, ptr %vf1.addr, align 16
+  // CHECK-NEXT: call <4 x float> @llvm.sinh.v4f32(<4 x float> [[VF1]])
+  vf2 = __builtin_elementwise_sinh(vf1);
+}
+
 void test_builtin_elementwise_sqrt(float f1, float f2, double d1, double d2,
                                   float4 vf1, float4 vf2) {
   // CHECK-LABEL: define void @test_builtin_elementwise_sqrt(
@@ -618,6 +698,22 @@ void test_builtin_elementwise_tan(float f1, float f2, double d1, double d2,
   // CHECK:      [[VF1:%.+]] = load <4 x float>, ptr %vf1.addr, align 16
   // CHECK-NEXT: call <4 x float> @llvm.tan.v4f32(<4 x float> [[VF1]])
   vf2 = __builtin_elementwise_tan(vf1);
+}
+
+void test_builtin_elementwise_tanh(float f1, float f2, double d1, double d2,
+                                  float4 vf1, float4 vf2) {
+  // CHECK-LABEL: define void @test_builtin_elementwise_tanh(
+  // CHECK:      [[F1:%.+]] = load float, ptr %f1.addr, align 4
+  // CHECK-NEXT:  call float @llvm.tanh.f32(float [[F1]])
+  f2 = __builtin_elementwise_tanh(f1);
+
+  // CHECK:      [[D1:%.+]] = load double, ptr %d1.addr, align 8
+  // CHECK-NEXT: call double @llvm.tanh.f64(double [[D1]])
+  d2 = __builtin_elementwise_tanh(d1);
+
+  // CHECK:      [[VF1:%.+]] = load <4 x float>, ptr %vf1.addr, align 16
+  // CHECK-NEXT: call <4 x float> @llvm.tanh.v4f32(<4 x float> [[VF1]])
+  vf2 = __builtin_elementwise_tanh(vf1);
 }
 
 void test_builtin_elementwise_trunc(float f1, float f2, double d1, double d2,

--- a/clang/test/CodeGen/strictfp-elementwise-bulitins.cpp
+++ b/clang/test/CodeGen/strictfp-elementwise-bulitins.cpp
@@ -57,6 +57,16 @@ float4 strict_elementwise_ceil(float4 a) {
   return __builtin_elementwise_ceil(a);
 }
 
+// CHECK-LABEL: define dso_local noundef <4 x float> @_Z23strict_elementwise_acosDv4_f
+// CHECK-SAME: (<4 x float> noundef [[A:%.*]]) local_unnamed_addr #[[ATTR2]] {
+// CHECK-NEXT:  entry:
+// CHECK-NEXT:    [[ELT_ACOS:%.*]] = tail call <4 x float> @llvm.acos.v4f32(<4 x float> [[A]]) #[[ATTR4]]
+// CHECK-NEXT:    ret <4 x float> [[ELT_ACOS]]
+//
+float4 strict_elementwise_acos(float4 a) {
+  return __builtin_elementwise_acos(a);
+}
+
 // CHECK-LABEL: define dso_local noundef <4 x float> @_Z22strict_elementwise_cosDv4_f
 // CHECK-SAME: (<4 x float> noundef [[A:%.*]]) local_unnamed_addr #[[ATTR2]] {
 // CHECK-NEXT:  entry:
@@ -65,6 +75,16 @@ float4 strict_elementwise_ceil(float4 a) {
 //
 float4 strict_elementwise_cos(float4 a) {
   return __builtin_elementwise_cos(a);
+}
+
+// CHECK-LABEL: define dso_local noundef <4 x float> @_Z23strict_elementwise_coshDv4_f
+// CHECK-SAME: (<4 x float> noundef [[A:%.*]]) local_unnamed_addr #[[ATTR2]] {
+// CHECK-NEXT:  entry:
+// CHECK-NEXT:    [[ELT_COSH:%.*]] = tail call <4 x float> @llvm.cosh.v4f32(<4 x float> [[A]]) #[[ATTR4]]
+// CHECK-NEXT:    ret <4 x float> [[ELT_COSH]]
+//
+float4 strict_elementwise_cosh(float4 a) {
+  return __builtin_elementwise_cosh(a);
 }
 
 // CHECK-LABEL: define dso_local noundef <4 x float> @_Z22strict_elementwise_expDv4_f
@@ -167,6 +187,16 @@ float4 strict_elementwise_nearbyint(float4 a) {
   return __builtin_elementwise_nearbyint(a);
 }
 
+// CHECK-LABEL: define dso_local noundef <4 x float> @_Z23strict_elementwise_asinDv4_f
+// CHECK-SAME: (<4 x float> noundef [[A:%.*]]) local_unnamed_addr #[[ATTR2]] {
+// CHECK-NEXT:  entry:
+// CHECK-NEXT:    [[ELT_ASIN:%.*]] = tail call <4 x float> @llvm.asin.v4f32(<4 x float> [[A]]) #[[ATTR4]]
+// CHECK-NEXT:    ret <4 x float> [[ELT_ASIN]]
+//
+float4 strict_elementwise_asin(float4 a) {
+  return __builtin_elementwise_asin(a);
+}
+
 // CHECK-LABEL: define dso_local noundef <4 x float> @_Z22strict_elementwise_sinDv4_f
 // CHECK-SAME: (<4 x float> noundef [[A:%.*]]) local_unnamed_addr #[[ATTR2]] {
 // CHECK-NEXT:  entry:
@@ -175,6 +205,16 @@ float4 strict_elementwise_nearbyint(float4 a) {
 //
 float4 strict_elementwise_sin(float4 a) {
   return __builtin_elementwise_sin(a);
+}
+
+// CHECK-LABEL: define dso_local noundef <4 x float> @_Z23strict_elementwise_sinhDv4_f
+// CHECK-SAME: (<4 x float> noundef [[A:%.*]]) local_unnamed_addr #[[ATTR2]] {
+// CHECK-NEXT:  entry:
+// CHECK-NEXT:    [[ELT_SINH:%.*]] = tail call <4 x float> @llvm.sinh.v4f32(<4 x float> [[A]]) #[[ATTR4]]
+// CHECK-NEXT:    ret <4 x float> [[ELT_SINH]]
+//
+float4 strict_elementwise_sinh(float4 a) {
+  return __builtin_elementwise_sinh(a);
 }
 
 // CHECK-LABEL: define dso_local noundef <4 x float> @_Z23strict_elementwise_sqrtDv4_f
@@ -187,6 +227,16 @@ float4 strict_elementwise_sqrt(float4 a) {
   return __builtin_elementwise_sqrt(a);
 }
 
+// CHECK-LABEL: define dso_local noundef <4 x float> @_Z23strict_elementwise_atanDv4_f
+// CHECK-SAME: (<4 x float> noundef [[A:%.*]]) local_unnamed_addr #[[ATTR2]] {
+// CHECK-NEXT:  entry:
+// CHECK-NEXT:    [[ELT_ATAN:%.*]] = tail call <4 x float> @llvm.atan.v4f32(<4 x float> [[A]]) #[[ATTR4]]
+// CHECK-NEXT:    ret <4 x float> [[ELT_ATAN]]
+//
+float4 strict_elementwise_atan(float4 a) {
+  return __builtin_elementwise_atan(a);
+}
+
 // CHECK-LABEL: define dso_local noundef <4 x float> @_Z22strict_elementwise_tanDv4_f
 // CHECK-SAME: (<4 x float> noundef [[A:%.*]]) local_unnamed_addr #[[ATTR2]] {
 // CHECK-NEXT:  entry:
@@ -195,6 +245,16 @@ float4 strict_elementwise_sqrt(float4 a) {
 //
 float4 strict_elementwise_tan(float4 a) {
   return __builtin_elementwise_tan(a);
+}
+
+// CHECK-LABEL: define dso_local noundef <4 x float> @_Z23strict_elementwise_tanhDv4_f
+// CHECK-SAME: (<4 x float> noundef [[A:%.*]]) local_unnamed_addr #[[ATTR2]] {
+// CHECK-NEXT:  entry:
+// CHECK-NEXT:    [[ELT_TANH:%.*]] = tail call <4 x float> @llvm.tanh.v4f32(<4 x float> [[A]]) #[[ATTR4]]
+// CHECK-NEXT:    ret <4 x float> [[ELT_TANH]]
+//
+float4 strict_elementwise_tanh(float4 a) {
+  return __builtin_elementwise_tanh(a);
 }
 
 // CHECK-LABEL: define dso_local noundef <4 x float> @_Z24strict_elementwise_truncDv4_f

--- a/clang/test/CodeGenHLSL/builtins/acos.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/acos.hlsl
@@ -1,0 +1,59 @@
+// RUN: %clang_cc1 -finclude-default-header -x hlsl -triple \
+// RUN:   dxil-pc-shadermodel6.3-library %s -fnative-half-type \
+// RUN:   -emit-llvm -disable-llvm-passes -o - | FileCheck %s \ 
+// RUN:   --check-prefixes=CHECK,NATIVE_HALF
+// RUN: %clang_cc1 -finclude-default-header -x hlsl -triple \
+// RUN:   spirv-unknown-vulkan-compute %s -emit-llvm -disable-llvm-passes \
+// RUN:   -o - | FileCheck %s --check-prefixes=CHECK,NO_HALF
+
+// CHECK-LABEL: test_acos_half
+// NATIVE_HALF: call half @llvm.acos.f16
+// NO_HALF: call float @llvm.acos.f32
+half test_acos_half ( half p0 ) {
+  return acos ( p0 );
+}
+
+// CHECK-LABEL: test_acos_half2
+// NATIVE_HALF: call <2 x half> @llvm.acos.v2f16
+// NO_HALF: call <2 x float> @llvm.acos.v2f32
+half2 test_acos_half2 ( half2 p0 ) {
+  return acos ( p0 );
+}
+
+// CHECK-LABEL: test_acos_half3
+// NATIVE_HALF: call <3 x half> @llvm.acos.v3f16
+// NO_HALF: call <3 x float> @llvm.acos.v3f32
+half3 test_acos_half3 ( half3 p0 ) {
+  return acos ( p0 );
+}
+
+// CHECK-LABEL: test_acos_half4
+// NATIVE_HALF: call <4 x half> @llvm.acos.v4f16
+// NO_HALF: call <4 x float> @llvm.acos.v4f32
+half4 test_acos_half4 ( half4 p0 ) {
+  return acos ( p0 );
+}
+
+// CHECK-LABEL: test_acos_float
+// CHECK: call float @llvm.acos.f32
+float test_acos_float ( float p0 ) {
+  return acos ( p0 );
+}
+
+// CHECK-LABEL: test_acos_float2
+// CHECK: call <2 x float> @llvm.acos.v2f32
+float2 test_acos_float2 ( float2 p0 ) {
+  return acos ( p0 );
+}
+
+// CHECK-LABEL: test_acos_float3
+// CHECK: call <3 x float> @llvm.acos.v3f32
+float3 test_acos_float3 ( float3 p0 ) {
+  return acos ( p0 );
+}
+
+// CHECK-LABEL: test_acos_float4
+// CHECK: call <4 x float> @llvm.acos.v4f32
+float4 test_acos_float4 ( float4 p0 ) {
+  return acos ( p0 );
+}

--- a/clang/test/CodeGenHLSL/builtins/asin.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/asin.hlsl
@@ -1,0 +1,59 @@
+// RUN: %clang_cc1 -finclude-default-header -x hlsl -triple \
+// RUN:   dxil-pc-shadermodel6.3-library %s -fnative-half-type \
+// RUN:   -emit-llvm -disable-llvm-passes -o - | FileCheck %s \ 
+// RUN:   --check-prefixes=CHECK,NATIVE_HALF
+// RUN: %clang_cc1 -finclude-default-header -x hlsl -triple \
+// RUN:   spirv-unknown-vulkan-compute %s -emit-llvm -disable-llvm-passes \
+// RUN:   -o - | FileCheck %s --check-prefixes=CHECK,NO_HALF
+
+// CHECK-LABEL: test_asin_half
+// NATIVE_HALF: call half @llvm.asin.f16
+// NO_HALF: call float @llvm.asin.f32
+half test_asin_half ( half p0 ) {
+  return asin ( p0 );
+}
+
+// CHECK-LABEL: test_asin_half2
+// NATIVE_HALF: call <2 x half> @llvm.asin.v2f16
+// NO_HALF: call <2 x float> @llvm.asin.v2f32
+half2 test_asin_half2 ( half2 p0 ) {
+  return asin ( p0 );
+}
+
+// CHECK-LABEL: test_asin_half3
+// NATIVE_HALF: call <3 x half> @llvm.asin.v3f16
+// NO_HALF: call <3 x float> @llvm.asin.v3f32
+half3 test_asin_half3 ( half3 p0 ) {
+  return asin ( p0 );
+}
+
+// CHECK-LABEL: test_asin_half4
+// NATIVE_HALF: call <4 x half> @llvm.asin.v4f16
+// NO_HALF: call <4 x float> @llvm.asin.v4f32
+half4 test_asin_half4 ( half4 p0 ) {
+  return asin ( p0 );
+}
+
+// CHECK-LABEL: test_asin_float
+// CHECK: call float @llvm.asin.f32
+float test_asin_float ( float p0 ) {
+  return asin ( p0 );
+}
+
+// CHECK-LABEL: test_asin_float2
+// CHECK: call <2 x float> @llvm.asin.v2f32
+float2 test_asin_float2 ( float2 p0 ) {
+  return asin ( p0 );
+}
+
+// CHECK-LABEL: test_asin_float3
+// CHECK: call <3 x float> @llvm.asin.v3f32
+float3 test_asin_float3 ( float3 p0 ) {
+  return asin ( p0 );
+}
+
+// CHECK-LABEL: test_asin_float4
+// CHECK: call <4 x float> @llvm.asin.v4f32
+float4 test_asin_float4 ( float4 p0 ) {
+  return asin ( p0 );
+}

--- a/clang/test/CodeGenHLSL/builtins/atan.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/atan.hlsl
@@ -1,0 +1,59 @@
+// RUN: %clang_cc1 -finclude-default-header -x hlsl -triple \
+// RUN:   dxil-pc-shadermodel6.3-library %s -fnative-half-type \
+// RUN:   -emit-llvm -disable-llvm-passes -o - | FileCheck %s \ 
+// RUN:   --check-prefixes=CHECK,NATIVE_HALF
+// RUN: %clang_cc1 -finclude-default-header -x hlsl -triple \
+// RUN:   spirv-unknown-vulkan-compute %s -emit-llvm -disable-llvm-passes \
+// RUN:   -o - | FileCheck %s --check-prefixes=CHECK,NO_HALF
+
+// CHECK-LABEL: test_atan_half
+// NATIVE_HALF: call half @llvm.atan.f16
+// NO_HALF: call float @llvm.atan.f32
+half test_atan_half ( half p0 ) {
+  return atan ( p0 );
+}
+
+// CHECK-LABEL: test_atan_half2
+// NATIVE_HALF: call <2 x half> @llvm.atan.v2f16
+// NO_HALF: call <2 x float> @llvm.atan.v2f32
+half2 test_atan_half2 ( half2 p0 ) {
+  return atan ( p0 );
+}
+
+// CHECK-LABEL: test_atan_half3
+// NATIVE_HALF: call <3 x half> @llvm.atan.v3f16
+// NO_HALF: call <3 x float> @llvm.atan.v3f32
+half3 test_atan_half3 ( half3 p0 ) {
+  return atan ( p0 );
+}
+
+// CHECK-LABEL: test_atan_half4
+// NATIVE_HALF: call <4 x half> @llvm.atan.v4f16
+// NO_HALF: call <4 x float> @llvm.atan.v4f32
+half4 test_atan_half4 ( half4 p0 ) {
+  return atan ( p0 );
+}
+
+// CHECK-LABEL: test_atan_float
+// CHECK: call float @llvm.atan.f32
+float test_atan_float ( float p0 ) {
+  return atan ( p0 );
+}
+
+// CHECK-LABEL: test_atan_float2
+// CHECK: call <2 x float> @llvm.atan.v2f32
+float2 test_atan_float2 ( float2 p0 ) {
+  return atan ( p0 );
+}
+
+// CHECK-LABEL: test_atan_float3
+// CHECK: call <3 x float> @llvm.atan.v3f32
+float3 test_atan_float3 ( float3 p0 ) {
+  return atan ( p0 );
+}
+
+// CHECK-LABEL: test_atan_float4
+// CHECK: call <4 x float> @llvm.atan.v4f32
+float4 test_atan_float4 ( float4 p0 ) {
+  return atan ( p0 );
+}

--- a/clang/test/CodeGenHLSL/builtins/cosh.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/cosh.hlsl
@@ -1,0 +1,59 @@
+// RUN: %clang_cc1 -finclude-default-header -x hlsl -triple \
+// RUN:   dxil-pc-shadermodel6.3-library %s -fnative-half-type \
+// RUN:   -emit-llvm -disable-llvm-passes -o - | FileCheck %s \ 
+// RUN:   --check-prefixes=CHECK,NATIVE_HALF
+// RUN: %clang_cc1 -finclude-default-header -x hlsl -triple \
+// RUN:   spirv-unknown-vulkan-compute %s -emit-llvm -disable-llvm-passes \
+// RUN:   -o - | FileCheck %s --check-prefixes=CHECK,NO_HALF
+
+// CHECK-LABEL: test_cosh_half
+// NATIVE_HALF: call half @llvm.cosh.f16
+// NO_HALF: call float @llvm.cosh.f32
+half test_cosh_half ( half p0 ) {
+  return cosh ( p0 );
+}
+
+// CHECK-LABEL: test_cosh_half2
+// NATIVE_HALF: call <2 x half> @llvm.cosh.v2f16
+// NO_HALF: call <2 x float> @llvm.cosh.v2f32
+half2 test_cosh_half2 ( half2 p0 ) {
+  return cosh ( p0 );
+}
+
+// CHECK-LABEL: test_cosh_half3
+// NATIVE_HALF: call <3 x half> @llvm.cosh.v3f16
+// NO_HALF: call <3 x float> @llvm.cosh.v3f32
+half3 test_cosh_half3 ( half3 p0 ) {
+  return cosh ( p0 );
+}
+
+// CHECK-LABEL: test_cosh_half4
+// NATIVE_HALF: call <4 x half> @llvm.cosh.v4f16
+// NO_HALF: call <4 x float> @llvm.cosh.v4f32
+half4 test_cosh_half4 ( half4 p0 ) {
+  return cosh ( p0 );
+}
+
+// CHECK-LABEL: test_cosh_float
+// CHECK: call float @llvm.cosh.f32
+float test_cosh_float ( float p0 ) {
+  return cosh ( p0 );
+}
+
+// CHECK-LABEL: test_cosh_float2
+// CHECK: call <2 x float> @llvm.cosh.v2f32
+float2 test_cosh_float2 ( float2 p0 ) {
+  return cosh ( p0 );
+}
+
+// CHECK-LABEL: test_cosh_float3
+// CHECK: call <3 x float> @llvm.cosh.v3f32
+float3 test_cosh_float3 ( float3 p0 ) {
+  return cosh ( p0 );
+}
+
+// CHECK-LABEL: test_cosh_float4
+// CHECK: call <4 x float> @llvm.cosh.v4f32
+float4 test_cosh_float4 ( float4 p0 ) {
+  return cosh ( p0 );
+}

--- a/clang/test/CodeGenHLSL/builtins/sinh.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/sinh.hlsl
@@ -1,0 +1,59 @@
+// RUN: %clang_cc1 -finclude-default-header -x hlsl -triple \
+// RUN:   dxil-pc-shadermodel6.3-library %s -fnative-half-type \
+// RUN:   -emit-llvm -disable-llvm-passes -o - | FileCheck %s \ 
+// RUN:   --check-prefixes=CHECK,NATIVE_HALF
+// RUN: %clang_cc1 -finclude-default-header -x hlsl -triple \
+// RUN:   spirv-unknown-vulkan-compute %s -emit-llvm -disable-llvm-passes \
+// RUN:   -o - | FileCheck %s --check-prefixes=CHECK,NO_HALF
+
+// CHECK-LABEL: test_sinh_half
+// NATIVE_HALF: call half @llvm.sinh.f16
+// NO_HALF: call float @llvm.sinh.f32
+half test_sinh_half ( half p0 ) {
+  return sinh ( p0 );
+}
+
+// CHECK-LABEL: test_sinh_half2
+// NATIVE_HALF: call <2 x half> @llvm.sinh.v2f16
+// NO_HALF: call <2 x float> @llvm.sinh.v2f32
+half2 test_sinh_half2 ( half2 p0 ) {
+  return sinh ( p0 );
+}
+
+// CHECK-LABEL: test_sinh_half3
+// NATIVE_HALF: call <3 x half> @llvm.sinh.v3f16
+// NO_HALF: call <3 x float> @llvm.sinh.v3f32
+half3 test_sinh_half3 ( half3 p0 ) {
+  return sinh ( p0 );
+}
+
+// CHECK-LABEL: test_sinh_half4
+// NATIVE_HALF: call <4 x half> @llvm.sinh.v4f16
+// NO_HALF: call <4 x float> @llvm.sinh.v4f32
+half4 test_sinh_half4 ( half4 p0 ) {
+  return sinh ( p0 );
+}
+
+// CHECK-LABEL: test_sinh_float
+// CHECK: call float @llvm.sinh.f32
+float test_sinh_float ( float p0 ) {
+  return sinh ( p0 );
+}
+
+// CHECK-LABEL: test_sinh_float2
+// CHECK: call <2 x float> @llvm.sinh.v2f32
+float2 test_sinh_float2 ( float2 p0 ) {
+  return sinh ( p0 );
+}
+
+// CHECK-LABEL: test_sinh_float3
+// CHECK: call <3 x float> @llvm.sinh.v3f32
+float3 test_sinh_float3 ( float3 p0 ) {
+  return sinh ( p0 );
+}
+
+// CHECK-LABEL: test_sinh_float4
+// CHECK: call <4 x float> @llvm.sinh.v4f32
+float4 test_sinh_float4 ( float4 p0 ) {
+  return sinh ( p0 );
+}

--- a/clang/test/CodeGenHLSL/builtins/tanh.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/tanh.hlsl
@@ -1,0 +1,59 @@
+// RUN: %clang_cc1 -finclude-default-header -x hlsl -triple \
+// RUN:   dxil-pc-shadermodel6.3-library %s -fnative-half-type \
+// RUN:   -emit-llvm -disable-llvm-passes -o - | FileCheck %s \ 
+// RUN:   --check-prefixes=CHECK,NATIVE_HALF
+// RUN: %clang_cc1 -finclude-default-header -x hlsl -triple \
+// RUN:   spirv-unknown-vulkan-compute %s -emit-llvm -disable-llvm-passes \
+// RUN:   -o - | FileCheck %s --check-prefixes=CHECK,NO_HALF
+
+// CHECK-LABEL: test_tanh_half
+// NATIVE_HALF: call half @llvm.tanh.f16
+// NO_HALF: call float @llvm.tanh.f32
+half test_tanh_half ( half p0 ) {
+  return tanh ( p0 );
+}
+
+// CHECK-LABEL: test_tanh_half2
+// NATIVE_HALF: call <2 x half> @llvm.tanh.v2f16
+// NO_HALF: call <2 x float> @llvm.tanh.v2f32
+half2 test_tanh_half2 ( half2 p0 ) {
+  return tanh ( p0 );
+}
+
+// CHECK-LABEL: test_tanh_half3
+// NATIVE_HALF: call <3 x half> @llvm.tanh.v3f16
+// NO_HALF: call <3 x float> @llvm.tanh.v3f32
+half3 test_tanh_half3 ( half3 p0 ) {
+  return tanh ( p0 );
+}
+
+// CHECK-LABEL: test_tanh_half4
+// NATIVE_HALF: call <4 x half> @llvm.tanh.v4f16
+// NO_HALF: call <4 x float> @llvm.tanh.v4f32
+half4 test_tanh_half4 ( half4 p0 ) {
+  return tanh ( p0 );
+}
+
+// CHECK-LABEL: test_tanh_float
+// CHECK: call float @llvm.tanh.f32
+float test_tanh_float ( float p0 ) {
+  return tanh ( p0 );
+}
+
+// CHECK-LABEL: test_tanh_float2
+// CHECK: call <2 x float> @llvm.tanh.v2f32
+float2 test_tanh_float2 ( float2 p0 ) {
+  return tanh ( p0 );
+}
+
+// CHECK-LABEL: test_tanh_float3
+// CHECK: call <3 x float> @llvm.tanh.v3f32
+float3 test_tanh_float3 ( float3 p0 ) {
+  return tanh ( p0 );
+}
+
+// CHECK-LABEL: test_tanh_float4
+// CHECK: call <4 x float> @llvm.tanh.v4f32
+float4 test_tanh_float4 ( float4 p0 ) {
+  return tanh ( p0 );
+}

--- a/clang/test/Sema/aarch64-sve-vector-trig-ops.c
+++ b/clang/test/Sema/aarch64-sve-vector-trig-ops.c
@@ -4,6 +4,23 @@
 
 #include <arm_sve.h>
 
+svfloat32_t test_asin_vv_i8mf8(svfloat32_t v) {
+
+  return __builtin_elementwise_asin(v);
+  // expected-error@-1 {{1st argument must be a vector, integer or floating point type}}
+}
+
+svfloat32_t test_acos_vv_i8mf8(svfloat32_t v) {
+
+  return __builtin_elementwise_acos(v);
+  // expected-error@-1 {{1st argument must be a vector, integer or floating point type}}
+}
+
+svfloat32_t test_atan_vv_i8mf8(svfloat32_t v) {
+
+  return __builtin_elementwise_atan(v);
+  // expected-error@-1 {{1st argument must be a vector, integer or floating point type}}
+}
 
 svfloat32_t test_sin_vv_i8mf8(svfloat32_t v) {
 
@@ -20,5 +37,23 @@ svfloat32_t test_cos_vv_i8mf8(svfloat32_t v) {
 svfloat32_t test_tan_vv_i8mf8(svfloat32_t v) {
 
   return __builtin_elementwise_tan(v);
+  // expected-error@-1 {{1st argument must be a vector, integer or floating point type}}
+}
+
+svfloat32_t test_sinh_vv_i8mf8(svfloat32_t v) {
+
+  return __builtin_elementwise_sinh(v);
+  // expected-error@-1 {{1st argument must be a vector, integer or floating point type}}
+}
+
+svfloat32_t test_cosh_vv_i8mf8(svfloat32_t v) {
+
+  return __builtin_elementwise_cosh(v);
+  // expected-error@-1 {{1st argument must be a vector, integer or floating point type}}
+}
+
+svfloat32_t test_tanh_vv_i8mf8(svfloat32_t v) {
+
+  return __builtin_elementwise_tanh(v);
   // expected-error@-1 {{1st argument must be a vector, integer or floating point type}}
 }

--- a/clang/test/Sema/builtins-elementwise-math.c
+++ b/clang/test/Sema/builtins-elementwise-math.c
@@ -315,6 +315,27 @@ void test_builtin_elementwise_ceil(int i, float f, double d, float4 v, int3 iv, 
   // expected-error@-1 {{1st argument must be a floating point type (was 'unsigned4' (vector of 4 'unsigned int' values))}}
 }
 
+void test_builtin_elementwise_acos(int i, float f, double d, float4 v, int3 iv, unsigned u, unsigned4 uv) {
+
+  struct Foo s = __builtin_elementwise_acos(f);
+  // expected-error@-1 {{initializing 'struct Foo' with an expression of incompatible type 'float'}}
+
+  i = __builtin_elementwise_acos();
+  // expected-error@-1 {{too few arguments to function call, expected 1, have 0}}
+
+  i = __builtin_elementwise_acos(i);
+  // expected-error@-1 {{1st argument must be a floating point type (was 'int')}}
+
+  i = __builtin_elementwise_acos(f, f);
+  // expected-error@-1 {{too many arguments to function call, expected 1, have 2}}
+
+  u = __builtin_elementwise_acos(u);
+  // expected-error@-1 {{1st argument must be a floating point type (was 'unsigned int')}}
+
+  uv = __builtin_elementwise_acos(uv);
+  // expected-error@-1 {{1st argument must be a floating point type (was 'unsigned4' (vector of 4 'unsigned int' values))}}
+}
+
 void test_builtin_elementwise_cos(int i, float f, double d, float4 v, int3 iv, unsigned u, unsigned4 uv) {
 
   struct Foo s = __builtin_elementwise_cos(f);
@@ -333,6 +354,27 @@ void test_builtin_elementwise_cos(int i, float f, double d, float4 v, int3 iv, u
   // expected-error@-1 {{1st argument must be a floating point type (was 'unsigned int')}}
 
   uv = __builtin_elementwise_cos(uv);
+  // expected-error@-1 {{1st argument must be a floating point type (was 'unsigned4' (vector of 4 'unsigned int' values))}}
+}
+
+void test_builtin_elementwise_cosh(int i, float f, double d, float4 v, int3 iv, unsigned u, unsigned4 uv) {
+
+  struct Foo s = __builtin_elementwise_cosh(f);
+  // expected-error@-1 {{initializing 'struct Foo' with an expression of incompatible type 'float'}}
+
+  i = __builtin_elementwise_cosh();
+  // expected-error@-1 {{too few arguments to function call, expected 1, have 0}}
+
+  i = __builtin_elementwise_cosh(i);
+  // expected-error@-1 {{1st argument must be a floating point type (was 'int')}}
+
+  i = __builtin_elementwise_cosh(f, f);
+  // expected-error@-1 {{too many arguments to function call, expected 1, have 2}}
+
+  u = __builtin_elementwise_cosh(u);
+  // expected-error@-1 {{1st argument must be a floating point type (was 'unsigned int')}}
+
+  uv = __builtin_elementwise_cosh(uv);
   // expected-error@-1 {{1st argument must be a floating point type (was 'unsigned4' (vector of 4 'unsigned int' values))}}
 }
 
@@ -584,6 +626,27 @@ void test_builtin_elementwise_nearbyint(int i, float f, double d, float4 v, int3
   // expected-error@-1 {{1st argument must be a vector, integer or floating point type (was '_Complex float')}}
 }
 
+void test_builtin_elementwise_asin(int i, float f, double d, float4 v, int3 iv, unsigned u, unsigned4 uv) {
+
+  struct Foo s = __builtin_elementwise_asin(f);
+  // expected-error@-1 {{initializing 'struct Foo' with an expression of incompatible type 'float'}}
+
+  i = __builtin_elementwise_asin();
+  // expected-error@-1 {{too few arguments to function call, expected 1, have 0}}
+
+  i = __builtin_elementwise_asin(i);
+  // expected-error@-1 {{1st argument must be a floating point type (was 'int')}}
+
+  i = __builtin_elementwise_asin(f, f);
+  // expected-error@-1 {{too many arguments to function call, expected 1, have 2}}
+
+  u = __builtin_elementwise_asin(u);
+  // expected-error@-1 {{1st argument must be a floating point type (was 'unsigned int')}}
+
+  uv = __builtin_elementwise_asin(uv);
+  // expected-error@-1 {{1st argument must be a floating point type (was 'unsigned4' (vector of 4 'unsigned int' values))}}
+}
+
 void test_builtin_elementwise_sin(int i, float f, double d, float4 v, int3 iv, unsigned u, unsigned4 uv) {
 
   struct Foo s = __builtin_elementwise_sin(f);
@@ -602,6 +665,27 @@ void test_builtin_elementwise_sin(int i, float f, double d, float4 v, int3 iv, u
   // expected-error@-1 {{1st argument must be a floating point type (was 'unsigned int')}}
 
   uv = __builtin_elementwise_sin(uv);
+  // expected-error@-1 {{1st argument must be a floating point type (was 'unsigned4' (vector of 4 'unsigned int' values))}}
+}
+
+void test_builtin_elementwise_sinh(int i, float f, double d, float4 v, int3 iv, unsigned u, unsigned4 uv) {
+
+  struct Foo s = __builtin_elementwise_sinh(f);
+  // expected-error@-1 {{initializing 'struct Foo' with an expression of incompatible type 'float'}}
+
+  i = __builtin_elementwise_sinh();
+  // expected-error@-1 {{too few arguments to function call, expected 1, have 0}}
+
+  i = __builtin_elementwise_sinh(i);
+  // expected-error@-1 {{1st argument must be a floating point type (was 'int')}}
+
+  i = __builtin_elementwise_sinh(f, f);
+  // expected-error@-1 {{too many arguments to function call, expected 1, have 2}}
+
+  u = __builtin_elementwise_sinh(u);
+  // expected-error@-1 {{1st argument must be a floating point type (was 'unsigned int')}}
+
+  uv = __builtin_elementwise_sinh(uv);
   // expected-error@-1 {{1st argument must be a floating point type (was 'unsigned4' (vector of 4 'unsigned int' values))}}
 }
 
@@ -626,6 +710,27 @@ void test_builtin_elementwise_sqrt(int i, float f, double d, float4 v, int3 iv, 
   // expected-error@-1 {{1st argument must be a floating point type (was 'unsigned4' (vector of 4 'unsigned int' values))}}
 }
 
+void test_builtin_elementwise_atan(int i, float f, double d, float4 v, int3 iv, unsigned u, unsigned4 uv) {
+
+  struct Foo s = __builtin_elementwise_atan(f);
+  // expected-error@-1 {{initializing 'struct Foo' with an expression of incompatible type 'float'}}
+
+  i = __builtin_elementwise_atan();
+  // expected-error@-1 {{too few arguments to function call, expected 1, have 0}}
+
+  i = __builtin_elementwise_atan(i);
+  // expected-error@-1 {{1st argument must be a floating point type (was 'int')}}
+
+  i = __builtin_elementwise_atan(f, f);
+  // expected-error@-1 {{too many arguments to function call, expected 1, have 2}}
+
+  u = __builtin_elementwise_atan(u);
+  // expected-error@-1 {{1st argument must be a floating point type (was 'unsigned int')}}
+
+  uv = __builtin_elementwise_atan(uv);
+  // expected-error@-1 {{1st argument must be a floating point type (was 'unsigned4' (vector of 4 'unsigned int' values))}}
+}
+
 void test_builtin_elementwise_tan(int i, float f, double d, float4 v, int3 iv, unsigned u, unsigned4 uv) {
 
   struct Foo s = __builtin_elementwise_tan(f);
@@ -644,6 +749,27 @@ void test_builtin_elementwise_tan(int i, float f, double d, float4 v, int3 iv, u
   // expected-error@-1 {{1st argument must be a floating point type (was 'unsigned int')}}
 
   uv = __builtin_elementwise_tan(uv);
+  // expected-error@-1 {{1st argument must be a floating point type (was 'unsigned4' (vector of 4 'unsigned int' values))}}
+}
+
+void test_builtin_elementwise_tanh(int i, float f, double d, float4 v, int3 iv, unsigned u, unsigned4 uv) {
+
+  struct Foo s = __builtin_elementwise_tanh(f);
+  // expected-error@-1 {{initializing 'struct Foo' with an expression of incompatible type 'float'}}
+
+  i = __builtin_elementwise_tanh();
+  // expected-error@-1 {{too few arguments to function call, expected 1, have 0}}
+
+  i = __builtin_elementwise_tanh(i);
+  // expected-error@-1 {{1st argument must be a floating point type (was 'int')}}
+
+  i = __builtin_elementwise_tanh(f, f);
+  // expected-error@-1 {{too many arguments to function call, expected 1, have 2}}
+
+  u = __builtin_elementwise_tanh(u);
+  // expected-error@-1 {{1st argument must be a floating point type (was 'unsigned int')}}
+
+  uv = __builtin_elementwise_tanh(uv);
   // expected-error@-1 {{1st argument must be a floating point type (was 'unsigned4' (vector of 4 'unsigned int' values))}}
 }
 

--- a/clang/test/Sema/riscv-rvv-vector-trig-ops.c
+++ b/clang/test/Sema/riscv-rvv-vector-trig-ops.c
@@ -5,6 +5,23 @@
 
 #include <riscv_vector.h>
 
+vfloat32mf2_t test_asin_vv_i8mf8(vfloat32mf2_t v) {
+
+    return __builtin_elementwise_asin(v);
+    // expected-error@-1 {{1st argument must be a vector, integer or floating point type}}
+  }
+  
+  vfloat32mf2_t test_acos_vv_i8mf8(vfloat32mf2_t v) {
+  
+    return __builtin_elementwise_acos(v);
+    // expected-error@-1 {{1st argument must be a vector, integer or floating point type}}
+  }
+  
+  vfloat32mf2_t test_atan_vv_i8mf8(vfloat32mf2_t v) {
+  
+    return __builtin_elementwise_atan(v);
+    // expected-error@-1 {{1st argument must be a vector, integer or floating point type}}
+  }
 
 vfloat32mf2_t test_sin_vv_i8mf8(vfloat32mf2_t v) {
 
@@ -23,3 +40,22 @@ vfloat32mf2_t test_tan_vv_i8mf8(vfloat32mf2_t v) {
   return __builtin_elementwise_tan(v);
   // expected-error@-1 {{1st argument must be a vector, integer or floating point type}}
 }
+
+vfloat32mf2_t test_sinh_vv_i8mf8(vfloat32mf2_t v) {
+
+    return __builtin_elementwise_sinh(v);
+    // expected-error@-1 {{1st argument must be a vector, integer or floating point type}}
+  }
+  
+  vfloat32mf2_t test_cosh_vv_i8mf8(vfloat32mf2_t v) {
+  
+    return __builtin_elementwise_cosh(v);
+    // expected-error@-1 {{1st argument must be a vector, integer or floating point type}}
+  }
+  
+  vfloat32mf2_t test_tanh_vv_i8mf8(vfloat32mf2_t v) {
+  
+    return __builtin_elementwise_tanh(v);
+    // expected-error@-1 {{1st argument must be a vector, integer or floating point type}}
+  }
+  

--- a/clang/test/SemaCXX/builtins-elementwise-math.cpp
+++ b/clang/test/SemaCXX/builtins-elementwise-math.cpp
@@ -83,11 +83,25 @@ void test_builtin_elementwise_ceil() {
   static_assert(!is_const<decltype(__builtin_elementwise_ceil(b))>::value);
 }
 
+void test_builtin_elementwise_acos() {
+  const float a = 42.0;
+  float b = 42.3;
+  static_assert(!is_const<decltype(__builtin_elementwise_acos(a))>::value);
+  static_assert(!is_const<decltype(__builtin_elementwise_acos(b))>::value);
+}
+
 void test_builtin_elementwise_cos() {
   const float a = 42.0;
   float b = 42.3;
   static_assert(!is_const<decltype(__builtin_elementwise_cos(a))>::value);
   static_assert(!is_const<decltype(__builtin_elementwise_cos(b))>::value);
+}
+
+void test_builtin_elementwise_cosh() {
+  const float a = 42.0;
+  float b = 42.3;
+  static_assert(!is_const<decltype(__builtin_elementwise_cosh(a))>::value);
+  static_assert(!is_const<decltype(__builtin_elementwise_cosh(b))>::value);
 }
 
 void test_builtin_elementwise_exp() {
@@ -104,6 +118,13 @@ void test_builtin_elementwise_exp2() {
   static_assert(!is_const<decltype(__builtin_elementwise_exp2(b))>::value);
 }
 
+void test_builtin_elementwise_asin() {
+  const float a = 42.0;
+  float b = 42.3;
+  static_assert(!is_const<decltype(__builtin_elementwise_asin(a))>::value);
+  static_assert(!is_const<decltype(__builtin_elementwise_asin(b))>::value);
+}
+
 void test_builtin_elementwise_sin() {
   const float a = 42.0;
   float b = 42.3;
@@ -111,11 +132,32 @@ void test_builtin_elementwise_sin() {
   static_assert(!is_const<decltype(__builtin_elementwise_sin(b))>::value);
 }
 
+void test_builtin_elementwise_sinh() {
+  const float a = 42.0;
+  float b = 42.3;
+  static_assert(!is_const<decltype(__builtin_elementwise_sinh(a))>::value);
+  static_assert(!is_const<decltype(__builtin_elementwise_sinh(b))>::value);
+}
+
+void test_builtin_elementwise_atan() {
+  const float a = 42.0;
+  float b = 42.3;
+  static_assert(!is_const<decltype(__builtin_elementwise_atan(a))>::value);
+  static_assert(!is_const<decltype(__builtin_elementwise_atan(b))>::value);
+}
+
 void test_builtin_elementwise_tan() {
   const float a = 42.0;
   float b = 42.3;
   static_assert(!is_const<decltype(__builtin_elementwise_tan(a))>::value);
   static_assert(!is_const<decltype(__builtin_elementwise_tan(b))>::value);
+}
+
+void test_builtin_elementwise_tanh() {
+  const float a = 42.0;
+  float b = 42.3;
+  static_assert(!is_const<decltype(__builtin_elementwise_tanh(a))>::value);
+  static_assert(!is_const<decltype(__builtin_elementwise_tanh(b))>::value);
 }
 
 void test_builtin_elementwise_sqrt() {

--- a/clang/test/SemaHLSL/BuiltIns/half-float-only-errors.hlsl
+++ b/clang/test/SemaHLSL/BuiltIns/half-float-only-errors.hlsl
@@ -1,5 +1,9 @@
+// RUN: %clang_cc1 -finclude-default-header -triple dxil-pc-shadermodel6.6-library %s -fnative-half-type -emit-llvm-only -disable-llvm-passes -verify -DTEST_FUNC=__builtin_elementwise_acos
+// RUN: %clang_cc1 -finclude-default-header -triple dxil-pc-shadermodel6.6-library %s -fnative-half-type -emit-llvm-only -disable-llvm-passes -verify -DTEST_FUNC=__builtin_elementwise_asin
+// RUN: %clang_cc1 -finclude-default-header -triple dxil-pc-shadermodel6.6-library %s -fnative-half-type -emit-llvm-only -disable-llvm-passes -verify -DTEST_FUNC=__builtin_elementwise_atan
 // RUN: %clang_cc1 -finclude-default-header -triple dxil-pc-shadermodel6.6-library %s -fnative-half-type -emit-llvm-only -disable-llvm-passes -verify -DTEST_FUNC=__builtin_elementwise_ceil
 // RUN: %clang_cc1 -finclude-default-header -triple dxil-pc-shadermodel6.6-library %s -fnative-half-type -emit-llvm-only -disable-llvm-passes -verify -DTEST_FUNC=__builtin_elementwise_cos
+// RUN: %clang_cc1 -finclude-default-header -triple dxil-pc-shadermodel6.6-library %s -fnative-half-type -emit-llvm-only -disable-llvm-passes -verify -DTEST_FUNC=__builtin_elementwise_cosh
 // RUN: %clang_cc1 -finclude-default-header -triple dxil-pc-shadermodel6.6-library %s -fnative-half-type -emit-llvm-only -disable-llvm-passes -verify -DTEST_FUNC=__builtin_elementwise_exp
 // RUN: %clang_cc1 -finclude-default-header -triple dxil-pc-shadermodel6.6-library %s -fnative-half-type -emit-llvm-only -disable-llvm-passes -verify -DTEST_FUNC=__builtin_elementwise_exp2
 // RUN: %clang_cc1 -finclude-default-header -triple dxil-pc-shadermodel6.6-library %s -fnative-half-type -emit-llvm-only -disable-llvm-passes -verify -DTEST_FUNC=__builtin_elementwise_floor
@@ -7,9 +11,11 @@
 // RUN: %clang_cc1 -finclude-default-header -triple dxil-pc-shadermodel6.6-library %s -fnative-half-type -emit-llvm-only -disable-llvm-passes -verify -DTEST_FUNC=__builtin_elementwise_log2
 // RUN: %clang_cc1 -finclude-default-header -triple dxil-pc-shadermodel6.6-library %s -fnative-half-type -emit-llvm-only -disable-llvm-passes -verify -DTEST_FUNC=__builtin_elementwise_log10
 // RUN: %clang_cc1 -finclude-default-header -triple dxil-pc-shadermodel6.6-library %s -fnative-half-type -emit-llvm-only -disable-llvm-passes -verify -DTEST_FUNC=__builtin_elementwise_sin
+// RUN: %clang_cc1 -finclude-default-header -triple dxil-pc-shadermodel6.6-library %s -fnative-half-type -emit-llvm-only -disable-llvm-passes -verify -DTEST_FUNC=__builtin_elementwise_sinh
 // RUN: %clang_cc1 -finclude-default-header -triple dxil-pc-shadermodel6.6-library %s -fnative-half-type -emit-llvm-only -disable-llvm-passes -verify -DTEST_FUNC=__builtin_elementwise_sqrt
 // RUN: %clang_cc1 -finclude-default-header -triple dxil-pc-shadermodel6.6-library %s -fnative-half-type -emit-llvm-only -disable-llvm-passes -verify -DTEST_FUNC=__builtin_elementwise_roundeven
 // RUN: %clang_cc1 -finclude-default-header -triple dxil-pc-shadermodel6.6-library %s -fnative-half-type -emit-llvm-only -disable-llvm-passes -verify -DTEST_FUNC=__builtin_elementwise_tan
+// RUN: %clang_cc1 -finclude-default-header -triple dxil-pc-shadermodel6.6-library %s -fnative-half-type -emit-llvm-only -disable-llvm-passes -verify -DTEST_FUNC=__builtin_elementwise_tanh
 // RUN: %clang_cc1 -finclude-default-header -triple dxil-pc-shadermodel6.6-library %s -fnative-half-type -emit-llvm-only -disable-llvm-passes -verify -DTEST_FUNC=__builtin_elementwise_trunc
 
 double2 test_double_builtin(double2 p0) {


### PR DESCRIPTION
This change is part of this proposal: https://discourse.llvm.org/t/rfc-all-the-math-intrinsics/78294

This is part 3 of 4 PRs. It sets the ground work for using the intrinsics in HLSL.

Add HLSL frontend apis for `acos`, `asin`, `atan`, `cosh`, `sinh`, and `tanh` 
resolves #70079
resolves #70080
resolves #70081
resolves #70083
resolves #70084
resolves #95966