### PR TITLE
[compiler-rt][nsan] Disable coredump creation

### DIFF
--- a/compiler-rt/lib/nsan/nsan.cpp
+++ b/compiler-rt/lib/nsan/nsan.cpp
@@ -779,16 +779,6 @@ extern "C" SANITIZER_INTERFACE_ATTRIBUTE void __nsan_dump_shadow_args() {
   printf("args tag: %lx\n", __nsan_shadow_args_tag);
 }
 
-static void OnStackUnwind(const SignalContext &sig, const void *,
-                          BufferedStackTrace *stack) {
-  stack->Unwind(StackTrace::GetNextInstructionPc(sig.pc), sig.bp, sig.context,
-                common_flags()->fast_unwind_on_fatal);
-}
-
-static void NsanOnDeadlySignal(int signo, void *siginfo, void *context) {
-  HandleDeadlySignal(siginfo, context, GetTid(), &OnStackUnwind, nullptr);
-}
-
 bool __nsan::nsan_initialized;
 bool __nsan::nsan_init_is_running;
 
@@ -803,7 +793,6 @@ extern "C" SANITIZER_INTERFACE_ATTRIBUTE void __nsan_init() {
   InitializePlatformEarly();
 
   DisableCoreDumperIfNecessary();
-  InstallDeadlySignalHandlers(NsanOnDeadlySignal);
 
   if (!MmapFixedNoReserve(TypesAddr(), UnusedAddr() - TypesAddr()))
     Die();


### PR DESCRIPTION
- Disable coredump creation
If NSAN_OPTIONS contains `abort_on_error=1` the process hangs because the kernel tries to create a very huge core

msan, asan, tsan etc. runtimes disables coredumps too

Fix #98806