### PR TITLE
[libc] Fix for unused variable warning

### DIFF
--- a/libc/src/__support/block.h
+++ b/libc/src/__support/block.h
@@ -442,8 +442,7 @@ Block<OffsetType, kAlign>::allocate(Block *block, size_t alignment,
 
   if (!info.block->is_usable_space_aligned(alignment)) {
     size_t adjustment = info.block->padding_for_alignment(alignment);
-    size_t new_inner_size = adjustment - BLOCK_OVERHEAD;
-    LIBC_ASSERT(new_inner_size % ALIGNMENT == 0 &&
+    LIBC_ASSERT((adjustment - BLOCK_OVERHEAD) % ALIGNMENT == 0 &&
                 "The adjustment calculation should always return a new size "
                 "that's a multiple of ALIGNMENT");
 


### PR DESCRIPTION
This fixes the `unused variable 'new_inner_size'` warning that arises when `new_inner_size` is only used by `LIBC_ASSERT` by performing the calculation directly in the macro.