### PR TITLE
[Clang] Guard against null in template instantiation process

### DIFF
--- a/clang/lib/Sema/SemaConcept.cpp
+++ b/clang/lib/Sema/SemaConcept.cpp
@@ -636,6 +636,9 @@ bool Sema::SetupConstraintScope(
             ? FD->getInstantiatedFromMemberFunction()
             : FD->getInstantiatedFromDecl();
 
+    if (!InstantiatedFrom)
+      return true;
+
     InstantiatingTemplate Inst(
         *this, FD->getPointOfInstantiation(),
         Sema::InstantiatingTemplate::ConstraintsCheck{}, InstantiatedFrom,


### PR DESCRIPTION
This patch adds a null check for InstantiatedFrom to prevent dereferencing a null pointer during the template instantiation process in clang::Sema::SetupConstraintScope().

The fix ensures that the function exits early with an appropriate error if the InstantiatedFrom pointer is not valid.