### PR TITLE
 [libc] Add missing `prctl` header def

### DIFF
--- a/libc/spec/linux.td
+++ b/libc/spec/linux.td
@@ -112,7 +112,19 @@ def Linux : StandardSpec<"Linux"> {
       [], // Macros
       [], // Types
       [], // Enumerations
-      []  // Functions
+      [
+        FunctionSpec<
+        "prctl",
+          RetValSpec<IntType>,
+          [
+            ArgSpec<IntType>, 
+            ArgSpec<UnsignedLongType>, 
+            ArgSpec<UnsignedLongType>, 
+            ArgSpec<UnsignedLongType>, 
+            ArgSpec<UnsignedLongType>
+          ]
+      >
+      ]  // Functions
   >;
 
   HeaderSpec SysRandom = HeaderSpec<


### PR DESCRIPTION
Does what it says on the box.