### PR TITLE
[AArch64][MachineOutliner][NFC] Re-enable some tests

### DIFF
--- a/llvm/test/CodeGen/AArch64/machine-outliner-retaddr-sign-cfi.ll
+++ b/llvm/test/CodeGen/AArch64/machine-outliner-retaddr-sign-cfi.ll
@@ -1,18 +1,17 @@
-; RUN: llc -verify-machineinstrs -enable-machine-outliner -mtriple \
-; RUN: aarch64 %s -o - | FileCheck %s --check-prefixes CHECK,V8A
-; RUN-V83A: llc -verify-machineinstrs -enable-machine-outliner -mtriple \
-; RUN-V83A: aarch64 -mattr=+v8.3a %s -o - > %t
-; RUN-V83A: FileCheck --check-prefixes CHECK,V83A < %t %s
+; RUN: llc -verify-machineinstrs -enable-machine-outliner -mtriple aarch64 %s -o - | \
+; RUN:   FileCheck %s --check-prefixes CHECK,V8A
+; RUN: llc -verify-machineinstrs -enable-machine-outliner -mtriple aarch64 -mattr=+v8.3a %s -o - | \
+; RUN:   FileCheck %s --check-prefixes CHECK,V83A
 
-; Function a's outlining candidate contains a sp modifying add without a
-; corresponsing sub, so we shouldn't outline it.
+;; Function a's outlining candidate contains a sp modifying add without a
+;; corresponsing sub, so we shouldn't outline it.
 define void @a() "sign-return-address"="all" "sign-return-address-key"="b_key" {
 ; CHECK-LABEL:         a:                     // @a
 ; CHECK:               // %bb.0:
 ; CHECK-NEXT:          .cfi_b_key_frame
 ; V8A-NEXT:            hint #27
 ; V83A-NEXT:           pacibsp
-; V8A-NEXT, V83A-NEXT: .cfi_negate_ra_state
+; CHECK-NEXT:          .cfi_negate_ra_state
   %1 = alloca i32, align 4
   %2 = alloca i32, align 4
   %3 = alloca i32, align 4
@@ -27,9 +26,8 @@ define void @a() "sign-return-address"="all" "sign-return-address-key"="b_key" {
   store i32 6, ptr %6, align 4
 ; CHECK-NOT:          bl OUTLINED_FUNCTION_{{[0-9]+}}
 ; V8A:                hint #31
-; V83A:               autibsp
-; V8A-NEXT, V83A-NEXT: .cfi_negate_ra_state
-; V8A-NEXT, V83A-NEXT: ret
+; V8A-NEXT:           ret
+; V83A:               retab
   ret void
 }
 
@@ -52,8 +50,8 @@ define void @b() "sign-return-address"="all" "sign-return-address-key"="b_key" n
   store i32 6, ptr %6, align 4
 ; CHECK:                bl [[OUTLINED_FUNC:OUTLINED_FUNCTION_[0-9]+]]
 ; V8A:                  hint #31
-; V83A:                 autibsp
-; V8A-NEXT, V83A-NEXT:  ret
+; V8A-NEXT:             ret
+; V83A:                 retab
   ret void
 }
 
@@ -76,8 +74,8 @@ define void @c() "sign-return-address"="all" "sign-return-address-key"="b_key" n
   store i32 6, ptr %6, align 4
 ; CHECK:                bl [[OUTLINED_FUNC]]
 ; V8A:                  hint #31
-; V83A:                 autibsp
-; V8A-NEXT, V83A-NEXT:  ret
+; V8A-NEXT:             ret
+; V83A:                 retab
   ret void
 }
 
@@ -86,5 +84,5 @@ define void @c() "sign-return-address"="all" "sign-return-address-key"="b_key" n
 ; V8A-NEXT:             hint #27
 ; V83A-NEXT:            pacibsp
 ; V8A:                  hint #31
-; V83A:                 autibsp
-; V8A-NEXT, V83A-NEXT:  ret
+; V8A-NEXT:             ret
+; V83A:                 retab

--- a/llvm/test/CodeGen/AArch64/machine-outliner-retaddr-sign-diff-scope-same-key.ll
+++ b/llvm/test/CodeGen/AArch64/machine-outliner-retaddr-sign-diff-scope-same-key.ll
@@ -1,8 +1,7 @@
-; RUN: llc -verify-machineinstrs -enable-machine-outliner -mtriple \
-; RUN: aarch64 %s -o - | FileCheck %s --check-prefixes CHECK,V8A
-; RUN-V83A: llc -verify-machineinstrs -enable-machine-outliner -mtriple \
-; RUN-V83A: aarch64 -mattr=+v8.3a %s -o - > %t
-; RUN-V83A: FileCheck --check-prefixes CHECK,V83A < %t %s
+; RUN: llc -verify-machineinstrs -enable-machine-outliner -mtriple aarch64 %s -o - | \
+; RUN:   FileCheck %s --check-prefixes CHECK,V8A
+; RUN: llc -verify-machineinstrs -enable-machine-outliner -mtriple aarch64 -mattr=+v8.3a %s -o - | \
+; RUN:   FileCheck %s --check-prefixes CHECK,V83A
 
 define void @a() "sign-return-address"="all" {
 ; CHECK-LABEL:      a:                                     // @a
@@ -22,13 +21,13 @@ define void @a() "sign-return-address"="all" {
   store i32 5, ptr %5, align 4
   store i32 6, ptr %6, align 4
 ; V8A:            hint #29
-; V83A:           autiasp
+; V83A:           retaa
   ret void
 ; CHECK:          .cfi_endproc
 }
 
 define void @b() "sign-return-address"="non-leaf" {
-; CHECK-LABE:      b:                                     // @b
+; CHECK-LABEL:     b:                                     // @b
 ; V8A-NOT:         hint #25
 ; V83A-NOT:        paciasp
 ; CHECK-NOT:       .cfi_negate_ra_state
@@ -46,6 +45,7 @@ define void @b() "sign-return-address"="non-leaf" {
   store i32 6, ptr %6, align 4
 ; V8A-NOT:          hint #29
 ; V83A-NOT:         autiasp
+; V83A-NOT:         retaa
   ret void
 ; CHECK:            .cfi_endproc
 }
@@ -54,7 +54,7 @@ define void @c() "sign-return-address"="all" {
 ; CHECK-LABEL:         c:              // @c
 ; V8A:                 hint #25
 ; V83A:                paciasp
-; V8A-NEXT, V83A-NEXT: .cfi_negate_ra_state
+; CHECK-NEXT:          .cfi_negate_ra_state
   %1 = alloca i32, align 4
   %2 = alloca i32, align 4
   %3 = alloca i32, align 4
@@ -68,7 +68,7 @@ define void @c() "sign-return-address"="all" {
   store i32 5, ptr %5, align 4
   store i32 6, ptr %6, align 4
 ; V8A:            hint #29
-; V83A:           autiasp
+; V83A:           retaa
   ret void
 ; CHECK:          .cfi_endproc
 }

--- a/llvm/test/CodeGen/AArch64/machine-outliner-retaddr-sign-non-leaf.ll
+++ b/llvm/test/CodeGen/AArch64/machine-outliner-retaddr-sign-non-leaf.ll
@@ -1,8 +1,7 @@
-; RUN: llc -verify-machineinstrs -enable-machine-outliner -mtriple \
-; RUN: aarch64 %s -o - | FileCheck %s --check-prefixes CHECK,V8A
-; RUN-V83A: llc -verify-machineinstrs -enable-machine-outliner -mtriple \
-; RUN-V83A: aarch64 -mattr=+v8.3a %s -o - > %t
-; RUN-V83A: FileCheck --check-prefixes CHECK,V83A < %t %s
+; RUN: llc -verify-machineinstrs -enable-machine-outliner -mtriple aarch64 %s -o - | \
+; RUN:   FileCheck %s --check-prefixes CHECK,V8A
+; RUN: llc -verify-machineinstrs -enable-machine-outliner -mtriple aarch64 -mattr=+v8.3a %s -o - | \
+; RUN:   FileCheck %s --check-prefixes CHECK,V83A
 
 define i64 @a(i64 %x) "sign-return-address"="non-leaf" "sign-return-address-key"="b_key" {
 ; CHECK-LABEL:      a:                                     // @a
@@ -70,7 +69,7 @@ define i64 @c(i64 %x) "sign-return-address"="non-leaf" "sign-return-address-key"
   ret i64 %x
 }
 
-; Outlined function is leaf-function => don't sign it
+;; Outlined function is leaf-function => don't sign it
 ; CHECK-LABEL:      OUTLINED_FUNCTION_0:
 ; CHECK-NOT:            .cfi_b_key_frame
 ; CHECK-NOT:            paci{{[a,b]}}sp

--- a/llvm/test/CodeGen/AArch64/machine-outliner-retaddr-sign-regsave.mir
+++ b/llvm/test/CodeGen/AArch64/machine-outliner-retaddr-sign-regsave.mir
@@ -126,6 +126,6 @@ body:             |
 # CHECK:         body:
 # CHECK-NEXT:     bb.0:
 # CHECK-NOT:        frame-setup EMITBKEY
-# CHECK-NOT:        frame-setup PACI{{[A,B]]}}SP
+# CHECK-NOT:        frame-setup PACI{{[A,B]}}SP
 # CHECK-NOT:        frame-setup CFI_INSTRUCTION negate_ra_sign_state
-# CHECK-NOT:        frame-destroy AUTI{{[A,B]]}}SP
+# CHECK-NOT:        frame-destroy AUTI{{[A,B]}}SP

--- a/llvm/test/CodeGen/AArch64/machine-outliner-retaddr-sign-same-scope-diff-key.ll
+++ b/llvm/test/CodeGen/AArch64/machine-outliner-retaddr-sign-same-scope-diff-key.ll
@@ -1,8 +1,7 @@
-; RUN: llc -verify-machineinstrs -enable-machine-outliner -mtriple \
-; RUN: aarch64 %s -o - | FileCheck %s --check-prefixes CHECK,V8A
-; RUN-V83A: llc -verify-machineinstrs -enable-machine-outliner -mtriple \
-; RUN-V83A: aarch64 -mattr=+v8.3a %s -o - > %t
-; RUN-V83A: FileCheck --check-prefixes CHECK,V83A < %t %s
+; RUN: llc -verify-machineinstrs -enable-machine-outliner -mtriple aarch64 %s -o - | \
+; RUN:   FileCheck %s --check-prefixes CHECK,V8A
+; RUN: llc -verify-machineinstrs -enable-machine-outliner -mtriple aarch64 -mattr=+v8.3a %s -o - | \
+; RUN:   FileCheck %s --check-prefixes CHECK,V83A
 
 define void @a() "sign-return-address"="all" {
 ; CHECK-LABEL:      a:                                     // @a
@@ -22,7 +21,7 @@ define void @a() "sign-return-address"="all" {
   store i32 5, ptr %5, align 4
   store i32 6, ptr %6, align 4
 ; V8A:            hint #29
-; V83A:           autiasp
+; V83A:           retaa
   ret void
 ; CHECK:          .cfi_endproc
 }
@@ -47,6 +46,7 @@ define void @b() "sign-return-address"="all" "sign-return-address-key"="b_key" {
   store i32 6, ptr %6, align 4
 ; V8A-NOT:          hint #29
 ; V83A-NOT:         autiasp
+; V83A-NOT:         retaa
   ret void
 ; CHECK:            .cfi_endproc
 }
@@ -69,7 +69,7 @@ define void @c() "sign-return-address"="all" {
   store i32 5, ptr %5, align 4
   store i32 6, ptr %6, align 4
 ; V8A:            hint #29
-; V83A:           autiasp
+; V83A:           retaa
   ret void
 ; CHECK:          .cfi_endproc
 }

--- a/llvm/test/CodeGen/AArch64/machine-outliner-retaddr-sign-same-scope-same-key-a.ll
+++ b/llvm/test/CodeGen/AArch64/machine-outliner-retaddr-sign-same-scope-same-key-a.ll
@@ -1,8 +1,7 @@
-; RUN: llc -verify-machineinstrs -enable-machine-outliner -mtriple \
-; RUN: aarch64 %s -o - | FileCheck %s --check-prefixes CHECK,V8A
-; RUN-V83A: llc -verify-machineinstrs -enable-machine-outliner -mtriple \
-; RUN-V83A: aarch64 -mattr=+v8.3a %s -o - > %t
-; RUN-V83A: FileCheck --check-prefixes CHECK,V83A < %t %s
+; RUN: llc -verify-machineinstrs -enable-machine-outliner -mtriple aarch64 %s -o - | \
+; RUN:   FileCheck %s --check-prefixes CHECK,V8A
+; RUN: llc -verify-machineinstrs -enable-machine-outliner -mtriple aarch64 -mattr=+v8.3a %s -o - | \
+; RUN:   FileCheck %s --check-prefixes CHECK,V83A
 
 define void @a() "sign-return-address"="all" "sign-return-address-key"="a_key" nounwind {
 ; CHECK-LABEL:      a:                                     // @a
@@ -21,7 +20,7 @@ define void @a() "sign-return-address"="all" "sign-return-address-key"="a_key" n
   store i32 5, ptr %5, align 4
   store i32 6, ptr %6, align 4
 ; V8A:              hint #29
-; V83A:             autiasp
+; V83A:             retaa
   ret void
 }
 
@@ -42,7 +41,7 @@ define void @b() "sign-return-address"="all" nounwind {
   store i32 5, ptr %5, align 4
   store i32 6, ptr %6, align 4
 ; V8A:              hint #29
-; V83A:             autiasp
+; V83A:             retaa
   ret void
 }
 
@@ -63,7 +62,7 @@ define void @c() "sign-return-address"="all" nounwind {
   store i32 5, ptr %5, align 4
   store i32 6, ptr %6, align 4
 ; V8A:              hint #29
-; V83A:             autiasp
+; V83A:             retaa
   ret void
 }
 
@@ -71,5 +70,5 @@ define void @c() "sign-return-address"="all" nounwind {
 ; V8A:                hint #25
 ; V83A:               paciasp
 ; V8A:                hint #29
-; V83A:               autiasp
-; CHECK-NEXT:         ret
+; V8A-NEXT:           ret
+; V83A:               retaa

--- a/llvm/test/CodeGen/AArch64/machine-outliner-retaddr-sign-same-scope-same-key-b.ll
+++ b/llvm/test/CodeGen/AArch64/machine-outliner-retaddr-sign-same-scope-same-key-b.ll
@@ -1,8 +1,7 @@
-; RUN: llc -verify-machineinstrs -enable-machine-outliner -mtriple \
-; RUN: aarch64 %s -o - | FileCheck %s --check-prefixes CHECK,V8A
-; RUN-V83A: llc -verify-machineinstrs -enable-machine-outliner -mtriple \
-; RUN-V83A: aarch64 -mattr=+v8.3a %s -o - > %t
-; RUN-V83A: FileCheck --check-prefixes CHECK,V83A < %t %s
+; RUN: llc -verify-machineinstrs -enable-machine-outliner -mtriple aarch64 %s -o - | \
+; RUN:   FileCheck %s --check-prefixes CHECK,V8A
+; RUN: llc -verify-machineinstrs -enable-machine-outliner -mtriple aarch64 -mattr=+v8.3a %s -o - | \
+; RUN:   FileCheck %s --check-prefixes CHECK,V83A
 
 define void @a() "sign-return-address"="all" "sign-return-address-key"="b_key" nounwind {
 ; CHECK-LABEL:      a:                                     // @a
@@ -22,7 +21,7 @@ define void @a() "sign-return-address"="all" "sign-return-address-key"="b_key" n
   store i32 5, ptr %5, align 4
   store i32 6, ptr %6, align 4
 ; V8A:              hint #31
-; V83A:             autibsp
+; V83A:             retab
   ret void
 }
 
@@ -44,7 +43,7 @@ define void @b() "sign-return-address"="all" "sign-return-address-key"="b_key" n
   store i32 5, ptr %5, align 4
   store i32 6, ptr %6, align 4
 ; V8A:              hint #31
-; V83A:             autibsp
+; V83A:             retab
   ret void
 }
 
@@ -66,7 +65,7 @@ define void @c() "sign-return-address"="all" "sign-return-address-key"="b_key" n
   store i32 5, ptr %5, align 4
   store i32 6, ptr %6, align 4
 ; V8A:              hint #31
-; V83A:             autibsp
+; V83A:             retab
   ret void
 }
 
@@ -75,5 +74,5 @@ define void @c() "sign-return-address"="all" "sign-return-address-key"="b_key" n
 ; V8A-NEXT:             hint #27
 ; V83A-NEXT:            pacibsp
 ; V8A:                  hint #31
-; V83A:                 autibsp
-; CHECK-NEXT:           ret
+; V8A-NEXT:             ret
+; V83A:                 retab

--- a/llvm/test/CodeGen/AArch64/machine-outliner-retaddr-sign-subtarget.ll
+++ b/llvm/test/CodeGen/AArch64/machine-outliner-retaddr-sign-subtarget.ll
@@ -24,8 +24,8 @@ define void @a() #0 {
   store i32 4, ptr %4, align 4
   store i32 5, ptr %5, align 4
   store i32 6, ptr %6, align 4
+; CHECK-NOT:              auti{{[a,b]}}sp
 ; CHECK:                  retab
-; CHECK-NOT:              auti[a,b]sp
   ret void
 }
 
@@ -48,8 +48,8 @@ define void @b() #0 {
   store i32 4, ptr %4, align 4
   store i32 5, ptr %5, align 4
   store i32 6, ptr %6, align 4
+; CHECK-NOT:              auti{{[a,b]}}sp
 ; CHECK:                  retab
-; CHECK-NOT:              auti[a,b]sp
   ret void
 }
 

--- a/llvm/test/CodeGen/AArch64/machine-outliner-retaddr-sign-thunk.ll
+++ b/llvm/test/CodeGen/AArch64/machine-outliner-retaddr-sign-thunk.ll
@@ -1,8 +1,8 @@
 ; RUN: llc -mtriple aarch64-arm-linux-gnu --enable-machine-outliner -outliner-leaf-descendants=false \
-; RUN: -verify-machineinstrs %s -o - | FileCheck --check-prefixes CHECK,V8A %s
-; RUN-V83A: llc -mtriple aarch64 -enable-machine-outliner -outliner-leaf-descendants=false \
-; RUN-V83A: -verify-machineinstrs -mattr=+v8.3a %s -o - > %t
-; RUN-V83A: FileCheck --check-prefixes CHECK,V83A < %t %s
+; RUN:   -verify-machineinstrs %s -o - | FileCheck --check-prefixes CHECK,V8A %s
+; RUN: llc -mtriple aarch64 -enable-machine-outliner -outliner-leaf-descendants=false \
+; RUN:   -verify-machineinstrs -mattr=+v8.3a %s -o - | \
+; RUN:   FileCheck %s --check-prefixes CHECK,V83A
 
 declare i32 @thunk_called_fn(i32, i32, i32, i32)
 
@@ -13,8 +13,8 @@ define i32 @a() #0 {
 ; V83A-NEXT:        paciasp
 ; CHECK-NEXT:       .cfi_negate_ra_state
 ; V8A:              hint #29
-; V83A:             autiasp
-; CHECK-NEXT:       ret
+; V8A-NEXT:         ret
+; V83A:             retaa
 entry:
   %call = tail call i32 @thunk_called_fn(i32 1, i32 2, i32 3, i32 4)
   %cx = add i32 %call, 8
@@ -28,8 +28,8 @@ define i32 @b() #0 {
 ; V83A-NEXT:        paciasp
 ; CHECK-NEXT:       .cfi_negate_ra_state
 ; V8A:              hint #29
-; V83A:             autiasp
-; CHECK-NEXT:       ret
+; V8A-NEXT:         ret
+; V83A:             retaa
 entry:
   %call = tail call i32 @thunk_called_fn(i32 1, i32 2, i32 3, i32 4)
   %cx = add i32 %call, 88
@@ -43,8 +43,8 @@ define hidden i32 @c(ptr %fptr) #0 {
 ; V83A-NEXT:        paciasp
 ; CHECK-NEXT:       .cfi_negate_ra_state
 ; V8A:              hint #29
-; V83A:             autiasp
-; CHECK-NEXT:       ret
+; V8A-NEXT:         ret
+; V83A:             retaa
 entry:
   %call = tail call i32 %fptr(i32 1, i32 2, i32 3, i32 4)
   %add = add nsw i32 %call, 8
@@ -58,8 +58,8 @@ define hidden i32 @d(ptr %fptr) #0 {
 ; V83A-NEXT:        paciasp
 ; CHECK-NEXT:       .cfi_negate_ra_state
 ; V8A:              hint #29
-; V83A:             autiasp
-; CHECK-NEXT:       ret
+; V8A-NEXT:         ret
+; V83A:             retaa
 entry:
   %call = tail call i32 %fptr(i32 1, i32 2, i32 3, i32 4)
   %add = add nsw i32 %call, 88

--- a/llvm/test/CodeGen/AArch64/machine-outliner-retaddr-sign-v8-3.ll
+++ b/llvm/test/CodeGen/AArch64/machine-outliner-retaddr-sign-v8-3.ll
@@ -21,8 +21,8 @@ define void @a() #0 {
   store i32 4, ptr %4, align 4
   store i32 5, ptr %5, align 4
   store i32 6, ptr %6, align 4
+; CHECK-NOT:              auti{{[a,b]}}sp
 ; CHECK:                  retab
-; CHECK-NOT:              auti[a,b]sp
   ret void
 }
 
@@ -43,8 +43,8 @@ define void @b() #0 {
   store i32 4, ptr %4, align 4
   store i32 5, ptr %5, align 4
   store i32 6, ptr %6, align 4
+; CHECK-NOT:              auti{{[a,b]}}sp
 ; CHECK:                  retab
-; CHECK-NOT:              auti[a,b]sp
   ret void
 }
 
@@ -65,8 +65,8 @@ define void @c() #0 {
   store i32 4, ptr %4, align 4
   store i32 5, ptr %5, align 4
   store i32 6, ptr %6, align 4
+; CHECK-NOT:              auti{{[a,b]}}sp
 ; CHECK:                  retab
-; CHECK-NOT:              auti[a,b]sp
   ret void
 }
 
@@ -78,5 +78,5 @@ attributes #0 = { "sign-return-address"="all"
 ; CHECK:            OUTLINED_FUNC
 ; CHECK:            // %bb.0:
 ; CHECK-NEXT:               pacibsp
+; CHECK-NOT:                auti{{[a,b]}}sp
 ; CHECK:                    retab
-; CHECK-NOT:                auti[a,b]sp


### PR DESCRIPTION
Part of the tests did not run and some checks were missing due to incorrect prefixes. The patch also updates the check lines to catch up with recent changes.

The problematic revisions were:
 * [D70635](https://reviews.llvm.org/D70635)
 * [D71658](https://reviews.llvm.org/D71658)
 * [D111780](https://reviews.llvm.org/D111780)