### PR TITLE
[llvm-cov] let text mode divider honor `--show-branch-summary` `--show-region-summary` etc

### DIFF
--- a/llvm/tools/llvm-cov/CoverageReport.cpp
+++ b/llvm/tools/llvm-cov/CoverageReport.cpp
@@ -102,8 +102,16 @@ void adjustColumnWidths(ArrayRef<StringRef> Files,
 
 /// Prints a horizontal divider long enough to cover the given column
 /// widths.
-void renderDivider(ArrayRef<size_t> ColumnWidths, raw_ostream &OS) {
+void renderDivider(ArrayRef<size_t> ColumnWidths, raw_ostream &OS, const CoverageViewOptions &Options) {
   size_t Length = std::accumulate(ColumnWidths.begin(), ColumnWidths.end(), 0);
+  if (!Options.ShowRegionSummary)
+    Length -= (FileReportColumns[1] + FileReportColumns[2] + FileReportColumns[3]);
+  if (!Options.ShowInstantiationSummary)
+    Length -= (FileReportColumns[7] + FileReportColumns[8] + FileReportColumns[9]);
+  if (!Options.ShowBranchSummary)
+    Length -= (FileReportColumns[13] + FileReportColumns[14] + FileReportColumns[15]);
+  if (!Options.ShowMCDCSummary)
+    Length -= (FileReportColumns[16] + FileReportColumns[17] + FileReportColumns[18]);
   for (size_t I = 0; I < Length; ++I)
     OS << '-';
 }
@@ -405,7 +413,7 @@ void CoverageReport::renderFunctionReports(ArrayRef<std::string> Files,
          << column("Miss", FunctionReportColumns[11], Column::RightAlignment)
          << column("Cover", FunctionReportColumns[12], Column::RightAlignment);
     OS << "\n";
-    renderDivider(FunctionReportColumns, OS);
+    renderDivider(FunctionReportColumns, OS, Options);
     OS << "\n";
     FunctionCoverageSummary Totals("TOTAL");
     for (const auto &F : Functions) {
@@ -418,7 +426,7 @@ void CoverageReport::renderFunctionReports(ArrayRef<std::string> Files,
       render(Function, DC, OS);
     }
     if (Totals.ExecutionCount) {
-      renderDivider(FunctionReportColumns, OS);
+      renderDivider(FunctionReportColumns, OS, Options);
       OS << "\n";
       render(Totals, DC, OS);
     }
@@ -544,7 +552,7 @@ void CoverageReport::renderFileReports(
                  Column::RightAlignment)
        << column("Cover", FileReportColumns[18], Column::RightAlignment);
   OS << "\n";
-  renderDivider(FileReportColumns, OS);
+  renderDivider(FileReportColumns, OS, Options);
   OS << "\n";
 
   std::vector<const FileCoverageSummary *> EmptyFiles;
@@ -563,7 +571,7 @@ void CoverageReport::renderFileReports(
       render(*FCS, OS);
   }
 
-  renderDivider(FileReportColumns, OS);
+  renderDivider(FileReportColumns, OS, Options);
   OS << "\n";
   render(Totals, OS);
 }

--- a/llvm/tools/llvm-cov/CoverageReport.cpp
+++ b/llvm/tools/llvm-cov/CoverageReport.cpp
@@ -102,16 +102,25 @@ void adjustColumnWidths(ArrayRef<StringRef> Files,
 
 /// Prints a horizontal divider long enough to cover the given column
 /// widths.
-void renderDivider(ArrayRef<size_t> ColumnWidths, raw_ostream &OS, const CoverageViewOptions &Options) {
-  size_t Length = std::accumulate(ColumnWidths.begin(), ColumnWidths.end(), 0);
-  if (!Options.ShowRegionSummary)
-    Length -= (FileReportColumns[1] + FileReportColumns[2] + FileReportColumns[3]);
-  if (!Options.ShowInstantiationSummary)
-    Length -= (FileReportColumns[7] + FileReportColumns[8] + FileReportColumns[9]);
-  if (!Options.ShowBranchSummary)
-    Length -= (FileReportColumns[13] + FileReportColumns[14] + FileReportColumns[15]);
-  if (!Options.ShowMCDCSummary)
-    Length -= (FileReportColumns[16] + FileReportColumns[17] + FileReportColumns[18]);
+void renderDivider(raw_ostream &OS, const CoverageViewOptions &Options, bool isFileReport) {
+  size_t Length;
+  if (isFileReport) {
+    Length = std::accumulate(std::begin(FileReportColumns), std::end(FileReportColumns), 0);
+    if (!Options.ShowRegionSummary)
+      Length -= (FileReportColumns[1] + FileReportColumns[2] + FileReportColumns[3]);
+    if (!Options.ShowInstantiationSummary)
+      Length -= (FileReportColumns[7] + FileReportColumns[8] + FileReportColumns[9]);
+    if (!Options.ShowBranchSummary)
+      Length -= (FileReportColumns[13] + FileReportColumns[14] + FileReportColumns[15]);
+    if (!Options.ShowMCDCSummary)
+      Length -= (FileReportColumns[16] + FileReportColumns[17] + FileReportColumns[18]);
+  } else {
+    Length = std::accumulate(std::begin(FunctionReportColumns), std::end(FunctionReportColumns), 0);
+    if (!Options.ShowBranchSummary)
+      Length -= (FunctionReportColumns[7] + FunctionReportColumns[8] + FunctionReportColumns[9]);
+    if (!Options.ShowMCDCSummary)
+      Length -= (FunctionReportColumns[10] + FunctionReportColumns[11] + FunctionReportColumns[12]);
+  }
   for (size_t I = 0; I < Length; ++I)
     OS << '-';
 }
@@ -413,7 +422,7 @@ void CoverageReport::renderFunctionReports(ArrayRef<std::string> Files,
          << column("Miss", FunctionReportColumns[11], Column::RightAlignment)
          << column("Cover", FunctionReportColumns[12], Column::RightAlignment);
     OS << "\n";
-    renderDivider(FunctionReportColumns, OS, Options);
+    renderDivider(OS, Options, false);
     OS << "\n";
     FunctionCoverageSummary Totals("TOTAL");
     for (const auto &F : Functions) {
@@ -426,7 +435,7 @@ void CoverageReport::renderFunctionReports(ArrayRef<std::string> Files,
       render(Function, DC, OS);
     }
     if (Totals.ExecutionCount) {
-      renderDivider(FunctionReportColumns, OS, Options);
+      renderDivider(OS, Options, false);
       OS << "\n";
       render(Totals, DC, OS);
     }
@@ -552,7 +561,7 @@ void CoverageReport::renderFileReports(
                  Column::RightAlignment)
        << column("Cover", FileReportColumns[18], Column::RightAlignment);
   OS << "\n";
-  renderDivider(FileReportColumns, OS, Options);
+  renderDivider(OS, Options, true);
   OS << "\n";
 
   std::vector<const FileCoverageSummary *> EmptyFiles;
@@ -571,7 +580,7 @@ void CoverageReport::renderFileReports(
       render(*FCS, OS);
   }
 
-  renderDivider(FileReportColumns, OS, Options);
+  renderDivider(OS, Options, true);
   OS << "\n";
   render(Totals, OS);
 }


### PR DESCRIPTION
Otherwise it would be unnecessarily too long

Before

![before](https://github.com/llvm/llvm-project/assets/35722712/9bff2b98-eaee-4c09-8802-b3fb92508454)

After

![after](https://github.com/llvm/llvm-project/assets/35722712/bf89f236-f83b-414c-9a2a-a4f8d1559e56)
