### PR TITLE
[libc] Mark external baremetal I/O symbols as extern "C"

### DIFF
--- a/libc/src/__support/OSUtil/baremetal/io.cpp
+++ b/libc/src/__support/OSUtil/baremetal/io.cpp
@@ -44,9 +44,9 @@ namespace LIBC_NAMESPACE_DECL {
 
 struct __llvm_libc_stdio_cookie;
 
-extern struct __llvm_libc_stdio_cookie __llvm_libc_stdin_cookie;
-extern struct __llvm_libc_stdio_cookie __llvm_libc_stdout_cookie;
-extern struct __llvm_libc_stdio_cookie __llvm_libc_stderr_cookie;
+extern "C" struct __llvm_libc_stdio_cookie __llvm_libc_stdin_cookie;
+extern "C" struct __llvm_libc_stdio_cookie __llvm_libc_stdout_cookie;
+extern "C" struct __llvm_libc_stdio_cookie __llvm_libc_stderr_cookie;
 
 extern "C" ssize_t __llvm_libc_stdio_read(void *cookie, char *buf, size_t size);
 extern "C" ssize_t __llvm_libc_stdio_write(void *cookie, const char *buf,


### PR DESCRIPTION
These need to use C ABI.