### PR TITLE
Fix Findzstd.cmake for compiler-rt with MSVC

### DIFF
--- a/llvm/cmake/modules/Findzstd.cmake
+++ b/llvm/cmake/modules/Findzstd.cmake
@@ -36,7 +36,9 @@ if(zstd_FOUND)
     if(MSVC)
       # IMPORTED_LOCATION is the path to the DLL and IMPORTED_IMPLIB is the "library".
       get_filename_component(zstd_DIRNAME "${zstd_LIBRARY}" DIRECTORY)
-      string(REGEX REPLACE "${CMAKE_INSTALL_LIBDIR}$" "${CMAKE_INSTALL_BINDIR}" zstd_DIRNAME "${zstd_DIRNAME}")
+      if(NOT "${CMAKE_INSTALL_LIBDIR}" STREQUAL "" AND NOT "${CMAKE_INSTALL_BINDIR}" STREQUAL "")
+        string(REGEX REPLACE "${CMAKE_INSTALL_LIBDIR}$" "${CMAKE_INSTALL_BINDIR}" zstd_DIRNAME "${zstd_DIRNAME}")
+      endif()
       get_filename_component(zstd_BASENAME "${zstd_LIBRARY}" NAME)
       string(REGEX REPLACE "\\${CMAKE_LINK_LIBRARY_SUFFIX}$" "${CMAKE_SHARED_LIBRARY_SUFFIX}" zstd_BASENAME "${zstd_BASENAME}")
       set_target_properties(zstd::libzstd_shared PROPERTIES


### PR DESCRIPTION
When building compiler-rt with MSVC, CMAKE_INSTALL_LIBDIR and CMAKE_INSTALL_BINDIR are empty.

This causes error in Findzstd.cmake like the following:

CMake Error at C:/llvm/cmake/modules/Findzstd.cmake:39 (string):
  string sub-command REGEX, mode REPLACE: regex "$" matched an empty string.

Do not do the REGEX when CMAKE_INSTALL_LIBDIR and CMAKE_INSTALL_BINDIR are empty.

Similar issues were reported by others at

https://github.com/llvm/llvm-project/commit/e7fc7540daa9333f0be4f380fc9c619236d17f57