### PR TITLE
[lldb][test] Add test-cases for packed/aligned structures

### DIFF
--- a/lldb/test/API/lang/cpp/alignas_base_class/TestAlignAsBaseClass.py
+++ b/lldb/test/API/lang/cpp/alignas_base_class/TestAlignAsBaseClass.py
@@ -16,3 +16,4 @@ class TestCase(TestBase):
         # Verify specified class alignments.
         self.expect_expr("alignof(B2)", result_value="8")
         self.expect_expr("alignof(EmptyClassAlign8)", result_value="8")
+        self.expect_expr("alignof(Derived)", result_value="8")

--- a/lldb/test/API/lang/cpp/alignas_base_class/main.cpp
+++ b/lldb/test/API/lang/cpp/alignas_base_class/main.cpp
@@ -13,4 +13,11 @@ D d3g;
 struct alignas(8) EmptyClassAlign8 {
 } t;
 
+struct alignas(8) __attribute__((packed)) AlignedAndPackedBase {
+} foo;
+
+struct Derived : AlignedAndPackedBase {
+} bar;
+static_assert(alignof(Derived) == 8);
+
 int main() {}

--- a/lldb/test/Shell/SymbolFile/DWARF/no_unique_address-alignment.cpp
+++ b/lldb/test/Shell/SymbolFile/DWARF/no_unique_address-alignment.cpp
@@ -1,0 +1,25 @@
+// XFAIL: *
+
+// RUN: %clangxx_host -gdwarf -o %t %s
+// RUN: %lldb %t \
+// RUN:   -o "b main" \
+// RUN:   -o "expr alignof(OverlappingFields)" \
+// RUN:   -o "expr sizeof(OverlappingFields)" \
+// RUN:   -o exit | FileCheck %s
+
+// CHECK:      (lldb) expr alignof(OverlappingFields)
+// CHECK-NEXT: ${{.*}} = 4
+// CHECK:      (lldb) expr sizeof(OverlappingFields)
+// CHECK-NEXT: ${{.*}} = 8
+
+struct Empty {};
+
+struct OverlappingFields {
+  char y;
+  [[no_unique_address]] Empty e;
+  int z;
+} g_packed_struct;
+static_assert(alignof(OverlappingFields) == 4);
+static_assert(sizeof(OverlappingFields) == 8);
+
+int main() {}

--- a/lldb/test/Shell/SymbolFile/DWARF/no_unique_address-alignment.cpp
+++ b/lldb/test/Shell/SymbolFile/DWARF/no_unique_address-alignment.cpp
@@ -2,7 +2,6 @@
 
 // RUN: %clangxx_host -gdwarf -o %t %s
 // RUN: %lldb %t \
-// RUN:   -o "b main" \
 // RUN:   -o "expr alignof(OverlappingFields)" \
 // RUN:   -o "expr sizeof(OverlappingFields)" \
 // RUN:   -o exit | FileCheck %s
@@ -18,7 +17,7 @@ struct OverlappingFields {
   char y;
   [[no_unique_address]] Empty e;
   int z;
-} g_packed_struct;
+} g_overlapping_struct;
 static_assert(alignof(OverlappingFields) == 4);
 static_assert(sizeof(OverlappingFields) == 8);
 

--- a/lldb/test/Shell/SymbolFile/DWARF/packed.cpp
+++ b/lldb/test/Shell/SymbolFile/DWARF/packed.cpp
@@ -1,0 +1,36 @@
+// RUN: %clangxx_host -gdwarf -o %t %s
+// RUN: %lldb %t \
+// RUN:   -o "b main" \
+// RUN:   -o "expr alignof(packed)" \
+// RUN:   -o "expr sizeof(packed)" \
+// RUN:   -o "expr alignof(packed_and_aligned)" \
+// RUN:   -o "expr sizeof(packed_and_aligned)" \
+// RUN:   -o exit | FileCheck %s
+
+// CHECK:      (lldb) expr alignof(packed)
+// CHECK-NEXT: ${{.*}} = 1
+// CHECK:      (lldb) expr sizeof(packed)
+// CHECK-NEXT: ${{.*}} = 9
+
+// CHECK:      (lldb) expr alignof(packed_and_aligned)
+// CHECK-NEXT: ${{.*}} = 16
+// CHECK:      (lldb) expr sizeof(packed_and_aligned)
+// CHECK-NEXT: ${{.*}} = 16
+
+struct __attribute__((packed)) packed {
+  int x;
+  char y;
+  int z;
+} g_packed_struct;
+static_assert(alignof(packed) == 1);
+static_assert(sizeof(packed) == 9);
+
+struct __attribute__((packed, aligned(16))) packed_and_aligned {
+  int x;
+  char y;
+  int z;
+} g_packed_and_aligned_struct;
+static_assert(alignof(packed_and_aligned) == 16);
+static_assert(sizeof(packed_and_aligned) == 16);
+
+int main() {}

--- a/lldb/test/Shell/SymbolFile/DWARF/packed.cpp
+++ b/lldb/test/Shell/SymbolFile/DWARF/packed.cpp
@@ -1,6 +1,5 @@
 // RUN: %clangxx_host -gdwarf -o %t %s
 // RUN: %lldb %t \
-// RUN:   -o "b main" \
 // RUN:   -o "expr alignof(packed)" \
 // RUN:   -o "expr sizeof(packed)" \
 // RUN:   -o "expr alignof(packed_and_aligned)" \


### PR DESCRIPTION
Adds test that checks whether LLDB correctly infers the
alignment of packed structures. Specifically, the
`InferAlignment` code-path of the `ItaniumRecordLayoutBuilder`
where it assumes that overlapping field offsets imply a
packed structure and thus sets alignment to `1`. See discussion
in https://github.com/llvm/llvm-project/pull/93809.

While here, also added a test-case where we check alignment of
a class whose base has an explicit `DW_AT_alignment
(those don't get transitively propagated in DWARF, but don't seem
like a problem for LLDB).

Lastly, also added an XFAIL-ed tests where the aforementioned
`InferAlignment` kicks in for overlapping fields (but in this
case incorrectly since the structure isn't actually packed).