### PR TITLE
[AsmPrinter] Reduce AsmPrinterHandlers virt. fn calls

### DIFF
--- a/llvm/include/llvm/CodeGen/AsmPrinter.h
+++ b/llvm/include/llvm/CodeGen/AsmPrinter.h
@@ -20,6 +20,7 @@
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/BinaryFormat/Dwarf.h"
 #include "llvm/CodeGen/AsmPrinterHandler.h"
+#include "llvm/CodeGen/DebugHandlerBase.h"
 #include "llvm/CodeGen/DwarfStringPoolEntry.h"
 #include "llvm/CodeGen/MachineFunctionPass.h"
 #include "llvm/CodeGen/StackMaps.h"
@@ -40,7 +41,6 @@ class Constant;
 class ConstantArray;
 class ConstantPtrAuth;
 class DataLayout;
-class DebugHandlerBase;
 class DIE;
 class DIEAbbrev;
 class DwarfDebug;
@@ -146,14 +146,14 @@ public:
 
   /// struct HandlerInfo and Handlers permit users or target extended
   /// AsmPrinter to add their own handlers.
-  struct HandlerInfo {
-    std::unique_ptr<AsmPrinterHandler> Handler;
+  template <class H> struct HandlerInfo {
+    std::unique_ptr<H> Handler;
     StringRef TimerName;
     StringRef TimerDescription;
     StringRef TimerGroupName;
     StringRef TimerGroupDescription;
 
-    HandlerInfo(std::unique_ptr<AsmPrinterHandler> Handler, StringRef TimerName,
+    HandlerInfo(std::unique_ptr<H> Handler, StringRef TimerName,
                 StringRef TimerDescription, StringRef TimerGroupName,
                 StringRef TimerGroupDescription)
         : Handler(std::move(Handler)), TimerName(TimerName),
@@ -206,11 +206,12 @@ protected:
 
   /// A vector of all debug/EH info emitters we should use. This vector
   /// maintains ownership of the emitters.
-  std::vector<HandlerInfo> Handlers;
+  SmallVector<HandlerInfo<AsmPrinterHandler>, 2> Handlers;
   size_t NumUserHandlers = 0;
 
   /// Debuginfo handler. Protected so that targets can add their own.
-  SmallVector<std::unique_ptr<DebugHandlerBase>, 1> DebugHandlers;
+  SmallVector<HandlerInfo<DebugHandlerBase>, 1> DebugHandlers;
+  size_t NumUserDebugHandlers = 0;
 
   StackMaps SM;
 
@@ -535,9 +536,14 @@ public:
   // Overridable Hooks
   //===------------------------------------------------------------------===//
 
-  void addAsmPrinterHandler(HandlerInfo Handler) {
+  void addAsmPrinterHandler(HandlerInfo<AsmPrinterHandler> Handler) {
     Handlers.insert(Handlers.begin(), std::move(Handler));
     NumUserHandlers++;
+  }
+
+  void addDebugHandler(HandlerInfo<DebugHandlerBase> Handler) {
+    DebugHandlers.insert(DebugHandlers.begin(), std::move(Handler));
+    NumUserDebugHandlers++;
   }
 
   // Targets can, or in the case of EmitInstruction, must implement these to

--- a/llvm/include/llvm/CodeGen/AsmPrinter.h
+++ b/llvm/include/llvm/CodeGen/AsmPrinter.h
@@ -40,6 +40,7 @@ class Constant;
 class ConstantArray;
 class ConstantPtrAuth;
 class DataLayout;
+class DebugHandlerBase;
 class DIE;
 class DIEAbbrev;
 class DwarfDebug;
@@ -208,6 +209,9 @@ protected:
   std::vector<HandlerInfo> Handlers;
   size_t NumUserHandlers = 0;
 
+  /// Debuginfo handler. Protected so that targets can add their own.
+  SmallVector<std::unique_ptr<DebugHandlerBase>, 1> DebugHandlers;
+
   StackMaps SM;
 
 private:
@@ -222,7 +226,7 @@ private:
 
   /// A handler that supports pseudo probe emission with embedded inline
   /// context.
-  PseudoProbeHandler *PP = nullptr;
+  std::unique_ptr<PseudoProbeHandler> PP;
 
   /// CFISection type the module needs i.e. either .eh_frame or .debug_frame.
   CFISection ModuleCFISection = CFISection::None;

--- a/llvm/include/llvm/CodeGen/AsmPrinterHandler.h
+++ b/llvm/include/llvm/CodeGen/AsmPrinterHandler.h
@@ -34,10 +34,6 @@ class AsmPrinterHandler {
 public:
   virtual ~AsmPrinterHandler();
 
-  /// For symbols that have a size designated (e.g. common symbols),
-  /// this tracks that size.
-  virtual void setSymbolSize(const MCSymbol *Sym, uint64_t Size) = 0;
-
   virtual void beginModule(Module *M) {}
 
   /// Emit all sections that should come after the content.
@@ -72,12 +68,6 @@ public:
   virtual void beginFunclet(const MachineBasicBlock &MBB,
                             MCSymbol *Sym = nullptr) {}
   virtual void endFunclet() {}
-
-  /// Process beginning of an instruction.
-  virtual void beginInstruction(const MachineInstr *MI) = 0;
-
-  /// Process end of an instruction.
-  virtual void endInstruction() = 0;
 };
 
 } // End of namespace llvm

--- a/llvm/include/llvm/CodeGen/DebugHandlerBase.h
+++ b/llvm/include/llvm/CodeGen/DebugHandlerBase.h
@@ -50,10 +50,14 @@ struct DbgVariableLocation {
 
 /// Base class for debug information backends. Common functionality related to
 /// tracking which variables and scopes are alive at a given PC live here.
-class DebugHandlerBase : public AsmPrinterHandler {
+class DebugHandlerBase {
 protected:
   DebugHandlerBase(AsmPrinter *A);
 
+public:
+  virtual ~DebugHandlerBase();
+
+protected:
   /// Target of debug info emission.
   AsmPrinter *Asm = nullptr;
 
@@ -116,18 +120,22 @@ protected:
 private:
   InstructionOrdering InstOrdering;
 
-  // AsmPrinterHandler overrides.
 public:
-  void beginModule(Module *M) override;
+  /// For symbols that have a size designated (e.g. common symbols),
+  /// this tracks that size. Only used by DWARF.
+  virtual void setSymbolSize(const MCSymbol *Sym, uint64_t Size) {};
 
-  void beginInstruction(const MachineInstr *MI) override;
-  void endInstruction() override;
+  virtual void beginModule(Module *M);
+  virtual void endModule() = 0;
 
-  void beginFunction(const MachineFunction *MF) override;
-  void endFunction(const MachineFunction *MF) override;
+  virtual void beginInstruction(const MachineInstr *MI);
+  virtual void endInstruction();
 
-  void beginBasicBlockSection(const MachineBasicBlock &MBB) override;
-  void endBasicBlockSection(const MachineBasicBlock &MBB) override;
+  void beginFunction(const MachineFunction *MF);
+  void endFunction(const MachineFunction *MF);
+
+  void beginBasicBlockSection(const MachineBasicBlock &MBB);
+  void endBasicBlockSection(const MachineBasicBlock &MBB);
 
   /// Return Label preceding the instruction.
   MCSymbol *getLabelBeforeInsn(const MachineInstr *MI);

--- a/llvm/include/llvm/CodeGen/DebugHandlerBase.h
+++ b/llvm/include/llvm/CodeGen/DebugHandlerBase.h
@@ -123,7 +123,7 @@ private:
 public:
   /// For symbols that have a size designated (e.g. common symbols),
   /// this tracks that size. Only used by DWARF.
-  virtual void setSymbolSize(const MCSymbol *Sym, uint64_t Size) {};
+  virtual void setSymbolSize(const MCSymbol *Sym, uint64_t Size) {}
 
   virtual void beginModule(Module *M);
   virtual void endModule() = 0;

--- a/llvm/lib/CodeGen/AsmPrinter/CodeViewDebug.h
+++ b/llvm/lib/CodeGen/AsmPrinter/CodeViewDebug.h
@@ -517,8 +517,6 @@ public:
 
   void beginModule(Module *M) override;
 
-  void setSymbolSize(const MCSymbol *, uint64_t) override {}
-
   /// Emit the COFF section that holds the line table information.
   void endModule() override;
 

--- a/llvm/lib/CodeGen/AsmPrinter/DebugHandlerBase.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/DebugHandlerBase.cpp
@@ -99,6 +99,8 @@ DbgVariableLocation::extractFromMachineInstruction(
 
 DebugHandlerBase::DebugHandlerBase(AsmPrinter *A) : Asm(A), MMI(Asm->MMI) {}
 
+DebugHandlerBase::~DebugHandlerBase() = default;
+
 void DebugHandlerBase::beginModule(Module *M) {
   if (M->debug_compile_units().empty())
     Asm = nullptr;

--- a/llvm/lib/CodeGen/AsmPrinter/EHStreamer.h
+++ b/llvm/lib/CodeGen/AsmPrinter/EHStreamer.h
@@ -150,11 +150,6 @@ public:
   EHStreamer(AsmPrinter *A);
   ~EHStreamer() override;
 
-  // Unused.
-  void setSymbolSize(const MCSymbol *Sym, uint64_t Size) override {}
-  void beginInstruction(const MachineInstr *MI) override {}
-  void endInstruction() override {}
-
   /// Return `true' if this is a call to a function marked `nounwind'. Return
   /// `false' otherwise.
   static bool callToNoUnwindFunction(const MachineInstr *MI);

--- a/llvm/lib/CodeGen/AsmPrinter/PseudoProbePrinter.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/PseudoProbePrinter.cpp
@@ -20,8 +20,6 @@
 
 using namespace llvm;
 
-PseudoProbeHandler::~PseudoProbeHandler() = default;
-
 void PseudoProbeHandler::emitPseudoProbe(uint64_t Guid, uint64_t Index,
                                          uint64_t Type, uint64_t Attr,
                                          const DILocation *DebugLoc) {

--- a/llvm/lib/CodeGen/AsmPrinter/PseudoProbePrinter.h
+++ b/llvm/lib/CodeGen/AsmPrinter/PseudoProbePrinter.h
@@ -21,7 +21,7 @@ namespace llvm {
 class AsmPrinter;
 class DILocation;
 
-class PseudoProbeHandler : public AsmPrinterHandler {
+class PseudoProbeHandler {
   // Target of pseudo probe emission.
   AsmPrinter *Asm;
   // Name to GUID map, used as caching/memoization for speed.
@@ -29,18 +29,9 @@ class PseudoProbeHandler : public AsmPrinterHandler {
 
 public:
   PseudoProbeHandler(AsmPrinter *A) : Asm(A){};
-  ~PseudoProbeHandler() override;
 
   void emitPseudoProbe(uint64_t Guid, uint64_t Index, uint64_t Type,
                        uint64_t Attr, const DILocation *DebugLoc);
-
-  // Unused.
-  void setSymbolSize(const MCSymbol *Sym, uint64_t Size) override {}
-  void endModule() override {}
-  void beginFunction(const MachineFunction *MF) override {}
-  void endFunction(const MachineFunction *MF) override {}
-  void beginInstruction(const MachineInstr *MI) override {}
-  void endInstruction() override {}
 };
 
 } // namespace llvm

--- a/llvm/lib/CodeGen/AsmPrinter/PseudoProbePrinter.h
+++ b/llvm/lib/CodeGen/AsmPrinter/PseudoProbePrinter.h
@@ -28,7 +28,7 @@ class PseudoProbeHandler {
   DenseMap<StringRef, uint64_t> NameGuidMap;
 
 public:
-  PseudoProbeHandler(AsmPrinter *A) : Asm(A){};
+  PseudoProbeHandler(AsmPrinter *A) : Asm(A) {};
 
   void emitPseudoProbe(uint64_t Guid, uint64_t Index, uint64_t Type,
                        uint64_t Attr, const DILocation *DebugLoc);

--- a/llvm/lib/CodeGen/AsmPrinter/WinCFGuard.h
+++ b/llvm/lib/CodeGen/AsmPrinter/WinCFGuard.h
@@ -30,8 +30,6 @@ public:
   WinCFGuard(AsmPrinter *A);
   ~WinCFGuard() override;
 
-  void setSymbolSize(const MCSymbol *Sym, uint64_t Size) override {}
-
   /// Emit the Control Flow Guard function ID table.
   void endModule() override;
 
@@ -44,12 +42,6 @@ public:
   /// Please note that some AsmPrinter implementations may not call
   /// beginFunction at all.
   void endFunction(const MachineFunction *MF) override;
-
-  /// Process beginning of an instruction.
-  void beginInstruction(const MachineInstr *MI) override {}
-
-  /// Process end of an instruction.
-  void endInstruction() override {}
 };
 
 } // namespace llvm

--- a/llvm/lib/Target/BPF/BPFAsmPrinter.cpp
+++ b/llvm/lib/Target/BPF/BPFAsmPrinter.cpp
@@ -61,9 +61,7 @@ bool BPFAsmPrinter::doInitialization(Module &M) {
   // Only emit BTF when debuginfo available.
   if (MAI->doesSupportDebugInformation() && !M.debug_compile_units().empty()) {
     BTF = new BTFDebug(this);
-    Handlers.push_back(HandlerInfo(std::unique_ptr<BTFDebug>(BTF), "emit",
-                                   "Debug Info Emission", "BTF",
-                                   "BTF Emission"));
+    DebugHandlers.push_back(std::unique_ptr<BTFDebug>(BTF));
   }
 
   return false;

--- a/llvm/lib/Target/BPF/BPFAsmPrinter.cpp
+++ b/llvm/lib/Target/BPF/BPFAsmPrinter.cpp
@@ -61,7 +61,8 @@ bool BPFAsmPrinter::doInitialization(Module &M) {
   // Only emit BTF when debuginfo available.
   if (MAI->doesSupportDebugInformation() && !M.debug_compile_units().empty()) {
     BTF = new BTFDebug(this);
-    DebugHandlers.push_back(std::unique_ptr<BTFDebug>(BTF));
+    DebugHandlers.emplace_back(std::unique_ptr<BTFDebug>(BTF), "emit",
+                               "Debug Info Emission", "BTF", "BTF Emission");
   }
 
   return false;

--- a/llvm/lib/Target/BPF/BTFDebug.h
+++ b/llvm/lib/Target/BPF/BTFDebug.h
@@ -420,8 +420,6 @@ public:
     return DIToIdMap[Ty];
   }
 
-  void setSymbolSize(const MCSymbol *Symbol, uint64_t Size) override {}
-
   /// Process beginning of an instruction.
   void beginInstruction(const MachineInstr *MI) override;
 

--- a/llvm/unittests/CodeGen/AsmPrinterDwarfTest.cpp
+++ b/llvm/unittests/CodeGen/AsmPrinterDwarfTest.cpp
@@ -382,13 +382,10 @@ class AsmPrinterHandlerTest : public AsmPrinterFixtureBase {
   public:
     TestHandler(AsmPrinterHandlerTest &Test) : Test(Test) {}
     virtual ~TestHandler() {}
-    virtual void setSymbolSize(const MCSymbol *Sym, uint64_t Size) override {}
     virtual void beginModule(Module *M) override { Test.BeginCount++; }
     virtual void endModule() override { Test.EndCount++; }
     virtual void beginFunction(const MachineFunction *MF) override {}
     virtual void endFunction(const MachineFunction *MF) override {}
-    virtual void beginInstruction(const MachineInstr *MI) override {}
-    virtual void endInstruction() override {}
   };
 
 protected:

--- a/llvm/unittests/CodeGen/AsmPrinterDwarfTest.cpp
+++ b/llvm/unittests/CodeGen/AsmPrinterDwarfTest.cpp
@@ -9,6 +9,8 @@
 #include "TestAsmPrinter.h"
 #include "llvm/BinaryFormat/ELF.h"
 #include "llvm/CodeGen/AsmPrinter.h"
+#include "llvm/CodeGen/AsmPrinterHandler.h"
+#include "llvm/CodeGen/DebugHandlerBase.h"
 #include "llvm/CodeGen/MachineModuleInfo.h"
 #include "llvm/IR/LegacyPassManager.h"
 #include "llvm/IR/Module.h"
@@ -395,7 +397,7 @@ protected:
       return false;
 
     auto *AP = TestPrinter->getAP();
-    AP->addAsmPrinterHandler(AsmPrinter::HandlerInfo(
+    AP->addAsmPrinterHandler(AsmPrinter::HandlerInfo<AsmPrinterHandler>(
         std::unique_ptr<AsmPrinterHandler>(new TestHandler(*this)),
         "TestTimerName", "TestTimerDesc", "TestGroupName", "TestGroupDesc"));
     LLVMTargetMachine *LLVMTM = static_cast<LLVMTargetMachine *>(&AP->TM);
@@ -407,7 +409,7 @@ protected:
     M->setDataLayout(LLVMTM->createDataLayout());
     PM.run(*M);
     // Now check that we can run it twice.
-    AP->addAsmPrinterHandler(AsmPrinter::HandlerInfo(
+    AP->addAsmPrinterHandler(AsmPrinter::HandlerInfo<AsmPrinterHandler>(
         std::unique_ptr<AsmPrinterHandler>(new TestHandler(*this)),
         "TestTimerName", "TestTimerDesc", "TestGroupName", "TestGroupDesc"));
     PM.run(*M);
@@ -419,6 +421,60 @@ protected:
 };
 
 TEST_F(AsmPrinterHandlerTest, Basic) {
+  if (!init("x86_64-pc-linux", /*DwarfVersion=*/4, dwarf::DWARF32))
+    GTEST_SKIP();
+
+  ASSERT_EQ(BeginCount, 3);
+  ASSERT_EQ(EndCount, 3);
+}
+
+class AsmPrinterDebugHandlerTest : public AsmPrinterFixtureBase {
+  class TestDebugHandler : public DebugHandlerBase {
+    AsmPrinterDebugHandlerTest &Test;
+
+  public:
+    TestDebugHandler(AsmPrinterDebugHandlerTest &Test, AsmPrinter *AP)
+        : DebugHandlerBase(AP), Test(Test) {}
+    virtual ~TestDebugHandler() {}
+    virtual void beginModule(Module *M) override { Test.BeginCount++; }
+    virtual void endModule() override { Test.EndCount++; }
+    virtual void beginFunctionImpl(const MachineFunction *MF) override {}
+    virtual void endFunctionImpl(const MachineFunction *MF) override {}
+    virtual void beginInstruction(const MachineInstr *MI) override {}
+    virtual void endInstruction() override {}
+  };
+
+protected:
+  bool init(const std::string &TripleStr, unsigned DwarfVersion,
+            dwarf::DwarfFormat DwarfFormat) {
+    if (!AsmPrinterFixtureBase::init(TripleStr, DwarfVersion, DwarfFormat))
+      return false;
+
+    auto *AP = TestPrinter->getAP();
+    AP->addDebugHandler(AsmPrinter::HandlerInfo<DebugHandlerBase>(
+        std::make_unique<TestDebugHandler>(*this, AP), "TestTimerName",
+        "TestTimerDesc", "TestGroupName", "TestGroupDesc"));
+    LLVMTargetMachine *LLVMTM = static_cast<LLVMTargetMachine *>(&AP->TM);
+    legacy::PassManager PM;
+    PM.add(new MachineModuleInfoWrapperPass(LLVMTM));
+    PM.add(TestPrinter->releaseAP()); // Takes ownership of destroying AP
+    LLVMContext Context;
+    std::unique_ptr<Module> M(new Module("TestModule", Context));
+    M->setDataLayout(LLVMTM->createDataLayout());
+    PM.run(*M);
+    // Now check that we can run it twice.
+    AP->addDebugHandler(AsmPrinter::HandlerInfo<DebugHandlerBase>(
+        std::make_unique<TestDebugHandler>(*this, AP), "TestTimerName",
+        "TestTimerDesc", "TestGroupName", "TestGroupDesc"));
+    PM.run(*M);
+    return true;
+  }
+
+  int BeginCount = 0;
+  int EndCount = 0;
+};
+
+TEST_F(AsmPrinterDebugHandlerTest, Basic) {
   if (!init("x86_64-pc-linux", /*DwarfVersion=*/4, dwarf::DWARF32))
     GTEST_SKIP();
 


### PR DESCRIPTION
Currently, an AsmPrinterHandler has several methods that allow to dynamically hook in unwind or debug info emission, e.g. at begin/end of every function or instruction. The class hierarchy and the actually overriden functions are as follows:

    (SymSz=setSymbolSize, mFE=markFunctionEnd, BBS=BasicBlockSection,
     FL=Funclet; b=beginX, e=endX)
                          SymSz   Mod Fn  mFE BBS FL  Inst
    AsmPrinterHandler     -       -   -   -   -   -   -
    ` PseudoProbeHandler  -       -   -   -   -   -   -
    ` WinCFGuard          -       e   e   -   -   -   -
    ` EHStreamer          -       -   -   -   -   -   -
      ` DwarfCFIException -       e   be  -   be  -   -
      ` ARMException      -       -   be  e   -   -   -
      ` AIXException      -       -   e   -   -   -   -
      ` WinException      -       e   be  e   -   be  -
      ` WasmException     -       e   be  -   -   -   -
    ` DebugHandlerBase    -       b   be  -   be  -   be
      ` BTFDebug          -       e   -   -   -   -   b
      ` CodeViewDebug     -       be  -   -   -   -   b
      ` DWARFDebug        yes     be  -   -   -   -   b

Doing virtual function calls per instruction is costly and useless when the called function does nothing.

This commit performs the following clean-up/improvements:

- PseudoProbeHandler is no longer an AsmPrinterHandler -- it used nothing of its functionality to hook in at the possible points. This avoids virtual function calls when a pseudo probe printer is present.

- DebugHandlerBase is no longer an AsmPrinterHandler, but a separate base class. DebugHandlerBase is the only remaining "hook" for begin/end instruction and setSymbolSize (only used by DWARFDebug). begin/end for function and basic block sections are never overriden and therefore are no longer virtual. (Originally I intended there to be only one debug handler, but BPF as the only target supports two at the same time: DWARF and BTF.)

- AsmPrinterHandler no longer has begin/end instruction and setSymbolSize hooks -- these were only used by DebugHandlerBase. This avoid iterating over handlers in every instruction.

- Remove NamedRegionTimer from instruction loop. Checking a global variable for every instruction (and doing an out-of-line function call) is too expensive for a profiling functionality.

```
    AsmPrinterHandler     Mod Fn  mFE BBS FL
    ` WinCFGuard          e   e   -   -   -
    ` EHStreamer          -   -   -   -   -
      ` DwarfCFIException e   be  -   be  -
      ` ARMException      -   be  e   -   -
      ` AIXException      -   e   -   -   -
      ` WinException      e   be  e   -   be
      ` WasmException     e   be  -   -   -

                          SymSz   Mod Fn  BBS Inst
    DebugHandlerBase      -       b   be  be  be
    ` BTFDebug            -       e           b
    ` CodeViewDebug       -       be          b
    ` DWARFDebug          yes     be          b

    PseudoProbeHandler (no shared methods)
```

This results in a performance improvement, especially in the -O0 -g0 case with unwind information (e.g., JIT baseline).

---

http://llvm-compile-time-tracker.com/compare.php?from=54cb5ca9f48fc542b920662a0eee7c0e6f35bee0&to=9ce05be2903285e1681ced36e5862ad3e155cb17&stat=instructions%3Au