### PR TITLE
[RISCV] Remove unused include in RISCVMCTargetDesc.h

### DIFF
--- a/llvm/lib/Target/RISCV/MCTargetDesc/RISCVMCTargetDesc.h
+++ b/llvm/lib/Target/RISCV/MCTargetDesc/RISCVMCTargetDesc.h
@@ -13,7 +13,6 @@
 #ifndef LLVM_LIB_TARGET_RISCV_MCTARGETDESC_RISCVMCTARGETDESC_H
 #define LLVM_LIB_TARGET_RISCV_MCTARGETDESC_RISCVMCTARGETDESC_H
 
-#include "llvm/Config/config.h"
 #include "llvm/MC/MCTargetOptions.h"
 #include "llvm/Support/DataTypes.h"
 #include <memory>


### PR DESCRIPTION
Goes in hand with #97130, split out to figure out CI fails. Should just build whatever subprojects utilize the `RISCVMCTargetDesc.h` header and it should build & test just like normal.