### PR TITLE
[LLDB][Minidump] Change expected directories to the correct type; size_t

### DIFF
--- a/lldb/source/Plugins/ObjectFile/Minidump/MinidumpFileBuilder.cpp
+++ b/lldb/source/Plugins/ObjectFile/Minidump/MinidumpFileBuilder.cpp
@@ -109,7 +109,7 @@ Status MinidumpFileBuilder::AddDirectory(StreamType type,
   if (m_directories.size() + 1 > m_expected_directories) {
     error.SetErrorStringWithFormat(
         "Unable to add directory for stream type %x, exceeded expected number "
-        "of directories %d.",
+        "of directories %zu.",
         (uint32_t)type, m_expected_directories);
     return error;
   }

--- a/lldb/source/Plugins/ObjectFile/Minidump/MinidumpFileBuilder.h
+++ b/lldb/source/Plugins/ObjectFile/Minidump/MinidumpFileBuilder.h
@@ -146,7 +146,7 @@ private:
   lldb_private::DataBufferHeap m_data;
   lldb::ProcessSP m_process_sp;
 
-  uint m_expected_directories = 0;
+  size_t m_expected_directories = 0;
   uint64_t m_saved_data_size = 0;
   lldb::offset_t m_thread_list_start = 0;
   // We set the max write amount to 128 mb, this is arbitrary


### PR DESCRIPTION
In #95312 I incorrectly set `m_expected_directories` to uint, this broke the windows build and is the incorrect type. 

`size_t` is more accurate because this value only ever represents the expected upper bound of the directory vector.