### PR TITLE
[MLIR][NFC]Fix unusued variable warning.

### DIFF
--- a/mlir/lib/Target/LLVMIR/ModuleTranslation.cpp
+++ b/mlir/lib/Target/LLVMIR/ModuleTranslation.cpp
@@ -639,8 +639,7 @@ llvm::Constant *mlir::LLVM::detail::getLLVMConstant(
         if (llvm::ConstantDataSequential::isElementTypeCompatible(
                 elementType)) {
           // TODO: Handle all compatible types. This code only handles integer.
-          if (llvm::IntegerType *iTy =
-                  dyn_cast<llvm::IntegerType>(elementType)) {
+          if (isa<llvm::IntegerType>(elementType)) {
             if (llvm::ConstantInt *ci = dyn_cast<llvm::ConstantInt>(child)) {
               if (ci->getBitWidth() == 8) {
                 SmallVector<int8_t> constants(numElements, ci->getZExtValue());


### PR DESCRIPTION
This just changes a dyn_cast to and isa call to check for type, which avoids getting a warning in clang. The variable `ity` is not used in the next block.

No functional change.