### PR TITLE
[MC] Make MCSection::isVirtualSection non-virtual

### DIFF
--- a/llvm/include/llvm/MC/MCSection.h
+++ b/llvm/include/llvm/MC/MCSection.h
@@ -106,6 +106,8 @@ private:
 
   bool IsText : 1;
 
+  bool IsVirtual : 1;
+
   MCDummyFragment DummyFragment;
 
   // Mapping from subsection number to fragment list. At layout time, the
@@ -127,7 +129,8 @@ protected:
   StringRef Name;
   SectionVariant Variant;
 
-  MCSection(SectionVariant V, StringRef Name, bool IsText, MCSymbol *Begin);
+  MCSection(SectionVariant V, StringRef Name, bool IsText, bool IsVirtual,
+            MCSymbol *Begin);
   ~MCSection();
 
 public:
@@ -219,7 +222,7 @@ public:
 
   /// Check whether this section is "virtual", that is has no actual object
   /// file contents.
-  virtual bool isVirtualSection() const = 0;
+  bool isVirtualSection() const { return IsVirtual; }
 
   virtual StringRef getVirtualSectionKind() const;
 

--- a/llvm/include/llvm/MC/MCSectionCOFF.h
+++ b/llvm/include/llvm/MC/MCSectionCOFF.h
@@ -53,6 +53,7 @@ private:
   MCSectionCOFF(StringRef Name, unsigned Characteristics,
                 MCSymbol *COMDATSymbol, int Selection, MCSymbol *Begin)
       : MCSection(SV_COFF, Name, Characteristics & COFF::IMAGE_SCN_CNT_CODE,
+                  Characteristics & COFF::IMAGE_SCN_CNT_UNINITIALIZED_DATA,
                   Begin),
         Characteristics(Characteristics), COMDATSymbol(COMDATSymbol),
         Selection(Selection) {
@@ -75,7 +76,6 @@ public:
                             raw_ostream &OS,
                             uint32_t Subsection) const override;
   bool useCodeAlign() const override;
-  bool isVirtualSection() const override;
   StringRef getVirtualSectionKind() const override;
 
   unsigned getOrAssignWinCFISectionID(unsigned *NextID) const {

--- a/llvm/include/llvm/MC/MCSectionDXContainer.h
+++ b/llvm/include/llvm/MC/MCSectionDXContainer.h
@@ -24,13 +24,13 @@ class MCSectionDXContainer final : public MCSection {
   friend class MCContext;
 
   MCSectionDXContainer(StringRef Name, SectionKind K, MCSymbol *Begin)
-      : MCSection(SV_DXContainer, Name, K.isText(), Begin) {}
+      : MCSection(SV_DXContainer, Name, K.isText(), /*IsVirtual=*/false,
+                  Begin) {}
 
 public:
   void printSwitchToSection(const MCAsmInfo &, const Triple &, raw_ostream &,
                             uint32_t) const override;
   bool useCodeAlign() const override { return false; }
-  bool isVirtualSection() const override { return false; }
 };
 
 } // end namespace llvm

--- a/llvm/include/llvm/MC/MCSectionELF.h
+++ b/llvm/include/llvm/MC/MCSectionELF.h
@@ -54,8 +54,9 @@ private:
                unsigned entrySize, const MCSymbolELF *group, bool IsComdat,
                unsigned UniqueID, MCSymbol *Begin,
                const MCSymbolELF *LinkedToSym)
-      : MCSection(SV_ELF, Name, flags & ELF::SHF_EXECINSTR, Begin), Type(type),
-        Flags(flags), UniqueID(UniqueID), EntrySize(entrySize),
+      : MCSection(SV_ELF, Name, flags & ELF::SHF_EXECINSTR,
+                  type == ELF::SHT_NOBITS, Begin),
+        Type(type), Flags(flags), UniqueID(UniqueID), EntrySize(entrySize),
         Group(group, IsComdat), LinkedToSym(LinkedToSym) {
     if (Group.getPointer())
       Group.getPointer()->setIsSignature();
@@ -81,7 +82,6 @@ public:
                             raw_ostream &OS,
                             uint32_t Subsection) const override;
   bool useCodeAlign() const override;
-  bool isVirtualSection() const override;
   StringRef getVirtualSectionKind() const override;
 
   bool isUnique() const { return UniqueID != NonUniqueID; }

--- a/llvm/include/llvm/MC/MCSectionGOFF.h
+++ b/llvm/include/llvm/MC/MCSectionGOFF.h
@@ -30,8 +30,8 @@ private:
 
   friend class MCContext;
   MCSectionGOFF(StringRef Name, SectionKind K, MCSection *P, uint32_t Sub)
-      : MCSection(SV_GOFF, Name, K.isText(), nullptr), Parent(P),
-        Subsection(Sub) {}
+      : MCSection(SV_GOFF, Name, K.isText(), /*IsVirtual=*/false, nullptr),
+        Parent(P), Subsection(Sub) {}
 
 public:
   void printSwitchToSection(const MCAsmInfo &MAI, const Triple &T,
@@ -41,8 +41,6 @@ public:
   }
 
   bool useCodeAlign() const override { return false; }
-
-  bool isVirtualSection() const override { return false; }
 
   MCSection *getParent() const { return Parent; }
   uint32_t getSubsection() const { return Subsection; }

--- a/llvm/include/llvm/MC/MCSectionMachO.h
+++ b/llvm/include/llvm/MC/MCSectionMachO.h
@@ -75,7 +75,6 @@ public:
                             raw_ostream &OS,
                             uint32_t Subsection) const override;
   bool useCodeAlign() const override;
-  bool isVirtualSection() const override;
 
   void allocAtoms();
   const MCSymbol *getAtom(size_t I) const;

--- a/llvm/include/llvm/MC/MCSectionSPIRV.h
+++ b/llvm/include/llvm/MC/MCSectionSPIRV.h
@@ -24,7 +24,8 @@ class MCSectionSPIRV final : public MCSection {
   friend class MCContext;
 
   MCSectionSPIRV()
-      : MCSection(SV_SPIRV, "", /*IsText=*/true, /*Begin=*/nullptr) {}
+      : MCSection(SV_SPIRV, "", /*IsText=*/true, /*IsVirtual=*/false,
+                  /*Begin=*/nullptr) {}
   // TODO: Add StringRef Name to MCSectionSPIRV.
 
 public:
@@ -33,7 +34,6 @@ public:
                             raw_ostream &OS,
                             uint32_t Subsection) const override {}
   bool useCodeAlign() const override { return false; }
-  bool isVirtualSection() const override { return false; }
 };
 
 } // end namespace llvm

--- a/llvm/include/llvm/MC/MCSectionWasm.h
+++ b/llvm/include/llvm/MC/MCSectionWasm.h
@@ -51,8 +51,9 @@ class MCSectionWasm final : public MCSection {
   friend class MCContext;
   MCSectionWasm(StringRef Name, SectionKind K, unsigned SegmentFlags,
                 const MCSymbolWasm *Group, unsigned UniqueID, MCSymbol *Begin)
-      : MCSection(SV_Wasm, Name, K.isText(), Begin), UniqueID(UniqueID),
-        Group(Group), IsWasmData(K.isReadOnly() || K.isWriteable()),
+      : MCSection(SV_Wasm, Name, K.isText(), /*IsVirtual=*/false, Begin),
+        UniqueID(UniqueID), Group(Group),
+        IsWasmData(K.isReadOnly() || K.isWriteable()),
         IsMetadata(K.isMetadata()), SegmentFlags(SegmentFlags) {}
 
 public:
@@ -67,7 +68,6 @@ public:
                             raw_ostream &OS,
                             uint32_t Subsection) const override;
   bool useCodeAlign() const override;
-  bool isVirtualSection() const override;
 
   bool isWasmData() const { return IsWasmData; }
   bool isMetadata() const { return IsMetadata; }

--- a/llvm/include/llvm/MC/MCSectionXCOFF.h
+++ b/llvm/include/llvm/MC/MCSectionXCOFF.h
@@ -41,11 +41,14 @@ class MCSectionXCOFF final : public MCSection {
   static constexpr unsigned DefaultAlignVal = 4;
   static constexpr unsigned DefaultTextAlignVal = 32;
 
+  // XTY_CM sections are virtual except for toc-data symbols.
   MCSectionXCOFF(StringRef Name, XCOFF::StorageMappingClass SMC,
                  XCOFF::SymbolType ST, SectionKind K, MCSymbolXCOFF *QualName,
                  MCSymbol *Begin, StringRef SymbolTableName,
                  bool MultiSymbolsAllowed)
-      : MCSection(SV_XCOFF, Name, K.isText(), Begin),
+      : MCSection(SV_XCOFF, Name, K.isText(),
+                  /*IsVirtual=*/ST == XCOFF::XTY_CM && SMC != XCOFF::XMC_TD,
+                  Begin),
         CsectProp(XCOFF::CsectProperties(SMC, ST)), QualName(QualName),
         SymbolTableName(SymbolTableName), DwarfSubtypeFlags(std::nullopt),
         MultiSymbolsAllowed(MultiSymbolsAllowed), Kind(K) {
@@ -69,12 +72,14 @@ class MCSectionXCOFF final : public MCSection {
     }
   }
 
+  // DWARF sections are never virtual.
   MCSectionXCOFF(StringRef Name, SectionKind K, MCSymbolXCOFF *QualName,
                  XCOFF::DwarfSectionSubtypeFlags DwarfSubtypeFlags,
                  MCSymbol *Begin, StringRef SymbolTableName,
                  bool MultiSymbolsAllowed)
-      : MCSection(SV_XCOFF, Name, K.isText(), Begin), QualName(QualName),
-        SymbolTableName(SymbolTableName), DwarfSubtypeFlags(DwarfSubtypeFlags),
+      : MCSection(SV_XCOFF, Name, K.isText(), /*IsVirtual=*/false, Begin),
+        QualName(QualName), SymbolTableName(SymbolTableName),
+        DwarfSubtypeFlags(DwarfSubtypeFlags),
         MultiSymbolsAllowed(MultiSymbolsAllowed), Kind(K) {
     assert(QualName != nullptr && "QualName is needed.");
 
@@ -114,7 +119,6 @@ public:
                             raw_ostream &OS,
                             uint32_t Subsection) const override;
   bool useCodeAlign() const override;
-  bool isVirtualSection() const override;
   StringRef getSymbolTableName() const { return SymbolTableName; }
   void setSymbolTableName(StringRef STN) { SymbolTableName = STN; }
   bool isMultiSymbolsAllowed() const { return MultiSymbolsAllowed; }

--- a/llvm/lib/MC/MCSection.cpp
+++ b/llvm/lib/MC/MCSection.cpp
@@ -21,10 +21,10 @@
 using namespace llvm;
 
 MCSection::MCSection(SectionVariant V, StringRef Name, bool IsText,
-                     MCSymbol *Begin)
+                     bool IsVirtual, MCSymbol *Begin)
     : Begin(Begin), BundleGroupBeforeFirstInst(false), HasInstructions(false),
-      HasLayout(false), IsRegistered(false), IsText(IsText), Name(Name),
-      Variant(V) {
+      HasLayout(false), IsRegistered(false), IsText(IsText),
+      IsVirtual(IsVirtual), Name(Name), Variant(V) {
   DummyFragment.setParent(this);
   // The initial subsection number is 0. Create a fragment list.
   CurFragList = &Subsections.emplace_back(0u, FragList{}).second;

--- a/llvm/lib/MC/MCSectionCOFF.cpp
+++ b/llvm/lib/MC/MCSectionCOFF.cpp
@@ -108,10 +108,6 @@ void MCSectionCOFF::printSwitchToSection(const MCAsmInfo &MAI, const Triple &T,
 
 bool MCSectionCOFF::useCodeAlign() const { return isText(); }
 
-bool MCSectionCOFF::isVirtualSection() const {
-  return getCharacteristics() & COFF::IMAGE_SCN_CNT_UNINITIALIZED_DATA;
-}
-
 StringRef MCSectionCOFF::getVirtualSectionKind() const {
   return "IMAGE_SCN_CNT_UNINITIALIZED_DATA";
 }

--- a/llvm/lib/MC/MCSectionELF.cpp
+++ b/llvm/lib/MC/MCSectionELF.cpp
@@ -210,8 +210,4 @@ bool MCSectionELF::useCodeAlign() const {
   return getFlags() & ELF::SHF_EXECINSTR;
 }
 
-bool MCSectionELF::isVirtualSection() const {
-  return getType() == ELF::SHT_NOBITS;
-}
-
 StringRef MCSectionELF::getVirtualSectionKind() const { return "SHT_NOBITS"; }

--- a/llvm/lib/MC/MCSectionMachO.cpp
+++ b/llvm/lib/MC/MCSectionMachO.cpp
@@ -92,8 +92,9 @@ ENTRY("" /*FIXME*/,          S_ATTR_LOC_RELOC)
 MCSectionMachO::MCSectionMachO(StringRef Segment, StringRef Section,
                                unsigned TAA, unsigned reserved2, SectionKind K,
                                MCSymbol *Begin)
-    : MCSection(SV_MachO, Section, K.isText(), Begin), TypeAndAttributes(TAA),
-      Reserved2(reserved2) {
+    : MCSection(SV_MachO, Section, K.isText(),
+                MachO::isVirtualSection(TAA & MachO::SECTION_TYPE), Begin),
+      TypeAndAttributes(TAA), Reserved2(reserved2) {
   assert(Segment.size() <= 16 && Section.size() <= 16 &&
          "Segment or section string too long");
   for (unsigned i = 0; i != 16; ++i) {
@@ -170,12 +171,6 @@ void MCSectionMachO::printSwitchToSection(const MCAsmInfo &MAI, const Triple &T,
 
 bool MCSectionMachO::useCodeAlign() const {
   return hasAttribute(MachO::S_ATTR_PURE_INSTRUCTIONS);
-}
-
-bool MCSectionMachO::isVirtualSection() const {
-  return (getType() == MachO::S_ZEROFILL ||
-          getType() == MachO::S_GB_ZEROFILL ||
-          getType() == MachO::S_THREAD_LOCAL_ZEROFILL);
 }
 
 /// ParseSectionSpecifier - Parse the section specifier indicated by "Spec".

--- a/llvm/lib/MC/MCSectionWasm.cpp
+++ b/llvm/lib/MC/MCSectionWasm.cpp
@@ -99,5 +99,3 @@ void MCSectionWasm::printSwitchToSection(const MCAsmInfo &MAI, const Triple &T,
 }
 
 bool MCSectionWasm::useCodeAlign() const { return false; }
-
-bool MCSectionWasm::isVirtualSection() const { return false; }

--- a/llvm/lib/MC/MCSectionXCOFF.cpp
+++ b/llvm/lib/MC/MCSectionXCOFF.cpp
@@ -132,14 +132,3 @@ void MCSectionXCOFF::printSwitchToSection(const MCAsmInfo &MAI, const Triple &T,
 }
 
 bool MCSectionXCOFF::useCodeAlign() const { return getKind().isText(); }
-
-bool MCSectionXCOFF::isVirtualSection() const {
-  // DWARF sections are always not virtual.
-  if (isDwarfSect())
-    return false;
-  assert(isCsect() &&
-         "Handling for isVirtualSection not implemented for this section!");
-  // XTY_CM sections are virtual except for toc-data symbols.
-  return (XCOFF::XTY_CM == CsectProp->Type) &&
-         (getMappingClass() != XCOFF::XMC_TD);
-}


### PR DESCRIPTION
This method is called once per encoded instruction, but never changes throughout the lifetime of a section. Store this information as a bit flag in the MCSection instead.