### PR TITLE
[libc] Fix BigInt's operator %=

### DIFF
--- a/libc/src/__support/big_int.h
+++ b/libc/src/__support/big_int.h
@@ -732,7 +732,8 @@ public:
   }
 
   LIBC_INLINE constexpr BigInt operator%=(const BigInt &other) {
-    return *this->div(other);
+    *this = *this % other;
+    return *this;
   }
 
   LIBC_INLINE constexpr BigInt &operator*=(const BigInt &other) {


### PR DESCRIPTION
This patch fixes cases where we try to do var %= 1. Previously this operator was calling .div directly since it would perform the inplace division and return the remainder, however, as an early exit condition a division by one returns zero as the remainder. The remainder being returned by div was not being assigned to var.