### PR TITLE
[libc++] Remove annotations for GCC 13 and update the documentation

### DIFF
--- a/libcxx/docs/index.rst
+++ b/libcxx/docs/index.rst
@@ -71,7 +71,7 @@ iOS, watchOS, and tvOS, Google Search, the Android operating system, and FreeBSD
 user base of over 1 billion daily active users.
 
 Since its inception, libc++ has focused on delivering high performance, standards-conformance, and portability. It has
-been extensively tested and optimized, making it robust and production ready. libc++ fully implements C++11 and C++14, 
+been extensively tested and optimized, making it robust and production ready. libc++ fully implements C++11 and C++14,
 with C++17, C++20, C++23, and C++26 features being actively developed and making steady progress.
 
 libc++ is continuously integrated and tested on a wide range of platforms and configurations, ensuring its reliability
@@ -137,7 +137,7 @@ Compiler     Versions        Restrictions               Support policy
 Clang        17, 18, 19-git                             latest two stable releases per `LLVM's release page <https://releases.llvm.org>`_ and the development version
 AppleClang   15                                         latest stable release per `Xcode's release page <https://developer.apple.com/documentation/xcode-release-notes>`_
 Open XL      17.1 (AIX)                                 latest stable release per `Open XL's documentation page <https://www.ibm.com/docs/en/openxl-c-and-cpp-aix>`_
-GCC          13              In C++11 or later only     latest stable release per `GCC's release page <https://gcc.gnu.org/releases.html>`_
+GCC          14              In C++11 or later only     latest stable release per `GCC's release page <https://gcc.gnu.org/releases.html>`_
 ============ =============== ========================== =====================
 
 Libc++ also supports common platforms and architectures:

--- a/libcxx/include/__configuration/compiler.h
+++ b/libcxx/include/__configuration/compiler.h
@@ -41,8 +41,8 @@
 #      warning "Libc++ only supports AppleClang 15 and later"
 #    endif
 #  elif defined(_LIBCPP_GCC_VER)
-#    if _LIBCPP_GCC_VER < 1300
-#      warning "Libc++ only supports GCC 13 and later"
+#    if _LIBCPP_GCC_VER < 1400
+#      warning "Libc++ only supports GCC 14 and later"
 #    endif
 #  endif
 

--- a/libcxx/test/libcxx/gdb/gdb_pretty_printer_test.sh.cpp
+++ b/libcxx/test/libcxx/gdb/gdb_pretty_printer_test.sh.cpp
@@ -14,9 +14,6 @@
 // TODO: Investigate these failures which break the CI.
 // UNSUPPORTED: clang-17, clang-18, clang-19
 
-// TODO: Investigate this failure on GCC 13 (in Ubuntu Jammy)
-// UNSUPPORTED: gcc-13
-
 // The Android libc++ tests are run on a non-Android host, connected to an
 // Android device over adb. gdb needs special support to make this work (e.g.
 // gdbclient.py, ndk-gdb.py, gdbserver), and the Android organization doesn't

--- a/libcxx/test/std/algorithms/robust_against_adl.compile.pass.cpp
+++ b/libcxx/test/std/algorithms/robust_against_adl.compile.pass.cpp
@@ -8,11 +8,6 @@
 
 // <algorithm>
 
-// https://buildkite.com/llvm-project/libcxx-ci/builds/15823#0184fc0b-d56b-4774-9e1d-35fe24e09e37
-// It seems like the CI gcc version is buggy. I can't reproduce the failure on my system or on
-// godbolt (https://godbolt.org/z/rsPv8e8fn).
-// UNSUPPORTED: gcc-13
-
 #include <algorithm>
 #include <cstddef>
 #include <functional>

--- a/libcxx/test/std/containers/views/mdspan/mdspan/index_operator.pass.cpp
+++ b/libcxx/test/std/containers/views/mdspan/mdspan/index_operator.pass.cpp
@@ -122,8 +122,8 @@ constexpr void test_layout() {
   test_iteration(construct_mapping(Layout(), std::extents<unsigned, 7, 8>()));
   test_iteration(construct_mapping(Layout(), std::extents<signed char, D, D, D, D>(1, 1, 1, 1)));
 
-// TODO enable for GCC 13, when the CI pipeline is switched, doesn't work with GCC 12
-#if defined(__clang_major__) && __clang_major__ >= 17
+// TODO(LLVM 20): Enable this once AppleClang is upgraded
+#ifndef TEST_COMPILER_APPLE_CLANG
   int data[1];
   // Check operator constraint for number of arguments
   static_assert(check_operator_constraints(std::mdspan(data, construct_mapping(Layout(), std::extents<int, D>(1))), 0));
@@ -216,7 +216,7 @@ constexpr void test_layout() {
       assert(!check_operator_constraints(std::mdspan(data, construct_mapping(Layout(), std::extents<int, D>(1))), s));
     }
   }
-#endif
+#endif // TEST_COMPILER_APPLE_CLANG
 }
 
 template <class Layout>

--- a/libcxx/test/std/time/time.zone/time.zone.leap/nonmembers/comparison.pass.cpp
+++ b/libcxx/test/std/time/time.zone/time.zone.leap/nonmembers/comparison.pass.cpp
@@ -10,7 +10,7 @@
 // UNSUPPORTED: no-filesystem, no-localization, no-tzdb
 
 // TODO TZDB investigate why this fails with GCC
-// UNSUPPORTED: gcc-13, gcc-14
+// UNSUPPORTED: gcc-14
 
 // XFAIL: libcpp-has-no-experimental-tzdb
 // XFAIL: availability-tzdb-missing

--- a/libcxx/test/std/utilities/expected/expected.expected/monadic/transform.pass.cpp
+++ b/libcxx/test/std/utilities/expected/expected.expected/monadic/transform.pass.cpp
@@ -10,7 +10,7 @@
 
 // GCC has a issue for `Guaranteed copy elision for potentially-overlapping non-static data members`,
 // please refer to: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=108333
-// XFAIL: gcc-13, gcc-14
+// XFAIL: gcc-14
 
 // <expected>
 

--- a/libcxx/test/std/utilities/expected/expected.expected/monadic/transform_error.pass.cpp
+++ b/libcxx/test/std/utilities/expected/expected.expected/monadic/transform_error.pass.cpp
@@ -10,7 +10,7 @@
 
 // GCC has a issue for `Guaranteed copy elision for potentially-overlapping non-static data members`,
 // please refer to: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=108333.
-// XFAIL: gcc-13, gcc-14
+// XFAIL: gcc-14
 
 // <expected>
 

--- a/libcxx/test/std/utilities/expected/expected.void/monadic/transform_error.pass.cpp
+++ b/libcxx/test/std/utilities/expected/expected.void/monadic/transform_error.pass.cpp
@@ -10,7 +10,7 @@
 
 // GCC has a issue for `Guaranteed copy elision for potentially-overlapping non-static data members`,
 // please refer to: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=108333
-// XFAIL: gcc-13, gcc-14
+// XFAIL: gcc-14
 
 // <expected>
 

--- a/libcxx/test/std/utilities/format/format.formatter/format.formatter.spec/formatter.char_array.pass.cpp
+++ b/libcxx/test/std/utilities/format/format.formatter/format.formatter.spec/formatter.char_array.pass.cpp
@@ -7,7 +7,7 @@
 
 // UNSUPPORTED: c++03, c++11, c++14, c++17
 // TODO FMT __builtin_memcpy isn't constexpr in GCC
-// UNSUPPORTED: gcc-13, gcc-14
+// UNSUPPORTED: gcc-14
 
 // <format>
 

--- a/libcxxabi/test/catch_member_function_pointer_02.pass.cpp
+++ b/libcxxabi/test/catch_member_function_pointer_02.pass.cpp
@@ -12,7 +12,7 @@
 
 // GCC supports noexcept function types but this test still fails.
 // This is likely a bug in their implementation. Investigation needed.
-// XFAIL: gcc-13, gcc-14
+// XFAIL: gcc-14
 
 #include <cassert>
 


### PR DESCRIPTION
GCC 14 has been released a while ago. We've updated the CI to use GCC 14 now. This removes any old annotations in the tests and updates the documentation to reflect the updated version requirements.
