### PR TITLE
[libc] Implement the 'remove' function on the GPU

### DIFF
--- a/libc/config/gpu/entrypoints.txt
+++ b/libc/config/gpu/entrypoints.txt
@@ -205,6 +205,7 @@ set(TARGET_LIBC_ENTRYPOINTS
     libc.src.stdio.putc
     libc.src.stdio.putchar
     libc.src.stdio.puts
+    libc.src.stdio.remove
     libc.src.stdio.stderr
     libc.src.stdio.stdin
     libc.src.stdio.stdout

--- a/libc/docs/gpu/support.rst
+++ b/libc/docs/gpu/support.rst
@@ -227,6 +227,7 @@ puts           |check|    |check|
 fputs          |check|    |check|
 fputc          |check|    |check|
 fwrite         |check|    |check|
+remove         |check|    |check|
 putc           |check|    |check|
 putchar        |check|    |check|
 fclose         |check|    |check|

--- a/libc/include/llvm-libc-types/rpc_opcodes_t.h
+++ b/libc/include/llvm-libc-types/rpc_opcodes_t.h
@@ -34,6 +34,7 @@ typedef enum {
   RPC_PRINTF_TO_STDOUT,
   RPC_PRINTF_TO_STDERR,
   RPC_PRINTF_TO_STREAM,
+  RPC_REMOVE,
   RPC_LAST = 0xFFFF,
 } rpc_opcode_t;
 

--- a/libc/src/stdio/gpu/CMakeLists.txt
+++ b/libc/src/stdio/gpu/CMakeLists.txt
@@ -263,6 +263,17 @@ add_entrypoint_object(
 )
 
 add_entrypoint_object(
+  remove
+  SRCS
+    remove.cpp
+  HDRS
+    ../remove.h
+  DEPENDS
+    libc.include.stdio
+    .gpu_file
+)
+
+add_entrypoint_object(
   stdin
   SRCS
     stdin.cpp

--- a/libc/src/stdio/gpu/remove.cpp
+++ b/libc/src/stdio/gpu/remove.cpp
@@ -1,0 +1,26 @@
+//===-- Implementation of remove ------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "src/stdio/remove.h"
+#include "file.h"
+
+#include <stdio.h>
+
+namespace LIBC_NAMESPACE {
+
+LLVM_LIBC_FUNCTION(int, remove, (const char *path)) {
+  int ret;
+  rpc::Client::Port port = rpc::client.open<RPC_REMOVE>();
+  port.send_n(path, internal::string_length(path) + 1);
+  port.recv(
+      [&](rpc::Buffer *buffer) { ret = static_cast<int>(buffer->data[0]); });
+  port.close();
+  return ret;
+}
+
+} // namespace LIBC_NAMESPACE

--- a/libc/utils/gpu/server/rpc_server.cpp
+++ b/libc/utils/gpu/server/rpc_server.cpp
@@ -343,6 +343,17 @@ rpc_status_t handle_server_impl(
     handle_printf<lane_size>(*port);
     break;
   }
+  case RPC_REMOVE: {
+    uint64_t sizes[lane_size] = {0};
+    void *args[lane_size] = {nullptr};
+    port->recv_n(args, sizes, [&](uint64_t size) { return new char[size]; });
+    port->send([&](rpc::Buffer *buffer, uint32_t id) {
+      buffer->data[0] = static_cast<uint64_t>(
+          remove(reinterpret_cast<const char *>(args[id])));
+      delete[] reinterpret_cast<uint8_t *>(args[id]);
+    });
+    break;
+  }
   case RPC_NOOP: {
     port->recv([](rpc::Buffer *) {});
     break;


### PR DESCRIPTION
Summary:
Straightforward RPC implementation of the `remove` function for the GPU.
Copies over the string and calls `remove` on it, passing the result
back. This is required for building some `libc++` functionality.
