### PR TITLE
[ADT] Remove StringRef::equals

### DIFF
--- a/llvm/include/llvm/ADT/StringRef.h
+++ b/llvm/include/llvm/ADT/StringRef.h
@@ -159,14 +159,6 @@ namespace llvm {
       return StringRef(S, Length);
     }
 
-    /// equals - Check for string equality, this is more efficient than
-    /// compare() when the relative ordering of inequal strings isn't needed.
-    [[nodiscard]] LLVM_DEPRECATED("Use == instead",
-                                  "==") bool equals(StringRef RHS) const {
-      return (Length == RHS.Length &&
-              compareMemory(Data, RHS.Data, RHS.Length) == 0);
-    }
-
     /// Check for string equality, ignoring case.
     [[nodiscard]] bool equals_insensitive(StringRef RHS) const {
       return Length == RHS.Length && compare_insensitive(RHS) == 0;


### PR DESCRIPTION
StringRef::equals has been deprecated since:

  commit de483ad513895c0adf7f21c7001c30f031998ea3
  Author: Kazu Hirata <kazu@google.com>
  Date:   Thu May 16 00:38:37 2024 -0700
