### PR TITLE
[llvm] Use std::make_unique (NFC)

### DIFF
--- a/llvm/include/llvm/BinaryFormat/MsgPackDocument.h
+++ b/llvm/include/llvm/BinaryFormat/MsgPackDocument.h
@@ -388,7 +388,7 @@ public:
   /// Create an empty Map node associated with this Document.
   MapDocNode getMapNode() {
     auto N = DocNode(&KindAndDocs[size_t(Type::Map)]);
-    Maps.push_back(std::unique_ptr<DocNode::MapTy>(new DocNode::MapTy));
+    Maps.push_back(std::make_unique<DocNode::MapTy>());
     N.Map = Maps.back().get();
     return N.getMap();
   }
@@ -396,7 +396,7 @@ public:
   /// Create an empty Array node associated with this Document.
   ArrayDocNode getArrayNode() {
     auto N = DocNode(&KindAndDocs[size_t(Type::Array)]);
-    Arrays.push_back(std::unique_ptr<DocNode::ArrayTy>(new DocNode::ArrayTy));
+    Arrays.push_back(std::make_unique<DocNode::ArrayTy>());
     N.Array = Arrays.back().get();
     return N.getArray();
   }

--- a/llvm/lib/DebugInfo/PDB/Native/SymbolCache.cpp
+++ b/llvm/lib/DebugInfo/PDB/Native/SymbolCache.cpp
@@ -618,8 +618,7 @@ SymbolCache::getSourceFileById(SymIndexId FileId) const {
   if (FileId == 0)
     return nullptr;
 
-  return std::unique_ptr<NativeSourceFile>(
-      new NativeSourceFile(*SourceFiles[FileId].get()));
+  return std::make_unique<NativeSourceFile>(*SourceFiles[FileId].get());
 }
 
 SymIndexId

--- a/llvm/lib/ExecutionEngine/Orc/Layer.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/Layer.cpp
@@ -200,9 +200,8 @@ BasicObjectLayerMaterializationUnit::Create(ObjectLayer &L,
   if (!ObjInterface)
     return ObjInterface.takeError();
 
-  return std::unique_ptr<BasicObjectLayerMaterializationUnit>(
-      new BasicObjectLayerMaterializationUnit(L, std::move(O),
-                                              std::move(*ObjInterface)));
+  return std::make_unique<BasicObjectLayerMaterializationUnit>(
+      L, std::move(O), std::move(*ObjInterface));
 }
 
 BasicObjectLayerMaterializationUnit::BasicObjectLayerMaterializationUnit(

--- a/llvm/lib/Object/TapiUniversal.cpp
+++ b/llvm/lib/Object/TapiUniversal.cpp
@@ -47,9 +47,9 @@ TapiUniversal::~TapiUniversal() = default;
 
 Expected<std::unique_ptr<TapiFile>>
 TapiUniversal::ObjectForArch::getAsObjectFile() const {
-  return std::unique_ptr<TapiFile>(new TapiFile(Parent->getMemoryBufferRef(),
-                                                *Parent->ParsedFile,
-                                                Parent->Libraries[Index].Arch));
+  return std::make_unique<TapiFile>(Parent->getMemoryBufferRef(),
+                                    *Parent->ParsedFile,
+                                    Parent->Libraries[Index].Arch);
 }
 
 Expected<std::unique_ptr<TapiUniversal>>

--- a/llvm/lib/Target/ARM/ARMBlockPlacement.cpp
+++ b/llvm/lib/Target/ARM/ARMBlockPlacement.cpp
@@ -219,7 +219,7 @@ bool ARMBlockPlacement::runOnMachineFunction(MachineFunction &MF) {
   LLVM_DEBUG(dbgs() << DEBUG_PREFIX << "Running on " << MF.getName() << "\n");
   MLI = &getAnalysis<MachineLoopInfo>();
   TII = static_cast<const ARMBaseInstrInfo *>(ST.getInstrInfo());
-  BBUtils = std::unique_ptr<ARMBasicBlockUtils>(new ARMBasicBlockUtils(MF));
+  BBUtils = std::make_unique<ARMBasicBlockUtils>(MF);
   MF.RenumberBlocks();
   BBUtils->computeAllBlockSizes();
   BBUtils->adjustBBOffsetsAfter(&MF.front());

--- a/llvm/lib/Target/ARM/ARMConstantIslandPass.cpp
+++ b/llvm/lib/Target/ARM/ARMConstantIslandPass.cpp
@@ -388,7 +388,7 @@ static bool AlignBlocks(MachineFunction *MF, const ARMSubtarget *STI) {
 bool ARMConstantIslands::runOnMachineFunction(MachineFunction &mf) {
   MF = &mf;
   MCP = mf.getConstantPool();
-  BBUtils = std::unique_ptr<ARMBasicBlockUtils>(new ARMBasicBlockUtils(mf));
+  BBUtils = std::make_unique<ARMBasicBlockUtils>(mf);
 
   LLVM_DEBUG(dbgs() << "***** ARMConstantIslands: "
                     << MCP->getConstants().size() << " CP entries, aligned to "

--- a/llvm/lib/Target/ARM/ARMLowOverheadLoops.cpp
+++ b/llvm/lib/Target/ARM/ARMLowOverheadLoops.cpp
@@ -1301,7 +1301,7 @@ bool ARMLowOverheadLoops::runOnMachineFunction(MachineFunction &mf) {
   MRI = &MF->getRegInfo();
   TII = static_cast<const ARMBaseInstrInfo*>(ST.getInstrInfo());
   TRI = ST.getRegisterInfo();
-  BBUtils = std::unique_ptr<ARMBasicBlockUtils>(new ARMBasicBlockUtils(*MF));
+  BBUtils = std::make_unique<ARMBasicBlockUtils>(*MF);
   BBUtils->computeAllBlockSizes();
   BBUtils->adjustBBOffsetsAfter(&MF->front());
 

--- a/llvm/lib/XRay/Profile.cpp
+++ b/llvm/lib/XRay/Profile.cpp
@@ -202,7 +202,7 @@ Profile mergeProfilesByThread(const Profile &L, const Profile &R) {
     for (const auto &Block : P.get()) {
       ThreadProfileIndexMap::iterator It;
       std::tie(It, std::ignore) = ThreadProfileIndex.insert(
-          {Block.Thread, PathDataMapPtr{new PathDataMap()}});
+          {Block.Thread, std::make_unique<PathDataMap>()});
       for (const auto &PathAndData : Block.PathData) {
         auto &PathID = PathAndData.first;
         auto &Data = PathAndData.second;

--- a/llvm/tools/lli/ForwardingMemoryManager.h
+++ b/llvm/tools/lli/ForwardingMemoryManager.h
@@ -98,8 +98,8 @@ public:
     auto H = DylibMgr->open("", 0);
     if (!H)
       return H.takeError();
-    return std::unique_ptr<RemoteResolver>(
-        new RemoteResolver(std::move(*DylibMgr), std::move(*H)));
+    return std::make_unique<RemoteResolver>(std::move(*DylibMgr),
+                                            std::move(*H));
   }
 
   JITSymbol findSymbol(const std::string &Name) override {

--- a/llvm/tools/sancov/sancov.cpp
+++ b/llvm/tools/sancov/sancov.cpp
@@ -262,7 +262,7 @@ RawCoverage::read(const std::string &FileName) {
   // to compactify the data.
   Addrs->erase(0);
 
-  return std::unique_ptr<RawCoverage>(new RawCoverage(std::move(Addrs)));
+  return std::make_unique<RawCoverage>(std::move(Addrs));
 }
 
 // Print coverage addresses.
@@ -460,8 +460,7 @@ static std::unique_ptr<symbolize::LLVMSymbolizer> createSymbolizer() {
   symbolize::LLVMSymbolizer::Options SymbolizerOptions;
   SymbolizerOptions.Demangle = ClDemangle;
   SymbolizerOptions.UseSymbolTable = true;
-  return std::unique_ptr<symbolize::LLVMSymbolizer>(
-      new symbolize::LLVMSymbolizer(SymbolizerOptions));
+  return std::make_unique<symbolize::LLVMSymbolizer>(SymbolizerOptions);
 }
 
 static std::string normalizeFilename(const std::string &FileName) {

--- a/llvm/unittests/Support/ErrorOrTest.cpp
+++ b/llvm/unittests/Support/ErrorOrTest.cpp
@@ -36,9 +36,7 @@ TEST(ErrorOr, SimpleValue) {
 #endif
 }
 
-ErrorOr<std::unique_ptr<int> > t3() {
-  return std::unique_ptr<int>(new int(3));
-}
+ErrorOr<std::unique_ptr<int>> t3() { return std::make_unique<int>(3); }
 
 TEST(ErrorOr, Types) {
   int x;


### PR DESCRIPTION
This patch is based on clang-tidy's modernize-make-unique but limited
to those cases where type names are mentioned twice like
std::unique_ptr<Type>(new Type()), which is a bit mouthful.
