### PR TITLE
[SCEV] Avoid unnecessary call to getExitingBlock() in computeExitLimit()

### DIFF
--- a/llvm/include/llvm/Analysis/ScalarEvolution.h
+++ b/llvm/include/llvm/Analysis/ScalarEvolution.h
@@ -1766,6 +1766,7 @@ private:
   /// this call will try to use a minimal set of SCEV predicates in order to
   /// return an exact answer.
   ExitLimit computeExitLimit(const Loop *L, BasicBlock *ExitingBlock,
+                             bool ControlsOnlyExit,
                              bool AllowPredicates = false);
 
   // Helper functions for computeExitLimitFromCond to avoid exponential time

--- a/llvm/include/llvm/Analysis/ScalarEvolution.h
+++ b/llvm/include/llvm/Analysis/ScalarEvolution.h
@@ -1766,8 +1766,7 @@ private:
   /// this call will try to use a minimal set of SCEV predicates in order to
   /// return an exact answer.
   ExitLimit computeExitLimit(const Loop *L, BasicBlock *ExitingBlock,
-                             bool ControlsOnlyExit,
-                             bool AllowPredicates = false);
+                             bool IsOnlyExit, bool AllowPredicates = false);
 
   // Helper functions for computeExitLimitFromCond to avoid exponential time
   // complexity.

--- a/llvm/lib/Analysis/ScalarEvolution.cpp
+++ b/llvm/lib/Analysis/ScalarEvolution.cpp
@@ -8868,7 +8868,7 @@ ScalarEvolution::computeBackedgeTakenCount(const Loop *L,
 
 ScalarEvolution::ExitLimit
 ScalarEvolution::computeExitLimit(const Loop *L, BasicBlock *ExitingBlock,
-                                  bool ControlsOnlyExit, bool AllowPredicates) {
+                                  bool IsOnlyExit, bool AllowPredicates) {
   assert(L->contains(ExitingBlock) && "Exit count for non-loop block?");
   // If our exiting block does not dominate the latch, then its connection with
   // loop's exit limit may be far from trivial.
@@ -8884,7 +8884,8 @@ ScalarEvolution::computeExitLimit(const Loop *L, BasicBlock *ExitingBlock,
            "It should have one successor in loop and one exit block!");
     // Proceed to the next level to examine the exit condition expression.
     return computeExitLimitFromCond(L, BI->getCondition(), ExitIfTrue,
-                                    ControlsOnlyExit, AllowPredicates);
+                                    /*ControlsOnlyExit=*/IsOnlyExit,
+                                    AllowPredicates);
   }
 
   if (SwitchInst *SI = dyn_cast<SwitchInst>(Term)) {
@@ -8897,7 +8898,8 @@ ScalarEvolution::computeExitLimit(const Loop *L, BasicBlock *ExitingBlock,
         Exit = SBB;
       }
     assert(Exit && "Exiting block must have at least one exit");
-    return computeExitLimitFromSingleExitSwitch(L, SI, Exit, ControlsOnlyExit);
+    return computeExitLimitFromSingleExitSwitch(
+        L, SI, Exit, /*ControlsOnlyExit=*/IsOnlyExit);
   }
 
   return getCouldNotCompute();


### PR DESCRIPTION
In `computeExitLimit()`, we use `getExitingBlock()` to check if loop has exactly one exiting block.
Since `computeExitLimit()` is only used in `computeBackedgeTakenCount()`, and `getExitingBlocks()` is called to get all exiting blocks in `computeBackedgeTakenCount()`, we can simply check if loop has exactly one exiting block by checking if the number of exiting blocks equals 1 in `computeBackedgeTakenCount()` and pass it as an argument to `computeExitLimit()`.

This change helps to improve the compile time for files containing large loops.