### PR TITLE
Fix compatibility version in test

### DIFF
--- a/clang/test/CodeGenCXX/mangle-concept.cpp
+++ b/clang/test/CodeGenCXX/mangle-concept.cpp
@@ -1,5 +1,5 @@
 // RUN: %clang_cc1 -verify -std=c++20 -emit-llvm -triple %itanium_abi_triple -o - %s -fclang-abi-compat=latest | FileCheck %s
-// RUN: %clang_cc1 -verify -std=c++20 -emit-llvm -triple %itanium_abi_triple -o - %s -fclang-abi-compat=17 | FileCheck %s --check-prefix=CLANG16
+// RUN: %clang_cc1 -verify -std=c++20 -emit-llvm -triple %itanium_abi_triple -o - %s -fclang-abi-compat=17 | FileCheck %s --check-prefix=CLANG17
 // expected-no-diagnostics
 
 namespace test1 {
@@ -8,7 +8,7 @@ template <typename> concept C = true;
 template <typename T = int> S<C<T>> f0() { return S<C<T>>{}; }
 template S<C<int>> f0<>();
 // CHECK: @_ZN5test12f0IiEENS_1SIX1CIT_EEEEv(
-// CLANG16: @_ZN5test12f0IiEENS_1SIL_ZNS_1CIT_EEEEEv(
+// CLANG17: @_ZN5test12f0IiEENS_1SIL_ZNS_1CIT_EEEEEv(
 }
 
 template <bool> struct S {};
@@ -18,12 +18,12 @@ template <typename, typename> concept D = true;
 template <typename T = int> S<test1::C<T>> f0a() { return S<C<T>>{}; }
 template S<test1::C<int>> f0a<>();
 // CHECK: @_Z3f0aIiE1SIXsr5test1E1CIT_EEEv(
-// CLANG16: @_Z3f0aIiE1SIL_ZN5test11CIT_EEEEv(
+// CLANG17: @_Z3f0aIiE1SIL_ZN5test11CIT_EEEEv(
 
 template <typename T = int> S<C<T>> f0() { return S<C<T>>{}; }
 template S<C<int>> f0<>();
 // CHECK: @_Z2f0IiE1SIX1CIT_EEEv(
-// CLANG16: @_Z2f0IiE1SIL_Z1CIT_EEEv(
+// CLANG17: @_Z2f0IiE1SIL_Z1CIT_EEEv(
 
 template<typename T> concept True = true;
 
@@ -56,25 +56,25 @@ namespace test2 {
   // CHECK-LABEL: define {{.*}}@{{.*}}test2{{.*}}use
   void use() {
     // CHECK: call {{.*}}@_ZN5test21AIiEF1fEzQ4TrueIT_E(
-    // CLANG16: call {{.*}}@_ZN5test21fEz(
+    // CLANG17: call {{.*}}@_ZN5test21fEz(
     f(ai);
     // CHECK: call {{.*}}@_ZN5test2F1gIvEEvzQaa4TrueIT_E4TrueITL0__E(
-    // CLANG16: call {{.*}}@_ZN5test21gIvEEvz(
+    // CLANG17: call {{.*}}@_ZN5test21gIvEEvz(
     g(ai);
     // CHECK: call {{.*}}@_ZN5test21hIvEEvzQ4TrueITL0__E(
-    // CLANG16: call {{.*}}@_ZN5test21hIvEEvz(
+    // CLANG17: call {{.*}}@_ZN5test21hIvEEvz(
     h(ai);
     // CHECK: call {{.*}}@_ZN5test2F1iIvQaa4TrueIT_E4TrueITL0__EEEvz(
-    // CLANG16: call {{.*}}@_ZN5test21iIvEEvz(
+    // CLANG17: call {{.*}}@_ZN5test21iIvEEvz(
     i(ai);
     // CHECK: call {{.*}}@_ZN5test21jIvQ4TrueITL0__EEEvz(
-    // CLANG16: call {{.*}}@_ZN5test21jIvEEvz(
+    // CLANG17: call {{.*}}@_ZN5test21jIvEEvz(
     j(ai);
     // CHECK: call {{.*}}@_ZN5test2F1kITk4TruevQ4TrueIT_EEEvz(
-    // CLANG16: call {{.*}}@_ZN5test21kIvEEvz(
+    // CLANG17: call {{.*}}@_ZN5test21kIvEEvz(
     k(ai);
     // CHECK: call {{.*}}@_ZN5test21lITk4TruevEEvz(
-    // CLANG16: call {{.*}}@_ZN5test21lIvEEvz(
+    // CLANG17: call {{.*}}@_ZN5test21lIvEEvz(
     l(ai);
   }
 }
@@ -84,38 +84,38 @@ namespace test3 {
   template<auto> void d() {}
   template void d<0>();
   // CHECK: define {{.*}}@_ZN5test31dITnDaLi0EEEvv(
-  // CLANG16: define {{.*}}@_ZN5test31dILi0EEEvv(
+  // CLANG17: define {{.*}}@_ZN5test31dILi0EEEvv(
 
   template<decltype(auto)> void e() {}
   template void e<0>();
   // CHECK: define {{.*}}@_ZN5test31eITnDcLi0EEEvv(
-  // CLANG16: define {{.*}}@_ZN5test31eILi0EEEvv(
+  // CLANG17: define {{.*}}@_ZN5test31eILi0EEEvv(
 
   // Constrained auto.
   template<C auto> void f() {}
   template void f<0>();
   // CHECK: define {{.*}}@_ZN5test31fITnDk1CLi0EEEvv(
-  // CLANG16: define {{.*}}@_ZN5test31fILi0EEEvv(
+  // CLANG17: define {{.*}}@_ZN5test31fILi0EEEvv(
 
   template<D<int> auto> void g() {}
   template void g<0>();
   // CHECK: define {{.*}}@_ZN5test31gITnDk1DIiELi0EEEvv(
-  // CLANG16: define {{.*}}@_ZN5test31gILi0EEEvv(
+  // CLANG17: define {{.*}}@_ZN5test31gILi0EEEvv(
 
   template<typename T, D<T> auto> void h() {}
   template void h<int, 0>();
   // CHECK: define {{.*}}@_ZN5test31hIiTnDk1DIT_ELi0EEEvv(
-  // CLANG16: define {{.*}}@_ZN5test31hIiLi0EEEvv(
+  // CLANG17: define {{.*}}@_ZN5test31hIiLi0EEEvv(
 
   template<typename T> void i(decltype(new C auto(T()))) {}
   template void i<int>(int*);
   // CHECK: define {{.*}}@_ZN5test31iIiEEvDTnw_Dk1CpicvT__EEE(
-  // CLANG16: define {{.*}}@_ZN5test31iIiEEvDTnw_DapicvT__EEE(
+  // CLANG17: define {{.*}}@_ZN5test31iIiEEvDTnw_DapicvT__EEE(
 
   template<typename T> void j(decltype(new C decltype(auto)(T()))) {}
   template void j<int>(int*);
   // CHECK: define {{.*}}@_ZN5test31jIiEEvDTnw_DK1CpicvT__EEE(
-  // CLANG16: define {{.*}}@_ZN5test31jIiEEvDTnw_DcpicvT__EEE(
+  // CLANG17: define {{.*}}@_ZN5test31jIiEEvDTnw_DcpicvT__EEE(
 }
 
 namespace test4 {
@@ -123,12 +123,12 @@ namespace test4 {
   template<C> void f() {}
   template void f<int>();
   // CHECK: define {{.*}}@_ZN5test41fITk1CiEEvv(
-  // CLANG16: define {{.*}}@_ZN5test41fIiEEvv(
+  // CLANG17: define {{.*}}@_ZN5test41fIiEEvv(
 
   template<D<int>> void g() {}
   template void g<int>();
   // CHECK: define {{.*}}@_ZN5test41gITk1DIiEiEEvv(
-  // CLANG16: define {{.*}}@_ZN5test41gIiEEvv(
+  // CLANG17: define {{.*}}@_ZN5test41gIiEEvv(
 }
 
 namespace test5 {
@@ -175,18 +175,18 @@ namespace test5 {
 
   template<template<typename ...> typename> void p() {}
   // CHECK: define {{.*}}@_ZN5test51pINS_1AEEEvv(
-  // CLANG16: define {{.*}}@_ZN5test51pINS_1AEEEvv(
+  // CLANG17: define {{.*}}@_ZN5test51pINS_1AEEEvv(
   template void p<A>();
   // CHECK: define {{.*}}@_ZN5test51pITtTpTyENS_1BEEEvv(
-  // CLANG16: define {{.*}}@_ZN5test51pINS_1BEEEvv(
+  // CLANG17: define {{.*}}@_ZN5test51pINS_1BEEEvv(
   template void p<B>();
 
   template<template<typename, typename> typename> void q() {}
   // CHECK: define {{.*}}@_ZN5test51qITtTyTyENS_1AEEEvv(
-  // CLANG16: define {{.*}}@_ZN5test51qINS_1AEEEvv(
+  // CLANG17: define {{.*}}@_ZN5test51qINS_1AEEEvv(
   template void q<A>();
   // CHECK: define {{.*}}@_ZN5test51qINS_1BEEEvv(
-  // CLANG16: define {{.*}}@_ZN5test51qINS_1BEEEvv(
+  // CLANG17: define {{.*}}@_ZN5test51qINS_1BEEEvv(
   template void q<B>();
 }
 
@@ -194,13 +194,13 @@ namespace test6 {
   // Abbreviated function templates.
   void f(C auto) {}
   // CHECK: define {{.*}}@_ZN5test61fITk1CiEEvT_(
-  // CLANG16: define {{.*}}@_ZN5test61fIiEEvT_(
+  // CLANG17: define {{.*}}@_ZN5test61fIiEEvT_(
   template void f(int);
 
   template<typename T>
   void g(D<T> auto) {}
   // CHECK: define {{.*}}@_ZN5test61gIiTk1DIT_EiEEvT0_(
-  // CLANG16: define {{.*}}@_ZN5test61gIiiEEvT0_(
+  // CLANG17: define {{.*}}@_ZN5test61gIiiEEvT0_(
   template void g<int>(int);
 }
 

--- a/clang/test/CodeGenCXX/mangle-concept.cpp
+++ b/clang/test/CodeGenCXX/mangle-concept.cpp
@@ -1,5 +1,5 @@
 // RUN: %clang_cc1 -verify -std=c++20 -emit-llvm -triple %itanium_abi_triple -o - %s -fclang-abi-compat=latest | FileCheck %s
-// RUN: %clang_cc1 -verify -std=c++20 -emit-llvm -triple %itanium_abi_triple -o - %s -fclang-abi-compat=16 | FileCheck %s --check-prefix=CLANG16
+// RUN: %clang_cc1 -verify -std=c++20 -emit-llvm -triple %itanium_abi_triple -o - %s -fclang-abi-compat=17 | FileCheck %s --check-prefix=CLANG16
 // expected-no-diagnostics
 
 namespace test1 {


### PR DESCRIPTION
The mangling compatibility being tested here changed between Clang 17 and 18, not between 16 and 17, so change the "old" version to 17.

As requested by @ahatanak in [post-commit review](https://github.com/llvm/llvm-project/commit/7421dd55a16f18919a568499e4c0888ed3a5e8b5#commitcomment-128651446).