### PR TITLE
[compiler-rt][test]Use c-style headers in instrprof-vtable-value-prof.cpp

### DIFF
--- a/compiler-rt/test/profile/Linux/instrprof-vtable-value-prof.cpp
+++ b/compiler-rt/test/profile/Linux/instrprof-vtable-value-prof.cpp
@@ -166,6 +166,7 @@
 // IR: [[MERGE0]]:
 // IR:    [[RES2:%.*]] = phi i32 [ [[RES1]], %[[MERGE1]] ], [ [[RESBB1]], %[[BB1]] ]
 
+#include <stdio.h>
 #include <stdlib.h>
 class Base {
 public:
@@ -196,8 +197,8 @@ __attribute__((noinline)) Base *createType(int a) {
   return base;
 }
 
-static volatile int sum = 0;
 int main(int argc, char **argv) {
+  int sum = 0;
   for (int i = 0; i < 1000; i++) {
     int a = rand();
     int b = rand();
@@ -207,5 +208,6 @@ int main(int argc, char **argv) {
 
     delete ptr;
   }
+  printf("sum is %d\n", sum);
   return 0;
 }

--- a/compiler-rt/test/profile/Linux/instrprof-vtable-value-prof.cpp
+++ b/compiler-rt/test/profile/Linux/instrprof-vtable-value-prof.cpp
@@ -165,8 +165,8 @@
 //
 // IR: [[MERGE0]]:
 // IR:    [[RES2:%.*]] = phi i32 [ [[RES1]], %[[MERGE1]] ], [ [[RESBB1]], %[[BB1]] ]
-#include <cstdio>
-#include <cstdlib>
+
+#include <stdlib.h>
 class Base {
 public:
   virtual int func(int a, int b) = 0;
@@ -195,8 +195,9 @@ __attribute__((noinline)) Base *createType(int a) {
     base = new Derived2();
   return base;
 }
+
+static volatile int sum = 0;
 int main(int argc, char **argv) {
-  int sum = 0;
   for (int i = 0; i < 1000; i++) {
     int a = rand();
     int b = rand();
@@ -206,6 +207,5 @@ int main(int argc, char **argv) {
 
     delete ptr;
   }
-  printf("sum is %d\n", sum);
   return 0;
 }


### PR DESCRIPTION
Use c-style headers just like other compiler-rt/profile tests do [1], to fix ` 'cstdio' file not found` in https://lab.llvm.org/buildbot/#/builders/122/builds/150

[1] https://github.com/llvm/llvm-project/blob/9b9405621bcc55b74d2177c960c21f62cc95e6fd/compiler-rt/test/profile/instrprof-value-prof.c#L27-L30 and https://github.com/llvm/llvm-project/blob/9b9405621bcc55b74d2177c960c21f62cc95e6fd/compiler-rt/test/tsan/printf-1.c#L6-L16