### PR TITLE
[libc][startup] check that we're cross compiling and using LLD

### DIFF
--- a/libc/startup/linux/CMakeLists.txt
+++ b/libc/startup/linux/CMakeLists.txt
@@ -26,7 +26,11 @@ function(merge_relocatable_object name)
   )
   # Pass -r to the driver is much cleaner than passing -Wl,-r: the compiler knows it is
   # a relocatable linking and will not pass other irrelevant flags to the linker.
-  target_link_options(${relocatable_target} PRIVATE -r -nostdlib --target=${explicit_target_triple})
+  set(link_opts -r -nostdlib)
+  if (explicit_target_triple AND LLVM_ENABLE_LLD)
+    list(APPEND link_opts --target=${explicit_target_triple})
+  endif()
+  target_link_options(${relocatable_target} PRIVATE ${link_opts})
   set_target_properties(
     ${relocatable_target}
     PROPERTIES


### PR DESCRIPTION
We only need to set `--target=` for LLD when cross compiling. This should fix
the host build using BFD or targeting the host.

Fixes: #96342