### PR TITLE
[libc][cmake] pass -mthumb for thumb triples

### DIFF
--- a/libc/cmake/modules/LLVMLibCArchitectures.cmake
+++ b/libc/cmake/modules/LLVMLibCArchitectures.cmake
@@ -33,7 +33,7 @@ function(get_arch_and_system_from_triple triple arch_var sys_var)
   # value.
   if(target_arch MATCHES "^mips")
     set(target_arch "mips")
-  elseif(target_arch MATCHES "^arm")
+  elseif(target_arch MATCHES "^arm" OR target_arch MATCHES "^thumb")
     # TODO(lntue): Shall we separate `arm64`?  It is currently recognized as
     # `arm` here.
     set(target_arch "arm")
@@ -203,6 +203,9 @@ if(explicit_target_triple AND
   else()
     list(APPEND
          LIBC_COMPILE_OPTIONS_DEFAULT "--target=${explicit_target_triple}")
+    if (explicit_target_triple MATCHES "^thumb")
+      list(APPEND LIBC_COMPILE_OPTIONS_DEFAULT "-mthumb")
+    endif()
   endif()
 endif()
 


### PR DESCRIPTION
Allows cross compiling for 32b ARM in thumb mode via
`-DLIBC_TARGET_TRIPLE=thumbv7-linux-gnueabihf`. Strangely, setting that target
triple doesn't imply `-mthumb`, so set that when using a triple that starts
with "thumb".

While our continuous testing of 32b ARM of llvm-libc uses ARM mode (-marm), it might be nice
to simplify testing -mthumb so that we can set up a thumb build bot.

Link: #96566