### PR TITLE
[lld][ELF] Fix wrap when __real_X is weak to avoid undefined symbol

### DIFF
--- a/lld/ELF/Driver.cpp
+++ b/lld/ELF/Driver.cpp
@@ -2551,8 +2551,12 @@ static std::vector<WrappedSymbol> addWrappedSymbols(opt::InputArgList &args) {
     // If __real_ is referenced, pull in the symbol if it is lazy. Do this after
     // processing __wrap_ as that may have referenced __real_.
     StringRef realName = saver().save("__real_" + name);
-    if (symtab.find(realName))
+    if (Symbol *real = symtab.find(realName)) {
       symtab.addUnusedUndefined(name, sym->binding);
+      // update sym's binding to __real_'s binding, as sym will replacing
+      // __real_ later in SymbolTable::wrap().
+      sym->binding = real->binding;
+    }
 
     Symbol *real = symtab.addUnusedUndefined(realName);
     v.push_back({sym, real, wrap});

--- a/lld/ELF/Driver.cpp
+++ b/lld/ELF/Driver.cpp
@@ -2553,8 +2553,8 @@ static std::vector<WrappedSymbol> addWrappedSymbols(opt::InputArgList &args) {
     StringRef realName = saver().save("__real_" + name);
     if (Symbol *real = symtab.find(realName)) {
       symtab.addUnusedUndefined(name, sym->binding);
-      // update sym's binding to __real_'s binding, as sym will replacing
-      // __real_ later in SymbolTable::wrap().
+      // Update sym's binding, which will replace real's later in
+      // SymbolTable::wrap.
       sym->binding = real->binding;
     }
 

--- a/lld/test/ELF/wrap-weak.s
+++ b/lld/test/ELF/wrap-weak.s
@@ -1,8 +1,8 @@
 # REQUIRES: x86
-# RUN: llvm-mc -filetype=obj -triple=x86_64-pc-linux %s -o %t.o
+# RUN: llvm-mc -filetype=obj -triple=x86_64 %s -o %t.o
 # RUN: ld.lld -shared -o %t.so %t.o -wrap foo
 
-# RUN: llvm-readelf --dyn-syms %t.so | FileCheck %s --check-prefix=CHECK
+# RUN: llvm-readelf --dyn-syms %t.so | FileCheck %s
 
 # CHECK:      Symbol table '.dynsym' contains 4 entries:
 # CHECK:      NOTYPE  LOCAL  DEFAULT   UND

--- a/lld/test/ELF/wrap-weak.s
+++ b/lld/test/ELF/wrap-weak.s
@@ -1,0 +1,23 @@
+# REQUIRES: x86
+# RUN: llvm-mc -filetype=obj -triple=x86_64-pc-linux %s -o %t.o
+# RUN: ld.lld -shared -o %t.so %t.o -wrap foo
+
+# RUN: llvm-readelf --dyn-syms %t.so | FileCheck %s --check-prefix=CHECK
+
+# CHECK:      Symbol table '.dynsym' contains 4 entries:
+# CHECK:      NOTYPE  LOCAL  DEFAULT   UND
+# CHECK-NEXT: NOTYPE  WEAK   DEFAULT   UND foo
+# CHECK-NEXT: NOTYPE  GLOBAL DEFAULT [[#]] __wrap_foo
+# CHECK-NEXT: NOTYPE  GLOBAL DEFAULT [[#]] _start
+
+.global foo
+.weak __real_foo
+
+.global __wrap_foo
+__wrap_foo:
+  movq __real_foo@gotpcrel(%rip), %rax
+  call __real_foo@plt
+
+.global _start
+_start:
+  call foo@plt


### PR DESCRIPTION
Fix #98294.

When you specify --wrap=foo, sometimes foo is undefined in any context. If you declare __real_foo as weak, GNU ld will not attempt to find the strong symbol foo, instead, it generates a weak undefined symbol.

This pull request imitates this behavior by copying the binding attribute from __real_foo to foo.