### PR TITLE
[AArch64] Update AUTIxSPPC and RETAxSPPC instructions for register va…

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64InstrInfo.td
+++ b/llvm/lib/Target/AArch64/AArch64InstrInfo.td
@@ -1845,8 +1845,8 @@ let Predicates = [HasPAuthLR] in {
     def AUTIASPPCi : SignAuthPCRel<0b00, "autiasppc">;
     def AUTIBSPPCi : SignAuthPCRel<0b01, "autibsppc">;
     //                              opcode2, opcode,   asm
-    def AUTIASPPCr : SignAuthOneReg<0b00001, 0b100100, "autiasppc">;
-    def AUTIBSPPCr : SignAuthOneReg<0b00001, 0b100101, "autibsppc">;
+    def AUTIASPPCr : SignAuthOneReg<0b00001, 0b100100, "autiasppcr">;
+    def AUTIBSPPCr : SignAuthOneReg<0b00001, 0b100101, "autibsppcr">;
     //                                  opcode2, opcode,   asm
     def PACIA171615 : SignAuthFixedRegs<0b00001, 0b100010, "pacia171615">;
     def PACIB171615 : SignAuthFixedRegs<0b00001, 0b100011, "pacib171615">;
@@ -1859,8 +1859,8 @@ let Predicates = [HasPAuthLR] in {
     def RETAASPPCi : SignAuthReturnPCRel<0b000, 0b11111, "retaasppc">;
     def RETABSPPCi : SignAuthReturnPCRel<0b001, 0b11111, "retabsppc">;
     //                                 op3,      asm
-    def RETAASPPCr : SignAuthReturnReg<0b000010, "retaasppc">;
-    def RETABSPPCr : SignAuthReturnReg<0b000011, "retabsppc">;
+    def RETAASPPCr : SignAuthReturnReg<0b000010, "retaasppcr">;
+    def RETABSPPCr : SignAuthReturnReg<0b000011, "retabsppcr">;
   }
   def : InstAlias<"pacm", (PACM), 1>;
 }

--- a/llvm/test/MC/AArch64/armv9.5a-pauthlr.s
+++ b/llvm/test/MC/AArch64/armv9.5a-pauthlr.s
@@ -70,30 +70,30 @@ label1:
 // CHECK-ERROR: instruction requires: pauth-lr
 // CHECK-UNKNOWN: f3bfffff <unknown>
 
-  autiasppc x0
-// CHECK-INST: autiasppc x0
-// CHECK-DISASS: autiasppc x0
+  autiasppcr x0
+// CHECK-INST: autiasppcr x0
+// CHECK-DISASS: autiasppcr x0
 // CHECK-ENCODING: [0x1e,0x90,0xc1,0xda]
 // CHECK-ERROR: instruction requires: pauth-lr
 // CHECK-UNKNOWN: dac1901e <unknown>
 
-  autibsppc x1
-// CHECK-INST: autibsppc x1
-// CHECK-DISASS: autibsppc x1
+  autibsppcr x1
+// CHECK-INST: autibsppcr x1
+// CHECK-DISASS: autibsppcr x1
 // CHECK-ENCODING: [0x3e,0x94,0xc1,0xda]
 // CHECK-ERROR: instruction requires: pauth-lr
 // CHECK-UNKNOWN: dac1943e <unknown>
 
-  autiasppc xzr
-// CHECK-INST: autiasppc xzr
-// CHECK-DISASS: autiasppc xzr
+  autiasppcr xzr
+// CHECK-INST: autiasppcr xzr
+// CHECK-DISASS: autiasppcr xzr
 // CHECK-ENCODING: [0xfe,0x93,0xc1,0xda]
 // CHECK-ERROR: instruction requires: pauth-lr
 // CHECK-UNKNOWN: dac193fe <unknown>
 
-  autibsppc xzr
-// CHECK-INST: autibsppc xzr
-// CHECK-DISASS: autibsppc xzr
+  autibsppcr xzr
+// CHECK-INST: autibsppcr xzr
+// CHECK-DISASS: autibsppcr xzr
 // CHECK-ENCODING: [0xfe,0x97,0xc1,0xda]
 // CHECK-ERROR: instruction requires: pauth-lr
 // CHECK-UNKNOWN: dac197fe <unknown>
@@ -156,16 +156,16 @@ label1:
 // CHECK-ERROR: instruction requires: pauth-lr
 // CHECK-UNKNOWN: 551fffff <unknown>
 
-  retaasppc x2
-// CHECK-INST: retaasppc x2
-// CHECK-DISASS: retaasppc x2
+  retaasppcr x2
+// CHECK-INST: retaasppcr x2
+// CHECK-DISASS: retaasppcr x2
 // CHECK-ENCODING: [0xe2,0x0b,0x5f,0xd6]
 // CHECK-ERROR: instruction requires: pauth-lr
 // CHECK-UNKNOWN: d65f0be2 <unknown>
 
-  retabsppc x3
-// CHECK-INST: retabsppc x3
-// CHECK-DISASS: retabsppc x3
+  retabsppcr x3
+// CHECK-INST: retabsppcr x3
+// CHECK-DISASS: retabsppcr x3
 // CHECK-ENCODING: [0xe3,0x0f,0x5f,0xd6]
 // CHECK-ERROR: instruction requires: pauth-lr
 // CHECK-UNKNOWN: d65f0fe3 <unknown>

--- a/llvm/test/MC/Disassembler/AArch64/armv9.5a-pauthlr.txt
+++ b/llvm/test/MC/Disassembler/AArch64/armv9.5a-pauthlr.txt
@@ -34,19 +34,19 @@
 # NO-PAUTHLR: invalid instruction encoding
 
 [0x1e,0x90,0xc1,0xda]
-# CHECK: autiasppc x0
+# CHECK: autiasppcr x0
 # NO-PAUTHLR: invalid instruction encoding
 
 [0x3e,0x94,0xc1,0xda]
-# CHECK: autibsppc x1
+# CHECK: autibsppcr x1
 # NO-PAUTHLR: invalid instruction encoding
 
 [0xfe,0x93,0xc1,0xda]
-# CHECK: autiasppc xzr
+# CHECK: autiasppcr xzr
 # NO-PAUTHLR: invalid instruction encoding
 
 [0xfe,0x97,0xc1,0xda]
-# CHECK: autibsppc xzr
+# CHECK: autibsppcr xzr
 # NO-PAUTHLR: invalid instruction encoding
 
 [0xfe,0x8b,0xc1,0xda]
@@ -82,11 +82,11 @@
 # NO-PAUTHLR: invalid instruction encoding
 
 [0xe2,0x0b,0x5f,0xd6]
-# CHECK: retaasppc x2
+# CHECK: retaasppcr x2
 # NO-PAUTHLR: invalid instruction encoding
 
 [0xe3,0x0f,0x5f,0xd6]
-# CHECK: retabsppc x3
+# CHECK: retabsppcr x3
 # NO-PAUTHLR: invalid instruction encoding
 
 [0xff,0x24,0x03,0xd5]


### PR DESCRIPTION
…riant.

As of the 2024.06 Arm Architecture release, the register variants of the AUTIxSPPC and RETAxSPPC instructions have been updated to be explicitly different to the immediate variant. The instructions now follow the format AUTIxSPPCR and RETAxSPPCR for the register variants, with the immediate variants keeping their current form.

The Specs can be found at the following locations
AUTIASPPCR: https://developer.arm.com/documentation/ddi0602/2024-06/Base-Instructions/AUTIASPPCR--Authenticate-return-address-using-key-A--using-a-register-?lang=en 
AUTIBSPPCR: https://developer.arm.com/documentation/ddi0602/2024-06/Base-Instructions/AUTIBSPPCR--Authenticate-return-address-using-key-B--using-a-register-?lang=en 
RETAASPPCR and RETABSPPCR: https://developer.arm.com/documentation/ddi0602/2024-06/Base-Instructions/RETAASPPCR--RETABSPPCR--Return-from-subroutine--with-enhanced-pointer-authentication-return-using-a-register-?lang=en