### PR TITLE
Move MCSection::LayoutOrder to MCSectionMachO

### DIFF
--- a/llvm/include/llvm/MC/MCSection.h
+++ b/llvm/include/llvm/MC/MCSection.h
@@ -86,8 +86,6 @@ private:
   Align Alignment;
   /// The section index in the assemblers section list.
   unsigned Ordinal = 0;
-  /// The index of this section in the layout order.
-  unsigned LayoutOrder = 0;
 
   /// Keeping track of bundle-locked state.
   BundleLockStateType BundleLockState = NotBundleLocked;
@@ -166,9 +164,6 @@ public:
 
   unsigned getOrdinal() const { return Ordinal; }
   void setOrdinal(unsigned Value) { Ordinal = Value; }
-
-  unsigned getLayoutOrder() const { return LayoutOrder; }
-  void setLayoutOrder(unsigned Value) { LayoutOrder = Value; }
 
   BundleLockStateType getBundleLockState() const { return BundleLockState; }
   void setBundleLockState(BundleLockStateType NewState);

--- a/llvm/include/llvm/MC/MCSectionMachO.h
+++ b/llvm/include/llvm/MC/MCSectionMachO.h
@@ -32,6 +32,10 @@ class MCSectionMachO final : public MCSection {
   /// for example.
   unsigned Reserved2;
 
+  // The index of this section in MachObjectWriter::SectionOrder, which is
+  // different from MCSection::Ordinal.
+  unsigned LayoutOrder = 0;
+
   // The defining non-temporary symbol for each fragment.
   SmallVector<const MCSymbol *, 0> Atoms;
 
@@ -79,6 +83,9 @@ public:
   void allocAtoms();
   const MCSymbol *getAtom(size_t I) const;
   void setAtom(size_t I, const MCSymbol *Sym);
+
+  unsigned getLayoutOrder() const { return LayoutOrder; }
+  void setLayoutOrder(unsigned Value) { LayoutOrder = Value; }
 
   static bool classof(const MCSection *S) {
     return S->getVariant() == SV_MachO;

--- a/llvm/lib/MC/MachObjectWriter.cpp
+++ b/llvm/lib/MC/MachObjectWriter.cpp
@@ -125,7 +125,7 @@ uint64_t MachObjectWriter::getSymbolAddress(const MCSymbol &S,
 uint64_t MachObjectWriter::getPaddingSize(const MCAssembler &Asm,
                                           const MCSection *Sec) const {
   uint64_t EndAddr = getSectionAddress(Sec) + Asm.getSectionAddressSize(*Sec);
-  unsigned Next = Sec->getLayoutOrder() + 1;
+  unsigned Next = cast<MCSectionMachO>(Sec)->getLayoutOrder() + 1;
   if (Next >= SectionOrder.size())
     return 0;
 
@@ -676,13 +676,13 @@ void MachObjectWriter::computeSectionAddresses(const MCAssembler &Asm) {
   for (MCSection &Sec : Asm) {
     if (!Sec.isVirtualSection()) {
       SectionOrder.push_back(&Sec);
-      Sec.setLayoutOrder(i++);
+      cast<MCSectionMachO>(Sec).setLayoutOrder(i++);
     }
   }
   for (MCSection &Sec : Asm) {
     if (Sec.isVirtualSection()) {
       SectionOrder.push_back(&Sec);
-      Sec.setLayoutOrder(i++);
+      cast<MCSectionMachO>(Sec).setLayoutOrder(i++);
     }
   }
 


### PR DESCRIPTION
This variable is similar to `Ordinal` but only used for Mach-O to place
zerofill sections ("virtual sections" in MC term) after non-zerofill ones.

Follow-up to 7840c0066837797cdeb62aab63044b964aa7f372.
