### PR TITLE
[dbginfo-tests] Use -march instead of -arch to avoid getting an error for non-darwin targets.

### DIFF
--- a/cross-project-tests/debuginfo-tests/llgdb-tests/asan.c
+++ b/cross-project-tests/debuginfo-tests/llgdb-tests/asan.c
@@ -1,4 +1,4 @@
-// RUN: %clang -fblocks %target_itanium_abi_host_triple -arch x86_64 %s -o %t.out -g -fsanitize=address
+// RUN: %clang -fblocks %target_itanium_abi_host_triple -march=x86-64 %s -o %t.out -g -fsanitize=address
 // RUN: %test_debuginfo %s %t.out
 // REQUIRES: !asan, compiler-rt
 //           Zorg configures the ASAN stage2 bots to not build the asan

--- a/cross-project-tests/debuginfo-tests/llgdb-tests/safestack.c
+++ b/cross-project-tests/debuginfo-tests/llgdb-tests/safestack.c
@@ -1,4 +1,4 @@
-// RUN: %clang %target_itanium_abi_host_triple -arch x86_64 %s -o %t.out -g -fsanitize=safe-stack
+// RUN: %clang %target_itanium_abi_host_triple -march=x86-64 %s -o %t.out -g -fsanitize=safe-stack
 // RUN: %test_debuginfo %s %t.out
 // UNSUPPORTED: system-darwin
 // REQUIRES: !asan, compiler-rt


### PR DESCRIPTION
Our upstream buildbot is getting an error with the -arch option on Ubuntu-22. Not sure why this isn't showing up anywhere else. Using -march instead, but is that OK with you @adrian-prantl ?