### PR TITLE
[llvm-mca] Add optional identifier field to mca::Instruction

### DIFF
--- a/llvm/include/llvm/MCA/Instruction.h
+++ b/llvm/include/llvm/MCA/Instruction.h
@@ -643,6 +643,9 @@ class Instruction : public InstructionBase {
   // True if this instruction has been optimized at register renaming stage.
   bool IsEliminated;
 
+  // Client-dependent identifier for this instruction.
+  std::optional<uint64_t> Identifier;
+
 public:
   Instruction(const InstrDesc &D, const unsigned Opcode)
       : InstructionBase(D, Opcode), Stage(IS_INVALID),
@@ -689,6 +692,9 @@ public:
   bool isExecuted() const { return Stage == IS_EXECUTED; }
   bool isRetired() const { return Stage == IS_RETIRED; }
   bool isEliminated() const { return IsEliminated; }
+
+  std::optional<uint64_t> getIdentifier() const { return Identifier; }
+  void setIdentifier(uint64_t Id) { Identifier = Id; }
 
   // Forces a transition from state IS_DISPATCHED to state IS_EXECUTED.
   void forceExecuted();


### PR DESCRIPTION
While using llvm-mca as a library (in MCA Daemon), we've been having trouble uniquely identifying instructions that go through the pipeline. Inspired by the discussion [here](https://github.com/llvm/llvm-project/pull/92849#discussion_r1621376233), I believe it may make sense to add an optional identifier to each `mca::Instruction`. 

A possible instance of use could be the `InstrBuilder` incrementing the `Identifier` by 1 after each instruction is created. I'm happy to add that too.