### PR TITLE
[NVPTX][NFC] Use same logic to get alignment in param declarations and function prototypes

### DIFF
--- a/llvm/lib/Target/NVPTX/NVPTXISelLowering.cpp
+++ b/llvm/lib/Target/NVPTX/NVPTXISelLowering.cpp
@@ -1438,10 +1438,8 @@ std::string NVPTXTargetLowering::getPrototype(
 
     if (!Outs[OIdx].Flags.isByVal()) {
       if (IsTypePassedAsArray(Ty)) {
-        const CallInst *CallI = cast<CallInst>(&CB);
         Align ParamAlign =
-            getAlign(*CallI, i + AttributeList::FirstArgIndex)
-                .value_or(getFunctionParamOptimizedAlign(F, Ty, DL));
+            getArgumentAlignment(&CB, Ty, i + AttributeList::FirstArgIndex, DL);
         O << ".param .align " << ParamAlign.value() << " .b8 ";
         O << "_";
         O << "[" << DL.getTypeAllocSize(Ty) << "]";


### PR DESCRIPTION
Unifies the logic used to choose function prototype argument alignment and param alignment declared in the caller. The call in `getPrototype` to `getAlign`/`getFunctionParamOptimizedAlign` is replaced with `getArgumentAlignment`, which is what is currently used to select the alignment for the param declarations. This avoids code duplication of `getAlign().value_or(getFunctionParamOptimizedAlign())` and ensures that param alignments are the same in declarations and prototypes.