### PR TITLE
[Clang] Protect ObjCMethodList assignment operator against self-assignment

### DIFF
--- a/clang/include/clang/Sema/ObjCMethodList.h
+++ b/clang/include/clang/Sema/ObjCMethodList.h
@@ -37,10 +37,8 @@ struct ObjCMethodList {
         NextAndExtraBits(L.NextAndExtraBits) {}
 
   ObjCMethodList &operator=(const ObjCMethodList &L) {
-    if (this != &L) { // Check for self-assignment
-      MethodAndHasMoreThanOneDecl = L.MethodAndHasMoreThanOneDecl;
-      NextAndExtraBits = L.NextAndExtraBits;
-    }
+    MethodAndHasMoreThanOneDecl = L.MethodAndHasMoreThanOneDecl;
+    NextAndExtraBits = L.NextAndExtraBits;
     return *this;
   }
 

--- a/clang/include/clang/Sema/ObjCMethodList.h
+++ b/clang/include/clang/Sema/ObjCMethodList.h
@@ -37,8 +37,10 @@ struct ObjCMethodList {
         NextAndExtraBits(L.NextAndExtraBits) {}
 
   ObjCMethodList &operator=(const ObjCMethodList &L) {
-    MethodAndHasMoreThanOneDecl = L.MethodAndHasMoreThanOneDecl;
-    NextAndExtraBits = L.NextAndExtraBits;
+    if (this != &L) { // Check for self-assignment
+      MethodAndHasMoreThanOneDecl = L.MethodAndHasMoreThanOneDecl;
+      NextAndExtraBits = L.NextAndExtraBits;
+    }
     return *this;
   }
 

--- a/llvm/include/llvm/ADT/PointerIntPair.h
+++ b/llvm/include/llvm/ADT/PointerIntPair.h
@@ -45,7 +45,9 @@ template <typename Ptr> struct PunnedPointer {
   constexpr operator intptr_t() const { return asInt(); }
 
   constexpr PunnedPointer &operator=(intptr_t V) {
-    std::memcpy(Data, &V, sizeof(Data));
+    if (reinterpret_cast<intptr_t>(Data) != V) {
+      std::memcpy(Data, &V, sizeof(Data));
+    }
     return *this;
   }
 

--- a/llvm/include/llvm/ADT/PointerIntPair.h
+++ b/llvm/include/llvm/ADT/PointerIntPair.h
@@ -45,9 +45,8 @@ template <typename Ptr> struct PunnedPointer {
   constexpr operator intptr_t() const { return asInt(); }
 
   constexpr PunnedPointer &operator=(intptr_t V) {
-    if (reinterpret_cast<intptr_t>(Data) != V) {
+    if (asInt() != V)
       std::memcpy(Data, &V, sizeof(Data));
-    }
     return *this;
   }
 


### PR DESCRIPTION
This patch adds a self-assignment check to the assignment operator of PunnedPointer. The check prevents potential undefined behavior and issues with self-assignment that could arise in use cases such as ObjCMethodList.

By comparing the current integer representation of the stored pointer with the incoming value, the operator avoids unnecessary memory operations when the assigned value is the same as the current value.

