### PR TITLE
[clang-tidy] Fix assert in performance-unnecessary-copy-init.

### DIFF
--- a/clang-tools-extra/clang-tidy/utils/DeclRefExprUtils.cpp
+++ b/clang-tools-extra/clang-tidy/utils/DeclRefExprUtils.cpp
@@ -296,7 +296,7 @@ AST_MATCHER_P(DeclRefExpr, doesNotMutateObject, int, Indirections) {
           return false;
         }
         const auto *const Method =
-            dyn_cast<CXXMethodDecl>(OpCall->getDirectCallee());
+            dyn_cast_or_null<CXXMethodDecl>(OpCall->getDirectCallee());
 
         if (Method == nullptr) {
           // This is not a member operator. Typically, a friend operator. These

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -398,7 +398,7 @@ Changes in existing checks
   analyzed, so the check now handles the common patterns
   `const auto e = (*vector_ptr)[i]` and `const auto e = vector_ptr->at(i);`.
   Calls to mutable function where there exists a `const` overload are also
-  handled.
+  handled. Fix crash in the case of a non-member operator call.
 
 - Improved :doc:`readability-avoid-return-with-void-value
   <clang-tidy/checks/readability/avoid-return-with-void-value>` check by adding

--- a/clang-tools-extra/test/clang-tidy/checkers/performance/unnecessary-copy-initialization.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/performance/unnecessary-copy-initialization.cpp
@@ -906,3 +906,12 @@ void negativeNonConstMemberExpr() {
   }
 }
 
+
+bool operator==(ExpensiveToCopyType, ExpensiveToCopyType);
+
+template<typename T> bool OperatorWithNoDirectCallee(T t) {
+  ExpensiveToCopyType a1;
+  ExpensiveToCopyType a2 = a1;
+  return a1 == t;
+}
+


### PR DESCRIPTION
`GetDirectCallee` can be null.

Fixes #96498.