### PR TITLE
[Clang] Prevent null pointer dereference in designated initializer check

### DIFF
--- a/clang/lib/Sema/SemaExprObjC.cpp
+++ b/clang/lib/Sema/SemaExprObjC.cpp
@@ -3207,8 +3207,7 @@ ExprResult SemaObjC::BuildInstanceMessage(
     if (!isDesignatedInitChain) {
       const ObjCMethodDecl *InitMethod = nullptr;
       auto *CurMD = SemaRef.getCurMethodDecl();
-      if (!CurMD)
-        return ExprResult((Expr *)nullptr);
+      assert(CurMD && "Current method declaration should not be null");
       bool isDesignated =
           CurMD->isDesignatedInitializerForTheInterface(&InitMethod);
       assert(isDesignated && InitMethod);

--- a/clang/lib/Sema/SemaExprObjC.cpp
+++ b/clang/lib/Sema/SemaExprObjC.cpp
@@ -3208,7 +3208,7 @@ ExprResult SemaObjC::BuildInstanceMessage(
       const ObjCMethodDecl *InitMethod = nullptr;
       auto *CurMD = SemaRef.getCurMethodDecl();
       if (!CurMD)
-        return ExprResult((Expr*)nullptr);
+        return ExprResult((Expr *)nullptr);
       bool isDesignated =
           CurMD->isDesignatedInitializerForTheInterface(&InitMethod);
       assert(isDesignated && InitMethod);

--- a/clang/lib/Sema/SemaExprObjC.cpp
+++ b/clang/lib/Sema/SemaExprObjC.cpp
@@ -3208,7 +3208,7 @@ ExprResult SemaObjC::BuildInstanceMessage(
       const ObjCMethodDecl *InitMethod = nullptr;
       auto *CurMD = SemaRef.getCurMethodDecl();
       if (!CurMD)
-        return nullptr;
+        return ExprResult((Expr*)nullptr);
       bool isDesignated =
           CurMD->isDesignatedInitializerForTheInterface(&InitMethod);
       assert(isDesignated && InitMethod);

--- a/clang/lib/Sema/SemaExprObjC.cpp
+++ b/clang/lib/Sema/SemaExprObjC.cpp
@@ -3206,9 +3206,11 @@ ExprResult SemaObjC::BuildInstanceMessage(
     }
     if (!isDesignatedInitChain) {
       const ObjCMethodDecl *InitMethod = nullptr;
+      auto *CurMD = SemaRef.getCurMethodDecl();
+      if (!CurMD)
+        return nullptr;
       bool isDesignated =
-          SemaRef.getCurMethodDecl()->isDesignatedInitializerForTheInterface(
-              &InitMethod);
+          CurMD->isDesignatedInitializerForTheInterface(&InitMethod);
       assert(isDesignated && InitMethod);
       (void)isDesignated;
       Diag(SelLoc, SuperLoc.isValid() ?


### PR DESCRIPTION
This patch adds an assertion in clang::SemaObjC::BuildInstanceMessage() to ensure getCurMethodDecl() returns a valid method declaration, addressing a static analyzer finding.