### PR TITLE
[AMDGPU][llvm-split] Fix division by zero

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPUSplitModule.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUSplitModule.cpp
@@ -256,11 +256,12 @@ calculateFunctionCosts(SplitModuleLogger &SML, GetTTIFn GetTTI, Module &M,
   }
 
   CostType FnCost = (ModuleCost - KernelCost);
+  CostType ModuleCostOr1 = ModuleCost ? ModuleCost : 1;
   SML << "=> Total Module Cost: " << ModuleCost << '\n'
       << "  => KernelCost: " << KernelCost << " ("
-      << format("%0.2f", (float(KernelCost) / ModuleCost) * 100) << "%)\n"
+      << format("%0.2f", (float(KernelCost) / ModuleCostOr1) * 100) << "%)\n"
       << "  => FnsCost: " << FnCost << " ("
-      << format("%0.2f", (float(FnCost) / ModuleCost) * 100) << "%)\n";
+      << format("%0.2f", (float(FnCost) / ModuleCostOr1) * 100) << "%)\n";
 
   return ModuleCost;
 }

--- a/llvm/test/tools/llvm-split/AMDGPU/declarations.ll
+++ b/llvm/test/tools/llvm-split/AMDGPU/declarations.ll
@@ -1,0 +1,15 @@
+; RUN: llvm-split -o %t %s -j 2 -mtriple amdgcn-amd-amdhsa
+; RUN: llvm-dis -o - %t0 | FileCheck --check-prefix=CHECK0 %s
+; RUN: llvm-dis -o - %t1 | FileCheck --check-prefix=CHECK1 %s
+
+; Check that all declarations are put into each partition.
+
+; CHECK0: declare void @A
+; CHECK0: declare void @B
+
+; CHECK1: declare void @A
+; CHECK1: declare void @B
+
+declare void @A()
+
+declare void @B()


### PR DESCRIPTION
An empty module, or one containing only declarations, would result in a division by a zero cost.