### PR TITLE
gn: hwasan: fixup hwasan-preinit

### DIFF
--- a/llvm/utils/gn/secondary/compiler-rt/lib/hwasan/BUILD.gn
+++ b/llvm/utils/gn/secondary/compiler-rt/lib/hwasan/BUILD.gn
@@ -120,7 +120,7 @@ shared_library("hwasan_shared") {
 
 static_library("hwasan_preinit") {
   output_dir = crt_current_out_dir
-  output_name = "clang_rt.${hwasan_name}_preinit$crt_current_target_suffix"
+  output_name = "clang_rt.${hwasan_name}-preinit$crt_current_target_suffix"
   complete_static_lib = true
   configs -= [
     "//llvm/utils/gn/build:llvm_code",

--- a/llvm/utils/gn/secondary/compiler-rt/test/hwasan/BUILD.gn
+++ b/llvm/utils/gn/secondary/compiler-rt/test/hwasan/BUILD.gn
@@ -38,6 +38,7 @@ if (current_toolchain != host_toolchain) {
       "//compiler-rt/include($host_toolchain)",
       "//compiler-rt/lib/cfi:ignorelist($host_toolchain)",
       "//compiler-rt/lib/hwasan:hwasan_shared",
+      "//compiler-rt/lib/hwasan:hwasan_preinit",
       "//compiler-rt/test:lit_common_configured",
       "//llvm/utils/FileCheck($host_toolchain)",
       "//llvm/utils/llvm-lit($host_toolchain)",


### PR DESCRIPTION
The build rule for hwasan_preinit outputs libclang_rt.hwasan_preinit,
but clang expects hwasan-preinit (with a dash, rather than an
underscore) when selecting the library in the frontend.

Also, we were missing the hwasan-preinit dependency in check-hwasan.

For posterity, this now passes hwasan unit tests on Android with:
 $ cat args.gn
clang_base_path = "/usr/local"
llvm_enable_assertions = true
llvm_targets_to_build = "all"
android_ndk_path = "/path/to/Android.sdk/ndk/25.2.9519653"
 $ /path/to/llvm/utils/gn/gn.py gen build
 $ ANDROID_SERIAL=xxx ninja -C build check-hwasan