### PR TITLE
[libc] Avoid the atexit and exit_handler dependency for exit

### DIFF
--- a/libc/config/baremetal/arm/entrypoints.txt
+++ b/libc/config/baremetal/arm/entrypoints.txt
@@ -176,6 +176,7 @@ set(TARGET_LIBC_ENTRYPOINTS
     libc.src.stdlib.bsearch
     libc.src.stdlib.calloc
     libc.src.stdlib.div
+    libc.src.stdlib.exit
     libc.src.stdlib.free
     libc.src.stdlib.freelist_malloc
     libc.src.stdlib.labs

--- a/libc/config/baremetal/riscv/entrypoints.txt
+++ b/libc/config/baremetal/riscv/entrypoints.txt
@@ -172,6 +172,7 @@ set(TARGET_LIBC_ENTRYPOINTS
     libc.src.stdlib.bsearch
     libc.src.stdlib.calloc
     libc.src.stdlib.div
+    libc.src.stdlib.exit
     libc.src.stdlib.free
     libc.src.stdlib.freelist_malloc
     libc.src.stdlib.labs

--- a/libc/src/stdlib/CMakeLists.txt
+++ b/libc/src/stdlib/CMakeLists.txt
@@ -505,9 +505,7 @@ add_entrypoint_object(
     exit.h
   DEPENDS
     ._Exit
-    .atexit
     libc.src.__support.OSUtil.osutil
-    .exit_handler
 )
 
 add_entrypoint_object(


### PR DESCRIPTION
These are not required and without these dependencies, we would wound up with an unresolved reference to __cxa_finalize, which can be provided by the vendor making this compatible with baremetal.