### PR TITLE
[bazel][mlir][OpenMP] Roll back path improvements from d5e4e70

### DIFF
--- a/mlir/test/mlir-tblgen/openmp-ops-verify.td
+++ b/mlir/test/mlir-tblgen/openmp-ops-verify.td
@@ -4,10 +4,10 @@
 // Run tablegen to generate OmpCommon.td in temp directory first.
 // RUN: mkdir -p %t/mlir/Dialect/OpenMP
 // RUN: mlir-tblgen --gen-directive-decl --directives-dialect=OpenMP \
-// RUN:   %llvm_src_root/include/llvm/Frontend/OpenMP/OMP.td \
-// RUN:   -I %llvm_src_root/include > %t/mlir/Dialect/OpenMP/OmpCommon.td
+// RUN:   %S/../../../llvm/include/llvm/Frontend/OpenMP/OMP.td \
+// RUN:   -I %S/../../../llvm/include > %t/mlir/Dialect/OpenMP/OmpCommon.td
 
-// RUN: not mlir-tblgen -verify-openmp-ops -I %mlir_src_root/include -I %t %s 2>&1 | FileCheck %s
+// RUN: not mlir-tblgen -verify-openmp-ops -I %S/../../include -I %t %s 2>&1 | FileCheck %s
 
 include "mlir/Dialect/OpenMP/OpenMPOpBase.td"
 

--- a/mlir/test/mlir-tblgen/openmp-ops.td
+++ b/mlir/test/mlir-tblgen/openmp-ops.td
@@ -6,11 +6,11 @@
 // Run tablegen to generate OmpCommon.td in temp directory first.
 // RUN: mkdir -p %t/mlir/Dialect/OpenMP
 // RUN: mlir-tblgen --gen-directive-decl --directives-dialect=OpenMP \
-// RUN:   %llvm_src_root/include/llvm/Frontend/OpenMP/OMP.td \
-// RUN:   -I %llvm_src_root/include > %t/mlir/Dialect/OpenMP/OmpCommon.td
+// RUN:   %S/../../../llvm/include/llvm/Frontend/OpenMP/OMP.td \
+// RUN:   -I %S/../../../llvm/include > %t/mlir/Dialect/OpenMP/OmpCommon.td
 
-// RUN: mlir-tblgen -gen-op-decls -I %mlir_src_root/include -I %t %s | FileCheck %s --check-prefix=DECL
-// RUN: mlir-tblgen -gen-op-doc -I %mlir_src_root/include -I %t %s | FileCheck %s --check-prefix=DOC
+// RUN: mlir-tblgen -gen-op-decls -I %S/../../include -I %t %s | FileCheck %s --check-prefix=DECL
+// RUN: mlir-tblgen -gen-op-doc -I %S/../../include -I %t %s | FileCheck %s --check-prefix=DOC
 
 include "mlir/Dialect/OpenMP/OpenMPOpBase.td"
 


### PR DESCRIPTION
The bazel setup is not ready to handle `%llvm/mlir_src_root`.
Roll back these improvements for now.
I will look into fixing the bazel setup and roll forward.