### PR TITLE
[AArch64][GlobalISel] Improve non-SVE popcount for 32bit and 64 bit using udot

### DIFF
--- a/llvm/lib/Target/AArch64/GISel/AArch64LegalizerInfo.cpp
+++ b/llvm/lib/Target/AArch64/GISel/AArch64LegalizerInfo.cpp
@@ -14,7 +14,6 @@
 #include "AArch64LegalizerInfo.h"
 #include "AArch64RegisterBankInfo.h"
 #include "AArch64Subtarget.h"
-#include "MCTargetDesc/AArch64MCTargetDesc.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/CodeGen/GlobalISel/GenericMachineInstrs.h"
 #include "llvm/CodeGen/GlobalISel/LegalizerHelper.h"
@@ -1915,21 +1914,21 @@ bool AArch64LegalizerInfo::legalizeCTPOP(MachineInstr &MI,
     LLT Dt = Ty == LLT::fixed_vector(2, 64) ? LLT::fixed_vector(4, 32) : Ty;
     auto Zeros = MIRBuilder.buildConstant(Dt, 0);
     auto Ones = MIRBuilder.buildConstant(VTy, 1);
-    MachineInstrBuilder SUM;
+    MachineInstrBuilder Sum;
 
     if (Ty == LLT::fixed_vector(2, 64)) {
       auto UDOT =
           MIRBuilder.buildInstr(AArch64::G_UDOT, {Dt}, {Zeros, Ones, CTPOP});
-      SUM = MIRBuilder.buildInstr(AArch64::G_UADDLP, {Ty}, {UDOT});
+      Sum = MIRBuilder.buildInstr(AArch64::G_UADDLP, {Ty}, {UDOT});
     } else if (Ty == LLT::fixed_vector(4, 32)) {
-      SUM = MIRBuilder.buildInstr(AArch64::G_UDOT, {Dt}, {Zeros, Ones, CTPOP});
+      Sum = MIRBuilder.buildInstr(AArch64::G_UDOT, {Dt}, {Zeros, Ones, CTPOP});
     } else if (Ty == LLT::fixed_vector(2, 32)) {
-      SUM = MIRBuilder.buildInstr(AArch64::G_UDOT, {Dt}, {Zeros, Ones, CTPOP});
+      Sum = MIRBuilder.buildInstr(AArch64::G_UDOT, {Dt}, {Zeros, Ones, CTPOP});
     } else {
       llvm_unreachable("unexpected vector shape");
     }
 
-    SUM->getOperand(0).setReg(Dst);
+    Sum->getOperand(0).setReg(Dst);
     MI.eraseFromParent();
     return true;
   }


### PR DESCRIPTION
Follow up for #95881

Use udot instead of a sequence of uaddlp instructions when summing up lanes for popcount.