### PR TITLE
enable file-headers option of llvm-objdump for XCOFF object files

### DIFF
--- a/llvm/include/llvm/Object/XCOFFObjectFile.h
+++ b/llvm/include/llvm/Object/XCOFFObjectFile.h
@@ -70,6 +70,9 @@ public:
   }
 
   uint16_t getVersion() const { return static_cast<const T *>(this)->Version; }
+  uint64_t getEntryPointAddr() const {
+    return static_cast<const T *>(this)->EntryPointAddr;
+  }
 };
 
 struct XCOFFAuxiliaryHeader32 : XCOFFAuxiliaryHeader<XCOFFAuxiliaryHeader32> {

--- a/llvm/lib/Object/XCOFFObjectFile.cpp
+++ b/llvm/lib/Object/XCOFFObjectFile.cpp
@@ -737,9 +737,11 @@ bool XCOFFObjectFile::isRelocatableObject() const {
 }
 
 Expected<uint64_t> XCOFFObjectFile::getStartAddress() const {
-  // TODO FIXME Should get from auxiliary_header->o_entry when support for the
-  // auxiliary_header is added.
-  return 0;
+  if (AuxiliaryHeader == nullptr)
+    return 0;
+
+  return is64Bit() ? auxiliaryHeader64()->getEntryPointAddr()
+                   : auxiliaryHeader32()->getEntryPointAddr();
 }
 
 StringRef XCOFFObjectFile::mapDebugSectionName(StringRef Name) const {

--- a/llvm/test/tools/llvm-objdump/XCOFF/file-headers.test
+++ b/llvm/test/tools/llvm-objdump/XCOFF/file-headers.test
@@ -16,41 +16,6 @@
 FileHeader:
   MagicNumber: [[MAGIC=0x1DF]]
 AuxiliaryHeader:
-  Magic:                 0x10B
-  Version:               0x1
-  TextSectionSize:       0x8
-  DataSectionSize:       0x9
-  BssSectionSize:        0x10
   EntryPointAddr:        0x1111
-  TextStartAddr:         0x2222
-  DataStartAddr:         0x3333
-  TOCAnchorAddr:         0x4444
-  SecNumOfEntryPoint:    1
-  SecNumOfText:          2
-  SecNumOfData:          3
-  SecNumOfTOC:           4
-  SecNumOfLoader:        5
-  SecNumOfBSS:           6
-  MaxAlignOfText:        0x7
-  MaxAlignOfData:        0x3
-  ModuleType:            0x1
-  TextPageSize:          0x1
-  DataPageSize:          0x1
-  StackPageSize:         0x1
-  SecNumOfTData:         7
-  SecNumOfTBSS:          8
   FlagAndTDataAlignment: 0x1
   Flag:                  [[FLAG64=<none>]]
-Sections:
-  - Flags:       [ STYP_TEXT ]
-    SectionData: "1232"
-  - Flags:       [ STYP_DATA ]
-    SectionData: "5678"
-  - Flags:       [ STYP_BSS ]
-    SectionData: "9101"
-  - Flags:       [ STYP_TDATA ]
-    SectionData: "1112"
-  - Flags:       [ STYP_TBSS ]
-    SectionData: "1314"
-  - Flags:       [ STYP_LOADER ]
-    SectionData: "1516"

--- a/llvm/test/tools/llvm-objdump/XCOFF/file-headers.test
+++ b/llvm/test/tools/llvm-objdump/XCOFF/file-headers.test
@@ -1,8 +1,10 @@
-# Test the `--file-headers` option of llvm-objdump for XCOFF object files.  
+## Test the `--file-headers` option of llvm-objdump for XCOFF object files.
 # RUN: yaml2obj %s -o %t1
-# RUN: llvm-objdump --file-headers %t1 | FileCheck %s --check-prefix=CHECK32
-# RUN: yaml2obj %s -DMAGIC=0x1F7 -DFLAG64=0x2 -o %t2
-# RUN: llvm-objdump --file-headers  %t2 | FileCheck %s --check-prefix=CHECK64
+# RUN: llvm-objdump --file-headers %t1 |\
+# RUN:   FileCheck %s --check-prefix=CHECK32 --match-full-lines
+# RUN: yaml2obj %s -DMAGIC=0x1F7 -o %t2
+# RUN: llvm-objdump --file-headers %t2 |\
+# RUN:   FileCheck %s --check-prefix=CHECK64 --match-full-lines
 
 # CHECK32:      {{.*}}file format aixcoff-rs6000 
 # CHECK32-NEXT: architecture: powerpc
@@ -17,5 +19,3 @@ FileHeader:
   MagicNumber: [[MAGIC=0x1DF]]
 AuxiliaryHeader:
   EntryPointAddr:        0x1111
-  FlagAndTDataAlignment: 0x1
-  Flag:                  [[FLAG64=<none>]]

--- a/llvm/test/tools/llvm-objdump/XCOFF/file-headers.test
+++ b/llvm/test/tools/llvm-objdump/XCOFF/file-headers.test
@@ -1,0 +1,56 @@
+# Test the `--file-headers` option of llvm-objdump for XCOFF object files.  
+# RUN: yaml2obj %s -o %t1
+# RUN: llvm-objdump --file-headers %t1 | FileCheck %s --check-prefix=CHECK32
+# RUN: yaml2obj %s -DMAGIC=0x1F7 -DFLAG64=0x2 -o %t2
+# RUN: llvm-objdump --file-headers  %t2 | FileCheck %s --check-prefix=CHECK64
+
+# CHECK32:      {{.*}}file format aixcoff-rs6000 
+# CHECK32-NEXT: architecture: powerpc
+# CHECK32-NEXT: start address: 0x00001111
+
+# CHECK64:      {{.*}}file format aix5coff64-rs6000
+# CHECK64-NEXT: architecture: powerpc64
+# CHECK64-NEXT: start address: 0x0000000000001111
+
+--- !XCOFF
+FileHeader:
+  MagicNumber: [[MAGIC=0x1DF]]
+AuxiliaryHeader:
+  Magic:                 0x10B
+  Version:               0x1
+  TextSectionSize:       0x8
+  DataSectionSize:       0x9
+  BssSectionSize:        0x10
+  EntryPointAddr:        0x1111
+  TextStartAddr:         0x2222
+  DataStartAddr:         0x3333
+  TOCAnchorAddr:         0x4444
+  SecNumOfEntryPoint:    1
+  SecNumOfText:          2
+  SecNumOfData:          3
+  SecNumOfTOC:           4
+  SecNumOfLoader:        5
+  SecNumOfBSS:           6
+  MaxAlignOfText:        0x7
+  MaxAlignOfData:        0x3
+  ModuleType:            0x1
+  TextPageSize:          0x1
+  DataPageSize:          0x1
+  StackPageSize:         0x1
+  SecNumOfTData:         7
+  SecNumOfTBSS:          8
+  FlagAndTDataAlignment: 0x1
+  Flag:                  [[FLAG64=<none>]]
+Sections:
+  - Flags:       [ STYP_TEXT ]
+    SectionData: "1232"
+  - Flags:       [ STYP_DATA ]
+    SectionData: "5678"
+  - Flags:       [ STYP_BSS ]
+    SectionData: "9101"
+  - Flags:       [ STYP_TDATA ]
+    SectionData: "1112"
+  - Flags:       [ STYP_TBSS ]
+    SectionData: "1314"
+  - Flags:       [ STYP_LOADER ]
+    SectionData: "1516"

--- a/llvm/tools/llvm-objdump/llvm-objdump.cpp
+++ b/llvm/tools/llvm-objdump/llvm-objdump.cpp
@@ -3151,7 +3151,7 @@ void Dumper::printPrivateHeaders() {
 }
 
 static void printFileHeaders(const ObjectFile *O) {
-  if (!O->isELF() && !O->isCOFF())
+  if (!O->isELF() && !O->isCOFF() && !O->isXCOFF())
     reportError(O->getFileName(), "Invalid/Unsupported object file format");
 
   Triple::ArchType AT = O->getArch();


### PR DESCRIPTION
the patch enable file-headers option of llvm-objdump for XCOFF object files