### PR TITLE
[libc] Disable `-ffreestanding` and `-fno-builtin` on the GPU build

### DIFF
--- a/libc/cmake/modules/LLVMLibCCompileOptionRules.cmake
+++ b/libc/cmake/modules/LLVMLibCCompileOptionRules.cmake
@@ -43,9 +43,11 @@ function(_get_common_compile_options output_var flags)
     list(APPEND compile_options "-fpie")
 
     if(LLVM_LIBC_FULL_BUILD)
+      # Only add -ffreestanding flag in non-GPU full build mode.
+      if(NOT LIBC_TARGET_OS_IS_GPU)
+        list(APPEND compile_options "-ffreestanding")
+      endif()
       list(APPEND compile_options "-DLIBC_FULL_BUILD")
-      # Only add -ffreestanding flag in full build mode.
-      list(APPEND compile_options "-ffreestanding")
       # Manually disable standard include paths to prevent system headers from
       # being included.
       if(LIBC_CC_SUPPORTS_NOSTDLIBINC)
@@ -60,7 +62,19 @@ function(_get_common_compile_options output_var flags)
       list(APPEND compile_options "-ffixed-point")
     endif()
 
-    list(APPEND compile_options "-fno-builtin")
+    # Builtin recognition causes issues when trying to implement the builtin
+    # functions themselves. The GPU backends do not use libcalls so we disable
+    # the known problematic ones. This allows inlining during LTO linking.
+    if(LIBC_TARGET_OS_IS_GPU)
+      set(libc_builtins bcmp strlen memmem bzero memcmp memcpy memmem memmove
+                        memset strcmp strstr)
+      foreach(builtin ${libc_builtins})
+        list(APPEND compile_options "-fno-builtin-${builtin}")
+      endforeach()
+    else()
+      list(APPEND compile_options "-fno-builtin")
+    endif()
+
     list(APPEND compile_options "-fno-exceptions")
     list(APPEND compile_options "-fno-lax-vector-conversions")
     list(APPEND compile_options "-fno-unwind-tables")


### PR DESCRIPTION
Summary:
This patch removed the `-ffreestanding` and `-fno-builtin` flags from
the publically installed version of the GPU library. The presense of
`-fno-builtin` caused issues that prevented all inlining in the GPU C
library, see https://discourse.llvm.org/t/rfc-libc-ffreestanding-fno-builtin/75883.
Previously, I attempted to fix this by loosening the restriction that
`"no-builtins"` functions cannot be inlined into functions without that
attribute. However, that opened up a lot of extra issues that stalled
that approach.

This patch instead removes that and instead passes `-fno-builtin-<xyz>`
for the few calls that are known to be problematic. I believe this works
in general as the GPU backends do not emit any libcalls and the
implementations of most of these simply reduce to builtins right now.
This is a very useful patch as we can now actually inline calls.
