### PR TITLE
[libc] newheadergen: added assert.yaml

### DIFF
--- a/libc/config/baremetal/api.td
+++ b/libc/config/baremetal/api.td
@@ -5,41 +5,6 @@ include "spec/stdc_ext.td"
 include "spec/bsd_ext.td"
 include "spec/llvm_libc_stdfix_ext.td"
 
-def AssertMacro : MacroDef<"assert"> {
-  let Defn = [{
-    #undef assert
-
-    #ifdef NDEBUG
-    #define assert(e) (void)0
-    #else
-
-    #ifdef __cplusplus
-    extern "C"
-    #endif
-    _Noreturn void __assert_fail(const char *, const char *, unsigned, const char *) __NOEXCEPT;
-
-    #define assert(e)  \
-      ((e) ? (void)0 : __assert_fail(#e, __FILE__, __LINE__, __PRETTY_FUNCTION__))
-
-    #endif
-  }];
-}
-
-def StaticAssertMacro : MacroDef<"static_assert"> {
-  let Defn = [{
-    #ifndef __cplusplus
-    #undef static_assert
-    #define static_assert _Static_assert
-    #endif
-  }];
-}
-
-def AssertAPI : PublicAPI<"assert.h"> {
-  let Macros = [
-    AssertMacro,
-    StaticAssertMacro,
-  ];
-}
 
 def CTypeAPI : PublicAPI<"ctype.h"> {
 }

--- a/libc/config/gpu/api.td
+++ b/libc/config/gpu/api.td
@@ -7,35 +7,6 @@ include "spec/gnu_ext.td"
 include "spec/stdc_ext.td"
 include "spec/llvm_libc_ext.td"
 
-def AssertMacro : MacroDef<"assert"> {
-  let Defn = [{
-    #undef assert
-
-    #ifdef NDEBUG
-    #define assert(e) (void)0
-    #else
-
-    #define assert(e)  \
-      ((e) ? (void)0 : __assert_fail(#e, __FILE__, __LINE__, __PRETTY_FUNCTION__))
-    #endif
-  }];
-}
-
-def StaticAssertMacro : MacroDef<"static_assert"> {
-  let Defn = [{
-    #ifndef __cplusplus
-    #undef static_assert
-    #define static_assert _Static_assert
-    #endif
-  }];
-}
-
-def AssertAPI : PublicAPI<"assert.h"> {
-  let Macros = [
-    AssertMacro,
-    StaticAssertMacro,
-  ];
-}
 
 def StringAPI : PublicAPI<"string.h"> {
   let Types = ["size_t"];

--- a/libc/config/linux/api.td
+++ b/libc/config/linux/api.td
@@ -9,42 +9,6 @@ include "spec/stdc_ext.td"
 include "spec/llvm_libc_ext.td"
 include "spec/llvm_libc_stdfix_ext.td"
 
-def AssertMacro : MacroDef<"assert"> {
-  let Defn = [{
-    #undef assert
-
-    #ifdef NDEBUG
-    #define assert(e) (void)0
-    #else
-
-    #ifdef __cplusplus
-    extern "C"
-    #endif
-    _Noreturn void __assert_fail(const char *, const char *, unsigned, const char *) __NOEXCEPT;
-
-    #define assert(e)  \
-      ((e) ? (void)0 : __assert_fail(#e, __FILE__, __LINE__, __PRETTY_FUNCTION__))
-
-    #endif
-  }];
-}
-
-def StaticAssertMacro : MacroDef<"static_assert"> {
-  let Defn = [{
-    #ifndef __cplusplus
-    #undef static_assert
-    #define static_assert _Static_assert
-    #endif
-  }];
-}
-
-def AssertAPI : PublicAPI<"assert.h"> {
-  let Macros = [
-    AssertMacro,
-    StaticAssertMacro,
-  ];
-}
-
 def CTypeAPI : PublicAPI<"ctype.h"> {
 }
 

--- a/libc/include/assert.h.def
+++ b/libc/include/assert.h.def
@@ -12,4 +12,24 @@
 // This file may be usefully included multiple times to change assert()'s
 // definition based on NDEBUG.
 
+
+#undef assert
+#ifdef NDEBUG
+#define assert(e) (void)0
+#else
+
+#ifndef __cplusplus
+#undef static_assert
+#define static_assert _Static_assert
+#endif
+
+#ifdef __cplusplus
+extern "C"
+#endif
+_Noreturn void __assert_fail(const char *, const char *, unsigned, const char *) __NOEXCEPT;
+
+#define assert(e)  \
+  ((e) ? (void)0 : __assert_fail(#e, __FILE__, __LINE__, __PRETTY_FUNCTION__))
+#endif
+
 %%public_api()

--- a/libc/newhdrgen/yaml/assert.yaml
+++ b/libc/newhdrgen/yaml/assert.yaml
@@ -1,0 +1,16 @@
+header: assert.h
+macros: []
+types: []
+enums: []
+objects: []
+functions:
+  - name: __assert_fail 
+    standards:
+      - llvm_libc_ext
+    return_type: _Noreturn void
+    arguments:
+      - type: const char *
+      - type: const char *
+      - type: unsigned
+      - type: const char *
+    guard: __cplusplus


### PR DESCRIPTION
- removed assert macro definitions in api.td
- included macro definitions in assert.h.def
- added assert.yaml
