### PR TITLE
Revert "[ADT] Always use 32-bit size type for SmallVector with 16-bit elements"

### DIFF
--- a/llvm/include/llvm/ADT/SmallVector.h
+++ b/llvm/include/llvm/ADT/SmallVector.h
@@ -116,7 +116,8 @@ protected:
 
 template <class T>
 using SmallVectorSizeType =
-    std::conditional_t<sizeof(T) == 1, size_t, uint32_t>;
+    std::conditional_t<sizeof(T) < 4 && sizeof(void *) >= 8, uint64_t,
+                       uint32_t>;
 
 /// Figure out the offset of the first element.
 template <class T, typename = void> struct SmallVectorAlignmentAndSize {

--- a/llvm/lib/Support/SmallVector.cpp
+++ b/llvm/lib/Support/SmallVector.cpp
@@ -37,7 +37,9 @@ struct Struct32B {
 #pragma GCC diagnostic pop
 #endif
 }
-
+static_assert(sizeof(SmallVector<void *, 0>) ==
+                  sizeof(unsigned) * 2 + sizeof(void *),
+              "wasted space in SmallVector size 0");
 static_assert(alignof(SmallVector<Struct16B, 0>) >= alignof(Struct16B),
               "wrong alignment for 16-byte aligned T");
 static_assert(alignof(SmallVector<Struct32B, 0>) >= alignof(Struct32B),
@@ -46,19 +48,13 @@ static_assert(sizeof(SmallVector<Struct16B, 0>) >= alignof(Struct16B),
               "missing padding for 16-byte aligned T");
 static_assert(sizeof(SmallVector<Struct32B, 0>) >= alignof(Struct32B),
               "missing padding for 32-byte aligned T");
-
-static_assert(sizeof(SmallVector<void *, 0>) ==
-                  sizeof(unsigned) * 2 + sizeof(void *),
-              "wasted space in SmallVector size 0");
 static_assert(sizeof(SmallVector<void *, 1>) ==
                   sizeof(unsigned) * 2 + sizeof(void *) * 2,
               "wasted space in SmallVector size 1");
+
 static_assert(sizeof(SmallVector<char, 0>) ==
                   sizeof(void *) * 2 + sizeof(void *),
               "1 byte elements have word-sized type for size and capacity");
-static_assert(sizeof(SmallVector<int16_t, 0>) ==
-                  sizeof(unsigned) * 2 + sizeof(void *),
-              "2 byte elements have 32-bit type for size and capacity");
 
 /// Report that MinSize doesn't fit into this vector's size type. Throws
 /// std::length_error or calls report_fatal_error.


### PR DESCRIPTION
Reverts llvm/llvm-project#95536, this is breaking macOS GreenDragon buildbots on arm64 and x86_64 https://green.lab.llvm.org/job/llvm.org/view/LLDB/job/as-lldb-cmake/6522/console, also breaks the Darwin LLVM buildbots: https://lab.llvm.org/buildbot/#/builders/23/builds/398