### PR TITLE
[clang-tidy] Ignore requires expr in bugprone-assignment-in-if-condition

### DIFF
--- a/clang-tools-extra/clang-tidy/bugprone/AssignmentInIfConditionCheck.cpp
+++ b/clang-tools-extra/clang-tidy/bugprone/AssignmentInIfConditionCheck.cpp
@@ -39,6 +39,12 @@ void AssignmentInIfConditionCheck::check(
           return true;
         }
 
+        // Dont traverse into any requires expressions.
+        bool TraverseRequiresExpr(RequiresExpr *,
+                                  DataRecursionQueue * = nullptr) {
+          return true;
+        }
+
         bool VisitBinaryOperator(BinaryOperator *BO) {
           if (BO->isAssignmentOp())
             Check.report(BO);

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -232,6 +232,10 @@ Changes in existing checks
   <clang-tidy/checks/bugprone/assert-side-effect>` check by detecting side
   effect from calling a method with non-const reference parameters.
 
+- Improved :doc:`bugprone-assignment-in-if-condition
+  <clang-tidy/checks/bugprone/assignment-in-if-condition>` check by ignoring
+  assignments in the C++20 ``requires`` clause.
+
 - Improved :doc:`bugprone-casting-through-void
   <clang-tidy/checks/bugprone/casting-through-void>` check by ignoring casts
   where source is already a ``void``` pointer, making middle ``void`` pointer

--- a/clang-tools-extra/test/clang-tidy/checkers/bugprone/assignment-in-if-condition-cxx20.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/bugprone/assignment-in-if-condition-cxx20.cpp
@@ -1,0 +1,6 @@
+// RUN: %check_clang_tidy -std=c++20 %s bugprone-assignment-in-if-condition %t
+
+void testRequires() {
+  if constexpr (requires(int &a) { a = 0; }) {
+  }
+}


### PR DESCRIPTION
Ignore assignments in RequiresExpr, to avoid false positives.

Fixes #97972