### PR TITLE
[Driver][X86] Add flang visibility for -mapx-features=

### DIFF
--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -6321,7 +6321,7 @@ def mno_scatter : Flag<["-"], "mno-scatter">, Group<m_Group>,
 def mapx_features_EQ : CommaJoined<["-"], "mapx-features=">, Group<m_x86_Features_Group>,
     HelpText<"Enable features of APX">, Values<"egpr,push2pop2,ppx,ndd,ccmp,nf,cf,zu">,  Visibility<[ClangOption, CLOption, FlangOption]>;
 def mno_apx_features_EQ : CommaJoined<["-"], "mno-apx-features=">, Group<m_x86_Features_Group>,
-    HelpText<"Disable features of APX">, Values<"egpr,push2pop2,ppx,ndd,ccmp,nf,cf,zu">;
+    HelpText<"Disable features of APX">, Values<"egpr,push2pop2,ppx,ndd,ccmp,nf,cf,zu">, Visibility<[ClangOption, CLOption, FlangOption]>;
 // For stability, we only add a feature to -mapxf after it passes the validation of llvm-test-suite && cpu2017 on Intel SDE.
 def mapxf : Flag<["-"], "mapxf">, Alias<mapx_features_EQ>, AliasArgs<["egpr","push2pop2","ppx","ndd","ccmp","nf","cf"]>;
 def mno_apxf : Flag<["-"], "mno-apxf">, Alias<mno_apx_features_EQ>, AliasArgs<["egpr","push2pop2","ppx","ndd","ccmp","nf","cf"]>;

--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -6319,7 +6319,7 @@ def mno_gather : Flag<["-"], "mno-gather">, Group<m_Group>,
 def mno_scatter : Flag<["-"], "mno-scatter">, Group<m_Group>,
                   HelpText<"Disable generation of scatter instructions in auto-vectorization(x86 only)">;
 def mapx_features_EQ : CommaJoined<["-"], "mapx-features=">, Group<m_x86_Features_Group>,
-    HelpText<"Enable features of APX">, Values<"egpr,push2pop2,ppx,ndd,ccmp,nf,cf,zu">;
+    HelpText<"Enable features of APX">, Values<"egpr,push2pop2,ppx,ndd,ccmp,nf,cf,zu">,  Visibility<[ClangOption, CLOption, FlangOption]>;
 def mno_apx_features_EQ : CommaJoined<["-"], "mno-apx-features=">, Group<m_x86_Features_Group>,
     HelpText<"Disable features of APX">, Values<"egpr,push2pop2,ppx,ndd,ccmp,nf,cf,zu">;
 // For stability, we only add a feature to -mapxf after it passes the validation of llvm-test-suite && cpu2017 on Intel SDE.

--- a/flang/test/Driver/target-cpu-features.f90
+++ b/flang/test/Driver/target-cpu-features.f90
@@ -17,6 +17,9 @@
 ! RUN: %flang --target=x86_64-linux-gnu -march=skylake -c %s -### 2>&1 \
 ! RUN: | FileCheck %s -check-prefix=CHECK-SKYLAKE
 
+! RUN: %flang --target=x86_64-linux-gnu -mapx-features=egpr -c %s -### 2>&1 \
+! RUN: | FileCheck %s -check-prefix=CHECK-APX
+
 ! RUN: %flang --target=x86_64h-linux-gnu -c %s -### 2>&1 \
 ! RUN: | FileCheck %s -check-prefix=CHECK-X86_64H
 
@@ -50,6 +53,9 @@
 
 ! CHECK-SKYLAKE: "-fc1" "-triple" "x86_64-unknown-linux-gnu"
 ! CHECK-SKYLAKE-SAME: "-target-cpu" "skylake"
+
+! CHECK-APX: "-fc1" "-triple" "x86_64-unknown-linux-gnu"
+! CHECK-APX-SAME: "-target-feature" "+egpr"
 
 ! CHECK-X86_64H: "-fc1" "-triple" "x86_64h-unknown-linux-gnu"
 ! CHECK-X86_64H-SAME: "-target-cpu" "x86-64" "-target-feature" "-rdrnd" "-target-feature" "-aes" "-target-feature" "-pclmul" "-target-feature" "-rtm" "-target-feature" "-fsgsbase"

--- a/flang/test/Driver/target-cpu-features.f90
+++ b/flang/test/Driver/target-cpu-features.f90
@@ -20,6 +20,9 @@
 ! RUN: %flang --target=x86_64-linux-gnu -mapx-features=egpr -c %s -### 2>&1 \
 ! RUN: | FileCheck %s -check-prefix=CHECK-APX
 
+! RUN: %flang --target=x86_64-linux-gnu -mno-apx-features=ccmp -c %s -### 2>&1 \
+! RUN: | FileCheck %s -check-prefix=CHECK-NO-APX
+
 ! RUN: %flang --target=x86_64h-linux-gnu -c %s -### 2>&1 \
 ! RUN: | FileCheck %s -check-prefix=CHECK-X86_64H
 
@@ -56,6 +59,9 @@
 
 ! CHECK-APX: "-fc1" "-triple" "x86_64-unknown-linux-gnu"
 ! CHECK-APX-SAME: "-target-feature" "+egpr"
+
+! CHECK-NO-APX: "-fc1" "-triple" "x86_64-unknown-linux-gnu"
+! CHECK-NO-APX-SAME: "-target-feature" "-ccmp"
 
 ! CHECK-X86_64H: "-fc1" "-triple" "x86_64h-unknown-linux-gnu"
 ! CHECK-X86_64H-SAME: "-target-cpu" "x86-64" "-target-feature" "-rdrnd" "-target-feature" "-aes" "-target-feature" "-pclmul" "-target-feature" "-rtm" "-target-feature" "-fsgsbase"


### PR DESCRIPTION
The default visibility of `m_x86_Features_Group` is `ClangOption, CLOption`. For x86, we expose `-march` to flang but not `-m<cpuid>`.  `apxf` is special b/c it contains several independent features like `egpr, ndd, ppx, push2pop2, ccmp, nf, cf` and `zu`.

Users may would like to turn on part of features in different cases

1. enable `ndd` only when writing a code-size sensitive library 
2. disable `ccmp`, `cf` when building component has strong security request on caches

Hence, we expose `-mapx-features=` to flang for Fortran users. 