### PR TITLE
[libc] Control freelist malloc buffer size with a config

### DIFF
--- a/libc/config/baremetal/config.json
+++ b/libc/config/baremetal/config.json
@@ -12,5 +12,10 @@
     "LIBC_CONF_PRINTF_FLOAT_TO_STR_USE_MEGA_LONG_DOUBLE_TABLE": {
       "value": false
     }
+  },
+  "malloc": {
+    "LIBC_CONF_FREELIST_MALLOC_BUFFER_SIZE": {
+      "value": 102400
+    }
   }
 }

--- a/libc/config/config.json
+++ b/libc/config/config.json
@@ -54,5 +54,11 @@
       "value": 100,
       "doc": "Default number of spins before blocking if a rwlock is in contention (default to 100)."
     }
+  },
+  "malloc": {
+    "LIBC_CONF_FREELIST_MALLOC_BUFFER_SIZE": {
+      "value": 1073741824,
+      "doc": "Default size for the constinit freelist buffer used for the freelist malloc implementation (default 1o 1GB)."
+    }
   }
 }

--- a/libc/docs/configure.rst
+++ b/libc/docs/configure.rst
@@ -28,6 +28,8 @@ to learn about the defaults for your platform and target.
 * **"codegen" options**
     - ``LIBC_CONF_ENABLE_STRONG_STACK_PROTECTOR``: Enable -fstack-protector-strong to defend against stack smashing attack.
     - ``LIBC_CONF_KEEP_FRAME_POINTER``: Keep frame pointer in functions for better debugging experience.
+* **"malloc" options**
+    - ``LIBC_CONF_FREELIST_MALLOC_BUFFER_SIZE``: Default size for the constinit freelist buffer used for the freelist malloc implementation (default 1o 1GB).
 * **"printf" options**
     - ``LIBC_CONF_PRINTF_DISABLE_FIXED_POINT``: Disable printing fixed point values in printf and friends.
     - ``LIBC_CONF_PRINTF_DISABLE_FLOAT``: Disable printing floating point values in printf and friends.

--- a/libc/src/stdlib/CMakeLists.txt
+++ b/libc/src/stdlib/CMakeLists.txt
@@ -390,6 +390,8 @@ else()
         malloc.h
       DEPENDS
         libc.src.__support.freelist_heap
+      COMPILE_OPTIONS
+        -DLIBC_FREELIST_MALLOC_SIZE=${LIBC_CONF_FREELIST_MALLOC_BUFFER_SIZE}
     )
   else()
     add_entrypoint_external(

--- a/libc/src/stdlib/freelist_malloc.cpp
+++ b/libc/src/stdlib/freelist_malloc.cpp
@@ -17,14 +17,11 @@
 namespace LIBC_NAMESPACE {
 
 namespace {
-// Users can define LIBC_FREELIST_MALLOC_SIZE for setting the default buffer
-// size used by freelist malloc.
 #ifdef LIBC_FREELIST_MALLOC_SIZE
+// This is set via the LIBC_CONF_FREELIST_MALLOC_BUFFER_SIZE configuration.
 constexpr size_t SIZE = LIBC_FREELIST_MALLOC_SIZE;
 #else
-// TODO: We should probably have something akin to what scudo/sanitizer
-// allocators do where each platform defines this.
-constexpr size_t SIZE = 0x40000000ULL; // 1GB
+#error "LIBC_FREELIST_MALLOC_SIZE was not defined for this build."
 #endif
 LIBC_CONSTINIT FreeListHeapBuffer<SIZE> freelist_heap_buffer;
 } // namespace


### PR DESCRIPTION
Rather than propgating a compile define, add an explicit cmake flag for controlling the size. The default for baremetal is 100KB and the default for others is 1GB.