### PR TITLE
[BOLT] Add CustomOffset flag for optimizing kernel

### DIFF
--- a/bolt/include/bolt/Profile/DataAggregator.h
+++ b/bolt/include/bolt/Profile/DataAggregator.h
@@ -426,7 +426,12 @@ private:
   /// the base load address. External addresses, i.e. addresses that do not
   /// correspond to the binary allocated address space, are adjusted to avoid
   /// conflicts.
-  void adjustAddress(uint64_t &Address, const MMapInfo &MMI) const {
+  void adjustAddress(uint64_t &Address, const MMapInfo &MMI,
+                     int64_t CustomOffset) const {
+    if (CustomOffset) {
+      Address += CustomOffset;
+      return;
+    }
     if (Address >= MMI.MMapAddress && Address < MMI.MMapAddress + MMI.Size) {
       Address -= MMI.BaseAddress;
     } else if (Address < MMI.Size) {
@@ -436,9 +441,10 @@ private:
   }
 
   /// Adjust addresses in \p LBR entry.
-  void adjustLBR(LBREntry &LBR, const MMapInfo &MMI) const {
-    adjustAddress(LBR.From, MMI);
-    adjustAddress(LBR.To, MMI);
+  void adjustLBR(LBREntry &LBR, const MMapInfo &MMI,
+                 int64_t CustomOffset) const {
+    adjustAddress(LBR.From, MMI, CustomOffset);
+    adjustAddress(LBR.To, MMI, CustomOffset);
   }
 
   /// Ignore kernel/user transition LBR if requested

--- a/bolt/lib/Profile/DataAggregator.cpp
+++ b/bolt/lib/Profile/DataAggregator.cpp
@@ -110,6 +110,10 @@ static cl::opt<bool> WriteAutoFDOData(
     "autofdo", cl::desc("generate autofdo textual data instead of bolt data"),
     cl::cat(AggregatorCategory));
 
+static cl::opt<long long> CustomOffset("custom_offset", cl::init(0),
+                                       cl::desc("address plus custom_offset"),
+                                       cl::Optional, cl::Hidden,
+                                       cl::cat(AggregatorCategory));
 } // namespace opts
 
 namespace {
@@ -1112,8 +1116,8 @@ ErrorOr<DataAggregator::PerfBranchSample> DataAggregator::parseBranchSample() {
     LBREntry LBR = LBRRes.get();
     if (ignoreKernelInterrupt(LBR))
       continue;
-    if (!BC->HasFixedLoadAddress)
-      adjustLBR(LBR, MMapInfoIter->second);
+    if (!BC->HasFixedLoadAddress || CustomOffset)
+      adjustLBR(LBR, MMapInfoIter->second, CustomOffset);
     Res.LBR.push_back(LBR);
   }
 
@@ -1154,8 +1158,8 @@ ErrorOr<DataAggregator::PerfBasicSample> DataAggregator::parseBasicSample() {
   }
 
   uint64_t Address = *AddrRes;
-  if (!BC->HasFixedLoadAddress)
-    adjustAddress(Address, MMapInfoIter->second);
+  if (!BC->HasFixedLoadAddress || CustomOffset)
+    adjustAddress(Address, MMapInfoIter->second, CustomOffset);
 
   return PerfBasicSample{Event.get(), Address};
 }
@@ -1209,8 +1213,8 @@ ErrorOr<DataAggregator::PerfMemSample> DataAggregator::parseMemSample() {
   }
 
   uint64_t Address = *AddrRes;
-  if (!BC->HasFixedLoadAddress)
-    adjustAddress(Address, MMapInfoIter->second);
+  if (!BC->HasFixedLoadAddress || CustomOffset)
+    adjustAddress(Address, MMapInfoIter->second, CustomOffset);
 
   return PerfMemSample{PCRes.get(), Address};
 }

--- a/bolt/lib/Profile/DataAggregator.cpp
+++ b/bolt/lib/Profile/DataAggregator.cpp
@@ -1116,8 +1116,8 @@ ErrorOr<DataAggregator::PerfBranchSample> DataAggregator::parseBranchSample() {
     LBREntry LBR = LBRRes.get();
     if (ignoreKernelInterrupt(LBR))
       continue;
-    if (!BC->HasFixedLoadAddress || CustomOffset)
-      adjustLBR(LBR, MMapInfoIter->second, CustomOffset);
+    if (!BC->HasFixedLoadAddress || opts::CustomOffset)
+      adjustLBR(LBR, MMapInfoIter->second, opts::CustomOffset);
     Res.LBR.push_back(LBR);
   }
 
@@ -1158,8 +1158,8 @@ ErrorOr<DataAggregator::PerfBasicSample> DataAggregator::parseBasicSample() {
   }
 
   uint64_t Address = *AddrRes;
-  if (!BC->HasFixedLoadAddress || CustomOffset)
-    adjustAddress(Address, MMapInfoIter->second, CustomOffset);
+  if (!BC->HasFixedLoadAddress || opts::CustomOffset)
+    adjustAddress(Address, MMapInfoIter->second, opts::CustomOffset);
 
   return PerfBasicSample{Event.get(), Address};
 }
@@ -1213,8 +1213,8 @@ ErrorOr<DataAggregator::PerfMemSample> DataAggregator::parseMemSample() {
   }
 
   uint64_t Address = *AddrRes;
-  if (!BC->HasFixedLoadAddress || CustomOffset)
-    adjustAddress(Address, MMapInfoIter->second, CustomOffset);
+  if (!BC->HasFixedLoadAddress || opts::CustomOffset)
+    adjustAddress(Address, MMapInfoIter->second, opts::CustomOffset);
 
   return PerfMemSample{PCRes.get(), Address};
 }


### PR DESCRIPTION
When I use BOLT to optimize kernel, I found there exists one offset between `vmlinux` and `/proc/kallsyms`. And the address that perf script output matches `/proc/kallsyms` and dismatches `vmlinux`.