### PR TITLE
[MLIR][NVVM] Reduce the scope of the LLVM_HAS_NVPTX_TARGET guard

### DIFF
--- a/mlir/lib/Dialect/GPU/Transforms/ModuleToBinary.cpp
+++ b/mlir/lib/Dialect/GPU/Transforms/ModuleToBinary.cpp
@@ -38,24 +38,9 @@ class GpuModuleToBinaryPass
     : public impl::GpuModuleToBinaryPassBase<GpuModuleToBinaryPass> {
 public:
   using Base::Base;
-  void getDependentDialects(DialectRegistry &registry) const override;
   void runOnOperation() final;
 };
 } // namespace
-
-void GpuModuleToBinaryPass::getDependentDialects(
-    DialectRegistry &registry) const {
-  // Register all GPU related translations.
-  registry.insert<gpu::GPUDialect>();
-  registry.insert<LLVM::LLVMDialect>();
-#if LLVM_HAS_NVPTX_TARGET
-  registry.insert<NVVM::NVVMDialect>();
-#endif
-#if MLIR_ENABLE_ROCM_CONVERSIONS
-  registry.insert<ROCDL::ROCDLDialect>();
-#endif
-  registry.insert<spirv::SPIRVDialect>();
-}
 
 void GpuModuleToBinaryPass::runOnOperation() {
   RewritePatternSet patterns(&getContext());


### PR DESCRIPTION
Most of the code here does not depend on the NVPTX target. In particular the simple offload can just emit LLVM IR and we can use this without the NVVM backend being built, which can be useful for a frontend that just need to serialize the IR and leave it up to the runtime to JIT further.