### PR TITLE
[libc++] Use GCC compilers from compiler explorer

### DIFF
--- a/libcxx/utils/ci/Dockerfile
+++ b/libcxx/utils/ci/Dockerfile
@@ -99,8 +99,8 @@ RUN sudo apt-get update \
         unzip \
         uuid-dev \
         wget \
+        xz-utils \
     && sudo rm -rf /var/lib/apt/lists/*
-
 
 # Install various tools used by the build or the test suite
 #RUN apt-get update && apt-get install -y ninja-build python3 python3-distutils python3-psutil git gdb ccache
@@ -142,13 +142,15 @@ EOF
 
 # Install the most recent GCC, like clang install the previous version as a transition.
 RUN <<EOF
-  sudo apt-get update
-  sudo apt-get install -y \
-    gcc-$((GCC_LATEST_VERSION - 1)) \
-    g++-$((GCC_LATEST_VERSION - 1)) \
-    gcc-$GCC_LATEST_VERSION \
-    g++-$GCC_LATEST_VERSION
-  sudo rm -rf /var/lib/apt/lists/*
+  sudo git clone https://github.com/compiler-explorer/infra.git /tmp/ce-infra
+  (cd /tmp/ce-infra && sudo make ce)
+  sudo /tmp/ce-infra/bin/ce_install install compilers/c++/x86/gcc $GCC_LATEST_VERSION.1.0
+  sudo /tmp/ce-infra/bin/ce_install install compilers/c++/x86/gcc $((GCC_LATEST_VERSION - 1)).1.0
+  sudo ln -s /opt/compiler-explorer/gcc-$GCC_LATEST_VERSION.1.0/bin/gcc /usr/bin/gcc-$GCC_LATEST_VERSION
+  sudo ln -s /opt/compiler-explorer/gcc-$GCC_LATEST_VERSION.1.0/bin/g++ /usr/bin/g++-$GCC_LATEST_VERSION
+  sudo ln -s /opt/compiler-explorer/gcc-$((GCC_LATEST_VERSION - 1)).1.0/bin/gcc /usr/bin/gcc-$((GCC_LATEST_VERSION - 1))
+  sudo ln -s /opt/compiler-explorer/gcc-$((GCC_LATEST_VERSION - 1)).1.0/bin/g++ /usr/bin/g++-$((GCC_LATEST_VERSION - 1))
+  sudo rm -rf /tmp/ce-infra
 EOF
 
 RUN <<EOF


### PR DESCRIPTION
This avoids the very recent system requirements for new GCC versions, making it a lot easier to update GCC in a timely manner.

