### PR TITLE
Revert "Revert "[lldb/test] Mark TestStepScripted.py as XFAIL temporarily (#96894)""

### DIFF
--- a/lldb/test/API/functionalities/step_scripted/Steps.py
+++ b/lldb/test/API/functionalities/step_scripted/Steps.py
@@ -92,7 +92,6 @@ class StepUntil(StepWithChild):
 
     def stop_description(self, stream):
         stream.Print(f"Stepped until {self.var_name} changed.")
-        return True
 
 
 # This plan does nothing, but sets stop_mode to the

--- a/lldb/test/API/functionalities/step_scripted/TestStepScripted.py
+++ b/lldb/test/API/functionalities/step_scripted/TestStepScripted.py
@@ -7,7 +7,6 @@ import lldbsuite.test.lldbutil as lldbutil
 from lldbsuite.test.decorators import *
 from lldbsuite.test.lldbtest import *
 
-
 class StepScriptedTestCase(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
 
@@ -16,12 +15,14 @@ class StepScriptedTestCase(TestBase):
         self.main_source_file = lldb.SBFileSpec("main.c")
         self.runCmd("command script import Steps.py")
 
+    @expectedFailureAll()
     def test_standard_step_out(self):
         """Tests stepping with the scripted thread plan laying over a standard
         thread plan for stepping out."""
         self.build()
         self.step_out_with_scripted_plan("Steps.StepOut")
 
+    @expectedFailureAll()
     def test_scripted_step_out(self):
         """Tests stepping with the scripted thread plan laying over an another
         scripted thread plan for stepping out."""
@@ -62,10 +63,12 @@ class StepScriptedTestCase(TestBase):
         # Make sure we didn't let the process run:
         self.assertEqual(stop_id, process.GetStopID(), "Process didn't run")
 
+    @expectedFailureAll()
     def test_checking_variable(self):
         """Test that we can call SBValue API's from a scripted thread plan - using SBAPI's to step"""
         self.do_test_checking_variable(False)
 
+    @expectedFailureAll()
     def test_checking_variable_cli(self):
         """Test that we can call SBValue API's from a scripted thread plan - using cli to step"""
         self.do_test_checking_variable(True)


### PR DESCRIPTION
Reverts llvm/llvm-project#96942 since the test failures are still happening:

https://lab.llvm.org/buildbot/#/builders/162/builds/899/