### PR TITLE
[flang] Fix bad parse tree rewrite into a substring

### DIFF
--- a/flang/lib/Semantics/expression.cpp
+++ b/flang/lib/Semantics/expression.cpp
@@ -523,7 +523,7 @@ static std::optional<parser::Substring> FixMisparsedSubstringDataRef(
                   parser::GetLastName(arrElement.base).symbol}) {
             const Symbol &ultimate{symbol->GetUltimate()};
             if (const semantics::DeclTypeSpec *type{ultimate.GetType()}) {
-              if (!ultimate.IsObjectArray() &&
+              if (ultimate.Rank() == 0 &&
                   type->category() == semantics::DeclTypeSpec::Character) {
                 // The ambiguous S(j:k) was parsed as an array section
                 // reference, but it's now clear that it's a substring.


### PR DESCRIPTION
Data designators like "a(j:k)" are parsed into array section references, but once rank and type information is in hand, some of them turn out to actually be substring references.  The code that recognizes these cases was suffering from a "false positive" in the case of a construct entity in a SELECT RANK construct due to the use of a predicate member function (Symbol::IsObjectArray) that only works on ObjectEntityDetails symbols.  Fix the test to use the more general Symbol::Rank() member function.