### PR TITLE
[RISCV][NFC] Add a newline when using --print-enabled-extensions

### DIFF
--- a/llvm/lib/TargetParser/RISCVISAInfo.cpp
+++ b/llvm/lib/TargetParser/RISCVISAInfo.cpp
@@ -151,7 +151,7 @@ void RISCVISAInfo::printEnabledExtensions(
 
   unsigned XLen = IsRV64 ? 64 : 32;
   if (auto ISAString = RISCVISAInfo::createFromExtMap(XLen, FullExtMap))
-    outs() << "\nISA String: " << ISAString.get()->toString();
+    outs() << "\nISA String: " << ISAString.get()->toString() << "\n";
 }
 
 static bool stripExperimentalPrefix(StringRef &Ext) {

--- a/llvm/unittests/TargetParser/RISCVISAInfoTest.cpp
+++ b/llvm/unittests/TargetParser/RISCVISAInfoTest.cpp
@@ -1080,7 +1080,8 @@ R"(Extensions enabled for the given RISC-V target
 Experimental extensions
     zicfilp              0.4       'Zicfilp' (Landing pad)
 
-ISA String: rv64i2p1_zicfilp0p4_zicsr2p0)";
+ISA String: rv64i2p1_zicfilp0p4_zicsr2p0
+)";
   // clang-format on
 
   StringMap<StringRef> DescMap;


### PR DESCRIPTION
The `--print-enabled-extensions` has been introduced in the https://github.com/llvm/llvm-project/pull/98207 , but it seems to be missing a newline in the end.
```shell
$ bin/clang --target=riscv64 --print-enabled-extensions
clang version 19.0.0git (https://github.com/sunshaoce/ssc-llvm.git 1b3e376ec0a77f7d7d20d0d32047678dafa142ae)
Target: riscv64
Thread model: posix
InstalledDir: /sw/sunshaoce/ssc-llvm/build/bin
Build config: +unoptimized, +assertions
Extensions enabled for the given RISC-V target

    Name                 Version   Description
    i                    2.1       'I' (Base Integer Instruction Set)
    m                    2.0       'M' (Integer Multiplication and Division)
    a                    2.1       'A' (Atomic Instructions)
    c                    2.0       'C' (Compressed Instructions)
    zmmul                1.0       'Zmmul' (Integer Multiplication)

Experimental extensions

ISA String: rv64i2p1_m2p0_a2p1_c2p0_zmmul1p0$
$
```