### PR TITLE
[libc] Fix compilation warnings on 32-bit archs

### DIFF
--- a/libc/src/sched/linux/sched_rr_get_interval.cpp
+++ b/libc/src/sched/linux/sched_rr_get_interval.cpp
@@ -36,7 +36,7 @@ LLVM_LIBC_FUNCTION(int, sched_rr_get_interval,
                                             tid, &ts32);
     if (ret == 0) {
       tp->tv_sec = ts32.tv_sec;
-      tp->tv_nsec = ts32.tv_nsec;
+      tp->tv_nsec = static_cast<long int>(ts32.tv_nsec);
     }
   } else
     // When tp is a nullptr, we still do the syscall to set ret and errno

--- a/libc/test/src/__support/time/linux/timeout_test.cpp
+++ b/libc/test/src/__support/time/linux/timeout_test.cpp
@@ -45,7 +45,7 @@ TEST(LlvmLibcSupportLinuxTimeoutTest, NoChangeIfClockIsMonotonic) {
   ensure_monotonicity(*result);
   ASSERT_FALSE(result->is_realtime());
   ASSERT_EQ(result->get_timespec().tv_sec, static_cast<time_t>(10000));
-  ASSERT_EQ(result->get_timespec().tv_nsec, static_cast<time_t>(0));
+  ASSERT_EQ(result->get_timespec().tv_nsec, static_cast<long int>(0));
 }
 TEST(LlvmLibcSupportLinuxTimeoutTest, ValidAfterConversion) {
   timespec ts;


### PR DESCRIPTION
timespec's tv_nsec is a long int, which has different sizes in 32-bit and 64-bit platforms, so this patch adds one and fixes another static_cast throw warnings in 32-bit archs