### PR TITLE
[Clang][Sema] fix assertion failure about invalid conversion when calling lambda

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -935,6 +935,7 @@ Bug Fixes to C++ Support
 - Fix an assertion failure caused by parsing a lambda used as a default argument for the value of a
   forward-declared class. (#GH93512).
 - Fixed a bug in access checking inside return-type-requirement of compound requirements. (#GH93788).
+- Fixed an assertion failure about invalid conversion when calling lambda. (#GH96205).
 
 Bug Fixes to AST Handling
 ^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/clang/lib/Sema/SemaOverload.cpp
+++ b/clang/lib/Sema/SemaOverload.cpp
@@ -12169,7 +12169,7 @@ static void NoteFunctionCandidate(Sema &S, OverloadCandidate *Cand,
   case ovl_fail_bad_conversion: {
     unsigned I = (Cand->IgnoreObjectArgument ? 1 : 0);
     for (unsigned N = Cand->Conversions.size(); I != N; ++I)
-      if (Cand->Conversions[I].isBad())
+      if (Cand->Conversions[I].isInitialized() && Cand->Conversions[I].isBad())
         return DiagnoseBadConversion(S, Cand, I, TakingCandidateAddress);
 
     // FIXME: this currently happens when we're called from SemaInit

--- a/clang/test/SemaCXX/lambda-call.cpp
+++ b/clang/test/SemaCXX/lambda-call.cpp
@@ -1,0 +1,11 @@
+// RUN: %clang_cc1 -std=c++23 -verify -fsyntax-only %s
+
+namespace GH96205 {
+
+void f() {
+  auto l = [](this auto& self, int) -> void { self("j"); }; // expected-error {{no matching function for call to object of type}} \
+                                                            // expected-note {{no known conversion from 'const char[2]' to 'int'}}
+  l(3); // expected-note {{requested here}}
+}
+
+}


### PR DESCRIPTION
fixes https://github.com/llvm/llvm-project/issues/96205

The cause is that some `Conversions[ConvIdx]` here is not initialized 

https://github.com/llvm/llvm-project/blob/eb76bc38ffc286e62fdb8f8d897b5de04b2575be/clang/lib/Sema/SemaOverload.cpp#L7888-L7901

and we do not check whether `Cand->Conversions[I]` is initialized or not here.

https://github.com/llvm/llvm-project/blob/eb76bc38ffc286e62fdb8f8d897b5de04b2575be/clang/lib/Sema/SemaOverload.cpp#L12148-L12158
