### PR TITLE
[clang-tidy] Do not warn on const variables in misc-use-internal-linkage

### DIFF
--- a/clang-tools-extra/clang-tidy/misc/UseInternalLinkageCheck.cpp
+++ b/clang-tools-extra/clang-tidy/misc/UseInternalLinkageCheck.cpp
@@ -121,6 +121,12 @@ void UseInternalLinkageCheck::check(const MatchFinder::MatchResult &Result) {
     return;
   }
   if (const auto *VD = Result.Nodes.getNodeAs<VarDecl>("var")) {
+    // In C++, const variables at file scope have implicit internal linkage,
+    // so we should not warn there. This is not the case in C.
+    // https://eel.is/c++draft/diff#basic-3
+    if (getLangOpts().CPlusPlus && VD->getType().isConstQualified())
+      return;
+
     DiagnosticBuilder DB = diag(VD->getLocation(), Message) << "variable" << VD;
     SourceLocation FixLoc = VD->getTypeSpecStartLoc();
     if (FixLoc.isInvalid() || FixLoc.isMacroID())

--- a/clang-tools-extra/test/clang-tidy/checkers/misc/use-internal-linkage-var.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/misc/use-internal-linkage-var.cpp
@@ -42,3 +42,6 @@ int global_in_extern_c_1;
 }
 
 extern "C" int global_in_extern_c_2;
+
+const int const_global = 123;
+constexpr int constexpr_global = 123;


### PR DESCRIPTION
Since in C++ they already have implicit internal linkage.

Fixes #97947