### PR TITLE
[polly] Add profitability check for expanded region.

### DIFF
--- a/polly/include/polly/ScopDetection.h
+++ b/polly/include/polly/ScopDetection.h
@@ -347,11 +347,13 @@ private:
 
   /// Check if an expanded region is profitable to optimize.
   ///
-  /// An expanded region may include basic blocks with memory accesses that
-  /// are not used in loops of the expanded region. These memory accesses add
-  /// complexity for building scop, compute optimization schedule and build
-  /// runtime alias checks. Such expansion is not profitable and should not
-  /// replace original unexpanded region.
+  /// An expanded region may add basic blocks that do not belong to any loop of
+  /// the expanded region. These blocks may contain unrelated memory accesses
+  /// that add complexity for building scop, compute optimization schedule and
+  /// build runtime alias checks. However if there are loops added due to region
+  /// expansion following these unprofitable blocks, we still want the expanded
+  /// region to encourage loop fusion. Otherwise such expansion is not
+  /// profitable and should not replace original unexpanded region.
   ///
   /// @param ExpandedRegion The expanded region to check.
   ///

--- a/polly/include/polly/ScopDetection.h
+++ b/polly/include/polly/ScopDetection.h
@@ -345,6 +345,20 @@ private:
   /// @return True if region is profitable to optimize, false otherwise.
   bool isProfitableRegion(DetectionContext &Context) const;
 
+  /// Check if an expanded region is profitable to optimize.
+  ///
+  /// An expanded region may include basic blocks with memory accesses that
+  /// are not used in loops of the expanded region. These memory accesses add
+  /// complexity for building scop, compute optimization schedule and build
+  /// runtime alias checks. Such expansion is not profitable and should not
+  /// replace original unexpanded region.
+  ///
+  /// @param ExpandedRegion The expanded region to check.
+  ///
+  /// @return True if the expanded region is profitable to optimize.
+  bool isRegionExpansionProfitable(const Region &ExpandedRegion,
+                                   LoopInfo &LI) const;
+
   /// Check if a region is a Scop.
   ///
   /// @param Context The context of scop detection.

--- a/polly/test/CodeGen/empty_domain_in_context.ll
+++ b/polly/test/CodeGen/empty_domain_in_context.ll
@@ -1,4 +1,5 @@
-; RUN: opt %loadNPMPolly '-passes=polly-optree,polly-opt-isl,polly-codegen' -S < %s | FileCheck %s
+; RUN: opt %loadNPMPolly '-passes=polly-optree,polly-opt-isl,polly-codegen' \
+; RUN: -polly-region-expansion-profitability-check=0 -S < %s | FileCheck %s
 ;
 ; llvm.org/PR35362
 ; isl codegen does not allow to generate isl_ast_expr from pw_aff which have an

--- a/polly/test/CodeGen/invariant_loads_ignore_parameter_bounds.ll
+++ b/polly/test/CodeGen/invariant_loads_ignore_parameter_bounds.ll
@@ -1,5 +1,6 @@
 ; RUN: opt %loadNPMPolly -passes=polly-codegen -polly-invariant-load-hoisting \
-; RUN:     -polly-ignore-parameter-bounds -S < %s | FileCheck %s
+; RUN: -polly-ignore-parameter-bounds -polly-region-expansion-profitability-check=0 \
+; RUN: -S < %s | FileCheck %s
 
 ; CHECK: polly.preload.begin:
 ; CHECK-NEXT: %global.load = load i32, ptr @global, align 4, !alias.scope !0, !noalias !3

--- a/polly/test/CodeGen/multiple-scops-in-a-row.ll
+++ b/polly/test/CodeGen/multiple-scops-in-a-row.ll
@@ -1,4 +1,5 @@
-; RUN: opt %loadNPMPolly -S -passes=polly-codegen < %s | FileCheck %s
+; RUN: opt %loadNPMPolly -S -passes=polly-codegen \
+; RUN: -polly-region-expansion-profitability-check=0 < %s | FileCheck %s
 
 ; This test case has two scops in a row. When code generating the first scop,
 ; the second scop is invalidated. This test case verifies that we do not crash

--- a/polly/test/CodeGen/reduction_2.ll
+++ b/polly/test/CodeGen/reduction_2.ll
@@ -1,4 +1,6 @@
-; RUN: opt %loadNPMPolly -aa-pipeline=basic-aa -polly-invariant-load-hoisting=true '-passes=print<polly-ast>' -disable-output < %s | FileCheck %s --allow-empty
+; RUN: opt %loadNPMPolly -aa-pipeline=basic-aa -polly-invariant-load-hoisting=true \
+; RUN: -polly-region-expansion-profitability-check=0 '-passes=print<polly-ast>' \
+; RUN: -disable-output < %s | FileCheck %s --allow-empty
 
 ;#include <string.h>
 ;#include <stdio.h>

--- a/polly/test/CodeGen/region_expansion_profitability_check.ll
+++ b/polly/test/CodeGen/region_expansion_profitability_check.ll
@@ -1,138 +1,68 @@
-; RUN: opt -polly-use-llvm-names -polly-region-expansion-profitability-check=1 \
+; RUN: opt %loadNPMPolly -polly-region-expansion-profitability-check=1 \
 ; RUN: "-passes=scop(polly-opt-isl,print<polly-ast>)" -disable-output < %s | \
 ; RUN: FileCheck %s --check-prefix=HEURISTIC
-; RUN: opt -polly-region-expansion-profitability-check=0 -passes=polly-codegen \
-; RUN: -pass-remarks-analysis="polly-scops" -disable-output < %s 2>&1 | \
-; RUN: FileCheck %s --check-prefix=NO_HEURISTIC
+; RUN: opt %loadNPMPolly -polly-region-expansion-profitability-check=0 \
+; RUN: -passes=polly-codegen -pass-remarks-analysis="polly-scops" \
+; RUN: -disable-output < %s 2>&1 | FileCheck %s --check-prefix=NO_HEURISTIC
 
-; void test(int **restrict a, int *restrict b, int *restrict c,
-;           int *restrict d, int *restrict e, int *restrict f,
-;	    int L, int M, int Val0) {
-;   for (int i = 1; i <= L; i++) { // L1
-;     for (int k = 1; k <= M; k++) { // L2: vectorizable loop.
-;       b[k] += e[k-1];
-;       if (k < M)
-;         c[k] += d[k];
-;     }
-;     // Memory accesses to a[i-1],a[i] are not used in L2.
-;     if ((Val0 = a[i-1][4]) > -987654321)
-;      a[i][4] = Val0;
-;   }
+; void test(int **restrict a, int *restrict b, int *restrict c, int M) {
+;   for (int k = 0; k < M; k++) // Vectorizable loop.
+;     b[k] += c[k];
+;
+;   // Non-loop blocks.
+;   // Load of a[0] is not relevant to vectorizable loop.
+;   if (a[0][4])
+;     a[0][4] = 0;
 ; }
-
 
 target datalayout = "e-m:e-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128-Fn32"
 
-define dso_local void @test(ptr noalias nocapture noundef readonly %a, ptr noalias nocapture noundef %b, ptr noalias nocapture noundef %c, ptr noalias nocapture noundef readonly %d, ptr noalias nocapture noundef readonly %e, ptr noalias nocapture noundef readnone %f, i32 noundef %L, i32 noundef %M, i32 noundef %Val0) {
+define void @test(ptr noalias nocapture noundef readonly %a, ptr noalias nocapture noundef %b, ptr noalias nocapture noundef readonly %c, i32 noundef %M) {
 entry:
-  %cmp.not39 = icmp slt i32 %L, 1
-  br i1 %cmp.not39, label %for.cond.cleanup, label %for.cond1.preheader.lr.ph
+  br label %entry.split
 
-for.cond1.preheader.lr.ph:                        ; preds = %entry
-  %invariant.gep = getelementptr i8, ptr %e, i64 -4
-  %cmp2.not37 = icmp slt i32 %M, 1
-  br i1 %cmp2.not37, label %for.cond1.preheader.us.preheader, label %for.cond1.preheader.preheader
+entry.split:                                      ; preds = %entry
+  %cmp11 = icmp sgt i32 %M, 0
+  br i1 %cmp11, label %for.body.preheader, label %for.cond.cleanup
 
-for.cond1.preheader.preheader:                    ; preds = %for.cond1.preheader.lr.ph
-  %0 = zext nneg i32 %M to i64
-  %1 = add nuw i32 %M, 1
-  %2 = add nuw i32 %L, 1
-  %wide.trip.count46 = zext i32 %2 to i64
-  %wide.trip.count = zext i32 %1 to i64
-  br label %for.cond1.preheader
+for.body.preheader:                               ; preds = %entry.split
+  %wide.trip.count = zext nneg i32 %M to i64
+  br label %for.body
 
-for.cond1.preheader.us.preheader:                 ; preds = %for.cond1.preheader.lr.ph
-  %3 = add nuw i32 %L, 1
-  %wide.trip.count51 = zext i32 %3 to i64
-  br label %for.cond1.preheader.us
-
-for.cond1.preheader.us:                           ; preds = %for.cond1.preheader.us.preheader, %for.inc23.us
-  %indvars.iv48 = phi i64 [ 1, %for.cond1.preheader.us.preheader ], [ %indvars.iv.next49, %for.inc23.us ]
-  %4 = getelementptr ptr, ptr %a, i64 %indvars.iv48
-  %arrayidx15.us = getelementptr i8, ptr %4, i64 -8
-  %5 = load ptr, ptr %arrayidx15.us, align 8
-  %arrayidx16.us = getelementptr inbounds i8, ptr %5, i64 16
-  %6 = load i32, ptr %arrayidx16.us, align 4
-  %cmp17.us = icmp sgt i32 %6, -987654321
-  br i1 %cmp17.us, label %if.then18.us, label %for.inc23.us
-
-if.then18.us:                                     ; preds = %for.cond1.preheader.us
-  %7 = load ptr, ptr %4, align 8
-  %arrayidx21.us = getelementptr inbounds i8, ptr %7, i64 16
-  store i32 %6, ptr %arrayidx21.us, align 4
-  br label %for.inc23.us
-
-for.inc23.us:                                     ; preds = %if.then18.us, %for.cond1.preheader.us
-  %indvars.iv.next49 = add nuw nsw i64 %indvars.iv48, 1
-  %exitcond52.not = icmp eq i64 %indvars.iv.next49, %wide.trip.count51
-  br i1 %exitcond52.not, label %for.cond.cleanup, label %for.cond1.preheader.us
-
-for.cond1.preheader:                              ; preds = %for.cond1.preheader.preheader, %for.inc23
-  %indvars.iv43 = phi i64 [ 1, %for.cond1.preheader.preheader ], [ %indvars.iv.next44, %for.inc23 ]
-  br label %for.body4
-
-for.cond.cleanup:                                 ; preds = %for.inc23, %for.inc23.us, %entry
-  ret void
-
-for.cond1.for.cond.cleanup3_crit_edge:            ; preds = %for.inc
-  %8 = getelementptr ptr, ptr %a, i64 %indvars.iv43
-  %arrayidx15 = getelementptr i8, ptr %8, i64 -8
-  %9 = load ptr, ptr %arrayidx15, align 8
-  %arrayidx16 = getelementptr inbounds i8, ptr %9, i64 16
-  %10 = load i32, ptr %arrayidx16, align 4
-  %cmp17 = icmp sgt i32 %10, -987654321
-  br i1 %cmp17, label %if.then18, label %for.inc23
-
-for.body4:                                        ; preds = %for.cond1.preheader, %for.inc
-  %indvars.iv = phi i64 [ 1, %for.cond1.preheader ], [ %indvars.iv.next, %for.inc ]
-  %gep = getelementptr i32, ptr %invariant.gep, i64 %indvars.iv
-  %11 = load i32, ptr %gep, align 4
-  %arrayidx6 = getelementptr inbounds i32, ptr %b, i64 %indvars.iv
-  %12 = load i32, ptr %arrayidx6, align 4
-  %add = add nsw i32 %12, %11
-  store i32 %add, ptr %arrayidx6, align 4
-  %cmp7 = icmp ult i64 %indvars.iv, %0
-  br i1 %cmp7, label %if.then, label %for.inc
-
-if.then:                                          ; preds = %for.body4
-  %arrayidx9 = getelementptr inbounds i32, ptr %d, i64 %indvars.iv
-  %13 = load i32, ptr %arrayidx9, align 4
-  %arrayidx11 = getelementptr inbounds i32, ptr %c, i64 %indvars.iv
-  %14 = load i32, ptr %arrayidx11, align 4
-  %add12 = add nsw i32 %14, %13
-  store i32 %add12, ptr %arrayidx11, align 4
-  br label %for.inc
-
-for.inc:                                          ; preds = %for.body4, %if.then
+for.body:                                         ; preds = %for.body.preheader, %for.body
+  %indvars.iv = phi i64 [ 0, %for.body.preheader ], [ %indvars.iv.next, %for.body ]
+  %arrayidx = getelementptr inbounds i32, ptr %c, i64 %indvars.iv
+  %i1 = load i32, ptr %arrayidx, align 4
+  %arrayidx2 = getelementptr inbounds i32, ptr %b, i64 %indvars.iv
+  %i2 = load i32, ptr %arrayidx2, align 4
+  %add = add nsw i32 %i2, %i1
+  store i32 %add, ptr %arrayidx2, align 4
   %indvars.iv.next = add nuw nsw i64 %indvars.iv, 1
   %exitcond.not = icmp eq i64 %indvars.iv.next, %wide.trip.count
-  br i1 %exitcond.not, label %for.cond1.for.cond.cleanup3_crit_edge, label %for.body4
+  br i1 %exitcond.not, label %for.cond.cleanup, label %for.body
 
-if.then18:                                        ; preds = %for.cond1.for.cond.cleanup3_crit_edge
-  %15 = load ptr, ptr %8, align 8
-  %arrayidx21 = getelementptr inbounds i8, ptr %15, i64 16
-  store i32 %10, ptr %arrayidx21, align 4
-  br label %for.inc23
+for.cond.cleanup:                                 ; preds = %for.body, %entry.split
+  %i3 = load ptr, ptr %a, align 8
+  %arrayidx4 = getelementptr inbounds i8, ptr %i3, i64 16
+  %i4 = load i32, ptr %arrayidx4, align 4
+  %tobool.not = icmp eq i32 %i4, 0
+  br i1 %tobool.not, label %if.end, label %if.then
 
-for.inc23:                                        ; preds = %for.cond1.for.cond.cleanup3_crit_edge, %if.then18
-  %indvars.iv.next44 = add nuw nsw i64 %indvars.iv43, 1
-  %exitcond47.not = icmp eq i64 %indvars.iv.next44, %wide.trip.count46
-  br i1 %exitcond47.not, label %for.cond.cleanup, label %for.cond1.preheader
+if.then:                                          ; preds = %for.cond.cleanup
+  store i32 0, ptr %arrayidx4, align 4
+  br label %if.end
+
+if.end:                                           ; preds = %if.then, %for.cond.cleanup
+  ret void
 }
 
-; Check that region %for.body4---%for.cond1.for.cond.cleanup3_crit_edge is
-; detected with region expansion profitability check.
-; HEURISTIC-LABLE: isl ast :: test :: %for.body4---%for.cond1.for.cond.cleanup3_crit_edge
+; Check that region %entry.split---%for.cond.cleanup without trailing blocks
+; %for.cond.cleanup---%if.end is detected with region expansion profitability check.
+; HEURISTIC-LABLE: isl ast :: test :: %entry.split---%for.cond.cleanup
 ; HEURISTIC:      for (int c0 = 0; c0 < M; c0 += 1)
-; HEURISTIC-NEXT:	Stmt_for_body4(c0);
-; HEURISTIC-NEXT: for (int c0 = 0; c0 < M - 1; c0 += 1)
-; HEURISTIC-NEXT:	Stmt_if_then(c0);
+; HEURISTIC-NEXT:	Stmt_for_body(c0);
 
 ; Check that without region expansion heuristic, vectorization is missed.
 ; NO_HEURISTIC: SCoP begins here.
-; NO_HEURISTIC-NEXT: No-overflows restriction:        [p_0, p_1] -> {  : p_0 = 2147483647 }
-; NO_HEURISTIC-NEXT: No-overflows restriction:        [p_0, p_1] -> {  : p_0 = 2147483647 }
-; NO_HEURISTIC-NEXT: Possibly aliasing pointer, use restrict keyword.
-; NO_HEURISTIC-NEXT: Possibly aliasing pointer, use restrict keyword.
-; NO_HEURISTIC-NEXT: Invariant load assumption:  [p_0, p_1] -> {  : false }
-; NO_HEURISTIC-NEXT : SCoP ends here but was dismissed.
+; NO_HEURISTIC-NEXT: Invariant load assumption:       [M] -> {  : false }
+; NO_HEURISTIC-NEXT: SCoP ends here but was dismissed.

--- a/polly/test/CodeGen/region_expansion_profitability_check.ll
+++ b/polly/test/CodeGen/region_expansion_profitability_check.ll
@@ -1,0 +1,138 @@
+; RUN: opt -polly-use-llvm-names -polly-region-expansion-profitability-check=1 \
+; RUN: "-passes=scop(polly-opt-isl,print<polly-ast>)" -disable-output < %s | \
+; RUN: FileCheck %s --check-prefix=HEURISTIC
+; RUN: opt -polly-region-expansion-profitability-check=0 -passes=polly-codegen \
+; RUN: -pass-remarks-analysis="polly-scops" -disable-output < %s 2>&1 | \
+; RUN: FileCheck %s --check-prefix=NO_HEURISTIC
+
+; void test(int **restrict a, int *restrict b, int *restrict c,
+;           int *restrict d, int *restrict e, int *restrict f,
+;	    int L, int M, int Val0) {
+;   for (int i = 1; i <= L; i++) { // L1
+;     for (int k = 1; k <= M; k++) { // L2: vectorizable loop.
+;       b[k] += e[k-1];
+;       if (k < M)
+;         c[k] += d[k];
+;     }
+;     // Memory accesses to a[i-1],a[i] are not used in L2.
+;     if ((Val0 = a[i-1][4]) > -987654321)
+;      a[i][4] = Val0;
+;   }
+; }
+
+
+target datalayout = "e-m:e-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128-Fn32"
+
+define dso_local void @test(ptr noalias nocapture noundef readonly %a, ptr noalias nocapture noundef %b, ptr noalias nocapture noundef %c, ptr noalias nocapture noundef readonly %d, ptr noalias nocapture noundef readonly %e, ptr noalias nocapture noundef readnone %f, i32 noundef %L, i32 noundef %M, i32 noundef %Val0) {
+entry:
+  %cmp.not39 = icmp slt i32 %L, 1
+  br i1 %cmp.not39, label %for.cond.cleanup, label %for.cond1.preheader.lr.ph
+
+for.cond1.preheader.lr.ph:                        ; preds = %entry
+  %invariant.gep = getelementptr i8, ptr %e, i64 -4
+  %cmp2.not37 = icmp slt i32 %M, 1
+  br i1 %cmp2.not37, label %for.cond1.preheader.us.preheader, label %for.cond1.preheader.preheader
+
+for.cond1.preheader.preheader:                    ; preds = %for.cond1.preheader.lr.ph
+  %0 = zext nneg i32 %M to i64
+  %1 = add nuw i32 %M, 1
+  %2 = add nuw i32 %L, 1
+  %wide.trip.count46 = zext i32 %2 to i64
+  %wide.trip.count = zext i32 %1 to i64
+  br label %for.cond1.preheader
+
+for.cond1.preheader.us.preheader:                 ; preds = %for.cond1.preheader.lr.ph
+  %3 = add nuw i32 %L, 1
+  %wide.trip.count51 = zext i32 %3 to i64
+  br label %for.cond1.preheader.us
+
+for.cond1.preheader.us:                           ; preds = %for.cond1.preheader.us.preheader, %for.inc23.us
+  %indvars.iv48 = phi i64 [ 1, %for.cond1.preheader.us.preheader ], [ %indvars.iv.next49, %for.inc23.us ]
+  %4 = getelementptr ptr, ptr %a, i64 %indvars.iv48
+  %arrayidx15.us = getelementptr i8, ptr %4, i64 -8
+  %5 = load ptr, ptr %arrayidx15.us, align 8
+  %arrayidx16.us = getelementptr inbounds i8, ptr %5, i64 16
+  %6 = load i32, ptr %arrayidx16.us, align 4
+  %cmp17.us = icmp sgt i32 %6, -987654321
+  br i1 %cmp17.us, label %if.then18.us, label %for.inc23.us
+
+if.then18.us:                                     ; preds = %for.cond1.preheader.us
+  %7 = load ptr, ptr %4, align 8
+  %arrayidx21.us = getelementptr inbounds i8, ptr %7, i64 16
+  store i32 %6, ptr %arrayidx21.us, align 4
+  br label %for.inc23.us
+
+for.inc23.us:                                     ; preds = %if.then18.us, %for.cond1.preheader.us
+  %indvars.iv.next49 = add nuw nsw i64 %indvars.iv48, 1
+  %exitcond52.not = icmp eq i64 %indvars.iv.next49, %wide.trip.count51
+  br i1 %exitcond52.not, label %for.cond.cleanup, label %for.cond1.preheader.us
+
+for.cond1.preheader:                              ; preds = %for.cond1.preheader.preheader, %for.inc23
+  %indvars.iv43 = phi i64 [ 1, %for.cond1.preheader.preheader ], [ %indvars.iv.next44, %for.inc23 ]
+  br label %for.body4
+
+for.cond.cleanup:                                 ; preds = %for.inc23, %for.inc23.us, %entry
+  ret void
+
+for.cond1.for.cond.cleanup3_crit_edge:            ; preds = %for.inc
+  %8 = getelementptr ptr, ptr %a, i64 %indvars.iv43
+  %arrayidx15 = getelementptr i8, ptr %8, i64 -8
+  %9 = load ptr, ptr %arrayidx15, align 8
+  %arrayidx16 = getelementptr inbounds i8, ptr %9, i64 16
+  %10 = load i32, ptr %arrayidx16, align 4
+  %cmp17 = icmp sgt i32 %10, -987654321
+  br i1 %cmp17, label %if.then18, label %for.inc23
+
+for.body4:                                        ; preds = %for.cond1.preheader, %for.inc
+  %indvars.iv = phi i64 [ 1, %for.cond1.preheader ], [ %indvars.iv.next, %for.inc ]
+  %gep = getelementptr i32, ptr %invariant.gep, i64 %indvars.iv
+  %11 = load i32, ptr %gep, align 4
+  %arrayidx6 = getelementptr inbounds i32, ptr %b, i64 %indvars.iv
+  %12 = load i32, ptr %arrayidx6, align 4
+  %add = add nsw i32 %12, %11
+  store i32 %add, ptr %arrayidx6, align 4
+  %cmp7 = icmp ult i64 %indvars.iv, %0
+  br i1 %cmp7, label %if.then, label %for.inc
+
+if.then:                                          ; preds = %for.body4
+  %arrayidx9 = getelementptr inbounds i32, ptr %d, i64 %indvars.iv
+  %13 = load i32, ptr %arrayidx9, align 4
+  %arrayidx11 = getelementptr inbounds i32, ptr %c, i64 %indvars.iv
+  %14 = load i32, ptr %arrayidx11, align 4
+  %add12 = add nsw i32 %14, %13
+  store i32 %add12, ptr %arrayidx11, align 4
+  br label %for.inc
+
+for.inc:                                          ; preds = %for.body4, %if.then
+  %indvars.iv.next = add nuw nsw i64 %indvars.iv, 1
+  %exitcond.not = icmp eq i64 %indvars.iv.next, %wide.trip.count
+  br i1 %exitcond.not, label %for.cond1.for.cond.cleanup3_crit_edge, label %for.body4
+
+if.then18:                                        ; preds = %for.cond1.for.cond.cleanup3_crit_edge
+  %15 = load ptr, ptr %8, align 8
+  %arrayidx21 = getelementptr inbounds i8, ptr %15, i64 16
+  store i32 %10, ptr %arrayidx21, align 4
+  br label %for.inc23
+
+for.inc23:                                        ; preds = %for.cond1.for.cond.cleanup3_crit_edge, %if.then18
+  %indvars.iv.next44 = add nuw nsw i64 %indvars.iv43, 1
+  %exitcond47.not = icmp eq i64 %indvars.iv.next44, %wide.trip.count46
+  br i1 %exitcond47.not, label %for.cond.cleanup, label %for.cond1.preheader
+}
+
+; Check that region %for.body4---%for.cond1.for.cond.cleanup3_crit_edge is
+; detected with region expansion profitability check.
+; HEURISTIC-LABLE: isl ast :: test :: %for.body4---%for.cond1.for.cond.cleanup3_crit_edge
+; HEURISTIC:      for (int c0 = 0; c0 < M; c0 += 1)
+; HEURISTIC-NEXT:	Stmt_for_body4(c0);
+; HEURISTIC-NEXT: for (int c0 = 0; c0 < M - 1; c0 += 1)
+; HEURISTIC-NEXT:	Stmt_if_then(c0);
+
+; Check that without region expansion heuristic, vectorization is missed.
+; NO_HEURISTIC: SCoP begins here.
+; NO_HEURISTIC-NEXT: No-overflows restriction:        [p_0, p_1] -> {  : p_0 = 2147483647 }
+; NO_HEURISTIC-NEXT: No-overflows restriction:        [p_0, p_1] -> {  : p_0 = 2147483647 }
+; NO_HEURISTIC-NEXT: Possibly aliasing pointer, use restrict keyword.
+; NO_HEURISTIC-NEXT: Possibly aliasing pointer, use restrict keyword.
+; NO_HEURISTIC-NEXT: Invariant load assumption:  [p_0, p_1] -> {  : false }
+; NO_HEURISTIC-NEXT : SCoP ends here but was dismissed.

--- a/polly/test/CodeGen/region_expansion_profitability_check_loopfusion_1.ll
+++ b/polly/test/CodeGen/region_expansion_profitability_check_loopfusion_1.ll
@@ -1,0 +1,56 @@
+; RUN: opt -polly-use-llvm-names -polly-region-expansion-profitability-check=1 \
+; RUN: -polly-loopfusion-greedy=1 "-passes=scop(polly-opt-isl,print<polly-ast>)" \
+; RUN: -disable-output < %s | FileCheck %s
+
+; void foo(int *restrict A, int *restrict B, int *restrict C, int n, int *restrict U) {
+;   for (int i = 0; i < 1024; ++i) // L1
+;     B[i] += A[i];
+;   for (int j = 0; j < 1024; ++j) // L2
+;     C[j] = B[j] + *U;
+; }
+
+define void @foo(ptr noalias nocapture noundef readonly %A, ptr noalias nocapture noundef %B, ptr noalias nocapture noundef writeonly %C, i32 noundef %n, ptr noalias nocapture noundef readonly %U) {
+entry:
+  br label %entry.split
+
+entry.split:                                      ; preds = %entry
+  br label %for.body
+
+for.cond3.preheader:                              ; preds = %for.body
+  %0 = load i32, ptr %U, align 4
+  br label %for.body6
+
+for.body:                                         ; preds = %entry.split, %for.body
+  %indvars.iv = phi i64 [ 0, %entry.split ], [ %indvars.iv.next, %for.body ]
+  %arrayidx = getelementptr inbounds i32, ptr %A, i64 %indvars.iv
+  %1 = load i32, ptr %arrayidx, align 4
+  %arrayidx2 = getelementptr inbounds i32, ptr %B, i64 %indvars.iv
+  %2 = load i32, ptr %arrayidx2, align 4
+  %add = add nsw i32 %2, %1
+  store i32 %add, ptr %arrayidx2, align 4
+  %indvars.iv.next = add nuw nsw i64 %indvars.iv, 1
+  %exitcond.not = icmp eq i64 %indvars.iv.next, 1024
+  br i1 %exitcond.not, label %for.cond3.preheader, label %for.body
+
+for.cond.cleanup5:                                ; preds = %for.body6
+  ret void
+
+for.body6:                                        ; preds = %for.cond3.preheader, %for.body6
+  %indvars.iv25 = phi i64 [ 0, %for.cond3.preheader ], [ %indvars.iv.next26, %for.body6 ]
+  %arrayidx8 = getelementptr inbounds i32, ptr %B, i64 %indvars.iv25
+  %3 = load i32, ptr %arrayidx8, align 4
+  %add9 = add nsw i32 %0, %3
+  %arrayidx11 = getelementptr inbounds i32, ptr %C, i64 %indvars.iv25
+  store i32 %add9, ptr %arrayidx11, align 4
+  %indvars.iv.next26 = add nuw nsw i64 %indvars.iv25, 1
+  %exitcond28.not = icmp eq i64 %indvars.iv.next26, 1024
+  br i1 %exitcond28.not, label %for.cond.cleanup5, label %for.body6
+}
+
+; Check that loop preheader block that containing loop invariant load *U is
+; handled properly by region expansion profitability check, L1 and L2 are fused.
+; CHECK-LABEL: isl ast :: foo :: %for.body---%for.cond.cleanup5
+; CHECK:           Stmt_for_cond3_preheader();
+; CHECK-NEXT:      for (int c0 = 0; c0 <= 1023; c0 += 1) {
+; CHECK-NEXT:        Stmt_for_body(c0);
+; CHECK-NEXT:        Stmt_for_body6(c0);

--- a/polly/test/CodeGen/region_expansion_profitability_check_loopfusion_1.ll
+++ b/polly/test/CodeGen/region_expansion_profitability_check_loopfusion_1.ll
@@ -1,12 +1,13 @@
-; RUN: opt -polly-use-llvm-names -polly-region-expansion-profitability-check=1 \
+; RUN: opt %loadNPMPolly -polly-region-expansion-profitability-check=1 \
 ; RUN: -polly-loopfusion-greedy=1 "-passes=scop(polly-opt-isl,print<polly-ast>)" \
 ; RUN: -disable-output < %s | FileCheck %s
 
 ; void foo(int *restrict A, int *restrict B, int *restrict C, int n, int *restrict U) {
 ;   for (int i = 0; i < 1024; ++i) // L1
 ;     B[i] += A[i];
+;   int u = *U; // LICM
 ;   for (int j = 0; j < 1024; ++j) // L2
-;     C[j] = B[j] + *U;
+;     C[j] = B[j] + u;
 ; }
 
 define void @foo(ptr noalias nocapture noundef readonly %A, ptr noalias nocapture noundef %B, ptr noalias nocapture noundef writeonly %C, i32 noundef %n, ptr noalias nocapture noundef readonly %U) {
@@ -16,35 +17,35 @@ entry:
 entry.split:                                      ; preds = %entry
   br label %for.body
 
-for.cond3.preheader:                              ; preds = %for.body
-  %0 = load i32, ptr %U, align 4
-  br label %for.body6
-
 for.body:                                         ; preds = %entry.split, %for.body
   %indvars.iv = phi i64 [ 0, %entry.split ], [ %indvars.iv.next, %for.body ]
   %arrayidx = getelementptr inbounds i32, ptr %A, i64 %indvars.iv
-  %1 = load i32, ptr %arrayidx, align 4
+  %i1 = load i32, ptr %arrayidx, align 4
   %arrayidx2 = getelementptr inbounds i32, ptr %B, i64 %indvars.iv
-  %2 = load i32, ptr %arrayidx2, align 4
-  %add = add nsw i32 %2, %1
+  %i2 = load i32, ptr %arrayidx2, align 4
+  %add = add nsw i32 %i2, %i1
   store i32 %add, ptr %arrayidx2, align 4
   %indvars.iv.next = add nuw nsw i64 %indvars.iv, 1
   %exitcond.not = icmp eq i64 %indvars.iv.next, 1024
   br i1 %exitcond.not, label %for.cond3.preheader, label %for.body
 
-for.cond.cleanup5:                                ; preds = %for.body6
-  ret void
+for.cond3.preheader:                              ; preds = %for.body
+  %i3 = load i32, ptr %U, align 4
+  br label %for.body6
 
 for.body6:                                        ; preds = %for.cond3.preheader, %for.body6
   %indvars.iv25 = phi i64 [ 0, %for.cond3.preheader ], [ %indvars.iv.next26, %for.body6 ]
   %arrayidx8 = getelementptr inbounds i32, ptr %B, i64 %indvars.iv25
-  %3 = load i32, ptr %arrayidx8, align 4
-  %add9 = add nsw i32 %0, %3
+  %i4 = load i32, ptr %arrayidx8, align 4
+  %add9 = add nsw i32 %i3, %i4
   %arrayidx11 = getelementptr inbounds i32, ptr %C, i64 %indvars.iv25
   store i32 %add9, ptr %arrayidx11, align 4
   %indvars.iv.next26 = add nuw nsw i64 %indvars.iv25, 1
   %exitcond28.not = icmp eq i64 %indvars.iv.next26, 1024
   br i1 %exitcond28.not, label %for.cond.cleanup5, label %for.body6
+
+for.cond.cleanup5:                                ; preds = %for.body6
+  ret void
 }
 
 ; Check that loop preheader block that containing loop invariant load *U is

--- a/polly/test/CodeGen/region_expansion_profitability_check_loopfusion_2.ll
+++ b/polly/test/CodeGen/region_expansion_profitability_check_loopfusion_2.ll
@@ -1,0 +1,70 @@
+; RUN: opt -polly-use-llvm-names -polly-region-expansion-profitability-check=1 \
+; RUN: -polly-loopfusion-greedy=1 "-passes=scop(polly-opt-isl,print<polly-ast>)" \
+; RUN: -disable-output < %s | FileCheck %s
+
+; void foo(int *A, int *B, int *C, int n, int *U) {
+;   for (int i = 0; i < 1024; ++i) // L1
+;     B[i] += A[i];
+;
+;   if (*U != 1) // Blocks with unrelated memory accesses.
+;     *U+=42;
+;
+;   for (int j = 0; j < 1024; ++j) // L2
+;     C[j] += B[j];
+; }
+
+define void @foo(ptr nocapture noundef readonly %A, ptr nocapture noundef %B, ptr nocapture noundef %C, i32 noundef %n, ptr nocapture noundef %U) {
+entry:
+  br label %entry.split
+
+entry.split:                                      ; preds = %entry
+  br label %for.body
+
+for.cond.cleanup:                                 ; preds = %for.body
+  %0 = load i32, ptr %U, align 4
+  %cmp3.not = icmp eq i32 %0, 1
+  br i1 %cmp3.not, label %if.end, label %if.then
+
+for.body:                                         ; preds = %entry.split, %for.body
+  %indvars.iv = phi i64 [ 0, %entry.split ], [ %indvars.iv.next, %for.body ]
+  %arrayidx = getelementptr inbounds i32, ptr %A, i64 %indvars.iv
+  %1 = load i32, ptr %arrayidx, align 4
+  %arrayidx2 = getelementptr inbounds i32, ptr %B, i64 %indvars.iv
+  %2 = load i32, ptr %arrayidx2, align 4
+  %add = add nsw i32 %2, %1
+  store i32 %add, ptr %arrayidx2, align 4
+  %indvars.iv.next = add nuw nsw i64 %indvars.iv, 1
+  %exitcond.not = icmp eq i64 %indvars.iv.next, 1024
+  br i1 %exitcond.not, label %for.cond.cleanup, label %for.body
+
+if.then:                                          ; preds = %for.cond.cleanup
+  %add4 = add nsw i32 %0, 42
+  store i32 %add4, ptr %U, align 4
+  br label %if.end
+
+if.end:                                           ; preds = %if.then, %for.cond.cleanup
+  br label %for.body8
+
+for.cond.cleanup7:                                ; preds = %for.body8
+  ret void
+
+for.body8:                                        ; preds = %if.end, %for.body8
+  %indvars.iv28 = phi i64 [ 0, %if.end ], [ %indvars.iv.next29, %for.body8 ]
+  %arrayidx10 = getelementptr inbounds i32, ptr %B, i64 %indvars.iv28
+  %3 = load i32, ptr %arrayidx10, align 4
+  %arrayidx12 = getelementptr inbounds i32, ptr %C, i64 %indvars.iv28
+  %4 = load i32, ptr %arrayidx12, align 4
+  %add13 = add nsw i32 %4, %3
+  store i32 %add13, ptr %arrayidx12, align 4
+  %indvars.iv.next29 = add nuw nsw i64 %indvars.iv28, 1
+  %exitcond31.not = icmp eq i64 %indvars.iv.next29, 1024
+  br i1 %exitcond31.not, label %for.cond.cleanup7, label %for.body8
+}
+
+; Check that if blocks with unrelated memory accesses are followed by another
+; loop from region expansion, loop fusion is encouraged with region expansion
+; profitability check. L1 and L2 are fused.
+; CHECK-LABEL: isl ast :: foo :: %for.body---%for.cond.cleanup7
+; CHECK:           for (int c0 = 0; c0 <= 1023; c0 += 1) {
+; CHECK-NEXT:        Stmt_for_body(c0);
+; CHECK-NEXT:        Stmt_for_body8(c0);

--- a/polly/test/CodeGen/region_expansion_profitability_check_loopfusion_2.ll
+++ b/polly/test/CodeGen/region_expansion_profitability_check_loopfusion_2.ll
@@ -1,4 +1,4 @@
-; RUN: opt -polly-use-llvm-names -polly-region-expansion-profitability-check=1 \
+; RUN: opt %loadNPMPolly -polly-region-expansion-profitability-check=1 \
 ; RUN: -polly-loopfusion-greedy=1 "-passes=scop(polly-opt-isl,print<polly-ast>)" \
 ; RUN: -disable-output < %s | FileCheck %s
 
@@ -20,50 +20,50 @@ entry:
 entry.split:                                      ; preds = %entry
   br label %for.body
 
-for.cond.cleanup:                                 ; preds = %for.body
-  %0 = load i32, ptr %U, align 4
-  %cmp3.not = icmp eq i32 %0, 1
-  br i1 %cmp3.not, label %if.end, label %if.then
-
 for.body:                                         ; preds = %entry.split, %for.body
   %indvars.iv = phi i64 [ 0, %entry.split ], [ %indvars.iv.next, %for.body ]
   %arrayidx = getelementptr inbounds i32, ptr %A, i64 %indvars.iv
-  %1 = load i32, ptr %arrayidx, align 4
+  %i1 = load i32, ptr %arrayidx, align 4
   %arrayidx2 = getelementptr inbounds i32, ptr %B, i64 %indvars.iv
-  %2 = load i32, ptr %arrayidx2, align 4
-  %add = add nsw i32 %2, %1
+  %i2 = load i32, ptr %arrayidx2, align 4
+  %add = add nsw i32 %i2, %i1
   store i32 %add, ptr %arrayidx2, align 4
   %indvars.iv.next = add nuw nsw i64 %indvars.iv, 1
   %exitcond.not = icmp eq i64 %indvars.iv.next, 1024
   br i1 %exitcond.not, label %for.cond.cleanup, label %for.body
 
+for.cond.cleanup:                                 ; preds = %for.body
+  %i3 = load i32, ptr %U, align 4
+  %cmp3.not = icmp eq i32 %i3, 1
+  br i1 %cmp3.not, label %if.end, label %if.then
+
 if.then:                                          ; preds = %for.cond.cleanup
-  %add4 = add nsw i32 %0, 42
+  %add4 = add nsw i32 %i3, 42
   store i32 %add4, ptr %U, align 4
   br label %if.end
 
 if.end:                                           ; preds = %if.then, %for.cond.cleanup
   br label %for.body8
 
-for.cond.cleanup7:                                ; preds = %for.body8
-  ret void
-
 for.body8:                                        ; preds = %if.end, %for.body8
   %indvars.iv28 = phi i64 [ 0, %if.end ], [ %indvars.iv.next29, %for.body8 ]
   %arrayidx10 = getelementptr inbounds i32, ptr %B, i64 %indvars.iv28
-  %3 = load i32, ptr %arrayidx10, align 4
+  %i4 = load i32, ptr %arrayidx10, align 4
   %arrayidx12 = getelementptr inbounds i32, ptr %C, i64 %indvars.iv28
-  %4 = load i32, ptr %arrayidx12, align 4
-  %add13 = add nsw i32 %4, %3
+  %i5 = load i32, ptr %arrayidx12, align 4
+  %add13 = add nsw i32 %i5, %i4
   store i32 %add13, ptr %arrayidx12, align 4
   %indvars.iv.next29 = add nuw nsw i64 %indvars.iv28, 1
   %exitcond31.not = icmp eq i64 %indvars.iv.next29, 1024
   br i1 %exitcond31.not, label %for.cond.cleanup7, label %for.body8
+
+for.cond.cleanup7:                                ; preds = %for.body8
+  ret void
 }
 
-; Check that if blocks with unrelated memory accesses are followed by another
-; loop from region expansion, loop fusion is encouraged with region expansion
-; profitability check. L1 and L2 are fused.
+; Check that if non-loop blocks are followed by another loop from region
+; expansion, loop fusion is encouraged with region expansion profitability
+; check. L1 and L2 are fused.
 ; CHECK-LABEL: isl ast :: foo :: %for.body---%for.cond.cleanup7
 ; CHECK:           for (int c0 = 0; c0 <= 1023; c0 += 1) {
 ; CHECK-NEXT:        Stmt_for_body(c0);

--- a/polly/test/CodeGen/scalar-store-from-same-bb.ll
+++ b/polly/test/CodeGen/scalar-store-from-same-bb.ll
@@ -1,4 +1,4 @@
-; RUN: opt %loadNPMPolly \
+; RUN: opt %loadNPMPolly -polly-region-expansion-profitability-check=0 \
 ; RUN: -passes=polly-codegen -S < %s | FileCheck %s
 
 ; This test ensures that the expression N + 1 that is stored in the phi-node

--- a/polly/test/CodeGen/scev_looking_through_bitcasts.ll
+++ b/polly/test/CodeGen/scev_looking_through_bitcasts.ll
@@ -1,4 +1,5 @@
-; RUN: opt %loadNPMPolly -passes=polly-codegen -S < %s | FileCheck %s
+; RUN: opt %loadNPMPolly -passes=polly-codegen \
+; RUN: -polly-region-expansion-profitability-check=0 -S < %s | FileCheck %s
 ;
 ; Scalar write of bitcasted value. Instead of writing %b of type
 ; %structty, the SCEV expression looks through the bitcast such that

--- a/polly/test/CodeGen/synthesizable_phi_write_after_loop.ll
+++ b/polly/test/CodeGen/synthesizable_phi_write_after_loop.ll
@@ -1,4 +1,5 @@
-; RUN: opt %loadNPMPolly -passes=polly-codegen -S < %s | FileCheck %s
+; RUN: opt %loadNPMPolly -polly-region-expansion-profitability-check=0 \
+; RUN: -passes=polly-codegen -S < %s | FileCheck %s
 ;
 ; Check for the correct written value of a scalar phi write whose value is
 ; defined within the loop, but its effective value is its last definition when

--- a/polly/test/CodeGen/two-loops-right-after-each-other-2.ll
+++ b/polly/test/CodeGen/two-loops-right-after-each-other-2.ll
@@ -1,4 +1,5 @@
-; RUN: opt %loadNPMPolly -passes=polly-codegen -S < %s | FileCheck %s
+; RUN: opt %loadNPMPolly -passes=polly-codegen \
+; RUN: -polly-region-expansion-profitability-check=0 -S < %s | FileCheck %s
 
 ; CHECK:       polly.merge_new_and_old:
 ; CHECK-NEXT:    merge = phi

--- a/polly/test/CodeGen/unpredictable-loop-unsynthesizable.ll
+++ b/polly/test/CodeGen/unpredictable-loop-unsynthesizable.ll
@@ -1,7 +1,9 @@
 ; RUN: opt %loadNPMPolly -polly-stmt-granularity=bb '-passes=print<polly-function-scops>' \
-; RUN: -polly-invariant-load-hoisting=true -disable-output < %s 2>&1 | FileCheck %s
+; RUN: -polly-invariant-load-hoisting=true -polly-region-expansion-profitability-check=0 \
+; RUN: -disable-output < %s 2>&1 | FileCheck %s
 ; RUN: opt %loadNPMPolly -polly-stmt-granularity=bb -passes=polly-codegen \
-; RUN: -polly-invariant-load-hoisting=true -disable-output < %s
+; RUN: -polly-invariant-load-hoisting=true -polly-region-expansion-profitability-check=0 \
+; RUN: -disable-output < %s
 
 ; The loop for.body is a scop with invariant load hoisting, but does not
 ; terminate predictably for ScalarEvolution. The scalar %1 therefore is not

--- a/polly/test/DeLICM/skip_notinloop.ll
+++ b/polly/test/DeLICM/skip_notinloop.ll
@@ -1,4 +1,5 @@
-; RUN: opt %loadNPMPolly '-passes=print<polly-delicm>' -pass-remarks-missed=polly-delicm -disable-output < %s 2>&1 | FileCheck %s
+; RUN: opt %loadNPMPolly '-passes=print<polly-delicm>' -pass-remarks-missed=polly-delicm \
+; RUN: -polly-region-expansion-profitability-check=0 -disable-output < %s 2>&1 | FileCheck %s
 ;
 ;    void func(double *A) {
 ;      double phi = 0.0;

--- a/polly/test/ScopDetect/expand-region-correctly-2.ll
+++ b/polly/test/ScopDetect/expand-region-correctly-2.ll
@@ -1,4 +1,5 @@
-; RUN: opt %loadNPMPolly '-passes=print<polly-detect>' -disable-output < %s 2>&1 | FileCheck %s
+; RUN: opt %loadNPMPolly '-passes=print<polly-detect>' -disable-output \
+; RUN: -polly-region-expansion-profitability-check=0 < %s 2>&1 | FileCheck %s
 ;
 ; CHECK: Valid Region for Scop: if.end.1631 => for.cond.1647.outer
 ;

--- a/polly/test/ScopDetect/expand-region-correctly.ll
+++ b/polly/test/ScopDetect/expand-region-correctly.ll
@@ -1,4 +1,5 @@
-; RUN: opt %loadNPMPolly '-passes=print<polly-detect>' -disable-output < %s 2>&1 | FileCheck %s
+; RUN: opt %loadNPMPolly '-passes=print<polly-detect>' -disable-output \
+; RUN: -polly-region-expansion-profitability-check=0 < %s 2>&1 | FileCheck %s
 
 ; CHECK: Valid Region for Scop: if.end.1631 => for.cond.1647.outer
 

--- a/polly/test/ScopDetect/non-affine-loop-condition-dependent-access_2.ll
+++ b/polly/test/ScopDetect/non-affine-loop-condition-dependent-access_2.ll
@@ -1,6 +1,15 @@
-; RUN: opt %loadNPMPolly -aa-pipeline=basic-aa -polly-allow-nonaffine-branches -polly-allow-nonaffine-loops=false                        '-passes=print<polly-detect>' -disable-output < %s 2>&1 | FileCheck %s --check-prefix=REJECTNONAFFINELOOPS
-; RUN: opt %loadNPMPolly -aa-pipeline=basic-aa -polly-allow-nonaffine-branches -polly-allow-nonaffine-loops=true                         '-passes=print<polly-detect>' -disable-output < %s 2>&1 | FileCheck %s --check-prefix=ALLOWNONAFFINELOOPS
-; RUN: opt %loadNPMPolly -aa-pipeline=basic-aa -polly-allow-nonaffine-branches -polly-allow-nonaffine-loops=true  -polly-allow-nonaffine '-passes=print<polly-detect>' -disable-output < %s 2>&1 | FileCheck %s --check-prefix=ALLOWNONAFFINELOOPSANDACCESSES
+; RUN: opt %loadNPMPolly -aa-pipeline=basic-aa -polly-allow-nonaffine-branches \
+; RUN: -polly-region-expansion-profitability-check=0 -polly-allow-nonaffine-loops=false \
+; RUN: '-passes=print<polly-detect>' -disable-output < %s 2>&1 | FileCheck %s \
+; RUN: --check-prefix=REJECTNONAFFINELOOPS
+; RUN: opt %loadNPMPolly -aa-pipeline=basic-aa -polly-allow-nonaffine-branches \
+; RUN: -polly-region-expansion-profitability-check=0 -polly-allow-nonaffine-loops=true \
+; RUN: '-passes=print<polly-detect>' -disable-output < %s 2>&1 | FileCheck %s \
+; RUN: --check-prefix=ALLOWNONAFFINELOOPS
+; RUN: opt %loadNPMPolly -aa-pipeline=basic-aa -polly-allow-nonaffine-branches \
+; RUN: -polly-region-expansion-profitability-check=0 -polly-allow-nonaffine-loops=true \
+; RUN: -polly-allow-nonaffine '-passes=print<polly-detect>' -disable-output < %s \
+; RUN: 2>&1 | FileCheck %s --check-prefix=ALLOWNONAFFINELOOPSANDACCESSES
 ;
 ; Here we have a non-affine loop (in the context of the loop nest)
 ; and also a non-affine access (A[k]). While we can always detect the

--- a/polly/test/ScopDetect/non-affine-loop-condition-dependent-access_3.ll
+++ b/polly/test/ScopDetect/non-affine-loop-condition-dependent-access_3.ll
@@ -1,6 +1,15 @@
-; RUN: opt %loadNPMPolly -aa-pipeline=basic-aa -polly-allow-nonaffine-branches -polly-allow-nonaffine-loops=false                        '-passes=print<polly-detect>' -disable-output < %s 2>&1 | FileCheck %s --check-prefix=REJECTNONAFFINELOOPS
-; RUN: opt %loadNPMPolly -aa-pipeline=basic-aa -polly-allow-nonaffine-branches -polly-allow-nonaffine-loops=true                         '-passes=print<polly-detect>' -disable-output < %s 2>&1 | FileCheck %s --check-prefix=ALLOWNONAFFINELOOPS
-; RUN: opt %loadNPMPolly -aa-pipeline=basic-aa -polly-allow-nonaffine-branches -polly-allow-nonaffine-loops=true  -polly-allow-nonaffine '-passes=print<polly-detect>' -disable-output < %s 2>&1 | FileCheck %s --check-prefix=ALLOWNONAFFINELOOPSANDACCESSES
+; RUN: opt %loadNPMPolly -aa-pipeline=basic-aa -polly-allow-nonaffine-branches \
+; RUN: -polly-region-expansion-profitability-check=0 -polly-allow-nonaffine-loops=false \
+; RUN: '-passes=print<polly-detect>' -disable-output < %s 2>&1 | FileCheck %s \
+; RUN: --check-prefix=REJECTNONAFFINELOOPS
+; RUN: opt %loadNPMPolly -aa-pipeline=basic-aa -polly-allow-nonaffine-branches \
+; RUN: -polly-region-expansion-profitability-check=0 -polly-allow-nonaffine-loops=true \
+; RUN: '-passes=print<polly-detect>' -disable-output < %s 2>&1 | FileCheck %s \
+; RUN: --check-prefix=ALLOWNONAFFINELOOPS
+; RUN: opt %loadNPMPolly -aa-pipeline=basic-aa -polly-allow-nonaffine-branches \
+; RUN: -polly-region-expansion-profitability-check=0 -polly-allow-nonaffine-loops=true \
+; RUN: -polly-allow-nonaffine '-passes=print<polly-detect>' -disable-output < %s \
+; RUN: 2>&1 | FileCheck %s --check-prefix=ALLOWNONAFFINELOOPSANDACCESSES
 ;
 ; Here we have a non-affine loop (in the context of the loop nest)
 ; and also a non-affine access (A[k]). While we can always detect the

--- a/polly/test/ScopDetect/profitability-two-nested-loops.ll
+++ b/polly/test/ScopDetect/profitability-two-nested-loops.ll
@@ -1,4 +1,5 @@
-; RUN: opt %loadNPMPolly '-passes=print<polly-detect>' -disable-output < %s 2>&1 | FileCheck %s
+; RUN: opt %loadNPMPolly '-passes=print<polly-detect>' -disable-output \
+; RUN: -polly-region-expansion-profitability-check=0 < %s 2>&1 | FileCheck %s
 
 ; CHECK: Valid Region for Scop: next => bb3
 ;

--- a/polly/test/ScopInfo/20111108-Parameter-not-detected.ll
+++ b/polly/test/ScopInfo/20111108-Parameter-not-detected.ll
@@ -1,4 +1,6 @@
-; RUN: opt %loadNPMPolly '-passes=print<polly-function-scops>' -disable-output < %s 2>&1 | FileCheck %s
+; RUN: opt %loadNPMPolly '-passes=print<polly-function-scops>' -disable-output \
+; RUN: -polly-region-expansion-profitability-check=0 < %s 2>&1 | FileCheck %s
+
 target datalayout = "e-p:64:64:64-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-f32:32:32-f64:64:64-v64:64:64-v128:128:128-a0:0:64-s0:64:64-f80:128:128-n8:16:32:64-S128"
 
 declare void @foo()

--- a/polly/test/ScopInfo/NonAffine/non-affine-loop-condition-dependent-access_2.ll
+++ b/polly/test/ScopInfo/NonAffine/non-affine-loop-condition-dependent-access_2.ll
@@ -1,6 +1,15 @@
-; RUN: opt %loadNPMPolly -aa-pipeline=basic-aa -polly-allow-nonaffine-branches -polly-allow-nonaffine-loops=false                       '-passes=print<polly-function-scops>' -disable-output < %s 2>&1 | FileCheck %s --check-prefix=INNERMOST
-; RUN: opt %loadNPMPolly -aa-pipeline=basic-aa -polly-allow-nonaffine-branches -polly-allow-nonaffine-loops=true                        '-passes=print<polly-function-scops>' -disable-output < %s 2>&1 | FileCheck %s --check-prefix=INNERMOST
-; RUN: opt %loadNPMPolly -aa-pipeline=basic-aa -polly-allow-nonaffine-branches -polly-allow-nonaffine-loops=true -polly-allow-nonaffine '-passes=print<polly-function-scops>' -disable-output < %s 2>&1 | FileCheck %s --check-prefix=ALL
+; RUN: opt %loadNPMPolly -aa-pipeline=basic-aa -polly-allow-nonaffine-branches \
+; RUN: -polly-region-expansion-profitability-check=0 -polly-allow-nonaffine-loops=false \
+; RUN: '-passes=print<polly-function-scops>' -disable-output < %s 2>&1 | \
+; RUN: FileCheck %s --check-prefix=INNERMOST
+; RUN: opt %loadNPMPolly -aa-pipeline=basic-aa -polly-allow-nonaffine-branches \
+; RUN: -polly-region-expansion-profitability-check=0 -polly-allow-nonaffine-loops=true \
+; RUN: '-passes=print<polly-function-scops>' -disable-output < %s 2>&1 | \
+; RUN: FileCheck %s --check-prefix=INNERMOST
+; RUN: opt %loadNPMPolly -aa-pipeline=basic-aa -polly-allow-nonaffine-branches \
+; RUN: -polly-region-expansion-profitability-check=0 -polly-allow-nonaffine-loops=true \
+; RUN: -polly-allow-nonaffine '-passes=print<polly-function-scops>' \
+; RUN: -disable-output < %s 2>&1 | FileCheck %s --check-prefix=ALL
 ;
 ; Here we have a non-affine loop (in the context of the loop nest)
 ; and also a non-affine access (A[k]). While we can always model the

--- a/polly/test/ScopInfo/NonAffine/non-affine-loop-condition-dependent-access_3.ll
+++ b/polly/test/ScopInfo/NonAffine/non-affine-loop-condition-dependent-access_3.ll
@@ -1,6 +1,15 @@
-; RUN: opt %loadNPMPolly -aa-pipeline=basic-aa -polly-allow-nonaffine-branches -polly-allow-nonaffine-loops=false                       '-passes=print<polly-function-scops>' -disable-output < %s 2>&1 | FileCheck %s --check-prefix=INNERMOST
-; RUN: opt %loadNPMPolly -aa-pipeline=basic-aa -polly-allow-nonaffine-branches -polly-allow-nonaffine-loops=true                        '-passes=print<polly-function-scops>' -disable-output < %s 2>&1 | FileCheck %s --check-prefix=INNERMOST
-; RUN: opt %loadNPMPolly -aa-pipeline=basic-aa -polly-allow-nonaffine-branches -polly-allow-nonaffine-loops=true -polly-allow-nonaffine '-passes=print<polly-function-scops>' -disable-output < %s 2>&1 | FileCheck %s --check-prefix=ALL
+; RUN: opt %loadNPMPolly -aa-pipeline=basic-aa -polly-allow-nonaffine-branches \
+; RUN: -polly-region-expansion-profitability-check=0 -polly-allow-nonaffine-loops=false \
+; RUN: '-passes=print<polly-function-scops>' -disable-output < %s 2>&1 | \
+; RUN: FileCheck %s --check-prefix=INNERMOST
+; RUN: opt %loadNPMPolly -aa-pipeline=basic-aa -polly-allow-nonaffine-branches \
+; RUN: -polly-region-expansion-profitability-check=0 -polly-allow-nonaffine-loops=true \
+; RUN: '-passes=print<polly-function-scops>' -disable-output < %s 2>&1 | \
+; RUN: FileCheck %s --check-prefix=INNERMOST
+; RUN: opt %loadNPMPolly -aa-pipeline=basic-aa -polly-allow-nonaffine-branches \
+; RUN: -polly-region-expansion-profitability-check=0 -polly-allow-nonaffine-loops=true \
+; RUN: -polly-allow-nonaffine '-passes=print<polly-function-scops>' \
+; RUN: -disable-output < %s 2>&1 | FileCheck %s --check-prefix=ALL
 ;
 ; Here we have a non-affine loop (in the context of the loop nest)
 ; and also a non-affine access (A[k]). While we can always model the

--- a/polly/test/ScopInfo/NonAffine/non_affine_conditional_surrounding_affine_loop.ll
+++ b/polly/test/ScopInfo/NonAffine/non_affine_conditional_surrounding_affine_loop.ll
@@ -1,12 +1,13 @@
 ; RUN: opt %loadNPMPolly -polly-allow-nonaffine-branches \
-; RUN:     -polly-invariant-load-hoisting=true \
-; RUN:     -polly-allow-nonaffine-loops=true \
-; RUN:     '-passes=print<polly-function-scops>' -disable-output < %s 2>&1 | FileCheck %s --check-prefix=INNERMOST
+; RUN: -polly-invariant-load-hoisting=true -polly-allow-nonaffine-loops=true \
+; RUN: -polly-region-expansion-profitability-check=0 \
+; RUN: '-passes=print<polly-function-scops>' -disable-output < %s 2>&1 | \
+; RUN: FileCheck %s --check-prefix=INNERMOST
 ; RUN: opt %loadNPMPolly -polly-allow-nonaffine \
-; RUN:     -polly-invariant-load-hoisting=true \
-; RUN:     -polly-allow-nonaffine-branches -polly-allow-nonaffine-loops=true \
-; RUN:     '-passes=print<polly-function-scops>' -disable-output < %s 2>&1 | FileCheck %s \
-; RUN:     --check-prefix=ALL
+; RUN: -polly-invariant-load-hoisting=true -polly-allow-nonaffine-branches \
+; RUN: -polly-allow-nonaffine-loops=true -polly-region-expansion-profitability-check=0 \
+; RUN: '-passes=print<polly-function-scops>' -disable-output < %s 2>&1 | FileCheck %s \
+; RUN: --check-prefix=ALL
 ;
 ; Negative test for INNERMOST.
 ; At the moment we will optimistically assume A[i] in the conditional before the inner

--- a/polly/test/ScopInfo/NonAffine/non_affine_conditional_surrounding_non_affine_loop.ll
+++ b/polly/test/ScopInfo/NonAffine/non_affine_conditional_surrounding_non_affine_loop.ll
@@ -1,16 +1,20 @@
 ; RUN: opt %loadNPMPolly -polly-allow-nonaffine-branches \
-; RUN:     -polly-invariant-load-hoisting=true \
-; RUN:     -polly-allow-nonaffine-loops=true \
-; RUN:     '-passes=print<polly-detect>,print<polly-function-scops>' -disable-output < %s 2>&1 | FileCheck %s --check-prefix=INNERMOST
+; RUN: -polly-invariant-load-hoisting=true -polly-allow-nonaffine-loops=true \
+; RUN: -polly-region-expansion-profitability-check=0 \
+; RUN: '-passes=print<polly-detect>,print<polly-function-scops>' \
+; RUN: -disable-output < %s 2>&1 | FileCheck %s --check-prefix=INNERMOST
 ; RUN: opt %loadNPMPolly -polly-allow-nonaffine \
-; RUN:     -polly-invariant-load-hoisting=true \
-; RUN:     -polly-allow-nonaffine-branches -polly-allow-nonaffine-loops=true \
-; RUN:     '-passes=print<polly-detect>,print<polly-function-scops>' -disable-output < %s 2>&1 | FileCheck %s --check-prefix=ALL
+; RUN: -polly-invariant-load-hoisting=true -polly-allow-nonaffine-branches \
+; RUN: -polly-allow-nonaffine-loops=true \
+; RUN: -polly-region-expansion-profitability-check=0 \
+; RUN: '-passes=print<polly-detect>,print<polly-function-scops>' -disable-output \
+; RUN: < %s 2>&1 | FileCheck %s --check-prefix=ALL
 ; RUN: opt %loadNPMPolly -polly-allow-nonaffine \
-; RUN:     -polly-invariant-load-hoisting=true \
-; RUN:     -polly-process-unprofitable=false \
-; RUN:     -polly-allow-nonaffine-branches -polly-allow-nonaffine-loops=true \
-; RUN:     '-passes=print<polly-detect>,print<polly-function-scops>' -disable-output < %s 2>&1 | FileCheck %s --check-prefix=PROFIT
+; RUN: -polly-invariant-load-hoisting=true -polly-process-unprofitable=false \
+; RUN: -polly-allow-nonaffine-branches -polly-allow-nonaffine-loops=true \
+; RUN: -polly-region-expansion-profitability-check=0 \
+; RUN: '-passes=print<polly-detect>,print<polly-function-scops>' -disable-output \
+; RUN: < %s 2>&1 | FileCheck %s --check-prefix=PROFIT
 ;
 ; Negative test for INNERMOST.
 ; At the moment we will optimistically assume A[i] in the conditional before the inner

--- a/polly/test/ScopInfo/branch-references-loop-scev-with-unknown-iterations-2.ll
+++ b/polly/test/ScopInfo/branch-references-loop-scev-with-unknown-iterations-2.ll
@@ -1,8 +1,8 @@
-; RUN: opt %loadNPMPolly '-passes=print<polly-detect>' -disable-output < %s 2>&1 | \
-; RUN:     FileCheck %s -check-prefix=DETECT
+; RUN: opt %loadNPMPolly '-passes=print<polly-detect>' -disable-output \
+; RUN: -polly-region-expansion-profitability-check=0 < %s 2>&1 | FileCheck %s -check-prefix=DETECT
 
-; RUN: opt %loadNPMPolly '-passes=print<polly-function-scops>' -disable-output < %s 2>&1 | \
-; RUN:     FileCheck %s -check-prefix=SCOP
+; RUN: opt %loadNPMPolly '-passes=print<polly-function-scops>' -disable-output \
+; RUN: -polly-region-expansion-profitability-check=0 < %s 2>&1 | FileCheck %s -check-prefix=SCOP
 
 ; DETECT: Valid Region for Scop: loop => barrier
 ; DETECT-NEXT: Valid Region for Scop: branch => end

--- a/polly/test/ScopInfo/branch-references-loop-scev-with-unknown-iterations-3.ll
+++ b/polly/test/ScopInfo/branch-references-loop-scev-with-unknown-iterations-3.ll
@@ -1,8 +1,9 @@
-; RUN: opt %loadNPMPolly -polly-stmt-granularity=bb '-passes=print<polly-function-scops>' -disable-output < %s 2>&1 | \
-; RUN:     FileCheck %s -check-prefix=NONAFFINE
+; RUN: opt %loadNPMPolly -polly-stmt-granularity=bb '-passes=print<polly-function-scops>' \
+; RUN: -polly-region-expansion-profitability-check=0 -disable-output < %s 2>&1 | \
+; RUN: FileCheck %s -check-prefix=NONAFFINE
 ; RUN: opt %loadNPMPolly -polly-stmt-granularity=bb '-passes=print<polly-function-scops>' -disable-output \
-; RUN:     -polly-allow-nonaffine-branches=false < %s 2>&1 | \
-; RUN:     FileCheck %s -check-prefix=NO-NONEAFFINE
+; RUN: -polly-region-expansion-profitability-check=0 -polly-allow-nonaffine-branches=false < %s 2>&1 | \
+; RUN: FileCheck %s -check-prefix=NO-NONEAFFINE
 
 ; NONAFFINE:      Statements {
 ; NONAFFINE-NEXT: 	Stmt_loop

--- a/polly/test/ScopInfo/branch-references-loop-scev-with-unknown-iterations.ll
+++ b/polly/test/ScopInfo/branch-references-loop-scev-with-unknown-iterations.ll
@@ -1,8 +1,9 @@
-; RUN: opt %loadNPMPolly '-passes=print<polly-detect>,print<polly-function-scops>' -disable-output < %s 2>&1 | \
-; RUN:     FileCheck %s -check-prefix=NONAFFINE
+; RUN: opt %loadNPMPolly '-passes=print<polly-detect>,print<polly-function-scops>' \
+; RUN: -polly-region-expansion-profitability-check=0 -disable-output < %s 2>&1 | \
+; RUN: FileCheck %s -check-prefix=NONAFFINE
 ; RUN: opt %loadNPMPolly '-passes=print<polly-detect>,print<polly-function-scops>' -disable-output \
-; RUN:     -polly-allow-nonaffine-branches=false < %s 2>&1 | \
-; RUN:     FileCheck %s -check-prefix=NO-NONEAFFINE
+; RUN: -polly-region-expansion-profitability-check=0 -polly-allow-nonaffine-branches=false < %s 2>&1 | \
+; RUN: FileCheck %s -check-prefix=NO-NONEAFFINE
 
 ; NONAFFINE-NOT: Statements
 

--- a/polly/test/ScopInfo/cfg_consequences.ll
+++ b/polly/test/ScopInfo/cfg_consequences.ll
@@ -1,4 +1,5 @@
-; RUN: opt %loadNPMPolly '-passes=print<polly-function-scops>' -disable-output < %s 2>&1 | FileCheck %s
+; RUN: opt %loadNPMPolly '-passes=print<polly-function-scops>' -disable-output \
+; RUN: -polly-region-expansion-profitability-check=0 < %s 2>&1 | FileCheck %s
 ;
 ; void consequences(int *A, int bool_cond, int lhs, int rhs) {
 ;

--- a/polly/test/ScopInfo/complex-successor-structure-3.ll
+++ b/polly/test/ScopInfo/complex-successor-structure-3.ll
@@ -1,5 +1,6 @@
 ; RUN: opt %loadNPMPolly -disable-output '-passes=print<polly-function-scops>' \
-; RUN: -polly-invariant-load-hoisting=true < %s 2>&1 | FileCheck %s
+; RUN: -polly-invariant-load-hoisting=true -polly-region-expansion-profitability-check=0 \
+; RUN: < %s 2>&1 | FileCheck %s
 ;
 ; Check that propagation of domains from A(X) to A(X+1) will keep the
 ; domains small and concise.

--- a/polly/test/ScopInfo/complex_execution_context.ll
+++ b/polly/test/ScopInfo/complex_execution_context.ll
@@ -1,6 +1,6 @@
 ; RUN: opt %loadNPMPolly -pass-remarks-analysis="polly-scops" '-passes=print<polly-function-scops>' \
-; RUN:     -polly-invariant-load-hoisting=true \
-; RUN:     -disable-output < %s 2>&1 | FileCheck %s
+; RUN: -polly-region-expansion-profitability-check=0 -polly-invariant-load-hoisting=true \
+; RUN: -disable-output < %s 2>&1 | FileCheck %s
 ;
 ; CHECK: Low complexity assumption:
 ;

--- a/polly/test/ScopInfo/constant_functions_outside_scop_as_unknown.ll
+++ b/polly/test/ScopInfo/constant_functions_outside_scop_as_unknown.ll
@@ -1,4 +1,6 @@
-; RUN: opt %loadNPMPolly -polly-process-unprofitable '-passes=print<polly-function-scops>' -disable-output < %s 2>&1 | FileCheck %s
+; RUN: opt %loadNPMPolly -polly-process-unprofitable \
+; RUN: '-passes=print<polly-function-scops>' -disable-output \
+; RUN: -polly-region-expansion-profitability-check=0 < %s 2>&1 | FileCheck %s
 
 target datalayout = "e-m:e-p:32:32-i64:64-v128:64:128-a:0:32-n32-S64"
 

--- a/polly/test/ScopInfo/exit-phi-2.ll
+++ b/polly/test/ScopInfo/exit-phi-2.ll
@@ -1,4 +1,6 @@
-; RUN: opt %loadNPMPolly -polly-stmt-granularity=bb '-passes=print<polly-function-scops>' -disable-output < %s 2>&1 | FileCheck %s
+; RUN: opt %loadNPMPolly -polly-stmt-granularity=bb \
+; RUN: -polly-region-expansion-profitability-check=0 \
+; RUN: '-passes=print<polly-function-scops>' -disable-output < %s 2>&1 | FileCheck %s
 ;
 ; Check that there is no MK_ExitPHI READ access.
 ;

--- a/polly/test/ScopInfo/infeasible_invalid_context.ll
+++ b/polly/test/ScopInfo/infeasible_invalid_context.ll
@@ -1,4 +1,5 @@
-; RUN: opt %loadNPMPolly '-passes=print<polly-detect>' -disable-output < %s 2>&1 \
+; RUN: opt %loadNPMPolly '-passes=print<polly-detect>' -disable-output \
+; RUN: -polly-region-expansion-profitability-check=0 < %s 2>&1 \
 ; RUN:  | FileCheck %s -check-prefix=DETECT
 
 ; RUN: opt %loadNPMPolly '-passes=print<polly-detect>,print<polly-function-scops>' -disable-output < %s 2>&1 \

--- a/polly/test/ScopInfo/long-sequence-of-error-blocks.ll
+++ b/polly/test/ScopInfo/long-sequence-of-error-blocks.ll
@@ -1,5 +1,6 @@
 ; RUN: opt %loadNPMPolly '-passes=print<polly-function-scops>' -disable-output \
-; RUN: -polly-invariant-load-hoisting=true < %s 2>&1 | FileCheck %s
+; RUN: -polly-region-expansion-profitability-check=0 -polly-invariant-load-hoisting=true \
+; RUN: < %s 2>&1 | FileCheck %s
 
 target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
 target triple = "x86_64-unknown-linux-gnu"

--- a/polly/test/ScopInfo/non-pure-function-calls-causes-dead-blocks.ll
+++ b/polly/test/ScopInfo/non-pure-function-calls-causes-dead-blocks.ll
@@ -1,4 +1,5 @@
-; RUN: opt %loadNPMPolly '-passes=print<polly-function-scops>' -disable-output < %s 2>&1 | FileCheck %s
+; RUN: opt %loadNPMPolly '-passes=print<polly-function-scops>' -disable-output \
+; RUN: -polly-region-expansion-profitability-check=0 < %s 2>&1 | FileCheck %s
 ;
 ; Error blocks are skipped during SCoP detection. We skip them during
 ; SCoP formation too as they might contain instructions we can not handle.

--- a/polly/test/ScopInfo/non-pure-function-calls.ll
+++ b/polly/test/ScopInfo/non-pure-function-calls.ll
@@ -1,4 +1,5 @@
-; RUN: opt %loadNPMPolly '-passes=print<polly-function-scops>' -disable-output < %s 2>&1 | FileCheck %s
+; RUN: opt %loadNPMPolly '-passes=print<polly-function-scops>' -disable-output \
+; RUN: -polly-region-expansion-profitability-check=0 < %s 2>&1 | FileCheck %s
 ;
 ; Allow the user to define function names that are treated as
 ; error functions and assumed not to be executed.

--- a/polly/test/ScopInfo/phi-in-non-affine-region.ll
+++ b/polly/test/ScopInfo/phi-in-non-affine-region.ll
@@ -1,4 +1,5 @@
-; RUN: opt %loadNPMPolly '-passes=print<polly-function-scops>' -disable-output < %s 2>&1 | FileCheck %s
+; RUN: opt %loadNPMPolly '-passes=print<polly-function-scops>' -disable-output \
+; RUN: -polly-region-expansion-profitability-check=0 < %s 2>&1 | FileCheck %s
 
 ; Verify that 'tmp' is stored in bb1 and read by bb3, as it is needed as
 ; incoming value for the tmp11 PHI node.

--- a/polly/test/ScopInfo/phi_after_error_block.ll
+++ b/polly/test/ScopInfo/phi_after_error_block.ll
@@ -1,4 +1,5 @@
-; RUN: opt %loadNPMPolly -polly-stmt-granularity=bb '-passes=print<polly-function-scops>' -disable-output < %s 2>&1 | FileCheck %s
+; RUN: opt %loadNPMPolly -polly-stmt-granularity=bb '-passes=print<polly-function-scops>' \
+; RUN: -polly-region-expansion-profitability-check=0 -disable-output < %s 2>&1 | FileCheck %s
 
 declare void @bar()
 

--- a/polly/test/ScopInfo/remarks.ll
+++ b/polly/test/ScopInfo/remarks.ll
@@ -2,12 +2,10 @@
 ; RUN: -polly-invariant-load-hoisting=true -disable-output < %s 2>&1 | FileCheck %s
 ;
 ; CHECK: remark: test/ScopInfo/remarks.c:4:7: SCoP begins here.
-; CHECK: remark: test/ScopInfo/remarks.c:4:7: No-overflows restriction:    [N, M] -> {  : M <= -2147483649 - N or M >= 2147483648 - N }
-; CHECK: remark: test/ScopInfo/remarks.c:5:13: SCoP ends here.
-; CHECK: remark: test/ScopInfo/remarks.c:7:3: SCoP begins here.
 ; CHECK: remark: test/ScopInfo/remarks.c:9:15: Inbounds assumption:    [N, M, Debug] -> {  : M <= 100 }
 ; CHECK: remark: test/ScopInfo/remarks.c:13:7: No-error restriction:    [N, M, Debug] -> {  : N > 0 and M >= 0 and (Debug < 0 or Debug > 0) }
 ; CHECK: remark: test/ScopInfo/remarks.c:8:5: Finite loop restriction:    [N, M, Debug] -> {  : N > 0 and M < 0 }
+; CHECK: remark: test/ScopInfo/remarks.c:4:7: No-overflows restriction:    [N, M, Debug] -> {  : M <= -2147483649 - N or M >= 2147483648 - N }
 ; CHECK: remark: test/ScopInfo/remarks.c:9:18: Possibly aliasing pointer, use restrict keyword.
 ; CHECK: remark: test/ScopInfo/remarks.c:9:33: Possibly aliasing pointer, use restrict keyword.
 ; CHECK: remark: test/ScopInfo/remarks.c:9:15: Possibly aliasing pointer, use restrict keyword.

--- a/polly/test/ScopInfo/remarks.ll
+++ b/polly/test/ScopInfo/remarks.ll
@@ -2,10 +2,12 @@
 ; RUN: -polly-invariant-load-hoisting=true -disable-output < %s 2>&1 | FileCheck %s
 ;
 ; CHECK: remark: test/ScopInfo/remarks.c:4:7: SCoP begins here.
+; CHECK: remark: test/ScopInfo/remarks.c:4:7: No-overflows restriction:    [N, M] -> {  : M <= -2147483649 - N or M >= 2147483648 - N }
+; CHECK: remark: test/ScopInfo/remarks.c:5:13: SCoP ends here.
+; CHECK: remark: test/ScopInfo/remarks.c:7:3: SCoP begins here.
 ; CHECK: remark: test/ScopInfo/remarks.c:9:15: Inbounds assumption:    [N, M, Debug] -> {  : M <= 100 }
 ; CHECK: remark: test/ScopInfo/remarks.c:13:7: No-error restriction:    [N, M, Debug] -> {  : N > 0 and M >= 0 and (Debug < 0 or Debug > 0) }
 ; CHECK: remark: test/ScopInfo/remarks.c:8:5: Finite loop restriction:    [N, M, Debug] -> {  : N > 0 and M < 0 }
-; CHECK: remark: test/ScopInfo/remarks.c:4:7: No-overflows restriction:    [N, M, Debug] -> {  : M <= -2147483649 - N or M >= 2147483648 - N }
 ; CHECK: remark: test/ScopInfo/remarks.c:9:18: Possibly aliasing pointer, use restrict keyword.
 ; CHECK: remark: test/ScopInfo/remarks.c:9:33: Possibly aliasing pointer, use restrict keyword.
 ; CHECK: remark: test/ScopInfo/remarks.c:9:15: Possibly aliasing pointer, use restrict keyword.

--- a/polly/test/ScopInfo/user_provided_assumptions.ll
+++ b/polly/test/ScopInfo/user_provided_assumptions.ll
@@ -4,12 +4,6 @@
 ; CHECK:      remark: <unknown>:0:0: SCoP begins here.
 ; CHECK-NEXT: remark: <unknown>:0:0: Use user assumption: [M, N] -> {  : N <= 2147483647 - M }
 ; CHECK-NEXT: remark: <unknown>:0:0: Use user assumption: [M, N] -> {  : -2147483648 - M <= N <= 2147483647 - M }
-; CHECK-NEXT: remark: <unknown>:0:0: Use user assumption: [M, N] -> {  : 0 < M <= 100 and -2147483648 - M <= N <= 2147483647 - M }
-; CHECK-NEXT: remark: <unknown>:0:0: Use user assumption: [M, N] -> {  : 0 < M <= 100 and 0 < N <= 2147483647 - M }
-; CHECK-NEXT: remark: <unknown>:0:0: SCoP ends here but was dismissed.
-; CHECK-NEXT: remark: <unknown>:0:0: SCoP begins here.
-; CHECK-NEXT: remark: <unknown>:0:0: Use user assumption: [M, N] -> {  : N <= 2147483647 - M }
-; CHECK-NEXT: remark: <unknown>:0:0: Use user assumption: [M, N] -> {  : -2147483648 - M <= N <= 2147483647 - M }
 ; CHECK-NEXT: remark: <unknown>:0:0: Use user assumption: [M, N, Debug] -> {  : Debug = 0 and 0 < M <= 100 and -2147483648 - M <= N <= 2147483647 - M }
 ; CHECK-NEXT: remark: <unknown>:0:0: Use user assumption: [M, N, Debug] -> {  : Debug = 0 and 0 < M <= 100 and 0 < N <= 2147483647 - M }
 ; CHECK-NEXT: remark: <unknown>:0:0: SCoP ends here.

--- a/polly/test/ScopInfo/user_provided_assumptions.ll
+++ b/polly/test/ScopInfo/user_provided_assumptions.ll
@@ -4,6 +4,12 @@
 ; CHECK:      remark: <unknown>:0:0: SCoP begins here.
 ; CHECK-NEXT: remark: <unknown>:0:0: Use user assumption: [M, N] -> {  : N <= 2147483647 - M }
 ; CHECK-NEXT: remark: <unknown>:0:0: Use user assumption: [M, N] -> {  : -2147483648 - M <= N <= 2147483647 - M }
+; CHECK-NEXT: remark: <unknown>:0:0: Use user assumption: [M, N] -> {  : 0 < M <= 100 and -2147483648 - M <= N <= 2147483647 - M }
+; CHECK-NEXT: remark: <unknown>:0:0: Use user assumption: [M, N] -> {  : 0 < M <= 100 and 0 < N <= 2147483647 - M }
+; CHECK-NEXT: remark: <unknown>:0:0: SCoP ends here but was dismissed.
+; CHECK-NEXT: remark: <unknown>:0:0: SCoP begins here.
+; CHECK-NEXT: remark: <unknown>:0:0: Use user assumption: [M, N] -> {  : N <= 2147483647 - M }
+; CHECK-NEXT: remark: <unknown>:0:0: Use user assumption: [M, N] -> {  : -2147483648 - M <= N <= 2147483647 - M }
 ; CHECK-NEXT: remark: <unknown>:0:0: Use user assumption: [M, N, Debug] -> {  : Debug = 0 and 0 < M <= 100 and -2147483648 - M <= N <= 2147483647 - M }
 ; CHECK-NEXT: remark: <unknown>:0:0: Use user assumption: [M, N, Debug] -> {  : Debug = 0 and 0 < M <= 100 and 0 < N <= 2147483647 - M }
 ; CHECK-NEXT: remark: <unknown>:0:0: SCoP ends here.


### PR DESCRIPTION
Region expansion may append a basic block that contains memory accesses not used in loops of original region, or any loops in regions to be joined. These additional memory accesses add complexity in building Scop, runtime alias checks and compute for optimization schedule. In certain cases may make original region unfeasible to analyze, e.g., access to a memory location that was loop invariant for loop in the origional region.

This patch adds a profitability check for region expansion. Mark the expanded region as unprofitable, if it includes basic blocks with memory accesses not used in loops of expanded region.