### PR TITLE
[LLD] [MinGW] Interpret an empty -entry option as no entry point

### DIFF
--- a/lld/MinGW/Driver.cpp
+++ b/lld/MinGW/Driver.cpp
@@ -223,8 +223,10 @@ bool link(ArrayRef<const char *> argsArr, llvm::raw_ostream &stdoutOS,
     StringRef s = a->getValue();
     if (args.getLastArgValue(OPT_m) == "i386pe" && s.starts_with("_"))
       add("-entry:" + s.substr(1));
-    else
+    else if (!s.empty())
       add("-entry:" + s);
+    else
+      add("-noentry");
   }
 
   if (args.hasArg(OPT_major_os_version, OPT_minor_os_version,

--- a/lld/test/MinGW/driver.test
+++ b/lld/test/MinGW/driver.test
@@ -60,6 +60,8 @@ RUN: ld.lld -### foo.o -m i386pep --entry bar 2>&1 | FileCheck -check-prefix=ENT
 RUN: ld.lld -### foo.o -m i386pep -entry=bar 2>&1 | FileCheck -check-prefix=ENTRY %s
 RUN: ld.lld -### foo.o -m i386pep --entry=bar 2>&1 | FileCheck -check-prefix=ENTRY %s
 ENTRY: -entry:bar
+RUN: ld.lld -### foo.o -m i386pep -e bar -entry= 2>&1 | FileCheck -check-prefix=NOENTRY --implicit-check-not=-entry %s
+NOENTRY: -noentry
 
 RUN: ld.lld -### foo.o -m i386pep -mllvm bar -mllvm baz 2>&1 | FileCheck -check-prefix=MLLVM %s
 MLLVM: -mllvm:bar -mllvm:baz


### PR DESCRIPTION
This fixes https://github.com/llvm/llvm-project/issues/93309, and seems to match how GNU ld handles this case.
