### PR TITLE
Update Clang extension criteria

### DIFF
--- a/clang/www/get_involved.html
+++ b/clang/www/get_involved.html
@@ -126,6 +126,12 @@ evaluation:</p>
   extension is not broken by ongoing maintenance in Clang. The test suite
   should be complete enough that another compiler vendor could conceivably
   validate their implementation of the feature against it.</li>
+
+  <li>A support story for other impacted projects within the monorepo: If the
+  extension can impact other parts of the project (libc++, lldb, compiler-rt,
+  etc), the proposal needs to document the impact for these projects to fully
+  support the extension and what level of support is expected. The impacted
+  project communities need to agree with that plan.</li>
 </ol>
 
 </div>


### PR DESCRIPTION
This updates Clang's extension criteria to explicitly mention impacts on other projects within the monorepo.

These changes were discussed in the following RFC: https://discourse.llvm.org/t/rfc-require-discussion-of-impact-to-monorepo-stakeholders-when-adding-new-clang-extensions/79613