### PR TITLE
[SSAUpdater] Avoid un-necessary SmallVector stores

### DIFF
--- a/llvm/include/llvm/Support/GenericIteratedDominanceFrontier.h
+++ b/llvm/include/llvm/Support/GenericIteratedDominanceFrontier.h
@@ -23,9 +23,9 @@
 #ifndef LLVM_SUPPORT_GENERICITERATEDDOMINANCEFRONTIER_H
 #define LLVM_SUPPORT_GENERICITERATEDDOMINANCEFRONTIER_H
 
-#include "llvm/ADT/iterator_range.h"
 #include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/iterator_range.h"
 #include "llvm/Support/GenericDomTree.h"
 #include <queue>
 

--- a/llvm/include/llvm/Support/GenericIteratedDominanceFrontier.h
+++ b/llvm/include/llvm/Support/GenericIteratedDominanceFrontier.h
@@ -23,6 +23,7 @@
 #ifndef LLVM_SUPPORT_GENERICITERATEDDOMINANCEFRONTIER_H
 #define LLVM_SUPPORT_GENERICITERATEDDOMINANCEFRONTIER_H
 
+#include "llvm/ADT/iterator_range.h"
 #include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/Support/GenericDomTree.h"
@@ -37,9 +38,10 @@ namespace IDFCalculatorDetail {
 /// successors.
 template <class NodeTy, bool IsPostDom> struct ChildrenGetterTy {
   using NodeRef = typename GraphTraits<NodeTy *>::NodeRef;
-  using ChildrenTy = SmallVector<NodeRef, 8>;
+  using ChildIteratorType = typename GraphTraits<NodeTy *>::ChildIteratorType;
+  using range = iterator_range<ChildIteratorType>;
 
-  ChildrenTy get(const NodeRef &N);
+  range get(const NodeRef &N);
 };
 
 } // end of namespace IDFCalculatorDetail
@@ -115,13 +117,12 @@ private:
 namespace IDFCalculatorDetail {
 
 template <class NodeTy, bool IsPostDom>
-typename ChildrenGetterTy<NodeTy, IsPostDom>::ChildrenTy
+typename ChildrenGetterTy<NodeTy, IsPostDom>::range
 ChildrenGetterTy<NodeTy, IsPostDom>::get(const NodeRef &N) {
   using OrderedNodeTy =
       typename IDFCalculatorBase<NodeTy, IsPostDom>::OrderedNodeTy;
 
-  auto Children = children<OrderedNodeTy>(N);
-  return {Children.begin(), Children.end()};
+  return children<OrderedNodeTy>(N);
 }
 
 } // end of namespace IDFCalculatorDetail


### PR DESCRIPTION
The default template for the generic IDF calculator fetching block-children will, by default:
 * Fetch the children range from the relevant `GraphTraits`,
 * Store all child nodes in a `SmallVector`,
 * Return that `SmallVector` into the IDF calculator.

The only place this `SmallVector` is used is in a for-range loop... thus there's no reason why we can't just iterate over the child range from `GraphTraits`, instead of storing all the nodes locally then iterating over the local copy. (If the children of a node change during IDF calculation, everything is broken anyway).

This yields a 0.14% debug-info build performance improvement on the compile time tracker, as InstrRefBasedLDV uses the SSA updater intensively on all functions.

http://llvm-compile-time-tracker.com/compare.php?from=a9f1d377013b1d208ac58f6f75548f1f24d174d2&to=e73fd09de063a113a387c09b561cb3ccfc50e35b&stat=instructions:u