### PR TITLE
[PPC][InlineASM] Mark the 'a' constraint as unsupported

### DIFF
--- a/clang/lib/Basic/Targets/PPC.h
+++ b/clang/lib/Basic/Targets/PPC.h
@@ -305,9 +305,11 @@ public:
               // asm statements)
       Info.setAllowsMemory();
       break;
-    case 'R': // AIX TOC entry
     case 'a': // Address operand that is an indexed or indirect from a
               // register (`p' is preferable for asm statements)
+              // TODO: Add full support for this constraint
+      return false;
+    case 'R': // AIX TOC entry
     case 'S': // Constant suitable as a 64-bit mask operand
     case 'T': // Constant suitable as a 32-bit mask operand
     case 'U': // System V Release 4 small data area reference

--- a/clang/test/CodeGen/PowerPC/inline-asm-constraints-error.c
+++ b/clang/test/CodeGen/PowerPC/inline-asm-constraints-error.c
@@ -1,4 +1,3 @@
-// RUN: %clang_cc1 -emit-llvm -triple powerpc64le-linux-gnu -verify %s
 // RUN: %clang_cc1 -emit-llvm -triple powerpc64-ibm-aix-xcoff -verify %s
 // RUN: %clang_cc1 -emit-llvm -triple powerpc-ibm-aix-xcoff -verify %s
 // This test case exist to test marking the 'a' inline assembly constraint as

--- a/clang/test/CodeGen/PowerPC/inline-asm-unsupported-constraint-error.c
+++ b/clang/test/CodeGen/PowerPC/inline-asm-unsupported-constraint-error.c
@@ -1,0 +1,8 @@
+// RUN: %clang_cc1 -emit-llvm -triple powerpc64le-unknown-unknown -verify %s
+// This test case exist to test marking the 'a' inline assembly constraint as
+// unsupported because powerpc previously marked it as supported.
+int foo(int arg){
+  asm goto ("bc %0,%1,%l[TEST_LABEL]" : : "a"(&&TEST_LABEL) : : TEST_LABEL); //expected-error {{invalid input constraint 'a' in asm}}
+  return 0;
+TEST_LABEL: return arg + 1;
+}

--- a/clang/test/CodeGen/PowerPC/inline-asm-unsupported-constraint-error.c
+++ b/clang/test/CodeGen/PowerPC/inline-asm-unsupported-constraint-error.c
@@ -1,8 +1,10 @@
-// RUN: %clang_cc1 -emit-llvm -triple powerpc64le-unknown-unknown -verify %s
+// RUN: %clang_cc1 -emit-llvm -triple powerpc64le-linux-gnu -verify %s
+// RUN: %clang_cc1 -emit-llvm -triple powerpc64-ibm-aix-xcoff -verify %s
+// RUN: %clang_cc1 -emit-llvm -triple powerpc-ibm-aix-xcoff -verify %s
 // This test case exist to test marking the 'a' inline assembly constraint as
 // unsupported because powerpc previously marked it as supported.
 int foo(int arg){
-  asm goto ("bc %0,%1,%l[TEST_LABEL]" : : "a"(&&TEST_LABEL) : : TEST_LABEL); //expected-error {{invalid input constraint 'a' in asm}}
+  asm goto ("bc 12,2,%l[TEST_LABEL]" : : "a"(&&TEST_LABEL) : : TEST_LABEL); //expected-error {{invalid input constraint 'a' in asm}}
   return 0;
 TEST_LABEL: return arg + 1;
 }


### PR DESCRIPTION
'a' is an input/ouput constraint for restraining assembly variables
to an indexed or indirect address operand. It previously was marked
as supported but would throw an assertion for unknown constraint type
in the back-end when this test case was compiled. This change marks it
as unsupported until we can add full support for address operands
constraining to the compiler code generation.
