### PR TITLE
[lldb] Fix help syntax for add-dsym (target symbols add)

### DIFF
--- a/lldb/source/Commands/CommandObjectTarget.cpp
+++ b/lldb/source/Commands/CommandObjectTarget.cpp
@@ -4252,7 +4252,7 @@ public:
     m_option_group.Append(&m_current_stack_option, LLDB_OPT_SET_2,
                           LLDB_OPT_SET_2);
     m_option_group.Finalize();
-    AddSimpleArgumentList(eArgTypeShlibName);
+    AddSimpleArgumentList(eArgTypeFilename);
   }
 
   ~CommandObjectTargetSymbolsAdd() override = default;

--- a/lldb/test/Shell/SymbolFile/add-dsym.test
+++ b/lldb/test/Shell/SymbolFile/add-dsym.test
@@ -1,5 +1,8 @@
 # REQUIRES: system-darwin
 
+# RUN: %lldb -o 'help add-dsym' | FileCheck %s --check-prefix=HELP
+# HELP: Syntax: add-dsym <cmd-options> <filename>
+
 # RUN: yaml2obj %S/Inputs/a.yaml -o %t.out
 # RUN: LLDB_APPLE_DSYMFORUUID_EXECUTABLE=%S/Inputs/dsymforuuid.sh %lldb %t.out -o 'add-dsym -u 41945CA4-5D9D-3CDE-82B4-37E4C09750B5' 2>&1 | FileCheck %s
 # CHECK: UUID information was not found


### PR DESCRIPTION
The help output incorrectly states that this command takes a shared library name (<shlib-name>) while really it takes a path to a symbol file.

rdar://131777043