### PR TITLE
Fix assertion failure during conversion function overload resolution.

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -217,6 +217,8 @@ Bug Fixes to C++ Support
 - Clang now preserves the unexpanded flag in a lambda transform used for pack expansion. (#GH56852), (#GH85667),
   (#GH99877).
 - Fixed a bug when diagnosing ambiguous explicit specializations of constrained member functions.
+- Fixed an assertion failure when selecting a function from an overload set that includes a 
+  specialization of a conversion function template.
 
 Bug Fixes to AST Handling
 ^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/clang/lib/Sema/SemaConcept.cpp
+++ b/clang/lib/Sema/SemaConcept.cpp
@@ -1743,8 +1743,7 @@ bool Sema::IsAtLeastAsConstrained(NamedDecl *D1,
     auto IsExpectedEntity = [](const FunctionDecl *FD) {
       FunctionDecl::TemplatedKind Kind = FD->getTemplatedKind();
       return Kind == FunctionDecl::TK_NonTemplate ||
-             Kind == FunctionDecl::TK_MemberSpecialization ||
-             Kind == FunctionDecl::TK_FunctionTemplateSpecialization;
+             Kind == FunctionDecl::TK_FunctionTemplate;
     };
     const auto *FD2 = dyn_cast<FunctionDecl>(D2);
     (void)IsExpectedEntity;

--- a/clang/lib/Sema/SemaConcept.cpp
+++ b/clang/lib/Sema/SemaConcept.cpp
@@ -1743,7 +1743,7 @@ bool Sema::IsAtLeastAsConstrained(NamedDecl *D1,
     auto IsExpectedEntity = [](const FunctionDecl *FD) {
       FunctionDecl::TemplatedKind Kind = FD->getTemplatedKind();
       return Kind == FunctionDecl::TK_NonTemplate ||
-             Kind == FunctionDecl::TK_FunctionTemplate ||
+             Kind == FunctionDecl::TK_MemberSpecialization ||
              Kind == FunctionDecl::TK_FunctionTemplateSpecialization;
     };
     const auto *FD2 = dyn_cast<FunctionDecl>(D2);

--- a/clang/lib/Sema/SemaConcept.cpp
+++ b/clang/lib/Sema/SemaConcept.cpp
@@ -1743,7 +1743,8 @@ bool Sema::IsAtLeastAsConstrained(NamedDecl *D1,
     auto IsExpectedEntity = [](const FunctionDecl *FD) {
       FunctionDecl::TemplatedKind Kind = FD->getTemplatedKind();
       return Kind == FunctionDecl::TK_NonTemplate ||
-             Kind == FunctionDecl::TK_FunctionTemplate;
+             Kind == FunctionDecl::TK_FunctionTemplate ||
+             Kind == FunctionDecl::TK_FunctionTemplateSpecialization;
     };
     const auto *FD2 = dyn_cast<FunctionDecl>(D2);
     (void)IsExpectedEntity;

--- a/clang/lib/Sema/SemaTemplateDeduction.cpp
+++ b/clang/lib/Sema/SemaTemplateDeduction.cpp
@@ -5805,22 +5805,18 @@ FunctionDecl *Sema::getMoreConstrainedFunction(FunctionDecl *FD1,
                                                FunctionDecl *FD2) {
   assert(!FD1->getDescribedTemplate() && !FD2->getDescribedTemplate() &&
          "not for function templates");
+  assert(!FD1->isFunctionTemplateSpecialization() ||
+         isa<CXXConversionDecl>(FD1));
+  assert(!FD2->isFunctionTemplateSpecialization() ||
+         isa<CXXConversionDecl>(FD2));
 
-  auto getTemplatePattern = [](FunctionDecl *FD) {
-    // Specializations of conversion function templates are believed to be the
-    // only case where a function template specialization reaches here.
-    assert(!FD->isFunctionTemplateSpecialization() ||
-           isa<CXXConversionDecl>(FD));
+  FunctionDecl *F1 = FD1;
+  if (FunctionDecl *P = FD1->getTemplateInstantiationPattern(false))
+    F1 = P;
 
-    if (FunctionDecl *MF = FD->getInstantiatedFromMemberFunction())
-      return MF;
-    else if (FunctionTemplateDecl *FTD = FD->getPrimaryTemplate())
-      return FTD->getTemplatedDecl();
-
-    return FD;
-  };
-  FunctionDecl *F1 = getTemplatePattern(FD1);
-  FunctionDecl *F2 = getTemplatePattern(FD2);
+  FunctionDecl *F2 = FD2;
+  if (FunctionDecl *P = FD2->getTemplateInstantiationPattern(false))
+    F2 = P;
 
   llvm::SmallVector<const Expr *, 1> AC1, AC2;
   F1->getAssociatedConstraints(AC1);

--- a/clang/test/SemaCXX/PR98671.cpp
+++ b/clang/test/SemaCXX/PR98671.cpp
@@ -1,6 +1,6 @@
 // RUN: %clang_cc1 -std=c++20 -fsyntax-only %s -verify
 
-struct S {
+struct S1 {
   operator int();
 
   template <typename T>
@@ -10,5 +10,19 @@ struct S {
 
 // Ensure that no assertion is raised when overload resolution fails while
 // choosing between an operator function template and an operator function.
-constexpr auto r = &S::operator int;
+constexpr auto r = &S1::operator int;
 // expected-error@-1 {{initializer of type '<overloaded function type>'}}
+
+
+template <typename T>
+struct S2 {
+  template <typename U=T>
+    S2(U={}) requires (sizeof(T) > 0) {}
+    // expected-note@-1 {{candidate constructor}}
+
+  template <typename U=T>
+    S2(U={}) requires (true) {}
+    // expected-note@-1 {{candidate constructor}}
+};
+
+S2<int> s;  // expected-error {{call to constructor of 'S2<int>' is ambiguous}}

--- a/clang/test/SemaCXX/PR98671.cpp
+++ b/clang/test/SemaCXX/PR98671.cpp
@@ -1,0 +1,14 @@
+// RUN: %clang_cc1 -std=c++20 -fsyntax-only %s -verify
+
+struct S {
+  operator int();
+
+  template <typename T>
+  operator T();
+};
+
+
+// Ensure that no assertion is raised when overload resolution fails while
+// choosing between an operator function template and an operator function.
+constexpr auto r = &S::operator int;
+// expected-error@-1 {{initializer of type '<overloaded function type>'}}


### PR DESCRIPTION
When clang is built with assertions, an otherwise silent (and seemingly innocuous) assertion failure from `SemaConcept.cpp` is triggered by the following program:

```cpp
struct S {
  operator int();
  template <typename T> operator T();
};

constexpr auto r = &S::operator int;
```

The function in question compares the "constrained-ness" of `S::operator int` and `S::operator T<int>`; the template kind of the former is `TK_NonTemplate`, whereas the template kind of the later is `TK_FunctionTemplateSpecialization`. The later kind is not "expected" by the function, thus the assertion-failure.