### PR TITLE
Branch folding: Avoid infinite loop with indirect target blocks

### DIFF
--- a/llvm/test/CodeGen/X86/branchfolding-no-inf-loop-with-callbr-indirect-blocks.ll
+++ b/llvm/test/CodeGen/X86/branchfolding-no-inf-loop-with-callbr-indirect-blocks.ll
@@ -1,0 +1,18 @@
+; RUN: llc -mtriple x86_64 %s -stop-after=branch-folder
+
+; Check branch-folder do not keep swapping %indirect.target.block.1 and
+; %indirect.target.block.2
+define void @no_inf_loop() {
+entry:
+  br label %bb1
+
+bb1:
+  callbr void asm "", "!i,!i"() to label %bb1
+    [label %indirect.target.block.1, label %indirect.target.block.2]
+
+indirect.target.block.1:
+  br label %bb1
+
+indirect.target.block.2:
+  br label %bb1
+}


### PR DESCRIPTION
Fixes #96893.

Tasks remaining:

- [x] Add in the comment about EHPad it's also necessary for indirect targets.
- [x] Add a sanity test with a timeout (I could not set a timeout duration for a specific test only so I add the test file).

also the test was only added for `x86`, tell me if you think it's not enough.

FYI, I wrote another PR https://github.com/llvm/llvm-project/pull/104240 to solve the same issue that doesn't use check explicitly for FallThrough not being a Indirect Target block. Feel free to indicate which PR is best. 