### PR TITLE
[clang][driver][clang-cl] Support `--precompile` and `-fmodule-*` options in Clang-CL

### DIFF
--- a/clang/docs/StandardCPlusPlusModules.rst
+++ b/clang/docs/StandardCPlusPlusModules.rst
@@ -403,7 +403,10 @@ clang-cl
 
 ``clang-cl`` supports the same options as ``clang++`` for modules as detailed above;
 there is no need to prefix these options with ``/clang:``. Note that ``cl.exe``
-options to emit `IFC files <https://devblogs.microsoft.com/cppblog/using-cpp-modules-in-msvc-from-the-command-line-part-1/>` are *not* supported. The precompiled modules are also not compatible for use with ``cl.exe``.
+`options to emit/consume IFC files <https://devblogs.microsoft.com/cppblog/using-cpp-modules-in-msvc-from-the-command-line-part-1/>` are *not* supported.
+The resultant precompiled modules are also not compatible for use with ``cl.exe``.
+
+We recommend that build system authors use the above-mentioned ``clang++`` options  with ``clang-cl`` to build modules.
 
 Consistency Requirements
 ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -1182,13 +1185,6 @@ Currently, Clang requires the file name of an ``importable module unit`` to
 have ``.cppm`` (or ``.ccm``, ``.cxxm``, ``.c++m``) as the file extension.
 However, the behavior is inconsistent with other compilers. This is tracked by
 `#57416 <https://github.com/llvm/llvm-project/issues/57416>`_.
-
-.. clang-cl is not compatible with standard C++ modules
-.. ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-.. ``/clang:-fmodule-file`` and ``/clang:-fprebuilt-module-path`` cannot be used
-.. to specify the BMI with ``clang-cl.exe``. This is tracked by
-.. `#64118 <https://github.com/llvm/llvm-project/issues/64118>`_.
 
 Incorrect ODR violation diagnostics
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/clang/docs/StandardCPlusPlusModules.rst
+++ b/clang/docs/StandardCPlusPlusModules.rst
@@ -398,6 +398,13 @@ BMIs cannot be shipped in an archive to create a module library. Instead, the
 BMIs(``*.pcm``) are compiled into object files(``*.o``) and those object files
 are added to the archive instead.
 
+clang-cl
+~~~~~~~~
+
+``clang-cl`` supports the same options as ``clang++`` for modules as detailed above;
+there is no need to prefix these options with ``/clang:``. Note that ``cl.exe``
+options to emit `IFC files <https://devblogs.microsoft.com/cppblog/using-cpp-modules-in-msvc-from-the-command-line-part-1/>` are *not* supported. The precompiled modules are also not compatible for use with ``cl.exe``.
+
 Consistency Requirements
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -1176,12 +1183,12 @@ have ``.cppm`` (or ``.ccm``, ``.cxxm``, ``.c++m``) as the file extension.
 However, the behavior is inconsistent with other compilers. This is tracked by
 `#57416 <https://github.com/llvm/llvm-project/issues/57416>`_.
 
-clang-cl is not compatible with standard C++ modules
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.. clang-cl is not compatible with standard C++ modules
+.. ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-``/clang:-fmodule-file`` and ``/clang:-fprebuilt-module-path`` cannot be used
-to specify the BMI with ``clang-cl.exe``. This is tracked by
-`#64118 <https://github.com/llvm/llvm-project/issues/64118>`_.
+.. ``/clang:-fmodule-file`` and ``/clang:-fprebuilt-module-path`` cannot be used
+.. to specify the BMI with ``clang-cl.exe``. This is tracked by
+.. `#64118 <https://github.com/llvm/llvm-project/issues/64118>`_.
 
 Incorrect ODR violation diagnostics
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/clang/docs/UsersManual.rst
+++ b/clang/docs/UsersManual.rst
@@ -4732,6 +4732,12 @@ Execute ``clang-cl /?`` to see a list of supported options:
       -flto=<value>           Set LTO mode to either 'full' or 'thin'
       -flto                   Enable LTO in 'full' mode
       -fmerge-all-constants   Allow merging of constants
+      -fmodule-file=<module_name>=<module-file>
+                              Use the specified module file that provides the module <module_name>
+      -fmodule-header=<header>
+                              Build <header> as a C++20 header unit
+      -fmodule-output=<path>
+                              Save intermediate module file results when compiling a standard C++ module unit.
       -fms-compatibility-version=<value>
                               Dot-separated value representing the Microsoft compiler version
                               number to report in _MSC_VER (0 = don't define it; default is same value as installed cl.exe, or 1933)

--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -3085,7 +3085,7 @@ def fmodules_user_build_path : Separate<["-"], "fmodules-user-build-path">, Grou
   HelpText<"Specify the module user build path">,
   MarshallingInfoString<HeaderSearchOpts<"ModuleUserBuildPath">>;
 def fprebuilt_module_path : Joined<["-"], "fprebuilt-module-path=">, Group<i_Group>,
-  Flags<[]>, Visibility<[ClangOption, CC1Option]>,
+  Flags<[]>, Visibility<[ClangOption, CLOption, CC1Option]>,
   MetaVarName<"<directory>">,
   HelpText<"Specify the prebuilt module path">;
 defm prebuilt_implicit_modules : BoolFOption<"prebuilt-implicit-modules",
@@ -5874,6 +5874,7 @@ def _output : Separate<["--"], "output">, Alias<o>;
 def _param : Separate<["--"], "param">, Group<CompileOnly_Group>;
 def _param_EQ : Joined<["--"], "param=">, Alias<_param>;
 def _precompile : Flag<["--"], "precompile">, Flags<[NoXarchOption]>,
+  Visibility<[ClangOption, CLOption]>,
   Group<Action_Group>, HelpText<"Only precompile the input">;
 def _prefix_EQ : Joined<["--"], "prefix=">, Alias<B>;
 def _prefix : Separate<["--"], "prefix">, Alias<B>;

--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -3094,11 +3094,11 @@ defm prebuilt_implicit_modules : BoolFOption<"prebuilt-implicit-modules",
   NegFlag<SetFalse>, BothFlags<[], [ClangOption, CC1Option]>>;
 
 def fmodule_output_EQ : Joined<["-"], "fmodule-output=">,
-  Flags<[NoXarchOption]>, Visibility<[ClangOption, CC1Option]>,
+  Flags<[NoXarchOption]>, Visibility<[ClangOption, CLOption, CC1Option]>,
   MarshallingInfoString<FrontendOpts<"ModuleOutputPath">>,
   HelpText<"Save intermediate module file results when compiling a standard C++ module unit.">;
 def fmodule_output : Flag<["-"], "fmodule-output">, Flags<[NoXarchOption]>,
-  Visibility<[ClangOption, CC1Option]>,
+  Visibility<[ClangOption, CLOption, CC1Option]>,
   HelpText<"Save intermediate module file results when compiling a standard C++ module unit.">;
 
 defm skip_odr_check_in_gmf : BoolOption<"f", "skip-odr-check-in-gmf",
@@ -3278,8 +3278,10 @@ def fretain_comments_from_system_headers : Flag<["-"], "fretain-comments-from-sy
   Visibility<[ClangOption, CC1Option]>,
   MarshallingInfoFlag<LangOpts<"RetainCommentsFromSystemHeaders">>;
 def fmodule_header : Flag <["-"], "fmodule-header">, Group<f_Group>,
+  Visibility<[ClangOption, CLOption]>,
   HelpText<"Build a C++20 Header Unit from a header">;
 def fmodule_header_EQ : Joined<["-"], "fmodule-header=">, Group<f_Group>,
+  Visibility<[ClangOption, CLOption]>,
   MetaVarName<"<kind>">,
   HelpText<"Build a C++20 Header Unit from a header that should be found in the user (fmodule-header=user) or system (fmodule-header=system) search path.">;
 

--- a/clang/test/Driver/cl-cxx20-modules.cppm
+++ b/clang/test/Driver/cl-cxx20-modules.cppm
@@ -1,8 +1,8 @@
-// RUN: %clang_cl /std:c++20 --precompile -### -- %s 2>&1 | FileCheck  %s
-// CHECK: --precompile
+// RUN: %clang_cl /std:c++20 --precompile -### -- %s 2>&1 | FileCheck --check-prefix=PRECOMPILE %s
+// PRECOMPILE: -emit-module-interface
 
-// RUN: %clang_cl /std:c++20 --fmodule-file=Foo=Foo.pcm -### -- %s 2>&1 | FileCheck  %s
-// CHECK: -fmodule-file=Foo=Foo.pcm
+// RUN: %clang_cl /std:c++20 --fmodule-file=Foo=Foo.pcm -### -- %s 2>&1 | FileCheck --check-prefix=FMODULEFILE %s
+// FMODULEFILE: -fmodule-file=Foo=Foo.pcm
 
-// RUN: %clang_cl /std:c++20 --fprebuilt-module-path=. -### -- %s 2>&1 | FileCheck  %s
-// CHECK: -fprebuilt-module-path=.
+// RUN: %clang_cl /std:c++20 --fprebuilt-module-path=. -### -- %s 2>&1 | FileCheck --check-prefix=FPREBUILT %s
+// FPREBUILT: -fprebuilt-module-path=.

--- a/clang/test/Driver/cl-cxx20-modules.cppm
+++ b/clang/test/Driver/cl-cxx20-modules.cppm
@@ -1,65 +1,8 @@
-// REQUIRES: system-windows
+// RUN: %clang_cl /std:c++20 --precompile -### -- %s 2>&1 | FileCheck  %s
+// CHECK: --precompile
 
-// RUN: rm -rf %t
-// RUN: mkdir -p %t
-// RUN: split-file %s %t
+// RUN: %clang_cl /std:c++20 --fmodule-file=Foo=Foo.pcm -### -- %s 2>&1 | FileCheck  %s
+// CHECK: -fmodule-file=Foo=Foo.pcm
 
-// RUN: %clang_cl /std:c++20 --precompile "%/t/Hello.cppm" "/Fo%/t/Hello.pcm"
-// RUN: %clang_cl /std:c++20 %/t/use.cpp -fmodule-file=Hello=%/t/Hello.pcm %/t/Hello.pcm /Fo%/t/SimpleHelloWorld.exe 2>&1
-
-// RUN: %/t/SimpleHelloWorld.exe
-// CHECK: Simple Hello World!
-
-//--- Hello.cppm
-module;
-#include <iostream>
-export module Hello;
-export void hello() {
-  std::cout << "Simple Hello World!\n";
-}
-
-//--- use.cpp
-import Hello;
-int main() {
-  hello();
-  return 0;
-}
-
-//--- M.cppm
-export module M;
-export import :interface_part;
-import :impl_part;
-export void Hello();
-
-//--- interface_part.cpp
-export module M:interface_part;
-export void World();
-
-//--- impl_part.cppm
-module;
-#include <iostream>
-#include <string>
-module M:impl_part;
-import :interface_part;
-
-std::string W = "World!";
-void World() {
-  std::cout << W << std::endl;
-}
-
-//--- Impl.cpp
-module;
-#include <iostream>
-module M;
-void Hello() {
-  std::cout << "Complex Hello ";
-}
-
-//--- User.cpp
-import M;
-int main() {
-  Hello();
-  World();
-  return 0;
-}
-
+// RUN: %clang_cl /std:c++20 --fprebuilt-module-path=. -### -- %s 2>&1 | FileCheck  %s
+// CHECK: -fprebuilt-module-path=.

--- a/clang/test/Driver/cl-cxx20-modules.cppm
+++ b/clang/test/Driver/cl-cxx20-modules.cppm
@@ -1,0 +1,65 @@
+// REQUIRES: system-windows
+
+// RUN: rm -rf %t
+// RUN: mkdir -p %t
+// RUN: split-file %s %t
+
+// RUN: %clang_cl /std:c++20 --precompile "%/t/Hello.cppm" "/Fo%/t/Hello.pcm"
+// RUN: %clang_cl /std:c++20 %/t/use.cpp -fmodule-file=Hello=%/t/Hello.pcm %/t/Hello.pcm /Fo%/t/SimpleHelloWorld.exe 2>&1
+
+// RUN: %/t/SimpleHelloWorld.exe
+// CHECK: Simple Hello World!
+
+//--- Hello.cppm
+module;
+#include <iostream>
+export module Hello;
+export void hello() {
+  std::cout << "Simple Hello World!\n";
+}
+
+//--- use.cpp
+import Hello;
+int main() {
+  hello();
+  return 0;
+}
+
+//--- M.cppm
+export module M;
+export import :interface_part;
+import :impl_part;
+export void Hello();
+
+//--- interface_part.cpp
+export module M:interface_part;
+export void World();
+
+//--- impl_part.cppm
+module;
+#include <iostream>
+#include <string>
+module M:impl_part;
+import :interface_part;
+
+std::string W = "World!";
+void World() {
+  std::cout << W << std::endl;
+}
+
+//--- Impl.cpp
+module;
+#include <iostream>
+module M;
+void Hello() {
+  std::cout << "Complex Hello ";
+}
+
+//--- User.cpp
+import M;
+int main() {
+  Hello();
+  World();
+  return 0;
+}
+


### PR DESCRIPTION
This PR is the first step in improving the situation for `clang-cl` detailed in [this LLVM Discourse thread](https://discourse.llvm.org/t/clang-cl-exe-support-for-c-modules/72257/28). There has been some work done in #89772. I believe this is somewhat orthogonal.

This is a work-in-progress; the functionality has only been tested with the [basic 'Hello World' example](https://clang.llvm.org/docs/StandardCPlusPlusModules.html#quick-start), and proper test cases need to be written. I'd like some thoughts on this, thanks!

Partially resolves #64118.