### PR TITLE
[libc] Move off_t and stdio macros to proxy hdrs

### DIFF
--- a/libc/config/gpu/api.td
+++ b/libc/config/gpu/api.td
@@ -59,11 +59,6 @@ def FenvAPI: PublicAPI<"fenv.h"> {
 }
 
 def StdIOAPI : PublicAPI<"stdio.h"> {
-  let Macros = [
-    SimpleMacroDef<"_IOFBF", "0">,
-    SimpleMacroDef<"_IOLBF", "1">,
-    SimpleMacroDef<"_IONBF", "2">,
-  ];
   let Types = [
     "FILE",
     "off_t",

--- a/libc/config/linux/api.td
+++ b/libc/config/linux/api.td
@@ -76,9 +76,6 @@ def StdIOAPI : PublicAPI<"stdio.h"> {
     SimpleMacroDef<"stderr", "stderr">,
     SimpleMacroDef<"stdin", "stdin">,
     SimpleMacroDef<"stdout", "stdout">,
-    SimpleMacroDef<"_IOFBF", "0">,
-    SimpleMacroDef<"_IOLBF", "1">,
-    SimpleMacroDef<"_IONBF", "2">,
   ];
   let Types = [
     "FILE",

--- a/libc/hdr/CMakeLists.txt
+++ b/libc/hdr/CMakeLists.txt
@@ -70,6 +70,16 @@ add_proxy_header_library(
 )
 
 add_proxy_header_library(
+  stdio_macros
+  HDRS
+    stdio_macros.h
+  FULL_BUILD_DEPENDS
+    libc.include.stdio
+    libc.include.llvm-libc-macros.stdio_macros
+    libc.include.llvm-libc-macros.file_seek_macros
+)
+
+add_proxy_header_library(
   sys_epoll_macros
   HDRS
     sys_epoll_macros.h

--- a/libc/hdr/stdio_macros.h
+++ b/libc/hdr/stdio_macros.h
@@ -1,0 +1,23 @@
+//===-- Definition of macros from stdio.h --------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_HDR_STDIO_MACROS_H
+#define LLVM_LIBC_HDR_STDIO_MACROS_H
+
+#ifdef LIBC_FULL_BUILD
+
+#include "include/llvm-libc-macros/file-seek-macros.h"
+#include "include/llvm-libc-macros/stdio-macros.h"
+
+#else // Overlay mode
+
+#include <stdio.h>
+
+#endif // LLVM_LIBC_FULL_BUILD
+
+#endif // LLVM_LIBC_HDR_STDIO_MACROS_H

--- a/libc/hdr/types/CMakeLists.txt
+++ b/libc/hdr/types/CMakeLists.txt
@@ -135,3 +135,12 @@ add_proxy_header_library(
     libc.include.llvm-libc-types.struct_sigaction
     libc.include.signal
 )
+
+add_proxy_header_library(
+  off_t
+  HDRS
+    off_t.h
+  FULL_BUILD_DEPENDS
+    libc.include.llvm-libc-types.off_t
+    libc.include.stdio
+)

--- a/libc/hdr/types/off_t.h
+++ b/libc/hdr/types/off_t.h
@@ -1,0 +1,22 @@
+//===-- Proxy for off_t ---------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_HDR_TYPES_OFF_T_H
+#define LLVM_LIBC_HDR_TYPES_OFF_T_H
+
+#ifdef LIBC_FULL_BUILD
+
+#include "include/llvm-libc-types/off_t.h"
+
+#else // Overlay mode
+
+#include <stdio.h>
+
+#endif // LLVM_LIBC_FULL_BUILD
+
+#endif // LLVM_LIBC_HDR_TYPES_OFF_T_H

--- a/libc/include/llvm-libc-macros/stdio-macros.h
+++ b/libc/include/llvm-libc-macros/stdio-macros.h
@@ -15,4 +15,8 @@
 
 #define BUFSIZ 1024
 
+#define _IONBF 2
+#define _IOLBF 1
+#define _IOFBF 0
+
 #endif // LLVM_LIBC_MACROS_STDIO_MACROS_H

--- a/libc/newhdrgen/yaml/stdio.yaml
+++ b/libc/newhdrgen/yaml/stdio.yaml
@@ -1,11 +1,5 @@
 header: stdio.h
 macros:
-  - macro_name: _IONBF
-    macro_value: 2
-  - macro_name: _IOLBF
-    macro_value: 1
-  - macro_name: _IOFBF
-    macro_value: 0
   - macro_name: stdout
     macro_value: stdout
   - macro_name: stdin

--- a/libc/src/__support/File/CMakeLists.txt
+++ b/libc/src/__support/File/CMakeLists.txt
@@ -16,6 +16,8 @@ add_object_library(
     libc.src.__support.CPP.span
     libc.src.__support.threads.mutex
     libc.src.__support.error_or
+    libc.hdr.types.off_t
+    libc.hdr.stdio_macros
 )
 
 add_object_library(

--- a/libc/src/__support/File/file.cpp
+++ b/libc/src/__support/File/file.cpp
@@ -8,12 +8,11 @@
 
 #include "file.h"
 
+#include "hdr/stdio_macros.h"
+#include "hdr/types/off_t.h"
 #include "src/__support/CPP/new.h"
 #include "src/__support/CPP/span.h"
 #include "src/errno/libc_errno.h" // For error macros
-
-#include <stdio.h>
-#include <stdlib.h>
 
 namespace LIBC_NAMESPACE {
 

--- a/libc/src/__support/File/file.h
+++ b/libc/src/__support/File/file.h
@@ -9,7 +9,8 @@
 #ifndef LLVM_LIBC_SRC___SUPPORT_FILE_FILE_H
 #define LLVM_LIBC_SRC___SUPPORT_FILE_FILE_H
 
-#include "include/llvm-libc-types/off_t.h"
+#include "hdr/stdio_macros.h"
+#include "hdr/types/off_t.h"
 #include "src/__support/CPP/new.h"
 #include "src/__support/error_or.h"
 #include "src/__support/macros/properties/architectures.h"

--- a/libc/src/__support/File/linux/CMakeLists.txt
+++ b/libc/src/__support/File/linux/CMakeLists.txt
@@ -5,6 +5,7 @@ add_object_library(
     file.cpp
   HDRS
     file.h
+    lseekImpl.h
   DEPENDS
     libc.include.fcntl
     libc.include.stdio
@@ -15,6 +16,8 @@ add_object_library(
     libc.src.errno.errno
     libc.src.__support.error_or
     libc.src.__support.File.file
+    libc.hdr.types.off_t
+    libc.hdr.stdio_macros
 )
 
 add_object_library(

--- a/libc/src/__support/File/linux/file.cpp
+++ b/libc/src/__support/File/linux/file.cpp
@@ -8,6 +8,8 @@
 
 #include "file.h"
 
+#include "hdr/stdio_macros.h"
+#include "hdr/types/off_t.h"
 #include "src/__support/CPP/new.h"
 #include "src/__support/File/file.h"
 #include "src/__support/File/linux/lseekImpl.h"
@@ -15,8 +17,7 @@
 #include "src/__support/OSUtil/syscall.h" // For internal syscall function.
 #include "src/errno/libc_errno.h"         // For error macros
 
-#include <fcntl.h> // For mode_t and other flags to the open syscall
-#include <stdio.h>
+#include <fcntl.h>       // For mode_t and other flags to the open syscall
 #include <sys/stat.h>    // For S_IS*, S_IF*, and S_IR* flags.
 #include <sys/syscall.h> // For syscall numbers
 

--- a/libc/src/__support/File/linux/file.h
+++ b/libc/src/__support/File/linux/file.h
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "hdr/types/off_t.h"
 #include "src/__support/File/file.h"
 
 namespace LIBC_NAMESPACE {

--- a/libc/src/__support/File/linux/lseekImpl.h
+++ b/libc/src/__support/File/linux/lseekImpl.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_LIBC_SRC___SUPPORT_FILE_LINUX_LSEEKIMPL_H
 #define LLVM_LIBC_SRC___SUPPORT_FILE_LINUX_LSEEKIMPL_H
 
+#include "hdr/types/off_t.h"
 #include "src/__support/OSUtil/syscall.h" // For internal syscall function.
 #include "src/__support/common.h"
 #include "src/__support/error_or.h"
@@ -16,7 +17,6 @@
 
 #include <stdint.h>      // For uint64_t.
 #include <sys/syscall.h> // For syscall numbers.
-#include <unistd.h>      // For off_t.
 
 namespace LIBC_NAMESPACE {
 namespace internal {

--- a/libc/src/__support/OSUtil/linux/CMakeLists.txt
+++ b/libc/src/__support/OSUtil/linux/CMakeLists.txt
@@ -21,4 +21,5 @@ add_object_library(
     libc.hdr.types.struct_flock
     libc.hdr.types.struct_flock64
     libc.hdr.types.struct_f_owner_ex
+    libc.hdr.types.off_t
 )

--- a/libc/src/__support/OSUtil/linux/fcntl.cpp
+++ b/libc/src/__support/OSUtil/linux/fcntl.cpp
@@ -9,6 +9,7 @@
 #include "src/__support/OSUtil/fcntl.h"
 
 #include "hdr/fcntl_macros.h"
+#include "hdr/types/off_t.h"
 #include "hdr/types/struct_f_owner_ex.h"
 #include "hdr/types/struct_flock.h"
 #include "hdr/types/struct_flock64.h"

--- a/libc/src/stdio/CMakeLists.txt
+++ b/libc/src/stdio/CMakeLists.txt
@@ -61,7 +61,8 @@ add_entrypoint_object(
   HDRS
     fopencookie.h
   DEPENDS
-    libc.include.stdio
+    libc.hdr.stdio_macros
+    libc.hdr.types.off_t
     libc.src.__support.CPP.new
     libc.src.__support.File.file
 )
@@ -74,7 +75,7 @@ add_entrypoint_object(
     setbuf.h
   DEPENDS
     libc.src.errno.errno
-    libc.include.stdio
+    libc.hdr.types.off_t
     libc.src.__support.File.file
     libc.src.__support.File.platform_file
 )

--- a/libc/src/stdio/fopencookie.cpp
+++ b/libc/src/stdio/fopencookie.cpp
@@ -7,12 +7,12 @@
 //===----------------------------------------------------------------------===//
 
 #include "src/stdio/fopencookie.h"
+#include "hdr/stdio_macros.h"
+#include "hdr/types/off_t.h"
 #include "src/__support/CPP/new.h"
 #include "src/__support/File/file.h"
 
 #include "src/errno/libc_errno.h"
-#include <stdio.h>
-#include <stdlib.h>
 
 namespace LIBC_NAMESPACE {
 

--- a/libc/src/stdio/setbuf.cpp
+++ b/libc/src/stdio/setbuf.cpp
@@ -7,10 +7,9 @@
 //===----------------------------------------------------------------------===//
 
 #include "src/stdio/setbuf.h"
+#include "hdr/stdio_macros.h"
 #include "src/__support/File/file.h"
-
 #include "src/errno/libc_errno.h"
-#include <stdio.h>
 
 namespace LIBC_NAMESPACE {
 

--- a/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
@@ -138,6 +138,11 @@ libc_support_library(
     hdrs = ["hdr/float_macros.h"],
 )
 
+libc_support_library(
+    name = "hdr_stdio_macros",
+    hdrs = ["hdr/stdio_macros.h"],
+)
+
 ############################ Type Proxy Header Files ###########################
 
 libc_support_library(
@@ -178,6 +183,11 @@ libc_support_library(
 libc_support_library(
     name = "types_pid_t",
     hdrs = ["hdr/types/pid_t.h"],
+)
+
+libc_support_library(
+    name = "types_off_t",
+    hdrs = ["hdr/types/off_t.h"],
 )
 
 ############################### Support libraries ##############################
@@ -667,6 +677,8 @@ libc_support_library(
         ":__support_error_or",
         ":__support_threads_mutex",
         ":errno",
+        ":hdr_stdio_macros",
+        ":types_off_t",
     ],
 )
 
@@ -678,6 +690,7 @@ libc_support_library(
         ":__support_error_or",
         ":__support_osutil_syscall",
         ":errno",
+        ":types_off_t",
     ],
 )
 


### PR DESCRIPTION
The arm32 build has been failing due to redefinitions of the off_t type.
This patch fixes this by moving off_t to a proper proxy header. To do
this, it also moves stdio macros to a proxy header to hopefully avoid
including this proxy header alongside this public stdio.h.
