### PR TITLE
Reland: [libc] Move off_t and stdio macros to proxy hdrs

### DIFF
--- a/libc/config/gpu/api.td
+++ b/libc/config/gpu/api.td
@@ -59,11 +59,6 @@ def FenvAPI: PublicAPI<"fenv.h"> {
 }
 
 def StdIOAPI : PublicAPI<"stdio.h"> {
-  let Macros = [
-    SimpleMacroDef<"_IOFBF", "0">,
-    SimpleMacroDef<"_IOLBF", "1">,
-    SimpleMacroDef<"_IONBF", "2">,
-  ];
   let Types = [
     "FILE",
     "off_t",

--- a/libc/config/linux/api.td
+++ b/libc/config/linux/api.td
@@ -76,9 +76,6 @@ def StdIOAPI : PublicAPI<"stdio.h"> {
     SimpleMacroDef<"stderr", "stderr">,
     SimpleMacroDef<"stdin", "stdin">,
     SimpleMacroDef<"stdout", "stdout">,
-    SimpleMacroDef<"_IOFBF", "0">,
-    SimpleMacroDef<"_IOLBF", "1">,
-    SimpleMacroDef<"_IONBF", "2">,
   ];
   let Types = [
     "FILE",

--- a/libc/hdr/CMakeLists.txt
+++ b/libc/hdr/CMakeLists.txt
@@ -70,6 +70,16 @@ add_proxy_header_library(
 )
 
 add_proxy_header_library(
+  stdio_macros
+  HDRS
+    stdio_macros.h
+  FULL_BUILD_DEPENDS
+    libc.include.stdio
+    libc.include.llvm-libc-macros.stdio_macros
+    libc.include.llvm-libc-macros.file_seek_macros
+)
+
+add_proxy_header_library(
   sys_epoll_macros
   HDRS
     sys_epoll_macros.h

--- a/libc/hdr/stdio_macros.h
+++ b/libc/hdr/stdio_macros.h
@@ -1,0 +1,23 @@
+//===-- Definition of macros from stdio.h --------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_HDR_STDIO_MACROS_H
+#define LLVM_LIBC_HDR_STDIO_MACROS_H
+
+#ifdef LIBC_FULL_BUILD
+
+#include "include/llvm-libc-macros/file-seek-macros.h"
+#include "include/llvm-libc-macros/stdio-macros.h"
+
+#else // Overlay mode
+
+#include <stdio.h>
+
+#endif // LLVM_LIBC_FULL_BUILD
+
+#endif // LLVM_LIBC_HDR_STDIO_MACROS_H

--- a/libc/hdr/types/CMakeLists.txt
+++ b/libc/hdr/types/CMakeLists.txt
@@ -135,3 +135,12 @@ add_proxy_header_library(
     libc.include.llvm-libc-types.struct_sigaction
     libc.include.signal
 )
+
+add_proxy_header_library(
+  off_t
+  HDRS
+    off_t.h
+  FULL_BUILD_DEPENDS
+    libc.include.llvm-libc-types.off_t
+    libc.include.stdio
+)

--- a/libc/hdr/types/CMakeLists.txt
+++ b/libc/hdr/types/CMakeLists.txt
@@ -137,10 +137,28 @@ add_proxy_header_library(
 )
 
 add_proxy_header_library(
+  FILE
+  HDRS
+    FILE.h
+  FULL_BUILD_DEPENDS
+    libc.include.llvm-libc-types.FILE
+    libc.include.stdio
+)
+
+add_proxy_header_library(
   off_t
   HDRS
     off_t.h
   FULL_BUILD_DEPENDS
     libc.include.llvm-libc-types.off_t
+    libc.include.stdio
+)
+
+add_proxy_header_library(
+  cookie_io_functions_t
+  HDRS
+    cookie_io_functions_t.h
+  FULL_BUILD_DEPENDS
+    libc.include.llvm-libc-types.cookie_io_functions_t
     libc.include.stdio
 )

--- a/libc/hdr/types/FILE.h
+++ b/libc/hdr/types/FILE.h
@@ -1,0 +1,22 @@
+//===-- Proxy for FILE ----------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_HDR_TYPES_FILE_H
+#define LLVM_LIBC_HDR_TYPES_FILE_H
+
+#ifdef LIBC_FULL_BUILD
+
+#include "include/llvm-libc-types/FILE.h"
+
+#else // Overlay mode
+
+#include <stdio.h>
+
+#endif // LLVM_LIBC_FULL_BUILD
+
+#endif // LLVM_LIBC_HDR_TYPES_FILE_H

--- a/libc/hdr/types/cookie_io_functions_t.h
+++ b/libc/hdr/types/cookie_io_functions_t.h
@@ -1,0 +1,22 @@
+//===-- Proxy for cookie_io_functions_t -----------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_HDR_TYPES_COOKIE_IO_FUNCTIONS_T_H
+#define LLVM_LIBC_HDR_TYPES_COOKIE_IO_FUNCTIONS_T_H
+
+#ifdef LIBC_FULL_BUILD
+
+#include "include/llvm-libc-types/cookie_io_functions_t.h"
+
+#else // Overlay mode
+
+#include <stdio.h>
+
+#endif // LLVM_LIBC_FULL_BUILD
+
+#endif // LLVM_LIBC_HDR_TYPES_COOKIE_IO_FUNCTIONS_T_H

--- a/libc/hdr/types/off_t.h
+++ b/libc/hdr/types/off_t.h
@@ -1,0 +1,22 @@
+//===-- Proxy for off_t ---------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_HDR_TYPES_OFF_T_H
+#define LLVM_LIBC_HDR_TYPES_OFF_T_H
+
+#ifdef LIBC_FULL_BUILD
+
+#include "include/llvm-libc-types/off_t.h"
+
+#else // Overlay mode
+
+#include <stdio.h>
+
+#endif // LLVM_LIBC_FULL_BUILD
+
+#endif // LLVM_LIBC_HDR_TYPES_OFF_T_H

--- a/libc/include/llvm-libc-macros/stdio-macros.h
+++ b/libc/include/llvm-libc-macros/stdio-macros.h
@@ -15,4 +15,8 @@
 
 #define BUFSIZ 1024
 
+#define _IONBF 2
+#define _IOLBF 1
+#define _IOFBF 0
+
 #endif // LLVM_LIBC_MACROS_STDIO_MACROS_H

--- a/libc/newhdrgen/yaml/stdio.yaml
+++ b/libc/newhdrgen/yaml/stdio.yaml
@@ -1,11 +1,5 @@
 header: stdio.h
 macros:
-  - macro_name: _IONBF
-    macro_value: 2
-  - macro_name: _IOLBF
-    macro_value: 1
-  - macro_name: _IOFBF
-    macro_value: 0
   - macro_name: stdout
     macro_value: stdout
   - macro_name: stdin

--- a/libc/src/__support/File/CMakeLists.txt
+++ b/libc/src/__support/File/CMakeLists.txt
@@ -16,6 +16,8 @@ add_object_library(
     libc.src.__support.CPP.span
     libc.src.__support.threads.mutex
     libc.src.__support.error_or
+    libc.hdr.types.off_t
+    libc.hdr.stdio_macros
 )
 
 add_object_library(

--- a/libc/src/__support/File/file.cpp
+++ b/libc/src/__support/File/file.cpp
@@ -8,12 +8,11 @@
 
 #include "file.h"
 
+#include "hdr/stdio_macros.h"
+#include "hdr/types/off_t.h"
 #include "src/__support/CPP/new.h"
 #include "src/__support/CPP/span.h"
 #include "src/errno/libc_errno.h" // For error macros
-
-#include <stdio.h>
-#include <stdlib.h>
 
 namespace LIBC_NAMESPACE {
 

--- a/libc/src/__support/File/file.h
+++ b/libc/src/__support/File/file.h
@@ -9,7 +9,8 @@
 #ifndef LLVM_LIBC_SRC___SUPPORT_FILE_FILE_H
 #define LLVM_LIBC_SRC___SUPPORT_FILE_FILE_H
 
-#include "include/llvm-libc-types/off_t.h"
+#include "hdr/stdio_macros.h"
+#include "hdr/types/off_t.h"
 #include "src/__support/CPP/new.h"
 #include "src/__support/error_or.h"
 #include "src/__support/macros/properties/architectures.h"

--- a/libc/src/__support/File/linux/CMakeLists.txt
+++ b/libc/src/__support/File/linux/CMakeLists.txt
@@ -5,6 +5,7 @@ add_object_library(
     file.cpp
   HDRS
     file.h
+    lseekImpl.h
   DEPENDS
     libc.include.fcntl
     libc.include.stdio
@@ -15,6 +16,8 @@ add_object_library(
     libc.src.errno.errno
     libc.src.__support.error_or
     libc.src.__support.File.file
+    libc.hdr.types.off_t
+    libc.hdr.stdio_macros
 )
 
 add_object_library(

--- a/libc/src/__support/File/linux/CMakeLists.txt
+++ b/libc/src/__support/File/linux/CMakeLists.txt
@@ -17,6 +17,7 @@ add_object_library(
     libc.src.__support.error_or
     libc.src.__support.File.file
     libc.hdr.types.off_t
+    libc.hdr.types.FILE
     libc.hdr.stdio_macros
 )
 
@@ -26,6 +27,8 @@ add_object_library(
     stdout.cpp
   DEPENDS
     .file
+    libc.hdr.types.FILE
+    libc.hdr.stdio_macros
 )
 
 add_object_library(
@@ -34,6 +37,8 @@ add_object_library(
     stdin.cpp
   DEPENDS
     .file
+    libc.hdr.types.FILE
+    libc.hdr.stdio_macros
 )
 
 add_object_library(
@@ -42,6 +47,8 @@ add_object_library(
     stderr.cpp
   DEPENDS
     .file
+    libc.hdr.types.FILE
+    libc.hdr.stdio_macros
 )
 
 add_object_library(

--- a/libc/src/__support/File/linux/file.cpp
+++ b/libc/src/__support/File/linux/file.cpp
@@ -8,6 +8,8 @@
 
 #include "file.h"
 
+#include "hdr/stdio_macros.h"
+#include "hdr/types/off_t.h"
 #include "src/__support/CPP/new.h"
 #include "src/__support/File/file.h"
 #include "src/__support/File/linux/lseekImpl.h"
@@ -15,8 +17,7 @@
 #include "src/__support/OSUtil/syscall.h" // For internal syscall function.
 #include "src/errno/libc_errno.h"         // For error macros
 
-#include <fcntl.h> // For mode_t and other flags to the open syscall
-#include <stdio.h>
+#include <fcntl.h>       // For mode_t and other flags to the open syscall
 #include <sys/stat.h>    // For S_IS*, S_IF*, and S_IR* flags.
 #include <sys/syscall.h> // For syscall numbers
 

--- a/libc/src/__support/File/linux/file.h
+++ b/libc/src/__support/File/linux/file.h
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "hdr/types/off_t.h"
 #include "src/__support/File/file.h"
 
 namespace LIBC_NAMESPACE {

--- a/libc/src/__support/File/linux/lseekImpl.h
+++ b/libc/src/__support/File/linux/lseekImpl.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_LIBC_SRC___SUPPORT_FILE_LINUX_LSEEKIMPL_H
 #define LLVM_LIBC_SRC___SUPPORT_FILE_LINUX_LSEEKIMPL_H
 
+#include "hdr/types/off_t.h"
 #include "src/__support/OSUtil/syscall.h" // For internal syscall function.
 #include "src/__support/common.h"
 #include "src/__support/error_or.h"
@@ -16,7 +17,6 @@
 
 #include <stdint.h>      // For uint64_t.
 #include <sys/syscall.h> // For syscall numbers.
-#include <unistd.h>      // For off_t.
 
 namespace LIBC_NAMESPACE {
 namespace internal {

--- a/libc/src/__support/File/linux/stderr.cpp
+++ b/libc/src/__support/File/linux/stderr.cpp
@@ -7,7 +7,8 @@
 //===----------------------------------------------------------------------===//
 
 #include "file.h"
-#include <stdio.h>
+#include "hdr/stdio_macros.h"
+#include "hdr/types/FILE.h"
 
 namespace LIBC_NAMESPACE {
 

--- a/libc/src/__support/File/linux/stdin.cpp
+++ b/libc/src/__support/File/linux/stdin.cpp
@@ -7,7 +7,8 @@
 //===----------------------------------------------------------------------===//
 
 #include "file.h"
-#include <stdio.h>
+#include "hdr/stdio_macros.h"
+#include "hdr/types/FILE.h"
 
 namespace LIBC_NAMESPACE {
 

--- a/libc/src/__support/File/linux/stdout.cpp
+++ b/libc/src/__support/File/linux/stdout.cpp
@@ -7,7 +7,8 @@
 //===----------------------------------------------------------------------===//
 
 #include "file.h"
-#include <stdio.h>
+#include "hdr/stdio_macros.h"
+#include "hdr/types/FILE.h"
 
 namespace LIBC_NAMESPACE {
 

--- a/libc/src/__support/OSUtil/linux/CMakeLists.txt
+++ b/libc/src/__support/OSUtil/linux/CMakeLists.txt
@@ -21,4 +21,5 @@ add_object_library(
     libc.hdr.types.struct_flock
     libc.hdr.types.struct_flock64
     libc.hdr.types.struct_f_owner_ex
+    libc.hdr.types.off_t
 )

--- a/libc/src/__support/OSUtil/linux/fcntl.cpp
+++ b/libc/src/__support/OSUtil/linux/fcntl.cpp
@@ -9,6 +9,7 @@
 #include "src/__support/OSUtil/fcntl.h"
 
 #include "hdr/fcntl_macros.h"
+#include "hdr/types/off_t.h"
 #include "hdr/types/struct_f_owner_ex.h"
 #include "hdr/types/struct_flock.h"
 #include "hdr/types/struct_flock64.h"

--- a/libc/src/gpu/rpc_fprintf.h
+++ b/libc/src/gpu/rpc_fprintf.h
@@ -9,8 +9,8 @@
 #ifndef LLVM_LIBC_SRC_GPU_RPC_HOST_CALL_H
 #define LLVM_LIBC_SRC_GPU_RPC_HOST_CALL_H
 
+#include "hdr/types/FILE.h"
 #include <stddef.h>
-#include <stdio.h>
 
 namespace LIBC_NAMESPACE {
 

--- a/libc/src/stdio/CMakeLists.txt
+++ b/libc/src/stdio/CMakeLists.txt
@@ -61,7 +61,8 @@ add_entrypoint_object(
   HDRS
     fopencookie.h
   DEPENDS
-    libc.include.stdio
+    libc.hdr.stdio_macros
+    libc.hdr.types.off_t
     libc.src.__support.CPP.new
     libc.src.__support.File.file
 )
@@ -74,7 +75,7 @@ add_entrypoint_object(
     setbuf.h
   DEPENDS
     libc.src.errno.errno
-    libc.include.stdio
+    libc.hdr.types.off_t
     libc.src.__support.File.file
     libc.src.__support.File.platform_file
 )

--- a/libc/src/stdio/CMakeLists.txt
+++ b/libc/src/stdio/CMakeLists.txt
@@ -37,7 +37,7 @@ add_entrypoint_object(
   HDRS
     flockfile.h
   DEPENDS
-    libc.include.stdio
+    libc.hdr.types.FILE
     libc.src.__support.File.file
     libc.src.__support.File.platform_file
 )
@@ -49,7 +49,7 @@ add_entrypoint_object(
   HDRS
     funlockfile.h
   DEPENDS
-    libc.include.stdio
+    libc.hdr.types.FILE
     libc.src.__support.File.file
     libc.src.__support.File.platform_file
 )
@@ -63,6 +63,8 @@ add_entrypoint_object(
   DEPENDS
     libc.hdr.stdio_macros
     libc.hdr.types.off_t
+    libc.hdr.types.cookie_io_functions_t
+    libc.hdr.types.FILE
     libc.src.__support.CPP.new
     libc.src.__support.File.file
 )
@@ -88,7 +90,7 @@ add_entrypoint_object(
     setvbuf.h
   DEPENDS
     libc.src.errno.errno
-    libc.include.stdio
+    libc.hdr.types.FILE
     libc.src.__support.File.file
     libc.src.__support.File.platform_file
 )
@@ -96,6 +98,7 @@ add_entrypoint_object(
 list(APPEND scanf_deps
       libc.src.__support.arg_list
       libc.src.stdio.scanf_core.vfscanf_internal
+      libc.hdr.types.FILE
 )
 
 if(LLVM_LIBC_FULL_BUILD)
@@ -167,6 +170,7 @@ add_entrypoint_object(
   HDRS
     fprintf.h
   DEPENDS
+    libc.hdr.types.FILE
     libc.src.__support.arg_list
     libc.src.stdio.printf_core.vfprintf_internal
 )
@@ -200,6 +204,7 @@ add_entrypoint_object(
   HDRS
     vfprintf.h
   DEPENDS
+    libc.hdr.types.FILE
     libc.src.__support.arg_list
     libc.src.stdio.printf_core.vfprintf_internal
 )

--- a/libc/src/stdio/baremetal/getchar.cpp
+++ b/libc/src/stdio/baremetal/getchar.cpp
@@ -9,7 +9,7 @@
 #include "src/stdio/getchar.h"
 #include "src/__support/OSUtil/io.h"
 
-#include <stdio.h>
+#include "hdr/types/FILE.h"
 
 namespace LIBC_NAMESPACE {
 

--- a/libc/src/stdio/baremetal/printf.cpp
+++ b/libc/src/stdio/baremetal/printf.cpp
@@ -14,6 +14,7 @@
 #include "src/stdio/printf_core/writer.h"
 
 #include <stdarg.h>
+#include <stddef.h>
 
 namespace LIBC_NAMESPACE {
 

--- a/libc/src/stdio/baremetal/vprintf.cpp
+++ b/libc/src/stdio/baremetal/vprintf.cpp
@@ -14,6 +14,7 @@
 #include "src/stdio/printf_core/writer.h"
 
 #include <stdarg.h>
+#include <stddef.h>
 
 namespace LIBC_NAMESPACE {
 

--- a/libc/src/stdio/clearerr.h
+++ b/libc/src/stdio/clearerr.h
@@ -9,7 +9,7 @@
 #ifndef LLVM_LIBC_SRC_STDIO_CLEARERR_H
 #define LLVM_LIBC_SRC_STDIO_CLEARERR_H
 
-#include <stdio.h>
+#include "hdr/types/FILE.h"
 
 namespace LIBC_NAMESPACE {
 

--- a/libc/src/stdio/clearerr_unlocked.h
+++ b/libc/src/stdio/clearerr_unlocked.h
@@ -9,7 +9,7 @@
 #ifndef LLVM_LIBC_SRC_STDIO_CLEARERR_UNLOCKED_H
 #define LLVM_LIBC_SRC_STDIO_CLEARERR_UNLOCKED_H
 
-#include <stdio.h>
+#include "hdr/types/FILE.h"
 
 namespace LIBC_NAMESPACE {
 

--- a/libc/src/stdio/fclose.h
+++ b/libc/src/stdio/fclose.h
@@ -9,7 +9,7 @@
 #ifndef LLVM_LIBC_SRC_STDIO_FCLOSE_H
 #define LLVM_LIBC_SRC_STDIO_FCLOSE_H
 
-#include <stdio.h>
+#include "hdr/types/FILE.h"
 
 namespace LIBC_NAMESPACE {
 

--- a/libc/src/stdio/fdopen.h
+++ b/libc/src/stdio/fdopen.h
@@ -9,11 +9,11 @@
 #ifndef LLVM_LIBC_SRC_STDIO_FDOPEN_H
 #define LLVM_LIBC_SRC_STDIO_FDOPEN_H
 
-#include <stdio.h>
+#include "hdr/types/FILE.h"
 
 namespace LIBC_NAMESPACE {
 
-FILE *fdopen(int fd, const char *mode);
+::FILE *fdopen(int fd, const char *mode);
 
 } // namespace LIBC_NAMESPACE
 

--- a/libc/src/stdio/feof.h
+++ b/libc/src/stdio/feof.h
@@ -9,7 +9,7 @@
 #ifndef LLVM_LIBC_SRC_STDIO_FEOF_H
 #define LLVM_LIBC_SRC_STDIO_FEOF_H
 
-#include <stdio.h>
+#include "hdr/types/FILE.h"
 
 namespace LIBC_NAMESPACE {
 

--- a/libc/src/stdio/feof_unlocked.h
+++ b/libc/src/stdio/feof_unlocked.h
@@ -9,7 +9,7 @@
 #ifndef LLVM_LIBC_SRC_STDIO_FEOF_UNLOCKED_H
 #define LLVM_LIBC_SRC_STDIO_FEOF_UNLOCKED_H
 
-#include <stdio.h>
+#include "hdr/types/FILE.h"
 
 namespace LIBC_NAMESPACE {
 

--- a/libc/src/stdio/ferror.h
+++ b/libc/src/stdio/ferror.h
@@ -9,7 +9,7 @@
 #ifndef LLVM_LIBC_SRC_STDIO_FERROR_H
 #define LLVM_LIBC_SRC_STDIO_FERROR_H
 
-#include <stdio.h>
+#include "hdr/types/FILE.h"
 
 namespace LIBC_NAMESPACE {
 

--- a/libc/src/stdio/ferror_unlocked.h
+++ b/libc/src/stdio/ferror_unlocked.h
@@ -9,7 +9,7 @@
 #ifndef LLVM_LIBC_SRC_STDIO_FERROR_UNLOCKED_H
 #define LLVM_LIBC_SRC_STDIO_FERROR_UNLOCKED_H
 
-#include <stdio.h>
+#include "hdr/types/FILE.h"
 
 namespace LIBC_NAMESPACE {
 

--- a/libc/src/stdio/fflush.h
+++ b/libc/src/stdio/fflush.h
@@ -9,7 +9,7 @@
 #ifndef LLVM_LIBC_SRC_STDIO_FFLUSH_H
 #define LLVM_LIBC_SRC_STDIO_FFLUSH_H
 
-#include <stdio.h>
+#include "hdr/types/FILE.h"
 
 namespace LIBC_NAMESPACE {
 

--- a/libc/src/stdio/fgetc.h
+++ b/libc/src/stdio/fgetc.h
@@ -9,7 +9,7 @@
 #ifndef LLVM_LIBC_SRC_STDIO_FGETC_H
 #define LLVM_LIBC_SRC_STDIO_FGETC_H
 
-#include <stdio.h>
+#include "hdr/types/FILE.h"
 
 namespace LIBC_NAMESPACE {
 

--- a/libc/src/stdio/fgetc_unlocked.h
+++ b/libc/src/stdio/fgetc_unlocked.h
@@ -9,7 +9,7 @@
 #ifndef LLVM_LIBC_SRC_STDIO_FGETC_UNLOCKED_H
 #define LLVM_LIBC_SRC_STDIO_FGETC_UNLOCKED_H
 
-#include <stdio.h>
+#include "hdr/types/FILE.h"
 
 namespace LIBC_NAMESPACE {
 

--- a/libc/src/stdio/fgets.h
+++ b/libc/src/stdio/fgets.h
@@ -9,7 +9,7 @@
 #ifndef LLVM_LIBC_SRC_STDIO_FGETS_H
 #define LLVM_LIBC_SRC_STDIO_FGETS_H
 
-#include <stdio.h>
+#include "hdr/types/FILE.h"
 
 namespace LIBC_NAMESPACE {
 

--- a/libc/src/stdio/flockfile.cpp
+++ b/libc/src/stdio/flockfile.cpp
@@ -9,7 +9,7 @@
 #include "src/stdio/flockfile.h"
 #include "src/__support/File/file.h"
 
-#include <stdio.h>
+#include "hdr/types/FILE.h"
 
 namespace LIBC_NAMESPACE {
 

--- a/libc/src/stdio/flockfile.h
+++ b/libc/src/stdio/flockfile.h
@@ -9,7 +9,7 @@
 #ifndef LLVM_LIBC_SRC_STDIO_FLOCKFILE_H
 #define LLVM_LIBC_SRC_STDIO_FLOCKFILE_H
 
-#include <stdio.h>
+#include "hdr/types/FILE.h"
 
 namespace LIBC_NAMESPACE {
 

--- a/libc/src/stdio/fopen.h
+++ b/libc/src/stdio/fopen.h
@@ -9,7 +9,7 @@
 #ifndef LLVM_LIBC_SRC_STDIO_FOPEN_H
 #define LLVM_LIBC_SRC_STDIO_FOPEN_H
 
-#include <stdio.h>
+#include "hdr/types/FILE.h"
 
 namespace LIBC_NAMESPACE {
 

--- a/libc/src/stdio/fopencookie.cpp
+++ b/libc/src/stdio/fopencookie.cpp
@@ -7,12 +7,12 @@
 //===----------------------------------------------------------------------===//
 
 #include "src/stdio/fopencookie.h"
+#include "hdr/stdio_macros.h"
+#include "hdr/types/off_t.h"
 #include "src/__support/CPP/new.h"
 #include "src/__support/File/file.h"
 
 #include "src/errno/libc_errno.h"
-#include <stdio.h>
-#include <stdlib.h>
 
 namespace LIBC_NAMESPACE {
 

--- a/libc/src/stdio/fopencookie.cpp
+++ b/libc/src/stdio/fopencookie.cpp
@@ -8,6 +8,8 @@
 
 #include "src/stdio/fopencookie.h"
 #include "hdr/stdio_macros.h"
+#include "hdr/types/FILE.h"
+#include "hdr/types/cookie_io_functions_t.h"
 #include "hdr/types/off_t.h"
 #include "src/__support/CPP/new.h"
 #include "src/__support/File/file.h"

--- a/libc/src/stdio/fopencookie.h
+++ b/libc/src/stdio/fopencookie.h
@@ -9,7 +9,8 @@
 #ifndef LLVM_LIBC_SRC_STDIO_FOPENCOOKIE_H
 #define LLVM_LIBC_SRC_STDIO_FOPENCOOKIE_H
 
-#include <stdio.h>
+#include "hdr/types/FILE.h"
+#include "hdr/types/cookie_io_functions_t.h"
 
 namespace LIBC_NAMESPACE {
 

--- a/libc/src/stdio/fprintf.cpp
+++ b/libc/src/stdio/fprintf.cpp
@@ -12,8 +12,8 @@
 #include "src/__support/arg_list.h"
 #include "src/stdio/printf_core/vfprintf_internal.h"
 
+#include "hdr/types/FILE.h"
 #include <stdarg.h>
-#include <stdio.h>
 
 namespace LIBC_NAMESPACE {
 

--- a/libc/src/stdio/fprintf.h
+++ b/libc/src/stdio/fprintf.h
@@ -9,7 +9,7 @@
 #ifndef LLVM_LIBC_SRC_STDIO_FPRINTF_H
 #define LLVM_LIBC_SRC_STDIO_FPRINTF_H
 
-#include <stdio.h>
+#include "hdr/types/FILE.h"
 
 namespace LIBC_NAMESPACE {
 

--- a/libc/src/stdio/fputc.h
+++ b/libc/src/stdio/fputc.h
@@ -9,7 +9,7 @@
 #ifndef LLVM_LIBC_SRC_STDIO_FPUTC_H
 #define LLVM_LIBC_SRC_STDIO_FPUTC_H
 
-#include <stdio.h>
+#include "hdr/types/FILE.h"
 
 namespace LIBC_NAMESPACE {
 

--- a/libc/src/stdio/fputs.h
+++ b/libc/src/stdio/fputs.h
@@ -9,7 +9,7 @@
 #ifndef LLVM_LIBC_SRC_STDIO_FPUTS_H
 #define LLVM_LIBC_SRC_STDIO_FPUTS_H
 
-#include <stdio.h>
+#include "hdr/types/FILE.h"
 
 namespace LIBC_NAMESPACE {
 

--- a/libc/src/stdio/fread.h
+++ b/libc/src/stdio/fread.h
@@ -9,7 +9,8 @@
 #ifndef LLVM_LIBC_SRC_STDIO_FREAD_H
 #define LLVM_LIBC_SRC_STDIO_FREAD_H
 
-#include <stdio.h>
+#include "hdr/types/FILE.h"
+#include <stddef.h>
 
 namespace LIBC_NAMESPACE {
 

--- a/libc/src/stdio/fread_unlocked.h
+++ b/libc/src/stdio/fread_unlocked.h
@@ -9,7 +9,8 @@
 #ifndef LLVM_LIBC_SRC_STDIO_FREAD_UNLOCKED_H
 #define LLVM_LIBC_SRC_STDIO_FREAD_UNLOCKED_H
 
-#include <stdio.h>
+#include "hdr/types/FILE.h"
+#include <stddef.h>
 
 namespace LIBC_NAMESPACE {
 

--- a/libc/src/stdio/fscanf.cpp
+++ b/libc/src/stdio/fscanf.cpp
@@ -12,8 +12,8 @@
 #include "src/__support/arg_list.h"
 #include "src/stdio/scanf_core/vfscanf_internal.h"
 
+#include "hdr/types/FILE.h"
 #include <stdarg.h>
-#include <stdio.h>
 
 namespace LIBC_NAMESPACE {
 

--- a/libc/src/stdio/fscanf.h
+++ b/libc/src/stdio/fscanf.h
@@ -9,7 +9,7 @@
 #ifndef LLVM_LIBC_SRC_STDIO_FSCANF_H
 #define LLVM_LIBC_SRC_STDIO_FSCANF_H
 
-#include <stdio.h>
+#include "hdr/types/FILE.h"
 
 namespace LIBC_NAMESPACE {
 

--- a/libc/src/stdio/fseek.h
+++ b/libc/src/stdio/fseek.h
@@ -9,7 +9,7 @@
 #ifndef LLVM_LIBC_SRC_STDIO_FSEEK_H
 #define LLVM_LIBC_SRC_STDIO_FSEEK_H
 
-#include <stdio.h>
+#include "hdr/types/FILE.h"
 
 namespace LIBC_NAMESPACE {
 

--- a/libc/src/stdio/fseeko.h
+++ b/libc/src/stdio/fseeko.h
@@ -9,7 +9,8 @@
 #ifndef LLVM_LIBC_SRC_STDIO_FSEEKO_H
 #define LLVM_LIBC_SRC_STDIO_FSEEKO_H
 
-#include <stdio.h>
+#include "hdr/types/FILE.h"
+#include "hdr/types/off_t.h"
 
 namespace LIBC_NAMESPACE {
 

--- a/libc/src/stdio/ftell.h
+++ b/libc/src/stdio/ftell.h
@@ -9,7 +9,7 @@
 #ifndef LLVM_LIBC_SRC_STDIO_FTELL_H
 #define LLVM_LIBC_SRC_STDIO_FTELL_H
 
-#include <stdio.h>
+#include "hdr/types/FILE.h"
 
 namespace LIBC_NAMESPACE {
 

--- a/libc/src/stdio/ftello.h
+++ b/libc/src/stdio/ftello.h
@@ -9,7 +9,8 @@
 #ifndef LLVM_LIBC_SRC_STDIO_FTELLO_H
 #define LLVM_LIBC_SRC_STDIO_FTELLO_H
 
-#include <stdio.h>
+#include "hdr/types/FILE.h"
+#include "hdr/types/off_t.h"
 
 namespace LIBC_NAMESPACE {
 

--- a/libc/src/stdio/funlockfile.cpp
+++ b/libc/src/stdio/funlockfile.cpp
@@ -9,7 +9,7 @@
 #include "src/stdio/funlockfile.h"
 #include "src/__support/File/file.h"
 
-#include <stdio.h>
+#include "hdr/types/FILE.h"
 
 namespace LIBC_NAMESPACE {
 

--- a/libc/src/stdio/funlockfile.h
+++ b/libc/src/stdio/funlockfile.h
@@ -9,7 +9,7 @@
 #ifndef LLVM_LIBC_SRC_STDIO_FUNLOCKFILE_H
 #define LLVM_LIBC_SRC_STDIO_FUNLOCKFILE_H
 
-#include <stdio.h>
+#include "hdr/types/FILE.h"
 
 namespace LIBC_NAMESPACE {
 

--- a/libc/src/stdio/fwrite.h
+++ b/libc/src/stdio/fwrite.h
@@ -9,7 +9,8 @@
 #ifndef LLVM_LIBC_SRC_STDIO_FWRITE_H
 #define LLVM_LIBC_SRC_STDIO_FWRITE_H
 
-#include <stdio.h>
+#include "hdr/types/FILE.h"
+#include <stddef.h>
 
 namespace LIBC_NAMESPACE {
 

--- a/libc/src/stdio/fwrite_unlocked.h
+++ b/libc/src/stdio/fwrite_unlocked.h
@@ -9,7 +9,8 @@
 #ifndef LLVM_LIBC_SRC_STDIO_FWRITE_UNLOCKED_H
 #define LLVM_LIBC_SRC_STDIO_FWRITE_UNLOCKED_H
 
-#include <stdio.h>
+#include "hdr/types/FILE.h"
+#include <stddef.h>
 
 namespace LIBC_NAMESPACE {
 

--- a/libc/src/stdio/generic/CMakeLists.txt
+++ b/libc/src/stdio/generic/CMakeLists.txt
@@ -5,7 +5,7 @@ add_entrypoint_object(
   HDRS
     ../clearerr.h
   DEPENDS
-    libc.hdr.types.file
+    libc.hdr.types.FILE
     libc.src.__support.File.file
     libc.src.__support.File.platform_file
 )
@@ -17,7 +17,7 @@ add_entrypoint_object(
   HDRS
     ../clearerr_unlocked.h
   DEPENDS
-    libc.hdr.types.file
+    libc.hdr.types.FILE
     libc.src.__support.File.file
     libc.src.__support.File.platform_file
 )
@@ -29,7 +29,7 @@ add_entrypoint_object(
   HDRS
     ../feof.h
   DEPENDS
-    libc.hdr.types.file
+    libc.hdr.types.FILE
     libc.src.__support.File.file
     libc.src.__support.File.platform_file
 )
@@ -41,7 +41,7 @@ add_entrypoint_object(
   HDRS
     ../feof_unlocked.h
   DEPENDS
-    libc.hdr.types.file
+    libc.hdr.types.FILE
     libc.src.__support.File.file
     libc.src.__support.File.platform_file
 )
@@ -53,7 +53,7 @@ add_entrypoint_object(
   HDRS
     ../ferror.h
   DEPENDS
-    libc.hdr.types.file
+    libc.hdr.types.FILE
     libc.src.__support.File.file
     libc.src.__support.File.platform_file
 )
@@ -65,7 +65,7 @@ add_entrypoint_object(
   HDRS
     ../ferror_unlocked.h
   DEPENDS
-    libc.hdr.types.file
+    libc.hdr.types.FILE
     libc.src.__support.File.file
     libc.src.__support.File.platform_file
 )
@@ -77,7 +77,7 @@ add_entrypoint_object(
   HDRS
     ../fileno.h
   DEPENDS
-    libc.hdr.types.file
+    libc.hdr.types.FILE
     libc.src.__support.File.file
     libc.src.__support.File.platform_file
 )
@@ -90,7 +90,7 @@ add_entrypoint_object(
     ../fflush.h
   DEPENDS
     libc.src.errno.errno
-    libc.hdr.types.file
+    libc.hdr.types.FILE
     libc.src.__support.File.file
     libc.src.__support.File.platform_file
 )
@@ -150,7 +150,7 @@ add_entrypoint_object(
   HDRS
     ../fopen.h
   DEPENDS
-    libc.hdr.types.file
+    libc.hdr.types.FILE
     libc.src.__support.File.file
     libc.src.__support.File.platform_file
 )
@@ -162,7 +162,7 @@ add_entrypoint_object(
   HDRS
     ../fclose.h
   DEPENDS
-    libc.hdr.types.file
+    libc.hdr.types.FILE
     libc.src.errno.errno
     libc.src.__support.File.file
     libc.src.__support.File.platform_file
@@ -176,7 +176,7 @@ add_entrypoint_object(
     ../fread_unlocked.h
   DEPENDS
     libc.src.errno.errno
-    libc.hdr.types.file
+    libc.hdr.types.FILE
     libc.src.__support.File.file
     libc.src.__support.File.platform_file
 )
@@ -189,7 +189,7 @@ add_entrypoint_object(
     ../fread.h
   DEPENDS
     libc.src.errno.errno
-    libc.hdr.types.file
+    libc.hdr.types.FILE
     libc.src.__support.File.file
     libc.src.__support.File.platform_file
 )
@@ -202,7 +202,7 @@ add_entrypoint_object(
     ../fputs.h
   DEPENDS
     libc.src.errno.errno
-    libc.hdr.types.file
+    libc.hdr.types.FILE
     libc.src.__support.File.file
     libc.src.__support.File.platform_file
 )
@@ -215,7 +215,7 @@ add_entrypoint_object(
     ../puts.h
   DEPENDS
     libc.src.errno.errno
-    libc.hdr.types.file
+    libc.hdr.types.FILE
     libc.src.__support.File.file
     libc.src.__support.File.platform_stdout
 )
@@ -228,7 +228,7 @@ add_entrypoint_object(
     ../fwrite_unlocked.h
   DEPENDS
     libc.src.errno.errno
-    libc.hdr.types.file
+    libc.hdr.types.FILE
     libc.src.__support.File.file
     libc.src.__support.File.platform_file
 )
@@ -241,7 +241,7 @@ add_entrypoint_object(
     ../fwrite.h
   DEPENDS
     libc.src.errno.errno
-    libc.hdr.types.file
+    libc.hdr.types.FILE
     libc.src.__support.File.file
     libc.src.__support.File.platform_file
 )
@@ -254,7 +254,7 @@ add_entrypoint_object(
     ../fputc.h
   DEPENDS
     libc.src.errno.errno
-    libc.hdr.types.file
+    libc.hdr.types.FILE
     libc.src.__support.File.file
     libc.src.__support.File.platform_file
 )
@@ -267,7 +267,7 @@ add_entrypoint_object(
     ../putc.h
   DEPENDS
     libc.src.errno.errno
-    libc.hdr.types.file
+    libc.hdr.types.FILE
     libc.src.__support.File.file
     libc.src.__support.File.platform_file
 )
@@ -280,7 +280,7 @@ add_entrypoint_object(
     ../putchar.h
   DEPENDS
     libc.src.errno.errno
-    libc.hdr.types.file
+    libc.hdr.types.FILE
     libc.src.__support.File.file
     libc.src.__support.File.platform_file
 )
@@ -293,7 +293,7 @@ add_entrypoint_object(
     ../fgetc.h
   DEPENDS
     libc.src.errno.errno
-    libc.hdr.types.file
+    libc.hdr.types.FILE
     libc.src.__support.File.file
     libc.src.__support.File.platform_file
 )
@@ -306,7 +306,7 @@ add_entrypoint_object(
     ../fgetc_unlocked.h
   DEPENDS
     libc.src.errno.errno
-    libc.hdr.types.file
+    libc.hdr.types.FILE
     libc.src.__support.File.file
     libc.src.__support.File.platform_file
 )
@@ -319,7 +319,7 @@ add_entrypoint_object(
     ../getc.h
   DEPENDS
     libc.src.errno.errno
-    libc.hdr.types.file
+    libc.hdr.types.FILE
     libc.src.__support.File.file
     libc.src.__support.File.platform_file
 )
@@ -332,7 +332,7 @@ add_entrypoint_object(
     ../getc_unlocked.h
   DEPENDS
     libc.src.errno.errno
-    libc.hdr.types.file
+    libc.hdr.types.FILE
     libc.src.__support.File.file
     libc.src.__support.File.platform_file
 )
@@ -345,7 +345,7 @@ add_entrypoint_object(
     ../getchar.h
   DEPENDS
     libc.src.errno.errno
-    libc.hdr.types.file
+    libc.hdr.types.FILE
     libc.src.__support.File.file
     libc.src.__support.File.platform_file
 )
@@ -358,7 +358,7 @@ add_entrypoint_object(
     ../getchar_unlocked.h
   DEPENDS
     libc.src.errno.errno
-    libc.hdr.types.file
+    libc.hdr.types.FILE
     libc.src.__support.File.file
     libc.src.__support.File.platform_file
 )
@@ -404,7 +404,7 @@ add_entrypoint_object(
     ../fgets.h
   DEPENDS
     libc.src.errno.errno
-    libc.hdr.types.file
+    libc.hdr.types.FILE
     libc.src.__support.File.file
     libc.src.__support.File.platform_file
 )
@@ -416,7 +416,7 @@ add_entrypoint_object(
   HDRS
     ../ungetc.h
   DEPENDS
-    libc.hdr.types.file
+    libc.hdr.types.FILE
     libc.src.__support.File.file
     libc.src.__support.File.platform_file
 )
@@ -428,7 +428,7 @@ add_entrypoint_object(
   HDRS
     ../stdin.h
   DEPENDS
-    libc.hdr.types.file
+    libc.hdr.types.FILE
     libc.src.__support.File.file
     libc.src.__support.File.platform_stdin
 )
@@ -440,7 +440,7 @@ add_entrypoint_object(
   HDRS
     ../stdout.h
   DEPENDS
-    libc.hdr.types.file
+    libc.hdr.types.FILE
     libc.src.__support.File.file
     libc.src.__support.File.platform_stdout
 )
@@ -452,7 +452,7 @@ add_entrypoint_object(
   HDRS
     ../stderr.h
   DEPENDS
-    libc.hdr.types.file
+    libc.hdr.types.FILE
     libc.src.__support.File.file
     libc.src.__support.File.platform_stderr
 )

--- a/libc/src/stdio/generic/CMakeLists.txt
+++ b/libc/src/stdio/generic/CMakeLists.txt
@@ -5,7 +5,7 @@ add_entrypoint_object(
   HDRS
     ../clearerr.h
   DEPENDS
-    libc.include.stdio
+    libc.hdr.types.file
     libc.src.__support.File.file
     libc.src.__support.File.platform_file
 )
@@ -17,7 +17,7 @@ add_entrypoint_object(
   HDRS
     ../clearerr_unlocked.h
   DEPENDS
-    libc.include.stdio
+    libc.hdr.types.file
     libc.src.__support.File.file
     libc.src.__support.File.platform_file
 )
@@ -29,7 +29,7 @@ add_entrypoint_object(
   HDRS
     ../feof.h
   DEPENDS
-    libc.include.stdio
+    libc.hdr.types.file
     libc.src.__support.File.file
     libc.src.__support.File.platform_file
 )
@@ -41,7 +41,7 @@ add_entrypoint_object(
   HDRS
     ../feof_unlocked.h
   DEPENDS
-    libc.include.stdio
+    libc.hdr.types.file
     libc.src.__support.File.file
     libc.src.__support.File.platform_file
 )
@@ -53,7 +53,7 @@ add_entrypoint_object(
   HDRS
     ../ferror.h
   DEPENDS
-    libc.include.stdio
+    libc.hdr.types.file
     libc.src.__support.File.file
     libc.src.__support.File.platform_file
 )
@@ -65,7 +65,7 @@ add_entrypoint_object(
   HDRS
     ../ferror_unlocked.h
   DEPENDS
-    libc.include.stdio
+    libc.hdr.types.file
     libc.src.__support.File.file
     libc.src.__support.File.platform_file
 )
@@ -77,7 +77,7 @@ add_entrypoint_object(
   HDRS
     ../fileno.h
   DEPENDS
-    libc.include.stdio
+    libc.hdr.types.file
     libc.src.__support.File.file
     libc.src.__support.File.platform_file
 )
@@ -90,7 +90,7 @@ add_entrypoint_object(
     ../fflush.h
   DEPENDS
     libc.src.errno.errno
-    libc.include.stdio
+    libc.hdr.types.file
     libc.src.__support.File.file
     libc.src.__support.File.platform_file
 )
@@ -150,7 +150,7 @@ add_entrypoint_object(
   HDRS
     ../fopen.h
   DEPENDS
-    libc.include.stdio
+    libc.hdr.types.file
     libc.src.__support.File.file
     libc.src.__support.File.platform_file
 )
@@ -162,7 +162,7 @@ add_entrypoint_object(
   HDRS
     ../fclose.h
   DEPENDS
-    libc.include.stdio
+    libc.hdr.types.file
     libc.src.errno.errno
     libc.src.__support.File.file
     libc.src.__support.File.platform_file
@@ -176,7 +176,7 @@ add_entrypoint_object(
     ../fread_unlocked.h
   DEPENDS
     libc.src.errno.errno
-    libc.include.stdio
+    libc.hdr.types.file
     libc.src.__support.File.file
     libc.src.__support.File.platform_file
 )
@@ -189,7 +189,7 @@ add_entrypoint_object(
     ../fread.h
   DEPENDS
     libc.src.errno.errno
-    libc.include.stdio
+    libc.hdr.types.file
     libc.src.__support.File.file
     libc.src.__support.File.platform_file
 )
@@ -202,7 +202,7 @@ add_entrypoint_object(
     ../fputs.h
   DEPENDS
     libc.src.errno.errno
-    libc.include.stdio
+    libc.hdr.types.file
     libc.src.__support.File.file
     libc.src.__support.File.platform_file
 )
@@ -215,7 +215,7 @@ add_entrypoint_object(
     ../puts.h
   DEPENDS
     libc.src.errno.errno
-    libc.include.stdio
+    libc.hdr.types.file
     libc.src.__support.File.file
     libc.src.__support.File.platform_stdout
 )
@@ -228,7 +228,7 @@ add_entrypoint_object(
     ../fwrite_unlocked.h
   DEPENDS
     libc.src.errno.errno
-    libc.include.stdio
+    libc.hdr.types.file
     libc.src.__support.File.file
     libc.src.__support.File.platform_file
 )
@@ -241,7 +241,7 @@ add_entrypoint_object(
     ../fwrite.h
   DEPENDS
     libc.src.errno.errno
-    libc.include.stdio
+    libc.hdr.types.file
     libc.src.__support.File.file
     libc.src.__support.File.platform_file
 )
@@ -254,7 +254,7 @@ add_entrypoint_object(
     ../fputc.h
   DEPENDS
     libc.src.errno.errno
-    libc.include.stdio
+    libc.hdr.types.file
     libc.src.__support.File.file
     libc.src.__support.File.platform_file
 )
@@ -267,7 +267,7 @@ add_entrypoint_object(
     ../putc.h
   DEPENDS
     libc.src.errno.errno
-    libc.include.stdio
+    libc.hdr.types.file
     libc.src.__support.File.file
     libc.src.__support.File.platform_file
 )
@@ -280,7 +280,7 @@ add_entrypoint_object(
     ../putchar.h
   DEPENDS
     libc.src.errno.errno
-    libc.include.stdio
+    libc.hdr.types.file
     libc.src.__support.File.file
     libc.src.__support.File.platform_file
 )
@@ -293,7 +293,7 @@ add_entrypoint_object(
     ../fgetc.h
   DEPENDS
     libc.src.errno.errno
-    libc.include.stdio
+    libc.hdr.types.file
     libc.src.__support.File.file
     libc.src.__support.File.platform_file
 )
@@ -306,7 +306,7 @@ add_entrypoint_object(
     ../fgetc_unlocked.h
   DEPENDS
     libc.src.errno.errno
-    libc.include.stdio
+    libc.hdr.types.file
     libc.src.__support.File.file
     libc.src.__support.File.platform_file
 )
@@ -319,7 +319,7 @@ add_entrypoint_object(
     ../getc.h
   DEPENDS
     libc.src.errno.errno
-    libc.include.stdio
+    libc.hdr.types.file
     libc.src.__support.File.file
     libc.src.__support.File.platform_file
 )
@@ -332,7 +332,7 @@ add_entrypoint_object(
     ../getc_unlocked.h
   DEPENDS
     libc.src.errno.errno
-    libc.include.stdio
+    libc.hdr.types.file
     libc.src.__support.File.file
     libc.src.__support.File.platform_file
 )
@@ -345,7 +345,7 @@ add_entrypoint_object(
     ../getchar.h
   DEPENDS
     libc.src.errno.errno
-    libc.include.stdio
+    libc.hdr.types.file
     libc.src.__support.File.file
     libc.src.__support.File.platform_file
 )
@@ -358,7 +358,7 @@ add_entrypoint_object(
     ../getchar_unlocked.h
   DEPENDS
     libc.src.errno.errno
-    libc.include.stdio
+    libc.hdr.types.file
     libc.src.__support.File.file
     libc.src.__support.File.platform_file
 )
@@ -404,7 +404,7 @@ add_entrypoint_object(
     ../fgets.h
   DEPENDS
     libc.src.errno.errno
-    libc.include.stdio
+    libc.hdr.types.file
     libc.src.__support.File.file
     libc.src.__support.File.platform_file
 )
@@ -416,7 +416,7 @@ add_entrypoint_object(
   HDRS
     ../ungetc.h
   DEPENDS
-    libc.include.stdio
+    libc.hdr.types.file
     libc.src.__support.File.file
     libc.src.__support.File.platform_file
 )
@@ -428,7 +428,7 @@ add_entrypoint_object(
   HDRS
     ../stdin.h
   DEPENDS
-    libc.include.stdio
+    libc.hdr.types.file
     libc.src.__support.File.file
     libc.src.__support.File.platform_stdin
 )
@@ -440,7 +440,7 @@ add_entrypoint_object(
   HDRS
     ../stdout.h
   DEPENDS
-    libc.include.stdio
+    libc.hdr.types.file
     libc.src.__support.File.file
     libc.src.__support.File.platform_stdout
 )
@@ -452,7 +452,7 @@ add_entrypoint_object(
   HDRS
     ../stderr.h
   DEPENDS
-    libc.include.stdio
+    libc.hdr.types.file
     libc.src.__support.File.file
     libc.src.__support.File.platform_stderr
 )

--- a/libc/src/stdio/generic/clearerr.cpp
+++ b/libc/src/stdio/generic/clearerr.cpp
@@ -9,7 +9,7 @@
 #include "src/stdio/clearerr.h"
 #include "src/__support/File/file.h"
 
-#include <stdio.h>
+#include "hdr/types/FILE.h"
 
 namespace LIBC_NAMESPACE {
 

--- a/libc/src/stdio/generic/clearerr_unlocked.cpp
+++ b/libc/src/stdio/generic/clearerr_unlocked.cpp
@@ -9,7 +9,7 @@
 #include "src/stdio/clearerr_unlocked.h"
 #include "src/__support/File/file.h"
 
-#include <stdio.h>
+#include "hdr/types/FILE.h"
 
 namespace LIBC_NAMESPACE {
 

--- a/libc/src/stdio/generic/fclose.cpp
+++ b/libc/src/stdio/generic/fclose.cpp
@@ -9,8 +9,8 @@
 #include "src/stdio/fclose.h"
 #include "src/__support/File/file.h"
 
+#include "hdr/types/FILE.h"
 #include "src/errno/libc_errno.h"
-#include <stdio.h>
 
 namespace LIBC_NAMESPACE {
 

--- a/libc/src/stdio/generic/feof.cpp
+++ b/libc/src/stdio/generic/feof.cpp
@@ -9,7 +9,7 @@
 #include "src/stdio/feof.h"
 #include "src/__support/File/file.h"
 
-#include <stdio.h>
+#include "hdr/types/FILE.h"
 
 namespace LIBC_NAMESPACE {
 

--- a/libc/src/stdio/generic/feof_unlocked.cpp
+++ b/libc/src/stdio/generic/feof_unlocked.cpp
@@ -9,7 +9,7 @@
 #include "src/stdio/feof_unlocked.h"
 #include "src/__support/File/file.h"
 
-#include <stdio.h>
+#include "hdr/types/FILE.h"
 
 namespace LIBC_NAMESPACE {
 

--- a/libc/src/stdio/generic/ferror.cpp
+++ b/libc/src/stdio/generic/ferror.cpp
@@ -9,7 +9,7 @@
 #include "src/stdio/ferror.h"
 #include "src/__support/File/file.h"
 
-#include <stdio.h>
+#include "hdr/types/FILE.h"
 
 namespace LIBC_NAMESPACE {
 

--- a/libc/src/stdio/generic/ferror_unlocked.cpp
+++ b/libc/src/stdio/generic/ferror_unlocked.cpp
@@ -9,7 +9,7 @@
 #include "src/stdio/ferror_unlocked.h"
 #include "src/__support/File/file.h"
 
-#include <stdio.h>
+#include "hdr/types/FILE.h"
 
 namespace LIBC_NAMESPACE {
 

--- a/libc/src/stdio/generic/fflush.cpp
+++ b/libc/src/stdio/generic/fflush.cpp
@@ -9,8 +9,8 @@
 #include "src/stdio/fflush.h"
 #include "src/__support/File/file.h"
 
+#include "hdr/types/FILE.h"
 #include "src/errno/libc_errno.h"
-#include <stdio.h>
 
 namespace LIBC_NAMESPACE {
 

--- a/libc/src/stdio/generic/fgetc.cpp
+++ b/libc/src/stdio/generic/fgetc.cpp
@@ -9,8 +9,9 @@
 #include "src/stdio/fgetc.h"
 #include "src/__support/File/file.h"
 
+#include "hdr/types/FILE.h"
 #include "src/errno/libc_errno.h"
-#include <stdio.h>
+#include <stddef.h>
 
 namespace LIBC_NAMESPACE {
 

--- a/libc/src/stdio/generic/fgetc_unlocked.cpp
+++ b/libc/src/stdio/generic/fgetc_unlocked.cpp
@@ -9,8 +9,9 @@
 #include "src/stdio/fgetc_unlocked.h"
 #include "src/__support/File/file.h"
 
+#include "hdr/types/FILE.h"
 #include "src/errno/libc_errno.h"
-#include <stdio.h>
+#include <stddef.h>
 
 namespace LIBC_NAMESPACE {
 

--- a/libc/src/stdio/generic/fgets.cpp
+++ b/libc/src/stdio/generic/fgets.cpp
@@ -9,9 +9,9 @@
 #include "src/stdio/fgets.h"
 #include "src/__support/File/file.h"
 
+#include "hdr/types/FILE.h"
 #include "src/errno/libc_errno.h"
 #include <stddef.h>
-#include <stdio.h>
 
 namespace LIBC_NAMESPACE {
 

--- a/libc/src/stdio/generic/fopen.cpp
+++ b/libc/src/stdio/generic/fopen.cpp
@@ -9,8 +9,8 @@
 #include "src/stdio/fopen.h"
 #include "src/__support/File/file.h"
 
+#include "hdr/types/FILE.h"
 #include "src/errno/libc_errno.h"
-#include <stdio.h>
 
 namespace LIBC_NAMESPACE {
 

--- a/libc/src/stdio/generic/fputc.cpp
+++ b/libc/src/stdio/generic/fputc.cpp
@@ -9,8 +9,9 @@
 #include "src/stdio/fputc.h"
 #include "src/__support/File/file.h"
 
+#include "hdr/types/FILE.h"
 #include "src/errno/libc_errno.h"
-#include <stdio.h>
+#include <stddef.h>
 
 namespace LIBC_NAMESPACE {
 

--- a/libc/src/stdio/generic/fputs.cpp
+++ b/libc/src/stdio/generic/fputs.cpp
@@ -10,8 +10,9 @@
 #include "src/__support/CPP/string_view.h"
 #include "src/__support/File/file.h"
 
+#include "hdr/types/FILE.h"
 #include "src/errno/libc_errno.h"
-#include <stdio.h>
+#include <stddef.h>
 
 namespace LIBC_NAMESPACE {
 

--- a/libc/src/stdio/generic/fread.cpp
+++ b/libc/src/stdio/generic/fread.cpp
@@ -9,8 +9,9 @@
 #include "src/stdio/fread.h"
 #include "src/__support/File/file.h"
 
+#include "hdr/types/FILE.h"
 #include "src/errno/libc_errno.h"
-#include <stdio.h>
+#include <stddef.h>
 
 namespace LIBC_NAMESPACE {
 

--- a/libc/src/stdio/generic/fread_unlocked.cpp
+++ b/libc/src/stdio/generic/fread_unlocked.cpp
@@ -9,8 +9,9 @@
 #include "src/stdio/fread_unlocked.h"
 #include "src/__support/File/file.h"
 
+#include "hdr/types/FILE.h"
 #include "src/errno/libc_errno.h"
-#include <stdio.h>
+#include <stddef.h>
 
 namespace LIBC_NAMESPACE {
 

--- a/libc/src/stdio/generic/fwrite.cpp
+++ b/libc/src/stdio/generic/fwrite.cpp
@@ -9,8 +9,9 @@
 #include "src/stdio/fwrite.h"
 #include "src/__support/File/file.h"
 
+#include "hdr/types/FILE.h"
 #include "src/errno/libc_errno.h"
-#include <stdio.h>
+#include <stddef.h>
 
 namespace LIBC_NAMESPACE {
 

--- a/libc/src/stdio/generic/fwrite_unlocked.cpp
+++ b/libc/src/stdio/generic/fwrite_unlocked.cpp
@@ -9,8 +9,9 @@
 #include "src/stdio/fwrite_unlocked.h"
 #include "src/__support/File/file.h"
 
+#include "hdr/types/FILE.h"
 #include "src/errno/libc_errno.h"
-#include <stdio.h>
+#include <stddef.h>
 
 namespace LIBC_NAMESPACE {
 

--- a/libc/src/stdio/generic/getc.cpp
+++ b/libc/src/stdio/generic/getc.cpp
@@ -9,8 +9,9 @@
 #include "src/stdio/getc.h"
 #include "src/__support/File/file.h"
 
+#include "hdr/types/FILE.h"
 #include "src/errno/libc_errno.h"
-#include <stdio.h>
+#include <stddef.h>
 
 namespace LIBC_NAMESPACE {
 

--- a/libc/src/stdio/generic/getc_unlocked.cpp
+++ b/libc/src/stdio/generic/getc_unlocked.cpp
@@ -9,8 +9,9 @@
 #include "src/stdio/getc_unlocked.h"
 #include "src/__support/File/file.h"
 
+#include "hdr/types/FILE.h"
 #include "src/errno/libc_errno.h"
-#include <stdio.h>
+#include <stddef.h>
 
 namespace LIBC_NAMESPACE {
 

--- a/libc/src/stdio/generic/getchar.cpp
+++ b/libc/src/stdio/generic/getchar.cpp
@@ -9,8 +9,8 @@
 #include "src/stdio/getchar.h"
 #include "src/__support/File/file.h"
 
+#include "hdr/types/FILE.h"
 #include "src/errno/libc_errno.h"
-#include <stdio.h>
 
 namespace LIBC_NAMESPACE {
 

--- a/libc/src/stdio/generic/getchar_unlocked.cpp
+++ b/libc/src/stdio/generic/getchar_unlocked.cpp
@@ -9,8 +9,8 @@
 #include "src/stdio/getchar_unlocked.h"
 #include "src/__support/File/file.h"
 
+#include "hdr/types/FILE.h"
 #include "src/errno/libc_errno.h"
-#include <stdio.h>
 
 namespace LIBC_NAMESPACE {
 

--- a/libc/src/stdio/generic/printf.cpp
+++ b/libc/src/stdio/generic/printf.cpp
@@ -12,8 +12,8 @@
 #include "src/__support/arg_list.h"
 #include "src/stdio/printf_core/vfprintf_internal.h"
 
+#include "hdr/types/FILE.h"
 #include <stdarg.h>
-#include <stdio.h>
 
 #ifndef LIBC_COPT_STDIO_USE_SYSTEM_FILE
 #define PRINTF_STDOUT LIBC_NAMESPACE::stdout

--- a/libc/src/stdio/generic/putc.cpp
+++ b/libc/src/stdio/generic/putc.cpp
@@ -9,8 +9,9 @@
 #include "src/stdio/putc.h"
 #include "src/__support/File/file.h"
 
+#include "hdr/types/FILE.h"
 #include "src/errno/libc_errno.h"
-#include <stdio.h>
+#include <stddef.h>
 
 namespace LIBC_NAMESPACE {
 

--- a/libc/src/stdio/generic/putchar.cpp
+++ b/libc/src/stdio/generic/putchar.cpp
@@ -9,8 +9,9 @@
 #include "src/stdio/putchar.h"
 #include "src/__support/File/file.h"
 
+#include "hdr/types/FILE.h"
 #include "src/errno/libc_errno.h"
-#include <stdio.h>
+#include <stddef.h>
 
 namespace LIBC_NAMESPACE {
 

--- a/libc/src/stdio/generic/puts.cpp
+++ b/libc/src/stdio/generic/puts.cpp
@@ -10,8 +10,9 @@
 #include "src/__support/CPP/string_view.h"
 #include "src/__support/File/file.h"
 
+#include "hdr/types/FILE.h"
 #include "src/errno/libc_errno.h"
-#include <stdio.h>
+#include <stddef.h>
 
 namespace LIBC_NAMESPACE {
 

--- a/libc/src/stdio/generic/stderr.cpp
+++ b/libc/src/stdio/generic/stderr.cpp
@@ -8,6 +8,6 @@
 
 #include "src/__support/File/file.h"
 
-#include <stdio.h>
+#include "hdr/types/FILE.h"
 
 extern "C" FILE *stderr;

--- a/libc/src/stdio/generic/stdin.cpp
+++ b/libc/src/stdio/generic/stdin.cpp
@@ -8,6 +8,6 @@
 
 #include "src/__support/File/file.h"
 
-#include <stdio.h>
+#include "hdr/types/FILE.h"
 
 extern "C" FILE *stdin;

--- a/libc/src/stdio/generic/stdout.cpp
+++ b/libc/src/stdio/generic/stdout.cpp
@@ -8,6 +8,6 @@
 
 #include "src/__support/File/file.h"
 
-#include <stdio.h>
+#include "hdr/types/FILE.h"
 
 extern "C" FILE *stdout;

--- a/libc/src/stdio/generic/ungetc.cpp
+++ b/libc/src/stdio/generic/ungetc.cpp
@@ -9,7 +9,7 @@
 #include "src/stdio/ungetc.h"
 #include "src/__support/File/file.h"
 
-#include <stdio.h>
+#include "hdr/types/FILE.h"
 
 namespace LIBC_NAMESPACE {
 

--- a/libc/src/stdio/generic/vprintf.cpp
+++ b/libc/src/stdio/generic/vprintf.cpp
@@ -12,8 +12,8 @@
 #include "src/__support/arg_list.h"
 #include "src/stdio/printf_core/vfprintf_internal.h"
 
+#include "hdr/types/FILE.h"
 #include <stdarg.h>
-#include <stdio.h>
 
 #ifndef LIBC_COPT_STDIO_USE_SYSTEM_FILE
 #define PRINTF_STDOUT LIBC_NAMESPACE::stdout

--- a/libc/src/stdio/getc.h
+++ b/libc/src/stdio/getc.h
@@ -9,7 +9,7 @@
 #ifndef LLVM_LIBC_SRC_STDIO_GETC_H
 #define LLVM_LIBC_SRC_STDIO_GETC_H
 
-#include <stdio.h>
+#include "hdr/types/FILE.h"
 
 namespace LIBC_NAMESPACE {
 

--- a/libc/src/stdio/getc_unlocked.h
+++ b/libc/src/stdio/getc_unlocked.h
@@ -9,7 +9,7 @@
 #ifndef LLVM_LIBC_SRC_STDIO_GETC_UNLOCKED_H
 #define LLVM_LIBC_SRC_STDIO_GETC_UNLOCKED_H
 
-#include <stdio.h>
+#include "hdr/types/FILE.h"
 
 namespace LIBC_NAMESPACE {
 

--- a/libc/src/stdio/gpu/CMakeLists.txt
+++ b/libc/src/stdio/gpu/CMakeLists.txt
@@ -3,6 +3,7 @@ add_header_library(
   HDRS
     file.h
   DEPENDS
+    libc.hdr.types.FILE
     libc.src.__support.RPC.rpc_client
     libc.src.__support.common
     .stdin
@@ -17,7 +18,7 @@ add_entrypoint_object(
   HDRS
     ../feof.h
   DEPENDS
-    libc.include.stdio
+    libc.hdr.types.FILE
     libc.src.__support.RPC.rpc_client
 )
 
@@ -28,7 +29,7 @@ add_entrypoint_object(
   HDRS
     ../ferror.h
   DEPENDS
-    libc.include.stdio
+    libc.hdr.types.FILE
     libc.src.__support.RPC.rpc_client
 )
 
@@ -39,7 +40,7 @@ add_entrypoint_object(
   HDRS
     ../fseek.h
   DEPENDS
-    libc.include.stdio
+    libc.hdr.types.file
     .gpu_file
 )
 
@@ -50,7 +51,7 @@ add_entrypoint_object(
   HDRS
     ../ftell.h
   DEPENDS
-    libc.include.stdio
+    libc.hdr.types.file
     .gpu_file
 )
 
@@ -61,7 +62,7 @@ add_entrypoint_object(
   HDRS
     ../fflush.h
   DEPENDS
-    libc.include.stdio
+    libc.hdr.types.file
     .gpu_file
 )
 
@@ -72,7 +73,7 @@ add_entrypoint_object(
   HDRS
     ../clearerr.h
   DEPENDS
-    libc.include.stdio
+    libc.hdr.types.file
     libc.src.__support.RPC.rpc_client
 )
 
@@ -83,7 +84,7 @@ add_entrypoint_object(
   HDRS
     ../fopen.h
   DEPENDS
-    libc.include.stdio
+    libc.hdr.types.file
 )
 
 add_entrypoint_object(
@@ -93,7 +94,7 @@ add_entrypoint_object(
   HDRS
     ../fclose.h
   DEPENDS
-    libc.include.stdio
+    libc.hdr.types.file
 )
 
 add_entrypoint_object(
@@ -103,7 +104,7 @@ add_entrypoint_object(
   HDRS
     ../fread.h
   DEPENDS
-    libc.include.stdio
+    libc.hdr.types.file
 )
 
 add_entrypoint_object(
@@ -113,7 +114,8 @@ add_entrypoint_object(
   HDRS
     ../puts.h
   DEPENDS
-    libc.include.stdio
+    libc.hdr.types.FILE
+    libc.include.stdio # needed for stdin
     .gpu_file
 )
 
@@ -124,7 +126,7 @@ add_entrypoint_object(
   HDRS
     ../fputs.h
   DEPENDS
-    libc.include.stdio
+    libc.hdr.types.file
     .gpu_file
 )
 
@@ -135,7 +137,7 @@ add_entrypoint_object(
   HDRS
     ../fwrite.h
   DEPENDS
-    libc.include.stdio
+    libc.hdr.types.file
     .gpu_file
 )
 
@@ -146,7 +148,7 @@ add_entrypoint_object(
   HDRS
     ../fputc.h
   DEPENDS
-    libc.include.stdio
+    libc.hdr.types.file
     .gpu_file
 )
 
@@ -157,7 +159,8 @@ add_entrypoint_object(
   HDRS
     ../putc.h
   DEPENDS
-    libc.include.stdio
+    libc.hdr.types.FILE
+    libc.include.stdio # needed for stdin
     .gpu_file
 )
 
@@ -168,7 +171,8 @@ add_entrypoint_object(
   HDRS
     ../putchar.h
   DEPENDS
-    libc.include.stdio
+    libc.hdr.types.FILE
+    libc.include.stdio # needed for stdin
     .gpu_file
 )
 
@@ -179,18 +183,7 @@ add_entrypoint_object(
   HDRS
     ../fgetc.h
   DEPENDS
-    libc.include.stdio
-    .gpu_file
-)
-
-add_entrypoint_object(
-  fgetc_unlocked
-  SRCS
-    fgetc_unlocked.cpp
-  HDRS
-    ../fgetc_unlocked.h
-  DEPENDS
-    libc.include.stdio
+    libc.hdr.types.file
     .gpu_file
 )
 
@@ -201,18 +194,8 @@ add_entrypoint_object(
   HDRS
     ../getc.h
   DEPENDS
-    libc.include.stdio
-    .gpu_file
-)
-
-add_entrypoint_object(
-  getc_unlocked
-  SRCS
-    getc_unlocked.cpp
-  HDRS
-    ../getc_unlocked.h
-  DEPENDS
-    libc.include.stdio
+    libc.hdr.types.FILE
+    libc.include.stdio # needed for stdin
     .gpu_file
 )
 
@@ -223,18 +206,8 @@ add_entrypoint_object(
   HDRS
     ../getchar.h
   DEPENDS
-    libc.include.stdio
-    .gpu_file
-)
-
-add_entrypoint_object(
-  getchar_unlocked
-  SRCS
-    getc_unlocked.cpp
-  HDRS
-    ../getc_unlocked.h
-  DEPENDS
-    libc.include.stdio
+    libc.hdr.types.FILE
+    libc.include.stdio # needed for stdin
     .gpu_file
 )
 
@@ -245,7 +218,7 @@ add_entrypoint_object(
   HDRS
     ../fgets.h
   DEPENDS
-    libc.include.stdio
+    libc.hdr.types.file
     .gpu_file
     .feof
     .ferror
@@ -258,7 +231,7 @@ add_entrypoint_object(
   HDRS
     ../ungetc.h
   DEPENDS
-    libc.include.stdio
+    libc.hdr.types.file
     .gpu_file
 )
 
@@ -269,7 +242,7 @@ add_entrypoint_object(
   HDRS
     ../remove.h
   DEPENDS
-    libc.include.stdio
+    libc.hdr.types.file
     .gpu_file
 )
 
@@ -280,7 +253,7 @@ add_entrypoint_object(
   HDRS
     ../stdin.h
   DEPENDS
-    libc.include.stdio
+    libc.hdr.types.file
 )
 
 add_entrypoint_object(
@@ -290,7 +263,7 @@ add_entrypoint_object(
   HDRS
     ../stdout.h
   DEPENDS
-    libc.include.stdio
+    libc.hdr.types.file
 )
 
 add_entrypoint_object(
@@ -300,5 +273,5 @@ add_entrypoint_object(
   HDRS
     ../stderr.h
   DEPENDS
-    libc.include.stdio
+    libc.hdr.types.file
 )

--- a/libc/src/stdio/gpu/CMakeLists.txt
+++ b/libc/src/stdio/gpu/CMakeLists.txt
@@ -40,7 +40,7 @@ add_entrypoint_object(
   HDRS
     ../fseek.h
   DEPENDS
-    libc.hdr.types.file
+    libc.hdr.types.FILE
     .gpu_file
 )
 
@@ -51,7 +51,7 @@ add_entrypoint_object(
   HDRS
     ../ftell.h
   DEPENDS
-    libc.hdr.types.file
+    libc.hdr.types.FILE
     .gpu_file
 )
 
@@ -62,7 +62,7 @@ add_entrypoint_object(
   HDRS
     ../fflush.h
   DEPENDS
-    libc.hdr.types.file
+    libc.hdr.types.FILE
     .gpu_file
 )
 
@@ -73,7 +73,7 @@ add_entrypoint_object(
   HDRS
     ../clearerr.h
   DEPENDS
-    libc.hdr.types.file
+    libc.hdr.types.FILE
     libc.src.__support.RPC.rpc_client
 )
 
@@ -84,7 +84,7 @@ add_entrypoint_object(
   HDRS
     ../fopen.h
   DEPENDS
-    libc.hdr.types.file
+    libc.hdr.types.FILE
 )
 
 add_entrypoint_object(
@@ -94,7 +94,7 @@ add_entrypoint_object(
   HDRS
     ../fclose.h
   DEPENDS
-    libc.hdr.types.file
+    libc.hdr.types.FILE
 )
 
 add_entrypoint_object(
@@ -104,7 +104,7 @@ add_entrypoint_object(
   HDRS
     ../fread.h
   DEPENDS
-    libc.hdr.types.file
+    libc.hdr.types.FILE
 )
 
 add_entrypoint_object(
@@ -126,7 +126,7 @@ add_entrypoint_object(
   HDRS
     ../fputs.h
   DEPENDS
-    libc.hdr.types.file
+    libc.hdr.types.FILE
     .gpu_file
 )
 
@@ -137,7 +137,7 @@ add_entrypoint_object(
   HDRS
     ../fwrite.h
   DEPENDS
-    libc.hdr.types.file
+    libc.hdr.types.FILE
     .gpu_file
 )
 
@@ -148,7 +148,7 @@ add_entrypoint_object(
   HDRS
     ../fputc.h
   DEPENDS
-    libc.hdr.types.file
+    libc.hdr.types.FILE
     .gpu_file
 )
 
@@ -183,7 +183,7 @@ add_entrypoint_object(
   HDRS
     ../fgetc.h
   DEPENDS
-    libc.hdr.types.file
+    libc.hdr.types.FILE
     .gpu_file
 )
 
@@ -218,7 +218,7 @@ add_entrypoint_object(
   HDRS
     ../fgets.h
   DEPENDS
-    libc.hdr.types.file
+    libc.hdr.types.FILE
     .gpu_file
     .feof
     .ferror
@@ -231,7 +231,7 @@ add_entrypoint_object(
   HDRS
     ../ungetc.h
   DEPENDS
-    libc.hdr.types.file
+    libc.hdr.types.FILE
     .gpu_file
 )
 
@@ -242,7 +242,7 @@ add_entrypoint_object(
   HDRS
     ../remove.h
   DEPENDS
-    libc.hdr.types.file
+    libc.hdr.types.FILE
     .gpu_file
 )
 
@@ -253,7 +253,7 @@ add_entrypoint_object(
   HDRS
     ../stdin.h
   DEPENDS
-    libc.hdr.types.file
+    libc.hdr.types.FILE
 )
 
 add_entrypoint_object(
@@ -263,7 +263,7 @@ add_entrypoint_object(
   HDRS
     ../stdout.h
   DEPENDS
-    libc.hdr.types.file
+    libc.hdr.types.FILE
 )
 
 add_entrypoint_object(
@@ -273,5 +273,5 @@ add_entrypoint_object(
   HDRS
     ../stderr.h
   DEPENDS
-    libc.hdr.types.file
+    libc.hdr.types.FILE
 )

--- a/libc/src/stdio/gpu/clearerr.cpp
+++ b/libc/src/stdio/gpu/clearerr.cpp
@@ -9,7 +9,7 @@
 #include "src/stdio/clearerr.h"
 #include "file.h"
 
-#include <stdio.h>
+#include "hdr/types/FILE.h"
 
 namespace LIBC_NAMESPACE {
 

--- a/libc/src/stdio/gpu/fclose.cpp
+++ b/libc/src/stdio/gpu/fclose.cpp
@@ -9,7 +9,8 @@
 #include "src/stdio/fclose.h"
 #include "src/stdio/gpu/file.h"
 
-#include <stdio.h>
+#include "hdr/stdio_macros.h"
+#include "hdr/types/FILE.h"
 
 namespace LIBC_NAMESPACE {
 

--- a/libc/src/stdio/gpu/feof.cpp
+++ b/libc/src/stdio/gpu/feof.cpp
@@ -9,7 +9,7 @@
 #include "src/stdio/feof.h"
 #include "file.h"
 
-#include <stdio.h>
+#include "hdr/types/FILE.h"
 
 namespace LIBC_NAMESPACE {
 

--- a/libc/src/stdio/gpu/ferror.cpp
+++ b/libc/src/stdio/gpu/ferror.cpp
@@ -9,7 +9,7 @@
 #include "src/stdio/ferror.h"
 #include "file.h"
 
-#include <stdio.h>
+#include "hdr/types/FILE.h"
 
 namespace LIBC_NAMESPACE {
 

--- a/libc/src/stdio/gpu/fflush.cpp
+++ b/libc/src/stdio/gpu/fflush.cpp
@@ -9,7 +9,7 @@
 #include "src/stdio/fflush.h"
 #include "file.h"
 
-#include <stdio.h>
+#include "hdr/types/FILE.h"
 
 namespace LIBC_NAMESPACE {
 

--- a/libc/src/stdio/gpu/fgetc.cpp
+++ b/libc/src/stdio/gpu/fgetc.cpp
@@ -9,7 +9,8 @@
 #include "src/stdio/fgetc.h"
 #include "file.h"
 
-#include <stdio.h>
+#include "hdr/stdio_macros.h" // for EOF.
+#include "hdr/types/FILE.h"
 
 namespace LIBC_NAMESPACE {
 

--- a/libc/src/stdio/gpu/fgets.cpp
+++ b/libc/src/stdio/gpu/fgets.cpp
@@ -11,8 +11,9 @@
 #include "src/stdio/feof.h"
 #include "src/stdio/ferror.h"
 
+#include "hdr/stdio_macros.h" // for EOF.
+#include "hdr/types/FILE.h"
 #include <stddef.h>
-#include <stdio.h>
 
 namespace LIBC_NAMESPACE {
 

--- a/libc/src/stdio/gpu/file.h
+++ b/libc/src/stdio/gpu/file.h
@@ -9,7 +9,9 @@
 #include "src/__support/RPC/rpc_client.h"
 #include "src/string/string_utils.h"
 
-#include <stdio.h>
+#include "hdr/types/FILE.h"
+
+#include <stdio.h> //needed for stdin/out/err
 
 namespace LIBC_NAMESPACE {
 namespace file {

--- a/libc/src/stdio/gpu/fopen.cpp
+++ b/libc/src/stdio/gpu/fopen.cpp
@@ -10,7 +10,7 @@
 #include "src/__support/CPP/string_view.h"
 #include "src/stdio/gpu/file.h"
 
-#include <stdio.h>
+#include "hdr/types/FILE.h"
 
 namespace LIBC_NAMESPACE {
 

--- a/libc/src/stdio/gpu/fputc.cpp
+++ b/libc/src/stdio/gpu/fputc.cpp
@@ -6,10 +6,11 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "file.h"
 #include "src/stdio/fputc.h"
+#include "file.h"
 
-#include <stdio.h>
+#include "hdr/stdio_macros.h" // for EOF.
+#include "hdr/types/FILE.h"
 
 namespace LIBC_NAMESPACE {
 

--- a/libc/src/stdio/gpu/fputs.cpp
+++ b/libc/src/stdio/gpu/fputs.cpp
@@ -11,7 +11,8 @@
 #include "src/errno/libc_errno.h"
 #include "src/stdio/gpu/file.h"
 
-#include <stdio.h>
+#include "hdr/stdio_macros.h" // for EOF.
+#include "hdr/types/FILE.h"
 
 namespace LIBC_NAMESPACE {
 

--- a/libc/src/stdio/gpu/fread.cpp
+++ b/libc/src/stdio/gpu/fread.cpp
@@ -9,7 +9,7 @@
 #include "src/stdio/fread.h"
 #include "src/stdio/gpu/file.h"
 
-#include <stdio.h>
+#include "hdr/types/FILE.h"
 
 namespace LIBC_NAMESPACE {
 

--- a/libc/src/stdio/gpu/fseek.cpp
+++ b/libc/src/stdio/gpu/fseek.cpp
@@ -9,7 +9,7 @@
 #include "src/stdio/fseek.h"
 #include "file.h"
 
-#include <stdio.h>
+#include "hdr/types/FILE.h"
 
 namespace LIBC_NAMESPACE {
 

--- a/libc/src/stdio/gpu/ftell.cpp
+++ b/libc/src/stdio/gpu/ftell.cpp
@@ -9,7 +9,7 @@
 #include "src/stdio/ftell.h"
 #include "file.h"
 
-#include <stdio.h>
+#include "hdr/types/FILE.h"
 
 namespace LIBC_NAMESPACE {
 

--- a/libc/src/stdio/gpu/fwrite.cpp
+++ b/libc/src/stdio/gpu/fwrite.cpp
@@ -9,7 +9,7 @@
 #include "src/stdio/fwrite.h"
 #include "file.h"
 
-#include <stdio.h>
+#include "hdr/types/FILE.h"
 
 namespace LIBC_NAMESPACE {
 

--- a/libc/src/stdio/gpu/getc.cpp
+++ b/libc/src/stdio/gpu/getc.cpp
@@ -9,7 +9,8 @@
 #include "src/stdio/getc.h"
 #include "file.h"
 
-#include <stdio.h>
+#include "hdr/stdio_macros.h" // for EOF.
+#include "hdr/types/FILE.h"
 
 namespace LIBC_NAMESPACE {
 

--- a/libc/src/stdio/gpu/getchar.cpp
+++ b/libc/src/stdio/gpu/getchar.cpp
@@ -9,7 +9,10 @@
 #include "src/stdio/getchar.h"
 #include "file.h"
 
-#include <stdio.h>
+#include "hdr/stdio_macros.h" // for EOF.
+#include "hdr/types/FILE.h"
+
+#include <stdio.h> //needed for stdin
 
 namespace LIBC_NAMESPACE {
 

--- a/libc/src/stdio/gpu/putc.cpp
+++ b/libc/src/stdio/gpu/putc.cpp
@@ -9,7 +9,8 @@
 #include "src/stdio/putc.h"
 #include "file.h"
 
-#include <stdio.h>
+#include "hdr/stdio_macros.h" // for EOF.
+#include "hdr/types/FILE.h"
 
 namespace LIBC_NAMESPACE {
 

--- a/libc/src/stdio/gpu/putchar.cpp
+++ b/libc/src/stdio/gpu/putchar.cpp
@@ -6,10 +6,13 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "file.h"
 #include "src/stdio/putchar.h"
+#include "file.h"
 
-#include <stdio.h>
+#include "hdr/stdio_macros.h" // for EOF.
+#include "hdr/types/FILE.h"
+
+#include <stdio.h> //needed for stdout
 
 namespace LIBC_NAMESPACE {
 

--- a/libc/src/stdio/gpu/puts.cpp
+++ b/libc/src/stdio/gpu/puts.cpp
@@ -11,7 +11,10 @@
 #include "src/errno/libc_errno.h"
 #include "src/stdio/gpu/file.h"
 
-#include <stdio.h>
+#include "hdr/stdio_macros.h" // for EOF.
+#include "hdr/types/FILE.h"
+
+#include <stdio.h> //needed for stdout
 
 namespace LIBC_NAMESPACE {
 

--- a/libc/src/stdio/gpu/remove.cpp
+++ b/libc/src/stdio/gpu/remove.cpp
@@ -9,7 +9,7 @@
 #include "src/stdio/remove.h"
 #include "file.h"
 
-#include <stdio.h>
+#include "hdr/types/FILE.h"
 
 namespace LIBC_NAMESPACE {
 

--- a/libc/src/stdio/gpu/stderr.cpp
+++ b/libc/src/stdio/gpu/stderr.cpp
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <stdio.h>
+#include "hdr/types/FILE.h"
 
 namespace LIBC_NAMESPACE {
 static struct {

--- a/libc/src/stdio/gpu/stdin.cpp
+++ b/libc/src/stdio/gpu/stdin.cpp
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <stdio.h>
+#include "hdr/types/FILE.h"
 
 namespace LIBC_NAMESPACE {
 static struct {

--- a/libc/src/stdio/gpu/stdout.cpp
+++ b/libc/src/stdio/gpu/stdout.cpp
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <stdio.h>
+#include "hdr/types/FILE.h"
 
 namespace LIBC_NAMESPACE {
 static struct {

--- a/libc/src/stdio/gpu/ungetc.cpp
+++ b/libc/src/stdio/gpu/ungetc.cpp
@@ -9,7 +9,7 @@
 #include "src/stdio/ungetc.h"
 #include "file.h"
 
-#include <stdio.h>
+#include "hdr/types/FILE.h"
 
 namespace LIBC_NAMESPACE {
 

--- a/libc/src/stdio/printf.h
+++ b/libc/src/stdio/printf.h
@@ -9,7 +9,7 @@
 #ifndef LLVM_LIBC_SRC_STDIO_PRINTF_H
 #define LLVM_LIBC_SRC_STDIO_PRINTF_H
 
-#include <stdio.h>
+#include "hdr/types/FILE.h"
 
 namespace LIBC_NAMESPACE {
 

--- a/libc/src/stdio/printf_core/vfprintf_internal.h
+++ b/libc/src/stdio/printf_core/vfprintf_internal.h
@@ -16,7 +16,7 @@
 #include "src/stdio/printf_core/printf_main.h"
 #include "src/stdio/printf_core/writer.h"
 
-#include <stdio.h>
+#include "hdr/types/FILE.h"
 
 namespace LIBC_NAMESPACE {
 

--- a/libc/src/stdio/putc.h
+++ b/libc/src/stdio/putc.h
@@ -9,7 +9,7 @@
 #ifndef LLVM_LIBC_SRC_STDIO_PUTC_H
 #define LLVM_LIBC_SRC_STDIO_PUTC_H
 
-#include <stdio.h>
+#include "hdr/types/FILE.h"
 
 namespace LIBC_NAMESPACE {
 

--- a/libc/src/stdio/remove.h
+++ b/libc/src/stdio/remove.h
@@ -9,7 +9,7 @@
 #ifndef LLVM_LIBC_SRC_STDIO_REMOVE_H
 #define LLVM_LIBC_SRC_STDIO_REMOVE_H
 
-#include <stdio.h>
+#include "hdr/types/FILE.h"
 
 namespace LIBC_NAMESPACE {
 

--- a/libc/src/stdio/scanf.cpp
+++ b/libc/src/stdio/scanf.cpp
@@ -12,8 +12,8 @@
 #include "src/__support/arg_list.h"
 #include "src/stdio/scanf_core/vfscanf_internal.h"
 
+#include "hdr/types/FILE.h"
 #include <stdarg.h>
-#include <stdio.h>
 
 #ifndef LIBC_COPT_STDIO_USE_SYSTEM_FILE
 #define SCANF_STDIN LIBC_NAMESPACE::stdin

--- a/libc/src/stdio/scanf_core/vfscanf_internal.h
+++ b/libc/src/stdio/scanf_core/vfscanf_internal.h
@@ -14,7 +14,8 @@
 #include "src/stdio/scanf_core/reader.h"
 #include "src/stdio/scanf_core/scanf_main.h"
 
-#include <stdio.h>
+#include "hdr/types/FILE.h"
+#include <stddef.h>
 
 namespace LIBC_NAMESPACE {
 

--- a/libc/src/stdio/setbuf.cpp
+++ b/libc/src/stdio/setbuf.cpp
@@ -7,10 +7,9 @@
 //===----------------------------------------------------------------------===//
 
 #include "src/stdio/setbuf.h"
+#include "hdr/stdio_macros.h"
 #include "src/__support/File/file.h"
-
 #include "src/errno/libc_errno.h"
-#include <stdio.h>
 
 namespace LIBC_NAMESPACE {
 

--- a/libc/src/stdio/setbuf.h
+++ b/libc/src/stdio/setbuf.h
@@ -9,7 +9,7 @@
 #ifndef LLVM_LIBC_SRC_STDIO_SETBUF_H
 #define LLVM_LIBC_SRC_STDIO_SETBUF_H
 
-#include <stdio.h>
+#include "hdr/types/FILE.h"
 
 namespace LIBC_NAMESPACE {
 

--- a/libc/src/stdio/setvbuf.cpp
+++ b/libc/src/stdio/setvbuf.cpp
@@ -9,8 +9,9 @@
 #include "src/stdio/setvbuf.h"
 #include "src/__support/File/file.h"
 
+#include "hdr/types/FILE.h"
 #include "src/errno/libc_errno.h"
-#include <stdio.h>
+#include <stddef.h>
 
 namespace LIBC_NAMESPACE {
 

--- a/libc/src/stdio/setvbuf.h
+++ b/libc/src/stdio/setvbuf.h
@@ -9,7 +9,8 @@
 #ifndef LLVM_LIBC_SRC_STDIO_SETVBUF_H
 #define LLVM_LIBC_SRC_STDIO_SETVBUF_H
 
-#include <stdio.h>
+#include "hdr/types/FILE.h"
+#include <stddef.h>
 
 namespace LIBC_NAMESPACE {
 

--- a/libc/src/stdio/sscanf.cpp
+++ b/libc/src/stdio/sscanf.cpp
@@ -13,8 +13,9 @@
 #include "src/stdio/scanf_core/reader.h"
 #include "src/stdio/scanf_core/scanf_main.h"
 
+#include "hdr/stdio_macros.h"
+#include "hdr/types/FILE.h"
 #include <stdarg.h>
-#include <stdio.h>
 
 namespace LIBC_NAMESPACE {
 

--- a/libc/src/stdio/ungetc.h
+++ b/libc/src/stdio/ungetc.h
@@ -9,7 +9,7 @@
 #ifndef LLVM_LIBC_SRC_STDIO_UNGETC_H
 #define LLVM_LIBC_SRC_STDIO_UNGETC_H
 
-#include <stdio.h>
+#include "hdr/types/FILE.h"
 
 namespace LIBC_NAMESPACE {
 

--- a/libc/src/stdio/vfprintf.cpp
+++ b/libc/src/stdio/vfprintf.cpp
@@ -12,8 +12,8 @@
 #include "src/__support/arg_list.h"
 #include "src/stdio/printf_core/vfprintf_internal.h"
 
+#include "hdr/types/FILE.h"
 #include <stdarg.h>
-#include <stdio.h>
 
 namespace LIBC_NAMESPACE {
 

--- a/libc/src/stdio/vfprintf.h
+++ b/libc/src/stdio/vfprintf.h
@@ -9,8 +9,8 @@
 #ifndef LLVM_LIBC_SRC_STDIO_VFPRINTF_H
 #define LLVM_LIBC_SRC_STDIO_VFPRINTF_H
 
+#include "hdr/types/FILE.h"
 #include <stdarg.h>
-#include <stdio.h>
 
 namespace LIBC_NAMESPACE {
 

--- a/libc/src/stdio/vprintf.h
+++ b/libc/src/stdio/vprintf.h
@@ -9,8 +9,8 @@
 #ifndef LLVM_LIBC_SRC_STDIO_VPRINTF_H
 #define LLVM_LIBC_SRC_STDIO_VPRINTF_H
 
+#include "hdr/types/FILE.h"
 #include <stdarg.h>
-#include <stdio.h>
 
 namespace LIBC_NAMESPACE {
 

--- a/libc/src/unistd/getopt.cpp
+++ b/libc/src/unistd/getopt.cpp
@@ -13,7 +13,7 @@
 #include "src/__support/common.h"
 #include "src/stdio/fprintf.h"
 
-#include <stdio.h>
+#include "hdr/types/FILE.h"
 
 // This is POSIX compliant and does not support GNU extensions, mainly this is
 // just the re-ordering of argv elements such that unknown arguments can be

--- a/libc/src/unistd/getopt.h
+++ b/libc/src/unistd/getopt.h
@@ -9,7 +9,7 @@
 #ifndef LLVM_LIBC_SRC_UNISTD_GETOPT_H
 #define LLVM_LIBC_SRC_UNISTD_GETOPT_H
 
-#include <stdio.h>
+#include "hdr/types/FILE.h"
 #include <unistd.h>
 
 namespace LIBC_NAMESPACE {

--- a/libc/src/wchar/btowc.cpp
+++ b/libc/src/wchar/btowc.cpp
@@ -10,7 +10,7 @@
 #include "src/__support/common.h"
 #include "src/__support/wctype_utils.h"
 
-#include <stdio.h> // for EOF.
+#include "hdr/stdio_macros.h" // for EOF.
 
 namespace LIBC_NAMESPACE {
 

--- a/libc/src/wchar/wctob.cpp
+++ b/libc/src/wchar/wctob.cpp
@@ -10,7 +10,7 @@
 #include "src/__support/common.h"
 #include "src/__support/wctype_utils.h"
 
-#include <stdio.h> // for EOF.
+#include "hdr/stdio_macros.h" // for EOF.
 
 namespace LIBC_NAMESPACE {
 

--- a/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
@@ -138,6 +138,11 @@ libc_support_library(
     hdrs = ["hdr/float_macros.h"],
 )
 
+libc_support_library(
+    name = "hdr_stdio_macros",
+    hdrs = ["hdr/stdio_macros.h"],
+)
+
 ############################ Type Proxy Header Files ###########################
 
 libc_support_library(
@@ -178,6 +183,11 @@ libc_support_library(
 libc_support_library(
     name = "types_pid_t",
     hdrs = ["hdr/types/pid_t.h"],
+)
+
+libc_support_library(
+    name = "types_off_t",
+    hdrs = ["hdr/types/off_t.h"],
 )
 
 ############################### Support libraries ##############################
@@ -667,6 +677,8 @@ libc_support_library(
         ":__support_error_or",
         ":__support_threads_mutex",
         ":errno",
+        ":hdr_stdio_macros",
+        ":types_off_t",
     ],
 )
 
@@ -678,6 +690,7 @@ libc_support_library(
         ":__support_error_or",
         ":__support_osutil_syscall",
         ":errno",
+        ":types_off_t",
     ],
 )
 

--- a/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
@@ -190,6 +190,11 @@ libc_support_library(
     hdrs = ["hdr/types/off_t.h"],
 )
 
+libc_support_library(
+    name = "types_FILE",
+    hdrs = ["hdr/types/FILE.h"],
+)
+
 ############################### Support libraries ##############################
 
 libc_support_library(
@@ -3443,6 +3448,7 @@ libc_function(
         ":__support_arg_list",
         ":__support_file_file",
         ":errno",
+        ":types_FILE",
         ":vfprintf_internal",
     ],
 )
@@ -3455,6 +3461,7 @@ libc_function(
         ":__support_arg_list",
         ":__support_file_file",
         ":errno",
+        ":types_FILE",
         ":vfprintf_internal",
     ],
 )
@@ -3492,6 +3499,7 @@ libc_function(
         ":__support_arg_list",
         ":__support_file_file",
         ":errno",
+        ":types_FILE",
         ":vfprintf_internal",
     ],
 )
@@ -3504,6 +3512,7 @@ libc_function(
         ":__support_arg_list",
         ":__support_file_file",
         ":errno",
+        ":types_FILE",
         ":vfprintf_internal",
     ],
 )
@@ -3516,6 +3525,7 @@ libc_function(
         ":__support_common",
         ":__support_osutil_syscall",
         ":errno",
+        ":types_FILE",
     ],
 )
 


### PR DESCRIPTION
reland of https://github.com/llvm/llvm-project/pull/98215

Additionally adds proxy headers for FILE and the fopencookie types

The arm32 build has been failing due to redefinitions of the off_t type.
This patch fixes this by moving off_t to a proper proxy header. To do
this, it also moves stdio macros to a proxy header to hopefully avoid
including this proxy header alongside this public stdio.h.
