### PR TITLE
[OpenMP][OMPT] Indicate loop schedule for worksharing-loop events

### DIFF
--- a/openmp/runtime/src/kmp_csupport.cpp
+++ b/openmp/runtime/src/kmp_csupport.cpp
@@ -2006,13 +2006,13 @@ void __kmpc_for_static_fini(ident_t *loc, kmp_int32 global_tid) {
 
 #if OMPT_SUPPORT && OMPT_OPTIONAL
   if (ompt_enabled.ompt_callback_work) {
-    ompt_work_t ompt_work_type = ompt_work_loop;
+    ompt_work_t ompt_work_type = ompt_work_loop_static;
     ompt_team_info_t *team_info = __ompt_get_teaminfo(0, NULL);
     ompt_task_info_t *task_info = __ompt_get_task_info_object(0);
     // Determine workshare type
     if (loc != NULL) {
       if ((loc->flags & KMP_IDENT_WORK_LOOP) != 0) {
-        ompt_work_type = ompt_work_loop;
+        ompt_work_type = ompt_work_loop_static;
       } else if ((loc->flags & KMP_IDENT_WORK_SECTIONS) != 0) {
         ompt_work_type = ompt_work_sections;
       } else if ((loc->flags & KMP_IDENT_WORK_DISTRIBUTE) != 0) {

--- a/openmp/runtime/src/kmp_dispatch.cpp
+++ b/openmp/runtime/src/kmp_dispatch.cpp
@@ -1164,8 +1164,9 @@ __kmp_dispatch_init(ident_t *loc, int gtid, enum sched_type schedule, T lb,
     ompt_team_info_t *team_info = __ompt_get_teaminfo(0, NULL);
     ompt_task_info_t *task_info = __ompt_get_task_info_object(0);
     ompt_callbacks.ompt_callback(ompt_callback_work)(
-        ompt_get_work_schedule(pr->schedule), ompt_scope_begin, &(team_info->parallel_data),
-        &(task_info->task_data), pr->u.p.tc, OMPT_LOAD_RETURN_ADDRESS(gtid));
+        ompt_get_work_schedule(pr->schedule), ompt_scope_begin,
+        &(team_info->parallel_data), &(task_info->task_data), pr->u.p.tc,
+        OMPT_LOAD_RETURN_ADDRESS(gtid));
   }
 #endif
   KMP_PUSH_PARTITIONED_TIMER(OMP_loop_dynamic);
@@ -2121,8 +2122,8 @@ int __kmp_dispatch_next_algorithm(int gtid,
       ompt_team_info_t *team_info = __ompt_get_teaminfo(0, NULL);              \
       ompt_task_info_t *task_info = __ompt_get_task_info_object(0);            \
       ompt_callbacks.ompt_callback(ompt_callback_work)(                        \
-          ompt_get_work_schedule(pr->schedule), ompt_scope_end, &(team_info->parallel_data),         \
-          &(task_info->task_data), 0, codeptr);                                \
+          ompt_get_work_schedule(pr->schedule), ompt_scope_end,                \
+          &(team_info->parallel_data), &(task_info->task_data), 0, codeptr);   \
     }                                                                          \
   }
 #define OMPT_LOOP_DISPATCH(lb, ub, st, status)                                 \

--- a/openmp/runtime/src/kmp_dispatch.cpp
+++ b/openmp/runtime/src/kmp_dispatch.cpp
@@ -1164,7 +1164,7 @@ __kmp_dispatch_init(ident_t *loc, int gtid, enum sched_type schedule, T lb,
     ompt_team_info_t *team_info = __ompt_get_teaminfo(0, NULL);
     ompt_task_info_t *task_info = __ompt_get_task_info_object(0);
     ompt_callbacks.ompt_callback(ompt_callback_work)(
-        ompt_work_loop, ompt_scope_begin, &(team_info->parallel_data),
+        ompt_get_work_schedule(pr->schedule), ompt_scope_begin, &(team_info->parallel_data),
         &(task_info->task_data), pr->u.p.tc, OMPT_LOAD_RETURN_ADDRESS(gtid));
   }
 #endif
@@ -2121,7 +2121,7 @@ int __kmp_dispatch_next_algorithm(int gtid,
       ompt_team_info_t *team_info = __ompt_get_teaminfo(0, NULL);              \
       ompt_task_info_t *task_info = __ompt_get_task_info_object(0);            \
       ompt_callbacks.ompt_callback(ompt_callback_work)(                        \
-          ompt_work_loop, ompt_scope_end, &(team_info->parallel_data),         \
+          ompt_get_work_schedule(pr->schedule), ompt_scope_end, &(team_info->parallel_data),         \
           &(task_info->task_data), 0, codeptr);                                \
     }                                                                          \
   }

--- a/openmp/runtime/src/kmp_sched.cpp
+++ b/openmp/runtime/src/kmp_sched.cpp
@@ -103,7 +103,7 @@ static void __kmp_for_static_init(ident_t *loc, kmp_int32 global_tid,
 #if OMPT_SUPPORT && OMPT_OPTIONAL
   ompt_team_info_t *team_info = NULL;
   ompt_task_info_t *task_info = NULL;
-  ompt_work_t ompt_work_type = ompt_work_loop;
+  ompt_work_t ompt_work_type = ompt_work_loop_static;
 
   static kmp_int8 warn = 0;
 
@@ -114,7 +114,7 @@ static void __kmp_for_static_init(ident_t *loc, kmp_int32 global_tid,
     // Determine workshare type
     if (loc != NULL) {
       if ((loc->flags & KMP_IDENT_WORK_LOOP) != 0) {
-        ompt_work_type = ompt_work_loop;
+        ompt_work_type = ompt_work_loop_static;
       } else if ((loc->flags & KMP_IDENT_WORK_SECTIONS) != 0) {
         ompt_work_type = ompt_work_sections;
       } else if ((loc->flags & KMP_IDENT_WORK_DISTRIBUTE) != 0) {

--- a/openmp/runtime/src/ompt-specific.h
+++ b/openmp/runtime/src/ompt-specific.h
@@ -133,7 +133,7 @@ inline const char *ompt_get_runtime_version() {
 inline ompt_work_t ompt_get_work_schedule(enum sched_type schedule) {
   switch (SCHEDULE_WITHOUT_MODIFIERS(schedule)) {
   case kmp_sch_static_chunked:
-  case kmp_sch_static_balanced: // Chunk is calculated in the switch above
+  case kmp_sch_static_balanced:
   case kmp_sch_static_greedy:
     return ompt_work_loop_static;
   case kmp_sch_dynamic_chunked:

--- a/openmp/runtime/src/ompt-specific.h
+++ b/openmp/runtime/src/ompt-specific.h
@@ -130,8 +130,7 @@ inline const char *ompt_get_runtime_version() {
   return &__kmp_version_lib_ver[KMP_VERSION_MAGIC_LEN];
 }
 
-inline ompt_work_t ompt_get_work_schedule(enum sched_type schedule){
-  printf("Schedule val: %i\n", schedule);
+inline ompt_work_t ompt_get_work_schedule(enum sched_type schedule) {
   switch (SCHEDULE_WITHOUT_MODIFIERS(schedule)) {
   case kmp_sch_static_chunked:
   case kmp_sch_static_balanced: // Chunk is calculated in the switch above
@@ -149,8 +148,6 @@ inline ompt_work_t ompt_get_work_schedule(enum sched_type schedule){
     return ompt_work_loop_other;
   }
 }
-
-
 
 class OmptReturnAddressGuard {
 private:

--- a/openmp/runtime/src/ompt-specific.h
+++ b/openmp/runtime/src/ompt-specific.h
@@ -130,6 +130,28 @@ inline const char *ompt_get_runtime_version() {
   return &__kmp_version_lib_ver[KMP_VERSION_MAGIC_LEN];
 }
 
+inline ompt_work_t ompt_get_work_schedule(enum sched_type schedule){
+  printf("Schedule val: %i\n", schedule);
+  switch (SCHEDULE_WITHOUT_MODIFIERS(schedule)) {
+  case kmp_sch_static_chunked:
+  case kmp_sch_static_balanced: // Chunk is calculated in the switch above
+  case kmp_sch_static_greedy:
+    return ompt_work_loop_static;
+  case kmp_sch_dynamic_chunked:
+  case kmp_sch_static_steal:
+    return ompt_work_loop_dynamic;
+  case kmp_sch_guided_iterative_chunked:
+  case kmp_sch_guided_analytical_chunked:
+  case kmp_sch_guided_chunked:
+  case kmp_sch_guided_simd:
+    return ompt_work_loop_guided;
+  default:
+    return ompt_work_loop_other;
+  }
+}
+
+
+
 class OmptReturnAddressGuard {
 private:
   bool SetAddress{false};

--- a/openmp/runtime/test/ompt/callback.h
+++ b/openmp/runtime/test/ompt/callback.h
@@ -47,6 +47,40 @@ static const char* ompt_cancel_flag_t_values[] = {
   "ompt_cancel_discarded_task"
 };
 
+static const char* ompt_work_t_values[] = {
+  "undefined",
+  "ompt_work_loop",
+  "ompt_work_sections",
+  "ompt_work_single_executor",
+  "ompt_work_single_other",
+  "ompt_work_workshare",
+  "ompt_work_distribute",
+  "ompt_work_taskloop",
+  "ompt_work_scope",
+  "ompt_work_workdistribute",
+  "ompt_work_loop_static",
+  "ompt_work_loop_dynamic",
+  "ompt_work_loop_guided",
+  "ompt_work_loop_other"
+};
+
+static const char* ompt_work_events_t_values[] = {
+  "undefined",
+  "ompt_event_loop",
+  "ompt_event_sections",
+  "ompt_event_single_in_block",
+  "ompt_event_single_others",
+  "ompt_event_workshare",
+  "ompt_event_distribute",
+  "ompt_event_taskloop",
+  "ompt_event_scope",
+  "ompt_event_workdistribute",
+  "ompt_event_loop_static",
+  "ompt_event_loop_dynamic",
+  "ompt_event_loop_guided",
+  "ompt_event_loop_other"
+};
+
 static const char *ompt_dependence_type_t_values[36] = {
     "ompt_dependence_type_UNDEFINED",
     "ompt_dependence_type_in", // 1
@@ -853,140 +887,20 @@ on_ompt_callback_work(
   switch(endpoint)
   {
     case ompt_scope_begin:
-      switch(wstype)
-      {
-        case ompt_work_loop:
-        case ompt_work_loop_static:
-        case ompt_work_loop_dynamic:
-        case ompt_work_loop_guided:
-        case ompt_work_loop_other:
-        // TODO: add schedule attribute for the different work_loop types.
-        // e.g., ", schedule=%s", ..., ompt_schedule_values[wstype]
           printf("%" PRIu64 ":" _TOOL_PREFIX
-                 " ompt_event_loop_begin: parallel_id=%" PRIu64
-                 ", parent_task_id=%" PRIu64 ", codeptr_ra=%p, count=%" PRIu64
+                 " %s_begin: parallel_id=%" PRIu64
+                 ", task_id=%" PRIu64 ", codeptr_ra=%p, count=%" PRIu64
                  "\n",
-                 ompt_get_thread_data()->value, parallel_data->value,
+                 ompt_get_thread_data()->value, ompt_work_events_t_values[wstype], parallel_data->value,
                  task_data->value, codeptr_ra, count);
-          break;
-        case ompt_work_sections:
-          printf("%" PRIu64 ":" _TOOL_PREFIX
-                 " ompt_event_sections_begin: parallel_id=%" PRIu64
-                 ", parent_task_id=%" PRIu64 ", codeptr_ra=%p, count=%" PRIu64
-                 "\n",
-                 ompt_get_thread_data()->value, parallel_data->value,
-                 task_data->value, codeptr_ra, count);
-          break;
-        case ompt_work_single_executor:
-          printf("%" PRIu64 ":" _TOOL_PREFIX
-                 " ompt_event_single_in_block_begin: parallel_id=%" PRIu64
-                 ", parent_task_id=%" PRIu64 ", codeptr_ra=%p, count=%" PRIu64
-                 "\n",
-                 ompt_get_thread_data()->value, parallel_data->value,
-                 task_data->value, codeptr_ra, count);
-          break;
-        case ompt_work_single_other:
-          printf("%" PRIu64 ":" _TOOL_PREFIX
-                 " ompt_event_single_others_begin: parallel_id=%" PRIu64
-                 ", task_id=%" PRIu64 ", codeptr_ra=%p, count=%" PRIu64 "\n",
-                 ompt_get_thread_data()->value, parallel_data->value,
-                 task_data->value, codeptr_ra, count);
-          break;
-        case ompt_work_workshare:
-          //impl
-          break;
-        case ompt_work_distribute:
-          printf("%" PRIu64 ":" _TOOL_PREFIX
-                 " ompt_event_distribute_begin: parallel_id=%" PRIu64
-                 ", parent_task_id=%" PRIu64 ", codeptr_ra=%p, count=%" PRIu64
-                 "\n",
-                 ompt_get_thread_data()->value, parallel_data->value,
-                 task_data->value, codeptr_ra, count);
-          break;
-        case ompt_work_taskloop:
-          //impl
-          printf("%" PRIu64 ":" _TOOL_PREFIX
-                 " ompt_event_taskloop_begin: parallel_id=%" PRIu64
-                 ", parent_task_id=%" PRIu64 ", codeptr_ra=%p, count=%" PRIu64
-                 "\n",
-                 ompt_get_thread_data()->value, parallel_data->value,
-                 task_data->value, codeptr_ra, count);
-          break;
-        case ompt_work_scope:
-          printf("%" PRIu64 ":" _TOOL_PREFIX
-                 " ompt_event_scope_begin: parallel_id=%" PRIu64
-                 ", parent_task_id=%" PRIu64 ", codeptr_ra=%p, count=%" PRIu64
-                 "\n",
-                 ompt_get_thread_data()->value, parallel_data->value,
-                 task_data->value, codeptr_ra, count);
-          break;
-      }
-      break;
+    break;
     case ompt_scope_end:
-      switch(wstype)
-      {
-        case ompt_work_loop:
-        case ompt_work_loop_static:
-        case ompt_work_loop_dynamic:
-        case ompt_work_loop_guided:
-        case ompt_work_loop_other:
-          printf("%" PRIu64 ":" _TOOL_PREFIX
-                 " ompt_event_loop_end: parallel_id=%" PRIu64
-                 ", task_id=%" PRIu64 ", codeptr_ra=%p, count=%" PRIu64 "\n",
-                 ompt_get_thread_data()->value, parallel_data->value,
-                 task_data->value, codeptr_ra, count);
-          break;
-        case ompt_work_sections:
-          printf("%" PRIu64 ":" _TOOL_PREFIX
-                 " ompt_event_sections_end: parallel_id=%" PRIu64
-                 ", task_id=%" PRIu64 ", codeptr_ra=%p, count=%" PRIu64 "\n",
-                 ompt_get_thread_data()->value, parallel_data->value,
-                 task_data->value, codeptr_ra, count);
-          break;
-        case ompt_work_single_executor:
-          printf("%" PRIu64 ":" _TOOL_PREFIX
-                 " ompt_event_single_in_block_end: parallel_id=%" PRIu64
-                 ", task_id=%" PRIu64 ", codeptr_ra=%p, count=%" PRIu64 "\n",
-                 ompt_get_thread_data()->value, parallel_data->value,
-                 task_data->value, codeptr_ra, count);
-          break;
-        case ompt_work_single_other:
-          printf("%" PRIu64 ":" _TOOL_PREFIX
-                 " ompt_event_single_others_end: parallel_id=%" PRIu64
-                 ", task_id=%" PRIu64 ", codeptr_ra=%p, count=%" PRIu64 "\n",
-                 ompt_get_thread_data()->value, parallel_data->value,
-                 task_data->value, codeptr_ra, count);
-          break;
-        case ompt_work_workshare:
-          //impl
-          break;
-        case ompt_work_distribute:
-          printf("%" PRIu64 ":" _TOOL_PREFIX
-                 " ompt_event_distribute_end: parallel_id=%" PRIu64
-                 ", parent_task_id=%" PRIu64 ", codeptr_ra=%p, count=%" PRIu64
-                 "\n",
-                 ompt_get_thread_data()->value, parallel_data->value,
-                 task_data->value, codeptr_ra, count);
-          break;
-        case ompt_work_taskloop:
-          //impl
-          printf("%" PRIu64 ":" _TOOL_PREFIX
-                 " ompt_event_taskloop_end: parallel_id=%" PRIu64
-                 ", parent_task_id=%" PRIu64 ", codeptr_ra=%p, count=%" PRIu64
-                 "\n",
-                 ompt_get_thread_data()->value, parallel_data->value,
-                 task_data->value, codeptr_ra, count);
-          break;
-        case ompt_work_scope:
-          printf("%" PRIu64 ":" _TOOL_PREFIX
-                 " ompt_event_scope_end: parallel_id=%" PRIu64
-                 ", parent_task_id=%" PRIu64 ", codeptr_ra=%p, count=%" PRIu64
-                 "\n",
-                 ompt_get_thread_data()->value, parallel_data->value,
-                 task_data->value, codeptr_ra, count);
-          break;
-      }
-      break;
+    printf("%" PRIu64 ":" _TOOL_PREFIX
+            " %s_end: parallel_id=%" PRIu64
+            ", task_id=%" PRIu64 ", codeptr_ra=%p, count=%" PRIu64 "\n",
+            ompt_get_thread_data()->value, ompt_work_events_t_values[wstype], parallel_data->value,
+            task_data->value, codeptr_ra, count);
+    break;
     case ompt_scope_beginend:
       printf("ompt_scope_beginend should never be passed to %s\n", __func__);
       exit(-1);

--- a/openmp/runtime/test/ompt/callback.h
+++ b/openmp/runtime/test/ompt/callback.h
@@ -47,39 +47,35 @@ static const char* ompt_cancel_flag_t_values[] = {
   "ompt_cancel_discarded_task"
 };
 
-static const char* ompt_work_t_values[] = {
-  "undefined",
-  "ompt_work_loop",
-  "ompt_work_sections",
-  "ompt_work_single_executor",
-  "ompt_work_single_other",
-  "ompt_work_workshare",
-  "ompt_work_distribute",
-  "ompt_work_taskloop",
-  "ompt_work_scope",
-  "ompt_work_workdistribute",
-  "ompt_work_loop_static",
-  "ompt_work_loop_dynamic",
-  "ompt_work_loop_guided",
-  "ompt_work_loop_other"
-};
+static const char *ompt_work_t_values[] = {"undefined",
+                                           "ompt_work_loop",
+                                           "ompt_work_sections",
+                                           "ompt_work_single_executor",
+                                           "ompt_work_single_other",
+                                           "ompt_work_workshare",
+                                           "ompt_work_distribute",
+                                           "ompt_work_taskloop",
+                                           "ompt_work_scope",
+                                           "ompt_work_workdistribute",
+                                           "ompt_work_loop_static",
+                                           "ompt_work_loop_dynamic",
+                                           "ompt_work_loop_guided",
+                                           "ompt_work_loop_other"};
 
-static const char* ompt_work_events_t_values[] = {
-  "undefined",
-  "ompt_event_loop",
-  "ompt_event_sections",
-  "ompt_event_single_in_block",
-  "ompt_event_single_others",
-  "ompt_event_workshare",
-  "ompt_event_distribute",
-  "ompt_event_taskloop",
-  "ompt_event_scope",
-  "ompt_event_workdistribute",
-  "ompt_event_loop_static",
-  "ompt_event_loop_dynamic",
-  "ompt_event_loop_guided",
-  "ompt_event_loop_other"
-};
+static const char *ompt_work_events_t_values[] = {"undefined",
+                                                  "ompt_event_loop",
+                                                  "ompt_event_sections",
+                                                  "ompt_event_single_in_block",
+                                                  "ompt_event_single_others",
+                                                  "ompt_event_workshare",
+                                                  "ompt_event_distribute",
+                                                  "ompt_event_taskloop",
+                                                  "ompt_event_scope",
+                                                  "ompt_event_workdistribute",
+                                                  "ompt_event_loop_static",
+                                                  "ompt_event_loop_dynamic",
+                                                  "ompt_event_loop_guided",
+                                                  "ompt_event_loop_other"};
 
 static const char *ompt_dependence_type_t_values[36] = {
     "ompt_dependence_type_UNDEFINED",
@@ -886,24 +882,21 @@ on_ompt_callback_work(
 {
   switch(endpoint)
   {
-    case ompt_scope_begin:
-          printf("%" PRIu64 ":" _TOOL_PREFIX
-                 " %s_begin: parallel_id=%" PRIu64
-                 ", task_id=%" PRIu64 ", codeptr_ra=%p, count=%" PRIu64
-                 "\n",
-                 ompt_get_thread_data()->value, ompt_work_events_t_values[wstype], parallel_data->value,
-                 task_data->value, codeptr_ra, count);
+  case ompt_scope_begin:
+    printf("%" PRIu64 ":" _TOOL_PREFIX " %s_begin: parallel_id=%" PRIu64
+           ", task_id=%" PRIu64 ", codeptr_ra=%p, count=%" PRIu64 "\n",
+           ompt_get_thread_data()->value, ompt_work_events_t_values[wstype],
+           parallel_data->value, task_data->value, codeptr_ra, count);
     break;
-    case ompt_scope_end:
-    printf("%" PRIu64 ":" _TOOL_PREFIX
-            " %s_end: parallel_id=%" PRIu64
-            ", task_id=%" PRIu64 ", codeptr_ra=%p, count=%" PRIu64 "\n",
-            ompt_get_thread_data()->value, ompt_work_events_t_values[wstype], parallel_data->value,
-            task_data->value, codeptr_ra, count);
+  case ompt_scope_end:
+    printf("%" PRIu64 ":" _TOOL_PREFIX " %s_end: parallel_id=%" PRIu64
+           ", task_id=%" PRIu64 ", codeptr_ra=%p, count=%" PRIu64 "\n",
+           ompt_get_thread_data()->value, ompt_work_events_t_values[wstype],
+           parallel_data->value, task_data->value, codeptr_ra, count);
     break;
-    case ompt_scope_beginend:
-      printf("ompt_scope_beginend should never be passed to %s\n", __func__);
-      exit(-1);
+  case ompt_scope_beginend:
+    printf("ompt_scope_beginend should never be passed to %s\n", __func__);
+    exit(-1);
   }
 }
 

--- a/openmp/runtime/test/ompt/synchronization/ordered_dependences.c
+++ b/openmp/runtime/test/ompt/synchronization/ordered_dependences.c
@@ -7,7 +7,7 @@
 int main() {
   int a[10][10];
 #pragma omp parallel num_threads(2)
-#pragma omp for ordered(2)
+#pragma omp for ordered(2) schedule(static)
   for (int i = 0; i < 2; i++)
     for (int j = 0; j < 2; j++) {
       a[i][j] = i + j + 1;
@@ -23,8 +23,8 @@ int main() {
 }
 // CHECK: 0: NULL_POINTER=[[NULL:.*$]]
 
-// CHECK: {{^}}[[MASTER:[0-9]+]]: ompt_event_loop_begin:
-// CHECK-SAME: parallel_id={{[0-9]+}}, parent_task_id=[[ITASK:[0-9]+]],
+// CHECK: {{^}}[[MASTER:[0-9]+]]: ompt_event_loop_static_begin:
+// CHECK-SAME: parallel_id={{[0-9]+}}, task_id=[[ITASK:[0-9]+]],
 
 // CHECK: {{^}}[[MASTER]]: ompt_event_dependences: task_id=[[ITASK]],
 // CHECK-SAME: deps=[(0, ompt_dependence_type_source), (0,
@@ -38,8 +38,8 @@ int main() {
 // CHECK-SAME: deps=[(0, ompt_dependence_type_source), (1,
 // CHECK-SAME: ompt_dependence_type_source)], ndeps=2
 
-// CHECK: {{^}}[[WORKER:[0-9]+]]: ompt_event_loop_begin:
-// CHECK-SAME: parallel_id={{[0-9]+}}, parent_task_id=[[ITASK:[0-9]+]],
+// CHECK: {{^}}[[WORKER:[0-9]+]]: ompt_event_loop_static_begin:
+// CHECK-SAME: parallel_id={{[0-9]+}}, task_id=[[ITASK:[0-9]+]],
 
 // CHECK: {{^}}[[WORKER]]: ompt_event_dependences: task_id=[[ITASK]],
 // CHECK-SAME: deps=[(0, ompt_dependence_type_sink), (0,

--- a/openmp/runtime/test/ompt/tasks/taskloop.c
+++ b/openmp/runtime/test/ompt/tasks/taskloop.c
@@ -37,7 +37,7 @@ int main() {
   // CHECK-SAME: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID1]]
   // CHECK: {{^}}[[MASTER_ID]]: ompt_event_taskloop_begin:
   // CHECK-SAME: parallel_id=[[PARALLEL_ID]]
-  // CHECK-SAME: parent_task_id=[[IMPLICIT_TASK_ID1]]
+  // CHECK-SAME: task_id=[[IMPLICIT_TASK_ID1]]
   // CHECK-SAME: codeptr_ra=[[RETURN_ADDRESS:0x[0-f]+]], count=2
   // CHECK: {{^}}[[MASTER_ID]]: ompt_event_task_create:
   // CHECK-SAME: parent_task_id=[[IMPLICIT_TASK_ID1]]
@@ -52,7 +52,7 @@ int main() {
   // CHECK-NOT: {{^}}[[MASTER_ID]]: ompt_event_task_create:
   // CHECK: {{^}}[[MASTER_ID]]: ompt_event_taskloop_end:
   // CHECK-SAME: parallel_id=[[PARALLEL_ID]]
-  // CHECK-SAME: parent_task_id=[[IMPLICIT_TASK_ID1]]
+  // CHECK-SAME: task_id=[[IMPLICIT_TASK_ID1]]
   // CHECK-SAME: count=2
   // CHECK-DAG: {{^}}[[MASTER_ID]]: ompt_event_wait_taskgroup_begin:
   // CHECK: {{^}}[[MASTER_ID]]: ompt_event_wait_taskgroup_end:

--- a/openmp/runtime/test/ompt/tasks/taskloop_dispatch.c
+++ b/openmp/runtime/test/ompt/tasks/taskloop_dispatch.c
@@ -32,7 +32,7 @@ int main() {
 
   // CHECK: {{^}}[[MASTER_ID]]: ompt_event_taskloop_begin:
   // CHECK-SAME: parallel_id=[[PARALLEL_ID]]
-  // CHECK-SAME: parent_task_id=[[IMPLICIT_TASK_ID1]]
+  // CHECK-SAME: task_id=[[IMPLICIT_TASK_ID1]]
   // CHECK-SAME: codeptr_ra=[[RETURN_ADDRESS:0x[0-f]+]], count=16
 
   // CHECK: {{^}}[[MASTER_ID]]: ompt_event_task_create:

--- a/openmp/runtime/test/ompt/teams/distribute_dispatch.c
+++ b/openmp/runtime/test/ompt/teams/distribute_dispatch.c
@@ -24,28 +24,28 @@ int main() {
 
 // CHECK: {{^}}[[THREAD_ID0:[0-9]+]]: ompt_event_distribute_begin:
 // CHECK-SAME: parallel_id=[[PARALLEL_ID0:[0-9]+]]
-// CHECK-SAME: parent_task_id=[[TASK_ID0:[0-9]+]]
+// CHECK-SAME: task_id=[[TASK_ID0:[0-9]+]]
 // CHECK: {{^}}[[THREAD_ID0]]: ompt_event_distribute_chunk_begin:
 // CHECK-SAME: parallel_id=[[PARALLEL_ID0]], task_id=[[TASK_ID0]]
 // CHECK-SAME: chunk_start={{[0-9]+}}, chunk_iterations=16
 
 // CHECK: {{^}}[[THREAD_ID1:[0-9]+]]: ompt_event_distribute_begin:
 // CHECK-SAME: parallel_id=[[PARALLEL_ID1:[0-9]+]]
-// CHECK-SAME: parent_task_id=[[TASK_ID1:[0-9]+]]
+// CHECK-SAME: task_id=[[TASK_ID1:[0-9]+]]
 // CHECK: {{^}}[[THREAD_ID1]]: ompt_event_distribute_chunk_begin:
 // CHECK-SAME: parallel_id=[[PARALLEL_ID1]], task_id=[[TASK_ID1]]
 // CHECK-SAME: chunk_start={{[0-9]+}}, chunk_iterations=16
 
 // CHECK: {{^}}[[THREAD_ID2:[0-9]+]]: ompt_event_distribute_begin:
 // CHECK-SAME: parallel_id=[[PARALLEL_ID2:[0-9]+]]
-// CHECK-SAME: parent_task_id=[[TASK_ID2:[0-9]+]]
+// CHECK-SAME: task_id=[[TASK_ID2:[0-9]+]]
 // CHECK: {{^}}[[THREAD_ID2]]: ompt_event_distribute_chunk_begin:
 // CHECK-SAME: parallel_id=[[PARALLEL_ID2]], task_id=[[TASK_ID2]]
 // CHECK-SAME: chunk_start={{[0-9]+}}, chunk_iterations=16
 
 // CHECK: {{^}}[[THREAD_ID3:[0-9]+]]: ompt_event_distribute_begin:
 // CHECK-SAME: parallel_id=[[PARALLEL_ID3:[0-9]+]]
-// CHECK-SAME: parent_task_id=[[TASK_ID3:[0-9]+]]
+// CHECK-SAME: task_id=[[TASK_ID3:[0-9]+]]
 // CHECK: {{^}}[[THREAD_ID3]]: ompt_event_distribute_chunk_begin:
 // CHECK-SAME: parallel_id=[[PARALLEL_ID3]], task_id=[[TASK_ID3]]
 // CHECK-SAME: chunk_start={{[0-9]+}}, chunk_iterations=16

--- a/openmp/runtime/test/ompt/worksharing/for/auto.c
+++ b/openmp/runtime/test/ompt/worksharing/for/auto.c
@@ -4,7 +4,7 @@
 // XFAIL: gcc
 
 #define SCHEDULE auto
-// The runtime uses guided schedule for auto, 
+// The runtime uses guided schedule for auto,
 // which is a reason choice
 #define SCHED_OUTPUT "guided"
 #include "base.h"

--- a/openmp/runtime/test/ompt/worksharing/for/auto.c
+++ b/openmp/runtime/test/ompt/worksharing/for/auto.c
@@ -4,4 +4,7 @@
 // XFAIL: gcc
 
 #define SCHEDULE auto
+// The runtime uses guided schedule for auto, 
+// which is a reason choice
+#define SCHED_OUTPUT "guided"
 #include "base.h"

--- a/openmp/runtime/test/ompt/worksharing/for/auto_serialized.c
+++ b/openmp/runtime/test/ompt/worksharing/for/auto_serialized.c
@@ -4,4 +4,7 @@
 // XFAIL: gcc
 
 #define SCHEDULE auto
+// The runtime uses static schedule for serialized loop, 
+// which is a reason choice
+#define SCHED_OUTPUT "static"
 #include "base_serialized.h"

--- a/openmp/runtime/test/ompt/worksharing/for/auto_serialized.c
+++ b/openmp/runtime/test/ompt/worksharing/for/auto_serialized.c
@@ -4,7 +4,7 @@
 // XFAIL: gcc
 
 #define SCHEDULE auto
-// The runtime uses static schedule for serialized loop, 
+// The runtime uses static schedule for serialized loop,
 // which is a reason choice
 #define SCHED_OUTPUT "static"
 #include "base_serialized.h"

--- a/openmp/runtime/test/ompt/worksharing/for/auto_split.c
+++ b/openmp/runtime/test/ompt/worksharing/for/auto_split.c
@@ -5,7 +5,7 @@
 // XFAIL: gcc
 
 #define SCHEDULE auto
-// The runtime uses guided schedule for auto, 
+// The runtime uses guided schedule for auto,
 // which is a reason choice
 #define SCHED_OUTPUT "guided"
 #include "base_split.h"

--- a/openmp/runtime/test/ompt/worksharing/for/auto_split.c
+++ b/openmp/runtime/test/ompt/worksharing/for/auto_split.c
@@ -5,4 +5,7 @@
 // XFAIL: gcc
 
 #define SCHEDULE auto
+// The runtime uses guided schedule for auto, 
+// which is a reason choice
+#define SCHED_OUTPUT "guided"
 #include "base_split.h"

--- a/openmp/runtime/test/ompt/worksharing/for/base.h
+++ b/openmp/runtime/test/ompt/worksharing/for/base.h
@@ -1,12 +1,20 @@
 #include "callback.h"
 #include <omp.h>
+#include <stdio.h>
+
+#define STRINGIFY(x) #x
+#define STR(x) STRINGIFY(x)
+#ifndef SCHED_OUTPUT
+#define SCHED_OUTPUT STR(SCHEDULE)
+#endif
 
 int main()
 {
   unsigned int i;
+  printf("0: Schedule: " SCHED_OUTPUT "\n");
 
   #pragma omp parallel for num_threads(4) schedule(SCHEDULE)
-  for (i = 0; i < 4; i++) {
+  for (i = 0; i < 100; i++) {
   }
 
   // Check if libomp supports the callbacks for this test.
@@ -15,28 +23,28 @@ int main()
   // CHECK-NOT: {{^}}0: Could not register callback 'ompt_callback_implicit_task'
   // CHECK-NOT: {{^}}0: Could not register callback 'ompt_callback_work'
 
-
   // CHECK: 0: NULL_POINTER=[[NULL:.*$]]
+  // CHECK: 0: Schedule: [[SCHED:[a-z]+]]
   // CHECK: {{^}}[[MASTER_ID:[0-9]+]]: ompt_event_parallel_begin: parent_task_id={{[0-9]+}}, parent_task_frame.exit=[[NULL]], parent_task_frame.reenter={{0x[0-f]+}}, parallel_id=[[PARALLEL_ID:[0-9]+]], requested_team_size=4, codeptr_ra=0x{{[0-f]+}}, invoker={{[0-9]+}}
 
   // CHECK: {{^}}[[MASTER_ID]]: ompt_event_implicit_task_begin: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID:[0-9]+]]
-  // CHECK: {{^}}[[MASTER_ID]]: ompt_event_loop_begin: parallel_id=[[PARALLEL_ID]], parent_task_id=[[IMPLICIT_TASK_ID]], codeptr_ra=
-  // CHECK: {{^}}[[MASTER_ID]]: ompt_event_loop_end: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]]
+  // CHECK: {{^}}[[MASTER_ID]]: ompt_event_loop_[[SCHED]]_begin: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]], codeptr_ra=
+  // CHECK: {{^}}[[MASTER_ID]]: ompt_event_loop_[[SCHED]]_end: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]]
   // CHECK: {{^}}[[MASTER_ID]]: ompt_event_implicit_task_end: parallel_id={{[0-9]+}}, task_id=[[IMPLICIT_TASK_ID]]
 
   // CHECK: {{^}}[[THREAD_ID:[0-9]+]]: ompt_event_implicit_task_begin: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID:[0-9]+]]
-  // CHECK: {{^}}[[THREAD_ID]]: ompt_event_loop_begin: parallel_id=[[PARALLEL_ID]], parent_task_id=[[IMPLICIT_TASK_ID]], codeptr_ra=
-  // CHECK: {{^}}[[THREAD_ID]]: ompt_event_loop_end: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]]
+  // CHECK: {{^}}[[THREAD_ID]]: ompt_event_loop_[[SCHED]]_begin: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]], codeptr_ra=
+  // CHECK: {{^}}[[THREAD_ID]]: ompt_event_loop_[[SCHED]]_end: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]]
   // CHECK: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_end: parallel_id={{[0-9]+}}, task_id=[[IMPLICIT_TASK_ID]]
 
   // CHECK: {{^}}[[THREAD_ID:[0-9]+]]: ompt_event_implicit_task_begin: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID:[0-9]+]]
-  // CHECK: {{^}}[[THREAD_ID]]: ompt_event_loop_begin: parallel_id=[[PARALLEL_ID]], parent_task_id=[[IMPLICIT_TASK_ID]], codeptr_ra=
-  // CHECK: {{^}}[[THREAD_ID]]: ompt_event_loop_end: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]]
+  // CHECK: {{^}}[[THREAD_ID]]: ompt_event_loop_[[SCHED]]_begin: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]], codeptr_ra=
+  // CHECK: {{^}}[[THREAD_ID]]: ompt_event_loop_[[SCHED]]_end: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]]
   // CHECK: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_end: parallel_id={{[0-9]+}}, task_id=[[IMPLICIT_TASK_ID]]
 
   // CHECK: {{^}}[[THREAD_ID:[0-9]+]]: ompt_event_implicit_task_begin: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID:[0-9]+]]
-  // CHECK: {{^}}[[THREAD_ID]]: ompt_event_loop_begin: parallel_id=[[PARALLEL_ID]], parent_task_id=[[IMPLICIT_TASK_ID]], codeptr_ra=
-  // CHECK: {{^}}[[THREAD_ID]]: ompt_event_loop_end: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]]
+  // CHECK: {{^}}[[THREAD_ID]]: ompt_event_loop_[[SCHED]]_begin: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]], codeptr_ra=
+  // CHECK: {{^}}[[THREAD_ID]]: ompt_event_loop_[[SCHED]]_end: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]]
   // CHECK: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_end: parallel_id={{[0-9]+}}, task_id=[[IMPLICIT_TASK_ID]]
 
   return 0;

--- a/openmp/runtime/test/ompt/worksharing/for/base.h
+++ b/openmp/runtime/test/ompt/worksharing/for/base.h
@@ -13,10 +13,11 @@ int main()
   unsigned int i;
   printf("0: Schedule: " SCHED_OUTPUT "\n");
 
-  #pragma omp parallel for num_threads(4) schedule(SCHEDULE)
-  for (i = 0; i < 100; i++) {
+#pragma omp parallel for num_threads(4) schedule(SCHEDULE)
+  for (i = 0; i < 64; i++) {
   }
 
+  // clang-format off
   // Check if libomp supports the callbacks for this test.
   // CHECK-NOT: {{^}}0: Could not register callback 'ompt_callback_parallel_begin'
   // CHECK-NOT: {{^}}0: Could not register callback 'ompt_callback_parallel_end'
@@ -46,6 +47,7 @@ int main()
   // CHECK: {{^}}[[THREAD_ID]]: ompt_event_loop_[[SCHED]]_begin: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]], codeptr_ra=
   // CHECK: {{^}}[[THREAD_ID]]: ompt_event_loop_[[SCHED]]_end: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]]
   // CHECK: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_end: parallel_id={{[0-9]+}}, task_id=[[IMPLICIT_TASK_ID]]
+  // clang-format on
 
   return 0;
 }

--- a/openmp/runtime/test/ompt/worksharing/for/base_serialized.h
+++ b/openmp/runtime/test/ompt/worksharing/for/base_serialized.h
@@ -1,12 +1,20 @@
 #include "callback.h"
 #include <omp.h>
+#include <stdio.h>
+
+#define STRINGIFY(x) #x
+#define STR(x) STRINGIFY(x)
+#ifndef SCHED_OUTPUT
+#define SCHED_OUTPUT STR(SCHEDULE)
+#endif
 
 int main()
 {
   unsigned int i;
+  printf("0: Schedule: " SCHED_OUTPUT "\n");
 
   #pragma omp parallel for num_threads(1) schedule(SCHEDULE)
-  for (i = 0; i < 1; i++) {
+  for (i = 0; i < 100; i++) {
   }
   
   // Check if libomp supports the callbacks for this test.
@@ -17,11 +25,12 @@ int main()
 
 
   // CHECK: 0: NULL_POINTER=[[NULL:.*$]]
+  // CHECK: 0: Schedule: [[SCHED:[a-z]+]]
   // CHECK: {{^}}[[MASTER_ID:[0-9]+]]: ompt_event_parallel_begin: parent_task_id=[[PARENT_TASK_ID:[0-9]+]], parent_task_frame.exit=[[NULL]], parent_task_frame.reenter={{0x[0-f]+}}, parallel_id=[[PARALLEL_ID:[0-9]+]], requested_team_size=1, codeptr_ra=0x{{[0-f]+}}, invoker={{[0-9]+}}
 
   // CHECK: {{^}}[[MASTER_ID]]: ompt_event_implicit_task_begin: parallel_id=[[PARALLEL_ID:[0-9]+]], task_id=[[IMPLICIT_TASK_ID:[0-9]+]]
-  // CHECK: {{^}}[[MASTER_ID]]: ompt_event_loop_begin: parallel_id=[[PARALLEL_ID]], parent_task_id=[[IMPLICIT_TASK_ID]], codeptr_ra=0x{{[0-f]+}}
-  // CHECK: {{^}}[[MASTER_ID]]: ompt_event_loop_end: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]]
+  // CHECK: {{^}}[[MASTER_ID]]: ompt_event_loop_[[SCHED]]_begin: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]], codeptr_ra=0x{{[0-f]+}}
+  // CHECK: {{^}}[[MASTER_ID]]: ompt_event_loop_[[SCHED]]_end: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]]
   // CHECK: {{^}}[[MASTER_ID]]: ompt_event_implicit_task_end: parallel_id={{[PARALLEL_ID,0]}}, task_id=[[IMPLICIT_TASK_ID]]
 
   return 0;

--- a/openmp/runtime/test/ompt/worksharing/for/base_serialized.h
+++ b/openmp/runtime/test/ompt/worksharing/for/base_serialized.h
@@ -13,10 +13,11 @@ int main()
   unsigned int i;
   printf("0: Schedule: " SCHED_OUTPUT "\n");
 
-  #pragma omp parallel for num_threads(1) schedule(SCHEDULE)
-  for (i = 0; i < 100; i++) {
+#pragma omp parallel for num_threads(1) schedule(SCHEDULE)
+  for (i = 0; i < 64; i++) {
   }
-  
+
+  // clang-format off
   // Check if libomp supports the callbacks for this test.
   // CHECK-NOT: {{^}}0: Could not register callback 'ompt_callback_parallel_begin'
   // CHECK-NOT: {{^}}0: Could not register callback 'ompt_callback_parallel_end'
@@ -32,6 +33,7 @@ int main()
   // CHECK: {{^}}[[MASTER_ID]]: ompt_event_loop_[[SCHED]]_begin: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]], codeptr_ra=0x{{[0-f]+}}
   // CHECK: {{^}}[[MASTER_ID]]: ompt_event_loop_[[SCHED]]_end: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]]
   // CHECK: {{^}}[[MASTER_ID]]: ompt_event_implicit_task_end: parallel_id={{[PARALLEL_ID,0]}}, task_id=[[IMPLICIT_TASK_ID]]
+  // clang-format on
 
   return 0;
 }

--- a/openmp/runtime/test/ompt/worksharing/for/base_split.h
+++ b/openmp/runtime/test/ompt/worksharing/for/base_split.h
@@ -1,5 +1,12 @@
 #include "callback.h"
 #include <omp.h>
+#include <stdio.h>
+
+#define STRINGIFY(x) #x
+#define STR(x) STRINGIFY(x)
+#ifndef SCHED_OUTPUT
+#define SCHED_OUTPUT STR(SCHEDULE)
+#endif
 
 /* With the combined parallel-for construct (base.h), the return-addresses are hard to compare.
    With the separate parallel and for-nowait construct, the addresses become more predictable,
@@ -10,12 +17,13 @@
 int main()
 {
   unsigned int i;
+  printf("0: Schedule: " SCHED_OUTPUT "\n");
 
   #pragma omp parallel num_threads(4) 
   {
     print_current_address(0);
     #pragma omp for schedule(SCHEDULE) nowait
-    for (i = 0; i < 4; i++) {
+    for (i = 0; i < 100; i++) {
       print_fuzzy_address(1);
     }
     print_fuzzy_address(2);
@@ -30,32 +38,34 @@ int main()
 
 
   // CHECK: 0: NULL_POINTER=[[NULL:.*$]]
+  // CHECK: 0: Schedule: [[SCHED:[a-z]+]]
   // CHECK: {{^}}[[MASTER_ID:[0-9]+]]: ompt_event_parallel_begin: parent_task_id={{[0-9]+}}, parent_task_frame.exit=[[NULL]], parent_task_frame.reenter={{0x[0-f]+}}, parallel_id=[[PARALLEL_ID:[0-9]+]], requested_team_size=4, codeptr_ra=[[PARALLEL_RETURN_ADDRESS:0x[0-f]+]]{{[0-f][0-f]}}, invoker={{[0-9]+}}
 
-  // CHECK: {{^}}[[MASTER_ID]]: ompt_event_loop_begin: parallel_id=[[PARALLEL_ID]], parent_task_id={{[0-9]+}}, codeptr_ra=[[LOOP_BEGIN_RETURN_ADDRESS:0x[0-f]+]]{{[0-f][0-f]}}
-  // CHECK: {{^}}[[MASTER_ID]]: ompt_event_loop_end: parallel_id=[[PARALLEL_ID]], task_id={{[0-9]+}}, codeptr_ra=[[LOOP_END_RETURN_ADDRESS:0x[0-f]+]]{{[0-f][0-f]}}
+  // CHECK: {{^}}[[MASTER_ID]]: ompt_event_loop_[[SCHED]]_begin: parallel_id=[[PARALLEL_ID]], task_id={{[0-9]+}}, codeptr_ra=[[LOOP_BEGIN_RETURN_ADDRESS:0x[0-f]+]]{{[0-f][0-f]}}
+  // CHECK: {{^}}[[MASTER_ID]]: ompt_event_loop_[[SCHED]]_end: parallel_id=[[PARALLEL_ID]], task_id={{[0-9]+}}, codeptr_ra=[[LOOP_END_RETURN_ADDRESS:0x[0-f]+]]{{[0-f][0-f]}}
   // CHECK: {{^}}[[MASTER_ID]]: fuzzy_address={{.*}}[[LOOP_END_RETURN_ADDRESS]]
 
   // CHECK: {{^}}[[MASTER_ID]]: ompt_event_parallel_end: parallel_id=[[PARALLEL_ID]], task_id={{[0-9]+}}, invoker={{[0-9]+}}, codeptr_ra=[[PARALLEL_RETURN_ADDRESS]]
   // CHECK: {{^}}[[MASTER_ID]]: fuzzy_address={{.*}}[[PARALLEL_RETURN_ADDRESS]]
   
-  // CHECK: {{^}}[[THREAD_ID:[0-9]+]]: ompt_event_loop_begin: parallel_id=[[PARALLEL_ID]], parent_task_id={{[0-9]+}}, codeptr_ra=0x{{[0-f]+}}
-  // CHECK: {{^}}[[THREAD_ID]]: ompt_event_loop_end: parallel_id=[[PARALLEL_ID]], task_id={{[0-9]+}}, codeptr_ra=[[LOOP_END_RETURN_ADDRESS:0x[0-f]+]]{{[0-f][0-f]}}
+  // CHECK: {{^}}[[THREAD_ID:[0-9]+]]: ompt_event_loop_[[SCHED]]_begin: parallel_id=[[PARALLEL_ID]], task_id={{[0-9]+}}, codeptr_ra=0x{{[0-f]+}}
+  // CHECK: {{^}}[[THREAD_ID]]: ompt_event_loop_[[SCHED]]_end: parallel_id=[[PARALLEL_ID]], task_id={{[0-9]+}}, codeptr_ra=[[LOOP_END_RETURN_ADDRESS:0x[0-f]+]]{{[0-f][0-f]}}
   // CHECK: {{^}}[[THREAD_ID]]: fuzzy_address={{.*}}[[LOOP_END_RETURN_ADDRESS]]
 
-  // CHECK: {{^}}[[THREAD_ID:[0-9]+]]: ompt_event_loop_begin: parallel_id=[[PARALLEL_ID]], parent_task_id={{[0-9]+}}, codeptr_ra=0x{{[0-f]+}}
-  // CHECK: {{^}}[[THREAD_ID]]: ompt_event_loop_end: parallel_id=[[PARALLEL_ID]], task_id={{[0-9]+}}, codeptr_ra=[[LOOP_END_RETURN_ADDRESS:0x[0-f]+]]{{[0-f][0-f]}}
+  // CHECK: {{^}}[[THREAD_ID:[0-9]+]]: ompt_event_loop_[[SCHED]]_begin: parallel_id=[[PARALLEL_ID]], task_id={{[0-9]+}}, codeptr_ra=0x{{[0-f]+}}
+  // CHECK: {{^}}[[THREAD_ID]]: ompt_event_loop_[[SCHED]]_end: parallel_id=[[PARALLEL_ID]], task_id={{[0-9]+}}, codeptr_ra=[[LOOP_END_RETURN_ADDRESS:0x[0-f]+]]{{[0-f][0-f]}}
   // CHECK: {{^}}[[THREAD_ID]]: fuzzy_address={{.*}}[[LOOP_END_RETURN_ADDRESS]]
 
-  // CHECK: {{^}}[[THREAD_ID:[0-9]+]]: ompt_event_loop_begin: parallel_id=[[PARALLEL_ID]], parent_task_id={{[0-9]+}}, codeptr_ra=0x{{[0-f]+}}
-  // CHECK: {{^}}[[THREAD_ID]]: ompt_event_loop_end: parallel_id=[[PARALLEL_ID]], task_id={{[0-9]+}}, codeptr_ra=[[LOOP_END_RETURN_ADDRESS:0x[0-f]+]]{{[0-f][0-f]}}
+  // CHECK: {{^}}[[THREAD_ID:[0-9]+]]: ompt_event_loop_[[SCHED]]_begin: parallel_id=[[PARALLEL_ID]], task_id={{[0-9]+}}, codeptr_ra=0x{{[0-f]+}}
+  // CHECK: {{^}}[[THREAD_ID]]: ompt_event_loop_[[SCHED]]_end: parallel_id=[[PARALLEL_ID]], task_id={{[0-9]+}}, codeptr_ra=[[LOOP_END_RETURN_ADDRESS:0x[0-f]+]]{{[0-f][0-f]}}
   // CHECK: {{^}}[[THREAD_ID]]: fuzzy_address={{.*}}[[LOOP_END_RETURN_ADDRESS]]
 
 
   // CHECK-LOOP: 0: NULL_POINTER=[[NULL:.*$]]
+  // CHECK-LOOP: 0: Schedule: [[SCHED:[a-z]+]]
   // CHECK-LOOP: 0: ompt_event_runtime_shutdown
   // CHECK-LOOP: {{^}}[[MASTER_ID:[0-9]+]]: ompt_event_parallel_begin: parent_task_id={{[0-9]+}}, parent_task_frame.exit=[[NULL]], parent_task_frame.reenter={{0x[0-f]+}}, parallel_id=[[PARALLEL_ID:[0-9]+]], requested_team_size=4, codeptr_ra={{0x[0-f]+}}, invoker={{[0-9]+}}
-  // CHECK-LOOP: {{^}}[[MASTER_ID]]: ompt_event_loop_begin: parallel_id=[[PARALLEL_ID]], parent_task_id={{[0-9]+}}, codeptr_ra=[[LOOP_BEGIN_RETURN_ADDRESS:0x[0-f]+]]{{[0-f][0-f]}}
+  // CHECK-LOOP: {{^}}[[MASTER_ID]]: ompt_event_loop_[[SCHED]]_begin: parallel_id=[[PARALLEL_ID]], task_id={{[0-9]+}}, codeptr_ra=[[LOOP_BEGIN_RETURN_ADDRESS:0x[0-f]+]]{{[0-f][0-f]}}
   // CHECK-LOOP: {{^}}{{[0-9]+}}: fuzzy_address={{.*}}[[LOOP_BEGIN_RETURN_ADDRESS]]
   // CHECK-LOOP: {{^}}{{[0-9]+}}: fuzzy_address={{.*}}[[LOOP_BEGIN_RETURN_ADDRESS]]
   // CHECK-LOOP: {{^}}{{[0-9]+}}: fuzzy_address={{.*}}[[LOOP_BEGIN_RETURN_ADDRESS]]

--- a/openmp/runtime/test/ompt/worksharing/for/base_split.h
+++ b/openmp/runtime/test/ompt/worksharing/for/base_split.h
@@ -19,17 +19,18 @@ int main()
   unsigned int i;
   printf("0: Schedule: " SCHED_OUTPUT "\n");
 
-  #pragma omp parallel num_threads(4) 
+#pragma omp parallel num_threads(4)
   {
     print_current_address(0);
     #pragma omp for schedule(SCHEDULE) nowait
-    for (i = 0; i < 100; i++) {
+    for (i = 0; i < 64; i++) {
       print_fuzzy_address(1);
     }
     print_fuzzy_address(2);
   }
   print_fuzzy_address(3);
 
+  // clang-format off
   // Check if libomp supports the callbacks for this test.
   // CHECK-NOT: {{^}}0: Could not register callback 'ompt_callback_parallel_begin'
   // CHECK-NOT: {{^}}0: Could not register callback 'ompt_callback_parallel_end'
@@ -70,7 +71,7 @@ int main()
   // CHECK-LOOP: {{^}}{{[0-9]+}}: fuzzy_address={{.*}}[[LOOP_BEGIN_RETURN_ADDRESS]]
   // CHECK-LOOP: {{^}}{{[0-9]+}}: fuzzy_address={{.*}}[[LOOP_BEGIN_RETURN_ADDRESS]]
   // CHECK-LOOP: {{^}}{{[0-9]+}}: fuzzy_address={{.*}}[[LOOP_BEGIN_RETURN_ADDRESS]]
-
+  // clang-format on
 
   return 0;
 }

--- a/openmp/runtime/test/ompt/worksharing/for/guided_serialized.c
+++ b/openmp/runtime/test/ompt/worksharing/for/guided_serialized.c
@@ -2,7 +2,7 @@
 // REQUIRES: ompt
 
 #define SCHEDULE guided
-// The runtime uses static schedule for serialized loop, 
+// The runtime uses static schedule for serialized loop,
 // which is a reason choice
 #define SCHED_OUTPUT "static"
 #include "base_serialized.h"

--- a/openmp/runtime/test/ompt/worksharing/for/guided_serialized.c
+++ b/openmp/runtime/test/ompt/worksharing/for/guided_serialized.c
@@ -2,4 +2,7 @@
 // REQUIRES: ompt
 
 #define SCHEDULE guided
+// The runtime uses static schedule for serialized loop, 
+// which is a reason choice
+#define SCHED_OUTPUT "static"
 #include "base_serialized.h"

--- a/openmp/runtime/test/ompt/worksharing/for/loop_dispatch.c
+++ b/openmp/runtime/test/ompt/worksharing/for/loop_dispatch.c
@@ -56,72 +56,72 @@ int main() {
 
 // CHECK: {{^}}[[THREAD_ID0]]: ompt_event_implicit_task_begin:
 // CHECK-SAME: task_id=[[TASK_ID0:[0-9]+]]
-// CHECK: {{^}}[[THREAD_ID0]]: ompt_event_loop_begin:
-// CHECK-SAME: parallel_id=[[PARALLEL_ID]], parent_task_id=[[TASK_ID0]]
+// CHECK: {{^}}[[THREAD_ID0]]: ompt_event_loop_static_begin:
+// CHECK-SAME: parallel_id=[[PARALLEL_ID]], task_id=[[TASK_ID0]]
 // CHECK: {{^}}[[THREAD_ID0]]: ompt_event_ws_loop_chunk_begin:
 // CHECK-SAME: parallel_id=[[PARALLEL_ID]], task_id=[[TASK_ID0]]
 // CHECK-SAME: chunk_start={{[0-9]+}}, chunk_iterations=16
-// CHECK: {{^}}[[THREAD_ID0]]: ompt_event_loop_begin:
-// CHECK-SAME: parallel_id=[[PARALLEL_ID]], parent_task_id=[[TASK_ID0]]
+// CHECK: {{^}}[[THREAD_ID0]]: ompt_event_loop_dynamic_begin:
+// CHECK-SAME: parallel_id=[[PARALLEL_ID]], task_id=[[TASK_ID0]]
 // CHECK: {{^}}[[THREAD_ID0]]: ompt_event_ws_loop_chunk_begin:
 // CHECK-SAME: parallel_id=[[PARALLEL_ID]], task_id=[[TASK_ID0]]
 // CHECK-SAME: chunk_start={{[0-9]+}}, chunk_iterations=1
-// CHECK: {{^}}[[THREAD_ID0]]: ompt_event_loop_begin:
-// CHECK-SAME: parallel_id=[[PARALLEL_ID]], parent_task_id=[[TASK_ID0]]
+// CHECK: {{^}}[[THREAD_ID0]]: ompt_event_loop_guided_begin:
+// CHECK-SAME: parallel_id=[[PARALLEL_ID]], task_id=[[TASK_ID0]]
 // CHECK: {{^}}[[THREAD_ID0]]: ompt_event_ws_loop_chunk_begin:
 // CHECK-SAME: parallel_id=[[PARALLEL_ID]], task_id=[[TASK_ID0]]
 // CHECK-SAME: chunk_start={{[0-9]+}}, chunk_iterations={{[1-9][0-9]*}}
 
 // CHECK: {{^}}[[THREAD_ID1:[0-9]+]]: ompt_event_implicit_task_begin:
 // CHECK-SAME: task_id=[[TASK_ID1:[0-9]+]]
-// CHECK: {{^}}[[THREAD_ID1]]: ompt_event_loop_begin:
-// CHECK-SAME: parallel_id=[[PARALLEL_ID]], parent_task_id=[[TASK_ID1]]
+// CHECK: {{^}}[[THREAD_ID1]]: ompt_event_loop_static_begin:
+// CHECK-SAME: parallel_id=[[PARALLEL_ID]], task_id=[[TASK_ID1]]
 // CHECK: {{^}}[[THREAD_ID1]]: ompt_event_ws_loop_chunk_begin:
 // CHECK-SAME: parallel_id=[[PARALLEL_ID]], task_id=[[TASK_ID1]]
 // CHECK-SAME: chunk_start={{[0-9]+}}, chunk_iterations=16
-// CHECK: {{^}}[[THREAD_ID1]]: ompt_event_loop_begin:
-// CHECK-SAME: parallel_id=[[PARALLEL_ID]], parent_task_id=[[TASK_ID1]]
+// CHECK: {{^}}[[THREAD_ID1]]: ompt_event_loop_dynamic_begin:
+// CHECK-SAME: parallel_id=[[PARALLEL_ID]], task_id=[[TASK_ID1]]
 // CHECK: {{^}}[[THREAD_ID1]]: ompt_event_ws_loop_chunk_begin:
 // CHECK-SAME: parallel_id=[[PARALLEL_ID]], task_id=[[TASK_ID1]]
 // CHECK-SAME: chunk_start={{[0-9]+}}, chunk_iterations=1
-// CHECK: {{^}}[[THREAD_ID1]]: ompt_event_loop_begin:
-// CHECK-SAME: parallel_id=[[PARALLEL_ID]], parent_task_id=[[TASK_ID1]]
+// CHECK: {{^}}[[THREAD_ID1]]: ompt_event_loop_guided_begin:
+// CHECK-SAME: parallel_id=[[PARALLEL_ID]], task_id=[[TASK_ID1]]
 // CHECK: {{^}}[[THREAD_ID1]]: ompt_event_ws_loop_chunk_begin:
 // CHECK-SAME: parallel_id=[[PARALLEL_ID]], task_id=[[TASK_ID1]]
 // CHECK-SAME: chunk_start={{[0-9]+}}, chunk_iterations={{[1-9][0-9]*}}
 
 // CHECK: {{^}}[[THREAD_ID2:[0-9]+]]: ompt_event_implicit_task_begin:
 // CHECK-SAME: task_id=[[TASK_ID2:[0-9]+]]
-// CHECK: {{^}}[[THREAD_ID2]]: ompt_event_loop_begin:
-// CHECK-SAME: parallel_id=[[PARALLEL_ID]], parent_task_id=[[TASK_ID2]]
+// CHECK: {{^}}[[THREAD_ID2]]: ompt_event_loop_static_begin:
+// CHECK-SAME: parallel_id=[[PARALLEL_ID]], task_id=[[TASK_ID2]]
 // CHECK: {{^}}[[THREAD_ID2]]: ompt_event_ws_loop_chunk_begin:
 // CHECK-SAME: parallel_id=[[PARALLEL_ID]], task_id=[[TASK_ID2]]
 // CHECK-SAME: chunk_start={{[0-9]+}}, chunk_iterations=16
-// CHECK: {{^}}[[THREAD_ID2]]: ompt_event_loop_begin:
-// CHECK-SAME: parallel_id=[[PARALLEL_ID]], parent_task_id=[[TASK_ID2]]
+// CHECK: {{^}}[[THREAD_ID2]]: ompt_event_loop_dynamic_begin:
+// CHECK-SAME: parallel_id=[[PARALLEL_ID]], task_id=[[TASK_ID2]]
 // CHECK: {{^}}[[THREAD_ID2]]: ompt_event_ws_loop_chunk_begin:
 // CHECK-SAME: parallel_id=[[PARALLEL_ID]], task_id=[[TASK_ID2]]
 // CHECK-SAME: chunk_start={{[0-9]+}}, chunk_iterations=1
-// CHECK: {{^}}[[THREAD_ID2]]: ompt_event_loop_begin:
-// CHECK-SAME: parallel_id=[[PARALLEL_ID]], parent_task_id=[[TASK_ID2]]
+// CHECK: {{^}}[[THREAD_ID2]]: ompt_event_loop_guided_begin:
+// CHECK-SAME: parallel_id=[[PARALLEL_ID]], task_id=[[TASK_ID2]]
 // CHECK: {{^}}[[THREAD_ID2]]: ompt_event_ws_loop_chunk_begin:
 // CHECK-SAME: parallel_id=[[PARALLEL_ID]], task_id=[[TASK_ID2]]
 // CHECK-SAME: chunk_start={{[0-9]+}}, chunk_iterations={{[1-9][0-9]*}}
 
 // CHECK: {{^}}[[THREAD_ID3:[0-9]+]]: ompt_event_implicit_task_begin:
 // CHECK-SAME: task_id=[[TASK_ID3:[0-9]+]]
-// CHECK: {{^}}[[THREAD_ID3]]: ompt_event_loop_begin:
-// CHECK-SAME: parallel_id=[[PARALLEL_ID]], parent_task_id=[[TASK_ID3]]
+// CHECK: {{^}}[[THREAD_ID3]]: ompt_event_loop_static_begin:
+// CHECK-SAME: parallel_id=[[PARALLEL_ID]], task_id=[[TASK_ID3]]
 // CHECK: {{^}}[[THREAD_ID3]]: ompt_event_ws_loop_chunk_begin:
 // CHECK-SAME: parallel_id=[[PARALLEL_ID]], task_id=[[TASK_ID3]]
 // CHECK-SAME: chunk_start={{[0-9]+}}, chunk_iterations=16
-// CHECK: {{^}}[[THREAD_ID3]]: ompt_event_loop_begin:
-// CHECK-SAME: parallel_id=[[PARALLEL_ID]], parent_task_id=[[TASK_ID3]]
+// CHECK: {{^}}[[THREAD_ID3]]: ompt_event_loop_dynamic_begin:
+// CHECK-SAME: parallel_id=[[PARALLEL_ID]], task_id=[[TASK_ID3]]
 // CHECK: {{^}}[[THREAD_ID3]]: ompt_event_ws_loop_chunk_begin:
 // CHECK-SAME: parallel_id=[[PARALLEL_ID]], task_id=[[TASK_ID3]]
 // CHECK-SAME: chunk_start={{[0-9]+}}, chunk_iterations=1
-// CHECK: {{^}}[[THREAD_ID3]]: ompt_event_loop_begin:
-// CHECK-SAME: parallel_id=[[PARALLEL_ID]], parent_task_id=[[TASK_ID3]]
+// CHECK: {{^}}[[THREAD_ID3]]: ompt_event_loop_guided_begin:
+// CHECK-SAME: parallel_id=[[PARALLEL_ID]], task_id=[[TASK_ID3]]
 // CHECK: {{^}}[[THREAD_ID3]]: ompt_event_ws_loop_chunk_begin:
 // CHECK-SAME: parallel_id=[[PARALLEL_ID]], task_id=[[TASK_ID3]]
 // CHECK-SAME: chunk_start={{[0-9]+}}, chunk_iterations={{[1-9][0-9]*}}

--- a/openmp/runtime/test/ompt/worksharing/for/runtime.c
+++ b/openmp/runtime/test/ompt/worksharing/for/runtime.c
@@ -2,4 +2,7 @@
 // REQUIRES: ompt
 
 #define SCHEDULE runtime
+// Without any schedule specified, the runtime uses static schedule,
+// which is a reason choice
+#define SCHED_OUTPUT "static"
 #include "base.h"

--- a/openmp/runtime/test/ompt/worksharing/for/runtime_serialized.c
+++ b/openmp/runtime/test/ompt/worksharing/for/runtime_serialized.c
@@ -2,4 +2,7 @@
 // REQUIRES: ompt
 
 #define SCHEDULE runtime
+// Without any schedule specified, the runtime uses static schedule,
+// which is a reason choice
+#define SCHED_OUTPUT "static"
 #include "base_serialized.h"

--- a/openmp/runtime/test/ompt/worksharing/for/runtime_split.c
+++ b/openmp/runtime/test/ompt/worksharing/for/runtime_split.c
@@ -4,4 +4,7 @@
 // UNSUPPORTED: gcc-4, gcc-5, gcc-6, gcc-7
 
 #define SCHEDULE runtime
+// Without any schedule specified, the runtime uses static schedule,
+// which is a reason choice
+#define SCHED_OUTPUT "static"
 #include "base_split.h"

--- a/openmp/runtime/test/ompt/worksharing/sections.c
+++ b/openmp/runtime/test/ompt/worksharing/sections.c
@@ -26,10 +26,10 @@ int main()
 
   // CHECK: 0: NULL_POINTER=[[NULL:.*$]]
 
-  // CHECK: {{^}}[[MASTER_ID:[0-9]+]]: ompt_event_sections_begin: parallel_id=[[PARALLEL_ID:[0-9]+]], parent_task_id=[[TASK_ID:[0-9]+]], codeptr_ra=[[SECT_BEGIN:0x[0-f]+]], count=2
+  // CHECK: {{^}}[[MASTER_ID:[0-9]+]]: ompt_event_sections_begin: parallel_id=[[PARALLEL_ID:[0-9]+]], task_id=[[TASK_ID:[0-9]+]], codeptr_ra=[[SECT_BEGIN:0x[0-f]+]], count=2
   // CHECK: {{^}}[[MASTER_ID]]: ompt_event_sections_end: parallel_id=[[PARALLEL_ID]], task_id={{[0-9]+}}, codeptr_ra=[[SECT_END:0x[0-f]+]]
 
-  // CHECK: {{^}}[[THREAD_ID:[0-9]+]]: ompt_event_sections_begin: parallel_id=[[PARALLEL_ID]], parent_task_id=[[TASK_ID:[0-9]+]], codeptr_ra=[[SECT_BEGIN]], count=2
+  // CHECK: {{^}}[[THREAD_ID:[0-9]+]]: ompt_event_sections_begin: parallel_id=[[PARALLEL_ID]], task_id=[[TASK_ID:[0-9]+]], codeptr_ra=[[SECT_BEGIN]], count=2
   // CHECK: {{^}}[[THREAD_ID]]: ompt_event_sections_end: parallel_id=[[PARALLEL_ID]], task_id={{[0-9]+}}, codeptr_ra=[[SECT_END]]
 
   return 0;

--- a/openmp/runtime/test/ompt/worksharing/sections.c
+++ b/openmp/runtime/test/ompt/worksharing/sections.c
@@ -21,6 +21,7 @@ int main()
     }
   }
 
+  // clang-format off
   // Check if libomp supports the callbacks for this test.
   // CHECK-NOT: {{^}}0: Could not register callback 'ompt_callback_work'
 
@@ -31,6 +32,7 @@ int main()
 
   // CHECK: {{^}}[[THREAD_ID:[0-9]+]]: ompt_event_sections_begin: parallel_id=[[PARALLEL_ID]], task_id=[[TASK_ID:[0-9]+]], codeptr_ra=[[SECT_BEGIN]], count=2
   // CHECK: {{^}}[[THREAD_ID]]: ompt_event_sections_end: parallel_id=[[PARALLEL_ID]], task_id={{[0-9]+}}, codeptr_ra=[[SECT_END]]
+  // clang-format on
 
   return 0;
 }

--- a/openmp/runtime/test/ompt/worksharing/sections_dispatch.c
+++ b/openmp/runtime/test/ompt/worksharing/sections_dispatch.c
@@ -29,7 +29,7 @@ int main()
 
   // CHECK: {{^}}[[MASTER_ID:[0-9]+]]: ompt_event_sections_begin:
   // CHECK-SAME: parallel_id=[[PARALLEL_ID:[0-9]+]],
-  // CHECK-SAME: parent_task_id=[[TASK_ID:[0-9]+]],
+  // CHECK-SAME: task_id=[[TASK_ID:[0-9]+]],
   // CHECK-SAME: codeptr_ra=[[SECT_BEGIN:0x[0-f]+]], count=2
   // CHECK: {{^}}[[MASTER_ID]]: ompt_event_section_begin:
   // CHECK-SAME: parallel_id=[[PARALLEL_ID]], task_id=[[TASK_ID]]
@@ -39,7 +39,7 @@ int main()
   // CHECK-SAME: codeptr_ra=[[SECT_END:0x[0-f]+]]
 
   // CHECK: {{^}}[[THREAD_ID:[0-9]+]]: ompt_event_sections_begin:
-  // CHECK-SAME: parallel_id=[[PARALLEL_ID]], parent_task_id=[[TASK_ID:[0-9]+]],
+  // CHECK-SAME: parallel_id=[[PARALLEL_ID]], task_id=[[TASK_ID:[0-9]+]],
   // CHECK-SAME: codeptr_ra=[[SECT_BEGIN]], count=2
   // CHECK: {{^}}[[THREAD_ID]]: ompt_event_section_begin:
   // CHECK-SAME: parallel_id=[[PARALLEL_ID]], task_id=[[TASK_ID]]

--- a/openmp/runtime/test/ompt/worksharing/single.c
+++ b/openmp/runtime/test/ompt/worksharing/single.c
@@ -25,7 +25,7 @@ int main()
 
   // CHECK: 0: NULL_POINTER=[[NULL:.*$]]
 
-  // CHECK-DAG: {{^}}[[THREAD_ID_1:[0-9]+]]: ompt_event_single_in_block_begin: parallel_id=[[PARALLEL_ID:[0-9]+]], parent_task_id=[[TASK_ID:[0-9]+]], codeptr_ra={{0x[0-f]+}}, count=1
+  // CHECK-DAG: {{^}}[[THREAD_ID_1:[0-9]+]]: ompt_event_single_in_block_begin: parallel_id=[[PARALLEL_ID:[0-9]+]], task_id=[[TASK_ID:[0-9]+]], codeptr_ra={{0x[0-f]+}}, count=1
   // CHECK-DAG: {{^}}[[THREAD_ID_1]]: in single
   // CHECK-DAG: {{^}}[[THREAD_ID_1]]: ompt_event_single_in_block_end: parallel_id=[[PARALLEL_ID]], task_id=[[TASK_ID]], codeptr_ra={{0x[0-f]+}}, count=1
 

--- a/openmp/runtime/test/ompt/worksharing/single.c
+++ b/openmp/runtime/test/ompt/worksharing/single.c
@@ -20,6 +20,7 @@ int main()
 
   printf("x=%d\n", x);
 
+  // clang-format off
   // Check if libomp supports the callbacks for this test.
   // CHECK-NOT: {{^}}0: Could not register callback 'ompt_callback_work'
 
@@ -31,6 +32,7 @@ int main()
 
   // CHECK-DAG: {{^}}[[THREAD_ID_2:[0-9]+]]: ompt_event_single_others_begin: parallel_id=[[PARALLEL_ID:[0-9]+]], task_id=[[TASK_ID:[0-9]+]], codeptr_ra={{0x[0-f]+}}, count=1
   // CHECK-DAG: {{^}}[[THREAD_ID_2]]: ompt_event_single_others_end: parallel_id=[[PARALLEL_ID]], task_id=[[TASK_ID]], codeptr_ra={{0x[0-f]+}}, count=1
+  // clang-format on
 
   return 0;
 }


### PR DESCRIPTION
Use more specific values from `ompt_work_t` to allow the tool identify the schedule of a worksharing-loop. With this patch, the runtime will report the schedule chosen by the runtime rather than necessarily the schedule literally requested by the clause.
E.g., for guided + just one iteration per thread, the runtime would choose and report static.

Fixes issue #63904