### PR TITLE
[Clang] Simplify release notes and remove irrelevant comment

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -224,9 +224,6 @@ C++20 Feature Support
   ``<expected>`` from libstdc++ to work correctly with Clang.
 
 - User defined constructors are allowed for copy-list-initialization with CTAD.
-  The example code for deduction guides for std::map in
-  (`cppreference <https://en.cppreference.com/w/cpp/container/map/deduction_guides>`_)
-  will now work.
   (#GH62925).
 
 C++23 Feature Support

--- a/clang/lib/Sema/SemaInit.cpp
+++ b/clang/lib/Sema/SemaInit.cpp
@@ -11041,9 +11041,6 @@ QualType Sema::DeduceTemplateSpecializationFromInitializer(
     // C++ [over.best.ics]p4:
     //   When [...] the constructor [...] is a candidate by
     //    - [over.match.copy] (in all cases)
-    // FIXME: The "second phase of [over.match.list] case can also
-    // theoretically happen here, but it's not clear whether we can
-    // ever have a parameter of the right type.
     if (TD) {
       SmallVector<Expr *, 8> TmpInits;
       for (Expr *E : Inits)


### PR DESCRIPTION
As discussed before with @cor3ntin before (https://github.com/llvm/llvm-project/pull/94752) here is the simplification of the release note written for the previously  mentioned PR and the removal of a comment that is no longer useful.

(Sorry for creating this PR this late.)