### PR TITLE
[lldb][test] Remove duplicate testcase names in API test-suite

### DIFF
--- a/lldb/test/API/commands/log/invalid-args/TestInvalidArgsLog.py
+++ b/lldb/test/API/commands/log/invalid-args/TestInvalidArgsLog.py
@@ -25,7 +25,7 @@ class InvalidArgsLogTestCase(TestBase):
         )
 
     @no_debug_info_test
-    def test_enable_empty(self):
+    def test_enable_invalid_path(self):
         invalid_path = os.path.join("this", "is", "not", "a", "valid", "path")
         self.expect(
             "log enable lldb all -f " + invalid_path,

--- a/lldb/test/API/commands/thread/backtrace/TestThreadBacktraceRepeat.py
+++ b/lldb/test/API/commands/thread/backtrace/TestThreadBacktraceRepeat.py
@@ -16,8 +16,6 @@ class TestThreadBacktracePage(TestBase):
         """Run a simplified version of the test that just hits one breakpoint and
         doesn't care about synchronizing the two threads - hopefully this will
         run on more systems."""
-
-    def test_thread_backtrace_one_thread(self):
         self.build()
         (
             self.inferior_target,

--- a/lldb/test/API/commands/trace/multiple-threads/TestTraceStartStopMultipleThreads.py
+++ b/lldb/test/API/commands/trace/multiple-threads/TestTraceStartStopMultipleThreads.py
@@ -36,43 +36,6 @@ class TestTraceStartStopMultipleThreads(TraceIntelPTTestCaseBase):
     def testStartMultipleLiveThreadsWithStops(self):
         self.build()
         exe = self.getBuildArtifact("a.out")
-
-        self.dbg.CreateTarget(exe)
-
-        self.expect("b main")
-        self.expect("b 6")
-        self.expect("b 11")
-
-        self.expect("r")
-        self.traceStartProcess()
-
-        # We'll see here the first thread
-        self.expect("continue")
-
-        # We are in thread 2
-        self.expect("thread trace dump instructions", substrs=["main.cpp:9"])
-        self.expect("thread trace dump instructions 2", substrs=["main.cpp:9"])
-
-        # We stop tracing it
-        self.expect("thread trace stop 2")
-
-        # The trace is still in memory
-        self.expect("thread trace dump instructions 2", substrs=["main.cpp:9"])
-
-        # We'll stop at the next breakpoint, thread 2 will be still alive, but not traced. Thread 3 will be traced
-        self.expect("continue")
-        self.expect("thread trace dump instructions", substrs=["main.cpp:4"])
-        self.expect("thread trace dump instructions 3", substrs=["main.cpp:4"])
-
-        self.expect("thread trace dump instructions 2", substrs=["not traced"])
-
-        self.traceStopProcess()
-
-    @skipIf(oslist=no_match(["linux"]), archs=no_match(["i386", "x86_64"]))
-    @testSBAPIAndCommands
-    def testStartMultipleLiveThreadsWithStops(self):
-        self.build()
-        exe = self.getBuildArtifact("a.out")
         self.dbg.CreateTarget(exe)
 
         self.expect("b main")

--- a/lldb/test/API/functionalities/completion/TestCompletion.py
+++ b/lldb/test/API/functionalities/completion/TestCompletion.py
@@ -197,12 +197,6 @@ class CommandLineCompletionTestCase(TestBase):
         self.complete_from_to("plugin load ", [])
 
     def test_log_enable(self):
-        self.complete_from_to("log enable ll", ["lldb"])
-        self.complete_from_to("log enable dw", ["dwarf"])
-        self.complete_from_to("log enable lldb al", ["all"])
-        self.complete_from_to("log enable lldb sym", ["symbol"])
-
-    def test_log_enable(self):
         self.complete_from_to("log disable ll", ["lldb"])
         self.complete_from_to("log disable dw", ["dwarf"])
         self.complete_from_to("log disable lldb al", ["all"])

--- a/lldb/test/API/functionalities/gdb_remote_client/TestIOSSimulator.py
+++ b/lldb/test/API/functionalities/gdb_remote_client/TestIOSSimulator.py
@@ -79,7 +79,7 @@ class TestIOSSimulator(GDBRemoteTestBase):
         )
 
     @skipIfRemote
-    def test_tvos_sim(self):
+    def test_watchos_sim(self):
         self.platform_test(
             host="macosx",
             process="watchossimulator",

--- a/lldb/test/API/functionalities/plugins/python_os_plugin/TestPythonOSPlugin.py
+++ b/lldb/test/API/functionalities/plugins/python_os_plugin/TestPythonOSPlugin.py
@@ -17,7 +17,7 @@ class PluginPythonOSPlugin(TestBase):
         self.build()
         self.run_python_os_funcionality()
 
-    def run_python_os_step(self):
+    def test_run_python_os_step(self):
         """Test that the Python operating system plugin works correctly when single stepping a virtual thread"""
         self.build()
         self.run_python_os_step()

--- a/lldb/test/API/lang/cpp/diamond/TestCppDiamond.py
+++ b/lldb/test/API/lang/cpp/diamond/TestCppDiamond.py
@@ -109,7 +109,7 @@ class TestCase(TestBase):
 
     @expectedFailureAll
     @no_debug_info_test
-    def test(self):
+    def test_invalid_member(self):
         self.build()
         lldbutil.run_to_source_breakpoint(
             self, "// breakpoint 1", lldb.SBFileSpec("main.cpp")

--- a/lldb/test/API/lang/cpp/member-and-local-vars-with-same-name/TestMembersAndLocalsWithSameName.py
+++ b/lldb/test/API/lang/cpp/member-and-local-vars-with-same-name/TestMembersAndLocalsWithSameName.py
@@ -3,7 +3,6 @@ from lldbsuite.test.decorators import *
 from lldbsuite.test.lldbtest import *
 import lldbsuite.test.lldbutil as lldbutil
 
-
 class TestMembersAndLocalsWithSameName(TestBase):
     def test_when_stopped_in_method(self):
         self._load_exe()

--- a/lldb/test/API/lang/cpp/member-and-local-vars-with-same-name/TestMembersAndLocalsWithSameName.py
+++ b/lldb/test/API/lang/cpp/member-and-local-vars-with-same-name/TestMembersAndLocalsWithSameName.py
@@ -3,6 +3,7 @@ from lldbsuite.test.decorators import *
 from lldbsuite.test.lldbtest import *
 import lldbsuite.test.lldbutil as lldbutil
 
+
 class TestMembersAndLocalsWithSameName(TestBase):
     def test_when_stopped_in_method(self):
         self._load_exe()

--- a/lldb/test/API/lang/objcxx/cxx-bridged-po/TestObjCXXBridgedPO.py
+++ b/lldb/test/API/lang/objcxx/cxx-bridged-po/TestObjCXXBridgedPO.py
@@ -7,7 +7,7 @@ import lldbsuite.test.lldbutil as lldbutil
 class TestObjCXXBridgedPO(TestBase):
     @skipIfDarwinEmbedded
     @skipIf(macos_version=[">=", "13.0"])
-    def test_bridged_type_po(self):
+    def test_bridged_type_po_old(self):
         self.build()
         lldbutil.run_to_source_breakpoint(
             self, "break here", lldb.SBFileSpec("main.mm")

--- a/lldb/test/API/lang/rust/enum-structs/TestRustEnumStructs.py
+++ b/lldb/test/API/lang/rust/enum-structs/TestRustEnumStructs.py
@@ -287,7 +287,7 @@ class TestRustEnumStructs(TestBase):
             (137, 1),
         )
 
-    def test_niche_layout_with_fields_3_a(self):
+    def test_niche_layout_with_fields_3_c(self):
         # static NICHE_W_FIELDS_3_C: NicheLayoutWithFields3 = NicheLayoutWithFields3::C(false);
         value = self.getFromGlobal("NICHE_W_FIELDS_3_C").getCurrentValue()
         self.assertEqual(

--- a/lldb/test/API/test_utils/TestDecorators.py
+++ b/lldb/test/API/test_utils/TestDecorators.py
@@ -29,7 +29,7 @@ class TestDecoratorsNoDebugInfoClass(TestBase):
         self.assertIsNone(self.getDebugInfo())
 
     @expectedFailureAll
-    def test_xfail_regexp(self):
+    def test_xfail_empty(self):
         """Test that expectedFailureAll can be empty (but please just use expectedFailure)"""
         self.fail()
 
@@ -92,7 +92,7 @@ class TestDecorators(TestBase):
         # self.assertNotEqual(self.getDebugInfo(), "dwarf")
 
     @expectedFailureAll
-    def test_xfail_regexp(self):
+    def test_xfail_empty(self):
         """Test that xfail can be empty"""
         self.fail()
 


### PR DESCRIPTION
In one of my recent PRs I mistakenly had two test-cases with the same name, preventing one of them to run. Since it's an easy mistake to make (e.g., copy pasting existing test-cases), I ran following sanity-check script over `lldb/test/API`, which found couple of tests which were losing coverage because of this (or in some cases simply had duplicate tests):
```
import ast
import sys

filename = sys.argv[1]
print(f'Checking {filename}...')
tree = ast.parse(open(filename, 'r').read())

for node in ast.walk(tree):
    if not isinstance(node, ast.ClassDef):
        continue

    func_names = []
    for child in ast.iter_child_nodes(node):
        if isinstance(child, ast.FunctionDef):
            func_names.append(child.name)

    seen_func_names = set()
    duplicate_func_names = []
    for name in func_names:
        if name in seen_func_names:
            duplicate_func_names.append(name)
        else:
            seen_func_names.add(name)

    if len(duplicate_func_names) != 0:
        print(f'Multiple func names found:\n\t{duplicate_func_names}\n\tclass {node.name}\n\tfile: {filename}')
```

This patch fixes these cases.