### PR TITLE
[DeviceRTL] Make defined 'libc' functions weak in OpenMP

### DIFF
--- a/offload/DeviceRTL/src/Debug.cpp
+++ b/offload/DeviceRTL/src/Debug.cpp
@@ -26,8 +26,8 @@ using namespace ompx;
 extern "C" {
 void __assert_assume(bool condition) { __builtin_assume(condition); }
 
-void __assert_fail(const char *expr, const char *file, unsigned line,
-                   const char *function) {
+[[gnu::weak]] void __assert_fail(const char *expr, const char *file,
+                                 unsigned line, const char *function) {
   __assert_fail_internal(expr, nullptr, file, line, function);
 }
 void __assert_fail_internal(const char *expr, const char *msg, const char *file,

--- a/offload/DeviceRTL/src/LibC.cpp
+++ b/offload/DeviceRTL/src/LibC.cpp
@@ -49,7 +49,7 @@ int32_t omp_vprintf(const char *Format, void *Arguments, uint32_t) {
 
 extern "C" {
 
-int memcmp(const void *lhs, const void *rhs, size_t count) {
+[[gnu::weak]] int memcmp(const void *lhs, const void *rhs, size_t count) {
   auto *L = reinterpret_cast<const unsigned char *>(lhs);
   auto *R = reinterpret_cast<const unsigned char *>(rhs);
 
@@ -60,7 +60,7 @@ int memcmp(const void *lhs, const void *rhs, size_t count) {
   return 0;
 }
 
-void memset(void *dst, int C, size_t count) {
+[[gnu::weak]] void memset(void *dst, int C, size_t count) {
   auto *dstc = reinterpret_cast<char *>(dst);
   for (size_t I = 0; I < count; ++I)
     dstc[I] = C;


### PR DESCRIPTION
Summary:
These functions provide special-case implementations internal to the
OpenMP device runtime. This can potentially conflict with the symbols
pulled in from the actual GPU `libc`. This patch makes these weak, so in
the case that the GPU libc functions exist they will be overridden. This
should not impact performance in the average case because the old
`-mlink-builtin-bitcode` version does internalization, deleting weak,
and the new LTO path will resolve to the strong reference and then
internalize it.
