### PR TITLE
[Clang] Allow diagnostics starting with Arm

### DIFF
--- a/clang/utils/TableGen/ClangDiagnosticsEmitter.cpp
+++ b/clang/utils/TableGen/ClangDiagnosticsEmitter.cpp
@@ -1232,6 +1232,7 @@ static bool isExemptAtStart(StringRef Text) {
   // Otherwise, there are a few other exemptions.
   return StringSwitch<bool>(Text)
       .Case("AddressSanitizer", true)
+      .Case("Arm", true)
       .Case("CFString", true)
       .Case("Clang", true)
       .Case("Fuchsia", true)


### PR DESCRIPTION
We (Arm) have a few downstream-only diagnostics that start with Arm, so wish to add Arm to the list of allowed start words.