### PR TITLE
[libunwind] Remove needless `sys/uio.h`

### DIFF
--- a/libunwind/src/UnwindCursor.hpp
+++ b/libunwind/src/UnwindCursor.hpp
@@ -36,7 +36,6 @@
 #include <errno.h>
 #include <signal.h>
 #include <sys/syscall.h>
-#include <sys/uio.h>
 #include <unistd.h>
 #define _LIBUNWIND_CHECK_LINUX_SIGRETURN 1
 #endif


### PR DESCRIPTION
No reference to `readv` or `writev`. This makes `libcxx` happy when compiling against clang's `libc` as part of https://github.com/llvm/llvm-project/issues/97191.