### PR TITLE
[lldb] Put the new debugger in synchronous mode in TestGlobalModuleCache

### DIFF
--- a/lldb/test/API/python_api/global_module_cache/TestGlobalModuleCache.py
+++ b/lldb/test/API/python_api/global_module_cache/TestGlobalModuleCache.py
@@ -111,6 +111,7 @@ class GlobalModuleCacheTestCase(TestBase):
         else:
             if one_target:
                 new_debugger = lldb.SBDebugger().Create()
+                new_debugger.SetAsync(False)
                 self.old_debugger = self.dbg
                 self.dbg = new_debugger
 


### PR DESCRIPTION
In async mode, the test terminates sooner than it should (`run_to_source_breakpoint` does not work in this mode), and then the test crashes due to #76057. Most of the time, the test does not fail because its already XFAILed, but the crash still registers as a failure.