### PR TITLE
[llvm][CodeGen] Update checking method of loop-carried phi in window scheduler

### DIFF
--- a/llvm/lib/CodeGen/WindowScheduler.cpp
+++ b/llvm/lib/CodeGen/WindowScheduler.cpp
@@ -198,19 +198,13 @@ bool WindowScheduler::initialize() {
     // Two cases are checked here: (1)The virtual register defined by the
     // preceding phi is used by the succeeding phi;(2)The preceding phi uses the
     // virtual register defined by the succeeding phi.
-    auto Def = Phi.getOperand(0);
-    if (Def.isReg()) {
-      if (PrevUses.count(Def.getReg()))
-        return true;
-      PrevDefs.insert(Def.getReg());
-    }
+    if (PrevUses.count(Phi.getOperand(0).getReg()))
+      return true;
+    PrevDefs.insert(Phi.getOperand(0).getReg());
     for (unsigned I = 1, E = Phi.getNumOperands(); I != E; I += 2) {
-      auto Use = Phi.getOperand(I);
-      if (Use.isReg()) {
-        if (PrevDefs.count(Use.getReg()))
-          return true;
-        PrevUses.insert(Use.getReg());
-      }
+      if (PrevDefs.count(Phi.getOperand(I).getReg()))
+        return true;
+      PrevUses.insert(Phi.getOperand(I).getReg());
     }
     return false;
   };

--- a/llvm/lib/CodeGen/WindowScheduler.cpp
+++ b/llvm/lib/CodeGen/WindowScheduler.cpp
@@ -192,22 +192,36 @@ bool WindowScheduler::initialize() {
     return false;
   }
   // Check each MI in MBB.
-  SmallVector<Register, 8> PhiDefs;
+  SmallSet<Register, 8> PrevDefs;
+  SmallSet<Register, 8> PrevUses;
+  auto IsLoopCarried = [&](MachineInstr &Phi) {
+    // Two cases are checked here: (1)The virtual register defined by the
+    // preceding phi is used by the succeeding phi;(2)The preceding phi uses the
+    // virtual register defined by the succeeding phi.
+    for (auto MO : Phi.operands()) {
+      if (!MO.isReg())
+        continue;
+      if (MO.isDef()) {
+        if (PrevUses.count(MO.getReg()))
+          return true;
+        PrevDefs.insert(MO.getReg());
+      } else if (MO.isUse()) {
+        if (PrevDefs.count(MO.getReg()))
+          return true;
+        PrevUses.insert(MO.getReg());
+      }
+    }
+    return false;
+  };
   auto PLI = TII->analyzeLoopForPipelining(MBB);
   for (auto &MI : *MBB) {
     if (MI.isMetaInstruction() || MI.isTerminator())
       continue;
     if (MI.isPHI()) {
-      for (auto Def : PhiDefs)
-        if (MI.readsRegister(Def, TRI)) {
-          LLVM_DEBUG(
-              dbgs()
-              << "Consecutive phis are not allowed in window scheduling!\n");
-          return false;
-        }
-      for (auto Def : MI.defs())
-        if (Def.isReg())
-          PhiDefs.push_back(Def.getReg());
+      if (IsLoopCarried(MI)) {
+        LLVM_DEBUG(dbgs() << "Loop carried phis are not supported yet!\n");
+        return false;
+      }
       ++SchedPhiNum;
       ++BestOffset;
     } else

--- a/llvm/test/CodeGen/Hexagon/swp-ws-dead-def.mir
+++ b/llvm/test/CodeGen/Hexagon/swp-ws-dead-def.mir
@@ -1,6 +1,7 @@
 # REQUIRES: asserts
 # RUN: llc --march=hexagon %s -run-pass=pipeliner -debug-only=pipeliner \
-# RUN: -window-sched=force -o - 2>&1 | FileCheck %s
+# RUN: -window-sched=force -filetype=null -verify-machineinstrs 2>&1 \
+# RUN: | FileCheck %s
 
 # CHECK: Best window offset is {{[0-9]+}} and Best II is {{[0-9]+}}.
 # CHECK-LABEL: name: exp_approx_top_six

--- a/llvm/test/CodeGen/Hexagon/swp-ws-exp-dbg.mir
+++ b/llvm/test/CodeGen/Hexagon/swp-ws-exp-dbg.mir
@@ -1,11 +1,12 @@
 # REQUIRES: asserts
 # RUN: llc --march=hexagon %s -run-pass=pipeliner -debug-only=pipeliner \
-# RUN: -window-sched=force -o - 2>&1 | FileCheck %s
-#
+# RUN: -window-sched=force -filetype=null -verify-machineinstrs 2>&1 \
+# RUN: | FileCheck %s
+
 # The Window Scheduling algorithm will discard the debug IR, just like the SMS
 # algorithm does. Additionally, the MMO information in the IR is also preserved
 # to ensure that no barrier dependencies are generated within the loop body.
-#
+
 # CHECK: Best window offset is {{[0-9]+}} and Best II is {{[0-9]+}}.
 # CHECK-LABEL: name: exp_approx
 # CHECK: bb.5.for.body:

--- a/llvm/test/CodeGen/Hexagon/swp-ws-exp.mir
+++ b/llvm/test/CodeGen/Hexagon/swp-ws-exp.mir
@@ -1,6 +1,7 @@
 # REQUIRES: asserts
 # RUN: llc --march=hexagon %s -run-pass=pipeliner -debug-only=pipeliner \
-# RUN: -window-sched=force -o - 2>&1 | FileCheck %s
+# RUN: -window-sched=force -filetype=null -verify-machineinstrs 2>&1 \
+# RUN: | FileCheck %s
 
 # CHECK: Best window offset is {{[0-9]+}} and Best II is {{[0-9]+}}.
 

--- a/llvm/test/CodeGen/Hexagon/swp-ws-fail-0.mir
+++ b/llvm/test/CodeGen/Hexagon/swp-ws-fail-0.mir
@@ -1,13 +1,14 @@
 # REQUIRES: asserts
 # RUN: llc --march=hexagon %s -run-pass=pipeliner -debug-only=pipeliner \
-# RUN: -window-sched=force -o - 2>&1 | FileCheck %s \
+# RUN: -window-sched=force -filetype=null -verify-machineinstrs 2>&1 \
+# RUN: | FileCheck %s \
 # RUN: --check-prefix=CHECK-INITIALIZE
 # RUN: llc --march=hexagon %s -run-pass=pipeliner -debug-only=pipeliner \
-# RUN: -window-sched=force -window-region-limit=1 -window-ii-limit=1 -o - \
-# RUN: 2>&1 | FileCheck %s --check-prefix=CHECK-ANALYSE-II
+# RUN: -window-sched=force -window-region-limit=1 -window-ii-limit=1 \
+# RUN: -filetype=null 2>&1 | FileCheck %s --check-prefix=CHECK-ANALYSE-II
 # RUN: llc --march=hexagon %s -run-pass=pipeliner -debug-only=pipeliner \
 # RUN: -window-sched=force -window-region-limit=1 -window-search-ratio=80 \
-# RUN: -o - 2>&1 | FileCheck %s --check-prefix=CHECK-SCHED-NOT-NEEDED
+# RUN: -filetype=null 2>&1 | FileCheck %s --check-prefix=CHECK-SCHED-NOT-NEEDED
 
 # CHECK-INITIALIZE: There are too few MIs in the window region!
 # CHECK-INITIALIZE: The WindowScheduler failed to initialize!

--- a/llvm/test/CodeGen/Hexagon/swp-ws-fail-2.mir
+++ b/llvm/test/CodeGen/Hexagon/swp-ws-fail-2.mir
@@ -1,6 +1,7 @@
 # REQUIRES: asserts
 # RUN: llc --march=hexagon %s -run-pass=pipeliner -debug-only=pipeliner \
-# RUN: -window-sched=force -o - 2>&1 | FileCheck %s
+# RUN: -window-sched=force -filetype=null -verify-machineinstrs 2>&1 \
+# RUN: | FileCheck %s
 
 # CHECK: The WindowScheduler failed to initialize!
 

--- a/llvm/test/CodeGen/Hexagon/swp-ws-fail-3.mir
+++ b/llvm/test/CodeGen/Hexagon/swp-ws-fail-3.mir
@@ -7,8 +7,8 @@
 # CHECK: The WindowScheduler failed to initialize!
 # CHECK-LABEL: body:             |
 # CHECK: bb.3 (machine-block-address-taken):
-# CHECK: [[REG:%[0-9]+]]:intregs = PHI {{%[0-9]+}}, %bb.1, {{%[0-9]+}}, %bb.3
-# CHECK: {{%[0-9]+}}:intregs = PHI {{%[0-9]+}}, %bb.1, [[REG]], %bb.3
+# CHECK: {{%[0-9]+}}:intregs = PHI {{%[0-9]+}}, %bb.1, [[REG:%[0-9]+]], %bb.3
+# CHECK: [[REG]]:intregs = PHI {{%[0-9]+}}, %bb.1, {{%[0-9]+}}, %bb.3
 
 ---
 name:            relu
@@ -17,35 +17,36 @@ body:             |
   bb.0:
     successors: %bb.2(0x30000000), %bb.1(0x50000000)
     liveins: $r0, $r1, $r2
-
+  
     %0:intregs = COPY $r2
     %1:intregs = COPY $r1
     %2:intregs = COPY $r0
     %3:predregs = C2_cmpeqi %2, 0
     J2_jumpt killed %3, %bb.2, implicit-def dead $pc
     J2_jump %bb.1, implicit-def dead $pc
-
+  
   bb.1:
     successors: %bb.3(0x80000000)
-
+  
     %4:hvxvr = V6_vd0
     %5:intregs = A2_addi %2, 31
     %6:intregs = S2_lsr_i_r %5, 5
     %7:intregs = COPY %6
     J2_loop0r %bb.3, %7, implicit-def $lc0, implicit-def $sa0, implicit-def $usr
     J2_jump %bb.3, implicit-def dead $pc
-
+  
   bb.2:
     PS_jmpret $r31, implicit-def dead $pc
-
+  
   bb.3 (machine-block-address-taken):
     successors: %bb.3(0x7c000000), %bb.2(0x04000000)
-
-    %8:intregs = PHI %1, %bb.1, %9, %bb.3
-    %10:intregs = PHI %0, %bb.1, %8, %bb.3
-    %11:hvxvr, %9:intregs = V6_vL32b_pi %8, 128
+  
+    %8:intregs = PHI %0, %bb.1, %9, %bb.3
+    %9:intregs = PHI %1, %bb.1, %10, %bb.3
+    %11:hvxvr, %10:intregs = V6_vL32b_pi %9, 128
     %12:hvxvr = V6_vmaxw killed %11, %4
-    %13:intregs = V6_vS32b_pi %10, 128, killed %12
+    %13:intregs = V6_vS32b_pi %8, 128, killed %12
     ENDLOOP0 %bb.3, implicit-def $pc, implicit-def $lc0, implicit $sa0, implicit $lc0
     J2_jump %bb.2, implicit-def dead $pc
+
 ...

--- a/llvm/test/CodeGen/Hexagon/swp-ws-meta-instr.mir
+++ b/llvm/test/CodeGen/Hexagon/swp-ws-meta-instr.mir
@@ -1,6 +1,7 @@
 # REQUIRES: asserts
 # RUN: llc --march=hexagon %s -run-pass=pipeliner -debug-only=pipeliner \
-# RUN: -window-sched=force -o - 2>&1 | FileCheck %s
+# RUN: -window-sched=force -filetype=null -verify-machineinstrs 2>&1 \
+# RUN: | FileCheck %s
 
 # CHECK-NOT: PSEUDO_PROBE
 # CHECK: Best window offset is {{[0-9]+}} and Best II is {{[0-9]+}}.

--- a/llvm/test/CodeGen/Hexagon/swp-ws-phi.mir
+++ b/llvm/test/CodeGen/Hexagon/swp-ws-phi.mir
@@ -1,6 +1,7 @@
 # REQUIRES: asserts
 # RUN: llc --march=hexagon %s -run-pass=pipeliner -debug-only=pipeliner \
-# RUN: -window-sched=force -filetype=null 2>&1 | FileCheck %s
+# RUN: -window-sched=force -filetype=null -verify-machineinstrs 2>&1 \
+# RUN: | FileCheck %s
 
 # CHECK: Window scheduling is not needed!
 # CHECK-LABEL: body:             |

--- a/llvm/test/CodeGen/Hexagon/swp-ws-sqrt.mir
+++ b/llvm/test/CodeGen/Hexagon/swp-ws-sqrt.mir
@@ -1,6 +1,7 @@
 # REQUIRES: asserts
 # RUN: llc --march=hexagon %s -run-pass=pipeliner -debug-only=pipeliner \
-# RUN: -window-sched=force -o - 2>&1 | FileCheck %s
+# RUN: -window-sched=force -filetype=null -verify-machineinstrs 2>&1 \
+# RUN: | FileCheck %s
 
 # CHECK: Best window offset is {{[0-9]+}} and Best II is {{[0-9]+}}.
 

--- a/llvm/test/CodeGen/Hexagon/swp-ws-weak-dep.mir
+++ b/llvm/test/CodeGen/Hexagon/swp-ws-weak-dep.mir
@@ -1,6 +1,7 @@
 # REQUIRES: asserts
 # RUN: llc --march=hexagon %s -run-pass=pipeliner -debug-only=pipeliner \
-# RUN: -window-sched=force -filetype=null 2>&1 | FileCheck %s
+# RUN: -window-sched=force -filetype=null -verify-machineinstrs 2>&1 \
+# RUN: | FileCheck %s
 
 # CHECK: SU(3): Ord  Latency=0 Weak
 # CHECK: SU(1): Ord  Latency=0 Weak


### PR DESCRIPTION
Added some logic to check loop-carried phis in the window scheduler. It
now includes the scenario where the preceding phi uses the virtual
register defined by the succeeding phi.
