### PR TITLE
[clang-tidy]: Use correct term for user-provided constructor

### DIFF
--- a/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/pro-type-member-init.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/pro-type-member-init.rst
@@ -3,7 +3,7 @@
 cppcoreguidelines-pro-type-member-init
 ======================================
 
-The check flags user-defined constructor definitions that do not
+The check flags user-provided constructor definitions that do not
 initialize all fields that would be left in an undefined state by
 default construction, e.g. builtins, pointers and record types without
 user-provided default constructors containing at least one such

--- a/clang-tools-extra/test/clang-tidy/checkers/cppcoreguidelines/pro-type-member-init.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/cppcoreguidelines/pro-type-member-init.cpp
@@ -243,7 +243,7 @@ struct PositiveUninitializedBaseOrdering : public NegativeAggregateType,
 };
 
 // We shouldn't need to initialize anything because PositiveUninitializedBase
-// has a user-defined constructor.
+// has a user-provided constructor.
 struct NegativeUninitializedBase : public PositiveUninitializedBase {
   NegativeUninitializedBase() {}
 };


### PR DESCRIPTION
First of all, fix a confusion in the documentation for pro-type-member-init which used the wrong term for a user-provided constructor. (In the corresponding comment in ProTypeMemberInitCheck.h, which was added in the same commit that added this documentation, we already use the correct term).

Second, also fix a comment in the corresponding test that had the same mistake.

https://timsong-cpp.github.io/cppwp/std23/dcl.fct.def.default#5:

> A function is user-provided if it is user-declared and not explicitly
> defaulted or deleted on its first declaration.

("user-defined constructor" is not a thing in the standard)