### PR TITLE
Provide access to raw bits in PackedVector. NFC.

### DIFF
--- a/llvm/include/llvm/ADT/PackedVector.h
+++ b/llvm/include/llvm/ADT/PackedVector.h
@@ -142,7 +142,7 @@ public:
     return *this;
   }
 
-  operator BitVectorTy() const { return Bits; }
+  const BitVectorTy &raw_bits() const { return Bits; }
 };
 
 // Leave BitNum=0 undefined.

--- a/llvm/include/llvm/ADT/PackedVector.h
+++ b/llvm/include/llvm/ADT/PackedVector.h
@@ -141,6 +141,8 @@ public:
     Bits |= RHS.Bits;
     return *this;
   }
+
+  operator BitVectorTy() const { return Bits; }
 };
 
 // Leave BitNum=0 undefined.


### PR DESCRIPTION
Needed for future patch to access vector as an integer mask.