### PR TITLE
[MLGO] Remove python-38 flag from tests

### DIFF
--- a/llvm/utils/mlgo-utils/tests/corpus/combine_training_corpus_script.test
+++ b/llvm/utils/mlgo-utils/tests/corpus/combine_training_corpus_script.test
@@ -1,4 +1,4 @@
-# REQUIRES: python-38, system-linux
+# REQUIRES: system-linux
 
 ## Testing that the combine_trainig_corpus script works as expected when
 ## invoked.

--- a/llvm/utils/mlgo-utils/tests/corpus/combine_training_corpus_test.py
+++ b/llvm/utils/mlgo-utils/tests/corpus/combine_training_corpus_test.py
@@ -1,4 +1,4 @@
-# REQUIRES: python-38, system-linux
+# REQUIRES: system-linux
 
 ## Test the functionality of combine_training_corpus_lib
 

--- a/llvm/utils/mlgo-utils/tests/corpus/extract_ir_script.test
+++ b/llvm/utils/mlgo-utils/tests/corpus/extract_ir_script.test
@@ -1,4 +1,4 @@
-# REQUIRES: python-38, system-linux
+# REQUIRES: system-linux
 
 ## Test that invoking the extract_ir script work as expected.
 

--- a/llvm/utils/mlgo-utils/tests/corpus/extract_ir_test.py
+++ b/llvm/utils/mlgo-utils/tests/corpus/extract_ir_test.py
@@ -1,4 +1,4 @@
-# REQUIRES: python-38, system-linux
+# REQUIRES: system-linux
 
 ## Test the functionality of extract_ir_lib
 

--- a/llvm/utils/mlgo-utils/tests/corpus/make_corpus_script.test
+++ b/llvm/utils/mlgo-utils/tests/corpus/make_corpus_script.test
@@ -1,4 +1,4 @@
-# REQUIRES: python-38, system-linux
+# REQUIRES: system-linux
 
 ## Testing that the make_corpus script works as expected when invoked.
 

--- a/llvm/utils/mlgo-utils/tests/corpus/make_corpus_test.py
+++ b/llvm/utils/mlgo-utils/tests/corpus/make_corpus_test.py
@@ -1,4 +1,4 @@
-# REQUIRES: python-38, system-linux
+# REQUIRES: system-linux
 
 ## Test the functionality of make_corpus_lib
 

--- a/llvm/utils/mlgo-utils/tests/lit.local.cfg
+++ b/llvm/utils/mlgo-utils/tests/lit.local.cfg
@@ -1,10 +1,5 @@
 import sys
 
-# TODO(boomanaiden154): Remove this flag once the minimum Python version for
-# the entire project has been bumped to 3.8.
-if sys.version_info > (3,8):
-    config.available_features.add("python-38")
-
 # TODO(boomanaiden154): Remove this flag once we enable type checking in the
 # precommit CI.
 try:


### PR DESCRIPTION
Previously, we had a python-38 flag for the mlgo-utils tests as they needed a python version higher than what LLVM required by default due to type annotations. Now that LLVM's default Python version minimum is 3.8, we can remove this flag.