### PR TITLE
[Serialization] Clear moved-from deque to ensure valid state post-move

### DIFF
--- a/clang/lib/Serialization/ASTReaderDecl.cpp
+++ b/clang/lib/Serialization/ASTReaderDecl.cpp
@@ -4215,6 +4215,7 @@ void ASTReader::PassInterestingDeclsToConsumer() {
   };
   std::deque<Decl *> MaybeInterestingDecls =
       std::move(PotentiallyInterestingDecls);
+  PotentiallyInterestingDecls.clear();
   assert(PotentiallyInterestingDecls.empty());
   while (!MaybeInterestingDecls.empty()) {
     Decl *D = MaybeInterestingDecls.front();


### PR DESCRIPTION
This patch addresses a use-after-move issue, reported by static analyzer tool, by clearing the `PotentiallyInterestingDecls` deque after it has been moved to `MaybeInterestingDecls`.

The fix ensures that the subsequent assert statement correctly checks for an empty state, preventing any undefined behavior in ASTReader::PassInterestingDeclsToConsumer().