### PR TITLE
[lldb] Print "0x0" for bitfield like enums where the value is 0

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp
+++ b/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp
@@ -8680,6 +8680,13 @@ static bool DumpEnumValue(const clang::QualType &qual_type, Stream &s,
     return true;
   }
 
+  if (!enum_uvalue) {
+    // This is a bitfield enum, but the value is 0 so we know it won't match
+    // with any of the enumerators.
+    s.Printf("0x%" PRIx64, enum_uvalue);
+    return true;
+  }
+
   uint64_t remaining_value = enum_uvalue;
   std::vector<std::pair<uint64_t, llvm::StringRef>> values;
   values.reserve(num_enumerators);
@@ -8704,7 +8711,8 @@ static bool DumpEnumValue(const clang::QualType &qual_type, Stream &s,
       s.PutCString(" | ");
   }
 
-  // If there is a remainder that is not covered by the value, print it as hex.
+  // If there is a remainder that is not covered by the value, print it as
+  // hex.
   if (remaining_value)
     s.Printf("0x%" PRIx64, remaining_value);
 

--- a/lldb/unittests/ValueObject/DumpValueObjectOptionsTests.cpp
+++ b/lldb/unittests/ValueObject/DumpValueObjectOptionsTests.cpp
@@ -149,12 +149,12 @@ TEST_F(ValueObjectMockProcessTest, Enum) {
 TEST_F(ValueObjectMockProcessTest, BitFieldLikeEnum) {
   // These enumerators set individual bits in the value, as if it were a flag
   // set. lldb treats this as a "bitfield like enum". This means we show values
-  // as hex, a value of 0 shows nothing, and values with no exact enumerator are
-  // shown as combinations of the other values.
+  // as hex, and values without exact matches are shown as a combination of
+  // enumerators and any remaining value left over.
   TestDumpValueObject(
       MakeEnumType({{"test_2", 2}, {"test_4", 4}}),
       {
-          {0, {}, "(TestEnum) test_var =\n"},
+          {0, {}, "(TestEnum) test_var = 0x0\n"},
           {1, {}, "(TestEnum) test_var = 0x1\n"},
           {2, {}, "(TestEnum) test_var = test_2\n"},
           {4, {}, "(TestEnum) test_var = test_4\n"},


### PR DESCRIPTION
Enums like this one are treated as bitfield like enums: enum FlagsLike {B=2, C=4};

lldb recognises them as collections of flags, so you can have "B | C". If there's any values not covered that's printed as hex "B | C | 0x1".

What happened if the value was 0 was we would not match any of the enumerators, then the remainder check requires that the remainder is non-zero. So lldb would print nothing at all.

Which I assume is a bug because knowing that no flags are set is useful, just as much as knowing that some unkown bit was set to make it non-zero.