### PR TITLE
Fix getParent / getNodeBaseParent to return pointer to const (#94224)

### DIFF
--- a/llvm/include/llvm/ADT/ilist_node.h
+++ b/llvm/include/llvm/ADT/ilist_node.h
@@ -17,6 +17,7 @@
 
 #include "llvm/ADT/ilist_node_base.h"
 #include "llvm/ADT/ilist_node_options.h"
+#include <type_traits>
 
 namespace llvm {
 
@@ -29,7 +30,9 @@ struct NodeAccess;
 /// has been set in the list options.
 template <class NodeTy, class ParentPtrTy> class node_parent_access {
 public:
-  inline const ParentPtrTy getParent() const {
+  using ConstParentPtrTy =
+      std::add_pointer_t<std::add_const_t<std::remove_pointer_t<ParentPtrTy>>>;
+  inline ConstParentPtrTy getParent() const {
     return static_cast<const NodeTy *>(this)->getNodeBaseParent();
   }
   inline ParentPtrTy getParent() {

--- a/llvm/include/llvm/ADT/ilist_node_base.h
+++ b/llvm/include/llvm/ADT/ilist_node_base.h
@@ -10,6 +10,7 @@
 #define LLVM_ADT_ILIST_NODE_BASE_H
 
 #include "llvm/ADT/PointerIntPair.h"
+#include <type_traits>
 
 namespace llvm {
 
@@ -48,10 +49,12 @@ public:
 
 template <class ParentPtrTy> class node_base_parent {
   ParentPtrTy Parent = nullptr;
+  using ConstParentPtrTy =
+      std::add_pointer_t<std::add_const_t<std::remove_pointer_t<ParentPtrTy>>>;
 
 public:
   void setNodeBaseParent(ParentPtrTy Parent) { this->Parent = Parent; }
-  inline const ParentPtrTy getNodeBaseParent() const { return Parent; }
+  inline ConstParentPtrTy getNodeBaseParent() const { return Parent; }
   inline ParentPtrTy getNodeBaseParent() { return Parent; }
 };
 template <> class node_base_parent<void> {};


### PR DESCRIPTION
Fix getParent / getNodeBaseParent to return pointer to const as opposed to const pointer.

This is particularly problematic as the returned object iterators get const bit unset.