### PR TITLE
[ParserHLSL] Attempt to parse HLSL annotations on Field Decls.

### DIFF
--- a/clang/include/clang/Parse/Parser.h
+++ b/clang/include/clang/Parse/Parser.h
@@ -3030,7 +3030,7 @@ private:
   void MaybeParseHLSLAnnotations(ParsedAttributes &Attrs,
                                  SourceLocation *EndLoc = nullptr) {
     assert(getLangOpts().HLSL && "MaybeParseHLSLAnnotations is for HLSL only");
-    if (getLangOpts().HLSL && Tok.is(tok::colon))
+    if (Tok.is(tok::colon))
       ParseHLSLAnnotations(Attrs, EndLoc);
   }
 

--- a/clang/include/clang/Parse/Parser.h
+++ b/clang/include/clang/Parse/Parser.h
@@ -3017,11 +3017,12 @@ private:
       const IdentifierInfo *EnclosingScope = nullptr);
 
   void MaybeParseHLSLAnnotations(Declarator &D,
-                                 SourceLocation *EndLoc = nullptr) {
+                                 SourceLocation *EndLoc = nullptr,
+                                 bool CouldBeBitField = false) {
     assert(getLangOpts().HLSL && "MaybeParseHLSLAnnotations is for HLSL only");
     if (Tok.is(tok::colon)) {
       ParsedAttributes Attrs(AttrFactory);
-      ParseHLSLAnnotations(Attrs, EndLoc);
+      ParseHLSLAnnotations(Attrs, EndLoc, CouldBeBitField);
       D.takeAttributes(Attrs);
     }
   }
@@ -3034,7 +3035,8 @@ private:
   }
 
   void ParseHLSLAnnotations(ParsedAttributes &Attrs,
-                            SourceLocation *EndLoc = nullptr);
+                            SourceLocation *EndLoc = nullptr,
+                            bool CouldBeBitField = false);
   Decl *ParseHLSLBuffer(SourceLocation &DeclEnd);
 
   void MaybeParseMicrosoftAttributes(ParsedAttributes &Attrs) {

--- a/clang/lib/Parse/ParseDeclCXX.cpp
+++ b/clang/lib/Parse/ParseDeclCXX.cpp
@@ -2647,7 +2647,8 @@ bool Parser::ParseCXXMemberDeclaratorBeforeInitializer(
     DeclaratorInfo.SetIdentifier(nullptr, Tok.getLocation());
 
   if (getLangOpts().HLSL)
-    MaybeParseHLSLAnnotations(DeclaratorInfo);
+    MaybeParseHLSLAnnotations(DeclaratorInfo, nullptr,
+                              /*CouldBeBitField*/ true);
 
   if (!DeclaratorInfo.isFunctionDeclarator() && TryConsumeToken(tok::colon)) {
     assert(DeclaratorInfo.isPastIdentifier() &&

--- a/clang/lib/Parse/ParseDeclCXX.cpp
+++ b/clang/lib/Parse/ParseDeclCXX.cpp
@@ -2646,6 +2646,9 @@ bool Parser::ParseCXXMemberDeclaratorBeforeInitializer(
   else
     DeclaratorInfo.SetIdentifier(nullptr, Tok.getLocation());
 
+  if (getLangOpts().HLSL)
+    MaybeParseHLSLAnnotations(DeclaratorInfo);
+
   if (!DeclaratorInfo.isFunctionDeclarator() && TryConsumeToken(tok::colon)) {
     assert(DeclaratorInfo.isPastIdentifier() &&
            "don't know where identifier would go yet?");

--- a/clang/lib/Parse/ParseHLSL.cpp
+++ b/clang/lib/Parse/ParseHLSL.cpp
@@ -119,9 +119,11 @@ static void fixSeparateAttrArgAndNumber(StringRef ArgStr, SourceLocation ArgLoc,
 }
 
 void Parser::ParseHLSLAnnotations(ParsedAttributes &Attrs,
-                                  SourceLocation *EndLoc) {
+                                  SourceLocation *EndLoc,
+                                  bool CouldBeBitField) {
 
   assert(Tok.is(tok::colon) && "Not a HLSL Annotation");
+  Token OldToken = Tok;
   ConsumeToken();
 
   IdentifierInfo *II = nullptr;
@@ -131,6 +133,10 @@ void Parser::ParseHLSLAnnotations(ParsedAttributes &Attrs,
     II = Tok.getIdentifierInfo();
 
   if (!II) {
+    if (CouldBeBitField) {
+      UnconsumeToken(OldToken);
+      return;
+    }
     Diag(Tok.getLocation(), diag::err_expected_semantic_identifier);
     return;
   }

--- a/clang/lib/Sema/SemaHLSL.cpp
+++ b/clang/lib/Sema/SemaHLSL.cpp
@@ -358,12 +358,7 @@ static bool isLegalTypeForHLSLSV_DispatchThreadID(QualType T) {
 
 void SemaHLSL::handleSV_DispatchThreadIDAttr(Decl *D, const ParsedAttr &AL) {
   // FIXME: support semantic on field.
-  // See https://github.com/llvm/llvm-project/issues/57889.
-  if (isa<FieldDecl>(D)) {
-    Diag(AL.getLoc(), diag::err_hlsl_attr_invalid_ast_node)
-        << AL << "parameter";
-    return;
-  }
+  // See https://github.com/llvm/llvm-project/issues/57889.  
 
   auto *VD = cast<ValueDecl>(D);
   if (!isLegalTypeForHLSLSV_DispatchThreadID(VD->getType())) {

--- a/clang/lib/Sema/SemaHLSL.cpp
+++ b/clang/lib/Sema/SemaHLSL.cpp
@@ -356,10 +356,7 @@ static bool isLegalTypeForHLSLSV_DispatchThreadID(QualType T) {
   return true;
 }
 
-void SemaHLSL::handleSV_DispatchThreadIDAttr(Decl *D, const ParsedAttr &AL) {
-  // FIXME: support semantic on field.
-  // See https://github.com/llvm/llvm-project/issues/57889.  
-
+void SemaHLSL::handleSV_DispatchThreadIDAttr(Decl *D, const ParsedAttr &AL) {  
   auto *VD = cast<ValueDecl>(D);
   if (!isLegalTypeForHLSLSV_DispatchThreadID(VD->getType())) {
     Diag(AL.getLoc(), diag::err_hlsl_attr_invalid_type)

--- a/clang/test/ParserHLSL/bitfields.hlsl
+++ b/clang/test/ParserHLSL/bitfields.hlsl
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -triple dxil-pc-shadermodel6.0-compute -ast-dump -x hlsl -o - %s | Filecheck %s
+// RUN: %clang_cc1 -triple dxil-pc-shadermodel6.0-compute -ast-dump -x hlsl -o - %s | FileCheck %s
 
 
 struct MyBitFields {

--- a/clang/test/ParserHLSL/bitfields.hlsl
+++ b/clang/test/ParserHLSL/bitfields.hlsl
@@ -1,11 +1,24 @@
-// RUN: %clang_cc1 -triple dxil-pc-shadermodel6.0-compute -x hlsl -o - %s -verify
+// RUN: %clang_cc1 -triple dxil-pc-shadermodel6.0-compute -ast-dump -x hlsl -o - %s | Filecheck %s
 
-// expected-no-diagnostics
 
 struct MyBitFields {
-    unsigned int field1 : 3; // 3 bits for field1
-    unsigned int field2 : 4; // 4 bits for field2
-    int field3 : 5;          // 5 bits for field3 (signed)
+  // CHECK: FieldDecl 0x{{[0-9a-f]+}} <line:9:3, col:25> col:16 referenced field1 'unsigned int'
+  // CHECK:-ConstantExpr 0x{{[0-9a-f]+}} <col:25> 'int'
+  // CHECK:-value: Int 3
+  // CHECK:-IntegerLiteral 0x{{[0-9a-f]+}} <col:25> 'int' 3
+  unsigned int field1 : 3; // 3 bits for field1
+
+  // CHECK:FieldDecl 0x{{[0-9a-f]+}} <line:15:3, col:25> col:16 referenced field2 'unsigned int'
+  // CHECK:-ConstantExpr 0x{{[0-9a-f]+}} <col:25> 'int'
+  // CHECK:-value: Int 4
+  // CHECK:-IntegerLiteral 0x{{[0-9a-f]+}} <col:25> 'int' 4
+  unsigned int field2 : 4; // 4 bits for field2
+  
+  // CHECK:FieldDecl 0x{{[0-9a-f]+}} <line:21:3, col:16> col:7 field3 'int'
+  // CHECK:-ConstantExpr 0x{{[0-9a-f]+}} <col:16> 'int'
+  // CHECK:-value: Int 5
+  // CHECK:-IntegerLiteral 0x{{[0-9a-f]+}} <col:16> 'int' 5
+  int field3 : 5;          // 5 bits for field3 (signed)
 };
 
 

--- a/clang/test/ParserHLSL/bitfields.hlsl
+++ b/clang/test/ParserHLSL/bitfields.hlsl
@@ -1,0 +1,18 @@
+// RUN: %clang_cc1 -triple dxil-pc-shadermodel6.0-compute -x hlsl -o - %s -verify
+
+// expected-no-diagnostics
+
+struct MyBitFields {
+    unsigned int field1 : 3; // 3 bits for field1
+    unsigned int field2 : 4; // 4 bits for field2
+    int field3 : 5;          // 5 bits for field3 (signed)
+};
+
+
+
+[numthreads(1,1,1)]
+void main() {
+  MyBitFields m;
+  m.field1 = 4;
+  m.field2 = m.field1*2;
+}

--- a/clang/test/ParserHLSL/hlsl_annotations_on_struct_members.hlsl
+++ b/clang/test/ParserHLSL/hlsl_annotations_on_struct_members.hlsl
@@ -1,10 +1,13 @@
-// RUN: %clang_cc1 -triple dxil-pc-shadermodel6.0-compute -x hlsl -o - %s -verify
+// RUN: %clang_cc1 -triple dxil-pc-shadermodel6.0-compute -x hlsl -ast-dump -o - %s | FileCheck %s
 
-// TODO: update once we handle annotations on struct fields
+// tests that hlsl annotations are properly parsed when applied on field decls,
+// and that the annotation gets properly placed on the AST.
 
 struct Eg9{
-// expected-error@+1{{attribute 'SV_DispatchThreadID' only applies to parameter}}
-  int a : SV_DispatchThreadID;
+  // CHECK: CXXRecordDecl 0x{{[0-9a-f]+}} <col:1, col:8> col:8 implicit struct Eg9
+  // CHECK: FieldDecl 0x{{[0-9a-f]+}} <line:10:3, col:16> col:16 referenced a 'unsigned int'
+  // CHECK: -HLSLSV_DispatchThreadIDAttr 0x{{[0-9a-f]+}} <col:20>
+  unsigned int a : SV_DispatchThreadID;
 };
 Eg9 e9;
 

--- a/clang/test/ParserHLSL/hlsl_annotations_on_struct_members.hlsl
+++ b/clang/test/ParserHLSL/hlsl_annotations_on_struct_members.hlsl
@@ -1,0 +1,30 @@
+// RUN: %clang_cc1 -triple dxil-pc-shadermodel6.0-compute -x hlsl -o - %s -verify
+
+// previously, this test would result in an error shown below on the line that 
+// declares variable a in struct Eg9:
+// error: use of undeclared identifier
+//     'SV_DispatchThreadID'
+// This is because the annotation is parsed as if it was a c++ bit field, and an identifier
+// that represents an integer is expected, but not found.
+
+// This test ensures that hlsl annotations are attempted to be parsed when parsing struct decls.
+// Ideally, we'd validate this behavior by ensuring the annotation is parsed and properly
+// attached as an attribute to the member in the struct in the AST. However, in this case
+// this can't happen presently because there are other issues with annotations on field decls.
+// This test just ensures we make progress by moving the validation error from the realm of
+// C++ and expecting bitfields, to HLSL and a specialized error for the recognized annotation.
+
+struct Eg9{
+// expected-error@+1{{attribute 'SV_DispatchThreadID' only applies to parameter}}
+  int a : SV_DispatchThreadID;
+};
+Eg9 e9;
+
+
+RWBuffer<int> In : register(u1);
+
+
+[numthreads(1,1,1)]
+void main() {
+  In[0] = e9.a;
+}

--- a/clang/test/ParserHLSL/hlsl_annotations_on_struct_members.hlsl
+++ b/clang/test/ParserHLSL/hlsl_annotations_on_struct_members.hlsl
@@ -1,18 +1,6 @@
 // RUN: %clang_cc1 -triple dxil-pc-shadermodel6.0-compute -x hlsl -o - %s -verify
 
-// previously, this test would result in an error shown below on the line that 
-// declares variable a in struct Eg9:
-// error: use of undeclared identifier
-//     'SV_DispatchThreadID'
-// This is because the annotation is parsed as if it was a c++ bit field, and an identifier
-// that represents an integer is expected, but not found.
-
-// This test ensures that hlsl annotations are attempted to be parsed when parsing struct decls.
-// Ideally, we'd validate this behavior by ensuring the annotation is parsed and properly
-// attached as an attribute to the member in the struct in the AST. However, in this case
-// this can't happen presently because there are other issues with annotations on field decls.
-// This test just ensures we make progress by moving the validation error from the realm of
-// C++ and expecting bitfields, to HLSL and a specialized error for the recognized annotation.
+// TODO: update once we handle annotations on struct fields
 
 struct Eg9{
 // expected-error@+1{{attribute 'SV_DispatchThreadID' only applies to parameter}}

--- a/clang/test/SemaHLSL/Semantics/invalid_entry_parameter.hlsl
+++ b/clang/test/SemaHLSL/Semantics/invalid_entry_parameter.hlsl
@@ -25,6 +25,5 @@ void foo() {
 struct ST2 {
 // expected-warning@+1 {{'SV_DispatchThreadID' attribute only applies to parameters and non-static data members}}
     static uint X : SV_DispatchThreadID;
-// expected-error@+1 {{attribute 'SV_DispatchThreadID' only applies to parameter}}
     uint s : SV_DispatchThreadID;
 };

--- a/clang/test/SemaHLSL/Semantics/invalid_entry_parameter.hlsl
+++ b/clang/test/SemaHLSL/Semantics/invalid_entry_parameter.hlsl
@@ -23,8 +23,8 @@ void foo() {
 }
 
 struct ST2 {
-// expected-error@+1 {{use of undeclared identifier 'SV_DispatchThreadID'}}
+// expected-warning@+1 {{'SV_DispatchThreadID' attribute only applies to parameters and non-static data members}}
     static uint X : SV_DispatchThreadID;
-// expected-error@+1 {{use of undeclared identifier 'SV_DispatchThreadID'}}
+// expected-error@+1 {{attribute 'SV_DispatchThreadID' only applies to parameter}}
     uint s : SV_DispatchThreadID;
 };

--- a/clang/test/SemaHLSL/resource_binding_attr_error.hlsl
+++ b/clang/test/SemaHLSL/resource_binding_attr_error.hlsl
@@ -55,6 +55,6 @@ void bar(RWBuffer<float> U : register(u3)) {
 struct S {
   // FIXME: generate better error when support semantic on struct field.
   // See https://github.com/llvm/llvm-project/issues/57889.
-  // expected-error@+1 {{expected expression}}
+  // expected-warning@+1 {{'register' attribute only applies to cbuffer/tbuffer and external global variables}}
   RWBuffer<float> U : register(u3);
 };


### PR DESCRIPTION
`MaybeParseHLSLAnnotations` should be run on Field Decls instead of just assuming that any colon after a field decl is a bitfield. In the case that HLSL is the language, the code after the colon may be an annotation. This PR gives the parser a chance to parse the subsequent text as if it was an HLSL annotation.

The burden of parsing is now on the HLSL parser, but the actual work needs to be done in handling every case of an hlsl annotation on a field decl. SV_DispatchThreadID was straightforward enough to implement in this PR, and tests have been added that the annotation appears as an attribute in the AST.

Previously, the `hlsl_annotations_on_struct_members.hlsl` test would result in an error shown below on the line that declares variable `a` in struct Eg9:
error: use of undeclared identifier
     'SV_DispatchThreadID'
This is because the annotation is parsed as if it was a c++ bit field, and an identifier
that represents an integer is expected, but not found.

This test ensures that hlsl annotations are parsed when parsing struct decls.
This test not only ensures we make progress by moving the validation error from the realm of
C++ and expecting bitfields, to HLSL and a specialized error for the recognized annotation, but also
validates that the parser does parse the annotation and adds an attribute to the field decl in the AST.

Fixes https://github.com/llvm/llvm-project/issues/57889