### PR TITLE
[clang] Improve diagnostics for constraints of inline asm (NFC)

### DIFF
--- a/clang/include/clang/Basic/DiagnosticCommonKinds.td
+++ b/clang/include/clang/Basic/DiagnosticCommonKinds.td
@@ -325,7 +325,7 @@ def err_asm_invalid_constraint_mem_or_reg : Error<
 def err_asm_invalid_constraint_missing_bracket : Error<
   "%sub{asm_invalid_constraint_generic}0,1: missing ']'">;
 def err_asm_invalid_constraint_wrong_symbol : Error<
-  "%sub{asm_invalid_constraint_generic}0,1: cannot find an output constraint"
+  "%sub{asm_invalid_constraint_generic}0,1: no matching output constraint"
   " with the specified name">;
 def err_asm_invalid_constraint_empty : Error<
   "%sub{asm_invalid_constraint_generic}0,1: empty constraint has been"
@@ -333,13 +333,13 @@ def err_asm_invalid_constraint_empty : Error<
 def err_asm_invalid_constraint_oob : Error<
   "%sub{asm_invalid_constraint_generic}0,1: the index is out of bounds">;
 def err_asm_invalid_constraint_missing : Error<
-  "%sub{asm_invalid_constraint_generic}0,1: references to a non-existing output"
+  "%sub{asm_invalid_constraint_generic}0,1: references non-existent output"
   " constraint">;
 def err_asm_invalid_constraint_wrongly_tied : Error<
   "%sub{asm_invalid_constraint_generic}0,1: tied constraint must be tied to"
   " the same operand referenced to by the number">;
 def err_asm_invalid_constraint_output_only : Error<
-  "%sub{asm_invalid_constraint_generic}0,1: must refer to an output only"
+  "%sub{asm_invalid_constraint_generic}0,1: must refer to an output-only"
   " operand">;
 
 def warn_stack_clash_protection_inline_asm : Warning<

--- a/clang/include/clang/Basic/DiagnosticCommonKinds.td
+++ b/clang/include/clang/Basic/DiagnosticCommonKinds.td
@@ -309,6 +309,39 @@ def err_asm_invalid_type : Error<
 def err_ms_asm_bitfield_unsupported : Error<
   "an inline asm block cannot have an operand which is a bit-field">;
 
+def asm_invalid_constraint_generic : TextSubstitution<
+  "invalid %select{input|output}0 constraint '%1' in asm">;
+def err_asm_invalid_constraint : Error<
+  "%sub{asm_invalid_constraint_generic}0,1">;
+def err_asm_invalid_constraint_start : Error<
+  "%sub{asm_invalid_constraint_generic}0,1: output constraint must start with"
+  " '=' or '+'">;
+def err_asm_invalid_constraint_rw_clobber : Error<
+  "%sub{asm_invalid_constraint_generic}0,1: early clobber with a read-write"
+  " constraint must be a register">;
+def err_asm_invalid_constraint_mem_or_reg : Error<
+  "%sub{asm_invalid_constraint_generic}0,1: constraint must allow either"
+  " memory or register operands">;
+def err_asm_invalid_constraint_missing_bracket : Error<
+  "%sub{asm_invalid_constraint_generic}0,1: missing ']'">;
+def err_asm_invalid_constraint_wrong_symbol : Error<
+  "%sub{asm_invalid_constraint_generic}0,1: cannot find an output constraint"
+  " with the specified name">;
+def err_asm_invalid_constraint_empty : Error<
+  "%sub{asm_invalid_constraint_generic}0,1: empty constraint has been"
+  " provided">;
+def err_asm_invalid_constraint_oob : Error<
+  "%sub{asm_invalid_constraint_generic}0,1: the index is out of bounds">;
+def err_asm_invalid_constraint_missing : Error<
+  "%sub{asm_invalid_constraint_generic}0,1: references to a non-existing output"
+  " constraint">;
+def err_asm_invalid_constraint_wrongly_tied : Error<
+  "%sub{asm_invalid_constraint_generic}0,1: tied constraint must be tied to"
+  " the same operand referenced to by the number">;
+def err_asm_invalid_constraint_output_only : Error<
+  "%sub{asm_invalid_constraint_generic}0,1: must refer to an output only"
+  " operand">;
+
 def warn_stack_clash_protection_inline_asm : Warning<
   "unable to protect inline asm that clobbers stack pointer against stack "
   "clash">, InGroup<DiagGroup<"stack-protector">>;

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -9280,12 +9280,8 @@ let CategoryName = "Inline Assembly Issue" in {
     : Error<"cannot pass a pointer-to-member through register-constrained "
             "inline assembly parameter">;
   def err_asm_invalid_lvalue_in_output : Error<"invalid lvalue in asm output">;
-  def err_asm_invalid_output_constraint : Error<
-    "invalid output constraint '%0' in asm">;
   def err_asm_invalid_lvalue_in_input : Error<
     "invalid lvalue in asm input for constraint '%0'">;
-  def err_asm_invalid_input_constraint : Error<
-    "invalid input constraint '%0' in asm">;
   def err_asm_tying_incompatible_types : Error<
     "unsupported inline asm: input with type "
     "%diff{$ matching output with type $|}0,1">;

--- a/clang/include/clang/Basic/TargetInfo.h
+++ b/clang/include/clang/Basic/TargetInfo.h
@@ -1197,7 +1197,6 @@ public:
 
   // validateOutputConstraint, validateInputConstraint - Checks that
   // a constraint is valid and provides information about it.
-  // FIXME: These should return a real error instead of just true/false.
   bool validateOutputConstraint(ConstraintInfo &Info,
                                 llvm::StringMap<bool> *FeatureMap,
                                 diag::kind &Diag) const;

--- a/clang/include/clang/Basic/TargetInfo.h
+++ b/clang/include/clang/Basic/TargetInfo.h
@@ -17,6 +17,7 @@
 #include "clang/Basic/AddressSpaces.h"
 #include "clang/Basic/BitmaskEnum.h"
 #include "clang/Basic/CodeGenOptions.h"
+#include "clang/Basic/DiagnosticIDs.h"
 #include "clang/Basic/LLVM.h"
 #include "clang/Basic/LangOptions.h"
 #include "clang/Basic/Specifiers.h"
@@ -1197,9 +1198,12 @@ public:
   // validateOutputConstraint, validateInputConstraint - Checks that
   // a constraint is valid and provides information about it.
   // FIXME: These should return a real error instead of just true/false.
-  bool validateOutputConstraint(ConstraintInfo &Info) const;
-  bool validateInputConstraint(MutableArrayRef<ConstraintInfo> OutputConstraints,
-                               ConstraintInfo &info) const;
+  bool validateOutputConstraint(ConstraintInfo &Info,
+                                llvm::StringMap<bool> *FeatureMap,
+                                diag::kind &Diag) const;
+  bool validateInputConstraint(
+      MutableArrayRef<ConstraintInfo> OutputConstraints, ConstraintInfo &Info,
+      llvm::StringMap<bool> *FeatureMap, diag::kind &Diag) const;
 
   virtual bool validateOutputSize(const llvm::StringMap<bool> &FeatureMap,
                                   StringRef /*Constraint*/,
@@ -1219,13 +1223,14 @@ public:
                              std::string &/*SuggestedModifier*/) const {
     return true;
   }
-  virtual bool
-  validateAsmConstraint(const char *&Name,
-                        TargetInfo::ConstraintInfo &info) const = 0;
+  virtual bool validateAsmConstraint(const char *&Name,
+                                     TargetInfo::ConstraintInfo &Info,
+                                     llvm::StringMap<bool> *FeatureMap,
+                                     diag::kind &Diag) const = 0;
 
   bool resolveSymbolicName(const char *&Name,
                            ArrayRef<ConstraintInfo> OutputConstraints,
-                           unsigned &Index) const;
+                           unsigned &Index, diag::kind &Diag) const;
 
   // Constraint parm will be left pointing at the last character of
   // the constraint.  In practice, it won't be changed unless the

--- a/clang/lib/Basic/Targets/AArch64.cpp
+++ b/clang/lib/Basic/Targets/AArch64.cpp
@@ -1339,8 +1339,10 @@ AArch64TargetInfo::convertConstraint(const char *&Constraint) const {
   return R;
 }
 
-bool AArch64TargetInfo::validateAsmConstraint(
-    const char *&Name, TargetInfo::ConstraintInfo &Info) const {
+bool AArch64TargetInfo::validateAsmConstraint(const char *&Name,
+                                              TargetInfo::ConstraintInfo &Info,
+                                              llvm::StringMap<bool> *FeatureMap,
+                                              diag::kind &Diag) const {
   switch (*Name) {
   default:
     return false;

--- a/clang/lib/Basic/Targets/AArch64.h
+++ b/clang/lib/Basic/Targets/AArch64.h
@@ -176,7 +176,9 @@ public:
   std::string convertConstraint(const char *&Constraint) const override;
 
   bool validateAsmConstraint(const char *&Name,
-                             TargetInfo::ConstraintInfo &Info) const override;
+                             TargetInfo::ConstraintInfo &Info,
+                             llvm::StringMap<bool> *FeatureMap,
+                             diag::kind &Diag) const override;
   bool
   validateConstraintModifier(StringRef Constraint, char Modifier, unsigned Size,
                              std::string &SuggestedModifier) const override;

--- a/clang/lib/Basic/Targets/AMDGPU.h
+++ b/clang/lib/Basic/Targets/AMDGPU.h
@@ -137,7 +137,9 @@ public:
   /// {s[n:m]}
   /// {a[n:m]}
   bool validateAsmConstraint(const char *&Name,
-                             TargetInfo::ConstraintInfo &Info) const override {
+                             TargetInfo::ConstraintInfo &Info,
+                             llvm::StringMap<bool> *FeatureMap,
+                             diag::kind &Diag) const override {
     static const ::llvm::StringSet<> SpecialRegs({
         "exec", "vcc", "flat_scratch", "m0", "scc", "tba", "tma",
         "flat_scratch_lo", "flat_scratch_hi", "vcc_lo", "vcc_hi", "exec_lo",
@@ -232,7 +234,8 @@ public:
 
     const char *Begin = Constraint;
     TargetInfo::ConstraintInfo Info("", "");
-    if (validateAsmConstraint(Constraint, Info))
+    diag::kind AsmDiag;
+    if (validateAsmConstraint(Constraint, Info, nullptr, AsmDiag))
       return std::string(Begin).substr(0, Constraint - Begin + 1);
 
     Constraint = Begin;

--- a/clang/lib/Basic/Targets/ARC.h
+++ b/clang/lib/Basic/Targets/ARC.h
@@ -64,7 +64,9 @@ public:
   }
 
   bool validateAsmConstraint(const char *&Name,
-                             TargetInfo::ConstraintInfo &Info) const override {
+                             TargetInfo::ConstraintInfo &Info,
+                             llvm::StringMap<bool> *FeatureMap,
+                             diag::kind &Diag) const override {
     return false;
   }
 

--- a/clang/lib/Basic/Targets/ARM.cpp
+++ b/clang/lib/Basic/Targets/ARM.cpp
@@ -1136,8 +1136,10 @@ ArrayRef<TargetInfo::GCCRegAlias> ARMTargetInfo::getGCCRegAliases() const {
   return llvm::ArrayRef(GCCRegAliases);
 }
 
-bool ARMTargetInfo::validateAsmConstraint(
-    const char *&Name, TargetInfo::ConstraintInfo &Info) const {
+bool ARMTargetInfo::validateAsmConstraint(const char *&Name,
+                                          TargetInfo::ConstraintInfo &Info,
+                                          llvm::StringMap<bool> *FeatureMap,
+                                          diag::kind &Diag) const {
   switch (*Name) {
   default:
     break;

--- a/clang/lib/Basic/Targets/ARM.h
+++ b/clang/lib/Basic/Targets/ARM.h
@@ -204,7 +204,9 @@ public:
   ArrayRef<const char *> getGCCRegNames() const override;
   ArrayRef<TargetInfo::GCCRegAlias> getGCCRegAliases() const override;
   bool validateAsmConstraint(const char *&Name,
-                             TargetInfo::ConstraintInfo &Info) const override;
+                             TargetInfo::ConstraintInfo &Info,
+                             llvm::StringMap<bool> *FeatureMap,
+                             diag::kind &Diag) const override;
   std::string convertConstraint(const char *&Constraint) const override;
   bool
   validateConstraintModifier(StringRef Constraint, char Modifier, unsigned Size,

--- a/clang/lib/Basic/Targets/AVR.h
+++ b/clang/lib/Basic/Targets/AVR.h
@@ -94,7 +94,9 @@ public:
   }
 
   bool validateAsmConstraint(const char *&Name,
-                             TargetInfo::ConstraintInfo &Info) const override {
+                             TargetInfo::ConstraintInfo &Info,
+                             llvm::StringMap<bool> *FeatureMap,
+                             diag::kind &Diag) const override {
     // There aren't any multi-character AVR specific constraints.
     if (StringRef(Name).size() > 1)
       return false;

--- a/clang/lib/Basic/Targets/BPF.h
+++ b/clang/lib/Basic/Targets/BPF.h
@@ -72,7 +72,9 @@ public:
   }
 
   bool validateAsmConstraint(const char *&Name,
-                             TargetInfo::ConstraintInfo &Info) const override {
+                             TargetInfo::ConstraintInfo &Info,
+                             llvm::StringMap<bool> *FeatureMap,
+                             diag::kind &Diag) const override {
     switch (*Name) {
     default:
       break;

--- a/clang/lib/Basic/Targets/CSKY.cpp
+++ b/clang/lib/Basic/Targets/CSKY.cpp
@@ -289,8 +289,10 @@ ArrayRef<TargetInfo::GCCRegAlias> CSKYTargetInfo::getGCCRegAliases() const {
   return llvm::ArrayRef(GCCRegAliases);
 }
 
-bool CSKYTargetInfo::validateAsmConstraint(
-    const char *&Name, TargetInfo::ConstraintInfo &Info) const {
+bool CSKYTargetInfo::validateAsmConstraint(const char *&Name,
+                                           TargetInfo::ConstraintInfo &Info,
+                                           llvm::StringMap<bool> *FeatureMap,
+                                           diag::kind &Diag) const {
   switch (*Name) {
   default:
     return false;

--- a/clang/lib/Basic/Targets/CSKY.h
+++ b/clang/lib/Basic/Targets/CSKY.h
@@ -80,7 +80,9 @@ public:
   }
 
   bool validateAsmConstraint(const char *&Name,
-                             TargetInfo::ConstraintInfo &info) const override;
+                             TargetInfo::ConstraintInfo &Info,
+                             llvm::StringMap<bool> *FeatureMap,
+                             diag::kind &Diag) const override;
 
   std::string_view getClobbers() const override { return ""; }
 

--- a/clang/lib/Basic/Targets/DirectX.h
+++ b/clang/lib/Basic/Targets/DirectX.h
@@ -83,7 +83,9 @@ public:
   }
 
   bool validateAsmConstraint(const char *&Name,
-                             TargetInfo::ConstraintInfo &info) const override {
+                             TargetInfo::ConstraintInfo &Info,
+                             llvm::StringMap<bool> *FeatureMap,
+                             diag::kind &Diag) const override {
     return true;
   }
 

--- a/clang/lib/Basic/Targets/Hexagon.h
+++ b/clang/lib/Basic/Targets/Hexagon.h
@@ -68,7 +68,9 @@ public:
   ArrayRef<Builtin::Info> getTargetBuiltins() const override;
 
   bool validateAsmConstraint(const char *&Name,
-                             TargetInfo::ConstraintInfo &Info) const override {
+                             TargetInfo::ConstraintInfo &Info,
+                             llvm::StringMap<bool> *FeatureMap,
+                             diag::kind &Diag) const override {
     switch (*Name) {
     case 'v':
     case 'q':

--- a/clang/lib/Basic/Targets/Lanai.h
+++ b/clang/lib/Basic/Targets/Lanai.h
@@ -83,7 +83,9 @@ public:
   }
 
   bool validateAsmConstraint(const char *&Name,
-                             TargetInfo::ConstraintInfo &info) const override {
+                             TargetInfo::ConstraintInfo &Info,
+                             llvm::StringMap<bool> *FeatureMap,
+                             diag::kind &Diag) const override {
     return false;
   }
 

--- a/clang/lib/Basic/Targets/Le64.h
+++ b/clang/lib/Basic/Targets/Le64.h
@@ -52,7 +52,9 @@ public:
   }
 
   bool validateAsmConstraint(const char *&Name,
-                             TargetInfo::ConstraintInfo &Info) const override {
+                             TargetInfo::ConstraintInfo &Info,
+                             llvm::StringMap<bool> *FeatureMap,
+                             diag::kind &Diag) const override {
     return false;
   }
 

--- a/clang/lib/Basic/Targets/LoongArch.cpp
+++ b/clang/lib/Basic/Targets/LoongArch.cpp
@@ -119,7 +119,8 @@ LoongArchTargetInfo::getGCCRegAliases() const {
 }
 
 bool LoongArchTargetInfo::validateAsmConstraint(
-    const char *&Name, TargetInfo::ConstraintInfo &Info) const {
+    const char *&Name, TargetInfo::ConstraintInfo &Info,
+    llvm::StringMap<bool> *FeatureMap, diag::kind &Diag) const {
   // See the GCC definitions here:
   // https://gcc.gnu.org/onlinedocs/gccint/Machine-Constraints.html
   // Note that the 'm' constraint is handled in TargetInfo.

--- a/clang/lib/Basic/Targets/LoongArch.h
+++ b/clang/lib/Basic/Targets/LoongArch.h
@@ -81,7 +81,9 @@ public:
   ArrayRef<TargetInfo::GCCRegAlias> getGCCRegAliases() const override;
 
   bool validateAsmConstraint(const char *&Name,
-                             TargetInfo::ConstraintInfo &Info) const override;
+                             TargetInfo::ConstraintInfo &Info,
+                             llvm::StringMap<bool> *FeatureMap,
+                             diag::kind &Diag) const override;
   std::string convertConstraint(const char *&Constraint) const override;
 
   bool hasBitIntType() const override { return true; }

--- a/clang/lib/Basic/Targets/M68k.cpp
+++ b/clang/lib/Basic/Targets/M68k.cpp
@@ -144,47 +144,49 @@ ArrayRef<TargetInfo::GCCRegAlias> M68kTargetInfo::getGCCRegAliases() const {
   return llvm::ArrayRef(GCCRegAliases);
 }
 
-bool M68kTargetInfo::validateAsmConstraint(
-    const char *&Name, TargetInfo::ConstraintInfo &info) const {
+bool M68kTargetInfo::validateAsmConstraint(const char *&Name,
+                                           TargetInfo::ConstraintInfo &Info,
+                                           llvm::StringMap<bool> *FeatureMap,
+                                           diag::kind &Diag) const {
   switch (*Name) {
   case 'a': // address register
   case 'd': // data register
-    info.setAllowsRegister();
+    Info.setAllowsRegister();
     return true;
   case 'I': // constant integer in the range [1,8]
-    info.setRequiresImmediate(1, 8);
+    Info.setRequiresImmediate(1, 8);
     return true;
   case 'J': // constant signed 16-bit integer
-    info.setRequiresImmediate(std::numeric_limits<int16_t>::min(),
+    Info.setRequiresImmediate(std::numeric_limits<int16_t>::min(),
                               std::numeric_limits<int16_t>::max());
     return true;
   case 'K': // constant that is NOT in the range of [-0x80, 0x80)
-    info.setRequiresImmediate();
+    Info.setRequiresImmediate();
     return true;
   case 'L': // constant integer in the range [-8,-1]
-    info.setRequiresImmediate(-8, -1);
+    Info.setRequiresImmediate(-8, -1);
     return true;
   case 'M': // constant that is NOT in the range of [-0x100, 0x100]
-    info.setRequiresImmediate();
+    Info.setRequiresImmediate();
     return true;
   case 'N': // constant integer in the range [24,31]
-    info.setRequiresImmediate(24, 31);
+    Info.setRequiresImmediate(24, 31);
     return true;
   case 'O': // constant integer 16
-    info.setRequiresImmediate(16);
+    Info.setRequiresImmediate(16);
     return true;
   case 'P': // constant integer in the range [8,15]
-    info.setRequiresImmediate(8, 15);
+    Info.setRequiresImmediate(8, 15);
     return true;
   case 'C':
     ++Name;
     switch (*Name) {
     case '0': // constant integer 0
-      info.setRequiresImmediate(0);
+      Info.setRequiresImmediate(0);
       return true;
     case 'i': // constant integer
     case 'j': // integer constant that doesn't fit in 16 bits
-      info.setRequiresImmediate();
+      Info.setRequiresImmediate();
       return true;
     default:
       break;
@@ -194,7 +196,7 @@ bool M68kTargetInfo::validateAsmConstraint(
   case 'U': // address register indirect w/ constant offset addressing
     // TODO: Handle 'S' (basically 'm' when pc-rel is enforced) when
     // '-mpcrel' flag is properly handled by the driver.
-    info.setAllowsMemory();
+    Info.setAllowsMemory();
     return true;
   default:
     break;

--- a/clang/lib/Basic/Targets/M68k.h
+++ b/clang/lib/Basic/Targets/M68k.h
@@ -50,7 +50,9 @@ public:
   ArrayRef<TargetInfo::GCCRegAlias> getGCCRegAliases() const override;
   std::string convertConstraint(const char *&Constraint) const override;
   bool validateAsmConstraint(const char *&Name,
-                             TargetInfo::ConstraintInfo &info) const override;
+                             TargetInfo::ConstraintInfo &Info,
+                             llvm::StringMap<bool> *FeatureMap,
+                             diag::kind &Diag) const override;
   std::optional<std::string> handleAsmEscapedChar(char EscChar) const override;
   std::string_view getClobbers() const override;
   BuiltinVaListKind getBuiltinVaListKind() const override;

--- a/clang/lib/Basic/Targets/MSP430.h
+++ b/clang/lib/Basic/Targets/MSP430.h
@@ -75,7 +75,9 @@ public:
   }
 
   bool validateAsmConstraint(const char *&Name,
-                             TargetInfo::ConstraintInfo &info) const override {
+                             TargetInfo::ConstraintInfo &Info,
+                             llvm::StringMap<bool> *FeatureMap,
+                             diag::kind &Diag) const override {
     // FIXME: implement
     switch (*Name) {
     case 'K': // the constant 1

--- a/clang/lib/Basic/Targets/Mips.h
+++ b/clang/lib/Basic/Targets/Mips.h
@@ -235,7 +235,9 @@ public:
   }
 
   bool validateAsmConstraint(const char *&Name,
-                             TargetInfo::ConstraintInfo &Info) const override {
+                             TargetInfo::ConstraintInfo &Info,
+                             llvm::StringMap<bool> *FeatureMap,
+                             diag::kind &Diag) const override {
     switch (*Name) {
     default:
       return false;

--- a/clang/lib/Basic/Targets/NVPTX.h
+++ b/clang/lib/Basic/Targets/NVPTX.h
@@ -95,7 +95,9 @@ public:
   }
 
   bool validateAsmConstraint(const char *&Name,
-                             TargetInfo::ConstraintInfo &Info) const override {
+                             TargetInfo::ConstraintInfo &Info,
+                             llvm::StringMap<bool> *FeatureMap,
+                             diag::kind &Diag) const override {
     switch (*Name) {
     default:
       return false;

--- a/clang/lib/Basic/Targets/PNaCl.h
+++ b/clang/lib/Basic/Targets/PNaCl.h
@@ -65,7 +65,9 @@ public:
   ArrayRef<TargetInfo::GCCRegAlias> getGCCRegAliases() const override;
 
   bool validateAsmConstraint(const char *&Name,
-                             TargetInfo::ConstraintInfo &Info) const override {
+                             TargetInfo::ConstraintInfo &Info,
+                             llvm::StringMap<bool> *FeatureMap,
+                             diag::kind &Diag) const override {
     return false;
   }
 

--- a/clang/lib/Basic/Targets/PPC.h
+++ b/clang/lib/Basic/Targets/PPC.h
@@ -210,7 +210,9 @@ public:
   ArrayRef<TargetInfo::AddlRegName> getGCCAddlRegNames() const override;
 
   bool validateAsmConstraint(const char *&Name,
-                             TargetInfo::ConstraintInfo &Info) const override {
+                             TargetInfo::ConstraintInfo &Info,
+                             llvm::StringMap<bool> *FeatureMap,
+                             diag::kind &Diag) const override {
     switch (*Name) {
     default:
       return false;

--- a/clang/lib/Basic/Targets/RISCV.cpp
+++ b/clang/lib/Basic/Targets/RISCV.cpp
@@ -71,8 +71,10 @@ ArrayRef<TargetInfo::GCCRegAlias> RISCVTargetInfo::getGCCRegAliases() const {
   return llvm::ArrayRef(GCCRegAliases);
 }
 
-bool RISCVTargetInfo::validateAsmConstraint(
-    const char *&Name, TargetInfo::ConstraintInfo &Info) const {
+bool RISCVTargetInfo::validateAsmConstraint(const char *&Name,
+                                            TargetInfo::ConstraintInfo &Info,
+                                            llvm::StringMap<bool> *FeatureMap,
+                                            diag::kind &Diag) const {
   switch (*Name) {
   default:
     return false;

--- a/clang/lib/Basic/Targets/RISCV.h
+++ b/clang/lib/Basic/Targets/RISCV.h
@@ -89,7 +89,9 @@ public:
   ArrayRef<TargetInfo::GCCRegAlias> getGCCRegAliases() const override;
 
   bool validateAsmConstraint(const char *&Name,
-                             TargetInfo::ConstraintInfo &Info) const override;
+                             TargetInfo::ConstraintInfo &Info,
+                             llvm::StringMap<bool> *FeatureMap,
+                             diag::kind &Diag) const override;
 
   std::string convertConstraint(const char *&Constraint) const override;
 

--- a/clang/lib/Basic/Targets/SPIR.cpp
+++ b/clang/lib/Basic/Targets/SPIR.cpp
@@ -72,8 +72,9 @@ bool SPIRV64AMDGCNTargetInfo::initFeatureMap(
 }
 
 bool SPIRV64AMDGCNTargetInfo::validateAsmConstraint(
-    const char *&Name, TargetInfo::ConstraintInfo &Info) const {
-  return AMDGPUTI.validateAsmConstraint(Name, Info);
+    const char *&Name, TargetInfo::ConstraintInfo &Info,
+    llvm::StringMap<bool> *FeatureMap, diag::kind &Diag) const {
+  return AMDGPUTI.validateAsmConstraint(Name, Info, FeatureMap, Diag);
 }
 
 std::string

--- a/clang/lib/Basic/Targets/SPIR.h
+++ b/clang/lib/Basic/Targets/SPIR.h
@@ -170,7 +170,9 @@ public:
   }
 
   bool validateAsmConstraint(const char *&Name,
-                             TargetInfo::ConstraintInfo &info) const override {
+                             TargetInfo::ConstraintInfo &Info,
+                             llvm::StringMap<bool> *FeatureMap,
+                             diag::kind &Diag) const override {
     return true;
   }
 
@@ -401,7 +403,9 @@ public:
                       const std::vector<std::string> &) const override;
 
   bool validateAsmConstraint(const char *&Name,
-                             TargetInfo::ConstraintInfo &Info) const override;
+                             TargetInfo::ConstraintInfo &Info,
+                             llvm::StringMap<bool> *FeatureMap,
+                             diag::kind &Diag) const override;
 
   std::string convertConstraint(const char *&Constraint) const override;
 

--- a/clang/lib/Basic/Targets/Sparc.h
+++ b/clang/lib/Basic/Targets/Sparc.h
@@ -58,7 +58,9 @@ public:
   ArrayRef<const char *> getGCCRegNames() const override;
   ArrayRef<TargetInfo::GCCRegAlias> getGCCRegAliases() const override;
   bool validateAsmConstraint(const char *&Name,
-                             TargetInfo::ConstraintInfo &info) const override {
+                             TargetInfo::ConstraintInfo &Info,
+                             llvm::StringMap<bool> *FeatureMap,
+                             diag::kind &Diag) const override {
     // FIXME: Implement!
     switch (*Name) {
     case 'I': // Signed 13-bit constant
@@ -72,7 +74,7 @@ public:
 
     case 'f':
     case 'e':
-      info.setAllowsRegister();
+      Info.setAllowsRegister();
       return true;
     }
     return false;

--- a/clang/lib/Basic/Targets/SystemZ.cpp
+++ b/clang/lib/Basic/Targets/SystemZ.cpp
@@ -53,8 +53,10 @@ ArrayRef<TargetInfo::AddlRegName> SystemZTargetInfo::getGCCAddlRegNames() const 
   return llvm::ArrayRef(GCCAddlRegNames);
 }
 
-bool SystemZTargetInfo::validateAsmConstraint(
-    const char *&Name, TargetInfo::ConstraintInfo &Info) const {
+bool SystemZTargetInfo::validateAsmConstraint(const char *&Name,
+                                              TargetInfo::ConstraintInfo &Info,
+                                              llvm::StringMap<bool> *FeatureMap,
+                                              diag::kind &Diag) const {
   switch (*Name) {
   default:
     return false;

--- a/clang/lib/Basic/Targets/SystemZ.h
+++ b/clang/lib/Basic/Targets/SystemZ.h
@@ -88,7 +88,9 @@ public:
   }
 
   bool validateAsmConstraint(const char *&Name,
-                             TargetInfo::ConstraintInfo &info) const override;
+                             TargetInfo::ConstraintInfo &Info,
+                             llvm::StringMap<bool> *FeatureMap,
+                             diag::kind &Diag) const override;
 
   std::string convertConstraint(const char *&Constraint) const override {
     switch (Constraint[0]) {

--- a/clang/lib/Basic/Targets/TCE.h
+++ b/clang/lib/Basic/Targets/TCE.h
@@ -110,7 +110,9 @@ public:
   }
 
   bool validateAsmConstraint(const char *&Name,
-                             TargetInfo::ConstraintInfo &info) const override {
+                             TargetInfo::ConstraintInfo &Info,
+                             llvm::StringMap<bool> *FeatureMap,
+                             diag::kind &Diag) const override {
     return true;
   }
 

--- a/clang/lib/Basic/Targets/VE.h
+++ b/clang/lib/Basic/Targets/VE.h
@@ -158,7 +158,9 @@ public:
   }
 
   bool validateAsmConstraint(const char *&Name,
-                             TargetInfo::ConstraintInfo &Info) const override {
+                             TargetInfo::ConstraintInfo &Info,
+                             llvm::StringMap<bool> *FeatureMap,
+                             diag::kind &Diag) const override {
     switch (*Name) {
     default:
       return false;

--- a/clang/lib/Basic/Targets/WebAssembly.h
+++ b/clang/lib/Basic/Targets/WebAssembly.h
@@ -132,7 +132,9 @@ private:
   }
 
   bool validateAsmConstraint(const char *&Name,
-                             TargetInfo::ConstraintInfo &Info) const final {
+                             TargetInfo::ConstraintInfo &Info,
+                             llvm::StringMap<bool> *FeatureMap,
+                             diag::kind &Diag) const final {
     return false;
   }
 

--- a/clang/lib/Basic/Targets/X86.cpp
+++ b/clang/lib/Basic/Targets/X86.cpp
@@ -1393,8 +1393,10 @@ static unsigned matchAsmCCConstraint(const char *Name) {
   return RV;
 }
 
-bool X86TargetInfo::validateAsmConstraint(
-    const char *&Name, TargetInfo::ConstraintInfo &Info) const {
+bool X86TargetInfo::validateAsmConstraint(const char *&Name,
+                                          TargetInfo::ConstraintInfo &Info,
+                                          llvm::StringMap<bool> *FeatureMap,
+                                          diag::kind &Diag) const {
   switch (*Name) {
   default:
     return false;

--- a/clang/lib/Basic/Targets/X86.h
+++ b/clang/lib/Basic/Targets/X86.h
@@ -239,7 +239,9 @@ public:
   std::optional<unsigned> getCPUCacheLineSize() const override;
 
   bool validateAsmConstraint(const char *&Name,
-                             TargetInfo::ConstraintInfo &info) const override;
+                             TargetInfo::ConstraintInfo &Info,
+                             llvm::StringMap<bool> *FeatureMap,
+                             diag::kind &Diag) const override;
 
   bool validateGlobalRegisterVariable(StringRef RegName, unsigned RegSize,
                                       bool &HasSizeMismatch) const override {

--- a/clang/lib/Basic/Targets/XCore.h
+++ b/clang/lib/Basic/Targets/XCore.h
@@ -64,7 +64,9 @@ public:
   }
 
   bool validateAsmConstraint(const char *&Name,
-                             TargetInfo::ConstraintInfo &Info) const override {
+                             TargetInfo::ConstraintInfo &Info,
+                             llvm::StringMap<bool> *FeatureMap,
+                             diag::kind &Diag) const override {
     return false;
   }
 

--- a/clang/lib/CodeGen/CGStmt.cpp
+++ b/clang/lib/CodeGen/CGStmt.cpp
@@ -2629,7 +2629,7 @@ void CodeGenFunction::EmitAsmStmt(const AsmStmt &S) {
   SmallVector<TargetInfo::ConstraintInfo, 4> OutputConstraintInfos;
   SmallVector<TargetInfo::ConstraintInfo, 4> InputConstraintInfos;
 
-  const FunctionDecl *FD = dyn_cast_or_null<FunctionDecl>(CurCodeDecl);
+  const auto *FD = dyn_cast_if_present<FunctionDecl>(CurCodeDecl);
   llvm::StringMap<bool> FeatureMap;
   CGM.getContext().getFunctionFeatureMap(FeatureMap, FD);
 

--- a/clang/lib/CodeGen/CGStmt.cpp
+++ b/clang/lib/CodeGen/CGStmt.cpp
@@ -2280,6 +2280,7 @@ static std::string
 SimplifyConstraint(const char *Constraint, const TargetInfo &Target,
                  SmallVectorImpl<TargetInfo::ConstraintInfo> *OutCons=nullptr) {
   std::string Result;
+  diag::kind Diag;
 
   while (*Constraint) {
     switch (*Constraint) {
@@ -2313,8 +2314,9 @@ SimplifyConstraint(const char *Constraint, const TargetInfo &Target,
       assert(OutCons &&
              "Must pass output names to constraints with a symbolic name");
       unsigned Index;
-      bool result = Target.resolveSymbolicName(Constraint, *OutCons, Index);
-      assert(result && "Could not resolve symbolic name"); (void)result;
+      [[maybe_unused]] bool result =
+          Target.resolveSymbolicName(Constraint, *OutCons, Index, Diag);
+      assert(result && "Could not resolve symbolic name");
       Result += llvm::utostr(Index);
       break;
     }
@@ -2351,7 +2353,8 @@ AddVariableConstraints(const std::string &Constraint, const Expr &AsmExpr,
   // We're using validateOutputConstraint here because we only care if
   // this is a register constraint.
   TargetInfo::ConstraintInfo Info(Constraint, "");
-  if (Target.validateOutputConstraint(Info) &&
+  diag::kind AsmDiag;
+  if (Target.validateOutputConstraint(Info, nullptr, AsmDiag) &&
       !Info.allowsRegister()) {
     CGM.ErrorUnsupported(&Stmt, "__asm__");
     return Constraint;
@@ -2626,14 +2629,20 @@ void CodeGenFunction::EmitAsmStmt(const AsmStmt &S) {
   SmallVector<TargetInfo::ConstraintInfo, 4> OutputConstraintInfos;
   SmallVector<TargetInfo::ConstraintInfo, 4> InputConstraintInfos;
 
+  const FunctionDecl *FD = dyn_cast_or_null<FunctionDecl>(CurCodeDecl);
+  llvm::StringMap<bool> FeatureMap;
+  CGM.getContext().getFunctionFeatureMap(FeatureMap, FD);
+
   bool IsHipStdPar = getLangOpts().HIPStdPar && getLangOpts().CUDAIsDevice;
   bool IsValidTargetAsm = true;
+  diag::kind AsmDiag;
   for (unsigned i = 0, e = S.getNumOutputs(); i != e && IsValidTargetAsm; i++) {
     StringRef Name;
     if (const GCCAsmStmt *GAS = dyn_cast<GCCAsmStmt>(&S))
       Name = GAS->getOutputName(i);
     TargetInfo::ConstraintInfo Info(S.getOutputConstraint(i), Name);
-    bool IsValid = getTarget().validateOutputConstraint(Info); (void)IsValid;
+    bool IsValid =
+        getTarget().validateOutputConstraint(Info, &FeatureMap, AsmDiag);
     if (IsHipStdPar && !IsValid)
       IsValidTargetAsm = false;
     else
@@ -2646,8 +2655,8 @@ void CodeGenFunction::EmitAsmStmt(const AsmStmt &S) {
     if (const GCCAsmStmt *GAS = dyn_cast<GCCAsmStmt>(&S))
       Name = GAS->getInputName(i);
     TargetInfo::ConstraintInfo Info(S.getInputConstraint(i), Name);
-    bool IsValid =
-      getTarget().validateInputConstraint(OutputConstraintInfos, Info);
+    bool IsValid = getTarget().validateInputConstraint(
+        OutputConstraintInfos, Info, &FeatureMap, AsmDiag);
     if (IsHipStdPar && !IsValid)
       IsValidTargetAsm = false;
     else

--- a/clang/test/Sema/asm.c
+++ b/clang/test/Sema/asm.c
@@ -12,7 +12,7 @@ void f(void) {
   asm ("foo\n" : [symbolic_name] "=a" (i) : "[symbolic_name]" (i));
   asm ("foo\n" : "=a" (i) : "[" (i)); // expected-error {{invalid input constraint '[' in asm: missing ']'}}
   asm ("foo\n" : "=a" (i) : "[foo" (i)); // expected-error {{invalid input constraint '[foo' in asm: missing ']'}}
-  asm ("foo\n" : "=a" (i) : "[symbolic_name]" (i)); // expected-error {{invalid input constraint '[symbolic_name]' in asm: cannot find an output constraint with the specified name}}
+  asm ("foo\n" : "=a" (i) : "[symbolic_name]" (i)); // expected-error {{invalid input constraint '[symbolic_name]' in asm: no matching output constraint with the specified name}}
 
   asm ("foo\n" : : "" (i)); // expected-error {{invalid input constraint '' in asm: empty constraint has been provided}}
   asm ("foo\n" : "=a" (i) : "" (i)); // expected-error {{invalid input constraint '' in asm: empty constraint has been provided}}
@@ -91,7 +91,7 @@ int test7(unsigned long long b) {
 // PR3904
 void test8(int i) {
   // A number in an input constraint can't point to a read-write constraint.
-  asm("" : "+r" (i), "=r"(i) :  "0" (i)); // expected-error{{invalid input constraint '0' in asm: must refer to an output only operand}}
+  asm("" : "+r" (i), "=r"(i) :  "0" (i)); // expected-error{{invalid input constraint '0' in asm: must refer to an output-only operand}}
 }
 
 // PR3905
@@ -234,14 +234,14 @@ void fn5(void) {
   int l;
     __asm__(""
           : [g] "+r"(l)
-          : "[g]"(l)); // expected-error {{invalid input constraint '[g]' in asm: must refer to an output only operand}}
+          : "[g]"(l)); // expected-error {{invalid input constraint '[g]' in asm: must refer to an output-only operand}}
 }
 
 void fn6(void) {
     int a;
   __asm__(""
             : "=rm"(a), "=rm"(a)
-            : "11m"(a)); // expected-error {{invalid input constraint '11m' in asm: references to a non-existing output constraint}}
+            : "11m"(a)); // expected-error {{invalid input constraint '11m' in asm: references non-existent output constraint}}
 }
 
 // PR14269
@@ -363,7 +363,6 @@ void test19(long long x)
 void test20(long long x)
 {
   st_size64 a;
-  asm ("" : "=rm" (a): "1" (1)); // expected-error {{invalid input constraint '1' in asm: references to a non-existing output constraint}}
   asm ("" : "=rm" (a): "9876543210" (1)); // expected-error {{invalid input constraint '9876543210' in asm: the index is out of bounds}}
   asm ("" : "rm" (a): "0" (1)); // expected-error {{invalid output constraint 'rm' in asm: output constraint must start with '=' or '+'}}
 }

--- a/clang/test/Sema/asm.c
+++ b/clang/test/Sema/asm.c
@@ -10,12 +10,12 @@ void f(void) {
   asm ("foo\n" : "=a" (i + 2)); // expected-error {{invalid lvalue in asm output}}
 
   asm ("foo\n" : [symbolic_name] "=a" (i) : "[symbolic_name]" (i));
-  asm ("foo\n" : "=a" (i) : "[" (i)); // expected-error {{invalid input constraint '[' in asm}}
-  asm ("foo\n" : "=a" (i) : "[foo" (i)); // expected-error {{invalid input constraint '[foo' in asm}}
-  asm ("foo\n" : "=a" (i) : "[symbolic_name]" (i)); // expected-error {{invalid input constraint '[symbolic_name]' in asm}}
+  asm ("foo\n" : "=a" (i) : "[" (i)); // expected-error {{invalid input constraint '[' in asm: missing ']'}}
+  asm ("foo\n" : "=a" (i) : "[foo" (i)); // expected-error {{invalid input constraint '[foo' in asm: missing ']'}}
+  asm ("foo\n" : "=a" (i) : "[symbolic_name]" (i)); // expected-error {{invalid input constraint '[symbolic_name]' in asm: cannot find an output constraint with the specified name}}
 
-  asm ("foo\n" : : "" (i)); // expected-error {{invalid input constraint '' in asm}}
-  asm ("foo\n" : "=a" (i) : "" (i)); // expected-error {{invalid input constraint '' in asm}}
+  asm ("foo\n" : : "" (i)); // expected-error {{invalid input constraint '' in asm: empty constraint has been provided}}
+  asm ("foo\n" : "=a" (i) : "" (i)); // expected-error {{invalid input constraint '' in asm: empty constraint has been provided}}
 }
 
 void clobbers(void) {
@@ -91,13 +91,13 @@ int test7(unsigned long long b) {
 // PR3904
 void test8(int i) {
   // A number in an input constraint can't point to a read-write constraint.
-  asm("" : "+r" (i), "=r"(i) :  "0" (i)); // expected-error{{invalid input constraint '0' in asm}}
+  asm("" : "+r" (i), "=r"(i) :  "0" (i)); // expected-error{{invalid input constraint '0' in asm: must refer to an output only operand}}
 }
 
 // PR3905
 void test9(int i) {
-  asm("" : [foo] "=r" (i), "=r"(i) : "1[foo]"(i)); // expected-error{{invalid input constraint '1[foo]' in asm}}
-  asm("" : [foo] "=r" (i), "=r"(i) : "[foo]1"(i)); // expected-error{{invalid input constraint '[foo]1' in asm}}
+  asm("" : [foo] "=r" (i), "=r"(i) : "1[foo]"(i)); // expected-error{{invalid input constraint '1[foo]' in asm: tied constraint must be tied to the same operand referenced to by the number}}
+  asm("" : [foo] "=r" (i), "=r"(i) : "[foo]1"(i)); // expected-error{{invalid input constraint '[foo]1' in asm: tied constraint must be tied to the same operand referenced to by the number}}
 }
 
 void test10(void){
@@ -139,14 +139,14 @@ void test14(struct S *s) {
 // PR15759.
 double test15(void) {
   double ret = 0;
-  __asm("0.0":"="(ret)); // expected-error {{invalid output constraint '=' in asm}}
-  __asm("0.0":"=&"(ret)); // expected-error {{invalid output constraint '=&' in asm}}
-  __asm("0.0":"+?"(ret)); // expected-error {{invalid output constraint '+?' in asm}}
-  __asm("0.0":"+!"(ret)); // expected-error {{invalid output constraint '+!' in asm}}
-  __asm("0.0":"+#"(ret)); // expected-error {{invalid output constraint '+#' in asm}}
-  __asm("0.0":"+*"(ret)); // expected-error {{invalid output constraint '+*' in asm}}
-  __asm("0.0":"=%"(ret)); // expected-error {{invalid output constraint '=%' in asm}}
-  __asm("0.0":"=,="(ret)); // expected-error {{invalid output constraint '=,=' in asm}}
+  __asm("0.0":"="(ret)); // expected-error {{invalid output constraint '=' in asm: constraint must allow either memory or register operands}}
+  __asm("0.0":"=&"(ret)); // expected-error {{invalid output constraint '=&' in asm: constraint must allow either memory or register operands}}
+  __asm("0.0":"+?"(ret)); // expected-error {{invalid output constraint '+?' in asm: constraint must allow either memory or register operands}}
+  __asm("0.0":"+!"(ret)); // expected-error {{invalid output constraint '+!' in asm: constraint must allow either memory or register operands}}
+  __asm("0.0":"+#"(ret)); // expected-error {{invalid output constraint '+#' in asm: constraint must allow either memory or register operands}}
+  __asm("0.0":"+*"(ret)); // expected-error {{invalid output constraint '+*' in asm: constraint must allow either memory or register operands}}
+  __asm("0.0":"=%"(ret)); // expected-error {{invalid output constraint '=%' in asm: constraint must allow either memory or register operands}}
+  __asm("0.0":"=,="(ret)); // expected-error {{invalid output constraint '=,=' in asm: constraint must allow either memory or register operands}}
   __asm("0.0":"=,g"(ret)); // no-error
   __asm("0.0":"=g"(ret)); // no-error
   return ret;
@@ -158,33 +158,33 @@ void iOutputConstraint(int x){
   __asm ("nop" : "=ig" (x) : :); // no-error
   __asm ("nop" : "=im" (x) : :); // no-error
   __asm ("nop" : "=imr" (x) : :); // no-error
-  __asm ("nop" : "=i" (x) : :); // expected-error{{invalid output constraint '=i' in asm}}
-  __asm ("nop" : "+i" (x) : :); // expected-error{{invalid output constraint '+i' in asm}}
-  __asm ("nop" : "=ii" (x) : :); // expected-error{{invalid output constraint '=ii' in asm}}
+  __asm ("nop" : "=i" (x) : :); // expected-error{{invalid output constraint '=i' in asm: constraint must allow either memory or register operands}}
+  __asm ("nop" : "+i" (x) : :); // expected-error{{invalid output constraint '+i' in asm: constraint must allow either memory or register operands}}
+  __asm ("nop" : "=ii" (x) : :); // expected-error{{invalid output constraint '=ii' in asm: constraint must allow either memory or register operands}}
   __asm ("nop" : "=nr" (x) : :); // no-error
   __asm ("nop" : "=rn" (x) : :); // no-error
   __asm ("nop" : "=ng" (x) : :); // no-error
   __asm ("nop" : "=nm" (x) : :); // no-error
   __asm ("nop" : "=nmr" (x) : :); // no-error
-  __asm ("nop" : "=n" (x) : :); // expected-error{{invalid output constraint '=n' in asm}}
-  __asm ("nop" : "+n" (x) : :); // expected-error{{invalid output constraint '+n' in asm}}
-  __asm ("nop" : "=nn" (x) : :); // expected-error{{invalid output constraint '=nn' in asm}}
+  __asm ("nop" : "=n" (x) : :); // expected-error{{invalid output constraint '=n' in asm: constraint must allow either memory or register operands}}
+  __asm ("nop" : "+n" (x) : :); // expected-error{{invalid output constraint '+n' in asm: constraint must allow either memory or register operands}}
+  __asm ("nop" : "=nn" (x) : :); // expected-error{{invalid output constraint '=nn' in asm: constraint must allow either memory or register operands}}
   __asm ("nop" : "=Fr" (x) : :); // no-error
   __asm ("nop" : "=rF" (x) : :); // no-error
   __asm ("nop" : "=Fg" (x) : :); // no-error
   __asm ("nop" : "=Fm" (x) : :); // no-error
   __asm ("nop" : "=Fmr" (x) : :); // no-error
-  __asm ("nop" : "=F" (x) : :); // expected-error{{invalid output constraint '=F' in asm}}
-  __asm ("nop" : "+F" (x) : :); // expected-error{{invalid output constraint '+F' in asm}}
-  __asm ("nop" : "=FF" (x) : :); // expected-error{{invalid output constraint '=FF' in asm}}
+  __asm ("nop" : "=F" (x) : :); // expected-error{{invalid output constraint '=F' in asm: constraint must allow either memory or register operands}}
+  __asm ("nop" : "+F" (x) : :); // expected-error{{invalid output constraint '+F' in asm: constraint must allow either memory or register operands}}
+  __asm ("nop" : "=FF" (x) : :); // expected-error{{invalid output constraint '=FF' in asm: constraint must allow either memory or register operands}}
   __asm ("nop" : "=Er" (x) : :); // no-error
   __asm ("nop" : "=rE" (x) : :); // no-error
   __asm ("nop" : "=Eg" (x) : :); // no-error
   __asm ("nop" : "=Em" (x) : :); // no-error
   __asm ("nop" : "=Emr" (x) : :); // no-error
-  __asm ("nop" : "=E" (x) : :); // expected-error{{invalid output constraint '=E' in asm}}
-  __asm ("nop" : "+E" (x) : :); // expected-error{{invalid output constraint '+E' in asm}}
-  __asm ("nop" : "=EE" (x) : :); // expected-error{{invalid output constraint '=EE' in asm}}
+  __asm ("nop" : "=E" (x) : :); // expected-error{{invalid output constraint '=E' in asm: constraint must allow either memory or register operands}}
+  __asm ("nop" : "+E" (x) : :); // expected-error{{invalid output constraint '+E' in asm: constraint must allow either memory or register operands}}
+  __asm ("nop" : "=EE" (x) : :); // expected-error{{invalid output constraint '=EE' in asm: constraint must allow either memory or register operands}}
 }
 
 // PR19837
@@ -214,13 +214,13 @@ void fn1(void) {
 void fn2(void) {
   int l;
  __asm__(""
-          : "+&m"(l)); // expected-error {{invalid output constraint '+&m' in asm}}
+          : "+&m"(l)); // expected-error {{invalid output constraint '+&m' in asm: early clobber with a read-write constraint must be a register}}
 }
 
 void fn3(void) {
   int l;
  __asm__(""
-          : "+#r"(l)); // expected-error {{invalid output constraint '+#r' in asm}}
+          : "+#r"(l)); // expected-error {{invalid output constraint '+#r' in asm: constraint must allow either memory or register operands}}
 }
 
 void fn4(void) {
@@ -234,14 +234,14 @@ void fn5(void) {
   int l;
     __asm__(""
           : [g] "+r"(l)
-          : "[g]"(l)); // expected-error {{invalid input constraint '[g]' in asm}}
+          : "[g]"(l)); // expected-error {{invalid input constraint '[g]' in asm: must refer to an output only operand}}
 }
 
 void fn6(void) {
     int a;
   __asm__(""
             : "=rm"(a), "=rm"(a)
-            : "11m"(a)); // expected-error {{invalid input constraint '11m' in asm}}
+            : "11m"(a)); // expected-error {{invalid input constraint '11m' in asm: references to a non-existing output constraint}}
 }
 
 // PR14269
@@ -358,4 +358,12 @@ void test19(long long x)
   asm ("" : "=rm" (e): "0" (1)); // no-error
   // FIXME: This case should be supported by codegen, but it fails now.
   asm ("" : "=rm" (x): "0" (e)); // expected-error {{unsupported inline asm: input with type 'st_size128' (aka 'struct _st_size128') matching output with type 'long long'}}
+}
+
+void test20(long long x)
+{
+  st_size64 a;
+  asm ("" : "=rm" (a): "1" (1)); // expected-error {{invalid input constraint '1' in asm: references to a non-existing output constraint}}
+  asm ("" : "=rm" (a): "9876543210" (1)); // expected-error {{invalid input constraint '9876543210' in asm: the index is out of bounds}}
+  asm ("" : "rm" (a): "0" (1)); // expected-error {{invalid output constraint 'rm' in asm: output constraint must start with '=' or '+'}}
 }


### PR DESCRIPTION
Introduce more detailed diagnostics for the constrains. Also provide an opportunity for backends to provide detailed diagnostics for target specific constraints based on enabled features. We provide features as a pointer intentionally because they are not available in some of existing uses. So backends need to consider whether features are available or not.