### PR TITLE
[MLIR][OpenMP] Refactor translation of `omp.loop_nest`

### DIFF
--- a/mlir/lib/Dialect/OpenMP/IR/OpenMPDialect.cpp
+++ b/mlir/lib/Dialect/OpenMP/IR/OpenMPDialect.cpp
@@ -2144,6 +2144,12 @@ void LoopNestOp::gatherWrappers(
     wrappers.push_back(wrapper);
     parent = parent->getParentOp();
   }
+
+  // omp.parallel can be misidentified as a loop wrapper when it's not taking
+  // that role but it contains no other operations in its region (e.g. parallel
+  // do/for).
+  if (llvm::isa<omp::ParallelOp>(wrappers.back()))
+    wrappers.pop_back();
 }
 
 //===----------------------------------------------------------------------===//

--- a/mlir/test/Target/LLVMIR/openmp-llvm.mlir
+++ b/mlir/test/Target/LLVMIR/openmp-llvm.mlir
@@ -699,7 +699,7 @@ llvm.func @simd_simple(%lb : i64, %ub : i64, %step : i64, %arg0: !llvm.ptr) {
 // CHECK-LABEL: @simd_simple_multiple
 llvm.func @simd_simple_multiple(%lb1 : i64, %ub1 : i64, %step1 : i64, %lb2 : i64, %ub2 : i64, %step2 : i64, %arg0: !llvm.ptr, %arg1: !llvm.ptr) {
   omp.simd {
-    omp.loop_nest (%iv1, %iv2) : i64 = (%lb1, %lb2) to (%ub1, %ub2) step (%step1, %step2) {
+    omp.loop_nest (%iv1, %iv2) : i64 = (%lb1, %lb2) to (%ub1, %ub2) inclusive step (%step1, %step2) {
       %3 = llvm.mlir.constant(2.000000e+00 : f32) : f32
       // The form of the emitted IR is controlled by OpenMPIRBuilder and
       // tested there. Just check that the right metadata is added and collapsed


### PR DESCRIPTION
The `omp.loop_nest` operation is always wrapped by a set of one or more OpenMP loop wrapper operations (i.e. implementing the `omp::LoopWrapperInterface`), which impact how it must be lowered.

However, the creation of the list of canonical loop objects and processing of the `collapse` information (plus potentially other loop transformations when supported in the future) have to be performed in the same way regardless of the loop wrappers applied. This patch extracts this common handling out of the translation functions for `omp.wsloop` and `omp.simd` and makes some infrastructure changes in preparation for handling multiple wrappers (i.e. composite constructs).

This work uncovered a couple bugs that are also addressed:
  - `LoopNestOp::gatherWrappers()` would include `omp.parallel` when not taking a loop wrapper role.
  - Translation to LLVM IR of `omp.loop_nest` inside of `omp.simd` always assumed the stop value was included, which wasn't caught due to a broken unit test.

This patch is implemented assuming `omp.parallel` remains a loop wrapper operation, which is currently under discussion in this [RFC](https://discourse.llvm.org/t/rfc-disambiguation-between-loop-and-block-associated-omp-parallelop/79972). Until consensus is reached there, this will remain as a draft PR.