### PR TITLE
[libc] Add `vsscanf` function

### DIFF
--- a/libc/spec/stdc.td
+++ b/libc/spec/stdc.td
@@ -968,6 +968,13 @@ def StdC : StandardSpec<"stdc"> {
               RetValSpec<IntType>,
               [ArgSpec<IntType>, ArgSpec<FILEPtr>]
           >,
+          FunctionSpec<
+              "vsscanf",
+              RetValSpec<IntType>,
+              [ArgSpec<ConstCharPtr>,
+               ArgSpec<ConstCharPtr>,
+               ArgSpec<VaListType>]
+          >,
       ],
       [
           ObjectSpec<

--- a/libc/src/stdio/CMakeLists.txt
+++ b/libc/src/stdio/CMakeLists.txt
@@ -203,6 +203,16 @@ add_entrypoint_object(
     libc.src.stdio.printf_core.vfprintf_internal
 )
 
+add_entrypoint_object(
+  vsscanf
+  SRCS
+    vsscanf.cpp
+  HDRS
+    vsscanf.h
+  DEPENDS
+    libc.src.__support.arg_list
+)
+
 add_stdio_entrypoint_object(
   fileno
   SRCS

--- a/libc/src/stdio/vsscanf.cpp
+++ b/libc/src/stdio/vsscanf.cpp
@@ -1,0 +1,36 @@
+//===-- Implementation of vsscanf -------------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "src/stdio/vsscanf.h"
+
+#include "src/__support/CPP/limits.h"
+#include "src/__support/arg_list.h"
+#include "src/stdio/scanf_core/reader.h"
+#include "src/stdio/scanf_core/scanf_main.h"
+
+#include <stdarg.h>
+#include <stdio.h>
+
+namespace LIBC_NAMESPACE {
+
+LLVM_LIBC_FUNCTION(int, vsscanf,
+                   (const char *buffer, const char *format, va_list vlist)) {
+  internal::ArgList args(vlist); // This holder class allows for easier copying
+                                 // and pointer semantics, as well as handling
+                                 // destruction automatically.
+
+  scanf_core::ReadBuffer rb{const_cast<char *>(buffer),
+                            cpp::numeric_limits<size_t>::max()};
+  scanf_core::Reader reader(&rb);
+  int ret_val = scanf_core::scanf_main(&reader, format, args);
+  // This is done to avoid including stdio.h in the internals. On most systems
+  // EOF is -1, so this will be transformed into just "return ret_val".
+  return (ret_val == -1) ? EOF : ret_val;
+}
+
+} // namespace LIBC_NAMESPACE

--- a/libc/src/stdio/vsscanf.h
+++ b/libc/src/stdio/vsscanf.h
@@ -1,0 +1,20 @@
+//===-- Implementation header of vsscanf ------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC_STDIO_VSSCANF_H
+#define LLVM_LIBC_SRC_STDIO_VSSCANF_H
+
+#include <stdarg.h>
+
+namespace LIBC_NAMESPACE {
+
+int vsscanf(const char *s, const char *format, va_list vlist);
+
+} // namespace LIBC_NAMESPACE
+
+#endif // LLVM_LIBC_SRC_STDIO_VSSCANF_H

--- a/libc/test/src/stdio/CMakeLists.txt
+++ b/libc/test/src/stdio/CMakeLists.txt
@@ -274,6 +274,18 @@ add_libc_test(
 )
 
 add_libc_test(
+  vsscanf_test
+  SUITE
+    libc_stdio_unittests
+  SRCS
+    vsscanf_test.cpp
+  DEPENDS
+    libc.src.stdio.vsscanf
+  LINK_LIBRARIES
+    LibcFPTestHelpers
+)
+
+add_libc_test(
   puts_test
   HERMETIC_TEST_ONLY # writes to libc's stdout
   SUITE

--- a/libc/test/src/stdio/vsscanf_test.cpp
+++ b/libc/test/src/stdio/vsscanf_test.cpp
@@ -1,0 +1,83 @@
+//===-- Unittests for vsscanf ---------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "src/__support/CPP/limits.h"
+#include "src/__support/arg_list.h"
+
+#include "src/stdio/vsscanf.h"
+
+#include "test/UnitTest/FPMatcher.h"
+#include "test/UnitTest/Test.h"
+
+TEST(LlvmLibcVSScanfTest, IntConvSimple) {
+  int result = 0;
+
+  auto fn = [](int fmt, ...) {
+    va_list vlist;
+    va_start(vlist, fmt);
+    return LIBC_NAMESPACE::vsscanf("123", "%d", vlist);
+  };
+  EXPECT_EQ(fn(0, &result), 1);
+  EXPECT_EQ(result, 123);
+
+  auto fn = [](int fmt, ...) {
+    va_list vlist;
+    va_start(vlist, fmt);
+    return LIBC_NAMESPACE::vsscanf("456", "%i", vlist);
+  };
+  EXPECT_EQ(fn(0, &result), 1);
+  EXPECT_EQ(result, 456);
+
+  auto fn = [](int fmt, ...) {
+    va_list vlist;
+    va_start(vlist, fmt);
+    return LIBC_NAMESPACE::vsscanf("789", "%x", vlist);
+  };
+  EXPECT_EQ(fn(0, &result), 1);
+  EXPECT_EQ(result, 0x789);
+
+  auto fn = [](int fmt, ...) {
+    va_list vlist;
+    va_start(vlist, fmt);
+    return LIBC_NAMESPACE::vsscanf("012", "%o", vlist);
+  };
+  EXPECT_EQ(fn(0, &result), 1);
+  EXPECT_EQ(result, 012);
+
+  auto fn = [](int fmt, ...) {
+    va_list vlist;
+    va_start(vlist, fmt);
+    return LIBC_NAMESPACE::vsscanf("345", "%u", vlist);
+  };
+  EXPECT_EQ(fn(0, &result), 1);
+  EXPECT_EQ(result, 345);
+
+  auto fn = [](int fmt, ...) {
+    va_list vlist;
+    va_start(vlist, fmt);
+    return LIBC_NAMESPACE::vsscanf("10000000000000000000000000000000"
+                                   "00000000000000000000000000000000"
+                                   "00000000000000000000000000000000"
+                                   "00000000000000000000000000000000"
+                                   "00000000000000000000000000000000"
+                                   "00000000000000000000000000000000"
+                                   "00000000000000000000000000000000"
+                                   "00000000000000000000000000000000"
+                                   "00000000000000000000000000000000",
+                                   "%d", vlist);
+  };
+  EXPECT_EQ(fn(0, &result), 1);
+  EXPECT_EQ(result, int(LIBC_NAMESPACE::cpp::numeric_limits<intmax_t>::max()));
+
+  auto fn = [](int fmt, ...) {
+    va_list vlist;
+    va_start(vlist, fmt);
+    return LIBC_NAMESPACE::vsscanf("Not an integer", "%d", vlist);
+  };
+  EXPECT_EQ(fn(0, &result), 0);
+}


### PR DESCRIPTION
Still needs proper implementation, but stubs are here.

See:
- https://linux.die.net/man/3/vsscanf
- https://android.googlesource.com/platform/bionic/+/froyo-release/libc/stdio/vsscanf.c