### PR TITLE
[mlir][linalg] added some conditions for values being undefined in the documentation for `linalg.generic`

### DIFF
--- a/mlir/include/mlir/Dialect/Linalg/IR/LinalgStructuredOps.td
+++ b/mlir/include/mlir/Dialect/Linalg/IR/LinalgStructuredOps.td
@@ -82,6 +82,11 @@ def GenericOp : LinalgStructuredBase_Op<"generic", [
         types:
           parallel, reduction, window
 
+    Any values within the output operands that are not unindexed by the 
+    `indexing_maps` are undefined.
+    Any dimensions associated with a `reduction` `iterator_types` must not 
+    be used for indexing output operands, otherwise the results are undefined.
+
     Example:
     Defining a #matmul_trait attribute in MLIR can be done as follows:
       ```mlir

--- a/mlir/include/mlir/Dialect/Linalg/IR/LinalgStructuredOps.td
+++ b/mlir/include/mlir/Dialect/Linalg/IR/LinalgStructuredOps.td
@@ -82,8 +82,13 @@ def GenericOp : LinalgStructuredBase_Op<"generic", [
         types:
           parallel, reduction, window
 
-    Any values within the output operands that are not unindexed by the 
-    `indexing_maps` are undefined.
+    Any element within the output operands that are not indexed by the 
+    `indexing_maps` are undefined. 
+    For example, if the output operand is a `tensor<2x2xf32>`, and is accessed
+    by the affine map `affine_map<(i) -> (i, i)>` indexing the diagonal elements
+    `[0, 0]` and `[1, 1]`, then the other elements (at `[0, 1]` and `[1, 0]`) are
+    undefined. 
+    
     Any dimensions associated with a `reduction` `iterator_types` must not 
     be used for indexing output operands, otherwise the results are undefined.
 


### PR DESCRIPTION
I've been quite confused by the "gotchas" in `linalg.generic` a couple of weeks back, running into undefined/unspecified behaviours a couple of times, case and point:
https://github.com/llvm/llvm-project/issues/94179
https://github.com/llvm/llvm-project/issues/94180

and I was helped by @ftynse to understand these issues. I thought it would be a good idea to document, in the specification, when the behaviours might be unexpected since they can be unintuitive. 

This is not specifying what "should" happen, but just specifying when things are undefined, reflective of the behaviour implemented within existing passes that I ran into. 

I'm not sure if these situations mentioned should be as strong as full undefined behaviour, versus just local "undefined values". 
This PR treats them as "undefined values" for now, but would be good to discuss them!