### PR TITLE
[llvm-strip] Remove empty SHT_GROUP sections.

### DIFF
--- a/llvm/lib/ObjCopy/ELF/ELFObject.cpp
+++ b/llvm/lib/ObjCopy/ELF/ELFObject.cpp
@@ -2206,8 +2206,15 @@ Error Object::removeSections(
   // Transfer removed sections into the Object RemovedSections container for use
   // later.
   std::move(Iter, Sections.end(), std::back_inserter(RemovedSections));
-  // Now finally get rid of them all together.
+  // Now get rid of them all together.
   Sections.erase(Iter, std::end(Sections));
+
+  // Finally iterate over all sections and erase empty SHT_GROUP sections.
+  for (auto Iter = Sections.begin(); Iter != Sections.end(); ++Iter)
+    if (auto GroupSec = dyn_cast<GroupSection>(Iter->get()))
+      if (GroupSec->getMembersCount() == 0)
+        Sections.erase(Iter);
+
   return Error::success();
 }
 

--- a/llvm/lib/ObjCopy/ELF/ELFObject.h
+++ b/llvm/lib/ObjCopy/ELF/ELFObject.h
@@ -963,6 +963,8 @@ public:
       const DenseMap<SectionBase *, SectionBase *> &FromTo) override;
   void onRemove() override;
 
+  size_t getMembersCount() { return GroupMembers.size(); }
+
   static bool classof(const SectionBase *S) {
     return S->OriginalType == ELF::SHT_GROUP;
   }

--- a/llvm/test/tools/llvm-objcopy/ELF/strip-debug-empty-group.test
+++ b/llvm/test/tools/llvm-objcopy/ELF/strip-debug-empty-group.test
@@ -1,0 +1,31 @@
+# RUN: yaml2obj %s -o %t
+# RUN: llvm-strip --strip-debug %t -o %t1
+# RUN: llvm-readelf --section-groups %t1 | FileCheck %s
+# RUN: llvm-strip --strip-unneeded %t -o %t2
+# RUN: llvm-readelf --section-groups %t2 | FileCheck %s
+# RUN: llvm-strip --remove-section=.debug_macro %t -o %t3
+# RUN: llvm-readelf --section-groups %t3 | FileCheck %s
+# RUN: llvm-strip --remove-section=.debug_* %t -o %t4
+# RUN: llvm-readelf --section-groups %t4 | FileCheck %s
+
+--- !ELF
+FileHeader:
+  Class:      ELFCLASS64
+  Data:       ELFDATA2LSB
+  Type:       ET_REL
+  Machine:    EM_X86_64
+Sections:
+  - Name:     .group
+    Type:     SHT_GROUP
+    Info:     foo_grp
+    Members:
+      - SectionOrType:  GRP_COMDAT
+      - SectionOrType:  .debug_macro
+  - Name:     .debug_macro
+    Type:     SHT_PROGBITS
+    Flags:    [ SHF_GROUP ]
+Symbols:
+  - Name:     foo_grp
+    Section:  .group
+
+# CHECK: There are no section groups in this file.


### PR DESCRIPTION
Currently llvm-strip in --strip-debug mode doesn't remove such sections. This behavior can lead to incompatibilities with GNU binutils (for examples ld.bfd cannot process the object file contains empty .group section). The ELF object that contains group section
with .debug_* sections inside can be obtained by gcc -g3. Fix #97139