### PR TITLE
[flang][runtime] Clear leftTabLimit at in FinishReadingRecord

### DIFF
--- a/flang/runtime/unit.cpp
+++ b/flang/runtime/unit.cpp
@@ -268,6 +268,7 @@ void ExternalFileUnit::FinishReadingRecord(IoErrorHandler &handler) {
     recordOffsetInFrame_ = 0;
   }
   BeginRecord();
+  leftTabLimit.reset();
 }
 
 bool ExternalFileUnit::AdvanceRecord(IoErrorHandler &handler) {


### PR DESCRIPTION
ExternalFileUnit::FinishReadingRecord() is called at the end of a READ statement, unless the read is non-advancing and there was no error.  In the event of an erroneous non-advancing read, however, FinishReadingRecord() leaves ConnectionState::leftTabLimit inhabited by a value, leaving the impression that the *next* record is undergoing a non-advancing operation, and this cause the next operation to fail.  In the test case in the reported bug, the next operation is a BACKSPACE, and it ends up doing nothing.  The fix is to always reset leftTabLimit in FinishReadingRecord.

Fixes https://github.com/llvm/llvm-project/issues/98783.