### PR TITLE
[clang] Prevent dangling StringRefs

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -830,6 +830,8 @@ Bug Fixes in This Version
 - ``__is_trivially_equality_comparable`` no longer returns true for types which
   have a constrained defaulted comparison operator (#GH89293).
 
+- Fixed Clang from generating dangling StringRefs when deserializing Exprs & Stmts (#GH98667)
+
 Bug Fixes to Compiler Builtins
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
Fix locations where dangling StringRefs are created.

* `ConstraintSatisfaction::SubstitutionDiagnostic`: typedef of `std::pair<SourceLocation, StringRef>`

* `concepts::Requirement::SubstitutionDiagnostic`: struct whose 1st and 3rd data members are `StringRef`s

Fixes #98667