### PR TITLE
[SimplifyLibCalls] Simplify cabs libcall if real or imaginary part of input is zero

### DIFF
--- a/llvm/lib/Transforms/Utils/SimplifyLibCalls.cpp
+++ b/llvm/lib/Transforms/Utils/SimplifyLibCalls.cpp
@@ -1979,7 +1979,6 @@ Value *LibCallSimplifier::optimizeCAbs(CallInst *CI, IRBuilderBase &B) {
     if (ConstReal->isZeroValue()) {
       IRBuilderBase::FastMathFlagGuard Guard(B);
       B.setFastMathFlags(CI->getFastMathFlags());
-      
       return copyFlags(
           *CI, B.CreateUnaryIntrinsic(Intrinsic::fabs, Imag, nullptr, "cabs"));
     }

--- a/llvm/test/Transforms/InstCombine/cabs-discrete.ll
+++ b/llvm/test/Transforms/InstCombine/cabs-discrete.ll
@@ -40,6 +40,24 @@ define double @fast_cabs(double %real, double %imag) {
   ret double %call
 }
 
+define double @fast_cabs_zero_real(double %imag) {
+; CHECK-LABEL: @fast_cabs_zero_real(
+; CHECK-NEXT:    [[CABS:%.*]] = tail call double @llvm.fabs.f64(double [[IMAG:%.*]])
+; CHECK-NEXT:    ret double [[CABS]]
+;
+  %call = tail call double @cabs(double 0.0, double %imag)
+  ret double %call
+}
+
+define double @fast_cabs_zero_real(double %real) {
+; CHECK-LABEL: @fast_cabs_zero_real(
+; CHECK-NEXT:    [[CABS:%.*]] = tail call double @llvm.fabs.f64(double [[REAL:%.*]])
+; CHECK-NEXT:    ret double [[CABS]]
+;
+  %call = tail call double @cabs(double %real, 0.0)
+  ret double %call
+}
+
 define float @fast_cabsf(float %real, float %imag) {
 ; CHECK-LABEL: @fast_cabsf(
 ; CHECK-NEXT:    [[TMP1:%.*]] = fmul fast float [[REAL:%.*]], [[REAL]]
@@ -52,6 +70,24 @@ define float @fast_cabsf(float %real, float %imag) {
   ret float %call
 }
 
+define float @fast_cabsf_zero_real(float %imag) {
+; CHECK-LABEL: @fast_cabsf_zero_real(
+; CHECK-NEXT:    [[CABS:%.*]] = tail call float @llvm.fabs.f32(float [[IMAG:%.*]])
+; CHECK-NEXT:    ret float [[CABS]]
+;
+  %call = tail call float @cabsf(float 0.0, float %imag)
+  ret float %call
+}
+
+define float @fast_cabsf_zero_real(float %real) {
+; CHECK-LABEL: @fast_cabsf_zero_real(
+; CHECK-NEXT:    [[CABS:%.*]] = tail call float @llvm.fabs.f64(float [[REAL:%.*]])
+; CHECK-NEXT:    ret float [[CABS]]
+;
+  %call = tail call float @cabsf(float %real, 0.0)
+  ret float %call
+}
+
 define fp128 @fast_cabsl(fp128 %real, fp128 %imag) {
 ; CHECK-LABEL: @fast_cabsl(
 ; CHECK-NEXT:    [[TMP1:%.*]] = fmul fast fp128 [[REAL:%.*]], [[REAL]]
@@ -61,6 +97,24 @@ define fp128 @fast_cabsl(fp128 %real, fp128 %imag) {
 ; CHECK-NEXT:    ret fp128 [[CABS]]
 ;
   %call = tail call fast fp128 @cabsl(fp128 %real, fp128 %imag)
+  ret fp128 %call
+}
+
+define fp128 @fast_cabsl_zero_real(fp128 %imag) {
+; CHECK-LABEL: @fast_cabsl_zero_real(
+; CHECK-NEXT:    [[CABS:%.*]] = tail call fp128 @llvm.fabsl.f128(fp128 [[IMAG:%.*]])
+; CHECK-NEXT:    ret fp128 [[CABS]]
+;
+  %call = tail call fp128 @cabsl(double 0.0, fp128 %imag)
+  ret fp128 %call
+}
+
+define fp128 @fast_cabsl_zero_real(fp128 %real) {
+; CHECK-LABEL: @fast_cabsl_zero_real(
+; CHECK-NEXT:    [[CABS:%.*]] = tail call fp128 @llvm.fabs.f128(fp128 [[REAL:%.*]])
+; CHECK-NEXT:    ret fp128 [[CABS]]
+;
+  %call = tail call fp128 @cabsl(fp128 %real, 0.0)
   ret fp128 %call
 }
 

--- a/llvm/test/Transforms/InstCombine/cabs-discrete.ll
+++ b/llvm/test/Transforms/InstCombine/cabs-discrete.ll
@@ -49,12 +49,12 @@ define double @fast_cabs_zero_real(double %imag) {
   ret double %call
 }
 
-define double @fast_cabs_zero_real(double %real) {
-; CHECK-LABEL: @fast_cabs_zero_real(
+define double @fast_cabs_zero_imag(double %real) {
+; CHECK-LABEL: @fast_cabs_zero_imag(
 ; CHECK-NEXT:    [[CABS:%.*]] = tail call double @llvm.fabs.f64(double [[REAL:%.*]])
 ; CHECK-NEXT:    ret double [[CABS]]
 ;
-  %call = tail call double @cabs(double %real, 0.0)
+  %call = tail call double @cabs(double %real, double 0.0)
   ret double %call
 }
 
@@ -79,12 +79,12 @@ define float @fast_cabsf_zero_real(float %imag) {
   ret float %call
 }
 
-define float @fast_cabsf_zero_real(float %real) {
-; CHECK-LABEL: @fast_cabsf_zero_real(
+define float @fast_cabsf_zero_imag(float %real) {
+; CHECK-LABEL: @fast_cabsf_zero_imag(
 ; CHECK-NEXT:    [[CABS:%.*]] = tail call float @llvm.fabs.f64(float [[REAL:%.*]])
 ; CHECK-NEXT:    ret float [[CABS]]
 ;
-  %call = tail call float @cabsf(float %real, 0.0)
+  %call = tail call float @cabsf(float %real, float 0.0)
   ret float %call
 }
 
@@ -109,12 +109,12 @@ define fp128 @fast_cabsl_zero_real(fp128 %imag) {
   ret fp128 %call
 }
 
-define fp128 @fast_cabsl_zero_real(fp128 %real) {
-; CHECK-LABEL: @fast_cabsl_zero_real(
+define fp128 @fast_cabsl_zero_imag(fp128 %real) {
+; CHECK-LABEL: @fast_cabsl_zero_imag(
 ; CHECK-NEXT:    [[CABS:%.*]] = tail call fp128 @llvm.fabs.f128(fp128 [[REAL:%.*]])
 ; CHECK-NEXT:    ret fp128 [[CABS]]
 ;
-  %call = tail call fp128 @cabsl(fp128 %real, 0.0)
+  %call = tail call fp128 @cabsl(fp128 %real, fp128 0.0)
   ret fp128 %call
 }
 

--- a/llvm/test/Transforms/InstCombine/cabs-discrete.ll
+++ b/llvm/test/Transforms/InstCombine/cabs-discrete.ll
@@ -49,6 +49,15 @@ define double @fast_cabs_zero_real(double %imag) {
   ret double %call
 }
 
+define double @fast_cabs_neg_zero_real(double %imag) {
+; CHECK-LABEL: @fast_cabs_neg_zero_real(
+; CHECK-NEXT:    [[CABS:%.*]] = tail call double @llvm.fabs.f64(double [[IMAG:%.*]])
+; CHECK-NEXT:    ret double [[CABS]]
+;
+  %call = tail call double @cabs(double -0.0, double %imag)
+  ret double %call
+}
+
 define double @fast_cabs_zero_imag(double %real) {
 ; CHECK-LABEL: @fast_cabs_zero_imag(
 ; CHECK-NEXT:    [[CABS:%.*]] = tail call double @llvm.fabs.f64(double [[REAL:%.*]])
@@ -79,9 +88,18 @@ define float @fast_cabsf_zero_real(float %imag) {
   ret float %call
 }
 
+define float @fast_cabsf_neg_zero_real(float %imag) {
+; CHECK-LABEL: @fast_cabsf_neg_zero_real(
+; CHECK-NEXT:    [[CABS:%.*]] = tail call float @llvm.fabs.f32(float [[IMAG:%.*]])
+; CHECK-NEXT:    ret float [[CABS]]
+;
+  %call = tail call float @cabsf(float -0.0, float %imag)
+  ret float %call
+}
+
 define float @fast_cabsf_zero_imag(float %real) {
 ; CHECK-LABEL: @fast_cabsf_zero_imag(
-; CHECK-NEXT:    [[CABS:%.*]] = tail call float @llvm.fabs.f64(float [[REAL:%.*]])
+; CHECK-NEXT:    [[CABS:%.*]] = tail call float @llvm.fabs.f32(float [[REAL:%.*]])
 ; CHECK-NEXT:    ret float [[CABS]]
 ;
   %call = tail call float @cabsf(float %real, float 0.0)
@@ -102,10 +120,10 @@ define fp128 @fast_cabsl(fp128 %real, fp128 %imag) {
 
 define fp128 @fast_cabsl_zero_real(fp128 %imag) {
 ; CHECK-LABEL: @fast_cabsl_zero_real(
-; CHECK-NEXT:    [[CABS:%.*]] = tail call fp128 @llvm.fabsl.f128(fp128 [[IMAG:%.*]])
+; CHECK-NEXT:    [[CABS:%.*]] = tail call fp128 @llvm.fabs.f128(fp128 [[IMAG:%.*]])
 ; CHECK-NEXT:    ret fp128 [[CABS]]
 ;
-  %call = tail call fp128 @cabsl(double 0.0, fp128 %imag)
+  %call = tail call fp128 @cabsl(fp128 0xL00000000000000000000000000000000, fp128 %imag)
   ret fp128 %call
 }
 
@@ -114,7 +132,16 @@ define fp128 @fast_cabsl_zero_imag(fp128 %real) {
 ; CHECK-NEXT:    [[CABS:%.*]] = tail call fp128 @llvm.fabs.f128(fp128 [[REAL:%.*]])
 ; CHECK-NEXT:    ret fp128 [[CABS]]
 ;
-  %call = tail call fp128 @cabsl(fp128 %real, fp128 0.0)
+  %call = tail call fp128 @cabsl(fp128 %real, fp128 0xL00000000000000000000000000000000)
+  ret fp128 %call
+}
+
+define fp128 @fast_cabsl_neg_zero_imag(fp128 %real) {
+; CHECK-LABEL: @fast_cabsl_neg_zero_imag(
+; CHECK-NEXT:    [[CABS:%.*]] = tail call fp128 @llvm.fabs.f128(fp128 [[REAL:%.*]])
+; CHECK-NEXT:    ret fp128 [[CABS]]
+;
+  %call = tail call fp128 @cabsl(fp128 %real, fp128 0xL80000000000000000000000000000000)
   ret fp128 %call
 }
 

--- a/llvm/test/Transforms/InstCombine/cabs-discrete.ll
+++ b/llvm/test/Transforms/InstCombine/cabs-discrete.ll
@@ -40,8 +40,8 @@ define double @fast_cabs(double %real, double %imag) {
   ret double %call
 }
 
-define double @fast_cabs_zero_real(double %imag) {
-; CHECK-LABEL: @fast_cabs_zero_real(
+define double @cabs_zero_real(double %imag) {
+; CHECK-LABEL: @cabs_zero_real(
 ; CHECK-NEXT:    [[CABS:%.*]] = tail call double @llvm.fabs.f64(double [[IMAG:%.*]])
 ; CHECK-NEXT:    ret double [[CABS]]
 ;
@@ -51,15 +51,15 @@ define double @fast_cabs_zero_real(double %imag) {
 
 define double @fast_cabs_neg_zero_real(double %imag) {
 ; CHECK-LABEL: @fast_cabs_neg_zero_real(
-; CHECK-NEXT:    [[CABS:%.*]] = tail call double @llvm.fabs.f64(double [[IMAG:%.*]])
+; CHECK-NEXT:    [[CABS:%.*]] = tail call fast double @llvm.fabs.f64(double [[IMAG:%.*]])
 ; CHECK-NEXT:    ret double [[CABS]]
 ;
-  %call = tail call double @cabs(double -0.0, double %imag)
+  %call = tail call fast double @cabs(double -0.0, double %imag)
   ret double %call
 }
 
-define double @fast_cabs_zero_imag(double %real) {
-; CHECK-LABEL: @fast_cabs_zero_imag(
+define double @cabs_zero_imag(double %real) {
+; CHECK-LABEL: @cabs_zero_imag(
 ; CHECK-NEXT:    [[CABS:%.*]] = tail call double @llvm.fabs.f64(double [[REAL:%.*]])
 ; CHECK-NEXT:    ret double [[CABS]]
 ;
@@ -79,8 +79,8 @@ define float @fast_cabsf(float %real, float %imag) {
   ret float %call
 }
 
-define float @fast_cabsf_zero_real(float %imag) {
-; CHECK-LABEL: @fast_cabsf_zero_real(
+define float @cabsf_zero_real(float %imag) {
+; CHECK-LABEL: @cabsf_zero_real(
 ; CHECK-NEXT:    [[CABS:%.*]] = tail call float @llvm.fabs.f32(float [[IMAG:%.*]])
 ; CHECK-NEXT:    ret float [[CABS]]
 ;
@@ -90,15 +90,15 @@ define float @fast_cabsf_zero_real(float %imag) {
 
 define float @fast_cabsf_neg_zero_real(float %imag) {
 ; CHECK-LABEL: @fast_cabsf_neg_zero_real(
-; CHECK-NEXT:    [[CABS:%.*]] = tail call float @llvm.fabs.f32(float [[IMAG:%.*]])
+; CHECK-NEXT:    [[CABS:%.*]] = tail call fast float @llvm.fabs.f32(float [[IMAG:%.*]])
 ; CHECK-NEXT:    ret float [[CABS]]
 ;
-  %call = tail call float @cabsf(float -0.0, float %imag)
+  %call = tail call fast float @cabsf(float -0.0, float %imag)
   ret float %call
 }
 
-define float @fast_cabsf_zero_imag(float %real) {
-; CHECK-LABEL: @fast_cabsf_zero_imag(
+define float @cabsf_zero_imag(float %real) {
+; CHECK-LABEL: @cabsf_zero_imag(
 ; CHECK-NEXT:    [[CABS:%.*]] = tail call float @llvm.fabs.f32(float [[REAL:%.*]])
 ; CHECK-NEXT:    ret float [[CABS]]
 ;
@@ -118,8 +118,8 @@ define fp128 @fast_cabsl(fp128 %real, fp128 %imag) {
   ret fp128 %call
 }
 
-define fp128 @fast_cabsl_zero_real(fp128 %imag) {
-; CHECK-LABEL: @fast_cabsl_zero_real(
+define fp128 @cabsl_zero_real(fp128 %imag) {
+; CHECK-LABEL: @cabsl_zero_real(
 ; CHECK-NEXT:    [[CABS:%.*]] = tail call fp128 @llvm.fabs.f128(fp128 [[IMAG:%.*]])
 ; CHECK-NEXT:    ret fp128 [[CABS]]
 ;
@@ -127,8 +127,8 @@ define fp128 @fast_cabsl_zero_real(fp128 %imag) {
   ret fp128 %call
 }
 
-define fp128 @fast_cabsl_zero_imag(fp128 %real) {
-; CHECK-LABEL: @fast_cabsl_zero_imag(
+define fp128 @cabsl_zero_imag(fp128 %real) {
+; CHECK-LABEL: @cabsl_zero_imag(
 ; CHECK-NEXT:    [[CABS:%.*]] = tail call fp128 @llvm.fabs.f128(fp128 [[REAL:%.*]])
 ; CHECK-NEXT:    ret fp128 [[CABS]]
 ;
@@ -138,10 +138,10 @@ define fp128 @fast_cabsl_zero_imag(fp128 %real) {
 
 define fp128 @fast_cabsl_neg_zero_imag(fp128 %real) {
 ; CHECK-LABEL: @fast_cabsl_neg_zero_imag(
-; CHECK-NEXT:    [[CABS:%.*]] = tail call fp128 @llvm.fabs.f128(fp128 [[REAL:%.*]])
+; CHECK-NEXT:    [[CABS:%.*]] = tail call fast fp128 @llvm.fabs.f128(fp128 [[REAL:%.*]])
 ; CHECK-NEXT:    ret fp128 [[CABS]]
 ;
-  %call = tail call fp128 @cabsl(fp128 %real, fp128 0xL80000000000000000000000000000000)
+  %call = tail call fast fp128 @cabsl(fp128 %real, fp128 0xL00000000000000008000000000000000)
   ret fp128 %call
 }
 


### PR DESCRIPTION
cabs(a + i0) -> abs(a)
cabs(0 +ib) -> abs(b)

Closes #97336
