### PR TITLE
[libc][stdlib] Remove LIBC_THREAD_LOCAL from rand_next

### DIFF
--- a/libc/src/stdlib/rand_util.cpp
+++ b/libc/src/stdlib/rand_util.cpp
@@ -14,11 +14,11 @@ namespace LIBC_NAMESPACE {
 #ifdef LIBC_TARGET_ARCH_IS_GPU
 // FIXME: Local GPU memory cannot be initialized so we cannot currently provide
 // a standard compliant default value.
-ThreadLocal<unsigned long> rand_next;
+unsigned long rand_next;
 #else
 // C standard 7.10p2: If 'rand' is called before 'srand' it is to proceed as if
 // the 'srand' function was called with a value of '1'.
-LIBC_THREAD_LOCAL unsigned long rand_next = 1;
+unsigned long rand_next = 1;
 #endif
 
 } // namespace LIBC_NAMESPACE

--- a/libc/src/stdlib/rand_util.h
+++ b/libc/src/stdlib/rand_util.h
@@ -14,28 +14,7 @@
 
 namespace LIBC_NAMESPACE {
 
-#ifdef LIBC_TARGET_ARCH_IS_GPU
-// Implement thread local storage on the GPU using local memory. Each thread
-// gets its slot in the local memory array and is private to the group.
-// TODO: We need to implement the 'thread_local' keyword on the GPU. This is an
-// inefficient and incomplete stand-in until that is done.
-template <typename T> class ThreadLocal {
-private:
-  static constexpr long MAX_THREADS = 1024;
-  [[clang::loader_uninitialized]] static inline gpu::Local<T>
-      storage[MAX_THREADS];
-
-public:
-  LIBC_INLINE operator T() const { return storage[gpu::get_thread_id()]; }
-  LIBC_INLINE void operator=(const T &value) {
-    storage[gpu::get_thread_id()] = value;
-  }
-};
-
-extern ThreadLocal<unsigned long> rand_next;
-#else
-extern LIBC_THREAD_LOCAL unsigned long rand_next;
-#endif
+extern unsigned long rand_next;
 
 } // namespace LIBC_NAMESPACE
 


### PR DESCRIPTION
srand and rand do not need to be threadsafe, so it should be permissible to remove thise from rand_next whose only users are srand and rand. This is helpful for the baremetal runtimes where we still need to setup the TLS machinery.