### PR TITLE
[CodeGen] Use a range-based for loop (NFC)

### DIFF
--- a/llvm/lib/CodeGen/RegAllocBase.cpp
+++ b/llvm/lib/CodeGen/RegAllocBase.cpp
@@ -116,11 +116,8 @@ void RegAllocBase::allocatePhysRegs() {
       // selectOrSplit failed to find a register!
       // Probably caused by an inline asm.
       MachineInstr *MI = nullptr;
-      for (MachineRegisterInfo::reg_instr_iterator
-               I = MRI->reg_instr_begin(VirtReg->reg()),
-               E = MRI->reg_instr_end();
-           I != E;) {
-        MI = &*(I++);
+      for (MachineInstr &MIR : MRI->reg_instructions(VirtReg->reg())) {
+        MI = &MIR;
         if (MI->isInlineAsm())
           break;
       }


### PR DESCRIPTION
I++ in the loop might appear to indicate that the loop modifies the
container in some way (deletion or insertion), but the loop just
examines the container.
