### PR TITLE
[libc] Mark all __llvm_libc_errno definitions as noexcept

### DIFF
--- a/libc/src/errno/libc_errno.cpp
+++ b/libc/src/errno/libc_errno.cpp
@@ -57,7 +57,7 @@ namespace {
 LIBC_THREAD_LOCAL int thread_errno;
 }
 
-extern "C" int *__llvm_libc_errno() { return &thread_errno; }
+extern "C" int *__llvm_libc_errno() noexcept { return &thread_errno; }
 
 void Errno::operator=(int a) { thread_errno = a; }
 Errno::operator int() { return thread_errno; }
@@ -68,7 +68,7 @@ namespace {
 int shared_errno;
 }
 
-extern "C" int *__llvm_libc_errno() { return &shared_errno; }
+extern "C" int *__llvm_libc_errno() noexcept { return &shared_errno; }
 
 void Errno::operator=(int a) { shared_errno = a; }
 Errno::operator int() { return shared_errno; }


### PR DESCRIPTION
The definitions must match the previous declaration in errno.h.