### PR TITLE
[lldb] Make Listener::m_broadcasters_mutex non-recursive

### DIFF
--- a/lldb/include/lldb/Utility/Listener.h
+++ b/lldb/include/lldb/Utility/Listener.h
@@ -127,7 +127,7 @@ private:
 
   std::string m_name;
   broadcaster_collection m_broadcasters;
-  std::recursive_mutex m_broadcasters_mutex; // Protects m_broadcasters
+  std::mutex m_broadcasters_mutex; // Protects m_broadcasters
   event_collection m_events;
   std::mutex m_events_mutex; // Protects m_broadcasters and m_events
   std::condition_variable m_events_condition;

--- a/lldb/source/Utility/Listener.cpp
+++ b/lldb/source/Utility/Listener.cpp
@@ -38,8 +38,7 @@ Listener::~Listener() {
 
 void Listener::Clear() {
   Log *log = GetLog(LLDBLog::Object);
-  std::lock_guard<std::recursive_mutex> broadcasters_guard(
-      m_broadcasters_mutex);
+  std::lock_guard<std::mutex> broadcasters_guard(m_broadcasters_mutex);
   broadcaster_collection::iterator pos, end = m_broadcasters.end();
   for (pos = m_broadcasters.begin(); pos != end; ++pos) {
     Broadcaster::BroadcasterImplSP broadcaster_sp(pos->first.lock());
@@ -68,8 +67,7 @@ uint32_t Listener::StartListeningForEvents(Broadcaster *broadcaster,
     // Scope for "locker"
     // Tell the broadcaster to add this object as a listener
     {
-      std::lock_guard<std::recursive_mutex> broadcasters_guard(
-          m_broadcasters_mutex);
+      std::lock_guard<std::mutex> broadcasters_guard(m_broadcasters_mutex);
       Broadcaster::BroadcasterImplWP impl_wp(broadcaster->GetBroadcasterImpl());
       m_broadcasters.insert(
           std::make_pair(impl_wp, BroadcasterInfo(event_mask)));
@@ -99,8 +97,7 @@ uint32_t Listener::StartListeningForEvents(Broadcaster *broadcaster,
     // Scope for "locker"
     // Tell the broadcaster to add this object as a listener
     {
-      std::lock_guard<std::recursive_mutex> broadcasters_guard(
-          m_broadcasters_mutex);
+      std::lock_guard<std::mutex> broadcasters_guard(m_broadcasters_mutex);
       Broadcaster::BroadcasterImplWP impl_wp(broadcaster->GetBroadcasterImpl());
       m_broadcasters.insert(std::make_pair(
           impl_wp, BroadcasterInfo(event_mask, callback, callback_user_data)));
@@ -131,8 +128,7 @@ bool Listener::StopListeningForEvents(Broadcaster *broadcaster,
   if (broadcaster) {
     // Scope for "locker"
     {
-      std::lock_guard<std::recursive_mutex> broadcasters_guard(
-          m_broadcasters_mutex);
+      std::lock_guard<std::mutex> broadcasters_guard(m_broadcasters_mutex);
       m_broadcasters.erase(broadcaster->GetBroadcasterImpl());
     }
     // Remove the broadcaster from our set of broadcasters
@@ -147,8 +143,7 @@ bool Listener::StopListeningForEvents(Broadcaster *broadcaster,
 void Listener::BroadcasterWillDestruct(Broadcaster *broadcaster) {
   // Scope for "broadcasters_locker"
   {
-    std::lock_guard<std::recursive_mutex> broadcasters_guard(
-        m_broadcasters_mutex);
+    std::lock_guard<std::mutex> broadcasters_guard(m_broadcasters_mutex);
     m_broadcasters.erase(broadcaster->GetBroadcasterImpl());
   }
 
@@ -322,7 +317,7 @@ bool Listener::GetEvent(EventSP &event_sp, const Timeout<std::micro> &timeout) {
 
 size_t Listener::HandleBroadcastEvent(EventSP &event_sp) {
   size_t num_handled = 0;
-  std::lock_guard<std::recursive_mutex> guard(m_broadcasters_mutex);
+  std::lock_guard<std::mutex> guard(m_broadcasters_mutex);
   Broadcaster *broadcaster = event_sp->GetBroadcaster();
   if (!broadcaster)
     return 0;
@@ -357,7 +352,7 @@ Listener::StartListeningForEventSpec(const BroadcasterManagerSP &manager_sp,
   // The BroadcasterManager mutex must be locked before m_broadcasters_mutex to
   // avoid violating the lock hierarchy (manager before broadcasters).
   std::lock_guard<std::mutex> manager_guard(manager_sp->m_manager_mutex);
-  std::lock_guard<std::recursive_mutex> guard(m_broadcasters_mutex);
+  std::lock_guard<std::mutex> guard(m_broadcasters_mutex);
 
   uint32_t bits_acquired = manager_sp->RegisterListenerForEventsNoLock(
       this->shared_from_this(), event_spec);
@@ -379,7 +374,7 @@ bool Listener::StopListeningForEventSpec(const BroadcasterManagerSP &manager_sp,
   // The BroadcasterManager mutex must be locked before m_broadcasters_mutex to
   // avoid violating the lock hierarchy (manager before broadcasters).
   std::lock_guard<std::mutex> manager_guard(manager_sp->m_manager_mutex);
-  std::lock_guard<std::recursive_mutex> guard(m_broadcasters_mutex);
+  std::lock_guard<std::mutex> guard(m_broadcasters_mutex);
   return manager_sp->UnregisterListenerForEventsNoLock(this->shared_from_this(),
                                                        event_spec);
 }


### PR DESCRIPTION
Follow-up to #97400.  No changes apart from changing the type were necessary. The mutex was already not used recursively.