### PR TITLE
[libc][mmap] force offset to long for mmap2

### DIFF
--- a/libc/src/sys/mman/linux/mmap.cpp
+++ b/libc/src/sys/mman/linux/mmap.cpp
@@ -39,10 +39,9 @@ LLVM_LIBC_FUNCTION(void *, mmap,
 #error "mmap or mmap2 syscalls not available."
 #endif
 
-  long ret =
-      LIBC_NAMESPACE::syscall_impl(syscall_number, reinterpret_cast<long>(addr),
-                                   size, prot, flags, fd,
-                                   static_cast<long>(offset));
+  long ret = LIBC_NAMESPACE::syscall_impl(
+      syscall_number, reinterpret_cast<long>(addr), size, prot, flags, fd,
+      static_cast<long>(offset));
 
   // The mmap/mmap2 syscalls return negative values on error. These negative
   // values are actually the negative values of the error codes. So, fix them

--- a/libc/src/sys/mman/linux/mmap.cpp
+++ b/libc/src/sys/mman/linux/mmap.cpp
@@ -41,7 +41,8 @@ LLVM_LIBC_FUNCTION(void *, mmap,
 
   long ret =
       LIBC_NAMESPACE::syscall_impl(syscall_number, reinterpret_cast<long>(addr),
-                                   size, prot, flags, fd, offset);
+                                   size, prot, flags, fd,
+                                   static_cast<long>(offset));
 
   // The mmap/mmap2 syscalls return negative values on error. These negative
   // values are actually the negative values of the error codes. So, fix them


### PR DESCRIPTION
llvm-libc's "Large File Support" isn't really complete.  We define off_t to be
a uint64_t always, which breaks with convention in an attempt to drop
historical baggage. We might need to revisit that decision in the future, but
for now, force off_t to long when using mmap2.

This avoids having to pass a 64b value to our syscall wrappers for 32b targets,
which we do not support on arm32.  Since we're using mmap2 rather than mmap, we
don't need a 64b value anyways.

Our mmap implementation still has further room for improvement...