### PR TITLE
[clang-tidy] ignore uninitialized std::array in member init

### DIFF
--- a/clang-tools-extra/clang-tidy/cppcoreguidelines/ProTypeMemberInitCheck.cpp
+++ b/clang-tools-extra/clang-tidy/cppcoreguidelines/ProTypeMemberInitCheck.cpp
@@ -432,6 +432,16 @@ static StringRef getInitializer(QualType QT, bool UseAssignment) {
   }
 }
 
+static bool isStdArray(QualType QT) {
+  const auto *RT = QT->getAs<RecordType>();
+  if (!RT)
+    return false;
+  const auto *RD = RT->getDecl();
+  if (!RD || !RD->getIdentifier())
+    return false;
+  return RD->getName() == "array" && RD->isInStdNamespace();
+}
+
 static void
 computeFieldsToInit(const ASTContext &Context, const RecordDecl &Record,
                     bool IgnoreArrays,
@@ -440,7 +450,8 @@ computeFieldsToInit(const ASTContext &Context, const RecordDecl &Record,
   forEachFieldWithFilter(
       Record, Record.fields(), AnyMemberHasInitPerUnion,
       [&](const FieldDecl *F) {
-        if (IgnoreArrays && F->getType()->isArrayType())
+        if (IgnoreArrays &&
+            (F->getType()->isArrayType() || isStdArray(F->getType())))
           return;
         if (F->hasInClassInitializer() && F->getParent()->isUnion()) {
           AnyMemberHasInitPerUnion = true;

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -109,6 +109,10 @@ New check aliases
 Changes in existing checks
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+- Improved :doc:`cppcoreguidelines-pro-type-member-init
+  <clang-tidy/checks/cppcoreguidelines/pro-type-member-init>` check by treating
+  ``std::array`` the same as built-in arrays when `IgnoreArrays` option is enabled.
+
 - Improved :doc:`misc-redundant-expression
   <clang-tidy/checks/misc/redundant-expression>` by fixing false positives in
   nested expressions involving different macros or a mix of macro and

--- a/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/pro-type-member-init.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/pro-type-member-init.rst
@@ -29,9 +29,10 @@ Options
 
 .. option:: IgnoreArrays
 
-   If set to `true`, the check will not warn about array members that are not
-   zero-initialized during construction. For performance critical code, it may
-   be important to not initialize fixed-size array members. Default is `false`.
+   If set to `true`, the check will not warn about array members (including
+   C arrays and ``std::array``) that are not zero-initialized during
+   construction. For performance critical code, it may be important to not
+   initialize fixed-size array members. Default is `false`.
 
 .. option:: UseAssignment
 

--- a/clang-tools-extra/test/clang-tidy/checkers/cppcoreguidelines/pro-type-member-init.ignorearrays.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/cppcoreguidelines/pro-type-member-init.ignorearrays.cpp
@@ -27,6 +27,13 @@ void test_local_std_array() {
   std::array<int, 4> a;
 }
 
+struct HasStdArrayMember {
+  // CHECK-MESSAGES: warning: constructor does not initialize these fields: Number
+  HasStdArrayMember() {}
+  std::array<int, 4> StdArray;
+  int Number;
+};
+
 struct OnlyArray {
   int a[4];
 };


### PR DESCRIPTION
cppcoreguidelines-pro-type-member-init check has an option IgnoreArrays for ignoring uninitialized C arrays. This patch adds support for C++ std::array as well.