### PR TITLE
[RISCV] Store a std::unique_ptr<RISCVRegisterBankInfo> in RISCVSubtarget. NFC

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVSubtarget.cpp
+++ b/llvm/lib/Target/RISCV/RISCVSubtarget.cpp
@@ -13,7 +13,6 @@
 #include "RISCVSubtarget.h"
 #include "GISel/RISCVCallLowering.h"
 #include "GISel/RISCVLegalizerInfo.h"
-#include "GISel/RISCVRegisterBankInfo.h"
 #include "RISCV.h"
 #include "RISCVFrameLowering.h"
 #include "RISCVTargetMachine.h"
@@ -109,7 +108,7 @@ InstructionSelector *RISCVSubtarget::getInstructionSelector() const {
   if (!InstSelector) {
     InstSelector.reset(createRISCVInstructionSelector(
         *static_cast<const RISCVTargetMachine *>(&TLInfo.getTargetMachine()),
-        *this, *static_cast<const RISCVRegisterBankInfo *>(getRegBankInfo())));
+        *this, *getRegBankInfo()));
   }
   return InstSelector.get();
 }
@@ -120,7 +119,7 @@ const LegalizerInfo *RISCVSubtarget::getLegalizerInfo() const {
   return Legalizer.get();
 }
 
-const RegisterBankInfo *RISCVSubtarget::getRegBankInfo() const {
+const RISCVRegisterBankInfo *RISCVSubtarget::getRegBankInfo() const {
   if (!RegBankInfo)
     RegBankInfo.reset(new RISCVRegisterBankInfo(getHwMode()));
   return RegBankInfo.get();

--- a/llvm/lib/Target/RISCV/RISCVSubtarget.h
+++ b/llvm/lib/Target/RISCV/RISCVSubtarget.h
@@ -13,6 +13,7 @@
 #ifndef LLVM_LIB_TARGET_RISCV_RISCVSUBTARGET_H
 #define LLVM_LIB_TARGET_RISCV_RISCVSUBTARGET_H
 
+#include "GISel/RISCVRegisterBankInfo.h"
 #include "MCTargetDesc/RISCVBaseInfo.h"
 #include "RISCVFrameLowering.h"
 #include "RISCVISelLowering.h"
@@ -20,7 +21,6 @@
 #include "llvm/CodeGen/GlobalISel/CallLowering.h"
 #include "llvm/CodeGen/GlobalISel/InstructionSelector.h"
 #include "llvm/CodeGen/GlobalISel/LegalizerInfo.h"
-#include "llvm/CodeGen/RegisterBankInfo.h"
 #include "llvm/CodeGen/SelectionDAGTargetInfo.h"
 #include "llvm/CodeGen/TargetSubtargetInfo.h"
 #include "llvm/IR/DataLayout.h"
@@ -248,7 +248,7 @@ protected:
   mutable std::unique_ptr<CallLowering> CallLoweringInfo;
   mutable std::unique_ptr<InstructionSelector> InstSelector;
   mutable std::unique_ptr<LegalizerInfo> Legalizer;
-  mutable std::unique_ptr<RegisterBankInfo> RegBankInfo;
+  mutable std::unique_ptr<RISCVRegisterBankInfo> RegBankInfo;
 
   // Return the known range for the bit length of RVV data registers as set
   // at the command line. A value of 0 means nothing is known about that particular
@@ -261,7 +261,7 @@ public:
   const CallLowering *getCallLowering() const override;
   InstructionSelector *getInstructionSelector() const override;
   const LegalizerInfo *getLegalizerInfo() const override;
-  const RegisterBankInfo *getRegBankInfo() const override;
+  const RISCVRegisterBankInfo *getRegBankInfo() const override;
 
   bool isTargetAndroid() const { return getTargetTriple().isAndroid(); }
   bool isTargetFuchsia() const { return getTargetTriple().isOSFuchsia(); }


### PR DESCRIPTION
Instead of std::unique_ptr<RegisterBankInfo>. This allows us to return a RISCVRegisterBankInfo* from getRegBankInfo so we can avoid a static_cast.

This does require an additional header file to be included in RISCVSubtarget.h, but I don't think it's a big deal.