### PR TITLE
[mlir] Fix missing FuncOps.h.inc

### DIFF
--- a/mlir/lib/Dialect/Affine/Analysis/CMakeLists.txt
+++ b/mlir/lib/Dialect/Affine/Analysis/CMakeLists.txt
@@ -8,6 +8,9 @@ add_mlir_dialect_library(MLIRAffineAnalysis
   ADDITIONAL_HEADER_DIRS
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Dialect/Affine
 
+  DEPENDS
+  MLIRFuncOpsIncGen
+
   LINK_LIBS PUBLIC
   MLIRAffineDialect
   MLIRAnalysis


### PR DESCRIPTION
Closes #84568

Similar to #71691 (reproduce with make -j1)

 /cc @tblah 