### PR TITLE
[MachineDominator] Align with IR version

### DIFF
--- a/llvm/include/llvm/CodeGen/MachineDominators.h
+++ b/llvm/include/llvm/CodeGen/MachineDominators.h
@@ -286,9 +286,10 @@ class MachineDominatorTreePrinterPass
   raw_ostream &OS;
 
 public:
-  MachineDominatorTreePrinterPass(raw_ostream &OS) : OS(OS) {}
+  explicit MachineDominatorTreePrinterPass(raw_ostream &OS) : OS(OS) {}
   PreservedAnalyses run(MachineFunction &MF,
                         MachineFunctionAnalysisManager &MFAM);
+  static bool isRequired() { return true; }
 };
 
 /// \brief Analysis pass which computes a \c MachineDominatorTree.

--- a/llvm/include/llvm/CodeGen/MachinePostDominators.h
+++ b/llvm/include/llvm/CodeGen/MachinePostDominators.h
@@ -81,9 +81,10 @@ class MachinePostDominatorTreePrinterPass
   raw_ostream &OS;
 
 public:
-  MachinePostDominatorTreePrinterPass(raw_ostream &OS) : OS(OS) {}
+  explicit MachinePostDominatorTreePrinterPass(raw_ostream &OS) : OS(OS) {}
   PreservedAnalyses run(MachineFunction &MF,
                         MachineFunctionAnalysisManager &MFAM);
+  static bool isRequired() { return true; }
 };
 
 class MachinePostDominatorTreeWrapperPass : public MachineFunctionPass {


### PR DESCRIPTION
- Mark constructor explicit.
- Provide `isRequired`.