### PR TITLE
[dsymutil] Move discriminator test to be executed with Arm support only

### DIFF
--- a/llvm/test/tools/dsymutil/ARM/discriminator.test
+++ b/llvm/test/tools/dsymutil/ARM/discriminator.test
@@ -7,13 +7,13 @@
 ; with -g -fdebug-info-for-profiling -O2.
 
 RUN: dsymutil --flat --linker=classic -oso-prepend-path %p -o - \
-RUN:  --oso-prepend-path %p/Inputs --verify-dwarf=none \
-RUN:  %p/Inputs/discriminator.arm64.dylib | llvm-dwarfdump -debug-line - \
+RUN:  --oso-prepend-path %p/../Inputs --verify-dwarf=none \
+RUN:  %p/../Inputs/discriminator.arm64.dylib | llvm-dwarfdump -debug-line - \
 RUN:  | FileCheck %s
 
 RUN: dsymutil --flat --linker=parallel -oso-prepend-path %p -o - \
-RUN:  --oso-prepend-path %p/Inputs --verify-dwarf=none \
-RUN:  %p/Inputs/discriminator.arm64.dylib | llvm-dwarfdump -debug-line - \
+RUN:  --oso-prepend-path %p/../Inputs --verify-dwarf=none \
+RUN:  %p/../Inputs/discriminator.arm64.dylib | llvm-dwarfdump -debug-line - \
 RUN:  | FileCheck %s
 
 CHECK:          Address            Line   Column File   ISA Discriminator OpIndex Flags


### PR DESCRIPTION
This fixes a test failure introduced in 9f71a6b.