### PR TITLE
[msan] Block signals during MsanThread::TSDDtor

### DIFF
--- a/compiler-rt/lib/msan/msan_linux.cpp
+++ b/compiler-rt/lib/msan/msan_linux.cpp
@@ -292,6 +292,7 @@ void MsanTSDDtor(void *tsd) {
     CHECK_EQ(0, pthread_setspecific(tsd_key, tsd));
     return;
   }
+  ScopedBlockSignals block(nullptr);
   msan_current_thread = nullptr;
   // Make sure that signal handler can not see a stale current thread pointer.
   atomic_signal_fence(memory_order_seq_cst);

--- a/compiler-rt/lib/msan/msan_thread.cpp
+++ b/compiler-rt/lib/msan/msan_thread.cpp
@@ -1,8 +1,8 @@
 
-#include "msan_thread.h"
-
 #include "msan.h"
+#include "msan_thread.h"
 #include "msan_interface_internal.h"
+
 #include "sanitizer_common/sanitizer_tls_get_addr.h"
 
 namespace __msan {

--- a/compiler-rt/lib/msan/msan_thread.cpp
+++ b/compiler-rt/lib/msan/msan_thread.cpp
@@ -1,8 +1,8 @@
 
-#include "msan.h"
 #include "msan_thread.h"
-#include "msan_interface_internal.h"
 
+#include "msan.h"
+#include "msan_interface_internal.h"
 #include "sanitizer_common/sanitizer_linux.h"
 #include "sanitizer_common/sanitizer_tls_get_addr.h"
 

--- a/compiler-rt/lib/msan/msan_thread.cpp
+++ b/compiler-rt/lib/msan/msan_thread.cpp
@@ -3,6 +3,7 @@
 #include "msan_thread.h"
 #include "msan_interface_internal.h"
 
+#include "sanitizer_common/sanitizer_linux.h"
 #include "sanitizer_common/sanitizer_tls_get_addr.h"
 
 namespace __msan {
@@ -56,6 +57,7 @@ void MsanThread::TSDDtor(void *tsd) {
 }
 
 void MsanThread::Destroy() {
+  ScopedBlockSignals block(nullptr);
   malloc_storage().CommitBack();
   // We also clear the shadow on thread destruction because
   // some code may still be executing in later TSD destructors

--- a/compiler-rt/lib/msan/msan_thread.cpp
+++ b/compiler-rt/lib/msan/msan_thread.cpp
@@ -3,7 +3,6 @@
 
 #include "msan.h"
 #include "msan_interface_internal.h"
-#include "sanitizer_common/sanitizer_linux.h"
 #include "sanitizer_common/sanitizer_tls_get_addr.h"
 
 namespace __msan {
@@ -57,7 +56,6 @@ void MsanThread::TSDDtor(void *tsd) {
 }
 
 void MsanThread::Destroy() {
-  ScopedBlockSignals block(nullptr);
   malloc_storage().CommitBack();
   // We also clear the shadow on thread destruction because
   // some code may still be executing in later TSD destructors

--- a/compiler-rt/lib/msan/msan_thread.cpp
+++ b/compiler-rt/lib/msan/msan_thread.cpp
@@ -57,7 +57,9 @@ void MsanThread::TSDDtor(void *tsd) {
 }
 
 void MsanThread::Destroy() {
+#if SANITIZER_LINUX
   ScopedBlockSignals block(nullptr);
+#endif
   malloc_storage().CommitBack();
   // We also clear the shadow on thread destruction because
   // some code may still be executing in later TSD destructors

--- a/compiler-rt/lib/msan/msan_thread.cpp
+++ b/compiler-rt/lib/msan/msan_thread.cpp
@@ -57,9 +57,7 @@ void MsanThread::TSDDtor(void *tsd) {
 }
 
 void MsanThread::Destroy() {
-#if SANITIZER_LINUX
   ScopedBlockSignals block(nullptr);
-#endif
   malloc_storage().CommitBack();
   // We also clear the shadow on thread destruction because
   // some code may still be executing in later TSD destructors


### PR DESCRIPTION
MSan may segfault inside a signal handler, if MSan instrumentation is trying to access thread-local storage that has already  been destroyed. This fixes the issue by blocking asychronous signals inside MsanThread::TSDDtor. This is based on an idea suggested by Paul Pluzhnikov (block async signals in MsanThread::Destroy()) and refined by Vitaly Buka.
    
Note: ed8565cf0b64ea5e88cc94f321b1870bb105d09d changed *BlockSignals to only block asynchronous signals, despite the name.
