### PR TITLE
[libc][math][c23] Temporarily disable f16div{l,f128} on AArch64

### DIFF
--- a/libc/config/linux/aarch64/entrypoints.txt
+++ b/libc/config/linux/aarch64/entrypoints.txt
@@ -509,7 +509,6 @@ if(LIBC_TYPES_HAS_FLOAT16)
     libc.src.math.copysignf16
     libc.src.math.f16div
     libc.src.math.f16divf
-    libc.src.math.f16divl
     libc.src.math.f16fmaf
     libc.src.math.f16sqrtf
     libc.src.math.fabsf16
@@ -562,13 +561,6 @@ if(LIBC_TYPES_HAS_FLOAT16)
     libc.src.math.ufromfpf16
     libc.src.math.ufromfpxf16
   )
-
-  if(LIBC_TYPES_HAS_FLOAT128)
-    list(APPEND TARGET_LIBM_ENTRYPOINTS
-      # math.h C23 mixed _Float16 and _Float128 entrypoints
-      libc.src.math.f16divf128
-    )
-  endif()
 endif()
 
 if(LIBC_TYPES_HAS_FLOAT128)


### PR DESCRIPTION
Due to Clang 11 backend error ("Unsupported library call operation!").

See Buildbot failures:

- https://lab.llvm.org/buildbot/#/builders/104/builds/1105
- https://lab.llvm.org/buildbot/#/builders/71/builds/1100
