### PR TITLE
[libc] fix float_comparison_test when an emulator is used to run the test

### DIFF
--- a/libc/test/src/__support/CMakeLists.txt
+++ b/libc/test/src/__support/CMakeLists.txt
@@ -238,7 +238,7 @@ if(NOT LIBC_TARGET_OS_IS_GPU)
 
   add_custom_command(TARGET libc_str_to_float_comparison_test
                      POST_BUILD
-                     COMMAND $<TARGET_FILE:libc_str_to_float_comparison_test> ${float_test_file}
+                     COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:libc_str_to_float_comparison_test> ${float_test_file}
                      DEPENDS ${float_test_file}
                      COMMENT "Test the strtof and strtod implementations against precomputed results."
                      VERBATIM)


### PR DESCRIPTION
…test

This patch adds a missing ${CMAKE_CROSSCOMPILING_EMULATOR} to the call to libc_str_to_float_comparison_test so the test can run in an emulator, if required.

This is currently required for the rv32 buildbot, which runs in a qemu emulator.