### PR TITLE
[InstSimplify] Add simplification for `({u,s}rem (mul {nuw,nsw} X, C1), C0)`

### DIFF
--- a/llvm/test/Transforms/InstSimplify/rem.ll
+++ b/llvm/test/Transforms/InstSimplify/rem.ll
@@ -265,7 +265,7 @@ define i32 @rem4() {
 ; CHECK-NEXT:    [[CALL:%.*]] = call i32 @external(), !range [[RNG0:![0-9]+]]
 ; CHECK-NEXT:    ret i32 [[CALL]]
 ;
-  %call = call i32 @external(), !range !0
+  %call = call i32 @external() , !range !0
   %urem = urem i32 %call, 3
   ret i32 %urem
 }
@@ -487,4 +487,59 @@ define i8 @urem_mul_sdiv(i8 %x, i8 %y) {
   %mul = mul i8 %y, %d
   %mod = urem i8 %mul, %y
   ret i8 %mod
+}
+
+define <2 x i8> @simplfy_srem_of_mul(<2 x i8> %x) {
+; CHECK-LABEL: @simplfy_srem_of_mul(
+; CHECK-NEXT:    [[MUL:%.*]] = mul nsw <2 x i8> [[X:%.*]], <i8 20, i8 10>
+; CHECK-NEXT:    [[R:%.*]] = srem <2 x i8> [[MUL]], <i8 5, i8 5>
+; CHECK-NEXT:    ret <2 x i8> [[R]]
+;
+  %mul = mul nsw <2 x i8> %x, <i8 20, i8 10>
+  %r = srem <2 x i8> %mul, <i8 5, i8 5>
+  ret <2 x i8> %r
+}
+
+define <2 x i8> @simplfy_srem_of_mul_fail_bad_mod(<2 x i8> %x) {
+; CHECK-LABEL: @simplfy_srem_of_mul_fail_bad_mod(
+; CHECK-NEXT:    [[MUL:%.*]] = mul nsw <2 x i8> [[X:%.*]], <i8 20, i8 11>
+; CHECK-NEXT:    [[R:%.*]] = srem <2 x i8> [[MUL]], <i8 5, i8 5>
+; CHECK-NEXT:    ret <2 x i8> [[R]]
+;
+  %mul = mul nsw <2 x i8> %x, <i8 20, i8 11>
+  %r = srem <2 x i8> %mul, <i8 5, i8 5>
+  ret <2 x i8> %r
+}
+
+define i8 @simplfy_urem_of_mul(i8 %x) {
+; CHECK-LABEL: @simplfy_urem_of_mul(
+; CHECK-NEXT:    [[MUL:%.*]] = mul nuw i8 [[X:%.*]], 30
+; CHECK-NEXT:    [[R:%.*]] = urem i8 [[MUL]], 10
+; CHECK-NEXT:    ret i8 [[R]]
+;
+  %mul = mul nuw i8 %x, 30
+  %r = urem i8 %mul, 10
+  ret i8 %r
+}
+
+define i8 @simplfy_urem_of_mul_fail_bad_flag(i8 %x) {
+; CHECK-LABEL: @simplfy_urem_of_mul_fail_bad_flag(
+; CHECK-NEXT:    [[MUL:%.*]] = mul nsw i8 [[X:%.*]], 30
+; CHECK-NEXT:    [[R:%.*]] = urem i8 [[MUL]], 10
+; CHECK-NEXT:    ret i8 [[R]]
+;
+  %mul = mul nsw i8 %x, 30
+  %r = urem i8 %mul, 10
+  ret i8 %r
+}
+
+define i8 @simplfy_urem_of_mul_fail_bad_mod(i8 %x) {
+; CHECK-LABEL: @simplfy_urem_of_mul_fail_bad_mod(
+; CHECK-NEXT:    [[MUL:%.*]] = mul nuw i8 [[X:%.*]], 31
+; CHECK-NEXT:    [[R:%.*]] = urem i8 [[MUL]], 10
+; CHECK-NEXT:    ret i8 [[R]]
+;
+  %mul = mul nuw i8 %x, 31
+  %r = urem i8 %mul, 10
+  ret i8 %r
 }

--- a/llvm/test/Transforms/InstSimplify/rem.ll
+++ b/llvm/test/Transforms/InstSimplify/rem.ll
@@ -491,9 +491,7 @@ define i8 @urem_mul_sdiv(i8 %x, i8 %y) {
 
 define <2 x i8> @simplfy_srem_of_mul(<2 x i8> %x) {
 ; CHECK-LABEL: @simplfy_srem_of_mul(
-; CHECK-NEXT:    [[MUL:%.*]] = mul nsw <2 x i8> [[X:%.*]], <i8 20, i8 10>
-; CHECK-NEXT:    [[R:%.*]] = srem <2 x i8> [[MUL]], <i8 5, i8 5>
-; CHECK-NEXT:    ret <2 x i8> [[R]]
+; CHECK-NEXT:    ret <2 x i8> zeroinitializer
 ;
   %mul = mul nsw <2 x i8> %x, <i8 20, i8 10>
   %r = srem <2 x i8> %mul, <i8 5, i8 5>
@@ -513,9 +511,7 @@ define <2 x i8> @simplfy_srem_of_mul_fail_bad_mod(<2 x i8> %x) {
 
 define i8 @simplfy_urem_of_mul(i8 %x) {
 ; CHECK-LABEL: @simplfy_urem_of_mul(
-; CHECK-NEXT:    [[MUL:%.*]] = mul nuw i8 [[X:%.*]], 30
-; CHECK-NEXT:    [[R:%.*]] = urem i8 [[MUL]], 10
-; CHECK-NEXT:    ret i8 [[R]]
+; CHECK-NEXT:    ret i8 0
 ;
   %mul = mul nuw i8 %x, 30
   %r = urem i8 %mul, 10


### PR DESCRIPTION
- **[InstSimplify] Add test for simplifying `({u,s}rem (mul {nuw,nsw} X, C1), C0)`; NFC**
- **[InstSimplify] Add simplification for `({u,s}rem (mul {nuw,nsw} X, C1), C0)`**

We can simplify these to `0` if `C1 % C0 == 0`

Proofs: https://alive2.llvm.org/ce/z/EejAdk