### PR TITLE
[mlir][sroa] Update name of subelement types in destructurable slots

### DIFF
--- a/mlir/include/mlir/Interfaces/MemorySlotInterfaces.h
+++ b/mlir/include/mlir/Interfaces/MemorySlotInterfaces.h
@@ -27,7 +27,7 @@ struct MemorySlot {
 /// Memory slot attached with information about its destructuring procedure.
 struct DestructurableMemorySlot : public MemorySlot {
   /// Maps an index within the memory slot to the corresponding subelement type.
-  DenseMap<Attribute, Type> elementPtrs;
+  DenseMap<Attribute, Type> subelementTypes;
 };
 
 /// Returned by operation promotion logic requesting the deletion of an

--- a/mlir/lib/Dialect/MemRef/IR/MemRefMemorySlot.cpp
+++ b/mlir/lib/Dialect/MemRef/IR/MemRefMemorySlot.cpp
@@ -277,7 +277,7 @@ bool memref::StoreOp::canRewire(const DestructurableMemorySlot &slot,
     return false;
   Attribute index = getAttributeIndexFromIndexOperands(
       getContext(), getIndices(), getMemRefType());
-  if (!index || !slot.elementPtrs.contains(index))
+  if (!index || !slot.subelementTypes.contains(index))
     return false;
   usedIndices.insert(index);
   return true;

--- a/mlir/lib/Transforms/SROA.cpp
+++ b/mlir/lib/Transforms/SROA.cpp
@@ -146,11 +146,11 @@ static void destructureSlot(
       allocator.destructure(slot, info.usedIndices, builder, newAllocators);
 
   if (statistics.slotsWithMemoryBenefit &&
-      slot.elementPtrs.size() != info.usedIndices.size())
+      slot.subelementTypes.size() != info.usedIndices.size())
     (*statistics.slotsWithMemoryBenefit)++;
 
   if (statistics.maxSubelementAmount)
-    statistics.maxSubelementAmount->updateMax(slot.elementPtrs.size());
+    statistics.maxSubelementAmount->updateMax(slot.subelementTypes.size());
 
   SetVector<Operation *> usersToRewire;
   for (Operation *user : llvm::make_first_range(info.userToBlockingUses))

--- a/mlir/test/lib/Dialect/Test/TestOpDefs.cpp
+++ b/mlir/test/lib/Dialect/Test/TestOpDefs.cpp
@@ -1321,7 +1321,7 @@ DenseMap<Attribute, MemorySlot> TestMultiSlotAlloca::destructure(
   DenseMap<Attribute, MemorySlot> slotMap;
 
   for (Attribute usedIndex : usedIndices) {
-    Type elemType = slot.elementPtrs.lookup(usedIndex);
+    Type elemType = slot.subelementTypes.lookup(usedIndex);
     MemRefType elemPtr = MemRefType::get({}, elemType);
     auto subAlloca = builder.create<TestMultiSlotAlloca>(getLoc(), elemPtr);
     newAllocators.push_back(subAlloca);


### PR DESCRIPTION
The `elementPtrs` has changed meaning over time and the name is now outdated which may be confusing. This PR updates it to a name representative of current usage.