### PR TITLE
[libc] Provide baremetal implementation of getchar

### DIFF
--- a/libc/config/baremetal/arm/entrypoints.txt
+++ b/libc/config/baremetal/arm/entrypoints.txt
@@ -83,6 +83,7 @@ set(TARGET_LIBC_ENTRYPOINTS
     libc.src.inttypes.strtoumax
 
     # stdio.h entrypoints
+    libc.src.stdio.getchar
     libc.src.stdio.printf
     libc.src.stdio.putchar
     libc.src.stdio.remove

--- a/libc/config/baremetal/riscv/entrypoints.txt
+++ b/libc/config/baremetal/riscv/entrypoints.txt
@@ -79,6 +79,7 @@ set(TARGET_LIBC_ENTRYPOINTS
     libc.src.inttypes.strtoumax
 
     # stdio.h entrypoints
+    libc.src.stdio.getchar
     libc.src.stdio.printf
     libc.src.stdio.putchar
     libc.src.stdio.remove

--- a/libc/src/__support/OSUtil/baremetal/io.cpp
+++ b/libc/src/__support/OSUtil/baremetal/io.cpp
@@ -20,7 +20,8 @@ extern "C" void __llvm_libc_log_write(const char *msg, size_t len);
 namespace LIBC_NAMESPACE {
 
 ssize_t read_from_stdin(char *buf, size_t size) {
-  return __llvm_libc_stdin_read(static_cast<void*>(&__llvm_libc_stdin), buf, size);
+  return __llvm_libc_stdin_read(static_cast<void *>(&__llvm_libc_stdin), buf,
+                                size);
 }
 
 void write_to_stderr(cpp::string_view msg) {

--- a/libc/src/__support/OSUtil/baremetal/io.cpp
+++ b/libc/src/__support/OSUtil/baremetal/io.cpp
@@ -20,8 +20,8 @@ extern "C" void __llvm_libc_log_write(const char *msg, size_t len);
 namespace LIBC_NAMESPACE {
 
 ssize_t read_from_stdin(char *buf, size_t size) {
-  return __llvm_libc_stdin_read(static_cast<void *>(&__llvm_libc_stdin), buf,
-                                size);
+  return __llvm_libc_stdin_read(reinterpret_cast<void *>(&__llvm_libc_stdin),
+                                buf, size);
 }
 
 void write_to_stderr(cpp::string_view msg) {

--- a/libc/src/__support/OSUtil/baremetal/io.cpp
+++ b/libc/src/__support/OSUtil/baremetal/io.cpp
@@ -11,9 +11,17 @@
 #include "src/__support/CPP/string_view.h"
 
 // This is intended to be provided by the vendor.
+
+extern struct __llvm_libc_stdin __llvm_libc_stdin;
+extern "C" ssize_t __llvm_libc_stdin_read(void *cookie, char *buf, size_t size);
+
 extern "C" void __llvm_libc_log_write(const char *msg, size_t len);
 
 namespace LIBC_NAMESPACE {
+
+ssize_t read_from_stdin(char *buf, size_t size) {
+  return __llvm_libc_stdin_read(static_cast<void*>(&__llvm_libc_stdin), buf, size);
+}
 
 void write_to_stderr(cpp::string_view msg) {
   __llvm_libc_log_write(msg.data(), msg.size());

--- a/libc/src/__support/OSUtil/baremetal/io.h
+++ b/libc/src/__support/OSUtil/baremetal/io.h
@@ -9,10 +9,13 @@
 #ifndef LLVM_LIBC_SRC___SUPPORT_OSUTIL_BAREMETAL_IO_H
 #define LLVM_LIBC_SRC___SUPPORT_OSUTIL_BAREMETAL_IO_H
 
+#include "include/llvm-libc-types/size_t.h"
+#include "include/llvm-libc-types/ssize_t.h"
 #include "src/__support/CPP/string_view.h"
 
 namespace LIBC_NAMESPACE {
 
+ssize_t read_from_stdin(char *buf, size_t size);
 void write_to_stderr(cpp::string_view msg);
 
 } // namespace LIBC_NAMESPACE

--- a/libc/src/stdio/baremetal/CMakeLists.txt
+++ b/libc/src/stdio/baremetal/CMakeLists.txt
@@ -1,4 +1,15 @@
 add_entrypoint_object(
+  getchar
+  SRCS
+    getchar.cpp
+  HDRS
+    ../getchar.h
+  DEPENDS
+    libc.src.__support.OSUtil.osutil
+    libc.src.__support.CPP.string_view
+)
+
+add_entrypoint_object(
   remove
   SRCS
     remove.cpp

--- a/libc/src/stdio/baremetal/getchar.cpp
+++ b/libc/src/stdio/baremetal/getchar.cpp
@@ -1,0 +1,24 @@
+//===-- Baremetal implementation of getchar -------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "src/stdio/getchar.h"
+#include "src/__support/OSUtil/io.h"
+
+#include <stdio.h>
+
+namespace LIBC_NAMESPACE {
+
+LLVM_LIBC_FUNCTION(int, getchar, ()) {
+  char buf[1];
+  auto result = read_from_stdin(buf, sizeof(buf));
+  if (result < 0)
+    return EOF;
+  return buf[0];
+}
+
+} // namespace LIBC_NAMESPACE


### PR DESCRIPTION
This introduces opaque type `struct __llvm_libc_stdin` and a symbol `__llvm_libc_stdin_read` that's intended to be provided by the vendor.

`__llvm_libc_stdin_read` intentionally has the same signature as `cookie_read_function_t` so it can be used with `fopencookie` to represent `stdin` as `FILE *` in the future.