### PR TITLE
[DomTreeUpdater] Fix use after free in unittests

### DIFF
--- a/llvm/unittests/CodeGen/MachineDomTreeUpdaterTest.cpp
+++ b/llvm/unittests/CodeGen/MachineDomTreeUpdaterTest.cpp
@@ -179,7 +179,6 @@ body:             |
   DTU.deleteBB(&*BB4);
   EXPECT_EQ(BB1->succ_size(), 1u);
   ASSERT_TRUE(DT.dominates(&*BB1, &*BB2));
-  ASSERT_EQ(DT.getNode(&*BB4), nullptr);
 }
 
 TEST_F(MachineDomTreeUpdaterTest, LazyUpdateBasicOperations) {
@@ -268,9 +267,9 @@ body:             |
   ASSERT_TRUE(DT.dominates(&*BB1, &*BB4));
   BB1->removeSuccessor(&*BB4);
   DTU.deleteBB(&*BB4);
+  ASSERT_TRUE(DTU.hasPendingDeletedBB());
   EXPECT_EQ(BB1->succ_size(), 1u);
   ASSERT_TRUE(DT.dominates(&*BB1, &*BB2));
   ASSERT_NE(DT.getNode(&*BB4), nullptr);
   DTU.flush();
-  ASSERT_EQ(DT.getNode(&*BB4), nullptr);
 }


### PR DESCRIPTION
In #96851, the unit test contains use after free, which triggers sanitizer error.
Fix https://lab.llvm.org/buildbot/#/builders/169/builds/490