### PR TITLE
[llvm] Fix the MCSubtargetInfo used for module-level assembly.

### DIFF
--- a/clang/test/CodeGen/asm-module-fp.ll
+++ b/clang/test/CodeGen/asm-module-fp.ll
@@ -1,0 +1,14 @@
+; REQUIRES: arm-registered-target
+
+; Check that module-level asm with FP instructions works when the target
+; features are not implied by the architecture.
+
+; RUN: %clang_cc1 -triple armv7r-unknown-none-eabi -target-feature +vfp4 -emit-llvm-bc %s -o %t.o
+
+target datalayout = "e-m:e-p:32:32-Fi8-i64:64-v128:64:128-a:0:32-n32-S64"
+target triple = "armv7r-unknown-none-eabi"
+
+module asm ".globl fp_add"
+module asm "fp_add:"
+module asm "vadd.f32 s0, s0, s1"
+module asm "bx lr"

--- a/llvm/lib/Object/ModuleSymbolTable.cpp
+++ b/llvm/lib/Object/ModuleSymbolTable.cpp
@@ -21,6 +21,7 @@
 #include "llvm/IR/GlobalValue.h"
 #include "llvm/IR/GlobalVariable.h"
 #include "llvm/IR/InlineAsm.h"
+#include "llvm/IR/LLVMContext.h"
 #include "llvm/IR/Module.h"
 #include "llvm/MC/MCAsmInfo.h"
 #include "llvm/MC/MCContext.h"
@@ -90,7 +91,9 @@ initializeRecordStreamer(const Module &M,
   if (!MAI)
     return;
 
-  std::unique_ptr<MCSubtargetInfo> STI(T->createMCSubtargetInfo(TT, "", ""));
+  LLVMContext &Context = M.getContext();
+  std::unique_ptr<MCSubtargetInfo> STI(T->createMCSubtargetInfo(
+      TT, Context.getDefaultTargetCPU(), Context.getDefaultTargetFeatures()));
   if (!STI)
     return;
 


### PR DESCRIPTION
Provide both the default target CPU and default target features from the
module's context, rather than empty strings.

Fixes #61991.
