### PR TITLE
[clang] Add deprecation warning for `-Ofast` driver option

### DIFF
--- a/clang/docs/CommandGuide/clang.rst
+++ b/clang/docs/CommandGuide/clang.rst
@@ -421,7 +421,8 @@ Code Generation Options
 
     :option:`-Ofast` Enables all the optimizations from :option:`-O3` along
     with other aggressive optimizations that may violate strict compliance with
-    language standards.
+    language standards. This is deprecated in favor of :option:`-O3`
+    in combination with :option:`-ffast-math`.
 
     :option:`-Os` Like :option:`-O2` with extra optimizations to reduce code
     size.

--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -470,6 +470,9 @@ New Compiler Flags
 Deprecated Compiler Flags
 -------------------------
 
+- ``-Ofast`` is deprecated in favor of ``-O3``, possibly combined with ``-ffast-math``.
+  See `RFC <https://discourse.llvm.org/t/rfc-deprecate-ofast/78687>`_ for details.
+
 Modified Compiler Flags
 -----------------------
 - Added a new diagnostic flag ``-Wreturn-mismatch`` which is grouped under

--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -470,7 +470,11 @@ New Compiler Flags
 Deprecated Compiler Flags
 -------------------------
 
-- ``-Ofast`` is deprecated in favor of ``-O3``, possibly combined with ``-ffast-math``.
+- The ``-Ofast`` command-line option has been deprecated. This option both
+  enables the ``-O3`` optimization-level, as well as enabling non-standard
+  ``-ffast-math`` behaviors. As such, it is somewhat misleading as an
+  "optimization level". Users are advised to switch to ``-O3 -ffast-math`` if
+  the use of non-standard math behavior is intended, and ``-O3`` otherwise.
   See `RFC <https://discourse.llvm.org/t/rfc-deprecate-ofast/78687>`_ for details.
 
 Modified Compiler Flags

--- a/clang/include/clang/Basic/DiagnosticDriverKinds.td
+++ b/clang/include/clang/Basic/DiagnosticDriverKinds.td
@@ -443,8 +443,8 @@ def warn_drv_deprecated_arg_no_relaxed_template_template_args : Warning<
   "argument '-fno-relaxed-template-template-args' is deprecated">,
   InGroup<DeprecatedNoRelaxedTemplateTemplateArgs>;
 def warn_drv_deprecated_arg_ofast : Warning<
-  "argument '-Ofast' is deprecated; use '-O3 -ffast-math' instead,"
-  " or just '-O3' if you do not intend to enable non-conforming optimizations">,
+  "argument '-Ofast' is deprecated; use '-O3 -ffast math' for the same behavior,"
+  " or '-O3' to enable conforming optimizations only">,
   InGroup<DeprecatedOFast>;
 def warn_drv_deprecated_custom : Warning<
   "argument '%0' is deprecated, %1">, InGroup<Deprecated>;

--- a/clang/include/clang/Basic/DiagnosticDriverKinds.td
+++ b/clang/include/clang/Basic/DiagnosticDriverKinds.td
@@ -444,7 +444,7 @@ def warn_drv_deprecated_arg_no_relaxed_template_template_args : Warning<
   InGroup<DeprecatedNoRelaxedTemplateTemplateArgs>;
 def warn_drv_deprecated_arg_ofast : Warning<
   "argument '-Ofast' is deprecated; use '-O3 -ffast math' for the same behavior,"
-  " or '-O3' to enable conforming optimizations only">,
+  " or '-O3' to enable only conforming optimizations">,
   InGroup<DeprecatedOFast>;
 def warn_drv_deprecated_custom : Warning<
   "argument '%0' is deprecated, %1">, InGroup<Deprecated>;

--- a/clang/include/clang/Basic/DiagnosticDriverKinds.td
+++ b/clang/include/clang/Basic/DiagnosticDriverKinds.td
@@ -443,7 +443,8 @@ def warn_drv_deprecated_arg_no_relaxed_template_template_args : Warning<
   "argument '-fno-relaxed-template-template-args' is deprecated">,
   InGroup<DeprecatedNoRelaxedTemplateTemplateArgs>;
 def warn_drv_deprecated_arg_ofast : Warning<
-  "argument '-Ofast' is deprecated; use '-O3', possibly with '-ffast-math'">,
+  "argument '-Ofast' is deprecated; use '-O3 -ffast-math' instead,"
+  " or just '-O3' if you do not intend to enable non-conforming optimizations">,
   InGroup<DeprecatedOFast>;
 def warn_drv_deprecated_custom : Warning<
   "argument '%0' is deprecated, %1">, InGroup<Deprecated>;

--- a/clang/include/clang/Basic/DiagnosticDriverKinds.td
+++ b/clang/include/clang/Basic/DiagnosticDriverKinds.td
@@ -442,6 +442,9 @@ def warn_drv_deprecated_arg : Warning<
 def warn_drv_deprecated_arg_no_relaxed_template_template_args : Warning<
   "argument '-fno-relaxed-template-template-args' is deprecated">,
   InGroup<DeprecatedNoRelaxedTemplateTemplateArgs>;
+def warn_drv_deprecated_arg_ofast : Warning<
+  "argument '-Ofast' is deprecated; use '-O3', possibly with '-ffast-math'">,
+  InGroup<DeprecatedOFast>;
 def warn_drv_deprecated_custom : Warning<
   "argument '%0' is deprecated, %1">, InGroup<Deprecated>;
 def warn_drv_assuming_mfloat_abi_is : Warning<

--- a/clang/include/clang/Basic/DiagnosticGroups.td
+++ b/clang/include/clang/Basic/DiagnosticGroups.td
@@ -103,6 +103,7 @@ def EnumConversion : DiagGroup<"enum-conversion",
                                 EnumFloatConversion,
                                 EnumCompareConditional]>;
 def DeprecatedNoRelaxedTemplateTemplateArgs : DiagGroup<"deprecated-no-relaxed-template-template-args">;
+def DeprecatedOFast : DiagGroup<"deprecated-ofast">;
 def ObjCSignedCharBoolImplicitIntConversion :
   DiagGroup<"objc-signed-char-bool-implicit-int-conversion">;
 def Shorten64To32 : DiagGroup<"shorten-64-to-32">;
@@ -228,6 +229,7 @@ def Deprecated : DiagGroup<"deprecated", [DeprecatedAnonEnumEnumConversion,
                                           DeprecatedPragma,
                                           DeprecatedRegister,
                                           DeprecatedNoRelaxedTemplateTemplateArgs,
+                                          DeprecatedOFast,
                                           DeprecatedThisCapture,
                                           DeprecatedType,
                                           DeprecatedVolatile,

--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -932,8 +932,8 @@ def O_flag : Flag<["-"], "O">, Visibility<[ClangOption, CC1Option, FC1Option]>,
   Alias<O>, AliasArgs<["1"]>;
 def Ofast : Joined<["-"], "Ofast">, Group<O_Group>,
   Visibility<[ClangOption, CC1Option, FlangOption]>,
-  HelpText<"Deprecated; use '-O3 -ffast-math' instead,"
-  " or just '-O3' if you don't intend to enable non-conforming optimizations">;
+  HelpText<"Deprecated; use '-O3 -ffast math' for the same behavior,"
+  " or '-O3' to enable conforming optimizations only">;
 def P : Flag<["-"], "P">,
   Visibility<[ClangOption, CC1Option, FlangOption, FC1Option]>,
   Group<Preprocessor_Group>,

--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -933,7 +933,7 @@ def O_flag : Flag<["-"], "O">, Visibility<[ClangOption, CC1Option, FC1Option]>,
 def Ofast : Joined<["-"], "Ofast">, Group<O_Group>,
   Visibility<[ClangOption, CC1Option, FlangOption]>,
   HelpText<"Deprecated; use '-O3 -ffast math' for the same behavior,"
-  " or '-O3' to enable conforming optimizations only">;
+  " or '-O3' to enable only conforming optimizations">;
 def P : Flag<["-"], "P">,
   Visibility<[ClangOption, CC1Option, FlangOption, FC1Option]>,
   Group<Preprocessor_Group>,

--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -932,7 +932,7 @@ def O_flag : Flag<["-"], "O">, Visibility<[ClangOption, CC1Option, FC1Option]>,
   Alias<O>, AliasArgs<["1"]>;
 def Ofast : Joined<["-"], "Ofast">, Group<O_Group>,
   Visibility<[ClangOption, CC1Option, FlangOption]>,
-  HelpText<"Deprecated; use '-O3 -ffast math' instead,"
+  HelpText<"Deprecated; use '-O3 -ffast-math' instead,"
   " or just '-O3' if you don't intend to enable non-conforming optimizations">;
 def P : Flag<["-"], "P">,
   Visibility<[ClangOption, CC1Option, FlangOption, FC1Option]>,

--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -932,7 +932,8 @@ def O_flag : Flag<["-"], "O">, Visibility<[ClangOption, CC1Option, FC1Option]>,
   Alias<O>, AliasArgs<["1"]>;
 def Ofast : Joined<["-"], "Ofast">, Group<O_Group>,
   Visibility<[ClangOption, CC1Option, FlangOption]>,
-  HelpText<"Deprecated; use -O3, possibly with -ffast-math">;
+  HelpText<"Deprecated; use '-O3 -ffast math' instead,"
+  " or just '-O3' if you don't intend to enable non-conforming optimizations">;
 def P : Flag<["-"], "P">,
   Visibility<[ClangOption, CC1Option, FlangOption, FC1Option]>,
   Group<Preprocessor_Group>,

--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -931,7 +931,8 @@ def O : Joined<["-"], "O">, Group<O_Group>,
 def O_flag : Flag<["-"], "O">, Visibility<[ClangOption, CC1Option, FC1Option]>,
   Alias<O>, AliasArgs<["1"]>;
 def Ofast : Joined<["-"], "Ofast">, Group<O_Group>,
-  Visibility<[ClangOption, CC1Option, FlangOption]>;
+  Visibility<[ClangOption, CC1Option, FlangOption]>,
+  HelpText<"Deprecated; use -O3, possibly with -ffast-math">;
 def P : Flag<["-"], "P">,
   Visibility<[ClangOption, CC1Option, FlangOption, FC1Option]>,
   Group<Preprocessor_Group>,

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -5712,6 +5712,8 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
                      options::OPT_fno_zero_initialized_in_bss);
 
   bool OFastEnabled = isOptimizationLevelFast(Args);
+  if (OFastEnabled)
+    D.Diag(diag::warn_drv_deprecated_arg_ofast);
   // If -Ofast is the optimization level, then -fstrict-aliasing should be
   // enabled.  This alias option is being used to simplify the hasFlag logic.
   OptSpecifier StrictAliasingAliasOption =

--- a/clang/test/Driver/Ofast.c
+++ b/clang/test/Driver/Ofast.c
@@ -3,21 +3,21 @@
 // RUN: %clang -fno-fast-math -Ofast -### %s 2>&1 | FileCheck -check-prefix=CHECK-OFAST %s
 // RUN: %clang -fno-strict-aliasing -Ofast -### %s 2>&1 | FileCheck -check-prefix=CHECK-OFAST %s
 // RUN: %clang -fno-vectorize -Ofast -### %s 2>&1 | FileCheck -check-prefix=CHECK-OFAST %s
-// RUN: %clang -Ofast -O2 -### %s 2>&1 | FileCheck -check-prefix=CHECK-OFAST-O2 \
+// RUN: %clang -Ofast -O2 -### -Werror %s 2>&1 | FileCheck -check-prefix=CHECK-OFAST-O2 \
 // RUN:  %if target={{.*-windows-msvc.*}} %{ --check-prefix=CHECK-OFAST-O2-ALIASING-MSVC %} \
 // RUN:  %else %{ --check-prefix=CHECK-OFAST-O2-ALIASING %} %s
 // RUN: %clang -Ofast -fno-fast-math -### %s 2>&1 | FileCheck -check-prefix=CHECK-OFAST-NO-FAST-MATH %s
 // RUN: %clang -Ofast -fno-strict-aliasing -### %s 2>&1 | FileCheck -check-prefix=CHECK-OFAST-NO-STRICT-ALIASING %s
 // RUN: %clang -Ofast -fno-vectorize -### %s 2>&1 | FileCheck -check-prefix=CHECK-OFAST-NO-VECTORIZE %s
 
-// CHECK-OFAST: argument '-Ofast' is deprecated; use '-O3 -ffast-math' instead, or just '-O3' if you do not intend to enable non-conforming optimizations
+// CHECK-OFAST: use '-O3 -ffast math' for the same behavior, or '-O3' to enable conforming optimizations only
 // CHECK-OFAST: -cc1
 // CHECK-OFAST-NOT: -relaxed-aliasing
 // CHECK-OFAST: -ffast-math
 // CHECK-OFAST: -Ofast
 // CHECK-OFAST: -vectorize-loops
 
-// CHECK-OFAST-O2-NOT: argument '-Ofast' is deprecated; use '-O3 -ffast-math' instead, or just '-O3' if you do not intend to enable non-conforming optimizations
+// Lack of warning about '-Ofast' deprecation is checked via -Werror
 // CHECK-OFAST-O2: -cc1
 // CHECK-OFAST-O2-ALIASING-NOT: -relaxed-aliasing
 // CHECK-OFAST-O2-ALIASING-MSVC: -relaxed-aliasing
@@ -25,21 +25,21 @@
 // CHECK-OFAST-O2-NOT: -Ofast
 // CHECK-OFAST-O2: -vectorize-loops
 
-// CHECK-OFAST-NO-FAST-MATH: argument '-Ofast' is deprecated; use '-O3 -ffast-math' instead, or just '-O3' if you do not intend to enable non-conforming optimizations
+// CHECK-OFAST-NO-FAST-MATH: use '-O3 -ffast math' for the same behavior, or '-O3' to enable conforming optimizations only
 // CHECK-OFAST-NO-FAST-MATH: -cc1
 // CHECK-OFAST-NO-FAST-MATH-NOT: -relaxed-aliasing
 // CHECK-OFAST-NO-FAST-MATH-NOT: -ffast-math
 // CHECK-OFAST-NO-FAST-MATH: -Ofast
 // CHECK-OFAST-NO-FAST-MATH: -vectorize-loops
 
-// CHECK-OFAST-NO-STRICT-ALIASING: argument '-Ofast' is deprecated; use '-O3 -ffast-math' instead, or just '-O3' if you do not intend to enable non-conforming optimizations
+// CHECK-OFAST-NO-STRICT-ALIASING: use '-O3 -ffast math' for the same behavior, or '-O3' to enable conforming optimizations only
 // CHECK-OFAST-NO-STRICT-ALIASING: -cc1
 // CHECK-OFAST-NO-STRICT-ALIASING: -relaxed-aliasing
 // CHECK-OFAST-NO-STRICT-ALIASING: -ffast-math
 // CHECK-OFAST-NO-STRICT-ALIASING: -Ofast
 // CHECK-OFAST-NO-STRICT-ALIASING: -vectorize-loops
 
-// CHECK-OFAST-NO-VECTORIZE: argument '-Ofast' is deprecated; use '-O3 -ffast-math' instead, or just '-O3' if you do not intend to enable non-conforming optimizations
+// CHECK-OFAST-NO-VECTORIZE: use '-O3 -ffast math' for the same behavior, or '-O3' to enable conforming optimizations only
 // CHECK-OFAST-NO-VECTORIZE: -cc1
 // CHECK-OFAST-NO-VECTORIZE-NOT: -relaxed-aliasing
 // CHECK-OFAST-NO-VECTORIZE: -ffast-math

--- a/clang/test/Driver/Ofast.c
+++ b/clang/test/Driver/Ofast.c
@@ -10,7 +10,7 @@
 // RUN: %clang -Ofast -fno-strict-aliasing -### %s 2>&1 | FileCheck -check-prefix=CHECK-OFAST-NO-STRICT-ALIASING %s
 // RUN: %clang -Ofast -fno-vectorize -### %s 2>&1 | FileCheck -check-prefix=CHECK-OFAST-NO-VECTORIZE %s
 
-// CHECK-OFAST: use '-O3 -ffast math' for the same behavior, or '-O3' to enable conforming optimizations only
+// CHECK-OFAST: use '-O3 -ffast math' for the same behavior, or '-O3' to enable only conforming optimizations
 // CHECK-OFAST: -cc1
 // CHECK-OFAST-NOT: -relaxed-aliasing
 // CHECK-OFAST: -ffast-math
@@ -25,21 +25,21 @@
 // CHECK-OFAST-O2-NOT: -Ofast
 // CHECK-OFAST-O2: -vectorize-loops
 
-// CHECK-OFAST-NO-FAST-MATH: use '-O3 -ffast math' for the same behavior, or '-O3' to enable conforming optimizations only
+// CHECK-OFAST-NO-FAST-MATH: use '-O3 -ffast math' for the same behavior, or '-O3' to enable only conforming optimizations
 // CHECK-OFAST-NO-FAST-MATH: -cc1
 // CHECK-OFAST-NO-FAST-MATH-NOT: -relaxed-aliasing
 // CHECK-OFAST-NO-FAST-MATH-NOT: -ffast-math
 // CHECK-OFAST-NO-FAST-MATH: -Ofast
 // CHECK-OFAST-NO-FAST-MATH: -vectorize-loops
 
-// CHECK-OFAST-NO-STRICT-ALIASING: use '-O3 -ffast math' for the same behavior, or '-O3' to enable conforming optimizations only
+// CHECK-OFAST-NO-STRICT-ALIASING: use '-O3 -ffast math' for the same behavior, or '-O3' to enable only conforming optimizations
 // CHECK-OFAST-NO-STRICT-ALIASING: -cc1
 // CHECK-OFAST-NO-STRICT-ALIASING: -relaxed-aliasing
 // CHECK-OFAST-NO-STRICT-ALIASING: -ffast-math
 // CHECK-OFAST-NO-STRICT-ALIASING: -Ofast
 // CHECK-OFAST-NO-STRICT-ALIASING: -vectorize-loops
 
-// CHECK-OFAST-NO-VECTORIZE: use '-O3 -ffast math' for the same behavior, or '-O3' to enable conforming optimizations only
+// CHECK-OFAST-NO-VECTORIZE: use '-O3 -ffast math' for the same behavior, or '-O3' to enable only conforming optimizations
 // CHECK-OFAST-NO-VECTORIZE: -cc1
 // CHECK-OFAST-NO-VECTORIZE-NOT: -relaxed-aliasing
 // CHECK-OFAST-NO-VECTORIZE: -ffast-math

--- a/clang/test/Driver/Ofast.c
+++ b/clang/test/Driver/Ofast.c
@@ -10,13 +10,14 @@
 // RUN: %clang -Ofast -fno-strict-aliasing -### %s 2>&1 | FileCheck -check-prefix=CHECK-OFAST-NO-STRICT-ALIASING %s
 // RUN: %clang -Ofast -fno-vectorize -### %s 2>&1 | FileCheck -check-prefix=CHECK-OFAST-NO-VECTORIZE %s
 
-// CHECK-OFAST: warning: argument '-Ofast' is deprecated; use '-O3', possibly with '-ffast-math'
+// CHECK-OFAST: argument '-Ofast' is deprecated; use '-O3 -ffast-math' instead, or just '-O3' if you do not intend to enable non-conforming optimizations
 // CHECK-OFAST: -cc1
 // CHECK-OFAST-NOT: -relaxed-aliasing
 // CHECK-OFAST: -ffast-math
 // CHECK-OFAST: -Ofast
 // CHECK-OFAST: -vectorize-loops
 
+// CHECK-OFAST-O2-NOT: argument '-Ofast' is deprecated; use '-O3 -ffast-math' instead, or just '-O3' if you do not intend to enable non-conforming optimizations
 // CHECK-OFAST-O2: -cc1
 // CHECK-OFAST-O2-ALIASING-NOT: -relaxed-aliasing
 // CHECK-OFAST-O2-ALIASING-MSVC: -relaxed-aliasing
@@ -24,21 +25,21 @@
 // CHECK-OFAST-O2-NOT: -Ofast
 // CHECK-OFAST-O2: -vectorize-loops
 
-// CHECK-OFAST-NO-FAST-MATH: warning: argument '-Ofast' is deprecated; use '-O3', possibly with '-ffast-math'
+// CHECK-OFAST-NO-FAST-MATH: argument '-Ofast' is deprecated; use '-O3 -ffast-math' instead, or just '-O3' if you do not intend to enable non-conforming optimizations
 // CHECK-OFAST-NO-FAST-MATH: -cc1
 // CHECK-OFAST-NO-FAST-MATH-NOT: -relaxed-aliasing
 // CHECK-OFAST-NO-FAST-MATH-NOT: -ffast-math
 // CHECK-OFAST-NO-FAST-MATH: -Ofast
 // CHECK-OFAST-NO-FAST-MATH: -vectorize-loops
 
-// CHECK-OFAST-NO-STRICT-ALIASING: warning: argument '-Ofast' is deprecated; use '-O3', possibly with '-ffast-math'
+// CHECK-OFAST-NO-STRICT-ALIASING: argument '-Ofast' is deprecated; use '-O3 -ffast-math' instead, or just '-O3' if you do not intend to enable non-conforming optimizations
 // CHECK-OFAST-NO-STRICT-ALIASING: -cc1
 // CHECK-OFAST-NO-STRICT-ALIASING: -relaxed-aliasing
 // CHECK-OFAST-NO-STRICT-ALIASING: -ffast-math
 // CHECK-OFAST-NO-STRICT-ALIASING: -Ofast
 // CHECK-OFAST-NO-STRICT-ALIASING: -vectorize-loops
 
-// CHECK-OFAST-NO-VECTORIZE: warning: argument '-Ofast' is deprecated; use '-O3', possibly with '-ffast-math'
+// CHECK-OFAST-NO-VECTORIZE: argument '-Ofast' is deprecated; use '-O3 -ffast-math' instead, or just '-O3' if you do not intend to enable non-conforming optimizations
 // CHECK-OFAST-NO-VECTORIZE: -cc1
 // CHECK-OFAST-NO-VECTORIZE-NOT: -relaxed-aliasing
 // CHECK-OFAST-NO-VECTORIZE: -ffast-math

--- a/clang/test/Driver/Ofast.c
+++ b/clang/test/Driver/Ofast.c
@@ -10,6 +10,7 @@
 // RUN: %clang -Ofast -fno-strict-aliasing -### %s 2>&1 | FileCheck -check-prefix=CHECK-OFAST-NO-STRICT-ALIASING %s
 // RUN: %clang -Ofast -fno-vectorize -### %s 2>&1 | FileCheck -check-prefix=CHECK-OFAST-NO-VECTORIZE %s
 
+// CHECK-OFAST: warning: argument '-Ofast' is deprecated; use '-O3', possibly with '-ffast-math'
 // CHECK-OFAST: -cc1
 // CHECK-OFAST-NOT: -relaxed-aliasing
 // CHECK-OFAST: -ffast-math
@@ -23,18 +24,21 @@
 // CHECK-OFAST-O2-NOT: -Ofast
 // CHECK-OFAST-O2: -vectorize-loops
 
+// CHECK-OFAST-NO-FAST-MATH: warning: argument '-Ofast' is deprecated; use '-O3', possibly with '-ffast-math'
 // CHECK-OFAST-NO-FAST-MATH: -cc1
 // CHECK-OFAST-NO-FAST-MATH-NOT: -relaxed-aliasing
 // CHECK-OFAST-NO-FAST-MATH-NOT: -ffast-math
 // CHECK-OFAST-NO-FAST-MATH: -Ofast
 // CHECK-OFAST-NO-FAST-MATH: -vectorize-loops
 
+// CHECK-OFAST-NO-STRICT-ALIASING: warning: argument '-Ofast' is deprecated; use '-O3', possibly with '-ffast-math'
 // CHECK-OFAST-NO-STRICT-ALIASING: -cc1
 // CHECK-OFAST-NO-STRICT-ALIASING: -relaxed-aliasing
 // CHECK-OFAST-NO-STRICT-ALIASING: -ffast-math
 // CHECK-OFAST-NO-STRICT-ALIASING: -Ofast
 // CHECK-OFAST-NO-STRICT-ALIASING: -vectorize-loops
 
+// CHECK-OFAST-NO-VECTORIZE: warning: argument '-Ofast' is deprecated; use '-O3', possibly with '-ffast-math'
 // CHECK-OFAST-NO-VECTORIZE: -cc1
 // CHECK-OFAST-NO-VECTORIZE-NOT: -relaxed-aliasing
 // CHECK-OFAST-NO-VECTORIZE: -ffast-math


### PR DESCRIPTION
This patch implements consensus on the corresponding RFC documented here: https://discourse.llvm.org/t/rfc-deprecate-ofast/78687/72
Specifically, I added a deprecation warning for `-Ofast`, that suggests to use `-O3` or `-O3` with `-ffast-math`, and a new diagnostic group for aforementioned warning.
Deprecation period is going to be lengthy, so I hope this PR can be merged in time for Clang 19.