### PR TITLE
[RISCV] Move RISCVInsertVSETVLI::coalesceVSETVLIs back to before insertReadVL

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVInsertVSETVLI.cpp
+++ b/llvm/lib/Target/RISCV/RISCVInsertVSETVLI.cpp
@@ -1813,11 +1813,6 @@ bool RISCVInsertVSETVLI::runOnMachineFunction(MachineFunction &MF) {
   for (MachineBasicBlock &MBB : MF)
     emitVSETVLIs(MBB);
 
-  // Insert PseudoReadVL after VLEFF/VLSEGFF and replace it with the vl output
-  // of VLEFF/VLSEGFF.
-  for (MachineBasicBlock &MBB : MF)
-    insertReadVL(MBB);
-
   // Now that all vsetvlis are explicit, go through and do block local
   // DSE and peephole based demanded fields based transforms.  Note that
   // this *must* be done outside the main dataflow so long as we allow
@@ -1826,6 +1821,11 @@ bool RISCVInsertVSETVLI::runOnMachineFunction(MachineFunction &MF) {
   // dataflow at the same time without introducing inconsistencies.
   for (MachineBasicBlock &MBB : MF)
     coalesceVSETVLIs(MBB);
+
+  // Insert PseudoReadVL after VLEFF/VLSEGFF and replace it with the vl output
+  // of VLEFF/VLSEGFF.
+  for (MachineBasicBlock &MBB : MF)
+    insertReadVL(MBB);
 
   BlockInfo.clear();
   return HaveVectorOp;


### PR DESCRIPTION
In #88295 we split out coalesceVSETVLIs (f.k.a doLocalPostpass) into a separate pass, which meant moving it past the call to insertReadVL. Whenever we merged it back in #92869, we left it after insertReadVL. This patch moves it back to its original position.
