### PR TITLE
[LoopRotate] Don't rotate loops when the minsize attribute is present

### DIFF
--- a/llvm/lib/Transforms/Scalar/LoopRotation.cpp
+++ b/llvm/lib/Transforms/Scalar/LoopRotation.cpp
@@ -64,10 +64,11 @@ PreservedAnalyses LoopRotatePass::run(Loop &L, LoopAnalysisManager &AM,
   // Vectorization requires loop-rotation. Use default threshold for loops the
   // user explicitly marked for vectorization, even when header duplication is
   // disabled.
-  int Threshold = EnableHeaderDuplication ||
-                          hasVectorizeTransformation(&L) == TM_ForcedByUser
-                      ? DefaultRotationThreshold
-                      : 0;
+  int Threshold =
+      (EnableHeaderDuplication && !L.getHeader()->getParent()->hasMinSize()) ||
+              hasVectorizeTransformation(&L) == TM_ForcedByUser
+          ? DefaultRotationThreshold
+          : 0;
   const DataLayout &DL = L.getHeader()->getDataLayout();
   const SimplifyQuery SQ = getBestSimplifyQuery(AR, DL);
 

--- a/llvm/test/Transforms/LoopRotate/minsize-disable.ll
+++ b/llvm/test/Transforms/LoopRotate/minsize-disable.ll
@@ -1,0 +1,32 @@
+; REQUIRES: asserts
+; RUN: opt < %s -S -passes=loop-rotate -debug -debug-only=loop-rotate 2>&1 | FileCheck %s
+
+; Loop should not be rotated for functions with the minsize attribute.
+; This is mostly useful for LTO which doesn't (yet) understand -Oz.
+; CHECK: LoopRotation: NOT rotating - contains 2 instructions, which is more
+
+@e = global i32 10
+
+declare void @use(i32)
+
+; Function attrs: minsize optsize
+define void @test() #0 {
+entry:
+  %end = load i32, ptr @e
+  br label %loop
+
+loop:
+  %n.phi = phi i32 [ %n, %loop.fin ], [ 0, %entry ]
+  %cond = icmp eq i32 %n.phi, %end
+  br i1 %cond, label %exit, label %loop.fin
+
+loop.fin:
+  %n = add i32 %n.phi, 1
+  call void @use(i32 %n)
+  br label %loop
+
+exit:
+  ret void
+}
+
+attributes #0 = { minsize optsize }


### PR DESCRIPTION
The main use for this patch is LTO. It is not (yet?) possible to set the size level (-Os, -Oz) in the linker, which means loops are still rotated even if -Oz is specified on the command line. Therefore, look at the function attribute instead of only at the size level to determine whether to rotate loops for a given function.

For discussion, see: https://reviews.llvm.org/D119342

An older version of this patch was already approved at https://reviews.llvm.org/D119342 but I never got around to committing it. The code changed so I had to make some minor updates to this patch and in the meantime I also lost commit access because I wasn't really using it. So here is an updated patch.