### PR TITLE
[Clang] Bring initFeatureMap back to AArch64TargetInfo.

### DIFF
--- a/clang/lib/Basic/Targets/AArch64.cpp
+++ b/clang/lib/Basic/Targets/AArch64.cpp
@@ -1173,19 +1173,19 @@ ParsedTargetAttr AArch64TargetInfo::parseTargetAttr(StringRef Features) const {
 bool AArch64TargetInfo::initFeatureMap(
      llvm::StringMap<bool> &Features, DiagnosticsEngine &Diags, StringRef CPU,
      const std::vector<std::string> &FeaturesVec) const {
-   std::vector<std::string> UpdatedFeaturesVec;
-   // Parse the CPU and add any implied features.
-   std::optional<llvm::AArch64::CpuInfo> CpuInfo = llvm::AArch64::parseCpu(CPU);
-   if (CpuInfo) {
-     auto Exts = CpuInfo->getImpliedExtensions();
-     std::vector<StringRef> CPUFeats;
-     llvm::AArch64::getExtensionFeatures(Exts, CPUFeats);
-     for (auto F : CPUFeats) {
-       assert((F[0] == '+' || F[0] == '-') && "Expected +/- in target feature!");
-       UpdatedFeaturesVec.push_back(F.str());
-     }
-   }
-   return TargetInfo::initFeatureMap(Features, Diags, CPU, UpdatedFeaturesVec);
+  std::vector<std::string> UpdatedFeaturesVec;
+  // Parse the CPU and add any implied features.
+  std::optional<llvm::AArch64::CpuInfo> CpuInfo = llvm::AArch64::parseCpu(CPU);
+  if (CpuInfo) {
+    auto Exts = CpuInfo->getImpliedExtensions();
+    std::vector<StringRef> CPUFeats;
+    llvm::AArch64::getExtensionFeatures(Exts, CPUFeats);
+    for (auto F : CPUFeats) {
+      assert((F[0] == '+' || F[0] == '-') && "Expected +/- in target feature!");
+      UpdatedFeaturesVec.push_back(F.str());
+    }
+  }
+  return TargetInfo::initFeatureMap(Features, Diags, CPU, UpdatedFeaturesVec);
 }
 
 bool AArch64TargetInfo::hasBFloat16Type() const {

--- a/clang/lib/Basic/Targets/AArch64.cpp
+++ b/clang/lib/Basic/Targets/AArch64.cpp
@@ -1170,6 +1170,24 @@ ParsedTargetAttr AArch64TargetInfo::parseTargetAttr(StringRef Features) const {
   return Ret;
 }
 
+bool AArch64TargetInfo::initFeatureMap(
+     llvm::StringMap<bool> &Features, DiagnosticsEngine &Diags, StringRef CPU,
+     const std::vector<std::string> &FeaturesVec) const {
+   std::vector<std::string> UpdatedFeaturesVec;
+   // Parse the CPU and add any implied features.
+   std::optional<llvm::AArch64::CpuInfo> CpuInfo = llvm::AArch64::parseCpu(CPU);
+   if (CpuInfo) {
+     auto Exts = CpuInfo->getImpliedExtensions();
+     std::vector<StringRef> CPUFeats;
+     llvm::AArch64::getExtensionFeatures(Exts, CPUFeats);
+     for (auto F : CPUFeats) {
+       assert((F[0] == '+' || F[0] == '-') && "Expected +/- in target feature!");
+       UpdatedFeaturesVec.push_back(F.str());
+     }
+   }
+   return TargetInfo::initFeatureMap(Features, Diags, CPU, UpdatedFeaturesVec);
+}
+
 bool AArch64TargetInfo::hasBFloat16Type() const {
   return true;
 }

--- a/clang/lib/Basic/Targets/AArch64.h
+++ b/clang/lib/Basic/Targets/AArch64.h
@@ -109,8 +109,8 @@ public:
 
   bool
   initFeatureMap(llvm::StringMap<bool> &Features, DiagnosticsEngine &Diags,
-                  StringRef CPU,
-                  const std::vector<std::string> &FeaturesVec) const override;
+                 StringRef CPU,
+                 const std::vector<std::string> &FeaturesVec) const override;
 
   bool useFP16ConversionIntrinsics() const override {
     return false;

--- a/clang/lib/Basic/Targets/AArch64.h
+++ b/clang/lib/Basic/Targets/AArch64.h
@@ -107,6 +107,11 @@ public:
   unsigned multiVersionSortPriority(StringRef Name) const override;
   unsigned multiVersionFeatureCost() const override;
 
+  bool
+  initFeatureMap(llvm::StringMap<bool> &Features, DiagnosticsEngine &Diags,
+                  StringRef CPU,
+                  const std::vector<std::string> &FeaturesVec) const override;
+
   bool useFP16ConversionIntrinsics() const override {
     return false;
   }


### PR DESCRIPTION
We noticed that `TargetInfo::CreateTargetInfo` is giving up back empty `opt->featureMap` for AArch64, which is probably related to [this change](https://github.com/llvm/llvm-project/commit/a03d06a736fd8921c8f40637667d6af9c2c76505#diff-2ccae12096c75c4b8422ea0d2fdf6b195896d2554d62cce604e8fcb56a78ef62L1067). 

Trying to bring the info back (if possible).