### PR TITLE
[libclc] More cross compilation fixes

### DIFF
--- a/clang/tools/driver/CMakeLists.txt
+++ b/clang/tools/driver/CMakeLists.txt
@@ -38,6 +38,8 @@ add_clang_tool(clang
   GENERATE_DRIVER
   )
 
+setup_host_tool(clang CLANG clang_exe clang_target)
+
 clang_target_link_libraries(clang
   PRIVATE
   clangBasic

--- a/libclc/CMakeLists.txt
+++ b/libclc/CMakeLists.txt
@@ -73,10 +73,10 @@ else()
   endif()
 
   if( NOT EXISTS ${LIBCLC_CUSTOM_LLVM_TOOLS_BINARY_DIR} )
-    setup_host_tool( clang CLANG clang_exe clang_target )
-    setup_host_tool( llvm-as LLVM_AS llvm-as_exe llvm-as_target )
-    setup_host_tool( llvm-link LLVM_LINK llvm-link_exe llvm-link_target )
-    setup_host_tool( opt OPT opt_exe opt_target )
+    get_host_tool_path( clang CLANG clang_exe clang_target )
+    get_host_tool_path( llvm-as LLVM_AS llvm-as_exe llvm-as_target )
+    get_host_tool_path( llvm-link LLVM_LINK llvm-link_exe llvm-link_target )
+    get_host_tool_path( opt OPT opt_exe opt_target )
   endif()
 endif()
 
@@ -97,17 +97,19 @@ if( EXISTS ${LIBCLC_CUSTOM_LLVM_TOOLS_BINARY_DIR} )
 endif()
 
 foreach( tool IN ITEMS clang opt llvm-as llvm-link )
-  if( NOT EXISTS "${${tool}_exe}" AND NOT TARGET "${${tool}_target}" )
+  if( NOT EXISTS "${${tool}_exe}" AND "${tool}_target" STREQUAL "" )
     message( FATAL_ERROR "libclc toolchain incomplete - missing tool ${tool}!" )
   endif()
 endforeach()
 
 # llvm-spirv is an optional dependency, used to build spirv-* targets.
-find_program( LLVM_SPIRV llvm-spirv PATHS ${LLVM_TOOLS_BINARY_DIR} NO_DEFAULT_PATH )
-
-if( LLVM_SPIRV )
-  add_executable( libclc::llvm-spirv IMPORTED GLOBAL )
-  set_target_properties( libclc::llvm-spirv PROPERTIES IMPORTED_LOCATION ${LLVM_SPIRV} )
+# It may be provided in-tree or externally.
+if( TARGET llvm-spirv )
+  get_host_tool_path( llvm-spirv LLVM_SPIRV llvm-spirv_exe llvm-spirv_target )
+else()
+  find_program( LLVM_SPIRV llvm-spirv PATHS ${LLVM_TOOLS_BINARY_DIR} NO_DEFAULT_PATH )
+  set( llvm-spirv_exe "${LLVM_SPIRV}" )
+  set( llvm-spirv_target )
 endif()
 
 # List of all targets. Note that some are added dynamically below.
@@ -130,7 +132,7 @@ endif()
 
 # spirv-mesa3d and spirv64-mesa3d targets can only be built with the (optional)
 # llvm-spirv external tool.
-if( TARGET libclc::llvm-spirv )
+if( llvm-spirv_exe )
   list( APPEND LIBCLC_TARGETS_ALL  spirv-mesa3d- spirv64-mesa3d- )
 endif()
 
@@ -143,7 +145,7 @@ list( SORT LIBCLC_TARGETS_TO_BUILD )
 # Verify that the user hasn't requested mesa3d targets without an available
 # llvm-spirv tool.
 if( "spirv-mesa3d-" IN_LIST LIBCLC_TARGETS_TO_BUILD OR "spirv64-mesa3d-" IN_LIST LIBCLC_TARGETS_TO_BUILD )
-  if( NOT TARGET libclc::llvm-spirv )
+  if( NOT llvm-spirv_exe )
     message( FATAL_ERROR "SPIR-V targets requested, but spirv-tools is not installed" )
   endif()
 endif()
@@ -401,8 +403,8 @@ foreach( t ${LIBCLC_TARGETS_TO_BUILD} )
     if( ARCH STREQUAL spirv OR ARCH STREQUAL spirv64 )
       set( spv_suffix ${arch_suffix}.spv )
       add_custom_command( OUTPUT ${spv_suffix}
-        COMMAND libclc::llvm-spirv ${spvflags} -o ${spv_suffix} ${builtins_link_lib}
-        DEPENDS ${builtins_link_lib} ${builtins_link_lib_tgt}
+        COMMAND ${llvm-spirv_exe} ${spvflags} -o ${spv_suffix} ${builtins_link_lib}
+        DEPENDS ${llvm-spirv_target} ${builtins_link_lib} ${builtins_link_lib_tgt}
       )
       add_custom_target( "prepare-${spv_suffix}" ALL DEPENDS "${spv_suffix}" )
       install( FILES ${CMAKE_CURRENT_BINARY_DIR}/${spv_suffix}

--- a/llvm/tools/llvm-as/CMakeLists.txt
+++ b/llvm/tools/llvm-as/CMakeLists.txt
@@ -11,3 +11,5 @@ add_llvm_tool(llvm-as
   DEPENDS
   intrinsics_gen
   )
+
+setup_host_tool(llvm-as LLVM_AS llvm_as_exe llvm_as_target)

--- a/llvm/tools/llvm-link/CMakeLists.txt
+++ b/llvm/tools/llvm-link/CMakeLists.txt
@@ -17,3 +17,5 @@ add_llvm_tool(llvm-link
   DEPENDS
   intrinsics_gen
   )
+
+setup_host_tool(llvm-link LLVM_LINK llvm_link_exe llvm_link_target)

--- a/llvm/tools/opt/CMakeLists.txt
+++ b/llvm/tools/opt/CMakeLists.txt
@@ -49,4 +49,6 @@ add_llvm_tool(opt
   )
 target_link_libraries(opt PRIVATE LLVMOptDriver)
 
+setup_host_tool(opt OPT opt_exe opt_target)
+
 export_executable_symbols_for_plugins(opt)


### PR DESCRIPTION
* Move the setup_host_tool calls to the directories of their tool. Although it works to call it in libclc, it can only appear in a single location so it fails the "what if everyone did this?" test and causes problems for downstream code that also wants to use native versions of these tools from other projects.
* Correct the TARGET "${${tool}_target}" check. "${${tool}_target}" may be set to the path to the executable, which works in dependencies but cannot be tested using if(TARGET). For lack of a better alternative, just check that "${${tool}_target}" is non-empty and trust that if it is, it is set to a meaningful value. If somehow it turns out to be a valid target, its value will still show up in error messages anyway.
* Account for llvm-spirv possibly being provided in-tree. Per https://github.com/KhronosGroup/SPIRV-LLVM-Translator?tab=readme-ov-file#llvm-in-tree-build it is possible to drop llvm-spirv into LLVM and have it built as part of LLVM's build. In this configuration, cross builds of LLVM require a native version of llvm-spirv to be built.