### PR TITLE
[clang] Change style of superseded issues on C++ DR status page

### DIFF
--- a/clang/www/cxx_dr_status.html
+++ b/clang/www/cxx_dr_status.html
@@ -8,12 +8,19 @@
   <link type="text/css" rel="stylesheet" href="content.css">
   <style type="text/css">
     .none { background-color: #FFCCCC }
+    .none-superseded { background-color: rgba(255, 204, 204, 0.65) }
     .unknown { background-color: #EBCAFE }
+    .unknown-superseded { background-color: rgba(234, 200, 254, 0.65) }
     .partial { background-color: #FFE0B0 }
+    .partial-superseded { background-color: rgba(255, 224, 179, 0.65) }
     .unreleased { background-color: #FFFF99 }
+    .unreleased-superseded { background-color: rgba(255, 255, 153, 0.65) }
     .full { background-color: #CCFF99 }
+    .full-superseded { background-color: rgba(214, 255, 173, 0.65) }
     .na { background-color: #DDDDDD }
+    .na-superseded { background-color: rgba(222, 222, 222, 0.65) }
     .open * { color: #AAAAAA }
+    .open-superseded * { color: rgba(171, 171, 171, 0.65) }
     //.open { filter: opacity(0.2) }
     tr:target { background-color: #FFFFBB }
     th { background-color: #FFDDAA }
@@ -110,7 +117,7 @@
     <td><a href="https://cplusplus.github.io/CWG/issues/12.html">12</a></td>
     <td>dup</td>
     <td>Default arguments on different declarations for the same function and the Koenig lookup</td>
-    <td class="full" align="center">Superseded by <a href="#239">239</a></td>
+    <td class="full-superseded" align="center">Superseded by <a href="#239">239</a></td>
   </tr>
   <tr id="13">
     <td><a href="https://cplusplus.github.io/CWG/issues/13.html">13</a></td>
@@ -146,7 +153,7 @@
     <td><a href="https://cplusplus.github.io/CWG/issues/18.html">18</a></td>
     <td>NAD</td>
     <td>f(TYPE) where TYPE is void should be allowed</td>
-    <td class="full" align="center">Superseded by <a href="#577">577</a></td>
+    <td class="full-superseded" align="center">Superseded by <a href="#577">577</a></td>
   </tr>
   <tr id="19">
     <td><a href="https://cplusplus.github.io/CWG/issues/19.html">19</a></td>
@@ -170,7 +177,7 @@
     <td><a href="https://cplusplus.github.io/CWG/issues/22.html">22</a></td>
     <td>TC1</td>
     <td>Template parameter with a default argument that refers to itself</td>
-    <td class="full" align="center">Superseded by <a href="#481">481</a></td>
+    <td class="full-superseded" align="center">Superseded by <a href="#481">481</a></td>
   </tr>
   <tr id="23">
     <td><a href="https://cplusplus.github.io/CWG/issues/23.html">23</a></td>
@@ -218,7 +225,7 @@
     <td><a href="https://cplusplus.github.io/CWG/issues/30.html">30</a></td>
     <td>TC1</td>
     <td>Valid uses of "<TT>::template</TT>"</td>
-    <td class="full" align="center">Superseded by <a href="#468">468</a> (C++11 onwards)</td>
+    <td class="full-superseded" align="center">Superseded by <a href="#468">468</a> (C++11 onwards)</td>
   </tr>
   <tr id="31">
     <td><a href="https://cplusplus.github.io/CWG/issues/31.html">31</a></td>
@@ -260,7 +267,7 @@
     <td><a href="https://cplusplus.github.io/CWG/issues/37.html">37</a></td>
     <td>NAD</td>
     <td>When is uncaught_exception() true?</td>
-    <td class="unknown" align="center">Superseded by <a href="#475">475</a></td>
+    <td class="unknown-superseded" align="center">Superseded by <a href="#475">475</a></td>
   </tr>
   <tr id="38">
     <td><a href="https://cplusplus.github.io/CWG/issues/38.html">38</a></td>
@@ -302,7 +309,7 @@
     <td><a href="https://cplusplus.github.io/CWG/issues/44.html">44</a></td>
     <td>CD1</td>
     <td>Member specializations</td>
-    <td class="partial" align="center">Superseded by <a href="#727">727</a></td>
+    <td class="partial-superseded" align="center">Superseded by <a href="#727">727</a></td>
   </tr>
   <tr id="45">
     <td><a href="https://cplusplus.github.io/CWG/issues/45.html">45</a></td>
@@ -320,7 +327,7 @@
     <td><a href="https://cplusplus.github.io/CWG/issues/47.html">47</a></td>
     <td>NAD</td>
     <td>Template friend issues</td>
-    <td class="full" align="center">Superseded by <a href="#329">329</a></td>
+    <td class="full-superseded" align="center">Superseded by <a href="#329">329</a></td>
   </tr>
   <tr id="48">
     <td><a href="https://cplusplus.github.io/CWG/issues/48.html">48</a></td>
@@ -476,7 +483,7 @@
     <td><a href="https://cplusplus.github.io/CWG/issues/73.html">73</a></td>
     <td>TC1</td>
     <td>Pointer equality</td>
-    <td class="full" align="center">Superseded by <a href="#1652">1652</a></td>
+    <td class="full-superseded" align="center">Superseded by <a href="#1652">1652</a></td>
   </tr>
   <tr id="74">
     <td><a href="https://cplusplus.github.io/CWG/issues/74.html">74</a></td>
@@ -632,7 +639,7 @@
     <td><a href="https://cplusplus.github.io/CWG/issues/99.html">99</a></td>
     <td>NAD</td>
     <td>Partial ordering, references and cv-qualifiers</td>
-    <td class="full" align="center">Superseded by <a href="#214">214</a></td>
+    <td class="full-superseded" align="center">Superseded by <a href="#214">214</a></td>
   </tr>
   <tr id="100">
     <td><a href="https://cplusplus.github.io/CWG/issues/100.html">100</a></td>
@@ -674,7 +681,7 @@
     <td><a href="https://cplusplus.github.io/CWG/issues/106.html">106</a></td>
     <td>CD1</td>
     <td>Creating references to references during template deduction/instantiation</td>
-    <td class="full" align="center">Superseded by <a href="#540">540</a></td>
+    <td class="full-superseded" align="center">Superseded by <a href="#540">540</a></td>
   </tr>
   <tr id="107">
     <td><a href="https://cplusplus.github.io/CWG/issues/107.html">107</a></td>
@@ -1040,7 +1047,7 @@
     <td><a href="https://cplusplus.github.io/CWG/issues/167.html">167</a></td>
     <td>NAD</td>
     <td>Deprecating static functions</td>
-    <td class="unknown" align="center">Superseded by <a href="#1012">1012</a></td>
+    <td class="unknown-superseded" align="center">Superseded by <a href="#1012">1012</a></td>
   </tr>
   <tr id="168">
     <td><a href="https://cplusplus.github.io/CWG/issues/168.html">168</a></td>
@@ -1082,7 +1089,7 @@
     <td><a href="https://cplusplus.github.io/CWG/issues/174.html">174</a></td>
     <td>NAD</td>
     <td>Undeprecating global static</td>
-    <td class="unknown" align="center">Superseded by <a href="#1012">1012</a></td>
+    <td class="unknown-superseded" align="center">Superseded by <a href="#1012">1012</a></td>
   </tr>
   <tr id="175">
     <td><a href="https://cplusplus.github.io/CWG/issues/175.html">175</a></td>
@@ -1136,7 +1143,7 @@
     <td><a href="https://cplusplus.github.io/CWG/issues/183.html">183</a></td>
     <td>TC1</td>
     <td><TT>typename</TT> in explicit specializations</td>
-    <td class="full" align="center">Superseded by <a href="#382">382</a></td>
+    <td class="full-superseded" align="center">Superseded by <a href="#382">382</a></td>
   </tr>
   <tr id="184">
     <td><a href="https://cplusplus.github.io/CWG/issues/184.html">184</a></td>
@@ -1160,7 +1167,7 @@
     <td><a href="https://cplusplus.github.io/CWG/issues/187.html">187</a></td>
     <td>TC1</td>
     <td>Scope of template parameter names</td>
-    <td class="full" align="center">Superseded by <a href="#481">481</a></td>
+    <td class="full-superseded" align="center">Superseded by <a href="#481">481</a></td>
   </tr>
   <tr id="188">
     <td><a href="https://cplusplus.github.io/CWG/issues/188.html">188</a></td>
@@ -1936,7 +1943,7 @@ of class templates</td>
     <td><a href="https://cplusplus.github.io/CWG/issues/316.html">316</a></td>
     <td>NAD</td>
     <td>Injected-class-name of template used as template template parameter</td>
-    <td class="full" align="center">Superseded by <a href="#1004">1004</a></td>
+    <td class="full-superseded" align="center">Superseded by <a href="#1004">1004</a></td>
   </tr>
   <tr id="317">
     <td><a href="https://cplusplus.github.io/CWG/issues/317.html">317</a></td>
@@ -1948,7 +1955,7 @@ of class templates</td>
     <td><a href="https://cplusplus.github.io/CWG/issues/318.html">318</a></td>
     <td>CD1</td>
     <td><TT>struct A::A</TT> should not name the constructor of <TT>A</TT></td>
-    <td class="full" align="center">Superseded by <a href="#1310">1310</a></td>
+    <td class="full-superseded" align="center">Superseded by <a href="#1310">1310</a></td>
   </tr>
   <tr id="319">
     <td><a href="https://cplusplus.github.io/CWG/issues/319.html">319</a></td>
@@ -2086,7 +2093,7 @@ of class templates</td>
     <td><a href="https://cplusplus.github.io/CWG/issues/341.html">341</a></td>
     <td>C++11</td>
     <td><TT>extern "C"</TT> namespace member function versus global variable</td>
-    <td class="unknown" align="center">Superseded by <a href="#1708">1708</a></td>
+    <td class="unknown-superseded" align="center">Superseded by <a href="#1708">1708</a></td>
   </tr>
   <tr id="342">
     <td><a href="https://cplusplus.github.io/CWG/issues/342.html">342</a></td>
@@ -2422,7 +2429,7 @@ of class templates</td>
     <td><a href="https://cplusplus.github.io/CWG/issues/397.html">397</a></td>
     <td>CD1</td>
     <td>Same address for string literals from default arguments in inline functions?</td>
-    <td class="unknown" align="center">Superseded by <a href="#1823">1823</a></td>
+    <td class="unknown-superseded" align="center">Superseded by <a href="#1823">1823</a></td>
   </tr>
   <tr id="398">
     <td><a href="https://cplusplus.github.io/CWG/issues/398.html">398</a></td>
@@ -2644,7 +2651,7 @@ of class templates</td>
     <td><a href="https://cplusplus.github.io/CWG/issues/434.html">434</a></td>
     <td>NAD</td>
     <td>Unclear suppression of standard conversions while binding reference to lvalue</td>
-    <td class="full" align="center">Superseded by <a href="#2352">2352</a></td>
+    <td class="full-superseded" align="center">Superseded by <a href="#2352">2352</a></td>
   </tr>
   <tr id="435">
     <td><a href="https://cplusplus.github.io/CWG/issues/435.html">435</a></td>
@@ -2662,7 +2669,7 @@ of class templates</td>
     <td><a href="https://cplusplus.github.io/CWG/issues/437.html">437</a></td>
     <td>CD1</td>
     <td>Is type of class allowed in member function exception specification?</td>
-    <td class="full" align="center">Superseded by <a href="#1308">1308</a></td>
+    <td class="full-superseded-superseded" align="center">Superseded by <a href="#1308">1308</a></td>
   </tr>
   <tr id="438">
     <td><a href="https://cplusplus.github.io/CWG/issues/438.html">438</a></td>
@@ -2692,7 +2699,7 @@ of class templates</td>
     <td><a href="https://cplusplus.github.io/CWG/issues/442.html">442</a></td>
     <td>CD1</td>
     <td>Incorrect use of null pointer constant in description of delete operator</td>
-    <td class="na" align="center">Superseded by <a href="#348">348</a></td>
+    <td class="na-superseded" align="center">Superseded by <a href="#348">348</a></td>
   </tr>
   <tr id="443">
     <td><a href="https://cplusplus.github.io/CWG/issues/443.html">443</a></td>
@@ -3016,13 +3023,13 @@ of class templates</td>
     <td><a href="https://cplusplus.github.io/CWG/issues/496.html">496</a></td>
     <td>CD3</td>
     <td>Is a volatile-qualified type really a POD?</td>
-    <td class="full" align="center">Superseded by <a href="#2094">2094</a></td>
+    <td class="full-superseded" align="center">Superseded by <a href="#2094">2094</a></td>
   </tr>
   <tr id="497">
     <td><a href="https://cplusplus.github.io/CWG/issues/497.html">497</a></td>
     <td>CD1</td>
     <td>Missing required initialization in example</td>
-    <td class="unknown" align="center">Superseded by <a href="#253">253</a></td>
+    <td class="unknown-superseded" align="center">Superseded by <a href="#253">253</a></td>
   </tr>
   <tr class="open" id="498">
     <td><a href="https://cplusplus.github.io/CWG/issues/498.html">498</a></td>
@@ -3130,7 +3137,7 @@ of class templates</td>
     <td><a href="https://cplusplus.github.io/CWG/issues/515.html">515</a></td>
     <td>CD1</td>
     <td>Non-dependent references to base class members</td>
-    <td class="unknown" align="center">Superseded by <a href="#1017">1017</a></td>
+    <td class="unknown-superseded" align="center">Superseded by <a href="#1017">1017</a></td>
   </tr>
   <tr id="516">
     <td><a href="https://cplusplus.github.io/CWG/issues/516.html">516</a></td>
@@ -3918,7 +3925,7 @@ and <I>POD class</I></td>
     <td><a href="https://cplusplus.github.io/CWG/issues/646.html">646</a></td>
     <td>NAD</td>
     <td>Can a class with a constexpr copy constructor be a literal type?</td>
-    <td class="unknown" align="center">Superseded by <a href="#981">981</a></td>
+    <td class="unknown-superseded" align="center">Superseded by <a href="#981">981</a></td>
   </tr>
   <tr id="647">
     <td><a href="https://cplusplus.github.io/CWG/issues/647.html">647</a></td>
@@ -3966,7 +3973,7 @@ and <I>POD class</I></td>
     <td><a href="https://cplusplus.github.io/CWG/issues/654.html">654</a></td>
     <td>CD1</td>
     <td>Conversions to and from <TT>nullptr_t</TT></td>
-    <td class="full" align="center">Superseded by <a href="#1423">1423</a></td>
+    <td class="full-superseded" align="center">Superseded by <a href="#1423">1423</a></td>
   </tr>
   <tr id="655">
     <td><a href="https://cplusplus.github.io/CWG/issues/655.html">655</a></td>
@@ -4146,7 +4153,7 @@ and <I>POD class</I></td>
     <td><a href="https://cplusplus.github.io/CWG/issues/684.html">684</a></td>
     <td>CD1</td>
     <td>Constant expressions involving the address of an automatic variable</td>
-    <td class="unknown" align="center">Superseded by <a href="#1454">1454</a></td>
+    <td class="unknown-superseded" align="center">Superseded by <a href="#1454">1454</a></td>
   </tr>
   <tr id="685">
     <td><a href="https://cplusplus.github.io/CWG/issues/685.html">685</a></td>
@@ -7656,7 +7663,7 @@ and <I>POD class</I></td>
     <td><a href="https://cplusplus.github.io/CWG/issues/1308.html">1308</a></td>
     <td>CD3</td>
     <td>Completeness of class type within an <I>exception-specification</I></td>
-    <td class="full" align="center">Superseded by <a href="#1330">1330</a></td>
+    <td class="full-superseded" align="center">Superseded by <a href="#1330">1330</a></td>
   </tr>
   <tr id="1309">
     <td><a href="https://cplusplus.github.io/CWG/issues/1309.html">1309</a></td>
@@ -7812,7 +7819,7 @@ and <I>POD class</I></td>
     <td><a href="https://cplusplus.github.io/CWG/issues/1334.html">1334</a></td>
     <td>NAD</td>
     <td>Layout compatibility and cv-qualification</td>
-    <td class="unreleased" align="center">Superseded by <a href="#1719">1719</a></td>
+    <td class="unreleased-superseded" align="center">Superseded by <a href="#1719">1719</a></td>
   </tr>
   <tr id="1335">
     <td><a href="https://cplusplus.github.io/CWG/issues/1335.html">1335</a></td>

--- a/clang/www/make_cxx_dr_status
+++ b/clang/www/make_cxx_dr_status
@@ -95,12 +95,19 @@ out_file.write('''\
   <link type="text/css" rel="stylesheet" href="content.css">
   <style type="text/css">
     .none { background-color: #FFCCCC }
+    .none-superseded { background-color: rgba(255, 204, 204, 0.65) }
     .unknown { background-color: #EBCAFE }
+    .unknown-superseded { background-color: rgba(234, 200, 254, 0.65) }
     .partial { background-color: #FFE0B0 }
+    .partial-superseded { background-color: rgba(255, 224, 179, 0.65) }
     .unreleased { background-color: #FFFF99 }
+    .unreleased-superseded { background-color: rgba(255, 255, 153, 0.65) }
     .full { background-color: #CCFF99 }
+    .full-superseded { background-color: rgba(214, 255, 173, 0.65) }
     .na { background-color: #DDDDDD }
+    .na-superseded { background-color: rgba(222, 222, 222, 0.65) }
     .open * { color: #AAAAAA }
+    .open-superseded * { color: rgba(171, 171, 171, 0.65) }
     //.open { filter: opacity(0.2) }
     tr:target { background-color: #FFFFBB }
     th { background-color: #FFDDAA }
@@ -149,6 +156,8 @@ def availability(issue):
     status = status[:-1-len(unresolved_status)]
 
   avail_suffix = ''
+  avail_style = ''
+  tooltip = ''
   if status.endswith(' c++11'):
     status = status[:-6]
     avail_suffix = ' (C++11 onwards)'
@@ -163,66 +172,67 @@ def availability(issue):
     avail_suffix = ' (C++20 onwards)'
   if status == 'unknown':
     avail = 'Unknown'
-    avail_style = ' class="unknown"'
+    avail_style = 'unknown'
   elif re.match(r'^[0-9]+\.?[0-9]*', status):
     if not proposed_resolution:
       avail = 'Clang %s' % status
       if float(status) > latest_release:
-        avail_style = ' class="unreleased"'
+        avail_style = 'unreleased'
       else:
-        avail_style = ' class="full"'
+        avail_style = 'full'
     else: 
       avail = 'Not Resolved*'
-      avail_style = f' title="Clang {status} implements {proposed_resolution} resolution"'
+      tooltip = f' title="Clang {status} implements {proposed_resolution} resolution"'
   elif status == 'yes':
     if not proposed_resolution:
       avail = 'Yes'
-      avail_style = ' class="full"'
+      avail_style = 'full'
     else:
       avail = 'Not Resolved*'
-      avail_style = f' title="Clang implements {proposed_resolution} resolution"'
+      tooltip = f' title="Clang implements {proposed_resolution} resolution"'
   elif status == 'partial':
     if not proposed_resolution:
       avail = 'Partial'
-      avail_style = ' class="partial"'
+      avail_style = 'partial'
     else:
       avail = 'Not Resolved*'
-      avail_style = f' title="Clang partially implements {proposed_resolution} resolution"'
+      tooltip = f' title="Clang partially implements {proposed_resolution} resolution"'
   elif status == 'no':
     if not proposed_resolution:
       avail = 'No'
-      avail_style = ' class="none"'
+      avail_style = 'none'
     else:
       avail = 'Not Resolved*'
-      avail_style = f' title="Clang does not implement {proposed_resolution} resolution"'
+      tooltip = f' title="Clang does not implement {proposed_resolution} resolution"'
   elif status == 'na':
     avail = 'N/A'
-    avail_style = ' class="na"'
+    avail_style = 'na'
   elif status == 'na lib':
     avail = 'N/A (Library DR)'
-    avail_style = ' class="na"'
+    avail_style = 'na'
   elif status == 'na abi':
     avail = 'N/A (ABI constraint)'
-    avail_style = ' class="na"'
+    avail_style = 'na'
   elif status.startswith('sup '):
     dup = status.split(' ', 1)[1]
     if dup.startswith('P'):
       avail = 'Superseded by <a href="https://wg21.link/%s">%s</a>' % (dup, dup)
-      avail_style = ' class="na"'
+      avail_style = 'na'
     else:
       avail = 'Superseded by <a href="#%s">%s</a>' % (dup, dup)
       try:
-        _, avail_style, _ = availability(int(dup))
+        _, avail_style, _, _ = availability(int(dup))
+        avail_style += '-superseded'
       except:
         print("issue %s marked as sup %s" % (issue, dup), file=sys.stderr)
-        avail_style = ' class="none"'
+        avail_style = 'none'
   elif status.startswith('dup '):
     dup = int(status.split(' ', 1)[1])
     avail = 'Duplicate of <a href="#%s">%s</a>' % (dup, dup)
-    _, avail_style, _ = availability(dup)
+    _, avail_style, _, _ = availability(dup)
   else:
     raise AvailabilityError('Unknown status %s for issue %s' % (status, dr.issue))
-  return (avail + avail_suffix, avail_style, unresolved_status)
+  return (avail + avail_suffix, avail_style, unresolved_status, tooltip)
 
 count = {}
 for dr in drs:
@@ -239,7 +249,7 @@ for dr in drs:
   elif dr.status in ('open', 'drafting', 'review', 'tentatively ready'):
     row_style = ' class="open"'
     try:
-      avail, avail_style, unresolved_status = availability(dr.issue)
+      avail, avail_style, unresolved_status, tooltip = availability(dr.issue)
     except AvailabilityError as e:
       availability_error_occurred = True
       print(e.args[0])
@@ -257,7 +267,7 @@ for dr in drs:
   else:
     row_style = ''
     try:
-      avail, avail_style, unresolved_status = availability(dr.issue)
+      avail, avail_style, unresolved_status, tooltip = availability(dr.issue)
     except AvailabilityError as e:
       availability_error_occurred = True
       print(e.args[0])
@@ -272,13 +282,15 @@ for dr in drs:
   if not avail.startswith('Sup') and not avail.startswith('Dup'):
     count[avail] = count.get(avail, 0) + 1
 
+  if avail_style != '':
+    avail_style = ' class="{}"'.format(avail_style)
   out_file.write('''
   <tr%s id="%s">
     <td><a href="https://cplusplus.github.io/CWG/issues/%s.html">%s</a></td>
     <td>%s</td>
     <td>%s</td>
-    <td%s align="center">%s</td>
-  </tr>''' % (row_style, dr.issue, dr.issue, dr.issue, dr.status, dr.title, avail_style, avail))
+    <td%s%s align="center">%s</td>
+  </tr>''' % (row_style, dr.issue, dr.issue, dr.issue, dr.status, dr.title, avail_style, tooltip, avail))
 
 if availability_error_occurred:
   exit(1)


### PR DESCRIPTION
This patch changes how superseded issues inherit the color of the issues that superseded them. Now they reduce the opacity of the color from 1.0 to 0.65, to make them distinguishable. This was requested during the review of #94876.

That's how it's going to look:
![a1rYVHQ](https://github.com/llvm/llvm-project/assets/12883766/00e624c0-accb-4440-9f9b-4089a157aab2)
