### PR TITLE
Revert "[flang] Add FLANG_PARALLEL_COMPILE_JOBS option"

### DIFF
--- a/flang/CMakeLists.txt
+++ b/flang/CMakeLists.txt
@@ -445,18 +445,6 @@ if (APPLE)
   endif()
 endif()
 
-# Set up job pools for flang.  Some of the flang sources take a lot of memory to
-# compile, so allow users to limit the number of parallel flang jobs.  This is
-# useful for building flang alongside several other projects since you can use
-# the maximum number of build jobs for the other projects while limiting the
-# number of flang compile jobs.
-#
-# We want this set to infinity by default
-set(FLANG_PARALLEL_COMPILE_JOBS 0 CACHE STRING
-  "The maximum number of concurrent compilation jobs (Ninja only)")
-
-set_property(GLOBAL APPEND PROPERTY JOB_POOLS flang_compile_job_pool=${FLANG_PARALLEL_COMPILE_JOBS})
-
 include(CMakeParseArguments)
 include(AddFlang)
 

--- a/flang/cmake/modules/AddFlang.cmake
+++ b/flang/cmake/modules/AddFlang.cmake
@@ -89,7 +89,6 @@ function(add_flang_library name)
       set_property(GLOBAL APPEND PROPERTY FLANG_LIBS ${name})
     endif()
     set_property(GLOBAL APPEND PROPERTY FLANG_EXPORTS ${name})
-    set_property(TARGET obj.${name} PROPERTY JOB_POOL_COMPILE flang_compile_job_pool)
   else()
     # Add empty "phony" target
     add_custom_target(${name})


### PR DESCRIPTION
Reverts llvm/llvm-project#95672

This is failing on build configurations that use the CMakeLists.txt file from flang/runtime instead of flang/