### PR TITLE
[libc++] Add testing configurations for libstdc++ and a native stdlib

### DIFF
--- a/libcxx/test/configs/stdlib-libstdc++.cfg.in
+++ b/libcxx/test/configs/stdlib-libstdc++.cfg.in
@@ -1,0 +1,64 @@
+#
+# This testing configuration runs the test suite using the libstdc++ Standard library.
+#
+# The additional '--param libstdcxx-install-prefix=<PATH>', '--param libstdcxx-triple=<TRIPLE>' and
+# '--param libstdcxx-version=<VERSION>' lit parameters must be provided when invoking lit for the
+# configuration to find the appropriate headers and library.
+#
+# For example:
+#
+#  $ ./libcxx/utils/libcxx-lit <BUILD> -sv libcxx/test/std --param libstdcxx-install-prefix=/opt/homebrew/Cellar/gcc/14.1.0_1 \
+#                                                          --param libstdcxx-version=14 \
+#                                                          --param libstdcxx-triple=aarch64-apple-darwin22
+#
+
+lit_config.load_config(config, '@CMAKE_CURRENT_BINARY_DIR@/cmake-bridge.cfg')
+
+import os, site
+site.addsitedir(os.path.join('@LIBCXX_SOURCE_DIR@', 'utils'))
+import libcxx.test.params, libcxx.test.config, libcxx.test.dsl
+
+# Additional parameters for libstdc++
+LIBSTDCXX_PARAMETERS = [
+    libcxx.test.dsl.Parameter(name='libstdcxx-install-prefix', type=str,
+        actions=lambda path: [libcxx.test.dsl.AddSubstitution('%{libstdcxx-install-prefix}', path)],
+        help="""
+        The installation prefix where libstdc++ was installed. This is used to find the libstdc++ headers,
+        link against its built library, etc.
+        """),
+    libcxx.test.dsl.Parameter(name='libstdcxx-triple', type=str,
+        actions=lambda triple: [libcxx.test.dsl.AddSubstitution('%{libstdcxx-triple}', triple)],
+        help="""
+        The target triple used for the target-specific include directory of libstdc++. This is used to find the
+        libstdc++ headers.
+        """),
+    libcxx.test.dsl.Parameter(name='libstdcxx-version', type=str,
+        actions=lambda version: [libcxx.test.dsl.AddSubstitution('%{libstdcxx-version}', version)],
+        help="""
+        The version of libstdc++. This is used to find the libstdc++ headers and library.
+        """),
+]
+
+# Configure the compiler and flags
+config.substitutions.append(('%{flags}',
+    '-pthread' + (' -isysroot {}'.format('@CMAKE_OSX_SYSROOT@') if '@CMAKE_OSX_SYSROOT@' else '')
+))
+config.substitutions.append(('%{compile_flags}',
+    '-nostdinc++ -isystem %{libstdcxx-install-prefix}/include/c++/%{libstdcxx-version} -isystem %{libstdcxx-install-prefix}/include/c++/%{libstdcxx-version}/%{libstdcxx-triple} -I %{libcxx-dir}/test/support'
+))
+config.substitutions.append(('%{link_flags}',
+    '-nostdlib++ -L %{libstdcxx-install-prefix}/lib/gcc/%{libstdcxx-version} -Wl,-rpath,%{libstdcxx-install-prefix}/lib/gcc/%{libstdcxx-version} -lstdc++'
+))
+config.substitutions.append(('%{exec}',
+    '%{executor} --execdir %T -- '
+))
+
+import os, site
+site.addsitedir(os.path.join('@LIBCXX_SOURCE_DIR@', 'utils'))
+import libcxx.test.params, libcxx.test.config
+libcxx.test.config.configure(
+    libcxx.test.params.DEFAULT_PARAMETERS + LIBSTDCXX_PARAMETERS,
+    libcxx.test.features.DEFAULT_FEATURES,
+    config,
+    lit_config
+)

--- a/libcxx/test/configs/stdlib-native.cfg.in
+++ b/libcxx/test/configs/stdlib-native.cfg.in
@@ -1,0 +1,24 @@
+#
+# This testing configuration handles running the test suite against the
+# native C++ Standard Library, i.e. whatever standard library is used by
+# default when no special compiler flags are provided.
+#
+
+lit_config.load_config(config, '@CMAKE_CURRENT_BINARY_DIR@/cmake-bridge.cfg')
+
+config.substitutions.append(('%{flags}',
+    '-pthread' + (' -isysroot {}'.format('@CMAKE_OSX_SYSROOT@') if '@CMAKE_OSX_SYSROOT@' else '')
+))
+config.substitutions.append(('%{compile_flags}', '-I %{libcxx-dir}/test/support'))
+config.substitutions.append(('%{link_flags}', ''))
+config.substitutions.append(('%{exec}', '%{executor} --execdir %T -- '))
+
+import os, site
+site.addsitedir(os.path.join('@LIBCXX_SOURCE_DIR@', 'utils'))
+import libcxx.test.params, libcxx.test.config
+libcxx.test.config.configure(
+    libcxx.test.params.DEFAULT_PARAMETERS,
+    libcxx.test.features.DEFAULT_FEATURES,
+    config,
+    lit_config
+)


### PR DESCRIPTION
This allows running the test suite against the native Standard Library on most systems, and against libstdc++ installed at a custom location.

Of course, these configurations don't run 100% clean at the moment. In particular, running against the native stdlib is almost guaranteed not to work out-of-the-box, since the test suite generally contains tests for things that have been implemented on tip-of-trunk but not released to most major platforms yet. However, having an easy way to run the test suite against that library is still both useful and interesting.