### PR TITLE
[PowerPC] Function descriptor symbol can be omitted for external symbol.

### DIFF
--- a/llvm/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
@@ -2327,12 +2327,7 @@ bool AsmPrinter::doFinalization(Module &M) {
 
     // If address is taken from an extern function, we need to emit linkage for
     // its function descriptor symbol.
-    if (F.hasAddressTaken(/*PutOffender=*/nullptr,
-                          /*IgnoreCallbackUses=*/false,
-                          /*IgnoreAssumeLikeCalls=*/true,
-                          /*IgnoreLLVMUsed=*/true,
-                          /*IgnoreARCAttachedCall=*/false,
-                          /*IgnoreCastedDirectCall=*/true))
+    if (F.hasAddressTaken())
       emitLinkage(&F, Name);
   }
 

--- a/llvm/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
@@ -2325,8 +2325,15 @@ bool AsmPrinter::doFinalization(Module &M) {
     // Emit linkage for the function entry point.
     emitLinkage(&F, FnEntryPointSym);
 
-    // Emit linkage for the function descriptor.
-    emitLinkage(&F, Name);
+    // If address is taken from an extern function, we need to emit linkage for
+    // its function descriptor symbol.
+    if (F.hasAddressTaken(/*PutOffender=*/nullptr,
+                          /*IgnoreCallbackUses=*/false,
+                          /*IgnoreAssumeLikeCalls=*/true,
+                          /*IgnoreLLVMUsed=*/true,
+                          /*IgnoreARCAttachedCall=*/false,
+                          /*IgnoreCastedDirectCall=*/true))
+      emitLinkage(&F, Name);
   }
 
   // Emit the remarks section contents.

--- a/llvm/test/CodeGen/PowerPC/aix-available-externally-linkage-fun.ll
+++ b/llvm/test/CodeGen/PowerPC/aix-available-externally-linkage-fun.ll
@@ -18,7 +18,6 @@ entry:
 }
 
 ; CHECK: .extern .foo[PR]
-; CHECK: .extern foo[DS]
 
 ; OBJ:      Name: .foo
 ; OBJ-NEXT: Value (RelocatableAddress): 0x0
@@ -34,18 +33,3 @@ entry:
 ; OBJ-NEXT:   SymbolAlignmentLog2: 0
 ; OBJ-NEXT:   SymbolType: XTY_ER (0x0)
 ; OBJ-NEXT:   StorageMappingClass: XMC_PR (0x0)
-
-; OBJ:      Name: foo
-; OBJ-NEXT: Value (RelocatableAddress): 0x0
-; OBJ-NEXT: Section: N_UNDEF
-; OBJ-NEXT: Type: 0x0
-; OBJ-NEXT: StorageClass: C_EXT (0x2)
-; OBJ-NEXT: NumberOfAuxEntries: 1
-; OBJ-NEXT: CSECT Auxiliary Entry {
-; OBJ-NEXT:   Index: [[#NFA+4]]
-; OBJ-NEXT:   SectionLen: 0
-; OBJ-NEXT:   ParameterHashIndex: 0x0
-; OBJ-NEXT:   TypeChkSectNum: 0x0
-; OBJ-NEXT:   SymbolAlignmentLog2: 0
-; OBJ-NEXT:   SymbolType: XTY_ER (0x0)
-; OBJ-NEXT:   StorageMappingClass: XMC_DS (0xA)

--- a/llvm/test/CodeGen/PowerPC/aix-extern-weak.ll
+++ b/llvm/test/CodeGen/PowerPC/aix-extern-weak.ll
@@ -55,7 +55,6 @@ declare extern_weak void @foo_ext_weak(ptr)
 ; COMMON-NEXT:    .weak   .foo_ext_weak_ref[PR]
 ; COMMON-NEXT:    .weak   foo_ext_weak_ref[DS]
 ; COMMON-NEXT:    .weak   .foo_ext_weak[PR]
-; COMMON-NEXT:    .weak   foo_ext_weak[DS]
 ; COMMON-NEXT:    .toc
 ; COMMON-NEXT: L..C0:
 ; COMMON-NEXT:    .tc foo_ext_weak_p[TC],foo_ext_weak_p
@@ -159,27 +158,6 @@ declare extern_weak void @foo_ext_weak(ptr)
 ; CHECKSYM-NEXT:   }
 ; CHECKSYM-NEXT:   Symbol {
 ; CHECKSYM-NEXT:     Index: [[#Index+8]]
-; CHECKSYM-NEXT:     Name: foo_ext_weak
-; CHECKSYM-NEXT:     Value (RelocatableAddress): 0x0
-; CHECKSYM-NEXT:     Section: N_UNDEF
-; CHECKSYM-NEXT:     Type: 0x0
-; CHECKSYM-NEXT:     StorageClass: C_WEAKEXT (0x6F)
-; CHECKSYM-NEXT:     NumberOfAuxEntries: 1
-; CHECKSYM-NEXT:     CSECT Auxiliary Entry {
-; CHECKSYM-NEXT:       Index: [[#Index+9]]
-; CHECKSYM-NEXT:       SectionLen: 0
-; CHECKSYM-NEXT:       ParameterHashIndex: 0x0
-; CHECKSYM-NEXT:       TypeChkSectNum: 0x0
-; CHECKSYM-NEXT:       SymbolAlignmentLog2: 0
-; CHECKSYM-NEXT:       SymbolType: XTY_ER (0x0)
-; CHECKSYM-NEXT:       StorageMappingClass: XMC_DS (0xA)
-; CHECKSYM32-NEXT:     StabInfoIndex: 0x0
-; CHECKSYM32-NEXT:     StabSectNum: 0x0
-; CHECKSYM64-NEXT:     Auxiliary Type: AUX_CSECT (0xFB)
-; CHECKSYM-NEXT:     }
-; CHECKSYM-NEXT:   }
-; CHECKSYM-NEXT:   Symbol {
-; CHECKSYM-NEXT:     Index: [[#Index+10]]
 ; CHECKSYM-NEXT:     Name:
 ; CHECKSYM-NEXT:     Value (RelocatableAddress): 0x0
 ; CHECKSYM-NEXT:     Section: .text
@@ -187,7 +165,7 @@ declare extern_weak void @foo_ext_weak(ptr)
 ; CHECKSYM-NEXT:     StorageClass: C_HIDEXT (0x6B)
 ; CHECKSYM-NEXT:     NumberOfAuxEntries: 1
 ; CHECKSYM-NEXT:     CSECT Auxiliary Entry {
-; CHECKSYM-NEXT:       Index: [[#Index+11]]
+; CHECKSYM-NEXT:       Index: [[#Index+9]]
 ; CHECKSYM-NEXT:       SectionLen: 80
 ; CHECKSYM-NEXT:       ParameterHashIndex: 0x0
 ; CHECKSYM-NEXT:       TypeChkSectNum: 0x0
@@ -200,7 +178,7 @@ declare extern_weak void @foo_ext_weak(ptr)
 ; CHECKSYM-NEXT:     }
 ; CHECKSYM-NEXT:   }
 ; CHECKSYM-NEXT:   Symbol {
-; CHECKSYM-NEXT:     Index: [[#Index+12]]
+; CHECKSYM-NEXT:     Index: [[#Index+10]]
 ; CHECKSYM-NEXT:     Name: .main
 ; CHECKSYM-NEXT:     Value (RelocatableAddress): 0x0
 ; CHECKSYM-NEXT:     Section: .text
@@ -208,8 +186,8 @@ declare extern_weak void @foo_ext_weak(ptr)
 ; CHECKSYM-NEXT:     StorageClass: C_EXT (0x2)
 ; CHECKSYM-NEXT:     NumberOfAuxEntries: 1
 ; CHECKSYM-NEXT:     CSECT Auxiliary Entry {
-; CHECKSYM-NEXT:       Index: [[#Index+13]]
-; CHECKSYM-NEXT:       ContainingCsectSymbolIndex: [[#Index+10]]
+; CHECKSYM-NEXT:       Index: [[#Index+11]]
+; CHECKSYM-NEXT:       ContainingCsectSymbolIndex: [[#Index+8]]
 ; CHECKSYM-NEXT:       ParameterHashIndex: 0x0
 ; CHECKSYM-NEXT:       TypeChkSectNum: 0x0
 ; CHECKSYM-NEXT:       SymbolAlignmentLog2: 0
@@ -221,7 +199,7 @@ declare extern_weak void @foo_ext_weak(ptr)
 ; CHECKSYM-NEXT:     }
 ; CHECKSYM-NEXT:   }
 ; CHECKSYM-NEXT:   Symbol {
-; CHECKSYM-NEXT:     Index: [[#Index+14]]
+; CHECKSYM-NEXT:     Index: [[#Index+12]]
 ; CHECKSYM-NEXT:     Name: .data
 ; CHECKSYM-NEXT:     Value (RelocatableAddress): 0x50
 ; CHECKSYM-NEXT:     Section: .data
@@ -229,7 +207,7 @@ declare extern_weak void @foo_ext_weak(ptr)
 ; CHECKSYM-NEXT:     StorageClass: C_HIDEXT (0x6B)
 ; CHECKSYM-NEXT:     NumberOfAuxEntries: 1
 ; CHECKSYM-NEXT:     CSECT Auxiliary Entry {
-; CHECKSYM-NEXT:       Index: [[#Index+15]]
+; CHECKSYM-NEXT:       Index: [[#Index+13]]
 ; CHECKSYM32-NEXT:     SectionLen: 4
 ; CHECKSYM64-NEXT:     SectionLen: 8
 ; CHECKSYM-NEXT:       ParameterHashIndex: 0x0
@@ -244,7 +222,7 @@ declare extern_weak void @foo_ext_weak(ptr)
 ; CHECKSYM-NEXT:     }
 ; CHECKSYM-NEXT:   }
 ; CHECKSYM-NEXT:   Symbol {
-; CHECKSYM-NEXT:     Index: [[#Index+16]]
+; CHECKSYM-NEXT:     Index: [[#Index+14]]
 ; CHECKSYM-NEXT:     Name: foo_ext_weak_p
 ; CHECKSYM-NEXT:     Value (RelocatableAddress): 0x50
 ; CHECKSYM-NEXT:     Section: .data
@@ -252,8 +230,8 @@ declare extern_weak void @foo_ext_weak(ptr)
 ; CHECKSYM-NEXT:     StorageClass: C_EXT (0x2)
 ; CHECKSYM-NEXT:     NumberOfAuxEntries: 1
 ; CHECKSYM-NEXT:     CSECT Auxiliary Entry {
-; CHECKSYM-NEXT:       Index: [[#Index+17]]
-; CHECKSYM-NEXT:       ContainingCsectSymbolIndex: [[#Index+14]]
+; CHECKSYM-NEXT:       Index: [[#Index+15]]
+; CHECKSYM-NEXT:       ContainingCsectSymbolIndex: [[#Index+12]]
 ; CHECKSYM-NEXT:       ParameterHashIndex: 0x0
 ; CHECKSYM-NEXT:       TypeChkSectNum: 0x0
 ; CHECKSYM-NEXT:       SymbolAlignmentLog2: 0
@@ -265,7 +243,7 @@ declare extern_weak void @foo_ext_weak(ptr)
 ; CHECKSYM-NEXT:     }
 ; CHECKSYM-NEXT:   }
 ; CHECKSYM-NEXT:   Symbol {
-; CHECKSYM-NEXT:     Index: [[#Index+18]]
+; CHECKSYM-NEXT:     Index: [[#Index+16]]
 ; CHECKSYM-NEXT:     Name: main
 ; CHECKSYM32-NEXT:   Value (RelocatableAddress): 0x54
 ; CHECKSYM64-NEXT:   Value (RelocatableAddress): 0x58
@@ -274,7 +252,7 @@ declare extern_weak void @foo_ext_weak(ptr)
 ; CHECKSYM-NEXT:     StorageClass: C_EXT (0x2)
 ; CHECKSYM-NEXT:     NumberOfAuxEntries: 1
 ; CHECKSYM-NEXT:     CSECT Auxiliary Entry {
-; CHECKSYM-NEXT:       Index: [[#Index+19]]
+; CHECKSYM-NEXT:       Index: [[#Index+17]]
 ; CHECKSYM32-NEXT:     SectionLen: 12
 ; CHECKSYM64-NEXT:     SectionLen: 24
 ; CHECKSYM-NEXT:       ParameterHashIndex: 0x0
@@ -289,7 +267,7 @@ declare extern_weak void @foo_ext_weak(ptr)
 ; CHECKSYM-NEXT:     }
 ; CHECKSYM-NEXT:   }
 ; CHECKSYM-NEXT:   Symbol {
-; CHECKSYM-NEXT:     Index: [[#Index+20]]
+; CHECKSYM-NEXT:     Index: [[#Index+18]]
 ; CHECKSYM-NEXT:     Name: TOC
 ; CHECKSYM32-NEXT:   Value (RelocatableAddress): 0x60
 ; CHECKSYM64-NEXT:   Value (RelocatableAddress): 0x70
@@ -298,7 +276,7 @@ declare extern_weak void @foo_ext_weak(ptr)
 ; CHECKSYM-NEXT:     StorageClass: C_HIDEXT (0x6B)
 ; CHECKSYM-NEXT:     NumberOfAuxEntries: 1
 ; CHECKSYM-NEXT:     CSECT Auxiliary Entry {
-; CHECKSYM-NEXT:       Index: [[#Index+21]]
+; CHECKSYM-NEXT:       Index: [[#Index+19]]
 ; CHECKSYM-NEXT:       SectionLen: 0
 ; CHECKSYM-NEXT:       ParameterHashIndex: 0x0
 ; CHECKSYM-NEXT:       TypeChkSectNum: 0x0
@@ -311,7 +289,7 @@ declare extern_weak void @foo_ext_weak(ptr)
 ; CHECKSYM-NEXT:     }
 ; CHECKSYM-NEXT:   }
 ; CHECKSYM-NEXT:   Symbol {
-; CHECKSYM-NEXT:     Index: [[#Index+22]]
+; CHECKSYM-NEXT:     Index: [[#Index+20]]
 ; CHECKSYM-NEXT:     Name: foo_ext_weak_p
 ; CHECKSYM32-NEXT:   Value (RelocatableAddress): 0x60
 ; CHECKSYM64-NEXT:   Value (RelocatableAddress): 0x70
@@ -320,7 +298,7 @@ declare extern_weak void @foo_ext_weak(ptr)
 ; CHECKSYM-NEXT:     StorageClass: C_HIDEXT (0x6B)
 ; CHECKSYM-NEXT:     NumberOfAuxEntries: 1
 ; CHECKSYM-NEXT:     CSECT Auxiliary Entry {
-; CHECKSYM-NEXT:       Index: [[#Index+23]]
+; CHECKSYM-NEXT:       Index: [[#Index+21]]
 ; CHECKSYM32-NEXT:     SectionLen: 4
 ; CHECKSYM64-NEXT:     SectionLen: 8
 ; CHECKSYM-NEXT:       ParameterHashIndex: 0x0
@@ -335,7 +313,7 @@ declare extern_weak void @foo_ext_weak(ptr)
 ; CHECKSYM-NEXT:     }
 ; CHECKSYM-NEXT:   }
 ; CHECKSYM-NEXT:   Symbol {
-; CHECKSYM-NEXT:     Index: [[#Index+24]]
+; CHECKSYM-NEXT:     Index: [[#Index+22]]
 ; CHECKSYM-NEXT:     Name: b_w
 ; CHECKSYM32-NEXT:   Value (RelocatableAddress): 0x64
 ; CHECKSYM64-NEXT:   Value (RelocatableAddress): 0x78
@@ -344,7 +322,7 @@ declare extern_weak void @foo_ext_weak(ptr)
 ; CHECKSYM-NEXT:     StorageClass: C_HIDEXT (0x6B)
 ; CHECKSYM-NEXT:     NumberOfAuxEntries: 1
 ; CHECKSYM-NEXT:     CSECT Auxiliary Entry {
-; CHECKSYM-NEXT:       Index: [[#Index+25]]
+; CHECKSYM-NEXT:       Index: [[#Index+23]]
 ; CHECKSYM32-NEXT:     SectionLen: 4
 ; CHECKSYM64-NEXT:     SectionLen: 8
 ; CHECKSYM-NEXT:       ParameterHashIndex: 0x0

--- a/llvm/test/CodeGen/PowerPC/aix-extern.ll
+++ b/llvm/test/CodeGen/PowerPC/aix-extern.ll
@@ -78,7 +78,6 @@ declare i32 @bar_extern(ptr)
 ; COMMON-NEXT:      .extern .bar_ref
 ; COMMON-NEXT:      .extern bar_ref[DS]
 ; COMMON-NEXT:	    .extern	.bar_extern
-; COMMON-NEXT:      .extern     bar_extern[DS]
 ; COMMON-NEXT:	    .toc
 ; COMMON-NEXT: L..C0:
 ; COMMON-NEXT:      .tc b_e[TC],b_e[UA]
@@ -182,27 +181,6 @@ declare i32 @bar_extern(ptr)
 ; CHECKSYM-NEXT:   }
 ; CHECKSYM-NEXT:   Symbol {
 ; CHECKSYM-NEXT:     Index: [[#Index+8]]
-; CHECKSYM-NEXT:     Name: bar_extern
-; CHECKSYM-NEXT:     Value (RelocatableAddress): 0x0
-; CHECKSYM-NEXT:     Section: N_UNDEF
-; CHECKSYM-NEXT:     Type: 0x0
-; CHECKSYM-NEXT:     StorageClass: C_EXT (0x2)
-; CHECKSYM-NEXT:     NumberOfAuxEntries: 1
-; CHECKSYM-NEXT:     CSECT Auxiliary Entry {
-; CHECKSYM-NEXT:       Index: [[#Index+9]]
-; CHECKSYM-NEXT:       SectionLen: 0
-; CHECKSYM-NEXT:       ParameterHashIndex: 0x0
-; CHECKSYM-NEXT:       TypeChkSectNum: 0x0
-; CHECKSYM-NEXT:       SymbolAlignmentLog2: 0
-; CHECKSYM-NEXT:       SymbolType: XTY_ER (0x0)
-; CHECKSYM-NEXT:       StorageMappingClass: XMC_DS (0xA)
-; CHECKSYM32-NEXT:     StabInfoIndex: 0x0
-; CHECKSYM32-NEXT:     StabSectNum: 0x0
-; CHECKSYM64-NEXT:     Auxiliary Type: AUX_CSECT (0xFB)
-; CHECKSYM-NEXT:     }
-; CHECKSYM-NEXT:   }
-; CHECKSYM-NEXT:   Symbol {
-; CHECKSYM-NEXT:     Index: [[#Index+10]]
 ; CHECKSYM-NEXT:     Name:
 ; CHECKSYM-NEXT:     Value (RelocatableAddress): 0x0
 ; CHECKSYM-NEXT:     Section: .text
@@ -210,7 +188,7 @@ declare i32 @bar_extern(ptr)
 ; CHECKSYM-NEXT:     StorageClass: C_HIDEXT (0x6B)
 ; CHECKSYM-NEXT:     NumberOfAuxEntries: 1
 ; CHECKSYM-NEXT:     CSECT Auxiliary Entry {
-; CHECKSYM-NEXT:       Index: [[#Index+11]]
+; CHECKSYM-NEXT:       Index: [[#Index+9]]
 ; CHECKSYM-NEXT:       SectionLen: 112
 ; CHECKSYM-NEXT:       ParameterHashIndex: 0x0
 ; CHECKSYM-NEXT:       TypeChkSectNum: 0x0
@@ -223,7 +201,7 @@ declare i32 @bar_extern(ptr)
 ; CHECKSYM-NEXT:     }
 ; CHECKSYM-NEXT:   }
 ; CHECKSYM-NEXT:   Symbol {
-; CHECKSYM-NEXT:     Index: [[#Index+12]]
+; CHECKSYM-NEXT:     Index: [[#Index+10]]
 ; CHECKSYM-NEXT:     Name: .foo
 ; CHECKSYM-NEXT:     Value (RelocatableAddress): 0x0
 ; CHECKSYM-NEXT:     Section: .text
@@ -231,8 +209,29 @@ declare i32 @bar_extern(ptr)
 ; CHECKSYM-NEXT:     StorageClass: C_EXT (0x2)
 ; CHECKSYM-NEXT:     NumberOfAuxEntries: 1
 ; CHECKSYM-NEXT:     CSECT Auxiliary Entry {
+; CHECKSYM-NEXT:       Index: [[#Index+11]]
+; CHECKSYM-NEXT:       ContainingCsectSymbolIndex: [[#Index+8]]
+; CHECKSYM-NEXT:       ParameterHashIndex: 0x0
+; CHECKSYM-NEXT:       TypeChkSectNum: 0x0
+; CHECKSYM-NEXT:       SymbolAlignmentLog2: 0
+; CHECKSYM-NEXT:       SymbolType: XTY_LD (0x2)
+; CHECKSYM-NEXT:       StorageMappingClass: XMC_PR (0x0)
+; CHECKSYM32-NEXT:     StabInfoIndex: 0x0
+; CHECKSYM32-NEXT:     StabSectNum: 0x0
+; CHECKSYM64-NEXT:     Auxiliary Type: AUX_CSECT (0xFB)
+; CHECKSYM-NEXT:     }
+; CHECKSYM-NEXT:   }
+; CHECKSYM-NEXT:   Symbol {
+; CHECKSYM-NEXT:     Index: [[#Index+12]]
+; CHECKSYM-NEXT:     Name: .main
+; CHECKSYM-NEXT:     Value (RelocatableAddress): 0x10
+; CHECKSYM-NEXT:     Section: .text
+; CHECKSYM-NEXT:     Type: 0x0
+; CHECKSYM-NEXT:     StorageClass: C_EXT (0x2)
+; CHECKSYM-NEXT:     NumberOfAuxEntries: 1
+; CHECKSYM-NEXT:     CSECT Auxiliary Entry {
 ; CHECKSYM-NEXT:       Index: [[#Index+13]]
-; CHECKSYM-NEXT:       ContainingCsectSymbolIndex: [[#Index+10]]
+; CHECKSYM-NEXT:       ContainingCsectSymbolIndex: [[#Index+8]]
 ; CHECKSYM-NEXT:       ParameterHashIndex: 0x0
 ; CHECKSYM-NEXT:       TypeChkSectNum: 0x0
 ; CHECKSYM-NEXT:       SymbolAlignmentLog2: 0
@@ -245,27 +244,6 @@ declare i32 @bar_extern(ptr)
 ; CHECKSYM-NEXT:   }
 ; CHECKSYM-NEXT:   Symbol {
 ; CHECKSYM-NEXT:     Index: [[#Index+14]]
-; CHECKSYM-NEXT:     Name: .main
-; CHECKSYM-NEXT:     Value (RelocatableAddress): 0x10
-; CHECKSYM-NEXT:     Section: .text
-; CHECKSYM-NEXT:     Type: 0x0
-; CHECKSYM-NEXT:     StorageClass: C_EXT (0x2)
-; CHECKSYM-NEXT:     NumberOfAuxEntries: 1
-; CHECKSYM-NEXT:     CSECT Auxiliary Entry {
-; CHECKSYM-NEXT:       Index: [[#Index+15]]
-; CHECKSYM-NEXT:       ContainingCsectSymbolIndex: [[#Index+10]]
-; CHECKSYM-NEXT:       ParameterHashIndex: 0x0
-; CHECKSYM-NEXT:       TypeChkSectNum: 0x0
-; CHECKSYM-NEXT:       SymbolAlignmentLog2: 0
-; CHECKSYM-NEXT:       SymbolType: XTY_LD (0x2)
-; CHECKSYM-NEXT:       StorageMappingClass: XMC_PR (0x0)
-; CHECKSYM32-NEXT:     StabInfoIndex: 0x0
-; CHECKSYM32-NEXT:     StabSectNum: 0x0
-; CHECKSYM64-NEXT:     Auxiliary Type: AUX_CSECT (0xFB)
-; CHECKSYM-NEXT:     }
-; CHECKSYM-NEXT:   }
-; CHECKSYM-NEXT:   Symbol {
-; CHECKSYM-NEXT:     Index: [[#Index+16]]
 ; CHECKSYM-NEXT:     Name: .data
 ; CHECKSYM-NEXT:     Value (RelocatableAddress): 0x70
 ; CHECKSYM-NEXT:     Section: .data
@@ -273,7 +251,7 @@ declare i32 @bar_extern(ptr)
 ; CHECKSYM-NEXT:     StorageClass: C_HIDEXT (0x6B)
 ; CHECKSYM-NEXT:     NumberOfAuxEntries: 1
 ; CHECKSYM-NEXT:     CSECT Auxiliary Entry {
-; CHECKSYM-NEXT:       Index: [[#Index+17]]
+; CHECKSYM-NEXT:       Index: [[#Index+15]]
 ; CHECKSYM32-NEXT:     SectionLen: 4
 ; CHECKSYM64-NEXT:     SectionLen: 8
 ; CHECKSYM-NEXT:       ParameterHashIndex: 0x0
@@ -288,7 +266,7 @@ declare i32 @bar_extern(ptr)
 ; CHECKSYM-NEXT:     }
 ; CHECKSYM-NEXT:   }
 ; CHECKSYM-NEXT:   Symbol {
-; CHECKSYM-NEXT:     Index: [[#Index+18]]
+; CHECKSYM-NEXT:     Index: [[#Index+16]]
 ; CHECKSYM-NEXT:     Name: bar_p
 ; CHECKSYM-NEXT:     Value (RelocatableAddress): 0x70
 ; CHECKSYM-NEXT:     Section: .data
@@ -296,8 +274,8 @@ declare i32 @bar_extern(ptr)
 ; CHECKSYM-NEXT:     StorageClass: C_EXT (0x2)
 ; CHECKSYM-NEXT:     NumberOfAuxEntries: 1
 ; CHECKSYM-NEXT:     CSECT Auxiliary Entry {
-; CHECKSYM-NEXT:       Index: [[#Index+19]]
-; CHECKSYM-NEXT:       ContainingCsectSymbolIndex: [[#Index+16]]
+; CHECKSYM-NEXT:       Index: [[#Index+17]]
+; CHECKSYM-NEXT:       ContainingCsectSymbolIndex: [[#Index+14]]
 ; CHECKSYM-NEXT:       ParameterHashIndex: 0x0
 ; CHECKSYM-NEXT:       TypeChkSectNum: 0x0
 ; CHECKSYM-NEXT:       SymbolAlignmentLog2: 0
@@ -309,10 +287,34 @@ declare i32 @bar_extern(ptr)
 ; CHECKSYM-NEXT:     }
 ; CHECKSYM-NEXT:   }
 ; CHECKSYM-NEXT:   Symbol {
-; CHECKSYM-NEXT:     Index: [[#Index+20]]
+; CHECKSYM-NEXT:     Index: [[#Index+18]]
 ; CHECKSYM-NEXT:     Name: foo
 ; CHECKSYM32-NEXT:   Value (RelocatableAddress): 0x74
 ; CHECKSYM64-NEXT:   Value (RelocatableAddress): 0x78
+; CHECKSYM-NEXT:     Section: .data
+; CHECKSYM-NEXT:     Type: 0x0
+; CHECKSYM-NEXT:     StorageClass: C_EXT (0x2)
+; CHECKSYM-NEXT:     NumberOfAuxEntries: 1
+; CHECKSYM-NEXT:     CSECT Auxiliary Entry {
+; CHECKSYM-NEXT:       Index: [[#Index+19]]
+; CHECKSYM32-NEXT:     SectionLen: 12
+; CHECKSYM64-NEXT:     SectionLen: 24
+; CHECKSYM-NEXT:       ParameterHashIndex: 0x0
+; CHECKSYM-NEXT:       TypeChkSectNum: 0x0
+; CHECKSYM32-NEXT:     SymbolAlignmentLog2: 2
+; CHECKSYM64-NEXT:     SymbolAlignmentLog2: 3
+; CHECKSYM-NEXT:       SymbolType: XTY_SD (0x1)
+; CHECKSYM-NEXT:       StorageMappingClass: XMC_DS (0xA)
+; CHECKSYM32-NEXT:     StabInfoIndex: 0x0
+; CHECKSYM32-NEXT:     StabSectNum: 0x0
+; CHECKSYM64-NEXT:     Auxiliary Type: AUX_CSECT (0xFB)
+; CHECKSYM-NEXT:     }
+; CHECKSYM-NEXT:   }
+; CHECKSYM-NEXT:   Symbol {
+; CHECKSYM-NEXT:     Index: [[#Index+20]]
+; CHECKSYM-NEXT:     Name: main
+; CHECKSYM32-NEXT:   Value (RelocatableAddress): 0x80
+; CHECKSYM64-NEXT:   Value (RelocatableAddress): 0x90
 ; CHECKSYM-NEXT:     Section: .data
 ; CHECKSYM-NEXT:     Type: 0x0
 ; CHECKSYM-NEXT:     StorageClass: C_EXT (0x2)
@@ -334,30 +336,6 @@ declare i32 @bar_extern(ptr)
 ; CHECKSYM-NEXT:   }
 ; CHECKSYM-NEXT:   Symbol {
 ; CHECKSYM-NEXT:     Index: [[#Index+22]]
-; CHECKSYM-NEXT:     Name: main
-; CHECKSYM32-NEXT:   Value (RelocatableAddress): 0x80
-; CHECKSYM64-NEXT:   Value (RelocatableAddress): 0x90
-; CHECKSYM-NEXT:     Section: .data
-; CHECKSYM-NEXT:     Type: 0x0
-; CHECKSYM-NEXT:     StorageClass: C_EXT (0x2)
-; CHECKSYM-NEXT:     NumberOfAuxEntries: 1
-; CHECKSYM-NEXT:     CSECT Auxiliary Entry {
-; CHECKSYM-NEXT:       Index: [[#Index+23]]
-; CHECKSYM32-NEXT:     SectionLen: 12
-; CHECKSYM64-NEXT:     SectionLen: 24
-; CHECKSYM-NEXT:       ParameterHashIndex: 0x0
-; CHECKSYM-NEXT:       TypeChkSectNum: 0x0
-; CHECKSYM32-NEXT:     SymbolAlignmentLog2: 2
-; CHECKSYM64-NEXT:     SymbolAlignmentLog2: 3
-; CHECKSYM-NEXT:       SymbolType: XTY_SD (0x1)
-; CHECKSYM-NEXT:       StorageMappingClass: XMC_DS (0xA)
-; CHECKSYM32-NEXT:     StabInfoIndex: 0x0
-; CHECKSYM32-NEXT:     StabSectNum: 0x0
-; CHECKSYM64-NEXT:     Auxiliary Type: AUX_CSECT (0xFB)
-; CHECKSYM-NEXT:     }
-; CHECKSYM-NEXT:   }
-; CHECKSYM-NEXT:   Symbol {
-; CHECKSYM-NEXT:     Index: [[#Index+24]]
 ; CHECKSYM-NEXT:     Name: TOC
 ; CHECKSYM32-NEXT:   Value (RelocatableAddress): 0x8C
 ; CHECKSYM64-NEXT:   Value (RelocatableAddress): 0xA8
@@ -366,7 +344,7 @@ declare i32 @bar_extern(ptr)
 ; CHECKSYM-NEXT:     StorageClass: C_HIDEXT (0x6B)
 ; CHECKSYM-NEXT:     NumberOfAuxEntries: 1
 ; CHECKSYM-NEXT:     CSECT Auxiliary Entry {
-; CHECKSYM-NEXT:       Index: [[#Index+25]]
+; CHECKSYM-NEXT:       Index: [[#Index+23]]
 ; CHECKSYM-NEXT:       SectionLen: 0
 ; CHECKSYM-NEXT:       ParameterHashIndex: 0x0
 ; CHECKSYM-NEXT:       TypeChkSectNum: 0x0
@@ -379,7 +357,7 @@ declare i32 @bar_extern(ptr)
 ; CHECKSYM-NEXT:     }
 ; CHECKSYM-NEXT:   }
 ; CHECKSYM-NEXT:   Symbol {
-; CHECKSYM-NEXT:     Index: [[#Index+26]]
+; CHECKSYM-NEXT:     Index: [[#Index+24]]
 ; CHECKSYM-NEXT:     Name: b_e
 ; CHECKSYM32-NEXT:   Value (RelocatableAddress): 0x8C
 ; CHECKSYM64-NEXT:   Value (RelocatableAddress): 0xA8
@@ -388,7 +366,7 @@ declare i32 @bar_extern(ptr)
 ; CHECKSYM-NEXT:     StorageClass: C_HIDEXT (0x6B)
 ; CHECKSYM-NEXT:     NumberOfAuxEntries: 1
 ; CHECKSYM-NEXT:     CSECT Auxiliary Entry {
-; CHECKSYM-NEXT:       Index: [[#Index+27]]
+; CHECKSYM-NEXT:       Index: [[#Index+25]]
 ; CHECKSYM32-NEXT:     SectionLen: 4
 ; CHECKSYM64-NEXT:     SectionLen: 8
 ; CHECKSYM-NEXT:       ParameterHashIndex: 0x0
@@ -403,7 +381,7 @@ declare i32 @bar_extern(ptr)
 ; CHECKSYM-NEXT:     }
 ; CHECKSYM-NEXT:   }
 ; CHECKSYM-NEXT:   Symbol {
-; CHECKSYM-NEXT:     Index: [[#Index+28]]
+; CHECKSYM-NEXT:     Index: [[#Index+26]]
 ; CHECKSYM-NEXT:     Name: bar_p
 ; CHECKSYM32-NEXT:   Value (RelocatableAddress): 0x90
 ; CHECKSYM64-NEXT:   Value (RelocatableAddress): 0xB0
@@ -412,7 +390,7 @@ declare i32 @bar_extern(ptr)
 ; CHECKSYM-NEXT:     StorageClass: C_HIDEXT (0x6B)
 ; CHECKSYM-NEXT:     NumberOfAuxEntries: 1
 ; CHECKSYM-NEXT:     CSECT Auxiliary Entry {
-; CHECKSYM-NEXT:       Index: [[#Index+29]]
+; CHECKSYM-NEXT:       Index: [[#Index+27]]
 ; CHECKSYM32-NEXT:     SectionLen: 4
 ; CHECKSYM64-NEXT:     SectionLen: 8
 ; CHECKSYM-NEXT:       ParameterHashIndex: 0x0

--- a/llvm/test/CodeGen/PowerPC/aix-text-ref.ll
+++ b/llvm/test/CodeGen/PowerPC/aix-text-ref.ll
@@ -14,7 +14,5 @@ entry:
 declare i32 @text(...)
 
 ; CHECK32: 00000000         *UND*  00000000 (idx: {{[[:digit:]]*}}) .text[PR]
-; CHECK32: 00000000         *UND*  00000000 (idx: {{[[:digit:]]*}}) text[DS]
 
 ; CHECK64: 0000000000000000         *UND*  0000000000000000 (idx: {{[[:digit:]]*}}) .text[PR]
-; CHECK64: 0000000000000000         *UND*  0000000000000000 (idx: {{[[:digit:]]*}}) text[DS]

--- a/llvm/test/CodeGen/PowerPC/aix-xcoff-funcsect.ll
+++ b/llvm/test/CodeGen/PowerPC/aix-xcoff-funcsect.ll
@@ -108,119 +108,122 @@ entry:
 ; ASM-NEXT:  # %bb.0:                                # %entry
 ; ASM-NEXT:  	blr
 ; ASM:        .extern	.extern_foo
+; ASM-NEXT:  	.extern	extern_foo[DS]
 ; ASM-NEXT:  	.globl	alias_foo
 ; ASM-NEXT:  	.globl	.alias_foo
 
 ; XCOFF32:      SYMBOL TABLE:
 ; XCOFF32-NEXT: 00000000      df *DEBUG*	00000000 (idx: 0) .file
 ; XCOFF32-NEXT: 00000000         *UND*	00000000 (idx: [[#NFA+1]]) .extern_foo[PR]
-; XCOFF32-NEXT: 00000000 l       .text	00000000 (idx: [[#NFA+3]]) [PR]
-; XCOFF32-NEXT: 00000000 g       .text	00000019 (idx: [[#NFA+5]]) .foo[PR]
-; XCOFF32-NEXT: 00000000 g     F .text (csect: (idx: [[#NFA+5]]) .foo[PR]) 	00000000 (idx: [[#NFA+7]]) .alias_foo
-; XCOFF32-NEXT: 00000020 g     F .text	00000020 .hidden (idx: [[#NFA+9]]) .hidden_foo[PR]
-; XCOFF32-NEXT: 00000040 g     F .text	00000059 (idx: [[#NFA+11]]) .bar[PR]
-; XCOFF32-NEXT: 000000c0 l     F .text	0000002a (idx: [[#NFA+13]]) .static_overalign_foo[PR]
-; XCOFF32-NEXT: 000000ec g     O .data	0000000c (idx: [[#NFA+15]]) foo[DS]
-; XCOFF32-NEXT: 000000ec g     O .data (csect: (idx: [[#NFA+15]]) foo[DS]) 	00000000 (idx: [[#NFA+17]]) alias_foo
-; XCOFF32-NEXT: 000000f8 g     O .data	0000000c .hidden (idx: [[#NFA+19]]) hidden_foo[DS]
-; XCOFF32-NEXT: 00000104 g     O .data	0000000c (idx: [[#NFA+21]]) bar[DS]
-; XCOFF32-NEXT: 00000110 l     O .data	0000000c (idx: [[#NFA+23]]) static_overalign_foo[DS]
-; XCOFF32-NEXT: 0000011c l       .data	00000000 (idx: [[#NFA+25]]) TOC[TC0]
+; XCOFF32-NEXT: 00000000         *UND*	00000000 (idx: [[#NFA+3]]) extern_foo[DS]
+; XCOFF32-NEXT: 00000000 l       .text	00000000 (idx: [[#NFA+5]]) [PR]
+; XCOFF32-NEXT: 00000000 g       .text	00000019 (idx: [[#NFA+7]]) .foo[PR]
+; XCOFF32-NEXT: 00000000 g     F .text (csect: (idx: [[#NFA+7]]) .foo[PR]) 	00000000 (idx: [[#NFA+9]]) .alias_foo
+; XCOFF32-NEXT: 00000020 g     F .text	00000020 .hidden (idx: [[#NFA+11]]) .hidden_foo[PR]
+; XCOFF32-NEXT: 00000040 g     F .text	00000059 (idx: [[#NFA+13]]) .bar[PR]
+; XCOFF32-NEXT: 000000c0 l     F .text	0000002a (idx: [[#NFA+15]]) .static_overalign_foo[PR]
+; XCOFF32-NEXT: 000000ec g     O .data	0000000c (idx: [[#NFA+17]]) foo[DS]
+; XCOFF32-NEXT: 000000ec g     O .data (csect: (idx: [[#NFA+17]]) foo[DS]) 	00000000 (idx: [[#NFA+19]]) alias_foo
+; XCOFF32-NEXT: 000000f8 g     O .data	0000000c .hidden (idx: [[#NFA+21]]) hidden_foo[DS]
+; XCOFF32-NEXT: 00000104 g     O .data	0000000c (idx: [[#NFA+23]]) bar[DS]
+; XCOFF32-NEXT: 00000110 l     O .data	0000000c (idx: [[#NFA+25]]) static_overalign_foo[DS]
+; XCOFF32-NEXT: 0000011c l       .data	00000000 (idx: [[#NFA+27]]) TOC[TC0]
 
 ; XCOFF32:      RELOCATION RECORDS FOR [.text]:
 ; XCOFF32-NEXT: OFFSET   TYPE                     VALUE
-; XCOFF32-NEXT: 0000004c R_RBR                    (idx: [[#NFA+5]]) .foo[PR]
-; XCOFF32-NEXT: 00000054 R_RBR                    (idx: [[#NFA+13]]) .static_overalign_foo[PR]
-; XCOFF32-NEXT: 0000005c R_RBR                    (idx: [[#NFA+7]]) .alias_foo
+; XCOFF32-NEXT: 0000004c R_RBR                    (idx: [[#NFA+7]]) .foo[PR]
+; XCOFF32-NEXT: 00000054 R_RBR                    (idx: [[#NFA+15]]) .static_overalign_foo[PR]
+; XCOFF32-NEXT: 0000005c R_RBR                    (idx: [[#NFA+9]]) .alias_foo
 ; XCOFF32-NEXT: 00000064 R_RBR                    (idx: [[#NFA+1]]) .extern_foo[PR]
-; XCOFF32-NEXT: 0000006c R_RBR                    (idx: [[#NFA+9]]) .hidden_foo[PR]
+; XCOFF32-NEXT: 0000006c R_RBR                    (idx: [[#NFA+11]]) .hidden_foo[PR]
 ; XCOFF32:      RELOCATION RECORDS FOR [.data]:
 ; XCOFF32-NEXT: OFFSET   TYPE                     VALUE
-; XCOFF32-NEXT: 00000000 R_POS                    (idx: [[#NFA+5]]) .foo[PR]
-; XCOFF32-NEXT: 00000004 R_POS                    (idx: [[#NFA+25]]) TOC[TC0]
-; XCOFF32-NEXT: 0000000c R_POS                    (idx: [[#NFA+9]]) .hidden_foo[PR]
-; XCOFF32-NEXT: 00000010 R_POS                    (idx: [[#NFA+25]]) TOC[TC0]
-; XCOFF32-NEXT: 00000018 R_POS                    (idx: [[#NFA+11]]) .bar[PR]
-; XCOFF32-NEXT: 0000001c R_POS                    (idx: [[#NFA+25]]) TOC[TC0]
-; XCOFF32-NEXT: 00000024 R_POS                    (idx: [[#NFA+13]]) .static_overalign_foo[PR]
-; XCOFF32-NEXT: 00000028 R_POS                    (idx: [[#NFA+25]]) TOC[TC0]
+; XCOFF32-NEXT: 00000000 R_POS                    (idx: [[#NFA+7]]) .foo[PR]
+; XCOFF32-NEXT: 00000004 R_POS                    (idx: [[#NFA+27]]) TOC[TC0]
+; XCOFF32-NEXT: 0000000c R_POS                    (idx: [[#NFA+11]]) .hidden_foo[PR]
+; XCOFF32-NEXT: 00000010 R_POS                    (idx: [[#NFA+27]]) TOC[TC0]
+; XCOFF32-NEXT: 00000018 R_POS                    (idx: [[#NFA+13]]) .bar[PR]
+; XCOFF32-NEXT: 0000001c R_POS                    (idx: [[#NFA+27]]) TOC[TC0]
+; XCOFF32-NEXT: 00000024 R_POS                    (idx: [[#NFA+15]]) .static_overalign_foo[PR]
+; XCOFF32-NEXT: 00000028 R_POS                    (idx: [[#NFA+27]]) TOC[TC0]
 
 ; XCOFF64:      SYMBOL TABLE:
 ; XCOFF64-NEXT: 0000000000000000      df *DEBUG*	0000000000000000 (idx: 0) .file
 ; XCOFF64-NEXT: 0000000000000000         *UND*	0000000000000000 (idx: [[#NFA+1]]) .extern_foo[PR]
-; XCOFF64-NEXT: 0000000000000000 l       .text	0000000000000000 (idx: [[#NFA+3]]) [PR]
-; XCOFF64-NEXT: 0000000000000000 g       .text	0000000000000019 (idx: [[#NFA+5]]) .foo[PR]
-; XCOFF64-NEXT: 0000000000000000 g     F .text (csect: (idx: [[#NFA+5]]) .foo[PR]) 	0000000000000000 (idx: [[#NFA+7]]) .alias_foo
-; XCOFF64-NEXT: 0000000000000020 g     F .text	0000000000000020 .hidden (idx: [[#NFA+9]]) .hidden_foo[PR]
-; XCOFF64-NEXT: 0000000000000040 g     F .text	0000000000000059 (idx: [[#NFA+11]]) .bar[PR]
-; XCOFF64-NEXT: 00000000000000c0 l     F .text	000000000000002a (idx: [[#NFA+13]]) .static_overalign_foo[PR]
-; XCOFF64-NEXT: 00000000000000f0 g     O .data	0000000000000018 (idx: [[#NFA+15]]) foo[DS]
-; XCOFF64-NEXT: 00000000000000f0 g     O .data (csect: (idx: [[#NFA+15]]) foo[DS]) 	0000000000000000 (idx: [[#NFA+17]]) alias_foo
-; XCOFF64-NEXT: 0000000000000108 g     O .data	0000000000000018 .hidden (idx: [[#NFA+19]]) hidden_foo[DS]
-; XCOFF64-NEXT: 0000000000000120 g     O .data	0000000000000018 (idx: [[#NFA+21]]) bar[DS]
-; XCOFF64-NEXT: 0000000000000138 l     O .data	0000000000000018 (idx: [[#NFA+23]]) static_overalign_foo[DS]
-; XCOFF64-NEXT: 0000000000000150 l       .data	0000000000000000 (idx: [[#NFA+25]]) TOC[TC0]
+; XCOFF64-NEXT: 0000000000000000         *UND*	0000000000000000 (idx: [[#NFA+3]]) extern_foo[DS]
+; XCOFF64-NEXT: 0000000000000000 l       .text	0000000000000000 (idx: [[#NFA+5]]) [PR]
+; XCOFF64-NEXT: 0000000000000000 g       .text	0000000000000019 (idx: [[#NFA+7]]) .foo[PR]
+; XCOFF64-NEXT: 0000000000000000 g     F .text (csect: (idx: [[#NFA+7]]) .foo[PR]) 	0000000000000000 (idx: [[#NFA+9]]) .alias_foo
+; XCOFF64-NEXT: 0000000000000020 g     F .text	0000000000000020 .hidden (idx: [[#NFA+11]]) .hidden_foo[PR]
+; XCOFF64-NEXT: 0000000000000040 g     F .text	0000000000000059 (idx: [[#NFA+13]]) .bar[PR]
+; XCOFF64-NEXT: 00000000000000c0 l     F .text	000000000000002a (idx: [[#NFA+15]]) .static_overalign_foo[PR]
+; XCOFF64-NEXT: 00000000000000f0 g     O .data	0000000000000018 (idx: [[#NFA+17]]) foo[DS]
+; XCOFF64-NEXT: 00000000000000f0 g     O .data (csect: (idx: [[#NFA+17]]) foo[DS]) 	0000000000000000 (idx: [[#NFA+19]]) alias_foo
+; XCOFF64-NEXT: 0000000000000108 g     O .data	0000000000000018 .hidden (idx: [[#NFA+21]]) hidden_foo[DS]
+; XCOFF64-NEXT: 0000000000000120 g     O .data	0000000000000018 (idx: [[#NFA+23]]) bar[DS]
+; XCOFF64-NEXT: 0000000000000138 l     O .data	0000000000000018 (idx: [[#NFA+25]]) static_overalign_foo[DS]
+; XCOFF64-NEXT: 0000000000000150 l       .data	0000000000000000 (idx: [[#NFA+27]]) TOC[TC0]
 
 ; XCOFF64:      RELOCATION RECORDS FOR [.text]:
 ; XCOFF64-NEXT: OFFSET           TYPE                     VALUE
-; XCOFF64-NEXT: 000000000000004c R_RBR                    (idx: [[#NFA+5]]) .foo[PR]
-; XCOFF64-NEXT: 0000000000000054 R_RBR                    (idx: [[#NFA+13]]) .static_overalign_foo[PR]
-; XCOFF64-NEXT: 000000000000005c R_RBR                    (idx: [[#NFA+7]]) .alias_foo
+; XCOFF64-NEXT: 000000000000004c R_RBR                    (idx: [[#NFA+7]]) .foo[PR]
+; XCOFF64-NEXT: 0000000000000054 R_RBR                    (idx: [[#NFA+15]]) .static_overalign_foo[PR]
+; XCOFF64-NEXT: 000000000000005c R_RBR                    (idx: [[#NFA+9]]) .alias_foo
 ; XCOFF64-NEXT: 0000000000000064 R_RBR                    (idx: [[#NFA+1]]) .extern_foo[PR]
-; XCOFF64-NEXT: 000000000000006c R_RBR                    (idx: [[#NFA+9]]) .hidden_foo[PR]
+; XCOFF64-NEXT: 000000000000006c R_RBR                    (idx: [[#NFA+11]]) .hidden_foo[PR]
 ; XCOFF64:      RELOCATION RECORDS FOR [.data]:
 ; XCOFF64-NEXT: OFFSET           TYPE                     VALUE
-; XCOFF64-NEXT: 0000000000000000 R_POS                    (idx: [[#NFA+5]]) .foo[PR]
-; XCOFF64-NEXT: 0000000000000008 R_POS                    (idx: [[#NFA+25]]) TOC[TC0]
-; XCOFF64-NEXT: 0000000000000018 R_POS                    (idx: [[#NFA+9]]) .hidden_foo[PR]
-; XCOFF64-NEXT: 0000000000000020 R_POS                    (idx: [[#NFA+25]]) TOC[TC0]
-; XCOFF64-NEXT: 0000000000000030 R_POS                    (idx: [[#NFA+11]]) .bar[PR]
-; XCOFF64-NEXT: 0000000000000038 R_POS                    (idx: [[#NFA+25]]) TOC[TC0]
-; XCOFF64-NEXT: 0000000000000048 R_POS                    (idx: [[#NFA+13]]) .static_overalign_foo[PR]
-; XCOFF64-NEXT: 0000000000000050 R_POS                    (idx: [[#NFA+25]]) TOC[TC0]
+; XCOFF64-NEXT: 0000000000000000 R_POS                    (idx: [[#NFA+7]]) .foo[PR]
+; XCOFF64-NEXT: 0000000000000008 R_POS                    (idx: [[#NFA+27]]) TOC[TC0]
+; XCOFF64-NEXT: 0000000000000018 R_POS                    (idx: [[#NFA+11]]) .hidden_foo[PR]
+; XCOFF64-NEXT: 0000000000000020 R_POS                    (idx: [[#NFA+27]]) TOC[TC0]
+; XCOFF64-NEXT: 0000000000000030 R_POS                    (idx: [[#NFA+13]]) .bar[PR]
+; XCOFF64-NEXT: 0000000000000038 R_POS                    (idx: [[#NFA+27]]) TOC[TC0]
+; XCOFF64-NEXT: 0000000000000048 R_POS                    (idx: [[#NFA+15]]) .static_overalign_foo[PR]
+; XCOFF64-NEXT: 0000000000000050 R_POS                    (idx: [[#NFA+27]]) TOC[TC0]
 
 ; DIS32:      Disassembly of section .text:
-; DIS32:      00000000 (idx: [[#NFA+7]]) .alias_foo:
-; DIS32:      00000020 (idx: [[#NFA+9]]) .hidden_foo[PR]:
-; DIS32:      00000040 (idx: [[#NFA+11]]) .bar[PR]:
+; DIS32:      00000000 (idx: [[#NFA+9]]) .alias_foo:
+; DIS32:      00000020 (idx: [[#NFA+11]]) .hidden_foo[PR]:
+; DIS32:      00000040 (idx: [[#NFA+13]]) .bar[PR]:
 ; DIS32-NEXT:       40: 7c 08 02 a6  	mflr 0
 ; DIS32-NEXT:       44: 94 21 ff c0  	stwu 1, -64(1)
 ; DIS32-NEXT:       48: 90 01 00 48  	stw 0, 72(1)
 ; DIS32-NEXT:       4c: 4b ff ff b5  	bl 0x0 <.foo>
-; DIS32-NEXT: 			0000004c:  R_RBR	(idx: [[#NFA+5]]) .foo[PR]
+; DIS32-NEXT: 			0000004c:  R_RBR	(idx: [[#NFA+7]]) .foo[PR]
 ; DIS32-NEXT:       50: 60 00 00 00  	nop
 ; DIS32-NEXT:       54: 48 00 00 6d  	bl 0xc0 <.static_overalign_foo>
-; DIS32-NEXT: 			00000054:  R_RBR	(idx: [[#NFA+13]]) .static_overalign_foo[PR]
+; DIS32-NEXT: 			00000054:  R_RBR	(idx: [[#NFA+15]]) .static_overalign_foo[PR]
 ; DIS32-NEXT:       58: 60 00 00 00  	nop
 ; DIS32-NEXT:       5c: 4b ff ff a5  	bl 0x0 <.alias_foo>
-; DIS32-NEXT: 			0000005c:  R_RBR	(idx: [[#NFA+7]]) .alias_foo
+; DIS32-NEXT: 			0000005c:  R_RBR	(idx: [[#NFA+9]]) .alias_foo
 ; DIS32-NEXT:       60: 60 00 00 00  	nop
 ; DIS32-NEXT:       64: 4b ff ff 9d  	bl 0x0 <.extern_foo>
 ; DIS32-NEXT: 			00000064:  R_RBR	(idx: [[#NFA+1]]) .extern_foo[PR]
 ; DIS32-NEXT:       68: 60 00 00 00  	nop
 ; DIS32-NEXT:       6c: 4b ff ff b5  	bl 0x20 <.hidden_foo>
-; DIS32-NEXT: 			0000006c:  R_RBR	(idx: [[#NFA+9]]) .hidden_foo[PR]
-; DIS32:      000000c0 (idx: [[#NFA+13]]) .static_overalign_foo[PR]:
+; DIS32-NEXT: 			0000006c:  R_RBR	(idx: [[#NFA+11]]) .hidden_foo[PR]
+; DIS32:      000000c0 (idx: [[#NFA+15]]) .static_overalign_foo[PR]:
 
 ; DIS64:      Disassembly of section .text:
-; DIS64:      0000000000000000 (idx: [[#NFA+7]]) .alias_foo:
-; DIS64:      0000000000000020 (idx: [[#NFA+9]]) .hidden_foo[PR]:
-; DIS64:      0000000000000040 (idx: [[#NFA+11]]) .bar[PR]:
+; DIS64:      0000000000000000 (idx: [[#NFA+9]]) .alias_foo:
+; DIS64:      0000000000000020 (idx: [[#NFA+11]]) .hidden_foo[PR]:
+; DIS64:      0000000000000040 (idx: [[#NFA+13]]) .bar[PR]:
 ; DIS64-NEXT:       40: 7c 08 02 a6  	mflr 0
 ; DIS64-NEXT:       44: f8 21 ff 91  	stdu 1, -112(1)
 ; DIS64-NEXT:       48: f8 01 00 80  	std 0, 128(1)
 ; DIS64-NEXT:       4c: 4b ff ff b5  	bl 0x0 <.foo>
-; DIS64-NEXT: 		000000000000004c:  R_RBR	(idx: [[#NFA+5]]) .foo[PR]
+; DIS64-NEXT: 		000000000000004c:  R_RBR	(idx: [[#NFA+7]]) .foo[PR]
 ; DIS64-NEXT:       50: 60 00 00 00  	nop
 ; DIS64-NEXT:       54: 48 00 00 6d  	bl 0xc0 <.static_overalign_foo>
-; DIS64-NEXT: 		0000000000000054:  R_RBR	(idx: [[#NFA+13]]) .static_overalign_foo[PR]
+; DIS64-NEXT: 		0000000000000054:  R_RBR	(idx: [[#NFA+15]]) .static_overalign_foo[PR]
 ; DIS64-NEXT:       58: 60 00 00 00  	nop
 ; DIS64-NEXT:       5c: 4b ff ff a5  	bl 0x0 <.alias_foo>
-; DIS64-NEXT: 		000000000000005c:  R_RBR	(idx: [[#NFA+7]]) .alias_foo
+; DIS64-NEXT: 		000000000000005c:  R_RBR	(idx: [[#NFA+9]]) .alias_foo
 ; DIS64-NEXT:       60: 60 00 00 00  	nop
 ; DIS64-NEXT:       64: 4b ff ff 9d  	bl 0x0 <.extern_foo>
 ; DIS64-NEXT: 		0000000000000064:  R_RBR	(idx: [[#NFA+1]]) .extern_foo[PR]
 ; DIS64-NEXT:       68: 60 00 00 00  	nop
 ; DIS64-NEXT:       6c: 4b ff ff b5  	bl 0x20 <.hidden_foo>
-; DIS64-NEXT: 		000000000000006c:  R_RBR	(idx: [[#NFA+9]]) .hidden_foo[PR]
-; DIS64:      00000000000000c0 (idx: [[#NFA+13]]) .static_overalign_foo[PR]:
+; DIS64-NEXT: 		000000000000006c:  R_RBR	(idx: [[#NFA+11]]) .hidden_foo[PR]
+; DIS64:      00000000000000c0 (idx: [[#NFA+15]]) .static_overalign_foo[PR]:

--- a/llvm/test/CodeGen/PowerPC/aix-xcoff-funcsect.ll
+++ b/llvm/test/CodeGen/PowerPC/aix-xcoff-funcsect.ll
@@ -108,122 +108,119 @@ entry:
 ; ASM-NEXT:  # %bb.0:                                # %entry
 ; ASM-NEXT:  	blr
 ; ASM:        .extern	.extern_foo
-; ASM-NEXT:  	.extern	extern_foo[DS]
 ; ASM-NEXT:  	.globl	alias_foo
 ; ASM-NEXT:  	.globl	.alias_foo
 
 ; XCOFF32:      SYMBOL TABLE:
 ; XCOFF32-NEXT: 00000000      df *DEBUG*	00000000 (idx: 0) .file
 ; XCOFF32-NEXT: 00000000         *UND*	00000000 (idx: [[#NFA+1]]) .extern_foo[PR]
-; XCOFF32-NEXT: 00000000         *UND*	00000000 (idx: [[#NFA+3]]) extern_foo[DS]
-; XCOFF32-NEXT: 00000000 l       .text	00000000 (idx: [[#NFA+5]]) [PR]
-; XCOFF32-NEXT: 00000000 g       .text	00000019 (idx: [[#NFA+7]]) .foo[PR]
-; XCOFF32-NEXT: 00000000 g     F .text (csect: (idx: [[#NFA+7]]) .foo[PR]) 	00000000 (idx: [[#NFA+9]]) .alias_foo
-; XCOFF32-NEXT: 00000020 g     F .text	00000020 .hidden (idx: [[#NFA+11]]) .hidden_foo[PR]
-; XCOFF32-NEXT: 00000040 g     F .text	00000059 (idx: [[#NFA+13]]) .bar[PR]
-; XCOFF32-NEXT: 000000c0 l     F .text	0000002a (idx: [[#NFA+15]]) .static_overalign_foo[PR]
-; XCOFF32-NEXT: 000000ec g     O .data	0000000c (idx: [[#NFA+17]]) foo[DS]
-; XCOFF32-NEXT: 000000ec g     O .data (csect: (idx: [[#NFA+17]]) foo[DS]) 	00000000 (idx: [[#NFA+19]]) alias_foo
-; XCOFF32-NEXT: 000000f8 g     O .data	0000000c .hidden (idx: [[#NFA+21]]) hidden_foo[DS]
-; XCOFF32-NEXT: 00000104 g     O .data	0000000c (idx: [[#NFA+23]]) bar[DS]
-; XCOFF32-NEXT: 00000110 l     O .data	0000000c (idx: [[#NFA+25]]) static_overalign_foo[DS]
-; XCOFF32-NEXT: 0000011c l       .data	00000000 (idx: [[#NFA+27]]) TOC[TC0]
+; XCOFF32-NEXT: 00000000 l       .text	00000000 (idx: [[#NFA+3]]) [PR]
+; XCOFF32-NEXT: 00000000 g       .text	00000019 (idx: [[#NFA+5]]) .foo[PR]
+; XCOFF32-NEXT: 00000000 g     F .text (csect: (idx: [[#NFA+5]]) .foo[PR]) 	00000000 (idx: [[#NFA+7]]) .alias_foo
+; XCOFF32-NEXT: 00000020 g     F .text	00000020 .hidden (idx: [[#NFA+9]]) .hidden_foo[PR]
+; XCOFF32-NEXT: 00000040 g     F .text	00000059 (idx: [[#NFA+11]]) .bar[PR]
+; XCOFF32-NEXT: 000000c0 l     F .text	0000002a (idx: [[#NFA+13]]) .static_overalign_foo[PR]
+; XCOFF32-NEXT: 000000ec g     O .data	0000000c (idx: [[#NFA+15]]) foo[DS]
+; XCOFF32-NEXT: 000000ec g     O .data (csect: (idx: [[#NFA+15]]) foo[DS]) 	00000000 (idx: [[#NFA+17]]) alias_foo
+; XCOFF32-NEXT: 000000f8 g     O .data	0000000c .hidden (idx: [[#NFA+19]]) hidden_foo[DS]
+; XCOFF32-NEXT: 00000104 g     O .data	0000000c (idx: [[#NFA+21]]) bar[DS]
+; XCOFF32-NEXT: 00000110 l     O .data	0000000c (idx: [[#NFA+23]]) static_overalign_foo[DS]
+; XCOFF32-NEXT: 0000011c l       .data	00000000 (idx: [[#NFA+25]]) TOC[TC0]
 
 ; XCOFF32:      RELOCATION RECORDS FOR [.text]:
 ; XCOFF32-NEXT: OFFSET   TYPE                     VALUE
-; XCOFF32-NEXT: 0000004c R_RBR                    (idx: [[#NFA+7]]) .foo[PR]
-; XCOFF32-NEXT: 00000054 R_RBR                    (idx: [[#NFA+15]]) .static_overalign_foo[PR]
-; XCOFF32-NEXT: 0000005c R_RBR                    (idx: [[#NFA+9]]) .alias_foo
+; XCOFF32-NEXT: 0000004c R_RBR                    (idx: [[#NFA+5]]) .foo[PR]
+; XCOFF32-NEXT: 00000054 R_RBR                    (idx: [[#NFA+13]]) .static_overalign_foo[PR]
+; XCOFF32-NEXT: 0000005c R_RBR                    (idx: [[#NFA+7]]) .alias_foo
 ; XCOFF32-NEXT: 00000064 R_RBR                    (idx: [[#NFA+1]]) .extern_foo[PR]
-; XCOFF32-NEXT: 0000006c R_RBR                    (idx: [[#NFA+11]]) .hidden_foo[PR]
+; XCOFF32-NEXT: 0000006c R_RBR                    (idx: [[#NFA+9]]) .hidden_foo[PR]
 ; XCOFF32:      RELOCATION RECORDS FOR [.data]:
 ; XCOFF32-NEXT: OFFSET   TYPE                     VALUE
-; XCOFF32-NEXT: 00000000 R_POS                    (idx: [[#NFA+7]]) .foo[PR]
-; XCOFF32-NEXT: 00000004 R_POS                    (idx: [[#NFA+27]]) TOC[TC0]
-; XCOFF32-NEXT: 0000000c R_POS                    (idx: [[#NFA+11]]) .hidden_foo[PR]
-; XCOFF32-NEXT: 00000010 R_POS                    (idx: [[#NFA+27]]) TOC[TC0]
-; XCOFF32-NEXT: 00000018 R_POS                    (idx: [[#NFA+13]]) .bar[PR]
-; XCOFF32-NEXT: 0000001c R_POS                    (idx: [[#NFA+27]]) TOC[TC0]
-; XCOFF32-NEXT: 00000024 R_POS                    (idx: [[#NFA+15]]) .static_overalign_foo[PR]
-; XCOFF32-NEXT: 00000028 R_POS                    (idx: [[#NFA+27]]) TOC[TC0]
+; XCOFF32-NEXT: 00000000 R_POS                    (idx: [[#NFA+5]]) .foo[PR]
+; XCOFF32-NEXT: 00000004 R_POS                    (idx: [[#NFA+25]]) TOC[TC0]
+; XCOFF32-NEXT: 0000000c R_POS                    (idx: [[#NFA+9]]) .hidden_foo[PR]
+; XCOFF32-NEXT: 00000010 R_POS                    (idx: [[#NFA+25]]) TOC[TC0]
+; XCOFF32-NEXT: 00000018 R_POS                    (idx: [[#NFA+11]]) .bar[PR]
+; XCOFF32-NEXT: 0000001c R_POS                    (idx: [[#NFA+25]]) TOC[TC0]
+; XCOFF32-NEXT: 00000024 R_POS                    (idx: [[#NFA+13]]) .static_overalign_foo[PR]
+; XCOFF32-NEXT: 00000028 R_POS                    (idx: [[#NFA+25]]) TOC[TC0]
 
 ; XCOFF64:      SYMBOL TABLE:
 ; XCOFF64-NEXT: 0000000000000000      df *DEBUG*	0000000000000000 (idx: 0) .file
 ; XCOFF64-NEXT: 0000000000000000         *UND*	0000000000000000 (idx: [[#NFA+1]]) .extern_foo[PR]
-; XCOFF64-NEXT: 0000000000000000         *UND*	0000000000000000 (idx: [[#NFA+3]]) extern_foo[DS]
-; XCOFF64-NEXT: 0000000000000000 l       .text	0000000000000000 (idx: [[#NFA+5]]) [PR]
-; XCOFF64-NEXT: 0000000000000000 g       .text	0000000000000019 (idx: [[#NFA+7]]) .foo[PR]
-; XCOFF64-NEXT: 0000000000000000 g     F .text (csect: (idx: [[#NFA+7]]) .foo[PR]) 	0000000000000000 (idx: [[#NFA+9]]) .alias_foo
-; XCOFF64-NEXT: 0000000000000020 g     F .text	0000000000000020 .hidden (idx: [[#NFA+11]]) .hidden_foo[PR]
-; XCOFF64-NEXT: 0000000000000040 g     F .text	0000000000000059 (idx: [[#NFA+13]]) .bar[PR]
-; XCOFF64-NEXT: 00000000000000c0 l     F .text	000000000000002a (idx: [[#NFA+15]]) .static_overalign_foo[PR]
-; XCOFF64-NEXT: 00000000000000f0 g     O .data	0000000000000018 (idx: [[#NFA+17]]) foo[DS]
-; XCOFF64-NEXT: 00000000000000f0 g     O .data (csect: (idx: [[#NFA+17]]) foo[DS]) 	0000000000000000 (idx: [[#NFA+19]]) alias_foo
-; XCOFF64-NEXT: 0000000000000108 g     O .data	0000000000000018 .hidden (idx: [[#NFA+21]]) hidden_foo[DS]
-; XCOFF64-NEXT: 0000000000000120 g     O .data	0000000000000018 (idx: [[#NFA+23]]) bar[DS]
-; XCOFF64-NEXT: 0000000000000138 l     O .data	0000000000000018 (idx: [[#NFA+25]]) static_overalign_foo[DS]
-; XCOFF64-NEXT: 0000000000000150 l       .data	0000000000000000 (idx: [[#NFA+27]]) TOC[TC0]
+; XCOFF64-NEXT: 0000000000000000 l       .text	0000000000000000 (idx: [[#NFA+3]]) [PR]
+; XCOFF64-NEXT: 0000000000000000 g       .text	0000000000000019 (idx: [[#NFA+5]]) .foo[PR]
+; XCOFF64-NEXT: 0000000000000000 g     F .text (csect: (idx: [[#NFA+5]]) .foo[PR]) 	0000000000000000 (idx: [[#NFA+7]]) .alias_foo
+; XCOFF64-NEXT: 0000000000000020 g     F .text	0000000000000020 .hidden (idx: [[#NFA+9]]) .hidden_foo[PR]
+; XCOFF64-NEXT: 0000000000000040 g     F .text	0000000000000059 (idx: [[#NFA+11]]) .bar[PR]
+; XCOFF64-NEXT: 00000000000000c0 l     F .text	000000000000002a (idx: [[#NFA+13]]) .static_overalign_foo[PR]
+; XCOFF64-NEXT: 00000000000000f0 g     O .data	0000000000000018 (idx: [[#NFA+15]]) foo[DS]
+; XCOFF64-NEXT: 00000000000000f0 g     O .data (csect: (idx: [[#NFA+15]]) foo[DS]) 	0000000000000000 (idx: [[#NFA+17]]) alias_foo
+; XCOFF64-NEXT: 0000000000000108 g     O .data	0000000000000018 .hidden (idx: [[#NFA+19]]) hidden_foo[DS]
+; XCOFF64-NEXT: 0000000000000120 g     O .data	0000000000000018 (idx: [[#NFA+21]]) bar[DS]
+; XCOFF64-NEXT: 0000000000000138 l     O .data	0000000000000018 (idx: [[#NFA+23]]) static_overalign_foo[DS]
+; XCOFF64-NEXT: 0000000000000150 l       .data	0000000000000000 (idx: [[#NFA+25]]) TOC[TC0]
 
 ; XCOFF64:      RELOCATION RECORDS FOR [.text]:
 ; XCOFF64-NEXT: OFFSET           TYPE                     VALUE
-; XCOFF64-NEXT: 000000000000004c R_RBR                    (idx: [[#NFA+7]]) .foo[PR]
-; XCOFF64-NEXT: 0000000000000054 R_RBR                    (idx: [[#NFA+15]]) .static_overalign_foo[PR]
-; XCOFF64-NEXT: 000000000000005c R_RBR                    (idx: [[#NFA+9]]) .alias_foo
+; XCOFF64-NEXT: 000000000000004c R_RBR                    (idx: [[#NFA+5]]) .foo[PR]
+; XCOFF64-NEXT: 0000000000000054 R_RBR                    (idx: [[#NFA+13]]) .static_overalign_foo[PR]
+; XCOFF64-NEXT: 000000000000005c R_RBR                    (idx: [[#NFA+7]]) .alias_foo
 ; XCOFF64-NEXT: 0000000000000064 R_RBR                    (idx: [[#NFA+1]]) .extern_foo[PR]
-; XCOFF64-NEXT: 000000000000006c R_RBR                    (idx: [[#NFA+11]]) .hidden_foo[PR]
+; XCOFF64-NEXT: 000000000000006c R_RBR                    (idx: [[#NFA+9]]) .hidden_foo[PR]
 ; XCOFF64:      RELOCATION RECORDS FOR [.data]:
 ; XCOFF64-NEXT: OFFSET           TYPE                     VALUE
-; XCOFF64-NEXT: 0000000000000000 R_POS                    (idx: [[#NFA+7]]) .foo[PR]
-; XCOFF64-NEXT: 0000000000000008 R_POS                    (idx: [[#NFA+27]]) TOC[TC0]
-; XCOFF64-NEXT: 0000000000000018 R_POS                    (idx: [[#NFA+11]]) .hidden_foo[PR]
-; XCOFF64-NEXT: 0000000000000020 R_POS                    (idx: [[#NFA+27]]) TOC[TC0]
-; XCOFF64-NEXT: 0000000000000030 R_POS                    (idx: [[#NFA+13]]) .bar[PR]
-; XCOFF64-NEXT: 0000000000000038 R_POS                    (idx: [[#NFA+27]]) TOC[TC0]
-; XCOFF64-NEXT: 0000000000000048 R_POS                    (idx: [[#NFA+15]]) .static_overalign_foo[PR]
-; XCOFF64-NEXT: 0000000000000050 R_POS                    (idx: [[#NFA+27]]) TOC[TC0]
+; XCOFF64-NEXT: 0000000000000000 R_POS                    (idx: [[#NFA+5]]) .foo[PR]
+; XCOFF64-NEXT: 0000000000000008 R_POS                    (idx: [[#NFA+25]]) TOC[TC0]
+; XCOFF64-NEXT: 0000000000000018 R_POS                    (idx: [[#NFA+9]]) .hidden_foo[PR]
+; XCOFF64-NEXT: 0000000000000020 R_POS                    (idx: [[#NFA+25]]) TOC[TC0]
+; XCOFF64-NEXT: 0000000000000030 R_POS                    (idx: [[#NFA+11]]) .bar[PR]
+; XCOFF64-NEXT: 0000000000000038 R_POS                    (idx: [[#NFA+25]]) TOC[TC0]
+; XCOFF64-NEXT: 0000000000000048 R_POS                    (idx: [[#NFA+13]]) .static_overalign_foo[PR]
+; XCOFF64-NEXT: 0000000000000050 R_POS                    (idx: [[#NFA+25]]) TOC[TC0]
 
 ; DIS32:      Disassembly of section .text:
-; DIS32:      00000000 (idx: [[#NFA+9]]) .alias_foo:
-; DIS32:      00000020 (idx: [[#NFA+11]]) .hidden_foo[PR]:
-; DIS32:      00000040 (idx: [[#NFA+13]]) .bar[PR]:
+; DIS32:      00000000 (idx: [[#NFA+7]]) .alias_foo:
+; DIS32:      00000020 (idx: [[#NFA+9]]) .hidden_foo[PR]:
+; DIS32:      00000040 (idx: [[#NFA+11]]) .bar[PR]:
 ; DIS32-NEXT:       40: 7c 08 02 a6  	mflr 0
 ; DIS32-NEXT:       44: 94 21 ff c0  	stwu 1, -64(1)
 ; DIS32-NEXT:       48: 90 01 00 48  	stw 0, 72(1)
 ; DIS32-NEXT:       4c: 4b ff ff b5  	bl 0x0 <.foo>
-; DIS32-NEXT: 			0000004c:  R_RBR	(idx: [[#NFA+7]]) .foo[PR]
+; DIS32-NEXT: 			0000004c:  R_RBR	(idx: [[#NFA+5]]) .foo[PR]
 ; DIS32-NEXT:       50: 60 00 00 00  	nop
 ; DIS32-NEXT:       54: 48 00 00 6d  	bl 0xc0 <.static_overalign_foo>
-; DIS32-NEXT: 			00000054:  R_RBR	(idx: [[#NFA+15]]) .static_overalign_foo[PR]
+; DIS32-NEXT: 			00000054:  R_RBR	(idx: [[#NFA+13]]) .static_overalign_foo[PR]
 ; DIS32-NEXT:       58: 60 00 00 00  	nop
 ; DIS32-NEXT:       5c: 4b ff ff a5  	bl 0x0 <.alias_foo>
-; DIS32-NEXT: 			0000005c:  R_RBR	(idx: [[#NFA+9]]) .alias_foo
+; DIS32-NEXT: 			0000005c:  R_RBR	(idx: [[#NFA+7]]) .alias_foo
 ; DIS32-NEXT:       60: 60 00 00 00  	nop
 ; DIS32-NEXT:       64: 4b ff ff 9d  	bl 0x0 <.extern_foo>
 ; DIS32-NEXT: 			00000064:  R_RBR	(idx: [[#NFA+1]]) .extern_foo[PR]
 ; DIS32-NEXT:       68: 60 00 00 00  	nop
 ; DIS32-NEXT:       6c: 4b ff ff b5  	bl 0x20 <.hidden_foo>
-; DIS32-NEXT: 			0000006c:  R_RBR	(idx: [[#NFA+11]]) .hidden_foo[PR]
-; DIS32:      000000c0 (idx: [[#NFA+15]]) .static_overalign_foo[PR]:
+; DIS32-NEXT: 			0000006c:  R_RBR	(idx: [[#NFA+9]]) .hidden_foo[PR]
+; DIS32:      000000c0 (idx: [[#NFA+13]]) .static_overalign_foo[PR]:
 
 ; DIS64:      Disassembly of section .text:
-; DIS64:      0000000000000000 (idx: [[#NFA+9]]) .alias_foo:
-; DIS64:      0000000000000020 (idx: [[#NFA+11]]) .hidden_foo[PR]:
-; DIS64:      0000000000000040 (idx: [[#NFA+13]]) .bar[PR]:
+; DIS64:      0000000000000000 (idx: [[#NFA+7]]) .alias_foo:
+; DIS64:      0000000000000020 (idx: [[#NFA+9]]) .hidden_foo[PR]:
+; DIS64:      0000000000000040 (idx: [[#NFA+11]]) .bar[PR]:
 ; DIS64-NEXT:       40: 7c 08 02 a6  	mflr 0
 ; DIS64-NEXT:       44: f8 21 ff 91  	stdu 1, -112(1)
 ; DIS64-NEXT:       48: f8 01 00 80  	std 0, 128(1)
 ; DIS64-NEXT:       4c: 4b ff ff b5  	bl 0x0 <.foo>
-; DIS64-NEXT: 		000000000000004c:  R_RBR	(idx: [[#NFA+7]]) .foo[PR]
+; DIS64-NEXT: 		000000000000004c:  R_RBR	(idx: [[#NFA+5]]) .foo[PR]
 ; DIS64-NEXT:       50: 60 00 00 00  	nop
 ; DIS64-NEXT:       54: 48 00 00 6d  	bl 0xc0 <.static_overalign_foo>
-; DIS64-NEXT: 		0000000000000054:  R_RBR	(idx: [[#NFA+15]]) .static_overalign_foo[PR]
+; DIS64-NEXT: 		0000000000000054:  R_RBR	(idx: [[#NFA+13]]) .static_overalign_foo[PR]
 ; DIS64-NEXT:       58: 60 00 00 00  	nop
 ; DIS64-NEXT:       5c: 4b ff ff a5  	bl 0x0 <.alias_foo>
-; DIS64-NEXT: 		000000000000005c:  R_RBR	(idx: [[#NFA+9]]) .alias_foo
+; DIS64-NEXT: 		000000000000005c:  R_RBR	(idx: [[#NFA+7]]) .alias_foo
 ; DIS64-NEXT:       60: 60 00 00 00  	nop
 ; DIS64-NEXT:       64: 4b ff ff 9d  	bl 0x0 <.extern_foo>
 ; DIS64-NEXT: 		0000000000000064:  R_RBR	(idx: [[#NFA+1]]) .extern_foo[PR]
 ; DIS64-NEXT:       68: 60 00 00 00  	nop
 ; DIS64-NEXT:       6c: 4b ff ff b5  	bl 0x20 <.hidden_foo>
-; DIS64-NEXT: 		000000000000006c:  R_RBR	(idx: [[#NFA+11]]) .hidden_foo[PR]
-; DIS64:      00000000000000c0 (idx: [[#NFA+15]]) .static_overalign_foo[PR]:
+; DIS64-NEXT: 		000000000000006c:  R_RBR	(idx: [[#NFA+9]]) .hidden_foo[PR]
+; DIS64:      00000000000000c0 (idx: [[#NFA+13]]) .static_overalign_foo[PR]:

--- a/llvm/test/CodeGen/PowerPC/aix-xcoff-reloc.ll
+++ b/llvm/test/CodeGen/PowerPC/aix-xcoff-reloc.ll
@@ -38,7 +38,7 @@ declare i32 @bar(i32)
 ; OBJ-NEXT:     TimeStamp: None (0x0)
 ; OBJ32-NEXT:   SymbolTableOffset: 0x13C
 ; OBJ64-NEXT:   SymbolTableOffset: 0x1B8
-; OBJ-NEXT:     SymbolTableEntries: [[#NFA+27]]
+; OBJ-NEXT:     SymbolTableEntries: [[#NFA+25]]
 ; OBJ-NEXT:     OptionalHeaderSize: 0x0
 ; OBJ-NEXT:     Flags: 0x0
 ; OBJ-NEXT:   }
@@ -88,7 +88,7 @@ declare i32 @bar(i32)
 ; RELOC-NEXT:     }
 ; RELOC-NEXT:     Relocation {
 ; RELOC-NEXT:       Virtual Address: 0x1A
-; RELOC-NEXT:       Symbol: globalA ([[#NFA+23]])
+; RELOC-NEXT:       Symbol: globalA ([[#NFA+21]])
 ; RELOC-NEXT:       IsSigned: No
 ; RELOC-NEXT:       FixupBitValue: 0
 ; RELOC-NEXT:       Length: 16
@@ -96,7 +96,7 @@ declare i32 @bar(i32)
 ; RELOC-NEXT:     }
 ; RELOC-NEXT:     Relocation {
 ; RELOC-NEXT:       Virtual Address: 0x1E
-; RELOC-NEXT:       Symbol: globalB ([[#NFA+25]])
+; RELOC-NEXT:       Symbol: globalB ([[#NFA+23]])
 ; RELOC-NEXT:       IsSigned: No
 ; RELOC-NEXT:       FixupBitValue: 0
 ; RELOC-NEXT:       Length: 16
@@ -106,7 +106,7 @@ declare i32 @bar(i32)
 ; RELOC-NEXT:   Section (index: 2) .data {
 ; RELOC-NEXT:     Relocation {
 ; RELOC-NEXT:       Virtual Address: 0x70
-; RELOC-NEXT:       Symbol: arr ([[#NFA+15]])
+; RELOC-NEXT:       Symbol: arr ([[#NFA+13]])
 ; RELOC-NEXT:       IsSigned: No
 ; RELOC-NEXT:       FixupBitValue: 0
 ; RELOC32-NEXT:     Length: 32
@@ -116,7 +116,7 @@ declare i32 @bar(i32)
 ; RELOC-NEXT:     Relocation {
 ; RELOC32-NEXT:     Virtual Address: 0x74
 ; RELOC64-NEXT:     Virtual Address: 0x78
-; RELOC-NEXT:       Symbol: .foo ([[#NFA+7]])
+; RELOC-NEXT:       Symbol: .foo ([[#NFA+5]])
 ; RELOC-NEXT:       IsSigned: No
 ; RELOC-NEXT:       FixupBitValue: 0
 ; RELOC32-NEXT:     Length: 32
@@ -126,7 +126,7 @@ declare i32 @bar(i32)
 ; RELOC-NEXT:     Relocation {
 ; RELOC32-NEXT:     Virtual Address: 0x78
 ; RELOC64-NEXT:     Virtual Address: 0x80
-; RELOC-NEXT:       Symbol: TOC ([[#NFA+21]])
+; RELOC-NEXT:       Symbol: TOC ([[#NFA+19]])
 ; RELOC-NEXT:       IsSigned: No
 ; RELOC-NEXT:       FixupBitValue: 0
 ; RELOC32-NEXT:     Length: 32
@@ -136,7 +136,7 @@ declare i32 @bar(i32)
 ; RELOC-NEXT:     Relocation {
 ; RELOC32-NEXT:     Virtual Address: 0x80
 ; RELOC64-NEXT:     Virtual Address: 0x90
-; RELOC-NEXT:       Symbol: globalA ([[#NFA+11]])
+; RELOC-NEXT:       Symbol: globalA ([[#NFA+9]])
 ; RELOC-NEXT:       IsSigned: No
 ; RELOC-NEXT:       FixupBitValue: 0
 ; RELOC32-NEXT:     Length: 32
@@ -146,7 +146,7 @@ declare i32 @bar(i32)
 ; RELOC-NEXT:     Relocation {
 ; RELOC32-NEXT:     Virtual Address: 0x84
 ; RELOC64-NEXT:     Virtual Address: 0x98
-; RELOC-NEXT:       Symbol: globalB ([[#NFA+13]])
+; RELOC-NEXT:       Symbol: globalB ([[#NFA+11]])
 ; RELOC-NEXT:       IsSigned: No
 ; RELOC-NEXT:       FixupBitValue: 0
 ; RELOC32-NEXT:     Length: 32
@@ -203,27 +203,6 @@ declare i32 @bar(i32)
 ; SYM-NEXT:   }
 ; SYM-NEXT:   Symbol {
 ; SYM-NEXT:     Index: [[#INDX+2]]
-; SYM-NEXT:     Name: bar
-; SYM-NEXT:     Value (RelocatableAddress): 0x0
-; SYM-NEXT:     Section: N_UNDEF
-; SYM-NEXT:     Type: 0x0
-; SYM-NEXT:     StorageClass: C_EXT (0x2)
-; SYM-NEXT:     NumberOfAuxEntries: 1
-; SYM-NEXT:     CSECT Auxiliary Entry {
-; SYM-NEXT:       Index: [[#INDX+3]]
-; SYM-NEXT:       SectionLen: 0
-; SYM-NEXT:       ParameterHashIndex: 0x0
-; SYM-NEXT:       TypeChkSectNum: 0x0
-; SYM-NEXT:       SymbolAlignmentLog2: 0
-; SYM-NEXT:       SymbolType: XTY_ER (0x0)
-; SYM-NEXT:       StorageMappingClass: XMC_DS (0xA)
-; SYM32-NEXT:     StabInfoIndex: 0x0
-; SYM32-NEXT:     StabSectNum: 0x0
-; SYM64-NEXT:     Auxiliary Type: AUX_CSECT (0xFB)
-; SYM-NEXT:     }
-; SYM-NEXT:   }
-; SYM-NEXT:   Symbol {
-; SYM-NEXT:     Index: [[#INDX+4]]
 ; SYM-NEXT:     Name:
 ; SYM-NEXT:     Value (RelocatableAddress): 0x0
 ; SYM-NEXT:     Section: .text
@@ -231,7 +210,7 @@ declare i32 @bar(i32)
 ; SYM-NEXT:     StorageClass: C_HIDEXT (0x6B)
 ; SYM-NEXT:     NumberOfAuxEntries: 1
 ; SYM-NEXT:     CSECT Auxiliary Entry {
-; SYM-NEXT:       Index: [[#INDX+5]]
+; SYM-NEXT:       Index: [[#INDX+3]]
 ; SYM-NEXT:       SectionLen: 64
 ; SYM-NEXT:       ParameterHashIndex: 0x0
 ; SYM-NEXT:       TypeChkSectNum: 0x0
@@ -244,7 +223,7 @@ declare i32 @bar(i32)
 ; SYM-NEXT:     }
 ; SYM-NEXT:   }
 ; SYM-NEXT:   Symbol {
-; SYM-NEXT:     Index: [[#INDX+6]]
+; SYM-NEXT:     Index: [[#INDX+4]]
 ; SYM-NEXT:     Name: .foo
 ; SYM-NEXT:     Value (RelocatableAddress): 0x0
 ; SYM-NEXT:     Section: .text
@@ -252,8 +231,8 @@ declare i32 @bar(i32)
 ; SYM-NEXT:     StorageClass: C_EXT (0x2)
 ; SYM-NEXT:     NumberOfAuxEntries: 1
 ; SYM-NEXT:     CSECT Auxiliary Entry {
-; SYM-NEXT:       Index: [[#INDX+7]]
-; SYM-NEXT:       ContainingCsectSymbolIndex: [[#INDX+4]]
+; SYM-NEXT:       Index: [[#INDX+5]]
+; SYM-NEXT:       ContainingCsectSymbolIndex: [[#INDX+2]]
 ; SYM-NEXT:       ParameterHashIndex: 0x0
 ; SYM-NEXT:       TypeChkSectNum: 0x0
 ; SYM-NEXT:       SymbolAlignmentLog2: 0
@@ -265,7 +244,7 @@ declare i32 @bar(i32)
 ; SYM-NEXT:     }
 ; SYM-NEXT:   }
 ; SYM-NEXT:   Symbol {
-; SYM-NEXT:     Index: [[#INDX+8]]
+; SYM-NEXT:     Index: [[#INDX+6]]
 ; SYM-NEXT:     Name: .data
 ; SYM-NEXT:     Value (RelocatableAddress): 0x40
 ; SYM-NEXT:     Section: .data
@@ -273,7 +252,7 @@ declare i32 @bar(i32)
 ; SYM-NEXT:     StorageClass: C_HIDEXT (0x6B)
 ; SYM-NEXT:     NumberOfAuxEntries: 1
 ; SYM-NEXT:     CSECT Auxiliary Entry {
-; SYM-NEXT:       Index: [[#INDX+9]]
+; SYM-NEXT:       Index: [[#INDX+7]]
 ; SYM32-NEXT:     SectionLen: 52
 ; SYM64-NEXT:     SectionLen: 56
 ; SYM-NEXT:       ParameterHashIndex: 0x0
@@ -288,7 +267,7 @@ declare i32 @bar(i32)
 ; SYM-NEXT:     }
 ; SYM-NEXT:   }
 ; SYM-NEXT:   Symbol {
-; SYM-NEXT:     Index: [[#INDX+10]]
+; SYM-NEXT:     Index: [[#INDX+8]]
 ; SYM-NEXT:     Name: globalA
 ; SYM-NEXT:     Value (RelocatableAddress): 0x40
 ; SYM-NEXT:     Section: .data
@@ -296,8 +275,29 @@ declare i32 @bar(i32)
 ; SYM-NEXT:     StorageClass: C_EXT (0x2)
 ; SYM-NEXT:     NumberOfAuxEntries: 1
 ; SYM-NEXT:     CSECT Auxiliary Entry {
+; SYM-NEXT:       Index: [[#INDX+9]]
+; SYM-NEXT:       ContainingCsectSymbolIndex: [[#INDX+6]]
+; SYM-NEXT:       ParameterHashIndex: 0x0
+; SYM-NEXT:       TypeChkSectNum: 0x0
+; SYM-NEXT:       SymbolAlignmentLog2: 0
+; SYM-NEXT:       SymbolType: XTY_LD (0x2)
+; SYM-NEXT:       StorageMappingClass: XMC_RW (0x5)
+; SYM32-NEXT:     StabInfoIndex: 0x0
+; SYM32-NEXT:     StabSectNum: 0x0
+; SYM64-NEXT:     Auxiliary Type: AUX_CSECT (0xFB)
+; SYM-NEXT:     }
+; SYM-NEXT:   }
+; SYM-NEXT:   Symbol {
+; SYM-NEXT:     Index: [[#INDX+10]]
+; SYM-NEXT:     Name: globalB
+; SYM-NEXT:     Value (RelocatableAddress): 0x44
+; SYM-NEXT:     Section: .data
+; SYM-NEXT:     Type: 0x0
+; SYM-NEXT:     StorageClass: C_EXT (0x2)
+; SYM-NEXT:     NumberOfAuxEntries: 1
+; SYM-NEXT:     CSECT Auxiliary Entry {
 ; SYM-NEXT:       Index: [[#INDX+11]]
-; SYM-NEXT:       ContainingCsectSymbolIndex: [[#INDX+8]]
+; SYM-NEXT:       ContainingCsectSymbolIndex: [[#INDX+6]]
 ; SYM-NEXT:       ParameterHashIndex: 0x0
 ; SYM-NEXT:       TypeChkSectNum: 0x0
 ; SYM-NEXT:       SymbolAlignmentLog2: 0
@@ -310,15 +310,15 @@ declare i32 @bar(i32)
 ; SYM-NEXT:   }
 ; SYM-NEXT:   Symbol {
 ; SYM-NEXT:     Index: [[#INDX+12]]
-; SYM-NEXT:     Name: globalB
-; SYM-NEXT:     Value (RelocatableAddress): 0x44
+; SYM-NEXT:     Name: arr
+; SYM-NEXT:     Value (RelocatableAddress): 0x48
 ; SYM-NEXT:     Section: .data
 ; SYM-NEXT:     Type: 0x0
 ; SYM-NEXT:     StorageClass: C_EXT (0x2)
 ; SYM-NEXT:     NumberOfAuxEntries: 1
 ; SYM-NEXT:     CSECT Auxiliary Entry {
 ; SYM-NEXT:       Index: [[#INDX+13]]
-; SYM-NEXT:       ContainingCsectSymbolIndex: [[#INDX+8]]
+; SYM-NEXT:       ContainingCsectSymbolIndex: [[#INDX+6]]
 ; SYM-NEXT:       ParameterHashIndex: 0x0
 ; SYM-NEXT:       TypeChkSectNum: 0x0
 ; SYM-NEXT:       SymbolAlignmentLog2: 0
@@ -331,15 +331,15 @@ declare i32 @bar(i32)
 ; SYM-NEXT:   }
 ; SYM-NEXT:   Symbol {
 ; SYM-NEXT:     Index: [[#INDX+14]]
-; SYM-NEXT:     Name: arr
-; SYM-NEXT:     Value (RelocatableAddress): 0x48
+; SYM-NEXT:     Name: p
+; SYM-NEXT:     Value (RelocatableAddress): 0x70
 ; SYM-NEXT:     Section: .data
 ; SYM-NEXT:     Type: 0x0
 ; SYM-NEXT:     StorageClass: C_EXT (0x2)
 ; SYM-NEXT:     NumberOfAuxEntries: 1
 ; SYM-NEXT:     CSECT Auxiliary Entry {
 ; SYM-NEXT:       Index: [[#INDX+15]]
-; SYM-NEXT:       ContainingCsectSymbolIndex: [[#INDX+8]]
+; SYM-NEXT:       ContainingCsectSymbolIndex: [[#INDX+6]]
 ; SYM-NEXT:       ParameterHashIndex: 0x0
 ; SYM-NEXT:       TypeChkSectNum: 0x0
 ; SYM-NEXT:       SymbolAlignmentLog2: 0
@@ -352,27 +352,6 @@ declare i32 @bar(i32)
 ; SYM-NEXT:   }
 ; SYM-NEXT:   Symbol {
 ; SYM-NEXT:     Index: [[#INDX+16]]
-; SYM-NEXT:     Name: p
-; SYM-NEXT:     Value (RelocatableAddress): 0x70
-; SYM-NEXT:     Section: .data
-; SYM-NEXT:     Type: 0x0
-; SYM-NEXT:     StorageClass: C_EXT (0x2)
-; SYM-NEXT:     NumberOfAuxEntries: 1
-; SYM-NEXT:     CSECT Auxiliary Entry {
-; SYM-NEXT:       Index: [[#INDX+17]]
-; SYM-NEXT:       ContainingCsectSymbolIndex: [[#INDX+8]]
-; SYM-NEXT:       ParameterHashIndex: 0x0
-; SYM-NEXT:       TypeChkSectNum: 0x0
-; SYM-NEXT:       SymbolAlignmentLog2: 0
-; SYM-NEXT:       SymbolType: XTY_LD (0x2)
-; SYM-NEXT:       StorageMappingClass: XMC_RW (0x5)
-; SYM32-NEXT:     StabInfoIndex: 0x0
-; SYM32-NEXT:     StabSectNum: 0x0
-; SYM64-NEXT:     Auxiliary Type: AUX_CSECT (0xFB)
-; SYM-NEXT:     }
-; SYM-NEXT:   }
-; SYM-NEXT:   Symbol {
-; SYM-NEXT:     Index: [[#INDX+18]]
 ; SYM-NEXT:     Name: foo
 ; SYM32-NEXT:   Value (RelocatableAddress): 0x74
 ; SYM64-NEXT:   Value (RelocatableAddress): 0x78
@@ -381,7 +360,7 @@ declare i32 @bar(i32)
 ; SYM-NEXT:     StorageClass: C_EXT (0x2)
 ; SYM-NEXT:     NumberOfAuxEntries: 1
 ; SYM-NEXT:     CSECT Auxiliary Entry {
-; SYM-NEXT:       Index: [[#INDX+19]]
+; SYM-NEXT:       Index: [[#INDX+17]]
 ; SYM32-NEXT:     SectionLen: 12
 ; SYM64-NEXT:     SectionLen: 24
 ; SYM-NEXT:       ParameterHashIndex: 0x0
@@ -396,7 +375,7 @@ declare i32 @bar(i32)
 ; SYM-NEXT:     }
 ; SYM-NEXT:   }
 ; SYM-NEXT:   Symbol {
-; SYM-NEXT:     Index: [[#INDX+20]]
+; SYM-NEXT:     Index: [[#INDX+18]]
 ; SYM-NEXT:     Name: TOC
 ; SYM32-NEXT:   Value (RelocatableAddress): 0x80
 ; SYM64-NEXT:   Value (RelocatableAddress): 0x90
@@ -405,7 +384,7 @@ declare i32 @bar(i32)
 ; SYM-NEXT:     StorageClass: C_HIDEXT (0x6B)
 ; SYM-NEXT:     NumberOfAuxEntries: 1
 ; SYM-NEXT:     CSECT Auxiliary Entry {
-; SYM-NEXT:       Index: [[#INDX+21]]
+; SYM-NEXT:       Index: [[#INDX+19]]
 ; SYM-NEXT:       SectionLen: 0
 ; SYM-NEXT:       ParameterHashIndex: 0x0
 ; SYM-NEXT:       TypeChkSectNum: 0x0
@@ -418,7 +397,7 @@ declare i32 @bar(i32)
 ; SYM-NEXT:     }
 ; SYM-NEXT:   }
 ; SYM-NEXT:   Symbol {
-; SYM-NEXT:     Index: [[#INDX+22]]
+; SYM-NEXT:     Index: [[#INDX+20]]
 ; SYM-NEXT:     Name: globalA
 ; SYM32-NEXT:   Value (RelocatableAddress): 0x80
 ; SYM64-NEXT:   Value (RelocatableAddress): 0x90
@@ -427,7 +406,7 @@ declare i32 @bar(i32)
 ; SYM-NEXT:     StorageClass: C_HIDEXT (0x6B)
 ; SYM-NEXT:     NumberOfAuxEntries: 1
 ; SYM-NEXT:     CSECT Auxiliary Entry {
-; SYM-NEXT:       Index: [[#INDX+23]]
+; SYM-NEXT:       Index: [[#INDX+21]]
 ; SYM32-NEXT:     SectionLen: 4
 ; SYM64-NEXT:     SectionLen: 8
 ; SYM-NEXT:       ParameterHashIndex: 0x0
@@ -442,7 +421,7 @@ declare i32 @bar(i32)
 ; SYM-NEXT:     }
 ; SYM-NEXT:   }
 ; SYM-NEXT:   Symbol {
-; SYM-NEXT:     Index: [[#INDX+24]]
+; SYM-NEXT:     Index: [[#INDX+22]]
 ; SYM-NEXT:     Name: globalB
 ; SYM32-NEXT:   Value (RelocatableAddress): 0x84
 ; SYM64-NEXT:   Value (RelocatableAddress): 0x98
@@ -451,7 +430,7 @@ declare i32 @bar(i32)
 ; SYM-NEXT:     StorageClass: C_HIDEXT (0x6B)
 ; SYM-NEXT:     NumberOfAuxEntries: 1
 ; SYM-NEXT:     CSECT Auxiliary Entry {
-; SYM-NEXT:       Index: [[#INDX+25]]
+; SYM-NEXT:       Index: [[#INDX+23]]
 ; SYM32-NEXT:     SectionLen: 4
 ; SYM64-NEXT:     SectionLen: 8
 ; SYM-NEXT:       ParameterHashIndex: 0x0

--- a/llvm/test/CodeGen/PowerPC/aix-xcoff-visibility.ll
+++ b/llvm/test/CodeGen/PowerPC/aix-xcoff-visibility.ll
@@ -79,11 +79,8 @@ declare dllexport i32 @bar_e(ptr)
 ; CHECK:        .weak   .zoo_weak_extern_h[PR],hidden
 ; CHECK:        .weak   zoo_weak_extern_h[DS],hidden
 ; CHECK:        .weak   .zoo_weak_extern_e[PR],exported
-; CHECK:        .weak   zoo_weak_extern_e[DS],exported
 ; CHECK:        .extern .bar_h[PR],hidden
-; CHECK:        .extern bar_h[DS],hidden
 ; CHECK:        .extern .bar_e[PR],exported
-; CHECK:        .extern bar_e[DS],exported
 
 ; AUX32:       AuxiliaryHeader {
 ; AUX32-NEXT:    Magic: 0x0
@@ -123,25 +120,7 @@ declare dllexport i32 @bar_e(ptr)
 ; SYM-NEXT:    Type: 0x4000
 ; SYM-NEXT:    StorageClass: C_WEAKEXT (0x6F)
 
-; SYM:         Name: zoo_weak_extern_e
-; SYM-NEXT:    Value (RelocatableAddress): 0x0
-; SYM-NEXT:    Section: N_UNDEF
-; SYM-NEXT:    Type: 0x4000
-; SYM-NEXT:    StorageClass: C_WEAKEXT (0x6F)
-
-; SYM:         Name: bar_h
-; SYM-NEXT:    Value (RelocatableAddress): 0x0
-; SYM-NEXT:    Section: N_UNDEF
-; SYM-NEXT:    Type: 0x2000
-; SYM-NEXT:    StorageClass: C_EXT (0x2)
-
 ; SYM:         Name: .bar_e
-; SYM-NEXT:    Value (RelocatableAddress): 0x0
-; SYM-NEXT:    Section: N_UNDEF
-; SYM-NEXT:    Type: 0x4000
-; SYM-NEXT:    StorageClass: C_EXT (0x2)
-
-; SYM:         Name: bar_e
 ; SYM-NEXT:    Value (RelocatableAddress): 0x0
 ; SYM-NEXT:    Section: N_UNDEF
 ; SYM-NEXT:    Type: 0x4000


### PR DESCRIPTION
For external symbols, the function descriptor may be omitted unless its address is taken.