### PR TITLE
[InstSimplify] Fold ptrtoint(ptradd(P,X-ptrtoint(P))) to X

### DIFF
--- a/llvm/lib/Analysis/InstructionSimplify.cpp
+++ b/llvm/lib/Analysis/InstructionSimplify.cpp
@@ -5333,6 +5333,14 @@ static Value *simplifyCastInst(unsigned CastOpc, Value *Op, Type *Ty,
     if (Op->getType() == Ty)
       return Op;
 
+  // ptrtoint (ptradd (Ptr, X - ptrtoint(Ptr))) -> X
+  Value *Ptr, *X;
+  if (CastOpc == Instruction::PtrToInt &&
+      match(Op, m_PtrAdd(m_Value(Ptr),
+                         m_Sub(m_Value(X), m_PtrToInt(m_Deferred(Ptr))))) &&
+      X->getType() == Ty && Ty == Q.DL.getIndexType(Ptr->getType()))
+    return X;
+
   return nullptr;
 }
 

--- a/llvm/test/Transforms/InstSimplify/ptrtoint.ll
+++ b/llvm/test/Transforms/InstSimplify/ptrtoint.ll
@@ -4,11 +4,7 @@
 define i64 @ptrtoint_gep_sub(ptr %ptr, i64 %end.addr) {
 ; CHECK-LABEL: define i64 @ptrtoint_gep_sub(
 ; CHECK-SAME: ptr [[PTR:%.*]], i64 [[END_ADDR:%.*]]) {
-; CHECK-NEXT:    [[PTR_ADDR:%.*]] = ptrtoint ptr [[PTR]] to i64
-; CHECK-NEXT:    [[SIZE:%.*]] = sub i64 [[END_ADDR]], [[PTR_ADDR]]
-; CHECK-NEXT:    [[END:%.*]] = getelementptr i8, ptr [[PTR]], i64 [[SIZE]]
-; CHECK-NEXT:    [[END_ADDR2:%.*]] = ptrtoint ptr [[END]] to i64
-; CHECK-NEXT:    ret i64 [[END_ADDR2]]
+; CHECK-NEXT:    ret i64 [[END_ADDR]]
 ;
   %ptr.addr = ptrtoint ptr %ptr to i64
   %size = sub i64 %end.addr, %ptr.addr
@@ -20,11 +16,7 @@ define i64 @ptrtoint_gep_sub(ptr %ptr, i64 %end.addr) {
 define <2 x i64> @ptrtoint_gep_sub_vector(<2 x ptr> %ptr, <2 x i64> %end.addr) {
 ; CHECK-LABEL: define <2 x i64> @ptrtoint_gep_sub_vector(
 ; CHECK-SAME: <2 x ptr> [[PTR:%.*]], <2 x i64> [[END_ADDR:%.*]]) {
-; CHECK-NEXT:    [[PTR_ADDR:%.*]] = ptrtoint <2 x ptr> [[PTR]] to <2 x i64>
-; CHECK-NEXT:    [[SIZE:%.*]] = sub <2 x i64> [[END_ADDR]], [[PTR_ADDR]]
-; CHECK-NEXT:    [[END:%.*]] = getelementptr i8, <2 x ptr> [[PTR]], <2 x i64> [[SIZE]]
-; CHECK-NEXT:    [[END_ADDR2:%.*]] = ptrtoint <2 x ptr> [[END]] to <2 x i64>
-; CHECK-NEXT:    ret <2 x i64> [[END_ADDR2]]
+; CHECK-NEXT:    ret <2 x i64> [[END_ADDR]]
 ;
   %ptr.addr = ptrtoint <2 x ptr> %ptr to <2 x i64>
   %size = sub <2 x i64> %end.addr, %ptr.addr


### PR DESCRIPTION
This is a special case of the general ptrtoint(gep) to add(ptrtoint) transform that is particularly profitable, as everything folds away.

Proof: https://alive2.llvm.org/ce/z/fwv8_L

Fixes https://github.com/llvm/llvm-project/issues/86417.