### PR TITLE
[llvm][CodeGen] respect booleanVectorContents while UnrollVSETCC

### DIFF
--- a/llvm/lib/CodeGen/SelectionDAG/LegalizeVectorOps.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/LegalizeVectorOps.cpp
@@ -2012,13 +2012,8 @@ SDValue VectorLegalizer::UnrollVSETCC(SDNode *Node) {
                                   DAG.getVectorIdxConstant(i, dl));
     SDValue RHSElem = DAG.getNode(ISD::EXTRACT_VECTOR_ELT, dl, TmpEltVT, RHS,
                                   DAG.getVectorIdxConstant(i, dl));
-    Ops[i] = DAG.getNode(ISD::SETCC, dl,
-                         TLI.getSetCCResultType(DAG.getDataLayout(),
-                                                *DAG.getContext(), TmpEltVT),
-                         LHSElem, RHSElem, CC);
-    Ops[i] = DAG.getSelect(dl, EltVT, Ops[i],
-                           DAG.getBoolConstant(true, dl, EltVT, VT),
-                           DAG.getConstant(0, dl, EltVT));
+    Ops[i] = DAG.getNode(ISD::SETCC, dl, MVT::i1, LHSElem, RHSElem, CC);
+    Ops[i] = DAG.getBoolExtOrTrunc(Ops[i], dl, EltVT, VT);
   }
   return DAG.getBuildVector(VT, dl, Ops);
 }

--- a/llvm/lib/CodeGen/SelectionDAG/LegalizeVectorOps.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/LegalizeVectorOps.cpp
@@ -2016,7 +2016,8 @@ SDValue VectorLegalizer::UnrollVSETCC(SDNode *Node) {
                          TLI.getSetCCResultType(DAG.getDataLayout(),
                                                 *DAG.getContext(), TmpEltVT),
                          LHSElem, RHSElem, CC);
-    Ops[i] = DAG.getSelect(dl, EltVT, Ops[i], DAG.getAllOnesConstant(dl, EltVT),
+    Ops[i] = DAG.getSelect(dl, EltVT, Ops[i],
+                           DAG.getBoolConstant(true, dl, EltVT, VT),
                            DAG.getConstant(0, dl, EltVT));
   }
   return DAG.getBuildVector(VT, dl, Ops);

--- a/llvm/lib/CodeGen/SelectionDAG/LegalizeVectorOps.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/LegalizeVectorOps.cpp
@@ -2017,7 +2017,7 @@ SDValue VectorLegalizer::UnrollVSETCC(SDNode *Node) {
                                                 *DAG.getContext(), TmpEltVT),
                          LHSElem, RHSElem, CC);
     Ops[i] = DAG.getSelect(dl, EltVT, Ops[i],
-                           DAG.getBoolConstant(true, dl, EltVT, EltVT),
+                           DAG.getBoolConstant(true, dl, EltVT, VT),
                            DAG.getConstant(0, dl, EltVT));
   }
   return DAG.getBuildVector(VT, dl, Ops);

--- a/llvm/lib/CodeGen/SelectionDAG/LegalizeVectorOps.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/LegalizeVectorOps.cpp
@@ -2017,7 +2017,7 @@ SDValue VectorLegalizer::UnrollVSETCC(SDNode *Node) {
                                                 *DAG.getContext(), TmpEltVT),
                          LHSElem, RHSElem, CC);
     Ops[i] = DAG.getSelect(dl, EltVT, Ops[i],
-                           DAG.getBoolConstant(true, dl, EltVT, VT),
+                           DAG.getBoolConstant(true, dl, EltVT, EltVT),
                            DAG.getConstant(0, dl, EltVT));
   }
   return DAG.getBuildVector(VT, dl, Ops);


### PR DESCRIPTION
This is an NFC patch that focus fixing correctness of UnrollVSETCC. For historical reason this function assumes all targets `setBooleanVectorContents` to `ZeroOrNegativeOneBooleanContent`. i.e. vector boolean values are "-1".

However this is not true for some targets, e.g. RISC-V, Sparc, VE, XCore, ARC...

Actually all these targets support native vector comparison. Thus it is no need to invoke this function and it is not coveraged by any test cases.

I'm not sure whether or not it is OK to submit such patch, but this does indeed fix potential miscompilation for furthur targets.