### PR TITLE
Allow unnecessary-value-param to match templated functions including lambdas with auto.

### DIFF
--- a/clang-tools-extra/clang-tidy/performance/UnnecessaryValueParamCheck.cpp
+++ b/clang-tools-extra/clang-tidy/performance/UnnecessaryValueParamCheck.cpp
@@ -75,7 +75,7 @@ void UnnecessaryValueParamCheck::registerMatchers(MatchFinder *Finder) {
           functionDecl(hasBody(stmt()), isDefinition(), unless(isImplicit()),
                        unless(cxxMethodDecl(anyOf(isOverride(), isFinal()))),
                        has(typeLoc(forEach(ExpensiveValueParamDecl))),
-                       unless(isInstantiated()), decl().bind("functionDecl"))),
+                       decl().bind("functionDecl"))),
       this);
 }
 
@@ -133,12 +133,9 @@ void UnnecessaryValueParamCheck::check(const MatchFinder::MatchResult &Result) {
   // 2. the function is virtual as it might break overrides
   // 3. the function is referenced outside of a call expression within the
   //    compilation unit as the signature change could introduce build errors.
-  // 4. the function is a primary template or an explicit template
-  // specialization.
   const auto *Method = llvm::dyn_cast<CXXMethodDecl>(Function);
   if (Param->getBeginLoc().isMacroID() || (Method && Method->isVirtual()) ||
-      isReferencedOutsideOfCallExpr(*Function, *Result.Context) ||
-      (Function->getTemplatedKind() != FunctionDecl::TK_NonTemplate))
+      isReferencedOutsideOfCallExpr(*Function, *Result.Context))
     return;
   for (const auto *FunctionDecl = Function; FunctionDecl != nullptr;
        FunctionDecl = FunctionDecl->getPreviousDecl()) {

--- a/clang-tools-extra/clang-tidy/performance/UnnecessaryValueParamCheck.cpp
+++ b/clang-tools-extra/clang-tidy/performance/UnnecessaryValueParamCheck.cpp
@@ -133,9 +133,11 @@ void UnnecessaryValueParamCheck::check(const MatchFinder::MatchResult &Result) {
   // 2. the function is virtual as it might break overrides
   // 3. the function is referenced outside of a call expression within the
   //    compilation unit as the signature change could introduce build errors.
+  // 4. the function is an explicit template/ specialization.
   const auto *Method = llvm::dyn_cast<CXXMethodDecl>(Function);
   if (Param->getBeginLoc().isMacroID() || (Method && Method->isVirtual()) ||
-      isReferencedOutsideOfCallExpr(*Function, *Result.Context))
+      isReferencedOutsideOfCallExpr(*Function, *Result.Context) ||
+      Function->getTemplateSpecializationKind() == TSK_ExplicitSpecialization)
     return;
   for (const auto *FunctionDecl = Function; FunctionDecl != nullptr;
        FunctionDecl = FunctionDecl->getPreviousDecl()) {

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -483,6 +483,12 @@ Changes in existing checks
   usages of ``std::string_view::compare``. Added a `StringLikeClasses` option
   to detect usages of ``compare`` method in custom string-like classes.
 
+- Improved :doc:`unnecessary-value-param
+  <clang-tidy/checks/performance/unnecessary-value-param>` check
+  detecting more cases for template functions including lambdas with `auto`.
+  E.g., `std::sort(a.begin(), a.end(), [](auto x, auto y) { return a > b; });`
+  will be detected for expensive to copy types.
+
 Removed checks
 ^^^^^^^^^^^^^^
 

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -485,8 +485,8 @@ Changes in existing checks
 
 - Improved :doc:`unnecessary-value-param
   <clang-tidy/checks/performance/unnecessary-value-param>` check
-  detecting more cases for template functions including lambdas with `auto`.
-  E.g., `std::sort(a.begin(), a.end(), [](auto x, auto y) { return a > b; });`
+  detecting more cases for template functions including lambdas with ``auto``.
+  E.g., ``std::sort(a.begin(), a.end(), [](auto x, auto y) { return a > b; });``
   will be detected for expensive to copy types.
 
 Removed checks

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -418,6 +418,12 @@ Changes in existing checks
   Calls to mutable function where there exists a `const` overload are also
   handled. Fix crash in the case of a non-member operator call.
 
+- Improved :doc:`performance-unnecessary-value-param
+  <clang-tidy/checks/performance/unnecessary-value-param>` check
+  detecting more cases for template functions including lambdas with ``auto``.
+  E.g., ``std::sort(a.begin(), a.end(), [](auto x, auto y) { return a > b; });``
+  will be detected for expensive to copy types.
+
 - Improved :doc:`readability-avoid-return-with-void-value
   <clang-tidy/checks/readability/avoid-return-with-void-value>` check by adding
   fix-its.
@@ -482,12 +488,6 @@ Changes in existing checks
   <clang-tidy/checks/readability/string-compare>` check to also detect
   usages of ``std::string_view::compare``. Added a `StringLikeClasses` option
   to detect usages of ``compare`` method in custom string-like classes.
-
-- Improved :doc:`unnecessary-value-param
-  <clang-tidy/checks/performance/unnecessary-value-param>` check
-  detecting more cases for template functions including lambdas with ``auto``.
-  E.g., ``std::sort(a.begin(), a.end(), [](auto x, auto y) { return a > b; });``
-  will be detected for expensive to copy types.
 
 Removed checks
 ^^^^^^^^^^^^^^

--- a/clang-tools-extra/test/clang-tidy/checkers/performance/unnecessary-value-param-delayed.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/performance/unnecessary-value-param-delayed.cpp
@@ -69,7 +69,8 @@ struct PositiveConstValueConstructor {
 
 template <typename T> void templateWithNonTemplatizedParameter(const ExpensiveToCopyType S, T V) {
   // CHECK-MESSAGES: [[@LINE-1]]:90: warning: the const qualified parameter 'S'
-  // CHECK-FIXES-NOT: template <typename T> void templateWithNonTemplatizedParameter(const ExpensiveToCopyType& S, T V) {
+  // CHECK-MESSAGES: [[@LINE-2]]:95: warning: the parameter 'V'
+  // CHECK-FIXES: template <typename T> void templateWithNonTemplatizedParameter(const ExpensiveToCopyType& S, const T& V) {
 }
 
 void instantiated() {

--- a/clang-tools-extra/test/clang-tidy/checkers/performance/unnecessary-value-param-templates.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/performance/unnecessary-value-param-templates.cpp
@@ -29,13 +29,18 @@ template <typename T> void nonInstantiatedTemplateWithConstValue(const T S) {}
 template <typename T> void nonInstantiatedTemplateWithNonConstValue(T S) {}
 
 template <typename T> void instantiatedTemplateSpecialization(T NoSpecS) {}
+template <> void instantiatedTemplateSpecialization<int>(int SpecSInt) {}
 template <>
 void instantiatedTemplateSpecialization<ExpensiveToCopyType>(
-    ExpensiveToCopyType SpecS) {
+    ExpensiveToCopyType SpecSExpensiveToCopy) {
   // CHECK-MESSAGES: [[@LINE-1]]:25: warning: the parameter 'SpecS'
-  // When updating a template specialization, we also update the main template.
-  // CHECK-FIXES: const T& NoSpecS
-  // CHECK-FIXES: const ExpensiveToCopyType& SpecS
+  // Updating template specialization would also require to update the main
+  // template and other specializations. Such specializations may be
+  // spreaded across across different translation units.
+  // For that reason we only issue a warning, but do not propose fixes.
+  // CHECK-FIXES-NOT: const T& NoSpecS
+  // CHECK-FIXES-NOT: const int& SpecSInt
+  // CHECK-FIXES-NOT: const ExpensiveToCopyType& SpecSExpensiveToCopy
 }
 
 void instantiatedTemplateSpecialization() {

--- a/clang-tools-extra/test/clang-tidy/checkers/performance/unnecessary-value-param-templates.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/performance/unnecessary-value-param-templates.cpp
@@ -33,6 +33,7 @@ template <>
 void instantiatedTemplateSpecialization<ExpensiveToCopyType>(
     ExpensiveToCopyType SpecS) {
   // CHECK-MESSAGES: [[@LINE-1]]:25: warning: the parameter 'SpecS'
+  // When updating a template specialization, we also update the main template.
   // CHECK-FIXES: const T& NoSpecS
   // CHECK-FIXES: const ExpensiveToCopyType& SpecS
 }

--- a/clang-tools-extra/test/clang-tidy/checkers/performance/unnecessary-value-param-templates.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/performance/unnecessary-value-param-templates.cpp
@@ -33,7 +33,7 @@ template <> void instantiatedTemplateSpecialization<int>(int SpecSInt) {}
 template <>
 void instantiatedTemplateSpecialization<ExpensiveToCopyType>(
     ExpensiveToCopyType SpecSExpensiveToCopy) {
-  // CHECK-MESSAGES: [[@LINE-1]]:25: warning: the parameter 'SpecS'
+  // CHECK-MESSAGES: [[@LINE-1]]:25: warning: the parameter 'SpecSExpensiveToCopy'
   // Updating template specialization would also require to update the main
   // template and other specializations. Such specializations may be
   // spreaded across across different translation units.

--- a/clang-tools-extra/test/clang-tidy/checkers/performance/unnecessary-value-param-templates.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/performance/unnecessary-value-param-templates.cpp
@@ -1,0 +1,92 @@
+// RUN: %check_clang_tidy  -std=c++14-or-later %s performance-unnecessary-value-param %t
+
+struct ExpensiveToCopyType {
+  virtual ~ExpensiveToCopyType();
+};
+
+template <typename T> void templateWithNonTemplatizedParameter(const ExpensiveToCopyType S, T V) {
+  // CHECK-MESSAGES: [[@LINE-1]]:90: warning: the const qualified parameter 'S'
+  // CHECK-MESSAGES: [[@LINE-2]]:95: warning: the parameter 'V'
+  // CHECK-FIXES: template <typename T> void templateWithNonTemplatizedParameter(const ExpensiveToCopyType& S, const T& V) {
+}
+
+void instantiatedWithExpensiveValue() {
+  templateWithNonTemplatizedParameter(
+      ExpensiveToCopyType(), ExpensiveToCopyType());
+  templateWithNonTemplatizedParameter(ExpensiveToCopyType(), 5);
+}
+
+template <typename T> void templateWithNonTemplatizedParameterCheapTemplate(const ExpensiveToCopyType S, T V) {
+  // CHECK-MESSAGES: [[@LINE-1]]:103: warning: the const qualified parameter 'S'
+  // CHECK-FIXES: template <typename T> void templateWithNonTemplatizedParameterCheapTemplate(const ExpensiveToCopyType& S, T V) {
+}
+
+void instantiatedWithCheapValue() {
+  templateWithNonTemplatizedParameterCheapTemplate(ExpensiveToCopyType(), 5);
+}
+
+template <typename T> void nonInstantiatedTemplateWithConstValue(const T S) {}
+template <typename T> void nonInstantiatedTemplateWithNonConstValue(T S) {}
+
+template <typename T> void instantiatedTemplateSpecialization(T NoSpecS) {}
+template <>
+void instantiatedTemplateSpecialization<ExpensiveToCopyType>(
+    ExpensiveToCopyType SpecS) {
+  // CHECK-MESSAGES: [[@LINE-1]]:25: warning: the parameter 'SpecS'
+  // CHECK-FIXES: const T& NoSpecS
+  // CHECK-FIXES: const ExpensiveToCopyType& SpecS
+}
+
+void instantiatedTemplateSpecialization() {
+  instantiatedTemplateSpecialization(ExpensiveToCopyType());
+}
+
+template <typename T> void instantiatedTemplateWithConstValue(const T S) {
+  // CHECK-MESSAGES: [[@LINE-1]]:71: warning: the const qualified parameter 'S'
+  // CHECK-FIXES: template <typename T> void instantiatedTemplateWithConstValue(const T& S) {
+}
+
+void instantiatedConstValue() {
+  instantiatedTemplateWithConstValue(ExpensiveToCopyType());
+}
+
+template <typename T> void instantiatedTemplateWithNonConstValue(T S) {
+  // CHECK-MESSAGES: [[@LINE-1]]:68: warning: the parameter 'S'
+  // CHECK-FIXES: template <typename T> void instantiatedTemplateWithNonConstValue(const T& S) {
+}
+
+void instantiatedNonConstValue() {
+  instantiatedTemplateWithNonConstValue(ExpensiveToCopyType());
+}
+
+void lambdaConstValue() {
+  auto fn = [](const ExpensiveToCopyType S) {
+    // CHECK-MESSAGES: [[@LINE-1]]:42: warning: the const qualified parameter 'S'
+    // CHECK-FIXES: auto fn = [](const ExpensiveToCopyType& S) {
+  };
+  fn(ExpensiveToCopyType());
+}
+
+void lambdaNonConstValue() {
+  auto fn = [](ExpensiveToCopyType S) {
+    // CHECK-MESSAGES: [[@LINE-1]]:36: warning: the parameter 'S'
+    // CHECK-FIXES: auto fn = [](const ExpensiveToCopyType& S) {
+  };
+  fn(ExpensiveToCopyType());
+}
+
+void lambdaConstAutoValue() {
+  auto fn = [](const auto S) {
+    // CHECK-MESSAGES: [[@LINE-1]]:27: warning: the const qualified parameter 'S'
+    // CHECK-FIXES: auto fn = [](const auto& S) {
+  };
+  fn(ExpensiveToCopyType());
+}
+
+void lambdaNonConstAutoValue() {
+  auto fn = [](auto S) {
+    // CHECK-MESSAGES: [[@LINE-1]]:21: warning: the parameter 'S'
+    // CHECK-FIXES: auto fn = [](const auto& S) {
+  };
+  fn(ExpensiveToCopyType());
+}

--- a/clang-tools-extra/test/clang-tidy/checkers/performance/unnecessary-value-param-templates.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/performance/unnecessary-value-param-templates.cpp
@@ -30,14 +30,14 @@ template <typename T> void nonInstantiatedTemplateWithNonConstValue(T S) {}
 
 template <typename T> void instantiatedTemplateSpecialization(T NoSpecS) {}
 template <> void instantiatedTemplateSpecialization<int>(int SpecSInt) {}
+// Updating template specialization would also require to update the main
+// template and other specializations. Such specializations may be
+// spreaded across different translation units.
+// For that reason we only issue a warning, but do not propose fixes.
 template <>
 void instantiatedTemplateSpecialization<ExpensiveToCopyType>(
     ExpensiveToCopyType SpecSExpensiveToCopy) {
   // CHECK-MESSAGES: [[@LINE-1]]:25: warning: the parameter 'SpecSExpensiveToCopy'
-  // Updating template specialization would also require to update the main
-  // template and other specializations. Such specializations may be
-  // spreaded across across different translation units.
-  // For that reason we only issue a warning, but do not propose fixes.
   // CHECK-FIXES-NOT: const T& NoSpecS
   // CHECK-FIXES-NOT: const int& SpecSInt
   // CHECK-FIXES-NOT: const ExpensiveToCopyType& SpecSExpensiveToCopy

--- a/clang-tools-extra/test/clang-tidy/checkers/performance/unnecessary-value-param.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/performance/unnecessary-value-param.cpp
@@ -107,19 +107,6 @@ struct PositiveConstValueConstructor {
   // CHECK-FIXES: PositiveConstValueConstructor(const ExpensiveToCopyType& ConstCopy) {}
 };
 
-template <typename T> void templateWithNonTemplatizedParameter(const ExpensiveToCopyType S, T V) {
-  // CHECK-MESSAGES: [[@LINE-1]]:90: warning: the const qualified parameter 'S'
-  // CHECK-FIXES-NOT: template <typename T> void templateWithNonTemplatizedParameter(const ExpensiveToCopyType& S, T V) {
-}
-
-void instantiated() {
-  templateWithNonTemplatizedParameter(ExpensiveToCopyType(), ExpensiveToCopyType());
-  templateWithNonTemplatizedParameter(ExpensiveToCopyType(), 5);
-}
-
-template <typename T> void negativeTemplateType(const T V) {
-}
-
 void negativeArray(const ExpensiveToCopyType[]) {
 }
 
@@ -369,36 +356,4 @@ struct NegativeUsingConstructor : public PositiveConstructor {
 void fun() {
   ExpensiveToCopyType E;
   NegativeUsingConstructor S(E);
-}
-
-template<typename T>
-void templateFunction(T) {
-}
-
-template<>
-void templateFunction<ExpensiveToCopyType>(ExpensiveToCopyType E) {
-  // CHECK-MESSAGES: [[@LINE-1]]:64: warning: the parameter 'E' is copied
-  // CHECK-FIXES: void templateFunction<ExpensiveToCopyType>(ExpensiveToCopyType E) {
-  E.constReference();
-}
-
-template <class T>
-T templateSpecializationFunction(ExpensiveToCopyType E) {
-  // CHECK-MESSAGES: [[@LINE-1]]:54: warning: the parameter 'E' is copied
-  // CHECK-FIXES-NOT: T templateSpecializationFunction(const ExpensiveToCopyType& E) {
-  return T();
-}
-
-template <>
-bool templateSpecializationFunction(ExpensiveToCopyType E) {
-  // CHECK-MESSAGES: [[@LINE-1]]:57: warning: the parameter 'E' is copied
-  // CHECK-FIXES-NOT: bool templateSpecializationFunction(const ExpensiveToCopyType& E) {
-  return true;
-}
-
-template <>
-int templateSpecializationFunction(ExpensiveToCopyType E) {
-  // CHECK-MESSAGES: [[@LINE-1]]:56: warning: the parameter 'E' is copied
-  // CHECK-FIXES-NOT: int templateSpecializationFunction(const ExpensiveToCopyType& E) {
-  return 0;
 }


### PR DESCRIPTION
Clang-Tidy unnecessary-value-param value param will be triggered for
templated functions if at least one instantiontion with expensive to
copy type is present in translation unit.

It is relatively common mistake to write lambda functions with auto
arguments for expensive to copy types.

Example:
Copy of the vectors will happen on every comparison.

```
void SortBySize(std::vector<std::vector<int>>& a) {
  std::sort(
      a.begin(), a.end(),
      [](auto x, auto y) { return a.size() < b.size()});
}
```