### PR TITLE
[libc] Use `stdio.h` for `off_t` instead of `unistd.h`

### DIFF
--- a/libc/src/__support/File/file.h
+++ b/libc/src/__support/File/file.h
@@ -16,7 +16,7 @@
 
 #include <stddef.h>
 #include <stdint.h>
-#include <unistd.h> // For off_t.
+#include <stdio.h>
 
 namespace LIBC_NAMESPACE {
 


### PR DESCRIPTION
Summary:
The `stdio.h` header should define `off_t` as defined for the platform.
This will use the system's in overlay mode, or what the llvm-libc-types
deems correct. If this `off_t` is incorrect it should be changed in
`llvm-libc-types`. This fixes the GPU build.
