### PR TITLE
[SPIRV] Emitting DebugSource, DebugCompileUnit

### DIFF
--- a/llvm/docs/SPIRVUsage.rst
+++ b/llvm/docs/SPIRVUsage.rst
@@ -181,6 +181,8 @@ list of supported SPIR-V extensions, sorted alphabetically by their extension na
      - Adds a new instruction that enables rotating values across invocations within a subgroup.
    * - ``SPV_KHR_uniform_group_instructions``
      - Allows support for additional group operations within uniform control flow.
+   * - ``SPV_KHR_non_semantic_info``
+     - Adds the ability to declare extended instruction sets that have no semantic impact and can be safely removed from a module.
 
 To enable multiple extensions, list them separated by spaces. For example, to enable support for atomic operations on floating-point numbers and arbitrary precision integers, use:
 

--- a/llvm/docs/SPIRVUsage.rst
+++ b/llvm/docs/SPIRVUsage.rst
@@ -33,7 +33,11 @@ Static Compiler Commands
    Command: `llc -O1 -mtriple=spirv64-unknown-unknown --spirv-ext=+SPV_INTEL_arbitrary_precision_integers input.ll -o output.spvt`
    Description: Compiles an LLVM IL file to SPIR-V with (`-O1`) optimizations, targeting a 64-bit architecture. It enables the SPV_INTEL_arbitrary_precision_integers extension.
 
-3. **SPIR-V Binary Generation**
+3. **Compilation with experimental NonSemantic.Shader.DebugInfo.100 support**
+   Command: `llc --spv-emit-nonsemantic-debug-info --spirv-ext=+SPV_KHR_non_semantic_info input.ll -o output.spvt`
+   Description: Compiles an LLVM IL file to SPIR-V with additional NonSemantic.Shader.DebugInfo.100 instructions. It enables the required SPV_KHR_non_semantic_info extension.
+
+4. **SPIR-V Binary Generation**
    Command: `llc -O0 -mtriple=spirv64-unknown-unknown -filetype=obj input.ll -o output.spvt`
    Description: Generates a SPIR-V object file (`output.spvt`) from an LLVM module, targeting a 64-bit SPIR-V architecture with no optimizations.
 

--- a/llvm/lib/Target/SPIRV/CMakeLists.txt
+++ b/llvm/lib/Target/SPIRV/CMakeLists.txt
@@ -40,6 +40,7 @@ add_llvm_target(SPIRVCodeGen
   SPIRVSubtarget.cpp
   SPIRVTargetMachine.cpp
   SPIRVUtils.cpp
+  SPIRVEmitNonSemanticDI.cpp
 
   LINK_COMPONENTS
   Analysis

--- a/llvm/lib/Target/SPIRV/SPIRV.h
+++ b/llvm/lib/Target/SPIRV/SPIRV.h
@@ -26,6 +26,7 @@ FunctionPass *createSPIRVRegularizerPass();
 FunctionPass *createSPIRVPreLegalizerPass();
 FunctionPass *createSPIRVPostLegalizerPass();
 ModulePass *createSPIRVEmitIntrinsicsPass(SPIRVTargetMachine *TM);
+MachineFunctionPass *createSPIRVEmitNonSemanticDIPass();
 InstructionSelector *
 createSPIRVInstructionSelector(const SPIRVTargetMachine &TM,
                                const SPIRVSubtarget &Subtarget,
@@ -36,6 +37,7 @@ void initializeSPIRVConvergenceRegionAnalysisWrapperPassPass(PassRegistry &);
 void initializeSPIRVPreLegalizerPass(PassRegistry &);
 void initializeSPIRVPostLegalizerPass(PassRegistry &);
 void initializeSPIRVEmitIntrinsicsPass(PassRegistry &);
+void initializeSPIRVEmitNonSemanticDIPass(PassRegistry &);
 } // namespace llvm
 
 #endif // LLVM_LIB_TARGET_SPIRV_SPIRV_H

--- a/llvm/lib/Target/SPIRV/SPIRV.h
+++ b/llvm/lib/Target/SPIRV/SPIRV.h
@@ -26,7 +26,7 @@ FunctionPass *createSPIRVRegularizerPass();
 FunctionPass *createSPIRVPreLegalizerPass();
 FunctionPass *createSPIRVPostLegalizerPass();
 ModulePass *createSPIRVEmitIntrinsicsPass(SPIRVTargetMachine *TM);
-MachineFunctionPass *createSPIRVEmitNonSemanticDIPass();
+MachineFunctionPass *createSPIRVEmitNonSemanticDIPass(SPIRVTargetMachine *TM);
 InstructionSelector *
 createSPIRVInstructionSelector(const SPIRVTargetMachine &TM,
                                const SPIRVSubtarget &Subtarget,

--- a/llvm/lib/Target/SPIRV/SPIRVAsmPrinter.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVAsmPrinter.cpp
@@ -274,6 +274,8 @@ void SPIRVAsmPrinter::outputDebugSourceAndStrings(const Module &M) {
     addStringImm(Str.first(), Inst);
     outputMCInst(Inst);
   }
+  // Output OpString.
+  outputModuleSection(SPIRV::MB_DebugStrings);
   // Output OpSource.
   MCInst Inst;
   Inst.setOpcode(SPIRV::OpSource);
@@ -589,9 +591,11 @@ void SPIRVAsmPrinter::outputModuleSections() {
   // the first section to allow use of: OpLine and OpNoLine debug information;
   // non-semantic instructions with OpExtInst.
   outputModuleSection(SPIRV::MB_TypeConstVars);
-  // 10. All function declarations (functions without a body).
+  // 10. All global NonSemantic.Shader.DebugInfo.100 instructions.
+  outputModuleSection(SPIRV::MB_NonSemanticGlobalDI);
+  // 11. All function declarations (functions without a body).
   outputExtFuncDecls();
-  // 11. All function definitions (functions with a body).
+  // 12. All function definitions (functions with a body).
   // This is done in regular function output.
 }
 

--- a/llvm/lib/Target/SPIRV/SPIRVCommandLine.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVCommandLine.cpp
@@ -68,7 +68,8 @@ static const std::map<std::string, SPIRV::Extension::Extension>
          SPIRV::Extension::Extension::SPV_KHR_shader_clock},
         {"SPV_KHR_cooperative_matrix",
          SPIRV::Extension::Extension::SPV_KHR_cooperative_matrix},
-};
+        {"SPV_KHR_non_semantic_info",
+         SPIRV::Extension::Extension::SPV_KHR_non_semantic_info}};
 
 bool SPIRVExtensionsParser::parse(cl::Option &O, llvm::StringRef ArgName,
                                   llvm::StringRef ArgValue,

--- a/llvm/lib/Target/SPIRV/SPIRVEmitNonSemanticDI.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVEmitNonSemanticDI.cpp
@@ -1,0 +1,55 @@
+#include "llvm/CodeGen/MachineFunction.h"
+#include "llvm/CodeGen/MachineFunctionPass.h"
+#include "llvm/CodeGen/MachineModuleInfo.h"
+#include "llvm/IR/DebugInfoMetadata.h"
+#include "llvm/IR/Metadata.h"
+#include "llvm/PassRegistry.h"
+#include "llvm/Support/Casting.h"
+
+namespace llvm {
+struct SPIRVEmitNonSemanticDI : public MachineFunctionPass {
+  static char ID;
+  SPIRVEmitNonSemanticDI();
+
+  bool runOnMachineFunction(MachineFunction &MF) override;
+};
+
+void initializeSPIRVEmitNonSemanticDIPass(PassRegistry &);
+
+FunctionPass *createSPIRVEmitNonSemanticDIPass() {
+  return new SPIRVEmitNonSemanticDI();
+}
+} // namespace llvm
+
+using namespace llvm;
+
+INITIALIZE_PASS(SPIRVEmitNonSemanticDI, "spirv-nonsemantic-debug-info",
+                "SPIRV NonSemantic.Shader.DebugInfo.100 emitter", false, false)
+
+char SPIRVEmitNonSemanticDI::ID = 0;
+
+SPIRVEmitNonSemanticDI::SPIRVEmitNonSemanticDI() : MachineFunctionPass(ID) {
+  initializeSPIRVEmitNonSemanticDIPass(*PassRegistry::getPassRegistry());
+}
+
+[[maybe_unused]]
+static void findCompileUnitDI(const MachineFunction &MF) {
+  MachineModuleInfo &MMI = MF.getMMI();
+  const Module *M = MMI.getModule();
+  NamedMDNode *DbgCu = M->getNamedMetadata("llvm.dbg.cu");
+  std::string FilePath;
+  if (DbgCu) {
+    unsigned NumOp = DbgCu->getNumOperands();
+    if (NumOp) {
+      if (const auto *CompileUnit =
+              dyn_cast<DICompileUnit>(DbgCu->getOperand(0))) {
+        DIFile *File = CompileUnit->getFile();
+        FilePath = ((File->getDirectory() + "/" + File->getFilename())).str();
+      }
+    }
+  }
+}
+
+bool SPIRVEmitNonSemanticDI::runOnMachineFunction(MachineFunction &MF) {
+  return false;
+}

--- a/llvm/lib/Target/SPIRV/SPIRVEmitNonSemanticDI.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVEmitNonSemanticDI.cpp
@@ -74,7 +74,7 @@ bool SPIRVEmitNonSemanticDI::emitGlobalDI(MachineFunction &MF) {
   // Searching through the Module metadata to find nescessary
   // information like DwarfVersion or SourceLanguage
   {
-    const MachineModuleInfo &MMI = MF.getMMI();
+    const MachineModuleInfo &MMI = getAnalysis<MachineModuleInfoWrapperPass>().getMMI();
     const Module *M = MMI.getModule();
     Context = &M->getContext();
     const NamedMDNode *DbgCu = M->getNamedMetadata("llvm.dbg.cu");

--- a/llvm/lib/Target/SPIRV/SPIRVEmitNonSemanticDI.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVEmitNonSemanticDI.cpp
@@ -114,7 +114,10 @@ bool SPIRVEmitNonSemanticDI::emitGlobalDI(MachineFunction &MF) {
     SPIRVGlobalRegistry *GR = TM->getSubtargetImpl()->getSPIRVGlobalRegistry();
     MachineRegisterInfo &MRI = MF.getRegInfo();
     MachineBasicBlock &MBB = *MF.begin();
-    MachineIRBuilder MIRBuilder(MBB, MBB.begin());
+
+    // To correct placement of a OpLabel instruction during SPIRVAsmPrinter
+    // emission all new instructions needs to be placed after OpFunction
+    MachineIRBuilder MIRBuilder(MBB, MBB.end());
 
     // Emit OpString with FilePath which is required by DebugSource
     const Register StrReg = MRI.createVirtualRegister(&SPIRV::IDRegClass);

--- a/llvm/lib/Target/SPIRV/SPIRVEmitNonSemanticDI.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVEmitNonSemanticDI.cpp
@@ -105,7 +105,7 @@ bool SPIRVEmitNonSemanticDI::emitGlobalDI(MachineFunction &MF) {
                 ->getSExtValue();
     }
   }
-  // NonSemantic.Shader.DebugInfo.100 global DI intruction emitting
+  // NonSemantic.Shader.DebugInfo.100 global DI instruction emitting
   {
     // Required LLVM variables for emitting logic
     const SPIRVInstrInfo *TII = TM->getSubtargetImpl()->getInstrInfo();

--- a/llvm/lib/Target/SPIRV/SPIRVEmitNonSemanticDI.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVEmitNonSemanticDI.cpp
@@ -111,6 +111,7 @@ bool SPIRVEmitNonSemanticDI::emitGlobalDI(MachineFunction &MF) {
 
   SPIRVType *VoidTyMI =
       GR->getOrCreateSPIRVType(Type::getVoidTy(M->getContext()), MIRBuilder);
+  GR->assignSPIRVTypeToVReg(VoidTyMI, GR->getSPIRVTypeID(VoidTyMI), MF);
 
   Register DebugSourceResIdReg = MRI.createVirtualRegister(&SPIRV::IDRegClass);
   MRI.setType(DebugSourceResIdReg, LLT::scalar(32));

--- a/llvm/lib/Target/SPIRV/SPIRVEmitNonSemanticDI.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVEmitNonSemanticDI.cpp
@@ -123,9 +123,8 @@ bool SPIRVEmitNonSemanticDI::emitGlobalDI(MachineFunction &MF) {
     MIB.addDef(StrReg);
     addStringImm(FilePath, MIB);
 
-    const SPIRVType *VoidTyMI =
+    const SPIRVType *VoidTy =
         GR->getOrCreateSPIRVType(Type::getVoidTy(*Context), MIRBuilder);
-    GR->assignSPIRVTypeToVReg(VoidTyMI, GR->getSPIRVTypeID(VoidTyMI), MF);
 
     // Emit DebugSource which is required by DebugCompilationUnit
     const Register DebugSourceResIdReg =
@@ -133,16 +132,16 @@ bool SPIRVEmitNonSemanticDI::emitGlobalDI(MachineFunction &MF) {
     MRI.setType(DebugSourceResIdReg, LLT::scalar(32));
     MIB = MIRBuilder.buildInstr(SPIRV::OpExtInst)
               .addDef(DebugSourceResIdReg)
-              .addUse(GR->getSPIRVTypeID(VoidTyMI))
+              .addUse(GR->getSPIRVTypeID(VoidTy))
               .addImm(static_cast<int64_t>(
                   SPIRV::InstructionSet::NonSemantic_Shader_DebugInfo_100))
               .addImm(SPIRV::NonSemanticExtInst::DebugSource)
               .addUse(StrReg);
     MIB.constrainAllUses(*TII, *TRI, *RBI);
+    GR->assignSPIRVTypeToVReg(VoidTy, DebugSourceResIdReg, MF);
 
     const SPIRVType *I32Ty =
         GR->getOrCreateSPIRVType(Type::getInt32Ty(*Context), MIRBuilder);
-    GR->assignSPIRVTypeToVReg(I32Ty, GR->getSPIRVTypeID(I32Ty), MF);
 
     // Convert DwarfVersion, DebugInfo and SourceLanguage integers to OpConstant
     // instructions required by DebugCompilationUnit
@@ -153,6 +152,7 @@ bool SPIRVEmitNonSemanticDI::emitGlobalDI(MachineFunction &MF) {
         .addDef(DwarfVersionReg)
         .addUse(GR->getSPIRVTypeID(I32Ty))
         .addImm(DwarfVersion);
+    GR->assignSPIRVTypeToVReg(I32Ty, DwarfVersionReg, MF);
 
     const Register DebugInfoVersionReg =
         MRI.createVirtualRegister(&SPIRV::IDRegClass);
@@ -161,6 +161,7 @@ bool SPIRVEmitNonSemanticDI::emitGlobalDI(MachineFunction &MF) {
         .addDef(DebugInfoVersionReg)
         .addUse(GR->getSPIRVTypeID(I32Ty))
         .addImm(DebugInfoVersion);
+    GR->assignSPIRVTypeToVReg(I32Ty, DebugInfoVersionReg, MF);
 
     const Register SourceLanguageReg =
         MRI.createVirtualRegister(&SPIRV::IDRegClass);
@@ -169,6 +170,7 @@ bool SPIRVEmitNonSemanticDI::emitGlobalDI(MachineFunction &MF) {
         .addDef(SourceLanguageReg)
         .addUse(GR->getSPIRVTypeID(I32Ty))
         .addImm(SourceLanguage);
+    GR->assignSPIRVTypeToVReg(I32Ty, SourceLanguageReg, MF);
 
     // Emit DebugCompilationUnit
     const Register DebugCompUnitResIdReg =
@@ -176,7 +178,7 @@ bool SPIRVEmitNonSemanticDI::emitGlobalDI(MachineFunction &MF) {
     MRI.setType(DebugCompUnitResIdReg, LLT::scalar(32));
     MIB = MIRBuilder.buildInstr(SPIRV::OpExtInst)
               .addDef(DebugCompUnitResIdReg)
-              .addUse(GR->getSPIRVTypeID(VoidTyMI))
+              .addUse(GR->getSPIRVTypeID(VoidTy))
               .addImm(static_cast<int64_t>(
                   SPIRV::InstructionSet::NonSemantic_Shader_DebugInfo_100))
               .addImm(SPIRV::NonSemanticExtInst::DebugCompilationUnit)
@@ -185,6 +187,7 @@ bool SPIRVEmitNonSemanticDI::emitGlobalDI(MachineFunction &MF) {
               .addUse(DebugSourceResIdReg)
               .addUse(SourceLanguageReg);
     MIB.constrainAllUses(*TII, *TRI, *RBI);
+    GR->assignSPIRVTypeToVReg(VoidTy, DebugCompUnitResIdReg, MF);
   }
   return true;
 }

--- a/llvm/lib/Target/SPIRV/SPIRVEmitNonSemanticDI.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVEmitNonSemanticDI.cpp
@@ -117,6 +117,7 @@ bool SPIRVEmitNonSemanticDI::emitGlobalDI(MachineFunction &MF) {
 
     // To correct placement of a OpLabel instruction during SPIRVAsmPrinter
     // emission all new instructions needs to be placed after OpFunction
+    // and before first terminator
     MachineIRBuilder MIRBuilder(MBB, MBB.getFirstTerminator());
 
     // Emit OpString with FilePath which is required by DebugSource

--- a/llvm/lib/Target/SPIRV/SPIRVEmitNonSemanticDI.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVEmitNonSemanticDI.cpp
@@ -74,7 +74,8 @@ bool SPIRVEmitNonSemanticDI::emitGlobalDI(MachineFunction &MF) {
   // Searching through the Module metadata to find nescessary
   // information like DwarfVersion or SourceLanguage
   {
-    const MachineModuleInfo &MMI = getAnalysis<MachineModuleInfoWrapperPass>().getMMI();
+    const MachineModuleInfo &MMI =
+        getAnalysis<MachineModuleInfoWrapperPass>().getMMI();
     const Module *M = MMI.getModule();
     Context = &M->getContext();
     const NamedMDNode *DbgCu = M->getNamedMetadata("llvm.dbg.cu");

--- a/llvm/lib/Target/SPIRV/SPIRVEmitNonSemanticDI.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVEmitNonSemanticDI.cpp
@@ -117,7 +117,7 @@ bool SPIRVEmitNonSemanticDI::emitGlobalDI(MachineFunction &MF) {
 
     // To correct placement of a OpLabel instruction during SPIRVAsmPrinter
     // emission all new instructions needs to be placed after OpFunction
-    MachineIRBuilder MIRBuilder(MBB, MBB.end());
+    MachineIRBuilder MIRBuilder(MBB, MBB.getFirstTerminator());
 
     // Emit OpString with FilePath which is required by DebugSource
     const Register StrReg = MRI.createVirtualRegister(&SPIRV::IDRegClass);

--- a/llvm/lib/Target/SPIRV/SPIRVEmitNonSemanticDI.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVEmitNonSemanticDI.cpp
@@ -1,6 +1,14 @@
+#include "MCTargetDesc/SPIRVBaseInfo.h"
+#include "SPIRVGlobalRegistry.h"
+#include "SPIRVRegisterInfo.h"
+#include "SPIRVTargetMachine.h"
+#include "llvm/CodeGen/GlobalISel/MachineIRBuilder.h"
 #include "llvm/CodeGen/MachineFunction.h"
 #include "llvm/CodeGen/MachineFunctionPass.h"
+#include "llvm/CodeGen/MachineInstr.h"
+#include "llvm/CodeGen/MachineInstrBuilder.h"
 #include "llvm/CodeGen/MachineModuleInfo.h"
+#include "llvm/CodeGen/MachineOperand.h"
 #include "llvm/IR/DebugInfoMetadata.h"
 #include "llvm/IR/Metadata.h"
 #include "llvm/PassRegistry.h"
@@ -9,15 +17,21 @@
 namespace llvm {
 struct SPIRVEmitNonSemanticDI : public MachineFunctionPass {
   static char ID;
+  SPIRVTargetMachine *TM;
+  SPIRVEmitNonSemanticDI(SPIRVTargetMachine *TM);
   SPIRVEmitNonSemanticDI();
 
   bool runOnMachineFunction(MachineFunction &MF) override;
+
+private:
+  bool IsGlobalDIEmitted = false;
+  bool emitGlobalDI(MachineFunction &MF);
 };
 
 void initializeSPIRVEmitNonSemanticDIPass(PassRegistry &);
 
-FunctionPass *createSPIRVEmitNonSemanticDIPass() {
-  return new SPIRVEmitNonSemanticDI();
+FunctionPass *createSPIRVEmitNonSemanticDIPass(SPIRVTargetMachine *TM) {
+  return new SPIRVEmitNonSemanticDI(TM);
 }
 } // namespace llvm
 
@@ -28,28 +42,107 @@ INITIALIZE_PASS(SPIRVEmitNonSemanticDI, "spirv-nonsemantic-debug-info",
 
 char SPIRVEmitNonSemanticDI::ID = 0;
 
+SPIRVEmitNonSemanticDI::SPIRVEmitNonSemanticDI(SPIRVTargetMachine *TM)
+    : MachineFunctionPass(ID), TM(TM) {
+  initializeSPIRVEmitNonSemanticDIPass(*PassRegistry::getPassRegistry());
+}
+
 SPIRVEmitNonSemanticDI::SPIRVEmitNonSemanticDI() : MachineFunctionPass(ID) {
   initializeSPIRVEmitNonSemanticDIPass(*PassRegistry::getPassRegistry());
 }
 
-[[maybe_unused]]
-static void findCompileUnitDI(const MachineFunction &MF) {
+bool SPIRVEmitNonSemanticDI::emitGlobalDI(MachineFunction &MF) {
   MachineModuleInfo &MMI = MF.getMMI();
   const Module *M = MMI.getModule();
   NamedMDNode *DbgCu = M->getNamedMetadata("llvm.dbg.cu");
+  if (!DbgCu) {
+    return false;
+  }
   std::string FilePath;
-  if (DbgCu) {
-    unsigned NumOp = DbgCu->getNumOperands();
-    if (NumOp) {
-      if (const auto *CompileUnit =
-              dyn_cast<DICompileUnit>(DbgCu->getOperand(0))) {
-        DIFile *File = CompileUnit->getFile();
-        FilePath = ((File->getDirectory() + "/" + File->getFilename())).str();
-      }
+  unsigned SourceLanguage;
+  unsigned NumOp = DbgCu->getNumOperands();
+  if (NumOp) {
+    if (const auto *CompileUnit =
+            dyn_cast<DICompileUnit>(DbgCu->getOperand(0))) {
+      DIFile *File = CompileUnit->getFile();
+      FilePath = ((File->getDirectory() + "/" + File->getFilename())).str();
+      SourceLanguage = CompileUnit->getSourceLanguage();
     }
   }
+  NamedMDNode *ModuleFlags = M->getNamedMetadata("llvm.module.flags");
+  int64_t DwarfVersion = 0;
+  int64_t DebugInfoVersion = 0;
+  for (auto *Op : ModuleFlags->operands()) {
+    const MDOperand &StrOp = Op->getOperand(1);
+    if (StrOp.equalsStr("Dwarf Version")) {
+      DwarfVersion =
+          cast<ConstantInt>(
+              cast<ConstantAsMetadata>(Op->getOperand(2))->getValue())
+              ->getSExtValue();
+    } else if (StrOp.equalsStr("Debug Info Version")) {
+      DebugInfoVersion =
+          cast<ConstantInt>(
+              cast<ConstantAsMetadata>(Op->getOperand(2))->getValue())
+              ->getSExtValue();
+    }
+  }
+  const SPIRVInstrInfo *TII = TM->getSubtargetImpl()->getInstrInfo();
+  const SPIRVRegisterInfo *TRI = TM->getSubtargetImpl()->getRegisterInfo();
+  const RegisterBankInfo *RBI = TM->getSubtargetImpl()->getRegBankInfo();
+  SPIRVGlobalRegistry *GR = TM->getSubtargetImpl()->getSPIRVGlobalRegistry();
+  MachineRegisterInfo &MRI = MF.getRegInfo();
+  for (MachineBasicBlock &MBB : MF) {
+    MachineIRBuilder MIRBuilder(MBB, MBB.begin());
+
+    MachineInstrBuilder MIB = MIRBuilder.buildInstr(SPIRV::OpString);
+    Register StrReg = MRI.createVirtualRegister(&SPIRV::IDRegClass);
+    MachineOperand StrRegOp = MachineOperand::CreateReg(StrReg, true);
+    MIB.add(StrRegOp);
+    addStringImm(FilePath, MIB);
+
+    const MachineInstr *VoidTyMI =
+        GR->getOrCreateSPIRVType(Type::getVoidTy(M->getContext()), MIRBuilder);
+
+    MIB = MIRBuilder.buildInstr(SPIRV::OpExtInst);
+    Register DebugSourceResIdReg =
+        MRI.createVirtualRegister(&SPIRV::IDRegClass);
+    MIB.addDef(DebugSourceResIdReg);              // Result ID
+    MIB.addUse(VoidTyMI->getOperand(0).getReg()); // Result Type
+    MIB.addImm(static_cast<int64_t>(
+        SPIRV::InstructionSet::NonSemantic_Shader_DebugInfo_100)); // Set ID
+    MIB.addImm(SPIRV::NonSemanticExtInst::DebugSource);            //
+    MIB.addUse(StrReg);
+    MIB.constrainAllUses(*TII, *TRI, *RBI);
+
+    Register DwarfVersionReg = GR->buildConstantInt(DwarfVersion, MIRBuilder);
+    Register DebugInfoVersionReg =
+        GR->buildConstantInt(DebugInfoVersion, MIRBuilder);
+    Register SourceLanguageReg =
+        GR->buildConstantInt(SourceLanguage, MIRBuilder);
+
+    MIB = MIRBuilder.buildInstr(SPIRV::OpExtInst);
+    Register DebugCompUnitResIdReg =
+        MRI.createVirtualRegister(&SPIRV::IDRegClass);
+    MIB.addDef(DebugCompUnitResIdReg);            // Result ID
+    MIB.addUse(VoidTyMI->getOperand(0).getReg()); // Result Type
+    MIB.addImm(static_cast<int64_t>(
+        SPIRV::InstructionSet::NonSemantic_Shader_DebugInfo_100)); // Set ID
+    MIB.addImm(SPIRV::NonSemanticExtInst::DebugCompilationUnit);
+    MIB.addUse(DebugInfoVersionReg);
+    MIB.addUse(DwarfVersionReg);
+    MIB.addUse(DebugSourceResIdReg);
+    MIB.addUse(SourceLanguageReg);
+    MIB.constrainAllUses(*TII, *TRI, *RBI);
+  }
+
+  return true;
 }
 
 bool SPIRVEmitNonSemanticDI::runOnMachineFunction(MachineFunction &MF) {
-  return false;
+  bool Res = false;
+  if (!IsGlobalDIEmitted) {
+    Res = emitGlobalDI(MF);
+    IsGlobalDIEmitted = true;
+  }
+  return Res;
 }

--- a/llvm/lib/Target/SPIRV/SPIRVModuleAnalysis.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVModuleAnalysis.cpp
@@ -910,6 +910,14 @@ void addInstrRequirements(const MachineInstr &MI,
       Reqs.addCapability(SPIRV::Capability::Float16Buffer);
     break;
   }
+  case SPIRV::OpExtInst: {
+    if (MI.getOperand(2).getImm() ==
+        static_cast<int64_t>(
+            SPIRV::InstructionSet::NonSemantic_Shader_DebugInfo_100)) {
+      Reqs.addExtension(SPIRV::Extension::SPV_KHR_non_semantic_info);
+    }
+    break;
+  }
   case SPIRV::OpBitReverse:
   case SPIRV::OpBitFieldInsert:
   case SPIRV::OpBitFieldSExtract:

--- a/llvm/lib/Target/SPIRV/SPIRVModuleAnalysis.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVModuleAnalysis.cpp
@@ -434,13 +434,10 @@ void SPIRVModuleAnalysis::processOtherInstrs(const Module &M) {
           static constexpr int64_t GlobalNonSemanticDITy[] = {
               NS::DebugSource, NS::DebugCompilationUnit};
           bool IsGlobalDI = false;
-          for (unsigned Idx = 0; Idx < std::size(GlobalNonSemanticDITy);
-               ++Idx) {
+          for (unsigned Idx = 0; Idx < std::size(GlobalNonSemanticDITy); ++Idx)
             IsGlobalDI |= Ins.getImm() == GlobalNonSemanticDITy[Idx];
-          }
-          if (IsGlobalDI) {
+          if (IsGlobalDI)
             collectOtherInstr(MI, MAI, SPIRV::MB_NonSemanticGlobalDI, IS);
-          }
         } else if (OpCode == SPIRV::OpName || OpCode == SPIRV::OpMemberName) {
           collectOtherInstr(MI, MAI, SPIRV::MB_DebugNames, IS);
         } else if (OpCode == SPIRV::OpEntryPoint) {

--- a/llvm/lib/Target/SPIRV/SPIRVModuleAnalysis.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVModuleAnalysis.cpp
@@ -21,7 +21,6 @@
 #include "SPIRVSubtarget.h"
 #include "SPIRVTargetMachine.h"
 #include "SPIRVUtils.h"
-#include "TargetInfo/SPIRVTargetInfo.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/CodeGen/MachineModuleInfo.h"
 #include "llvm/CodeGen/TargetPassConfig.h"
@@ -427,7 +426,22 @@ void SPIRVModuleAnalysis::processOtherInstrs(const Module &M) {
         if (MAI.getSkipEmission(&MI))
           continue;
         const unsigned OpCode = MI.getOpcode();
-        if (OpCode == SPIRV::OpName || OpCode == SPIRV::OpMemberName) {
+        if (OpCode == SPIRV::OpString) {
+          collectOtherInstr(MI, MAI, SPIRV::MB_DebugStrings, IS);
+        } else if (OpCode == SPIRV::OpExtInst) {
+          MachineOperand Ins = MI.getOperand(3);
+          namespace NS = SPIRV::NonSemanticExtInst;
+          static constexpr int64_t GlobalNonSemanticDITy[] = {
+              NS::DebugSource, NS::DebugCompilationUnit};
+          bool IsGlobalDI = false;
+          for (unsigned Idx = 0; Idx < std::size(GlobalNonSemanticDITy);
+               ++Idx) {
+            IsGlobalDI |= Ins.getImm() == GlobalNonSemanticDITy[Idx];
+          }
+          if (IsGlobalDI) {
+            collectOtherInstr(MI, MAI, SPIRV::MB_NonSemanticGlobalDI, IS);
+          }
+        } else if (OpCode == SPIRV::OpName || OpCode == SPIRV::OpMemberName) {
           collectOtherInstr(MI, MAI, SPIRV::MB_DebugNames, IS);
         } else if (OpCode == SPIRV::OpEntryPoint) {
           collectOtherInstr(MI, MAI, SPIRV::MB_EntryPoints, IS);

--- a/llvm/lib/Target/SPIRV/SPIRVModuleAnalysis.h
+++ b/llvm/lib/Target/SPIRV/SPIRVModuleAnalysis.h
@@ -20,7 +20,6 @@
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/SmallSet.h"
 #include "llvm/ADT/SmallVector.h"
-#include "llvm/ADT/StringMap.h"
 
 namespace llvm {
 class SPIRVSubtarget;
@@ -34,9 +33,11 @@ enum ModuleSectionType {
   MB_EntryPoints, // All OpEntryPoint instructions (if any).
   //  MB_ExecutionModes, MB_DebugSourceAndStrings,
   MB_DebugNames,           // All OpName and OpMemberName intrs.
+  MB_DebugStrings,         // All OpString intrs.
   MB_DebugModuleProcessed, // All OpModuleProcessed instructions.
   MB_Annotations,          // OpDecorate, OpMemberDecorate etc.
   MB_TypeConstVars,        // OpTypeXXX, OpConstantXXX, and global OpVariables.
+  MB_NonSemanticGlobalDI,  // OpExtInst with e.g. DebugSource, DebugTypeBasic.
   MB_ExtFuncDecls,         // OpFunction etc. to declare for external funcs.
   NUM_MODULE_SECTIONS      // Total number of sections requiring basic blocks.
 };

--- a/llvm/lib/Target/SPIRV/SPIRVTargetMachine.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVTargetMachine.cpp
@@ -115,6 +115,7 @@ public:
   void addOptimizedRegAlloc() override {}
 
   void addPostRegAlloc() override;
+  void addMachinePasses() override;
 
 private:
   const SPIRVTargetMachine &TM;
@@ -199,7 +200,6 @@ void SPIRVPassConfig::addPreLegalizeMachineIR() {
 bool SPIRVPassConfig::addLegalizeMachineIR() {
   addPass(new Legalizer());
   addPass(createSPIRVPostLegalizerPass());
-  addPass(createSPIRVEmitNonSemanticDIPass(&getTM<SPIRVTargetMachine>()));
   return false;
 }
 
@@ -207,6 +207,11 @@ bool SPIRVPassConfig::addLegalizeMachineIR() {
 bool SPIRVPassConfig::addRegBankSelect() {
   disablePass(&RegBankSelect::ID);
   return false;
+}
+
+void SPIRVPassConfig::addMachinePasses() {
+  TargetPassConfig::addMachinePasses();
+  addPass(createSPIRVEmitNonSemanticDIPass(&getTM<SPIRVTargetMachine>()));
 }
 
 namespace {

--- a/llvm/lib/Target/SPIRV/SPIRVTargetMachine.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVTargetMachine.cpp
@@ -199,7 +199,7 @@ void SPIRVPassConfig::addPreLegalizeMachineIR() {
 bool SPIRVPassConfig::addLegalizeMachineIR() {
   addPass(new Legalizer());
   addPass(createSPIRVPostLegalizerPass());
-  addPass(createSPIRVEmitNonSemanticDIPass());
+  addPass(createSPIRVEmitNonSemanticDIPass(&getTM<SPIRVTargetMachine>()));
   return false;
 }
 

--- a/llvm/lib/Target/SPIRV/SPIRVTargetMachine.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVTargetMachine.cpp
@@ -199,6 +199,7 @@ void SPIRVPassConfig::addPreLegalizeMachineIR() {
 bool SPIRVPassConfig::addLegalizeMachineIR() {
   addPass(new Legalizer());
   addPass(createSPIRVPostLegalizerPass());
+  addPass(createSPIRVEmitNonSemanticDIPass());
   return false;
 }
 

--- a/llvm/lib/Target/SPIRV/SPIRVTargetMachine.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVTargetMachine.cpp
@@ -115,7 +115,7 @@ public:
   void addOptimizedRegAlloc() override {}
 
   void addPostRegAlloc() override;
-  void addMachinePasses() override;
+  void addPreEmitPass() override;
 
 private:
   const SPIRVTargetMachine &TM;
@@ -209,8 +209,7 @@ bool SPIRVPassConfig::addRegBankSelect() {
   return false;
 }
 
-void SPIRVPassConfig::addMachinePasses() {
-  TargetPassConfig::addMachinePasses();
+void SPIRVPassConfig::addPreEmitPass() {
   addPass(createSPIRVEmitNonSemanticDIPass(&getTM<SPIRVTargetMachine>()));
 }
 

--- a/llvm/lib/Target/SPIRV/SPIRVTargetMachine.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVTargetMachine.cpp
@@ -209,8 +209,15 @@ bool SPIRVPassConfig::addRegBankSelect() {
   return false;
 }
 
+static cl::opt<bool> SPVEnableNonSemanticDI(
+    "spv-emit-nonsemantic-debug-info",
+    cl::desc("Emit SPIR-V NonSemantic.Shader.DebugInfo.100 instructions"),
+    cl::Optional, cl::init(false));
+
 void SPIRVPassConfig::addPreEmitPass() {
-  addPass(createSPIRVEmitNonSemanticDIPass(&getTM<SPIRVTargetMachine>()));
+  if (SPVEnableNonSemanticDI) {
+    addPass(createSPIRVEmitNonSemanticDIPass(&getTM<SPIRVTargetMachine>()));
+  }
 }
 
 namespace {

--- a/llvm/test/CodeGen/SPIRV/debug-info/basic-global-di.ll
+++ b/llvm/test/CodeGen/SPIRV/debug-info/basic-global-di.ll
@@ -1,0 +1,129 @@
+; RUN: llc -O0 -mtriple=spirv64-unknown-unknown %s -o - | FileCheck %s --check-prefix=CHECK-SPIRV
+
+source_filename = "example.c"
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-G1"
+target triple = "spir"
+
+%struct.A = type { i32, float }
+
+; CHECK-SPIRV: [[ext_inst_non_semantic:%[0-9]+]] = OpExtInstImport "NonSemantic.Shader.DebugInfo.100"
+; CHECK-SPIRV: [[filename_str:%[0-9]+]] = OpString "/AAAAAAAAAA/BBBBBBBB/CCCCCCCCC/example.c" 
+; CHECK-SPIRV-DAG: [[type_void:%[0-9]+]] = OpTypeVoid
+; CHECK-SPIRV-DAG: [[type_i32:%[0-9]+]] = OpTypeInt 32 0
+; CHECK-SPIRV-DAG: [[dwarf_version:%[0-9]+]] = OpConstant [[type_i32]] 5 
+; CHECK-SPIRV-DAG: [[debug_info_version:%[0-9]+]] = OpConstant [[type_i32]] 21 
+; CHECK-SPIRV-DAG: [[source_language:%[0-9]+]] = OpConstant [[type_i32]] 3 
+; CHECK-SPIRV: [[debug_source:%[0-9]+]] = OpExtInst [[type_void]] [[ext_inst_non_semantic]] DebugSource [[filename_str]]
+; CHECK-SPIRV: [[debug_compiation_unit:%[0-9]+]] = OpExtInst [[type_void]] [[ext_inst_non_semantic]] DebugCompilationUnit [[source_language]] [[dwarf_version]] [[debug_source]] [[debug_info_version]]
+
+; Function Attrs: convergent noinline norecurse nounwind optnone
+define dso_local spir_func i32 @bar(i32 noundef %n) #0 !dbg !8 {
+entry:
+  %n.addr = alloca i32, align 4
+  store i32 %n, ptr %n.addr, align 4
+    #dbg_declare(ptr %n.addr, !13, !DIExpression(DW_OP_constu, 0, DW_OP_swap, DW_OP_xderef), !14)
+  %0 = load i32, ptr %n.addr, align 4, !dbg !15
+  %1 = load i32, ptr %n.addr, align 4, !dbg !16
+  %mul = mul nsw i32 %0, %1, !dbg !17
+  %2 = load i32, ptr %n.addr, align 4, !dbg !18
+  %add = add nsw i32 %mul, %2, !dbg !19
+  ret i32 %add, !dbg !20
+}
+
+; Function Attrs: convergent noinline norecurse nounwind optnone
+define dso_local spir_func i32 @foo(i32 noundef %num, ptr addrspace(4) noundef %a) #0 !dbg !21 {
+entry:
+  %num.addr = alloca i32, align 4
+  %a.addr = alloca ptr addrspace(4), align 4
+  store i32 %num, ptr %num.addr, align 4
+    #dbg_declare(ptr %num.addr, !30, !DIExpression(DW_OP_constu, 0, DW_OP_swap, DW_OP_xderef), !31)
+  store ptr addrspace(4) %a, ptr %a.addr, align 4
+    #dbg_declare(ptr %a.addr, !32, !DIExpression(DW_OP_constu, 0, DW_OP_swap, DW_OP_xderef), !33)
+  %0 = load i32, ptr %num.addr, align 4, !dbg !34
+  %1 = load i32, ptr %num.addr, align 4, !dbg !35
+  %mul = mul nsw i32 %0, %1, !dbg !36
+  %2 = load ptr addrspace(4), ptr %a.addr, align 4, !dbg !37
+  %a1 = getelementptr inbounds %struct.A, ptr addrspace(4) %2, i32 0, i32 0, !dbg !38
+  %3 = load i32, ptr addrspace(4) %a1, align 4, !dbg !38
+  %mul2 = mul nsw i32 %mul, %3, !dbg !39
+  %conv = sitofp i32 %mul2 to float, !dbg !34
+  %4 = load ptr addrspace(4), ptr %a.addr, align 4, !dbg !40
+  %b = getelementptr inbounds %struct.A, ptr addrspace(4) %4, i32 0, i32 1, !dbg !41
+  %5 = load float, ptr addrspace(4) %b, align 4, !dbg !41
+  %6 = load i32, ptr %num.addr, align 4, !dbg !42
+  %call = call spir_func i32 @bar(i32 noundef %6) #2, !dbg !43
+  %conv4 = sitofp i32 %call to float, !dbg !43
+  %7 = call float @llvm.fmuladd.f32(float %conv, float %5, float %conv4), !dbg !44
+  %conv5 = fptosi float %7 to i32, !dbg !34
+  ret i32 %conv5, !dbg !45
+}
+
+; Function Attrs: nocallback nofree nosync nounwind speculatable willreturn memory(none)
+declare float @llvm.fmuladd.f32(float, float, float) #1
+
+; Function Attrs: convergent noinline norecurse nounwind optnone
+define dso_local spir_func void @zar() #0 !dbg !46 {
+entry:
+  ret void, !dbg !49
+}
+
+attributes #0 = { convergent noinline norecurse nounwind optnone "frame-pointer"="all" "no-trapping-math"="true" "stack-protector-buffer-size"="8" }
+attributes #1 = { nocallback nofree nosync nounwind speculatable willreturn memory(none) }
+attributes #2 = { convergent nounwind }
+
+!llvm.dbg.cu = !{!0}
+!llvm.module.flags = !{!2, !3, !4, !5}
+!opencl.ocl.version = !{!6}
+!opencl.spir.version = !{!6}
+!llvm.ident = !{!7}
+
+!0 = distinct !DICompileUnit(language: DW_LANG_OpenCL, file: !1, producer: "clang version 19.0.0git (fffffffffffffffffffffffffffffffffffffffff zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, splitDebugInlining: false, nameTableKind: None)
+!1 = !DIFile(filename: "example.c", directory: "/AAAAAAAAAA/BBBBBBBB/CCCCCCCCC", checksumkind: CSK_MD5, checksum: "ffffffffffffffffffffffffffffffff")
+!2 = !{i32 7, !"Dwarf Version", i32 5}
+!3 = !{i32 2, !"Debug Info Version", i32 3}
+!4 = !{i32 1, !"wchar_size", i32 4}
+!5 = !{i32 7, !"frame-pointer", i32 2}
+!6 = !{i32 3, i32 0}
+!7 = !{!"clang version 19.0.0git (fffffffffffffffffffffffffffffffffffffffff zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz)"}
+!8 = distinct !DISubprogram(name: "bar", scope: !1, file: !1, line: 6, type: !9, scopeLine: 6, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !12)
+!9 = !DISubroutineType(cc: DW_CC_LLVM_SpirFunction, types: !10)
+!10 = !{!11, !11}
+!11 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+!12 = !{}
+!13 = !DILocalVariable(name: "n", arg: 1, scope: !8, file: !1, line: 6, type: !11)
+!14 = !DILocation(line: 6, column: 13, scope: !8)
+!15 = !DILocation(line: 6, column: 25, scope: !8)
+!16 = !DILocation(line: 6, column: 29, scope: !8)
+!17 = !DILocation(line: 6, column: 27, scope: !8)
+!18 = !DILocation(line: 6, column: 33, scope: !8)
+!19 = !DILocation(line: 6, column: 31, scope: !8)
+!20 = !DILocation(line: 6, column: 18, scope: !8)
+!21 = distinct !DISubprogram(name: "foo", scope: !1, file: !1, line: 8, type: !22, scopeLine: 8, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !12)
+!22 = !DISubroutineType(cc: DW_CC_LLVM_SpirFunction, types: !23)
+!23 = !{!11, !11, !24}
+!24 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !25, size: 32, dwarfAddressSpace: 4)
+!25 = distinct !DICompositeType(tag: DW_TAG_structure_type, name: "A", file: !1, line: 1, size: 64, elements: !26)
+!26 = !{!27, !28}
+!27 = !DIDerivedType(tag: DW_TAG_member, name: "a", scope: !25, file: !1, line: 2, baseType: !11, size: 32)
+!28 = !DIDerivedType(tag: DW_TAG_member, name: "b", scope: !25, file: !1, line: 3, baseType: !29, size: 32, offset: 32)
+!29 = !DIBasicType(name: "float", size: 32, encoding: DW_ATE_float)
+!30 = !DILocalVariable(name: "num", arg: 1, scope: !21, file: !1, line: 8, type: !11)
+!31 = !DILocation(line: 8, column: 13, scope: !21)
+!32 = !DILocalVariable(name: "a", arg: 2, scope: !21, file: !1, line: 8, type: !24)
+!33 = !DILocation(line: 8, column: 28, scope: !21)
+!34 = !DILocation(line: 8, column: 40, scope: !21)
+!35 = !DILocation(line: 8, column: 46, scope: !21)
+!36 = !DILocation(line: 8, column: 44, scope: !21)
+!37 = !DILocation(line: 8, column: 52, scope: !21)
+!38 = !DILocation(line: 8, column: 55, scope: !21)
+!39 = !DILocation(line: 8, column: 50, scope: !21)
+!40 = !DILocation(line: 8, column: 59, scope: !21)
+!41 = !DILocation(line: 8, column: 62, scope: !21)
+!42 = !DILocation(line: 8, column: 70, scope: !21)
+!43 = !DILocation(line: 8, column: 66, scope: !21)
+!44 = !DILocation(line: 8, column: 64, scope: !21)
+!45 = !DILocation(line: 8, column: 33, scope: !21)
+!46 = distinct !DISubprogram(name: "zar", scope: !1, file: !1, line: 10, type: !47, scopeLine: 10, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0)
+!47 = !DISubroutineType(cc: DW_CC_LLVM_SpirFunction, types: !48)
+!48 = !{null}
+!49 = !DILocation(line: 10, column: 13, scope: !46)

--- a/llvm/test/CodeGen/SPIRV/debug-info/basic-global-di.ll
+++ b/llvm/test/CodeGen/SPIRV/debug-info/basic-global-di.ll
@@ -1,10 +1,15 @@
+; RUN: llc --print-after=spirv-nonsemantic-debug-info -O0 -mtriple=spirv64-unknown-unknown %s -o - 2>&1 | FileCheck %s --check-prefix=CHECK-MIR
 ; RUN: llc -O0 -mtriple=spirv64-unknown-unknown %s -o - | FileCheck %s --check-prefix=CHECK-SPIRV
+; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv64-unknown-unknown %s -o - -filetype=obj | spirv-val %}
 
-source_filename = "example.c"
-target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-G1"
-target triple = "spir"
-
-%struct.A = type { i32, float }
+; CHECK-MIR-DAG: [[type_void:%[0-9]+\:type]] = OpTypeVoid
+; CHECK-MIR-DAG: [[type_i32:%[0-9]+\:type\(s32\)]] = OpTypeInt 32, 0
+; CHECK-MIR-DAG: [[dwarf_version:%[0-9]+\:id\(s32\)]] = OpConstantI [[type_i32]], 5
+; CHECK-MIR-DAG: [[source_language:%[0-9]+\:id\(s32\)]] = OpConstantI [[type_i32]], 3
+; CHECK-MIR-DAG: [[debug_info_version:%[0-9]+\:id\(s32\)]] = OpConstantI [[type_i32]], 21
+; CHECK-MIR-DAG: [[filename_str:%[0-9]+\:id\(s32\)]] = OpString 1094795567, 1094795585, 792805697, 1111638594, 1111638594, 1128481583, 1128481603, 1697596227, 1886216568, 1663985004, 0 
+; CHECK-MIR-DAG: [[debug_source:%[0-9]+\:id\(s32\)]] = OpExtInst [[type_void]], 3, 35, [[filename_str]]
+; CHECK-MIR-DAG: [[debug_compilation_unit:%[0-9]+\:id\(s32\)]] = OpExtInst [[type_void]], 3, 1, [[source_language]], [[dwarf_version]], [[debug_source]], [[debug_info_version]]
 
 ; CHECK-SPIRV: [[ext_inst_non_semantic:%[0-9]+]] = OpExtInstImport "NonSemantic.Shader.DebugInfo.100"
 ; CHECK-SPIRV: [[filename_str:%[0-9]+]] = OpString "/AAAAAAAAAA/BBBBBBBB/CCCCCCCCC/example.c" 
@@ -16,114 +21,22 @@ target triple = "spir"
 ; CHECK-SPIRV: [[debug_source:%[0-9]+]] = OpExtInst [[type_void]] [[ext_inst_non_semantic]] DebugSource [[filename_str]]
 ; CHECK-SPIRV: [[debug_compiation_unit:%[0-9]+]] = OpExtInst [[type_void]] [[ext_inst_non_semantic]] DebugCompilationUnit [[source_language]] [[dwarf_version]] [[debug_source]] [[debug_info_version]]
 
-; Function Attrs: convergent noinline norecurse nounwind optnone
-define dso_local spir_func i32 @bar(i32 noundef %n) #0 !dbg !8 {
+define spir_func void @foo() {
 entry:
-  %n.addr = alloca i32, align 4
-  store i32 %n, ptr %n.addr, align 4
-    #dbg_declare(ptr %n.addr, !13, !DIExpression(DW_OP_constu, 0, DW_OP_swap, DW_OP_xderef), !14)
-  %0 = load i32, ptr %n.addr, align 4, !dbg !15
-  %1 = load i32, ptr %n.addr, align 4, !dbg !16
-  %mul = mul nsw i32 %0, %1, !dbg !17
-  %2 = load i32, ptr %n.addr, align 4, !dbg !18
-  %add = add nsw i32 %mul, %2, !dbg !19
-  ret i32 %add, !dbg !20
+  ret void
 }
 
-; Function Attrs: convergent noinline norecurse nounwind optnone
-define dso_local spir_func i32 @foo(i32 noundef %num, ptr addrspace(4) noundef %a) #0 !dbg !21 {
+define spir_func void @bar() {
 entry:
-  %num.addr = alloca i32, align 4
-  %a.addr = alloca ptr addrspace(4), align 4
-  store i32 %num, ptr %num.addr, align 4
-    #dbg_declare(ptr %num.addr, !30, !DIExpression(DW_OP_constu, 0, DW_OP_swap, DW_OP_xderef), !31)
-  store ptr addrspace(4) %a, ptr %a.addr, align 4
-    #dbg_declare(ptr %a.addr, !32, !DIExpression(DW_OP_constu, 0, DW_OP_swap, DW_OP_xderef), !33)
-  %0 = load i32, ptr %num.addr, align 4, !dbg !34
-  %1 = load i32, ptr %num.addr, align 4, !dbg !35
-  %mul = mul nsw i32 %0, %1, !dbg !36
-  %2 = load ptr addrspace(4), ptr %a.addr, align 4, !dbg !37
-  %a1 = getelementptr inbounds %struct.A, ptr addrspace(4) %2, i32 0, i32 0, !dbg !38
-  %3 = load i32, ptr addrspace(4) %a1, align 4, !dbg !38
-  %mul2 = mul nsw i32 %mul, %3, !dbg !39
-  %conv = sitofp i32 %mul2 to float, !dbg !34
-  %4 = load ptr addrspace(4), ptr %a.addr, align 4, !dbg !40
-  %b = getelementptr inbounds %struct.A, ptr addrspace(4) %4, i32 0, i32 1, !dbg !41
-  %5 = load float, ptr addrspace(4) %b, align 4, !dbg !41
-  %6 = load i32, ptr %num.addr, align 4, !dbg !42
-  %call = call spir_func i32 @bar(i32 noundef %6) #2, !dbg !43
-  %conv4 = sitofp i32 %call to float, !dbg !43
-  %7 = call float @llvm.fmuladd.f32(float %conv, float %5, float %conv4), !dbg !44
-  %conv5 = fptosi float %7 to i32, !dbg !34
-  ret i32 %conv5, !dbg !45
+  ret void
 }
-
-; Function Attrs: nocallback nofree nosync nounwind speculatable willreturn memory(none)
-declare float @llvm.fmuladd.f32(float, float, float) #1
-
-; Function Attrs: convergent noinline norecurse nounwind optnone
-define dso_local spir_func void @zar() #0 !dbg !46 {
-entry:
-  ret void, !dbg !49
-}
-
-attributes #0 = { convergent noinline norecurse nounwind optnone "frame-pointer"="all" "no-trapping-math"="true" "stack-protector-buffer-size"="8" }
-attributes #1 = { nocallback nofree nosync nounwind speculatable willreturn memory(none) }
-attributes #2 = { convergent nounwind }
 
 !llvm.dbg.cu = !{!0}
 !llvm.module.flags = !{!2, !3, !4, !5}
-!opencl.ocl.version = !{!6}
-!opencl.spir.version = !{!6}
-!llvm.ident = !{!7}
 
-!0 = distinct !DICompileUnit(language: DW_LANG_OpenCL, file: !1, producer: "clang version 19.0.0git (fffffffffffffffffffffffffffffffffffffffff zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, splitDebugInlining: false, nameTableKind: None)
-!1 = !DIFile(filename: "example.c", directory: "/AAAAAAAAAA/BBBBBBBB/CCCCCCCCC", checksumkind: CSK_MD5, checksum: "ffffffffffffffffffffffffffffffff")
+!0 = distinct !DICompileUnit(language: DW_LANG_OpenCL, file: !1, producer: "clang version XX.X.XXXX (FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, splitDebugInlining: false, nameTableKind: None)
+!1 = !DIFile(filename: "example.c", directory: "/AAAAAAAAAA/BBBBBBBB/CCCCCCCCC", checksumkind: CSK_MD5, checksum: "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF")
 !2 = !{i32 7, !"Dwarf Version", i32 5}
 !3 = !{i32 2, !"Debug Info Version", i32 3}
 !4 = !{i32 1, !"wchar_size", i32 4}
 !5 = !{i32 7, !"frame-pointer", i32 2}
-!6 = !{i32 3, i32 0}
-!7 = !{!"clang version 19.0.0git (fffffffffffffffffffffffffffffffffffffffff zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz)"}
-!8 = distinct !DISubprogram(name: "bar", scope: !1, file: !1, line: 6, type: !9, scopeLine: 6, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !12)
-!9 = !DISubroutineType(cc: DW_CC_LLVM_SpirFunction, types: !10)
-!10 = !{!11, !11}
-!11 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
-!12 = !{}
-!13 = !DILocalVariable(name: "n", arg: 1, scope: !8, file: !1, line: 6, type: !11)
-!14 = !DILocation(line: 6, column: 13, scope: !8)
-!15 = !DILocation(line: 6, column: 25, scope: !8)
-!16 = !DILocation(line: 6, column: 29, scope: !8)
-!17 = !DILocation(line: 6, column: 27, scope: !8)
-!18 = !DILocation(line: 6, column: 33, scope: !8)
-!19 = !DILocation(line: 6, column: 31, scope: !8)
-!20 = !DILocation(line: 6, column: 18, scope: !8)
-!21 = distinct !DISubprogram(name: "foo", scope: !1, file: !1, line: 8, type: !22, scopeLine: 8, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !12)
-!22 = !DISubroutineType(cc: DW_CC_LLVM_SpirFunction, types: !23)
-!23 = !{!11, !11, !24}
-!24 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !25, size: 32, dwarfAddressSpace: 4)
-!25 = distinct !DICompositeType(tag: DW_TAG_structure_type, name: "A", file: !1, line: 1, size: 64, elements: !26)
-!26 = !{!27, !28}
-!27 = !DIDerivedType(tag: DW_TAG_member, name: "a", scope: !25, file: !1, line: 2, baseType: !11, size: 32)
-!28 = !DIDerivedType(tag: DW_TAG_member, name: "b", scope: !25, file: !1, line: 3, baseType: !29, size: 32, offset: 32)
-!29 = !DIBasicType(name: "float", size: 32, encoding: DW_ATE_float)
-!30 = !DILocalVariable(name: "num", arg: 1, scope: !21, file: !1, line: 8, type: !11)
-!31 = !DILocation(line: 8, column: 13, scope: !21)
-!32 = !DILocalVariable(name: "a", arg: 2, scope: !21, file: !1, line: 8, type: !24)
-!33 = !DILocation(line: 8, column: 28, scope: !21)
-!34 = !DILocation(line: 8, column: 40, scope: !21)
-!35 = !DILocation(line: 8, column: 46, scope: !21)
-!36 = !DILocation(line: 8, column: 44, scope: !21)
-!37 = !DILocation(line: 8, column: 52, scope: !21)
-!38 = !DILocation(line: 8, column: 55, scope: !21)
-!39 = !DILocation(line: 8, column: 50, scope: !21)
-!40 = !DILocation(line: 8, column: 59, scope: !21)
-!41 = !DILocation(line: 8, column: 62, scope: !21)
-!42 = !DILocation(line: 8, column: 70, scope: !21)
-!43 = !DILocation(line: 8, column: 66, scope: !21)
-!44 = !DILocation(line: 8, column: 64, scope: !21)
-!45 = !DILocation(line: 8, column: 33, scope: !21)
-!46 = distinct !DISubprogram(name: "zar", scope: !1, file: !1, line: 10, type: !47, scopeLine: 10, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0)
-!47 = !DISubroutineType(cc: DW_CC_LLVM_SpirFunction, types: !48)
-!48 = !{null}
-!49 = !DILocation(line: 10, column: 13, scope: !46)

--- a/llvm/test/CodeGen/SPIRV/debug-info/basic-global-di.ll
+++ b/llvm/test/CodeGen/SPIRV/debug-info/basic-global-di.ll
@@ -5,9 +5,9 @@
 
 ; CHECK-MIR-DAG: [[type_void:%[0-9]+\:type]] = OpTypeVoid
 ; CHECK-MIR-DAG: [[type_i32:%[0-9]+\:type\(s32\)]] = OpTypeInt 32, 0
-; CHECK-MIR-DAG: [[dwarf_version:%[0-9]+\:id\(s32\)]] = OpConstantI [[type_i32]], 5
-; CHECK-MIR-DAG: [[source_language:%[0-9]+\:id\(s32\)]] = OpConstantI [[type_i32]], 3
-; CHECK-MIR-DAG: [[debug_info_version:%[0-9]+\:id\(s32\)]] = OpConstantI [[type_i32]], 21
+; CHECK-MIR-DAG: [[dwarf_version:%[0-9]+\:iid\(s32\)]] = OpConstantI [[type_i32]], 5
+; CHECK-MIR-DAG: [[source_language:%[0-9]+\:iid\(s32\)]] = OpConstantI [[type_i32]], 3
+; CHECK-MIR-DAG: [[debug_info_version:%[0-9]+\:iid\(s32\)]] = OpConstantI [[type_i32]], 21
 ; CHECK-MIR-DAG: [[filename_str:%[0-9]+\:id\(s32\)]] = OpString 1094795567, 1094795585, 792805697, 1111638594, 1111638594, 1128481583, 1128481603, 1697596227, 1886216568, 1663985004, 0
 ; CHECK-MIR-DAG: [[debug_source:%[0-9]+\:id\(s32\)]] = OpExtInst [[type_void]], 3, 35, [[filename_str]]
 ; CHECK-MIR-DAG: [[debug_compilation_unit:%[0-9]+\:id\(s32\)]] = OpExtInst [[type_void]], 3, 1, [[source_language]], [[dwarf_version]], [[debug_source]], [[debug_info_version]]

--- a/llvm/test/CodeGen/SPIRV/debug-info/basic-global-di.ll
+++ b/llvm/test/CodeGen/SPIRV/debug-info/basic-global-di.ll
@@ -1,5 +1,6 @@
-; RUN: llc --spirv-ext=+SPV_KHR_non_semantic_info --print-after=spirv-nonsemantic-debug-info -O0 -mtriple=spirv64-unknown-unknown %s -o - 2>&1 | FileCheck %s --check-prefix=CHECK-MIR
-; RUN: llc --spirv-ext=+SPV_KHR_non_semantic_info -O0 -mtriple=spirv64-unknown-unknown %s -o - | FileCheck %s --check-prefix=CHECK-SPIRV
+; RUN: llc --spv-emit-nonsemantic-debug-info --spirv-ext=+SPV_KHR_non_semantic_info --print-after=spirv-nonsemantic-debug-info -O0 -mtriple=spirv64-unknown-unknown %s -o - 2>&1 | FileCheck %s --check-prefix=CHECK-MIR
+; RUN: llc --spv-emit-nonsemantic-debug-info --spirv-ext=+SPV_KHR_non_semantic_info -O0 -mtriple=spirv64-unknown-unknown %s -o - | FileCheck %s --check-prefix=CHECK-SPIRV
+; RUN: llc -O0 -mtriple=spirv64-unknown-unknown --spirv-ext=+SPV_KHR_non_semantic_info %s -o - | FileCheck %s --check-prefix=CHECK-OPTION 
 ; RUN: %if spirv-tools %{ llc --spirv-ext=+SPV_KHR_non_semantic_info -O0 -mtriple=spirv64-unknown-unknown %s -o - -filetype=obj | spirv-val %}
 
 ; CHECK-MIR-DAG: [[type_void:%[0-9]+\:type]] = OpTypeVoid
@@ -7,19 +8,22 @@
 ; CHECK-MIR-DAG: [[dwarf_version:%[0-9]+\:id\(s32\)]] = OpConstantI [[type_i32]], 5
 ; CHECK-MIR-DAG: [[source_language:%[0-9]+\:id\(s32\)]] = OpConstantI [[type_i32]], 3
 ; CHECK-MIR-DAG: [[debug_info_version:%[0-9]+\:id\(s32\)]] = OpConstantI [[type_i32]], 21
-; CHECK-MIR-DAG: [[filename_str:%[0-9]+\:id\(s32\)]] = OpString 1094795567, 1094795585, 792805697, 1111638594, 1111638594, 1128481583, 1128481603, 1697596227, 1886216568, 1663985004, 0 
+; CHECK-MIR-DAG: [[filename_str:%[0-9]+\:id\(s32\)]] = OpString 1094795567, 1094795585, 792805697, 1111638594, 1111638594, 1128481583, 1128481603, 1697596227, 1886216568, 1663985004, 0
 ; CHECK-MIR-DAG: [[debug_source:%[0-9]+\:id\(s32\)]] = OpExtInst [[type_void]], 3, 35, [[filename_str]]
 ; CHECK-MIR-DAG: [[debug_compilation_unit:%[0-9]+\:id\(s32\)]] = OpExtInst [[type_void]], 3, 1, [[source_language]], [[dwarf_version]], [[debug_source]], [[debug_info_version]]
 
 ; CHECK-SPIRV: [[ext_inst_non_semantic:%[0-9]+]] = OpExtInstImport "NonSemantic.Shader.DebugInfo.100"
-; CHECK-SPIRV: [[filename_str:%[0-9]+]] = OpString "/AAAAAAAAAA/BBBBBBBB/CCCCCCCCC/example.c" 
+; CHECK-SPIRV: [[filename_str:%[0-9]+]] = OpString "/AAAAAAAAAA/BBBBBBBB/CCCCCCCCC/example.c"
 ; CHECK-SPIRV-DAG: [[type_void:%[0-9]+]] = OpTypeVoid
 ; CHECK-SPIRV-DAG: [[type_i32:%[0-9]+]] = OpTypeInt 32 0
-; CHECK-SPIRV-DAG: [[dwarf_version:%[0-9]+]] = OpConstant [[type_i32]] 5 
-; CHECK-SPIRV-DAG: [[debug_info_version:%[0-9]+]] = OpConstant [[type_i32]] 21 
-; CHECK-SPIRV-DAG: [[source_language:%[0-9]+]] = OpConstant [[type_i32]] 3 
+; CHECK-SPIRV-DAG: [[dwarf_version:%[0-9]+]] = OpConstant [[type_i32]] 5
+; CHECK-SPIRV-DAG: [[debug_info_version:%[0-9]+]] = OpConstant [[type_i32]] 21
+; CHECK-SPIRV-DAG: [[source_language:%[0-9]+]] = OpConstant [[type_i32]] 3
 ; CHECK-SPIRV: [[debug_source:%[0-9]+]] = OpExtInst [[type_void]] [[ext_inst_non_semantic]] DebugSource [[filename_str]]
 ; CHECK-SPIRV: [[debug_compiation_unit:%[0-9]+]] = OpExtInst [[type_void]] [[ext_inst_non_semantic]] DebugCompilationUnit [[source_language]] [[dwarf_version]] [[debug_source]] [[debug_info_version]]
+
+; CHECK-OPTION-NOT: OpExtInstImport "NonSemantic.Shader.DebugInfo.100"
+; CHECK-OPTION-NOT: OpString "/AAAAAAAAAA/BBBBBBBB/CCCCCCCCC/example.c"
 
 define spir_func void @foo() {
 entry:

--- a/llvm/test/CodeGen/SPIRV/debug-info/basic-global-di.ll
+++ b/llvm/test/CodeGen/SPIRV/debug-info/basic-global-di.ll
@@ -1,6 +1,6 @@
-; RUN: llc --spv-emit-nonsemantic-debug-info --spirv-ext=+SPV_KHR_non_semantic_info --print-after=spirv-nonsemantic-debug-info -O0 -mtriple=spirv64-unknown-unknown %s -o - 2>&1 | FileCheck %s --check-prefix=CHECK-MIR
-; RUN: llc --spv-emit-nonsemantic-debug-info --spirv-ext=+SPV_KHR_non_semantic_info -O0 -mtriple=spirv64-unknown-unknown %s -o - | FileCheck %s --check-prefix=CHECK-SPIRV
-; RUN: llc -O0 -mtriple=spirv64-unknown-unknown --spirv-ext=+SPV_KHR_non_semantic_info %s -o - | FileCheck %s --check-prefix=CHECK-OPTION 
+; RUN: llc --verify-machineinstrs --spv-emit-nonsemantic-debug-info --spirv-ext=+SPV_KHR_non_semantic_info --print-after=spirv-nonsemantic-debug-info -O0 -mtriple=spirv64-unknown-unknown %s -o - 2>&1 | FileCheck %s --check-prefix=CHECK-MIR
+; RUN: llc --verify-machineinstrs --spv-emit-nonsemantic-debug-info --spirv-ext=+SPV_KHR_non_semantic_info -O0 -mtriple=spirv64-unknown-unknown %s -o - | FileCheck %s --check-prefix=CHECK-SPIRV
+; RUN: llc --verify-machineinstrs -O0 -mtriple=spirv64-unknown-unknown --spirv-ext=+SPV_KHR_non_semantic_info %s -o - | FileCheck %s --check-prefix=CHECK-OPTION 
 ; RUN: %if spirv-tools %{ llc --spirv-ext=+SPV_KHR_non_semantic_info -O0 -mtriple=spirv64-unknown-unknown %s -o - -filetype=obj | spirv-val %}
 
 ; CHECK-MIR-DAG: [[type_void:%[0-9]+\:type]] = OpTypeVoid

--- a/llvm/test/CodeGen/SPIRV/debug-info/basic-global-di.ll
+++ b/llvm/test/CodeGen/SPIRV/debug-info/basic-global-di.ll
@@ -1,6 +1,6 @@
-; RUN: llc --print-after=spirv-nonsemantic-debug-info -O0 -mtriple=spirv64-unknown-unknown %s -o - 2>&1 | FileCheck %s --check-prefix=CHECK-MIR
-; RUN: llc -O0 -mtriple=spirv64-unknown-unknown %s -o - | FileCheck %s --check-prefix=CHECK-SPIRV
-; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv64-unknown-unknown %s -o - -filetype=obj | spirv-val %}
+; RUN: llc --spirv-ext=+SPV_KHR_non_semantic_info --print-after=spirv-nonsemantic-debug-info -O0 -mtriple=spirv64-unknown-unknown %s -o - 2>&1 | FileCheck %s --check-prefix=CHECK-MIR
+; RUN: llc --spirv-ext=+SPV_KHR_non_semantic_info -O0 -mtriple=spirv64-unknown-unknown %s -o - | FileCheck %s --check-prefix=CHECK-SPIRV
+; RUN: %if spirv-tools %{ llc --spirv-ext=+SPV_KHR_non_semantic_info -O0 -mtriple=spirv64-unknown-unknown %s -o - -filetype=obj | spirv-val %}
 
 ; CHECK-MIR-DAG: [[type_void:%[0-9]+\:type]] = OpTypeVoid
 ; CHECK-MIR-DAG: [[type_i32:%[0-9]+\:type\(s32\)]] = OpTypeInt 32, 0

--- a/llvm/test/CodeGen/SPIRV/debug-info/basic-global-di.ll
+++ b/llvm/test/CodeGen/SPIRV/debug-info/basic-global-di.ll
@@ -4,10 +4,10 @@
 ; RUN: %if spirv-tools %{ llc --spirv-ext=+SPV_KHR_non_semantic_info -O0 -mtriple=spirv64-unknown-unknown %s -o - -filetype=obj | spirv-val %}
 
 ; CHECK-MIR-DAG: [[type_void:%[0-9]+\:type]] = OpTypeVoid
-; CHECK-MIR-DAG: [[type_i32:%[0-9]+\:type\(s32\)]] = OpTypeInt 32, 0
-; CHECK-MIR-DAG: [[dwarf_version:%[0-9]+\:iid\(s32\)]] = OpConstantI [[type_i32]], 5
-; CHECK-MIR-DAG: [[source_language:%[0-9]+\:iid\(s32\)]] = OpConstantI [[type_i32]], 3
-; CHECK-MIR-DAG: [[debug_info_version:%[0-9]+\:iid\(s32\)]] = OpConstantI [[type_i32]], 21
+; CHECK-MIR-DAG: [[type_i64:%[0-9]+\:type\(s64\)]] = OpTypeInt 32, 0
+; CHECK-MIR-DAG: [[dwarf_version:%[0-9]+\:iid\(s32\)]] = OpConstantI [[type_i64]], 5
+; CHECK-MIR-DAG: [[source_language:%[0-9]+\:iid\(s32\)]] = OpConstantI [[type_i64]], 3
+; CHECK-MIR-DAG: [[debug_info_version:%[0-9]+\:iid\(s32\)]] = OpConstantI [[type_i64]], 21
 ; CHECK-MIR-DAG: [[filename_str:%[0-9]+\:id\(s32\)]] = OpString 1094795567, 1094795585, 792805697, 1111638594, 1111638594, 1128481583, 1128481603, 1697596227, 1886216568, 1663985004, 0
 ; CHECK-MIR-DAG: [[debug_source:%[0-9]+\:id\(s32\)]] = OpExtInst [[type_void]], 3, 35, [[filename_str]]
 ; CHECK-MIR-DAG: [[debug_compilation_unit:%[0-9]+\:id\(s32\)]] = OpExtInst [[type_void]], 3, 1, [[source_language]], [[dwarf_version]], [[debug_source]], [[debug_info_version]]


### PR DESCRIPTION
This commit introduces emission of DebugSource, DebugCompileUnit from NonSemantic.Shader.DebugInfo.100 and required OpString with filename.
NonSemantic.Shader.DebugInfo.100 is divided, following DWARF into two main concepts – emitting DIE and Line.
In DWARF .debug_abbriev and .debug_info sections are responsible for emitting tree with information (DEIs) about e.g. types, compilation unit. Corresponding to that in NonSemantic.Shader.DebugInfo.100 have instructions like DebugSource, DebugCompileUnit etc. which preforms same role in SPIR-V file. The difference is in fact that in SPIR-V there are no sections but logical layout which forces order of the instruction emission.
The NonSemantic.Shader.DebugInfo.100 requires for this type of global information to be emitted after OpTypeXXX and OpConstantXXX instructions.
One of the goals was to minimize changes and interaction with SPIRVModuleAnalysis as possible which current commit achieves by emitting it’s instructions directly into MachineFunction.
The possibility of duplicates are mitigated by guard inside pass which emits the global information only once in one function.
By that method duplicates don’t have chance to be emitted.
From that point, adding new debug global instructions should be straightforward.