### PR TITLE
[Doc] Update documentation for no-transitive-change

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -157,6 +157,13 @@ here. Generic improvements to Clang as a whole or to its underlying
 infrastructure are described first, followed by language-specific
 sections with improvements to Clang's support for those languages.
 
+- Clang implemented improvements to BMI of C++20 Modules that can reduce
+  the number of rebuilds during incremental recompilation. We are seeking
+  feedback from Build System authors and other interested users, especially
+  when you feel Clang changes the BMI and missses an opportunity to avoid
+  recompilations or causes correctness issues. See StandardCPlusPlusModules
+  `StandardCPlusPlusModules <StandardCPlusPlusModules.html>`_ for more details.
+
 - The ``\par`` documentation comment command now supports an optional
   argument, which denotes the header of the paragraph started by
   an instance of the ``\par`` command comment. The implementation
@@ -228,10 +235,6 @@ C++20 Feature Support
   (`cppreference <https://en.cppreference.com/w/cpp/container/map/deduction_guides>`_)
   will now work.
   (#GH62925).
-
-- Clang refactored the BMI format to make it possible to support no transitive changes
-  mode for modules. See `StandardCPlusPlusModules <StandardCPlusPlusModules.html>`_ for
-  details.
 
 C++23 Feature Support
 ^^^^^^^^^^^^^^^^^^^^^

--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -157,10 +157,10 @@ here. Generic improvements to Clang as a whole or to its underlying
 infrastructure are described first, followed by language-specific
 sections with improvements to Clang's support for those languages.
 
-- Clang implemented improvements to BMI of C++20 Modules that can reduce
+- Implemented improvements to BMIs for C++20 Modules that can reduce
   the number of rebuilds during incremental recompilation. We are seeking
   feedback from Build System authors and other interested users, especially
-  when you feel Clang changes the BMI and missses an opportunity to avoid
+  when you feel Clang changes the BMI and misses an opportunity to avoid
   recompilations or causes correctness issues. See StandardCPlusPlusModules
   `StandardCPlusPlusModules <StandardCPlusPlusModules.html>`_ for more details.
 

--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -229,6 +229,10 @@ C++20 Feature Support
   will now work.
   (#GH62925).
 
+- Clang refactored the BMI format to make it possible to support no transitive changes
+  mode for modules. See `StandardCPlusPlusModules <StandardCPlusPlusModules.html>`_ for
+  details.
+
 C++23 Feature Support
 ^^^^^^^^^^^^^^^^^^^^^
 

--- a/clang/docs/StandardCPlusPlusModules.rst
+++ b/clang/docs/StandardCPlusPlusModules.rst
@@ -737,6 +737,9 @@ What is considered to be a potential contributory BMIs is currently unspecified.
 However, it is a severe bug for a BMI to remain unchanged following an observable change
 that affects its consumers.
 
+Build systems may utilize this optimization by doing an update-if-changed operation to the BMI
+that is consumed from the BMI that is output by the compiler.
+
 We encourage build systems to add an experimental mode that
 reuses the cached BMI when **direct** dependencies did not change,
 even if **transitive** dependencies did change.

--- a/clang/docs/StandardCPlusPlusModules.rst
+++ b/clang/docs/StandardCPlusPlusModules.rst
@@ -652,14 +652,14 @@ in the future. The expected roadmap for Reduced BMIs as of Clang 19.x is:
    comes, the term BMI will refer to the Reduced BMI and the Full BMI will only
    be meaningful to build systems which elect to support two-phase compilation.
 
-Experimental No Transitive Change
----------------------------------
+Experimental Non Cascade Change
+-------------------------------
 
 This section is primarily for build system vendors. For end compiler users,
 if you don't want to read it all, this is helpful to reduce recompilations
 We encourage build system vendors and end users try this out and bring feedbacks
 
-Before Clang 19, a change in BMI of any (transitive) dependency would case the
+Before Clang 19, a change in BMI of any (transitive) dependency would cause the
 outputs of the BMI to change. Starting with Clang 19, changes to non-direct
 dependencies should not directly affect the output BMI, unless they affect the
 results of the compilations. We expect that there are many more opportunities
@@ -727,9 +727,9 @@ then the contents of ``useBOnly.pcm`` remain unchanged.
 Consequently, if the build system only bases recompilation decisions on directly imported modules,
 it becomes possible to skip the recompilation of ``Use.cc``.
 It should be fine because the altered interfaces do not affect ``Use.cc`` in any way;
-there are no transitive changes.
+there are non cascade changes.
 
-When clang generates a BMI, it records the hash values of all potentially contributory BMIs
+When ``Clang`` generates a BMI, it records the hash values of all potentially contributory BMIs
 for the BMI being produced. This ensures that build systems are not required to consider
 transitively imported modules when deciding whether to recompile.
 
@@ -743,7 +743,7 @@ can go back to the transitive change mode safely at any time.
 Interactions with Reduced BMI
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-With reduced BMI, the no transitive change feature can be more powerful. For example,
+With reduced BMI, the non cascade change feature can be more powerful. For example,
 
 .. code-block:: c++
 
@@ -760,7 +760,7 @@ With reduced BMI, the no transitive change feature can be more powerful. For exa
 
   $ clang++ -std=c++20 A.cppm -c -fmodule-output=A.pcm  -fexperimental-modules-reduced-bmi -o A.o
   $ clang++ -std=c++20 B.cppm -c -fmodule-output=B.pcm  -fexperimental-modules-reduced-bmi -o B.o -fmodule-file=A=A.pcm
-  $md5sum B.pcm
+  $ md5sum B.pcm
   6c2bd452ca32ab418bf35cd141b060b9  B.pcm
 
 And let's change the implementation for ``A.cppm`` into:
@@ -777,7 +777,7 @@ and recompile the example:
 
   $ clang++ -std=c++20 A.cppm -c -fmodule-output=A.pcm  -fexperimental-modules-reduced-bmi -o A.o
   $ clang++ -std=c++20 B.cppm -c -fmodule-output=B.pcm  -fexperimental-modules-reduced-bmi -o B.o -fmodule-file=A=A.pcm
-  $md5sum B.pcm
+  $ md5sum B.pcm
   6c2bd452ca32ab418bf35cd141b060b9  B.pcm
 
 We should find the contents of ``B.pcm`` keeps the same. In such case, the build system is

--- a/clang/docs/StandardCPlusPlusModules.rst
+++ b/clang/docs/StandardCPlusPlusModules.rst
@@ -652,12 +652,12 @@ in the future. The expected roadmap for Reduced BMIs as of Clang 19.x is:
    comes, the term BMI will refer to the Reduced BMI and the Full BMI will only
    be meaningful to build systems which elect to support two-phase compilation.
 
-Experimental Non Cascade Change
--------------------------------
+Experimental Non-Cascading Changes
+----------------------------------
 
 This section is primarily for build system vendors. For end compiler users,
-if you don't want to read it all, this is helpful to reduce recompilations
-We encourage build system vendors and end users try this out and bring feedbacks
+if you don't want to read it all, this is helpful to reduce recompilations.
+We encourage build system vendors and end users try this out and bring feedback.
 
 Before Clang 19, a change in BMI of any (transitive) dependency would cause the
 outputs of the BMI to change. Starting with Clang 19, changes to non-direct
@@ -727,7 +727,7 @@ then the contents of ``useBOnly.pcm`` remain unchanged.
 Consequently, if the build system only bases recompilation decisions on directly imported modules,
 it becomes possible to skip the recompilation of ``Use.cc``.
 It should be fine because the altered interfaces do not affect ``Use.cc`` in any way;
-there are non cascade changes.
+the changes do not cascade.
 
 When ``Clang`` generates a BMI, it records the hash values of all potentially contributory BMIs
 for the BMI being produced. This ensures that build systems are not required to consider
@@ -737,13 +737,18 @@ What is considered to be a potential contributory BMIs is currently unspecified.
 However, it is a severe bug for a BMI to remain unchanged following an observable change
 that affects its consumers.
 
-We recommend that build systems support this feature as a configurable option so that users
+We encourage build systems to add an experimental mode that
+reuses the cached BMI when **direct** dependencies did not change,
+even if **transitive** dependencies did change.
+
+Given there are potential compiler bugs, we recommend that build systems
+support this feature as a configurable option so that users
 can go back to the transitive change mode safely at any time.
 
 Interactions with Reduced BMI
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-With reduced BMI, the non cascade change feature can be more powerful. For example,
+With reduced BMI, non-cascading changes can be more powerful. For example,
 
 .. code-block:: c++
 
@@ -780,11 +785,11 @@ and recompile the example:
   $ md5sum B.pcm
   6c2bd452ca32ab418bf35cd141b060b9  B.pcm
 
-We should find the contents of ``B.pcm`` keeps the same. In such case, the build system is
-allowed to skip recompilations of TUs which solely and directly dependent on module B.
+We should find the contents of ``B.pcm`` remains the same. In this case, the build system is
+allowed to skip recompilations of TUs which solely and directly depend on module ``B``.
 
-This only happens with reduced BMI. Since with reduced BMI, we won't record the function body
-of ``int b()`` in the BMI for ``B`` so that the module A doesn't contribute to the BMI of ``B``
+This only happens with a reduced BMI. With reduced BMIs, we won't record the function body
+of ``int b()`` in the BMI for ``B`` so that the module ``A`` doesn't contribute to the BMI of ``B``
 and we have less dependencies.
 
 Performance Tips


### PR DESCRIPTION
(Some backgrounds, not required to read: https://discourse.llvm.org/t/rfc-c-20-modules-introduce-thin-bmi-and-decls-hash/74755)

This is the document part for the no-transitive-change (https://github.com/llvm/llvm-project/pull/86912, https://github.com/llvm/llvm-project/pull/92083, https://github.com/llvm/llvm-project/pull/92085, https://github.com/llvm/llvm-project/pull/92511) to provide the ability for build system to skip some unnecessary recompilations.

See the patch for examples.

CC: @mathstuf @boris-kolpackov 