### PR TITLE
[RISCV][GISel] Add missing fclass tests. NFC

### DIFF
--- a/llvm/test/CodeGen/RISCV/GlobalISel/instruction-select/is-fpclass-rv32.mir
+++ b/llvm/test/CodeGen/RISCV/GlobalISel/instruction-select/is-fpclass-rv32.mir
@@ -80,3 +80,81 @@ body:             |
     $x10 = COPY %7(s32)
     PseudoRET implicit $x10
 ...
+---
+name:            is_fpclass_f64
+legalized:       true
+regBankSelected: true
+body:             |
+  bb.0:
+    liveins: $f10_d
+
+    ; CHECK-LABEL: name: is_fpclass_f64
+    ; CHECK: liveins: $f10_d
+    ; CHECK-NEXT: {{  $}}
+    ; CHECK-NEXT: [[COPY:%[0-9]+]]:fpr64 = COPY $f10_d
+    ; CHECK-NEXT: [[FCLASS_D:%[0-9]+]]:gpr = FCLASS_D [[COPY]]
+    ; CHECK-NEXT: [[ANDI:%[0-9]+]]:gpr = ANDI [[FCLASS_D]], 152
+    ; CHECK-NEXT: [[SLTU:%[0-9]+]]:gpr = SLTU $x0, [[ANDI]]
+    ; CHECK-NEXT: $x10 = COPY [[SLTU]]
+    ; CHECK-NEXT: PseudoRET implicit $x10
+    %0:fprb(s64) = COPY $f10_d
+    %3:gprb(s32) = G_CONSTANT i32 152
+    %4:gprb(s32) = G_CONSTANT i32 0
+    %5:gprb(s32) = G_FCLASS %0(s64)
+    %6:gprb(s32) = G_AND %5, %3
+    %7:gprb(s32) = G_ICMP intpred(ne), %6(s32), %4
+    $x10 = COPY %7(s32)
+    PseudoRET implicit $x10
+...
+---
+name:            is_fpclass_f64_onehot
+legalized:       true
+regBankSelected: true
+body:             |
+  bb.0:
+    liveins: $f10_d
+
+    ; CHECK-LABEL: name: is_fpclass_f64_onehot
+    ; CHECK: liveins: $f10_d
+    ; CHECK-NEXT: {{  $}}
+    ; CHECK-NEXT: [[COPY:%[0-9]+]]:fpr64 = COPY $f10_d
+    ; CHECK-NEXT: [[FCLASS_D:%[0-9]+]]:gpr = FCLASS_D [[COPY]]
+    ; CHECK-NEXT: [[ANDI:%[0-9]+]]:gpr = ANDI [[FCLASS_D]], 256
+    ; CHECK-NEXT: [[SLTU:%[0-9]+]]:gpr = SLTU $x0, [[ANDI]]
+    ; CHECK-NEXT: $x10 = COPY [[SLTU]]
+    ; CHECK-NEXT: PseudoRET implicit $x10
+    %0:fprb(s64) = COPY $f10_d
+    %3:gprb(s32) = G_CONSTANT i32 256
+    %4:gprb(s32) = G_CONSTANT i32 0
+    %5:gprb(s32) = G_FCLASS %0(s64)
+    %6:gprb(s32) = G_AND %5, %3
+    %7:gprb(s32) = G_ICMP intpred(ne), %6(s32), %4
+    $x10 = COPY %7(s32)
+    PseudoRET implicit $x10
+...
+---
+name:            is_fpclass_f64_one
+legalized:       true
+regBankSelected: true
+body:             |
+  bb.0:
+    liveins: $f10_d
+
+    ; CHECK-LABEL: name: is_fpclass_f64_one
+    ; CHECK: liveins: $f10_d
+    ; CHECK-NEXT: {{  $}}
+    ; CHECK-NEXT: [[COPY:%[0-9]+]]:fpr64 = COPY $f10_d
+    ; CHECK-NEXT: [[FCLASS_D:%[0-9]+]]:gpr = FCLASS_D [[COPY]]
+    ; CHECK-NEXT: [[ANDI:%[0-9]+]]:gpr = ANDI [[FCLASS_D]], 1
+    ; CHECK-NEXT: [[SLTU:%[0-9]+]]:gpr = SLTU $x0, [[ANDI]]
+    ; CHECK-NEXT: $x10 = COPY [[SLTU]]
+    ; CHECK-NEXT: PseudoRET implicit $x10
+    %0:fprb(s64) = COPY $f10_d
+    %3:gprb(s32) = G_CONSTANT i32 1
+    %4:gprb(s32) = G_CONSTANT i32 0
+    %5:gprb(s32) = G_FCLASS %0(s64)
+    %6:gprb(s32) = G_AND %5, %3
+    %7:gprb(s32) = G_ICMP intpred(ne), %6(s32), %4
+    $x10 = COPY %7(s32)
+    PseudoRET implicit $x10
+...

--- a/llvm/test/CodeGen/RISCV/GlobalISel/instruction-select/is-fpclass-rv64.mir
+++ b/llvm/test/CodeGen/RISCV/GlobalISel/instruction-select/is-fpclass-rv64.mir
@@ -3,6 +3,84 @@
 # RUN: FileCheck %s
 
 ---
+name:            is_fpclass_f32
+legalized:       true
+regBankSelected: true
+body:             |
+  bb.0:
+    liveins: $f10_f
+
+    ; CHECK-LABEL: name: is_fpclass_f32
+    ; CHECK: liveins: $f10_f
+    ; CHECK-NEXT: {{  $}}
+    ; CHECK-NEXT: [[COPY:%[0-9]+]]:fpr32 = COPY $f10_f
+    ; CHECK-NEXT: [[FCLASS_S:%[0-9]+]]:gpr = FCLASS_S [[COPY]]
+    ; CHECK-NEXT: [[ANDI:%[0-9]+]]:gpr = ANDI [[FCLASS_S]], 152
+    ; CHECK-NEXT: [[SLTU:%[0-9]+]]:gpr = SLTU $x0, [[ANDI]]
+    ; CHECK-NEXT: $x10 = COPY [[SLTU]]
+    ; CHECK-NEXT: PseudoRET implicit $x10
+    %0:fprb(s32) = COPY $f10_f
+    %3:gprb(s64) = G_CONSTANT i64 152
+    %4:gprb(s64) = G_CONSTANT i64 0
+    %5:gprb(s64) = G_FCLASS %0(s32)
+    %6:gprb(s64) = G_AND %5, %3
+    %7:gprb(s64) = G_ICMP intpred(ne), %6(s64), %4
+    $x10 = COPY %7(s64)
+    PseudoRET implicit $x10
+...
+---
+name:            is_fpclass_f32_onehot
+legalized:       true
+regBankSelected: true
+body:             |
+  bb.0:
+    liveins: $f10_f
+
+    ; CHECK-LABEL: name: is_fpclass_f32_onehot
+    ; CHECK: liveins: $f10_f
+    ; CHECK-NEXT: {{  $}}
+    ; CHECK-NEXT: [[COPY:%[0-9]+]]:fpr32 = COPY $f10_f
+    ; CHECK-NEXT: [[FCLASS_S:%[0-9]+]]:gpr = FCLASS_S [[COPY]]
+    ; CHECK-NEXT: [[ANDI:%[0-9]+]]:gpr = ANDI [[FCLASS_S]], 256
+    ; CHECK-NEXT: [[SLTU:%[0-9]+]]:gpr = SLTU $x0, [[ANDI]]
+    ; CHECK-NEXT: $x10 = COPY [[SLTU]]
+    ; CHECK-NEXT: PseudoRET implicit $x10
+    %0:fprb(s32) = COPY $f10_f
+    %3:gprb(s64) = G_CONSTANT i64 256
+    %4:gprb(s64) = G_CONSTANT i64 0
+    %5:gprb(s64) = G_FCLASS %0(s32)
+    %6:gprb(s64) = G_AND %5, %3
+    %7:gprb(s64) = G_ICMP intpred(ne), %6(s64), %4
+    $x10 = COPY %7(s64)
+    PseudoRET implicit $x10
+...
+---
+name:            is_fpclass_f32_one
+legalized:       true
+regBankSelected: true
+body:             |
+  bb.0:
+    liveins: $f10_f
+
+    ; CHECK-LABEL: name: is_fpclass_f32_one
+    ; CHECK: liveins: $f10_f
+    ; CHECK-NEXT: {{  $}}
+    ; CHECK-NEXT: [[COPY:%[0-9]+]]:fpr32 = COPY $f10_f
+    ; CHECK-NEXT: [[FCLASS_S:%[0-9]+]]:gpr = FCLASS_S [[COPY]]
+    ; CHECK-NEXT: [[ANDI:%[0-9]+]]:gpr = ANDI [[FCLASS_S]], 1
+    ; CHECK-NEXT: [[SLTU:%[0-9]+]]:gpr = SLTU $x0, [[ANDI]]
+    ; CHECK-NEXT: $x10 = COPY [[SLTU]]
+    ; CHECK-NEXT: PseudoRET implicit $x10
+    %0:fprb(s32) = COPY $f10_f
+    %3:gprb(s64) = G_CONSTANT i64 1
+    %4:gprb(s64) = G_CONSTANT i64 0
+    %5:gprb(s64) = G_FCLASS %0(s32)
+    %6:gprb(s64) = G_AND %5, %3
+    %7:gprb(s64) = G_ICMP intpred(ne), %6(s64), %4
+    $x10 = COPY %7(s64)
+    PseudoRET implicit $x10
+...
+---
 name:            is_fpclass_f64
 legalized:       true
 regBankSelected: true

--- a/llvm/test/CodeGen/RISCV/GlobalISel/legalizer/legalize-is-fpclass-rv32.mir
+++ b/llvm/test/CodeGen/RISCV/GlobalISel/legalizer/legalize-is-fpclass-rv32.mir
@@ -26,3 +26,27 @@ body:             |
     PseudoRET implicit $x10
 
 ...
+---
+name:            is_fpclass_f64
+body:             |
+  bb.1:
+    liveins: $f10_d
+
+    ; CHECK-LABEL: name: is_fpclass_f64
+    ; CHECK: liveins: $f10_d
+    ; CHECK-NEXT: {{  $}}
+    ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(s64) = COPY $f10_d
+    ; CHECK-NEXT: [[C:%[0-9]+]]:_(s32) = G_CONSTANT i32 152
+    ; CHECK-NEXT: [[C1:%[0-9]+]]:_(s32) = G_CONSTANT i32 0
+    ; CHECK-NEXT: [[FCLASS:%[0-9]+]]:_(s32) = G_FCLASS [[COPY]](s64)
+    ; CHECK-NEXT: [[AND:%[0-9]+]]:_(s32) = G_AND [[FCLASS]], [[C]]
+    ; CHECK-NEXT: [[ICMP:%[0-9]+]]:_(s32) = G_ICMP intpred(ne), [[AND]](s32), [[C1]]
+    ; CHECK-NEXT: $x10 = COPY [[ICMP]](s32)
+    ; CHECK-NEXT: PseudoRET implicit $x10
+    %0:_(s64) = COPY $f10_d
+    %1:_(s1) = G_IS_FPCLASS %0(s64), 608
+    %2:_(s32) = G_ANYEXT %1(s1)
+    $x10 = COPY %2(s32)
+    PseudoRET implicit $x10
+
+...

--- a/llvm/test/CodeGen/RISCV/GlobalISel/legalizer/legalize-is-fpclass-rv64.mir
+++ b/llvm/test/CodeGen/RISCV/GlobalISel/legalizer/legalize-is-fpclass-rv64.mir
@@ -3,6 +3,30 @@
 # RUN: | FileCheck %s
 
 ---
+name:            is_fpclass_f32
+body:             |
+  bb.1:
+    liveins: $f10_f
+
+    ; CHECK-LABEL: name: is_fpclass_f32
+    ; CHECK: liveins: $f10_f
+    ; CHECK-NEXT: {{  $}}
+    ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(s32) = COPY $f10_f
+    ; CHECK-NEXT: [[C:%[0-9]+]]:_(s64) = G_CONSTANT i64 152
+    ; CHECK-NEXT: [[C1:%[0-9]+]]:_(s64) = G_CONSTANT i64 0
+    ; CHECK-NEXT: [[FCLASS:%[0-9]+]]:_(s64) = G_FCLASS [[COPY]](s32)
+    ; CHECK-NEXT: [[AND:%[0-9]+]]:_(s64) = G_AND [[FCLASS]], [[C]]
+    ; CHECK-NEXT: [[ICMP:%[0-9]+]]:_(s64) = G_ICMP intpred(ne), [[AND]](s64), [[C1]]
+    ; CHECK-NEXT: $x10 = COPY [[ICMP]](s64)
+    ; CHECK-NEXT: PseudoRET implicit $x10
+    %0:_(s32) = COPY $f10_f
+    %1:_(s1) = G_IS_FPCLASS %0(s32), 608
+    %2:_(s64) = G_ANYEXT %1(s1)
+    $x10 = COPY %2(s64)
+    PseudoRET implicit $x10
+
+...
+---
 name:            is_fpclass_f64
 body:             |
   bb.1:

--- a/llvm/test/CodeGen/RISCV/GlobalISel/regbankselect/is-fpclass-rv32.mir
+++ b/llvm/test/CodeGen/RISCV/GlobalISel/regbankselect/is-fpclass-rv32.mir
@@ -29,3 +29,30 @@ body:             |
     $x10 = COPY %7(s32)
     PseudoRET implicit $x10
 ...
+---
+name:            is_fpclass_f64
+legalized:       true
+body:             |
+  bb.0:
+    liveins: $f10_d
+
+    ; CHECK-LABEL: name: is_fpclass_f64
+    ; CHECK: liveins: $f10_d
+    ; CHECK-NEXT: {{  $}}
+    ; CHECK-NEXT: [[COPY:%[0-9]+]]:fprb(s64) = COPY $f10_d
+    ; CHECK-NEXT: [[C:%[0-9]+]]:gprb(s32) = G_CONSTANT i32 152
+    ; CHECK-NEXT: [[C1:%[0-9]+]]:gprb(s32) = G_CONSTANT i32 0
+    ; CHECK-NEXT: [[FCLASS:%[0-9]+]]:gprb(s32) = G_FCLASS [[COPY]](s64)
+    ; CHECK-NEXT: [[AND:%[0-9]+]]:gprb(s32) = G_AND [[FCLASS]], [[C]]
+    ; CHECK-NEXT: [[ICMP:%[0-9]+]]:gprb(s32) = G_ICMP intpred(ne), [[AND]](s32), [[C1]]
+    ; CHECK-NEXT: $x10 = COPY [[ICMP]](s32)
+    ; CHECK-NEXT: PseudoRET implicit $x10
+    %0:_(s64) = COPY $f10_d
+    %3:_(s32) = G_CONSTANT i32 152
+    %4:_(s32) = G_CONSTANT i32 0
+    %5:_(s32) = G_FCLASS %0(s64)
+    %6:_(s32) = G_AND %5, %3
+    %7:_(s32) = G_ICMP intpred(ne), %6(s32), %4
+    $x10 = COPY %7(s32)
+    PseudoRET implicit $x10
+...

--- a/llvm/test/CodeGen/RISCV/GlobalISel/regbankselect/is-fpclass-rv64.mir
+++ b/llvm/test/CodeGen/RISCV/GlobalISel/regbankselect/is-fpclass-rv64.mir
@@ -3,6 +3,33 @@
 # RUN: | FileCheck %s
 
 ---
+name:            is_fpclass_f32
+legalized:       true
+body:             |
+  bb.0:
+    liveins: $f10_f
+
+    ; CHECK-LABEL: name: is_fpclass_f32
+    ; CHECK: liveins: $f10_f
+    ; CHECK-NEXT: {{  $}}
+    ; CHECK-NEXT: [[COPY:%[0-9]+]]:fprb(s32) = COPY $f10_f
+    ; CHECK-NEXT: [[C:%[0-9]+]]:gprb(s64) = G_CONSTANT i64 152
+    ; CHECK-NEXT: [[C1:%[0-9]+]]:gprb(s64) = G_CONSTANT i64 0
+    ; CHECK-NEXT: [[FCLASS:%[0-9]+]]:gprb(s64) = G_FCLASS [[COPY]](s32)
+    ; CHECK-NEXT: [[AND:%[0-9]+]]:gprb(s64) = G_AND [[FCLASS]], [[C]]
+    ; CHECK-NEXT: [[ICMP:%[0-9]+]]:gprb(s64) = G_ICMP intpred(ne), [[AND]](s64), [[C1]]
+    ; CHECK-NEXT: $x10 = COPY [[ICMP]](s64)
+    ; CHECK-NEXT: PseudoRET implicit $x10
+    %0:_(s32) = COPY $f10_f
+    %3:_(s64) = G_CONSTANT i64 152
+    %4:_(s64) = G_CONSTANT i64 0
+    %5:_(s64) = G_FCLASS %0(s32)
+    %6:_(s64) = G_AND %5, %3
+    %7:_(s64) = G_ICMP intpred(ne), %6(s64), %4
+    $x10 = COPY %7(s64)
+    PseudoRET implicit $x10
+...
+---
 name:            is_fpclass_f64
 legalized:       true
 body:             |


### PR DESCRIPTION
We were only testing f32 on rv32 and f64 on rv64. We need to test f32 and f64 on both rv32 and rv64.