### PR TITLE
[ADT] DenseMapInfo<unsigned long>::getHashValue - avoid MSVC out of bounds shift warning

### DIFF
--- a/llvm/include/llvm/ADT/DenseMapInfo.h
+++ b/llvm/include/llvm/ADT/DenseMapInfo.h
@@ -142,7 +142,7 @@ template<> struct DenseMapInfo<unsigned long> {
     if constexpr (sizeof(Val) == 4)
       return DenseMapInfo<unsigned>::getHashValue(Val);
     else
-      return detail::combineHashValue(Val >> (4 * sizeof(Val)), Val);
+      return densemap::detail::mix(Val);
   }
 
   static bool isEqual(const unsigned long& LHS, const unsigned long& RHS) {

--- a/llvm/include/llvm/ADT/DenseMapInfo.h
+++ b/llvm/include/llvm/ADT/DenseMapInfo.h
@@ -156,7 +156,7 @@ template<> struct DenseMapInfo<unsigned long long> {
   static inline unsigned long long getTombstoneKey() { return ~0ULL - 1ULL; }
 
   static unsigned getHashValue(const unsigned long long& Val) {
-    return detail::combineHashValue(Val >> 32, Val);
+    return densemap::detail::mix(Val);
   }
 
   static bool isEqual(const unsigned long long& LHS,

--- a/llvm/include/llvm/ADT/DenseMapInfo.h
+++ b/llvm/include/llvm/ADT/DenseMapInfo.h
@@ -142,7 +142,7 @@ template<> struct DenseMapInfo<unsigned long> {
     if constexpr (sizeof(Val) == 4)
       return DenseMapInfo<unsigned>::getHashValue(Val);
     else
-      return detail::combineHashValue(Val >> 32, Val);
+      return detail::combineHashValue(Val >> (4 * sizeof(Val)), Val);
   }
 
   static bool isEqual(const unsigned long& LHS, const unsigned long& RHS) {


### PR DESCRIPTION
Fixes MSVC warning after #95734 - despite it taking the `sizeof(Val) == 4` path, it still warns that the 32-bit unsigned long shift by 32 is out of bounds.