### PR TITLE
[Support] Don't use StringRef::equals in Path.inc

### DIFF
--- a/llvm/lib/Support/Unix/Path.inc
+++ b/llvm/lib/Support/Unix/Path.inc
@@ -516,7 +516,7 @@ static bool is_local_impl(struct STATVFS &Vfs) {
   // target
   StringRef fstype(Vfs.f_basetype);
   // NFS is the only non-local fstype??
-  return !fstype.equals("nfs");
+  return fstype != "nfs";
 #elif defined(_AIX)
   // Call mntctl; try more than twice in case of timing issues with a concurrent
   // mount.


### PR DESCRIPTION
The removal of StringRef::equals in
3fa409f2318ef790cc44836afe9a72830715ad84 broke the [Solaris/sparcv9](https://lab.llvm.org/buildbot/#/builders/13/builds/724) and [Solaris/amd64](https://lab.llvm.org/staging/#/builders/94/builds/5176) buildbots:
```
In file included from /vol/llvm/src/llvm-project/git/llvm/lib/Support/Path.cpp:1200:
/vol/llvm/src/llvm-project/git/llvm/lib/Support/Unix/Path.inc:519:18: error: no member named 'equals' in 'llvm::StringRef'
  519 |   return !fstype.equals("nfs");
      |           ~~~~~~ ^
```

Fixed by switching to `operator!=` instead.

Tested on sparcv9-sun-solaris2.11 and amd64-pc-solaris2.11.