### PR TITLE
[AMDGPU][MC] Improve error message for missing dim operand

### DIFF
--- a/llvm/lib/Target/AMDGPU/AsmParser/AMDGPUAsmParser.cpp
+++ b/llvm/lib/Target/AMDGPU/AsmParser/AMDGPUAsmParser.cpp
@@ -4009,41 +4009,18 @@ bool AMDGPUAsmParser::validateMIMGGatherDMask(const MCInst &Inst) {
 
 bool AMDGPUAsmParser::validateMIMGDim(const MCInst &Inst,
                                       const OperandVector &Operands) {
+  if (!isGFX10Plus())
+    return true;
+
   const unsigned Opc = Inst.getOpcode();
   const MCInstrDesc &Desc = MII.get(Opc);
 
   if ((Desc.TSFlags & MIMGFlags) == 0)
     return true;
 
-  if (!isGFX10Plus())
+  // image_bvh_intersect_ray instructions do not have dim
+  if (AMDGPU::getMIMGBaseOpcode(Opc)->BVH)
     return true;
-
-  switch (Opc) {
-  case IMAGE_BVH64_INTERSECT_RAY_a16_gfx12:
-  case IMAGE_BVH64_INTERSECT_RAY_a16_nsa_gfx10:
-  case IMAGE_BVH64_INTERSECT_RAY_a16_nsa_gfx11:
-  case IMAGE_BVH64_INTERSECT_RAY_a16_sa_gfx10:
-  case IMAGE_BVH64_INTERSECT_RAY_a16_sa_gfx11:
-  case IMAGE_BVH64_INTERSECT_RAY_gfx12:
-  case IMAGE_BVH64_INTERSECT_RAY_nsa_gfx10:
-  case IMAGE_BVH64_INTERSECT_RAY_nsa_gfx11:
-  case IMAGE_BVH64_INTERSECT_RAY_sa_gfx10:
-  case IMAGE_BVH64_INTERSECT_RAY_sa_gfx11:
-
-  case IMAGE_BVH_INTERSECT_RAY_a16_gfx12:
-  case IMAGE_BVH_INTERSECT_RAY_a16_nsa_gfx10:
-  case IMAGE_BVH_INTERSECT_RAY_a16_nsa_gfx11:
-  case IMAGE_BVH_INTERSECT_RAY_a16_sa_gfx10:
-  case IMAGE_BVH_INTERSECT_RAY_a16_sa_gfx11:
-  case IMAGE_BVH_INTERSECT_RAY_gfx12:
-  case IMAGE_BVH_INTERSECT_RAY_nsa_gfx10:
-  case IMAGE_BVH_INTERSECT_RAY_nsa_gfx11:
-  case IMAGE_BVH_INTERSECT_RAY_sa_gfx10:
-  case IMAGE_BVH_INTERSECT_RAY_sa_gfx11:
-    return true;
-  default:
-    break;
-  }
 
   for (unsigned i = 1, e = Operands.size(); i != e; ++i) {
     AMDGPUOperand &Op = ((AMDGPUOperand &)*Operands[i]);

--- a/llvm/lib/Target/AMDGPU/SIInstrInfo.td
+++ b/llvm/lib/Target/AMDGPU/SIInstrInfo.td
@@ -1089,6 +1089,10 @@ def exp_vm : NamedBitOperand<"vm", "ExpVM">;
 def FORMAT : CustomOperand<i8>;
 
 def DMask : NamedIntOperand<i16, "dmask">;
+
+// The second argument (Optional) makes Dim optional for the AsmMatcher.
+// This allows proper handling of the case where dim is missing. A validation
+// function would ensure dim is present when required.
 def Dim : CustomOperand<i8, 1>;
 
 def dst_sel : SDWAOperand<"dst_sel", "SDWADstSel">;

--- a/llvm/lib/Target/AMDGPU/SIInstrInfo.td
+++ b/llvm/lib/Target/AMDGPU/SIInstrInfo.td
@@ -1089,7 +1089,7 @@ def exp_vm : NamedBitOperand<"vm", "ExpVM">;
 def FORMAT : CustomOperand<i8>;
 
 def DMask : NamedIntOperand<i16, "dmask">;
-def Dim : CustomOperand<i8>;
+def Dim : CustomOperand<i8, 1>;
 
 def dst_sel : SDWAOperand<"dst_sel", "SDWADstSel">;
 def src0_sel : SDWAOperand<"src0_sel", "SDWASrc0Sel">;

--- a/llvm/lib/Target/AMDGPU/SIInstrInfo.td
+++ b/llvm/lib/Target/AMDGPU/SIInstrInfo.td
@@ -1090,10 +1090,7 @@ def FORMAT : CustomOperand<i8>;
 
 def DMask : NamedIntOperand<i16, "dmask">;
 
-// The second argument (Optional) makes Dim optional for the AsmMatcher.
-// This allows proper handling of the case where dim is missing. A validation
-// function would ensure dim is present when required.
-def Dim : CustomOperand<i8, 1>;
+def Dim : CustomOperand<i8, /*optional=*/1>;
 
 def dst_sel : SDWAOperand<"dst_sel", "SDWADstSel">;
 def src0_sel : SDWAOperand<"src0_sel", "SDWASrc0Sel">;

--- a/llvm/test/MC/AMDGPU/gfx1030_err.s
+++ b/llvm/test/MC/AMDGPU/gfx1030_err.s
@@ -207,3 +207,7 @@ image_bvh_intersect_ray v[4:7], v[9:16], s[4:7] noa16
 
 image_bvh_intersect_ray v[39:42], [v50, v46, v23, v17, v16, v15, v21, v20], s[12:15] noa16
 // GFX10: :[[@LINE-1]]:{{[0-9]+}}: error: image address size does not match a16
+
+// missing dim
+image_msaa_load v[1:4], v[5:7], s[8:15] dmask:0xf glc
+// GFX10: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand

--- a/llvm/test/MC/AMDGPU/gfx10_asm_mimg_err.s
+++ b/llvm/test/MC/AMDGPU/gfx10_asm_mimg_err.s
@@ -1,8 +1,331 @@
 // RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1010 %s 2>&1 | FileCheck --check-prefixes=NOGFX10 --implicit-check-not=error: %s
 
-// TODO: more helpful error message for missing dim operand
+image_atomic_add v5, v1, s[8:15] dmask:0x1 unorm glc
+// NOGFX10: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_atomic_and v5, v1, s[8:15] dmask:0x1 unorm glc
+// NOGFX10: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_atomic_cmpswap v[5:6], v1, s[8:15] dmask:0x3 unorm glc
+// NOGFX10: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_atomic_dec v5, v1, s[8:15] dmask:0x1 unorm glc
+// NOGFX10: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_atomic_fcmpswap v[1:2], v2, s[12:19] dmask:0x3 unorm glc
+// NOGFX10: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_atomic_fmax v4, v32, s[96:103] dmask:0x1 glc
+// NOGFX10: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_atomic_fmin v4, v32, s[96:103] dmask:0x1 glc
+// NOGFX10: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_atomic_inc v5, v1, s[8:15] dmask:0x1 unorm
+// NOGFX10: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_atomic_or v5, v1, s[8:15] dmask:0x1 unorm
+// NOGFX10: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_atomic_smax v5, v1, s[8:15] dmask:0x1 unorm
+// NOGFX10: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_atomic_smin v5, v1, s[8:15] dmask:0x1 unorm
+// NOGFX10: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_atomic_sub v5, v1, s[8:15] dmask:0x1 unorm
+// NOGFX10: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_atomic_swap v5, v1, s[8:15] dmask:0x1 unorm
+// NOGFX10: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_atomic_umax v5, v1, s[8:15] dmask:0x1 unorm
+// NOGFX10: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_atomic_umin v5, v1, s[8:15] dmask:0x1 unorm
+// NOGFX10: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_atomic_xor v5, v1, s[8:15] dmask:0x1 unorm
+// NOGFX10: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_gather4 v[5:8], v[1:2], s[8:15], s[12:15] dmask:0x1 unorm
+// NOGFX10: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_gather4_b v[5:8], v[1:3], s[8:15], s[12:15] dmask:0x1 unorm
+// NOGFX10: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_gather4_b_cl v[5:8], v[1:4], s[8:15], s[12:15] dmask:0x1 unorm
+// NOGFX10: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_gather4_b_cl_o v[5:8], v[1:8], s[8:15], s[12:15] dmask:0x1 unorm
+// NOGFX10: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_gather4_b_o v[5:8], v[1:4], s[8:15], s[12:15] dmask:0x1 unorm
+// NOGFX10: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_gather4_c v[5:8], v[1:3], s[8:15], s[12:15] dmask:0x1 unorm
+// NOGFX10: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_gather4_c_b v[5:8], v[1:4], s[8:15], s[12:15] dmask:0x1 unorm
+// NOGFX10: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_gather4_c_b_cl v[5:8], v[1:8], s[8:15], s[12:15] dmask:0x1 unorm
+// NOGFX10: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_gather4_c_b_cl_o v[5:8], v[1:8], s[8:15], s[12:15] dmask:0x1 unorm
+// NOGFX10: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_gather4_c_b_o v[5:8], v[1:8], s[8:15], s[12:15] dmask:0x1 unorm
+// NOGFX10: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_gather4_c_cl v[5:8], v[1:4], s[8:15], s[12:15] dmask:0x1 unorm
+// NOGFX10: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_gather4_c_cl_o v[5:8], v[1:8], s[8:15], s[12:15] dmask:0x1 unorm
+// NOGFX10: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_gather4_c_l v[5:8], v[1:4], s[8:15], s[12:15] dmask:0x1 unorm
+// NOGFX10: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_gather4_cl v[5:8], v[1:3], s[8:15], s[12:15] dmask:0x1 unorm
+// NOGFX10: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_gather4_c_l_o v[5:8], v[1:8], s[8:15], s[12:15] dmask:0x1 unorm
+// NOGFX10: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_gather4_cl_o v[5:8], v[1:4], s[8:15], s[12:15] dmask:0x1 unorm
+// NOGFX10: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_gather4_c_lz v[5:8], v[1:3], s[8:15], s[12:15] dmask:0x1 unorm
+// NOGFX10: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_gather4_c_lz_o v[5:8], v[1:4], s[8:15], s[12:15] dmask:0x1 unorm
+// NOGFX10: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_gather4_c_o v[5:8], v[1:4], s[8:15], s[12:15] dmask:0x1 unorm
+// NOGFX10: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_gather4h v[254:255], v[254:255], ttmp[8:15], ttmp[12:15] dmask:0x4 unorm
+// NOGFX10: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_gather4_l v[5:8], v[1:3], s[8:15], s[12:15] dmask:0x1 unorm
+// NOGFX10: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_gather4_l_o v[5:8], v[1:4], s[8:15], s[12:15] dmask:0x1 unorm
+// NOGFX10: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_gather4_lz v[5:8], v[1:2], s[8:15], s[12:15] dmask:0x1 unorm
+// NOGFX10: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_gather4_lz_o v[5:8], v[1:3], s[8:15], s[12:15] dmask:0x1 unorm
+// NOGFX10: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_gather4_o v[5:8], v[1:3], s[8:15], s[12:15] dmask:0x1 unorm
+// NOGFX10: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_get_lod v5, v1, s[8:15], s[12:15] dmask:0x1 unorm
+// NOGFX10: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_get_resinfo v5, v1, s[8:15] dmask:0x1 unorm
+// NOGFX10: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
 image_load v[0:3], v0, s[0:7] dmask:0xf unorm
-// NOGFX10: :[[@LINE-1]]:{{[0-9]+}}: error: operands are not valid for this GPU or mode
+// NOGFX10: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_load_mip v[5:6], v1, s[8:15] dmask:0x3 a16
+// NOGFX10: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_load_pck v[5:6], v1, s[8:15] dmask:0x1 tfe
+// NOGFX10: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_load_pck_sgn v5, v1, s[8:15] dmask:0x1 unorm
+// NOGFX10: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_load_mip_pck v5, v[1:2], s[8:15] dmask:0x1 unorm
+// NOGFX10: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_load_mip_pck_sgn v5, v[1:2], s[8:15] dmask:0x1 unorm
+// NOGFX10: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_sample v[5:6], v1, s[8:15], s[12:15] dmask:0x1 tfe
+// NOGFX10: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_sample_b v5, v[1:2], s[8:15], s[12:15] dmask:0x1 unorm
+// NOGFX10: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_sample_b_cl v5, v[1:3], s[8:15], s[12:15] dmask:0x1 unorm
+// NOGFX10: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_sample_b_cl_o v5, v[1:4], s[8:15], s[12:15] dmask:0x1 unorm
+// NOGFX10: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_sample_b_o v5, v[1:3], s[8:15], s[12:15] dmask:0x1 unorm
+// NOGFX10: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_sample_c v5, v[1:2], s[8:15], s[12:15] dmask:0x1 unorm
+// NOGFX10: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_sample_c_b v5, v[1:3], s[8:15], s[12:15] dmask:0x1 unorm
+// NOGFX10: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_sample_c_b_cl v5, v[1:4], s[8:15], s[12:15] dmask:0x1 unorm
+// NOGFX10: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_sample_c_b_cl_o v5, v[1:8], s[8:15], s[12:15] dmask:0x1 unorm
+// NOGFX10: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_sample_c_b_o v5, v[1:4], s[8:15], s[12:15] dmask:0x1 unorm
+// NOGFX10: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_sample_c_cd v5, v[1:4], s[8:15], s[12:15] dmask:0x1 unorm
+// NOGFX10: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_sample_c_cd_cl v5, v[1:8], s[8:15], s[12:15] dmask:0x1 unorm
+// NOGFX10: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_sample_c_cd_cl_g16 v[0:3], v[0:4], s[0:7], s[8:11] dmask:0xf
+// NOGFX10: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_sample_c_cd_cl_o v5, v[1:8], s[8:15], s[12:15] dmask:0x1 unorm
+// NOGFX10: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_sample_c_cd_cl_o_g16 v[5:6], v[1:6], s[8:15], s[12:15] dmask:0x3
+// NOGFX10: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_sample_c_cd_g16 v[5:6], v[1:4], s[8:15], s[12:15] dmask:0x3
+// NOGFX10: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_sample_c_cd_o v5, v[1:8], s[8:15], s[12:15] dmask:0x1 unorm
+// NOGFX10: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_sample_c_cd_o_g16 v[5:6], v[1:5], s[8:15], s[12:15] dmask:0x3
+// NOGFX10: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_sample_c_cl v5, v[1:3], s[8:15], s[12:15] dmask:0x1 unorm
+// NOGFX10: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_sample_c_cl_o v5, v[1:4], s[8:15], s[12:15] dmask:0x1 unorm
+// NOGFX10: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_sample_c_d v5, v[1:4], s[8:15], s[12:15] dmask:0x1 unorm
+// NOGFX10: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_sample_cd v5, v[1:3], s[8:15], s[12:15] dmask:0x1 unorm
+// NOGFX10: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_sample_c_d_cl v5, v[1:8], s[8:15], s[12:15] dmask:0x1 unorm
+// NOGFX10: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_sample_cd_cl v5, v[1:4], s[8:15], s[12:15] dmask:0x1 unorm
+// NOGFX10: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_sample_c_d_cl_g16 v[0:3], v[0:4], s[0:7], s[8:11] dmask:0xf
+// NOGFX10: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_sample_cd_cl_g16 v[0:3], v[0:3], s[0:7], s[8:11] dmask:0xf
+// NOGFX10: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_sample_c_d_cl_o v5, v[1:8], s[8:15], s[12:15] dmask:0x1 unorm
+// NOGFX10: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_sample_cd_cl_o v5, v[1:8], s[8:15], s[12:15] dmask:0x1 unorm
+// NOGFX10: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_sample_c_d_cl_o_g16 v[5:6], v[1:6], s[8:15], s[12:15] dmask:0x3
+// NOGFX10: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_sample_cd_cl_o_g16 v[5:6], v[1:5], s[8:15], s[12:15] dmask:0x3
+// NOGFX10: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_sample_c_d_g16 v[0:3], v[0:3], s[0:7], s[8:11] dmask:0xf
+// NOGFX10: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_sample_cd_g16 v[0:3], v[0:2], s[0:7], s[8:11] dmask:0xf
+// NOGFX10: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_sample_c_d_o v5, v[1:8], s[8:15], s[12:15] dmask:0x1 unorm
+// NOGFX10: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_sample_cd_o v5, v[1:4], s[8:15], s[12:15] dmask:0x1 unorm
+// NOGFX10: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_sample_c_d_o_g16 v0, [v0, v1, v2, v4, v6, v7, v8], s[0:7], s[8:11] dmask:0x4
+// NOGFX10: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_sample_cd_o_g16 v[5:6], v[1:4], s[8:15], s[12:15] dmask:0x3
+// NOGFX10: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_sample_c_l v5, v[1:3], s[8:15], s[12:15] dmask:0x1 unorm
+// NOGFX10: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_sample_cl v5, v[1:2], s[8:15], s[12:15] dmask:0x1 unorm
+// NOGFX10: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_sample_c_l_o v5, v[1:4], s[8:15], s[12:15] dmask:0x1 unorm
+// NOGFX10: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_sample_cl_o v5, v[1:3], s[8:15], s[12:15] dmask:0x1 unorm
+// NOGFX10: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_sample_c_lz v5, v[1:2], s[8:15], s[12:15] dmask:0x1 unorm
+// NOGFX10: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_sample_c_lz_o v5, v[1:3], s[8:15], s[12:15] dmask:0x1 unorm
+// NOGFX10: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_sample_c_o v5, v[1:3], s[8:15], s[12:15] dmask:0x1 unorm
+// NOGFX10: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_sample_d v5, v[1:3], s[8:15], s[12:15] dmask:0x1 unorm
+// NOGFX10: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_sample_d_cl v5, v[1:4], s[8:15], s[12:15] dmask:0x1 unorm
+// NOGFX10: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_sample_d_cl_g16 v[0:3], v[0:3], s[0:7], s[8:11] dmask:0xf
+// NOGFX10: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_sample_d_cl_o v5, v[1:8], s[8:15], s[12:15] dmask:0x1 unorm
+// NOGFX10: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_sample_d_cl_o_g16 v[5:6], v[1:5], s[8:15], s[12:15] dmask:0x3
+// NOGFX10: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_sample_d_g16 v[0:3], v[0:2], s[0:7], s[8:11] dmask:0xf
+// NOGFX10: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_sample_d_o v5, v[1:4], s[8:15], s[12:15] dmask:0x1 unorm
+// NOGFX10: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_sample_d_o_g16 v[5:6], v[1:4], s[8:15], s[12:15] dmask:0x3
+// NOGFX10: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_sample_l v5, v[1:2], s[8:15], s[12:15] dmask:0x1 unorm
+// NOGFX10: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_sample_l_o v5, v[1:3], s[8:15], s[12:15] dmask:0x1 unorm
+// NOGFX10: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_sample_lz v5, v1, s[8:15], s[12:15] dmask:0x1 unorm
+// NOGFX10: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_sample_lz_o v5, v[1:2], s[8:15], s[12:15] dmask:0x1 unorm
+// NOGFX10: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_sample_o v5, v[1:2], s[8:15], s[12:15] dmask:0x1 unorm
+// NOGFX10: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_store v1, v2, s[12:19] dmask:0x0 unorm
+// NOGFX10: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_store_mip v1, v[2:3], s[12:19] dmask:0x0 unorm
+// NOGFX10: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_store_pck v1, v[2:3], s[12:19] dmask:0x1 unorm
+// NOGFX10: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_store_mip_pck v1, v[2:3], s[12:19] dmask:0x0 unorm
+// NOGFX10: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
 
 image_load v[0:3], v0, s[0:7] dmask:0xf dim:SQ_RSRC_IMG_1D da
 // NOGFX10: :[[@LINE-1]]:{{[0-9]+}}: error: invalid operand for instruction

--- a/llvm/test/MC/AMDGPU/gfx10_err_pos.s
+++ b/llvm/test/MC/AMDGPU/gfx10_err_pos.s
@@ -4,7 +4,7 @@
 // operands are not valid for this GPU or mode
 
 image_atomic_add v252, v2, s[8:15]
-// CHECK: :[[@LINE-1]]:{{[0-9]+}}: error: operands are not valid for this GPU or mode
+// CHECK: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
 // CHECK-NEXT:{{^}}image_atomic_add v252, v2, s[8:15]
 // CHECK-NEXT:{{^}}^
 

--- a/llvm/test/MC/AMDGPU/gfx11_asm_mimg_err.s
+++ b/llvm/test/MC/AMDGPU/gfx11_asm_mimg_err.s
@@ -152,3 +152,251 @@ image_bvh_intersect_ray v[4:7], v[9:16], s[4:7] noa16
 
 image_bvh_intersect_ray v[39:42], [v50, v46, v[20:22], v[40:42]], s[12:15] noa16
 // NOGFX11: :[[@LINE-1]]:{{[0-9]+}}: error: image address size does not match a16
+
+// missing dim
+image_atomic_add v5, v1, s[8:15] dmask:0x1 unorm glc
+// NOGFX11: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_atomic_and v5, v1, s[8:15] dmask:0x1 unorm glc
+// NOGFX11: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_atomic_cmpswap v[5:6], v1, s[8:15] dmask:0x3 unorm glc
+// NOGFX11: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_atomic_dec v5, v1, s[8:15] dmask:0x1 unorm glc
+// NOGFX11: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_atomic_inc v5, v1, s[8:15] dmask:0x1 unorm
+// NOGFX11: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_atomic_or v5, v1, s[8:15] dmask:0x1 unorm
+// NOGFX11: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_atomic_smax v5, v1, s[8:15] dmask:0x1 unorm
+// NOGFX11: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_atomic_smin v5, v1, s[8:15] dmask:0x1 unorm
+// NOGFX11: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_atomic_sub v5, v1, s[8:15] dmask:0x1 unorm
+// NOGFX11: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_atomic_swap v5, v1, s[8:15] dmask:0x1 unorm
+// NOGFX11: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_atomic_umax v5, v1, s[8:15] dmask:0x1 unorm
+// NOGFX11: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_atomic_umin v5, v1, s[8:15] dmask:0x1 unorm
+// NOGFX11: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_atomic_xor v5, v1, s[8:15] dmask:0x1 unorm
+// NOGFX11: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_gather4 v[5:8], v[1:2], s[8:15], s[12:15] dmask:0x1 unorm
+// NOGFX11: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_gather4_b v[5:8], v[1:3], s[8:15], s[12:15] dmask:0x1 unorm
+// NOGFX11: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_gather4_b_cl v[5:8], v[1:4], s[8:15], s[12:15] dmask:0x1 unorm
+// NOGFX11: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_gather4_c v[5:8], v[1:3], s[8:15], s[12:15] dmask:0x1 unorm
+// NOGFX11: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_gather4_c_b v[5:8], v[1:4], s[8:15], s[12:15] dmask:0x1 unorm
+// NOGFX11: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_gather4_c_b_cl v[5:8], v[1:8], s[8:15], s[12:15] dmask:0x1 unorm
+// NOGFX11: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_gather4_c_cl v[5:8], v[1:4], s[8:15], s[12:15] dmask:0x1 unorm
+// NOGFX11: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_gather4_c_l v[5:8], v[1:4], s[8:15], s[12:15] dmask:0x1 unorm
+// NOGFX11: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_gather4_cl v[5:8], v[1:3], s[8:15], s[12:15] dmask:0x1 unorm
+// NOGFX11: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_gather4_c_lz v[5:8], v[1:3], s[8:15], s[12:15] dmask:0x1 unorm
+// NOGFX11: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_gather4_c_lz_o v[5:8], v[1:4], s[8:15], s[12:15] dmask:0x1 unorm
+// NOGFX11: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_gather4h v[254:255], v[254:255], ttmp[8:15], ttmp[12:15] dmask:0x4 unorm
+// NOGFX11: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_gather4_l v[5:8], v[1:3], s[8:15], s[12:15] dmask:0x1 unorm
+// NOGFX11: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_gather4_lz v[5:8], v[1:2], s[8:15], s[12:15] dmask:0x1 unorm
+// NOGFX11: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_gather4_lz_o v[5:8], v[1:3], s[8:15], s[12:15] dmask:0x1 unorm
+// NOGFX11: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_gather4_o v[5:8], v[1:3], s[8:15], s[12:15] dmask:0x1 unorm
+// NOGFX11: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_get_lod v5, v1, s[8:15], s[12:15] dmask:0x1 unorm
+// NOGFX11: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_get_resinfo v5, v1, s[8:15] dmask:0x1 unorm
+// NOGFX11: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_load v[0:3], v0, s[0:7] dmask:0xf unorm
+// NOGFX11: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_load_mip v[5:6], v1, s[8:15] dmask:0x3 a16
+// NOGFX11: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_load_pck v[5:6], v1, s[8:15] dmask:0x1 tfe
+// NOGFX11: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_load_pck_sgn v5, v1, s[8:15] dmask:0x1 unorm
+// NOGFX11: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_load_mip_pck v5, v[1:2], s[8:15] dmask:0x1 unorm
+// NOGFX11: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_load_mip_pck_sgn v5, v[1:2], s[8:15] dmask:0x1 unorm
+// NOGFX11: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_msaa_load v[5:7], v[1:2], s[96:103] dmask:0x4 a16 tfe d16
+// NOGFX11: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_sample v[5:6], v1, s[8:15], s[12:15] dmask:0x1 tfe
+// NOGFX11: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_sample_b v5, v[1:2], s[8:15], s[12:15] dmask:0x1 unorm
+// NOGFX11: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_sample_b_cl v5, v[1:3], s[8:15], s[12:15] dmask:0x1 unorm
+// NOGFX11: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_sample_b_cl_o v5, v[1:4], s[8:15], s[12:15] dmask:0x1 unorm
+// NOGFX11: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_sample_b_o v5, v[1:3], s[8:15], s[12:15] dmask:0x1 unorm
+// NOGFX11: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_sample_c v5, v[1:2], s[8:15], s[12:15] dmask:0x1 unorm
+// NOGFX11: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_sample_c_b v5, v[1:3], s[8:15], s[12:15] dmask:0x1 unorm
+// NOGFX11: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_sample_c_b_cl v5, v[1:4], s[8:15], s[12:15] dmask:0x1 unorm
+// NOGFX11: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_sample_c_b_cl_o v5, v[1:8], s[8:15], s[12:15] dmask:0x1 unorm
+// NOGFX11: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_sample_c_b_o v5, v[1:4], s[8:15], s[12:15] dmask:0x1 unorm
+// NOGFX11: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_sample_c_cl v5, v[1:3], s[8:15], s[12:15] dmask:0x1 unorm
+// NOGFX11: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_sample_c_cl_o v5, v[1:4], s[8:15], s[12:15] dmask:0x1 unorm
+// NOGFX11: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_sample_c_d v5, v[1:4], s[8:15], s[12:15] dmask:0x1 unorm
+// NOGFX11: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_sample_c_d_cl v5, v[1:8], s[8:15], s[12:15] dmask:0x1 unorm
+// NOGFX11: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_sample_c_d_cl_g16 v[0:3], v[0:4], s[0:7], s[8:11] dmask:0xf
+// NOGFX11: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_sample_c_d_cl_o v5, v[1:8], s[8:15], s[12:15] dmask:0x1 unorm
+// NOGFX11: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_sample_c_d_cl_o_g16 v[5:6], v[1:6], s[8:15], s[12:15] dmask:0x3
+// NOGFX11: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_sample_c_d_g16 v[0:3], v[0:3], s[0:7], s[8:11] dmask:0xf
+// NOGFX11: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_sample_c_d_o v5, v[1:8], s[8:15], s[12:15] dmask:0x1 unorm
+// NOGFX11: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_sample_c_d_o_g16 v[5:6], v[1:5], s[8:15], s[12:15] dmask:0x3
+// NOGFX11: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_sample_c_l v5, v[1:3], s[8:15], s[12:15] dmask:0x1 unorm
+// NOGFX11: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_sample_cl v5, v[1:2], s[8:15], s[12:15] dmask:0x1 unorm
+// NOGFX11: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_sample_c_l_o v5, v[1:4], s[8:15], s[12:15] dmask:0x1 unorm
+// NOGFX11: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_sample_cl_o v5, v[1:3], s[8:15], s[12:15] dmask:0x1 unorm
+// NOGFX11: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_sample_c_lz v5, v[1:2], s[8:15], s[12:15] dmask:0x1 unorm
+// NOGFX11: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_sample_c_lz_o v5, v[1:3], s[8:15], s[12:15] dmask:0x1 unorm
+// NOGFX11: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_sample_c_o v5, v[1:3], s[8:15], s[12:15] dmask:0x1 unorm
+// NOGFX11: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_sample_d v5, v[1:3], s[8:15], s[12:15] dmask:0x1 unorm
+// NOGFX11: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_sample_d_cl v5, v[1:4], s[8:15], s[12:15] dmask:0x1 unorm
+// NOGFX11: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_sample_d_cl_g16 v[0:3], v[0:3], s[0:7], s[8:11] dmask:0xf
+// NOGFX11: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_sample_d_cl_o v5, v[1:8], s[8:15], s[12:15] dmask:0x1 unorm
+// NOGFX11: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_sample_d_cl_o_g16 v[5:6], v[1:5], s[8:15], s[12:15] dmask:0x3
+// NOGFX11: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_sample_d_g16 v[0:3], v[0:2], s[0:7], s[8:11] dmask:0xf
+// NOGFX11: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_sample_d_o v5, v[1:4], s[8:15], s[12:15] dmask:0x1 unorm
+// NOGFX11: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_sample_d_o_g16 v[5:6], v[1:4], s[8:15], s[12:15] dmask:0x3
+// NOGFX11: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_sample_l v5, v[1:2], s[8:15], s[12:15] dmask:0x1 unorm
+// NOGFX11: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_sample_l_o v5, v[1:3], s[8:15], s[12:15] dmask:0x1 unorm
+// NOGFX11: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_sample_lz v5, v1, s[8:15], s[12:15] dmask:0x1 unorm
+// NOGFX11: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_sample_lz_o v5, v[1:2], s[8:15], s[12:15] dmask:0x1 unorm
+// NOGFX11: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_sample_o v5, v[1:2], s[8:15], s[12:15] dmask:0x1 unorm
+// NOGFX11: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_store v1, v2, s[12:19] dmask:0x0 unorm
+// NOGFX11: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_store_mip v1, v[2:3], s[12:19] dmask:0x0 unorm
+// NOGFX11: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_store_pck v1, v[2:3], s[12:19] dmask:0x1 unorm
+// NOGFX11: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_store_mip_pck v1, v[2:3], s[12:19] dmask:0x0 unorm
+// NOGFX11: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+

--- a/llvm/test/MC/AMDGPU/gfx12_asm_mimg_err.s
+++ b/llvm/test/MC/AMDGPU/gfx12_asm_mimg_err.s
@@ -1,0 +1,257 @@
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1200 %s 2>&1 | FileCheck --check-prefixes=NOGFX12 --implicit-check-not=error: %s
+
+// missing dim
+image_atomic_add_flt v0, v0, s[0:7] dmask:0x1
+// NOGFX12: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_atomic_add_uint v0, v0, s[0:7] dmask:0x1
+// NOGFX12: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_atomic_and v5, v1, s[8:15] dmask:0x1
+// NOGFX12: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_atomic_cmpswap v[0:1], v0, s[0:7] dmask:0x3
+// NOGFX12: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_atomic_dec_uint v0, v0, s[0:7] dmask:0x1 th:TH_ATOMIC_NT
+// NOGFX12: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_atomic_inc_uint v0, v0, s[0:7] dmask:0x1 th:TH_ATOMIC_NT
+// NOGFX12: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_atomic_max_flt v0, v0, s[0:7] dmask:0x1 th:TH_ATOMIC_NT
+// NOGFX12: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_atomic_max_int v0, v0, s[0:7] dmask:0x1 th:TH_ATOMIC_NT
+// NOGFX12: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_atomic_max_uint v0, v0, s[0:7] dmask:0x1 th:TH_ATOMIC_NT
+// NOGFX12: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_atomic_min_flt v0, v0, s[0:7] dmask:0x1 th:TH_ATOMIC_NT
+// NOGFX12: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_atomic_min_int v0, v0, s[0:7] dmask:0x1 th:TH_ATOMIC_NT
+// NOGFX12: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_atomic_min_uint v0, v0, s[0:7] dmask:0x1 th:TH_ATOMIC_NT
+// NOGFX12: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_atomic_or v0, v0, s[0:7] dmask:0x1 th:TH_ATOMIC_NT
+// NOGFX12: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_atomic_pk_add_bf16 v0, v0, s[0:7] dmask:0x1 th:TH_ATOMIC_NT
+// NOGFX12: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_atomic_pk_add_f16 v0, v0, s[0:7] dmask:0x1 th:TH_ATOMIC_NT
+// NOGFX12: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_atomic_sub_uint v0, v0, s[0:7] dmask:0x1 th:TH_ATOMIC_NT
+// NOGFX12: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_atomic_swap v0, v0, s[0:7] dmask:0x1 th:TH_ATOMIC_NT
+// NOGFX12: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_atomic_xor v0, v0, s[0:7] dmask:0x1 th:TH_ATOMIC_NT
+// NOGFX12: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_gather4 v[0:3], [v4, v5], s[0:7], s[100:103] dmask:0x8 unorm
+// NOGFX12: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_gather4_b v[64:67], [v32, v33], s[4:11], s[4:7] dmask:0x1 a16
+// NOGFX12: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_gather4_b_cl v[64:67], [v32, v33, v34], s[4:11], s[4:7] dmask:0x1 a16
+// NOGFX12: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_gather4_c v[64:67], [v32, v33], s[4:11], s[4:7] dmask:0x1 a16
+// NOGFX12: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_gather4_c_b v[64:67], [v32, v33, v34], s[4:11], s[4:7] dmask:0x1 a16
+// NOGFX12: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_gather4_c_b_cl v[64:67], [v32, v33, v34, v35], s[4:11], s[4:7] dmask:0x1 a16
+// NOGFX12: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_gather4_c_cl v[64:67], [v32, v33, v34], s[4:11], s[4:7] dmask:0x1 a16
+// NOGFX12: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_gather4_c_l v[64:67], [v32, v33, v34], s[4:11], s[4:7] dmask:0x1 a16
+// NOGFX12: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_gather4_cl v[64:67], [v32, v33, v34], s[4:11], s[4:7] dmask:0x1 a16
+// NOGFX12: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_gather4_c_lz v[64:67], [v32, v33], s[4:11], s[4:7] dmask:0x1 a16
+// NOGFX12: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_gather4_c_lz_o v[64:67], [v32, v33, v34], s[4:11], s[4:7] dmask:0x1 a16
+// NOGFX12: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_gather4h v[64:67], v32, s[4:11], s[4:7] dmask:0x8 a16
+// NOGFX12: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_gather4_l v[64:67], [v32, v33], s[4:11], s[4:7] dmask:0x1 a16
+// NOGFX12: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_gather4_lz v[64:67], v32, s[4:11], s[4:7] dmask:0x1 a16
+// NOGFX12: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_gather4_lz_o v[64:67], [v32, v33], s[4:11], s[4:7] dmask:0x1 a16
+// NOGFX12: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_get_lod v[64:67], [v32, v33, v34], s[4:11], s[100:103] dmask:0xf
+// NOGFX12: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_get_resinfo v4, v32, s[96:103] dmask:0x1 th:TH_LOAD_RT
+// NOGFX12: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_load v0, v0, s[0:7] dmask:0x1 th:TH_STORE_NT
+// NOGFX12: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_load_mip v[252:255], [v0, v1], s[0:7] dmask:0xf th:TH_LOAD_NT
+// NOGFX12: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_load_pck v5, v1, s[8:15] dmask:0x1 th:TH_LOAD_NT
+// NOGFX12: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_load_pck_sgn v5, v1, s[8:15] dmask:0x1 th:TH_LOAD_NT
+// NOGFX12: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_load_mip_pck v5, [v0, v1], s[8:15] dmask:0x1 th:TH_LOAD_NT
+// NOGFX12: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_load_mip_pck_sgn v5, [v0, v1], s[8:15] dmask:0x1 th:TH_LOAD_NT
+// NOGFX12: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_sample v[34:36], v37, s[36:43], s[64:67] dmask:0x3 tfe
+// NOGFX12: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_sample_b v64, [v32, v33], s[4:11], s[4:7] dmask:0x1
+// NOGFX12: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_sample_b_cl v64, [v32, v33, v34], s[4:11], s[4:7] dmask:0x1
+// NOGFX12: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_sample_b_cl_o v64, [v32, v33, v34, v35], s[4:11], s[4:7] dmask:0x1
+// NOGFX12: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_sample_b_o v64, [v32, v33, v34], s[4:11], s[4:7] dmask:0x1
+// NOGFX12: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_sample_c v64, [v32, v33], s[4:11], s[4:7] dmask:0x1
+// NOGFX12: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_sample_c_b v64, [v32, v33, v34], s[4:11], s[4:7] dmask:0x1
+// NOGFX12: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_sample_c_b_cl v64, [v32, v33, v34, v35], s[4:11], s[4:7] dmask:0x1
+// NOGFX12: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_sample_c_b_cl_o v64, [v32, v33, v34, v[35:36]], s[4:11], s[4:7] dmask:0x1
+// NOGFX12: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_sample_c_b_o v64, [v32, v33, v34, v35], s[4:11], s[4:7] dmask:0x1
+// NOGFX12: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_sample_c_cl v64, [v32, v33, v34], s[4:11], s[4:7] dmask:0x1
+// NOGFX12: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_sample_c_cl_o v64, [v32, v33, v34, v35], s[4:11], s[4:7] dmask:0x1
+// NOGFX12: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_sample_c_d v64, [v32, v33, v34, v35], s[4:11], s[4:7] dmask:0x1
+// NOGFX12: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_sample_c_d_cl v64, [v32, v33, v34, v[35:36]], s[4:11], s[4:7] dmask:0x1
+// NOGFX12: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_sample_c_d_cl_g16 v64, [v32, v33, v34, v[35:36]], s[4:11], s[4:7] dmask:0x1
+// NOGFX12: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_sample_c_d_cl_o v64, [v32, v33, v34, v[35:37]], s[4:11], s[4:7] dmask:0x1
+// NOGFX12: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_sample_c_d_cl_o_g16 v64, [v32, v33, v34, v[35:37]], s[4:11], s[4:7] dmask:0x1
+// NOGFX12: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_sample_c_d_g16 v64, [v32, v33, v34, v35], s[4:11], s[4:7] dmask:0x1
+// NOGFX12: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_sample_c_d_o v64, [v32, v33, v34, v[35:36]], s[4:11], s[4:7] dmask:0x1
+// NOGFX12: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_sample_c_d_o_g16 v64, [v32, v33, v34, v[35:36]], s[4:11], s[4:7] dmask:0x1
+// NOGFX12: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_sample_c_l v64, [v32, v33, v34], s[4:11], s[4:7] dmask:0x1
+// NOGFX12: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_sample_cl v64, [v32, v33], s[4:11], s[4:7] dmask:0x1
+// NOGFX12: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_sample_c_l_o v64, [v32, v33, v34, v35], s[4:11], s[4:7] dmask:0x1
+// NOGFX12: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_sample_cl_o v64, [v32, v33, v34], s[4:11], s[4:7] dmask:0x1
+// NOGFX12: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_sample_c_lz v64, [v32, v33], s[4:11], s[4:7] dmask:0x1
+// NOGFX12: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_sample_c_lz_o v64, [v32, v33, v34], s[4:11], s[4:7] dmask:0x1
+// NOGFX12: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_sample_c_o v64, [v32, v33, v34], s[4:11], s[4:7] dmask:0x1
+// NOGFX12: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_sample_d v64, [v32, v33, v34], s[4:11], s[4:7] dmask:0x1
+// NOGFX12: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_sample_d_cl v64, [v32, v33, v34, v35], s[4:11], s[4:7] dmask:0x1
+// NOGFX12: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_sample_d_cl_g16 v64, [v32, v33, v34, v35], s[4:11], s[4:7] dmask:0x1
+// NOGFX12: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_sample_d_cl_o v64, [v32, v33, v34, v[35:36]], s[4:11], s[4:7] dmask:0x1
+// NOGFX12: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_sample_d_cl_o_g16 v64, [v32, v33, v34, v[35:36]], s[4:11], s[4:7] dmask:0x1
+// NOGFX12: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_sample_d_g16 v64, [v32, v33, v34], s[4:11], s[4:7] dmask:0x1
+// NOGFX12: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_sample_d_o v64, [v32, v33, v34, v35], s[4:11], s[4:7] dmask:0x1
+// NOGFX12: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_sample_d_o_g16 v64, [v32, v33, v34, v35], s[4:11], s[4:7] dmask:0x1
+// NOGFX12: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_sample_l v64, [v32, v33], s[4:11], s[4:7] dmask:0x1
+// NOGFX12: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_sample_l_o v64, [v32, v33, v34], s[4:11], s[4:7] dmask:0x1
+// NOGFX12: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_sample_lz v64, v32, s[4:11], s[4:7] dmask:0x1
+// NOGFX12: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_sample_lz_o v64, [v32, v33], s[4:11], s[4:7] dmask:0x1
+// NOGFX12: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_sample_o v64, [v32, v33], s[4:11], s[4:7] dmask:0x1
+// NOGFX12: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_store v[0:3], v0, s[0:7] dmask:0xf a16
+// NOGFX12: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_store_mip v[252:255], [v0, v1], s[0:7] dmask:0xf th:TH_STORE_NT
+// NOGFX12: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_store_pck v5, v1, s[8:15] dmask:0x1 th:TH_STORE_NT
+// NOGFX12: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand
+
+image_store_mip_pck v5, [v0, v1], s[8:15] dmask:0x1 th:TH_STORE_NT
+// NOGFX12: :[[@LINE-1]]:{{[0-9]+}}: error: missing dim operand

--- a/llvm/test/MC/AMDGPU/gfx12_err.s
+++ b/llvm/test/MC/AMDGPU/gfx12_err.s
@@ -118,10 +118,10 @@ s_load_b128 s[20:23], s[2:3], vcc_lo th:TH_LOAD_NT_HT
 // GFX12-ERR: :[[@LINE-1]]:{{[0-9]+}}: error: invalid th value for SMEM instruction
 
 image_load v0, v0, s[0:7] dmask:0x1 dim:SQ_RSRC_IMG_1D th:TH_LOAD_HT scope:SCOPE_SE th:TH_LOAD_HT
-// GFX12-ERR: :[[@LINE-1]]:{{[0-9]+}}: error: not a valid operand
+// GFX12-ERR: :[[@LINE-1]]:{{[0-9]+}}: error: invalid operand for instruction
 
 image_load v0, v0, s[0:7] dmask:0x1 dim:SQ_RSRC_IMG_1D scope:SCOPE_SE th:TH_LOAD_HT scope:SCOPE_SE
-// GFX12-ERR: :[[@LINE-1]]:{{[0-9]+}}: error: not a valid operand
+// GFX12-ERR: :[[@LINE-1]]:{{[0-9]+}}: error: invalid operand for instruction
 
 s_prefetch_inst s[14:15], 0xffffff, m0, 7
 // GFX12-ERR: :[[@LINE-1]]:{{[0-9]+}}: error: expected a 24-bit signed offset


### PR DESCRIPTION
For GFX10+, the MIMG instrucitons generally require a dim operand. However, when dim is missing, the assembler produces the error message "operands are not valid for this GPU or mode" (See issue https://github.com/llvm/llvm-project/issues/47585). This patch fixes the issure by producing a more direct error message.