### PR TITLE
[Analysis] Migrate to a new version of getValueProfDataFromInst

### DIFF
--- a/llvm/include/llvm/Analysis/IndirectCallPromotionAnalysis.h
+++ b/llvm/include/llvm/Analysis/IndirectCallPromotionAnalysis.h
@@ -24,7 +24,7 @@ class Instruction;
 class ICallPromotionAnalysis {
 private:
   // Allocate space to read the profile annotation.
-  std::unique_ptr<InstrProfValueData[]> ValueDataArray;
+  SmallVector<InstrProfValueData, 4> ValueDataArray;
 
   // Count is the call count for the direct-call target.
   // TotalCount is the total call count for the indirect-call callsite.
@@ -36,7 +36,6 @@ private:
   // Returns the number of profitable candidates to promote for the
   // current ValueDataArray and the given \p Inst.
   uint32_t getProfitablePromotionCandidates(const Instruction *Inst,
-                                            uint32_t NumVals,
                                             uint64_t TotalCount);
 
   // Noncopyable
@@ -45,7 +44,7 @@ private:
   operator=(const ICallPromotionAnalysis &other) = delete;
 
 public:
-  ICallPromotionAnalysis();
+  ICallPromotionAnalysis() = default;
 
   /// Returns reference to array of InstrProfValueData for the given
   /// instruction \p I.

--- a/llvm/lib/Analysis/IndirectCallPromotionAnalysis.cpp
+++ b/llvm/lib/Analysis/IndirectCallPromotionAnalysis.cpp
@@ -49,10 +49,6 @@ cl::opt<unsigned> MaxNumVTableAnnotations(
     "icp-max-num-vtables", cl::init(6), cl::Hidden,
     cl::desc("Max number of vtables annotated for a vtable load instruction."));
 
-ICallPromotionAnalysis::ICallPromotionAnalysis() {
-  ValueDataArray = std::make_unique<InstrProfValueData[]>(MaxNumPromotions);
-}
-
 bool ICallPromotionAnalysis::isPromotionProfitable(uint64_t Count,
                                                    uint64_t TotalCount,
                                                    uint64_t RemainingCount) {
@@ -64,19 +60,17 @@ bool ICallPromotionAnalysis::isPromotionProfitable(uint64_t Count,
 // the count. Stop at the first target that is not promoted. Returns the
 // number of candidates deemed profitable.
 uint32_t ICallPromotionAnalysis::getProfitablePromotionCandidates(
-    const Instruction *Inst, uint32_t NumVals, uint64_t TotalCount) {
-  ArrayRef<InstrProfValueData> ValueDataRef(ValueDataArray.get(), NumVals);
-
+    const Instruction *Inst, uint64_t TotalCount) {
   LLVM_DEBUG(dbgs() << " \nWork on callsite " << *Inst
-                    << " Num_targets: " << NumVals << "\n");
+                    << " Num_targets: " << ValueDataArray.size() << "\n");
 
   uint32_t I = 0;
   uint64_t RemainingCount = TotalCount;
-  for (; I < MaxNumPromotions && I < NumVals; I++) {
-    uint64_t Count = ValueDataRef[I].Count;
+  for (; I < MaxNumPromotions && I < ValueDataArray.size(); I++) {
+    uint64_t Count = ValueDataArray[I].Count;
     assert(Count <= RemainingCount);
     LLVM_DEBUG(dbgs() << " Candidate " << I << " Count=" << Count
-                      << "  Target_func: " << ValueDataRef[I].Value << "\n");
+                      << "  Target_func: " << ValueDataArray[I].Value << "\n");
 
     if (!isPromotionProfitable(Count, TotalCount, RemainingCount)) {
       LLVM_DEBUG(dbgs() << " Not promote: Cold target.\n");
@@ -90,14 +84,12 @@ uint32_t ICallPromotionAnalysis::getProfitablePromotionCandidates(
 MutableArrayRef<InstrProfValueData>
 ICallPromotionAnalysis::getPromotionCandidatesForInstruction(
     const Instruction *I, uint64_t &TotalCount, uint32_t &NumCandidates) {
-  uint32_t NumVals;
-  auto Res = getValueProfDataFromInst(*I, IPVK_IndirectCallTarget,
-                                      MaxNumPromotions, NumVals, TotalCount);
-  if (!Res) {
+  ValueDataArray = getValueProfDataFromInst(*I, IPVK_IndirectCallTarget,
+                                            MaxNumPromotions, TotalCount);
+  if (ValueDataArray.empty()) {
     NumCandidates = 0;
     return MutableArrayRef<InstrProfValueData>();
   }
-  ValueDataArray = std::move(Res);
-  NumCandidates = getProfitablePromotionCandidates(I, NumVals, TotalCount);
-  return MutableArrayRef<InstrProfValueData>(ValueDataArray.get(), NumVals);
+  NumCandidates = getProfitablePromotionCandidates(I, TotalCount);
+  return ValueDataArray;
 }


### PR DESCRIPTION
This patch migrates a use of getValueProfDataFromInst in the indirect
call promotion to a new version.

Without this patch, getProfitablePromotionCandidates is a little
strange in that it takes value profiling data from member variable
ValueDataArray while taking its length as a function parameter.  This
patch rectifies that by teaching the function to refer to
ValueDataArray, which is now a SmallVector.
