### PR TITLE
Make BytecodeOpInterface self-contained

### DIFF
--- a/utils/bazel/llvm-project-overlay/mlir/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/mlir/BUILD.bazel
@@ -8643,7 +8643,11 @@ gentbl_cc_library(
 
 cc_library(
     name = "BytecodeOpInterface",
-    srcs = ["lib/Bytecode/BytecodeOpInterface.cpp"],
+    srcs = [
+        "include/mlir/Bytecode/BytecodeReader.h",
+        "include/mlir/Bytecode/BytecodeWriter.h",
+        "lib/Bytecode/BytecodeOpInterface.cpp",
+    ],
     hdrs = [
         "include/mlir/Bytecode/BytecodeImplementation.h",
         "include/mlir/Bytecode/BytecodeOpInterface.h",


### PR DESCRIPTION
BytecodeOpInterface.h includes BytecodeReader.h and BytecodeWriter.h

However, the BytecodeReader and BytecodeWriter targets depend on the
BytecodeOpInterface target, so they can't be added to deps without
creating a circular dependency.

Work around this by adding the headers to srcs.
