### PR TITLE
[memprof] Switch allocator to dynamic base address

### DIFF
--- a/compiler-rt/lib/memprof/memprof_allocator.h
+++ b/compiler-rt/lib/memprof/memprof_allocator.h
@@ -46,11 +46,7 @@ struct MemprofMapUnmapCallback {
   void OnUnmap(uptr p, uptr size) const;
 };
 
-#if SANITIZER_APPLE
-constexpr uptr kAllocatorSpace = 0x600000000000ULL;
-#else
 constexpr uptr kAllocatorSpace = ~(uptr)0;
-#endif
 constexpr uptr kAllocatorSize = 0x40000000000ULL; // 4T.
 typedef DefaultSizeClassMap SizeClassMap;
 template <typename AddressSpaceViewTy>

--- a/compiler-rt/lib/memprof/memprof_allocator.h
+++ b/compiler-rt/lib/memprof/memprof_allocator.h
@@ -49,7 +49,7 @@ struct MemprofMapUnmapCallback {
 #if SANITIZER_APPLE
 constexpr uptr kAllocatorSpace = 0x600000000000ULL;
 #else
-constexpr uptr kAllocatorSpace = 0x500000000000ULL;
+constexpr uptr kAllocatorSpace = ~(uptr)0;
 #endif
 constexpr uptr kAllocatorSize = 0x40000000000ULL; // 4T.
 typedef DefaultSizeClassMap SizeClassMap;


### PR DESCRIPTION
memprof_rtl.cpp calls InitializeShadowMemory() - which dynamically/"randomly" chooses a base address for the shadow mapping - prior to InitializeAllocator(). If we are unlucky, the shadow memory may be mapped in the same region where the allocator wants to be.

This patch fixes the issue by changing the allocator to dynamically choosing a base address, as suggested by Vitaly. For comparison, HWASan already dynamically chooses the base addresses for the shadow mapping and allocator.

The "unlucky" failure was observed on a new buildbot: https://lab.llvm.org/buildbot/#/builders/66/builds/1361/steps/17/logs/stdio