### PR TITLE
Split DWARFFormValue::getReference into four functions

### DIFF
--- a/llvm/include/llvm/DebugInfo/DWARF/DWARFFormValue.h
+++ b/llvm/include/llvm/DebugInfo/DWARF/DWARFFormValue.h
@@ -260,7 +260,7 @@ toRelativeReference(const std::optional<DWARFFormValue> &V) {
 /// \returns the extracted reference value or Default if the V doesn't have a
 /// value or the form value's encoding wasn't a relative offset reference form.
 inline uint64_t toRelativeReference(const std::optional<DWARFFormValue> &V,
-                            uint64_t Default) {
+                                    uint64_t Default) {
   return toRelativeReference(V).value_or(Default);
 }
 
@@ -286,7 +286,7 @@ toDebugInfoReference(const std::optional<DWARFFormValue> &V) {
 /// value or the form value's encoding wasn't an absolute debug info offset
 /// reference form.
 inline uint64_t toDebugInfoReference(const std::optional<DWARFFormValue> &V,
-                            uint64_t Default) {
+                                     uint64_t Default) {
   return toDebugInfoReference(V).value_or(Default);
 }
 
@@ -309,7 +309,7 @@ toSignatureReference(const std::optional<DWARFFormValue> &V) {
 /// \returns the extracted reference value or Default if the V doesn't have a
 /// value or the form value's encoding wasn't a signature reference form.
 inline uint64_t toSignatureReference(const std::optional<DWARFFormValue> &V,
-                            uint64_t Default) {
+                                     uint64_t Default) {
   return toSignatureReference(V).value_or(Default);
 }
 
@@ -334,7 +334,7 @@ toSupplementaryReference(const std::optional<DWARFFormValue> &V) {
 /// \returns the extracted reference value or Default if the V doesn't have a
 /// value or the form value's encoding wasn't a supplementary reference form.
 inline uint64_t toSupplementaryReference(const std::optional<DWARFFormValue> &V,
-                            uint64_t Default) {
+                                         uint64_t Default) {
   return toSupplementaryReference(V).value_or(Default);
 }
 

--- a/llvm/include/llvm/DebugInfo/DWARF/DWARFFormValue.h
+++ b/llvm/include/llvm/DebugInfo/DWARF/DWARFFormValue.h
@@ -107,12 +107,10 @@ public:
 
   /// getAsFoo functions below return the extracted value as Foo if only
   /// DWARFFormValue has form class is suitable for representing Foo.
-  std::optional<uint64_t> getAsReference() const;
-  struct UnitOffset {
-    DWARFUnit *Unit;
-    uint64_t Offset;
-  };
-  std::optional<UnitOffset> getAsRelativeReference() const;
+  std::optional<uint64_t> getAsRelativeReference() const;
+  std::optional<uint64_t> getAsDebugInfoReference() const;
+  std::optional<uint64_t> getAsSignatureReference() const;
+  std::optional<uint64_t> getAsSupplementaryReference() const;
   std::optional<uint64_t> getAsUnsignedConstant() const;
   std::optional<int64_t> getAsSignedConstant() const;
   Expected<const char *> getAsCString() const;
@@ -242,27 +240,102 @@ inline uint64_t toUnsigned(const std::optional<DWARFFormValue> &V,
   return toUnsigned(V).value_or(Default);
 }
 
-/// Take an optional DWARFFormValue and try to extract an reference.
+/// Take an optional DWARFFormValue and try to extract a relative offset
+/// reference.
 ///
-/// \param V and optional DWARFFormValue to attempt to extract the value from.
+/// \param V an optional DWARFFormValue to attempt to extract the value from.
 /// \returns an optional value that contains a value if the form value
-/// was valid and has a reference form.
+/// was valid and has a relative reference form.
 inline std::optional<uint64_t>
-toReference(const std::optional<DWARFFormValue> &V) {
+toRelativeReference(const std::optional<DWARFFormValue> &V) {
   if (V)
-    return V->getAsReference();
+    return V->getAsRelativeReference();
   return std::nullopt;
 }
 
-/// Take an optional DWARFFormValue and extract a reference.
+/// Take an optional DWARFFormValue and extract a relative offset reference.
 ///
-/// \param V and optional DWARFFormValue to attempt to extract the value from.
+/// \param V an optional DWARFFormValue to attempt to extract the value from.
 /// \param Default the default value to return in case of failure.
 /// \returns the extracted reference value or Default if the V doesn't have a
-/// value or the form value's encoding wasn't a reference form.
-inline uint64_t toReference(const std::optional<DWARFFormValue> &V,
+/// value or the form value's encoding wasn't a relative offset reference form.
+inline uint64_t toRelativeReference(const std::optional<DWARFFormValue> &V,
                             uint64_t Default) {
-  return toReference(V).value_or(Default);
+  return toRelativeReference(V).value_or(Default);
+}
+
+/// Take an optional DWARFFormValue and try to extract an absolute debug info
+/// offset reference.
+///
+/// \param V an optional DWARFFormValue to attempt to extract the value from.
+/// \returns an optional value that contains a value if the form value
+/// was valid and has an (absolute) debug info offset reference form.
+inline std::optional<uint64_t>
+toDebugInfoReference(const std::optional<DWARFFormValue> &V) {
+  if (V)
+    return V->getAsDebugInfoReference();
+  return std::nullopt;
+}
+
+/// Take an optional DWARFFormValue and extract an absolute debug info offset
+/// reference.
+///
+/// \param V an optional DWARFFormValue to attempt to extract the value from.
+/// \param Default the default value to return in case of failure.
+/// \returns the extracted reference value or Default if the V doesn't have a
+/// value or the form value's encoding wasn't an absolute debug info offset
+/// reference form.
+inline uint64_t toDebugInfoReference(const std::optional<DWARFFormValue> &V,
+                            uint64_t Default) {
+  return toDebugInfoReference(V).value_or(Default);
+}
+
+/// Take an optional DWARFFormValue and try to extract a signature reference.
+///
+/// \param V an optional DWARFFormValue to attempt to extract the value from.
+/// \returns an optional value that contains a value if the form value
+/// was valid and has a signature reference form.
+inline std::optional<uint64_t>
+toSignatureReference(const std::optional<DWARFFormValue> &V) {
+  if (V)
+    return V->getAsSignatureReference();
+  return std::nullopt;
+}
+
+/// Take an optional DWARFFormValue and extract a signature reference.
+///
+/// \param V an optional DWARFFormValue to attempt to extract the value from.
+/// \param Default the default value to return in case of failure.
+/// \returns the extracted reference value or Default if the V doesn't have a
+/// value or the form value's encoding wasn't a signature reference form.
+inline uint64_t toSignatureReference(const std::optional<DWARFFormValue> &V,
+                            uint64_t Default) {
+  return toSignatureReference(V).value_or(Default);
+}
+
+/// Take an optional DWARFFormValue and try to extract a supplementary debug
+/// info reference.
+///
+/// \param V an optional DWARFFormValue to attempt to extract the value from.
+/// \returns an optional value that contains a value if the form value
+/// was valid and has a supplementary reference form.
+inline std::optional<uint64_t>
+toSupplementaryReference(const std::optional<DWARFFormValue> &V) {
+  if (V)
+    return V->getAsSupplementaryReference();
+  return std::nullopt;
+}
+
+/// Take an optional DWARFFormValue and extract a supplementary debug info
+/// reference.
+///
+/// \param V an optional DWARFFormValue to attempt to extract the value from.
+/// \param Default the default value to return in case of failure.
+/// \returns the extracted reference value or Default if the V doesn't have a
+/// value or the form value's encoding wasn't a supplementary reference form.
+inline uint64_t toSupplementaryReference(const std::optional<DWARFFormValue> &V,
+                            uint64_t Default) {
+  return toSupplementaryReference(V).value_or(Default);
 }
 
 /// Take an optional DWARFFormValue and try to extract an signed constant.

--- a/llvm/lib/DWARFLinker/Classic/DWARFLinker.cpp
+++ b/llvm/lib/DWARFLinker/Classic/DWARFLinker.cpp
@@ -1082,7 +1082,7 @@ unsigned DWARFLinker::DIECloner::cloneDieReferenceAttribute(
     CompileUnit &Unit) {
   const DWARFUnit &U = Unit.getOrigUnit();
   uint64_t Ref;
-  if (std::optional<uint64_t> Off = Val.getAsRelativeReference()) 
+  if (std::optional<uint64_t> Off = Val.getAsRelativeReference())
     Ref = Val.getUnit()->getOffset() + *Off;
   else if (Off = Val.getAsDebugInfoReference(); Off)
     Ref = *Off;

--- a/llvm/lib/DWARFLinker/Classic/DWARFLinker.cpp
+++ b/llvm/lib/DWARFLinker/Classic/DWARFLinker.cpp
@@ -77,7 +77,15 @@ DWARFDie DWARFLinker::resolveDIEReference(const DWARFFile &File,
                                           const DWARFDie &DIE,
                                           CompileUnit *&RefCU) {
   assert(RefValue.isFormClass(DWARFFormValue::FC_Reference));
-  uint64_t RefOffset = *RefValue.getAsReference();
+  uint64_t RefOffset;
+  if (std::optional<uint64_t> Off = RefValue.getAsRelativeReference()) {
+    RefOffset = RefValue.getUnit()->getOffset() + *Off;
+  } else if (Off = RefValue.getAsDebugInfoReference(); Off) {
+    RefOffset = *Off;
+  } else {
+    reportWarning("Unsupported reference type", File, &DIE);
+    return DWARFDie();
+  }
   if ((RefCU = getUnitForOffset(Units, RefOffset)))
     if (const auto RefDie = RefCU->getOrigUnit().getDIEForOffset(RefOffset)) {
       // In a file with broken references, an attribute might point to a NULL
@@ -1073,7 +1081,13 @@ unsigned DWARFLinker::DIECloner::cloneDieReferenceAttribute(
     unsigned AttrSize, const DWARFFormValue &Val, const DWARFFile &File,
     CompileUnit &Unit) {
   const DWARFUnit &U = Unit.getOrigUnit();
-  uint64_t Ref = *Val.getAsReference();
+  uint64_t Ref;
+  if (std::optional<uint64_t> Off = Val.getAsRelativeReference()) 
+    Ref = Val.getUnit()->getOffset() + *Off;
+  else if (Off = Val.getAsDebugInfoReference(); Off)
+    Ref = *Off;
+  else
+    return 0;
 
   DIE *NewRefDie = nullptr;
   CompileUnit *RefUnit = nullptr;

--- a/llvm/lib/DebugInfo/DWARF/DWARFFormValue.cpp
+++ b/llvm/lib/DebugInfo/DWARF/DWARFFormValue.cpp
@@ -665,16 +665,7 @@ DWARFFormValue::getAsSectionedAddress() const {
   return getAsSectionedAddress(Value, Form, U);
 }
 
-std::optional<uint64_t> DWARFFormValue::getAsReference() const {
-  if (auto R = getAsRelativeReference())
-    return R->Unit ? R->Unit->getOffset() + R->Offset : R->Offset;
-  return std::nullopt;
-}
-
-std::optional<DWARFFormValue::UnitOffset>
-DWARFFormValue::getAsRelativeReference() const {
-  if (!isFormClass(FC_Reference))
-    return std::nullopt;
+std::optional<uint64_t> DWARFFormValue::getAsRelativeReference() const {
   switch (Form) {
   case DW_FORM_ref1:
   case DW_FORM_ref2:
@@ -683,11 +674,31 @@ DWARFFormValue::getAsRelativeReference() const {
   case DW_FORM_ref_udata:
     if (!U)
       return std::nullopt;
-    return UnitOffset{const_cast<DWARFUnit*>(U), Value.uval};
-  case DW_FORM_ref_addr:
-  case DW_FORM_ref_sig8:
+    return Value.uval;
+  default:
+    return std::nullopt;
+  }
+}
+
+std::optional<uint64_t> DWARFFormValue::getAsDebugInfoReference() const {
+  if (Form == DW_FORM_ref_addr)
+    return Value.uval;
+  return std::nullopt;
+}
+
+
+std::optional<uint64_t> DWARFFormValue::getAsSignatureReference() const {
+  if (Form == DW_FORM_ref_sig8)
+    return Value.uval;
+  return std::nullopt;
+}
+
+std::optional<uint64_t> DWARFFormValue::getAsSupplementaryReference() const {
+  switch (Form) {
   case DW_FORM_GNU_ref_alt:
-    return UnitOffset{nullptr, Value.uval};
+  case DW_FORM_ref_sup4:
+  case DW_FORM_ref_sup8:
+    return Value.uval;
   default:
     return std::nullopt;
   }

--- a/llvm/lib/DebugInfo/DWARF/DWARFFormValue.cpp
+++ b/llvm/lib/DebugInfo/DWARF/DWARFFormValue.cpp
@@ -686,7 +686,6 @@ std::optional<uint64_t> DWARFFormValue::getAsDebugInfoReference() const {
   return std::nullopt;
 }
 
-
 std::optional<uint64_t> DWARFFormValue::getAsSignatureReference() const {
   if (Form == DW_FORM_ref_sig8)
     return Value.uval;

--- a/llvm/lib/DebugInfo/DWARF/DWARFVerifier.cpp
+++ b/llvm/lib/DebugInfo/DWARF/DWARFVerifier.cpp
@@ -836,7 +836,7 @@ unsigned DWARFVerifier::verifyDebugInfoForm(const DWARFDie &Die,
   case DW_FORM_ref8:
   case DW_FORM_ref_udata: {
     // Verify all CU relative references are valid CU offsets.
-    std::optional<uint64_t> RefVal = AttrValue.Value.getAsReference();
+    std::optional<uint64_t> RefVal = AttrValue.Value.getAsRelativeReference();
     assert(RefVal);
     if (RefVal) {
       auto CUSize = DieCU->getNextUnitOffset() - DieCU->getOffset();
@@ -854,7 +854,8 @@ unsigned DWARFVerifier::verifyDebugInfoForm(const DWARFDie &Die,
       } else {
         // Valid reference, but we will verify it points to an actual
         // DIE later.
-        LocalReferences[*RefVal].insert(Die.getOffset());
+        LocalReferences[AttrValue.Value.getUnit()->getOffset() + *RefVal]
+            .insert(Die.getOffset());
       }
     }
     break;
@@ -862,7 +863,7 @@ unsigned DWARFVerifier::verifyDebugInfoForm(const DWARFDie &Die,
   case DW_FORM_ref_addr: {
     // Verify all absolute DIE references have valid offsets in the
     // .debug_info section.
-    std::optional<uint64_t> RefVal = AttrValue.Value.getAsReference();
+    std::optional<uint64_t> RefVal = AttrValue.Value.getAsDebugInfoReference();
     assert(RefVal);
     if (RefVal) {
       if (*RefVal >= DieCU->getInfoSection().Data.size()) {

--- a/llvm/lib/DebugInfo/LogicalView/Readers/LVDWARFReader.cpp
+++ b/llvm/lib/DebugInfo/LogicalView/Readers/LVDWARFReader.cpp
@@ -1082,10 +1082,17 @@ void LVDWARFReader::updateReference(dwarf::Attribute Attr,
   // FIXME: We are assuming that at most one Reference (DW_AT_specification,
   // DW_AT_abstract_origin, ...) and at most one Type (DW_AT_import, DW_AT_type)
   // appear in any single DIE, but this may not be true.
-  uint64_t Reference = *FormValue.getAsReference();
+  uint64_t Offset;
+  if (std::optional<uint64_t> Off = FormValue.getAsRelativeReference())
+    Offset = FormValue.getUnit()->getOffset() + *Off;
+  else if (Off = FormValue.getAsDebugInfoReference(); Off)
+    Offset = *Off;
+  else
+    llvm_unreachable("Unsupported reference type");
+
   // Get target for the given reference, if already created.
   LVElement *Target = getElementForOffset(
-      Reference, CurrentElement,
+      Offset, CurrentElement,
       /*IsType=*/Attr == dwarf::DW_AT_import || Attr == dwarf::DW_AT_type);
   // Check if we are dealing with cross CU references.
   if (FormValue.getForm() == dwarf::DW_FORM_ref_addr) {
@@ -1093,10 +1100,10 @@ void LVDWARFReader::updateReference(dwarf::Attribute Attr,
       // The global reference is ready. Mark it as global.
       Target->setIsGlobalReference();
       // Remove global reference from the unseen list.
-      removeGlobalOffset(Reference);
+      removeGlobalOffset(Offset);
     } else
       // Record the unseen cross CU reference.
-      addGlobalOffset(Reference);
+      addGlobalOffset(Offset);
   }
 
   // At this point, 'Target' can be null, in the case of the target element

--- a/llvm/unittests/DebugInfo/DWARF/DWARFDebugInfoTest.cpp
+++ b/llvm/unittests/DebugInfo/DWARF/DWARFDebugInfoTest.cpp
@@ -384,15 +384,18 @@ void TestAllForms() {
   //----------------------------------------------------------------------
   // Test reference forms
   //----------------------------------------------------------------------
-  EXPECT_EQ(RefAddr, toDebugInfoReference(DieDG.find(Attr_DW_FORM_ref_addr), 0));
+  EXPECT_EQ(RefAddr,
+            toDebugInfoReference(DieDG.find(Attr_DW_FORM_ref_addr), 0));
   EXPECT_EQ(Data1, toRelativeReference(DieDG.find(Attr_DW_FORM_ref1), 0));
   EXPECT_EQ(Data2, toRelativeReference(DieDG.find(Attr_DW_FORM_ref2), 0));
   EXPECT_EQ(Data4, toRelativeReference(DieDG.find(Attr_DW_FORM_ref4), 0));
   EXPECT_EQ(Data8, toRelativeReference(DieDG.find(Attr_DW_FORM_ref8), 0));
   if (Version >= 4) {
-    EXPECT_EQ(Data8_2, toSignatureReference(DieDG.find(Attr_DW_FORM_ref_sig8), 0));
+    EXPECT_EQ(Data8_2,
+              toSignatureReference(DieDG.find(Attr_DW_FORM_ref_sig8), 0));
   }
-  EXPECT_EQ(UData[0], toRelativeReference(DieDG.find(Attr_DW_FORM_ref_udata), 0));
+  EXPECT_EQ(UData[0],
+            toRelativeReference(DieDG.find(Attr_DW_FORM_ref_udata), 0));
 
   //----------------------------------------------------------------------
   // Test flag forms

--- a/llvm/unittests/DebugInfo/DWARF/DWARFDebugInfoTest.cpp
+++ b/llvm/unittests/DebugInfo/DWARF/DWARFDebugInfoTest.cpp
@@ -384,15 +384,15 @@ void TestAllForms() {
   //----------------------------------------------------------------------
   // Test reference forms
   //----------------------------------------------------------------------
-  EXPECT_EQ(RefAddr, toReference(DieDG.find(Attr_DW_FORM_ref_addr), 0));
-  EXPECT_EQ(Data1, toReference(DieDG.find(Attr_DW_FORM_ref1), 0));
-  EXPECT_EQ(Data2, toReference(DieDG.find(Attr_DW_FORM_ref2), 0));
-  EXPECT_EQ(Data4, toReference(DieDG.find(Attr_DW_FORM_ref4), 0));
-  EXPECT_EQ(Data8, toReference(DieDG.find(Attr_DW_FORM_ref8), 0));
+  EXPECT_EQ(RefAddr, toDebugInfoReference(DieDG.find(Attr_DW_FORM_ref_addr), 0));
+  EXPECT_EQ(Data1, toRelativeReference(DieDG.find(Attr_DW_FORM_ref1), 0));
+  EXPECT_EQ(Data2, toRelativeReference(DieDG.find(Attr_DW_FORM_ref2), 0));
+  EXPECT_EQ(Data4, toRelativeReference(DieDG.find(Attr_DW_FORM_ref4), 0));
+  EXPECT_EQ(Data8, toRelativeReference(DieDG.find(Attr_DW_FORM_ref8), 0));
   if (Version >= 4) {
-    EXPECT_EQ(Data8_2, toReference(DieDG.find(Attr_DW_FORM_ref_sig8), 0));
+    EXPECT_EQ(Data8_2, toSignatureReference(DieDG.find(Attr_DW_FORM_ref_sig8), 0));
   }
-  EXPECT_EQ(UData[0], toReference(DieDG.find(Attr_DW_FORM_ref_udata), 0));
+  EXPECT_EQ(UData[0], toRelativeReference(DieDG.find(Attr_DW_FORM_ref_udata), 0));
 
   //----------------------------------------------------------------------
   // Test flag forms
@@ -420,7 +420,7 @@ void TestAllForms() {
   // Test DWARF32/DWARF64 forms
   //----------------------------------------------------------------------
   EXPECT_EQ(Dwarf32Values[0],
-            toReference(DieDG.find(Attr_DW_FORM_GNU_ref_alt), 0));
+            toSupplementaryReference(DieDG.find(Attr_DW_FORM_GNU_ref_alt), 0));
   if (Version >= 4) {
     EXPECT_EQ(Dwarf32Values[1],
               toSectionOffset(DieDG.find(Attr_DW_FORM_sec_offset), 0));
@@ -761,14 +761,14 @@ template <uint16_t Version, class AddrType> void TestReferences() {
   EXPECT_TRUE(CU1Ref1DieDG.isValid());
   EXPECT_EQ(CU1Ref1DieDG.getTag(), DW_TAG_variable);
   EXPECT_EQ(CU1TypeDieDG.getOffset(),
-            toReference(CU1Ref1DieDG.find(DW_AT_type), -1ULL));
+            toRelativeReference(CU1Ref1DieDG.find(DW_AT_type), -1ULL));
   // Verify the sibling is our Ref2 DIE and that its DW_AT_type points to our
   // base type DIE in CU1.
   auto CU1Ref2DieDG = CU1Ref1DieDG.getSibling();
   EXPECT_TRUE(CU1Ref2DieDG.isValid());
   EXPECT_EQ(CU1Ref2DieDG.getTag(), DW_TAG_variable);
   EXPECT_EQ(CU1TypeDieDG.getOffset(),
-            toReference(CU1Ref2DieDG.find(DW_AT_type), -1ULL));
+            toRelativeReference(CU1Ref2DieDG.find(DW_AT_type), -1ULL));
 
   // Verify the sibling is our Ref4 DIE and that its DW_AT_type points to our
   // base type DIE in CU1.
@@ -776,7 +776,7 @@ template <uint16_t Version, class AddrType> void TestReferences() {
   EXPECT_TRUE(CU1Ref4DieDG.isValid());
   EXPECT_EQ(CU1Ref4DieDG.getTag(), DW_TAG_variable);
   EXPECT_EQ(CU1TypeDieDG.getOffset(),
-            toReference(CU1Ref4DieDG.find(DW_AT_type), -1ULL));
+            toRelativeReference(CU1Ref4DieDG.find(DW_AT_type), -1ULL));
 
   // Verify the sibling is our Ref8 DIE and that its DW_AT_type points to our
   // base type DIE in CU1.
@@ -784,7 +784,7 @@ template <uint16_t Version, class AddrType> void TestReferences() {
   EXPECT_TRUE(CU1Ref8DieDG.isValid());
   EXPECT_EQ(CU1Ref8DieDG.getTag(), DW_TAG_variable);
   EXPECT_EQ(CU1TypeDieDG.getOffset(),
-            toReference(CU1Ref8DieDG.find(DW_AT_type), -1ULL));
+            toRelativeReference(CU1Ref8DieDG.find(DW_AT_type), -1ULL));
 
   // Verify the sibling is our RefAddr DIE and that its DW_AT_type points to our
   // base type DIE in CU1.
@@ -792,7 +792,7 @@ template <uint16_t Version, class AddrType> void TestReferences() {
   EXPECT_TRUE(CU1RefAddrDieDG.isValid());
   EXPECT_EQ(CU1RefAddrDieDG.getTag(), DW_TAG_variable);
   EXPECT_EQ(CU1TypeDieDG.getOffset(),
-            toReference(CU1RefAddrDieDG.find(DW_AT_type), -1ULL));
+            toDebugInfoReference(CU1RefAddrDieDG.find(DW_AT_type), -1ULL));
 
   // Verify the sibling of the Ref4 DIE is our RefAddr DIE and that its
   // DW_AT_type points to our base type DIE.
@@ -800,38 +800,38 @@ template <uint16_t Version, class AddrType> void TestReferences() {
   EXPECT_TRUE(CU1ToCU2RefAddrDieDG.isValid());
   EXPECT_EQ(CU1ToCU2RefAddrDieDG.getTag(), DW_TAG_variable);
   EXPECT_EQ(CU2TypeDieDG.getOffset(),
-            toReference(CU1ToCU2RefAddrDieDG.find(DW_AT_type), -1ULL));
+            toDebugInfoReference(CU1ToCU2RefAddrDieDG.find(DW_AT_type), -1ULL));
 
   // Verify the sibling of the base type DIE is our Ref1 DIE and that its
   // DW_AT_type points to our base type DIE.
   auto CU2Ref1DieDG = CU2TypeDieDG.getSibling();
   EXPECT_TRUE(CU2Ref1DieDG.isValid());
   EXPECT_EQ(CU2Ref1DieDG.getTag(), DW_TAG_variable);
-  EXPECT_EQ(CU2TypeDieDG.getOffset(),
-            toReference(CU2Ref1DieDG.find(DW_AT_type), -1ULL));
+  EXPECT_EQ(CU2TypeDieDG.getOffset() - CU2TypeDieDG.getDwarfUnit()->getOffset(),
+            toRelativeReference(CU2Ref1DieDG.find(DW_AT_type), -1ULL));
   // Verify the sibling is our Ref2 DIE and that its DW_AT_type points to our
   // base type DIE in CU2.
   auto CU2Ref2DieDG = CU2Ref1DieDG.getSibling();
   EXPECT_TRUE(CU2Ref2DieDG.isValid());
   EXPECT_EQ(CU2Ref2DieDG.getTag(), DW_TAG_variable);
-  EXPECT_EQ(CU2TypeDieDG.getOffset(),
-            toReference(CU2Ref2DieDG.find(DW_AT_type), -1ULL));
+  EXPECT_EQ(CU2TypeDieDG.getOffset() - CU2TypeDieDG.getDwarfUnit()->getOffset(),
+            toRelativeReference(CU2Ref2DieDG.find(DW_AT_type), -1ULL));
 
   // Verify the sibling is our Ref4 DIE and that its DW_AT_type points to our
   // base type DIE in CU2.
   auto CU2Ref4DieDG = CU2Ref2DieDG.getSibling();
   EXPECT_TRUE(CU2Ref4DieDG.isValid());
   EXPECT_EQ(CU2Ref4DieDG.getTag(), DW_TAG_variable);
-  EXPECT_EQ(CU2TypeDieDG.getOffset(),
-            toReference(CU2Ref4DieDG.find(DW_AT_type), -1ULL));
+  EXPECT_EQ(CU2TypeDieDG.getOffset() - CU2TypeDieDG.getDwarfUnit()->getOffset(),
+            toRelativeReference(CU2Ref4DieDG.find(DW_AT_type), -1ULL));
 
   // Verify the sibling is our Ref8 DIE and that its DW_AT_type points to our
   // base type DIE in CU2.
   auto CU2Ref8DieDG = CU2Ref4DieDG.getSibling();
   EXPECT_TRUE(CU2Ref8DieDG.isValid());
   EXPECT_EQ(CU2Ref8DieDG.getTag(), DW_TAG_variable);
-  EXPECT_EQ(CU2TypeDieDG.getOffset(),
-            toReference(CU2Ref8DieDG.find(DW_AT_type), -1ULL));
+  EXPECT_EQ(CU2TypeDieDG.getOffset() - CU2TypeDieDG.getDwarfUnit()->getOffset(),
+            toRelativeReference(CU2Ref8DieDG.find(DW_AT_type), -1ULL));
 
   // Verify the sibling is our RefAddr DIE and that its DW_AT_type points to our
   // base type DIE in CU2.
@@ -839,7 +839,7 @@ template <uint16_t Version, class AddrType> void TestReferences() {
   EXPECT_TRUE(CU2RefAddrDieDG.isValid());
   EXPECT_EQ(CU2RefAddrDieDG.getTag(), DW_TAG_variable);
   EXPECT_EQ(CU2TypeDieDG.getOffset(),
-            toReference(CU2RefAddrDieDG.find(DW_AT_type), -1ULL));
+            toDebugInfoReference(CU2RefAddrDieDG.find(DW_AT_type), -1ULL));
 
   // Verify the sibling of the Ref4 DIE is our RefAddr DIE and that its
   // DW_AT_type points to our base type DIE.
@@ -847,7 +847,7 @@ template <uint16_t Version, class AddrType> void TestReferences() {
   EXPECT_TRUE(CU2ToCU1RefAddrDieDG.isValid());
   EXPECT_EQ(CU2ToCU1RefAddrDieDG.getTag(), DW_TAG_variable);
   EXPECT_EQ(CU1TypeDieDG.getOffset(),
-            toReference(CU2ToCU1RefAddrDieDG.find(DW_AT_type), -1ULL));
+            toDebugInfoReference(CU2ToCU1RefAddrDieDG.find(DW_AT_type), -1ULL));
 }
 
 TEST(DWARFDebugInfo, TestDWARF32Version2Addr4References) {
@@ -1662,14 +1662,20 @@ TEST(DWARFDebugInfo, TestDwarfToFunctions) {
   std::optional<DWARFFormValue> FormValOpt1 = DWARFFormValue();
   EXPECT_FALSE(toString(FormValOpt1).has_value());
   EXPECT_FALSE(toUnsigned(FormValOpt1).has_value());
-  EXPECT_FALSE(toReference(FormValOpt1).has_value());
+  EXPECT_FALSE(toRelativeReference(FormValOpt1).has_value());
+  EXPECT_FALSE(toDebugInfoReference(FormValOpt1).has_value());
+  EXPECT_FALSE(toSignatureReference(FormValOpt1).has_value());
+  EXPECT_FALSE(toSupplementaryReference(FormValOpt1).has_value());
   EXPECT_FALSE(toSigned(FormValOpt1).has_value());
   EXPECT_FALSE(toAddress(FormValOpt1).has_value());
   EXPECT_FALSE(toSectionOffset(FormValOpt1).has_value());
   EXPECT_FALSE(toBlock(FormValOpt1).has_value());
   EXPECT_EQ(nullptr, toString(FormValOpt1, nullptr));
   EXPECT_EQ(InvalidU64, toUnsigned(FormValOpt1, InvalidU64));
-  EXPECT_EQ(InvalidU64, toReference(FormValOpt1, InvalidU64));
+  EXPECT_EQ(InvalidU64, toRelativeReference(FormValOpt1, InvalidU64));
+  EXPECT_EQ(InvalidU64, toDebugInfoReference(FormValOpt1, InvalidU64));
+  EXPECT_EQ(InvalidU64, toSignatureReference(FormValOpt1, InvalidU64));
+  EXPECT_EQ(InvalidU64, toSupplementaryReference(FormValOpt1, InvalidU64));
   EXPECT_EQ(InvalidU64, toAddress(FormValOpt1, InvalidU64));
   EXPECT_EQ(InvalidU64, toSectionOffset(FormValOpt1, InvalidU64));
   EXPECT_EQ(InvalidS64, toSigned(FormValOpt1, InvalidS64));
@@ -1681,14 +1687,20 @@ TEST(DWARFDebugInfo, TestDwarfToFunctions) {
 
   EXPECT_FALSE(toString(FormValOpt2).has_value());
   EXPECT_FALSE(toUnsigned(FormValOpt2).has_value());
-  EXPECT_FALSE(toReference(FormValOpt2).has_value());
+  EXPECT_FALSE(toRelativeReference(FormValOpt2).has_value());
+  EXPECT_FALSE(toDebugInfoReference(FormValOpt2).has_value());
+  EXPECT_FALSE(toSignatureReference(FormValOpt2).has_value());
+  EXPECT_FALSE(toSupplementaryReference(FormValOpt2).has_value());
   EXPECT_FALSE(toSigned(FormValOpt2).has_value());
   EXPECT_TRUE(toAddress(FormValOpt2).has_value());
   EXPECT_FALSE(toSectionOffset(FormValOpt2).has_value());
   EXPECT_FALSE(toBlock(FormValOpt2).has_value());
   EXPECT_EQ(nullptr, toString(FormValOpt2, nullptr));
   EXPECT_EQ(InvalidU64, toUnsigned(FormValOpt2, InvalidU64));
-  EXPECT_EQ(InvalidU64, toReference(FormValOpt2, InvalidU64));
+  EXPECT_EQ(InvalidU64, toRelativeReference(FormValOpt2, InvalidU64));
+  EXPECT_EQ(InvalidU64, toDebugInfoReference(FormValOpt2, InvalidU64));
+  EXPECT_EQ(InvalidU64, toSignatureReference(FormValOpt2, InvalidU64));
+  EXPECT_EQ(InvalidU64, toSupplementaryReference(FormValOpt2, InvalidU64));
   EXPECT_EQ(Address, toAddress(FormValOpt2, InvalidU64));
   EXPECT_EQ(InvalidU64, toSectionOffset(FormValOpt2, InvalidU64));
   EXPECT_EQ(InvalidS64, toSigned(FormValOpt2, InvalidU64));
@@ -1700,36 +1712,98 @@ TEST(DWARFDebugInfo, TestDwarfToFunctions) {
 
   EXPECT_FALSE(toString(FormValOpt3).has_value());
   EXPECT_TRUE(toUnsigned(FormValOpt3).has_value());
-  EXPECT_FALSE(toReference(FormValOpt3).has_value());
+  EXPECT_FALSE(toRelativeReference(FormValOpt3).has_value());
+  EXPECT_FALSE(toDebugInfoReference(FormValOpt3).has_value());
+  EXPECT_FALSE(toSignatureReference(FormValOpt3).has_value());
+  EXPECT_FALSE(toSupplementaryReference(FormValOpt3).has_value());
   EXPECT_TRUE(toSigned(FormValOpt3).has_value());
   EXPECT_FALSE(toAddress(FormValOpt3).has_value());
   EXPECT_FALSE(toSectionOffset(FormValOpt3).has_value());
   EXPECT_FALSE(toBlock(FormValOpt3).has_value());
   EXPECT_EQ(nullptr, toString(FormValOpt3, nullptr));
   EXPECT_EQ(UData8, toUnsigned(FormValOpt3, InvalidU64));
-  EXPECT_EQ(InvalidU64, toReference(FormValOpt3, InvalidU64));
+  EXPECT_EQ(InvalidU64, toRelativeReference(FormValOpt3, InvalidU64));
+  EXPECT_EQ(InvalidU64, toDebugInfoReference(FormValOpt3, InvalidU64));
+  EXPECT_EQ(InvalidU64, toSignatureReference(FormValOpt3, InvalidU64));
+  EXPECT_EQ(InvalidU64, toSupplementaryReference(FormValOpt3, InvalidU64));
   EXPECT_EQ(InvalidU64, toAddress(FormValOpt3, InvalidU64));
   EXPECT_EQ(InvalidU64, toSectionOffset(FormValOpt3, InvalidU64));
   EXPECT_EQ((int64_t)UData8, toSigned(FormValOpt3, InvalidU64));
 
-  // Test successful and unsuccessful reference decoding.
+  // Test successful and unsuccessful ref_addr decoding.
   uint32_t RefData = 0x11223344U;
-  std::optional<DWARFFormValue> FormValOpt4 =
+  std::optional<DWARFFormValue> FormValOpt4Addr =
       DWARFFormValue::createFromUValue(DW_FORM_ref_addr, RefData);
 
-  EXPECT_FALSE(toString(FormValOpt4).has_value());
-  EXPECT_FALSE(toUnsigned(FormValOpt4).has_value());
-  EXPECT_TRUE(toReference(FormValOpt4).has_value());
-  EXPECT_FALSE(toSigned(FormValOpt4).has_value());
-  EXPECT_FALSE(toAddress(FormValOpt4).has_value());
-  EXPECT_FALSE(toSectionOffset(FormValOpt4).has_value());
-  EXPECT_FALSE(toBlock(FormValOpt4).has_value());
-  EXPECT_EQ(nullptr, toString(FormValOpt4, nullptr));
-  EXPECT_EQ(InvalidU64, toUnsigned(FormValOpt4, InvalidU64));
-  EXPECT_EQ(RefData, toReference(FormValOpt4, InvalidU64));
-  EXPECT_EQ(InvalidU64, toAddress(FormValOpt4, InvalidU64));
-  EXPECT_EQ(InvalidU64, toSectionOffset(FormValOpt4, InvalidU64));
-  EXPECT_EQ(InvalidS64, toSigned(FormValOpt4, InvalidU64));
+  EXPECT_FALSE(toString(FormValOpt4Addr).has_value());
+  EXPECT_FALSE(toUnsigned(FormValOpt4Addr).has_value());
+  EXPECT_FALSE(toRelativeReference(FormValOpt4Addr).has_value());
+  EXPECT_TRUE(toDebugInfoReference(FormValOpt4Addr).has_value());
+  EXPECT_FALSE(toSignatureReference(FormValOpt4Addr).has_value());
+  EXPECT_FALSE(toSupplementaryReference(FormValOpt4Addr).has_value());
+  EXPECT_FALSE(toSigned(FormValOpt4Addr).has_value());
+  EXPECT_FALSE(toAddress(FormValOpt4Addr).has_value());
+  EXPECT_FALSE(toSectionOffset(FormValOpt4Addr).has_value());
+  EXPECT_FALSE(toBlock(FormValOpt4Addr).has_value());
+  EXPECT_EQ(nullptr, toString(FormValOpt4Addr, nullptr));
+  EXPECT_EQ(InvalidU64, toUnsigned(FormValOpt4Addr, InvalidU64));
+  EXPECT_EQ(InvalidU64, toRelativeReference(FormValOpt4Addr, InvalidU64));
+  EXPECT_EQ(RefData, toDebugInfoReference(FormValOpt4Addr, InvalidU64));
+  EXPECT_EQ(InvalidU64, toSignatureReference(FormValOpt4Addr, InvalidU64));
+  EXPECT_EQ(InvalidU64, toSupplementaryReference(FormValOpt4Addr, InvalidU64));
+  EXPECT_EQ(InvalidU64, toAddress(FormValOpt4Addr, InvalidU64));
+  EXPECT_EQ(InvalidU64, toSectionOffset(FormValOpt4Addr, InvalidU64));
+  EXPECT_EQ(InvalidS64, toSigned(FormValOpt4Addr, InvalidU64));
+
+  // Test successful and unsuccessful ref_sig8 decoding.
+  std::optional<DWARFFormValue> FormValOpt4Sig =
+      DWARFFormValue::createFromUValue(DW_FORM_ref_sig8, RefData);
+
+  EXPECT_FALSE(toString(FormValOpt4Sig).has_value());
+  EXPECT_FALSE(toUnsigned(FormValOpt4Sig).has_value());
+  EXPECT_FALSE(toRelativeReference(FormValOpt4Sig).has_value());
+  EXPECT_FALSE(toDebugInfoReference(FormValOpt4Sig).has_value());
+  EXPECT_TRUE(toSignatureReference(FormValOpt4Sig).has_value());
+  EXPECT_FALSE(toSupplementaryReference(FormValOpt4Sig).has_value());
+  EXPECT_FALSE(toSigned(FormValOpt4Sig).has_value());
+  EXPECT_FALSE(toAddress(FormValOpt4Sig).has_value());
+  EXPECT_FALSE(toSectionOffset(FormValOpt4Sig).has_value());
+  EXPECT_FALSE(toBlock(FormValOpt4Sig).has_value());
+  EXPECT_EQ(nullptr, toString(FormValOpt4Sig, nullptr));
+  EXPECT_EQ(InvalidU64, toUnsigned(FormValOpt4Sig, InvalidU64));
+  EXPECT_EQ(InvalidU64, toRelativeReference(FormValOpt4Sig, InvalidU64));
+  EXPECT_EQ(InvalidU64, toDebugInfoReference(FormValOpt4Sig, InvalidU64));
+  EXPECT_EQ(RefData, toSignatureReference(FormValOpt4Sig, InvalidU64));
+  EXPECT_EQ(InvalidU64, toSupplementaryReference(FormValOpt4Sig, InvalidU64));
+  EXPECT_EQ(InvalidU64, toAddress(FormValOpt4Sig, InvalidU64));
+  EXPECT_EQ(InvalidU64, toSectionOffset(FormValOpt4Sig, InvalidU64));
+  EXPECT_EQ(InvalidS64, toSigned(FormValOpt4Sig, InvalidU64));
+
+  // Test successful and unsuccessful ref_alt decoding.
+  // Not testing relative reference forms here, as they require a valid
+  // DWARFUnit object.
+  std::optional<DWARFFormValue> FormValOpt4Alt =
+      DWARFFormValue::createFromUValue(DW_FORM_GNU_ref_alt, RefData);
+
+  EXPECT_FALSE(toString(FormValOpt4Alt).has_value());
+  EXPECT_FALSE(toUnsigned(FormValOpt4Alt).has_value());
+  EXPECT_FALSE(toRelativeReference(FormValOpt4Alt).has_value());
+  EXPECT_FALSE(toDebugInfoReference(FormValOpt4Alt).has_value());
+  EXPECT_FALSE(toSignatureReference(FormValOpt4Alt).has_value());
+  EXPECT_TRUE(toSupplementaryReference(FormValOpt4Alt).has_value());
+  EXPECT_FALSE(toSigned(FormValOpt4Alt).has_value());
+  EXPECT_FALSE(toAddress(FormValOpt4Alt).has_value());
+  EXPECT_FALSE(toSectionOffset(FormValOpt4Alt).has_value());
+  EXPECT_FALSE(toBlock(FormValOpt4Alt).has_value());
+  EXPECT_EQ(nullptr, toString(FormValOpt4Alt, nullptr));
+  EXPECT_EQ(InvalidU64, toUnsigned(FormValOpt4Alt, InvalidU64));
+  EXPECT_EQ(InvalidU64, toRelativeReference(FormValOpt4Alt, InvalidU64));
+  EXPECT_EQ(InvalidU64, toDebugInfoReference(FormValOpt4Alt, InvalidU64));
+  EXPECT_EQ(InvalidU64, toSignatureReference(FormValOpt4Alt, InvalidU64));
+  EXPECT_EQ(RefData, toSupplementaryReference(FormValOpt4Alt, InvalidU64));
+  EXPECT_EQ(InvalidU64, toAddress(FormValOpt4Alt, InvalidU64));
+  EXPECT_EQ(InvalidU64, toSectionOffset(FormValOpt4Alt, InvalidU64));
+  EXPECT_EQ(InvalidS64, toSigned(FormValOpt4Alt, InvalidU64));
 
   // Test successful and unsuccessful signed constant decoding.
   int64_t SData8 = 0x1020304050607080ULL;
@@ -1738,14 +1812,20 @@ TEST(DWARFDebugInfo, TestDwarfToFunctions) {
 
   EXPECT_FALSE(toString(FormValOpt5).has_value());
   EXPECT_TRUE(toUnsigned(FormValOpt5).has_value());
-  EXPECT_FALSE(toReference(FormValOpt5).has_value());
+  EXPECT_FALSE(toRelativeReference(FormValOpt5).has_value());
+  EXPECT_FALSE(toDebugInfoReference(FormValOpt5).has_value());
+  EXPECT_FALSE(toSignatureReference(FormValOpt5).has_value());
+  EXPECT_FALSE(toSupplementaryReference(FormValOpt5).has_value());
   EXPECT_TRUE(toSigned(FormValOpt5).has_value());
   EXPECT_FALSE(toAddress(FormValOpt5).has_value());
   EXPECT_FALSE(toSectionOffset(FormValOpt5).has_value());
   EXPECT_FALSE(toBlock(FormValOpt5).has_value());
   EXPECT_EQ(nullptr, toString(FormValOpt5, nullptr));
   EXPECT_EQ((uint64_t)SData8, toUnsigned(FormValOpt5, InvalidU64));
-  EXPECT_EQ(InvalidU64, toReference(FormValOpt5, InvalidU64));
+  EXPECT_EQ(InvalidU64, toRelativeReference(FormValOpt5, InvalidU64));
+  EXPECT_EQ(InvalidU64, toDebugInfoReference(FormValOpt5, InvalidU64));
+  EXPECT_EQ(InvalidU64, toSignatureReference(FormValOpt5, InvalidU64));
+  EXPECT_EQ(InvalidU64, toSupplementaryReference(FormValOpt5, InvalidU64));
   EXPECT_EQ(InvalidU64, toAddress(FormValOpt5, InvalidU64));
   EXPECT_EQ(InvalidU64, toSectionOffset(FormValOpt5, InvalidU64));
   EXPECT_EQ(SData8, toSigned(FormValOpt5, InvalidU64));
@@ -1758,7 +1838,10 @@ TEST(DWARFDebugInfo, TestDwarfToFunctions) {
 
   EXPECT_FALSE(toString(FormValOpt6).has_value());
   EXPECT_FALSE(toUnsigned(FormValOpt6).has_value());
-  EXPECT_FALSE(toReference(FormValOpt6).has_value());
+  EXPECT_FALSE(toRelativeReference(FormValOpt6).has_value());
+  EXPECT_FALSE(toDebugInfoReference(FormValOpt6).has_value());
+  EXPECT_FALSE(toSignatureReference(FormValOpt6).has_value());
+  EXPECT_FALSE(toSupplementaryReference(FormValOpt6).has_value());
   EXPECT_FALSE(toSigned(FormValOpt6).has_value());
   EXPECT_FALSE(toAddress(FormValOpt6).has_value());
   EXPECT_FALSE(toSectionOffset(FormValOpt6).has_value());
@@ -1767,7 +1850,10 @@ TEST(DWARFDebugInfo, TestDwarfToFunctions) {
   EXPECT_EQ(*BlockOpt, Array);
   EXPECT_EQ(nullptr, toString(FormValOpt6, nullptr));
   EXPECT_EQ(InvalidU64, toUnsigned(FormValOpt6, InvalidU64));
-  EXPECT_EQ(InvalidU64, toReference(FormValOpt6, InvalidU64));
+  EXPECT_EQ(InvalidU64, toRelativeReference(FormValOpt6, InvalidU64));
+  EXPECT_EQ(InvalidU64, toDebugInfoReference(FormValOpt6, InvalidU64));
+  EXPECT_EQ(InvalidU64, toSignatureReference(FormValOpt6, InvalidU64));
+  EXPECT_EQ(InvalidU64, toSupplementaryReference(FormValOpt6, InvalidU64));
   EXPECT_EQ(InvalidU64, toAddress(FormValOpt6, InvalidU64));
   EXPECT_EQ(InvalidU64, toSectionOffset(FormValOpt6, InvalidU64));
   EXPECT_EQ(InvalidS64, toSigned(FormValOpt6, InvalidU64));


### PR DESCRIPTION
The result of the function cannot be correctly interpreted without knowing the precise form type (a type signature needs to be looked up very differently from a supplementary debug info reference). The function sort of worked because the two reference types (unit-relative and section-relative) that can be handled uniformly are also the most common types of references, but this setup made it easy to write code which does not support other kinds of reference (and if one tried to support them, the result didn't look pretty --
https://github.com/llvm/llvm-project/pull/97423/files#r1676217081).

The split is based on the reference type classification from DWARFv5 (Section 7.5.5 Classes and Forms), and it should enable uniform (if slightly more verbose) hadling. Note that this only affects users which want more control of how (or if) the references are resolved. Users which just want to access the referenced DIE can use the higher level API (DWARFDie::GetAttributeValueAsReferencedDie) which returns (or will return after #97423 is merged) the correct die for all reference types (except for supplementary references, which we don't support right now).