### PR TITLE
[lldb] Fix printing of unsigned enum bitfields when they contain the max value

### DIFF
--- a/lldb/test/API/commands/expression/bitfield_enums/Makefile
+++ b/lldb/test/API/commands/expression/bitfield_enums/Makefile
@@ -1,0 +1,3 @@
+CXX_SOURCES := main.cpp
+
+include Makefile.rules

--- a/lldb/test/API/commands/expression/bitfield_enums/TestBitfieldEnums.py
+++ b/lldb/test/API/commands/expression/bitfield_enums/TestBitfieldEnums.py
@@ -1,0 +1,31 @@
+"""
+Test that the expression parser accounts for the underlying type of bitfield
+enums when looking for matching values.
+"""
+
+import lldb
+from lldbsuite.test.decorators import *
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test import lldbutil
+
+
+class TestBitfieldEnum(TestBase):
+    def test_bitfield_enums(self):
+        self.build()
+
+        lldbutil.run_to_source_breakpoint(
+            self, "// break here", lldb.SBFileSpec("main.cpp", False)
+        )
+
+        self.expect_expr(
+            "bfs",
+            result_type="BitfieldStruct",
+            result_children=[
+                ValueCheck(name="signed_min", value="min"),
+                ValueCheck(name="signed_other", value="-1"),
+                ValueCheck(name="signed_max", value="max"),
+                ValueCheck(name="unsigned_min", value="min"),
+                ValueCheck(name="unsigned_other", value="1"),
+                ValueCheck(name="unsigned_max", value="max"),
+            ],
+        )

--- a/lldb/test/API/commands/expression/bitfield_enums/main.cpp
+++ b/lldb/test/API/commands/expression/bitfield_enums/main.cpp
@@ -1,0 +1,24 @@
+enum class SignedEnum : int { min = -2, max = 1 };
+enum class UnsignedEnum : unsigned { min = 0, max = 3 };
+
+struct BitfieldStruct {
+  SignedEnum signed_min : 2;
+  SignedEnum signed_other : 2;
+  SignedEnum signed_max : 2;
+  UnsignedEnum unsigned_min : 2;
+  UnsignedEnum unsigned_other : 2;
+  UnsignedEnum unsigned_max : 2;
+};
+
+int main() {
+  BitfieldStruct bfs;
+  bfs.signed_min = SignedEnum::min;
+  bfs.signed_other = static_cast<SignedEnum>(-1);
+  bfs.signed_max = SignedEnum::max;
+
+  bfs.unsigned_min = UnsignedEnum::min;
+  bfs.unsigned_other = static_cast<UnsignedEnum>(1);
+  bfs.unsigned_max = UnsignedEnum::max;
+
+  return 0; // break here
+}


### PR DESCRIPTION
While testing register fields I found that if you put the max value into a bitfield with an underlying type that is an unsigned enum, lldb would not print the enum name.

This is because the code to match values to names wasn't checking whether the enum's type was signed, it just assumed it was.

So for example a 2 bit field with value 3 got signed extended to -1, which didn't match the enumerator value of 3. So lldb just printed the number instead of the name.

For a value of 1, the top bit was 0 so the sign extend became a zero extend, and lldb did print the name of the enumerator.

I added a new test because I needed to use C++ to get typed enums. It checks min, max and an in between value for signed and unsigned enums applied to a bitfield.