### PR TITLE
[libc++][test] XFAIL sized deallocation tests for AIX, z/OS, and MinGW

### DIFF
--- a/libcxx/test/std/language.support/support.dynamic/new.delete/new.delete.array/sized_delete_array14.pass.cpp
+++ b/libcxx/test/std/language.support/support.dynamic/new.delete/new.delete.array/sized_delete_array14.pass.cpp
@@ -16,7 +16,7 @@
 // XFAIL: using-built-library-before-llvm-11
 
 // AIX, z/OS, and MinGW default to -fno-sized-deallocation.
-// XFAIL: target={{.+}}-aix{{.*}}, target={{.+}}-zos{{.*}}, target={{.+}}-mingw32{{.*}}
+// XFAIL: target={{.+}}-aix{{.*}}, target={{.+}}-zos{{.*}}, target={{.+}}-windows-gnu
 
 #include <new>
 #include <cstddef>

--- a/libcxx/test/std/language.support/support.dynamic/new.delete/new.delete.array/sized_delete_array14.pass.cpp
+++ b/libcxx/test/std/language.support/support.dynamic/new.delete/new.delete.array/sized_delete_array14.pass.cpp
@@ -15,6 +15,9 @@
 // XFAIL: apple-clang
 // XFAIL: using-built-library-before-llvm-11
 
+// AIX, z/OS, and MinGW default to -fno-sized-deallocation.
+// XFAIL: target={{.+}}-aix{{.*}}, target={{.+}}-zos{{.*}}, target={{.+}}-mingw32{{.*}}
+
 #include <new>
 #include <cstddef>
 #include <cstdlib>

--- a/libcxx/test/std/language.support/support.dynamic/new.delete/new.delete.single/sized_delete14.pass.cpp
+++ b/libcxx/test/std/language.support/support.dynamic/new.delete/new.delete.single/sized_delete14.pass.cpp
@@ -16,7 +16,7 @@
 // XFAIL: using-built-library-before-llvm-11
 
 // AIX, z/OS, and MinGW default to -fno-sized-deallocation.
-// XFAIL: target={{.+}}-aix{{.*}}, target={{.+}}-zos{{.*}}, target={{.+}}-mingw32{{.*}}
+// XFAIL: target={{.+}}-aix{{.*}}, target={{.+}}-zos{{.*}}, target={{.+}}-windows-gnu
 
 #include <new>
 #include <cstddef>

--- a/libcxx/test/std/language.support/support.dynamic/new.delete/new.delete.single/sized_delete14.pass.cpp
+++ b/libcxx/test/std/language.support/support.dynamic/new.delete/new.delete.single/sized_delete14.pass.cpp
@@ -15,6 +15,9 @@
 // XFAIL: apple-clang
 // XFAIL: using-built-library-before-llvm-11
 
+// AIX, z/OS, and MinGW default to -fno-sized-deallocation.
+// XFAIL: target={{.+}}-aix{{.*}}, target={{.+}}-zos{{.*}}, target={{.+}}-mingw32{{.*}}
+
 #include <new>
 #include <cstddef>
 #include <cstdlib>


### PR DESCRIPTION
The sized deallocation test cases fail on AIX, z/OS, and MinGW because they default to `-fno-sized-deallocation`. This patch XFAILs these test cases for the affected targets. Once they change the default, we will get `unexpectedly pass`.