### PR TITLE
[libc++] Add empty release notes file for LLVM 20

### DIFF
--- a/libcxx/docs/ReleaseNotes.rst
+++ b/libcxx/docs/ReleaseNotes.rst
@@ -1,10 +1,11 @@
 .. include:: ReleaseNotes/19.rst
 
-.. Make sure to reference the previous release notes in a toctree to avoid Sphinx errors.
+.. Make sure to reference the non-live release notes in a toctree to avoid Sphinx errors.
 .. toctree::
     :hidden:
 
     ReleaseNotes/18
+    ReleaseNotes/20
 
 .. The release notes are in versioned files, but we make sure to keep publishing
 .. them in an unversioned ReleaseNotes.html page for external sites to reference.

--- a/libcxx/docs/ReleaseNotes/20.rst
+++ b/libcxx/docs/ReleaseNotes/20.rst
@@ -1,0 +1,75 @@
+===========================================
+Libc++ 20.0.0 (In-Progress) Release Notes
+===========================================
+
+.. contents::
+   :local:
+   :depth: 2
+
+Written by the `Libc++ Team <https://libcxx.llvm.org>`_
+
+.. warning::
+
+   These are in-progress notes for the upcoming libc++ 20.0.0 release.
+   Release notes for previous releases can be found on
+   `the Download Page <https://releases.llvm.org/download.html>`_.
+
+Introduction
+============
+
+This document contains the release notes for the libc++ C++ Standard Library,
+part of the LLVM Compiler Infrastructure, release 20.0.0. Here we describe the
+status of libc++ in some detail, including major improvements from the previous
+release and new feature work. For the general LLVM release notes, see `the LLVM
+documentation <https://llvm.org/docs/ReleaseNotes.html>`_. All LLVM releases may
+be downloaded from the `LLVM releases web site <https://llvm.org/releases/>`_.
+
+For more information about libc++, please see the `Libc++ Web Site
+<https://libcxx.llvm.org>`_ or the `LLVM Web Site <https://llvm.org>`_.
+
+Note that if you are reading this file from a Git checkout or the
+main Libc++ web page, this document applies to the *next* release, not
+the current one. To see the release notes for a specific release, please
+see the `releases page <https://llvm.org/releases/>`_.
+
+What's New in Libc++ 20.0.0?
+==============================
+
+Implemented Papers
+------------------
+
+- TODO
+
+
+Improvements and New Features
+-----------------------------
+
+- TODO
+
+
+Deprecations and Removals
+-------------------------
+
+- TODO: The ``LIBCXX_ENABLE_ASSERTIONS`` CMake variable and the ``_LIBCPP_ENABLE_ASSERTIONS`` macro that were used to enable
+  the safe mode will be removed in LLVM 20.
+
+
+Upcoming Deprecations and Removals
+----------------------------------
+
+LLVM 21
+~~~~~~~
+
+- TODO
+
+
+ABI Affecting Changes
+---------------------
+
+- TODO
+
+
+Build System Changes
+--------------------
+
+- TODO


### PR DESCRIPTION
While we haven't branched yet, this will make it easier for folks to add release notes for PRs that won't be merged before the LLVM 19 branch point.