### PR TITLE
[libc] Fix statfs_to_statvfs conversion function on rv32

### DIFF
--- a/libc/src/sys/statvfs/linux/statfs_utils.h
+++ b/libc/src/sys/statvfs/linux/statfs_utils.h
@@ -77,14 +77,15 @@ LIBC_INLINE struct statvfs statfs_to_statvfs(const LinuxStatFs &in) {
   struct statvfs out;
   out.f_bsize = in.f_bsize;
   out.f_frsize = in.f_frsize;
-  out.f_blocks = in.f_blocks;
-  out.f_bfree = in.f_bfree;
-  out.f_bavail = in.f_bavail;
-  out.f_files = in.f_files;
-  out.f_ffree = in.f_ffree;
-  out.f_favail = in.f_ffree;
-  out.f_fsid = in.f_fsid.val[0] |
-               static_cast<decltype(out.f_fsid)>(in.f_fsid.val[1]) << 32;
+  out.f_blocks = static_cast<decltype(out.f_blocks)>(in.f_blocks);
+  out.f_bfree = static_cast<decltype(out.f_bfree)>(in.f_bfree);
+  out.f_bavail = static_cast<decltype(out.f_bavail)>(in.f_bavail);
+  out.f_files = static_cast<decltype(out.f_files)>(in.f_files);
+  out.f_ffree = static_cast<decltype(out.f_ffree)>(in.f_ffree);
+  out.f_favail = static_cast<decltype(out.f_favail)>(in.f_ffree);
+  out.f_fsid = in.f_fsid.val[0];
+  if constexpr (sizeof(decltype(out.f_fsid)) == sizeof(uint64_t))
+    out.f_fsid |= static_cast<decltype(out.f_fsid)>(in.f_fsid.val[1]) << 32;
   out.f_flag = in.f_flags;
   out.f_namemax = in.f_namelen;
   return out;


### PR DESCRIPTION
This patch fixes implicit conversion loses integer precision warnings by adding explicit casts. Should be NFC for 64-bit systems.