### PR TITLE
[SLP] Use poison instead of undef in reorderScalars()

### DIFF
--- a/llvm/lib/Transforms/Vectorize/SLPVectorizer.cpp
+++ b/llvm/lib/Transforms/Vectorize/SLPVectorizer.cpp
@@ -999,7 +999,7 @@ static void reorderScalars(SmallVectorImpl<Value *> &Scalars,
                            ArrayRef<int> Mask) {
   assert(!Mask.empty() && "Expected non-empty mask.");
   SmallVector<Value *> Prev(Scalars.size(),
-                            UndefValue::get(Scalars.front()->getType()));
+                            PoisonValue::get(Scalars.front()->getType()));
   Prev.swap(Scalars);
   for (unsigned I = 0, E = Prev.size(); I < E; ++I)
     if (Mask[I] != PoisonMaskElem)


### PR DESCRIPTION
-1 mask elements are specified to return poison rather than undef nowadays , so update the reorderScalars() implementation to match.

This doesn't cause any actual test changes. Putting up a PR for this just in case there is some SLP-specific divergence I'm not aware of.