### PR TITLE
[clang-doc] add enum test

### DIFF
--- a/clang-tools-extra/test/clang-doc/enum.cpp
+++ b/clang-tools-extra/test/clang-doc/enum.cpp
@@ -21,7 +21,7 @@ enum Color {
 // HTML-INDEX:     <li>Green</li>
 // HTML-INDEX:     <li>Blue</li>
 // HTML-INDEX:   </ul>
-// HTML-INDEX:   <p>Defined at line 11 of file {{.*}}clang-tools-extra{{[\/]}}test{{[\/]}}clang-doc{{[\/]}}enum.cpp</p>
+// HTML-INDEX:   <p>Defined at line 9 of file {{.*}}clang-tools-extra{{[\/]}}test{{[\/]}}clang-doc{{[\/]}}enum.cpp</p>
 // HTML-INDEX:   <div>
 // HTML-INDEX:     <div></div>
 // HTML-INDEX:   </div>

--- a/clang-tools-extra/test/clang-doc/enum.cpp
+++ b/clang-tools-extra/test/clang-doc/enum.cpp
@@ -1,0 +1,38 @@
+// RUN: clang-doc --format=html --doxygen --output=%t/docs --executor=standalone %s
+// RUN: clang-doc --format=md --doxygen --output=%t/docs --executor=standalone %s
+// RUN: FileCheck %s -input-file=%t/docs/GlobalNamespace/index.html -check-prefix=HTML-INDEX
+// RUN: FileCheck %s -input-file=%t/docs/GlobalNamespace/index.md -check-prefix=MD-INDEX
+
+/**
+ * @brief For specifying RGB colors
+ */
+enum Color {
+  Red, // Red enums
+  Green, // Green enums
+  Blue // Blue enums
+};
+
+// HTML-INDEX: <h1>Global Namespace</h1>
+// HTML-INDEX: <h2 id="Enums">Enums</h2>
+// HTML-INDEX: <div>
+// HTML-INDEX:   <h3 id="{{([0-9A-F]{40})}}">enum Color</h3>
+// HTML-INDEX:   <ul>
+// HTML-INDEX:     <li>Red</li>
+// HTML-INDEX:     <li>Green</li>
+// HTML-INDEX:     <li>Blue</li>
+// HTML-INDEX:   </ul>
+// HTML-INDEX:   <p>Defined at line 11 of file {{.*}}clang-tools-extra{{[\/]}}test{{[\/]}}clang-doc{{[\/]}}enum.cpp</p>
+// HTML-INDEX:   <div>
+// HTML-INDEX:     <div></div>
+// HTML-INDEX:   </div>
+// HTML-INDEX: </div>
+
+// MD-INDEX: # Global Namespace
+// MD-INDEX: ## Enums
+// MD-INDEX: | enum Color |
+// MD-INDEX: --
+// MD-INDEX: | Red |
+// MD-INDEX: | Green |
+// MD-INDEX: | Blue |
+// MD-INDEX: *Defined at {{.*}}clang-tools-extra{{[\/]}}test{{[\/]}}clang-doc{{[\/]}}enum.cpp#11*
+// MD-INDEX: **brief** For specifying RGB colors

--- a/clang-tools-extra/test/clang-doc/enum.cpp
+++ b/clang-tools-extra/test/clang-doc/enum.cpp
@@ -34,5 +34,5 @@ enum Color {
 // MD-INDEX: | Red |
 // MD-INDEX: | Green |
 // MD-INDEX: | Blue |
-// MD-INDEX: *Defined at {{.*}}clang-tools-extra{{[\/]}}test{{[\/]}}clang-doc{{[\/]}}enum.cpp#11*
+// MD-INDEX: *Defined at {{.*}}clang-tools-extra{{[\/]}}test{{[\/]}}clang-doc{{[\/]}}enum.cpp#9*
 // MD-INDEX: **brief** For specifying RGB colors

--- a/clang-tools-extra/test/clang-doc/enum.cpp
+++ b/clang-tools-extra/test/clang-doc/enum.cpp
@@ -1,31 +1,25 @@
-// RUN: clang-doc --format=html --doxygen --output=%t/docs --executor=standalone %s
-// RUN: clang-doc --format=md --doxygen --output=%t/docs --executor=standalone %s
-// RUN: FileCheck %s -input-file=%t/docs/GlobalNamespace/index.html -check-prefix=HTML-INDEX
-// RUN: FileCheck %s -input-file=%t/docs/GlobalNamespace/index.md -check-prefix=MD-INDEX
+// RUN: rm -rf %t && mkdir -p %t
+// RUN: clang-doc --format=html --doxygen --output=%t --executor=standalone %s
+// RUN: clang-doc --format=md --doxygen --output=%t --executor=standalone %s
+// RUN: FileCheck %s < %t/GlobalNamespace/index.html -check-prefix=HTML-INDEX
+// RUN: FileCheck %s < %t/GlobalNamespace/index.md -check-prefix=MD-INDEX
 
 /**
  * @brief For specifying RGB colors
  */
 enum Color {
-  Red, // Red enums
-  Green, // Green enums
-  Blue // Blue enums
+  Red,
+  Green,
+  Blue
 };
 
 // HTML-INDEX: <h1>Global Namespace</h1>
 // HTML-INDEX: <h2 id="Enums">Enums</h2>
-// HTML-INDEX: <div>
-// HTML-INDEX:   <h3 id="{{([0-9A-F]{40})}}">enum Color</h3>
-// HTML-INDEX:   <ul>
-// HTML-INDEX:     <li>Red</li>
-// HTML-INDEX:     <li>Green</li>
-// HTML-INDEX:     <li>Blue</li>
-// HTML-INDEX:   </ul>
-// HTML-INDEX:   <p>Defined at line 9 of file {{.*}}clang-tools-extra{{[\/]}}test{{[\/]}}clang-doc{{[\/]}}enum.cpp</p>
-// HTML-INDEX:   <div>
-// HTML-INDEX:     <div></div>
-// HTML-INDEX:   </div>
-// HTML-INDEX: </div>
+// HTML-INDEX: <h3 id="{{([0-9A-F]{40})}}">enum Color</h3>
+// HTML-INDEX: <li>Red</li>
+// HTML-INDEX: <li>Green</li>
+// HTML-INDEX: <li>Blue</li>
+// HTML-INDEX: <p>Defined at line 10 of file {{.*}}clang-tools-extra{{[\/]}}test{{[\/]}}clang-doc{{[\/]}}enum.cpp</p>
 
 // MD-INDEX: # Global Namespace
 // MD-INDEX: ## Enums
@@ -34,5 +28,5 @@ enum Color {
 // MD-INDEX: | Red |
 // MD-INDEX: | Green |
 // MD-INDEX: | Blue |
-// MD-INDEX: *Defined at {{.*}}clang-tools-extra{{[\/]}}test{{[\/]}}clang-doc{{[\/]}}enum.cpp#9*
+// MD-INDEX: *Defined at {{.*}}clang-tools-extra{{[\/]}}test{{[\/]}}clang-doc{{[\/]}}enum.cpp#10*
 // MD-INDEX: **brief** For specifying RGB colors

--- a/clang-tools-extra/test/clang-doc/enum.cpp
+++ b/clang-tools-extra/test/clang-doc/enum.cpp
@@ -2,24 +2,13 @@
 // RUN: clang-doc --format=html --doxygen --output=%t --executor=standalone %s
 // RUN: clang-doc --format=md --doxygen --output=%t --executor=standalone %s
 // RUN: FileCheck %s < %t/GlobalNamespace/index.html -check-prefix=HTML-INDEX
+// RUN: FileCheck %s < %t/GlobalNamespace/Animals.html -check-prefix=HTML-ANIMAL
+// RUN: FileCheck %s < %t/Vehicles/index.html -check-prefix=HTML-VEHICLES
 // RUN: FileCheck %s < %t/GlobalNamespace/index.md -check-prefix=MD-INDEX
+// RUN: FileCheck %s < %t/GlobalNamespace/Animals.md -check-prefix=MD-ANIMAL
+// RUN: FileCheck %s < %t/Vehicles/index.md -check-prefix=MD-VEHICLES
 
-/**
- * @brief For specifying RGB colors
- */
-enum Color {
-  Red,
-  Green,
-  Blue
-};
 
-// HTML-INDEX: <h1>Global Namespace</h1>
-// HTML-INDEX: <h2 id="Enums">Enums</h2>
-// HTML-INDEX: <h3 id="{{([0-9A-F]{40})}}">enum Color</h3>
-// HTML-INDEX: <li>Red</li>
-// HTML-INDEX: <li>Green</li>
-// HTML-INDEX: <li>Blue</li>
-// HTML-INDEX: <p>Defined at line 10 of file {{.*}}clang-tools-extra{{[\/]}}test{{[\/]}}clang-doc{{[\/]}}enum.cpp</p>
 
 // MD-INDEX: # Global Namespace
 // MD-INDEX: ## Enums
@@ -28,5 +17,112 @@ enum Color {
 // MD-INDEX: | Red |
 // MD-INDEX: | Green |
 // MD-INDEX: | Blue |
-// MD-INDEX: *Defined at {{.*}}clang-tools-extra{{[\/]}}test{{[\/]}}clang-doc{{[\/]}}enum.cpp#10*
+// MD-INDEX: *Defined at {{.*}}clang-tools-extra{{[\/]}}test{{[\/]}}clang-doc{{[\/]}}enum.cpp#[[@LINE+13]]*
 // MD-INDEX: **brief** For specifying RGB colors
+
+// HTML-INDEX: <h1>Global Namespace</h1>
+// HTML-INDEX: <h2 id="Enums">Enums</h2>
+// HTML-INDEX: <h3 id="{{([0-9A-F]{40})}}">enum Color</h3>
+// HTML-INDEX: <li>Red</li>
+// HTML-INDEX: <li>Green</li>
+// HTML-INDEX: <li>Blue</li>
+// HTML-INDEX: <p>Defined at line [[@LINE+4]] of file {{.*}}clang-tools-extra{{[\/]}}test{{[\/]}}clang-doc{{[\/]}}enum.cpp</p>
+/**
+ * @brief For specifying RGB colors
+ */
+enum Color {
+  Red, ///< Red
+  Green, ///< Green
+  Blue ///< Blue
+};
+
+
+// MD-INDEX: | enum class Shapes |
+// MD-INDEX: --
+// MD-INDEX: | Circle |
+// MD-INDEX: | Rectangle |
+// MD-INDEX: | Triangle |
+// MD-INDEX: *Defined at {{.*}}clang-tools-extra{{[\/]}}test{{[\/]}}clang-doc{{[\/]}}enum.cpp#[[@LINE+11]]*
+// MD-INDEX: **brief** Shape Types
+
+// HTML-INDEX: <h3 id="{{([0-9A-F]{40})}}">enum class Shapes</h3>
+// HTML-INDEX: <li>Circle</li>
+// HTML-INDEX: <li>Rectangle</li>
+// HTML-INDEX: <li>Triangle</li>
+// HTML-INDEX: <p>Defined at line [[@LINE+4]] of file {{.*}}clang-tools-extra{{[\/]}}test{{[\/]}}clang-doc{{[\/]}}enum.cpp</p>
+/**
+ * @brief Shape Types
+ */
+enum class Shapes {
+  /// Circle
+  Circle,
+  /// Rectangle
+  Rectangle,
+  /// Triangle
+  Triangle
+};
+
+
+// MD-ANIMAL: # class Animals
+// MD-ANIMAL: *Defined at {{.*}}clang-tools-extra{{[\/]}}test{{[\/]}}clang-doc{{[\/]}}enum.cpp#[[@LINE+18]]*
+// MD-ANIMAL: ## Enums
+// MD-ANIMAL: | enum AnimalType |
+// MD-ANIMAL: --
+// MD-ANIMAL: | Dog |
+// MD-ANIMAL: | Cat |
+// MD-ANIMAL: | Iguana |
+// MD-ANIMAL: *Defined at {{.*}}clang-tools-extra{{[\/]}}test{{[\/]}}clang-doc{{[\/]}}enum.cpp#[[@LINE+16]]*
+// MD-ANIMAL: **brief** specify what animal the class is
+
+// HTML-ANIMAL: <h1>class Animals</h1>
+// HTML-ANIMAL: <p>Defined at line [[@LINE+7]] of file {{.*}}clang-tools-extra{{[\/]}}test{{[\/]}}clang-doc{{[\/]}}enum.cpp</p>
+// HTML-ANIMAL: <h2 id="Enums">Enums</h2>
+// HTML-ANIMAL: <h3 id="{{([0-9A-F]{40})}}">enum AnimalType</h3>
+// HTML-ANIMAL: <li>Dog</li>
+// HTML-ANIMAL: <li>Cat</li>
+// HTML-ANIMAL: <li>Iguana</li>
+// HTML-ANIMAL: <p>Defined at line [[@LINE+6]] of file {{.*}}clang-tools-extra{{[\/]}}test{{[\/]}}clang-doc{{[\/]}}enum.cpp</p>
+class Animals {
+public:
+      /**
+       * @brief specify what animal the class is
+       */
+      enum AnimalType {
+          Dog, /// Man's best friend
+          Cat, /// Man's other best friend
+          Iguana /// A lizard
+      };
+};
+
+
+
+// MD-VEHICLES: # namespace Vehicles
+// MD-VEHICLES: ## Enums
+// MD-VEHICLES: | enum Car |
+// MD-VEHICLES: --
+// MD-VEHICLES: | Sedan |
+// MD-VEHICLES: | SUV |
+// MD-VEHICLES: | Pickup |
+// MD-VEHICLES: | Hatchback |
+// MD-VEHICLES: *Defined at {{.*}}clang-tools-extra{{[\/]}}test{{[\/]}}clang-doc{{[\/]}}enum.cpp#[[@LINE+15]]*
+// MD-VEHICLES: **brief** specify type of car
+
+// HTML-VEHICLES: <h1>namespace Vehicles</h1>
+// HTML-VEHICLES: <h2 id="Enums">Enums</h2>
+// HTML-VEHICLES: <h3 id="{{([0-9A-F]{40})}}">enum Car</h3>
+// HTML-VEHICLES: <li>Sedan</li>
+// HTML-VEHICLES: <li>SUV</li>
+// HTML-VEHICLES: <li>Pickup</li>
+// HTML-VEHICLES: <li>Hatchback</li>
+// HTML-VEHICLES: <p>Defined at line [[@LINE+5]] of file {{.*}}clang-tools-extra{{[\/]}}test{{[\/]}}clang-doc{{[\/]}}enum.cpp</p>
+namespace Vehicles {
+    /**
+     * @brief specify type of car
+     */
+    enum Car {
+       Sedan, /// Sedan
+       SUV, /// SUV
+       Pickup, /// Pickup
+       Hatchback /// Hatchback
+    };
+}

--- a/clang-tools-extra/test/clang-doc/enum.cpp
+++ b/clang-tools-extra/test/clang-doc/enum.cpp
@@ -1,59 +1,51 @@
 // RUN: rm -rf %t && mkdir -p %t
 // RUN: clang-doc --format=html --doxygen --output=%t --executor=standalone %s
 // RUN: clang-doc --format=md --doxygen --output=%t --executor=standalone %s
-// RUN: FileCheck %s < %t/GlobalNamespace/index.html -check-prefix=HTML-INDEX
-// RUN: FileCheck %s < %t/GlobalNamespace/Animals.html -check-prefix=HTML-ANIMAL
-// RUN: FileCheck %s < %t/Vehicles/index.html -check-prefix=HTML-VEHICLES
-// RUN: FileCheck %s < %t/GlobalNamespace/index.md -check-prefix=MD-INDEX
-// RUN: FileCheck %s < %t/GlobalNamespace/Animals.md -check-prefix=MD-ANIMAL
-// RUN: FileCheck %s < %t/Vehicles/index.md -check-prefix=MD-VEHICLES
+// RUN: FileCheck %s < %t/GlobalNamespace/index.html --check-prefix=HTML-INDEX-LINE
+// RUN: FileCheck %s < %t/GlobalNamespace/index.html --check-prefix=HTML-INDEX
+// RUN: FileCheck %s < %t/GlobalNamespace/Animals.html --check-prefix=HTML-ANIMAL-LINE
+// RUN: FileCheck %s < %t/GlobalNamespace/Animals.html --check-prefix=HTML-ANIMAL
+// RUN: FileCheck %s < %t/Vehicles/index.html --check-prefix=HTML-VEHICLES-LINE
+// RUN: FileCheck %s < %t/Vehicles/index.html --check-prefix=HTML-VEHICLES
+// RUN: FileCheck %s < %t/GlobalNamespace/index.md --check-prefix=MD-INDEX-LINE
+// RUN: FileCheck %s < %t/GlobalNamespace/index.md --check-prefix=MD-INDEX
+// RUN: FileCheck %s < %t/GlobalNamespace/Animals.md --check-prefix=MD-ANIMAL-LINE
+// RUN: FileCheck %s < %t/GlobalNamespace/Animals.md --check-prefix=MD-ANIMAL
+// RUN: FileCheck %s < %t/Vehicles/index.md --check-prefix=MD-VEHICLES-LINE
+// RUN: FileCheck %s < %t/Vehicles/index.md --check-prefix=MD-VEHICLES
 
 
+/**
+ * @brief For specifying RGB colors
+ */
+enum Color {
+// MD-INDEX-LINE: *Defined at {{.*}}clang-tools-extra{{[\/]}}test{{[\/]}}clang-doc{{[\/]}}enum.cpp#[[@LINE-1]]*
+// HTML-INDEX-LINE: <p>Defined at line [[@LINE-2]] of file {{.*}}clang-tools-extra{{[\/]}}test{{[\/]}}clang-doc{{[\/]}}enum.cpp</p>
+  Red, ///< Red
+  Green, ///< Green
+  Blue ///< Blue
+};
 
-// MD-INDEX: # Global Namespace
 // MD-INDEX: ## Enums
 // MD-INDEX: | enum Color |
 // MD-INDEX: --
 // MD-INDEX: | Red |
 // MD-INDEX: | Green |
 // MD-INDEX: | Blue |
-// MD-INDEX: *Defined at {{.*}}clang-tools-extra{{[\/]}}test{{[\/]}}clang-doc{{[\/]}}enum.cpp#[[@LINE+13]]*
 // MD-INDEX: **brief** For specifying RGB colors
 
-// HTML-INDEX: <h1>Global Namespace</h1>
 // HTML-INDEX: <h2 id="Enums">Enums</h2>
 // HTML-INDEX: <h3 id="{{([0-9A-F]{40})}}">enum Color</h3>
 // HTML-INDEX: <li>Red</li>
 // HTML-INDEX: <li>Green</li>
 // HTML-INDEX: <li>Blue</li>
-// HTML-INDEX: <p>Defined at line [[@LINE+4]] of file {{.*}}clang-tools-extra{{[\/]}}test{{[\/]}}clang-doc{{[\/]}}enum.cpp</p>
-/**
- * @brief For specifying RGB colors
- */
-enum Color {
-  Red, ///< Red
-  Green, ///< Green
-  Blue ///< Blue
-};
 
-
-// MD-INDEX: | enum class Shapes |
-// MD-INDEX: --
-// MD-INDEX: | Circle |
-// MD-INDEX: | Rectangle |
-// MD-INDEX: | Triangle |
-// MD-INDEX: *Defined at {{.*}}clang-tools-extra{{[\/]}}test{{[\/]}}clang-doc{{[\/]}}enum.cpp#[[@LINE+11]]*
-// MD-INDEX: **brief** Shape Types
-
-// HTML-INDEX: <h3 id="{{([0-9A-F]{40})}}">enum class Shapes</h3>
-// HTML-INDEX: <li>Circle</li>
-// HTML-INDEX: <li>Rectangle</li>
-// HTML-INDEX: <li>Triangle</li>
-// HTML-INDEX: <p>Defined at line [[@LINE+4]] of file {{.*}}clang-tools-extra{{[\/]}}test{{[\/]}}clang-doc{{[\/]}}enum.cpp</p>
 /**
  * @brief Shape Types
  */
 enum class Shapes {
+// MD-INDEX-LINE: *Defined at {{.*}}clang-tools-extra{{[\/]}}test{{[\/]}}clang-doc{{[\/]}}enum.cpp#[[@LINE-1]]*
+// HTML-INDEX-LINE: <p>Defined at line [[@LINE-2]] of file {{.*}}clang-tools-extra{{[\/]}}test{{[\/]}}clang-doc{{[\/]}}enum.cpp</p>
   /// Circle
   Circle,
   /// Rectangle
@@ -61,40 +53,65 @@ enum class Shapes {
   /// Triangle
   Triangle
 };
+// MD-INDEX: | enum class Shapes |
+// MD-INDEX: --
+// MD-INDEX: | Circle |
+// MD-INDEX: | Rectangle |
+// MD-INDEX: | Triangle |
+// MD-INDEX: **brief** Shape Types
+
+// HTML-INDEX: <h3 id="{{([0-9A-F]{40})}}">enum class Shapes</h3>
+// HTML-INDEX: <li>Circle</li>
+// HTML-INDEX: <li>Rectangle</li>
+// HTML-INDEX: <li>Triangle</li>
 
 
-// MD-ANIMAL: # class Animals
-// MD-ANIMAL: *Defined at {{.*}}clang-tools-extra{{[\/]}}test{{[\/]}}clang-doc{{[\/]}}enum.cpp#[[@LINE+18]]*
-// MD-ANIMAL: ## Enums
-// MD-ANIMAL: | enum AnimalType |
-// MD-ANIMAL: --
-// MD-ANIMAL: | Dog |
-// MD-ANIMAL: | Cat |
-// MD-ANIMAL: | Iguana |
-// MD-ANIMAL: *Defined at {{.*}}clang-tools-extra{{[\/]}}test{{[\/]}}clang-doc{{[\/]}}enum.cpp#[[@LINE+16]]*
-// MD-ANIMAL: **brief** specify what animal the class is
-
-// HTML-ANIMAL: <h1>class Animals</h1>
-// HTML-ANIMAL: <p>Defined at line [[@LINE+7]] of file {{.*}}clang-tools-extra{{[\/]}}test{{[\/]}}clang-doc{{[\/]}}enum.cpp</p>
-// HTML-ANIMAL: <h2 id="Enums">Enums</h2>
-// HTML-ANIMAL: <h3 id="{{([0-9A-F]{40})}}">enum AnimalType</h3>
-// HTML-ANIMAL: <li>Dog</li>
-// HTML-ANIMAL: <li>Cat</li>
-// HTML-ANIMAL: <li>Iguana</li>
-// HTML-ANIMAL: <p>Defined at line [[@LINE+6]] of file {{.*}}clang-tools-extra{{[\/]}}test{{[\/]}}clang-doc{{[\/]}}enum.cpp</p>
 class Animals {
+// MD-ANIMAL-LINE: *Defined at {{.*}}clang-tools-extra{{[\/]}}test{{[\/]}}clang-doc{{[\/]}}enum.cpp#[[@LINE-1]]*
+// HTML-ANIMAL-LINE: <p>Defined at line [[@LINE-2]] of file {{.*}}clang-tools-extra{{[\/]}}test{{[\/]}}clang-doc{{[\/]}}enum.cpp</p>
 public:
       /**
        * @brief specify what animal the class is
        */
       enum AnimalType {
+// MD-ANIMAL-LINE: *Defined at {{.*}}clang-tools-extra{{[\/]}}test{{[\/]}}clang-doc{{[\/]}}enum.cpp#[[@LINE-1]]*
+// HTML-ANIMAL-LINE: <p>Defined at line [[@LINE-2]] of file {{.*}}clang-tools-extra{{[\/]}}test{{[\/]}}clang-doc{{[\/]}}enum.cpp</p>
           Dog, /// Man's best friend
           Cat, /// Man's other best friend
           Iguana /// A lizard
       };
 };
 
+// HTML-ANIMAL: <h1>class Animals</h1>
+// HTML-ANIMAL: <h2 id="Enums">Enums</h2>
+// HTML-ANIMAL: <h3 id="{{([0-9A-F]{40})}}">enum AnimalType</h3>
+// HTML-ANIMAL: <li>Dog</li>
+// HTML-ANIMAL: <li>Cat</li>
+// HTML-ANIMAL: <li>Iguana</li>
 
+// MD-ANIMAL: # class Animals
+// MD-ANIMAL: ## Enums
+// MD-ANIMAL: | enum AnimalType |
+// MD-ANIMAL: --
+// MD-ANIMAL: | Dog |
+// MD-ANIMAL: | Cat |
+// MD-ANIMAL: | Iguana |
+// MD-ANIMAL: **brief** specify what animal the class is
+
+
+namespace Vehicles {
+    /**
+     * @brief specify type of car
+     */
+    enum Car {
+// MD-VEHICLES-LINE: *Defined at {{.*}}clang-tools-extra{{[\/]}}test{{[\/]}}clang-doc{{[\/]}}enum.cpp#[[@LINE-1]]*
+// HTML-VEHICLES-LINE: <p>Defined at line [[@LINE-2]] of file {{.*}}clang-tools-extra{{[\/]}}test{{[\/]}}clang-doc{{[\/]}}enum.cpp</p>
+       Sedan, /// Sedan
+       SUV, /// SUV
+       Pickup, /// Pickup
+       Hatchback /// Hatchback
+    };
+}
 
 // MD-VEHICLES: # namespace Vehicles
 // MD-VEHICLES: ## Enums
@@ -104,7 +121,6 @@ public:
 // MD-VEHICLES: | SUV |
 // MD-VEHICLES: | Pickup |
 // MD-VEHICLES: | Hatchback |
-// MD-VEHICLES: *Defined at {{.*}}clang-tools-extra{{[\/]}}test{{[\/]}}clang-doc{{[\/]}}enum.cpp#[[@LINE+15]]*
 // MD-VEHICLES: **brief** specify type of car
 
 // HTML-VEHICLES: <h1>namespace Vehicles</h1>
@@ -114,15 +130,3 @@ public:
 // HTML-VEHICLES: <li>SUV</li>
 // HTML-VEHICLES: <li>Pickup</li>
 // HTML-VEHICLES: <li>Hatchback</li>
-// HTML-VEHICLES: <p>Defined at line [[@LINE+5]] of file {{.*}}clang-tools-extra{{[\/]}}test{{[\/]}}clang-doc{{[\/]}}enum.cpp</p>
-namespace Vehicles {
-    /**
-     * @brief specify type of car
-     */
-    enum Car {
-       Sedan, /// Sedan
-       SUV, /// SUV
-       Pickup, /// Pickup
-       Hatchback /// Hatchback
-    };
-}


### PR DESCRIPTION
This patch adds a test which test the enum generation for clang-doc. 

