### PR TITLE
[llvm-objcopy][ELF] Disable huge section offset

### DIFF
--- a/llvm/docs/CommandGuide/llvm-objcopy.rst
+++ b/llvm/docs/CommandGuide/llvm-objcopy.rst
@@ -350,11 +350,6 @@ them.
 
  Extract the named partition from the output.
 
-.. option:: --set-max-section-offset <value>
-
- Emit an error if input section has a file offset greater than the specified
- ``<value>``.
-
 .. option:: --gap-fill <value>
 
  For binary outputs, fill the gaps between sections with ``<value>`` instead
@@ -427,6 +422,11 @@ them.
  represents a single symbol, with leading and trailing whitespace ignored, as is
  anything following a '#'. Can be specified multiple times to read names from
  multiple files.
+
+.. option:: --max-section-offset <value>
+
+ Emit an error if input section has a file offset greater than the specified
+ ``<value>``.
 
 .. option:: --new-symbol-visibility <visibility>
 

--- a/llvm/docs/CommandGuide/llvm-objcopy.rst
+++ b/llvm/docs/CommandGuide/llvm-objcopy.rst
@@ -350,6 +350,11 @@ them.
 
  Extract the named partition from the output.
 
+.. option:: --set-max-section-offset <value>
+
+ Emit an error if input section has a file offset greater than the specified
+ ``<value>``.
+
 .. option:: --gap-fill <value>
 
  For binary outputs, fill the gaps between sections with ``<value>`` instead

--- a/llvm/include/llvm/ObjCopy/ELF/ELFConfig.h
+++ b/llvm/include/llvm/ObjCopy/ELF/ELFConfig.h
@@ -31,6 +31,7 @@ struct ELFConfig {
   bool KeepFileSymbols = false;
   bool LocalizeHidden = false;
   bool VerifyNoteSections = true;
+  std::optional<uint64_t> MaxSectionOffset;
 };
 
 } // namespace objcopy

--- a/llvm/lib/ObjCopy/ELF/ELFObjcopy.cpp
+++ b/llvm/lib/ObjCopy/ELF/ELFObjcopy.cpp
@@ -176,11 +176,12 @@ static std::unique_ptr<Writer> createELFWriter(const CommonConfig &Config,
 }
 
 static std::unique_ptr<Writer> createWriter(const CommonConfig &Config,
+                                            const ELFConfig &ELFConfig,
                                             Object &Obj, raw_ostream &Out,
                                             ElfType OutputElfType) {
   switch (Config.OutputFormat) {
   case FileFormat::Binary:
-    return std::make_unique<BinaryWriter>(Obj, Out, Config);
+    return std::make_unique<BinaryWriter>(Obj, Out, Config, ELFConfig);
   case FileFormat::IHex:
     return std::make_unique<IHexWriter>(Obj, Out, Config.OutputFilename);
   case FileFormat::SREC:
@@ -926,10 +927,10 @@ static Error handleArgs(const CommonConfig &Config, const ELFConfig &ELFConfig,
   return Error::success();
 }
 
-static Error writeOutput(const CommonConfig &Config, Object &Obj,
-                         raw_ostream &Out, ElfType OutputElfType) {
+static Error writeOutput(const CommonConfig &Config, const ELFConfig &ELFConfig,
+                         Object &Obj, raw_ostream &Out, ElfType OutputElfType) {
   std::unique_ptr<Writer> Writer =
-      createWriter(Config, Obj, Out, OutputElfType);
+      createWriter(Config, ELFConfig, Obj, Out, OutputElfType);
   if (Error E = Writer->finalize())
     return E;
   return Writer->write();
@@ -947,7 +948,7 @@ Error objcopy::elf::executeObjcopyOnIHex(const CommonConfig &Config,
       getOutputElfType(Config.OutputArch.value_or(MachineInfo()));
   if (Error E = handleArgs(Config, ELFConfig, OutputElfType, **Obj))
     return E;
-  return writeOutput(Config, **Obj, Out, OutputElfType);
+  return writeOutput(Config, ELFConfig, **Obj, Out, OutputElfType);
 }
 
 Error objcopy::elf::executeObjcopyOnRawBinary(const CommonConfig &Config,
@@ -965,7 +966,7 @@ Error objcopy::elf::executeObjcopyOnRawBinary(const CommonConfig &Config,
       getOutputElfType(Config.OutputArch.value_or(MachineInfo()));
   if (Error E = handleArgs(Config, ELFConfig, OutputElfType, **Obj))
     return E;
-  return writeOutput(Config, **Obj, Out, OutputElfType);
+  return writeOutput(Config, ELFConfig, **Obj, Out, OutputElfType);
 }
 
 Error objcopy::elf::executeObjcopyOnBinary(const CommonConfig &Config,
@@ -985,7 +986,7 @@ Error objcopy::elf::executeObjcopyOnBinary(const CommonConfig &Config,
   if (Error E = handleArgs(Config, ELFConfig, OutputElfType, **Obj))
     return createFileError(Config.InputFilename, std::move(E));
 
-  if (Error E = writeOutput(Config, **Obj, Out, OutputElfType))
+  if (Error E = writeOutput(Config, ELFConfig, **Obj, Out, OutputElfType))
     return createFileError(Config.InputFilename, std::move(E));
 
   return Error::success();

--- a/llvm/lib/ObjCopy/ELF/ELFObject.cpp
+++ b/llvm/lib/ObjCopy/ELF/ELFObject.cpp
@@ -2751,7 +2751,7 @@ Error BinaryWriter::finalize() {
             "writing section " + Sec.Name + " at offset 0x" +
                 Twine::utohexstr(Sec.Offset) + " greater than max offset 0x" +
                 Twine::utohexstr(*MaxSectionOffset) +
-                " specified by --set-max-section-offset");
+                " specified by --max-section-offset");
       }
     }
 

--- a/llvm/lib/ObjCopy/ELF/ELFObject.cpp
+++ b/llvm/lib/ObjCopy/ELF/ELFObject.cpp
@@ -2744,6 +2744,15 @@ Error BinaryWriter::finalize() {
     if (Sec.Type != SHT_NOBITS && Sec.Size > 0) {
       Sec.Offset = Sec.Addr - MinAddr;
       TotalSize = std::max(TotalSize, Sec.Offset + Sec.Size);
+
+      if (MaxSectionOffset && Sec.Offset > *MaxSectionOffset) {
+        return createStringError(
+            errc::file_too_large,
+            "writing section " + Sec.Name + " at offset 0x" +
+                Twine::utohexstr(Sec.Offset) + " greater than max offset 0x" +
+                Twine::utohexstr(*MaxSectionOffset) +
+                " specified by --set-max-section-offset");
+      }
     }
 
   Buf = WritableMemoryBuffer::getNewMemBuffer(TotalSize);

--- a/llvm/lib/ObjCopy/ELF/ELFObject.h
+++ b/llvm/lib/ObjCopy/ELF/ELFObject.h
@@ -15,6 +15,7 @@
 #include "llvm/BinaryFormat/ELF.h"
 #include "llvm/MC/StringTableBuilder.h"
 #include "llvm/ObjCopy/CommonConfig.h"
+#include "llvm/ObjCopy/ELF/ELFConfig.h"
 #include "llvm/Object/ELFObjectFile.h"
 #include "llvm/Support/Errc.h"
 #include "llvm/Support/FileOutputBuffer.h"
@@ -366,12 +367,16 @@ private:
 
   uint64_t TotalSize = 0;
 
+  std::optional<uint64_t> MaxSectionOffset;
+
 public:
   ~BinaryWriter() {}
   Error finalize() override;
   Error write() override;
-  BinaryWriter(Object &Obj, raw_ostream &Out, const CommonConfig &Config)
-      : Writer(Obj, Out), GapFill(Config.GapFill), PadTo(Config.PadTo) {}
+  BinaryWriter(Object &Obj, raw_ostream &Out, const CommonConfig &Config,
+               const ELFConfig &ELFConfig)
+      : Writer(Obj, Out), GapFill(Config.GapFill), PadTo(Config.PadTo),
+        MaxSectionOffset(ELFConfig.MaxSectionOffset) {}
 };
 
 // A base class for writing ascii hex formats such as srec and ihex.

--- a/llvm/test/tools/llvm-objcopy/ELF/max-section-offset.yaml
+++ b/llvm/test/tools/llvm-objcopy/ELF/max-section-offset.yaml
@@ -2,7 +2,7 @@
 # RUN: not llvm-objcopy -O binary %t %t2 --max-section-offset=15 2>&1 | FileCheck -DFILE=%t %s --check-prefix=INVALID-COPY
 # RUN: llvm-objcopy -O binary %t %t2 --max-section-offset=16
 
-# INVALID-COPY: error: '[[FILE]]': writing section .high_addr at offset 0x10 greater than max offset 0xf specified by --set-max-section-offset
+# INVALID-COPY: error: '[[FILE]]': writing section .high_addr at offset 0x10 greater than max offset 0xf specified by --max-section-offset
 
 --- !ELF
 FileHeader:

--- a/llvm/test/tools/llvm-objcopy/ELF/max-section-offset.yaml
+++ b/llvm/test/tools/llvm-objcopy/ELF/max-section-offset.yaml
@@ -1,6 +1,6 @@
 # RUN: yaml2obj %s --docnum=1 -o %t
-# RUN: not llvm-objcopy -O binary %t %t2 --set-max-section-offset=15 2>&1 | FileCheck -DFILE=%t %s --check-prefix=INVALID-COPY
-# RUN: llvm-objcopy -O binary %t %t2 --set-max-section-offset=16
+# RUN: not llvm-objcopy -O binary %t %t2 --max-section-offset=15 2>&1 | FileCheck -DFILE=%t %s --check-prefix=INVALID-COPY
+# RUN: llvm-objcopy -O binary %t %t2 --max-section-offset=16
 
 # INVALID-COPY: error: '[[FILE]]': writing section .high_addr at offset 0x10 greater than max offset 0xf specified by --set-max-section-offset
 

--- a/llvm/test/tools/llvm-objcopy/ELF/set-max-section-offset.yaml
+++ b/llvm/test/tools/llvm-objcopy/ELF/set-max-section-offset.yaml
@@ -1,0 +1,23 @@
+# RUN: yaml2obj %s --docnum=1 -o %t
+# RUN: not llvm-objcopy -O binary %t %t2 --set-max-section-offset=15 2>&1 | FileCheck -DFILE=%t %s --check-prefix=INVALID-COPY
+# RUN: llvm-objcopy -O binary %t %t2 --set-max-section-offset=16
+
+# INVALID-COPY: error: '[[FILE]]': writing section .high_addr at offset 0x10 greater than max offset 0xf specified by --set-max-section-offset
+
+--- !ELF
+FileHeader:
+  Class:           ELFCLASS64
+  Data:            ELFDATA2LSB
+  Type:            ET_EXEC
+  Machine:         EM_X86_64
+Sections:
+  - Name:            .text
+    Type:            SHT_PROGBITS
+    Flags:           [ SHF_ALLOC ]
+    Address:         0x0
+    Content:         "10"
+  - Name:            .high_addr
+    Type:            SHT_PROGBITS
+    Flags:           [ SHF_ALLOC ]
+    Address:         0x10
+    Content:         "10"

--- a/llvm/tools/llvm-objcopy/ObjcopyOptions.cpp
+++ b/llvm/tools/llvm-objcopy/ObjcopyOptions.cpp
@@ -1055,9 +1055,8 @@ objcopy::parseObjcopyOptions(ArrayRef<const char *> RawArgsArr,
       InputArgs.hasArg(OBJCOPY_extract_main_partition);
   ELFConfig.LocalizeHidden = InputArgs.hasArg(OBJCOPY_localize_hidden);
 
-  if (auto *Arg = InputArgs.getLastArg(OBJCOPY_set_max_section_offset)) {
+  if (auto *Arg = InputArgs.getLastArg(OBJCOPY_max_section_offset))
     ELFConfig.MaxSectionOffset = std::stoull(Arg->getValue());
-  }
 
   Config.Weaken = InputArgs.hasArg(OBJCOPY_weaken);
   if (auto *Arg =

--- a/llvm/tools/llvm-objcopy/ObjcopyOptions.cpp
+++ b/llvm/tools/llvm-objcopy/ObjcopyOptions.cpp
@@ -1054,6 +1054,11 @@ objcopy::parseObjcopyOptions(ArrayRef<const char *> RawArgsArr,
   Config.ExtractMainPartition =
       InputArgs.hasArg(OBJCOPY_extract_main_partition);
   ELFConfig.LocalizeHidden = InputArgs.hasArg(OBJCOPY_localize_hidden);
+
+  if (auto *Arg = InputArgs.getLastArg(OBJCOPY_set_max_section_offset)) {
+    ELFConfig.MaxSectionOffset = std::stoull(Arg->getValue());
+  }
+
   Config.Weaken = InputArgs.hasArg(OBJCOPY_weaken);
   if (auto *Arg =
           InputArgs.getLastArg(OBJCOPY_discard_all, OBJCOPY_discard_locals)) {

--- a/llvm/tools/llvm-objcopy/ObjcopyOpts.td
+++ b/llvm/tools/llvm-objcopy/ObjcopyOpts.td
@@ -146,8 +146,8 @@ def extract_main_partition
     : Flag<["--"], "extract-main-partition">,
       HelpText<"Extract main partition from the input file">;
 
-defm set_max_section_offset
-    : Eq<"set-max-section-offset",
+defm max_section_offset
+    : Eq<"max-section-offset",
          "Emit an error if input section has a file offset greater than the "
          "specified `offset`">,
       MetaVarName<"offset">;

--- a/llvm/tools/llvm-objcopy/ObjcopyOpts.td
+++ b/llvm/tools/llvm-objcopy/ObjcopyOpts.td
@@ -146,6 +146,12 @@ def extract_main_partition
     : Flag<["--"], "extract-main-partition">,
       HelpText<"Extract main partition from the input file">;
 
+defm set_max_section_offset
+    : Eq<"set-max-section-offset",
+         "Emit an error if input section has a file offset greater than the "
+         "specified `offset`">,
+      MetaVarName<"offset">;
+
 def localize_hidden
     : Flag<["--"], "localize-hidden">,
       HelpText<


### PR DESCRIPTION
By default, GNU objcopy issues a warning for large offsets in ELF
files. To align with this behavior, we introduce an option to
define a maximum file offset for a section. This allows us to skip
creating excessively large files by specifying a threshold beyond
which the file offset will trigger an error.

It addresses the problem described in [0].

[0] https://github.com/llvm/llvm-project/issues/88878
