### PR TITLE
[MachO] Detect overflow in section offset.

### DIFF
--- a/llvm/lib/MC/MachObjectWriter.cpp
+++ b/llvm/lib/MC/MachObjectWriter.cpp
@@ -911,13 +911,13 @@ uint64_t MachObjectWriter::writeObject(MCAssembler &Asm) {
     if (!cast<MCSectionMachO>(Sec).isVirtualSection() &&
         !isUInt<32>(SectionStart)) {
       Asm.getContext().reportError(
-          SMLoc(), "Cannot encode offset of section; object file too large");
+          SMLoc(), "cannot encode offset of section; object file too large");
       return NumBytesWritten();
     }
     if (NumRelocs && !isUInt<32>(RelocTableEnd)) {
       Asm.getContext().reportError(
           SMLoc(),
-          "Cannot encode offset of relocations; object file too large");
+          "cannot encode offset of relocations; object file too large");
       return NumBytesWritten();
     }
     writeSection(Asm, Sec, getSectionAddress(&Sec), SectionStart, Flags,

--- a/llvm/lib/MC/MachObjectWriter.cpp
+++ b/llvm/lib/MC/MachObjectWriter.cpp
@@ -282,6 +282,8 @@ void MachObjectWriter::writeSection(const MCAssembler &Asm,
   W.write<uint32_t>(FileOffset);
 
   W.write<uint32_t>(Log2(Section.getAlign()));
+  if (NumRelocations && !isUInt<32>(RelocationsStart))
+    report_fatal_error("Cannot encode offset of relocations");
   W.write<uint32_t>(NumRelocations ? RelocationsStart : 0);
   W.write<uint32_t>(NumRelocations);
   W.write<uint32_t>(Flags);

--- a/llvm/lib/MC/MachObjectWriter.cpp
+++ b/llvm/lib/MC/MachObjectWriter.cpp
@@ -277,6 +277,8 @@ void MachObjectWriter::writeSection(const MCAssembler &Asm,
     W.write<uint32_t>(VMAddr);      // address
     W.write<uint32_t>(SectionSize); // size
   }
+  if (!isUInt<32>(FileOffset))
+    report_fatal_error("Cannot encode offset of section");
   W.write<uint32_t>(FileOffset);
 
   W.write<uint32_t>(Log2(Section.getAlign()));

--- a/llvm/lib/MC/MachObjectWriter.cpp
+++ b/llvm/lib/MC/MachObjectWriter.cpp
@@ -277,13 +277,12 @@ void MachObjectWriter::writeSection(const MCAssembler &Asm,
     W.write<uint32_t>(VMAddr);      // address
     W.write<uint32_t>(SectionSize); // size
   }
-  if (!isUInt<32>(FileOffset))
-    report_fatal_error("Cannot encode offset of section");
+  assert(isUInt<32>(FileOffset) && "Cannot encode offset of section");
   W.write<uint32_t>(FileOffset);
 
   W.write<uint32_t>(Log2(Section.getAlign()));
-  if (NumRelocations && !isUInt<32>(RelocationsStart))
-    report_fatal_error("Cannot encode offset of relocations");
+  assert((!NumRelocations || isUInt<32>(RelocationsStart)) &&
+         "Cannot encode offset of relocations");
   W.write<uint32_t>(NumRelocations ? RelocationsStart : 0);
   W.write<uint32_t>(NumRelocations);
   W.write<uint32_t>(Flags);
@@ -779,6 +778,7 @@ void MachObjectWriter::populateAddrSigSection(MCAssembler &Asm) {
 
 uint64_t MachObjectWriter::writeObject(MCAssembler &Asm) {
   uint64_t StartOffset = W.OS.tell();
+  auto NumBytesWritten = [&] { return W.OS.tell() - StartOffset; };
 
   populateAddrSigSection(Asm);
 
@@ -908,6 +908,18 @@ uint64_t MachObjectWriter::writeObject(MCAssembler &Asm) {
     unsigned Flags = Sec.getTypeAndAttributes();
     if (Sec.hasInstructions())
       Flags |= MachO::S_ATTR_SOME_INSTRUCTIONS;
+    if (!cast<MCSectionMachO>(Sec).isVirtualSection() &&
+        !isUInt<32>(SectionStart)) {
+      Asm.getContext().reportError(
+          SMLoc(), "Cannot encode offset of section; object file too large");
+      return NumBytesWritten();
+    }
+    if (NumRelocs && !isUInt<32>(RelocTableEnd)) {
+      Asm.getContext().reportError(
+          SMLoc(),
+          "Cannot encode offset of relocations; object file too large");
+      return NumBytesWritten();
+    }
     writeSection(Asm, Sec, getSectionAddress(&Sec), SectionStart, Flags,
                  RelocTableEnd, NumRelocs);
     RelocTableEnd += NumRelocs * sizeof(MachO::any_relocation_info);
@@ -1092,7 +1104,7 @@ uint64_t MachObjectWriter::writeObject(MCAssembler &Asm) {
     StringTable.write(W.OS);
   }
 
-  return W.OS.tell() - StartOffset;
+  return NumBytesWritten();
 }
 
 std::unique_ptr<MCObjectWriter>

--- a/llvm/test/MC/MachO/section-offset-overflow.s
+++ b/llvm/test/MC/MachO/section-offset-overflow.s
@@ -1,6 +1,6 @@
-// RUN: not llvm-mc -triple x86_64-apple-macosx -filetype=obj -o /dev/null %s 2>&1 | FileCheck  %s
+// RUN: not llvm-mc -triple x86_64-apple-macosx -filetype=obj -o /dev/null %s 2>&1 | FileCheck %s
 
-// CHECK: Cannot encode offset of section
+// CHECK: error: cannot encode offset of section
 
         .data
         .long 1

--- a/llvm/test/MC/MachO/section-offset-overflow.s
+++ b/llvm/test/MC/MachO/section-offset-overflow.s
@@ -1,4 +1,4 @@
-// RUN: not --crash llvm-mc -triple x86_64-apple-macosx -filetype=obj -o /dev/null %s 2>&1 | FileCheck  %s
+// RUN: not llvm-mc -triple x86_64-apple-macosx -filetype=obj -o /dev/null %s 2>&1 | FileCheck  %s
 
 // CHECK: Cannot encode offset of section
 

--- a/llvm/test/MC/MachO/section-offset-overflow.s
+++ b/llvm/test/MC/MachO/section-offset-overflow.s
@@ -1,0 +1,9 @@
+// RUN: not --crash llvm-mc -triple x86_64-apple-macosx -filetype=obj -o /dev/null %s 2>&1 | FileCheck  %s
+
+// CHECK: Cannot encode offset of section
+
+        .data
+        .long 1
+        .zero 0x100000000
+        .const
+        .long 1


### PR DESCRIPTION
The section offset field is only 32 bits; if the computed section offset is larger, make sure we don't emit a corrupt object file.