### PR TITLE
Default aarch64-min-jump-table-entries to 9

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64Subtarget.cpp
+++ b/llvm/lib/Target/AArch64/AArch64Subtarget.cpp
@@ -72,7 +72,7 @@ static cl::opt<AArch64PAuth::AuthCheckMethod>
                                cl::values(AUTH_CHECK_METHOD_CL_VALUES_LR));
 
 static cl::opt<unsigned> AArch64MinimumJumpTableEntries(
-    "aarch64-min-jump-table-entries", cl::init(13), cl::Hidden,
+    "aarch64-min-jump-table-entries", cl::init(9), cl::Hidden,
     cl::desc("Set minimum number of entries to use a jump table on AArch64"));
 
 unsigned AArch64Subtarget::getVectorInsertExtractBaseCost() const {


### PR DESCRIPTION
The previous experiment in https://github.com/llvm/llvm-project/pull/71166 set to 13 but the results weren't significantly better. Setting to 9


See #98223 for the motivation.