### PR TITLE
Fix the docs for the boost/modernize use-ranges checks

### DIFF
--- a/clang-tools-extra/docs/clang-tidy/checks/boost/use-ranges.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/boost/use-ranges.rst
@@ -16,42 +16,128 @@ Example
                             std::end(Items2));
 
 
-transforms to:
+Transforms to:
 
 .. code-block:: c++
 
   auto Iter1 = boost::range::find(Items, 0);
   auto AreSame = boost::range::equal(Items1, Items2);
 
+Supported algorithms
+--------------------
+
 Calls to the following std library algorithms are checked:
-``includes``,``set_union``,``set_intersection``,``set_difference``,
-``set_symmetric_difference``,``unique``,``lower_bound``,``stable_sort``,
-``equal_range``,``remove_if``,``sort``,``random_shuffle``,``remove_copy``,
-``stable_partition``,``remove_copy_if``,``count``,``copy_backward``,
-``reverse_copy``,``adjacent_find``,``remove``,``upper_bound``,``binary_search``,
-``replace_copy_if``,``for_each``,``generate``,``count_if``,``min_element``,
-``reverse``,``replace_copy``,``fill``,``unique_copy``,``transform``,``copy``,
-``replace``,``find``,``replace_if``,``find_if``,``partition``,``max_element``,
-``find_end``,``merge``,``partial_sort_copy``,``find_first_of``,``search``,
-``lexicographical_compare``,``equal``,``mismatch``,``next_permutation``,
-``prev_permutation``,``push_heap``,``pop_heap``,``make_heap``,``sort_heap``,
-``copy_if``,``is_permutation``,``is_partitioned``,``find_if_not``,
-``partition_copy``,``any_of``,``iota``,``all_of``,``partition_point``,
-``is_sorted``,``none_of``,``is_sorted_until``,``reduce``,``accumulate``,
-``parital_sum``,``adjacent_difference``.
+
+``std::accumulate``,
+``std::adjacent_difference``,
+``std::adjacent_find``,
+``std::all_of``,
+``std::any_of``,
+``std::binary_search``,
+``std::copy_backward``,
+``std::copy_if``,
+``std::copy``,
+``std::count_if``,
+``std::count``,
+``std::equal_range``,
+``std::equal``,
+``std::fill``,
+``std::find_end``,
+``std::find_first_of``,
+``std::find_if_not``,
+``std::find_if``,
+``std::find``,
+``std::for_each``,
+``std::generate``,
+``std::includes``,
+``std::iota``,
+``std::is_partitioned``,
+``std::is_permutation``,
+``std::is_sorted_until``,
+``std::is_sorted``,
+``std::lexicographical_compare``,
+``std::lower_bound``,
+``std::make_heap``,
+``std::max_element``,
+``std::merge``,
+``std::min_element``,
+``std::mismatch``,
+``std::next_permutation``,
+``std::none_of``,
+``std::parital_sum``,
+``std::partial_sort_copy``,
+``std::partition_copy``,
+``std::partition_point``,
+``std::partition``,
+``std::pop_heap``,
+``std::prev_permutation``,
+``std::push_heap``,
+``std::random_shuffle``,
+``std::reduce``,
+``std::remove_copy_if``,
+``std::remove_copy``,
+``std::remove_if``,
+``std::remove``,
+``std::replace_copy_if``,
+``std::replace_copy``,
+``std::replace_if``,
+``std::replace``,
+``std::reverse_copy``,
+``std::reverse``,
+``std::search``,
+``std::set_difference``,
+``std::set_intersection``,
+``std::set_symmetric_difference``,
+``std::set_union``,
+``std::sort_heap``,
+``std::sort``,
+``std::stable_partition``,
+``std::stable_sort``,
+``std::transform``,
+``std::unique_copy``,
+``std::unique``,
+``std::upper_bound``.
 
 The check will also look for the following functions from the
 ``boost::algorithm`` namespace:
-``reduce``,``find_backward``,``find_not_backward``,``find_if_backward``,
-``find_if_not_backward``,``hex``,``hex_lower``,``unhex``,
-``is_partitioned_until``,``is_palindrome``,``copy_if``,``copy_while``,
-``copy_until``,``copy_if_while``,``copy_if_until``,``is_permutation``,
-``is_partitioned``,``one_of``,``one_of_equal``,``find_if_not``,
-``partition_copy``,``any_of``,``any_of_equal``,``iota``,``all_of``,
-``all_of_equal``,``partition_point``,``is_sorted_until``,``is_sorted``,
-``is_increasing``,``is_decreasing``,``is_strictly_increasing``,
-``is_strictly_decreasing``,``none_of``,``none_of_equal``,``clamp_range``,
-``apply_permutation``,``apply_reverse_permutation``.
+
+``all_of_equal``,
+``any_of_equal``,
+``any_of``,
+``apply_permutation``,
+``apply_reverse_permutation``,
+``clamp_range``,
+``copy_if_until``,
+``copy_if_while``,
+``copy_if``,
+``copy_until``,
+``copy_while``,
+``find_backward``,
+``find_if_backward``,
+``find_if_not_backward``,
+``find_if_not``,
+``find_not_backward``,
+``hex_lower``,
+``hex``,
+``iota``, ``all_of``,
+``is_decreasing``,
+``is_increasing``,
+``is_palindrome``,
+``is_partitioned_until``,
+``is_partitioned``,
+``is_permutation``,
+``is_sorted_until``,
+``is_sorted``,
+``is_strictly_decreasing``,
+``is_strictly_increasing``,
+``none_of_equal``,
+``none_of``,
+``one_of_equal``,
+``one_of``,
+``partition_copy``,
+``partition_point``,
+``reduce``,
+``unhex``.
 
 Reverse Iteration
 -----------------
@@ -64,7 +150,7 @@ fixed using the ``boost::adaptors::reverse`` adaptor.
   auto AreSame = std::equal(Items1.rbegin(), Items1.rend(),
                             std::crbegin(Items2), std::crend(Items2));
 
-transformst to:
+Transforms to:
 
 .. code-block:: c++
 

--- a/clang-tools-extra/docs/clang-tidy/checks/modernize/use-ranges.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/modernize/use-ranges.rst
@@ -16,40 +16,90 @@ Example
                             std::begin(Items2), std::end(Items2));
 
 
-transforms to:
+Transforms to:
 
 .. code-block:: c++
 
   auto Iter1 = std::ranges::find(Items, 0);
   auto AreSame = std::ranges::equal(Items1, Items2);
 
+Supported algorithms
+--------------------
+
 Calls to the following std library algorithms are checked:
-``::std::all_of``,``::std::any_of``,``::std::none_of``,``::std::for_each``,
-``::std::find``,``::std::find_if``,``::std::find_if_not``,
-``::std::adjacent_find``,``::std::copy``,``::std::copy_if``,
-``::std::copy_backward``,``::std::move``,``::std::move_backward``,
-``::std::fill``,``::std::transform``,``::std::replace``,``::std::replace_if``,
-``::std::generate``,``::std::remove``,``::std::remove_if``,
-``::std::remove_copy``,``::std::remove_copy_if``,``::std::unique``,
-``::std::unique_copy``,``::std::sample``,``::std::partition_point``,
-``::std::lower_bound``,``::std::upper_bound``,``::std::equal_range``,
-``::std::binary_search``,``::std::push_heap``,``::std::pop_heap``,
-``::std::make_heap``,``::std::sort_heap``,``::std::next_permutation``,
-``::std::prev_permutation``,``::std::iota``,``::std::reverse``,
-``::std::reverse_copy``,``::std::shift_left``,``::std::shift_right``,
-``::std::is_partitioned``,``::std::partition``,``::std::partition_copy``,
-``::std::stable_partition``,``::std::sort``,``::std::stable_sort``,
-``::std::is_sorted``,``::std::is_sorted_until``,``::std::is_heap``,
-``::std::is_heap_until``,``::std::max_element``,``::std::min_element``,
-``::std::minmax_element``,``::std::uninitialized_copy``,
-``::std::uninitialized_fill``,``::std::uninitialized_move``,
-``::std::uninitialized_default_construct``,
-``::std::uninitialized_value_construct``,``::std::destroy``,
-``::std::partial_sort_copy``,``::std::includes``,
-``::std::set_union``,``::std::set_intersection``,``::std::set_difference``,
-``::std::set_symmetric_difference``,``::std::merge``,
-``::std::lexicographical_compare``,``::std::find_end``,``::std::search``,
-``::std::is_permutation``,``::std::equal``,``::std::mismatch``.
+
+``std::adjacent_find``,
+``std::all_of``,
+``std::any_of``,
+``std::binary_search``,
+``std::copy_backward``,
+``std::copy_if``,
+``std::copy``,
+``std::destroy``,
+``std::equal_range``,
+``std::equal``,
+``std::fill``,
+``std::find_end``,
+``std::find_if_not``,
+``std::find_if``,
+``std::find``,
+``std::for_each``,
+``std::generate``,
+``std::includes``,
+``std::iota``,
+``std::is_heap_until``,
+``std::is_heap``,
+``std::is_partitioned``,
+``std::is_permutation``,
+``std::is_sorted_until``,
+``std::is_sorted``,
+``std::lexicographical_compare``,
+``std::lower_bound``,
+``std::make_heap``,
+``std::max_element``,
+``std::merge``,
+``std::min_element``,
+``std::minmax_element``,
+``std::mismatch``,
+``std::move_backward``,
+``std::move``,
+``std::next_permutation``,
+``std::none_of``,
+``std::partial_sort_copy``,
+``std::partition_copy``,
+``std::partition_point``,
+``std::partition``,
+``std::pop_heap``,
+``std::prev_permutation``,
+``std::push_heap``,
+``std::remove_copy_if``,
+``std::remove_copy``,
+``std::remove``, ``std::remove_if``,
+``std::replace_if``,
+``std::replace``,
+``std::reverse_copy``,
+``std::reverse``,
+``std::sample``,
+``std::search``,
+``std::set_difference``,
+``std::set_intersection``,
+``std::set_symmetric_difference``,
+``std::set_union``,
+``std::shift_left``,
+``std::shift_right``,
+``std::sort_heap``,
+``std::sort``,
+``std::stable_partition``,
+``std::stable_sort``,
+``std::transform``,
+``std::uninitialized_copy``,
+``std::uninitialized_default_construct``,
+``std::uninitialized_fill``,
+``std::uninitialized_move``,
+``std::uninitialized_value_construct``,
+``std::unique_copy``,
+``std::unique``,
+``std::upper_bound``.
 
 Reverse Iteration
 -----------------
@@ -62,7 +112,7 @@ fixed using the ``std::views::reverse`` adaptor.
   auto AreSame = std::equal(Items1.rbegin(), Items1.rend(),
                             std::crbegin(Items2), std::crend(Items2));
 
-transformst to:
+Transforms to:
 
 .. code-block:: c++
 


### PR DESCRIPTION
The formatting looked a little off in the Release notes webpage. This should address those issues