### PR TITLE
[PowerPC] Remove extraneous ArrayRef (NFC)

### DIFF
--- a/llvm/lib/Target/PowerPC/PPCISelLowering.cpp
+++ b/llvm/lib/Target/PowerPC/PPCISelLowering.cpp
@@ -5608,7 +5608,7 @@ static void prepareIndirectCall(SelectionDAG &DAG, SDValue &Callee,
                                 const SDLoc &dl) {
   SDValue MTCTROps[] = {Chain, Callee, Glue};
   EVT ReturnTypes[] = {MVT::Other, MVT::Glue};
-  Chain = DAG.getNode(PPCISD::MTCTR, dl, ArrayRef(ReturnTypes, 2),
+  Chain = DAG.getNode(PPCISD::MTCTR, dl, ReturnTypes,
                       ArrayRef(MTCTROps, Glue.getNode() ? 3 : 2));
   // The glue is the second value produced.
   Glue = Chain.getValue(1);
@@ -10937,10 +10937,10 @@ SDValue PPCTargetLowering::LowerINTRINSIC_WO_CHAIN(SDValue Op,
   case Intrinsic::ppc_mma_disassemble_acc: {
     if (Subtarget.isISAFuture()) {
       EVT ReturnTypes[] = {MVT::v256i1, MVT::v256i1};
-      SDValue WideVec = SDValue(DAG.getMachineNode(PPC::DMXXEXTFDMR512, dl,
-                                                   ArrayRef(ReturnTypes, 2),
-                                                   Op.getOperand(1)),
-                                0);
+      SDValue WideVec =
+          SDValue(DAG.getMachineNode(PPC::DMXXEXTFDMR512, dl, ReturnTypes,
+                                     Op.getOperand(1)),
+                  0);
       SmallVector<SDValue, 4> RetOps;
       SDValue Value = SDValue(WideVec.getNode(), 0);
       SDValue Value2 = SDValue(WideVec.getNode(), 1);
@@ -11609,7 +11609,7 @@ SDValue PPCTargetLowering::LowerVectorStore(SDValue Op,
     if (Subtarget.isISAFuture()) {
       EVT ReturnTypes[] = {MVT::v256i1, MVT::v256i1};
       MachineSDNode *ExtNode = DAG.getMachineNode(
-          PPC::DMXXEXTFDMR512, dl, ArrayRef(ReturnTypes, 2), Op.getOperand(1));
+          PPC::DMXXEXTFDMR512, dl, ReturnTypes, Op.getOperand(1));
 
       Value = SDValue(ExtNode, 0);
       Value2 = SDValue(ExtNode, 1);


### PR DESCRIPTION
ArrayRef can be implicitly constructed from a C array while inferring
its size.