### PR TITLE
[Clang][Driver] Warn about `-c/-S` with `-fsyntax-only`

### DIFF
--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -794,10 +794,6 @@ static void addPGOAndCoverageFlags(const ToolChain &TC, Compilation &C,
       Args.hasArg(options::OPT_coverage))
     FProfileDir = Args.getLastArg(options::OPT_fprofile_dir);
 
-  // TODO: Don't claim -c/-S to warn about -fsyntax-only -c/-S, -E -c/-S,
-  // like we warn about -fsyntax-only -E.
-  (void)(Args.hasArg(options::OPT_c) || Args.hasArg(options::OPT_S));
-
   // Put the .gcno and .gcda files (if needed) next to the primary output file,
   // or fall back to a file in the current directory for `clang -c --coverage
   // d/a.c` in the absence of -o.

--- a/clang/test/Driver/warn-fsyntax-only-c-S.c
+++ b/clang/test/Driver/warn-fsyntax-only-c-S.c
@@ -1,0 +1,9 @@
+// RUN: %clang -fsyntax-only -S %s 2>&1 | FileCheck %s --check-prefix=CHECK-ASM
+// RUN: %clang -fsyntax-only -c %s 2>&1 | FileCheck %s --check-prefix=CHECK-OBJ
+// RUN: %clang -fsyntax-only -S -c %s 2>&1 | FileCheck %s --check-prefix=CHECK-BOTH
+
+// CHECK-ASM: warning: argument unused during compilation: '-S' [-Wunused-command-line-argument]
+// CHECK-OBJ: warning: argument unused during compilation: '-c' [-Wunused-command-line-argument]
+
+// CHECK-BOTH: warning: argument unused during compilation: '-S' [-Wunused-command-line-argument]
+// CHECK-NEXT: warning: argument unused during compilation: '-c' [-Wunused-command-line-argument]

--- a/clang/test/Driver/warn-fsyntax-only.c
+++ b/clang/test/Driver/warn-fsyntax-only.c
@@ -1,9 +1,8 @@
+// RUN: %clang -fsyntax-only -E %s 2>&1 | FileCheck %s --check-prefix=CHECK-PP
 // RUN: %clang -fsyntax-only -S %s 2>&1 | FileCheck %s --check-prefix=CHECK-ASM
 // RUN: %clang -fsyntax-only -c %s 2>&1 | FileCheck %s --check-prefix=CHECK-OBJ
-// RUN: %clang -fsyntax-only -S -c %s 2>&1 | FileCheck %s --check-prefix=CHECK-BOTH
 
+// CHECK-PP:  warning: argument unused during compilation: '-fsyntax-only' [-Wunused-command-line-argument]
 // CHECK-ASM: warning: argument unused during compilation: '-S' [-Wunused-command-line-argument]
 // CHECK-OBJ: warning: argument unused during compilation: '-c' [-Wunused-command-line-argument]
 
-// CHECK-BOTH: warning: argument unused during compilation: '-S' [-Wunused-command-line-argument]
-// CHECK-NEXT: warning: argument unused during compilation: '-c' [-Wunused-command-line-argument]

--- a/clang/test/Driver/warn-fsyntax-only.c
+++ b/clang/test/Driver/warn-fsyntax-only.c
@@ -5,4 +5,3 @@
 // CHECK-PP:  warning: argument unused during compilation: '-fsyntax-only' [-Wunused-command-line-argument]
 // CHECK-ASM: warning: argument unused during compilation: '-S' [-Wunused-command-line-argument]
 // CHECK-OBJ: warning: argument unused during compilation: '-c' [-Wunused-command-line-argument]
-


### PR DESCRIPTION
Emit warning that `-S` and/or `-c` arguments are not used if `-fsyntax-only` is also passed to clang
`addPGOAndCoverageFlags` is not the right place
to produce this warning
Now `-fsyntax-only -c/-S` combination handles like `-fsyntax-only -E` in `BuildJobs()` driver function