### PR TITLE
[libc] fix baremetal getchar

### DIFF
--- a/libc/src/stdio/baremetal/CMakeLists.txt
+++ b/libc/src/stdio/baremetal/CMakeLists.txt
@@ -5,7 +5,7 @@ add_entrypoint_object(
   HDRS
     ../getchar.h
   DEPENDS
-    libc.include.stdio
+    libc.hdr.stdio_macros
     libc.src.__support.OSUtil.osutil
     libc.src.__support.CPP.string_view
 )

--- a/libc/src/stdio/baremetal/getchar.cpp
+++ b/libc/src/stdio/baremetal/getchar.cpp
@@ -9,7 +9,7 @@
 #include "src/stdio/getchar.h"
 #include "src/__support/OSUtil/io.h"
 
-#include "hdr/types/FILE.h"
+#include "hdr/stdio_macros.h" // for EOF.
 
 namespace LIBC_NAMESPACE {
 


### PR DESCRIPTION
baremetal getchar got the wrong find/replace in the initial patch. This
patch fixes it.
