### PR TITLE
[clang] Use std::make_unique (NFC)

### DIFF
--- a/clang/lib/CodeGen/CGCoroutine.cpp
+++ b/clang/lib/CodeGen/CGCoroutine.cpp
@@ -103,7 +103,7 @@ static void createCoroData(CodeGenFunction &CGF,
     return;
   }
 
-  CurCoro.Data = std::unique_ptr<CGCoroData>(new CGCoroData);
+  CurCoro.Data = std::make_unique<CGCoroData>();
   CurCoro.Data->CoroId = CoroId;
   CurCoro.Data->CoroIdExpr = CoroIdExpr;
 }

--- a/clang/lib/Interpreter/CodeCompletion.cpp
+++ b/clang/lib/Interpreter/CodeCompletion.cpp
@@ -368,8 +368,7 @@ void ReplCodeCompleter::codeComplete(CompilerInstance *InterpCI,
   llvm::SmallVector<const llvm::MemoryBuffer *, 1> tb = {};
   InterpCI->getFrontendOpts().Inputs[0] = FrontendInputFile(
       CodeCompletionFileName, Language::CXX, InputKind::Source);
-  auto Act = std::unique_ptr<IncrementalSyntaxOnlyAction>(
-      new IncrementalSyntaxOnlyAction(ParentCI));
+  auto Act = std::make_unique<IncrementalSyntaxOnlyAction>(ParentCI);
   std::unique_ptr<llvm::MemoryBuffer> MB =
       llvm::MemoryBuffer::getMemBufferCopy(Content, CodeCompletionFileName);
   llvm::SmallVector<ASTUnit::RemappedFile, 4> RemappedFiles;


### PR DESCRIPTION
This patch is based on clang-tidy's modernize-make-unique but limited
to those cases where type names are mentioned twice like
`std::unique_ptr<Type>(new Type())`, which is a bit mouthful.
