### PR TITLE
[llvm][utils] Avoid 'raw_string_ostream::str()' (NFC)

### DIFF
--- a/llvm/utils/FileCheck/FileCheck.cpp
+++ b/llvm/utils/FileCheck/FileCheck.cpp
@@ -641,7 +641,7 @@ static void DumpAnnotatedInput(raw_ostream &OS, const FileCheckRequest &Req,
       LineOS = &ElidedLinesOS;
     else {
       LineOS = &OS;
-      DumpEllipsisOrElidedLines(OS, ElidedLinesOS.str(), LabelWidth);
+      DumpEllipsisOrElidedLines(OS, ElidedLines, LabelWidth);
     }
 
     // Print right-aligned line number.
@@ -723,7 +723,7 @@ static void DumpAnnotatedInput(raw_ostream &OS, const FileCheckRequest &Req,
       ++AnnotationItr;
     }
   }
-  DumpEllipsisOrElidedLines(OS, ElidedLinesOS.str(), LabelWidth);
+  DumpEllipsisOrElidedLines(OS, ElidedLines, LabelWidth);
 
   OS << ">>>>>>\n";
 }

--- a/llvm/utils/TableGen/AsmMatcherEmitter.cpp
+++ b/llvm/utils/TableGen/AsmMatcherEmitter.cpp
@@ -2367,10 +2367,10 @@ emitConvertFuncs(CodeGenTarget &Target, StringRef ClassName,
   OS << "};\n\n";
 
   // Spit out the conversion driver function.
-  OS << CvtOS.str();
+  OS << ConvertFnBody;
 
   // Spit out the operand number lookup function.
-  OS << OpOS.str();
+  OS << OperandFnBody;
 
   return ConversionTable.size();
 }

--- a/llvm/utils/TableGen/AsmWriterEmitter.cpp
+++ b/llvm/utils/TableGen/AsmWriterEmitter.cpp
@@ -1162,8 +1162,8 @@ void AsmWriterEmitter::EmitPrintAliasInstruction(raw_ostream &O) {
                        PatternCount - PatternStart);
   }
 
-  if (OpcodeO.str().empty()) {
-    O << HeaderO.str();
+  if (PatternsForOpcode.empty()) {
+    O << Header;
     O << "  return false;\n";
     O << "}\n\n";
     O << "#endif // PRINT_ALIAS_INSTR\n";
@@ -1177,15 +1177,15 @@ void AsmWriterEmitter::EmitPrintAliasInstruction(raw_ostream &O) {
       << "                  const MCSubtargetInfo &STI,\n"
       << "                  unsigned PredicateIndex);\n";
 
-  O << HeaderO.str();
+  O << Header;
   O.indent(2) << "static const PatternsForOpcode OpToPatterns[] = {\n";
-  O << OpcodeO.str();
+  O << PatternsForOpcode;
   O.indent(2) << "};\n\n";
   O.indent(2) << "static const AliasPattern Patterns[] = {\n";
-  O << PatternO.str();
+  O << Patterns;
   O.indent(2) << "};\n\n";
   O.indent(2) << "static const AliasPatternCond Conds[] = {\n";
-  O << CondO.str();
+  O << Conds;
   O.indent(2) << "};\n\n";
   O.indent(2) << "static const char AsmStrings[] =\n";
   for (const auto &P : AsmStrings) {

--- a/llvm/utils/TableGen/Common/VarLenCodeEmitterGen.cpp
+++ b/llvm/utils/TableGen/Common/VarLenCodeEmitterGen.cpp
@@ -405,7 +405,7 @@ void VarLenCodeEmitterGen::emitInstructionBaseValues(
   IS.indent(4) << "{/*NumBits*/0, /*Index*/0}\n  };\n";
   SS.indent(4) << "UINT64_C(0)\n  };\n";
 
-  OS << IS.str() << SS.str();
+  OS << IndexArray << StorageArray;
 }
 
 std::string VarLenCodeEmitterGen::getInstructionCases(Record *R,


### PR DESCRIPTION
Since `raw_string_ostream` doesn't own the string buffer, it is desirable (in terms of memory safety) for users to directly reference the string buffer rather than use `raw_string_ostream::str()`.

Work towards TODO comment to remove `raw_string_ostream::str()`.