### PR TITLE
[clang][dataflow] reland #96766 with fix

### DIFF
--- a/clang/include/clang/Analysis/FlowSensitive/ASTOps.h
+++ b/clang/include/clang/Analysis/FlowSensitive/ASTOps.h
@@ -113,7 +113,11 @@ public:
   // nevertheless it appears in the Clang CFG, so we don't exclude it here.
   bool TraverseDecltypeTypeLoc(DecltypeTypeLoc) { return true; }
   bool TraverseTypeOfExprTypeLoc(TypeOfExprTypeLoc) { return true; }
-  bool TraverseCXXTypeidExpr(CXXTypeidExpr *) { return true; }
+  bool TraverseCXXTypeidExpr(CXXTypeidExpr *TIE) {
+    if (TIE->isPotentiallyEvaluated())
+      return RecursiveASTVisitor<Derived>::TraverseCXXTypeidExpr(TIE);
+    return true;
+  }
   bool TraverseUnaryExprOrTypeTraitExpr(UnaryExprOrTypeTraitExpr *) {
     return true;
   }

--- a/clang/unittests/Analysis/FlowSensitive/TestingSupport.cpp
+++ b/clang/unittests/Analysis/FlowSensitive/TestingSupport.cpp
@@ -176,13 +176,18 @@ llvm::Error test::checkDataflowWithNoopAnalysis(
     DataflowAnalysisOptions Options, LangStandard::Kind Std,
     std::function<llvm::StringMap<QualType>(QualType)> SyntheticFieldCallback) {
   llvm::SmallVector<std::string, 3> ASTBuildArgs = {
+      "-fsyntax-only",
       // -fnodelayed-template-parsing is the default everywhere but on Windows.
       // Set it explicitly so that tests behave the same on Windows as on other
       // platforms.
+      "-fno-delayed-template-parsing",
       // Set -Wno-unused-value because it's often desirable in tests to write
       // expressions with unused value, and we don't want the output to be
       // cluttered with warnings about them.
-      "-fsyntax-only", "-fno-delayed-template-parsing", "-Wno-unused-value",
+      "-Wno-unused-value",
+      // Some build environments don't have RTTI enabled by default.
+      // Enable it explicitly to make sure tests work in all environments.
+      "-frtti",
       "-std=" +
           std::string(LangStandard::getLangStandardForKind(Std).getName())};
   AnalysisInputs<NoopAnalysis> AI(


### PR DESCRIPTION
- **Reapply "[clang][dataflow] Teach `AnalysisASTVisitor` that `typeid()` can be evaluated." (#96766)**
- **Turn on RTTI explicitly in `checkDataflowWithNoopAnalysis()`.**
