### PR TITLE
[libc] Use -nostdlibinc in the full build mode

### DIFF
--- a/libc/cmake/modules/CheckCompilerFeatures.cmake
+++ b/libc/cmake/modules/CheckCompilerFeatures.cmake
@@ -75,4 +75,4 @@ check_cxx_compiler_flag("-ftrivial-auto-var-init=pattern" LIBC_CC_SUPPORTS_PATTE
 check_cxx_compiler_flag("-nostdlib++" LIBC_CC_SUPPORTS_NOSTDLIBPP)
 
 # clang-3.0+
-check_c_compiler_flag("-nostdlibinc" LIBC_C_SUPPORTS_NOSTDLIBINC)
+check_cxx_compiler_flag("-nostdlibinc" LIBC_CC_SUPPORTS_NOSTDLIBINC)

--- a/libc/cmake/modules/CheckCompilerFeatures.cmake
+++ b/libc/cmake/modules/CheckCompilerFeatures.cmake
@@ -73,3 +73,6 @@ check_cxx_compiler_flag("-ftrivial-auto-var-init=pattern" LIBC_CC_SUPPORTS_PATTE
 
 # clang-6+, gcc-13+
 check_cxx_compiler_flag("-nostdlib++" LIBC_CC_SUPPORTS_NOSTDLIBPP)
+
+# clang-3.0+
+check_c_compiler_flag("-nostdlibinc" LIBC_C_SUPPORTS_NOSTDLIBINC)

--- a/libc/cmake/modules/LLVMLibCCompileOptionRules.cmake
+++ b/libc/cmake/modules/LLVMLibCCompileOptionRules.cmake
@@ -46,9 +46,13 @@ function(_get_common_compile_options output_var flags)
       list(APPEND compile_options "-DLIBC_FULL_BUILD")
       # Only add -ffreestanding flag in full build mode.
       list(APPEND compile_options "-ffreestanding")
-      # Manually disable all standard include paths.
+      # Manually disable standard include paths to prevent system headers from
+      # being included.
       if(LIBC_C_SUPPORTS_NOSTDLIBINC)
         list(APPEND compile_options "-nostdlibinc")
+      else()
+        list(APPEND compile_options "-isystem${COMPILER_RESOURCE_DIR}/include")
+        list(APPEND compile_options "-nostdinc")
       endif()
     endif()
 
@@ -113,10 +117,14 @@ function(_get_common_compile_options output_var flags)
       list(APPEND compile_options "SHELL:-Xclang -mcode-object-version=none")
     endif()
 
-    # Manually disable all standard include paths and include the resource
-    # directory to prevent system headers from being included.
-    list(APPEND compile_options "-isystem${COMPILER_RESOURCE_DIR}/include")
-    list(APPEND compile_options "-nostdinc")
+    # Manually disable standard include paths to prevent system headers from
+    # being included.
+    if(LIBC_C_SUPPORTS_NOSTDLIBINC)
+      list(APPEND compile_options "-nostdlibinc")
+    else()
+      list(APPEND compile_options "-isystem${COMPILER_RESOURCE_DIR}/include")
+      list(APPEND compile_options "-nostdinc")
+    endif()
   endif()
   set(${output_var} ${compile_options} PARENT_SCOPE)
 endfunction()

--- a/libc/cmake/modules/LLVMLibCCompileOptionRules.cmake
+++ b/libc/cmake/modules/LLVMLibCCompileOptionRules.cmake
@@ -48,7 +48,7 @@ function(_get_common_compile_options output_var flags)
       list(APPEND compile_options "-ffreestanding")
       # Manually disable standard include paths to prevent system headers from
       # being included.
-      if(LIBC_C_SUPPORTS_NOSTDLIBINC)
+      if(LIBC_CC_SUPPORTS_NOSTDLIBINC)
         list(APPEND compile_options "-nostdlibinc")
       else()
         list(APPEND compile_options "-isystem${COMPILER_RESOURCE_DIR}/include")
@@ -115,15 +115,6 @@ function(_get_common_compile_options output_var flags)
       endif()
     elseif(LIBC_TARGET_ARCHITECTURE_IS_AMDGPU)
       list(APPEND compile_options "SHELL:-Xclang -mcode-object-version=none")
-    endif()
-
-    # Manually disable standard include paths to prevent system headers from
-    # being included.
-    if(LIBC_C_SUPPORTS_NOSTDLIBINC)
-      list(APPEND compile_options "-nostdlibinc")
-    else()
-      list(APPEND compile_options "-isystem${COMPILER_RESOURCE_DIR}/include")
-      list(APPEND compile_options "-nostdinc")
     endif()
   endif()
   set(${output_var} ${compile_options} PARENT_SCOPE)

--- a/libc/cmake/modules/LLVMLibCCompileOptionRules.cmake
+++ b/libc/cmake/modules/LLVMLibCCompileOptionRules.cmake
@@ -46,6 +46,10 @@ function(_get_common_compile_options output_var flags)
       list(APPEND compile_options "-DLIBC_FULL_BUILD")
       # Only add -ffreestanding flag in full build mode.
       list(APPEND compile_options "-ffreestanding")
+      # Manually disable all standard include paths.
+      if(LIBC_C_SUPPORTS_NOSTDLIBINC)
+        list(APPEND compile_options "-nostdlibinc")
+      endif()
     endif()
 
     if(LIBC_COMPILER_HAS_FIXED_POINT)


### PR DESCRIPTION
This avoids accidentally including system headers.