### PR TITLE
Missed disabling the baseline test for DWP stuff

### DIFF
--- a/lldb/test/API/debuginfod/SplitDWARF/TestDebuginfodDWP.py
+++ b/lldb/test/API/debuginfod/SplitDWARF/TestDebuginfodDWP.py
@@ -25,7 +25,7 @@ class DebugInfodDWPTests(TestBase):
     # No need to try every flavor of debug inf.
     NO_DEBUG_INFO_TESTCASE = True
 
-    @skipUnlessPlatform(["linux", "freebsd"])
+    @skipUnlessPlatform(["linux_freebsd_but_old_dwp_tools_on_build_bots_are_broken"])
     def test_normal_stripped(self):
         """
         Validate behavior with a stripped binary, no symbols or symbol locator.


### PR DESCRIPTION
This should disable the failing test on the ubuntu build bots @JDevlieghere (I forgot to disable the 'baseline' test, as it tests the debugger's basic handling of DWP files, but again, the API infrastructure doesn't quite support DWP generation)

https://github.com/llvm/llvm-project/pull/98344#issuecomment-2221000566

