### PR TITLE
[libc][NFC] Fix printed test time in 32-bit systems

### DIFF
--- a/libc/test/UnitTest/LibcTest.cpp
+++ b/libc/test/UnitTest/LibcTest.cpp
@@ -159,13 +159,13 @@ int Test::runTests(const TestOptions &Options) {
     }
 
     tlog << green << "[ RUN      ] " << reset << TestName << '\n';
-    [[maybe_unused]] const auto start_time = clock();
+    [[maybe_unused]] const uint64_t start_time = clock();
     RunContext Ctx;
     T->SetUp();
     T->setContext(&Ctx);
     T->Run();
     T->TearDown();
-    [[maybe_unused]] const auto end_time = clock();
+    [[maybe_unused]] const uint64_t end_time = clock();
     switch (Ctx.status()) {
     case RunContext::RunResult::Fail:
       tlog << red << "[  FAILED  ] " << reset << TestName << '\n';


### PR DESCRIPTION
clock() returns a clock_t, which is a long and might overflow in 32-bit systems when the test takes a long time to run. Changing it to uint64_t fixes this issue. Before:

[ RUN      ] LlvmLibcHashTest.Avalanche
[       OK ] LlvmLibcHashTest.Avalanche (18446744073709551138 ms)

After this patch:

[ RUN      ] LlvmLibcHashTest.Avalanche
[       OK ] LlvmLibcHashTest.Avalanche (4154 ms)