### PR TITLE
[clang] Fix crash in concept deprecation

### DIFF
--- a/clang/lib/Sema/SemaDecl.cpp
+++ b/clang/lib/Sema/SemaDecl.cpp
@@ -7416,10 +7416,9 @@ NamedDecl *Sema::ActOnVariableDeclarator(
     tryToFixVariablyModifiedVarType(TInfo, R, D.getIdentifierLoc(),
                                     /*DiagID=*/0);
 
-  if (const AutoType *AutoT = R->getAs<AutoType>()) {
-    AutoTypeLoc Loc = TInfo->getTypeLoc().getContainedAutoTypeLoc();
-    CheckConstrainedAuto(AutoT,
-                         Loc ? Loc.getConceptNameLoc() : SourceLocation());
+  if (AutoTypeLoc TL = TInfo->getTypeLoc().getContainedAutoTypeLoc()) {
+    const AutoType *AT = TL.getTypePtr();
+    CheckConstrainedAuto(AT, TL.getConceptNameLoc());
   }
 
   bool IsMemberSpecialization = false;

--- a/clang/lib/Sema/SemaDecl.cpp
+++ b/clang/lib/Sema/SemaDecl.cpp
@@ -7416,10 +7416,11 @@ NamedDecl *Sema::ActOnVariableDeclarator(
     tryToFixVariablyModifiedVarType(TInfo, R, D.getIdentifierLoc(),
                                     /*DiagID=*/0);
 
-  if (const AutoType *AutoT = R->getAs<AutoType>())
-    CheckConstrainedAuto(
-        AutoT,
-        TInfo->getTypeLoc().getContainedAutoTypeLoc().getConceptNameLoc());
+  if (const AutoType *AutoT = R->getAs<AutoType>()) {
+    AutoTypeLoc Loc = TInfo->getTypeLoc().getContainedAutoTypeLoc();
+    CheckConstrainedAuto(AutoT,
+                         Loc ? Loc.getConceptNameLoc() : SourceLocation());
+  }
 
   bool IsMemberSpecialization = false;
   bool IsVariableTemplateSpecialization = false;

--- a/clang/lib/Sema/SemaType.cpp
+++ b/clang/lib/Sema/SemaType.cpp
@@ -6308,10 +6308,9 @@ TypeResult Sema::ActOnTypeName(Declarator &D) {
     CheckExtraCXXDefaultArguments(D);
   }
 
-  if (const AutoType *AutoT = T->getAs<AutoType>()) {
-    AutoTypeLoc Loc = TInfo->getTypeLoc().getContainedAutoTypeLoc();
-    CheckConstrainedAuto(AutoT,
-                         Loc ? Loc.getConceptNameLoc() : SourceLocation());
+  if (AutoTypeLoc TL = TInfo->getTypeLoc().getContainedAutoTypeLoc()) {
+    const AutoType *AT = TL.getTypePtr();
+    CheckConstrainedAuto(AT, TL.getConceptNameLoc());
   }
   return CreateParsedType(T, TInfo);
 }

--- a/clang/lib/Sema/SemaType.cpp
+++ b/clang/lib/Sema/SemaType.cpp
@@ -6308,11 +6308,11 @@ TypeResult Sema::ActOnTypeName(Declarator &D) {
     CheckExtraCXXDefaultArguments(D);
   }
 
-  if (const AutoType *AutoT = T->getAs<AutoType>())
-    CheckConstrainedAuto(
-        AutoT,
-        TInfo->getTypeLoc().getContainedAutoTypeLoc().getConceptNameLoc());
-
+  if (const AutoType *AutoT = T->getAs<AutoType>()) {
+    AutoTypeLoc Loc = TInfo->getTypeLoc().getContainedAutoTypeLoc();
+    CheckConstrainedAuto(AutoT,
+                         Loc ? Loc.getConceptNameLoc() : SourceLocation());
+  }
   return CreateParsedType(T, TInfo);
 }
 

--- a/clang/test/CXX/drs/cwg24xx.cpp
+++ b/clang/test/CXX/drs/cwg24xx.cpp
@@ -82,6 +82,15 @@ auto h() -> C auto {
   C auto foo = T();
   // expected-warning@-1 {{'C' is deprecated}}
   //   expected-note@#cwg2428-C {{'C' has been explicitly marked deprecated here}}
+  C auto *bar = T();
+  // expected-warning@-1 {{'C' is deprecated}}
+  //   expected-note@#cwg2428-C {{'C' has been explicitly marked deprecated here}}
+  C auto &baz = T();
+  // expected-warning@-1 {{'C' is deprecated}}
+  //   expected-note@#cwg2428-C {{'C' has been explicitly marked deprecated here}}
+  C auto &&quux = T();
+  // expected-warning@-1 {{'C' is deprecated}}
+  //   expected-note@#cwg2428-C {{'C' has been explicitly marked deprecated here}}
   return foo;
 }
 #endif

--- a/clang/test/SemaCXX/cxx-deprecated.cpp
+++ b/clang/test/SemaCXX/cxx-deprecated.cpp
@@ -37,10 +37,12 @@ template <C T>
 //   expected-note@#C {{'C' has been explicitly marked deprecated here}}
 void f();
 
+namespace GH98164 {
 template <int>
 auto b() = delete; // #b
 
 decltype(b<0>()) x;
 // expected-error@-1 {{call to deleted function 'b'}}
 //   expected-note@#b {{candidate function [with $0 = 0] has been explicitly deleted}}
+} // namespace GH98164
 } // namespace cxx20_concept

--- a/clang/test/SemaCXX/cxx-deprecated.cpp
+++ b/clang/test/SemaCXX/cxx-deprecated.cpp
@@ -36,4 +36,11 @@ template <C T>
 // expected-warning@-1 {{'C' is deprecated}}
 //   expected-note@#C {{'C' has been explicitly marked deprecated here}}
 void f();
+
+template <int>
+auto b() = delete; // #b
+
+decltype(b<0>()) x;
+// expected-error@-1 {{call to deleted function 'b'}}
+//   expected-note@#b {{candidate function [with $0 = 0] has been explicitly deleted}}
 } // namespace cxx20_concept


### PR DESCRIPTION
There is a gap between `getAs<AutoType>()` and `getConstrainedAutoType()` that the original patch #92295 was not aware of.

Fixes #98164