### PR TITLE
Reset PostAllocaInsertPt when the AllocaInsertPt is changed in clang::CodeGenFunction

### DIFF
--- a/clang/lib/CodeGen/CodeGenFunction.h
+++ b/clang/lib/CodeGen/CodeGenFunction.h
@@ -428,7 +428,6 @@ public:
   /// we prefer to insert allocas.
   llvm::AssertingVH<llvm::Instruction> AllocaInsertPt;
 
-private:
   /// PostAllocaInsertPt - This is a place in the prologue where code can be
   /// inserted that will be dominated by all the static allocas. This helps
   /// achieve two things:
@@ -439,7 +438,6 @@ private:
   /// PostAllocaInsertPt will be lazily created when it is *really* required.
   llvm::AssertingVH<llvm::Instruction> PostAllocaInsertPt = nullptr;
 
-public:
   /// Return PostAllocaInsertPt. If it is not yet created, then insert it
   /// immediately after AllocaInsertPt.
   llvm::Instruction *getPostAllocaInsertPoint() {
@@ -2004,11 +2002,17 @@ public:
 
         OldReturnBlock = CGF.ReturnBlock;
         CGF.ReturnBlock = CGF.getJumpDestInCurrentScope(&RetBB);
+
+        CGF.PostAllocaInsertPt = nullptr;
+
       }
 
       ~OutlinedRegionBodyRAII() {
         CGF.AllocaInsertPt = OldAllocaIP;
         CGF.ReturnBlock = OldReturnBlock;
+
+        CGF.PostAllocaInsertPt = nullptr;
+
       }
     };
 
@@ -2031,8 +2035,10 @@ public:
                "Insertion point should be in the entry block of containing "
                "function!");
         OldAllocaIP = CGF.AllocaInsertPt;
-        if (AllocaIP.isSet())
+        if (AllocaIP.isSet()) {
           CGF.AllocaInsertPt = &*AllocaIP.getPoint();
+          CGF.PostAllocaInsertPt = nullptr;
+        }
 
         // TODO: Remove the call, after making sure the counter is not used by
         //       the EHStack.
@@ -2042,7 +2048,11 @@ public:
         (void)CGF.getJumpDestInCurrentScope(&FiniBB);
       }
 
-      ~InlinedRegionBodyRAII() { CGF.AllocaInsertPt = OldAllocaIP; }
+      ~InlinedRegionBodyRAII()
+      {
+        CGF.AllocaInsertPt = OldAllocaIP;
+        CGF.PostAllocaInsertPt = nullptr;
+      }
     };
   };
 


### PR DESCRIPTION
Clang's CodeGenFunction tracks two insert points for "allocas". One where the alloca instructions are placed, and another (immediately following the allocas) where any address space casts are placed. For code outlining the two helper classes (OutlinedRegionBodyRAII and InlinedRegionBodyRAII) both change the first insert point which then causes a desync between the two insert points.

This changes nulls out the PostAllocaInsertPt whenever the AllocaInsertPt is changed which will cause those two insert points to sync up again the next time the PostAllocaInsertPt is referenced.