### PR TITLE
[mlir][bytecode] Fix external resource bytecode parsing

### DIFF
--- a/mlir/lib/Bytecode/Reader/BytecodeReader.cpp
+++ b/mlir/lib/Bytecode/Reader/BytecodeReader.cpp
@@ -707,7 +707,7 @@ LogicalResult ResourceSectionReader::initialize(
     auto resolveKey = [&](StringRef key) -> StringRef {
       auto it = dialectResourceHandleRenamingMap.find(key);
       if (it == dialectResourceHandleRenamingMap.end())
-        return "";
+        return key;
       return it->second;
     };
 

--- a/mlir/test/Bytecode/external_resources.mlir
+++ b/mlir/test/Bytecode/external_resources.mlir
@@ -1,0 +1,19 @@
+// RUN: mlir-opt %s -emit-bytecode | mlir-opt
+
+module {
+}
+
+{-#
+  // CHECK: external_resources
+  external_resources: {
+    // CHECK-NEXT: mlir_reproducer
+    mlir_reproducer: {
+      // CHECK-NEXT: pipeline: "builtin.module(func.func(canonicalize,cse))"
+      pipeline: "builtin.module(func.func(canonicalize,cse))",
+      // CHECK-NEXT: disable_threading: true
+      disable_threading: true,
+      // CHECK-NEXT: verify_each: true
+      verify_each: true
+    }
+  }
+#-}

--- a/mlir/test/Bytecode/external_resources.mlir
+++ b/mlir/test/Bytecode/external_resources.mlir
@@ -1,4 +1,4 @@
-// RUN: mlir-opt %s -emit-bytecode | mlir-opt
+// RUN: mlir-opt %s -emit-bytecode | mlir-opt | FileCheck %s
 
 module {
 }
@@ -8,7 +8,7 @@ module {
   external_resources: {
     // CHECK-NEXT: mlir_reproducer
     mlir_reproducer: {
-      // CHECK-NEXT: pipeline: "builtin.module(func.func(canonicalize,cse))"
+      // CHECK-NEXT: pipeline: "builtin.module(func.func(canonicalize,cse))",
       pipeline: "builtin.module(func.func(canonicalize,cse))",
       // CHECK-NEXT: disable_threading: true
       disable_threading: true,


### PR DESCRIPTION
The key was being dropped for external resources because they aren't present in the dialect resource name mapper.