### PR TITLE
[sanitizer] Replace ALIGNED with alignas

### DIFF
--- a/compiler-rt/lib/asan/asan_globals_win.cpp
+++ b/compiler-rt/lib/asan/asan_globals_win.cpp
@@ -17,10 +17,10 @@ namespace __asan {
 
 #pragma section(".ASAN$GA", read, write)
 #pragma section(".ASAN$GZ", read, write)
-extern "C" __declspec(allocate(".ASAN$GA"))
-    ALIGNED(sizeof(__asan_global)) __asan_global __asan_globals_start = {};
-extern "C" __declspec(allocate(".ASAN$GZ"))
-    ALIGNED(sizeof(__asan_global)) __asan_global __asan_globals_end = {};
+extern "C" alignas(sizeof(__asan_global))
+    __declspec(allocate(".ASAN$GA")) __asan_global __asan_globals_start = {};
+extern "C" alignas(sizeof(__asan_global))
+    __declspec(allocate(".ASAN$GZ")) __asan_global __asan_globals_end = {};
 #pragma comment(linker, "/merge:.ASAN=.data")
 
 static void call_on_globals(void (*hook)(__asan_global *, uptr)) {

--- a/compiler-rt/lib/asan/asan_malloc_linux.cpp
+++ b/compiler-rt/lib/asan/asan_malloc_linux.cpp
@@ -185,11 +185,11 @@ struct MallocDebugL {
   void* (*valloc)(uptr size);
 };
 
-ALIGNED(32) const MallocDebugK asan_malloc_dispatch_k = {
+alignas(32) const MallocDebugK asan_malloc_dispatch_k = {
     WRAP(malloc),  WRAP(free),     WRAP(calloc),
     WRAP(realloc), WRAP(memalign), WRAP(malloc_usable_size)};
 
-ALIGNED(32) const MallocDebugL asan_malloc_dispatch_l = {
+alignas(32) const MallocDebugL asan_malloc_dispatch_l = {
     WRAP(calloc),         WRAP(free),               WRAP(mallinfo),
     WRAP(malloc),         WRAP(malloc_usable_size), WRAP(memalign),
     WRAP(posix_memalign), WRAP(pvalloc),            WRAP(realloc),

--- a/compiler-rt/lib/asan/asan_report.cpp
+++ b/compiler-rt/lib/asan/asan_report.cpp
@@ -34,8 +34,8 @@ namespace __asan {
 // -------------------- User-specified callbacks ----------------- {{{1
 static void (*error_report_callback)(const char*);
 using ErrorMessageBuffer = InternalMmapVectorNoCtor<char, true>;
-static ALIGNED(
-    alignof(ErrorMessageBuffer)) char error_message_buffer_placeholder
+alignas(
+    alignof(ErrorMessageBuffer)) static char error_message_buffer_placeholder
     [sizeof(ErrorMessageBuffer)];
 static ErrorMessageBuffer *error_message_buffer = nullptr;
 static Mutex error_message_buf_mutex;

--- a/compiler-rt/lib/asan/asan_suppressions.cpp
+++ b/compiler-rt/lib/asan/asan_suppressions.cpp
@@ -20,7 +20,7 @@
 
 namespace __asan {
 
-ALIGNED(64) static char suppression_placeholder[sizeof(SuppressionContext)];
+alignas(64) static char suppression_placeholder[sizeof(SuppressionContext)];
 static SuppressionContext *suppression_ctx = nullptr;
 static const char kInterceptorName[] = "interceptor_name";
 static const char kInterceptorViaFunction[] = "interceptor_via_fun";

--- a/compiler-rt/lib/asan/asan_thread.cpp
+++ b/compiler-rt/lib/asan/asan_thread.cpp
@@ -67,10 +67,10 @@ static void InitThreads() {
   // thread before all TSD destructors will be called for it.
 
   // MIPS requires aligned address
-  static ALIGNED(alignof(
-      ThreadRegistry)) char thread_registry_placeholder[sizeof(ThreadRegistry)];
-  static ALIGNED(alignof(
-      ThreadArgRetval)) char thread_data_placeholder[sizeof(ThreadArgRetval)];
+  alignas(alignof(ThreadRegistry)) static char
+      thread_registry_placeholder[sizeof(ThreadRegistry)];
+  alignas(alignof(ThreadArgRetval)) static char
+      thread_data_placeholder[sizeof(ThreadArgRetval)];
 
   asan_thread_registry =
       new (thread_registry_placeholder) ThreadRegistry(GetAsanThreadContext);

--- a/compiler-rt/lib/dfsan/dfsan_allocator.h
+++ b/compiler-rt/lib/dfsan/dfsan_allocator.h
@@ -18,7 +18,7 @@
 namespace __dfsan {
 
 struct DFsanThreadLocalMallocStorage {
-  ALIGNED(8) uptr allocator_cache[96 * (512 * 8 + 16)];  // Opaque.
+  alignas(8) uptr allocator_cache[96 * (512 * 8 + 16)];  // Opaque.
   void CommitBack();
 
  private:

--- a/compiler-rt/lib/hwasan/hwasan_allocator.cpp
+++ b/compiler-rt/lib/hwasan/hwasan_allocator.cpp
@@ -44,7 +44,7 @@ enum {
 
 
 // Initialized in HwasanAllocatorInit, an never changed.
-static ALIGNED(16) u8 tail_magic[kShadowAlignment - 1];
+alignas(16) static u8 tail_magic[kShadowAlignment - 1];
 static uptr max_malloc_size;
 
 bool HwasanChunkView::IsAllocated() const {

--- a/compiler-rt/lib/hwasan/hwasan_thread_list.cpp
+++ b/compiler-rt/lib/hwasan/hwasan_thread_list.cpp
@@ -14,15 +14,15 @@ ThreadArgRetval &hwasanThreadArgRetval() { return *thread_data; }
 void InitThreadList(uptr storage, uptr size) {
   CHECK_EQ(hwasan_thread_list, nullptr);
 
-  static ALIGNED(alignof(
-      HwasanThreadList)) char thread_list_placeholder[sizeof(HwasanThreadList)];
+  alignas(alignof(HwasanThreadList)) static char
+      thread_list_placeholder[sizeof(HwasanThreadList)];
   hwasan_thread_list =
       new (thread_list_placeholder) HwasanThreadList(storage, size);
 
   CHECK_EQ(thread_data, nullptr);
 
-  static ALIGNED(alignof(
-      ThreadArgRetval)) char thread_data_placeholder[sizeof(ThreadArgRetval)];
+  alignas(alignof(ThreadArgRetval)) static char
+      thread_data_placeholder[sizeof(ThreadArgRetval)];
   thread_data = new (thread_data_placeholder) ThreadArgRetval();
 }
 

--- a/compiler-rt/lib/lsan/lsan_common.cpp
+++ b/compiler-rt/lib/lsan/lsan_common.cpp
@@ -108,7 +108,7 @@ class LeakSuppressionContext {
   void PrintMatchedSuppressions();
 };
 
-ALIGNED(64) static char suppression_placeholder[sizeof(LeakSuppressionContext)];
+alignas(64) static char suppression_placeholder[sizeof(LeakSuppressionContext)];
 static LeakSuppressionContext *suppression_ctx = nullptr;
 static const char kSuppressionLeak[] = "leak";
 static const char *kSuppressionTypes[] = {kSuppressionLeak};

--- a/compiler-rt/lib/lsan/lsan_common_linux.cpp
+++ b/compiler-rt/lib/lsan/lsan_common_linux.cpp
@@ -28,7 +28,7 @@ namespace __lsan {
 
 static const char kLinkerName[] = "ld";
 
-static char linker_placeholder[sizeof(LoadedModule)] ALIGNED(64);
+alignas(64) static char linker_placeholder[sizeof(LoadedModule)];
 static LoadedModule *linker = nullptr;
 
 static bool IsLinker(const LoadedModule& module) {

--- a/compiler-rt/lib/lsan/lsan_thread.cpp
+++ b/compiler-rt/lib/lsan/lsan_thread.cpp
@@ -35,12 +35,12 @@ static ThreadContextBase *CreateThreadContext(u32 tid) {
 }
 
 void InitializeThreads() {
-  static ALIGNED(alignof(
-      ThreadRegistry)) char thread_registry_placeholder[sizeof(ThreadRegistry)];
+  alignas(alignof(ThreadRegistry)) static char
+      thread_registry_placeholder[sizeof(ThreadRegistry)];
   thread_registry =
       new (thread_registry_placeholder) ThreadRegistry(CreateThreadContext);
 
-  static ALIGNED(alignof(ThreadArgRetval)) char
+  alignas(alignof(ThreadArgRetval)) static char
       thread_arg_retval_placeholder[sizeof(ThreadArgRetval)];
   thread_arg_retval = new (thread_arg_retval_placeholder) ThreadArgRetval();
 }

--- a/compiler-rt/lib/memprof/memprof_thread.cpp
+++ b/compiler-rt/lib/memprof/memprof_thread.cpp
@@ -37,7 +37,7 @@ void MemprofThreadContext::OnFinished() {
   thread = nullptr;
 }
 
-static ALIGNED(16) char thread_registry_placeholder[sizeof(ThreadRegistry)];
+alignas(16) static char thread_registry_placeholder[sizeof(ThreadRegistry)];
 static ThreadRegistry *memprof_thread_registry;
 
 static Mutex mu_for_thread_context;

--- a/compiler-rt/lib/msan/msan.cpp
+++ b/compiler-rt/lib/msan/msan.cpp
@@ -56,12 +56,11 @@ THREADLOCAL u64 __msan_retval_tls[kMsanRetvalTlsSize / sizeof(u64)];
 SANITIZER_INTERFACE_ATTRIBUTE
 THREADLOCAL u32 __msan_retval_origin_tls;
 
-SANITIZER_INTERFACE_ATTRIBUTE
-ALIGNED(16) THREADLOCAL u64 __msan_va_arg_tls[kMsanParamTlsSize / sizeof(u64)];
+alignas(16) SANITIZER_INTERFACE_ATTRIBUTE THREADLOCAL u64
+    __msan_va_arg_tls[kMsanParamTlsSize / sizeof(u64)];
 
-SANITIZER_INTERFACE_ATTRIBUTE
-ALIGNED(16)
-THREADLOCAL u32 __msan_va_arg_origin_tls[kMsanParamTlsSize / sizeof(u32)];
+alignas(16) SANITIZER_INTERFACE_ATTRIBUTE THREADLOCAL u32
+    __msan_va_arg_origin_tls[kMsanParamTlsSize / sizeof(u32)];
 
 SANITIZER_INTERFACE_ATTRIBUTE
 THREADLOCAL u64 __msan_va_arg_overflow_size_tls;

--- a/compiler-rt/lib/msan/msan_allocator.h
+++ b/compiler-rt/lib/msan/msan_allocator.h
@@ -19,7 +19,7 @@ namespace __msan {
 
 struct MsanThreadLocalMallocStorage {
   // Allocator cache contains atomic_uint64_t which must be 8-byte aligned.
-  ALIGNED(8) uptr allocator_cache[96 * (512 * 8 + 16)];  // Opaque.
+  alignas(8) uptr allocator_cache[96 * (512 * 8 + 16)];  // Opaque.
   void Init();
   void CommitBack();
 

--- a/compiler-rt/lib/msan/msan_interceptors.cpp
+++ b/compiler-rt/lib/msan/msan_interceptors.cpp
@@ -1255,7 +1255,7 @@ struct InterceptorContext {
   }
 };
 
-static ALIGNED(64) char interceptor_placeholder[sizeof(InterceptorContext)];
+alignas(64) static char interceptor_placeholder[sizeof(InterceptorContext)];
 InterceptorContext *interceptor_ctx() {
   return reinterpret_cast<InterceptorContext*>(&interceptor_placeholder[0]);
 }

--- a/compiler-rt/lib/sanitizer_common/sanitizer_allocator.cpp
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_allocator.cpp
@@ -25,7 +25,7 @@ namespace __sanitizer {
 const char *PrimaryAllocatorName = "SizeClassAllocator";
 const char *SecondaryAllocatorName = "LargeMmapAllocator";
 
-static ALIGNED(64) char internal_alloc_placeholder[sizeof(InternalAllocator)];
+alignas(64) static char internal_alloc_placeholder[sizeof(InternalAllocator)];
 static atomic_uint8_t internal_allocator_initialized;
 static StaticSpinMutex internal_alloc_init_mu;
 

--- a/compiler-rt/lib/sanitizer_common/sanitizer_allocator_primary32.h
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_allocator_primary32.h
@@ -278,7 +278,7 @@ class SizeClassAllocator32 {
   static const uptr kRegionSize = 1 << kRegionSizeLog;
   static const uptr kNumPossibleRegions = kSpaceSize / kRegionSize;
 
-  struct ALIGNED(SANITIZER_CACHE_LINE_SIZE) SizeClassInfo {
+  struct alignas(SANITIZER_CACHE_LINE_SIZE) SizeClassInfo {
     StaticSpinMutex mutex;
     IntrusiveList<TransferBatch> free_list;
     u32 rand_state;

--- a/compiler-rt/lib/sanitizer_common/sanitizer_allocator_primary64.h
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_allocator_primary64.h
@@ -667,7 +667,7 @@ class SizeClassAllocator64 {
     u64 last_released_bytes;
   };
 
-  struct ALIGNED(SANITIZER_CACHE_LINE_SIZE) RegionInfo {
+  struct alignas(SANITIZER_CACHE_LINE_SIZE) RegionInfo {
     Mutex mutex;
     uptr num_freed_chunks;  // Number of elements in the freearray.
     uptr mapped_free_array;  // Bytes mapped for freearray.

--- a/compiler-rt/lib/sanitizer_common/sanitizer_atomic.h
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_atomic.h
@@ -61,7 +61,7 @@ struct atomic_uint32_t {
 struct atomic_uint64_t {
   typedef u64 Type;
   // On 32-bit platforms u64 is not necessary aligned on 8 bytes.
-  volatile ALIGNED(8) Type val_dont_use;
+  alignas(8) volatile Type val_dont_use;
 };
 
 struct atomic_uintptr_t {

--- a/compiler-rt/lib/ubsan/ubsan_diag.cpp
+++ b/compiler-rt/lib/ubsan/ubsan_diag.cpp
@@ -402,7 +402,7 @@ ScopedReport::~ScopedReport() {
     Die();
 }
 
-ALIGNED(64) static char suppression_placeholder[sizeof(SuppressionContext)];
+alignas(64) static char suppression_placeholder[sizeof(SuppressionContext)];
 static SuppressionContext *suppression_ctx = nullptr;
 static const char kVptrCheck[] = "vptr_check";
 static const char *kSuppressionTypes[] = {


### PR DESCRIPTION
C++11 `alignas` is already used extensively. `alignas` must precede
`static`, so adjust the ordering accordingly.

msan.cpp: Clang 15 doesn't allow `__attribute__((visibility("default"))) alignas(16)`.
Use the order `alignas(16) SANITIZER_INTERFACE_ATTRIBUTE`. Tested with Clang 7.
