### PR TITLE
[test] Add triple in test introduced in #98317

### DIFF
--- a/llvm/test/CodeGen/X86/machine-block-freq.mir
+++ b/llvm/test/CodeGen/X86/machine-block-freq.mir
@@ -1,4 +1,4 @@
-# RUN: llc --passes='print<machine-block-freq>' -filetype=null 2>&1 %s | FileCheck %s
+# RUN: llc -mtriple=x86_64-gnu-linux --passes='print<machine-block-freq>' -filetype=null 2>&1 %s | FileCheck %s
 
 ---
 name:            is_odd


### PR DESCRIPTION
Missing `-mtriple` in test, causes failure on some none x86 default targets.