### PR TITLE
[hwasan] Report unavalible fixed shadow range

### DIFF
--- a/compiler-rt/lib/hwasan/hwasan_linux.cpp
+++ b/compiler-rt/lib/hwasan/hwasan_linux.cpp
@@ -109,6 +109,15 @@ static void InitializeShadowBaseAddress(uptr shadow_size_bytes) {
   // FIXME: Android should init flags before shadow.
   if (!SANITIZER_ANDROID && flags()->fixed_shadow_base != (uptr)-1) {
     __hwasan_shadow_memory_dynamic_address = flags()->fixed_shadow_base;
+    uptr beg = __hwasan_shadow_memory_dynamic_address;
+    uptr end = beg + shadow_size_bytes;
+    if (!MemoryRangeIsAvailable(beg, end)) {
+      Report(
+          "FATAL: HWAddressSanitizer: Shadow range %p-%p is not available.\n",
+          (void *)beg, (void *)end);
+      DumpProcessMap();
+      CHECK(MemoryRangeIsAvailable(beg, end));
+    }
   } else {
     __hwasan_shadow_memory_dynamic_address =
         FindDynamicShadowStart(shadow_size_bytes);

--- a/compiler-rt/test/hwasan/TestCases/Linux/fixed-shadow.c
+++ b/compiler-rt/test/hwasan/TestCases/Linux/fixed-shadow.c
@@ -1,15 +1,19 @@
 // Test fixed shadow base functionality.
 //
 // Default compiler instrumentation works with any shadow base (dynamic or fixed).
-// RUN: %clang_hwasan %s -o %t && %run %t
-// RUN: %clang_hwasan %s -o %t && HWASAN_OPTIONS=fixed_shadow_base=263878495698944 %run %t
-// RUN: %clang_hwasan %s -o %t && HWASAN_OPTIONS=fixed_shadow_base=4398046511104 %run %t
+// RUN: %clang_hwasan %s -o %t
+// RUN: %run %t
+// RUN: HWASAN_OPTIONS=fixed_shadow_base=263878495698944 %run %t 2>%t.out || (cat %t.out | FileCheck %s)
+// RUN: HWASAN_OPTIONS=fixed_shadow_base=4398046511104 %run %t 2>%t.out || (cat %t.out | FileCheck %s)
 //
 // If -hwasan-mapping-offset is set, then the fixed_shadow_base needs to match.
-// RUN: %clang_hwasan %s -mllvm -hwasan-mapping-offset=263878495698944 -o %t && HWASAN_OPTIONS=fixed_shadow_base=263878495698944 %run %t
-// RUN: %clang_hwasan %s -mllvm -hwasan-mapping-offset=4398046511104 -o %t && HWASAN_OPTIONS=fixed_shadow_base=4398046511104 %run %t
-// RUN: %clang_hwasan %s -mllvm -hwasan-mapping-offset=263878495698944 -o %t && HWASAN_OPTIONS=fixed_shadow_base=4398046511104 not %run %t
-// RUN: %clang_hwasan %s -mllvm -hwasan-mapping-offset=4398046511104 -o %t && HWASAN_OPTIONS=fixed_shadow_base=263878495698944 not %run %t
+// RUN: %clang_hwasan %s -mllvm -hwasan-mapping-offset=263878495698944 -o %t
+// RUN: HWASAN_OPTIONS=fixed_shadow_base=263878495698944 %run %t 2>%t.out || (cat %t.out | FileCheck %s)
+// RUN: HWASAN_OPTIONS=fixed_shadow_base=4398046511104 not %run %t
+
+// RUN: %clang_hwasan %s -mllvm -hwasan-mapping-offset=4398046511104 -o %t
+// RUN: HWASAN_OPTIONS=fixed_shadow_base=4398046511104 %run %t 2>%t.out || (cat %t.out | FileCheck %s)
+// RUN: HWASAN_OPTIONS=fixed_shadow_base=263878495698944 not %run %t
 //
 // Note: if fixed_shadow_base is not set, compiler-rt will dynamically choose a
 // shadow base, which has a tiny but non-zero probability of matching the
@@ -22,8 +26,7 @@
 //
 // UNSUPPORTED: android
 
-// FIXME: SEGV on Ubuntu 24.04. Looking.
-// UNSUPPORTED: linux
+// CHECK: FATAL: HWAddressSanitizer: Shadow range {{.*}} is not available
 
 #include <assert.h>
 #include <sanitizer/allocator_interface.h>


### PR DESCRIPTION
Before the patch `fixed-shadow.c` test died with an obscure SEGV, 
because shadow was mapped over libc.so.

Note, FindDynamicShadowStart is expected to select in available region. 