### PR TITLE
[safestack] Support multilib testing

### DIFF
--- a/compiler-rt/test/safestack/CMakeLists.txt
+++ b/compiler-rt/test/safestack/CMakeLists.txt
@@ -1,29 +1,40 @@
 set(SAFESTACK_LIT_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR})
 set(SAFESTACK_LIT_BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR})
 
+set(SAFESTACK_TESTSUITES)
 set(SAFESTACK_TEST_DEPS ${SANITIZER_COMMON_LIT_TEST_DEPS})
 list(APPEND SAFESTACK_TEST_DEPS safestack)
-if(NOT COMPILER_RT_STANDALONE_BUILD)
-  # Some tests require LTO, so add a dependency on the relevant LTO plugin.
-  if(LLVM_ENABLE_PIC)
-    if(LLVM_BINUTILS_INCDIR)
-      list(APPEND SAFESTACK_TEST_DEPS
-        LLVMgold
-      )
-    endif()
-    if(APPLE)
-      list(APPEND SAFESTACK_TEST_DEPS
-        LTO
-      )
+
+macro(add_safestack_testsuite test_mode sanitizer arch)
+  set(SAFESTACK_LIT_TEST_MODE "${test_mode}")
+  set(CONFIG_NAME ${SAFESTACK_LIT_TEST_MODE})
+
+  if(NOT COMPILER_RT_STANDALONE_BUILD)
+    # Some tests require LTO, so add a dependency on the relevant LTO plugin.
+    if(LLVM_ENABLE_PIC)
+      if(LLVM_BINUTILS_INCDIR)
+        list(APPEND SAFESTACK_TEST_DEPS LLVMgold)
+      endif()
+      if(APPLE)
+        list(APPEND SAFESTACK_TEST_DEPS LTO)
+      endif()
     endif()
   endif()
-endif()
+  set(CONFIG_NAME ${CONFIG_NAME}-${arch})
+  configure_lit_site_cfg(
+    ${CMAKE_CURRENT_SOURCE_DIR}/lit.site.cfg.py.in
+    ${CMAKE_CURRENT_BINARY_DIR}/${CONFIG_NAME}/lit.site.cfg.py)
+  list(APPEND SAFESTACK_TESTSUITES ${CMAKE_CURRENT_BINARY_DIR}/${CONFIG_NAME})
+endmacro()
 
-configure_lit_site_cfg(
-  ${CMAKE_CURRENT_SOURCE_DIR}/lit.site.cfg.py.in
-  ${CMAKE_CURRENT_BINARY_DIR}/lit.site.cfg.py
-  )
+set(SAFESTACK_TEST_ARCH ${SAFESTACK_SUPPORTED_ARCH})
+
+foreach(arch ${SAFESTACK_TEST_ARCH})
+  set(SAFESTACK_TEST_TARGET_ARCH ${arch})
+  get_test_cc_for_arch(${arch} SAFESTACK_TEST_TARGET_CC SAFESTACK_TEST_TARGET_CFLAGS)
+  add_safestack_testsuite("Standalone" safestack ${arch})
+endforeach()
 
 add_lit_testsuite(check-safestack "Running the SafeStack tests"
-  ${CMAKE_CURRENT_BINARY_DIR}
+  ${SAFESTACK_TESTSUITES}
   DEPENDS ${SAFESTACK_TEST_DEPS})

--- a/compiler-rt/test/safestack/lit.cfg.py
+++ b/compiler-rt/test/safestack/lit.cfg.py
@@ -3,7 +3,7 @@
 import os
 
 # Setup config name.
-config.name = "SafeStack"
+config.name = "SafeStack-" + config.name_suffix
 
 # Setup source root.
 config.test_source_root = os.path.dirname(__file__)

--- a/compiler-rt/test/safestack/lit.site.cfg.py.in
+++ b/compiler-rt/test/safestack/lit.site.cfg.py.in
@@ -1,5 +1,11 @@
 @LIT_SITE_CFG_IN_HEADER@
 
+# Tool-specific config options.
+config.name_suffix = "@CONFIG_NAME@"
+config.safestack_lit_test_mode = "@SAFESTACK_LIT_TEST_MODE@"
+config.target_cflags = "@SAFESTACK_TEST_TARGET_CFLAGS@"
+config.target_arch = "@SAFESTACK_TEST_TARGET_ARCH@"
+
 # Load common config for all compiler-rt lit tests.
 lit_config.load_config(config, "@COMPILER_RT_BINARY_DIR@/test/lit.common.configured")
 


### PR DESCRIPTION
While working on my safestack patches, I noticed that only the default multilib was tested even though all multilib versions of `libclang_rt.safestack.a` were built.

This patch fixes this, patterned after the ubsan testing support.

Tested on `amd64-pc-solaris2.11` (`amd64` and `i386`), `sparcv9-sun-solaris2.11` (`sparcv9` and `sparc`), `x86_64-pc-linux-gnu` (`x86_64` and `i386`), and `sparc64-unknown-linux-gnu` (`sparcv9` and `sparc`).