### PR TITLE
[lldb][test] Fix TestStdCXXDisassembly test for case when tests are linked with libc++ statically

### DIFF
--- a/lldb/test/API/lang/cpp/stl/Makefile
+++ b/lldb/test/API/lang/cpp/stl/Makefile
@@ -1,3 +1,5 @@
 CXX_SOURCES := main.cpp
 
+USE_SYSTEM_STDLIB := 1
+
 include Makefile.rules

--- a/lldb/test/API/lang/cpp/stl/TestStdCXXDisassembly.py
+++ b/lldb/test/API/lang/cpp/stl/TestStdCXXDisassembly.py
@@ -44,7 +44,7 @@ class StdCXXDisassembleTestCase(TestBase):
         # module is the corresponding SBModule.
 
         self.expect(
-            lib_stdcxx, "Libraray StdC++ is located", exe=False, substrs=["lib"]
+            lib_stdcxx, "Library StdC++ is located", exe=False, substrs=["lib"]
         )
 
         self.runCmd("image dump symtab '%s'" % lib_stdcxx)

--- a/lldb/test/API/lang/cpp/stl/TestStdCXXDisassembly.py
+++ b/lldb/test/API/lang/cpp/stl/TestStdCXXDisassembly.py
@@ -43,9 +43,7 @@ class StdCXXDisassembleTestCase(TestBase):
         # At this point, lib_stdcxx is the full path to the stdc++ library and
         # module is the corresponding SBModule.
 
-        self.expect(
-            lib_stdcxx, "Library StdC++ is located", exe=False, substrs=["lib"]
-        )
+        self.expect(lib_stdcxx, "Library StdC++ is located", exe=False, substrs=["lib"])
 
         self.runCmd("image dump symtab '%s'" % lib_stdcxx)
         raw_output = self.res.GetOutput()


### PR DESCRIPTION
This is to fix buildbot failure https://lab.llvm.org/staging/#/builders/195/builds/4255.

The test expects 'libstdc++' or 'libc++' SO module in the module list. In case when static linking with libc++ is on by default, none of them may be present.

Thus, USE_SYSTEM_STDLIB is added to ensure the presence of any of them.