### PR TITLE
[flang] Handle BOZ as right-hand side of assignment

### DIFF
--- a/flang/test/Semantics/boz-literal-constants.f90
+++ b/flang/test/Semantics/boz-literal-constants.f90
@@ -7,7 +7,12 @@ subroutine bozchecks
   integer :: f, realpart = B"0101", img = B"1111", resint
   logical :: resbit
   complex :: rescmplx
+  character :: reschar
   real :: dbl, e
+  type :: dt
+    integer :: n
+  end type
+  type(dt) :: resdt
   interface
     subroutine explicit(n, x, c)
       integer :: n
@@ -97,6 +102,17 @@ subroutine bozchecks
   res = KIND(z'feedface')
 
   res = REAL(B"1101")
+
+  resint = z'ff' ! ok
+  res = z'3f800000' ! ok
+  !ERROR: Right-hand side of this assignment may not be BOZ
+  rescmplx = z'123'
+  !ERROR: Right-hand side of this assignment may not be BOZ
+  resbit = z'123'
+  !ERROR: Right-hand side of this assignment may not be BOZ
+  reschar = z'123'
+  !ERROR: Right-hand side of this assignment may not be BOZ
+  resdt = z'123'
 
   !Ok
   call explicit(z'deadbeef', o'666', 'a')


### PR DESCRIPTION
F'2023 allows BOZ to appear in more contexts, including the common extension of the right-hand side of an assignment to an INTEGER or REAL variable.  Implement that one case now.