### PR TITLE
[libc++] Add a test case for std::bit_cast with std::complex

### DIFF
--- a/libcxx/test/std/numerics/complex.number/complex/bit_cast.pass.cpp
+++ b/libcxx/test/std/numerics/complex.number/complex/bit_cast.pass.cpp
@@ -1,0 +1,37 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: c++03, c++11, c++14, c++17
+
+// Make sure that std::bit_cast works with std::complex. Test case extracted from
+// https://github.com/llvm/llvm-project/issues/94620.
+
+#include <bit>
+#include <complex>
+
+template <class T>
+constexpr void test() {
+  using Complex                       = std::complex<T>;
+  unsigned char data[sizeof(Complex)] = {0};
+
+  Complex c = std::bit_cast<Complex>(data);
+  (void)c;
+}
+
+constexpr bool test_all() {
+  test<float>();
+  test<double>();
+  test<long double>();
+  return true;
+}
+
+int main(int, char**) {
+  test_all();
+  static_assert(test_all());
+  return 0;
+}

--- a/libcxx/test/std/numerics/complex.number/complex/bit_cast.pass.cpp
+++ b/libcxx/test/std/numerics/complex.number/complex/bit_cast.pass.cpp
@@ -19,8 +19,7 @@ constexpr void test() {
   using Complex                       = std::complex<T>;
   unsigned char data[sizeof(Complex)] = {0};
 
-  Complex c = std::bit_cast<Complex>(data);
-  (void)c;
+  [[maybe_unused]] Complex c = std::bit_cast<Complex>(data);
 }
 
 constexpr bool test_all() {


### PR DESCRIPTION
This is extracted from #94620. While libc++ doesn't have the problem described in that issue, a test case is a good idea to ensure that we don't regress this behavior in the future. This could happen for example if we decide to use `_Complex` in the implementation of `std::complex` while Clang doesn't handle bit_cast with _Complex yet.