### PR TITLE
__asan_register_elf_globals: properly check the "no instrumented global variable" case

### DIFF
--- a/compiler-rt/lib/asan/asan_globals.cpp
+++ b/compiler-rt/lib/asan/asan_globals.cpp
@@ -344,8 +344,8 @@ void __asan_unregister_image_globals(uptr *flag) {
 }
 
 void __asan_register_elf_globals(uptr *flag, void *start, void *stop) {
-  if (*flag) return;
-  if (!start) return;
+  if (*flag || start == stop)
+    return;
   CHECK_EQ(0, ((uptr)stop - (uptr)start) % sizeof(__asan_global));
   __asan_global *globals_start = (__asan_global*)start;
   __asan_global *globals_stop = (__asan_global*)stop;
@@ -354,8 +354,8 @@ void __asan_register_elf_globals(uptr *flag, void *start, void *stop) {
 }
 
 void __asan_unregister_elf_globals(uptr *flag, void *start, void *stop) {
-  if (!*flag) return;
-  if (!start) return;
+  if (!*flag || start == stop)
+    return;
   CHECK_EQ(0, ((uptr)stop - (uptr)start) % sizeof(__asan_global));
   __asan_global *globals_start = (__asan_global*)start;
   __asan_global *globals_stop = (__asan_global*)stop;


### PR DESCRIPTION
On ELF platforms, the instrumentation registers global variables using
`__asan_register_elf_globals` for the default `UseGlobalsGC` case. If
all instrumented global variables in a module are discarded by linker
GC, we will have `start == stop`.

Normally `start == 0`, but `start != 0` is possible with a linker script
retaining `asan_globals`. The called `__asan_register_globals` would
access out-of-bounds `globals[n-1]`, though there is likely no runtime
failure.
