### PR TITLE
[clang] Add test for CWG2811 "Clarify "use" of main"

### DIFF
--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -964,7 +964,7 @@ def err_main_global_variable :
 def warn_main_redefined : Warning<"variable named 'main' with external linkage "
     "has undefined behavior">, InGroup<Main>;
 def ext_main_used : Extension<
-  "expressions that refer to 'main' are a Clang extension">, InGroup<Main>;
+    "referring to 'main' within an expression is a Clang extension">, InGroup<Main>;
 
 /// parser diagnostics
 def ext_no_declarators : ExtWarn<"declaration does not declare anything">,

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -964,7 +964,7 @@ def err_main_global_variable :
 def warn_main_redefined : Warning<"variable named 'main' with external linkage "
     "has undefined behavior">, InGroup<Main>;
 def ext_main_used : Extension<
-  "expressions that refer to 'main' are an extension">, InGroup<Main>;
+  "expressions that refer to 'main' are a Clang extension">, InGroup<Main>;
 
 /// parser diagnostics
 def ext_no_declarators : ExtWarn<"declaration does not declare anything">,

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -964,7 +964,7 @@ def err_main_global_variable :
 def warn_main_redefined : Warning<"variable named 'main' with external linkage "
     "has undefined behavior">, InGroup<Main>;
 def ext_main_used : Extension<
-  "ISO C++ does not allow 'main' to be used by a program">, InGroup<Main>;
+  "expressions that refer to 'main' are an extension">, InGroup<Main>;
 
 /// parser diagnostics
 def ext_no_declarators : ExtWarn<"declaration does not declare anything">,

--- a/clang/test/CXX/basic/basic.start/basic.start.init/p3.cpp
+++ b/clang/test/CXX/basic/basic.start/basic.start.init/p3.cpp
@@ -16,9 +16,9 @@ int main(int argc, char **argv)
   = delete; // expected-error {{'main' is not allowed to be deleted}}
 #else
 {
-  int (*pmain)(int, char**) = &main; // expected-error {{ISO C++ does not allow 'main' to be used by a program}}
+  int (*pmain)(int, char**) = &main; // expected-error {{expressions that refer to 'main' are an extension}}
 
   if (argc)
-    main(0, 0); // expected-error {{ISO C++ does not allow 'main' to be used by a program}}
+    main(0, 0); // expected-error {{expressions that refer to 'main' are an extension}}
 }
 #endif

--- a/clang/test/CXX/basic/basic.start/basic.start.init/p3.cpp
+++ b/clang/test/CXX/basic/basic.start/basic.start.init/p3.cpp
@@ -16,9 +16,9 @@ int main(int argc, char **argv)
   = delete; // expected-error {{'main' is not allowed to be deleted}}
 #else
 {
-  int (*pmain)(int, char**) = &main; // expected-error {{expressions that refer to 'main' are an extension}}
+  int (*pmain)(int, char**) = &main; // expected-error {{expressions that refer to 'main' are a Clang extension}}
 
   if (argc)
-    main(0, 0); // expected-error {{expressions that refer to 'main' are an extension}}
+    main(0, 0); // expected-error {{expressions that refer to 'main' are a Clang extension}}
 }
 #endif

--- a/clang/test/CXX/basic/basic.start/basic.start.init/p3.cpp
+++ b/clang/test/CXX/basic/basic.start/basic.start.init/p3.cpp
@@ -16,9 +16,9 @@ int main(int argc, char **argv)
   = delete; // expected-error {{'main' is not allowed to be deleted}}
 #else
 {
-  int (*pmain)(int, char**) = &main; // expected-error {{expressions that refer to 'main' are a Clang extension}}
+  int (*pmain)(int, char**) = &main; // expected-error {{referring to 'main' within an expression is a Clang extension}}
 
   if (argc)
-    main(0, 0); // expected-error {{expressions that refer to 'main' are a Clang extension}}
+    main(0, 0); // expected-error {{referring to 'main' within an expression is a Clang extension}}
 }
 #endif

--- a/clang/test/CXX/drs/cwg28xx.cpp
+++ b/clang/test/CXX/drs/cwg28xx.cpp
@@ -14,14 +14,14 @@ namespace cwg2811 { // cwg2811: 3.5
 void f() {
   (void)[&] {
     using T = decltype(main);
-    // expected-error@-1 {{expressions that refer to 'main' are a Clang extension}}
+    // expected-error@-1 {{referring to 'main' within an expression is a Clang extension}}
   };
   using T2 = decltype(main);
-  // expected-error@-1 {{expressions that refer to 'main' are a Clang extension}}
+  // expected-error@-1 {{referring to 'main' within an expression is a Clang extension}}
 }
 
 using T = decltype(main);
-// expected-error@-1 {{expressions that refer to 'main' are a Clang extension}}
+// expected-error@-1 {{referring to 'main' within an expression is a Clang extension}}
 
 int main();
 

--- a/clang/test/CXX/drs/cwg28xx.cpp
+++ b/clang/test/CXX/drs/cwg28xx.cpp
@@ -22,6 +22,11 @@ void f() {
 
 using T = decltype(main);
 // expected-error@-1 {{expressions that refer to 'main' are an extension}}
+
+int main();
+
+using U = decltype(main);
+using U2 = decltype(&main);
 #endif
 } // namespace cwg2811
 

--- a/clang/test/CXX/drs/cwg28xx.cpp
+++ b/clang/test/CXX/drs/cwg28xx.cpp
@@ -14,14 +14,14 @@ namespace cwg2811 { // cwg2811: 3.5
 void f() {
   (void)[&] {
     using T = decltype(main);
-    // expected-error@-1 {{expressions that refer to 'main' are an extension}}
+    // expected-error@-1 {{expressions that refer to 'main' are a Clang extension}}
   };
   using T2 = decltype(main);
-  // expected-error@-1 {{expressions that refer to 'main' are an extension}}
+  // expected-error@-1 {{expressions that refer to 'main' are a Clang extension}}
 }
 
 using T = decltype(main);
-// expected-error@-1 {{expressions that refer to 'main' are an extension}}
+// expected-error@-1 {{expressions that refer to 'main' are a Clang extension}}
 
 int main();
 

--- a/clang/test/CXX/drs/cwg28xx.cpp
+++ b/clang/test/CXX/drs/cwg28xx.cpp
@@ -6,6 +6,25 @@
 // RUN: %clang_cc1 -std=c++23 -pedantic-errors -verify=expected,since-cxx20,since-cxx23 %s
 // RUN: %clang_cc1 -std=c++2c -pedantic-errors -verify=expected,since-cxx20,since-cxx23,since-cxx26 %s
 
+
+int main() {} // required for cwg2811
+
+namespace cwg2811 { // cwg2811: 3.5
+#if __cplusplus >= 201103L
+void f() {
+  (void)[&] {
+    using T = decltype(main);
+    // expected-error@-1 {{expressions that refer to 'main' are an extension}}
+  };
+  using T2 = decltype(main);
+  // expected-error@-1 {{expressions that refer to 'main' are an extension}}
+}
+
+using T = decltype(main);
+// expected-error@-1 {{expressions that refer to 'main' are an extension}}
+#endif
+} // namespace cwg2811
+
 namespace cwg2819 { // cwg2819: 19 tentatively ready 2023-12-01
 #if __cpp_constexpr >= 202306L
   constexpr void* p = nullptr;

--- a/clang/www/cxx_dr_status.html
+++ b/clang/www/cxx_dr_status.html
@@ -16675,7 +16675,7 @@ objects</td>
     <td><a href="https://cplusplus.github.io/CWG/issues/2811.html">2811</a></td>
     <td>DR</td>
     <td>Clarify "use" of main</td>
-    <td class="unknown" align="center">Unknown</td>
+    <td class="full" align="center">Clang 3.5</td>
   </tr>
   <tr class="open" id="2812">
     <td><a href="https://cplusplus.github.io/CWG/issues/2812.html">2812</a></td>


### PR DESCRIPTION
This patch covers [CWG2811](https://cplusplus.github.io/CWG/issues/2811.html) "Clarify "use" of main", basically adding a test for `-Wmain`, focusing on usages of `main` in unevaluated contexts.

To my understanding, the diagnostic message is based on the wording, so I updated it based on the new wording. I also replaces "ISO C++ requires" with a phrasing that explicitly says "extension".
