### PR TITLE
[libc][docs] List `rand` and `srand` as supported on the GPU

### DIFF
--- a/libc/docs/gpu/support.rst
+++ b/libc/docs/gpu/support.rst
@@ -190,6 +190,8 @@ strtold        |check|
 strtoll        |check|
 strtoul        |check|
 strtoull       |check|
+srand          |check|
+rand           |check|
 =============  =========  ============
 
 inttypes.h

--- a/libc/src/stdlib/rand_util.cpp
+++ b/libc/src/stdlib/rand_util.cpp
@@ -12,7 +12,7 @@
 
 namespace LIBC_NAMESPACE {
 
-//  C standard 7.10p2: If 'rand' is called before 'srand' it is to
+// C standard 7.10p2: If 'rand' is called before 'srand' it is to
 // proceed as if the 'srand' function was called with a value of '1'.
 cpp::Atomic<unsigned long> rand_next = 1;
 


### PR DESCRIPTION
Summary:
I initially didn't report these as supported because they didn't provide
expected behavior and were very wasteful. The recent patch moved them to
a lock-free atomic implementation so they can now actually be used.
