### PR TITLE
[Clang] Fix null pointer dereference in VisitUsingEnumDecl

### DIFF
--- a/clang/lib/Sema/SemaTemplateInstantiateDecl.cpp
+++ b/clang/lib/Sema/SemaTemplateInstantiateDecl.cpp
@@ -3413,6 +3413,10 @@ Decl *TemplateDeclInstantiator::VisitUsingEnumDecl(UsingEnumDecl *D) {
 
   TypeSourceInfo *TSI = SemaRef.SubstType(D->getEnumType(), TemplateArgs,
                                           D->getLocation(), D->getDeclName());
+
+  if (!TSI)
+    return nullptr;
+
   UsingEnumDecl *NewUD =
       UsingEnumDecl::Create(SemaRef.Context, Owner, D->getUsingLoc(),
                             D->getEnumLoc(), D->getLocation(), TSI);


### PR DESCRIPTION
This patch addresses static analyzer concern where TSI could be dereferenced after being assigned a null value from SubstType in clang::TemplateDeclInstantiator::VisitUsingEnumDecl(clang::UsingEnumDecl *).

The fix now checks null value of TSI after the call to SubstType and return nullptr to prevent potential null pointer dereferences when calling UsingEnumDecl::Create() and ensures safe execution.