### PR TITLE
[flang] Use std::make_unique (NFC)

### DIFF
--- a/flang/lib/Optimizer/Builder/TemporaryStorage.cpp
+++ b/flang/lib/Optimizer/Builder/TemporaryStorage.cpp
@@ -305,8 +305,7 @@ fir::factory::AnyVectorSubscriptStack::AnyVectorSubscriptStack(
     mlir::Type variableStaticType, bool shapeCanBeSavedAsRegister, int rank)
     : AnyVariableStack{loc, builder, variableStaticType} {
   if (shapeCanBeSavedAsRegister) {
-    shapeTemp =
-        std::unique_ptr<TemporaryStorage>(new TemporaryStorage{SSARegister{}});
+    shapeTemp = std::make_unique<TemporaryStorage>(SSARegister{});
     return;
   }
   // The shape will be tracked as the dimension inside a descriptor because
@@ -315,8 +314,8 @@ fir::factory::AnyVectorSubscriptStack::AnyVectorSubscriptStack(
   mlir::Type type =
       fir::BoxType::get(builder.getVarLenSeqTy(builder.getI32Type(), rank));
   boxType = type;
-  shapeTemp = std::unique_ptr<TemporaryStorage>(
-      new TemporaryStorage{AnyVariableStack{loc, builder, type}});
+  shapeTemp =
+      std::make_unique<TemporaryStorage>(AnyVariableStack{loc, builder, type});
 }
 
 void fir::factory::AnyVectorSubscriptStack::pushShape(


### PR DESCRIPTION
This patch is based on clang-tidy's modernize-make-unique but limited
to those cases where type names are mentioned twice like
`std::unique_ptr<Type>(new Type())`, which is a bit mouthful.
