### PR TITLE
Add AsmParser::parseDecimalInteger.

### DIFF
--- a/mlir/include/mlir/IR/OpImplementation.h
+++ b/mlir/include/mlir/IR/OpImplementation.h
@@ -714,16 +714,27 @@ public:
     return *parseResult;
   }
 
+  /// Parse a decimal integer value from the stream.
+  template <typename IntT>
+  ParseResult parseDecimalInteger(IntT &result) {
+    auto loc = getCurrentLocation();
+    OptionalParseResult parseResult = parseOptionalDecimalInteger(result);
+    if (!parseResult.has_value())
+      return emitError(loc, "expected decimal integer value");
+    return *parseResult;
+  }
+
   /// Parse an optional integer value from the stream.
   virtual OptionalParseResult parseOptionalInteger(APInt &result) = 0;
+  virtual OptionalParseResult parseOptionalDecimalInteger(APInt &result) = 0;
 
-  template <typename IntT>
-  OptionalParseResult parseOptionalInteger(IntT &result) {
+ private:
+  template <typename IntT, typename ParseFn>
+  OptionalParseResult parseOptionalIntegerAndCheck(IntT &result,
+                                                   ParseFn &&parseFn) {
     auto loc = getCurrentLocation();
-
-    // Parse the unsigned variant.
     APInt uintResult;
-    OptionalParseResult parseResult = parseOptionalInteger(uintResult);
+    OptionalParseResult parseResult = parseFn(uintResult);
     if (!parseResult.has_value() || failed(*parseResult))
       return parseResult;
 
@@ -735,6 +746,20 @@ public:
     if (APInt(uintResult.getBitWidth(), result) != uintResult)
       return emitError(loc, "integer value too large");
     return success();
+  }
+
+ public:
+  template <typename IntT>
+  OptionalParseResult parseOptionalInteger(IntT &result) {
+    return parseOptionalIntegerAndCheck(
+        result, [&](APInt &result) { return parseOptionalInteger(result); });
+  }
+
+  template <typename IntT>
+  OptionalParseResult parseOptionalDecimalInteger(IntT &result) {
+    return parseOptionalIntegerAndCheck(result, [&](APInt &result) {
+      return parseOptionalDecimalInteger(result);
+    });
   }
 
   /// These are the supported delimiters around operand lists and region

--- a/mlir/lib/AsmParser/AsmParserImpl.h
+++ b/mlir/lib/AsmParser/AsmParserImpl.h
@@ -322,6 +322,11 @@ public:
     return parser.parseOptionalInteger(result);
   }
 
+  /// Parse an optional integer value from the stream.
+  OptionalParseResult parseOptionalDecimalInteger(APInt &result) override {
+    return parser.parseOptionalDecimalInteger(result);
+  }
+
   /// Parse a list of comma-separated items with an optional delimiter.  If a
   /// delimiter is provided, then an empty list is allowed.  If not, then at
   /// least one element will be parsed.

--- a/mlir/lib/AsmParser/Parser.cpp
+++ b/mlir/lib/AsmParser/Parser.cpp
@@ -308,13 +308,6 @@ OptionalParseResult Parser::parseOptionalInteger(APInt &result) {
   return success();
 }
 
-namespace {
-bool isBinOrHexOrOctIndicator(char c) {
-  return (llvm::toLower(c) == 'x' || llvm::toLower(c) == 'b' ||
-          llvm::isDigit(c));
-}
-} // namespace
-
 /// Parse an optional integer value only in decimal format from the stream.
 OptionalParseResult Parser::parseOptionalDecimalInteger(APInt &result) {
   Token curToken = getToken();
@@ -329,10 +322,11 @@ OptionalParseResult Parser::parseOptionalDecimalInteger(APInt &result) {
   }
 
   StringRef spelling = curTok.getSpelling();
-  // If the integer is in bin, hex, or oct format, return only the 0 and reset
-  // the lex pointer.
+  // If the integer is in hexadecimal return only the 0. The lexer has already
+  // moved past the entire hexidecimal encoded integer so we reset the lex
+  // pointer to just past the 0 we actualy want to consume.
   if (spelling[0] == '0' && spelling.size() > 1 &&
-      isBinOrHexOrOctIndicator(spelling[1])) {
+      llvm::toLower(spelling[1]) == 'x') {
     result = 0;
     state.lex.resetPointer(spelling.data() + 1);
     consumeToken();

--- a/mlir/lib/AsmParser/Parser.h
+++ b/mlir/lib/AsmParser/Parser.h
@@ -144,6 +144,9 @@ public:
   /// Parse an optional integer value from the stream.
   OptionalParseResult parseOptionalInteger(APInt &result);
 
+  /// Parse an optional integer value only in decimal format from the stream.
+  OptionalParseResult parseOptionalDecimalInteger(APInt &result);
+
   /// Parse a floating point value from an integer literal token.
   ParseResult parseFloatFromIntegerLiteral(std::optional<APFloat> &result,
                                            const Token &tok, bool isNegative,

--- a/mlir/test/lib/Dialect/Test/TestAttrDefs.td
+++ b/mlir/test/lib/Dialect/Test/TestAttrDefs.td
@@ -81,11 +81,11 @@ def AttrWithTrait : Test_Attr<"AttrWithTrait", [TestAttrTrait]> {
   let mnemonic = "attr_with_trait";
 }
 
-// An attribute of decimal formatted integer.
-def TestDecimalIntegerAttr : Test_Attr<"TestDecimalInteger"> {
-  let mnemonic = "decimal_integer";
+// An attribute of a list of decimal formatted integers in similar format to shapes.
+def TestDecimalShapeAttr : Test_Attr<"TestDecimalShape"> {
+  let mnemonic = "decimal_shape";
 
-  let parameters = (ins "int64_t":$value);
+  let parameters = (ins ArrayRefParameter<"int64_t">:$shape);
 
   let hasCustomAssemblyFormat = 1;
 }

--- a/mlir/test/lib/Dialect/Test/TestAttrDefs.td
+++ b/mlir/test/lib/Dialect/Test/TestAttrDefs.td
@@ -81,6 +81,15 @@ def AttrWithTrait : Test_Attr<"AttrWithTrait", [TestAttrTrait]> {
   let mnemonic = "attr_with_trait";
 }
 
+// An attribute of decimal formatted integer.
+def TestDecimalIntegerAttr : Test_Attr<"TestDecimalInteger"> {
+  let mnemonic = "decimal_integer";
+
+  let parameters = (ins "int64_t":$value);
+
+  let hasCustomAssemblyFormat = 1;
+}
+
 // Test support for ElementsAttrInterface.
 def TestI64ElementsAttr : Test_Attr<"TestI64Elements", [ElementsAttrInterface]> {
   let mnemonic = "i64_elements";

--- a/mlir/test/lib/Dialect/Test/TestAttributes.cpp
+++ b/mlir/test/lib/Dialect/Test/TestAttributes.cpp
@@ -66,7 +66,6 @@ void CompoundAAttr::print(AsmPrinter &printer) const {
 // CompoundAAttr
 //===----------------------------------------------------------------------===//
 
-
 Attribute TestDecimalShapeAttr::parse(AsmParser &parser, Type type) {
   if (parser.parseLess()){
     return Attribute();

--- a/mlir/test/lib/Dialect/Test/TestAttributes.cpp
+++ b/mlir/test/lib/Dialect/Test/TestAttributes.cpp
@@ -14,6 +14,7 @@
 #include "TestAttributes.h"
 #include "TestDialect.h"
 #include "TestTypes.h"
+#include "mlir/IR/Attributes.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/DialectImplementation.h"
 #include "mlir/IR/ExtensibleDialect.h"
@@ -66,22 +67,37 @@ void CompoundAAttr::print(AsmPrinter &printer) const {
 //===----------------------------------------------------------------------===//
 
 
-Attribute TestDecimalIntegerAttr::parse(AsmParser &parser, Type type) {
+Attribute TestDecimalShapeAttr::parse(AsmParser &parser, Type type) {
   if (parser.parseLess()){
     return Attribute();
   }
-  uint64_t intVal;
-  if (failed(*parser.parseOptionalDecimalInteger(intVal))) {
-    return Attribute();
+  SmallVector<int64_t> shape;
+  if (parser.parseOptionalGreater()) {
+    auto parseDecimal = [&]() {
+      shape.emplace_back();
+      auto parseResult = parser.parseOptionalDecimalInteger(shape.back());
+      if (!parseResult.has_value() || failed(*parseResult)) {
+        parser.emitError(parser.getCurrentLocation()) << "expected an integer";
+        return failure();
+      }
+      return success();
+    };
+    if (failed(parseDecimal())) {
+      return Attribute();
+    }
+    while (failed(parser.parseOptionalGreater())) {
+      if (failed(parser.parseXInDimensionList()) || failed(parseDecimal())) {
+        return Attribute();
+      }
+    }
   }
-  if (parser.parseGreater()) {
-    return Attribute();
-  }
-  return get(parser.getContext(), intVal);
+  return get(parser.getContext(), shape);
 }
 
-void TestDecimalIntegerAttr::print(AsmPrinter &printer) const {
-  printer << "<" << getValue() << ">";
+void TestDecimalShapeAttr::print(AsmPrinter &printer) const {
+  printer << "<";
+  llvm::interleave(getShape(), printer, "x");
+  printer << ">";
 }
 
 Attribute TestI64ElementsAttr::parse(AsmParser &parser, Type type) {

--- a/mlir/test/lib/Dialect/Test/TestAttributes.cpp
+++ b/mlir/test/lib/Dialect/Test/TestAttributes.cpp
@@ -13,9 +13,11 @@
 
 #include "TestAttributes.h"
 #include "TestDialect.h"
+#include "TestTypes.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/DialectImplementation.h"
 #include "mlir/IR/ExtensibleDialect.h"
+#include "mlir/IR/OpImplementation.h"
 #include "mlir/IR/Types.h"
 #include "llvm/ADT/APFloat.h"
 #include "llvm/ADT/Hashing.h"
@@ -62,6 +64,25 @@ void CompoundAAttr::print(AsmPrinter &printer) const {
 //===----------------------------------------------------------------------===//
 // CompoundAAttr
 //===----------------------------------------------------------------------===//
+
+
+Attribute TestDecimalIntegerAttr::parse(AsmParser &parser, Type type) {
+  if (parser.parseLess()){
+    return Attribute();
+  }
+  uint64_t intVal;
+  if (failed(*parser.parseOptionalDecimalInteger(intVal))) {
+    return Attribute();
+  }
+  if (parser.parseGreater()) {
+    return Attribute();
+  }
+  return get(parser.getContext(), intVal);
+}
+
+void TestDecimalIntegerAttr::print(AsmPrinter &printer) const {
+  printer << "<" << getValue() << ">";
+}
 
 Attribute TestI64ElementsAttr::parse(AsmParser &parser, Type type) {
   SmallVector<uint64_t> elements;

--- a/mlir/test/mlir-tblgen/testdialect-attrdefs.mlir
+++ b/mlir/test/mlir-tblgen/testdialect-attrdefs.mlir
@@ -1,4 +1,4 @@
-// RUN: mlir-opt %s | mlir-opt -verify-diagnostics | FileCheck %s
+// RUN: mlir-opt %s -split-input-file -verify-diagnostics | FileCheck %s
 
 // CHECK-LABEL: func private @compoundA()
 // CHECK-SAME: #test.cmpnd_a<1, !test.smpla, [5, 6]>
@@ -18,4 +18,17 @@ func.func private @qualifiedAttr() attributes {foo = #test.cmpnd_nested_outer_qu
 // CHECK-SAME: foo = 5 : index
 func.func private @overriddenAttr() attributes {
   foo = #test.override_builder<5>
+}
+
+// CHECK-LABEL: @decimalInteger
+// CHECK-SAME: foo = #test.decimal_integer<5>
+func.func private @decimalInteger() attributes {
+  foo = #test.decimal_integer<5>
+}
+
+// -----
+
+func.func private @hexdecimalInteger() attributes {
+// expected-error @below {{expected '>'}}
+  foo = #test.decimal_integer<0x5>
 }

--- a/mlir/test/mlir-tblgen/testdialect-attrdefs.mlir
+++ b/mlir/test/mlir-tblgen/testdialect-attrdefs.mlir
@@ -20,15 +20,27 @@ func.func private @overriddenAttr() attributes {
   foo = #test.override_builder<5>
 }
 
-// CHECK-LABEL: @decimalInteger
-// CHECK-SAME: foo = #test.decimal_integer<5>
-func.func private @decimalInteger() attributes {
-  foo = #test.decimal_integer<5>
+// CHECK-LABEL: @decimalIntegerShapeEmpty
+// CHECK-SAME: foo = #test.decimal_shape<>
+func.func private @decimalIntegerShapeEmpty() attributes {
+  foo = #test.decimal_shape<>
+}
+
+// CHECK-LABEL: @decimalIntegerShape
+// CHECK-SAME: foo = #test.decimal_shape<5>
+func.func private @decimalIntegerShape() attributes {
+  foo = #test.decimal_shape<5>
+}
+
+// CHECK-LABEL: @decimalIntegerShapeMultiple
+// CHECK-SAME: foo = #test.decimal_shape<0x3x7>
+func.func private @decimalIntegerShapeMultiple() attributes {
+  foo = #test.decimal_shape<0x3x7>
 }
 
 // -----
 
 func.func private @hexdecimalInteger() attributes {
-// expected-error @below {{expected '>'}}
-  foo = #test.decimal_integer<0x5>
+// expected-error @below {{expected an integer}}
+  sdg = #test.decimal_shape<1x0xb>
 }


### PR DESCRIPTION
An attribute parser needs to parse lists of possibly negative integers separated by x in a way which is foiled by parseInteger handling hex formats and parseIntegerInDimensionList does not allow negatives.