### PR TITLE
[sanitizer] Suggest checking ulimit -d in addition to ulimit -v

### DIFF
--- a/compiler-rt/lib/sanitizer_common/sanitizer_common_libcdep.cpp
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_common_libcdep.cpp
@@ -169,7 +169,7 @@ void ReserveShadowMemoryRange(uptr beg, uptr end, const char *name,
                      : !MmapFixedNoReserve(beg, size, name)) {
     Report(
         "ReserveShadowMemoryRange failed while trying to map 0x%zx bytes. "
-        "Perhaps you're using ulimit -v\n",
+        "Perhaps you're using ulimit -v or ulimit -d\n",
         size);
     Abort();
   }


### PR DESCRIPTION
Since Linux 4.7, RLIMIT_DATA may result in mmap() returning ENOMEM. Example:

    $ clang -fsanitize=address -o hello hello.c
    $ ulimit -d 100000
    $ ./hello
    ==3349007==ERROR: AddressSanitizer failed to allocate 0x10000000 (268435456) bytes at address 7fff7000 (errno: 12)
    ==3349007==ReserveShadowMemoryRange failed while trying to map 0x10000000 bytes. Perhaps you're using ulimit -v

Suggest checking ulimit -d in addition to ulimit -v.