### PR TITLE
[Flang][OpenMP] Add --cg-rewrite pass to convert-to-llvm-openmp-and-fir.fir test

### DIFF
--- a/flang/test/Fir/convert-to-llvm-openmp-and-fir.fir
+++ b/flang/test/Fir/convert-to-llvm-openmp-and-fir.fir
@@ -1,4 +1,4 @@
-// RUN: fir-opt --split-input-file --cfg-conversion --fir-to-llvm-ir="target=aarch64-unknown-linux-gnu" %s | FileCheck %s
+// RUN: fir-opt --split-input-file --cg-rewrite --cfg-conversion --fir-to-llvm-ir="target=aarch64-unknown-linux-gnu" %s | FileCheck %s
 
 func.func @_QPsb1(%arg0: !fir.ref<i32> {fir.bindc_name = "n"}, %arg1: !fir.ref<!fir.array<?xi32>> {fir.bindc_name = "arr"}) {
   %c1_i64 = arith.constant 1 : i64


### PR DESCRIPTION
Currently this is missing from the fir-opt command in this test, which means we can't use certain fir.operations inside of the test without causing verification issues. As an example fir::DeclareOp, which I believe the cg-rewrite pass normally converts to fir::cg::XDeclareOp prior to CodeGen'ng to LLVM-IR.

Perhaps, there's a reason for not including this option in the command list originally that I am not aware of! But it would be helpful to enable this pass to allow the full (or at least a wider) range of FIR operations to be used within the test cases.