### PR TITLE
[libc] Make GPU `libm` use generic implementations

### DIFF
--- a/libc/include/llvm-libc-macros/math-macros.h
+++ b/libc/include/llvm-libc-macros/math-macros.h
@@ -41,12 +41,10 @@
 #define FP_LLOGBNAN LONG_MAX
 #endif
 
-#ifdef __FAST_MATH__
+#if defined(__NVPTX__) || defined(__AMDGPU__) || defined(__FAST_MATH__)
 #define math_errhandling 0
 #elif defined(__NO_MATH_ERRNO__)
 #define math_errhandling (MATH_ERREXCEPT)
-#elif defined(__NVPTX__) || defined(__AMDGPU__)
-#define math_errhandling (MATH_ERRNO)
 #else
 #define math_errhandling (MATH_ERRNO | MATH_ERREXCEPT)
 #endif

--- a/libc/src/math/amdgpu/CMakeLists.txt
+++ b/libc/src/math/amdgpu/CMakeLists.txt
@@ -286,6 +286,66 @@ add_entrypoint_object(
     -O2
 )
 
+add_entrypoint_object(
+  frexp
+  SRCS
+    frexp.cpp
+  HDRS
+    ../frexp.h
+  COMPILE_OPTIONS
+    -O2
+)
+
+add_entrypoint_object(
+  frexpf
+  SRCS
+    frexpf.cpp
+  HDRS
+    ../frexpf.h
+  COMPILE_OPTIONS
+    -O2
+)
+
+add_entrypoint_object(
+  scalbn
+  SRCS
+    scalbn.cpp
+  HDRS
+    ../scalbn.h
+  COMPILE_OPTIONS
+    -O2
+)
+
+add_entrypoint_object(
+  scalbnf
+  SRCS
+    scalbnf.cpp
+  HDRS
+    ../scalbnf.h
+  COMPILE_OPTIONS
+    -O2
+)
+
+add_entrypoint_object(
+  ldexp
+  SRCS
+    ldexp.cpp
+  HDRS
+    ../ldexp.h
+  COMPILE_OPTIONS
+    -O2
+)
+
+add_entrypoint_object(
+  ldexpf
+  SRCS
+    ldexpf.cpp
+  HDRS
+    ../ldexpf.h
+  COMPILE_OPTIONS
+    -O2
+)
+
 # The following functions currently are not implemented natively and borrow from
 # existing implementations. This will be removed in the future.
 add_entrypoint_object(
@@ -301,18 +361,6 @@ add_entrypoint_object(
 )
 
 add_entrypoint_object(
-  acosf
-  SRCS
-    acosf.cpp
-  HDRS
-    ../acosf.h
-  COMPILE_OPTIONS
-    ${bitcode_link_flags}
-    -O2
-  VENDOR
-)
-
-add_entrypoint_object(
   acosh
   SRCS
     acosh.cpp
@@ -325,35 +373,11 @@ add_entrypoint_object(
 )
 
 add_entrypoint_object(
-  acoshf
-  SRCS
-    acoshf.cpp
-  HDRS
-    ../acoshf.h
-  COMPILE_OPTIONS
-    ${bitcode_link_flags}
-    -O2
-  VENDOR
-)
-
-add_entrypoint_object(
   asin
   SRCS
     asin.cpp
   HDRS
     ../asin.h
-  COMPILE_OPTIONS
-    ${bitcode_link_flags}
-    -O2
-  VENDOR
-)
-
-add_entrypoint_object(
-  asinf
-  SRCS
-    asinf.cpp
-  HDRS
-    ../asinf.h
   COMPILE_OPTIONS
     ${bitcode_link_flags}
     -O2
@@ -385,35 +409,11 @@ add_entrypoint_object(
 )
 
 add_entrypoint_object(
-  atanf
-  SRCS
-    atanf.cpp
-  HDRS
-    ../atanf.h
-  COMPILE_OPTIONS
-    ${bitcode_link_flags}
-    -O2
-  VENDOR
-)
-
-add_entrypoint_object(
   atan2
   SRCS
     atan2.cpp
   HDRS
     ../atan2.h
-  COMPILE_OPTIONS
-    ${bitcode_link_flags}
-    -O2
-  VENDOR
-)
-
-add_entrypoint_object(
-  atan2f
-  SRCS
-    atan2f.cpp
-  HDRS
-    ../atan2f.h
   COMPILE_OPTIONS
     ${bitcode_link_flags}
     -O2
@@ -433,42 +433,6 @@ add_entrypoint_object(
 )
 
 add_entrypoint_object(
-  atanhf
-  SRCS
-    atanhf.cpp
-  HDRS
-    ../atanhf.h
-  COMPILE_OPTIONS
-    ${bitcode_link_flags}
-    -O2
-  VENDOR
-)
-
-add_entrypoint_object(
-  cos
-  SRCS
-    cos.cpp
-  HDRS
-    ../cos.h
-  COMPILE_OPTIONS
-    ${bitcode_link_flags}
-    -O2
-  VENDOR
-)
-
-add_entrypoint_object(
-  cosf
-  SRCS
-    cosf.cpp
-  HDRS
-    ../cosf.h
-  COMPILE_OPTIONS
-    ${bitcode_link_flags}
-    -O2
-  VENDOR
-)
-
-add_entrypoint_object(
   cosh
   SRCS
     cosh.cpp
@@ -481,275 +445,11 @@ add_entrypoint_object(
 )
 
 add_entrypoint_object(
-  coshf
-  SRCS
-    coshf.cpp
-  HDRS
-    ../coshf.h
-  COMPILE_OPTIONS
-    ${bitcode_link_flags}
-    -O2
-  VENDOR
-)
-
-add_entrypoint_object(
   erf
   SRCS
     erf.cpp
   HDRS
     ../erf.h
-  COMPILE_OPTIONS
-    ${bitcode_link_flags}
-    -O2
-  VENDOR
-)
-
-add_entrypoint_object(
-  erff
-  SRCS
-    erff.cpp
-  HDRS
-    ../erff.h
-  COMPILE_OPTIONS
-    ${bitcode_link_flags}
-    -O2
-  VENDOR
-)
-
-add_entrypoint_object(
-  exp
-  SRCS
-    exp.cpp
-  HDRS
-    ../exp.h
-  COMPILE_OPTIONS
-    ${bitcode_link_flags}
-    -O2
-  VENDOR
-)
-
-add_entrypoint_object(
-  exp10
-  SRCS
-    exp10.cpp
-  HDRS
-    ../exp10.h
-  COMPILE_OPTIONS
-    ${bitcode_link_flags}
-    -O2
-  VENDOR
-)
-
-add_entrypoint_object(
-  exp10f
-  SRCS
-    exp10f.cpp
-  HDRS
-    ../exp10f.h
-  COMPILE_OPTIONS
-    ${bitcode_link_flags}
-    -O2
-  VENDOR
-)
-
-add_entrypoint_object(
-  exp2
-  SRCS
-    exp2.cpp
-  HDRS
-    ../exp2.h
-  COMPILE_OPTIONS
-    ${bitcode_link_flags}
-    -O2
-  VENDOR
-)
-
-add_entrypoint_object(
-  exp2f
-  SRCS
-    exp2f.cpp
-  HDRS
-    ../exp2f.h
-  COMPILE_OPTIONS
-    ${bitcode_link_flags}
-    -O2
-  VENDOR
-)
-
-add_entrypoint_object(
-  expf
-  SRCS
-    expf.cpp
-  HDRS
-    ../expf.h
-  COMPILE_OPTIONS
-    ${bitcode_link_flags}
-    -O2
-  VENDOR
-)
-
-add_entrypoint_object(
-  expm1
-  SRCS
-    expm1.cpp
-  HDRS
-    ../expm1.h
-  COMPILE_OPTIONS
-    ${bitcode_link_flags}
-    -O2
-  VENDOR
-)
-
-add_entrypoint_object(
-  expm1f
-  SRCS
-    expm1f.cpp
-  HDRS
-    ../expm1f.h
-  COMPILE_OPTIONS
-    ${bitcode_link_flags}
-    -O2
-  VENDOR
-)
-
-add_entrypoint_object(
-  fdim
-  SRCS
-    fdim.cpp
-  HDRS
-    ../fdim.h
-  COMPILE_OPTIONS
-    ${bitcode_link_flags}
-    -O2
-  VENDOR
-)
-
-add_entrypoint_object(
-  fdimf
-  SRCS
-    fdimf.cpp
-  HDRS
-    ../fdimf.h
-  COMPILE_OPTIONS
-    ${bitcode_link_flags}
-    -O2
-  VENDOR
-)
-
-add_entrypoint_object(
-  hypot
-  SRCS
-    hypot.cpp
-  HDRS
-    ../hypot.h
-  COMPILE_OPTIONS
-    ${bitcode_link_flags}
-    -O2
-  VENDOR
-)
-
-add_entrypoint_object(
-  hypotf
-  SRCS
-    hypotf.cpp
-  HDRS
-    ../hypotf.h
-  COMPILE_OPTIONS
-    ${bitcode_link_flags}
-    -O2
-  VENDOR
-)
-
-add_entrypoint_object(
-  ilogb
-  SRCS
-    ilogb.cpp
-  HDRS
-    ../ilogb.h
-  COMPILE_OPTIONS
-    ${bitcode_link_flags}
-    -O2
-  VENDOR
-)
-
-add_entrypoint_object(
-  ilogbf
-  SRCS
-    ilogbf.cpp
-  HDRS
-    ../ilogbf.h
-  COMPILE_OPTIONS
-    ${bitcode_link_flags}
-    -O2
-  VENDOR
-)
-
-add_entrypoint_object(
-  log10
-  SRCS
-    log10.cpp
-  HDRS
-    ../log10.h
-  COMPILE_OPTIONS
-    ${bitcode_link_flags}
-    -O2
-  VENDOR
-)
-
-add_entrypoint_object(
-  log10f
-  SRCS
-    log10f.cpp
-  HDRS
-    ../log10f.h
-  COMPILE_OPTIONS
-    ${bitcode_link_flags}
-    -O2
-  VENDOR
-)
-
-add_entrypoint_object(
-  log2
-  SRCS
-    log2.cpp
-  HDRS
-    ../log2.h
-  COMPILE_OPTIONS
-    ${bitcode_link_flags}
-    -O2
-  VENDOR
-)
-
-add_entrypoint_object(
-  log2f
-  SRCS
-    log2f.cpp
-  HDRS
-    ../log2f.h
-  COMPILE_OPTIONS
-    ${bitcode_link_flags}
-    -O2
-  VENDOR
-)
-
-add_entrypoint_object(
-  log
-  SRCS
-    log.cpp
-  HDRS
-    ../log.h
-  COMPILE_OPTIONS
-    ${bitcode_link_flags}
-    -O2
-  VENDOR
-)
-
-add_entrypoint_object(
-  logf
-  SRCS
-    logf.cpp
-  HDRS
-    ../logf.h
   COMPILE_OPTIONS
     ${bitcode_link_flags}
     -O2
@@ -781,54 +481,6 @@ add_entrypoint_object(
 )
 
 add_entrypoint_object(
-  ldexp
-  SRCS
-    ldexp.cpp
-  HDRS
-    ../ldexp.h
-  COMPILE_OPTIONS
-    ${bitcode_link_flags}
-    -O2
-  VENDOR
-)
-
-add_entrypoint_object(
-  ldexpf
-  SRCS
-    ldexpf.cpp
-  HDRS
-    ../ldexpf.h
-  COMPILE_OPTIONS
-    ${bitcode_link_flags}
-    -O2
-  VENDOR
-)
-
-add_entrypoint_object(
-  log1p
-  SRCS
-    log1p.cpp
-  HDRS
-    ../log1p.h
-  COMPILE_OPTIONS
-    ${bitcode_link_flags}
-    -O2
-  VENDOR
-)
-
-add_entrypoint_object(
-  log1pf
-  SRCS
-    log1pf.cpp
-  HDRS
-    ../log1pf.h
-  COMPILE_OPTIONS
-    ${bitcode_link_flags}
-    -O2
-  VENDOR
-)
-
-add_entrypoint_object(
   llrint
   SRCS
     llrint.cpp
@@ -853,144 +505,11 @@ add_entrypoint_object(
 )
 
 add_entrypoint_object(
-  remquo
-  SRCS
-    remquo.cpp
-  HDRS
-    ../remquo.h
-  COMPILE_OPTIONS
-    ${bitcode_link_flags}
-    -O2
-  VENDOR
-)
-
-add_entrypoint_object(
-  remquof
-  SRCS
-    remquof.cpp
-  HDRS
-    ../remquof.h
-  COMPILE_OPTIONS
-    ${bitcode_link_flags}
-    -O2
-  VENDOR
-)
-
-add_entrypoint_object(
-  scalbn
-  SRCS
-    scalbn.cpp
-  HDRS
-    ../scalbn.h
-  COMPILE_OPTIONS
-    ${bitcode_link_flags}
-    -O2
-  VENDOR
-)
-
-add_entrypoint_object(
-  scalbnf
-  SRCS
-    scalbnf.cpp
-  HDRS
-    ../scalbnf.h
-  COMPILE_OPTIONS
-    ${bitcode_link_flags}
-    -O2
-  VENDOR
-)
-
-
-add_entrypoint_object(
-  nextafter
-  SRCS
-    nextafter.cpp
-  HDRS
-    ../nextafter.h
-  COMPILE_OPTIONS
-    ${bitcode_link_flags}
-    -O2
-  VENDOR
-)
-
-add_entrypoint_object(
-  nextafterf
-  SRCS
-    nextafterf.cpp
-  HDRS
-    ../nextafterf.h
-  COMPILE_OPTIONS
-    ${bitcode_link_flags}
-    -O2
-  VENDOR
-)
-
-add_entrypoint_object(
   pow
   SRCS
     pow.cpp
   HDRS
     ../pow.h
-  COMPILE_OPTIONS
-    ${bitcode_link_flags}
-    -O2
-  VENDOR
-)
-
-add_entrypoint_object(
-  powf
-  SRCS
-    powf.cpp
-  HDRS
-    ../powf.h
-  COMPILE_OPTIONS
-    ${bitcode_link_flags}
-    -O2
-  VENDOR
-)
-
-add_entrypoint_object(
-  sin
-  SRCS
-    sin.cpp
-  HDRS
-    ../sin.h
-  COMPILE_OPTIONS
-    ${bitcode_link_flags}
-    -O2
-  VENDOR
-)
-
-add_entrypoint_object(
-  sinf
-  SRCS
-    sinf.cpp
-  HDRS
-    ../sinf.h
-  COMPILE_OPTIONS
-    ${bitcode_link_flags}
-    -O2
-  VENDOR
-)
-
-add_entrypoint_object(
-  sincos
-  SRCS
-    sincos.cpp
-  HDRS
-    ../sincos.h
-  COMPILE_OPTIONS
-    ${bitcode_link_flags}
-    -O2
-  VENDOR
-)
-
-add_entrypoint_object(
-  sincosf
-  SRCS
-    sincosf.cpp
-  HDRS
-    ../sincosf.h
   COMPILE_OPTIONS
     ${bitcode_link_flags}
     -O2
@@ -1010,59 +529,11 @@ add_entrypoint_object(
 )
 
 add_entrypoint_object(
-  sinhf
-  SRCS
-    sinhf.cpp
-  HDRS
-    ../sinhf.h
-  COMPILE_OPTIONS
-    ${bitcode_link_flags}
-    -O2
-  VENDOR
-)
-
-add_entrypoint_object(
-  tan
-  SRCS
-    tan.cpp
-  HDRS
-    ../tan.h
-  COMPILE_OPTIONS
-    ${bitcode_link_flags}
-    -O2
-  VENDOR
-)
-
-add_entrypoint_object(
-  tanf
-  SRCS
-    tanf.cpp
-  HDRS
-    ../tanf.h
-  COMPILE_OPTIONS
-    ${bitcode_link_flags}
-    -O2
-  VENDOR
-)
-
-add_entrypoint_object(
   tanh
   SRCS
     tanh.cpp
   HDRS
     ../tanh.h
-  COMPILE_OPTIONS
-    ${bitcode_link_flags}
-    -O2
-  VENDOR
-)
-
-add_entrypoint_object(
-  tanhf
-  SRCS
-    tanhf.cpp
-  HDRS
-    ../tanhf.h
   COMPILE_OPTIONS
     ${bitcode_link_flags}
     -O2
@@ -1087,30 +558,6 @@ add_entrypoint_object(
     tgammaf.cpp
   HDRS
     ../tgammaf.h
-  COMPILE_OPTIONS
-    ${bitcode_link_flags}
-    -O2
-  VENDOR
-)
-
-add_entrypoint_object(
-  frexp
-  SRCS
-    frexp.cpp
-  HDRS
-    ../frexp.h
-  COMPILE_OPTIONS
-    ${bitcode_link_flags}
-    -O2
-  VENDOR
-)
-
-add_entrypoint_object(
-  frexpf
-  SRCS
-    frexpf.cpp
-  HDRS
-    ../frexpf.h
   COMPILE_OPTIONS
     ${bitcode_link_flags}
     -O2

--- a/libc/src/math/nvptx/CMakeLists.txt
+++ b/libc/src/math/nvptx/CMakeLists.txt
@@ -302,18 +302,6 @@ add_entrypoint_object(
 )
 
 add_entrypoint_object(
-  acosf
-  SRCS
-    acosf.cpp
-  HDRS
-    ../acosf.h
-  COMPILE_OPTIONS
-    ${bitcode_link_flags}
-    -O2
-  VENDOR
-)
-
-add_entrypoint_object(
   acosh
   SRCS
     acosh.cpp
@@ -326,35 +314,11 @@ add_entrypoint_object(
 )
 
 add_entrypoint_object(
-  acoshf
-  SRCS
-    acoshf.cpp
-  HDRS
-    ../acoshf.h
-  COMPILE_OPTIONS
-    ${bitcode_link_flags}
-    -O2
-  VENDOR
-)
-
-add_entrypoint_object(
   asin
   SRCS
     asin.cpp
   HDRS
     ../asin.h
-  COMPILE_OPTIONS
-    ${bitcode_link_flags}
-    -O2
-  VENDOR
-)
-
-add_entrypoint_object(
-  asinf
-  SRCS
-    asinf.cpp
-  HDRS
-    ../asinf.h
   COMPILE_OPTIONS
     ${bitcode_link_flags}
     -O2
@@ -386,35 +350,11 @@ add_entrypoint_object(
 )
 
 add_entrypoint_object(
-  atanf
-  SRCS
-    atanf.cpp
-  HDRS
-    ../atanf.h
-  COMPILE_OPTIONS
-    ${bitcode_link_flags}
-    -O2
-  VENDOR
-)
-
-add_entrypoint_object(
   atan2
   SRCS
     atan2.cpp
   HDRS
     ../atan2.h
-  COMPILE_OPTIONS
-    ${bitcode_link_flags}
-    -O2
-  VENDOR
-)
-
-add_entrypoint_object(
-  atan2f
-  SRCS
-    atan2f.cpp
-  HDRS
-    ../atan2f.h
   COMPILE_OPTIONS
     ${bitcode_link_flags}
     -O2
@@ -434,35 +374,11 @@ add_entrypoint_object(
 )
 
 add_entrypoint_object(
-  atanhf
-  SRCS
-    atanhf.cpp
-  HDRS
-    ../atanhf.h
-  COMPILE_OPTIONS
-    ${bitcode_link_flags}
-    -O2
-  VENDOR
-)
-
-add_entrypoint_object(
   cos
   SRCS
     cos.cpp
   HDRS
     ../cos.h
-  COMPILE_OPTIONS
-    ${bitcode_link_flags}
-    -O2
-  VENDOR
-)
-
-add_entrypoint_object(
-  cosf
-  SRCS
-    cosf.cpp
-  HDRS
-    ../cosf.h
   COMPILE_OPTIONS
     ${bitcode_link_flags}
     -O2
@@ -482,275 +398,11 @@ add_entrypoint_object(
 )
 
 add_entrypoint_object(
-  coshf
-  SRCS
-    coshf.cpp
-  HDRS
-    ../coshf.h
-  COMPILE_OPTIONS
-    ${bitcode_link_flags}
-    -O2
-  VENDOR
-)
-
-add_entrypoint_object(
   erf
   SRCS
     erf.cpp
   HDRS
     ../erf.h
-  COMPILE_OPTIONS
-    ${bitcode_link_flags}
-    -O2
-  VENDOR
-)
-
-add_entrypoint_object(
-  erff
-  SRCS
-    erff.cpp
-  HDRS
-    ../erff.h
-  COMPILE_OPTIONS
-    ${bitcode_link_flags}
-    -O2
-  VENDOR
-)
-
-add_entrypoint_object(
-  exp
-  SRCS
-    exp.cpp
-  HDRS
-    ../exp.h
-  COMPILE_OPTIONS
-    ${bitcode_link_flags}
-    -O2
-  VENDOR
-)
-
-add_entrypoint_object(
-  exp10
-  SRCS
-    exp10.cpp
-  HDRS
-    ../exp10.h
-  COMPILE_OPTIONS
-    ${bitcode_link_flags}
-    -O2
-  VENDOR
-)
-
-add_entrypoint_object(
-  exp10f
-  SRCS
-    exp10f.cpp
-  HDRS
-    ../exp10f.h
-  COMPILE_OPTIONS
-    ${bitcode_link_flags}
-    -O2
-  VENDOR
-)
-
-add_entrypoint_object(
-  exp2
-  SRCS
-    exp2.cpp
-  HDRS
-    ../exp2.h
-  COMPILE_OPTIONS
-    ${bitcode_link_flags}
-    -O2
-  VENDOR
-)
-
-add_entrypoint_object(
-  exp2f
-  SRCS
-    exp2f.cpp
-  HDRS
-    ../exp2f.h
-  COMPILE_OPTIONS
-    ${bitcode_link_flags}
-    -O2
-  VENDOR
-)
-
-add_entrypoint_object(
-  expf
-  SRCS
-    expf.cpp
-  HDRS
-    ../expf.h
-  COMPILE_OPTIONS
-    ${bitcode_link_flags}
-    -O2
-  VENDOR
-)
-
-add_entrypoint_object(
-  expm1
-  SRCS
-    expm1.cpp
-  HDRS
-    ../expm1.h
-  COMPILE_OPTIONS
-    ${bitcode_link_flags}
-    -O2
-  VENDOR
-)
-
-add_entrypoint_object(
-  expm1f
-  SRCS
-    expm1f.cpp
-  HDRS
-    ../expm1f.h
-  COMPILE_OPTIONS
-    ${bitcode_link_flags}
-    -O2
-  VENDOR
-)
-
-add_entrypoint_object(
-  fdim
-  SRCS
-    fdim.cpp
-  HDRS
-    ../fdim.h
-  COMPILE_OPTIONS
-    ${bitcode_link_flags}
-    -O2
-  VENDOR
-)
-
-add_entrypoint_object(
-  fdimf
-  SRCS
-    fdimf.cpp
-  HDRS
-    ../fdimf.h
-  COMPILE_OPTIONS
-    ${bitcode_link_flags}
-    -O2
-  VENDOR
-)
-
-add_entrypoint_object(
-  hypot
-  SRCS
-    hypot.cpp
-  HDRS
-    ../hypot.h
-  COMPILE_OPTIONS
-    ${bitcode_link_flags}
-    -O2
-  VENDOR
-)
-
-add_entrypoint_object(
-  hypotf
-  SRCS
-    hypotf.cpp
-  HDRS
-    ../hypotf.h
-  COMPILE_OPTIONS
-    ${bitcode_link_flags}
-    -O2
-  VENDOR
-)
-
-add_entrypoint_object(
-  ilogb
-  SRCS
-    ilogb.cpp
-  HDRS
-    ../ilogb.h
-  COMPILE_OPTIONS
-    ${bitcode_link_flags}
-    -O2
-  VENDOR
-)
-
-add_entrypoint_object(
-  ilogbf
-  SRCS
-    ilogbf.cpp
-  HDRS
-    ../ilogbf.h
-  COMPILE_OPTIONS
-    ${bitcode_link_flags}
-    -O2
-  VENDOR
-)
-
-add_entrypoint_object(
-  log10
-  SRCS
-    log10.cpp
-  HDRS
-    ../log10.h
-  COMPILE_OPTIONS
-    ${bitcode_link_flags}
-    -O2
-  VENDOR
-)
-
-add_entrypoint_object(
-  log10f
-  SRCS
-    log10f.cpp
-  HDRS
-    ../log10f.h
-  COMPILE_OPTIONS
-    ${bitcode_link_flags}
-    -O2
-  VENDOR
-)
-
-add_entrypoint_object(
-  log2
-  SRCS
-    log2.cpp
-  HDRS
-    ../log2.h
-  COMPILE_OPTIONS
-    ${bitcode_link_flags}
-    -O2
-  VENDOR
-)
-
-add_entrypoint_object(
-  log2f
-  SRCS
-    log2f.cpp
-  HDRS
-    ../log2f.h
-  COMPILE_OPTIONS
-    ${bitcode_link_flags}
-    -O2
-  VENDOR
-)
-
-add_entrypoint_object(
-  log
-  SRCS
-    log.cpp
-  HDRS
-    ../log.h
-  COMPILE_OPTIONS
-    ${bitcode_link_flags}
-    -O2
-  VENDOR
-)
-
-add_entrypoint_object(
-  logf
-  SRCS
-    logf.cpp
-  HDRS
-    ../logf.h
   COMPILE_OPTIONS
     ${bitcode_link_flags}
     -O2
@@ -782,54 +434,6 @@ add_entrypoint_object(
 )
 
 add_entrypoint_object(
-  ldexp
-  SRCS
-    ldexp.cpp
-  HDRS
-    ../ldexp.h
-  COMPILE_OPTIONS
-    ${bitcode_link_flags}
-    -O2
-  VENDOR
-)
-
-add_entrypoint_object(
-  ldexpf
-  SRCS
-    ldexpf.cpp
-  HDRS
-    ../ldexpf.h
-  COMPILE_OPTIONS
-    ${bitcode_link_flags}
-    -O2
-  VENDOR
-)
-
-add_entrypoint_object(
-  log1p
-  SRCS
-    log1p.cpp
-  HDRS
-    ../log1p.h
-  COMPILE_OPTIONS
-    ${bitcode_link_flags}
-    -O2
-  VENDOR
-)
-
-add_entrypoint_object(
-  log1pf
-  SRCS
-    log1pf.cpp
-  HDRS
-    ../log1pf.h
-  COMPILE_OPTIONS
-    ${bitcode_link_flags}
-    -O2
-  VENDOR
-)
-
-add_entrypoint_object(
   llrint
   SRCS
     llrint.cpp
@@ -854,144 +458,11 @@ add_entrypoint_object(
 )
 
 add_entrypoint_object(
-  remquo
-  SRCS
-    remquo.cpp
-  HDRS
-    ../remquo.h
-  COMPILE_OPTIONS
-    ${bitcode_link_flags}
-    -O2
-  VENDOR
-)
-
-add_entrypoint_object(
-  remquof
-  SRCS
-    remquof.cpp
-  HDRS
-    ../remquof.h
-  COMPILE_OPTIONS
-    ${bitcode_link_flags}
-    -O2
-  VENDOR
-)
-
-add_entrypoint_object(
-  scalbn
-  SRCS
-    scalbn.cpp
-  HDRS
-    ../scalbn.h
-  COMPILE_OPTIONS
-    ${bitcode_link_flags}
-    -O2
-  VENDOR
-)
-
-add_entrypoint_object(
-  scalbnf
-  SRCS
-    scalbnf.cpp
-  HDRS
-    ../scalbnf.h
-  COMPILE_OPTIONS
-    ${bitcode_link_flags}
-    -O2
-  VENDOR
-)
-
-
-add_entrypoint_object(
-  nextafter
-  SRCS
-    nextafter.cpp
-  HDRS
-    ../nextafter.h
-  COMPILE_OPTIONS
-    ${bitcode_link_flags}
-    -O2
-  VENDOR
-)
-
-add_entrypoint_object(
-  nextafterf
-  SRCS
-    nextafterf.cpp
-  HDRS
-    ../nextafterf.h
-  COMPILE_OPTIONS
-    ${bitcode_link_flags}
-    -O2
-  VENDOR
-)
-
-add_entrypoint_object(
   pow
   SRCS
     pow.cpp
   HDRS
     ../pow.h
-  COMPILE_OPTIONS
-    ${bitcode_link_flags}
-    -O2
-  VENDOR
-)
-
-add_entrypoint_object(
-  powf
-  SRCS
-    powf.cpp
-  HDRS
-    ../powf.h
-  COMPILE_OPTIONS
-    ${bitcode_link_flags}
-    -O2
-  VENDOR
-)
-
-add_entrypoint_object(
-  sin
-  SRCS
-    sin.cpp
-  HDRS
-    ../sin.h
-  COMPILE_OPTIONS
-    ${bitcode_link_flags}
-    -O2
-  VENDOR
-)
-
-add_entrypoint_object(
-  sinf
-  SRCS
-    sinf.cpp
-  HDRS
-    ../sinf.h
-  COMPILE_OPTIONS
-    ${bitcode_link_flags}
-    -O2
-  VENDOR
-)
-
-add_entrypoint_object(
-  sincos
-  SRCS
-    sincos.cpp
-  HDRS
-    ../sincos.h
-  COMPILE_OPTIONS
-    ${bitcode_link_flags}
-    -O2
-  VENDOR
-)
-
-add_entrypoint_object(
-  sincosf
-  SRCS
-    sincosf.cpp
-  HDRS
-    ../sincosf.h
   COMPILE_OPTIONS
     ${bitcode_link_flags}
     -O2
@@ -1011,59 +482,11 @@ add_entrypoint_object(
 )
 
 add_entrypoint_object(
-  sinhf
-  SRCS
-    sinhf.cpp
-  HDRS
-    ../sinhf.h
-  COMPILE_OPTIONS
-    ${bitcode_link_flags}
-    -O2
-  VENDOR
-)
-
-add_entrypoint_object(
-  tan
-  SRCS
-    tan.cpp
-  HDRS
-    ../tan.h
-  COMPILE_OPTIONS
-    ${bitcode_link_flags}
-    -O2
-  VENDOR
-)
-
-add_entrypoint_object(
-  tanf
-  SRCS
-    tanf.cpp
-  HDRS
-    ../tanf.h
-  COMPILE_OPTIONS
-    ${bitcode_link_flags}
-    -O2
-  VENDOR
-)
-
-add_entrypoint_object(
   tanh
   SRCS
     tanh.cpp
   HDRS
     ../tanh.h
-  COMPILE_OPTIONS
-    ${bitcode_link_flags}
-    -O2
-  VENDOR
-)
-
-add_entrypoint_object(
-  tanhf
-  SRCS
-    tanhf.cpp
-  HDRS
-    ../tanhf.h
   COMPILE_OPTIONS
     ${bitcode_link_flags}
     -O2
@@ -1090,30 +513,6 @@ add_entrypoint_object(
     ../tgammaf.h
   COMPILE_OPTIONS
     ${bitcode_link_flags}
-    -O2
-  VENDOR
-)
-
-add_entrypoint_object(
-  frexp
-  SRCS
-    frexp.cpp
-  HDRS
-    ../frexp.h
-  COMPILE_OPTIONS
-    ${bitcode_link_flags}
-    -O2
-  VENDOR
-)
-
-add_entrypoint_object(
-  frexpf
-  SRCS
-    frexpf.cpp
-  HDRS
-    ../frexpf.h
-  COMPILE_OPTIONS
-    ${itcode_link_flags}
     -O2
   VENDOR
 )

--- a/libc/src/math/nvptx/llrint.cpp
+++ b/libc/src/math/nvptx/llrint.cpp
@@ -13,6 +13,8 @@
 
 namespace LIBC_NAMESPACE {
 
-LLVM_LIBC_FUNCTION(long long, llrint, (double x)) { return __nv_llrint(x); }
+LLVM_LIBC_FUNCTION(long long, llrint, (double x)) {
+  return static_cast<long long>(__builtin_rint(x));
+}
 
 } // namespace LIBC_NAMESPACE

--- a/libc/src/math/nvptx/llrintf.cpp
+++ b/libc/src/math/nvptx/llrintf.cpp
@@ -13,6 +13,8 @@
 
 namespace LIBC_NAMESPACE {
 
-LLVM_LIBC_FUNCTION(long long, llrintf, (float x)) { return __nv_llrintf(x); }
+LLVM_LIBC_FUNCTION(long long, llrintf, (float x)) {
+  return static_cast<long long>(__builtin_rintf(x));
+}
 
 } // namespace LIBC_NAMESPACE

--- a/libc/src/math/nvptx/lrint.cpp
+++ b/libc/src/math/nvptx/lrint.cpp
@@ -13,6 +13,8 @@
 
 namespace LIBC_NAMESPACE {
 
-LLVM_LIBC_FUNCTION(long, lrint, (double x)) { return __nv_lrint(x); }
+LLVM_LIBC_FUNCTION(long, lrint, (double x)) {
+  return static_cast<long>(__builtin_rint(x));
+}
 
 } // namespace LIBC_NAMESPACE


### PR DESCRIPTION
Summary:
This patch moves a lot of the old vendor implementations to the new
generic math functions. Previously a lot of these were done through the
vendor functions, but the long term goal is to completely phase these
out. In order to make the tests pass I had to disable exceptions so they
only perform functional tests.
