### PR TITLE
[compiler-rt][memprof] Do not add libdl to MEMPROF_UNITTEST_LINK_LIBRARIES

### DIFF
--- a/compiler-rt/lib/memprof/tests/CMakeLists.txt
+++ b/compiler-rt/lib/memprof/tests/CMakeLists.txt
@@ -49,7 +49,6 @@ endif()
 set(MEMPROF_UNITTEST_LINK_LIBRARIES
   ${COMPILER_RT_UNWINDER_LINK_LIBS}
   ${SANITIZER_TEST_CXX_LIBRARIES})
-append_list_if(COMPILER_RT_HAS_LIBDL -ldl MEMPROF_UNITTEST_LINK_LIBRARIES)
 
 # Adds memprof tests for each architecture.
 macro(add_memprof_tests_for_arch arch)


### PR DESCRIPTION
The memprof tests do not actually depend on libdl. 
They might have a transitive dependency on libdl through the runtime, but the runtime takes care of itself.
Based on the offline discussions it looks like this piece of code in cmake is a historical artifact.

Test plan: ninja check-all