### PR TITLE
[WebAssembly] Disable running `wasm-opt` on components

### DIFF
--- a/clang/lib/Driver/ToolChains/WebAssembly.cpp
+++ b/clang/lib/Driver/ToolChains/WebAssembly.cpp
@@ -166,7 +166,8 @@ void wasm::Linker::ConstructJob(Compilation &C, const JobAction &JA,
   // components at this time. Retain the historical default otherwise, though,
   // of running `wasm-opt` by default.
   bool WasmOptDefault = !IsWasip2(ToolChain.getTriple());
-  bool RunWasmOpt = Args.hasFlag(options::OPT_wasm_opt, options::OPT_no_wasm_opt, WasmOptDefault);
+  bool RunWasmOpt = Args.hasFlag(options::OPT_wasm_opt,
+                                 options::OPT_no_wasm_opt, WasmOptDefault);
 
   // If wasm-opt is enabled and optimizations are happening look for the
   // `wasm-opt` program. If it's not found auto-disable it.

--- a/clang/lib/Driver/ToolChains/WebAssembly.cpp
+++ b/clang/lib/Driver/ToolChains/WebAssembly.cpp
@@ -64,9 +64,8 @@ std::string wasm::Linker::getLinkerPath(const ArgList &Args) const {
 static bool TargetBuildsComponents(const llvm::Triple &TargetTriple) {
   // WASIp2 and above are all based on components, so test for WASI but exclude
   // the original `wasi` target in addition to the `wasip1` name.
-  return TargetTriple.isOSWASI()
-         && TargetTriple.getOSName() != "wasip1"
-         && TargetTriple.getOSName() != "wasi";
+  return TargetTriple.isOSWASI() && TargetTriple.getOSName() != "wasip1" &&
+         TargetTriple.getOSName() != "wasi";
 }
 
 void wasm::Linker::ConstructJob(Compilation &C, const JobAction &JA,


### PR DESCRIPTION
This commit adds a check that disables `wasm-opt` for the `wasm32-wasip2` target because `wasm-opt` doesn't support components at this time. This also fixes a minor issue from #95208 where if `wasm-opt` was disabled then the linker wouldn't run at all.