### PR TITLE
[NFCI][clang][analyzer] Make ProgramStatePartialTrait a template definition

### DIFF
--- a/clang/include/clang/StaticAnalyzer/Core/PathSensitive/ProgramStateTrait.h
+++ b/clang/include/clang/StaticAnalyzer/Core/PathSensitive/ProgramStateTrait.h
@@ -26,7 +26,8 @@
 namespace clang {
 namespace ento {
 
-template <typename T, typename Enable = void> struct ProgramStatePartialTrait;
+template <typename T, typename Enable = void>
+struct ProgramStatePartialTrait {};
 
 /// Declares a program state trait for type \p Type called \p Name, and
 /// introduce a type named \c NameTy.


### PR DESCRIPTION
N4860 13 [class.derived]/2 mandates that base classes must be complete
types. Before this patch, ProgramStatePartialTrait is a forward
declaration of a class template, thus an incomplete type. Explicit
specializations of forward declared templates are also incomplete types,
until the body of the specialization is seen, thus should not appear as
a base class.
This patch makes ProgramStatePartialTrait a definition with an empty
body by default, enabling it to appear in a base-specifier list, and
practically eliminating a compiler warning given by GCC13.
