### PR TITLE
[flang] Fix broken atan_real16 test

### DIFF
--- a/flang/test/Lower/Intrinsics/atan_real16.f90
+++ b/flang/test/Lower/Intrinsics/atan_real16.f90
@@ -6,15 +6,15 @@
 function test_real16(x)
   real(16) :: x, test_real16
   test_real16 = atan(x)
-end function test_real16
+end function
 
 ! CHECK-LABEL: @_QPtest_real16
 ! CHECK: fir.call @_FortranAAtanF128({{.*}}){{.*}}: (f128) -> f128
 
 function test_real16_2(y, x)
-  real(16) :: y, x, test_real16
-  test_real16 = atan(y, x)
-end function test_real16_2
+  real(16) :: y, x, test_real16_2
+  test_real16_2 = atan(y, x)
+end function
 
-! CHECK-LABEL: @_QPtest_real16
+! CHECK-LABEL: @_QPtest_real16_2
 ! CHECK: fir.call @_FortranAAtan2F128({{.*}}){{.*}}: (f128, f128) -> f128

--- a/flang/test/Lower/Intrinsics/atan_real16.f90
+++ b/flang/test/Lower/Intrinsics/atan_real16.f90
@@ -6,7 +6,7 @@
 function test_real16(x)
   real(16) :: x, test_real16
   test_real16 = atan(x)
-end function real16
+end function test_real16
 
 ! CHECK-LABEL: @_QPtest_real16
 ! CHECK: fir.call @_FortranAAtanF128({{.*}}){{.*}}: (f128) -> f128
@@ -14,7 +14,7 @@ end function real16
 function test_real16_2(y, x)
   real(16) :: y, x, test_real16
   test_real16 = atan(y, x)
-end function real16_2
+end function test_real16_2
 
 ! CHECK-LABEL: @_QPtest_real16
 ! CHECK: fir.call @_FortranAAtan2F128({{.*}}){{.*}}: (f128, f128) -> f128


### PR DESCRIPTION
The names in the `end function` were incorrect. Those have been removed.