### PR TITLE
[clang] Do not allow unorderable features in [[gnu::target{,_clones}]]

### DIFF
--- a/clang/lib/Sema/SemaDecl.cpp
+++ b/clang/lib/Sema/SemaDecl.cpp
@@ -11108,7 +11108,9 @@ static bool CheckMultiVersionValue(Sema &S, const FunctionDecl *FD) {
       }
 
       if (!TargetInfo.validateCpuSupports(BareFeat) ||
-          !TargetInfo.isValidFeatureName(BareFeat)) {
+          !TargetInfo.isValidFeatureName(BareFeat) ||
+          (BareFeat != "default" &&
+           TargetInfo.multiVersionSortPriority(BareFeat) == 0)) {
         S.Diag(FD->getLocation(), diag::err_bad_multiversion_option)
             << Feature << BareFeat;
         return true;

--- a/clang/lib/Sema/SemaDecl.cpp
+++ b/clang/lib/Sema/SemaDecl.cpp
@@ -11109,8 +11109,7 @@ static bool CheckMultiVersionValue(Sema &S, const FunctionDecl *FD) {
 
       if (!TargetInfo.validateCpuSupports(BareFeat) ||
           !TargetInfo.isValidFeatureName(BareFeat) ||
-          (BareFeat != "default" &&
-           TargetInfo.multiVersionSortPriority(BareFeat) == 0)) {
+          (BareFeat != "default" && TargetInfo.getFMVPriority(BareFeat) == 0)) {
         S.Diag(FD->getLocation(), diag::err_bad_multiversion_option)
             << Feature << BareFeat;
         return true;

--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -3289,7 +3289,8 @@ bool Sema::checkTargetClonesAttrString(
       } else if (Cur == "default") {
         DefaultIsDupe = HasDefault;
         HasDefault = true;
-      } else if (!Context.getTargetInfo().isValidFeatureName(Cur))
+      } else if (!Context.getTargetInfo().isValidFeatureName(Cur) ||
+                 Context.getTargetInfo().multiVersionSortPriority(Cur) == 0)
         return Diag(CurLoc, diag::warn_unsupported_target_attribute)
                << Unsupported << None << Cur << TargetClones;
       if (llvm::is_contained(StringsBuffer, Cur) || DefaultIsDupe)

--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -3290,7 +3290,7 @@ bool Sema::checkTargetClonesAttrString(
         DefaultIsDupe = HasDefault;
         HasDefault = true;
       } else if (!Context.getTargetInfo().isValidFeatureName(Cur) ||
-                 Context.getTargetInfo().multiVersionSortPriority(Cur) == 0)
+                 Context.getTargetInfo().getFMVPriority(Cur) == 0)
         return Diag(CurLoc, diag::warn_unsupported_target_attribute)
                << Unsupported << None << Cur << TargetClones;
       if (llvm::is_contained(StringsBuffer, Cur) || DefaultIsDupe)

--- a/clang/test/Sema/attr-target-clones.c
+++ b/clang/test/Sema/attr-target-clones.c
@@ -122,3 +122,6 @@ void good_overload5(int) __attribute__((target_clones("mmx", "sse4.2", "default"
 void good_isa_level(int) __attribute__((target_clones("default", "arch=x86-64", "arch=x86-64-v2", "arch=x86-64-v3", "arch=x86-64-v4")));
 // expected-warning@+1 {{unsupported CPU 'x86-64-v5' in the 'target_clones' attribute string; 'target_clones' attribute ignored}}
 void bad_isa_level(int) __attribute__((target_clones("default", "arch=x86-64-v5")));
+
+// expected-warning@+1 {{unsupported 'sha' in the 'target_clones' attribute string; 'target_clones' attribute ignored}}
+void bad_feature(void) __attribute__((target_clones("default", "sse4.2", "sha")));

--- a/clang/test/Sema/attr-target-mv.c
+++ b/clang/test/Sema/attr-target-mv.c
@@ -170,3 +170,17 @@ int __attribute__((__overloadable__)) __attribute__((target("arch=sandybridge"))
 
 int __attribute__((__overloadable__)) __attribute__((target("sse4.2"))) good_overload7(void);
 int __attribute__((target("arch=sandybridge"))) good_overload7(int);
+
+// expected-error@+2 {{function multiversioning doesn't support feature 'sha'}}
+// expected-note@+2 {{function multiversioning caused by this declaration}}
+int __attribute__((target("sha"))) no_priority1(void);
+int __attribute__((target("default"))) no_priority1(void);
+
+int __attribute__((target("default"))) no_priority2(void);
+// expected-error@+1 {{function multiversioning doesn't support feature 'sha'}}
+int __attribute__((target("sha"))) no_priority2(void);
+
+int __attribute__((target("default"))) no_priority3(void);
+int __attribute__((target("avx2"))) no_priority3(void);
+// expected-error@+1 {{function multiversioning doesn't support feature 'sha'}}
+int __attribute__((target("sha"))) no_priority3(void);

--- a/clang/test/Sema/attr-target.c
+++ b/clang/test/Sema/attr-target.c
@@ -33,6 +33,8 @@ void __attribute__((target("x86-64"))) baseline(void) {}
 //expected-warning@+1 {{unsupported 'x86-64-v2' in the 'target' attribute string}}
 void __attribute__((target("x86-64-v2"))) v2(void) {}
 
+int __attribute__((target("sha"))) good_target_but_not_for_fmv() { return 5; }
+
 #elifdef __aarch64__
 
 int __attribute__((target("sve,arch=armv8-a"))) foo(void) { return 4; }


### PR DESCRIPTION
This partially addresses #98244.