### PR TITLE
[ELF] Reinstate the former spelling in the version message

### DIFF
--- a/lld/ELF/Driver.cpp
+++ b/lld/ELF/Driver.cpp
@@ -631,7 +631,7 @@ void LinkerDriver::linkerMain(ArrayRef<const char *> argsArr) {
   // of Libtool. We cannot convince every software developer to migrate to
   // the latest version and re-generate scripts. So we have this hack.
   if (args.hasArg(OPT_v) || args.hasArg(OPT_version))
-    message(getLLDVersion() + ", compatible with GNU linkers");
+    message(getLLDVersion() + " (compatible with GNU linkers)");
 
   if (const char *path = getReproduceOption(args)) {
     // Note that --reproduce is a debug option so you can ignore it

--- a/lld/test/ELF/version.test
+++ b/lld/test/ELF/version.test
@@ -7,4 +7,4 @@
 # RUN: ld.lld -V 2>&1 | FileCheck %s
 # RUN: not ld.lld -V %t/not-exist 2>&1 | FileCheck %s
 
-# CHECK: LLD {{.*}}, compatible with GNU linkers
+# CHECK: LLD {{.+}} (compatible with GNU linkers)


### PR DESCRIPTION
With `LLVM_APPEND_VC_REV=off`, the new version message after #97323
looks like:
```
% /tmp/out/custom2/bin/ld.lld --version
LLD 19.0.0, compatible with GNU linkers
```

A trailing comma after the version string might cause issues with
version detection tools that don't strip it, as seen in the Linux
kernel's scripts/ld-version.sh script.
