### PR TITLE
[lldb] Fixed the error `unable to launch a GDB server` in API tests

### DIFF
--- a/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationServerPlatform.cpp
+++ b/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationServerPlatform.cpp
@@ -46,11 +46,13 @@ using namespace lldb_private;
 
 GDBRemoteCommunicationServerPlatform::PortMap::PortMap(uint16_t min_port,
                                                        uint16_t max_port) {
+  assert(min_port);
   for (; min_port < max_port; ++min_port)
     m_port_map[min_port] = LLDB_INVALID_PROCESS_ID;
 }
 
 void GDBRemoteCommunicationServerPlatform::PortMap::AllowPort(uint16_t port) {
+  assert(port);
   // Do not modify existing mappings
   m_port_map.insert({port, LLDB_INVALID_PROCESS_ID});
 }


### PR DESCRIPTION
TestPlatformLaunchGDBServer.py runs `ldb-server` w/o parameters `--min-gdbserver-port`, `--max-gdbserver-port` or `--gdbserver-port`. So `gdbserver_portmap` is empty and `gdbserver_portmap.GetNextAvailablePort()` will return 0. Do not call `portmap_for_child.AllowPort(0)` in this case. Otherwise `portmap_for_child.GetNextAvailablePort()` will allocate and never free the port 0 and next call `portmap_for_child.GetNextAvailablePort()` will fail. 

Added few asserts in `GDBRemoteCommunicationServerPlatform::PortMap` to avoid such issue in the future. 

This patch fixes a bug added in #88845. The behaviour is very close to #97537 w/o parameters `--min-gdbserver-port`, `--max-gdbserver-port` and `--gdbserver-port`.