### PR TITLE
[LLD] [COFF] Zero-intialization & proper constructor invocation in COFF's Symbol

### DIFF
--- a/lld/COFF/Symbols.h
+++ b/lld/COFF/Symbols.h
@@ -98,10 +98,10 @@ protected:
   friend SymbolTable;
   explicit Symbol(Kind k, StringRef n = "")
       : symbolKind(k), isExternal(true), isCOMDAT(false),
-        writtenToSymtab(false), pendingArchiveLoad(false), isGCRoot(false),
-        isRuntimePseudoReloc(false), deferUndefined(false), canInline(true),
-        isWeak(false), nameSize(n.size()),
-        nameData(n.empty() ? nullptr : n.data()) {
+        writtenToSymtab(false), isUsedInRegularObj(false),
+        pendingArchiveLoad(false), isGCRoot(false), isRuntimePseudoReloc(false),
+        deferUndefined(false), canInline(true), isWeak(false),
+        nameSize(n.size()), nameData(n.empty() ? nullptr : n.data()) {
     assert((!n.empty() || k <= LastDefinedCOFFKind) &&
            "If the name is empty, the Symbol must be a DefinedCOFF.");
   }
@@ -499,8 +499,10 @@ void replaceSymbol(Symbol *s, ArgT &&... arg) {
   assert(static_cast<Symbol *>(static_cast<T *>(nullptr)) == nullptr &&
          "Not a Symbol");
   bool canInline = s->canInline;
+  bool isUsedInRegularObj = s->isUsedInRegularObj;
   new (s) T(std::forward<ArgT>(arg)...);
   s->canInline = canInline;
+  s->isUsedInRegularObj = isUsedInRegularObj;
 }
 } // namespace coff
 


### PR DESCRIPTION
It happened due to lld's COFF linker multiple regression tests failure. It got reliably reproduced after the needed intialization of isUsedinRegularObject bit in the Symbol's ctor, but not handled at replaceSymbol API properly while creating a specific symbol to insert in symbol table. 

So, now while creating the specific symbol using replaceSymbol, by explicitly setting the value of isUsedinRegularObject to newly created symbol around the ctor call of symbol would solve the regression failure