### PR TITLE
[lld] Change `--lto-emit-llvm` to use the pre-codegen module

### DIFF
--- a/lld/ELF/LTO.cpp
+++ b/lld/ELF/LTO.cpp
@@ -147,7 +147,7 @@ static lto::Config createConfig() {
   c.PGOWarnMismatch = config->ltoPGOWarnMismatch;
 
   if (config->emitLLVM) {
-    c.PostInternalizeModuleHook = [](size_t task, const Module &m) {
+    c.PreCodeGenModuleHook = [](size_t task, const Module &m) {
       if (std::unique_ptr<raw_fd_ostream> os =
               openLTOOutputFile(config->outputFile))
         WriteBitcodeToFile(m, *os, false);

--- a/lld/test/ELF/lto/emit-llvm.ll
+++ b/lld/test/ELF/lto/emit-llvm.ll
@@ -9,11 +9,13 @@
 ; RUN: ld.lld --plugin-opt=emit-llvm -mllvm -bitcode-flush-threshold=0 -o /dev/null %t.o
 ; RUN: ld.lld --lto-emit-llvm -mllvm -bitcode-flush-threshold=0 -o /dev/null %t.o
 
-; CHECK: define internal void @main()
+; CHECK: define hidden void @main()
 
 target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
 target triple = "x86_64-unknown-linux-gnu"
 
-define void @main() {
+@llvm.compiler.used = appending global [1 x ptr] [ptr @main], section "llvm.metadata"
+
+define hidden void @main() {
   ret void
 }


### PR DESCRIPTION
Summary:
Currently the `--lto-emit-llvm` option writes out the
post-internalization bitcode. This is the bitcode before any
optimizations or other pipelines have been run on it. This patch changes
that to use the pre-codegen module, which is the state of the LLVM-IR
after the optimizations have been run.

I believe that this makes sense as the `--lto-emit-llvm` option seems to
imply that we should emit the final output of the LLVM pass as if it
were the desired output. This should include optimizations at the
requested optimization level. My main motivation for this change is to
be able to use this to link several LLVM-IR files into a single one that
I can then pass back to `ld.lld` later (for JIT purposes).
