### PR TITLE
[libc++] Fix sized deallocation comments in tests

### DIFF
--- a/libcxx/test/libcxx/language.support/support.dynamic/libcpp_deallocate.sh.cpp
+++ b/libcxx/test/libcxx/language.support/support.dynamic/libcpp_deallocate.sh.cpp
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// test libc++'s implementation of align_val_t, and the relevant new/delete
+// Test libc++'s implementation of align_val_t, and the relevant new/delete
 // overloads in all dialects when -faligned-allocation is present.
 
 // Libc++ when built for z/OS doesn't contain the aligned allocation functions,
@@ -20,9 +20,6 @@
 
 // GCC doesn't support the aligned-allocation flags.
 // XFAIL: gcc
-
-// These compiler versions do not have proper sized deallocation support.
-// UNSUPPORTED: clang-17, clang-18
 
 // RUN: %{build} -faligned-allocation -fsized-deallocation
 // RUN: %{run}

--- a/libcxx/test/std/language.support/support.dynamic/new.delete/new.delete.array/sized_delete_array14.pass.cpp
+++ b/libcxx/test/std/language.support/support.dynamic/new.delete/new.delete.array/sized_delete_array14.pass.cpp
@@ -8,7 +8,7 @@
 
 // test sized operator delete[] replacement.
 
-// These compiler versions do not have proper sized deallocation support.
+// These compiler versions don't enable sized deallocation by default.
 // UNSUPPORTED: clang-17, clang-18
 
 // UNSUPPORTED: sanitizer-new-delete, c++03, c++11

--- a/libcxx/test/std/language.support/support.dynamic/new.delete/new.delete.single/sized_delete14.pass.cpp
+++ b/libcxx/test/std/language.support/support.dynamic/new.delete/new.delete.single/sized_delete14.pass.cpp
@@ -6,9 +6,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-// test sized operator delete replacement.
+// Test sized operator delete replacement.
 
-// These compiler versions do not have proper sized deallocation support.
+// These compiler versions do not enable sized deallocation by default.
 // UNSUPPORTED: clang-17, clang-18
 
 // UNSUPPORTED: sanitizer-new-delete, c++03, c++11


### PR DESCRIPTION
Clang 19 turned on sized deallocation *by default*, but older versions of Clang did support sized deallocation nonetheless. This updates a few comments and removes UNSUPPORTED annotations that shouldn't be needed in a test that passes -fsized-deallocation directly.