### PR TITLE
[SPARC][Driver] Add -m(no-)v8plus flags handling

### DIFF
--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -6077,6 +6077,10 @@ def mvis3 : Flag<["-"], "mvis3">, Group<m_sparc_Features_Group>;
 def mno_vis3 : Flag<["-"], "mno-vis3">, Group<m_sparc_Features_Group>;
 def mhard_quad_float : Flag<["-"], "mhard-quad-float">, Group<m_sparc_Features_Group>;
 def msoft_quad_float : Flag<["-"], "msoft-quad-float">, Group<m_sparc_Features_Group>;
+def mv8plus : Flag<["-"], "mv8plus">, Group<m_sparc_Features_Group>,
+  HelpText<"Enable V8+ mode, allowing use of 64-bit V9 instructions in 32-bit code">;
+def mno_v8plus : Flag<["-"], "mno-v8plus">, Group<m_sparc_Features_Group>,
+  HelpText<"Disable V8+ mode">;
 foreach i = 1 ... 7 in
   def ffixed_g#i : Flag<["-"], "ffixed-g"#i>, Group<m_sparc_Features_Group>,
     HelpText<"Reserve the G"#i#" register (SPARC only)">;

--- a/clang/lib/Driver/ToolChains/Arch/Sparc.cpp
+++ b/clang/lib/Driver/ToolChains/Arch/Sparc.cpp
@@ -181,9 +181,7 @@ void sparc::getSparcTargetFeatures(const Driver &D, const ArgList &Args,
 
   if (Arg *A = Args.getLastArg(options::OPT_mv8plus, options::OPT_mno_v8plus)) {
     if (A->getOption().matches(options::OPT_mv8plus))
-      Features.push_back("+v9");
-    else
-      Features.push_back("-v9");
+      Features.push_back("+v8plus");
   }
 
   if (Args.hasArg(options::OPT_ffixed_g1))

--- a/clang/lib/Driver/ToolChains/Arch/Sparc.cpp
+++ b/clang/lib/Driver/ToolChains/Arch/Sparc.cpp
@@ -179,6 +179,13 @@ void sparc::getSparcTargetFeatures(const Driver &D, const ArgList &Args,
       Features.push_back("-hard-quad-float");
   }
 
+  if (Arg *A = Args.getLastArg(options::OPT_mv8plus, options::OPT_mno_v8plus)) {
+    if (A->getOption().matches(options::OPT_mv8plus))
+      Features.push_back("+v9");
+    else
+      Features.push_back("-v9");
+  }
+
   if (Args.hasArg(options::OPT_ffixed_g1))
     Features.push_back("+reserve-g1");
 

--- a/clang/test/Driver/sparc-target-features.c
+++ b/clang/test/Driver/sparc-target-features.c
@@ -34,6 +34,4 @@
 // SOFT-QUAD-FLOAT: "-target-feature" "-hard-quad-float"
 
 // RUN: %clang --target=sparc -mv8plus %s -### 2>&1 | FileCheck -check-prefix=V8PLUS %s
-// RUN: %clang --target=sparc -mno-v8plus %s -### 2>&1 | FileCheck -check-prefix=NO-V8PLUS %s
-// V8PLUS: "-target-feature" "+v9"
-// NO-V8PLUS: "-target-feature" "-v9"
+// V8PLUS: "-target-feature" "+v8plus"

--- a/clang/test/Driver/sparc-target-features.c
+++ b/clang/test/Driver/sparc-target-features.c
@@ -32,3 +32,8 @@
 // RUN: %clang --target=sparc -msoft-quad-float %s -### 2>&1 | FileCheck -check-prefix=SOFT-QUAD-FLOAT %s
 // HARD-QUAD-FLOAT: "-target-feature" "+hard-quad-float"
 // SOFT-QUAD-FLOAT: "-target-feature" "-hard-quad-float"
+
+// RUN: %clang --target=sparc -mv8plus %s -### 2>&1 | FileCheck -check-prefix=V8PLUS %s
+// RUN: %clang --target=sparc -mno-v8plus %s -### 2>&1 | FileCheck -check-prefix=NO-V8PLUS %s
+// V8PLUS: "-target-feature" "+v9"
+// NO-V8PLUS: "-target-feature" "-v9"


### PR DESCRIPTION
Implement handling for `-m(no-)v8plus` flags to allow the user to switch between V8 and V8+ mode with 32-bit code.

Currently it only toggles the V8+ feature bit, ABI and codegen changes will be done in future patches.