### PR TITLE
[AMDGPU] Remove default wavefrontsize attribute in asm parser

### DIFF
--- a/llvm/lib/Target/AMDGPU/AsmParser/AMDGPUAsmParser.cpp
+++ b/llvm/lib/Target/AMDGPU/AsmParser/AMDGPUAsmParser.cpp
@@ -1408,7 +1408,20 @@ public:
       copySTI().ToggleFeature("southern-islands");
     }
 
-    setAvailableFeatures(ComputeAvailableFeatures(getFeatureBits()));
+    StringRef FS = getSTI().getFeatureString();
+    FeatureBitset FB = getFeatureBits();
+    int isWave32 = FS.contains("+wavefrontsize32");
+    int isWave64 = FS.contains("+wavefrontsize64");
+    // Reset default wavefrontsize features.
+    if (isWave32 + isWave64 == 1) {
+      if (isWave32 && FB[AMDGPU::FeatureWavefrontSize64])
+        copySTI().ToggleFeature(AMDGPU::FeatureWavefrontSize64);
+      else if (isWave64 && FB[AMDGPU::FeatureWavefrontSize32])
+        copySTI().ToggleFeature(AMDGPU::FeatureWavefrontSize32);
+      FB = getFeatureBits();
+    }
+
+    setAvailableFeatures(ComputeAvailableFeatures(FB));
 
     AMDGPU::IsaVersion ISA = AMDGPU::getIsaVersion(getSTI().getCPU());
     if (ISA.Major >= 6 && isHsaAbi(getSTI())) {

--- a/llvm/test/MC/AMDGPU/expressions-gfx10.s
+++ b/llvm/test/MC/AMDGPU/expressions-gfx10.s
@@ -1,5 +1,5 @@
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1010 -mattr=-wavefrontsize32,+wavefrontsize64 -show-encoding %s | FileCheck %s --check-prefix=GFX10
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1010 -mattr=-wavefrontsize32,+wavefrontsize64 %s 2>&1 | FileCheck -check-prefix=NOGFX10 --implicit-check-not=error: %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1010 -mattr=+wavefrontsize64 -show-encoding %s | FileCheck %s --check-prefix=GFX10
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1010 -mattr=+wavefrontsize64 %s 2>&1 | FileCheck -check-prefix=NOGFX10 --implicit-check-not=error: %s
 
 i1=1
 

--- a/llvm/test/MC/AMDGPU/gfx1013.s
+++ b/llvm/test/MC/AMDGPU/gfx1013.s
@@ -1,4 +1,4 @@
-// RUN: llvm-mc -triple=amdgcn -mcpu=gfx1013 -mattr=+wavefrontsize32,-wavefrontsize64 -show-encoding %s | FileCheck %s
+// RUN: llvm-mc -triple=amdgcn -mcpu=gfx1013 -mattr=+wavefrontsize32 -show-encoding %s | FileCheck %s
 
 image_bvh64_intersect_ray v[5:8], v[1:12], s[8:11]
 // CHECK: [0x01,0x9f,0x9c,0xf1,0x01,0x05,0x02,0x00]

--- a/llvm/test/MC/AMDGPU/gfx1030_unsupported.s
+++ b/llvm/test/MC/AMDGPU/gfx1030_unsupported.s
@@ -1,5 +1,5 @@
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1030 -mattr=+wavefrontsize32,-wavefrontsize64 %s 2>&1 | FileCheck --implicit-check-not=error: %s
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1030 -mattr=-wavefrontsize32,+wavefrontsize64 %s 2>&1 | FileCheck --implicit-check-not=error: %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1030 -mattr=+wavefrontsize32 %s 2>&1 | FileCheck --implicit-check-not=error: %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1030 -mattr=+wavefrontsize64 %s 2>&1 | FileCheck --implicit-check-not=error: %s
 
 v_mul_lo_i32 v0, v1, v2
 // CHECK: :[[@LINE-1]]:{{[0-9]+}}: error: instruction not supported on this GPU

--- a/llvm/test/MC/AMDGPU/gfx10_asm_dpp16.s
+++ b/llvm/test/MC/AMDGPU/gfx10_asm_dpp16.s
@@ -1,7 +1,7 @@
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1010 -mattr=+wavefrontsize32,-wavefrontsize64 -show-encoding %s | FileCheck --check-prefixes=GFX10,W32 %s
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1010 -mattr=-wavefrontsize32,+wavefrontsize64 -show-encoding %s | FileCheck --check-prefixes=GFX10,W64 %s
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1010 -mattr=+wavefrontsize32,-wavefrontsize64 %s 2>&1 | FileCheck --check-prefix=W32-ERR --implicit-check-not=error: %s
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1010 -mattr=-wavefrontsize32,+wavefrontsize64 %s 2>&1 | FileCheck --check-prefix=W64-ERR --implicit-check-not=error: %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1010 -mattr=+wavefrontsize32 -show-encoding %s | FileCheck --check-prefixes=GFX10,W32 %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1010 -mattr=+wavefrontsize64 -show-encoding %s | FileCheck --check-prefixes=GFX10,W64 %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1010 -mattr=+wavefrontsize32 %s 2>&1 | FileCheck --check-prefix=W32-ERR --implicit-check-not=error: %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1010 -mattr=+wavefrontsize64 %s 2>&1 | FileCheck --check-prefix=W64-ERR --implicit-check-not=error: %s
 
 v_mov_b32_dpp v5, v1 quad_perm:[3,2,1,0] row_mask:0x0 bank_mask:0x0
 // GFX10: [0xfa,0x02,0x0a,0x7e,0x01,0x1b,0x00,0x00]

--- a/llvm/test/MC/AMDGPU/gfx10_asm_dpp8.s
+++ b/llvm/test/MC/AMDGPU/gfx10_asm_dpp8.s
@@ -1,7 +1,7 @@
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1010 -mattr=+wavefrontsize32,-wavefrontsize64 -show-encoding %s | FileCheck --check-prefixes=GFX10,W32 %s
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1010 -mattr=-wavefrontsize32,+wavefrontsize64 -show-encoding %s | FileCheck --check-prefixes=GFX10,W64 %s
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1010 -mattr=+wavefrontsize32,-wavefrontsize64 %s 2>&1 | FileCheck --check-prefix=W32-ERR --implicit-check-not=error: %s
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1010 -mattr=-wavefrontsize32,+wavefrontsize64 %s 2>&1 | FileCheck --check-prefix=W64-ERR --implicit-check-not=error: %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1010 -mattr=+wavefrontsize32 -show-encoding %s | FileCheck --check-prefixes=GFX10,W32 %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1010 -mattr=+wavefrontsize64 -show-encoding %s | FileCheck --check-prefixes=GFX10,W64 %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1010 -mattr=+wavefrontsize32 %s 2>&1 | FileCheck --check-prefix=W32-ERR --implicit-check-not=error: %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1010 -mattr=+wavefrontsize64 %s 2>&1 | FileCheck --check-prefix=W64-ERR --implicit-check-not=error: %s
 
 v_mov_b32_dpp v5, v1 dpp8:[0,1,2,3,4,5,6,7]
 // GFX10: encoding: [0xe9,0x02,0x0a,0x7e,0x01,0x88,0xc6,0xfa]

--- a/llvm/test/MC/AMDGPU/gfx10_asm_ds.s
+++ b/llvm/test/MC/AMDGPU/gfx10_asm_ds.s
@@ -1,5 +1,5 @@
-// RUN: llvm-mc -triple=amdgcn -mcpu=gfx1010 -mattr=+wavefrontsize32,-wavefrontsize64 -show-encoding %s | FileCheck --check-prefix=GFX10 %s
-// RUN: llvm-mc -triple=amdgcn -mcpu=gfx1010 -mattr=-wavefrontsize32,+wavefrontsize64 -show-encoding %s | FileCheck --check-prefix=GFX10 %s
+// RUN: llvm-mc -triple=amdgcn -mcpu=gfx1010 -mattr=+wavefrontsize32 -show-encoding %s | FileCheck --check-prefix=GFX10 %s
+// RUN: llvm-mc -triple=amdgcn -mcpu=gfx1010 -mattr=+wavefrontsize64 -show-encoding %s | FileCheck --check-prefix=GFX10 %s
 
 //===----------------------------------------------------------------------===//
 // ENC_DS.

--- a/llvm/test/MC/AMDGPU/gfx10_asm_err.s
+++ b/llvm/test/MC/AMDGPU/gfx10_asm_err.s
@@ -2,8 +2,8 @@
 // RUN: not llvm-mc -triple=amdgcn -mcpu=gfx701 %s 2>&1 | FileCheck --check-prefixes=GFX6-7,GFX6-8,GFX6-9 --implicit-check-not=error: %s
 // RUN: not llvm-mc -triple=amdgcn -mcpu=gfx801 %s 2>&1 | FileCheck --check-prefixes=GFX6-8,GFX6-9,GFX8-9 --implicit-check-not=error: %s
 // RUN: not llvm-mc -triple=amdgcn -mcpu=gfx900 %s 2>&1 | FileCheck --check-prefixes=GFX6-9,GFX8-9 --implicit-check-not=error: %s
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1010 -mattr=+wavefrontsize32,-wavefrontsize64 %s 2>&1 | FileCheck --check-prefixes=GFX10 --implicit-check-not=error: %s
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1010 -mattr=-wavefrontsize32,+wavefrontsize64 %s 2>&1 | FileCheck --check-prefixes=GFX10 --implicit-check-not=error: %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1010 -mattr=+wavefrontsize32 %s 2>&1 | FileCheck --check-prefixes=GFX10 --implicit-check-not=error: %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1010 -mattr=+wavefrontsize64 %s 2>&1 | FileCheck --check-prefixes=GFX10 --implicit-check-not=error: %s
 
 //===----------------------------------------------------------------------===//
 // ENC_DS.

--- a/llvm/test/MC/AMDGPU/gfx10_asm_flat.s
+++ b/llvm/test/MC/AMDGPU/gfx10_asm_flat.s
@@ -1,5 +1,5 @@
-// RUN: llvm-mc -triple=amdgcn -mcpu=gfx1010 -mattr=+wavefrontsize32,-wavefrontsize64 -show-encoding %s | FileCheck --check-prefix=GFX10 %s
-// RUN: llvm-mc -triple=amdgcn -mcpu=gfx1010 -mattr=-wavefrontsize32,+wavefrontsize64 -show-encoding %s | FileCheck --check-prefix=GFX10 %s
+// RUN: llvm-mc -triple=amdgcn -mcpu=gfx1010 -mattr=+wavefrontsize32 -show-encoding %s | FileCheck --check-prefix=GFX10 %s
+// RUN: llvm-mc -triple=amdgcn -mcpu=gfx1010 -mattr=+wavefrontsize64 -show-encoding %s | FileCheck --check-prefix=GFX10 %s
 
 //===----------------------------------------------------------------------===//
 // ENC_FLAT.

--- a/llvm/test/MC/AMDGPU/gfx10_asm_mubuf.s
+++ b/llvm/test/MC/AMDGPU/gfx10_asm_mubuf.s
@@ -1,5 +1,5 @@
-// RUN: llvm-mc -triple=amdgcn -mcpu=gfx1010 -mattr=+wavefrontsize32,-wavefrontsize64 -show-encoding %s | FileCheck --check-prefix=GFX10 %s
-// RUN: llvm-mc -triple=amdgcn -mcpu=gfx1010 -mattr=-wavefrontsize32,+wavefrontsize64 -show-encoding %s | FileCheck --check-prefix=GFX10 %s
+// RUN: llvm-mc -triple=amdgcn -mcpu=gfx1010 -mattr=+wavefrontsize32 -show-encoding %s | FileCheck --check-prefix=GFX10 %s
+// RUN: llvm-mc -triple=amdgcn -mcpu=gfx1010 -mattr=+wavefrontsize64 -show-encoding %s | FileCheck --check-prefix=GFX10 %s
 
 //===----------------------------------------------------------------------===//
 // ENC_MUBUF.

--- a/llvm/test/MC/AMDGPU/gfx10_asm_smem.s
+++ b/llvm/test/MC/AMDGPU/gfx10_asm_smem.s
@@ -1,5 +1,5 @@
-// RUN: llvm-mc -triple=amdgcn -mcpu=gfx1010 -mattr=+wavefrontsize32,-wavefrontsize64 -show-encoding %s | FileCheck --check-prefix=GFX10 %s
-// RUN: llvm-mc -triple=amdgcn -mcpu=gfx1010 -mattr=-wavefrontsize32,+wavefrontsize64 -show-encoding %s | FileCheck --check-prefix=GFX10 %s
+// RUN: llvm-mc -triple=amdgcn -mcpu=gfx1010 -mattr=+wavefrontsize32 -show-encoding %s | FileCheck --check-prefix=GFX10 %s
+// RUN: llvm-mc -triple=amdgcn -mcpu=gfx1010 -mattr=+wavefrontsize64 -show-encoding %s | FileCheck --check-prefix=GFX10 %s
 
 //===----------------------------------------------------------------------===//
 // ENC_SMEM.

--- a/llvm/test/MC/AMDGPU/gfx10_asm_sop.s
+++ b/llvm/test/MC/AMDGPU/gfx10_asm_sop.s
@@ -1,5 +1,5 @@
-// RUN: llvm-mc -triple=amdgcn -mcpu=gfx1010 -mattr=+wavefrontsize32,-wavefrontsize64 -show-encoding %s | FileCheck --check-prefix=GFX10 %s
-// RUN: llvm-mc -triple=amdgcn -mcpu=gfx1010 -mattr=-wavefrontsize32,+wavefrontsize64 -show-encoding %s | FileCheck --check-prefix=GFX10 %s
+// RUN: llvm-mc -triple=amdgcn -mcpu=gfx1010 -mattr=+wavefrontsize32 -show-encoding %s | FileCheck --check-prefix=GFX10 %s
+// RUN: llvm-mc -triple=amdgcn -mcpu=gfx1010 -mattr=+wavefrontsize64 -show-encoding %s | FileCheck --check-prefix=GFX10 %s
 
 //===----------------------------------------------------------------------===//
 // ENC_SOP1.

--- a/llvm/test/MC/AMDGPU/gfx10_asm_vop1.s
+++ b/llvm/test/MC/AMDGPU/gfx10_asm_vop1.s
@@ -1,7 +1,7 @@
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1010 -mattr=+wavefrontsize32,-wavefrontsize64 -show-encoding %s | FileCheck --check-prefix=GFX10 %s
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1010 -mattr=-wavefrontsize32,+wavefrontsize64 -show-encoding %s | FileCheck --check-prefix=GFX10 %s
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1010 -mattr=+wavefrontsize32,-wavefrontsize64 %s 2>&1 | FileCheck --check-prefix=GFX10-ERR --implicit-check-not=error: %s
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1010 -mattr=-wavefrontsize32,+wavefrontsize64 %s 2>&1 | FileCheck --check-prefix=GFX10-ERR --implicit-check-not=error: %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1010 -mattr=+wavefrontsize32 -show-encoding %s | FileCheck --check-prefix=GFX10 %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1010 -mattr=+wavefrontsize64 -show-encoding %s | FileCheck --check-prefix=GFX10 %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1010 -mattr=+wavefrontsize32 %s 2>&1 | FileCheck --check-prefix=GFX10-ERR --implicit-check-not=error: %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1010 -mattr=+wavefrontsize64 %s 2>&1 | FileCheck --check-prefix=GFX10-ERR --implicit-check-not=error: %s
 
 //===----------------------------------------------------------------------===//
 // ENC_VOP1.

--- a/llvm/test/MC/AMDGPU/gfx10_asm_vop2.s
+++ b/llvm/test/MC/AMDGPU/gfx10_asm_vop2.s
@@ -1,7 +1,7 @@
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1010 -mattr=+wavefrontsize32,-wavefrontsize64 -show-encoding %s | FileCheck --check-prefixes=GFX10,W32 %s
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1010 -mattr=-wavefrontsize32,+wavefrontsize64 -show-encoding %s | FileCheck --check-prefixes=GFX10,W64 %s
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1010 -mattr=+wavefrontsize32,-wavefrontsize64 %s 2>&1 | FileCheck --check-prefix=W32-ERR --implicit-check-not=error: %s
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1010 -mattr=-wavefrontsize32,+wavefrontsize64 %s 2>&1 | FileCheck --check-prefix=W64-ERR --implicit-check-not=error: %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1010 -mattr=+wavefrontsize32 -show-encoding %s | FileCheck --check-prefixes=GFX10,W32 %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1010 -mattr=+wavefrontsize64 -show-encoding %s | FileCheck --check-prefixes=GFX10,W64 %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1010 -mattr=+wavefrontsize32 %s 2>&1 | FileCheck --check-prefix=W32-ERR --implicit-check-not=error: %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1010 -mattr=+wavefrontsize64 %s 2>&1 | FileCheck --check-prefix=W64-ERR --implicit-check-not=error: %s
 
 //===----------------------------------------------------------------------===//
 // ENC_VOP2.

--- a/llvm/test/MC/AMDGPU/gfx10_asm_vop3.s
+++ b/llvm/test/MC/AMDGPU/gfx10_asm_vop3.s
@@ -1,7 +1,7 @@
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1010 -mattr=+wavefrontsize32,-wavefrontsize64 -show-encoding %s | FileCheck --check-prefixes=GFX10,W32 %s
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1010 -mattr=-wavefrontsize32,+wavefrontsize64 -show-encoding %s | FileCheck --check-prefixes=GFX10,W64 %s
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1010 -mattr=+wavefrontsize32,-wavefrontsize64 %s 2>&1 | FileCheck --check-prefixes=GFX10-ERR,W32-ERR --implicit-check-not=error: %s
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1010 -mattr=-wavefrontsize32,+wavefrontsize64 %s 2>&1 | FileCheck --check-prefixes=GFX10-ERR,W64-ERR --implicit-check-not=error: %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1010 -mattr=+wavefrontsize32 -show-encoding %s | FileCheck --check-prefixes=GFX10,W32 %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1010 -mattr=+wavefrontsize64 -show-encoding %s | FileCheck --check-prefixes=GFX10,W64 %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1010 -mattr=+wavefrontsize32 %s 2>&1 | FileCheck --check-prefixes=GFX10-ERR,W32-ERR --implicit-check-not=error: %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1010 -mattr=+wavefrontsize64 %s 2>&1 | FileCheck --check-prefixes=GFX10-ERR,W64-ERR --implicit-check-not=error: %s
 
 //===----------------------------------------------------------------------===//
 // ENC_VOP3.

--- a/llvm/test/MC/AMDGPU/gfx10_asm_vopc.s
+++ b/llvm/test/MC/AMDGPU/gfx10_asm_vopc.s
@@ -1,7 +1,7 @@
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1010 -mattr=+wavefrontsize32,-wavefrontsize64 -show-encoding %s | FileCheck --check-prefix=W32 %s
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1010 -mattr=-wavefrontsize32,+wavefrontsize64 -show-encoding %s | FileCheck --check-prefix=W64 %s
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1010 -mattr=+wavefrontsize32,-wavefrontsize64 %s 2>&1 | FileCheck --check-prefix=W32-ERR --implicit-check-not=error: %s
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1010 -mattr=-wavefrontsize32,+wavefrontsize64 %s 2>&1 | FileCheck --check-prefix=W64-ERR --implicit-check-not=error: %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1010 -mattr=+wavefrontsize32 -show-encoding %s | FileCheck --check-prefix=W32 %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1010 -mattr=+wavefrontsize64 -show-encoding %s | FileCheck --check-prefix=W64 %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1010 -mattr=+wavefrontsize32 %s 2>&1 | FileCheck --check-prefix=W32-ERR --implicit-check-not=error: %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1010 -mattr=+wavefrontsize64 %s 2>&1 | FileCheck --check-prefix=W64-ERR --implicit-check-not=error: %s
 
 //===----------------------------------------------------------------------===//
 // ENC_VOPC - v_cmp_* opcodes.

--- a/llvm/test/MC/AMDGPU/gfx10_asm_vopc_e64.s
+++ b/llvm/test/MC/AMDGPU/gfx10_asm_vopc_e64.s
@@ -1,7 +1,7 @@
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1010 -mattr=+wavefrontsize32,-wavefrontsize64 -show-encoding %s | FileCheck --check-prefix=W32 %s
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1010 -mattr=-wavefrontsize32,+wavefrontsize64 -show-encoding %s | FileCheck --check-prefix=W64 %s
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1010 -mattr=+wavefrontsize32,-wavefrontsize64 %s 2>&1 | FileCheck --check-prefix=W32-ERR --implicit-check-not=error: %s
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1010 -mattr=-wavefrontsize32,+wavefrontsize64 %s 2>&1 | FileCheck --check-prefix=W64-ERR --implicit-check-not=error: %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1010 -mattr=+wavefrontsize32 -show-encoding %s | FileCheck --check-prefix=W32 %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1010 -mattr=+wavefrontsize64 -show-encoding %s | FileCheck --check-prefix=W64 %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1010 -mattr=+wavefrontsize32 %s 2>&1 | FileCheck --check-prefix=W32-ERR --implicit-check-not=error: %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1010 -mattr=+wavefrontsize64 %s 2>&1 | FileCheck --check-prefix=W64-ERR --implicit-check-not=error: %s
 
 //===----------------------------------------------------------------------===//
 // ENC_VOPC, VOP3 variant.

--- a/llvm/test/MC/AMDGPU/gfx10_asm_vopc_sdwa.s
+++ b/llvm/test/MC/AMDGPU/gfx10_asm_vopc_sdwa.s
@@ -1,7 +1,7 @@
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1010 -mattr=+wavefrontsize32,-wavefrontsize64 -show-encoding %s | FileCheck --check-prefix=W32 %s
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1010 -mattr=-wavefrontsize32,+wavefrontsize64 -show-encoding %s | FileCheck --check-prefix=W64 %s
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1010 -mattr=+wavefrontsize32,-wavefrontsize64 %s 2>&1 | FileCheck --check-prefix=W32-ERR --implicit-check-not=error: %s
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1010 -mattr=-wavefrontsize32,+wavefrontsize64 %s 2>&1 | FileCheck --check-prefix=W64-ERR --implicit-check-not=error: %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1010 -mattr=+wavefrontsize32 -show-encoding %s | FileCheck --check-prefix=W32 %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1010 -mattr=+wavefrontsize64 -show-encoding %s | FileCheck --check-prefix=W64 %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1010 -mattr=+wavefrontsize32 %s 2>&1 | FileCheck --check-prefix=W32-ERR --implicit-check-not=error: %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1010 -mattr=+wavefrontsize64 %s 2>&1 | FileCheck --check-prefix=W64-ERR --implicit-check-not=error: %s
 
 //===----------------------------------------------------------------------===//
 // ENC_VOPC, SDWA variant.

--- a/llvm/test/MC/AMDGPU/gfx10_asm_vopcx.s
+++ b/llvm/test/MC/AMDGPU/gfx10_asm_vopcx.s
@@ -1,5 +1,5 @@
-// RUN: llvm-mc -triple=amdgcn -mcpu=gfx1010 -mattr=+wavefrontsize32,-wavefrontsize64 -show-encoding %s | FileCheck --check-prefix=GFX10 %s
-// RUN: llvm-mc -triple=amdgcn -mcpu=gfx1010 -mattr=-wavefrontsize32,+wavefrontsize64 -show-encoding %s | FileCheck --check-prefix=GFX10 %s
+// RUN: llvm-mc -triple=amdgcn -mcpu=gfx1010 -mattr=+wavefrontsize32 -show-encoding %s | FileCheck --check-prefix=GFX10 %s
+// RUN: llvm-mc -triple=amdgcn -mcpu=gfx1010 -mattr=+wavefrontsize64 -show-encoding %s | FileCheck --check-prefix=GFX10 %s
 
 //===----------------------------------------------------------------------===//
 // ENC_VOPC - v_cmpx_* opcodes.

--- a/llvm/test/MC/AMDGPU/gfx10_unsupported.s
+++ b/llvm/test/MC/AMDGPU/gfx10_unsupported.s
@@ -1,6 +1,6 @@
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1010 -mattr=+wavefrontsize32,-wavefrontsize64 %s 2>&1 | FileCheck --check-prefixes=CHECK,GFX1010 --implicit-check-not=error: %s
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1010 -mattr=-wavefrontsize32,+wavefrontsize64 %s 2>&1 | FileCheck --check-prefixes=CHECK,GFX1010 --implicit-check-not=error: %s
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1013 -mattr=+wavefrontsize32,-wavefrontsize64 %s 2>&1 | FileCheck --implicit-check-not=error: %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1010 -mattr=+wavefrontsize32 %s 2>&1 | FileCheck --check-prefixes=CHECK,GFX1010 --implicit-check-not=error: %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1010 -mattr=+wavefrontsize64 %s 2>&1 | FileCheck --check-prefixes=CHECK,GFX1010 --implicit-check-not=error: %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1013 -mattr=+wavefrontsize32 %s 2>&1 | FileCheck --implicit-check-not=error: %s
 
 buffer_atomic_add_f32 v0, v2, s[4:7], 0 idxen glc
 // CHECK: :[[@LINE-1]]:{{[0-9]+}}: error: instruction not supported on this GPU

--- a/llvm/test/MC/AMDGPU/gfx10_unsupported_dpp.s
+++ b/llvm/test/MC/AMDGPU/gfx10_unsupported_dpp.s
@@ -1,6 +1,6 @@
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1010 -mattr=+wavefrontsize32,-wavefrontsize64 %s 2>&1 | FileCheck --implicit-check-not=error: %s
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1010 -mattr=-wavefrontsize32,+wavefrontsize64 %s 2>&1 | FileCheck --implicit-check-not=error: %s
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1013 -mattr=+wavefrontsize32,-wavefrontsize64 %s 2>&1 | FileCheck --implicit-check-not=error: %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1010 -mattr=+wavefrontsize32 %s 2>&1 | FileCheck --implicit-check-not=error: %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1010 -mattr=+wavefrontsize64 %s 2>&1 | FileCheck --implicit-check-not=error: %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1013 -mattr=+wavefrontsize32 %s 2>&1 | FileCheck --implicit-check-not=error: %s
 
 v_add_co_u32_dpp v255, vcc, v1, v2 quad_perm:[0,1,2,3] row_mask:0x0 bank_mask:0x0
 // CHECK: :[[@LINE-1]]:{{[0-9]+}}: error: dpp variant of this instruction is not supported

--- a/llvm/test/MC/AMDGPU/gfx10_unsupported_e32.s
+++ b/llvm/test/MC/AMDGPU/gfx10_unsupported_e32.s
@@ -1,6 +1,6 @@
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1010 -mattr=+wavefrontsize32,-wavefrontsize64 %s 2>&1 | FileCheck --implicit-check-not=error: %s
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1010 -mattr=-wavefrontsize32,+wavefrontsize64 %s 2>&1 | FileCheck --implicit-check-not=error: %s
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1013 -mattr=+wavefrontsize32,-wavefrontsize64 %s 2>&1 | FileCheck --implicit-check-not=error: %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1010 -mattr=+wavefrontsize32 %s 2>&1 | FileCheck --implicit-check-not=error: %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1010 -mattr=+wavefrontsize64 %s 2>&1 | FileCheck --implicit-check-not=error: %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1013 -mattr=+wavefrontsize32 %s 2>&1 | FileCheck --implicit-check-not=error: %s
 
 v_add_co_u32_e32 v2, vcc, s0, v2
 // CHECK: :[[@LINE-1]]:{{[0-9]+}}: error: e32 variant of this instruction is not supported

--- a/llvm/test/MC/AMDGPU/gfx10_unsupported_e64.s
+++ b/llvm/test/MC/AMDGPU/gfx10_unsupported_e64.s
@@ -1,6 +1,6 @@
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1010 -mattr=+wavefrontsize32,-wavefrontsize64 %s 2>&1 | FileCheck --implicit-check-not=error: %s
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1010 -mattr=-wavefrontsize32,+wavefrontsize64 %s 2>&1 | FileCheck --implicit-check-not=error: %s
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1013 -mattr=+wavefrontsize32,-wavefrontsize64 %s 2>&1 | FileCheck --implicit-check-not=error: %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1010 -mattr=+wavefrontsize32 %s 2>&1 | FileCheck --implicit-check-not=error: %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1010 -mattr=+wavefrontsize64 %s 2>&1 | FileCheck --implicit-check-not=error: %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1013 -mattr=+wavefrontsize32 %s 2>&1 | FileCheck --implicit-check-not=error: %s
 
 v_swap_b32_e64 v1, v2
 // CHECK: :[[@LINE-1]]:{{[0-9]+}}: error: e64 variant of this instruction is not supported

--- a/llvm/test/MC/AMDGPU/gfx10_unsupported_e64_dpp.s
+++ b/llvm/test/MC/AMDGPU/gfx10_unsupported_e64_dpp.s
@@ -1,6 +1,6 @@
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1010 -mattr=+wavefrontsize32,-wavefrontsize64 %s 2>&1 | FileCheck --implicit-check-not=error: %s
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1010 -mattr=-wavefrontsize32,+wavefrontsize64 %s 2>&1 | FileCheck --implicit-check-not=error: %s
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1013 -mattr=+wavefrontsize32,-wavefrontsize64 %s 2>&1 | FileCheck --implicit-check-not=error: %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1010 -mattr=+wavefrontsize32 %s 2>&1 | FileCheck --implicit-check-not=error: %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1010 -mattr=+wavefrontsize64 %s 2>&1 | FileCheck --implicit-check-not=error: %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1013 -mattr=+wavefrontsize32 %s 2>&1 | FileCheck --implicit-check-not=error: %s
 
 v_add3_u32_e64_dpp v5, v1, s1, v0 dpp8:[7,6,5,4,3,2,1,0]
 // CHECK: :[[@LINE-1]]:{{[0-9]+}}: error: e64_dpp variant of this instruction is not supported

--- a/llvm/test/MC/AMDGPU/gfx10_unsupported_sdwa.s
+++ b/llvm/test/MC/AMDGPU/gfx10_unsupported_sdwa.s
@@ -1,6 +1,6 @@
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1010 -mattr=+wavefrontsize32,-wavefrontsize64 %s 2>&1 | FileCheck --implicit-check-not=error: %s
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1010 -mattr=-wavefrontsize32,+wavefrontsize64 %s 2>&1 | FileCheck --implicit-check-not=error: %s
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1013 -mattr=+wavefrontsize32,-wavefrontsize64 %s 2>&1 | FileCheck --implicit-check-not=error: %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1010 -mattr=+wavefrontsize32 %s 2>&1 | FileCheck --implicit-check-not=error: %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1010 -mattr=+wavefrontsize64 %s 2>&1 | FileCheck --implicit-check-not=error: %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1013 -mattr=+wavefrontsize32 %s 2>&1 | FileCheck --implicit-check-not=error: %s
 
 v_add_co_u32_sdwa v0, v0, v4 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:DWORD src1_sel:BYTE_0
 // CHECK: :[[@LINE-1]]:{{[0-9]+}}: error: sdwa variant of this instruction is not supported

--- a/llvm/test/MC/AMDGPU/gfx11-promotions.s
+++ b/llvm/test/MC/AMDGPU/gfx11-promotions.s
@@ -1,4 +1,4 @@
-// RUN: llvm-mc -triple=amdgcn -show-encoding -mcpu=gfx1100 -mattr=+wavefrontsize32,-wavefrontsize64 %s | FileCheck --check-prefix=GFX11 %s
+// RUN: llvm-mc -triple=amdgcn -show-encoding -mcpu=gfx1100 -mattr=+wavefrontsize32 %s | FileCheck --check-prefix=GFX11 %s
 
 // Check opcode promotions and forced suffices.
 // 1. When a suffix is optional, check that it may be omitted.

--- a/llvm/test/MC/AMDGPU/gfx11_asm_flat.s
+++ b/llvm/test/MC/AMDGPU/gfx11_asm_flat.s
@@ -1,5 +1,5 @@
-// RUN: llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=+wavefrontsize32,-wavefrontsize64 -show-encoding %s | FileCheck --check-prefix=GFX11 %s
-// RUN: llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=-wavefrontsize32,+wavefrontsize64 -show-encoding %s | FileCheck --check-prefix=GFX11 %s
+// RUN: llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=+wavefrontsize32 -show-encoding %s | FileCheck --check-prefix=GFX11 %s
+// RUN: llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=+wavefrontsize64 -show-encoding %s | FileCheck --check-prefix=GFX11 %s
 
 //===----------------------------------------------------------------------===//
 // FLAT.

--- a/llvm/test/MC/AMDGPU/gfx11_asm_vop1-fake16.s
+++ b/llvm/test/MC/AMDGPU/gfx11_asm_vop1-fake16.s
@@ -1,5 +1,5 @@
-// RUN: llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=-real-true16,+wavefrontsize32,-wavefrontsize64 -show-encoding %s | FileCheck --check-prefix=GFX11 %s
-// RUN: llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=-real-true16,-wavefrontsize32,+wavefrontsize64 -show-encoding %s | FileCheck --check-prefix=GFX11 %s
+// RUN: llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=-real-true16,+wavefrontsize32 -show-encoding %s | FileCheck --check-prefix=GFX11 %s
+// RUN: llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=-real-true16,+wavefrontsize64 -show-encoding %s | FileCheck --check-prefix=GFX11 %s
 
 v_floor_f16 v5, v1
 // GFX11: encoding: [0x01,0xb7,0x0a,0x7e]

--- a/llvm/test/MC/AMDGPU/gfx11_asm_vop1.s
+++ b/llvm/test/MC/AMDGPU/gfx11_asm_vop1.s
@@ -1,5 +1,5 @@
-// RUN: llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=+real-true16,+wavefrontsize32,-wavefrontsize64 -show-encoding %s | FileCheck --check-prefix=GFX11 %s
-// RUN: llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=+real-true16,-wavefrontsize32,+wavefrontsize64 -show-encoding %s | FileCheck --check-prefix=GFX11 %s
+// RUN: llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=+real-true16,+wavefrontsize32 -show-encoding %s | FileCheck --check-prefix=GFX11 %s
+// RUN: llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=+real-true16,+wavefrontsize64 -show-encoding %s | FileCheck --check-prefix=GFX11 %s
 
 v_bfrev_b32_e32 v5, v1
 // GFX11: encoding: [0x01,0x71,0x0a,0x7e]

--- a/llvm/test/MC/AMDGPU/gfx11_asm_vop1_dpp16-fake16.s
+++ b/llvm/test/MC/AMDGPU/gfx11_asm_vop1_dpp16-fake16.s
@@ -1,5 +1,5 @@
-// RUN: llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=-real-true16,+wavefrontsize32,-wavefrontsize64 -show-encoding %s | FileCheck --check-prefixes=GFX11 %s
-// RUN: llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=-real-true16,-wavefrontsize32,+wavefrontsize64 -show-encoding %s | FileCheck --check-prefixes=GFX11 %s
+// RUN: llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=-real-true16,+wavefrontsize32 -show-encoding %s | FileCheck --check-prefixes=GFX11 %s
+// RUN: llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=-real-true16,+wavefrontsize64 -show-encoding %s | FileCheck --check-prefixes=GFX11 %s
 
 v_floor_f16 v5, v1 quad_perm:[3,2,1,0]
 // GFX11: encoding: [0xfa,0xb6,0x0a,0x7e,0x01,0x1b,0x00,0xff]

--- a/llvm/test/MC/AMDGPU/gfx11_asm_vop1_dpp16.s
+++ b/llvm/test/MC/AMDGPU/gfx11_asm_vop1_dpp16.s
@@ -1,5 +1,5 @@
-// RUN: llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=+real-true16,+wavefrontsize32,-wavefrontsize64 -show-encoding %s | FileCheck --check-prefixes=GFX11 %s
-// RUN: llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=+real-true16,-wavefrontsize32,+wavefrontsize64 -show-encoding %s | FileCheck --check-prefixes=GFX11 %s
+// RUN: llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=+real-true16,+wavefrontsize32 -show-encoding %s | FileCheck --check-prefixes=GFX11 %s
+// RUN: llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=+real-true16,+wavefrontsize64 -show-encoding %s | FileCheck --check-prefixes=GFX11 %s
 
 v_bfrev_b32_dpp v5, v1 quad_perm:[3,2,1,0]
 // GFX11: encoding: [0xfa,0x70,0x0a,0x7e,0x01,0x1b,0x00,0xff]

--- a/llvm/test/MC/AMDGPU/gfx11_asm_vop1_dpp8-fake16.s
+++ b/llvm/test/MC/AMDGPU/gfx11_asm_vop1_dpp8-fake16.s
@@ -1,5 +1,5 @@
-// RUN: llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=-real-true16,+wavefrontsize32,-wavefrontsize64 -show-encoding %s | FileCheck --check-prefixes=GFX11 %s
-// RUN: llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=-real-true16,-wavefrontsize32,+wavefrontsize64 -show-encoding %s | FileCheck --check-prefixes=GFX11 %s
+// RUN: llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=-real-true16,+wavefrontsize32 -show-encoding %s | FileCheck --check-prefixes=GFX11 %s
+// RUN: llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=-real-true16,+wavefrontsize64 -show-encoding %s | FileCheck --check-prefixes=GFX11 %s
 
 v_floor_f16 v5, v1 dpp8:[7,6,5,4,3,2,1,0]
 // GFX11: encoding: [0xe9,0xb6,0x0a,0x7e,0x01,0x77,0x39,0x05]

--- a/llvm/test/MC/AMDGPU/gfx11_asm_vop1_dpp8.s
+++ b/llvm/test/MC/AMDGPU/gfx11_asm_vop1_dpp8.s
@@ -1,5 +1,5 @@
-// RUN: llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=+real-true16,+wavefrontsize32,-wavefrontsize64 -show-encoding %s | FileCheck --check-prefixes=GFX11 %s
-// RUN: llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=+real-true16,-wavefrontsize32,+wavefrontsize64 -show-encoding %s | FileCheck --check-prefixes=GFX11 %s
+// RUN: llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=+real-true16,+wavefrontsize32 -show-encoding %s | FileCheck --check-prefixes=GFX11 %s
+// RUN: llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=+real-true16,+wavefrontsize64 -show-encoding %s | FileCheck --check-prefixes=GFX11 %s
 
 v_bfrev_b32_dpp v5, v1 dpp8:[7,6,5,4,3,2,1,0]
 // GFX11: encoding: [0xe9,0x70,0x0a,0x7e,0x01,0x77,0x39,0x05]

--- a/llvm/test/MC/AMDGPU/gfx11_asm_vop1_t16_err-fake16.s
+++ b/llvm/test/MC/AMDGPU/gfx11_asm_vop1_t16_err-fake16.s
@@ -1,5 +1,5 @@
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=-real-true16,+wavefrontsize32,-wavefrontsize64 -show-encoding %s 2>&1 | FileCheck --check-prefix=GFX11 --implicit-check-not=error: %s
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=-real-true16,-wavefrontsize32,+wavefrontsize64 -show-encoding %s 2>&1 | FileCheck --check-prefix=GFX11 --implicit-check-not=error: %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=-real-true16,+wavefrontsize32 -show-encoding %s 2>&1 | FileCheck --check-prefix=GFX11 --implicit-check-not=error: %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=-real-true16,+wavefrontsize64 -show-encoding %s 2>&1 | FileCheck --check-prefix=GFX11 --implicit-check-not=error: %s
 
 v_floor_f16_e32 v128, 0xfe0b
 // GFX11: :[[@LINE-1]]:{{[0-9]+}}: error: operands are not valid for this GPU or mode

--- a/llvm/test/MC/AMDGPU/gfx11_asm_vop1_t16_err.s
+++ b/llvm/test/MC/AMDGPU/gfx11_asm_vop1_t16_err.s
@@ -1,5 +1,5 @@
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=+real-true16,+wavefrontsize32,-wavefrontsize64 -show-encoding %s 2>&1 | FileCheck --check-prefix=GFX11 --implicit-check-not=error: %s
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=+real-true16,-wavefrontsize32,+wavefrontsize64 -show-encoding %s 2>&1 | FileCheck --check-prefix=GFX11 --implicit-check-not=error: %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=+real-true16,+wavefrontsize32 -show-encoding %s 2>&1 | FileCheck --check-prefix=GFX11 --implicit-check-not=error: %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=+real-true16,+wavefrontsize64 -show-encoding %s 2>&1 | FileCheck --check-prefix=GFX11 --implicit-check-not=error: %s
 
 v_ceil_f16_e32 v128.l, 0xfe0b
 // GFX11: :[[@LINE-1]]:{{[0-9]+}}: error: invalid operand for instruction

--- a/llvm/test/MC/AMDGPU/gfx11_asm_vop1_t16_promote.s
+++ b/llvm/test/MC/AMDGPU/gfx11_asm_vop1_t16_promote.s
@@ -1,5 +1,5 @@
-// RUN: llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=+wavefrontsize32,-wavefrontsize64 -show-encoding %s | FileCheck --check-prefix=GFX11 --implicit-check-not=_e32 %s
-// RUN: llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=-wavefrontsize32,+wavefrontsize64 -show-encoding %s | FileCheck --check-prefix=GFX11 --implicit-check-not=_e32 %s
+// RUN: llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=+wavefrontsize32 -show-encoding %s | FileCheck --check-prefix=GFX11 --implicit-check-not=_e32 %s
+// RUN: llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=+wavefrontsize64 -show-encoding %s | FileCheck --check-prefix=GFX11 --implicit-check-not=_e32 %s
 
 v_ceil_f16 v128, 0xfe0b
 // GFX11: v_ceil_f16_e64

--- a/llvm/test/MC/AMDGPU/gfx11_asm_vop2.s
+++ b/llvm/test/MC/AMDGPU/gfx11_asm_vop2.s
@@ -1,7 +1,7 @@
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=+wavefrontsize32,-wavefrontsize64 -show-encoding %s | FileCheck --check-prefixes=GFX11,W32 %s
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=-wavefrontsize32,+wavefrontsize64 -show-encoding %s | FileCheck --check-prefixes=GFX11,W64 %s
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=+wavefrontsize32,-wavefrontsize64 %s 2>&1 | FileCheck --check-prefix=W32-ERR --implicit-check-not=error: %s
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=-wavefrontsize32,+wavefrontsize64 %s 2>&1 | FileCheck --check-prefix=W64-ERR --implicit-check-not=error: %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=+wavefrontsize32 -show-encoding %s | FileCheck --check-prefixes=GFX11,W32 %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=+wavefrontsize64 -show-encoding %s | FileCheck --check-prefixes=GFX11,W64 %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=+wavefrontsize32 %s 2>&1 | FileCheck --check-prefix=W32-ERR --implicit-check-not=error: %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=+wavefrontsize64 %s 2>&1 | FileCheck --check-prefix=W64-ERR --implicit-check-not=error: %s
 
 v_add_co_ci_u32_e32 v5, vcc_lo, v1, v2, vcc_lo
 // W32: encoding: [0x01,0x05,0x0a,0x40]

--- a/llvm/test/MC/AMDGPU/gfx11_asm_vop2_dpp16.s
+++ b/llvm/test/MC/AMDGPU/gfx11_asm_vop2_dpp16.s
@@ -1,7 +1,7 @@
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=+wavefrontsize32,-wavefrontsize64 -show-encoding %s | FileCheck --check-prefixes=GFX11,W32 %s
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=-wavefrontsize32,+wavefrontsize64 -show-encoding %s | FileCheck --check-prefixes=GFX11,W64 %s
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=+wavefrontsize32,-wavefrontsize64 %s 2>&1 | FileCheck --check-prefix=W32-ERR --implicit-check-not=error: %s
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=-wavefrontsize32,+wavefrontsize64 %s 2>&1 | FileCheck --check-prefix=W64-ERR --implicit-check-not=error: %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=+wavefrontsize32 -show-encoding %s | FileCheck --check-prefixes=GFX11,W32 %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=+wavefrontsize64 -show-encoding %s | FileCheck --check-prefixes=GFX11,W64 %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=+wavefrontsize32 %s 2>&1 | FileCheck --check-prefix=W32-ERR --implicit-check-not=error: %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=+wavefrontsize64 %s 2>&1 | FileCheck --check-prefix=W64-ERR --implicit-check-not=error: %s
 
 v_add_co_ci_u32_dpp v5, vcc_lo, v1, v2, vcc_lo quad_perm:[3,2,1,0]
 // W32: encoding: [0xfa,0x04,0x0a,0x40,0x01,0x1b,0x00,0xff]

--- a/llvm/test/MC/AMDGPU/gfx11_asm_vop2_dpp8.s
+++ b/llvm/test/MC/AMDGPU/gfx11_asm_vop2_dpp8.s
@@ -1,7 +1,7 @@
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=+wavefrontsize32,-wavefrontsize64 -show-encoding %s | FileCheck --check-prefixes=GFX11,W32 %s
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=-wavefrontsize32,+wavefrontsize64 -show-encoding %s | FileCheck --check-prefixes=GFX11,W64 %s
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=+wavefrontsize32,-wavefrontsize64 %s 2>&1 | FileCheck --check-prefix=W32-ERR --implicit-check-not=error: %s
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=-wavefrontsize32,+wavefrontsize64 %s 2>&1 | FileCheck --check-prefix=W64-ERR --implicit-check-not=error: %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=+wavefrontsize32 -show-encoding %s | FileCheck --check-prefixes=GFX11,W32 %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=+wavefrontsize64 -show-encoding %s | FileCheck --check-prefixes=GFX11,W64 %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=+wavefrontsize32 %s 2>&1 | FileCheck --check-prefix=W32-ERR --implicit-check-not=error: %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=+wavefrontsize64 %s 2>&1 | FileCheck --check-prefix=W64-ERR --implicit-check-not=error: %s
 
 v_add_co_ci_u32_dpp v5, vcc_lo, v1, v2, vcc_lo dpp8:[7,6,5,4,3,2,1,0]
 // W32: encoding: [0xe9,0x04,0x0a,0x40,0x01,0x77,0x39,0x05]

--- a/llvm/test/MC/AMDGPU/gfx11_asm_vop2_t16_err.s
+++ b/llvm/test/MC/AMDGPU/gfx11_asm_vop2_t16_err.s
@@ -1,5 +1,5 @@
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=+wavefrontsize32,-wavefrontsize64 -show-encoding %s 2>&1 | FileCheck --check-prefix=GFX11 --implicit-check-not=error: %s
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=-wavefrontsize32,+wavefrontsize64 -show-encoding %s 2>&1 | FileCheck --check-prefix=GFX11 --implicit-check-not=error: %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=+wavefrontsize32 -show-encoding %s 2>&1 | FileCheck --check-prefix=GFX11 --implicit-check-not=error: %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=+wavefrontsize64 -show-encoding %s 2>&1 | FileCheck --check-prefix=GFX11 --implicit-check-not=error: %s
 
 v_add_f16_e32 v255, v1, v2
 // GFX11: :[[@LINE-1]]:{{[0-9]+}}: error: operands are not valid for this GPU or mode

--- a/llvm/test/MC/AMDGPU/gfx11_asm_vop2_t16_promote.s
+++ b/llvm/test/MC/AMDGPU/gfx11_asm_vop2_t16_promote.s
@@ -1,5 +1,5 @@
-// RUN: llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=+wavefrontsize32,-wavefrontsize64 -show-encoding %s 2>&1 | FileCheck --check-prefix=GFX11 --implicit-check-not=_e32 %s
-// RUN: llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=-wavefrontsize32,+wavefrontsize64 -show-encoding %s 2>&1 | FileCheck --check-prefix=GFX11 --implicit-check-not=_e32 %s
+// RUN: llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=+wavefrontsize32 -show-encoding %s 2>&1 | FileCheck --check-prefix=GFX11 --implicit-check-not=_e32 %s
+// RUN: llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=+wavefrontsize64 -show-encoding %s 2>&1 | FileCheck --check-prefix=GFX11 --implicit-check-not=_e32 %s
 
 v_add_f16 v255, v1, v2
 // GFX11: v_add_f16_e64

--- a/llvm/test/MC/AMDGPU/gfx11_asm_vop3.s
+++ b/llvm/test/MC/AMDGPU/gfx11_asm_vop3.s
@@ -1,7 +1,7 @@
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=+wavefrontsize32,-wavefrontsize64 -show-encoding %s | FileCheck --check-prefixes=GFX11,W32 %s
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=-wavefrontsize32,+wavefrontsize64 -show-encoding %s | FileCheck --check-prefixes=GFX11,W64 %s
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=+wavefrontsize32,-wavefrontsize64 %s 2>&1 | FileCheck --check-prefix=W32-ERR --implicit-check-not=error: %s
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=-wavefrontsize32,+wavefrontsize64 %s 2>&1 | FileCheck --check-prefix=W64-ERR --implicit-check-not=error: %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=+wavefrontsize32 -show-encoding %s | FileCheck --check-prefixes=GFX11,W32 %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=+wavefrontsize64 -show-encoding %s | FileCheck --check-prefixes=GFX11,W64 %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=+wavefrontsize32 %s 2>&1 | FileCheck --check-prefix=W32-ERR --implicit-check-not=error: %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=+wavefrontsize64 %s 2>&1 | FileCheck --check-prefix=W64-ERR --implicit-check-not=error: %s
 
 v_add3_u32 v5, v1, v2, s3
 // GFX11: encoding: [0x05,0x00,0x55,0xd6,0x01,0x05,0x0e,0x00]

--- a/llvm/test/MC/AMDGPU/gfx11_asm_vop3_alias.s
+++ b/llvm/test/MC/AMDGPU/gfx11_asm_vop3_alias.s
@@ -1,5 +1,5 @@
-// RUN: llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=+wavefrontsize32,-wavefrontsize64 -show-encoding %s | FileCheck -check-prefix=GFX11 %s
-// RUN: llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=-wavefrontsize32,+wavefrontsize64 -show-encoding %s | FileCheck -check-prefix=GFX11 %s
+// RUN: llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=+wavefrontsize32 -show-encoding %s | FileCheck -check-prefix=GFX11 %s
+// RUN: llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=+wavefrontsize64 -show-encoding %s | FileCheck -check-prefix=GFX11 %s
 
 v_cvt_pknorm_i16_f16 v5, v1, v2
 // GFX11: v_cvt_pk_norm_i16_f16 v5, v1, v2        ; encoding: [0x05,0x00,0x12,0xd7,0x01,0x05,0x02,0x00]

--- a/llvm/test/MC/AMDGPU/gfx11_asm_vop3_dpp16.s
+++ b/llvm/test/MC/AMDGPU/gfx11_asm_vop3_dpp16.s
@@ -1,7 +1,7 @@
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=+wavefrontsize32,-wavefrontsize64 -show-encoding %s | FileCheck --check-prefixes=GFX11,W32 %s
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=-wavefrontsize32,+wavefrontsize64 -show-encoding %s | FileCheck --check-prefixes=GFX11,W64 %s
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=+wavefrontsize32,-wavefrontsize64 %s 2>&1 | FileCheck --check-prefixes=GFX11-ERR,W32-ERR --implicit-check-not=error: %s
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=-wavefrontsize32,+wavefrontsize64 %s 2>&1 | FileCheck --check-prefixes=GFX11-ERR,W64-ERR --implicit-check-not=error: %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=+wavefrontsize32 -show-encoding %s | FileCheck --check-prefixes=GFX11,W32 %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=+wavefrontsize64 -show-encoding %s | FileCheck --check-prefixes=GFX11,W64 %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=+wavefrontsize32 %s 2>&1 | FileCheck --check-prefixes=GFX11-ERR,W32-ERR --implicit-check-not=error: %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=+wavefrontsize64 %s 2>&1 | FileCheck --check-prefixes=GFX11-ERR,W64-ERR --implicit-check-not=error: %s
 
 v_add3_u32_e64_dpp v5, v1, v2, v3 quad_perm:[3,2,1,0]
 // GFX11: [0x05,0x00,0x55,0xd6,0xfa,0x04,0x0e,0x04,0x01,0x1b,0x00,0xff]

--- a/llvm/test/MC/AMDGPU/gfx11_asm_vop3_dpp16_from_vop1-fake16.s
+++ b/llvm/test/MC/AMDGPU/gfx11_asm_vop3_dpp16_from_vop1-fake16.s
@@ -1,4 +1,4 @@
-// RUN: llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=-real-true16,+wavefrontsize32,-wavefrontsize64 -show-encoding %s | FileCheck --check-prefixes=GFX11 %s
+// RUN: llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=-real-true16,+wavefrontsize32 -show-encoding %s | FileCheck --check-prefixes=GFX11 %s
 
 v_ceil_f16_e64_dpp v5, v1 quad_perm:[3,2,1,0]
 // GFX11: [0x05,0x00,0xdc,0xd5,0xfa,0x00,0x00,0x00,0x01,0x1b,0x00,0xff]

--- a/llvm/test/MC/AMDGPU/gfx11_asm_vop3_dpp16_from_vop1.s
+++ b/llvm/test/MC/AMDGPU/gfx11_asm_vop3_dpp16_from_vop1.s
@@ -1,4 +1,4 @@
-// RUN: llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=+real-true16,+wavefrontsize32,-wavefrontsize64 -show-encoding %s | FileCheck --check-prefixes=GFX11 %s
+// RUN: llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=+real-true16,+wavefrontsize32 -show-encoding %s | FileCheck --check-prefixes=GFX11 %s
 
 v_bfrev_b32_e64_dpp v5, v1 quad_perm:[3,2,1,0]
 // GFX11: [0x05,0x00,0xb8,0xd5,0xfa,0x00,0x00,0x00,0x01,0x1b,0x00,0xff]

--- a/llvm/test/MC/AMDGPU/gfx11_asm_vop3_dpp16_from_vop2.s
+++ b/llvm/test/MC/AMDGPU/gfx11_asm_vop3_dpp16_from_vop2.s
@@ -1,7 +1,7 @@
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=+wavefrontsize32,-wavefrontsize64 -show-encoding %s | FileCheck --check-prefixes=GFX11,W32 %s
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=-wavefrontsize32,+wavefrontsize64 -show-encoding %s | FileCheck --check-prefixes=GFX11,W64 %s
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=+wavefrontsize32,-wavefrontsize64 %s 2>&1 | FileCheck --check-prefixes=W32-ERR --implicit-check-not=error: %s
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=-wavefrontsize32,+wavefrontsize64 %s 2>&1 | FileCheck --check-prefixes=W64-ERR --implicit-check-not=error: %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=+wavefrontsize32 -show-encoding %s | FileCheck --check-prefixes=GFX11,W32 %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=+wavefrontsize64 -show-encoding %s | FileCheck --check-prefixes=GFX11,W64 %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=+wavefrontsize32 %s 2>&1 | FileCheck --check-prefixes=W32-ERR --implicit-check-not=error: %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=+wavefrontsize64 %s 2>&1 | FileCheck --check-prefixes=W64-ERR --implicit-check-not=error: %s
 
 v_add_co_ci_u32_e64_dpp v5, s6, v1, v2, s3 quad_perm:[3,2,1,0]
 // W32: [0x05,0x06,0x20,0xd5,0xfa,0x04,0x0e,0x00,0x01,0x1b,0x00,0xff]

--- a/llvm/test/MC/AMDGPU/gfx11_asm_vop3_dpp16_from_vopc.s
+++ b/llvm/test/MC/AMDGPU/gfx11_asm_vop3_dpp16_from_vopc.s
@@ -1,7 +1,7 @@
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=+wavefrontsize32,-wavefrontsize64 -show-encoding %s | FileCheck --check-prefixes=GFX11,W32 %s
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=-wavefrontsize32,+wavefrontsize64 -show-encoding %s | FileCheck --check-prefixes=GFX11,W64 %s
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=+wavefrontsize32,-wavefrontsize64 %s 2>&1 | FileCheck --check-prefix=W32-ERR --implicit-check-not=error: %s
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=-wavefrontsize32,+wavefrontsize64 %s 2>&1 | FileCheck --check-prefix=W64-ERR --implicit-check-not=error: %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=+wavefrontsize32 -show-encoding %s | FileCheck --check-prefixes=GFX11,W32 %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=+wavefrontsize64 -show-encoding %s | FileCheck --check-prefixes=GFX11,W64 %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=+wavefrontsize32 %s 2>&1 | FileCheck --check-prefix=W32-ERR --implicit-check-not=error: %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=+wavefrontsize64 %s 2>&1 | FileCheck --check-prefix=W64-ERR --implicit-check-not=error: %s
 
 v_cmp_class_f16_e64_dpp s5, v1, v2 quad_perm:[3,2,1,0]
 // W32: [0x05,0x00,0x7d,0xd4,0xfa,0x04,0x02,0x00,0x01,0x1b,0x00,0xff]

--- a/llvm/test/MC/AMDGPU/gfx11_asm_vop3_dpp16_from_vopcx.s
+++ b/llvm/test/MC/AMDGPU/gfx11_asm_vop3_dpp16_from_vopcx.s
@@ -1,5 +1,5 @@
-// RUN: llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=+wavefrontsize32,-wavefrontsize64 -show-encoding %s | FileCheck --check-prefixes=GFX11 %s
-// RUN: llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=-wavefrontsize32,+wavefrontsize64 -show-encoding %s | FileCheck --check-prefixes=GFX11 %s
+// RUN: llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=+wavefrontsize32 -show-encoding %s | FileCheck --check-prefixes=GFX11 %s
+// RUN: llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=+wavefrontsize64 -show-encoding %s | FileCheck --check-prefixes=GFX11 %s
 
 
 v_cmpx_class_f16_e64_dpp v1, v2 quad_perm:[3,2,1,0]

--- a/llvm/test/MC/AMDGPU/gfx11_asm_vop3_dpp8.s
+++ b/llvm/test/MC/AMDGPU/gfx11_asm_vop3_dpp8.s
@@ -1,7 +1,7 @@
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=+wavefrontsize32,-wavefrontsize64 -show-encoding %s | FileCheck --check-prefixes=GFX11,W32 %s
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=-wavefrontsize32,+wavefrontsize64 -show-encoding %s | FileCheck --check-prefixes=GFX11,W64 %s
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=+wavefrontsize32,-wavefrontsize64 %s 2>&1 | FileCheck --check-prefixes=GFX11-ERR,W32-ERR --implicit-check-not=error: %s
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=-wavefrontsize32,+wavefrontsize64 %s 2>&1 | FileCheck --check-prefixes=GFX11-ERR,W64-ERR --implicit-check-not=error: %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=+wavefrontsize32 -show-encoding %s | FileCheck --check-prefixes=GFX11,W32 %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=+wavefrontsize64 -show-encoding %s | FileCheck --check-prefixes=GFX11,W64 %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=+wavefrontsize32 %s 2>&1 | FileCheck --check-prefixes=GFX11-ERR,W32-ERR --implicit-check-not=error: %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=+wavefrontsize64 %s 2>&1 | FileCheck --check-prefixes=GFX11-ERR,W64-ERR --implicit-check-not=error: %s
 
 v_add3_u32_e64_dpp v5, v1, v2, v3 dpp8:[7,6,5,4,3,2,1,0]
 // GFX11: [0x05,0x00,0x55,0xd6,0xe9,0x04,0x0e,0x04,0x01,0x77,0x39,0x05]

--- a/llvm/test/MC/AMDGPU/gfx11_asm_vop3_dpp8_from_vop1-fake16.s
+++ b/llvm/test/MC/AMDGPU/gfx11_asm_vop3_dpp8_from_vop1-fake16.s
@@ -1,4 +1,4 @@
-// RUN: llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=-real-true16,+wavefrontsize32,-wavefrontsize64 -show-encoding %s | FileCheck --check-prefix=GFX11 %s
+// RUN: llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=-real-true16,+wavefrontsize32 -show-encoding %s | FileCheck --check-prefix=GFX11 %s
 
 v_ceil_f16_e64_dpp v5, v1 dpp8:[7,6,5,4,3,2,1,0]
 // GFX11: [0x05,0x00,0xdc,0xd5,0xe9,0x00,0x00,0x00,0x01,0x77,0x39,0x05]

--- a/llvm/test/MC/AMDGPU/gfx11_asm_vop3_dpp8_from_vop1.s
+++ b/llvm/test/MC/AMDGPU/gfx11_asm_vop3_dpp8_from_vop1.s
@@ -1,4 +1,4 @@
-// RUN: llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=+real-true16,+wavefrontsize32,-wavefrontsize64 -show-encoding %s | FileCheck --check-prefix=GFX11 %s
+// RUN: llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=+real-true16,+wavefrontsize32 -show-encoding %s | FileCheck --check-prefix=GFX11 %s
 
 v_bfrev_b32_e64_dpp v5, v1 dpp8:[7,6,5,4,3,2,1,0]
 // GFX11: [0x05,0x00,0xb8,0xd5,0xe9,0x00,0x00,0x00,0x01,0x77,0x39,0x05]

--- a/llvm/test/MC/AMDGPU/gfx11_asm_vop3_dpp8_from_vop2.s
+++ b/llvm/test/MC/AMDGPU/gfx11_asm_vop3_dpp8_from_vop2.s
@@ -1,7 +1,7 @@
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=+wavefrontsize32,-wavefrontsize64 -show-encoding %s | FileCheck --check-prefixes=GFX11,W32 %s
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=-wavefrontsize32,+wavefrontsize64 -show-encoding %s | FileCheck --check-prefixes=GFX11,W64 %s
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=+wavefrontsize32,-wavefrontsize64 %s 2>&1 | FileCheck --check-prefixes=W32-ERR --implicit-check-not=error: %s
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=-wavefrontsize32,+wavefrontsize64 %s 2>&1 | FileCheck --check-prefixes=W64-ERR --implicit-check-not=error: %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=+wavefrontsize32 -show-encoding %s | FileCheck --check-prefixes=GFX11,W32 %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=+wavefrontsize64 -show-encoding %s | FileCheck --check-prefixes=GFX11,W64 %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=+wavefrontsize32 %s 2>&1 | FileCheck --check-prefixes=W32-ERR --implicit-check-not=error: %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=+wavefrontsize64 %s 2>&1 | FileCheck --check-prefixes=W64-ERR --implicit-check-not=error: %s
 
 v_add_co_ci_u32_e64_dpp v5, s6, v1, v2, s3 dpp8:[7,6,5,4,3,2,1,0]
 // W32: [0x05,0x06,0x20,0xd5,0xe9,0x04,0x0e,0x00,0x01,0x77,0x39,0x05]

--- a/llvm/test/MC/AMDGPU/gfx11_asm_vop3_dpp8_from_vopc.s
+++ b/llvm/test/MC/AMDGPU/gfx11_asm_vop3_dpp8_from_vopc.s
@@ -1,7 +1,7 @@
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=+wavefrontsize32,-wavefrontsize64 -show-encoding %s | FileCheck --check-prefixes=GFX11,W32 %s
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=-wavefrontsize32,+wavefrontsize64 -show-encoding %s | FileCheck --check-prefixes=GFX11,W64 %s
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=+wavefrontsize32,-wavefrontsize64 %s 2>&1 | FileCheck --check-prefix=W32-ERR --implicit-check-not=error: %s
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=-wavefrontsize32,+wavefrontsize64 %s 2>&1 | FileCheck --check-prefix=W64-ERR --implicit-check-not=error: %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=+wavefrontsize32 -show-encoding %s | FileCheck --check-prefixes=GFX11,W32 %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=+wavefrontsize64 -show-encoding %s | FileCheck --check-prefixes=GFX11,W64 %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=+wavefrontsize32 %s 2>&1 | FileCheck --check-prefix=W32-ERR --implicit-check-not=error: %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=+wavefrontsize64 %s 2>&1 | FileCheck --check-prefix=W64-ERR --implicit-check-not=error: %s
 
 v_cmp_class_f16_e64_dpp s5, v1, v2 dpp8:[7,6,5,4,3,2,1,0]
 // W32: [0x05,0x00,0x7d,0xd4,0xe9,0x04,0x02,0x00,0x01,0x77,0x39,0x05]

--- a/llvm/test/MC/AMDGPU/gfx11_asm_vop3_dpp8_from_vopcx.s
+++ b/llvm/test/MC/AMDGPU/gfx11_asm_vop3_dpp8_from_vopcx.s
@@ -1,5 +1,5 @@
-// RUN: llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=+wavefrontsize32,-wavefrontsize64 -show-encoding %s | FileCheck --check-prefixes=GFX11 %s
-// RUN: llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=-wavefrontsize32,+wavefrontsize64 -show-encoding %s | FileCheck --check-prefixes=GFX11 %s
+// RUN: llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=+wavefrontsize32 -show-encoding %s | FileCheck --check-prefixes=GFX11 %s
+// RUN: llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=+wavefrontsize64 -show-encoding %s | FileCheck --check-prefixes=GFX11 %s
 
 v_cmpx_class_f16_e64_dpp v1, v2 dpp8:[7,6,5,4,3,2,1,0]
 // GFX11: [0x7e,0x00,0xfd,0xd4,0xe9,0x04,0x02,0x00,0x01,0x77,0x39,0x05]

--- a/llvm/test/MC/AMDGPU/gfx11_asm_vop3_err.s
+++ b/llvm/test/MC/AMDGPU/gfx11_asm_vop3_err.s
@@ -1,5 +1,5 @@
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=+wavefrontsize32,-wavefrontsize64 -show-encoding %s 2>&1 | FileCheck --check-prefix=GFX11 --implicit-check-not=error: %s
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=-wavefrontsize32,+wavefrontsize64 -show-encoding %s 2>&1 | FileCheck --check-prefix=GFX11 --implicit-check-not=error: %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=+wavefrontsize32 -show-encoding %s 2>&1 | FileCheck --check-prefix=GFX11 --implicit-check-not=error: %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=+wavefrontsize64 -show-encoding %s 2>&1 | FileCheck --check-prefix=GFX11 --implicit-check-not=error: %s
 
 v_permlane16_b32 v5, v1, s2, s3 op_sel:[0, 0, 0, 1]
 // GFX11: :[[@LINE-1]]:{{[0-9]+}}: error: invalid op_sel operand

--- a/llvm/test/MC/AMDGPU/gfx11_asm_vop3_from_vop1.s
+++ b/llvm/test/MC/AMDGPU/gfx11_asm_vop3_from_vop1.s
@@ -1,4 +1,4 @@
-// RUN: llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=+wavefrontsize32,-wavefrontsize64 -show-encoding %s | FileCheck --check-prefix=GFX11 %s
+// RUN: llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=+wavefrontsize32 -show-encoding %s | FileCheck --check-prefix=GFX11 %s
 
 v_bfrev_b32_e64 v5, v1
 // GFX11: encoding: [0x05,0x00,0xb8,0xd5,0x01,0x01,0x00,0x00]

--- a/llvm/test/MC/AMDGPU/gfx11_asm_vop3_from_vop2.s
+++ b/llvm/test/MC/AMDGPU/gfx11_asm_vop3_from_vop2.s
@@ -1,7 +1,7 @@
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=+wavefrontsize32,-wavefrontsize64 -show-encoding %s | FileCheck --check-prefixes=GFX11,W32 %s
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=-wavefrontsize32,+wavefrontsize64 -show-encoding %s | FileCheck --check-prefixes=GFX11,W64 %s
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=+wavefrontsize32,-wavefrontsize64 %s 2>&1 | FileCheck --check-prefix=W32-ERR --implicit-check-not=error: %s
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=-wavefrontsize32,+wavefrontsize64 %s 2>&1 | FileCheck --check-prefix=W64-ERR --implicit-check-not=error: %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=+wavefrontsize32 -show-encoding %s | FileCheck --check-prefixes=GFX11,W32 %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=+wavefrontsize64 -show-encoding %s | FileCheck --check-prefixes=GFX11,W64 %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=+wavefrontsize32 %s 2>&1 | FileCheck --check-prefix=W32-ERR --implicit-check-not=error: %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=+wavefrontsize64 %s 2>&1 | FileCheck --check-prefix=W64-ERR --implicit-check-not=error: %s
 
 v_add_co_ci_u32_e64 v5, s6, v1, 0xaf123456, s3
 // W32: encoding: [0x05,0x06,0x20,0xd5,0x01,0xff,0x0d,0x00,0x56,0x34,0x12,0xaf]

--- a/llvm/test/MC/AMDGPU/gfx11_asm_vop3_from_vopc.s
+++ b/llvm/test/MC/AMDGPU/gfx11_asm_vop3_from_vopc.s
@@ -1,7 +1,7 @@
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=+wavefrontsize32,-wavefrontsize64 -show-encoding %s | FileCheck --check-prefixes=GFX11,W32 %s
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=-wavefrontsize32,+wavefrontsize64 -show-encoding %s | FileCheck --check-prefixes=GFX11,W64 %s
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=+wavefrontsize32,-wavefrontsize64 %s 2>&1 | FileCheck --check-prefix=W32-ERR --implicit-check-not=error: %s
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=-wavefrontsize32,+wavefrontsize64 %s 2>&1 | FileCheck --check-prefix=W64-ERR --implicit-check-not=error: %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=+wavefrontsize32 -show-encoding %s | FileCheck --check-prefixes=GFX11,W32 %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=+wavefrontsize64 -show-encoding %s | FileCheck --check-prefixes=GFX11,W64 %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=+wavefrontsize32 %s 2>&1 | FileCheck --check-prefix=W32-ERR --implicit-check-not=error: %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=+wavefrontsize64 %s 2>&1 | FileCheck --check-prefix=W64-ERR --implicit-check-not=error: %s
 
 v_cmp_class_f16_e64 s5, v1, v2
 // W32: encoding: [0x05,0x00,0x7d,0xd4,0x01,0x05,0x02,0x00]

--- a/llvm/test/MC/AMDGPU/gfx11_asm_vop3_from_vopcx.s
+++ b/llvm/test/MC/AMDGPU/gfx11_asm_vop3_from_vopcx.s
@@ -1,5 +1,5 @@
-// RUN: llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=+wavefrontsize32,-wavefrontsize64 -show-encoding %s | FileCheck --check-prefixes=GFX11 %s
-// RUN: llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=-wavefrontsize32,+wavefrontsize64 -show-encoding %s | FileCheck --check-prefixes=GFX11 %s
+// RUN: llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=+wavefrontsize32 -show-encoding %s | FileCheck --check-prefixes=GFX11 %s
+// RUN: llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=+wavefrontsize64 -show-encoding %s | FileCheck --check-prefixes=GFX11 %s
 
 v_cmpx_class_f16_e64 v1, v2
 // GFX11: encoding: [0x7e,0x00,0xfd,0xd4,0x01,0x05,0x02,0x00]

--- a/llvm/test/MC/AMDGPU/gfx11_asm_vop3p_dpp16.s
+++ b/llvm/test/MC/AMDGPU/gfx11_asm_vop3p_dpp16.s
@@ -1,5 +1,5 @@
-// RUN: llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=+wavefrontsize32,-wavefrontsize64 -show-encoding %s | FileCheck --check-prefixes=GFX11 %s
-// RUN: llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=-wavefrontsize32,+wavefrontsize64 -show-encoding %s | FileCheck --check-prefixes=GFX11 %s
+// RUN: llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=+wavefrontsize32 -show-encoding %s | FileCheck --check-prefixes=GFX11 %s
+// RUN: llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=+wavefrontsize64 -show-encoding %s | FileCheck --check-prefixes=GFX11 %s
 
 v_dot2_f32_f16 v0, v1, v2, v3 neg_lo:[0,0,0] neg_hi:[0,0,0] quad_perm:[2,2,3,1] bound_ctrl:0 fi:1
 // GFX11: v_dot2_f32_f16_e64_dpp v0, v1, v2, v3 quad_perm:[2,2,3,1] row_mask:0xf bank_mask:0xf fi:1 ; encoding: [0x00,0x40,0x13,0xcc,0xfa,0x04,0x0e,0x1c,0x01,0x7a,0x04,0xff]

--- a/llvm/test/MC/AMDGPU/gfx11_asm_vop3p_dpp8.s
+++ b/llvm/test/MC/AMDGPU/gfx11_asm_vop3p_dpp8.s
@@ -1,5 +1,5 @@
-// RUN: llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=+wavefrontsize32,-wavefrontsize64 -show-encoding %s | FileCheck --check-prefixes=GFX11 %s
-// RUN: llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=-wavefrontsize32,+wavefrontsize64 -show-encoding %s | FileCheck --check-prefixes=GFX11 %s
+// RUN: llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=+wavefrontsize32 -show-encoding %s | FileCheck --check-prefixes=GFX11 %s
+// RUN: llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=+wavefrontsize64 -show-encoding %s | FileCheck --check-prefixes=GFX11 %s
 
 v_fma_mix_f32 v0, v1, v2, v3 dpp8:[2,2,2,2,4,4,4,4]
 // GFX11: encoding: [0x00,0x00,0x20,0xcc,0xe9,0x04,0x0e,0x04,0x01,0x92,0x44,0x92]

--- a/llvm/test/MC/AMDGPU/gfx11_asm_vopc.s
+++ b/llvm/test/MC/AMDGPU/gfx11_asm_vopc.s
@@ -1,7 +1,7 @@
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=+wavefrontsize32,-wavefrontsize64 -show-encoding %s | FileCheck --check-prefix=W32 %s
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=-wavefrontsize32,+wavefrontsize64 -show-encoding %s | FileCheck --check-prefix=W64 %s
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=+wavefrontsize32,-wavefrontsize64 %s 2>&1 | FileCheck --check-prefix=W32-ERR --implicit-check-not=error: %s
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=-wavefrontsize32,+wavefrontsize64 %s 2>&1 | FileCheck --check-prefix=W64-ERR --implicit-check-not=error: %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=+wavefrontsize32 -show-encoding %s | FileCheck --check-prefix=W32 %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=+wavefrontsize64 -show-encoding %s | FileCheck --check-prefix=W64 %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=+wavefrontsize32 %s 2>&1 | FileCheck --check-prefix=W32-ERR --implicit-check-not=error: %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=+wavefrontsize64 %s 2>&1 | FileCheck --check-prefix=W64-ERR --implicit-check-not=error: %s
 
 v_cmp_class_f16_e32 vcc_lo, v1, v2
 // W32: encoding: [0x01,0x05,0xfa,0x7c]

--- a/llvm/test/MC/AMDGPU/gfx11_asm_vopc_dpp16.s
+++ b/llvm/test/MC/AMDGPU/gfx11_asm_vopc_dpp16.s
@@ -1,7 +1,7 @@
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=+wavefrontsize32,-wavefrontsize64 -show-encoding %s | FileCheck --check-prefix=W32 %s
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=-wavefrontsize32,+wavefrontsize64 -show-encoding %s | FileCheck --check-prefix=W64 %s
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=+wavefrontsize32,-wavefrontsize64 %s 2>&1 | FileCheck --check-prefix=W32-ERR --implicit-check-not=error: %s
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=-wavefrontsize32,+wavefrontsize64 %s 2>&1 | FileCheck --check-prefix=W64-ERR --implicit-check-not=error: %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=+wavefrontsize32 -show-encoding %s | FileCheck --check-prefix=W32 %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=+wavefrontsize64 -show-encoding %s | FileCheck --check-prefix=W64 %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=+wavefrontsize32 %s 2>&1 | FileCheck --check-prefix=W32-ERR --implicit-check-not=error: %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=+wavefrontsize64 %s 2>&1 | FileCheck --check-prefix=W64-ERR --implicit-check-not=error: %s
 
 v_cmp_class_f16_dpp vcc_lo, v1, v2 quad_perm:[3,2,1,0]
 // W32: encoding: [0xfa,0x04,0xfa,0x7c,0x01,0x1b,0x00,0xff]

--- a/llvm/test/MC/AMDGPU/gfx11_asm_vopc_dpp8.s
+++ b/llvm/test/MC/AMDGPU/gfx11_asm_vopc_dpp8.s
@@ -1,7 +1,7 @@
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=+wavefrontsize32,-wavefrontsize64 -show-encoding %s | FileCheck --check-prefix=W32 %s
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=-wavefrontsize32,+wavefrontsize64 -show-encoding %s | FileCheck --check-prefix=W64 %s
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=+wavefrontsize32,-wavefrontsize64 %s 2>&1 | FileCheck --check-prefix=W32-ERR --implicit-check-not=error: %s
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=-wavefrontsize32,+wavefrontsize64 %s 2>&1 | FileCheck --check-prefix=W64-ERR --implicit-check-not=error: %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=+wavefrontsize32 -show-encoding %s | FileCheck --check-prefix=W32 %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=+wavefrontsize64 -show-encoding %s | FileCheck --check-prefix=W64 %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=+wavefrontsize32 %s 2>&1 | FileCheck --check-prefix=W32-ERR --implicit-check-not=error: %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=+wavefrontsize64 %s 2>&1 | FileCheck --check-prefix=W64-ERR --implicit-check-not=error: %s
 
 v_cmp_class_f16_dpp vcc_lo, v1, v2 dpp8:[7,6,5,4,3,2,1,0]
 // W32: encoding: [0xe9,0x04,0xfa,0x7c,0x01,0x77,0x39,0x05]

--- a/llvm/test/MC/AMDGPU/gfx11_asm_vopc_t16_promote.s
+++ b/llvm/test/MC/AMDGPU/gfx11_asm_vopc_t16_promote.s
@@ -12,13 +12,13 @@ v_cmp_class_f16 vcc, vcc_hi, v255
 v_cmp_class_f16 vcc, vcc_lo, v255
 // GFX11: v_cmp_class_f16_e64
 
-v_cmp_class_f16 vcc_lo, v127, v255
+v_cmp_class_f16 vcc, v127, v255
 // GFX11: v_cmp_class_f16_e64
 
-v_cmp_class_f16 vcc_lo, vcc_hi, v255
+v_cmp_class_f16 vcc, vcc_hi, v255
 // GFX11: v_cmp_class_f16_e64
 
-v_cmp_class_f16 vcc_lo, vcc_lo, v255
+v_cmp_class_f16 vcc, vcc_lo, v255
 // GFX11: v_cmp_class_f16_e64
 
 v_cmp_eq_f16 vcc, v1, v255
@@ -33,16 +33,16 @@ v_cmp_eq_f16 vcc, vcc_hi, v255
 v_cmp_eq_f16 vcc, vcc_lo, v255
 // GFX11: v_cmp_eq_f16_e64
 
-v_cmp_eq_f16 vcc_lo, v1, v255
+v_cmp_eq_f16 vcc, v1, v255
 // GFX11: v_cmp_eq_f16_e64
 
-v_cmp_eq_f16 vcc_lo, v127, v255
+v_cmp_eq_f16 vcc, v127, v255
 // GFX11: v_cmp_eq_f16_e64
 
-v_cmp_eq_f16 vcc_lo, vcc_hi, v255
+v_cmp_eq_f16 vcc, vcc_hi, v255
 // GFX11: v_cmp_eq_f16_e64
 
-v_cmp_eq_f16 vcc_lo, vcc_lo, v255
+v_cmp_eq_f16 vcc, vcc_lo, v255
 // GFX11: v_cmp_eq_f16_e64
 
 v_cmp_eq_i16 vcc, v1, v255
@@ -57,16 +57,16 @@ v_cmp_eq_i16 vcc, vcc_hi, v255
 v_cmp_eq_i16 vcc, vcc_lo, v255
 // GFX11: v_cmp_eq_i16_e64
 
-v_cmp_eq_i16 vcc_lo, v1, v255
+v_cmp_eq_i16 vcc, v1, v255
 // GFX11: v_cmp_eq_i16_e64
 
-v_cmp_eq_i16 vcc_lo, v127, v255
+v_cmp_eq_i16 vcc, v127, v255
 // GFX11: v_cmp_eq_i16_e64
 
-v_cmp_eq_i16 vcc_lo, vcc_hi, v255
+v_cmp_eq_i16 vcc, vcc_hi, v255
 // GFX11: v_cmp_eq_i16_e64
 
-v_cmp_eq_i16 vcc_lo, vcc_lo, v255
+v_cmp_eq_i16 vcc, vcc_lo, v255
 // GFX11: v_cmp_eq_i16_e64
 
 v_cmp_eq_u16 vcc, v1, v255
@@ -81,16 +81,16 @@ v_cmp_eq_u16 vcc, vcc_hi, v255
 v_cmp_eq_u16 vcc, vcc_lo, v255
 // GFX11: v_cmp_eq_u16_e64
 
-v_cmp_eq_u16 vcc_lo, v1, v255
+v_cmp_eq_u16 vcc, v1, v255
 // GFX11: v_cmp_eq_u16_e64
 
-v_cmp_eq_u16 vcc_lo, v127, v255
+v_cmp_eq_u16 vcc, v127, v255
 // GFX11: v_cmp_eq_u16_e64
 
-v_cmp_eq_u16 vcc_lo, vcc_hi, v255
+v_cmp_eq_u16 vcc, vcc_hi, v255
 // GFX11: v_cmp_eq_u16_e64
 
-v_cmp_eq_u16 vcc_lo, vcc_lo, v255
+v_cmp_eq_u16 vcc, vcc_lo, v255
 // GFX11: v_cmp_eq_u16_e64
 
 v_cmp_f_f16 vcc, v1, v255
@@ -105,16 +105,16 @@ v_cmp_f_f16 vcc, vcc_hi, v255
 v_cmp_f_f16 vcc, vcc_lo, v255
 // GFX11: v_cmp_f_f16_e64
 
-v_cmp_f_f16 vcc_lo, v1, v255
+v_cmp_f_f16 vcc, v1, v255
 // GFX11: v_cmp_f_f16_e64
 
-v_cmp_f_f16 vcc_lo, v127, v255
+v_cmp_f_f16 vcc, v127, v255
 // GFX11: v_cmp_f_f16_e64
 
-v_cmp_f_f16 vcc_lo, vcc_hi, v255
+v_cmp_f_f16 vcc, vcc_hi, v255
 // GFX11: v_cmp_f_f16_e64
 
-v_cmp_f_f16 vcc_lo, vcc_lo, v255
+v_cmp_f_f16 vcc, vcc_lo, v255
 // GFX11: v_cmp_f_f16_e64
 
 v_cmp_ge_f16 vcc, v1, v255
@@ -129,16 +129,16 @@ v_cmp_ge_f16 vcc, vcc_hi, v255
 v_cmp_ge_f16 vcc, vcc_lo, v255
 // GFX11: v_cmp_ge_f16_e64
 
-v_cmp_ge_f16 vcc_lo, v1, v255
+v_cmp_ge_f16 vcc, v1, v255
 // GFX11: v_cmp_ge_f16_e64
 
-v_cmp_ge_f16 vcc_lo, v127, v255
+v_cmp_ge_f16 vcc, v127, v255
 // GFX11: v_cmp_ge_f16_e64
 
-v_cmp_ge_f16 vcc_lo, vcc_hi, v255
+v_cmp_ge_f16 vcc, vcc_hi, v255
 // GFX11: v_cmp_ge_f16_e64
 
-v_cmp_ge_f16 vcc_lo, vcc_lo, v255
+v_cmp_ge_f16 vcc, vcc_lo, v255
 // GFX11: v_cmp_ge_f16_e64
 
 v_cmp_ge_i16 vcc, v1, v255
@@ -153,16 +153,16 @@ v_cmp_ge_i16 vcc, vcc_hi, v255
 v_cmp_ge_i16 vcc, vcc_lo, v255
 // GFX11: v_cmp_ge_i16_e64
 
-v_cmp_ge_i16 vcc_lo, v1, v255
+v_cmp_ge_i16 vcc, v1, v255
 // GFX11: v_cmp_ge_i16_e64
 
-v_cmp_ge_i16 vcc_lo, v127, v255
+v_cmp_ge_i16 vcc, v127, v255
 // GFX11: v_cmp_ge_i16_e64
 
-v_cmp_ge_i16 vcc_lo, vcc_hi, v255
+v_cmp_ge_i16 vcc, vcc_hi, v255
 // GFX11: v_cmp_ge_i16_e64
 
-v_cmp_ge_i16 vcc_lo, vcc_lo, v255
+v_cmp_ge_i16 vcc, vcc_lo, v255
 // GFX11: v_cmp_ge_i16_e64
 
 v_cmp_ge_u16 vcc, v1, v255
@@ -177,16 +177,16 @@ v_cmp_ge_u16 vcc, vcc_hi, v255
 v_cmp_ge_u16 vcc, vcc_lo, v255
 // GFX11: v_cmp_ge_u16_e64
 
-v_cmp_ge_u16 vcc_lo, v1, v255
+v_cmp_ge_u16 vcc, v1, v255
 // GFX11: v_cmp_ge_u16_e64
 
-v_cmp_ge_u16 vcc_lo, v127, v255
+v_cmp_ge_u16 vcc, v127, v255
 // GFX11: v_cmp_ge_u16_e64
 
-v_cmp_ge_u16 vcc_lo, vcc_hi, v255
+v_cmp_ge_u16 vcc, vcc_hi, v255
 // GFX11: v_cmp_ge_u16_e64
 
-v_cmp_ge_u16 vcc_lo, vcc_lo, v255
+v_cmp_ge_u16 vcc, vcc_lo, v255
 // GFX11: v_cmp_ge_u16_e64
 
 v_cmp_gt_f16 vcc, v1, v255
@@ -201,16 +201,16 @@ v_cmp_gt_f16 vcc, vcc_hi, v255
 v_cmp_gt_f16 vcc, vcc_lo, v255
 // GFX11: v_cmp_gt_f16_e64
 
-v_cmp_gt_f16 vcc_lo, v1, v255
+v_cmp_gt_f16 vcc, v1, v255
 // GFX11: v_cmp_gt_f16_e64
 
-v_cmp_gt_f16 vcc_lo, v127, v255
+v_cmp_gt_f16 vcc, v127, v255
 // GFX11: v_cmp_gt_f16_e64
 
-v_cmp_gt_f16 vcc_lo, vcc_hi, v255
+v_cmp_gt_f16 vcc, vcc_hi, v255
 // GFX11: v_cmp_gt_f16_e64
 
-v_cmp_gt_f16 vcc_lo, vcc_lo, v255
+v_cmp_gt_f16 vcc, vcc_lo, v255
 // GFX11: v_cmp_gt_f16_e64
 
 v_cmp_gt_i16 vcc, v1, v255
@@ -225,16 +225,16 @@ v_cmp_gt_i16 vcc, vcc_hi, v255
 v_cmp_gt_i16 vcc, vcc_lo, v255
 // GFX11: v_cmp_gt_i16_e64
 
-v_cmp_gt_i16 vcc_lo, v1, v255
+v_cmp_gt_i16 vcc, v1, v255
 // GFX11: v_cmp_gt_i16_e64
 
-v_cmp_gt_i16 vcc_lo, v127, v255
+v_cmp_gt_i16 vcc, v127, v255
 // GFX11: v_cmp_gt_i16_e64
 
-v_cmp_gt_i16 vcc_lo, vcc_hi, v255
+v_cmp_gt_i16 vcc, vcc_hi, v255
 // GFX11: v_cmp_gt_i16_e64
 
-v_cmp_gt_i16 vcc_lo, vcc_lo, v255
+v_cmp_gt_i16 vcc, vcc_lo, v255
 // GFX11: v_cmp_gt_i16_e64
 
 v_cmp_gt_u16 vcc, v1, v255
@@ -249,16 +249,16 @@ v_cmp_gt_u16 vcc, vcc_hi, v255
 v_cmp_gt_u16 vcc, vcc_lo, v255
 // GFX11: v_cmp_gt_u16_e64
 
-v_cmp_gt_u16 vcc_lo, v1, v255
+v_cmp_gt_u16 vcc, v1, v255
 // GFX11: v_cmp_gt_u16_e64
 
-v_cmp_gt_u16 vcc_lo, v127, v255
+v_cmp_gt_u16 vcc, v127, v255
 // GFX11: v_cmp_gt_u16_e64
 
-v_cmp_gt_u16 vcc_lo, vcc_hi, v255
+v_cmp_gt_u16 vcc, vcc_hi, v255
 // GFX11: v_cmp_gt_u16_e64
 
-v_cmp_gt_u16 vcc_lo, vcc_lo, v255
+v_cmp_gt_u16 vcc, vcc_lo, v255
 // GFX11: v_cmp_gt_u16_e64
 
 v_cmp_le_f16 vcc, v1, v255
@@ -273,16 +273,16 @@ v_cmp_le_f16 vcc, vcc_hi, v255
 v_cmp_le_f16 vcc, vcc_lo, v255
 // GFX11: v_cmp_le_f16_e64
 
-v_cmp_le_f16 vcc_lo, v1, v255
+v_cmp_le_f16 vcc, v1, v255
 // GFX11: v_cmp_le_f16_e64
 
-v_cmp_le_f16 vcc_lo, v127, v255
+v_cmp_le_f16 vcc, v127, v255
 // GFX11: v_cmp_le_f16_e64
 
-v_cmp_le_f16 vcc_lo, vcc_hi, v255
+v_cmp_le_f16 vcc, vcc_hi, v255
 // GFX11: v_cmp_le_f16_e64
 
-v_cmp_le_f16 vcc_lo, vcc_lo, v255
+v_cmp_le_f16 vcc, vcc_lo, v255
 // GFX11: v_cmp_le_f16_e64
 
 v_cmp_le_i16 vcc, v1, v255
@@ -297,16 +297,16 @@ v_cmp_le_i16 vcc, vcc_hi, v255
 v_cmp_le_i16 vcc, vcc_lo, v255
 // GFX11: v_cmp_le_i16_e64
 
-v_cmp_le_i16 vcc_lo, v1, v255
+v_cmp_le_i16 vcc, v1, v255
 // GFX11: v_cmp_le_i16_e64
 
-v_cmp_le_i16 vcc_lo, v127, v255
+v_cmp_le_i16 vcc, v127, v255
 // GFX11: v_cmp_le_i16_e64
 
-v_cmp_le_i16 vcc_lo, vcc_hi, v255
+v_cmp_le_i16 vcc, vcc_hi, v255
 // GFX11: v_cmp_le_i16_e64
 
-v_cmp_le_i16 vcc_lo, vcc_lo, v255
+v_cmp_le_i16 vcc, vcc_lo, v255
 // GFX11: v_cmp_le_i16_e64
 
 v_cmp_le_u16 vcc, v1, v255
@@ -321,16 +321,16 @@ v_cmp_le_u16 vcc, vcc_hi, v255
 v_cmp_le_u16 vcc, vcc_lo, v255
 // GFX11: v_cmp_le_u16_e64
 
-v_cmp_le_u16 vcc_lo, v1, v255
+v_cmp_le_u16 vcc, v1, v255
 // GFX11: v_cmp_le_u16_e64
 
-v_cmp_le_u16 vcc_lo, v127, v255
+v_cmp_le_u16 vcc, v127, v255
 // GFX11: v_cmp_le_u16_e64
 
-v_cmp_le_u16 vcc_lo, vcc_hi, v255
+v_cmp_le_u16 vcc, vcc_hi, v255
 // GFX11: v_cmp_le_u16_e64
 
-v_cmp_le_u16 vcc_lo, vcc_lo, v255
+v_cmp_le_u16 vcc, vcc_lo, v255
 // GFX11: v_cmp_le_u16_e64
 
 v_cmp_lg_f16 vcc, v1, v255
@@ -345,16 +345,16 @@ v_cmp_lg_f16 vcc, vcc_hi, v255
 v_cmp_lg_f16 vcc, vcc_lo, v255
 // GFX11: v_cmp_lg_f16_e64
 
-v_cmp_lg_f16 vcc_lo, v1, v255
+v_cmp_lg_f16 vcc, v1, v255
 // GFX11: v_cmp_lg_f16_e64
 
-v_cmp_lg_f16 vcc_lo, v127, v255
+v_cmp_lg_f16 vcc, v127, v255
 // GFX11: v_cmp_lg_f16_e64
 
-v_cmp_lg_f16 vcc_lo, vcc_hi, v255
+v_cmp_lg_f16 vcc, vcc_hi, v255
 // GFX11: v_cmp_lg_f16_e64
 
-v_cmp_lg_f16 vcc_lo, vcc_lo, v255
+v_cmp_lg_f16 vcc, vcc_lo, v255
 // GFX11: v_cmp_lg_f16_e64
 
 v_cmp_lt_f16 vcc, v1, v255
@@ -369,16 +369,16 @@ v_cmp_lt_f16 vcc, vcc_hi, v255
 v_cmp_lt_f16 vcc, vcc_lo, v255
 // GFX11: v_cmp_lt_f16_e64
 
-v_cmp_lt_f16 vcc_lo, v1, v255
+v_cmp_lt_f16 vcc, v1, v255
 // GFX11: v_cmp_lt_f16_e64
 
-v_cmp_lt_f16 vcc_lo, v127, v255
+v_cmp_lt_f16 vcc, v127, v255
 // GFX11: v_cmp_lt_f16_e64
 
-v_cmp_lt_f16 vcc_lo, vcc_hi, v255
+v_cmp_lt_f16 vcc, vcc_hi, v255
 // GFX11: v_cmp_lt_f16_e64
 
-v_cmp_lt_f16 vcc_lo, vcc_lo, v255
+v_cmp_lt_f16 vcc, vcc_lo, v255
 // GFX11: v_cmp_lt_f16_e64
 
 v_cmp_lt_i16 vcc, v1, v255
@@ -393,16 +393,16 @@ v_cmp_lt_i16 vcc, vcc_hi, v255
 v_cmp_lt_i16 vcc, vcc_lo, v255
 // GFX11: v_cmp_lt_i16_e64
 
-v_cmp_lt_i16 vcc_lo, v1, v255
+v_cmp_lt_i16 vcc, v1, v255
 // GFX11: v_cmp_lt_i16_e64
 
-v_cmp_lt_i16 vcc_lo, v127, v255
+v_cmp_lt_i16 vcc, v127, v255
 // GFX11: v_cmp_lt_i16_e64
 
-v_cmp_lt_i16 vcc_lo, vcc_hi, v255
+v_cmp_lt_i16 vcc, vcc_hi, v255
 // GFX11: v_cmp_lt_i16_e64
 
-v_cmp_lt_i16 vcc_lo, vcc_lo, v255
+v_cmp_lt_i16 vcc, vcc_lo, v255
 // GFX11: v_cmp_lt_i16_e64
 
 v_cmp_lt_u16 vcc, v1, v255
@@ -417,16 +417,16 @@ v_cmp_lt_u16 vcc, vcc_hi, v255
 v_cmp_lt_u16 vcc, vcc_lo, v255
 // GFX11: v_cmp_lt_u16_e64
 
-v_cmp_lt_u16 vcc_lo, v1, v255
+v_cmp_lt_u16 vcc, v1, v255
 // GFX11: v_cmp_lt_u16_e64
 
-v_cmp_lt_u16 vcc_lo, v127, v255
+v_cmp_lt_u16 vcc, v127, v255
 // GFX11: v_cmp_lt_u16_e64
 
-v_cmp_lt_u16 vcc_lo, vcc_hi, v255
+v_cmp_lt_u16 vcc, vcc_hi, v255
 // GFX11: v_cmp_lt_u16_e64
 
-v_cmp_lt_u16 vcc_lo, vcc_lo, v255
+v_cmp_lt_u16 vcc, vcc_lo, v255
 // GFX11: v_cmp_lt_u16_e64
 
 v_cmp_ne_i16 vcc, v1, v255
@@ -441,16 +441,16 @@ v_cmp_ne_i16 vcc, vcc_hi, v255
 v_cmp_ne_i16 vcc, vcc_lo, v255
 // GFX11: v_cmp_ne_i16_e64
 
-v_cmp_ne_i16 vcc_lo, v1, v255
+v_cmp_ne_i16 vcc, v1, v255
 // GFX11: v_cmp_ne_i16_e64
 
-v_cmp_ne_i16 vcc_lo, v127, v255
+v_cmp_ne_i16 vcc, v127, v255
 // GFX11: v_cmp_ne_i16_e64
 
-v_cmp_ne_i16 vcc_lo, vcc_hi, v255
+v_cmp_ne_i16 vcc, vcc_hi, v255
 // GFX11: v_cmp_ne_i16_e64
 
-v_cmp_ne_i16 vcc_lo, vcc_lo, v255
+v_cmp_ne_i16 vcc, vcc_lo, v255
 // GFX11: v_cmp_ne_i16_e64
 
 v_cmp_ne_u16 vcc, v1, v255
@@ -465,16 +465,16 @@ v_cmp_ne_u16 vcc, vcc_hi, v255
 v_cmp_ne_u16 vcc, vcc_lo, v255
 // GFX11: v_cmp_ne_u16_e64
 
-v_cmp_ne_u16 vcc_lo, v1, v255
+v_cmp_ne_u16 vcc, v1, v255
 // GFX11: v_cmp_ne_u16_e64
 
-v_cmp_ne_u16 vcc_lo, v127, v255
+v_cmp_ne_u16 vcc, v127, v255
 // GFX11: v_cmp_ne_u16_e64
 
-v_cmp_ne_u16 vcc_lo, vcc_hi, v255
+v_cmp_ne_u16 vcc, vcc_hi, v255
 // GFX11: v_cmp_ne_u16_e64
 
-v_cmp_ne_u16 vcc_lo, vcc_lo, v255
+v_cmp_ne_u16 vcc, vcc_lo, v255
 // GFX11: v_cmp_ne_u16_e64
 
 v_cmp_neq_f16 vcc, v1, v255
@@ -489,16 +489,16 @@ v_cmp_neq_f16 vcc, vcc_hi, v255
 v_cmp_neq_f16 vcc, vcc_lo, v255
 // GFX11: v_cmp_neq_f16_e64
 
-v_cmp_neq_f16 vcc_lo, v1, v255
+v_cmp_neq_f16 vcc, v1, v255
 // GFX11: v_cmp_neq_f16_e64
 
-v_cmp_neq_f16 vcc_lo, v127, v255
+v_cmp_neq_f16 vcc, v127, v255
 // GFX11: v_cmp_neq_f16_e64
 
-v_cmp_neq_f16 vcc_lo, vcc_hi, v255
+v_cmp_neq_f16 vcc, vcc_hi, v255
 // GFX11: v_cmp_neq_f16_e64
 
-v_cmp_neq_f16 vcc_lo, vcc_lo, v255
+v_cmp_neq_f16 vcc, vcc_lo, v255
 // GFX11: v_cmp_neq_f16_e64
 
 v_cmp_nge_f16 vcc, v1, v255
@@ -513,16 +513,16 @@ v_cmp_nge_f16 vcc, vcc_hi, v255
 v_cmp_nge_f16 vcc, vcc_lo, v255
 // GFX11: v_cmp_nge_f16_e64
 
-v_cmp_nge_f16 vcc_lo, v1, v255
+v_cmp_nge_f16 vcc, v1, v255
 // GFX11: v_cmp_nge_f16_e64
 
-v_cmp_nge_f16 vcc_lo, v127, v255
+v_cmp_nge_f16 vcc, v127, v255
 // GFX11: v_cmp_nge_f16_e64
 
-v_cmp_nge_f16 vcc_lo, vcc_hi, v255
+v_cmp_nge_f16 vcc, vcc_hi, v255
 // GFX11: v_cmp_nge_f16_e64
 
-v_cmp_nge_f16 vcc_lo, vcc_lo, v255
+v_cmp_nge_f16 vcc, vcc_lo, v255
 // GFX11: v_cmp_nge_f16_e64
 
 v_cmp_ngt_f16 vcc, v1, v255
@@ -537,16 +537,16 @@ v_cmp_ngt_f16 vcc, vcc_hi, v255
 v_cmp_ngt_f16 vcc, vcc_lo, v255
 // GFX11: v_cmp_ngt_f16_e64
 
-v_cmp_ngt_f16 vcc_lo, v1, v255
+v_cmp_ngt_f16 vcc, v1, v255
 // GFX11: v_cmp_ngt_f16_e64
 
-v_cmp_ngt_f16 vcc_lo, v127, v255
+v_cmp_ngt_f16 vcc, v127, v255
 // GFX11: v_cmp_ngt_f16_e64
 
-v_cmp_ngt_f16 vcc_lo, vcc_hi, v255
+v_cmp_ngt_f16 vcc, vcc_hi, v255
 // GFX11: v_cmp_ngt_f16_e64
 
-v_cmp_ngt_f16 vcc_lo, vcc_lo, v255
+v_cmp_ngt_f16 vcc, vcc_lo, v255
 // GFX11: v_cmp_ngt_f16_e64
 
 v_cmp_nle_f16 vcc, v1, v255
@@ -561,16 +561,16 @@ v_cmp_nle_f16 vcc, vcc_hi, v255
 v_cmp_nle_f16 vcc, vcc_lo, v255
 // GFX11: v_cmp_nle_f16_e64
 
-v_cmp_nle_f16 vcc_lo, v1, v255
+v_cmp_nle_f16 vcc, v1, v255
 // GFX11: v_cmp_nle_f16_e64
 
-v_cmp_nle_f16 vcc_lo, v127, v255
+v_cmp_nle_f16 vcc, v127, v255
 // GFX11: v_cmp_nle_f16_e64
 
-v_cmp_nle_f16 vcc_lo, vcc_hi, v255
+v_cmp_nle_f16 vcc, vcc_hi, v255
 // GFX11: v_cmp_nle_f16_e64
 
-v_cmp_nle_f16 vcc_lo, vcc_lo, v255
+v_cmp_nle_f16 vcc, vcc_lo, v255
 // GFX11: v_cmp_nle_f16_e64
 
 v_cmp_nlg_f16 vcc, v1, v255
@@ -585,16 +585,16 @@ v_cmp_nlg_f16 vcc, vcc_hi, v255
 v_cmp_nlg_f16 vcc, vcc_lo, v255
 // GFX11: v_cmp_nlg_f16_e64
 
-v_cmp_nlg_f16 vcc_lo, v1, v255
+v_cmp_nlg_f16 vcc, v1, v255
 // GFX11: v_cmp_nlg_f16_e64
 
-v_cmp_nlg_f16 vcc_lo, v127, v255
+v_cmp_nlg_f16 vcc, v127, v255
 // GFX11: v_cmp_nlg_f16_e64
 
-v_cmp_nlg_f16 vcc_lo, vcc_hi, v255
+v_cmp_nlg_f16 vcc, vcc_hi, v255
 // GFX11: v_cmp_nlg_f16_e64
 
-v_cmp_nlg_f16 vcc_lo, vcc_lo, v255
+v_cmp_nlg_f16 vcc, vcc_lo, v255
 // GFX11: v_cmp_nlg_f16_e64
 
 v_cmp_nlt_f16 vcc, v1, v255
@@ -609,16 +609,16 @@ v_cmp_nlt_f16 vcc, vcc_hi, v255
 v_cmp_nlt_f16 vcc, vcc_lo, v255
 // GFX11: v_cmp_nlt_f16_e64
 
-v_cmp_nlt_f16 vcc_lo, v1, v255
+v_cmp_nlt_f16 vcc, v1, v255
 // GFX11: v_cmp_nlt_f16_e64
 
-v_cmp_nlt_f16 vcc_lo, v127, v255
+v_cmp_nlt_f16 vcc, v127, v255
 // GFX11: v_cmp_nlt_f16_e64
 
-v_cmp_nlt_f16 vcc_lo, vcc_hi, v255
+v_cmp_nlt_f16 vcc, vcc_hi, v255
 // GFX11: v_cmp_nlt_f16_e64
 
-v_cmp_nlt_f16 vcc_lo, vcc_lo, v255
+v_cmp_nlt_f16 vcc, vcc_lo, v255
 // GFX11: v_cmp_nlt_f16_e64
 
 v_cmp_o_f16 vcc, v1, v255
@@ -633,16 +633,16 @@ v_cmp_o_f16 vcc, vcc_hi, v255
 v_cmp_o_f16 vcc, vcc_lo, v255
 // GFX11: v_cmp_o_f16_e64
 
-v_cmp_o_f16 vcc_lo, v1, v255
+v_cmp_o_f16 vcc, v1, v255
 // GFX11: v_cmp_o_f16_e64
 
-v_cmp_o_f16 vcc_lo, v127, v255
+v_cmp_o_f16 vcc, v127, v255
 // GFX11: v_cmp_o_f16_e64
 
-v_cmp_o_f16 vcc_lo, vcc_hi, v255
+v_cmp_o_f16 vcc, vcc_hi, v255
 // GFX11: v_cmp_o_f16_e64
 
-v_cmp_o_f16 vcc_lo, vcc_lo, v255
+v_cmp_o_f16 vcc, vcc_lo, v255
 // GFX11: v_cmp_o_f16_e64
 
 v_cmp_t_f16 vcc, v1, v255
@@ -657,16 +657,16 @@ v_cmp_t_f16 vcc, vcc_hi, v255
 v_cmp_t_f16 vcc, vcc_lo, v255
 // GFX11: v_cmp_t_f16_e64
 
-v_cmp_t_f16 vcc_lo, v1, v255
+v_cmp_t_f16 vcc, v1, v255
 // GFX11: v_cmp_t_f16_e64
 
-v_cmp_t_f16 vcc_lo, v127, v255
+v_cmp_t_f16 vcc, v127, v255
 // GFX11: v_cmp_t_f16_e64
 
-v_cmp_t_f16 vcc_lo, vcc_hi, v255
+v_cmp_t_f16 vcc, vcc_hi, v255
 // GFX11: v_cmp_t_f16_e64
 
-v_cmp_t_f16 vcc_lo, vcc_lo, v255
+v_cmp_t_f16 vcc, vcc_lo, v255
 // GFX11: v_cmp_t_f16_e64
 
 v_cmp_tru_f16 vcc, v1, v255
@@ -681,16 +681,16 @@ v_cmp_tru_f16 vcc, vcc_hi, v255
 v_cmp_tru_f16 vcc, vcc_lo, v255
 // GFX11: v_cmp_t_f16_e64
 
-v_cmp_tru_f16 vcc_lo, v1, v255
+v_cmp_tru_f16 vcc, v1, v255
 // GFX11: v_cmp_t_f16_e64
 
-v_cmp_tru_f16 vcc_lo, v127, v255
+v_cmp_tru_f16 vcc, v127, v255
 // GFX11: v_cmp_t_f16_e64
 
-v_cmp_tru_f16 vcc_lo, vcc_hi, v255
+v_cmp_tru_f16 vcc, vcc_hi, v255
 // GFX11: v_cmp_t_f16_e64
 
-v_cmp_tru_f16 vcc_lo, vcc_lo, v255
+v_cmp_tru_f16 vcc, vcc_lo, v255
 // GFX11: v_cmp_t_f16_e64
 
 v_cmp_u_f16 vcc, v1, v255
@@ -705,196 +705,196 @@ v_cmp_u_f16 vcc, vcc_hi, v255
 v_cmp_u_f16 vcc, vcc_lo, v255
 // GFX11: v_cmp_u_f16_e64
 
-v_cmp_u_f16 vcc_lo, v1, v255
+v_cmp_u_f16 vcc, v1, v255
 // GFX11: v_cmp_u_f16_e64
 
-v_cmp_u_f16 vcc_lo, v127, v255
+v_cmp_u_f16 vcc, v127, v255
 // GFX11: v_cmp_u_f16_e64
 
-v_cmp_u_f16 vcc_lo, vcc_hi, v255
+v_cmp_u_f16 vcc, vcc_hi, v255
 // GFX11: v_cmp_u_f16_e64
 
-v_cmp_u_f16 vcc_lo, vcc_lo, v255
+v_cmp_u_f16 vcc, vcc_lo, v255
 // GFX11: v_cmp_u_f16_e64
 
 v_cmp_class_f16 vcc, v128, v2
 // GFX11: v_cmp_class_f16_e64
 
-v_cmp_class_f16 vcc_lo, v128, v2
+v_cmp_class_f16 vcc, v128, v2
 // GFX11: v_cmp_class_f16_e64
 
 v_cmp_eq_f16 vcc, v128, v2
 // GFX11: v_cmp_eq_f16_e64
 
-v_cmp_eq_f16 vcc_lo, v128, v2
+v_cmp_eq_f16 vcc, v128, v2
 // GFX11: v_cmp_eq_f16_e64
 
 v_cmp_eq_i16 vcc, v128, v2
 // GFX11: v_cmp_eq_i16_e64
 
-v_cmp_eq_i16 vcc_lo, v128, v2
+v_cmp_eq_i16 vcc, v128, v2
 // GFX11: v_cmp_eq_i16_e64
 
 v_cmp_eq_u16 vcc, v128, v2
 // GFX11: v_cmp_eq_u16_e64
 
-v_cmp_eq_u16 vcc_lo, v128, v2
+v_cmp_eq_u16 vcc, v128, v2
 // GFX11: v_cmp_eq_u16_e64
 
 v_cmp_f_f16 vcc, v128, v2
 // GFX11: v_cmp_f_f16_e64
 
-v_cmp_f_f16 vcc_lo, v128, v2
+v_cmp_f_f16 vcc, v128, v2
 // GFX11: v_cmp_f_f16_e64
 
 v_cmp_ge_f16 vcc, v128, v2
 // GFX11: v_cmp_ge_f16_e64
 
-v_cmp_ge_f16 vcc_lo, v128, v2
+v_cmp_ge_f16 vcc, v128, v2
 // GFX11: v_cmp_ge_f16_e64
 
 v_cmp_ge_i16 vcc, v128, v2
 // GFX11: v_cmp_ge_i16_e64
 
-v_cmp_ge_i16 vcc_lo, v128, v2
+v_cmp_ge_i16 vcc, v128, v2
 // GFX11: v_cmp_ge_i16_e64
 
 v_cmp_ge_u16 vcc, v128, v2
 // GFX11: v_cmp_ge_u16_e64
 
-v_cmp_ge_u16 vcc_lo, v128, v2
+v_cmp_ge_u16 vcc, v128, v2
 // GFX11: v_cmp_ge_u16_e64
 
 v_cmp_gt_f16 vcc, v128, v2
 // GFX11: v_cmp_gt_f16_e64
 
-v_cmp_gt_f16 vcc_lo, v128, v2
+v_cmp_gt_f16 vcc, v128, v2
 // GFX11: v_cmp_gt_f16_e64
 
 v_cmp_gt_i16 vcc, v128, v2
 // GFX11: v_cmp_gt_i16_e64
 
-v_cmp_gt_i16 vcc_lo, v128, v2
+v_cmp_gt_i16 vcc, v128, v2
 // GFX11: v_cmp_gt_i16_e64
 
 v_cmp_gt_u16 vcc, v128, v2
 // GFX11: v_cmp_gt_u16_e64
 
-v_cmp_gt_u16 vcc_lo, v128, v2
+v_cmp_gt_u16 vcc, v128, v2
 // GFX11: v_cmp_gt_u16_e64
 
 v_cmp_le_f16 vcc, v128, v2
 // GFX11: v_cmp_le_f16_e64
 
-v_cmp_le_f16 vcc_lo, v128, v2
+v_cmp_le_f16 vcc, v128, v2
 // GFX11: v_cmp_le_f16_e64
 
 v_cmp_le_i16 vcc, v128, v2
 // GFX11: v_cmp_le_i16_e64
 
-v_cmp_le_i16 vcc_lo, v128, v2
+v_cmp_le_i16 vcc, v128, v2
 // GFX11: v_cmp_le_i16_e64
 
 v_cmp_le_u16 vcc, v128, v2
 // GFX11: v_cmp_le_u16_e64
 
-v_cmp_le_u16 vcc_lo, v128, v2
+v_cmp_le_u16 vcc, v128, v2
 // GFX11: v_cmp_le_u16_e64
 
 v_cmp_lg_f16 vcc, v128, v2
 // GFX11: v_cmp_lg_f16_e64
 
-v_cmp_lg_f16 vcc_lo, v128, v2
+v_cmp_lg_f16 vcc, v128, v2
 // GFX11: v_cmp_lg_f16_e64
 
 v_cmp_lt_f16 vcc, v128, v2
 // GFX11: v_cmp_lt_f16_e64
 
-v_cmp_lt_f16 vcc_lo, v128, v2
+v_cmp_lt_f16 vcc, v128, v2
 // GFX11: v_cmp_lt_f16_e64
 
 v_cmp_lt_i16 vcc, v128, v2
 // GFX11: v_cmp_lt_i16_e64
 
-v_cmp_lt_i16 vcc_lo, v128, v2
+v_cmp_lt_i16 vcc, v128, v2
 // GFX11: v_cmp_lt_i16_e64
 
 v_cmp_lt_u16 vcc, v128, v2
 // GFX11: v_cmp_lt_u16_e64
 
-v_cmp_lt_u16 vcc_lo, v128, v2
+v_cmp_lt_u16 vcc, v128, v2
 // GFX11: v_cmp_lt_u16_e64
 
 v_cmp_ne_i16 vcc, v128, v2
 // GFX11: v_cmp_ne_i16_e64
 
-v_cmp_ne_i16 vcc_lo, v128, v2
+v_cmp_ne_i16 vcc, v128, v2
 // GFX11: v_cmp_ne_i16_e64
 
 v_cmp_ne_u16 vcc, v128, v2
 // GFX11: v_cmp_ne_u16_e64
 
-v_cmp_ne_u16 vcc_lo, v128, v2
+v_cmp_ne_u16 vcc, v128, v2
 // GFX11: v_cmp_ne_u16_e64
 
 v_cmp_neq_f16 vcc, v128, v2
 // GFX11: v_cmp_neq_f16_e64
 
-v_cmp_neq_f16 vcc_lo, v128, v2
+v_cmp_neq_f16 vcc, v128, v2
 // GFX11: v_cmp_neq_f16_e64
 
 v_cmp_nge_f16 vcc, v128, v2
 // GFX11: v_cmp_nge_f16_e64
 
-v_cmp_nge_f16 vcc_lo, v128, v2
+v_cmp_nge_f16 vcc, v128, v2
 // GFX11: v_cmp_nge_f16_e64
 
 v_cmp_ngt_f16 vcc, v128, v2
 // GFX11: v_cmp_ngt_f16_e64
 
-v_cmp_ngt_f16 vcc_lo, v128, v2
+v_cmp_ngt_f16 vcc, v128, v2
 // GFX11: v_cmp_ngt_f16_e64
 
 v_cmp_nle_f16 vcc, v128, v2
 // GFX11: v_cmp_nle_f16_e64
 
-v_cmp_nle_f16 vcc_lo, v128, v2
+v_cmp_nle_f16 vcc, v128, v2
 // GFX11: v_cmp_nle_f16_e64
 
 v_cmp_nlg_f16 vcc, v128, v2
 // GFX11: v_cmp_nlg_f16_e64
 
-v_cmp_nlg_f16 vcc_lo, v128, v2
+v_cmp_nlg_f16 vcc, v128, v2
 // GFX11: v_cmp_nlg_f16_e64
 
 v_cmp_nlt_f16 vcc, v128, v2
 // GFX11: v_cmp_nlt_f16_e64
 
-v_cmp_nlt_f16 vcc_lo, v128, v2
+v_cmp_nlt_f16 vcc, v128, v2
 // GFX11: v_cmp_nlt_f16_e64
 
 v_cmp_o_f16 vcc, v128, v2
 // GFX11: v_cmp_o_f16_e64
 
-v_cmp_o_f16 vcc_lo, v128, v2
+v_cmp_o_f16 vcc, v128, v2
 // GFX11: v_cmp_o_f16_e64
 
 v_cmp_t_f16 vcc, v128, v2
 // GFX11: v_cmp_t_f16_e64
 
-v_cmp_t_f16 vcc_lo, v128, v2
+v_cmp_t_f16 vcc, v128, v2
 // GFX11: v_cmp_t_f16_e64
 
 v_cmp_tru_f16 vcc, v128, v2
 // GFX11: v_cmp_t_f16_e64
 
-v_cmp_tru_f16 vcc_lo, v128, v2
+v_cmp_tru_f16 vcc, v128, v2
 // GFX11: v_cmp_t_f16_e64
 
 v_cmp_u_f16 vcc, v128, v2
 // GFX11: v_cmp_u_f16_e64
 
-v_cmp_u_f16 vcc_lo, v128, v2
+v_cmp_u_f16 vcc, v128, v2
 // GFX11: v_cmp_u_f16_e64
 
 v_cmp_class_f16 vcc, v1, v255 quad_perm:[3,2,1,0]
@@ -903,7 +903,7 @@ v_cmp_class_f16 vcc, v1, v255 quad_perm:[3,2,1,0]
 v_cmp_class_f16 vcc, v127, v255 quad_perm:[3,2,1,0]
 // GFX11: v_cmp_class_f16_e64
 
-v_cmp_class_f16 vcc_lo, v127, v255 quad_perm:[3,2,1,0]
+v_cmp_class_f16 vcc, v127, v255 quad_perm:[3,2,1,0]
 // GFX11: v_cmp_class_f16_e64
 
 v_cmp_eq_f16 vcc, v1, v255 quad_perm:[3,2,1,0]
@@ -912,10 +912,10 @@ v_cmp_eq_f16 vcc, v1, v255 quad_perm:[3,2,1,0]
 v_cmp_eq_f16 vcc, v127, v255 quad_perm:[3,2,1,0]
 // GFX11: v_cmp_eq_f16_e64
 
-v_cmp_eq_f16 vcc_lo, v1, v255 quad_perm:[3,2,1,0]
+v_cmp_eq_f16 vcc, v1, v255 quad_perm:[3,2,1,0]
 // GFX11: v_cmp_eq_f16_e64
 
-v_cmp_eq_f16 vcc_lo, v127, v255 quad_perm:[3,2,1,0]
+v_cmp_eq_f16 vcc, v127, v255 quad_perm:[3,2,1,0]
 // GFX11: v_cmp_eq_f16_e64
 
 v_cmp_eq_i16 vcc, v1, v255 quad_perm:[3,2,1,0]
@@ -924,10 +924,10 @@ v_cmp_eq_i16 vcc, v1, v255 quad_perm:[3,2,1,0]
 v_cmp_eq_i16 vcc, v127, v255 quad_perm:[3,2,1,0]
 // GFX11: v_cmp_eq_i16_e64
 
-v_cmp_eq_i16 vcc_lo, v1, v255 quad_perm:[3,2,1,0]
+v_cmp_eq_i16 vcc, v1, v255 quad_perm:[3,2,1,0]
 // GFX11: v_cmp_eq_i16_e64
 
-v_cmp_eq_i16 vcc_lo, v127, v255 quad_perm:[3,2,1,0]
+v_cmp_eq_i16 vcc, v127, v255 quad_perm:[3,2,1,0]
 // GFX11: v_cmp_eq_i16_e64
 
 v_cmp_eq_u16 vcc, v1, v255 quad_perm:[3,2,1,0]
@@ -936,10 +936,10 @@ v_cmp_eq_u16 vcc, v1, v255 quad_perm:[3,2,1,0]
 v_cmp_eq_u16 vcc, v127, v255 quad_perm:[3,2,1,0]
 // GFX11: v_cmp_eq_u16_e64
 
-v_cmp_eq_u16 vcc_lo, v1, v255 quad_perm:[3,2,1,0]
+v_cmp_eq_u16 vcc, v1, v255 quad_perm:[3,2,1,0]
 // GFX11: v_cmp_eq_u16_e64
 
-v_cmp_eq_u16 vcc_lo, v127, v255 quad_perm:[3,2,1,0]
+v_cmp_eq_u16 vcc, v127, v255 quad_perm:[3,2,1,0]
 // GFX11: v_cmp_eq_u16_e64
 
 v_cmp_f_f16 vcc, v1, v255 quad_perm:[3,2,1,0]
@@ -948,10 +948,10 @@ v_cmp_f_f16 vcc, v1, v255 quad_perm:[3,2,1,0]
 v_cmp_f_f16 vcc, v127, v255 quad_perm:[3,2,1,0]
 // GFX11: v_cmp_f_f16_e64
 
-v_cmp_f_f16 vcc_lo, v1, v255 quad_perm:[3,2,1,0]
+v_cmp_f_f16 vcc, v1, v255 quad_perm:[3,2,1,0]
 // GFX11: v_cmp_f_f16_e64
 
-v_cmp_f_f16 vcc_lo, v127, v255 quad_perm:[3,2,1,0]
+v_cmp_f_f16 vcc, v127, v255 quad_perm:[3,2,1,0]
 // GFX11: v_cmp_f_f16_e64
 
 v_cmp_ge_f16 vcc, v1, v255 quad_perm:[3,2,1,0]
@@ -960,10 +960,10 @@ v_cmp_ge_f16 vcc, v1, v255 quad_perm:[3,2,1,0]
 v_cmp_ge_f16 vcc, v127, v255 quad_perm:[3,2,1,0]
 // GFX11: v_cmp_ge_f16_e64
 
-v_cmp_ge_f16 vcc_lo, v1, v255 quad_perm:[3,2,1,0]
+v_cmp_ge_f16 vcc, v1, v255 quad_perm:[3,2,1,0]
 // GFX11: v_cmp_ge_f16_e64
 
-v_cmp_ge_f16 vcc_lo, v127, v255 quad_perm:[3,2,1,0]
+v_cmp_ge_f16 vcc, v127, v255 quad_perm:[3,2,1,0]
 // GFX11: v_cmp_ge_f16_e64
 
 v_cmp_ge_i16 vcc, v1, v255 quad_perm:[3,2,1,0]
@@ -972,10 +972,10 @@ v_cmp_ge_i16 vcc, v1, v255 quad_perm:[3,2,1,0]
 v_cmp_ge_i16 vcc, v127, v255 quad_perm:[3,2,1,0]
 // GFX11: v_cmp_ge_i16_e64
 
-v_cmp_ge_i16 vcc_lo, v1, v255 quad_perm:[3,2,1,0]
+v_cmp_ge_i16 vcc, v1, v255 quad_perm:[3,2,1,0]
 // GFX11: v_cmp_ge_i16_e64
 
-v_cmp_ge_i16 vcc_lo, v127, v255 quad_perm:[3,2,1,0]
+v_cmp_ge_i16 vcc, v127, v255 quad_perm:[3,2,1,0]
 // GFX11: v_cmp_ge_i16_e64
 
 v_cmp_ge_u16 vcc, v1, v255 quad_perm:[3,2,1,0]
@@ -984,10 +984,10 @@ v_cmp_ge_u16 vcc, v1, v255 quad_perm:[3,2,1,0]
 v_cmp_ge_u16 vcc, v127, v255 quad_perm:[3,2,1,0]
 // GFX11: v_cmp_ge_u16_e64
 
-v_cmp_ge_u16 vcc_lo, v1, v255 quad_perm:[3,2,1,0]
+v_cmp_ge_u16 vcc, v1, v255 quad_perm:[3,2,1,0]
 // GFX11: v_cmp_ge_u16_e64
 
-v_cmp_ge_u16 vcc_lo, v127, v255 quad_perm:[3,2,1,0]
+v_cmp_ge_u16 vcc, v127, v255 quad_perm:[3,2,1,0]
 // GFX11: v_cmp_ge_u16_e64
 
 v_cmp_gt_f16 vcc, v1, v255 quad_perm:[3,2,1,0]
@@ -996,10 +996,10 @@ v_cmp_gt_f16 vcc, v1, v255 quad_perm:[3,2,1,0]
 v_cmp_gt_f16 vcc, v127, v255 quad_perm:[3,2,1,0]
 // GFX11: v_cmp_gt_f16_e64
 
-v_cmp_gt_f16 vcc_lo, v1, v255 quad_perm:[3,2,1,0]
+v_cmp_gt_f16 vcc, v1, v255 quad_perm:[3,2,1,0]
 // GFX11: v_cmp_gt_f16_e64
 
-v_cmp_gt_f16 vcc_lo, v127, v255 quad_perm:[3,2,1,0]
+v_cmp_gt_f16 vcc, v127, v255 quad_perm:[3,2,1,0]
 // GFX11: v_cmp_gt_f16_e64
 
 v_cmp_gt_i16 vcc, v1, v255 quad_perm:[3,2,1,0]
@@ -1008,10 +1008,10 @@ v_cmp_gt_i16 vcc, v1, v255 quad_perm:[3,2,1,0]
 v_cmp_gt_i16 vcc, v127, v255 quad_perm:[3,2,1,0]
 // GFX11: v_cmp_gt_i16_e64
 
-v_cmp_gt_i16 vcc_lo, v1, v255 quad_perm:[3,2,1,0]
+v_cmp_gt_i16 vcc, v1, v255 quad_perm:[3,2,1,0]
 // GFX11: v_cmp_gt_i16_e64
 
-v_cmp_gt_i16 vcc_lo, v127, v255 quad_perm:[3,2,1,0]
+v_cmp_gt_i16 vcc, v127, v255 quad_perm:[3,2,1,0]
 // GFX11: v_cmp_gt_i16_e64
 
 v_cmp_gt_u16 vcc, v1, v255 quad_perm:[3,2,1,0]
@@ -1020,10 +1020,10 @@ v_cmp_gt_u16 vcc, v1, v255 quad_perm:[3,2,1,0]
 v_cmp_gt_u16 vcc, v127, v255 quad_perm:[3,2,1,0]
 // GFX11: v_cmp_gt_u16_e64
 
-v_cmp_gt_u16 vcc_lo, v1, v255 quad_perm:[3,2,1,0]
+v_cmp_gt_u16 vcc, v1, v255 quad_perm:[3,2,1,0]
 // GFX11: v_cmp_gt_u16_e64
 
-v_cmp_gt_u16 vcc_lo, v127, v255 quad_perm:[3,2,1,0]
+v_cmp_gt_u16 vcc, v127, v255 quad_perm:[3,2,1,0]
 // GFX11: v_cmp_gt_u16_e64
 
 v_cmp_le_f16 vcc, v1, v255 quad_perm:[3,2,1,0]
@@ -1032,10 +1032,10 @@ v_cmp_le_f16 vcc, v1, v255 quad_perm:[3,2,1,0]
 v_cmp_le_f16 vcc, v127, v255 quad_perm:[3,2,1,0]
 // GFX11: v_cmp_le_f16_e64
 
-v_cmp_le_f16 vcc_lo, v1, v255 quad_perm:[3,2,1,0]
+v_cmp_le_f16 vcc, v1, v255 quad_perm:[3,2,1,0]
 // GFX11: v_cmp_le_f16_e64
 
-v_cmp_le_f16 vcc_lo, v127, v255 quad_perm:[3,2,1,0]
+v_cmp_le_f16 vcc, v127, v255 quad_perm:[3,2,1,0]
 // GFX11: v_cmp_le_f16_e64
 
 v_cmp_le_i16 vcc, v1, v255 quad_perm:[3,2,1,0]
@@ -1044,10 +1044,10 @@ v_cmp_le_i16 vcc, v1, v255 quad_perm:[3,2,1,0]
 v_cmp_le_i16 vcc, v127, v255 quad_perm:[3,2,1,0]
 // GFX11: v_cmp_le_i16_e64
 
-v_cmp_le_i16 vcc_lo, v1, v255 quad_perm:[3,2,1,0]
+v_cmp_le_i16 vcc, v1, v255 quad_perm:[3,2,1,0]
 // GFX11: v_cmp_le_i16_e64
 
-v_cmp_le_i16 vcc_lo, v127, v255 quad_perm:[3,2,1,0]
+v_cmp_le_i16 vcc, v127, v255 quad_perm:[3,2,1,0]
 // GFX11: v_cmp_le_i16_e64
 
 v_cmp_le_u16 vcc, v1, v255 quad_perm:[3,2,1,0]
@@ -1056,10 +1056,10 @@ v_cmp_le_u16 vcc, v1, v255 quad_perm:[3,2,1,0]
 v_cmp_le_u16 vcc, v127, v255 quad_perm:[3,2,1,0]
 // GFX11: v_cmp_le_u16_e64
 
-v_cmp_le_u16 vcc_lo, v1, v255 quad_perm:[3,2,1,0]
+v_cmp_le_u16 vcc, v1, v255 quad_perm:[3,2,1,0]
 // GFX11: v_cmp_le_u16_e64
 
-v_cmp_le_u16 vcc_lo, v127, v255 quad_perm:[3,2,1,0]
+v_cmp_le_u16 vcc, v127, v255 quad_perm:[3,2,1,0]
 // GFX11: v_cmp_le_u16_e64
 
 v_cmp_lg_f16 vcc, v1, v255 quad_perm:[3,2,1,0]
@@ -1068,10 +1068,10 @@ v_cmp_lg_f16 vcc, v1, v255 quad_perm:[3,2,1,0]
 v_cmp_lg_f16 vcc, v127, v255 quad_perm:[3,2,1,0]
 // GFX11: v_cmp_lg_f16_e64
 
-v_cmp_lg_f16 vcc_lo, v1, v255 quad_perm:[3,2,1,0]
+v_cmp_lg_f16 vcc, v1, v255 quad_perm:[3,2,1,0]
 // GFX11: v_cmp_lg_f16_e64
 
-v_cmp_lg_f16 vcc_lo, v127, v255 quad_perm:[3,2,1,0]
+v_cmp_lg_f16 vcc, v127, v255 quad_perm:[3,2,1,0]
 // GFX11: v_cmp_lg_f16_e64
 
 v_cmp_lt_f16 vcc, v1, v255 quad_perm:[3,2,1,0]
@@ -1080,10 +1080,10 @@ v_cmp_lt_f16 vcc, v1, v255 quad_perm:[3,2,1,0]
 v_cmp_lt_f16 vcc, v127, v255 quad_perm:[3,2,1,0]
 // GFX11: v_cmp_lt_f16_e64
 
-v_cmp_lt_f16 vcc_lo, v1, v255 quad_perm:[3,2,1,0]
+v_cmp_lt_f16 vcc, v1, v255 quad_perm:[3,2,1,0]
 // GFX11: v_cmp_lt_f16_e64
 
-v_cmp_lt_f16 vcc_lo, v127, v255 quad_perm:[3,2,1,0]
+v_cmp_lt_f16 vcc, v127, v255 quad_perm:[3,2,1,0]
 // GFX11: v_cmp_lt_f16_e64
 
 v_cmp_lt_i16 vcc, v1, v255 quad_perm:[3,2,1,0]
@@ -1092,10 +1092,10 @@ v_cmp_lt_i16 vcc, v1, v255 quad_perm:[3,2,1,0]
 v_cmp_lt_i16 vcc, v127, v255 quad_perm:[3,2,1,0]
 // GFX11: v_cmp_lt_i16_e64
 
-v_cmp_lt_i16 vcc_lo, v1, v255 quad_perm:[3,2,1,0]
+v_cmp_lt_i16 vcc, v1, v255 quad_perm:[3,2,1,0]
 // GFX11: v_cmp_lt_i16_e64
 
-v_cmp_lt_i16 vcc_lo, v127, v255 quad_perm:[3,2,1,0]
+v_cmp_lt_i16 vcc, v127, v255 quad_perm:[3,2,1,0]
 // GFX11: v_cmp_lt_i16_e64
 
 v_cmp_lt_u16 vcc, v1, v255 quad_perm:[3,2,1,0]
@@ -1104,10 +1104,10 @@ v_cmp_lt_u16 vcc, v1, v255 quad_perm:[3,2,1,0]
 v_cmp_lt_u16 vcc, v127, v255 quad_perm:[3,2,1,0]
 // GFX11: v_cmp_lt_u16_e64
 
-v_cmp_lt_u16 vcc_lo, v1, v255 quad_perm:[3,2,1,0]
+v_cmp_lt_u16 vcc, v1, v255 quad_perm:[3,2,1,0]
 // GFX11: v_cmp_lt_u16_e64
 
-v_cmp_lt_u16 vcc_lo, v127, v255 quad_perm:[3,2,1,0]
+v_cmp_lt_u16 vcc, v127, v255 quad_perm:[3,2,1,0]
 // GFX11: v_cmp_lt_u16_e64
 
 v_cmp_ne_i16 vcc, v1, v255 quad_perm:[3,2,1,0]
@@ -1116,10 +1116,10 @@ v_cmp_ne_i16 vcc, v1, v255 quad_perm:[3,2,1,0]
 v_cmp_ne_i16 vcc, v127, v255 quad_perm:[3,2,1,0]
 // GFX11: v_cmp_ne_i16_e64
 
-v_cmp_ne_i16 vcc_lo, v1, v255 quad_perm:[3,2,1,0]
+v_cmp_ne_i16 vcc, v1, v255 quad_perm:[3,2,1,0]
 // GFX11: v_cmp_ne_i16_e64
 
-v_cmp_ne_i16 vcc_lo, v127, v255 quad_perm:[3,2,1,0]
+v_cmp_ne_i16 vcc, v127, v255 quad_perm:[3,2,1,0]
 // GFX11: v_cmp_ne_i16_e64
 
 v_cmp_ne_u16 vcc, v1, v255 quad_perm:[3,2,1,0]
@@ -1128,10 +1128,10 @@ v_cmp_ne_u16 vcc, v1, v255 quad_perm:[3,2,1,0]
 v_cmp_ne_u16 vcc, v127, v255 quad_perm:[3,2,1,0]
 // GFX11: v_cmp_ne_u16_e64
 
-v_cmp_ne_u16 vcc_lo, v1, v255 quad_perm:[3,2,1,0]
+v_cmp_ne_u16 vcc, v1, v255 quad_perm:[3,2,1,0]
 // GFX11: v_cmp_ne_u16_e64
 
-v_cmp_ne_u16 vcc_lo, v127, v255 quad_perm:[3,2,1,0]
+v_cmp_ne_u16 vcc, v127, v255 quad_perm:[3,2,1,0]
 // GFX11: v_cmp_ne_u16_e64
 
 v_cmp_neq_f16 vcc, v1, v255 quad_perm:[3,2,1,0]
@@ -1140,10 +1140,10 @@ v_cmp_neq_f16 vcc, v1, v255 quad_perm:[3,2,1,0]
 v_cmp_neq_f16 vcc, v127, v255 quad_perm:[3,2,1,0]
 // GFX11: v_cmp_neq_f16_e64
 
-v_cmp_neq_f16 vcc_lo, v1, v255 quad_perm:[3,2,1,0]
+v_cmp_neq_f16 vcc, v1, v255 quad_perm:[3,2,1,0]
 // GFX11: v_cmp_neq_f16_e64
 
-v_cmp_neq_f16 vcc_lo, v127, v255 quad_perm:[3,2,1,0]
+v_cmp_neq_f16 vcc, v127, v255 quad_perm:[3,2,1,0]
 // GFX11: v_cmp_neq_f16_e64
 
 v_cmp_nge_f16 vcc, v1, v255 quad_perm:[3,2,1,0]
@@ -1152,10 +1152,10 @@ v_cmp_nge_f16 vcc, v1, v255 quad_perm:[3,2,1,0]
 v_cmp_nge_f16 vcc, v127, v255 quad_perm:[3,2,1,0]
 // GFX11: v_cmp_nge_f16_e64
 
-v_cmp_nge_f16 vcc_lo, v1, v255 quad_perm:[3,2,1,0]
+v_cmp_nge_f16 vcc, v1, v255 quad_perm:[3,2,1,0]
 // GFX11: v_cmp_nge_f16_e64
 
-v_cmp_nge_f16 vcc_lo, v127, v255 quad_perm:[3,2,1,0]
+v_cmp_nge_f16 vcc, v127, v255 quad_perm:[3,2,1,0]
 // GFX11: v_cmp_nge_f16_e64
 
 v_cmp_ngt_f16 vcc, v1, v255 quad_perm:[3,2,1,0]
@@ -1164,10 +1164,10 @@ v_cmp_ngt_f16 vcc, v1, v255 quad_perm:[3,2,1,0]
 v_cmp_ngt_f16 vcc, v127, v255 quad_perm:[3,2,1,0]
 // GFX11: v_cmp_ngt_f16_e64
 
-v_cmp_ngt_f16 vcc_lo, v1, v255 quad_perm:[3,2,1,0]
+v_cmp_ngt_f16 vcc, v1, v255 quad_perm:[3,2,1,0]
 // GFX11: v_cmp_ngt_f16_e64
 
-v_cmp_ngt_f16 vcc_lo, v127, v255 quad_perm:[3,2,1,0]
+v_cmp_ngt_f16 vcc, v127, v255 quad_perm:[3,2,1,0]
 // GFX11: v_cmp_ngt_f16_e64
 
 v_cmp_nle_f16 vcc, v1, v255 quad_perm:[3,2,1,0]
@@ -1176,10 +1176,10 @@ v_cmp_nle_f16 vcc, v1, v255 quad_perm:[3,2,1,0]
 v_cmp_nle_f16 vcc, v127, v255 quad_perm:[3,2,1,0]
 // GFX11: v_cmp_nle_f16_e64
 
-v_cmp_nle_f16 vcc_lo, v1, v255 quad_perm:[3,2,1,0]
+v_cmp_nle_f16 vcc, v1, v255 quad_perm:[3,2,1,0]
 // GFX11: v_cmp_nle_f16_e64
 
-v_cmp_nle_f16 vcc_lo, v127, v255 quad_perm:[3,2,1,0]
+v_cmp_nle_f16 vcc, v127, v255 quad_perm:[3,2,1,0]
 // GFX11: v_cmp_nle_f16_e64
 
 v_cmp_nlg_f16 vcc, v1, v255 quad_perm:[3,2,1,0]
@@ -1188,10 +1188,10 @@ v_cmp_nlg_f16 vcc, v1, v255 quad_perm:[3,2,1,0]
 v_cmp_nlg_f16 vcc, v127, v255 quad_perm:[3,2,1,0]
 // GFX11: v_cmp_nlg_f16_e64
 
-v_cmp_nlg_f16 vcc_lo, v1, v255 quad_perm:[3,2,1,0]
+v_cmp_nlg_f16 vcc, v1, v255 quad_perm:[3,2,1,0]
 // GFX11: v_cmp_nlg_f16_e64
 
-v_cmp_nlg_f16 vcc_lo, v127, v255 quad_perm:[3,2,1,0]
+v_cmp_nlg_f16 vcc, v127, v255 quad_perm:[3,2,1,0]
 // GFX11: v_cmp_nlg_f16_e64
 
 v_cmp_nlt_f16 vcc, v1, v255 quad_perm:[3,2,1,0]
@@ -1200,10 +1200,10 @@ v_cmp_nlt_f16 vcc, v1, v255 quad_perm:[3,2,1,0]
 v_cmp_nlt_f16 vcc, v127, v255 quad_perm:[3,2,1,0]
 // GFX11: v_cmp_nlt_f16_e64
 
-v_cmp_nlt_f16 vcc_lo, v1, v255 quad_perm:[3,2,1,0]
+v_cmp_nlt_f16 vcc, v1, v255 quad_perm:[3,2,1,0]
 // GFX11: v_cmp_nlt_f16_e64
 
-v_cmp_nlt_f16 vcc_lo, v127, v255 quad_perm:[3,2,1,0]
+v_cmp_nlt_f16 vcc, v127, v255 quad_perm:[3,2,1,0]
 // GFX11: v_cmp_nlt_f16_e64
 
 v_cmp_o_f16 vcc, v1, v255 quad_perm:[3,2,1,0]
@@ -1212,10 +1212,10 @@ v_cmp_o_f16 vcc, v1, v255 quad_perm:[3,2,1,0]
 v_cmp_o_f16 vcc, v127, v255 quad_perm:[3,2,1,0]
 // GFX11: v_cmp_o_f16_e64
 
-v_cmp_o_f16 vcc_lo, v1, v255 quad_perm:[3,2,1,0]
+v_cmp_o_f16 vcc, v1, v255 quad_perm:[3,2,1,0]
 // GFX11: v_cmp_o_f16_e64
 
-v_cmp_o_f16 vcc_lo, v127, v255 quad_perm:[3,2,1,0]
+v_cmp_o_f16 vcc, v127, v255 quad_perm:[3,2,1,0]
 // GFX11: v_cmp_o_f16_e64
 
 v_cmp_t_f16 vcc, v1, v255 quad_perm:[3,2,1,0]
@@ -1224,10 +1224,10 @@ v_cmp_t_f16 vcc, v1, v255 quad_perm:[3,2,1,0]
 v_cmp_t_f16 vcc, v127, v255 quad_perm:[3,2,1,0]
 // GFX11: v_cmp_t_f16_e64
 
-v_cmp_t_f16 vcc_lo, v1, v255 quad_perm:[3,2,1,0]
+v_cmp_t_f16 vcc, v1, v255 quad_perm:[3,2,1,0]
 // GFX11: v_cmp_t_f16_e64
 
-v_cmp_t_f16 vcc_lo, v127, v255 quad_perm:[3,2,1,0]
+v_cmp_t_f16 vcc, v127, v255 quad_perm:[3,2,1,0]
 // GFX11: v_cmp_t_f16_e64
 
 v_cmp_tru_f16 vcc, v1, v255 quad_perm:[3,2,1,0]
@@ -1236,10 +1236,10 @@ v_cmp_tru_f16 vcc, v1, v255 quad_perm:[3,2,1,0]
 v_cmp_tru_f16 vcc, v127, v255 quad_perm:[3,2,1,0]
 // GFX11: v_cmp_t_f16_e64
 
-v_cmp_tru_f16 vcc_lo, v1, v255 quad_perm:[3,2,1,0]
+v_cmp_tru_f16 vcc, v1, v255 quad_perm:[3,2,1,0]
 // GFX11: v_cmp_t_f16_e64
 
-v_cmp_tru_f16 vcc_lo, v127, v255 quad_perm:[3,2,1,0]
+v_cmp_tru_f16 vcc, v127, v255 quad_perm:[3,2,1,0]
 // GFX11: v_cmp_t_f16_e64
 
 v_cmp_u_f16 vcc, v1, v255 quad_perm:[3,2,1,0]
@@ -1248,190 +1248,190 @@ v_cmp_u_f16 vcc, v1, v255 quad_perm:[3,2,1,0]
 v_cmp_u_f16 vcc, v127, v255 quad_perm:[3,2,1,0]
 // GFX11: v_cmp_u_f16_e64
 
-v_cmp_u_f16 vcc_lo, v1, v255 quad_perm:[3,2,1,0]
+v_cmp_u_f16 vcc, v1, v255 quad_perm:[3,2,1,0]
 // GFX11: v_cmp_u_f16_e64
 
-v_cmp_u_f16 vcc_lo, v127, v255 quad_perm:[3,2,1,0]
+v_cmp_u_f16 vcc, v127, v255 quad_perm:[3,2,1,0]
 // GFX11: v_cmp_u_f16_e64
 
 v_cmp_class_f16 vcc, v128, v2 quad_perm:[3,2,1,0]
 // GFX11: v_cmp_class_f16_e64
 
-v_cmp_class_f16 vcc_lo, v128, v2 quad_perm:[3,2,1,0]
+v_cmp_class_f16 vcc, v128, v2 quad_perm:[3,2,1,0]
 // GFX11: v_cmp_class_f16_e64
 
 v_cmp_eq_f16 vcc, v128, v2 quad_perm:[3,2,1,0]
 // GFX11: v_cmp_eq_f16_e64
 
-v_cmp_eq_f16 vcc_lo, v128, v2 quad_perm:[3,2,1,0]
+v_cmp_eq_f16 vcc, v128, v2 quad_perm:[3,2,1,0]
 // GFX11: v_cmp_eq_f16_e64
 
 v_cmp_eq_i16 vcc, v128, v2 quad_perm:[3,2,1,0]
 // GFX11: v_cmp_eq_i16_e64
 
-v_cmp_eq_i16 vcc_lo, v128, v2 quad_perm:[3,2,1,0]
+v_cmp_eq_i16 vcc, v128, v2 quad_perm:[3,2,1,0]
 // GFX11: v_cmp_eq_i16_e64
 
 v_cmp_eq_u16 vcc, v128, v2 quad_perm:[3,2,1,0]
 // GFX11: v_cmp_eq_u16_e64
 
-v_cmp_eq_u16 vcc_lo, v128, v2 quad_perm:[3,2,1,0]
+v_cmp_eq_u16 vcc, v128, v2 quad_perm:[3,2,1,0]
 // GFX11: v_cmp_eq_u16_e64
 
 v_cmp_f_f16 vcc, v128, v2 quad_perm:[3,2,1,0]
 // GFX11: v_cmp_f_f16_e64
 
-v_cmp_f_f16 vcc_lo, v128, v2 quad_perm:[3,2,1,0]
+v_cmp_f_f16 vcc, v128, v2 quad_perm:[3,2,1,0]
 // GFX11: v_cmp_f_f16_e64
 
 v_cmp_ge_f16 vcc, v128, v2 quad_perm:[3,2,1,0]
 // GFX11: v_cmp_ge_f16_e64
 
-v_cmp_ge_f16 vcc_lo, v128, v2 quad_perm:[3,2,1,0]
+v_cmp_ge_f16 vcc, v128, v2 quad_perm:[3,2,1,0]
 // GFX11: v_cmp_ge_f16_e64
 
 v_cmp_ge_i16 vcc, v128, v2 quad_perm:[3,2,1,0]
 // GFX11: v_cmp_ge_i16_e64
 
-v_cmp_ge_i16 vcc_lo, v128, v2 quad_perm:[3,2,1,0]
+v_cmp_ge_i16 vcc, v128, v2 quad_perm:[3,2,1,0]
 // GFX11: v_cmp_ge_i16_e64
 
 v_cmp_ge_u16 vcc, v128, v2 quad_perm:[3,2,1,0]
 // GFX11: v_cmp_ge_u16_e64
 
-v_cmp_ge_u16 vcc_lo, v128, v2 quad_perm:[3,2,1,0]
+v_cmp_ge_u16 vcc, v128, v2 quad_perm:[3,2,1,0]
 // GFX11: v_cmp_ge_u16_e64
 
 v_cmp_gt_f16 vcc, v128, v2 quad_perm:[3,2,1,0]
 // GFX11: v_cmp_gt_f16_e64
 
-v_cmp_gt_f16 vcc_lo, v128, v2 quad_perm:[3,2,1,0]
+v_cmp_gt_f16 vcc, v128, v2 quad_perm:[3,2,1,0]
 // GFX11: v_cmp_gt_f16_e64
 
 v_cmp_gt_i16 vcc, v128, v2 quad_perm:[3,2,1,0]
 // GFX11: v_cmp_gt_i16_e64
 
-v_cmp_gt_i16 vcc_lo, v128, v2 quad_perm:[3,2,1,0]
+v_cmp_gt_i16 vcc, v128, v2 quad_perm:[3,2,1,0]
 // GFX11: v_cmp_gt_i16_e64
 
 v_cmp_gt_u16 vcc, v128, v2 quad_perm:[3,2,1,0]
 // GFX11: v_cmp_gt_u16_e64
 
-v_cmp_gt_u16 vcc_lo, v128, v2 quad_perm:[3,2,1,0]
+v_cmp_gt_u16 vcc, v128, v2 quad_perm:[3,2,1,0]
 // GFX11: v_cmp_gt_u16_e64
 
 v_cmp_le_f16 vcc, v128, v2 quad_perm:[3,2,1,0]
 // GFX11: v_cmp_le_f16_e64
 
-v_cmp_le_f16 vcc_lo, v128, v2 quad_perm:[3,2,1,0]
+v_cmp_le_f16 vcc, v128, v2 quad_perm:[3,2,1,0]
 // GFX11: v_cmp_le_f16_e64
 
 v_cmp_le_i16 vcc, v128, v2 quad_perm:[3,2,1,0]
 // GFX11: v_cmp_le_i16_e64
 
-v_cmp_le_i16 vcc_lo, v128, v2 quad_perm:[3,2,1,0]
+v_cmp_le_i16 vcc, v128, v2 quad_perm:[3,2,1,0]
 // GFX11: v_cmp_le_i16_e64
 
 v_cmp_le_u16 vcc, v128, v2 quad_perm:[3,2,1,0]
 // GFX11: v_cmp_le_u16_e64
 
-v_cmp_le_u16 vcc_lo, v128, v2 quad_perm:[3,2,1,0]
+v_cmp_le_u16 vcc, v128, v2 quad_perm:[3,2,1,0]
 // GFX11: v_cmp_le_u16_e64
 
 v_cmp_lg_f16 vcc, v128, v2 quad_perm:[3,2,1,0]
 // GFX11: v_cmp_lg_f16_e64
 
-v_cmp_lg_f16 vcc_lo, v128, v2 quad_perm:[3,2,1,0]
+v_cmp_lg_f16 vcc, v128, v2 quad_perm:[3,2,1,0]
 // GFX11: v_cmp_lg_f16_e64
 
 v_cmp_lt_f16 vcc, v128, v2 quad_perm:[3,2,1,0]
 // GFX11: v_cmp_lt_f16_e64
 
-v_cmp_lt_f16 vcc_lo, v128, v2 quad_perm:[3,2,1,0]
+v_cmp_lt_f16 vcc, v128, v2 quad_perm:[3,2,1,0]
 // GFX11: v_cmp_lt_f16_e64
 
 v_cmp_lt_i16 vcc, v128, v2 quad_perm:[3,2,1,0]
 // GFX11: v_cmp_lt_i16_e64
 
-v_cmp_lt_i16 vcc_lo, v128, v2 quad_perm:[3,2,1,0]
+v_cmp_lt_i16 vcc, v128, v2 quad_perm:[3,2,1,0]
 // GFX11: v_cmp_lt_i16_e64
 
 v_cmp_lt_u16 vcc, v128, v2 quad_perm:[3,2,1,0]
 // GFX11: v_cmp_lt_u16_e64
 
-v_cmp_lt_u16 vcc_lo, v128, v2 quad_perm:[3,2,1,0]
+v_cmp_lt_u16 vcc, v128, v2 quad_perm:[3,2,1,0]
 // GFX11: v_cmp_lt_u16_e64
 
 v_cmp_ne_i16 vcc, v128, v2 quad_perm:[3,2,1,0]
 // GFX11: v_cmp_ne_i16_e64
 
-v_cmp_ne_i16 vcc_lo, v128, v2 quad_perm:[3,2,1,0]
+v_cmp_ne_i16 vcc, v128, v2 quad_perm:[3,2,1,0]
 // GFX11: v_cmp_ne_i16_e64
 
 v_cmp_ne_u16 vcc, v128, v2 quad_perm:[3,2,1,0]
 // GFX11: v_cmp_ne_u16_e64
 
-v_cmp_ne_u16 vcc_lo, v128, v2 quad_perm:[3,2,1,0]
+v_cmp_ne_u16 vcc, v128, v2 quad_perm:[3,2,1,0]
 // GFX11: v_cmp_ne_u16_e64
 
 v_cmp_neq_f16 vcc, v128, v2 quad_perm:[3,2,1,0]
 // GFX11: v_cmp_neq_f16_e64
 
-v_cmp_neq_f16 vcc_lo, v128, v2 quad_perm:[3,2,1,0]
+v_cmp_neq_f16 vcc, v128, v2 quad_perm:[3,2,1,0]
 // GFX11: v_cmp_neq_f16_e64
 
 v_cmp_nge_f16 vcc, v128, v2 quad_perm:[3,2,1,0]
 // GFX11: v_cmp_nge_f16_e64
 
-v_cmp_nge_f16 vcc_lo, v128, v2 quad_perm:[3,2,1,0]
+v_cmp_nge_f16 vcc, v128, v2 quad_perm:[3,2,1,0]
 // GFX11: v_cmp_nge_f16_e64
 
 v_cmp_ngt_f16 vcc, v128, v2 quad_perm:[3,2,1,0]
 // GFX11: v_cmp_ngt_f16_e64
 
-v_cmp_ngt_f16 vcc_lo, v128, v2 quad_perm:[3,2,1,0]
+v_cmp_ngt_f16 vcc, v128, v2 quad_perm:[3,2,1,0]
 // GFX11: v_cmp_ngt_f16_e64
 
 v_cmp_nle_f16 vcc, v128, v2 quad_perm:[3,2,1,0]
 // GFX11: v_cmp_nle_f16_e64
 
-v_cmp_nle_f16 vcc_lo, v128, v2 quad_perm:[3,2,1,0]
+v_cmp_nle_f16 vcc, v128, v2 quad_perm:[3,2,1,0]
 // GFX11: v_cmp_nle_f16_e64
 
 v_cmp_nlg_f16 vcc, v128, v2 quad_perm:[3,2,1,0]
 // GFX11: v_cmp_nlg_f16_e64
 
-v_cmp_nlg_f16 vcc_lo, v128, v2 quad_perm:[3,2,1,0]
+v_cmp_nlg_f16 vcc, v128, v2 quad_perm:[3,2,1,0]
 // GFX11: v_cmp_nlg_f16_e64
 
 v_cmp_nlt_f16 vcc, v128, v2 quad_perm:[3,2,1,0]
 // GFX11: v_cmp_nlt_f16_e64
 
-v_cmp_nlt_f16 vcc_lo, v128, v2 quad_perm:[3,2,1,0]
+v_cmp_nlt_f16 vcc, v128, v2 quad_perm:[3,2,1,0]
 // GFX11: v_cmp_nlt_f16_e64
 
 v_cmp_o_f16 vcc, v128, v2 quad_perm:[3,2,1,0]
 // GFX11: v_cmp_o_f16_e64
 
-v_cmp_o_f16 vcc_lo, v128, v2 quad_perm:[3,2,1,0]
+v_cmp_o_f16 vcc, v128, v2 quad_perm:[3,2,1,0]
 // GFX11: v_cmp_o_f16_e64
 
 v_cmp_t_f16 vcc, v128, v2 quad_perm:[3,2,1,0]
 // GFX11: v_cmp_t_f16_e64
 
-v_cmp_t_f16 vcc_lo, v128, v2 quad_perm:[3,2,1,0]
+v_cmp_t_f16 vcc, v128, v2 quad_perm:[3,2,1,0]
 // GFX11: v_cmp_t_f16_e64
 
 v_cmp_tru_f16 vcc, v128, v2 quad_perm:[3,2,1,0]
 // GFX11: v_cmp_t_f16_e64
 
-v_cmp_tru_f16 vcc_lo, v128, v2 quad_perm:[3,2,1,0]
+v_cmp_tru_f16 vcc, v128, v2 quad_perm:[3,2,1,0]
 // GFX11: v_cmp_t_f16_e64
 
 v_cmp_u_f16 vcc, v128, v2 quad_perm:[3,2,1,0]
 // GFX11: v_cmp_u_f16_e64
 
-v_cmp_u_f16 vcc_lo, v128, v2 quad_perm:[3,2,1,0]
+v_cmp_u_f16 vcc, v128, v2 quad_perm:[3,2,1,0]
 // GFX11: v_cmp_u_f16_e64
 
 v_cmp_class_f16 vcc, v1, v255 dpp8:[7,6,5,4,3,2,1,0]
@@ -1440,7 +1440,7 @@ v_cmp_class_f16 vcc, v1, v255 dpp8:[7,6,5,4,3,2,1,0]
 v_cmp_class_f16 vcc, v127, v255 dpp8:[7,6,5,4,3,2,1,0]
 // GFX11: v_cmp_class_f16_e64
 
-v_cmp_class_f16 vcc_lo, v127, v255 dpp8:[7,6,5,4,3,2,1,0]
+v_cmp_class_f16 vcc, v127, v255 dpp8:[7,6,5,4,3,2,1,0]
 // GFX11: v_cmp_class_f16_e64
 
 v_cmp_eq_f16 vcc, v1, v255 dpp8:[7,6,5,4,3,2,1,0]
@@ -1449,10 +1449,10 @@ v_cmp_eq_f16 vcc, v1, v255 dpp8:[7,6,5,4,3,2,1,0]
 v_cmp_eq_f16 vcc, v127, v255 dpp8:[7,6,5,4,3,2,1,0]
 // GFX11: v_cmp_eq_f16_e64
 
-v_cmp_eq_f16 vcc_lo, v1, v255 dpp8:[7,6,5,4,3,2,1,0]
+v_cmp_eq_f16 vcc, v1, v255 dpp8:[7,6,5,4,3,2,1,0]
 // GFX11: v_cmp_eq_f16_e64
 
-v_cmp_eq_f16 vcc_lo, v127, v255 dpp8:[7,6,5,4,3,2,1,0]
+v_cmp_eq_f16 vcc, v127, v255 dpp8:[7,6,5,4,3,2,1,0]
 // GFX11: v_cmp_eq_f16_e64
 
 v_cmp_eq_i16 vcc, v1, v255 dpp8:[7,6,5,4,3,2,1,0]
@@ -1461,10 +1461,10 @@ v_cmp_eq_i16 vcc, v1, v255 dpp8:[7,6,5,4,3,2,1,0]
 v_cmp_eq_i16 vcc, v127, v255 dpp8:[7,6,5,4,3,2,1,0]
 // GFX11: v_cmp_eq_i16_e64
 
-v_cmp_eq_i16 vcc_lo, v1, v255 dpp8:[7,6,5,4,3,2,1,0]
+v_cmp_eq_i16 vcc, v1, v255 dpp8:[7,6,5,4,3,2,1,0]
 // GFX11: v_cmp_eq_i16_e64
 
-v_cmp_eq_i16 vcc_lo, v127, v255 dpp8:[7,6,5,4,3,2,1,0]
+v_cmp_eq_i16 vcc, v127, v255 dpp8:[7,6,5,4,3,2,1,0]
 // GFX11: v_cmp_eq_i16_e64
 
 v_cmp_eq_u16 vcc, v1, v255 dpp8:[7,6,5,4,3,2,1,0]
@@ -1473,10 +1473,10 @@ v_cmp_eq_u16 vcc, v1, v255 dpp8:[7,6,5,4,3,2,1,0]
 v_cmp_eq_u16 vcc, v127, v255 dpp8:[7,6,5,4,3,2,1,0]
 // GFX11: v_cmp_eq_u16_e64
 
-v_cmp_eq_u16 vcc_lo, v1, v255 dpp8:[7,6,5,4,3,2,1,0]
+v_cmp_eq_u16 vcc, v1, v255 dpp8:[7,6,5,4,3,2,1,0]
 // GFX11: v_cmp_eq_u16_e64
 
-v_cmp_eq_u16 vcc_lo, v127, v255 dpp8:[7,6,5,4,3,2,1,0]
+v_cmp_eq_u16 vcc, v127, v255 dpp8:[7,6,5,4,3,2,1,0]
 // GFX11: v_cmp_eq_u16_e64
 
 v_cmp_f_f16 vcc, v1, v255 dpp8:[7,6,5,4,3,2,1,0]
@@ -1485,10 +1485,10 @@ v_cmp_f_f16 vcc, v1, v255 dpp8:[7,6,5,4,3,2,1,0]
 v_cmp_f_f16 vcc, v127, v255 dpp8:[7,6,5,4,3,2,1,0]
 // GFX11: v_cmp_f_f16_e64
 
-v_cmp_f_f16 vcc_lo, v1, v255 dpp8:[7,6,5,4,3,2,1,0]
+v_cmp_f_f16 vcc, v1, v255 dpp8:[7,6,5,4,3,2,1,0]
 // GFX11: v_cmp_f_f16_e64
 
-v_cmp_f_f16 vcc_lo, v127, v255 dpp8:[7,6,5,4,3,2,1,0]
+v_cmp_f_f16 vcc, v127, v255 dpp8:[7,6,5,4,3,2,1,0]
 // GFX11: v_cmp_f_f16_e64
 
 v_cmp_ge_f16 vcc, v1, v255 dpp8:[7,6,5,4,3,2,1,0]
@@ -1497,10 +1497,10 @@ v_cmp_ge_f16 vcc, v1, v255 dpp8:[7,6,5,4,3,2,1,0]
 v_cmp_ge_f16 vcc, v127, v255 dpp8:[7,6,5,4,3,2,1,0]
 // GFX11: v_cmp_ge_f16_e64
 
-v_cmp_ge_f16 vcc_lo, v1, v255 dpp8:[7,6,5,4,3,2,1,0]
+v_cmp_ge_f16 vcc, v1, v255 dpp8:[7,6,5,4,3,2,1,0]
 // GFX11: v_cmp_ge_f16_e64
 
-v_cmp_ge_f16 vcc_lo, v127, v255 dpp8:[7,6,5,4,3,2,1,0]
+v_cmp_ge_f16 vcc, v127, v255 dpp8:[7,6,5,4,3,2,1,0]
 // GFX11: v_cmp_ge_f16_e64
 
 v_cmp_ge_i16 vcc, v1, v255 dpp8:[7,6,5,4,3,2,1,0]
@@ -1509,10 +1509,10 @@ v_cmp_ge_i16 vcc, v1, v255 dpp8:[7,6,5,4,3,2,1,0]
 v_cmp_ge_i16 vcc, v127, v255 dpp8:[7,6,5,4,3,2,1,0]
 // GFX11: v_cmp_ge_i16_e64
 
-v_cmp_ge_i16 vcc_lo, v1, v255 dpp8:[7,6,5,4,3,2,1,0]
+v_cmp_ge_i16 vcc, v1, v255 dpp8:[7,6,5,4,3,2,1,0]
 // GFX11: v_cmp_ge_i16_e64
 
-v_cmp_ge_i16 vcc_lo, v127, v255 dpp8:[7,6,5,4,3,2,1,0]
+v_cmp_ge_i16 vcc, v127, v255 dpp8:[7,6,5,4,3,2,1,0]
 // GFX11: v_cmp_ge_i16_e64
 
 v_cmp_ge_u16 vcc, v1, v255 dpp8:[7,6,5,4,3,2,1,0]
@@ -1521,10 +1521,10 @@ v_cmp_ge_u16 vcc, v1, v255 dpp8:[7,6,5,4,3,2,1,0]
 v_cmp_ge_u16 vcc, v127, v255 dpp8:[7,6,5,4,3,2,1,0]
 // GFX11: v_cmp_ge_u16_e64
 
-v_cmp_ge_u16 vcc_lo, v1, v255 dpp8:[7,6,5,4,3,2,1,0]
+v_cmp_ge_u16 vcc, v1, v255 dpp8:[7,6,5,4,3,2,1,0]
 // GFX11: v_cmp_ge_u16_e64
 
-v_cmp_ge_u16 vcc_lo, v127, v255 dpp8:[7,6,5,4,3,2,1,0]
+v_cmp_ge_u16 vcc, v127, v255 dpp8:[7,6,5,4,3,2,1,0]
 // GFX11: v_cmp_ge_u16_e64
 
 v_cmp_gt_f16 vcc, v1, v255 dpp8:[7,6,5,4,3,2,1,0]
@@ -1533,10 +1533,10 @@ v_cmp_gt_f16 vcc, v1, v255 dpp8:[7,6,5,4,3,2,1,0]
 v_cmp_gt_f16 vcc, v127, v255 dpp8:[7,6,5,4,3,2,1,0]
 // GFX11: v_cmp_gt_f16_e64
 
-v_cmp_gt_f16 vcc_lo, v1, v255 dpp8:[7,6,5,4,3,2,1,0]
+v_cmp_gt_f16 vcc, v1, v255 dpp8:[7,6,5,4,3,2,1,0]
 // GFX11: v_cmp_gt_f16_e64
 
-v_cmp_gt_f16 vcc_lo, v127, v255 dpp8:[7,6,5,4,3,2,1,0]
+v_cmp_gt_f16 vcc, v127, v255 dpp8:[7,6,5,4,3,2,1,0]
 // GFX11: v_cmp_gt_f16_e64
 
 v_cmp_gt_i16 vcc, v1, v255 dpp8:[7,6,5,4,3,2,1,0]
@@ -1545,10 +1545,10 @@ v_cmp_gt_i16 vcc, v1, v255 dpp8:[7,6,5,4,3,2,1,0]
 v_cmp_gt_i16 vcc, v127, v255 dpp8:[7,6,5,4,3,2,1,0]
 // GFX11: v_cmp_gt_i16_e64
 
-v_cmp_gt_i16 vcc_lo, v1, v255 dpp8:[7,6,5,4,3,2,1,0]
+v_cmp_gt_i16 vcc, v1, v255 dpp8:[7,6,5,4,3,2,1,0]
 // GFX11: v_cmp_gt_i16_e64
 
-v_cmp_gt_i16 vcc_lo, v127, v255 dpp8:[7,6,5,4,3,2,1,0]
+v_cmp_gt_i16 vcc, v127, v255 dpp8:[7,6,5,4,3,2,1,0]
 // GFX11: v_cmp_gt_i16_e64
 
 v_cmp_gt_u16 vcc, v1, v255 dpp8:[7,6,5,4,3,2,1,0]
@@ -1557,10 +1557,10 @@ v_cmp_gt_u16 vcc, v1, v255 dpp8:[7,6,5,4,3,2,1,0]
 v_cmp_gt_u16 vcc, v127, v255 dpp8:[7,6,5,4,3,2,1,0]
 // GFX11: v_cmp_gt_u16_e64
 
-v_cmp_gt_u16 vcc_lo, v1, v255 dpp8:[7,6,5,4,3,2,1,0]
+v_cmp_gt_u16 vcc, v1, v255 dpp8:[7,6,5,4,3,2,1,0]
 // GFX11: v_cmp_gt_u16_e64
 
-v_cmp_gt_u16 vcc_lo, v127, v255 dpp8:[7,6,5,4,3,2,1,0]
+v_cmp_gt_u16 vcc, v127, v255 dpp8:[7,6,5,4,3,2,1,0]
 // GFX11: v_cmp_gt_u16_e64
 
 v_cmp_le_f16 vcc, v1, v255 dpp8:[7,6,5,4,3,2,1,0]
@@ -1569,10 +1569,10 @@ v_cmp_le_f16 vcc, v1, v255 dpp8:[7,6,5,4,3,2,1,0]
 v_cmp_le_f16 vcc, v127, v255 dpp8:[7,6,5,4,3,2,1,0]
 // GFX11: v_cmp_le_f16_e64
 
-v_cmp_le_f16 vcc_lo, v1, v255 dpp8:[7,6,5,4,3,2,1,0]
+v_cmp_le_f16 vcc, v1, v255 dpp8:[7,6,5,4,3,2,1,0]
 // GFX11: v_cmp_le_f16_e64
 
-v_cmp_le_f16 vcc_lo, v127, v255 dpp8:[7,6,5,4,3,2,1,0]
+v_cmp_le_f16 vcc, v127, v255 dpp8:[7,6,5,4,3,2,1,0]
 // GFX11: v_cmp_le_f16_e64
 
 v_cmp_le_i16 vcc, v1, v255 dpp8:[7,6,5,4,3,2,1,0]
@@ -1581,10 +1581,10 @@ v_cmp_le_i16 vcc, v1, v255 dpp8:[7,6,5,4,3,2,1,0]
 v_cmp_le_i16 vcc, v127, v255 dpp8:[7,6,5,4,3,2,1,0]
 // GFX11: v_cmp_le_i16_e64
 
-v_cmp_le_i16 vcc_lo, v1, v255 dpp8:[7,6,5,4,3,2,1,0]
+v_cmp_le_i16 vcc, v1, v255 dpp8:[7,6,5,4,3,2,1,0]
 // GFX11: v_cmp_le_i16_e64
 
-v_cmp_le_i16 vcc_lo, v127, v255 dpp8:[7,6,5,4,3,2,1,0]
+v_cmp_le_i16 vcc, v127, v255 dpp8:[7,6,5,4,3,2,1,0]
 // GFX11: v_cmp_le_i16_e64
 
 v_cmp_le_u16 vcc, v1, v255 dpp8:[7,6,5,4,3,2,1,0]
@@ -1593,10 +1593,10 @@ v_cmp_le_u16 vcc, v1, v255 dpp8:[7,6,5,4,3,2,1,0]
 v_cmp_le_u16 vcc, v127, v255 dpp8:[7,6,5,4,3,2,1,0]
 // GFX11: v_cmp_le_u16_e64
 
-v_cmp_le_u16 vcc_lo, v1, v255 dpp8:[7,6,5,4,3,2,1,0]
+v_cmp_le_u16 vcc, v1, v255 dpp8:[7,6,5,4,3,2,1,0]
 // GFX11: v_cmp_le_u16_e64
 
-v_cmp_le_u16 vcc_lo, v127, v255 dpp8:[7,6,5,4,3,2,1,0]
+v_cmp_le_u16 vcc, v127, v255 dpp8:[7,6,5,4,3,2,1,0]
 // GFX11: v_cmp_le_u16_e64
 
 v_cmp_lg_f16 vcc, v1, v255 dpp8:[7,6,5,4,3,2,1,0]
@@ -1605,10 +1605,10 @@ v_cmp_lg_f16 vcc, v1, v255 dpp8:[7,6,5,4,3,2,1,0]
 v_cmp_lg_f16 vcc, v127, v255 dpp8:[7,6,5,4,3,2,1,0]
 // GFX11: v_cmp_lg_f16_e64
 
-v_cmp_lg_f16 vcc_lo, v1, v255 dpp8:[7,6,5,4,3,2,1,0]
+v_cmp_lg_f16 vcc, v1, v255 dpp8:[7,6,5,4,3,2,1,0]
 // GFX11: v_cmp_lg_f16_e64
 
-v_cmp_lg_f16 vcc_lo, v127, v255 dpp8:[7,6,5,4,3,2,1,0]
+v_cmp_lg_f16 vcc, v127, v255 dpp8:[7,6,5,4,3,2,1,0]
 // GFX11: v_cmp_lg_f16_e64
 
 v_cmp_lt_f16 vcc, v1, v255 dpp8:[7,6,5,4,3,2,1,0]
@@ -1617,10 +1617,10 @@ v_cmp_lt_f16 vcc, v1, v255 dpp8:[7,6,5,4,3,2,1,0]
 v_cmp_lt_f16 vcc, v127, v255 dpp8:[7,6,5,4,3,2,1,0]
 // GFX11: v_cmp_lt_f16_e64
 
-v_cmp_lt_f16 vcc_lo, v1, v255 dpp8:[7,6,5,4,3,2,1,0]
+v_cmp_lt_f16 vcc, v1, v255 dpp8:[7,6,5,4,3,2,1,0]
 // GFX11: v_cmp_lt_f16_e64
 
-v_cmp_lt_f16 vcc_lo, v127, v255 dpp8:[7,6,5,4,3,2,1,0]
+v_cmp_lt_f16 vcc, v127, v255 dpp8:[7,6,5,4,3,2,1,0]
 // GFX11: v_cmp_lt_f16_e64
 
 v_cmp_lt_i16 vcc, v1, v255 dpp8:[7,6,5,4,3,2,1,0]
@@ -1629,10 +1629,10 @@ v_cmp_lt_i16 vcc, v1, v255 dpp8:[7,6,5,4,3,2,1,0]
 v_cmp_lt_i16 vcc, v127, v255 dpp8:[7,6,5,4,3,2,1,0]
 // GFX11: v_cmp_lt_i16_e64
 
-v_cmp_lt_i16 vcc_lo, v1, v255 dpp8:[7,6,5,4,3,2,1,0]
+v_cmp_lt_i16 vcc, v1, v255 dpp8:[7,6,5,4,3,2,1,0]
 // GFX11: v_cmp_lt_i16_e64
 
-v_cmp_lt_i16 vcc_lo, v127, v255 dpp8:[7,6,5,4,3,2,1,0]
+v_cmp_lt_i16 vcc, v127, v255 dpp8:[7,6,5,4,3,2,1,0]
 // GFX11: v_cmp_lt_i16_e64
 
 v_cmp_lt_u16 vcc, v1, v255 dpp8:[7,6,5,4,3,2,1,0]
@@ -1641,10 +1641,10 @@ v_cmp_lt_u16 vcc, v1, v255 dpp8:[7,6,5,4,3,2,1,0]
 v_cmp_lt_u16 vcc, v127, v255 dpp8:[7,6,5,4,3,2,1,0]
 // GFX11: v_cmp_lt_u16_e64
 
-v_cmp_lt_u16 vcc_lo, v1, v255 dpp8:[7,6,5,4,3,2,1,0]
+v_cmp_lt_u16 vcc, v1, v255 dpp8:[7,6,5,4,3,2,1,0]
 // GFX11: v_cmp_lt_u16_e64
 
-v_cmp_lt_u16 vcc_lo, v127, v255 dpp8:[7,6,5,4,3,2,1,0]
+v_cmp_lt_u16 vcc, v127, v255 dpp8:[7,6,5,4,3,2,1,0]
 // GFX11: v_cmp_lt_u16_e64
 
 v_cmp_ne_i16 vcc, v1, v255 dpp8:[7,6,5,4,3,2,1,0]
@@ -1653,10 +1653,10 @@ v_cmp_ne_i16 vcc, v1, v255 dpp8:[7,6,5,4,3,2,1,0]
 v_cmp_ne_i16 vcc, v127, v255 dpp8:[7,6,5,4,3,2,1,0]
 // GFX11: v_cmp_ne_i16_e64
 
-v_cmp_ne_i16 vcc_lo, v1, v255 dpp8:[7,6,5,4,3,2,1,0]
+v_cmp_ne_i16 vcc, v1, v255 dpp8:[7,6,5,4,3,2,1,0]
 // GFX11: v_cmp_ne_i16_e64
 
-v_cmp_ne_i16 vcc_lo, v127, v255 dpp8:[7,6,5,4,3,2,1,0]
+v_cmp_ne_i16 vcc, v127, v255 dpp8:[7,6,5,4,3,2,1,0]
 // GFX11: v_cmp_ne_i16_e64
 
 v_cmp_ne_u16 vcc, v1, v255 dpp8:[7,6,5,4,3,2,1,0]
@@ -1665,10 +1665,10 @@ v_cmp_ne_u16 vcc, v1, v255 dpp8:[7,6,5,4,3,2,1,0]
 v_cmp_ne_u16 vcc, v127, v255 dpp8:[7,6,5,4,3,2,1,0]
 // GFX11: v_cmp_ne_u16_e64
 
-v_cmp_ne_u16 vcc_lo, v1, v255 dpp8:[7,6,5,4,3,2,1,0]
+v_cmp_ne_u16 vcc, v1, v255 dpp8:[7,6,5,4,3,2,1,0]
 // GFX11: v_cmp_ne_u16_e64
 
-v_cmp_ne_u16 vcc_lo, v127, v255 dpp8:[7,6,5,4,3,2,1,0]
+v_cmp_ne_u16 vcc, v127, v255 dpp8:[7,6,5,4,3,2,1,0]
 // GFX11: v_cmp_ne_u16_e64
 
 v_cmp_neq_f16 vcc, v1, v255 dpp8:[7,6,5,4,3,2,1,0]
@@ -1677,10 +1677,10 @@ v_cmp_neq_f16 vcc, v1, v255 dpp8:[7,6,5,4,3,2,1,0]
 v_cmp_neq_f16 vcc, v127, v255 dpp8:[7,6,5,4,3,2,1,0]
 // GFX11: v_cmp_neq_f16_e64
 
-v_cmp_neq_f16 vcc_lo, v1, v255 dpp8:[7,6,5,4,3,2,1,0]
+v_cmp_neq_f16 vcc, v1, v255 dpp8:[7,6,5,4,3,2,1,0]
 // GFX11: v_cmp_neq_f16_e64
 
-v_cmp_neq_f16 vcc_lo, v127, v255 dpp8:[7,6,5,4,3,2,1,0]
+v_cmp_neq_f16 vcc, v127, v255 dpp8:[7,6,5,4,3,2,1,0]
 // GFX11: v_cmp_neq_f16_e64
 
 v_cmp_nge_f16 vcc, v1, v255 dpp8:[7,6,5,4,3,2,1,0]
@@ -1689,10 +1689,10 @@ v_cmp_nge_f16 vcc, v1, v255 dpp8:[7,6,5,4,3,2,1,0]
 v_cmp_nge_f16 vcc, v127, v255 dpp8:[7,6,5,4,3,2,1,0]
 // GFX11: v_cmp_nge_f16_e64
 
-v_cmp_nge_f16 vcc_lo, v1, v255 dpp8:[7,6,5,4,3,2,1,0]
+v_cmp_nge_f16 vcc, v1, v255 dpp8:[7,6,5,4,3,2,1,0]
 // GFX11: v_cmp_nge_f16_e64
 
-v_cmp_nge_f16 vcc_lo, v127, v255 dpp8:[7,6,5,4,3,2,1,0]
+v_cmp_nge_f16 vcc, v127, v255 dpp8:[7,6,5,4,3,2,1,0]
 // GFX11: v_cmp_nge_f16_e64
 
 v_cmp_ngt_f16 vcc, v1, v255 dpp8:[7,6,5,4,3,2,1,0]
@@ -1701,10 +1701,10 @@ v_cmp_ngt_f16 vcc, v1, v255 dpp8:[7,6,5,4,3,2,1,0]
 v_cmp_ngt_f16 vcc, v127, v255 dpp8:[7,6,5,4,3,2,1,0]
 // GFX11: v_cmp_ngt_f16_e64
 
-v_cmp_ngt_f16 vcc_lo, v1, v255 dpp8:[7,6,5,4,3,2,1,0]
+v_cmp_ngt_f16 vcc, v1, v255 dpp8:[7,6,5,4,3,2,1,0]
 // GFX11: v_cmp_ngt_f16_e64
 
-v_cmp_ngt_f16 vcc_lo, v127, v255 dpp8:[7,6,5,4,3,2,1,0]
+v_cmp_ngt_f16 vcc, v127, v255 dpp8:[7,6,5,4,3,2,1,0]
 // GFX11: v_cmp_ngt_f16_e64
 
 v_cmp_nle_f16 vcc, v1, v255 dpp8:[7,6,5,4,3,2,1,0]
@@ -1713,10 +1713,10 @@ v_cmp_nle_f16 vcc, v1, v255 dpp8:[7,6,5,4,3,2,1,0]
 v_cmp_nle_f16 vcc, v127, v255 dpp8:[7,6,5,4,3,2,1,0]
 // GFX11: v_cmp_nle_f16_e64
 
-v_cmp_nle_f16 vcc_lo, v1, v255 dpp8:[7,6,5,4,3,2,1,0]
+v_cmp_nle_f16 vcc, v1, v255 dpp8:[7,6,5,4,3,2,1,0]
 // GFX11: v_cmp_nle_f16_e64
 
-v_cmp_nle_f16 vcc_lo, v127, v255 dpp8:[7,6,5,4,3,2,1,0]
+v_cmp_nle_f16 vcc, v127, v255 dpp8:[7,6,5,4,3,2,1,0]
 // GFX11: v_cmp_nle_f16_e64
 
 v_cmp_nlg_f16 vcc, v1, v255 dpp8:[7,6,5,4,3,2,1,0]
@@ -1725,10 +1725,10 @@ v_cmp_nlg_f16 vcc, v1, v255 dpp8:[7,6,5,4,3,2,1,0]
 v_cmp_nlg_f16 vcc, v127, v255 dpp8:[7,6,5,4,3,2,1,0]
 // GFX11: v_cmp_nlg_f16_e64
 
-v_cmp_nlg_f16 vcc_lo, v1, v255 dpp8:[7,6,5,4,3,2,1,0]
+v_cmp_nlg_f16 vcc, v1, v255 dpp8:[7,6,5,4,3,2,1,0]
 // GFX11: v_cmp_nlg_f16_e64
 
-v_cmp_nlg_f16 vcc_lo, v127, v255 dpp8:[7,6,5,4,3,2,1,0]
+v_cmp_nlg_f16 vcc, v127, v255 dpp8:[7,6,5,4,3,2,1,0]
 // GFX11: v_cmp_nlg_f16_e64
 
 v_cmp_nlt_f16 vcc, v1, v255 dpp8:[7,6,5,4,3,2,1,0]
@@ -1737,10 +1737,10 @@ v_cmp_nlt_f16 vcc, v1, v255 dpp8:[7,6,5,4,3,2,1,0]
 v_cmp_nlt_f16 vcc, v127, v255 dpp8:[7,6,5,4,3,2,1,0]
 // GFX11: v_cmp_nlt_f16_e64
 
-v_cmp_nlt_f16 vcc_lo, v1, v255 dpp8:[7,6,5,4,3,2,1,0]
+v_cmp_nlt_f16 vcc, v1, v255 dpp8:[7,6,5,4,3,2,1,0]
 // GFX11: v_cmp_nlt_f16_e64
 
-v_cmp_nlt_f16 vcc_lo, v127, v255 dpp8:[7,6,5,4,3,2,1,0]
+v_cmp_nlt_f16 vcc, v127, v255 dpp8:[7,6,5,4,3,2,1,0]
 // GFX11: v_cmp_nlt_f16_e64
 
 v_cmp_o_f16 vcc, v1, v255 dpp8:[7,6,5,4,3,2,1,0]
@@ -1749,10 +1749,10 @@ v_cmp_o_f16 vcc, v1, v255 dpp8:[7,6,5,4,3,2,1,0]
 v_cmp_o_f16 vcc, v127, v255 dpp8:[7,6,5,4,3,2,1,0]
 // GFX11: v_cmp_o_f16_e64
 
-v_cmp_o_f16 vcc_lo, v1, v255 dpp8:[7,6,5,4,3,2,1,0]
+v_cmp_o_f16 vcc, v1, v255 dpp8:[7,6,5,4,3,2,1,0]
 // GFX11: v_cmp_o_f16_e64
 
-v_cmp_o_f16 vcc_lo, v127, v255 dpp8:[7,6,5,4,3,2,1,0]
+v_cmp_o_f16 vcc, v127, v255 dpp8:[7,6,5,4,3,2,1,0]
 // GFX11: v_cmp_o_f16_e64
 
 v_cmp_t_f16 vcc, v1, v255 dpp8:[7,6,5,4,3,2,1,0]
@@ -1761,10 +1761,10 @@ v_cmp_t_f16 vcc, v1, v255 dpp8:[7,6,5,4,3,2,1,0]
 v_cmp_t_f16 vcc, v127, v255 dpp8:[7,6,5,4,3,2,1,0]
 // GFX11: v_cmp_t_f16_e64
 
-v_cmp_t_f16 vcc_lo, v1, v255 dpp8:[7,6,5,4,3,2,1,0]
+v_cmp_t_f16 vcc, v1, v255 dpp8:[7,6,5,4,3,2,1,0]
 // GFX11: v_cmp_t_f16_e64
 
-v_cmp_t_f16 vcc_lo, v127, v255 dpp8:[7,6,5,4,3,2,1,0]
+v_cmp_t_f16 vcc, v127, v255 dpp8:[7,6,5,4,3,2,1,0]
 // GFX11: v_cmp_t_f16_e64
 
 v_cmp_tru_f16 vcc, v1, v255 dpp8:[7,6,5,4,3,2,1,0]
@@ -1773,10 +1773,10 @@ v_cmp_tru_f16 vcc, v1, v255 dpp8:[7,6,5,4,3,2,1,0]
 v_cmp_tru_f16 vcc, v127, v255 dpp8:[7,6,5,4,3,2,1,0]
 // GFX11: v_cmp_t_f16_e64
 
-v_cmp_tru_f16 vcc_lo, v1, v255 dpp8:[7,6,5,4,3,2,1,0]
+v_cmp_tru_f16 vcc, v1, v255 dpp8:[7,6,5,4,3,2,1,0]
 // GFX11: v_cmp_t_f16_e64
 
-v_cmp_tru_f16 vcc_lo, v127, v255 dpp8:[7,6,5,4,3,2,1,0]
+v_cmp_tru_f16 vcc, v127, v255 dpp8:[7,6,5,4,3,2,1,0]
 // GFX11: v_cmp_t_f16_e64
 
 v_cmp_u_f16 vcc, v1, v255 dpp8:[7,6,5,4,3,2,1,0]
@@ -1785,189 +1785,189 @@ v_cmp_u_f16 vcc, v1, v255 dpp8:[7,6,5,4,3,2,1,0]
 v_cmp_u_f16 vcc, v127, v255 dpp8:[7,6,5,4,3,2,1,0]
 // GFX11: v_cmp_u_f16_e64
 
-v_cmp_u_f16 vcc_lo, v1, v255 dpp8:[7,6,5,4,3,2,1,0]
+v_cmp_u_f16 vcc, v1, v255 dpp8:[7,6,5,4,3,2,1,0]
 // GFX11: v_cmp_u_f16_e64
 
-v_cmp_u_f16 vcc_lo, v127, v255 dpp8:[7,6,5,4,3,2,1,0]
+v_cmp_u_f16 vcc, v127, v255 dpp8:[7,6,5,4,3,2,1,0]
 // GFX11: v_cmp_u_f16_e64
 
 v_cmp_class_f16 vcc, v128, v2 dpp8:[7,6,5,4,3,2,1,0]
 // GFX11: v_cmp_class_f16_e64
 
-v_cmp_class_f16 vcc_lo, v128, v2 dpp8:[7,6,5,4,3,2,1,0]
+v_cmp_class_f16 vcc, v128, v2 dpp8:[7,6,5,4,3,2,1,0]
 // GFX11: v_cmp_class_f16_e64
 
 v_cmp_eq_f16 vcc, v128, v2 dpp8:[7,6,5,4,3,2,1,0]
 // GFX11: v_cmp_eq_f16_e64
 
-v_cmp_eq_f16 vcc_lo, v128, v2 dpp8:[7,6,5,4,3,2,1,0]
+v_cmp_eq_f16 vcc, v128, v2 dpp8:[7,6,5,4,3,2,1,0]
 // GFX11: v_cmp_eq_f16_e64
 
 v_cmp_eq_i16 vcc, v128, v2 dpp8:[7,6,5,4,3,2,1,0]
 // GFX11: v_cmp_eq_i16_e64
 
-v_cmp_eq_i16 vcc_lo, v128, v2 dpp8:[7,6,5,4,3,2,1,0]
+v_cmp_eq_i16 vcc, v128, v2 dpp8:[7,6,5,4,3,2,1,0]
 // GFX11: v_cmp_eq_i16_e64
 
 v_cmp_eq_u16 vcc, v128, v2 dpp8:[7,6,5,4,3,2,1,0]
 // GFX11: v_cmp_eq_u16_e64
 
-v_cmp_eq_u16 vcc_lo, v128, v2 dpp8:[7,6,5,4,3,2,1,0]
+v_cmp_eq_u16 vcc, v128, v2 dpp8:[7,6,5,4,3,2,1,0]
 // GFX11: v_cmp_eq_u16_e64
 
 v_cmp_f_f16 vcc, v128, v2 dpp8:[7,6,5,4,3,2,1,0]
 // GFX11: v_cmp_f_f16_e64
 
-v_cmp_f_f16 vcc_lo, v128, v2 dpp8:[7,6,5,4,3,2,1,0]
+v_cmp_f_f16 vcc, v128, v2 dpp8:[7,6,5,4,3,2,1,0]
 // GFX11: v_cmp_f_f16_e64
 
 v_cmp_ge_f16 vcc, v128, v2 dpp8:[7,6,5,4,3,2,1,0]
 // GFX11: v_cmp_ge_f16_e64
 
-v_cmp_ge_f16 vcc_lo, v128, v2 dpp8:[7,6,5,4,3,2,1,0]
+v_cmp_ge_f16 vcc, v128, v2 dpp8:[7,6,5,4,3,2,1,0]
 // GFX11: v_cmp_ge_f16_e64
 
 v_cmp_ge_i16 vcc, v128, v2 dpp8:[7,6,5,4,3,2,1,0]
 // GFX11: v_cmp_ge_i16_e64
 
-v_cmp_ge_i16 vcc_lo, v128, v2 dpp8:[7,6,5,4,3,2,1,0]
+v_cmp_ge_i16 vcc, v128, v2 dpp8:[7,6,5,4,3,2,1,0]
 // GFX11: v_cmp_ge_i16_e64
 
 v_cmp_ge_u16 vcc, v128, v2 dpp8:[7,6,5,4,3,2,1,0]
 // GFX11: v_cmp_ge_u16_e64
 
-v_cmp_ge_u16 vcc_lo, v128, v2 dpp8:[7,6,5,4,3,2,1,0]
+v_cmp_ge_u16 vcc, v128, v2 dpp8:[7,6,5,4,3,2,1,0]
 // GFX11: v_cmp_ge_u16_e64
 
 v_cmp_gt_f16 vcc, v128, v2 dpp8:[7,6,5,4,3,2,1,0]
 // GFX11: v_cmp_gt_f16_e64
 
-v_cmp_gt_f16 vcc_lo, v128, v2 dpp8:[7,6,5,4,3,2,1,0]
+v_cmp_gt_f16 vcc, v128, v2 dpp8:[7,6,5,4,3,2,1,0]
 // GFX11: v_cmp_gt_f16_e64
 
 v_cmp_gt_i16 vcc, v128, v2 dpp8:[7,6,5,4,3,2,1,0]
 // GFX11: v_cmp_gt_i16_e64
 
-v_cmp_gt_i16 vcc_lo, v128, v2 dpp8:[7,6,5,4,3,2,1,0]
+v_cmp_gt_i16 vcc, v128, v2 dpp8:[7,6,5,4,3,2,1,0]
 // GFX11: v_cmp_gt_i16_e64
 
 v_cmp_gt_u16 vcc, v128, v2 dpp8:[7,6,5,4,3,2,1,0]
 // GFX11: v_cmp_gt_u16_e64
 
-v_cmp_gt_u16 vcc_lo, v128, v2 dpp8:[7,6,5,4,3,2,1,0]
+v_cmp_gt_u16 vcc, v128, v2 dpp8:[7,6,5,4,3,2,1,0]
 // GFX11: v_cmp_gt_u16_e64
 
 v_cmp_le_f16 vcc, v128, v2 dpp8:[7,6,5,4,3,2,1,0]
 // GFX11: v_cmp_le_f16_e64
 
-v_cmp_le_f16 vcc_lo, v128, v2 dpp8:[7,6,5,4,3,2,1,0]
+v_cmp_le_f16 vcc, v128, v2 dpp8:[7,6,5,4,3,2,1,0]
 // GFX11: v_cmp_le_f16_e64
 
 v_cmp_le_i16 vcc, v128, v2 dpp8:[7,6,5,4,3,2,1,0]
 // GFX11: v_cmp_le_i16_e64
 
-v_cmp_le_i16 vcc_lo, v128, v2 dpp8:[7,6,5,4,3,2,1,0]
+v_cmp_le_i16 vcc, v128, v2 dpp8:[7,6,5,4,3,2,1,0]
 // GFX11: v_cmp_le_i16_e64
 
 v_cmp_le_u16 vcc, v128, v2 dpp8:[7,6,5,4,3,2,1,0]
 // GFX11: v_cmp_le_u16_e64
 
-v_cmp_le_u16 vcc_lo, v128, v2 dpp8:[7,6,5,4,3,2,1,0]
+v_cmp_le_u16 vcc, v128, v2 dpp8:[7,6,5,4,3,2,1,0]
 // GFX11: v_cmp_le_u16_e64
 
 v_cmp_lg_f16 vcc, v128, v2 dpp8:[7,6,5,4,3,2,1,0]
 // GFX11: v_cmp_lg_f16_e64
 
-v_cmp_lg_f16 vcc_lo, v128, v2 dpp8:[7,6,5,4,3,2,1,0]
+v_cmp_lg_f16 vcc, v128, v2 dpp8:[7,6,5,4,3,2,1,0]
 // GFX11: v_cmp_lg_f16_e64
 
 v_cmp_lt_f16 vcc, v128, v2 dpp8:[7,6,5,4,3,2,1,0]
 // GFX11: v_cmp_lt_f16_e64
 
-v_cmp_lt_f16 vcc_lo, v128, v2 dpp8:[7,6,5,4,3,2,1,0]
+v_cmp_lt_f16 vcc, v128, v2 dpp8:[7,6,5,4,3,2,1,0]
 // GFX11: v_cmp_lt_f16_e64
 
 v_cmp_lt_i16 vcc, v128, v2 dpp8:[7,6,5,4,3,2,1,0]
 // GFX11: v_cmp_lt_i16_e64
 
-v_cmp_lt_i16 vcc_lo, v128, v2 dpp8:[7,6,5,4,3,2,1,0]
+v_cmp_lt_i16 vcc, v128, v2 dpp8:[7,6,5,4,3,2,1,0]
 // GFX11: v_cmp_lt_i16_e64
 
 v_cmp_lt_u16 vcc, v128, v2 dpp8:[7,6,5,4,3,2,1,0]
 // GFX11: v_cmp_lt_u16_e64
 
-v_cmp_lt_u16 vcc_lo, v128, v2 dpp8:[7,6,5,4,3,2,1,0]
+v_cmp_lt_u16 vcc, v128, v2 dpp8:[7,6,5,4,3,2,1,0]
 // GFX11: v_cmp_lt_u16_e64
 
 v_cmp_ne_i16 vcc, v128, v2 dpp8:[7,6,5,4,3,2,1,0]
 // GFX11: v_cmp_ne_i16_e64
 
-v_cmp_ne_i16 vcc_lo, v128, v2 dpp8:[7,6,5,4,3,2,1,0]
+v_cmp_ne_i16 vcc, v128, v2 dpp8:[7,6,5,4,3,2,1,0]
 // GFX11: v_cmp_ne_i16_e64
 
 v_cmp_ne_u16 vcc, v128, v2 dpp8:[7,6,5,4,3,2,1,0]
 // GFX11: v_cmp_ne_u16_e64
 
-v_cmp_ne_u16 vcc_lo, v128, v2 dpp8:[7,6,5,4,3,2,1,0]
+v_cmp_ne_u16 vcc, v128, v2 dpp8:[7,6,5,4,3,2,1,0]
 // GFX11: v_cmp_ne_u16_e64
 
 v_cmp_neq_f16 vcc, v128, v2 dpp8:[7,6,5,4,3,2,1,0]
 // GFX11: v_cmp_neq_f16_e64
 
-v_cmp_neq_f16 vcc_lo, v128, v2 dpp8:[7,6,5,4,3,2,1,0]
+v_cmp_neq_f16 vcc, v128, v2 dpp8:[7,6,5,4,3,2,1,0]
 // GFX11: v_cmp_neq_f16_e64
 
 v_cmp_nge_f16 vcc, v128, v2 dpp8:[7,6,5,4,3,2,1,0]
 // GFX11: v_cmp_nge_f16_e64
 
-v_cmp_nge_f16 vcc_lo, v128, v2 dpp8:[7,6,5,4,3,2,1,0]
+v_cmp_nge_f16 vcc, v128, v2 dpp8:[7,6,5,4,3,2,1,0]
 // GFX11: v_cmp_nge_f16_e64
 
 v_cmp_ngt_f16 vcc, v128, v2 dpp8:[7,6,5,4,3,2,1,0]
 // GFX11: v_cmp_ngt_f16_e64
 
-v_cmp_ngt_f16 vcc_lo, v128, v2 dpp8:[7,6,5,4,3,2,1,0]
+v_cmp_ngt_f16 vcc, v128, v2 dpp8:[7,6,5,4,3,2,1,0]
 // GFX11: v_cmp_ngt_f16_e64
 
 v_cmp_nle_f16 vcc, v128, v2 dpp8:[7,6,5,4,3,2,1,0]
 // GFX11: v_cmp_nle_f16_e64
 
-v_cmp_nle_f16 vcc_lo, v128, v2 dpp8:[7,6,5,4,3,2,1,0]
+v_cmp_nle_f16 vcc, v128, v2 dpp8:[7,6,5,4,3,2,1,0]
 // GFX11: v_cmp_nle_f16_e64
 
 v_cmp_nlg_f16 vcc, v128, v2 dpp8:[7,6,5,4,3,2,1,0]
 // GFX11: v_cmp_nlg_f16_e64
 
-v_cmp_nlg_f16 vcc_lo, v128, v2 dpp8:[7,6,5,4,3,2,1,0]
+v_cmp_nlg_f16 vcc, v128, v2 dpp8:[7,6,5,4,3,2,1,0]
 // GFX11: v_cmp_nlg_f16_e64
 
 v_cmp_nlt_f16 vcc, v128, v2 dpp8:[7,6,5,4,3,2,1,0]
 // GFX11: v_cmp_nlt_f16_e64
 
-v_cmp_nlt_f16 vcc_lo, v128, v2 dpp8:[7,6,5,4,3,2,1,0]
+v_cmp_nlt_f16 vcc, v128, v2 dpp8:[7,6,5,4,3,2,1,0]
 // GFX11: v_cmp_nlt_f16_e64
 
 v_cmp_o_f16 vcc, v128, v2 dpp8:[7,6,5,4,3,2,1,0]
 // GFX11: v_cmp_o_f16_e64
 
-v_cmp_o_f16 vcc_lo, v128, v2 dpp8:[7,6,5,4,3,2,1,0]
+v_cmp_o_f16 vcc, v128, v2 dpp8:[7,6,5,4,3,2,1,0]
 // GFX11: v_cmp_o_f16_e64
 
 v_cmp_t_f16 vcc, v128, v2 dpp8:[7,6,5,4,3,2,1,0]
 // GFX11: v_cmp_t_f16_e64
 
-v_cmp_t_f16 vcc_lo, v128, v2 dpp8:[7,6,5,4,3,2,1,0]
+v_cmp_t_f16 vcc, v128, v2 dpp8:[7,6,5,4,3,2,1,0]
 // GFX11: v_cmp_t_f16_e64
 
 v_cmp_tru_f16 vcc, v128, v2 dpp8:[7,6,5,4,3,2,1,0]
 // GFX11: v_cmp_t_f16_e64
 
-v_cmp_tru_f16 vcc_lo, v128, v2 dpp8:[7,6,5,4,3,2,1,0]
+v_cmp_tru_f16 vcc, v128, v2 dpp8:[7,6,5,4,3,2,1,0]
 // GFX11: v_cmp_t_f16_e64
 
 v_cmp_u_f16 vcc, v128, v2 dpp8:[7,6,5,4,3,2,1,0]
 // GFX11: v_cmp_u_f16_e64
 
-v_cmp_u_f16 vcc_lo, v128, v2 dpp8:[7,6,5,4,3,2,1,0]
+v_cmp_u_f16 vcc, v128, v2 dpp8:[7,6,5,4,3,2,1,0]
 // GFX11: v_cmp_u_f16_e64
 

--- a/llvm/test/MC/AMDGPU/gfx11_asm_vopcx.s
+++ b/llvm/test/MC/AMDGPU/gfx11_asm_vopcx.s
@@ -1,5 +1,5 @@
-// RUN: llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=+wavefrontsize32,-wavefrontsize64 -show-encoding %s | FileCheck --check-prefixes=GFX11 %s
-// RUN: llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=-wavefrontsize32,+wavefrontsize64 -show-encoding %s | FileCheck --check-prefixes=GFX11 %s
+// RUN: llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=+wavefrontsize32 -show-encoding %s | FileCheck --check-prefixes=GFX11 %s
+// RUN: llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=+wavefrontsize64 -show-encoding %s | FileCheck --check-prefixes=GFX11 %s
 
 v_cmpx_class_f16_e32 v1, v2
 // GFX11: encoding: [0x01,0x05,0xfa,0x7d]

--- a/llvm/test/MC/AMDGPU/gfx11_asm_vopcx_dpp16.s
+++ b/llvm/test/MC/AMDGPU/gfx11_asm_vopcx_dpp16.s
@@ -1,5 +1,5 @@
-// RUN: llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=+wavefrontsize32,-wavefrontsize64 -show-encoding %s | FileCheck --check-prefixes=GFX11 %s
-// RUN: llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=-wavefrontsize32,+wavefrontsize64 -show-encoding %s | FileCheck --check-prefixes=GFX11 %s
+// RUN: llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=+wavefrontsize32 -show-encoding %s | FileCheck --check-prefixes=GFX11 %s
+// RUN: llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=+wavefrontsize64 -show-encoding %s | FileCheck --check-prefixes=GFX11 %s
 
 v_cmpx_class_f16_dpp v1, v2 quad_perm:[3,2,1,0]
 // GFX11: encoding: [0xfa,0x04,0xfa,0x7d,0x01,0x1b,0x00,0xff]

--- a/llvm/test/MC/AMDGPU/gfx11_asm_vopcx_dpp8.s
+++ b/llvm/test/MC/AMDGPU/gfx11_asm_vopcx_dpp8.s
@@ -1,5 +1,5 @@
-// RUN: llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=+wavefrontsize32,-wavefrontsize64 -show-encoding %s | FileCheck --check-prefixes=GFX11 %s
-// RUN: llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=-wavefrontsize32,+wavefrontsize64 -show-encoding %s | FileCheck --check-prefixes=GFX11 %s
+// RUN: llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=+wavefrontsize32 -show-encoding %s | FileCheck --check-prefixes=GFX11 %s
+// RUN: llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=+wavefrontsize64 -show-encoding %s | FileCheck --check-prefixes=GFX11 %s
 
 v_cmpx_class_f16_dpp v1, v2 dpp8:[7,6,5,4,3,2,1,0]
 // GFX11: encoding: [0xe9,0x04,0xfa,0x7d,0x01,0x77,0x39,0x05]

--- a/llvm/test/MC/AMDGPU/gfx11_asm_vopd.s
+++ b/llvm/test/MC/AMDGPU/gfx11_asm_vopd.s
@@ -1,6 +1,6 @@
-// RUN: llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=+wavefrontsize32,-wavefrontsize64 -show-encoding %s | FileCheck --check-prefixes=GFX11 %s
+// RUN: llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=+wavefrontsize32 -show-encoding %s | FileCheck --check-prefixes=GFX11 %s
 // RUN: llvm-mc -triple=amdgcn -mcpu=gfx1100 -show-encoding %s | FileCheck --check-prefixes=GFX11 %s
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=-wavefrontsize32,+wavefrontsize64 -show-encoding %s 2>&1 | FileCheck --check-prefixes=W64-ERR --implicit-check-not=error: %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=+wavefrontsize64 -show-encoding %s 2>&1 | FileCheck --check-prefixes=W64-ERR --implicit-check-not=error: %s
 
 v_dual_add_f32 v255, v4, v2 :: v_dual_add_f32 v6, v1, v3
 // GFX11: encoding: [0x04,0x05,0x08,0xc9,0x01,0x07,0x06,0xff]

--- a/llvm/test/MC/AMDGPU/gfx11_asm_wmma.s
+++ b/llvm/test/MC/AMDGPU/gfx11_asm_wmma.s
@@ -1,7 +1,7 @@
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=+wavefrontsize32,-wavefrontsize64 -show-encoding %s | FileCheck --check-prefix=W32 %s
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=-wavefrontsize32,+wavefrontsize64 -show-encoding %s | FileCheck --check-prefix=W64 %s
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=+wavefrontsize32,-wavefrontsize64 %s 2>&1 | FileCheck --check-prefix=W32-ERR --implicit-check-not=error: %s
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=-wavefrontsize32,+wavefrontsize64 %s 2>&1 | FileCheck --check-prefix=W64-ERR --implicit-check-not=error: %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=+wavefrontsize32 -show-encoding %s | FileCheck --check-prefix=W32 %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=+wavefrontsize64 -show-encoding %s | FileCheck --check-prefix=W64 %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=+wavefrontsize32 %s 2>&1 | FileCheck --check-prefix=W32-ERR --implicit-check-not=error: %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=+wavefrontsize64 %s 2>&1 | FileCheck --check-prefix=W64-ERR --implicit-check-not=error: %s
 
 //
 // Test v_wmma_f32_16x16x16_f16

--- a/llvm/test/MC/AMDGPU/gfx11_unsupported.s
+++ b/llvm/test/MC/AMDGPU/gfx11_unsupported.s
@@ -1,5 +1,5 @@
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=+wavefrontsize32,-wavefrontsize64 %s 2>&1 | FileCheck --implicit-check-not=error: %s
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=-wavefrontsize32,+wavefrontsize64 %s 2>&1 | FileCheck --implicit-check-not=error: %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=+wavefrontsize32 %s 2>&1 | FileCheck --implicit-check-not=error: %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=+wavefrontsize64 %s 2>&1 | FileCheck --implicit-check-not=error: %s
 
 buffer_atomic_add_f64 v[2:3], off, s[12:15], s4 offset:4095
 // CHECK: :[[@LINE-1]]:{{[0-9]+}}: error: instruction not supported on this GPU

--- a/llvm/test/MC/AMDGPU/gfx11_unsupported_dpp.s
+++ b/llvm/test/MC/AMDGPU/gfx11_unsupported_dpp.s
@@ -1,5 +1,5 @@
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=+wavefrontsize32,-wavefrontsize64 %s 2>&1 | FileCheck --implicit-check-not=error: %s
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=-wavefrontsize32,+wavefrontsize64 %s 2>&1 | FileCheck --implicit-check-not=error: %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=+wavefrontsize32 %s 2>&1 | FileCheck --implicit-check-not=error: %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=+wavefrontsize64 %s 2>&1 | FileCheck --implicit-check-not=error: %s
 
 v_add_co_u32_dpp v255, vcc, v1, v2 quad_perm:[0,1,2,3] row_mask:0x0 bank_mask:0x0
 // CHECK: :[[@LINE-1]]:{{[0-9]+}}: error: dpp variant of this instruction is not supported

--- a/llvm/test/MC/AMDGPU/gfx11_unsupported_e32.s
+++ b/llvm/test/MC/AMDGPU/gfx11_unsupported_e32.s
@@ -1,5 +1,5 @@
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=+wavefrontsize32,-wavefrontsize64 %s 2>&1 | FileCheck --implicit-check-not=error: %s
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=-wavefrontsize32,+wavefrontsize64 %s 2>&1 | FileCheck --implicit-check-not=error: %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=+wavefrontsize32 %s 2>&1 | FileCheck --implicit-check-not=error: %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=+wavefrontsize64 %s 2>&1 | FileCheck --implicit-check-not=error: %s
 
 v_add_co_u32_e32 v2, vcc, s0, v2
 // CHECK: :[[@LINE-1]]:{{[0-9]+}}: error: e32 variant of this instruction is not supported

--- a/llvm/test/MC/AMDGPU/gfx11_unsupported_e64.s
+++ b/llvm/test/MC/AMDGPU/gfx11_unsupported_e64.s
@@ -1,5 +1,5 @@
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=+wavefrontsize32,-wavefrontsize64 %s 2>&1 | FileCheck --implicit-check-not=error: %s
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=-wavefrontsize32,+wavefrontsize64 %s 2>&1 | FileCheck --implicit-check-not=error: %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=+wavefrontsize32 %s 2>&1 | FileCheck --implicit-check-not=error: %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=+wavefrontsize64 %s 2>&1 | FileCheck --implicit-check-not=error: %s
 
 v_dot2c_f32_f16_e64 v0, v1, v2
 // CHECK: :[[@LINE-1]]:{{[0-9]+}}: error: e64 variant of this instruction is not supported

--- a/llvm/test/MC/AMDGPU/gfx11_unsupported_sdwa-fake16.s
+++ b/llvm/test/MC/AMDGPU/gfx11_unsupported_sdwa-fake16.s
@@ -1,5 +1,5 @@
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=-real-true16,+wavefrontsize32,-wavefrontsize64 %s 2>&1 | FileCheck --implicit-check-not=error: %s
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=-real-true16,-wavefrontsize32,+wavefrontsize64 %s 2>&1 | FileCheck --implicit-check-not=error: %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=-real-true16,+wavefrontsize32 %s 2>&1 | FileCheck --implicit-check-not=error: %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=-real-true16,+wavefrontsize64 %s 2>&1 | FileCheck --implicit-check-not=error: %s
 
 v_floor_f16_sdwa v255, v1 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:DWORD
 // CHECK: :[[@LINE-1]]:{{[0-9]+}}: error: sdwa variant of this instruction is not supported

--- a/llvm/test/MC/AMDGPU/gfx11_unsupported_sdwa.s
+++ b/llvm/test/MC/AMDGPU/gfx11_unsupported_sdwa.s
@@ -1,5 +1,5 @@
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=+real-true16,+wavefrontsize32,-wavefrontsize64 %s 2>&1 | FileCheck --implicit-check-not=error: %s
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=+real-true16,-wavefrontsize32,+wavefrontsize64 %s 2>&1 | FileCheck --implicit-check-not=error: %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=+real-true16,+wavefrontsize32 %s 2>&1 | FileCheck --implicit-check-not=error: %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=+real-true16,+wavefrontsize64 %s 2>&1 | FileCheck --implicit-check-not=error: %s
 
 v_add_co_ci_u32_sdwa v1, v1, v4 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:BYTE_0 src1_sel:DWORD
 // CHECK: :[[@LINE-1]]:{{[0-9]+}}: error: sdwa variant of this instruction is not supported

--- a/llvm/test/MC/AMDGPU/gfx12_asm_global_load_tr.s
+++ b/llvm/test/MC/AMDGPU/gfx12_asm_global_load_tr.s
@@ -1,7 +1,7 @@
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=-wavefrontsize32,+wavefrontsize64 -show-encoding %s | FileCheck --check-prefix=W64 %s
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=+wavefrontsize32,-wavefrontsize64 -show-encoding %s | FileCheck --check-prefix=W32 %s
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=-wavefrontsize32,+wavefrontsize64 %s 2>&1 | FileCheck --check-prefix=W64-ERR --implicit-check-not=error: %s
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=+wavefrontsize32,-wavefrontsize64 %s 2>&1 | FileCheck --check-prefix=W32-ERR --implicit-check-not=error: %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=+wavefrontsize64 -show-encoding %s | FileCheck --check-prefix=W64 %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=+wavefrontsize32 -show-encoding %s | FileCheck --check-prefix=W32 %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=+wavefrontsize64 %s 2>&1 | FileCheck --check-prefix=W64-ERR --implicit-check-not=error: %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=+wavefrontsize32 %s 2>&1 | FileCheck --check-prefix=W32-ERR --implicit-check-not=error: %s
 
 global_load_tr_b128 v[1:4], v0, s[0:1] offset:-64
 // W64-ERR: :[[@LINE-1]]:{{[0-9]+}}: error: operands are not valid for this GPU or mode

--- a/llvm/test/MC/AMDGPU/gfx12_asm_vop1.s
+++ b/llvm/test/MC/AMDGPU/gfx12_asm_vop1.s
@@ -1,5 +1,5 @@
-// RUN: llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=+wavefrontsize32,-wavefrontsize64 -show-encoding %s | FileCheck --check-prefix=GFX12 %s
-// RUN: llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=-wavefrontsize32,+wavefrontsize64 -show-encoding %s | FileCheck --check-prefix=GFX12 %s
+// RUN: llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=+wavefrontsize32 -show-encoding %s | FileCheck --check-prefix=GFX12 %s
+// RUN: llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=+wavefrontsize64 -show-encoding %s | FileCheck --check-prefix=GFX12 %s
 
 v_bfrev_b32_e32 v5, v1
 // GFX12: encoding: [0x01,0x71,0x0a,0x7e]

--- a/llvm/test/MC/AMDGPU/gfx12_asm_vop1_dpp16.s
+++ b/llvm/test/MC/AMDGPU/gfx12_asm_vop1_dpp16.s
@@ -1,5 +1,5 @@
-// RUN: llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=+wavefrontsize32,-wavefrontsize64 -show-encoding %s | FileCheck --check-prefixes=GFX12 %s
-// RUN: llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=-wavefrontsize32,+wavefrontsize64 -show-encoding %s | FileCheck --check-prefixes=GFX12 %s
+// RUN: llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=+wavefrontsize32 -show-encoding %s | FileCheck --check-prefixes=GFX12 %s
+// RUN: llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=+wavefrontsize64 -show-encoding %s | FileCheck --check-prefixes=GFX12 %s
 
 v_bfrev_b32_dpp v5, v1 quad_perm:[3,2,1,0]
 // GFX12: encoding: [0xfa,0x70,0x0a,0x7e,0x01,0x1b,0x00,0xff]

--- a/llvm/test/MC/AMDGPU/gfx12_asm_vop1_dpp8.s
+++ b/llvm/test/MC/AMDGPU/gfx12_asm_vop1_dpp8.s
@@ -1,5 +1,5 @@
-// RUN: llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=+wavefrontsize32,-wavefrontsize64 -show-encoding %s | FileCheck --check-prefixes=GFX12 %s
-// RUN: llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=-wavefrontsize32,+wavefrontsize64 -show-encoding %s | FileCheck --check-prefixes=GFX12 %s
+// RUN: llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=+wavefrontsize32 -show-encoding %s | FileCheck --check-prefixes=GFX12 %s
+// RUN: llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=+wavefrontsize64 -show-encoding %s | FileCheck --check-prefixes=GFX12 %s
 
 v_bfrev_b32_dpp v5, v1 dpp8:[7,6,5,4,3,2,1,0]
 // GFX12: encoding: [0xe9,0x70,0x0a,0x7e,0x01,0x77,0x39,0x05]

--- a/llvm/test/MC/AMDGPU/gfx12_asm_vop2.s
+++ b/llvm/test/MC/AMDGPU/gfx12_asm_vop2.s
@@ -1,7 +1,7 @@
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=+wavefrontsize32,-wavefrontsize64 -show-encoding %s | FileCheck --check-prefixes=GFX12,W32 %s
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=-wavefrontsize32,+wavefrontsize64 -show-encoding %s | FileCheck --check-prefixes=GFX12,W64 %s
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=+wavefrontsize32,-wavefrontsize64 %s 2>&1 | FileCheck --check-prefix=W32-ERR --implicit-check-not=error: %s
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=-wavefrontsize32,+wavefrontsize64 %s 2>&1 | FileCheck --check-prefix=W64-ERR --implicit-check-not=error: %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=+wavefrontsize32 -show-encoding %s | FileCheck --check-prefixes=GFX12,W32 %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=+wavefrontsize64 -show-encoding %s | FileCheck --check-prefixes=GFX12,W64 %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=+wavefrontsize32 %s 2>&1 | FileCheck --check-prefix=W32-ERR --implicit-check-not=error: %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=+wavefrontsize64 %s 2>&1 | FileCheck --check-prefix=W64-ERR --implicit-check-not=error: %s
 
 v_add_co_ci_u32_e32 v5, vcc_lo, v1, v2, vcc_lo
 // W32: encoding: [0x01,0x05,0x0a,0x40]

--- a/llvm/test/MC/AMDGPU/gfx12_asm_vop2_aliases.s
+++ b/llvm/test/MC/AMDGPU/gfx12_asm_vop2_aliases.s
@@ -1,4 +1,4 @@
-// RUN: llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=+wavefrontsize32,-wavefrontsize64 -show-encoding %s | FileCheck --check-prefixes=GFX12 %s
+// RUN: llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=+wavefrontsize32 -show-encoding %s | FileCheck --check-prefixes=GFX12 %s
 
 v_min_f32 v5, v1, v2
 // GFX12: v_min_num_f32_e32 v5, v1, v2            ; encoding: [0x01,0x05,0x0a,0x2a]

--- a/llvm/test/MC/AMDGPU/gfx12_asm_vop2_dpp16.s
+++ b/llvm/test/MC/AMDGPU/gfx12_asm_vop2_dpp16.s
@@ -1,7 +1,7 @@
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=+wavefrontsize32,-wavefrontsize64 -show-encoding %s | FileCheck --check-prefixes=GFX12,W32 %s
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=-wavefrontsize32,+wavefrontsize64 -show-encoding %s | FileCheck --check-prefixes=GFX12,W64 %s
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=+wavefrontsize32,-wavefrontsize64 %s 2>&1 | FileCheck --check-prefix=W32-ERR --implicit-check-not=error: %s
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=-wavefrontsize32,+wavefrontsize64 %s 2>&1 | FileCheck --check-prefix=W64-ERR --implicit-check-not=error: %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=+wavefrontsize32 -show-encoding %s | FileCheck --check-prefixes=GFX12,W32 %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=+wavefrontsize64 -show-encoding %s | FileCheck --check-prefixes=GFX12,W64 %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=+wavefrontsize32 %s 2>&1 | FileCheck --check-prefix=W32-ERR --implicit-check-not=error: %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=+wavefrontsize64 %s 2>&1 | FileCheck --check-prefix=W64-ERR --implicit-check-not=error: %s
 
 v_add_co_ci_u32_dpp v5, vcc_lo, v1, v2, vcc_lo quad_perm:[3,2,1,0]
 // W32: encoding: [0xfa,0x04,0x0a,0x40,0x01,0x1b,0x00,0xff]

--- a/llvm/test/MC/AMDGPU/gfx12_asm_vop2_dpp8.s
+++ b/llvm/test/MC/AMDGPU/gfx12_asm_vop2_dpp8.s
@@ -1,7 +1,7 @@
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=+wavefrontsize32,-wavefrontsize64 -show-encoding %s | FileCheck --check-prefixes=GFX12,W32 %s
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=-wavefrontsize32,+wavefrontsize64 -show-encoding %s | FileCheck --check-prefixes=GFX12,W64 %s
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=+wavefrontsize32,-wavefrontsize64 %s 2>&1 | FileCheck --check-prefix=W32-ERR --implicit-check-not=error: %s
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=-wavefrontsize32,+wavefrontsize64 %s 2>&1 | FileCheck --check-prefix=W64-ERR --implicit-check-not=error: %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=+wavefrontsize32 -show-encoding %s | FileCheck --check-prefixes=GFX12,W32 %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=+wavefrontsize64 -show-encoding %s | FileCheck --check-prefixes=GFX12,W64 %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=+wavefrontsize32 %s 2>&1 | FileCheck --check-prefix=W32-ERR --implicit-check-not=error: %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=+wavefrontsize64 %s 2>&1 | FileCheck --check-prefix=W64-ERR --implicit-check-not=error: %s
 
 v_add_co_ci_u32_dpp v5, vcc_lo, v1, v2, vcc_lo dpp8:[7,6,5,4,3,2,1,0]
 // W32: encoding: [0xe9,0x04,0x0a,0x40,0x01,0x77,0x39,0x05]

--- a/llvm/test/MC/AMDGPU/gfx12_asm_vop3.s
+++ b/llvm/test/MC/AMDGPU/gfx12_asm_vop3.s
@@ -1,7 +1,7 @@
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=+wavefrontsize32,-wavefrontsize64 -show-encoding %s | FileCheck --check-prefixes=GFX12,W32 %s
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=-wavefrontsize32,+wavefrontsize64 -show-encoding %s | FileCheck --check-prefixes=GFX12,W64 %s
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=+wavefrontsize32,-wavefrontsize64 %s 2>&1 | FileCheck --check-prefix=W32-ERR --implicit-check-not=error: %s
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=-wavefrontsize32,+wavefrontsize64 %s 2>&1 | FileCheck --check-prefix=W64-ERR --implicit-check-not=error: %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=+wavefrontsize32 -show-encoding %s | FileCheck --check-prefixes=GFX12,W32 %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=+wavefrontsize64 -show-encoding %s | FileCheck --check-prefixes=GFX12,W64 %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=+wavefrontsize32 %s 2>&1 | FileCheck --check-prefix=W32-ERR --implicit-check-not=error: %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=+wavefrontsize64 %s 2>&1 | FileCheck --check-prefix=W64-ERR --implicit-check-not=error: %s
 
 v_add3_u32 v5, v1, v2, s3
 // GFX12: encoding: [0x05,0x00,0x55,0xd6,0x01,0x05,0x0e,0x00]

--- a/llvm/test/MC/AMDGPU/gfx12_asm_vop3_aliases.s
+++ b/llvm/test/MC/AMDGPU/gfx12_asm_vop3_aliases.s
@@ -1,4 +1,4 @@
-// RUN: llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=+wavefrontsize32,-wavefrontsize64 -show-encoding %s | FileCheck --check-prefixes=GFX12 %s
+// RUN: llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=+wavefrontsize32 -show-encoding %s | FileCheck --check-prefixes=GFX12 %s
 
 v_min3_f32 v5, v1, v2, v3
 // GFX12: v_min3_num_f32 v5, v1, v2, v3           ; encoding: [0x05,0x00,0x29,0xd6,0x01,0x05,0x0e,0x04]

--- a/llvm/test/MC/AMDGPU/gfx12_asm_vop3_dpp16.s
+++ b/llvm/test/MC/AMDGPU/gfx12_asm_vop3_dpp16.s
@@ -1,7 +1,7 @@
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=+wavefrontsize32,-wavefrontsize64 -show-encoding %s | FileCheck --check-prefixes=GFX12,W32 %s
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=-wavefrontsize32,+wavefrontsize64 -show-encoding %s | FileCheck --check-prefixes=GFX12,W64 %s
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=+wavefrontsize32,-wavefrontsize64 %s 2>&1 | FileCheck --check-prefixes=GFX12-ERR,W32-ERR --implicit-check-not=error: %s
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=-wavefrontsize32,+wavefrontsize64 %s 2>&1 | FileCheck --check-prefixes=GFX12-ERR,W64-ERR --implicit-check-not=error: %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=+wavefrontsize32 -show-encoding %s | FileCheck --check-prefixes=GFX12,W32 %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=+wavefrontsize64 -show-encoding %s | FileCheck --check-prefixes=GFX12,W64 %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=+wavefrontsize32 %s 2>&1 | FileCheck --check-prefixes=GFX12-ERR,W32-ERR --implicit-check-not=error: %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=+wavefrontsize64 %s 2>&1 | FileCheck --check-prefixes=GFX12-ERR,W64-ERR --implicit-check-not=error: %s
 
 v_add3_u32_e64_dpp v5, v1, v2, v3 quad_perm:[3,2,1,0]
 // GFX12: [0x05,0x00,0x55,0xd6,0xfa,0x04,0x0e,0x04,0x01,0x1b,0x00,0xff]

--- a/llvm/test/MC/AMDGPU/gfx12_asm_vop3_dpp8.s
+++ b/llvm/test/MC/AMDGPU/gfx12_asm_vop3_dpp8.s
@@ -1,7 +1,7 @@
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=+wavefrontsize32,-wavefrontsize64 -show-encoding %s | FileCheck --check-prefixes=GFX12,W32 %s
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=-wavefrontsize32,+wavefrontsize64 -show-encoding %s | FileCheck --check-prefixes=GFX12,W64 %s
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=+wavefrontsize32,-wavefrontsize64 %s 2>&1 | FileCheck --check-prefixes=GFX12-ERR,W32-ERR --implicit-check-not=error: %s
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=-wavefrontsize32,+wavefrontsize64 %s 2>&1 | FileCheck --check-prefixes=GFX12-ERR,W64-ERR --implicit-check-not=error: %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=+wavefrontsize32 -show-encoding %s | FileCheck --check-prefixes=GFX12,W32 %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=+wavefrontsize64 -show-encoding %s | FileCheck --check-prefixes=GFX12,W64 %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=+wavefrontsize32 %s 2>&1 | FileCheck --check-prefixes=GFX12-ERR,W32-ERR --implicit-check-not=error: %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=+wavefrontsize64 %s 2>&1 | FileCheck --check-prefixes=GFX12-ERR,W64-ERR --implicit-check-not=error: %s
 
 v_add3_u32_e64_dpp v5, v1, v2, v3 dpp8:[7,6,5,4,3,2,1,0]
 // GFX12: [0x05,0x00,0x55,0xd6,0xe9,0x04,0x0e,0x04,0x01,0x77,0x39,0x05]

--- a/llvm/test/MC/AMDGPU/gfx12_asm_vop3_err.s
+++ b/llvm/test/MC/AMDGPU/gfx12_asm_vop3_err.s
@@ -1,5 +1,5 @@
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=+wavefrontsize32,-wavefrontsize64 -show-encoding %s 2>&1 | FileCheck --check-prefix=GFX12 --strict-whitespace --implicit-check-not=error %s
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=-wavefrontsize32,+wavefrontsize64 -show-encoding %s 2>&1 | FileCheck --check-prefix=GFX12 --strict-whitespace --implicit-check-not=error %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=+wavefrontsize32 -show-encoding %s 2>&1 | FileCheck --check-prefix=GFX12 --strict-whitespace --implicit-check-not=error %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=+wavefrontsize64 -show-encoding %s 2>&1 | FileCheck --check-prefix=GFX12 --strict-whitespace --implicit-check-not=error %s
 
 v_permlane16_b32 v5, v1, s2, s3 op_sel:[0, 0, 0, 1]
 // GFX12: :[[@LINE-1]]:{{[0-9]+}}: error: invalid op_sel operand

--- a/llvm/test/MC/AMDGPU/gfx12_asm_vop3_from_vop1.s
+++ b/llvm/test/MC/AMDGPU/gfx12_asm_vop3_from_vop1.s
@@ -1,4 +1,4 @@
-// RUN: llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=+wavefrontsize32,-wavefrontsize64 -show-encoding %s | FileCheck --check-prefix=GFX12 %s
+// RUN: llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=+wavefrontsize32 -show-encoding %s | FileCheck --check-prefix=GFX12 %s
 
 v_bfrev_b32_e64 v5, v1
 // GFX12: encoding: [0x05,0x00,0xb8,0xd5,0x01,0x01,0x00,0x00]

--- a/llvm/test/MC/AMDGPU/gfx12_asm_vop3_from_vop1_dpp16.s
+++ b/llvm/test/MC/AMDGPU/gfx12_asm_vop3_from_vop1_dpp16.s
@@ -1,4 +1,4 @@
-// RUN: llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=+wavefrontsize32,-wavefrontsize64 -show-encoding %s | FileCheck --check-prefix=GFX12 %s
+// RUN: llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=+wavefrontsize32 -show-encoding %s | FileCheck --check-prefix=GFX12 %s
 
 v_bfrev_b32_e64_dpp v5, v1 quad_perm:[3,2,1,0]
 // GFX12: [0x05,0x00,0xb8,0xd5,0xfa,0x00,0x00,0x00,0x01,0x1b,0x00,0xff]

--- a/llvm/test/MC/AMDGPU/gfx12_asm_vop3_from_vop1_dpp8.s
+++ b/llvm/test/MC/AMDGPU/gfx12_asm_vop3_from_vop1_dpp8.s
@@ -1,4 +1,4 @@
-// RUN: llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=+wavefrontsize32,-wavefrontsize64 -show-encoding %s | FileCheck --check-prefix=GFX12 %s
+// RUN: llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=+wavefrontsize32 -show-encoding %s | FileCheck --check-prefix=GFX12 %s
 
 v_bfrev_b32_e64_dpp v5, v1 dpp8:[7,6,5,4,3,2,1,0]
 // GFX12: [0x05,0x00,0xb8,0xd5,0xe9,0x00,0x00,0x00,0x01,0x77,0x39,0x05]

--- a/llvm/test/MC/AMDGPU/gfx12_asm_vop3_from_vop2.s
+++ b/llvm/test/MC/AMDGPU/gfx12_asm_vop3_from_vop2.s
@@ -1,7 +1,7 @@
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=+wavefrontsize32,-wavefrontsize64 -show-encoding %s | FileCheck --check-prefixes=GFX12,W32 %s
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=-wavefrontsize32,+wavefrontsize64 -show-encoding %s | FileCheck --check-prefixes=GFX12,W64 %s
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=+wavefrontsize32,-wavefrontsize64 %s 2>&1 | FileCheck --check-prefix=W32-ERR --implicit-check-not=error: %s
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=-wavefrontsize32,+wavefrontsize64 %s 2>&1 | FileCheck --check-prefix=W64-ERR --implicit-check-not=error: %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=+wavefrontsize32 -show-encoding %s | FileCheck --check-prefixes=GFX12,W32 %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=+wavefrontsize64 -show-encoding %s | FileCheck --check-prefixes=GFX12,W64 %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=+wavefrontsize32 %s 2>&1 | FileCheck --check-prefix=W32-ERR --implicit-check-not=error: %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=+wavefrontsize64 %s 2>&1 | FileCheck --check-prefix=W64-ERR --implicit-check-not=error: %s
 
 v_add_co_ci_u32_e64 v5, s6, v1, 0xaf123456, s3
 // W32: encoding: [0x05,0x06,0x20,0xd5,0x01,0xff,0x0d,0x00,0x56,0x34,0x12,0xaf]

--- a/llvm/test/MC/AMDGPU/gfx12_asm_vop3_from_vop2_dpp16.s
+++ b/llvm/test/MC/AMDGPU/gfx12_asm_vop3_from_vop2_dpp16.s
@@ -1,7 +1,7 @@
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=+wavefrontsize32,-wavefrontsize64 -show-encoding %s | FileCheck --check-prefixes=GFX12,W32 %s
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=-wavefrontsize32,+wavefrontsize64 -show-encoding %s | FileCheck --check-prefixes=GFX12,W64 %s
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=+wavefrontsize32,-wavefrontsize64 %s 2>&1 | FileCheck --check-prefix=W32-ERR --implicit-check-not=error: %s
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=-wavefrontsize32,+wavefrontsize64 %s 2>&1 | FileCheck --check-prefix=W64-ERR --implicit-check-not=error: %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=+wavefrontsize32 -show-encoding %s | FileCheck --check-prefixes=GFX12,W32 %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=+wavefrontsize64 -show-encoding %s | FileCheck --check-prefixes=GFX12,W64 %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=+wavefrontsize32 %s 2>&1 | FileCheck --check-prefix=W32-ERR --implicit-check-not=error: %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=+wavefrontsize64 %s 2>&1 | FileCheck --check-prefix=W64-ERR --implicit-check-not=error: %s
 
 v_add_co_ci_u32_e64_dpp v5, s6, v1, v2, s3 quad_perm:[3,2,1,0]
 // W32: [0x05,0x06,0x20,0xd5,0xfa,0x04,0x0e,0x00,0x01,0x1b,0x00,0xff]

--- a/llvm/test/MC/AMDGPU/gfx12_asm_vop3_from_vop2_dpp8.s
+++ b/llvm/test/MC/AMDGPU/gfx12_asm_vop3_from_vop2_dpp8.s
@@ -1,7 +1,7 @@
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=+wavefrontsize32,-wavefrontsize64 -show-encoding %s | FileCheck --check-prefixes=GFX12,W32 %s
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=-wavefrontsize32,+wavefrontsize64 -show-encoding %s | FileCheck --check-prefixes=GFX12,W64 %s
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=+wavefrontsize32,-wavefrontsize64 %s 2>&1 | FileCheck --check-prefix=W32-ERR --implicit-check-not=error: %s
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=-wavefrontsize32,+wavefrontsize64 %s 2>&1 | FileCheck --check-prefix=W64-ERR --implicit-check-not=error: %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=+wavefrontsize32 -show-encoding %s | FileCheck --check-prefixes=GFX12,W32 %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=+wavefrontsize64 -show-encoding %s | FileCheck --check-prefixes=GFX12,W64 %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=+wavefrontsize32 %s 2>&1 | FileCheck --check-prefix=W32-ERR --implicit-check-not=error: %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=+wavefrontsize64 %s 2>&1 | FileCheck --check-prefix=W64-ERR --implicit-check-not=error: %s
 
 v_add_co_ci_u32_e64_dpp v5, s6, v1, v2, s3 dpp8:[7,6,5,4,3,2,1,0]
 // W32: [0x05,0x06,0x20,0xd5,0xe9,0x04,0x0e,0x00,0x01,0x77,0x39,0x05]

--- a/llvm/test/MC/AMDGPU/gfx12_asm_vop3c.s
+++ b/llvm/test/MC/AMDGPU/gfx12_asm_vop3c.s
@@ -1,7 +1,7 @@
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=+wavefrontsize32,-wavefrontsize64 -show-encoding %s | FileCheck --check-prefixes=GFX12,W32 %s
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=-wavefrontsize32,+wavefrontsize64 -show-encoding %s | FileCheck --check-prefixes=GFX12,W64 %s
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=+wavefrontsize32,-wavefrontsize64 %s 2>&1 | FileCheck --check-prefix=W32-ERR --implicit-check-not=error: %s
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=-wavefrontsize32,+wavefrontsize64 %s 2>&1 | FileCheck --check-prefix=W64-ERR --implicit-check-not=error: %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=+wavefrontsize32 -show-encoding %s | FileCheck --check-prefixes=GFX12,W32 %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=+wavefrontsize64 -show-encoding %s | FileCheck --check-prefixes=GFX12,W64 %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=+wavefrontsize32 %s 2>&1 | FileCheck --check-prefix=W32-ERR --implicit-check-not=error: %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=+wavefrontsize64 %s 2>&1 | FileCheck --check-prefix=W64-ERR --implicit-check-not=error: %s
 
 v_cmp_class_f16_e64 s5, v1, v2
 // W32: encoding: [0x05,0x00,0x7d,0xd4,0x01,0x05,0x02,0x00]

--- a/llvm/test/MC/AMDGPU/gfx12_asm_vop3c_dpp16.s
+++ b/llvm/test/MC/AMDGPU/gfx12_asm_vop3c_dpp16.s
@@ -1,7 +1,7 @@
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=+wavefrontsize32,-wavefrontsize64 -show-encoding %s | FileCheck --check-prefixes=GFX12,W32 %s
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=-wavefrontsize32,+wavefrontsize64 -show-encoding %s | FileCheck --check-prefixes=GFX12,W64 %s
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=+wavefrontsize32,-wavefrontsize64 %s 2>&1 | FileCheck --check-prefix=W32-ERR --implicit-check-not=error: %s
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=-wavefrontsize32,+wavefrontsize64 %s 2>&1 | FileCheck --check-prefix=W64-ERR --implicit-check-not=error: %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=+wavefrontsize32 -show-encoding %s | FileCheck --check-prefixes=GFX12,W32 %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=+wavefrontsize64 -show-encoding %s | FileCheck --check-prefixes=GFX12,W64 %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=+wavefrontsize32 %s 2>&1 | FileCheck --check-prefix=W32-ERR --implicit-check-not=error: %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=+wavefrontsize64 %s 2>&1 | FileCheck --check-prefix=W64-ERR --implicit-check-not=error: %s
 
 v_cmp_class_f16_e64_dpp s5, v1, v2 quad_perm:[3,2,1,0]
 // W32: [0x05,0x00,0x7d,0xd4,0xfa,0x04,0x02,0x00,0x01,0x1b,0x00,0xff]

--- a/llvm/test/MC/AMDGPU/gfx12_asm_vop3c_dpp8.s
+++ b/llvm/test/MC/AMDGPU/gfx12_asm_vop3c_dpp8.s
@@ -1,7 +1,7 @@
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=+wavefrontsize32,-wavefrontsize64 -show-encoding %s | FileCheck --check-prefixes=GFX12,W32 %s
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=-wavefrontsize32,+wavefrontsize64 -show-encoding %s | FileCheck --check-prefixes=GFX12,W64 %s
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=+wavefrontsize32,-wavefrontsize64 %s 2>&1 | FileCheck --check-prefix=W32-ERR --implicit-check-not=error: %s
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=-wavefrontsize32,+wavefrontsize64 %s 2>&1 | FileCheck --check-prefix=W64-ERR --implicit-check-not=error: %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=+wavefrontsize32 -show-encoding %s | FileCheck --check-prefixes=GFX12,W32 %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=+wavefrontsize64 -show-encoding %s | FileCheck --check-prefixes=GFX12,W64 %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=+wavefrontsize32 %s 2>&1 | FileCheck --check-prefix=W32-ERR --implicit-check-not=error: %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=+wavefrontsize64 %s 2>&1 | FileCheck --check-prefix=W64-ERR --implicit-check-not=error: %s
 
 v_cmp_class_f16_e64_dpp s5, v1, v2 dpp8:[7,6,5,4,3,2,1,0]
 // W32: [0x05,0x00,0x7d,0xd4,0xe9,0x04,0x02,0x00,0x01,0x77,0x39,0x05]

--- a/llvm/test/MC/AMDGPU/gfx12_asm_vop3cx.s
+++ b/llvm/test/MC/AMDGPU/gfx12_asm_vop3cx.s
@@ -1,5 +1,5 @@
-// RUN: llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=+wavefrontsize32,-wavefrontsize64 -show-encoding %s | FileCheck --check-prefixes=GFX12 %s
-// RUN: llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=-wavefrontsize32,+wavefrontsize64 -show-encoding %s | FileCheck --check-prefixes=GFX12 %s
+// RUN: llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=+wavefrontsize32 -show-encoding %s | FileCheck --check-prefixes=GFX12 %s
+// RUN: llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=+wavefrontsize64 -show-encoding %s | FileCheck --check-prefixes=GFX12 %s
 
 v_cmpx_class_f16_e64 v1, v2
 // GFX12: encoding: [0x7e,0x00,0xfd,0xd4,0x01,0x05,0x02,0x00]

--- a/llvm/test/MC/AMDGPU/gfx12_asm_vop3cx_dpp16.s
+++ b/llvm/test/MC/AMDGPU/gfx12_asm_vop3cx_dpp16.s
@@ -1,5 +1,5 @@
-// RUN: llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=+wavefrontsize32,-wavefrontsize64 -show-encoding %s | FileCheck --check-prefixes=GFX12 %s
-// RUN: llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=-wavefrontsize32,+wavefrontsize64 -show-encoding %s | FileCheck --check-prefixes=GFX12 %s
+// RUN: llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=+wavefrontsize32 -show-encoding %s | FileCheck --check-prefixes=GFX12 %s
+// RUN: llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=+wavefrontsize64 -show-encoding %s | FileCheck --check-prefixes=GFX12 %s
 
 v_cmpx_class_f16_e64_dpp v1, v2 quad_perm:[3,2,1,0]
 // GFX12: [0x7e,0x00,0xfd,0xd4,0xfa,0x04,0x02,0x00,0x01,0x1b,0x00,0xff]

--- a/llvm/test/MC/AMDGPU/gfx12_asm_vop3cx_dpp8.s
+++ b/llvm/test/MC/AMDGPU/gfx12_asm_vop3cx_dpp8.s
@@ -1,5 +1,5 @@
-// RUN: llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=+wavefrontsize32,-wavefrontsize64 -show-encoding %s | FileCheck --check-prefixes=GFX12 %s
-// RUN: llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=-wavefrontsize32,+wavefrontsize64 -show-encoding %s | FileCheck --check-prefixes=GFX12 %s
+// RUN: llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=+wavefrontsize32 -show-encoding %s | FileCheck --check-prefixes=GFX12 %s
+// RUN: llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=+wavefrontsize64 -show-encoding %s | FileCheck --check-prefixes=GFX12 %s
 
 v_cmpx_class_f16_e64_dpp v1, v2 dpp8:[7,6,5,4,3,2,1,0]
 // GFX12: [0x7e,0x00,0xfd,0xd4,0xe9,0x04,0x02,0x00,0x01,0x77,0x39,0x05]

--- a/llvm/test/MC/AMDGPU/gfx12_asm_vop3p_aliases.s
+++ b/llvm/test/MC/AMDGPU/gfx12_asm_vop3p_aliases.s
@@ -1,4 +1,4 @@
-// RUN: llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=+wavefrontsize32,-wavefrontsize64 -show-encoding %s | FileCheck --check-prefixes=GFX12 %s
+// RUN: llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=+wavefrontsize32 -show-encoding %s | FileCheck --check-prefixes=GFX12 %s
 
 v_pk_min_f16 v0, v1, v2
 // GFX12: v_pk_min_num_f16 v0, v1, v2             ; encoding: [0x00,0x40,0x1b,0xcc,0x01,0x05,0x02,0x18]

--- a/llvm/test/MC/AMDGPU/gfx12_asm_vop3p_dpp16.s
+++ b/llvm/test/MC/AMDGPU/gfx12_asm_vop3p_dpp16.s
@@ -1,5 +1,5 @@
-// RUN: llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=+wavefrontsize32,-wavefrontsize64 -show-encoding %s | FileCheck --check-prefixes=GFX12 %s
-// RUN: llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=-wavefrontsize32,+wavefrontsize64 -show-encoding %s | FileCheck --check-prefixes=GFX12 %s
+// RUN: llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=+wavefrontsize32 -show-encoding %s | FileCheck --check-prefixes=GFX12 %s
+// RUN: llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=+wavefrontsize64 -show-encoding %s | FileCheck --check-prefixes=GFX12 %s
 
 v_dot2_f32_f16 v0, v1, v2, v3 neg_lo:[0,0,0] neg_hi:[0,0,0] quad_perm:[2,2,3,1] bound_ctrl:0 fi:1
 // GFX12: v_dot2_f32_f16_e64_dpp v0, v1, v2, v3 quad_perm:[2,2,3,1] row_mask:0xf bank_mask:0xf fi:1 ; encoding: [0x00,0x40,0x13,0xcc,0xfa,0x04,0x0e,0x1c,0x01,0x7a,0x04,0xff]

--- a/llvm/test/MC/AMDGPU/gfx12_asm_vop3p_dpp8.s
+++ b/llvm/test/MC/AMDGPU/gfx12_asm_vop3p_dpp8.s
@@ -1,5 +1,5 @@
-// RUN: llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=+wavefrontsize32,-wavefrontsize64 -show-encoding %s | FileCheck --check-prefixes=GFX12 %s
-// RUN: llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=-wavefrontsize32,+wavefrontsize64 -show-encoding %s | FileCheck --check-prefixes=GFX12 %s
+// RUN: llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=+wavefrontsize32 -show-encoding %s | FileCheck --check-prefixes=GFX12 %s
+// RUN: llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=+wavefrontsize64 -show-encoding %s | FileCheck --check-prefixes=GFX12 %s
 
 v_fma_mix_f32 v0, v1, v2, v3 dpp8:[2,2,2,2,4,4,4,4]
 // GFX12: encoding: [0x00,0x00,0x20,0xcc,0xe9,0x04,0x0e,0x04,0x01,0x92,0x44,0x92]

--- a/llvm/test/MC/AMDGPU/gfx12_asm_vopc.s
+++ b/llvm/test/MC/AMDGPU/gfx12_asm_vopc.s
@@ -1,7 +1,7 @@
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=+wavefrontsize32,-wavefrontsize64 -show-encoding %s | FileCheck --check-prefix=W32 %s
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=-wavefrontsize32,+wavefrontsize64 -show-encoding %s | FileCheck --check-prefix=W64 %s
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=+wavefrontsize32,-wavefrontsize64 %s 2>&1 | FileCheck --check-prefix=W32-ERR --implicit-check-not=error: %s
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=-wavefrontsize32,+wavefrontsize64 %s 2>&1 | FileCheck --check-prefix=W64-ERR --implicit-check-not=error: %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=+wavefrontsize32 -show-encoding %s | FileCheck --check-prefix=W32 %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=+wavefrontsize64 -show-encoding %s | FileCheck --check-prefix=W64 %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=+wavefrontsize32 %s 2>&1 | FileCheck --check-prefix=W32-ERR --implicit-check-not=error: %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=+wavefrontsize64 %s 2>&1 | FileCheck --check-prefix=W64-ERR --implicit-check-not=error: %s
 
 v_cmp_class_f16_e32 vcc_lo, v1, v2
 // W32: encoding: [0x01,0x05,0xfa,0x7c]

--- a/llvm/test/MC/AMDGPU/gfx12_asm_vopc_dpp16.s
+++ b/llvm/test/MC/AMDGPU/gfx12_asm_vopc_dpp16.s
@@ -1,7 +1,7 @@
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=+wavefrontsize32,-wavefrontsize64 -show-encoding %s | FileCheck --check-prefix=W32 %s
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=-wavefrontsize32,+wavefrontsize64 -show-encoding %s | FileCheck --check-prefix=W64 %s
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=+wavefrontsize32,-wavefrontsize64 %s 2>&1 | FileCheck --check-prefix=W32-ERR --implicit-check-not=error: %s
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=-wavefrontsize32,+wavefrontsize64 %s 2>&1 | FileCheck --check-prefix=W64-ERR --implicit-check-not=error: %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=+wavefrontsize32 -show-encoding %s | FileCheck --check-prefix=W32 %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=+wavefrontsize64 -show-encoding %s | FileCheck --check-prefix=W64 %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=+wavefrontsize32 %s 2>&1 | FileCheck --check-prefix=W32-ERR --implicit-check-not=error: %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=+wavefrontsize64 %s 2>&1 | FileCheck --check-prefix=W64-ERR --implicit-check-not=error: %s
 
 v_cmp_class_f16_dpp vcc_lo, v1, v2 quad_perm:[3,2,1,0]
 // W32: encoding: [0xfa,0x04,0xfa,0x7c,0x01,0x1b,0x00,0xff]

--- a/llvm/test/MC/AMDGPU/gfx12_asm_vopc_dpp8.s
+++ b/llvm/test/MC/AMDGPU/gfx12_asm_vopc_dpp8.s
@@ -1,7 +1,7 @@
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=+wavefrontsize32,-wavefrontsize64 -show-encoding %s | FileCheck --check-prefix=W32 %s
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=-wavefrontsize32,+wavefrontsize64 -show-encoding %s | FileCheck --check-prefix=W64 %s
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=+wavefrontsize32,-wavefrontsize64 %s 2>&1 | FileCheck --check-prefix=W32-ERR --implicit-check-not=error: %s
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=-wavefrontsize32,+wavefrontsize64 %s 2>&1 | FileCheck --check-prefix=W64-ERR --implicit-check-not=error: %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=+wavefrontsize32 -show-encoding %s | FileCheck --check-prefix=W32 %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=+wavefrontsize64 -show-encoding %s | FileCheck --check-prefix=W64 %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=+wavefrontsize32 %s 2>&1 | FileCheck --check-prefix=W32-ERR --implicit-check-not=error: %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=+wavefrontsize64 %s 2>&1 | FileCheck --check-prefix=W64-ERR --implicit-check-not=error: %s
 
 v_cmp_class_f16_dpp vcc_lo, v1, v2 dpp8:[7,6,5,4,3,2,1,0]
 // W32: encoding: [0xe9,0x04,0xfa,0x7c,0x01,0x77,0x39,0x05]

--- a/llvm/test/MC/AMDGPU/gfx12_asm_vopc_t16_promote.s
+++ b/llvm/test/MC/AMDGPU/gfx12_asm_vopc_t16_promote.s
@@ -1,7 +1,7 @@
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=+wavefrontsize32,-wavefrontsize64 -show-encoding %s | FileCheck --check-prefix=W32 %s
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=-wavefrontsize32,+wavefrontsize64 -show-encoding %s | FileCheck --check-prefix=W64 %s
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=+wavefrontsize32,-wavefrontsize64 %s 2>&1 | FileCheck --check-prefix=W32-ERR --implicit-check-not=error: %s
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=-wavefrontsize32,+wavefrontsize64 %s 2>&1 | FileCheck --check-prefix=W64-ERR --implicit-check-not=error: %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=+wavefrontsize32 -show-encoding %s | FileCheck --check-prefix=W32 %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=+wavefrontsize64 -show-encoding %s | FileCheck --check-prefix=W64 %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=+wavefrontsize32 %s 2>&1 | FileCheck --check-prefix=W32-ERR --implicit-check-not=error: %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=+wavefrontsize64 %s 2>&1 | FileCheck --check-prefix=W64-ERR --implicit-check-not=error: %s
 
 v_cmp_class_f16 vcc, v1, v255
 // W64: v_cmp_class_f16_e64 vcc, v1, v255

--- a/llvm/test/MC/AMDGPU/gfx12_asm_vopcx.s
+++ b/llvm/test/MC/AMDGPU/gfx12_asm_vopcx.s
@@ -1,5 +1,5 @@
-// RUN: llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=+wavefrontsize32,-wavefrontsize64 -show-encoding %s | FileCheck --check-prefixes=GFX12 %s
-// RUN: llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=-wavefrontsize32,+wavefrontsize64 -show-encoding %s | FileCheck --check-prefixes=GFX12 %s
+// RUN: llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=+wavefrontsize32 -show-encoding %s | FileCheck --check-prefixes=GFX12 %s
+// RUN: llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=+wavefrontsize64 -show-encoding %s | FileCheck --check-prefixes=GFX12 %s
 
 v_cmpx_class_f16_e32 v1, v2
 // GFX12: encoding: [0x01,0x05,0xfa,0x7d]

--- a/llvm/test/MC/AMDGPU/gfx12_asm_vopcx_dpp16.s
+++ b/llvm/test/MC/AMDGPU/gfx12_asm_vopcx_dpp16.s
@@ -1,5 +1,5 @@
-// RUN: llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=+wavefrontsize32,-wavefrontsize64 -show-encoding %s | FileCheck --check-prefixes=GFX12 %s
-// RUN: llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=-wavefrontsize32,+wavefrontsize64 -show-encoding %s | FileCheck --check-prefixes=GFX12 %s
+// RUN: llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=+wavefrontsize32 -show-encoding %s | FileCheck --check-prefixes=GFX12 %s
+// RUN: llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=+wavefrontsize64 -show-encoding %s | FileCheck --check-prefixes=GFX12 %s
 
 v_cmpx_class_f16_dpp v1, v2 quad_perm:[3,2,1,0]
 // GFX12: encoding: [0xfa,0x04,0xfa,0x7d,0x01,0x1b,0x00,0xff]

--- a/llvm/test/MC/AMDGPU/gfx12_asm_vopcx_dpp8.s
+++ b/llvm/test/MC/AMDGPU/gfx12_asm_vopcx_dpp8.s
@@ -1,5 +1,5 @@
-// RUN: llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=+wavefrontsize32,-wavefrontsize64 -show-encoding %s | FileCheck --check-prefixes=GFX12 %s
-// RUN: llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=-wavefrontsize32,+wavefrontsize64 -show-encoding %s | FileCheck --check-prefixes=GFX12 %s
+// RUN: llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=+wavefrontsize32 -show-encoding %s | FileCheck --check-prefixes=GFX12 %s
+// RUN: llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=+wavefrontsize64 -show-encoding %s | FileCheck --check-prefixes=GFX12 %s
 
 v_cmpx_class_f16_dpp v1, v2 dpp8:[7,6,5,4,3,2,1,0]
 // GFX12: encoding: [0xe9,0x04,0xfa,0x7d,0x01,0x77,0x39,0x05]

--- a/llvm/test/MC/AMDGPU/gfx12_asm_vopd.s
+++ b/llvm/test/MC/AMDGPU/gfx12_asm_vopd.s
@@ -1,6 +1,6 @@
-// RUN: llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=+wavefrontsize32,-wavefrontsize64 -show-encoding %s | FileCheck --check-prefixes=GFX12 %s
+// RUN: llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=+wavefrontsize32 -show-encoding %s | FileCheck --check-prefixes=GFX12 %s
 // RUN: llvm-mc -triple=amdgcn -mcpu=gfx1200 -show-encoding %s | FileCheck --check-prefixes=GFX12 %s
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=-wavefrontsize32,+wavefrontsize64 -show-encoding %s 2>&1 | FileCheck --check-prefixes=W64-ERR --implicit-check-not=error: %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=+wavefrontsize64 -show-encoding %s 2>&1 | FileCheck --check-prefixes=W64-ERR --implicit-check-not=error: %s
 
 v_dual_add_f32 v255, v4, v2 :: v_dual_add_f32 v6, v1, v3
 // GFX12: encoding: [0x04,0x05,0x08,0xc9,0x01,0x07,0x06,0xff]

--- a/llvm/test/MC/AMDGPU/gfx12_asm_wmma_w64.s
+++ b/llvm/test/MC/AMDGPU/gfx12_asm_wmma_w64.s
@@ -1,5 +1,5 @@
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=-wavefrontsize32,+wavefrontsize64 -show-encoding %s | FileCheck --check-prefix=GFX12 %s
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=-wavefrontsize32,+wavefrontsize64 %s 2>&1 | FileCheck --check-prefix=GFX12-ERR --implicit-check-not=error: %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=+wavefrontsize64 -show-encoding %s | FileCheck --check-prefix=GFX12 %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=+wavefrontsize64 %s 2>&1 | FileCheck --check-prefix=GFX12-ERR --implicit-check-not=error: %s
 
 v_wmma_f32_16x16x16_f16 v[4:7], v[0:1], v[2:3], v[4:7]
 // GFX12: v_wmma_f32_16x16x16_f16 v[4:7], v[0:1], v[2:3], v[4:7] ; encoding: [0x04,0x40,0x40,0xcc,0x00,0x05,0x12,0x1c]

--- a/llvm/test/MC/AMDGPU/vop3-literal.s
+++ b/llvm/test/MC/AMDGPU/vop3-literal.s
@@ -1,6 +1,6 @@
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1010 -mattr=-wavefrontsize32,+wavefrontsize64 -show-encoding %s | FileCheck -check-prefix=GFX10 %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1010 -mattr=+wavefrontsize64 -show-encoding %s | FileCheck -check-prefix=GFX10 %s
 // RUN: not llvm-mc -triple=amdgcn -mcpu=gfx900  -show-encoding %s | FileCheck -check-prefix=GFX9 %s
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1010 -mattr=-wavefrontsize32,+wavefrontsize64 %s 2>&1 | FileCheck -check-prefix=GFX10-ERR --implicit-check-not=error: %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1010 -mattr=+wavefrontsize64 %s 2>&1 | FileCheck -check-prefix=GFX10-ERR --implicit-check-not=error: %s
 // RUN: not llvm-mc -triple=amdgcn -mcpu=gfx900  %s 2>&1 | FileCheck -check-prefix=GFX9-ERR --implicit-check-not=error: %s
 
 v_bfe_u32 v0, 0x3039, v1, s1

--- a/llvm/test/MC/AMDGPU/wave32.s
+++ b/llvm/test/MC/AMDGPU/wave32.s
@@ -1,7 +1,7 @@
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1010 -mattr=+wavefrontsize32,-wavefrontsize64 -show-encoding %s | FileCheck -check-prefix=GFX1032 %s
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1010 -mattr=-wavefrontsize32,+wavefrontsize64 -show-encoding %s | FileCheck -check-prefix=GFX1064 %s
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1010 -mattr=+wavefrontsize32,-wavefrontsize64 %s 2>&1 | FileCheck -check-prefix=GFX1032-ERR --implicit-check-not=error: %s
-// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1010 -mattr=-wavefrontsize32,+wavefrontsize64 %s 2>&1 | FileCheck -check-prefix=GFX1064-ERR --implicit-check-not=error: %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1010 -mattr=+wavefrontsize32 -show-encoding %s | FileCheck -check-prefix=GFX1032 %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1010 -mattr=+wavefrontsize64 -show-encoding %s | FileCheck -check-prefix=GFX1064 %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1010 -mattr=+wavefrontsize32 %s 2>&1 | FileCheck -check-prefix=GFX1032-ERR --implicit-check-not=error: %s
+// RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1010 -mattr=+wavefrontsize64 %s 2>&1 | FileCheck -check-prefix=GFX1064-ERR --implicit-check-not=error: %s
 
 v_cmp_ge_i32_e32 s0, v0
 // GFX1032: v_cmp_ge_i32_e32 vcc_lo, s0, v0 ; encoding: [0x00,0x00,0x0c,0x7d]


### PR DESCRIPTION
If a non-default wavefrontsize is requested in the command line we end up with both wavefrontsize32 and wavefrontsize64 set in the feature bits, one from the command line and one from the target defaults. Because of this many of our tests has -mattr=-wavefrontsize32,+wavefrontsize64 idiom.

Remove the default feature bit in this case.