### PR TITLE
[SPIRV] Added new stub pass for NonSemantic DI

### DIFF
--- a/llvm/lib/Target/SPIRV/CMakeLists.txt
+++ b/llvm/lib/Target/SPIRV/CMakeLists.txt
@@ -40,6 +40,7 @@ add_llvm_target(SPIRVCodeGen
   SPIRVSubtarget.cpp
   SPIRVTargetMachine.cpp
   SPIRVUtils.cpp
+  SPIRVEmitNonSemanticDI.cpp
 
   LINK_COMPONENTS
   Analysis

--- a/llvm/lib/Target/SPIRV/SPIRV.h
+++ b/llvm/lib/Target/SPIRV/SPIRV.h
@@ -26,6 +26,7 @@ FunctionPass *createSPIRVRegularizerPass();
 FunctionPass *createSPIRVPreLegalizerPass();
 FunctionPass *createSPIRVPostLegalizerPass();
 ModulePass *createSPIRVEmitIntrinsicsPass(SPIRVTargetMachine *TM);
+MachineFunctionPass *createSPIRVEmitNonSemanticDIPass();
 InstructionSelector *
 createSPIRVInstructionSelector(const SPIRVTargetMachine &TM,
                                const SPIRVSubtarget &Subtarget,
@@ -36,6 +37,7 @@ void initializeSPIRVConvergenceRegionAnalysisWrapperPassPass(PassRegistry &);
 void initializeSPIRVPreLegalizerPass(PassRegistry &);
 void initializeSPIRVPostLegalizerPass(PassRegistry &);
 void initializeSPIRVEmitIntrinsicsPass(PassRegistry &);
+void initializeSPIRVEmitNonSemanticDIPass(PassRegistry &);
 } // namespace llvm
 
 #endif // LLVM_LIB_TARGET_SPIRV_SPIRV_H

--- a/llvm/lib/Target/SPIRV/SPIRV.h
+++ b/llvm/lib/Target/SPIRV/SPIRV.h
@@ -9,9 +9,7 @@
 #ifndef LLVM_LIB_TARGET_SPIRV_SPIRV_H
 #define LLVM_LIB_TARGET_SPIRV_SPIRV_H
 
-#include "MCTargetDesc/SPIRVMCTargetDesc.h"
 #include "llvm/CodeGen/MachineFunctionPass.h"
-#include "llvm/Target/TargetMachine.h"
 
 namespace llvm {
 class SPIRVTargetMachine;
@@ -26,7 +24,7 @@ FunctionPass *createSPIRVRegularizerPass();
 FunctionPass *createSPIRVPreLegalizerPass();
 FunctionPass *createSPIRVPostLegalizerPass();
 ModulePass *createSPIRVEmitIntrinsicsPass(SPIRVTargetMachine *TM);
-MachineFunctionPass *createSPIRVEmitNonSemanticDIPass();
+MachineFunctionPass *createSPIRVEmitNonSemanticDIPass(SPIRVTargetMachine *TM);
 InstructionSelector *
 createSPIRVInstructionSelector(const SPIRVTargetMachine &TM,
                                const SPIRVSubtarget &Subtarget,

--- a/llvm/lib/Target/SPIRV/SPIRVAsmPrinter.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVAsmPrinter.cpp
@@ -273,6 +273,8 @@ void SPIRVAsmPrinter::outputDebugSourceAndStrings(const Module &M) {
     addStringImm(Str.first(), Inst);
     outputMCInst(Inst);
   }
+  // Output OpString.
+  outputModuleSection(SPIRV::MB_DebugStrings);
   // Output OpSource.
   MCInst Inst;
   Inst.setOpcode(SPIRV::OpSource);
@@ -588,9 +590,11 @@ void SPIRVAsmPrinter::outputModuleSections() {
   // the first section to allow use of: OpLine and OpNoLine debug information;
   // non-semantic instructions with OpExtInst.
   outputModuleSection(SPIRV::MB_TypeConstVars);
-  // 10. All function declarations (functions without a body).
+  // 10. All global NonSemantic.Shader.DebugInfo.100 instructions.
+  outputModuleSection(SPIRV::MB_NonSemanticGlobalDI);
+  // 11. All function declarations (functions without a body).
   outputExtFuncDecls();
-  // 11. All function definitions (functions with a body).
+  // 12. All function definitions (functions with a body).
   // This is done in regular function output.
 }
 

--- a/llvm/lib/Target/SPIRV/SPIRVEmitNonSemanticDI.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVEmitNonSemanticDI.cpp
@@ -1,0 +1,55 @@
+#include "llvm/CodeGen/MachineFunction.h"
+#include "llvm/CodeGen/MachineFunctionPass.h"
+#include "llvm/CodeGen/MachineModuleInfo.h"
+#include "llvm/IR/DebugInfoMetadata.h"
+#include "llvm/IR/Metadata.h"
+#include "llvm/PassRegistry.h"
+#include "llvm/Support/Casting.h"
+
+namespace llvm {
+struct SPIRVEmitNonSemanticDI : public MachineFunctionPass {
+  static char ID;
+  SPIRVEmitNonSemanticDI();
+
+  bool runOnMachineFunction(MachineFunction &MF) override;
+};
+
+void initializeSPIRVEmitNonSemanticDIPass(PassRegistry &);
+
+FunctionPass *createSPIRVEmitNonSemanticDIPass() {
+  return new SPIRVEmitNonSemanticDI();
+}
+} // namespace llvm
+
+using namespace llvm;
+
+INITIALIZE_PASS(SPIRVEmitNonSemanticDI, "spirv-nonsemantic-debug-info",
+                "SPIRV NonSemantic.Shader.DebugInfo.100 emitter", false, false)
+
+char SPIRVEmitNonSemanticDI::ID = 0;
+
+SPIRVEmitNonSemanticDI::SPIRVEmitNonSemanticDI() : MachineFunctionPass(ID) {
+  initializeSPIRVEmitNonSemanticDIPass(*PassRegistry::getPassRegistry());
+}
+
+[[maybe_unused]]
+static void findCompileUnitDI(const MachineFunction &MF) {
+  MachineModuleInfo &MMI = MF.getMMI();
+  const Module *M = MMI.getModule();
+  NamedMDNode *DbgCu = M->getNamedMetadata("llvm.dbg.cu");
+  std::string FilePath;
+  if (DbgCu) {
+    unsigned NumOp = DbgCu->getNumOperands();
+    if (NumOp) {
+      if (const auto *CompileUnit =
+              dyn_cast<DICompileUnit>(DbgCu->getOperand(0))) {
+        DIFile *File = CompileUnit->getFile();
+        FilePath = ((File->getDirectory() + "/" + File->getFilename())).str();
+      }
+    }
+  }
+}
+
+bool SPIRVEmitNonSemanticDI::runOnMachineFunction(MachineFunction &MF) {
+  return false;
+}

--- a/llvm/lib/Target/SPIRV/SPIRVEmitNonSemanticDI.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVEmitNonSemanticDI.cpp
@@ -1,6 +1,14 @@
+#include "MCTargetDesc/SPIRVBaseInfo.h"
+#include "SPIRVGlobalRegistry.h"
+#include "SPIRVRegisterInfo.h"
+#include "SPIRVTargetMachine.h"
+#include "llvm/CodeGen/GlobalISel/MachineIRBuilder.h"
 #include "llvm/CodeGen/MachineFunction.h"
 #include "llvm/CodeGen/MachineFunctionPass.h"
+#include "llvm/CodeGen/MachineInstr.h"
+#include "llvm/CodeGen/MachineInstrBuilder.h"
 #include "llvm/CodeGen/MachineModuleInfo.h"
+#include "llvm/CodeGen/MachineOperand.h"
 #include "llvm/IR/DebugInfoMetadata.h"
 #include "llvm/IR/Metadata.h"
 #include "llvm/PassRegistry.h"
@@ -9,15 +17,21 @@
 namespace llvm {
 struct SPIRVEmitNonSemanticDI : public MachineFunctionPass {
   static char ID;
+  SPIRVTargetMachine *TM;
+  SPIRVEmitNonSemanticDI(SPIRVTargetMachine *TM);
   SPIRVEmitNonSemanticDI();
 
   bool runOnMachineFunction(MachineFunction &MF) override;
+
+private:
+  bool IsGlobalDIEmitted = false;
+  bool emitGlobalDI(MachineFunction &MF);
 };
 
 void initializeSPIRVEmitNonSemanticDIPass(PassRegistry &);
 
-FunctionPass *createSPIRVEmitNonSemanticDIPass() {
-  return new SPIRVEmitNonSemanticDI();
+FunctionPass *createSPIRVEmitNonSemanticDIPass(SPIRVTargetMachine *TM) {
+  return new SPIRVEmitNonSemanticDI(TM);
 }
 } // namespace llvm
 
@@ -28,28 +42,107 @@ INITIALIZE_PASS(SPIRVEmitNonSemanticDI, "spirv-nonsemantic-debug-info",
 
 char SPIRVEmitNonSemanticDI::ID = 0;
 
+SPIRVEmitNonSemanticDI::SPIRVEmitNonSemanticDI(SPIRVTargetMachine *TM)
+    : MachineFunctionPass(ID), TM(TM) {
+  initializeSPIRVEmitNonSemanticDIPass(*PassRegistry::getPassRegistry());
+}
+
 SPIRVEmitNonSemanticDI::SPIRVEmitNonSemanticDI() : MachineFunctionPass(ID) {
   initializeSPIRVEmitNonSemanticDIPass(*PassRegistry::getPassRegistry());
 }
 
-[[maybe_unused]]
-static void findCompileUnitDI(const MachineFunction &MF) {
+bool SPIRVEmitNonSemanticDI::emitGlobalDI(MachineFunction &MF) {
   MachineModuleInfo &MMI = MF.getMMI();
   const Module *M = MMI.getModule();
   NamedMDNode *DbgCu = M->getNamedMetadata("llvm.dbg.cu");
+  if (!DbgCu) {
+    return false;
+  }
   std::string FilePath;
-  if (DbgCu) {
-    unsigned NumOp = DbgCu->getNumOperands();
-    if (NumOp) {
-      if (const auto *CompileUnit =
-              dyn_cast<DICompileUnit>(DbgCu->getOperand(0))) {
-        DIFile *File = CompileUnit->getFile();
-        FilePath = ((File->getDirectory() + "/" + File->getFilename())).str();
-      }
+  unsigned SourceLanguage;
+  unsigned NumOp = DbgCu->getNumOperands();
+  if (NumOp) {
+    if (const auto *CompileUnit =
+            dyn_cast<DICompileUnit>(DbgCu->getOperand(0))) {
+      DIFile *File = CompileUnit->getFile();
+      FilePath = ((File->getDirectory() + "/" + File->getFilename())).str();
+      SourceLanguage = CompileUnit->getSourceLanguage();
     }
   }
+  NamedMDNode *ModuleFlags = M->getNamedMetadata("llvm.module.flags");
+  int64_t DwarfVersion = 0;
+  int64_t DebugInfoVersion = 0;
+  for (auto *Op : ModuleFlags->operands()) {
+    const MDOperand &StrOp = Op->getOperand(1);
+    if (StrOp.equalsStr("Dwarf Version")) {
+      DwarfVersion =
+          cast<ConstantInt>(
+              cast<ConstantAsMetadata>(Op->getOperand(2))->getValue())
+              ->getSExtValue();
+    } else if (StrOp.equalsStr("Debug Info Version")) {
+      DebugInfoVersion =
+          cast<ConstantInt>(
+              cast<ConstantAsMetadata>(Op->getOperand(2))->getValue())
+              ->getSExtValue();
+    }
+  }
+  const SPIRVInstrInfo *TII = TM->getSubtargetImpl()->getInstrInfo();
+  const SPIRVRegisterInfo *TRI = TM->getSubtargetImpl()->getRegisterInfo();
+  const RegisterBankInfo *RBI = TM->getSubtargetImpl()->getRegBankInfo();
+  SPIRVGlobalRegistry *GR = TM->getSubtargetImpl()->getSPIRVGlobalRegistry();
+  MachineRegisterInfo &MRI = MF.getRegInfo();
+  for (MachineBasicBlock &MBB : MF) {
+    MachineIRBuilder MIRBuilder(MBB, MBB.begin());
+
+    MachineInstrBuilder MIB = MIRBuilder.buildInstr(SPIRV::OpString);
+    Register StrReg = MRI.createVirtualRegister(&SPIRV::IDRegClass);
+    MachineOperand StrRegOp = MachineOperand::CreateReg(StrReg, true);
+    MIB.add(StrRegOp);
+    addStringImm(FilePath, MIB);
+
+    const MachineInstr *VoidTyMI =
+        GR->getOrCreateSPIRVType(Type::getVoidTy(M->getContext()), MIRBuilder);
+
+    MIB = MIRBuilder.buildInstr(SPIRV::OpExtInst);
+    Register DebugSourceResIdReg =
+        MRI.createVirtualRegister(&SPIRV::IDRegClass);
+    MIB.addDef(DebugSourceResIdReg);              // Result ID
+    MIB.addUse(VoidTyMI->getOperand(0).getReg()); // Result Type
+    MIB.addImm(static_cast<int64_t>(
+        SPIRV::InstructionSet::NonSemantic_Shader_DebugInfo_100)); // Set ID
+    MIB.addImm(SPIRV::NonSemanticExtInst::DebugSource);            //
+    MIB.addUse(StrReg);
+    MIB.constrainAllUses(*TII, *TRI, *RBI);
+
+    Register DwarfVersionReg = GR->buildConstantInt(DwarfVersion, MIRBuilder);
+    Register DebugInfoVersionReg =
+        GR->buildConstantInt(DebugInfoVersion, MIRBuilder);
+    Register SourceLanguageReg =
+        GR->buildConstantInt(SourceLanguage, MIRBuilder);
+
+    MIB = MIRBuilder.buildInstr(SPIRV::OpExtInst);
+    Register DebugCompUnitResIdReg =
+        MRI.createVirtualRegister(&SPIRV::IDRegClass);
+    MIB.addDef(DebugCompUnitResIdReg);            // Result ID
+    MIB.addUse(VoidTyMI->getOperand(0).getReg()); // Result Type
+    MIB.addImm(static_cast<int64_t>(
+        SPIRV::InstructionSet::NonSemantic_Shader_DebugInfo_100)); // Set ID
+    MIB.addImm(SPIRV::NonSemanticExtInst::DebugCompilationUnit);
+    MIB.addUse(DebugInfoVersionReg);
+    MIB.addUse(DwarfVersionReg);
+    MIB.addUse(DebugSourceResIdReg);
+    MIB.addUse(SourceLanguageReg);
+    MIB.constrainAllUses(*TII, *TRI, *RBI);
+  }
+
+  return true;
 }
 
 bool SPIRVEmitNonSemanticDI::runOnMachineFunction(MachineFunction &MF) {
-  return false;
+  bool Res = false;
+  if (!IsGlobalDIEmitted) {
+    Res = emitGlobalDI(MF);
+    IsGlobalDIEmitted = true;
+  }
+  return Res;
 }

--- a/llvm/lib/Target/SPIRV/SPIRVModuleAnalysis.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVModuleAnalysis.cpp
@@ -21,7 +21,6 @@
 #include "SPIRVSubtarget.h"
 #include "SPIRVTargetMachine.h"
 #include "SPIRVUtils.h"
-#include "TargetInfo/SPIRVTargetInfo.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/CodeGen/MachineModuleInfo.h"
 #include "llvm/CodeGen/TargetPassConfig.h"
@@ -427,7 +426,21 @@ void SPIRVModuleAnalysis::processOtherInstrs(const Module &M) {
         if (MAI.getSkipEmission(&MI))
           continue;
         const unsigned OpCode = MI.getOpcode();
-        if (OpCode == SPIRV::OpName || OpCode == SPIRV::OpMemberName) {
+        if (OpCode == SPIRV::OpString) {
+          collectOtherInstr(MI, MAI, SPIRV::MB_DebugStrings, IS);
+        } else if (OpCode == SPIRV::OpExtInst) {
+          MachineOperand Ins = MI.getOperand(3);
+          namespace NS = SPIRV::NonSemanticExtInst;
+          static constexpr int64_t GlobalNonSemanticDITy[] = {
+              NS::DebugSource, NS::DebugCompilationUnit};
+          bool IsGlobalDI = false;
+          for (unsigned Idx = 0; Idx < std::size(GlobalNonSemanticDITy); ++Idx) {
+            IsGlobalDI |= Ins.getImm() == GlobalNonSemanticDITy[Idx];
+          }
+          if (IsGlobalDI) {
+            collectOtherInstr(MI, MAI, SPIRV::MB_NonSemanticGlobalDI, IS);
+          }
+        } else if (OpCode == SPIRV::OpName || OpCode == SPIRV::OpMemberName) {
           collectOtherInstr(MI, MAI, SPIRV::MB_DebugNames, IS);
         } else if (OpCode == SPIRV::OpEntryPoint) {
           collectOtherInstr(MI, MAI, SPIRV::MB_EntryPoints, IS);

--- a/llvm/lib/Target/SPIRV/SPIRVModuleAnalysis.h
+++ b/llvm/lib/Target/SPIRV/SPIRVModuleAnalysis.h
@@ -20,7 +20,6 @@
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/SmallSet.h"
 #include "llvm/ADT/SmallVector.h"
-#include "llvm/ADT/StringMap.h"
 
 namespace llvm {
 class SPIRVSubtarget;
@@ -34,9 +33,11 @@ enum ModuleSectionType {
   MB_EntryPoints, // All OpEntryPoint instructions (if any).
   //  MB_ExecutionModes, MB_DebugSourceAndStrings,
   MB_DebugNames,           // All OpName and OpMemberName intrs.
+  MB_DebugStrings,         // All OpString intrs.
   MB_DebugModuleProcessed, // All OpModuleProcessed instructions.
   MB_Annotations,          // OpDecorate, OpMemberDecorate etc.
   MB_TypeConstVars,        // OpTypeXXX, OpConstantXXX, and global OpVariables.
+  MB_NonSemanticGlobalDI,  // OpExtInst with e.g. DebugSource, DebugTypeBasic.
   MB_ExtFuncDecls,         // OpFunction etc. to declare for external funcs.
   NUM_MODULE_SECTIONS      // Total number of sections requiring basic blocks.
 };

--- a/llvm/lib/Target/SPIRV/SPIRVTargetMachine.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVTargetMachine.cpp
@@ -199,7 +199,7 @@ void SPIRVPassConfig::addPreLegalizeMachineIR() {
 bool SPIRVPassConfig::addLegalizeMachineIR() {
   addPass(new Legalizer());
   addPass(createSPIRVPostLegalizerPass());
-  addPass(createSPIRVEmitNonSemanticDIPass());
+  addPass(createSPIRVEmitNonSemanticDIPass(&getTM<SPIRVTargetMachine>()));
   return false;
 }
 

--- a/llvm/lib/Target/SPIRV/SPIRVTargetMachine.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVTargetMachine.cpp
@@ -199,6 +199,7 @@ void SPIRVPassConfig::addPreLegalizeMachineIR() {
 bool SPIRVPassConfig::addLegalizeMachineIR() {
   addPass(new Legalizer());
   addPass(createSPIRVPostLegalizerPass());
+  addPass(createSPIRVEmitNonSemanticDIPass());
   return false;
 }
 


### PR DESCRIPTION
The commit adds new empty pass for emission of NonSemantic.Shader.DebugInfo.100 instructions.
The pass is a basis for future development and can be (and likely will be) a subject of change.
In addition to that there is additional unused function which main purpose is to be basis of accessing global metadata which is inaccessible in MIR. Accessing such metadata is necessary for emitting such instructions like DebugCompilationUnit or DebugSource.