### PR TITLE
[libc] Partially implement 'errno' on the GPU

### DIFF
--- a/libc/docs/gpu/motivation.rst
+++ b/libc/docs/gpu/motivation.rst
@@ -44,7 +44,7 @@ Limitations
 
 We only implement a subset of the standard C library. The GPU does not
 currently support thread local variables in all cases, so variables like
-``errno`` are not provided. Furthermore, the GPU under the OpenCL execution
+``errno`` are atomic and global. Furthermore, the GPU under the OpenCL execution
 model cannot safely provide a mutex interface. This means that features like
 file buffering are not implemented on the GPU. We can also not easily provide
 threading features on the GPU due to the execution model so these will be

--- a/libc/include/errno.h.def
+++ b/libc/include/errno.h.def
@@ -25,8 +25,9 @@
 #include "llvm-libc-macros/generic-error-number-macros.h"
 #endif
 
-#if !defined(__AMDGPU__) && !defined(__NVPTX__)
-
+#if defined(__AMDGPU__) || defined(__NVPTX__)
+extern int __llvmlibc_errno; // Not thread_local!
+#else
 #ifdef __cplusplus
 extern "C" {
 extern thread_local int __llvmlibc_errno;
@@ -34,8 +35,8 @@ extern thread_local int __llvmlibc_errno;
 #else
 extern _Thread_local int __llvmlibc_errno;
 #endif // __cplusplus
+#endif
 
 #define errno __llvmlibc_errno
-#endif
 
 #endif // LLVM_LIBC_ERRNO_H


### PR DESCRIPTION
Summary:
The `errno` variable is expected to be `thread_local` by the standard.
However, the GPU targets do not support `thread_local` and implementing
that would be a large endeavor. Because of that, we previously didn't
provide the `errno` symbol at all. However, to build some programs we at
least need to be able to link against `errno`. Many things that would
normally set `errno` completely ignore it currently (i.e. stdio) but
some programs still need to be able to link against correct C programs.

For this purpose this patch exports the `errno` symbol as a simple
global. Internally, this will be updated atomically so it's at least not
racy. Externally, this will be on the user. I've updated the
documentation to state as such. This is required to get `libc++` to
build.
