### PR TITLE
[RFC] [clang][Toolchain] Treat "pc"/"unknown" vendor interchangeable

### DIFF
--- a/clang/lib/Driver/ToolChain.cpp
+++ b/clang/lib/Driver/ToolChain.cpp
@@ -765,6 +765,26 @@ ToolChain::getTargetSubDirPath(StringRef BaseDir) const {
   if (auto Path = getPathForTriple(getTriple()))
     return *Path;
 
+  // Treat "pc" and "unknown" vendors interchangeable
+  switch (getTriple().getVendor()) {
+  case Triple::UnknownVendor: {
+    llvm::Triple TripleFallback = Triple;
+    TripleFallback.setVendor(Triple::PC);
+    if (auto Path = getPathForTriple(TripleFallback))
+      return *Path;
+    break;
+  }
+  case Triple::PC: {
+    llvm::Triple TripleFallback = Triple;
+    TripleFallback.setVendor(Triple::UnknownVendor);
+    if (auto Path = getPathForTriple(TripleFallback))
+      return *Path;
+    break;
+  }
+  default:
+    break;
+  }
+
   // When building with per target runtime directories, various ways of naming
   // the Arm architecture may have been normalised to simply "arm".
   // For example "armv8l" (Armv8 AArch32 little endian) is replaced with "arm".

--- a/clang/test/Driver/pc-unknown-toolchain.c
+++ b/clang/test/Driver/pc-unknown-toolchain.c
@@ -1,0 +1,6 @@
+// UNSUPPORTED: system-windows
+
+// RUN: %clang -### %s -fsanitize=address --target=x86_64-pc-linux-gnu 2>&1 | FileCheck -check-prefix=CHECK-ASAN-PC %s
+// CHECK-ASAN-PC: x86_64-unknown-linux-gnu/libclang_rt.asan_static.a
+// RUN: %clang -### %s -fsanitize=address --target=x86_64-unknown-linux-gnu 2>&1 | FileCheck -check-prefix=CHECK-ASAN-UNKNOWN %s
+// CHECK-ASAN-UNKNOWN: x86_64-unknown-linux-gnu/libclang_rt.asan_static.a


### PR DESCRIPTION
Right now if you have runtime libraries under
lib/x86_64-unknown-linux-gnu you should use --target x86_64-unknown-linux-gnu, x86_64-pc-linux-gnu will not work.

Treat the interchangeable so that you can use any.

The initial reason for this patch is that debian packages uses x86_64-pc-linux-gnu, and after they enabled
LLVM_ENABLE_PER_TARGET_RUNTIME_DIR [1], clang cannot find runtime libraries for sanitizers.

  [1]: https://salsa.debian.org/pkg-llvm-team/llvm-toolchain/-/commit/9ca35f30383d89e4fdd45d15e0eb82c832df4b8c

Fixes: https://github.com/llvm/llvm-project/issues/95792