### PR TITLE
[RISCV] Form VFWMUL.VF when fp_extend is scalar and then splatted.

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
+++ b/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
@@ -14303,6 +14303,13 @@ struct NodeExtensionHelper {
     case RISCVISD::VMV_V_X_VL:
       return DAG.getNode(RISCVISD::VMV_V_X_VL, DL, NarrowVT,
                          DAG.getUNDEF(NarrowVT), Source.getOperand(1), VL);
+    case RISCVISD::VFMV_V_F_VL:
+      Source = Source.getOperand(1);
+      assert(Source.getOpcode() == ISD::FP_EXTEND && "Unexpected source");
+      Source = Source.getOperand(0);
+      assert(Source.getValueType() == NarrowVT.getVectorElementType());
+      return DAG.getNode(RISCVISD::VFMV_V_F_VL, DL, NarrowVT,
+                         DAG.getUNDEF(NarrowVT), Source, VL);
     default:
       // Other opcodes can only come from the original LHS of VW(ADD|SUB)_W_VL
       // and that operand should already have the right NarrowVT so no
@@ -14460,7 +14467,7 @@ struct NodeExtensionHelper {
     if (ScalarBits < EltBits)
       return;
 
-    unsigned NarrowSize = VT.getScalarSizeInBits() / 2;
+    unsigned NarrowSize = EltBits / 2;
     // If the narrow type cannot be expressed with a legal VMV,
     // this is not a valid candidate.
     if (NarrowSize < 8)
@@ -14518,6 +14525,24 @@ struct NodeExtensionHelper {
     case RISCVISD::VMV_V_X_VL:
       fillUpExtensionSupportForSplat(Root, DAG, Subtarget);
       break;
+    case RISCVISD::VFMV_V_F_VL: {
+      MVT VT = OrigOperand.getSimpleValueType();
+
+      if (!OrigOperand.getOperand(0).isUndef())
+        break;
+
+      SDValue Op = OrigOperand.getOperand(1);
+      if (Op.getOpcode() != ISD::FP_EXTEND)
+        break;
+
+      unsigned NarrowSize = VT.getScalarSizeInBits() / 2;
+      unsigned ScalarBits = Op.getOperand(0).getValueSizeInBits();
+      if (NarrowSize != ScalarBits)
+        break;
+
+      SupportsFPExt = true;
+      break;
+    }
     default:
       break;
     }

--- a/llvm/test/CodeGen/RISCV/rvv/fixed-vectors-vfwadd.ll
+++ b/llvm/test/CodeGen/RISCV/rvv/fixed-vectors-vfwadd.ll
@@ -663,3 +663,31 @@ define <16 x double> @vfwadd_wf_v16f32(ptr %x, float %y) {
   %e = fadd <16 x double> %d, %a
   ret <16 x double> %e
 }
+
+define <2 x float> @vfwadd_vf2_v2f32(<2 x half> %x, half %y) {
+; CHECK-LABEL: vfwadd_vf2_v2f32:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    vsetivli zero, 2, e16, mf4, ta, ma
+; CHECK-NEXT:    vfwadd.vf v9, v8, fa0
+; CHECK-NEXT:    vmv1r.v v8, v9
+; CHECK-NEXT:    ret
+  %a = fpext <2 x half> %x to <2 x float>
+  %b = fpext half %y to float
+  %c = insertelement <2 x float> poison, float %b, i32 0
+  %d = shufflevector <2 x float> %c, <2 x float> poison, <2 x i32> zeroinitializer
+  %e = fadd <2 x float> %a, %d
+  ret <2 x float> %e
+}
+
+define <2 x float> @vfwadd_wf2_v2f32(<2 x float> %x, half %y) {
+; CHECK-LABEL: vfwadd_wf2_v2f32:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    vsetivli zero, 2, e16, mf4, ta, ma
+; CHECK-NEXT:    vfwadd.wf v8, v8, fa0
+; CHECK-NEXT:    ret
+  %b = fpext half %y to float
+  %c = insertelement <2 x float> poison, float %b, i32 0
+  %d = shufflevector <2 x float> %c, <2 x float> poison, <2 x i32> zeroinitializer
+  %e = fadd <2 x float> %x, %d
+  ret <2 x float> %e
+}

--- a/llvm/test/CodeGen/RISCV/rvv/fixed-vectors-vfwmul.ll
+++ b/llvm/test/CodeGen/RISCV/rvv/fixed-vectors-vfwmul.ll
@@ -448,3 +448,18 @@ define <2 x double> @vfwmul_squared_v2f16_v2f64(ptr %x) {
   %c = fmul <2 x double> %b, %b
   ret <2 x double> %c
 }
+
+define <2 x float> @vfwmacc_vf_nxv1f32(<2 x half> %x, half %y) {
+; CHECK-LABEL: vfwmacc_vf_nxv1f32:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    vsetivli zero, 2, e16, mf4, ta, ma
+; CHECK-NEXT:    vfwmul.vf v9, v8, fa0
+; CHECK-NEXT:    vmv1r.v v8, v9
+; CHECK-NEXT:    ret
+  %a = fpext <2 x half> %x to <2 x float>
+  %b = fpext half %y to float
+  %c = insertelement <2 x float> poison, float %b, i32 0
+  %d = shufflevector <2 x float> %c, <2 x float> poison, <2 x i32> zeroinitializer
+  %e = fmul <2 x float> %a, %d
+  ret <2 x float> %e
+}

--- a/llvm/test/CodeGen/RISCV/rvv/fixed-vectors-vfwmul.ll
+++ b/llvm/test/CodeGen/RISCV/rvv/fixed-vectors-vfwmul.ll
@@ -449,8 +449,8 @@ define <2 x double> @vfwmul_squared_v2f16_v2f64(ptr %x) {
   ret <2 x double> %c
 }
 
-define <2 x float> @vfwmacc_vf_nxv1f32(<2 x half> %x, half %y) {
-; CHECK-LABEL: vfwmacc_vf_nxv1f32:
+define <2 x float> @vfwmul_vf2_v2f32(<2 x half> %x, half %y) {
+; CHECK-LABEL: vfwmul_vf2_v2f32:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    vsetivli zero, 2, e16, mf4, ta, ma
 ; CHECK-NEXT:    vfwmul.vf v9, v8, fa0


### PR DESCRIPTION
Previously we only supported the extend being in the vector domain after the splat.