### PR TITLE
[libc] Add missing dependency on src.__support.macros.config

### DIFF
--- a/libc/test/src/math/performance_testing/CMakeLists.txt
+++ b/libc/test/src/math/performance_testing/CMakeLists.txt
@@ -3,6 +3,7 @@ add_library(
   Timer.cpp
   Timer.h
 )
+add_dependencies(libc_diff_test_utils libc.src.__support.macros.config)
 
 # A convenience target to build all performance tests.
 add_custom_target(libc-math-performance-tests)


### PR DESCRIPTION
We automatically inject this dependency into all object libraries that use the libc CMake functions, but libc_diff_test_utils uses add_library so we need to add this dependency manually.