### PR TITLE
[RISCV][GISEL] Do not initialize GlobalISel objects unless needed

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVSubtarget.cpp
+++ b/llvm/lib/Target/RISCV/RISCVSubtarget.cpp
@@ -97,29 +97,32 @@ RISCVSubtarget::RISCVSubtarget(const Triple &TT, StringRef CPU,
       RVVVectorBitsMin(RVVVectorBitsMin), RVVVectorBitsMax(RVVVectorBitsMax),
       FrameLowering(
           initializeSubtargetDependencies(TT, CPU, TuneCPU, FS, ABIName)),
-      InstrInfo(*this), RegInfo(getHwMode()), TLInfo(TM, *this) {
-  CallLoweringInfo.reset(new RISCVCallLowering(*getTargetLowering()));
-  Legalizer.reset(new RISCVLegalizerInfo(*this));
-
-  auto *RBI = new RISCVRegisterBankInfo(getHwMode());
-  RegBankInfo.reset(RBI);
-  InstSelector.reset(createRISCVInstructionSelector(
-      *static_cast<const RISCVTargetMachine *>(&TM), *this, *RBI));
-}
+      InstrInfo(*this), RegInfo(getHwMode()), TLInfo(TM, *this) {}
 
 const CallLowering *RISCVSubtarget::getCallLowering() const {
+  if (!CallLoweringInfo)
+    CallLoweringInfo.reset(new RISCVCallLowering(*getTargetLowering()));
   return CallLoweringInfo.get();
 }
 
 InstructionSelector *RISCVSubtarget::getInstructionSelector() const {
+  if (!InstSelector) {
+    InstSelector.reset(createRISCVInstructionSelector(
+        *static_cast<const RISCVTargetMachine *>(&TLInfo.getTargetMachine()),
+        *this, *static_cast<const RISCVRegisterBankInfo *>(getRegBankInfo())));
+  }
   return InstSelector.get();
 }
 
 const LegalizerInfo *RISCVSubtarget::getLegalizerInfo() const {
+  if (!Legalizer)
+    Legalizer.reset(new RISCVLegalizerInfo(*this));
   return Legalizer.get();
 }
 
 const RegisterBankInfo *RISCVSubtarget::getRegBankInfo() const {
+  if (!RegBankInfo)
+    RegBankInfo.reset(new RISCVRegisterBankInfo(getHwMode()));
   return RegBankInfo.get();
 }
 

--- a/llvm/lib/Target/RISCV/RISCVSubtarget.h
+++ b/llvm/lib/Target/RISCV/RISCVSubtarget.h
@@ -245,10 +245,10 @@ public:
 
 protected:
   // GlobalISel related APIs.
-  std::unique_ptr<CallLowering> CallLoweringInfo;
-  std::unique_ptr<InstructionSelector> InstSelector;
-  std::unique_ptr<LegalizerInfo> Legalizer;
-  std::unique_ptr<RegisterBankInfo> RegBankInfo;
+  mutable std::unique_ptr<CallLowering> CallLoweringInfo;
+  mutable std::unique_ptr<InstructionSelector> InstSelector;
+  mutable std::unique_ptr<LegalizerInfo> Legalizer;
+  mutable std::unique_ptr<RegisterBankInfo> RegBankInfo;
 
   // Return the known range for the bit length of RVV data registers as set
   // at the command line. A value of 0 means nothing is known about that particular


### PR DESCRIPTION
Prior to this commit, we created the GlobalISel objects in the RISCVSubtarget constructor, even if we are not running GlobalISel. This patch moves creation of the GlobalISel objects into their getters, which ensures that we only create these objects if they are actually needed. This helps since some of the constructors of the GlobalISel objects have a significant amount of code.

We make the `unique_ptr`s `mutable` since GlobalISel passes only have access to `const TargetSubtargetInfo` through `MF.getSubtarget()`.

This patch is tested by the fact that all existing RISC-V GlobalISel tests remain passing.