### PR TITLE
[libc++] Add constant folding for optimized std::find variants

### DIFF
--- a/libcxx/include/__string/constexpr_c_functions.h
+++ b/libcxx/include/__string/constexpr_c_functions.h
@@ -132,6 +132,19 @@ _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 _Tp* __constexpr_memchr(_Tp*
   static_assert(sizeof(_Tp) == 1 && __libcpp_is_trivially_equality_comparable<_Tp, _Up>::value,
                 "Calling memchr on non-trivially equality comparable types is unsafe.");
 
+  if (__builtin_constant_p(__count) && __builtin_constant_p(__value)) {
+    for (; __count; --__count) {
+      if (!__builtin_constant_p(*__str))
+        break;
+      if (*__str == __value)
+        return __str;
+      ++__str;
+    }
+  }
+
+  if (__builtin_constant_p(__count) && __count == 0)
+    return nullptr;
+
   if (__libcpp_is_constant_evaluated()) {
 // use __builtin_char_memchr to optimize constexpr evaluation if we can
 #if _LIBCPP_STD_VER >= 17 && __has_builtin(__builtin_char_memchr)

--- a/libcxx/include/cwchar
+++ b/libcxx/include/cwchar
@@ -231,6 +231,19 @@ _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 _Tp* __constexpr_wmemchr(_Tp
                     __libcpp_is_trivially_equality_comparable<_Tp, _Tp>::value,
                 "Calling wmemchr on non-trivially equality comparable types is unsafe.");
 
+  if (__builtin_constant_p(__count) && __builtin_constant_p(__value)) {
+    for (; __count; --__count) {
+      if (!__builtin_constant_p(*__str))
+        break;
+      if (*__str == __value)
+        return __str;
+      ++__str;
+    }
+  }
+
+  if (__builtin_constant_p(__count) && __count == 0)
+    return nullptr;
+
 #if __has_builtin(__builtin_wmemchr)
   if (!__libcpp_is_constant_evaluated()) {
     wchar_t __value_buffer = 0;


### PR DESCRIPTION
Currently Clang isn't able to constant fold `memchr` and `wmemchr`. This adds some basic constant folding to `__constexpr_memchr` and `__constexpr_wmemchr`, mostly alleviating the problem.

While not necessarily representative of the real world, an optimized version of the `find.pass.cpp` test is reduced from ~13k to ~4.5k lines of assembly.

