### PR TITLE
[Clang] Prevent null pointer dereference in template deduction guide creation

### DIFF
--- a/clang/lib/Sema/SemaTemplate.cpp
+++ b/clang/lib/Sema/SemaTemplate.cpp
@@ -2513,6 +2513,9 @@ struct ConvertConstructorToDeductionGuideTransform {
       TSI = SemaRef.SubstType(TSI, OuterInstantiationArgs, Loc,
                               DeductionGuideName);
 
+    if (!TSI)
+      return nullptr;
+
     FunctionProtoTypeLoc FPTL =
         TSI->getTypeLoc().castAs<FunctionProtoTypeLoc>();
 
@@ -2523,6 +2526,9 @@ struct ConvertConstructorToDeductionGuideTransform {
       if (NestedPattern)
         TSI = SemaRef.SubstType(TSI, OuterInstantiationArgs, Loc,
                                 DeclarationName());
+      if (!TSI)
+        return nullptr;
+
       ParmVarDecl *NewParam =
           ParmVarDecl::Create(SemaRef.Context, DC, Loc, Loc, nullptr,
                               TSI->getType(), TSI, SC_None, nullptr);


### PR DESCRIPTION
This patch addresses static analyzer concerns where `TSI` could be dereferenced after being assigned a null value from `SubstType` in `ConvertConstructorToDeductionGuideTransform()`.

The fixes now check null value of `TSI` after the call to `SubstType` and return `nullptr` to prevent potential null pointer dereferences when calling getTypeLoc() or getType() and ensure safe execution.