### PR TITLE
Revert "[clang][dataflow] Teach `AnalysisASTVisitor` that `typeid()` can be evaluated."

### DIFF
--- a/clang/include/clang/Analysis/FlowSensitive/ASTOps.h
+++ b/clang/include/clang/Analysis/FlowSensitive/ASTOps.h
@@ -113,11 +113,7 @@ public:
   // nevertheless it appears in the Clang CFG, so we don't exclude it here.
   bool TraverseDecltypeTypeLoc(DecltypeTypeLoc) { return true; }
   bool TraverseTypeOfExprTypeLoc(TypeOfExprTypeLoc) { return true; }
-  bool TraverseCXXTypeidExpr(CXXTypeidExpr *TIE) {
-    if (TIE->isPotentiallyEvaluated())
-      return RecursiveASTVisitor<Derived>::TraverseCXXTypeidExpr(TIE);
-    return true;
-  }
+  bool TraverseCXXTypeidExpr(CXXTypeidExpr *) { return true; }
   bool TraverseUnaryExprOrTypeTraitExpr(UnaryExprOrTypeTraitExpr *) {
     return true;
   }

--- a/clang/unittests/Analysis/FlowSensitive/TransferTest.cpp
+++ b/clang/unittests/Analysis/FlowSensitive/TransferTest.cpp
@@ -1637,49 +1637,6 @@ TEST(TransferTest, StructModeledFieldsWithAccessor) {
       });
 }
 
-TEST(TransferTest, StructModeledFieldsInTypeid) {
-  // Test that we model fields mentioned inside a `typeid()` expression only if
-  // that expression is potentially evaluated -- i.e. if the expression inside
-  // `typeid()` is a glvalue of polymorphic type (see
-  // `CXXTypeidExpr::isPotentiallyEvaluated()` and [expr.typeid]p3).
-  std::string Code = R"(
-    // Definitions needed for `typeid`.
-    namespace std {
-      class type_info {};
-      class bad_typeid {};
-    }  // namespace std
-
-    struct NonPolymorphic {};
-
-    struct Polymorphic {
-      virtual ~Polymorphic() = default;
-    };
-
-    struct S {
-      NonPolymorphic *NonPoly;
-      Polymorphic *Poly;
-    };
-
-    void target(S &s) {
-      typeid(*s.NonPoly);
-      typeid(*s.Poly);
-      // [[p]]
-    }
-  )";
-  runDataflow(
-      Code,
-      [](const llvm::StringMap<DataflowAnalysisState<NoopLattice>> &Results,
-         ASTContext &ASTCtx) {
-        const Environment &Env = getEnvironmentAtAnnotation(Results, "p");
-        auto &SLoc = getLocForDecl<RecordStorageLocation>(ASTCtx, Env, "s");
-        std::vector<const ValueDecl *> Fields;
-        for (auto [Field, _] : SLoc.children())
-          Fields.push_back(Field);
-        EXPECT_THAT(Fields,
-                    UnorderedElementsAre(findValueDecl(ASTCtx, "Poly")));
-      });
-}
-
 TEST(TransferTest, StructModeledFieldsWithComplicatedInheritance) {
   std::string Code = R"(
     struct Base1 {


### PR DESCRIPTION
Reverts llvm/llvm-project#96731

It causes CI failures.