### PR TITLE
[libc++] Get the GCC build mostly clean of warnings

### DIFF
--- a/libcxx/include/__atomic/atomic_init.h
+++ b/libcxx/include/__atomic/atomic_init.h
@@ -18,7 +18,7 @@
 #define ATOMIC_FLAG_INIT {false}
 #define ATOMIC_VAR_INIT(__v) {__v}
 
-#if _LIBCPP_STD_VER >= 20 && !defined(_LIBCPP_DISABLE_DEPRECATION_WARNINGS)
+#if _LIBCPP_STD_VER >= 20 && defined(_LIBCPP_COMPILER_CLANG_BASED) && !defined(_LIBCPP_DISABLE_DEPRECATION_WARNINGS)
 #  pragma clang deprecated(ATOMIC_VAR_INIT)
 #endif
 

--- a/libcxx/src/barrier.cpp
+++ b/libcxx/src/barrier.cpp
@@ -21,17 +21,17 @@ public:
     } __tickets[64];
   };
 
-  ptrdiff_t& __expected;
-  unique_ptr<__state_t[]> __state;
+  ptrdiff_t& __expected_;
+  unique_ptr<__state_t[]> __state_;
 
-  _LIBCPP_HIDDEN __barrier_algorithm_base(ptrdiff_t& __expected) : __expected(__expected) {
+  _LIBCPP_HIDDEN __barrier_algorithm_base(ptrdiff_t& __expected) : __expected_(__expected) {
     size_t const __count = (__expected + 1) >> 1;
-    __state              = unique_ptr<__state_t[]>(new __state_t[__count]);
+    __state_             = unique_ptr<__state_t[]>(new __state_t[__count]);
   }
   _LIBCPP_HIDDEN bool __arrive(__barrier_phase_t __old_phase) {
     __barrier_phase_t const __half_step = __old_phase + 1, __full_step = __old_phase + 2;
-    size_t __current_expected = __expected,
-           __current          = hash<thread::id>()(this_thread::get_id()) % ((__expected + 1) >> 1);
+    size_t __current_expected = __expected_,
+           __current          = hash<thread::id>()(this_thread::get_id()) % ((__expected_ + 1) >> 1);
     for (int __round = 0;; ++__round) {
       if (__current_expected <= 1)
         return true;
@@ -41,14 +41,14 @@ public:
           __current = 0;
         __barrier_phase_t expect = __old_phase;
         if (__current == __last_node && (__current_expected & 1)) {
-          if (__state[__current].__tickets[__round].__phase.compare_exchange_strong(
+          if (__state_[__current].__tickets[__round].__phase.compare_exchange_strong(
                   expect, __full_step, memory_order_acq_rel))
             break; // I'm 1 in 1, go to next __round
-        } else if (__state[__current].__tickets[__round].__phase.compare_exchange_strong(
+        } else if (__state_[__current].__tickets[__round].__phase.compare_exchange_strong(
                        expect, __half_step, memory_order_acq_rel)) {
           return false; // I'm 1 in 2, done with arrival
         } else if (expect == __half_step) {
-          if (__state[__current].__tickets[__round].__phase.compare_exchange_strong(
+          if (__state_[__current].__tickets[__round].__phase.compare_exchange_strong(
                   expect, __full_step, memory_order_acq_rel))
             break; // I'm 2 in 2, go to next __round
         }

--- a/libcxx/src/filesystem/operations.cpp
+++ b/libcxx/src/filesystem/operations.cpp
@@ -934,7 +934,7 @@ path __weakly_canonical(const path& p, error_code* ec) {
   vector<string_view_t> DNEParts;
 
   error_code m_ec;
-  while (PP.State != PathParser::PS_BeforeBegin) {
+  while (PP.State_ != PathParser::PS_BeforeBegin) {
     tmp.assign(createView(p.native().data(), &PP.RawEntry.back()));
     file_status st = __status(tmp, &m_ec);
     if (!status_known(st)) {
@@ -949,7 +949,7 @@ path __weakly_canonical(const path& p, error_code* ec) {
     DNEParts.push_back(*PP);
     --PP;
   }
-  if (PP.State == PathParser::PS_BeforeBegin) {
+  if (PP.State_ == PathParser::PS_BeforeBegin) {
     result = __canonical("", &m_ec);
     if (m_ec) {
       return err.report(m_ec);

--- a/libcxx/src/filesystem/path.cpp
+++ b/libcxx/src/filesystem/path.cpp
@@ -45,23 +45,23 @@ path& path::replace_extension(path const& replacement) {
 
 string_view_t path::__root_name() const {
   auto PP = PathParser::CreateBegin(__pn_);
-  if (PP.State == PathParser::PS_InRootName)
+  if (PP.State_ == PathParser::PS_InRootName)
     return *PP;
   return {};
 }
 
 string_view_t path::__root_directory() const {
   auto PP = PathParser::CreateBegin(__pn_);
-  if (PP.State == PathParser::PS_InRootName)
+  if (PP.State_ == PathParser::PS_InRootName)
     ++PP;
-  if (PP.State == PathParser::PS_InRootDir)
+  if (PP.State_ == PathParser::PS_InRootDir)
     return *PP;
   return {};
 }
 
 string_view_t path::__root_path_raw() const {
   auto PP = PathParser::CreateBegin(__pn_);
-  if (PP.State == PathParser::PS_InRootName) {
+  if (PP.State_ == PathParser::PS_InRootName) {
     auto NextCh = PP.peek();
     if (NextCh && isSeparator(*NextCh)) {
       ++PP;
@@ -69,24 +69,24 @@ string_view_t path::__root_path_raw() const {
     }
     return PP.RawEntry;
   }
-  if (PP.State == PathParser::PS_InRootDir)
+  if (PP.State_ == PathParser::PS_InRootDir)
     return *PP;
   return {};
 }
 
 static bool ConsumeRootName(PathParser* PP) {
   static_assert(PathParser::PS_BeforeBegin == 1 && PathParser::PS_InRootName == 2, "Values for enums are incorrect");
-  while (PP->State <= PathParser::PS_InRootName)
+  while (PP->State_ <= PathParser::PS_InRootName)
     ++(*PP);
-  return PP->State == PathParser::PS_AtEnd;
+  return PP->State_ == PathParser::PS_AtEnd;
 }
 
 static bool ConsumeRootDir(PathParser* PP) {
   static_assert(PathParser::PS_BeforeBegin == 1 && PathParser::PS_InRootName == 2 && PathParser::PS_InRootDir == 3,
                 "Values for enums are incorrect");
-  while (PP->State <= PathParser::PS_InRootDir)
+  while (PP->State_ <= PathParser::PS_InRootDir)
     ++(*PP);
-  return PP->State == PathParser::PS_AtEnd;
+  return PP->State_ == PathParser::PS_AtEnd;
 }
 
 string_view_t path::__relative_path() const {
@@ -248,7 +248,7 @@ path path::lexically_relative(const path& base) const {
     auto PP                      = PathParser::CreateBegin(__pn_);
     auto PPBase                  = PathParser::CreateBegin(base.__pn_);
     auto CheckIterMismatchAtBase = [&]() {
-      return PP.State != PPBase.State && (PP.inRootPath() || PPBase.inRootPath());
+      return PP.State_ != PPBase.State_ && (PP.inRootPath() || PPBase.inRootPath());
     };
     if (PP.inRootName() && PPBase.inRootName()) {
       if (*PP != *PPBase)
@@ -267,7 +267,7 @@ path path::lexically_relative(const path& base) const {
   // Find the first mismatching element
   auto PP     = PathParser::CreateBegin(__pn_);
   auto PPBase = PathParser::CreateBegin(base.__pn_);
-  while (PP && PPBase && PP.State == PPBase.State && *PP == *PPBase) {
+  while (PP && PPBase && PP.State_ == PPBase.State_ && *PP == *PPBase) {
     ++PP;
     ++PPBase;
   }
@@ -380,7 +380,7 @@ path::iterator path::begin() const {
   auto PP = PathParser::CreateBegin(__pn_);
   iterator it;
   it.__path_ptr_ = this;
-  it.__state_    = static_cast<path::iterator::_ParserState>(PP.State);
+  it.__state_    = static_cast<path::iterator::_ParserState>(PP.State_);
   it.__entry_    = PP.RawEntry;
   it.__stashed_elem_.__assign_view(*PP);
   return it;
@@ -396,7 +396,7 @@ path::iterator path::end() const {
 path::iterator& path::iterator::__increment() {
   PathParser PP(__path_ptr_->native(), __entry_, __state_);
   ++PP;
-  __state_ = static_cast<_ParserState>(PP.State);
+  __state_ = static_cast<_ParserState>(PP.State_);
   __entry_ = PP.RawEntry;
   __stashed_elem_.__assign_view(*PP);
   return *this;
@@ -405,7 +405,7 @@ path::iterator& path::iterator::__increment() {
 path::iterator& path::iterator::__decrement() {
   PathParser PP(__path_ptr_->native(), __entry_, __state_);
   --PP;
-  __state_ = static_cast<_ParserState>(PP.State);
+  __state_ = static_cast<_ParserState>(PP.State_);
   __entry_ = PP.RawEntry;
   __stashed_elem_.__assign_view(*PP);
   return *this;

--- a/libcxx/src/locale.cpp
+++ b/libcxx/src/locale.cpp
@@ -557,9 +557,9 @@ locale::locale(const locale& other, const locale& one, category c)
 
 string locale::name() const { return __locale_->name(); }
 
-void locale::__install_ctor(const locale& other, facet* f, long id) {
+void locale::__install_ctor(const locale& other, facet* f, long facet_id) {
   if (f)
-    __locale_ = new __imp(*other.__locale_, f, id);
+    __locale_ = new __imp(*other.__locale_, f, facet_id);
   else
     __locale_ = other.__locale_;
   __locale_->acquire();

--- a/runtimes/cmake/Modules/WarningFlags.cmake
+++ b/runtimes/cmake/Modules/WarningFlags.cmake
@@ -60,6 +60,12 @@ function(cxx_add_warning_flags target enable_werror enable_pedantic)
       -Wno-c++14-compat
       -Wno-noexcept-type
       -Wno-suggest-override
+      -Wno-alloc-size-larger-than
+      -Wno-deprecated-declarations
+      -Wno-dangling-reference
+      -Wno-strict-overflow
+      -Wno-maybe-uninitialized
+      -Wno-strict-aliasing
       )
 
   endif()


### PR DESCRIPTION
The GCC build has gotten to the point where it's often hard to find the actual error in the build log. We should look into enabling these warnings again in the future, but it looks like a lot of them are bogous.
