### PR TITLE
[CodeGen][NewPM] Port `LiveVariables` to new pass manager

### DIFF
--- a/llvm/include/llvm/InitializePasses.h
+++ b/llvm/include/llvm/InitializePasses.h
@@ -155,7 +155,7 @@ void initializeLiveIntervalsPass(PassRegistry&);
 void initializeLiveRangeShrinkPass(PassRegistry&);
 void initializeLiveRegMatrixPass(PassRegistry&);
 void initializeLiveStacksPass(PassRegistry&);
-void initializeLiveVariablesPass(PassRegistry &);
+void initializeLiveVariablesWrapperPassPass(PassRegistry &);
 void initializeLoadStoreOptPass(PassRegistry &);
 void initializeLoadStoreVectorizerLegacyPassPass(PassRegistry&);
 void initializeLocalStackSlotPassPass(PassRegistry&);

--- a/llvm/include/llvm/Passes/MachinePassRegistry.def
+++ b/llvm/include/llvm/Passes/MachinePassRegistry.def
@@ -89,6 +89,12 @@ LOOP_PASS("loop-reduce", LoopStrengthReducePass())
 #ifndef MACHINE_FUNCTION_ANALYSIS
 #define MACHINE_FUNCTION_ANALYSIS(NAME, CREATE_PASS)
 #endif
+// LiveVariables currently requires pure SSA form.
+// FIXME: Once TwoAddressInstruction pass no longer uses kill flags,
+// LiveVariables can be removed completely, and LiveIntervals can be directly
+// computed. (We still either need to regenerate kill flags after regalloc, or
+// preferably fix the scavenger to not depend on them).
+MACHINE_FUNCTION_ANALYSIS("live-vars", LiveVariablesAnalysis())
 MACHINE_FUNCTION_ANALYSIS("machine-branch-prob",
                           MachineBranchProbabilityAnalysis())
 MACHINE_FUNCTION_ANALYSIS("machine-dom-tree", MachineDominatorTreeAnalysis())
@@ -96,13 +102,6 @@ MACHINE_FUNCTION_ANALYSIS("machine-loops", MachineLoopAnalysis())
 MACHINE_FUNCTION_ANALYSIS("machine-post-dom-tree",
                           MachinePostDominatorTreeAnalysis())
 MACHINE_FUNCTION_ANALYSIS("pass-instrumentation", PassInstrumentationAnalysis(PIC))
-// LiveVariables currently requires pure SSA form.
-// FIXME: Once TwoAddressInstruction pass no longer uses kill flags,
-// LiveVariables can be removed completely, and LiveIntervals can be directly
-// computed. (We still either need to regenerate kill flags after regalloc, or
-// preferably fix the scavenger to not depend on them).
-// MACHINE_FUNCTION_ANALYSIS("live-vars", LiveVariablesAnalysis())
-
 // MACHINE_FUNCTION_ANALYSIS("live-stacks", LiveStacksPass())
 // MACHINE_FUNCTION_ANALYSIS("slot-indexes", SlotIndexesAnalysis())
 // MACHINE_FUNCTION_ANALYSIS("edge-bundles", EdgeBundlesAnalysis())
@@ -133,6 +132,7 @@ MACHINE_FUNCTION_PASS("finalize-isel", FinalizeISelPass())
 MACHINE_FUNCTION_PASS("localstackalloc", LocalStackSlotAllocationPass())
 MACHINE_FUNCTION_PASS("no-op-machine-function", NoOpMachineFunctionPass())
 MACHINE_FUNCTION_PASS("print", PrintMIRPass())
+MACHINE_FUNCTION_PASS("print<live-vars>", LiveVariablesPrinterPass(dbgs()))
 MACHINE_FUNCTION_PASS("print<machine-branch-prob>",
                       MachineBranchProbabilityPrinterPass(dbgs()))
 MACHINE_FUNCTION_PASS("print<machine-dom-tree>",

--- a/llvm/lib/CodeGen/CodeGen.cpp
+++ b/llvm/lib/CodeGen/CodeGen.cpp
@@ -63,7 +63,7 @@ void llvm::initializeCodeGen(PassRegistry &Registry) {
   initializeLiveIntervalsPass(Registry);
   initializeLiveRangeShrinkPass(Registry);
   initializeLiveStacksPass(Registry);
-  initializeLiveVariablesPass(Registry);
+  initializeLiveVariablesWrapperPassPass(Registry);
   initializeLocalStackSlotPassPass(Registry);
   initializeLowerGlobalDtorsLegacyPassPass(Registry);
   initializeLowerIntrinsicsPass(Registry);

--- a/llvm/lib/CodeGen/LiveIntervals.cpp
+++ b/llvm/lib/CodeGen/LiveIntervals.cpp
@@ -85,7 +85,7 @@ cl::opt<bool> UseSegmentSetForPhysRegs(
 
 void LiveIntervals::getAnalysisUsage(AnalysisUsage &AU) const {
   AU.setPreservesCFG();
-  AU.addPreserved<LiveVariables>();
+  AU.addPreserved<LiveVariablesWrapperPass>();
   AU.addPreservedID(MachineLoopInfoID);
   AU.addRequiredTransitiveID(MachineDominatorsID);
   AU.addPreservedID(MachineDominatorsID);

--- a/llvm/lib/CodeGen/MachineBasicBlock.cpp
+++ b/llvm/lib/CodeGen/MachineBasicBlock.cpp
@@ -1171,7 +1171,8 @@ MachineBasicBlock *MachineBasicBlock::SplitCriticalEdge(
   // On some targets like Mips, branches may kill virtual registers. Make sure
   // that LiveVariables is properly updated after updateTerminator replaces the
   // terminators.
-  LiveVariables *LV = P.getAnalysisIfAvailable<LiveVariables>();
+  auto *LVWrapper = P.getAnalysisIfAvailable<LiveVariablesWrapperPass>();
+  LiveVariables *LV = LVWrapper ? &LVWrapper->getLV() : nullptr;
 
   // Collect a list of virtual registers killed by the terminators.
   SmallVector<Register, 4> KilledRegs;

--- a/llvm/lib/CodeGen/MachineVerifier.cpp
+++ b/llvm/lib/CodeGen/MachineVerifier.cpp
@@ -314,7 +314,7 @@ namespace {
 
     void getAnalysisUsage(AnalysisUsage &AU) const override {
       AU.addUsedIfAvailable<LiveStacks>();
-      AU.addUsedIfAvailable<LiveVariables>();
+      AU.addUsedIfAvailable<LiveVariablesWrapperPass>();
       AU.addUsedIfAvailable<SlotIndexes>();
       AU.addUsedIfAvailable<LiveIntervals>();
       AU.setPreservesAll();
@@ -430,8 +430,9 @@ unsigned MachineVerifier::verify(const MachineFunction &MF) {
   if (PASS) {
     LiveInts = PASS->getAnalysisIfAvailable<LiveIntervals>();
     // We don't want to verify LiveVariables if LiveIntervals is available.
+    auto *LVWrapper = PASS->getAnalysisIfAvailable<LiveVariablesWrapperPass>();
     if (!LiveInts)
-      LiveVars = PASS->getAnalysisIfAvailable<LiveVariables>();
+      LiveVars = LVWrapper ? &LVWrapper->getLV() : nullptr;
     LiveStks = PASS->getAnalysisIfAvailable<LiveStacks>();
     Indexes = PASS->getAnalysisIfAvailable<SlotIndexes>();
   }

--- a/llvm/lib/CodeGen/PHIElimination.cpp
+++ b/llvm/lib/CodeGen/PHIElimination.cpp
@@ -131,13 +131,13 @@ char& llvm::PHIEliminationID = PHIElimination::ID;
 INITIALIZE_PASS_BEGIN(PHIElimination, DEBUG_TYPE,
                       "Eliminate PHI nodes for register allocation",
                       false, false)
-INITIALIZE_PASS_DEPENDENCY(LiveVariables)
+INITIALIZE_PASS_DEPENDENCY(LiveVariablesWrapperPass)
 INITIALIZE_PASS_END(PHIElimination, DEBUG_TYPE,
                     "Eliminate PHI nodes for register allocation", false, false)
 
 void PHIElimination::getAnalysisUsage(AnalysisUsage &AU) const {
-  AU.addUsedIfAvailable<LiveVariables>();
-  AU.addPreserved<LiveVariables>();
+  AU.addUsedIfAvailable<LiveVariablesWrapperPass>();
+  AU.addPreserved<LiveVariablesWrapperPass>();
   AU.addPreserved<SlotIndexes>();
   AU.addPreserved<LiveIntervals>();
   AU.addPreserved<MachineDominatorTreeWrapperPass>();
@@ -147,7 +147,8 @@ void PHIElimination::getAnalysisUsage(AnalysisUsage &AU) const {
 
 bool PHIElimination::runOnMachineFunction(MachineFunction &MF) {
   MRI = &MF.getRegInfo();
-  LV = getAnalysisIfAvailable<LiveVariables>();
+  auto *LVWrapper = getAnalysisIfAvailable<LiveVariablesWrapperPass>();
+  LV = LVWrapper ? &LVWrapper->getLV() : nullptr;
   LIS = getAnalysisIfAvailable<LiveIntervals>();
 
   bool Changed = false;

--- a/llvm/lib/CodeGen/TwoAddressInstructionPass.cpp
+++ b/llvm/lib/CodeGen/TwoAddressInstructionPass.cpp
@@ -195,8 +195,8 @@ public:
   void getAnalysisUsage(AnalysisUsage &AU) const override {
     AU.setPreservesCFG();
     AU.addUsedIfAvailable<AAResultsWrapperPass>();
-    AU.addUsedIfAvailable<LiveVariables>();
-    AU.addPreserved<LiveVariables>();
+    AU.addUsedIfAvailable<LiveVariablesWrapperPass>();
+    AU.addPreserved<LiveVariablesWrapperPass>();
     AU.addPreserved<SlotIndexes>();
     AU.addPreserved<LiveIntervals>();
     AU.addPreservedID(MachineLoopInfoID);
@@ -1762,7 +1762,8 @@ bool TwoAddressInstructionPass::runOnMachineFunction(MachineFunction &Func) {
   TII = MF->getSubtarget().getInstrInfo();
   TRI = MF->getSubtarget().getRegisterInfo();
   InstrItins = MF->getSubtarget().getInstrItineraryData();
-  LV = getAnalysisIfAvailable<LiveVariables>();
+  auto *LVWrapper = getAnalysisIfAvailable<LiveVariablesWrapperPass>();
+  LV = LVWrapper ? &LVWrapper->getLV() : nullptr;
   LIS = getAnalysisIfAvailable<LiveIntervals>();
   if (auto *AAPass = getAnalysisIfAvailable<AAResultsWrapperPass>())
     AA = &AAPass->getAAResults();

--- a/llvm/lib/Passes/PassBuilder.cpp
+++ b/llvm/lib/Passes/PassBuilder.cpp
@@ -90,6 +90,7 @@
 #include "llvm/CodeGen/InterleavedAccess.h"
 #include "llvm/CodeGen/InterleavedLoadCombine.h"
 #include "llvm/CodeGen/JMCInstrumenter.h"
+#include "llvm/CodeGen/LiveVariables.h"
 #include "llvm/CodeGen/LocalStackSlotAllocation.h"
 #include "llvm/CodeGen/LowerEmuTLS.h"
 #include "llvm/CodeGen/MIRPrinter.h"

--- a/llvm/lib/Target/AMDGPU/SILowerControlFlow.cpp
+++ b/llvm/lib/Target/AMDGPU/SILowerControlFlow.cpp
@@ -763,7 +763,8 @@ bool SILowerControlFlow::runOnMachineFunction(MachineFunction &MF) {
   // This doesn't actually need LiveIntervals, but we can preserve them.
   LIS = getAnalysisIfAvailable<LiveIntervals>();
   // This doesn't actually need LiveVariables, but we can preserve them.
-  LV = getAnalysisIfAvailable<LiveVariables>();
+  auto *LVWrapper = getAnalysisIfAvailable<LiveVariablesWrapperPass>();
+  LV = LVWrapper ? &LVWrapper->getLV() : nullptr;
   auto *MDTWrapper = getAnalysisIfAvailable<MachineDominatorTreeWrapperPass>();
   MDT = MDTWrapper ? &MDTWrapper->getDomTree() : nullptr;
   MRI = &MF.getRegInfo();

--- a/llvm/lib/Target/AMDGPU/SIOptimizeVGPRLiveRange.cpp
+++ b/llvm/lib/Target/AMDGPU/SIOptimizeVGPRLiveRange.cpp
@@ -147,10 +147,10 @@ public:
   }
 
   void getAnalysisUsage(AnalysisUsage &AU) const override {
-    AU.addRequired<LiveVariables>();
+    AU.addRequired<LiveVariablesWrapperPass>();
     AU.addRequired<MachineDominatorTreeWrapperPass>();
     AU.addRequired<MachineLoopInfoWrapperPass>();
-    AU.addPreserved<LiveVariables>();
+    AU.addPreserved<LiveVariablesWrapperPass>();
     AU.addPreserved<MachineDominatorTreeWrapperPass>();
     AU.addPreserved<MachineLoopInfoWrapperPass>();
     MachineFunctionPass::getAnalysisUsage(AU);
@@ -620,7 +620,7 @@ INITIALIZE_PASS_BEGIN(SIOptimizeVGPRLiveRange, DEBUG_TYPE,
                       "SI Optimize VGPR LiveRange", false, false)
 INITIALIZE_PASS_DEPENDENCY(MachineDominatorTreeWrapperPass)
 INITIALIZE_PASS_DEPENDENCY(MachineLoopInfoWrapperPass)
-INITIALIZE_PASS_DEPENDENCY(LiveVariables)
+INITIALIZE_PASS_DEPENDENCY(LiveVariablesWrapperPass)
 INITIALIZE_PASS_END(SIOptimizeVGPRLiveRange, DEBUG_TYPE,
                     "SI Optimize VGPR LiveRange", false, false)
 
@@ -637,7 +637,7 @@ bool SIOptimizeVGPRLiveRange::runOnMachineFunction(MachineFunction &MF) {
   TRI = &TII->getRegisterInfo();
   MDT = &getAnalysis<MachineDominatorTreeWrapperPass>().getDomTree();
   Loops = &getAnalysis<MachineLoopInfoWrapperPass>().getLI();
-  LV = &getAnalysis<LiveVariables>();
+  LV = &getAnalysis<LiveVariablesWrapperPass>().getLV();
   MRI = &MF.getRegInfo();
 
   if (skipFunction(MF.getFunction()))

--- a/llvm/lib/Target/PowerPC/PPCMIPeephole.cpp
+++ b/llvm/lib/Target/PowerPC/PPCMIPeephole.cpp
@@ -155,11 +155,11 @@ private:
 public:
 
   void getAnalysisUsage(AnalysisUsage &AU) const override {
-    AU.addRequired<LiveVariables>();
+    AU.addRequired<LiveVariablesWrapperPass>();
     AU.addRequired<MachineDominatorTreeWrapperPass>();
     AU.addRequired<MachinePostDominatorTreeWrapperPass>();
     AU.addRequired<MachineBlockFrequencyInfo>();
-    AU.addPreserved<LiveVariables>();
+    AU.addPreserved<LiveVariablesWrapperPass>();
     AU.addPreserved<MachineDominatorTreeWrapperPass>();
     AU.addPreserved<MachinePostDominatorTreeWrapperPass>();
     AU.addPreserved<MachineBlockFrequencyInfo>();
@@ -203,7 +203,7 @@ void PPCMIPeephole::initialize(MachineFunction &MFParm) {
   MDT = &getAnalysis<MachineDominatorTreeWrapperPass>().getDomTree();
   MPDT = &getAnalysis<MachinePostDominatorTreeWrapperPass>().getPostDomTree();
   MBFI = &getAnalysis<MachineBlockFrequencyInfo>();
-  LV = &getAnalysis<LiveVariables>();
+  LV = &getAnalysis<LiveVariablesWrapperPass>().getLV();
   EntryFreq = MBFI->getEntryFreq();
   TII = MF->getSubtarget<PPCSubtarget>().getInstrInfo();
   RegsToUpdate.clear();
@@ -2034,7 +2034,7 @@ INITIALIZE_PASS_BEGIN(PPCMIPeephole, DEBUG_TYPE,
 INITIALIZE_PASS_DEPENDENCY(MachineBlockFrequencyInfo)
 INITIALIZE_PASS_DEPENDENCY(MachineDominatorTreeWrapperPass)
 INITIALIZE_PASS_DEPENDENCY(MachinePostDominatorTreeWrapperPass)
-INITIALIZE_PASS_DEPENDENCY(LiveVariables)
+INITIALIZE_PASS_DEPENDENCY(LiveVariablesWrapperPass)
 INITIALIZE_PASS_END(PPCMIPeephole, DEBUG_TYPE,
                     "PowerPC MI Peephole Optimization", false, false)
 

--- a/llvm/test/CodeGen/X86/live-vars.ll
+++ b/llvm/test/CodeGen/X86/live-vars.ll
@@ -1,0 +1,27 @@
+; RUN: llc -enable-new-pm -mtriple=x86_64-unknown -stop-after=x86-isel %s -o - | llc -passes='print<live-vars>' -x mir 2>&1 | FileCheck %s
+
+define i32 @foo(i32 noundef %0) local_unnamed_addr {
+  %2 = icmp eq i32 %0, 0
+  br i1 %2, label %13, label %3
+
+3:                                                ; preds = %1
+  %4 = add i32 %0, -1
+  %5 = zext i32 %4 to i33
+  %6 = add i32 %0, -2
+  %7 = zext i32 %6 to i33
+  %8 = mul i33 %5, %7
+  %9 = lshr i33 %8, 1
+  %10 = trunc i33 %9 to i32
+  %11 = add i32 %10, %0
+  %12 = add i32 %11, -1
+  br label %13
+
+13:                                               ; preds = %3, %1
+  %14 = phi i32 [ 0, %1 ], [ %12, %3 ]
+  ret i32 %14
+}
+
+; CHECK: Live variables in machine function: foo
+; CHECK: Virtual register '%0':
+; CHECK:   Alive in blocks:
+; CHECK:   Killed by: No instructions.

--- a/llvm/unittests/MI/LiveIntervalTest.cpp
+++ b/llvm/unittests/MI/LiveIntervalTest.cpp
@@ -235,8 +235,8 @@ body: |
 }
 
 static void liveVariablesTest(StringRef MIRFunc,
-                             TestPassT<LiveVariables>::TestFx T,
-                             bool ShouldPass = true) {
+                              TestPassT<LiveVariablesWrapperPass>::TestFx T,
+                              bool ShouldPass = true) {
   SmallString<160> S;
   StringRef MIRString = (Twine(R"MIR(
 ---
@@ -248,7 +248,7 @@ registers:
 body: |
   bb.0:
 )MIR") + Twine(MIRFunc) + Twine("...\n")).toNullTerminatedStringRef(S);
-  doTest<LiveVariables>(MIRString, T, ShouldPass);
+  doTest<LiveVariablesWrapperPass>(MIRString, T, ShouldPass);
 }
 
 } // End of anonymous namespace.
@@ -812,43 +812,49 @@ TEST(LiveIntervalTest, LiveThroughSegments) {
 }
 
 TEST(LiveVariablesTest, recomputeForSingleDefVirtReg_handle_undef1) {
-  liveVariablesTest(R"MIR(
+  liveVariablesTest(
+      R"MIR(
     %0 = IMPLICIT_DEF
     S_NOP 0, implicit %0
     S_NOP 0, implicit undef %0
-)MIR", [](MachineFunction &MF, LiveVariables &LV) {
-     auto &FirstNop = getMI(MF, 1, 0);
-     auto &SecondNop = getMI(MF, 2, 0);
-     EXPECT_TRUE(FirstNop.getOperand(1).isKill());
-     EXPECT_FALSE(SecondNop.getOperand(1).isKill());
+)MIR",
+      [](MachineFunction &MF, LiveVariablesWrapperPass &LVWrapper) {
+        auto &LV = LVWrapper.getLV();
+        auto &FirstNop = getMI(MF, 1, 0);
+        auto &SecondNop = getMI(MF, 2, 0);
+        EXPECT_TRUE(FirstNop.getOperand(1).isKill());
+        EXPECT_FALSE(SecondNop.getOperand(1).isKill());
 
-     Register R = Register::index2VirtReg(0);
-     LV.recomputeForSingleDefVirtReg(R);
+        Register R = Register::index2VirtReg(0);
+        LV.recomputeForSingleDefVirtReg(R);
 
-     EXPECT_TRUE(FirstNop.getOperand(1).isKill());
-     EXPECT_FALSE(SecondNop.getOperand(1).isKill());
-  });
+        EXPECT_TRUE(FirstNop.getOperand(1).isKill());
+        EXPECT_FALSE(SecondNop.getOperand(1).isKill());
+      });
 }
 
 TEST(LiveVariablesTest, recomputeForSingleDefVirtReg_handle_undef2) {
-  liveVariablesTest(R"MIR(
+  liveVariablesTest(
+      R"MIR(
     %0 = IMPLICIT_DEF
     S_NOP 0, implicit %0
     S_NOP 0, implicit undef %0, implicit %0
-)MIR", [](MachineFunction &MF, LiveVariables &LV) {
-     auto &FirstNop = getMI(MF, 1, 0);
-     auto &SecondNop = getMI(MF, 2, 0);
-     EXPECT_FALSE(FirstNop.getOperand(1).isKill());
-     EXPECT_FALSE(SecondNop.getOperand(1).isKill());
-     EXPECT_TRUE(SecondNop.getOperand(2).isKill());
+)MIR",
+      [](MachineFunction &MF, LiveVariablesWrapperPass &LVWrapper) {
+        auto &LV = LVWrapper.getLV();
+        auto &FirstNop = getMI(MF, 1, 0);
+        auto &SecondNop = getMI(MF, 2, 0);
+        EXPECT_FALSE(FirstNop.getOperand(1).isKill());
+        EXPECT_FALSE(SecondNop.getOperand(1).isKill());
+        EXPECT_TRUE(SecondNop.getOperand(2).isKill());
 
-     Register R = Register::index2VirtReg(0);
-     LV.recomputeForSingleDefVirtReg(R);
+        Register R = Register::index2VirtReg(0);
+        LV.recomputeForSingleDefVirtReg(R);
 
-     EXPECT_FALSE(FirstNop.getOperand(1).isKill());
-     EXPECT_FALSE(SecondNop.getOperand(1).isKill());
-     EXPECT_TRUE(SecondNop.getOperand(2).isKill());
-  });
+        EXPECT_FALSE(FirstNop.getOperand(1).isKill());
+        EXPECT_FALSE(SecondNop.getOperand(1).isKill());
+        EXPECT_TRUE(SecondNop.getOperand(2).isKill());
+      });
 }
 
 int main(int argc, char **argv) {


### PR DESCRIPTION
- Port `LiveVariables` to new pass manager.
- Convert to `LiveVariablesWrapperPass` in legacy pass manager.