### PR TITLE
[lld-link] Change /lldemit:llvm to use the pre-codegen module

### DIFF
--- a/lld/COFF/LTO.cpp
+++ b/lld/COFF/LTO.cpp
@@ -91,7 +91,7 @@ lto::Config BitcodeCompiler::createConfig() {
   c.TimeTraceGranularity = ctx.config.timeTraceGranularity;
 
   if (ctx.config.emit == EmitKind::LLVM) {
-    c.PostInternalizeModuleHook = [this](size_t task, const Module &m) {
+    c.PreCodeGenModuleHook = [this](size_t task, const Module &m) {
       if (std::unique_ptr<raw_fd_ostream> os =
               openLTOOutputFile(ctx.config.outputFile))
         WriteBitcodeToFile(m, *os, false);

--- a/lld/test/COFF/lto-emit-llvm.ll
+++ b/lld/test/COFF/lto-emit-llvm.ll
@@ -1,10 +1,11 @@
 ; REQUIRES: x86
-; RUN: llvm-as -o %T/lto.obj %s
+; RUN: rm -rf %t && mkdir %t
+; RUN: llvm-as -o %t/lto.obj %s
 
-; RUN: lld-link /lldemit:llvm /out:%T/lto.bc /entry:main /subsystem:console %T/lto.obj
-; RUN: llvm-dis %T/lto.bc -o - | FileCheck %s
+; RUN: lld-link /lldemit:llvm /out:%t/lto.bc /entry:main /subsystem:console %t/lto.obj
+; RUN: llvm-dis %t/lto.bc -o - | FileCheck %s
 
-; CHECK: define void @main()
+; CHECK: define void @main() local_unnamed_addr
 
 target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
 target triple = "x86_64-pc-windows-msvc"


### PR DESCRIPTION
This matches ELF (#97480). clang cc1 -emit-llvm and -emit-llvm-bc for
ThinLTO backend compilation also uses `PreCodeGenModuleHook`.

While here, replace deprecated %T with %t.
