### PR TITLE
[sanitizer_common] Fix TgKill on Solaris

### DIFF
--- a/compiler-rt/lib/sanitizer_common/sanitizer_linux.cpp
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_linux.cpp
@@ -563,7 +563,9 @@ int TgKill(pid_t pid, tid_t tid, int sig) {
   return internal_syscall(SYSCALL(thr_kill2), pid, tid, sig);
 #    elif SANITIZER_SOLARIS
   (void)pid;
-  return thr_kill(tid, sig);
+  errno = thr_kill(tid, sig);
+  // TgKill is expected to return -1 on error, not an errno.
+  return errno != 0 ? -1 : 0;
 #    endif
 }
 #  endif


### PR DESCRIPTION
While working on safestack on Solaris, I noticed that the `TgKill` implementation is wrong here: `TgKill` is supposed to return `-1` on error, while `thr_kill` returns `errno` instead.  This patch compensates for that.

This went unnoticed so far since `TgKill` has been unused.

Tested on `amd64-pc-solaris2.11` and `sparcv9-sun-solaris2.11` together with a subsequent patch to make safestack actually work on Solaris.