### PR TITLE
fix assert in AArch64Arm64ECCallLowering.cpp

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64Arm64ECCallLowering.cpp
+++ b/llvm/lib/Target/AArch64/AArch64Arm64ECCallLowering.cpp
@@ -525,7 +525,7 @@ Function *AArch64Arm64ECCallLowering::buildEntryThunk(Function *F) {
   unsigned ThunkArgOffset = TransformDirectToSRet ? 2 : 1;
   unsigned PassthroughArgSize =
       (F->isVarArg() ? 5 : Thunk->arg_size()) - ThunkArgOffset;
-  assert(ArgTranslations.size() == F->isVarArg() ? 5 : PassthroughArgSize);
+  assert(ArgTranslations.size() == (F->isVarArg() ? 5 : PassthroughArgSize));
 
   // Translate arguments to call.
   SmallVector<Value *> Args;


### PR DESCRIPTION
The precedence of `==` operator is superior to `?:` operator. This line is evaluated as:

```cpp
assert((ArgTranslations.size() == F->isVarArg()) ? 5 : PassthroughArgSize);
```
I guess this is not what is wanted. This causes a warning with gcc:
```
[131/602] Building CXX object lib/Target/AArch64/CMakeFiles/LLVMAArch64CodeGen.dir/AArch64Arm64ECCallLowering.cpp.o
In file included from /usr/include/c++/11/cassert:44,
                 from /home/linux/dev/llvm-project/llvm/include/llvm/Support/CommandLine.h:33,
                 from /home/linux/dev/llvm-project/llvm/lib/Target/AArch64/AArch64Arm64ECCallLowering.cpp:31:
/home/linux/dev/llvm-project/llvm/lib/Target/AArch64/AArch64Arm64ECCallLowering.cpp: In member function ‘llvm::Function* {anonymous}::AArch64Arm64ECCallLowering::buildEntryThunk(llvm::Function*)’:
/home/linux/dev/llvm-project/llvm/lib/Target/AArch64/AArch64Arm64ECCallLowering.cpp:528:50: warning: ‘?:’ using integer constants in boolean context [-Wint-in-bool-context]
  528 |   assert(ArgTranslations.size() == F->isVarArg() ? 5 : PassthroughArgSize);
      |          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~
```
Add parenthesis to fix the problem.


