### PR TITLE
[libc] Add basic `ioctl` function

### DIFF
--- a/libc/config/linux/aarch64/entrypoints.txt
+++ b/libc/config/linux/aarch64/entrypoints.txt
@@ -206,6 +206,9 @@ set(TARGET_LIBC_ENTRYPOINTS
     libc.src.stdio.vsnprintf
     libc.src.stdio.vsprintf
 
+    # sys/ioctl.h entrypoints
+    libc.src.sys.ioctl.ioctl
+
     # sys/mman.h entrypoints
     libc.src.sys.mman.madvise
     libc.src.sys.mman.mincore

--- a/libc/config/linux/x86_64/entrypoints.txt
+++ b/libc/config/linux/x86_64/entrypoints.txt
@@ -226,6 +226,9 @@ set(TARGET_LIBC_ENTRYPOINTS
     # https://github.com/llvm/llvm-project/issues/80060
     # libc.src.sys.epoll.epoll_pwait2
 
+    # sys/ioctl.h entrypoints
+    libc.src.sys.ioctl.ioctl
+
     # sys/mman.h entrypoints
     libc.src.sys.mman.madvise
     libc.src.sys.mman.mincore

--- a/libc/spec/posix.td
+++ b/libc/spec/posix.td
@@ -1442,7 +1442,13 @@ def POSIX : StandardSpec<"POSIX"> {
     ],  // Macros
     [], // Types
     [], // Enumerations
-    []  // Functions
+    [
+      FunctionSpec<
+        "ioctl",
+        RetValSpec<IntType>,
+        [ArgSpec<IntType>, ArgSpec<IntType>, ArgSpec<VarArgType>]
+      >
+    ]  // Functions
   >;
 
   HeaderSpec Spawn = HeaderSpec<

--- a/libc/src/sys/CMakeLists.txt
+++ b/libc/src/sys/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_subdirectory(auxv)
 add_subdirectory(epoll)
+add_subdirectory(ioctl)
 add_subdirectory(mman)
 add_subdirectory(random)
 add_subdirectory(resource)

--- a/libc/src/sys/ioctl/CMakeLists.txt
+++ b/libc/src/sys/ioctl/CMakeLists.txt
@@ -1,0 +1,10 @@
+if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/${LIBC_TARGET_OS})
+  add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/${LIBC_TARGET_OS})
+endif()
+
+add_entrypoint_object(
+  ioctl
+  ALIAS
+  DEPENDS
+    .${LIBC_TARGET_OS}.ioctl
+)

--- a/libc/src/sys/ioctl/ioctl.h
+++ b/libc/src/sys/ioctl/ioctl.h
@@ -1,0 +1,18 @@
+//===-- Implementation header for ioctl -------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC_SYS_IOCTL_IOCTL_H
+#define LLVM_LIBC_SRC_SYS_IOCTL_IOCTL_H
+
+namespace LIBC_NAMESPACE {
+
+int ioctl(int fd, int req, ...);
+
+} // namespace LIBC_NAMESPACE
+
+#endif // LLVM_LIBC_SRC_SYS_IOCTL_IOCTL_H

--- a/libc/src/sys/ioctl/linux/CMakeLists.txt
+++ b/libc/src/sys/ioctl/linux/CMakeLists.txt
@@ -1,0 +1,12 @@
+add_entrypoint_object(
+  ioctl
+  SRCS
+    ioctl.cpp
+  HDRS
+    ../ioctl.h
+  DEPENDS
+    libc.include.sys_ioctl
+    libc.include.sys_syscall
+    libc.src.__support.OSUtil.osutil
+    libc.src.errno.errno
+)

--- a/libc/src/sys/ioctl/linux/ioctl.cpp
+++ b/libc/src/sys/ioctl/linux/ioctl.cpp
@@ -1,0 +1,24 @@
+#include <stdarg.h>
+#include <sys/syscall.h> // For syscall numbers.
+
+#include "src/__support/OSUtil/syscall.h" // For internal syscall function.
+#include "src/__support/common.h"
+#include "src/sys/ioctl/ioctl.h"
+
+#include "src/errno/libc_errno.h"
+
+namespace LIBC_NAMESPACE {
+
+LLVM_LIBC_FUNCTION(int, ioctl, (int fd, int req, ...)) {
+  void *arg;
+  va_list ap;
+  va_start(ap, req);
+  arg = va_arg(ap, void *);
+  va_end(ap);
+  int ret = LIBC_NAMESPACE::syscall_impl<int>(SYS_ioctl, fd, req, arg);
+  // FIXME(@izaakschroeder): There is probably more to do here.
+  // See: https://github.com/kraj/musl/blob/kraj/master/src/misc/ioctl.c
+  return ret;
+}
+
+} // namespace LIBC_NAMESPACE


### PR DESCRIPTION
There's probably a lot more to do here but it's a start. This is enough for `libcxx` to compile with `LIBCXX_ENABLE_RANDOM_DEVICE=ON` as part of https://github.com/llvm/llvm-project/issues/97191

See:
- https://linux.die.net/man/3/ioctl
- https://android.googlesource.com/platform/bionic/+/android-9.0.0_r3/libc/bionic/ioctl.cpp
- https://github.com/kraj/musl/blob/kraj/master/src/misc/ioctl.c