### PR TITLE
[lldb/Symbol] Hoist SymbolLocation from AssertFrameRecognizer to reuse it

### DIFF
--- a/lldb/include/lldb/Symbol/SymbolLocation.h
+++ b/lldb/include/lldb/Symbol/SymbolLocation.h
@@ -1,0 +1,32 @@
+//===-- SymbolLocation.h ----------------------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLDB_SYMBOL_SYMBOLLOCATION_H
+#define LLDB_SYMBOL_SYMBOLLOCATION_H
+
+#include "lldb/Utility/ConstString.h"
+#include "lldb/Utility/FileSpec.h"
+#include "lldb/lldb-private.h"
+
+#include <vector>
+
+namespace lldb_private {
+
+/// Stores a function module spec, symbol name and possibly an alternate symbol
+/// name.
+struct SymbolLocation {
+  FileSpec module_spec;
+  std::vector<ConstString> symbols;
+
+  // The symbols are regular expressions. In such case all symbols are matched
+  // with their trailing @VER symbol version stripped.
+  bool symbols_are_regex = false;
+};
+
+} // namespace lldb_private
+#endif // LLDB_SYMBOL_SYMBOLLOCATION_H

--- a/lldb/source/Target/AssertFrameRecognizer.cpp
+++ b/lldb/source/Target/AssertFrameRecognizer.cpp
@@ -2,6 +2,7 @@
 #include "lldb/Core/Module.h"
 #include "lldb/Symbol/Function.h"
 #include "lldb/Symbol/SymbolContext.h"
+#include "lldb/Symbol/SymbolLocation.h"
 #include "lldb/Target/Process.h"
 #include "lldb/Target/StackFrameList.h"
 #include "lldb/Target/Target.h"
@@ -13,18 +14,6 @@ using namespace lldb;
 using namespace lldb_private;
 
 namespace lldb_private {
-
-/// Stores a function module spec, symbol name and possibly an alternate symbol
-/// name.
-struct SymbolLocation {
-  FileSpec module_spec;
-  std::vector<ConstString> symbols;
-
-  // The symbols are regular expressions. In such case all symbols are matched
-  // with their trailing @VER symbol version stripped.
-  bool symbols_are_regex = false;
-};
-
 /// Fetches the abort frame location depending on the current platform.
 ///
 /// \param[in] os


### PR DESCRIPTION
This patch hoists the `SymbolLocation` struct from the `AssertFrameRecognizer` source file, since it's pretty generic and could be reused for other purposes.