### PR TITLE
[ADT] Make set_subtract more efficient when subtrahend is larger (NFC)

### DIFF
--- a/llvm/include/llvm/ADT/SetOperations.h
+++ b/llvm/include/llvm/ADT/SetOperations.h
@@ -92,9 +92,27 @@ S1Ty set_difference(const S1Ty &S1, const S2Ty &S2) {
   return Result;
 }
 
+/// set_subtract_vec(A, B) - Compute A := A - B, where B can be a vector.
+///
+template <class S1Ty, class S2Ty>
+void set_subtract_vec(S1Ty &S1, const S2Ty &S2) {
+  for (typename S2Ty::const_iterator SI = S2.begin(), SE = S2.end(); SI != SE;
+       ++SI)
+    S1.erase(*SI);
+}
+
 /// set_subtract(A, B) - Compute A := A - B
 ///
+/// Selects the set to iterate based on the relative sizes of A and B for better
+/// efficiency.
+///
 template <class S1Ty, class S2Ty> void set_subtract(S1Ty &S1, const S2Ty &S2) {
+  if (S1.size() < S2.size()) {
+    for (typename S1Ty::iterator SI = S1.begin(), SE = S1.end(); SI != SE; ++SI)
+      if (S2.count(*SI))
+        S1.erase(SI);
+    return;
+  }
   for (typename S2Ty::const_iterator SI = S2.begin(), SE = S2.end(); SI != SE;
        ++SI)
     S1.erase(*SI);

--- a/llvm/include/llvm/ADT/SetOperations.h
+++ b/llvm/include/llvm/ADT/SetOperations.h
@@ -99,15 +99,13 @@ S1Ty set_difference(const S1Ty &S1, const S2Ty &S2) {
 ///
 template <class S1Ty, class S2Ty> void set_subtract(S1Ty &S1, const S2Ty &S2) {
   using ElemTy = decltype(*S1.begin());
-  // A couple callers pass a vector for S2, which doesn't support count(), and
-  // wouldn't be efficient if it did. In the absence of a more direct check,
-  // ensure the type supports the contains or find interfaces.
-  if constexpr (detail::HasMemberContains<S2Ty, ElemTy> ||
-                detail::HasMemberFind<S2Ty, ElemTy>) {
+  // A couple callers pass a vector for S2, which doesn't support contains(),
+  // and wouldn't be efficient if it did.
+  if constexpr (detail::HasMemberContains<S2Ty, ElemTy>) {
     if (S1.size() < S2.size()) {
       for (typename S1Ty::iterator SI = S1.begin(), SE = S1.end(); SI != SE;
            ++SI)
-        if (S2.count(*SI))
+        if (S2.contains(*SI))
           S1.erase(SI);
       return;
     }

--- a/llvm/include/llvm/ADT/SetOperations.h
+++ b/llvm/include/llvm/ADT/SetOperations.h
@@ -92,26 +92,25 @@ S1Ty set_difference(const S1Ty &S1, const S2Ty &S2) {
   return Result;
 }
 
-/// set_subtract_vec(A, B) - Compute A := A - B, where B can be a vector.
-///
-template <class S1Ty, class S2Ty>
-void set_subtract_vec(S1Ty &S1, const S2Ty &S2) {
-  for (typename S2Ty::const_iterator SI = S2.begin(), SE = S2.end(); SI != SE;
-       ++SI)
-    S1.erase(*SI);
-}
-
 /// set_subtract(A, B) - Compute A := A - B
 ///
 /// Selects the set to iterate based on the relative sizes of A and B for better
 /// efficiency.
 ///
 template <class S1Ty, class S2Ty> void set_subtract(S1Ty &S1, const S2Ty &S2) {
-  if (S1.size() < S2.size()) {
-    for (typename S1Ty::iterator SI = S1.begin(), SE = S1.end(); SI != SE; ++SI)
-      if (S2.count(*SI))
-        S1.erase(SI);
-    return;
+  using ElemTy = decltype(*S1.begin());
+  // A couple callers pass a vector for S2, which doesn't support count(), and
+  // wouldn't be efficient if it did. In the absence of a more direct check,
+  // ensure the type supports the contains or find interfaces.
+  if constexpr (detail::HasMemberContains<S2Ty, ElemTy> ||
+                detail::HasMemberFind<S2Ty, ElemTy>) {
+    if (S1.size() < S2.size()) {
+      for (typename S1Ty::iterator SI = S1.begin(), SE = S1.end(); SI != SE;
+           ++SI)
+        if (S2.count(*SI))
+          S1.erase(SI);
+      return;
+    }
   }
   for (typename S2Ty::const_iterator SI = S2.begin(), SE = S2.end(); SI != SE;
        ++SI)

--- a/llvm/lib/CodeGen/MachineVerifier.cpp
+++ b/llvm/lib/CodeGen/MachineVerifier.cpp
@@ -2909,7 +2909,8 @@ void MachineVerifier::checkLiveness(const MachineOperand *MO, unsigned MONum) {
 void MachineVerifier::visitMachineBundleAfter(const MachineInstr *MI) {
   BBInfo &MInfo = MBBInfoMap[MI->getParent()];
   set_union(MInfo.regsKilled, regsKilled);
-  set_subtract(regsLive, regsKilled); regsKilled.clear();
+  set_subtract_vec(regsLive, regsKilled);
+  regsKilled.clear();
   // Kill any masked registers.
   while (!regMasks.empty()) {
     const uint32_t *Mask = regMasks.pop_back_val();
@@ -2918,7 +2919,8 @@ void MachineVerifier::visitMachineBundleAfter(const MachineInstr *MI) {
           MachineOperand::clobbersPhysReg(Mask, Reg.asMCReg()))
         regsDead.push_back(Reg);
   }
-  set_subtract(regsLive, regsDead);   regsDead.clear();
+  set_subtract_vec(regsLive, regsDead);
+  regsDead.clear();
   set_union(regsLive, regsDefined);   regsDefined.clear();
 }
 

--- a/llvm/lib/CodeGen/MachineVerifier.cpp
+++ b/llvm/lib/CodeGen/MachineVerifier.cpp
@@ -2909,8 +2909,7 @@ void MachineVerifier::checkLiveness(const MachineOperand *MO, unsigned MONum) {
 void MachineVerifier::visitMachineBundleAfter(const MachineInstr *MI) {
   BBInfo &MInfo = MBBInfoMap[MI->getParent()];
   set_union(MInfo.regsKilled, regsKilled);
-  set_subtract_vec(regsLive, regsKilled);
-  regsKilled.clear();
+  set_subtract(regsLive, regsKilled); regsKilled.clear();
   // Kill any masked registers.
   while (!regMasks.empty()) {
     const uint32_t *Mask = regMasks.pop_back_val();
@@ -2919,8 +2918,7 @@ void MachineVerifier::visitMachineBundleAfter(const MachineInstr *MI) {
           MachineOperand::clobbersPhysReg(Mask, Reg.asMCReg()))
         regsDead.push_back(Reg);
   }
-  set_subtract_vec(regsLive, regsDead);
-  regsDead.clear();
+  set_subtract(regsLive, regsDead);   regsDead.clear();
   set_union(regsLive, regsDefined);   regsDefined.clear();
 }
 


### PR DESCRIPTION
If the subtrahend is larger, iterate the minuend set instead.

Noticed when subtracting a large set from a number of other smaller
sets for an upcoming MemProf change, this change makes that much faster.

I subsequently found a couple of callsites in one file that were calling
set_subtract with a vector subtrahend, which doesn't have the "count()"
interface. Add a separate helper for subtracting a vector.
