### PR TITLE
[mlir][vector] Project out anonymous bounds in ScalableValueBoundsConstraintSet

### DIFF
--- a/mlir/lib/Dialect/Vector/IR/ScalableValueBoundsConstraintSet.cpp
+++ b/mlir/lib/Dialect/Vector/IR/ScalableValueBoundsConstraintSet.cpp
@@ -8,6 +8,7 @@
 
 #include "mlir/Dialect/Vector/IR/ScalableValueBoundsConstraintSet.h"
 #include "mlir/Dialect/Vector/IR/VectorOps.h"
+
 namespace mlir::vector {
 
 FailureOr<ConstantOrScalableBound::BoundSize>
@@ -74,6 +75,7 @@ ScalableValueBoundsConstraintSet::computeScalableBound(
     return p.first != scalableCstr.getVscaleValue() && !isStartingPoint;
   };
   scalableCstr.projectOut(projectOutFn);
+  scalableCstr.projectOutAnonymous(/*except=*/pos);
   // Also project out local variables (these are not tracked by the
   // ValueBoundsConstraintSet).
   for (unsigned i = 0, e = scalableCstr.cstr.getNumLocalVars(); i < e; ++i) {


### PR DESCRIPTION
If we don't eliminate these columns, then in some cases we fail to compute a scalable bound. Test case reduced from a real-world example.