### PR TITLE
[libc]: fix missing `linux/error-number-macros.h`

### DIFF
--- a/libc/include/CMakeLists.txt
+++ b/libc/include/CMakeLists.txt
@@ -223,6 +223,7 @@ add_gen_header(
   GEN_HDR errno.h
   DEPENDS
     .llvm-libc-macros.generic_error_number_macros
+    .llvm-libc-macros.error_number_macros
 )
 
 add_gen_header(


### PR DESCRIPTION
The headers installation previously missed platform-specific number macros, and this fixes that. From discussion on LLVM discord with `michaelrj` – ccing @michaelrj-google who hopefully is the same person 😅 

N.B. I have tested this manually in my Linux Dockerfile and it appears to do the right thing; I haven't done much more than that.