### PR TITLE
Reject half vector types without cl_khr_fp16

### DIFF
--- a/clang/lib/Sema/SemaDecl.cpp
+++ b/clang/lib/Sema/SemaDecl.cpp
@@ -7448,9 +7448,15 @@ static bool diagnoseOpenCLTypes(Sema &Se, VarDecl *NewVD) {
 
   if (!Se.getOpenCLOptions().isAvailableOption("cl_khr_fp16",
                                                Se.getLangOpts())) {
-    // OpenCL v1.2 s6.1.1.1: reject declaring variables of the half and
-    // half array type (unless the cl_khr_fp16 extension is enabled).
-    if (Se.Context.getBaseElementType(R)->isHalfType()) {
+    // OpenCL v1.2 s6.1.1.1: reject declaring variables of the half/halfn and
+    // half/halfn array type (unless the cl_khr_fp16 extension is enabled).
+    auto HasHalfTy = [](QualType T) {
+      if (const auto *EVTy = T->getAs<ExtVectorType>()) {
+        return EVTy->getElementType()->isHalfType();
+      }
+      return T->isHalfType();
+    };
+    if (HasHalfTy(R) || HasHalfTy(Se.Context.getBaseElementType(R))) {
       Se.Diag(NewVD->getLocation(), diag::err_opencl_half_declaration) << R;
       NewVD->setInvalidDecl();
       return false;

--- a/clang/test/SemaOpenCL/half.cl
+++ b/clang/test/SemaOpenCL/half.cl
@@ -23,6 +23,8 @@ half half_disabled(half *p, // expected-error{{declaring function return value o
   half *allowed3 = p + 1;
 
 #ifdef HAVE_BUILTINS
+  half2 h2; // expected-error{{declaring variable of type '__private half2' (vector of 2 'half' values) is not allowed}}
+  half4 h4a[2]; // expected-error{{declaring variable of type '__private half4[2]' is not allowed}}
   (void)ilogb(*p); // expected-error{{loading directly from pointer to type '__private half' requires cl_khr_fp16. Use vector data load builtin functions instead}}
   vstore_half(42.0f, 0, p);
 #endif
@@ -55,6 +57,8 @@ half half_enabled(half *p, half h)
   half *allowed3 = p + 1;
 
 #ifdef HAVE_BUILTINS
+  half2 h2;
+  half4 h4a[2];
   (void)ilogb(*p);
   vstore_half(42.0f, 0, p);
 #endif


### PR DESCRIPTION
Reject `half` vector types (`halfn`) if the `cl_khr_fp16` extension is disabled, in line with the already existing rejection of `half` scalar types and `half` array types.