### PR TITLE
[flang][debug] Support pointer type.

### DIFF
--- a/flang/lib/Optimizer/Transforms/DebugTypeGenerator.cpp
+++ b/flang/lib/Optimizer/Transforms/DebugTypeGenerator.cpp
@@ -284,6 +284,10 @@ DebugTypeGenerator::convertType(mlir::Type Ty, mlir::LLVM::DIFileAttr fileAttr,
       return convertPointerLikeType(heapTy.getElementType(), fileAttr, scope,
                                     loc, /*genAllocated=*/true,
                                     /*genAssociated=*/false);
+    if (auto ptrTy = mlir::dyn_cast_or_null<fir::PointerType>(elTy))
+      return convertPointerLikeType(ptrTy.getElementType(), fileAttr, scope,
+                                    loc, /*genAllocated=*/false,
+                                    /*genAssociated=*/true);
     return genPlaceholderType(context);
   } else {
     // FIXME: These types are currently unhandled. We are generating a

--- a/flang/test/Integration/debug-ptr-type.f90
+++ b/flang/test/Integration/debug-ptr-type.f90
@@ -1,0 +1,50 @@
+! RUN: %flang_fc1 -emit-llvm -debug-info-kind=standalone %s -o - | FileCheck  %s
+
+subroutine ff(n, m)
+  implicit none
+  integer i, j, m, n
+  real(4), pointer :: par(:, :)
+  integer, pointer :: psc
+  integer, pointer :: par2(:)
+  character(len=16), pointer :: pstr
+  real(4), target :: ar(4, 5)
+  integer, target :: sc
+  integer, target, allocatable :: ar2(:)
+  character(len=:), target, allocatable :: str
+
+  str = 'Hello'
+  pstr => str
+  allocate(ar2(4))
+  par2 => ar2
+  do i=1,5
+    do j=1,4
+    ar(j,i) = 0.1
+    par2(j) = j
+    end do
+  end do
+  sc = 3
+  psc => sc
+  par => ar
+
+  print *, sc
+  print *, ar
+  print *, ar2
+  print *, str
+  print *, psc
+  print *, par
+  print *, par2
+  print *, pstr
+end subroutine ff
+
+
+! CHECK-DAG: ![[INT_TY:[0-9]+]] = !DIBasicType(name: "integer"{{.*}})
+! CHECK-DAG: ![[ELEMS1:[0-9]+]] = !{!{{[0-9]+}}}
+! CHECK-DAG: !DILocalVariable(name: "par"{{.*}}type: ![[ARR_TY1:[0-9]+]])
+! CHECK-DAG: ![[ARR_TY1]] = !DICompositeType(tag: DW_TAG_array_type{{.*}}elements: ![[ELEMS2:[0-9]+]], dataLocation: !DIExpression(DW_OP_push_object_address, DW_OP_deref), associated: !DIExpression(DW_OP_push_object_address, DW_OP_deref, DW_OP_lit0, DW_OP_ne))
+! CHECK-DAG: ![[ELEMS2]] = !{!{{[0-9]+}}, !{{[0-9]+}}}
+! CHECK-DAG: !DILocalVariable(name: "par2"{{.*}}type: ![[ARR_TY2:[0-9]+]])
+! CHECK-DAG: ![[ARR_TY2]] = !DICompositeType(tag: DW_TAG_array_type{{.*}}, elements: ![[ELEMS1]], dataLocation: !DIExpression(DW_OP_push_object_address, DW_OP_deref), associated: !DIExpression(DW_OP_push_object_address, DW_OP_deref, DW_OP_lit0, DW_OP_ne))
+! CHECK-DAG: !DILocalVariable(name: "psc"{{.*}}type: ![[PTR_TY:[0-9]+]])
+! CHECK-DAG: ![[PTR_TY]] = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: ![[INT_TY]]{{.*}})
+! CHECK-DAG: !DILocalVariable(name: "pstr"{{.*}}type: ![[PTR_TY:[0-9]+]])
+! CHECK-DAG: ![[PTR_TY]] = !DIStringType(stringLengthExpression: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 8), stringLocationExpression: !DIExpression(DW_OP_push_object_address, DW_OP_deref), encoding: DW_ATE_ASCII)

--- a/flang/test/Integration/debug-ptr-type.f90
+++ b/flang/test/Integration/debug-ptr-type.f90
@@ -46,5 +46,3 @@ end subroutine ff
 ! CHECK-DAG: ![[ARR_TY2]] = !DICompositeType(tag: DW_TAG_array_type{{.*}}, elements: ![[ELEMS1]], dataLocation: !DIExpression(DW_OP_push_object_address, DW_OP_deref), associated: !DIExpression(DW_OP_push_object_address, DW_OP_deref, DW_OP_lit0, DW_OP_ne))
 ! CHECK-DAG: !DILocalVariable(name: "psc"{{.*}}type: ![[PTR_TY:[0-9]+]])
 ! CHECK-DAG: ![[PTR_TY]] = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: ![[INT_TY]]{{.*}})
-! CHECK-DAG: !DILocalVariable(name: "pstr"{{.*}}type: ![[PTR_TY:[0-9]+]])
-! CHECK-DAG: ![[PTR_TY]] = !DIStringType(stringLengthExpression: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 8), stringLocationExpression: !DIExpression(DW_OP_push_object_address, DW_OP_deref), encoding: DW_ATE_ASCII)

--- a/flang/test/Transforms/debug-ptr-type.fir
+++ b/flang/test/Transforms/debug-ptr-type.fir
@@ -35,8 +35,6 @@ module attributes {dlti.dl_spec = #dlti.dl_spec<>} {
 // CHECK-DAG: #[[ARR1_TY:.*]] = #llvm.di_composite_type<tag = DW_TAG_array_type{{.*}}elements = #llvm.di_subrange<lowerBound = #llvm.di_expression{{.*}}, upperBound = #llvm.di_expression{{.*}}>, #llvm.di_subrange<lowerBound = #llvm.di_expression{{.*}}, upperBound = #llvm.di_expression{{.*}}>, dataLocation = {{.*}}, associated = <[DW_OP_push_object_address, DW_OP_deref, DW_OP_lit0, DW_OP_ne]>>
 // CHECK-DAG: #[[ARR2_TY:.*]] = #llvm.di_composite_type<tag = DW_TAG_array_type{{.*}}elements = #llvm.di_subrange<lowerBound = #llvm.di_expression{{.*}}, upperBound = #llvm.di_expression{{.*}}>, dataLocation = {{.*}}, associated = <[DW_OP_push_object_address, DW_OP_deref, DW_OP_lit0, DW_OP_ne]>>
 // CHECK-DAG: #[[PTR_TY:.*]] = #llvm.di_derived_type<tag = DW_TAG_pointer_type{{.*}}baseType = #[[INT_TY]]{{.*}}>
-// CHECK-DAG: #[[STR_TY:.*]] = #llvm.di_string_type<tag = DW_TAG_string_type{{.*}}stringLengthExp = <[DW_OP_push_object_address, DW_OP_plus_uconst(8)]>, stringLocationExp = <[DW_OP_push_object_address, DW_OP_deref]>, encoding = DW_ATE_ASCII>
 // CHECK-DAG: #llvm.di_global_variable<{{.*}}name = "par"{{.*}}type = #[[ARR1_TY]]{{.*}}>
 // CHECK-DAG: #llvm.di_global_variable<{{.*}}name = "par2"{{.*}}type = #[[ARR2_TY]]{{.*}}>
 // CHECK-DAG: #llvm.di_global_variable<{{.*}}name = "psc"{{.*}}type = #[[PTR_TY]]{{.*}}>
-// CHECK-DAG: #llvm.di_global_variable<{{.*}}name = "pstr"{{.*}}type = #[[STR_TY]]{{.*}}>

--- a/flang/test/Transforms/debug-ptr-type.fir
+++ b/flang/test/Transforms/debug-ptr-type.fir
@@ -1,0 +1,42 @@
+// RUN: fir-opt --add-debug-info --mlir-print-debuginfo %s | FileCheck %s
+
+module attributes {dlti.dl_spec = #dlti.dl_spec<>} {
+  fir.global @_QMhelperEpar : !fir.box<!fir.ptr<!fir.array<?x?xf32>>> {
+    %0 = fir.zero_bits !fir.ptr<!fir.array<?x?xf32>>
+    %c0 = arith.constant 0 : index
+    %1 = fir.shape %c0, %c0 : (index, index) -> !fir.shape<2>
+    %2 = fir.embox %0(%1) : (!fir.ptr<!fir.array<?x?xf32>>, !fir.shape<2>) -> !fir.box<!fir.ptr<!fir.array<?x?xf32>>>
+    fir.has_value %2 : !fir.box<!fir.ptr<!fir.array<?x?xf32>>>
+  } loc(#loc1)
+  fir.global @_QMhelperEpar2 : !fir.box<!fir.ptr<!fir.array<?xi32>>> {
+    %0 = fir.zero_bits !fir.ptr<!fir.array<?xi32>>
+    %c0 = arith.constant 0 : index
+    %1 = fir.shape %c0 : (index) -> !fir.shape<1>
+    %2 = fir.embox %0(%1) : (!fir.ptr<!fir.array<?xi32>>, !fir.shape<1>) -> !fir.box<!fir.ptr<!fir.array<?xi32>>>
+    fir.has_value %2 : !fir.box<!fir.ptr<!fir.array<?xi32>>>
+  } loc(#loc2)
+  fir.global @_QMhelperEpsc : !fir.box<!fir.ptr<i32>> {
+    %0 = fir.zero_bits !fir.ptr<i32>
+    %1 = fir.embox %0 : (!fir.ptr<i32>) -> !fir.box<!fir.ptr<i32>>
+    fir.has_value %1 : !fir.box<!fir.ptr<i32>>
+  } loc(#loc3)
+  fir.global @_QMmEpstr : !fir.box<!fir.ptr<!fir.char<1,16>>> {
+    %0 = fir.zero_bits !fir.ptr<!fir.char<1,16>>
+    %1 = fir.embox %0 : (!fir.ptr<!fir.char<1,16>>) -> !fir.box<!fir.ptr<!fir.char<1,16>>>
+    fir.has_value %1 : !fir.box<!fir.ptr<!fir.char<1,16>>>
+  } loc(#loc4)
+}
+#loc1 = loc("test.f90":5:1)
+#loc2 = loc("test.f90":6:1)
+#loc3 = loc("test.f90":7:1)
+#loc4 = loc("test.f90":8:1)
+
+// CHECK-DAG: #[[INT_TY:.*]] = #llvm.di_basic_type<tag = DW_TAG_base_type, name = "integer"{{.*}}>
+// CHECK-DAG: #[[ARR1_TY:.*]] = #llvm.di_composite_type<tag = DW_TAG_array_type{{.*}}elements = #llvm.di_subrange<lowerBound = #llvm.di_expression{{.*}}, upperBound = #llvm.di_expression{{.*}}>, #llvm.di_subrange<lowerBound = #llvm.di_expression{{.*}}, upperBound = #llvm.di_expression{{.*}}>, dataLocation = {{.*}}, associated = <[DW_OP_push_object_address, DW_OP_deref, DW_OP_lit0, DW_OP_ne]>>
+// CHECK-DAG: #[[ARR2_TY:.*]] = #llvm.di_composite_type<tag = DW_TAG_array_type{{.*}}elements = #llvm.di_subrange<lowerBound = #llvm.di_expression{{.*}}, upperBound = #llvm.di_expression{{.*}}>, dataLocation = {{.*}}, associated = <[DW_OP_push_object_address, DW_OP_deref, DW_OP_lit0, DW_OP_ne]>>
+// CHECK-DAG: #[[PTR_TY:.*]] = #llvm.di_derived_type<tag = DW_TAG_pointer_type{{.*}}baseType = #[[INT_TY]]{{.*}}>
+// CHECK-DAG: #[[STR_TY:.*]] = #llvm.di_string_type<tag = DW_TAG_string_type{{.*}}stringLengthExp = <[DW_OP_push_object_address, DW_OP_plus_uconst(8)]>, stringLocationExp = <[DW_OP_push_object_address, DW_OP_deref]>, encoding = DW_ATE_ASCII>
+// CHECK-DAG: #llvm.di_global_variable<{{.*}}name = "par"{{.*}}type = #[[ARR1_TY]]{{.*}}>
+// CHECK-DAG: #llvm.di_global_variable<{{.*}}name = "par2"{{.*}}type = #[[ARR2_TY]]{{.*}}>
+// CHECK-DAG: #llvm.di_global_variable<{{.*}}name = "psc"{{.*}}type = #[[PTR_TY]]{{.*}}>
+// CHECK-DAG: #llvm.di_global_variable<{{.*}}name = "pstr"{{.*}}type = #[[STR_TY]]{{.*}}>


### PR DESCRIPTION
The handling of `PointerType` is similar to `HeapType`. The only difference is that allocated flag is generated for `HeapType` and associated flag for `PointerType`. The tests for pointer to allocatable strings are disabled for now. I will enable them once #95906 is merged.

The debugging in GDB looks like this:
    
      integer, pointer :: par2(:)
      integer, target, allocatable :: ar2(:) 
      integer, target :: sc
      integer, pointer :: psc
      allocate(ar2(4))
      par2 => ar2
      psc => sc
    
    19        par2 => ar2
    (gdb) p par2
    $3 = <not associated>
    (gdb) n
    20        do i=1,5
    (gdb) p par2
    $4 = (0, 0, 0, 0)
    (gdb) ptype par2
    type = integer (4)
    (gdb) p sc
    $5 = 3
    (gdb) p psc
    $6 = (PTR TO -> ( integer )) 0x7fffffffda24
    (gdb) p *psc
    $7 = 3