### PR TITLE
[libc] Fix readlink tests on 32-bit systems

### DIFF
--- a/libc/test/src/unistd/CMakeLists.txt
+++ b/libc/test/src/unistd/CMakeLists.txt
@@ -262,6 +262,7 @@ add_libc_unittest(
     libc.include.unistd
     libc.src.errno.errno
     libc.src.unistd.readlink
+    libc.src.string.string_utils
     libc.src.unistd.symlink
     libc.src.unistd.unlink
     libc.src.__support.CPP.string_view
@@ -279,6 +280,7 @@ add_libc_unittest(
     libc.include.unistd
     libc.src.errno.errno
     libc.src.unistd.readlinkat
+    libc.src.string.string_utils
     libc.src.unistd.symlink
     libc.src.unistd.unlink
     libc.src.__support.CPP.string_view

--- a/libc/test/src/unistd/readlinkat_test.cpp
+++ b/libc/test/src/unistd/readlinkat_test.cpp
@@ -8,6 +8,7 @@
 
 #include "src/__support/CPP/string_view.h"
 #include "src/errno/libc_errno.h"
+#include "src/string/string_utils.h"
 #include "src/unistd/readlinkat.h"
 #include "src/unistd/symlink.h"
 #include "src/unistd/unlink.h"
@@ -32,8 +33,9 @@ TEST(LlvmLibcReadlinkatTest, CreateAndUnlink) {
   //   3. Cleanup the symlink created in step #1.
   ASSERT_THAT(LIBC_NAMESPACE::symlink(LINK_VAL, LINK), Succeeds(0));
 
-  char buf[sizeof(LINK_VAL)];
-  ssize_t len = LIBC_NAMESPACE::readlinkat(AT_FDCWD, LINK, buf, sizeof(buf));
+  char buf[256];
+  ssize_t len = LIBC_NAMESPACE::readlinkat(
+      AT_FDCWD, LINK, buf, LIBC_NAMESPACE::internal::string_length(FILENAME));
   ASSERT_ERRNO_SUCCESS();
   ASSERT_EQ(cpp::string_view(buf, len), cpp::string_view(LINK_VAL));
 
@@ -42,8 +44,9 @@ TEST(LlvmLibcReadlinkatTest, CreateAndUnlink) {
 
 TEST(LlvmLibcReadlinkatTest, ReadlinkInNonExistentPath) {
   using LIBC_NAMESPACE::testing::ErrnoSetterMatcher::Fails;
-  char buf[8];
-  ASSERT_THAT(LIBC_NAMESPACE::readlinkat(AT_FDCWD, "non-existent-link", buf,
-                                         sizeof(buf)),
-              Fails(ENOENT));
+  constexpr auto LEN = 8;
+  char buf[LEN];
+  ASSERT_THAT(
+      LIBC_NAMESPACE::readlinkat(AT_FDCWD, "non-existent-link", buf, LEN),
+      Fails(ENOENT));
 }


### PR DESCRIPTION
This patch changes the call sizeof(<Cstring>) to call malloc with the actual lenght of the string to allocate space for buf.

The test case worked in 64-bit systems because the sizeof(CString) was big enough (19 bytes) to hold the contents of FILENAME, but in 32-bit systems sizeof(CString) is only 12 bytes long, causing a truncation of FILENAME when placing it in buf.

I also changed the vla to a malloc instead to silence a "variable length arrays are a C99 feature [-Wvla-extension]" warning.