### PR TITLE
[mlir][tablegen] make enum parser optional

### DIFF
--- a/mlir/include/mlir/IR/EnumAttr.td
+++ b/mlir/include/mlir/IR/EnumAttr.td
@@ -168,6 +168,7 @@ class EnumAttrInfo<
 
   // Generate specialized Attribute class
   bit genSpecializedAttr = 1;
+  bit genParser = 1;
   // The underlying Attribute class, which holds the enum value
   Attr baseAttrClass = baseClass;
   // The name of specialized Enum Attribute class

--- a/mlir/include/mlir/TableGen/Attribute.h
+++ b/mlir/include/mlir/TableGen/Attribute.h
@@ -204,6 +204,7 @@ public:
   std::vector<EnumAttrCase> getAllCases() const;
 
   bool genSpecializedAttr() const;
+  bool genParser() const;
   llvm::Record *getBaseAttrClass() const;
   StringRef getSpecializedAttrClassName() const;
   bool printBitEnumPrimaryGroups() const;

--- a/mlir/lib/TableGen/Attribute.cpp
+++ b/mlir/lib/TableGen/Attribute.cpp
@@ -229,6 +229,8 @@ bool EnumAttr::genSpecializedAttr() const {
   return def->getValueAsBit("genSpecializedAttr");
 }
 
+bool EnumAttr::genParser() const { return def->getValueAsBit("genParser"); }
+
 llvm::Record *EnumAttr::getBaseAttrClass() const {
   return def->getValueAsDef("baseAttrClass");
 }

--- a/mlir/test/mlir-tblgen/enums-gen.td
+++ b/mlir/test/mlir-tblgen/enums-gen.td
@@ -101,3 +101,11 @@ def MyNonKeywordBitEnum: I32BitEnumAttr<"MyNonKeywordBitEnum", "An example bit e
 // DECL: inline ::llvm::raw_ostream &operator<<(::llvm::raw_ostream &p, ::MyNonKeywordBitEnum value) {
 // DECL:   auto valueStr = stringifyEnum(value);
 // DECL:   return p << '"' << valueStr << '"';
+
+def NoParserEnum: I32BitEnumAttr<"NoParserEnum", "An example enum with no parser emitted",
+                           [None, Bit0, Bit1, Bit2, Bit3, BitGroup]> {
+  let genParser = 0;
+}
+
+// DECL-NOT: struct FieldParser<::NoParserEnum, ::NoParserEnum>
+// DECL: inline ::llvm::raw_ostream &operator<<(::llvm::raw_ostream &p, ::NoParserEnum value)

--- a/mlir/tools/mlir-tblgen/EnumsGen.cpp
+++ b/mlir/tools/mlir-tblgen/EnumsGen.cpp
@@ -81,7 +81,7 @@ static void emitParserPrinter(const EnumAttr &enumAttr, StringRef qualName,
       nonKeywordCases.set(index);
 
   // Generate the parser and the start of the printer for the enum.
-  const char *parsedAndPrinterStart = R"(
+  const char *parser = R"(
 namespace mlir {
 template <typename T, typename>
 struct FieldParser;
@@ -103,13 +103,16 @@ struct FieldParser<{0}, {0}> {{
   }
 };
 } // namespace mlir
+)";
+  if (enumAttr.genParser())
+    os << formatv(parser, qualName, cppNamespace, enumAttr.getSummary());
 
+  const char *printerStart = R"(
 namespace llvm {
 inline ::llvm::raw_ostream &operator<<(::llvm::raw_ostream &p, {0} value) {{
   auto valueStr = stringifyEnum(value);
 )";
-  os << formatv(parsedAndPrinterStart, qualName, cppNamespace,
-                enumAttr.getSummary());
+  os << formatv(printerStart, qualName, cppNamespace, enumAttr.getSummary());
 
   // If all cases require a string, always wrap.
   if (nonKeywordCases.all()) {


### PR DESCRIPTION
Make parser emission opt-out. Reason/point: plenty of useful stuff emitted for enums even if you don't want to connect them to IR (like `llvm::raw_ostream &operator<<` and `DenseMapInfo`).

Precedent: we already have such opt-outs in `hasCustomAssemblyFormat` for various things.