### PR TITLE
Fix the test to deal with non-deterministic output.

### DIFF
--- a/lldb/test/Shell/SymbolFile/DWARF/x86/dwp-foreign-type-units.cpp
+++ b/lldb/test/Shell/SymbolFile/DWARF/x86/dwp-foreign-type-units.cpp
@@ -30,24 +30,14 @@
 // RUN:   -o "type lookup CustomType" \
 // RUN:   -b %t | FileCheck %s --check-prefix=NODWP
 // NODWP: (lldb) type lookup IntegerType
-// NODWP-NEXT: int
-// NODWP-NEXT: unsigned int
+// NODWP-DAG: int
+// NODWP-DAG: unsigned int
 // NODWP: (lldb) type lookup FloatType
-// NODWP-NEXT: double
-// NODWP-NEXT: float
+// NODWP-DAG: double
+// NODWP-DAG: float
 // NODWP: (lldb) type lookup CustomType
-// NODWP-NEXT: struct CustomType {
-// NODWP-NEXT:     typedef int IntegerType;
-// NODWP-NEXT:     typedef double FloatType;
-// NODWP-NEXT:     CustomType::IntegerType x;
-// NODWP-NEXT:     CustomType::FloatType y;
-// NODWP-NEXT: }
-// NODWP-NEXT: struct CustomType {
-// NODWP-NEXT:     typedef unsigned int IntegerType;
-// NODWP-NEXT:     typedef float FloatType;
-// NODWP-NEXT:     CustomType::IntegerType x;
-// NODWP-NEXT:     CustomType::FloatType y;
-// NODWP-NEXT: }
+// NODWP: struct CustomType {
+// NODWP: struct CustomType {
 
 // Check when we make the .dwp file with %t.main.dwo first so it will
 // pick the type unit from %t.main.dwo. Verify we find only the types from


### PR DESCRIPTION
When we check for the "struct CustomType" in the NODWP, we can just make sure that we have both types showing up, the next tests will validate the types are correct. Also added a "-DAG" to the integer and float types. This should fix the flakiness in this test.