### PR TITLE
[libc] newheadergen: quick fixes to tests

### DIFF
--- a/libc/newhdrgen/header.py
+++ b/libc/newhdrgen/header.py
@@ -62,6 +62,9 @@ class HeaderFile:
             content.append("")
         for object in self.objects:
             content.append(str(object))
-        content.append("__END_C_DECLS")
+        if self.objects:
+            content.append("\n__END_C_DECLS")
+        else:
+            content.append("__END_C_DECLS")
 
         return "\n".join(content)

--- a/libc/newhdrgen/tests/expected_output/test_header.h
+++ b/libc/newhdrgen/tests/expected_output/test_header.h
@@ -27,11 +27,11 @@ enum {
 __BEGIN_C_DECLS
 
 #ifdef FUNC_A_16
-void func_a()CONST_FUNC_A;
+CONST_FUNC_A void func_a() __NOEXCEPT;
 #endif // FUNC_A_16
 
 #ifdef FUNC_B_16
-int func_b(int, float)CONST_FUNC_B;
+CONST_FUNC_B int func_b(int, float) __NOEXCEPT;
 #endif // FUNC_B_16
 
 extern obj object_1;

--- a/libc/newhdrgen/tests/input/test_small.yaml
+++ b/libc/newhdrgen/tests/input/test_small.yaml
@@ -24,7 +24,8 @@ functions:
     standards: 
       - stdc
     guard: FUNC_A_16
-    attributes: CONST_FUNC_A
+    attributes: 
+      - CONST_FUNC_A
   - name: func_b
     return_type: int
     arguments:
@@ -33,4 +34,5 @@ functions:
     standards: 
       - stdc
     guard: FUNC_B_16
-    attributes: CONST_FUNC_B
+    attributes: 
+      - CONST_FUNC_B


### PR DESCRIPTION
- if there is an object made there is a space after
- fixed tests.yaml -- spacing between characters issue
