### PR TITLE
[compiler-rt][test] Fix typo in stderr redirection

### DIFF
--- a/compiler-rt/test/msan/Linux/sigandorset.cpp
+++ b/compiler-rt/test/msan/Linux/sigandorset.cpp
@@ -1,6 +1,6 @@
 // RUN: %clangxx_msan -std=c++11 -O0 -g %s -o %t && not %run %t 2>&1 | FileCheck %s
 // RUN: %clangxx_msan -DLEFT_OK -std=c++11 -O0 -g %s -o %t && not %run %t 2>&1 | FileCheck %s
-// RUN: %clangxx_msan -DRIGHT_OK -std=c++11 -O0 -g %s -o %t && not %run %t 2<&1 | FileCheck %s
+// RUN: %clangxx_msan -DRIGHT_OK -std=c++11 -O0 -g %s -o %t && not %run %t 2>&1 | FileCheck %s
 // RUN: %clangxx_msan -DLEFT_OK -DRIGHT_OK -std=c++11 -O0 -g %s -o %t && %run %t
 // REQUIRES: !android
 


### PR DESCRIPTION
This patch fixes a typo in the RUN line where stderr should be redirected to stdout instead of the other way around.

Fixed https://github.com/llvm/llvm-project/issues/102385