### PR TITLE
[Support] Fix llvm::xxh3_128bits for win 32 builds

### DIFF
--- a/llvm/lib/Support/xxhash.cpp
+++ b/llvm/lib/Support/xxhash.cpp
@@ -46,6 +46,9 @@
 #include "llvm/Support/Endian.h"
 
 #include <stdlib.h>
+#if defined(_MSC_VER) && defined(_M_IX86)
+#include <intrin.h>
+#endif
 
 using namespace llvm;
 using namespace support;


### PR DESCRIPTION
#95863 caused build failures for Win32 builds.
This change includes the necessary include to fix it.

