### PR TITLE
[lldb][man][nfc] Don't register a markdown parser when building man packages

### DIFF
--- a/lldb/docs/conf.py
+++ b/lldb/docs/conf.py
@@ -89,8 +89,12 @@ templates_path = ["_templates"]
 # The suffix of source filenames.
 source_suffix = {
     ".rst": "restructuredtext",
-    ".md": "markdown",
 }
+
+# Man pages do not use markdown pages, so we don't need to register a markdown
+# parser.
+if not building_man_page:
+  source_suffix[".md"] = "markdown"
 
 # The encoding of source files.
 # source_encoding = 'utf-8-sig'

--- a/lldb/docs/conf.py
+++ b/lldb/docs/conf.py
@@ -94,7 +94,7 @@ source_suffix = {
 # Man pages do not use markdown pages, so we don't need to register a markdown
 # parser.
 if not building_man_page:
-  source_suffix[".md"] = "markdown"
+    source_suffix[".md"] = "markdown"
 
 # The encoding of source files.
 # source_encoding = 'utf-8-sig'

--- a/lldb/docs/conf.py
+++ b/lldb/docs/conf.py
@@ -64,6 +64,11 @@ myst_heading_slug_func = make_slug
 
 autodoc_default_options = {"special-members": True}
 
+# The suffix of source filenames.
+source_suffix = {
+    ".rst": "restructuredtext",
+}
+
 # Unless we only generate the basic manpage we need the plugin for generating
 # the Python API documentation.
 if not building_man_page:
@@ -83,18 +88,12 @@ if not building_man_page:
     # a list of builtin themes.
     html_theme = "furo"
 
+    # Since man pages do not use markdown, we do not need to register a markdown
+    # parser.
+    source_suffix[".md"] = "markdown"
+
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]
-
-# The suffix of source filenames.
-source_suffix = {
-    ".rst": "restructuredtext",
-}
-
-# Man pages do not use markdown pages, so we don't need to register a markdown
-# parser.
-if not building_man_page:
-    source_suffix[".md"] = "markdown"
 
 # The encoding of source files.
 # source_encoding = 'utf-8-sig'


### PR DESCRIPTION
This reduces Sphinx dependencies for building lldb man pages as lldb man pages don't use markdown.

