### PR TITLE
[Support] Silence warnings when retrieving exported functions

### DIFF
--- a/llvm/include/llvm/Support/Windows/WindowsSupport.h
+++ b/llvm/include/llvm/Support/Windows/WindowsSupport.h
@@ -245,12 +245,6 @@ std::error_code GetCommandLineArguments(SmallVectorImpl<const char *> &Args,
 std::error_code widenPath(const Twine &Path8, SmallVectorImpl<wchar_t> &Path16,
                           size_t MaxPathLen = MAX_PATH);
 
-/// Dynamically retrieve an exported function from a DLL, while casting it to a
-/// known type. This avoids -Wcast-function-type-mismatch.
-template <typename T> T funcFromModule(HMODULE Mod, StringRef Name) {
-  return (T)(void *)::GetProcAddress(Mod, Name.data());
-}
-
 } // end namespace windows
 } // end namespace sys
 } // end namespace llvm.

--- a/llvm/include/llvm/Support/Windows/WindowsSupport.h
+++ b/llvm/include/llvm/Support/Windows/WindowsSupport.h
@@ -245,6 +245,12 @@ std::error_code GetCommandLineArguments(SmallVectorImpl<const char *> &Args,
 std::error_code widenPath(const Twine &Path8, SmallVectorImpl<wchar_t> &Path16,
                           size_t MaxPathLen = MAX_PATH);
 
+/// Dynamically retrieve an exported function from a DLL, while casting it to a
+/// known type. This avoids -Wcast-function-type-mismatch.
+template <typename T> T funcFromModule(HMODULE Mod, StringRef Name) {
+  return (T)(void *)::GetProcAddress(Mod, Name.data());
+}
+
 } // end namespace windows
 } // end namespace sys
 } // end namespace llvm.

--- a/llvm/lib/Support/Windows/Process.inc
+++ b/llvm/lib/Support/Windows/Process.inc
@@ -482,8 +482,8 @@ static RTL_OSVERSIONINFOEXW GetWindowsVer() {
     HMODULE hMod = ::GetModuleHandleW(L"ntdll.dll");
     assert(hMod);
 
-    auto getVer = llvm::sys::windows::funcFromModule<RtlGetVersionPtr>(
-        hMod, "RtlGetVersion");
+    auto getVer =
+        (RtlGetVersionPtr)(void *)::GetProcAddress(hMod, "RtlGetVersion");
     assert(getVer);
 
     RTL_OSVERSIONINFOEXW info{};

--- a/llvm/lib/Support/Windows/Process.inc
+++ b/llvm/lib/Support/Windows/Process.inc
@@ -482,7 +482,8 @@ static RTL_OSVERSIONINFOEXW GetWindowsVer() {
     HMODULE hMod = ::GetModuleHandleW(L"ntdll.dll");
     assert(hMod);
 
-    auto getVer = (RtlGetVersionPtr)::GetProcAddress(hMod, "RtlGetVersion");
+    auto getVer = llvm::sys::windows::funcFromModule<RtlGetVersionPtr>(
+        hMod, "RtlGetVersion");
     assert(getVer);
 
     RTL_OSVERSIONINFOEXW info{};

--- a/llvm/lib/Support/Windows/Signals.inc
+++ b/llvm/lib/Support/Windows/Signals.inc
@@ -168,28 +168,30 @@ static bool isDebugHelpInitialized() {
 }
 
 static bool load64BitDebugHelp(void) {
-  using namespace llvm::sys::windows;
-
   HMODULE hLib =
       ::LoadLibraryExA("Dbghelp.dll", NULL, LOAD_LIBRARY_SEARCH_SYSTEM32);
   if (hLib) {
-    fMiniDumpWriteDump =
-        funcFromModule<fpMiniDumpWriteDump>(hLib, "MiniDumpWriteDump");
-    fStackWalk64 = funcFromModule<fpStackWalk64>(hLib, "StackWalk64");
-    fSymGetModuleBase64 =
-        funcFromModule<fpSymGetModuleBase64>(hLib, "SymGetModuleBase64");
-    fSymGetSymFromAddr64 =
-        funcFromModule<fpSymGetSymFromAddr64>(hLib, "SymGetSymFromAddr64");
-    fSymGetLineFromAddr64 =
-        funcFromModule<fpSymGetLineFromAddr64>(hLib, "SymGetLineFromAddr64");
-    fSymGetModuleInfo64 =
-        funcFromModule<fpSymGetModuleInfo64>(hLib, "SymGetModuleInfo64");
-    fSymFunctionTableAccess64 = funcFromModule<fpSymFunctionTableAccess64>(
-        hLib, "SymFunctionTableAccess64");
-    fSymSetOptions = funcFromModule<fpSymSetOptions>(hLib, "SymSetOptions");
-    fSymInitialize = funcFromModule<fpSymInitialize>(hLib, "SymInitialize");
-    fEnumerateLoadedModules = funcFromModule<fpEnumerateLoadedModules>(
-        hLib, "EnumerateLoadedModules64");
+    fMiniDumpWriteDump = (fpMiniDumpWriteDump)(void *)::GetProcAddress(
+        hLib, "MiniDumpWriteDump");
+    fStackWalk64 = (fpStackWalk64)::GetProcAddress(hLib, "StackWalk64");
+    fSymGetModuleBase64 = (fpSymGetModuleBase64)(void *)::GetProcAddress(
+        hLib, "SymGetModuleBase64");
+    fSymGetSymFromAddr64 = (fpSymGetSymFromAddr64)(void *)::GetProcAddress(
+        hLib, "SymGetSymFromAddr64");
+    fSymGetLineFromAddr64 = (fpSymGetLineFromAddr64)(void *)::GetProcAddress(
+        hLib, "SymGetLineFromAddr64");
+    fSymGetModuleInfo64 = (fpSymGetModuleInfo64)(void *)::GetProcAddress(
+        hLib, "SymGetModuleInfo64");
+    fSymFunctionTableAccess64 =
+        (fpSymFunctionTableAccess64)(void *)::GetProcAddress(
+            hLib, "SymFunctionTableAccess64");
+    fSymSetOptions =
+        (fpSymSetOptions)(void *)::GetProcAddress(hLib, "SymSetOptions");
+    fSymInitialize =
+        (fpSymInitialize)(void *)::GetProcAddress(hLib, "SymInitialize");
+    fEnumerateLoadedModules =
+        (fpEnumerateLoadedModules)(void *)::GetProcAddress(
+            hLib, "EnumerateLoadedModules64");
   }
   return isDebugHelpInitialized();
 }

--- a/llvm/lib/Support/Windows/Signals.inc
+++ b/llvm/lib/Support/Windows/Signals.inc
@@ -173,7 +173,7 @@ static bool load64BitDebugHelp(void) {
   if (hLib) {
     fMiniDumpWriteDump = (fpMiniDumpWriteDump)(void *)::GetProcAddress(
         hLib, "MiniDumpWriteDump");
-    fStackWalk64 = (fpStackWalk64)::GetProcAddress(hLib, "StackWalk64");
+    fStackWalk64 = (fpStackWalk64)(void *)::GetProcAddress(hLib, "StackWalk64");
     fSymGetModuleBase64 = (fpSymGetModuleBase64)(void *)::GetProcAddress(
         hLib, "SymGetModuleBase64");
     fSymGetSymFromAddr64 = (fpSymGetSymFromAddr64)(void *)::GetProcAddress(

--- a/llvm/lib/Support/Windows/Signals.inc
+++ b/llvm/lib/Support/Windows/Signals.inc
@@ -168,25 +168,27 @@ static bool isDebugHelpInitialized() {
 }
 
 static bool load64BitDebugHelp(void) {
+  using namespace llvm::sys::windows;
+
   HMODULE hLib =
       ::LoadLibraryExA("Dbghelp.dll", NULL, LOAD_LIBRARY_SEARCH_SYSTEM32);
   if (hLib) {
     fMiniDumpWriteDump =
-        (fpMiniDumpWriteDump)::GetProcAddress(hLib, "MiniDumpWriteDump");
-    fStackWalk64 = (fpStackWalk64)::GetProcAddress(hLib, "StackWalk64");
+        funcFromModule<fpMiniDumpWriteDump>(hLib, "MiniDumpWriteDump");
+    fStackWalk64 = funcFromModule<fpStackWalk64>(hLib, "StackWalk64");
     fSymGetModuleBase64 =
-        (fpSymGetModuleBase64)::GetProcAddress(hLib, "SymGetModuleBase64");
+        funcFromModule<fpSymGetModuleBase64>(hLib, "SymGetModuleBase64");
     fSymGetSymFromAddr64 =
-        (fpSymGetSymFromAddr64)::GetProcAddress(hLib, "SymGetSymFromAddr64");
+        funcFromModule<fpSymGetSymFromAddr64>(hLib, "SymGetSymFromAddr64");
     fSymGetLineFromAddr64 =
-        (fpSymGetLineFromAddr64)::GetProcAddress(hLib, "SymGetLineFromAddr64");
+        funcFromModule<fpSymGetLineFromAddr64>(hLib, "SymGetLineFromAddr64");
     fSymGetModuleInfo64 =
-        (fpSymGetModuleInfo64)::GetProcAddress(hLib, "SymGetModuleInfo64");
-    fSymFunctionTableAccess64 = (fpSymFunctionTableAccess64)::GetProcAddress(
+        funcFromModule<fpSymGetModuleInfo64>(hLib, "SymGetModuleInfo64");
+    fSymFunctionTableAccess64 = funcFromModule<fpSymFunctionTableAccess64>(
         hLib, "SymFunctionTableAccess64");
-    fSymSetOptions = (fpSymSetOptions)::GetProcAddress(hLib, "SymSetOptions");
-    fSymInitialize = (fpSymInitialize)::GetProcAddress(hLib, "SymInitialize");
-    fEnumerateLoadedModules = (fpEnumerateLoadedModules)::GetProcAddress(
+    fSymSetOptions = funcFromModule<fpSymSetOptions>(hLib, "SymSetOptions");
+    fSymInitialize = funcFromModule<fpSymInitialize>(hLib, "SymInitialize");
+    fEnumerateLoadedModules = funcFromModule<fpEnumerateLoadedModules>(
         hLib, "EnumerateLoadedModules64");
   }
   return isDebugHelpInitialized();


### PR DESCRIPTION
Since functions exported from DLLs are type-erased, before this patch I was seeing the new Clang 19 warning `-Wcast-function-type-mismatch`.

This happens when building LLVM on Windows.

Following discussion in https://github.com/llvm/llvm-project/commit/593f708118aef792f434185547f74fedeaf51dd4#commitcomment-143905744