### PR TITLE
[clang-doc] Improve clang-doc performance through memoization

### DIFF
--- a/clang-tools-extra/clang-doc/HTMLGenerator.cpp
+++ b/clang-tools-extra/clang-doc/HTMLGenerator.cpp
@@ -983,7 +983,7 @@ static llvm::Error serializeIndex(ClangDocContext &CDCtx) {
   llvm::json::OStream J(OS, 2);
   std::function<void(Index)> IndexToJSON = [&](const Index &I) {
     J.object([&] {
-      //J.attribute("USR", toHex(llvm::toStringRef(I.USR)));
+      J.attribute("USR", toHex(llvm::toStringRef(I.USR)));
       J.attribute("Name", I.Name);
       J.attribute("RefType", getRefType(I.RefType));
       J.attribute("Path", I.getRelativeFilePath(""));

--- a/clang-tools-extra/clang-doc/HTMLGenerator.cpp
+++ b/clang-tools-extra/clang-doc/HTMLGenerator.cpp
@@ -983,7 +983,7 @@ static llvm::Error serializeIndex(ClangDocContext &CDCtx) {
   llvm::json::OStream J(OS, 2);
   std::function<void(Index)> IndexToJSON = [&](const Index &I) {
     J.object([&] {
-      J.attribute("USR", toHex(llvm::toStringRef(I.USR)));
+      //J.attribute("USR", toHex(llvm::toStringRef(I.USR)));
       J.attribute("Name", I.Name);
       J.attribute("RefType", getRefType(I.RefType));
       J.attribute("Path", I.getRelativeFilePath(""));

--- a/clang-tools-extra/clang-doc/Mapper.cpp
+++ b/clang-tools-extra/clang-doc/Mapper.cpp
@@ -12,7 +12,8 @@
 #include "clang/AST/Comment.h"
 #include "clang/Index/USRGeneration.h"
 #include "llvm/ADT/StringExtras.h"
-#include "llvm/Support/Error.h"
+#include "llvm/Support/Mutex.h"
+#include <unordered_set>
 
 namespace clang {
 namespace doc {
@@ -57,10 +58,6 @@ template <typename T> bool MapASTVisitor::mapDecl(const T *D) {
                                getLine(D, D->getASTContext()), File,
                                IsFileInRootDir, CDCtx.PublicOnly);
 
-  // Bitcode
-  if (CDCtx.NoBitcode) {
-    return true;
-  }
 
   // A null in place of I indicates that the serializer is skipping this decl
   // for some reason (e.g. we're only reporting public decls).

--- a/clang-tools-extra/clang-doc/Mapper.cpp
+++ b/clang-tools-extra/clang-doc/Mapper.cpp
@@ -43,11 +43,12 @@ template <typename T> bool MapASTVisitor::mapDecl(const T *D,
   // Prevent Visiting USR twice
   {
     std::lock_guard<llvm::sys::Mutex> Guard(USRVisitedGuard);
-    if (USRVisited.count(USR.str()))
+    StringRef Visited = USR.str();
+    if (USRVisited.count(Visited))
       return true;
     // We considered a USR to be visited only when its defined
     if (IsDefinition)
-      USRVisited.insert(USR.str());
+      USRVisited.insert(Visited);
   }
 
   bool IsFileInRootDir;

--- a/clang-tools-extra/clang-doc/Mapper.cpp
+++ b/clang-tools-extra/clang-doc/Mapper.cpp
@@ -46,7 +46,6 @@ bool MapASTVisitor::mapDecl(const T *D, bool IsDefinition) {
   // If there is an error generating a USR for the decl, skip this decl.
   if (index::generateUSRForDecl(D, USR))
     return true;
-
   // Prevent Visiting USR twice
   {
     std::lock_guard<llvm::sys::Mutex> Guard(USRVisitedGuard);
@@ -57,7 +56,6 @@ bool MapASTVisitor::mapDecl(const T *D, bool IsDefinition) {
     if (IsDefinition)
       USRVisited.insert(Visited);
   }
-
   bool IsFileInRootDir;
   llvm::SmallString<128> File =
       getFile(D, D->getASTContext(), CDCtx.SourceRoot, IsFileInRootDir);
@@ -144,6 +142,8 @@ llvm::SmallString<128> MapASTVisitor::getFile(const NamedDecl *D,
   llvm::sys::path::replace_path_prefix(File, Prefix, "");
   return File;
 }
+
+
 
 } // namespace doc
 } // namespace clang

--- a/clang-tools-extra/clang-doc/Mapper.cpp
+++ b/clang-tools-extra/clang-doc/Mapper.cpp
@@ -143,7 +143,5 @@ llvm::SmallString<128> MapASTVisitor::getFile(const NamedDecl *D,
   return File;
 }
 
-
-
 } // namespace doc
 } // namespace clang

--- a/clang-tools-extra/clang-doc/Mapper.cpp
+++ b/clang-tools-extra/clang-doc/Mapper.cpp
@@ -21,12 +21,9 @@ namespace doc {
 static llvm::StringSet USRVisited;
 static llvm::sys::Mutex USRVisitedGuard;
 
-
-template <typename T> bool isTypedefAnonRecord(const T* D) {
+template <typename T> bool isTypedefAnonRecord(const T *D) {
   if (const auto *C = dyn_cast<CXXRecordDecl>(D)) {
-    if (const TypedefNameDecl *TD = C->getTypedefNameForAnonDecl()) {
-      return true;
-    }
+    return C->getTypedefNameForAnonDecl();
   }
   return false;
 }
@@ -35,8 +32,8 @@ void MapASTVisitor::HandleTranslationUnit(ASTContext &Context) {
   TraverseDecl(Context.getTranslationUnitDecl());
 }
 
-template <typename T> bool MapASTVisitor::mapDecl(const T *D,
-                            bool IsDefinition) {
+template <typename T>
+bool MapASTVisitor::mapDecl(const T *D, bool IsDefinition) {
   // If we're looking a decl not in user files, skip this decl.
   if (D->getASTContext().getSourceManager().isInSystemHeader(D->getLocation()))
     return true;
@@ -80,7 +77,7 @@ template <typename T> bool MapASTVisitor::mapDecl(const T *D,
 }
 
 bool MapASTVisitor::VisitNamespaceDecl(const NamespaceDecl *D) {
-  return mapDecl(D, true);
+  return mapDecl(D, /*isDefinition=*/true);
 }
 
 bool MapASTVisitor::VisitRecordDecl(const RecordDecl *D) {
@@ -103,11 +100,11 @@ bool MapASTVisitor::VisitFunctionDecl(const FunctionDecl *D) {
 }
 
 bool MapASTVisitor::VisitTypedefDecl(const TypedefDecl *D) {
-  return mapDecl(D, true);
+  return mapDecl(D, /*isDefinition=*/true);
 }
 
 bool MapASTVisitor::VisitTypeAliasDecl(const TypeAliasDecl *D) {
-  return mapDecl(D, true);
+  return mapDecl(D, /*isDefinition=*/true);
 }
 
 comments::FullComment *

--- a/clang-tools-extra/clang-doc/Mapper.cpp
+++ b/clang-tools-extra/clang-doc/Mapper.cpp
@@ -18,7 +18,7 @@
 namespace clang {
 namespace doc {
 
-static llvm::StringSet USRVisited;
+static llvm::StringSet<> USRVisited;
 static llvm::sys::Mutex USRVisitedGuard;
 
 template <typename T> bool isTypedefAnonRecord(const T *D) {

--- a/clang-tools-extra/clang-doc/Mapper.h
+++ b/clang-tools-extra/clang-doc/Mapper.h
@@ -20,8 +20,6 @@
 #include "Representation.h"
 #include "clang/AST/RecursiveASTVisitor.h"
 #include "clang/Tooling/Execution.h"
-#include "llvm/Support/Mutex.h"
-#include <unordered_set>
 
 using namespace clang::comments;
 using namespace clang::tooling;
@@ -55,7 +53,6 @@ private:
                                     const ASTContext &Context) const;
 
   ClangDocContext CDCtx;
-
 };
 
 } // namespace doc

--- a/clang-tools-extra/clang-doc/Mapper.h
+++ b/clang-tools-extra/clang-doc/Mapper.h
@@ -20,6 +20,8 @@
 #include "Representation.h"
 #include "clang/AST/RecursiveASTVisitor.h"
 #include "clang/Tooling/Execution.h"
+#include "llvm/Support/Mutex.h"
+#include <unordered_set>
 
 using namespace clang::comments;
 using namespace clang::tooling;
@@ -53,6 +55,7 @@ private:
                                     const ASTContext &Context) const;
 
   ClangDocContext CDCtx;
+
 };
 
 } // namespace doc

--- a/clang-tools-extra/clang-doc/Mapper.h
+++ b/clang-tools-extra/clang-doc/Mapper.h
@@ -43,7 +43,7 @@ public:
   bool VisitTypeAliasDecl(const TypeAliasDecl *D);
 
 private:
-  template <typename T> bool mapDecl(const T *D);
+  template <typename T> bool mapDecl(const T *D, bool isDefinition);
 
   int getLine(const NamedDecl *D, const ASTContext &Context) const;
   llvm::SmallString<128> getFile(const NamedDecl *D, const ASTContext &Context,

--- a/clang-tools-extra/clang-doc/Mapper.h
+++ b/clang-tools-extra/clang-doc/Mapper.h
@@ -43,7 +43,7 @@ public:
   bool VisitTypeAliasDecl(const TypeAliasDecl *D);
 
 private:
-  template <typename T> bool mapDecl(const T *D, bool isDefinition);
+  template <typename T> bool mapDecl(const T *D, bool IsDefinition);
 
   int getLine(const NamedDecl *D, const ASTContext &Context) const;
   llvm::SmallString<128> getFile(const NamedDecl *D, const ASTContext &Context,

--- a/clang-tools-extra/clang-doc/tool/ClangDocMain.cpp
+++ b/clang-tools-extra/clang-doc/tool/ClangDocMain.cpp
@@ -313,12 +313,6 @@ Example usage for a project using a compile commands database:
 
   // First reducing phase (reduce all decls into one info per decl).
   llvm::outs() << "Reducing " << USRToBitcode.size() << " infos...\n";
-  int i = 0;
-  for(auto &Group : USRToBitcode) {
-    i += USRToBitcode.size();
-  }
-  llvm::outs() << "USR: " << i << "\n";
-
   std::atomic<bool> Error;
   Error = false;
   llvm::sys::Mutex IndexMutex;

--- a/clang-tools-extra/clang-doc/tool/ClangDocMain.cpp
+++ b/clang-tools-extra/clang-doc/tool/ClangDocMain.cpp
@@ -18,12 +18,9 @@
 //===----------------------------------------------------------------------===//
 
 #include "BitcodeReader.h"
-#include "BitcodeWriter.h"
 #include "ClangDoc.h"
 #include "Generators.h"
 #include "Representation.h"
-#include "clang/AST/AST.h"
-#include "clang/AST/Decl.h"
 #include "clang/ASTMatchers/ASTMatchFinder.h"
 #include "clang/ASTMatchers/ASTMatchersInternal.h"
 #include "clang/Driver/Options.h"
@@ -31,14 +28,11 @@
 #include "clang/Tooling/AllTUsExecution.h"
 #include "clang/Tooling/CommonOptionsParser.h"
 #include "clang/Tooling/Execution.h"
-#include "clang/Tooling/Tooling.h"
-#include "llvm/ADT/APFloat.h"
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/Error.h"
 #include "llvm/Support/FileSystem.h"
 #include "llvm/Support/Mutex.h"
 #include "llvm/Support/Path.h"
-#include "llvm/Support/Process.h"
 #include "llvm/Support/Signals.h"
 #include "llvm/Support/ThreadPool.h"
 #include "llvm/Support/raw_ostream.h"
@@ -70,6 +64,11 @@ static llvm::cl::opt<std::string>
     OutDirectory("output",
                  llvm::cl::desc("Directory for outputting generated files."),
                  llvm::cl::init("docs"), llvm::cl::cat(ClangDocCategory));
+
+static llvm::cl::opt<bool> NoBitcode(
+     "nobitcode",
+     llvm::cl::desc("Do not emit bitcode for faster processing time"),
+     llvm::cl::init(false), llvm::cl::cat(ClangDocCategory));
 
 static llvm::cl::opt<bool>
     PublicOnly("public", llvm::cl::desc("Document only public declarations."),
@@ -267,6 +266,7 @@ Example usage for a project using a compile commands database:
       Executor->get()->getExecutionContext(),
       ProjectName,
       PublicOnly,
+      NoBitcode,
       OutDirectory,
       SourceRoot,
       RepositoryUrl,
@@ -313,6 +313,7 @@ Example usage for a project using a compile commands database:
 
   // First reducing phase (reduce all decls into one info per decl).
   llvm::outs() << "Reducing " << USRToBitcode.size() << " infos...\n";
+
   std::atomic<bool> Error;
   Error = false;
   llvm::sys::Mutex IndexMutex;

--- a/clang-tools-extra/clang-doc/tool/ClangDocMain.cpp
+++ b/clang-tools-extra/clang-doc/tool/ClangDocMain.cpp
@@ -18,9 +18,12 @@
 //===----------------------------------------------------------------------===//
 
 #include "BitcodeReader.h"
+#include "BitcodeWriter.h"
 #include "ClangDoc.h"
 #include "Generators.h"
 #include "Representation.h"
+#include "clang/AST/AST.h"
+#include "clang/AST/Decl.h"
 #include "clang/ASTMatchers/ASTMatchFinder.h"
 #include "clang/ASTMatchers/ASTMatchersInternal.h"
 #include "clang/Driver/Options.h"
@@ -28,11 +31,14 @@
 #include "clang/Tooling/AllTUsExecution.h"
 #include "clang/Tooling/CommonOptionsParser.h"
 #include "clang/Tooling/Execution.h"
+#include "clang/Tooling/Tooling.h"
+#include "llvm/ADT/APFloat.h"
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/Error.h"
 #include "llvm/Support/FileSystem.h"
 #include "llvm/Support/Mutex.h"
 #include "llvm/Support/Path.h"
+#include "llvm/Support/Process.h"
 #include "llvm/Support/Signals.h"
 #include "llvm/Support/ThreadPool.h"
 #include "llvm/Support/raw_ostream.h"
@@ -64,11 +70,6 @@ static llvm::cl::opt<std::string>
     OutDirectory("output",
                  llvm::cl::desc("Directory for outputting generated files."),
                  llvm::cl::init("docs"), llvm::cl::cat(ClangDocCategory));
-
-static llvm::cl::opt<bool> NoBitcode(
-     "nobitcode",
-     llvm::cl::desc("Do not emit bitcode for faster processing time"),
-     llvm::cl::init(false), llvm::cl::cat(ClangDocCategory));
 
 static llvm::cl::opt<bool>
     PublicOnly("public", llvm::cl::desc("Document only public declarations."),
@@ -266,7 +267,6 @@ Example usage for a project using a compile commands database:
       Executor->get()->getExecutionContext(),
       ProjectName,
       PublicOnly,
-      NoBitcode,
       OutDirectory,
       SourceRoot,
       RepositoryUrl,
@@ -313,7 +313,6 @@ Example usage for a project using a compile commands database:
 
   // First reducing phase (reduce all decls into one info per decl).
   llvm::outs() << "Reducing " << USRToBitcode.size() << " infos...\n";
-
   std::atomic<bool> Error;
   Error = false;
   llvm::sys::Mutex IndexMutex;

--- a/clang-tools-extra/clang-doc/tool/ClangDocMain.cpp
+++ b/clang-tools-extra/clang-doc/tool/ClangDocMain.cpp
@@ -231,7 +231,6 @@ Example usage for a project using a compile commands database:
 
   // Fail early if an invalid format was provided.
   std::string Format = getFormatString();
-  llvm::outs() << "Unoptimized\n";
   llvm::outs() << "Emiting docs in " << Format << " format.\n";
   auto G = doc::findGeneratorByName(Format);
   if (!G) {

--- a/clang-tools-extra/clang-doc/tool/ClangDocMain.cpp
+++ b/clang-tools-extra/clang-doc/tool/ClangDocMain.cpp
@@ -313,6 +313,12 @@ Example usage for a project using a compile commands database:
 
   // First reducing phase (reduce all decls into one info per decl).
   llvm::outs() << "Reducing " << USRToBitcode.size() << " infos...\n";
+  int i = 0;
+  for(auto &Group : USRToBitcode) {
+    i += USRToBitcode.size();
+  }
+  llvm::outs() << "USR: " << i << "\n";
+
   std::atomic<bool> Error;
   Error = false;
   llvm::sys::Mutex IndexMutex;


### PR DESCRIPTION
This patch adds a short circuit which address performance problem referenced in 
issue: https://github.com/llvm/llvm-project/issues/96570

We memoize the results after visiting a USR definition. Since the definition is always parsed last so we can safely exit earlier next time we visit the USR because everything relevant to the doc generator would've been parsed already. 
 
From my local testing it cut the runtime of generating LLVM docs from 10 hours to around 1 hour

The only differences between this output and the last are changes due to the racy nature of clang-docs doc generation. Because it is multithreaded the generated infos may be reordered in a different way, but the results remain the same
