### PR TITLE
[clang] Add -Wimplicit-fallthrough to -Wextra

### DIFF
--- a/clang/include/clang/Basic/DiagnosticGroups.td
+++ b/clang/include/clang/Basic/DiagnosticGroups.td
@@ -1212,6 +1212,7 @@ def Extra : DiagGroup<"extra", [
     CastFunctionTypeMismatch,
     InitStringTooLongMissingNonString,
     WarnUnnecessaryVirtualSpecifier,
+    ImplicitFallthrough,
   ]>;
 
 def Most : DiagGroup<"most", [

--- a/clang/test/Sema/fallthrough-attr.c
+++ b/clang/test/Sema/fallthrough-attr.c
@@ -2,6 +2,7 @@
 // RUN: %clang_cc1 -fsyntax-only -std=gnu99 -verify -Wimplicit-fallthrough %s
 // RUN: %clang_cc1 -fsyntax-only -std=c99 -verify -Wimplicit-fallthrough %s
 // RUN: %clang_cc1 -fsyntax-only -std=c11 -verify -Wimplicit-fallthrough %s
+// RUN: %clang_cc1 -fsyntax-only -std=c11 -verify -Wextra %s
 // RUN: %clang_cc1 -fsyntax-only -std=c2x -DC2X -verify -Wimplicit-fallthrough %s
 
 int fallthrough_attribute_spelling(int n) {

--- a/clang/test/SemaCXX/switch-implicit-fallthrough-macro.cpp
+++ b/clang/test/SemaCXX/switch-implicit-fallthrough-macro.cpp
@@ -3,6 +3,7 @@
 // RUN: %clang_cc1 -fsyntax-only -verify -std=c++1z -Wimplicit-fallthrough -DCLANG_PREFIX -DCOMMAND_LINE_FALLTHROUGH=[[clang::fallthrough]] %s
 // RUN: %clang_cc1 -fsyntax-only -verify -std=c++1z -Wimplicit-fallthrough -DCOMMAND_LINE_FALLTHROUGH=[[clang::fallthrough]] %s
 // RUN: %clang_cc1 -fsyntax-only -verify -std=c++1z -Wimplicit-fallthrough -DCOMMAND_LINE_FALLTHROUGH=[[fallthrough]] -DUNCHOSEN=[[clang::fallthrough]] %s
+// RUN: %clang_cc1 -fsyntax-only -verify -std=c++1z -Wextra -DCOMMAND_LINE_FALLTHROUGH=[[fallthrough]] -DUNCHOSEN=[[clang::fallthrough]] %s
 
 int fallthrough_compatibility_macro_from_command_line(int n) {
   switch (n) {


### PR DESCRIPTION
This patch adds -Wimplicit-fallthrough to -Wextra. GCC already includes it in -Wextra.

This patch also adds a test to check that -Wimplicit-fallthrough is included in -Wextra.

Note: This patch may regress performance when building with -Wextra.
This is because -Wextra requires forming a CFG for every function.
