### PR TITLE
[Clang] Reconsider the timing of instantiation of local constexpr lambdas

### DIFF
--- a/clang/test/SemaTemplate/instantiate-local-class.cpp
+++ b/clang/test/SemaTemplate/instantiate-local-class.cpp
@@ -532,4 +532,30 @@ int main() {
 
 } // namespace GH35052
 
+namespace GH98526 {
+
+template <typename F> struct recursive_lambda {
+  template <typename... Args> auto operator()(Args &&...args) const {
+    return fn(*this, args...);
+  }
+  F fn;
+};
+
+template <typename F> recursive_lambda(F) -> recursive_lambda<F>;
+
+struct Tree {
+  Tree *left, *right;
+};
+
+int sumSize(Tree *tree) {
+  auto accumulate =
+      recursive_lambda{[&](auto &self_fn, Tree *element_node) -> int {
+        return 1 + self_fn(tree->left) + self_fn(tree->right);
+      }};
+
+  return accumulate(tree);
+}
+
+} // namespace GH98526
+
 #endif


### PR DESCRIPTION
In the previous patch https://github.com/llvm/llvm-project/pull/95660, we used a strategy of eagerly instantiating local constexpr lambdas. However, that caused a regression in recursive local lambda calls.

This patch addresses that by adding an instantiation requirement to the expression constant evaluation, like what we did when deducing the function return type.

Closes https://github.com/llvm/llvm-project/issues/98526

(The reduced examples in https://github.com/llvm/llvm-project/issues/97680 seem different, as they don't compile in Clang 18 either. However, #97680 per se should work again with this patch.)