### PR TITLE
[lldb][test][NFC] Remove BOM characters from tests

### DIFF
--- a/lldb/test/API/commands/expression/call-restarts/TestCallThatRestarts.py
+++ b/lldb/test/API/commands/expression/call-restarts/TestCallThatRestarts.py
@@ -1,4 +1,4 @@
-﻿"""
+"""
 Test calling a function that hits a signal set to auto-restart, make sure the call completes.
 """
 

--- a/lldb/test/API/functionalities/load_lazy/TestLoadUsingLazyBind.py
+++ b/lldb/test/API/functionalities/load_lazy/TestLoadUsingLazyBind.py
@@ -1,4 +1,4 @@
-﻿"""
+"""
 Test that SBProcess.LoadImageUsingPaths uses RTLD_LAZY
 """
 

--- a/lldb/test/API/functionalities/load_unload/TestLoadUnload.py
+++ b/lldb/test/API/functionalities/load_unload/TestLoadUnload.py
@@ -1,4 +1,4 @@
-﻿"""
+"""
 Test that breakpoint by symbol name works correctly with dynamic libs.
 """
 

--- a/lldb/test/API/functionalities/load_using_paths/TestLoadUsingPaths.py
+++ b/lldb/test/API/functionalities/load_using_paths/TestLoadUsingPaths.py
@@ -1,4 +1,4 @@
-﻿"""
+"""
 Test that SBProcess.LoadImageUsingPaths works correctly.
 """
 

--- a/lldb/test/API/functionalities/location-list-lookup/TestLocationListLookup.py
+++ b/lldb/test/API/functionalities/location-list-lookup/TestLocationListLookup.py
@@ -1,4 +1,4 @@
-﻿"""Test that lldb picks the correct DWARF location list entry with a return-pc out of bounds."""
+"""Test that lldb picks the correct DWARF location list entry with a return-pc out of bounds."""
 
 import lldb
 from lldbsuite.test.decorators import *

--- a/lldb/test/API/functionalities/signal/TestSendSignal.py
+++ b/lldb/test/API/functionalities/signal/TestSendSignal.py
@@ -1,4 +1,4 @@
-﻿"""Test that lldb command 'process signal SIGUSR1' to send a signal to the inferior works."""
+"""Test that lldb command 'process signal SIGUSR1' to send a signal to the inferior works."""
 
 
 import lldb


### PR DESCRIPTION
These handful of tests had a BOM (Byte order mark) at the beginning of the file. This marker is unnecessary in our test files. The main motivation for this is that the `ast` python module breaks when passing a file to it with a BOM marker (and might break other tooling which doesn't expect it). E.g.,:
```
"""Test that lldb command 'process signal SIGUSR1' to send a signal to the inferior works."""
^
SyntaxError: invalid non-printable character U+FEFF
```

If anyone is aware of a good reason to keep it, happy to drop this.