### PR TITLE
[Analysis] Use BitVector::test in areInlineCompatible (NFC)

### DIFF
--- a/llvm/include/llvm/Analysis/TargetLibraryInfo.h
+++ b/llvm/include/llvm/Analysis/TargetLibraryInfo.h
@@ -327,11 +327,9 @@ public:
                            bool AllowCallerSuperset) const {
     if (!AllowCallerSuperset)
       return OverrideAsUnavailable == CalleeTLI.OverrideAsUnavailable;
-    BitVector B = OverrideAsUnavailable;
-    B |= CalleeTLI.OverrideAsUnavailable;
-    // We can inline if the union of the caller and callee's nobuiltin
-    // attributes is no stricter than the caller's nobuiltin attributes.
-    return B == OverrideAsUnavailable;
+    // We can inline if the callee's nobuiltin attributes are no stricter than
+    // the caller's.
+    return !CalleeTLI.OverrideAsUnavailable.test(OverrideAsUnavailable);
   }
 
   /// Return true if the function type FTy is valid for the library function


### PR DESCRIPTION
areInlineCompatible checks to see if CalleeTLI.OverrideAsUnavailable
is a subset of OverrideAsUnavailable by computing a union of the two
and comparing the union and OverrideAsUnavailable.

The problem is that computing a union involves memory allocations.
This patch removes the need for memory allocations by switching to
BitVector::test.  Note that A.test(B) returns true if A - B is
non-empty.  That is, !A.test(B) is true if A if a subset of B.

The use of BitVector::test here saves 0.20% of heap allocations during
the compilation of X86ISelLowering.cpp.ii, a preprocessed version of
X86ISelLowering.cpp.
