### PR TITLE
Prevent copying of ArenaAllocator

### DIFF
--- a/llvm/include/llvm/Demangle/MicrosoftDemangle.h
+++ b/llvm/include/llvm/Demangle/MicrosoftDemangle.h
@@ -54,6 +54,10 @@ public:
     }
   }
 
+  // Delete the copy constructor and the copy assignment operator.
+  ArenaAllocator(const ArenaAllocator &) = delete;
+  ArenaAllocator &operator=(const ArenaAllocator &) = delete;
+
   char *allocUnalignedBuffer(size_t Size) {
     assert(Head && Head->Buf);
 


### PR DESCRIPTION
This patch removes copy constructor and assignment operator from ArenaAllocator class to prevent resource duplication and ensure it remains non-copyable as per design intent.