### PR TITLE
[libc] fix fileno includes

### DIFF
--- a/libc/src/stdio/CMakeLists.txt
+++ b/libc/src/stdio/CMakeLists.txt
@@ -209,15 +209,6 @@ add_entrypoint_object(
     libc.src.stdio.printf_core.vfprintf_internal
 )
 
-add_stdio_entrypoint_object(
-  fileno
-  SRCS
-    fileno.cpp
-  HDRS
-    fileno.h
-  DEPENDS
-    libc.src.stdio.fileno
-)
 
 add_subdirectory(printf_core)
 add_subdirectory(scanf_core)
@@ -251,6 +242,7 @@ add_stdio_entrypoint_object(ferror_unlocked)
 add_stdio_entrypoint_object(fseek)
 add_stdio_entrypoint_object(ftell)
 add_stdio_entrypoint_object(fseeko)
+add_stdio_entrypoint_object(fileno)
 add_stdio_entrypoint_object(ftello)
 add_stdio_entrypoint_object(fflush)
 add_stdio_entrypoint_object(clearerr)

--- a/libc/src/stdio/fileno.h
+++ b/libc/src/stdio/fileno.h
@@ -1,5 +1,4 @@
-//===-- Implementation header of fileno --------------------------*- C++
-//-*-===//
+//===-- Implementation header of fileno -------------------------*- C++ -*-===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -10,7 +9,7 @@
 #ifndef LLVM_LIBC_SRC_STDIO_FILENO_H
 #define LLVM_LIBC_SRC_STDIO_FILENO_H
 
-#include "include/llvm-libc-types/FILE.h"
+#include "hdr/types/FILE.h"
 
 namespace LIBC_NAMESPACE {
 

--- a/libc/src/stdio/generic/fileno.cpp
+++ b/libc/src/stdio/generic/fileno.cpp
@@ -9,7 +9,7 @@
 
 #include "src/stdio/fileno.h"
 
-#include "include/llvm-libc-types/FILE.h"
+#include "hdr/types/FILE.h"
 #include "src/__support/File/file.h"
 
 namespace LIBC_NAMESPACE {


### PR DESCRIPTION
Fileno was directly including the FILE and so I missed it when replacing
all of the direct includes of stdio.h
