### PR TITLE
[MLIR][OpenMP] Remove OpenMPDialectFoldInterface

### DIFF
--- a/mlir/lib/Dialect/OpenMP/IR/OpenMPDialect.cpp
+++ b/mlir/lib/Dialect/OpenMP/IR/OpenMPDialect.cpp
@@ -66,15 +66,6 @@ struct LLVMPointerPointerLikeModel
                                             LLVM::LLVMPointerType> {
   Type getElementType(Type pointer) const { return Type(); }
 };
-
-struct OpenMPDialectFoldInterface : public DialectFoldInterface {
-  using DialectFoldInterface::DialectFoldInterface;
-
-  bool shouldMaterializeInto(Region *region) const final {
-    // Avoid folding constants across target regions
-    return isa<TargetOp>(region->getParentOp());
-  }
-};
 } // namespace
 
 void OpenMPDialect::initialize() {
@@ -91,7 +82,6 @@ void OpenMPDialect::initialize() {
 #include "mlir/Dialect/OpenMP/OpenMPOpsTypes.cpp.inc"
       >();
 
-  addInterface<OpenMPDialectFoldInterface>();
   MemRefType::attachInterface<MemRefPointerLikeModel>(*getContext());
   LLVM::LLVMPointerType::attachInterface<LLVMPointerPointerLikeModel>(
       *getContext());


### PR DESCRIPTION
The `OpenMPDialectFoldInterface` was originally introduced to prevent constants from being hoisted out of `omp.target` regions. This hasn't been necessary since the `IsolatedFromAbove` trait was added to that operation, so it's safe to remove this interface.