### PR TITLE
Revert "[Clang] Instantiate local constexpr functions eagerly (#95660)"

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -960,7 +960,6 @@ Bug Fixes to C++ Support
 - Fixed several bugs in capturing variables within unevaluated contexts. (#GH63845), (#GH67260), (#GH69307),
   (#GH88081), (#GH89496), (#GH90669) and (#GH91633).
 - Fixed handling of brace ellison when building deduction guides. (#GH64625), (#GH83368).
-- Clang now instantiates local constexpr functions eagerly for constant evaluators. (#GH35052), (#GH94849)
 - Fixed a failed assertion when attempting to convert an integer representing the difference
   between the addresses of two labels (a GNU extension) to a pointer within a constant expression. (#GH95366).
 - Fix immediate escalation bugs in the presence of dependent call arguments. (#GH94935)

--- a/clang/lib/Sema/SemaExpr.cpp
+++ b/clang/lib/Sema/SemaExpr.cpp
@@ -17938,17 +17938,16 @@ void Sema::MarkFunctionReferenced(SourceLocation Loc, FunctionDecl *Func,
 
         if (FirstInstantiation || TSK != TSK_ImplicitInstantiation ||
             Func->isConstexpr()) {
-          if (Func->isConstexpr())
+          if (isa<CXXRecordDecl>(Func->getDeclContext()) &&
+              cast<CXXRecordDecl>(Func->getDeclContext())->isLocalClass() &&
+              CodeSynthesisContexts.size())
+            PendingLocalImplicitInstantiations.push_back(
+                std::make_pair(Func, PointOfInstantiation));
+          else if (Func->isConstexpr())
             // Do not defer instantiations of constexpr functions, to avoid the
             // expression evaluator needing to call back into Sema if it sees a
             // call to such a function.
             InstantiateFunctionDefinition(PointOfInstantiation, Func);
-          else if (isa<CXXRecordDecl>(Func->getDeclContext()) &&
-                   cast<CXXRecordDecl>(Func->getDeclContext())
-                       ->isLocalClass() &&
-                   CodeSynthesisContexts.size())
-            PendingLocalImplicitInstantiations.push_back(
-                std::make_pair(Func, PointOfInstantiation));
           else {
             Func->setInstantiationIsPending(true);
             PendingInstantiations.push_back(

--- a/clang/test/SemaTemplate/instantiate-local-class.cpp
+++ b/clang/test/SemaTemplate/instantiate-local-class.cpp
@@ -513,6 +513,8 @@ namespace LambdaInDefaultMemberInitializer {
 
 #if __cplusplus >= 201703L
 
+// Reduced from https://github.com/llvm/llvm-project/issues/98526
+// This relies on the deferral instantiation of the local lambda, otherwise we would fail in DeduceReturnType().
 namespace local_recursive_lambda {
 
 template <typename F> struct recursive_lambda {
@@ -524,17 +526,10 @@ template <typename F> struct recursive_lambda {
 
 template <typename F> recursive_lambda(F) -> recursive_lambda<F>;
 
-struct Tree {
-  Tree *left, *right;
-};
-
-int sumSize(Tree *tree) {
-  auto accumulate =
-      recursive_lambda{[&](auto &self_fn, Tree *element_node) -> int {
-        return 1 + self_fn(tree->left) + self_fn(tree->right);
-      }};
-
-  return accumulate(tree);
+void foo() {
+  recursive_lambda{[&](auto &self_fn, int) -> int {
+    return self_fn(0);
+  }}(0);
 }
 
 } // namespace local_recursive_lambda

--- a/clang/test/SemaTemplate/instantiate-local-class.cpp
+++ b/clang/test/SemaTemplate/instantiate-local-class.cpp
@@ -512,24 +512,31 @@ namespace LambdaInDefaultMemberInitializer {
 }
 
 #if __cplusplus >= 201703L
-namespace GH35052 {
 
-template <typename F> constexpr int func(F f) {
-  if constexpr (f(1UL)) {
-    return 1;
+namespace local_recursive_lambda {
+
+template <typename F> struct recursive_lambda {
+  template <typename... Args> auto operator()(Args &&...args) const {
+    return fn(*this, args...);
   }
-  return 0;
+  F fn;
+};
+
+template <typename F> recursive_lambda(F) -> recursive_lambda<F>;
+
+struct Tree {
+  Tree *left, *right;
+};
+
+int sumSize(Tree *tree) {
+  auto accumulate =
+      recursive_lambda{[&](auto &self_fn, Tree *element_node) -> int {
+        return 1 + self_fn(tree->left) + self_fn(tree->right);
+      }};
+
+  return accumulate(tree);
 }
 
-int main() {
-  auto predicate = [](auto v) /*implicit constexpr*/ -> bool {
-    return v == 1;
-  };
-
-  static_assert(predicate(1));
-  return func(predicate);
-}
-
-} // namespace GH35052
+} // namespace local_recursive_lambda
 
 #endif


### PR DESCRIPTION
Unfortunately, #95660 has caused a regression in DeduceReturnType(), which is a problem in that some of the local recursive lambdas are getting incorrectly rejected.

This reverts commit 5548ea34341e9d0ae645719c34b466ca3b9eaa5a. Also, this adds an offending case to the test.

Closes #98526
