### PR TITLE
[Clang] Fix null pointer dereference in enum debug info generation

### DIFF
--- a/clang/lib/CodeGen/CGDebugInfo.cpp
+++ b/clang/lib/CodeGen/CGDebugInfo.cpp
@@ -3518,6 +3518,10 @@ llvm::DIType *CGDebugInfo::CreateTypeDefinition(const EnumType *Ty) {
 
   SmallVector<llvm::Metadata *, 16> Enumerators;
   ED = ED->getDefinition();
+
+  if (!ED)
+    return nullptr;
+
   for (const auto *Enum : ED->enumerators()) {
     Enumerators.push_back(
         DBuilder.createEnumerator(Enum->getName(), Enum->getInitVal()));

--- a/clang/test/CodeGen/debug-info-enum.cpp
+++ b/clang/test/CodeGen/debug-info-enum.cpp
@@ -98,3 +98,6 @@ enum E8 { A8 = -128, B8 = 127 } x8;
 // CHECK-NOT: DIFlagEnumClass
 // CHECK: !DIEnumerator(name: "A8", value: -128)
 
+// Forward declaration of an enum class.
+enum class Color : int;
+// CHECK-NOT: !DICompositeType(tag: DW_TAG_enumeration_type, name: "Color"


### PR DESCRIPTION
This patch prevents dereferencing a null enum definition by returning `nullptr` if `getDefinition()` fails in `CreateTypeDefinition()`.