### PR TITLE
[mojo-lang] Use Lower Case in TailCallAttribute Member Names

### DIFF
--- a/mlir/include/mlir/Dialect/LLVMIR/LLVMAttrDefs.td
+++ b/mlir/include/mlir/Dialect/LLVMIR/LLVMAttrDefs.td
@@ -1082,8 +1082,8 @@ def LLVM_ZeroAttr : LLVM_Attr<"Zero", "zero">;
 //===----------------------------------------------------------------------===//
 
 def TailCallKindAttr : LLVM_Attr<"TailCallKind", "tailcallkind"> {
-  let parameters = (ins "TailCallKind":$TailCallKind);
-  let assemblyFormat = "`<` $TailCallKind `>`";
+  let parameters = (ins "TailCallKind":$tailCallKind);
+  let assemblyFormat = "`<` $tailCallKind `>`";
 }
 
 #endif // LLVMIR_ATTRDEFS


### PR DESCRIPTION
The build is broken with the error message:
```
error: declaration of 'mlir::LLVM::tailcallkind::TailCallKind mlir::LLVM::detail::TailCallKindAttrStorage::TailCallKind' changes meaning of 'TailCallKind'
```
I cannot replicate the error locally because I think it's only reported by GCC not clang. However, I think the change in this patch may fix it.