### PR TITLE
[LoongArch][clang] Modify `loongarch-msimd.c` to avoid `grep -o`. NFC

### DIFF
--- a/clang/test/Driver/loongarch-msimd.c
+++ b/clang/test/Driver/loongarch-msimd.c
@@ -2,128 +2,94 @@
 
 /// COM: -msimd=none
 // RUN: %clang --target=loongarch64 -mlasx -msimd=none -fsyntax-only %s -### 2>&1 | \
-// RUN:   grep -o '"-target-feature" "+[[:alnum:]]\+"' | sort -r | \
 // RUN:   FileCheck %s --check-prefixes=LSX,LASX
 // RUN: %clang --target=loongarch64 -mlasx -mlsx -msimd=none -fsyntax-only %s -### 2>&1 | \
-// RUN:   grep -o '"-target-feature" "+[[:alnum:]]\+"' | sort -r | \
 // RUN:   FileCheck %s --check-prefixes=LSX,LASX
 
 // RUN: %clang --target=loongarch64 -msimd=none -fsyntax-only %s -### 2>&1 | \
-// RUN:   grep -o '"-target-feature" "+[[:alnum:]]\+"' | sort -r | \
 // RUN:   FileCheck %s --check-prefixes=NOLSX,NOLASX
 // RUN: %clang --target=loongarch64 -mlasx -mno-lasx -msimd=none -fsyntax-only %s -### 2>&1 | \
-// RUN:   grep -o '"-target-feature" "+[[:alnum:]]\+"' | sort -r | \
 // RUN:   FileCheck %s --check-prefixes=NOLSX,NOLASX
 // RUN: %clang --target=loongarch64 -mlasx -mno-lasx -mlsx -mno-lsx -msimd=none -fsyntax-only %s -### 2>&1 | \
-// RUN:   grep -o '"-target-feature" "+[[:alnum:]]\+"' | sort -r | \
 // RUN:   FileCheck %s --check-prefixes=NOLSX,NOLASX
 // RUN: %clang --target=loongarch64 -mlasx -mno-lasx -mno-lsx -msimd=none -fsyntax-only %s -### 2>&1 | \
-// RUN:   grep -o '"-target-feature" "+[[:alnum:]]\+"' | sort -r | \
 // RUN:   FileCheck %s --check-prefixes=NOLSX,NOLASX
 // RUN: %clang --target=loongarch64 -mlsx -mno-lsx -msimd=none -fsyntax-only %s -### 2>&1 | \
-// RUN:   grep -o '"-target-feature" "+[[:alnum:]]\+"' | sort -r | \
 // RUN:   FileCheck %s --check-prefixes=NOLSX,NOLASX
 // RUN: %clang --target=loongarch64 -mno-lasx -msimd=none -fsyntax-only %s -### 2>&1 | \
-// RUN:   grep -o '"-target-feature" "+[[:alnum:]]\+"' | sort -r | \
 // RUN:   FileCheck %s --check-prefixes=NOLSX,NOLASX
 // RUN: %clang --target=loongarch64 -mno-lasx -mlsx -mno-lsx -msimd=none -fsyntax-only %s -### 2>&1 | \
-// RUN:   grep -o '"-target-feature" "+[[:alnum:]]\+"' | sort -r | \
 // RUN:   FileCheck %s --check-prefixes=NOLSX,NOLASX
 // RUN: %clang --target=loongarch64 -mno-lasx -mno-lsx -msimd=none -fsyntax-only %s -### 2>&1 | \
-// RUN:   grep -o '"-target-feature" "+[[:alnum:]]\+"' | sort -r | \
 // RUN:   FileCheck %s --check-prefixes=NOLSX,NOLASX
 // RUN: %clang --target=loongarch64 -mno-lsx -msimd=none -fsyntax-only %s -### 2>&1 | \
-// RUN:   grep -o '"-target-feature" "+[[:alnum:]]\+"' | sort -r | \
 // RUN:   FileCheck %s --check-prefixes=NOLSX,NOLASX
 
 // RUN: %clang --target=loongarch64 -mlasx -mno-lasx -mlsx -msimd=none -fsyntax-only %s -### 2>&1 | \
-// RUN:   grep -o '"-target-feature" "+[[:alnum:]]\+"' | sort -r | \
 // RUN:   FileCheck %s --check-prefixes=LSX,NOLASX
 // RUN: %clang --target=loongarch64 -mno-lasx -mlsx -msimd=none -fsyntax-only %s -### 2>&1 | \
-// RUN:   grep -o '"-target-feature" "+[[:alnum:]]\+"' | sort -r | \
 // RUN:   FileCheck %s --check-prefixes=LSX,NOLASX
 // RUN: %clang --target=loongarch64 -mlsx -msimd=none -fsyntax-only %s -### 2>&1 | \
-// RUN:   grep -o '"-target-feature" "+[[:alnum:]]\+"' | sort -r | \
 // RUN:   FileCheck %s --check-prefixes=LSX,NOLASX
 
 
 /// COM: -msimd=lsx
 // RUN: %clang --target=loongarch64 -mlasx -msimd=lsx -fsyntax-only %s -### 2>&1 | \
-// RUN:   grep -o '"-target-feature" "+[[:alnum:]]\+"' | sort -r | \
 // RUN:   FileCheck %s --check-prefixes=LSX,LASX
 // RUN: %clang --target=loongarch64 -mlasx -mlsx -msimd=lsx -fsyntax-only %s -### 2>&1 | \
-// RUN:   grep -o '"-target-feature" "+[[:alnum:]]\+"' | sort -r | \
 // RUN:   FileCheck %s --check-prefixes=LSX,LASX
 
 // RUN: %clang --target=loongarch64 -mlasx -mno-lasx -mno-lsx -msimd=lsx -fsyntax-only %s -### 2>&1 | \
-// RUN:   grep -o '"-target-feature" "+[[:alnum:]]\+"' | sort -r | \
 // RUN:   FileCheck %s --check-prefixes=NOLSX,NOLASX
 // RUN: %clang --target=loongarch64 -mlsx -mno-lsx -msimd=lsx -fsyntax-only %s -### 2>&1 | \
-// RUN:   grep -o '"-target-feature" "+[[:alnum:]]\+"' | sort -r | \
 // RUN:   FileCheck %s --check-prefixes=NOLSX,NOLASX
 // RUN: %clang --target=loongarch64 -mno-lasx -mlsx -mno-lsx -msimd=lsx -fsyntax-only %s -### 2>&1 | \
-// RUN:   grep -o '"-target-feature" "+[[:alnum:]]\+"' | sort -r | \
 // RUN:   FileCheck %s --check-prefixes=NOLSX,NOLASX
 // RUN: %clang --target=loongarch64 -mno-lasx -mno-lsx -msimd=lsx -fsyntax-only %s -### 2>&1 | \
-// RUN:   grep -o '"-target-feature" "+[[:alnum:]]\+"' | sort -r | \
 // RUN:   FileCheck %s --check-prefixes=NOLSX,NOLASX
 // RUN: %clang --target=loongarch64 -mno-lsx -msimd=lsx -fsyntax-only %s -### 2>&1 | \
-// RUN:   grep -o '"-target-feature" "+[[:alnum:]]\+"' | sort -r | \
 // RUN:   FileCheck %s --check-prefixes=NOLSX,NOLASX
 // RUN: %clang --target=loongarch64 -mlasx -mno-lasx -mlsx -mno-lsx -msimd=lsx -fsyntax-only %s -### 2>&1 | \
-// RUN:   grep -o '"-target-feature" "+[[:alnum:]]\+"' | sort -r | \
 // RUN:   FileCheck %s --check-prefixes=NOLSX,NOLASX
 
 // RUN: %clang --target=loongarch64 -msimd=lsx -fsyntax-only %s -### 2>&1 | \
-// RUN:   grep -o '"-target-feature" "+[[:alnum:]]\+"' | sort -r | \
 // RUN:   FileCheck %s --check-prefixes=LSX,NOLASX
 // RUN: %clang --target=loongarch64 -mlasx -mno-lasx -msimd=lsx -fsyntax-only %s -### 2>&1 | \
-// RUN:   grep -o '"-target-feature" "+[[:alnum:]]\+"' | sort -r | \
 // RUN:   FileCheck %s --check-prefixes=LSX,NOLASX
 // RUN: %clang --target=loongarch64 -mlsx -msimd=lsx -fsyntax-only %s -### 2>&1 | \
-// RUN:   grep -o '"-target-feature" "+[[:alnum:]]\+"' | sort -r | \
 // RUN:   FileCheck %s --check-prefixes=LSX,NOLASX
 // RUN: %clang --target=loongarch64 -mno-lasx -msimd=lsx -fsyntax-only %s -### 2>&1 | \
-// RUN:   grep -o '"-target-feature" "+[[:alnum:]]\+"' | sort -r | \
 // RUN:   FileCheck %s --check-prefixes=LSX,NOLASX
 // RUN: %clang --target=loongarch64 -mno-lasx -mlsx -msimd=lsx -fsyntax-only %s -### 2>&1 | \
-// RUN:   grep -o '"-target-feature" "+[[:alnum:]]\+"' | sort -r | \
 // RUN:   FileCheck %s --check-prefixes=LSX,NOLASX
 
 
 /// COM: -msimd=lasx
 // RUN: %clang --target=loongarch64 -msimd=lasx -fsyntax-only %s -### 2>&1 | \
-// RUN:   grep -o '"-target-feature" "+[[:alnum:]]\+"' | sort -r | \
 // RUN:   FileCheck %s --check-prefixes=LSX,LASX
 // RUN: %clang --target=loongarch64 -mlasx -msimd=lasx -fsyntax-only %s -### 2>&1 | \
-// RUN:   grep -o '"-target-feature" "+[[:alnum:]]\+"' | sort -r | \
 // RUN:   FileCheck %s --check-prefixes=LSX,LASX
 // RUN: %clang --target=loongarch64 -mlasx -mlsx -msimd=lasx -fsyntax-only %s -### 2>&1 | \
-// RUN:   grep -o '"-target-feature" "+[[:alnum:]]\+"' | sort -r | \
 // RUN:   FileCheck %s --check-prefixes=LSX,LASX
 // RUN: %clang --target=loongarch64 -mlsx -msimd=lasx -fsyntax-only %s -### 2>&1 | \
-// RUN:   grep -o '"-target-feature" "+[[:alnum:]]\+"' | sort -r | \
 // RUN:   FileCheck %s --check-prefixes=LSX,LASX
 
 // RUN: %clang --target=loongarch64 -mlasx -mno-lasx -msimd=lasx -fsyntax-only %s -### 2>&1 | \
-// RUN:   grep -o '"-target-feature" "+[[:alnum:]]\+"' | sort -r | \
 // RUN:   FileCheck %s --check-prefixes=NOLSX,NOLASX
 // RUN: %clang --target=loongarch64 -mno-lasx -msimd=lasx -fsyntax-only %s -### 2>&1 | \
-// RUN:   grep -o '"-target-feature" "+[[:alnum:]]\+"' | sort -r | \
 // RUN:   FileCheck %s --check-prefixes=NOLSX,NOLASX
 
 // RUN: %clang --target=loongarch64 -mlasx -mno-lasx -mlsx -msimd=lasx -fsyntax-only %s -### 2>&1 | \
-// RUN:   grep -o '"-target-feature" "+[[:alnum:]]\+"' | sort -r | \
 // RUN:   FileCheck %s --check-prefixes=LSX,NOLASX
 // RUN: %clang --target=loongarch64 -mno-lasx -mlsx -msimd=lasx -fsyntax-only %s -### 2>&1 | \
-// RUN:   grep -o '"-target-feature" "+[[:alnum:]]\+"' | sort -r | \
 // RUN:   FileCheck %s --check-prefixes=LSX,NOLASX
 // RUN: %clang --target=loongarch64 -mlasx -mno-lasx -mlsx -msimd=lsx -fsyntax-only %s -### 2>&1 | \
-// RUN:   grep -o '"-target-feature" "+[[:alnum:]]\+"' | sort -r | \
 // RUN:   FileCheck %s --check-prefixes=LSX,NOLASX
 
 
-// LSX: "-target-feature" "+lsx"
-// LASX: "-target-feature" "+lasx"
+// NOLSX-NOT: "-target-feature" "+lsx"
+// NOLASX-NOT: "-target-feature" "+lasx"
+// LSX-DAG: "-target-feature" "+lsx"
+// LASX-DAG: "-target-feature" "+lasx"
 // NOLSX-NOT: "-target-feature" "+lsx"
 // NOLASX-NOT: "-target-feature" "+lasx"


### PR DESCRIPTION
    https://lab.llvm.org/buildbot/#/builders/64/builds/250/steps/6/logs/FAIL__Clang__loongarch-msimd_c