### PR TITLE
[libc++] Handle _LIBCPP_HAS_NO_{THREADS,LOCALIZATION} consistently with other carve-outs

### DIFF
--- a/libcxx/docs/ReleaseNotes/19.rst
+++ b/libcxx/docs/ReleaseNotes/19.rst
@@ -130,6 +130,12 @@ Deprecations and Removals
   `std-allocator-const <https://clang.llvm.org/extra/clang-tidy/checks/portability/std-allocator-const.html>`
   enabled.
 
+- When configuring libc++ with localization or threads disabled, the library no longer emits an error when
+  trying to ``#include <locale>`` and other such headers. Instead, those headers have no content. This is
+  consistent with the behavior for all other libc++ carve-outs like filesystem, wide characters, a source
+  of randomness, and others. Users that were checking whether including a header would fail (e.g. via a script
+  or CMake's ``try_compile`` will experience a change in behavior).
+
 
 Upcoming Deprecations and Removals
 ----------------------------------

--- a/libcxx/include/barrier
+++ b/libcxx/include/barrier
@@ -47,30 +47,28 @@ namespace std
 
 #include <__config>
 
-#ifdef _LIBCPP_HAS_NO_THREADS
-#  error "<barrier> is not supported since libc++ has been configured without support for threads."
-#endif
+#if !defined(_LIBCPP_HAS_NO_THREADS)
 
-#include <__assert>
-#include <__atomic/atomic_base.h>
-#include <__atomic/memory_order.h>
-#include <__memory/unique_ptr.h>
-#include <__thread/poll_with_backoff.h>
-#include <__thread/timed_backoff_policy.h>
-#include <__utility/move.h>
-#include <cstddef>
-#include <cstdint>
-#include <limits>
-#include <version>
+#  include <__assert>
+#  include <__atomic/atomic_base.h>
+#  include <__atomic/memory_order.h>
+#  include <__memory/unique_ptr.h>
+#  include <__thread/poll_with_backoff.h>
+#  include <__thread/timed_backoff_policy.h>
+#  include <__utility/move.h>
+#  include <cstddef>
+#  include <cstdint>
+#  include <limits>
+#  include <version>
 
-#if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
-#  pragma GCC system_header
-#endif
+#  if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
+#    pragma GCC system_header
+#  endif
 
 _LIBCPP_PUSH_MACROS
-#include <__undef_macros>
+#  include <__undef_macros>
 
-#if _LIBCPP_STD_VER >= 14
+#  if _LIBCPP_STD_VER >= 14
 
 _LIBCPP_BEGIN_NAMESPACE_STD
 
@@ -78,7 +76,7 @@ struct __empty_completion {
   inline _LIBCPP_HIDE_FROM_ABI void operator()() noexcept {}
 };
 
-#  ifndef _LIBCPP_HAS_NO_TREE_BARRIER
+#    ifndef _LIBCPP_HAS_NO_TREE_BARRIER
 
 /*
 
@@ -152,7 +150,7 @@ public:
   }
 };
 
-#  else
+#    else
 
 /*
 
@@ -253,7 +251,7 @@ public:
   }
 };
 
-#  endif // !_LIBCPP_HAS_NO_TREE_BARRIER
+#    endif // !_LIBCPP_HAS_NO_TREE_BARRIER
 
 template <class _CompletionF = __empty_completion>
 class _LIBCPP_DEPRECATED_ATOMIC_SYNC barrier {
@@ -265,7 +263,7 @@ public:
   static _LIBCPP_HIDE_FROM_ABI constexpr ptrdiff_t max() noexcept { return __barrier_base<_CompletionF>::max(); }
 
   _LIBCPP_AVAILABILITY_SYNC
-      _LIBCPP_HIDE_FROM_ABI explicit barrier(ptrdiff_t __count, _CompletionF __completion = _CompletionF())
+  _LIBCPP_HIDE_FROM_ABI explicit barrier(ptrdiff_t __count, _CompletionF __completion = _CompletionF())
       : __b_(__count, std::move(__completion)) {
     _LIBCPP_ASSERT_ARGUMENT_WITHIN_DOMAIN(
         __count >= 0,
@@ -292,9 +290,11 @@ public:
 
 _LIBCPP_END_NAMESPACE_STD
 
-#endif // _LIBCPP_STD_VER >= 14
+#  endif // _LIBCPP_STD_VER >= 14
 
 _LIBCPP_POP_MACROS
+
+#endif // !defined(_LIBCPP_HAS_NO_THREADS)
 
 #if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
 #  include <atomic>

--- a/libcxx/include/future
+++ b/libcxx/include/future
@@ -364,44 +364,42 @@ template <class R, class Alloc> struct uses_allocator<packaged_task<R>, Alloc>;
 
 #include <__config>
 
-#ifdef _LIBCPP_HAS_NO_THREADS
-#  error "<future> is not supported since libc++ has been configured without support for threads."
-#endif
+#if !defined(_LIBCPP_HAS_NO_THREADS)
 
-#include <__assert>
-#include <__chrono/duration.h>
-#include <__chrono/time_point.h>
-#include <__exception/exception_ptr.h>
-#include <__memory/addressof.h>
-#include <__memory/allocator.h>
-#include <__memory/allocator_arg_t.h>
-#include <__memory/allocator_destructor.h>
-#include <__memory/allocator_traits.h>
-#include <__memory/compressed_pair.h>
-#include <__memory/pointer_traits.h>
-#include <__memory/shared_ptr.h>
-#include <__memory/unique_ptr.h>
-#include <__memory/uses_allocator.h>
-#include <__system_error/error_category.h>
-#include <__system_error/error_code.h>
-#include <__system_error/error_condition.h>
-#include <__type_traits/aligned_storage.h>
-#include <__type_traits/strip_signature.h>
-#include <__utility/auto_cast.h>
-#include <__utility/forward.h>
-#include <__utility/move.h>
-#include <mutex>
-#include <new>
-#include <stdexcept>
-#include <thread>
-#include <version>
+#  include <__assert>
+#  include <__chrono/duration.h>
+#  include <__chrono/time_point.h>
+#  include <__exception/exception_ptr.h>
+#  include <__memory/addressof.h>
+#  include <__memory/allocator.h>
+#  include <__memory/allocator_arg_t.h>
+#  include <__memory/allocator_destructor.h>
+#  include <__memory/allocator_traits.h>
+#  include <__memory/compressed_pair.h>
+#  include <__memory/pointer_traits.h>
+#  include <__memory/shared_ptr.h>
+#  include <__memory/unique_ptr.h>
+#  include <__memory/uses_allocator.h>
+#  include <__system_error/error_category.h>
+#  include <__system_error/error_code.h>
+#  include <__system_error/error_condition.h>
+#  include <__type_traits/aligned_storage.h>
+#  include <__type_traits/strip_signature.h>
+#  include <__utility/auto_cast.h>
+#  include <__utility/forward.h>
+#  include <__utility/move.h>
+#  include <mutex>
+#  include <new>
+#  include <stdexcept>
+#  include <thread>
+#  include <version>
 
-#if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
-#  pragma GCC system_header
-#endif
+#  if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
+#    pragma GCC system_header
+#  endif
 
 _LIBCPP_PUSH_MACROS
-#include <__undef_macros>
+#  include <__undef_macros>
 
 _LIBCPP_BEGIN_NAMESPACE_STD
 
@@ -413,16 +411,16 @@ _LIBCPP_DECLARE_STRONG_ENUM_EPILOG(future_errc)
 template <>
 struct _LIBCPP_TEMPLATE_VIS is_error_code_enum<future_errc> : public true_type {};
 
-#ifdef _LIBCPP_CXX03_LANG
+#  ifdef _LIBCPP_CXX03_LANG
 template <>
 struct _LIBCPP_TEMPLATE_VIS is_error_code_enum<future_errc::__lx> : public true_type {};
-#endif
+#  endif
 
 // enum class launch
 _LIBCPP_DECLARE_STRONG_ENUM(launch){async = 1, deferred = 2, any = async | deferred};
 _LIBCPP_DECLARE_STRONG_ENUM_EPILOG(launch)
 
-#ifndef _LIBCPP_CXX03_LANG
+#  ifndef _LIBCPP_CXX03_LANG
 
 typedef underlying_type<launch>::type __launch_underlying_type;
 
@@ -457,7 +455,7 @@ inline _LIBCPP_HIDE_FROM_ABI launch& operator^=(launch& __x, launch __y) {
   return __x;
 }
 
-#endif // !_LIBCPP_CXX03_LANG
+#  endif // !_LIBCPP_CXX03_LANG
 
 // enum class future_status
 _LIBCPP_DECLARE_STRONG_ENUM(future_status){ready, timeout, deferred};
@@ -484,9 +482,9 @@ class _LIBCPP_EXPORTED_FROM_ABI future_error : public logic_error {
   friend class promise;
 
 public:
-#if _LIBCPP_STD_VER >= 17
+#  if _LIBCPP_STD_VER >= 17
   _LIBCPP_HIDE_FROM_ABI explicit future_error(future_errc __ec) : future_error(std::make_error_code(__ec)) {}
-#endif
+#  endif
 
   _LIBCPP_HIDE_FROM_ABI const error_code& code() const _NOEXCEPT { return __ec_; }
 
@@ -496,12 +494,12 @@ public:
 
 // Declared above std::future_error
 void __throw_future_error(future_errc __ev) {
-#ifndef _LIBCPP_HAS_NO_EXCEPTIONS
+#  ifndef _LIBCPP_HAS_NO_EXCEPTIONS
   throw future_error(make_error_code(__ev));
-#else
+#  else
   (void)__ev;
   _LIBCPP_VERBOSE_ABORT("future_error was thrown in -fno-exceptions mode");
-#endif
+#  endif
 }
 
 class _LIBCPP_EXPORTED_FROM_ABI __assoc_sub_state : public __shared_count {
@@ -775,15 +773,15 @@ inline __deferred_assoc_state<_Rp, _Fp>::__deferred_assoc_state(_Fp&& __f) : __f
 
 template <class _Rp, class _Fp>
 void __deferred_assoc_state<_Rp, _Fp>::__execute() {
-#ifndef _LIBCPP_HAS_NO_EXCEPTIONS
+#  ifndef _LIBCPP_HAS_NO_EXCEPTIONS
   try {
-#endif // _LIBCPP_HAS_NO_EXCEPTIONS
+#  endif // _LIBCPP_HAS_NO_EXCEPTIONS
     this->set_value(__func_());
-#ifndef _LIBCPP_HAS_NO_EXCEPTIONS
+#  ifndef _LIBCPP_HAS_NO_EXCEPTIONS
   } catch (...) {
     this->set_exception(current_exception());
   }
-#endif // _LIBCPP_HAS_NO_EXCEPTIONS
+#  endif // _LIBCPP_HAS_NO_EXCEPTIONS
 }
 
 template <class _Fp>
@@ -805,16 +803,16 @@ inline __deferred_assoc_state<void, _Fp>::__deferred_assoc_state(_Fp&& __f) : __
 
 template <class _Fp>
 void __deferred_assoc_state<void, _Fp>::__execute() {
-#ifndef _LIBCPP_HAS_NO_EXCEPTIONS
+#  ifndef _LIBCPP_HAS_NO_EXCEPTIONS
   try {
-#endif // _LIBCPP_HAS_NO_EXCEPTIONS
+#  endif // _LIBCPP_HAS_NO_EXCEPTIONS
     __func_();
     this->set_value();
-#ifndef _LIBCPP_HAS_NO_EXCEPTIONS
+#  ifndef _LIBCPP_HAS_NO_EXCEPTIONS
   } catch (...) {
     this->set_exception(current_exception());
   }
-#endif // _LIBCPP_HAS_NO_EXCEPTIONS
+#  endif // _LIBCPP_HAS_NO_EXCEPTIONS
 }
 
 template <class _Rp, class _Fp>
@@ -836,15 +834,15 @@ inline __async_assoc_state<_Rp, _Fp>::__async_assoc_state(_Fp&& __f) : __func_(s
 
 template <class _Rp, class _Fp>
 void __async_assoc_state<_Rp, _Fp>::__execute() {
-#ifndef _LIBCPP_HAS_NO_EXCEPTIONS
+#  ifndef _LIBCPP_HAS_NO_EXCEPTIONS
   try {
-#endif // _LIBCPP_HAS_NO_EXCEPTIONS
+#  endif // _LIBCPP_HAS_NO_EXCEPTIONS
     this->set_value(__func_());
-#ifndef _LIBCPP_HAS_NO_EXCEPTIONS
+#  ifndef _LIBCPP_HAS_NO_EXCEPTIONS
   } catch (...) {
     this->set_exception(current_exception());
   }
-#endif // _LIBCPP_HAS_NO_EXCEPTIONS
+#  endif // _LIBCPP_HAS_NO_EXCEPTIONS
 }
 
 template <class _Rp, class _Fp>
@@ -872,16 +870,16 @@ inline __async_assoc_state<void, _Fp>::__async_assoc_state(_Fp&& __f) : __func_(
 
 template <class _Fp>
 void __async_assoc_state<void, _Fp>::__execute() {
-#ifndef _LIBCPP_HAS_NO_EXCEPTIONS
+#  ifndef _LIBCPP_HAS_NO_EXCEPTIONS
   try {
-#endif // _LIBCPP_HAS_NO_EXCEPTIONS
+#  endif // _LIBCPP_HAS_NO_EXCEPTIONS
     __func_();
     this->set_value();
-#ifndef _LIBCPP_HAS_NO_EXCEPTIONS
+#  ifndef _LIBCPP_HAS_NO_EXCEPTIONS
   } catch (...) {
     this->set_exception(current_exception());
   }
-#endif // _LIBCPP_HAS_NO_EXCEPTIONS
+#  endif // _LIBCPP_HAS_NO_EXCEPTIONS
 }
 
 template <class _Fp>
@@ -1386,7 +1384,7 @@ template <class _Rp, class... _ArgTypes>
 class __packaged_task_base<_Rp(_ArgTypes...)> {
 public:
   _LIBCPP_HIDE_FROM_ABI __packaged_task_base() {}
-  __packaged_task_base(const __packaged_task_base&) = delete;
+  __packaged_task_base(const __packaged_task_base&)            = delete;
   __packaged_task_base& operator=(const __packaged_task_base&) = delete;
   _LIBCPP_HIDE_FROM_ABI_VIRTUAL
   virtual ~__packaged_task_base() {}
@@ -1648,15 +1646,15 @@ void packaged_task<_Rp(_ArgTypes...)>::operator()(_ArgTypes... __args) {
     __throw_future_error(future_errc::no_state);
   if (__p_.__state_->__has_value())
     __throw_future_error(future_errc::promise_already_satisfied);
-#ifndef _LIBCPP_HAS_NO_EXCEPTIONS
+#  ifndef _LIBCPP_HAS_NO_EXCEPTIONS
   try {
-#endif // _LIBCPP_HAS_NO_EXCEPTIONS
+#  endif // _LIBCPP_HAS_NO_EXCEPTIONS
     __p_.set_value(__f_(std::forward<_ArgTypes>(__args)...));
-#ifndef _LIBCPP_HAS_NO_EXCEPTIONS
+#  ifndef _LIBCPP_HAS_NO_EXCEPTIONS
   } catch (...) {
     __p_.set_exception(current_exception());
   }
-#endif // _LIBCPP_HAS_NO_EXCEPTIONS
+#  endif // _LIBCPP_HAS_NO_EXCEPTIONS
 }
 
 template <class _Rp, class... _ArgTypes>
@@ -1665,15 +1663,15 @@ void packaged_task<_Rp(_ArgTypes...)>::make_ready_at_thread_exit(_ArgTypes... __
     __throw_future_error(future_errc::no_state);
   if (__p_.__state_->__has_value())
     __throw_future_error(future_errc::promise_already_satisfied);
-#ifndef _LIBCPP_HAS_NO_EXCEPTIONS
+#  ifndef _LIBCPP_HAS_NO_EXCEPTIONS
   try {
-#endif // _LIBCPP_HAS_NO_EXCEPTIONS
+#  endif // _LIBCPP_HAS_NO_EXCEPTIONS
     __p_.set_value_at_thread_exit(__f_(std::forward<_ArgTypes>(__args)...));
-#ifndef _LIBCPP_HAS_NO_EXCEPTIONS
+#  ifndef _LIBCPP_HAS_NO_EXCEPTIONS
   } catch (...) {
     __p_.set_exception_at_thread_exit(current_exception());
   }
-#endif // _LIBCPP_HAS_NO_EXCEPTIONS
+#  endif // _LIBCPP_HAS_NO_EXCEPTIONS
 }
 
 template <class _Rp, class... _ArgTypes>
@@ -1732,7 +1730,7 @@ public:
   _LIBCPP_HIDE_FROM_ABI void reset();
 };
 
-#if _LIBCPP_STD_VER >= 17
+#  if _LIBCPP_STD_VER >= 17
 
 template <class _Rp, class... _Args>
 packaged_task(_Rp (*)(_Args...)) -> packaged_task<_Rp(_Args...)>;
@@ -1740,7 +1738,7 @@ packaged_task(_Rp (*)(_Args...)) -> packaged_task<_Rp(_Args...)>;
 template <class _Fp, class _Stripped = typename __strip_signature<decltype(&_Fp::operator())>::type>
 packaged_task(_Fp) -> packaged_task<_Stripped>;
 
-#endif
+#  endif
 
 template <class... _ArgTypes>
 void packaged_task<void(_ArgTypes...)>::operator()(_ArgTypes... __args) {
@@ -1748,16 +1746,16 @@ void packaged_task<void(_ArgTypes...)>::operator()(_ArgTypes... __args) {
     __throw_future_error(future_errc::no_state);
   if (__p_.__state_->__has_value())
     __throw_future_error(future_errc::promise_already_satisfied);
-#ifndef _LIBCPP_HAS_NO_EXCEPTIONS
+#  ifndef _LIBCPP_HAS_NO_EXCEPTIONS
   try {
-#endif // _LIBCPP_HAS_NO_EXCEPTIONS
+#  endif // _LIBCPP_HAS_NO_EXCEPTIONS
     __f_(std::forward<_ArgTypes>(__args)...);
     __p_.set_value();
-#ifndef _LIBCPP_HAS_NO_EXCEPTIONS
+#  ifndef _LIBCPP_HAS_NO_EXCEPTIONS
   } catch (...) {
     __p_.set_exception(current_exception());
   }
-#endif // _LIBCPP_HAS_NO_EXCEPTIONS
+#  endif // _LIBCPP_HAS_NO_EXCEPTIONS
 }
 
 template <class... _ArgTypes>
@@ -1766,16 +1764,16 @@ void packaged_task<void(_ArgTypes...)>::make_ready_at_thread_exit(_ArgTypes... _
     __throw_future_error(future_errc::no_state);
   if (__p_.__state_->__has_value())
     __throw_future_error(future_errc::promise_already_satisfied);
-#ifndef _LIBCPP_HAS_NO_EXCEPTIONS
+#  ifndef _LIBCPP_HAS_NO_EXCEPTIONS
   try {
-#endif // _LIBCPP_HAS_NO_EXCEPTIONS
+#  endif // _LIBCPP_HAS_NO_EXCEPTIONS
     __f_(std::forward<_ArgTypes>(__args)...);
     __p_.set_value_at_thread_exit();
-#ifndef _LIBCPP_HAS_NO_EXCEPTIONS
+#  ifndef _LIBCPP_HAS_NO_EXCEPTIONS
   } catch (...) {
     __p_.set_exception_at_thread_exit(current_exception());
   }
-#endif // _LIBCPP_HAS_NO_EXCEPTIONS
+#  endif // _LIBCPP_HAS_NO_EXCEPTIONS
 }
 
 template <class... _ArgTypes>
@@ -1809,7 +1807,7 @@ _LIBCPP_HIDE_FROM_ABI future<_Rp> __make_async_assoc_state(_Fp&& __f) {
   return future<_Rp>(__h.get());
 }
 
-#ifndef _LIBCPP_CXX03_LANG
+#  ifndef _LIBCPP_CXX03_LANG
 
 template <class _Fp, class... _Args>
 class _LIBCPP_HIDDEN __async_func {
@@ -1845,18 +1843,18 @@ async(launch __policy, _Fp&& __f, _Args&&... __args) {
   typedef __async_func<__decay_t<_Fp>, __decay_t<_Args>...> _BF;
   typedef typename _BF::_Rp _Rp;
 
-#  ifndef _LIBCPP_HAS_NO_EXCEPTIONS
+#    ifndef _LIBCPP_HAS_NO_EXCEPTIONS
   try {
-#  endif
+#    endif
     if (__does_policy_contain(__policy, launch::async))
       return std::__make_async_assoc_state<_Rp>(
           _BF(_LIBCPP_AUTO_CAST(std::forward<_Fp>(__f)), _LIBCPP_AUTO_CAST(std::forward<_Args>(__args))...));
-#  ifndef _LIBCPP_HAS_NO_EXCEPTIONS
+#    ifndef _LIBCPP_HAS_NO_EXCEPTIONS
   } catch (...) {
     if (__policy == launch::async)
       throw;
   }
-#  endif
+#    endif
 
   if (__does_policy_contain(__policy, launch::deferred))
     return std::__make_deferred_assoc_state<_Rp>(
@@ -1870,7 +1868,7 @@ async(_Fp&& __f, _Args&&... __args) {
   return std::async(launch::any, std::forward<_Fp>(__f), std::forward<_Args>(__args)...);
 }
 
-#endif // C++03
+#  endif // C++03
 
 // shared_future
 
@@ -2046,6 +2044,8 @@ inline shared_future<void> future<void>::share() _NOEXCEPT { return shared_futur
 _LIBCPP_END_NAMESPACE_STD
 
 _LIBCPP_POP_MACROS
+
+#endif // !defined(_LIBCPP_HAS_NO_THREADS)
 
 #if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 17
 #  include <chrono>

--- a/libcxx/include/ios
+++ b/libcxx/include/ios
@@ -213,36 +213,34 @@ storage-class-specifier const error_category& iostream_category() noexcept;
 
 #include <__config>
 
-#if defined(_LIBCPP_HAS_NO_LOCALIZATION)
-#  error "The iostreams library is not supported since libc++ has been configured without support for localization."
-#endif
+#if !defined(_LIBCPP_HAS_NO_LOCALIZATION)
 
-#include <__fwd/ios.h>
-#include <__ios/fpos.h>
-#include <__locale>
-#include <__system_error/error_category.h>
-#include <__system_error/error_code.h>
-#include <__system_error/error_condition.h>
-#include <__system_error/system_error.h>
-#include <__utility/swap.h>
-#include <__verbose_abort>
-#include <version>
+#  include <__fwd/ios.h>
+#  include <__ios/fpos.h>
+#  include <__locale>
+#  include <__system_error/error_category.h>
+#  include <__system_error/error_code.h>
+#  include <__system_error/error_condition.h>
+#  include <__system_error/system_error.h>
+#  include <__utility/swap.h>
+#  include <__verbose_abort>
+#  include <version>
 
 // standard-mandated includes
 
 // [ios.syn]
-#include <iosfwd>
+#  include <iosfwd>
 
-#if !defined(_LIBCPP_HAS_NO_ATOMIC_HEADER)
-#  include <__atomic/atomic.h> // for __xindex_
-#endif
+#  if !defined(_LIBCPP_HAS_NO_ATOMIC_HEADER)
+#    include <__atomic/atomic.h> // for __xindex_
+#  endif
 
-#if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
-#  pragma GCC system_header
-#endif
+#  if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
+#    pragma GCC system_header
+#  endif
 
 _LIBCPP_PUSH_MACROS
-#include <__undef_macros>
+#  include <__undef_macros>
 
 _LIBCPP_BEGIN_NAMESPACE_STD
 
@@ -285,20 +283,20 @@ public:
   static const openmode in     = 0x08;
   static const openmode out    = 0x10;
   static const openmode trunc  = 0x20;
-#if _LIBCPP_STD_VER >= 23
+#  if _LIBCPP_STD_VER >= 23
   static const openmode noreplace = 0x40;
-#endif
+#  endif
 
   enum seekdir { beg, cur, end };
 
-#if _LIBCPP_STD_VER <= 14
+#  if _LIBCPP_STD_VER <= 14
   typedef iostate io_state;
   typedef openmode open_mode;
   typedef seekdir seek_dir;
 
   typedef std::streamoff streamoff;
   typedef std::streampos streampos;
-#endif
+#  endif
 
   class _LIBCPP_EXPORTED_FROM_ABI Init;
 
@@ -398,11 +396,11 @@ private:
   size_t __event_cap_;
 // TODO(EricWF): Enable this for both Clang and GCC. Currently it is only
 // enabled with clang.
-#if defined(_LIBCPP_HAS_C_ATOMIC_IMP) && !defined(_LIBCPP_HAS_NO_THREADS)
+#  if defined(_LIBCPP_HAS_C_ATOMIC_IMP) && !defined(_LIBCPP_HAS_NO_THREADS)
   static atomic<int> __xindex_;
-#else
+#  else
   static int __xindex_;
-#endif
+#  endif
   long* __iarray_;
   size_t __iarray_size_;
   size_t __iarray_cap_;
@@ -418,10 +416,10 @@ _LIBCPP_DECLARE_STRONG_ENUM_EPILOG(io_errc)
 template <>
 struct _LIBCPP_TEMPLATE_VIS is_error_code_enum<io_errc> : public true_type {};
 
-#ifdef _LIBCPP_CXX03_LANG
+#  ifdef _LIBCPP_CXX03_LANG
 template <>
 struct _LIBCPP_TEMPLATE_VIS is_error_code_enum<io_errc::__lx> : public true_type {};
-#endif
+#  endif
 
 _LIBCPP_EXPORTED_FROM_ABI const error_category& iostream_category() _NOEXCEPT;
 
@@ -442,11 +440,11 @@ public:
 };
 
 _LIBCPP_NORETURN inline _LIBCPP_HIDE_FROM_ABI void __throw_failure(char const* __msg) {
-#ifndef _LIBCPP_HAS_NO_EXCEPTIONS
+#  ifndef _LIBCPP_HAS_NO_EXCEPTIONS
   throw ios_base::failure(__msg);
-#else
+#  else
   _LIBCPP_VERBOSE_ABORT("ios_base::failure was thrown in -fno-exceptions mode with message \"%s\"", __msg);
-#endif
+#  endif
 }
 
 class _LIBCPP_EXPORTED_FROM_ABI ios_base::Init {
@@ -535,13 +533,13 @@ public:
   static_assert(is_same<_CharT, typename traits_type::char_type>::value,
                 "traits_type::char_type must be the same type as CharT");
 
-#ifdef _LIBCPP_CXX03_LANG
+#  ifdef _LIBCPP_CXX03_LANG
   // Preserve the ability to compare with literal 0,
   // and implicitly convert to bool, but not implicitly convert to int.
   _LIBCPP_HIDE_FROM_ABI operator void*() const { return fail() ? nullptr : (void*)this; }
-#else
+#  else
   _LIBCPP_HIDE_FROM_ABI explicit operator bool() const { return !fail(); }
-#endif
+#  endif
 
   _LIBCPP_HIDE_FROM_ABI bool operator!() const { return fail(); }
   _LIBCPP_HIDE_FROM_ABI iostate rdstate() const { return ios_base::rdstate(); }
@@ -704,9 +702,9 @@ inline _LIBCPP_HIDE_FROM_ABI void basic_ios<_CharT, _Traits>::set_rdbuf(basic_st
 
 extern template class _LIBCPP_EXTERN_TEMPLATE_TYPE_VIS basic_ios<char>;
 
-#ifndef _LIBCPP_HAS_NO_WIDE_CHARACTERS
+#  ifndef _LIBCPP_HAS_NO_WIDE_CHARACTERS
 extern template class _LIBCPP_EXTERN_TEMPLATE_TYPE_VIS basic_ios<wchar_t>;
-#endif
+#  endif
 
 _LIBCPP_HIDE_FROM_ABI inline ios_base& boolalpha(ios_base& __str) {
   __str.setf(ios_base::boolalpha);
@@ -831,6 +829,8 @@ _LIBCPP_HIDE_FROM_ABI inline ios_base& defaultfloat(ios_base& __str) {
 _LIBCPP_END_NAMESPACE_STD
 
 _LIBCPP_POP_MACROS
+
+#endif // !defined(_LIBCPP_HAS_NO_LOCALIZATION)
 
 #if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
 #  include <atomic>

--- a/libcxx/include/latch
+++ b/libcxx/include/latch
@@ -42,26 +42,24 @@ namespace std
 
 #include <__config>
 
-#ifdef _LIBCPP_HAS_NO_THREADS
-#  error "<latch> is not supported since libc++ has been configured without support for threads."
-#endif
+#if !defined(_LIBCPP_HAS_NO_THREADS)
 
-#include <__assert>
-#include <__atomic/atomic_base.h>
-#include <__atomic/atomic_sync.h>
-#include <__atomic/memory_order.h>
-#include <cstddef>
-#include <limits>
-#include <version>
+#  include <__assert>
+#  include <__atomic/atomic_base.h>
+#  include <__atomic/atomic_sync.h>
+#  include <__atomic/memory_order.h>
+#  include <cstddef>
+#  include <limits>
+#  include <version>
 
-#if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
-#  pragma GCC system_header
-#endif
+#  if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
+#    pragma GCC system_header
+#  endif
 
 _LIBCPP_PUSH_MACROS
-#include <__undef_macros>
+#  include <__undef_macros>
 
-#if _LIBCPP_STD_VER >= 14
+#  if _LIBCPP_STD_VER >= 14
 
 _LIBCPP_BEGIN_NAMESPACE_STD
 
@@ -118,9 +116,11 @@ private:
 
 _LIBCPP_END_NAMESPACE_STD
 
-#endif // _LIBCPP_STD_VER >= 14
+#  endif // _LIBCPP_STD_VER >= 14
 
 _LIBCPP_POP_MACROS
+
+#endif // !defined(_LIBCPP_HAS_NO_THREADS)
 
 #if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
 #  include <atomic>

--- a/libcxx/include/locale
+++ b/libcxx/include/locale
@@ -187,67 +187,70 @@ template <class charT> class messages_byname;
 
 */
 
-#include <__algorithm/copy.h>
-#include <__algorithm/equal.h>
-#include <__algorithm/find.h>
-#include <__algorithm/max.h>
-#include <__algorithm/reverse.h>
-#include <__algorithm/unwrap_iter.h>
-#include <__assert>
 #include <__config>
-#include <__iterator/access.h>
-#include <__iterator/back_insert_iterator.h>
-#include <__iterator/istreambuf_iterator.h>
-#include <__iterator/ostreambuf_iterator.h>
-#include <__locale>
-#include <__memory/unique_ptr.h>
-#include <__type_traits/make_unsigned.h>
-#include <cerrno>
-#include <cstdio>
-#include <cstdlib>
-#include <ctime>
-#include <ios>
-#include <limits>
-#include <new>
-#include <streambuf>
-#include <version>
+
+#if !defined(_LIBCPP_HAS_NO_LOCALIZATION)
+
+#  include <__algorithm/copy.h>
+#  include <__algorithm/equal.h>
+#  include <__algorithm/find.h>
+#  include <__algorithm/max.h>
+#  include <__algorithm/reverse.h>
+#  include <__algorithm/unwrap_iter.h>
+#  include <__assert>
+#  include <__iterator/access.h>
+#  include <__iterator/back_insert_iterator.h>
+#  include <__iterator/istreambuf_iterator.h>
+#  include <__iterator/ostreambuf_iterator.h>
+#  include <__locale>
+#  include <__memory/unique_ptr.h>
+#  include <__type_traits/make_unsigned.h>
+#  include <cerrno>
+#  include <cstdio>
+#  include <cstdlib>
+#  include <ctime>
+#  include <ios>
+#  include <limits>
+#  include <new>
+#  include <streambuf>
+#  include <version>
 
 // TODO: Fix __bsd_locale_defaults.h
 // NOLINTBEGIN(libcpp-robust-against-adl)
 
-#if defined(__unix__) || (defined(__APPLE__) && defined(__MACH__))
+#  if defined(__unix__) || (defined(__APPLE__) && defined(__MACH__))
 // Most unix variants have catopen.  These are the specific ones that don't.
-#  if !defined(__BIONIC__) && !defined(_NEWLIB_VERSION) && !defined(__EMSCRIPTEN__)
-#    define _LIBCPP_HAS_CATOPEN 1
-#    include <nl_types.h>
+#    if !defined(__BIONIC__) && !defined(_NEWLIB_VERSION) && !defined(__EMSCRIPTEN__)
+#      define _LIBCPP_HAS_CATOPEN 1
+#      include <nl_types.h>
+#    endif
 #  endif
-#endif
 
-#ifdef _LIBCPP_LOCALE__L_EXTENSIONS
-#  include <__locale_dir/locale_base_api/bsd_locale_defaults.h>
-#else
-#  include <__locale_dir/locale_base_api/bsd_locale_fallbacks.h>
-#endif
+#  ifdef _LIBCPP_LOCALE__L_EXTENSIONS
+#    include <__locale_dir/locale_base_api/bsd_locale_defaults.h>
+#  else
+#    include <__locale_dir/locale_base_api/bsd_locale_fallbacks.h>
+#  endif
 
-#if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
-#  pragma GCC system_header
-#endif
+#  if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
+#    pragma GCC system_header
+#  endif
 
 _LIBCPP_PUSH_MACROS
-#include <__undef_macros>
+#  include <__undef_macros>
 
 _LIBCPP_BEGIN_NAMESPACE_STD
 
-#if defined(__APPLE__) || defined(__FreeBSD__)
-#  define _LIBCPP_GET_C_LOCALE 0
-#elif defined(__NetBSD__)
-#  define _LIBCPP_GET_C_LOCALE LC_C_LOCALE
-#else
-#  define _LIBCPP_GET_C_LOCALE __cloc()
+#  if defined(__APPLE__) || defined(__FreeBSD__)
+#    define _LIBCPP_GET_C_LOCALE 0
+#  elif defined(__NetBSD__)
+#    define _LIBCPP_GET_C_LOCALE LC_C_LOCALE
+#  else
+#    define _LIBCPP_GET_C_LOCALE __cloc()
 // Get the C locale object
 _LIBCPP_EXPORTED_FROM_ABI locale_t __cloc();
-#  define __cloc_defined
-#endif
+#    define __cloc_defined
+#  endif
 
 // __scan_keyword
 // Scans [__b, __e) until a match is found in the basic_strings range
@@ -395,7 +398,7 @@ struct __num_get : protected __num_get_base {
       unsigned*& __g_end,
       unsigned& __dc,
       _CharT* __atoms);
-#ifndef _LIBCPP_ABI_OPTIMIZED_LOCALE_NUM_GET
+#  ifndef _LIBCPP_ABI_OPTIMIZED_LOCALE_NUM_GET
   static string __stage2_int_prep(ios_base& __iob, _CharT* __atoms, _CharT& __thousands_sep);
   static int __stage2_int_loop(
       _CharT __ct,
@@ -409,7 +412,7 @@ struct __num_get : protected __num_get_base {
       unsigned*& __g_end,
       _CharT* __atoms);
 
-#else
+#  else
   static string __stage2_int_prep(ios_base& __iob, _CharT& __thousands_sep) {
     locale __loc                 = __iob.getloc();
     const numpunct<_CharT>& __np = use_facet<numpunct<_CharT> >(__loc);
@@ -444,10 +447,10 @@ private:
     (void)__atoms;
     return __src;
   }
-#endif
+#  endif
 };
 
-#ifndef _LIBCPP_ABI_OPTIMIZED_LOCALE_NUM_GET
+#  ifndef _LIBCPP_ABI_OPTIMIZED_LOCALE_NUM_GET
 template <class _CharT>
 string __num_get<_CharT>::__stage2_int_prep(ios_base& __iob, _CharT* __atoms, _CharT& __thousands_sep) {
   locale __loc = __iob.getloc();
@@ -456,7 +459,7 @@ string __num_get<_CharT>::__stage2_int_prep(ios_base& __iob, _CharT* __atoms, _C
   __thousands_sep              = __np.thousands_sep();
   return __np.grouping();
 }
-#endif
+#  endif
 
 template <class _CharT>
 string __num_get<_CharT>::__stage2_float_prep(
@@ -471,16 +474,16 @@ string __num_get<_CharT>::__stage2_float_prep(
 
 template <class _CharT>
 int
-#ifndef _LIBCPP_ABI_OPTIMIZED_LOCALE_NUM_GET
+#  ifndef _LIBCPP_ABI_OPTIMIZED_LOCALE_NUM_GET
 __num_get<_CharT>::__stage2_int_loop(_CharT __ct, int __base, char* __a, char*& __a_end,
                   unsigned& __dc, _CharT __thousands_sep, const string& __grouping,
                   unsigned* __g, unsigned*& __g_end, _CharT* __atoms)
-#else
+#  else
 __num_get<_CharT>::__stage2_int_loop(_CharT __ct, int __base, char* __a, char*& __a_end,
                   unsigned& __dc, _CharT __thousands_sep, const string& __grouping,
                   unsigned* __g, unsigned*& __g_end, const _CharT* __atoms)
 
-#endif
+#  endif
 {
   if (__a_end == __a && (__ct == __atoms[24] || __ct == __atoms[25])) {
     *__a_end++ = __ct == __atoms[24] ? '+' : '-';
@@ -579,9 +582,9 @@ int __num_get<_CharT>::__stage2_float_loop(
 }
 
 extern template struct _LIBCPP_EXTERN_TEMPLATE_TYPE_VIS __num_get<char>;
-#ifndef _LIBCPP_HAS_NO_WIDE_CHARACTERS
+#  ifndef _LIBCPP_HAS_NO_WIDE_CHARACTERS
 extern template struct _LIBCPP_EXTERN_TEMPLATE_TYPE_VIS __num_get<wchar_t>;
-#endif
+#  endif
 
 template <class _CharT, class _InputIterator = istreambuf_iterator<_CharT> >
 class _LIBCPP_TEMPLATE_VIS num_get : public locale::facet, private __num_get<_CharT> {
@@ -851,14 +854,14 @@ _InputIterator num_get<_CharT, _InputIterator>::__do_get_signed(
   // Stage 2
   char_type __thousands_sep;
   const int __atoms_size = __num_get_base::__int_chr_cnt;
-#ifdef _LIBCPP_ABI_OPTIMIZED_LOCALE_NUM_GET
+#  ifdef _LIBCPP_ABI_OPTIMIZED_LOCALE_NUM_GET
   char_type __atoms1[__atoms_size];
   const char_type* __atoms = this->__do_widen(__iob, __atoms1);
   string __grouping        = this->__stage2_int_prep(__iob, __thousands_sep);
-#else
+#  else
   char_type __atoms[__atoms_size];
   string __grouping = this->__stage2_int_prep(__iob, __atoms, __thousands_sep);
-#endif
+#  endif
   string __buf;
   __buf.resize(__buf.capacity());
   char* __a     = &__buf[0];
@@ -900,14 +903,14 @@ _InputIterator num_get<_CharT, _InputIterator>::__do_get_unsigned(
   // Stage 2
   char_type __thousands_sep;
   const int __atoms_size = __num_get_base::__int_chr_cnt;
-#ifdef _LIBCPP_ABI_OPTIMIZED_LOCALE_NUM_GET
+#  ifdef _LIBCPP_ABI_OPTIMIZED_LOCALE_NUM_GET
   char_type __atoms1[__atoms_size];
   const char_type* __atoms = this->__do_widen(__iob, __atoms1);
   string __grouping        = this->__stage2_int_prep(__iob, __thousands_sep);
-#else
+#  else
   char_type __atoms[__atoms_size];
   string __grouping = this->__stage2_int_prep(__iob, __atoms, __thousands_sep);
-#endif
+#  endif
   string __buf;
   __buf.resize(__buf.capacity());
   char* __a     = &__buf[0];
@@ -1050,9 +1053,9 @@ _InputIterator num_get<_CharT, _InputIterator>::do_get(
 }
 
 extern template class _LIBCPP_EXTERN_TEMPLATE_TYPE_VIS num_get<char>;
-#ifndef _LIBCPP_HAS_NO_WIDE_CHARACTERS
+#  ifndef _LIBCPP_HAS_NO_WIDE_CHARACTERS
 extern template class _LIBCPP_EXTERN_TEMPLATE_TYPE_VIS num_get<wchar_t>;
-#endif
+#  endif
 
 struct _LIBCPP_EXPORTED_FROM_ABI __num_put_base {
 protected:
@@ -1168,9 +1171,9 @@ void __num_put<_CharT>::__widen_and_group_float(
 }
 
 extern template struct _LIBCPP_EXTERN_TEMPLATE_TYPE_VIS __num_put<char>;
-#ifndef _LIBCPP_HAS_NO_WIDE_CHARACTERS
+#  ifndef _LIBCPP_HAS_NO_WIDE_CHARACTERS
 extern template struct _LIBCPP_EXTERN_TEMPLATE_TYPE_VIS __num_put<wchar_t>;
-#endif
+#  endif
 
 template <class _CharT, class _OutputIterator = ostreambuf_iterator<_CharT> >
 class _LIBCPP_TEMPLATE_VIS num_put : public locale::facet, private __num_put<_CharT> {
@@ -1455,9 +1458,9 @@ num_put<_CharT, _OutputIterator>::do_put(iter_type __s, ios_base& __iob, char_ty
 }
 
 extern template class _LIBCPP_EXTERN_TEMPLATE_TYPE_VIS num_put<char>;
-#ifndef _LIBCPP_HAS_NO_WIDE_CHARACTERS
+#  ifndef _LIBCPP_HAS_NO_WIDE_CHARACTERS
 extern template class _LIBCPP_EXTERN_TEMPLATE_TYPE_VIS num_put<wchar_t>;
-#endif
+#  endif
 
 template <class _CharT, class _InputIterator>
 _LIBCPP_HIDE_FROM_ABI int __get_up_to_n_digits(
@@ -1522,7 +1525,7 @@ _LIBCPP_EXPORTED_FROM_ABI const string& __time_get_c_storage<char>::__x() const;
 template <>
 _LIBCPP_EXPORTED_FROM_ABI const string& __time_get_c_storage<char>::__X() const;
 
-#ifndef _LIBCPP_HAS_NO_WIDE_CHARACTERS
+#  ifndef _LIBCPP_HAS_NO_WIDE_CHARACTERS
 template <>
 _LIBCPP_EXPORTED_FROM_ABI const wstring* __time_get_c_storage<wchar_t>::__weeks() const;
 template <>
@@ -1537,7 +1540,7 @@ template <>
 _LIBCPP_EXPORTED_FROM_ABI const wstring& __time_get_c_storage<wchar_t>::__x() const;
 template <>
 _LIBCPP_EXPORTED_FROM_ABI const wstring& __time_get_c_storage<wchar_t>::__X() const;
-#endif
+#  endif
 
 template <class _CharT, class _InputIterator = istreambuf_iterator<_CharT> >
 class _LIBCPP_TEMPLATE_VIS time_get : public locale::facet, public time_base, private __time_get_c_storage<_CharT> {
@@ -1991,9 +1994,9 @@ _InputIterator time_get<_CharT, _InputIterator>::do_get(
 }
 
 extern template class _LIBCPP_EXTERN_TEMPLATE_TYPE_VIS time_get<char>;
-#ifndef _LIBCPP_HAS_NO_WIDE_CHARACTERS
+#  ifndef _LIBCPP_HAS_NO_WIDE_CHARACTERS
 extern template class _LIBCPP_EXTERN_TEMPLATE_TYPE_VIS time_get<wchar_t>;
-#endif
+#  endif
 
 class _LIBCPP_EXPORTED_FROM_ABI __time_get {
 protected:
@@ -2029,31 +2032,32 @@ private:
   string_type __analyze(char __fmt, const ctype<_CharT>&);
 };
 
-#define _LIBCPP_TIME_GET_STORAGE_EXPLICIT_INSTANTIATION(_CharT)                                                        \
-  template <>                                                                                                          \
-  _LIBCPP_EXPORTED_FROM_ABI time_base::dateorder __time_get_storage<_CharT>::__do_date_order() const;                  \
-  template <>                                                                                                          \
-  _LIBCPP_EXPORTED_FROM_ABI __time_get_storage<_CharT>::__time_get_storage(const char*);                               \
-  template <>                                                                                                          \
-  _LIBCPP_EXPORTED_FROM_ABI __time_get_storage<_CharT>::__time_get_storage(const string&);                             \
-  template <>                                                                                                          \
-  _LIBCPP_EXPORTED_FROM_ABI void __time_get_storage<_CharT>::init(const ctype<_CharT>&);                               \
-  template <>                                                                                                          \
-  _LIBCPP_EXPORTED_FROM_ABI __time_get_storage<_CharT>::string_type __time_get_storage<_CharT>::__analyze(             \
-      char, const ctype<_CharT>&);                                                                                     \
-  extern template _LIBCPP_EXPORTED_FROM_ABI time_base::dateorder __time_get_storage<_CharT>::__do_date_order() const;  \
-  extern template _LIBCPP_EXPORTED_FROM_ABI __time_get_storage<_CharT>::__time_get_storage(const char*);               \
-  extern template _LIBCPP_EXPORTED_FROM_ABI __time_get_storage<_CharT>::__time_get_storage(const string&);             \
-  extern template _LIBCPP_EXPORTED_FROM_ABI void __time_get_storage<_CharT>::init(const ctype<_CharT>&);               \
-  extern template _LIBCPP_EXPORTED_FROM_ABI __time_get_storage<_CharT>::string_type                                    \
-  __time_get_storage<_CharT>::__analyze(char, const ctype<_CharT>&);                                                   \
-  /**/
+#  define _LIBCPP_TIME_GET_STORAGE_EXPLICIT_INSTANTIATION(_CharT)                                                      \
+    template <>                                                                                                        \
+    _LIBCPP_EXPORTED_FROM_ABI time_base::dateorder __time_get_storage<_CharT>::__do_date_order() const;                \
+    template <>                                                                                                        \
+    _LIBCPP_EXPORTED_FROM_ABI __time_get_storage<_CharT>::__time_get_storage(const char*);                             \
+    template <>                                                                                                        \
+    _LIBCPP_EXPORTED_FROM_ABI __time_get_storage<_CharT>::__time_get_storage(const string&);                           \
+    template <>                                                                                                        \
+    _LIBCPP_EXPORTED_FROM_ABI void __time_get_storage<_CharT>::init(const ctype<_CharT>&);                             \
+    template <>                                                                                                        \
+    _LIBCPP_EXPORTED_FROM_ABI __time_get_storage<_CharT>::string_type __time_get_storage<_CharT>::__analyze(           \
+        char, const ctype<_CharT>&);                                                                                   \
+    extern template _LIBCPP_EXPORTED_FROM_ABI time_base::dateorder __time_get_storage<_CharT>::__do_date_order()       \
+        const;                                                                                                         \
+    extern template _LIBCPP_EXPORTED_FROM_ABI __time_get_storage<_CharT>::__time_get_storage(const char*);             \
+    extern template _LIBCPP_EXPORTED_FROM_ABI __time_get_storage<_CharT>::__time_get_storage(const string&);           \
+    extern template _LIBCPP_EXPORTED_FROM_ABI void __time_get_storage<_CharT>::init(const ctype<_CharT>&);             \
+    extern template _LIBCPP_EXPORTED_FROM_ABI __time_get_storage<_CharT>::string_type                                  \
+    __time_get_storage<_CharT>::__analyze(char, const ctype<_CharT>&);                                                 \
+    /**/
 
 _LIBCPP_TIME_GET_STORAGE_EXPLICIT_INSTANTIATION(char)
-#ifndef _LIBCPP_HAS_NO_WIDE_CHARACTERS
+#  ifndef _LIBCPP_HAS_NO_WIDE_CHARACTERS
 _LIBCPP_TIME_GET_STORAGE_EXPLICIT_INSTANTIATION(wchar_t)
-#endif
-#undef _LIBCPP_TIME_GET_STORAGE_EXPLICIT_INSTANTIATION
+#  endif
+#  undef _LIBCPP_TIME_GET_STORAGE_EXPLICIT_INSTANTIATION
 
 template <class _CharT, class _InputIterator = istreambuf_iterator<_CharT> >
 class _LIBCPP_TEMPLATE_VIS time_get_byname
@@ -2086,9 +2090,9 @@ private:
 };
 
 extern template class _LIBCPP_EXTERN_TEMPLATE_TYPE_VIS time_get_byname<char>;
-#ifndef _LIBCPP_HAS_NO_WIDE_CHARACTERS
+#  ifndef _LIBCPP_HAS_NO_WIDE_CHARACTERS
 extern template class _LIBCPP_EXTERN_TEMPLATE_TYPE_VIS time_get_byname<wchar_t>;
-#endif
+#  endif
 
 class _LIBCPP_EXPORTED_FROM_ABI __time_put {
   locale_t __loc_;
@@ -2099,9 +2103,9 @@ protected:
   __time_put(const string& __nm);
   ~__time_put();
   void __do_put(char* __nb, char*& __ne, const tm* __tm, char __fmt, char __mod) const;
-#ifndef _LIBCPP_HAS_NO_WIDE_CHARACTERS
+#  ifndef _LIBCPP_HAS_NO_WIDE_CHARACTERS
   void __do_put(wchar_t* __wb, wchar_t*& __we, const tm* __tm, char __fmt, char __mod) const;
-#endif
+#  endif
 };
 
 template <class _CharT, class _OutputIterator = ostreambuf_iterator<_CharT> >
@@ -2175,9 +2179,9 @@ _OutputIterator time_put<_CharT, _OutputIterator>::do_put(
 }
 
 extern template class _LIBCPP_EXTERN_TEMPLATE_TYPE_VIS time_put<char>;
-#ifndef _LIBCPP_HAS_NO_WIDE_CHARACTERS
+#  ifndef _LIBCPP_HAS_NO_WIDE_CHARACTERS
 extern template class _LIBCPP_EXTERN_TEMPLATE_TYPE_VIS time_put<wchar_t>;
-#endif
+#  endif
 
 template <class _CharT, class _OutputIterator = ostreambuf_iterator<_CharT> >
 class _LIBCPP_TEMPLATE_VIS time_put_byname : public time_put<_CharT, _OutputIterator> {
@@ -2193,9 +2197,9 @@ protected:
 };
 
 extern template class _LIBCPP_EXTERN_TEMPLATE_TYPE_VIS time_put_byname<char>;
-#ifndef _LIBCPP_HAS_NO_WIDE_CHARACTERS
+#  ifndef _LIBCPP_HAS_NO_WIDE_CHARACTERS
 extern template class _LIBCPP_EXTERN_TEMPLATE_TYPE_VIS time_put_byname<wchar_t>;
-#endif
+#  endif
 
 // money_base
 
@@ -2260,10 +2264,10 @@ const bool moneypunct<_CharT, _International>::intl;
 
 extern template class _LIBCPP_EXTERN_TEMPLATE_TYPE_VIS moneypunct<char, false>;
 extern template class _LIBCPP_EXTERN_TEMPLATE_TYPE_VIS moneypunct<char, true>;
-#ifndef _LIBCPP_HAS_NO_WIDE_CHARACTERS
+#  ifndef _LIBCPP_HAS_NO_WIDE_CHARACTERS
 extern template class _LIBCPP_EXTERN_TEMPLATE_TYPE_VIS moneypunct<wchar_t, false>;
 extern template class _LIBCPP_EXTERN_TEMPLATE_TYPE_VIS moneypunct<wchar_t, true>;
-#endif
+#  endif
 
 // moneypunct_byname
 
@@ -2318,14 +2322,14 @@ _LIBCPP_EXPORTED_FROM_ABI void moneypunct_byname<char, true>::init(const char*);
 extern template class _LIBCPP_EXTERN_TEMPLATE_TYPE_VIS moneypunct_byname<char, false>;
 extern template class _LIBCPP_EXTERN_TEMPLATE_TYPE_VIS moneypunct_byname<char, true>;
 
-#ifndef _LIBCPP_HAS_NO_WIDE_CHARACTERS
+#  ifndef _LIBCPP_HAS_NO_WIDE_CHARACTERS
 template <>
 _LIBCPP_EXPORTED_FROM_ABI void moneypunct_byname<wchar_t, false>::init(const char*);
 template <>
 _LIBCPP_EXPORTED_FROM_ABI void moneypunct_byname<wchar_t, true>::init(const char*);
 extern template class _LIBCPP_EXTERN_TEMPLATE_TYPE_VIS moneypunct_byname<wchar_t, false>;
 extern template class _LIBCPP_EXTERN_TEMPLATE_TYPE_VIS moneypunct_byname<wchar_t, true>;
-#endif
+#  endif
 
 // money_get
 
@@ -2386,9 +2390,9 @@ void __money_get<_CharT>::__gather_info(
 }
 
 extern template class _LIBCPP_EXTERN_TEMPLATE_TYPE_VIS __money_get<char>;
-#ifndef _LIBCPP_HAS_NO_WIDE_CHARACTERS
+#  ifndef _LIBCPP_HAS_NO_WIDE_CHARACTERS
 extern template class _LIBCPP_EXTERN_TEMPLATE_TYPE_VIS __money_get<wchar_t>;
-#endif
+#  endif
 
 template <class _CharT, class _InputIterator = istreambuf_iterator<_CharT> >
 class _LIBCPP_TEMPLATE_VIS money_get : public locale::facet, private __money_get<_CharT> {
@@ -2696,9 +2700,9 @@ _InputIterator money_get<_CharT, _InputIterator>::do_get(
 }
 
 extern template class _LIBCPP_EXTERN_TEMPLATE_TYPE_VIS money_get<char>;
-#ifndef _LIBCPP_HAS_NO_WIDE_CHARACTERS
+#  ifndef _LIBCPP_HAS_NO_WIDE_CHARACTERS
 extern template class _LIBCPP_EXTERN_TEMPLATE_TYPE_VIS money_get<wchar_t>;
-#endif
+#  endif
 
 // money_put
 
@@ -2874,9 +2878,9 @@ void __money_put<_CharT>::__format(
 }
 
 extern template class _LIBCPP_EXTERN_TEMPLATE_TYPE_VIS __money_put<char>;
-#ifndef _LIBCPP_HAS_NO_WIDE_CHARACTERS
+#  ifndef _LIBCPP_HAS_NO_WIDE_CHARACTERS
 extern template class _LIBCPP_EXTERN_TEMPLATE_TYPE_VIS __money_put<wchar_t>;
-#endif
+#  endif
 
 template <class _CharT, class _OutputIterator = ostreambuf_iterator<_CharT> >
 class _LIBCPP_TEMPLATE_VIS money_put : public locale::facet, private __money_put<_CharT> {
@@ -3020,9 +3024,9 @@ _OutputIterator money_put<_CharT, _OutputIterator>::do_put(
 }
 
 extern template class _LIBCPP_EXTERN_TEMPLATE_TYPE_VIS money_put<char>;
-#ifndef _LIBCPP_HAS_NO_WIDE_CHARACTERS
+#  ifndef _LIBCPP_HAS_NO_WIDE_CHARACTERS
 extern template class _LIBCPP_EXTERN_TEMPLATE_TYPE_VIS money_put<wchar_t>;
-#endif
+#  endif
 
 // messages
 
@@ -3066,18 +3070,18 @@ locale::id messages<_CharT>::id;
 
 template <class _CharT>
 typename messages<_CharT>::catalog messages<_CharT>::do_open(const basic_string<char>& __nm, const locale&) const {
-#ifdef _LIBCPP_HAS_CATOPEN
+#  ifdef _LIBCPP_HAS_CATOPEN
   return (catalog)catopen(__nm.c_str(), NL_CAT_LOCALE);
-#else  // !_LIBCPP_HAS_CATOPEN
+#  else  // !_LIBCPP_HAS_CATOPEN
   (void)__nm;
   return -1;
-#endif // _LIBCPP_HAS_CATOPEN
+#  endif // _LIBCPP_HAS_CATOPEN
 }
 
 template <class _CharT>
 typename messages<_CharT>::string_type
 messages<_CharT>::do_get(catalog __c, int __set, int __msgid, const string_type& __dflt) const {
-#ifdef _LIBCPP_HAS_CATOPEN
+#  ifdef _LIBCPP_HAS_CATOPEN
   string __ndflt;
   __narrow_to_utf8<sizeof(char_type) * __CHAR_BIT__>()(
       std::back_inserter(__ndflt), __dflt.c_str(), __dflt.c_str() + __dflt.size());
@@ -3087,27 +3091,27 @@ messages<_CharT>::do_get(catalog __c, int __set, int __msgid, const string_type&
   string_type __w;
   __widen_from_utf8<sizeof(char_type) * __CHAR_BIT__>()(std::back_inserter(__w), __n, __n + std::strlen(__n));
   return __w;
-#else  // !_LIBCPP_HAS_CATOPEN
+#  else  // !_LIBCPP_HAS_CATOPEN
   (void)__c;
   (void)__set;
   (void)__msgid;
   return __dflt;
-#endif // _LIBCPP_HAS_CATOPEN
+#  endif // _LIBCPP_HAS_CATOPEN
 }
 
 template <class _CharT>
 void messages<_CharT>::do_close(catalog __c) const {
-#ifdef _LIBCPP_HAS_CATOPEN
+#  ifdef _LIBCPP_HAS_CATOPEN
   catclose((nl_catd)__c);
-#else  // !_LIBCPP_HAS_CATOPEN
+#  else  // !_LIBCPP_HAS_CATOPEN
   (void)__c;
-#endif // _LIBCPP_HAS_CATOPEN
+#  endif // _LIBCPP_HAS_CATOPEN
 }
 
 extern template class _LIBCPP_EXTERN_TEMPLATE_TYPE_VIS messages<char>;
-#ifndef _LIBCPP_HAS_NO_WIDE_CHARACTERS
+#  ifndef _LIBCPP_HAS_NO_WIDE_CHARACTERS
 extern template class _LIBCPP_EXTERN_TEMPLATE_TYPE_VIS messages<wchar_t>;
-#endif
+#  endif
 
 template <class _CharT>
 class _LIBCPP_TEMPLATE_VIS messages_byname : public messages<_CharT> {
@@ -3124,11 +3128,11 @@ protected:
 };
 
 extern template class _LIBCPP_EXTERN_TEMPLATE_TYPE_VIS messages_byname<char>;
-#ifndef _LIBCPP_HAS_NO_WIDE_CHARACTERS
+#  ifndef _LIBCPP_HAS_NO_WIDE_CHARACTERS
 extern template class _LIBCPP_EXTERN_TEMPLATE_TYPE_VIS messages_byname<wchar_t>;
-#endif
+#  endif
 
-#if _LIBCPP_STD_VER < 26 || defined(_LIBCPP_ENABLE_CXX26_REMOVED_WSTRING_CONVERT)
+#  if _LIBCPP_STD_VER < 26 || defined(_LIBCPP_ENABLE_CXX26_REMOVED_WSTRING_CONVERT)
 
 template <class _Codecvt,
           class _Elem      = wchar_t,
@@ -3149,19 +3153,19 @@ private:
   size_t __cvtcount_;
 
 public:
-#  ifndef _LIBCPP_CXX03_LANG
+#    ifndef _LIBCPP_CXX03_LANG
   _LIBCPP_HIDE_FROM_ABI wstring_convert() : wstring_convert(new _Codecvt) {}
   _LIBCPP_HIDE_FROM_ABI explicit wstring_convert(_Codecvt* __pcvt);
-#  else
+#    else
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_EXPLICIT_SINCE_CXX14 wstring_convert(_Codecvt* __pcvt = new _Codecvt);
-#  endif
+#    endif
 
   _LIBCPP_HIDE_FROM_ABI wstring_convert(_Codecvt* __pcvt, state_type __state);
   _LIBCPP_EXPLICIT_SINCE_CXX14 _LIBCPP_HIDE_FROM_ABI
   wstring_convert(const byte_string& __byte_err, const wide_string& __wide_err = wide_string());
-#  ifndef _LIBCPP_CXX03_LANG
+#    ifndef _LIBCPP_CXX03_LANG
   _LIBCPP_HIDE_FROM_ABI wstring_convert(wstring_convert&& __wc);
-#  endif
+#    endif
   _LIBCPP_HIDE_FROM_ABI ~wstring_convert();
 
   wstring_convert(const wstring_convert& __wc)            = delete;
@@ -3206,7 +3210,7 @@ wstring_convert<_Codecvt, _Elem, _WideAlloc, _ByteAlloc>::wstring_convert(
   __cvtptr_ = new _Codecvt;
 }
 
-#  ifndef _LIBCPP_CXX03_LANG
+#    ifndef _LIBCPP_CXX03_LANG
 
 template <class _Codecvt, class _Elem, class _WideAlloc, class _ByteAlloc>
 inline wstring_convert<_Codecvt, _Elem, _WideAlloc, _ByteAlloc>::wstring_convert(wstring_convert&& __wc)
@@ -3218,7 +3222,7 @@ inline wstring_convert<_Codecvt, _Elem, _WideAlloc, _ByteAlloc>::wstring_convert
   __wc.__cvtptr_ = nullptr;
 }
 
-#  endif // _LIBCPP_CXX03_LANG
+#    endif // _LIBCPP_CXX03_LANG
 
 _LIBCPP_SUPPRESS_DEPRECATED_PUSH
 template <class _Codecvt, class _Elem, class _WideAlloc, class _ByteAlloc>
@@ -3372,14 +3376,14 @@ private:
   bool __always_noconv_;
 
 public:
-#  ifndef _LIBCPP_CXX03_LANG
+#    ifndef _LIBCPP_CXX03_LANG
   _LIBCPP_HIDE_FROM_ABI wbuffer_convert() : wbuffer_convert(nullptr) {}
   explicit _LIBCPP_HIDE_FROM_ABI
   wbuffer_convert(streambuf* __bytebuf, _Codecvt* __pcvt = new _Codecvt, state_type __state = state_type());
-#  else
+#    else
   _LIBCPP_EXPLICIT_SINCE_CXX14 _LIBCPP_HIDE_FROM_ABI
   wbuffer_convert(streambuf* __bytebuf = nullptr, _Codecvt* __pcvt = new _Codecvt, state_type __state = state_type());
-#  endif
+#    endif
 
   _LIBCPP_HIDE_FROM_ABI ~wbuffer_convert();
 
@@ -3735,13 +3739,15 @@ wbuffer_convert<_Codecvt, _Elem, _Tr>* wbuffer_convert<_Codecvt, _Elem, _Tr>::__
 
 _LIBCPP_SUPPRESS_DEPRECATED_POP
 
-#endif // _LIBCPP_STD_VER < 26 || defined(_LIBCPP_ENABLE_CXX26_REMOVED_WSTRING_CONVERT)
+#  endif // _LIBCPP_STD_VER < 26 || defined(_LIBCPP_ENABLE_CXX26_REMOVED_WSTRING_CONVERT)
 
 _LIBCPP_END_NAMESPACE_STD
 
 _LIBCPP_POP_MACROS
 
 // NOLINTEND(libcpp-robust-against-adl)
+
+#endif // !defined(_LIBCPP_HAS_NO_LOCALIZATION)
 
 #if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
 #  include <atomic>

--- a/libcxx/include/locale.h
+++ b/libcxx/include/locale.h
@@ -35,10 +35,6 @@ Functions:
 
 #include <__config>
 
-#if defined(_LIBCPP_HAS_NO_LOCALIZATION)
-#  error "<locale.h> is not supported since libc++ has been configured without support for localization."
-#endif
-
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
 #  pragma GCC system_header
 #endif

--- a/libcxx/include/semaphore
+++ b/libcxx/include/semaphore
@@ -47,30 +47,28 @@ using binary_semaphore = counting_semaphore<1>;
 
 #include <__config>
 
-#ifdef _LIBCPP_HAS_NO_THREADS
-#  error "<semaphore> is not supported since libc++ has been configured without support for threads."
-#endif
+#if !defined(_LIBCPP_HAS_NO_THREADS)
 
-#include <__assert>
-#include <__atomic/atomic_base.h>
-#include <__atomic/atomic_sync.h>
-#include <__atomic/memory_order.h>
-#include <__chrono/time_point.h>
-#include <__thread/poll_with_backoff.h>
-#include <__thread/support.h>
-#include <__thread/timed_backoff_policy.h>
-#include <cstddef>
-#include <limits>
-#include <version>
+#  include <__assert>
+#  include <__atomic/atomic_base.h>
+#  include <__atomic/atomic_sync.h>
+#  include <__atomic/memory_order.h>
+#  include <__chrono/time_point.h>
+#  include <__thread/poll_with_backoff.h>
+#  include <__thread/support.h>
+#  include <__thread/timed_backoff_policy.h>
+#  include <cstddef>
+#  include <limits>
+#  include <version>
 
-#if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
-#  pragma GCC system_header
-#endif
+#  if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
+#    pragma GCC system_header
+#  endif
 
 _LIBCPP_PUSH_MACROS
-#include <__undef_macros>
+#  include <__undef_macros>
 
-#if _LIBCPP_STD_VER >= 14
+#  if _LIBCPP_STD_VER >= 14
 
 _LIBCPP_BEGIN_NAMESPACE_STD
 
@@ -82,7 +80,7 @@ functions. It avoids contention against users' own use of those facilities.
 
 */
 
-#  define _LIBCPP_SEMAPHORE_MAX (numeric_limits<ptrdiff_t>::max())
+#    define _LIBCPP_SEMAPHORE_MAX (numeric_limits<ptrdiff_t>::max())
 
 class __atomic_semaphore_base {
   __atomic_base<ptrdiff_t> __a_;
@@ -177,9 +175,11 @@ _LIBCPP_SUPPRESS_DEPRECATED_POP
 
 _LIBCPP_END_NAMESPACE_STD
 
-#endif // _LIBCPP_STD_VER >= 14
+#  endif // _LIBCPP_STD_VER >= 14
 
 _LIBCPP_POP_MACROS
+
+#endif // !defined(_LIBCPP_HAS_NO_THREADS)
 
 #if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
 #  include <atomic>

--- a/libcxx/include/shared_mutex
+++ b/libcxx/include/shared_mutex
@@ -124,31 +124,29 @@ template <class Mutex>
 
 #include <__config>
 
-#ifdef _LIBCPP_HAS_NO_THREADS
-#  error "<shared_mutex> is not supported since libc++ has been configured without support for threads."
-#endif
+#if !defined(_LIBCPP_HAS_NO_THREADS)
 
-#include <__chrono/duration.h>
-#include <__chrono/steady_clock.h>
-#include <__chrono/time_point.h>
-#include <__condition_variable/condition_variable.h>
-#include <__memory/addressof.h>
-#include <__mutex/mutex.h>
-#include <__mutex/tag_types.h>
-#include <__mutex/unique_lock.h>
-#include <__system_error/system_error.h>
-#include <__utility/swap.h>
-#include <cerrno>
-#include <version>
+#  include <__chrono/duration.h>
+#  include <__chrono/steady_clock.h>
+#  include <__chrono/time_point.h>
+#  include <__condition_variable/condition_variable.h>
+#  include <__memory/addressof.h>
+#  include <__mutex/mutex.h>
+#  include <__mutex/tag_types.h>
+#  include <__mutex/unique_lock.h>
+#  include <__system_error/system_error.h>
+#  include <__utility/swap.h>
+#  include <cerrno>
+#  include <version>
 
 _LIBCPP_PUSH_MACROS
-#include <__undef_macros>
+#  include <__undef_macros>
 
-#if _LIBCPP_STD_VER >= 14
+#  if _LIBCPP_STD_VER >= 14
 
-#  if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
-#    pragma GCC system_header
-#  endif
+#    if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
+#      pragma GCC system_header
+#    endif
 
 _LIBCPP_BEGIN_NAMESPACE_STD
 
@@ -181,7 +179,7 @@ struct _LIBCPP_EXPORTED_FROM_ABI __shared_mutex_base {
   //     native_handle_type native_handle(); // See 30.2.3
 };
 
-#  if _LIBCPP_STD_VER >= 17
+#    if _LIBCPP_STD_VER >= 17
 class _LIBCPP_EXPORTED_FROM_ABI _LIBCPP_THREAD_SAFETY_ANNOTATION(__capability__("shared_mutex")) shared_mutex {
   __shared_mutex_base __base_;
 
@@ -218,7 +216,7 @@ public:
   //     typedef __shared_mutex_base::native_handle_type native_handle_type;
   //     _LIBCPP_HIDE_FROM_ABI native_handle_type native_handle() { return __base::unlock_shared(); }
 };
-#  endif
+#    endif
 
 class _LIBCPP_EXPORTED_FROM_ABI
 _LIBCPP_THREAD_SAFETY_ANNOTATION(__capability__("shared_timed_mutex")) shared_timed_mutex {
@@ -453,9 +451,11 @@ inline _LIBCPP_HIDE_FROM_ABI void swap(shared_lock<_Mutex>& __x, shared_lock<_Mu
 
 _LIBCPP_END_NAMESPACE_STD
 
-#endif // _LIBCPP_STD_VER >= 14
+#  endif // _LIBCPP_STD_VER >= 14
 
 _LIBCPP_POP_MACROS
+
+#endif // !defined(_LIBCPP_HAS_NO_THREADS)
 
 #if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
 #  include <system_error>

--- a/libcxx/include/stop_token
+++ b/libcxx/include/stop_token
@@ -33,18 +33,18 @@ namespace std {
 
 #include <__config>
 
-#ifdef _LIBCPP_HAS_NO_THREADS
-#  error "<stop_token> is not supported since libc++ has been configured without support for threads."
-#endif
+#if !defined(_LIBCPP_HAS_NO_THREADS)
 
-#include <__stop_token/stop_callback.h>
-#include <__stop_token/stop_source.h>
-#include <__stop_token/stop_token.h>
-#include <version>
+#  include <__stop_token/stop_callback.h>
+#  include <__stop_token/stop_source.h>
+#  include <__stop_token/stop_token.h>
+#  include <version>
 
-#if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
-#  pragma GCC system_header
-#endif
+#  if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
+#    pragma GCC system_header
+#  endif
+
+#endif // !defined(_LIBCPP_HAS_NO_THREADS)
 
 #if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
 #  include <iosfwd>

--- a/libcxx/include/thread
+++ b/libcxx/include/thread
@@ -88,25 +88,25 @@ void sleep_for(const chrono::duration<Rep, Period>& rel_time);
 
 #include <__config>
 
-#ifdef _LIBCPP_HAS_NO_THREADS
-#  error "<thread> is not supported since libc++ has been configured without support for threads."
-#endif
+#if !defined(_LIBCPP_HAS_NO_THREADS)
 
-#include <__thread/formatter.h>
-#include <__thread/jthread.h>
-#include <__thread/support.h>
-#include <__thread/this_thread.h>
-#include <__thread/thread.h>
-#include <version>
+#  include <__thread/formatter.h>
+#  include <__thread/jthread.h>
+#  include <__thread/support.h>
+#  include <__thread/this_thread.h>
+#  include <__thread/thread.h>
+#  include <version>
 
 // standard-mandated includes
 
 // [thread.syn]
-#include <compare>
+#  include <compare>
 
-#if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
-#  pragma GCC system_header
-#endif
+#  if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
+#    pragma GCC system_header
+#  endif
+
+#endif // !defined(_LIBCPP_HAS_NO_THREADS)
 
 #if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES)
 #  include <cstddef>


### PR DESCRIPTION
Previously, we would issue an #error when using a header that requires threading support or localization support in a configuration where that is disabled. This is unlike what we do for all the other carve outs like no-filesystem, no-wide-characters or no-random-device. Instead of issuing an #error, we normally just remove the problematic parts of the header.

This patch makes the handling of no-localization and no-threads consistent with the other carve-outs. I dislike the fact that users won't get an explicit error message when trying to use e.g. ios in a build that doesn't support localization, but I think it is better to handle things consistently. Note that besides the consistency argument, the #error approach doesn't really work anyways since it would break down if we moved towards assuming the C locale only in the no-localization mode.