### PR TITLE
Adding warning for Master as it is deprecated in 5.2

### DIFF
--- a/flang/lib/Semantics/resolve-directives.cpp
+++ b/flang/lib/Semantics/resolve-directives.cpp
@@ -2760,10 +2760,20 @@ void OmpAttributeVisitor::AddOmpRequiresToScope(Scope &scope,
 
 void OmpAttributeVisitor::IssueNonConformanceWarning(
     llvm::omp::Directive D, parser::CharBlock source) {
+  std::string warnStr = "";
+  std::string dirName = llvm::omp::getOpenMPDirectiveName(D).str();
+  switch (D) {
+  case llvm::omp::OMPD_master:
+    warnStr = "OpenMP directive " + dirName +
+        " has been deprecated, please use masked instead.";
+    break;
+  case llvm::omp::OMPD_target_loop:
+  default:
+    warnStr = "Usage of directive " + dirName +
+        "is non-confirming to OpenMP standard.";
+  }
   if (context_.ShouldWarn(common::UsageWarning::OpenMPUsage)) {
-    context_.Say(source,
-        "Usage of directive %s is non-confirming to OpenMP standard"_warn_en_US,
-        llvm::omp::getOpenMPDirectiveName(D).str());
+    context_.Say(source, "%s"_warn_en_US, warnStr);
   }
 }
 } // namespace Fortran::semantics

--- a/flang/lib/Semantics/resolve-directives.cpp
+++ b/flang/lib/Semantics/resolve-directives.cpp
@@ -2764,13 +2764,12 @@ void OmpAttributeVisitor::IssueNonConformanceWarning(
   std::string dirName = llvm::omp::getOpenMPDirectiveName(D).str();
   switch (D) {
   case llvm::omp::OMPD_master:
-    warnStr = "OpenMP directive " + dirName +
-        " has been deprecated, please use masked instead.";
+    warnStr = "OpenMP directive '" + dirName +
+        "' has been deprecated, please use 'masked' instead.";
     break;
   case llvm::omp::OMPD_target_loop:
   default:
-    warnStr = "Usage of directive " + dirName +
-        "is non-confirming to OpenMP standard.";
+    warnStr = "OpenMP directive '" + dirName + "' has been deprecated.";
   }
   if (context_.ShouldWarn(common::UsageWarning::OpenMPUsage)) {
     context_.Say(source, "%s"_warn_en_US, warnStr);

--- a/flang/lib/Semantics/resolve-directives.cpp
+++ b/flang/lib/Semantics/resolve-directives.cpp
@@ -734,6 +734,8 @@ private:
 
   void AddOmpRequiresToScope(Scope &, WithOmpDeclarative::RequiresFlags,
       std::optional<common::OmpAtomicDefaultMemOrderType>);
+  void IssueNonConformanceWarning(
+      llvm::omp::Directive D, parser::CharBlock source);
 };
 
 template <typename T>
@@ -1524,6 +1526,8 @@ bool OmpAttributeVisitor::Pre(const parser::OpenMPBlockConstruct &x) {
     // TODO others
     break;
   }
+  if (beginDir.v == llvm::omp::Directive::OMPD_master)
+    IssueNonConformanceWarning(beginDir.v, beginDir.source);
   ClearDataSharingAttributeObjects();
   ClearPrivateDataSharingAttributeObjects();
   ClearAllocateNames();
@@ -1634,11 +1638,7 @@ bool OmpAttributeVisitor::Pre(const parser::OpenMPLoopConstruct &x) {
     break;
   }
   if (beginDir.v == llvm::omp::Directive::OMPD_target_loop)
-    if (context_.ShouldWarn(common::UsageWarning::OpenMPUsage)) {
-      context_.Say(beginDir.source,
-          "Usage of directive %s is non-confirming to OpenMP standard"_warn_en_US,
-          llvm::omp::getOpenMPDirectiveName(beginDir.v).str());
-    }
+    IssueNonConformanceWarning(beginDir.v, beginDir.source);
   ClearDataSharingAttributeObjects();
   SetContextAssociatedLoopLevel(GetAssociatedLoopLevelFromClauses(clauseList));
 
@@ -2758,4 +2758,12 @@ void OmpAttributeVisitor::AddOmpRequiresToScope(Scope &scope,
   } while (!scopeIter->IsGlobal());
 }
 
+void OmpAttributeVisitor::IssueNonConformanceWarning(
+    llvm::omp::Directive D, parser::CharBlock source) {
+  if (context_.ShouldWarn(common::UsageWarning::OpenMPUsage)) {
+    context_.Say(source,
+        "Usage of directive %s is non-confirming to OpenMP standard"_warn_en_US,
+        llvm::omp::getOpenMPDirectiveName(D).str());
+  }
+}
 } // namespace Fortran::semantics

--- a/flang/test/Semantics/OpenMP/clause-validity01.f90
+++ b/flang/test/Semantics/OpenMP/clause-validity01.f90
@@ -469,14 +469,14 @@ use omp_lib
 ! 2.13.1 master
 
   !$omp parallel
-  !WARNING: Usage of directive master is non-confirming to OpenMP standard
+  !WARNING: OpenMP directive master has been deprecated, please use masked instead.
   !$omp master
   a=3.14
   !$omp end master
   !$omp end parallel
 
   !$omp parallel
-  !WARNING: Usage of directive master is non-confirming to OpenMP standard
+  !WARNING: OpenMP directive master has been deprecated, please use masked instead.
   !ERROR: NUM_THREADS clause is not allowed on the MASTER directive
   !$omp master num_threads(4)
   a=3.14

--- a/flang/test/Semantics/OpenMP/clause-validity01.f90
+++ b/flang/test/Semantics/OpenMP/clause-validity01.f90
@@ -469,14 +469,14 @@ use omp_lib
 ! 2.13.1 master
 
   !$omp parallel
-  !WARNING: OpenMP directive master has been deprecated, please use masked instead.
+  !WARNING: OpenMP directive 'master' has been deprecated, please use 'masked' instead.
   !$omp master
   a=3.14
   !$omp end master
   !$omp end parallel
 
   !$omp parallel
-  !WARNING: OpenMP directive master has been deprecated, please use masked instead.
+  !WARNING: OpenMP directive 'master' has been deprecated, please use 'masked' instead.
   !ERROR: NUM_THREADS clause is not allowed on the MASTER directive
   !$omp master num_threads(4)
   a=3.14

--- a/flang/test/Semantics/OpenMP/clause-validity01.f90
+++ b/flang/test/Semantics/OpenMP/clause-validity01.f90
@@ -469,12 +469,14 @@ use omp_lib
 ! 2.13.1 master
 
   !$omp parallel
+  !WARNING: Usage of directive master is non-confirming to OpenMP standard
   !$omp master
   a=3.14
   !$omp end master
   !$omp end parallel
 
   !$omp parallel
+  !WARNING: Usage of directive master is non-confirming to OpenMP standard
   !ERROR: NUM_THREADS clause is not allowed on the MASTER directive
   !$omp master num_threads(4)
   a=3.14

--- a/flang/test/Semantics/OpenMP/flush02.f90
+++ b/flang/test/Semantics/OpenMP/flush02.f90
@@ -80,7 +80,7 @@ use omp_lib
 
   !$omp parallel num_threads(4)
     array = (/1, 2, 3, 4, 5, 6, 7, 8, 9, 10/)
-    !WARNING: Usage of directive master is non-confirming to OpenMP standard
+    !WARNING: OpenMP directive master has been deprecated, please use masked instead.
     !$omp master
       !$omp flush (array)
     !$omp end master

--- a/flang/test/Semantics/OpenMP/flush02.f90
+++ b/flang/test/Semantics/OpenMP/flush02.f90
@@ -80,7 +80,7 @@ use omp_lib
 
   !$omp parallel num_threads(4)
     array = (/1, 2, 3, 4, 5, 6, 7, 8, 9, 10/)
-    !WARNING: OpenMP directive master has been deprecated, please use masked instead.
+    !WARNING: OpenMP directive 'master' has been deprecated, please use 'masked' instead.
     !$omp master
       !$omp flush (array)
     !$omp end master

--- a/flang/test/Semantics/OpenMP/flush02.f90
+++ b/flang/test/Semantics/OpenMP/flush02.f90
@@ -80,6 +80,7 @@ use omp_lib
 
   !$omp parallel num_threads(4)
     array = (/1, 2, 3, 4, 5, 6, 7, 8, 9, 10/)
+    !WARNING: Usage of directive master is non-confirming to OpenMP standard
     !$omp master
       !$omp flush (array)
     !$omp end master

--- a/flang/test/Semantics/OpenMP/nested-barrier.f90
+++ b/flang/test/Semantics/OpenMP/nested-barrier.f90
@@ -75,7 +75,7 @@ program omp_nest_barrier
   end do
   !$omp end critical
 
-  !WARNING: Usage of directive master is non-confirming to OpenMP standard
+  !WARNING: OpenMP directive master has been deprecated, please use masked instead.
   !$omp master
   do i = 1, 10
     k = k + 1
@@ -108,7 +108,7 @@ program omp_nest_barrier
   end do
   !$omp end ordered
 
-  !WARNING: Usage of directive master is non-confirming to OpenMP standard
+  !WARNING: OpenMP directive master has been deprecated, please use masked instead.
   !$omp master
   do i = 1, 10
     !ERROR: `DISTRIBUTE` region has to be strictly nested inside `TEAMS` region.

--- a/flang/test/Semantics/OpenMP/nested-barrier.f90
+++ b/flang/test/Semantics/OpenMP/nested-barrier.f90
@@ -75,7 +75,7 @@ program omp_nest_barrier
   end do
   !$omp end critical
 
-  !WARNING: OpenMP directive master has been deprecated, please use masked instead.
+  !WARNING: OpenMP directive 'master' has been deprecated, please use 'masked' instead.
   !$omp master
   do i = 1, 10
     k = k + 1
@@ -108,7 +108,7 @@ program omp_nest_barrier
   end do
   !$omp end ordered
 
-  !WARNING: OpenMP directive master has been deprecated, please use masked instead.
+  !WARNING: OpenMP directive 'master' has been deprecated, please use 'masked' instead.
   !$omp master
   do i = 1, 10
     !ERROR: `DISTRIBUTE` region has to be strictly nested inside `TEAMS` region.

--- a/flang/test/Semantics/OpenMP/nested-barrier.f90
+++ b/flang/test/Semantics/OpenMP/nested-barrier.f90
@@ -75,6 +75,7 @@ program omp_nest_barrier
   end do
   !$omp end critical
 
+  !WARNING: Usage of directive master is non-confirming to OpenMP standard
   !$omp master
   do i = 1, 10
     k = k + 1
@@ -107,6 +108,7 @@ program omp_nest_barrier
   end do
   !$omp end ordered
 
+  !WARNING: Usage of directive master is non-confirming to OpenMP standard
   !$omp master
   do i = 1, 10
     !ERROR: `DISTRIBUTE` region has to be strictly nested inside `TEAMS` region.

--- a/flang/test/Semantics/OpenMP/nested-master.f90
+++ b/flang/test/Semantics/OpenMP/nested-master.f90
@@ -9,7 +9,7 @@ program omp_nest_master
   !$omp do
   do i = 1, 10
     k = k + 1
-    !WARNING: Usage of directive master is non-confirming to OpenMP standard
+    !WARNING: OpenMP directive master has been deprecated, please use masked instead.
     !ERROR: `MASTER` region may not be closely nested inside of `WORKSHARING`, `LOOP`, `TASK`, `TASKLOOP`, or `ATOMIC` region.
     !$omp master
     j = j -1
@@ -17,7 +17,7 @@ program omp_nest_master
   end do
 
   !$omp sections 
-  !WARNING: Usage of directive master is non-confirming to OpenMP standard
+  !WARNING: OpenMP directive master has been deprecated, please use masked instead.
   !ERROR: `MASTER` region may not be closely nested inside of `WORKSHARING`, `LOOP`, `TASK`, `TASKLOOP`, or `ATOMIC` region.
     !$omp master
     do i = 1, 10
@@ -27,7 +27,7 @@ program omp_nest_master
   !$omp end sections
 
   !$omp single 
-  !WARNING: Usage of directive master is non-confirming to OpenMP standard
+  !WARNING: OpenMP directive master has been deprecated, please use masked instead.
   !ERROR: `MASTER` region may not be closely nested inside of `WORKSHARING`, `LOOP`, `TASK`, `TASKLOOP`, or `ATOMIC` region.
     !$omp master
     do i = 1, 10
@@ -41,7 +41,7 @@ program omp_nest_master
   !$omp task
   do i = 1, 10
     k = k + 1
-    !WARNING: Usage of directive master is non-confirming to OpenMP standard
+    !WARNING: OpenMP directive master has been deprecated, please use masked instead.
     !ERROR: `MASTER` region may not be closely nested inside of `WORKSHARING`, `LOOP`, `TASK`, `TASKLOOP`, or `ATOMIC` region.
     !$omp master
     j = j -1
@@ -52,7 +52,7 @@ program omp_nest_master
   !$omp taskloop
   do i = 1, 10
     k = k + 1
-    !WARNING: Usage of directive master is non-confirming to OpenMP standard
+    !WARNING: OpenMP directive master has been deprecated, please use masked instead.
     !ERROR: `MASTER` region may not be closely nested inside of `WORKSHARING`, `LOOP`, `TASK`, `TASKLOOP`, or `ATOMIC` region.
     !$omp master
     j = j -1
@@ -63,7 +63,7 @@ program omp_nest_master
   !$omp target parallel do simd
   do i = 1, 10
     k = k + 1
-    !WARNING: Usage of directive master is non-confirming to OpenMP standard
+    !WARNING: OpenMP directive master has been deprecated, please use masked instead.
     !ERROR: The only OpenMP constructs that can be encountered during execution of a 'SIMD' region are the `ATOMIC` construct, the `LOOP` construct, the `SIMD` construct and the `ORDERED` construct with the `SIMD` clause.
     !ERROR: `MASTER` region may not be closely nested inside of `WORKSHARING`, `LOOP`, `TASK`, `TASKLOOP`, or `ATOMIC` region.
     !$omp master
@@ -75,7 +75,7 @@ program omp_nest_master
   !$omp critical
   do i = 1, 10
     k = k + 1
-    !WARNING: Usage of directive master is non-confirming to OpenMP standard
+    !WARNING: OpenMP directive master has been deprecated, please use masked instead.
     !$omp master
     j = j -1
     !$omp end master
@@ -85,7 +85,7 @@ program omp_nest_master
   !$omp ordered
   do i = 1, 10
     k = k + 1
-    !WARNING: Usage of directive master is non-confirming to OpenMP standard
+    !WARNING: OpenMP directive master has been deprecated, please use masked instead.
     !$omp master
     j = j -1
     !$omp end master
@@ -99,7 +99,7 @@ program omp_nest_master
     !$omp distribute
     do k =1, 10
       print *, "hello"
-      !WARNING: Usage of directive master is non-confirming to OpenMP standard
+      !WARNING: OpenMP directive master has been deprecated, please use masked instead.
       !$omp master
       j = j -1
       !$omp end master
@@ -116,7 +116,7 @@ program omp_nest_master
     !$omp distribute
     do k =1, 10
       print *, "hello"
-      !WARNING: Usage of directive master is non-confirming to OpenMP standard
+      !WARNING: OpenMP directive master has been deprecated, please use masked instead.
       !$omp master
       j = j -1
       !$omp end master
@@ -133,7 +133,7 @@ program omp_nest_master
     !$omp distribute
     do k =1, 10
       print *, "hello"
-      !WARNING: Usage of directive master is non-confirming to OpenMP standard
+      !WARNING: OpenMP directive master has been deprecated, please use masked instead.
       !ERROR: `MASTER` region may not be closely nested inside of `WORKSHARING`, `LOOP`, `TASK`, `TASKLOOP`, or `ATOMIC` region.
       !$omp master
       j = j -1
@@ -151,7 +151,7 @@ program omp_nest_master
     !$omp distribute
     do k =1, 10
       print *, "hello"
-      !WARNING: Usage of directive master is non-confirming to OpenMP standard
+      !WARNING: OpenMP directive master has been deprecated, please use masked instead.
       !ERROR: `MASTER` region may not be closely nested inside of `WORKSHARING`, `LOOP`, `TASK`, `TASKLOOP`, or `ATOMIC` region.
       !$omp master
       j = j -1

--- a/flang/test/Semantics/OpenMP/nested-master.f90
+++ b/flang/test/Semantics/OpenMP/nested-master.f90
@@ -9,7 +9,7 @@ program omp_nest_master
   !$omp do
   do i = 1, 10
     k = k + 1
-    !WARNING: OpenMP directive master has been deprecated, please use masked instead.
+    !WARNING: OpenMP directive 'master' has been deprecated, please use 'masked' instead.
     !ERROR: `MASTER` region may not be closely nested inside of `WORKSHARING`, `LOOP`, `TASK`, `TASKLOOP`, or `ATOMIC` region.
     !$omp master
     j = j -1
@@ -17,7 +17,7 @@ program omp_nest_master
   end do
 
   !$omp sections 
-  !WARNING: OpenMP directive master has been deprecated, please use masked instead.
+  !WARNING: OpenMP directive 'master' has been deprecated, please use 'masked' instead.
   !ERROR: `MASTER` region may not be closely nested inside of `WORKSHARING`, `LOOP`, `TASK`, `TASKLOOP`, or `ATOMIC` region.
     !$omp master
     do i = 1, 10
@@ -27,7 +27,7 @@ program omp_nest_master
   !$omp end sections
 
   !$omp single 
-  !WARNING: OpenMP directive master has been deprecated, please use masked instead.
+  !WARNING: OpenMP directive 'master' has been deprecated, please use 'masked' instead.
   !ERROR: `MASTER` region may not be closely nested inside of `WORKSHARING`, `LOOP`, `TASK`, `TASKLOOP`, or `ATOMIC` region.
     !$omp master
     do i = 1, 10
@@ -41,7 +41,7 @@ program omp_nest_master
   !$omp task
   do i = 1, 10
     k = k + 1
-    !WARNING: OpenMP directive master has been deprecated, please use masked instead.
+    !WARNING: OpenMP directive 'master' has been deprecated, please use 'masked' instead.
     !ERROR: `MASTER` region may not be closely nested inside of `WORKSHARING`, `LOOP`, `TASK`, `TASKLOOP`, or `ATOMIC` region.
     !$omp master
     j = j -1
@@ -52,7 +52,7 @@ program omp_nest_master
   !$omp taskloop
   do i = 1, 10
     k = k + 1
-    !WARNING: OpenMP directive master has been deprecated, please use masked instead.
+    !WARNING: OpenMP directive 'master' has been deprecated, please use 'masked' instead.
     !ERROR: `MASTER` region may not be closely nested inside of `WORKSHARING`, `LOOP`, `TASK`, `TASKLOOP`, or `ATOMIC` region.
     !$omp master
     j = j -1
@@ -63,7 +63,7 @@ program omp_nest_master
   !$omp target parallel do simd
   do i = 1, 10
     k = k + 1
-    !WARNING: OpenMP directive master has been deprecated, please use masked instead.
+    !WARNING: OpenMP directive 'master' has been deprecated, please use 'masked' instead.
     !ERROR: The only OpenMP constructs that can be encountered during execution of a 'SIMD' region are the `ATOMIC` construct, the `LOOP` construct, the `SIMD` construct and the `ORDERED` construct with the `SIMD` clause.
     !ERROR: `MASTER` region may not be closely nested inside of `WORKSHARING`, `LOOP`, `TASK`, `TASKLOOP`, or `ATOMIC` region.
     !$omp master
@@ -75,7 +75,7 @@ program omp_nest_master
   !$omp critical
   do i = 1, 10
     k = k + 1
-    !WARNING: OpenMP directive master has been deprecated, please use masked instead.
+    !WARNING: OpenMP directive 'master' has been deprecated, please use 'masked' instead.
     !$omp master
     j = j -1
     !$omp end master
@@ -85,7 +85,7 @@ program omp_nest_master
   !$omp ordered
   do i = 1, 10
     k = k + 1
-    !WARNING: OpenMP directive master has been deprecated, please use masked instead.
+    !WARNING: OpenMP directive 'master' has been deprecated, please use 'masked' instead.
     !$omp master
     j = j -1
     !$omp end master
@@ -99,7 +99,7 @@ program omp_nest_master
     !$omp distribute
     do k =1, 10
       print *, "hello"
-      !WARNING: OpenMP directive master has been deprecated, please use masked instead.
+      !WARNING: OpenMP directive 'master' has been deprecated, please use 'masked' instead.
       !$omp master
       j = j -1
       !$omp end master
@@ -116,7 +116,7 @@ program omp_nest_master
     !$omp distribute
     do k =1, 10
       print *, "hello"
-      !WARNING: OpenMP directive master has been deprecated, please use masked instead.
+      !WARNING: OpenMP directive 'master' has been deprecated, please use 'masked' instead.
       !$omp master
       j = j -1
       !$omp end master
@@ -133,7 +133,7 @@ program omp_nest_master
     !$omp distribute
     do k =1, 10
       print *, "hello"
-      !WARNING: OpenMP directive master has been deprecated, please use masked instead.
+      !WARNING: OpenMP directive 'master' has been deprecated, please use 'masked' instead.
       !ERROR: `MASTER` region may not be closely nested inside of `WORKSHARING`, `LOOP`, `TASK`, `TASKLOOP`, or `ATOMIC` region.
       !$omp master
       j = j -1
@@ -151,7 +151,7 @@ program omp_nest_master
     !$omp distribute
     do k =1, 10
       print *, "hello"
-      !WARNING: OpenMP directive master has been deprecated, please use masked instead.
+      !WARNING: OpenMP directive 'master' has been deprecated, please use 'masked' instead.
       !ERROR: `MASTER` region may not be closely nested inside of `WORKSHARING`, `LOOP`, `TASK`, `TASKLOOP`, or `ATOMIC` region.
       !$omp master
       j = j -1

--- a/flang/test/Semantics/OpenMP/nested-master.f90
+++ b/flang/test/Semantics/OpenMP/nested-master.f90
@@ -9,6 +9,7 @@ program omp_nest_master
   !$omp do
   do i = 1, 10
     k = k + 1
+    !WARNING: Usage of directive master is non-confirming to OpenMP standard
     !ERROR: `MASTER` region may not be closely nested inside of `WORKSHARING`, `LOOP`, `TASK`, `TASKLOOP`, or `ATOMIC` region.
     !$omp master
     j = j -1
@@ -16,6 +17,7 @@ program omp_nest_master
   end do
 
   !$omp sections 
+  !WARNING: Usage of directive master is non-confirming to OpenMP standard
   !ERROR: `MASTER` region may not be closely nested inside of `WORKSHARING`, `LOOP`, `TASK`, `TASKLOOP`, or `ATOMIC` region.
     !$omp master
     do i = 1, 10
@@ -25,6 +27,7 @@ program omp_nest_master
   !$omp end sections
 
   !$omp single 
+  !WARNING: Usage of directive master is non-confirming to OpenMP standard
   !ERROR: `MASTER` region may not be closely nested inside of `WORKSHARING`, `LOOP`, `TASK`, `TASKLOOP`, or `ATOMIC` region.
     !$omp master
     do i = 1, 10
@@ -38,6 +41,7 @@ program omp_nest_master
   !$omp task
   do i = 1, 10
     k = k + 1
+    !WARNING: Usage of directive master is non-confirming to OpenMP standard
     !ERROR: `MASTER` region may not be closely nested inside of `WORKSHARING`, `LOOP`, `TASK`, `TASKLOOP`, or `ATOMIC` region.
     !$omp master
     j = j -1
@@ -48,6 +52,7 @@ program omp_nest_master
   !$omp taskloop
   do i = 1, 10
     k = k + 1
+    !WARNING: Usage of directive master is non-confirming to OpenMP standard
     !ERROR: `MASTER` region may not be closely nested inside of `WORKSHARING`, `LOOP`, `TASK`, `TASKLOOP`, or `ATOMIC` region.
     !$omp master
     j = j -1
@@ -58,6 +63,7 @@ program omp_nest_master
   !$omp target parallel do simd
   do i = 1, 10
     k = k + 1
+    !WARNING: Usage of directive master is non-confirming to OpenMP standard
     !ERROR: The only OpenMP constructs that can be encountered during execution of a 'SIMD' region are the `ATOMIC` construct, the `LOOP` construct, the `SIMD` construct and the `ORDERED` construct with the `SIMD` clause.
     !ERROR: `MASTER` region may not be closely nested inside of `WORKSHARING`, `LOOP`, `TASK`, `TASKLOOP`, or `ATOMIC` region.
     !$omp master
@@ -69,6 +75,7 @@ program omp_nest_master
   !$omp critical
   do i = 1, 10
     k = k + 1
+    !WARNING: Usage of directive master is non-confirming to OpenMP standard
     !$omp master
     j = j -1
     !$omp end master
@@ -78,6 +85,7 @@ program omp_nest_master
   !$omp ordered
   do i = 1, 10
     k = k + 1
+    !WARNING: Usage of directive master is non-confirming to OpenMP standard
     !$omp master
     j = j -1
     !$omp end master
@@ -91,6 +99,7 @@ program omp_nest_master
     !$omp distribute
     do k =1, 10
       print *, "hello"
+      !WARNING: Usage of directive master is non-confirming to OpenMP standard
       !$omp master
       j = j -1
       !$omp end master
@@ -107,6 +116,7 @@ program omp_nest_master
     !$omp distribute
     do k =1, 10
       print *, "hello"
+      !WARNING: Usage of directive master is non-confirming to OpenMP standard
       !$omp master
       j = j -1
       !$omp end master
@@ -123,6 +133,7 @@ program omp_nest_master
     !$omp distribute
     do k =1, 10
       print *, "hello"
+      !WARNING: Usage of directive master is non-confirming to OpenMP standard
       !ERROR: `MASTER` region may not be closely nested inside of `WORKSHARING`, `LOOP`, `TASK`, `TASKLOOP`, or `ATOMIC` region.
       !$omp master
       j = j -1
@@ -140,6 +151,7 @@ program omp_nest_master
     !$omp distribute
     do k =1, 10
       print *, "hello"
+      !WARNING: Usage of directive master is non-confirming to OpenMP standard
       !ERROR: `MASTER` region may not be closely nested inside of `WORKSHARING`, `LOOP`, `TASK`, `TASKLOOP`, or `ATOMIC` region.
       !$omp master
       j = j -1

--- a/flang/test/Semantics/OpenMP/nested-teams.f90
+++ b/flang/test/Semantics/OpenMP/nested-teams.f90
@@ -42,7 +42,7 @@ program main
   !$omp end teams
   end do
 
-  !WARNING: Usage of directive master is non-confirming to OpenMP standard
+  !WARNING: OpenMP directive master has been deprecated, please use masked instead.
   !$omp master
   !ERROR: TEAMS region can only be strictly nested within the implicit parallel region or TARGET region
   !$omp teams

--- a/flang/test/Semantics/OpenMP/nested-teams.f90
+++ b/flang/test/Semantics/OpenMP/nested-teams.f90
@@ -42,7 +42,7 @@ program main
   !$omp end teams
   end do
 
-  !WARNING: OpenMP directive master has been deprecated, please use masked instead.
+  !WARNING: OpenMP directive 'master' has been deprecated, please use 'masked' instead.
   !$omp master
   !ERROR: TEAMS region can only be strictly nested within the implicit parallel region or TARGET region
   !$omp teams

--- a/flang/test/Semantics/OpenMP/nested-teams.f90
+++ b/flang/test/Semantics/OpenMP/nested-teams.f90
@@ -42,6 +42,7 @@ program main
   !$omp end teams
   end do
 
+  !WARNING: Usage of directive master is non-confirming to OpenMP standard
   !$omp master
   !ERROR: TEAMS region can only be strictly nested within the implicit parallel region or TARGET region
   !$omp teams

--- a/flang/test/Semantics/OpenMP/ordered-simd.f90
+++ b/flang/test/Semantics/OpenMP/ordered-simd.f90
@@ -95,7 +95,7 @@ SUBROUTINE ORDERED_BAD(N)
 
   !$OMP CRITICAL  
     C =  C - A * B
-    !WARNING: Usage of directive master is non-confirming to OpenMP standard
+    !WARNING: OpenMP directive master has been deprecated, please use masked instead.
     !$OMP MASTER
     DO I = 1,N
       !ERROR: `ORDERED` region may not be closely nested inside of `CRITICAL`, `ORDERED`, explicit `TASK` or `TASKLOOP` region.
@@ -108,7 +108,7 @@ SUBROUTINE ORDERED_BAD(N)
 
   !$OMP ORDERED  
     C =  C - A * B
-    !WARNING: Usage of directive master is non-confirming to OpenMP standard
+    !WARNING: OpenMP directive master has been deprecated, please use masked instead.
     !$OMP MASTER
     DO I = 1,N
       !ERROR: `ORDERED` region may not be closely nested inside of `CRITICAL`, `ORDERED`, explicit `TASK` or `TASKLOOP` region.
@@ -121,7 +121,7 @@ SUBROUTINE ORDERED_BAD(N)
 
   !$OMP TASK  
     C =  C - A * B
-    !WARNING: Usage of directive master is non-confirming to OpenMP standard
+    !WARNING: OpenMP directive master has been deprecated, please use masked instead.
     !ERROR: `MASTER` region may not be closely nested inside of `WORKSHARING`, `LOOP`, `TASK`, `TASKLOOP`, or `ATOMIC` region.
     !$OMP MASTER
     DO I = 1,N
@@ -136,7 +136,7 @@ SUBROUTINE ORDERED_BAD(N)
   !$OMP TASKLOOP
   DO J= 1,N  
     C =  C - A * B
-    !WARNING: Usage of directive master is non-confirming to OpenMP standard
+    !WARNING: OpenMP directive master has been deprecated, please use masked instead.
     !ERROR: `MASTER` region may not be closely nested inside of `WORKSHARING`, `LOOP`, `TASK`, `TASKLOOP`, or `ATOMIC` region.
     !$OMP MASTER
     DO I = 1,N

--- a/flang/test/Semantics/OpenMP/ordered-simd.f90
+++ b/flang/test/Semantics/OpenMP/ordered-simd.f90
@@ -95,7 +95,7 @@ SUBROUTINE ORDERED_BAD(N)
 
   !$OMP CRITICAL  
     C =  C - A * B
-    !WARNING: OpenMP directive master has been deprecated, please use masked instead.
+    !WARNING: OpenMP directive 'master' has been deprecated, please use 'masked' instead.
     !$OMP MASTER
     DO I = 1,N
       !ERROR: `ORDERED` region may not be closely nested inside of `CRITICAL`, `ORDERED`, explicit `TASK` or `TASKLOOP` region.
@@ -108,7 +108,7 @@ SUBROUTINE ORDERED_BAD(N)
 
   !$OMP ORDERED  
     C =  C - A * B
-    !WARNING: OpenMP directive master has been deprecated, please use masked instead.
+    !WARNING: OpenMP directive 'master' has been deprecated, please use 'masked' instead.
     !$OMP MASTER
     DO I = 1,N
       !ERROR: `ORDERED` region may not be closely nested inside of `CRITICAL`, `ORDERED`, explicit `TASK` or `TASKLOOP` region.
@@ -121,7 +121,7 @@ SUBROUTINE ORDERED_BAD(N)
 
   !$OMP TASK  
     C =  C - A * B
-    !WARNING: OpenMP directive master has been deprecated, please use masked instead.
+    !WARNING: OpenMP directive 'master' has been deprecated, please use 'masked' instead.
     !ERROR: `MASTER` region may not be closely nested inside of `WORKSHARING`, `LOOP`, `TASK`, `TASKLOOP`, or `ATOMIC` region.
     !$OMP MASTER
     DO I = 1,N
@@ -136,7 +136,7 @@ SUBROUTINE ORDERED_BAD(N)
   !$OMP TASKLOOP
   DO J= 1,N  
     C =  C - A * B
-    !WARNING: OpenMP directive master has been deprecated, please use masked instead.
+    !WARNING: OpenMP directive 'master' has been deprecated, please use 'masked' instead.
     !ERROR: `MASTER` region may not be closely nested inside of `WORKSHARING`, `LOOP`, `TASK`, `TASKLOOP`, or `ATOMIC` region.
     !$OMP MASTER
     DO I = 1,N

--- a/flang/test/Semantics/OpenMP/ordered-simd.f90
+++ b/flang/test/Semantics/OpenMP/ordered-simd.f90
@@ -95,6 +95,7 @@ SUBROUTINE ORDERED_BAD(N)
 
   !$OMP CRITICAL  
     C =  C - A * B
+    !WARNING: Usage of directive master is non-confirming to OpenMP standard
     !$OMP MASTER
     DO I = 1,N
       !ERROR: `ORDERED` region may not be closely nested inside of `CRITICAL`, `ORDERED`, explicit `TASK` or `TASKLOOP` region.
@@ -107,6 +108,7 @@ SUBROUTINE ORDERED_BAD(N)
 
   !$OMP ORDERED  
     C =  C - A * B
+    !WARNING: Usage of directive master is non-confirming to OpenMP standard
     !$OMP MASTER
     DO I = 1,N
       !ERROR: `ORDERED` region may not be closely nested inside of `CRITICAL`, `ORDERED`, explicit `TASK` or `TASKLOOP` region.
@@ -119,6 +121,7 @@ SUBROUTINE ORDERED_BAD(N)
 
   !$OMP TASK  
     C =  C - A * B
+    !WARNING: Usage of directive master is non-confirming to OpenMP standard
     !ERROR: `MASTER` region may not be closely nested inside of `WORKSHARING`, `LOOP`, `TASK`, `TASKLOOP`, or `ATOMIC` region.
     !$OMP MASTER
     DO I = 1,N
@@ -133,6 +136,7 @@ SUBROUTINE ORDERED_BAD(N)
   !$OMP TASKLOOP
   DO J= 1,N  
     C =  C - A * B
+    !WARNING: Usage of directive master is non-confirming to OpenMP standard
     !ERROR: `MASTER` region may not be closely nested inside of `WORKSHARING`, `LOOP`, `TASK`, `TASKLOOP`, or `ATOMIC` region.
     !$OMP MASTER
     DO I = 1,N


### PR DESCRIPTION
Since `master` is deprecated from OpenMP spec 5.2, warning is added. Using `masked` is the recommended alternative as per spec
