### PR TITLE
Revert "[lldb/test] Mark TestStepScripted.py as XFAIL temporarily (#96894)"

### DIFF
--- a/lldb/test/API/functionalities/step_scripted/Steps.py
+++ b/lldb/test/API/functionalities/step_scripted/Steps.py
@@ -92,6 +92,7 @@ class StepUntil(StepWithChild):
 
     def stop_description(self, stream):
         stream.Print(f"Stepped until {self.var_name} changed.")
+        return True
 
 
 # This plan does nothing, but sets stop_mode to the

--- a/lldb/test/API/functionalities/step_scripted/TestStepScripted.py
+++ b/lldb/test/API/functionalities/step_scripted/TestStepScripted.py
@@ -7,6 +7,7 @@ import lldbsuite.test.lldbutil as lldbutil
 from lldbsuite.test.decorators import *
 from lldbsuite.test.lldbtest import *
 
+
 class StepScriptedTestCase(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
 
@@ -15,14 +16,12 @@ class StepScriptedTestCase(TestBase):
         self.main_source_file = lldb.SBFileSpec("main.c")
         self.runCmd("command script import Steps.py")
 
-    @expectedFailureAll()
     def test_standard_step_out(self):
         """Tests stepping with the scripted thread plan laying over a standard
         thread plan for stepping out."""
         self.build()
         self.step_out_with_scripted_plan("Steps.StepOut")
 
-    @expectedFailureAll()
     def test_scripted_step_out(self):
         """Tests stepping with the scripted thread plan laying over an another
         scripted thread plan for stepping out."""
@@ -63,12 +62,10 @@ class StepScriptedTestCase(TestBase):
         # Make sure we didn't let the process run:
         self.assertEqual(stop_id, process.GetStopID(), "Process didn't run")
 
-    @expectedFailureAll()
     def test_checking_variable(self):
         """Test that we can call SBValue API's from a scripted thread plan - using SBAPI's to step"""
         self.do_test_checking_variable(False)
 
-    @expectedFailureAll()
     def test_checking_variable_cli(self):
         """Test that we can call SBValue API's from a scripted thread plan - using cli to step"""
         self.do_test_checking_variable(True)


### PR DESCRIPTION
This tentatively reverts commit 204c403b5215197ecdbdb68ca7f11402d6d9892b to remove the XFAIL from the tests while also trying to fix them at the same time.