### PR TITLE
[clang] inherit GD to let the codegen add kcfi type for ifunc

### DIFF
--- a/clang/lib/CodeGen/CodeGenModule.cpp
+++ b/clang/lib/CodeGen/CodeGenModule.cpp
@@ -5995,7 +5995,7 @@ void CodeGenModule::emitIFuncDefinition(GlobalDecl GD) {
   llvm::Type *DeclTy = getTypes().ConvertTypeForMem(D->getType());
   llvm::Type *ResolverTy = llvm::GlobalIFunc::getResolverFunctionType(DeclTy);
   llvm::Constant *Resolver =
-      GetOrCreateLLVMFunction(IFA->getResolver(), ResolverTy, {},
+      GetOrCreateLLVMFunction(IFA->getResolver(), ResolverTy, GD,
                               /*ForVTable=*/false);
   llvm::GlobalIFunc *GIF =
       llvm::GlobalIFunc::create(DeclTy, 0, llvm::Function::ExternalLinkage,


### PR DESCRIPTION
In FreeBSD, we use ifunc to select best performance function in load time. However, the resolver is also a function itself but not been tagged kcfi by clang.  The problems is caused by 
```
if (D)
CodeGenModule::SetFunctionAttribute()
``` 
called by CodeGenModule::GetOrCreateLLVMFunction where  D is empty originally.