### PR TITLE
[libc] added grouping of guarded functions in header generation

### DIFF
--- a/libc/newhdrgen/class_implementation/classes/function.py
+++ b/libc/newhdrgen/class_implementation/classes/function.py
@@ -29,6 +29,4 @@ class Function:
             result = f"{self.return_type} {self.name}({arguments_str}) __NOEXCEPT;"
         else:
             result = f"{attributes_str} {self.return_type} {self.name}({arguments_str}) __NOEXCEPT;"
-        if self.guard:
-            result = f"#ifdef {self.guard}\n{result}\n#endif // {self.guard}"
         return result

--- a/libc/newhdrgen/header.py
+++ b/libc/newhdrgen/header.py
@@ -83,8 +83,7 @@ class HeaderFile:
         if current_guard != None:
             content.pop()
             content.append(f"#endif // {current_guard}")
-            content.append("")
-                                        
+            content.append("")      
 
         for object in self.objects:
             content.append(str(object))

--- a/libc/newhdrgen/header.py
+++ b/libc/newhdrgen/header.py
@@ -59,7 +59,6 @@ class HeaderFile:
 
         current_guard = None
         for function in self.functions:
-            # due to sorting, all guarded functions will be at the end
             if function.guard == None:
                 content.append(str(function))
                 content.append("")

--- a/libc/newhdrgen/header.py
+++ b/libc/newhdrgen/header.py
@@ -57,9 +57,35 @@ class HeaderFile:
 
         content.append("\n__BEGIN_C_DECLS\n")
 
+        current_guard = None
         for function in self.functions:
-            content.append(str(function))
+            # due to sorting, all guarded functions will be at the end
+            if function.guard == None:
+                content.append(str(function))
+                content.append("")
+            else:
+                if current_guard == None:
+                    current_guard = function.guard
+                    content.append(f"#ifdef {current_guard}")
+                    content.append(str(function))
+                    content.append("")
+                elif current_guard == function.guard:
+                    content.append(str(function))
+                    content.append("")
+                else:
+                    content.pop()
+                    content.append(f"#endif // {current_guard}")
+                    content.append("")
+                    current_guard = function.guard
+                    content.append(f"#ifdef {current_guard}")
+                    content.append(str(function))
+                    content.append("")
+        if current_guard != None:
+            content.pop()
+            content.append(f"#endif // {current_guard}")
             content.append("")
+                                        
+
         for object in self.objects:
             content.append(str(object))
         if self.objects:

--- a/libc/newhdrgen/tests/expected_output/test_header.h
+++ b/libc/newhdrgen/tests/expected_output/test_header.h
@@ -10,7 +10,9 @@
 #define LLVM_LIBC_TEST_SMALL_H
 
 #include "__llvm-libc-common.h"
+#include "llvm-libc-macros/float16-macros.h"
 #include "llvm-libc-macros/test_small-macros.h"
+#include "llvm-libc-types/float128.h"
 
 #define MACRO_A 1
 
@@ -26,13 +28,21 @@ enum {
 
 __BEGIN_C_DECLS
 
-#ifdef FUNC_A_16
 CONST_FUNC_A void func_a() __NOEXCEPT;
-#endif // FUNC_A_16
 
-#ifdef FUNC_B_16
-CONST_FUNC_B int func_b(int, float) __NOEXCEPT;
-#endif // FUNC_B_16
+#ifdef LIBC_TYPES_HAS_FLOAT128
+float128 func_b() __NOEXCEPT;
+#endif // LIBC_TYPES_HAS_FLOAT128
+
+#ifdef LIBC_TYPES_HAS_FLOAT16
+_Float16 func_c(int, float) __NOEXCEPT;
+
+_Float16 func_d(int, float) __NOEXCEPT;
+#endif // LIBC_TYPES_HAS_FLOAT16
+
+#ifdef LIBC_TYPES_HAS_FLOAT16_AND_FLOAT128
+_Float16 func_e(float128) __NOEXCEPT;
+#endif // LIBC_TYPES_HAS_FLOAT16_AND_FLOAT128
 
 extern obj object_1;
 extern obj object_2;

--- a/libc/newhdrgen/tests/input/test_small.h.def
+++ b/libc/newhdrgen/tests/input/test_small.h.def
@@ -10,7 +10,9 @@
 #define LLVM_LIBC_TEST_SMALL_H
 
 #include "__llvm-libc-common.h"
+#include "llvm-libc-macros/float16-macros.h"
 #include "llvm-libc-macros/test_small-macros.h"
+#include "llvm-libc-types/float128.h"
 
 %%public_api()
 

--- a/libc/newhdrgen/tests/input/test_small.yaml
+++ b/libc/newhdrgen/tests/input/test_small.yaml
@@ -23,16 +23,35 @@ functions:
     arguments: []
     standards: 
       - stdc
-    guard: FUNC_A_16
     attributes: 
       - CONST_FUNC_A
   - name: func_b
-    return_type: int
+    return_type: float128
+    arguments: []
+    standards: 
+      - stdc
+    guard: LIBC_TYPES_HAS_FLOAT128
+  - name: func_c
+    return_type: _Float16
     arguments:
       - type: int
       - type: float
     standards: 
       - stdc
-    guard: FUNC_B_16
-    attributes: 
-      - CONST_FUNC_B
+    guard: LIBC_TYPES_HAS_FLOAT16
+  - name: func_d
+    return_type: _Float16
+    arguments:
+      - type: int
+      - type: float
+    standards: 
+      - stdc
+    guard: LIBC_TYPES_HAS_FLOAT16
+  - name: func_e
+    return_type: _Float16
+    arguments:
+      - type: float128
+    standards: 
+      - stdc
+    guard: LIBC_TYPES_HAS_FLOAT16_AND_FLOAT128
+

--- a/libc/newhdrgen/tests/output/test_small.h
+++ b/libc/newhdrgen/tests/output/test_small.h
@@ -1,0 +1,52 @@
+//===-- C standard library header test_small-------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_TEST_SMALL_H
+#define LLVM_LIBC_TEST_SMALL_H
+
+#include "__llvm-libc-common.h"
+#include "llvm-libc-macros/float16-macros.h"
+#include "llvm-libc-macros/test_small-macros.h"
+#include "llvm-libc-types/float128.h"
+
+#define MACRO_A 1
+
+#define MACRO_B 2
+
+#include <llvm-libc-types/type_a.h>
+#include <llvm-libc-types/type_b.h>
+
+enum {
+  enum_a = value_1,
+  enum_b = value_2,
+};
+
+__BEGIN_C_DECLS
+
+CONST_FUNC_A void func_a() __NOEXCEPT;
+
+#ifdef LIBC_TYPES_HAS_FLOAT128
+float128 func_b() __NOEXCEPT;
+#endif // LIBC_TYPES_HAS_FLOAT128
+
+#ifdef LIBC_TYPES_HAS_FLOAT16
+_Float16 func_c(int, float) __NOEXCEPT;
+
+_Float16 func_d(int, float) __NOEXCEPT;
+#endif // LIBC_TYPES_HAS_FLOAT16
+
+#ifdef LIBC_TYPES_HAS_FLOAT16_AND_FLOAT128
+_Float16 func_e(float128) __NOEXCEPT;
+#endif // LIBC_TYPES_HAS_FLOAT16_AND_FLOAT128
+
+extern obj object_1;
+extern obj object_2;
+
+__END_C_DECLS
+
+#endif // LLVM_LIBC_TEST_SMALL_H


### PR DESCRIPTION
Instead of #ifdef guards for each individual function, #ifdef and #endif
will surround all functions that have the same guard.
