### PR TITLE
Add ConstantRangeList::unionWith() and ::intersectWith()

### DIFF
--- a/llvm/include/llvm/IR/ConstantRangeList.h
+++ b/llvm/include/llvm/IR/ConstantRangeList.h
@@ -72,12 +72,12 @@ public:
                          APInt(64, Upper, /*isSigned=*/true)));
   }
 
-  /// Return the range list that results from the union of this range
-  /// with another range list.
+  /// Return the range list that results from the union of this
+  /// ConstantRangeList with another ConstantRangeList, "CRL".
   ConstantRangeList unionWith(const ConstantRangeList &CRL) const;
 
-  /// Return the range list that results from the intersection of this range
-  /// with another range list.
+  /// Return the range list that results from the intersection of this
+  /// ConstantRangeList with another ConstantRangeList, "CRL".
   ConstantRangeList intersectWith(const ConstantRangeList &CRL) const;
 
   /// Return true if this range list is equal to another range list.

--- a/llvm/include/llvm/IR/ConstantRangeList.h
+++ b/llvm/include/llvm/IR/ConstantRangeList.h
@@ -72,6 +72,14 @@ public:
                          APInt(64, Upper, /*isSigned=*/true)));
   }
 
+  /// Return the range list that results from the union of this range
+  /// with another range list.
+  ConstantRangeList unionWith(const ConstantRangeList &CRL) const;
+
+  /// Return the range list that results from the intersection of this range
+  /// with another range list.
+  ConstantRangeList intersectWith(const ConstantRangeList &CRL) const;
+
   /// Return true if this range list is equal to another range list.
   bool operator==(const ConstantRangeList &CRL) const {
     return Ranges == CRL.Ranges;

--- a/llvm/lib/IR/ConstantRangeList.cpp
+++ b/llvm/lib/IR/ConstantRangeList.cpp
@@ -84,7 +84,7 @@ void ConstantRangeList::insert(const ConstantRange &NewRange) {
 ConstantRangeList
 ConstantRangeList::unionWith(const ConstantRangeList &CRL) const {
   assert(getBitWidth() == CRL.getBitWidth() &&
-         "ConstantRangeList types don't agree!");
+         "ConstantRangeList bitwidths don't agree!");
   // Handle common cases.
   if (empty())
     return CRL;
@@ -136,7 +136,7 @@ ConstantRangeList::unionWith(const ConstantRangeList &CRL) const {
 ConstantRangeList
 ConstantRangeList::intersectWith(const ConstantRangeList &CRL) const {
   assert(getBitWidth() == CRL.getBitWidth() &&
-         "ConstantRangeList types don't agree!");
+         "ConstantRangeList bitwidths don't agree!");
 
   // Handle common cases.
   if (empty())

--- a/llvm/lib/IR/ConstantRangeList.cpp
+++ b/llvm/lib/IR/ConstantRangeList.cpp
@@ -81,6 +81,86 @@ void ConstantRangeList::insert(const ConstantRange &NewRange) {
   }
 }
 
+ConstantRangeList
+ConstantRangeList::unionWith(const ConstantRangeList &CRL) const {
+  assert(getBitWidth() == CRL.getBitWidth() &&
+         "ConstantRangeList types don't agree!");
+  // Handle common cases.
+  if (empty())
+    return CRL;
+  if (CRL.empty())
+    return *this;
+
+  ConstantRangeList Result;
+  size_t i = 0, j = 0;
+  ConstantRange PreviousRange(getBitWidth(), false);
+  if (Ranges[i].getLower().slt(CRL.Ranges[j].getLower())) {
+    PreviousRange = Ranges[i++];
+  } else {
+    PreviousRange = CRL.Ranges[j++];
+  }
+  auto UnionAndUpdateRange = [&PreviousRange,
+                              &Result](const ConstantRange &CR) {
+    assert(!CR.isSignWrappedSet() && "Upper wrapped ranges are not supported");
+    if (PreviousRange.getUpper().slt(CR.getLower())) {
+      Result.Ranges.push_back(PreviousRange);
+      PreviousRange = CR;
+    } else {
+      PreviousRange = ConstantRange(
+          PreviousRange.getLower(),
+          APIntOps::smax(PreviousRange.getUpper(), CR.getUpper()));
+    }
+  };
+  while (i < size() || j < CRL.size()) {
+    if (j == CRL.size() ||
+        (i < size() && Ranges[i].getLower().slt(CRL.Ranges[j].getLower()))) {
+      // Merge PreviousRange with this.
+      UnionAndUpdateRange(Ranges[i++]);
+    } else {
+      // Merge PreviousRange with CRL.
+      UnionAndUpdateRange(CRL.Ranges[j++]);
+    }
+  }
+  Result.Ranges.push_back(PreviousRange);
+  return Result;
+}
+
+ConstantRangeList
+ConstantRangeList::intersectWith(const ConstantRangeList &CRL) const {
+  assert(getBitWidth() == CRL.getBitWidth() &&
+         "ConstantRangeList types don't agree!");
+
+  // Handle common cases.
+  if (empty())
+    return *this;
+  if (CRL.empty())
+    return CRL;
+
+  ConstantRangeList Result;
+  size_t i = 0, j = 0;
+  while (i < size() && j < CRL.size()) {
+    auto &Range = this->Ranges[i];
+    auto &OtherRange = CRL.Ranges[j];
+    assert(!Range.isSignWrappedSet() && !OtherRange.isSignWrappedSet() &&
+           "Upper wrapped ranges are not supported");
+
+    APInt Start = Range.getLower().slt(OtherRange.getLower())
+                      ? OtherRange.getLower()
+                      : Range.getLower();
+    APInt End = Range.getUpper().slt(OtherRange.getUpper())
+                    ? Range.getUpper()
+                    : OtherRange.getUpper();
+    if (Start.slt(End))
+      Result.Ranges.push_back(ConstantRange(Start, End));
+
+    if (Range.getUpper().slt(OtherRange.getUpper()))
+      i++;
+    else
+      j++;
+  }
+  return Result;
+}
+
 void ConstantRangeList::print(raw_ostream &OS) const {
   interleaveComma(Ranges, OS, [&](ConstantRange CR) {
     OS << "(" << CR.getLower() << ", " << CR.getUpper() << ")";

--- a/llvm/unittests/IR/ConstantRangeListTest.cpp
+++ b/llvm/unittests/IR/ConstantRangeListTest.cpp
@@ -94,7 +94,7 @@ TEST_F(ConstantRangeListTest, Insert) {
   EXPECT_TRUE(CRL == Expected);
 }
 
-ConstantRangeList GetCRL(const SmallVector<std::pair<APInt, APInt>, 2> &Pairs) {
+ConstantRangeList GetCRL(ArrayRef<std::pair<APInt, APInt>> Pairs) {
   SmallVector<ConstantRange, 2> Ranges;
   for (auto &[Start, End] : Pairs)
     Ranges.push_back(ConstantRange(Start, End));
@@ -102,59 +102,58 @@ ConstantRangeList GetCRL(const SmallVector<std::pair<APInt, APInt>, 2> &Pairs) {
 }
 
 TEST_F(ConstantRangeListTest, Union) {
+  APInt APN4 = APInt(64, -4, /*isSigned=*/true);
+  APInt APN2 = APInt(64, -2, /*isSigned=*/true);
   APInt AP0 = APInt(64, 0, /*isSigned=*/true);
   APInt AP2 = APInt(64, 2, /*isSigned=*/true);
   APInt AP4 = APInt(64, 4, /*isSigned=*/true);
+  APInt AP6 = APInt(64, 6, /*isSigned=*/true);
+  APInt AP7 = APInt(64, 7, /*isSigned=*/true);
   APInt AP8 = APInt(64, 8, /*isSigned=*/true);
   APInt AP10 = APInt(64, 10, /*isSigned=*/true);
   APInt AP11 = APInt(64, 11, /*isSigned=*/true);
   APInt AP12 = APInt(64, 12, /*isSigned=*/true);
+  APInt AP16 = APInt(64, 16, /*isSigned=*/true);
+  APInt AP18 = APInt(64, 18, /*isSigned=*/true);
   ConstantRangeList CRL = GetCRL({{AP0, AP4}, {AP8, AP12}});
 
   // Union with a subset.
   ConstantRangeList Empty;
-  EXPECT_TRUE(CRL.unionWith(Empty) == CRL);
-  EXPECT_TRUE(Empty.unionWith(CRL) == CRL);
+  EXPECT_EQ(CRL.unionWith(Empty), CRL);
+  EXPECT_EQ(Empty.unionWith(CRL), CRL);
 
-  EXPECT_TRUE(CRL.unionWith(GetCRL({{AP0, AP2}})) == CRL);
-  EXPECT_TRUE(CRL.unionWith(GetCRL({{AP10, AP12}})) == CRL);
+  EXPECT_EQ(CRL.unionWith(GetCRL({{AP0, AP2}})), CRL);
+  EXPECT_EQ(CRL.unionWith(GetCRL({{AP10, AP12}})), CRL);
 
-  EXPECT_TRUE(CRL.unionWith(GetCRL({{AP0, AP2}, {AP8, AP10}})) == CRL);
-  EXPECT_TRUE(CRL.unionWith(GetCRL({{AP0, AP2}, {AP10, AP12}})) == CRL);
-  EXPECT_TRUE(CRL.unionWith(GetCRL({{AP2, AP4}, {AP8, AP10}})) == CRL);
-  EXPECT_TRUE(CRL.unionWith(GetCRL({{AP2, AP4}, {AP10, AP12}})) == CRL);
+  EXPECT_EQ(CRL.unionWith(GetCRL({{AP0, AP2}, {AP8, AP10}})), CRL);
+  EXPECT_EQ(CRL.unionWith(GetCRL({{AP0, AP2}, {AP10, AP12}})), CRL);
+  EXPECT_EQ(CRL.unionWith(GetCRL({{AP2, AP4}, {AP8, AP10}})), CRL);
+  EXPECT_EQ(CRL.unionWith(GetCRL({{AP2, AP4}, {AP10, AP12}})), CRL);
 
-  EXPECT_TRUE(CRL.unionWith(GetCRL({{AP0, AP4}, {AP8, AP10}, {AP11, AP12}})) ==
-              CRL);
+  EXPECT_EQ(CRL.unionWith(GetCRL({{AP0, AP4}, {AP8, AP10}, {AP11, AP12}})),
+            CRL);
 
-  EXPECT_TRUE(CRL.unionWith(CRL) == CRL);
+  EXPECT_EQ(CRL.unionWith(CRL), CRL);
 
   // Union with new ranges.
-  APInt APN4 = APInt(64, -4, /*isSigned=*/true);
-  APInt APN2 = APInt(64, -2, /*isSigned=*/true);
-  APInt AP6 = APInt(64, 6, /*isSigned=*/true);
-  APInt AP7 = APInt(64, 7, /*isSigned=*/true);
-  APInt AP16 = APInt(64, 16, /*isSigned=*/true);
-  APInt AP18 = APInt(64, 18, /*isSigned=*/true);
+  EXPECT_EQ(CRL.unionWith(GetCRL({{APN4, APN2}})),
+            GetCRL({{APN4, APN2}, {AP0, AP4}, {AP8, AP12}}));
+  EXPECT_EQ(CRL.unionWith(GetCRL({{AP6, AP7}})),
+            GetCRL({{AP0, AP4}, {AP6, AP7}, {AP8, AP12}}));
+  EXPECT_EQ(CRL.unionWith(GetCRL({{AP16, AP18}})),
+            GetCRL({{AP0, AP4}, {AP8, AP12}, {AP16, AP18}}));
 
-  EXPECT_TRUE(CRL.unionWith(GetCRL({{APN4, APN2}})) ==
-              GetCRL({{APN4, APN2}, {AP0, AP4}, {AP8, AP12}}));
-  EXPECT_TRUE(CRL.unionWith(GetCRL({{AP6, AP7}})) ==
-              GetCRL({{AP0, AP4}, {AP6, AP7}, {AP8, AP12}}));
-  EXPECT_TRUE(CRL.unionWith(GetCRL({{AP16, AP18}})) ==
-              GetCRL({{AP0, AP4}, {AP8, AP12}, {AP16, AP18}}));
+  EXPECT_EQ(CRL.unionWith(GetCRL({{APN2, AP2}})),
+            GetCRL({{APN2, AP4}, {AP8, AP12}}));
+  EXPECT_EQ(CRL.unionWith(GetCRL({{AP2, AP6}})),
+            GetCRL({{AP0, AP6}, {AP8, AP12}}));
+  EXPECT_EQ(CRL.unionWith(GetCRL({{AP10, AP16}})),
+            GetCRL({{AP0, AP4}, {AP8, AP16}}));
 
-  EXPECT_TRUE(CRL.unionWith(GetCRL({{APN2, AP2}})) ==
-              GetCRL({{APN2, AP4}, {AP8, AP12}}));
-  EXPECT_TRUE(CRL.unionWith(GetCRL({{AP2, AP6}})) ==
-              GetCRL({{AP0, AP6}, {AP8, AP12}}));
-  EXPECT_TRUE(CRL.unionWith(GetCRL({{AP10, AP16}})) ==
-              GetCRL({{AP0, AP4}, {AP8, AP16}}));
-
-  EXPECT_TRUE(CRL.unionWith(GetCRL({{APN2, AP10}})) == GetCRL({{APN2, AP12}}));
-  EXPECT_TRUE(CRL.unionWith(GetCRL({{AP2, AP10}})) == GetCRL({{AP0, AP12}}));
-  EXPECT_TRUE(CRL.unionWith(GetCRL({{AP4, AP16}})) == GetCRL({{AP0, AP16}}));
-  EXPECT_TRUE(CRL.unionWith(GetCRL({{APN2, AP16}})) == GetCRL({{APN2, AP16}}));
+  EXPECT_EQ(CRL.unionWith(GetCRL({{APN2, AP10}})), GetCRL({{APN2, AP12}}));
+  EXPECT_EQ(CRL.unionWith(GetCRL({{AP2, AP10}})), GetCRL({{AP0, AP12}}));
+  EXPECT_EQ(CRL.unionWith(GetCRL({{AP4, AP16}})), GetCRL({{AP0, AP16}}));
+  EXPECT_EQ(CRL.unionWith(GetCRL({{APN2, AP16}})), GetCRL({{APN2, AP16}}));
 }
 
 TEST_F(ConstantRangeListTest, Intersect) {
@@ -173,43 +172,39 @@ TEST_F(ConstantRangeListTest, Intersect) {
 
   // No intersection.
   ConstantRangeList Empty;
-  EXPECT_TRUE(CRL.intersectWith(Empty) == Empty);
-  EXPECT_TRUE(Empty.intersectWith(CRL) == Empty);
+  EXPECT_EQ(CRL.intersectWith(Empty), Empty);
+  EXPECT_EQ(Empty.intersectWith(CRL), Empty);
 
-  EXPECT_TRUE(CRL.intersectWith(GetCRL({{APN2, AP0}})) == Empty);
-  EXPECT_TRUE(CRL.intersectWith(GetCRL({{AP6, AP8}})) == Empty);
-  EXPECT_TRUE(CRL.intersectWith(GetCRL({{AP12, AP16}})) == Empty);
+  EXPECT_EQ(CRL.intersectWith(GetCRL({{APN2, AP0}})), Empty);
+  EXPECT_EQ(CRL.intersectWith(GetCRL({{AP6, AP8}})), Empty);
+  EXPECT_EQ(CRL.intersectWith(GetCRL({{AP12, AP16}})), Empty);
 
   // Single intersect range.
-  EXPECT_TRUE(CRL.intersectWith(GetCRL({{APN2, AP2}})) == GetCRL({{AP0, AP2}}));
-  EXPECT_TRUE(CRL.intersectWith(GetCRL({{APN2, AP6}})) == GetCRL({{AP0, AP4}}));
-  EXPECT_TRUE(CRL.intersectWith(GetCRL({{AP2, AP4}})) == GetCRL({{AP2, AP4}}));
-  EXPECT_TRUE(CRL.intersectWith(GetCRL({{AP2, AP6}})) == GetCRL({{AP2, AP4}}));
-  EXPECT_TRUE(CRL.intersectWith(GetCRL({{AP6, AP10}})) ==
-              GetCRL({{AP8, AP10}}));
-  EXPECT_TRUE(CRL.intersectWith(GetCRL({{AP6, AP16}})) ==
-              GetCRL({{AP8, AP12}}));
-  EXPECT_TRUE(CRL.intersectWith(GetCRL({{AP10, AP12}})) ==
-              GetCRL({{AP10, AP12}}));
-  EXPECT_TRUE(CRL.intersectWith(GetCRL({{AP10, AP16}})) ==
-              GetCRL({{AP10, AP12}}));
+  EXPECT_EQ(CRL.intersectWith(GetCRL({{APN2, AP2}})), GetCRL({{AP0, AP2}}));
+  EXPECT_EQ(CRL.intersectWith(GetCRL({{APN2, AP6}})), GetCRL({{AP0, AP4}}));
+  EXPECT_EQ(CRL.intersectWith(GetCRL({{AP2, AP4}})), GetCRL({{AP2, AP4}}));
+  EXPECT_EQ(CRL.intersectWith(GetCRL({{AP2, AP6}})), GetCRL({{AP2, AP4}}));
+  EXPECT_EQ(CRL.intersectWith(GetCRL({{AP6, AP10}})), GetCRL({{AP8, AP10}}));
+  EXPECT_EQ(CRL.intersectWith(GetCRL({{AP6, AP16}})), GetCRL({{AP8, AP12}}));
+  EXPECT_EQ(CRL.intersectWith(GetCRL({{AP10, AP12}})), GetCRL({{AP10, AP12}}));
+  EXPECT_EQ(CRL.intersectWith(GetCRL({{AP10, AP16}})), GetCRL({{AP10, AP12}}));
 
   // Multiple intersect ranges.
-  EXPECT_TRUE(CRL.intersectWith(GetCRL({{APN2, AP10}})) ==
-              GetCRL({{AP0, AP4}, {AP8, AP10}}));
-  EXPECT_TRUE(CRL.intersectWith(GetCRL({{APN2, AP16}})) == CRL);
-  EXPECT_TRUE(CRL.intersectWith(GetCRL({{AP2, AP10}})) ==
-              GetCRL({{AP2, AP4}, {AP8, AP10}}));
-  EXPECT_TRUE(CRL.intersectWith(GetCRL({{AP2, AP16}})) ==
-              GetCRL({{AP2, AP4}, {AP8, AP12}}));
-  EXPECT_TRUE(CRL.intersectWith(GetCRL({{{APN2, AP2}, {AP6, AP10}}})) ==
-              GetCRL({{AP0, AP2}, {AP8, AP10}}));
-  EXPECT_TRUE(CRL.intersectWith(GetCRL({{{AP2, AP6}, {AP10, AP16}}})) ==
-              GetCRL({{AP2, AP4}, {AP10, AP12}}));
-  EXPECT_TRUE(
-      CRL.intersectWith(GetCRL({{{APN2, AP2}, {AP7, AP10}, {AP11, AP16}}})) ==
+  EXPECT_EQ(CRL.intersectWith(GetCRL({{APN2, AP10}})),
+            GetCRL({{AP0, AP4}, {AP8, AP10}}));
+  EXPECT_EQ(CRL.intersectWith(GetCRL({{APN2, AP16}})), CRL);
+  EXPECT_EQ(CRL.intersectWith(GetCRL({{AP2, AP10}})),
+            GetCRL({{AP2, AP4}, {AP8, AP10}}));
+  EXPECT_EQ(CRL.intersectWith(GetCRL({{AP2, AP16}})),
+            GetCRL({{AP2, AP4}, {AP8, AP12}}));
+  EXPECT_EQ(CRL.intersectWith(GetCRL({{{APN2, AP2}, {AP6, AP10}}})),
+            GetCRL({{AP0, AP2}, {AP8, AP10}}));
+  EXPECT_EQ(CRL.intersectWith(GetCRL({{{AP2, AP6}, {AP10, AP16}}})),
+            GetCRL({{AP2, AP4}, {AP10, AP12}}));
+  EXPECT_EQ(
+      CRL.intersectWith(GetCRL({{{APN2, AP2}, {AP7, AP10}, {AP11, AP16}}})),
       GetCRL({{AP0, AP2}, {AP8, AP10}, {AP11, AP12}}));
-  EXPECT_TRUE(CRL.intersectWith(CRL) == CRL);
+  EXPECT_EQ(CRL.intersectWith(CRL), CRL);
 }
 
 } // anonymous namespace

--- a/llvm/unittests/IR/ConstantRangeListTest.cpp
+++ b/llvm/unittests/IR/ConstantRangeListTest.cpp
@@ -197,13 +197,12 @@ TEST_F(ConstantRangeListTest, Intersect) {
             GetCRL({{AP2, AP4}, {AP8, AP10}}));
   EXPECT_EQ(CRL.intersectWith(GetCRL({{AP2, AP16}})),
             GetCRL({{AP2, AP4}, {AP8, AP12}}));
-  EXPECT_EQ(CRL.intersectWith(GetCRL({{{APN2, AP2}, {AP6, AP10}}})),
+  EXPECT_EQ(CRL.intersectWith(GetCRL({{APN2, AP2}, {AP6, AP10}})),
             GetCRL({{AP0, AP2}, {AP8, AP10}}));
-  EXPECT_EQ(CRL.intersectWith(GetCRL({{{AP2, AP6}, {AP10, AP16}}})),
+  EXPECT_EQ(CRL.intersectWith(GetCRL({{AP2, AP6}, {AP10, AP16}})),
             GetCRL({{AP2, AP4}, {AP10, AP12}}));
-  EXPECT_EQ(
-      CRL.intersectWith(GetCRL({{{APN2, AP2}, {AP7, AP10}, {AP11, AP16}}})),
-      GetCRL({{AP0, AP2}, {AP8, AP10}, {AP11, AP12}}));
+  EXPECT_EQ(CRL.intersectWith(GetCRL({{APN2, AP2}, {AP7, AP10}, {AP11, AP16}})),
+            GetCRL({{AP0, AP2}, {AP8, AP10}, {AP11, AP12}}));
   EXPECT_EQ(CRL.intersectWith(CRL), CRL);
 }
 

--- a/llvm/unittests/IR/ConstantRangeListTest.cpp
+++ b/llvm/unittests/IR/ConstantRangeListTest.cpp
@@ -94,4 +94,122 @@ TEST_F(ConstantRangeListTest, Insert) {
   EXPECT_TRUE(CRL == Expected);
 }
 
+ConstantRangeList GetCRL(const SmallVector<std::pair<APInt, APInt>, 2> &Pairs) {
+  SmallVector<ConstantRange, 2> Ranges;
+  for (auto &[Start, End] : Pairs)
+    Ranges.push_back(ConstantRange(Start, End));
+  return ConstantRangeList(Ranges);
+}
+
+TEST_F(ConstantRangeListTest, Union) {
+  APInt AP0 = APInt(64, 0, /*isSigned=*/true);
+  APInt AP2 = APInt(64, 2, /*isSigned=*/true);
+  APInt AP4 = APInt(64, 4, /*isSigned=*/true);
+  APInt AP8 = APInt(64, 8, /*isSigned=*/true);
+  APInt AP10 = APInt(64, 10, /*isSigned=*/true);
+  APInt AP11 = APInt(64, 11, /*isSigned=*/true);
+  APInt AP12 = APInt(64, 12, /*isSigned=*/true);
+  ConstantRangeList CRL = GetCRL({{AP0, AP4}, {AP8, AP12}});
+
+  // Union with a subset.
+  ConstantRangeList Empty;
+  EXPECT_TRUE(CRL.unionWith(Empty) == CRL);
+  EXPECT_TRUE(Empty.unionWith(CRL) == CRL);
+
+  EXPECT_TRUE(CRL.unionWith(GetCRL({{AP0, AP2}})) == CRL);
+  EXPECT_TRUE(CRL.unionWith(GetCRL({{AP10, AP12}})) == CRL);
+
+  EXPECT_TRUE(CRL.unionWith(GetCRL({{AP0, AP2}, {AP8, AP10}})) == CRL);
+  EXPECT_TRUE(CRL.unionWith(GetCRL({{AP0, AP2}, {AP10, AP12}})) == CRL);
+  EXPECT_TRUE(CRL.unionWith(GetCRL({{AP2, AP4}, {AP8, AP10}})) == CRL);
+  EXPECT_TRUE(CRL.unionWith(GetCRL({{AP2, AP4}, {AP10, AP12}})) == CRL);
+
+  EXPECT_TRUE(CRL.unionWith(GetCRL({{AP0, AP4}, {AP8, AP10}, {AP11, AP12}})) ==
+              CRL);
+
+  EXPECT_TRUE(CRL.unionWith(CRL) == CRL);
+
+  // Union with new ranges.
+  APInt APN4 = APInt(64, -4, /*isSigned=*/true);
+  APInt APN2 = APInt(64, -2, /*isSigned=*/true);
+  APInt AP6 = APInt(64, 6, /*isSigned=*/true);
+  APInt AP7 = APInt(64, 7, /*isSigned=*/true);
+  APInt AP16 = APInt(64, 16, /*isSigned=*/true);
+  APInt AP18 = APInt(64, 18, /*isSigned=*/true);
+
+  EXPECT_TRUE(CRL.unionWith(GetCRL({{APN4, APN2}})) ==
+              GetCRL({{APN4, APN2}, {AP0, AP4}, {AP8, AP12}}));
+  EXPECT_TRUE(CRL.unionWith(GetCRL({{AP6, AP7}})) ==
+              GetCRL({{AP0, AP4}, {AP6, AP7}, {AP8, AP12}}));
+  EXPECT_TRUE(CRL.unionWith(GetCRL({{AP16, AP18}})) ==
+              GetCRL({{AP0, AP4}, {AP8, AP12}, {AP16, AP18}}));
+
+  EXPECT_TRUE(CRL.unionWith(GetCRL({{APN2, AP2}})) ==
+              GetCRL({{APN2, AP4}, {AP8, AP12}}));
+  EXPECT_TRUE(CRL.unionWith(GetCRL({{AP2, AP6}})) ==
+              GetCRL({{AP0, AP6}, {AP8, AP12}}));
+  EXPECT_TRUE(CRL.unionWith(GetCRL({{AP10, AP16}})) ==
+              GetCRL({{AP0, AP4}, {AP8, AP16}}));
+
+  EXPECT_TRUE(CRL.unionWith(GetCRL({{APN2, AP10}})) == GetCRL({{APN2, AP12}}));
+  EXPECT_TRUE(CRL.unionWith(GetCRL({{AP2, AP10}})) == GetCRL({{AP0, AP12}}));
+  EXPECT_TRUE(CRL.unionWith(GetCRL({{AP4, AP16}})) == GetCRL({{AP0, AP16}}));
+  EXPECT_TRUE(CRL.unionWith(GetCRL({{APN2, AP16}})) == GetCRL({{APN2, AP16}}));
+}
+
+TEST_F(ConstantRangeListTest, Intersect) {
+  APInt APN2 = APInt(64, -2, /*isSigned=*/true);
+  APInt AP0 = APInt(64, 0, /*isSigned=*/true);
+  APInt AP2 = APInt(64, 2, /*isSigned=*/true);
+  APInt AP4 = APInt(64, 4, /*isSigned=*/true);
+  APInt AP6 = APInt(64, 6, /*isSigned=*/true);
+  APInt AP7 = APInt(64, 7, /*isSigned=*/true);
+  APInt AP8 = APInt(64, 8, /*isSigned=*/true);
+  APInt AP10 = APInt(64, 10, /*isSigned=*/true);
+  APInt AP11 = APInt(64, 11, /*isSigned=*/true);
+  APInt AP12 = APInt(64, 12, /*isSigned=*/true);
+  APInt AP16 = APInt(64, 16, /*isSigned=*/true);
+  ConstantRangeList CRL = GetCRL({{AP0, AP4}, {AP8, AP12}});
+
+  // No intersection.
+  ConstantRangeList Empty;
+  EXPECT_TRUE(CRL.intersectWith(Empty) == Empty);
+  EXPECT_TRUE(Empty.intersectWith(CRL) == Empty);
+
+  EXPECT_TRUE(CRL.intersectWith(GetCRL({{APN2, AP0}})) == Empty);
+  EXPECT_TRUE(CRL.intersectWith(GetCRL({{AP6, AP8}})) == Empty);
+  EXPECT_TRUE(CRL.intersectWith(GetCRL({{AP12, AP16}})) == Empty);
+
+  // Single intersect range.
+  EXPECT_TRUE(CRL.intersectWith(GetCRL({{APN2, AP2}})) == GetCRL({{AP0, AP2}}));
+  EXPECT_TRUE(CRL.intersectWith(GetCRL({{APN2, AP6}})) == GetCRL({{AP0, AP4}}));
+  EXPECT_TRUE(CRL.intersectWith(GetCRL({{AP2, AP4}})) == GetCRL({{AP2, AP4}}));
+  EXPECT_TRUE(CRL.intersectWith(GetCRL({{AP2, AP6}})) == GetCRL({{AP2, AP4}}));
+  EXPECT_TRUE(CRL.intersectWith(GetCRL({{AP6, AP10}})) ==
+              GetCRL({{AP8, AP10}}));
+  EXPECT_TRUE(CRL.intersectWith(GetCRL({{AP6, AP16}})) ==
+              GetCRL({{AP8, AP12}}));
+  EXPECT_TRUE(CRL.intersectWith(GetCRL({{AP10, AP12}})) ==
+              GetCRL({{AP10, AP12}}));
+  EXPECT_TRUE(CRL.intersectWith(GetCRL({{AP10, AP16}})) ==
+              GetCRL({{AP10, AP12}}));
+
+  // Multiple intersect ranges.
+  EXPECT_TRUE(CRL.intersectWith(GetCRL({{APN2, AP10}})) ==
+              GetCRL({{AP0, AP4}, {AP8, AP10}}));
+  EXPECT_TRUE(CRL.intersectWith(GetCRL({{APN2, AP16}})) == CRL);
+  EXPECT_TRUE(CRL.intersectWith(GetCRL({{AP2, AP10}})) ==
+              GetCRL({{AP2, AP4}, {AP8, AP10}}));
+  EXPECT_TRUE(CRL.intersectWith(GetCRL({{AP2, AP16}})) ==
+              GetCRL({{AP2, AP4}, {AP8, AP12}}));
+  EXPECT_TRUE(CRL.intersectWith(GetCRL({{{APN2, AP2}, {AP6, AP10}}})) ==
+              GetCRL({{AP0, AP2}, {AP8, AP10}}));
+  EXPECT_TRUE(CRL.intersectWith(GetCRL({{{AP2, AP6}, {AP10, AP16}}})) ==
+              GetCRL({{AP2, AP4}, {AP10, AP12}}));
+  EXPECT_TRUE(
+      CRL.intersectWith(GetCRL({{{APN2, AP2}, {AP7, AP10}, {AP11, AP16}}})) ==
+      GetCRL({{AP0, AP2}, {AP8, AP10}, {AP11, AP12}}));
+  EXPECT_TRUE(CRL.intersectWith(CRL) == CRL);
+}
+
 } // anonymous namespace


### PR DESCRIPTION
Add ConstantRangeList::unionWith() and ::intersectWith().

These methods will be used in the "initializes" attribute inference.
https://github.com/llvm/llvm-project/commit/df11106068294fb00f11988d3f48336e2cbed364