### PR TITLE
Add lldb version into initialize response lldb-dap

### DIFF
--- a/lldb/test/API/tools/lldb-dap/launch/TestDAP_launch.py
+++ b/lldb/test/API/tools/lldb-dap/launch/TestDAP_launch.py
@@ -475,3 +475,33 @@ class TestDAP_launch(lldbdap_testcase.DAPTestCaseBase):
             pattern=terminateCommands[0],
         )
         self.verify_commands("terminateCommands", output, terminateCommands)
+
+    @skipIfWindows
+    def test_version(self):
+        """
+        Tests that "initialize" response contains the "version" string the same
+        as the one returned by "version" command.
+        """
+        program = self.getBuildArtifact("a.out")
+        self.build_and_launch(program)
+
+        source = "main.c"
+        breakpoint_line = line_number(source, "// breakpoint 1")
+        lines = [breakpoint_line]
+        # Set breakpoint in the thread function so we can step the threads
+        breakpoint_ids = self.set_source_breakpoints(source, lines)
+        self.continue_to_breakpoints(breakpoint_ids)
+
+        version_eval_response = self.dap_server.request_evaluate(
+            "`version", context="repl"
+        )
+        version_eval_output = version_eval_response["body"]["result"]
+
+        # The first line is the prompt line like "(lldb) version", so we skip it.
+        version_eval_output_without_prompt_line = version_eval_output.splitlines()[1:]
+        version_string = self.dap_server.get_initialize_value("version")
+        self.assertEqual(
+            version_eval_output_without_prompt_line,
+            version_string.splitlines(),
+            "version string does not match",
+        )

--- a/lldb/test/API/tools/lldb-dap/launch/TestDAP_launch.py
+++ b/lldb/test/API/tools/lldb-dap/launch/TestDAP_launch.py
@@ -499,7 +499,8 @@ class TestDAP_launch(lldbdap_testcase.DAPTestCaseBase):
 
         # The first line is the prompt line like "(lldb) version", so we skip it.
         version_eval_output_without_prompt_line = version_eval_output.splitlines()[1:]
-        version_string = self.dap_server.get_initialize_value("version")
+        lldb_json = self.dap_server.get_initialize_value("__lldb")
+        version_string = lldb_json["version"]
         self.assertEqual(
             version_eval_output_without_prompt_line,
             version_string.splitlines(),

--- a/lldb/tools/lldb-dap/lldb-dap.cpp
+++ b/lldb/tools/lldb-dap/lldb-dap.cpp
@@ -1710,6 +1710,8 @@ void request_initialize(const llvm::json::Object &request) {
   body.try_emplace("supportsLogPoints", true);
   // The debug adapter supports data watchpoints.
   body.try_emplace("supportsDataBreakpoints", true);
+  // Putting version string. Note: this is not part of DAP spec.
+  body.try_emplace("version", g_dap.debugger.GetVersionString());
 
   response.try_emplace("body", std::move(body));
   g_dap.SendJSON(llvm::json::Value(std::move(response)));

--- a/lldb/tools/lldb-dap/lldb-dap.cpp
+++ b/lldb/tools/lldb-dap/lldb-dap.cpp
@@ -1710,8 +1710,11 @@ void request_initialize(const llvm::json::Object &request) {
   body.try_emplace("supportsLogPoints", true);
   // The debug adapter supports data watchpoints.
   body.try_emplace("supportsDataBreakpoints", true);
-  // Putting version string. Note: this is not part of DAP spec.
-  body.try_emplace("version", g_dap.debugger.GetVersionString());
+
+  // Put in non-DAP specification lldb specific information.
+  llvm::json::Object lldb_json;
+  lldb_json.try_emplace("version", g_dap.debugger.GetVersionString());
+  body.try_emplace("__lldb", std::move(lldb_json));
 
   response.try_emplace("body", std::move(body));
   g_dap.SendJSON(llvm::json::Value(std::move(response)));


### PR DESCRIPTION
Frequently, while troubleshooting user's debugging issues in VScode, we would like to know lldb version so that we can confirm if certain patch/feature is in or not.

This PR adds version string into `initialize` response so that telemetry can track it. 