### PR TITLE
[Clang] Prevent null pointer dereference in DiagnoseDeclAvailability()

### DIFF
--- a/clang/lib/Sema/SemaAvailability.cpp
+++ b/clang/lib/Sema/SemaAvailability.cpp
@@ -842,6 +842,7 @@ void DiagnoseUnguardedAvailability::DiagnoseDeclAvailability(
 
     const AvailabilityAttr *AA =
       getAttrForPlatform(SemaRef.getASTContext(), OffendingDecl);
+    assert(AA != nullptr && "expecting valid availability attribute");
     bool EnvironmentMatchesOrNone =
         hasMatchingEnvironmentOrNone(SemaRef.getASTContext(), AA);
     VersionTuple Introduced = AA->getIntroduced();


### PR DESCRIPTION
This patch adds an assertion in the DiagnoseDeclAvailabilit() function to ensure that the expected availability attribute is not null before they are passed to hasMatchingEnvironmentOrNone() to prevent potential null pointer dereferences and improve the robustness of the availability diagnostics process.