### PR TITLE
[libc][startup] set --target= for linker when cross compiling

### DIFF
--- a/libc/startup/linux/CMakeLists.txt
+++ b/libc/startup/linux/CMakeLists.txt
@@ -26,7 +26,7 @@ function(merge_relocatable_object name)
   )
   # Pass -r to the driver is much cleaner than passing -Wl,-r: the compiler knows it is
   # a relocatable linking and will not pass other irrelevant flags to the linker.
-  target_link_options(${relocatable_target} PRIVATE -r -nostdlib)
+  target_link_options(${relocatable_target} PRIVATE -r -nostdlib --target=${explicit_target_triple})
   set_target_properties(
     ${relocatable_target}
     PROPERTIES


### PR DESCRIPTION
Otherwise the startup objects will fail to link since they were cross compiled,
but the linker is not informed of the intent to cross compile, which results in
linker errors when the host architecture does not match the target
architecture.