### PR TITLE
[llvm][lld][NFC] Avoid reopening namespace std

### DIFF
--- a/lld/include/lld/Common/LLVM.h
+++ b/lld/include/lld/Common/LLVM.h
@@ -98,13 +98,10 @@ using llvm::wasm::WasmTableType;
 using llvm::wasm::WasmTag;
 } // end namespace lld.
 
-namespace std {
-template <> struct hash<llvm::StringRef> {
-public:
+template <> struct std::hash<llvm::StringRef> {
   size_t operator()(const llvm::StringRef &s) const {
     return llvm::hash_value(s);
   }
 };
-} // namespace std
 
 #endif

--- a/llvm/include/llvm/ADT/Hashing.h
+++ b/llvm/include/llvm/ADT/Hashing.h
@@ -686,15 +686,11 @@ template <> struct DenseMapInfo<hash_code, void> {
 } // namespace llvm
 
 /// Implement std::hash so that hash_code can be used in STL containers.
-namespace std {
-
-template<>
-struct hash<llvm::hash_code> {
-  size_t operator()(llvm::hash_code const& Val) const {
+template <>
+struct std::hash<llvm::hash_code> {
+  size_t operator()(llvm::hash_code Val) const {
     return Val;
   }
 };
-
-} // namespace std;
 
 #endif

--- a/llvm/include/llvm/ADT/PointerIntPair.h
+++ b/llvm/include/llvm/ADT/PointerIntPair.h
@@ -277,18 +277,16 @@ get(const PointerIntPair<PointerTy, IntBits, IntType, PtrTraits, Info> &Pair) {
 
 } // end namespace llvm
 
-namespace std {
 template <typename PointerTy, unsigned IntBits, typename IntType,
           typename PtrTraits, typename Info>
-struct tuple_size<
+struct std::tuple_size<
     llvm::PointerIntPair<PointerTy, IntBits, IntType, PtrTraits, Info>>
     : std::integral_constant<std::size_t, 2> {};
 
 template <std::size_t I, typename PointerTy, unsigned IntBits, typename IntType,
           typename PtrTraits, typename Info>
-struct tuple_element<
+struct std::tuple_element<
     I, llvm::PointerIntPair<PointerTy, IntBits, IntType, PtrTraits, Info>>
     : std::conditional<I == 0, PointerTy, IntType> {};
-} // namespace std
 
 #endif // LLVM_ADT_POINTERINTPAIR_H

--- a/llvm/include/llvm/ADT/STLExtras.h
+++ b/llvm/include/llvm/ADT/STLExtras.h
@@ -2550,19 +2550,16 @@ constexpr bool is_incomplete_v = !is_detected<detail::has_sizeof, T>::value;
 
 } // end namespace llvm
 
-namespace std {
 template <typename... Refs>
-struct tuple_size<llvm::detail::enumerator_result<Refs...>>
+struct std::tuple_size<llvm::detail::enumerator_result<Refs...>>
     : std::integral_constant<std::size_t, sizeof...(Refs)> {};
 
 template <std::size_t I, typename... Refs>
-struct tuple_element<I, llvm::detail::enumerator_result<Refs...>>
+struct std::tuple_element<I, llvm::detail::enumerator_result<Refs...>>
     : std::tuple_element<I, std::tuple<Refs...>> {};
 
 template <std::size_t I, typename... Refs>
-struct tuple_element<I, const llvm::detail::enumerator_result<Refs...>>
+struct std::tuple_element<I, const llvm::detail::enumerator_result<Refs...>>
     : std::tuple_element<I, std::tuple<Refs...>> {};
-
-} // namespace std
 
 #endif // LLVM_ADT_STLEXTRAS_H

--- a/llvm/include/llvm/ADT/StringMapEntry.h
+++ b/llvm/include/llvm/ADT/StringMapEntry.h
@@ -160,14 +160,12 @@ decltype(auto) get(const StringMapEntry<ValueTy> &E) {
 
 } // end namespace llvm
 
-namespace std {
 template <typename ValueTy>
-struct tuple_size<llvm::StringMapEntry<ValueTy>>
+struct std::tuple_size<llvm::StringMapEntry<ValueTy>>
     : std::integral_constant<std::size_t, 2> {};
 
 template <std::size_t I, typename ValueTy>
-struct tuple_element<I, llvm::StringMapEntry<ValueTy>>
+struct std::tuple_element<I, llvm::StringMapEntry<ValueTy>>
     : std::conditional<I == 0, llvm::StringRef, ValueTy> {};
-} // namespace std
 
 #endif // LLVM_ADT_STRINGMAPENTRY_H

--- a/llvm/include/llvm/Bitcode/BitcodeReader.h
+++ b/llvm/include/llvm/Bitcode/BitcodeReader.h
@@ -313,10 +313,7 @@ struct ParserCallbacks {
 
 } // end namespace llvm
 
-namespace std {
-
-template <> struct is_error_code_enum<llvm::BitcodeError> : std::true_type {};
-
-} // end namespace std
+template <>
+struct std::is_error_code_enum<llvm::BitcodeError> : std::true_type {};
 
 #endif // LLVM_BITCODE_BITCODEREADER_H

--- a/llvm/include/llvm/CodeGen/RDFLiveness.h
+++ b/llvm/include/llvm/CodeGen/RDFLiveness.h
@@ -39,16 +39,14 @@ using NodeRef = std::pair<NodeId, LaneBitmask>;
 } // namespace rdf
 } // namespace llvm
 
-namespace std {
 
-template <> struct hash<llvm::rdf::detail::NodeRef> {
+template <> struct std::hash<llvm::rdf::detail::NodeRef> {
   std::size_t operator()(llvm::rdf::detail::NodeRef R) const {
     return std::hash<llvm::rdf::NodeId>{}(R.first) ^
            std::hash<llvm::LaneBitmask::Type>{}(R.second.getAsInteger());
   }
 };
 
-} // namespace std
 
 namespace llvm::rdf {
 

--- a/llvm/include/llvm/CodeGen/RDFRegisters.h
+++ b/llvm/include/llvm/CodeGen/RDFRegisters.h
@@ -322,21 +322,20 @@ raw_ostream &operator<<(raw_ostream &OS, const PrintLaneMaskShort &P);
 } // end namespace rdf
 } // end namespace llvm
 
-namespace std {
 
-template <> struct hash<llvm::rdf::RegisterRef> {
+template <> struct std::hash<llvm::rdf::RegisterRef> {
   size_t operator()(llvm::rdf::RegisterRef A) const { //
     return A.hash();
   }
 };
 
-template <> struct hash<llvm::rdf::RegisterAggr> {
+template <> struct std::hash<llvm::rdf::RegisterAggr> {
   size_t operator()(const llvm::rdf::RegisterAggr &A) const { //
     return A.hash();
   }
 };
 
-template <> struct equal_to<llvm::rdf::RegisterRef> {
+template <> struct std::equal_to<llvm::rdf::RegisterRef> {
   constexpr equal_to(const llvm::rdf::PhysicalRegisterInfo &pri) : PRI(&pri) {}
 
   bool operator()(llvm::rdf::RegisterRef A, llvm::rdf::RegisterRef B) const {
@@ -348,14 +347,14 @@ private:
   const llvm::rdf::PhysicalRegisterInfo *PRI;
 };
 
-template <> struct equal_to<llvm::rdf::RegisterAggr> {
+template <> struct std::equal_to<llvm::rdf::RegisterAggr> {
   bool operator()(const llvm::rdf::RegisterAggr &A,
                   const llvm::rdf::RegisterAggr &B) const {
     return A == B;
   }
 };
 
-template <> struct less<llvm::rdf::RegisterRef> {
+template <> struct std::less<llvm::rdf::RegisterRef> {
   constexpr less(const llvm::rdf::PhysicalRegisterInfo &pri) : PRI(&pri) {}
 
   bool operator()(llvm::rdf::RegisterRef A, llvm::rdf::RegisterRef B) const {
@@ -368,7 +367,6 @@ private:
   const llvm::rdf::PhysicalRegisterInfo *PRI;
 };
 
-} // namespace std
 
 namespace llvm::rdf {
 using RegisterSet = std::set<RegisterRef, std::less<RegisterRef>>;

--- a/llvm/include/llvm/DebugInfo/CodeView/CodeViewError.h
+++ b/llvm/include/llvm/DebugInfo/CodeView/CodeViewError.h
@@ -24,10 +24,9 @@ enum class cv_error_code {
 } // namespace codeview
 } // namespace llvm
 
-namespace std {
 template <>
-struct is_error_code_enum<llvm::codeview::cv_error_code> : std::true_type {};
-} // namespace std
+struct std::is_error_code_enum<llvm::codeview::cv_error_code>
+    : std::true_type {};
 
 namespace llvm {
 namespace codeview {

--- a/llvm/include/llvm/DebugInfo/DWARF/DWARFDie.h
+++ b/llvm/include/llvm/DebugInfo/DWARF/DWARFDie.h
@@ -398,10 +398,9 @@ inline iterator_range<DWARFDie::iterator> DWARFDie::children() const {
 
 } // end namespace llvm
 
-namespace std {
 
 template <>
-class reverse_iterator<llvm::DWARFDie::iterator>
+class std::reverse_iterator<llvm::DWARFDie::iterator>
     : public llvm::iterator_facade_base<
           reverse_iterator<llvm::DWARFDie::iterator>,
           bidirectional_iterator_tag, const llvm::DWARFDie> {
@@ -454,7 +453,6 @@ public:
   }
 };
 
-} // namespace std
 
 namespace llvm {
 

--- a/llvm/include/llvm/DebugInfo/MSF/MSFError.h
+++ b/llvm/include/llvm/DebugInfo/MSF/MSFError.h
@@ -29,10 +29,8 @@ enum class msf_error_code {
 } // namespace msf
 } // namespace llvm
 
-namespace std {
 template <>
-struct is_error_code_enum<llvm::msf::msf_error_code> : std::true_type {};
-} // namespace std
+struct std::is_error_code_enum<llvm::msf::msf_error_code> : std::true_type {};
 
 namespace llvm {
 namespace msf {

--- a/llvm/include/llvm/DebugInfo/PDB/DIA/DIAError.h
+++ b/llvm/include/llvm/DebugInfo/PDB/DIA/DIAError.h
@@ -25,10 +25,8 @@ enum class dia_error_code {
 } // namespace pdb
 } // namespace llvm
 
-namespace std {
 template <>
-struct is_error_code_enum<llvm::pdb::dia_error_code> : std::true_type {};
-} // namespace std
+struct std::is_error_code_enum<llvm::pdb::dia_error_code> : std::true_type {};
 
 namespace llvm {
 namespace pdb {

--- a/llvm/include/llvm/DebugInfo/PDB/GenericError.h
+++ b/llvm/include/llvm/DebugInfo/PDB/GenericError.h
@@ -25,10 +25,8 @@ enum class pdb_error_code {
 } // namespace pdb
 } // namespace llvm
 
-namespace std {
 template <>
-struct is_error_code_enum<llvm::pdb::pdb_error_code> : std::true_type {};
-} // namespace std
+struct std::is_error_code_enum<llvm::pdb::pdb_error_code> : std::true_type {};
 
 namespace llvm {
 namespace pdb {

--- a/llvm/include/llvm/DebugInfo/PDB/Native/RawError.h
+++ b/llvm/include/llvm/DebugInfo/PDB/Native/RawError.h
@@ -31,10 +31,8 @@ enum class raw_error_code {
 } // namespace pdb
 } // namespace llvm
 
-namespace std {
 template <>
-struct is_error_code_enum<llvm::pdb::raw_error_code> : std::true_type {};
-} // namespace std
+struct std::is_error_code_enum<llvm::pdb::raw_error_code> : std::true_type {};
 
 namespace llvm {
 namespace pdb {

--- a/llvm/include/llvm/DebugInfo/PDB/PDBTypes.h
+++ b/llvm/include/llvm/DebugInfo/PDB/PDBTypes.h
@@ -595,17 +595,10 @@ struct Variant {
 } // end namespace pdb
 } // end namespace llvm
 
-namespace std {
-
-template <> struct hash<llvm::pdb::PDB_SymType> {
-  using argument_type = llvm::pdb::PDB_SymType;
-  using result_type = std::size_t;
-
-  result_type operator()(const argument_type &Arg) const {
+template <> struct std::hash<llvm::pdb::PDB_SymType> {
+  std::size_t operator()(llvm::pdb::PDB_SymType Arg) const {
     return std::hash<int>()(static_cast<int>(Arg));
   }
 };
-
-} // end namespace std
 
 #endif // LLVM_DEBUGINFO_PDB_PDBTYPES_H

--- a/llvm/include/llvm/Object/Error.h
+++ b/llvm/include/llvm/Object/Error.h
@@ -89,9 +89,7 @@ inline Error createError(const Twine &Err) {
 
 } // end namespace llvm.
 
-namespace std {
 template <>
-struct is_error_code_enum<llvm::object::object_error> : std::true_type {};
-}
+struct std::is_error_code_enum<llvm::object::object_error> : std::true_type {};
 
 #endif

--- a/llvm/include/llvm/ProfileData/FunctionId.h
+++ b/llvm/include/llvm/ProfileData/FunctionId.h
@@ -198,16 +198,12 @@ template <> struct DenseMapInfo<sampleprof::FunctionId, void> {
 
 } // end namespace llvm
 
-namespace std {
-
 /// Template specialization for FunctionId so that it can be used in STL
 /// containers.
-template <> struct hash<llvm::sampleprof::FunctionId> {
+template <> struct std::hash<llvm::sampleprof::FunctionId> {
   size_t operator()(const llvm::sampleprof::FunctionId &Val) const {
     return Val.getHashCode();
   }
 };
-
-} // end namespace std
 
 #endif // LLVM_PROFILEDATA_FUNCTIONID_H

--- a/llvm/include/llvm/ProfileData/SampleProf.h
+++ b/llvm/include/llvm/ProfileData/SampleProf.h
@@ -78,12 +78,8 @@ inline sampleprof_error MergeResult(sampleprof_error &Accumulator,
 
 } // end namespace llvm
 
-namespace std {
-
 template <>
-struct is_error_code_enum<llvm::sampleprof_error> : std::true_type {};
-
-} // end namespace std
+struct std::is_error_code_enum<llvm::sampleprof_error> : std::true_type {};
 
 namespace llvm {
 namespace sampleprof {

--- a/llvm/include/llvm/Support/Errc.h
+++ b/llvm/include/llvm/Support/Errc.h
@@ -84,7 +84,6 @@ inline std::error_code make_error_code(errc E) {
 }
 }
 
-namespace std {
-template <> struct is_error_code_enum<llvm::errc> : std::true_type {};
-}
+template <> struct std::is_error_code_enum<llvm::errc> : std::true_type {};
+
 #endif

--- a/llvm/lib/CodeGen/AssignmentTrackingAnalysis.cpp
+++ b/llvm/lib/CodeGen/AssignmentTrackingAnalysis.cpp
@@ -83,16 +83,11 @@ template <> struct llvm::DenseMapInfo<VariableID> {
 
 using VarLocInsertPt = PointerUnion<const Instruction *, const DbgRecord *>;
 
-namespace std {
-template <> struct hash<VarLocInsertPt> {
-  using argument_type = VarLocInsertPt;
-  using result_type = std::size_t;
-
-  result_type operator()(const argument_type &Arg) const {
+template <> struct std::hash<VarLocInsertPt> {
+  std::size_t operator()(VarLocInsertPt Arg) const {
     return std::hash<void *>()(Arg.getOpaqueValue());
   }
 };
-} // namespace std
 
 /// Helper class to build FunctionVarLocs, since that class isn't easy to
 /// modify. TODO: There's not a great deal of value in the split, it could be

--- a/llvm/tools/llvm-cxxdump/Error.h
+++ b/llvm/tools/llvm-cxxdump/Error.h
@@ -30,9 +30,7 @@ inline std::error_code make_error_code(cxxdump_error e) {
 
 } // namespace llvm
 
-namespace std {
 template <>
-struct is_error_code_enum<llvm::cxxdump_error> : std::true_type {};
-}
+struct std::is_error_code_enum<llvm::cxxdump_error> : std::true_type {};
 
 #endif


### PR DESCRIPTION
When defining specializations for stardard library templates, avoid reopening namespace `std`.