### PR TITLE
[lldb] Fix section printing to always align.

### DIFF
--- a/lldb/source/Core/Section.cpp
+++ b/lldb/source/Core/Section.cpp
@@ -275,7 +275,7 @@ bool Section::ContainsFileAddress(addr_t vm_addr) const {
 void Section::Dump(llvm::raw_ostream &s, unsigned indent, Target *target,
                    uint32_t depth) const {
   s.indent(indent);
-  s << llvm::format("0x%8.8" PRIx64 " %-16s ", GetID(), GetTypeAsCString());
+  s << llvm::format("0x%16.16" PRIx64 " %-22s ", GetID(), GetTypeAsCString());
   bool resolved = true;
   addr_t addr = LLDB_INVALID_ADDRESS;
 
@@ -642,14 +642,12 @@ void SectionList::Dump(llvm::raw_ostream &s, unsigned indent, Target *target,
   if (show_header && !m_sections.empty()) {
     s.indent(indent);
     s << llvm::formatv(
-        "SectID     Type             {0} Address                          "
-        "   Perm File Off.  File Size  Flags "
-        "     Section Name\n",
+        "SectID             Type                   {0} Address                "
+        "             Perm File Off.  File Size  Flags      Section Name\n",
         target_has_loaded_sections ? "Load" : "File");
     s.indent(indent);
-    s << "---------- ---------------- "
-         "---------------------------------------  ---- ---------- "
-         "---------- "
+    s << "------------------ ---------------------- "
+         "---------------------------------------  ---- ---------- ---------- "
          "---------- ----------------------------\n";
   }
 

--- a/lldb/test/Shell/Commands/command-target-modules-dump-sections.yaml
+++ b/lldb/test/Shell/Commands/command-target-modules-dump-sections.yaml
@@ -3,18 +3,18 @@
 # RUN:   | FileCheck --match-full-lines --strict-whitespace %s
 
 #      CHECK:Sections for '{{.*}}command-target-modules-dump-sections.yaml.tmp' (x86_64):
-# CHECK-NEXT:  SectID     Type             File Address                             Perm File Off.  File Size  Flags      Section Name
-# CHECK-NEXT:  ---------- ---------------- ---------------------------------------  ---- ---------- ---------- ---------- ----------------------------
-# CHECK-NEXT:  0x00000001 code             [0x0000000000004000-0x0000000000005000)  r-x  0x00001000 0x00001000 0x00000006 command-target-modules-dump-sections.yaml.tmp..text
-# CHECK-NEXT:  0x00000002 regular          [0x0000000000005000-0x0000000000005100)  r--  0x00002000 0x00000100 0x00000002 command-target-modules-dump-sections.yaml.tmp..rodata
-# CHECK-NEXT:  0x00000003 eh-frame         [0x0000000000006000-0x0000000000006040)  r--  0x00002100 0x00000040 0x00000002 command-target-modules-dump-sections.yaml.tmp..eh_frame
+# CHECK-NEXT:  SectID             Type                   File Address                             Perm File Off.  File Size  Flags      Section Name
+# CHECK-NEXT:  ------------------ ---------------------- ---------------------------------------  ---- ---------- ---------- ---------- ----------------------------
+# CHECK-NEXT:  0x0000000000000001 code                   [0x0000000000004000-0x0000000000005000)  r-x  0x00001000 0x00001000 0x00000006 command-target-modules-dump-sections.yaml.tmp..text
+# CHECK-NEXT:  0x0000000000000002 regular                [0x0000000000005000-0x0000000000005100)  r--  0x00002000 0x00000100 0x00000002 command-target-modules-dump-sections.yaml.tmp..rodata
+# CHECK-NEXT:  0x0000000000000003 eh-frame               [0x0000000000006000-0x0000000000006040)  r--  0x00002100 0x00000040 0x00000002 command-target-modules-dump-sections.yaml.tmp..eh_frame
 --- !ELF
-FileHeader:      
+FileHeader:
   Class:           ELFCLASS64
   Data:            ELFDATA2LSB
   Type:            ET_EXEC
   Machine:         EM_X86_64
-Sections:        
+Sections:
   - Name:            .text
     Type:            SHT_PROGBITS
     Flags:           [ SHF_ALLOC, SHF_EXECINSTR ]


### PR DESCRIPTION
Section IDs are 64 bit and if a section ID was over 4GB, then the tabular output of the "target modules dump sections" command would not align to the column headers. Also if the section type's name was too long, the output wouldn't algin. This patch fixes this issue.

Old output looked like:
```
(lldb) image dump sections a.out
Sections for '/tmp/a.out' (arm):
  SectID     Type             File Address                             Perm File Off.  File Size  Flags      Section Name
  ---------- ---------------- ---------------------------------------  ---- ---------- ---------- ---------- ----------------------------
  0xffffffffffffffff container        [0x0000000000001000-0x0000000000001010)  rw-  0x00000074 0x00000010 0x00000000 a.out.PT_LOAD[0]
  0x00000001 data             [0x0000000000001000-0x0000000000001010)  rw-  0x00000074 0x00000010 0x00000003 a.out.PT_LOAD[0]..data
  0xfffffffffffffffe container        [0x0000000000001000-0x0000000000001010)  rw-  0x00000084 0x00000000 0x00000000 a.out.PT_TLS[0]
  0x00000002 zero-fill        [0x0000000000001000-0x0000000000001010)  rw-  0x00000084 0x00000000 0x00000403 a.out.PT_TLS[0]..tbss
  0x00000003 regular                                                   ---  0x00000084 0x00000001 0x00000000 a.out..strtab
  0x00000004 regular                                                   ---  0x00000085 0x0000001f 0x00000000 a.out..shstrtab
```
New output looks like:
```
(lldb) image dump sections a.out
Sections for '/tmp/a.out' (arm):
  SectID             Type                   File Address                             Perm File Off.  File Size  Flags      Section Name
  ------------------ ---------------------- ---------------------------------------  ---- ---------- ---------- ---------- ----------------------------
  0xffffffffffffffff container              [0x0000000000001000-0x0000000000001010)  rw-  0x00000074 0x00000010 0x00000000 a.out.PT_LOAD[0]
  0x0000000000000001 data                   [0x0000000000001000-0x0000000000001010)  rw-  0x00000074 0x00000010 0x00000003 a.out.PT_LOAD[0]..data
  0xfffffffffffffffe container              [0x0000000000001000-0x0000000000001010)  rw-  0x00000084 0x00000000 0x00000000 a.out.PT_TLS[0]
  0x0000000000000002 zero-fill              [0x0000000000001000-0x0000000000001010)  rw-  0x00000084 0x00000000 0x00000403 a.out.PT_TLS[0]..tbss
  0x0000000000000003 regular                                                         ---  0x00000084 0x00000001 0x00000000 a.out..strtab
  0x0000000000000004 regular                                                         ---  0x00000085 0x0000001f 0x00000000 a.out..shstrtab
```