### PR TITLE
[clang] Disable C++14 sized deallocation by default for MinGW targets

### DIFF
--- a/clang/unittests/StaticAnalyzer/CallEventTest.cpp
+++ b/clang/unittests/StaticAnalyzer/CallEventTest.cpp
@@ -76,8 +76,8 @@ TEST(CXXDeallocatorCall, SimpleDestructor) {
     }
   )",
                                                          Diags));
-#if defined(_AIX) || defined(__MVS__)
-  // AIX and ZOS default to -fno-sized-deallocation.
+#if defined(_AIX) || defined(__MVS__) || defined(__MINGW32__)
+  // AIX, ZOS and MinGW default to -fno-sized-deallocation.
   EXPECT_EQ(Diags, "test.CXXDeallocator: NumArgs: 1\n");
 #else
   EXPECT_EQ(Diags, "test.CXXDeallocator: NumArgs: 2\n");


### PR DESCRIPTION
This reverts 130e93cc26ca9d3ac50ec5a92e3109577ca2e702 for the MinGW target.

This avoids the issue that is discussed in
https://github.com/llvm/llvm-project/issues/96899 (and which is summarized in the code comment). This is intended as a temporary workaround until the issue is handled better within libc++.