### PR TITLE
[HLSL] Set default DwarfVersion to 4 for HLSL.

### DIFF
--- a/clang/lib/Driver/ToolChains/HLSL.h
+++ b/clang/lib/Driver/ToolChains/HLSL.h
@@ -52,6 +52,9 @@ public:
   static std::optional<std::string> parseTargetProfile(StringRef TargetProfile);
   bool requiresValidation(llvm::opt::DerivedArgList &Args) const;
 
+  // Set default DWARF version to 4 for DXIL uses version 4.
+  unsigned GetDefaultDwarfVersion() const override { return 4; }
+
 private:
   mutable std::unique_ptr<tools::hlsl::Validator> Validator;
 };

--- a/clang/test/Driver/dxc_debug.hlsl
+++ b/clang/test/Driver/dxc_debug.hlsl
@@ -11,4 +11,5 @@
 // CHECK: "-cc1"
 // CHECK-CV-SAME: -gcodeview
 // CHECK-SAME: "-debug-info-kind=constructor"
-// CHECK-DWARF-SAME: -dwarf-version
+// Make sure dwarf-version is 4.
+// CHECK-DWARF-SAME: -dwarf-version=4


### PR DESCRIPTION
Set default DwarfVersion to 4 for HLSL to match DXIL which does not support DwarfVersion 5.

Based on https://registry.khronos.org/SPIR-V/specs/unified1/DebugInfo.html SPIRV is currently using Dwarf4 as well.

This is for the Dwarf Version 5 part of #96912.