### PR TITLE
[libc++abi] Use __has_feature check to enable usage of thread_local for exception storage

### DIFF
--- a/libcxxabi/src/cxa_exception_storage.cpp
+++ b/libcxxabi/src/cxa_exception_storage.cpp
@@ -24,7 +24,7 @@ extern "C" {
 } // extern "C"
 } // namespace __cxxabiv1
 
-#elif defined(HAS_THREAD_LOCAL)
+#elif __has_feature(cxx_thread_local)
 
 namespace __cxxabiv1 {
 namespace {


### PR DESCRIPTION
Previously, we'd use HAS_THREAD_LOCAL which was never defined. Hence, we'd basically never use the code path where we use thread_local.

Fixes #78207