### PR TITLE
[clang] Add option to opt out of the missing_dependent_template_keyword diagnostic

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -313,6 +313,7 @@ Resolutions to C++ Defect Reports
 
 - Clang now correctly implements lookup for the terminal name of a member-qualified nested-name-specifier.
   (`CWG1835: Dependent member lookup before < <https://cplusplus.github.io/CWG/issues/1835.html>`_).
+  The warning can be disabled via `-Wno-missing-dependent-template-keyword`.
 
 C Language Changes
 ------------------

--- a/clang/include/clang/Basic/DiagnosticParseKinds.td
+++ b/clang/include/clang/Basic/DiagnosticParseKinds.td
@@ -896,7 +896,8 @@ def missing_template_arg_list_after_template_kw : Extension<
   DefaultError;
 
 def ext_missing_dependent_template_keyword : ExtWarn<
-  "use 'template' keyword to treat '%0' as a dependent template name">;
+  "use 'template' keyword to treat '%0' as a dependent template name">,
+  InGroup<DiagGroup<"missing-dependent-template-keyword">>;
 
 def ext_extern_template : Extension<
   "extern templates are a C++11 extension">, InGroup<CXX11>;

--- a/clang/test/Misc/warning-flags.c
+++ b/clang/test/Misc/warning-flags.c
@@ -18,10 +18,9 @@ This test serves two purposes:
 
 The list of warnings below should NEVER grow.  It should gradually shrink to 0.
 
-CHECK: Warnings without flags (65):
+CHECK: Warnings without flags (64):
 
 CHECK-NEXT:   ext_expected_semi_decl_list
-CHECK-NEXT:   ext_missing_dependent_template_keyword
 CHECK-NEXT:   ext_missing_whitespace_after_macro_name
 CHECK-NEXT:   ext_new_paren_array_nonconst
 CHECK-NEXT:   ext_plain_complex


### PR DESCRIPTION
After commit ce4aada6e2135e29839f672a6599db628b53295d, we observed many warnings in our internal codebase. It is 
 infeasible to fix all at once.

Currently, there is no way to disable this warning. This patch provides a way to disable it using the `-Wno-missing-dependent-template-keyword` flag.