### PR TITLE
[LLD] [COFF] Don't crash on an empty -entry: argument

### DIFF
--- a/lld/COFF/Driver.cpp
+++ b/lld/COFF/Driver.cpp
@@ -412,6 +412,8 @@ void LinkerDriver::parseDirectives(InputFile *file) {
         enqueuePath(*path, false, false);
       break;
     case OPT_entry:
+      if (!arg->getValue()[0])
+        fatal("missing entry point symbol name");
       ctx.config.entry = addUndefined(mangle(arg->getValue()));
       break;
     case OPT_failifmismatch:
@@ -2248,6 +2250,8 @@ void LinkerDriver::linkerMain(ArrayRef<const char *> argsArr) {
   {
     llvm::TimeTraceScope timeScope("Entry point");
     if (auto *arg = args.getLastArg(OPT_entry)) {
+      if (!arg->getValue()[0])
+        fatal("missing entry point symbol name");
       config->entry = addUndefined(mangle(arg->getValue()));
     } else if (!config->entry && !config->noEntry) {
       if (args.hasArg(OPT_dll)) {

--- a/lld/test/COFF/invalid-entry.s
+++ b/lld/test/COFF/invalid-entry.s
@@ -1,0 +1,20 @@
+# REQUIRES: x86
+# RUN: split-file %s %t.dir && cd %t.dir
+
+# RUN: llvm-mc -filetype=obj -triple=x86_64-windows test.s -o test.obj
+# RUN: llvm-mc -filetype=obj -triple=x86_64-windows drectve.s -o drectve.obj
+
+# RUN: env LLD_IN_TEST=1 not lld-link -out:out.dll test.obj -dll -entry: 2>&1 | FileCheck %s
+# RUN: env LLD_IN_TEST=1 not lld-link -out:out.dll test.obj -dll drectve.obj 2>&1 | FileCheck %s
+
+# CHECK: error: missing entry point symbol name
+
+#--- test.s
+        .text
+        .globl func
+func:
+        ret
+
+#--- drectve.s
+        .section .drectve, "yn"
+        .ascii " -entry:"


### PR DESCRIPTION
We can't pass an empty string to addUndefined().

This fixes the crash that was encountered in
https://github.com/llvm/llvm-project/issues/93309 (turning the crash into a properly handled error; making it do the right thing is handled in https://github.com/llvm/llvm-project/pull/96055).