### PR TITLE
[Clang] Don't crash if input file is not a module.

### DIFF
--- a/clang/include/clang/Basic/DiagnosticFrontendKinds.td
+++ b/clang/include/clang/Basic/DiagnosticFrontendKinds.td
@@ -226,7 +226,7 @@ def err_module_map_not_found : Error<"module map file '%0' not found">,
 def err_missing_module_name : Error<
   "no module name provided; specify one with -fmodule-name=">,
   DefaultFatal;
-def err_file_is_not_module : Error<"file '%0' is not a module">, DefaultFatal;
+def err_file_is_not_module : Error<"file '%0' is not a module file">, DefaultFatal;
 def err_missing_module : Error<
   "no module named '%0' declared in module map file '%1'">, DefaultFatal;
 def err_no_submodule : Error<"no submodule named %0 in module '%1'">;

--- a/clang/include/clang/Basic/DiagnosticFrontendKinds.td
+++ b/clang/include/clang/Basic/DiagnosticFrontendKinds.td
@@ -226,6 +226,7 @@ def err_module_map_not_found : Error<"module map file '%0' not found">,
 def err_missing_module_name : Error<
   "no module name provided; specify one with -fmodule-name=">,
   DefaultFatal;
+def err_file_is_not_module : Error<"file '%0' is not a module">, DefaultFatal;
 def err_missing_module : Error<
   "no module named '%0' declared in module map file '%1'">, DefaultFatal;
 def err_no_submodule : Error<"no submodule named %0 in module '%1'">;

--- a/clang/lib/Frontend/FrontendActions.cpp
+++ b/clang/lib/Frontend/FrontendActions.cpp
@@ -841,9 +841,15 @@ static StringRef ModuleKindName(Module::ModuleKind MK) {
 }
 
 void DumpModuleInfoAction::ExecuteAction() {
-  assert(isCurrentFileAST() && "dumping non-AST?");
-  // Set up the output file.
   CompilerInstance &CI = getCompilerInstance();
+
+  // Don't process files of type other than module to avoid crash
+  if (!isCurrentFileAST()) {
+    CI.getDiagnostics().Report(diag::err_file_is_not_module) << getCurrentFile();
+    return;
+  }
+
+  // Set up the output file.
   StringRef OutputFileName = CI.getFrontendOpts().OutputFile;
   if (!OutputFileName.empty() && OutputFileName != "-") {
     std::error_code EC;

--- a/clang/lib/Frontend/FrontendActions.cpp
+++ b/clang/lib/Frontend/FrontendActions.cpp
@@ -845,7 +845,8 @@ void DumpModuleInfoAction::ExecuteAction() {
 
   // Don't process files of type other than module to avoid crash
   if (!isCurrentFileAST()) {
-    CI.getDiagnostics().Report(diag::err_file_is_not_module) << getCurrentFile();
+    CI.getDiagnostics().Report(diag::err_file_is_not_module)
+        << getCurrentFile();
     return;
   }
 

--- a/clang/test/Frontend/module-file-info-not-a-module.c
+++ b/clang/test/Frontend/module-file-info-not-a-module.c
@@ -1,3 +1,3 @@
 // RUN: not %clang_cc1 -module-file-info %s 2>&1 | FileCheck %s
 
-// CHECK: fatal error: file '{{.*}}module-file-info-not-a-module.c' is not a module
+// CHECK: fatal error: file '{{.*}}module-file-info-not-a-module.c' is not a module file

--- a/clang/test/Frontend/module-file-info-not-a-module.c
+++ b/clang/test/Frontend/module-file-info-not-a-module.c
@@ -1,0 +1,3 @@
+// RUN: not %clang_cc1 -module-file-info %s 2>&1 | FileCheck %s
+
+// CHECK: fatal error: file '{{.*}}module-file-info-not-a-module.c' is not a module


### PR DESCRIPTION
Currently clang crashes with `-module-file-info` and input file which is not a module
Emit error instead of segfaulting.
Fix #98365