### PR TITLE
[ASan][libc++] Turn off SSO annotations for Apple platforms

### DIFF
--- a/libcxx/include/string
+++ b/libcxx/include/string
@@ -1931,6 +1931,7 @@ private:
     (void)__new_mid;
 #if !defined(_LIBCPP_HAS_NO_ASAN) && defined(_LIBCPP_INSTRUMENTED_WITH_ASAN)
   #if defined(__APPLE__)
+    // TODO: remove after addressing issue #96099 (https://github.com/llvm/llvm-project/issues/96099)
     if(!__is_long())
       return;
   #endif

--- a/libcxx/include/string
+++ b/libcxx/include/string
@@ -1930,6 +1930,10 @@ private:
     (void)__old_mid;
     (void)__new_mid;
 #if !defined(_LIBCPP_HAS_NO_ASAN) && defined(_LIBCPP_INSTRUMENTED_WITH_ASAN)
+  #if defined(__APPLE__)
+    if(!__is_long())
+      return;
+  #endif
     std::__annotate_contiguous_container<_Allocator>(data(), data() + capacity() + 1, __old_mid, __new_mid);
 #endif
   }


### PR DESCRIPTION
This commit disables short string AddressSanitizer annotations on Apple platforms as a temporary solution to the problem reported in issue #96099.

For more information on Apple's block implementation, please refer to [`clang/docs/Block-ABI-Apple.rst`](https://github.com/llvm/llvm-project/blob/main/clang/docs/Block-ABI-Apple.rst). The core issue lies in the fact that blocks are unaware of their content, causing AddressSanitizer errors when blocks are moved using `memmove`.

I believe - and I'm not alone - that the issue should ideally be addressed within the block moving logic. However, if a timely resolution is not feasible, this temporary fix can be used. Before merging, we should ensure that a more permanent solution cannot be implemented in time and that this change effectively resolves the issue.