### PR TITLE
[BOLT] Omit CFI state while printing functions without CFI

### DIFF
--- a/bolt/lib/Core/BinaryFunction.cpp
+++ b/bolt/lib/Core/BinaryFunction.cpp
@@ -543,7 +543,7 @@ void BinaryFunction::print(raw_ostream &OS, std::string Annotation) {
         else
           OS << "<unknown>\n";
       }
-      if (BB->getCFIState() >= 0)
+      if (hasCFI())
         OS << "  CFI State : " << BB->getCFIState() << '\n';
       if (opts::EnableBAT) {
         OS << "  Input offset: 0x" << Twine::utohexstr(BB->getInputOffset())
@@ -611,7 +611,7 @@ void BinaryFunction::print(raw_ostream &OS, std::string Annotation) {
       }
 
       // In CFG_Finalized state we can miscalculate CFI state at exit.
-      if (CurrentState == State::CFG) {
+      if (CurrentState == State::CFG && hasCFI()) {
         const int32_t CFIStateAtExit = BB->getCFIStateAtExit();
         if (CFIStateAtExit >= 0)
           OS << "  CFI State: " << CFIStateAtExit << '\n';

--- a/bolt/test/X86/issue20.s
+++ b/bolt/test/X86/issue20.s
@@ -13,7 +13,6 @@
 # CHECK-NOT: BOLT-INFO: UCE removed {{.*}} blocks and {{.*}} bytes of code
 # CHECK: Binary Function "main"
 # CHECK:      .LFT{{.*}} (2 instructions, align : 1)
-# CHECK-NEXT:   CFI State : 0
 # CHECK-NEXT:     00000004:   andq
 # CHECK-NEXT:     00000008:   jmpq
 # CHECK-NEXT:   Successors: .Ltmp{{.*}}, .Ltmp{{.*}}, .Ltmp{{.*}}, .Ltmp{{.*}}

--- a/bolt/test/X86/issue20.test
+++ b/bolt/test/X86/issue20.test
@@ -9,7 +9,6 @@
 CHECK-NOT: BOLT-INFO: UCE removed {{.*}} blocks and {{.*}}| bytes of code
 CHECK: Binary Function "main"
 CHECK:      .LFT0 (2 instructions, align : 1)
-CHECK-NEXT:   CFI State : 0
 CHECK-NEXT:     00000004:   andq
 CHECK-NEXT:     00000008:   jmpq
 CHECK-NEXT:   Successors: .Ltmp1, .Ltmp2, .Ltmp3, .Ltmp4

--- a/bolt/test/X86/sctc-bug4.test
+++ b/bolt/test/X86/sctc-bug4.test
@@ -6,24 +6,19 @@ RUN: llvm-bolt %t -o %t.null --enable-bat \
 RUN:   -funcs=test_func -print-sctc -sequential-disassembly 2>&1 | FileCheck %s
 
 CHECK:      .Ltmp2 (3 instructions, align : 1)
-CHECK-NEXT:   CFI State : 0
 CHECK-NEXT:   Input offset: 0x24
 CHECK-NEXT:   Predecessors: .LFT1
 CHECK-NEXT:     00000024: 	cmpq	$0x20, %rsi
 CHECK-NEXT:     00000028: 	ja	dummy # TAILCALL # Offset: 53 # CTCTakenCount: 0
 CHECK-NEXT:     0000002a: 	jmp .Ltmp4
 CHECK-NEXT:   Successors: .Ltmp4
-CHECK-NEXT:   CFI State: 0
 
 CHECK:      .Ltmp1 (2 instructions, align : 1)
-CHECK-NEXT:   CFI State : 0
 CHECK-NEXT:   Input offset: 0x2c
 CHECK-NEXT:   Predecessors: .LFT0
 CHECK-NEXT:     0000002c: 	xorq	%r11, %rax
 CHECK-NEXT:     0000002f: 	retq
-CHECK-NEXT:   CFI State: 0
 
 CHECK:      .Ltmp4 (4 instructions, align : 1)
-CHECK-NEXT:  CFI State : 0
 CHECK-NEXT:  Input offset: 0x3a
 CHECK-NEXT:  Predecessors: .Ltmp2


### PR DESCRIPTION
If a function has no CFI program attached to it, do not print redundant empty CFI state for every basic block.