### PR TITLE
[libc] Fix readlink tests on 32-bit systems

### DIFF
--- a/libc/test/src/unistd/CMakeLists.txt
+++ b/libc/test/src/unistd/CMakeLists.txt
@@ -262,6 +262,7 @@ add_libc_unittest(
     libc.include.unistd
     libc.src.errno.errno
     libc.src.unistd.readlink
+    libc.src.string.string_utils
     libc.src.unistd.symlink
     libc.src.unistd.unlink
     libc.src.__support.CPP.string_view
@@ -278,6 +279,7 @@ add_libc_unittest(
     libc.include.fcntl
     libc.include.unistd
     libc.src.errno.errno
+    libc.src.string.string_utils
     libc.src.unistd.readlinkat
     libc.src.unistd.symlink
     libc.src.unistd.unlink

--- a/libc/test/src/unistd/readlink_test.cpp
+++ b/libc/test/src/unistd/readlink_test.cpp
@@ -9,6 +9,7 @@
 #include "src/__support/CPP/string_view.h"
 #include "src/errno/libc_errno.h"
 #include "src/unistd/readlink.h"
+#include "src/string/string_utils.h"
 #include "src/unistd/symlink.h"
 #include "src/unistd/unlink.h"
 #include "test/UnitTest/ErrnoSetterMatcher.h"
@@ -30,8 +31,9 @@ TEST(LlvmLibcReadlinkTest, CreateAndUnlink) {
   //   3. Cleanup the symlink created in step #1.
   ASSERT_THAT(LIBC_NAMESPACE::symlink(LINK_VAL, LINK), Succeeds(0));
 
-  char buf[sizeof(LINK_VAL)];
-  ssize_t len = LIBC_NAMESPACE::readlink(LINK, buf, sizeof(buf));
+  char buf[sizeof(FILENAME)];
+  ssize_t len = LIBC_NAMESPACE::readlink(
+      LINK, buf, LIBC_NAMESPACE::internal::string_length(FILENAME));
   ASSERT_ERRNO_SUCCESS();
   ASSERT_EQ(cpp::string_view(buf, len), cpp::string_view(LINK_VAL));
 
@@ -40,7 +42,8 @@ TEST(LlvmLibcReadlinkTest, CreateAndUnlink) {
 
 TEST(LlvmLibcReadlinkTest, ReadlinkInNonExistentPath) {
   using LIBC_NAMESPACE::testing::ErrnoSetterMatcher::Fails;
-  char buf[8];
-  ASSERT_THAT(LIBC_NAMESPACE::readlink("non-existent-link", buf, sizeof(buf)),
+  constexpr auto len = 8;
+  char buf[len];
+  ASSERT_THAT(LIBC_NAMESPACE::readlink("non-existent-link", buf, len),
               Fails(ENOENT));
 }

--- a/libc/test/src/unistd/readlinkat_test.cpp
+++ b/libc/test/src/unistd/readlinkat_test.cpp
@@ -9,6 +9,7 @@
 #include "src/__support/CPP/string_view.h"
 #include "src/errno/libc_errno.h"
 #include "src/unistd/readlinkat.h"
+#include "src/string/string_utils.h"
 #include "src/unistd/symlink.h"
 #include "src/unistd/unlink.h"
 #include "test/UnitTest/ErrnoSetterMatcher.h"
@@ -32,8 +33,9 @@ TEST(LlvmLibcReadlinkatTest, CreateAndUnlink) {
   //   3. Cleanup the symlink created in step #1.
   ASSERT_THAT(LIBC_NAMESPACE::symlink(LINK_VAL, LINK), Succeeds(0));
 
-  char buf[sizeof(LINK_VAL)];
-  ssize_t len = LIBC_NAMESPACE::readlinkat(AT_FDCWD, LINK, buf, sizeof(buf));
+  char buf[sizeof(FILENAME)];
+  ssize_t len = LIBC_NAMESPACE::readlinkat(
+      AT_FDCWD, LINK, buf, LIBC_NAMESPACE::internal::string_length(FILENAME));
   ASSERT_ERRNO_SUCCESS();
   ASSERT_EQ(cpp::string_view(buf, len), cpp::string_view(LINK_VAL));
 
@@ -42,8 +44,9 @@ TEST(LlvmLibcReadlinkatTest, CreateAndUnlink) {
 
 TEST(LlvmLibcReadlinkatTest, ReadlinkInNonExistentPath) {
   using LIBC_NAMESPACE::testing::ErrnoSetterMatcher::Fails;
-  char buf[8];
-  ASSERT_THAT(LIBC_NAMESPACE::readlinkat(AT_FDCWD, "non-existent-link", buf,
-                                         sizeof(buf)),
-              Fails(ENOENT));
+  constexpr auto len = 8;
+  char buf[len];
+  ASSERT_THAT(
+      LIBC_NAMESPACE::readlinkat(AT_FDCWD, "non-existent-link", buf, len),
+      Fails(ENOENT));
 }


### PR DESCRIPTION
Use sizeof in a string literal instead of a CString so we get the right size when creating the buf array.

We also now use strlen(FILENAME) to get the string lenght when calling readlink and readlinkat.