### PR TITLE
[llvm] [Triple] Add QNX Neutrino RTOS to llvm::Triple

### DIFF
--- a/llvm/include/llvm/TargetParser/Triple.h
+++ b/llvm/include/llvm/TargetParser/Triple.h
@@ -239,7 +239,8 @@ public:
     LiteOS,
     Serenity,
     Vulkan, // Vulkan SPIR-V
-    LastOSType = Vulkan
+    QNX,        // BlackBerry QNX
+    LastOSType = QNX
   };
   enum EnvironmentType {
     UnknownEnvironment,

--- a/llvm/lib/TargetParser/Triple.cpp
+++ b/llvm/lib/TargetParser/Triple.cpp
@@ -302,6 +302,7 @@ StringRef Triple::getOSTypeName(OSType Kind) {
   case LiteOS: return "liteos";
   case XROS: return "xros";
   case Vulkan: return "vulkan";
+  case QNX: return "qnx";
   }
 
   llvm_unreachable("Invalid OSType");
@@ -682,6 +683,7 @@ static Triple::OSType parseOS(StringRef OSName) {
     .StartsWith("liteos", Triple::LiteOS)
     .StartsWith("serenity", Triple::Serenity)
     .StartsWith("vulkan", Triple::Vulkan)
+    .StartsWith("qnx", Triple::QNX)
     .Default(Triple::UnknownOS);
 }
 


### PR DESCRIPTION
This change adds the _QNX Neutrino Real-Time Operating System_ to _llvm::Triple_, and is the first in a series of changes (specifically, #97417, #97439, #97487, #97536, and #97630) that look to facilitate remote debug of _AArch64_ targets on _QNX_.

_QNX Neutrino Real-Time Operating System_ is a commercial Unix-like real-time operating system primarily targeting the embedded systems market including automotive, medical devices, robotics, transportation, and industrial embedded systems.

The series of changes in question looks to provision support for –

- Launching a debuggee
- Attaching to a debuggee
- Having the debuggee come up stopped at the entry point
- Setting breakpoints
- Stopping at breakpoints
- Reading/writing contents of/to the debuggee's memory
- Reading/writing contents of/to the debuggee's registers
- Reading/writing contents of/to the debuggee's variables
- Resuming the debuggee's execution
- Single-stepping the debuggee's execution
- Interrupting the debuggee's execution
- Dumping information pertaining to the debuggee's stack trace

Kindly note that _ptrace_ isn't available on QNX. Instead, _devctl_ can be leveraged to observe and control the execution of a process under debug on _QNX_.

Any additional support (including the facilitation of execution of tests) will be the subject of future work.