### PR TITLE
[APINotes] Refactor: remove references to `ObjCContext...`

### DIFF
--- a/clang/include/clang/APINotes/APINotesReader.h
+++ b/clang/include/clang/APINotes/APINotesReader.h
@@ -101,7 +101,7 @@ public:
   /// \param Name The name of the class we're looking for.
   ///
   /// \returns The information about the class, if known.
-  VersionedInfo<ObjCContextInfo> lookupObjCClassInfo(llvm::StringRef Name);
+  VersionedInfo<ContextInfo> lookupObjCClassInfo(llvm::StringRef Name);
 
   /// Look for the context ID of the given Objective-C protocol.
   ///
@@ -115,7 +115,7 @@ public:
   /// \param Name The name of the protocol we're looking for.
   ///
   /// \returns The information about the protocol, if known.
-  VersionedInfo<ObjCContextInfo> lookupObjCProtocolInfo(llvm::StringRef Name);
+  VersionedInfo<ContextInfo> lookupObjCProtocolInfo(llvm::StringRef Name);
 
   /// Look for information regarding the given Objective-C property in
   /// the given context.

--- a/clang/include/clang/APINotes/APINotesWriter.h
+++ b/clang/include/clang/APINotes/APINotesWriter.h
@@ -53,10 +53,10 @@ public:
   ///
   /// \returns the ID of the class, protocol, or namespace, which can be used to
   /// add properties and methods to the class/protocol/namespace.
-  ContextID addObjCContext(std::optional<ContextID> ParentCtxID,
-                           llvm::StringRef Name, ContextKind Kind,
-                           const ObjCContextInfo &Info,
-                           llvm::VersionTuple SwiftVersion);
+  ContextID addContext(std::optional<ContextID> ParentCtxID,
+                       llvm::StringRef Name, ContextKind Kind,
+                       const ContextInfo &Info,
+                       llvm::VersionTuple SwiftVersion);
 
   /// Add information about a specific Objective-C property.
   ///

--- a/clang/include/clang/APINotes/Types.h
+++ b/clang/include/clang/APINotes/Types.h
@@ -192,8 +192,9 @@ inline bool operator!=(const CommonTypeInfo &LHS, const CommonTypeInfo &RHS) {
   return !(LHS == RHS);
 }
 
-/// Describes API notes data for an Objective-C class or protocol.
-class ObjCContextInfo : public CommonTypeInfo {
+/// Describes API notes data for an Objective-C class or protocol or a C++
+/// namespace.
+class ContextInfo : public CommonTypeInfo {
   /// Whether this class has a default nullability.
   LLVM_PREFERRED_TYPE(bool)
   unsigned HasDefaultNullability : 1;
@@ -217,7 +218,7 @@ class ObjCContextInfo : public CommonTypeInfo {
   unsigned SwiftObjCMembers : 1;
 
 public:
-  ObjCContextInfo()
+  ContextInfo()
       : HasDefaultNullability(0), DefaultNullability(0), HasDesignatedInits(0),
         SwiftImportAsNonGenericSpecified(false), SwiftImportAsNonGeneric(false),
         SwiftObjCMembersSpecified(false), SwiftObjCMembers(false) {}
@@ -269,9 +270,9 @@ public:
     DefaultNullability = 0;
   }
 
-  friend bool operator==(const ObjCContextInfo &, const ObjCContextInfo &);
+  friend bool operator==(const ContextInfo &, const ContextInfo &);
 
-  ObjCContextInfo &operator|=(const ObjCContextInfo &RHS) {
+  ContextInfo &operator|=(const ContextInfo &RHS) {
     // Merge inherited info.
     static_cast<CommonTypeInfo &>(*this) |= RHS;
 
@@ -294,7 +295,7 @@ public:
   LLVM_DUMP_METHOD void dump(llvm::raw_ostream &OS);
 };
 
-inline bool operator==(const ObjCContextInfo &LHS, const ObjCContextInfo &RHS) {
+inline bool operator==(const ContextInfo &LHS, const ContextInfo &RHS) {
   return static_cast<const CommonTypeInfo &>(LHS) == RHS &&
          LHS.getDefaultNullability() == RHS.getDefaultNullability() &&
          LHS.HasDesignatedInits == RHS.HasDesignatedInits &&
@@ -302,7 +303,7 @@ inline bool operator==(const ObjCContextInfo &LHS, const ObjCContextInfo &RHS) {
          LHS.getSwiftObjCMembers() == RHS.getSwiftObjCMembers();
 }
 
-inline bool operator!=(const ObjCContextInfo &LHS, const ObjCContextInfo &RHS) {
+inline bool operator!=(const ContextInfo &LHS, const ContextInfo &RHS) {
   return !(LHS == RHS);
 }
 
@@ -387,7 +388,7 @@ public:
   friend bool operator==(const ObjCPropertyInfo &, const ObjCPropertyInfo &);
 
   /// Merge class-wide information into the given property.
-  ObjCPropertyInfo &operator|=(const ObjCContextInfo &RHS) {
+  ObjCPropertyInfo &operator|=(const ContextInfo &RHS) {
     static_cast<CommonEntityInfo &>(*this) |= RHS;
 
     // Merge nullability.
@@ -626,7 +627,7 @@ public:
 
   friend bool operator==(const ObjCMethodInfo &, const ObjCMethodInfo &);
 
-  ObjCMethodInfo &operator|=(const ObjCContextInfo &RHS) {
+  ObjCMethodInfo &operator|=(const ContextInfo &RHS) {
     // Merge Nullability.
     if (!NullabilityAudited) {
       if (auto Nullable = RHS.getDefaultNullability()) {

--- a/clang/lib/APINotes/APINotesFormat.h
+++ b/clang/lib/APINotes/APINotesFormat.h
@@ -132,26 +132,26 @@ using IdentifierDataLayout = llvm::BCRecordLayout<
     >;
 } // namespace identifier_block
 
-namespace objc_context_block {
+namespace context_block {
 enum {
-  OBJC_CONTEXT_ID_DATA = 1,
-  OBJC_CONTEXT_INFO_DATA = 2,
+  CONTEXT_ID_DATA = 1,
+  CONTEXT_INFO_DATA = 2,
 };
 
-using ObjCContextIDLayout =
-    llvm::BCRecordLayout<OBJC_CONTEXT_ID_DATA, // record ID
+using ContextIDLayout =
+    llvm::BCRecordLayout<CONTEXT_ID_DATA, // record ID
                          llvm::BCVBR<16>, // table offset within the blob (see
                                           // below)
                          llvm::BCBlob // map from ObjC class names/protocol (as
                                       // IDs) to context IDs
                          >;
 
-using ObjCContextInfoLayout = llvm::BCRecordLayout<
-    OBJC_CONTEXT_INFO_DATA, // record ID
-    llvm::BCVBR<16>,        // table offset within the blob (see below)
-    llvm::BCBlob            // map from ObjC context IDs to context information.
+using ContextInfoLayout = llvm::BCRecordLayout<
+    CONTEXT_INFO_DATA, // record ID
+    llvm::BCVBR<16>,   // table offset within the blob (see below)
+    llvm::BCBlob       // map from ObjC context IDs to context information.
     >;
-} // namespace objc_context_block
+} // namespace context_block
 
 namespace objc_property_block {
 enum {

--- a/clang/lib/APINotes/APINotesTypes.cpp
+++ b/clang/lib/APINotes/APINotesTypes.cpp
@@ -32,7 +32,7 @@ LLVM_DUMP_METHOD void CommonTypeInfo::dump(llvm::raw_ostream &OS) const {
   OS << '\n';
 }
 
-LLVM_DUMP_METHOD void ObjCContextInfo::dump(llvm::raw_ostream &OS) {
+LLVM_DUMP_METHOD void ContextInfo::dump(llvm::raw_ostream &OS) {
   static_cast<CommonTypeInfo &>(*this).dump(OS);
   if (HasDefaultNullability)
     OS << "DefaultNullability: " << DefaultNullability << ' ';

--- a/clang/lib/APINotes/APINotesWriter.cpp
+++ b/clang/lib/APINotes/APINotesWriter.cpp
@@ -42,8 +42,8 @@ class APINotesWriter::Implementation {
   /// this context and provides both the context ID and information describing
   /// the context within that module.
   llvm::DenseMap<ContextTableKey,
-                 std::pair<unsigned, VersionedSmallVector<ObjCContextInfo>>>
-      ObjCContexts;
+                 std::pair<unsigned, VersionedSmallVector<ContextInfo>>>
+      Contexts;
 
   /// Information about parent contexts for each context.
   ///
@@ -51,7 +51,7 @@ class APINotesWriter::Implementation {
   llvm::DenseMap<uint32_t, uint32_t> ParentContexts;
 
   /// Mapping from context IDs to the identifier ID holding the name.
-  llvm::DenseMap<unsigned, unsigned> ObjCContextNames;
+  llvm::DenseMap<unsigned, unsigned> ContextNames;
 
   /// Information about Objective-C properties.
   ///
@@ -147,7 +147,7 @@ private:
   void writeBlockInfoBlock(llvm::BitstreamWriter &Stream);
   void writeControlBlock(llvm::BitstreamWriter &Stream);
   void writeIdentifierBlock(llvm::BitstreamWriter &Stream);
-  void writeObjCContextBlock(llvm::BitstreamWriter &Stream);
+  void writeContextBlock(llvm::BitstreamWriter &Stream);
   void writeObjCPropertyBlock(llvm::BitstreamWriter &Stream);
   void writeObjCMethodBlock(llvm::BitstreamWriter &Stream);
   void writeObjCSelectorBlock(llvm::BitstreamWriter &Stream);
@@ -178,7 +178,7 @@ void APINotesWriter::Implementation::writeToStream(llvm::raw_ostream &OS) {
     writeBlockInfoBlock(Stream);
     writeControlBlock(Stream);
     writeIdentifierBlock(Stream);
-    writeObjCContextBlock(Stream);
+    writeContextBlock(Stream);
     writeObjCPropertyBlock(Stream);
     writeObjCMethodBlock(Stream);
     writeObjCSelectorBlock(Stream);
@@ -240,7 +240,7 @@ void APINotesWriter::Implementation::writeBlockInfoBlock(
   BLOCK_RECORD(identifier_block, IDENTIFIER_DATA);
 
   BLOCK(OBJC_CONTEXT_BLOCK);
-  BLOCK_RECORD(objc_context_block, OBJC_CONTEXT_ID_DATA);
+  BLOCK_RECORD(context_block, CONTEXT_ID_DATA);
 
   BLOCK(OBJC_PROPERTY_BLOCK);
   BLOCK_RECORD(objc_property_block, OBJC_PROPERTY_DATA);
@@ -337,7 +337,7 @@ void APINotesWriter::Implementation::writeIdentifierBlock(
 
 namespace {
 /// Used to serialize the on-disk Objective-C context table.
-class ObjCContextIDTableInfo {
+class ContextIDTableInfo {
 public:
   using key_type = ContextTableKey;
   using key_type_ref = key_type;
@@ -552,9 +552,8 @@ void emitCommonTypeInfo(raw_ostream &OS, const CommonTypeInfo &CTI) {
 }
 
 /// Used to serialize the on-disk Objective-C property table.
-class ObjCContextInfoTableInfo
-    : public VersionedTableInfo<ObjCContextInfoTableInfo, unsigned,
-                                ObjCContextInfo> {
+class ContextInfoTableInfo
+    : public VersionedTableInfo<ContextInfoTableInfo, unsigned, ContextInfo> {
 public:
   unsigned getKeyLength(key_type_ref) { return sizeof(uint32_t); }
 
@@ -567,11 +566,11 @@ public:
     return static_cast<size_t>(llvm::hash_value(Key));
   }
 
-  unsigned getUnversionedInfoSize(const ObjCContextInfo &OCI) {
+  unsigned getUnversionedInfoSize(const ContextInfo &OCI) {
     return getCommonTypeInfoSize(OCI) + 1;
   }
 
-  void emitUnversionedInfo(raw_ostream &OS, const ObjCContextInfo &OCI) {
+  void emitUnversionedInfo(raw_ostream &OS, const ContextInfo &OCI) {
     emitCommonTypeInfo(OS, OCI);
 
     uint8_t payload = 0;
@@ -590,19 +589,19 @@ public:
 };
 } // namespace
 
-void APINotesWriter::Implementation::writeObjCContextBlock(
+void APINotesWriter::Implementation::writeContextBlock(
     llvm::BitstreamWriter &Stream) {
   llvm::BCBlockRAII restoreBlock(Stream, OBJC_CONTEXT_BLOCK_ID, 3);
 
-  if (ObjCContexts.empty())
+  if (Contexts.empty())
     return;
 
   {
     llvm::SmallString<4096> HashTableBlob;
     uint32_t Offset;
     {
-      llvm::OnDiskChainedHashTableGenerator<ObjCContextIDTableInfo> Generator;
-      for (auto &OC : ObjCContexts)
+      llvm::OnDiskChainedHashTableGenerator<ContextIDTableInfo> Generator;
+      for (auto &OC : Contexts)
         Generator.insert(OC.first, OC.second.first);
 
       llvm::raw_svector_ostream BlobStream(HashTableBlob);
@@ -612,16 +611,16 @@ void APINotesWriter::Implementation::writeObjCContextBlock(
       Offset = Generator.Emit(BlobStream);
     }
 
-    objc_context_block::ObjCContextIDLayout ObjCContextID(Stream);
-    ObjCContextID.emit(Scratch, Offset, HashTableBlob);
+    context_block::ContextIDLayout ContextID(Stream);
+    ContextID.emit(Scratch, Offset, HashTableBlob);
   }
 
   {
     llvm::SmallString<4096> HashTableBlob;
     uint32_t Offset;
     {
-      llvm::OnDiskChainedHashTableGenerator<ObjCContextInfoTableInfo> Generator;
-      for (auto &OC : ObjCContexts)
+      llvm::OnDiskChainedHashTableGenerator<ContextInfoTableInfo> Generator;
+      for (auto &OC : Contexts)
         Generator.insert(OC.second.first, OC.second.second);
 
       llvm::raw_svector_ostream BlobStream(HashTableBlob);
@@ -631,8 +630,8 @@ void APINotesWriter::Implementation::writeObjCContextBlock(
       Offset = Generator.Emit(BlobStream);
     }
 
-    objc_context_block::ObjCContextInfoLayout ObjCContextInfo(Stream);
-    ObjCContextInfo.emit(Scratch, Offset, HashTableBlob);
+    context_block::ContextInfoLayout ContextInfo(Stream);
+    ContextInfo.emit(Scratch, Offset, HashTableBlob);
   }
 }
 
@@ -1263,25 +1262,25 @@ void APINotesWriter::writeToStream(llvm::raw_ostream &OS) {
   Implementation->writeToStream(OS);
 }
 
-ContextID APINotesWriter::addObjCContext(std::optional<ContextID> ParentCtxID,
-                                         StringRef Name, ContextKind Kind,
-                                         const ObjCContextInfo &Info,
-                                         VersionTuple SwiftVersion) {
+ContextID APINotesWriter::addContext(std::optional<ContextID> ParentCtxID,
+                                     llvm::StringRef Name, ContextKind Kind,
+                                     const ContextInfo &Info,
+                                     llvm::VersionTuple SwiftVersion) {
   IdentifierID NameID = Implementation->getIdentifier(Name);
 
   uint32_t RawParentCtxID = ParentCtxID ? ParentCtxID->Value : -1;
   ContextTableKey Key(RawParentCtxID, static_cast<uint8_t>(Kind), NameID);
-  auto Known = Implementation->ObjCContexts.find(Key);
-  if (Known == Implementation->ObjCContexts.end()) {
-    unsigned NextID = Implementation->ObjCContexts.size() + 1;
+  auto Known = Implementation->Contexts.find(Key);
+  if (Known == Implementation->Contexts.end()) {
+    unsigned NextID = Implementation->Contexts.size() + 1;
 
-    Implementation::VersionedSmallVector<ObjCContextInfo> EmptyVersionedInfo;
-    Known = Implementation->ObjCContexts
+    Implementation::VersionedSmallVector<ContextInfo> EmptyVersionedInfo;
+    Known = Implementation->Contexts
                 .insert(std::make_pair(
                     Key, std::make_pair(NextID, EmptyVersionedInfo)))
                 .first;
 
-    Implementation->ObjCContextNames[NextID] = NameID;
+    Implementation->ContextNames[NextID] = NameID;
     Implementation->ParentContexts[NextID] = RawParentCtxID;
   }
 
@@ -1328,9 +1327,9 @@ void APINotesWriter::addObjCMethod(ContextID CtxID, ObjCSelectorRef Selector,
     uint32_t ParentCtxID = Implementation->ParentContexts[CtxID.Value];
     ContextTableKey CtxKey(ParentCtxID,
                            static_cast<uint8_t>(ContextKind::ObjCClass),
-                           Implementation->ObjCContextNames[CtxID.Value]);
-    assert(Implementation->ObjCContexts.contains(CtxKey));
-    auto &VersionedVec = Implementation->ObjCContexts[CtxKey].second;
+                           Implementation->ContextNames[CtxID.Value]);
+    assert(Implementation->Contexts.contains(CtxKey));
+    auto &VersionedVec = Implementation->Contexts[CtxKey].second;
     bool Found = false;
     for (auto &Versioned : VersionedVec) {
       if (Versioned.first == SwiftVersion) {
@@ -1341,7 +1340,7 @@ void APINotesWriter::addObjCMethod(ContextID CtxID, ObjCSelectorRef Selector,
     }
 
     if (!Found) {
-      VersionedVec.push_back({SwiftVersion, ObjCContextInfo()});
+      VersionedVec.push_back({SwiftVersion, ContextInfo()});
       VersionedVec.back().second.setHasDesignatedInits(true);
     }
   }

--- a/clang/lib/APINotes/APINotesYAMLCompiler.cpp
+++ b/clang/lib/APINotes/APINotesYAMLCompiler.cpp
@@ -786,7 +786,7 @@ public:
   void convertContext(std::optional<ContextID> ParentContextID, const Class &C,
                       ContextKind Kind, VersionTuple SwiftVersion) {
     // Write the class.
-    ObjCContextInfo CI;
+    ContextInfo CI;
     convertCommonType(C, CI, C.Name);
 
     if (C.AuditedForNullability)
@@ -797,7 +797,7 @@ public:
       CI.setSwiftObjCMembers(*C.SwiftObjCMembers);
 
     ContextID CtxID =
-        Writer.addObjCContext(ParentContextID, C.Name, Kind, CI, SwiftVersion);
+        Writer.addContext(ParentContextID, C.Name, Kind, CI, SwiftVersion);
 
     // Write all methods.
     llvm::StringMap<std::pair<bool, bool>> KnownMethods;
@@ -863,12 +863,12 @@ public:
                                const Namespace &TheNamespace,
                                VersionTuple SwiftVersion) {
     // Write the namespace.
-    ObjCContextInfo CI;
+    ContextInfo CI;
     convertCommonEntity(TheNamespace, CI, TheNamespace.Name);
 
     ContextID CtxID =
-        Writer.addObjCContext(ParentContextID, TheNamespace.Name,
-                              ContextKind::Namespace, CI, SwiftVersion);
+        Writer.addContext(ParentContextID, TheNamespace.Name,
+                          ContextKind::Namespace, CI, SwiftVersion);
 
     convertTopLevelItems(Context(CtxID, ContextKind::Namespace),
                          TheNamespace.Items, SwiftVersion);

--- a/clang/lib/Sema/SemaAPINotes.cpp
+++ b/clang/lib/Sema/SemaAPINotes.cpp
@@ -674,7 +674,7 @@ static void ProcessAPINotes(Sema &S, TypedefNameDecl *D,
 
 /// Process API notes for an Objective-C class or protocol.
 static void ProcessAPINotes(Sema &S, ObjCContainerDecl *D,
-                            const api_notes::ObjCContextInfo &Info,
+                            const api_notes::ContextInfo &Info,
                             VersionedInfoMetadata Metadata) {
   // Handle common type information.
   ProcessAPINotes(S, D, static_cast<const api_notes::CommonTypeInfo &>(Info),
@@ -683,7 +683,7 @@ static void ProcessAPINotes(Sema &S, ObjCContainerDecl *D,
 
 /// Process API notes for an Objective-C class.
 static void ProcessAPINotes(Sema &S, ObjCInterfaceDecl *D,
-                            const api_notes::ObjCContextInfo &Info,
+                            const api_notes::ContextInfo &Info,
                             VersionedInfoMetadata Metadata) {
   if (auto AsNonGeneric = Info.getSwiftImportAsNonGeneric()) {
     handleAPINotedAttribute<SwiftImportAsNonGenericAttr>(


### PR DESCRIPTION
API Notes now support in C++. In preparation for supporting C++ methods in API Notes, this change renames the remaining usages of `ObjCContextABC` into `ContextABC` to make it clear that those contexts might actually be C++, not Objective-C.

This is NFC-ish.