### PR TITLE
Fix assertion failure in PR98681

### DIFF
--- a/llvm/lib/Analysis/ConstantFolding.cpp
+++ b/llvm/lib/Analysis/ConstantFolding.cpp
@@ -2759,7 +2759,7 @@ static Constant *ConstantFoldIntrinsicCall2(Intrinsic::ID IntrinsicID, Type *Ty,
         switch (Ty->getTypeID()) {
         case Type::HalfTyID:
         case Type::FloatTyID: {
-          APFloat Res(std::pow(Op1V.convertToFloat(), Exp));
+          APFloat Res(static_cast<float>(std::pow(Op1V.convertToFloat(), Exp)));
           if (Ty->isHalfTy()) {
             bool Unused;
             Res.convert(APFloat::IEEEhalf(), APFloat::rmNearestTiesToEven,

--- a/llvm/test/Transforms/EarlyCSE/math-2.ll
+++ b/llvm/test/Transforms/EarlyCSE/math-2.ll
@@ -4,7 +4,7 @@
 declare double @atan2(double, double) #0
 define double @f_atan2() {
 ; CHECK-LABEL: @f_atan2(
-; CHECK-NEXT:    ret double 0x3FDDAC670561BB4F
+; CHECK-NEXT:    ret double 0x3FDDAC6{{.+}}
 ;
   %res = tail call fast double @atan2(double 1.0, double 2.0)
   ret double %res

--- a/llvm/test/Transforms/EarlyCSE/math-2.ll
+++ b/llvm/test/Transforms/EarlyCSE/math-2.ll
@@ -4,7 +4,7 @@
 declare double @atan2(double, double) #0
 define double @f_atan2() {
 ; CHECK-LABEL: @f_atan2(
-; CHECK-NEXT:    ret double 0x3FDDAC6{{.+}}
+; CHECK-NEXT:    ret double 0x3FDDAC670561BB4F
 ;
   %res = tail call fast double @atan2(double 1.0, double 2.0)
   ret double %res
@@ -106,6 +106,14 @@ define half @pr98665() {
 ;
   %x = call half @llvm.powi.f16.i32(half 0xH3C00, i32 1)
   ret half %x
+}
+
+define float @powi_f32() {
+; CHECK-LABEL: @powi_f32(
+; CHECK-NEXT:    ret float 0.000000e+00
+;
+  %y = call float @llvm.powi.f32.i32(float 0.0, i32 10)
+  ret float %y
 }
 
 attributes #0 = { nofree nounwind willreturn }


### PR DESCRIPTION
See https://en.cppreference.com/w/cpp/numeric/math/pow:
```
C++98 added overloads where exp has type int on top of C [pow()](https://en.cppreference.com/w/c/numeric/math/pow), and the return type of std::pow(float, int) was float. However, the additional overloads introduced in C++11 specify that std::pow(float, int) should return double. [LWG issue 550](https://cplusplus.github.io/LWG/issue550) was raised to target this conflict, and the resolution is to removed the extra int exp overloads.
```
