### PR TITLE
[LLDB] Fix remote executables load and caching

### DIFF
--- a/lldb/source/Target/Platform.cpp
+++ b/lldb/source/Target/Platform.cpp
@@ -1446,7 +1446,8 @@ Platform::GetCachedExecutable(ModuleSpec &module_spec,
   Status error = GetRemoteSharedModule(
       module_spec, nullptr, module_sp,
       [&](const ModuleSpec &spec) {
-        return ResolveExecutable(spec, module_sp, module_search_paths_ptr);
+        return Platform::ResolveExecutable(spec, module_sp,
+                                           module_search_paths_ptr);
       },
       nullptr);
   if (error.Success()) {

--- a/lldb/source/Target/RemoteAwarePlatform.cpp
+++ b/lldb/source/Target/RemoteAwarePlatform.cpp
@@ -46,6 +46,9 @@ Status RemoteAwarePlatform::ResolveExecutable(
 
     if (!FileSystem::Instance().Exists(resolved_file_spec))
       FileSystem::Instance().ResolveExecutableLocation(resolved_file_spec);
+  } else if (m_remote_platform_sp) {
+    return GetCachedExecutable(resolved_module_spec, exe_module_sp,
+                               module_search_paths_ptr);
   }
 
   return Platform::ResolveExecutable(resolved_module_spec, exe_module_sp,


### PR DESCRIPTION
Seemingly, #96256 removed the only call to
Platform::GetCachedExecutable, which broke the resolution of executable modules in the remote debugging mode
(https://github.com/llvm/llvm-project/issues/97410).

This commit fixes that.