### PR TITLE
[mlir][vector] Add tests xfer-permute-lowering (nfc)(2/n)

### DIFF
--- a/mlir/test/Dialect/Vector/vector-transfer-permutation-lowering.mlir
+++ b/mlir/test/Dialect/Vector/vector-transfer-permutation-lowering.mlir
@@ -1,6 +1,5 @@
 // RUN: mlir-opt %s --transform-interpreter --split-input-file | FileCheck %s
 
-// TODO: Replace %arg0 with %vec and
 // TODO: Align naming with e.g. vector-transfer-flatten.mlir
 // TODO: Replace %arg0 with %vec
 // TODO: Replace index args as %idx

--- a/mlir/test/Dialect/Vector/vector-transfer-permutation-lowering.mlir
+++ b/mlir/test/Dialect/Vector/vector-transfer-permutation-lowering.mlir
@@ -37,10 +37,14 @@ func.func @xfer_write_transposing_permutation_map(
 // CHECK-LABEL:   func.func @xfer_write_transposing_permutation_map_out_of_bounds
 // CHECK-SAME:       %[[ARG_0:.*]]: vector<4x8xi16>,
 // CHECK-SAME:       %[[MEM:.*]]: memref<2x2x?x?xi16>) {
+// CHECK:           %[[C0:.*]] = arith.constant 0 : index
 // CHECK:           %[[TR:.*]] = vector.transpose %[[ARG_0]], [1, 0] : vector<4x8xi16> to vector<8x4xi16>
+// Expect the in_bounds attribute to be preserved. Since we don't print it when
+// all flags are "false", it should not appear in the output.
+// CHECK-NOT:       in_bounds
 // CHECK:           vector.transfer_write
 // CHECK-NOT:       permutation_map
-// CHECK-SAME:      %[[TR]], %[[MEM]]{{.*}} {in_bounds = [false, false]} : vector<8x4xi16>, memref<2x2x?x?xi16>
+// CHECK-SAME:      %[[TR]], %[[MEM]][%[[C0]], %[[C0]], %[[C0]], %[[C0]]] : vector<8x4xi16>, memref<2x2x?x?xi16>
 func.func @xfer_write_transposing_permutation_map_out_of_bounds(
     %arg0: vector<4x8xi16>,
     %mem: memref<2x2x?x?xi16>) {
@@ -125,7 +129,7 @@ func.func @xfer_write_non_transposing_permutation_map(
   return
 }
 
-// The broadcast dimension is in bounds, so the transformation is safe
+// Even with out-of-bounds, it is safe to apply this pattern
 // CHECK-LABEL:   func.func @xfer_write_non_transposing_permutation_map_with_mask_out_of_bounds(
 // CHECK-SAME:      %[[MEM:.*]]: memref<?x?xf32>,
 // CHECK-SAME:      %[[VEC:.*]]: vector<7xf32>,


### PR DESCRIPTION
Adds more tests to:
  * vector-transfer-permutation-lowering.mlir

Specifically, adds tests for:
  * out-of-bounds access for the `TransferWritePermutationLowering`
    pattern
  * in-bounds access for `TransferWriteNonPermutationLowering` +
    `TransferWritePermutationLowering`

Also renames `@permutation_with_mask_xfer_write_fixed_width` as
`@xfer_write_non_transposing_permutation_map`.

This is a part of a larger effort to make sure that all key cases for
patterns under populateVectorTransferPermutationMapLoweringPatterns
(*) are tested. I also want to make sure that tests use consistent
function and variable names.

(*) transform.apply_patterns.vector.transfer_permutation_patterns in
TD parlance)