### PR TITLE
[clang][ThreadSafety] Fix code block syntax in ThreadSafetyAnalysis.rst

### DIFF
--- a/clang/docs/ThreadSafetyAnalysis.rst
+++ b/clang/docs/ThreadSafetyAnalysis.rst
@@ -464,6 +464,7 @@ on success and ``LockNotAcquired`` on failure, the analysis may fail to detect
 access to guarded data without holding the mutex because they are both non-zero.
 
 .. code-block:: c++
+
   // *** Beware: this code demonstrates incorrect usage. ***
 
   enum TrylockResult { LockAcquired = 1, LockNotAcquired = 2 };


### PR DESCRIPTION
Without a newline, documentation was failing to build with this error:

    Warning, treated as error:
    /home/runner/work/llvm-project/llvm-project/clang-build/tools/clang/docs/ThreadSafetyAnalysis.rst:466:Error in "code-block" directive:
    maximum 1 argument(s) allowed, 10 supplied.

Issue #92408