### PR TITLE
[libc] Add a missing math-function-macros.h include

### DIFF
--- a/libc/hdr/math_macros.h
+++ b/libc/hdr/math_macros.h
@@ -11,8 +11,8 @@
 
 #ifdef LIBC_FULL_BUILD
 
-#include "include/llvm-libc-macros/math-macros.h"
 #include "include/llvm-libc-macros/math-function-macros.h"
+#include "include/llvm-libc-macros/math-macros.h"
 
 #else // Overlay mode
 

--- a/libc/hdr/math_macros.h
+++ b/libc/hdr/math_macros.h
@@ -12,6 +12,7 @@
 #ifdef LIBC_FULL_BUILD
 
 #include "include/llvm-libc-macros/math-macros.h"
+#include "include/llvm-libc-macros/math-function-macros.h"
 
 #else // Overlay mode
 


### PR DESCRIPTION
This was accidentally omitted in #96008.