### PR TITLE
[lldb] Use correct path separator for C++ library files lookup

### DIFF
--- a/lldb/source/Plugins/ExpressionParser/Clang/CppModuleConfiguration.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Clang/CppModuleConfiguration.cpp
@@ -71,7 +71,7 @@ bool CppModuleConfiguration::analyzeFile(const FileSpec &f,
   // If the path is in the libc++ include directory use it as the found libc++
   // path. Ignore subdirectories such as /c++/v1/experimental as those don't
   // need to be specified in the header search.
-  if (libcpp_regex.match(f.GetPath()) &&
+  if (libcpp_regex.match(convert_to_slash(f.GetPath())) &&
       parent_path(posix_dir, Style::posix).ends_with("c++")) {
     if (!m_std_inc.TrySet(posix_dir))
       return false;


### PR DESCRIPTION
Use POSIX-style path separators when checking for libcpp library path.
This is necessary to run API tests from 'std-module' group compiled on Windows host for Linux target.