### PR TITLE
[lldb][ExpressionParser][NFCI] Add new DoPrepareForExecution interface to be implemented by language plugins

### DIFF
--- a/lldb/include/lldb/Expression/ExpressionParser.h
+++ b/lldb/include/lldb/Expression/ExpressionParser.h
@@ -119,13 +119,34 @@ public:
   /// \return
   ///     An error code indicating the success or failure of the operation.
   ///     Test with Success().
-  virtual Status
+  Status
   PrepareForExecution(lldb::addr_t &func_addr, lldb::addr_t &func_end,
                       std::shared_ptr<IRExecutionUnit> &execution_unit_sp,
                       ExecutionContext &exe_ctx, bool &can_interpret,
-                      lldb_private::ExecutionPolicy execution_policy) = 0;
+                      lldb_private::ExecutionPolicy execution_policy);
 
   bool GetGenerateDebugInfo() const { return m_generate_debug_info; }
+
+protected:
+  virtual Status
+  DoPrepareForExecution(lldb::addr_t &func_addr, lldb::addr_t &func_end,
+                        std::shared_ptr<IRExecutionUnit> &execution_unit_sp,
+                        ExecutionContext &exe_ctx, bool &can_interpret,
+                        lldb_private::ExecutionPolicy execution_policy) = 0;
+
+private:
+  /// Run all static initializers for an execution unit.
+  ///
+  /// \param[in] execution_unit_sp
+  ///     The execution unit.
+  ///
+  /// \param[in] exe_ctx
+  ///     The execution context to use when running them.  Thread can't be null.
+  ///
+  /// \return
+  ///     The error code indicating the
+  Status RunStaticInitializers(lldb::IRExecutionUnitSP &execution_unit_sp,
+                               ExecutionContext &exe_ctx);
 
 protected:
   Expression &m_expr; ///< The expression to be parsed

--- a/lldb/source/Expression/CMakeLists.txt
+++ b/lldb/source/Expression/CMakeLists.txt
@@ -3,6 +3,7 @@ add_lldb_library(lldbExpression NO_PLUGIN_DEPENDENCIES
   DWARFExpression.cpp
   DWARFExpressionList.cpp
   Expression.cpp
+  ExpressionParser.cpp
   ExpressionTypeSystemHelper.cpp
   ExpressionVariable.cpp
   FunctionCaller.cpp

--- a/lldb/source/Expression/ExpressionParser.cpp
+++ b/lldb/source/Expression/ExpressionParser.cpp
@@ -1,0 +1,73 @@
+//===-- ExpressionParser.cpp ----------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "lldb/Expression/ExpressionParser.h"
+#include "lldb/Expression/DiagnosticManager.h"
+#include "lldb/Expression/IRExecutionUnit.h"
+#include "lldb/Target/ExecutionContext.h"
+#include "lldb/Target/ThreadPlanCallFunction.h"
+
+using namespace lldb_private;
+
+Status ExpressionParser::PrepareForExecution(
+    lldb::addr_t &func_addr, lldb::addr_t &func_end,
+    std::shared_ptr<IRExecutionUnit> &execution_unit_sp,
+    ExecutionContext &exe_ctx, bool &can_interpret,
+    lldb_private::ExecutionPolicy execution_policy) {
+  Status status =
+      DoPrepareForExecution(func_addr, func_end, execution_unit_sp, exe_ctx,
+                            can_interpret, execution_policy);
+  if (status.Success() && exe_ctx.GetProcessPtr() && exe_ctx.HasThreadScope()) {
+    status = RunStaticInitializers(execution_unit_sp, exe_ctx);
+  }
+  return status;
+}
+
+Status ExpressionParser::RunStaticInitializers(
+    lldb::IRExecutionUnitSP &execution_unit_sp, ExecutionContext &exe_ctx) {
+  lldb_private::Status err;
+
+  lldbassert(execution_unit_sp.get());
+  lldbassert(exe_ctx.HasThreadScope());
+
+  if (!execution_unit_sp.get()) {
+    err.SetErrorString(
+        "can't run static initializers for a NULL execution unit");
+    return err;
+  }
+
+  if (!exe_ctx.HasThreadScope()) {
+    err.SetErrorString("can't run static initializers without a thread");
+    return err;
+  }
+
+  std::vector<lldb::addr_t> static_initializers;
+
+  execution_unit_sp->GetStaticInitializers(static_initializers);
+
+  for (lldb::addr_t static_initializer : static_initializers) {
+    EvaluateExpressionOptions options;
+
+    lldb::ThreadPlanSP call_static_initializer(new ThreadPlanCallFunction(
+        exe_ctx.GetThreadRef(), Address(static_initializer), CompilerType(),
+        llvm::ArrayRef<lldb::addr_t>(), options));
+
+    DiagnosticManager execution_errors;
+    lldb::ExpressionResults results =
+        exe_ctx.GetThreadRef().GetProcess()->RunThreadPlan(
+            exe_ctx, call_static_initializer, options, execution_errors);
+
+    if (results != lldb::eExpressionCompleted) {
+      err.SetErrorStringWithFormat("couldn't run static initializer: %s",
+                                   execution_errors.GetString().c_str());
+      return err;
+    }
+  }
+
+  return err;
+}

--- a/lldb/source/Expression/ExpressionParser.cpp
+++ b/lldb/source/Expression/ExpressionParser.cpp
@@ -29,8 +29,9 @@ Status ExpressionParser::PrepareForExecution(
   return status;
 }
 
-Status ExpressionParser::RunStaticInitializers(
-    IRExecutionUnitSP &execution_unit_sp, ExecutionContext &exe_ctx) {
+Status
+ExpressionParser::RunStaticInitializers(IRExecutionUnitSP &execution_unit_sp,
+                                        ExecutionContext &exe_ctx) {
   Status err;
 
   if (!execution_unit_sp.get()) {

--- a/lldb/source/Expression/ExpressionParser.cpp
+++ b/lldb/source/Expression/ExpressionParser.cpp
@@ -12,28 +12,26 @@
 #include "lldb/Target/ExecutionContext.h"
 #include "lldb/Target/ThreadPlanCallFunction.h"
 
+using namespace lldb;
 using namespace lldb_private;
 
 Status ExpressionParser::PrepareForExecution(
-    lldb::addr_t &func_addr, lldb::addr_t &func_end,
+    addr_t &func_addr, addr_t &func_end,
     std::shared_ptr<IRExecutionUnit> &execution_unit_sp,
     ExecutionContext &exe_ctx, bool &can_interpret,
-    lldb_private::ExecutionPolicy execution_policy) {
+    ExecutionPolicy execution_policy) {
   Status status =
       DoPrepareForExecution(func_addr, func_end, execution_unit_sp, exe_ctx,
                             can_interpret, execution_policy);
-  if (status.Success() && exe_ctx.GetProcessPtr() && exe_ctx.HasThreadScope()) {
+  if (status.Success() && exe_ctx.GetProcessPtr() && exe_ctx.HasThreadScope())
     status = RunStaticInitializers(execution_unit_sp, exe_ctx);
-  }
+
   return status;
 }
 
 Status ExpressionParser::RunStaticInitializers(
-    lldb::IRExecutionUnitSP &execution_unit_sp, ExecutionContext &exe_ctx) {
-  lldb_private::Status err;
-
-  lldbassert(execution_unit_sp.get());
-  lldbassert(exe_ctx.HasThreadScope());
+    IRExecutionUnitSP &execution_unit_sp, ExecutionContext &exe_ctx) {
+  Status err;
 
   if (!execution_unit_sp.get()) {
     err.SetErrorString(
@@ -46,23 +44,23 @@ Status ExpressionParser::RunStaticInitializers(
     return err;
   }
 
-  std::vector<lldb::addr_t> static_initializers;
+  std::vector<addr_t> static_initializers;
 
   execution_unit_sp->GetStaticInitializers(static_initializers);
 
-  for (lldb::addr_t static_initializer : static_initializers) {
+  for (addr_t static_initializer : static_initializers) {
     EvaluateExpressionOptions options;
 
-    lldb::ThreadPlanSP call_static_initializer(new ThreadPlanCallFunction(
+    ThreadPlanSP call_static_initializer(new ThreadPlanCallFunction(
         exe_ctx.GetThreadRef(), Address(static_initializer), CompilerType(),
-        llvm::ArrayRef<lldb::addr_t>(), options));
+        llvm::ArrayRef<addr_t>(), options));
 
     DiagnosticManager execution_errors;
-    lldb::ExpressionResults results =
+    ExpressionResults results =
         exe_ctx.GetThreadRef().GetProcess()->RunThreadPlan(
             exe_ctx, call_static_initializer, options, execution_errors);
 
-    if (results != lldb::eExpressionCompleted) {
+    if (results != eExpressionCompleted) {
       err.SetErrorStringWithFormat("couldn't run static initializer: %s",
                                    execution_errors.GetString().c_str());
       return err;

--- a/lldb/source/Plugins/ExpressionParser/Clang/ClangExpressionParser.h
+++ b/lldb/source/Plugins/ExpressionParser/Clang/ClangExpressionParser.h
@@ -113,24 +113,11 @@ public:
   /// \return
   ///     An error code indicating the success or failure of the operation.
   ///     Test with Success().
-  Status
-  PrepareForExecution(lldb::addr_t &func_addr, lldb::addr_t &func_end,
-                      lldb::IRExecutionUnitSP &execution_unit_sp,
-                      ExecutionContext &exe_ctx, bool &can_interpret,
-                      lldb_private::ExecutionPolicy execution_policy) override;
-
-  /// Run all static initializers for an execution unit.
-  ///
-  /// \param[in] execution_unit_sp
-  ///     The execution unit.
-  ///
-  /// \param[in] exe_ctx
-  ///     The execution context to use when running them.  Thread can't be null.
-  ///
-  /// \return
-  ///     The error code indicating the
-  Status RunStaticInitializers(lldb::IRExecutionUnitSP &execution_unit_sp,
-                               ExecutionContext &exe_ctx);
+  Status DoPrepareForExecution(
+      lldb::addr_t &func_addr, lldb::addr_t &func_end,
+      lldb::IRExecutionUnitSP &execution_unit_sp, ExecutionContext &exe_ctx,
+      bool &can_interpret,
+      lldb_private::ExecutionPolicy execution_policy) override;
 
   /// Returns a string representing current ABI.
   ///

--- a/lldb/source/Plugins/ExpressionParser/Clang/ClangUserExpression.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Clang/ClangUserExpression.cpp
@@ -698,21 +698,6 @@ bool ClangUserExpression::Parse(DiagnosticManager &diagnostic_manager,
   if (!parse_success)
     return false;
 
-  if (exe_ctx.GetProcessPtr() && execution_policy == eExecutionPolicyTopLevel) {
-    Status static_init_error =
-        m_parser->RunStaticInitializers(m_execution_unit_sp, exe_ctx);
-
-    if (!static_init_error.Success()) {
-      const char *error_cstr = static_init_error.AsCString();
-      if (error_cstr && error_cstr[0])
-        diagnostic_manager.Printf(lldb::eSeverityError, "%s\n", error_cstr);
-      else
-        diagnostic_manager.PutString(lldb::eSeverityError,
-                                     "couldn't run static initializers\n");
-      return false;
-    }
-  }
-
   if (m_execution_unit_sp) {
     bool register_execution_unit = false;
 


### PR DESCRIPTION
This patch adds a new `DoPrepareForExecution` API, which can be implemented by the Clang and Swift language plugins. This also moves `RunStaticInitializers` into `ExpressionParser::PrepareForExecution`, so we call it consistently between language plugins.

This *should* be mostly NFC (the static initializers will still only run after we finished parsing). We've been living on this patch downstream for sometime now.

rdar://130267058