### PR TITLE
[compiler-rt] Replace direct calls to pipe with internal_pipe

### DIFF
--- a/compiler-rt/lib/sanitizer_common/sanitizer_linux.cpp
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_linux.cpp
@@ -847,6 +847,10 @@ uptr internal_lseek(fd_t fd, OFF_T offset, int whence) {
   return internal_syscall(SYSCALL(lseek), fd, offset, whence);
 }
 
+uptr internal_pipe(fd_t pipefd[2]) {
+  return internal_syscall(SYSCALL(pipe), pipefd);
+}
+
 #    if SANITIZER_LINUX
 uptr internal_prctl(int option, uptr arg2, uptr arg3, uptr arg4, uptr arg5) {
   return internal_syscall(SYSCALL(prctl), option, arg2, arg3, arg4, arg5);

--- a/compiler-rt/lib/sanitizer_common/sanitizer_mac.cpp
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_mac.cpp
@@ -213,6 +213,8 @@ uptr internal_unlink(const char *path) {
   return unlink(path);
 }
 
+uptr internal_pipe(fd_t fildes[2]) { return pipe(fildes); }
+
 uptr internal_sched_yield() {
   return sched_yield();
 }

--- a/compiler-rt/lib/sanitizer_common/sanitizer_netbsd.cpp
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_netbsd.cpp
@@ -204,6 +204,11 @@ uptr internal_rename(const char *oldpath, const char *newpath) {
   return _REAL(rename, oldpath, newpath);
 }
 
+uptr internal_pipe(fd_t fildes[2]) {
+  DEFINE__REAL(int, pipe, int a[2]);
+  return _REAL(pipe, fildes);
+}
+
 uptr internal_sched_yield() {
   CHECK(&_sys_sched_yield);
   return _sys_sched_yield();

--- a/compiler-rt/lib/sanitizer_common/sanitizer_posix.h
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_posix.h
@@ -56,7 +56,9 @@ uptr internal_unlink(const char *path);
 uptr internal_rename(const char *oldpath, const char *newpath);
 uptr internal_lseek(fd_t fd, OFF_T offset, int whence);
 
-#if SANITIZER_NETBSD
+uptr internal_pipe(fd_t pipefd[2]);
+
+#  if SANITIZER_NETBSD
 uptr internal_ptrace(int request, int pid, void *addr, int data);
 #else
 uptr internal_ptrace(int request, int pid, void *addr, void *data);

--- a/compiler-rt/lib/sanitizer_common/sanitizer_posix_libcdep.cpp
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_posix_libcdep.cpp
@@ -302,7 +302,7 @@ bool IsAccessibleMemoryRange(uptr beg, uptr size) {
     // `read` from `fds[0]` into a dummy buffer to free up the pipe buffer for
     // more `write` is slower than just recreating a pipe.
     int fds[2];
-    CHECK_EQ(0, pipe(fds));
+    CHECK_EQ(0, internal_pipe(fds));
 
     auto cleanup = at_scope_exit([&]() {
       internal_close(fds[0]);
@@ -330,7 +330,7 @@ bool TryMemCpy(void *dest, const void *src, uptr n) {
   if (!n)
     return true;
   int fds[2];
-  CHECK_EQ(0, pipe(fds));
+  CHECK_EQ(0, internal_pipe(fds));
 
   auto cleanup = at_scope_exit([&]() {
     internal_close(fds[0]);

--- a/compiler-rt/test/tsan/pipe.cpp
+++ b/compiler-rt/test/tsan/pipe.cpp
@@ -1,0 +1,30 @@
+// RUN: %clangxx_tsan -fsanitize=undefined -O1 %s -o %t && %run %t 2>&1 | FileCheck %s
+
+#include <iostream>
+#include <thread>
+
+class Foo {
+public:
+  void produce(int) {}
+  void consume() {}
+
+  void run() {
+    w1_ = std::thread{&Foo::produce, this, 0};
+    w2_ = std::thread{&Foo::consume, this};
+    w1_.join();
+    w2_.join();
+  }
+
+private:
+  std::thread w1_;
+  std::thread w2_;
+};
+
+int main() {
+  Foo f;
+  f.run();
+  std::cerr << "Pass\n";
+  // CHECK-NOT: data race
+  // CHECK: Pass
+  return 0;
+}


### PR DESCRIPTION
This PR tries to resolve google/sanitizers#1106 by introducing a new `internal_pipe` function which will not be intercepted by TSAN.