### PR TITLE
[Flang][Runtime] Simplify StringLength implementation

### DIFF
--- a/flang/runtime/command.cpp
+++ b/flang/runtime/command.cpp
@@ -47,13 +47,9 @@ pid_t RTNAME(GetPID)() { return getpid(); }
 // Returns the length of the \p string. Assumes \p string is valid.
 static std::int64_t StringLength(const char *string) {
   std::size_t length{std::strlen(string)};
-  if constexpr (sizeof(std::size_t) < sizeof(std::int64_t)) {
+  if (length <= std::numeric_limits<std::int64_t>::max())
     return static_cast<std::int64_t>(length);
-  } else {
-    std::size_t max{std::numeric_limits<std::int64_t>::max()};
-    return length > max ? 0 // Just fail.
-                        : static_cast<std::int64_t>(length);
-  }
+  return 0;
 }
 
 static void FillWithSpaces(const Descriptor &value, std::size_t offset = 0) {


### PR DESCRIPTION
This implementation relies on arithmetic conversion, let's see what happens when we do

    std::size_t length{std::strlen(string)};
    if (length <= std::numeric_limits<std::int64_t>::max())
        return static_cast<std::int64_t>(length);

1) if size_t == uint32_t (or lower), then the comparison operator
   invokes integral promotion to uint64_t, the comparison happens, it's
   fine.

2) if size_t == uint64_t, then the comparison is done between unsigned
   types, which implies a conversion of
   std::numeric_limits<std::int64_t>::max() to uint64_t, which happens
   without accuracy loss, fine

3) if size_t == uint128_t (or higher), then we invoke integral promotion
   of std::int64_t, it's also fine.

So this snippet has the same behavior as the existing one, while being easier to read.