### PR TITLE
[ADT] Fix missing 'template' keyword

### DIFF
--- a/llvm/include/llvm/ADT/ArrayRef.h
+++ b/llvm/include/llvm/ADT/ArrayRef.h
@@ -460,8 +460,8 @@ namespace llvm {
 
     OwningArrayRef &operator=(OwningArrayRef &&Other) {
       delete[] this->data();
-      this->MutableArrayRef<T>::operator=(Other);
-      Other.MutableArrayRef<T>::operator=(MutableArrayRef<T>());
+      this->template MutableArrayRef<T>::operator=(Other);
+      Other.template MutableArrayRef<T>::operator=(MutableArrayRef<T>());
       return *this;
     }
 


### PR DESCRIPTION
Fixes instances where the `template` keyword should be used to interpret `<` as the delimiter of a _template-argument-list_ after #92957.