### PR TITLE
[Github] Make issue write workflow only run after success/failure

### DIFF
--- a/.github/workflows/issue-write.yml
+++ b/.github/workflows/issue-write.yml
@@ -18,7 +18,11 @@ jobs:
     permissions:
       pull-requests: write
     if: >
-      github.event.workflow_run.event == 'pull_request'
+      github.event.workflow_run.event == 'pull_request' &&
+      (
+        github.event.workflow_run.conclusion == 'success' ||
+        github.event.workflow_run.conclusion == 'failure'
+      )
     steps:
       - name: 'Download artifact'
         uses: actions/download-artifact@6b208ae046db98c579e8a3aa621ab581ff575935 # v4.1.1


### PR DESCRIPTION
This patch makes the issue write workflow only run after success or failure of the workflow invoking it, preventing it from running where the original workflow was skipped.

Fixes #97294