### PR TITLE
[NFC][MLIR] Fix: `alloca` promotion for `AllocationOpInterface`

### DIFF
--- a/mlir/lib/Dialect/Bufferization/Transforms/BufferOptimizations.cpp
+++ b/mlir/lib/Dialect/Bufferization/Transforms/BufferOptimizations.cpp
@@ -397,12 +397,12 @@ public:
       OpBuilder builder(startOperation);
       Operation *allocOp = alloc.getDefiningOp();
       if (auto allocInterface = dyn_cast<AllocationOpInterface>(allocOp)) {
-        Operation *alloca =
-            allocInterface.buildPromotedAlloc(builder, alloc).value();
+        std::optional<Operation *> alloca =
+            allocInterface.buildPromotedAlloc(builder, alloc);
         if (!alloca)
           continue;
         // Replace the original alloc by a newly created alloca.
-        allocOp->replaceAllUsesWith(alloca);
+        allocOp->replaceAllUsesWith(alloca.value());
         allocOp->erase();
       }
     }


### PR DESCRIPTION
The std::optional returned by buildPromotedAlloc was directly dereferenced and assumed to be non-null, even though the documentation for AllocationOpInterface indicates that std::nullopt is a legal value if buffer stack promotion is not supported (and is the default value supplied by the TableGen interface file). This patch removes the direct dereference so that the optional can be null-checked prior to use.