### PR TITLE
[llvm][AArch64] Fix an assertion message in TargetParserTests. NFC

### DIFF
--- a/llvm/unittests/TargetParser/TargetParserTest.cpp
+++ b/llvm/unittests/TargetParser/TargetParserTest.cpp
@@ -110,14 +110,14 @@ template <ARM::ISAKind ISAKind> struct AssertSameExtensionFlags {
     if (ExpectedFlags == GotFlags)
       return testing::AssertionSuccess();
 
-    return testing::AssertionFailure() << llvm::formatv(
-               "CPU: {4}\n"
-               "Expected extension flags: {0} ({1:x})\n"
-               "     Got extension flags: {2} ({3:x})\n"
-               "                    Diff: {5} ({6:x})\n",
-               FormatExtensionFlags(ExpectedFlags), ExpectedFlags,
-               FormatExtensionFlags(GotFlags), GotFlags, CPUName,
-               FormatExtensionFlags(ExpectedFlags ^ GotFlags));
+    return testing::AssertionFailure()
+           << llvm::formatv("CPU: {4}\n"
+                            "Expected extension flags: {0} ({1:x})\n"
+                            "     Got extension flags: {2} ({3:x})\n"
+                            "                    Diff: {5} ({6:x})\n",
+                            FormatExtensionFlags(ExpectedFlags), ExpectedFlags,
+                            FormatExtensionFlags(GotFlags), GotFlags, CPUName,
+                            FormatExtensionFlags(ExpectedFlags ^ GotFlags));
   }
 
   testing::AssertionResult operator()(const char *m_expr, const char *n_expr,

--- a/llvm/unittests/TargetParser/TargetParserTest.cpp
+++ b/llvm/unittests/TargetParser/TargetParserTest.cpp
@@ -113,9 +113,11 @@ template <ARM::ISAKind ISAKind> struct AssertSameExtensionFlags {
     return testing::AssertionFailure() << llvm::formatv(
                "CPU: {4}\n"
                "Expected extension flags: {0} ({1:x})\n"
-               "     Got extension flags: {2} ({3:x})\n",
+               "     Got extension flags: {2} ({3:x})\n"
+               "                    Diff: {5} ({6:x})\n",
                FormatExtensionFlags(ExpectedFlags), ExpectedFlags,
-               FormatExtensionFlags(GotFlags), ExpectedFlags, CPUName);
+               FormatExtensionFlags(GotFlags), GotFlags, CPUName,
+               FormatExtensionFlags(ExpectedFlags ^ GotFlags));
   }
 
   testing::AssertionResult operator()(const char *m_expr, const char *n_expr,
@@ -127,11 +129,14 @@ template <ARM::ISAKind ISAKind> struct AssertSameExtensionFlags {
     return testing::AssertionFailure()
            << llvm::formatv("CPU: {4}\n"
                             "Expected extension flags: {0} ({1})\n"
-                            "     Got extension flags: {2} ({3})\n",
+                            "     Got extension flags: {2} ({3})\n"
+                            "                    Diff: {5} ({6})\n",
                             FormatExtensionFlags(ExpectedFlags),
                             SerializeExtensionFlags(ExpectedFlags),
                             FormatExtensionFlags(GotFlags),
-                            SerializeExtensionFlags(ExpectedFlags), CPUName);
+                            SerializeExtensionFlags(GotFlags), CPUName,
+                            FormatExtensionFlags(ExpectedFlags ^ GotFlags),
+                            SerializeExtensionFlags(ExpectedFlags ^ GotFlags));
   }
 
 private:


### PR DESCRIPTION
For both overloads, we were printing the bit-pattern for ExpectedFlags twice. While we're here, also add a convenience line that highlights the difference between the two sets.