### PR TITLE
[Clang][ExprConstant] fix constant expression did not evaluate to integer

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -967,7 +967,8 @@ Bug Fixes to C++ Support
 - Fixed an assertion failure about invalid conversion when calling lambda. (#GH96205).
 - Fixed a bug where the first operand of binary ``operator&`` would be transformed as if it was the operand
   of the address of operator. (#GH97483).
-- Fixed an assertion failure about constant expression did not evaluate to integer. (#GH96670).
+- Fixed an assertion failure about a constant expression which is a known integer but is not
+  evaluated to an integer. (#GH96670).
 
 Bug Fixes to AST Handling
 ^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -967,6 +967,7 @@ Bug Fixes to C++ Support
 - Fixed an assertion failure about invalid conversion when calling lambda. (#GH96205).
 - Fixed a bug where the first operand of binary ``operator&`` would be transformed as if it was the operand
   of the address of operator. (#GH97483).
+- Fixed an assertion failure about constant expression did not evaluate to integer. (#GH96670).
 
 Bug Fixes to AST Handling
 ^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/clang/lib/AST/ExprConstant.cpp
+++ b/clang/lib/AST/ExprConstant.cpp
@@ -15858,7 +15858,7 @@ static bool FastEvaluateAsRValue(const Expr *Exp, Expr::EvalResult &Result,
   }
 
   if (const auto *CE = dyn_cast<ConstantExpr>(Exp)) {
-    if (CE->hasAPValueResult()) {
+    if (CE->hasAPValueResult() && !CE->getAPValueResult().isLValue()) {
       Result.Val = CE->getAPValueResult();
       IsConst = true;
       return true;

--- a/clang/lib/AST/ExprConstant.cpp
+++ b/clang/lib/AST/ExprConstant.cpp
@@ -15858,10 +15858,13 @@ static bool FastEvaluateAsRValue(const Expr *Exp, Expr::EvalResult &Result,
   }
 
   if (const auto *CE = dyn_cast<ConstantExpr>(Exp)) {
-    if (CE->hasAPValueResult() && !CE->getAPValueResult().isLValue()) {
-      Result.Val = CE->getAPValueResult();
-      IsConst = true;
-      return true;
+    if (CE->hasAPValueResult()) {
+      APValue APV = CE->getAPValueResult();
+      if (!APV.isLValue()) {
+        Result.Val = std::move(APV);
+        IsConst = true;
+        return true;
+      }
     }
 
     // The SubExpr is usually just an IntegerLiteral.

--- a/clang/test/SemaCXX/eval-crashes.cpp
+++ b/clang/test/SemaCXX/eval-crashes.cpp
@@ -61,3 +61,13 @@ struct array {
   array() : data(*new int[1][2]) {}
 };
 }
+
+namespace GH96670 {
+inline constexpr long ullNil = -1;
+
+template<typename T = long, const T &Nil = ullNil>
+struct Test {};
+
+inline constexpr long lNil = -1;
+Test<long, lNil> c;
+}


### PR DESCRIPTION
fixes https://github.com/llvm/llvm-project/issues/96670

The cause is that we might return a lvalue here at

https://github.com/llvm/llvm-project/blob/3e53c97d33210db68188e731e93ee48dbaeeae32/clang/lib/AST/ExprConstant.cpp#L15861-L15865

This PR will make sure we return a rvalue in `FastEvaluateAsRValue`.