### PR TITLE
[Clang][Sema] Treat explicit specializations of static data member templates declared without 'static' as static data members when diagnosing uses of 'auto'

### DIFF
--- a/clang/lib/Sema/SemaType.cpp
+++ b/clang/lib/Sema/SemaType.cpp
@@ -3194,8 +3194,7 @@ static QualType GetDeclSpecTypeForDeclarator(TypeProcessingState &state,
       break;
     }
     case DeclaratorContext::Member: {
-      if (D.getDeclSpec().getStorageClassSpec() == DeclSpec::SCS_static ||
-          D.isFunctionDeclarator())
+      if (D.isStaticMember() || D.isFunctionDeclarator())
         break;
       bool Cxx = SemaRef.getLangOpts().CPlusPlus;
       if (isa<ObjCContainerDecl>(SemaRef.CurContext)) {

--- a/clang/test/CXX/dcl.dcl/dcl.spec/dcl.type/dcl.spec.auto/p5-cxx14.cpp
+++ b/clang/test/CXX/dcl.dcl/dcl.spec/dcl.type/dcl.spec.auto/p5-cxx14.cpp
@@ -1,0 +1,12 @@
+// RUN: %clang_cc1 -fsyntax-only -verify %s -std=c++14
+
+struct A {
+  template<int N>
+  static constexpr auto x = N;
+
+  template<>
+  constexpr auto x<1> = 1;
+
+  template<>
+  static constexpr auto x<2> = 2; // expected-warning{{explicit specialization cannot have a storage class}}
+};


### PR DESCRIPTION
After #93873 clang no longer permits declarations of explicit specializations of static data member templates to use the `auto` _placeholder-type-specifier_:
```cpp
struct A {
  template<int N>
  static constexpr auto x = 0;

  template<>
  constexpr auto x<1> = 1; // error: 'auto' not allowed in non-static struct member
};
```
This patch fixes the issue.