### PR TITLE
Extend -Wnonportable-include-path with a warning about trailing whitespace or dots

### DIFF
--- a/clang/include/clang/Basic/DiagnosticGroups.td
+++ b/clang/include/clang/Basic/DiagnosticGroups.td
@@ -1543,3 +1543,6 @@ def ExtractAPIMisuse : DiagGroup<"extractapi-misuse">;
 // Warnings about using the non-standard extension having an explicit specialization
 // with a storage class specifier.
 def ExplicitSpecializationStorageClass : DiagGroup<"explicit-specialization-storage-class">;
+
+// Warnings about non-portable include paths
+def NonportablePath : DiagGroup<"nonportable-include-path">;

--- a/clang/include/clang/Basic/DiagnosticLexKinds.td
+++ b/clang/include/clang/Basic/DiagnosticLexKinds.td
@@ -361,7 +361,11 @@ class NonportablePath  : Warning<
   "non-portable path to file '%0'; specified path differs in case from file"
   " name on disk">;
 def pp_nonportable_path : NonportablePath,
-  InGroup<DiagGroup<"nonportable-include-path">>;
+  InGroup<NonportablePath>;
+def pp_nonportable_path_trailing_whitespace : Warning<
+  "non-portable path to file '%0'; specified path contains trailing"
+  "whitespace or dots">,
+  InGroup<NonportablePath>;
 def pp_nonportable_system_path : NonportablePath, DefaultIgnore,
   InGroup<DiagGroup<"nonportable-system-include-path">>;
 

--- a/clang/lib/Lex/PPDirectives.cpp
+++ b/clang/lib/Lex/PPDirectives.cpp
@@ -2098,6 +2098,23 @@ OptionalFileEntryRef Preprocessor::LookupHeaderIncludeOrImport(
     const FileEntry *LookupFromFile, StringRef &LookupFilename,
     SmallVectorImpl<char> &RelativePath, SmallVectorImpl<char> &SearchPath,
     ModuleMap::KnownHeader &SuggestedModule, bool isAngled) {
+
+  // Check for trailing whitespace or dots in the include path.
+  // This must be done before looking up the file, as Windows will still
+  // find the file even if there are trailing dots or whitespace.
+  size_t TrailingPos = Filename.find_last_not_of(" .");
+  if (TrailingPos != StringRef::npos && TrailingPos < Filename.size() - 1) {
+    StringRef TrimmedFilename = Filename.rtrim(" .");
+
+    auto Hint = isAngled
+                    ? FixItHint::CreateReplacement(
+                          FilenameRange, "<" + TrimmedFilename.str() + ">")
+                    : FixItHint::CreateReplacement(
+                          FilenameRange, "\"" + TrimmedFilename.str() + "\"");
+    Diag(FilenameTok, diag::pp_nonportable_path_trailing_whitespace)
+        << Filename << TrimmedFilename << Hint;
+  }
+
   auto DiagnoseHeaderInclusion = [&](FileEntryRef FE) {
     if (LangOpts.AsmPreprocessor)
       return;

--- a/clang/test/Preprocessor/nonportable-include-trailing-whitespace.c
+++ b/clang/test/Preprocessor/nonportable-include-trailing-whitespace.c
@@ -1,0 +1,11 @@
+// REQUIRES: case-insensitive-filesystem
+// RUN: %clang_cc1 -Wall %s
+
+#include "empty_file_to_include.h " // expected-warning {{non-portable path}}
+#include "empty_file_to_include.h." // expected-warning {{non-portable path}}
+#include "empty_file_to_include.h       " // expected-warning {{non-portable path}}
+#include "empty_file_to_include.h......." // expected-warning {{non-portable path}}
+#include "empty_file_to_include.h . . . " // expected-warning {{non-portable path}}
+#include "empty_file_to_include.h.. .. " // expected-warning {{non-portable path}}
+
+#include "empty_file_to_include.h" // No warning


### PR DESCRIPTION
Resolves #96064

Extends `-Wnonportable-include-path` with a warning about trailing whitespace or dots in include paths. 

![Screenshot from 2024-06-27 22-10-26](https://github.com/llvm/llvm-project/assets/56530704/9dbb7ddb-3f0e-4f8d-9eaf-dbb773baca27)
