### PR TITLE
[libc] Added const modifier to SigSetPtrType

### DIFF
--- a/libc/spec/linux.td
+++ b/libc/spec/linux.td
@@ -205,7 +205,7 @@ def Linux : StandardSpec<"Linux"> {
             ArgSpec<StructEpollEventPtr>,
             ArgSpec<IntType>,
             ArgSpec<IntType>,
-            ArgSpec<SigSetPtrType>
+            ArgSpec<ConstSigSetPtrType>
           ]
         >,
         FunctionSpec<
@@ -216,7 +216,7 @@ def Linux : StandardSpec<"Linux"> {
             ArgSpec<StructEpollEventPtr>,
             ArgSpec<IntType>,
             ArgSpec<ConstStructTimeSpecPtr>,
-            ArgSpec<SigSetPtrType>
+            ArgSpec<ConstSigSetPtrType>
           ]
         >,
       ]  // Functions


### PR DESCRIPTION
Function header files for epoll_pwait and epoll_pwait2 have const modifier on
SigSetPtrType in function signature, but the linux.td file does not
reflect that.

.td file located in libc/spec/linux.td
epoll functions located in libc/src/sys/epoll