### PR TITLE
[Flang][OpenMP] Prevent allocas from being inserted into loop wrappers

### DIFF
--- a/flang/lib/Lower/OpenMP/DataSharingProcessor.cpp
+++ b/flang/lib/Lower/OpenMP/DataSharingProcessor.cpp
@@ -72,11 +72,8 @@ void DataSharingProcessor::processStep2(mlir::Operation *op, bool isLoop) {
     firOpBuilder.setInsertionPointAfter(op);
     insertDeallocs();
   } else {
-    // insert dummy instruction to mark the insertion position
-    mlir::Value undefMarker = firOpBuilder.create<fir::UndefOp>(
-        op->getLoc(), firOpBuilder.getIndexType());
+    mlir::OpBuilder::InsertionGuard guard(firOpBuilder);
     insertDeallocs();
-    firOpBuilder.setInsertionPointAfter(undefMarker.getDefiningOp());
   }
 }
 


### PR DESCRIPTION
This patch updates the `FirOpBuilder::getAllocaBlock()` method to avoid returning blocks which are part of a region owned by a loop wrapper operation.

This avoids introducing `fir.alloca` operations inside of loop wrappers, which would cause verifier errors due to strict restrictions on their allowed contents. These allocations will be created in the entry block of the first non-loop wrapper parent region.