### PR TITLE
[lldb][AArch64] Add register field enum information

### DIFF
--- a/lldb/source/Plugins/Process/Utility/RegisterFlagsDetector_arm64.cpp
+++ b/lldb/source/Plugins/Process/Utility/RegisterFlagsDetector_arm64.cpp
@@ -53,16 +53,22 @@ Arm64RegisterFlagsDetector::DetectMTECtrlFields(uint64_t hwcap,
   // Represents the contents of NT_ARM_TAGGED_ADDR_CTRL and the value passed
   // to prctl(PR_TAGGED_ADDR_CTRL...). Fields are derived from the defines
   // used to build the value.
+
+  static const FieldEnum tcf_enum(
+      "tcf_enum",
+      {{0, "TCF_NONE"}, {1, "TCF_SYNC"}, {2, "TCF_ASYNC"}, {3, "TCF_ASYMM"}});
   return {{"TAGS", 3, 18}, // 16 bit bitfield shifted up by PR_MTE_TAG_SHIFT.
-          {"TCF_ASYNC", 2},
-          {"TCF_SYNC", 1},
+          {"TCF", 1, 2, &tcf_enum},
           {"TAGGED_ADDR_ENABLE", 0}};
 }
 
 Arm64RegisterFlagsDetector::Fields
 Arm64RegisterFlagsDetector::DetectFPCRFields(uint64_t hwcap, uint64_t hwcap2) {
+  static const FieldEnum rmode_enum(
+      "rmode_enum", {{0, "RN"}, {1, "RP"}, {2, "RM"}, {3, "RZ"}});
+
   std::vector<RegisterFlags::Field> fpcr_fields{
-      {"AHP", 26}, {"DN", 25}, {"FZ", 24}, {"RMode", 22, 23},
+      {"AHP", 26}, {"DN", 25}, {"FZ", 24}, {"RMode", 22, 23, &rmode_enum},
       // Bits 21-20 are "Stride" which is unused in AArch64 state.
   };
 

--- a/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationServerLLGS.cpp
+++ b/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationServerLLGS.cpp
@@ -3083,6 +3083,7 @@ GDBRemoteCommunicationServerLLGS::BuildTargetXml() {
   if (registers_count)
     response.IndentMore();
 
+  llvm::StringSet<> field_enums_seen;
   for (int reg_index = 0; reg_index < registers_count; reg_index++) {
     const RegisterInfo *reg_info =
         reg_context.GetRegisterInfoAtIndex(reg_index);
@@ -3096,6 +3097,7 @@ GDBRemoteCommunicationServerLLGS::BuildTargetXml() {
 
     if (reg_info->flags_type) {
       response.IndentMore();
+      reg_info->flags_type->EnumsToXML(response, field_enums_seen);
       reg_info->flags_type->ToXML(response);
       response.IndentLess();
     }

--- a/lldb/test/API/commands/register/register/register_command/TestRegisters.py
+++ b/lldb/test/API/commands/register/register/register_command/TestRegisters.py
@@ -632,7 +632,13 @@ class RegisterCommandsTestCase(TestBase):
         self.expect("register read fpsr", substrs=["= (QC = 0, IDC = 0, IXC = 0"])
         # AHP/DN/FZ/RMode always present, others may vary.
         self.expect(
-            "register read fpcr", substrs=["= (AHP = 0, DN = 0, FZ = 0, RMode = 0"]
+            "register read fpcr", substrs=["= (AHP = 0, DN = 0, FZ = 0, RMode = RN"]
+        )
+
+        # Should get enumerator descriptions for RMode.
+        self.expect(
+            "register info fpcr",
+            substrs=["RMode: 0 = RN, 1 = RP, 2 = RM, 3 = RZ"],
         )
 
     @skipUnlessPlatform(["linux"])

--- a/lldb/test/API/functionalities/postmortem/elf-core/TestLinuxCore.py
+++ b/lldb/test/API/functionalities/postmortem/elf-core/TestLinuxCore.py
@@ -583,7 +583,12 @@ class LinuxCoreTestCase(TestBase):
         self.expect("register read fpsr", substrs=["= (QC = 0, IDC = 0, IXC = 0"])
         # AHP/DN/FZ/RMode always present, others may vary.
         self.expect(
-            "register read fpcr", substrs=["= (AHP = 0, DN = 0, FZ = 0, RMode = 0"]
+            "register read fpcr", substrs=["= (AHP = 0, DN = 0, FZ = 0, RMode = RN"]
+        )
+        # RMode should have enumerator descriptions.
+        self.expect(
+            "register info fpcr",
+            substrs=["RMode: 0 = RN, 1 = RP, 2 = RM, 3 = RZ"],
         )
 
     @skipIfLLVMTargetMissing("AArch64")

--- a/lldb/test/API/linux/aarch64/mte_core_file/TestAArch64LinuxMTEMemoryTagCoreFile.py
+++ b/lldb/test/API/linux/aarch64/mte_core_file/TestAArch64LinuxMTEMemoryTagCoreFile.py
@@ -238,8 +238,15 @@ class AArch64LinuxMTEMemoryTagCoreFileTestCase(TestBase):
         expected = ["mte_ctrl = 0x000000000007fffb"]
 
         if self.hasXMLSupport():
-            expected.append(
-                "(TAGS = 65535, TCF_ASYNC = 0, TCF_SYNC = 1, TAGGED_ADDR_ENABLE = 1)"
-            )
+            expected.append("(TAGS = 65535, TCF = TCF_SYNC, TAGGED_ADDR_ENABLE = 1)")
 
         self.expect("register read mte_ctrl", substrs=expected)
+
+        if self.hasXMLSupport():
+            # Should get enumerator descriptions for TCF
+            self.expect(
+                "register info mte_ctrl",
+                substrs=[
+                    "TCF: 0 = TCF_NONE, 1 = TCF_SYNC, 2 = TCF_ASYNC, 3 = TCF_ASYMM"
+                ],
+            )

--- a/lldb/test/Shell/Register/Core/aarch64-freebsd-register-fields.test
+++ b/lldb/test/Shell/Register/Core/aarch64-freebsd-register-fields.test
@@ -12,4 +12,4 @@ register read fpsr
 # CHECK-NEXT:      = (QC = 0, IDC = 0, IXC = 0, UFC = 0, OFC = 0, DZC = 0, IOC = 0)
 register read fpcr
 # CHECK:      fpcr = 0x02000000
-# CHECK-NEXT:      = (AHP = 0, DN = 1, FZ = 0, RMode = 0, IDE = 0, IXE = 0, UFE = 0, OFE = 0, DZE = 0, IOE = 0)
+# CHECK-NEXT:      = (AHP = 0, DN = 1, FZ = 0, RMode = RN, IDE = 0, IXE = 0, UFE = 0, OFE = 0, DZE = 0, IOE = 0)


### PR DESCRIPTION
This enables XML output for enums and adds enums for 2 fields on AArch64 Linux:
* mte_ctrl.tcf, which controls how tag faults are delivered.
* fpcr.rmode, which sets the rounding mode for floating point operations.

The other one we could do is cpsr.btype, but it is not clear what would be useful here so I'm not including it in this change.