### PR TITLE
[BasicAA] Use nuw attribute of GEPs

### DIFF
--- a/llvm/include/llvm/Analysis/BasicAliasAnalysis.h
+++ b/llvm/include/llvm/Analysis/BasicAliasAnalysis.h
@@ -122,7 +122,8 @@ private:
   bool isValueEqualInPotentialCycles(const Value *V1, const Value *V2,
                                      const AAQueryInfo &AAQI);
 
-  void subtractDecomposedGEPs(DecomposedGEP &DestGEP, DecomposedGEP &SrcGEP,
+  void subtractDecomposedGEPs(DecomposedGEP &DestGEP,
+                              const DecomposedGEP &SrcGEP,
                               const AAQueryInfo &AAQI);
 
   AliasResult aliasGEP(const GEPOperator *V1, LocationSize V1Size,

--- a/llvm/include/llvm/Analysis/BasicAliasAnalysis.h
+++ b/llvm/include/llvm/Analysis/BasicAliasAnalysis.h
@@ -122,8 +122,7 @@ private:
   bool isValueEqualInPotentialCycles(const Value *V1, const Value *V2,
                                      const AAQueryInfo &AAQI);
 
-  void subtractDecomposedGEPs(DecomposedGEP &DestGEP,
-                              const DecomposedGEP &SrcGEP,
+  void subtractDecomposedGEPs(DecomposedGEP &DestGEP, DecomposedGEP &SrcGEP,
                               const AAQueryInfo &AAQI);
 
   AliasResult aliasGEP(const GEPOperator *V1, LocationSize V1Size,

--- a/llvm/lib/Analysis/BasicAliasAnalysis.cpp
+++ b/llvm/lib/Analysis/BasicAliasAnalysis.cpp
@@ -563,10 +563,10 @@ struct BasicAAResult::DecomposedGEP {
     dbgs() << "\n";
   }
   void print(raw_ostream &OS) const {
-    OS << "(DecomposedGEP Base=" << Base->getName()
-       << ", inbounds=" << (NWFlags.isInBounds() ? "1" : "0")
+    OS << ", inbounds=" << (NWFlags.isInBounds() ? "1" : "0")
        << ", nuw=" << (NWFlags.hasNoUnsignedWrap() ? "1" : "0")
-       << ", Offset=" << Offset << ", VarIndices=[";
+       << "(DecomposedGEP Base=" << Base->getName() << ", Offset=" << Offset
+       << ", VarIndices=[";
     for (size_t i = 0; i < VarIndices.size(); i++) {
       if (i != 0)
         OS << ", ";

--- a/llvm/lib/Analysis/BasicAliasAnalysis.cpp
+++ b/llvm/lib/Analysis/BasicAliasAnalysis.cpp
@@ -1259,7 +1259,7 @@ AliasResult BasicAAResult::aliasGEP(
 
     bool IndicesFromRight = DecompGEP1.VarIndices.front().IsNegated == Swapped;
     if (IndicesFromRight && DecompRight.NWFlags->hasNoUnsignedWrap())
-      if (!VLeftSize.isScalable() && VLeftSize.hasValue() &&
+      if (VLeftSize.hasValue() && !VLeftSize.isScalable() &&
           Off.abs().uge(VLeftSize.getValue()))
         return AliasResult::NoAlias;
   }

--- a/llvm/lib/Analysis/BasicAliasAnalysis.cpp
+++ b/llvm/lib/Analysis/BasicAliasAnalysis.cpp
@@ -556,7 +556,7 @@ struct BasicAAResult::DecomposedGEP {
   // Scaled variable (non-constant) indices.
   SmallVector<VariableGEPIndex, 4> VarIndices;
   // Nowrap flags common to all GEP operations involved in expression.
-  GEPNoWrapFlags NWFlags = GEPNoWrapFlags::none();
+  GEPNoWrapFlags NWFlags = GEPNoWrapFlags::all();
 
   void dump() const {
     print(dbgs());
@@ -591,8 +591,6 @@ BasicAAResult::DecomposeGEPExpression(const Value *V, const DataLayout &DL,
   unsigned MaxLookup = MaxLookupSearchDepth;
   SearchTimes++;
   const Instruction *CxtI = dyn_cast<Instruction>(V);
-
-  bool SeenGEPNWFlags = false;
 
   unsigned MaxIndexSize = DL.getMaxIndexSizeInBits();
   DecomposedGEP Decomposed;
@@ -647,12 +645,7 @@ BasicAAResult::DecomposeGEPExpression(const Value *V, const DataLayout &DL,
     }
 
     // Track the common nowrap flags for all GEPs we see.
-    if (SeenGEPNWFlags) {
-      Decomposed.NWFlags &= GEPOp->getNoWrapFlags();
-    } else {
-      Decomposed.NWFlags = GEPOp->getNoWrapFlags();
-      SeenGEPNWFlags = true;
-    }
+    Decomposed.NWFlags &= GEPOp->getNoWrapFlags();
 
     assert(GEPOp->getSourceElementType()->isSized() && "GEP must be sized");
 

--- a/llvm/test/Analysis/BasicAA/gep-nuw-alias.ll
+++ b/llvm/test/Analysis/BasicAA/gep-nuw-alias.ll
@@ -1,7 +1,5 @@
 ; RUN: opt < %s -aa-pipeline=basic-aa -passes=aa-eval -print-all-alias-modref-info -disable-output 2>&1 | FileCheck %s
 
-target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
-
 ; CHECK-LABEL: test_no_lower_bound
 ;
 ; CHECK-DAG: MayAlias: i32* %a, i32* %b

--- a/llvm/test/Analysis/BasicAA/gep-nuw-alias.ll
+++ b/llvm/test/Analysis/BasicAA/gep-nuw-alias.ll
@@ -1,0 +1,142 @@
+; RUN: opt < %s -aa-pipeline=basic-aa -passes=aa-eval -print-all-alias-modref-info -disable-output 2>&1 | FileCheck %s
+
+target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
+
+; CHECK-LABEL: test_no_lower_bound
+;
+; CHECK-DAG: MayAlias: i32* %a, i32* %b
+define void @test_no_lower_bound(ptr %p, i64 %i) {
+  %a = getelementptr i8, ptr %p, i64 4
+  %b = getelementptr nuw i8, ptr %p, i64 %i
+
+  load i32, ptr %a
+  load i32, ptr %b
+
+  ret void
+}
+
+; CHECK-LABEL: test_lower_bound_lt_size
+;
+; CHECK-DAG: MayAlias: i32* %a, i32* %b
+define void @test_lower_bound_lt_size(ptr %p, i64 %i) {
+  %a = getelementptr i8, ptr %p
+  %add = getelementptr nuw i8, ptr %p, i64 2
+  %b = getelementptr nuw i8, ptr %add, i64 %i
+
+  load i32, ptr %a
+  load i32, ptr %b
+
+  ret void
+}
+
+; CHECK-LABEL: test_lower_bound_ge_size
+;
+; CHECK-DAG: NoAlias: i32* %a, i32* %b
+define void @test_lower_bound_ge_size(ptr %p, i64 %i) {
+  %a = getelementptr i8, ptr %p
+  %add = getelementptr nuw i8, ptr %p, i64 4
+  %b = getelementptr nuw i8, ptr %add, i64 %i
+
+  load i32, ptr %a
+  load i32, ptr %b
+
+  ret void
+}
+
+; CHECK-LABEL: test_not_all_nuw
+;
+; If part of the addressing is done with non-nuw GEPs, we can't use properties
+; implied by the last GEP with the whole offset. In this case, the calculation
+; of %add (%p + 4) could wrap the pointer index type, such that %add +<nuw> %i
+; could still alias with %p.
+;
+; CHECK-DAG: MayAlias: i32* %a, i32* %b
+define void @test_not_all_nuw(ptr %p, i64 %i) {
+  %a = getelementptr i8, ptr %p
+  %add = getelementptr i8, ptr %p, i64 4
+  %b = getelementptr nuw i8, ptr %add, i64 %i
+
+  load i32, ptr %a
+  load i32, ptr %b
+
+  ret void
+}
+
+; CHECK-LABEL: test_multi_step_not_all_nuw
+;
+; CHECK-DAG: MayAlias: i32* %a, i32* %b
+define void @test_multi_step_not_all_nuw(ptr %p, i64 %i, i64 %j, i64 %k) {
+  %a = getelementptr i8, ptr %p
+  %add = getelementptr i8, ptr %p, i64 4
+  %step1 = getelementptr i8, ptr %add, i64 %i
+  %step2 = getelementptr i8, ptr %step1, i64 %j
+  %b = getelementptr nuw i8, ptr %step2, i64 %k
+
+  load i32, ptr %a
+  load i32, ptr %b
+
+  ret void
+}
+
+; CHECK-LABEL: test_multi_step_all_nuw
+;
+; CHECK-DAG: NoAlias: i32* %a, i32* %b
+define void @test_multi_step_all_nuw(ptr %p, i64 %i, i64 %j, i64 %k) {
+  %a = getelementptr i8, ptr %p
+  %add = getelementptr nuw i8, ptr %p, i64 4
+  %step1 = getelementptr nuw i8, ptr %add, i64 %i
+  %step2 = getelementptr nuw i8, ptr %step1, i64 %j
+  %b = getelementptr nuw i8, ptr %step2, i64 %k
+
+  load i32, ptr %a
+  load i32, ptr %b
+
+  ret void
+}
+
+%struct = type { i64, [2 x i32], i64 }
+
+; CHECK-LABEL: test_struct_no_nuw
+;
+; The array access may alias with the struct elements before and after, because
+; we cannot prove that (%arr + %i) does not alias with the base pointer %p.
+;
+; CHECK-DAG: MayAlias: i32* %arrayidx, i64* %st
+; CHECK-DAG: NoAlias: i64* %after, i64* %st
+; CHECK-DAG: MayAlias: i64* %after, i32* %arrayidx
+
+define void @test_struct_no_nuw(ptr %st, i64 %i) {
+  %arr = getelementptr i8, ptr %st, i64 8
+  %arrayidx = getelementptr [2 x i32], ptr %arr, i64 0, i64 %i
+  %after = getelementptr i8, ptr %st, i64 16
+
+  load i64, ptr %st
+  load i32, ptr %arrayidx
+  load i64, ptr %after
+
+  ret void
+}
+
+; CHECK-LABEL: test_struct_nuw
+;
+; We can prove that the array access does not alias with struct element before,
+; because we can prove that (%arr +<nuw> %i) does not wrap the pointer index
+; type (add nuw). The array access may still alias with the struct element
+; after, as the add nuw property does not preclude this.
+;
+; CHECK-DAG: NoAlias: i32* %arrayidx, i64* %st
+; CHECK-DAG: NoAlias: i64* %after, i64* %st
+; CHECK-DAG: MayAlias: i64* %after, i32* %arrayidx
+
+define void @test_struct_nuw(ptr %st, i64 %i) {
+  %arr = getelementptr nuw i8, ptr %st, i64 8
+  %arrayidx = getelementptr nuw [2 x i32], ptr %arr, i64 0, i64 %i
+  %after = getelementptr nuw i8, ptr %st, i64 16
+
+  load i64, ptr %st
+  load i32, ptr %arrayidx
+  load i64, ptr %after
+
+  ret void
+}
+

--- a/llvm/test/Analysis/BasicAA/gep-nuw-alias.ll
+++ b/llvm/test/Analysis/BasicAA/gep-nuw-alias.ll
@@ -158,24 +158,6 @@ define void @constant_offset_overflow(ptr %p, i64 %i) {
   ret void
 }
 
-; CHECK-LABEL: constant_offset_overflow_rev_order
-;
-; Same as above test, just verifying correct behaviour when GEPs encountered
-; in the reverse order;
-;
-; CHECK-DAG: MayAlias: i32* %a, i32* %b
-
-define void @constant_offset_overflow_rev_order(ptr %p, i64 %i) {
-  %a = getelementptr i8, ptr %p, i64 -8
-  %add = getelementptr nuw i8, ptr %p, i64 4
-  %b = getelementptr nuw i8, ptr %add, i64 %i
-
-  load i32, ptr %b
-  load i32, ptr %a
-
-  ret void
-}
-
 ; CHECK-LABEL: equal_var_idx_noalias
 ;
 ; If GEPs have equal variable indices, we can prove NoAlias when the Scale of


### PR DESCRIPTION
Use the nuw attribute of GEPs to prove that pointers do not alias, in cases matching the following:

```
   +                +                     +
   | BaseOffset     |   +<nuw> Indices    |
   ---------------->|-------------------->|
   |-->VLeftSize    |                     |------->VRightSize
  LHS                                    RHS
```

If the difference between pointers is Offset +<nuw> Indices (the variable indices all come from nuw GEPs) then we know that the addition does not wrap the pointer index type (add nuw) and the constant Offset is a lower bound on the distance between the pointers. We can then prove NoAlias via Offset u>= VLeftSize.