### PR TITLE
[Clang][AST] Let DeclPrinter print trailing requires expressions for template parameters

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -99,6 +99,7 @@ AST Dumping Potentially Breaking Changes
 ----------------------------------------
 
 - The text ast-dumper has improved printing of TemplateArguments.
+- The text decl-dumper prints template parameters' trailing requires expressions now.
 
 Clang Frontend Potentially Breaking Changes
 -------------------------------------------

--- a/clang/lib/AST/DeclPrinter.cpp
+++ b/clang/lib/AST/DeclPrinter.cpp
@@ -1187,18 +1187,15 @@ void DeclPrinter::printTemplateParameters(const TemplateParameterList *Params,
   }
 
   Out << '>';
-  if (!OmitTemplateKW)
-    Out << ' ';
 
   if (const Expr *RequiresClause = Params->getRequiresClause()) {
-    if (OmitTemplateKW)
-      Out << ' ';
-    Out << "requires ";
+    Out << " requires ";
     RequiresClause->printPretty(Out, nullptr, Policy, Indentation, "\n",
                                 &Context);
-    if (!OmitTemplateKW)
-      Out << ' ';
   }
+
+  if (!OmitTemplateKW)
+    Out << ' ';
 }
 
 void DeclPrinter::printTemplateArguments(ArrayRef<TemplateArgument> Args,

--- a/clang/lib/AST/DeclPrinter.cpp
+++ b/clang/lib/AST/DeclPrinter.cpp
@@ -1189,6 +1189,16 @@ void DeclPrinter::printTemplateParameters(const TemplateParameterList *Params,
   Out << '>';
   if (!OmitTemplateKW)
     Out << ' ';
+
+  if (const Expr *RequiresClause = Params->getRequiresClause()) {
+    if (OmitTemplateKW)
+      Out << ' ';
+    Out << "requires ";
+    RequiresClause->printPretty(Out, nullptr, Policy, Indentation, "\n",
+                                &Context);
+    if (!OmitTemplateKW)
+      Out << ' ';
+  }
 }
 
 void DeclPrinter::printTemplateArguments(ArrayRef<TemplateArgument> Args,

--- a/clang/test/PCH/cxx2a-requires-expr.cpp
+++ b/clang/test/PCH/cxx2a-requires-expr.cpp
@@ -22,3 +22,20 @@ bool f() {
     requires C<typename T::val> || (C<typename T::val> || C<T>);
   };
 }
+
+namespace trailing_requires_expression {
+
+template <typename T> requires C<T> && C2<T, T>
+// CHECK: template <typename T> requires C<T> && C2<T, T> void g();
+void g();
+
+template <typename T> requires C<T> || C2<T, T>
+// CHECK: template <typename T> requires C<T> || C2<T, T> constexpr int h = sizeof(T);
+constexpr int h = sizeof(T);
+
+template <typename T> requires C<T>
+// CHECK:      template <typename T> requires C<T> class i {
+// CHECK-NEXT: };
+class i {};
+
+}


### PR DESCRIPTION
As discussed in https://github.com/llvm/llvm-project/pull/96084#discussion_r1654629993, it would be nice to present these trailing constraints on template parameters when printing CTAD decls through a DeclPrinter.