### PR TITLE
[lld][WebAssembly] Work around limited architecture detection for wasm64 shared libraries

### DIFF
--- a/lld/test/wasm/dylink.s
+++ b/lld/test/wasm/dylink.s
@@ -6,6 +6,16 @@
 # RUN: wasm-ld --experimental-pic -pie -o %t.wasm %t.o %t.lib.so
 # RUN: obj2yaml %t.wasm | FileCheck %s
 
+# Same again for wasm64
+
+# RUN: llvm-mc -filetype=obj -triple=wasm64-unknown-emscripten -o %t.o %s
+# RUN: llvm-mc -filetype=obj -triple=wasm64-unknown-emscripten %p/Inputs/ret32.s -o %t.ret32.o
+# RUN: llvm-mc -filetype=obj -triple=wasm64-unknown-emscripten %p/Inputs/libsearch-dyn.s -o %t.dyn.o
+# RUN: wasm-ld --experimental-pic -mwasm64 -shared %t.ret32.o %t.dyn.o -o %t.lib.so
+# RUN: not wasm-ld --experimental-pic -mwasm64 -pie -o %t.wasm %t.o 2>&1 | FileCheck --check-prefix=ERROR %s
+# RUN: wasm-ld --experimental-pic -mwasm64 -pie -o %t.wasm %t.o %t.lib.so
+# RUN: obj2yaml %t.wasm | FileCheck %s
+
 # ERROR: error: {{.*}}: undefined symbol: ret32
 # ERROR: error: {{.*}}: undefined symbol: _bar
 .functype ret32 (f32) -> (i32)

--- a/lld/wasm/InputFiles.cpp
+++ b/lld/wasm/InputFiles.cpp
@@ -408,6 +408,12 @@ ObjFile::ObjFile(MemoryBufferRef m, StringRef archiveName, bool lazy)
   this->lazy = lazy;
   this->archiveName = std::string(archiveName);
 
+  // Currently we only do this check for regular object file, and not for shared
+  // object files.  This is because architecture detection for shared objects is
+  // currently based on a heuristic, which is fallable:
+  // https://github.com/llvm/llvm-project/issues/98778
+  checkArch(wasmObj->getArch());
+
   // If this isn't part of an archive, it's eagerly linked, so mark it live.
   if (archiveName.empty())
     markLive();
@@ -456,8 +462,6 @@ WasmFileBase::WasmFileBase(Kind k, MemoryBufferRef m) : InputFile(k, m) {
 
   bin.release();
   wasmObj.reset(obj);
-
-  checkArch(obj->getArch());
 }
 
 void ObjFile::parse(bool ignoreComdats) {


### PR DESCRIPTION
We don't currently have a great way to detect the architecture of shared object files under wasm.  The currently method involves checking if the imported or exported memory is 64-bit.  However some shared libraries don't use linear memory at all.

See https://github.com/llvm/llvm-project/issues/98778