### PR TITLE
[Clang] Correctly recognize unexpanded packs in lambda template params

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -103,7 +103,7 @@ ABI Changes in This Version
   ifuncs. Its purpose was to preserve backwards compatibility when the ".ifunc"
   suffix got removed from the name mangling. The alias interacts badly with
   GlobalOpt (see the issue #96197).
-  
+
 - Fixed Microsoft name mangling for auto non-type template arguments of pointer
   type for MSVC 1920+. This change resolves incompatibilities with code compiled
   by MSVC 1920+ but will introduce incompatibilities with code compiled by
@@ -1024,6 +1024,8 @@ Bug Fixes to C++ Support
 - Fixed a bug where references to lambda capture inside a ``noexcept`` specifier were not correctly
   instantiated. (#GH95735).
 - Fixed a CTAD substitution bug involving type aliases that reference outer template parameters. (#GH94614).
+- Clang now correctly handles unexpanded packs in the template parameter list of a generic lambda expression
+  (#GH48937)
 
 Bug Fixes to AST Handling
 ^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/clang/lib/Sema/SemaLambda.cpp
+++ b/clang/lib/Sema/SemaLambda.cpp
@@ -1380,6 +1380,8 @@ void Sema::ActOnLambdaClosureParameters(
     AddTemplateParametersToLambdaCallOperator(LSI->CallOperator, LSI->Lambda,
                                               TemplateParams);
     LSI->Lambda->setLambdaIsGeneric(true);
+    LSI->ContainsUnexpandedParameterPack |=
+        TemplateParams->containsUnexpandedParameterPack();
   }
   LSI->AfterParameterList = true;
 }

--- a/clang/test/SemaCXX/lambda-pack-expansion.cpp
+++ b/clang/test/SemaCXX/lambda-pack-expansion.cpp
@@ -20,3 +20,24 @@ void foo() {
   take_by_ref(x);
 }
 }
+
+namespace GH48937 {
+
+template <typename... Ts>
+consteval int f(Ts... ts) {
+  return ([]<Ts a = 42>(){ return a;}, ...)();
+}
+
+static_assert(f(0, 42) == 42);
+
+template <typename Ts>
+int g(Ts ts) {
+  return ([]<Ts a = 42>(){ return a;}, ...)();  // expected-error {{pack expansion does not contain any unexpanded parameter packs}}
+}
+
+template <typename... Ts>
+int h(Ts... ts) {
+  return ([]<Ts a = 42>(){ return a;})();  // expected-error {{expression contains unexpanded parameter pack 'Ts'}}
+}
+
+}


### PR DESCRIPTION
Fixes #48937
Fixes #49099