### PR TITLE
[lldb][test] Enable static linking with libcxx for import-std-module tests

### DIFF
--- a/lldb/test/API/commands/expression/import-std-module/array/Makefile
+++ b/lldb/test/API/commands/expression/import-std-module/array/Makefile
@@ -1,3 +1,8 @@
 USE_LIBCPP := 1
 CXX_SOURCES := main.cpp
+
+ifneq ($(OS),Darwin)
+	LD_EXTRAS := -Xlinker --whole-archive -Xlinker --allow-multiple-definition
+endif
+
 include Makefile.rules

--- a/lldb/test/API/commands/expression/import-std-module/deque-dbg-info-content/Makefile
+++ b/lldb/test/API/commands/expression/import-std-module/deque-dbg-info-content/Makefile
@@ -1,3 +1,8 @@
 USE_LIBCPP := 1
 CXX_SOURCES := main.cpp
+
+ifneq ($(OS),Darwin)
+	LD_EXTRAS := -Xlinker --whole-archive -Xlinker --allow-multiple-definition
+endif
+
 include Makefile.rules

--- a/lldb/test/API/commands/expression/import-std-module/list-dbg-info-content/Makefile
+++ b/lldb/test/API/commands/expression/import-std-module/list-dbg-info-content/Makefile
@@ -1,3 +1,8 @@
 USE_LIBCPP := 1
 CXX_SOURCES := main.cpp
+
+ifneq ($(OS),Darwin)
+	LD_EXTRAS := -Xlinker --whole-archive -Xlinker --allow-multiple-definition
+endif
+
 include Makefile.rules

--- a/lldb/test/API/commands/expression/import-std-module/vector-dbg-info-content/Makefile
+++ b/lldb/test/API/commands/expression/import-std-module/vector-dbg-info-content/Makefile
@@ -1,3 +1,8 @@
 USE_LIBCPP := 1
 CXX_SOURCES := main.cpp
+
+ifneq ($(OS),Darwin)
+	LD_EXTRAS := -Xlinker --whole-archive -Xlinker --allow-multiple-definition
+endif
+
 include Makefile.rules

--- a/lldb/test/API/commands/expression/import-std-module/vector-of-vectors/Makefile
+++ b/lldb/test/API/commands/expression/import-std-module/vector-of-vectors/Makefile
@@ -1,3 +1,8 @@
 USE_LIBCPP := 1
 CXX_SOURCES := main.cpp
+
+ifneq ($(OS),Darwin)
+	LD_EXTRAS := -Xlinker --whole-archive -Xlinker --allow-multiple-definition
+endif
+
 include Makefile.rules


### PR DESCRIPTION
--whole-archive and --allow-multiple-definition options has been added to linker flags of these import-std-module tests in order to make them pass with libcxx static linking enabled.

Darwin has been excluded since it doesn't seem to be built in this configuration.

Also, some tests were switched from system stdlib to libcxx since the problem described in https://reviews.llvm.org/D139361 seems to be fixed.