### PR TITLE
[LLDB][Windows Build]Removed header and validated on new windows machine

### DIFF
--- a/lldb/source/Plugins/ObjectFile/Minidump/ObjectFileMinidump.cpp
+++ b/lldb/source/Plugins/ObjectFile/Minidump/ObjectFileMinidump.cpp
@@ -18,7 +18,6 @@
 #include "lldb/Utility/Log.h"
 
 #include "llvm/Support/FileSystem.h"
-#include <unistd.h>
 
 using namespace lldb;
 using namespace lldb_private;


### PR DESCRIPTION
![image](https://github.com/llvm/llvm-project/assets/25160653/2044cc8e-72d5-49ec-9439-256555f5fd2b)

In #95312 uint and `#include <unistd.h>` were introduced. These broke the windows build. I addressed uint in #96564, but include went unfixed. So I acquired myself a windows machine to validate.