### PR TITLE
[DebugInfo][DivRemPairs] Fix missing debug location updates

### DIFF
--- a/llvm/lib/Transforms/Scalar/DivRemPairs.cpp
+++ b/llvm/lib/Transforms/Scalar/DivRemPairs.cpp
@@ -215,6 +215,7 @@ static bool optimizeDivRem(Function &F, const TargetTransformInfo &TTI,
       RemInst = RealRem;
       // And replace the original instruction with the new one.
       OrigRemInst->replaceAllUsesWith(RealRem);
+      RealRem->setDebugLoc(OrigRemInst->getDebugLoc());
       OrigRemInst->eraseFromParent();
       NumRecomposed++;
       // Note that we have left ((X / Y) * Y) around.
@@ -366,7 +367,9 @@ static bool optimizeDivRem(Function &F, const TargetTransformInfo &TTI,
       if (!DivDominates)
         DivInst->moveBefore(RemInst);
       Mul->insertAfter(RemInst);
+      Mul->setDebugLoc(RemInst->getDebugLoc());
       Sub->insertAfter(Mul);
+      Sub->setDebugLoc(RemInst->getDebugLoc());
 
       // If DivInst has the exact flag, remove it. Otherwise this optimization
       // may replace a well-defined value 'X % Y' with poison.
@@ -384,6 +387,7 @@ static bool optimizeDivRem(Function &F, const TargetTransformInfo &TTI,
       if (!isGuaranteedNotToBeUndef(X, nullptr, DivInst, &DT)) {
         auto *FrX =
             new FreezeInst(X, X->getName() + ".frozen", DivInst->getIterator());
+        FrX->setDebugLoc(DivInst->getDebugLoc());
         DivInst->setOperand(0, FrX);
         Sub->setOperand(0, FrX);
       }
@@ -392,6 +396,7 @@ static bool optimizeDivRem(Function &F, const TargetTransformInfo &TTI,
       if (!isGuaranteedNotToBeUndef(Y, nullptr, DivInst, &DT)) {
         auto *FrY =
             new FreezeInst(Y, Y->getName() + ".frozen", DivInst->getIterator());
+        FrY->setDebugLoc(DivInst->getDebugLoc());
         DivInst->setOperand(1, FrY);
         Mul->setOperand(1, FrY);
       }

--- a/llvm/test/Transforms/DivRemPairs/X86/preserving-debugloc-frx-fry-mul-sub.ll
+++ b/llvm/test/Transforms/DivRemPairs/X86/preserving-debugloc-frx-fry-mul-sub.ll
@@ -1,0 +1,50 @@
+; RUN: opt -S -passes=div-rem-pairs -mtriple=x86_64-unknown-unknown < %s | FileCheck %s
+
+; Check that DivRemPairs's optimizeDivRem() correctly propagates debug locations
+; of `%div` and `%rem` to new freeze, mul and sub instructions.
+
+define i128 @dont_hoist_urem(i128 %a, i128 %b) !dbg !5 {
+; CHECK-LABEL: define i128 @dont_hoist_urem(
+; CHECK-SAME: i128 [[A:%.*]], i128 [[B:%.*]])
+; CHECK:       entry:
+; CHECK-NEXT:    [[A_FROZEN:%.*]] = freeze i128 [[A]], !dbg [[DBG8:![0-9]+]]
+; CHECK-NEXT:    [[B_FROZEN:%.*]] = freeze i128 [[B]], !dbg [[DBG8]]
+; CHECK:       if:
+; CHECK-NEXT:    [[TMP0:%.*]] = mul i128 [[DIV:%.*]], [[B_FROZEN]], !dbg [[DBG11:![0-9]+]]
+; CHECK-NEXT:    [[REM_DECOMPOSED:%.*]] = sub i128 [[A_FROZEN]], [[TMP0:%.*]], !dbg [[DBG11]]
+; CHECK:       end:
+entry:
+  %div = udiv i128 %a, %b, !dbg !8
+  %cmp = icmp eq i128 %div, 42, !dbg !9
+  br i1 %cmp, label %if, label %end, !dbg !10
+
+if:                                               ; preds = %entry
+  %rem = urem i128 %a, %b, !dbg !11
+  br label %end, !dbg !12
+
+end:                                              ; preds = %if, %entry
+  %ret = phi i128 [ %rem, %if ], [ 3, %entry ], !dbg !13
+  ret i128 %ret, !dbg !14
+}
+
+!llvm.dbg.cu = !{!0}
+!llvm.debugify = !{!2, !3}
+!llvm.module.flags = !{!4}
+
+!0 = distinct !DICompileUnit(language: DW_LANG_C, file: !1, producer: "debugify", isOptimized: true, runtimeVersion: 0, emissionKind: FullDebug)
+!1 = !DIFile(filename: "frx_fry_.preserve.ll", directory: "/")
+!2 = !{i32 7}
+!3 = !{i32 0}
+!4 = !{i32 2, !"Debug Info Version", i32 3}
+!5 = distinct !DISubprogram(name: "dont_hoist_urem", linkageName: "dont_hoist_urem", scope: null, file: !1, line: 1, type: !6, scopeLine: 1, spFlags: DISPFlagDefinition | DISPFlagOptimized, unit: !0)
+!6 = !DISubroutineType(types: !7)
+!7 = !{}
+!8 = !DILocation(line: 1, column: 1, scope: !5)
+!9 = !DILocation(line: 2, column: 1, scope: !5)
+!10 = !DILocation(line: 3, column: 1, scope: !5)
+!11 = !DILocation(line: 4, column: 1, scope: !5)
+!12 = !DILocation(line: 5, column: 1, scope: !5)
+!13 = !DILocation(line: 6, column: 1, scope: !5)
+!14 = !DILocation(line: 7, column: 1, scope: !5)
+; CHECK: [[DBG8]] = !DILocation(line: 1,
+; CHECK: [[DBG11]] = !DILocation(line: 4,

--- a/llvm/test/Transforms/DivRemPairs/X86/preserving-debugloc-realrem.ll
+++ b/llvm/test/Transforms/DivRemPairs/X86/preserving-debugloc-realrem.ll
@@ -1,0 +1,56 @@
+; RUN: opt -S -passes=div-rem-pairs -mtriple=x86_64-unknown-unknown < %s | FileCheck %s
+
+; Check that DivRemPairs's optimizeDivRem() propagates the debug location of
+; replaced `%rem` to the new srem or urem instruction.
+; @decompose_illegal_srem_same_block tests it when the operands of `%rem` is signed.
+; @decompose_illegal_urem_same_block tests it when the operands of `%rem` is unsigned.
+
+define void @decompose_illegal_srem_same_block(i32 %a, i32 %b) !dbg !5 {
+; CHECK-LABEL: define void @decompose_illegal_srem_same_block(
+; CHECK:         %rem.recomposed = srem i32 [[A:%.*]], [[B:%.*]], !dbg [[DBG10:![0-9]+]]
+  %div = sdiv i32 %a, %b, !dbg !8
+  %t0 = mul i32 %div, %b, !dbg !9
+  %rem = sub i32 %a, %t0, !dbg !10
+  call void @foo(i32 %rem, i32 %div), !dbg !11
+  ret void, !dbg !12
+}
+
+define void @decompose_illegal_urem_same_block(i32 %a, i32 %b) !dbg !13 {
+; CHECK-LABEL: define void @decompose_illegal_urem_same_block(
+; CHECK:         %rem.recomposed = urem i32 [[A:%.*]], [[B:%.*]], !dbg [[DBG16:![0-9]+]]
+  %div = udiv i32 %a, %b, !dbg !14
+  %t0 = mul i32 %div, %b, !dbg !15
+  %rem = sub i32 %a, %t0, !dbg !16
+  call void @foo(i32 %rem, i32 %div), !dbg !17
+  ret void, !dbg !18
+}
+
+declare void @foo(i32, i32)
+
+!llvm.dbg.cu = !{!0}
+!llvm.debugify = !{!2, !3}
+!llvm.module.flags = !{!4}
+
+!0 = distinct !DICompileUnit(language: DW_LANG_C, file: !1, producer: "debugify", isOptimized: true, runtimeVersion: 0, emissionKind: FullDebug)
+!1 = !DIFile(filename: "realrem_preverse.ll", directory: "/")
+!2 = !{i32 10}
+!3 = !{i32 0}
+!4 = !{i32 2, !"Debug Info Version", i32 3}
+!5 = distinct !DISubprogram(name: "decompose_illegal_srem_same_block", linkageName: "decompose_illegal_srem_same_block", scope: null, file: !1, line: 1, type: !6, scopeLine: 1, spFlags: DISPFlagDefinition | DISPFlagOptimized, unit: !0)
+!6 = !DISubroutineType(types: !7)
+!7 = !{}
+!8 = !DILocation(line: 1, column: 1, scope: !5)
+!9 = !DILocation(line: 2, column: 1, scope: !5)
+!10 = !DILocation(line: 3, column: 1, scope: !5)
+!11 = !DILocation(line: 4, column: 1, scope: !5)
+!12 = !DILocation(line: 5, column: 1, scope: !5)
+!13 = distinct !DISubprogram(name: "decompose_illegal_urem_same_block", linkageName: "decompose_illegal_urem_same_block", scope: null, file: !1, line: 6, type: !6, scopeLine: 6, spFlags: DISPFlagDefinition | DISPFlagOptimized, unit: !0)
+!14 = !DILocation(line: 6, column: 1, scope: !13)
+!15 = !DILocation(line: 7, column: 1, scope: !13)
+!16 = !DILocation(line: 8, column: 1, scope: !13)
+!17 = !DILocation(line: 9, column: 1, scope: !13)
+!18 = !DILocation(line: 10, column: 1, scope: !13)
+
+; CHECK: [[DBG10]] = !DILocation(line: 3,
+; CHECK: [[DBG16]] = !DILocation(line: 8,
+


### PR DESCRIPTION
Fix #96014 .

preserving-debugloc-realrem.ll tests the debug location propagation under two scenarios – whether the operands are signed.