### PR TITLE
[libc] Include realloc in baremetal entrypoints

### DIFF
--- a/libc/config/baremetal/arm/entrypoints.txt
+++ b/libc/config/baremetal/arm/entrypoints.txt
@@ -188,6 +188,7 @@ set(TARGET_LIBC_ENTRYPOINTS
     libc.src.stdlib.malloc
     libc.src.stdlib.qsort
     libc.src.stdlib.rand
+    libc.src.stdlib.realloc
     libc.src.stdlib.srand
     libc.src.stdlib.strtod
     libc.src.stdlib.strtof

--- a/libc/config/baremetal/riscv/entrypoints.txt
+++ b/libc/config/baremetal/riscv/entrypoints.txt
@@ -184,6 +184,7 @@ set(TARGET_LIBC_ENTRYPOINTS
     libc.src.stdlib.malloc
     libc.src.stdlib.qsort
     libc.src.stdlib.rand
+    libc.src.stdlib.realloc
     libc.src.stdlib.srand
     libc.src.stdlib.strtod
     libc.src.stdlib.strtof


### PR DESCRIPTION
This is used in some embedded projects.