### PR TITLE
[mlir][openacc] Added custom builder for acc::ParallelOp

### DIFF
--- a/mlir/include/mlir/Dialect/OpenACC/OpenACCOps.td
+++ b/mlir/include/mlir/Dialect/OpenACC/OpenACCOps.td
@@ -1121,6 +1121,20 @@ def OpenACC_ParallelOp : OpenACC_Op<"parallel",
 
   let regions = (region AnyRegion:$region);
 
+  let builders = [
+    OpBuilder<(ins
+      CArg<"mlir::ValueRange", "{}">:$numGangs,
+      CArg<"mlir::ValueRange", "{}">:$numWorkers,
+      CArg<"mlir::ValueRange", "{}">:$vectorLength,
+      CArg<"mlir::ValueRange", "{}">:$asyncOperands,
+      CArg<"mlir::ValueRange", "{}">:$waitOperands,
+      CArg<"mlir::Value", "{}">:$ifCond,
+      CArg<"mlir::Value", "{}">:$selfCond,
+      CArg<"mlir::ValueRange", "{}">:$reductionOperands,
+      CArg<"mlir::ValueRange", "{}">:$gangPrivateOperands,
+      CArg<"mlir::ValueRange", "{}">:$gangFirstPrivateOperands,
+      CArg<"mlir::ValueRange", "{}">:$dataClauseOperands)>];
+
   let extraClassDeclaration = [{
     /// The number of data operands.
     unsigned getNumDataOperands();

--- a/mlir/lib/Dialect/OpenACC/IR/OpenACC.cpp
+++ b/mlir/lib/Dialect/OpenACC/IR/OpenACC.cpp
@@ -905,6 +905,31 @@ mlir::Value ParallelOp::getWaitDevnum(mlir::acc::DeviceType deviceType) {
                             deviceType);
 }
 
+void ParallelOp::build(mlir::OpBuilder &odsBuilder,
+                       mlir::OperationState &odsState,
+                       mlir::ValueRange numGangs, mlir::ValueRange numWorkers,
+                       mlir::ValueRange vectorLength,
+                       mlir::ValueRange asyncOperands,
+                       mlir::ValueRange waitOperands, mlir::Value ifCond,
+                       mlir::Value selfCond, mlir::ValueRange reductionOperands,
+                       mlir::ValueRange gangPrivateOperands,
+                       mlir::ValueRange gangFirstPrivateOperands,
+                       mlir::ValueRange dataClauseOperands) {
+
+  ParallelOp::build(
+      odsBuilder, odsState, asyncOperands, /*asyncOperandsDeviceType=*/nullptr,
+      /*asyncOnly=*/nullptr, waitOperands, /*waitOperandsSegments=*/nullptr,
+      /*waitOperandsDeviceType=*/nullptr, /*hasWaitDevnum=*/nullptr,
+      /*waitOnly=*/nullptr, numGangs, /*numGangsSegments=*/nullptr,
+      /*numGangsDeviceType=*/nullptr, numWorkers,
+      /*numWorkersDeviceType=*/nullptr, vectorLength,
+      /*vectorLengthDeviceType=*/nullptr, ifCond, selfCond,
+      /*selfAttr=*/nullptr, reductionOperands, /*reductionRecipes=*/nullptr,
+      gangPrivateOperands, /*privatizations=*/nullptr, gangFirstPrivateOperands,
+      /*firstprivatizations=*/nullptr, dataClauseOperands,
+      /*defaultAttr=*/nullptr, /*combined=*/nullptr);
+}
+
 static ParseResult parseNumGangs(
     mlir::OpAsmParser &parser,
     llvm::SmallVectorImpl<mlir::OpAsmParser::UnresolvedOperand> &operands,
@@ -2085,8 +2110,8 @@ void printLoopControl(OpAsmPrinter &p, Operation *op, Region &region,
     llvm::interleaveComma(regionArgs, p,
                           [&p](Value v) { p << v << " : " << v.getType(); });
     p << ") = (" << lowerbound << " : " << lowerboundType << ") to ("
-      << upperbound << " : " << upperboundType << ") "
-      << " step (" << steps << " : " << stepType << ") ";
+      << upperbound << " : " << upperboundType << ") " << " step (" << steps
+      << " : " << stepType << ") ";
   }
   p.printRegion(region, /*printEntryBlockArgs=*/false);
 }


### PR DESCRIPTION
This change adds a custom builder for `acc::ParallelOp`. This enables users to only specify the operands they would need for their `acc::ParallelOp` while building it. They can specify nothing to create an empty `acc.parallel`, or all of the 11 operands listed [here](https://mlir.llvm.org/docs/Dialects/OpenACCDialect/#operands-27), or anywhere in between following the specified order in this custom builder. Unspecified operands are left empty. Additionally, users can later set the optional attributes such as `numGangsDeviceType` using the available attribute setters for `acc::ParallelOp`.