### PR TITLE
[SystemZ] Fix handling of target triples on Debian (#95407)

### DIFF
--- a/llvm/cmake/config.guess
+++ b/llvm/cmake/config.guess
@@ -1028,11 +1028,7 @@ EOF
 	echo ${UNAME_MACHINE}-unknown-linux-${LIBC}
 	exit ;;
     s390:Linux:*:* | s390x:Linux:*:*)
-	if [ "$(grep -Ei 'debian|ubuntu' /etc/lsb-release)" ]; then
-	    echo ${UNAME_MACHINE}-linux-gnu
-	else
-	    echo ${UNAME_MACHINE}-ibm-linux
-	fi
+	echo ${UNAME_MACHINE}-unknown-linux-gnu
 	exit ;;
     sh64*:Linux:*:*)
 	echo ${UNAME_MACHINE}-unknown-linux-gnu


### PR DESCRIPTION
Debian's GCC installation has target triple "s390x-linux-gnu". Since, unlike in Ubuntu, there is no /etc/lsb-release, config.guess detects "s390x-ibm-linux". Generic_GCC::GCCInstallationDetector::init() only tries to strip the "unknown" vendor, so GCC installation detection fails.

Checking /etc/os-release in addition to /etc/lsb-release fixes this problem. However, LLVM-built sanitizer runtimes still cannot be found: the driver looks for them in lib/clang/19/lib/s390x-linux-gnu, but the build system places them in lib/clang/19/lib/s390x-unknown-linux-gnu.

According to @MaskRay, the build system is doing the right thing [1]: on the file system, full arch-vendor-os-environment triples must be used. In order to satisfy both GCCInstallationDetector and this rule, use the "s390x-unknown-linux-gnu" triple.

[1] https://github.com/llvm/llvm-project/issues/95407#issuecomment-2167390240