### PR TITLE
[clang-tidy] bugprone-implicit-widening ignores const exprs that fit

### DIFF
--- a/clang-tools-extra/clang-tidy/bugprone/ImplicitWideningOfMultiplicationResultCheck.h
+++ b/clang-tools-extra/clang-tidy/bugprone/ImplicitWideningOfMultiplicationResultCheck.h
@@ -41,6 +41,7 @@ public:
 private:
   const bool UseCXXStaticCastsInCppSources;
   const bool UseCXXHeadersInCppSources;
+  const bool IgnoreConstantIntExpr;
   utils::IncludeInserter IncludeInserter;
 };
 

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -241,6 +241,11 @@ Changes in existing checks
   <clang-tidy/checks/bugprone/forwarding-reference-overload>`
   check to ignore deleted constructors which won't hide other overloads.
 
+- Improved :doc:`bugprone-implicit-widening-of-multiplication-result
+  <clang-tidy/checks/bugprone/implicit-widening-of-multiplication-result>` check
+  by adding an option to ignore constant expressions of signed integer types
+  that fit in the source expression type.
+
 - Improved :doc:`bugprone-inc-dec-in-conditions
   <clang-tidy/checks/bugprone/inc-dec-in-conditions>` check to ignore code
   within unevaluated contexts, such as ``decltype``.

--- a/clang-tools-extra/docs/clang-tidy/checks/bugprone/implicit-widening-of-multiplication-result.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/bugprone/implicit-widening-of-multiplication-result.rst
@@ -50,7 +50,7 @@ Options
    If the multiplication operands are compile-time constants (like literals or
    are ``constexpr``) and fit within the source expression type, do not emit a
    diagnostic or suggested fix.  Only considers expressions where the source
-   expression is a signed integer type.
+   expression is a signed integer type.  Defaults to ``false``.
 
 Examples:
 

--- a/clang-tools-extra/docs/clang-tidy/checks/bugprone/implicit-widening-of-multiplication-result.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/bugprone/implicit-widening-of-multiplication-result.rst
@@ -45,6 +45,12 @@ Options
    should ``<cstddef>`` header be suggested, or ``<stddef.h>``.
    Defaults to ``true``.
 
+.. option:: IgnoreConstantIntExpr
+
+   If the multiplication operands are compile-time constants (like literals or
+   are ``constexpr``) and fit within the source expression type, do not emit a
+   diagnostic or suggested fix.  Only considers expressions where the source
+   expression is a signed integer type.
 
 Examples:
 

--- a/clang-tools-extra/test/clang-tidy/checkers/bugprone/implicit-widening-of-multiplication-result-constants.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/bugprone/implicit-widening-of-multiplication-result-constants.cpp
@@ -1,0 +1,81 @@
+// RUN: %check_clang_tidy -check-suffixes=ALL,NI %s bugprone-implicit-widening-of-multiplication-result %t -- -- -target x86_64-unknown-unknown -x c++
+// RUN: %check_clang_tidy -check-suffixes=ALL %s bugprone-implicit-widening-of-multiplication-result %t -- \
+// RUN:     -config='{CheckOptions: { \
+// RUN:         bugprone-implicit-widening-of-multiplication-result.IgnoreConstantIntExpr: true \
+// RUN:     }}' -- -target x86_64-unknown-unknown -x c++
+
+long t0() {
+  return 1 * 4;
+  // CHECK-NOTES-NI: :[[@LINE-1]]:10: warning: performing an implicit widening conversion to type 'long' of a multiplication performed in type 'int'
+  // CHECK-NOTES-NI: :[[@LINE-2]]:10: note: make conversion explicit to silence this warning
+  // CHECK-NOTES-NI:                  static_cast<long>( )
+  // CHECK-NOTES-NI: :[[@LINE-4]]:10: note: perform multiplication in a wider type
+}
+
+unsigned long t1() {
+  const int a = 2;
+  const int b = 3;
+  return a * b;
+  // CHECK-NOTES-NI: :[[@LINE-1]]:10: warning: performing an implicit widening conversion to type 'unsigned long' of a multiplication performed in type 'int'
+  // CHECK-NOTES-NI: :[[@LINE-2]]:10: note: make conversion explicit to silence this warning
+  // CHECK-NOTES-NI:                  static_cast<unsigned long>( )
+  // CHECK-NOTES-NI: :[[@LINE-4]]:10: note: perform multiplication in a wider type
+}
+
+long t2() {
+  constexpr int a = 16383; // ~1/2 of int16_t max
+  constexpr int b = 2;
+  return a * b;
+  // CHECK-NOTES-NI: :[[@LINE-1]]:10: warning: performing an implicit widening conversion to type 'long' of a multiplication performed in type 'int'
+  // CHECK-NOTES-NI: :[[@LINE-2]]:10: note: make conversion explicit to silence this warning
+  // CHECK-NOTES-NI:                  static_cast<long>( )
+  // CHECK-NOTES-NI: :[[@LINE-4]]:10: note: perform multiplication in a wider type
+}
+
+constexpr int global_value() {
+  return 16;
+}
+
+unsigned long t3() {
+  constexpr int a = 3;
+  return a * global_value();
+  // CHECK-NOTES-NI: :[[@LINE-1]]:10: warning: performing an implicit widening conversion to type 'unsigned long' of a multiplication performed in type 'int'
+  // CHECK-NOTES-NI: :[[@LINE-2]]:10: note: make conversion explicit to silence this warning
+  // CHECK-NOTES-NI:                  static_cast<unsigned long>( )
+  // CHECK-NOTES-NI: :[[@LINE-4]]:10: note: perform multiplication in a wider type
+}
+
+long t4() {
+  const char a = 3;
+  const short b = 2;
+  const int c = 5;
+  return c * b * a;
+  // CHECK-NOTES-NI: :[[@LINE-1]]:10: warning: performing an implicit widening conversion to type 'long' of a multiplication performed in type 'int'
+  // CHECK-NOTES-NI: :[[@LINE-2]]:10: note: make conversion explicit to silence this warning
+  // CHECK-NOTES-NI:                  static_cast<long>( )
+  // CHECK-NOTES-NI: :[[@LINE-4]]:10: note: perform multiplication in a wider type
+}
+
+long t5() {
+  constexpr int min_int = (-2147483647 - 1); // A literal of -2147483648 evaluates to long
+  return 1 * min_int;
+  // CHECK-NOTES-NI: :[[@LINE-1]]:10: warning: performing an implicit widening conversion to type 'long' of a multiplication performed in type 'int'
+  // CHECK-NOTES-NI: :[[@LINE-2]]:10: note: make conversion explicit to silence this warning
+  // CHECK-NOTES-NI:                  static_cast<long>( )
+  // CHECK-NOTES-NI: :[[@LINE-4]]:10: note: perform multiplication in a wider type
+}
+
+unsigned long n0() {
+  const int a = 1073741824; // 1/2 of int32_t max
+  const int b = 3;
+  return a * b;
+  // CHECK-NOTES-ALL: :[[@LINE-1]]:10: warning: performing an implicit widening conversion to type 'unsigned long' of a multiplication performed in type 'int'
+  // CHECK-NOTES-ALL: :[[@LINE-2]]:10: note: make conversion explicit to silence this warning
+  // CHECK-NOTES-ALL:                  static_cast<unsigned long>( )
+  // CHECK-NOTES-ALL: :[[@LINE-4]]:10: note: perform multiplication in a wider type
+}
+
+double n1() {
+  const long a = 100000000;
+  return a * 400;
+}

--- a/clang-tools-extra/test/clang-tidy/checkers/bugprone/implicit-widening-of-multiplication-result-constants.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/bugprone/implicit-widening-of-multiplication-result-constants.cpp
@@ -1,35 +1,22 @@
-// RUN: %check_clang_tidy -check-suffixes=ALL,NI %s bugprone-implicit-widening-of-multiplication-result %t -- -- -target x86_64-unknown-unknown -x c++
-// RUN: %check_clang_tidy -check-suffixes=ALL %s bugprone-implicit-widening-of-multiplication-result %t -- \
+// RUN: %check_clang_tidy %s bugprone-implicit-widening-of-multiplication-result %t -- \
 // RUN:     -config='{CheckOptions: { \
 // RUN:         bugprone-implicit-widening-of-multiplication-result.IgnoreConstantIntExpr: true \
 // RUN:     }}' -- -target x86_64-unknown-unknown -x c++
 
 long t0() {
   return 1 * 4;
-  // CHECK-NOTES-NI: :[[@LINE-1]]:10: warning: performing an implicit widening conversion to type 'long' of a multiplication performed in type 'int'
-  // CHECK-NOTES-NI: :[[@LINE-2]]:10: note: make conversion explicit to silence this warning
-  // CHECK-NOTES-NI:                  static_cast<long>( )
-  // CHECK-NOTES-NI: :[[@LINE-4]]:10: note: perform multiplication in a wider type
 }
 
 unsigned long t1() {
   const int a = 2;
   const int b = 3;
   return a * b;
-  // CHECK-NOTES-NI: :[[@LINE-1]]:10: warning: performing an implicit widening conversion to type 'unsigned long' of a multiplication performed in type 'int'
-  // CHECK-NOTES-NI: :[[@LINE-2]]:10: note: make conversion explicit to silence this warning
-  // CHECK-NOTES-NI:                  static_cast<unsigned long>( )
-  // CHECK-NOTES-NI: :[[@LINE-4]]:10: note: perform multiplication in a wider type
 }
 
 long t2() {
   constexpr int a = 16383; // ~1/2 of int16_t max
   constexpr int b = 2;
   return a * b;
-  // CHECK-NOTES-NI: :[[@LINE-1]]:10: warning: performing an implicit widening conversion to type 'long' of a multiplication performed in type 'int'
-  // CHECK-NOTES-NI: :[[@LINE-2]]:10: note: make conversion explicit to silence this warning
-  // CHECK-NOTES-NI:                  static_cast<long>( )
-  // CHECK-NOTES-NI: :[[@LINE-4]]:10: note: perform multiplication in a wider type
 }
 
 constexpr int global_value() {
@@ -39,10 +26,6 @@ constexpr int global_value() {
 unsigned long t3() {
   constexpr int a = 3;
   return a * global_value();
-  // CHECK-NOTES-NI: :[[@LINE-1]]:10: warning: performing an implicit widening conversion to type 'unsigned long' of a multiplication performed in type 'int'
-  // CHECK-NOTES-NI: :[[@LINE-2]]:10: note: make conversion explicit to silence this warning
-  // CHECK-NOTES-NI:                  static_cast<unsigned long>( )
-  // CHECK-NOTES-NI: :[[@LINE-4]]:10: note: perform multiplication in a wider type
 }
 
 long t4() {
@@ -50,29 +33,21 @@ long t4() {
   const short b = 2;
   const int c = 5;
   return c * b * a;
-  // CHECK-NOTES-NI: :[[@LINE-1]]:10: warning: performing an implicit widening conversion to type 'long' of a multiplication performed in type 'int'
-  // CHECK-NOTES-NI: :[[@LINE-2]]:10: note: make conversion explicit to silence this warning
-  // CHECK-NOTES-NI:                  static_cast<long>( )
-  // CHECK-NOTES-NI: :[[@LINE-4]]:10: note: perform multiplication in a wider type
 }
 
 long t5() {
   constexpr int min_int = (-2147483647 - 1); // A literal of -2147483648 evaluates to long
   return 1 * min_int;
-  // CHECK-NOTES-NI: :[[@LINE-1]]:10: warning: performing an implicit widening conversion to type 'long' of a multiplication performed in type 'int'
-  // CHECK-NOTES-NI: :[[@LINE-2]]:10: note: make conversion explicit to silence this warning
-  // CHECK-NOTES-NI:                  static_cast<long>( )
-  // CHECK-NOTES-NI: :[[@LINE-4]]:10: note: perform multiplication in a wider type
 }
 
 unsigned long n0() {
   const int a = 1073741824; // 1/2 of int32_t max
   const int b = 3;
   return a * b;
-  // CHECK-NOTES-ALL: :[[@LINE-1]]:10: warning: performing an implicit widening conversion to type 'unsigned long' of a multiplication performed in type 'int'
-  // CHECK-NOTES-ALL: :[[@LINE-2]]:10: note: make conversion explicit to silence this warning
-  // CHECK-NOTES-ALL:                  static_cast<unsigned long>( )
-  // CHECK-NOTES-ALL: :[[@LINE-4]]:10: note: perform multiplication in a wider type
+  // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: performing an implicit widening conversion to type 'unsigned long' of a multiplication performed in type 'int'
+  // CHECK-MESSAGES: :[[@LINE-2]]:10: note: make conversion explicit to silence this warning
+  // CHECK-MESSAGES:                  static_cast<unsigned long>( )
+  // CHECK-MESSAGES: :[[@LINE-4]]:10: note: perform multiplication in a wider type
 }
 
 double n1() {


### PR DESCRIPTION
Add an option to the `bugprone-implicit-widening-of-multiplication-result` clang-tidy checker to suppress warnings when the expression is made up of all compile-time constants (literals, `constexpr` values or results, etc.) and the result of the multiplication is guaranteed to fit in both the source and destination types.

This currently only works for signed integer types:

* For unsigned integers, the well-defined rollover behavior on overflow prevents the checker from detecting that the expression does not actually fit in the source expr type, and would produce false negatives.  I have a somewhat-hacky stab at addressing this I'd like to submit as a follow-on PR
* For floating-point types, there's probably a little additional work to be done to `Expr` to calculate the result at compile time

Even still, this seems like a helpful addition just for signed types, and additional types can be added.