### PR TITLE
[llvm-cov] Remove View member from MCDCView and BranchView

### DIFF
--- a/llvm/tools/llvm-cov/CodeCoverage.cpp
+++ b/llvm/tools/llvm-cov/CodeCoverage.cpp
@@ -100,15 +100,12 @@ private:
                                const CoverageMapping &Coverage);
 
   /// Create source views for the branches of the view.
-  void attachBranchSubViews(SourceCoverageView &View, StringRef SourceName,
-                            ArrayRef<CountedRegion> Branches,
-                            const MemoryBuffer &File,
-                            CoverageData &CoverageInfo);
+  void attachBranchSubViews(SourceCoverageView &View,
+                            ArrayRef<CountedRegion> Branches);
 
   /// Create source views for the MCDC records.
-  void attachMCDCSubViews(SourceCoverageView &View, StringRef SourceName,
-                          ArrayRef<MCDCRecord> MCDCRecords,
-                          const MemoryBuffer &File, CoverageData &CoverageInfo);
+  void attachMCDCSubViews(SourceCoverageView &View,
+                          ArrayRef<MCDCRecord> MCDCRecords);
 
   /// Create the source view of a particular function.
   std::unique_ptr<SourceCoverageView>
@@ -324,17 +321,13 @@ void CodeCoverageTool::attachExpansionSubViews(
         SourceCoverageView::create(Expansion.Function.Name, SourceBuffer.get(),
                                    ViewOpts, std::move(ExpansionCoverage));
     attachExpansionSubViews(*SubView, SubViewExpansions, Coverage);
-    attachBranchSubViews(*SubView, Expansion.Function.Name, SubViewBranches,
-                         SourceBuffer.get(), ExpansionCoverage);
+    attachBranchSubViews(*SubView, SubViewBranches);
     View.addExpansion(Expansion.Region, std::move(SubView));
   }
 }
 
 void CodeCoverageTool::attachBranchSubViews(SourceCoverageView &View,
-                                            StringRef SourceName,
-                                            ArrayRef<CountedRegion> Branches,
-                                            const MemoryBuffer &File,
-                                            CoverageData &CoverageInfo) {
+                                            ArrayRef<CountedRegion> Branches) {
   if (!ViewOpts.ShowBranchCounts && !ViewOpts.ShowBranchPercents)
     return;
 
@@ -348,17 +341,12 @@ void CodeCoverageTool::attachBranchSubViews(SourceCoverageView &View,
     while (NextBranch != EndBranch && CurrentLine == NextBranch->LineStart)
       ViewBranches.push_back(*NextBranch++);
 
-    View.addBranch(CurrentLine, std::move(ViewBranches),
-                   SourceCoverageView::create(SourceName, File, ViewOpts,
-                                              std::move(CoverageInfo)));
+    View.addBranch(CurrentLine, std::move(ViewBranches));
   }
 }
 
 void CodeCoverageTool::attachMCDCSubViews(SourceCoverageView &View,
-                                          StringRef SourceName,
-                                          ArrayRef<MCDCRecord> MCDCRecords,
-                                          const MemoryBuffer &File,
-                                          CoverageData &CoverageInfo) {
+                                          ArrayRef<MCDCRecord> MCDCRecords) {
   if (!ViewOpts.ShowMCDC)
     return;
 
@@ -374,9 +362,7 @@ void CodeCoverageTool::attachMCDCSubViews(SourceCoverageView &View,
            CurrentLine == NextRecord->getDecisionRegion().LineEnd)
       ViewMCDCRecords.push_back(*NextRecord++);
 
-    View.addMCDCRecord(CurrentLine, std::move(ViewMCDCRecords),
-                       SourceCoverageView::create(SourceName, File, ViewOpts,
-                                                  std::move(CoverageInfo)));
+    View.addMCDCRecord(CurrentLine, std::move(ViewMCDCRecords));
   }
 }
 
@@ -397,10 +383,8 @@ CodeCoverageTool::createFunctionView(const FunctionRecord &Function,
                                          SourceBuffer.get(), ViewOpts,
                                          std::move(FunctionCoverage));
   attachExpansionSubViews(*View, Expansions, Coverage);
-  attachBranchSubViews(*View, DC.demangle(Function.Name), Branches,
-                       SourceBuffer.get(), FunctionCoverage);
-  attachMCDCSubViews(*View, DC.demangle(Function.Name), MCDCRecords,
-                     SourceBuffer.get(), FunctionCoverage);
+  attachBranchSubViews(*View, Branches);
+  attachMCDCSubViews(*View, MCDCRecords);
 
   return View;
 }
@@ -421,10 +405,8 @@ CodeCoverageTool::createSourceFileView(StringRef SourceFile,
   auto View = SourceCoverageView::create(SourceFile, SourceBuffer.get(),
                                          ViewOpts, std::move(FileCoverage));
   attachExpansionSubViews(*View, Expansions, Coverage);
-  attachBranchSubViews(*View, SourceFile, Branches, SourceBuffer.get(),
-                       FileCoverage);
-  attachMCDCSubViews(*View, SourceFile, MCDCRecords, SourceBuffer.get(),
-                     FileCoverage);
+  attachBranchSubViews(*View, Branches);
+  attachMCDCSubViews(*View, MCDCRecords);
   if (!ViewOpts.ShowFunctionInstantiations)
     return View;
 
@@ -446,10 +428,8 @@ CodeCoverageTool::createSourceFileView(StringRef SourceFile,
         SubView = SourceCoverageView::create(
             Funcname, SourceBuffer.get(), ViewOpts, std::move(SubViewCoverage));
         attachExpansionSubViews(*SubView, SubViewExpansions, Coverage);
-        attachBranchSubViews(*SubView, SourceFile, SubViewBranches,
-                             SourceBuffer.get(), SubViewCoverage);
-        attachMCDCSubViews(*SubView, SourceFile, SubViewMCDCRecords,
-                           SourceBuffer.get(), SubViewCoverage);
+        attachBranchSubViews(*SubView, SubViewBranches);
+        attachMCDCSubViews(*SubView, SubViewMCDCRecords);
       }
 
       unsigned FileID = Function->CountedRegions.front().FileID;

--- a/llvm/tools/llvm-cov/SourceCoverageView.cpp
+++ b/llvm/tools/llvm-cov/SourceCoverageView.cpp
@@ -175,15 +175,13 @@ void SourceCoverageView::addExpansion(
 }
 
 void SourceCoverageView::addBranch(unsigned Line,
-                                   SmallVector<CountedRegion, 0> Regions,
-                                   std::unique_ptr<SourceCoverageView> View) {
-  BranchSubViews.emplace_back(Line, std::move(Regions), std::move(View));
+                                   SmallVector<CountedRegion, 0> Regions) {
+  BranchSubViews.emplace_back(Line, std::move(Regions));
 }
 
-void SourceCoverageView::addMCDCRecord(
-    unsigned Line, SmallVector<MCDCRecord, 0> Records,
-    std::unique_ptr<SourceCoverageView> View) {
-  MCDCSubViews.emplace_back(Line, std::move(Records), std::move(View));
+void SourceCoverageView::addMCDCRecord(unsigned Line,
+                                       SmallVector<MCDCRecord, 0> Records) {
+  MCDCSubViews.emplace_back(Line, std::move(Records));
 }
 
 void SourceCoverageView::addInstantiation(

--- a/llvm/tools/llvm-cov/SourceCoverageView.h
+++ b/llvm/tools/llvm-cov/SourceCoverageView.h
@@ -70,12 +70,10 @@ struct InstantiationView {
 /// A view that represents one or more branch regions on a given source line.
 struct BranchView {
   SmallVector<CountedRegion, 0> Regions;
-  std::unique_ptr<SourceCoverageView> View;
   unsigned Line;
 
-  BranchView(unsigned Line, SmallVector<CountedRegion, 0> Regions,
-             std::unique_ptr<SourceCoverageView> View)
-      : Regions(std::move(Regions)), View(std::move(View)), Line(Line) {}
+  BranchView(unsigned Line, SmallVector<CountedRegion, 0> Regions)
+      : Regions(std::move(Regions)), Line(Line) {}
 
   unsigned getLine() const { return Line; }
 
@@ -87,12 +85,10 @@ struct BranchView {
 /// A view that represents one or more MCDC regions on a given source line.
 struct MCDCView {
   SmallVector<MCDCRecord, 0> Records;
-  std::unique_ptr<SourceCoverageView> View;
   unsigned Line;
 
-  MCDCView(unsigned Line, SmallVector<MCDCRecord, 0> Records,
-           std::unique_ptr<SourceCoverageView> View)
-      : Records(std::move(Records)), View(std::move(View)), Line(Line) {}
+  MCDCView(unsigned Line, SmallVector<MCDCRecord, 0> Records)
+      : Records(std::move(Records)), Line(Line) {}
 
   unsigned getLine() const { return Line; }
 
@@ -303,12 +299,10 @@ public:
                         std::unique_ptr<SourceCoverageView> View);
 
   /// Add a branch subview to this view.
-  void addBranch(unsigned Line, SmallVector<CountedRegion, 0> Regions,
-                 std::unique_ptr<SourceCoverageView> View);
+  void addBranch(unsigned Line, SmallVector<CountedRegion, 0> Regions);
 
   /// Add an MCDC subview to this view.
-  void addMCDCRecord(unsigned Line, SmallVector<MCDCRecord, 0> Records,
-                     std::unique_ptr<SourceCoverageView> View);
+  void addMCDCRecord(unsigned Line, SmallVector<MCDCRecord, 0> Records);
 
   /// Print the code coverage information for a specific portion of a
   /// source file to the output stream.


### PR DESCRIPTION
These were never actually used, and the way they were constructed doesn't really make sense.

Fixes https://github.com/llvm/llvm-project/issues/93798.