### PR TITLE
[clang-doc] fix paths by hard coding path to share

### DIFF
--- a/clang-tools-extra/clang-doc/tool/CMakeLists.txt
+++ b/clang-tools-extra/clang-doc/tool/CMakeLists.txt
@@ -25,7 +25,7 @@ set(assets
 )
 
 set(asset_dir "${CMAKE_CURRENT_SOURCE_DIR}/../assets")
-set(resource_dir "${CMAKE_BINARY_DIR}/share/clang-doc")
+set(resource_dir "${LLVM_RUNTIME_OUTPUT_INTDIR}/../share/clang-doc")
 set(out_files)
 
 function(copy_files_to_dst src_dir dst_dir file)


### PR DESCRIPTION
[clang-doc][cmake] Fix asset directory location for other generator types

This patch fixes how clang-doc copies asset files for the build to 
match the install location for all CMake generator types. The previous
version of this patch did not account for standalone builds of
clang that may use older LLVM installs, ane which do not have the
`LLVM_SHARE_OUTPUT_INTDIR` defined. Instead, we create an
equivalent path using `LLVM_RUNTIME_OUTPUT_INTDIR`.

Fixes #97507