### PR TITLE
[RISCV] Don't expose any constructors of RISCVISAInfo publicly.

### DIFF
--- a/lld/ELF/Arch/RISCV.cpp
+++ b/lld/ELF/Arch/RISCV.cpp
@@ -1251,9 +1251,8 @@ mergeAttributesSection(const SmallVector<InputSectionBase *, 0> &sections) {
     }
   }
 
-  if (hasArch) {
-    if (auto result = RISCVISAInfo::postProcessAndChecking(
-            std::make_unique<RISCVISAInfo>(xlen, exts))) {
+  if (hasArch && xlen != 0) {
+    if (auto result = RISCVISAInfo::createFromExtMap(xlen, exts)) {
       merged.strAttr.try_emplace(RISCVAttrs::ARCH,
                                  saver().save((*result)->toString()));
     } else {

--- a/llvm/include/llvm/TargetParser/RISCVISAInfo.h
+++ b/llvm/include/llvm/TargetParser/RISCVISAInfo.h
@@ -26,9 +26,6 @@ public:
   RISCVISAInfo(const RISCVISAInfo &) = delete;
   RISCVISAInfo &operator=(const RISCVISAInfo &) = delete;
 
-  RISCVISAInfo(unsigned XLen, RISCVISAUtils::OrderedExtensionMap &Exts)
-      : XLen(XLen), FLen(0), MinVLen(0), MaxELen(0), MaxELenFp(0), Exts(Exts) {}
-
   /// Parse RISC-V ISA info from arch string.
   /// If IgnoreUnknown is set, any unrecognised extension names or
   /// extensions with unrecognised versions will be silently dropped, except
@@ -47,6 +44,10 @@ public:
   /// Parse RISC-V ISA info from feature vector.
   static llvm::Expected<std::unique_ptr<RISCVISAInfo>>
   parseFeatures(unsigned XLen, const std::vector<std::string> &Features);
+
+  static llvm::Expected<std::unique_ptr<RISCVISAInfo>>
+  createFromExtMap(unsigned XLen,
+                   const RISCVISAUtils::OrderedExtensionMap &Exts);
 
   /// Convert RISC-V ISA info to a feature vector.
   std::vector<std::string> toFeatures(bool AddAllExtensions = false,
@@ -72,8 +73,6 @@ public:
   static bool isSupportedExtensionWithVersion(StringRef Ext);
   static bool isSupportedExtension(StringRef Ext, unsigned MajorVersion,
                                    unsigned MinorVersion);
-  static llvm::Expected<std::unique_ptr<RISCVISAInfo>>
-  postProcessAndChecking(std::unique_ptr<RISCVISAInfo> &&ISAInfo);
   static std::string getTargetFeatureForExtension(StringRef Ext);
 
 private:
@@ -93,6 +92,9 @@ private:
 
   /// Update FLen, MinVLen, MaxELen, and MaxELenFp.
   void updateImpliedLengths();
+
+  static llvm::Expected<std::unique_ptr<RISCVISAInfo>>
+  postProcessAndChecking(std::unique_ptr<RISCVISAInfo> &&ISAInfo);
 };
 
 } // namespace llvm

--- a/llvm/lib/TargetParser/RISCVISAInfo.cpp
+++ b/llvm/lib/TargetParser/RISCVISAInfo.cpp
@@ -396,6 +396,17 @@ static Error getExtensionVersion(StringRef Ext, StringRef In, unsigned &Major,
 }
 
 llvm::Expected<std::unique_ptr<RISCVISAInfo>>
+RISCVISAInfo::createFromExtMap(unsigned XLen,
+                               const RISCVISAUtils::OrderedExtensionMap &Exts) {
+  assert(XLen == 32 || XLen == 64);
+  std::unique_ptr<RISCVISAInfo> ISAInfo(new RISCVISAInfo(XLen));
+
+  ISAInfo->Exts = Exts;
+
+  return RISCVISAInfo::postProcessAndChecking(std::move(ISAInfo));
+}
+
+llvm::Expected<std::unique_ptr<RISCVISAInfo>>
 RISCVISAInfo::parseFeatures(unsigned XLen,
                             const std::vector<std::string> &Features) {
   assert(XLen == 32 || XLen == 64);


### PR DESCRIPTION
lld was using RISCVISAInfo(unsigned XLen, RISCVISAUtils::OrderedExtensionMap &Exts). This required a call to RISCVISAInfo::postProcessAndChecking to validate the RISCVISAInfo that was created. This exposes too much about RISCVISAInfo to lld.

Replace with a new RISCVISAInfo::createFromExtMap that is responsible for creating the object and calling postProcessAndChecking.