### PR TITLE
[clang][CodeGen] Remove unnecessary ShouldLinkFiles conditional

### DIFF
--- a/clang/lib/CodeGen/BackendConsumer.h
+++ b/clang/lib/CodeGen/BackendConsumer.h
@@ -112,7 +112,7 @@ public:
   void HandleVTable(CXXRecordDecl *RD) override;
 
   // Links each entry in LinkModules into our module.  Returns true on error.
-  bool LinkInModules(llvm::Module *M, bool ShouldLinkFiles = true);
+  bool LinkInModules(llvm::Module *M);
 
   /// Get the best possible source location to represent a diagnostic that
   /// may have associated debug info.

--- a/clang/lib/CodeGen/BackendUtil.cpp
+++ b/clang/lib/CodeGen/BackendUtil.cpp
@@ -1035,7 +1035,7 @@ void EmitAssemblyHelper::RunOptimizationPipeline(
 
   // Link against bitcodes supplied via the -mlink-builtin-bitcode option
   if (CodeGenOpts.LinkBitcodePostopt)
-    MPM.addPass(LinkInModulesPass(BC, false));
+    MPM.addPass(LinkInModulesPass(BC));
 
   // Add a verifier pass if requested. We don't have to do this if the action
   // requires code generation because there will already be a verifier pass in

--- a/clang/lib/CodeGen/CodeGenAction.cpp
+++ b/clang/lib/CodeGen/CodeGenAction.cpp
@@ -226,15 +226,10 @@ void BackendConsumer::HandleInterestingDecl(DeclGroupRef D) {
     HandleTopLevelDecl(D);
 }
 
-// Links each entry in LinkModules into our module.  Returns true on error.
-bool BackendConsumer::LinkInModules(llvm::Module *M, bool ShouldLinkFiles) {
+// Links each entry in LinkModules into our module. Returns true on error.
+bool BackendConsumer::LinkInModules(llvm::Module *M) {
   for (auto &LM : LinkModules) {
     assert(LM.Module && "LinkModule does not actually have a module");
-
-    // If ShouldLinkFiles is not set, skip files added via the
-    // -mlink-bitcode-files, only linking -mlink-builtin-bitcode
-    if (!LM.Internalize && !ShouldLinkFiles)
-      continue;
 
     if (LM.PropagateAttrs)
       for (Function &F : *LM.Module) {

--- a/clang/lib/CodeGen/LinkInModulesPass.cpp
+++ b/clang/lib/CodeGen/LinkInModulesPass.cpp
@@ -20,15 +20,14 @@
 
 using namespace llvm;
 
-LinkInModulesPass::LinkInModulesPass(clang::BackendConsumer *BC,
-                                     bool ShouldLinkFiles)
-    : BC(BC), ShouldLinkFiles(ShouldLinkFiles) {}
+LinkInModulesPass::LinkInModulesPass(clang::BackendConsumer *BC) : BC(BC),
+  ShouldLinkFiles(ShouldLinkFiles) {}
 
 PreservedAnalyses LinkInModulesPass::run(Module &M, ModuleAnalysisManager &AM) {
   if (!BC)
     return PreservedAnalyses::all();
 
-  if (BC->LinkInModules(&M, ShouldLinkFiles))
+  if (BC->LinkInModules(&M))
     report_fatal_error("Bitcode module postopt linking failed, aborted!");
 
   return PreservedAnalyses::none();

--- a/clang/lib/CodeGen/LinkInModulesPass.h
+++ b/clang/lib/CodeGen/LinkInModulesPass.h
@@ -31,7 +31,7 @@ class LinkInModulesPass : public PassInfoMixin<LinkInModulesPass> {
   bool ShouldLinkFiles;
 
 public:
-  LinkInModulesPass(clang::BackendConsumer *BC, bool ShouldLinkFiles = true);
+  LinkInModulesPass(clang::BackendConsumer *BC);
 
   PreservedAnalyses run(Module &M, AnalysisManager<Module> &);
   static bool isRequired() { return true; }


### PR DESCRIPTION
We have reworked the bitcode linking option to no longer link twice if post-optimization linking is requested. As such, we no longer need to conditionally link bitcodes supplied via -mlink-bitcode-file, as there is no danger of linking them twice