### PR TITLE
[clang] fix sema init crashing on initialization sequences

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -813,6 +813,8 @@ Bug Fixes in This Version
 
 - Fixed `static_cast` to array of unknown bound. Fixes (#GH62863).
 
+- Fixed Clang crashing when failing to perform some C++ Initialization Sequences. (#GH98102)
+
 Bug Fixes to Compiler Builtins
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/clang/lib/Sema/SemaInit.cpp
+++ b/clang/lib/Sema/SemaInit.cpp
@@ -5576,6 +5576,10 @@ static void TryOrBuildParenListInitialization(
       ExprResult ER;
       ER = IS.Perform(S, SubEntity, SubKind,
                       Arg ? MultiExprArg(Arg) : std::nullopt);
+
+      if (ER.isInvalid())
+        return false;
+
       if (InitExpr)
         *InitExpr = ER.get();
       else

--- a/clang/test/SemaCXX/pr98102.cpp
+++ b/clang/test/SemaCXX/pr98102.cpp
@@ -1,0 +1,33 @@
+// RUN: %clang_cc1 -fsyntax-only -verify -std=c++20 %s
+// expected-no-diagnostics
+
+template <bool v>
+struct BC {
+  static constexpr bool value = v;
+};
+
+template <typename T, typename Arg>
+struct Constructible : BC<__is_constructible(T, Arg)> {};
+
+template <typename T>
+using Requires = T::value;
+
+template <typename T>
+struct optional {
+  template <typename U, Requires<Constructible<T, U>> = true>
+  optional(U) {}
+};
+
+struct MO {};
+struct S : MO {};
+struct TB {
+  TB(optional<S>) {}
+};
+
+class TD : TB, MO {
+  using TB::TB;
+};
+
+void foo() {
+  static_assert(Constructible<TD, TD>::value);
+}


### PR DESCRIPTION
We ran into a FE crash and root caused to `ER.get()` on line 5584 here being nullptr. I think this is a result of not checking if ER here is invalid. 

Example of crash-on-valid C++ https://gist.github.com/yuxuanchen1997/576dce964666f0f8713fccacf5847138

Note that this crash happens only with `-std=c++20`.