### PR TITLE
[CodeGen] Format `PHIElimination.cpp` NFC

### DIFF
--- a/llvm/lib/CodeGen/PHIElimination.cpp
+++ b/llvm/lib/CodeGen/PHIElimination.cpp
@@ -47,14 +47,16 @@ using namespace llvm;
 #define DEBUG_TYPE "phi-node-elimination"
 
 static cl::opt<bool>
-DisableEdgeSplitting("disable-phi-elim-edge-splitting", cl::init(false),
-                     cl::Hidden, cl::desc("Disable critical edge splitting "
-                                          "during PHI elimination"));
+    DisableEdgeSplitting("disable-phi-elim-edge-splitting", cl::init(false),
+                         cl::Hidden,
+                         cl::desc("Disable critical edge splitting "
+                                  "during PHI elimination"));
 
 static cl::opt<bool>
-SplitAllCriticalEdges("phi-elim-split-all-critical-edges", cl::init(false),
-                      cl::Hidden, cl::desc("Split all critical edges during "
-                                           "PHI elimination"));
+    SplitAllCriticalEdges("phi-elim-split-all-critical-edges", cl::init(false),
+                          cl::Hidden,
+                          cl::desc("Split all critical edges during "
+                                   "PHI elimination"));
 
 static cl::opt<bool> NoPhiElimLiveOutEarlyExit(
     "no-phi-elim-live-out-early-exit", cl::init(false), cl::Hidden,
@@ -62,61 +64,61 @@ static cl::opt<bool> NoPhiElimLiveOutEarlyExit(
 
 namespace {
 
-  class PHIElimination : public MachineFunctionPass {
-    MachineRegisterInfo *MRI = nullptr; // Machine register information
-    LiveVariables *LV = nullptr;
-    LiveIntervals *LIS = nullptr;
+class PHIElimination : public MachineFunctionPass {
+  MachineRegisterInfo *MRI = nullptr; // Machine register information
+  LiveVariables *LV = nullptr;
+  LiveIntervals *LIS = nullptr;
 
-  public:
-    static char ID; // Pass identification, replacement for typeid
+public:
+  static char ID; // Pass identification, replacement for typeid
 
-    PHIElimination() : MachineFunctionPass(ID) {
-      initializePHIEliminationPass(*PassRegistry::getPassRegistry());
-    }
+  PHIElimination() : MachineFunctionPass(ID) {
+    initializePHIEliminationPass(*PassRegistry::getPassRegistry());
+  }
 
-    bool runOnMachineFunction(MachineFunction &MF) override;
-    void getAnalysisUsage(AnalysisUsage &AU) const override;
+  bool runOnMachineFunction(MachineFunction &MF) override;
+  void getAnalysisUsage(AnalysisUsage &AU) const override;
 
-  private:
-    /// EliminatePHINodes - Eliminate phi nodes by inserting copy instructions
-    /// in predecessor basic blocks.
-    bool EliminatePHINodes(MachineFunction &MF, MachineBasicBlock &MBB);
+private:
+  /// EliminatePHINodes - Eliminate phi nodes by inserting copy instructions
+  /// in predecessor basic blocks.
+  bool EliminatePHINodes(MachineFunction &MF, MachineBasicBlock &MBB);
 
-    void LowerPHINode(MachineBasicBlock &MBB,
-                      MachineBasicBlock::iterator LastPHIIt,
-                      bool AllEdgesCritical);
+  void LowerPHINode(MachineBasicBlock &MBB,
+                    MachineBasicBlock::iterator LastPHIIt,
+                    bool AllEdgesCritical);
 
-    /// analyzePHINodes - Gather information about the PHI nodes in
-    /// here. In particular, we want to map the number of uses of a virtual
-    /// register which is used in a PHI node. We map that to the BB the
-    /// vreg is coming from. This is used later to determine when the vreg
-    /// is killed in the BB.
-    void analyzePHINodes(const MachineFunction& MF);
+  /// analyzePHINodes - Gather information about the PHI nodes in
+  /// here. In particular, we want to map the number of uses of a virtual
+  /// register which is used in a PHI node. We map that to the BB the
+  /// vreg is coming from. This is used later to determine when the vreg
+  /// is killed in the BB.
+  void analyzePHINodes(const MachineFunction &MF);
 
-    /// Split critical edges where necessary for good coalescer performance.
-    bool SplitPHIEdges(MachineFunction &MF, MachineBasicBlock &MBB,
-                       MachineLoopInfo *MLI,
-                       std::vector<SparseBitVector<>> *LiveInSets);
+  /// Split critical edges where necessary for good coalescer performance.
+  bool SplitPHIEdges(MachineFunction &MF, MachineBasicBlock &MBB,
+                     MachineLoopInfo *MLI,
+                     std::vector<SparseBitVector<>> *LiveInSets);
 
-    // These functions are temporary abstractions around LiveVariables and
-    // LiveIntervals, so they can go away when LiveVariables does.
-    bool isLiveIn(Register Reg, const MachineBasicBlock *MBB);
-    bool isLiveOutPastPHIs(Register Reg, const MachineBasicBlock *MBB);
+  // These functions are temporary abstractions around LiveVariables and
+  // LiveIntervals, so they can go away when LiveVariables does.
+  bool isLiveIn(Register Reg, const MachineBasicBlock *MBB);
+  bool isLiveOutPastPHIs(Register Reg, const MachineBasicBlock *MBB);
 
-    using BBVRegPair = std::pair<unsigned, Register>;
-    using VRegPHIUse = DenseMap<BBVRegPair, unsigned>;
+  using BBVRegPair = std::pair<unsigned, Register>;
+  using VRegPHIUse = DenseMap<BBVRegPair, unsigned>;
 
-    // Count the number of non-undef PHI uses of each register in each BB.
-    VRegPHIUse VRegPHIUseCount;
+  // Count the number of non-undef PHI uses of each register in each BB.
+  VRegPHIUse VRegPHIUseCount;
 
-    // Defs of PHI sources which are implicit_def.
-    SmallPtrSet<MachineInstr*, 4> ImpDefs;
+  // Defs of PHI sources which are implicit_def.
+  SmallPtrSet<MachineInstr *, 4> ImpDefs;
 
-    // Map reusable lowered PHI node -> incoming join register.
-    using LoweredPHIMap =
-        DenseMap<MachineInstr*, unsigned, MachineInstrExpressionTrait>;
-    LoweredPHIMap LoweredPHIs;
-  };
+  // Map reusable lowered PHI node -> incoming join register.
+  using LoweredPHIMap =
+      DenseMap<MachineInstr *, unsigned, MachineInstrExpressionTrait>;
+  LoweredPHIMap LoweredPHIs;
+};
 
 } // end anonymous namespace
 
@@ -126,11 +128,11 @@ STATISTIC(NumReused, "Number of reused lowered phis");
 
 char PHIElimination::ID = 0;
 
-char& llvm::PHIEliminationID = PHIElimination::ID;
+char &llvm::PHIEliminationID = PHIElimination::ID;
 
 INITIALIZE_PASS_BEGIN(PHIElimination, DEBUG_TYPE,
-                      "Eliminate PHI nodes for register allocation",
-                      false, false)
+                      "Eliminate PHI nodes for register allocation", false,
+                      false)
 INITIALIZE_PASS_DEPENDENCY(LiveVariablesWrapperPass)
 INITIALIZE_PASS_END(PHIElimination, DEBUG_TYPE,
                     "Eliminate PHI nodes for register allocation", false, false)
@@ -238,11 +240,11 @@ bool PHIElimination::runOnMachineFunction(MachineFunction &MF) {
 bool PHIElimination::EliminatePHINodes(MachineFunction &MF,
                                        MachineBasicBlock &MBB) {
   if (MBB.empty() || !MBB.front().isPHI())
-    return false;   // Quick exit for basic blocks without PHIs.
+    return false; // Quick exit for basic blocks without PHIs.
 
   // Get an iterator to the last PHI node.
   MachineBasicBlock::iterator LastPHIIt =
-    std::prev(MBB.SkipPHIsAndLabels(MBB.begin()));
+      std::prev(MBB.SkipPHIsAndLabels(MBB.begin()));
 
   // If all incoming edges are critical, we try to deduplicate identical PHIs so
   // that we generate fewer copies. If at any edge is non-critical, we either
@@ -301,8 +303,8 @@ void PHIElimination::LowerPHINode(MachineBasicBlock &MBB,
   // Create a new register for the incoming PHI arguments.
   MachineFunction &MF = *MBB.getParent();
   unsigned IncomingReg = 0;
-  bool EliminateNow = true;     // delay elimination of nodes in LoweredPHIs
-  bool reusedIncoming = false;  // Is IncomingReg reused from an earlier PHI?
+  bool EliminateNow = true;    // delay elimination of nodes in LoweredPHIs
+  bool reusedIncoming = false; // Is IncomingReg reused from an earlier PHI?
 
   // Insert a register to register copy at the top of the current block (but
   // after any remaining phi nodes) which copies the new incoming register
@@ -313,7 +315,7 @@ void PHIElimination::LowerPHINode(MachineBasicBlock &MBB,
     // If all sources of a PHI node are implicit_def or undef uses, just emit an
     // implicit_def instead of a copy.
     PHICopy = BuildMI(MBB, AfterPHIsIt, MPhi->getDebugLoc(),
-            TII->get(TargetOpcode::IMPLICIT_DEF), DestReg);
+                      TII->get(TargetOpcode::IMPLICIT_DEF), DestReg);
   else {
     // Can we reuse an earlier PHI node? This only happens for critical edges,
     // typically those created by tail duplication. Typically, an identical PHI
@@ -339,8 +341,8 @@ void PHIElimination::LowerPHINode(MachineBasicBlock &MBB,
     }
 
     // Give the target possiblity to handle special cases fallthrough otherwise
-    PHICopy = TII->createPHIDestinationCopy(MBB, AfterPHIsIt, MPhi->getDebugLoc(),
-                                  IncomingReg, DestReg);
+    PHICopy = TII->createPHIDestinationCopy(
+        MBB, AfterPHIsIt, MPhi->getDebugLoc(), IncomingReg, DestReg);
   }
 
   if (MPhi->peekDebugInstrNum()) {
@@ -367,8 +369,8 @@ void PHIElimination::LowerPHINode(MachineBasicBlock &MBB,
         // by default, so it's before the OldKill. But some Target hooks for
         // createPHIDestinationCopy() may modify the default insert position of
         // PHICopy.
-        for (auto I = MBB.SkipPHIsAndLabels(MBB.begin()), E = MBB.end();
-             I != E; ++I) {
+        for (auto I = MBB.SkipPHIsAndLabels(MBB.begin()), E = MBB.end(); I != E;
+             ++I) {
           if (I == PHICopy)
             break;
 
@@ -420,11 +422,10 @@ void PHIElimination::LowerPHINode(MachineBasicBlock &MBB,
       LiveInterval &IncomingLI = LIS->getOrCreateEmptyInterval(IncomingReg);
       VNInfo *IncomingVNI = IncomingLI.getVNInfoAt(MBBStartIndex);
       if (!IncomingVNI)
-        IncomingVNI = IncomingLI.getNextValue(MBBStartIndex,
-                                              LIS->getVNInfoAllocator());
-      IncomingLI.addSegment(LiveInterval::Segment(MBBStartIndex,
-                                                  DestCopyIndex.getRegSlot(),
-                                                  IncomingVNI));
+        IncomingVNI =
+            IncomingLI.getNextValue(MBBStartIndex, LIS->getVNInfoAllocator());
+      IncomingLI.addSegment(LiveInterval::Segment(
+          MBBStartIndex, DestCopyIndex.getRegSlot(), IncomingVNI));
     }
 
     LiveInterval &DestLI = LIS->getInterval(DestReg);
@@ -485,24 +486,24 @@ void PHIElimination::LowerPHINode(MachineBasicBlock &MBB,
 
   // Now loop over all of the incoming arguments, changing them to copy into the
   // IncomingReg register in the corresponding predecessor basic block.
-  SmallPtrSet<MachineBasicBlock*, 8> MBBsInsertedInto;
+  SmallPtrSet<MachineBasicBlock *, 8> MBBsInsertedInto;
   for (int i = NumSrcs - 1; i >= 0; --i) {
     Register SrcReg = MPhi->getOperand(i * 2 + 1).getReg();
-    unsigned SrcSubReg = MPhi->getOperand(i*2+1).getSubReg();
-    bool SrcUndef = MPhi->getOperand(i*2+1).isUndef() ||
-      isImplicitlyDefined(SrcReg, *MRI);
+    unsigned SrcSubReg = MPhi->getOperand(i * 2 + 1).getSubReg();
+    bool SrcUndef = MPhi->getOperand(i * 2 + 1).isUndef() ||
+                    isImplicitlyDefined(SrcReg, *MRI);
     assert(SrcReg.isVirtual() &&
            "Machine PHI Operands must all be virtual registers!");
 
     // Get the MachineBasicBlock equivalent of the BasicBlock that is the source
     // path the PHI.
-    MachineBasicBlock &opBlock = *MPhi->getOperand(i*2+2).getMBB();
+    MachineBasicBlock &opBlock = *MPhi->getOperand(i * 2 + 2).getMBB();
 
     // Check to make sure we haven't already emitted the copy for this block.
     // This can happen because PHI nodes may have multiple entries for the same
     // basic block.
     if (!MBBsInsertedInto.insert(&opBlock).second)
-      continue;  // If the copy has already been emitted, we're done.
+      continue; // If the copy has already been emitted, we're done.
 
     MachineInstr *SrcRegDef = MRI->getVRegDef(SrcReg);
     if (SrcRegDef && TII->isUnspillableTerminator(SrcRegDef)) {
@@ -529,7 +530,7 @@ void PHIElimination::LowerPHINode(MachineBasicBlock &MBB,
     // Find a safe location to insert the copy, this may be the first terminator
     // in the block (or end()).
     MachineBasicBlock::iterator InsertPos =
-      findPHICopyInsertPoint(&opBlock, &MBB, SrcReg);
+        findPHICopyInsertPoint(&opBlock, &MBB, SrcReg);
 
     // Insert the copy.
     MachineInstr *NewSrcInstr = nullptr;
@@ -538,9 +539,9 @@ void PHIElimination::LowerPHINode(MachineBasicBlock &MBB,
         // The source register is undefined, so there is no need for a real
         // COPY, but we still need to ensure joint dominance by defs.
         // Insert an IMPLICIT_DEF instruction.
-        NewSrcInstr = BuildMI(opBlock, InsertPos, MPhi->getDebugLoc(),
-                              TII->get(TargetOpcode::IMPLICIT_DEF),
-                              IncomingReg);
+        NewSrcInstr =
+            BuildMI(opBlock, InsertPos, MPhi->getDebugLoc(),
+                    TII->get(TargetOpcode::IMPLICIT_DEF), IncomingReg);
 
         // Clean up the old implicit-def, if there even was one.
         if (MachineInstr *DefMI = MRI->getVRegDef(SrcReg))
@@ -687,7 +688,7 @@ void PHIElimination::LowerPHINode(MachineBasicBlock &MBB,
 /// particular, we want to map the number of uses of a virtual register which is
 /// used in a PHI node. We map that to the BB the vreg is coming from. This is
 /// used later to determine when the vreg is killed in the BB.
-void PHIElimination::analyzePHINodes(const MachineFunction& MF) {
+void PHIElimination::analyzePHINodes(const MachineFunction &MF) {
   for (const auto &MBB : MF) {
     for (const auto &BBI : MBB) {
       if (!BBI.isPHI())
@@ -703,12 +704,11 @@ void PHIElimination::analyzePHINodes(const MachineFunction& MF) {
   }
 }
 
-bool PHIElimination::SplitPHIEdges(MachineFunction &MF,
-                                   MachineBasicBlock &MBB,
+bool PHIElimination::SplitPHIEdges(MachineFunction &MF, MachineBasicBlock &MBB,
                                    MachineLoopInfo *MLI,
                                    std::vector<SparseBitVector<>> *LiveInSets) {
   if (MBB.empty() || !MBB.front().isPHI() || MBB.isEHPad())
-    return false;   // Quick exit for basic blocks without PHIs.
+    return false; // Quick exit for basic blocks without PHIs.
 
   const MachineLoop *CurLoop = MLI ? MLI->getLoopFor(&MBB) : nullptr;
   bool IsLoopHeader = CurLoop && &MBB == CurLoop->getHeader();
@@ -718,7 +718,7 @@ bool PHIElimination::SplitPHIEdges(MachineFunction &MF,
        BBI != BBE && BBI->isPHI(); ++BBI) {
     for (unsigned i = 1, e = BBI->getNumOperands(); i != e; i += 2) {
       Register Reg = BBI->getOperand(i).getReg();
-      MachineBasicBlock *PreMBB = BBI->getOperand(i+1).getMBB();
+      MachineBasicBlock *PreMBB = BBI->getOperand(i + 1).getMBB();
       // Is there a critical edge from PreMBB to MBB?
       if (PreMBB->succ_size() == 1)
         continue;
@@ -799,9 +799,9 @@ bool PHIElimination::isLiveOutPastPHIs(Register Reg,
          "isLiveOutPastPHIs() requires either LiveVariables or LiveIntervals");
   // LiveVariables considers uses in PHIs to be in the predecessor basic block,
   // so that a register used only in a PHI is not live out of the block. In
-  // contrast, LiveIntervals considers uses in PHIs to be on the edge rather than
-  // in the predecessor basic block, so that a register used only in a PHI is live
-  // out of the block.
+  // contrast, LiveIntervals considers uses in PHIs to be on the edge rather
+  // than in the predecessor basic block, so that a register used only in a PHI
+  // is live out of the block.
   if (LIS) {
     const LiveInterval &LI = LIS->getInterval(Reg);
     for (const MachineBasicBlock *SI : MBB->successors())


### PR DESCRIPTION
clang-format will format entire class when `class PHIElimination : public MachineFunctionPass {` is changed. Format it firstly to reduce unnecessary changes when porting it to new pass manager.