### PR TITLE
Fixed __llvm_profile_write_buffer in presence of ValueProfileData.

### DIFF
--- a/compiler-rt/lib/profile/InstrProfilingBuffer.c
+++ b/compiler-rt/lib/profile/InstrProfilingBuffer.c
@@ -220,12 +220,19 @@ uint64_t __llvm_profile_get_size_for_buffer_internal(
       &PaddingBytesAfterNames, &PaddingBytesAfterVTable,
       &PaddingBytesAfterVNames);
 
+  /* Compute size of ValueProfData. */
+  int64_t VPDSize = __llvm_profile_getSizeOfValueProfData(
+      lprofGetVPDataReader(), DataBegin, DataEnd);
+  if (VPDSize < 0) {
+    /* Got error marker. We will not increase the size below. */
+    VPDSize = 0;
+  }
   return sizeof(__llvm_profile_header) + __llvm_write_binary_ids(NULL) +
          DataSize + PaddingBytesBeforeCounters + CountersSize +
          PaddingBytesAfterCounters + NumBitmapBytes +
          PaddingBytesAfterBitmapBytes + NamesSize + PaddingBytesAfterNames +
          VTableSize + PaddingBytesAfterVTable + VNameSize +
-         PaddingBytesAfterVNames;
+         PaddingBytesAfterVNames + VPDSize;
 }
 
 COMPILER_RT_VISIBILITY
@@ -237,7 +244,18 @@ void initBufferWriter(ProfDataWriter *BufferWriter, char *Buffer) {
 COMPILER_RT_VISIBILITY int __llvm_profile_write_buffer(char *Buffer) {
   ProfDataWriter BufferWriter;
   initBufferWriter(&BufferWriter, Buffer);
-  return lprofWriteData(&BufferWriter, 0, 0);
+
+  /* Pass VPDataReader hook, if it will not fail. */
+  const __llvm_profile_data *DataBegin = __llvm_profile_begin_data();
+  const __llvm_profile_data *DataEnd = __llvm_profile_end_data();
+  VPDataReaderType *Reader = lprofGetVPDataReader();
+  if (__llvm_profile_getSizeOfValueProfData(Reader,DataBegin, DataEnd) < 0) {
+    /* Attempt to use lprofGetVPDataReader will result in an error, so
+     * do not use it. Generate profile data without VPDataReader.
+    */
+    Reader = 0;
+  }
+  return lprofWriteData(&BufferWriter, Reader, 0);
 }
 
 COMPILER_RT_VISIBILITY int __llvm_profile_write_buffer_internal(

--- a/compiler-rt/lib/profile/InstrProfilingBuffer.c
+++ b/compiler-rt/lib/profile/InstrProfilingBuffer.c
@@ -249,10 +249,10 @@ COMPILER_RT_VISIBILITY int __llvm_profile_write_buffer(char *Buffer) {
   const __llvm_profile_data *DataBegin = __llvm_profile_begin_data();
   const __llvm_profile_data *DataEnd = __llvm_profile_end_data();
   VPDataReaderType *Reader = lprofGetVPDataReader();
-  if (__llvm_profile_getSizeOfValueProfData(Reader,DataBegin, DataEnd) < 0) {
+  if (__llvm_profile_getSizeOfValueProfData(Reader, DataBegin, DataEnd) < 0) {
     /* Attempt to use lprofGetVPDataReader will result in an error, so
      * do not use it. Generate profile data without VPDataReader.
-    */
+     */
     Reader = 0;
   }
   return lprofWriteData(&BufferWriter, Reader, 0);

--- a/compiler-rt/lib/profile/InstrProfilingInternal.h
+++ b/compiler-rt/lib/profile/InstrProfilingInternal.h
@@ -79,6 +79,8 @@ typedef struct ProfBufferIO {
   uint32_t BufferSz;
   /* Current byte offset from the start of the buffer. */
   uint32_t CurOffset;
+  /* The number of bytes already flushed. */
+  uint64_t FlushedSize;
 } ProfBufferIO;
 
 /* The creator interface used by testing.  */
@@ -168,6 +170,11 @@ void lprofMergeValueProfData(struct ValueProfData *SrcValueProfData,
                              __llvm_profile_data *DstData);
 
 VPDataReaderType *lprofGetVPDataReader();
+
+/* Compute size of VPData. Return -1 on error (0 is a valid return value). */
+int64_t __llvm_profile_getSizeOfValueProfData(VPDataReaderType *VPDataReader,
+                                      const __llvm_profile_data *DataBegin,
+                                      const __llvm_profile_data *DataEnd);
 
 /* Internal interface used by test to reset the max number of 
  * tracked values per value site to be \p MaxVals.

--- a/compiler-rt/test/profile/instrprof-without-libc.c
+++ b/compiler-rt/test/profile/instrprof-without-libc.c
@@ -66,13 +66,7 @@ int main(int argc, const char *argv[]) {
 // CHECK-SYMBOLS-NOT: {{ }}_fdopen
 // CHECK-SYMBOLS-NOT: {{ }}_fopen
 // CHECK-SYMBOLS-NOT: {{ }}_fwrite
-// CHECK-SYMBOLS-NOT: {{ }}_getenv
-// CHECK-SYMBOLS-NOT: {{ }}getenv
 // CHECK-SYMBOLS-NOT: {{ }}_malloc
 // CHECK-SYMBOLS-NOT: {{ }}malloc
-// CHECK-SYMBOLS-NOT: {{ }}_calloc
-// CHECK-SYMBOLS-NOT: {{ }}calloc
-// CHECK-SYMBOLS-NOT: {{ }}_free
-// CHECK-SYMBOLS-NOT: {{ }}free
 // CHECK-SYMBOLS-NOT: {{ }}_open
 // CHECK-SYMBOLS-NOT: {{ }}_getpagesize

--- a/compiler-rt/test/profile/instrprof-write-buffer.c
+++ b/compiler-rt/test/profile/instrprof-write-buffer.c
@@ -6,7 +6,12 @@
 // RUN: rm -f %t.buf.profraw
 // RUN: %clang_pgogen -o %t %s
 // RUN: %run %t %t.buf.profraw
-// RUN: llvm-profdata show %t.buf.profraw
+// RUN: llvm-profdata show %t.buf.profraw | FileCheck %s
+
+// CHECK: Instrumentation level: IR  entry_first = 0
+// CHECK: Total functions: 2
+// CHECK: Maximum function count: 0
+// CHECK: Maximum internal block count: 0
 
 #include <stdint.h>
 #include <stdio.h>

--- a/compiler-rt/test/profile/instrprof-write-buffer.c
+++ b/compiler-rt/test/profile/instrprof-write-buffer.c
@@ -1,0 +1,42 @@
+// UNSUPPORTED: target={{.*windows.*}}
+// This test is derived from "compiler-rt/test/profile/instrprof-write-buffer-internal.c",
+// and that test was disabled on Windows due to sanitizer-windows bot failures.
+// Doing the same here. See 2fcc3f4b18.
+//
+// RUN: rm -f %t.buf.profraw
+// RUN: %clang_pgogen -o %t %s
+// RUN: %run %t %t.buf.profraw
+// RUN: llvm-profdata show %t.buf.profraw
+
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+void threadFunc(void* callback) // Needed for failure.
+{
+  typedef void (FuncPtr)();
+  (*(FuncPtr*)callback)();
+}
+
+uint64_t __llvm_profile_get_size_for_buffer();
+int __llvm_profile_write_buffer(char*);
+
+int main(int argc, const char *argv[])
+{
+  // Write to a buffer, and write that to a file.
+  uint64_t bufsize = __llvm_profile_get_size_for_buffer();
+  char *buf = malloc(bufsize);
+  int ret = __llvm_profile_write_buffer(buf);
+
+  if (ret != 0) {
+    fprintf(stderr, "failed to write buffer");
+    return ret;
+  }
+
+  FILE *f = fopen(argv[1], "w");
+  fwrite(buf, bufsize, 1, f);
+  fclose(f);
+  free(buf);
+
+  return 0;
+}


### PR DESCRIPTION
__llvm_profile_write_buffer generated invalid profile files in presence of non empty ValueProfileData. Fixed that by precomputing the size of ValueProfileData, adding it to the total size, and then filling that.

The new test, instrprof-write-buffer.c is an example of the failure.

The changes to instrprof-without-libc.c are a bit questionable. I don't understand the purpose of this test, but the new code pulls in three function that this test does not like.

I don't see an easy way to avoid this change (instrprof-without-libc.c), though it may be possible to achieve that by splitting some files to ensure that the new changes are not pulled in this test. 
I am open to suggestions.