### PR TITLE
[llvm-readobj][ELF] Alter JSON/LLVM output on note sections to allow for multiple notes per section in JSON

### DIFF
--- a/lld/test/ELF/gnu-property-align-32.s
+++ b/lld/test/ELF/gnu-property-align-32.s
@@ -17,7 +17,9 @@
 # CHECK-NEXT: Info: 0
 # CHECK-NEXT: AddressAlignment: 4
 
-# CHECK:      Note {
+# CHECK:	  Size: 0x1C
+# CHECK-NEXT: Notes [
+# CHECK-NEXT: {
 # CHECK-NEXT:   Owner: GNU
 # CHECK-NEXT:   Data size: 0xC
 # CHECK-NEXT:   Type: NT_GNU_PROPERTY_TYPE_0 (property note)

--- a/lld/test/ELF/gnu-property-align-32.s
+++ b/lld/test/ELF/gnu-property-align-32.s
@@ -17,7 +17,7 @@
 # CHECK-NEXT: Info: 0
 # CHECK-NEXT: AddressAlignment: 4
 
-# CHECK:	  Size: 0x1C
+# CHECK:      Size: 0x1C
 # CHECK-NEXT: Notes [
 # CHECK-NEXT: {
 # CHECK-NEXT:   Owner: GNU

--- a/lld/test/ELF/gnu-property-align.s
+++ b/lld/test/ELF/gnu-property-align.s
@@ -17,7 +17,9 @@
 # CHECK-NEXT: Info: 0
 # CHECK-NEXT: AddressAlignment: 8
 
-# CHECK:      Note {
+# CHECK:	  Size: 0x20
+# CHECK-NEXT: Notes [
+# CHECK-NEXT: {
 # CHECK-NEXT:   Owner: GNU
 # CHECK-NEXT:   Data size: 0x10
 # CHECK-NEXT:   Type: NT_GNU_PROPERTY_TYPE_0 (property note)

--- a/lld/test/ELF/gnu-property-align.s
+++ b/lld/test/ELF/gnu-property-align.s
@@ -17,7 +17,7 @@
 # CHECK-NEXT: Info: 0
 # CHECK-NEXT: AddressAlignment: 8
 
-# CHECK:	  Size: 0x20
+# CHECK:      Size: 0x20
 # CHECK-NEXT: Notes [
 # CHECK-NEXT: {
 # CHECK-NEXT:   Owner: GNU

--- a/lld/test/ELF/partition-notes.s
+++ b/lld/test/ELF/partition-notes.s
@@ -15,7 +15,7 @@
 // CHECK:        Type: PT_NOTE
 // CHECK-NEXT:   Offset: 0x{{0*}}[[NOTE_OFFSET:[^ ]*]]
 
-// CHECK:      Notes [
+// CHECK:      NoteSectionList [
 // CHECK-NEXT:   NoteSection {
 // CHECK-NEXT:     Name: .note.obj
 // CHECK-NEXT:     Offset: 0x{{0*}}[[NOTE_OFFSET]]

--- a/lld/test/ELF/partition-notes.s
+++ b/lld/test/ELF/partition-notes.s
@@ -20,7 +20,8 @@
 // CHECK-NEXT:     Name: .note.obj
 // CHECK-NEXT:     Offset: 0x{{0*}}[[NOTE_OFFSET]]
 // CHECK-NEXT:     Size:
-// CHECK-NEXT:     Note {
+// CHECK-NEXT:	   Notes [
+// CHECK-NEXT:     {
 // CHECK-NEXT:       Owner: foo
 // CHECK-NEXT:       Data size: 0x4
 // CHECK-NEXT:       Type: NT_VERSION (version)
@@ -28,17 +29,20 @@
 // CHECK-NEXT:         0000: 62617200                             |bar.|
 // CHECK-NEXT:       )
 // CHECK-NEXT:     }
+// CHECK-NEXT:	  ]
 // CHECK-NEXT:   }
 // CHECK-NEXT:   NoteSection {
 // CHECK-NEXT:     Name: .note.gnu.build-id
 // CHECK-NEXT:     Offset:
 // CHECK-NEXT:     Size:
-// CHECK-NEXT:     Note {
+// CHECK-NEXT:	   Notes [
+// CHECK-NEXT:     {
 // CHECK-NEXT:       Owner: GNU
 // CHECK-NEXT:       Data size:
 // CHECK-NEXT:       Type: NT_GNU_BUILD_ID (unique build ID bitstring)
 // CHECK-NEXT:       Build ID: d5101cb9d03b7e836ba9b64f5768a0b31980920f{{$}}
 // CHECK-NEXT:     }
+// CHECK-NEXT:	  ]
 // CHECK-NEXT:   }
 // CHECK-NEXT: ]
 

--- a/lld/test/ELF/partition-notes.s
+++ b/lld/test/ELF/partition-notes.s
@@ -15,7 +15,7 @@
 // CHECK:        Type: PT_NOTE
 // CHECK-NEXT:   Offset: 0x{{0*}}[[NOTE_OFFSET:[^ ]*]]
 
-// CHECK:      NoteSectionList [
+// CHECK:      NoteSections [
 // CHECK-NEXT:   NoteSection {
 // CHECK-NEXT:     Name: .note.obj
 // CHECK-NEXT:     Offset: 0x{{0*}}[[NOTE_OFFSET]]

--- a/llvm/test/tools/llvm-objcopy/ELF/add-note.test
+++ b/llvm/test/tools/llvm-objcopy/ELF/add-note.test
@@ -22,7 +22,7 @@ FileHeader:
   Type:            ET_REL
   Machine:         EM_X86_64
 
-# CHECK:      Notes [
+# CHECK:      NoteSectionList [
 # CHECK-NEXT:   NoteSection {
 # CHECK-NEXT:     Name: .note.gnu.build-id
 # CHECK-NEXT:     Offset:

--- a/llvm/test/tools/llvm-objcopy/ELF/add-note.test
+++ b/llvm/test/tools/llvm-objcopy/ELF/add-note.test
@@ -27,11 +27,13 @@ FileHeader:
 # CHECK-NEXT:     Name: .note.gnu.build-id
 # CHECK-NEXT:     Offset:
 # CHECK-NEXT:     Size:
-# CHECK-NEXT:     Note {
+# CHECK-NEXT:     Notes [
+# CHECK-NEXT:     {
 # CHECK-NEXT:       Owner: GNU
 # CHECK-NEXT:       Data size: 0x10
 # CHECK-NEXT:       Type: NT_GNU_BUILD_ID
 # CHECK-NEXT:       Build ID: 000102030405060708090a0b0c0d0e0f
 # CHECK-NEXT:     }
+# CHECK-NEXT:   ]
 # CHECK-NEXT:   }
 # CHECK-NEXT: ]

--- a/llvm/test/tools/llvm-objcopy/ELF/add-note.test
+++ b/llvm/test/tools/llvm-objcopy/ELF/add-note.test
@@ -22,7 +22,7 @@ FileHeader:
   Type:            ET_REL
   Machine:         EM_X86_64
 
-# CHECK:      NoteSectionList [
+# CHECK:      NoteSections [
 # CHECK-NEXT:   NoteSection {
 # CHECK-NEXT:     Name: .note.gnu.build-id
 # CHECK-NEXT:     Offset:

--- a/llvm/test/tools/llvm-readobj/ELF/AArch64/aarch64-feature-pauth.s
+++ b/llvm/test/tools/llvm-readobj/ELF/AArch64/aarch64-feature-pauth.s
@@ -27,7 +27,7 @@ end:
 # ELF-NEXT:   GNU                   0x00000018	NT_GNU_PROPERTY_TYPE_0 (property note)
 # ELF-NEXT:   AArch64 PAuth ABI core info: platform [[PLATFORM]], version [[VERSION]]
 
-# OBJ:      Notes [
+# OBJ:      NoteSectionList [
 # OBJ-NEXT:   NoteSection {
 # OBJ-NEXT:     Name: .note.gnu.property
 # OBJ-NEXT:     Offset: 0x40
@@ -164,7 +164,7 @@ end:
 # ELF-ERR-NEXT:   GNU                   0x000000[[DATASIZE]]	NT_GNU_PROPERTY_TYPE_0 (property note)
 # ELF-ERR-NEXT:   AArch64 PAuth ABI core info: [[ERR]]
 
-# OBJ-ERR:      Notes [
+# OBJ-ERR:      NoteSectionList [
 # OBJ-ERR-NEXT:   NoteSection {
 # OBJ-ERR-NEXT:     Name: .note.gnu.property
 # OBJ-ERR-NEXT:     Offset: 0x40

--- a/llvm/test/tools/llvm-readobj/ELF/AArch64/aarch64-feature-pauth.s
+++ b/llvm/test/tools/llvm-readobj/ELF/AArch64/aarch64-feature-pauth.s
@@ -32,7 +32,8 @@ end:
 # OBJ-NEXT:     Name: .note.gnu.property
 # OBJ-NEXT:     Offset: 0x40
 # OBJ-NEXT:     Size: 0x28
-# OBJ-NEXT:     Note {
+# OBJ-NEXT:     Notes [
+# OBJ-NEXT:     {
 # OBJ-NEXT:       Owner: GNU
 # OBJ-NEXT:       Data size: 0x18
 # OBJ-NEXT:       Type: NT_GNU_PROPERTY_TYPE_0 (property note)
@@ -40,6 +41,7 @@ end:
 # OBJ-NEXT:         AArch64 PAuth ABI core info: platform [[PLATFORM]], version [[VERSION]]
 # OBJ-NEXT:       ]
 # OBJ-NEXT:     }
+# OBJ-NEXT:		]
 # OBJ-NEXT:   }
 # OBJ-NEXT: ]
 

--- a/llvm/test/tools/llvm-readobj/ELF/AArch64/aarch64-feature-pauth.s
+++ b/llvm/test/tools/llvm-readobj/ELF/AArch64/aarch64-feature-pauth.s
@@ -169,7 +169,8 @@ end:
 # OBJ-ERR-NEXT:     Name: .note.gnu.property
 # OBJ-ERR-NEXT:     Offset: 0x40
 # OBJ-ERR-NEXT:     Size: 0x[[SIZE]]
-# OBJ-ERR-NEXT:     Note {
+# OBJ-ERR-NEXT:     Notes [
+# OBJ-ERR-NEXT:     {
 # OBJ-ERR-NEXT:       Owner: GNU
 # OBJ-ERR-NEXT:       Data size: 0x[[DATASIZE]]
 # OBJ-ERR-NEXT:       Type: NT_GNU_PROPERTY_TYPE_0 (property note)
@@ -177,6 +178,7 @@ end:
 # OBJ-ERR-NEXT:         AArch64 PAuth ABI core info: [[ERR]]
 # OBJ-ERR-NEXT:       ]
 # OBJ-ERR-NEXT:     }
+# OBJ-ERR-NEXT:    ]
 # OBJ-ERR-NEXT:   }
 # OBJ-ERR-NEXT: ]
 

--- a/llvm/test/tools/llvm-readobj/ELF/AArch64/aarch64-feature-pauth.s
+++ b/llvm/test/tools/llvm-readobj/ELF/AArch64/aarch64-feature-pauth.s
@@ -27,7 +27,7 @@ end:
 # ELF-NEXT:   GNU                   0x00000018	NT_GNU_PROPERTY_TYPE_0 (property note)
 # ELF-NEXT:   AArch64 PAuth ABI core info: platform [[PLATFORM]], version [[VERSION]]
 
-# OBJ:      NoteSectionList [
+# OBJ:      NoteSections [
 # OBJ-NEXT:   NoteSection {
 # OBJ-NEXT:     Name: .note.gnu.property
 # OBJ-NEXT:     Offset: 0x40
@@ -164,7 +164,7 @@ end:
 # ELF-ERR-NEXT:   GNU                   0x000000[[DATASIZE]]	NT_GNU_PROPERTY_TYPE_0 (property note)
 # ELF-ERR-NEXT:   AArch64 PAuth ABI core info: [[ERR]]
 
-# OBJ-ERR:      NoteSectionList [
+# OBJ-ERR:      NoteSections [
 # OBJ-ERR-NEXT:   NoteSection {
 # OBJ-ERR-NEXT:     Name: .note.gnu.property
 # OBJ-ERR-NEXT:     Offset: 0x40

--- a/llvm/test/tools/llvm-readobj/ELF/AArch64/aarch64-feature-pauth.s
+++ b/llvm/test/tools/llvm-readobj/ELF/AArch64/aarch64-feature-pauth.s
@@ -41,7 +41,7 @@ end:
 # OBJ-NEXT:         AArch64 PAuth ABI core info: platform [[PLATFORM]], version [[VERSION]]
 # OBJ-NEXT:       ]
 # OBJ-NEXT:     }
-# OBJ-NEXT:		]
+# OBJ-NEXT:    ]
 # OBJ-NEXT:   }
 # OBJ-NEXT: ]
 

--- a/llvm/test/tools/llvm-readobj/ELF/AArch64/aarch64-note-gnu-property.s
+++ b/llvm/test/tools/llvm-readobj/ELF/AArch64/aarch64-note-gnu-property.s
@@ -14,7 +14,8 @@
 // LLVM-NEXT:     Name: .note.gnu.property
 // LLVM-NEXT:     Offset: 0x40
 // LLVM-NEXT:     Size: 0x20
-// LLVM-NEXT:     Note {
+// LLVM-NEXT:     Notes [
+// LLVM-NEXT:     {
 // LLVM-NEXT:       Owner: GNU
 // LLVM-NEXT:       Data size: 0x10
 // LLVM-NEXT:       Type: NT_GNU_PROPERTY_TYPE_0 (property note)
@@ -22,6 +23,7 @@
 // LLVM-NEXT:         aarch64 feature: BTI, PAC, GCS
 // LLVM-NEXT:       ]
 // LLVM-NEXT:     }
+// LLVM-NEXT:	 ]
 // LLVM-NEXT:   }
 // LLVM-NEXT: ]
 

--- a/llvm/test/tools/llvm-readobj/ELF/AArch64/aarch64-note-gnu-property.s
+++ b/llvm/test/tools/llvm-readobj/ELF/AArch64/aarch64-note-gnu-property.s
@@ -9,7 +9,7 @@
 // GNU-NEXT:   GNU                   0x00000010	NT_GNU_PROPERTY_TYPE_0 (property note)
 // GNU-NEXT:     Properties:    aarch64 feature: BTI, PAC, GCS
 
-// LLVM:      Notes [
+// LLVM:      NoteSectionList [
 // LLVM-NEXT:   NoteSection {
 // LLVM-NEXT:     Name: .note.gnu.property
 // LLVM-NEXT:     Offset: 0x40

--- a/llvm/test/tools/llvm-readobj/ELF/AArch64/aarch64-note-gnu-property.s
+++ b/llvm/test/tools/llvm-readobj/ELF/AArch64/aarch64-note-gnu-property.s
@@ -9,7 +9,7 @@
 // GNU-NEXT:   GNU                   0x00000010	NT_GNU_PROPERTY_TYPE_0 (property note)
 // GNU-NEXT:     Properties:    aarch64 feature: BTI, PAC, GCS
 
-// LLVM:      NoteSectionList [
+// LLVM:      NoteSections [
 // LLVM-NEXT:   NoteSection {
 // LLVM-NEXT:     Name: .note.gnu.property
 // LLVM-NEXT:     Offset: 0x40

--- a/llvm/test/tools/llvm-readobj/ELF/AArch64/memtag.test
+++ b/llvm/test/tools/llvm-readobj/ELF/AArch64/memtag.test
@@ -90,7 +90,7 @@
 # GNU-OK-NEXT:  Android  0x00000004  NT_ANDROID_TYPE_MEMTAG (Android memory tagging information)
 # GNU-BAD-NEXT: Android  0x00000000  NT_ANDROID_TYPE_MEMTAG (Android memory tagging information)
 
-# LLVM:      Notes [
+# LLVM:      NoteSectionList [
 # LLVM-NEXT:   NoteSection {
 # LLVM-NEXT:     Name: .note.android.memtag
 # LLVM-NEXT:     Offset: 0x40

--- a/llvm/test/tools/llvm-readobj/ELF/AArch64/memtag.test
+++ b/llvm/test/tools/llvm-readobj/ELF/AArch64/memtag.test
@@ -96,7 +96,8 @@
 # LLVM-NEXT:     Offset: 0x40
 # LLVM-OK-NEXT:  Size: 0x18
 # LLVM-BAD-NEXT: Size: 0x14
-# LLVM-NEXT:     Note {
+# LLVM-NEXT:     Notes [
+# LLVM-NEXT:     {
 # LLVM-NEXT:       Owner: Android
 # LLVM-OK-NEXT:    Data size: 0x4
 # LLVM-BAD-NEXT:   Data size: 0x0
@@ -114,6 +115,7 @@
 # NOSTACK-NEXT:    Stack: Disabled
 
 # LLVM-NEXT:     }
+# LLVM-NEXT:    ]
 # LLVM-NEXT:   }
 # LLVM-NEXT: ]
 

--- a/llvm/test/tools/llvm-readobj/ELF/AArch64/memtag.test
+++ b/llvm/test/tools/llvm-readobj/ELF/AArch64/memtag.test
@@ -90,7 +90,7 @@
 # GNU-OK-NEXT:  Android  0x00000004  NT_ANDROID_TYPE_MEMTAG (Android memory tagging information)
 # GNU-BAD-NEXT: Android  0x00000000  NT_ANDROID_TYPE_MEMTAG (Android memory tagging information)
 
-# LLVM:      NoteSectionList [
+# LLVM:      NoteSections [
 # LLVM-NEXT:   NoteSection {
 # LLVM-NEXT:     Name: .note.android.memtag
 # LLVM-NEXT:     Offset: 0x40

--- a/llvm/test/tools/llvm-readobj/ELF/AArch64/note-android-unknown.test
+++ b/llvm/test/tools/llvm-readobj/ELF/AArch64/note-android-unknown.test
@@ -7,7 +7,7 @@
 # GNU-NEXT: Android  0x00000005  Unknown note type: (0x00001337)
 # GNU-NEXT: description data: 01 23 45 67 89
 
-# LLVM:      Notes [
+# LLVM:      NoteSectionList [
 # LLVM-NEXT:   NoteSection {
 # LLVM-NEXT:     Name: .note.android.unknown
 # LLVM-NEXT:     Offset: 0x40

--- a/llvm/test/tools/llvm-readobj/ELF/AArch64/note-android-unknown.test
+++ b/llvm/test/tools/llvm-readobj/ELF/AArch64/note-android-unknown.test
@@ -12,7 +12,8 @@
 # LLVM-NEXT:     Name: .note.android.unknown
 # LLVM-NEXT:     Offset: 0x40
 # LLVM-NEXT:     Size: 0x1C
-# LLVM-NEXT:     Note {
+# LLVM-NEXT:     Notes [
+# LLVM-NEXT:     {
 # LLVM-NEXT:       Owner: Android
 # LLVM-NEXT:       Data size: 0x5
 # LLVM-NEXT:       Type: Unknown (0x00001337)
@@ -20,6 +21,7 @@
 # LLVM-NEXT:         0000: 01234567 89
 # LLVM-NEXT:       )
 # LLVM-NEXT:     }
+# LLVM-NEXT:    ]
 # LLVM-NEXT:   }
 # LLVM-NEXT: ]
 

--- a/llvm/test/tools/llvm-readobj/ELF/AArch64/note-android-unknown.test
+++ b/llvm/test/tools/llvm-readobj/ELF/AArch64/note-android-unknown.test
@@ -7,7 +7,7 @@
 # GNU-NEXT: Android  0x00000005  Unknown note type: (0x00001337)
 # GNU-NEXT: description data: 01 23 45 67 89
 
-# LLVM:      NoteSectionList [
+# LLVM:      NoteSections [
 # LLVM-NEXT:   NoteSection {
 # LLVM-NEXT:     Name: .note.android.unknown
 # LLVM-NEXT:     Offset: 0x40

--- a/llvm/test/tools/llvm-readobj/ELF/gnu-note-size.test
+++ b/llvm/test/tools/llvm-readobj/ELF/gnu-note-size.test
@@ -16,7 +16,8 @@
 # LLVM-NEXT:     Name: .note.ABI-tag
 # LLVM-NEXT:     Offset:
 # LLVM-NEXT:     Size: 0x14
-# LLVM-NEXT:     Note {
+# LLVM-NEXT:     Notes [
+# LLVM-NEXT:     {
 # LLVM-NEXT:       Owner: GNU
 # LLVM-NEXT:       Data size: 0x4
 # LLVM-NEXT:       Type: NT_GNU_ABI_TAG (ABI version tag)
@@ -25,6 +26,7 @@
 # LLVM-NEXT:         0000: 00000000 |....|
 # LLVM-NEXT:       )
 # LLVM-NEXT:     }
+# LLVM-NEXT:    ]
 # LLVM-NEXT:   }
 # LLVM-NEXT: ]
 

--- a/llvm/test/tools/llvm-readobj/ELF/gnu-note-size.test
+++ b/llvm/test/tools/llvm-readobj/ELF/gnu-note-size.test
@@ -11,7 +11,7 @@
 # GNU-NEXT:     <corrupt GNU_ABI_TAG>
 # GNU-EMPTY:
 
-# LLVM:      Notes [
+# LLVM:      NoteSectionList [
 # LLVM-NEXT:   NoteSection {
 # LLVM-NEXT:     Name: .note.ABI-tag
 # LLVM-NEXT:     Offset:

--- a/llvm/test/tools/llvm-readobj/ELF/gnu-note-size.test
+++ b/llvm/test/tools/llvm-readobj/ELF/gnu-note-size.test
@@ -11,7 +11,7 @@
 # GNU-NEXT:     <corrupt GNU_ABI_TAG>
 # GNU-EMPTY:
 
-# LLVM:      NoteSectionList [
+# LLVM:      NoteSections [
 # LLVM-NEXT:   NoteSection {
 # LLVM-NEXT:     Name: .note.ABI-tag
 # LLVM-NEXT:     Offset:

--- a/llvm/test/tools/llvm-readobj/ELF/gnu-notes.test
+++ b/llvm/test/tools/llvm-readobj/ELF/gnu-notes.test
@@ -28,7 +28,7 @@
 # GNU-NEXT:   description data: 61 62 63 64
 # GNU-EMPTY:
 
-# LLVM:      Notes [
+# LLVM:      NoteSectionList [
 # LLVM-NEXT:   NoteSection {
 # LLVM-NEXT:     Name: .note.ABI-tag
 # LLVM-NEXT:     Offset: 0x78
@@ -87,7 +87,7 @@
 # LLVM-NEXT: ]
 
 ## Note: the section name is <?> here because the section header table is not present.
-# LLVM-STRIPPED:      Notes [
+# LLVM-STRIPPED:      NoteSectionList [
 # LLVM-STRIPPED-NEXT:   NoteSection {
 # LLVM-STRIPPED-NEXT:     Name: <?>
 # LLVM-STRIPPED-NEXT:     Offset: 0x78
@@ -154,7 +154,7 @@ ProgramHeaders:
 # ERR1-GNU-NEXT: warning: '[[FILE]]': unable to read notes from the SHT_NOTE section with index 1: invalid offset (0xffff0000) or size (0x0)
 # ERR1-GNU-EMPTY:
 
-# ERR1-LLVM:      Notes [
+# ERR1-LLVM:      NoteSectionList [
 # ERR1-LLVM-NEXT:   NoteSection {
 # ERR1-LLVM-NEXT:     Name:   .note
 # ERR1-LLVM-NEXT:     Offset: 0xFFFF0000
@@ -189,7 +189,7 @@ Sections:
 # ERR2-GNU-NEXT: warning: '[[FILE]]': unable to read notes from the SHT_NOTE section with index 1: invalid offset (0x40) or size (0xffff0000)
 # ERR2-GNU-EMPTY:
 
-# ERR2-LLVM:      Notes [
+# ERR2-LLVM:      NoteSectionList [
 # ERR2-LLVM-NEXT:   NoteSection {
 # ERR2-LLVM-NEXT:     Name: .note
 # ERR2-LLVM-NEXT:     Offset: 0x40
@@ -212,7 +212,7 @@ Sections:
 # ERR3-GNU-NEXT: warning: '[[FILE]]': unable to read notes from the PT_NOTE segment with index 0: invalid offset (0xffff0000) or size (0x0)
 # ERR3-GNU-NOT: {{.}}
 
-# ERR3-LLVM:      Notes [
+# ERR3-LLVM:      NoteSectionList [
 # ERR3-LLVM-NEXT:   NoteSection {
 # ERR3-LLVM-NEXT:     Name: <?>
 # ERR3-LLVM-NEXT:     Offset: 0xFFFF0000
@@ -245,7 +245,7 @@ ProgramHeaders:
 # ERR4-GNU-NEXT: warning: '[[FILE]]': unable to read notes from the PT_NOTE segment with index 0: invalid offset (0x0) or size (0xffff0000)
 # ERR4-GNU-EMPTY:
 
-# ERR4-LLVM:      Notes [
+# ERR4-LLVM:      NoteSectionList [
 # ERR4-LLVM-NEXT:   NoteSection {
 # ERR4-LLVM-NEXT:     Name: <?>
 # ERR4-LLVM-NEXT:     Offset: 0x0
@@ -265,6 +265,6 @@ ProgramHeaders:
 # PHENTSIZE-WARN-GNU: warning: '[[FILE]]': unable to read program headers to locate the PT_DYNAMIC segment: invalid e_phentsize: 1
 # PHENTSIZE-WARN-GNU: warning: '[[FILE]]': unable to read program headers to locate the PT_NOTE segment: invalid e_phentsize: 1
 
-# PHENTSIZE-WARN-LLVM:      Notes [
+# PHENTSIZE-WARN-LLVM:      NoteSectionList [
 # PHENTSIZE-WARN-LLVM-NEXT: warning: '[[FILE]]': unable to read program headers to locate the PT_NOTE segment: invalid e_phentsize: 1
 # PHENTSIZE-WARN-LLVM-NEXT: ]

--- a/llvm/test/tools/llvm-readobj/ELF/gnu-notes.test
+++ b/llvm/test/tools/llvm-readobj/ELF/gnu-notes.test
@@ -33,41 +33,48 @@
 # LLVM-NEXT:     Name: .note.ABI-tag
 # LLVM-NEXT:     Offset: 0x78
 # LLVM-NEXT:     Size: 0x20
-# LLVM-NEXT:     Note {
+# LLVM-NEXT:     Notes [
+# LLVM-NEXT:     {
 # LLVM-NEXT:       Owner: GNU
 # LLVM-NEXT:       Data size: 0x10
 # LLVM-NEXT:       Type: NT_GNU_ABI_TAG (ABI version tag)
 # LLVM-NEXT:       OS: Linux
 # LLVM-NEXT:       ABI: 2.6.32
 # LLVM-NEXT:     }
+# LLVM-NEXT:    ]
 # LLVM-NEXT:   }
 # LLVM-NEXT:   NoteSection {
 # LLVM-NEXT:     Name: .note.gnu.build-id
 # LLVM-NEXT:     Offset: 0x98
 # LLVM-NEXT:     Size: 0x20
-# LLVM-NEXT:     Note {
+# LLVM-NEXT:     Notes [
+# LLVM-NEXT:     {
 # LLVM-NEXT:       Owner: GNU
 # LLVM-NEXT:       Data size: 0x10
 # LLVM-NEXT:       Type: NT_GNU_BUILD_ID (unique build ID bitstring)
 # LLVM-NEXT:       Build ID: 4fcb712aa6387724a9f465a32cd8c14b
 # LLVM-NEXT:     }
+# LLVM-NEXT:    ]
 # LLVM-NEXT:   }
 # LLVM-NEXT:   NoteSection {
 # LLVM-NEXT:     Name: .note.gnu.gold-version
 # LLVM-NEXT:     Offset: 0xB8
 # LLVM-NEXT:     Size: 0x1C
-# LLVM-NEXT:     Note {
+# LLVM-NEXT:     Notes [
+# LLVM-NEXT:     {
 # LLVM-NEXT:       Owner: GNU
 # LLVM-NEXT:       Data size: 0x9
 # LLVM-NEXT:       Type: NT_GNU_GOLD_VERSION (gold version)
 # LLVM-NEXT:       Version: gold 1.11
 # LLVM-NEXT:     }
+# LLVM-NEXT:    ]
 # LLVM-NEXT:   }
 # LLVM-NEXT:   NoteSection {
 # LLVM-NEXT:     Name: .note.gnu.unknown
 # LLVM-NEXT:     Offset: 0xD4
 # LLVM-NEXT:     Size: 0x14
-# LLVM-NEXT:     Note {
+# LLVM-NEXT:     Notes [
+# LLVM-NEXT:     {
 # LLVM-NEXT:       Owner: GNU
 # LLVM-NEXT:       Data size: 0x4
 # LLVM-NEXT:       Type: Unknown (0x0000abcd)
@@ -75,6 +82,7 @@
 # LLVM-NEXT:         0000: 61626364                             |abcd|
 # LLVM-NEXT:       )
 # LLVM-NEXT:     }
+# LLVM-NEXT:    ]
 # LLVM-NEXT:   }
 # LLVM-NEXT: ]
 
@@ -84,12 +92,14 @@
 # LLVM-STRIPPED-NEXT:     Name: <?>
 # LLVM-STRIPPED-NEXT:     Offset: 0x78
 # LLVM-STRIPPED-NEXT:     Size: 0x20
-# LLVM-STRIPPED-NEXT:     Note {
+# LLVM-STRIPPED-NEXT:     Notes [
+# LLVM-STRIPPED-NEXT:     {
 # LLVM-STRIPPED-NEXT:       Owner: GNU
 # LLVM-STRIPPED-NEXT:       Data size: 0x10
 # LLVM-STRIPPED-NEXT:       Type: NT_GNU_BUILD_ID (unique build ID bitstring)
 # LLVM-STRIPPED-NEXT:       Build ID: 4fcb712aa6387724a9f465a32cd8c14b
 # LLVM-STRIPPED-NEXT:     }
+# LLVM-STRIPPED-NEXT:    ]
 # LLVM-STRIPPED-NEXT:   }
 # LLVM-STRIPPED-NEXT: ]
 
@@ -149,7 +159,9 @@ ProgramHeaders:
 # ERR1-LLVM-NEXT:     Name:   .note
 # ERR1-LLVM-NEXT:     Offset: 0xFFFF0000
 # ERR1-LLVM-NEXT:     Size:   0x0
+# ERR1-LLVM-NEXT:     Notes [
 # ERR1-LLVM-NEXT: warning: '[[FILE]]': unable to read notes from the SHT_NOTE section with index 1: invalid offset (0xffff0000) or size (0x0)
+# ERR1-LLVM-NEXT:    ]
 # ERR1-LLVM-NEXT:   }
 # ERR1-LLVM-NEXT: ]
 
@@ -182,7 +194,9 @@ Sections:
 # ERR2-LLVM-NEXT:     Name: .note
 # ERR2-LLVM-NEXT:     Offset: 0x40
 # ERR2-LLVM-NEXT:     Size: 0xFFFF0000
+# ERR2-LLVM-NEXT:     Notes [
 # ERR2-LLVM-NEXT: warning: '[[FILE]]': unable to read notes from the SHT_NOTE section with index 1: invalid offset (0x40) or size (0xffff0000)
+# ERR2-LLVM-NEXT:    ]
 # ERR2-LLVM-NEXT:   }
 # ERR2-LLVM-NEXT: ]
 
@@ -203,7 +217,9 @@ Sections:
 # ERR3-LLVM-NEXT:     Name: <?>
 # ERR3-LLVM-NEXT:     Offset: 0xFFFF0000
 # ERR3-LLVM-NEXT:     Size: 0x0
+# ERR3-LLVM-NEXT:     Notes [
 # ERR3-LLVM-NEXT: warning: '[[FILE]]': unable to read notes from the PT_NOTE segment with index 0: invalid offset (0xffff0000) or size (0x0)
+# ERR3-LLVM-NEXT:    ]
 # ERR3-LLVM-NEXT:   }
 # ERR3-LLVM-NEXT: ]
 
@@ -234,7 +250,9 @@ ProgramHeaders:
 # ERR4-LLVM-NEXT:     Name: <?>
 # ERR4-LLVM-NEXT:     Offset: 0x0
 # ERR4-LLVM-NEXT:     Size: 0xFFFF0000
+# ERR4-LLVM-NEXT:     Notes [
 # ERR4-LLVM-NEXT: warning: '[[FILE]]': unable to read notes from the PT_NOTE segment with index 0: invalid offset (0x0) or size (0xffff0000)
+# ERR4-LLVM-NEXT:    ]
 # ERR4-LLVM-NEXT:   }
 # ERR4-LLVM-NEXT: ]
 

--- a/llvm/test/tools/llvm-readobj/ELF/gnu-notes.test
+++ b/llvm/test/tools/llvm-readobj/ELF/gnu-notes.test
@@ -28,7 +28,7 @@
 # GNU-NEXT:   description data: 61 62 63 64
 # GNU-EMPTY:
 
-# LLVM:      NoteSectionList [
+# LLVM:      NoteSections [
 # LLVM-NEXT:   NoteSection {
 # LLVM-NEXT:     Name: .note.ABI-tag
 # LLVM-NEXT:     Offset: 0x78
@@ -87,7 +87,7 @@
 # LLVM-NEXT: ]
 
 ## Note: the section name is <?> here because the section header table is not present.
-# LLVM-STRIPPED:      NoteSectionList [
+# LLVM-STRIPPED:      NoteSections [
 # LLVM-STRIPPED-NEXT:   NoteSection {
 # LLVM-STRIPPED-NEXT:     Name: <?>
 # LLVM-STRIPPED-NEXT:     Offset: 0x78
@@ -154,7 +154,7 @@ ProgramHeaders:
 # ERR1-GNU-NEXT: warning: '[[FILE]]': unable to read notes from the SHT_NOTE section with index 1: invalid offset (0xffff0000) or size (0x0)
 # ERR1-GNU-EMPTY:
 
-# ERR1-LLVM:      NoteSectionList [
+# ERR1-LLVM:      NoteSections [
 # ERR1-LLVM-NEXT:   NoteSection {
 # ERR1-LLVM-NEXT:     Name:   .note
 # ERR1-LLVM-NEXT:     Offset: 0xFFFF0000
@@ -189,7 +189,7 @@ Sections:
 # ERR2-GNU-NEXT: warning: '[[FILE]]': unable to read notes from the SHT_NOTE section with index 1: invalid offset (0x40) or size (0xffff0000)
 # ERR2-GNU-EMPTY:
 
-# ERR2-LLVM:      NoteSectionList [
+# ERR2-LLVM:      NoteSections [
 # ERR2-LLVM-NEXT:   NoteSection {
 # ERR2-LLVM-NEXT:     Name: .note
 # ERR2-LLVM-NEXT:     Offset: 0x40
@@ -212,7 +212,7 @@ Sections:
 # ERR3-GNU-NEXT: warning: '[[FILE]]': unable to read notes from the PT_NOTE segment with index 0: invalid offset (0xffff0000) or size (0x0)
 # ERR3-GNU-NOT: {{.}}
 
-# ERR3-LLVM:      NoteSectionList [
+# ERR3-LLVM:      NoteSections [
 # ERR3-LLVM-NEXT:   NoteSection {
 # ERR3-LLVM-NEXT:     Name: <?>
 # ERR3-LLVM-NEXT:     Offset: 0xFFFF0000
@@ -245,7 +245,7 @@ ProgramHeaders:
 # ERR4-GNU-NEXT: warning: '[[FILE]]': unable to read notes from the PT_NOTE segment with index 0: invalid offset (0x0) or size (0xffff0000)
 # ERR4-GNU-EMPTY:
 
-# ERR4-LLVM:      NoteSectionList [
+# ERR4-LLVM:      NoteSections [
 # ERR4-LLVM-NEXT:   NoteSection {
 # ERR4-LLVM-NEXT:     Name: <?>
 # ERR4-LLVM-NEXT:     Offset: 0x0
@@ -265,6 +265,6 @@ ProgramHeaders:
 # PHENTSIZE-WARN-GNU: warning: '[[FILE]]': unable to read program headers to locate the PT_DYNAMIC segment: invalid e_phentsize: 1
 # PHENTSIZE-WARN-GNU: warning: '[[FILE]]': unable to read program headers to locate the PT_NOTE segment: invalid e_phentsize: 1
 
-# PHENTSIZE-WARN-LLVM:      NoteSectionList [
+# PHENTSIZE-WARN-LLVM:      NoteSections [
 # PHENTSIZE-WARN-LLVM-NEXT: warning: '[[FILE]]': unable to read program headers to locate the PT_NOTE segment: invalid e_phentsize: 1
 # PHENTSIZE-WARN-LLVM-NEXT: ]

--- a/llvm/test/tools/llvm-readobj/ELF/note-amd-invalid-v2.test
+++ b/llvm/test/tools/llvm-readobj/ELF/note-amd-invalid-v2.test
@@ -5,7 +5,7 @@
 # RUN: llvm-readobj --notes %t.o | FileCheck %s --match-full-lines --check-prefix=LLVM
 # RUN: llvm-readelf --notes %t.o | FileCheck %s --match-full-lines --check-prefix=GNU
 
-# LLVM:      Notes [
+# LLVM:      NoteSectionList [
 # LLVM-NEXT:   NoteSection {
 # LLVM-NEXT:     Name: .note.nt_amd_hsa_code_object_version_0
 # LLVM-NEXT:     Offset: 0x40

--- a/llvm/test/tools/llvm-readobj/ELF/note-amd-invalid-v2.test
+++ b/llvm/test/tools/llvm-readobj/ELF/note-amd-invalid-v2.test
@@ -10,100 +10,118 @@
 # LLVM-NEXT:     Name: .note.nt_amd_hsa_code_object_version_0
 # LLVM-NEXT:     Offset: 0x40
 # LLVM-NEXT:     Size: 0x14
-# LLVM-NEXT:     Note {
+# LLVM-NEXT:     Notes [
+# LLVM-NEXT:     {
 # LLVM-NEXT:       Owner: AMD
 # LLVM-NEXT:       Data size: 0x4
 # LLVM-NEXT:       Type: NT_AMD_HSA_CODE_OBJECT_VERSION (AMD HSA Code Object Version)
 # LLVM-NEXT:       AMD HSA Code Object Version: Invalid AMD HSA Code Object Version
 # LLVM-NEXT:     }
+# LLVM-NEXT:    ]
 # LLVM-NEXT:   }
 # LLVM-NEXT:   NoteSection {
 # LLVM-NEXT:     Name: .note.nt_amd_hsa_code_object_version_1
 # LLVM-NEXT:     Offset: 0x54
 # LLVM-NEXT:     Size: 0x1C
-# LLVM-NEXT:     Note {
+# LLVM-NEXT:     Notes [
+# LLVM-NEXT:     {
 # LLVM-NEXT:       Owner: AMD
 # LLVM-NEXT:       Data size: 0xC
 # LLVM-NEXT:       Type: NT_AMD_HSA_CODE_OBJECT_VERSION (AMD HSA Code Object Version)
 # LLVM-NEXT:       AMD HSA Code Object Version: Invalid AMD HSA Code Object Version
 # LLVM-NEXT:     }
+# LLVM-NEXT:    ]
 # LLVM-NEXT:   }
 # LLVM-NEXT:   NoteSection {
 # LLVM-NEXT:     Name: .note.nt_amd_hsa_hsail_0
 # LLVM-NEXT:     Offset: 0x70
 # LLVM-NEXT:     Size: 0x1C
-# LLVM-NEXT:     Note {
+# LLVM-NEXT:     Notes [
+# LLVM-NEXT:     {
 # LLVM-NEXT:       Owner: AMD
 # LLVM-NEXT:       Data size: 0xA
 # LLVM-NEXT:       Type: NT_AMD_HSA_HSAIL (AMD HSA HSAIL Properties)
 # LLVM-NEXT:       AMD HSA HSAIL Properties: Invalid AMD HSA HSAIL Properties
 # LLVM-NEXT:     }
+# LLVM-NEXT:    ]
 # LLVM-NEXT:   }
 # LLVM-NEXT:   NoteSection {
 # LLVM-NEXT:     Name: .note.nt_amd_hsa_hsail_1
 # LLVM-NEXT:     Offset: 0x8C
 # LLVM-NEXT:     Size: 0x24
-# LLVM-NEXT:     Note {
+# LLVM-NEXT:     Notes [
+# LLVM-NEXT:     {
 # LLVM-NEXT:       Owner: AMD
 # LLVM-NEXT:       Data size: 0x14
 # LLVM-NEXT:       Type: NT_AMD_HSA_HSAIL (AMD HSA HSAIL Properties)
 # LLVM-NEXT:       AMD HSA HSAIL Properties: Invalid AMD HSA HSAIL Properties
 # LLVM-NEXT:     }
+# LLVM-NEXT:    ]
 # LLVM-NEXT:   }
 # LLVM-NEXT:   NoteSection {
 # LLVM-NEXT:     Name: .note.nt_amd_hsa_isa_version_0
 # LLVM-NEXT:     Offset: 0xB0
 # LLVM-NEXT:     Size: 0x18
-# LLVM-NEXT:     Note {
+# LLVM-NEXT:     Notes [
+# LLVM-NEXT:     {
 # LLVM-NEXT:       Owner: AMD
 # LLVM-NEXT:       Data size: 0x8
 # LLVM-NEXT:       Type: NT_AMD_HSA_ISA_VERSION (AMD HSA ISA Version)
 # LLVM-NEXT:       AMD HSA ISA Version: Invalid AMD HSA ISA Version
 # LLVM-NEXT:     }
+# LLVM-NEXT:    ]
 # LLVM-NEXT:   }
 # LLVM-NEXT:   NoteSection {
 # LLVM-NEXT:     Name: .note.nt_amd_hsa_isa_version_1
 # LLVM-NEXT:     Offset: 0xC8
 # LLVM-NEXT:     Size: 0x28
-# LLVM-NEXT:     Note {
+# LLVM-NEXT:     Notes [
+# LLVM-NEXT:     {
 # LLVM-NEXT:       Owner: AMD
 # LLVM-NEXT:       Data size: 0x17
 # LLVM-NEXT:       Type: NT_AMD_HSA_ISA_VERSION (AMD HSA ISA Version)
 # LLVM-NEXT:       AMD HSA ISA Version: Invalid AMD HSA ISA Version
 # LLVM-NEXT:     }
+# LLVM-NEXT:    ]
 # LLVM-NEXT:   }
 # LLVM-NEXT:   NoteSection {
 # LLVM-NEXT:     Name: .note.nt_amd_hsa_isa_version_2
 # LLVM-NEXT:     Offset: 0xF0
 # LLVM-NEXT:     Size: 0x28
-# LLVM-NEXT:     Note {
+# LLVM-NEXT:     Notes [
+# LLVM-NEXT:     {
 # LLVM-NEXT:       Owner: AMD
 # LLVM-NEXT:       Data size: 0x17
 # LLVM-NEXT:       Type: NT_AMD_HSA_ISA_VERSION (AMD HSA ISA Version)
 # LLVM-NEXT:       AMD HSA ISA Version: Invalid AMD HSA ISA Version
 # LLVM-NEXT:     }
+# LLVM-NEXT:    ]
 # LLVM-NEXT:   }
 # LLVM-NEXT:   NoteSection {
 # LLVM-NEXT:     Name: .note.nt_amd_hsa_isa_version_3
 # LLVM-NEXT:     Offset: 0x118
 # LLVM-NEXT:     Size: 0x28
-# LLVM-NEXT:     Note {
+# LLVM-NEXT:     Notes [
+# LLVM-NEXT:     {
 # LLVM-NEXT:       Owner: AMD
 # LLVM-NEXT:       Data size: 0x17
 # LLVM-NEXT:       Type: NT_AMD_HSA_ISA_VERSION (AMD HSA ISA Version)
 # LLVM-NEXT:       AMD HSA ISA Version: Invalid AMD HSA ISA Version
 # LLVM-NEXT:     }
+# LLVM-NEXT:    ]
 # LLVM-NEXT:   }
 # LLVM-NEXT:   NoteSection {
 # LLVM-NEXT:     Name: .note.nt_amd_pal_metadata
 # LLVM-NEXT:     Offset: 0x140
 # LLVM-NEXT:     Size: 0x14
-# LLVM-NEXT:     Note {
+# LLVM-NEXT:     Notes [
+# LLVM-NEXT:     {
 # LLVM-NEXT:       Owner: AMD
 # LLVM-NEXT:       Data size: 0x4
 # LLVM-NEXT:       Type: NT_AMD_PAL_METADATA (AMD PAL Metadata)
 # LLVM-NEXT:       AMD PAL Metadata: Invalid AMD PAL Metadata
 # LLVM-NEXT:     }
+# LLVM-NEXT:    ]
 # LLVM-NEXT:   }
 # LLVM-NEXT: ]
 

--- a/llvm/test/tools/llvm-readobj/ELF/note-amd-invalid-v2.test
+++ b/llvm/test/tools/llvm-readobj/ELF/note-amd-invalid-v2.test
@@ -5,7 +5,7 @@
 # RUN: llvm-readobj --notes %t.o | FileCheck %s --match-full-lines --check-prefix=LLVM
 # RUN: llvm-readelf --notes %t.o | FileCheck %s --match-full-lines --check-prefix=GNU
 
-# LLVM:      NoteSectionList [
+# LLVM:      NoteSections [
 # LLVM-NEXT:   NoteSection {
 # LLVM-NEXT:     Name: .note.nt_amd_hsa_code_object_version_0
 # LLVM-NEXT:     Offset: 0x40

--- a/llvm/test/tools/llvm-readobj/ELF/note-amd-invalid-v3.test
+++ b/llvm/test/tools/llvm-readobj/ELF/note-amd-invalid-v3.test
@@ -10,7 +10,8 @@
 # LLVM-NEXT:      Name: .note.nt_amdgpu_metadata
 # LLVM-NEXT:      Offset: 0x40
 # LLVM-NEXT:      Size: 0x38
-# LLVM-NEXT:      Note {
+# LLVM-NEXT:      Notes [
+# LLVM-NEXT:      {
 # LLVM-NEXT:        Owner: AMDGPU
 # LLVM-NEXT:        Data size: 0x24
 # LLVM-NEXT:        Type: NT_AMDGPU_METADATA (AMDGPU Metadata)
@@ -21,6 +22,7 @@
 # LLVM-NEXT:  ...
 # LLVM-EMPTY:
 # LLVM-NEXT:      }
+# LLVM-NEXT:     ]
 # LLVM-NEXT:    }
 # LLVM-NEXT:  ]
 

--- a/llvm/test/tools/llvm-readobj/ELF/note-amd-invalid-v3.test
+++ b/llvm/test/tools/llvm-readobj/ELF/note-amd-invalid-v3.test
@@ -5,7 +5,7 @@
 # RUN: llvm-readobj --notes %t.o | FileCheck %s --match-full-lines --check-prefix=LLVM
 # RUN: llvm-readelf --notes %t.o | FileCheck %s --match-full-lines --check-prefix=GNU
 
-# LLVM:       Notes [
+# LLVM:       NoteSectionList [
 # LLVM-NEXT:    NoteSection {
 # LLVM-NEXT:      Name: .note.nt_amdgpu_metadata
 # LLVM-NEXT:      Offset: 0x40

--- a/llvm/test/tools/llvm-readobj/ELF/note-amd-invalid-v3.test
+++ b/llvm/test/tools/llvm-readobj/ELF/note-amd-invalid-v3.test
@@ -5,7 +5,7 @@
 # RUN: llvm-readobj --notes %t.o | FileCheck %s --match-full-lines --check-prefix=LLVM
 # RUN: llvm-readelf --notes %t.o | FileCheck %s --match-full-lines --check-prefix=GNU
 
-# LLVM:       NoteSectionList [
+# LLVM:       NoteSections [
 # LLVM-NEXT:    NoteSection {
 # LLVM-NEXT:      Name: .note.nt_amdgpu_metadata
 # LLVM-NEXT:      Offset: 0x40

--- a/llvm/test/tools/llvm-readobj/ELF/note-amd-valid-v2.test
+++ b/llvm/test/tools/llvm-readobj/ELF/note-amd-valid-v2.test
@@ -10,89 +10,105 @@
 # LLVM-NEXT:     Name: .note.nt_amd_hsa_code_object_version
 # LLVM-NEXT:     Offset: 0x40
 # LLVM-NEXT:     Size: 0x18
-# LLVM-NEXT:     Note {
+# LLVM-NEXT:     Notes [
+# LLVM-NEXT:     {
 # LLVM-NEXT:       Owner: AMD
 # LLVM-NEXT:       Data size: 0x8
 # LLVM-NEXT:       Type: NT_AMD_HSA_CODE_OBJECT_VERSION (AMD HSA Code Object Version)
 # LLVM-NEXT:       AMD HSA Code Object Version: [Major: 2, Minor: 1]
 # LLVM-NEXT:     }
+# LLVM-NEXT:    ]
 # LLVM-NEXT:   }
 # LLVM-NEXT:   NoteSection {
 # LLVM-NEXT:     Name: .note.nt_amd_hsa_hsail
 # LLVM-NEXT:     Offset: 0x58
 # LLVM-NEXT:     Size: 0x1C
-# LLVM-NEXT:     Note {
+# LLVM-NEXT:     Notes [
+# LLVM-NEXT:     {
 # LLVM-NEXT:       Owner: AMD
 # LLVM-NEXT:       Data size: 0xC
 # LLVM-NEXT:       Type: NT_AMD_HSA_HSAIL (AMD HSA HSAIL Properties)
 # LLVM-NEXT:       AMD HSA HSAIL Properties: [HSAIL Major: 2, HSAIL Minor: 1, Profile: 1, Machine Model: 2, Default Float Round: 3]
 # LLVM-NEXT:     }
+# LLVM-NEXT:    ]
 # LLVM-NEXT:   }
 # LLVM-NEXT:   NoteSection {
 # LLVM-NEXT:     Name: .note.nt_amd_hsa_isa_version
 # LLVM-NEXT:     Offset: 0x74
 # LLVM-NEXT:     Size: 0x2C
-# LLVM-NEXT:     Note {
+# LLVM-NEXT:     Notes [
+# LLVM-NEXT:     {
 # LLVM-NEXT:       Owner: AMD
 # LLVM-NEXT:       Data size: 0x1B
 # LLVM-NEXT:       Type: NT_AMD_HSA_ISA_VERSION (AMD HSA ISA Version)
 # LLVM-NEXT:       AMD HSA ISA Version: [Vendor: AMD, Architecture: AMDGPU, Major: 8, Minor: 0, Stepping: 2]
 # LLVM-NEXT:     }
+# LLVM-NEXT:    ]
 # LLVM-NEXT:   }
 # LLVM-NEXT:   NoteSection {
 # LLVM-NEXT:     Name: .note.nt_amd_hsa_metadata_0
 # LLVM-NEXT:     Offset: 0xA0
 # LLVM-NEXT:     Size: 0x10
-# LLVM-NEXT:     Note {
+# LLVM-NEXT:     Notes [
+# LLVM-NEXT:     {
 # LLVM-NEXT:       Owner: AMD
 # LLVM-NEXT:       Data size: 0x0
 # LLVM-NEXT:       Type: NT_AMD_HSA_METADATA (AMD HSA Metadata)
 # LLVM-NEXT:       AMD HSA Metadata:
 # LLVM-NEXT:     }
+# LLVM-NEXT:    ]
 # LLVM-NEXT:   }
 # LLVM-NEXT:   NoteSection {
 # LLVM-NEXT:     Name: .note.nt_amd_hsa_metadata_1
 # LLVM-NEXT:     Offset: 0xB0
 # LLVM-NEXT:     Size: 0x18
-# LLVM-NEXT:     Note {
+# LLVM-NEXT:     Notes [
+# LLVM-NEXT:     {
 # LLVM-NEXT:       Owner: AMD
 # LLVM-NEXT:       Data size: 0x6
 # LLVM-NEXT:       Type: NT_AMD_HSA_METADATA (AMD HSA Metadata)
 # LLVM-NEXT:       AMD HSA Metadata: abcde
 # LLVM-NEXT:     }
+# LLVM-NEXT:    ]
 # LLVM-NEXT:   }
 # LLVM-NEXT:   NoteSection {
 # LLVM-NEXT:     Name: .note.nt_amd_hsa_isa_name_0
 # LLVM-NEXT:     Offset: 0xC8
 # LLVM-NEXT:     Size: 0x10
-# LLVM-NEXT:     Note {
+# LLVM-NEXT:     Notes [
+# LLVM-NEXT:     {
 # LLVM-NEXT:       Owner: AMD
 # LLVM-NEXT:       Data size: 0x0
 # LLVM-NEXT:       Type: NT_AMD_HSA_ISA_NAME (AMD HSA ISA Name)
 # LLVM-NEXT:       AMD HSA ISA Name:
 # LLVM-NEXT:     }
+# LLVM-NEXT:    ]
 # LLVM-NEXT:   }
 # LLVM-NEXT:   NoteSection {
 # LLVM-NEXT:     Name: .note.nt_amd_hsa_isa_name_1
 # LLVM-NEXT:     Offset: 0xD8
 # LLVM-NEXT:     Size: 0x18
-# LLVM-NEXT:     Note {
+# LLVM-NEXT:     Notes [
+# LLVM-NEXT:     {
 # LLVM-NEXT:       Owner: AMD
 # LLVM-NEXT:       Data size: 0x6
 # LLVM-NEXT:       Type: NT_AMD_HSA_ISA_NAME (AMD HSA ISA Name)
 # LLVM-NEXT:       AMD HSA ISA Name: abcdef
 # LLVM-NEXT:     }
+# LLVM-NEXT:    ]
 # LLVM-NEXT:   }
 # LLVM-NEXT:   NoteSection {
 # LLVM-NEXT:     Name: .note.nt_amd_pal_metadata
 # LLVM-NEXT:     Offset: 0xF0
 # LLVM-NEXT:     Size: 0x28
-# LLVM-NEXT:     Note {
+# LLVM-NEXT:     Notes [
+# LLVM-NEXT:     {
 # LLVM-NEXT:       Owner: AMD
 # LLVM-NEXT:       Data size: 0x18
 # LLVM-NEXT:       Type: NT_AMD_PAL_METADATA (AMD PAL Metadata)
 # LLVM-NEXT:       AMD PAL Metadata: [2: 1][4: 2][8: 4]
 # LLVM-NEXT:     }
+# LLVM-NEXT:    ]
 # LLVM-NEXT:   }
 # LLVM-NEXT: ]
 

--- a/llvm/test/tools/llvm-readobj/ELF/note-amd-valid-v2.test
+++ b/llvm/test/tools/llvm-readobj/ELF/note-amd-valid-v2.test
@@ -5,7 +5,7 @@
 # RUN: llvm-readobj --notes %t.o | FileCheck %s --match-full-lines --check-prefix=LLVM
 # RUN: llvm-readelf --notes %t.o | FileCheck %s --match-full-lines --check-prefix=GNU
 
-# LLVM:      Notes [
+# LLVM:      NoteSectionList [
 # LLVM-NEXT:   NoteSection {
 # LLVM-NEXT:     Name: .note.nt_amd_hsa_code_object_version
 # LLVM-NEXT:     Offset: 0x40

--- a/llvm/test/tools/llvm-readobj/ELF/note-amd-valid-v2.test
+++ b/llvm/test/tools/llvm-readobj/ELF/note-amd-valid-v2.test
@@ -5,7 +5,7 @@
 # RUN: llvm-readobj --notes %t.o | FileCheck %s --match-full-lines --check-prefix=LLVM
 # RUN: llvm-readelf --notes %t.o | FileCheck %s --match-full-lines --check-prefix=GNU
 
-# LLVM:      NoteSectionList [
+# LLVM:      NoteSections [
 # LLVM-NEXT:   NoteSection {
 # LLVM-NEXT:     Name: .note.nt_amd_hsa_code_object_version
 # LLVM-NEXT:     Offset: 0x40

--- a/llvm/test/tools/llvm-readobj/ELF/note-amd-valid-v3.s
+++ b/llvm/test/tools/llvm-readobj/ELF/note-amd-valid-v3.s
@@ -6,7 +6,7 @@
 # RUN: llvm-mc -triple=amdgcn-amd-amdhsa -mcpu=gfx900 -filetype=obj < %s | llvm-readobj --notes - | FileCheck %s --match-full-lines --check-prefix=LLVM
 # RUN: llvm-mc -triple=amdgcn-amd-amdhsa -mcpu=gfx900 -filetype=obj < %s | llvm-readelf --notes - | FileCheck %s --match-full-lines --check-prefix=GNU
 
-#LLVM:       Notes [
+#LLVM:       NoteSectionList [
 #LLVM-NEXT:    NoteSection {
 #LLVM-NEXT:      Name: .note
 #LLVM-NEXT:      Offset: 0x40

--- a/llvm/test/tools/llvm-readobj/ELF/note-amd-valid-v3.s
+++ b/llvm/test/tools/llvm-readobj/ELF/note-amd-valid-v3.s
@@ -11,7 +11,8 @@
 #LLVM-NEXT:      Name: .note
 #LLVM-NEXT:      Offset: 0x40
 #LLVM-NEXT:      Size: 0x110
-#LLVM-NEXT:      Note {
+#LLVM-NEXT:      Notes [
+#LLVM-NEXT:      {
 #LLVM-NEXT:        Owner: AMDGPU
 #LLVM-NEXT:        Data size: 0xFC
 #LLVM-NEXT:        Type: NT_AMDGPU_METADATA (AMDGPU Metadata)
@@ -33,6 +34,7 @@
 #LLVM-NEXT:  ...
 #LLVM-EMPTY:
 #LLVM-NEXT:      }
+#LLVM-NEXT:     ]
 #LLVM-NEXT:    }
 #LLVM-NEXT:  ]
 

--- a/llvm/test/tools/llvm-readobj/ELF/note-amd-valid-v3.s
+++ b/llvm/test/tools/llvm-readobj/ELF/note-amd-valid-v3.s
@@ -6,7 +6,7 @@
 # RUN: llvm-mc -triple=amdgcn-amd-amdhsa -mcpu=gfx900 -filetype=obj < %s | llvm-readobj --notes - | FileCheck %s --match-full-lines --check-prefix=LLVM
 # RUN: llvm-mc -triple=amdgcn-amd-amdhsa -mcpu=gfx900 -filetype=obj < %s | llvm-readelf --notes - | FileCheck %s --match-full-lines --check-prefix=GNU
 
-#LLVM:       NoteSectionList [
+#LLVM:       NoteSections [
 #LLVM-NEXT:    NoteSection {
 #LLVM-NEXT:      Name: .note
 #LLVM-NEXT:      Offset: 0x40

--- a/llvm/test/tools/llvm-readobj/ELF/note-amd.s
+++ b/llvm/test/tools/llvm-readobj/ELF/note-amd.s
@@ -39,52 +39,59 @@
 // LLVM-NEXT:     Name: .note.no.desc
 // LLVM-NEXT:     Offset:
 // LLVM-NEXT:     Size:
-// LLVM-NEXT:     Note {
+// LLVM-NEXT:	  Notes [
+// LLVM-NEXT:     {
 // LLVM-NEXT:       Owner: AMD
 // LLVM-NEXT:       Data size: 0x0
 // LLVM-NEXT:       Type: NT_AMD_HSA_METADATA (AMD HSA Metadata)
 // LLVM-NEXT:       AMD HSA Metadata:
 // LLVM-NEXT:     }
-// LLVM-NEXT:     Note {
+// LLVM-NEXT:     {
 // LLVM-NEXT:       Owner: AMD
 // LLVM-NEXT:       Data size: 0x0
 // LLVM-NEXT:       Type: NT_AMD_HSA_ISA_NAME (AMD HSA ISA Name)
 // LLVM-NEXT:       AMD HSA ISA Name:
 // LLVM-NEXT:     }
+// LLVM-NEXT:	 ]
 // LLVM-NEXT:   }
 // LLVM-NEXT:   NoteSection {
 // LLVM-NEXT:     Name: .note.desc
 // LLVM-NEXT:     Offset:
 // LLVM-NEXT:     Size:
-// LLVM-NEXT:     Note {
+// LLVM-NEXT:	  Notes [
+// LLVM-NEXT:     {
 // LLVM-NEXT:       Owner: AMD
 // LLVM-NEXT:       Data size: 0xA
 // LLVM-NEXT:       Type: NT_AMD_HSA_METADATA (AMD HSA Metadata)
 // LLVM-NEXT:       AMD HSA Metadata: meta_blah
 // LLVM-NEXT:     }
-// LLVM-NEXT:     Note {
+// LLVM-NEXT:     {
 // LLVM-NEXT:       Owner: AMD
 // LLVM-NEXT:       Data size: 0x9
 // LLVM-NEXT:       Type: NT_AMD_HSA_ISA_NAME (AMD HSA ISA Name)
 // LLVM-NEXT:       AMD HSA ISA Name: isa_blah
 // LLVM-NEXT:     }
+// LLVM-NEXT:	 ]
 // LLVM-NEXT:   }
 // LLVM-NEXT:   NoteSection {
 // LLVM-NEXT:     Name: .note.other
 // LLVM-NEXT:     Offset:
 // LLVM-NEXT:     Size:
-// LLVM-NEXT:     Note {
+// LLVM-NEXT:	  Notes [
+// LLVM-NEXT:     {
 // LLVM-NEXT:       Owner: AMD
 // LLVM-NEXT:       Data size: 0x0
 // LLVM-NEXT:       Type: NT_AMD_PAL_METADATA (AMD PAL Metadata)
 // LLVM-NEXT:       AMD PAL Metadata:
 // LLVM-NEXT:     }
+// LLVM-NEXT:	 ]
 // LLVM-NEXT:   }
 // LLVM-NEXT:   NoteSection {
 // LLVM-NEXT:     Name: .note.unknown
 // LLVM-NEXT:     Offset:
 // LLVM-NEXT:     Size:
-// LLVM-NEXT:     Note {
+// LLVM-NEXT:	  Notes [
+// LLVM-NEXT:     {
 // LLVM-NEXT:       Owner: AMD
 // LLVM-NEXT:       Data size: 0x7
 // LLVM-NEXT:       Type: Unknown (0x000004d2)
@@ -92,6 +99,7 @@
 // LLVM-NEXT:         0000: 61626364 656600                      |abcdef.|
 // LLVM-NEXT:       )
 // LLVM-NEXT:     }
+// LLVM-NEXT:	 ]
 // LLVM-NEXT:   }
 // LLVM-NEXT: ]
 

--- a/llvm/test/tools/llvm-readobj/ELF/note-amd.s
+++ b/llvm/test/tools/llvm-readobj/ELF/note-amd.s
@@ -34,7 +34,7 @@
 // GNU-NEXT:    description data: 61 62 63 64 65 66 00
 // GNU-EMPTY:
 
-// LLVM:      Notes [
+// LLVM:      NoteSectionList [
 // LLVM-NEXT:   NoteSection {
 // LLVM-NEXT:     Name: .note.no.desc
 // LLVM-NEXT:     Offset:

--- a/llvm/test/tools/llvm-readobj/ELF/note-amd.s
+++ b/llvm/test/tools/llvm-readobj/ELF/note-amd.s
@@ -34,7 +34,7 @@
 // GNU-NEXT:    description data: 61 62 63 64 65 66 00
 // GNU-EMPTY:
 
-// LLVM:      NoteSectionList [
+// LLVM:      NoteSections [
 // LLVM-NEXT:   NoteSection {
 // LLVM-NEXT:     Name: .note.no.desc
 // LLVM-NEXT:     Offset:

--- a/llvm/test/tools/llvm-readobj/ELF/note-amdgpu-invalid.s
+++ b/llvm/test/tools/llvm-readobj/ELF/note-amdgpu-invalid.s
@@ -30,7 +30,7 @@
 # GNU-NEXT:    description data: ab cd ef
 # GNU-EMPTY:
 
-# LLVM:      Notes [
+# LLVM:      NoteSectionList [
 # LLVM-NEXT:   NoteSection {
 # LLVM-NEXT:     Name: .note.foo
 # LLVM-NEXT:     Offset: 0x40

--- a/llvm/test/tools/llvm-readobj/ELF/note-amdgpu-invalid.s
+++ b/llvm/test/tools/llvm-readobj/ELF/note-amdgpu-invalid.s
@@ -35,7 +35,8 @@
 # LLVM-NEXT:     Name: .note.foo
 # LLVM-NEXT:     Offset: 0x40
 # LLVM-NEXT:     Size: 0xE8
-# LLVM-NEXT:     Note {
+# LLVM-NEXT:	 Notes [
+# LLVM-NEXT:     {
 # LLVM-NEXT:       Owner: AMDGPU
 # LLVM-NEXT:       Data size: 0xD4
 # LLVM-NEXT:       Type: NT_AMDGPU_METADATA (AMDGPU Metadata)
@@ -55,12 +56,14 @@
 # LLVM-NEXT: ...
 # LLVM-EMPTY:
 # LLVM-NEXT:     }
+# LLVM-NEXT:	]
 # LLVM-NEXT:   }
 # LLVM-NEXT:  NoteSection {
 # LLVM-NEXT:    Name: .note.bar
 # LLVM-NEXT:    Offset: 0x128
 # LLVM-NEXT:    Size: 0x30
-# LLVM-NEXT:    Note {
+# LLVM-NEXT:	Notes [
+# LLVM-NEXT:    {
 # LLVM-NEXT:      Owner: AMDGPU
 # LLVM-NEXT:      Data size: 0x3
 # LLVM-NEXT:      Type: NT_AMDGPU_METADATA (AMDGPU Metadata)
@@ -68,7 +71,7 @@
 # LLVM-NEXT:        0000: 123456                               |.4V|
 # LLVM-NEXT:      )
 # LLVM-NEXT:    }
-# LLVM-NEXT:    Note {
+# LLVM-NEXT:    {
 # LLVM-NEXT:      Owner: AMDGPU
 # LLVM-NEXT:      Data size: 0x3
 # LLVM-NEXT:      Type: NT_AMDGPU_METADATA (AMDGPU Metadata)
@@ -76,6 +79,7 @@
 # LLVM-NEXT:        0000: ABCDEF                               |...|
 # LLVM-NEXT:      )
 # LLVM-NEXT:    }
+# LLVM-NEXT:   ]
 # LLVM-NEXT:  }
 # LLVM-NEXT:]
 

--- a/llvm/test/tools/llvm-readobj/ELF/note-amdgpu-invalid.s
+++ b/llvm/test/tools/llvm-readobj/ELF/note-amdgpu-invalid.s
@@ -30,7 +30,7 @@
 # GNU-NEXT:    description data: ab cd ef
 # GNU-EMPTY:
 
-# LLVM:      NoteSectionList [
+# LLVM:      NoteSections [
 # LLVM-NEXT:   NoteSection {
 # LLVM-NEXT:     Name: .note.foo
 # LLVM-NEXT:     Offset: 0x40

--- a/llvm/test/tools/llvm-readobj/ELF/note-amdgpu.test
+++ b/llvm/test/tools/llvm-readobj/ELF/note-amdgpu.test
@@ -36,7 +36,8 @@
 # LLVM-NEXT:     Name: .note.foo
 # LLVM-NEXT:     Offset:
 # LLVM-NEXT:     Size:
-# LLVM-NEXT:     Note {
+# LLVM-NEXT:     Notes [
+# LLVM-NEXT:     {
 # LLVM-NEXT:       Owner: AMDGPU
 # LLVM-NEXT:       Data size: 0xFB
 # LLVM-NEXT:       Type: NT_AMDGPU_METADATA (AMDGPU Metadata)
@@ -59,12 +60,14 @@
 # LLVM-NEXT: ...
 # LLVM-EMPTY:
 # LLVM-NEXT:     }
+# LLVM-NEXT:    ]
 # LLVM-NEXT:   }
 # LLVM-NEXT:   NoteSection {
 # LLVM-NEXT:     Name: .note.unknown
 # LLVM-NEXT:     Offset: 0x150
 # LLVM-NEXT:     Size: 0x18
-# LLVM-NEXT:     Note {
+# LLVM-NEXT:     Notes [
+# LLVM-NEXT:     {
 # LLVM-NEXT:       Owner: AMDGPU
 # LLVM-NEXT:       Data size: 0x2
 # LLVM-NEXT:       Type: Unknown (0x00000101)
@@ -72,6 +75,7 @@
 # LLVM-NEXT:         0000: ABCD                                 |..|
 # LLVM-NEXT:       )
 # LLVM-NEXT:     }
+# LLVM-NEXT:     ]
 # LLVM-NEXT:   }
 # LLVM-NEXT: ]
 

--- a/llvm/test/tools/llvm-readobj/ELF/note-amdgpu.test
+++ b/llvm/test/tools/llvm-readobj/ELF/note-amdgpu.test
@@ -31,7 +31,7 @@
 # GNU-NEXT:    description data: ab cd
 # GNU-EMPTY:
 
-# LLVM:      Notes [
+# LLVM:      NoteSectionList [
 # LLVM-NEXT:   NoteSection {
 # LLVM-NEXT:     Name: .note.foo
 # LLVM-NEXT:     Offset:

--- a/llvm/test/tools/llvm-readobj/ELF/note-amdgpu.test
+++ b/llvm/test/tools/llvm-readobj/ELF/note-amdgpu.test
@@ -31,7 +31,7 @@
 # GNU-NEXT:    description data: ab cd
 # GNU-EMPTY:
 
-# LLVM:      NoteSectionList [
+# LLVM:      NoteSections [
 # LLVM-NEXT:   NoteSection {
 # LLVM-NEXT:     Name: .note.foo
 # LLVM-NEXT:     Offset:

--- a/llvm/test/tools/llvm-readobj/ELF/note-core-multiple-sections.test
+++ b/llvm/test/tools/llvm-readobj/ELF/note-core-multiple-sections.test
@@ -1,0 +1,39 @@
+## Test that note values are interpreted correctly for core files with multiple sections.
+
+## Check NT_PRSTATUS + NT_PRPSINFO.
+# RUN: yaml2obj %s -DTYPE1=0x1 -DTYPE2=0x3 -o %t1.o
+# RUN: llvm-readelf --elf-output-style=JSON --pretty-print --notes %t1.o | FileCheck %s --check-prefix=CHECK-JSON  -DDESC1="NT_PRSTATUS (prstatus structure)" -DDESC2="NT_PRPSINFO (prpsinfo structure)"
+# CHECK-JSON:       "Size": 40,
+# CHECK-JSON-NEXT:  "Notes": [
+# CHECK-JSON-NEXT:  {
+# CHECK-JSON-NEXT:   "Owner": "CORE",
+# CHECK-JSON-NEXT:   "Data size": 0,
+# CHECK-JSON-NEXT:   "Type": "[[DESC1]]"
+# CHECK-JSON-NEXT:  },
+# CHECK-JSON-NEXT:  {
+# CHECK-JSON-NEXT:   "Owner": "CORE",
+# CHECK-JSON-NEXT:   "Data size": 0,
+# CHECK-JSON-NEXT:   "Type": "[[DESC2]]"
+# CHECK-JSON-NEXT:  }
+# CHECK-JSON-NEXT:  ]
+
+--- !ELF
+FileHeader:
+  Class: ELFCLASS64
+  Data:  ELFDATA2LSB
+  Type:  ET_CORE
+Sections:
+  - Name: .note.first
+    Type: SHT_NOTE
+    Notes:
+      - Name: CORE
+        Type: [[TYPE1]]
+  - Name: .note.second
+    Type: SHT_NOTE
+    Notes:
+      - Name: CORE
+        Type: [[TYPE2]]
+ProgramHeaders:
+  - Type:     PT_NOTE
+    FirstSec: .note.first
+    LastSec:  .note.second

--- a/llvm/test/tools/llvm-readobj/ELF/note-core-ntfile.test
+++ b/llvm/test/tools/llvm-readobj/ELF/note-core-ntfile.test
@@ -68,32 +68,34 @@ ProgramHeaders:
 # LLVM-NEXT:     Name: <?>
 # LLVM-NEXT:     Offset:
 # LLVM-NEXT:     Size:
-# LLVM-NEXT:     Note {
-# LLVM-NEXT:       Owner: CORE
-# LLVM-NEXT:       Data size: 0x80
-# LLVM-NEXT:       Type: NT_FILE (mapped files)
-# LLVM-NEXT:       Page Size: 4096
-# LLVM-NEXT:       Mappings [
+# LLVM-NEXT:     Notes [
 # LLVM-NEXT:        {
-# LLVM-NEXT:         Start: 0x1000
-# LLVM-NEXT:         End: 0x2000
-# LLVM-NEXT:         Offset: 0x3000
-# LLVM-NEXT:         Filename: /path/to/a.out
+# LLVM-NEXT:            Owner: CORE
+# LLVM-NEXT:            Data size: 0x80
+# LLVM-NEXT:            Type: NT_FILE (mapped files)
+# LLVM-NEXT:            Page Size: 4096
+# LLVM-NEXT:            Mappings [
+# LLVM-NEXT:                {
+# LLVM-NEXT:                    Start: 0x1000
+# LLVM-NEXT:                    End: 0x2000
+# LLVM-NEXT:                    Offset: 0x3000
+# LLVM-NEXT:                    Filename: /path/to/a.out
+# LLVM-NEXT:                }
+# LLVM-NEXT:                {
+# LLVM-NEXT:                    Start: 0x4000
+# LLVM-NEXT:                    End: 0x5000
+# LLVM-NEXT:                    Offset: 0x6000
+# LLVM-NEXT:                    Filename: /path/to/libc.so
+# LLVM-NEXT:                }
+# LLVM-NEXT:                {
+# LLVM-NEXT:                    Start: 0x7000
+# LLVM-NEXT:                    End: 0x8000
+# LLVM-NEXT:                    Offset: 0x9000
+# LLVM-NEXT:                    Filename: [stack]
+# LLVM-NEXT:                }
+# LLVM-NEXT:            ]
 # LLVM-NEXT:        }
-# LLVM-NEXT:        {
-# LLVM-NEXT:         Start: 0x4000
-# LLVM-NEXT:         End: 0x5000
-# LLVM-NEXT:         Offset: 0x6000
-# LLVM-NEXT:         Filename: /path/to/libc.so
-# LLVM-NEXT:        }
-# LLVM-NEXT:        {
-# LLVM-NEXT:         Start: 0x7000
-# LLVM-NEXT:         End: 0x8000
-# LLVM-NEXT:         Offset: 0x9000
-# LLVM-NEXT:         Filename: [stack]
-# LLVM-NEXT:       }
-# LLVM-NEXT:     ]
-# LLVM-NEXT:   }
+# LLVM-NEXT:    ]
 # LLVM-NEXT: }
 # LLVM-NEXT: ]
 
@@ -103,32 +105,34 @@ ProgramHeaders:
 # JSON-NEXT:          "Name": "<?>",
 # JSON-NEXT:          "Offset": 120,
 # JSON-NEXT:          "Size": 148,
-# JSON-NEXT:          "Note": {
-# JSON-NEXT:              "Owner": "CORE",
-# JSON-NEXT:              "Data size": 128,
-# JSON-NEXT:              "Type": "NT_FILE (mapped files)",
-# JSON-NEXT:              "Page Size": 4096,
-# JSON-NEXT:              "Mappings": [
-# JSON-NEXT:                {
-# JSON-NEXT:                  "Start": 4096,
-# JSON-NEXT:                  "End": 8192,
-# JSON-NEXT:                  "Offset": 12288,
-# JSON-NEXT:                  "Filename": "/path/to/a.out"
-# JSON-NEXT:                },
-# JSON-NEXT:                {
-# JSON-NEXT:                  "Start": 16384,
-# JSON-NEXT:                  "End": 20480,
-# JSON-NEXT:                  "Offset": 24576,
-# JSON-NEXT:                  "Filename": "/path/to/libc.so"
-# JSON-NEXT:                },
-# JSON-NEXT:                {
-# JSON-NEXT:                  "Start": 28672,
-# JSON-NEXT:                  "End": 32768,
-# JSON-NEXT:                  "Offset": 36864,
-# JSON-NEXT:                  "Filename": "[stack]"
-# JSON-NEXT:                }
-# JSON-NEXT:            ]
-# JSON-NEXT:          }
+# JSON-NEXT:          "Notes": [
+# JSON-NEXT:            {
+# JSON-NEXT:                "Owner": "CORE",
+# JSON-NEXT:                "Data size": 128,
+# JSON-NEXT:                "Type": "NT_FILE (mapped files)",
+# JSON-NEXT:                "Page Size": 4096,
+# JSON-NEXT:                "Mappings": [
+# JSON-NEXT:                    {
+# JSON-NEXT:                        "Start": 4096,
+# JSON-NEXT:                        "End": 8192,
+# JSON-NEXT:                        "Offset": 12288,
+# JSON-NEXT:                        "Filename": "/path/to/a.out"
+# JSON-NEXT:                    },
+# JSON-NEXT:                    {
+# JSON-NEXT:                        "Start": 16384,
+# JSON-NEXT:                        "End": 20480,
+# JSON-NEXT:                        "Offset": 24576,
+# JSON-NEXT:                        "Filename": "/path/to/libc.so"
+# JSON-NEXT:                    },
+# JSON-NEXT:                    {
+# JSON-NEXT:                        "Start": 28672,
+# JSON-NEXT:                        "End": 32768,
+# JSON-NEXT:                        "Offset": 36864,
+# JSON-NEXT:                        "Filename": "[stack]"
+# JSON-NEXT:                    }
+# JSON-NEXT:                ]
+# JSON-NEXT:            }
+# JSON-NEXT:        ]
 # JSON-NEXT:      }
 # JSON-NEXT: }
 # JSON-NEXT: ]

--- a/llvm/test/tools/llvm-readobj/ELF/note-core-ntfile.test
+++ b/llvm/test/tools/llvm-readobj/ELF/note-core-ntfile.test
@@ -63,7 +63,7 @@ ProgramHeaders:
 # GNU-NEXT:         [stack]
 # GNU-EMPTY:
 
-# LLVM:      Notes [
+# LLVM:      NoteSectionList [
 # LLVM-NEXT:   NoteSection {
 # LLVM-NEXT:     Name: <?>
 # LLVM-NEXT:     Offset:
@@ -99,7 +99,7 @@ ProgramHeaders:
 # LLVM-NEXT: }
 # LLVM-NEXT: ]
 
-# JSON:      "Notes": [
+# JSON:      "NoteSectionList": [
 # JSON-NEXT:  {
 # JSON-NEXT:      "NoteSection": {
 # JSON-NEXT:          "Name": "<?>",

--- a/llvm/test/tools/llvm-readobj/ELF/note-core-ntfile.test
+++ b/llvm/test/tools/llvm-readobj/ELF/note-core-ntfile.test
@@ -63,7 +63,7 @@ ProgramHeaders:
 # GNU-NEXT:         [stack]
 # GNU-EMPTY:
 
-# LLVM:      NoteSectionList [
+# LLVM:      NoteSections [
 # LLVM-NEXT:   NoteSection {
 # LLVM-NEXT:     Name: <?>
 # LLVM-NEXT:     Offset:
@@ -99,7 +99,7 @@ ProgramHeaders:
 # LLVM-NEXT: }
 # LLVM-NEXT: ]
 
-# JSON:      "NoteSectionList": [
+# JSON:      "NoteSections": [
 # JSON-NEXT:  {
 # JSON-NEXT:      "NoteSection": {
 # JSON-NEXT:          "Name": "<?>",

--- a/llvm/test/tools/llvm-readobj/ELF/note-core.test
+++ b/llvm/test/tools/llvm-readobj/ELF/note-core.test
@@ -284,11 +284,13 @@
 # CHECK-GNU-NEXT: CORE  0x00000000 [[DESC]]
 # CHECK-GNU-EMPTY:
 
-# CHECK-LLVM:      Note {
+# CHECK-LLVM:       Size: 0x14
+# CHECK-LLVM-NEXT:  Notes: [
+# CHECK-LLVM-NEXT:  {
 # CHECK-LLVM-NEXT:   Owner: CORE
 # CHECK-LLVM-NEXT:   Data size: 0x0
 # CHECK-LLVM-NEXT:   Type: [[DESC]]
-# CHECK-LLVM-NEXT: }
+# CHECK-LLVM-NEXT:  }
 
 --- !ELF
 FileHeader:

--- a/llvm/test/tools/llvm-readobj/ELF/note-core.test
+++ b/llvm/test/tools/llvm-readobj/ELF/note-core.test
@@ -285,7 +285,7 @@
 # CHECK-GNU-EMPTY:
 
 # CHECK-LLVM:       Size: 0x14
-# CHECK-LLVM-NEXT:  Notes: [
+# CHECK-LLVM-NEXT:  Notes [
 # CHECK-LLVM-NEXT:  {
 # CHECK-LLVM-NEXT:   Owner: CORE
 # CHECK-LLVM-NEXT:   Data size: 0x0

--- a/llvm/test/tools/llvm-readobj/ELF/note-core.test
+++ b/llvm/test/tools/llvm-readobj/ELF/note-core.test
@@ -291,6 +291,7 @@
 # CHECK-LLVM-NEXT:   Data size: 0x0
 # CHECK-LLVM-NEXT:   Type: [[DESC]]
 # CHECK-LLVM-NEXT:  }
+# CHECK-LLVM-NEXT:  ]
 
 --- !ELF
 FileHeader:

--- a/llvm/test/tools/llvm-readobj/ELF/note-freebsd-core.test
+++ b/llvm/test/tools/llvm-readobj/ELF/note-freebsd-core.test
@@ -73,73 +73,77 @@ ProgramHeaders:
 # LLVM-NEXT:     Name: <?>
 # LLVM-NEXT:     Offset: 0xB0
 # LLVM-NEXT:     Size: 0xDC
-# LLVM-NEXT:     Note {
-# LLVM-NEXT:       Owner: FreeBSD
-# LLVM-NEXT:       Data size: 0x0
-# LLVM-NEXT:       Type: NT_THRMISC (thrmisc structure)
-# LLVM-NEXT:     }
-# LLVM-NEXT:     Note {
-# LLVM-NEXT:       Owner: FreeBSD
-# LLVM-NEXT:       Data size: 0x0
-# LLVM-NEXT:       Type: NT_PROCSTAT_PROC (proc data)
-# LLVM-NEXT:     }
-# LLVM-NEXT:     Note {
-# LLVM-NEXT:       Owner: FreeBSD
-# LLVM-NEXT:       Data size: 0x0
-# LLVM-NEXT:       Type: NT_PROCSTAT_FILES (files data)
-# LLVM-NEXT:     }
-# LLVM-NEXT:     Note {
-# LLVM-NEXT:       Owner: FreeBSD
-# LLVM-NEXT:       Data size: 0x0
-# LLVM-NEXT:       Type: NT_PROCSTAT_VMMAP (vmmap data)
-# LLVM-NEXT:     }
-# LLVM-NEXT:     Note {
-# LLVM-NEXT:       Owner: FreeBSD
-# LLVM-NEXT:       Data size: 0x0
-# LLVM-NEXT:       Type: NT_PROCSTAT_GROUPS (groups data)
-# LLVM-NEXT:     }
-# LLVM-NEXT:     Note {
-# LLVM-NEXT:       Owner: FreeBSD
-# LLVM-NEXT:       Data size: 0x0
-# LLVM-NEXT:       Type: NT_PROCSTAT_UMASK (umask data)
-# LLVM-NEXT:     }
-# LLVM-NEXT:     Note {
-# LLVM-NEXT:       Owner: FreeBSD
-# LLVM-NEXT:       Data size: 0x0
-# LLVM-NEXT:       Type: NT_PROCSTAT_RLIMIT (rlimit data)
-# LLVM-NEXT:     }
-# LLVM-NEXT:     Note {
-# LLVM-NEXT:       Owner: FreeBSD
-# LLVM-NEXT:       Data size: 0x0
-# LLVM-NEXT:       Type: NT_PROCSTAT_OSREL (osreldate data)
-# LLVM-NEXT:     }
-# LLVM-NEXT:     Note {
-# LLVM-NEXT:       Owner: FreeBSD
-# LLVM-NEXT:       Data size: 0x0
-# LLVM-NEXT:       Type: NT_PROCSTAT_PSSTRINGS (ps_strings data)
-# LLVM-NEXT:     }
-# LLVM-NEXT:     Note {
-# LLVM-NEXT:       Owner: FreeBSD
-# LLVM-NEXT:       Data size: 0x0
-# LLVM-NEXT:       Type: NT_PROCSTAT_AUXV (auxv data)
-# LLVM-NEXT:     }
-# LLVM-NEXT:     Note {
-# LLVM-NEXT:       Owner: FreeBSD
-# LLVM-NEXT:       Data size: 0x0
-# LLVM-NEXT:       Type: Unknown (0x00012345)
-# LLVM-NEXT:     }
+# LLVM-NEXT:     Notes [
+# LLVM-NEXT:        {
+# LLVM-NEXT:            Owner: FreeBSD
+# LLVM-NEXT:            Data size: 0x0
+# LLVM-NEXT:            Type: NT_THRMISC (thrmisc structure)
+# LLVM-NEXT:        }
+# LLVM-NEXT:        {
+# LLVM-NEXT:            Owner: FreeBSD
+# LLVM-NEXT:            Data size: 0x0
+# LLVM-NEXT:            Type: NT_PROCSTAT_PROC (proc data)
+# LLVM-NEXT:        }
+# LLVM-NEXT:        {
+# LLVM-NEXT:            Owner: FreeBSD
+# LLVM-NEXT:            Data size: 0x0
+# LLVM-NEXT:            Type: NT_PROCSTAT_FILES (files data)
+# LLVM-NEXT:        }
+# LLVM-NEXT:        {
+# LLVM-NEXT:            Owner: FreeBSD
+# LLVM-NEXT:            Data size: 0x0
+# LLVM-NEXT:            Type: NT_PROCSTAT_VMMAP (vmmap data)
+# LLVM-NEXT:        }
+# LLVM-NEXT:        {
+# LLVM-NEXT:            Owner: FreeBSD
+# LLVM-NEXT:            Data size: 0x0
+# LLVM-NEXT:            Type: NT_PROCSTAT_GROUPS (groups data)
+# LLVM-NEXT:        }
+# LLVM-NEXT:        {
+# LLVM-NEXT:            Owner: FreeBSD
+# LLVM-NEXT:            Data size: 0x0
+# LLVM-NEXT:            Type: NT_PROCSTAT_UMASK (umask data)
+# LLVM-NEXT:        }
+# LLVM-NEXT:        {
+# LLVM-NEXT:            Owner: FreeBSD
+# LLVM-NEXT:            Data size: 0x0
+# LLVM-NEXT:            Type: NT_PROCSTAT_RLIMIT (rlimit data)
+# LLVM-NEXT:        }
+# LLVM-NEXT:        {
+# LLVM-NEXT:            Owner: FreeBSD
+# LLVM-NEXT:            Data size: 0x0
+# LLVM-NEXT:            Type: NT_PROCSTAT_OSREL (osreldate data)
+# LLVM-NEXT:        }
+# LLVM-NEXT:        {
+# LLVM-NEXT:            Owner: FreeBSD
+# LLVM-NEXT:            Data size: 0x0
+# LLVM-NEXT:            Type: NT_PROCSTAT_PSSTRINGS (ps_strings data)
+# LLVM-NEXT:        }
+# LLVM-NEXT:        {
+# LLVM-NEXT:            Owner: FreeBSD
+# LLVM-NEXT:            Data size: 0x0
+# LLVM-NEXT:            Type: NT_PROCSTAT_AUXV (auxv data)
+# LLVM-NEXT:        }
+# LLVM-NEXT:        {
+# LLVM-NEXT:            Owner: FreeBSD
+# LLVM-NEXT:            Data size: 0x0
+# LLVM-NEXT:            Type: Unknown (0x00012345)
+# LLVM-NEXT:        }
+# LLVM-NEXT:     ]
 # LLVM-NEXT:   }
 # LLVM-NEXT:   NoteSection {
 # LLVM-NEXT:     Name: <?>
 # LLVM-NEXT:     Offset: 0x18C
 # LLVM-NEXT:     Size: 0x1C
-# LLVM-NEXT:     Note {
-# LLVM-NEXT:       Owner: FreeBSD
-# LLVM-NEXT:       Data size: 0x6
-# LLVM-NEXT:       Type: NT_PRPSINFO (prpsinfo structure)
-# LLVM-NEXT:       Description data (
-# LLVM-NEXT:         0000: AABBCCDD EEFF                        |......|
-# LLVM-NEXT:       )
-# LLVM-NEXT:     }
+# LLVM-NEXT:     Notes [
+# LLVM-NEXT:        {
+# LLVM-NEXT:            Owner: FreeBSD
+# LLVM-NEXT:            Data size: 0x6
+# LLVM-NEXT:            Type: NT_PRPSINFO (prpsinfo structure)
+# LLVM-NEXT:            Description data (
+# LLVM-NEXT:                0000: AABBCCDD EEFF                        |......|
+# LLVM-NEXT:        )
+# LLVM-NEXT:        }
+# LLVM-NEXT:    ]
 # LLVM-NEXT:   }
 # LLVM-NEXT: ]

--- a/llvm/test/tools/llvm-readobj/ELF/note-freebsd-core.test
+++ b/llvm/test/tools/llvm-readobj/ELF/note-freebsd-core.test
@@ -68,7 +68,7 @@ ProgramHeaders:
 # GNU-NEXT:     description data: aa bb cc dd ee ff
 # GNU-EMPTY:
 
-# LLVM:      Notes [
+# LLVM:      NoteSectionList [
 # LLVM-NEXT:   NoteSection {
 # LLVM-NEXT:     Name: <?>
 # LLVM-NEXT:     Offset: 0xB0

--- a/llvm/test/tools/llvm-readobj/ELF/note-freebsd-core.test
+++ b/llvm/test/tools/llvm-readobj/ELF/note-freebsd-core.test
@@ -142,7 +142,7 @@ ProgramHeaders:
 # LLVM-NEXT:            Type: NT_PRPSINFO (prpsinfo structure)
 # LLVM-NEXT:            Description data (
 # LLVM-NEXT:                0000: AABBCCDD EEFF                        |......|
-# LLVM-NEXT:        )
+# LLVM-NEXT:            )
 # LLVM-NEXT:        }
 # LLVM-NEXT:    ]
 # LLVM-NEXT:   }

--- a/llvm/test/tools/llvm-readobj/ELF/note-freebsd-core.test
+++ b/llvm/test/tools/llvm-readobj/ELF/note-freebsd-core.test
@@ -68,7 +68,7 @@ ProgramHeaders:
 # GNU-NEXT:     description data: aa bb cc dd ee ff
 # GNU-EMPTY:
 
-# LLVM:      NoteSectionList [
+# LLVM:      NoteSections [
 # LLVM-NEXT:   NoteSection {
 # LLVM-NEXT:     Name: <?>
 # LLVM-NEXT:     Offset: 0xB0

--- a/llvm/test/tools/llvm-readobj/ELF/note-freebsd.test
+++ b/llvm/test/tools/llvm-readobj/ELF/note-freebsd.test
@@ -66,63 +66,65 @@ Sections:
 # LLVM-NEXT:    Name: .note.tag
 # LLVM-NEXT:    Offset: 0x40
 # LLVM-NEXT:    Size: 0xCC
-# LLVM-NEXT:    Note {
-# LLVM-NEXT:      Owner: FreeBSD
-# LLVM-NEXT:      Data size: 0x4
-# LLVM-NEXT:      Type: NT_FREEBSD_ABI_TAG (ABI version tag)
-# LLVM-NEXT:      ABI tag: 1300076
-# LLVM-NEXT:    }
-# LLVM-NEXT:    Note {
-# LLVM-NEXT:      Owner: FreeBSD
-# LLVM-NEXT:      Data size: 0x1
-# LLVM-NEXT:      Type: NT_FREEBSD_ABI_TAG (ABI version tag)
-# LLVM-NEXT:      Description data (
-# LLVM-NEXT:        0000: 6C                                   |l|
-# LLVM-NEXT:      )
-# LLVM-NEXT:    }
-# LLVM-NEXT:    Note {
-# LLVM-NEXT:      Owner: FreeBSD
-# LLVM-NEXT:      Data size: 0x7
-# LLVM-NEXT:      Type: NT_FREEBSD_ARCH_TAG (architecture tag)
-# LLVM-NEXT:      Arch tag: aarch64
-# LLVM-NEXT:    }
-# LLVM-NEXT:    Note {
-# LLVM-NEXT:      Owner: FreeBSD
-# LLVM-NEXT:      Data size: 0x4
-# LLVM-NEXT:      Type: NT_FREEBSD_FEATURE_CTL (FreeBSD feature control)
-# LLVM-NEXT:      Feature flags: ASLR_DISABLE PROTMAX_DISABLE STKGAP_DISABLE WXNEEDED LA48 ASG_DISABLE (0xFFFFFFFF)
-# LLVM-NEXT:    }
-# LLVM-NEXT:    Note {
-# LLVM-NEXT:      Owner: FreeBSD
-# LLVM-NEXT:      Data size: 0x1
-# LLVM-NEXT:      Type: NT_FREEBSD_FEATURE_CTL (FreeBSD feature control)
-# LLVM-NEXT:      Description data (
-# LLVM-NEXT:        0000: 00                                   |.|
-# LLVM-NEXT:      )
-# LLVM-NEXT:    }
-# LLVM-NEXT:    Note {
-# LLVM-NEXT:      Owner: FreeBSD
-# LLVM-NEXT:      Data size: 0x4
-# LLVM-NEXT:      Type: NT_FREEBSD_NOINIT_TAG (no .init tag)
-# LLVM-NEXT:      Description data (
-# LLVM-NEXT:        0000: 00000000                             |....|
-# LLVM-NEXT:      )
-# LLVM-NEXT:    }
-# LLVM-NEXT:    Note {
-# LLVM-NEXT:      Owner: FreeBSD
-# LLVM-NEXT:      Data size: 0x6
-# LLVM-NEXT:      Type: Unknown (0x00abcdef)
-# LLVM-NEXT:      Description data (
-# LLVM-NEXT:        0000: 61626364 6566                        |abcdef|
-# LLVM-NEXT:      )
-# LLVM-NEXT:    }
-# LLVM-NEXT:    Note {
-# LLVM-NEXT:      Owner: FreeBSD
-# LLVM-NEXT:      Data size: 0x6
-# LLVM-NEXT:      Type: Unknown (0x0000000d)
-# LLVM-NEXT:      Description data (
-# LLVM-NEXT:        0000: 61626364 6566                        |abcdef|
-# LLVM-NEXT:      )
-# LLVM-NEXT:    }
+# LLVM-NEXT:    Notes [
+# LLVM-NEXT:        {
+# LLVM-NEXT:            Owner: FreeBSD
+# LLVM-NEXT:            Data size: 0x4
+# LLVM-NEXT:            Type: NT_FREEBSD_ABI_TAG (ABI version tag)
+# LLVM-NEXT:            ABI tag: 1300076
+# LLVM-NEXT:        }
+# LLVM-NEXT:        {
+# LLVM-NEXT:            Owner: FreeBSD
+# LLVM-NEXT:            Data size: 0x1
+# LLVM-NEXT:            Type: NT_FREEBSD_ABI_TAG (ABI version tag)
+# LLVM-NEXT:            Description data (
+# LLVM-NEXT:                0000: 6C                                   |l|
+# LLVM-NEXT:            )
+# LLVM-NEXT:        }
+# LLVM-NEXT:        {
+# LLVM-NEXT:            Owner: FreeBSD
+# LLVM-NEXT:            Data size: 0x7
+# LLVM-NEXT:            Type: NT_FREEBSD_ARCH_TAG (architecture tag)
+# LLVM-NEXT:            Arch tag: aarch64
+# LLVM-NEXT:        }
+# LLVM-NEXT:        {
+# LLVM-NEXT:            Owner: FreeBSD
+# LLVM-NEXT:            Data size: 0x4
+# LLVM-NEXT:            Type: NT_FREEBSD_FEATURE_CTL (FreeBSD feature control)
+# LLVM-NEXT:            Feature flags: ASLR_DISABLE PROTMAX_DISABLE STKGAP_DISABLE WXNEEDED LA48 ASG_DISABLE (0xFFFFFFFF)
+# LLVM-NEXT:        }
+# LLVM-NEXT:        {
+# LLVM-NEXT:            Owner: FreeBSD
+# LLVM-NEXT:            Data size: 0x1
+# LLVM-NEXT:            Type: NT_FREEBSD_FEATURE_CTL (FreeBSD feature control)
+# LLVM-NEXT:            Description data (
+# LLVM-NEXT:                0000: 00                                   |.|
+# LLVM-NEXT:            )
+# LLVM-NEXT:        }
+# LLVM-NEXT:        {
+# LLVM-NEXT:            Owner: FreeBSD
+# LLVM-NEXT:            Data size: 0x4
+# LLVM-NEXT:            Type: NT_FREEBSD_NOINIT_TAG (no .init tag)
+# LLVM-NEXT:            Description data (
+# LLVM-NEXT:                0000: 00000000                             |....|
+# LLVM-NEXT:            )
+# LLVM-NEXT:        }
+# LLVM-NEXT:        {
+# LLVM-NEXT:            Owner: FreeBSD
+# LLVM-NEXT:            Data size: 0x6
+# LLVM-NEXT:            Type: Unknown (0x00abcdef)
+# LLVM-NEXT:            Description data (
+# LLVM-NEXT:                0000: 61626364 6566                        |abcdef|
+# LLVM-NEXT:            )
+# LLVM-NEXT:        }
+# LLVM-NEXT:        {
+# LLVM-NEXT:            Owner: FreeBSD
+# LLVM-NEXT:            Data size: 0x6
+# LLVM-NEXT:            Type: Unknown (0x0000000d)
+# LLVM-NEXT:            Description data (
+# LLVM-NEXT:                0000: 61626364 6566                        |abcdef|
+# LLVM-NEXT:        )
+# LLVM-NEXT:        }
+# LLVM-NEXT:    ]
 # LLVM-NEXT:  }
 # LLVM-NEXT:]

--- a/llvm/test/tools/llvm-readobj/ELF/note-freebsd.test
+++ b/llvm/test/tools/llvm-readobj/ELF/note-freebsd.test
@@ -61,7 +61,7 @@ Sections:
 # GNU-NEXT:   description data: 61 62 63 64 65 66
 # GNU-EMPTY:
 
-# LLVM:     Notes [
+# LLVM:     NoteSectionList [
 # LLVM-NEXT:  NoteSection {
 # LLVM-NEXT:    Name: .note.tag
 # LLVM-NEXT:    Offset: 0x40

--- a/llvm/test/tools/llvm-readobj/ELF/note-freebsd.test
+++ b/llvm/test/tools/llvm-readobj/ELF/note-freebsd.test
@@ -61,7 +61,7 @@ Sections:
 # GNU-NEXT:   description data: 61 62 63 64 65 66
 # GNU-EMPTY:
 
-# LLVM:     NoteSectionList [
+# LLVM:     NoteSections [
 # LLVM-NEXT:  NoteSection {
 # LLVM-NEXT:    Name: .note.tag
 # LLVM-NEXT:    Offset: 0x40

--- a/llvm/test/tools/llvm-readobj/ELF/note-freebsd.test
+++ b/llvm/test/tools/llvm-readobj/ELF/note-freebsd.test
@@ -123,7 +123,7 @@ Sections:
 # LLVM-NEXT:            Type: Unknown (0x0000000d)
 # LLVM-NEXT:            Description data (
 # LLVM-NEXT:                0000: 61626364 6566                        |abcdef|
-# LLVM-NEXT:        )
+# LLVM-NEXT:            )
 # LLVM-NEXT:        }
 # LLVM-NEXT:    ]
 # LLVM-NEXT:  }

--- a/llvm/test/tools/llvm-readobj/ELF/note-generic.s
+++ b/llvm/test/tools/llvm-readobj/ELF/note-generic.s
@@ -20,7 +20,7 @@
 // GNU-NEXT:   Owner                Data size 	Description
 // GNU-NEXT:   XYZ                  0x00000000	func
 
-// LLVM:      Notes [
+// LLVM:      NoteSectionList [
 // LLVM-NEXT:   NoteSection {
 // LLVM-NEXT:     Name: .note.version
 // LLVM-NEXT:     Offset: 0x40

--- a/llvm/test/tools/llvm-readobj/ELF/note-generic.s
+++ b/llvm/test/tools/llvm-readobj/ELF/note-generic.s
@@ -25,41 +25,49 @@
 // LLVM-NEXT:     Name: .note.version
 // LLVM-NEXT:     Offset: 0x40
 // LLVM-NEXT:     Size: 0x10
-// LLVM-NEXT:     Note {
-// LLVM-NEXT:       Owner: XYZ
-// LLVM-NEXT:       Data size: 0x0
-// LLVM-NEXT:       Type: NT_VERSION (version)
-// LLVM-NEXT:     }
+// LLVM-NEXT:	  Notes [
+// LLVM-NEXT:		{
+// LLVM-NEXT:			Owner: XYZ
+// LLVM-NEXT:			Data size: 0x0
+// LLVM-NEXT:			Type: NT_VERSION (version)
+// LLVM-NEXT:		}
+// LLVM-NEXT:	  ]
 // LLVM-NEXT:   }
 // LLVM-NEXT:   NoteSection {
 // LLVM-NEXT:     Name: .note.arch
 // LLVM-NEXT:     Offset: 0x50
 // LLVM-NEXT:     Size: 0x10
-// LLVM-NEXT:     Note {
-// LLVM-NEXT:       Owner: XYZ
-// LLVM-NEXT:       Data size: 0x0
-// LLVM-NEXT:       Type: NT_ARCH (architecture)
-// LLVM-NEXT:     }
+// LLVM-NEXT:	  Notes [
+// LLVM-NEXT:		{
+// LLVM-NEXT:			Owner: XYZ
+// LLVM-NEXT:			Data size: 0x0
+// LLVM-NEXT:			Type: NT_ARCH (architecture)
+// LLVM-NEXT:		}
+// LLVM-NEXT:	  ]
 // LLVM-NEXT:   }
 // LLVM-NEXT:   NoteSection {
 // LLVM-NEXT:     Name: .note.open
 // LLVM-NEXT:     Offset: 0x60
 // LLVM-NEXT:     Size: 0x10
-// LLVM-NEXT:     Note {
-// LLVM-NEXT:       Owner: XYZ
-// LLVM-NEXT:       Data size: 0x0
-// LLVM-NEXT:       Type: OPEN
-// LLVM-NEXT:     }
+// LLVM-NEXT:	  Notes [
+// LLVM-NEXT:		{
+// LLVM-NEXT:			Owner: XYZ
+// LLVM-NEXT:			Data size: 0x0
+// LLVM-NEXT:			Type: OPEN
+// LLVM-NEXT:		}
+// LLVM-NEXT:	  ]
 // LLVM-NEXT:   }
 // LLVM-NEXT:   NoteSection {
 // LLVM-NEXT:     Name: .note.func
 // LLVM-NEXT:     Offset: 0x70
 // LLVM-NEXT:     Size: 0x10
-// LLVM-NEXT:     Note {
-// LLVM-NEXT:       Owner: XYZ
-// LLVM-NEXT:       Data size: 0x0
-// LLVM-NEXT:       Type: func
-// LLVM-NEXT:     }
+// LLVM-NEXT:	  Notes [
+// LLVM-NEXT:		{
+// LLVM-NEXT:			Owner: XYZ
+// LLVM-NEXT:			Data size: 0x0
+// LLVM-NEXT:			Type: func
+// LLVM-NEXT:		}
+// LLVM-NEXT:	 ]
 // LLVM-NEXT:   }
 // LLVM-NEXT: ]
 

--- a/llvm/test/tools/llvm-readobj/ELF/note-generic.s
+++ b/llvm/test/tools/llvm-readobj/ELF/note-generic.s
@@ -20,7 +20,7 @@
 // GNU-NEXT:   Owner                Data size 	Description
 // GNU-NEXT:   XYZ                  0x00000000	func
 
-// LLVM:      NoteSectionList [
+// LLVM:      NoteSections [
 // LLVM-NEXT:   NoteSection {
 // LLVM-NEXT:     Name: .note.version
 // LLVM-NEXT:     Offset: 0x40

--- a/llvm/test/tools/llvm-readobj/ELF/note-gnu-property.s
+++ b/llvm/test/tools/llvm-readobj/ELF/note-gnu-property.s
@@ -29,30 +29,32 @@
 // LLVM-NEXT:     Name: .note.gnu.property
 // LLVM-NEXT:     Offset: 0x40
 // LLVM-NEXT:     Size: 0xF8
-// LLVM-NEXT:     Note {
-// LLVM-NEXT:       Owner: GNU
-// LLVM-NEXT:       Data size: 0xE8
-// LLVM-NEXT:       Type: NT_GNU_PROPERTY_TYPE_0 (property note)
-// LLVM-NEXT:       Property [
-// LLVM-NEXT:         stack size: 0x100
-// LLVM-NEXT:         stack size: 0x100
-// LLVM-NEXT:         no copy on protected
-// LLVM-NEXT:         x86 feature: SHSTK
-// LLVM-NEXT:         x86 feature: IBT, SHSTK
-// LLVM-NEXT:         x86 feature: <None>
-// LLVM-NEXT:         x86 feature needed: x86, x87, MMX, XMM, YMM
-// LLVM-NEXT:         x86 feature used: ZMM, FXSR, XSAVE, XSAVEOPT, XSAVEC
-// LLVM-NEXT:         x86 ISA needed: x86-64-baseline, x86-64-v2, x86-64-v3, x86-64-v4
-// LLVM-NEXT:         x86 ISA used: x86-64-baseline, x86-64-v2, x86-64-v3, x86-64-v4
-// LLVM-NEXT:         <application-specific type 0xfefefefe>
-// LLVM-NEXT:         stack size: <corrupt length: 0x0>
-// LLVM-NEXT:         stack size: <corrupt length: 0x4>
-// LLVM-NEXT:         no copy on protected <corrupt length: 0x1>
-// LLVM-NEXT:         x86 feature: <corrupt length: 0x0>
-// LLVM-NEXT:         x86 feature: IBT, <unknown flags: 0xf000f000>
-// LLVM-NEXT:         <corrupt type (0x2) datasz: 0x1>
-// LLVM-NEXT:       ]
-// LLVM-NEXT:     }
+// LLVM-NEXT:	  Notes [
+// LLVM-NEXT:		{
+// LLVM-NEXT:			Owner: GNU
+// LLVM-NEXT:			Data size: 0xE8
+// LLVM-NEXT:			Type: NT_GNU_PROPERTY_TYPE_0 (property note)
+// LLVM-NEXT:			Property [
+// LLVM-NEXT:				stack size: 0x100
+// LLVM-NEXT:				stack size: 0x100
+// LLVM-NEXT:				no copy on protected
+// LLVM-NEXT:				x86 feature: SHSTK
+// LLVM-NEXT:				x86 feature: IBT, SHSTK
+// LLVM-NEXT:				x86 feature: <None>
+// LLVM-NEXT:				x86 feature needed: x86, x87, MMX, XMM, YMM
+// LLVM-NEXT:				x86 feature used: ZMM, FXSR, XSAVE, XSAVEOPT, XSAVEC
+// LLVM-NEXT:				x86 ISA needed: x86-64-baseline, x86-64-v2, x86-64-v3, x86-64-v4
+// LLVM-NEXT:				x86 ISA used: x86-64-baseline, x86-64-v2, x86-64-v3, x86-64-v4
+// LLVM-NEXT:				<application-specific type 0xfefefefe>
+// LLVM-NEXT:				stack size: <corrupt length: 0x0>
+// LLVM-NEXT:				stack size: <corrupt length: 0x4>
+// LLVM-NEXT:				no copy on protected <corrupt length: 0x1>
+// LLVM-NEXT:				x86 feature: <corrupt length: 0x0>
+// LLVM-NEXT:				x86 feature: IBT, <unknown flags: 0xf000f000>
+// LLVM-NEXT:				<corrupt type (0x2) datasz: 0x1>
+// LLVM-NEXT:			]
+// LLVM-NEXT:		}
+// LLVM-NEXT:	  ]
 // LLVM-NEXT:   }
 // LLVM-NEXT: ]
 

--- a/llvm/test/tools/llvm-readobj/ELF/note-gnu-property.s
+++ b/llvm/test/tools/llvm-readobj/ELF/note-gnu-property.s
@@ -24,7 +24,7 @@
 // GNU-NEXT:     x86 feature: IBT, <unknown flags: 0xf000f000>
 // GNU-NEXT:     <corrupt type (0x2) datasz: 0x1>
 
-// LLVM:      Notes [
+// LLVM:      NoteSectionList [
 // LLVM-NEXT:   NoteSection {
 // LLVM-NEXT:     Name: .note.gnu.property
 // LLVM-NEXT:     Offset: 0x40

--- a/llvm/test/tools/llvm-readobj/ELF/note-gnu-property.s
+++ b/llvm/test/tools/llvm-readobj/ELF/note-gnu-property.s
@@ -24,7 +24,7 @@
 // GNU-NEXT:     x86 feature: IBT, <unknown flags: 0xf000f000>
 // GNU-NEXT:     <corrupt type (0x2) datasz: 0x1>
 
-// LLVM:      NoteSectionList [
+// LLVM:      NoteSections [
 // LLVM-NEXT:   NoteSection {
 // LLVM-NEXT:     Name: .note.gnu.property
 // LLVM-NEXT:     Offset: 0x40

--- a/llvm/test/tools/llvm-readobj/ELF/note-gnu-property2.s
+++ b/llvm/test/tools/llvm-readobj/ELF/note-gnu-property2.s
@@ -8,7 +8,7 @@
 // GNU-NEXT:   GNU                   0x00000004      NT_GNU_PROPERTY_TYPE_0 (property note)
 // GNU-NEXT:     Properties:    <corrupted GNU_PROPERTY_TYPE_0>
 
-// LLVM:      Notes [
+// LLVM:      NoteSectionList [
 // LLVM-NEXT:   NoteSection {
 // LLVM-NEXT:     Name: .note.gnu.property
 // LLVM-NEXT:     Offset: 0x40

--- a/llvm/test/tools/llvm-readobj/ELF/note-gnu-property2.s
+++ b/llvm/test/tools/llvm-readobj/ELF/note-gnu-property2.s
@@ -13,14 +13,16 @@
 // LLVM-NEXT:     Name: .note.gnu.property
 // LLVM-NEXT:     Offset: 0x40
 // LLVM-NEXT:     Size: 0x18
-// LLVM-NEXT:     Note {
-// LLVM-NEXT:       Owner: GNU
-// LLVM-NEXT:       Data size: 0x4
-// LLVM-NEXT:       Type: NT_GNU_PROPERTY_TYPE_0 (property note)
-// LLVM-NEXT:       Property [
-// LLVM-NEXT:         <corrupted GNU_PROPERTY_TYPE_0>
-// LLVM-NEXT:       ]
-// LLVM-NEXT:     }
+// LLVM-NEXT:	  Notes [
+// LLVM-NEXT:		{
+// LLVM-NEXT:			Owner: GNU
+// LLVM-NEXT:			Data size: 0x4
+// LLVM-NEXT:			Type: NT_GNU_PROPERTY_TYPE_0 (property note)
+// LLVM-NEXT:			Property [
+// LLVM-NEXT:				<corrupted GNU_PROPERTY_TYPE_0>
+// LLVM-NEXT:			]
+// LLVM-NEXT:		}
+// LLVM-NEXT:	  ]
 // LLVM-NEXT:   }
 // LLVM-NEXT: ]
 

--- a/llvm/test/tools/llvm-readobj/ELF/note-gnu-property2.s
+++ b/llvm/test/tools/llvm-readobj/ELF/note-gnu-property2.s
@@ -8,7 +8,7 @@
 // GNU-NEXT:   GNU                   0x00000004      NT_GNU_PROPERTY_TYPE_0 (property note)
 // GNU-NEXT:     Properties:    <corrupted GNU_PROPERTY_TYPE_0>
 
-// LLVM:      NoteSectionList [
+// LLVM:      NoteSections [
 // LLVM-NEXT:   NoteSection {
 // LLVM-NEXT:     Name: .note.gnu.property
 // LLVM-NEXT:     Offset: 0x40

--- a/llvm/test/tools/llvm-readobj/ELF/note-llvmompoffload.test
+++ b/llvm/test/tools/llvm-readobj/ELF/note-llvmompoffload.test
@@ -13,7 +13,7 @@
 # RUN: llvm-readobj --notes %t.32be | FileCheck %s --match-full-lines --check-prefix=NOTES
 # RUN: llvm-readelf --notes %t.32be | FileCheck %s --match-full-lines --check-prefix=NOTES-GNU
 
-# NOTES:      Notes [
+# NOTES:      NoteSectionList [
 # NOTES-NEXT:   NoteSection {
 # NOTES-NEXT:     Name: .note.openmp
 # NOTES-NEXT:     Offset: {{.*}}

--- a/llvm/test/tools/llvm-readobj/ELF/note-llvmompoffload.test
+++ b/llvm/test/tools/llvm-readobj/ELF/note-llvmompoffload.test
@@ -18,24 +18,26 @@
 # NOTES-NEXT:     Name: .note.openmp
 # NOTES-NEXT:     Offset: {{.*}}
 # NOTES-NEXT:     Size: {{.*}}
-# NOTES-NEXT:     Note {
-# NOTES-NEXT:       Owner: LLVMOMPOFFLOAD
-# NOTES-NEXT:       Data size: 0x3
-# NOTES-NEXT:       Type: NT_LLVM_OPENMP_OFFLOAD_VERSION (image format version)
-# NOTES-NEXT:       Version: 1.0
-# NOTES-NEXT:     }
-# NOTES-NEXT:     Note {
-# NOTES-NEXT:       Owner: LLVMOMPOFFLOAD
-# NOTES-NEXT:       Data size: 0x4
-# NOTES-NEXT:       Type: NT_LLVM_OPENMP_OFFLOAD_PRODUCER (producing toolchain)
-# NOTES-NEXT:       Producer: LLVM
-# NOTES-NEXT:     }
-# NOTES-NEXT:     Note {
-# NOTES-NEXT:       Owner: LLVMOMPOFFLOAD
-# NOTES-NEXT:       Data size: 0x9
-# NOTES-NEXT:       Type: NT_LLVM_OPENMP_OFFLOAD_PRODUCER_VERSION (producing toolchain version)
-# NOTES-NEXT:       Producer version: 13.0.0git
-# NOTES-NEXT:     }
+# NOTES-NEXT:     Notes [
+# NOTES-NEXT:       {
+# NOTES-NEXT:           Owner: LLVMOMPOFFLOAD
+# NOTES-NEXT:           Data size: 0x3
+# NOTES-NEXT:           Type: NT_LLVM_OPENMP_OFFLOAD_VERSION (image format version)
+# NOTES-NEXT:           Version: 1.0
+# NOTES-NEXT:       }
+# NOTES-NEXT:       {
+# NOTES-NEXT:           Owner: LLVMOMPOFFLOAD
+# NOTES-NEXT:           Data size: 0x4
+# NOTES-NEXT:           Type: NT_LLVM_OPENMP_OFFLOAD_PRODUCER (producing toolchain)
+# NOTES-NEXT:           Producer: LLVM
+# NOTES-NEXT:       }
+# NOTES-NEXT:       {
+# NOTES-NEXT:           Owner: LLVMOMPOFFLOAD
+# NOTES-NEXT:           Data size: 0x9
+# NOTES-NEXT:           Type: NT_LLVM_OPENMP_OFFLOAD_PRODUCER_VERSION (producing toolchain version)
+# NOTES-NEXT:           Producer version: 13.0.0git
+# NOTES-NEXT:       }
+# NOTES-NEXT:    ]
 # NOTES-NEXT:   }
 # NOTES-NEXT: ]
 

--- a/llvm/test/tools/llvm-readobj/ELF/note-llvmompoffload.test
+++ b/llvm/test/tools/llvm-readobj/ELF/note-llvmompoffload.test
@@ -13,7 +13,7 @@
 # RUN: llvm-readobj --notes %t.32be | FileCheck %s --match-full-lines --check-prefix=NOTES
 # RUN: llvm-readelf --notes %t.32be | FileCheck %s --match-full-lines --check-prefix=NOTES-GNU
 
-# NOTES:      NoteSectionList [
+# NOTES:      NoteSections [
 # NOTES-NEXT:   NoteSection {
 # NOTES-NEXT:     Name: .note.openmp
 # NOTES-NEXT:     Offset: {{.*}}

--- a/llvm/test/tools/llvm-readobj/ELF/note-multiple-sections.test
+++ b/llvm/test/tools/llvm-readobj/ELF/note-multiple-sections.test
@@ -1,4 +1,4 @@
-## Test that note values are interpreted correctly for core files with multiple sections.
+## Test that note values are interpreted correctly for files with multiple sections.
 
 ## Check NT_PRSTATUS + NT_PRPSINFO.
 # RUN: yaml2obj %s -DTYPE1=0x1 -DTYPE2=0x3 -o %t1.o

--- a/llvm/test/tools/llvm-readobj/ELF/note-netbsd-core.test
+++ b/llvm/test/tools/llvm-readobj/ELF/note-netbsd-core.test
@@ -30,7 +30,7 @@ ProgramHeaders:
 # GNU-NEXT:   NetBSD-CORE          0x00000000	NT_NETBSDCORE_AUXV (ELF auxiliary vector data)
 # GNU-NEXT:   NetBSD-CORE@3615     0x00000000	PT_LWPSTATUS (ptrace_lwpstatus structure)
 
-# LLVM:      Notes [
+# LLVM:      NoteSectionList [
 # LLVM-NEXT:   NoteSection {
 # LLVM-NEXT:     Name: <?>
 # LLVM-NEXT:     Offset: 0x78

--- a/llvm/test/tools/llvm-readobj/ELF/note-netbsd-core.test
+++ b/llvm/test/tools/llvm-readobj/ELF/note-netbsd-core.test
@@ -35,20 +35,22 @@ ProgramHeaders:
 # LLVM-NEXT:     Name: <?>
 # LLVM-NEXT:     Offset: 0x78
 # LLVM-NEXT:     Size: 0x50
-# LLVM-NEXT:     Note {
-# LLVM-NEXT:       Owner: NetBSD-CORE
-# LLVM-NEXT:       Data size: 0x0
-# LLVM-NEXT:       Type: NT_NETBSDCORE_PROCINFO (procinfo structure)
-# LLVM-NEXT:     }
-# LLVM-NEXT:     Note {
-# LLVM-NEXT:       Owner: NetBSD-CORE
-# LLVM-NEXT:       Data size: 0x0
-# LLVM-NEXT:       Type: NT_NETBSDCORE_AUXV (ELF auxiliary vector data)
-# LLVM-NEXT:     }
-# LLVM-NEXT:     Note {
-# LLVM-NEXT:       Owner: NetBSD-CORE@3615
-# LLVM-NEXT:       Data size: 0x0
-# LLVM-NEXT:       Type: PT_LWPSTATUS (ptrace_lwpstatus structure)
-# LLVM-NEXT:     }
+# LLVM-NEXT:     Notes [
+# LLVM-NEXT:        {
+# LLVM-NEXT:            Owner: NetBSD-CORE
+# LLVM-NEXT:            Data size: 0x0
+# LLVM-NEXT:            Type: NT_NETBSDCORE_PROCINFO (procinfo structure)
+# LLVM-NEXT:        }
+# LLVM-NEXT:        {
+# LLVM-NEXT:            Owner: NetBSD-CORE
+# LLVM-NEXT:            Data size: 0x0
+# LLVM-NEXT:            Type: NT_NETBSDCORE_AUXV (ELF auxiliary vector data)
+# LLVM-NEXT:            }
+# LLVM-NEXT:        {
+# LLVM-NEXT:            Owner: NetBSD-CORE@3615
+# LLVM-NEXT:            Data size: 0x0
+# LLVM-NEXT:            Type: PT_LWPSTATUS (ptrace_lwpstatus structure)
+# LLVM-NEXT:        }
+# LLVM-NEXT:    ]
 # LLVM-NEXT:   }
 # LLVM-NEXT: ]

--- a/llvm/test/tools/llvm-readobj/ELF/note-netbsd-core.test
+++ b/llvm/test/tools/llvm-readobj/ELF/note-netbsd-core.test
@@ -30,7 +30,7 @@ ProgramHeaders:
 # GNU-NEXT:   NetBSD-CORE          0x00000000	NT_NETBSDCORE_AUXV (ELF auxiliary vector data)
 # GNU-NEXT:   NetBSD-CORE@3615     0x00000000	PT_LWPSTATUS (ptrace_lwpstatus structure)
 
-# LLVM:      NoteSectionList [
+# LLVM:      NoteSections [
 # LLVM-NEXT:   NoteSection {
 # LLVM-NEXT:     Name: <?>
 # LLVM-NEXT:     Offset: 0x78

--- a/llvm/test/tools/llvm-readobj/ELF/note-openbsd-core.test
+++ b/llvm/test/tools/llvm-readobj/ELF/note-openbsd-core.test
@@ -35,7 +35,7 @@ ProgramHeaders:
 # GNU-NEXT:   OpenBSD@31337        0x00000000	NT_OPENBSD_REGS (regular registers)
 # GNU-NEXT:   OpenBSD@31337        0x00000000	NT_OPENBSD_FPREGS (floating point registers)
 
-# LLVM:      Notes [
+# LLVM:      NoteSectionList [
 # LLVM-NEXT:   NoteSection {
 # LLVM-NEXT:     Name: <?>
 # LLVM-NEXT:     Offset: 0x78

--- a/llvm/test/tools/llvm-readobj/ELF/note-openbsd-core.test
+++ b/llvm/test/tools/llvm-readobj/ELF/note-openbsd-core.test
@@ -40,30 +40,32 @@ ProgramHeaders:
 # LLVM-NEXT:     Name: <?>
 # LLVM-NEXT:     Offset: 0x78
 # LLVM-NEXT:     Size: 0x74
-# LLVM-NEXT:     Note {
-# LLVM-NEXT:       Owner: OpenBSD
-# LLVM-NEXT:       Data size: 0x0
-# LLVM-NEXT:       Type: NT_OPENBSD_PROCINFO (procinfo structure)
-# LLVM-NEXT:     }
-# LLVM-NEXT:     Note {
-# LLVM-NEXT:       Owner: OpenBSD
-# LLVM-NEXT:       Data size: 0x0
-# LLVM-NEXT:       Type: NT_OPENBSD_AUXV (ELF auxiliary vector data)
-# LLVM-NEXT:     }
-# LLVM-NEXT:     Note {
-# LLVM-NEXT:       Owner: OpenBSD
-# LLVM-NEXT:       Data size: 0x0
-# LLVM-NEXT:       Type: NT_OPENBSD_WCOOKIE (window cookie)
-# LLVM-NEXT:     }
-# LLVM-NEXT:     Note {
-# LLVM-NEXT:       Owner: OpenBSD@31337
-# LLVM-NEXT:       Data size: 0x0
-# LLVM-NEXT:       Type: NT_OPENBSD_REGS (regular registers)
-# LLVM-NEXT:     }
-# LLVM-NEXT:     Note {
-# LLVM-NEXT:       Owner: OpenBSD@31337
-# LLVM-NEXT:       Data size: 0x0
-# LLVM-NEXT:       Type: NT_OPENBSD_FPREGS (floating point registers)
-# LLVM-NEXT:     }
+# LLVM-NEXT:     Notes [
+# LLVM-NEXT:        {
+# LLVM-NEXT:            Owner: OpenBSD
+# LLVM-NEXT:            Data size: 0x0
+# LLVM-NEXT:            Type: NT_OPENBSD_PROCINFO (procinfo structure)
+# LLVM-NEXT:        }
+# LLVM-NEXT:        {
+# LLVM-NEXT:            Owner: OpenBSD
+# LLVM-NEXT:            Data size: 0x0
+# LLVM-NEXT:            Type: NT_OPENBSD_AUXV (ELF auxiliary vector data)
+# LLVM-NEXT:        }
+# LLVM-NEXT:        {
+# LLVM-NEXT:            Owner: OpenBSD
+# LLVM-NEXT:            Data size: 0x0
+# LLVM-NEXT:            Type: NT_OPENBSD_WCOOKIE (window cookie)
+# LLVM-NEXT:        }
+# LLVM-NEXT:        {
+# LLVM-NEXT:            Owner: OpenBSD@31337
+# LLVM-NEXT:            Data size: 0x0
+# LLVM-NEXT:            Type: NT_OPENBSD_REGS (regular registers)
+# LLVM-NEXT:        }
+# LLVM-NEXT:        {
+# LLVM-NEXT:            Owner: OpenBSD@31337
+# LLVM-NEXT:            Data size: 0x0
+# LLVM-NEXT:            Type: NT_OPENBSD_FPREGS (floating point registers)
+# LLVM-NEXT:        }
+# LLVM-NEXT:    ]
 # LLVM-NEXT:   }
 # LLVM-NEXT: ]

--- a/llvm/test/tools/llvm-readobj/ELF/note-openbsd-core.test
+++ b/llvm/test/tools/llvm-readobj/ELF/note-openbsd-core.test
@@ -35,7 +35,7 @@ ProgramHeaders:
 # GNU-NEXT:   OpenBSD@31337        0x00000000	NT_OPENBSD_REGS (regular registers)
 # GNU-NEXT:   OpenBSD@31337        0x00000000	NT_OPENBSD_FPREGS (floating point registers)
 
-# LLVM:      NoteSectionList [
+# LLVM:      NoteSections [
 # LLVM-NEXT:   NoteSection {
 # LLVM-NEXT:     Name: <?>
 # LLVM-NEXT:     Offset: 0x78

--- a/llvm/test/tools/llvm-readobj/ELF/note-unknown.s
+++ b/llvm/test/tools/llvm-readobj/ELF/note-unknown.s
@@ -20,11 +20,11 @@
 // LLVM-NEXT:     Offset: 0x40
 // LLVM-NEXT:     Size: 0x10
 // LLVM-NEXT:	  Notes [
-// LLVM-NEXT:		{
-// LLVM-NEXT:			Owner: XYZ
-// LLVM-NEXT:			Data size: 0x0
-// LLVM-NEXT:			Type: Unknown (0x00000003)
-// LLVM-NEXT:		}
+// LLVM-NEXT:       {
+// LLVM-NEXT:           Owner: XYZ
+// LLVM-NEXT:           Data size: 0x0
+// LLVM-NEXT:           Type: Unknown (0x00000003)
+// LLVM-NEXT:       }
 // LLVM-NEXT:	  ]
 // LLVM-NEXT:   }
 // LLVM-NEXT:   NoteSection {
@@ -32,15 +32,15 @@
 // LLVM-NEXT:     Offset: 0x50
 // LLVM-NEXT:     Size: 0x2C
 // LLVM-NEXT:	  Notes [
-// LLVM-NEXT:		{
-// LLVM-NEXT:			Owner: XYZ
-// LLVM-NEXT:			Data size: 0x1C
-// LLVM-NEXT:			Type: Unknown (0x00000003)
-// LLVM-NEXT:			Description data (
-// LLVM-NEXT:				0000: 4C6F7265 6D206970 73756D20 646F6C6F  |Lorem ipsum dolo|
-// LLVM-NEXT:				0010: 72207369 7420616D 65740000           |r sit amet..|
-// LLVM-NEXT:			)
-// LLVM-NEXT:		}
+// LLVM-NEXT:       {
+// LLVM-NEXT:           Owner: XYZ
+// LLVM-NEXT:           Data size: 0x1C
+// LLVM-NEXT:           Type: Unknown (0x00000003)
+// LLVM-NEXT:           Description data (
+// LLVM-NEXT:               0000: 4C6F7265 6D206970 73756D20 646F6C6F  |Lorem ipsum dolo|
+// LLVM-NEXT:               0010: 72207369 7420616D 65740000           |r sit amet..|
+// LLVM-NEXT:           )
+// LLVM-NEXT:       }
 // LLVM-NEXT:	 ]
 // LLVM-NEXT:   }
 // LLVM-NEXT:   NoteSection {
@@ -48,22 +48,22 @@
 // LLVM-NEXT:     Offset: 0x80
 // LLVM-NEXT:     Size: 0x40
 // LLVM-NEXT:	  Notes [
-// LLVM-NEXT:		{
-// LLVM-NEXT:			Owner: WXYZ
-// LLVM-NEXT:			Data size: 0x8
-// LLVM-NEXT:			Type: Unknown (0x00000006)
-// LLVM-NEXT:			Description data (
-// LLVM-NEXT:				0000: 4C6F7265 6D000000                    |Lorem...|
-// LLVM-NEXT:			)
-// LLVM-NEXT:		}
-// LLVM-NEXT:		{
-// LLVM-NEXT:			Owner: VWXYZ
-// LLVM-NEXT:			Data size: 0x8
-// LLVM-NEXT:			Type: Unknown (0x00000006)
-// LLVM-NEXT:			Description data (
-// LLVM-NEXT:				0000: 78787800 00000000                    |xxx.....|
-// LLVM-NEXT:			)
-// LLVM-NEXT:		}
+// LLVM-NEXT:       {
+// LLVM-NEXT:           Owner: WXYZ
+// LLVM-NEXT:           Data size: 0x8
+// LLVM-NEXT:           Type: Unknown (0x00000006)
+// LLVM-NEXT:           Description data (
+// LLVM-NEXT:               0000: 4C6F7265 6D000000                    |Lorem...|
+// LLVM-NEXT:           )
+// LLVM-NEXT:       }
+// LLVM-NEXT:       {
+// LLVM-NEXT:           Owner: VWXYZ
+// LLVM-NEXT:           Data size: 0x8
+// LLVM-NEXT:           Type: Unknown (0x00000006)
+// LLVM-NEXT:           Description data (
+// LLVM-NEXT:               0000: 78787800 00000000                    |xxx.....|
+// LLVM-NEXT:           )
+// LLVM-NEXT:       }
 // LLVM-NEXT:	 ]
 // LLVM-NEXT:   }
 // LLVM-NEXT: ]

--- a/llvm/test/tools/llvm-readobj/ELF/note-unknown.s
+++ b/llvm/test/tools/llvm-readobj/ELF/note-unknown.s
@@ -19,46 +19,52 @@
 // LLVM-NEXT:     Name: .note.foo
 // LLVM-NEXT:     Offset: 0x40
 // LLVM-NEXT:     Size: 0x10
-// LLVM-NEXT:     Note {
-// LLVM-NEXT:       Owner: XYZ
-// LLVM-NEXT:       Data size: 0x0
-// LLVM-NEXT:       Type: Unknown (0x00000003)
-// LLVM-NEXT:     }
+// LLVM-NEXT:	  Notes [
+// LLVM-NEXT:		{
+// LLVM-NEXT:			Owner: XYZ
+// LLVM-NEXT:			Data size: 0x0
+// LLVM-NEXT:			Type: Unknown (0x00000003)
+// LLVM-NEXT:		}
+// LLVM-NEXT:	  ]
 // LLVM-NEXT:   }
 // LLVM-NEXT:   NoteSection {
 // LLVM-NEXT:     Name: .note.bar
 // LLVM-NEXT:     Offset: 0x50
 // LLVM-NEXT:     Size: 0x2C
-// LLVM-NEXT:     Note {
-// LLVM-NEXT:       Owner: XYZ
-// LLVM-NEXT:       Data size: 0x1C
-// LLVM-NEXT:       Type: Unknown (0x00000003)
-// LLVM-NEXT:       Description data (
-// LLVM-NEXT:         0000: 4C6F7265 6D206970 73756D20 646F6C6F  |Lorem ipsum dolo|
-// LLVM-NEXT:         0010: 72207369 7420616D 65740000           |r sit amet..|
-// LLVM-NEXT:       )
-// LLVM-NEXT:     }
+// LLVM-NEXT:	  Notes [
+// LLVM-NEXT:		{
+// LLVM-NEXT:			Owner: XYZ
+// LLVM-NEXT:			Data size: 0x1C
+// LLVM-NEXT:			Type: Unknown (0x00000003)
+// LLVM-NEXT:			Description data (
+// LLVM-NEXT:				0000: 4C6F7265 6D206970 73756D20 646F6C6F  |Lorem ipsum dolo|
+// LLVM-NEXT:				0010: 72207369 7420616D 65740000           |r sit amet..|
+// LLVM-NEXT:			)
+// LLVM-NEXT:		}
+// LLVM-NEXT:	 ]
 // LLVM-NEXT:   }
 // LLVM-NEXT:   NoteSection {
 // LLVM-NEXT:     Name: .note.8
 // LLVM-NEXT:     Offset: 0x80
 // LLVM-NEXT:     Size: 0x40
-// LLVM-NEXT:     Note {
-// LLVM-NEXT:       Owner: WXYZ
-// LLVM-NEXT:       Data size: 0x8
-// LLVM-NEXT:       Type: Unknown (0x00000006)
-// LLVM-NEXT:       Description data (
-// LLVM-NEXT:         0000: 4C6F7265 6D000000                    |Lorem...|
-// LLVM-NEXT:       )
-// LLVM-NEXT:     }
-// LLVM-NEXT:     Note {
-// LLVM-NEXT:       Owner: VWXYZ
-// LLVM-NEXT:       Data size: 0x8
-// LLVM-NEXT:       Type: Unknown (0x00000006)
-// LLVM-NEXT:       Description data (
-// LLVM-NEXT:         0000: 78787800 00000000                    |xxx.....|
-// LLVM-NEXT:       )
-// LLVM-NEXT:     }
+// LLVM-NEXT:	  Notes [
+// LLVM-NEXT:		{
+// LLVM-NEXT:			Owner: WXYZ
+// LLVM-NEXT:			Data size: 0x8
+// LLVM-NEXT:			Type: Unknown (0x00000006)
+// LLVM-NEXT:			Description data (
+// LLVM-NEXT:				0000: 4C6F7265 6D000000                    |Lorem...|
+// LLVM-NEXT:			)
+// LLVM-NEXT:		}
+// LLVM-NEXT:		{
+// LLVM-NEXT:			Owner: VWXYZ
+// LLVM-NEXT:			Data size: 0x8
+// LLVM-NEXT:			Type: Unknown (0x00000006)
+// LLVM-NEXT:			Description data (
+// LLVM-NEXT:				0000: 78787800 00000000                    |xxx.....|
+// LLVM-NEXT:			)
+// LLVM-NEXT:		}
+// LLVM-NEXT:	 ]
 // LLVM-NEXT:   }
 // LLVM-NEXT: ]
 

--- a/llvm/test/tools/llvm-readobj/ELF/note-unknown.s
+++ b/llvm/test/tools/llvm-readobj/ELF/note-unknown.s
@@ -14,7 +14,7 @@
 // GNU-NEXT:     description data: 4c 6f 72 65 6d 20 69 70 73 75 6d 20 64 6f 6c 6f 72 20 73 69 74 20 61 6d 65 74 00 00
 // GNU-EMPTY:
 
-// LLVM:      Notes [
+// LLVM:      NoteSectionList [
 // LLVM-NEXT:   NoteSection {
 // LLVM-NEXT:     Name: .note.foo
 // LLVM-NEXT:     Offset: 0x40

--- a/llvm/test/tools/llvm-readobj/ELF/note-unknown.s
+++ b/llvm/test/tools/llvm-readobj/ELF/note-unknown.s
@@ -14,7 +14,7 @@
 // GNU-NEXT:     description data: 4c 6f 72 65 6d 20 69 70 73 75 6d 20 64 6f 6c 6f 72 20 73 69 74 20 61 6d 65 74 00 00
 // GNU-EMPTY:
 
-// LLVM:      NoteSectionList [
+// LLVM:      NoteSections [
 // LLVM-NEXT:   NoteSection {
 // LLVM-NEXT:     Name: .note.foo
 // LLVM-NEXT:     Offset: 0x40

--- a/llvm/test/tools/llvm-readobj/archive.test
+++ b/llvm/test/tools/llvm-readobj/archive.test
@@ -21,7 +21,7 @@
 # LLVM: Sections [
 # LLVM: Relocations [
 # LLVM: Symbols [
-# LLVM: Notes [
+# LLVM: NoteSectionList [
 # LLVM: ]
 # LLVM: StackSizes [
 # LLVM: ]
@@ -41,7 +41,7 @@
 # LLVM: Sections [
 # LLVM: Relocations [
 # LLVM: Symbols [
-# LLVM: Notes [
+# LLVM: NoteSectionList [
 # LLVM: ]
 # LLVM: StackSizes [
 # LLVM: ]

--- a/llvm/test/tools/llvm-readobj/archive.test
+++ b/llvm/test/tools/llvm-readobj/archive.test
@@ -21,7 +21,7 @@
 # LLVM: Sections [
 # LLVM: Relocations [
 # LLVM: Symbols [
-# LLVM: NoteSectionList [
+# LLVM: NoteSections [
 # LLVM: ]
 # LLVM: StackSizes [
 # LLVM: ]
@@ -41,7 +41,7 @@
 # LLVM: Sections [
 # LLVM: Relocations [
 # LLVM: Symbols [
-# LLVM: NoteSectionList [
+# LLVM: NoteSections [
 # LLVM: ]
 # LLVM: StackSizes [
 # LLVM: ]

--- a/llvm/tools/llvm-readobj/ELFDumper.cpp
+++ b/llvm/tools/llvm-readobj/ELFDumper.cpp
@@ -7915,22 +7915,27 @@ static void printCoreNoteLLVMStyle(const CoreNote &Note, ScopedPrinter &W) {
 template <class ELFT> void LLVMELFDumper<ELFT>::printNotes() {
   ListScope L(W, "Notes");
 
-  std::unique_ptr<DictScope> NoteScope;
+  std::unique_ptr<DictScope> NoteSectionScope;
+  std::unique_ptr<ListScope> NotesScope;
   size_t Align = 0;
   auto StartNotes = [&](std::optional<StringRef> SecName,
                         const typename ELFT::Off Offset,
                         const typename ELFT::Addr Size, size_t Al) {
     Align = std::max<size_t>(Al, 4);
-    NoteScope = std::make_unique<DictScope>(W, "NoteSection");
+    NoteSectionScope = std::make_unique<DictScope>(W, "NoteSection");
     W.printString("Name", SecName ? *SecName : "<?>");
     W.printHex("Offset", Offset);
     W.printHex("Size", Size);
+    NotesScope = std::make_unique<ListScope>(W, "Notes");
   };
 
-  auto EndNotes = [&] { NoteScope.reset(); };
+  auto EndNotes = [&] {
+    NotesScope.reset();
+    NoteSectionScope.reset();
+  };
 
   auto ProcessNote = [&](const Elf_Note &Note, bool IsCore) -> Error {
-    DictScope D2(W, "Note");
+    DictScope D2(W);
     StringRef Name = Note.getName();
     ArrayRef<uint8_t> Descriptor = Note.getDesc(Align);
     Elf_Word Type = Note.getType();

--- a/llvm/tools/llvm-readobj/ELFDumper.cpp
+++ b/llvm/tools/llvm-readobj/ELFDumper.cpp
@@ -7913,7 +7913,7 @@ static void printCoreNoteLLVMStyle(const CoreNote &Note, ScopedPrinter &W) {
 }
 
 template <class ELFT> void LLVMELFDumper<ELFT>::printNotes() {
-  ListScope L(W, "Notes");
+  ListScope L(W, "NoteSectionList");
 
   std::unique_ptr<DictScope> NoteSectionScope;
   std::unique_ptr<ListScope> NotesScope;

--- a/llvm/tools/llvm-readobj/ELFDumper.cpp
+++ b/llvm/tools/llvm-readobj/ELFDumper.cpp
@@ -7913,7 +7913,7 @@ static void printCoreNoteLLVMStyle(const CoreNote &Note, ScopedPrinter &W) {
 }
 
 template <class ELFT> void LLVMELFDumper<ELFT>::printNotes() {
-  ListScope L(W, "NoteSectionList");
+  ListScope L(W, "NoteSections");
 
   std::unique_ptr<DictScope> NoteSectionScope;
   std::unique_ptr<ListScope> NotesScope;


### PR DESCRIPTION
It turns out that the notes section for corefiles (or really any elf file with multiple notes) is set up in such a way for LLVM formatted output that the JSON equivalent only has the last note since the notes are held in a dictionary with every key being Note. This pr alters the layout for the notes to a list of dictionaries to sidestep this issue for JSON output. Prior to this pr a note section in the output looked like (for LLVM output):

```
Notes [
  NoteSection {
    Name: <?>
    Offset: 0x2148
    Size: 0x1F864
    Note {
      Owner: CORE
      Data size: 0x150
      Type: NT_PRSTATUS (prstatus structure)
      Description data (
        0000: 06000000 00000000 00000000 06000000  |................|
        ...
      )
    }
    Note {
      Owner: CORE
      Data size: 0x88
      Type: NT_PRPSINFO (prpsinfo structure)
      Description data (
        0000: 02440000 00000000 04054040 00000000  |.D........@@....|
	....
```

But is now:

```
NoteSections [
  NoteSection {
    Name: <?>
    Offset: 0x2148
    Size: 0x1F864
    Notes [
      {
        Owner: CORE
        Data size: 0x150
        Type: NT_PRSTATUS (prstatus structure)
        Description data (
          0000: 06000000 00000000 00000000 06000000  |................|
          ...
        )
      }
      {
        Owner: CORE
        Data size: 0x88
        Type: NT_PRPSINFO (prpsinfo structure)
        Description data (
          0000: 02440000 00000000 04054040 00000000  |.D........@@....|
	  ...
```