### PR TITLE
[PatternMatch] Fix issue of stale reference in new `m_{I,F,}Cmp` matchers

### DIFF
--- a/llvm/include/llvm/IR/PatternMatch.h
+++ b/llvm/include/llvm/IR/PatternMatch.h
@@ -1550,23 +1550,27 @@ template <typename T> inline Exact_match<T> m_Exact(const T &SubPattern) {
 template <typename LHS_t, typename RHS_t, typename Class, typename PredicateTy,
           bool Commutable = false>
 struct CmpClass_match {
-  PredicateTy &Predicate;
+  PredicateTy *Predicate;
   LHS_t L;
   RHS_t R;
 
   // The evaluation order is always stable, regardless of Commutability.
   // The LHS is always matched first.
   CmpClass_match(PredicateTy &Pred, const LHS_t &LHS, const RHS_t &RHS)
-      : Predicate(Pred), L(LHS), R(RHS) {}
+      : Predicate(&Pred), L(LHS), R(RHS) {}
+  CmpClass_match(const LHS_t &LHS, const RHS_t &RHS)
+      : Predicate(nullptr), L(LHS), R(RHS) {}
 
   template <typename OpTy> bool match(OpTy *V) {
     if (auto *I = dyn_cast<Class>(V)) {
       if (L.match(I->getOperand(0)) && R.match(I->getOperand(1))) {
-        Predicate = I->getPredicate();
+        if (Predicate)
+          *Predicate = I->getPredicate();
         return true;
       } else if (Commutable && L.match(I->getOperand(1)) &&
                  R.match(I->getOperand(0))) {
-        Predicate = I->getSwappedPredicate();
+        if (Predicate)
+          *Predicate = I->getSwappedPredicate();
         return true;
       }
     }
@@ -1595,22 +1599,19 @@ m_FCmp(FCmpInst::Predicate &Pred, const LHS &L, const RHS &R) {
 template <typename LHS, typename RHS>
 inline CmpClass_match<LHS, RHS, CmpInst, CmpInst::Predicate>
 m_Cmp(const LHS &L, const RHS &R) {
-  CmpInst::Predicate Unused;
-  return CmpClass_match<LHS, RHS, CmpInst, CmpInst::Predicate>(Unused, L, R);
+  return CmpClass_match<LHS, RHS, CmpInst, CmpInst::Predicate>(L, R);
 }
 
 template <typename LHS, typename RHS>
 inline CmpClass_match<LHS, RHS, ICmpInst, ICmpInst::Predicate>
 m_ICmp(const LHS &L, const RHS &R) {
-  ICmpInst::Predicate Unused;
-  return CmpClass_match<LHS, RHS, ICmpInst, ICmpInst::Predicate>(Unused, L, R);
+  return CmpClass_match<LHS, RHS, ICmpInst, ICmpInst::Predicate>(L, R);
 }
 
 template <typename LHS, typename RHS>
 inline CmpClass_match<LHS, RHS, FCmpInst, FCmpInst::Predicate>
 m_FCmp(const LHS &L, const RHS &R) {
-  FCmpInst::Predicate Unused;
-  return CmpClass_match<LHS, RHS, FCmpInst, FCmpInst::Predicate>(Unused, L, R);
+  return CmpClass_match<LHS, RHS, FCmpInst, FCmpInst::Predicate>(L, R);
 }
 
 // Same as CmpClass, but instead of saving Pred as out output variable, match a

--- a/llvm/unittests/IR/PatternMatch.cpp
+++ b/llvm/unittests/IR/PatternMatch.cpp
@@ -2235,7 +2235,7 @@ typedef ::testing::Types<std::tuple<Value*, Instruction*>,
     MutableConstTestTypes;
 TYPED_TEST_SUITE(MutableConstTest, MutableConstTestTypes, );
 
-TYPED_TEST(MutableConstTest, /* FIXME: UAR bug */ DISABLED_ICmp) {
+TYPED_TEST(MutableConstTest, ICmp) {
   auto &IRB = PatternMatchTest::IRB;
 
   typedef std::tuple_element_t<0, TypeParam> ValueType;
@@ -2319,7 +2319,7 @@ TYPED_TEST(MutableConstTest, /* FIXME: UAR bug */ DISABLED_ICmp) {
                    .match((InstructionType)IRB.CreateICmp(Pred, L, R)));
 }
 
-TYPED_TEST(MutableConstTest, /* FIXME: UAR bug */ DISABLED_FCmp) {
+TYPED_TEST(MutableConstTest, FCmp) {
   auto &IRB = PatternMatchTest::IRB;
 
   typedef std::tuple_element_t<0, TypeParam> ValueType;


### PR DESCRIPTION
The new matchers don't output pred. Previously we where just creating
a value on the stack and using it as a dummy output for the matchers,
but this results in a stale reference upon return.

To fix, this patch changes the output variable to a pointer, and
passes in `nullptr` for the matchers that don't output `pred.`
