### PR TITLE
[lldb] Make variant formatter work with libstdc++-14

### DIFF
--- a/lldb/examples/synthetic/gnu_libstdcpp.py
+++ b/lldb/examples/synthetic/gnu_libstdcpp.py
@@ -915,7 +915,7 @@ def VariantSummaryProvider(valobj, dict):
         return " No Value"
 
     # Strip references and typedefs.
-    variant_type = raw_obj.GetType().GetCanonicalType().GetDereferencedType();
+    variant_type = raw_obj.GetType().GetCanonicalType().GetDereferencedType()
     template_arg_count = variant_type.GetNumberOfTemplateArguments()
 
     # Invalid index can happen when the variant is not initialized yet.

--- a/lldb/examples/synthetic/gnu_libstdcpp.py
+++ b/lldb/examples/synthetic/gnu_libstdcpp.py
@@ -914,12 +914,15 @@ def VariantSummaryProvider(valobj, dict):
     if index == npos_value:
         return " No Value"
 
+    # Strip references and typedefs.
+    variant_type = raw_obj.GetType().GetCanonicalType().GetDereferencedType();
+    template_arg_count = variant_type.GetNumberOfTemplateArguments()
+
     # Invalid index can happen when the variant is not initialized yet.
-    template_arg_count = data_obj.GetType().GetNumberOfTemplateArguments()
     if index >= template_arg_count:
         return " <Invalid>"
 
-    active_type = data_obj.GetType().GetTemplateArgumentType(index)
+    active_type = variant_type.GetTemplateArgumentType(index)
     return f" Active Type = {active_type.GetDisplayTypeName()} "
 
 

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libstdcpp/variant/TestDataFormatterLibStdcxxVariant.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libstdcpp/variant/TestDataFormatterLibStdcxxVariant.py
@@ -22,16 +22,16 @@ class LibStdcxxVariantDataFormatterTestCase(TestBase):
         lldbutil.continue_to_breakpoint(self.process, bkpt)
 
         for name in ["v1", "v1_typedef"]:
-          self.expect(
-              "frame variable " + name,
-              substrs=[name + " =  Active Type = int  {", "Value = 12", "}"],
-          )
+            self.expect(
+                "frame variable " + name,
+                substrs=[name + " =  Active Type = int  {", "Value = 12", "}"],
+            )
 
         for name in ["v1_ref", "v1_typedef_ref"]:
-          self.expect(
-              "frame variable " + name,
-              substrs=[name + " =  Active Type = int : {", "Value = 12", "}"],
-          )
+            self.expect(
+                "frame variable " + name,
+                substrs=[name + " =  Active Type = int : {", "Value = 12", "}"],
+            )
 
         self.expect(
             "frame variable v_v1",

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libstdcpp/variant/TestDataFormatterLibStdcxxVariant.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libstdcpp/variant/TestDataFormatterLibStdcxxVariant.py
@@ -21,15 +21,17 @@ class LibStdcxxVariantDataFormatterTestCase(TestBase):
 
         lldbutil.continue_to_breakpoint(self.process, bkpt)
 
-        self.expect(
-            "frame variable v1",
-            substrs=["v1 =  Active Type = int  {", "Value = 12", "}"],
-        )
+        for name in ["v1", "v1_typedef"]:
+          self.expect(
+              "frame variable " + name,
+              substrs=[name + " =  Active Type = int  {", "Value = 12", "}"],
+          )
 
-        self.expect(
-            "frame variable v1_ref",
-            substrs=["v1_ref =  Active Type = int : {", "Value = 12", "}"],
-        )
+        for name in ["v1_ref", "v1_typedef_ref"]:
+          self.expect(
+              "frame variable " + name,
+              substrs=[name + " =  Active Type = int : {", "Value = 12", "}"],
+          )
 
         self.expect(
             "frame variable v_v1",

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libstdcpp/variant/main.cpp
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libstdcpp/variant/main.cpp
@@ -14,6 +14,10 @@ int main() {
 
   std::variant<int, double, char> v1;
   std::variant<int, double, char> &v1_ref = v1;
+  using V1_typedef = std::variant<int, double, char>;
+  V1_typedef v1_typedef;
+  V1_typedef &v1_typedef_ref = v1_typedef;
+
   std::variant<int, double, char> v2;
   std::variant<int, double, char> v3;
   std::variant<std::variant<int, double, char>> v_v1;
@@ -43,6 +47,7 @@ int main() {
       v_many_types_no_value;
 
   v1 = 12; // v contains int
+  v1_typedef = v1;
   v_v1 = v1;
   int i = std::get<int>(v1);
   printf("%d\n", i); // break here


### PR DESCRIPTION
In this version the internal data member has grown an additional template parameter (bool), which was throwing the summary provider off.

This patch uses the type of the entire variant object. This is part of the API/ABI, so it should be more stable, but it means we have to explicitly strip typedefs and references to get to the interesting bits, which is why I've extended the test case with examples of those.