### PR TITLE
[llvm] Avoid 'raw_string_ostream::str()' (NFC)

### DIFF
--- a/llvm/include/llvm/ADT/FloatingPointMode.h
+++ b/llvm/include/llvm/ADT/FloatingPointMode.h
@@ -176,7 +176,7 @@ struct DenormalMode {
     std::string storage;
     raw_string_ostream OS(storage);
     print(OS);
-    return OS.str();
+    return storage;
   }
 };
 

--- a/llvm/include/llvm/Analysis/CFGPrinter.h
+++ b/llvm/include/llvm/Analysis/CFGPrinter.h
@@ -133,7 +133,7 @@ std::string SimpleNodeLabelString(const BasicBlockT *Node) {
   raw_string_ostream OS(Str);
 
   Node->printAsOperand(OS, false);
-  return OS.str();
+  return Str;
 }
 
 template <typename BasicBlockT>
@@ -148,7 +148,7 @@ std::string CompleteNodeLabelString(
   std::string Str;
   raw_string_ostream OS(Str);
   HandleBasicBlock(OS, *Node);
-  std::string OutStr = OS.str();
+  std::string OutStr(Str);
   // Remove "%" from BB name
   if (OutStr[0] == '%') {
     OutStr.erase(OutStr.begin());
@@ -247,7 +247,7 @@ struct DOTGraphTraits<DOTFuncInfo *> : public DefaultDOTGraphTraits {
       raw_string_ostream OS(Str);
       auto Case = *SwitchInst::ConstCaseIt::fromSuccessorIndex(SI, SuccNo);
       OS << Case.getCaseValue()->getValue();
-      return OS.str();
+      return Str;
     }
     return "";
   }
@@ -257,7 +257,6 @@ struct DOTGraphTraits<DOTFuncInfo *> : public DefaultDOTGraphTraits {
     if (NodeName.empty()) {
       raw_string_ostream NodeOS(NodeName);
       Node->printAsOperand(NodeOS, false);
-      NodeName = NodeOS.str();
       // Removing %
       NodeName.erase(NodeName.begin());
     }

--- a/llvm/include/llvm/Analysis/CFGPrinter.h
+++ b/llvm/include/llvm/Analysis/CFGPrinter.h
@@ -145,10 +145,9 @@ std::string CompleteNodeLabelString(
         HandleComment) {
 
   enum { MaxColumns = 80 };
-  std::string Str;
-  raw_string_ostream OS(Str);
+  std::string OutStr;
+  raw_string_ostream OS(OutStr);
   HandleBasicBlock(OS, *Node);
-  std::string OutStr(Str);
   // Remove "%" from BB name
   if (OutStr[0] == '%') {
     OutStr.erase(OutStr.begin());

--- a/llvm/include/llvm/Analysis/DDG.h
+++ b/llvm/include/llvm/Analysis/DDG.h
@@ -467,16 +467,16 @@ DependenceGraphInfo<NodeType>::getDependenceString(const NodeType &Src,
   raw_string_ostream OS(Str);
   DependenceList Deps;
   if (!getDependencies(Src, Dst, Deps))
-    return OS.str();
+    return Str;
   interleaveComma(Deps, OS, [&](const std::unique_ptr<Dependence> &D) {
     D->dump(OS);
     // Remove the extra new-line character printed by the dump
     // method
-    if (OS.str().back() == '\n')
-      OS.str().pop_back();
+    if (Str.back() == '\n')
+      Str.pop_back();
   });
 
-  return OS.str();
+  return Str;
 }
 
 //===--------------------------------------------------------------------===//

--- a/llvm/include/llvm/DebugInfo/LogicalView/Core/LVSupport.h
+++ b/llvm/include/llvm/DebugInfo/LogicalView/Core/LVSupport.h
@@ -110,7 +110,7 @@ inline std::string hexString(uint64_t Value, size_t Width = HEX_WIDTH) {
   std::string String;
   raw_string_ostream Stream(String);
   Stream << hexValue(Value, Width, false);
-  return Stream.str();
+  return String;
 }
 
 // Get a hexadecimal string representation for the given value.

--- a/llvm/include/llvm/IR/ModuleSummaryIndex.h
+++ b/llvm/include/llvm/IR/ModuleSummaryIndex.h
@@ -793,7 +793,7 @@ public:
       OS << ", hasUnknownCall: " << this->HasUnknownCall;
       OS << ", mustBeUnreachable: " << this->MustBeUnreachable;
       OS << ")";
-      return OS.str();
+      return Output;
     }
   };
 

--- a/llvm/include/llvm/Object/MachO.h
+++ b/llvm/include/llvm/Object/MachO.h
@@ -799,7 +799,7 @@ public:
       std::string ret;
       raw_string_ostream ss(ret);
       ss << format_hex(platform, 8, true);
-      return ss.str();
+      return ret;
     }
   }
 
@@ -814,7 +814,7 @@ public:
       std::string ret;
       raw_string_ostream ss(ret);
       ss << format_hex(tools, 8, true);
-      return ss.str();
+      return ret;
     }
   }
 


### PR DESCRIPTION
Since `raw_string_ostream` doesn't own the string buffer, it is desirable (in terms of memory safety) for users to directly reference the string buffer rather than use `raw_string_ostream::str()`.

Work towards TODO comment to remove `raw_string_ostream::str()`.