### PR TITLE
[libc++] Clean up and update deployment target features

### DIFF
--- a/libcxx/include/__configuration/availability.h
+++ b/libcxx/include/__configuration/availability.h
@@ -87,171 +87,193 @@
 // in all versions of the library are available.
 #if defined(_LIBCPP_HAS_NO_VENDOR_AVAILABILITY_ANNOTATIONS)
 
-#  define _LIBCPP_INTRODUCED_IN_LLVM_4 1
-#  define _LIBCPP_INTRODUCED_IN_LLVM_4_ATTRIBUTE /* nothing */
+#  define _LIBCPP_INTRODUCED_IN_LLVM_19 1
+#  define _LIBCPP_INTRODUCED_IN_LLVM_19_ATTRIBUTE /* nothing */
+
+#  define _LIBCPP_INTRODUCED_IN_LLVM_18 1
+#  define _LIBCPP_INTRODUCED_IN_LLVM_18_ATTRIBUTE /* nothing */
+
+#  define _LIBCPP_INTRODUCED_IN_LLVM_17 1
+#  define _LIBCPP_INTRODUCED_IN_LLVM_17_ATTRIBUTE /* nothing */
+
+#  define _LIBCPP_INTRODUCED_IN_LLVM_16 1
+#  define _LIBCPP_INTRODUCED_IN_LLVM_16_ATTRIBUTE /* nothing */
+
+#  define _LIBCPP_INTRODUCED_IN_LLVM_15 1
+#  define _LIBCPP_INTRODUCED_IN_LLVM_15_ATTRIBUTE /* nothing */
+
+#  define _LIBCPP_INTRODUCED_IN_LLVM_14 1
+#  define _LIBCPP_INTRODUCED_IN_LLVM_14_ATTRIBUTE /* nothing */
+
+#  define _LIBCPP_INTRODUCED_IN_LLVM_13 1
+#  define _LIBCPP_INTRODUCED_IN_LLVM_13_ATTRIBUTE /* nothing */
+
+#  define _LIBCPP_INTRODUCED_IN_LLVM_12 1
+#  define _LIBCPP_INTRODUCED_IN_LLVM_12_ATTRIBUTE /* nothing */
+
+#  define _LIBCPP_INTRODUCED_IN_LLVM_11 1
+#  define _LIBCPP_INTRODUCED_IN_LLVM_11_ATTRIBUTE /* nothing */
+
+#  define _LIBCPP_INTRODUCED_IN_LLVM_10 1
+#  define _LIBCPP_INTRODUCED_IN_LLVM_10_ATTRIBUTE /* nothing */
 
 #  define _LIBCPP_INTRODUCED_IN_LLVM_9 1
 #  define _LIBCPP_INTRODUCED_IN_LLVM_9_ATTRIBUTE      /* nothing */
 #  define _LIBCPP_INTRODUCED_IN_LLVM_9_ATTRIBUTE_PUSH /* nothing */
 #  define _LIBCPP_INTRODUCED_IN_LLVM_9_ATTRIBUTE_POP  /* nothing */
 
-#  define _LIBCPP_INTRODUCED_IN_LLVM_11 1
-#  define _LIBCPP_INTRODUCED_IN_LLVM_11_ATTRIBUTE /* nothing */
+#  define _LIBCPP_INTRODUCED_IN_LLVM_8 1
+#  define _LIBCPP_INTRODUCED_IN_LLVM_8_ATTRIBUTE /* nothing */
 
-#  define _LIBCPP_INTRODUCED_IN_LLVM_12 1
-#  define _LIBCPP_INTRODUCED_IN_LLVM_12_ATTRIBUTE /* nothing */
-
-#  define _LIBCPP_INTRODUCED_IN_LLVM_14 1
-#  define _LIBCPP_INTRODUCED_IN_LLVM_14_ATTRIBUTE /* nothing */
-
-#  define _LIBCPP_INTRODUCED_IN_LLVM_15 1
-#  define _LIBCPP_INTRODUCED_IN_LLVM_15_ATTRIBUTE /* nothing */
-
-#  define _LIBCPP_INTRODUCED_IN_LLVM_16 1
-#  define _LIBCPP_INTRODUCED_IN_LLVM_16_ATTRIBUTE /* nothing */
-
-#  define _LIBCPP_INTRODUCED_IN_LLVM_18 1
-#  define _LIBCPP_INTRODUCED_IN_LLVM_18_ATTRIBUTE /* nothing */
-
-#  define _LIBCPP_INTRODUCED_IN_LLVM_19 1
-#  define _LIBCPP_INTRODUCED_IN_LLVM_19_ATTRIBUTE /* nothing */
+#  define _LIBCPP_INTRODUCED_IN_LLVM_4 1
+#  define _LIBCPP_INTRODUCED_IN_LLVM_4_ATTRIBUTE /* nothing */
 
 #elif defined(__APPLE__)
 
-// LLVM 4
-#  if defined(__ENVIRONMENT_WATCH_OS_VERSION_MIN_REQUIRED__) && __ENVIRONMENT_WATCH_OS_VERSION_MIN_REQUIRED__ < 50000
-#    define _LIBCPP_INTRODUCED_IN_LLVM_4 0
-#    define _LIBCPP_INTRODUCED_IN_LLVM_4_ATTRIBUTE __attribute__((availability(watchos, strict, introduced = 5.0)))
-#  else
-#    define _LIBCPP_INTRODUCED_IN_LLVM_4 1
-#    define _LIBCPP_INTRODUCED_IN_LLVM_4_ATTRIBUTE /* nothing */
-#  endif
+// clang-format off
 
-// LLVM 9
-// clang-format off
-#  if (defined(__ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__) && __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ < 101500) ||   \
-      (defined(__ENVIRONMENT_IPHONE_OS_VERSION_MIN_REQUIRED__) && __ENVIRONMENT_IPHONE_OS_VERSION_MIN_REQUIRED__ < 130000) || \
-      (defined(__ENVIRONMENT_TV_OS_VERSION_MIN_REQUIRED__) && __ENVIRONMENT_TV_OS_VERSION_MIN_REQUIRED__ < 130000) ||         \
-      (defined(__ENVIRONMENT_WATCH_OS_VERSION_MIN_REQUIRED__) && __ENVIRONMENT_WATCH_OS_VERSION_MIN_REQUIRED__ < 60000)
-// clang-format on
-#    define _LIBCPP_INTRODUCED_IN_LLVM_9 0
-#    define _LIBCPP_INTRODUCED_IN_LLVM_9_ATTRIBUTE                                                                     \
-      __attribute__((availability(macos, strict, introduced = 10.15)))                                                 \
-      __attribute__((availability(ios, strict, introduced = 13.0)))                                                    \
-      __attribute__((availability(tvos, strict, introduced = 13.0)))                                                   \
-      __attribute__((availability(watchos, strict, introduced = 6.0)))
-// clang-format off
-#    define _LIBCPP_INTRODUCED_IN_LLVM_9_ATTRIBUTE_PUSH                                                                               \
-      _Pragma("clang attribute push(__attribute__((availability(macos,strict,introduced=10.15))), apply_to=any(function,record))") \
-      _Pragma("clang attribute push(__attribute__((availability(ios,strict,introduced=13.0))), apply_to=any(function,record))")    \
-      _Pragma("clang attribute push(__attribute__((availability(tvos,strict,introduced=13.0))), apply_to=any(function,record))")   \
-      _Pragma("clang attribute push(__attribute__((availability(watchos,strict,introduced=6.0))), apply_to=any(function,record))")
-#    define _LIBCPP_INTRODUCED_IN_LLVM_9_ATTRIBUTE_POP                                                                    \
-      _Pragma("clang attribute pop") \
-      _Pragma("clang attribute pop") \
-      _Pragma("clang attribute pop") \
-      _Pragma("clang attribute pop")
-// clang-format on
-#  else
-#    define _LIBCPP_INTRODUCED_IN_LLVM_9 1
-#    define _LIBCPP_INTRODUCED_IN_LLVM_9_ATTRIBUTE      /* nothing */
-#    define _LIBCPP_INTRODUCED_IN_LLVM_9_ATTRIBUTE_PUSH /* nothing */
-#    define _LIBCPP_INTRODUCED_IN_LLVM_9_ATTRIBUTE_POP  /* nothing */
-#  endif
+// LLVM 19
+// TODO: Fill this in
+#  define _LIBCPP_INTRODUCED_IN_LLVM_19 0
+#  define _LIBCPP_INTRODUCED_IN_LLVM_19_ATTRIBUTE __attribute__((unavailable))
 
-// LLVM 11
-// clang-format off
-#  if (defined(__ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__) && __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ < 110000) ||   \
-      (defined(__ENVIRONMENT_IPHONE_OS_VERSION_MIN_REQUIRED__) && __ENVIRONMENT_IPHONE_OS_VERSION_MIN_REQUIRED__ < 140000) || \
-      (defined(__ENVIRONMENT_TV_OS_VERSION_MIN_REQUIRED__) && __ENVIRONMENT_TV_OS_VERSION_MIN_REQUIRED__ < 140000) ||         \
-      (defined(__ENVIRONMENT_WATCH_OS_VERSION_MIN_REQUIRED__) && __ENVIRONMENT_WATCH_OS_VERSION_MIN_REQUIRED__ < 70000)
-// clang-format on
-#    define _LIBCPP_INTRODUCED_IN_LLVM_11 0
-#    define _LIBCPP_INTRODUCED_IN_LLVM_11_ATTRIBUTE                                                                    \
-      __attribute__((availability(macos, strict, introduced = 11.0)))                                                  \
-      __attribute__((availability(ios, strict, introduced = 14.0)))                                                    \
-      __attribute__((availability(tvos, strict, introduced = 14.0)))                                                   \
-      __attribute__((availability(watchos, strict, introduced = 7.0)))
-#  else
-#    define _LIBCPP_INTRODUCED_IN_LLVM_11 1
-#    define _LIBCPP_INTRODUCED_IN_LLVM_11_ATTRIBUTE /* nothing */
-#  endif
+// LLVM 18
+// TODO: Fill this in
+#  define _LIBCPP_INTRODUCED_IN_LLVM_18 0
+#  define _LIBCPP_INTRODUCED_IN_LLVM_18_ATTRIBUTE __attribute__((unavailable))
 
-// LLVM 12
-// clang-format off
-#  if (defined(__ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__) && __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ < 120000)   || \
-      (defined(__ENVIRONMENT_IPHONE_OS_VERSION_MIN_REQUIRED__) && __ENVIRONMENT_IPHONE_OS_VERSION_MIN_REQUIRED__ < 150000) || \
-      (defined(__ENVIRONMENT_TV_OS_VERSION_MIN_REQUIRED__) && __ENVIRONMENT_TV_OS_VERSION_MIN_REQUIRED__ < 150000)         || \
-      (defined(__ENVIRONMENT_WATCH_OS_VERSION_MIN_REQUIRED__) && __ENVIRONMENT_WATCH_OS_VERSION_MIN_REQUIRED__ < 80000)
-// clang-format on
-#    define _LIBCPP_INTRODUCED_IN_LLVM_12 0
-#    define _LIBCPP_INTRODUCED_IN_LLVM_12_ATTRIBUTE                                                                    \
-      __attribute__((availability(macos, strict, introduced = 12.0)))                                                  \
-      __attribute__((availability(ios, strict, introduced = 15.0)))                                                    \
-      __attribute__((availability(tvos, strict, introduced = 15.0)))                                                   \
-      __attribute__((availability(watchos, strict, introduced = 8.0)))
+// LLVM 17
+#  if (defined(__ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__) && __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ < 140400) ||       \
+      (defined(__ENVIRONMENT_IPHONE_OS_VERSION_MIN_REQUIRED__) && __ENVIRONMENT_IPHONE_OS_VERSION_MIN_REQUIRED__ < 170400) ||     \
+      (defined(__ENVIRONMENT_TV_OS_VERSION_MIN_REQUIRED__) && __ENVIRONMENT_TV_OS_VERSION_MIN_REQUIRED__ < 170400) ||             \
+      (defined(__ENVIRONMENT_WATCH_OS_VERSION_MIN_REQUIRED__) && __ENVIRONMENT_WATCH_OS_VERSION_MIN_REQUIRED__ < 100400)
+#    define _LIBCPP_INTRODUCED_IN_LLVM_17 0
 #  else
-#    define _LIBCPP_INTRODUCED_IN_LLVM_12 1
-#    define _LIBCPP_INTRODUCED_IN_LLVM_12_ATTRIBUTE /* nothing */
+#    define _LIBCPP_INTRODUCED_IN_LLVM_17 1
 #  endif
+#  define _LIBCPP_INTRODUCED_IN_LLVM_17_ATTRIBUTE                                                                 \
+    __attribute__((availability(macos, strict, introduced = 14.4)))                                               \
+    __attribute__((availability(ios, strict, introduced = 17.4)))                                                 \
+    __attribute__((availability(tvos, strict, introduced = 17.4)))                                                \
+    __attribute__((availability(watchos, strict, introduced = 10.4)))
 
-// LLVM 14
-// clang-format off
+// LLVM 16
+#  if (defined(__ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__) && __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ < 140000) ||       \
+      (defined(__ENVIRONMENT_IPHONE_OS_VERSION_MIN_REQUIRED__) && __ENVIRONMENT_IPHONE_OS_VERSION_MIN_REQUIRED__ < 170000) ||     \
+      (defined(__ENVIRONMENT_TV_OS_VERSION_MIN_REQUIRED__) && __ENVIRONMENT_TV_OS_VERSION_MIN_REQUIRED__ < 170000) ||             \
+      (defined(__ENVIRONMENT_WATCH_OS_VERSION_MIN_REQUIRED__) && __ENVIRONMENT_WATCH_OS_VERSION_MIN_REQUIRED__ < 100000)
+#    define _LIBCPP_INTRODUCED_IN_LLVM_16 0
+#  else
+#    define _LIBCPP_INTRODUCED_IN_LLVM_16 1
+#  endif
+#  define _LIBCPP_INTRODUCED_IN_LLVM_16_ATTRIBUTE                                                                 \
+    __attribute__((availability(macos, strict, introduced = 14.0)))                                               \
+    __attribute__((availability(ios, strict, introduced = 17.0)))                                                 \
+    __attribute__((availability(tvos, strict, introduced = 17.0)))                                                \
+    __attribute__((availability(watchos, strict, introduced = 10.0)))
+
+// LLVM 15
 #  if (defined(__ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__) && __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ < 130400) ||   \
       (defined(__ENVIRONMENT_IPHONE_OS_VERSION_MIN_REQUIRED__) && __ENVIRONMENT_IPHONE_OS_VERSION_MIN_REQUIRED__ < 160500) || \
       (defined(__ENVIRONMENT_TV_OS_VERSION_MIN_REQUIRED__) && __ENVIRONMENT_TV_OS_VERSION_MIN_REQUIRED__ < 160500) ||         \
       (defined(__ENVIRONMENT_WATCH_OS_VERSION_MIN_REQUIRED__) && __ENVIRONMENT_WATCH_OS_VERSION_MIN_REQUIRED__ < 90500)
+#    define _LIBCPP_INTRODUCED_IN_LLVM_15 0
+#  else
+#    define _LIBCPP_INTRODUCED_IN_LLVM_15 1
+#  endif
+#  define _LIBCPP_INTRODUCED_IN_LLVM_15_ATTRIBUTE                                                                 \
+    __attribute__((availability(macos, strict, introduced = 13.4)))                                               \
+    __attribute__((availability(ios, strict, introduced = 16.5)))                                                 \
+    __attribute__((availability(tvos, strict, introduced = 16.5)))                                                \
+    __attribute__((availability(watchos, strict, introduced = 9.5)))
+
+// LLVM 14
+#  define _LIBCPP_INTRODUCED_IN_LLVM_14 _LIBCPP_INTRODUCED_IN_LLVM_15
+#  define _LIBCPP_INTRODUCED_IN_LLVM_14_ATTRIBUTE _LIBCPP_INTRODUCED_IN_LLVM_15_ATTRIBUTE
+
+// LLVM 13
+#  if (defined(__ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__) && __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ < 130000) ||   \
+      (defined(__ENVIRONMENT_IPHONE_OS_VERSION_MIN_REQUIRED__) && __ENVIRONMENT_IPHONE_OS_VERSION_MIN_REQUIRED__ < 160000) || \
+      (defined(__ENVIRONMENT_TV_OS_VERSION_MIN_REQUIRED__) && __ENVIRONMENT_TV_OS_VERSION_MIN_REQUIRED__ < 160000) ||         \
+      (defined(__ENVIRONMENT_WATCH_OS_VERSION_MIN_REQUIRED__) && __ENVIRONMENT_WATCH_OS_VERSION_MIN_REQUIRED__ < 90000)
+#    define _LIBCPP_INTRODUCED_IN_LLVM_13 0
+#  else
+#    define _LIBCPP_INTRODUCED_IN_LLVM_13 1
+#  endif
+#  define _LIBCPP_INTRODUCED_IN_LLVM_13_ATTRIBUTE                                                                 \
+    __attribute__((availability(macos, strict, introduced = 13.0)))                                               \
+    __attribute__((availability(ios, strict, introduced = 16.0)))                                                 \
+    __attribute__((availability(tvos, strict, introduced = 16.0)))                                                \
+    __attribute__((availability(watchos, strict, introduced = 9.0)))
+
+// LLVM 12
+#  if (defined(__ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__) && __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ < 120300)   ||     \
+      (defined(__ENVIRONMENT_IPHONE_OS_VERSION_MIN_REQUIRED__) && __ENVIRONMENT_IPHONE_OS_VERSION_MIN_REQUIRED__ < 150300) ||     \
+      (defined(__ENVIRONMENT_TV_OS_VERSION_MIN_REQUIRED__) && __ENVIRONMENT_TV_OS_VERSION_MIN_REQUIRED__ < 150300)         ||     \
+      (defined(__ENVIRONMENT_WATCH_OS_VERSION_MIN_REQUIRED__) && __ENVIRONMENT_WATCH_OS_VERSION_MIN_REQUIRED__ < 80300)
+#    define _LIBCPP_INTRODUCED_IN_LLVM_12 0
+#  else
+#    define _LIBCPP_INTRODUCED_IN_LLVM_12 1
+#  endif
+#  define _LIBCPP_INTRODUCED_IN_LLVM_12_ATTRIBUTE                                                                 \
+    __attribute__((availability(macos, strict, introduced = 12.3)))                                               \
+    __attribute__((availability(ios, strict, introduced = 15.3)))                                                 \
+    __attribute__((availability(tvos, strict, introduced = 15.3)))                                                \
+    __attribute__((availability(watchos, strict, introduced = 8.3)))
+
+// LLVM 11
+#  if (defined(__ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__) && __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ < 110000) ||   \
+      (defined(__ENVIRONMENT_IPHONE_OS_VERSION_MIN_REQUIRED__) && __ENVIRONMENT_IPHONE_OS_VERSION_MIN_REQUIRED__ < 140000) || \
+      (defined(__ENVIRONMENT_TV_OS_VERSION_MIN_REQUIRED__) && __ENVIRONMENT_TV_OS_VERSION_MIN_REQUIRED__ < 140000) ||         \
+      (defined(__ENVIRONMENT_WATCH_OS_VERSION_MIN_REQUIRED__) && __ENVIRONMENT_WATCH_OS_VERSION_MIN_REQUIRED__ < 70000)
+#    define _LIBCPP_INTRODUCED_IN_LLVM_11 0
+#  else
+#    define _LIBCPP_INTRODUCED_IN_LLVM_11 1
+#  endif
+#  define _LIBCPP_INTRODUCED_IN_LLVM_11_ATTRIBUTE                                                                 \
+    __attribute__((availability(macos, strict, introduced = 11.0)))                                               \
+    __attribute__((availability(ios, strict, introduced = 14.0)))                                                 \
+    __attribute__((availability(tvos, strict, introduced = 14.0)))                                                \
+    __attribute__((availability(watchos, strict, introduced = 7.0)))
+
+// LLVM 10
+#  define _LIBCPP_INTRODUCED_IN_LLVM_10 _LIBCPP_INTRODUCED_IN_LLVM_11
+#  define _LIBCPP_INTRODUCED_IN_LLVM_10_ATTRIBUTE _LIBCPP_INTRODUCED_IN_LLVM_11_ATTRIBUTE
+
+// LLVM 9
+#  if (defined(__ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__) && __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ < 101500) ||   \
+      (defined(__ENVIRONMENT_IPHONE_OS_VERSION_MIN_REQUIRED__) && __ENVIRONMENT_IPHONE_OS_VERSION_MIN_REQUIRED__ < 130000) || \
+      (defined(__ENVIRONMENT_TV_OS_VERSION_MIN_REQUIRED__) && __ENVIRONMENT_TV_OS_VERSION_MIN_REQUIRED__ < 130000) ||         \
+      (defined(__ENVIRONMENT_WATCH_OS_VERSION_MIN_REQUIRED__) && __ENVIRONMENT_WATCH_OS_VERSION_MIN_REQUIRED__ < 60000)
+#    define _LIBCPP_INTRODUCED_IN_LLVM_9 0
+#  else
+#    define _LIBCPP_INTRODUCED_IN_LLVM_9 1
+#  endif
+#  define _LIBCPP_INTRODUCED_IN_LLVM_9_ATTRIBUTE                                                                  \
+    __attribute__((availability(macos, strict, introduced = 10.15)))                                              \
+    __attribute__((availability(ios, strict, introduced = 13.0)))                                                 \
+    __attribute__((availability(tvos, strict, introduced = 13.0)))                                                \
+    __attribute__((availability(watchos, strict, introduced = 6.0)))
+#  define _LIBCPP_INTRODUCED_IN_LLVM_9_ATTRIBUTE_PUSH                                                                            \
+    _Pragma("clang attribute push(__attribute__((availability(macos,strict,introduced=10.15))), apply_to=any(function,record))") \
+    _Pragma("clang attribute push(__attribute__((availability(ios,strict,introduced=13.0))), apply_to=any(function,record))")    \
+    _Pragma("clang attribute push(__attribute__((availability(tvos,strict,introduced=13.0))), apply_to=any(function,record))")   \
+    _Pragma("clang attribute push(__attribute__((availability(watchos,strict,introduced=6.0))), apply_to=any(function,record))")
+#  define _LIBCPP_INTRODUCED_IN_LLVM_9_ATTRIBUTE_POP                                                                    \
+    _Pragma("clang attribute pop") \
+    _Pragma("clang attribute pop") \
+    _Pragma("clang attribute pop") \
+    _Pragma("clang attribute pop")
+
+// LLVM 4
+#  if defined(__ENVIRONMENT_WATCH_OS_VERSION_MIN_REQUIRED__) && __ENVIRONMENT_WATCH_OS_VERSION_MIN_REQUIRED__ < 50000
+#    define _LIBCPP_INTRODUCED_IN_LLVM_4 0
+#  else
+#    define _LIBCPP_INTRODUCED_IN_LLVM_4 1
+#  endif
+#  define _LIBCPP_INTRODUCED_IN_LLVM_4_ATTRIBUTE __attribute__((availability(watchos, strict, introduced = 5.0)))
+
 // clang-format on
-#    define _LIBCPP_INTRODUCED_IN_LLVM_14 0
-#    define _LIBCPP_INTRODUCED_IN_LLVM_14_ATTRIBUTE                                                                    \
-      __attribute__((availability(macos, strict, introduced = 13.4)))                                                  \
-      __attribute__((availability(ios, strict, introduced = 16.5)))                                                    \
-      __attribute__((availability(tvos, strict, introduced = 16.5)))                                                   \
-      __attribute__((availability(watchos, strict, introduced = 9.5)))
-#  else
-#    define _LIBCPP_INTRODUCED_IN_LLVM_14 1
-#    define _LIBCPP_INTRODUCED_IN_LLVM_14_ATTRIBUTE /* nothing */
-#  endif
-
-// LLVM 15-16
-#  define _LIBCPP_INTRODUCED_IN_LLVM_15 _LIBCPP_INTRODUCED_IN_LLVM_16
-#  define _LIBCPP_INTRODUCED_IN_LLVM_15_ATTRIBUTE _LIBCPP_INTRODUCED_IN_LLVM_16_ATTRIBUTE
-// clang-format off
-#  if (defined(__ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__) && __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ < 140000) ||   \
-      (defined(__ENVIRONMENT_IPHONE_OS_VERSION_MIN_REQUIRED__) && __ENVIRONMENT_IPHONE_OS_VERSION_MIN_REQUIRED__ < 170000) || \
-      (defined(__ENVIRONMENT_TV_OS_VERSION_MIN_REQUIRED__) && __ENVIRONMENT_TV_OS_VERSION_MIN_REQUIRED__ < 170000) ||         \
-      (defined(__ENVIRONMENT_WATCH_OS_VERSION_MIN_REQUIRED__) && __ENVIRONMENT_WATCH_OS_VERSION_MIN_REQUIRED__ < 100000)
-// clang-format on
-#    define _LIBCPP_INTRODUCED_IN_LLVM_16 0
-#    define _LIBCPP_INTRODUCED_IN_LLVM_16_ATTRIBUTE                                                                    \
-      __attribute__((availability(macos, strict, introduced = 14.0)))                                                  \
-      __attribute__((availability(ios, strict, introduced = 17.0)))                                                    \
-      __attribute__((availability(tvos, strict, introduced = 17.0)))                                                   \
-      __attribute__((availability(watchos, strict, introduced = 10.0)))
-#  else
-#    define _LIBCPP_INTRODUCED_IN_LLVM_16 1
-#    define _LIBCPP_INTRODUCED_IN_LLVM_16_ATTRIBUTE /* nothing */
-#  endif
-
-// LLVM 18
-// TODO: Fill this in
-#  if 1
-#    define _LIBCPP_INTRODUCED_IN_LLVM_18 0
-#    define _LIBCPP_INTRODUCED_IN_LLVM_18_ATTRIBUTE __attribute__((unavailable))
-#  else
-#    define _LIBCPP_INTRODUCED_IN_LLVM_18 1
-#    define _LIBCPP_INTRODUCED_IN_LLVM_18_ATTRIBUTE /* nothing */
-#  endif
-
-// LLVM 19
-// TODO: Fill this in
-#  if 1
-#    define _LIBCPP_INTRODUCED_IN_LLVM_19 0
-#    define _LIBCPP_INTRODUCED_IN_LLVM_19_ATTRIBUTE __attribute__((unavailable))
-#  else
-#    define _LIBCPP_INTRODUCED_IN_LLVM_19 1
-#    define _LIBCPP_INTRODUCED_IN_LLVM_19_ATTRIBUTE /* nothing */
-#  endif
 
 #else
 

--- a/libcxx/test/libcxx/strings/basic.string/string.capacity/PR53170.pass.cpp
+++ b/libcxx/test/libcxx/strings/basic.string/string.capacity/PR53170.pass.cpp
@@ -21,8 +21,8 @@
 //
 // Reported as https://llvm.org/PR53170.
 
-// reserve(n) used to shrink the string until https://llvm.org/D117332 was shipped.
-// XFAIL: stdlib=system && target={{.+}}-apple-macosx{{10.9|10.10|10.11|10.12|10.13|10.14|10.15|11.0|12.0}}
+// reserve(n) used to shrink the string until https://llvm.org/D117332 was shipped in LLVM 14.
+// XFAIL: using-built-library-before-llvm-14
 
 #include <string>
 #include <stdexcept>

--- a/libcxx/test/libcxx/strings/basic.string/string.capacity/allocation_size.pass.cpp
+++ b/libcxx/test/libcxx/strings/basic.string/string.capacity/allocation_size.pass.cpp
@@ -6,12 +6,13 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: stdlib=system && target={{.+}}-apple-macosx{{10.13|10.14|10.15|11.0}}
-
 // <string>
 
 // This test demonstrates the smaller allocation sizes when the alignment
 // requirements of std::string are dropped from 16 to 8.
+//
+// XFAIL: using-built-library-before-llvm-19
+
 #include <algorithm>
 #include <cassert>
 #include <cstddef>

--- a/libcxx/test/libcxx/thread/thread.condition/PR30202_notify_from_pthread_created_thread.pass.cpp
+++ b/libcxx/test/libcxx/thread/thread.condition/PR30202_notify_from_pthread_created_thread.pass.cpp
@@ -13,9 +13,6 @@
 // unique_lock.
 // UNSUPPORTED: c++03
 
-// PR30202 was fixed starting in macosx10.13.
-// XFAIL: stdlib=system && target={{.+}}-apple-macosx10.{{9|10|11|12}}
-
 // <condition_variable>
 
 // void notify_all_at_thread_exit(condition_variable& cond, unique_lock<mutex> lk);

--- a/libcxx/test/libcxx/thread/thread.threads/thread.thread.this/sleep_for.pass.cpp
+++ b/libcxx/test/libcxx/thread/thread.threads/thread.thread.this/sleep_for.pass.cpp
@@ -8,11 +8,6 @@
 
 // UNSUPPORTED: no-threads
 
-// Until 58a0a70fb2f1, this_thread::sleep_for could sometimes get interrupted
-// by signals and this test would fail spuriously. Disable the test on the
-// corresponding system libraries.
-// XFAIL: stdlib=system && target={{.+}}-apple-macosx10.{{9|10|11}}
-
 // ALLOW_RETRIES: 3
 
 // <thread>

--- a/libcxx/test/libcxx/thread/thread.threads/thread.thread.this/sleep_for.signals.pass.cpp
+++ b/libcxx/test/libcxx/thread/thread.threads/thread.thread.this/sleep_for.signals.pass.cpp
@@ -11,11 +11,6 @@
 // This test uses the POSIX header <sys/time.h> which Windows doesn't provide
 // UNSUPPORTED: windows
 
-// Until 58a0a70fb2f1, this_thread::sleep_for misbehaves when interrupted by
-// a signal, as tested here. Disable the test on the corresponding system
-// libraries.
-// XFAIL: stdlib=system && target={{.+}}-apple-macosx10.{{9|10|11}}
-
 // ALLOW_RETRIES: 3
 
 // <thread>

--- a/libcxx/test/std/depr/depr.c.headers/stdlib_h.aligned_alloc.compile.pass.cpp
+++ b/libcxx/test/std/depr/depr.c.headers/stdlib_h.aligned_alloc.compile.pass.cpp
@@ -13,7 +13,7 @@
 
 // ::aligned_alloc is provided by the C library, but it's marked as unavailable
 // until macOS 10.15
-// XFAIL: stdlib=system && target={{.+}}-apple-macosx10.{{9|10|11|12|13|14}}
+// XFAIL: target={{.+}}-apple-macosx10.{{(13|14)(.0)?}}
 
 // ::aligned_alloc is not implemented on Windows
 // XFAIL: target={{.+}}-windows-{{.+}}

--- a/libcxx/test/std/diagnostics/syserr/syserr.errcat/syserr.errcat.objects/generic_category.pass.cpp
+++ b/libcxx/test/std/diagnostics/syserr/syserr.errcat/syserr.errcat.objects/generic_category.pass.cpp
@@ -6,8 +6,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: stdlib=system && target={{.+}}-apple-macosx10.{{9|10|11|12}}
-
 // <system_error>
 
 // class error_category

--- a/libcxx/test/std/diagnostics/syserr/syserr.errcat/syserr.errcat.objects/system_category.pass.cpp
+++ b/libcxx/test/std/diagnostics/syserr/syserr.errcat/syserr.errcat.objects/system_category.pass.cpp
@@ -12,8 +12,6 @@
 
 // const error_category& system_category();
 
-// XFAIL: stdlib=system && target={{.+}}-apple-macosx10.{{9|10|11|12}}
-
 #include <system_error>
 #include <cassert>
 #include <string>

--- a/libcxx/test/std/input.output/filesystems/class.directory_entry/directory_entry.mods/refresh.pass.cpp
+++ b/libcxx/test/std/input.output/filesystems/class.directory_entry/directory_entry.mods/refresh.pass.cpp
@@ -10,8 +10,8 @@
 // UNSUPPORTED: c++03, c++11, c++14
 
 // The string reported on errors changed, which makes those tests fail when run
-// against already-released libc++'s.
-// XFAIL: stdlib=system && target={{.+}}-apple-macosx{{10.15|11.0}}
+// against a built library that doesn't contain 0aa637b2037d.
+// XFAIL: using-built-library-before-llvm-13
 
 // <filesystem>
 

--- a/libcxx/test/std/input.output/filesystems/class.directory_entry/directory_entry.obs/file_size.pass.cpp
+++ b/libcxx/test/std/input.output/filesystems/class.directory_entry/directory_entry.obs/file_size.pass.cpp
@@ -10,8 +10,8 @@
 // UNSUPPORTED: c++03, c++11, c++14
 
 // The string reported on errors changed, which makes those tests fail when run
-// against already-released libc++'s.
-// XFAIL: stdlib=system && target={{.+}}-apple-macosx{{10.15|11.0}}
+// against a built library that doesn't contain 0aa637b2037d.
+// XFAIL: using-built-library-before-llvm-13
 
 // Starting in Android N (API 24), SELinux policy prevents the shell user from
 // creating a FIFO file.

--- a/libcxx/test/std/input.output/filesystems/class.directory_entry/directory_entry.obs/hard_link_count.pass.cpp
+++ b/libcxx/test/std/input.output/filesystems/class.directory_entry/directory_entry.obs/hard_link_count.pass.cpp
@@ -10,8 +10,8 @@
 // UNSUPPORTED: c++03, c++11, c++14
 
 // The string reported on errors changed, which makes those tests fail when run
-// against already-released libc++'s.
-// XFAIL: stdlib=system && target={{.+}}-apple-macosx{{10.15|11.0}}
+// against a built library that doesn't contain 0aa637b2037d.
+// XFAIL: using-built-library-before-llvm-13
 
 // Starting in Android N (API 24), SELinux policy prevents the shell user from
 // creating a hard link.

--- a/libcxx/test/std/input.output/filesystems/class.directory_entry/directory_entry.obs/last_write_time.pass.cpp
+++ b/libcxx/test/std/input.output/filesystems/class.directory_entry/directory_entry.obs/last_write_time.pass.cpp
@@ -10,8 +10,8 @@
 // UNSUPPORTED: c++03, c++11, c++14
 
 // The string reported on errors changed, which makes those tests fail when run
-// against already-released libc++'s.
-// XFAIL: stdlib=system && target={{.+}}-apple-macosx{{10.15|11.0}}
+// against a built library that doesn't contain 0aa637b2037d.
+// XFAIL: using-built-library-before-llvm-13
 
 // <filesystem>
 

--- a/libcxx/test/std/input.output/filesystems/fs.op.funcs/fs.op.copy_file/copy_file.pass.cpp
+++ b/libcxx/test/std/input.output/filesystems/fs.op.funcs/fs.op.copy_file/copy_file.pass.cpp
@@ -11,8 +11,8 @@
 // UNSUPPORTED: availability-filesystem-missing
 
 // The string reported on errors changed, which makes those tests fail when run
-// against already-released libc++'s.
-// XFAIL: stdlib=system && target={{.+}}-apple-macosx{{10.15|11.0}}
+// against a built library that doesn't contain 0aa637b2037d.
+// XFAIL: using-built-library-before-llvm-13
 
 // Starting in Android N (API 24), SELinux policy prevents the shell user from
 // creating a FIFO file.

--- a/libcxx/test/std/input.output/filesystems/fs.op.funcs/fs.op.create_directories/create_directories.pass.cpp
+++ b/libcxx/test/std/input.output/filesystems/fs.op.funcs/fs.op.create_directories/create_directories.pass.cpp
@@ -11,8 +11,8 @@
 // UNSUPPORTED: no-filesystem
 // UNSUPPORTED: availability-filesystem-missing
 
-// This test requires the dylib support introduced in D92769.
-// XFAIL: stdlib=system && target={{.+}}-apple-macosx{{10.15|11.0}}
+// This test requires the dylib support introduced in e4ed349c7658.
+// XFAIL: using-built-library-before-llvm-12
 
 // <filesystem>
 

--- a/libcxx/test/std/input.output/filesystems/fs.op.funcs/fs.op.create_directory/create_directory.pass.cpp
+++ b/libcxx/test/std/input.output/filesystems/fs.op.funcs/fs.op.create_directory/create_directory.pass.cpp
@@ -11,8 +11,8 @@
 // UNSUPPORTED: no-filesystem
 // UNSUPPORTED: availability-filesystem-missing
 
-// This test requires the dylib support introduced in http://llvm.org/D92769.
-// XFAIL: stdlib=system && target={{.+}}-apple-macosx{{10.15|11.0}}
+// This test requires the dylib support introduced in e4ed349c7658.
+// XFAIL: using-built-library-before-llvm-12
 
 // <filesystem>
 

--- a/libcxx/test/std/input.output/filesystems/fs.op.funcs/fs.op.create_directory/create_directory_with_attributes.pass.cpp
+++ b/libcxx/test/std/input.output/filesystems/fs.op.funcs/fs.op.create_directory/create_directory_with_attributes.pass.cpp
@@ -11,8 +11,8 @@
 // UNSUPPORTED: no-filesystem
 // UNSUPPORTED: availability-filesystem-missing
 
-// This test requires the dylib support introduced in http://llvm.org/D92769.
-// XFAIL: stdlib=system && target={{.+}}-apple-macosx{{10.15|11.0}}
+// This test requires the dylib support introduced in e4ed349c7658.
+// XFAIL: using-built-library-before-llvm-12
 
 // <filesystem>
 

--- a/libcxx/test/std/input.output/filesystems/fs.op.funcs/fs.op.file_size/file_size.pass.cpp
+++ b/libcxx/test/std/input.output/filesystems/fs.op.funcs/fs.op.file_size/file_size.pass.cpp
@@ -12,8 +12,8 @@
 // UNSUPPORTED: availability-filesystem-missing
 
 // The string reported on errors changed, which makes those tests fail when run
-// against already-released libc++'s.
-// XFAIL: stdlib=system && target={{.+}}-apple-macosx{{10.15|11.0}}
+// against a built library that doesn't contain 0aa637b2037d.
+// XFAIL: using-built-library-before-llvm-13
 
 // <filesystem>
 

--- a/libcxx/test/std/input.output/filesystems/fs.op.funcs/fs.op.last_write_time/last_write_time.pass.cpp
+++ b/libcxx/test/std/input.output/filesystems/fs.op.funcs/fs.op.last_write_time/last_write_time.pass.cpp
@@ -12,8 +12,8 @@
 // UNSUPPORTED: availability-filesystem-missing
 
 // The string reported on errors changed, which makes those tests fail when run
-// against already-released libc++'s.
-// XFAIL: stdlib=system && target={{.+}}-apple-macosx{{10.15|11.0}}
+// against a built library that doesn't contain 0aa637b2037d.
+// XFAIL: using-built-library-before-llvm-13
 
 // <filesystem>
 

--- a/libcxx/test/std/input.output/filesystems/fs.op.funcs/fs.op.remove_all/toctou.pass.cpp
+++ b/libcxx/test/std/input.output/filesystems/fs.op.funcs/fs.op.remove_all/toctou.pass.cpp
@@ -29,11 +29,9 @@
 //
 // This is taken from https://github.com/rust-lang/wg-security-response/blob/master/patches/CVE-2022-21658/0002-Fix-CVE-2022-21658-for-UNIX-like.patch
 
-// This test requires a dylib containing the fix shipped in https://reviews.llvm.org/D118134.
+// This test requires a dylib containing the fix shipped in https://reviews.llvm.org/D118134 (4f67a909902d).
 // We use UNSUPPORTED instead of XFAIL because the test might not fail reliably.
-// UNSUPPORTED: stdlib=system && target={{.+}}-apple-macosx10.{{9|10|11|12|13|14|15}}
-// UNSUPPORTED: stdlib=system && target={{.+}}-apple-macosx11.0
-// UNSUPPORTED: stdlib=system && target={{.+}}-apple-macosx12.{{0|1|2}}
+// UNSUPPORTED: using-built-library-before-llvm-14
 
 // Windows doesn't support the necessary APIs to mitigate this issue.
 // XFAIL: target={{.+}}-windows-{{.+}}

--- a/libcxx/test/std/input.output/iostream.format/input.streams/istream.formatted/istream.formatted.arithmetic/bool.pass.cpp
+++ b/libcxx/test/std/input.output/iostream.format/input.streams/istream.formatted/istream.formatted.arithmetic/bool.pass.cpp
@@ -6,7 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: stdlib=system && target={{.+}}-apple-macosx10.{{9|10|11|12|13|14}}
+// Requires 396145d in the built library.
+// XFAIL: using-built-library-before-llvm-9
 
 // <istream>
 

--- a/libcxx/test/std/input.output/iostream.format/input.streams/istream.formatted/istream.formatted.arithmetic/double.pass.cpp
+++ b/libcxx/test/std/input.output/iostream.format/input.streams/istream.formatted/istream.formatted.arithmetic/double.pass.cpp
@@ -6,7 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: stdlib=system && target={{.+}}-apple-macosx10.{{9|10|11|12|13|14}}
+// Requires 396145d in the built library.
+// XFAIL: using-built-library-before-llvm-9
 
 // <istream>
 

--- a/libcxx/test/std/input.output/iostream.format/input.streams/istream.formatted/istream.formatted.arithmetic/float.pass.cpp
+++ b/libcxx/test/std/input.output/iostream.format/input.streams/istream.formatted/istream.formatted.arithmetic/float.pass.cpp
@@ -6,7 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: stdlib=system && target={{.+}}-apple-macosx10.{{9|10|11|12|13|14}}
+// Requires 396145d in the built library.
+// XFAIL: using-built-library-before-llvm-9
 
 // <istream>
 

--- a/libcxx/test/std/input.output/iostream.format/input.streams/istream.formatted/istream.formatted.arithmetic/int.pass.cpp
+++ b/libcxx/test/std/input.output/iostream.format/input.streams/istream.formatted/istream.formatted.arithmetic/int.pass.cpp
@@ -6,7 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: stdlib=system && target={{.+}}-apple-macosx10.{{9|10|11|12|13|14}}
+// Requires 396145d in the built library.
+// XFAIL: using-built-library-before-llvm-9
 
 // <istream>
 

--- a/libcxx/test/std/input.output/iostream.format/input.streams/istream.formatted/istream.formatted.arithmetic/long.pass.cpp
+++ b/libcxx/test/std/input.output/iostream.format/input.streams/istream.formatted/istream.formatted.arithmetic/long.pass.cpp
@@ -6,7 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: stdlib=system && target={{.+}}-apple-macosx10.{{9|10|11|12|13|14}}
+// Requires 396145d in the built library.
+// XFAIL: using-built-library-before-llvm-9
 
 // <istream>
 

--- a/libcxx/test/std/input.output/iostream.format/input.streams/istream.formatted/istream.formatted.arithmetic/long_double.pass.cpp
+++ b/libcxx/test/std/input.output/iostream.format/input.streams/istream.formatted/istream.formatted.arithmetic/long_double.pass.cpp
@@ -6,7 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: stdlib=system && target={{.+}}-apple-macosx10.{{9|10|11|12|13|14}}
+// Requires 396145d in the built library.
+// XFAIL: using-built-library-before-llvm-9
 
 // <istream>
 

--- a/libcxx/test/std/input.output/iostream.format/input.streams/istream.formatted/istream.formatted.arithmetic/long_long.pass.cpp
+++ b/libcxx/test/std/input.output/iostream.format/input.streams/istream.formatted/istream.formatted.arithmetic/long_long.pass.cpp
@@ -6,7 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: stdlib=system && target={{.+}}-apple-macosx10.{{9|10|11|12|13|14}}
+// Requires 396145d in the built library.
+// XFAIL: using-built-library-before-llvm-9
 
 // <istream>
 

--- a/libcxx/test/std/input.output/iostream.format/input.streams/istream.formatted/istream.formatted.arithmetic/pointer.pass.cpp
+++ b/libcxx/test/std/input.output/iostream.format/input.streams/istream.formatted/istream.formatted.arithmetic/pointer.pass.cpp
@@ -6,7 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: stdlib=system && target={{.+}}-apple-macosx10.{{9|10|11|12|13|14}}
+// Requires 396145d in the built library.
+// XFAIL: using-built-library-before-llvm-9
 
 // <istream>
 

--- a/libcxx/test/std/input.output/iostream.format/input.streams/istream.formatted/istream.formatted.arithmetic/short.pass.cpp
+++ b/libcxx/test/std/input.output/iostream.format/input.streams/istream.formatted/istream.formatted.arithmetic/short.pass.cpp
@@ -6,7 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: stdlib=system && target={{.+}}-apple-macosx10.{{9|10|11|12|13|14}}
+// Requires 396145d in the built library.
+// XFAIL: using-built-library-before-llvm-9
 
 // <istream>
 

--- a/libcxx/test/std/input.output/iostream.format/input.streams/istream.formatted/istream.formatted.arithmetic/unsigned_int.pass.cpp
+++ b/libcxx/test/std/input.output/iostream.format/input.streams/istream.formatted/istream.formatted.arithmetic/unsigned_int.pass.cpp
@@ -6,7 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: stdlib=system && target={{.+}}-apple-macosx10.{{9|10|11|12|13|14}}
+// Requires 396145d in the built library.
+// XFAIL: using-built-library-before-llvm-9
 
 // <istream>
 

--- a/libcxx/test/std/input.output/iostream.format/input.streams/istream.formatted/istream.formatted.arithmetic/unsigned_long.pass.cpp
+++ b/libcxx/test/std/input.output/iostream.format/input.streams/istream.formatted/istream.formatted.arithmetic/unsigned_long.pass.cpp
@@ -6,7 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: stdlib=system && target={{.+}}-apple-macosx10.{{9|10|11|12|13|14}}
+// Requires 396145d in the built library.
+// XFAIL: using-built-library-before-llvm-9
 
 // <istream>
 

--- a/libcxx/test/std/input.output/iostream.format/input.streams/istream.formatted/istream.formatted.arithmetic/unsigned_long_long.pass.cpp
+++ b/libcxx/test/std/input.output/iostream.format/input.streams/istream.formatted/istream.formatted.arithmetic/unsigned_long_long.pass.cpp
@@ -6,7 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: stdlib=system && target={{.+}}-apple-macosx10.{{9|10|11|12|13|14}}
+// Requires 396145d in the built library.
+// XFAIL: using-built-library-before-llvm-9
 
 // <istream>
 

--- a/libcxx/test/std/input.output/iostream.format/input.streams/istream.formatted/istream.formatted.arithmetic/unsigned_short.pass.cpp
+++ b/libcxx/test/std/input.output/iostream.format/input.streams/istream.formatted/istream.formatted.arithmetic/unsigned_short.pass.cpp
@@ -6,7 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: stdlib=system && target={{.+}}-apple-macosx10.{{9|10|11|12|13|14}}
+// Requires 396145d in the built library.
+// XFAIL: using-built-library-before-llvm-9
 
 // <istream>
 

--- a/libcxx/test/std/input.output/iostream.format/input.streams/istream.formatted/istream_extractors/streambuf.pass.cpp
+++ b/libcxx/test/std/input.output/iostream.format/input.streams/istream.formatted/istream_extractors/streambuf.pass.cpp
@@ -6,7 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: stdlib=system && target={{.+}}-apple-macosx10.{{9|10|11|12|13|14}}
+// Requires 396145d in the built library.
+// XFAIL: using-built-library-before-llvm-9
 
 // <istream>
 

--- a/libcxx/test/std/input.output/iostream.format/input.streams/istream.unformatted/get.pass.cpp
+++ b/libcxx/test/std/input.output/iostream.format/input.streams/istream.unformatted/get.pass.cpp
@@ -6,7 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: stdlib=system && target={{.+}}-apple-macosx10.{{9|10|11|12|13|14}}
+// Requires 396145d in the built library.
+// XFAIL: using-built-library-before-llvm-9
 
 // <istream>
 

--- a/libcxx/test/std/input.output/iostream.format/input.streams/istream.unformatted/get_chart.pass.cpp
+++ b/libcxx/test/std/input.output/iostream.format/input.streams/istream.unformatted/get_chart.pass.cpp
@@ -6,7 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: stdlib=system && target={{.+}}-apple-macosx10.{{9|10|11|12|13|14}}
+// Requires 396145d in the built library.
+// XFAIL: using-built-library-before-llvm-9
 
 // <istream>
 

--- a/libcxx/test/std/input.output/iostream.format/input.streams/istream.unformatted/get_pointer_size.pass.cpp
+++ b/libcxx/test/std/input.output/iostream.format/input.streams/istream.unformatted/get_pointer_size.pass.cpp
@@ -8,7 +8,8 @@
 
 // In macosx10.9 to macosx10.14, streams are provided in the dylib AND they
 // have a bug in how they handle null-termination in case of errors (see D40677).
-// XFAIL: stdlib=system && target={{.+}}-apple-macosx10.{{9|10|11|12|13|14}}
+// Requires 396145d in the built library.
+// XFAIL: using-built-library-before-llvm-9
 
 // <istream>
 

--- a/libcxx/test/std/input.output/iostream.format/input.streams/istream.unformatted/get_pointer_size_chart.pass.cpp
+++ b/libcxx/test/std/input.output/iostream.format/input.streams/istream.unformatted/get_pointer_size_chart.pass.cpp
@@ -8,7 +8,8 @@
 
 // In macosx10.9 to macosx10.14, streams are provided in the dylib AND they
 // have a bug in how they handle null-termination in case of errors (see D40677).
-// XFAIL: stdlib=system && target={{.+}}-apple-macosx10.{{9|10|11|12|13|14}}
+// Requires 396145d in the built library.
+// XFAIL: using-built-library-before-llvm-9
 
 // <istream>
 

--- a/libcxx/test/std/input.output/iostream.format/input.streams/istream.unformatted/get_streambuf.pass.cpp
+++ b/libcxx/test/std/input.output/iostream.format/input.streams/istream.unformatted/get_streambuf.pass.cpp
@@ -6,7 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: stdlib=system && target={{.+}}-apple-macosx10.{{9|10|11|12|13|14}}
+// Requires 396145d in the built library.
+// XFAIL: using-built-library-before-llvm-9
 
 // <istream>
 

--- a/libcxx/test/std/input.output/iostream.format/input.streams/istream.unformatted/get_streambuf_chart.pass.cpp
+++ b/libcxx/test/std/input.output/iostream.format/input.streams/istream.unformatted/get_streambuf_chart.pass.cpp
@@ -6,7 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: stdlib=system && target={{.+}}-apple-macosx10.{{9|10|11|12|13|14}}
+// Requires 396145d in the built library.
+// XFAIL: using-built-library-before-llvm-9
 
 // <istream>
 

--- a/libcxx/test/std/input.output/iostream.format/input.streams/istream.unformatted/getline_pointer_size.pass.cpp
+++ b/libcxx/test/std/input.output/iostream.format/input.streams/istream.unformatted/getline_pointer_size.pass.cpp
@@ -8,7 +8,8 @@
 
 // In macosx10.9 to macosx10.14, streams are provided in the dylib AND they
 // have a bug in how they handle null-termination in case of errors (see D40677).
-// XFAIL: stdlib=system && target={{.+}}-apple-macosx10.{{9|10|11|12|13|14}}
+// Requires 396145d in the built library.
+// XFAIL: using-built-library-before-llvm-9
 
 // <istream>
 

--- a/libcxx/test/std/input.output/iostream.format/input.streams/istream.unformatted/getline_pointer_size_chart.pass.cpp
+++ b/libcxx/test/std/input.output/iostream.format/input.streams/istream.unformatted/getline_pointer_size_chart.pass.cpp
@@ -8,7 +8,8 @@
 
 // In macosx10.9 to macosx10.14, streams are provided in the dylib AND they
 // have a bug in how they handle null-termination in case of errors (see D40677).
-// XFAIL: stdlib=system && target={{.+}}-apple-macosx10.{{9|10|11|12|13|14}}
+// Requires 396145d in the built library.
+// XFAIL: using-built-library-before-llvm-9
 
 // <istream>
 

--- a/libcxx/test/std/input.output/iostream.format/input.streams/istream.unformatted/ignore.pass.cpp
+++ b/libcxx/test/std/input.output/iostream.format/input.streams/istream.unformatted/ignore.pass.cpp
@@ -6,7 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: stdlib=system && target={{.+}}-apple-macosx10.{{9|10|11|12|13|14}}
+// Requires 396145d in the built library.
+// XFAIL: using-built-library-before-llvm-9
 
 // <istream>
 

--- a/libcxx/test/std/input.output/iostream.format/input.streams/istream.unformatted/peek.pass.cpp
+++ b/libcxx/test/std/input.output/iostream.format/input.streams/istream.unformatted/peek.pass.cpp
@@ -6,7 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: stdlib=system && target={{.+}}-apple-macosx10.{{9|10|11|12|13|14}}
+// Requires 396145d in the built library.
+// XFAIL: using-built-library-before-llvm-9
 
 // <istream>
 

--- a/libcxx/test/std/input.output/iostream.format/input.streams/istream.unformatted/read.pass.cpp
+++ b/libcxx/test/std/input.output/iostream.format/input.streams/istream.unformatted/read.pass.cpp
@@ -6,7 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: stdlib=system && target={{.+}}-apple-macosx10.{{9|10|11|12|13|14}}
+// Requires 396145d in the built library.
+// XFAIL: using-built-library-before-llvm-9
 
 // <istream>
 

--- a/libcxx/test/std/input.output/iostream.format/input.streams/istream.unformatted/seekg_off.pass.cpp
+++ b/libcxx/test/std/input.output/iostream.format/input.streams/istream.unformatted/seekg_off.pass.cpp
@@ -6,8 +6,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: stdlib=system && target={{.+}}-apple-macosx10.{{9|10|11}}
-
 // <istream>
 
 // basic_istream<charT,traits>& seekg(off_type off, ios_base::seekdir dir);

--- a/libcxx/test/std/input.output/iostream.format/output.streams/ostream.formatted/ostream.inserters.arithmetic/minmax_showbase.pass.cpp
+++ b/libcxx/test/std/input.output/iostream.format/output.streams/ostream.formatted/ostream.inserters.arithmetic/minmax_showbase.pass.cpp
@@ -25,7 +25,7 @@
 
 // This test exposes a regression that was not fixed yet in the libc++
 // shipped with macOS 10.12, 10.13 and 10.14. See D32670 for details.
-// XFAIL: stdlib=system && target={{.+}}-apple-macosx10.{{12|13|14}}
+// XFAIL: stdlib=system && target={{.+}}-apple-macosx10.{{(13|14)(.0)?}}
 
 #include <cassert>
 #include <cstdint>

--- a/libcxx/test/std/input.output/iostream.format/output.streams/ostream.formatted/ostream.inserters.arithmetic/minus1.pass.cpp
+++ b/libcxx/test/std/input.output/iostream.format/output.streams/ostream.formatted/ostream.inserters.arithmetic/minus1.pass.cpp
@@ -6,8 +6,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: stdlib=system && target={{.+}}-apple-macosx10.12
-
 // <ostream>
 
 // template <class charT, class traits = char_traits<charT> >

--- a/libcxx/test/std/input.output/iostreams.base/ios.base/ios.types/ios_Init/ios_Init.multiple.pass.cpp
+++ b/libcxx/test/std/input.output/iostreams.base/ios.base/ios.types/ios_Init/ios_Init.multiple.pass.cpp
@@ -14,9 +14,8 @@
 // Test to make sure that the streams only get initialized once
 // Taken from https://llvm.org/PR43300
 
-// The dylibs shipped on macOS so far do not contain the fix for PR43300, so
-// this test fails.
-// XFAIL: stdlib=system && target={{.+}}-apple-macosx10.{{9|10|11|12|13|14}}
+// This test requires the fix for PR43300 (7b81a13bfcd1).
+// XFAIL: using-built-library-before-llvm-9
 
 int main(int, char**)
 {

--- a/libcxx/test/std/language.support/support.dynamic/new.delete/new.delete.array/sized_delete_array_fsizeddeallocation.pass.cpp
+++ b/libcxx/test/std/language.support/support.dynamic/new.delete/new.delete.array/sized_delete_array_fsizeddeallocation.pass.cpp
@@ -12,7 +12,6 @@
 // when sized deallocation is not supported, e.g., prior to C++14.
 
 // UNSUPPORTED: sanitizer-new-delete
-// XFAIL: stdlib=system && target={{.+}}-apple-macosx10.{{9|10|11}}
 
 // REQUIRES: -fsized-deallocation
 // ADDITIONAL_COMPILE_FLAGS: -fsized-deallocation

--- a/libcxx/test/std/language.support/support.dynamic/new.delete/new.delete.single/sized_delete_fsizeddeallocation.pass.cpp
+++ b/libcxx/test/std/language.support/support.dynamic/new.delete/new.delete.single/sized_delete_fsizeddeallocation.pass.cpp
@@ -12,7 +12,6 @@
 // when sized deallocation is not supported, e.g., prior to C++14.
 
 // UNSUPPORTED: sanitizer-new-delete
-// XFAIL: stdlib=system && target={{.+}}-apple-macosx10.{{9|10|11}}
 
 // REQUIRES: -fsized-deallocation
 // ADDITIONAL_COMPILE_FLAGS: -fsized-deallocation -O3

--- a/libcxx/test/std/language.support/support.exception/uncaught/uncaught_exceptions.pass.cpp
+++ b/libcxx/test/std/language.support/support.exception/uncaught/uncaught_exceptions.pass.cpp
@@ -8,12 +8,10 @@
 
 // UNSUPPORTED: no-exceptions
 
-// std::uncaught_exceptions() was introduced in the dylib on Mac OS 10.12
-// XFAIL: stdlib=system && target={{.+}}-apple-macosx10.{{9|10|11}}
-
-// However, std::uncaught_exceptions() gives the wrong answer in Mac OS 10.12
-// and 10.13, where it only gives 0 or 1. This was fixed later.
-// XFAIL: stdlib=system && target={{.+}}-apple-macosx10.{{12|13}}
+// std::uncaught_exceptions() gives the wrong answer in versions of
+// the dylib that don't contain 3a92ecc. Previously, it only returned
+// 0 or 1.
+// XFAIL: using-built-library-before-llvm-9
 
 // test uncaught_exceptions
 

--- a/libcxx/test/std/language.support/support.runtime/cstdlib.aligned_alloc.compile.pass.cpp
+++ b/libcxx/test/std/language.support/support.runtime/cstdlib.aligned_alloc.compile.pass.cpp
@@ -13,7 +13,7 @@
 
 // ::aligned_alloc is provided by the C library, but it's marked as unavailable
 // until macOS 10.15
-// XFAIL: stdlib=system && target={{.+}}-apple-macosx10.{{9|10|11|12|13|14}}
+// XFAIL: target={{.+}}-apple-macosx10.{{13|14}}
 
 // ::aligned_alloc is not implemented on Windows
 // XFAIL: target={{.+}}-windows-{{.+}}

--- a/libcxx/test/std/language.support/support.runtime/ctime.timespec.compile.pass.cpp
+++ b/libcxx/test/std/language.support/support.runtime/ctime.timespec.compile.pass.cpp
@@ -16,7 +16,7 @@
 
 // ::timespec_get is provided by the C library, but it's marked as
 // unavailable until macOS 10.15
-// XFAIL: stdlib=system && target={{.+}}-apple-macosx10.{{9|10|11|12|13|14}}
+// XFAIL: target={{.+}}-apple-macosx10.{{13|14}}
 
 // ::timespec_get is available starting with Android Q (API 29)
 // XFAIL: target={{.+}}-android{{(eabi)?(21|22|23|24|25|26|27|28)}}

--- a/libcxx/test/std/localization/codecvt_unicode.pass.cpp
+++ b/libcxx/test/std/localization/codecvt_unicode.pass.cpp
@@ -7,7 +7,9 @@
 //===----------------------------------------------------------------------===//
 
 // ADDITIONAL_COMPILE_FLAGS: -D_LIBCPP_DISABLE_DEPRECATION_WARNINGS -D_LIBCPP_ENABLE_CXX26_REMOVED_CODECVT
-// XFAIL: stdlib=system && target={{.+}}-apple-macosx{{10.9|10.10|10.11|10.12|10.13|10.14|10.15|11.0|12.0|13.0}}
+
+// Requires the fix in 390840f.
+// XFAIL: using-built-library-before-llvm-18
 
 #include <algorithm>
 #include <cassert>

--- a/libcxx/test/std/localization/locale.categories/category.ctype/facet.ctype.special/facet.ctype.char.statics/table_size.pass.cpp
+++ b/libcxx/test/std/localization/locale.categories/category.ctype/facet.ctype.special/facet.ctype.char.statics/table_size.pass.cpp
@@ -12,10 +12,9 @@
 
 // Make sure we can reference std::ctype<char>::table_size.
 
-// Before https://llvm.org/D110647, the shared library did not contain
+// Before https://llvm.org/D110647 (049f6c29a6f0), the shared library did not contain
 // std::ctype<char>::table_size, so this test fails with a link error.
-// XFAIL: stdlib=system && target={{.+}}-apple-macosx10.{{9|10|11|12|13|14|15}}
-// XFAIL: stdlib=system && target={{.+}}-apple-macosx{{11.0|12.0|13.0}}
+// XFAIL: using-built-library-before-llvm-14
 
 #include <locale>
 #include <cassert>

--- a/libcxx/test/std/localization/locale.categories/category.numeric/locale.num.get/facet.num.get.members/get_long.pass.cpp
+++ b/libcxx/test/std/localization/locale.categories/category.numeric/locale.num.get/facet.num.get.members/get_long.pass.cpp
@@ -13,9 +13,9 @@
 // iter_type get(iter_type in, iter_type end, ios_base&,
 //               ios_base::iostate& err, long& v) const;
 
-// This test exercises the fix for PR28704, which isn't in the dylib for
-// some systems.
-// XFAIL: stdlib=system && target={{.+}}-apple-macosx10.{{9|10|11|12|13|14}}
+// This test exercises the fix for http://llvm.org/PR28704 (2dda1ff), which
+// isn't in the dylib for some systems.
+// XFAIL: using-built-library-before-llvm-9
 
 #include <locale>
 #include <ios>

--- a/libcxx/test/std/localization/locales/locale/locale.cons/name_construction.pass.cpp
+++ b/libcxx/test/std/localization/locales/locale/locale.cons/name_construction.pass.cpp
@@ -16,9 +16,9 @@
 // locale(const locale& other, const string& std_name, category cat);
 // locale(const locale& other, const locale& one, category cats);
 
-// This test exercises the fix for locale name construction (D119441), which
-// isn't in the dylib for some systems.
-// XFAIL: stdlib=system && target={{.+}}-apple-macosx{{10.9|10.10|10.11|10.12|10.13|10.14|10.15|11.0|12.0}}
+// This test exercises the fix for locale name construction (http://llvm.org/D119441 aka 643b7bcdb404),
+// which isn't in the dylib for some systems.
+// XFAIL: using-built-library-before-llvm-17
 
 #include <locale>
 #include <cassert>

--- a/libcxx/test/std/numerics/rand/rand.device/ctor.pass.cpp
+++ b/libcxx/test/std/numerics/rand/rand.device/ctor.pass.cpp
@@ -6,12 +6,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-// See https://llvm.org/PR20183
-// XFAIL: stdlib=system && target={{.+}}-apple-macosx10.{{9|10|11}}
-
 // The behavior of std::random_device changed on Apple platforms with
-// https://llvm.org/D116045.
-// XFAIL: stdlib=system && target={{.+}}-apple-macosx{{10.9|10.10|10.11|10.12|10.13|10.14|10.15|11.0|12.0}}
+// https://llvm.org/D116045 (d202c76441e1).
+// XFAIL: target={{.+}}-apple-{{.+}} && using-built-library-before-llvm-14
 
 // UNSUPPORTED: no-random-device
 

--- a/libcxx/test/std/strings/basic.string/string.capacity/max_size.pass.cpp
+++ b/libcxx/test/std/strings/basic.string/string.capacity/max_size.pass.cpp
@@ -8,10 +8,11 @@
 
 // UNSUPPORTED: no-exceptions
 
-// After changing the alignment of the allocated pointer from 16 to 8, the exception thrown is no longer `bad_alloc`
-// but instead length_error on systems using new headers but older dylibs.
+// After changing the alignment of the allocated pointer from 16 to 8, the exception
+// thrown is no longer `bad_alloc` but instead length_error on systems using new
+// headers but a dylib that doesn't contain 04ce0ba.
 //
-// XFAIL: using-built-library-before-llvm-18
+// XFAIL: using-built-library-before-llvm-19
 
 // <string>
 

--- a/libcxx/test/std/strings/basic.string/string.capacity/over_max_size.pass.cpp
+++ b/libcxx/test/std/strings/basic.string/string.capacity/over_max_size.pass.cpp
@@ -7,12 +7,6 @@
 //===----------------------------------------------------------------------===//
 
 // UNSUPPORTED: no-exceptions
-// XFAIL: stdlib=system && target={{.+}}-apple-macosx10.{{9|10|11}}
-
-// Prior to http://llvm.org/D123580, there was a bug with how the max_size()
-// was calculated. That was inlined into some functions in the dylib, which leads
-// to failures when running this test against an older system dylib.
-// XFAIL: stdlib=system && target=arm64-apple-macosx{{11.0|12.0}}
 
 // <string>
 

--- a/libcxx/test/std/strings/basic.string/string.capacity/reserve_size.pass.cpp
+++ b/libcxx/test/std/strings/basic.string/string.capacity/reserve_size.pass.cpp
@@ -10,9 +10,9 @@
 
 // void reserve(size_type res_arg); // constexpr since C++20
 
-// This test relies on https://llvm.org/PR45368 being fixed, which isn't in
-// older Apple dylibs
-// XFAIL: stdlib=system && target={{.+}}-apple-macosx{{10.9|10.10|10.11|10.12|10.13|10.14|10.15|11.0}}
+// This test relies on https://llvm.org/PR45368 (841132e) being fixed, which isn't in
+// older Apple dylibs.
+// XFAIL: using-built-library-before-llvm-12
 
 #include <string>
 #include <stdexcept>

--- a/libcxx/test/std/thread/futures/futures.async/async_race.38682.pass.cpp
+++ b/libcxx/test/std/thread/futures/futures.async/async_race.38682.pass.cpp
@@ -9,9 +9,9 @@
 // UNSUPPORTED: no-threads
 // UNSUPPORTED: c++03
 
-// There's currently no release of OS X whose dylib contains the patch for
-// PR38682. Since the fix for future<void> is in the dylib, this test may fail.
-// UNSUPPORTED: stdlib=system && target={{.+}}-apple-macosx10.{{9|10|11|12|13|14}}
+// This test requires the fix for http://llvm.org/PR38682 (616ef1863fae). We mark the
+// test as UNSUPPORTED instead of XFAIL because the test doesn't fail consistently.
+// UNSUPPORTED: using-built-library-before-llvm-10
 
 // This test is designed to cause and allow TSAN to detect a race condition
 // in std::async, as reported in https://llvm.org/PR38682.

--- a/libcxx/test/std/thread/futures/futures.future_error/what.pass.cpp
+++ b/libcxx/test/std/thread/futures/futures.future_error/what.pass.cpp
@@ -8,11 +8,6 @@
 //
 // UNSUPPORTED: no-threads
 
-// LWG 2056 changed the values of future_errc, so if we're using new headers
-// with an old library we'll get incorrect messages.
-//
-// XFAIL: stdlib=system && target={{.+}}-apple-macosx10.{{9|10|11}}
-
 // VC Runtime's std::exception::what() method is not marked as noexcept, so
 // this fails.
 // UNSUPPORTED: target=x86_64-pc-windows-msvc

--- a/libcxx/test/std/thread/thread.condition/notify_all_at_thread_exit_lwg3343.pass.cpp
+++ b/libcxx/test/std/thread/thread.condition/notify_all_at_thread_exit_lwg3343.pass.cpp
@@ -11,11 +11,11 @@
 // notify_all_at_thread_exit(...) requires move semantics to transfer the unique_lock.
 // UNSUPPORTED: c++03
 
-// The fix of LWG3343 is done in the dylib. That means Apple backdeployment
-// targets remain broken. Due to the nature of the test, testing on a broken
-// system does not guarantee that the test fails, so the test can't use XFAIL.
-// UNSUPPORTED: stdlib=system && target={{.+}}-apple-macosx10.{{.+}}
-// UNSUPPORTED: stdlib=system && target={{.+}}-apple-macosx11.{{.+}}
+// This test requires the fix for LWG3343 (64fc3cd), which is done in the dylib
+// and landed in LLVM 16. Due to the nature of the test, testing on a broken
+// system does not guarantee that the test fails, so we use UNSUPPORTED instead
+// of XFAIL.
+// UNSUPPORTED: using-built-library-before-llvm-16
 
 // This is a regression test for LWG3343.
 //

--- a/libcxx/test/std/utilities/memory/temporary.buffer/overaligned.pass.cpp
+++ b/libcxx/test/std/utilities/memory/temporary.buffer/overaligned.pass.cpp
@@ -8,11 +8,6 @@
 
 // UNSUPPORTED: c++03
 
-// Aligned allocations are not supported on macOS < 10.13
-// Note: use 'unsupported' instead of 'xfail' to ensure
-// we won't pass prior to c++17.
-// XFAIL: stdlib=system && target={{.+}}-apple-macosx10.{{9|10|11|12}}
-
 // ADDITIONAL_COMPILE_FLAGS: -D_LIBCPP_DISABLE_DEPRECATION_WARNINGS
 
 // <memory>

--- a/libcxx/utils/libcxx/test/features.py
+++ b/libcxx/utils/libcxx/test/features.py
@@ -585,69 +585,65 @@ DEFAULT_FEATURES += [
 # Those are used for backdeployment features below, do not use directly in tests.
 DEFAULT_FEATURES += [
     Feature(
-        name="_target-before-llvm-11",
+        name="_target-has-llvm-17",
         when=lambda cfg: BooleanExpression.evaluate(
-            "target={{.+}}-apple-macosx{{(10.13|10.14|10.15)(.0)?}}",
+            "target={{.+}}-apple-macosx{{14.[4-9](.0)?}}",
             cfg.available_features,
         ),
     ),
     Feature(
-        name="_target-before-llvm-12",
+        name="_target-has-llvm-16",
         when=lambda cfg: BooleanExpression.evaluate(
-            "_target-before-llvm-11 || target={{.+}}-apple-macosx{{(11(.\d+)?|12.[0-2])(.0)?}}",
+            "_target-has-llvm-17 || target={{.+}}-apple-macosx{{14.[0-3](.0)?}}",
             cfg.available_features,
         ),
     ),
     Feature(
-        name="_target-before-llvm-13",
+        name="_target-has-llvm-15",
         when=lambda cfg: BooleanExpression.evaluate(
-            "_target-before-llvm-12 || target={{.+}}-apple-macosx{{(12.[3-7]|13.[0-3])(.0)?}}",
+            "_target-has-llvm-16 || target={{.+}}-apple-macosx{{13.[4-9](.0)?}}",
             cfg.available_features,
         ),
     ),
     Feature(
-        name="_target-before-llvm-14",
+        name="_target-has-llvm-14",
         when=lambda cfg: BooleanExpression.evaluate(
-            "_target-before-llvm-13",
+            "_target-has-llvm-15",
             cfg.available_features,
         ),
     ),
     Feature(
-        name="_target-before-llvm-15",
+        name="_target-has-llvm-13",
         when=lambda cfg: BooleanExpression.evaluate(
-            "_target-before-llvm-14 || target={{.+}}-apple-macosx{{13.[4-6](.0)?}}",
+            "_target-has-llvm-14 || target={{.+}}-apple-macosx{{13.[0-3](.0)?}}",
             cfg.available_features,
         ),
     ),
     Feature(
-        name="_target-before-llvm-16",
+        name="_target-has-llvm-12",
         when=lambda cfg: BooleanExpression.evaluate(
-            "_target-before-llvm-15 || target={{.+}}-apple-macosx{{12.[0-3](.0)?}}",
+            "_target-has-llvm-13 || target={{.+}}-apple-macosx{{12.[3-9](.0)?}}",
             cfg.available_features,
         ),
     ),
     Feature(
-        name="_target-before-llvm-17",
+        name="_target-has-llvm-11",
         when=lambda cfg: BooleanExpression.evaluate(
-            "_target-before-llvm-16",
+            "_target-has-llvm-12 || target={{.+}}-apple-macosx{{(11.[0-9]|12.[0-2])(.0)?}}",
             cfg.available_features,
         ),
     ),
-    # For now, no released version of macOS contains LLVM 18
-    # TODO(ldionne) Please provide the correct value.
     Feature(
-        name="_target-before-llvm-18",
+        name="_target-has-llvm-10",
         when=lambda cfg: BooleanExpression.evaluate(
-            "_target-before-llvm-17 || target={{.+}}-apple-macosx{{.+}}",
+            "_target-has-llvm-11",
             cfg.available_features,
         ),
     ),
-    # For now, no released version of macOS contains LLVM 19
-    # TODO(ldionne) Please provide the correct value.
     Feature(
-        name="_target-before-llvm-19",
+        name="_target-has-llvm-9",
         when=lambda cfg: BooleanExpression.evaluate(
-            "_target-before-llvm-18 || target={{.+}}-apple-macosx{{.+}}",
+            "_target-has-llvm-10 || target={{.+}}-apple-macosx{{10.15(.0)?}}",
             cfg.available_features,
         ),
     ),
@@ -690,12 +686,12 @@ DEFAULT_FEATURES += [
 # a libc++ flavor that enables availability markup. Similarly, a test could fail when
 # run against the system library of an older version of FreeBSD, even though FreeBSD
 # doesn't provide availability markup at the time of writing this.
-for version in ("11", "12", "13", "14", "15", "16", "17", "18", "19"):
+for version in ("9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19"):
     DEFAULT_FEATURES.append(
         Feature(
             name="using-built-library-before-llvm-{}".format(version),
-            when=lambda cfg: BooleanExpression.evaluate(
-                "stdlib=system && _target-before-llvm-{}".format(version),
+            when=lambda cfg, v=version: BooleanExpression.evaluate(
+                "stdlib=system && !_target-has-llvm-{}".format(v),
                 cfg.available_features,
             ),
         )
@@ -706,7 +702,7 @@ DEFAULT_FEATURES += [
     Feature(
         name="availability-filesystem-missing",
         when=lambda cfg: BooleanExpression.evaluate(
-            "!libcpp-has-no-availability-markup && (stdlib=apple-libc++ && target={{.+}}-apple-macosx10.{{(13|14)(.0)?}})",
+            "!libcpp-has-no-availability-markup && (stdlib=apple-libc++ && !_target-has-llvm-9)",
             cfg.available_features,
         ),
     ),
@@ -714,7 +710,7 @@ DEFAULT_FEATURES += [
     Feature(
         name="availability-synchronization_library-missing",
         when=lambda cfg: BooleanExpression.evaluate(
-            "!libcpp-has-no-availability-markup && (stdlib=apple-libc++ && _target-before-llvm-11)",
+            "!libcpp-has-no-availability-markup && (stdlib=apple-libc++ && !_target-has-llvm-11)",
             cfg.available_features,
         ),
     ),
@@ -722,7 +718,7 @@ DEFAULT_FEATURES += [
     Feature(
         name="availability-char8_t_support-missing",
         when=lambda cfg: BooleanExpression.evaluate(
-            "!libcpp-has-no-availability-markup && (stdlib=apple-libc++ && _target-before-llvm-12)",
+            "!libcpp-has-no-availability-markup && (stdlib=apple-libc++ && !_target-has-llvm-12)",
             cfg.available_features,
         ),
     ),
@@ -730,7 +726,7 @@ DEFAULT_FEATURES += [
     Feature(
         name="availability-verbose_abort-missing",
         when=lambda cfg: BooleanExpression.evaluate(
-            "!libcpp-has-no-availability-markup && (stdlib=apple-libc++ && _target-before-llvm-13)",
+            "!libcpp-has-no-availability-markup && (stdlib=apple-libc++ && !_target-has-llvm-13)",
             cfg.available_features,
         ),
     ),
@@ -738,7 +734,7 @@ DEFAULT_FEATURES += [
     Feature(
         name="availability-pmr-missing",
         when=lambda cfg: BooleanExpression.evaluate(
-            "!libcpp-has-no-availability-markup && (stdlib=apple-libc++ && _target-before-llvm-13)",
+            "!libcpp-has-no-availability-markup && (stdlib=apple-libc++ && !_target-has-llvm-13)",
             cfg.available_features,
         ),
     ),
@@ -746,7 +742,7 @@ DEFAULT_FEATURES += [
     Feature(
         name="availability-fp_to_chars-missing",
         when=lambda cfg: BooleanExpression.evaluate(
-            "!libcpp-has-no-availability-markup && (stdlib=apple-libc++ && _target-before-llvm-14)",
+            "!libcpp-has-no-availability-markup && (stdlib=apple-libc++ && !_target-has-llvm-14)",
             cfg.available_features,
         ),
     ),
@@ -754,7 +750,7 @@ DEFAULT_FEATURES += [
     Feature(
         name="availability-print-missing",
         when=lambda cfg: BooleanExpression.evaluate(
-            "!libcpp-has-no-availability-markup && (stdlib=apple-libc++ && _target-before-llvm-18)",
+            "!libcpp-has-no-availability-markup && (stdlib=apple-libc++ && !_target-has-llvm-18)",
             cfg.available_features,
         ),
     ),
@@ -762,7 +758,7 @@ DEFAULT_FEATURES += [
     Feature(
         name="availability-tzdb-missing",
         when=lambda cfg: BooleanExpression.evaluate(
-            "!libcpp-has-no-availability-markup && (stdlib=apple-libc++ && _target-before-llvm-19)",
+            "!libcpp-has-no-availability-markup && (stdlib=apple-libc++ && !_target-has-llvm-19)",
             cfg.available_features,
         ),
     ),

--- a/libcxxabi/test/catch_function_01.pass.cpp
+++ b/libcxxabi/test/catch_function_01.pass.cpp
@@ -8,13 +8,11 @@
 
 // Can you have a catch clause of array type that catches anything?
 
+// UNSUPPORTED: no-exceptions
+
 // GCC incorrectly allows function pointer to be caught by reference.
 // See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=69372
 // XFAIL: gcc
-// UNSUPPORTED: no-exceptions
-
-// 65ace9daa360 made it in the dylib in macOS 10.11
-// XFAIL: stdlib=system && target={{.+}}-apple-macosx10.{{9|10}}
 
 #include <cassert>
 

--- a/libcxxabi/test/catch_function_03.pass.cpp
+++ b/libcxxabi/test/catch_function_03.pass.cpp
@@ -10,9 +10,6 @@
 // UNSUPPORTED: c++03, c++11, c++14
 // UNSUPPORTED: no-exceptions
 
-// Support for catching a function pointer including noexcept was shipped in macOS 10.13
-// XFAIL: stdlib=system && target={{.+}}-apple-macosx10.{{9|10|11|12}}
-
 #include <cassert>
 
 template<bool Noexcept> void f() noexcept(Noexcept) {}

--- a/libcxxabi/test/catch_member_data_pointer_01.pass.cpp
+++ b/libcxxabi/test/catch_member_data_pointer_01.pass.cpp
@@ -8,9 +8,6 @@
 
 // UNSUPPORTED: no-exceptions
 
-// 1b00fc5d8133 made it in the dylib in macOS 10.11
-// XFAIL: stdlib=system && target={{.+}}-apple-macosx10.{{9|10}}
-
 #include <cassert>
 
 struct A

--- a/libcxxabi/test/catch_member_function_pointer_02.pass.cpp
+++ b/libcxxabi/test/catch_member_function_pointer_02.pass.cpp
@@ -10,9 +10,6 @@
 // UNSUPPORTED: c++03, c++11, c++14
 // UNSUPPORTED: no-exceptions
 
-// Support for catching a function pointer including noexcept was shipped in macOS 10.13
-// XFAIL: stdlib=system && target={{.+}}-apple-macosx10.{{9|10|11|12}}
-
 // GCC supports noexcept function types but this test still fails.
 // This is likely a bug in their implementation. Investigation needed.
 // XFAIL: gcc-13, gcc-14

--- a/libcxxabi/test/catch_member_pointer_nullptr.pass.cpp
+++ b/libcxxabi/test/catch_member_pointer_nullptr.pass.cpp
@@ -6,10 +6,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// Catching an exception thrown as nullptr was not properly handled before
-// 2f984cab4fa7, which landed in macOS 10.13
-// XFAIL: stdlib=system && target={{.+}}-apple-macosx10.{{9|10|11|12}}
-
 // UNSUPPORTED: no-exceptions
 
 #include <cassert>

--- a/libcxxabi/test/catch_multi_level_pointer.pass.cpp
+++ b/libcxxabi/test/catch_multi_level_pointer.pass.cpp
@@ -8,9 +8,6 @@
 
 // UNSUPPORTED: no-exceptions
 
-// 1b00fc5d8133 made it in the dylib in macOS 10.11
-// XFAIL: stdlib=system && target={{.+}}-apple-macosx10.{{9|10}}
-
 // mps2-an385 machine used for testing of picolibc has just 4 MB of "flash"
 // memory and this test requires almost 5 MB
 // UNSUPPORTED: LIBCXX-PICOLIBC-FIXME

--- a/libcxxabi/test/catch_null_pointer_to_object_pr64953.pass.cpp
+++ b/libcxxabi/test/catch_null_pointer_to_object_pr64953.pass.cpp
@@ -25,17 +25,10 @@
 //===----------------------------------------------------------------------===//
 
 // UNSUPPORTED: no-exceptions
-// This test requires the fix to
-// https://github.com/llvm/llvm-project/issues/64953, which is in libc++abi.dylib.
-// The fix is not contained in older macOS system dylibs, so the test will fail
-// there.
-// FIXME: In the case that we are testing `natively` with the CI scripts we
-// currently pass the newly-built libraries to the execution, this leads to an
-// XPASS here so that we have to make these UNSUPPORTED for now (they should be
-// XFAILs when tested against current [macOS14] and previous installed libc++abi
-// as described above).
-// UNSUPPORTED: stdlib=system && target={{.+}}-apple-macosx10.{{9|10|11|12|13|14|15}}{{.*}}
-// UNSUPPORTED: stdlib=system && target={{.+}}-apple-macosx{{11|12|13|14}}{{.*}}
+
+// This test requires the fix to https://github.com/llvm/llvm-project/issues/64953,
+// which landed in d5f84e6 and is in the libc++abi built library.
+// XFAIL: using-built-library-before-llvm-18
 
 #include <exception>
 #include <stdlib.h>

--- a/libcxxabi/test/catch_pointer_nullptr.pass.cpp
+++ b/libcxxabi/test/catch_pointer_nullptr.pass.cpp
@@ -6,10 +6,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// Catching an exception thrown as nullptr was not properly handled before
-// 2f984cab4fa7, which landed in macOS 10.13
-// XFAIL: stdlib=system && target={{.+}}-apple-macosx10.{{9|10|11|12}}
-
 // UNSUPPORTED: c++03
 // UNSUPPORTED: no-exceptions
 

--- a/libcxxabi/test/catch_ptr_02.pass.cpp
+++ b/libcxxabi/test/catch_ptr_02.pass.cpp
@@ -13,9 +13,6 @@
 // behavior under test.
 // ADDITIONAL_COMPILE_FLAGS: -Wno-exceptions
 
-// The fix for PR17222 made it in the dylib for macOS 10.10
-// XFAIL: stdlib=system && target={{.+}}-apple-macosx10.9
-
 #include <cassert>
 #include <stdint.h>
 

--- a/libcxxabi/test/cxa_vec_new_overflow_PR41395.pass.cpp
+++ b/libcxxabi/test/cxa_vec_new_overflow_PR41395.pass.cpp
@@ -8,8 +8,8 @@
 
 // UNSUPPORTED: no-exceptions
 
-// PR41395 isn't fixed until the dylib shipped with macOS 10.15
-// XFAIL: stdlib=system && target={{.+}}-apple-macosx10.{{9|10|11|12|13|14}}
+// This test requires the fix in http://llvm.org/PR41395 (c4225e124f9e).
+// XFAIL: using-built-library-before-llvm-9
 
 #include "cxxabi.h"
 #include <new>

--- a/libcxxabi/test/dynamic_cast.pass.cpp
+++ b/libcxxabi/test/dynamic_cast.pass.cpp
@@ -6,11 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-// PR33425 and PR33487 are not fixed until the dylib shipped with macOS 10.15
-// XFAIL: stdlib=system && target={{.+}}-apple-macosx10.14
-
-// PR33439 isn't fixed until the dylib shipped with macOS 10.14
-// XFAIL: stdlib=system && target={{.+}}-apple-macosx10.{{9|10|11|12|13}}
+// This test requires PR33425, PR33487 and PR33439.
+// XFAIL: using-built-library-before-llvm-9
 
 #include <cassert>
 

--- a/libcxxabi/test/exception_object_alignment.pass.cpp
+++ b/libcxxabi/test/exception_object_alignment.pass.cpp
@@ -8,12 +8,6 @@
 
 // UNSUPPORTED: no-exceptions
 
-// The situation for the alignment of exception objects is badly messed up
-// before macOS 10.14. The test fails on macOS 10.9 to 10.12, passes on macOS
-// 10.13 (no investigation done), and passes afterwards. Just mark all the OSes
-// before 10.14 as unsupported.
-// UNSUPPORTED: stdlib=system && target={{.+}}-apple-macosx10.{{9|10|11|12|13}}
-
 // Check that the pointer __cxa_allocate_exception returns is aligned to the
 // default alignment for the target architecture.
 

--- a/libcxxabi/test/incomplete_type.sh.cpp
+++ b/libcxxabi/test/incomplete_type.sh.cpp
@@ -16,9 +16,6 @@
 // UNSUPPORTED: no-exceptions
 // UNSUPPORTED: no-rtti
 
-// The fix for PR25898 landed in the system dylibs in macOS 10.13
-// XFAIL: stdlib=system && target={{.+}}-apple-macosx10.{{9|10|11|12}}
-
 // RUN: %{cxx} %{flags} %{compile_flags} -Wno-unreachable-code -c %s -o %t.one.o
 // RUN: %{cxx} %{flags} %{compile_flags} -Wno-unreachable-code -c %s -o %t.two.o -DTU_ONE
 // RUN: %{cxx} %{flags} %t.one.o %t.two.o %{link_flags} -o %t.exe

--- a/libcxxabi/test/test_aux_runtime_op_array_new.pass.cpp
+++ b/libcxxabi/test/test_aux_runtime_op_array_new.pass.cpp
@@ -9,8 +9,8 @@
 // UNSUPPORTED: no-exceptions
 
 // ___cxa_throw_bad_array_new_length is re-exported from libc++ only starting
-// in macosx 10.15
-// XFAIL: stdlib=system && target={{.+}}-apple-macosx10.{{9|10|11|12|13|14}}
+// in LLVM 9.
+// XFAIL: using-built-library-before-llvm-9
 
 #include <cxxabi.h>
 #include <new>

--- a/libcxxabi/test/test_exception_address_alignment.pass.cpp
+++ b/libcxxabi/test/test_exception_address_alignment.pass.cpp
@@ -9,12 +9,6 @@
 // UNSUPPORTED: no-exceptions
 // UNSUPPORTED: c++03
 
-// The <unwind.h> header provided in the SDK of older Xcodes used to provide
-// an incorrectly aligned _Unwind_Exception type on non-ARM. That causes these
-// tests to fail when running against a system libc++abi and libunwind that was
-// compiled with an incorrect definition of _Unwind_Exception.
-// XFAIL: stdlib=system && target={{.+}}-apple-macosx10.{{9|10|11|12}}
-
 // Test that the address of the exception object is properly aligned as required
 // by the relevant ABI
 

--- a/libcxxabi/test/uncaught_exception.pass.cpp
+++ b/libcxxabi/test/uncaught_exception.pass.cpp
@@ -15,8 +15,7 @@
 // to undefined symbols when linking against a libc++ that re-exports the symbols,
 // but running against a libc++ that doesn't. Fortunately, usage of __cxa_uncaught_exception()
 // in the wild seems to be close to non-existent.
-// XFAIL: stdlib=system && target={{.+}}-apple-macosx10.{{9|10|11|12|13|14|15}}
-// XFAIL: stdlib=system && target={{.+}}-apple-macosx{{(11|12|13|14)([.][0-9]+)?}}
+// XFAIL: using-built-library-before-llvm-19
 
 #include <cxxabi.h>
 #include <cassert>

--- a/libcxxabi/test/uncaught_exceptions.pass.cpp
+++ b/libcxxabi/test/uncaught_exceptions.pass.cpp
@@ -8,8 +8,8 @@
 
 // UNSUPPORTED: no-exceptions
 
-// __cxa_uncaught_exceptions is not re-exported from libc++ until macOS 10.15.
-// XFAIL: stdlib=system && target={{.+}}-apple-macosx10.{{9|10|11|12|13|14}}
+// __cxa_uncaught_exceptions is not re-exported from libc++ until LLVM 9.
+// XFAIL: using-built-library-before-llvm-9
 
 #include <cxxabi.h>
 #include <cassert>


### PR DESCRIPTION
This patch removes many annotations that are not relevant anymore since we don't support or test back-deploying to macOS < 10.13. It also cleans up raw usage of target triples to identify versions of dylibs shipped on prior versions of macOS, and uses the target-agnostic Lit features instead. Finally, it reorders both the Lit backdeployment features and the corresponding availability macros in the library in a way that makes more sense, and reformulates the Lit backdeployment features in terms of when a version of LLVM was introduced instead of encoding the system versions on which it hasn't been introduced yet. Although one can be derived from the other, encoding the negative form is extremely error-prone.

Fixes #80901