### PR TITLE
[llvm][DebugInfo] Add DW_AT_type to DW_TAG_enumeration_type in non-strict DWARF v2 mode

### DIFF
--- a/llvm/docs/ReleaseNotes.rst
+++ b/llvm/docs/ReleaseNotes.rst
@@ -316,11 +316,11 @@ Changes to the Debug Info
   the `migration docs <https://llvm.org/docs/RemoveDIsDebugInfo.html>`_.
 
 * When emitting DWARF v2 and not in strict DWARF mode, LLVM will now add
-  a ``DW_AT_type`` to ``DW_TAG_enumeration_type``s. This is actually a DWARF v3
-  feature which tells tools what the enum's underlying type is. Emitting this
-  for v2 as well will help users who have to build binaries with DWARF v2 but
-  are using tools that understand newer DWARF standards. Older tools will ignore
-  it. (`#98335 <https://github.com/llvm/llvm-project/pull/98335>`_)
+  a ``DW_AT_type`` to instances of ``DW_TAG_enumeration_type``. This is actually
+  a DWARF v3 feature which tells tools what the enum's underlying type is.
+  Emitting this for v2 as well will help users who have to build binaries with
+  DWARF v2 but are using tools that understand newer DWARF standards. Older
+  tools will ignore it. (`#98335 <https://github.com/llvm/llvm-project/pull/98335>`_)
 
 Changes to the LLVM tools
 ---------------------------------

--- a/llvm/docs/ReleaseNotes.rst
+++ b/llvm/docs/ReleaseNotes.rst
@@ -315,6 +315,13 @@ Changes to the Debug Info
   supported on a best-effort basis from here onwards; for more information, see
   the `migration docs <https://llvm.org/docs/RemoveDIsDebugInfo.html>`_.
 
+* When emitting DWARF v2 and not in strict DWARF mode, LLVM will now add
+  a ``DW_AT_type`` to ``DW_TAG_enumeration_type``s. This is actually a DWARF v3
+  feature which tells tools what the enum's underlying type is. Emitting this
+  for v2 as well will help users who have to build binaries with DWARF v2 but
+  are using tools that understand newer DWARF standards. Older tools will ignore
+  it. (`#98335 <https://github.com/llvm/llvm-project/pull/98335>`_)
+
 Changes to the LLVM tools
 ---------------------------------
 * llvm-nm and llvm-objdump can now print symbol information from linked

--- a/llvm/lib/CodeGen/AsmPrinter/DwarfUnit.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/DwarfUnit.cpp
@@ -1585,7 +1585,7 @@ void DwarfUnit::constructEnumTypeDIE(DIE &Buffer, const DICompositeType *CTy) {
   const DIType *DTy = CTy->getBaseType();
   bool IsUnsigned = DTy && DD->isUnsignedDIType(DTy);
   if (DTy) {
-    if (DD->getDwarfVersion() >= 3)
+    if (!Asm->TM.Options.DebugStrictDwarf || DD->getDwarfVersion() >= 3)
       addType(Buffer, DTy);
     if (DD->getDwarfVersion() >= 4 && (CTy->getFlags() & DINode::FlagEnumClass))
       addFlag(Buffer, dwarf::DW_AT_enum_class);

--- a/llvm/test/DebugInfo/X86/dbg-rust-valid-enum-as-scope.ll
+++ b/llvm/test/DebugInfo/X86/dbg-rust-valid-enum-as-scope.ll
@@ -3,6 +3,7 @@
 ; CHECK:   DW_AT_language	(DW_LANG_Rust)
 ; CHECK:   DW_TAG_namespace
 ; CHECK:     DW_TAG_enumeration_type
+; CHECK:     DW_AT_type (0x{{[0-9]+}} "u8")
 ; CHECK:     DW_AT_name	("E")
 ; CHECK:       DW_TAG_enumerator
 ; CHECK:       DW_TAG_enumerator
@@ -12,6 +13,8 @@
 ; CHECK:         NULL
 ; CHECK:       NULL
 ; CHECK:     NULL
+; CHECK:   DW_TAG_base_type
+; CHECK:     DW_AT_name ("u8")
 ; CHECK:   DW_TAG_pointer_type
 ; CHECK:   NULL
 

--- a/llvm/test/DebugInfo/X86/dbg-rust-valid-enum-as-scope.ll
+++ b/llvm/test/DebugInfo/X86/dbg-rust-valid-enum-as-scope.ll
@@ -3,7 +3,7 @@
 ; CHECK:   DW_AT_language	(DW_LANG_Rust)
 ; CHECK:   DW_TAG_namespace
 ; CHECK:     DW_TAG_enumeration_type
-; CHECK:     DW_AT_type (0x{{[0-9]+}} "u8")
+; CHECK:     DW_AT_type (0x{{[0-9A-Fa-f]+}} "u8")
 ; CHECK:     DW_AT_name	("E")
 ; CHECK:       DW_TAG_enumerator
 ; CHECK:       DW_TAG_enumerator


### PR DESCRIPTION
During testing of https://github.com/llvm/llvm-project/pull/96202 we found that when clang set to DWARF v2 was used to build the test file, lldb could not tell that the unsigned enum type was in fact unsigned. So it defaulted to signed and printed the wrong value.

The reason for this is that DWARFv2 does not include DW_AT_type in DW_TAG_enumeration_type. This was added in DWARF v3:
"The enumeration type entry may also have a DW_AT_type attribute which refers to the underlying data type used to implement the enumeration.

In C or C++, the underlying type will be the appropriate integral type determined by the compiler from the properties of the enumeration literal values."

I noticed that gcc does emit this attribute for DWARF v2 but not when strict DWARF is requested (more details in https://gcc.gnu.org/bugzilla/show_bug.cgi?id=16063#c7).

This patch changes to clang to do the same. This will improve the experience of anyone using tools that can understand the attribute but for whatever reason are stuck building binaries containing v2 only.

You can see a current clang/gcc comparison here: https://godbolt.org/z/eG9Kc9WGf

https://reviews.llvm.org/D42734 added the original code that emitted this for >= v3 only.