### PR TITLE
[Attributor]: AApointerInfo - store the full chain of instructions that make up the access

### DIFF
--- a/llvm/include/llvm/Transforms/IPO/Attributor.h
+++ b/llvm/include/llvm/Transforms/IPO/Attributor.h
@@ -103,7 +103,9 @@
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SetOperations.h"
 #include "llvm/ADT/SetVector.h"
+#include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/ADT/SmallSet.h"
+#include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/iterator.h"
 #include "llvm/Analysis/AssumeBundleQueries.h"
 #include "llvm/Analysis/CFG.h"
@@ -318,6 +320,10 @@ inline raw_ostream &operator<<(raw_ostream &OS, const RangeTy &R) {
 
 inline bool operator==(const RangeTy &A, const RangeTy &B) {
   return A.Offset == B.Offset && A.Size == B.Size;
+}
+
+inline bool operator<(const RangeTy &A, const RangeTy &B) {
+  return A.Offset < B.Offset;
 }
 
 inline bool operator!=(const RangeTy &A, const RangeTy &B) { return !(A == B); }
@@ -5785,6 +5791,139 @@ struct AAPointerInfo : public AbstractAttribute {
     AK_MUST_READ_WRITE = AK_MUST | AK_R | AK_W,
   };
 
+  /// A helper containing a list of offsets computed for a Use. Ideally this
+  /// list should be strictly ascending, but we ensure that only when we
+  /// actually translate the list of offsets to a RangeList.
+  struct OffsetInfo {
+    using VecTy = SmallVector<AA::RangeTy>;
+    // A map to store depth 1 predecessors per offset.
+    using OriginsTy = SmallVector<SmallPtrSet<Value *, 4>>;
+    using const_iterator = VecTy::const_iterator;
+    OriginsTy Origins;
+    VecTy Ranges;
+
+    const_iterator begin() const { return Ranges.begin(); }
+    const_iterator end() const { return Ranges.end(); }
+
+    bool operator==(const OffsetInfo &RHS) const {
+      return Ranges == RHS.Ranges && Origins == RHS.Origins;
+    }
+
+    bool operator!=(const OffsetInfo &RHS) const { return !(*this == RHS); }
+
+    // Insert a new Range and Origin
+    void insert(AA::RangeTy Range, Value &V) {
+      auto *It = std::find(Ranges.begin(), Ranges.end(), Range);
+      // Offset exists in Offsets map
+      if (It != Ranges.end()) {
+        size_t Index = It - Ranges.begin();
+        if (Index < Origins.size())
+          Origins[Index].insert(&V);
+      } else {
+        Ranges.push_back(Range);
+        Origins.emplace_back();
+        Origins.back().insert(&V);
+      }
+    }
+
+    // Set the size of the offset for all ranges.
+    void setSizeAll(uint64_t Size) {
+      for (auto &Range : Ranges)
+        Range.Size = Size;
+    }
+
+    // Helper function to get just the offsets from Ranges.
+    void getOnlyOffsets(SmallVector<int64_t> &Offsets) {
+      for (auto &Range : Ranges)
+        Offsets.push_back(Range.Offset);
+      // ensure unique
+      sort(Offsets.begin(), Offsets.end());
+      Offsets.erase(std::unique(Offsets.begin(), Offsets.end()), Offsets.end());
+    }
+
+    bool isUnassigned() const { return Ranges.empty(); }
+
+    bool isUnknown() const {
+      if (isUnassigned())
+        return false;
+      if (Ranges.size() == 1)
+        return Ranges.front().Offset == AA::RangeTy::Unknown;
+      return false;
+    }
+
+    void setUnknown(Value &V) {
+      Ranges.clear();
+      Origins.clear();
+      insert(AA::RangeTy{AA::RangeTy::Unknown, AA::RangeTy::Unknown}, V);
+    }
+
+    // Increment all ranges by Inc.
+    // Add an origin V to all offsets.
+    void addToAll(int64_t Inc, Value &V) {
+      for (auto &Range : Ranges)
+        Range.Offset += Inc;
+
+      if (!Origins.empty()) {
+        for (auto &Origin : Origins)
+          Origin.insert(&V);
+      } else {
+        for (size_t Index = 0; Index < Ranges.size(); Index++) {
+          Origins.emplace_back();
+          Origins[Index].insert(&V);
+        }
+      }
+    }
+
+    // Increment all ranges by Inc.
+    void addToAll(int64_t Inc) {
+      for (auto &Range : Ranges)
+        Range.Offset += Inc;
+    }
+
+    /// Copy offsets from \p R into the current list.
+    ///
+    /// Ideally all lists should be strictly ascending, but we defer that to the
+    /// actual use of the list. So we just blindly append here.
+    void merge(const OffsetInfo &R) {
+      Ranges.append(R.Ranges);
+      // ensure elements are unique.
+      sort(Ranges.begin(), Ranges.end());
+      Ranges.erase(std::unique(Ranges.begin(), Ranges.end()), Ranges.end());
+
+      OriginsTy ToBeMergeOrigins = R.Origins;
+      for (auto &Origin : ToBeMergeOrigins)
+        Origins.emplace_back(Origin);
+    }
+
+    // Merge two OffsetInfo structs.
+    // takes an additional origin argument
+    // and adds it to the corresponding offset in the
+    // origins map.
+    void mergeWithOffset(const OffsetInfo &R, Value &CurPtr) {
+      Ranges.append(R.Ranges);
+      // ensure elements are unique.
+      sort(Ranges.begin(), Ranges.end());
+      Ranges.erase(std::unique(Ranges.begin(), Ranges.end()), Ranges.end());
+      auto &ROffsets = R.Ranges;
+      for (auto Offset : ROffsets) {
+        auto *It = std::find(Ranges.begin(), Ranges.end(), Offset);
+        if (It == Ranges.end())
+          continue;
+        size_t Index = It - Ranges.begin();
+        if (Index >= Origins.size()) {
+          Origins.emplace_back();
+          Origins.back().insert(&CurPtr);
+        } else {
+          Origins[Index].insert(&CurPtr);
+        }
+      }
+    }
+  };
+
+  using OffsetInfoMapTy = DenseMap<Value *, OffsetInfo>;
+  using AccessPathTy = SmallVector<Value *, 4>;
+  using AccessPathSetTy = SmallPtrSet<AccessPathTy *, 4>;
+
   /// A container for a list of ranges.
   struct RangeList {
     // The set of ranges rarely contains more than one element, and is unlikely
@@ -5939,15 +6078,17 @@ struct AAPointerInfo : public AbstractAttribute {
   /// An access description.
   struct Access {
     Access(Instruction *I, int64_t Offset, int64_t Size,
-           std::optional<Value *> Content, AccessKind Kind, Type *Ty)
+           std::optional<Value *> Content, AccessKind Kind, Type *Ty,
+           AccessPathSetTy *AccessPaths)
         : LocalI(I), RemoteI(I), Content(Content), Ranges(Offset, Size),
-          Kind(Kind), Ty(Ty) {
+          Kind(Kind), Ty(Ty), AccessPaths(AccessPaths) {
       verify();
     }
     Access(Instruction *LocalI, Instruction *RemoteI, const RangeList &Ranges,
-           std::optional<Value *> Content, AccessKind K, Type *Ty)
+           std::optional<Value *> Content, AccessKind K, Type *Ty,
+           AccessPathSetTy *AccessPaths)
         : LocalI(LocalI), RemoteI(RemoteI), Content(Content), Ranges(Ranges),
-          Kind(K), Ty(Ty) {
+          Kind(K), Ty(Ty), AccessPaths(AccessPaths) {
       if (Ranges.size() > 1) {
         Kind = AccessKind(Kind | AK_MAY);
         Kind = AccessKind(Kind & ~AK_MUST);
@@ -5956,9 +6097,9 @@ struct AAPointerInfo : public AbstractAttribute {
     }
     Access(Instruction *LocalI, Instruction *RemoteI, int64_t Offset,
            int64_t Size, std::optional<Value *> Content, AccessKind Kind,
-           Type *Ty)
+           Type *Ty, AccessPathSetTy *AccessPaths)
         : LocalI(LocalI), RemoteI(RemoteI), Content(Content),
-          Ranges(Offset, Size), Kind(Kind), Ty(Ty) {
+          Ranges(Offset, Size), Kind(Kind), Ty(Ty), AccessPaths(AccessPaths) {
       verify();
     }
     Access(const Access &Other) = default;
@@ -5966,7 +6107,8 @@ struct AAPointerInfo : public AbstractAttribute {
     Access &operator=(const Access &Other) = default;
     bool operator==(const Access &R) const {
       return LocalI == R.LocalI && RemoteI == R.RemoteI && Ranges == R.Ranges &&
-             Content == R.Content && Kind == R.Kind;
+             Content == R.Content && Kind == R.Kind &&
+             checkAccessPathsAreSame(R.AccessPaths);
     }
     bool operator!=(const Access &R) const { return !(*this == R); }
 
@@ -6078,11 +6220,57 @@ struct AAPointerInfo : public AbstractAttribute {
       }
     }
 
+    // Merge two access paths into one.
+    void mergeAccessPaths(Attributor &A,
+                          const AccessPathSetTy *AccessPathsNew) const {
+      for (auto *Path : *AccessPathsNew)
+        if (!existsChain(Path)) {
+          AccessPathTy *CopiedPath =
+              new (A.Allocator) AccessPathTy(Path->begin(), Path->end());
+          AccessPaths->insert(CopiedPath);
+        }
+    }
+
+    // Check if the given access paths are same.
+    bool checkAccessPathsAreSame(const AccessPathSetTy *AccessPathsR) const {
+      bool IsSame = true;
+      if (AccessPaths->size() != AccessPathsR->size())
+        return false;
+
+      for (auto *Path : *AccessPathsR) {
+        if (!existsChain(Path))
+          IsSame = false;
+      }
+      return IsSame;
+    }
+
+    // Check if the chain exists in the AccessPathsSet.
+    bool existsChain(const AccessPathTy *NewPath) const {
+      for (auto *OldPath : *AccessPaths)
+        if (*OldPath == *NewPath)
+          return true;
+
+      return false;
+    }
+
+    void dumpAccessPaths(raw_ostream &O) const {
+      O << "Print all access paths found:"
+        << "\n";
+      for (auto *It : *AccessPaths) {
+        O << "Backtrack a unique access path:\n";
+        for (Value *Ins : *It) {
+          O << *Ins << "\n";
+        }
+      }
+    }
+
+    const AccessPathSetTy *getAccessChain() const { return AccessPaths; }
     const RangeList &getRanges() const { return Ranges; }
 
     using const_iterator = RangeList::const_iterator;
     const_iterator begin() const { return Ranges.begin(); }
     const_iterator end() const { return Ranges.end(); }
+    size_t size() const { return Ranges.size(); }
 
   private:
     /// The instruction responsible for the access with respect to the local
@@ -6105,6 +6293,10 @@ struct AAPointerInfo : public AbstractAttribute {
     /// The type of the content, thus the type read/written, can be null if not
     /// available.
     Type *Ty;
+
+    /// The full chain of instructions that participate in the Access.
+    /// There may be more than one access chain.
+    AccessPathSetTy *AccessPaths;
   };
 
   /// Create an abstract attribute view for the position \p IRP.

--- a/llvm/test/Transforms/Attributor/pointer-info-track-access-chain.ll
+++ b/llvm/test/Transforms/Attributor/pointer-info-track-access-chain.ll
@@ -1,0 +1,387 @@
+; RUN: opt -aa-pipeline=basic-aa -passes=attributor -attributor-manifest-internal -debug-only=attributor  -attributor-annotate-decl-cs  -S < %s 2>&1 | FileCheck %s
+; RUN: opt -aa-pipeline=basic-aa -passes=attributor-cgscc -attributor-manifest-internal -debug-only=attributor  -attributor-annotate-decl-cs -S < %s 2>&1  | FileCheck %s
+; REQUIRES: asserts
+
+
+@globalBytes = internal global [1024 x i8] zeroinitializer, align 16
+
+; CHECK: Accesses by bin after update:
+; CHECK: [8-12] : 1
+; CHECK:      - 5 -   %1 = load i32, ptr %field22, align 4
+; CHECK:        - c: <unknown>
+; CHECK: Print all access paths found:
+; CHECK: Backtrack a unique access path:
+; CHECK:   %1 = load i32, ptr %field22, align 4
+; CHECK:   %field22 = getelementptr i32, ptr %field2, i32 0
+; CHECK:   %field2 = getelementptr inbounds [10 x i32], ptr %f, i32 0, i32 2
+; CHECK:   %f = alloca [10 x i32], align 4
+; CHECK: [4-5] : 1
+; CHECK:      - 9 -   store i8 10, ptr %field11, align 4
+; CHECK:        - c: i8 10
+; CHECK: Print all access paths found:
+; CHECK: Backtrack a unique access path:
+; CHECK:   store i8 10, ptr %field11, align 4
+; CHECK:   %field11 = getelementptr i32, ptr %field1, i32 0
+; CHECK:   %field1 = getelementptr inbounds [10 x i32], ptr %f, i32 0, i32 1
+; CHECK:   %f = alloca [10 x i32], align 4
+; CHECK: [32-36] : 1
+; CHECK:      - 9 -   store i32 %3, ptr %field8, align 4
+; CHECK:        - c:   %3 = load i32, ptr %val, align 4
+; CHECK: Print all access paths found:
+; CHECK: Backtrack a unique access path:
+; CHECK:   store i32 %3, ptr %field8, align 4
+; CHECK:   %field8 = getelementptr inbounds [10 x i32], ptr %f, i32 0, i32 8
+; CHECK:   %f = alloca [10 x i32], align 4
+; CHECK: [4-8] : 1
+; CHECK:      - 5 -   %0 = load i32, ptr %field11, align 4
+; CHECK:        - c: <unknown>
+; CHECK: Print all access paths found:
+; CHECK: Backtrack a unique access path:
+; CHECK:   %0 = load i32, ptr %field11, align 4
+; CHECK:   %field11 = getelementptr i32, ptr %field1, i32 0
+; CHECK:   %field1 = getelementptr inbounds [10 x i32], ptr %f, i32 0, i32 1
+; CHECK:   %f = alloca [10 x i32], align 4
+; CHECK: [8-9] : 1
+; CHECK:      - 9 -   store i8 12, ptr %field22, align 4
+; CHECK:        - c: i8 12
+; CHECK: Print all access paths found:
+; CHECK: Backtrack a unique access path:
+; CHECK:   store i8 12, ptr %field22, align 4
+; CHECK:   %field22 = getelementptr i32, ptr %field2, i32 0
+; CHECK:   %field2 = getelementptr inbounds [10 x i32], ptr %f, i32 0, i32 2
+; CHECK:   %f = alloca [10 x i32], align 4
+define dso_local i32 @track_chain(ptr nocapture %val) #0 {
+entry:
+  %f = alloca [10 x i32]
+  %field1 = getelementptr inbounds [10 x i32], ptr %f, i32 0, i32 1
+  %field2 = getelementptr inbounds [10 x i32], ptr %f, i32 0, i32 2
+  %field3 = getelementptr inbounds [10 x i32], ptr %f, i32 0, i32 3
+  %field8 = getelementptr inbounds [10 x i32], ptr %f, i32 0, i32 8
+
+  %field11 = getelementptr i32, ptr %field1, i32 0
+  %field22 = getelementptr i32, ptr %field2, i32 0
+  store i8 10, ptr %field11, align 4
+  store i8 12, ptr %field22, align 4
+
+  %1 = load i32, ptr %field11, align 4
+  %2 = load i32, ptr %field22, align 4
+  %3 = add i32 %1, %2
+
+  %4 = load i32, ptr %val, align 4
+  store i32 %4, ptr %field8, align 4
+
+  %5 = add i32 %4, %3
+
+  ret i32 %5
+}
+
+
+; CHECK: Accesses by bin after update:
+; CHECK: [12-16] : 1
+; CHECK:      - 5 -   %0 = load i32, ptr %field11, align 4
+; CHECK:        - c: <unknown>
+; CHECK: Print all access paths found:
+; CHECK: Backtrack a unique access path:
+; CHECK:   %0 = load i32, ptr %field11, align 4
+; CHECK:   %field11 = getelementptr i32, ptr %field1, i32 2
+; CHECK:   %field1 = getelementptr inbounds [10 x i32], ptr %f, i32 0, i32 1
+; CHECK:   %f = alloca [10 x i32], align 4
+; CHECK: [16-17] : 1
+; CHECK:      - 9 -   store i8 12, ptr %field22, align 4
+; CHECK:        - c: i8 12
+; CHECK: Print all access paths found:
+; CHECK: Backtrack a unique access path:
+; CHECK:   store i8 12, ptr %field22, align 4
+; CHECK:   %field22 = getelementptr i32, ptr %field2, i32 2
+; CHECK:   %field2 = getelementptr inbounds [10 x i32], ptr %f, i32 0, i32 2
+; CHECK:   %f = alloca [10 x i32], align 4
+; CHECK: [32-36] : 1
+; CHECK:      - 9 -   store i32 %3, ptr %field8, align 4
+; CHECK:        - c:   %3 = load i32, ptr %val, align 4
+; CHECK: Print all access paths found:
+; CHECK: Backtrack a unique access path:
+; CHECK:   store i32 %3, ptr %field8, align 4
+; CHECK:   %field8 = getelementptr inbounds [10 x i32], ptr %f, i32 0, i32 8
+; CHECK:   %f = alloca [10 x i32], align 4
+; CHECK: [16-20] : 1
+; CHECK:      - 5 -   %1 = load i32, ptr %field22, align 4
+; CHECK:        - c: <unknown>
+; CHECK: Print all access paths found:
+; CHECK: Backtrack a unique access path:
+; CHECK:   %1 = load i32, ptr %field22, align 4
+; CHECK:   %field22 = getelementptr i32, ptr %field2, i32 2
+; CHECK:   %field2 = getelementptr inbounds [10 x i32], ptr %f, i32 0, i32 2
+; CHECK:   %f = alloca [10 x i32], align 4
+; CHECK: [12-13] : 1
+; CHECK:      - 9 -   store i8 10, ptr %field11, align 4
+; CHECK:        - c: i8 10
+; CHECK: Print all access paths found:
+; CHECK: Backtrack a unique access path:
+; CHECK:   store i8 10, ptr %field11, align 4
+; CHECK:   %field11 = getelementptr i32, ptr %field1, i32 2
+; CHECK:   %field1 = getelementptr inbounds [10 x i32], ptr %f, i32 0, i32 1
+; CHECK:   %f = alloca [10 x i32], align 4
+define dso_local i32 @track_chain_2(ptr nocapture %val) #0 {
+entry:
+  %f = alloca [10 x i32]
+  %field1 = getelementptr inbounds [10 x i32], ptr %f, i32 0, i32 1
+  %field2 = getelementptr inbounds [10 x i32], ptr %f, i32 0, i32 2
+  %field3 = getelementptr inbounds [10 x i32], ptr %f, i32 0, i32 3
+  %field8 = getelementptr inbounds [10 x i32], ptr %f, i32 0, i32 8
+
+  %field11 = getelementptr i32, ptr %field1, i32 2
+  %field22 = getelementptr i32, ptr %field2, i32 2
+  store i8 10, ptr %field11, align 4
+  store i8 12, ptr %field22, align 4
+
+  %1 = load i32, ptr %field11, align 4
+  %2 = load i32, ptr %field22, align 4
+  %3 = add i32 %1, %2
+
+  %4 = load i32, ptr %val, align 4
+  store i32 %4, ptr %field8, align 4
+
+  %5 = add i32 %4, %3
+
+  ret i32 %5
+}
+
+
+; CHECK: Accesses by bin after update:
+; CHECK: [12-16] : 3
+; CHECK:      - 5 -   %0 = load i32, ptr %field11, align 4
+; CHECK:       - c: <unknown>
+; CHECK: Print all access paths found:
+; CHECK: Backtrack a unique access path:
+; CHECK:   %0 = load i32, ptr %field11, align 4
+; CHECK:   %field11 = getelementptr i32, ptr %field1, i32 2
+; CHECK:   %field1 = getelementptr inbounds [10 x i32], ptr %f, i32 0, i32 1
+; CHECK:   %f = alloca [10 x i32], align 4
+; CHECK:      - 5 -   %b = load i32, ptr %field3, align 4
+; CHECK:        - c: <unknown>
+; CHECK: Print all access paths found:
+; CHECK: Backtrack a unique access path:
+; CHECK:   %b = load i32, ptr %field3, align 4
+; CHECK:   %field3 = getelementptr inbounds [10 x i32], ptr %f, i32 0, i32 3
+; CHECK:   %f = alloca [10 x i32], align 4
+; CHECK:      - 10 -   store i32 1000, ptr %6, align 4
+; CHECK:        - c: i32 1000
+; CHECK: Print all access paths found:
+; CHECK: Backtrack a unique access path:
+; CHECK:   store i32 1000, ptr %6, align 4
+; CHECK:   %6 = select i1 %cond, ptr %field3, ptr %field8
+; CHECK:   %field3 = getelementptr inbounds [10 x i32], ptr %f, i32 0, i32 3
+; CHECK:   %f = alloca [10 x i32], align 4
+; CHECK: Backtrack a unique access path:
+; CHECK:   store i32 1000, ptr %6, align 4
+; CHECK:   %6 = select i1 %cond, ptr %field3, ptr %field8
+; CHECK:   %field8 = getelementptr inbounds [10 x i32], ptr %f, i32 0, i32 8
+; CHECK:   %f = alloca [10 x i32], align 4
+; CHECK: [16-17] : 1
+; CHECK:      - 9 -   store i8 12, ptr %field22, align 4
+; CHECK:       - c: i8 12
+; CHECK: Print all access paths found:
+; CHECK: Backtrack a unique access path:
+; CHECK:   store i8 12, ptr %field22, align 4
+; CHECK:   %field22 = getelementptr i32, ptr %field2, i32 2
+; CHECK:   %field2 = getelementptr inbounds [10 x i32], ptr %f, i32 0, i32 2
+; CHECK:   %f = alloca [10 x i32], align 4
+; CHECK: [32-36] : 4
+; CHECK:      - 9 -   store i32 %3, ptr %field8, align 4
+; CHECK:        - c:   %3 = load i32, ptr %val, align 4
+; CHECK: Print all access paths found:
+; CHECK: Backtrack a unique access path:
+; CHECK:   store i32 %3, ptr %field8, align 4
+; CHECK:   %field8 = getelementptr inbounds [10 x i32], ptr %f, i32 0, i32 8
+; CHECK:   %f = alloca [10 x i32], align 4
+; CHECK:      - 5 -   %a1 = load i32, ptr %field8, align 4
+; CHECK:        - c: <unknown>
+; CHECK: Print all access paths found:
+; CHECK: Backtrack a unique access path:
+; CHECK:   %a1 = load i32, ptr %field8, align 4
+; CHECK:   %field8 = getelementptr inbounds [10 x i32], ptr %f, i32 0, i32 8
+; CHECK:   %f = alloca [10 x i32], align 4
+; CHECK:      - 10 -   store i32 1000, ptr %6, align 4
+; CHECK:        - c: i32 1000
+; CHECK: Print all access paths found:
+; CHECK: Backtrack a unique access path:
+; CHECK:   store i32 1000, ptr %6, align 4
+; CHECK:   %6 = select i1 %cond, ptr %field3, ptr %field8
+; CHECK:   %field3 = getelementptr inbounds [10 x i32], ptr %f, i32 0, i32 3
+; CHECK:   %f = alloca [10 x i32], align 4
+; CHECK: Backtrack a unique access path:
+; CHECK:   store i32 1000, ptr %6, align 4
+; CHECK:   %6 = select i1 %cond, ptr %field3, ptr %field8
+; CHECK:  %field8 = getelementptr inbounds [10 x i32], ptr %f, i32 0, i32 8
+; CHECK:   %f = alloca [10 x i32], align 4
+; CHECK:      - 5 -   %8 = load i32, ptr %field8, align 4
+; CHECK:        - c: <unknown>
+; CHECK: Print all access paths found:
+; CHECK: Backtrack a unique access path:
+; CHECK:  %8 = load i32, ptr %field8, align 4
+; CHECK:  %field8 = getelementptr inbounds [10 x i32], ptr %f, i32 0, i32 8
+; CHECK:  %f = alloca [10 x i32], align 4
+; CHECK: [16-20] : 1
+; CHECK:      - 5 -   %1 = load i32, ptr %field22, align 4
+; CHECK:        - c: <unknown>
+; CHECK: Print all access paths found:
+; CHECK: Backtrack a unique access path:
+; CHECK:   %1 = load i32, ptr %field22, align 4
+; CHECK:   %field22 = getelementptr i32, ptr %field2, i32 2
+; CHECK:   %field2 = getelementptr inbounds [10 x i32], ptr %f, i32 0, i32 2
+; CHECK:   %f = alloca [10 x i32], align 4
+; CHECK: [12-13] : 1
+; CHECK:      - 9 -   store i8 10, ptr %field11, align 4
+; CHECK:        - c: i8 10
+; CHECK: Print all access paths found:
+; CHECK: Backtrack a unique access path:
+; CHECK:   store i8 10, ptr %field11, align 4
+; CHECK:   %field11 = getelementptr i32, ptr %field1, i32 2
+; CHECK:   %field1 = getelementptr inbounds [10 x i32], ptr %f, i32 0, i32 1
+; CHECK:   %f = alloca [10 x i32], align 4
+define dso_local i32 @track_chain_3(ptr nocapture %val, i1 %cond) #0 {
+entry:
+  %f = alloca [10 x i32]
+  %field1 = getelementptr inbounds [10 x i32], ptr %f, i32 0, i32 1
+  %field2 = getelementptr inbounds [10 x i32], ptr %f, i32 0, i32 2
+  %field3 = getelementptr inbounds [10 x i32], ptr %f, i32 0, i32 3
+  %field8 = getelementptr inbounds [10 x i32], ptr %f, i32 0, i32 8
+
+  %field11 = getelementptr i32, ptr %field1, i32 2
+  %field22 = getelementptr i32, ptr %field2, i32 2
+  store i8 10, ptr %field11, align 4
+  store i8 12, ptr %field22, align 4
+  %1 = load i32, ptr %field11, align 4
+  %2 = load i32, ptr %field22, align 4
+  %3 = add i32 %1, %2
+  %4 = load i32, ptr %val, align 4
+  store i32 %4, ptr %field8, align 4
+  %5 = add i32 %4, %3
+  %6 = load i32, ptr %val
+  %a1 = load i32, ptr %field8
+  %a = add i32 %a1, %6
+  %b = load i32, ptr %field3
+  ;%b  = sub i32 %b1, %6
+  %7 = select i1 %cond, ptr %field3, ptr %field8
+  store i32 1000, ptr %7
+  %8 = add i32 %5, %b
+  %9 = load i32, ptr %field8
+  %10 = add i32 %9, %8
+  ret i32 %10
+}
+
+; CHECK: Accesses by bin after update:
+; CHECK: [8-12] : 2
+; CHECK:      - 9 -   store i32 %0, ptr %field2, align 4
+; CHECK:        - c:   %0 = load i32, ptr %val, align 4
+; CHECK: Print all access paths found:
+; CHECK: Backtrack a unique access path:
+; CHECK:   store i32 %0, ptr %field2, align 4
+; CHECK:   %field2 = getelementptr i32, ptr @globalBytes, i32 2
+; CHECK: @globalBytes = internal global [1024 x i8] zeroinitializer, align 16
+; CHECK:      - 6 -   %ret = load i32, ptr %x, align 4
+; CHECK:        - c: <unknown>
+; CHECK: Print all access paths found:
+; CHECK: Backtrack a unique access path:
+; CHECK:   %ret = load i32, ptr %x, align 4
+; CHECK:   %x = phi ptr [ %field2, %then ], [ %field8, %else ]
+; CHECK:   %field2 = getelementptr i32, ptr @globalBytes, i32 2
+; CHECK: @globalBytes = internal global [1024 x i8] zeroinitializer, align 16
+; CHECK: Backtrack a unique access path:
+; CHECK:   %ret = load i32, ptr %x, align 4
+; CHECK:   %x = phi ptr [ %field2, %then ], [ %field8, %else ]
+; CHECK:   %field8 = getelementptr i32, ptr @globalBytes, i32 8
+; CHECK: @globalBytes = internal global [1024 x i8] zeroinitializer, align 16
+; CHECK: [32-36] : 5
+; CHECK:      - 6 -   %ret = load i32, ptr %x, align 4
+; CHECK:        - c: <unknown>
+; CHECK: Print all access paths found:
+; CHECK: Backtrack a unique access path:
+; CHECK:   %ret = load i32, ptr %x, align 4
+; CHECK:   %x = phi ptr [ %field2, %then ], [ %field8, %else ]
+; CHECK:   %field2 = getelementptr i32, ptr @globalBytes, i32 2
+; CHECK: @globalBytes = internal global [1024 x i8] zeroinitializer, align 16
+; CHECK: Backtrack a unique access path:
+; CHECK:   %ret = load i32, ptr %x, align 4
+; CHECK:   %x = phi ptr [ %field2, %then ], [ %field8, %else ]
+; CHECK:   %field8 = getelementptr i32, ptr @globalBytes, i32 8
+; CHECK: @globalBytes = internal global [1024 x i8] zeroinitializer, align 16
+; CHECK:      - 9 -   store i32 %1, ptr %field8, align 4
+; CHECK:        - c:   %1 = load i32, ptr %val2, align 4
+; CHECK: Print all access paths found:
+; CHECK: Backtrack a unique access path:
+; CHECK:   store i32 %1, ptr %field8, align 4
+; CHECK:   %field8 = getelementptr i32, ptr @globalBytes, i32 8
+; CHECK: @globalBytes = internal global [1024 x i8] zeroinitializer, align 16
+; CHECK:      - 9 -   store i32 %0, ptr %field2, align 4
+; CHECK:        - c:   %0 = load i32, ptr %val, align 4
+; CHECK: Print all access paths found:
+; CHECK: Backtrack a unique access path:
+; CHECK:   store i32 %0, ptr %field2, align 4
+; CHECK:   %field2 = getelementptr i32, ptr @globalBytes, i32 8
+; CHECK: @globalBytes = internal global [1024 x i8] zeroinitializer, align 16
+; CHECK:      - 6 -   %ret = load i32, ptr %x, align 4
+; CHECK:        - c: <unknown>
+; CHECK: Print all access paths found:
+; CHECK: Backtrack a unique access path:
+; CHECK:   %ret = load i32, ptr %x, align 4
+; CHECK:   %x = phi ptr [ %field2, %then ], [ %field8, %else ]
+; CHECK:   %field2 = getelementptr i32, ptr @globalBytes, i32 8
+; CHECK: @globalBytes = internal global [1024 x i8] zeroinitializer, align 16
+; CHECK: Backtrack a unique access path:
+; CHECK:   %ret = load i32, ptr %x, align 4
+; CHECK:   %x = phi ptr [ %field2, %then ], [ %field8, %else ]
+; CHECK:   %field8 = getelementptr i32, ptr @globalBytes, i32 8
+; CHECK: @globalBytes = internal global [1024 x i8] zeroinitializer, align 16
+; CHECK:      - 9 -   store i32 %1, ptr %field8, align 4
+; CHECK:        - c:   %1 = load i32, ptr %val2, align 4
+; CHECK: Print all access paths found:
+; CHECK: Backtrack a unique access path:
+; CHECK:   store i32 %1, ptr %field8, align 4
+; CHECK:   %field8 = getelementptr i32, ptr @globalBytes, i32 8
+; CHECK: @globalBytes = internal global [1024 x i8] zeroinitializer, align 16
+
+define dso_local i32 @phi_different_offsets(ptr nocapture %val, ptr nocapture %val2, i1 %cmp) {
+entry:
+  br i1 %cmp, label %then, label %else
+
+then:
+  %field2 = getelementptr i32, ptr @globalBytes, i32 2
+  %0 = load i32, ptr %val
+  store i32 %0, ptr %field2
+  br label %end
+
+else:
+  %field8 = getelementptr i32, ptr @globalBytes, i32 8
+  %2 = load i32, ptr %val2
+  store i32 %2, ptr %field8
+  br label %end
+
+end:
+  %x = phi ptr [ %field2, %then ], [ %field8, %else ]
+  %ret = load i32, ptr %x
+  ret i32 %ret
+
+}
+
+define dso_local i32 @phi_same_offsets(ptr nocapture %val, ptr nocapture %val2, i1 %cmp) {
+entry:
+  br i1 %cmp, label %then, label %else
+
+then:
+  %field2 = getelementptr i32, ptr @globalBytes, i32 8
+  %0 = load i32, ptr %val
+  store i32 %0, ptr %field2
+  br label %end
+
+else:
+  %field8 = getelementptr i32, ptr @globalBytes, i32 8
+  %2 = load i32, ptr %val2
+  store i32 %2, ptr %field8
+  br label %end
+
+end:
+  %x = phi ptr [ %field2, %then ], [ %field8, %else ]
+  %ret = load i32, ptr %x
+  ret i32 %ret
+}


### PR DESCRIPTION
Support for keeping track of the full chain of instructions in AAPointerInfo. 
We need this for modifying intermediate instructions rather than add new instructions to the final load/store when offsets change. Corresponding PR: https://github.com/llvm/llvm-project/pull/72029
