### PR TITLE
[Sema] LambdaScopeForCallOperatorInstantiationRAII - fix typo in early out logic

### DIFF
--- a/clang/lib/Sema/SemaLambda.cpp
+++ b/clang/lib/Sema/SemaLambda.cpp
@@ -2391,7 +2391,7 @@ Sema::LambdaScopeForCallOperatorInstantiationRAII::
       Pattern =
           dyn_cast<FunctionDecl>(getLambdaAwareParentOfDeclContext(Pattern));
 
-      if (!FD || !Pattern)
+      if (!ParentFD || !Pattern)
         break;
 
       SemaRef.addInstantiatedParametersToScope(ParentFD, Pattern, Scope, MLTAL);


### PR DESCRIPTION
We should be checking for a failed dyn_cast on the ParentFD result - not the loop invariant FD root value.

Seems to have been introduced in #65193

Noticed by static analyser (I have no specific test case).