### PR TITLE
[DirectX] Add stub PSV0 section

### DIFF
--- a/llvm/include/llvm/MC/DXContainerPSVInfo.h
+++ b/llvm/include/llvm/MC/DXContainerPSVInfo.h
@@ -47,7 +47,9 @@ struct PSVSignatureElement {
 // modifiable format, and can be used to serialize the data back into valid PSV
 // RuntimeInfo.
 struct PSVRuntimeInfo {
-  PSVRuntimeInfo() : DXConStrTabBuilder(StringTableBuilder::DXContainer) {}
+  PSVRuntimeInfo() : DXConStrTabBuilder(StringTableBuilder::DXContainer) {
+    memset((void *)&BaseData, 0, sizeof(dxbc::PSV::v3::RuntimeInfo));
+  }
   bool IsFinalized = false;
   dxbc::PSV::v3::RuntimeInfo BaseData;
   SmallVector<dxbc::PSV::v2::ResourceBindInfo> Resources;

--- a/llvm/test/CodeGen/DirectX/ContainerData/PipelineStateValidation.ll
+++ b/llvm/test/CodeGen/DirectX/ContainerData/PipelineStateValidation.ll
@@ -1,0 +1,41 @@
+; RUN: opt %s -dxil-embed -dxil-globals -S -o - | FileCheck %s
+; RUN: llc %s --filetype=obj -o - | obj2yaml | FileCheck %s --check-prefix=DXC
+target triple = "dxil-unknown-shadermodel6.0-compute"
+
+; CHECK: @dx.psv0 = private constant  [76 x i8] c"{{.*}}", section "PSV0", align 4
+
+define void @main() #0 {
+entry:
+  ret void
+}
+
+attributes #0 = { "hlsl.numthreads"="1,1,1" "hlsl.shader"="compute" }
+
+!dx.valver = !{!0}
+
+!0 = !{i32 1, i32 7}
+
+; DXC: - Name:            PSV0
+; DXC:     Size:            76
+; DXC:     PSVInfo:
+; DXC:       Version:         3
+; DXC:       ShaderStage:     5
+; DXC:       MinimumWaveLaneCount: 0
+; DXC:       MaximumWaveLaneCount: 4294967295
+; DXC:       UsesViewID:      0
+; DXC:       SigInputVectors: 0
+; DXC:       SigOutputVectors: [ 0, 0, 0, 0 ]
+; DXC:       NumThreadsX:     1
+; DXC:       NumThreadsY:     1
+; DXC:       NumThreadsZ:     1
+; DXC:       EntryName:       main
+; DXC:       ResourceStride:  24
+; DXC:       Resources:       []
+; DXC:       SigInputElements: []
+; DXC:       SigOutputElements: []
+; DXC:       SigPatchOrPrimElements: []
+; DXC:       InputOutputMap:
+; DXC:         - [  ]
+; DXC:         - [  ]
+; DXC:         - [  ]
+; DXC:         - [  ]


### PR DESCRIPTION
Direct3D requires a PSV0 section to be present in the DXContainer in order to be able to load and use the shader.

This change adds a minimal stub PSV0, with some hard-coded values, that are just enough to unblock loading into Direct3D.

Contributes to llvm/wg-hlsl#7 