### PR TITLE
[libc] Mark internal __llvm_libc_errno as noexcept

### DIFF
--- a/libc/src/errno/libc_errno.h
+++ b/libc/src/errno/libc_errno.h
@@ -33,7 +33,7 @@
 
 namespace LIBC_NAMESPACE_DECL {
 
-extern "C" int *__llvm_libc_errno();
+extern "C" int *__llvm_libc_errno() noexcept;
 
 struct Errno {
   void operator=(int);


### PR DESCRIPTION
The declaration must match the previous declaration in errno.h.