### PR TITLE
[MLIR][Linalg] Fix named structured ops yaml file

### DIFF
--- a/mlir/include/mlir/Dialect/Linalg/IR/LinalgNamedStructuredOps.yaml
+++ b/mlir/include/mlir/Dialect/Linalg/IR/LinalgNamedStructuredOps.yaml
@@ -516,7 +516,7 @@ structured_op: !LinalgStructuredOpConfig
 --- !LinalgOpConfig
 metadata: !LinalgOpMetadata
   name: erf
-  cpp_class_name: erfOp
+  cpp_class_name: ErfOp
   doc: |-
     Applies erf(x) elementwise.
 

--- a/mlir/python/mlir/dialects/linalg/opdsl/lang/comprehension.py
+++ b/mlir/python/mlir/dialects/linalg/opdsl/lang/comprehension.py
@@ -292,6 +292,7 @@ class UnaryFn:
     ceil = UnaryFnType("ceil")
     floor = UnaryFnType("floor")
     negf = UnaryFnType("negf")
+    reciprocal = UnaryFnType("reciprocal")
     round = UnaryFnType("round")
     sqrt = UnaryFnType("sqrt")
     rsqrt = UnaryFnType("rsqrt")

--- a/mlir/python/mlir/dialects/linalg/opdsl/ops/core_named_ops.py
+++ b/mlir/python/mlir/dialects/linalg/opdsl/ops/core_named_ops.py
@@ -108,6 +108,18 @@ def negf(
     O[None] = UnaryFn.negf(I[None])
 
 
+@linalg_structured_op(op_class_name="ReciprocalOp")
+def reciprocal(
+    I=TensorDef(T1),
+    O=TensorDef(T1, output=True),
+):
+    """Applies reciprocal(x) elementwise.
+
+    No numeric casting is performed on the input operand.
+    """
+    O[None] = UnaryFn.reciprocal(I[None])
+
+
 @linalg_structured_op
 def round(
     I=TensorDef(T1),


### PR DESCRIPTION
Added missing reciprocal to Python file and fixed ErfOp name in yaml file. Now running the bash script yields the same output.