### PR TITLE
[OpenMP] Add ompt_start_tool declaration in omp-tools.h

### DIFF
--- a/openmp/runtime/src/include/omp-tools.h.var
+++ b/openmp/runtime/src/include/omp-tools.h.var
@@ -1410,6 +1410,8 @@ typedef ompt_record_ompt_t *(*ompt_get_record_ompt_t) (
 
 #ifdef _WIN32
 __declspec(dllexport)
+#else
+__attribute__((visibility("default")))
 #endif
 ompt_start_tool_result_t *ompt_start_tool(unsigned int omp_version,
                                           const char *runtime_version);

--- a/openmp/runtime/src/include/omp-tools.h.var
+++ b/openmp/runtime/src/include/omp-tools.h.var
@@ -1408,6 +1408,12 @@ typedef ompt_record_ompt_t *(*ompt_get_record_ompt_t) (
   ompt_buffer_cursor_t current
 );
 
+#ifdef _WIN32
+__declspec(dllexport)
+#endif
+ompt_start_tool_result_t *ompt_start_tool(unsigned int omp_version,
+                                          const char *runtime_version);
+
 #define ompt_id_none 0
 #define ompt_data_none {0}
 #define ompt_time_none 0


### PR DESCRIPTION
The function ompt_start_tool is a globally-visible C function according to the specification.