### PR TITLE
[Test][compiler-rt]Require lld for instrprof-vtable-value-prof.cpp

### DIFF
--- a/compiler-rt/test/profile/Linux/instrprof-vtable-value-prof.cpp
+++ b/compiler-rt/test/profile/Linux/instrprof-vtable-value-prof.cpp
@@ -1,4 +1,4 @@
-// REQUIRES: lld-available
+// REQUIRES: lld, lld-available
 
 // Building the instrumented binary will fail because lld doesn't support
 // big-endian ELF for PPC (aka ABI 1).


### PR DESCRIPTION
Fix test failure on https://lab.llvm.org/buildbot/#/builders/95/builds/672
* lld project is disabled on that build bot [1] and external lld `/home/buildbots/llvm-external-buildbots/clang.16.0.1/bin/ld.lld` is used to run the test  [2]. It doesn't know new options like `-enable-vtable-value-profiling` (which was introduced in https://github.com/llvm/llvm-project/commit/1351d17826e1efa3da3b29b6e345d44cb0ce3bc9)
* Update test to require `lld` and `lld-available`.

Tested:
1. By disabling lld in the project and using old `lld` installed previously[3], I can reproduce the failure.
2. With `requires: lld`, the test become unsupported.

[1] https://lab.llvm.org/buildbot/#/builders/95/builds/672/steps/4/logs/stdio
[2] https://lab.llvm.org/buildbot/#/builders/95/builds/672/steps/6/logs/FAIL__Profile-powerpc64le__instrprof-vtable-value-
[3] `cmake -G Ninja -DCMAKE_BUILD_TYPE=Debug -DLLVM_ENABLE_PROJECTS='clang;compiler-rt' -DLLVM_USE_SPLIT_DWARF=On -DLLVM_USE_LINKER=lld -DLLVM_ENABLE_SPHINX=ON -DLLVM_OPTIMIZED_TABLEGEN=TRUE -DLLVM_TARGETS_TO_BUILD=X86 -DLLVM_ENABLE_ZLIB=1 ../llvm`