### PR TITLE
[Clang][Sema] Fix crash when rebuilding MemberExprs with invalid object expressions

### DIFF
--- a/clang/lib/Sema/TreeTransform.h
+++ b/clang/lib/Sema/TreeTransform.h
@@ -2896,6 +2896,9 @@ public:
     SS.Adopt(QualifierLoc);
 
     Base = BaseResult.get();
+    if (Base->containsErrors())
+      return ExprError();
+
     QualType BaseType = Base->getType();
 
     if (isArrow && !BaseType->isPointerType())

--- a/clang/test/CXX/temp/temp.res/temp.dep/temp.dep.type/p4.cpp
+++ b/clang/test/CXX/temp/temp.res/temp.dep/temp.dep.type/p4.cpp
@@ -574,3 +574,34 @@ namespace N4 {
     }
   };
 } // namespace N4
+
+namespace N5 {
+  struct A {
+    int x;
+  };
+
+  template<typename T>
+  void f() {
+    A y = T::x; // expected-error {{type 'int' cannot be used prior to '::' because it has no members}}
+    y.x;
+  }
+
+  template void f<int>(); // expected-note {{in instantiation of}}
+
+  struct B {
+    template<typename T>
+    B(T&&);
+
+    int x;
+  };
+
+  template<typename T>
+  void g(T y) {
+    B z([&]() { // expected-note {{while substituting into a lambda expression here}}
+      h(&y); // expected-error {{use of undeclared identifier 'h'}}
+    });
+    z.x;
+  }
+
+  template void g(int); // expected-note {{in instantiation of}}
+} // namespace N5


### PR DESCRIPTION
Fixes #95778