### PR TITLE
[libc] fix aarch64 GCC build

### DIFF
--- a/libc/hdr/CMakeLists.txt
+++ b/libc/hdr/CMakeLists.txt
@@ -27,8 +27,6 @@ add_proxy_header_library(
   math_macros
   HDRS
     math_macros.h
-  DEPENDS
-    libc.src.__support.macros.properties.compiler
   FULL_BUILD_DEPENDS
     libc.include.llvm-libc-macros.math_macros
     libc.include.math

--- a/libc/hdr/CMakeLists.txt
+++ b/libc/hdr/CMakeLists.txt
@@ -27,6 +27,8 @@ add_proxy_header_library(
   math_macros
   HDRS
     math_macros.h
+  DEPENDS
+    libc.src.__support.macros.properties.compiler
   FULL_BUILD_DEPENDS
     libc.include.llvm-libc-macros.math_macros
     libc.include.math

--- a/libc/hdr/math_macros.h
+++ b/libc/hdr/math_macros.h
@@ -17,8 +17,7 @@
 
 // GCC will include CXX headers when __cplusplus is defined. This behavior
 // can be suppressed by defining _GLIBCXX_INCLUDE_NEXT_C_HEADERS.
-#include "src/__support/macros/properties/compiler.h"
-#ifdef LIBC_COMPILER_IS_GCC
+#if defined(__GNUC__) && !defined(__clang__)
 #define _GLIBCXX_INCLUDE_NEXT_C_HEADERS
 #endif
 #include <math.h>

--- a/libc/hdr/math_macros.h
+++ b/libc/hdr/math_macros.h
@@ -15,6 +15,9 @@
 
 #else // Overlay mode
 
+// GCC will include CXX headers when __cplusplus is defined. This behavior
+// can be suppressed by defining _GLIBCXX_INCLUDE_NEXT_C_HEADERS.
+#define _GLIBCXX_INCLUDE_NEXT_C_HEADERS
 #include <math.h>
 
 // Some older math.h header does not have FP_INT_* constants yet.

--- a/libc/hdr/math_macros.h
+++ b/libc/hdr/math_macros.h
@@ -17,7 +17,10 @@
 
 // GCC will include CXX headers when __cplusplus is defined. This behavior
 // can be suppressed by defining _GLIBCXX_INCLUDE_NEXT_C_HEADERS.
+#include "src/__support/macros/properties/compiler.h"
+#ifdef LIBC_COMPILER_IS_GCC
 #define _GLIBCXX_INCLUDE_NEXT_C_HEADERS
+#endif
 #include <math.h>
 
 // Some older math.h header does not have FP_INT_* constants yet.

--- a/libc/src/__support/File/linux/CMakeLists.txt
+++ b/libc/src/__support/File/linux/CMakeLists.txt
@@ -1,3 +1,4 @@
+# TODO: migrate to proxy headers
 add_object_library(
   file
   SRCS
@@ -8,6 +9,7 @@ add_object_library(
     libc.include.fcntl
     libc.include.stdio
     libc.include.sys_syscall
+    libc.include.sys_stat
     libc.src.__support.CPP.new
     libc.src.__support.OSUtil.osutil
     libc.src.errno.errno

--- a/libc/src/__support/threads/sleep.h
+++ b/libc/src/__support/threads/sleep.h
@@ -22,8 +22,10 @@ LIBC_INLINE void sleep_briefly() {
   __builtin_amdgcn_s_sleep(2);
 #elif defined(LIBC_TARGET_ARCH_IS_X86)
   __builtin_ia32_pause();
-#elif defined(LIBC_TARGET_ARCH_IS_AARCH64)
+#elif defined(LIBC_TARGET_ARCH_IS_AARCH64) && __has_builtin(__builtin_arm_isb)
   __builtin_arm_isb(0xf);
+#elif defined(LIBC_TARGET_ARCH_IS_AARCH64)
+  asm volatile("isb\n" ::: "memory");
 #else
   // Simply do nothing if sleeping isn't supported on this platform.
 #endif

--- a/libc/src/math/generic/cos.cpp
+++ b/libc/src/math/generic/cos.cpp
@@ -61,7 +61,7 @@ LLVM_LIBC_FUNCTION(double, cos, (double x)) {
 
   DoubleDouble y;
   unsigned k;
-  generic::LargeRangeReduction<NO_FMA> range_reduction_large;
+  generic::LargeRangeReduction<NO_FMA> range_reduction_large{};
 
   // |x| < 2^32 (with FMA) or |x| < 2^23 (w/o FMA)
   if (LIBC_LIKELY(x_e < FPBits::EXP_BIAS + FAST_PASS_EXPONENT)) {

--- a/libc/src/math/generic/sin.cpp
+++ b/libc/src/math/generic/sin.cpp
@@ -62,7 +62,7 @@ LLVM_LIBC_FUNCTION(double, sin, (double x)) {
 
   DoubleDouble y;
   unsigned k;
-  generic::LargeRangeReduction<NO_FMA> range_reduction_large;
+  generic::LargeRangeReduction<NO_FMA> range_reduction_large{};
 
   // |x| < 2^32 (with FMA) or |x| < 2^23 (w/o FMA)
   if (LIBC_LIKELY(x_e < FPBits::EXP_BIAS + FAST_PASS_EXPONENT)) {

--- a/libc/src/math/generic/sincos.cpp
+++ b/libc/src/math/generic/sincos.cpp
@@ -63,7 +63,7 @@ LLVM_LIBC_FUNCTION(void, sincos, (double x, double *sin_x, double *cos_x)) {
 
   DoubleDouble y;
   unsigned k;
-  generic::LargeRangeReduction<NO_FMA> range_reduction_large;
+  generic::LargeRangeReduction<NO_FMA> range_reduction_large{};
 
   // |x| < 2^32 (with FMA) or |x| < 2^23 (w/o FMA)
   if (LIBC_LIKELY(x_e < FPBits::EXP_BIAS + FAST_PASS_EXPONENT)) {

--- a/libc/src/search/hsearch.cpp
+++ b/libc/src/search/hsearch.cpp
@@ -14,7 +14,7 @@
 
 namespace LIBC_NAMESPACE {
 LLVM_LIBC_FUNCTION(ENTRY *, hsearch, (ENTRY item, ACTION action)) {
-  ENTRY *result;
+  ENTRY *result = nullptr;
   if (internal::global_hash_table == nullptr) {
     // If global_hash_table is null, we create a new hash table with a minimal
     // capacity. Such hashtable will be expanded as needed.

--- a/libc/startup/linux/aarch64/tls.cpp
+++ b/libc/startup/linux/aarch64/tls.cpp
@@ -80,7 +80,18 @@ void cleanup_tls(uintptr_t addr, uintptr_t size) {
 }
 
 bool set_thread_ptr(uintptr_t val) {
-  __arm_wsr64("tpidr_el0", val);
+// The PR for __arm_wsr64 support in GCC was merged on Dec 6, 2023, and it is
+// not yet usable in 13.3.0
+// https://github.com/gcc-mirror/gcc/commit/fc42900d21abd5eacb7537c3c8ffc5278d510195
+#if __has_builtin(__builtin_arm_wsr64)
+  __builtin_arm_wsr64("tpidr_el0", val);
+#elif __has_builtin(__builtin_aarch64_wsr)
+  __builtin_aarch64_wsr("tpidr_el0", val);
+#elif defined(__GNUC__)
+  asm volatile("msr tpidr_el0, %0" ::"r"(val));
+#else
+#error "Unsupported compiler"
+#endif
   return true;
 }
 } // namespace LIBC_NAMESPACE


### PR DESCRIPTION
This PR fix several build errors on aarch64 targets when building with gcc:
- uninitialized values leading to `Werrors`
- undefined builtin functions
- glibc header pollution