### PR TITLE
[compiler-rt][nsan] Make nsan output more user-friendly

### DIFF
--- a/compiler-rt/lib/nsan/nsan.cpp
+++ b/compiler-rt/lib/nsan/nsan.cpp
@@ -513,6 +513,8 @@ int32_t checkFT(const FT value, ShadowFT Shadow, CheckTypeT CheckType,
     }
     using ValuePrinter = FTPrinter<FT>;
     using ShadowPrinter = FTPrinter<ShadowFT>;
+    Printf("%s", D.Default());
+
     Printf("\n"
            "%-12s precision  (native): dec: %s  hex: %s\n"
            "%-12s precision  (shadow): dec: %s  hex: %s\n"
@@ -638,8 +640,9 @@ void fCmpFailFT(const FT Lhs, const FT Rhs, ShadowFT LhsShadow,
   const char *const PredicateName = GetPredicateName(Predicate);
   Printf("%s", D.Warning());
   Printf("WARNING: NumericalStabilitySanitizer: floating-point comparison "
-         "results depend on precision\n"
-         "%-12s precision dec (native): %s %s %s (%s)\n"
+         "results depend on precision\n");
+  Printf("%s", D.Default());
+  Printf("%-12s precision dec (native): %s %s %s (%s)\n"
          "%-12s precision dec (shadow): %s %s %s (%s)\n"
          "%-12s precision hex (native): %s %s %s (%s)\n"
          "%-12s precision hex (shadow): %s %s %s (%s)\n"
@@ -658,7 +661,6 @@ void fCmpFailFT(const FT Lhs, const FT Rhs, ShadowFT LhsShadow,
          FTInfo<ShadowFT>::kCppTypeName, ShadowPrinter::hex(LhsShadow).Buffer,
          PredicateName, ShadowPrinter::hex(RhsShadow).Buffer,
          GetTruthValueName(ShadowResult), D.End());
-  Printf("%s", D.Default());
   stack.Print();
   if (flags().halt_on_error) {
     Printf("Exiting\n");


### PR DESCRIPTION
Currently NSAN prints reports that are entirely red and the terminal prompt after the program exits is red too. With this change we make red only `WARNING` summary and the rest of the report isn't colored
This behaviour is similar to the behavior of other sanitizers reports like asan, ubsan etc

![nsan](https://github.com/user-attachments/assets/5796e46d-b88a-48e7-afad-c3c946a11570)

Now:
![nsan_pretty](https://github.com/user-attachments/assets/c1e1ded0-ba7e-4b53-a8e7-7c2417757139)
