### PR TITLE
[libc++][vector] Fixes shrink_to_fit.

### DIFF
--- a/libcxx/include/vector
+++ b/libcxx/include/vector
@@ -1443,7 +1443,11 @@ _LIBCPP_CONSTEXPR_SINCE_CXX20 void vector<_Tp, _Allocator>::shrink_to_fit() _NOE
 #endif // _LIBCPP_HAS_NO_EXCEPTIONS
       allocator_type& __a = this->__alloc();
       __split_buffer<value_type, allocator_type&> __v(size(), size(), __a);
-      __swap_out_circular_buffer(__v);
+      // The Standard mandates shrink_to_fit() does not increase the capacity.
+      // With equal capacity keep the existing buffer. This avoids extra work
+      // due to swapping the elements.
+      if (__v.capacity() < capacity())
+        __swap_out_circular_buffer(__v);
 #ifndef _LIBCPP_HAS_NO_EXCEPTIONS
     } catch (...) {
     }

--- a/libcxx/test/std/containers/sequences/vector/vector.capacity/shrink_to_fit.pass.cpp
+++ b/libcxx/test/std/containers/sequences/vector/vector.capacity/shrink_to_fit.pass.cpp
@@ -71,9 +71,50 @@ TEST_CONSTEXPR_CXX20 bool tests() {
     return true;
 }
 
+#if TEST_STD_VER >= 23
+std::size_t min_bytes = 1000;
+
+template <typename T>
+struct increasing_allocator {
+  using value_type       = T;
+  increasing_allocator() = default;
+  template <typename U>
+  increasing_allocator(const increasing_allocator<U>&) noexcept {}
+  std::allocation_result<T*> allocate_at_least(std::size_t n) {
+    std::size_t allocation_amount = n * sizeof(T);
+    if (allocation_amount < min_bytes)
+      allocation_amount = min_bytes;
+    min_bytes += 1000;
+    return {static_cast<T*>(::operator new(allocation_amount)), allocation_amount};
+  }
+  T* allocate(std::size_t n) { return allocate_at_least(n).ptr; }
+  void deallocate(T* p, std::size_t) noexcept { ::operator delete(static_cast<void*>(p)); }
+};
+
+template <typename T, typename U>
+bool operator==(increasing_allocator<T>, increasing_allocator<U>) {
+  return true;
+}
+
+// https://github.com/llvm/llvm-project/issues/95161
+void test_increasing_allocator() {
+  std::vector<int, increasing_allocator<int>> v;
+  v.push_back(1);
+  assert(is_contiguous_container_asan_correct(v));
+  std::size_t capacity = v.capacity();
+  v.shrink_to_fit();
+  assert(v.capacity() == capacity);
+  assert(v.size() == 1);
+  assert(is_contiguous_container_asan_correct(v));
+}
+#endif // TEST_STD_VER >= 23
+
 int main(int, char**)
 {
     tests();
+#if TEST_STD_VER >= 23
+    test_increasing_allocator();
+#endif
 #if TEST_STD_VER > 17
     static_assert(tests());
 #endif

--- a/libcxx/test/std/containers/sequences/vector/vector.capacity/shrink_to_fit.pass.cpp
+++ b/libcxx/test/std/containers/sequences/vector/vector.capacity/shrink_to_fit.pass.cpp
@@ -72,23 +72,23 @@ TEST_CONSTEXPR_CXX20 bool tests() {
 }
 
 #if TEST_STD_VER >= 23
-std::size_t min_bytes = 1000;
-
 template <typename T>
 struct increasing_allocator {
-  using value_type       = T;
-  increasing_allocator() = default;
+  using value_type         = T;
+  std::size_t min_elements = 1000;
+  increasing_allocator()   = default;
+
   template <typename U>
-  increasing_allocator(const increasing_allocator<U>&) noexcept {}
-  std::allocation_result<T*> allocate_at_least(std::size_t n) {
-    std::size_t allocation_amount = n * sizeof(T);
-    if (allocation_amount < min_bytes)
-      allocation_amount = min_bytes;
-    min_bytes += 1000;
-    return {static_cast<T*>(::operator new(allocation_amount)), allocation_amount};
+  constexpr increasing_allocator(const increasing_allocator<U>& other) noexcept : min_elements(other.min_elements) {}
+
+  constexpr std::allocation_result<T*> allocate_at_least(std::size_t n) {
+    if (n < min_elements)
+      n = min_elements;
+    min_elements += 1000;
+    return std::allocator<T>{}.allocate_at_least(n);
   }
-  T* allocate(std::size_t n) { return allocate_at_least(n).ptr; }
-  void deallocate(T* p, std::size_t) noexcept { ::operator delete(static_cast<void*>(p)); }
+  constexpr T* allocate(std::size_t n) { return allocate_at_least(n).ptr; }
+  constexpr void deallocate(T* p, std::size_t n) noexcept { std::allocator<T>{}.deallocate(p, n); }
 };
 
 template <typename T, typename U>
@@ -97,26 +97,30 @@ bool operator==(increasing_allocator<T>, increasing_allocator<U>) {
 }
 
 // https://github.com/llvm/llvm-project/issues/95161
-void test_increasing_allocator() {
+constexpr bool test_increasing_allocator() {
   std::vector<int, increasing_allocator<int>> v;
   v.push_back(1);
   assert(is_contiguous_container_asan_correct(v));
   std::size_t capacity = v.capacity();
   v.shrink_to_fit();
-  assert(v.capacity() == capacity);
+  assert(v.capacity() <= capacity);
   assert(v.size() == 1);
   assert(is_contiguous_container_asan_correct(v));
+
+  return true;
 }
 #endif // TEST_STD_VER >= 23
 
 int main(int, char**)
 {
-    tests();
-#if TEST_STD_VER >= 23
-    test_increasing_allocator();
-#endif
+  tests();
 #if TEST_STD_VER > 17
     static_assert(tests());
 #endif
+#if TEST_STD_VER >= 23
+    test_increasing_allocator();
+    static_assert(test_increasing_allocator());
+#endif
+
     return 0;
 }


### PR DESCRIPTION
This assures shrink_to_fit does not increase the allocated size.

Partly addresses https://github.com/llvm/llvm-project/issues/95161