### PR TITLE
[libc++] Fix acceptance of convertible-to-{float,double,long double} in std::isfinite()

### DIFF
--- a/libcxx/include/__math/traits.h
+++ b/libcxx/include/__math/traits.h
@@ -55,20 +55,18 @@ _LIBCPP_NODISCARD _LIBCPP_CONSTEXPR_SINCE_CXX23 _LIBCPP_HIDE_FROM_ABI bool isfin
   return true;
 }
 
-#ifdef _LIBCPP_PREFERRED_OVERLOAD
 _LIBCPP_NODISCARD inline _LIBCPP_CONSTEXPR_SINCE_CXX23 _LIBCPP_HIDE_FROM_ABI bool isfinite(float __x) _NOEXCEPT {
   return __builtin_isfinite(__x);
 }
 
-_LIBCPP_NODISCARD inline _LIBCPP_CONSTEXPR_SINCE_CXX23 _LIBCPP_HIDE_FROM_ABI _LIBCPP_PREFERRED_OVERLOAD bool
-isfinite(double __x) _NOEXCEPT {
+_LIBCPP_NODISCARD inline _LIBCPP_CONSTEXPR_SINCE_CXX23 _LIBCPP_HIDE_FROM_ABI bool isfinite(double __x) _NOEXCEPT {
   return __builtin_isfinite(__x);
 }
 
 _LIBCPP_NODISCARD inline _LIBCPP_CONSTEXPR_SINCE_CXX23 _LIBCPP_HIDE_FROM_ABI bool isfinite(long double __x) _NOEXCEPT {
   return __builtin_isfinite(__x);
 }
-#endif
+
 // isinf
 
 template <class _A1, __enable_if_t<is_arithmetic<_A1>::value && numeric_limits<_A1>::has_infinity, int> = 0>

--- a/libcxx/include/__math/traits.h
+++ b/libcxx/include/__math/traits.h
@@ -60,6 +60,10 @@ _LIBCPP_NODISCARD inline _LIBCPP_CONSTEXPR_SINCE_CXX23 _LIBCPP_HIDE_FROM_ABI boo
   return __builtin_isfinite(__x);
 }
 
+_LIBCPP_NODISCARD inline _LIBCPP_CONSTEXPR_SINCE_CXX23 _LIBCPP_HIDE_FROM_ABI _LIBCPP_PREFERRED_OVERLOAD bool
+isfinite(double __x) _NOEXCEPT {
+  return __builtin_isfinite(__x);
+}
 #endif
 // isinf
 

--- a/libcxx/include/__math/traits.h
+++ b/libcxx/include/__math/traits.h
@@ -64,6 +64,10 @@ _LIBCPP_NODISCARD inline _LIBCPP_CONSTEXPR_SINCE_CXX23 _LIBCPP_HIDE_FROM_ABI _LI
 isfinite(double __x) _NOEXCEPT {
   return __builtin_isfinite(__x);
 }
+
+_LIBCPP_NODISCARD inline _LIBCPP_CONSTEXPR_SINCE_CXX23 _LIBCPP_HIDE_FROM_ABI bool isfinite(long double __x) _NOEXCEPT {
+  return __builtin_isfinite(__x);
+}
 #endif
 // isinf
 

--- a/libcxx/include/__math/traits.h
+++ b/libcxx/include/__math/traits.h
@@ -55,6 +55,12 @@ _LIBCPP_NODISCARD _LIBCPP_CONSTEXPR_SINCE_CXX23 _LIBCPP_HIDE_FROM_ABI bool isfin
   return true;
 }
 
+#ifdef _LIBCPP_PREFERRED_OVERLOAD
+_LIBCPP_NODISCARD inline _LIBCPP_CONSTEXPR_SINCE_CXX23 _LIBCPP_HIDE_FROM_ABI bool isfinite(float __x) _NOEXCEPT {
+  return __builtin_isfinite(__x);
+}
+
+#endif
 // isinf
 
 template <class _A1, __enable_if_t<is_arithmetic<_A1>::value && numeric_limits<_A1>::has_infinity, int> = 0>

--- a/libcxx/test/std/numerics/c.math/isfinite.pass.cpp
+++ b/libcxx/test/std/numerics/c.math/isfinite.pass.cpp
@@ -62,30 +62,21 @@ struct TestInt {
   }
 };
 
-struct ConvertibleFloat {
-  int value;
-  ConvertibleFloat(int v) : value(v) {}
-  operator float() const { return static_cast<float>(value); }
-};
-
-struct ConvertibleDouble {
-  int value;
-  ConvertibleDouble(int v) : value(v) {}
-  operator double() const { return static_cast<double>(value); }
-};
-
-struct ConvertibleLongDouble {
-  int value;
-  ConvertibleLongDouble(int v) : value(v) {}
-  operator long double() const { return static_cast<long double>(value); }
+template <typename T>
+struct ConvertibleTo {
+  operator T() const { return T(); }
 };
 
 int main(int, char**) {
   types::for_each(types::floating_point_types(), TestFloat());
   types::for_each(types::integral_types(), TestInt());
-  assert(std::isfinite(ConvertibleFloat(0)));
-  assert(std::isfinite(ConvertibleDouble(0)));
-  assert(std::isfinite(ConvertibleLongDouble(0)));
+
+  // Make sure we can call `std::isfinite` with convertible types
+  {
+    assert(std::isfinite(ConvertibleTo<float>()));
+    assert(std::isfinite(ConvertibleTo<double>()));
+    assert(std::isfinite(ConvertibleTo<long double>()));
+  }
 
   return 0;
 }

--- a/libcxx/test/std/numerics/c.math/isfinite.pass.cpp
+++ b/libcxx/test/std/numerics/c.math/isfinite.pass.cpp
@@ -62,9 +62,20 @@ struct TestInt {
   }
 };
 
+struct ConvertibleFloat {
+    int value;
+
+    ConvertibleFloat(int v) : value(v) {}
+
+    operator float() const {
+        return static_cast<float>(value);
+    }
+};
+
 int main(int, char**) {
   types::for_each(types::floating_point_types(), TestFloat());
   types::for_each(types::integral_types(), TestInt());
+  assert(std::isfinite(ConvertibleFloat(0)));
 
   return 0;
 }

--- a/libcxx/test/std/numerics/c.math/isfinite.pass.cpp
+++ b/libcxx/test/std/numerics/c.math/isfinite.pass.cpp
@@ -82,11 +82,22 @@ struct ConvertibleDouble {
     }
 };
 
+struct ConvertibleLongDouble {
+    int value;
+
+    ConvertibleLongDouble(int v) : value(v) {}
+
+    operator long double() const {
+        return static_cast<long double>(value);
+    }
+};
+
 int main(int, char**) {
   types::for_each(types::floating_point_types(), TestFloat());
   types::for_each(types::integral_types(), TestInt());
   assert(std::isfinite(ConvertibleFloat(0)));
   assert(std::isfinite(ConvertibleDouble(0)));
+  assert(std::isfinite(ConvertibleLongDouble(0)));
 
   return 0;
 }

--- a/libcxx/test/std/numerics/c.math/isfinite.pass.cpp
+++ b/libcxx/test/std/numerics/c.math/isfinite.pass.cpp
@@ -63,33 +63,21 @@ struct TestInt {
 };
 
 struct ConvertibleFloat {
-    int value;
-
-    ConvertibleFloat(int v) : value(v) {}
-
-    operator float() const {
-        return static_cast<float>(value);
-    }
+  int value;
+  ConvertibleFloat(int v) : value(v) {}
+  operator float() const { return static_cast<float>(value); }
 };
 
 struct ConvertibleDouble {
-    int value;
-
-    ConvertibleDouble(int v) : value(v) {}
-
-    operator double() const {
-        return static_cast<double>(value);
-    }
+  int value;
+  ConvertibleDouble(int v) : value(v) {}
+  operator double() const { return static_cast<double>(value); }
 };
 
 struct ConvertibleLongDouble {
-    int value;
-
-    ConvertibleLongDouble(int v) : value(v) {}
-
-    operator long double() const {
-        return static_cast<long double>(value);
-    }
+  int value;
+  ConvertibleLongDouble(int v) : value(v) {}
+  operator long double() const { return static_cast<long double>(value); }
 };
 
 int main(int, char**) {

--- a/libcxx/test/std/numerics/c.math/isfinite.pass.cpp
+++ b/libcxx/test/std/numerics/c.math/isfinite.pass.cpp
@@ -72,10 +72,21 @@ struct ConvertibleFloat {
     }
 };
 
+struct ConvertibleDouble {
+    int value;
+
+    ConvertibleDouble(int v) : value(v) {}
+
+    operator double() const {
+        return static_cast<double>(value);
+    }
+};
+
 int main(int, char**) {
   types::for_each(types::floating_point_types(), TestFloat());
   types::for_each(types::integral_types(), TestInt());
   assert(std::isfinite(ConvertibleFloat(0)));
+  assert(std::isfinite(ConvertibleDouble(0)));
 
   return 0;
 }


### PR DESCRIPTION
Closes https://github.com/llvm/llvm-project/issues/98816.