### PR TITLE
[flang][preprocessor] Expand some keyword macros in quoted character …

### DIFF
--- a/flang/test/Preprocessing/kw-in-char.F90
+++ b/flang/test/Preprocessing/kw-in-char.F90
@@ -1,0 +1,14 @@
+! RUN: %flang -E %s 2>&1 | FileCheck %s
+! CHECK: subroutine test_b_wrapper_c() bind(C, name="test_b_c_f")
+#define TEMP_LETTER b
+#define VAL c
+subroutine test_&
+TEMP_LETTER&
+_wrapper_&
+VAL&
+ () bind(C, name="test_&
+    &TEMP_LETTER&
+    &_&
+    &VAL&
+    &_f")
+end


### PR DESCRIPTION
…literals

To help port codes from compilers using pre-ANSI C preprocessors, which didn't care much about context when replacing macros, support the replacement of keyword macros in quoted character literals when (and only when) the name of the keyword macro constitutes the entire significant portion of a free form continuation line.  See the new test case for a motivating example.

Fixes https://github.com/llvm/llvm-project/issues/96781.