### PR TITLE
APFloat: Add minimumnum and maximumnum

### DIFF
--- a/llvm/include/llvm/ADT/APFloat.h
+++ b/llvm/include/llvm/ADT/APFloat.h
@@ -1483,6 +1483,19 @@ inline APFloat minimum(const APFloat &A, const APFloat &B) {
   return B < A ? B : A;
 }
 
+/// Implements IEEE 754-2019 minimumNumber semantics. Returns the smaller
+/// of 2 arguments, not propagating NaNs and treating -0 as less than +0.
+LLVM_READONLY
+inline APFloat minimumnum(const APFloat &A, const APFloat &B) {
+  if (A.isNaN())
+    return B.isNaN() ? B.makeQuiet() : B;
+  if (B.isNaN())
+    return A;
+  if (A.isZero() && B.isZero() && (A.isNegative() != B.isNegative()))
+    return A.isNegative() ? A : B;
+  return B < A ? B : A;
+}
+
 /// Implements IEEE 754-2019 maximum semantics. Returns the larger of 2
 /// arguments, propagating NaNs and treating -0 as less than +0.
 LLVM_READONLY
@@ -1491,6 +1504,19 @@ inline APFloat maximum(const APFloat &A, const APFloat &B) {
     return A;
   if (B.isNaN())
     return B;
+  if (A.isZero() && B.isZero() && (A.isNegative() != B.isNegative()))
+    return A.isNegative() ? B : A;
+  return A < B ? B : A;
+}
+
+/// Implements IEEE 754-2019 maximumNumber semantics. Returns the larger
+/// of 2 arguments, not propagating NaNs and treating -0 as less than +0.
+LLVM_READONLY
+inline APFloat maximumnum(const APFloat &A, const APFloat &B) {
+  if (A.isNaN())
+    return B.isNaN() ? B.makeQuiet() : B;
+  if (B.isNaN())
+    return A;
   if (A.isZero() && B.isZero() && (A.isNegative() != B.isNegative()))
     return A.isNegative() ? B : A;
   return A < B ? B : A;

--- a/llvm/unittests/ADT/APFloatTest.cpp
+++ b/llvm/unittests/ADT/APFloatTest.cpp
@@ -631,6 +631,54 @@ TEST(APFloatTest, Maximum) {
   EXPECT_TRUE(std::isnan(maximum(nan, f1).convertToDouble()));
 }
 
+TEST(APFloatTest, MinimumNumber) {
+  APFloat f1(1.0);
+  APFloat f2(2.0);
+  APFloat zp(0.0);
+  APFloat zn(-0.0);
+  APFloat nan = APFloat::getNaN(APFloat::IEEEdouble());
+  APFloat snan = APFloat::getSNaN(APFloat::IEEEdouble());
+
+  EXPECT_EQ(1.0, minimumnum(f1, f2).convertToDouble());
+  EXPECT_EQ(1.0, minimumnum(f2, f1).convertToDouble());
+  EXPECT_EQ(-0.0, minimumnum(zp, zn).convertToDouble());
+  EXPECT_EQ(-0.0, minimumnum(zn, zp).convertToDouble());
+  EXPECT_TRUE(minimumnum(zn, zp).isNegative());
+  EXPECT_TRUE(minimumnum(zp, zn).isNegative());
+  EXPECT_TRUE(minimumnum(zn, zn).isNegative());
+  EXPECT_FALSE(minimumnum(zp, zp).isNegative());
+  EXPECT_FALSE(std::isnan(minimumnum(f1, nan).convertToDouble()));
+  EXPECT_FALSE(std::isnan(minimumnum(nan, f1).convertToDouble()));
+  EXPECT_FALSE(std::isnan(minimumnum(f1, snan).convertToDouble()));
+  EXPECT_FALSE(std::isnan(minimumnum(snan, f1).convertToDouble()));
+  EXPECT_FALSE(minimumnum(snan, nan).isSignaling());
+  EXPECT_FALSE(minimumnum(snan, snan).isSignaling());
+}
+
+TEST(APFloatTest, MaximumNumber) {
+  APFloat f1(1.0);
+  APFloat f2(2.0);
+  APFloat zp(0.0);
+  APFloat zn(-0.0);
+  APFloat nan = APFloat::getNaN(APFloat::IEEEdouble());
+  APFloat snan = APFloat::getSNaN(APFloat::IEEEdouble());
+
+  EXPECT_EQ(2.0, maximumnum(f1, f2).convertToDouble());
+  EXPECT_EQ(2.0, maximumnum(f2, f1).convertToDouble());
+  EXPECT_EQ(0.0, maximumnum(zp, zn).convertToDouble());
+  EXPECT_EQ(0.0, maximumnum(zn, zp).convertToDouble());
+  EXPECT_FALSE(maximumnum(zn, zp).isNegative());
+  EXPECT_FALSE(maximumnum(zp, zn).isNegative());
+  EXPECT_TRUE(maximumnum(zn, zn).isNegative());
+  EXPECT_FALSE(maximumnum(zp, zp).isNegative());
+  EXPECT_FALSE(std::isnan(maximumnum(f1, nan).convertToDouble()));
+  EXPECT_FALSE(std::isnan(maximumnum(nan, f1).convertToDouble()));
+  EXPECT_FALSE(std::isnan(maximumnum(f1, snan).convertToDouble()));
+  EXPECT_FALSE(std::isnan(maximumnum(snan, f1).convertToDouble()));
+  EXPECT_FALSE(maximumnum(snan, nan).isSignaling());
+  EXPECT_FALSE(maximumnum(snan, snan).isSignaling());
+}
+
 TEST(APFloatTest, Denormal) {
   APFloat::roundingMode rdmd = APFloat::rmNearestTiesToEven;
 

--- a/llvm/unittests/ADT/APFloatTest.cpp
+++ b/llvm/unittests/ADT/APFloatTest.cpp
@@ -696,10 +696,10 @@ TEST(APFloatTest, MaximumNumber) {
       APFloat::getSNaN(APFloat::IEEEdouble(), true, &intPayload_cdef),
       APFloat::getNaN(APFloat::IEEEdouble(), true, 0xcdef)};
 
-  EXPECT_TRUE(f2.bitwiseIsEqual(minimumnum(f1, f2)));
-  EXPECT_TRUE(f2.bitwiseIsEqual(minimumnum(f2, f1)));
-  EXPECT_TRUE(zp.bitwiseIsEqual(minimumnum(zp, zn)));
-  EXPECT_TRUE(zp.bitwiseIsEqual(minimumnum(zn, zp)));
+  EXPECT_TRUE(f2.bitwiseIsEqual(maximumnum(f1, f2)));
+  EXPECT_TRUE(f2.bitwiseIsEqual(maximumnum(f2, f1)));
+  EXPECT_TRUE(zp.bitwiseIsEqual(maximumnum(zp, zn)));
+  EXPECT_TRUE(zp.bitwiseIsEqual(maximumnum(zn, zp)));
 
   EXPECT_FALSE(maximumnum(zn, zp).isNegative());
   EXPECT_FALSE(maximumnum(zp, zn).isNegative());

--- a/llvm/unittests/ADT/APFloatTest.cpp
+++ b/llvm/unittests/ADT/APFloatTest.cpp
@@ -649,10 +649,10 @@ TEST(APFloatTest, MinimumNumber) {
       APFloat::getSNaN(APFloat::IEEEdouble(), true, &intPayload_cdef),
       APFloat::getNaN(APFloat::IEEEdouble(), true, 0xcdef)};
 
-  EXPECT_EQ(1.0, minimumnum(f1, f2).convertToDouble());
-  EXPECT_EQ(1.0, minimumnum(f2, f1).convertToDouble());
-  EXPECT_EQ(-0.0, minimumnum(zp, zn).convertToDouble());
-  EXPECT_EQ(-0.0, minimumnum(zn, zp).convertToDouble());
+  EXPECT_TRUE(f1.bitwiseIsEqual(minimumnum(f1, f2)));
+  EXPECT_TRUE(f1.bitwiseIsEqual(minimumnum(f2, f1)));
+  EXPECT_TRUE(zn.bitwiseIsEqual(minimumnum(zp, zn)));
+  EXPECT_TRUE(zn.bitwiseIsEqual(minimumnum(zn, zp)));
 
   EXPECT_TRUE(minimumnum(zn, zp).isNegative());
   EXPECT_TRUE(minimumnum(zp, zn).isNegative());
@@ -696,10 +696,10 @@ TEST(APFloatTest, MaximumNumber) {
       APFloat::getSNaN(APFloat::IEEEdouble(), true, &intPayload_cdef),
       APFloat::getNaN(APFloat::IEEEdouble(), true, 0xcdef)};
 
-  EXPECT_EQ(2.0, maximumnum(f1, f2).convertToDouble());
-  EXPECT_EQ(2.0, maximumnum(f2, f1).convertToDouble());
-  EXPECT_EQ(0.0, maximumnum(zp, zn).convertToDouble());
-  EXPECT_EQ(0.0, maximumnum(zn, zp).convertToDouble());
+  EXPECT_TRUE(f2.bitwiseIsEqual(minimumnum(f1, f2)));
+  EXPECT_TRUE(f2.bitwiseIsEqual(minimumnum(f2, f1)));
+  EXPECT_TRUE(zp.bitwiseIsEqual(minimumnum(zp, zn)));
+  EXPECT_TRUE(zp.bitwiseIsEqual(minimumnum(zn, zp)));
 
   EXPECT_FALSE(maximumnum(zn, zp).isNegative());
   EXPECT_FALSE(maximumnum(zp, zn).isNegative());


### PR DESCRIPTION
They implements IEEE754-2019 minimumNumber and maximumNumber semantics.

Newer libc also has these 2 functions with names
   fminimum_num
   fmaximum_num

We are planning add minimumnum and maximumnum intrinsic. This is a step to the goal.