### PR TITLE
[clang] [TargetCXXABI] Fix -Wextra-semi warning (NFC)

### DIFF
--- a/clang/include/clang/Basic/TargetCXXABI.h
+++ b/clang/include/clang/Basic/TargetCXXABI.h
@@ -116,7 +116,7 @@ public:
       return T.isKnownWindowsMSVCEnvironment();
     }
     llvm_unreachable("invalid CXXABI kind");
-  };
+  }
 
   /// Does this ABI generally fall into the Itanium family of ABIs?
   bool isItaniumFamily() const {


### PR DESCRIPTION
While building a downstream project including `TargetCXXABI.h`, I received a `-Wextra-semi` warning.  This PR removes the extra semicolon, fixing the warning.