### PR TITLE
[Flang][OpenMP] Use InsertionGuard in DataSharingProcessor

### DIFF
--- a/flang/lib/Lower/OpenMP/DataSharingProcessor.cpp
+++ b/flang/lib/Lower/OpenMP/DataSharingProcessor.cpp
@@ -72,11 +72,8 @@ void DataSharingProcessor::processStep2(mlir::Operation *op, bool isLoop) {
     firOpBuilder.setInsertionPointAfter(op);
     insertDeallocs();
   } else {
-    // insert dummy instruction to mark the insertion position
-    mlir::Value undefMarker = firOpBuilder.create<fir::UndefOp>(
-        op->getLoc(), firOpBuilder.getIndexType());
+    mlir::OpBuilder::InsertionGuard guard(firOpBuilder);
     insertDeallocs();
-    firOpBuilder.setInsertionPointAfter(undefMarker.getDefiningOp());
   }
 }
 


### PR DESCRIPTION
This patch removes the introduction of `fir.undef` operations as a way to keep track of insertion points inside of the `DataSharingProcessor`, and it replaces them with an `InsertionGuard` to avoid creating such operations inside of loop wrappers.

Leaving any `fir.undef` operation inside of a loop wrapper would result in a verifier error, since they enforce strict requirements on the contents of their code regions.