### PR TITLE
[lldb] [ObjectFileELF] Detect QNX Neutrino RTOS targets

### DIFF
--- a/lldb/source/Plugins/ObjectFile/ELF/ObjectFileELF.cpp
+++ b/lldb/source/Plugins/ObjectFile/ELF/ObjectFileELF.cpp
@@ -66,6 +66,7 @@ static const char *const LLDB_NT_OWNER_OPENBSD = "OpenBSD";
 static const char *const LLDB_NT_OWNER_ANDROID = "Android";
 static const char *const LLDB_NT_OWNER_CORE = "CORE";
 static const char *const LLDB_NT_OWNER_LINUX = "LINUX";
+static const char *const LLDB_NT_OWNER_QNX = "QNX";
 
 // ELF note type definitions
 static const elf_word LLDB_NT_FREEBSD_ABI_TAG = 0x01;
@@ -1284,6 +1285,8 @@ ObjectFileELF::RefineModuleDetailsFromNote(lldb_private::DataExtractor &data,
           // cases (e.g. compile with -nostdlib) Hence set OS to Linux
           arch_spec.GetTriple().setOS(llvm::Triple::OSType::Linux);
       }
+    } else if (note.n_name == LLDB_NT_OWNER_QNX) {
+      arch_spec.GetTriple().setOS(llvm::Triple::OSType::QNX);
     }
 
     // Calculate the offset of the next note just in case "offset" has been


### PR DESCRIPTION
This change detects _QNX Neutrino Real-Time Operating System_ targets, and is the second in a series of changes (specifically, #97417, #97439, #97487, #97536, and #97630) that look to facilitate remote debug of _AArch64_ targets on _QNX_.

_QNX Neutrino Real-Time Operating System_ is a commercial Unix-like real-time operating system primarily targeting the embedded systems market including automotive, medical devices, robotics, transportation, and industrial embedded systems.

The series of changes in question looks to provision support for –

- Launching a debuggee
- Attaching to a debuggee
- Having the debuggee come up stopped at the entry point
- Setting breakpoints
- Stopping at breakpoints
- Reading/writing contents of/to the debuggee's memory
- Reading/writing contents of/to the debuggee's registers
- Reading/writing contents of/to the debuggee's variables
- Resuming the debuggee's execution
- Single-stepping the debuggee's execution
- Interrupting the debuggee's execution
- Dumping information pertaining to the debuggee's stack trace

Kindly note that _ptrace_ isn't available on _QNX_. Instead, _devctl_ can be leveraged to observe and control the execution of a process under debug on _QNX_.

Any additional support (including the facilitation of execution of tests) will be the subject of future work.