### PR TITLE
[Clang] Prevent null pointer dereference in TransformUnaryTransformType()

### DIFF
--- a/clang/lib/Sema/TreeTransform.h
+++ b/clang/lib/Sema/TreeTransform.h
@@ -6734,8 +6734,12 @@ QualType TreeTransform<Derived>::TransformUnaryTransformType(
   QualType Result = TL.getType();
   if (Result->isDependentType()) {
     const UnaryTransformType *T = TL.getTypePtr();
-    QualType NewBase =
-      getDerived().TransformType(TL.getUnderlyingTInfo())->getType();
+
+    QualType NewBaseType = getDerived().TransformType(TL.getUnderlyingTInfo());
+    if (!NewBaseType)
+      return QualType();
+    QualType NewBase = NewBaseType->getType();
+
     Result = getDerived().RebuildUnaryTransformType(NewBase,
                                                     T->getUTTKind(),
                                                     TL.getKWLoc());

--- a/clang/lib/Sema/TreeTransform.h
+++ b/clang/lib/Sema/TreeTransform.h
@@ -6736,10 +6736,10 @@ QualType TreeTransform<Derived>::TransformUnaryTransformType(
     const UnaryTransformType *T = TL.getTypePtr();
 
     TypeSourceInfo *NewBaseTSI =
-      getDerived().TransformType(TL.getUnderlyingTInfo());
+        getDerived().TransformType(TL.getUnderlyingTInfo());
     if (!NewBaseTSI)
       return QualType();
-    QualType NewBaseTSI = NewBaseType->getType();
+    QualType NewBase = NewBaseTSI->getType();
 
     Result = getDerived().RebuildUnaryTransformType(NewBase,
                                                     T->getUTTKind(),

--- a/clang/lib/Sema/TreeTransform.h
+++ b/clang/lib/Sema/TreeTransform.h
@@ -6735,10 +6735,11 @@ QualType TreeTransform<Derived>::TransformUnaryTransformType(
   if (Result->isDependentType()) {
     const UnaryTransformType *T = TL.getTypePtr();
 
-    QualType NewBaseType = getDerived().TransformType(TL.getUnderlyingTInfo());
-    if (!NewBaseType)
+    TypeSourceInfo *NewBaseTSI =
+      getDerived().TransformType(TL.getUnderlyingTInfo());
+    if (!NewBaseTSI)
       return QualType();
-    QualType NewBase = NewBaseType->getType();
+    QualType NewBaseTSI = NewBaseType->getType();
 
     Result = getDerived().RebuildUnaryTransformType(NewBase,
                                                     T->getUTTKind(),


### PR DESCRIPTION
This patch adds null check after TransformType call to avoid dereferencing a null pointer when calling getType().