### PR TITLE
[clangd] Enable passing a `FeatureModuleSet` to `clangdMain`.

### DIFF
--- a/clang-tools-extra/clangd/tool/ClangdMain.cpp
+++ b/clang-tools-extra/clangd/tool/ClangdMain.cpp
@@ -13,6 +13,7 @@
 #include "Config.h"
 #include "ConfigProvider.h"
 #include "Feature.h"
+#include "FeatureModuleSet.h"
 #include "IncludeCleaner.h"
 #include "PathMapping.h"
 #include "Protocol.h"
@@ -712,6 +713,10 @@ enum class ErrorResultCode : int {
 };
 
 int clangdMain(int argc, char *argv[]) {
+  return clangdMain(arc, argv, nullptr);
+}
+
+int clangdMain(int argc, char *argv[], FeatureModuleSet* FeatureModules) {
   // Clang could run on the main thread. e.g., when the flag '-check' or '-sync'
   // is enabled.
   clang::noteBottomOfStack();
@@ -898,6 +903,7 @@ clangd accepts flags on the commandline, and in the CLANGD_FLAGS environment var
   Opts.StaticIndex = PAI.get();
   Opts.AsyncThreadsCount = WorkerThreadsCount;
   Opts.MemoryCleanup = getMemoryCleanupFunction();
+  Opts.FeatureModules = FeatureModules;
 
   Opts.CodeComplete.IncludeIneligibleResults = IncludeIneligibleResults;
   Opts.CodeComplete.Limit = LimitResults;

--- a/clang-tools-extra/clangd/tool/ClangdMain.h
+++ b/clang-tools-extra/clangd/tool/ClangdMain.h
@@ -11,8 +11,10 @@
 
 namespace clang {
 namespace clangd {
+class FeatureModuleSet;
 // clangd main function (clangd server loop)
 int clangdMain(int argc, char *argv[]);
+int clangdMain(int argc, char *argv[], FeatureModuleSet *FeatureModules);
 } // namespace clangd
 } // namespace clang
 


### PR DESCRIPTION
This diff adds an overload of `clangdMain` that makes a `FeatureModuleSet`. `clangdMain` was initially added in 56ac9d46a7c1 to allow custom builds of clangd outside of the LLVM repo that link against clangd. Currently, there's no way for such custom builds to use their own `FeatureModule`s.

This adds a new overload of `clangdMain` rather than adding a new default parameter since that would break existing code that links against the library.

It's also possible that there is a use that takes the address of `clangdMain` which this change would break. That seems very unlikely, and is not addressed in this diff. If this turns out to be a problem, we can add a `clangdMainWithFeatures` instead of adding a new overload.