### PR TITLE
[NFC][opt] Improve help message

### DIFF
--- a/llvm/tools/opt/optdriver.cpp
+++ b/llvm/tools/opt/optdriver.cpp
@@ -68,7 +68,7 @@ static codegen::RegisterCodeGenFlags CFG;
 // The OptimizationList is automatically populated with registered Passes by the
 // PassNameParser.
 static cl::list<const PassInfo *, bool, PassNameParser> PassList(cl::desc(
-    "Optimizations available (use '-passes=' for the new pass manager)"));
+    "Optimizations available (use \"-passes=\" for the new pass manager)"));
 
 static cl::opt<bool> EnableLegacyPassManager(
     "bugpoint-enable-legacy-pm",
@@ -85,7 +85,7 @@ static cl::opt<std::string> PassPipeline(
     "passes",
     cl::desc(
         "A textual description of the pass pipeline. To have analysis passes "
-        "available before a certain pass, add 'require<foo-analysis>'."));
+        "available before a certain pass, add \"require<foo-analysis>\"."));
 static cl::alias PassPipeline2("p", cl::aliasopt(PassPipeline),
                                cl::desc("Alias for -passes"));
 
@@ -154,28 +154,28 @@ static cl::opt<bool>
 
 static cl::opt<bool>
     OptLevelO0("O0", cl::desc("Optimization level 0. Similar to clang -O0. "
-                              "Same as -passes='default<O0>'"));
+                              "Same as -passes=\"default<O0>\""));
 
 static cl::opt<bool>
     OptLevelO1("O1", cl::desc("Optimization level 1. Similar to clang -O1. "
-                              "Same as -passes='default<O1>'"));
+                              "Same as -passes=\"default<O1>\""));
 
 static cl::opt<bool>
     OptLevelO2("O2", cl::desc("Optimization level 2. Similar to clang -O2. "
-                              "Same as -passes='default<O2>'"));
+                              "Same as -passes=\"default<O2>\""));
 
 static cl::opt<bool>
     OptLevelOs("Os", cl::desc("Like -O2 but size-conscious. Similar to clang "
-                              "-Os. Same as -passes='default<Os>'"));
+                              "-Os. Same as -passes=\"default<Os>\""));
 
 static cl::opt<bool> OptLevelOz(
     "Oz",
     cl::desc("Like -O2 but optimize for code size above all else. Similar to "
-             "clang -Oz. Same as -passes='default<Oz>'"));
+             "clang -Oz. Same as -passes=\"default<Oz>\""));
 
 static cl::opt<bool>
     OptLevelO3("O3", cl::desc("Optimization level 3. Similar to clang -O3. "
-                              "Same as -passes='default<O3>'"));
+                              "Same as -passes=\"default<O3>\""));
 
 static cl::opt<unsigned> CodeGenOptLevelCL(
     "codegen-opt-level",


### PR DESCRIPTION
This patch changes all single quotes in the help text to double quotes for the sake of cross platform correctness.

The single quotes previously used in the help message are correct for bash and most other shells but aren't correct for the Windows command prompt as it only interprets double quotes in the manner intended in the help message.

This patch was prompted by the fact that if you aren't aware of the aformentioned quirk the single quotes result in very confusing error messages from the command prompt.