### PR TITLE
[MC] set OpenBSD's ELFOSABI by default

### DIFF
--- a/llvm/include/llvm/MC/MCELFObjectWriter.h
+++ b/llvm/include/llvm/MC/MCELFObjectWriter.h
@@ -78,6 +78,8 @@ public:
         return ELF::ELFOSABI_FREEBSD;
       case Triple::Solaris:
         return ELF::ELFOSABI_SOLARIS;
+      case Triple::OpenBSD:
+        return ELF::ELFOSABI_OPENBSD;
       default:
         return ELF::ELFOSABI_NONE;
     }

--- a/llvm/test/MC/ELF/osabi.s
+++ b/llvm/test/MC/ELF/osabi.s
@@ -10,3 +10,7 @@
 # RUN: llvm-mc -filetype=obj -triple=x86_64-unknown-freebsd %s | llvm-readobj -h - | \
 # RUN:   FileCheck %s --check-prefix=FREEBSD
 # FREEBSD: OS/ABI: FreeBSD
+
+# RUN: llvm-mc -filetype=obj -triple=x86_64-unknown-openbsd %s | llvm-readobj -h - | \
+# RUN:   FileCheck %s --check-prefix=OPENBSD
+# OPENBSD: OS/ABI: OpenBSD


### PR DESCRIPTION
This matches what is done for FreeBSD.

OpenBSD has a few special program header types, and other such ELF extensions. Setting the ELFOSABI like so will allow LLD to support them without needlessly impacting non-OpenBSD ELFs.

Testing strategy matches 06cecdc60ec9ebfdd4d8cdb2586d201272bdf6bd.

Leveraged by #97122