### PR TITLE
XFAIL llvm/test/DebugInfo/attr-btf_type_tag.ll on AIX

### DIFF
--- a/llvm/test/DebugInfo/attr-btf_type_tag.ll
+++ b/llvm/test/DebugInfo/attr-btf_type_tag.ll
@@ -1,3 +1,4 @@
+; XFAIL: target={{.*}}-aix{{.*}}
 ; REQUIRES: object-emission
 ; RUN: llc -filetype=obj -o %t %s
 ; RUN: llvm-dwarfdump -debug-info %t | FileCheck %s


### PR DESCRIPTION
This PR XFAILS `llvm/test/DebugInfo/attr-btf_type_tag.ll` on AIX since we we don’t have `.debug_addr` section.