### PR TITLE
[LegacyPassManager] Verify all available analyses

### DIFF
--- a/llvm/include/llvm/Analysis/RegionInfoImpl.h
+++ b/llvm/include/llvm/Analysis/RegionInfoImpl.h
@@ -272,7 +272,7 @@ void RegionBase<Tr>::verifyWalk(BlockT *BB, std::set<BlockT *> *visited) const {
 template <class Tr>
 void RegionBase<Tr>::verifyRegion() const {
   // Only do verification when user wants to, otherwise this expensive check
-  // will be invoked by PMDataManager::verifyPreservedAnalysis when
+  // will be invoked by PMDataManager::verifyAvailableAnalyses when
   // a regionpass (marked PreservedAll) finish.
   if (!RegionInfoBase<Tr>::VerifyRegionInfo)
     return;

--- a/llvm/include/llvm/IR/LegacyPassManagers.h
+++ b/llvm/include/llvm/IR/LegacyPassManagers.h
@@ -303,8 +303,8 @@ public:
   /// Augment AvailableAnalysis by adding analysis made available by pass P.
   void recordAvailableAnalysis(Pass *P);
 
-  /// verifyPreservedAnalysis -- Verify analysis presreved by pass P.
-  void verifyPreservedAnalysis(Pass *P);
+  /// verifyAvailableAnalyses -- Verify all available analyses.
+  void verifyAvailableAnalyses();
 
   /// Remove Analysis that is not preserved by the pass
   void removeNotPreservedAnalysis(Pass *P);

--- a/llvm/lib/Analysis/CallGraphSCCPass.cpp
+++ b/llvm/lib/Analysis/CallGraphSCCPass.cpp
@@ -482,9 +482,9 @@ bool CGPassManager::RunAllPassesOnSCC(CallGraphSCC &CurSCC, CallGraph &CG,
       dumpPassInfo(P, MODIFICATION_MSG, ON_CG_MSG, "");
     dumpPreservedSet(P);
 
-    verifyPreservedAnalysis(P);
     if (LocalChanged)
       removeNotPreservedAnalysis(P);
+    verifyAvailableAnalyses();
     recordAvailableAnalysis(P);
     removeDeadPasses(P, "", ON_CG_MSG);
   }

--- a/llvm/lib/Analysis/LoopPass.cpp
+++ b/llvm/lib/Analysis/LoopPass.cpp
@@ -246,14 +246,12 @@ bool LPPassManager::runOnFunction(Function &F) {
           assert(CurrentLoop->isRecursivelyLCSSAForm(*DT, *LI));
 #endif
 
-        // Then call the regular verifyAnalysis functions.
-        verifyPreservedAnalysis(P);
-
         F.getContext().yield();
       }
 
       if (LocalChanged)
         removeNotPreservedAnalysis(P);
+      verifyAvailableAnalyses();
       recordAvailableAnalysis(P);
       removeDeadPasses(P,
                        CurrentLoopDeleted ? "<deleted>"

--- a/llvm/lib/Analysis/RegionPass.cpp
+++ b/llvm/lib/Analysis/RegionPass.cpp
@@ -127,11 +127,9 @@ bool RGPassManager::runOnFunction(Function &F) {
         CurrentRegion->verifyRegion();
       }
 
-      // Then call the regular verifyAnalysis functions.
-      verifyPreservedAnalysis(P);
-
       if (LocalChanged)
         removeNotPreservedAnalysis(P);
+      verifyAvailableAnalyses();
       recordAvailableAnalysis(P);
       removeDeadPasses(P,
                        (!isPassDebuggingExecutionsOrMore())

--- a/llvm/lib/CodeGen/MachineRegionInfo.cpp
+++ b/llvm/lib/CodeGen/MachineRegionInfo.cpp
@@ -102,7 +102,7 @@ void MachineRegionInfoPass::releaseMemory() {
 
 void MachineRegionInfoPass::verifyAnalysis() const {
   // Only do verification when user wants to, otherwise this expensive check
-  // will be invoked by PMDataManager::verifyPreservedAnalysis when
+  // will be invoked by PMDataManager::verifyAvailableAnalyses when
   // a regionpass (marked PreservedAll) finish.
   if (MachineRegionInfo::VerifyRegionInfo)
     RI.verifyAnalysis();

--- a/llvm/lib/IR/LegacyPassManager.cpp
+++ b/llvm/lib/IR/LegacyPassManager.cpp
@@ -905,21 +905,16 @@ bool PMDataManager::preserveHigherLevelAnalysis(Pass *P) {
   return true;
 }
 
-/// verifyPreservedAnalysis -- Verify analysis preserved by pass P.
-void PMDataManager::verifyPreservedAnalysis(Pass *P) {
+/// verifyAvailableAnalyses -- Verify all available analyses.
+void PMDataManager::verifyAvailableAnalyses() {
   // Don't do this unless assertions are enabled.
 #ifdef NDEBUG
   return;
 #endif
-  AnalysisUsage *AnUsage = TPM->findAnalysisUsage(P);
-  const AnalysisUsage::VectorType &PreservedSet = AnUsage->getPreservedSet();
-
-  // Verify preserved analysis
-  for (AnalysisID AID : PreservedSet) {
-    if (Pass *AP = findAnalysisPass(AID, true)) {
-      TimeRegion PassTimer(getPassTimer(AP));
-      AP->verifyAnalysis();
-    }
+  for (auto AA : AvailableAnalysis) {
+    Pass *AP = AA.second;
+    TimeRegion PassTimer(getPassTimer(AP));
+    AP->verifyAnalysis();
   }
 }
 
@@ -1469,9 +1464,9 @@ bool FPPassManager::runOnFunction(Function &F) {
     dumpPreservedSet(FP);
     dumpUsedSet(FP);
 
-    verifyPreservedAnalysis(FP);
     if (LocalChanged)
       removeNotPreservedAnalysis(FP);
+    verifyAvailableAnalyses();
     recordAvailableAnalysis(FP);
     removeDeadPasses(FP, Name, ON_FUNCTION_MSG);
   }
@@ -1579,9 +1574,9 @@ MPPassManager::runOnModule(Module &M) {
     dumpPreservedSet(MP);
     dumpUsedSet(MP);
 
-    verifyPreservedAnalysis(MP);
     if (LocalChanged)
       removeNotPreservedAnalysis(MP);
+    verifyAvailableAnalyses();
     recordAvailableAnalysis(MP);
     removeDeadPasses(MP, M.getModuleIdentifier(), ON_MODULE_MSG);
   }


### PR DESCRIPTION
After a pass that setPreservesAll(), verify all available analyses.
Previously we would only verify analyses that were explicitly preserved
with addPreserved().

In my Release+Asserts build this makes check-llvm-codegen measurably
*faster* because although it verifies more analyses, it involves fewer
calls to the slow function findAnalysisPass.
