### PR TITLE
[IR] Remove variants of dropUnknownNonDebugMetadata

### DIFF
--- a/llvm/include/llvm/IR/Instruction.h
+++ b/llvm/include/llvm/IR/Instruction.h
@@ -433,17 +433,7 @@ public:
   /// convenience method for passes to do so.
   /// dropUBImplyingAttrsAndUnknownMetadata should be used instead of
   /// this API if the Instruction being modified is a call.
-  void dropUnknownNonDebugMetadata(ArrayRef<unsigned> KnownIDs);
-  void dropUnknownNonDebugMetadata() {
-    return dropUnknownNonDebugMetadata(std::nullopt);
-  }
-  void dropUnknownNonDebugMetadata(unsigned ID1) {
-    return dropUnknownNonDebugMetadata(ArrayRef(ID1));
-  }
-  void dropUnknownNonDebugMetadata(unsigned ID1, unsigned ID2) {
-    unsigned IDs[] = {ID1, ID2};
-    return dropUnknownNonDebugMetadata(IDs);
-  }
+  void dropUnknownNonDebugMetadata(ArrayRef<unsigned> KnownIDs = std::nullopt);
   /// @}
 
   /// Adds an !annotation metadata node with \p Annotation to this instruction.


### PR DESCRIPTION
This patch removes:

- dropUnknownNonDebugMetadata()
- dropUnknownNonDebugMetadata(ID1)
- dropUnknownNonDebugMetadata(ID1, ID2)

The first variant has existing uses, but we can accommodate those by
adding a default parameter to the main variant.

The second and third variant do not have any existing use AFAICT.
