### PR TITLE
[libc++] Remove _If and use conditional_t instead

### DIFF
--- a/libcxx/include/__bit_reference
+++ b/libcxx/include/__bit_reference
@@ -824,7 +824,7 @@ public:
   // When _IsConst=true, the assignment operators are
   // implicitly generated and trivial.
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 __bit_iterator&
-  operator=(const _If<_IsConst, struct __private_nat, __bit_iterator>& __it) {
+  operator=(const __conditional_t<_IsConst, struct __private_nat, __bit_iterator>& __it) {
     __seg_ = __it.__seg_;
     __ctz_ = __it.__ctz_;
     return *this;

--- a/libcxx/include/__expected/expected.h
+++ b/libcxx/include/__expected/expected.h
@@ -506,20 +506,20 @@ private:
   using __can_convert =
       _And< is_constructible<_Tp, _UfQual>,
             is_constructible<_Err, _OtherErrQual>,
-            _If<_Not<is_same<remove_cv_t<_Tp>, bool>>::value,
-                _And< _Not<is_constructible<_Tp, expected<_Up, _OtherErr>&>>,
-                      _Not<is_constructible<_Tp, expected<_Up, _OtherErr>>>,
-                      _Not<is_constructible<_Tp, const expected<_Up, _OtherErr>&>>,
-                      _Not<is_constructible<_Tp, const expected<_Up, _OtherErr>>>,
-                      _Not<is_convertible<expected<_Up, _OtherErr>&, _Tp>>,
-                      _Not<is_convertible<expected<_Up, _OtherErr>&&, _Tp>>,
-                      _Not<is_convertible<const expected<_Up, _OtherErr>&, _Tp>>,
-                      _Not<is_convertible<const expected<_Up, _OtherErr>&&, _Tp>>>,
-                true_type>,
+            conditional_t<_Not<is_same<remove_cv_t<_Tp>, bool>>::value,
+                          _And<_Not<is_constructible<_Tp, expected<_Up, _OtherErr>&>>,
+                               _Not<is_constructible<_Tp, expected<_Up, _OtherErr>>>,
+                               _Not<is_constructible<_Tp, const expected<_Up, _OtherErr>&>>,
+                               _Not<is_constructible<_Tp, const expected<_Up, _OtherErr>>>,
+                               _Not<is_convertible<expected<_Up, _OtherErr>&, _Tp>>,
+                               _Not<is_convertible<expected<_Up, _OtherErr>&&, _Tp>>,
+                               _Not<is_convertible<const expected<_Up, _OtherErr>&, _Tp>>,
+                               _Not<is_convertible<const expected<_Up, _OtherErr>&&, _Tp>>>,
+                          true_type>,
             _Not<is_constructible<unexpected<_Err>, expected<_Up, _OtherErr>&>>,
             _Not<is_constructible<unexpected<_Err>, expected<_Up, _OtherErr>>>,
             _Not<is_constructible<unexpected<_Err>, const expected<_Up, _OtherErr>&>>,
-            _Not<is_constructible<unexpected<_Err>, const expected<_Up, _OtherErr>>> >;
+            _Not<is_constructible<unexpected<_Err>, const expected<_Up, _OtherErr>>>>;
 
   template <class _Func, class... _Args>
   _LIBCPP_HIDE_FROM_ABI constexpr explicit expected(

--- a/libcxx/include/__functional/bind.h
+++ b/libcxx/include/__functional/bind.h
@@ -28,7 +28,9 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _Tp>
 struct is_bind_expression
-    : _If< _IsSame<_Tp, __remove_cvref_t<_Tp> >::value, false_type, is_bind_expression<__remove_cvref_t<_Tp> > > {};
+    : __conditional_t<_IsSame<_Tp, __remove_cvref_t<_Tp> >::value,
+                      false_type,
+                      is_bind_expression<__remove_cvref_t<_Tp> > > {};
 
 #if _LIBCPP_STD_VER >= 17
 template <class _Tp>
@@ -37,9 +39,9 @@ inline constexpr bool is_bind_expression_v = is_bind_expression<_Tp>::value;
 
 template <class _Tp>
 struct is_placeholder
-    : _If< _IsSame<_Tp, __remove_cvref_t<_Tp> >::value,
-           integral_constant<int, 0>,
-           is_placeholder<__remove_cvref_t<_Tp> > > {};
+    : __conditional_t<_IsSame<_Tp, __remove_cvref_t<_Tp> >::value,
+                      integral_constant<int, 0>,
+                      is_placeholder<__remove_cvref_t<_Tp> > > {};
 
 #if _LIBCPP_STD_VER >= 17
 template <class _Tp>

--- a/libcxx/include/__iterator/common_iterator.h
+++ b/libcxx/include/__iterator/common_iterator.h
@@ -282,8 +282,8 @@ struct __arrow_type_or_void<_Iter, _Sent> {
 
 template <input_iterator _Iter, class _Sent>
 struct iterator_traits<common_iterator<_Iter, _Sent>> {
-  using iterator_concept  = _If<forward_iterator<_Iter>, forward_iterator_tag, input_iterator_tag>;
-  using iterator_category = _If<__denotes_forward_iter<_Iter>, forward_iterator_tag, input_iterator_tag>;
+  using iterator_concept  = __conditional_t<forward_iterator<_Iter>, forward_iterator_tag, input_iterator_tag>;
+  using iterator_category = __conditional_t<__denotes_forward_iter<_Iter>, forward_iterator_tag, input_iterator_tag>;
   using pointer           = typename __arrow_type_or_void<_Iter, _Sent>::type;
   using value_type        = iter_value_t<_Iter>;
   using difference_type   = iter_difference_t<_Iter>;

--- a/libcxx/include/__iterator/iterator_traits.h
+++ b/libcxx/include/__iterator/iterator_traits.h
@@ -75,7 +75,7 @@ struct _LIBCPP_TEMPLATE_VIS contiguous_iterator_tag : public random_access_itera
 
 template <class _Iter>
 struct __iter_traits_cache {
-  using type = _If< __is_primary_template<iterator_traits<_Iter> >::value, _Iter, iterator_traits<_Iter> >;
+  using type = __conditional_t<__is_primary_template<iterator_traits<_Iter> >::value, _Iter, iterator_traits<_Iter> >;
 };
 template <class _Iter>
 using _ITER_TRAITS = typename __iter_traits_cache<_Iter>::type;

--- a/libcxx/include/__iterator/move_iterator.h
+++ b/libcxx/include/__iterator/move_iterator.h
@@ -52,9 +52,9 @@ template <class _Iter>
   requires requires { typename iterator_traits<_Iter>::iterator_category; }
 struct __move_iter_category_base<_Iter> {
   using iterator_category =
-      _If< derived_from<typename iterator_traits<_Iter>::iterator_category, random_access_iterator_tag>,
-           random_access_iterator_tag,
-           typename iterator_traits<_Iter>::iterator_category >;
+      __conditional_t<derived_from<typename iterator_traits<_Iter>::iterator_category, random_access_iterator_tag>,
+                      random_access_iterator_tag,
+                      typename iterator_traits<_Iter>::iterator_category>;
 };
 
 template <class _Iter, class _Sent>
@@ -96,9 +96,9 @@ public:
   using reference       = iter_rvalue_reference_t<_Iter>;
 #else
   typedef _Iter iterator_type;
-  typedef _If< __has_random_access_iterator_category<_Iter>::value,
-               random_access_iterator_tag,
-               typename iterator_traits<_Iter>::iterator_category >
+  typedef __conditional_t<__has_random_access_iterator_category<_Iter>::value,
+                          random_access_iterator_tag,
+                          typename iterator_traits<_Iter>::iterator_category >
       iterator_category;
   typedef typename iterator_traits<iterator_type>::value_type value_type;
   typedef typename iterator_traits<iterator_type>::difference_type difference_type;

--- a/libcxx/include/__iterator/reverse_iterator.h
+++ b/libcxx/include/__iterator/reverse_iterator.h
@@ -76,15 +76,16 @@ public:
   using iterator_type = _Iter;
 
   using iterator_category =
-      _If<__has_random_access_iterator_category<_Iter>::value,
-          random_access_iterator_tag,
-          typename iterator_traits<_Iter>::iterator_category>;
+      __conditional_t<__has_random_access_iterator_category<_Iter>::value,
+                      random_access_iterator_tag,
+                      typename iterator_traits<_Iter>::iterator_category>;
   using pointer = typename iterator_traits<_Iter>::pointer;
 #if _LIBCPP_STD_VER >= 20
-  using iterator_concept = _If<random_access_iterator<_Iter>, random_access_iterator_tag, bidirectional_iterator_tag>;
-  using value_type       = iter_value_t<_Iter>;
-  using difference_type  = iter_difference_t<_Iter>;
-  using reference        = iter_reference_t<_Iter>;
+  using iterator_concept =
+      conditional_t<random_access_iterator<_Iter>, random_access_iterator_tag, bidirectional_iterator_tag>;
+  using value_type      = iter_value_t<_Iter>;
+  using difference_type = iter_difference_t<_Iter>;
+  using reference       = iter_reference_t<_Iter>;
 #else
   using value_type      = typename iterator_traits<_Iter>::value_type;
   using difference_type = typename iterator_traits<_Iter>::difference_type;

--- a/libcxx/include/__memory/shared_ptr.h
+++ b/libcxx/include/__memory/shared_ptr.h
@@ -437,17 +437,18 @@ public:
 
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR shared_ptr(nullptr_t) _NOEXCEPT : __ptr_(nullptr), __cntrl_(nullptr) {}
 
-  template <class _Yp,
-            __enable_if_t< _And< __raw_pointer_compatible_with<_Yp, _Tp>
+  template <
+      class _Yp,
+      __enable_if_t< _And< __raw_pointer_compatible_with<_Yp, _Tp>
   // In C++03 we get errors when trying to do SFINAE with the
   // delete operator, so we always pretend that it's deletable.
   // The same happens on GCC.
 #if !defined(_LIBCPP_CXX03_LANG) && !defined(_LIBCPP_COMPILER_GCC)
-                                 ,
-                                 _If<is_array<_Tp>::value, __is_array_deletable<_Yp*>, __is_deletable<_Yp*> >
+                           ,
+                           __conditional_t<is_array<_Tp>::value, __is_array_deletable<_Yp*>, __is_deletable<_Yp*> >
 #endif
-                                 >::value,
-                           int> = 0>
+                           >::value,
+                     int> = 0>
   _LIBCPP_HIDE_FROM_ABI explicit shared_ptr(_Yp* __p) : __ptr_(__p) {
     unique_ptr<_Yp> __hold(__p);
     typedef typename __shared_ptr_default_allocator<_Yp>::type _AllocT;

--- a/libcxx/include/__pstl/dispatch.h
+++ b/libcxx/include/__pstl/dispatch.h
@@ -51,9 +51,9 @@ struct __find_first_implemented<_Algorithm, __backend_configuration<>, _Executio
 
 template <template <class, class> class _Algorithm, class _B1, class... _Bn, class _ExecutionPolicy>
 struct __find_first_implemented<_Algorithm, __backend_configuration<_B1, _Bn...>, _ExecutionPolicy>
-    : _If<__is_implemented_v<_Algorithm, _B1, _ExecutionPolicy>,
-          __type_identity<_Algorithm<_B1, _ExecutionPolicy>>,
-          __find_first_implemented<_Algorithm, __backend_configuration<_Bn...>, _ExecutionPolicy> > {};
+    : __conditional_t<__is_implemented_v<_Algorithm, _B1, _ExecutionPolicy>,
+                      __type_identity<_Algorithm<_B1, _ExecutionPolicy>>,
+                      __find_first_implemented<_Algorithm, __backend_configuration<_Bn...>, _ExecutionPolicy>> {};
 
 template <template <class, class> class _Algorithm, class _BackendConfiguration, class _ExecutionPolicy>
 using __dispatch = typename __find_first_implemented<_Algorithm, _BackendConfiguration, _ExecutionPolicy>::type;

--- a/libcxx/include/__ranges/dangling.h
+++ b/libcxx/include/__ranges/dangling.h
@@ -30,7 +30,7 @@ struct dangling {
 };
 
 template <range _Rp>
-using borrowed_iterator_t = _If<borrowed_range<_Rp>, iterator_t<_Rp>, dangling>;
+using borrowed_iterator_t = conditional_t<borrowed_range<_Rp>, iterator_t<_Rp>, dangling>;
 
 // borrowed_subrange_t defined in <__ranges/subrange.h>
 } // namespace ranges

--- a/libcxx/include/__ranges/drop_view.h
+++ b/libcxx/include/__ranges/drop_view.h
@@ -64,7 +64,7 @@ class drop_view : public view_interface<drop_view<_View>> {
   // Note: drop_view<input-range>::begin() is still trivially amortized O(1) because
   // one can't call begin() on it more than once.
   static constexpr bool _UseCache = forward_range<_View> && !(random_access_range<_View> && sized_range<_View>);
-  using _Cache                    = _If<_UseCache, __non_propagating_cache<iterator_t<_View>>, __empty_cache>;
+  using _Cache                    = conditional_t<_UseCache, __non_propagating_cache<iterator_t<_View>>, __empty_cache>;
   _LIBCPP_NO_UNIQUE_ADDRESS _Cache __cached_begin_ = _Cache();
   range_difference_t<_View> __count_               = 0;
   _View __base_                                    = _View();

--- a/libcxx/include/__ranges/drop_while_view.h
+++ b/libcxx/include/__ranges/drop_while_view.h
@@ -90,7 +90,7 @@ private:
   _LIBCPP_NO_UNIQUE_ADDRESS __movable_box<_Pred> __pred_;
 
   static constexpr bool _UseCache = forward_range<_View>;
-  using _Cache                    = _If<_UseCache, __non_propagating_cache<iterator_t<_View>>, __empty_cache>;
+  using _Cache                    = conditional_t<_UseCache, __non_propagating_cache<iterator_t<_View>>, __empty_cache>;
   _LIBCPP_NO_UNIQUE_ADDRESS _Cache __cached_begin_ = _Cache();
 };
 

--- a/libcxx/include/__ranges/filter_view.h
+++ b/libcxx/include/__ranges/filter_view.h
@@ -61,7 +61,7 @@ class _LIBCPP_ABI_LLVM18_NO_UNIQUE_ADDRESS filter_view : public view_interface<f
   // We cache the result of begin() to allow providing an amortized O(1) begin() whenever
   // the underlying range is at least a forward_range.
   static constexpr bool _UseCache = forward_range<_View>;
-  using _Cache                    = _If<_UseCache, __non_propagating_cache<iterator_t<_View>>, __empty_cache>;
+  using _Cache                    = conditional_t<_UseCache, __non_propagating_cache<iterator_t<_View>>, __empty_cache>;
   _LIBCPP_NO_UNIQUE_ADDRESS _Cache __cached_begin_ = _Cache();
 
   class __iterator;
@@ -117,11 +117,11 @@ template <forward_range _View>
 struct __filter_iterator_category<_View> {
   using _Cat = typename iterator_traits<iterator_t<_View>>::iterator_category;
   using iterator_category =
-      _If<derived_from<_Cat, bidirectional_iterator_tag>,
-          bidirectional_iterator_tag,
-          _If<derived_from<_Cat, forward_iterator_tag>,
-              forward_iterator_tag,
-              /* else */ _Cat >>;
+      conditional_t<derived_from<_Cat, bidirectional_iterator_tag>,
+                    bidirectional_iterator_tag,
+                    conditional_t<derived_from<_Cat, forward_iterator_tag>,
+                                  forward_iterator_tag,
+                                  /* else */ _Cat >>;
 };
 
 template <input_range _View, indirect_unary_predicate<iterator_t<_View>> _Pred>
@@ -132,11 +132,11 @@ public:
   _LIBCPP_NO_UNIQUE_ADDRESS filter_view* __parent_       = nullptr;
 
   using iterator_concept =
-      _If<bidirectional_range<_View>,
-          bidirectional_iterator_tag,
-          _If<forward_range<_View>,
-              forward_iterator_tag,
-              /* else */ input_iterator_tag >>;
+      conditional_t<bidirectional_range<_View>,
+                    bidirectional_iterator_tag,
+                    conditional_t<forward_range<_View>,
+                                  forward_iterator_tag,
+                                  /* else */ input_iterator_tag >>;
   // using iterator_category = inherited;
   using value_type      = range_value_t<_View>;
   using difference_type = range_difference_t<_View>;

--- a/libcxx/include/__ranges/iota_view.h
+++ b/libcxx/include/__ranges/iota_view.h
@@ -70,9 +70,9 @@ struct __get_wider_signed {
 
 template <class _Start>
 using _IotaDiffT =
-    typename _If< (!integral<_Start> || sizeof(iter_difference_t<_Start>) > sizeof(_Start)),
-                  type_identity<iter_difference_t<_Start>>,
-                  __get_wider_signed<_Start> >::type;
+    typename conditional_t<(!integral<_Start> || sizeof(iter_difference_t<_Start>) > sizeof(_Start)),
+                           type_identity<iter_difference_t<_Start>>,
+                           __get_wider_signed<_Start> >::type;
 
 template <class _Iter>
 concept __decrementable = incrementable<_Iter> && requires(_Iter __i) {
@@ -107,13 +107,13 @@ class iota_view : public view_interface<iota_view<_Start, _BoundSentinel>> {
     friend class iota_view;
 
     using iterator_concept =
-        _If<__advanceable<_Start>,
-            random_access_iterator_tag,
-            _If<__decrementable<_Start>,
-                bidirectional_iterator_tag,
-                _If<incrementable<_Start>,
-                    forward_iterator_tag,
-                    /*Else*/ input_iterator_tag>>>;
+        conditional_t<__advanceable<_Start>,
+                      random_access_iterator_tag,
+                      conditional_t<__decrementable<_Start>,
+                                    bidirectional_iterator_tag,
+                                    conditional_t<incrementable<_Start>,
+                                                  forward_iterator_tag,
+                                                  /*Else*/ input_iterator_tag>>>;
 
     using value_type      = _Start;
     using difference_type = _IotaDiffT<_Start>;

--- a/libcxx/include/__ranges/join_view.h
+++ b/libcxx/include/__ranges/join_view.h
@@ -58,13 +58,13 @@ struct __join_view_iterator_category<_View> {
   using _OuterC = typename iterator_traits<iterator_t<_View>>::iterator_category;
   using _InnerC = typename iterator_traits<iterator_t<range_reference_t<_View>>>::iterator_category;
 
-  using iterator_category =
-      _If< derived_from<_OuterC, bidirectional_iterator_tag> && derived_from<_InnerC, bidirectional_iterator_tag> &&
-               common_range<range_reference_t<_View>>,
-           bidirectional_iterator_tag,
-           _If< derived_from<_OuterC, forward_iterator_tag> && derived_from<_InnerC, forward_iterator_tag>,
-                forward_iterator_tag,
-                input_iterator_tag > >;
+  using iterator_category = __conditional_t<
+      derived_from<_OuterC, bidirectional_iterator_tag> && derived_from<_InnerC, bidirectional_iterator_tag> &&
+          common_range<range_reference_t<_View>>,
+      bidirectional_iterator_tag,
+      __conditional_t<derived_from<_OuterC, forward_iterator_tag> && derived_from<_InnerC, forward_iterator_tag>,
+                      forward_iterator_tag,
+                      input_iterator_tag > >;
 };
 
 template <input_range _View>
@@ -85,11 +85,12 @@ private:
   _LIBCPP_NO_UNIQUE_ADDRESS _View __base_ = _View();
 
   static constexpr bool _UseOuterCache = !forward_range<_View>;
-  using _OuterCache                    = _If<_UseOuterCache, __non_propagating_cache<iterator_t<_View>>, __empty_cache>;
+  using _OuterCache = conditional_t<_UseOuterCache, __non_propagating_cache<iterator_t<_View>>, __empty_cache>;
   _LIBCPP_NO_UNIQUE_ADDRESS _OuterCache __outer_;
 
   static constexpr bool _UseInnerCache = !is_reference_v<_InnerRange>;
-  using _InnerCache = _If<_UseInnerCache, __non_propagating_cache<remove_cvref_t<_InnerRange>>, __empty_cache>;
+  using _InnerCache =
+      conditional_t<_UseInnerCache, __non_propagating_cache<remove_cvref_t<_InnerRange>>, __empty_cache>;
   _LIBCPP_NO_UNIQUE_ADDRESS _InnerCache __inner_;
 
 public:
@@ -201,7 +202,7 @@ private:
   static constexpr bool __ref_is_glvalue = is_reference_v<range_reference_t<_Base>>;
 
   static constexpr bool _OuterPresent           = forward_range<_Base>;
-  using _OuterType                              = _If<_OuterPresent, _Outer, std::__empty>;
+  using _OuterType                              = conditional_t<_OuterPresent, _Outer, std::__empty>;
   _LIBCPP_NO_UNIQUE_ADDRESS _OuterType __outer_ = _OuterType();
 
   optional<_Inner> __inner_;
@@ -258,12 +259,12 @@ private:
 
 public:
   using iterator_concept =
-      _If< __ref_is_glvalue && bidirectional_range<_Base> && bidirectional_range<range_reference_t<_Base>> &&
-               common_range<range_reference_t<_Base>>,
-           bidirectional_iterator_tag,
-           _If< __ref_is_glvalue && forward_range<_Base> && forward_range<range_reference_t<_Base>>,
-                forward_iterator_tag,
-                input_iterator_tag > >;
+      conditional_t<__ref_is_glvalue && bidirectional_range<_Base> && bidirectional_range<range_reference_t<_Base>> &&
+                        common_range<range_reference_t<_Base>>,
+                    bidirectional_iterator_tag,
+                    conditional_t<__ref_is_glvalue && forward_range<_Base> && forward_range<range_reference_t<_Base>>,
+                                  forward_iterator_tag,
+                                  input_iterator_tag>>;
 
   using value_type = range_value_t<range_reference_t<_Base>>;
 

--- a/libcxx/include/__ranges/lazy_split_view.h
+++ b/libcxx/include/__ranges/lazy_split_view.h
@@ -72,7 +72,7 @@ class lazy_split_view : public view_interface<lazy_split_view<_View, _Pattern>> 
   _LIBCPP_NO_UNIQUE_ADDRESS _View __base_       = _View();
   _LIBCPP_NO_UNIQUE_ADDRESS _Pattern __pattern_ = _Pattern();
 
-  using _MaybeCurrent = _If<!forward_range<_View>, __non_propagating_cache<iterator_t<_View>>, __empty_cache>;
+  using _MaybeCurrent = conditional_t<!forward_range<_View>, __non_propagating_cache<iterator_t<_View>>, __empty_cache>;
   _LIBCPP_NO_UNIQUE_ADDRESS _MaybeCurrent __current_ = _MaybeCurrent();
 
   template <bool>
@@ -149,8 +149,8 @@ private:
     using _Parent = __maybe_const<_Const, lazy_split_view>;
     using _Base   = __maybe_const<_Const, _View>;
 
-    _Parent* __parent_                                 = nullptr;
-    using _MaybeCurrent                                = _If<forward_range<_View>, iterator_t<_Base>, __empty_cache>;
+    _Parent* __parent_  = nullptr;
+    using _MaybeCurrent = conditional_t<forward_range<_View>, iterator_t<_Base>, __empty_cache>;
     _LIBCPP_NO_UNIQUE_ADDRESS _MaybeCurrent __current_ = _MaybeCurrent();
     bool __trailing_empty_                             = false;
 
@@ -275,9 +275,9 @@ private:
   template <forward_range _Tp>
   struct __inner_iterator_category<_Tp> {
     using iterator_category =
-        _If< derived_from<typename iterator_traits<iterator_t<_Tp>>::iterator_category, forward_iterator_tag>,
-             forward_iterator_tag,
-             typename iterator_traits<iterator_t<_Tp>>::iterator_category >;
+        conditional_t<derived_from<typename iterator_traits<iterator_t<_Tp>>::iterator_category, forward_iterator_tag>,
+                      forward_iterator_tag,
+                      typename iterator_traits<iterator_t<_Tp>>::iterator_category >;
   };
 
   template <bool _Const>

--- a/libcxx/include/__ranges/reverse_view.h
+++ b/libcxx/include/__ranges/reverse_view.h
@@ -47,7 +47,7 @@ class reverse_view : public view_interface<reverse_view<_View>> {
   // We cache begin() whenever ranges::next is not guaranteed O(1) to provide an
   // amortized O(1) begin() method.
   static constexpr bool _UseCache = !random_access_range<_View> && !common_range<_View>;
-  using _Cache = _If<_UseCache, __non_propagating_cache<reverse_iterator<iterator_t<_View>>>, __empty_cache>;
+  using _Cache = conditional_t<_UseCache, __non_propagating_cache<reverse_iterator<iterator_t<_View>>>, __empty_cache>;
   _LIBCPP_NO_UNIQUE_ADDRESS _Cache __cached_begin_ = _Cache();
   _LIBCPP_NO_UNIQUE_ADDRESS _View __base_          = _View();
 

--- a/libcxx/include/__ranges/subrange.h
+++ b/libcxx/include/__ranges/subrange.h
@@ -232,7 +232,7 @@ template <class _Ip, class _Sp, subrange_kind _Kp>
 inline constexpr bool enable_borrowed_range<subrange<_Ip, _Sp, _Kp>> = true;
 
 template <range _Rp>
-using borrowed_subrange_t = _If<borrowed_range<_Rp>, subrange<iterator_t<_Rp>>, dangling>;
+using borrowed_subrange_t = conditional_t<borrowed_range<_Rp>, subrange<iterator_t<_Rp>>, dangling>;
 } // namespace ranges
 
 // [range.subrange.general]

--- a/libcxx/include/__type_traits/conditional.h
+++ b/libcxx/include/__type_traits/conditional.h
@@ -32,9 +32,6 @@ struct _IfImpl<false> {
   using _Select _LIBCPP_NODEBUG = _ElseRes;
 };
 
-template <bool _Cond, class _IfRes, class _ElseRes>
-using _If _LIBCPP_NODEBUG = typename _IfImpl<_Cond>::template _Select<_IfRes, _ElseRes>;
-
 template <bool _Bp, class _If, class _Then>
 struct _LIBCPP_TEMPLATE_VIS conditional {
   using type _LIBCPP_NODEBUG = _If;
@@ -45,7 +42,7 @@ struct _LIBCPP_TEMPLATE_VIS conditional<false, _If, _Then> {
 };
 
 template <bool _Bp, class _IfRes, class _ElseRes>
-using __conditional_t _LIBCPP_NODEBUG = _If<_Bp, _IfRes, _ElseRes>;
+using __conditional_t _LIBCPP_NODEBUG = typename _IfImpl<_Bp>::template _Select<_IfRes, _ElseRes>;
 
 #if _LIBCPP_STD_VER >= 14
 template <bool _Bp, class _IfRes, class _ElseRes>

--- a/libcxx/include/__utility/forward_like.h
+++ b/libcxx/include/__utility/forward_like.h
@@ -25,10 +25,10 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 #if _LIBCPP_STD_VER >= 23
 
 template <class _Ap, class _Bp>
-using _CopyConst = _If<is_const_v<_Ap>, const _Bp, _Bp>;
+using _CopyConst = conditional_t<is_const_v<_Ap>, const _Bp, _Bp>;
 
 template <class _Ap, class _Bp>
-using _OverrideRef = _If<is_rvalue_reference_v<_Ap>, remove_reference_t<_Bp>&&, _Bp&>;
+using _OverrideRef = conditional_t<is_rvalue_reference_v<_Ap>, remove_reference_t<_Bp>&&, _Bp&>;
 
 template <class _Ap, class _Bp>
 using _ForwardLike = _OverrideRef<_Ap&&, _CopyConst<remove_reference_t<_Ap>, remove_reference_t<_Bp>>>;

--- a/libcxx/include/optional
+++ b/libcxx/include/optional
@@ -605,12 +605,14 @@ private:
       return is_constructible_v<_Tp, _Up&&> && !is_convertible_v<_Up&&, _Tp>;
     }
   };
+
   template <class _Up>
-  using _CheckOptionalArgsCtor =
-      _If< _IsNotSame<__remove_cvref_t<_Up>, in_place_t>::value && _IsNotSame<__remove_cvref_t<_Up>, optional>::value &&
-               (!is_same_v<remove_cv_t<_Tp>, bool> || !__is_std_optional<__remove_cvref_t<_Up>>::value),
-           _CheckOptionalArgsConstructor,
-           __check_tuple_constructor_fail >;
+  using _CheckOptionalArgsCtor = __conditional_t<
+      _IsNotSame<__remove_cvref_t<_Up>, in_place_t>::value && _IsNotSame<__remove_cvref_t<_Up>, optional>::value &&
+          (!is_same_v<remove_cv_t<_Tp>, bool> || !__is_std_optional<__remove_cvref_t<_Up>>::value),
+      _CheckOptionalArgsConstructor,
+      __check_tuple_constructor_fail>;
+
   template <class _QualUp>
   struct _CheckOptionalLikeConstructor {
     template <class _Up, class _Opt = optional<_Up>>
@@ -649,14 +651,14 @@ private:
 
   template <class _Up, class _QualUp>
   using _CheckOptionalLikeCtor =
-      _If< _And< _IsNotSame<_Up, _Tp>, is_constructible<_Tp, _QualUp> >::value,
-           _CheckOptionalLikeConstructor<_QualUp>,
-           __check_tuple_constructor_fail >;
+      conditional_t<_And< _IsNotSame<_Up, _Tp>, is_constructible<_Tp, _QualUp> >::value,
+                    _CheckOptionalLikeConstructor<_QualUp>,
+                    __check_tuple_constructor_fail >;
   template <class _Up, class _QualUp>
   using _CheckOptionalLikeAssign =
-      _If< _And< _IsNotSame<_Up, _Tp>, is_constructible<_Tp, _QualUp>, is_assignable<_Tp&, _QualUp> >::value,
-           _CheckOptionalLikeConstructor<_QualUp>,
-           __check_tuple_constructor_fail >;
+      conditional_t<_And< _IsNotSame<_Up, _Tp>, is_constructible<_Tp, _QualUp>, is_assignable<_Tp&, _QualUp> >::value,
+                    _CheckOptionalLikeConstructor<_QualUp>,
+                    __check_tuple_constructor_fail >;
 
 public:
   _LIBCPP_HIDE_FROM_ABI constexpr optional() noexcept {}

--- a/libcxx/include/tuple
+++ b/libcxx/include/tuple
@@ -827,8 +827,8 @@ public:
 
   // [tuple.assign]
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 tuple&
-  operator=(_If<_And<is_copy_assignable<_Tp>...>::value, tuple, __nat> const& __tuple)
-      noexcept(_And<is_nothrow_copy_assignable<_Tp>...>::value) {
+  operator=(__conditional_t<_And<is_copy_assignable<_Tp>...>::value, tuple, __nat> const& __tuple) noexcept(
+      _And<is_nothrow_copy_assignable<_Tp>...>::value) {
     std::__memberwise_copy_assign(*this, __tuple, typename __make_tuple_indices<sizeof...(_Tp)>::type());
     return *this;
   }
@@ -851,8 +851,8 @@ public:
 #  endif // _LIBCPP_STD_VER >= 23
 
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 tuple&
-  operator=(_If<_And<is_move_assignable<_Tp>...>::value, tuple, __nat>&& __tuple)
-      noexcept(_And<is_nothrow_move_assignable<_Tp>...>::value) {
+  operator=(__conditional_t<_And<is_move_assignable<_Tp>...>::value, tuple, __nat>&& __tuple) noexcept(
+      _And<is_nothrow_move_assignable<_Tp>...>::value) {
     std::__memberwise_forward_assign(
         *this, std::move(__tuple), __tuple_types<_Tp...>(), typename __make_tuple_indices<sizeof...(_Tp)>::type());
     return *this;
@@ -972,7 +972,7 @@ public:
     std::__memberwise_forward_assign(
         *this,
         std::move(__array),
-        __tuple_types<_If<true, _Up, _Tp>...>(),
+        __tuple_types<__conditional_t<true, _Up, _Tp>...>(),
         typename __make_tuple_indices<sizeof...(_Tp)>::type());
     return *this;
   }

--- a/libcxx/include/variant
+++ b/libcxx/include/variant
@@ -1117,8 +1117,8 @@ struct __narrowing_check {
 
 template <class _Dest, class _Source>
 using __check_for_narrowing _LIBCPP_NODEBUG =
-    typename _If< is_arithmetic<_Dest>::value, __narrowing_check, __no_narrowing_check >::template _Apply<_Dest,
-                                                                                                          _Source>;
+    typename conditional_t< is_arithmetic<_Dest>::value, __narrowing_check, __no_narrowing_check >::
+        template _Apply<_Dest, _Source>;
 
 template <class _Tp, size_t _Idx>
 struct __overload {

--- a/libcxx/test/libcxx/utilities/meta/meta_base.pass.cpp
+++ b/libcxx/test/libcxx/utilities/meta/meta_base.pass.cpp
@@ -23,11 +23,6 @@ struct BOOM {
 using True = std::true_type;
 using False = std::false_type;
 
-void test_if() {
-  ASSERT_SAME_TYPE(std::_If<true, int, long>, int);
-  ASSERT_SAME_TYPE(std::_If<false, int, long>, long);
-}
-
 void test_and() {
   static_assert(std::_And<True>::value, "");
   static_assert(!std::_And<False>::value, "");


### PR DESCRIPTION
`_If` and `conditional_t` now have the same definition. This simply removes one of the ways to spell the same thing.
