### PR TITLE
[bazel] Port #96596

### DIFF
--- a/utils/bazel/llvm-project-overlay/bolt/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/bolt/BUILD.bazel
@@ -133,6 +133,13 @@ cc_library(
 )
 
 cc_library(
+    name = "ProfileHeaders",
+    hdrs = glob(["include/bolt/Profile/*.h"]),
+    includes = ["include"],
+    visibility = ["//visibility:private"],
+)
+
+cc_library(
     name = "Profile",
     srcs = glob([
         "lib/Profile/*.cpp",
@@ -258,6 +265,7 @@ cc_library(
     ]),
     includes = ["include"],
     deps = [
+        ":ProfileHeaders",
         ":Utils",
         "//llvm:Analysis",
         "//llvm:BinaryFormat",


### PR DESCRIPTION
This change added a circular dependency in the profile and core headers,
so this splits out a target with just the headers for use by the core
library.
