### PR TITLE
[libc] Fix atexit not getting linked on linux

### DIFF
--- a/libc/src/stdlib/CMakeLists.txt
+++ b/libc/src/stdlib/CMakeLists.txt
@@ -502,9 +502,9 @@ list(APPEND exit_deps
   ._Exit
 )
 if (NOT LIBC_TARGET_OS_IS_BAREMETAL)
-  # list(APPEND exit_deps
-  #   .atexit
-  # )
+  list(APPEND exit_deps
+    .atexit
+  )
 endif()
 
 add_entrypoint_object(

--- a/libc/src/stdlib/CMakeLists.txt
+++ b/libc/src/stdlib/CMakeLists.txt
@@ -497,6 +497,16 @@ add_entrypoint_object(
     .exit_handler
 )
 
+list(APPEND exit_deps
+  libc.src.__support.OSUtil.osutil
+  ._Exit
+)
+if (NOT LIBC_TARGET_OS_IS_BAREMETAL)
+  # list(APPEND exit_deps
+  #   .atexit
+  # )
+endif()
+
 add_entrypoint_object(
   exit
   SRCS
@@ -504,8 +514,7 @@ add_entrypoint_object(
   HDRS
     exit.h
   DEPENDS
-    ._Exit
-    libc.src.__support.OSUtil.osutil
+    ${exit_deps}
 )
 
 add_entrypoint_object(


### PR DESCRIPTION
Atexit needs to be linked into exit on linux since atexit defines
__cxa_finalize. This should probably be fixed a different way but this
works for now.
