### PR TITLE
[RISCV] Add ability to list extensions enabled for a target

### DIFF
--- a/clang/docs/CommandGuide/clang.rst
+++ b/clang/docs/CommandGuide/clang.rst
@@ -393,6 +393,12 @@ number of cross compilers, or may only support a native target.
   allowed to generate instructions that are valid on i486 and later processors,
   but which may not exist on earlier ones.
 
+.. option:: --print-enabled-extensions
+
+  Prints the list of extensions that are enabled for the target specified by the
+  combination of `--target`, `-march`, and `-mcpu` values. Currently, this
+  option is only supported on AArch64 and RISC-V. On RISC-V, this option also
+  prints out the ISA string of enabled extensions.
 
 Code Generation Options
 ~~~~~~~~~~~~~~~~~~~~~~~

--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -5730,7 +5730,7 @@ def print_supported_extensions : Flag<["-", "--"], "print-supported-extensions">
 def print_enabled_extensions : Flag<["-", "--"], "print-enabled-extensions">,
   Visibility<[ClangOption, CC1Option, CLOption]>,
   HelpText<"Print the extensions enabled by the given target and -march/-mcpu options."
-           " (AArch64 only)">,
+           " (AArch64 and RISC-V only)">,
   MarshallingInfoFlag<FrontendOpts<"PrintEnabledExtensions">>;
 def : Flag<["-"], "mcpu=help">, Alias<print_supported_cpus>;
 def : Flag<["-"], "mtune=help">, Alias<print_supported_cpus>;

--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -4367,6 +4367,7 @@ void Driver::BuildActions(Compilation &C, DerivedArgList &Args,
         return;
       }
       if (Opt == options::OPT_print_enabled_extensions &&
+          !C.getDefaultToolChain().getTriple().isRISCV() &&
           !C.getDefaultToolChain().getTriple().isAArch64()) {
         C.getDriver().Diag(diag::err_opt_not_valid_on_target)
             << "--print-enabled-extensions";

--- a/clang/tools/driver/cc1_main.cpp
+++ b/clang/tools/driver/cc1_main.cpp
@@ -147,7 +147,7 @@ static int PrintSupportedExtensions(std::string TargetStr) {
     DescMap.insert({feature.Key, feature.Desc});
 
   if (MachineTriple.isRISCV())
-    llvm::riscvExtensionsHelp(DescMap);
+    llvm::printSupportedExtensions(DescMap);
   else if (MachineTriple.isAArch64())
     llvm::AArch64::PrintSupportedExtensions();
   else if (MachineTriple.isARM())
@@ -190,13 +190,19 @@ static int PrintEnabledExtensions(const TargetOptions& TargetOpts) {
   for (const llvm::SubtargetFeatureKV &feature : Features)
     EnabledFeatureNames.insert(feature.Key);
 
-  if (!MachineTriple.isAArch64()) {
+  if (MachineTriple.isAArch64())
+    llvm::AArch64::printEnabledExtensions(EnabledFeatureNames);
+  else if (MachineTriple.isRISCV()) {
+    llvm::StringMap<llvm::StringRef> DescMap;
+    for (const llvm::SubtargetFeatureKV &feature : Features)
+      DescMap.insert({feature.Key, feature.Desc});
+    llvm::printEnabledExtensions(MachineTriple.isArch64Bit(), EnabledFeatureNames, DescMap);
+  } else {
     // The option was already checked in Driver::HandleImmediateArgs,
     // so we do not expect to get here if we are not a supported architecture.
     assert(0 && "Unhandled triple for --print-enabled-extensions option.");
     return 1;
   }
-  llvm::AArch64::printEnabledExtensions(EnabledFeatureNames);
 
   return 0;
 }

--- a/clang/tools/driver/cc1_main.cpp
+++ b/clang/tools/driver/cc1_main.cpp
@@ -147,7 +147,7 @@ static int PrintSupportedExtensions(std::string TargetStr) {
     DescMap.insert({feature.Key, feature.Desc});
 
   if (MachineTriple.isRISCV())
-    llvm::printSupportedExtensions(DescMap);
+    llvm::RISCVISAInfo::printSupportedExtensions(DescMap);
   else if (MachineTriple.isAArch64())
     llvm::AArch64::PrintSupportedExtensions();
   else if (MachineTriple.isARM())
@@ -196,7 +196,8 @@ static int PrintEnabledExtensions(const TargetOptions& TargetOpts) {
     llvm::StringMap<llvm::StringRef> DescMap;
     for (const llvm::SubtargetFeatureKV &feature : Features)
       DescMap.insert({feature.Key, feature.Desc});
-    llvm::printEnabledExtensions(MachineTriple.isArch64Bit(), EnabledFeatureNames, DescMap);
+    llvm::RISCVISAInfo::printEnabledExtensions(MachineTriple.isArch64Bit(),
+                                               EnabledFeatureNames, DescMap);
   } else {
     // The option was already checked in Driver::HandleImmediateArgs,
     // so we do not expect to get here if we are not a supported architecture.

--- a/llvm/include/llvm/TargetParser/RISCVISAInfo.h
+++ b/llvm/include/llvm/TargetParser/RISCVISAInfo.h
@@ -20,10 +20,6 @@
 #include <vector>
 
 namespace llvm {
-void printSupportedExtensions(StringMap<StringRef> &DescMap);
-void printEnabledExtensions(bool IsRV64,
-                            std::set<StringRef> &EnabledFeatureNames,
-                            StringMap<StringRef> &DescMap);
 
 class RISCVISAInfo {
 public:
@@ -78,6 +74,11 @@ public:
   static bool isSupportedExtension(StringRef Ext, unsigned MajorVersion,
                                    unsigned MinorVersion);
   static std::string getTargetFeatureForExtension(StringRef Ext);
+
+  static void printSupportedExtensions(StringMap<StringRef> &DescMap);
+  static void printEnabledExtensions(bool IsRV64,
+                                     std::set<StringRef> &EnabledFeatureNames,
+                                     StringMap<StringRef> &DescMap);
 
 private:
   RISCVISAInfo(unsigned XLen) : XLen(XLen) {}

--- a/llvm/include/llvm/TargetParser/RISCVISAInfo.h
+++ b/llvm/include/llvm/TargetParser/RISCVISAInfo.h
@@ -15,11 +15,15 @@
 #include "llvm/Support/RISCVISAUtils.h"
 
 #include <map>
+#include <set>
 #include <string>
 #include <vector>
 
 namespace llvm {
-void riscvExtensionsHelp(StringMap<StringRef> DescMap);
+void printSupportedExtensions(StringMap<StringRef> &DescMap);
+void printEnabledExtensions(bool IsRV64,
+                            std::set<StringRef> &EnabledFeatureNames,
+                            StringMap<StringRef> &DescMap);
 
 class RISCVISAInfo {
 public:

--- a/llvm/lib/TargetParser/RISCVISAInfo.cpp
+++ b/llvm/lib/TargetParser/RISCVISAInfo.cpp
@@ -80,8 +80,7 @@ static void PrintExtension(StringRef Name, StringRef Version,
          << Description << "\n";
 }
 
-void llvm::riscvExtensionsHelp(StringMap<StringRef> DescMap) {
-
+void llvm::printSupportedExtensions(StringMap<StringRef> &DescMap) {
   outs() << "All available -march extensions for RISC-V\n\n";
   PrintExtension("Name", "Version", (DescMap.empty() ? "" : "Description"));
 
@@ -114,6 +113,45 @@ void llvm::riscvExtensionsHelp(StringMap<StringRef> DescMap) {
 
   outs() << "\nUse -march to specify the target's extension.\n"
             "For example, clang -march=rv32i_v1p0\n";
+}
+
+void llvm::printEnabledExtensions(bool IsRV64,
+                                  std::set<StringRef> &EnabledFeatureNames,
+                                  StringMap<StringRef> &DescMap) {
+  outs() << "Extensions enabled for the given RISC-V target\n\n";
+  PrintExtension("Name", "Version", (DescMap.empty() ? "" : "Description"));
+
+  RISCVISAUtils::OrderedExtensionMap FullExtMap;
+  RISCVISAUtils::OrderedExtensionMap ExtMap;
+  for (const auto &E : SupportedExtensions)
+    if (EnabledFeatureNames.find(E.Name) != EnabledFeatureNames.end()) {
+      FullExtMap[E.Name] = {E.Version.Major, E.Version.Minor};
+      ExtMap[E.Name] = {E.Version.Major, E.Version.Minor};
+    }
+  for (const auto &E : ExtMap) {
+    std::string Version =
+        std::to_string(E.second.Major) + "." + std::to_string(E.second.Minor);
+    PrintExtension(E.first, Version, DescMap[E.first]);
+  }
+
+  outs() << "\nExperimental extensions\n";
+  ExtMap.clear();
+  for (const auto &E : SupportedExperimentalExtensions) {
+    StringRef Name(E.Name);
+    if (EnabledFeatureNames.find("experimental-" + Name.str()) !=
+        EnabledFeatureNames.end()) {
+      FullExtMap[E.Name] = {E.Version.Major, E.Version.Minor};
+      ExtMap[E.Name] = {E.Version.Major, E.Version.Minor};
+    }
+  }
+  for (const auto &E : ExtMap) {
+    std::string Version =
+        std::to_string(E.second.Major) + "." + std::to_string(E.second.Minor);
+    PrintExtension(E.first, Version, DescMap["experimental-" + E.first]);
+  }
+
+  unsigned XLen = IsRV64 ? 64 : 32;
+  outs() << "\nISA String: " << RISCVISAInfo(XLen, FullExtMap).toString();
 }
 
 static bool stripExperimentalPrefix(StringRef &Ext) {

--- a/llvm/lib/TargetParser/RISCVISAInfo.cpp
+++ b/llvm/lib/TargetParser/RISCVISAInfo.cpp
@@ -80,7 +80,7 @@ static void PrintExtension(StringRef Name, StringRef Version,
          << Description << "\n";
 }
 
-void llvm::printSupportedExtensions(StringMap<StringRef> &DescMap) {
+void RISCVISAInfo::printSupportedExtensions(StringMap<StringRef> &DescMap) {
   outs() << "All available -march extensions for RISC-V\n\n";
   PrintExtension("Name", "Version", (DescMap.empty() ? "" : "Description"));
 
@@ -115,9 +115,9 @@ void llvm::printSupportedExtensions(StringMap<StringRef> &DescMap) {
             "For example, clang -march=rv32i_v1p0\n";
 }
 
-void llvm::printEnabledExtensions(bool IsRV64,
-                                  std::set<StringRef> &EnabledFeatureNames,
-                                  StringMap<StringRef> &DescMap) {
+void RISCVISAInfo::printEnabledExtensions(
+    bool IsRV64, std::set<StringRef> &EnabledFeatureNames,
+    StringMap<StringRef> &DescMap) {
   outs() << "Extensions enabled for the given RISC-V target\n\n";
   PrintExtension("Name", "Version", (DescMap.empty() ? "" : "Description"));
 

--- a/llvm/lib/TargetParser/RISCVISAInfo.cpp
+++ b/llvm/lib/TargetParser/RISCVISAInfo.cpp
@@ -150,7 +150,8 @@ void RISCVISAInfo::printEnabledExtensions(
   }
 
   unsigned XLen = IsRV64 ? 64 : 32;
-  outs() << "\nISA String: " << RISCVISAInfo(XLen, FullExtMap).toString();
+  if (auto ISAString = RISCVISAInfo::createFromExtMap(XLen, FullExtMap))
+    outs() << "\nISA String: " << ISAString.get()->toString();
 }
 
 static bool stripExperimentalPrefix(StringRef &Ext) {

--- a/llvm/lib/TargetParser/RISCVISAInfo.cpp
+++ b/llvm/lib/TargetParser/RISCVISAInfo.cpp
@@ -124,7 +124,7 @@ void RISCVISAInfo::printEnabledExtensions(
   RISCVISAUtils::OrderedExtensionMap FullExtMap;
   RISCVISAUtils::OrderedExtensionMap ExtMap;
   for (const auto &E : SupportedExtensions)
-    if (EnabledFeatureNames.find(E.Name) != EnabledFeatureNames.end()) {
+    if (EnabledFeatureNames.count(E.Name) != 0) {
       FullExtMap[E.Name] = {E.Version.Major, E.Version.Minor};
       ExtMap[E.Name] = {E.Version.Major, E.Version.Minor};
     }
@@ -138,8 +138,7 @@ void RISCVISAInfo::printEnabledExtensions(
   ExtMap.clear();
   for (const auto &E : SupportedExperimentalExtensions) {
     StringRef Name(E.Name);
-    if (EnabledFeatureNames.find("experimental-" + Name.str()) !=
-        EnabledFeatureNames.end()) {
+    if (EnabledFeatureNames.count("experimental-" + Name.str()) != 0) {
       FullExtMap[E.Name] = {E.Version.Major, E.Version.Minor};
       ExtMap[E.Name] = {E.Version.Major, E.Version.Minor};
     }

--- a/llvm/unittests/TargetParser/RISCVISAInfoTest.cpp
+++ b/llvm/unittests/TargetParser/RISCVISAInfoTest.cpp
@@ -1060,7 +1060,7 @@ For example, clang -march=rv32i_v1p0)";
 
   outs().flush();
   testing::internal::CaptureStdout();
-  printSupportedExtensions(DummyMap);
+  RISCVISAInfo::printSupportedExtensions(DummyMap);
   outs().flush();
 
   std::string CapturedOutput = testing::internal::GetCapturedStdout();
@@ -1090,7 +1090,8 @@ ISA String: rv64i2p1_ztso0p1)";
 
   outs().flush();
   testing::internal::CaptureStdout();
-  llvm::printEnabledExtensions(/*IsRV64=*/true, EnabledExtensions, DescMap);
+  RISCVISAInfo::printEnabledExtensions(/*IsRV64=*/true, EnabledExtensions,
+                                        DescMap);
   outs().flush();
   std::string CapturedOutput = testing::internal::GetCapturedStdout();
 

--- a/llvm/unittests/TargetParser/RISCVISAInfoTest.cpp
+++ b/llvm/unittests/TargetParser/RISCVISAInfoTest.cpp
@@ -1060,11 +1060,39 @@ For example, clang -march=rv32i_v1p0)";
 
   outs().flush();
   testing::internal::CaptureStdout();
-  riscvExtensionsHelp(DummyMap);
+  printSupportedExtensions(DummyMap);
   outs().flush();
 
   std::string CapturedOutput = testing::internal::GetCapturedStdout();
   EXPECT_TRUE([](std::string &Captured, std::string &Expected) {
                 return Captured.find(Expected) != std::string::npos;
               }(CapturedOutput, ExpectedOutput));
+}
+
+TEST(TargetParserTest, RISCVPrintEnabledExtensions) {
+  // clang-format off
+  std::string ExpectedOutput =
+R"(Extensions enabled for the given RISC-V target
+
+    Name                 Version   Description
+    i                    2.1       'I' (Base Integer Instruction Set)
+
+Experimental extensions
+    ztso                 0.1       'Ztso' (Memory Model - Total Store Order)
+
+ISA String: rv64i2p1_ztso0p1)";
+  // clang-format on
+
+  StringMap<StringRef> DescMap;
+  DescMap["i"] = "'I' (Base Integer Instruction Set)";
+  DescMap["experimental-ztso"] = "'Ztso' (Memory Model - Total Store Order)";
+  std::set<StringRef> EnabledExtensions = {"i", "experimental-ztso"};
+
+  outs().flush();
+  testing::internal::CaptureStdout();
+  llvm::printEnabledExtensions(/*IsRV64=*/true, EnabledExtensions, DescMap);
+  outs().flush();
+  std::string CapturedOutput = testing::internal::GetCapturedStdout();
+
+  EXPECT_EQ(CapturedOutput, ExpectedOutput);
 }

--- a/llvm/unittests/TargetParser/RISCVISAInfoTest.cpp
+++ b/llvm/unittests/TargetParser/RISCVISAInfoTest.cpp
@@ -1078,20 +1078,20 @@ R"(Extensions enabled for the given RISC-V target
     i                    2.1       'I' (Base Integer Instruction Set)
 
 Experimental extensions
-    ztso                 0.1       'Ztso' (Memory Model - Total Store Order)
+    zicfilp              0.4       'Zicfilp' (Landing pad)
 
-ISA String: rv64i2p1_ztso0p1)";
+ISA String: rv64i2p1_zicfilp0p4)";
   // clang-format on
 
   StringMap<StringRef> DescMap;
   DescMap["i"] = "'I' (Base Integer Instruction Set)";
-  DescMap["experimental-ztso"] = "'Ztso' (Memory Model - Total Store Order)";
-  std::set<StringRef> EnabledExtensions = {"i", "experimental-ztso"};
+  DescMap["experimental-zicfilp"] = "'Zicfilp' (Landing pad)";
+  std::set<StringRef> EnabledExtensions = {"i", "experimental-zicfilp"};
 
   outs().flush();
   testing::internal::CaptureStdout();
   RISCVISAInfo::printEnabledExtensions(/*IsRV64=*/true, EnabledExtensions,
-                                        DescMap);
+                                       DescMap);
   outs().flush();
   std::string CapturedOutput = testing::internal::GetCapturedStdout();
 

--- a/llvm/unittests/TargetParser/RISCVISAInfoTest.cpp
+++ b/llvm/unittests/TargetParser/RISCVISAInfoTest.cpp
@@ -1080,7 +1080,7 @@ R"(Extensions enabled for the given RISC-V target
 Experimental extensions
     zicfilp              0.4       'Zicfilp' (Landing pad)
 
-ISA String: rv64i2p1_zicfilp0p4)";
+ISA String: rv64i2p1_zicfilp0p4_zicsr2p0)";
   // clang-format on
 
   StringMap<StringRef> DescMap;


### PR DESCRIPTION
bb83a3d introduced `--print-enabled-extensions` command line option for AArch64. This patch introduces RISC-V support for this option.

`riscvExtensionsHelp` is renamed to `printSupportedExtensions` to by synonymous with AArch64 and so it is clear what that function does.