### PR TITLE
[libc] Enable 'wchar.h' for the GPU

### DIFF
--- a/libc/config/gpu/entrypoints.txt
+++ b/libc/config/gpu/entrypoints.txt
@@ -218,6 +218,9 @@ set(TARGET_LIBC_ENTRYPOINTS
     libc.src.time.clock
     libc.src.time.nanosleep
 
+    # wchar.h entrypoints
+    libc.src.wchar.wctob
+
     # gpu/rpc.h entrypoints
     libc.src.gpu.rpc_host_call
     libc.src.gpu.rpc_fprintf

--- a/libc/config/gpu/headers.txt
+++ b/libc/config/gpu/headers.txt
@@ -12,6 +12,8 @@ set(TARGET_PUBLIC_HEADERS
     libc.include.errno
     libc.include.stdlib
     libc.include.stdio
+    libc.include.wchar
+    libc.include.uchar
 
     # Header for RPC extensions
     libc.include.gpu_rpc

--- a/libc/include/uchar.h.def
+++ b/libc/include/uchar.h.def
@@ -10,6 +10,7 @@
 #define LLVM_LIBC_UCHAR_H
 
 #include "__llvm-libc-common.h"
+#include "llvm-libc-types/mbstate_t.h"
 
 %%public_api()
 

--- a/libc/include/wchar.h.def
+++ b/libc/include/wchar.h.def
@@ -11,6 +11,8 @@
 
 #include "__llvm-libc-common.h"
 #include "llvm-libc-macros/wchar-macros.h"
+#include "llvm-libc-types/wint_t.h"
+#include "llvm-libc-types/mbstate_t.h"
 
 %%public_api()
 


### PR DESCRIPTION
Summary:
This file is not really well populated, but is required for some targets
to configure. Enable it on the GPU for now.
