### PR TITLE
[Clang][Sanitizers] Enable NSAN on Linux only

### DIFF
--- a/clang/lib/Driver/ToolChains/Darwin.cpp
+++ b/clang/lib/Driver/ToolChains/Darwin.cpp
@@ -3474,9 +3474,6 @@ SanitizerMask Darwin::getSupportedSanitizers() const {
     Res |= SanitizerKind::Thread;
   }
 
-  if (IsX86_64)
-    Res |= SanitizerKind::NumericalStability;
-
   return Res;
 }
 

--- a/clang/test/Driver/fsanitize.c
+++ b/clang/test/Driver/fsanitize.c
@@ -468,8 +468,8 @@
 // RUN: not %clang --target=mips-unknown-linux -fsanitize=numerical %s -### 2>&1 | FileCheck %s --check-prefix=CHECK-NSAN-MIPS-LINUX
 // CHECK-NSAN-MIPS-LINUX: error: unsupported option '-fsanitize=numerical' for target 'mips-unknown-linux'
 
-// RUN: %clang --target=x86_64-apple-macos -fsanitize=numerical %s -### 2>&1 | FileCheck %s --check-prefix=CHECK-NSAN-X86-64-MACOS
-// CHECK-NSAN-X86-64-MACOS: "-fsanitize=numerical"
+// RUN: not %clang --target=x86_64-apple-macos -fsanitize=numerical %s -### 2>&1 | FileCheck %s --check-prefix=CHECK-NSAN-X86-64-MACOS
+// CHECK-NSAN-X86-64-MACOS: error: unsupported option '-fsanitize=numerical' for target 'x86_64-apple-macos'
 
 // RUN: not %clang --target=arm64-apple-macos -fsanitize=numerical %s -### 2>&1 | FileCheck %s --check-prefix=CHECK-NSAN-ARM64-MACOS
 // CHECK-NSAN-ARM64-MACOS: error: unsupported option '-fsanitize=numerical' for target 'arm64-apple-macos'


### PR DESCRIPTION
Enable nsan on Linux only.
Adding support for X86_64 MacOS requires minimal efforts
(might need to copy some bits from other sanitizers (in compiler-rt)).
Currently the functionality has been tested on Linux only.
