### PR TITLE
Fix erroneous `-Wmissing-prototypes` for Win32 entry points

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -654,6 +654,9 @@ Improvements to Clang's diagnostics
 
 - Clang now shows implicit deduction guides when diagnosing overload resolution failure. #GH92393.
 
+- Clong no longer emits a no previous prototype warning for Win32 entry points under ``-Wmissing-prototypes``.
+  Fixes #GH94366.
+
 Improvements to Clang's time-trace
 ----------------------------------
 

--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -654,7 +654,7 @@ Improvements to Clang's diagnostics
 
 - Clang now shows implicit deduction guides when diagnosing overload resolution failure. #GH92393.
 
-- Clong no longer emits a no previous prototype warning for Win32 entry points under ``-Wmissing-prototypes``.
+- Clang no longer emits a "no previous prototype" warning for Win32 entry points under ``-Wmissing-prototypes``.
   Fixes #GH94366.
 
 Improvements to Clang's time-trace

--- a/clang/lib/Sema/SemaDecl.cpp
+++ b/clang/lib/Sema/SemaDecl.cpp
@@ -15214,6 +15214,9 @@ ShouldWarnAboutMissingPrototype(const FunctionDecl *FD,
       if (II->isStr("main") || II->isStr("efi_main"))
         return false;
 
+  if (FD->isMSVCRTEntryPoint())
+    return false;
+
   // Don't warn about inline functions.
   if (FD->isInlined())
     return false;

--- a/clang/test/Sema/no-warn-missing-prototype.c
+++ b/clang/test/Sema/no-warn-missing-prototype.c
@@ -3,31 +3,27 @@
 // RUN: %clang_cc1 -fms-compatibility -fsyntax-only -x c++ -ffreestanding -triple=x86_64-pc-win32 -verify -DMS %s
 // expected-no-diagnostics
 int main() {
-    return 0;
+  return 0;
 }
 
 int efi_main() {
-    return 0;
+  return 0;
 }
 
 #ifdef MS
-int wmain(int, wchar_t *[], wchar_t *[])
-{
-    return 0;
+int wmain(int, wchar_t *[], wchar_t *[]) {
+  return 0;
 }
 
-int wWinMain(void*, void*, wchar_t*, int)
-{
-    return 0;
+int wWinMain(void*, void*, wchar_t*, int) {
+  return 0;
 }
 
-int WinMain(void*, void*, char*, int)
-{
-    return 0;
+int WinMain(void*, void*, char*, int) {
+  return 0;
 }
 
-bool DllMain(void*, unsigned, void*)
-{
-    return true;
+bool DllMain(void*, unsigned, void* {
+  return true;
 }
 #endif

--- a/clang/test/Sema/no-warn-missing-prototype.c
+++ b/clang/test/Sema/no-warn-missing-prototype.c
@@ -1,10 +1,33 @@
 // RUN: %clang_cc1 -fsyntax-only -Wmissing-prototypes -x c -ffreestanding -verify %s
 // RUN: %clang_cc1 -fsyntax-only -Wmissing-prototypes -x c++ -ffreestanding -verify %s
+// RUN: %clang_cc1 -fms-compatibility -fsyntax-only -x c++ -ffreestanding -triple=x86_64-pc-win32 -verify -DMS %s
 // expected-no-diagnostics
 int main() {
-  return 0;
+    return 0;
 }
 
 int efi_main() {
-  return 0;
+    return 0;
 }
+
+#ifdef MS
+int wmain(int, wchar_t *[], wchar_t *[])
+{
+    return 0;
+}
+
+int wWinMain(void*, void*, wchar_t*, int)
+{
+    return 0;
+}
+
+int WinMain(void*, void*, char*, int)
+{
+    return 0;
+}
+
+bool DllMain(void*, unsigned, void*)
+{
+    return true;
+}
+#endif

--- a/clang/test/Sema/no-warn-missing-prototype.c
+++ b/clang/test/Sema/no-warn-missing-prototype.c
@@ -1,6 +1,6 @@
 // RUN: %clang_cc1 -fsyntax-only -Wmissing-prototypes -x c -ffreestanding -verify %s
 // RUN: %clang_cc1 -fsyntax-only -Wmissing-prototypes -x c++ -ffreestanding -verify %s
-// RUN: %clang_cc1 -fms-compatibility -fsyntax-only -x c++ -ffreestanding -triple=x86_64-pc-win32 -verify -DMS %s
+// RUN: %clang_cc1 -fms-compatibility -fsyntax-only -Wmissing-prototypes -x c++ -ffreestanding -triple=x86_64-pc-win32 -verify -DMS %s
 // expected-no-diagnostics
 int main() {
   return 0;
@@ -23,7 +23,7 @@ int WinMain(void*, void*, char*, int) {
   return 0;
 }
 
-bool DllMain(void*, unsigned, void* {
+bool DllMain(void*, unsigned, void*) {
   return true;
 }
 #endif


### PR DESCRIPTION
Fixes https://github.com/llvm/llvm-project/issues/94366.