### PR TITLE
[clang][Driver] Fix Linux/sparc64 -m32

### DIFF
--- a/clang/lib/Driver/ToolChains/Gnu.cpp
+++ b/clang/lib/Driver/ToolChains/Gnu.cpp
@@ -2563,9 +2563,11 @@ void Generic_GCC::GCCInstallationDetector::AddDefaultGCCPrefixes(
                                                "riscv64-unknown-elf"};
 
   static const char *const SPARCv8LibDirs[] = {"/lib32", "/lib"};
-  static const char *const SPARCv8Triples[] = {"sparcv8-linux-gnu"};
+  static const char *const SPARCv8Triples[] = {"sparc-linux-gnu",
+                                               "sparcv8-linux-gnu"};
   static const char *const SPARCv9LibDirs[] = {"/lib64", "/lib"};
-  static const char *const SPARCv9Triples[] = {"sparcv9-linux-gnu"};
+  static const char *const SPARCv9Triples[] = {"sparc64-linux-gnu",
+                                               "sparcv9-linux-gnu"};
 
   static const char *const SystemZLibDirs[] = {"/lib64", "/lib"};
   static const char *const SystemZTriples[] = {


### PR DESCRIPTION
`clang` currently fails to find a GCC installation on Linux/sparc64 with `-m32`.  `strace` reveals that `clang` tries to access `/usr/lib/gcc/sparcv9-linux-gnu` (which doesn't exist) instead of `/usr/lib/gcc/sparc64-linux-gnu`.

It turns out that 20d497c26fc95c80a1bacb38820d92e5f52bec58 was overeager in removing some of the necessary directories.

Fixed by reverting the Linux/sparc* part of the patch.

Tested on `sparc64-unknown-linux-gnu`.