### PR TITLE
[ADT] Add a missing call to a unique_function destructor after move

### DIFF
--- a/llvm/include/llvm/ADT/FunctionExtras.h
+++ b/llvm/include/llvm/ADT/FunctionExtras.h
@@ -80,6 +80,7 @@ using EnableIfCallable = std::enable_if_t<std::disjunction<
 template <typename ReturnT, typename... ParamTs> class UniqueFunctionBase {
 protected:
   static constexpr size_t InlineStorageSize = sizeof(void *) * 3;
+  static constexpr size_t InlineStorageAlign = alignof(void *);
 
   template <typename T, class = void>
   struct IsSizeLessThanThresholdT : std::false_type {};
@@ -161,7 +162,8 @@ protected:
     // provide three pointers worth of storage here.
     // This is mutable as an inlined `const unique_function<void() const>` may
     // still modify its own mutable members.
-    alignas(void *) mutable std::byte InlineStorage[InlineStorageSize];
+    alignas(InlineStorageAlign) mutable std::byte
+        InlineStorage[InlineStorageSize];
   } StorageUnion;
 
   // A compressed pointer to either our dispatching callback or our table of
@@ -262,7 +264,7 @@ protected:
     bool IsInlineStorage = true;
     void *CallableAddr = getInlineStorage();
     if (sizeof(CallableT) > InlineStorageSize ||
-        alignof(CallableT) > alignof(decltype(StorageUnion.InlineStorage))) {
+        alignof(CallableT) > InlineStorageAlign) {
       IsInlineStorage = false;
       // Allocate out-of-line storage. FIXME: Use an explicit alignment
       // parameter in C++17 mode.

--- a/llvm/include/llvm/ADT/FunctionExtras.h
+++ b/llvm/include/llvm/ADT/FunctionExtras.h
@@ -80,7 +80,6 @@ using EnableIfCallable = std::enable_if_t<std::disjunction<
 template <typename ReturnT, typename... ParamTs> class UniqueFunctionBase {
 protected:
   static constexpr size_t InlineStorageSize = sizeof(void *) * 3;
-  static constexpr size_t InlineStorageAlign = alignof(void *);
 
   template <typename T, class = void>
   struct IsSizeLessThanThresholdT : std::false_type {};
@@ -162,8 +161,7 @@ protected:
     // provide three pointers worth of storage here.
     // This is mutable as an inlined `const unique_function<void() const>` may
     // still modify its own mutable members.
-    alignas(InlineStorageAlign) mutable std::byte
-        InlineStorage[InlineStorageSize];
+    alignas(void *) mutable std::byte InlineStorage[InlineStorageSize];
   } StorageUnion;
 
   // A compressed pointer to either our dispatching callback or our table of
@@ -264,7 +262,7 @@ protected:
     bool IsInlineStorage = true;
     void *CallableAddr = getInlineStorage();
     if (sizeof(CallableT) > InlineStorageSize ||
-        alignof(CallableT) > InlineStorageAlign) {
+        alignof(CallableT) > alignof(decltype(StorageUnion.InlineStorage))) {
       IsInlineStorage = false;
       // Allocate out-of-line storage. FIXME: Use an explicit alignment
       // parameter in C++17 mode.

--- a/llvm/include/llvm/ADT/FunctionExtras.h
+++ b/llvm/include/llvm/ADT/FunctionExtras.h
@@ -314,6 +314,7 @@ protected:
       // Non-trivial move, so dispatch to a type-erased implementation.
       getNonTrivialCallbacks()->MovePtr(getInlineStorage(),
                                         RHS.getInlineStorage());
+      getNonTrivialCallbacks()->DestroyPtr(RHS.getInlineStorage());
     }
 
     // Clear the old callback and inline flag to get back to as-if-null.

--- a/llvm/unittests/ADT/CountCopyAndMove.cpp
+++ b/llvm/unittests/ADT/CountCopyAndMove.cpp
@@ -10,7 +10,8 @@
 
 using namespace llvm;
 
-int CountCopyAndMove::Constructions = 0;
+int CountCopyAndMove::DefaultConstructions = 0;
+int CountCopyAndMove::ValueConstructions = 0;
 int CountCopyAndMove::CopyConstructions = 0;
 int CountCopyAndMove::CopyAssignments = 0;
 int CountCopyAndMove::MoveConstructions = 0;

--- a/llvm/unittests/ADT/CountCopyAndMove.cpp
+++ b/llvm/unittests/ADT/CountCopyAndMove.cpp
@@ -10,6 +10,7 @@
 
 using namespace llvm;
 
+int CountCopyAndMove::Constructions = 0;
 int CountCopyAndMove::CopyConstructions = 0;
 int CountCopyAndMove::CopyAssignments = 0;
 int CountCopyAndMove::MoveConstructions = 0;

--- a/llvm/unittests/ADT/CountCopyAndMove.h
+++ b/llvm/unittests/ADT/CountCopyAndMove.h
@@ -12,6 +12,7 @@
 namespace llvm {
 
 struct CountCopyAndMove {
+  static int Constructions;
   static int CopyConstructions;
   static int CopyAssignments;
   static int MoveConstructions;
@@ -19,8 +20,8 @@ struct CountCopyAndMove {
   static int Destructions;
   int val;
 
-  CountCopyAndMove() = default;
-  explicit CountCopyAndMove(int val) : val(val) {}
+  CountCopyAndMove() { ++Constructions; }
+  explicit CountCopyAndMove(int val) : val(val) { ++Constructions; }
   CountCopyAndMove(const CountCopyAndMove &other) : val(other.val) {
     ++CopyConstructions;
   }
@@ -40,11 +41,16 @@ struct CountCopyAndMove {
   ~CountCopyAndMove() { ++Destructions; }
 
   static void ResetCounts() {
+    Constructions = 0;
     CopyConstructions = 0;
     CopyAssignments = 0;
     MoveConstructions = 0;
     MoveAssignments = 0;
     Destructions = 0;
+  }
+
+  static int TotalConstructions() {
+    return Constructions + MoveConstructions + CopyConstructions;
   }
 
   static int TotalCopies() { return CopyConstructions + CopyAssignments; }

--- a/llvm/unittests/ADT/CountCopyAndMove.h
+++ b/llvm/unittests/ADT/CountCopyAndMove.h
@@ -12,7 +12,8 @@
 namespace llvm {
 
 struct CountCopyAndMove {
-  static int Constructions;
+  static int DefaultConstructions;
+  static int ValueConstructions;
   static int CopyConstructions;
   static int CopyAssignments;
   static int MoveConstructions;
@@ -20,8 +21,8 @@ struct CountCopyAndMove {
   static int Destructions;
   int val;
 
-  CountCopyAndMove() { ++Constructions; }
-  explicit CountCopyAndMove(int val) : val(val) { ++Constructions; }
+  CountCopyAndMove() { ++DefaultConstructions; }
+  explicit CountCopyAndMove(int val) : val(val) { ++ValueConstructions; }
   CountCopyAndMove(const CountCopyAndMove &other) : val(other.val) {
     ++CopyConstructions;
   }
@@ -41,7 +42,8 @@ struct CountCopyAndMove {
   ~CountCopyAndMove() { ++Destructions; }
 
   static void ResetCounts() {
-    Constructions = 0;
+    DefaultConstructions = 0;
+    ValueConstructions = 0;
     CopyConstructions = 0;
     CopyAssignments = 0;
     MoveConstructions = 0;
@@ -50,7 +52,7 @@ struct CountCopyAndMove {
   }
 
   static int TotalConstructions() {
-    return Constructions + MoveConstructions + CopyConstructions;
+    return DefaultConstructions + ValueConstructions + MoveConstructions + CopyConstructions;
   }
 
   static int TotalCopies() { return CopyConstructions + CopyAssignments; }

--- a/llvm/unittests/ADT/CountCopyAndMove.h
+++ b/llvm/unittests/ADT/CountCopyAndMove.h
@@ -52,7 +52,8 @@ struct CountCopyAndMove {
   }
 
   static int TotalConstructions() {
-    return DefaultConstructions + ValueConstructions + MoveConstructions + CopyConstructions;
+    return DefaultConstructions + ValueConstructions + MoveConstructions +
+           CopyConstructions;
   }
 
   static int TotalCopies() { return CopyConstructions + CopyAssignments; }

--- a/llvm/unittests/ADT/FunctionExtrasTest.cpp
+++ b/llvm/unittests/ADT/FunctionExtrasTest.cpp
@@ -336,10 +336,7 @@ TEST(UniqueFunctionTest, MovedFromStateIsDestroyedCorrectly) {
   static int NumOfDestructorsCalled = 0;
   struct State {
     State() = default;
-    State(const State &) = delete;
     State(State &&) { ++NumOfMovesCalled; }
-    State &operator=(const State &) = delete;
-    State &operator=(State &&Rhs) { return *new (this) State{std::move(Rhs)}; }
     ~State() { ++NumOfDestructorsCalled; }
   };
   {
@@ -347,6 +344,7 @@ TEST(UniqueFunctionTest, MovedFromStateIsDestroyedCorrectly) {
     unique_function<void()> CapturingFunctionMoved{
         std::move(CapturingFunction)};
   }
+  printf("%i, %i\n", NumOfMovesCalled, NumOfDestructorsCalled);
   EXPECT_EQ(NumOfDestructorsCalled, 1 + NumOfMovesCalled);
 }
 

--- a/llvm/unittests/ADT/FunctionExtrasTest.cpp
+++ b/llvm/unittests/ADT/FunctionExtrasTest.cpp
@@ -329,4 +329,22 @@ TEST(UniqueFunctionTest, InlineStorageWorks) {
   UniqueFunctionWithInlineStorage(&UniqueFunctionWithInlineStorage);
 }
 
+// Check that the moved-from captured state is properly destroyed during
+// move construction/assignment.
+TEST(UniqueFunctionTest, MovedFromStateIsDestroyedCorrectly) {
+  static int NumOfDestructorsCalled = 0;
+  struct State {
+    State() = default;
+    State(State &&) = default;
+    State &operator=(State &&) = default;
+    ~State() { ++NumOfDestructorsCalled; }
+  };
+  {
+    unique_function<void()> CapturingFunction{[state = State{}] {}};
+    unique_function<void()> CapturingFunctionMoved{
+        std::move(CapturingFunction)};
+  }
+  EXPECT_EQ(NumOfDestructorsCalled, 4);
+}
+
 } // anonymous namespace


### PR DESCRIPTION
Right now immediately after moving the captured state, we 'disarm' the moved-from object's destructor by resetting the `RHS.CallbackAndInlineFlag`. This means that we never properly destroy the RHS object's captured state.