### PR TITLE
[MC][ELF] Eliminate some hash maps from ELFObjectWriter

### DIFF
--- a/llvm/include/llvm/MC/MCSectionELF.h
+++ b/llvm/include/llvm/MC/MCSectionELF.h
@@ -46,6 +46,10 @@ class MCSectionELF final : public MCSection {
   /// section header index of the section where LinkedToSym is defined.
   const MCSymbol *LinkedToSym;
 
+  /// Start/end offset in file, used by ELFWriter.
+  uint64_t StartOffset;
+  uint64_t EndOffset;
+
 private:
   friend class MCContext;
 
@@ -91,6 +95,14 @@ public:
     return &LinkedToSym->getSection();
   }
   const MCSymbol *getLinkedToSymbol() const { return LinkedToSym; }
+
+  void setOffsets(uint64_t Start, uint64_t End) {
+    StartOffset = Start;
+    EndOffset = End;
+  }
+  std::pair<uint64_t, uint64_t> getOffsets() const {
+    return std::make_pair(StartOffset, EndOffset);
+  }
 
   static bool classof(const MCSection *S) {
     return S->getVariant() == SV_ELF;

--- a/llvm/include/llvm/MC/MCSymbolELF.h
+++ b/llvm/include/llvm/MC/MCSymbolELF.h
@@ -17,6 +17,9 @@ class MCSymbolELF : public MCSymbol {
   /// symbol has no size this field will be NULL.
   const MCExpr *SymbolSize = nullptr;
 
+  /// Group section index for signature symbols. Set by ELFWriter.
+  mutable unsigned GroupIndex = 0;
+
 public:
   MCSymbolELF(const MCSymbolTableEntry *Name, bool isTemporary)
       : MCSymbol(SymbolKindELF, Name, isTemporary) {}
@@ -43,6 +46,9 @@ public:
 
   void setIsSignature() const;
   bool isSignature() const;
+
+  void setGroupIndex(unsigned Index) const { GroupIndex = Index; }
+  unsigned getGroupIndex() const { return GroupIndex; }
 
   void setMemtag(bool Tagged);
   bool isMemtag() const;

--- a/llvm/include/llvm/MC/MCSymbolELF.h
+++ b/llvm/include/llvm/MC/MCSymbolELF.h
@@ -17,9 +17,6 @@ class MCSymbolELF : public MCSymbol {
   /// symbol has no size this field will be NULL.
   const MCExpr *SymbolSize = nullptr;
 
-  /// Group section index for signature symbols. Set by ELFWriter.
-  mutable unsigned GroupIndex = 0;
-
 public:
   MCSymbolELF(const MCSymbolTableEntry *Name, bool isTemporary)
       : MCSymbol(SymbolKindELF, Name, isTemporary) {}
@@ -46,9 +43,6 @@ public:
 
   void setIsSignature() const;
   bool isSignature() const;
-
-  void setGroupIndex(unsigned Index) const { GroupIndex = Index; }
-  unsigned getGroupIndex() const { return GroupIndex; }
 
   void setMemtag(bool Tagged);
   bool isMemtag() const;

--- a/llvm/lib/MC/ELFObjectWriter.cpp
+++ b/llvm/lib/MC/ELFObjectWriter.cpp
@@ -176,8 +176,7 @@ public:
   ///
   /// \param Asm - The assembler.
   /// \param RevGroupMap - Maps a signature symbol to the group section.
-  void computeSymbolTable(MCAssembler &Asm,
-                          const RevGroupMapTy &RevGroupMap);
+  void computeSymbolTable(MCAssembler &Asm, const RevGroupMapTy &RevGroupMap);
 
   void writeAddrsigSection();
 

--- a/llvm/lib/MC/ELFObjectWriter.cpp
+++ b/llvm/lib/MC/ELFObjectWriter.cpp
@@ -66,8 +66,6 @@ using namespace llvm;
 
 namespace {
 
-using SectionIndexMapTy = DenseMap<const MCSectionELF *, uint32_t>;
-
 class ELFObjectWriter;
 struct ELFWriter;
 
@@ -181,10 +179,8 @@ public:
   /// Compute the symbol table data
   ///
   /// \param Asm - The assembler.
-  /// \param SectionIndexMap - Maps a section to its index.
   /// \param RevGroupMap - Maps a signature symbol to the group section.
   void computeSymbolTable(MCAssembler &Asm,
-                          const SectionIndexMapTy &SectionIndexMap,
                           const RevGroupMapTy &RevGroupMap,
                           SectionOffsetsTy &SectionOffsets);
 
@@ -194,7 +190,6 @@ public:
                                         const MCSectionELF &Sec);
 
   void writeSectionHeader(const MCAssembler &Asm,
-                          const SectionIndexMapTy &SectionIndexMap,
                           const SectionOffsetsTy &SectionOffsets);
 
   void writeSectionData(const MCAssembler &Asm, MCSection &Sec);
@@ -207,8 +202,7 @@ public:
   void writeRelocations(const MCAssembler &Asm, const MCSectionELF &Sec);
 
   uint64_t writeObject(MCAssembler &Asm);
-  void writeSection(const SectionIndexMapTy &SectionIndexMap,
-                    uint32_t GroupSymbolIndex, uint64_t Offset, uint64_t Size,
+  void writeSection(uint32_t GroupSymbolIndex, uint64_t Offset, uint64_t Size,
                     const MCSectionELF &Section);
 };
 
@@ -612,7 +606,6 @@ bool ELFWriter::isInSymtab(const MCAssembler &Asm, const MCSymbolELF &Symbol,
 }
 
 void ELFWriter::computeSymbolTable(MCAssembler &Asm,
-                                   const SectionIndexMapTy &SectionIndexMap,
                                    const RevGroupMapTy &RevGroupMap,
                                    SectionOffsetsTy &SectionOffsets) {
   MCContext &Ctx = Asm.getContext();
@@ -697,7 +690,7 @@ void ELFWriter::computeSymbolTable(MCAssembler &Asm,
 
       if (Mode == NonDwoOnly && isDwoSection(Section))
         continue;
-      MSD.SectionIndex = SectionIndexMap.lookup(&Section);
+      MSD.SectionIndex = Section.getLayoutOrder();
       assert(MSD.SectionIndex && "Invalid section index!");
       if (MSD.SectionIndex >= ELF::SHN_LORESERVE)
         HasLargeSectionIndex = true;
@@ -1030,8 +1023,7 @@ void ELFWriter::writeRelocations(const MCAssembler &Asm,
   }
 }
 
-void ELFWriter::writeSection(const SectionIndexMapTy &SectionIndexMap,
-                             uint32_t GroupSymbolIndex, uint64_t Offset,
+void ELFWriter::writeSection(uint32_t GroupSymbolIndex, uint64_t Offset,
                              uint64_t Size, const MCSectionELF &Section) {
   uint64_t sh_link = 0;
   uint64_t sh_info = 0;
@@ -1050,7 +1042,7 @@ void ELFWriter::writeSection(const SectionIndexMapTy &SectionIndexMap,
     sh_link = SymbolTableIndex;
     assert(sh_link && ".symtab not found");
     const MCSection *InfoSection = Section.getLinkedToSection();
-    sh_info = SectionIndexMap.lookup(cast<MCSectionELF>(InfoSection));
+    sh_info = InfoSection->getLayoutOrder();
     break;
   }
 
@@ -1075,10 +1067,8 @@ void ELFWriter::writeSection(const SectionIndexMapTy &SectionIndexMap,
     // If the value in the associated metadata is not a definition, Sym will be
     // undefined. Represent this with sh_link=0.
     const MCSymbol *Sym = Section.getLinkedToSymbol();
-    if (Sym && Sym->isInSection()) {
-      const MCSectionELF *Sec = cast<MCSectionELF>(&Sym->getSection());
-      sh_link = SectionIndexMap.lookup(Sec);
-    }
+    if (Sym && Sym->isInSection())
+      sh_link = Sym->getSection().getLayoutOrder();
   }
 
   WriteSecHdrEntry(StrTabBuilder.getOffset(Section.getName()),
@@ -1088,7 +1078,6 @@ void ELFWriter::writeSection(const SectionIndexMapTy &SectionIndexMap,
 }
 
 void ELFWriter::writeSectionHeader(const MCAssembler &Asm,
-                                   const SectionIndexMapTy &SectionIndexMap,
                                    const SectionOffsetsTy &SectionOffsets) {
   const unsigned NumSections = SectionTable.size();
 
@@ -1113,8 +1102,7 @@ void ELFWriter::writeSectionHeader(const MCAssembler &Asm,
     else
       Size = Offsets.second - Offsets.first;
 
-    writeSection(SectionIndexMap, GroupSymbolIndex, Offsets.first, Size,
-                 *Section);
+    writeSection(GroupSymbolIndex, Offsets.first, Size, *Section);
   }
 }
 
@@ -1127,7 +1115,6 @@ uint64_t ELFWriter::writeObject(MCAssembler &Asm) {
   StringTableIndex = addToSectionTable(StrtabSection);
 
   RevGroupMapTy RevGroupMap;
-  SectionIndexMapTy SectionIndexMap;
 
   DenseMap<const MCSymbol *, SmallVector<const MCSectionELF *, 0>> GroupMembers;
 
@@ -1172,9 +1159,9 @@ uint64_t ELFWriter::writeObject(MCAssembler &Asm) {
         Members.push_back(RelSection);
     }
 
-    SectionIndexMap[&Section] = addToSectionTable(&Section);
+    Section.setLayoutOrder(addToSectionTable(&Section));
     if (RelSection) {
-      SectionIndexMap[RelSection] = addToSectionTable(RelSection);
+      RelSection->setLayoutOrder(addToSectionTable(RelSection));
       Relocations.push_back(RelSection);
     }
 
@@ -1188,10 +1175,8 @@ uint64_t ELFWriter::writeObject(MCAssembler &Asm) {
     const MCSymbol *SignatureSymbol = Group->getGroup();
     assert(SignatureSymbol);
     write(uint32_t(Group->isComdat() ? unsigned(ELF::GRP_COMDAT) : 0));
-    for (const MCSectionELF *Member : GroupMembers[SignatureSymbol]) {
-      uint32_t SecIndex = SectionIndexMap.lookup(Member);
-      write(SecIndex);
-    }
+    for (const MCSectionELF *Member : GroupMembers[SignatureSymbol])
+      write(Member->getLayoutOrder());
 
     uint64_t SecEnd = W.OS.tell();
     SectionOffsets[Group] = std::make_pair(SecStart, SecEnd);
@@ -1210,7 +1195,7 @@ uint64_t ELFWriter::writeObject(MCAssembler &Asm) {
     }
 
     // Compute symbol table information.
-    computeSymbolTable(Asm, SectionIndexMap, RevGroupMap, SectionOffsets);
+    computeSymbolTable(Asm, RevGroupMap, SectionOffsets);
 
     for (MCSectionELF *RelSection : Relocations) {
       // Remember the offset into the file for this section.
@@ -1240,7 +1225,7 @@ uint64_t ELFWriter::writeObject(MCAssembler &Asm) {
   const uint64_t SectionHeaderOffset = align(is64Bit() ? Align(8) : Align(4));
 
   // ... then the section header table ...
-  writeSectionHeader(Asm, SectionIndexMap, SectionOffsets);
+  writeSectionHeader(Asm, SectionOffsets);
 
   uint16_t NumSections = support::endian::byte_swap<uint16_t>(
       (SectionTable.size() + 1 >= ELF::SHN_LORESERVE) ? (uint16_t)ELF::SHN_UNDEF

--- a/llvm/lib/MC/ELFObjectWriter.cpp
+++ b/llvm/lib/MC/ELFObjectWriter.cpp
@@ -683,7 +683,7 @@ void ELFWriter::computeSymbolTable(MCAssembler &Asm,
 
       if (Mode == NonDwoOnly && isDwoSection(Section))
         continue;
-      MSD.SectionIndex = Section.getLayoutOrder();
+      MSD.SectionIndex = Section.getOrdinal();
       assert(MSD.SectionIndex && "Invalid section index!");
       if (MSD.SectionIndex >= ELF::SHN_LORESERVE)
         HasLargeSectionIndex = true;
@@ -1034,7 +1034,7 @@ void ELFWriter::writeSection(uint32_t GroupSymbolIndex, uint64_t Offset,
     sh_link = SymbolTableIndex;
     assert(sh_link && ".symtab not found");
     const MCSection *InfoSection = Section.getLinkedToSection();
-    sh_info = InfoSection->getLayoutOrder();
+    sh_info = InfoSection->getOrdinal();
     break;
   }
 
@@ -1060,7 +1060,7 @@ void ELFWriter::writeSection(uint32_t GroupSymbolIndex, uint64_t Offset,
     // undefined. Represent this with sh_link=0.
     const MCSymbol *Sym = Section.getLinkedToSymbol();
     if (Sym && Sym->isInSection())
-      sh_link = Sym->getSection().getLayoutOrder();
+      sh_link = Sym->getSection().getOrdinal();
   }
 
   WriteSecHdrEntry(StrTabBuilder.getOffset(Section.getName()),
@@ -1147,17 +1147,17 @@ uint64_t ELFWriter::writeObject(MCAssembler &Asm) {
       }
     }
 
-    Section.setLayoutOrder(addToSectionTable(&Section));
+    Section.setOrdinal(addToSectionTable(&Section));
     if (RelSection) {
-      RelSection->setLayoutOrder(addToSectionTable(RelSection));
+      RelSection->setOrdinal(addToSectionTable(RelSection));
       Relocations.push_back(RelSection);
     }
 
     if (GroupIdxEntry) {
       auto &Members = Groups[GroupMap[*GroupIdxEntry]];
-      Members.second.push_back(Section.getLayoutOrder());
+      Members.second.push_back(Section.getOrdinal());
       if (RelSection)
-        Members.second.push_back(RelSection->getLayoutOrder());
+        Members.second.push_back(RelSection->getOrdinal());
     }
 
     OWriter.TargetObjectWriter->addTargetSectionFlags(Ctx, Section);


### PR DESCRIPTION
Remove some maps. Unfortunately, it didn't result in a measurable performance improvements, but at least some parts of this are a nice to have regardless.

- Replace SectionIndexMap with layout order: The section layout order is only used in MachO, so we can repurpose the field as section table index.
- Store section offsets in MCSectionELF: No need for a map, and especially not a std::map. Direct access to the underlying (and easily modifyable) data structure is always faster.
- Store signature group index in MCSymbolELF: This removes the need for a reverse lookup map.
- Improve storage of groups: There's no point in having a DenseMap, the number of sections and groups are reasonably small to use vectors.

---

I'm unsure about the third part, it increases the size of MCSymbolELF and therefore max-rss. On the other hand, MCSymbol currently has 28 padding bits and an extra four padding bytes (if I counted correctly, the bit fields sum up to 36), but this seems unintended. @MaskRay what do you think? Use padding bytes in MCSymbol or drop the third commit and fix MCSymbol bit fields later?