### PR TITLE
[libcxx] responds to Clang Tidy feedback

### DIFF
--- a/libcxx/include/__functional/function.h
+++ b/libcxx/include/__functional/function.h
@@ -754,7 +754,7 @@ public:
 #    ifdef _LIBCPP_HAS_OBJC_ARC
       : __f_(__f)
 #    else
-      : __f_(reinterpret_cast<__block_type>(__f ? _Block_copy(__f) : nullptr))
+      : __f_(reinterpret_cast<__block_type>(__f ? std::__function::_Block_copy(__f) : nullptr))
 #    endif
   {
   }
@@ -765,7 +765,7 @@ public:
 #    ifdef _LIBCPP_HAS_OBJC_ARC
       : __f_(__f)
 #    else
-      : __f_(reinterpret_cast<__block_type>(__f ? _Block_copy(__f) : nullptr))
+      : __f_(reinterpret_cast<__block_type>(__f ? std::__function::_Block_copy(__f) : nullptr))
 #    endif
   {
   }
@@ -786,7 +786,7 @@ public:
   _LIBCPP_HIDE_FROM_ABI_VIRTUAL virtual void destroy() _NOEXCEPT {
 #    ifndef _LIBCPP_HAS_OBJC_ARC
     if (__f_)
-      _Block_release(__f_);
+      std::__function::_Block_release(__f_);
 #    endif
     __f_ = 0;
   }

--- a/libcxx/include/__thread/id.h
+++ b/libcxx/include/__thread/id.h
@@ -42,17 +42,17 @@ class _LIBCPP_TEMPLATE_VIS __thread_id {
 
   static _LIBCPP_HIDE_FROM_ABI bool
   __lt_impl(__thread_id __x, __thread_id __y) _NOEXCEPT { // id==0 is always less than any other thread_id
-    if (__x.__id_ == 0)
-      return __y.__id_ != 0;
-    if (__y.__id_ == 0)
+    if (__x.__id_ == nullptr)
+      return __y.__id_ != nullptr;
+    if (__y.__id_ == nullptr)
       return false;
     return __libcpp_thread_id_less(__x.__id_, __y.__id_);
   }
 
 public:
-  _LIBCPP_HIDE_FROM_ABI __thread_id() _NOEXCEPT : __id_(0) {}
+  _LIBCPP_HIDE_FROM_ABI __thread_id() _NOEXCEPT : __id_(nullptr) {}
 
-  _LIBCPP_HIDE_FROM_ABI void __reset() { __id_ = 0; }
+  _LIBCPP_HIDE_FROM_ABI void __reset() { __id_ = nullptr; }
 
   friend _LIBCPP_HIDE_FROM_ABI bool operator==(__thread_id __x, __thread_id __y) _NOEXCEPT;
 #  if _LIBCPP_STD_VER <= 17
@@ -77,9 +77,9 @@ private:
 
 inline _LIBCPP_HIDE_FROM_ABI bool operator==(__thread_id __x, __thread_id __y) _NOEXCEPT {
   // Don't pass id==0 to underlying routines
-  if (__x.__id_ == 0)
-    return __y.__id_ == 0;
-  if (__y.__id_ == 0)
+  if (__x.__id_ == nullptr)
+    return __y.__id_ == nullptr;
+  if (__y.__id_ == nullptr)
     return false;
   return __libcpp_thread_id_equal(__x.__id_, __y.__id_);
 }

--- a/libcxx/include/__thread/support/pthread.h
+++ b/libcxx/include/__thread/support/pthread.h
@@ -175,7 +175,7 @@ inline _LIBCPP_HIDE_FROM_ABI __libcpp_thread_id __libcpp_thread_get_id(const __l
 }
 
 inline _LIBCPP_HIDE_FROM_ABI bool __libcpp_thread_isnull(const __libcpp_thread_t* __t) {
-  return __libcpp_thread_get_id(__t) == 0;
+  return __libcpp_thread_get_id(__t) == nullptr;
 }
 
 inline _LIBCPP_HIDE_FROM_ABI int __libcpp_thread_create(__libcpp_thread_t* __t, void* (*__func)(void*), void* __arg) {


### PR DESCRIPTION
Clang Tidy flagged the following as problematic when running tests locally.