### PR TITLE
[lldb][test] Add tests for alignof on class with overlapping bases

### DIFF
--- a/lldb/test/Shell/SymbolFile/DWARF/no_unique_address-base-alignment.cpp
+++ b/lldb/test/Shell/SymbolFile/DWARF/no_unique_address-base-alignment.cpp
@@ -6,11 +6,6 @@
 // RUN:   -o "expr sizeof(OverlappingDerived)" \
 // RUN:   -o exit | FileCheck %s
 
-// CHECK:      (lldb) expr alignof(OverlappingDerived)
-// CHECK-NEXT: ${{.*}} = 4
-// CHECK:      (lldb) expr sizeof(OverlappingDerived)
-// CHECK-NEXT: ${{.*}} = 4
-
 struct Empty {};
 
 struct OverlappingBase {
@@ -26,5 +21,10 @@ struct Base {
 struct OverlappingDerived : Base, OverlappingBase {};
 static_assert(alignof(OverlappingDerived) == 4);
 static_assert(sizeof(OverlappingDerived) == 4);
+
+// CHECK:      (lldb) expr alignof(OverlappingDerived)
+// CHECK-NEXT: ${{.*}} = 4
+// CHECK:      (lldb) expr sizeof(OverlappingDerived)
+// CHECK-NEXT: ${{.*}} = 4
 
 int main() { OverlappingDerived d; }

--- a/lldb/test/Shell/SymbolFile/DWARF/no_unique_address-base-alignment.cpp
+++ b/lldb/test/Shell/SymbolFile/DWARF/no_unique_address-base-alignment.cpp
@@ -1,0 +1,30 @@
+// XFAIL: *
+
+// RUN: %clangxx_host -gdwarf -o %t %s
+// RUN: %lldb %t \
+// RUN:   -o "expr alignof(OverlappingDerived)" \
+// RUN:   -o "expr sizeof(OverlappingDerived)" \
+// RUN:   -o exit | FileCheck %s
+
+// CHECK:      (lldb) expr alignof(OverlappingDerived)
+// CHECK-NEXT: ${{.*}} = 4
+// CHECK:      (lldb) expr sizeof(OverlappingDerived)
+// CHECK-NEXT: ${{.*}} = 4
+
+struct Empty {};
+
+struct OverlappingBase {
+  [[no_unique_address]] Empty e;
+};
+static_assert(sizeof(OverlappingBase) == 1);
+static_assert(alignof(OverlappingBase) == 1);
+
+struct Base {
+  int mem;
+};
+
+struct OverlappingDerived : Base, OverlappingBase {};
+static_assert(alignof(OverlappingDerived) == 4);
+static_assert(sizeof(OverlappingDerived) == 4);
+
+int main() { OverlappingDerived d; }

--- a/lldb/test/Shell/SymbolFile/DWARF/packed-alignof.cpp
+++ b/lldb/test/Shell/SymbolFile/DWARF/packed-alignof.cpp
@@ -8,15 +8,6 @@
 // RUN:   -o "expr sizeof(derived)" \
 // RUN:   -o exit | FileCheck %s
 
-// CHECK:      (lldb) expr alignof(base)
-// CHECK-NEXT: ${{.*}} = 4
-// CHECK:      (lldb) expr alignof(packed_base)
-// CHECK-NEXT: ${{.*}} = 1
-// CHECK:      (lldb) expr alignof(derived)
-// CHECK-NEXT: ${{.*}} = 2
-// CHECK:      (lldb) expr sizeof(derived)
-// CHECK-NEXT: ${{.*}} = 16
-
 struct __attribute__((packed)) packed {
   int x;
   char y;
@@ -28,14 +19,25 @@ struct foo {};
 struct base : foo { int x; };
 static_assert(alignof(base) == 4);
 
+// CHECK:      (lldb) expr alignof(base)
+// CHECK-NEXT: ${{.*}} = 4
+
 // LLDB incorrectly calculates alignof(packed_base)
 struct __attribute__((packed)) packed_base { int x; };
 static_assert(alignof(packed_base) == 1);
+
+// CHECK:      (lldb) expr alignof(packed_base)
+// CHECK-NEXT: ${{.*}} = 1
 
 struct derived : packed, packed_base {
   short s;
 } g_derived;
 static_assert(alignof(derived) == 2);
 static_assert(sizeof(derived) == 16);
+
+// CHECK:      (lldb) expr alignof(derived)
+// CHECK-NEXT: ${{.*}} = 2
+// CHECK:      (lldb) expr sizeof(derived)
+// CHECK-NEXT: ${{.*}} = 16
 
 int main() {}

--- a/lldb/test/Shell/SymbolFile/DWARF/packed-alignof.cpp
+++ b/lldb/test/Shell/SymbolFile/DWARF/packed-alignof.cpp
@@ -1,0 +1,41 @@
+// XFAIL: *
+//
+// RUN: %clangxx_host -gdwarf -o %t %s
+// RUN: %lldb %t \
+// RUN:   -o "expr alignof(base)" \
+// RUN:   -o "expr alignof(packed_base)" \
+// RUN:   -o "expr alignof(derived)" \
+// RUN:   -o "expr sizeof(derived)" \
+// RUN:   -o exit | FileCheck %s
+
+// CHECK:      (lldb) expr alignof(base)
+// CHECK-NEXT: ${{.*}} = 4
+// CHECK:      (lldb) expr alignof(packed_base)
+// CHECK-NEXT: ${{.*}} = 1
+// CHECK:      (lldb) expr alignof(derived)
+// CHECK-NEXT: ${{.*}} = 2
+// CHECK:      (lldb) expr sizeof(derived)
+// CHECK-NEXT: ${{.*}} = 16
+
+struct __attribute__((packed)) packed {
+  int x;
+  char y;
+  int z;
+} g_packed_struct;
+
+// LLDB incorrectly calculates alignof(base)
+struct foo {};
+struct base : foo { int x; };
+static_assert(alignof(base) == 4);
+
+// LLDB incorrectly calculates alignof(packed_base)
+struct __attribute__((packed)) packed_base { int x; };
+static_assert(alignof(packed_base) == 1);
+
+struct derived : packed, packed_base {
+  short s;
+} g_derived;
+static_assert(alignof(derived) == 2);
+static_assert(sizeof(derived) == 16);
+
+int main() {}

--- a/lldb/test/Shell/SymbolFile/DWARF/packed.cpp
+++ b/lldb/test/Shell/SymbolFile/DWARF/packed.cpp
@@ -8,21 +8,6 @@
 // RUN:   -o "expr sizeof(derived)" \
 // RUN:   -o exit | FileCheck %s
 
-// CHECK:      (lldb) expr alignof(packed)
-// CHECK-NEXT: ${{.*}} = 1
-// CHECK:      (lldb) expr sizeof(packed)
-// CHECK-NEXT: ${{.*}} = 9
-
-// CHECK:      (lldb) expr alignof(packed_and_aligned)
-// CHECK-NEXT: ${{.*}} = 16
-// CHECK:      (lldb) expr sizeof(packed_and_aligned)
-// CHECK-NEXT: ${{.*}} = 16
-
-// CHECK:      (lldb) expr alignof(derived)
-// CHECK-NEXT: ${{.*}} = 1
-// CHECK:      (lldb) expr sizeof(derived)
-// CHECK-NEXT: ${{.*}} = 13
-
 struct __attribute__((packed)) packed {
   int x;
   char y;
@@ -30,6 +15,11 @@ struct __attribute__((packed)) packed {
 } g_packed_struct;
 static_assert(alignof(packed) == 1);
 static_assert(sizeof(packed) == 9);
+
+// CHECK:      (lldb) expr alignof(packed)
+// CHECK-NEXT: ${{.*}} = 1
+// CHECK:      (lldb) expr sizeof(packed)
+// CHECK-NEXT: ${{.*}} = 9
 
 struct __attribute__((packed, aligned(16))) packed_and_aligned {
   int x;
@@ -39,11 +29,21 @@ struct __attribute__((packed, aligned(16))) packed_and_aligned {
 static_assert(alignof(packed_and_aligned) == 16);
 static_assert(sizeof(packed_and_aligned) == 16);
 
+// CHECK:      (lldb) expr alignof(packed_and_aligned)
+// CHECK-NEXT: ${{.*}} = 16
+// CHECK:      (lldb) expr sizeof(packed_and_aligned)
+// CHECK-NEXT: ${{.*}} = 16
+
 struct __attribute__((packed)) packed_base { int x; };
 static_assert(alignof(packed_base) == 1);
 
 struct derived : packed, packed_base {} g_derived;
 static_assert(alignof(derived) == 1);
 static_assert(sizeof(derived) == 13);
+
+// CHECK:      (lldb) expr alignof(derived)
+// CHECK-NEXT: ${{.*}} = 1
+// CHECK:      (lldb) expr sizeof(derived)
+// CHECK-NEXT: ${{.*}} = 13
 
 int main() {}

--- a/lldb/test/Shell/SymbolFile/DWARF/packed.cpp
+++ b/lldb/test/Shell/SymbolFile/DWARF/packed.cpp
@@ -4,6 +4,8 @@
 // RUN:   -o "expr sizeof(packed)" \
 // RUN:   -o "expr alignof(packed_and_aligned)" \
 // RUN:   -o "expr sizeof(packed_and_aligned)" \
+// RUN:   -o "expr alignof(derived)" \
+// RUN:   -o "expr sizeof(derived)" \
 // RUN:   -o exit | FileCheck %s
 
 // CHECK:      (lldb) expr alignof(packed)
@@ -15,6 +17,11 @@
 // CHECK-NEXT: ${{.*}} = 16
 // CHECK:      (lldb) expr sizeof(packed_and_aligned)
 // CHECK-NEXT: ${{.*}} = 16
+
+// CHECK:      (lldb) expr alignof(derived)
+// CHECK-NEXT: ${{.*}} = 1
+// CHECK:      (lldb) expr sizeof(derived)
+// CHECK-NEXT: ${{.*}} = 13
 
 struct __attribute__((packed)) packed {
   int x;
@@ -31,5 +38,12 @@ struct __attribute__((packed, aligned(16))) packed_and_aligned {
 } g_packed_and_aligned_struct;
 static_assert(alignof(packed_and_aligned) == 16);
 static_assert(sizeof(packed_and_aligned) == 16);
+
+struct __attribute__((packed)) packed_base { int x; };
+static_assert(alignof(packed_base) == 1);
+
+struct derived : packed, packed_base {} g_derived;
+static_assert(alignof(derived) == 1);
+static_assert(sizeof(derived) == 13);
 
 int main() {}


### PR DESCRIPTION
Follow-up to https://github.com/llvm/llvm-project/pull/96932

Adds XFAILed test where LLDB incorrectly infers the alignment of a derived class whose bases are overlapping due to [[no_unique_address]]. Specifically, the `InferAlignment` code-path of the `ItaniumRecordLayoutBuilder` assumes that overlapping base offsets imply a packed structure and thus sets alignment to 1. See discussion in https://github.com/llvm/llvm-project/pull/93809.

Also adds test where LLDB correctly infers an alignment of `1` when a packed base class is overlapping with other bases.

Lastly, there were a couple of `alignof` inconsistencies which I encapsulated in an XFAIL-ed `packed-alignof.cpp`.