### PR TITLE
[PGO][compiler-rt] Add a test to ensure include files do not diverge

### DIFF
--- a/compiler-rt/test/profile/check-same-common-code.test
+++ b/compiler-rt/test/profile/check-same-common-code.test
@@ -1,5 +1,5 @@
 ;
-; NOTE: if this test fails, please make sure the relevant copies are identical
+; NOTE: if this test fails, please make sure the files are identical
 ; copies of each other.
 ;
 ; RUN: diff %crt_src/include/profile/MIBEntryDef.inc %llvm_src/include/llvm/ProfileData/MIBEntryDef.inc

--- a/compiler-rt/test/profile/check-same-common-code.test
+++ b/compiler-rt/test/profile/check-same-common-code.test
@@ -1,0 +1,6 @@
+;
+; NOTE: if this test fails, please make sure the relevant copies are identical
+; copies of each other.
+;
+; RUN: diff %crt_src/include/profile/MIBEntryDef.inc %llvm_src/include/llvm/ProfileData/MIBEntryDef.inc
+; RUN: diff %crt_src/include/profile/MemProfData.inc %llvm_src/include/llvm/ProfileData/MemProfData.inc

--- a/compiler-rt/test/profile/check-same-common-code.test
+++ b/compiler-rt/test/profile/check-same-common-code.test
@@ -4,3 +4,4 @@
 ;
 ; RUN: diff %crt_src/include/profile/MIBEntryDef.inc %llvm_src/include/llvm/ProfileData/MIBEntryDef.inc
 ; RUN: diff %crt_src/include/profile/MemProfData.inc %llvm_src/include/llvm/ProfileData/MemProfData.inc
+; RUN: diff %crt_src/include/profile/InstrProfData.inc %llvm_src/include/llvm/ProfileData/InstrProfData.inc


### PR DESCRIPTION
Memprof has two include files that are duplicated between LLVM and compiler-rt. They need to stay in sync to ensure correct functionality, but the comments can be somewhat easy to miss, which causes fixups like 839ed1ba553346b0c225e9b839cf3cb716dc7412 to be needed. This patch adds a test to ensure that the files are the same between LLVM and compiler-rt to catch this ideally before commit, but if not, soon afterwards.

There is additionally `InstrProfData.inc` for some PGO variants that is added to the same test here as well.