### PR TITLE
[LLDB] Make 'process load' take remote os path delimiter into account

### DIFF
--- a/lldb/source/Commands/CommandObjectProcess.cpp
+++ b/lldb/source/Commands/CommandObjectProcess.cpp
@@ -950,11 +950,13 @@ public:
                           ExecutionContext *execution_context) override {
       Status error;
       const int short_option = m_getopt_table[option_idx].val;
+      ArchSpec arch =
+          execution_context->GetProcessPtr()->GetSystemArchitecture();
       switch (short_option) {
       case 'i':
         do_install = true;
         if (!option_arg.empty())
-          install_path.SetFile(option_arg, FileSpec::Style::native);
+          install_path.SetFile(option_arg, arch.GetTriple());
         break;
       default:
         llvm_unreachable("Unimplemented option");

--- a/lldb/test/API/functionalities/load_unload/TestLoadUnload.py
+++ b/lldb/test/API/functionalities/load_unload/TestLoadUnload.py
@@ -62,7 +62,7 @@ class LoadUnloadTestCase(TestBase):
             for f in shlibs:
                 err = lldb.remote_platform.Put(
                     lldb.SBFileSpec(self.getBuildArtifact(f)),
-                    lldb.SBFileSpec(os.path.join(wd, f)),
+                    lldb.SBFileSpec(lldbutil.join_remote_paths(wd, f)),
                 )
                 if err.Fail():
                     raise RuntimeError(
@@ -71,7 +71,7 @@ class LoadUnloadTestCase(TestBase):
             if hidden_dir:
                 shlib = "libloadunload_d." + ext
                 hidden_dir = os.path.join(wd, "hidden")
-                hidden_file = os.path.join(hidden_dir, shlib)
+                hidden_file = lldbutil.join_remote_paths(hidden_dir, shlib)
                 err = lldb.remote_platform.MakeDirectory(hidden_dir)
                 if err.Fail():
                     raise RuntimeError(
@@ -405,8 +405,10 @@ class LoadUnloadTestCase(TestBase):
 
     # We can't find a breakpoint location for d_init before launching because
     # executable dependencies are resolved relative to the debuggers PWD. Bug?
+    # The remote lldb server resolves the executable dependencies correctly.
     @expectedFailureAll(
-        oslist=["freebsd", "linux", "netbsd"], triple=no_match("aarch64-.*-android")
+        oslist=["freebsd", "linux", "netbsd"],
+        remote=False,
     )
     @expectedFailureAll(oslist=["windows"], archs=["aarch64"])
     def test_static_init_during_load(self):


### PR DESCRIPTION
Currently, if we execute 'process load' with remote debugging, it uses the host's path delimiter to look up files on a target machine. If we run remote debugging of Linux target on Windows and execute "process load C:\foo\a.so", lldb-server tries to load \foo\a.so instead of /foo/a.so on the remote.

It affects several API tests.

This commit fixes that error. Also, it contains minor fixes for TestLoadUnload.py for testing on Windows host and Linux target.