### PR TITLE
[CMake] enable CMP0144 policy if available

### DIFF
--- a/cmake/Modules/CMakePolicy.cmake
+++ b/cmake/Modules/CMakePolicy.cmake
@@ -23,3 +23,9 @@ endif()
 if(POLICY CMP0141)
   cmake_policy(SET CMP0141 NEW)
 endif()
+
+# CMP0144: find_package() uses uppercase <PackageName>_ROOT variables.
+# New in CMake 3.27: https://cmake.org/cmake/help/latest/policy/CMP0144.html
+if(POLICY CMP0144)
+  cmake_policy(SET CMP0144 NEW)
+endif()


### PR DESCRIPTION
- Enable CMP0144 policy if available, this will make the find_package() more robust.