### PR TITLE
[mlir] Fix -Wextra-semi warnings in generated code (NFC)

### DIFF
--- a/mlir/tools/mlir-tblgen/RewriterGen.cpp
+++ b/mlir/tools/mlir-tblgen/RewriterGen.cpp
@@ -1117,7 +1117,7 @@ void PatternEmitter::emit(StringRef rewriteName) {
 
       os << "return ::mlir::success();\n";
     }
-    os << "};\n";
+    os << "}\n";
   }
   os << "};\n\n";
 }


### PR DESCRIPTION
While building a downstream project including `mlir-tblgen`-generated headers, I received some `-Wextra-semi` warnings.  Fix these in the generated code by removing the extra semicolon in the generator.