### PR TITLE
llvm_gtest: Only install once

### DIFF
--- a/third-party/unittest/CMakeLists.txt
+++ b/third-party/unittest/CMakeLists.txt
@@ -85,8 +85,6 @@ target_include_directories(llvm_gtest
 add_subdirectory(UnitTestMain)
 
 if (LLVM_INSTALL_GTEST)
-  install(TARGETS llvm_gtest llvm_gtest_main LLVMTestingSupport LLVMTestingAnnotations
-	  ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}" COMPONENT llvm_gtest)
   install(DIRECTORY googletest/include/gtest/ DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/llvm-gtest/gtest/" COMPONENT llvm_gtest)
   install(DIRECTORY googlemock/include/gmock/ DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/llvm-gmock/gmock/" COMPONENT llvm_gtest)
 endif()


### PR DESCRIPTION
llvm_gtest and its dependencies were being installed twice (and into two different locations depending on the cmake options).