### PR TITLE
[MLIR][Python] add value attr for PyAffineMapAttribute

### DIFF
--- a/mlir/lib/Bindings/Python/IRAttributes.cpp
+++ b/mlir/lib/Bindings/Python/IRAttributes.cpp
@@ -142,6 +142,8 @@ public:
           return PyAffineMapAttribute(affineMap.getContext(), attr);
         },
         py::arg("affine_map"), "Gets an attribute wrapping an AffineMap.");
+    c.def_property_readonly("value", mlirAffineMapAttrGetValue,
+                            "Returns the value of the AffineMap attribute");
   }
 };
 

--- a/mlir/test/python/ir/attributes.py
+++ b/mlir/test/python/ir/attributes.py
@@ -157,7 +157,7 @@ def testAffineMapAttr():
         # CHECK: affine_map<(d0, d1)[s0, s1, s2] -> ()>
         attr_built = AffineMapAttr.get(map0)
         print(str(attr_built))
-
+        assert attr_built.value == map0
         attr_parsed = Attribute.parse(str(attr_built))
         assert attr_built == attr_parsed
 


### PR DESCRIPTION
Similar to other attributes in Binding, the `PyAffineMapAttribute` should include a value attribute to enable users to directly retrieve the `AffineMap` from the `AffineMapAttr`.