### PR TITLE
[RISCV] Support constant hoisting of immediate store values

### DIFF
--- a/llvm/lib/Target/RISCV/MCTargetDesc/RISCVMatInt.cpp
+++ b/llvm/lib/Target/RISCV/MCTargetDesc/RISCVMatInt.cpp
@@ -499,7 +499,7 @@ InstSeq generateTwoRegInstSeq(int64_t Val, const MCSubtargetInfo &STI,
 }
 
 int getIntMatCost(const APInt &Val, unsigned Size, const MCSubtargetInfo &STI,
-                  bool CompressionCost) {
+                  bool CompressionCost, bool FreeZeroes) {
   bool IsRV64 = STI.hasFeature(RISCV::Feature64Bit);
   bool HasRVC = CompressionCost && (STI.hasFeature(RISCV::FeatureStdExtC) ||
                                     STI.hasFeature(RISCV::FeatureStdExtZca));
@@ -510,10 +510,12 @@ int getIntMatCost(const APInt &Val, unsigned Size, const MCSubtargetInfo &STI,
   int Cost = 0;
   for (unsigned ShiftVal = 0; ShiftVal < Size; ShiftVal += PlatRegSize) {
     APInt Chunk = Val.ashr(ShiftVal).sextOrTrunc(PlatRegSize);
+    if (FreeZeroes && Chunk == 0)
+      continue;
     InstSeq MatSeq = generateInstSeq(Chunk.getSExtValue(), STI);
     Cost += getInstSeqCost(MatSeq, HasRVC);
   }
-  return std::max(1, Cost);
+  return std::max(FreeZeroes ? 0 : 1, Cost);
 }
 
 OpndKind Inst::getOpndKind() const {

--- a/llvm/lib/Target/RISCV/MCTargetDesc/RISCVMatInt.cpp
+++ b/llvm/lib/Target/RISCV/MCTargetDesc/RISCVMatInt.cpp
@@ -510,7 +510,7 @@ int getIntMatCost(const APInt &Val, unsigned Size, const MCSubtargetInfo &STI,
   int Cost = 0;
   for (unsigned ShiftVal = 0; ShiftVal < Size; ShiftVal += PlatRegSize) {
     APInt Chunk = Val.ashr(ShiftVal).sextOrTrunc(PlatRegSize);
-    if (FreeZeroes && Chunk == 0)
+    if (FreeZeroes && Chunk.getSExtValue() == 0)
       continue;
     InstSeq MatSeq = generateInstSeq(Chunk.getSExtValue(), STI);
     Cost += getInstSeqCost(MatSeq, HasRVC);

--- a/llvm/lib/Target/RISCV/MCTargetDesc/RISCVMatInt.h
+++ b/llvm/lib/Target/RISCV/MCTargetDesc/RISCVMatInt.h
@@ -71,8 +71,13 @@ InstSeq generateTwoRegInstSeq(int64_t Val, const MCSubtargetInfo &STI,
 // If CompressionCost is true it will use a different cost calculation if RVC is
 // enabled. This should be used to compare two different sequences to determine
 // which is more compressible.
+//
+// If FreeZeroes is true, it will be assumed free to materialize any
+// XLen-sized chunks that are 0. This is appropriate to use in instances when
+// the zero register can be used, e.g. when estimating the cost of
+// materializing a value used by a particular operation.
 int getIntMatCost(const APInt &Val, unsigned Size, const MCSubtargetInfo &STI,
-                  bool CompressionCost = false);
+                  bool CompressionCost = false, bool FreeZeroes = false);
 } // namespace RISCVMatInt
 } // namespace llvm
 #endif

--- a/llvm/test/CodeGen/RISCV/pr64935.ll
+++ b/llvm/test/CodeGen/RISCV/pr64935.ll
@@ -4,7 +4,10 @@
 define i1 @f() {
 ; CHECK-LABEL: f:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    li a0, 1
+; CHECK-NEXT:    lui a0, 524288
+; CHECK-NEXT:    not a0, a0
+; CHECK-NEXT:    sltiu a0, a0, 2
+; CHECK-NEXT:    xori a0, a0, 1
 ; CHECK-NEXT:    ret
   %B25 = shl i64 4294967296, -9223372036854775808
   %B13 = sub i64 -1, -9223372036854775808

--- a/llvm/test/CodeGen/RISCV/pr64935.ll
+++ b/llvm/test/CodeGen/RISCV/pr64935.ll
@@ -4,10 +4,7 @@
 define i1 @f() {
 ; CHECK-LABEL: f:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    lui a0, 524288
-; CHECK-NEXT:    not a0, a0
-; CHECK-NEXT:    sltiu a0, a0, 2
-; CHECK-NEXT:    xori a0, a0, 1
+; CHECK-NEXT:    li a0, 1
 ; CHECK-NEXT:    ret
   %B25 = shl i64 4294967296, -9223372036854775808
   %B13 = sub i64 -1, -9223372036854775808

--- a/llvm/test/Transforms/ConstantHoisting/RISCV/immediates.ll
+++ b/llvm/test/Transforms/ConstantHoisting/RISCV/immediates.ll
@@ -221,3 +221,54 @@ define void @test20(ptr %p1, ptr %p2) {
   store i32 15111112, ptr %p2, align 4
   ret void
 }
+
+define void @test21(ptr %p1, ptr %p2) {
+; CHECK-LABEL: define void @test21(
+; CHECK-SAME: ptr [[P1:%.*]], ptr [[P2:%.*]]) {
+; CHECK-NEXT:    store i32 15111111, ptr [[P1]], align 1
+; CHECK-NEXT:    store i32 15111112, ptr [[P2]], align 1
+; CHECK-NEXT:    ret void
+;
+  store i32 15111111, ptr %p1, align 1
+  store i32 15111112, ptr %p2, align 1
+  ret void
+}
+
+; 0 immediates shouldn't be hoisted.
+define void @test22(ptr %p1, ptr %p2) {
+; CHECK-LABEL: define void @test22(
+; CHECK-SAME: ptr [[P1:%.*]], ptr [[P2:%.*]]) {
+; CHECK-NEXT:    store i128 0, ptr [[P1]], align 8
+; CHECK-NEXT:    store i128 -1, ptr [[P2]], align 8
+; CHECK-NEXT:    ret void
+;
+  store i64 0, ptr %p1, align 8
+  store i64 -1, ptr %p2, align 8
+  ret void
+}
+
+; 0 immediates shouldn't be hoisted.
+define void @test23(ptr %p1, ptr %p2) {
+; CHECK-LABEL: define void @test23(
+; CHECK-SAME: ptr [[P1:%.*]], ptr [[P2:%.*]]) {
+; CHECK-NEXT:    store i127 0, ptr [[P1]], align 8
+; CHECK-NEXT:    store i127 -1, ptr [[P2]], align 8
+; CHECK-NEXT:    ret void
+;
+  store i127 0, ptr %p1, align 8
+  store i127 -1, ptr %p2, align 8
+  ret void
+}
+
+; Hoisting doesn't happen for types that aren't legal.
+define void @test24(ptr %p1, ptr %p2) {
+; CHECK-LABEL: define void @test24(
+; CHECK-SAME: ptr [[P1:%.*]], ptr [[P2:%.*]]) {
+; CHECK-NEXT:    store i128 15111111, ptr [[P1]], align 4
+; CHECK-NEXT:    store i128 15111112, ptr [[P2]], align 4
+; CHECK-NEXT:    ret void
+;
+  store i128 15111111, ptr %p1, align 4
+  store i128 15111112, ptr %p2, align 4
+  ret void
+}

--- a/llvm/test/Transforms/ConstantHoisting/RISCV/immediates.ll
+++ b/llvm/test/Transforms/ConstantHoisting/RISCV/immediates.ll
@@ -238,8 +238,8 @@ define void @test21(ptr %p1, ptr %p2) {
 define void @test22(ptr %p1, ptr %p2) {
 ; CHECK-LABEL: define void @test22(
 ; CHECK-SAME: ptr [[P1:%.*]], ptr [[P2:%.*]]) {
-; CHECK-NEXT:    store i128 0, ptr [[P1]], align 8
-; CHECK-NEXT:    store i128 -1, ptr [[P2]], align 8
+; CHECK-NEXT:    store i64 0, ptr [[P1]], align 8
+; CHECK-NEXT:    store i64 -1, ptr [[P2]], align 8
 ; CHECK-NEXT:    ret void
 ;
   store i64 0, ptr %p1, align 8

--- a/llvm/test/Transforms/ConstantHoisting/RISCV/immediates.ll
+++ b/llvm/test/Transforms/ConstantHoisting/RISCV/immediates.ll
@@ -211,11 +211,12 @@ exit:
 
 ; Check that we use a common base for immediates needed by a store if the
 ; constants require more than 1 instruction.
-; TODO: This doesn't trigger currently.
 define void @test20(ptr %p1, ptr %p2) {
 ; CHECK-LABEL: test20
-; CHECK: store i32 15111111, ptr %p1
-; CHECK: store i32 15111112, ptr %p2
+; CHECK: %const = bitcast i32 15111111 to i32
+; CHECK: store i32 %const, ptr %p1, align 4
+; CHECK: %const_mat = add i32 %const, 1
+; CHECK: store i32 %const_mat, ptr %p2, align 4
   store i32 15111111, ptr %p1, align 4
   store i32 15111112, ptr %p2, align 4
   ret void


### PR DESCRIPTION
Previously getIntImmInstCost only calculated the cost of materialising the argument of a store if it was the address. This means ConstantHoisting's transformation wouldn't kick in for cases like storing two values that require multiple instructions to materialise but where one can be cheaply generated from the other (e.g. by an addition).

Two key changes were needed to avoid regressions when enabling this:
* Allowing constant materialisation cost to be calculated assuming zeroes are free (as might happen if you had a 2*XLEN constant and one half is zero).
* Avoiding constant hoisting if we have a misaligned store that's going to be a legalised to a sequence of narrower stores. I'm seeing cases where hoisting the constant ends up with worse codegen in that case.