### PR TITLE
[llvm-cov] Option to ignore hash mismatches for non-emitted symbols

### DIFF
--- a/llvm/include/llvm/ProfileData/Coverage/CoverageMapping.h
+++ b/llvm/include/llvm/ProfileData/Coverage/CoverageMapping.h
@@ -973,7 +973,8 @@ public:
        vfs::FileSystem &FS, ArrayRef<StringRef> Arches = std::nullopt,
        StringRef CompilationDir = "",
        const object::BuildIDFetcher *BIDFetcher = nullptr,
-       bool CheckBinaryIDs = false);
+       bool CheckBinaryIDs = false,
+       bool IgnoreEmptyHashMismatches = false);
 
   /// The number of functions that couldn't have their profiles mapped.
   ///

--- a/llvm/include/llvm/ProfileData/InstrProfReader.h
+++ b/llvm/include/llvm/ProfileData/InstrProfReader.h
@@ -703,6 +703,9 @@ private:
   // Index to the current record in the record array.
   unsigned RecordIndex = 0;
 
+  // Flag to ignore empty (zero-hash) mismatches
+  bool IgnoreEmptyHashMismatches = false;
+
   // Read the profile summary. Return a pointer pointing to one byte past the
   // end of the summary data if it exists or the input \c Cur.
   // \c UseCS indicates whether to use the context-sensitive profile summary.
@@ -796,11 +799,13 @@ public:
   /// Factory method to create an indexed reader.
   static Expected<std::unique_ptr<IndexedInstrProfReader>>
   create(const Twine &Path, vfs::FileSystem &FS,
-         const Twine &RemappingPath = "");
+         const Twine &RemappingPath = "",
+         bool IgnoreEmptyHashMismatches = false);
 
   static Expected<std::unique_ptr<IndexedInstrProfReader>>
   create(std::unique_ptr<MemoryBuffer> Buffer,
-         std::unique_ptr<MemoryBuffer> RemappingBuffer = nullptr);
+         std::unique_ptr<MemoryBuffer> RemappingBuffer = nullptr,
+         bool IgnoreEmptyHashMismatches = false);
 
   // Used for testing purpose only.
   void setValueProfDataEndianness(llvm::endianness Endianness) {

--- a/llvm/lib/ProfileData/Coverage/CoverageMapping.cpp
+++ b/llvm/lib/ProfileData/Coverage/CoverageMapping.cpp
@@ -1008,8 +1008,10 @@ Error CoverageMapping::loadFromFile(
 Expected<std::unique_ptr<CoverageMapping>> CoverageMapping::load(
     ArrayRef<StringRef> ObjectFilenames, StringRef ProfileFilename,
     vfs::FileSystem &FS, ArrayRef<StringRef> Arches, StringRef CompilationDir,
-    const object::BuildIDFetcher *BIDFetcher, bool CheckBinaryIDs) {
-  auto ProfileReaderOrErr = IndexedInstrProfReader::create(ProfileFilename, FS);
+    const object::BuildIDFetcher *BIDFetcher, bool CheckBinaryIDs,
+    bool IgnoreEmptyHashMismatches) {
+  auto ProfileReaderOrErr = IndexedInstrProfReader::create(ProfileFilename, FS,
+   "" /* RemappingPath */, IgnoreEmptyHashMismatches);
   if (Error E = ProfileReaderOrErr.takeError())
     return createFileError(ProfileFilename, std::move(E));
   auto ProfileReader = std::move(ProfileReaderOrErr.get());

--- a/llvm/lib/ProfileData/InstrProfReader.cpp
+++ b/llvm/lib/ProfileData/InstrProfReader.cpp
@@ -191,7 +191,8 @@ InstrProfReader::create(std::unique_ptr<MemoryBuffer> Buffer,
 
 Expected<std::unique_ptr<IndexedInstrProfReader>>
 IndexedInstrProfReader::create(const Twine &Path, vfs::FileSystem &FS,
-                               const Twine &RemappingPath) {
+                               const Twine &RemappingPath,
+                               bool IgnoreEmptyHashMismatches) {
   // Set up the buffer to read.
   auto BufferOrError = setupMemoryBuffer(Path, FS);
   if (Error E = BufferOrError.takeError())
@@ -208,12 +209,14 @@ IndexedInstrProfReader::create(const Twine &Path, vfs::FileSystem &FS,
   }
 
   return IndexedInstrProfReader::create(std::move(BufferOrError.get()),
-                                        std::move(RemappingBuffer));
+                                        std::move(RemappingBuffer),
+                                        IgnoreEmptyHashMismatches);
 }
 
 Expected<std::unique_ptr<IndexedInstrProfReader>>
 IndexedInstrProfReader::create(std::unique_ptr<MemoryBuffer> Buffer,
-                               std::unique_ptr<MemoryBuffer> RemappingBuffer) {
+                               std::unique_ptr<MemoryBuffer> RemappingBuffer,
+                               bool IgnoreEmptyHashMismatches) {
   // Create the reader.
   if (!IndexedInstrProfReader::hasFormat(*Buffer))
     return make_error<InstrProfError>(instrprof_error::bad_magic);
@@ -223,6 +226,8 @@ IndexedInstrProfReader::create(std::unique_ptr<MemoryBuffer> Buffer,
   // Initialize the reader and return the result.
   if (Error E = initializeReader(*Result))
     return std::move(E);
+
+  Result->IgnoreEmptyHashMismatches = IgnoreEmptyHashMismatches;
 
   return std::move(Result);
 }
@@ -1500,6 +1505,11 @@ Expected<InstrProfRecord> IndexedInstrProfReader::getInstrProfRecord(
       return std::move(Err2);
   }
   // Found it. Look for counters with the right hash.
+
+  // Ignore possible hash mismatch if hash is 0.
+  if (IgnoreEmptyHashMismatches && FuncHash == 0x0 && Data.size() == 1) {
+    return std::move(Data.front());
+  }
 
   // A flag to indicate if the records are from the same type
   // of profile (i.e cs vs nocs).

--- a/llvm/tools/llvm-cov/CodeCoverage.cpp
+++ b/llvm/tools/llvm-cov/CodeCoverage.cpp
@@ -193,6 +193,8 @@ private:
   std::unique_ptr<object::BuildIDFetcher> BIDFetcher;
 
   bool CheckBinaryIDs;
+
+  bool IgnoreHashMismatch;
 };
 }
 
@@ -482,7 +484,8 @@ std::unique_ptr<CoverageMapping> CodeCoverageTool::load() {
   auto FS = vfs::getRealFileSystem();
   auto CoverageOrErr = CoverageMapping::load(
       ObjectFilenames, PGOFilename, *FS, CoverageArches,
-      ViewOpts.CompilationDirectory, BIDFetcher.get(), CheckBinaryIDs);
+      ViewOpts.CompilationDirectory, BIDFetcher.get(), CheckBinaryIDs, 
+      IgnoreHashMismatch);
   if (Error E = CoverageOrErr.takeError()) {
     error("failed to load coverage: " + toString(std::move(E)));
     return nullptr;
@@ -815,6 +818,9 @@ int CodeCoverageTool::run(Command Cmd, int argc, const char **argv) {
       "check-binary-ids", cl::desc("Fail if an object couldn't be found for a "
                                    "binary ID in the profile"));
 
+  cl::opt<bool> IgnoreHashMismatch(
+      "ignore-hash-mismatch", cl::desc("Ignore hash mismatches."));
+
   auto commandLineParser = [&, this](int argc, const char **argv) -> int {
     cl::ParseCommandLineOptions(argc, argv, "LLVM code coverage tool\n");
     ViewOpts.Debug = DebugDump;
@@ -825,6 +831,7 @@ int CodeCoverageTool::run(Command Cmd, int argc, const char **argv) {
       BIDFetcher = std::make_unique<object::BuildIDFetcher>(DebugFileDirectory);
     }
     this->CheckBinaryIDs = CheckBinaryIDs;
+    this->IgnoreHashMismatch = IgnoreHashMismatch;
 
     if (!CovFilename.empty())
       ObjectFilenames.emplace_back(CovFilename);


### PR DESCRIPTION
Potential workaround for #72786 and #32849 
See [discussion](https://discourse.llvm.org/t/llvm-cov-hash-mismatches-originating-from-class-methods-implemented-in-header-files/79832)