### PR TITLE
Add patterns for Hexagon backend labels

### DIFF
--- a/.github/new-prs-labeler.yml
+++ b/.github/new-prs-labeler.yml
@@ -775,6 +775,29 @@ backend:AArch64:
   - clang/include/clang/Sema/SemaARM.h
   - clang/lib/Sema/SemaARM.cpp
 
+backend:Hexagon:
+  - clang/include/clang/Basic/BuiltinsHexagon*.def
+  - clang/include/clang/Sema/SemaHexagon.h
+  - clang/lib/Basic/Targets/Hexagon.*
+  - clang/lib/CodeGen/Targets/Hexagon.cpp
+  - clang/lib/Driver/ToolChains/Hexagon.*
+  - clang/lib/Sema/SemaHexagon.cpp
+  - lld/ELF/Arch/Hexagon.cpp
+  - lldb/source/Plugins/ABI/Hexagon/**
+  - lldb/source/Plugins/DynamicLoader/Hexagon-DYLD/**
+  - llvm/include/llvm/BinaryFormat/ELFRelocs/Hexagon.def
+  - llvm/include/llvm/IR/IntrinsicsHexagon*
+  - llvm/include/llvm/Support/Hexagon*
+  - llvm/lib/Support/Hexagon*
+  - llvm/lib/Target/Hexagon/**
+  - llvm/test/CodeGen/Hexagon/**
+  - llvm/test/CodeGen/*/Hexagon/**
+  - llvm/test/DebugInfo/*/Hexagon/**
+  - llvm/test/Transforms/*/Hexagon
+  - llvm/test/MC/Disassembler/Hexagon/**
+  - llvm/test/MC/Hexagon/**
+  - llvm/test/tools/llvm-objdump/ELF/Hexagon/**
+
 backend:loongarch:
   - llvm/include/llvm/IR/IntrinsicsLoongArch.td
   - llvm/test/MC/LoongArch/**


### PR DESCRIPTION
It happened that the Hexagon backend team did not exist, so subscriptions are not possible.

@tstellar please create `pr-subscribers-backend:Hexagon` team. This change contains the list of filters. Thanks!