### PR TITLE
[libc++] Guard transitive include of `<locale>` with availability macro

### DIFF
--- a/libcxx/include/chrono
+++ b/libcxx/include/chrono
@@ -996,7 +996,9 @@ constexpr chrono::year                                  operator ""y(unsigned lo
 
 #if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER == 20
 #  include <charconv>
-#  include <locale>
+#  if !defined(_LIBCPP_HAS_NO_LOCALIZATION)
+#    include <locale>
+#  endif
 #  include <ostream>
 #endif
 


### PR DESCRIPTION
This is a follow-up to https://github.com/llvm/llvm-project/pull/85521,
similar to https://github.com/llvm/llvm-project/pull/95686.
