### PR TITLE
[FPEnv] Add strictfp attribute to the FP environment manipulation intrinsics

### DIFF
--- a/llvm/include/llvm/IR/Intrinsics.td
+++ b/llvm/include/llvm/IR/Intrinsics.td
@@ -1093,7 +1093,11 @@ def int_objectsize : DefaultAttrsIntrinsic<[llvm_anyint_ty],
 //===--------------- Access to Floating Point Environment -----------------===//
 //
 
-let IntrProperties = [IntrInaccessibleMemOnly, IntrWillReturn] in {
+/// IntrStrictFP - The intrinsic is allowed to be used in an alternate
+/// floating point environment or touches the current one.
+def IntrStrictFP : IntrinsicProperty;
+
+let IntrProperties = [IntrInaccessibleMemOnly, IntrWillReturn, IntrStrictFP] in {
   def int_get_rounding  : DefaultAttrsIntrinsic<[llvm_i32_ty], []>;
   def int_set_rounding  : DefaultAttrsIntrinsic<[], [llvm_i32_ty]>;
   def int_get_fpenv     : DefaultAttrsIntrinsic<[llvm_anyint_ty], []>;
@@ -1114,10 +1118,6 @@ def int_is_fpclass
 
 //===--------------- Constrained Floating Point Intrinsics ----------------===//
 //
-
-/// IntrStrictFP - The intrinsic is allowed to be used in an alternate
-/// floating point environment.
-def IntrStrictFP : IntrinsicProperty;
 
 let IntrProperties = [IntrInaccessibleMemOnly, IntrWillReturn, IntrStrictFP] in {
   def int_experimental_constrained_fadd : DefaultAttrsIntrinsic<[ llvm_anyfloat_ty ],


### PR DESCRIPTION
The constrained intrinsics already have strictfp added in the tablegen definitions. These environment manipulation intrinsics should as well since they touch the FP environment.

No change in visible behavior, and calls to them won't need the strictfp attribute because it was already added here. Existing tests don't need to be changed because calls from non-strictfp function to strictfp functions are allowed.