### PR TITLE
[DebugInfo] Add 'REQUIRES: object-emission' in the test.

### DIFF
--- a/llvm/test/DebugInfo/subrange-missing-upperBound.ll
+++ b/llvm/test/DebugInfo/subrange-missing-upperBound.ll
@@ -1,5 +1,6 @@
 ; RUN: %llc_dwarf %s -filetype=obj -o %t
 ; RUN: llvm-dwarfdump -debug-info %t | FileCheck %s
+; REQUIRES: object-emission
 
 
 ; ModuleID = 'test.ll'

--- a/llvm/test/DebugInfo/subrange-missing-upperBound.ll
+++ b/llvm/test/DebugInfo/subrange-missing-upperBound.ll
@@ -1,4 +1,6 @@
-; RUN: %llc_dwarf %s -filetype=obj -o - | llvm-dwarfdump - | FileCheck %s
+; RUN: %llc_dwarf %s -filetype=obj -o %t
+; RUN: llvm-dwarfdump -debug-info %t | FileCheck %s
+
 
 ; ModuleID = 'test.ll'
 source_filename = "test.f90"


### PR DESCRIPTION
The test added in #96474 seems to cause buildbot failure on some system. I have added `REQUIRES: object-emission` in the test and also used `%t` instead of `-` for output.