### PR TITLE
[lldb] [DynamicLoaderPOSIXDYLD] Enable POSIX-DYLD for QNX

### DIFF
--- a/lldb/source/Plugins/DynamicLoader/POSIX-DYLD/DynamicLoaderPOSIXDYLD.cpp
+++ b/lldb/source/Plugins/DynamicLoader/POSIX-DYLD/DynamicLoaderPOSIXDYLD.cpp
@@ -54,7 +54,8 @@ DynamicLoader *DynamicLoaderPOSIXDYLD::CreateInstance(Process *process,
     if (triple_ref.getOS() == llvm::Triple::FreeBSD ||
         triple_ref.getOS() == llvm::Triple::Linux ||
         triple_ref.getOS() == llvm::Triple::NetBSD ||
-        triple_ref.getOS() == llvm::Triple::OpenBSD)
+        triple_ref.getOS() == llvm::Triple::OpenBSD ||
+        triple_ref.getOS() == llvm::Triple::QNX)
       create = true;
   }
 


### PR DESCRIPTION
This change enables the _POSIX_ dynamic loader plugin for _QNX_, and is the fourth in a series of changes (specifically, #97417, #97439, #97487, #97536, and #97630) that look to facilitate remote debug of _AArch64_ targets on _QNX_.

_QNX Neutrino Real-Time Operating System_ is a commercial Unix-like real-time operating system primarily targeting the embedded systems market including automotive, medical devices, robotics, transportation, and industrial embedded systems.

The series of changes in question looks to provision support for –

- Launching a debuggee
- Attaching to a debuggee
- Having the debuggee come up stopped at the entry point
- Setting breakpoints
- Stopping at breakpoints
- Reading/writing contents of/to the debuggee's memory
- Reading/writing contents of/to the debuggee's registers
- Reading/writing contents of/to the debuggee's variables
- Resuming the debuggee's execution
- Single-stepping the debuggee's execution
- Interrupting the debuggee's execution
- Dumping information pertaining to the debuggee's stack trace

Kindly note that _ptrace_ isn't available on _QNX_. Instead, _devctl_ can be leveraged to observe and control the execution of a process under debug on _QNX_.

Any additional support (including the facilitation of execution of tests) will be the subject of future work.