### PR TITLE
[Clang] Fix parsing of invalid type-requirement

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -1029,6 +1029,7 @@ Bug Fixes to C++ Support
 - Fixed a CTAD substitution bug involving type aliases that reference outer template parameters. (#GH94614).
 - Clang now correctly handles unexpanded packs in the template parameter list of a generic lambda expression
   (#GH48937)
+- Fix a crash when parsing an invalid type-requirement in a requires expression. (#GH51868)
 
 Bug Fixes to AST Handling
 ^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/clang/lib/Sema/SemaTemplate.cpp
+++ b/clang/lib/Sema/SemaTemplate.cpp
@@ -11698,6 +11698,13 @@ Sema::ActOnTypenameType(Scope *S, SourceLocation TypenameLoc,
     // Construct a dependent template specialization type.
     assert(DTN && "dependent template has non-dependent name?");
     assert(DTN->getQualifier() == SS.getScopeRep());
+
+    if (!DTN->isIdentifier()) {
+      Diag(TemplateIILoc, diag::err_template_id_not_a_type) << Template;
+      NoteAllFoundTemplates(Template);
+      return true;
+    }
+
     QualType T = Context.getDependentTemplateSpecializationType(
         ElaboratedTypeKeyword::Typename, DTN->getQualifier(),
         DTN->getIdentifier(), TemplateArgs.arguments());

--- a/clang/test/Parser/cxx-concepts-requires-clause.cpp
+++ b/clang/test/Parser/cxx-concepts-requires-clause.cpp
@@ -195,3 +195,12 @@ void F() {
 int a = []<int=0> requires requires { [](auto){}; } { return 0; }();
 
 } // namespace GH78524
+
+
+namespace GH51868 {
+template<auto L>
+concept C = requires {
+  typename decltype(L)::template operator()<int>;
+  // expected-error@-1 {{template name refers to non-type template 'decltype(L)::template operator ()'}}
+};
+}


### PR DESCRIPTION
A type-requirement cannot be an operator-function-id

Fixes #51868