### PR TITLE
[MLIR][LLVM] Add ftz and fuse FP ops related function attribute support

### DIFF
--- a/mlir/include/mlir/Dialect/LLVMIR/LLVMOps.td
+++ b/mlir/include/mlir/Dialect/LLVMIR/LLVMOps.td
@@ -1454,6 +1454,9 @@ def LLVM_LLVMFuncOp : LLVM_Op<"func", [
     OptionalAttr<BoolAttr>:$no_nans_fp_math,
     OptionalAttr<BoolAttr>:$approx_func_fp_math,
     OptionalAttr<BoolAttr>:$no_signed_zeros_fp_math,
+    OptionalAttr<StrAttr>:$denormal_fp_math,
+    OptionalAttr<StrAttr>:$denormal_fp_math_f32,
+    OptionalAttr<StrAttr>:$fp_contract,
     OptionalAttr<UnitAttr>:$no_inline,
     OptionalAttr<UnitAttr>:$always_inline,
     OptionalAttr<UnitAttr>:$optimize_none

--- a/mlir/lib/Target/LLVMIR/ModuleImport.cpp
+++ b/mlir/lib/Target/LLVMIR/ModuleImport.cpp
@@ -1676,6 +1676,9 @@ static constexpr std::array kExplicitAttributes{
     StringLiteral("alwaysinline"),
     StringLiteral("approx-func-fp-math"),
     StringLiteral("convergent"),
+    StringLiteral("denormal-fp-math"),
+    StringLiteral("denormal-fp-math-f32"),
+    StringLiteral("fp-contract"),
     StringLiteral("frame-pointer"),
     StringLiteral("no-infs-fp-math"),
     StringLiteral("no-nans-fp-math"),
@@ -1823,6 +1826,20 @@ void ModuleImport::processFunctionAttributes(llvm::Function *func,
   if (llvm::Attribute attr = func->getFnAttribute("no-signed-zeros-fp-math");
       attr.isStringAttribute())
     funcOp.setNoSignedZerosFpMath(attr.getValueAsBool());
+
+  if (llvm::Attribute attr = func->getFnAttribute("denormal-fp-math");
+      attr.isStringAttribute())
+    funcOp.setDenormalFpMathAttr(
+        StringAttr::get(context, attr.getValueAsString()));
+
+  if (llvm::Attribute attr = func->getFnAttribute("denormal-fp-math-f32");
+      attr.isStringAttribute())
+    funcOp.setDenormalFpMathF32Attr(
+        StringAttr::get(context, attr.getValueAsString()));
+
+  if (llvm::Attribute attr = func->getFnAttribute("fp-contract");
+      attr.isStringAttribute())
+    funcOp.setFpContractAttr(StringAttr::get(context, attr.getValueAsString()));
 }
 
 DictionaryAttr

--- a/mlir/lib/Target/LLVMIR/ModuleTranslation.cpp
+++ b/mlir/lib/Target/LLVMIR/ModuleTranslation.cpp
@@ -1351,6 +1351,15 @@ LogicalResult ModuleTranslation::convertOneFunction(LLVMFuncOp func) {
     llvmFunc->addFnAttr("no-signed-zeros-fp-math",
                         llvm::toStringRef(*noSignedZerosFpMath));
 
+  if (auto denormalFpMath = func.getDenormalFpMath())
+    llvmFunc->addFnAttr("denormal-fp-math", *denormalFpMath);
+
+  if (auto denormalFpMathF32 = func.getDenormalFpMathF32())
+    llvmFunc->addFnAttr("denormal-fp-math-f32", *denormalFpMathF32);
+
+  if (auto fpContract = func.getFpContract())
+    llvmFunc->addFnAttr("fp-contract", *fpContract);
+
   // Add function attribute frame-pointer, if found.
   if (FramePointerKindAttr attr = func.getFramePointerAttr())
     llvmFunc->addFnAttr("frame-pointer",

--- a/mlir/test/Dialect/LLVMIR/func.mlir
+++ b/mlir/test/Dialect/LLVMIR/func.mlir
@@ -293,6 +293,25 @@ module {
     // CHECK-SAME: attributes {convergent}
     llvm.return
   }
+
+  llvm.func @denormal_fp_math_roundtrip() attributes {denormal_fp_math = "preserve-sign"} {
+    // CHECK: @denormal_fp_math_roundtrip
+    // CHECK-SAME: attributes {denormal_fp_math = "preserve-sign"}
+    llvm.return
+  }
+
+  llvm.func @denormal_fp_math_f32_roundtrip() attributes {denormal_fp_math_f32 = "preserve-sign"} {
+    // CHECK: @denormal_fp_math_f32_roundtrip
+    // CHECK-SAME: attributes {denormal_fp_math_f32 = "preserve-sign"}
+    llvm.return
+  }
+
+  llvm.func @fp_contract_roundtrip() attributes {fp_contract = "fast"} {
+    // CHECK: @fp_contract_roundtrip
+    // CHECK-SAME: attributes {fp_contract = "fast"}
+    llvm.return
+  }
+
 }
 
 // -----

--- a/mlir/test/Target/LLVMIR/Import/function-attributes.ll
+++ b/mlir/test/Target/LLVMIR/Import/function-attributes.ll
@@ -344,6 +344,24 @@ declare void @func_attr_no_signed_zeros_fp_math_true() "no-signed-zeros-fp-math"
 ; CHECK-SAME: attributes {no_signed_zeros_fp_math = false}
 declare void @func_attr_no_signed_zeros_fp_math_false() "no-signed-zeros-fp-math"="false"
 
+; // -----
+
+; CHECK-LABEL: @func_attr_denormal_fp_math_ieee
+; CHECK-SAME: attributes {denormal_fp_math = "ieee"}
+declare void @func_attr_denormal_fp_math_ieee() "denormal-fp-math"="ieee"
+
+; // -----
+
+; CHECK-LABEL: @func_attr_denormal_fp_math_f32_preserve_sign
+; CHECK-SAME: attributes {denormal_fp_math_f32 = "preserve-sign"}
+declare void @func_attr_denormal_fp_math_f32_preserve_sign() "denormal-fp-math-f32"="preserve-sign"
+
+; // -----
+
+; CHECK-LABEL: @func_attr_fp_contract_fast
+; CHECK-SAME: attributes {fp_contract = "fast"}
+declare void @func_attr_fp_contract_fast() "fp-contract"="fast"
+
 // -----
 
 ; CHECK-LABEL: @noinline_attribute

--- a/mlir/test/Target/LLVMIR/fp-math-function-attributes.mlir
+++ b/mlir/test/Target/LLVMIR/fp-math-function-attributes.mlir
@@ -87,3 +87,30 @@ llvm.func @no_signed_zeros_fp_math_func_false() attributes {no_signed_zeros_fp_m
   llvm.return
 }
 // CHECK: attributes #[[ATTRS]] = { "no-signed-zeros-fp-math"="false" }
+
+// -----
+
+// CHECK-LABEL: define void @denormal_fp_math_func_ieee()
+// CHECK-SAME: #[[ATTRS:[0-9]+]]
+llvm.func @denormal_fp_math_func_ieee() attributes {denormal_fp_math = "ieee"}  {
+  llvm.return
+}
+// CHECK: attributes #[[ATTRS]] = { "denormal-fp-math"="ieee" }
+
+// -----
+
+// CHECK-LABEL: define void @denormal_fp_math_f32_func_preserve_sign()
+// CHECK-SAME: #[[ATTRS:[0-9]+]]
+llvm.func @denormal_fp_math_f32_func_preserve_sign() attributes {denormal_fp_math_f32 = "preserve-sign"}  {
+  llvm.return
+}
+// CHECK: attributes #[[ATTRS]] = { "denormal-fp-math-f32"="preserve-sign" }
+
+// -----
+
+// CHECK-LABEL: define void @fp_contract_func_fast()
+// CHECK-SAME: #[[ATTRS:[0-9]+]]
+llvm.func @fp_contract_func_fast() attributes {fp_contract = "fast"}  {
+  llvm.return
+}
+// CHECK: attributes #[[ATTRS]] = { "fp-contract"="fast" }


### PR DESCRIPTION
Adds  `denormal-fp-math-f32`, `denormal-fp-math`, `fp-contract` to llvmFuncOp attributes.

`denormal-fp-math-f32` and `denormal-fp-math` can enable the ftz, that is , flushing denormal to zero.

`fp-contract` can enable the fma fusion such as `mul + add -> fma`