### PR TITLE
[lldb][test] Fix type error when calling random.randrange with 'float' arg

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/tools/lldb-server/lldbgdbserverutils.py
+++ b/lldb/packages/Python/lldbsuite/test/tools/lldb-server/lldbgdbserverutils.py
@@ -1042,7 +1042,7 @@ if lldbplatformutil.getHostPlatform() == "windows":
     class Pipe(object):
         def __init__(self, prefix):
             while True:
-                self.name = "lldb-" + str(random.randrange(1e10))
+                self.name = "lldb-" + str(random.randrange(10**10))
                 full_name = "\\\\.\\pipe\\" + self.name
                 self._handle = CreateNamedPipe(
                     full_name,


### PR DESCRIPTION
This test only runs on Windows and fails because we're passing a literal of the wrong type to random.randrange.