### PR TITLE
[flang] Fix build problem caused by #96807

### DIFF
--- a/flang/lib/Evaluate/intrinsics-library.cpp
+++ b/flang/lib/Evaluate/intrinsics-library.cpp
@@ -807,7 +807,7 @@ static bool VerifyAtan2LikeArguments(
 template <ArgumentVerifierFunc... F>
 static bool CombineVerifiers(
     const std::vector<Expr<SomeType>> &args, FoldingContext &context) {
-  return (... & F(args, context));
+  return (... && F(args, context));
 }
 
 /// Define argument names to be used error messages when the intrinsic have


### PR DESCRIPTION
I had erroneously used a bitwise '&' with boolean operands which caused a warning on the ARM build.  This change fixes that.