### PR TITLE
[libc] Fix compilation error on targets without 128-bit int types

### DIFF
--- a/libc/src/__support/high_precision_decimal.h
+++ b/libc/src/__support/high_precision_decimal.h
@@ -409,7 +409,8 @@ public:
       result *= 10;
       ++cur_digit;
     }
-    return result + this->should_round_up(this->decimal_point, round);
+    return result + static_cast<unsigned int>(
+                        this->should_round_up(this->decimal_point, round));
   }
 
   // Extra functions for testing.

--- a/libc/test/src/__support/math_extras_test.cpp
+++ b/libc/test/src/__support/math_extras_test.cpp
@@ -102,7 +102,7 @@ TYPED_TEST(LlvmLibcBitTest, CountZeros, UnsignedTypesNoBigInt) {
 }
 
 using UnsignedTypes = testing::TypeList<
-#if defined(__SIZEOF_INT128__)
+#if defined(LIBC_TYPES_HAS_INT128)
     __uint128_t,
 #endif
     unsigned char, unsigned short, unsigned int, unsigned long,


### PR DESCRIPTION
See Buildbot failures:

- https://lab.llvm.org/buildbot/#/builders/11/builds/743
- https://lab.llvm.org/buildbot/#/builders/182/builds/362
