### PR TITLE
[offload][cmake] always define pythonize_bool macro

### DIFF
--- a/offload/CMakeLists.txt
+++ b/offload/CMakeLists.txt
@@ -282,15 +282,15 @@ if(OPENMP_STANDALONE_BUILD)
       ${LLVM_LIBRARY_DIRS}
     REQUIRED
   )
-
-  macro(pythonize_bool var)
-  if (${var})
-    set(${var} True)
-  else()
-    set(${var} False)
-  endif()
-  endmacro()
 endif()
+
+macro(pythonize_bool var)
+if (${var})
+  set(${var} True)
+else()
+  set(${var} False)
+endif()
+endmacro()
 
 if(OPENMP_STANDALONE_BUILD OR TARGET omp)
   # Check LIBOMP_HAVE_VERSION_SCRIPT_FLAG


### PR DESCRIPTION
I use the following cmake config to build offload and openmp
```
cmake -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Release -DLLVM_TARGETS_TO_BUILD="X86" -DLLVM_ENABLE_PROJECTS="clang;openmp"  -DLLVM_ENABLE_RUNTIMES="offload"  -DLLVM_LIT_ARGS="-vv -a" -DLLVM_ENABLE_ASSERTIONS=ON  ../llvm
```
and got the following error:
```
CMake Error at /tmp/build-llvm/llvm/offload/CMakeLists.txt:321 (pythonize_bool):
  Unknown CMake command "pythonize_bool". 
```

After some search I find out that the "correct" way to build this is putting openmp and offload to the ENABLE_RUNTIMES like
```
cmake -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Release -DLLVM_TARGETS_TO_BUILD="X86" -DLLVM_ENABLE_PROJECTS="clang"  -DLLVM_ENABLE_RUNTIMES="openmp;offload"  -DLLVM_LIT_ARGS="-vv -a" -DLLVM_ENABLE_ASSERTIONS=ON  ../llvm
```
.


But since we don't forbid to config them using openmp as PROJECT and offload as RUNTIME, then we probably support it. The fix is to always define the pythonize_bool macro. For cmake, it is okay to redefine a macro, it does not cause a warning or else.