### PR TITLE
[WORKAROUND][BOLT][AArch64] Static binary patching for ELF.

### DIFF
--- a/bolt/test/AArch64/patch-elfstatic-libc.test
+++ b/bolt/test/AArch64/patch-elfstatic-libc.test
@@ -11,5 +11,6 @@ REQUIRES: system-linux
 
 RUN: %clang %p/../Inputs/main.c -o %t -Wl,-q -static
 RUN: llvm-bolt %t -o %t.bolt > /dev/null 2>&1
-RUN: not --crash %t.bolt 2>&1 | FileCheck %s
-CHECK: Unexpected reloc type in static binary.
+RUN: not %t.bolt 2>&1 | FileCheck %s --allow-empty
+
+CHECK-NOT: Unexpected reloc type in static binary.

--- a/bolt/test/AArch64/patch-elfstatic-libc.test
+++ b/bolt/test/AArch64/patch-elfstatic-libc.test
@@ -1,0 +1,15 @@
+// Tests that statically linked AArch64 binaries do not crash at binary loading
+// time.
+//
+// Functions like `_init` do not appear in the `.text` section of the original
+// binary. For those cases, the BOLT'ed binary creates an alias (ie, `.init`),
+// which  matches the address of the relevant function in the original binary.
+// If such function appears in the GOT and is patched, it leads to a runtime
+// crash.
+
+REQUIRES: system-linux
+
+RUN: %clang %p/../Inputs/main.c -o %t -Wl,-q -static
+RUN: llvm-bolt %t -o %t.bolt > /dev/null 2>&1
+RUN: not --crash %t.bolt 2>&1 | FileCheck %s
+CHECK: Unexpected reloc type in static binary.

--- a/bolt/test/Inputs/main.c
+++ b/bolt/test/Inputs/main.c
@@ -1,0 +1,3 @@
+// dummy function just for emitting relocations to the linker.
+int foo() { return 0; }
+int main(int argc, char **argv) { return foo() + 1; }


### PR DESCRIPTION
 When patching statically linked binaries, avoid patching GOT entries
that did not belong to the original text section and had an alias.
    

One such special case is the '_init' function that belongs to the '.init'
section. It has '.init' as an alias, which points to the same address of
'_init' in the original binary.
    
This was observed with GNU linker. BOLT normally rejects these cases.

See issue:
- https://github.com/llvm/llvm-project/issues/100096