### PR TITLE
Fix Android build failure in InferIntRangeCommon

### DIFF
--- a/mlir/lib/Interfaces/Utils/InferIntRangeCommon.cpp
+++ b/mlir/lib/Interfaces/Utils/InferIntRangeCommon.cpp
@@ -35,6 +35,8 @@ using namespace mlir;
 /// constants and returns std::nullopt on overflow.
 using ConstArithFn =
     function_ref<std::optional<APInt>(const APInt &, const APInt &)>;
+using ConstArithStdFn =
+    std::function<std::optional<APInt>(const APInt &, const APInt &)>;
 
 /// Compute op(minLeft, minRight) and op(maxLeft, maxRight) if possible,
 /// If either computation overflows, make the result unbounded.
@@ -182,16 +184,16 @@ mlir::intrange::inferAdd(ArrayRef<ConstantIntRanges> argRanges,
                          OverflowFlags ovfFlags) {
   const ConstantIntRanges &lhs = argRanges[0], &rhs = argRanges[1];
 
-  std::function uadd = [=](const APInt &a,
-                           const APInt &b) -> std::optional<APInt> {
+  ConstArithStdFn uadd = [=](const APInt &a,
+                             const APInt &b) -> std::optional<APInt> {
     bool overflowed = false;
     APInt result = any(ovfFlags & OverflowFlags::Nuw)
                        ? a.uadd_sat(b)
                        : a.uadd_ov(b, overflowed);
     return overflowed ? std::optional<APInt>() : result;
   };
-  std::function sadd = [=](const APInt &a,
-                           const APInt &b) -> std::optional<APInt> {
+  ConstArithStdFn sadd = [=](const APInt &a,
+                             const APInt &b) -> std::optional<APInt> {
     bool overflowed = false;
     APInt result = any(ovfFlags & OverflowFlags::Nsw)
                        ? a.sadd_sat(b)
@@ -215,16 +217,16 @@ mlir::intrange::inferSub(ArrayRef<ConstantIntRanges> argRanges,
                          OverflowFlags ovfFlags) {
   const ConstantIntRanges &lhs = argRanges[0], &rhs = argRanges[1];
 
-  std::function usub = [=](const APInt &a,
-                           const APInt &b) -> std::optional<APInt> {
+  ConstArithStdFn usub = [=](const APInt &a,
+                             const APInt &b) -> std::optional<APInt> {
     bool overflowed = false;
     APInt result = any(ovfFlags & OverflowFlags::Nuw)
                        ? a.usub_sat(b)
                        : a.usub_ov(b, overflowed);
     return overflowed ? std::optional<APInt>() : result;
   };
-  std::function ssub = [=](const APInt &a,
-                           const APInt &b) -> std::optional<APInt> {
+  ConstArithStdFn ssub = [=](const APInt &a,
+                             const APInt &b) -> std::optional<APInt> {
     bool overflowed = false;
     APInt result = any(ovfFlags & OverflowFlags::Nsw)
                        ? a.ssub_sat(b)
@@ -247,16 +249,16 @@ mlir::intrange::inferMul(ArrayRef<ConstantIntRanges> argRanges,
                          OverflowFlags ovfFlags) {
   const ConstantIntRanges &lhs = argRanges[0], &rhs = argRanges[1];
 
-  std::function umul = [=](const APInt &a,
-                           const APInt &b) -> std::optional<APInt> {
+  ConstArithStdFn umul = [=](const APInt &a,
+                             const APInt &b) -> std::optional<APInt> {
     bool overflowed = false;
     APInt result = any(ovfFlags & OverflowFlags::Nuw)
                        ? a.umul_sat(b)
                        : a.umul_ov(b, overflowed);
     return overflowed ? std::optional<APInt>() : result;
   };
-  std::function smul = [=](const APInt &a,
-                           const APInt &b) -> std::optional<APInt> {
+  ConstArithStdFn smul = [=](const APInt &a,
+                             const APInt &b) -> std::optional<APInt> {
     bool overflowed = false;
     APInt result = any(ovfFlags & OverflowFlags::Nsw)
                        ? a.smul_sat(b)
@@ -565,16 +567,16 @@ mlir::intrange::inferShl(ArrayRef<ConstantIntRanges> argRanges,
 
   // The signed/unsigned overflow behavior of shl by `rhs` matches a mul with
   // 2^rhs.
-  std::function ushl = [=](const APInt &l,
-                           const APInt &r) -> std::optional<APInt> {
+  ConstArithStdFn ushl = [=](const APInt &l,
+                             const APInt &r) -> std::optional<APInt> {
     bool overflowed = false;
     APInt result = any(ovfFlags & OverflowFlags::Nuw)
                        ? l.ushl_sat(r)
                        : l.ushl_ov(r, overflowed);
     return overflowed ? std::optional<APInt>() : result;
   };
-  std::function sshl = [=](const APInt &l,
-                           const APInt &r) -> std::optional<APInt> {
+  ConstArithStdFn sshl = [=](const APInt &l,
+                             const APInt &r) -> std::optional<APInt> {
     bool overflowed = false;
     APInt result = any(ovfFlags & OverflowFlags::Nsw)
                        ? l.sshl_sat(r)


### PR DESCRIPTION
As of today, Android's libcxx is missing C++17's std::function's CTAD
added in e1eabcdfad89f67ae575b0c86aa4a72d277378b4. This leads to
InferIntRangeCommon.cpp to fail to compile. This commit makes the
template parameter of std::function in that function explicit, therefore
avoiding CTAD. While LLVM/MLIR's requirement is C++17, the rest of the
code builds fine so hopefully this is acceptable.
