### PR TITLE
[libc][arm] additions to configure 32b ARM cross build

### DIFF
--- a/libc/config/linux/arm/entrypoints.txt
+++ b/libc/config/linux/arm/entrypoints.txt
@@ -367,6 +367,18 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.ufromfpxl
 )
 
+if(LLVM_LIBC_FULL_BUILD)
+  list(APPEND TARGET_LIBC_ENTRYPOINTS
+    # stdlib.h entrypoints
+    libc.src.stdlib._Exit
+    libc.src.stdlib.atexit
+    libc.src.stdlib.exit
+
+    # unistd.h entrypoints
+    libc.src.unistd.environ
+  )
+endif()
+
 set(TARGET_LLVMLIBC_ENTRYPOINTS
   ${TARGET_LIBC_ENTRYPOINTS}
   ${TARGET_LIBM_ENTRYPOINTS}

--- a/libc/startup/linux/arm/CMakeLists.txt
+++ b/libc/startup/linux/arm/CMakeLists.txt
@@ -1,0 +1,13 @@
+add_startup_object(
+  tls
+  SRC
+    tls.cpp
+)
+
+add_startup_object(
+  start
+  SRC
+    start.cpp
+  DEPENDS
+    libc.config.linux.app_h
+)

--- a/libc/startup/linux/arm/start.cpp
+++ b/libc/startup/linux/arm/start.cpp
@@ -1,0 +1,16 @@
+//===-- Implementation of _start for arm ----------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "startup/linux/do_start.h"
+
+extern "C" [[noreturn]] void _start() {
+  // TODO: implement me! https://github.com/llvm/llvm-project/issues/96326
+  // LIBC_NAMESPACE::app.args = reinterpret_cast<LIBC_NAMESPACE::Args *>(
+  //     reinterpret_cast<uintptr_t *>(__builtin_frame_address(0)) + 2);
+  LIBC_NAMESPACE::do_start();
+}

--- a/libc/startup/linux/arm/tls.cpp
+++ b/libc/startup/linux/arm/tls.cpp
@@ -1,0 +1,22 @@
+//===-- Implementation of tls for arm -------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "config/linux/app.h" // TLSDescriptor
+
+namespace LIBC_NAMESPACE {
+
+
+void init_tls(TLSDescriptor &) {
+  // TODO: implement me! https://github.com/llvm/llvm-project/issues/96326
+}
+
+void cleanup_tls(uintptr_t, uintptr_t) {
+  // TODO: implement me! https://github.com/llvm/llvm-project/issues/96326
+}
+
+} // namespace LIBC_NAMESPACE


### PR DESCRIPTION
After this change, we should now be able to configure the build via:

    cmake ../runtimes -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang -G
    Ninja -DLLVM_ENABLE_LLD=ON -DCMAKE_BUILD_TYPE=Release
    -DLLVM_ENABLE_RUNTIMES="libc" -DLLVM_LIBC_FULL_BUILD=ON
    -DLIBC_HDRGEN_EXE=$HDRGEN -DLIBC_TARGET_TRIPLE=armv7-linux-gnueabihf

The resulting configuration is full of build errors, which need to be worked
through.  Then the startup code is wrong, but simply being able to configure
this build is a start.

We need to support arm32 for Android. Being able to build the unit tests on my
host machine would allow me to play with QEMU support for running the cross
compiled unit tests.

Link: #96326