### PR TITLE
[emacs] Fix autoloading for llvm-mir-mode

### DIFF
--- a/llvm/utils/emacs/llvm-mir-mode.el
+++ b/llvm/utils/emacs/llvm-mir-mode.el
@@ -56,7 +56,7 @@
    llvm-font-lock-keywords)
   "Keyword highlighting specification for `llvm-mir-mode'.")
 
- ;;;###autoload
+;;;###autoload
 (define-derived-mode llvm-mir-mode prog-mode "LLVM MIR"
   "A major mode for editing LLVM MIR files."
   (setq-local comment-start "; ")


### PR DESCRIPTION
Without this patch, the autoloading of the major mode `llvm-mir-mode` is not generated, which breaks its autoloading functionality.

To test this patch, use the following command to generate an autoload file:

```console
cd llvm/utils/emacs
emacs --quick --batch --load=package --eval='(package-generate-autoloads "llvm-mir-mode" ".")'
```

Diff of generated autoload files is as follows:

```diff
> (autoload 'llvm-mir-mode "llvm-mir-mode" "\
> A major mode for editing LLVM MIR files.
> 
> (fn)" t)
```

CC @bogner for review