### PR TITLE
[libc++][vector<bool>] Tests shrink_to_fit requirement.

### DIFF
--- a/libcxx/test/std/containers/sequences/vector.bool/shrink_to_fit.pass.cpp
+++ b/libcxx/test/std/containers/sequences/vector.bool/shrink_to_fit.pass.cpp
@@ -39,9 +39,48 @@ TEST_CONSTEXPR_CXX20 bool tests()
     return true;
 }
 
+#if TEST_STD_VER >= 23
+std::size_t min_bytes = 1000;
+
+template <typename T>
+struct increasing_allocator {
+  using value_type       = T;
+  increasing_allocator() = default;
+  template <typename U>
+  increasing_allocator(const increasing_allocator<U>&) noexcept {}
+  std::allocation_result<T*> allocate_at_least(std::size_t n) {
+    std::size_t allocation_amount = n * sizeof(T);
+    if (allocation_amount < min_bytes)
+      allocation_amount = min_bytes;
+    min_bytes += 1000;
+    return {static_cast<T*>(::operator new(allocation_amount)), allocation_amount / sizeof(T)};
+  }
+  T* allocate(std::size_t n) { return allocate_at_least(n).ptr; }
+  void deallocate(T* p, std::size_t) noexcept { ::operator delete(static_cast<void*>(p)); }
+};
+
+template <typename T, typename U>
+bool operator==(increasing_allocator<T>, increasing_allocator<U>) {
+  return true;
+}
+
+// https://github.com/llvm/llvm-project/issues/95161
+void test_increasing_allocator() {
+  std::vector<bool, increasing_allocator<bool>> v;
+  v.push_back(1);
+  std::size_t capacity = v.capacity();
+  v.shrink_to_fit();
+  assert(v.capacity() <= capacity);
+  assert(v.size() == 1);
+}
+#endif // TEST_STD_VER >= 23
+
 int main(int, char**)
 {
     tests();
+#if TEST_STD_VER >= 23
+    test_increasing_allocator();
+#endif // TEST_STD_VER >= 23
 #if TEST_STD_VER > 17
     static_assert(tests());
 #endif

--- a/libcxx/test/std/containers/sequences/vector.bool/shrink_to_fit.pass.cpp
+++ b/libcxx/test/std/containers/sequences/vector.bool/shrink_to_fit.pass.cpp
@@ -40,23 +40,23 @@ TEST_CONSTEXPR_CXX20 bool tests()
 }
 
 #if TEST_STD_VER >= 23
-std::size_t min_bytes = 1000;
-
 template <typename T>
 struct increasing_allocator {
-  using value_type       = T;
-  increasing_allocator() = default;
+  using value_type         = T;
+  std::size_t min_elements = 1000;
+  increasing_allocator()   = default;
+
   template <typename U>
-  increasing_allocator(const increasing_allocator<U>&) noexcept {}
-  std::allocation_result<T*> allocate_at_least(std::size_t n) {
-    std::size_t allocation_amount = n * sizeof(T);
-    if (allocation_amount < min_bytes)
-      allocation_amount = min_bytes;
-    min_bytes += 1000;
-    return {static_cast<T*>(::operator new(allocation_amount)), allocation_amount / sizeof(T)};
+  constexpr increasing_allocator(const increasing_allocator<U>& other) noexcept : min_elements(other.min_elements) {}
+
+  constexpr std::allocation_result<T*> allocate_at_least(std::size_t n) {
+    if (n < min_elements)
+      n = min_elements;
+    min_elements += 1000;
+    return std::allocator<T>{}.allocate_at_least(n);
   }
-  T* allocate(std::size_t n) { return allocate_at_least(n).ptr; }
-  void deallocate(T* p, std::size_t) noexcept { ::operator delete(static_cast<void*>(p)); }
+  constexpr T* allocate(std::size_t n) { return allocate_at_least(n).ptr; }
+  constexpr void deallocate(T* p, std::size_t n) noexcept { std::allocator<T>{}.deallocate(p, n); }
 };
 
 template <typename T, typename U>
@@ -65,24 +65,28 @@ bool operator==(increasing_allocator<T>, increasing_allocator<U>) {
 }
 
 // https://github.com/llvm/llvm-project/issues/95161
-void test_increasing_allocator() {
+constexpr bool test_increasing_allocator() {
   std::vector<bool, increasing_allocator<bool>> v;
   v.push_back(1);
   std::size_t capacity = v.capacity();
   v.shrink_to_fit();
   assert(v.capacity() <= capacity);
   assert(v.size() == 1);
+
+  return true;
 }
 #endif // TEST_STD_VER >= 23
 
 int main(int, char**)
 {
-    tests();
-#if TEST_STD_VER >= 23
-    test_increasing_allocator();
-#endif // TEST_STD_VER >= 23
+  tests();
 #if TEST_STD_VER > 17
     static_assert(tests());
 #endif
+#if TEST_STD_VER >= 23
+    test_increasing_allocator();
+    static_assert(test_increasing_allocator());
+#endif // TEST_STD_VER >= 23
+
     return 0;
 }


### PR DESCRIPTION
`vector<bool>`'s shrink_to_fit implementation is using the "swap-to-free-container-resources-trick" which only shrinks when the input vector is empty. Since the request to shrink_to_fit is non-binding, this is a valid implementation. It is not a high-quality implementation. Since `vector<bool>` is not a very popular container the implementation has not been changed and only a test to validate the non-growing property has been added.

This was discovered while investigating https://github.com/llvm/llvm-project/issues/95161