### PR TITLE
[SSAUpdater] Don't use large SmallSets for IDFcalc

### DIFF
--- a/llvm/include/llvm/ADT/SmallPtrSet.h
+++ b/llvm/include/llvm/ADT/SmallPtrSet.h
@@ -93,6 +93,7 @@ public:
 
   [[nodiscard]] bool empty() const { return size() == 0; }
   size_type size() const { return NumNonEmpty - NumTombstones; }
+  size_type capacity() const { return CurArraySize; }
 
   void clear() {
     incrementEpoch();
@@ -111,17 +112,22 @@ public:
 
   void reserve(size_type NumEntries) {
     incrementEpoch();
+    // Do nothing if we're given zero as a reservation size.
+    if (!NumEntries)
+      return;
     // No need to expand if we're small and NumEntries will fit in the space.
     if (isSmall() && NumEntries <= CurArraySize)
       return;
     // insert_imp_big will reallocate if stores is more than 75% full, on the
     // /final/ insertion.
-    if (!isSmall() && ((NumEntries-1) * 4) < (CurArraySize * 3))
+    if (!isSmall() && ((NumEntries - 1) * 4) < (CurArraySize * 3))
       return;
     // We must Grow -- find the size where we'd be 75% full, then round up to
     // the next power of two.
     size_type NewSize = NumEntries + (NumEntries / 3);
     NewSize = 1 << (Log2_32_Ceil(NewSize) + 1);
+    // Like insert_imp_big, always allocate at least 128 elements.
+    NewSize = std::max(128u, NewSize);
     Grow(NewSize);
   }
 

--- a/llvm/include/llvm/ADT/SmallPtrSet.h
+++ b/llvm/include/llvm/ADT/SmallPtrSet.h
@@ -112,10 +112,11 @@ public:
   void reserve(size_type NumEntries) {
     incrementEpoch();
     // No need to expand if we're small and NumEntries will fit in the space.
-    if (isSmall() && NumEntries < CurArraySize)
+    if (isSmall() && NumEntries <= CurArraySize)
       return;
-    // insert_imp_big will reallocate if stores is more than 75% full.
-    if (!isSmall() && (NumEntries * 4) <= (CurArraySize * 3))
+    // insert_imp_big will reallocate if stores is more than 75% full, on the
+    // /final/ insertion.
+    if (!isSmall() && ((NumEntries-1) * 4) < (CurArraySize * 3))
       return;
     // We must Grow -- find the size where we'd be 75% full, then round up to
     // the next power of two.

--- a/llvm/include/llvm/ADT/SmallPtrSet.h
+++ b/llvm/include/llvm/ADT/SmallPtrSet.h
@@ -17,6 +17,7 @@
 
 #include "llvm/ADT/EpochTracker.h"
 #include "llvm/Support/Compiler.h"
+#include "llvm/Support/MathExtras.h"
 #include "llvm/Support/ReverseIteration.h"
 #include "llvm/Support/type_traits.h"
 #include <cassert>
@@ -106,6 +107,21 @@ public:
 
     NumNonEmpty = 0;
     NumTombstones = 0;
+  }
+
+  void reserve(size_type NumEntries) {
+    incrementEpoch();
+    // No need to expand if we're small and NumEntries will fit in the space.
+    if (isSmall() && NumEntries < CurArraySize)
+      return;
+    // insert_imp_big will reallocate if stores is more than 75% full.
+    if (!isSmall() && (NumEntries * 4) <= (CurArraySize * 3))
+      return;
+    // We must Grow -- find the size where we'd be 75% full, then round up to
+    // the next power of two.
+    size_type NewSize = NumEntries + (NumEntries / 3);
+    NewSize = 1 << (Log2_32_Ceil(NewSize) + 1);
+    Grow(NewSize);
   }
 
 protected:

--- a/llvm/include/llvm/ADT/SmallPtrSet.h
+++ b/llvm/include/llvm/ADT/SmallPtrSet.h
@@ -113,7 +113,7 @@ public:
   void reserve(size_type NumEntries) {
     incrementEpoch();
     // Do nothing if we're given zero as a reservation size.
-    if (!NumEntries)
+    if (NumEntries == 0)
       return;
     // No need to expand if we're small and NumEntries will fit in the space.
     if (isSmall() && NumEntries <= CurArraySize)

--- a/llvm/include/llvm/Support/GenericIteratedDominanceFrontier.h
+++ b/llvm/include/llvm/Support/GenericIteratedDominanceFrontier.h
@@ -144,8 +144,8 @@ void IDFCalculatorBase<NodeTy, IsPostDom>::calculate(
   DT.updateDFSNumbers();
 
   SmallVector<DomTreeNodeBase<NodeTy> *, 32> Worklist;
-  SmallDenseSet<DomTreeNodeBase<NodeTy> *, 16> VisitedPQ;
-  SmallDenseSet<DomTreeNodeBase<NodeTy> *, 16> VisitedWorklist;
+  SmallPtrSet<DomTreeNodeBase<NodeTy> *, 16> VisitedPQ;
+  SmallPtrSet<DomTreeNodeBase<NodeTy> *, 16> VisitedWorklist;
   if (useLiveIn) {
     VisitedPQ.reserve(LiveInBlocks->size());
     VisitedWorklist.reserve(LiveInBlocks->size());

--- a/llvm/include/llvm/Support/GenericIteratedDominanceFrontier.h
+++ b/llvm/include/llvm/Support/GenericIteratedDominanceFrontier.h
@@ -144,8 +144,12 @@ void IDFCalculatorBase<NodeTy, IsPostDom>::calculate(
   DT.updateDFSNumbers();
 
   SmallVector<DomTreeNodeBase<NodeTy> *, 32> Worklist;
-  SmallPtrSet<DomTreeNodeBase<NodeTy> *, 32> VisitedPQ;
-  SmallPtrSet<DomTreeNodeBase<NodeTy> *, 32> VisitedWorklist;
+  SmallDenseSet<DomTreeNodeBase<NodeTy> *, 16> VisitedPQ;
+  SmallDenseSet<DomTreeNodeBase<NodeTy> *, 16> VisitedWorklist;
+  if (useLiveIn) {
+    VisitedPQ.reserve(LiveInBlocks->size());
+    VisitedWorklist.reserve(LiveInBlocks->size());
+  }
 
   for (NodeTy *BB : *DefBlocks)
     if (DomTreeNodeBase<NodeTy> *Node = DT.getNode(BB)) {

--- a/llvm/unittests/ADT/SmallPtrSetTest.cpp
+++ b/llvm/unittests/ADT/SmallPtrSetTest.cpp
@@ -408,3 +408,49 @@ TEST(SmallPtrSetTest, RemoveIf) {
   Removed = Set.remove_if([](int *Ptr) { return false; });
   EXPECT_FALSE(Removed);
 }
+
+TEST(SmallPtrSetTest, Reserve) {
+  // Check that we don't do anything silly when using reserve().
+  SmallPtrSet<int *, 4> Set;
+  int Vals[8] = {0, 1, 2, 3, 4, 5, 6, 7};
+
+  Set.insert(&Vals[0]);
+
+  // We shouldn't reallocate when this happens.
+  Set.reserve(4);
+
+  Set.insert(&Vals[1]);
+  Set.insert(&Vals[2]);
+  Set.insert(&Vals[3]);
+
+  // We shouldn't reallocate this time either.
+  Set.reserve(4);
+  EXPECT_EQ(Set.size(), 4u);
+  EXPECT_TRUE(Set.contains(&Vals[0]));
+  EXPECT_TRUE(Set.contains(&Vals[1]));
+  EXPECT_TRUE(Set.contains(&Vals[2]));
+  EXPECT_TRUE(Set.contains(&Vals[3]));
+
+  // Reserving further should lead to a reallocation.
+  Set.reserve(5);
+  EXPECT_EQ(Set.size(), 4u);
+  EXPECT_TRUE(Set.contains(&Vals[0]));
+  EXPECT_TRUE(Set.contains(&Vals[1]));
+  EXPECT_TRUE(Set.contains(&Vals[2]));
+  EXPECT_TRUE(Set.contains(&Vals[3]));
+
+  // And we should be able to insert another two or three elements without
+  // reallocating.
+  Set.insert(&Vals[4]);
+  Set.insert(&Vals[5]);
+
+  // Calling a smaller reserve size should have no effect.
+  Set.reserve(1);
+  EXPECT_EQ(Set.size(), 6u);
+  EXPECT_TRUE(Set.contains(&Vals[0]));
+  EXPECT_TRUE(Set.contains(&Vals[1]));
+  EXPECT_TRUE(Set.contains(&Vals[2]));
+  EXPECT_TRUE(Set.contains(&Vals[3]));
+  EXPECT_TRUE(Set.contains(&Vals[4]));
+  EXPECT_TRUE(Set.contains(&Vals[5]));
+}

--- a/llvm/unittests/ADT/SmallPtrSetTest.cpp
+++ b/llvm/unittests/ADT/SmallPtrSetTest.cpp
@@ -430,14 +430,16 @@ TEST(SmallPtrSetTest, Reserve) {
   Set.reserve(4);
   EXPECT_EQ(Set.capacity(), 4u);
   EXPECT_EQ(Set.size(), 4u);
-  EXPECT_THAT(Set, UnorderedElementsAre(&Vals[0], &Vals[1], &Vals[2], &Vals[3]));
+  EXPECT_THAT(Set,
+              UnorderedElementsAre(&Vals[0], &Vals[1], &Vals[2], &Vals[3]));
 
   // Reserving further should lead to a reallocation. And matching the existing
   // insertion approach, we immediately allocate up to 128 elements.
   Set.reserve(5);
   EXPECT_EQ(Set.capacity(), 128u);
   EXPECT_EQ(Set.size(), 4u);
-  EXPECT_THAT(Set, UnorderedElementsAre(&Vals[0], &Vals[1], &Vals[2], &Vals[3]));
+  EXPECT_THAT(Set,
+              UnorderedElementsAre(&Vals[0], &Vals[1], &Vals[2], &Vals[3]));
 
   // And we should be able to insert another two or three elements without
   // reallocating.


### PR DESCRIPTION
As per the LLVM programmers manual, SmallSets do linear scans on insertion and then turn into a hash-table if the set gets big. Here in the IDFCalculator, the SmallSets have been configured to have 32 elements in each static allocation... which means that we linearly scan for all problems with up to 32 elements, which I feel is quite a large N.

Replace these SmallSets with a plain DenseSet (and use reserve to avoid any repeated allocations). Doing this yields a 0.13% compile-time improvement for debug-info builds, as we hit IDFCalculator pretty hard in InstrRefBasedLDV. Adding @nikic as this could affect more than debug-info things, although apparently not in a visible way on CTMark.

http://llvm-compile-time-tracker.com/compare.php?from=4ce6cc488083a931e795dafe30e69a0e4a96a3e4&to=a9f1d377013b1d208ac58f6f75548f1f24d174d2&stat=instructions%3Au

(tracker link is across a few commits, with this patch being the summary).