### PR TITLE
[libc++][NFC] Replace conditional<>::type with __conditional_t

### DIFF
--- a/libcxx/include/__iterator/move_iterator.h
+++ b/libcxx/include/__iterator/move_iterator.h
@@ -105,9 +105,8 @@ public:
   typedef iterator_type pointer;
 
   typedef typename iterator_traits<iterator_type>::reference __reference;
-  typedef typename conditional< is_reference<__reference>::value,
-                                __libcpp_remove_reference_t<__reference>&&,
-                                __reference >::type reference;
+  typedef __conditional_t<is_reference<__reference>::value, __libcpp_remove_reference_t<__reference>&&, __reference>
+      reference;
 #endif // _LIBCPP_STD_VER >= 20
 
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX17 explicit move_iterator(_Iter __i) : __current_(std::move(__i)) {}

--- a/libcxx/include/__type_traits/common_type.h
+++ b/libcxx/include/__type_traits/common_type.h
@@ -82,9 +82,9 @@ struct _LIBCPP_TEMPLATE_VIS common_type<_Tp> : public common_type<_Tp, _Tp> {};
 // sub-bullet 1 - "If is_same_v<T1, D1> is false or ..."
 template <class _Tp, class _Up>
 struct _LIBCPP_TEMPLATE_VIS common_type<_Tp, _Up>
-    : conditional<_IsSame<_Tp, __decay_t<_Tp> >::value && _IsSame<_Up, __decay_t<_Up> >::value,
-                  __common_type2_imp<_Tp, _Up>,
-                  common_type<__decay_t<_Tp>, __decay_t<_Up> > >::type {};
+    : __conditional_t<_IsSame<_Tp, __decay_t<_Tp> >::value && _IsSame<_Up, __decay_t<_Up> >::value,
+                      __common_type2_imp<_Tp, _Up>,
+                      common_type<__decay_t<_Tp>, __decay_t<_Up> > > {};
 
 // bullet 4 - sizeof...(Tp) > 2
 

--- a/libcxx/include/__type_traits/decay.h
+++ b/libcxx/include/__type_traits/decay.h
@@ -43,11 +43,11 @@ struct __decay {
 template <class _Up>
 struct __decay<_Up, true> {
 public:
-  typedef _LIBCPP_NODEBUG typename conditional<
-      is_array<_Up>::value,
-      __add_pointer_t<__remove_extent_t<_Up> >,
-      typename conditional<is_function<_Up>::value, typename add_pointer<_Up>::type, __remove_cv_t<_Up> >::type >::type
-      type;
+  typedef _LIBCPP_NODEBUG
+      __conditional_t<is_array<_Up>::value,
+                      __add_pointer_t<__remove_extent_t<_Up> >,
+                      __conditional_t<is_function<_Up>::value, typename add_pointer<_Up>::type, __remove_cv_t<_Up> > >
+          type;
 };
 
 template <class _Tp>


### PR DESCRIPTION
`__conditional_t` is move efficient than `conditional`, since it avoids instantiating a template for every type combination.
