### PR TITLE
[SPARC][IAS] Emit the correct 32-bit ELF machine type

### DIFF
--- a/llvm/lib/Target/Sparc/MCTargetDesc/SparcAsmBackend.cpp
+++ b/llvm/lib/Target/Sparc/MCTargetDesc/SparcAsmBackend.cpp
@@ -136,10 +136,10 @@ namespace {
 
   public:
     SparcAsmBackend(const Target &T, const MCSubtargetInfo &STI)
-        : MCAsmBackend(StringRef(T.getName()) == "sparcel"
+        : MCAsmBackend(STI.getTargetTriple().isLittleEndian()
                            ? llvm::endianness::little
                            : llvm::endianness::big),
-          Is64Bit(StringRef(T.getName()) == "sparcv9"),
+          Is64Bit(STI.getTargetTriple().isArch64Bit()),
           HasV9(STI.hasFeature(Sparc::FeatureV9)) {}
 
     unsigned getNumFixupKinds() const override {

--- a/llvm/lib/Target/Sparc/MCTargetDesc/SparcAsmBackend.cpp
+++ b/llvm/lib/Target/Sparc/MCTargetDesc/SparcAsmBackend.cpp
@@ -135,7 +135,7 @@ namespace {
     bool HasV9;
 
   public:
-    SparcAsmBackend(const Target &T, const MCSubtargetInfo &STI)
+    SparcAsmBackend(const MCSubtargetInfo &STI)
         : MCAsmBackend(STI.getTargetTriple().isLittleEndian()
                            ? llvm::endianness::little
                            : llvm::endianness::big),
@@ -341,9 +341,8 @@ namespace {
   class ELFSparcAsmBackend : public SparcAsmBackend {
     Triple::OSType OSType;
   public:
-    ELFSparcAsmBackend(const Target &T, const MCSubtargetInfo &STI,
-                       Triple::OSType OSType)
-        : SparcAsmBackend(T, STI), OSType(OSType) {}
+    ELFSparcAsmBackend(const MCSubtargetInfo &STI, Triple::OSType OSType)
+        : SparcAsmBackend(STI), OSType(OSType) {}
 
     void applyFixup(const MCAssembler &Asm, const MCFixup &Fixup,
                     const MCValue &Target, MutableArrayRef<char> Data,
@@ -380,5 +379,5 @@ MCAsmBackend *llvm::createSparcAsmBackend(const Target &T,
                                           const MCSubtargetInfo &STI,
                                           const MCRegisterInfo &MRI,
                                           const MCTargetOptions &Options) {
-  return new ELFSparcAsmBackend(T, STI, STI.getTargetTriple().getOS());
+  return new ELFSparcAsmBackend(STI, STI.getTargetTriple().getOS());
 }

--- a/llvm/lib/Target/Sparc/MCTargetDesc/SparcAsmBackend.cpp
+++ b/llvm/lib/Target/Sparc/MCTargetDesc/SparcAsmBackend.cpp
@@ -131,8 +131,6 @@ static unsigned getFixupKindNumBytes(unsigned Kind) {
 namespace {
   class SparcAsmBackend : public MCAsmBackend {
   protected:
-    const Target &TheTarget;
-    const MCSubtargetInfo &TheSTI;
     bool Is64Bit;
     bool HasV9;
 
@@ -141,9 +139,8 @@ namespace {
         : MCAsmBackend(StringRef(T.getName()) == "sparcel"
                            ? llvm::endianness::little
                            : llvm::endianness::big),
-          TheTarget(T), TheSTI(STI),
-          Is64Bit(StringRef(TheTarget.getName()) == "sparcv9"),
-          HasV9(TheSTI.hasFeature(Sparc::FeatureV9)) {}
+          Is64Bit(StringRef(T.getName()) == "sparcv9"),
+          HasV9(STI.hasFeature(Sparc::FeatureV9)) {}
 
     unsigned getNumFixupKinds() const override {
       return Sparc::NumTargetFixupKinds;

--- a/llvm/lib/Target/Sparc/MCTargetDesc/SparcELFObjectWriter.cpp
+++ b/llvm/lib/Target/Sparc/MCTargetDesc/SparcELFObjectWriter.cpp
@@ -21,10 +21,12 @@ using namespace llvm;
 namespace {
   class SparcELFObjectWriter : public MCELFObjectTargetWriter {
   public:
-    SparcELFObjectWriter(bool Is64Bit, uint8_t OSABI)
-      : MCELFObjectTargetWriter(Is64Bit, OSABI,
-                                Is64Bit ?  ELF::EM_SPARCV9 : ELF::EM_SPARC,
-                                /*HasRelocationAddend*/ true) {}
+    SparcELFObjectWriter(bool Is64Bit, bool HasV9, uint8_t OSABI)
+        : MCELFObjectTargetWriter(
+              Is64Bit, OSABI,
+              Is64Bit ? ELF::EM_SPARCV9
+                      : (HasV9 ? ELF::EM_SPARC32PLUS : ELF::EM_SPARC),
+              /*HasRelocationAddend*/ true) {}
 
     ~SparcELFObjectWriter() override = default;
 
@@ -146,6 +148,6 @@ bool SparcELFObjectWriter::needsRelocateWithSymbol(const MCValue &,
 }
 
 std::unique_ptr<MCObjectTargetWriter>
-llvm::createSparcELFObjectWriter(bool Is64Bit, uint8_t OSABI) {
-  return std::make_unique<SparcELFObjectWriter>(Is64Bit, OSABI);
+llvm::createSparcELFObjectWriter(bool Is64Bit, bool HasV9, uint8_t OSABI) {
+  return std::make_unique<SparcELFObjectWriter>(Is64Bit, HasV9, OSABI);
 }

--- a/llvm/lib/Target/Sparc/MCTargetDesc/SparcMCTargetDesc.h
+++ b/llvm/lib/Target/Sparc/MCTargetDesc/SparcMCTargetDesc.h
@@ -34,8 +34,8 @@ MCCodeEmitter *createSparcMCCodeEmitter(const MCInstrInfo &MCII,
 MCAsmBackend *createSparcAsmBackend(const Target &T, const MCSubtargetInfo &STI,
                                     const MCRegisterInfo &MRI,
                                     const MCTargetOptions &Options);
-std::unique_ptr<MCObjectTargetWriter> createSparcELFObjectWriter(bool Is64Bit,
-                                                                 uint8_t OSABI);
+std::unique_ptr<MCObjectTargetWriter>
+createSparcELFObjectWriter(bool Is64Bit, bool HasV9, uint8_t OSABI);
 
 // Defines symbolic names for Sparc v9 ASI tag names.
 namespace SparcASITag {

--- a/llvm/test/MC/Sparc/elf-sparc-machine-type.s
+++ b/llvm/test/MC/Sparc/elf-sparc-machine-type.s
@@ -1,0 +1,12 @@
+## Emit correct machine type depending on triple and cpu options.
+## - `-triple sparc` emits an object of type EM_SPARC;
+## - `-triple sparc -mcpu=v9` emits EM_SPARC32PLUS; and
+## - `-triple sparcv9` emits EM_SPARCV9.
+
+# RUN: llvm-mc -filetype=obj -triple sparc            %s -o - | llvm-readobj -h - | FileCheck --check-prefixes=SPARC       %s
+# RUN: llvm-mc -filetype=obj -triple sparc   -mcpu=v9 %s -o - | llvm-readobj -h - | FileCheck --check-prefixes=SPARC32PLUS %s
+# RUN: llvm-mc -filetype=obj -triple sparcv9          %s -o - | llvm-readobj -h - | FileCheck --check-prefixes=SPARCV9     %s
+
+# SPARC:       Machine: EM_SPARC (0x2)
+# SPARC32PLUS: Machine: EM_SPARC32PLUS(0x12)
+# SPARCV9:     Machine: EM_SPARCV9 (0x2B)

--- a/llvm/test/MC/Sparc/elf-sparc-machine-type.s
+++ b/llvm/test/MC/Sparc/elf-sparc-machine-type.s
@@ -8,5 +8,5 @@
 # RUN: llvm-mc -filetype=obj -triple sparcv9          %s -o - | llvm-readobj -h - | FileCheck --check-prefixes=SPARCV9     %s
 
 # SPARC:       Machine: EM_SPARC (0x2)
-# SPARC32PLUS: Machine: EM_SPARC32PLUS(0x12)
+# SPARC32PLUS: Machine: EM_SPARC32PLUS (0x12)
 # SPARCV9:     Machine: EM_SPARCV9 (0x2B)


### PR DESCRIPTION
Emit the correct machine type when writing out 32-bit ELF objects. This patch is modeled on GCC's behavior:
- `-m32` emits an object of type EM_SPARC;
- `-m32 -mcpu=v9` emits EM_SPARC32PLUS (however, see below); and
- `-m64` emits EM_SPARCV9.

Note:
GNU as doesn't actually support user control of emitted machine type. It will always autodetect the type based on the instruction mix:
- If there's a V9 instruction inside, then use EM_SPARC32PLUS; and
- Emit EM_SPARC otherwise.

GCC simply happens to try to emit V9 instructions whenever possible with `-m32 -mcpu=v9`, so there's a high chance that the resulting object file will be of a EM_SPARC32PLUS type, however it is not a guaranteed behavior.

For this patch, I opt for deterministic behavior for simplicity.