### PR TITLE
Fix test assertions in TestDAP_stepInTargets.py

### DIFF
--- a/lldb/test/API/tools/lldb-dap/stepInTargets/TestDAP_stepInTargets.py
+++ b/lldb/test/API/tools/lldb-dap/stepInTargets/TestDAP_stepInTargets.py
@@ -55,14 +55,24 @@ class TestDAP_stepInTargets(lldbdap_testcase.DAPTestCaseBase):
         self.assertEqual(len(step_in_targets), 3, "expect 3 step in targets")
 
         # Verify the target names are correct.
-        self.assertEqual(step_in_targets[0]["label"], "bar()", "expect bar()")
-        self.assertEqual(step_in_targets[1]["label"], "bar2()", "expect bar2()")
-        self.assertEqual(
-            step_in_targets[2]["label"], "foo(int, int)", "expect foo(int, int)"
-        )
+        # The order of funcA and funcB may change depending on the compiler ABI.
+        funcA_target = None
+        funcB_target = None
+        for target in step_in_targets[0:2]:
+            if "funcB" in target["label"]:
+                funcB_target = target
+            elif "funcA" in target["label"]:
+                funcA_target = target
+            else:
+                self.fail(f"Unexpected step in target: {target}")
 
-        # Choose to step into second target and verify that we are in bar2()
+        self.assertIsNotNone(funcA_target, "expect funcA")
+        self.assertIsNotNone(funcB_target, "expect funcB")
+        self.assertIn("foo", step_in_targets[2]["label"], "expect foo")
+
+        # Choose to step into second target and verify that we are in the second target,
+        # be it funcA or funcB.
         self.stepIn(threadId=tid, targetId=step_in_targets[1]["id"], waitForStop=True)
         leaf_frame = self.dap_server.get_stackFrame()
         self.assertIsNotNone(leaf_frame, "expect a leaf frame")
-        self.assertEqual(leaf_frame["name"], "bar2()")
+        self.assertEqual(step_in_targets[1]["label"], leaf_frame["name"])

--- a/lldb/test/API/tools/lldb-dap/stepInTargets/TestDAP_stepInTargets.py
+++ b/lldb/test/API/tools/lldb-dap/stepInTargets/TestDAP_stepInTargets.py
@@ -10,9 +10,11 @@ from lldbsuite.test import lldbutil
 
 
 class TestDAP_stepInTargets(lldbdap_testcase.DAPTestCaseBase):
-    @skipIf(
-        archs=no_match(["x86_64"])
-    )  # InstructionControlFlowKind for ARM is not supported yet.
+    @expectedFailureAll(oslist=["windows"])
+    @skipIf(archs=no_match(["x86_64"]))
+    # InstructionControlFlowKind for ARM is not supported yet.
+    # On Windows, lldb-dap seems to ignore targetId when stepping into functions.
+    # For more context, see https://github.com/llvm/llvm-project/issues/98509.
     def test_basic(self):
         """
         Tests the basic stepping in targets with directly calls.

--- a/lldb/test/API/tools/lldb-dap/stepInTargets/main.cpp
+++ b/lldb/test/API/tools/lldb-dap/stepInTargets/main.cpp
@@ -1,11 +1,11 @@
 
 int foo(int val, int extra) { return val + extra; }
 
-int bar() { return 22; }
+int funcA() { return 22; }
 
-int bar2() { return 54; }
+int funcB() { return 54; }
 
 int main(int argc, char const *argv[]) {
-  foo(bar(), bar2()); // set breakpoint here
+  foo(funcA(), funcB()); // set breakpoint here
   return 0;
 }


### PR DESCRIPTION
The strings this test is using seem to consistently fail to match against the expected values when built & run targeting Windows amd64. This PR updates them to the expected values.

To fix the test and avoid over-specifying for a specific platform, use `assertIn(<target-substring>,...)` to see if we've got the correct target label instead of comparing the demangler output for an exact string match.