### PR TITLE
[InstSimplify] Provide information about the range of possible values that `ucmp`/`scmp` can return

### DIFF
--- a/llvm/lib/Analysis/ValueTracking.cpp
+++ b/llvm/lib/Analysis/ValueTracking.cpp
@@ -9396,7 +9396,7 @@ static ConstantRange getRangeForIntrinsic(const IntrinsicInst &II) {
   case Intrinsic::scmp:
   case Intrinsic::ucmp:
     return ConstantRange::getNonEmpty(APInt::getAllOnes(Width),
-                                      APInt::getOneBitSet(Width, 0));
+                                      APInt(Width, 2));
   default:
     break;
   }

--- a/llvm/lib/Analysis/ValueTracking.cpp
+++ b/llvm/lib/Analysis/ValueTracking.cpp
@@ -9393,6 +9393,10 @@ static ConstantRange getRangeForIntrinsic(const IntrinsicInst &II) {
     if (!II.getParent() || !II.getFunction())
       break;
     return getVScaleRange(II.getFunction(), Width);
+  case Intrinsic::scmp:
+  case Intrinsic::ucmp:
+    return ConstantRange::getNonEmpty(APInt::getAllOnes(Width),
+                                      APInt::getOneBitSet(Width, 0));
   default:
     break;
   }

--- a/llvm/test/Transforms/InstSimplify/uscmp.ll
+++ b/llvm/test/Transforms/InstSimplify/uscmp.ll
@@ -229,6 +229,30 @@ define <4 x i8> @ucmp_with_addition_vec(<4 x i32> %x) {
   ret <4 x i8> %2
 }
 
+define i1 @scmp_eq_4(i32 %x, i32 %y) {
+; CHECK-LABEL: define i1 @scmp_eq_4(
+; CHECK-SAME: i32 [[X:%.*]], i32 [[Y:%.*]]) {
+; CHECK-NEXT:    [[TMP1:%.*]] = call i8 @llvm.scmp.i8.i32(i32 [[X]], i32 [[Y]])
+; CHECK-NEXT:    [[TMP2:%.*]] = icmp eq i8 [[TMP1]], 4
+; CHECK-NEXT:    ret i1 [[TMP2]]
+;
+  %1 = call i8 @llvm.scmp(i32 %x, i32 %y)
+  %2 = icmp eq i8 %1, 4
+  ret i1 %2
+}
+
+define i1 @ucmp_ne_negative_2(i32 %x, i32 %y) {
+; CHECK-LABEL: define i1 @ucmp_ne_negative_2(
+; CHECK-SAME: i32 [[X:%.*]], i32 [[Y:%.*]]) {
+; CHECK-NEXT:    [[TMP1:%.*]] = call i8 @llvm.ucmp.i8.i32(i32 [[X]], i32 [[Y]])
+; CHECK-NEXT:    [[TMP2:%.*]] = icmp ne i8 [[TMP1]], -2
+; CHECK-NEXT:    ret i1 [[TMP2]]
+;
+  %1 = call i8 @llvm.ucmp(i32 %x, i32 %y)
+  %2 = icmp ne i8 %1, -2
+  ret i1 %2
+}
+
 ; Negative case: mismatched signedness of predicates
 define i8 @scmp_known_ugt(i32 %x, i32 %y) {
 ; CHECK-LABEL: define i8 @scmp_known_ugt(

--- a/llvm/test/Transforms/InstSimplify/uscmp.ll
+++ b/llvm/test/Transforms/InstSimplify/uscmp.ll
@@ -232,9 +232,7 @@ define <4 x i8> @ucmp_with_addition_vec(<4 x i32> %x) {
 define i1 @scmp_eq_4(i32 %x, i32 %y) {
 ; CHECK-LABEL: define i1 @scmp_eq_4(
 ; CHECK-SAME: i32 [[X:%.*]], i32 [[Y:%.*]]) {
-; CHECK-NEXT:    [[TMP1:%.*]] = call i8 @llvm.scmp.i8.i32(i32 [[X]], i32 [[Y]])
-; CHECK-NEXT:    [[TMP2:%.*]] = icmp eq i8 [[TMP1]], 4
-; CHECK-NEXT:    ret i1 [[TMP2]]
+; CHECK-NEXT:    ret i1 false
 ;
   %1 = call i8 @llvm.scmp(i32 %x, i32 %y)
   %2 = icmp eq i8 %1, 4
@@ -244,9 +242,7 @@ define i1 @scmp_eq_4(i32 %x, i32 %y) {
 define i1 @ucmp_ne_negative_2(i32 %x, i32 %y) {
 ; CHECK-LABEL: define i1 @ucmp_ne_negative_2(
 ; CHECK-SAME: i32 [[X:%.*]], i32 [[Y:%.*]]) {
-; CHECK-NEXT:    [[TMP1:%.*]] = call i8 @llvm.ucmp.i8.i32(i32 [[X]], i32 [[Y]])
-; CHECK-NEXT:    [[TMP2:%.*]] = icmp ne i8 [[TMP1]], -2
-; CHECK-NEXT:    ret i1 [[TMP2]]
+; CHECK-NEXT:    ret i1 true
 ;
   %1 = call i8 @llvm.ucmp(i32 %x, i32 %y)
   %2 = icmp ne i8 %1, -2


### PR DESCRIPTION
This makes it possible to fold dumb comparisons like `ucmp(x, y) == 7`.