### PR TITLE
fix ConstantFoldFP128 params

### DIFF
--- a/llvm/lib/Analysis/ConstantFolding.cpp
+++ b/llvm/lib/Analysis/ConstantFolding.cpp
@@ -1784,7 +1784,7 @@ Constant *ConstantFoldFP(double (*NativeFP)(double), const APFloat &V,
 }
 
 #if defined(HAS_IEE754_FLOAT128) && defined(HAS_LOGF128)
-Constant *ConstantFoldFP128(long double (*NativeFP)(long double),
+Constant *ConstantFoldFP128(float128 (*NativeFP)(float128),
                             const APFloat &V, Type *Ty) {
   llvm_fenv_clearexcept();
   float128 Result = NativeFP(V.convertToQuad());

--- a/llvm/lib/Analysis/ConstantFolding.cpp
+++ b/llvm/lib/Analysis/ConstantFolding.cpp
@@ -1784,8 +1784,8 @@ Constant *ConstantFoldFP(double (*NativeFP)(double), const APFloat &V,
 }
 
 #if defined(HAS_IEE754_FLOAT128) && defined(HAS_LOGF128)
-Constant *ConstantFoldFP128(float128 (*NativeFP)(float128),
-                            const APFloat &V, Type *Ty) {
+Constant *ConstantFoldFP128(float128 (*NativeFP)(float128), const APFloat &V,
+                            Type *Ty) {
   llvm_fenv_clearexcept();
   float128 Result = NativeFP(V.convertToQuad());
   if (llvm_fenv_testexcept()) {


### PR DESCRIPTION
I ran into this error while building:
```
llvm/lib/Analysis/ConstantFolding.cpp:2129:16: error: no matching function for call to 'ConstantFoldFP128'
 2129 |         return ConstantFoldFP128(logf128, Op->getValueAPF(), Ty);
      |                ^~~~~~~~~~~~~~~~~
llvm/lib/Analysis/ConstantFolding.cpp:1787:11: note: candidate function not viable: no known conversion from '_Float128 (_Float128) throw()' (aka '__float128 (__float128) throw()') to 'long double (*)(long double)' for 1st argument
 1787 | Constant *ConstantFoldFP128(long double (*NativeFP)(long double),
      |           ^                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
1 error generated.
```

I'm pretty sure switching from `long double` to `float128` is correct here, and that certainly makes it work on my machine.

with glibc, logf128 is not available when compiling with clang and it is available with gcc. But, in llvm, has_float128 define isn't set unless you're using clang. So the combination of those means this block ~never actually gets used (unless you're doing something weird like I am).

This fixes what happens when this block is used, but doesn't address it actually being used.