### PR TITLE
[MLIR] Fix LocationSnapshot: Use provided flags

### DIFF
--- a/mlir/lib/Transforms/LocationSnapshot.cpp
+++ b/mlir/lib/Transforms/LocationSnapshot.cpp
@@ -140,7 +140,7 @@ struct LocationSnapshotPass
 
   void runOnOperation() override {
     Operation *op = getOperation();
-    if (failed(generateLocationsFromIR(fileName, op, OpPrintingFlags(), tag)))
+    if (failed(generateLocationsFromIR(fileName, op, flags, tag)))
       return signalPassFailure();
   }
 


### PR DESCRIPTION
The LocationSnapshot pass does not use the provided OpPrintingFlags passed in. Small one-line fix for that.