### PR TITLE
[asan] Switch allocator to dynamic base address

### DIFF
--- a/compiler-rt/lib/asan/asan_allocator.h
+++ b/compiler-rt/lib/asan/asan_allocator.h
@@ -182,42 +182,38 @@ static_assert(SizeClassMap::kNumClassesRounded <= 32,
               "allocator size and SizeClassMap tunings that allows us to "
               "reliably run all bringup tests in a sanitized environment.");
 
-#    else
+#    else   // SANITIZER_RISCV64
 // These are the default allocator tunings for non-RISCV environments where the
 // VMA is usually 48 bits and we have lots of space.
 const uptr kAllocatorSize = 0x40000000000ULL;  // 4T.
 typedef DefaultSizeClassMap SizeClassMap;
-#    endif
-#  elif defined(__powerpc64__)
+#    endif  // SANITIZER_RISCV64
+#  else     // SANITIZER_FUCHSIA
 const uptr kAllocatorSpace = ~(uptr)0;
+#    if defined(__powerpc64__)
 const uptr kAllocatorSize  =  0x20000000000ULL;  // 2T.
 typedef DefaultSizeClassMap SizeClassMap;
-#  elif defined(__aarch64__) && SANITIZER_ANDROID
+#    elif defined(__aarch64__) && SANITIZER_ANDROID
 // Android needs to support 39, 42 and 48 bit VMA.
-const uptr kAllocatorSpace =  ~(uptr)0;
 const uptr kAllocatorSize  =  0x2000000000ULL;  // 128G.
 typedef VeryCompactSizeClassMap SizeClassMap;
-#  elif SANITIZER_RISCV64
-const uptr kAllocatorSpace = ~(uptr)0;
+#    elif SANITIZER_RISCV64
 const uptr kAllocatorSize = 0x2000000000ULL;  // 128G.
 typedef VeryDenseSizeClassMap SizeClassMap;
-#  elif defined(__sparc__)
-const uptr kAllocatorSpace = ~(uptr)0;
+#    elif defined(__sparc__)
 const uptr kAllocatorSize = 0x20000000000ULL;  // 2T.
 typedef DefaultSizeClassMap SizeClassMap;
-#  elif SANITIZER_WINDOWS
-const uptr kAllocatorSpace = ~(uptr)0;
+#    elif SANITIZER_WINDOWS
 const uptr kAllocatorSize  =  0x8000000000ULL;  // 500G
 typedef DefaultSizeClassMap SizeClassMap;
-#  elif SANITIZER_APPLE
-const uptr kAllocatorSpace = 0x600000000000ULL;
+#    elif SANITIZER_APPLE
 const uptr kAllocatorSize  =  0x40000000000ULL;  // 4T.
 typedef DefaultSizeClassMap SizeClassMap;
-#  else
-const uptr kAllocatorSpace = ~(uptr)0;
+#    else
 const uptr kAllocatorSize = 0x40000000000ULL;  // 4T.
 typedef DefaultSizeClassMap SizeClassMap;
-#  endif
+#    endif  // defined(__powerpc64__) etc.
+#  endif    // SANITIZER_FUCHSIA
 template <typename AddressSpaceViewTy>
 struct AP64 {  // Allocator64 parameters. Deliberately using a short name.
   static const uptr kSpaceBeg = kAllocatorSpace;
@@ -232,7 +228,7 @@ struct AP64 {  // Allocator64 parameters. Deliberately using a short name.
 template <typename AddressSpaceView>
 using PrimaryAllocatorASVT = SizeClassAllocator64<AP64<AddressSpaceView>>;
 using PrimaryAllocator = PrimaryAllocatorASVT<LocalAddressSpaceView>;
-#else  // Fallback to SizeClassAllocator32.
+#else   // SANITIZER_CAN_USE_ALLOCATOR64. Fallback to SizeClassAllocator32.
 typedef CompactSizeClassMap SizeClassMap;
 template <typename AddressSpaceViewTy>
 struct AP32 {

--- a/compiler-rt/lib/asan/asan_allocator.h
+++ b/compiler-rt/lib/asan/asan_allocator.h
@@ -214,7 +214,7 @@ const uptr kAllocatorSpace = 0x600000000000ULL;
 const uptr kAllocatorSize  =  0x40000000000ULL;  // 4T.
 typedef DefaultSizeClassMap SizeClassMap;
 #  else
-const uptr kAllocatorSpace = 0x500000000000ULL;
+const uptr kAllocatorSpace = ~(uptr)0;
 const uptr kAllocatorSize = 0x40000000000ULL;  // 4T.
 typedef DefaultSizeClassMap SizeClassMap;
 #  endif


### PR DESCRIPTION
This ports a fix from memprof (https://github.com/llvm/llvm-project/pull/98510), which has a shadow mapping that is similar to ASan (8 bytes of shadow memory per 64 bytes of app memory). This patch changes the allocator to dynamically choose a base address, as suggested by Vitaly for memprof. This simplifies ASan's #ifdef's and avoids potential conflict in the event that ASan were to switch to a dynamic shadow offset in the future [1].

[1] Since shadow memory is mapped before the allocator is mapped:
- dynamic shadow and fixed allocator (old memprof): could fail if
"unlucky" (e.g., https://lab.llvm.org/buildbot/#/builders/66/builds/1361/steps/17/logs/stdio)
- dynamic shadow and dynamic allocator (HWASan; current memprof): always works
- fixed shadow and fixed allocator (current ASan): always works, if
constants are carefully chosen
- fixed shadow and dynamic allocator (ASan with this patch): always works