### PR TITLE
[llvm-objcopy][COFF] Add aliases for some --subsystem options

### DIFF
--- a/llvm/test/tools/llvm-objcopy/COFF/subsystem.test
+++ b/llvm/test/tools/llvm-objcopy/COFF/subsystem.test
@@ -30,14 +30,20 @@
 # INVALID-MAJOR-NUMBER: 'foo' is not a valid subsystem major version
 # INVALID-MINOR-NUMBER: 'bar' is not a valid subsystem minor version
 
-# RUN: llvm-objcopy --subsystem=efi_application %t.in.exe
-# RUN: llvm-objcopy --subsystem=efi-app %t.in.exe
+# RUN: llvm-objcopy --subsystem=efi_application %t.in.exe - | llvm-readobj --file-headers - | FileCheck %s --check-prefix=EFI-APPLICATION
+# RUN: llvm-objcopy --subsystem=efi-app %t.in.exe -         | llvm-readobj --file-headers - | FileCheck %s --check-prefix=EFI-APPLICATION
 
-# RUN: llvm-objcopy --subsystem=efi_boot_service_driver %t.in.exe
-# RUN: llvm-objcopy --subsystem=efi-bsd %t.in.exe
+# EFI-APPLICATION: Subsystem: IMAGE_SUBSYSTEM_EFI_APPLICATION
 
-# RUN: llvm-objcopy --subsystem=efi_runtime_driver %t.in.exe
-# RUN: llvm-objcopy --subsystem=efi-rtd %t.in.exe
+# RUN: llvm-objcopy --subsystem=efi_boot_service_driver %t.in.exe - | llvm-readobj --file-headers - | FileCheck %s --check-prefix=EFI-BOOT-SERVICE-DRIVER
+# RUN: llvm-objcopy --subsystem=efi-bsd %t.in.exe -                 | llvm-readobj --file-headers - | FileCheck %s --check-prefix=EFI-BOOT-SERVICE-DRIVER
+
+# EFI-BOOT-SERVICE-DRIVER: Subsystem: IMAGE_SUBSYSTEM_EFI_BOOT_SERVICE_DRIVER
+
+# RUN: llvm-objcopy --subsystem=efi_runtime_driver %t.in.exe - | llvm-readobj --file-headers - | FileCheck %s --check-prefix=EFI-RUNTIME-DRIVER
+# RUN: llvm-objcopy --subsystem=efi-rtd %t.in.exe -            | llvm-readobj --file-headers - | FileCheck %s --check-prefix=EFI-RUNTIME-DRIVER
+
+# EFI-RUNTIME-DRIVER: Subsystem: IMAGE_SUBSYSTEM_EFI_RUNTIME_DRIVER
 
 --- !COFF
 OptionalHeader:

--- a/llvm/test/tools/llvm-objcopy/COFF/subsystem.test
+++ b/llvm/test/tools/llvm-objcopy/COFF/subsystem.test
@@ -30,6 +30,15 @@
 # INVALID-MAJOR-NUMBER: 'foo' is not a valid subsystem major version
 # INVALID-MINOR-NUMBER: 'bar' is not a valid subsystem minor version
 
+# RUN: llvm-objcopy --subsystem=efi_application %t.in.exe
+# RUN: llvm-objcopy --subsystem=efi-app %t.in.exe
+
+# RUN: llvm-objcopy --subsystem=efi_boot_service_driver %t.in.exe
+# RUN: llvm-objcopy --subsystem=efi-bsd %t.in.exe
+
+# RUN: llvm-objcopy --subsystem=efi_runtime_driver %t.in.exe
+# RUN: llvm-objcopy --subsystem=efi-rtd %t.in.exe
+
 --- !COFF
 OptionalHeader:
   AddressOfEntryPoint: 4096

--- a/llvm/test/tools/llvm-objcopy/COFF/subsystem.test
+++ b/llvm/test/tools/llvm-objcopy/COFF/subsystem.test
@@ -30,18 +30,24 @@
 # INVALID-MAJOR-NUMBER: 'foo' is not a valid subsystem major version
 # INVALID-MINOR-NUMBER: 'bar' is not a valid subsystem minor version
 
-# RUN: llvm-objcopy --subsystem=efi_application %t.in.exe - | llvm-readobj --file-headers - | FileCheck %s --check-prefix=EFI-APPLICATION
-# RUN: llvm-objcopy --subsystem=efi-app %t.in.exe -         | llvm-readobj --file-headers - | FileCheck %s --check-prefix=EFI-APPLICATION
+# RUN: llvm-objcopy --subsystem=efi_application %t.in.exe %t.out.exe
+# RUN: llvm-readobj --file-headers %t.out.exe | FileCheck %s --check-prefix=EFI-APPLICATION
+# RUN: llvm-objcopy --subsystem=efi-app %t.in.exe %t.out.exe
+# RUN: llvm-readobj --file-headers %t.out.exe | FileCheck %s --check-prefix=EFI-APPLICATION
 
 # EFI-APPLICATION: Subsystem: IMAGE_SUBSYSTEM_EFI_APPLICATION
 
-# RUN: llvm-objcopy --subsystem=efi_boot_service_driver %t.in.exe - | llvm-readobj --file-headers - | FileCheck %s --check-prefix=EFI-BOOT-SERVICE-DRIVER
-# RUN: llvm-objcopy --subsystem=efi-bsd %t.in.exe -                 | llvm-readobj --file-headers - | FileCheck %s --check-prefix=EFI-BOOT-SERVICE-DRIVER
+# RUN: llvm-objcopy --subsystem=efi_boot_service_driver %t.in.exe %t.out.exe
+# RUN: llvm-readobj --file-headers %t.out.exe | FileCheck %s --check-prefix=EFI-BOOT-SERVICE-DRIVER
+# RUN: llvm-objcopy --subsystem=efi-bsd %t.in.exe %t.out.exe
+# RUN: llvm-readobj --file-headers %t.out.exe | FileCheck %s --check-prefix=EFI-BOOT-SERVICE-DRIVER
 
 # EFI-BOOT-SERVICE-DRIVER: Subsystem: IMAGE_SUBSYSTEM_EFI_BOOT_SERVICE_DRIVER
 
-# RUN: llvm-objcopy --subsystem=efi_runtime_driver %t.in.exe - | llvm-readobj --file-headers - | FileCheck %s --check-prefix=EFI-RUNTIME-DRIVER
-# RUN: llvm-objcopy --subsystem=efi-rtd %t.in.exe -            | llvm-readobj --file-headers - | FileCheck %s --check-prefix=EFI-RUNTIME-DRIVER
+# RUN: llvm-objcopy --subsystem=efi_runtime_driver %t.in.exe %t.out.exe
+# RUN: llvm-readobj --file-headers %t.out.exe | FileCheck %s --check-prefix=EFI-RUNTIME-DRIVER
+# RUN: llvm-objcopy --subsystem=efi-rtd %t.in.exe %t.out.exe
+# RUN: llvm-readobj --file-headers %t.out.exe | FileCheck %s --check-prefix=EFI-RUNTIME-DRIVER
 
 # EFI-RUNTIME-DRIVER: Subsystem: IMAGE_SUBSYSTEM_EFI_RUNTIME_DRIVER
 

--- a/llvm/tools/llvm-objcopy/ObjcopyOptions.cpp
+++ b/llvm/tools/llvm-objcopy/ObjcopyOptions.cpp
@@ -678,12 +678,13 @@ objcopy::parseObjcopyOptions(ArrayRef<const char *> RawArgsArr,
             .Case("boot_application",
                   COFF::IMAGE_SUBSYSTEM_WINDOWS_BOOT_APPLICATION)
             .Case("console", COFF::IMAGE_SUBSYSTEM_WINDOWS_CUI)
-            .Case("efi_application", COFF::IMAGE_SUBSYSTEM_EFI_APPLICATION)
-            .Case("efi_boot_service_driver",
-                  COFF::IMAGE_SUBSYSTEM_EFI_BOOT_SERVICE_DRIVER)
+            .Cases("efi_application", "efi-app",
+                   COFF::IMAGE_SUBSYSTEM_EFI_APPLICATION)
+            .Cases("efi_boot_service_driver", "efi-bsd",
+                   COFF::IMAGE_SUBSYSTEM_EFI_BOOT_SERVICE_DRIVER)
             .Case("efi_rom", COFF::IMAGE_SUBSYSTEM_EFI_ROM)
-            .Case("efi_runtime_driver",
-                  COFF::IMAGE_SUBSYSTEM_EFI_RUNTIME_DRIVER)
+            .Cases("efi_runtime_driver", "efi-rtd",
+                   COFF::IMAGE_SUBSYSTEM_EFI_RUNTIME_DRIVER)
             .Case("native", COFF::IMAGE_SUBSYSTEM_NATIVE)
             .Case("posix", COFF::IMAGE_SUBSYSTEM_POSIX_CUI)
             .Case("windows", COFF::IMAGE_SUBSYSTEM_WINDOWS_GUI)


### PR DESCRIPTION
GNU objcopy has some --subsystem options that aren't present in LLVM's. They are in fact just aliases to some of the existing options.

For the sake of compatibility with the GNU toolchain, this patch adds these aliases to LLVM objcopy.

The alias list is not exhaustive as this is an incremental change.