### PR TITLE
[clang-tidy] Attempt to fix issue 96247

### DIFF
--- a/clang-tools-extra/test/CMakeLists.txt
+++ b/clang-tools-extra/test/CMakeLists.txt
@@ -70,6 +70,12 @@ endforeach()
 if (NOT WIN32 OR NOT LLVM_LINK_LLVM_DYLIB)
   llvm_add_library(
       CTTestTidyModule
+      LINK_LIBS
+      clangAST
+      clangASTMatchers
+      clangTooling
+      clangBasic
+      clangTidy
       MODULE clang-tidy/CTTestTidyModule.cpp
       PLUGIN_TOOL clang-tidy)
 endif()


### PR DESCRIPTION
https://github.com/llvm/llvm-project/issues/96247

These libraries are not linked for windows gnu targets since the libraries are not linked. I need to find out what's going on here. But first, I will just run CI to see whether anything breaks. I guess the CMakeListst.txt File is just wrong by not linking. However, it looks weird it is only an issue on windows-gnu target since other targets should have the same issue, right?