### PR TITLE
[LLD] [MinGW] Reinstate the former spelling in the version message

### DIFF
--- a/lld/MinGW/Driver.cpp
+++ b/lld/MinGW/Driver.cpp
@@ -199,7 +199,7 @@ bool link(ArrayRef<const char *> argsArr, llvm::raw_ostream &stdoutOS,
   // a GNU compatible linker. As long as an output for the -v option
   // contains "GNU" or "with BFD", they recognize us as GNU-compatible.
   if (args.hasArg(OPT_v) || args.hasArg(OPT_version))
-    message(getLLDVersion() + ", compatible with GNU linkers");
+    message(getLLDVersion() + " (compatible with GNU linkers)");
 
   // The behavior of -v or --version is a bit strange, but this is
   // needed for compatibility with GNU linkers.

--- a/lld/test/MinGW/driver.test
+++ b/lld/test/MinGW/driver.test
@@ -268,6 +268,8 @@ APPCONTAINER: -appcontainer
 RUN: ld.lld -m i386pep --version 2>&1 | FileCheck -check-prefix=VERSION %s
 RUN: ld.lld -m i386pep -v 2>&1 | FileCheck -check-prefix=VERSION %s
 RUN: not ld.lld -m i386pep -v xyz 2>&1 | FileCheck -check-prefix=VERSION %s
+# This literal string is required for compatibility with older Meson versions,
+# see https://github.com/mesonbuild/meson/pull/13383.
 VERSION: LLD {{.*}} (compatible with GNU linkers)
 
 RUN: ld.lld -m i386pep --help 2>&1 | FileCheck -check-prefix=HELP %s

--- a/lld/test/MinGW/driver.test
+++ b/lld/test/MinGW/driver.test
@@ -268,7 +268,7 @@ APPCONTAINER: -appcontainer
 RUN: ld.lld -m i386pep --version 2>&1 | FileCheck -check-prefix=VERSION %s
 RUN: ld.lld -m i386pep -v 2>&1 | FileCheck -check-prefix=VERSION %s
 RUN: not ld.lld -m i386pep -v xyz 2>&1 | FileCheck -check-prefix=VERSION %s
-VERSION: LLD {{.*}}, compatible with GNU linkers
+VERSION: LLD {{.*}} (compatible with GNU linkers)
 
 RUN: ld.lld -m i386pep --help 2>&1 | FileCheck -check-prefix=HELP %s
 HELP: USAGE:


### PR DESCRIPTION
0f9fbbb63cfcd2069441aa2ebef622c9716f8dbb changed the version printouts. This broke linker detection in Meson, when disambiguating between the ld.lld and lld-link interfaces, in
https://github.com/mesonbuild/meson/blob/1.4.1/mesonbuild/linkers/detect.py#L67, which checks for the string "(compatible with GNU linkers)" including the parentheses.

Reinstate the parentheses in the printout here, for compatibility with Meson. The printout looks a little odd in this form, "LLD 19.0.0 (https://github.com/llvm/llvm-project 173514d58ec4e6166670f1e37a038df3865c8b96) (compatible with GNU linkers)", but works with Meson.

The Meson check should ideally be loosened. But even then, we should only change LLD to the new form once older versions of Meson aren't used for these targets any longer, i.e. earliest within a few years.