### PR TITLE
[libc] Move the internal extern "C" symbols inside the namespace

### DIFF
--- a/libc/src/__support/OSUtil/baremetal/exit.cpp
+++ b/libc/src/__support/OSUtil/baremetal/exit.cpp
@@ -8,10 +8,10 @@
 
 #include "src/__support/OSUtil/exit.h"
 
+namespace LIBC_NAMESPACE::internal {
+
 // This is intended to be provided by the vendor.
 extern "C" [[noreturn]] void __llvm_libc_exit(int status);
-
-namespace LIBC_NAMESPACE::internal {
 
 [[noreturn]] void exit(int status) { __llvm_libc_exit(status); }
 

--- a/libc/src/__support/OSUtil/baremetal/io.cpp
+++ b/libc/src/__support/OSUtil/baremetal/io.cpp
@@ -10,14 +10,14 @@
 
 #include "src/__support/CPP/string_view.h"
 
+namespace LIBC_NAMESPACE {
+
 // This is intended to be provided by the vendor.
 
 extern struct __llvm_libc_stdin __llvm_libc_stdin;
 extern "C" ssize_t __llvm_libc_stdin_read(void *cookie, char *buf, size_t size);
 
 extern "C" void __llvm_libc_log_write(const char *msg, size_t len);
-
-namespace LIBC_NAMESPACE {
 
 ssize_t read_from_stdin(char *buf, size_t size) {
   return __llvm_libc_stdin_read(reinterpret_cast<void *>(&__llvm_libc_stdin),

--- a/libc/src/stdlib/exit.cpp
+++ b/libc/src/stdlib/exit.cpp
@@ -10,9 +10,9 @@
 #include "src/__support/OSUtil/exit.h"
 #include "src/__support/common.h"
 
-extern "C" void __cxa_finalize(void *);
-
 namespace LIBC_NAMESPACE {
+
+extern "C" void __cxa_finalize(void *);
 
 [[noreturn]] LLVM_LIBC_FUNCTION(void, exit, (int status)) {
   __cxa_finalize(nullptr);

--- a/libc/startup/baremetal/fini.cpp
+++ b/libc/startup/baremetal/fini.cpp
@@ -9,12 +9,12 @@
 #include <stddef.h>
 #include <stdint.h>
 
+namespace LIBC_NAMESPACE {
+
 extern "C" {
 extern uintptr_t __fini_array_start[];
 extern uintptr_t __fini_array_end[];
 }
-
-namespace LIBC_NAMESPACE {
 
 using FiniCallback = void(void);
 

--- a/libc/startup/baremetal/init.cpp
+++ b/libc/startup/baremetal/init.cpp
@@ -9,14 +9,14 @@
 #include <stddef.h>
 #include <stdint.h>
 
+namespace LIBC_NAMESPACE {
+
 extern "C" {
 extern uintptr_t __preinit_array_start[];
 extern uintptr_t __preinit_array_end[];
 extern uintptr_t __init_array_start[];
 extern uintptr_t __init_array_end[];
 }
-
-namespace LIBC_NAMESPACE {
 
 using InitCallback = void(void);
 


### PR DESCRIPTION
This ensures that these symbols inherit the namespace visibility.