### PR TITLE
[clang-installapi] ] Fix potential null pointer dereference in file enumeration

### DIFF
--- a/clang/lib/InstallAPI/HeaderFile.cpp
+++ b/clang/lib/InstallAPI/HeaderFile.cpp
@@ -52,7 +52,7 @@ llvm::Expected<PathSeq> enumerateFiles(FileManager &FM, StringRef Directory) {
       return errorCodeToError(EC);
 
     // Ensure the iterator is valid before dereferencing.
-    if (i == ie || !i->isValid())
+    if (i == ie)
       break;
 
     // Skip files that do not exist. This usually happens for broken symlinks.

--- a/clang/lib/InstallAPI/HeaderFile.cpp
+++ b/clang/lib/InstallAPI/HeaderFile.cpp
@@ -51,8 +51,13 @@ llvm::Expected<PathSeq> enumerateFiles(FileManager &FM, StringRef Directory) {
     if (EC)
       return errorCodeToError(EC);
 
+    Ensure the iterator is valid before dereferencing.
+    if (i == ie || !i->isValid())
+      break;
+
     // Skip files that do not exist. This usually happens for broken symlinks.
-    if (FS.status(i->path()) == std::errc::no_such_file_or_directory)
+    auto StatusOrErr = FS.status(i->path());
+    if (!StatusOrErr || StatusOrErr.getError() == std::errc::no_such_file_or_directory)
       continue;
 
     StringRef Path = i->path();

--- a/clang/lib/InstallAPI/HeaderFile.cpp
+++ b/clang/lib/InstallAPI/HeaderFile.cpp
@@ -51,13 +51,14 @@ llvm::Expected<PathSeq> enumerateFiles(FileManager &FM, StringRef Directory) {
     if (EC)
       return errorCodeToError(EC);
 
-    Ensure the iterator is valid before dereferencing.
+    // Ensure the iterator is valid before dereferencing.
     if (i == ie || !i->isValid())
       break;
 
     // Skip files that do not exist. This usually happens for broken symlinks.
     auto StatusOrErr = FS.status(i->path());
-    if (!StatusOrErr || StatusOrErr.getError() == std::errc::no_such_file_or_directory)
+    if (!StatusOrErr ||
+        StatusOrErr.getError() == std::errc::no_such_file_or_directory)
       continue;
 
     StringRef Path = i->path();


### PR DESCRIPTION
This patch addresses a static analyser concern about a potential null pointer dereference in the clang::installapi::enumerateFiles function.

The recursive_directory_iterator could become invalid (i.e., i.State set to nullptr) when iterating over files.

We now check the validity of the iterator before dereferencing it and handle possible errors from FS.status. This fix ensures safe iteration over the directory entries and prevents crashes due to undefined behavior.