### PR TITLE
[flang] Fix BoxAnalyzer.h for LLVM_ENABLE_EXPENSIVE_CHECKS

### DIFF
--- a/flang/include/flang/Lower/BoxAnalyzer.h
+++ b/flang/include/flang/Lower/BoxAnalyzer.h
@@ -97,7 +97,7 @@ struct ScalarDynamicDerived : ScalarSym {
       : ScalarSym{sym}, lens{std::move(lens)} {}
 
 private:
-  llvm::SmallVector<Fortran::lower::SomeExpr> lens;
+  llvm::SmallVector<Fortran::lower::SomeExpr, 1> lens;
 };
 
 struct LBoundsAndShape {


### PR DESCRIPTION
Fixes assert seen trying to use default number of inlined elements for `SmallVector<T>` but `sizeof(T)` is really big. Seen with -DLLVM_ENABLE_EXPENSIVE_CHECKS.