### PR TITLE
[BOLT] Store FileSymRefs in a multimap

### DIFF
--- a/bolt/include/bolt/Rewrite/RewriteInstance.h
+++ b/bolt/include/bolt/Rewrite/RewriteInstance.h
@@ -490,7 +490,7 @@ private:
   std::unordered_map<const MCSymbol *, uint32_t> SymbolIndex;
 
   /// Store all non-zero symbols in this map for a quick address lookup.
-  std::map<uint64_t, llvm::object::SymbolRef> FileSymRefs;
+  std::multimap<uint64_t, llvm::object::SymbolRef> FileSymRefs;
 
   /// FILE symbols used for disambiguating split function parents.
   std::vector<ELFSymbolRef> FileSymbols;

--- a/bolt/lib/Rewrite/RewriteInstance.cpp
+++ b/bolt/lib/Rewrite/RewriteInstance.cpp
@@ -1262,6 +1262,7 @@ void RewriteInstance::discoverFileObjects() {
 
   registerFragments();
   FileSymbols.clear();
+  FileSymRefs.clear();
 
   discoverBOLTReserved();
 }

--- a/bolt/test/X86/Inputs/ambiguous_fragment.s
+++ b/bolt/test/X86/Inputs/ambiguous_fragment.s
@@ -1,0 +1,54 @@
+#--- file1
+.file "file1.cpp"
+.section .text.cold
+.type __func.cold.0, @function
+__func.cold.0:
+  ud2
+  .size __func.cold.0, .-__func.cold.0
+.section .text
+.type __func, @function
+__func:
+  ud2
+  .size __func, .-__func
+
+#--- file2
+.file "file2.cpp"
+.section .text.cold
+.type __func.cold.0, @function
+__func.cold.0:
+  ud2
+  .size __func.cold.0, .-__func.cold.0
+.section .text
+.type __func, @function
+__func:
+  ud2
+  .size __func, .-__func
+
+#--- file3
+.file "file3.cpp"
+.section .text.cold
+.type __func.cold.0, @function
+__func.cold.0:
+  ud2
+  .size __func.cold.0, .-__func.cold.0
+.section .text
+.type __func, @function
+__func:
+  ud2
+  .size __func, .-__func
+
+#--- file4
+.file "file4.cpp"
+.section .text.cold
+.type __func.cold.0, @function
+__func.cold.0:
+  ud2
+  .size __func.cold.0, .-__func.cold.0
+.section .text
+.type __func, @function
+__func:
+  ud2
+  .size __func, .-__func
+
+#--- file5
+.file "bolt-pseudo.o"

--- a/bolt/test/X86/Inputs/ambiguous_fragment.script
+++ b/bolt/test/X86/Inputs/ambiguous_fragment.script
@@ -1,0 +1,6 @@
+SECTIONS {
+  . = 0x10000;
+  .text : { *(.text) }
+  . = 0x20000;
+  .text.cold : { *(.text.cold) }
+}

--- a/bolt/test/X86/ambiguous_fragment.test
+++ b/bolt/test/X86/ambiguous_fragment.test
@@ -1,0 +1,28 @@
+## This reproduces a bug with misidentification of a parent fragment.
+
+RUN: split-file %p/Inputs/ambiguous_fragment.s %t
+
+RUN: llvm-mc --filetype=obj --triple x86_64-unknown-unknown %t/file1 -o %t1.o
+RUN: llvm-mc --filetype=obj --triple x86_64-unknown-unknown %t/file2 -o %t2.o
+RUN: llvm-mc --filetype=obj --triple x86_64-unknown-unknown %t/file3 -o %t3.o
+RUN: llvm-mc --filetype=obj --triple x86_64-unknown-unknown %t/file4 -o %t4.o
+RUN: llvm-mc --filetype=obj --triple x86_64-unknown-unknown %t/file5 -o %t5.o
+
+RUN: ld.lld %t1.o %t2.o %t3.o %t4.o %t5.o -o %t.exe \
+RUN:   --script %p/Inputs/ambiguous_fragment.script
+
+RUN: llvm-objcopy %t.exe %t.exe2 \
+RUN:   --add-symbol=_Zfunc.cold.0=.text.cold:0x4,local,function \
+RUN:   --add-symbol=_Zfunc=.text:0xc,function
+
+RUN: llvm-objdump --syms %t.exe2 | FileCheck %s --check-prefix=CHECK-SYMS
+
+RUN: link_fdata %s %t.exe2 %t.preagg PREAGG
+RUN: perf2bolt -v=1 %t.exe2 -p %t.preagg --pa -o %t.fdata -w %t.yaml | FileCheck %s
+
+# PREAGG: B X:0 #__func# 1 0
+
+CHECK-SYMS: 0000000000020004 {{.*}} __func.cold.0
+CHECK-SYMS: 0000000000020004 {{.*}} _Zfunc.cold.0
+
+CHECK: BOLT-INFO

--- a/bolt/test/X86/ambiguous_fragment.test
+++ b/bolt/test/X86/ambiguous_fragment.test
@@ -25,4 +25,9 @@ RUN: perf2bolt -v=1 %t.exe2 -p %t.preagg --pa -o %t.fdata -w %t.yaml | FileCheck
 CHECK-SYMS: 0000000000020004 {{.*}} __func.cold.0
 CHECK-SYMS: 0000000000020004 {{.*}} _Zfunc.cold.0
 
-CHECK: BOLT-INFO
+CHECK-NOT:  BOLT-ERROR: parent function not found for __func.cold.0
+CHECK:      BOLT-INFO: marking __func.cold.0/3(*4) as a fragment of __func/4(*3)
+CHECK-NEXT: BOLT-INFO: marking __func.cold.0/1(*2) as a fragment of __func/1(*2)
+CHECK-NEXT: BOLT-INFO: marking __func.cold.0/2(*2) as a fragment of __func/2(*2)
+CHECK-NEXT: BOLT-INFO: marking __func.cold.0/3(*4) as a fragment of __func/3(*2)
+CHECK-NEXT: BOLT-INFO: marking __func.cold.0/4(*2) as a fragment of __func/4(*3)


### PR DESCRIPTION
With aggressive ICF, it's possible to have different local symbols
(under different FILE symbols) to be mapped to the same address.

FileSymRefs only keeps a single SymbolRef per address, which prevents
fragment matching from finding the correct symbol to perform parent
function lookup.

Work around this issue by switching FileSymRefs to a multimap. In
future, uses of FileSymRefs can be replaced with SortedSymbols which
keeps essentially the same information.

Test Plan: added ambiguous_fragment.test
