### PR TITLE
[llvm-objdump] Print out  xcoff file header for xcoff object file with option private-headers

### DIFF
--- a/llvm/test/tools/llvm-objdump/XCOFF/private-headers-option.test
+++ b/llvm/test/tools/llvm-objdump/XCOFF/private-headers-option.test
@@ -1,7 +1,7 @@
-## Test the --privated-headers option for XCOFF object files.
+## Test the --private-headers option for XCOFF object files.
 
-# RUN: yaml2obj --docnum=1 %s -o %t_xcoff32.o
-# RUN: yaml2obj --docnum=2  %s -o %t_xcoff64.o
+# RUN: yaml2obj -DMAGIC=0x1DF %s -o %t_xcoff32.o
+# RUN: yaml2obj -DMAGIC=0x1F7 %s -o %t_xcoff64.o
 # RUN: llvm-objdump --private-headers %t_xcoff32.o |\
 # RUN:   FileCheck %s --check-prefixes=CHECK32 --match-full-lines
 # RUN: llvm-objdump --private-headers %t_xcoff64.o |\
@@ -9,75 +9,30 @@
 
 --- !XCOFF
 FileHeader:
-  MagicNumber:       0x1DF
+  MagicNumber:       [[MAGIC]]
 Sections:
-  - Name:            .loader
-    Flags:           [ STYP_LOADER ]
-    SectionData:     "0000000100000003000000050000016D00000001000000A40000001800000211"
-##                    ^-------                                                           -Version=1
-##                            ^-------                                                   -NumberOfSymbolEntries=3
-##                                    ^-------                                           -NumberOfRelocationEntries=5
-##                                            ^-------                                   -LengthOfImportFileIDStringTable=365
-##                                                    ^-------                           -NumberOfImportFileIDs=1
-##                                                            ^-------                   -OffsetToImportFileIDs=0xA4
-##                                                                    ^-------           -LengthOfStringTable=24
-##                                                                            ^-------   -OffsetToStringTable=0x211
-
-
---- !XCOFF
-FileHeader:
-  MagicNumber:       0x1F7
-Sections:
-  - Name:            .loader
-    Flags:           [ STYP_LOADER ]
-    SectionData:     "0000000200000003000000050000016D000000010000002300000000000000D0000000000000023D00000000000000380000000000000080"
-##                    ^-------                                                           -Version=2
-##                            ^-------                                                   -NumberOfSymbolEntries=3
-##                                    ^-------                                           -NumberOfRelocationEntries=5
-##                                            ^-------                                   -LengthOfImportFileIDStringTable=365
-##                                                    ^-------                           -NumberOfImportFileIDs=1
-##                                                            ^-------                   --LengthOfStringTable=0x23
-##                                                                    ^---------------   -OffsetToImportFileIDs=0xD0
-##                                                                                    ^---------------                                        -OffsetToStringTable=0x23D
-##                                                                                                    ^--------------                         -OffsetToSymbolTable=0x38
-##                                                                                                                    ^---------------        -OffsetToRelocationEntries=0x80
+  - Name:            .text
+    Flags:           [ STYP_TEXT ]
+    SectionData:     "9061FFF880820000"
+  - Name:            .data
+    Flags:           [ STYP_DATA ]
+    SectionData:     "0000000000000FC0"
 
 # CHECK32:      ---File Header:
 # CHECK32-NEXT: Magic:              0x1df
-# CHECK32-NEXT: NumberOfSections:   1
+# CHECK32-NEXT: NumberOfSections:   2
 # CHECK32-NEXT: TimeStamp:          None (0)
 # CHECK32-NEXT: SymbolTableOffset:  0x0
 # CHECK32-NEXT: SymbolTableEntries: 0
 # CHECK32-NEXT: OptionalHeaderSize: 0x0
 # CHECK32-NEXT: Flags:              0x0
 
-# CHECK32:      ---Loader Section Header:
-# CHECK32-NEXT: Version:                           1
-# CHECK32-NEXT: NumberOfSymbolEntries:             3
-# CHECK32-NEXT: NumberOfRelocationEntries:         5
-# CHECK32-NEXT: LengthOfImportFileIDStringTable:   365
-# CHECK32-NEXT: NumberOfImportFileIDs:             1
-# CHECK32-NEXT: OffsetToImportFileIDs:             0xa4
-# CHECK32-NEXT: LengthOfStringTable:               24
-# CHECK32-NEXT: OffsetToStringTable:               0x211
-
 # CHECK64:      ---File Header:
 # CHECK64-NEXT: Magic:              0x1f7
-# CHECK64-NEXT: NumberOfSections:   1
+# CHECK64-NEXT: NumberOfSections:   2
 # CHECK64-NEXT: TimeStamp:          None (0)
 # CHECK64-NEXT: SymbolTableOffset:  0x0
 # CHECK64-NEXT: SymbolTableEntries: 0
 # CHECK64-NEXT: OptionalHeaderSize: 0x0
 # CHECK64-NEXT: Flags:              0x0
 
-# CHECK64:      ---Loader Section Header:
-# CHECK64-NEXT: Version:                           2
-# CHECK64-NEXT: NumberOfSymbolEntries:             3
-# CHECK64-NEXT: NumberOfRelocationEntries:         5
-# CHECK64-NEXT: LengthOfImportFileIDStringTable:   365
-# CHECK64-NEXT: NumberOfImportFileIDs:             1
-# CHECK64-NEXT: OffsetToImportFileIDs:             0xd0
-# CHECK64-NEXT: LengthOfStringTable:               35
-# CHECK64-NEXT: OffsetToStringTable:               0x23d
-# CHECK64-NEXT: OffsetToSymbolTable                0x38
-# CHECK64-NEXT: OffsetToRelocationEntries          0x80

--- a/llvm/test/tools/llvm-objdump/XCOFF/private-headers-option.test
+++ b/llvm/test/tools/llvm-objdump/XCOFF/private-headers-option.test
@@ -1,11 +1,15 @@
 ## Test the --private-headers option for XCOFF object files.
 
-# RUN: yaml2obj -DMAGIC=0x1DF %s -o %t_xcoff32.o
-# RUN: yaml2obj -DMAGIC=0x1F7 %s -o %t_xcoff64.o
-# RUN: llvm-objdump --private-headers %t_xcoff32.o |\
-# RUN:   FileCheck %s --check-prefixes=CHECK32 --match-full-lines
-# RUN: llvm-objdump --private-headers %t_xcoff64.o |\
-# RUN:   FileCheck %s --check-prefixes=CHECK64 --match-full-lines
+# RUN: yaml2obj -DMAGIC=0x1DF --docnum=1 %s -o %t_xcoff32.o
+# RUN: yaml2obj -DMAGIC=0x1F7 --docnum=1 %s -o %t_xcoff64.o
+# RUN: llvm-objdump --private-headers %t_xcoff32.o | \
+# RUN:   FileCheck %s --check-prefixes=CHECK32 --match-full-lines --strict-whitespace
+# RUN: llvm-objdump --private-headers %t_xcoff64.o | \
+# RUN:   FileCheck %s --check-prefixes=CHECK64 --match-full-lines --strict-whitespace
+
+# RUN: yaml2obj -DMAGIC=0x1DF --docnum=2 %s -o %t_xcoff_timestamp.o
+# RUN: llvm-objdump --private-headers %t_xcoff_timestamp.o | \
+# RUN:   FileCheck %s --match-full-lines
 
 --- !XCOFF
 FileHeader:
@@ -18,21 +22,29 @@ Sections:
     Flags:           [ STYP_DATA ]
     SectionData:     "0000000000000FC0"
 
-# CHECK32:      ---File Header:
-# CHECK32-NEXT: Magic:              0x1df
-# CHECK32-NEXT: NumberOfSections:   2
-# CHECK32-NEXT: TimeStamp:          None (0)
-# CHECK32-NEXT: SymbolTableOffset:  0x0
-# CHECK32-NEXT: SymbolTableEntries: 0
-# CHECK32-NEXT: OptionalHeaderSize: 0x0
-# CHECK32-NEXT: Flags:              0x0
+# CHECK32:---File Header:
+# CHECK32-NEXT:Magic:              0x1df
+# CHECK32-NEXT:NumberOfSections:   2
+# CHECK32-NEXT:TimeStamp:          None (0)
+# CHECK32-NEXT:SymbolTableOffset:  0x0
+# CHECK32-NEXT:SymbolTableEntries: 0
+# CHECK32-NEXT:OptionalHeaderSize: 0x0
+# CHECK32-NEXT:Flags:              0x0
 
-# CHECK64:      ---File Header:
-# CHECK64-NEXT: Magic:              0x1f7
-# CHECK64-NEXT: NumberOfSections:   2
-# CHECK64-NEXT: TimeStamp:          None (0)
-# CHECK64-NEXT: SymbolTableOffset:  0x0
-# CHECK64-NEXT: SymbolTableEntries: 0
-# CHECK64-NEXT: OptionalHeaderSize: 0x0
-# CHECK64-NEXT: Flags:              0x0
+# CHECK64:---File Header:
+# CHECK64-NEXT:Magic:              0x1f7
+# CHECK64-NEXT:NumberOfSections:   2
+# CHECK64-NEXT:TimeStamp:          None (0)
+# CHECK64-NEXT:SymbolTableOffset:  0x0
+# CHECK64-NEXT:SymbolTableEntries: 0
+# CHECK64-NEXT:OptionalHeaderSize: 0x0
+# CHECK64-NEXT:Flags:              0x0
 
+--- !XCOFF
+FileHeader:
+  MagicNumber:       0x1DF
+  CreationTime:      1234
+  EntriesInSymbolTable: -1
+
+# CHECK: TimeStamp:          1970-01-01 00:20:34 (1234)
+# CHECK: SymbolTableEntries: Reserved Value (-1)

--- a/llvm/test/tools/llvm-objdump/XCOFF/private-headers-option.test
+++ b/llvm/test/tools/llvm-objdump/XCOFF/private-headers-option.test
@@ -1,0 +1,83 @@
+## Test the --privated-headers option for XCOFF object files.
+
+# RUN: yaml2obj --docnum=1 %s -o %t_xcoff32.o
+# RUN: yaml2obj --docnum=2  %s -o %t_xcoff64.o
+# RUN: llvm-objdump --private-headers %t_xcoff32.o |\
+# RUN:   FileCheck %s --check-prefixes=CHECK32 --match-full-lines
+# RUN: llvm-objdump --private-headers %t_xcoff64.o |\
+# RUN:   FileCheck %s --check-prefixes=CHECK64 --match-full-lines
+
+--- !XCOFF
+FileHeader:
+  MagicNumber:       0x1DF
+Sections:
+  - Name:            .loader
+    Flags:           [ STYP_LOADER ]
+    SectionData:     "0000000100000003000000050000016D00000001000000A40000001800000211"
+##                    ^-------                                                           -Version=1
+##                            ^-------                                                   -NumberOfSymbolEntries=3
+##                                    ^-------                                           -NumberOfRelocationEntries=5
+##                                            ^-------                                   -LengthOfImportFileIDStringTable=365
+##                                                    ^-------                           -NumberOfImportFileIDs=1
+##                                                            ^-------                   -OffsetToImportFileIDs=0xA4
+##                                                                    ^-------           -LengthOfStringTable=24
+##                                                                            ^-------   -OffsetToStringTable=0x211
+
+
+--- !XCOFF
+FileHeader:
+  MagicNumber:       0x1F7
+Sections:
+  - Name:            .loader
+    Flags:           [ STYP_LOADER ]
+    SectionData:     "0000000200000003000000050000016D000000010000002300000000000000D0000000000000023D00000000000000380000000000000080"
+##                    ^-------                                                           -Version=2
+##                            ^-------                                                   -NumberOfSymbolEntries=3
+##                                    ^-------                                           -NumberOfRelocationEntries=5
+##                                            ^-------                                   -LengthOfImportFileIDStringTable=365
+##                                                    ^-------                           -NumberOfImportFileIDs=1
+##                                                            ^-------                   --LengthOfStringTable=0x23
+##                                                                    ^---------------   -OffsetToImportFileIDs=0xD0
+##                                                                                    ^---------------                                        -OffsetToStringTable=0x23D
+##                                                                                                    ^--------------                         -OffsetToSymbolTable=0x38
+##                                                                                                                    ^---------------        -OffsetToRelocationEntries=0x80
+
+# CHECK32:      ---File Header:
+# CHECK32-NEXT: Magic:              0x1df
+# CHECK32-NEXT: NumberOfSections:   1
+# CHECK32-NEXT: TimeStamp:          None (0)
+# CHECK32-NEXT: SymbolTableOffset:  0x0
+# CHECK32-NEXT: SymbolTableEntries: 0
+# CHECK32-NEXT: OptionalHeaderSize: 0x0
+# CHECK32-NEXT: Flags:              0x0
+
+# CHECK32:      ---Loader Section Header:
+# CHECK32-NEXT: Version:                           1
+# CHECK32-NEXT: NumberOfSymbolEntries:             3
+# CHECK32-NEXT: NumberOfRelocationEntries:         5
+# CHECK32-NEXT: LengthOfImportFileIDStringTable:   365
+# CHECK32-NEXT: NumberOfImportFileIDs:             1
+# CHECK32-NEXT: OffsetToImportFileIDs:             0xa4
+# CHECK32-NEXT: LengthOfStringTable:               24
+# CHECK32-NEXT: OffsetToStringTable:               0x211
+
+# CHECK64:      ---File Header:
+# CHECK64-NEXT: Magic:              0x1f7
+# CHECK64-NEXT: NumberOfSections:   1
+# CHECK64-NEXT: TimeStamp:          None (0)
+# CHECK64-NEXT: SymbolTableOffset:  0x0
+# CHECK64-NEXT: SymbolTableEntries: 0
+# CHECK64-NEXT: OptionalHeaderSize: 0x0
+# CHECK64-NEXT: Flags:              0x0
+
+# CHECK64:      ---Loader Section Header:
+# CHECK64-NEXT: Version:                           2
+# CHECK64-NEXT: NumberOfSymbolEntries:             3
+# CHECK64-NEXT: NumberOfRelocationEntries:         5
+# CHECK64-NEXT: LengthOfImportFileIDStringTable:   365
+# CHECK64-NEXT: NumberOfImportFileIDs:             1
+# CHECK64-NEXT: OffsetToImportFileIDs:             0xd0
+# CHECK64-NEXT: LengthOfStringTable:               35
+# CHECK64-NEXT: OffsetToStringTable:               0x23d
+# CHECK64-NEXT: OffsetToSymbolTable                0x38
+# CHECK64-NEXT: OffsetToRelocationEntries          0x80

--- a/llvm/test/tools/llvm-objdump/XCOFF/private-headers.test
+++ b/llvm/test/tools/llvm-objdump/XCOFF/private-headers.test
@@ -7,13 +7,10 @@
 # RUN: llvm-objdump --private-headers %t_xcoff64.o | \
 # RUN:   FileCheck %s --check-prefixes=CHECK64 --match-full-lines --strict-whitespace
 
-# RUN: yaml2obj -DMAGIC=0x1DF --docnum=2 %s -o %t_xcoff_timestamp.o
-# RUN: llvm-objdump --private-headers %t_xcoff_timestamp.o | \
-# RUN:   FileCheck %s --match-full-lines
-
 --- !XCOFF
 FileHeader:
   MagicNumber:       [[MAGIC]]
+  CreationTime:      1234
 Sections:
   - Name:            .text
     Flags:           [ STYP_TEXT ]
@@ -22,29 +19,34 @@ Sections:
     Flags:           [ STYP_DATA ]
     SectionData:     "0000000000000FC0"
 
-# CHECK32:---File Header:
+#      CHECK32:---File Header:
 # CHECK32-NEXT:Magic:              0x1df
 # CHECK32-NEXT:NumberOfSections:   2
-# CHECK32-NEXT:TimeStamp:          None (0)
+# CHECK32-NEXT:Timestamp:          1970-01-01 00:20:34 (1234)
 # CHECK32-NEXT:SymbolTableOffset:  0x0
 # CHECK32-NEXT:SymbolTableEntries: 0
 # CHECK32-NEXT:OptionalHeaderSize: 0x0
 # CHECK32-NEXT:Flags:              0x0
 
-# CHECK64:---File Header:
+#      CHECK64:---File Header:
 # CHECK64-NEXT:Magic:              0x1f7
 # CHECK64-NEXT:NumberOfSections:   2
-# CHECK64-NEXT:TimeStamp:          None (0)
+# CHECK64-NEXT:Timestamp:          1970-01-01 00:20:34 (1234)
 # CHECK64-NEXT:SymbolTableOffset:  0x0
 # CHECK64-NEXT:SymbolTableEntries: 0
 # CHECK64-NEXT:OptionalHeaderSize: 0x0
 # CHECK64-NEXT:Flags:              0x0
 
+
+## Test if the creation time of XCOFF is zero and the number of symbols is negative.
+# RUN: yaml2obj -DMAGIC=0x1DF --docnum=2 %s -o %t_xcoff_timestamp.o
+# RUN: llvm-objdump --private-headers %t_xcoff_timestamp.o | \
+# RUN:   FileCheck %s --match-full-lines
+
 --- !XCOFF
 FileHeader:
-  MagicNumber:       0x1DF
-  CreationTime:      1234
+  MagicNumber:          0x1DF
   EntriesInSymbolTable: -1
 
-# CHECK: TimeStamp:          1970-01-01 00:20:34 (1234)
+# CHECK: Timestamp:          None (0)
 # CHECK: SymbolTableEntries: Reserved Value (-1)

--- a/llvm/test/tools/llvm-objdump/XCOFF/private-headers.test
+++ b/llvm/test/tools/llvm-objdump/XCOFF/private-headers.test
@@ -37,7 +37,6 @@ Sections:
 # CHECK64-NEXT:OptionalHeaderSize: 0x0
 # CHECK64-NEXT:Flags:              0x0
 
-
 ## Test if the creation time of XCOFF is zero and the number of symbols is negative.
 # RUN: yaml2obj -DMAGIC=0x1DF --docnum=2 %s -o %t_xcoff_timestamp.o
 # RUN: llvm-objdump --private-headers %t_xcoff_timestamp.o | \
@@ -46,6 +45,7 @@ Sections:
 --- !XCOFF
 FileHeader:
   MagicNumber:          0x1DF
+  CreationTime:         0
   EntriesInSymbolTable: -1
 
 # CHECK: Timestamp:          None (0)

--- a/llvm/tools/llvm-objdump/XCOFFDump.cpp
+++ b/llvm/tools/llvm-objdump/XCOFFDump.cpp
@@ -63,8 +63,8 @@ void XCOFFDumper::printNumber(StringRef Name, uint64_t Value) {
 }
 
 void XCOFFDumper::printStrHex(StringRef Name, StringRef Str, uint64_t Value) {
-  outs() << formatName(Name) << Str << " (" << format_decimal(Value, 0) << ")"
-         << "\n";
+  outs() << formatName(Name) << Str << " (" << format_decimal(Value, 0)
+         << ")\n";
 }
 
 void XCOFFDumper::printFileHeader() {
@@ -73,30 +73,30 @@ void XCOFFDumper::printFileHeader() {
   printHex("Magic:", Obj.getMagic());
   printNumber("NumberOfSections:", Obj.getNumberOfSections());
 
-  int32_t TimeStamp = Obj.getTimeStamp();
+  int32_t Timestamp = Obj.getTimeStamp();
   if (TimeStamp > 0) {
-    // This handling of the time stamp assumes that the host  system's time_t is
-    // compatible with AIX time_t. If a platform is not  compatible, the lit
+    // This handling of the timestamp assumes that the host system's time_t is
+    // compatible with AIX time_t. If a platform is not compatible, the lit
     // tests will let us know.
     time_t TimeDate = TimeStamp;
 
     char FormattedTime[80] = {};
 
-    size_t BytesFormatted = strftime(FormattedTime, sizeof(FormattedTime),
-                                     "%F %T", gmtime(&TimeDate));
+    size_t BytesFormatted = std::strftime(FormattedTime, sizeof(FormattedTime),
+                                          "%F %T", gmtime(&TimeDate));
     if (BytesFormatted)
-      printStrHex("TimeStamp:", FormattedTime, TimeStamp);
+      printStrHex("Timestamp:", FormattedTime, TimeStamp);
     else
       printHex("Timestamp:", TimeStamp);
   } else {
     // Negative timestamp values are reserved for future use.
-    printStrHex("TimeStamp:", TimeStamp == 0 ? "None" : "Reserved Value",
+    printStrHex("Timestamp:", TimeStamp == 0 ? "None" : "Reserved Value",
                 TimeStamp);
   }
 
-  // The number of symbol table entries is an unsigned value in
-  // 64-bit objects and a signed value (with negative values
-  // being 'reserved') in 32-bit objects.
+  // The number of symbol table entries is an unsigned value in 64-bit objects
+  // and a signed value (with negative values being 'reserved') in 32-bit
+  // objects.
   if (Obj.is64Bit()) {
     printHex("SymbolTableOffset:", Obj.getSymbolTableOffset64());
     printNumber("SymbolTableEntries:", Obj.getNumberOfSymbolTableEntries64());

--- a/llvm/tools/llvm-objdump/XCOFFDump.cpp
+++ b/llvm/tools/llvm-objdump/XCOFFDump.cpp
@@ -73,24 +73,24 @@ void XCOFFDumper::printFileHeader() {
   printHex("Magic:", Obj.getMagic());
   printNumber("NumberOfSections:", Obj.getNumberOfSections());
 
-  int32_t TimeStamp = Obj.getTimeStamp();
-  if (TimeStamp > 0) {
+  int32_t Timestamp = Obj.getTimeStamp();
+  if (Timestamp > 0) {
     // This handling of the timestamp assumes that the host system's time_t is
     // compatible with AIX time_t. If a platform is not compatible, the lit
     // tests will let us know.
-    time_t TimeDate = TimeStamp;
+    time_t TimeDate = Timestamp;
 
-    char FormattedTime[80] = {};
+    char FormattedTime[20] = {};
 
     size_t BytesFormatted = std::strftime(FormattedTime, sizeof(FormattedTime),
-                                          "%F %T", gmtime(&TimeDate));
+                                          "%F %T", std::gmtime(&TimeDate));
     assert(BytesFormatted && "The size of the buffer FormattedTime is less "
                              "than the size of the date/time string.");
-    printStrHex("Timestamp:", FormattedTime, TimeStamp);
+    printStrHex("Timestamp:", FormattedTime, Timestamp);
   } else {
     // Negative timestamp values are reserved for future use.
-    printStrHex("Timestamp:", TimeStamp == 0 ? "None" : "Reserved Value",
-                TimeStamp);
+    printStrHex("Timestamp:", Timestamp == 0 ? "None" : "Reserved Value",
+                Timestamp);
   }
 
   // The number of symbol table entries is an unsigned value in 64-bit objects

--- a/llvm/tools/llvm-objdump/XCOFFDump.cpp
+++ b/llvm/tools/llvm-objdump/XCOFFDump.cpp
@@ -73,7 +73,7 @@ void XCOFFDumper::printFileHeader() {
   printHex("Magic:", Obj.getMagic());
   printNumber("NumberOfSections:", Obj.getNumberOfSections());
 
-  int32_t Timestamp = Obj.getTimeStamp();
+  int32_t TimeStamp = Obj.getTimeStamp();
   if (TimeStamp > 0) {
     // This handling of the timestamp assumes that the host system's time_t is
     // compatible with AIX time_t. If a platform is not compatible, the lit
@@ -84,10 +84,9 @@ void XCOFFDumper::printFileHeader() {
 
     size_t BytesFormatted = std::strftime(FormattedTime, sizeof(FormattedTime),
                                           "%F %T", gmtime(&TimeDate));
-    if (BytesFormatted)
-      printStrHex("Timestamp:", FormattedTime, TimeStamp);
-    else
-      printHex("Timestamp:", TimeStamp);
+    assert(BytesFormatted && "The size of the buffer FormattedTime is less "
+                             "than the size of the date/time string.");
+    printStrHex("Timestamp:", FormattedTime, TimeStamp);
   } else {
     // Negative timestamp values are reserved for future use.
     printStrHex("Timestamp:", TimeStamp == 0 ? "None" : "Reserved Value",

--- a/llvm/tools/llvm-objdump/XCOFFDump.cpp
+++ b/llvm/tools/llvm-objdump/XCOFFDump.cpp
@@ -41,7 +41,7 @@ public:
 private:
   void printPrivateHeaders() override;
   void printFileHeader();
-  void printAuxiliaryHeader(){};
+  void printAuxiliaryHeader() {};
   void printLoaderSectionHeader();
   FormattedString formatName(StringRef Name);
   void printHex(StringRef Name, uint64_t Value);

--- a/llvm/tools/llvm-objdump/XCOFFDump.cpp
+++ b/llvm/tools/llvm-objdump/XCOFFDump.cpp
@@ -48,9 +48,7 @@ private:
   void setWidth(unsigned W) { Width = W; };
 };
 
-void XCOFFDumper::printPrivateHeaders() {
-  printFileHeader();
-}
+void XCOFFDumper::printPrivateHeaders() { printFileHeader(); }
 
 FormattedString XCOFFDumper::formatName(StringRef Name) {
   return FormattedString(Name, Width, FormattedString::JustifyLeft);

--- a/llvm/tools/llvm-objdump/XCOFFDump.cpp
+++ b/llvm/tools/llvm-objdump/XCOFFDump.cpp
@@ -36,6 +36,8 @@ class XCOFFDumper : public objdump::Dumper {
   unsigned Width;
 public:
   XCOFFDumper(const object::XCOFFObjectFile &O) : Dumper(O), Obj(O) {}
+
+private:
   void printPrivateHeaders() override;
   void printFileHeader();
   void printAuxiliaryHeader(){};
@@ -44,7 +46,7 @@ public:
   void printHex(StringRef Name, uint64_t Value);
   void printNumber(StringRef Name, uint64_t Value);
   void printStrHex(StringRef Name, StringRef Str, uint64_t Value);
-  void setWidth(unsigned W) {Width =W;};
+  void setWidth(unsigned W) { Width = W; };
 };
 
 void XCOFFDumper::printPrivateHeaders() {
@@ -76,14 +78,12 @@ void XCOFFDumper::printFileHeader() {
   printHex("Magic:", Obj.getMagic());
   printNumber("NumberOfSections:", Obj.getNumberOfSections());
 
-  // Negative timestamp values are reserved for future use.
   int32_t TimeStamp = Obj.getTimeStamp();
+  // Negative timestamp values are reserved for future use.
   if (TimeStamp > 0) {
-    // This handling of the time stamp assumes that the host
-    // system's time_t is
-    //  compatible with AIX time_t. If a platform is not
-    //  compatible, the lit
-    // tests will let us know.
+    // This handling of the time stamp assumes that the host  system's time_t is
+    // compatible with AIX time_t. If a platform is not
+    //  compatible, the lit tests will let us know.
     time_t TimeDate = TimeStamp;
 
     char FormattedTime[80] = {};
@@ -102,7 +102,6 @@ void XCOFFDumper::printFileHeader() {
   // The number of symbol table entries is an unsigned value in
   // 64-bit objects and a signed value (with negative values
   // being 'reserved') in 32-bit objects.
-
   if (Obj.is64Bit()) {
     printHex("SymbolTableOffset:", Obj.getSymbolTableOffset64());
     printNumber("SymbolTableEntries:", Obj.getNumberOfSymbolTableEntries64());

--- a/llvm/tools/llvm-objdump/XCOFFDump.cpp
+++ b/llvm/tools/llvm-objdump/XCOFFDump.cpp
@@ -34,6 +34,7 @@ namespace {
 class XCOFFDumper : public objdump::Dumper {
   const XCOFFObjectFile &Obj;
   unsigned Width;
+
 public:
   XCOFFDumper(const object::XCOFFObjectFile &O) : Dumper(O), Obj(O) {}
 

--- a/llvm/tools/llvm-objdump/XCOFFDump.cpp
+++ b/llvm/tools/llvm-objdump/XCOFFDump.cpp
@@ -128,6 +128,9 @@ void XCOFFDumper::printLoaderSectionHeader() {
   }
   uintptr_t LoaderSectionAddr = LoaderSectionAddrOrError.get();
 
+  if (LoaderSectionAddr == 0)
+    return;
+
   auto PrintLoadSecHeaderCommon = [&](const auto *LDHeader) {
     printNumber("Version:", LDHeader->Version);
     printNumber("NumberOfSymbolEntries:", LDHeader->NumberOfSymTabEnt);


### PR DESCRIPTION
Print out the XCOFF file header and load section header for the XCOFF object file using llvm-objdump with the --private-headers option.