### PR TITLE
[clang-doc] update install path to share/clang-doc instead of share/clang

### DIFF
--- a/clang-tools-extra/clang-doc/tool/CMakeLists.txt
+++ b/clang-tools-extra/clang-doc/tool/CMakeLists.txt
@@ -25,7 +25,7 @@ set(assets
 )
 
 set(asset_dir "${CMAKE_CURRENT_SOURCE_DIR}/../assets")
-set(resource_dir "${CMAKE_BINARY_DIR}/share/clang")
+set(resource_dir "${CMAKE_BINARY_DIR}/share/clang-doc")
 set(out_files)
 
 function(copy_files_to_dst src_dir dst_dir file)
@@ -42,7 +42,7 @@ endfunction(copy_files_to_dst)
 
 foreach(f ${assets})
   install(FILES ${asset_dir}/${f}
-    DESTINATION "${CMAKE_INSTALL_DATADIR}/clang"
+    DESTINATION "${CMAKE_INSTALL_DATADIR}/clang-doc"
     COMPONENT clang-doc)
   copy_files_to_dst(${asset_dir} ${resource_dir} ${f})
 endforeach(f)

--- a/clang-tools-extra/clang-doc/tool/ClangDocMain.cpp
+++ b/clang-tools-extra/clang-doc/tool/ClangDocMain.cpp
@@ -188,7 +188,7 @@ Example usage for a project using a compile commands database:
     llvm::sys::path::native(ClangDocPath, NativeClangDocPath);
     llvm::SmallString<128> AssetsPath;
     AssetsPath = llvm::sys::path::parent_path(NativeClangDocPath);
-    llvm::sys::path::append(AssetsPath, "..", "share", "clang");
+    llvm::sys::path::append(AssetsPath, "..", "share", "clang-doc");
     llvm::SmallString<128> DefaultStylesheet;
     llvm::sys::path::native(AssetsPath, DefaultStylesheet);
     llvm::sys::path::append(DefaultStylesheet,


### PR DESCRIPTION
Updates the install path for clang-doc to share/clang-doc instead share/clang to avoid confusion