### PR TITLE
[llvm][TargetParser] Return StringMap from getHostCPUFeatures

### DIFF
--- a/clang/lib/Driver/ToolChains/Arch/ARM.cpp
+++ b/clang/lib/Driver/ToolChains/Arch/ARM.cpp
@@ -591,9 +591,9 @@ llvm::ARM::FPUKind arm::getARMTargetFeatures(const Driver &D,
 
   // Add CPU features for generic CPUs
   if (CPUName == "native") {
-    llvm::StringMap<bool> HostFeatures;
-    if (llvm::sys::getHostCPUFeatures(HostFeatures))
-      for (auto &F : HostFeatures)
+    if (std::optional<llvm::StringMap<bool>> HostFeatures =
+            llvm::sys::getHostCPUFeatures())
+      for (auto &F : *HostFeatures)
         Features.push_back(
             Args.MakeArgString((F.second ? "+" : "-") + F.first()));
   } else if (!CPUName.empty()) {

--- a/clang/lib/Driver/ToolChains/Arch/ARM.cpp
+++ b/clang/lib/Driver/ToolChains/Arch/ARM.cpp
@@ -591,11 +591,9 @@ llvm::ARM::FPUKind arm::getARMTargetFeatures(const Driver &D,
 
   // Add CPU features for generic CPUs
   if (CPUName == "native") {
-    if (std::optional<llvm::StringMap<bool>> HostFeatures =
-            llvm::sys::getHostCPUFeatures())
-      for (auto &F : *HostFeatures)
-        Features.push_back(
-            Args.MakeArgString((F.second ? "+" : "-") + F.first()));
+    for (auto &F : llvm::sys::getHostCPUFeatures())
+      Features.push_back(
+          Args.MakeArgString((F.second ? "+" : "-") + F.first()));
   } else if (!CPUName.empty()) {
     // This sets the default features for the specified CPU. We certainly don't
     // want to override the features that have been explicitly specified on the

--- a/clang/lib/Driver/ToolChains/Arch/X86.cpp
+++ b/clang/lib/Driver/ToolChains/Arch/X86.cpp
@@ -131,9 +131,9 @@ void x86::getX86TargetFeatures(const Driver &D, const llvm::Triple &Triple,
   // If -march=native, autodetect the feature list.
   if (const Arg *A = Args.getLastArg(clang::driver::options::OPT_march_EQ)) {
     if (StringRef(A->getValue()) == "native") {
-      llvm::StringMap<bool> HostFeatures;
-      if (llvm::sys::getHostCPUFeatures(HostFeatures))
-        for (auto &F : HostFeatures)
+      if (std::optional<llvm::StringMap<bool>> HostFeatures =
+              llvm::sys::getHostCPUFeatures())
+        for (auto &F : *HostFeatures)
           Features.push_back(
               Args.MakeArgString((F.second ? "+" : "-") + F.first()));
     }

--- a/clang/lib/Driver/ToolChains/Arch/X86.cpp
+++ b/clang/lib/Driver/ToolChains/Arch/X86.cpp
@@ -131,11 +131,9 @@ void x86::getX86TargetFeatures(const Driver &D, const llvm::Triple &Triple,
   // If -march=native, autodetect the feature list.
   if (const Arg *A = Args.getLastArg(clang::driver::options::OPT_march_EQ)) {
     if (StringRef(A->getValue()) == "native") {
-      if (std::optional<llvm::StringMap<bool>> HostFeatures =
-              llvm::sys::getHostCPUFeatures())
-        for (auto &F : *HostFeatures)
-          Features.push_back(
-              Args.MakeArgString((F.second ? "+" : "-") + F.first()));
+      for (auto &F : llvm::sys::getHostCPUFeatures())
+        Features.push_back(
+            Args.MakeArgString((F.second ? "+" : "-") + F.first()));
     }
   }
 

--- a/lldb/utils/lit-cpuid/lit-cpuid.cpp
+++ b/lldb/utils/lit-cpuid/lit-cpuid.cpp
@@ -15,22 +15,23 @@
 #include "llvm/Support/raw_ostream.h"
 #include "llvm/TargetParser/Host.h"
 
+#include <optional>
+
 using namespace llvm;
 
 int main(int argc, char **argv) {
 #if defined(__i386__) || defined(_M_IX86) || \
     defined(__x86_64__) || defined(_M_X64)
-  StringMap<bool> features;
-
-  if (!sys::getHostCPUFeatures(features))
+  if (std::optional<StringMap<bool>> features =
+          sys::getHostCPUFeatures(features)) {
+    if ((*features)["sse"])
+      outs() << "sse\n";
+    if ((*features)["avx"])
+      outs() << "avx\n";
+    if ((*features)["avx512f"])
+      outs() << "avx512f\n";
+  } else
     return 1;
-
-  if (features["sse"])
-    outs() << "sse\n";
-  if (features["avx"])
-    outs() << "avx\n";
-  if (features["avx512f"])
-    outs() << "avx512f\n";
 #endif
 
   return 0;

--- a/lldb/utils/lit-cpuid/lit-cpuid.cpp
+++ b/lldb/utils/lit-cpuid/lit-cpuid.cpp
@@ -22,13 +22,13 @@ using namespace llvm;
 int main(int argc, char **argv) {
 #if defined(__i386__) || defined(_M_IX86) || \
     defined(__x86_64__) || defined(_M_X64)
-  if (std::optional<StringMap<bool>> features =
+  if (const std::optional<StringMap<bool>> features =
           sys::getHostCPUFeatures(features)) {
-    if ((*features)["sse"])
+    if (features->contains("sse"))
       outs() << "sse\n";
-    if ((*features)["avx"])
+    if (features->contains("avx"))
       outs() << "avx\n";
-    if ((*features)["avx512f"])
+    if (features->contains("avx512f"))
       outs() << "avx512f\n";
   } else
     return 1;

--- a/lldb/utils/lit-cpuid/lit-cpuid.cpp
+++ b/lldb/utils/lit-cpuid/lit-cpuid.cpp
@@ -20,7 +20,7 @@ using namespace llvm;
 int main(int argc, char **argv) {
 #if defined(__i386__) || defined(_M_IX86) || \
     defined(__x86_64__) || defined(_M_X64)
-  const StringMap<bool> features = sys::getHostCPUFeatures(features);
+  const StringMap<bool> features = sys::getHostCPUFeatures();
   if (features.empty())
     return 1;
 

--- a/lldb/utils/lit-cpuid/lit-cpuid.cpp
+++ b/lldb/utils/lit-cpuid/lit-cpuid.cpp
@@ -22,16 +22,16 @@ using namespace llvm;
 int main(int argc, char **argv) {
 #if defined(__i386__) || defined(_M_IX86) || \
     defined(__x86_64__) || defined(_M_X64)
-  if (const std::optional<StringMap<bool>> features =
-          sys::getHostCPUFeatures(features)) {
-    if (features->lookup("sse"))
-      outs() << "sse\n";
-    if (features->lookup("avx"))
-      outs() << "avx\n";
-    if (features->lookup("avx512f"))
-      outs() << "avx512f\n";
-  } else
+  const < StringMap<bool> features = sys::getHostCPUFeatures(features);
+  if (features.empty())
     return 1;
+
+  if (features->lookup("sse"))
+    outs() << "sse\n";
+  if (features->lookup("avx"))
+    outs() << "avx\n";
+  if (features->lookup("avx512f"))
+    outs() << "avx512f\n";
 #endif
 
   return 0;

--- a/lldb/utils/lit-cpuid/lit-cpuid.cpp
+++ b/lldb/utils/lit-cpuid/lit-cpuid.cpp
@@ -15,8 +15,6 @@
 #include "llvm/Support/raw_ostream.h"
 #include "llvm/TargetParser/Host.h"
 
-#include <optional>
-
 using namespace llvm;
 
 int main(int argc, char **argv) {

--- a/lldb/utils/lit-cpuid/lit-cpuid.cpp
+++ b/lldb/utils/lit-cpuid/lit-cpuid.cpp
@@ -24,11 +24,11 @@ int main(int argc, char **argv) {
   if (features.empty())
     return 1;
 
-  if (features->lookup("sse"))
+  if (features.lookup("sse"))
     outs() << "sse\n";
-  if (features->lookup("avx"))
+  if (features.lookup("avx"))
     outs() << "avx\n";
-  if (features->lookup("avx512f"))
+  if (features.lookup("avx512f"))
     outs() << "avx512f\n";
 #endif
 

--- a/lldb/utils/lit-cpuid/lit-cpuid.cpp
+++ b/lldb/utils/lit-cpuid/lit-cpuid.cpp
@@ -24,11 +24,11 @@ int main(int argc, char **argv) {
     defined(__x86_64__) || defined(_M_X64)
   if (const std::optional<StringMap<bool>> features =
           sys::getHostCPUFeatures(features)) {
-    if (features->contains("sse"))
+    if (features->lookup("sse"))
       outs() << "sse\n";
-    if (features->contains("avx"))
+    if (features->lookup("avx"))
       outs() << "avx\n";
-    if (features->contains("avx512f"))
+    if (features->lookup("avx512f"))
       outs() << "avx512f\n";
   } else
     return 1;

--- a/lldb/utils/lit-cpuid/lit-cpuid.cpp
+++ b/lldb/utils/lit-cpuid/lit-cpuid.cpp
@@ -20,7 +20,7 @@ using namespace llvm;
 int main(int argc, char **argv) {
 #if defined(__i386__) || defined(_M_IX86) || \
     defined(__x86_64__) || defined(_M_X64)
-  const < StringMap<bool> features = sys::getHostCPUFeatures(features);
+  const StringMap<bool> features = sys::getHostCPUFeatures(features);
   if (features.empty())
     return 1;
 

--- a/llvm/include/llvm/TargetParser/Host.h
+++ b/llvm/include/llvm/TargetParser/Host.h
@@ -52,7 +52,7 @@ namespace sys {
   /// which features may appear in this map, except that they are all valid LLVM
   /// feature names. The map can be empty, for example if feature detection
   /// fails.
-  StringMap<bool, MallocAllocator> getHostCPUFeatures();
+  const StringMap<bool, MallocAllocator> getHostCPUFeatures();
 
   /// This is a function compatible with cl::AddExtraVersionPrinter, which adds
   /// info about the current target triple and detected CPU.

--- a/llvm/include/llvm/TargetParser/Host.h
+++ b/llvm/include/llvm/TargetParser/Host.h
@@ -13,6 +13,7 @@
 #ifndef LLVM_TARGETPARSER_HOST_H
 #define LLVM_TARGETPARSER_HOST_H
 
+#include <optional>
 #include <string>
 
 namespace llvm {
@@ -47,13 +48,12 @@ namespace sys {
   /// The particular format of the names are target dependent, and suitable for
   /// passing as -mattr to the target which matches the host.
   ///
-  /// \param Features - A string mapping feature names to either
-  /// true (if enabled) or false (if disabled). This routine makes no guarantees
-  /// about exactly which features may appear in this map, except that they are
-  /// all valid LLVM feature names.
-  ///
-  /// \return - True on success.
-  bool getHostCPUFeatures(StringMap<bool, MallocAllocator> &Features);
+  /// \return - If feature detection succeeds, a string map mapping feature
+  /// names to either true (if enabled) or false (if disabled). This routine
+  /// makes no guarantees about exactly which features may appear in this map,
+  /// except that they are all valid LLVM feature names. If feature detection
+  /// fails, an empty optional is returned.
+  std::optional<StringMap<bool, MallocAllocator>> getHostCPUFeatures();
 
   /// This is a function compatible with cl::AddExtraVersionPrinter, which adds
   /// info about the current target triple and detected CPU.

--- a/llvm/include/llvm/TargetParser/Host.h
+++ b/llvm/include/llvm/TargetParser/Host.h
@@ -48,12 +48,12 @@ namespace sys {
   /// The particular format of the names are target dependent, and suitable for
   /// passing as -mattr to the target which matches the host.
   ///
-  /// \return - If feature detection succeeds, a string map mapping feature
-  /// names to either true (if enabled) or false (if disabled). This routine
-  /// makes no guarantees about exactly which features may appear in this map,
-  /// except that they are all valid LLVM feature names. If feature detection
-  /// fails, an empty optional is returned.
-  std::optional<StringMap<bool, MallocAllocator>> getHostCPUFeatures();
+  /// \return - A string map mapping feature names to either true (if enabled)
+  /// or false (if disabled). This routine makes no guarantees about exactly
+  /// which features may appear in this map, except that they are all valid LLVM
+  /// feature names. The map can be empty, for example if feature detection
+  /// fails.
+  StringMap<bool, MallocAllocator> getHostCPUFeatures();
 
   /// This is a function compatible with cl::AddExtraVersionPrinter, which adds
   /// info about the current target triple and detected CPU.

--- a/llvm/include/llvm/TargetParser/Host.h
+++ b/llvm/include/llvm/TargetParser/Host.h
@@ -13,7 +13,6 @@
 #ifndef LLVM_TARGETPARSER_HOST_H
 #define LLVM_TARGETPARSER_HOST_H
 
-#include <optional>
 #include <string>
 
 namespace llvm {

--- a/llvm/lib/CodeGen/CommandFlags.cpp
+++ b/llvm/lib/CodeGen/CommandFlags.cpp
@@ -625,9 +625,8 @@ std::string codegen::getFeaturesStr() {
   // features the autodetected CPU name lists in the target. For example,
   // not all Sandybridge processors support AVX.
   if (getMCPU() == "native")
-    if (std::optional<StringMap<bool>> HostFeatures = sys::getHostCPUFeatures())
-      for (const auto &[Feature, IsEnabled] : *HostFeatures)
-        Features.AddFeature(Feature, IsEnabled);
+    for (const auto &[Feature, IsEnabled] : sys::getHostCPUFeatures())
+      Features.AddFeature(Feature, IsEnabled);
 
   for (auto const &MAttr : getMAttrs())
     Features.AddFeature(MAttr);
@@ -643,9 +642,8 @@ std::vector<std::string> codegen::getFeatureList() {
   // features the autodetected CPU name lists in the target. For example,
   // not all Sandybridge processors support AVX.
   if (getMCPU() == "native")
-    if (std::optional<StringMap<bool>> HostFeatures = sys::getHostCPUFeatures())
-      for (const auto &[Feature, IsEnabled] : *HostFeatures)
-        Features.AddFeature(Feature, IsEnabled);
+    for (const auto &[Feature, IsEnabled] : sys::getHostCPUFeatures())
+      Features.AddFeature(Feature, IsEnabled);
 
   for (auto const &MAttr : getMAttrs())
     Features.AddFeature(MAttr);

--- a/llvm/lib/CodeGen/CommandFlags.cpp
+++ b/llvm/lib/CodeGen/CommandFlags.cpp
@@ -624,12 +624,10 @@ std::string codegen::getFeaturesStr() {
   // This is necessary for x86 where the CPU might not support all the
   // features the autodetected CPU name lists in the target. For example,
   // not all Sandybridge processors support AVX.
-  if (getMCPU() == "native") {
-    StringMap<bool> HostFeatures;
-    if (sys::getHostCPUFeatures(HostFeatures))
-      for (const auto &[Feature, IsEnabled] : HostFeatures)
+  if (getMCPU() == "native")
+    if (std::optional<StringMap<bool>> HostFeatures = sys::getHostCPUFeatures())
+      for (const auto &[Feature, IsEnabled] : *HostFeatures)
         Features.AddFeature(Feature, IsEnabled);
-  }
 
   for (auto const &MAttr : getMAttrs())
     Features.AddFeature(MAttr);
@@ -644,12 +642,10 @@ std::vector<std::string> codegen::getFeatureList() {
   // This is necessary for x86 where the CPU might not support all the
   // features the autodetected CPU name lists in the target. For example,
   // not all Sandybridge processors support AVX.
-  if (getMCPU() == "native") {
-    StringMap<bool> HostFeatures;
-    if (sys::getHostCPUFeatures(HostFeatures))
-      for (const auto &[Feature, IsEnabled] : HostFeatures)
+  if (getMCPU() == "native")
+    if (std::optional<StringMap<bool>> HostFeatures = sys::getHostCPUFeatures())
+      for (const auto &[Feature, IsEnabled] : *HostFeatures)
         Features.AddFeature(Feature, IsEnabled);
-  }
 
   for (auto const &MAttr : getMAttrs())
     Features.AddFeature(MAttr);

--- a/llvm/lib/ExecutionEngine/Orc/JITTargetMachineBuilder.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/JITTargetMachineBuilder.cpp
@@ -28,10 +28,8 @@ Expected<JITTargetMachineBuilder> JITTargetMachineBuilder::detectHost() {
   // Retrieve host CPU name and sub-target features and add them to builder.
   // Relocation model, code model and codegen opt level are kept to default
   // values.
-  if (std::optional<StringMap<bool>> FeatureMap =
-          llvm::sys::getHostCPUFeatures())
-    for (auto &Feature : *FeatureMap)
-      TMBuilder.getFeatures().AddFeature(Feature.first(), Feature.second);
+  for (auto &Feature : llvm::sys::getHostCPUFeatures())
+    TMBuilder.getFeatures().AddFeature(Feature.first(), Feature.second);
 
   TMBuilder.setCPU(std::string(llvm::sys::getHostCPUName()));
 

--- a/llvm/lib/ExecutionEngine/Orc/JITTargetMachineBuilder.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/JITTargetMachineBuilder.cpp
@@ -28,7 +28,7 @@ Expected<JITTargetMachineBuilder> JITTargetMachineBuilder::detectHost() {
   // Retrieve host CPU name and sub-target features and add them to builder.
   // Relocation model, code model and codegen opt level are kept to default
   // values.
-  for (auto &Feature : llvm::sys::getHostCPUFeatures())
+  for (const auto &Feature : llvm::sys::getHostCPUFeatures())
     TMBuilder.getFeatures().AddFeature(Feature.first(), Feature.second);
 
   TMBuilder.setCPU(std::string(llvm::sys::getHostCPUName()));

--- a/llvm/lib/ExecutionEngine/Orc/JITTargetMachineBuilder.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/JITTargetMachineBuilder.cpp
@@ -28,10 +28,10 @@ Expected<JITTargetMachineBuilder> JITTargetMachineBuilder::detectHost() {
   // Retrieve host CPU name and sub-target features and add them to builder.
   // Relocation model, code model and codegen opt level are kept to default
   // values.
-  llvm::StringMap<bool> FeatureMap;
-  llvm::sys::getHostCPUFeatures(FeatureMap);
-  for (auto &Feature : FeatureMap)
-    TMBuilder.getFeatures().AddFeature(Feature.first(), Feature.second);
+  if (std::optional<StringMap<bool>> FeatureMap =
+          llvm::sys::getHostCPUFeatures())
+    for (auto &Feature : *FeatureMap)
+      TMBuilder.getFeatures().AddFeature(Feature.first(), Feature.second);
 
   TMBuilder.setCPU(std::string(llvm::sys::getHostCPUName()));
 

--- a/llvm/lib/Target/TargetMachineC.cpp
+++ b/llvm/lib/Target/TargetMachineC.cpp
@@ -363,10 +363,9 @@ char *LLVMGetHostCPUName(void) {
 
 char *LLVMGetHostCPUFeatures(void) {
   SubtargetFeatures Features;
-  StringMap<bool> HostFeatures;
 
-  if (sys::getHostCPUFeatures(HostFeatures))
-    for (const auto &[Feature, IsEnabled] : HostFeatures)
+  if (std::optional<StringMap<bool>> HostFeatures = sys::getHostCPUFeatures())
+    for (const auto &[Feature, IsEnabled] : *HostFeatures)
       Features.AddFeature(Feature, IsEnabled);
 
   return strdup(Features.getString().c_str());

--- a/llvm/lib/Target/TargetMachineC.cpp
+++ b/llvm/lib/Target/TargetMachineC.cpp
@@ -363,10 +363,8 @@ char *LLVMGetHostCPUName(void) {
 
 char *LLVMGetHostCPUFeatures(void) {
   SubtargetFeatures Features;
-
-  if (std::optional<StringMap<bool>> HostFeatures = sys::getHostCPUFeatures())
-    for (const auto &[Feature, IsEnabled] : *HostFeatures)
-      Features.AddFeature(Feature, IsEnabled);
+  for (const auto &[Feature, IsEnabled] : sys::getHostCPUFeatures())
+    Features.AddFeature(Feature, IsEnabled);
 
   return strdup(Features.getString().c_str());
 }

--- a/llvm/lib/TargetParser/Host.cpp
+++ b/llvm/lib/TargetParser/Host.cpp
@@ -1710,7 +1710,7 @@ VendorSignatures getVendorSignature(unsigned *MaxLeaf) {
 
 #if defined(__i386__) || defined(_M_IX86) || \
     defined(__x86_64__) || defined(_M_X64)
-StringMap<bool> sys::getHostCPUFeatures() {
+const StringMap<bool> sys::getHostCPUFeatures() {
   unsigned EAX = 0, EBX = 0, ECX = 0, EDX = 0;
   unsigned MaxLevel;
   StringMap<bool> Features;
@@ -1907,7 +1907,7 @@ StringMap<bool> sys::getHostCPUFeatures() {
   return Features;
 }
 #elif defined(__linux__) && (defined(__arm__) || defined(__aarch64__))
-StringMap<bool> sys::getHostCPUFeatures() {
+const StringMap<bool> sys::getHostCPUFeatures() {
   StringMap<bool> Features;
   std::unique_ptr<llvm::MemoryBuffer> P = getProcCpuinfoContent();
   if (!P)
@@ -1977,7 +1977,7 @@ StringMap<bool> sys::getHostCPUFeatures() {
   return Features;
 }
 #elif defined(_WIN32) && (defined(__aarch64__) || defined(_M_ARM64))
-StringMap<bool> sys::getHostCPUFeatures() {
+const StringMap<bool> sys::getHostCPUFeatures() {
   StringMap<bool> Features;
 
   if (IsProcessorFeaturePresent(PF_ARM_NEON_INSTRUCTIONS_AVAILABLE))
@@ -1991,7 +1991,7 @@ StringMap<bool> sys::getHostCPUFeatures() {
 }
 #elif defined(__linux__) && defined(__loongarch__)
 #include <sys/auxv.h>
-StringMap<bool> sys::getHostCPUFeatures() {
+const StringMap<bool> sys::getHostCPUFeatures() {
   unsigned long hwcap = getauxval(AT_HWCAP);
   bool HasFPU = hwcap & (1UL << 3); // HWCAP_LOONGARCH_FPU
   uint32_t cpucfg2 = 0x2;
@@ -2009,7 +2009,7 @@ StringMap<bool> sys::getHostCPUFeatures() {
   return Features;
 }
 #else
-StringMap<bool> sys::getHostCPUFeatures() { return {}; }
+const StringMap<bool> sys::getHostCPUFeatures() { return {}; }
 #endif
 
 #if __APPLE__


### PR DESCRIPTION
Previously this took a reference to a map and returned a bool to say whether it succeeded. We can return a StringMap instead, as all callers but 1 simply iterated the map if the bool was true, and passed in empty maps as the starting point.

lldb's lit-cpuid did specifically check whether the call failed, but due to the way the x86 routines work this works out the same as checking if the returned map is empty.