### PR TITLE
[libc] Use Atomics in GPU Benchmarks

### DIFF
--- a/libc/benchmarks/gpu/CMakeLists.txt
+++ b/libc/benchmarks/gpu/CMakeLists.txt
@@ -43,6 +43,7 @@ add_unittest_framework_library(
     libc.src.__support.CPP.functional
     libc.src.__support.CPP.limits
     libc.src.__support.CPP.algorithm
+    libc.src.__support.CPP.atomic
     libc.src.__support.fixed_point.fx_rep
     libc.src.__support.macros.properties.types
     libc.src.__support.OSUtil.osutil

--- a/libc/benchmarks/gpu/LibcGpuBenchmark.cpp
+++ b/libc/benchmarks/gpu/LibcGpuBenchmark.cpp
@@ -78,27 +78,27 @@ void print_results(Benchmark *b) {
 
   BenchmarkResult result;
   gpu::memory_fence();
-  int num_threads = all_results.active_threads.load(cpp::MemoryOrder::RELAXED);
+  int num_threads = all_results.active_threads.load(cpp::MemoryOrder::RELEASE);
   result.cycles =
-      all_results.cycles_sum.load(cpp::MemoryOrder::RELAXED) / num_threads;
+      all_results.cycles_sum.load(cpp::MemoryOrder::RELEASE) / num_threads;
   result.standard_deviation =
-      all_results.standard_deviation_sum.load(cpp::MemoryOrder::RELAXED) /
+      all_results.standard_deviation_sum.load(cpp::MemoryOrder::RELEASE) /
       num_threads;
-  result.min = all_results.min.load(cpp::MemoryOrder::RELAXED);
-  result.max = all_results.max.load(cpp::MemoryOrder::RELAXED);
+  result.min = all_results.min.load(cpp::MemoryOrder::RELEASE);
+  result.max = all_results.max.load(cpp::MemoryOrder::RELEASE);
   result.samples =
-      all_results.samples_sum.load(cpp::MemoryOrder::RELAXED) / num_threads;
+      all_results.samples_sum.load(cpp::MemoryOrder::RELEASE) / num_threads;
   result.total_iterations =
-      all_results.iterations_sum.load(cpp::MemoryOrder::RELAXED) / num_threads;
+      all_results.iterations_sum.load(cpp::MemoryOrder::RELEASE) / num_threads;
   result.total_time =
-      all_results.time_sum.load(cpp::MemoryOrder::RELAXED) / num_threads;
+      all_results.time_sum.load(cpp::MemoryOrder::RELEASE) / num_threads;
   gpu::memory_fence();
   log << GREEN << "[ RUN      ] " << RESET << b->get_name() << '\n';
   log << GREEN << "[       OK ] " << RESET << b->get_name() << ": "
       << result.cycles << " cycles, " << result.min << " min, " << result.max
       << " max, " << result.total_iterations << " iterations, "
       << result.total_time << " ns, "
-      << static_cast<long>(result.standard_deviation)
+      << static_cast<uint64_t>(result.standard_deviation)
       << " stddev (num threads: " << num_threads << ")\n";
 }
 

--- a/libc/benchmarks/gpu/LibcGpuBenchmark.cpp
+++ b/libc/benchmarks/gpu/LibcGpuBenchmark.cpp
@@ -110,14 +110,10 @@ void Benchmark::run_benchmarks() {
   gpu::sync_threads();
 
   for (Benchmark *b : benchmarks) {
-    gpu::memory_fence();
-
     if (id == 0)
       all_results.reset();
 
-    gpu::memory_fence();
     gpu::sync_threads();
-
     auto current_result = b->run();
     all_results.update(current_result);
     gpu::sync_threads();

--- a/libc/benchmarks/gpu/LibcGpuBenchmark.h
+++ b/libc/benchmarks/gpu/LibcGpuBenchmark.h
@@ -88,6 +88,7 @@ public:
   }
 
   static void run_benchmarks();
+  const cpp::string_view get_name() const { return name; }
 
 protected:
   static void add_benchmark(Benchmark *benchmark);
@@ -97,13 +98,12 @@ private:
     BenchmarkOptions options;
     return benchmark(options, func);
   }
-  const cpp::string_view get_name() const { return name; }
 };
 } // namespace benchmarks
 } // namespace LIBC_NAMESPACE_DECL
 
 #define BENCHMARK(SuiteName, TestName, Func)                                   \
   LIBC_NAMESPACE::benchmarks::Benchmark SuiteName##_##TestName##_Instance(     \
-      Func, #SuiteName "." #TestName);
+      Func, #SuiteName "." #TestName)
 
 #endif


### PR DESCRIPTION
This PR replaces our old method of reducing the benchmark results by using an array to using atomics instead. This should help us implement single threaded benchmarks.