### PR TITLE
[bolt][test] Require asserts in X86/match-functions-with-calls-as-anchors.test

### DIFF
--- a/bolt/test/X86/match-functions-with-calls-as-anchors.test
+++ b/bolt/test/X86/match-functions-with-calls-as-anchors.test
@@ -1,6 +1,6 @@
 ## Tests blocks matching by called function names in inferStaleProfile.
 
-# REQUIRES: system-linux
+# REQUIRES: system-linux, asserts
 # RUN: split-file %s %t
 # RUN: llvm-mc -filetype=obj -triple x86_64-unknown-unknown %t/main.s -o %t.o
 # RUN: %clang %cflags %t.o -o %t.exe -Wl,-q -nostdlib


### PR DESCRIPTION
Otherwise, it fails due to the unsupported `--debug` flag in non-asserts builds.