### PR TITLE
Private process events were being delivered to the secondary listener

### DIFF
--- a/lldb/include/lldb/Target/Process.h
+++ b/lldb/include/lldb/Target/Process.h
@@ -465,6 +465,9 @@ public:
     static bool SetUpdateStateOnRemoval(Event *event_ptr);
 
   private:
+  
+    bool ForwardEventToPendingListeners(Event *event_ptr) override;
+
     void SetUpdateStateOnRemoval() { m_update_state++; }
 
     void SetRestarted(bool new_value) { m_restarted = new_value; }

--- a/lldb/include/lldb/Target/Process.h
+++ b/lldb/include/lldb/Target/Process.h
@@ -465,7 +465,6 @@ public:
     static bool SetUpdateStateOnRemoval(Event *event_ptr);
 
   private:
-  
     bool ForwardEventToPendingListeners(Event *event_ptr) override;
 
     void SetUpdateStateOnRemoval() { m_update_state++; }

--- a/lldb/include/lldb/Utility/Event.h
+++ b/lldb/include/lldb/Utility/Event.h
@@ -50,16 +50,14 @@ public:
 private:
   /// This will be queried for a Broadcaster with a primary and some secondary
   /// listeners after the primary listener pulled the event from the event queue
-  /// and ran its DoOnRemoval, right before the event is delivered.  
-  /// If it returns true, the event will also be forwarded to the secondary  
-  /// listeners, and if false, event propagation stops at the primary listener. 
+  /// and ran its DoOnRemoval, right before the event is delivered.
+  /// If it returns true, the event will also be forwarded to the secondary
+  /// listeners, and if false, event propagation stops at the primary listener.
   /// Some broadcasters (particularly the Process broadcaster) fetch events on
   /// a private Listener, and then forward the event to the Public Listeners
   /// after some processing.  The Process broadcaster does not want to forward
   /// to the secondary listeners at the private processing stage.
-  virtual bool ForwardEventToPendingListeners(Event *event_ptr) {
-    return true;
-  }
+  virtual bool ForwardEventToPendingListeners(Event *event_ptr) { return true; }
 
   virtual void DoOnRemoval(Event *event_ptr) {}
 

--- a/lldb/include/lldb/Utility/Event.h
+++ b/lldb/include/lldb/Utility/Event.h
@@ -48,6 +48,19 @@ public:
   virtual void Dump(Stream *s) const;
 
 private:
+  /// This will be queried for a Broadcaster with a primary and some secondary
+  /// listeners after the primary listener pulled the event from the event queue
+  /// and ran its DoOnRemoval, right before the event is delivered.  
+  /// If it returns true, the event will also be forwarded to the secondary  
+  /// listeners, and if false, event propagation stops at the primary listener. 
+  /// Some broadcasters (particularly the Process broadcaster) fetch events on
+  /// a private Listener, and then forward the event to the Public Listeners
+  /// after some processing.  The Process broadcaster does not want to forward
+  /// to the secondary listeners at the private processing stage.
+  virtual bool ForwardEventToPendingListeners(Event *event_ptr) {
+    return true;
+  }
+
   virtual void DoOnRemoval(Event *event_ptr) {}
 
   EventData(const EventData &) = delete;

--- a/lldb/source/Target/Process.cpp
+++ b/lldb/source/Target/Process.cpp
@@ -4248,7 +4248,21 @@ bool Process::ProcessEventData::ShouldStop(Event *event_ptr,
   return still_should_stop;
 }
 
+bool Process::ProcessEventData::ForwardEventToPendingListeners(Event *event_ptr) {
+  // STDIO and the other async event notifications should always be forwarded.
+  if (event_ptr->GetType() != Process::eBroadcastBitStateChanged)
+    return true;
+
+  // For state changed events, if the update state is one, we are handling 
+  // this on the private state thread.  We should wait for the public event.
+  return m_update_state == 1;
+}
+
 void Process::ProcessEventData::DoOnRemoval(Event *event_ptr) {
+  // We only have work to do for state changed events:
+  if (event_ptr->GetType() != Process::eBroadcastBitStateChanged)
+    return;
+
   ProcessSP process_sp(m_process_wp.lock());
 
   if (!process_sp)

--- a/lldb/source/Target/Process.cpp
+++ b/lldb/source/Target/Process.cpp
@@ -4248,12 +4248,13 @@ bool Process::ProcessEventData::ShouldStop(Event *event_ptr,
   return still_should_stop;
 }
 
-bool Process::ProcessEventData::ForwardEventToPendingListeners(Event *event_ptr) {
+bool Process::ProcessEventData::ForwardEventToPendingListeners(
+    Event *event_ptr) {
   // STDIO and the other async event notifications should always be forwarded.
   if (event_ptr->GetType() != Process::eBroadcastBitStateChanged)
     return true;
 
-  // For state changed events, if the update state is one, we are handling 
+  // For state changed events, if the update state is one, we are handling
   // this on the private state thread.  We should wait for the public event.
   return m_update_state == 1;
 }

--- a/lldb/source/Target/Process.cpp
+++ b/lldb/source/Target/Process.cpp
@@ -4254,7 +4254,7 @@ bool Process::ProcessEventData::ForwardEventToPendingListeners(
   if (event_ptr->GetType() != Process::eBroadcastBitStateChanged)
     return true;
 
-  // For state changed events, if the update state is one, we are handling
+  // For state changed events, if the update state is zero, we are handling
   // this on the private state thread.  We should wait for the public event.
   return m_update_state == 1;
 }

--- a/lldb/test/API/python_api/event/TestEvents.py
+++ b/lldb/test/API/python_api/event/TestEvents.py
@@ -345,10 +345,9 @@ class EventAPITestCase(TestBase):
                 self.assertEqual(
                     stop_hook.StopHook.counter[self.instance],
                     self.stop_counter,
-                    "matching stop hook"
+                    "matching stop hook",
                 )
-                
-            
+
         if expected_state is not None:
             self.assertEqual(
                 state, expected_state, "Primary thread got the correct event"
@@ -360,14 +359,10 @@ class EventAPITestCase(TestBase):
         self.assertTrue(success, "Shadow listener got event too")
         shadow_event_type = event.GetType()
         self.assertEqual(
-            primary_event_type,
-            shadow_event_type,
-            "It was the same event type"
-        ) 
+            primary_event_type, shadow_event_type, "It was the same event type"
+        )
         self.assertEqual(
-            state,
-            lldb.SBProcess.GetStateFromEvent(event),
-            "It was the same state"
+            state, lldb.SBProcess.GetStateFromEvent(event), "It was the same state"
         )
         self.assertEqual(
             restart,
@@ -415,9 +410,12 @@ class EventAPITestCase(TestBase):
         stop_hook_path = os.path.join(self.getSourceDir(), "stop_hook.py")
         self.runCmd(f"command script import {stop_hook_path}")
         import stop_hook
-        self.runCmd(f"target stop-hook add -P stop_hook.StopHook -k instance -v {self.instance}")
+
+        self.runCmd(
+            f"target stop-hook add -P stop_hook.StopHook -k instance -v {self.instance}"
+        )
         self.stop_counter = 0
-        
+
         self.process = target.Launch(launch_info, error)
         self.assertSuccess(error, "Process launched successfully")
 
@@ -427,13 +425,13 @@ class EventAPITestCase(TestBase):
         # Events in the launch sequence might be platform dependent, so don't
         # expect any particular event till we get the stopped:
         state = lldb.eStateInvalid
-        
+
         while state != lldb.eStateStopped:
             state, restart = self.wait_for_next_event(None, False)
-        
+
         # Okay, we're now at a good stop, so try a next:
         self.cur_thread = self.process.threads[0]
-        
+
         # Make sure we're at our expected breakpoint:
         self.assertTrue(self.cur_thread.IsValid(), "Got a zeroth thread")
         self.assertEqual(self.cur_thread.stop_reason, lldb.eStopReasonBreakpoint)
@@ -474,7 +472,6 @@ class EventAPITestCase(TestBase):
         # Put in a counter to make sure we don't spin forever if there is some
         # error in the logic.
         counter = 0
-        run_wo_stop = False
         while state != lldb.eStateExited:
             counter += 1
             self.assertLess(

--- a/lldb/test/API/python_api/event/TestEvents.py
+++ b/lldb/test/API/python_api/event/TestEvents.py
@@ -7,7 +7,7 @@ import lldb
 from lldbsuite.test.decorators import *
 from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
-
+import random
 
 @skipIfLinux  # llvm.org/pr25924, sometimes generating SIGSEGV
 class EventAPITestCase(TestBase):
@@ -20,6 +20,7 @@ class EventAPITestCase(TestBase):
         self.line = line_number(
             "main.c", '// Find the line number of function "c" here.'
         )
+        random.seed()
 
     @expectedFailureAll(
         oslist=["linux"], bugnumber="llvm.org/pr23730 Flaky, fails ~1/10 cases"
@@ -318,6 +319,7 @@ class EventAPITestCase(TestBase):
         """Wait for an event from self.primary & self.shadow listener.
         If test_shadow is true, we also check that the shadow listener only
         receives events AFTER the primary listener does."""
+        import stop_hook
         # Waiting on the shadow listener shouldn't have events yet because
         # we haven't fetched them for the primary listener yet:
         event = lldb.SBEvent()
@@ -328,13 +330,25 @@ class EventAPITestCase(TestBase):
 
         # But there should be an event for the primary listener:
         success = self.primary_listener.WaitForEvent(5, event)
+
         self.assertTrue(success, "Primary listener got the event")
 
         state = lldb.SBProcess.GetStateFromEvent(event)
+        primary_event_type = event.GetType()
         restart = False
         if state == lldb.eStateStopped:
             restart = lldb.SBProcess.GetRestartedFromEvent(event)
-
+            # This counter is matching the stop hooks, which don't get run
+            # for auto-restarting stops.
+            if not restart:
+                self.stop_counter += 1
+                self.assertEqual(
+                    stop_hook.StopHook.counter[self.instance],
+                    self.stop_counter,
+                    "matching stop hook"
+                )
+                
+            
         if expected_state is not None:
             self.assertEqual(
                 state, expected_state, "Primary thread got the correct event"
@@ -344,15 +358,22 @@ class EventAPITestCase(TestBase):
         # listener:
         success = self.shadow_listener.WaitForEvent(5, event)
         self.assertTrue(success, "Shadow listener got event too")
+        shadow_event_type = event.GetType()
         self.assertEqual(
-            state, lldb.SBProcess.GetStateFromEvent(event), "It was the same event"
+            primary_event_type,
+            shadow_event_type,
+            "It was the same event type"
+        ) 
+        self.assertEqual(
+            state,
+            lldb.SBProcess.GetStateFromEvent(event),
+            "It was the same state"
         )
         self.assertEqual(
             restart,
             lldb.SBProcess.GetRestartedFromEvent(event),
             "It was the same restarted",
         )
-
         return state, restart
 
     @expectedFlakeyLinux("llvm.org/pr23730")  # Flaky, fails ~1/100 cases
@@ -386,6 +407,17 @@ class EventAPITestCase(TestBase):
         )
         self.dbg.SetAsync(True)
 
+        # Now make our stop hook - we want to ensure it stays up to date with
+        # the events.  We can't get our hands on the stop-hook instance directly,
+        # so we'll pass in an instance key, and use that to retrieve the data from
+        # this instance of the stop hook:
+        self.instance = f"Key{random.randint(0,10000)}"
+        stop_hook_path = os.path.join(self.getSourceDir(), "stop_hook.py")
+        self.runCmd(f"command script import {stop_hook_path}")
+        import stop_hook
+        self.runCmd(f"target stop-hook add -P stop_hook.StopHook -k instance -v {self.instance}")
+        self.stop_counter = 0
+        
         self.process = target.Launch(launch_info, error)
         self.assertSuccess(error, "Process launched successfully")
 
@@ -395,12 +427,13 @@ class EventAPITestCase(TestBase):
         # Events in the launch sequence might be platform dependent, so don't
         # expect any particular event till we get the stopped:
         state = lldb.eStateInvalid
+        
         while state != lldb.eStateStopped:
             state, restart = self.wait_for_next_event(None, False)
-
+        
         # Okay, we're now at a good stop, so try a next:
         self.cur_thread = self.process.threads[0]
-
+        
         # Make sure we're at our expected breakpoint:
         self.assertTrue(self.cur_thread.IsValid(), "Got a zeroth thread")
         self.assertEqual(self.cur_thread.stop_reason, lldb.eStopReasonBreakpoint)
@@ -412,8 +445,6 @@ class EventAPITestCase(TestBase):
             self.cur_thread.GetStopReasonDataAtIndex(0),
             "Hit the right breakpoint",
         )
-        # Disable the first breakpoint so it doesn't get in the way...
-        bkpt1.SetEnabled(False)
 
         self.cur_thread.StepOver()
         # We'll run the test for "shadow listener blocked by primary listener
@@ -443,6 +474,7 @@ class EventAPITestCase(TestBase):
         # Put in a counter to make sure we don't spin forever if there is some
         # error in the logic.
         counter = 0
+        run_wo_stop = False
         while state != lldb.eStateExited:
             counter += 1
             self.assertLess(
@@ -450,4 +482,9 @@ class EventAPITestCase(TestBase):
             )
             if state == lldb.eStateStopped and not restarted:
                 self.process.Continue()
+
             state, restarted = self.wait_for_next_event(None, False)
+
+        # Now make sure we agree with the stop hook counter:
+        self.assertEqual(self.stop_counter, stop_hook.StopHook.counter[self.instance])
+        self.assertEqual(stop_hook.StopHook.non_stops[self.instance], 0, "No non stops")


### PR DESCRIPTION
This fixes a bug where Process events were being delivered to secondary listeners when the Private state thread listener was processing the event.  That meant the secondary listener could get an event before the Primary listener did.  That in turn meant the state when the secondary listener got the event wasn't right yet.  Plus it meant that the secondary listener saw more events than the primary (not all events get forwarded from the private to the public Process listener.)

This bug became much more evident when we had a stop hook that did some work, since that delays the Primary listener event delivery.  So I also added a stop-hook to the test, and put a little delay in as well.