### PR TITLE
[clang] CTAD: use index and depth to retrieve template parameter for TemplateParamsReferencedInTemplateArgumentList

### DIFF
--- a/clang/lib/Sema/SemaTemplate.cpp
+++ b/clang/lib/Sema/SemaTemplate.cpp
@@ -2779,7 +2779,7 @@ SmallVector<unsigned> TemplateParamsReferencedInTemplateArgumentList(
     ArrayRef<TemplateArgument> DeducedArgs) {
   struct TemplateParamsReferencedFinder
       : public RecursiveASTVisitor<TemplateParamsReferencedFinder> {
-    const TemplateParameterList* TemplateParamList;
+    const TemplateParameterList *TemplateParamList;
     llvm::BitVector ReferencedTemplateParams;
 
     TemplateParamsReferencedFinder(

--- a/clang/lib/Sema/SemaTemplate.cpp
+++ b/clang/lib/Sema/SemaTemplate.cpp
@@ -2775,7 +2775,7 @@ unsigned getTemplateParameterIndex(NamedDecl *TemplateParam) {
 // Find all template parameters that appear in the given DeducedArgs.
 // Return the indices of the template parameters in the TemplateParams.
 SmallVector<unsigned> TemplateParamsReferencedInTemplateArgumentList(
-    const TemplateParameterList* TemplateParamsList,
+    const TemplateParameterList *TemplateParamsList,
     ArrayRef<TemplateArgument> DeducedArgs) {
   struct TemplateParamsReferencedFinder
       : public RecursiveASTVisitor<TemplateParamsReferencedFinder> {

--- a/clang/test/AST/ast-dump-ctad-alias.cpp
+++ b/clang/test/AST/ast-dump-ctad-alias.cpp
@@ -99,3 +99,28 @@ BFoo b2(1.0, 2.0);
 // CHECK-NEXT: | | |-ParmVarDecl {{.*}} 'type-parameter-0-0'
 // CHECK-NEXT: | | `-ParmVarDecl {{.*}} 'type-parameter-0-0'
 // CHECK-NEXT: | `-CXXDeductionGuideDecl {{.*}} implicit used <deduction guide for BFoo> 'auto (double, double) -> Foo<double, double>' implicit_instantiation
+
+namespace GH90209 {
+template <class Ts>
+struct List {
+  List(int);
+};
+
+template <class T1>
+struct TemplatedClass {
+  TemplatedClass(T1);
+};
+
+template <class T1>
+TemplatedClass(T1) -> TemplatedClass<List<T1>>;
+
+template <class T2>
+using ATemplatedClass = TemplatedClass<List<T2>>;
+
+ATemplatedClass test(1);
+// Verify that we have a correct template parameter list for the deduction guide.
+//
+// CHECK:      FunctionTemplateDecl {{.*}} <deduction guide for ATemplatedClass>
+// CHECK-NEXT: |-TemplateTypeParmDecl {{.*}} class depth 0 index 0 T2
+// CHECK-NEXT: |-TypeTraitExpr {{.*}} 'bool' __is_deducible
+} // namespace GH90209

--- a/clang/test/AST/ast-dump-ctad-alias.cpp
+++ b/clang/test/AST/ast-dump-ctad-alias.cpp
@@ -101,26 +101,56 @@ BFoo b2(1.0, 2.0);
 // CHECK-NEXT: | `-CXXDeductionGuideDecl {{.*}} implicit used <deduction guide for BFoo> 'auto (double, double) -> Foo<double, double>' implicit_instantiation
 
 namespace GH90209 {
+// Case 1: type template parameter
 template <class Ts>
-struct List {
-  List(int);
+struct List1 {
+  List1(int);
 };
 
 template <class T1>
-struct TemplatedClass {
-  TemplatedClass(T1);
+struct TemplatedClass1 {
+  TemplatedClass1(T1);
 };
 
 template <class T1>
-TemplatedClass(T1) -> TemplatedClass<List<T1>>;
+TemplatedClass1(T1) -> TemplatedClass1<List1<T1>>;
 
 template <class T2>
-using ATemplatedClass = TemplatedClass<List<T2>>;
+using ATemplatedClass1 = TemplatedClass1<List1<T2>>;
 
-ATemplatedClass test(1);
+ATemplatedClass1 test1(1);
 // Verify that we have a correct template parameter list for the deduction guide.
 //
-// CHECK:      FunctionTemplateDecl {{.*}} <deduction guide for ATemplatedClass>
+// CHECK:      FunctionTemplateDecl {{.*}} <deduction guide for ATemplatedClass1>
 // CHECK-NEXT: |-TemplateTypeParmDecl {{.*}} class depth 0 index 0 T2
 // CHECK-NEXT: |-TypeTraitExpr {{.*}} 'bool' __is_deducible
+
+// Case 2: template template parameter
+template<typename K> struct Foo{};
+
+template <template<typename> typename Ts>
+struct List2 {
+  List2(int);
+};
+
+template <typename T1>
+struct TemplatedClass2 {
+  TemplatedClass2(T1);
+};
+
+template <template<typename> typename T1>
+TemplatedClass2(T1<int>) -> TemplatedClass2<List2<T1>>;
+
+template <template<typename> typename T2>
+using ATemplatedClass2 = TemplatedClass2<List2<T2>>;
+
+List2<Foo> list(1);
+ATemplatedClass2 test2(list);
+// Verify that we have a correct template parameter list for the deduction guide.
+//
+// CHECK:      FunctionTemplateDecl {{.*}} <deduction guide for ATemplatedClass2>
+// CHECK-NEXT: |-TemplateTemplateParmDecl {{.*}} depth 0 index 0 T2
+// CHECK-NEXT: | `-TemplateTypeParmDecl {{.*}} typename depth 0 index 0
+// CHECK-NEXT: |-TypeTraitExpr {{.*}} 'bool' __is_deducible
+
 } // namespace GH90209


### PR DESCRIPTION
As described in https://github.com/llvm/llvm-project/issues/90209#issuecomment-2135972202, Clang may not preserve enough information during template argument deduction. This can result in a merely canonical `TemplateTypeParmType` with a null `Decl`, leading to an incomplete template parameter list for the synthesized deduction guide.

This patch addresses the issue by using the index and depth information to retrieve the corresponding template parameter, rather than relying on `TTP->getDecl()`.

Fixes #90209