### PR TITLE
[MemCpyOpt] Use `dyn_cast` to fix assertion failure in `processMemCpyMemCpyDependence`

### DIFF
--- a/llvm/lib/Transforms/Scalar/MemCpyOptimizer.cpp
+++ b/llvm/lib/Transforms/Scalar/MemCpyOptimizer.cpp
@@ -1188,8 +1188,9 @@ bool MemCpyOptPass::processMemCpyMemCpyDependence(MemCpyInst *M,
     if (MDestOffset == MForwardOffset)
       CopySource = M->getDest();
     else {
-      NewCopySource = cast<Instruction>(Builder.CreateInBoundsPtrAdd(
-          CopySource, Builder.getInt64(MForwardOffset)));
+      NewCopySource = GetElementPtrInst::CreateInBounds(
+          Builder.getInt8Ty(), CopySource, Builder.getInt64(MForwardOffset), "",
+          Builder.GetInsertPoint());
       CopySource = NewCopySource;
     }
     // We need to update `MCopyLoc` if an offset exists.

--- a/llvm/lib/Transforms/Scalar/MemCpyOptimizer.cpp
+++ b/llvm/lib/Transforms/Scalar/MemCpyOptimizer.cpp
@@ -1188,10 +1188,9 @@ bool MemCpyOptPass::processMemCpyMemCpyDependence(MemCpyInst *M,
     if (MDestOffset == MForwardOffset)
       CopySource = M->getDest();
     else {
-      NewCopySource = GetElementPtrInst::CreateInBounds(
-          Builder.getInt8Ty(), CopySource, Builder.getInt64(MForwardOffset), "",
-          Builder.GetInsertPoint());
-      CopySource = NewCopySource;
+      CopySource = Builder.CreateInBoundsPtrAdd(
+          CopySource, Builder.getInt64(MForwardOffset));
+      NewCopySource = dyn_cast<Instruction>(CopySource);
     }
     // We need to update `MCopyLoc` if an offset exists.
     MCopyLoc = MCopyLoc.getWithNewPtr(CopySource);

--- a/llvm/test/Transforms/MemCpyOpt/memcpy-memcpy-offset.ll
+++ b/llvm/test/Transforms/MemCpyOpt/memcpy-memcpy-offset.ll
@@ -205,8 +205,7 @@ define void @pr98675(ptr noalias %p1, ptr noalias %p2) {
 ; CHECK-SAME: ptr noalias [[P1:%.*]], ptr noalias [[P2:%.*]]) {
 ; CHECK-NEXT:    call void @llvm.memcpy.p0.p0.i64(ptr [[P1]], ptr @buf, i64 26, i1 false)
 ; CHECK-NEXT:    [[GEP:%.*]] = getelementptr i8, ptr [[P1]], i64 10
-; CHECK-NEXT:    [[TMP1:%.*]] = getelementptr inbounds i8, ptr @buf, i64 10
-; CHECK-NEXT:    call void @llvm.memcpy.p0.p0.i64(ptr [[P2]], ptr [[TMP1]], i64 1, i1 false)
+; CHECK-NEXT:    call void @llvm.memcpy.p0.p0.i64(ptr [[P2]], ptr getelementptr inbounds (i8, ptr @buf, i64 10), i64 1, i1 false)
 ; CHECK-NEXT:    ret void
 ;
   call void @llvm.memcpy.p0.p0.i64(ptr %p1, ptr @buf, i64 26, i1 false)

--- a/llvm/test/Transforms/MemCpyOpt/memcpy-memcpy-offset.ll
+++ b/llvm/test/Transforms/MemCpyOpt/memcpy-memcpy-offset.ll
@@ -197,6 +197,24 @@ define void @do_not_forward_offset_and_store(ptr %src, ptr %dest) {
   ret void
 }
 
+; Make sure we don't crash when the copy source is a constant.
+@buf = external global [32 x i8]
+
+define void @pr98675(ptr noalias %p1, ptr noalias %p2) {
+; CHECK-LABEL: define void @pr98675(
+; CHECK-SAME: ptr noalias [[P1:%.*]], ptr noalias [[P2:%.*]]) {
+; CHECK-NEXT:    call void @llvm.memcpy.p0.p0.i64(ptr [[P1]], ptr @buf, i64 26, i1 false)
+; CHECK-NEXT:    [[GEP:%.*]] = getelementptr i8, ptr [[P1]], i64 10
+; CHECK-NEXT:    [[TMP1:%.*]] = getelementptr inbounds i8, ptr @buf, i64 10
+; CHECK-NEXT:    call void @llvm.memcpy.p0.p0.i64(ptr [[P2]], ptr [[TMP1]], i64 1, i1 false)
+; CHECK-NEXT:    ret void
+;
+  call void @llvm.memcpy.p0.p0.i64(ptr %p1, ptr @buf, i64 26, i1 false)
+  %gep = getelementptr i8, ptr %p1, i64 10
+  call void @llvm.memmove.p0.p0.i64(ptr %p2, ptr %gep, i64 1, i1 false)
+  ret void
+}
+
 declare void @use(ptr)
 
 declare void @llvm.memcpy.p0.p0.i64(ptr nocapture, ptr nocapture, i64, i1)


### PR DESCRIPTION
Fixes https://github.com/llvm/llvm-project/issues/98675.
