### PR TITLE
On AIX we don’t have .debug_addr section.

### DIFF
--- a/llvm/test/DebugInfo/attr-btf_type_tag.ll
+++ b/llvm/test/DebugInfo/attr-btf_type_tag.ll
@@ -1,4 +1,4 @@
-; XFAIL: target={{.*}}-aix{{.*}}
+; UNSUPPORTED: target={{.*}}-aix{{.*}}
 ; REQUIRES: object-emission
 ; RUN: llc -filetype=obj -o %t %s
 ; RUN: llvm-dwarfdump -debug-info %t | FileCheck %s


### PR DESCRIPTION
According to Zheng @chenzheng1030, there is no  .debug_addr section on AIX.
Due to its absence on AIX, the test case may produce inconsistent results, either passing or failing. This PR ensures that the test case is marked as not applicable for AIX.