### PR TITLE
[libc] Include stdio.h in baremetal getchar.cpp

### DIFF
--- a/libc/src/stdio/baremetal/CMakeLists.txt
+++ b/libc/src/stdio/baremetal/CMakeLists.txt
@@ -5,6 +5,7 @@ add_entrypoint_object(
   HDRS
     ../getchar.h
   DEPENDS
+    libc.include.stdio
     libc.src.__support.OSUtil.osutil
     libc.src.__support.CPP.string_view
 )

--- a/libc/src/stdio/baremetal/getchar.cpp
+++ b/libc/src/stdio/baremetal/getchar.cpp
@@ -9,6 +9,8 @@
 #include "src/stdio/getchar.h"
 #include "src/__support/OSUtil/io.h"
 
+#include <stdio.h>
+
 namespace LIBC_NAMESPACE {
 
 LLVM_LIBC_FUNCTION(int, getchar, ()) {


### PR DESCRIPTION
This is needed for the EOF constant.