### PR TITLE
[libc] Use global errno for baremetal

### DIFF
--- a/libc/include/errno.h.def
+++ b/libc/include/errno.h.def
@@ -25,7 +25,8 @@
 #include "llvm-libc-macros/generic-error-number-macros.h"
 #endif
 
-#if defined(__AMDGPU__) || defined(__NVPTX__)
+#if defined(__AMDGPU__) || defined(__NVPTX__) || \
+  (defined(__ELF__) && !defined(__linux__) && !defined(__Fuchsia__))
 extern int __llvmlibc_errno; // Not thread_local!
 #else
 #ifdef __cplusplus

--- a/libc/src/errno/libc_errno.cpp
+++ b/libc/src/errno/libc_errno.cpp
@@ -23,6 +23,15 @@ LIBC_NAMESPACE::Errno::operator int() {
   return __llvmlibc_errno.load(cpp::MemoryOrder::RELAXED);
 }
 
+#elif defined(__ELF__) && !defined(__linux__) && !defined(__Fuchsia__)
+// This is the baremetal case which currently uses a global errno.
+extern "C" {
+int __llvmlibc_errno;
+}
+
+void LIBC_NAMESPACE::Errno::operator=(int a) { __llvmlibc_errno = a; }
+LIBC_NAMESPACE::Errno::operator int() { return __llvmlibc_errno; }
+
 #elif !defined(LIBC_COPT_PUBLIC_PACKAGING)
 // This mode is for unit testing.  We just use our internal errno.
 LIBC_THREAD_LOCAL int __llvmlibc_internal_errno;


### PR DESCRIPTION
We want to avoid thread local variables on baremetal since the TLS support may not be universally available in those environments.