### PR TITLE
[Clang][Index] Add support for dependent class scope explicit specializations of function templates to USRGenerator

### DIFF
--- a/clang/lib/Index/USRGeneration.cpp
+++ b/clang/lib/Index/USRGeneration.cpp
@@ -257,12 +257,20 @@ void USRGenerator::VisitFunctionDecl(const FunctionDecl *D) {
       !D->hasAttr<OverloadableAttr>())
     return;
 
-  if (const TemplateArgumentList *
-        SpecArgs = D->getTemplateSpecializationArgs()) {
+  if (D->isFunctionTemplateSpecialization()) {
     Out << '<';
-    for (unsigned I = 0, N = SpecArgs->size(); I != N; ++I) {
-      Out << '#';
-      VisitTemplateArgument(SpecArgs->get(I));
+    if (const TemplateArgumentList *SpecArgs =
+            D->getTemplateSpecializationArgs()) {
+      for (const auto &Arg : SpecArgs->asArray()) {
+        Out << '#';
+        VisitTemplateArgument(Arg);
+      }
+    } else if (const ASTTemplateArgumentListInfo *SpecArgsWritten =
+                   D->getTemplateSpecializationArgsAsWritten()) {
+      for (const auto &ArgLoc : SpecArgsWritten->arguments()) {
+        Out << '#';
+        VisitTemplateArgument(ArgLoc.getArgument());
+      }
     }
     Out << '>';
   }

--- a/clang/test/Index/USR/func-template.cpp
+++ b/clang/test/Index/USR/func-template.cpp
@@ -1,0 +1,15 @@
+// RUN: c-index-test core -print-source-symbols -- %s | FileCheck %s
+
+template<typename T>
+struct A {
+  void f(int);
+  // CHECK: {{[0-9]+}}:8 | instance-method/C++ | f | c:@ST>1#T@A@F@f#I# |
+  
+  template<typename U>
+  void f(U);
+  // CHECK: {{[0-9]+}}:8 | instance-method/C++ | f | c:@ST>1#T@A@FT@>1#Tf#t1.0#v# |
+  
+  template<>
+  void f<int>(int);
+  // CHECK: {{[0-9]+}}:8 | instance-method/C++ | f | c:@ST>1#T@A@F@f<#I>#I# |
+};


### PR DESCRIPTION
Given the following:
```cpp
template<typename T>
struct A
{
    void f(int); // #1
    
    template<typename U>
    void f(U); // #2
    
    template<>
    void f<int>(int); // #3
};
```
Clang will generate the same USR for `#1` and `#2`. This patch fixes the issue by including the template arguments of dependent class scope explicit specializations in their USRs.