### PR TITLE
[libc++] Improve aligned allocation support with picolibc.

### DIFF
--- a/libcxx/include/__config
+++ b/libcxx/include/__config
@@ -679,6 +679,9 @@ typedef __char32_t char32_t;
 #    define _LIBCPP_HAS_NO_ALIGNED_ALLOCATION
 #  endif
 
+// _LIBCPP_HAS_NO_C11_ALIGNED_ALLOC should be defined on platforms
+// where you would expect C11 aligned_alloc() to exist but it doesn't.
+
 // It is not yet possible to use aligned_alloc() on all Apple platforms since
 // 10.15 was the first version to ship an implementation of aligned_alloc().
 #  if defined(__APPLE__)
@@ -689,6 +692,16 @@ typedef __char32_t char32_t;
 #  elif defined(__ANDROID__) && __ANDROID_API__ < 28
 // Android only provides aligned_alloc when targeting API 28 or higher.
 #    define _LIBCPP_HAS_NO_C11_ALIGNED_ALLOC
+#  endif
+
+// _LIBCPP_HAS_C11_ALIGNED_ALLOC may be defined on platforms where C11
+// aligned_alloc() is known to exist even if you might not expect it.
+
+// picolibc has two memory allocators, one of which doesn't provide
+// posix_memalign(). But they both reliably provide C11
+// aligned_alloc(), at least since 1.4.4.
+#  if defined(__PICOLIBC__) && (__PICOLIBC__ > 1 || (__PICOLIBC__ == 1 && (__PICOLIBC_MINOR__ > 4 || (__PICOLIBC_MINOR__ == 4 && __PICOLIBC_PATCHLEVEL__ >= 4))))
+#    define _LIBCPP_HAS_C11_ALIGNED_ALLOC
 #  endif
 
 #  if defined(__APPLE__) || defined(__FreeBSD__)

--- a/libcxx/include/__memory/aligned_alloc.h
+++ b/libcxx/include/__memory/aligned_alloc.h
@@ -30,7 +30,7 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 inline _LIBCPP_HIDE_FROM_ABI void* __libcpp_aligned_alloc(std::size_t __alignment, std::size_t __size) {
 #  if defined(_LIBCPP_MSVCRT_LIKE)
   return ::_aligned_malloc(__size, __alignment);
-#  elif _LIBCPP_STD_VER >= 17 && !defined(_LIBCPP_HAS_NO_C11_ALIGNED_ALLOC)
+#  elif defined(_LIBCPP_HAS_C11_ALIGNED_ALLOC) || (_LIBCPP_STD_VER >= 17 && !defined(_LIBCPP_HAS_NO_C11_ALIGNED_ALLOC))
   // aligned_alloc() requires that __size is a multiple of __alignment,
   // but for C++ [new.delete.general], only states "if the value of an
   // alignment argument passed to any of these functions is not a valid


### PR DESCRIPTION
picolibc has two memory allocators, one of which doesn't provide posix_memalign(). But both of them provide C11 aligned_alloc(). Unfortunately the libc++ test support code has no option to use aligned_alloc, only posix_memalign or MSVC-style _aligned_malloc.

This patch modifies the aligned allocation in libc++ test support to use the __libcpp_aligned_alloc helper function already defined in <include/__memory>, if it's available. That already has an option to use aligned_alloc and knows how to use it right.

Also added version detection for picolibc in <include/__config>, so that __libcpp_aligned_alloc can switch to aligned_alloc() if that's a better choice than posix_memalign.

Finally, I couldn't resist renaming the test support function `alocate_aligned_impl` so that it spells 'allocate' correctly. (Keeping track of identifiers in software is hard enough without also having to remember which ones have which spelling mistakes.)