### PR TITLE
[libc++][format] LWG4106: `basic_format_args` should not be default-constructible

### DIFF
--- a/libcxx/docs/Status/Cxx2cIssues.csv
+++ b/libcxx/docs/Status/Cxx2cIssues.csv
@@ -74,7 +74,7 @@
 "`4096 <https://wg21.link/LWG4096>`__","``views::iota(views::iota(0))`` should be rejected","St. Louis June 2024","","","|ranges|"
 "`4098 <https://wg21.link/LWG4098>`__","``views::adjacent<0>`` should reject non-forward ranges","St. Louis June 2024","","","|ranges|"
 "`4105 <https://wg21.link/LWG4105>`__","``ranges::ends_with``\`s Returns misses difference casting","St. Louis June 2024","","","|ranges|"
-"`4106 <https://wg21.link/LWG4106>`__","``basic_format_args`` should not be default-constructible","St. Louis June 2024","","","|format|"
+"`4106 <https://wg21.link/LWG4106>`__","``basic_format_args`` should not be default-constructible","St. Louis June 2024","|Complete|","19.0","|format|"
 "","","","","",""
 "`3343 <https://wg21.link/LWG3343>`__","Ordering of calls to ``unlock()`` and ``notify_all()`` in Effects element of ``notify_all_at_thread_exit()`` should be reversed","Not Yet Adopted","|Complete|","16.0",""
 "XXXX","","The sys_info range should be affected by save","Not Yet Adopted","|Complete|","19.0"

--- a/libcxx/include/__format/format_args.h
+++ b/libcxx/include/__format/format_args.h
@@ -28,8 +28,6 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 template <class _Context>
 class _LIBCPP_TEMPLATE_VIS basic_format_args {
 public:
-  basic_format_args() noexcept = default;
-
   template <class... _Args>
   _LIBCPP_HIDE_FROM_ABI basic_format_args(const __format_arg_store<_Context, _Args...>& __store) noexcept
       : __size_(sizeof...(_Args)) {

--- a/libcxx/test/std/utilities/format/format.arguments/format.args/ctor.pass.cpp
+++ b/libcxx/test/std/utilities/format/format.arguments/format.args/ctor.pass.cpp
@@ -9,12 +9,12 @@
 
 // <format>
 
-// basic_format_args() noexcept;
 // template<class... Args>
 //   basic_format_args(const format-arg-store<Context, Args...>& store) noexcept;
 
 #include <format>
 #include <cassert>
+#include <type_traits>
 
 #include "test_macros.h"
 
@@ -24,12 +24,7 @@ void test() {
   char c        = 'c';
   nullptr_t p   = nullptr;
   using Context = std::basic_format_context<CharT*, CharT>;
-  {
-    ASSERT_NOEXCEPT(std::basic_format_args<Context>{});
-
-    std::basic_format_args<Context> format_args{};
-    assert(!format_args.get(0));
-  }
+  static_assert(!std::is_default_constructible_v<std::basic_format_args<Context>>);
   {
     auto store = std::make_format_args<Context>(i);
     ASSERT_NOEXCEPT(std::basic_format_args<Context>{store});

--- a/libcxx/test/std/utilities/format/format.arguments/format.args/get.pass.cpp
+++ b/libcxx/test/std/utilities/format/format.arguments/format.args/get.pass.cpp
@@ -81,13 +81,7 @@ void test_string_view(From value) {
 
 template <class CharT>
 void test() {
-  using Context = std::basic_format_context<CharT*, CharT>;
-  {
-    const std::basic_format_args<Context> format_args{};
-    ASSERT_NOEXCEPT(format_args.get(0));
-    assert(!format_args.get(0));
-  }
-
+  using Context   = std::basic_format_context<CharT*, CharT>;
   using char_type = typename Context::char_type;
   std::basic_string<char_type> empty;
   std::basic_string<char_type> str = MAKE_STRING(char_type, "abc");


### PR DESCRIPTION
See [LWG4106](https://cplusplus.github.io/LWG/issue4106) and [P3341R0](https://wg21.link/p3341r0).

The test coverage for the empty state of `basic_format_args` in `get.pass.cpp` is to be completely removed, because the non-default-constructibility is covered in `ctor.pass.cpp`.