### PR TITLE
[LLVM][test][nfc] Updating test to work with internal shell

### DIFF
--- a/llvm/test/ExecutionEngine/JITLink/x86-64/ELF_perf.s
+++ b/llvm/test/ExecutionEngine/JITLink/x86-64/ELF_perf.s
@@ -6,7 +6,7 @@
 # RUN: rm -rf %t && mkdir -p %t
 # RUN: llvm-mc -triple=x86_64-unknown-linux -position-independent \
 # RUN:     -filetype=obj -o %t/ELF_x86-64_perf.o %s
-# RUN: JITDUMPDIR="%t" llvm-jitlink -perf-support \
+# RUN: env JITDUMPDIR="%t" llvm-jitlink -perf-support \
 # RUN:     %t/ELF_x86-64_perf.o
 # RUN: test -f %t/.debug/jit/llvm-IR-jit-*/jit-*.dump
 


### PR DESCRIPTION
The RUN line attempts to set the JITDUMPDIR environment variable, which fails in llvm-lit's internal shell. This patch prefixes JITDUMPDIR with env so that the behavior of setting the variable is as expected in the internal shell.

Fixes https://github.com/llvm/llvm-project/issues/102395