### PR TITLE
[llvm] Fix typos in target features' descriptions

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64Features.td
+++ b/llvm/lib/Target/AArch64/AArch64Features.td
@@ -194,7 +194,7 @@ def FeatureComplxNum : ExtensionWithMArch<"complxnum", "ComplxNum", "FEAT_FCMA",
   [FeatureNEON]>;
 
 def FeatureNV : Extension<"nv", "NV", "FEAT_NV, FEAT_NV2",
-  "Enable v8.4-A Nested Virtualization Enchancement">;
+  "Enable v8.4-A Nested Virtualization Enhancement">;
 
 //===----------------------------------------------------------------------===//
 //  Armv8.4 Architecture Extensions
@@ -467,10 +467,10 @@ def FeatureFAMINMAX: ExtensionWithMArch<"faminmax", "FAMINMAX", "FEAT_FAMINMAX",
 
 def FeatureLUT: ExtensionWithMArch<"lut", "LUT", "FEAT_LUT",
  "Enable Lookup Table instructions">;
-   
+
 def FeatureFP8 : ExtensionWithMArch<"fp8", "FP8", "FEAT_FP8",
   "Enable FP8 instructions", [FeatureFAMINMAX, FeatureLUT, FeatureBF16]>;
-  
+
 def FeatureFP8FMA : ExtensionWithMArch<"fp8fma", "FP8FMA", "FEAT_FP8FMA",
   "Enable fp8 multiply-add instructions", [FeatureFP8]>;
 
@@ -479,7 +479,7 @@ def FeatureSSVE_FP8FMA : ExtensionWithMArch<"ssve-fp8fma", "SSVE_FP8FMA", "FEAT_
 
 def FeatureFP8DOT4: ExtensionWithMArch<"fp8dot4", "FP8DOT4", "FEAT_FP8DOT4",
   "Enable fp8 4-way dot instructions", [FeatureFP8FMA]>;
-  
+
 def FeatureFP8DOT2: ExtensionWithMArch<"fp8dot2", "FP8DOT2", "FEAT_FP8DOT2",
   "Enable fp8 2-way dot instructions", [FeatureFP8DOT4]>;
 

--- a/llvm/lib/Target/ARM/ARMFeatures.td
+++ b/llvm/lib/Target/ARM/ARMFeatures.td
@@ -523,11 +523,11 @@ def FeatureLOB            : SubtargetFeature<"lob", "HasLOB", "true",
                                              "Enable Low Overhead Branch "
                                              "extensions">;
 
-// Mitigate against the cve-2021-35465 security vulnurability.
+// Mitigate against the cve-2021-35465 security vulnerability.
 def FeatureFixCMSE_CVE_2021_35465 : SubtargetFeature<"fix-cmse-cve-2021-35465",
                                         "FixCMSE_CVE_2021_35465", "true",
                                         "Mitigate against the cve-2021-35465 "
-                                        "security vulnurability">;
+                                        "security vulnerability">;
 
 def FeaturePACBTI         : SubtargetFeature<"pacbti", "HasPACBTI", "true",
                                              "Enable Pointer Authentication and Branch "
@@ -761,4 +761,3 @@ def FeatureHardenSlsNoComdat : SubtargetFeature<"harden-sls-nocomdat",
 def ModeBigEndianInstructions : SubtargetFeature<"big-endian-instructions",
     "BigEndianInstructions", "true",
      "Expect instructions to be stored big-endian.">;
-

--- a/llvm/lib/Target/CSKY/CSKY.td
+++ b/llvm/lib/Target/CSKY/CSKY.td
@@ -97,28 +97,28 @@ def iHasFLOAT7E60 : Predicate<"Subtarget->hasFLOAT7E60()">,
              "Support CSKY float7e60 instructions">;
 
 def FeatureHWDiv : SubtargetFeature<"hwdiv", "HasHardwareDivide", "true",
-                                    "Enable divide instrutions">;
+                                    "Enable divide instructions">;
 def HasHWDiv : Predicate<"Subtarget->hasHardwareDivide()">,
                AssemblerPredicate<(all_of FeatureHWDiv),
-               "Enable divide instrutions">;
+               "Enable divide instructions">;
 
 def FeatureSTM : SubtargetFeature<"multiple_stld", "HasSTM", "true",
-                                  "Enable multiple load/store instrutions">;
+                                  "Enable multiple load/store instructions">;
 def HasSTM : Predicate<"Subtarget->hasSTM()">,
              AssemblerPredicate<(all_of FeatureSTM),
-             "Enable multiple load/store instrutions">;
+             "Enable multiple load/store instructions">;
 
 def FeaturePushPop : SubtargetFeature<"pushpop", "HasPushPop", "true",
-                                      "Enable push/pop instrutions">;
+                                      "Enable push/pop instructions">;
 def HasPushPop : Predicate<"Subtarget->hasPushPop()">,
                  AssemblerPredicate<(all_of FeaturePushPop),
-                 "Enable push/pop instrutions">;
+                 "Enable push/pop instructions">;
 
 def FeatureDSP
-    : SubtargetFeature<"edsp", "HasDSP", "true", "Enable DSP instrutions">;
+    : SubtargetFeature<"edsp", "HasDSP", "true", "Enable DSP instructions">;
 def HasDSP : Predicate<"Subtarget->hasDSP()">,
              AssemblerPredicate<(all_of FeatureDSP),
-             "Enable DSP instrutions">;
+             "Enable DSP instructions">;
 
 def HasDSP1E2
     : SubtargetFeature<"dsp1e2", "HasDSP1E2", "true", "Support CSKY dsp1e2 instructions">;
@@ -133,16 +133,16 @@ def iHasDSPE60 : Predicate<"Subtarget->hasDSPE60()">,
              "Support CSKY dspe60 instructions">;
 
 def FeatureDSPV2 : SubtargetFeature<"dspv2", "HasDSPV2", "true",
-                                    "Enable DSP V2.0 instrutions">;
+                                    "Enable DSP V2.0 instructions">;
 def HasDSPV2 : Predicate<"Subtarget->hasDSPV2()">,
                AssemblerPredicate<(all_of FeatureDSPV2),
-               "Enable DSP V2.0 instrutions">;
+               "Enable DSP V2.0 instructions">;
 
 def FeatureDSP_Silan : SubtargetFeature<"dsp_silan", "HasDSP_Silan", "true",
-                                    "Enable DSP Silan instrutions">;
+                                    "Enable DSP Silan instructions">;
 def HasDSP_Silan : Predicate<"Subtarget->hasDSP_Silan()">,
                AssemblerPredicate<(all_of FeatureDSP_Silan),
-               "Enable DSP Silan instrutions">;
+               "Enable DSP Silan instructions">;
 
 // Atomic Support
 def FeatureBTST16 : SubtargetFeature<"btst16", "HasBTST16", "true",
@@ -232,11 +232,11 @@ def FeatureSoftTP : SubtargetFeature<"soft-tp", "ReadTPHard", "false",
                                      "Disable TLS Pointer register">;
 
 def FeatureIstack : SubtargetFeature<"istack", "EnableInterruptAttribute",
-                                     "true", "Enable interrput attribute">;
+                                     "true", "Enable interrupt attribute">;
 def EnableInterruptAttribute
     : Predicate<"Subtarget->enableInterruptAttribute()">,
       AssemblerPredicate<(all_of FeatureIstack),
-      "Enable interrput attribute">;
+      "Enable interrupt attribute">;
 
 def FeatureConstPool : SubtargetFeature<"constpool", "DumpConstPool", "true",
                                         "Dump the constant pool by compiler">;


### PR DESCRIPTION
Upstreaming typo fixes from here:

https://github.com/ziglang/zig/pull/20560#discussion_r1671256234