### PR TITLE
[MC] getSymbolOffsetImpl - only use report_fatal_error if ReportError is true, else just return false

### DIFF
--- a/llvm/lib/MC/MCFragment.cpp
+++ b/llvm/lib/MC/MCFragment.cpp
@@ -64,9 +64,12 @@ static bool getSymbolOffsetImpl(const MCAsmLayout &Layout, const MCSymbol &S,
 
   // If SD is a variable, evaluate it.
   MCValue Target;
-  if (!S.getVariableValue()->evaluateAsValue(Target, Layout))
-    report_fatal_error("unable to evaluate offset for variable '" +
-                       S.getName() + "'");
+  if (!S.getVariableValue()->evaluateAsValue(Target, Layout)) {
+    if (ReportError)
+      report_fatal_error("unable to evaluate offset for variable '" +
+                         S.getName() + "'");
+    return false;
+  }
 
   uint64_t Offset = Target.getConstant();
 
@@ -95,12 +98,12 @@ static bool getSymbolOffsetImpl(const MCAsmLayout &Layout, const MCSymbol &S,
 }
 
 bool MCAsmLayout::getSymbolOffset(const MCSymbol &S, uint64_t &Val) const {
-  return getSymbolOffsetImpl(*this, S, false, Val);
+  return getSymbolOffsetImpl(*this, S, /*ReportError=*/false, Val);
 }
 
 uint64_t MCAsmLayout::getSymbolOffset(const MCSymbol &S) const {
   uint64_t Val;
-  getSymbolOffsetImpl(*this, S, true, Val);
+  getSymbolOffsetImpl(*this, S, /*ReportError=*/true, Val);
   return Val;
 }
 


### PR DESCRIPTION
Fixes static analysis warnings regarding uninitialized values - this appears to have been introduced by fee224f942b707d855e97f8b0f1e31c70667d7ee

Fix by inspection, I don't have a test case