### PR TITLE
[llvm-lit] Resolve TypeError in built-in cat -v implementation

### DIFF
--- a/llvm/utils/lit/lit/builtin_commands/cat.py
+++ b/llvm/utils/lit/lit/builtin_commands/cat.py
@@ -10,7 +10,7 @@ except ImportError:
 def convertToCaretAndMNotation(data):
     newdata = StringIO()
     if isinstance(data, str):
-        data = bytearray(data)
+        data = bytearray(data.encode())
 
     for intval in data:
         if intval == 9 or intval == 10:


### PR DESCRIPTION
When using -v in lit's internal implementation of cat, there is a TypeError when the file data is passed into convertToCaretAndMNotation() as a str, because bytearray() requires an encoded string. This patch encodes the str before passing it through bytearray().

Fixed #102374 