### PR TITLE
[libc] Disable hidden visibility for LIBC_NAMESPACE with GCC

### DIFF
--- a/libc/src/__support/macros/config.h
+++ b/libc/src/__support/macros/config.h
@@ -28,7 +28,7 @@
 #define LIBC_HAS_FEATURE(f) 0
 #endif
 
-#ifndef __GNUC__
+#ifdef __clang__
 // Declare a LIBC_NAMESPACE with hidden visibility. `namespace
 // LIBC_NAMESPACE_DECL {` should be used around all declarations and definitions
 // for libc internals as opposed to just `namespace LIBC_NAMESPACE {`. This

--- a/libc/src/__support/macros/config.h
+++ b/libc/src/__support/macros/config.h
@@ -28,6 +28,7 @@
 #define LIBC_HAS_FEATURE(f) 0
 #endif
 
+#ifndef __GNUC__
 // Declare a LIBC_NAMESPACE with hidden visibility. `namespace
 // LIBC_NAMESPACE_DECL {` should be used around all declarations and definitions
 // for libc internals as opposed to just `namespace LIBC_NAMESPACE {`. This
@@ -37,5 +38,10 @@
 // dynamic relocations. This does not affect the public C symbols which are
 // controlled independently via `LLVM_LIBC_FUNCTION_ATTR`.
 #define LIBC_NAMESPACE_DECL [[gnu::visibility("hidden")]] LIBC_NAMESPACE
+#else
+// TODO(#98548): GCC emits a warning when using the visibility attribute which
+// needs to be diagnosed and addressed.
+#define LIBC_NAMESPACE_DECL LIBC_NAMESPACE
+#endif
 
 #endif // LLVM_LIBC_SRC___SUPPORT_MACROS_CONFIG_H


### PR DESCRIPTION
GCC emits a warning when using the visibility attribute which needs to be diagnosed and addressed, but this change should unbreak the GCC build as a temporary workaround.

The issue is tracked as #98548.