### PR TITLE
[libc] Fix Fuscia builder failing on atomic warnings

### DIFF
--- a/libc/src/stdlib/rand.cpp
+++ b/libc/src/stdlib/rand.cpp
@@ -13,6 +13,10 @@
 
 namespace LIBC_NAMESPACE {
 
+// Silence warnings on targets with slow atomics.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Watomic-alignment"
+
 // An implementation of the xorshift64star pseudo random number generator. This
 // is a good general purpose generator for most non-cryptographics applications.
 LLVM_LIBC_FUNCTION(int, rand, (void)) {
@@ -28,5 +32,7 @@ LLVM_LIBC_FUNCTION(int, rand, (void)) {
     sleep_briefly();
   }
 }
+
+#pragma GCC diagnostic pop
 
 } // namespace LIBC_NAMESPACE

--- a/libc/src/stdlib/srand.cpp
+++ b/libc/src/stdlib/srand.cpp
@@ -12,8 +12,14 @@
 
 namespace LIBC_NAMESPACE {
 
+// Silence warnings on targets with slow atomics.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Watomic-alignment"
+
 LLVM_LIBC_FUNCTION(void, srand, (unsigned int seed)) {
   rand_next.store(seed, cpp::MemoryOrder::RELAXED);
 }
+
+#pragma GCC diagnostic pop
 
 } // namespace LIBC_NAMESPACE


### PR DESCRIPTION
Summary:
This function uses atomics now, which emit warnings on some platforms
that don't support full lock-free atomics. These aren't specifically
wrong, and in the future we could investigate a libc configuration
specialized for single-threaded microprocessors, but for now we should
get the bot running again.
