### PR TITLE
[clang-format][doc] Add clarification to `PointerAlignment`

### DIFF
--- a/clang/docs/ClangFormatStyleOptions.rst
+++ b/clang/docs/ClangFormatStyleOptions.rst
@@ -5015,7 +5015,7 @@ the configuration (without a prefix: ``Auto``).
 .. _PointerAlignment:
 
 **PointerAlignment** (``PointerAlignmentStyle``) :versionbadge:`clang-format 3.7` :ref:`¶ <PointerAlignment>`
-  Pointer and reference alignment style.
+  Pointer and reference alignment style. Only used if ``DerivePointerAlignment`` is not ``true``.
 
   Possible values:
 


### PR DESCRIPTION
Clarify that `PointerAlignment` is not used if `DerivePointerAlignment` is set to `true`. So far this was only mentioned under `DerivePointerAlignment` which could lead to confusion if someone only looked at `PointerAlignment`.