### PR TITLE
[libcxx] Add `locale` support for llvm `libc`

### DIFF
--- a/libcxx/include/__config
+++ b/libcxx/include/__config
@@ -914,7 +914,7 @@ typedef __char32_t char32_t;
 #  endif
 
 #  if defined(__BIONIC__) || defined(__NuttX__) || defined(__Fuchsia__) || defined(__wasi__) ||                        \
-      defined(_LIBCPP_HAS_MUSL_LIBC) || defined(__OpenBSD__)
+      defined(_LIBCPP_HAS_MUSL_LIBC) || defined(__OpenBSD__) || defined(__LLVM_LIBC__)
 #    define _LIBCPP_PROVIDES_DEFAULT_RUNE_TABLE
 #  endif
 

--- a/libcxx/include/locale
+++ b/libcxx/include/locale
@@ -217,7 +217,7 @@ template <class charT> class messages_byname;
 
 #if defined(__unix__) || (defined(__APPLE__) && defined(__MACH__))
 // Most unix variants have catopen.  These are the specific ones that don't.
-#  if !defined(__BIONIC__) && !defined(_NEWLIB_VERSION) && !defined(__EMSCRIPTEN__)
+#  if !defined(__BIONIC__) && !defined(_NEWLIB_VERSION) && !defined(__EMSCRIPTEN__) && !defined(__LLVM_LIBC__)
 #    define _LIBCPP_HAS_CATOPEN 1
 #    include <nl_types.h>
 #  endif

--- a/libcxx/src/locale.cpp
+++ b/libcxx/src/locale.cpp
@@ -34,7 +34,8 @@
 #  define _CTYPE_DISABLE_MACROS
 #endif
 
-#if !defined(_LIBCPP_MSVCRT) && !defined(__MINGW32__) && !defined(__BIONIC__) && !defined(__NuttX__)
+#if !defined(_LIBCPP_MSVCRT) && !defined(__MINGW32__) && !defined(__BIONIC__) && !defined(__NuttX__) &&                \
+    !defined(__LLVM_LIBC__)
 #  include <langinfo.h>
 #endif
 


### PR DESCRIPTION
`libcxx` companion to https://github.com/llvm/llvm-project/pull/97494 and https://github.com/llvm/llvm-project/issues/97191

More or  less adds `__LLVM_LIBC__` in the same places as `__Fuchsia__` as fuchsia itself relies on parts of LLVM `libc` this seems like the most reasonable choice.