### PR TITLE
[NFC][Clang] Move set functions out BranchProtectionInfo.

### DIFF
--- a/clang/include/clang/Basic/TargetInfo.h
+++ b/clang/include/clang/Basic/TargetInfo.h
@@ -32,9 +32,7 @@
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ADT/StringSet.h"
 #include "llvm/Frontend/OpenMP/OMPGridValues.h"
-#include "llvm/IR/Attributes.h"
 #include "llvm/IR/DerivedTypes.h"
-#include "llvm/IR/Function.h"
 #include "llvm/Support/DataTypes.h"
 #include "llvm/Support/Error.h"
 #include "llvm/Support/VersionTuple.h"
@@ -1410,7 +1408,6 @@ public:
     bool BranchProtectionPAuthLR;
     bool GuardedControlStack;
 
-  protected:
     const char *getSignReturnAddrStr() const {
       switch (SignReturnAddr) {
       case LangOptions::SignReturnAddressScopeKind::None:
@@ -1433,7 +1430,6 @@ public:
       llvm_unreachable("Unexpected SignReturnAddressKeyKind");
     }
 
-  public:
     BranchProtectionInfo()
         : SignReturnAddr(LangOptions::SignReturnAddressScopeKind::None),
           SignKey(LangOptions::SignReturnAddressKeyKind::AKey),
@@ -1453,25 +1449,6 @@ public:
       BranchTargetEnforcement = LangOpts.BranchTargetEnforcement;
       BranchProtectionPAuthLR = LangOpts.BranchProtectionPAuthLR;
       GuardedControlStack = LangOpts.GuardedControlStack;
-    }
-
-    void setFnAttributes(llvm::Function &F) {
-      llvm::AttrBuilder FuncAttrs(F.getContext());
-      setFnAttributes(FuncAttrs);
-      F.addFnAttrs(FuncAttrs);
-    }
-
-    void setFnAttributes(llvm::AttrBuilder &FuncAttrs) {
-      if (SignReturnAddr != LangOptions::SignReturnAddressScopeKind::None) {
-        FuncAttrs.addAttribute("sign-return-address", getSignReturnAddrStr());
-        FuncAttrs.addAttribute("sign-return-address-key", getSignKeyStr());
-      }
-      if (BranchTargetEnforcement)
-        FuncAttrs.addAttribute("branch-target-enforcement");
-      if (BranchProtectionPAuthLR)
-        FuncAttrs.addAttribute("branch-protection-pauth-lr");
-      if (GuardedControlStack)
-        FuncAttrs.addAttribute("guarded-control-stack");
     }
   };
 

--- a/clang/lib/CodeGen/TargetInfo.cpp
+++ b/clang/lib/CodeGen/TargetInfo.cpp
@@ -19,6 +19,7 @@
 #include "clang/CodeGen/CGFunctionInfo.h"
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/ADT/Twine.h"
+#include "llvm/IR/Function.h"
 #include "llvm/IR/Type.h"
 #include "llvm/Support/raw_ostream.h"
 
@@ -204,6 +205,28 @@ llvm::Value *TargetCodeGenInfo::createEnqueuedBlockKernel(
   Builder.CreateRetVoid();
   Builder.restoreIP(IP);
   return F;
+}
+
+void TargetCodeGenInfo::setFnAttributes(
+    const TargetInfo::BranchProtectionInfo &BPI, llvm::Function &F) const {
+  llvm::AttrBuilder FuncAttrs(F.getContext());
+  setFnAttributes(BPI, FuncAttrs);
+  F.addFnAttrs(FuncAttrs);
+}
+
+void TargetCodeGenInfo::setFnAttributes(
+    const TargetInfo::BranchProtectionInfo &BPI,
+    llvm::AttrBuilder &FuncAttrs) const {
+  if (BPI.SignReturnAddr != LangOptions::SignReturnAddressScopeKind::None) {
+    FuncAttrs.addAttribute("sign-return-address", BPI.getSignReturnAddrStr());
+    FuncAttrs.addAttribute("sign-return-address-key", BPI.getSignKeyStr());
+  }
+  if (BPI.BranchTargetEnforcement)
+    FuncAttrs.addAttribute("branch-target-enforcement");
+  if (BPI.BranchProtectionPAuthLR)
+    FuncAttrs.addAttribute("branch-protection-pauth-lr");
+  if (BPI.GuardedControlStack)
+    FuncAttrs.addAttribute("guarded-control-stack");
 }
 
 namespace {

--- a/clang/lib/CodeGen/TargetInfo.cpp
+++ b/clang/lib/CodeGen/TargetInfo.cpp
@@ -207,14 +207,14 @@ llvm::Value *TargetCodeGenInfo::createEnqueuedBlockKernel(
   return F;
 }
 
-void TargetCodeGenInfo::setFnAttributes(
+void TargetCodeGenInfo::setBranchProtectionFnAttributes(
     const TargetInfo::BranchProtectionInfo &BPI, llvm::Function &F) const {
   llvm::AttrBuilder FuncAttrs(F.getContext());
-  setFnAttributes(BPI, FuncAttrs);
+  setBranchProtectionFnAttributes(BPI, FuncAttrs);
   F.addFnAttrs(FuncAttrs);
 }
 
-void TargetCodeGenInfo::setFnAttributes(
+void TargetCodeGenInfo::setBranchProtectionFnAttributes(
     const TargetInfo::BranchProtectionInfo &BPI,
     llvm::AttrBuilder &FuncAttrs) const {
   if (BPI.SignReturnAddr != LangOptions::SignReturnAddressScopeKind::None) {

--- a/clang/lib/CodeGen/TargetInfo.cpp
+++ b/clang/lib/CodeGen/TargetInfo.cpp
@@ -208,7 +208,7 @@ llvm::Value *TargetCodeGenInfo::createEnqueuedBlockKernel(
 }
 
 void TargetCodeGenInfo::setBranchProtectionFnAttributes(
-    const TargetInfo::BranchProtectionInfo &BPI, llvm::Function &F) const {
+    const TargetInfo::BranchProtectionInfo &BPI, llvm::Function &F) {
   llvm::AttrBuilder FuncAttrs(F.getContext());
   setBranchProtectionFnAttributes(BPI, FuncAttrs);
   F.addFnAttrs(FuncAttrs);
@@ -216,7 +216,7 @@ void TargetCodeGenInfo::setBranchProtectionFnAttributes(
 
 void TargetCodeGenInfo::setBranchProtectionFnAttributes(
     const TargetInfo::BranchProtectionInfo &BPI,
-    llvm::AttrBuilder &FuncAttrs) const {
+    llvm::AttrBuilder &FuncAttrs) {
   if (BPI.SignReturnAddr != LangOptions::SignReturnAddressScopeKind::None) {
     FuncAttrs.addAttribute("sign-return-address", BPI.getSignReturnAddrStr());
     FuncAttrs.addAttribute("sign-return-address-key", BPI.getSignKeyStr());

--- a/clang/lib/CodeGen/TargetInfo.cpp
+++ b/clang/lib/CodeGen/TargetInfo.cpp
@@ -215,8 +215,7 @@ void TargetCodeGenInfo::setBranchProtectionFnAttributes(
 }
 
 void TargetCodeGenInfo::setBranchProtectionFnAttributes(
-    const TargetInfo::BranchProtectionInfo &BPI,
-    llvm::AttrBuilder &FuncAttrs) {
+    const TargetInfo::BranchProtectionInfo &BPI, llvm::AttrBuilder &FuncAttrs) {
   if (BPI.SignReturnAddr != LangOptions::SignReturnAddressScopeKind::None) {
     FuncAttrs.addAttribute("sign-return-address", BPI.getSignReturnAddrStr());
     FuncAttrs.addAttribute("sign-return-address-key", BPI.getSignKeyStr());

--- a/clang/lib/CodeGen/TargetInfo.h
+++ b/clang/lib/CodeGen/TargetInfo.h
@@ -15,11 +15,12 @@
 #define LLVM_CLANG_LIB_CODEGEN_TARGETINFO_H
 
 #include "CGBuilder.h"
-#include "CodeGenModule.h"
 #include "CGValue.h"
+#include "CodeGenModule.h"
 #include "clang/AST/Type.h"
 #include "clang/Basic/LLVM.h"
 #include "clang/Basic/SyncScope.h"
+#include "clang/Basic/TargetInfo.h"
 #include "llvm/ADT/SmallString.h"
 #include "llvm/ADT/StringRef.h"
 
@@ -412,6 +413,12 @@ public:
   virtual llvm::Type *getOpenCLType(CodeGenModule &CGM, const Type *T) const {
     return nullptr;
   }
+
+  void setFnAttributes(const TargetInfo::BranchProtectionInfo &BPI,
+                       llvm::Function &F) const;
+
+  void setFnAttributes(const TargetInfo::BranchProtectionInfo &BPI,
+                       llvm::AttrBuilder &FuncAttrs) const;
 
 protected:
   static std::string qualifyWindowsLibrary(StringRef Lib);

--- a/clang/lib/CodeGen/TargetInfo.h
+++ b/clang/lib/CodeGen/TargetInfo.h
@@ -414,13 +414,13 @@ public:
     return nullptr;
   }
 
-  void
+  static void
   setBranchProtectionFnAttributes(const TargetInfo::BranchProtectionInfo &BPI,
-                                  llvm::Function &F) const;
+                                  llvm::Function &F);
 
-  void
+  static void
   setBranchProtectionFnAttributes(const TargetInfo::BranchProtectionInfo &BPI,
-                                  llvm::AttrBuilder &FuncAttrs) const;
+                                  llvm::AttrBuilder &FuncAttrs);
 
 protected:
   static std::string qualifyWindowsLibrary(StringRef Lib);

--- a/clang/lib/CodeGen/TargetInfo.h
+++ b/clang/lib/CodeGen/TargetInfo.h
@@ -414,11 +414,13 @@ public:
     return nullptr;
   }
 
-  void setFnAttributes(const TargetInfo::BranchProtectionInfo &BPI,
-                       llvm::Function &F) const;
+  void
+  setBranchProtectionFnAttributes(const TargetInfo::BranchProtectionInfo &BPI,
+                                  llvm::Function &F) const;
 
-  void setFnAttributes(const TargetInfo::BranchProtectionInfo &BPI,
-                       llvm::AttrBuilder &FuncAttrs) const;
+  void
+  setBranchProtectionFnAttributes(const TargetInfo::BranchProtectionInfo &BPI,
+                                  llvm::AttrBuilder &FuncAttrs) const;
 
 protected:
   static std::string qualifyWindowsLibrary(StringRef Lib);

--- a/clang/lib/CodeGen/Targets/AArch64.cpp
+++ b/clang/lib/CodeGen/Targets/AArch64.cpp
@@ -133,7 +133,7 @@ public:
       }
     }
     auto *Fn = cast<llvm::Function>(GV);
-    BPI.setFnAttributes(*Fn);
+    CGM.getTargetCodeGenInfo().setFnAttributes(BPI, *Fn);
   }
 
   bool isScalarizableAsmOperand(CodeGen::CodeGenFunction &CGF,

--- a/clang/lib/CodeGen/Targets/AArch64.cpp
+++ b/clang/lib/CodeGen/Targets/AArch64.cpp
@@ -133,7 +133,7 @@ public:
       }
     }
     auto *Fn = cast<llvm::Function>(GV);
-    CGM.getTargetCodeGenInfo().setFnAttributes(BPI, *Fn);
+    setBranchProtectionFnAttributes(BPI, *Fn);
   }
 
   bool isScalarizableAsmOperand(CodeGen::CodeGenFunction &CGF,

--- a/clang/lib/CodeGen/Targets/ARM.cpp
+++ b/clang/lib/CodeGen/Targets/ARM.cpp
@@ -152,7 +152,7 @@ public:
               diag::warn_target_unsupported_branch_protection_attribute)
               << Arch;
         } else {
-          BPI.setFnAttributes(*Fn);
+          CGM.getTargetCodeGenInfo().setFnAttributes(BPI, (*Fn));
         }
       } else if (CGM.getLangOpts().BranchTargetEnforcement ||
                  CGM.getLangOpts().hasSignReturnAddress()) {
@@ -168,7 +168,7 @@ public:
     } else if (CGM.getTarget().isBranchProtectionSupportedArch(
                    CGM.getTarget().getTargetOpts().CPU)) {
       TargetInfo::BranchProtectionInfo BPI(CGM.getLangOpts());
-      BPI.setFnAttributes(*Fn);
+      CGM.getTargetCodeGenInfo().setFnAttributes(BPI, (*Fn));
     }
 
     const ARMInterruptAttr *Attr = FD->getAttr<ARMInterruptAttr>();

--- a/clang/lib/CodeGen/Targets/ARM.cpp
+++ b/clang/lib/CodeGen/Targets/ARM.cpp
@@ -152,7 +152,7 @@ public:
               diag::warn_target_unsupported_branch_protection_attribute)
               << Arch;
         } else {
-          CGM.getTargetCodeGenInfo().setFnAttributes(BPI, (*Fn));
+          setBranchProtectionFnAttributes(BPI, (*Fn));
         }
       } else if (CGM.getLangOpts().BranchTargetEnforcement ||
                  CGM.getLangOpts().hasSignReturnAddress()) {
@@ -168,7 +168,7 @@ public:
     } else if (CGM.getTarget().isBranchProtectionSupportedArch(
                    CGM.getTarget().getTargetOpts().CPU)) {
       TargetInfo::BranchProtectionInfo BPI(CGM.getLangOpts());
-      CGM.getTargetCodeGenInfo().setFnAttributes(BPI, (*Fn));
+      setBranchProtectionFnAttributes(BPI, (*Fn));
     }
 
     const ARMInterruptAttr *Attr = FD->getAttr<ARMInterruptAttr>();

--- a/clang/lib/CodeGen/Targets/ARM.cpp
+++ b/clang/lib/CodeGen/Targets/ARM.cpp
@@ -151,9 +151,8 @@ public:
               D->getLocation(),
               diag::warn_target_unsupported_branch_protection_attribute)
               << Arch;
-        } else {
+        } else
           setBranchProtectionFnAttributes(BPI, (*Fn));
-        }
       } else if (CGM.getLangOpts().BranchTargetEnforcement ||
                  CGM.getLangOpts().hasSignReturnAddress()) {
         // If the Branch Protection attribute is missing, validate the target


### PR DESCRIPTION
To reduce build times move them to TargetCodeGenInfo.
Refactor of #98329