### PR TITLE
[C++20][Modules] static data members of template classes should be allowed in header units

### DIFF
--- a/clang/lib/Sema/SemaDecl.cpp
+++ b/clang/lib/Sema/SemaDecl.cpp
@@ -13305,7 +13305,8 @@ void Sema::AddInitializerToDecl(Decl *RealDecl, Expr *Init, bool DirectInit) {
   if (getLangOpts().CPlusPlusModules && currentModuleIsHeaderUnit() &&
       !VDecl->isInvalidDecl() && VDecl->isThisDeclarationADefinition() &&
       VDecl->getFormalLinkage() == Linkage::External && !VDecl->isInline() &&
-      !VDecl->isTemplated() && !isa<VarTemplateSpecializationDecl>(VDecl)) {
+      !VDecl->isTemplated() && !isa<VarTemplateSpecializationDecl>(VDecl) &&
+      !VDecl->getInstantiatedFromStaticDataMember()) {
     Diag(VDecl->getLocation(), diag::err_extern_def_in_header_unit);
     VDecl->setInvalidDecl();
   }

--- a/clang/test/CXX/module/module.import/p6.cpp
+++ b/clang/test/CXX/module/module.import/p6.cpp
@@ -67,3 +67,13 @@ void* tmpl_fn_ok
 inline int foo (int a) {
   return tmpl_OK (a);
 }
+
+template <typename T> struct S2 { static int v; };
+template <typename T> int S2<T>::v = 10;
+
+template <typename T> bool b() {
+    bool b1 = S2<T>::v == 10;
+    return b1 && true;
+}
+
+inline bool B = b<int>();


### PR DESCRIPTION
Summary:
There is no sense to report these cases as an error or add `inline` explicitly in these cases. If it is not required in normal headers. Similar to #60079.

Test Plan: check-clang