### PR TITLE
[SystemZ][z/OS] Update autoconversion functions to improve support for UTF-8

### DIFF
--- a/clang/include/clang/Basic/FileEntry.h
+++ b/clang/include/clang/Basic/FileEntry.h
@@ -70,6 +70,11 @@ public:
   const FileEntry &getFileEntry() const {
     return *getBaseMapEntry().second->V.get<FileEntry *>();
   }
+#ifdef __MVS__
+  FileEntry &getFileEntry() {
+    return *getBaseMapEntry().second->V.get<FileEntry *>();
+  }
+#endif
   DirectoryEntryRef getDir() const { return ME->second->Dir; }
 
   inline off_t getSize() const;
@@ -323,6 +328,10 @@ public:
 
   StringRef tryGetRealPathName() const { return RealPathName; }
   off_t getSize() const { return Size; }
+#ifdef __MVS__
+  // Size may increase due to potential z/OS EBCDIC -> UTF-8 conversion.
+  void setSize(off_t NewSize) { Size = NewSize; }
+#endif
   unsigned getUID() const { return UID; }
   const llvm::sys::fs::UniqueID &getUniqueID() const { return UniqueID; }
   time_t getModificationTime() const { return ModTime; }

--- a/clang/include/clang/Basic/FileEntry.h
+++ b/clang/include/clang/Basic/FileEntry.h
@@ -71,11 +71,9 @@ public:
     return *getBaseMapEntry().second->V.get<FileEntry *>();
   }
 
-  // This is a non const version of getFileEntry() which is used if the buffer
-  // size needs to be increased due to potential z/OS EBCDIC -> UTF-8 conversion
-  FileEntry &getFileEntryToUpdate() {
-    return *getBaseMapEntry().second->V.get<FileEntry *>();
-  }
+  // This function is used if the buffer size needs to be increased
+  // due to potential z/OS EBCDIC -> UTF-8 conversion
+  inline void updateFileEntryBufferSize(unsigned BufferSize);
 
   DirectoryEntryRef getDir() const { return ME->second->Dir; }
 
@@ -361,6 +359,10 @@ time_t FileEntryRef::getModificationTime() const {
 bool FileEntryRef::isNamedPipe() const { return getFileEntry().isNamedPipe(); }
 
 void FileEntryRef::closeFile() const { getFileEntry().closeFile(); }
+
+void FileEntryRef::updateFileEntryBufferSize(unsigned BufferSize) {
+  getBaseMapEntry().second->V.get<FileEntry *>()->setSize(BufferSize);
+}
 
 } // end namespace clang
 

--- a/clang/include/clang/Basic/FileEntry.h
+++ b/clang/include/clang/Basic/FileEntry.h
@@ -70,11 +70,13 @@ public:
   const FileEntry &getFileEntry() const {
     return *getBaseMapEntry().second->V.get<FileEntry *>();
   }
-#ifdef __MVS__
-  FileEntry &getFileEntry() {
+
+  // This is a non const version of getFileEntry() which is used if the buffer
+  // size needs to be increased due to potential z/OS EBCDIC -> UTF-8 conversion
+  FileEntry &getFileEntryToUpdate() {
     return *getBaseMapEntry().second->V.get<FileEntry *>();
   }
-#endif
+
   DirectoryEntryRef getDir() const { return ME->second->Dir; }
 
   inline off_t getSize() const;
@@ -328,10 +330,8 @@ public:
 
   StringRef tryGetRealPathName() const { return RealPathName; }
   off_t getSize() const { return Size; }
-#ifdef __MVS__
   // Size may increase due to potential z/OS EBCDIC -> UTF-8 conversion.
   void setSize(off_t NewSize) { Size = NewSize; }
-#endif
   unsigned getUID() const { return UID; }
   const llvm::sys::fs::UniqueID &getUniqueID() const { return UniqueID; }
   time_t getModificationTime() const { return ModTime; }

--- a/clang/lib/Basic/SourceManager.cpp
+++ b/clang/lib/Basic/SourceManager.cpp
@@ -24,6 +24,7 @@
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ADT/StringSwitch.h"
 #include "llvm/Support/Allocator.h"
+#include "llvm/Support/AutoConvert.h"
 #include "llvm/Support/Capacity.h"
 #include "llvm/Support/Compiler.h"
 #include "llvm/Support/Endian.h"
@@ -156,10 +157,16 @@ ContentCache::getBufferOrNone(DiagnosticsEngine &Diag, FileManager &FM,
   // Unless this is a named pipe (in which case we can handle a mismatch),
   // check that the file's size is the same as in the file entry (which may
   // have come from a stat cache).
+#ifndef __MVS__
   if (!ContentsEntry->isNamedPipe() &&
       Buffer->getBufferSize() != (size_t)ContentsEntry->getSize()) {
+#else
+  // The buffer will always be larger than the file size on z/OS in the presence
+  // of characters outside the base character set.
+  if (!ContentsEntry->isNamedPipe() &&
+      Buffer->getBufferSize() < (size_t)ContentsEntry->getSize()) {
+#endif
     Diag.Report(Loc, diag::err_file_modified) << ContentsEntry->getName();
-
     return std::nullopt;
   }
 
@@ -602,6 +609,23 @@ FileID SourceManager::createFileIDImpl(ContentCache &File, StringRef Filename,
     return FileID::get(LoadedID);
   }
   unsigned FileSize = File.getSize();
+#ifdef __MVS__
+  llvm::ErrorOr<bool> NeedConversion =
+      llvm::needzOSConversion(Filename.str().c_str());
+  if (NeedConversion && *NeedConversion) {
+    // Buffer size may increase due to potential z/OS EBCDIC to UTF-8
+    // conversion.
+    if (std::optional<llvm::MemoryBufferRef> Buffer =
+            File.getBufferOrNone(Diag, getFileManager())) {
+      unsigned BufSize = Buffer->getBufferSize();
+      if (BufSize > FileSize) {
+        if (File.ContentsEntry.has_value())
+          File.ContentsEntry->getFileEntry().setSize(BufSize);
+        FileSize = BufSize;
+      }
+    }
+  }
+#endif
   if (!(NextLocalOffset + FileSize + 1 > NextLocalOffset &&
         NextLocalOffset + FileSize + 1 <= CurrentLoadedOffset)) {
     Diag.Report(IncludePos, diag::err_sloc_space_too_large);

--- a/clang/lib/Basic/SourceManager.cpp
+++ b/clang/lib/Basic/SourceManager.cpp
@@ -627,7 +627,7 @@ FileID SourceManager::createFileIDImpl(ContentCache &File, StringRef Filename,
       unsigned BufSize = Buffer->getBufferSize();
       if (BufSize > FileSize) {
         if (File.ContentsEntry.has_value())
-          File.ContentsEntry->getFileEntryToUpdate().setSize(BufSize);
+          File.ContentsEntry->updateFileEntryBufferSize(BufSize);
         FileSize = BufSize;
       }
     }

--- a/llvm/include/llvm/Support/AutoConvert.h
+++ b/llvm/include/llvm/Support/AutoConvert.h
@@ -17,6 +17,7 @@
 #ifdef __MVS__
 #include <_Ccsid.h>
 #ifdef __cplusplus
+#include "llvm/Support/ErrorOr.h"
 #include <system_error>
 #endif /* __cplusplus */
 
@@ -54,8 +55,14 @@ std::error_code restorezOSStdHandleAutoConversion(int FD);
 /** \brief Set the tag information for a file descriptor. */
 std::error_code setzOSFileTag(int FD, int CCSID, bool Text);
 
-} /* namespace llvm */
-#endif /* __cplusplus */
+// Get the the tag ccsid for a file name or a file descriptor.
+ErrorOr<__ccsid_t> getzOSFileTag(const char *FileName, const int FD = -1);
+
+// Query the file tag to determine if it needs conversion to UTF-8 codepage.
+ErrorOr<bool> needzOSConversion(const char *FileName, const int FD = -1);
+
+} // namespace llvm
+#endif // __cplusplus
 
 #endif /* __MVS__ */
 


### PR DESCRIPTION
This fixes the following error when reading source and header files on z/OS: error: source file is not valid UTF-8