### PR TITLE
[Memprof] Fixes memory leak in MemInfoBlock histogram.

### DIFF
--- a/llvm/lib/ProfileData/MemProfReader.cpp
+++ b/llvm/lib/ProfileData/MemProfReader.cpp
@@ -633,6 +633,8 @@ Error RawMemProfReader::symbolizeAndFilterStackFrames(
   // Drop the entries where the callstack is empty.
   for (const uint64_t Id : EntriesToErase) {
     StackMap.erase(Id);
+    if(CallstackProfileData[Id].AccessHistogramSize > 0)
+      free((void*) CallstackProfileData[Id].AccessHistogram);
     CallstackProfileData.erase(Id);
   }
 


### PR DESCRIPTION
MemInfoBlocks (MIB) with empty callstacks are erased prematurely from the CallStackProfileData. This patch frees allocated histogram buffers when the MIB is associated with an empty callstack.