### PR TITLE
[clang-doc] Support markdown and simplify checks

### DIFF
--- a/clang-tools-extra/test/clang-doc/basic-project.test
+++ b/clang-tools-extra/test/clang-doc/basic-project.test
@@ -54,306 +54,249 @@
 // JSON-INDEX-NEXT: };
 // JSON-INDEX-NEXT: }
 
-// HTML-SHAPE: <!DOCTYPE html>
-// HTML-SHAPE-NEXT: <meta charset="utf-8"/>
-// HTML-SHAPE-NEXT: <title>class Shape</title>
-// HTML-SHAPE-NEXT: <link rel="stylesheet" href="../clang-doc-default-stylesheet.css"/>
-// HTML-SHAPE-NEXT: <script src="{{.*}}index_json.js"></script>
-// HTML-SHAPE-NEXT: <script src="{{.*}}index.js"></script>
-// HTML-SHAPE-NEXT: <header id="project-title"></header>
-// HTML-SHAPE-NEXT: <main>
-// HTML-SHAPE-NEXT:   <div id="sidebar-left" path="GlobalNamespace" class="col-xs-6 col-sm-3 col-md-2 sidebar sidebar-offcanvas-left"></div>
-// HTML-SHAPE-NEXT:   <div id="main-content" class="col-xs-12 col-sm-9 col-md-8 main-content">
-// HTML-SHAPE-NEXT:     <h1>class Shape</h1>
-// HTML-SHAPE-NEXT:     <p>Defined at line 8 of file {{.*}}Shape.h</p>
-// HTML-SHAPE-NEXT:     <div>
-// HTML-SHAPE-NEXT:       <div>
-// HTML-SHAPE-NEXT:         <p> Provides a common interface for different types of shapes.</p>
-// HTML-SHAPE-NEXT:       </div>
-// HTML-SHAPE-NEXT:     </div>
-// HTML-SHAPE-NEXT:     <h2 id="Functions">Functions</h2>
-// HTML-SHAPE-NEXT:     <div>
-// HTML-SHAPE-NEXT:       <h3 id="{{([0-9A-F]{40})}}">~Shape</h3>
-// HTML-SHAPE-NEXT:       <p>public void ~Shape()</p>
-// HTML-SHAPE-NEXT:       <p>Defined at line 13 of file {{.*}}Shape.h</p>
-// HTML-SHAPE-NEXT:       <div>
-// HTML-SHAPE-NEXT:         <div></div>
-// HTML-SHAPE-NEXT:       </div>
-// HTML-SHAPE-NEXT:       <h3 id="{{([0-9A-F]{40})}}">area</h3>
-// HTML-SHAPE-NEXT:       <p>public double area()</p>
-// HTML-SHAPE-NEXT:       <div>
-// HTML-SHAPE-NEXT:         <div></div>
-// HTML-SHAPE-NEXT:       </div>
-// HTML-SHAPE-NEXT:       <h3 id="{{([0-9A-F]{40})}}">perimeter</h3>
-// HTML-SHAPE-NEXT:       <p>public double perimeter()</p>
-// HTML-SHAPE-NEXT:       <div>
-// HTML-SHAPE-NEXT:         <div></div>
-// HTML-SHAPE-NEXT:       </div>
-// HTML-SHAPE-NEXT:     </div>
-// HTML-SHAPE-NEXT:   </div>
-// HTML-SHAPE-NEXT:   <div id="sidebar-right" class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">
-// HTML-SHAPE-NEXT:     <ol>
-// HTML-SHAPE-NEXT:       <li>
-// HTML-SHAPE-NEXT:         <span>
-// HTML-SHAPE-NEXT:           <a href="#Functions">Functions</a>
-// HTML-SHAPE-NEXT:         </span>
-// HTML-SHAPE-NEXT:         <ul>
-// HTML-SHAPE-NEXT:           <li>
-// HTML-SHAPE-NEXT:             <span>
-// HTML-SHAPE-NEXT:               <a href="#{{([0-9A-F]{40})}}">~Shape</a>
-// HTML-SHAPE-NEXT:             </span>
-// HTML-SHAPE-NEXT:           </li>
-// HTML-SHAPE-NEXT:           <li>
-// HTML-SHAPE-NEXT:             <span>
-// HTML-SHAPE-NEXT:               <a href="#{{([0-9A-F]{40})}}">area</a>
-// HTML-SHAPE-NEXT:             </span>
-// HTML-SHAPE-NEXT:           </li>
-// HTML-SHAPE-NEXT:           <li>
-// HTML-SHAPE-NEXT:             <span>
-// HTML-SHAPE-NEXT:               <a href="#{{([0-9A-F]{40})}}">perimeter</a>
-// HTML-SHAPE-NEXT:             </span>
-// HTML-SHAPE-NEXT:           </li>
-// HTML-SHAPE-NEXT:         </ul>
-// HTML-SHAPE-NEXT:       </li>
-// HTML-SHAPE-NEXT:     </ol>
-// HTML-SHAPE-NEXT:   </div>
-// HTML-SHAPE-NEXT: </main>
+// HTML-SHAPE: <h1>class Shape</h1>
+// HTML-SHAPE: <p>Defined at line 8 of file {{.*}}Shape.h</p>
+// HTML-SHAPE: <div>
+// HTML-SHAPE:   <div>
+// HTML-SHAPE:     <p> Provides a common interface for different types of shapes.</p>
+// HTML-SHAPE:   </div>
+// HTML-SHAPE: </div>
+// HTML-SHAPE: <h2 id="Functions">Functions</h2>
+// HTML-SHAPE: <div>
+// HTML-SHAPE:   <h3 id="{{([0-9A-F]{40})}}">~Shape</h3>
+// HTML-SHAPE:   <p>public void ~Shape()</p>
+// HTML-SHAPE:   <p>Defined at line 13 of file {{.*}}Shape.h</p>
+// HTML-SHAPE:   <div>
+// HTML-SHAPE:     <div></div>
+// HTML-SHAPE:   </div>
+// HTML-SHAPE:   <h3 id="{{([0-9A-F]{40})}}">area</h3>
+// HTML-SHAPE:   <p>public double area()</p>
+// HTML-SHAPE:   <div>
+// HTML-SHAPE:     <div></div>
+// HTML-SHAPE:   </div>
+// HTML-SHAPE:   <h3 id="{{([0-9A-F]{40})}}">perimeter</h3>
+// HTML-SHAPE:   <p>public double perimeter()</p>
+// HTML-SHAPE:   <div>
+// HTML-SHAPE:     <div></div>
+// HTML-SHAPE:   </div>
+// HTML-SHAPE: </div>
 
-// HTML-CALC: <!DOCTYPE html>
-// HTML-CALC-NEXT: <meta charset="utf-8"/>
-// HTML-CALC-NEXT: <title>class Calculator</title>
-// HTML-CALC-NEXT: <link rel="stylesheet" href="{{.*}}clang-doc-default-stylesheet.css"/>
-// HTML-CALC-NEXT: <script src="{{.*}}index_json.js"></script>
-// HTML-CALC-NEXT: <script src="{{.*}}index.js"></script>
-// HTML-CALC-NEXT: <header id="project-title"></header>
-// HTML-CALC-NEXT: <main>
-// HTML-CALC-NEXT:   <div id="sidebar-left" path="GlobalNamespace" class="col-xs-6 col-sm-3 col-md-2 sidebar sidebar-offcanvas-left"></div>
-// HTML-CALC-NEXT:   <div id="main-content" class="col-xs-12 col-sm-9 col-md-8 main-content">
-// HTML-CALC-NEXT:     <h1>class Calculator</h1>
-// HTML-CALC-NEXT:     <p>Defined at line 8 of file {{.*}}Calculator.h</p>
-// HTML-CALC-NEXT:     <div>
-// HTML-CALC-NEXT:       <div>
-// HTML-CALC-NEXT:         <p> Provides basic arithmetic operations.</p>
-// HTML-CALC-NEXT:       </div>
-// HTML-CALC-NEXT:     </div>
-// HTML-CALC-NEXT:     <h2 id="Functions">Functions</h2>
-// HTML-CALC-NEXT:     <div>
-// HTML-CALC-NEXT:       <h3 id="{{([0-9A-F]{40})}}">add</h3>
-// HTML-CALC-NEXT:       <p>public int add(int a, int b)</p>
-// HTML-CALC-NEXT:       <p>Defined at line 3 of file {{.*}}Calculator.cpp</p>
-// HTML-CALC-NEXT:       <div>
-// HTML-CALC-NEXT:         <div></div>
-// HTML-CALC-NEXT:       </div>
-// HTML-CALC-NEXT:       <h3 id="{{([0-9A-F]{40})}}">subtract</h3>
-// HTML-CALC-NEXT:       <p>public int subtract(int a, int b)</p>
-// HTML-CALC-NEXT:       <p>Defined at line 7 of file {{.*}}Calculator.cpp</p>
-// HTML-CALC-NEXT:       <div>
-// HTML-CALC-NEXT:         <div></div>
-// HTML-CALC-NEXT:       </div>
-// HTML-CALC-NEXT:       <h3 id="{{([0-9A-F]{40})}}">multiply</h3>
-// HTML-CALC-NEXT:       <p>public int multiply(int a, int b)</p>
-// HTML-CALC-NEXT:       <p>Defined at line 11 of file {{.*}}Calculator.cpp</p>
-// HTML-CALC-NEXT:       <div>
-// HTML-CALC-NEXT:         <div></div>
-// HTML-CALC-NEXT:       </div>
-// HTML-CALC-NEXT:       <h3 id="{{([0-9A-F]{40})}}">divide</h3>
-// HTML-CALC-NEXT:       <p>public double divide(int a, int b)</p>
-// HTML-CALC-NEXT:       <p>Defined at line 15 of file {{.*}}Calculator.cpp</p>
-// HTML-CALC-NEXT:       <div>
-// HTML-CALC-NEXT:         <div></div>
-// HTML-CALC-NEXT:       </div>
-// HTML-CALC-NEXT:     </div>
-// HTML-CALC-NEXT:   </div>
-// HTML-CALC-NEXT:   <div id="sidebar-right" class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">
-// HTML-CALC-NEXT:     <ol>
-// HTML-CALC-NEXT:       <li>
-// HTML-CALC-NEXT:         <span>
-// HTML-CALC-NEXT:           <a href="#Functions">Functions</a>
-// HTML-CALC-NEXT:         </span>
-// HTML-CALC-NEXT:         <ul>
-// HTML-CALC-NEXT:           <li>
-// HTML-CALC-NEXT:             <span>
-// HTML-CALC-NEXT:               <a href="#{{([0-9A-F]{40})}}">add</a>
-// HTML-CALC-NEXT:             </span>
-// HTML-CALC-NEXT:           </li>
-// HTML-CALC-NEXT:           <li>
-// HTML-CALC-NEXT:             <span>
-// HTML-CALC-NEXT:               <a href="#{{([0-9A-F]{40})}}">subtract</a>
-// HTML-CALC-NEXT:             </span>
-// HTML-CALC-NEXT:           </li>
-// HTML-CALC-NEXT:           <li>
-// HTML-CALC-NEXT:             <span>
-// HTML-CALC-NEXT:               <a href="#{{([0-9A-F]{40})}}">multiply</a>
-// HTML-CALC-NEXT:             </span>
-// HTML-CALC-NEXT:           </li>
-// HTML-CALC-NEXT:           <li>
-// HTML-CALC-NEXT:             <span>
-// HTML-CALC-NEXT:               <a href="#{{([0-9A-F]{40})}}">divide</a>
-// HTML-CALC-NEXT:             </span>
-// HTML-CALC-NEXT:           </li>
-// HTML-CALC-NEXT:         </ul>
-// HTML-CALC-NEXT:       </li>
-// HTML-CALC-NEXT:     </ol>
-// HTML-CALC-NEXT:   </div>
-// HTML-CALC-NEXT: </main>
 
-// HTML-RECTANGLE: <!DOCTYPE html>
-// HTML-RECTANGLE-NEXT: <meta charset="utf-8"/>
-// HTML-RECTANGLE-NEXT: <title>class Rectangle</title>
-// HTML-RECTANGLE-NEXT: <link rel="stylesheet" href="{{.*}}clang-doc-default-stylesheet.css"/>
-// HTML-RECTANGLE-NEXT: <script src="{{.*}}index_json.js"></script>
-// HTML-RECTANGLE-NEXT: <script src="{{.*}}index.js"></script>
-// HTML-RECTANGLE-NEXT: <header id="project-title"></header>
-// HTML-RECTANGLE-NEXT: <main>
-// HTML-RECTANGLE-NEXT:   <div id="sidebar-left" path="GlobalNamespace" class="col-xs-6 col-sm-3 col-md-2 sidebar sidebar-offcanvas-left"></div>
-// HTML-RECTANGLE-NEXT:   <div id="main-content" class="col-xs-12 col-sm-9 col-md-8 main-content">
-// HTML-RECTANGLE-NEXT:     <h1>class Rectangle</h1>
-// HTML-RECTANGLE-NEXT:     <p>Defined at line 10 of file {{.*}}Rectangle.h</p>
-// HTML-RECTANGLE-NEXT:     <div>
-// HTML-RECTANGLE-NEXT:       <div>
-// HTML-RECTANGLE-NEXT:         <p> Represents a rectangle with a given width and height.</p>
-// HTML-RECTANGLE-NEXT:       </div>
-// HTML-RECTANGLE-NEXT:     </div>
-// HTML-RECTANGLE-NEXT:     <p>
-// HTML-RECTANGLE-NEXT:       Inherits from
-// HTML-RECTANGLE-NEXT:       <a href="Shape.html">Shape</a>
-// HTML-RECTANGLE-NEXT:     </p>
-// HTML-RECTANGLE-NEXT:     <h2 id="Members">Members</h2>
-// HTML-RECTANGLE-NEXT:     <ul>
-// HTML-RECTANGLE-NEXT:       <li>private double width_</li>
-// HTML-RECTANGLE-NEXT:       <li>private double height_</li>
-// HTML-RECTANGLE-NEXT:     </ul>
-// HTML-RECTANGLE-NEXT:     <h2 id="Functions">Functions</h2>
-// HTML-RECTANGLE-NEXT:     <div>
-// HTML-RECTANGLE-NEXT:       <h3 id="{{([0-9A-F]{40})}}">Rectangle</h3>
-// HTML-RECTANGLE-NEXT:       <p>public void Rectangle(double width, double height)</p>
-// HTML-RECTANGLE-NEXT:       <p>Defined at line 3 of file {{.*}}Rectangle.cpp</p>
-// HTML-RECTANGLE-NEXT:       <div>
-// HTML-RECTANGLE-NEXT:         <div></div>
-// HTML-RECTANGLE-NEXT:       </div>
-// HTML-RECTANGLE-NEXT:       <h3 id="{{([0-9A-F]{40})}}">area</h3>
-// HTML-RECTANGLE-NEXT:       <p>public double area()</p>
-// HTML-RECTANGLE-NEXT:       <p>Defined at line 6 of file {{.*}}Rectangle.cpp</p>
-// HTML-RECTANGLE-NEXT:       <div>
-// HTML-RECTANGLE-NEXT:         <div></div>
-// HTML-RECTANGLE-NEXT:       </div>
-// HTML-RECTANGLE-NEXT:       <h3 id="{{([0-9A-F]{40})}}">perimeter</h3>
-// HTML-RECTANGLE-NEXT:       <p>public double perimeter()</p>
-// HTML-RECTANGLE-NEXT:       <p>Defined at line 10 of file {{.*}}Rectangle.cpp</p>
-// HTML-RECTANGLE-NEXT:       <div>
-// HTML-RECTANGLE-NEXT:         <div></div>
-// HTML-RECTANGLE-NEXT:       </div>
-// HTML-RECTANGLE-NEXT:     </div>
-// HTML-RECTANGLE-NEXT:   </div>
-// HTML-RECTANGLE-NEXT:   <div id="sidebar-right" class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">
-// HTML-RECTANGLE-NEXT:     <ol>
-// HTML-RECTANGLE-NEXT:       <li>
-// HTML-RECTANGLE-NEXT:         <span>
-// HTML-RECTANGLE-NEXT:           <a href="#Members">Members</a>
-// HTML-RECTANGLE-NEXT:         </span>
-// HTML-RECTANGLE-NEXT:       </li>
-// HTML-RECTANGLE-NEXT:       <li>
-// HTML-RECTANGLE-NEXT:         <span>
-// HTML-RECTANGLE-NEXT:           <a href="#Functions">Functions</a>
-// HTML-RECTANGLE-NEXT:         </span>
-// HTML-RECTANGLE-NEXT:         <ul>
-// HTML-RECTANGLE-NEXT:           <li>
-// HTML-RECTANGLE-NEXT:             <span>
-// HTML-RECTANGLE-NEXT:               <a href="#{{([0-9A-F]{40})}}">Rectangle</a>
-// HTML-RECTANGLE-NEXT:             </span>
-// HTML-RECTANGLE-NEXT:           </li>
-// HTML-RECTANGLE-NEXT:           <li>
-// HTML-RECTANGLE-NEXT:             <span>
-// HTML-RECTANGLE-NEXT:               <a href="#{{([0-9A-F]{40})}}">area</a>
-// HTML-RECTANGLE-NEXT:             </span>
-// HTML-RECTANGLE-NEXT:           </li>
-// HTML-RECTANGLE-NEXT:           <li>
-// HTML-RECTANGLE-NEXT:             <span>
-// HTML-RECTANGLE-NEXT:               <a href="#{{([0-9A-F]{40})}}">perimeter</a>
-// HTML-RECTANGLE-NEXT:             </span>
-// HTML-RECTANGLE-NEXT:           </li>
-// HTML-RECTANGLE-NEXT:         </ul>
-// HTML-RECTANGLE-NEXT:       </li>
-// HTML-RECTANGLE-NEXT:     </ol>
-// HTML-RECTANGLE-NEXT:   </div>
-// HTML-RECTANGLE-NEXT: </main>
+// HTML-CALC:  <h1>class Calculator</h1>
+// HTML-CALC:  <p>Defined at line 8 of file {{.*}}Calculator.h</p>
+// HTML-CALC:  <div>
+// HTML-CALC:    <div>
+// HTML-CALC:      <p> Provides basic arithmetic operations.</p>
+// HTML-CALC:    </div>
+// HTML-CALC:  </div>
+// HTML-CALC:  <h2 id="Functions">Functions</h2>
+// HTML-CALC:  <div>
+// HTML-CALC:    <h3 id="{{([0-9A-F]{40})}}">add</h3>
+// HTML-CALC:    <p>public int add(int a, int b)</p>
+// HTML-CALC:    <p>Defined at line 3 of file {{.*}}Calculator.cpp</p>
+// HTML-CALC:    <div>
+// HTML-CALC:      <div></div>
+// HTML-CALC:    </div>
+// HTML-CALC:    <h3 id="{{([0-9A-F]{40})}}">subtract</h3>
+// HTML-CALC:    <p>public int subtract(int a, int b)</p>
+// HTML-CALC:    <p>Defined at line 7 of file {{.*}}Calculator.cpp</p>
+// HTML-CALC:    <div>
+// HTML-CALC:      <div></div>
+// HTML-CALC:    </div>
+// HTML-CALC:    <h3 id="{{([0-9A-F]{40})}}">multiply</h3>
+// HTML-CALC:    <p>public int multiply(int a, int b)</p>
+// HTML-CALC:    <p>Defined at line 11 of file {{.*}}Calculator.cpp</p>
+// HTML-CALC:    <div>
+// HTML-CALC:      <div></div>
+// HTML-CALC:    </div>
+// HTML-CALC:    <h3 id="{{([0-9A-F]{40})}}">divide</h3>
+// HTML-CALC:    <p>public double divide(int a, int b)</p>
+// HTML-CALC:    <p>Defined at line 15 of file {{.*}}Calculator.cpp</p>
+// HTML-CALC:    <div>
+// HTML-CALC:      <div></div>
+// HTML-CALC:    </div>
+// HTML-CALC:  </div>
 
-// HTML-CIRCLE: <!DOCTYPE html>
-// HTML-CIRCLE-NEXT: <meta charset="utf-8"/>
-// HTML-CIRCLE-NEXT: <title>class Circle</title>
-// HTML-CIRCLE-NEXT: <link rel="stylesheet" href="{{.*}}clang-doc-default-stylesheet.css"/>
-// HTML-CIRCLE-NEXT: <script src="{{.*}}index_json.js"></script>
-// HTML-CIRCLE-NEXT: <script src="{{.*}}index.js"></script>
-// HTML-CIRCLE-NEXT: <header id="project-title"></header>
-// HTML-CIRCLE-NEXT: <main>
-// HTML-CIRCLE-NEXT:   <div id="sidebar-left" path="GlobalNamespace" class="col-xs-6 col-sm-3 col-md-2 sidebar sidebar-offcanvas-left"></div>
-// HTML-CIRCLE-NEXT:   <div id="main-content" class="col-xs-12 col-sm-9 col-md-8 main-content">
-// HTML-CIRCLE-NEXT:     <h1>class Circle</h1>
-// HTML-CIRCLE-NEXT:     <p>Defined at line 10 of file {{.*}}Circle.h</p>
-// HTML-CIRCLE-NEXT:     <div>
-// HTML-CIRCLE-NEXT:       <div>
-// HTML-CIRCLE-NEXT:         <p> Represents a circle with a given radius.</p>
-// HTML-CIRCLE-NEXT:       </div>
-// HTML-CIRCLE-NEXT:     </div>
-// HTML-CIRCLE-NEXT:     <p>
-// HTML-CIRCLE-NEXT:       Inherits from
-// HTML-CIRCLE-NEXT:       <a href="Shape.html">Shape</a>
-// HTML-CIRCLE-NEXT:     </p>
-// HTML-CIRCLE-NEXT:     <h2 id="Members">Members</h2>
-// HTML-CIRCLE-NEXT:     <ul>
-// HTML-CIRCLE-NEXT:       <li>private double radius_</li>
-// HTML-CIRCLE-NEXT:     </ul>
-// HTML-CIRCLE-NEXT:     <h2 id="Functions">Functions</h2>
-// HTML-CIRCLE-NEXT:     <div>
-// HTML-CIRCLE-NEXT:       <h3 id="{{([0-9A-F]{40})}}">Circle</h3>
-// HTML-CIRCLE-NEXT:       <p>public void Circle(double radius)</p>
-// HTML-CIRCLE-NEXT:       <p>Defined at line 3 of file {{.*}}Circle.cpp</p>
-// HTML-CIRCLE-NEXT:       <div>
-// HTML-CIRCLE-NEXT:         <div></div>
-// HTML-CIRCLE-NEXT:       </div>
-// HTML-CIRCLE-NEXT:       <h3 id="{{([0-9A-F]{40})}}">area</h3>
-// HTML-CIRCLE-NEXT:       <p>public double area()</p>
-// HTML-CIRCLE-NEXT:       <p>Defined at line 5 of file {{.*}}Circle.cpp</p>
-// HTML-CIRCLE-NEXT:       <div>
-// HTML-CIRCLE-NEXT:         <div></div>
-// HTML-CIRCLE-NEXT:       </div>
-// HTML-CIRCLE-NEXT:       <h3 id="{{([0-9A-F]{40})}}">perimeter</h3>
-// HTML-CIRCLE-NEXT:       <p>public double perimeter()</p>
-// HTML-CIRCLE-NEXT:       <p>Defined at line 9 of file {{.*}}Circle.cpp</p>
-// HTML-CIRCLE-NEXT:       <div>
-// HTML-CIRCLE-NEXT:         <div></div>
-// HTML-CIRCLE-NEXT:       </div>
-// HTML-CIRCLE-NEXT:     </div>
-// HTML-CIRCLE-NEXT:   </div>
-// HTML-CIRCLE-NEXT:   <div id="sidebar-right" class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">
-// HTML-CIRCLE-NEXT:     <ol>
-// HTML-CIRCLE-NEXT:       <li>
-// HTML-CIRCLE-NEXT:         <span>
-// HTML-CIRCLE-NEXT:           <a href="#Members">Members</a>
-// HTML-CIRCLE-NEXT:         </span>
-// HTML-CIRCLE-NEXT:       </li>
-// HTML-CIRCLE-NEXT:       <li>
-// HTML-CIRCLE-NEXT:         <span>
-// HTML-CIRCLE-NEXT:           <a href="#Functions">Functions</a>
-// HTML-CIRCLE-NEXT:         </span>
-// HTML-CIRCLE-NEXT:         <ul>
-// HTML-CIRCLE-NEXT:           <li>
-// HTML-CIRCLE-NEXT:             <span>
-// HTML-CIRCLE-NEXT:               <a href="#{{([0-9A-F]{40})}}">Circle</a>
-// HTML-CIRCLE-NEXT:             </span>
-// HTML-CIRCLE-NEXT:           </li>
-// HTML-CIRCLE-NEXT:           <li>
-// HTML-CIRCLE-NEXT:             <span>
-// HTML-CIRCLE-NEXT:               <a href="#{{([0-9A-F]{40})}}">area</a>
-// HTML-CIRCLE-NEXT:             </span>
-// HTML-CIRCLE-NEXT:           </li>
-// HTML-CIRCLE-NEXT:           <li>
-// HTML-CIRCLE-NEXT:             <span>
-// HTML-CIRCLE-NEXT:               <a href="#{{([0-9A-F]{40})}}">perimeter</a>
-// HTML-CIRCLE-NEXT:             </span>
-// HTML-CIRCLE-NEXT:           </li>
-// HTML-CIRCLE-NEXT:         </ul>
-// HTML-CIRCLE-NEXT:       </li>
-// HTML-CIRCLE-NEXT:     </ol>
-// HTML-CIRCLE-NEXT:   </div>
-// HTML-CIRCLE-NEXT: </main>
+// HTML-RECTANGLE: <h1>class Rectangle</h1>
+// HTML-RECTANGLE: <p>Defined at line 10 of file {{.*}}Rectangle.h</p>
+// HTML-RECTANGLE: <div>
+// HTML-RECTANGLE:   <div>
+// HTML-RECTANGLE:     <p> Represents a rectangle with a given width and height.</p>
+// HTML-RECTANGLE:   </div>
+// HTML-RECTANGLE: </div>
+// HTML-RECTANGLE: <p>
+// HTML-RECTANGLE:   Inherits from
+// HTML-RECTANGLE:   <a href="Shape.html">Shape</a>
+// HTML-RECTANGLE: </p>
+// HTML-RECTANGLE: <h2 id="Members">Members</h2>
+// HTML-RECTANGLE: <ul>
+// HTML-RECTANGLE:   <li>private double width_</li>
+// HTML-RECTANGLE:   <li>private double height_</li>
+// HTML-RECTANGLE: </ul>
+// HTML-RECTANGLE: <h2 id="Functions">Functions</h2>
+// HTML-RECTANGLE: <div>
+// HTML-RECTANGLE:   <h3 id="{{([0-9A-F]{40})}}">Rectangle</h3>
+// HTML-RECTANGLE:   <p>public void Rectangle(double width, double height)</p>
+// HTML-RECTANGLE:   <p>Defined at line 3 of file {{.*}}Rectangle.cpp</p>
+// HTML-RECTANGLE:   <div>
+// HTML-RECTANGLE:     <div></div>
+// HTML-RECTANGLE:   </div>
+// HTML-RECTANGLE:   <h3 id="{{([0-9A-F]{40})}}">area</h3>
+// HTML-RECTANGLE:   <p>public double area()</p>
+// HTML-RECTANGLE:   <p>Defined at line 6 of file {{.*}}Rectangle.cpp</p>
+// HTML-RECTANGLE:   <div>
+// HTML-RECTANGLE:     <div></div>
+// HTML-RECTANGLE:   </div>
+// HTML-RECTANGLE:   <h3 id="{{([0-9A-F]{40})}}">perimeter</h3>
+// HTML-RECTANGLE:   <p>public double perimeter()</p>
+// HTML-RECTANGLE:   <p>Defined at line 10 of file {{.*}}Rectangle.cpp</p>
+// HTML-RECTANGLE:   <div>
+// HTML-RECTANGLE:     <div></div>
+// HTML-RECTANGLE:   </div>
+// HTML-RECTANGLE: </div>
+
+// HTML-CIRCLE: <h1>class Circle</h1>
+// HTML-CIRCLE: <p>Defined at line 10 of file {{.*}}Circle.h</p>
+// HTML-CIRCLE: <div>
+// HTML-CIRCLE:   <div>
+// HTML-CIRCLE:     <p> Represents a circle with a given radius.</p>
+// HTML-CIRCLE:   </div>
+// HTML-CIRCLE: </div>
+// HTML-CIRCLE: <p>
+// HTML-CIRCLE:   Inherits from
+// HTML-CIRCLE:   <a href="Shape.html">Shape</a>
+// HTML-CIRCLE: </p>
+// HTML-CIRCLE: <h2 id="Members">Members</h2>
+// HTML-CIRCLE: <ul>
+// HTML-CIRCLE:   <li>private double radius_</li>
+// HTML-CIRCLE: </ul>
+// HTML-CIRCLE: <h2 id="Functions">Functions</h2>
+// HTML-CIRCLE: <div>
+// HTML-CIRCLE:   <h3 id="{{([0-9A-F]{40})}}">Circle</h3>
+// HTML-CIRCLE:   <p>public void Circle(double radius)</p>
+// HTML-CIRCLE:   <p>Defined at line 3 of file {{.*}}Circle.cpp</p>
+// HTML-CIRCLE:   <div>
+// HTML-CIRCLE:     <div></div>
+// HTML-CIRCLE:   </div>
+// HTML-CIRCLE:   <h3 id="{{([0-9A-F]{40})}}">area</h3>
+// HTML-CIRCLE:   <p>public double area()</p>
+// HTML-CIRCLE:   <p>Defined at line 5 of file {{.*}}Circle.cpp</p>
+// HTML-CIRCLE:   <div>
+// HTML-CIRCLE:     <div></div>
+// HTML-CIRCLE:   </div>
+// HTML-CIRCLE:   <h3 id="{{([0-9A-F]{40})}}">perimeter</h3>
+// HTML-CIRCLE:   <p>public double perimeter()</p>
+// HTML-CIRCLE:   <p>Defined at line 9 of file {{.*}}Circle.cpp</p>
+// HTML-CIRCLE:   <div>
+// HTML-CIRCLE:     <div></div>
+// HTML-CIRCLE:   </div>
+// HTML-CIRCLE: </div>
+
+// MD-CALC: # class Calculator
+// MD-CALC: *Defined at .{{[\/]}}include{{[\/]}}Calculator.h#8*
+// MD-CALC: **brief** A simple calculator class.
+// MD-CALC:  Provides basic arithmetic operations.
+// MD-CALC: ## Functions
+// MD-CALC: ### add
+// MD-CALC: *public int add(int a, int b)*
+// MD-CALC: *Defined at .{{[\/]}}src{{[\/]}}Calculator.cpp#3*
+// MD-CALC: **brief** Adds two integers.
+// MD-CALC: **a** First integer.
+// MD-CALC: **b** Second integer.
+// MD-CALC: **return** int The sum of a and b.
+// MD-CALC: ### subtract
+// MD-CALC: *public int subtract(int a, int b)*
+// MD-CALC: *Defined at .{{[\/]}}src{{[\/]}}Calculator.cpp#7*
+// MD-CALC: **brief** Subtracts the second integer from the first.
+// MD-CALC: **a** First integer.
+// MD-CALC: **b** Second integer.
+// MD-CALC: **return** int The result of a - b.
+// MD-CALC: ### multiply
+// MD-CALC: *public int multiply(int a, int b)*
+// MD-CALC: *Defined at .{{[\/]}}src{{[\/]}}Calculator.cpp#11*
+// MD-CALC: **brief** Multiplies two integers.
+// MD-CALC: **a** First integer.
+// MD-CALC: **b** Second integer.
+// MD-CALC: **return** int The product of a and b.
+// MD-CALC: ### divide
+// MD-CALC: *public double divide(int a, int b)*
+// MD-CALC: *Defined at .{{[\/]}}src{{[\/]}}Calculator.cpp#15*
+// MD-CALC: **brief** Divides the first integer by the second.
+// MD-CALC: **a** First integer.
+// MD-CALC: **b** Second integer.
+// MD-CALC: **return** double The result of a / b.
+// MD-CALC: **throw**if b is zero.
+
+// MD-CIRCLE: # class Circle
+// MD-CIRCLE: *Defined at .{{[\/]}}include{{[\/]}}Circle.h#10*
+// MD-CIRCLE: **brief** Circle class derived from Shape.
+// MD-CIRCLE:  Represents a circle with a given radius.
+// MD-CIRCLE: Inherits from Shape
+// MD-CIRCLE: ## Members
+// MD-CIRCLE: private double radius_
+// MD-CIRCLE: ## Functions
+// MD-CIRCLE: ### Circle
+// MD-CIRCLE: *public void Circle(double radius)*
+// MD-CIRCLE: *Defined at .{{[\/]}}src{{[\/]}}Circle.cpp#3*
+// MD-CIRCLE: **brief** Constructs a new Circle object.
+// MD-CIRCLE: **radius** Radius of the circle.
+// MD-CIRCLE: ### area
+// MD-CIRCLE: *public double area()*
+// MD-CIRCLE: *Defined at .{{[\/]}}src{{[\/]}}Circle.cpp#5*
+// MD-CIRCLE: **brief** Calculates the area of the circle.
+// MD-CIRCLE: **return** double The area of the circle.
+// MD-CIRCLE: ### perimeter
+// MD-CIRCLE: *public double perimeter()*
+// MD-CIRCLE: *Defined at .{{[\/]}}src{{[\/]}}Circle.cpp#9*
+// MD-CIRCLE: **brief** Calculates the perimeter of the circle.
+// MD-CIRCLE: **return** double The perimeter of the circle.
+
+// MD-RECTANGLE: # class Rectangle
+// MD-RECTANGLE: *Defined at .{{[\/]}}include{{[\/]}}Rectangle.h#10*
+// MD-RECTANGLE: **brief** Rectangle class derived from Shape.
+// MD-RECTANGLE:  Represents a rectangle with a given width and height.
+// MD-RECTANGLE: Inherits from Shape
+// MD-RECTANGLE: ## Members
+// MD-RECTANGLE: private double width_
+// MD-RECTANGLE: private double height_
+// MD-RECTANGLE: ## Functions
+// MD-RECTANGLE: ### Rectangle
+// MD-RECTANGLE: *public void Rectangle(double width, double height)*
+// MD-RECTANGLE: *Defined at .{{[\/]}}src{{[\/]}}Rectangle.cpp#3*
+// MD-RECTANGLE: **brief** Constructs a new Rectangle object.
+// MD-RECTANGLE: **width** Width of the rectangle.
+// MD-RECTANGLE: **height** Height of the rectangle.
+// MD-RECTANGLE: ### area
+// MD-RECTANGLE: *public double area()*
+// MD-RECTANGLE: *Defined at .{{[\/]}}src{{[\/]}}Rectangle.cpp#6*
+// MD-RECTANGLE: **brief** Calculates the area of the rectangle.
+// MD-RECTANGLE: **return** double The area of the rectangle.
+// MD-RECTANGLE: ### perimeter
+// MD-RECTANGLE: *public double perimeter()*
+// MD-RECTANGLE: *Defined at .{{[\/]}}src{{[\/]}}Rectangle.cpp#10*
+// MD-RECTANGLE: **brief** Calculates the perimeter of the rectangle.
+// MD-RECTANGLE: **return** double The perimeter of the rectangle.
+
+// MD-SHAPE: # class Shape
+// MD-SHAPE: *Defined at .{{[\/]}}include{{[\/]}}Shape.h#8*
+// MD-SHAPE: **brief** Abstract base class for shapes.
+// MD-SHAPE:  Provides a common interface for different types of shapes.
+// MD-SHAPE: ## Functions
+// MD-SHAPE: ### ~Shape
+// MD-SHAPE: *public void ~Shape()*
+// MD-SHAPE: *Defined at .{{[\/]}}include{{[\/]}}Shape.h#13*
+// MD-SHAPE: **brief** Virtual destructor.
+// MD-SHAPE: ### area
+// MD-SHAPE: *public double area()*
+// MD-SHAPE: **brief** Calculates the area of the shape.
+// MD-SHAPE: **return** double The area of the shape.
+// MD-SHAPE: ### perimeter
+// MD-SHAPE: *public double perimeter()*
+// MD-SHAPE: **brief** Calculates the perimeter of the shape.
+// MD-SHAPE: **return** double The perimeter of the shape.
+
+// MD-ALL-FILES: # All Files
+// MD-ALL-FILES: ## [GlobalNamespace](GlobalNamespace{{[\/]}}index.md)
+
+// MD-INDEX: #  C/C++ Reference
+// MD-INDEX: * Namespace: [GlobalNamespace](GlobalNamespace)

--- a/clang-tools-extra/test/clang-doc/basic-project.test
+++ b/clang-tools-extra/test/clang-doc/basic-project.test
@@ -56,141 +56,73 @@
 
 // HTML-SHAPE: <h1>class Shape</h1>
 // HTML-SHAPE: <p>Defined at line 8 of file {{.*}}Shape.h</p>
-// HTML-SHAPE: <div>
-// HTML-SHAPE:   <div>
-// HTML-SHAPE:     <p> Provides a common interface for different types of shapes.</p>
-// HTML-SHAPE:   </div>
-// HTML-SHAPE: </div>
+// HTML-SHAPE: <p> Provides a common interface for different types of shapes.</p>
 // HTML-SHAPE: <h2 id="Functions">Functions</h2>
-// HTML-SHAPE: <div>
-// HTML-SHAPE:   <h3 id="{{([0-9A-F]{40})}}">~Shape</h3>
-// HTML-SHAPE:   <p>public void ~Shape()</p>
-// HTML-SHAPE:   <p>Defined at line 13 of file {{.*}}Shape.h</p>
-// HTML-SHAPE:   <div>
-// HTML-SHAPE:     <div></div>
-// HTML-SHAPE:   </div>
-// HTML-SHAPE:   <h3 id="{{([0-9A-F]{40})}}">area</h3>
-// HTML-SHAPE:   <p>public double area()</p>
-// HTML-SHAPE:   <div>
-// HTML-SHAPE:     <div></div>
-// HTML-SHAPE:   </div>
-// HTML-SHAPE:   <h3 id="{{([0-9A-F]{40})}}">perimeter</h3>
-// HTML-SHAPE:   <p>public double perimeter()</p>
-// HTML-SHAPE:   <div>
-// HTML-SHAPE:     <div></div>
-// HTML-SHAPE:   </div>
-// HTML-SHAPE: </div>
-
+// HTML-SHAPE: <h3 id="{{([0-9A-F]{40})}}">~Shape</h3>
+// HTML-SHAPE: <p>public void ~Shape()</p>
+// HTML-SHAPE: <p>Defined at line 13 of file {{.*}}Shape.h</p>
+// HTML-SHAPE: <h3 id="{{([0-9A-F]{40})}}">area</h3>
+// HTML-SHAPE: <p>public double area()</p>
+// HTML-SHAPE: <h3 id="{{([0-9A-F]{40})}}">perimeter</h3>
+// HTML-SHAPE: <p>public double perimeter()</p>
 
 // HTML-CALC:  <h1>class Calculator</h1>
 // HTML-CALC:  <p>Defined at line 8 of file {{.*}}Calculator.h</p>
-// HTML-CALC:  <div>
-// HTML-CALC:    <div>
-// HTML-CALC:      <p> Provides basic arithmetic operations.</p>
-// HTML-CALC:    </div>
-// HTML-CALC:  </div>
+// HTML-CALC:  <p> Provides basic arithmetic operations.</p>
 // HTML-CALC:  <h2 id="Functions">Functions</h2>
-// HTML-CALC:  <div>
-// HTML-CALC:    <h3 id="{{([0-9A-F]{40})}}">add</h3>
-// HTML-CALC:    <p>public int add(int a, int b)</p>
-// HTML-CALC:    <p>Defined at line 3 of file {{.*}}Calculator.cpp</p>
-// HTML-CALC:    <div>
-// HTML-CALC:      <div></div>
-// HTML-CALC:    </div>
-// HTML-CALC:    <h3 id="{{([0-9A-F]{40})}}">subtract</h3>
-// HTML-CALC:    <p>public int subtract(int a, int b)</p>
-// HTML-CALC:    <p>Defined at line 7 of file {{.*}}Calculator.cpp</p>
-// HTML-CALC:    <div>
-// HTML-CALC:      <div></div>
-// HTML-CALC:    </div>
-// HTML-CALC:    <h3 id="{{([0-9A-F]{40})}}">multiply</h3>
-// HTML-CALC:    <p>public int multiply(int a, int b)</p>
-// HTML-CALC:    <p>Defined at line 11 of file {{.*}}Calculator.cpp</p>
-// HTML-CALC:    <div>
-// HTML-CALC:      <div></div>
-// HTML-CALC:    </div>
-// HTML-CALC:    <h3 id="{{([0-9A-F]{40})}}">divide</h3>
-// HTML-CALC:    <p>public double divide(int a, int b)</p>
-// HTML-CALC:    <p>Defined at line 15 of file {{.*}}Calculator.cpp</p>
-// HTML-CALC:    <div>
-// HTML-CALC:      <div></div>
-// HTML-CALC:    </div>
-// HTML-CALC:  </div>
+// HTML-CALC:  <h3 id="{{([0-9A-F]{40})}}">add</h3>
+// HTML-CALC:  <p>public int add(int a, int b)</p>
+// HTML-CALC:  <p>Defined at line 3 of file {{.*}}Calculator.cpp</p>
+// HTML-CALC:  <h3 id="{{([0-9A-F]{40})}}">subtract</h3>
+// HTML-CALC:  <p>public int subtract(int a, int b)</p>
+// HTML-CALC:  <p>Defined at line 7 of file {{.*}}Calculator.cpp</p>
+// HTML-CALC:  <h3 id="{{([0-9A-F]{40})}}">multiply</h3>
+// HTML-CALC:  <p>public int multiply(int a, int b)</p>
+// HTML-CALC:  <p>Defined at line 11 of file {{.*}}Calculator.cpp</p>
+// HTML-CALC:  <h3 id="{{([0-9A-F]{40})}}">divide</h3>
+// HTML-CALC:  <p>public double divide(int a, int b)</p>
+// HTML-CALC:  <p>Defined at line 15 of file {{.*}}Calculator.cpp</p>
 
 // HTML-RECTANGLE: <h1>class Rectangle</h1>
 // HTML-RECTANGLE: <p>Defined at line 10 of file {{.*}}Rectangle.h</p>
-// HTML-RECTANGLE: <div>
-// HTML-RECTANGLE:   <div>
-// HTML-RECTANGLE:     <p> Represents a rectangle with a given width and height.</p>
-// HTML-RECTANGLE:   </div>
-// HTML-RECTANGLE: </div>
+// HTML-RECTANGLE: <p> Represents a rectangle with a given width and height.</p
 // HTML-RECTANGLE: <p>
 // HTML-RECTANGLE:   Inherits from
 // HTML-RECTANGLE:   <a href="Shape.html">Shape</a>
 // HTML-RECTANGLE: </p>
 // HTML-RECTANGLE: <h2 id="Members">Members</h2>
-// HTML-RECTANGLE: <ul>
-// HTML-RECTANGLE:   <li>private double width_</li>
-// HTML-RECTANGLE:   <li>private double height_</li>
-// HTML-RECTANGLE: </ul>
+// HTML-RECTANGLE: <li>private double width_</li>
+// HTML-RECTANGLE: <li>private double height_</li>
 // HTML-RECTANGLE: <h2 id="Functions">Functions</h2>
-// HTML-RECTANGLE: <div>
-// HTML-RECTANGLE:   <h3 id="{{([0-9A-F]{40})}}">Rectangle</h3>
-// HTML-RECTANGLE:   <p>public void Rectangle(double width, double height)</p>
-// HTML-RECTANGLE:   <p>Defined at line 3 of file {{.*}}Rectangle.cpp</p>
-// HTML-RECTANGLE:   <div>
-// HTML-RECTANGLE:     <div></div>
-// HTML-RECTANGLE:   </div>
-// HTML-RECTANGLE:   <h3 id="{{([0-9A-F]{40})}}">area</h3>
-// HTML-RECTANGLE:   <p>public double area()</p>
-// HTML-RECTANGLE:   <p>Defined at line 6 of file {{.*}}Rectangle.cpp</p>
-// HTML-RECTANGLE:   <div>
-// HTML-RECTANGLE:     <div></div>
-// HTML-RECTANGLE:   </div>
-// HTML-RECTANGLE:   <h3 id="{{([0-9A-F]{40})}}">perimeter</h3>
-// HTML-RECTANGLE:   <p>public double perimeter()</p>
-// HTML-RECTANGLE:   <p>Defined at line 10 of file {{.*}}Rectangle.cpp</p>
-// HTML-RECTANGLE:   <div>
-// HTML-RECTANGLE:     <div></div>
-// HTML-RECTANGLE:   </div>
-// HTML-RECTANGLE: </div>
+// HTML-RECTANGLE: <h3 id="{{([0-9A-F]{40})}}">Rectangle</h3>
+// HTML-RECTANGLE: <p>public void Rectangle(double width, double height)</p>
+// HTML-RECTANGLE: <p>Defined at line 3 of file {{.*}}Rectangle.cpp</p>
+// HTML-RECTANGLE: <h3 id="{{([0-9A-F]{40})}}">area</h3>
+// HTML-RECTANGLE: <p>public double area()</p>
+// HTML-RECTANGLE: <p>Defined at line 6 of file {{.*}}Rectangle.cpp</p>
+// HTML-RECTANGLE: <h3 id="{{([0-9A-F]{40})}}">perimeter</h3>
+// HTML-RECTANGLE: <p>public double perimeter()</p>
+// HTML-RECTANGLE: <p>Defined at line 10 of file {{.*}}Rectangle.cpp</p>
 
 // HTML-CIRCLE: <h1>class Circle</h1>
 // HTML-CIRCLE: <p>Defined at line 10 of file {{.*}}Circle.h</p>
-// HTML-CIRCLE: <div>
-// HTML-CIRCLE:   <div>
-// HTML-CIRCLE:     <p> Represents a circle with a given radius.</p>
-// HTML-CIRCLE:   </div>
-// HTML-CIRCLE: </div>
+// HTML-CIRCLE: <p> Represents a circle with a given radius.</p>
 // HTML-CIRCLE: <p>
 // HTML-CIRCLE:   Inherits from
 // HTML-CIRCLE:   <a href="Shape.html">Shape</a>
 // HTML-CIRCLE: </p>
 // HTML-CIRCLE: <h2 id="Members">Members</h2>
-// HTML-CIRCLE: <ul>
-// HTML-CIRCLE:   <li>private double radius_</li>
-// HTML-CIRCLE: </ul>
+// HTML-CIRCLE: <li>private double radius_</li>
 // HTML-CIRCLE: <h2 id="Functions">Functions</h2>
-// HTML-CIRCLE: <div>
-// HTML-CIRCLE:   <h3 id="{{([0-9A-F]{40})}}">Circle</h3>
-// HTML-CIRCLE:   <p>public void Circle(double radius)</p>
-// HTML-CIRCLE:   <p>Defined at line 3 of file {{.*}}Circle.cpp</p>
-// HTML-CIRCLE:   <div>
-// HTML-CIRCLE:     <div></div>
-// HTML-CIRCLE:   </div>
-// HTML-CIRCLE:   <h3 id="{{([0-9A-F]{40})}}">area</h3>
-// HTML-CIRCLE:   <p>public double area()</p>
-// HTML-CIRCLE:   <p>Defined at line 5 of file {{.*}}Circle.cpp</p>
-// HTML-CIRCLE:   <div>
-// HTML-CIRCLE:     <div></div>
-// HTML-CIRCLE:   </div>
-// HTML-CIRCLE:   <h3 id="{{([0-9A-F]{40})}}">perimeter</h3>
-// HTML-CIRCLE:   <p>public double perimeter()</p>
-// HTML-CIRCLE:   <p>Defined at line 9 of file {{.*}}Circle.cpp</p>
-// HTML-CIRCLE:   <div>
-// HTML-CIRCLE:     <div></div>
-// HTML-CIRCLE:   </div>
-// HTML-CIRCLE: </div>
+// HTML-CIRCLE: <h3 id="{{([0-9A-F]{40})}}">Circle</h3>
+// HTML-CIRCLE: <p>public void Circle(double radius)</p>
+// HTML-CIRCLE: <p>Defined at line 3 of file {{.*}}Circle.cpp</p>
+// HTML-CIRCLE: <h3 id="{{([0-9A-F]{40})}}">area</h3>
+// HTML-CIRCLE: <p>public double area()</p>
+// HTML-CIRCLE: <p>Defined at line 5 of file {{.*}}Circle.cpp</p>
+// HTML-CIRCLE: <h3 id="{{([0-9A-F]{40})}}">perimeter</h3>
+// HTML-CIRCLE: <p>public double perimeter()</p>
+// HTML-CIRCLE: <p>Defined at line 9 of file {{.*}}Circle.cpp</p>
 
 // MD-CALC: # class Calculator
 // MD-CALC: *Defined at .{{[\/]}}include{{[\/]}}Calculator.h#8*


### PR DESCRIPTION
This patch modifies the basic-project in clang-doc. Currently we're matching the entire html output. This patch modifies it so that we only match the parts relevant to the documentation logic instead just matching the boilerplate code. This patch also adds the markdown output to the basic-project test