### PR TITLE
[ThinLTO] Use a set rather than a map to track exported ValueInfos.

### DIFF
--- a/llvm/include/llvm/Transforms/IPO/FunctionImport.h
+++ b/llvm/include/llvm/Transforms/IPO/FunctionImport.h
@@ -104,13 +104,10 @@ public:
   /// index's module path string table).
   using ImportMapTy = DenseMap<StringRef, FunctionsToImportTy>;
 
-  /// The map contains an entry for every global value the module exports.
-  /// The key is ValueInfo, and the value indicates whether the definition
-  /// or declaration is visible to another module. If a function's definition is
-  /// visible to other modules, the global values this function referenced are
-  /// visible and shouldn't be internalized.
-  /// TODO: Rename to `ExportMapTy`.
-  using ExportSetTy = DenseMap<ValueInfo, GlobalValueSummary::ImportKind>;
+  /// The set contains an entry for every global value that the module exports.
+  /// Depending on the user context, this container is allowed to contain
+  /// definitions, declarations or a mix of both.
+  using ExportSetTy = DenseSet<ValueInfo>;
 
   /// A function of this type is used to load modules referenced by the index.
   using ModuleLoaderTy =

--- a/llvm/lib/Transforms/IPO/FunctionImport.cpp
+++ b/llvm/lib/Transforms/IPO/FunctionImport.cpp
@@ -995,7 +995,7 @@ static bool isGlobalVarSummary(const ModuleSummaryIndex &Index,
   return false;
 }
 
-// Return the number of global summaries in ExportSet.
+// Return the number of global variable summaries in ExportSet.
 static unsigned
 numGlobalVarSummaries(const ModuleSummaryIndex &Index,
                       FunctionImporter::ExportSetTy &ExportSet) {
@@ -1006,8 +1006,8 @@ numGlobalVarSummaries(const ModuleSummaryIndex &Index,
   return NumGVS;
 }
 
-// Given ImportMap, return the number of global summaries and record the number
-// of defined function summaries as output parameter.
+// Given ImportMap, return the number of global variable summaries and record
+// the number of defined function summaries as output parameter.
 static unsigned
 numGlobalVarSummaries(const ModuleSummaryIndex &Index,
                       FunctionImporter::FunctionsToImportTy &ImportMap,

--- a/llvm/lib/Transforms/IPO/FunctionImport.cpp
+++ b/llvm/lib/Transforms/IPO/FunctionImport.cpp
@@ -995,26 +995,19 @@ static bool isGlobalVarSummary(const ModuleSummaryIndex &Index,
   return false;
 }
 
-// Return the number of global summaries and record the number of function
-// summaries as output parameter.
-static unsigned numGlobalVarSummaries(const ModuleSummaryIndex &Index,
-                                      FunctionImporter::ExportSetTy &ExportSet,
-                                      unsigned &DefinedFS) {
+// Return the number of global summaries in ExportSet.
+static unsigned
+numGlobalVarSummaries(const ModuleSummaryIndex &Index,
+                      FunctionImporter::ExportSetTy &ExportSet) {
   unsigned NumGVS = 0;
-  DefinedFS = 0;
-  for (auto &VI : ExportSet) {
+  for (auto &VI : ExportSet)
     if (isGlobalVarSummary(Index, VI.getGUID()))
       ++NumGVS;
-    else
-      ++DefinedFS;
-  }
   return NumGVS;
 }
 
-// Return the number of global summaries and record the number of function
-// summaries as output parameter. This is the same as `numGlobalVarSummaries`
-// except that it takes `FunctionImporter::FunctionsToImportTy` as input
-// parameter.
+// Given ImportMap, return the number of global summaries and record the number
+// of defined function summaries as output parameter.
 static unsigned
 numGlobalVarSummaries(const ModuleSummaryIndex &Index,
                       FunctionImporter::FunctionsToImportTy &ImportMap,
@@ -1147,12 +1140,9 @@ void llvm::ComputeCrossModuleImport(
   for (auto &ModuleImports : ImportLists) {
     auto ModName = ModuleImports.first;
     auto &Exports = ExportLists[ModName];
-    unsigned DefinedFS = 0;
-    unsigned NumGVS = numGlobalVarSummaries(Index, Exports, DefinedFS);
-    LLVM_DEBUG(dbgs() << "* Module " << ModName << " exports " << DefinedFS
-                      << " function as definitions, "
-                      << Exports.size() - NumGVS - DefinedFS
-                      << " functions as declarations and " << NumGVS
+    unsigned NumGVS = numGlobalVarSummaries(Index, Exports);
+    LLVM_DEBUG(dbgs() << "* Module " << ModName << " exports "
+                      << Exports.size() - NumGVS << " functions and " << NumGVS
                       << " vars. Imports from " << ModuleImports.second.size()
                       << " modules.\n");
     for (auto &Src : ModuleImports.second) {

--- a/llvm/test/ThinLTO/X86/funcimport-stats.ll
+++ b/llvm/test/ThinLTO/X86/funcimport-stats.ll
@@ -10,7 +10,7 @@
 ; RUN: cat %t4 | FileCheck %s
 
 ; CHECK:      - [[NUM_FUNCS:[0-9]+]] function definitions and 0 function declarations imported from
-; CHECK-NEXT: - [[NUM_VARS:[0-9]+]] global vars definition and 0 global vars declaration imported from
+; CHECK-NEXT: - [[NUM_VARS:[0-9]+]] global vars imported from
 
 ; CHECK:      [[NUM_FUNCS]] function-import - Number of functions imported in backend
 ; CHECK-NEXT: [[NUM_FUNCS]] function-import - Number of functions thin link decided to import

--- a/llvm/test/Transforms/FunctionImport/funcimport.ll
+++ b/llvm/test/Transforms/FunctionImport/funcimport.ll
@@ -167,7 +167,7 @@ declare void @variadic_va_start(...)
 
 ; DUMP:       Module [[M1:.*]] imports from 1 module
 ; DUMP-NEXT:  15 function definitions and 0 function declarations imported from [[M2:.*]]
-; DUMP-NEXT:  4 var definitions and 0 var declarations imported from [[M2]]
+; DUMP-NEXT:  4 vars imported from [[M2]]
 
 ; DUMP:       Imported 15 functions for Module [[M1]]
 ; DUMP-NEXT:  Imported 4 global variables for Module [[M1]]


### PR DESCRIPTION
https://github.com/llvm/llvm-project/pull/95482 is a reland of https://github.com/llvm/llvm-project/pull/88024.  https://github.com/llvm/llvm-project/pull/95482 keeps indexing memory usage reasonable by using unordered_map and doesn't make other changes to originally reviewed code.

While discussing possible ways to minimize indexing memory usage, Teresa asked whether I need `ExportSetTy` as a map or a set is sufficient. This PR implements the idea. It uses a set rather than a map to track exposed ValueInfos.

Currently, `ExportLists` has two use cases, and neither needs to track a ValueInfo's import/export status. So using a set is sufficient and correct.
1) In both in-process and distributed ThinLTO,  it's used to decide if a function or global variable is [visible](https://github.com/llvm/llvm-project/blob/66cd8ec4c08252ebc73c82e4883a8da247ed146b/llvm/lib/LTO/LTO.cpp#L1815-L1819) from another module after importing creates additional cross-module references.
    * If a cross-module call edge is seen today, the callee must be visible to another module without keeping track of its export status already. For instance, [this](https://github.com/llvm/llvm-project/blob/66cd8ec4c08252ebc73c82e4883a8da247ed146b/llvm/lib/LTO/LTO.cpp#L1783-L1794) is how callees of direct calls get exported.
2) For [in-process ThinLTO](https://github.com/llvm/llvm-project/blob/66cd8ec4c08252ebc73c82e4883a8da247ed146b/llvm/lib/LTO/LTO.cpp#L1494-L1496), it's used to compute lto cache key.
    * The cache key computation [already hashes](https://github.com/llvm/llvm-project/blob/b76100e220591fab2bf0a4917b216439f7aa4b09/llvm/lib/LTO/LTO.cpp#L194-L222) 'ImportList' , and 'ExportList' is determined by 'ImportList'. So it's fine to not track 'import type' for export list.


