### PR TITLE
[RISCV] Prune dead LI in vsetvli coalescing with trivially dead vsetvli

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVInsertVSETVLI.cpp
+++ b/llvm/lib/Target/RISCV/RISCVInsertVSETVLI.cpp
@@ -1727,7 +1727,6 @@ void RISCVInsertVSETVLI::coalesceVSETVLIs(MachineBasicBlock &MBB) const {
     MI->eraseFromParent();
     if (OldAVLReg && OldAVLReg.isVirtual())
       afterDroppedAVLUse(OldAVLReg);
-
   }
 }
 

--- a/llvm/test/CodeGen/RISCV/rvv/vsetvli-insert.mir
+++ b/llvm/test/CodeGen/RISCV/rvv/vsetvli-insert.mir
@@ -589,7 +589,6 @@ body: |
     ; CHECK-LABEL: name: coalesce_shrink_removed_vsetvlis_uses
     ; CHECK: liveins: $x10, $v8
     ; CHECK-NEXT: {{  $}}
-    ; CHECK-NEXT: %avl1:gprnox0 = ADDI $x0, 1
     ; CHECK-NEXT: %avl2:gprnox0 = ADDI $x0, 2
     ; CHECK-NEXT: dead $x0 = PseudoVSETVLI %avl2, 209 /* e32, m2, ta, ma */, implicit-def $vl, implicit-def $vtype
     ; CHECK-NEXT: %x:gpr = COPY $x10


### PR DESCRIPTION
This is a follow up to ff8a03a7.  On the review for that, I'd suggested a stylistic rework, but after discussion we decided to move forward with the fix as it was.  This change is a small part of that suggested rework. Once I sat down and wrote the code, I think I've convinced myself of an entirely different approach (tbd), but for the moment, let's use a lambda to share code so that we can pickup a missed optimization, and reduce some duplication.