### PR TITLE
[mlir] Remove bytecode reader & writer header from interface.

### DIFF
--- a/mlir/include/mlir/Bytecode/BytecodeOpInterface.h
+++ b/mlir/include/mlir/Bytecode/BytecodeOpInterface.h
@@ -15,8 +15,6 @@
 #define MLIR_BYTECODE_BYTECODEOPINTERFACE_H
 
 #include "mlir/Bytecode/BytecodeImplementation.h"
-#include "mlir/Bytecode/BytecodeReader.h"
-#include "mlir/Bytecode/BytecodeWriter.h"
 #include "mlir/IR/OpDefinition.h"
 
 /// Include the generated interface declarations.

--- a/mlir/include/mlir/Bytecode/BytecodeReaderConfig.h
+++ b/mlir/include/mlir/Bytecode/BytecodeReaderConfig.h
@@ -1,4 +1,4 @@
-//===- BytecodeReader.h - MLIR Bytecode Reader ------------------*- C++ -*-===//
+//===- BytecodeReaderConfig.h - MLIR Bytecode Reader Config -----*- C++ -*-===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 //
-// This header defines interfaces to read MLIR bytecode files/streams.
+// This header config for reading MLIR bytecode files/streams.
 //
 //===----------------------------------------------------------------------===//
 

--- a/mlir/lib/Bytecode/Writer/IRNumbering.cpp
+++ b/mlir/lib/Bytecode/Writer/IRNumbering.cpp
@@ -9,6 +9,7 @@
 #include "IRNumbering.h"
 #include "mlir/Bytecode/BytecodeImplementation.h"
 #include "mlir/Bytecode/BytecodeOpInterface.h"
+#include "mlir/Bytecode/BytecodeWriter.h"
 #include "mlir/Bytecode/Encoding.h"
 #include "mlir/IR/AsmState.h"
 #include "mlir/IR/BuiltinTypes.h"

--- a/mlir/lib/Dialect/OpenMP/IR/OpenMPDialect.cpp
+++ b/mlir/lib/Dialect/OpenMP/IR/OpenMPDialect.cpp
@@ -33,6 +33,7 @@
 #include <cstddef>
 #include <iterator>
 #include <optional>
+#include <variant>
 
 #include "mlir/Dialect/OpenMP/OpenMPOpsDialect.cpp.inc"
 #include "mlir/Dialect/OpenMP/OpenMPOpsEnums.cpp.inc"

--- a/mlir/lib/Target/LLVMIR/DebugImporter.h
+++ b/mlir/lib/Target/LLVMIR/DebugImporter.h
@@ -18,6 +18,7 @@
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/MLIRContext.h"
 #include "mlir/Support/CyclicReplacerCache.h"
+#include "llvm/ADT/MapVector.h"
 #include "llvm/IR/DebugInfoMetadata.h"
 
 namespace mlir {


### PR DESCRIPTION
Flagged some additional headers missing in process.

Inspired by #98676