### PR TITLE
[NewPM] Add deduction guide to `MFPropsModifier` to suppress warning

### DIFF
--- a/llvm/include/llvm/CodeGen/MachinePassManager.h
+++ b/llvm/include/llvm/CodeGen/MachinePassManager.h
@@ -99,6 +99,10 @@ private:
       is_detected<has_get_cleared_properties_t, T>::value;
 };
 
+// Additional deduction guide to suppress warning.
+template <typename PassT>
+MFPropsModifier(PassT &P, MachineFunction &MF) -> MFPropsModifier<PassT>;
+
 using MachineFunctionAnalysisManagerModuleProxy =
     InnerAnalysisManagerProxy<MachineFunctionAnalysisManager, Module>;
 


### PR DESCRIPTION
Buildbot `clang-ppc64le-rhel` failed with:
```sh
error: 'MFPropsModifier' may not intend to support class template argument deduction [-Werror,-Wctad-maybe-unsupported]
note: add a deduction guide to suppress this warning
```
after #94854. This PR adds deduction guide explicitly to suppress warning.