### PR TITLE
[mlir] Allow unroll & jam on SCF loops with results

### DIFF
--- a/mlir/lib/Dialect/SCF/Utils/Utils.cpp
+++ b/mlir/lib/Dialect/SCF/Utils/Utils.cpp
@@ -486,20 +486,25 @@ LogicalResult mlir::loopUnrollByFactor(
 }
 
 /// Check if bounds of all inner loops are defined outside of `forOp`
-/// and return false if not.
+/// or defined by constants, and return false if not.
 static bool areInnerBoundsInvariant(scf::ForOp forOp) {
   auto walkResult = forOp.walk([&](scf::ForOp innerForOp) {
-    if (!forOp.isDefinedOutsideOfLoop(innerForOp.getLowerBound()) ||
-        !forOp.isDefinedOutsideOfLoop(innerForOp.getUpperBound()) ||
-        !forOp.isDefinedOutsideOfLoop(innerForOp.getStep()))
+    auto isValueInvariantInLoop = [&forOp](Value v) -> bool {
+      return forOp.isDefinedOutsideOfLoop(v) ||
+             isa<arith::ConstantOp>(v.getDefiningOp());
+    };
+    if (!isValueInvariantInLoop(innerForOp.getLowerBound()) ||
+        !isValueInvariantInLoop(innerForOp.getUpperBound()) ||
+        !isValueInvariantInLoop(innerForOp.getStep()))
       return WalkResult::interrupt();
-
     return WalkResult::advance();
   });
   return !walkResult.wasInterrupted();
 }
 
 /// Unrolls and jams this loop by the specified factor.
+/// This function doesn't verify that the loop is parallel, if there are true
+/// loop carried dependencies, this function will produce invalid code.
 LogicalResult mlir::loopUnrollJamByFactor(scf::ForOp forOp,
                                           uint64_t unrollJamFactor) {
   assert(unrollJamFactor > 0 && "unroll jam factor should be positive");
@@ -511,12 +516,6 @@ LogicalResult mlir::loopUnrollJamByFactor(scf::ForOp forOp,
   // `forOp`, no unroll jam.
   if (!areInnerBoundsInvariant(forOp)) {
     LDBG("failed to unroll and jam: inner bounds are not invariant");
-    return failure();
-  }
-
-  // Currently, for operations with results are not supported.
-  if (forOp->getNumResults() > 0) {
-    LDBG("failed to unroll and jam: unsupported loop with results");
     return failure();
   }
 

--- a/mlir/test/Dialect/SCF/transform-ops-invalid.mlir
+++ b/mlir/test/Dialect/SCF/transform-ops-invalid.mlir
@@ -63,29 +63,6 @@ module attributes {transform.with_named_sequence} {
 
 // -----
 
-func.func @loop_unroll_and_jam_unsupported_loop_with_results() -> index {
-  %c0 = arith.constant 0 : index
-  %c40 = arith.constant 40 : index
-  %c2 = arith.constant 2 : index
-  %sum = scf.for %i = %c0 to %c40 step %c2 iter_args(%does_not_alias_aggregated = %c0) -> (index) {
-    %sum = arith.addi %i, %i : index
-    scf.yield %sum : index
-  }
-  return %sum : index
-}
-
-module attributes {transform.with_named_sequence} {
-  transform.named_sequence @__transform_main(%arg1: !transform.any_op {transform.readonly}) {
-    %0 = transform.structured.match ops{["arith.addi"]} in %arg1 : (!transform.any_op) -> !transform.any_op
-    %1 = transform.get_parent_op %0 {op_name = "scf.for"} : (!transform.any_op) -> !transform.op<"scf.for">
-    // expected-error @below {{failed to unroll and jam}}
-    transform.loop.unroll_and_jam %1 { factor = 4 } : !transform.op<"scf.for">
-    transform.yield
-  }
-}
-
-// -----
-
 func.func private @loop_unroll_and_jam_unsupported_dynamic_trip_count(%arg0: memref<96x128xi8, 3>, %arg1: memref<128xi8, 3>) {
   %c96 = arith.constant 96 : index
   %c1 = arith.constant 1 : index


### PR DESCRIPTION
Unlike the affine version, the unroll & jam version for SCF loops does not support loops with results/iter_args, but there's not real reason to have this difference between the two.

Even though `iter_args` may indicate a loop-carried dependency and, therefore, its unsuitability for unroll & jam, there are many transformations that materialize loops with "transient" `iter_args` that don't represent real dependencies, and will eventually go away. E.g.: `linalg::tileLinalgOp` on non-bufferized linalg ops.

Given that this transformation doesn't perform a full dependency analysis to ensure its safety, it's already up to the user to make sure that the loop is parallel before proceeding. Allowing loops with results makes this transformation more widely applicable without really losing on safety.