### PR TITLE
[RISCV] Return nullptr for PHI defs in VSETVLIInfo::getAVLDefMI

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVInsertVSETVLI.cpp
+++ b/llvm/lib/Target/RISCV/RISCVInsertVSETVLI.cpp
@@ -586,13 +586,14 @@ public:
   }
   // Most AVLIsReg infos will have a single defining MachineInstr, unless it was
   // a PHI node. In that case getAVLVNInfo()->def will point to the block
-  // boundary slot.  If LiveIntervals isn't available, then nullptr is returned.
+  // boundary slot and this will return nullptr.  If LiveIntervals isn't
+  // available, nullptr is also returned.
   const MachineInstr *getAVLDefMI(const LiveIntervals *LIS) const {
     assert(hasAVLReg());
-    if (!LIS)
+    if (!LIS || getAVLVNInfo()->isPHIDef())
       return nullptr;
     auto *MI = LIS->getInstructionFromIndex(getAVLVNInfo()->def);
-    assert(!(getAVLVNInfo()->isPHIDef() && MI));
+    assert(MI);
     return MI;
   }
 

--- a/llvm/test/CodeGen/RISCV/rvv/vsetvli-insert-crossbb.ll
+++ b/llvm/test/CodeGen/RISCV/rvv/vsetvli-insert-crossbb.ll
@@ -1063,11 +1063,17 @@ exit:
   ret <vscale x 2 x i32> %c
 }
 
-define void @vlmax_avl_phi(i1 %cmp, ptr %p) {
+define void @vlmax_avl_phi(i1 %cmp, ptr %p, i64 %a, i64 %b) {
 ; CHECK-LABEL: vlmax_avl_phi:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    andi a0, a0, 1
-; CHECK-NEXT:    vsetvli a0, zero, e8, m1, ta, ma
+; CHECK-NEXT:    beqz a0, .LBB25_2
+; CHECK-NEXT:  # %bb.1: # %foo
+; CHECK-NEXT:    vsetvli zero, a2, e8, m1, ta, ma
+; CHECK-NEXT:    j .LBB25_3
+; CHECK-NEXT:  .LBB25_2: # %bar
+; CHECK-NEXT:    vsetvli zero, a3, e8, m1, ta, ma
+; CHECK-NEXT:  .LBB25_3: # %exit
 ; CHECK-NEXT:    vmv.v.i v8, 0
 ; CHECK-NEXT:    vsetivli zero, 1, e8, m1, ta, ma
 ; CHECK-NEXT:    vse8.v v8, (a1)
@@ -1076,11 +1082,11 @@ entry:
   br i1 %cmp, label %foo, label %bar
 
 foo:
-  %vl.foo = tail call i64 @llvm.riscv.vsetvlimax.i64(i64 0, i64 0)
+  %vl.foo = tail call i64 @llvm.riscv.vsetvli.i64(i64 %a, i64 0, i64 0)
   br label %exit
 
 bar:
-  %vl.bar = tail call i64 @llvm.riscv.vsetvlimax.i64(i64 0, i64 0)
+  %vl.bar = tail call i64 @llvm.riscv.vsetvli.i64(i64 %b, i64 0, i64 0)
   br label %exit
 
 exit:


### PR DESCRIPTION
When checking if a VSETVLIInfo is compatible, we call hasEquallyZeroAVL when only the AVL-zeroness is demanded. This will try to lookup the defining MachineInstr (to check if it's an ADDI immediate) via getAVLDefMI, but in it we were asserting that the VSETVLIInfo's AVL wouldn't come from a phi. It turns out this can happen in normal circumstances.

This causes a crash when compiling highway, so this fixes it by relaxing the assertion.
