### PR TITLE
[MC][NFC] Make getCurrentFragment inline

### DIFF
--- a/llvm/include/llvm/MC/MCStreamer.h
+++ b/llvm/include/llvm/MC/MCStreamer.h
@@ -410,7 +410,11 @@ public:
     return MCSectionSubPair();
   }
 
-  MCFragment *getCurrentFragment() const;
+  MCFragment *getCurrentFragment() const {
+    assert(!getCurrentSection().first ||
+           CurFrag->getParent() == getCurrentSection().first);
+    return CurFrag;
+  }
 
   /// Returns an index to represent the order a symbol was emitted in.
   /// (zero if we did not emit that symbol)

--- a/llvm/lib/MC/MCStreamer.cpp
+++ b/llvm/lib/MC/MCStreamer.cpp
@@ -118,12 +118,6 @@ ArrayRef<MCDwarfFrameInfo> MCStreamer::getDwarfFrameInfos() const {
   return DwarfFrameInfos;
 }
 
-MCFragment *MCStreamer::getCurrentFragment() const {
-  assert(!getCurrentSection().first ||
-         CurFrag->getParent() == getCurrentSection().first);
-  return CurFrag;
-}
-
 void MCStreamer::emitRawComment(const Twine &T, bool TabPrefix) {}
 
 void MCStreamer::addExplicitComment(const Twine &T) {}


### PR DESCRIPTION
It's a very simple method now, which is called quite often, so make it
an inline function.
