### PR TITLE
[nsan] Swap alignas and visibility order (NFC)

### DIFF
--- a/compiler-rt/lib/nsan/nsan.cpp
+++ b/compiler-rt/lib/nsan/nsan.cpp
@@ -390,24 +390,23 @@ __nsan_dump_shadow_mem(const u8 *addr, size_t size_bytes, size_t bytes_per_line,
   }
 }
 
-SANITIZER_INTERFACE_ATTRIBUTE
-ALIGNED(16) thread_local uptr __nsan_shadow_ret_tag = 0;
+alignas(16) SANITIZER_INTERFACE_ATTRIBUTE
+    thread_local uptr __nsan_shadow_ret_tag = 0;
 
-SANITIZER_INTERFACE_ATTRIBUTE
-ALIGNED(16)
-thread_local char __nsan_shadow_ret_ptr[kMaxVectorWidth * sizeof(__float128)];
+alignas(16) SANITIZER_INTERFACE_ATTRIBUTE
+    thread_local char __nsan_shadow_ret_ptr[kMaxVectorWidth *
+                                            sizeof(__float128)];
 
-SANITIZER_INTERFACE_ATTRIBUTE
-ALIGNED(16) thread_local uptr __nsan_shadow_args_tag = 0;
+alignas(16) SANITIZER_INTERFACE_ATTRIBUTE
+    thread_local uptr __nsan_shadow_args_tag = 0;
 
 // Maximum number of args. This should be enough for anyone (tm). An alternate
 // scheme is to have the generated code create an alloca and make
 // __nsan_shadow_args_ptr point ot the alloca.
 constexpr const int kMaxNumArgs = 128;
-SANITIZER_INTERFACE_ATTRIBUTE
-ALIGNED(16)
-thread_local char
-    __nsan_shadow_args_ptr[kMaxVectorWidth * kMaxNumArgs * sizeof(__float128)];
+alignas(16) SANITIZER_INTERFACE_ATTRIBUTE
+    thread_local char __nsan_shadow_args_ptr[kMaxVectorWidth * kMaxNumArgs *
+                                             sizeof(__float128)];
 
 enum ContinuationType { // Keep in sync with instrumentation pass.
   kContinueWithShadow = 0,

--- a/compiler-rt/lib/nsan/nsan.cpp
+++ b/compiler-rt/lib/nsan/nsan.cpp
@@ -391,23 +391,23 @@ __nsan_dump_shadow_mem(const u8 *addr, size_t size_bytes, size_t bytes_per_line,
 }
 
 SANITIZER_INTERFACE_ATTRIBUTE
-alignas(16) thread_local uptr __nsan_shadow_ret_tag = 0;
+ALIGNED(16) thread_local uptr __nsan_shadow_ret_tag = 0;
 
 SANITIZER_INTERFACE_ATTRIBUTE
-alignas(16) thread_local char __nsan_shadow_ret_ptr[kMaxVectorWidth *
-                                                    sizeof(__float128)];
+ALIGNED(16)
+thread_local char __nsan_shadow_ret_ptr[kMaxVectorWidth * sizeof(__float128)];
 
 SANITIZER_INTERFACE_ATTRIBUTE
-alignas(16) thread_local uptr __nsan_shadow_args_tag = 0;
+ALIGNED(16) thread_local uptr __nsan_shadow_args_tag = 0;
 
 // Maximum number of args. This should be enough for anyone (tm). An alternate
 // scheme is to have the generated code create an alloca and make
 // __nsan_shadow_args_ptr point ot the alloca.
 constexpr const int kMaxNumArgs = 128;
 SANITIZER_INTERFACE_ATTRIBUTE
-alignas(
-    16) thread_local char __nsan_shadow_args_ptr[kMaxVectorWidth * kMaxNumArgs *
-                                                 sizeof(__float128)];
+ALIGNED(16)
+thread_local char
+    __nsan_shadow_args_ptr[kMaxVectorWidth * kMaxNumArgs * sizeof(__float128)];
 
 enum ContinuationType { // Keep in sync with instrumentation pass.
   kContinueWithShadow = 0,


### PR DESCRIPTION
Use `alignas(16) SANITIZER_INTERFACE_ATTRIBUTE` instead of `SANITIZER_INTERFACE_ATTRIBUTE alignas(16)`, as the former is not supported prior to clang 16. See https://clang.godbolt.org/z/Wj1193xWK.

This was broken by https://github.com/llvm/llvm-project/pull/96142 as part of other style changes.