### PR TITLE
[LLDB] Support exception breakpoints for plugin-provided languages

### DIFF
--- a/lldb/include/lldb/Target/Language.h
+++ b/lldb/include/lldb/Target/Language.h
@@ -245,7 +245,7 @@ public:
   // a match.  But we wouldn't want this to match AnotherA::my_function.  The
   // user is specifying a truncated path, not a truncated set of characters.
   // This function does a language-aware comparison for those purposes.
-  virtual bool DemangledNameContainsPath(llvm::StringRef path,
+  virtual bool DemangledNameContainsPath(llvm::StringRef path, 
                                          ConstString demangled) const;
 
   // if a language has a custom format for printing variable declarations that

--- a/lldb/include/lldb/Target/Language.h
+++ b/lldb/include/lldb/Target/Language.h
@@ -245,7 +245,7 @@ public:
   // a match.  But we wouldn't want this to match AnotherA::my_function.  The
   // user is specifying a truncated path, not a truncated set of characters.
   // This function does a language-aware comparison for those purposes.
-  virtual bool DemangledNameContainsPath(llvm::StringRef path, 
+  virtual bool DemangledNameContainsPath(llvm::StringRef path,
                                          ConstString demangled) const;
 
   // if a language has a custom format for printing variable declarations that
@@ -362,6 +362,10 @@ public:
   virtual bool IgnoreForLineBreakpoints(const SymbolContext &) const {
     return false;
   }
+
+  /// Returns true if this Language supports exception breakpoints via a
+  /// corresponding LanguageRuntime plugin.
+  virtual bool SupportsExceptionBreakpoints() const { return false; }
 
 protected:
   // Classes that inherit from Language can see and modify these

--- a/lldb/source/Commands/CommandObjectBreakpoint.cpp
+++ b/lldb/source/Commands/CommandObjectBreakpoint.cpp
@@ -308,9 +308,6 @@ public:
         case eLanguageTypeC_plus_plus_14:
           m_exception_language = eLanguageTypeC_plus_plus;
           break;
-        case eLanguageTypeObjC:
-          m_exception_language = eLanguageTypeObjC;
-          break;
         case eLanguageTypeObjC_plus_plus:
           error_context =
               "Set exception breakpoints separately for c++ and objective-c";
@@ -319,6 +316,12 @@ public:
           error_context = "Unknown language type for exception breakpoint";
           break;
         default:
+          if (Language *languagePlugin = Language::FindPlugin(language)) {
+            if (languagePlugin->SupportsExceptionBreakpoints()) {
+              m_exception_language = language;
+              break;
+            }
+          }
           error_context = "Unsupported language type for exception breakpoint";
         }
         if (!error_context.empty())

--- a/lldb/source/Plugins/Language/ObjC/ObjCLanguage.h
+++ b/lldb/source/Plugins/Language/ObjC/ObjCLanguage.h
@@ -194,6 +194,8 @@ public:
 
   llvm::StringRef GetInstanceVariableName() override { return "self"; }
 
+  bool SupportsExceptionBreakpoints() const override { return true; }
+
   // PluginInterface protocol
   llvm::StringRef GetPluginName() override { return GetPluginNameStatic(); }
 };


### PR DESCRIPTION
CommandObjectBreakpoint has a harcoded list of languages for which exception breakpoints can be enabled. I'm making this a bit more generic so that my Mojo plugin can get this feature.
Basically, I'm adding a new overridable method `Language::SupportsExceptionBreakpoints` that can be used by language plugins to determine whether they support this feature or not. This method is used in addition to the hardcoded list and, as an example, I'm using it for the ObjC language support.

Another route is simply to avoid doing the check that it's being done right now and simply try to the create the exception breakpoint for whatever language that is not in the hardcoded list. I'm happy to do that if the reviewers think it's a good idea.

As a note, the other possible place for adding this `SupportsExceptionBreakpoints` method is in `LanguageRuntime`. However, accessing it requires having a process, which is not always the case when invoking the `breakpoint set -E` command. The process might not be alive yet, so `Language` is a good second place for this.

And as a final note, I don't want to make this `SupportsExceptionBreakpoints` complicated. I'm keeping it as simple as possible because it can easily evolve as it's not part of the public API.
