### PR TITLE
NFC][BOLT] Rename createDummyReturnFunction to createReturnInstructi..

### DIFF
--- a/bolt/include/bolt/Core/MCPlusBuilder.h
+++ b/bolt/include/bolt/Core/MCPlusBuilder.h
@@ -2044,7 +2044,8 @@ public:
   /// Returns a function body that contains only a return instruction. An
   /// example usage is a workaround for the '__bolt_fini_trampoline' of
   // Instrumentation.
-  virtual InstructionListType createDummyReturnFunction(MCContext *Ctx) const {
+  virtual InstructionListType
+  createReturnInstructionList(MCContext *Ctx) const {
     InstructionListType Insts(1);
     createReturn(Insts[0]);
     return Insts;

--- a/bolt/lib/Passes/Instrumentation.cpp
+++ b/bolt/lib/Passes/Instrumentation.cpp
@@ -754,7 +754,7 @@ void Instrumentation::createAuxiliaryFunctions(BinaryContext &BC) {
       // with unknown symbol in runtime library. E.g. for static PIE
       // executable
       createSimpleFunction("__bolt_fini_trampoline",
-                           BC.MIB->createDummyReturnFunction(BC.Ctx.get()));
+                           BC.MIB->createReturnInstructionList(BC.Ctx.get()));
     }
   }
 }


### PR DESCRIPTION
`createDummyReturnFunction` is not creating a function but instead only
a function body that is simply a return statement.
This patch renames it to: `createReturnInstructionList`

---

Stacked on top of:
- #96626