### PR TITLE
[clang] Default to -fno-sized-deallocation for AIX

### DIFF
--- a/clang/lib/Driver/ToolChains/AIX.cpp
+++ b/clang/lib/Driver/ToolChains/AIX.cpp
@@ -551,6 +551,12 @@ void AIX::addClangTargetOptions(
   if (Args.hasFlag(options::OPT_fxl_pragma_pack,
                    options::OPT_fno_xl_pragma_pack, true))
     CC1Args.push_back("-fxl-pragma-pack");
+
+  // Pass "-fno-sized-deallocation" only when the user hasn't manually enabled
+  // or disabled sized deallocations.
+  if (!Args.getLastArgNoClaim(options::OPT_fsized_deallocation,
+                              options::OPT_fno_sized_deallocation))
+    CC1Args.push_back("-fno-sized-deallocation");
 }
 
 void AIX::addProfileRTLibs(const llvm::opt::ArgList &Args,

--- a/clang/unittests/StaticAnalyzer/CallEventTest.cpp
+++ b/clang/unittests/StaticAnalyzer/CallEventTest.cpp
@@ -76,7 +76,11 @@ TEST(CXXDeallocatorCall, SimpleDestructor) {
     }
   )",
                                                          Diags));
+#if !defined(__cpp_sized_deallocation)
+  EXPECT_EQ(Diags, "test.CXXDeallocator: NumArgs: 1\n");
+#else
   EXPECT_EQ(Diags, "test.CXXDeallocator: NumArgs: 2\n");
+#endif
 }
 
 } // namespace

--- a/clang/unittests/StaticAnalyzer/CallEventTest.cpp
+++ b/clang/unittests/StaticAnalyzer/CallEventTest.cpp
@@ -76,7 +76,8 @@ TEST(CXXDeallocatorCall, SimpleDestructor) {
     }
   )",
                                                          Diags));
-#if !defined(__cpp_sized_deallocation)
+#if defined(_AIX) || defined(__MVS__)
+  // AIX and ZOS default to -fno-sized-deallocation.
   EXPECT_EQ(Diags, "test.CXXDeallocator: NumArgs: 1\n");
 #else
   EXPECT_EQ(Diags, "test.CXXDeallocator: NumArgs: 2\n");


### PR DESCRIPTION
Some `libc++` LIT test cases and user code define their own version of `operator delete` that are not sized. With `-fno-sized-deallocation`, destructors call the non-sized `operator delete` and it will be resolved to the user defined version. However, with `-fsized-deallocation`, destructors will call the sized `operator delete` which will be resolved to the weak definition in `libc++abi` because the user code does not define the corresponding sized version. The `libc++abi` sized `operator delete` in turn calls the non-sized version of `operator delete` of the same shared object inside `libc++abi` instead of the user defined version on AIX because runtime linking is not the default for AIX and therefore, fails the tests or user code. This patch sets `-fno-sized-deallocation` as the default for AIX if neither `-fsize-deallocation` nor `-fno-sized-deallocation` is explicitly set, similar to what is done for ZOS.