### PR TITLE
[lldb][test] Add a new __compressed_pair layout to libcxx simulator tests

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/make/libcxx-simulators-common/compressed_pair.h
+++ b/lldb/packages/Python/lldbsuite/test/make/libcxx-simulators-common/compressed_pair.h
@@ -7,7 +7,7 @@
 namespace std {
 namespace __lldb {
 
-// Post-c88580c layout
+#if COMPRESSED_PAIR_REV == 0 // Post-c88580c layout
 struct __value_init_tag {};
 struct __default_init_tag {};
 
@@ -52,6 +52,38 @@ public:
 
   _T1 &first() { return static_cast<_Base1 &>(*this).__get(); }
 };
+#elif COMPRESSED_PAIR_REV == 1
+template <class _ToPad> class __compressed_pair_padding {
+  char __padding_[(is_empty<_ToPad>::value && !__libcpp_is_final<_ToPad>::value)
+                      ? 0
+                      : sizeof(_ToPad) - __datasizeof(_ToPad)];
+};
+
+#define _LLDB_COMPRESSED_PAIR(T1, Initializer1, T2, Initializer2)              \
+  [[__gnu__::__aligned__(alignof(T2))]] [[no_unique_address]] T1 Initializer1; \
+  [[no_unique_address]] __compressed_pair_padding<T1> __padding1_;             \
+  [[no_unique_address]] T2 Initializer2;                                       \
+  [[no_unique_address]] __compressed_pair_padding<T2> __padding2_;
+
+#define _LLDB_COMPRESSED_TRIPLE(T1, Initializer1, T2, Initializer2, T3,        \
+                                Initializer3)                                  \
+  [[using __gnu__: __aligned__(alignof(T2)),                                   \
+    __aligned__(alignof(T3))]] [[no_unique_address]] T1 Initializer1;          \
+  [[no_unique_address]] __compressed_pair_padding<T1> __padding1_;             \
+  [[no_unique_address]] T2 Initializer2;                                       \
+  [[no_unique_address]] __compressed_pair_padding<T2> __padding2_;             \
+  [[no_unique_address]] T3 Initializer3;                                       \
+  [[no_unique_address]] __compressed_pair_padding<T3> __padding3_;
+#elif COMPRESSED_PAIR_REV == 2
+#define _LLDB_COMPRESSED_PAIR(T1, Name1, T2, Name2)                            \
+  [[no_unique_address]] T1 Name1;                                              \
+  [[no_unique_address]] T2 Name2
+
+#define _LLDB_COMPRESSED_TRIPLE(T1, Name1, T2, Name2, T3, Name3)               \
+  [[no_unique_address]] T1 Name1;                                              \
+  [[no_unique_address]] T2 Name2;                                              \
+  [[no_unique_address]] T3 Name3
+#endif
 } // namespace __lldb
 } // namespace std
 

--- a/lldb/packages/Python/lldbsuite/test/make/libcxx-simulators-common/compressed_pair.h
+++ b/lldb/packages/Python/lldbsuite/test/make/libcxx-simulators-common/compressed_pair.h
@@ -53,10 +53,25 @@ public:
   _T1 &first() { return static_cast<_Base1 &>(*this).__get(); }
 };
 #elif COMPRESSED_PAIR_REV == 1
+// From libc++ datasizeof.h
+template <class _Tp> struct _FirstPaddingByte {
+  [[no_unique_address]] _Tp __v_;
+  char __first_padding_byte_;
+};
+
+template <class _Tp>
+inline const size_t __datasizeof_v =
+    __builtin_offsetof(_FirstPaddingByte<_Tp>, __first_padding_byte_);
+
+template <class _Tp>
+struct __lldb_is_final : public integral_constant<bool, __is_final(_Tp)> {};
+
 template <class _ToPad> class __compressed_pair_padding {
-  char __padding_[(is_empty<_ToPad>::value && !__libcpp_is_final<_ToPad>::value)
+  char __padding_[((is_empty<_ToPad>::value &&
+                    !__lldb_is_final<_ToPad>::value) ||
+                   is_reference<_ToPad>::value)
                       ? 0
-                      : sizeof(_ToPad) - __datasizeof(_ToPad)];
+                      : sizeof(_ToPad) - __datasizeof_v<_ToPad>];
 };
 
 #define _LLDB_COMPRESSED_PAIR(T1, Initializer1, T2, Initializer2)              \

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libcxx-simulators/string/TestDataFormatterLibcxxStringSimulator.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libcxx-simulators/string/TestDataFormatterLibcxxStringSimulator.py
@@ -28,12 +28,13 @@ class LibcxxStringDataFormatterSimulatorTestCase(TestBase):
 
 for v in [None, "ALTERNATE_LAYOUT"]:
     for r in range(5):
-        name = "test_r%d" % r
-        defines = ["REVISION=%d" % r]
-        if v:
-            name += "_" + v
-            defines += [v]
-        f = functools.partialmethod(
-            LibcxxStringDataFormatterSimulatorTestCase._run_test, defines
-        )
-        setattr(LibcxxStringDataFormatterSimulatorTestCase, name, f)
+        for c in range(3):
+            name = "test_r%d_c%d" % (r, c)
+            defines = ["REVISION=%d" % r, "COMPRESSED_PAIR_REV=%d" % c]
+            if v:
+                name += "_" + v
+                defines += [v]
+            f = functools.partialmethod(
+                LibcxxStringDataFormatterSimulatorTestCase._run_test, defines
+            )
+            setattr(LibcxxStringDataFormatterSimulatorTestCase, name, f)

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libcxx-simulators/string/main.cpp
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libcxx-simulators/string/main.cpp
@@ -184,16 +184,26 @@ public:
     };
   };
 
+  __long &getLongRep() {
+#if COMPRESSED_PAIR_REV == 0
+    return __r_.first().__l
+#elif COMPRESSED_PAIR_REV <= 2
+    return __rep_.__l;
+#endif
+  }
+
+  __short &getShortRep() {
+#if COMPRESSED_PAIR_REV == 0
+    return __r_.first().__s
+#elif COMPRESSED_PAIR_REV <= 2
+    return __rep_.__s;
+#endif
+  }
+
 #if COMPRESSED_PAIR_REV == 0
   std::__lldb::__compressed_pair<__rep, allocator_type> __r_;
-#define __R_ __r_
-#define __R_L __r_.first().__l
-#define __R_S __r_.first().__s
 #elif COMPRESSED_PAIR_REV <= 2
   _LLDB_COMPRESSED_PAIR(__rep, __rep_, allocator_type, __alloc_);
-#define __R_ __rep_
-#define __R_L __rep_.__l
-#define __R_S __rep_.__s
 #endif
 
 public:
@@ -201,23 +211,23 @@ public:
   basic_string(unsigned char __size, const value_type (&__data)[__N]) {
     static_assert(__N < __min_cap, "");
 #ifdef BITMASKS
-    __R_S.__size_ = __size << __short_shift;
+    getShortRep().__size_ = __size << __short_shift;
 #else
-    __R_S.__size_ = __size;
-    __R_S.__is_long_ = false;
+    getShortRep().__size_ = __size;
+    getShortRep().__is_long_ = false;
 #endif
     for (size_t __i = 0; __i < __N; ++__i)
-      __R_S.__data_[__i] = __data[__i];
+      getShortRep().__data_[__i] = __data[__i];
   }
   basic_string(size_t __cap, size_type __size, pointer __data) {
 #ifdef BITMASKS
-    __R_L.__cap_ = __cap | __long_mask;
+    getLongRep().__cap_ = __cap | __long_mask;
 #else
-    __R_L.__cap_ = __cap / __endian_factor;
-    __R_L.__is_long_ = true;
+    getLongRep().__cap_ = __cap / __endian_factor;
+    getLongRep().__is_long_ = true;
 #endif
-    __R_L.__size_ = __size;
-    __R_L.__data_ = __data;
+    getLongRep().__size_ = __size;
+    getLongRep().__data_ = __data;
   }
 };
 

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libcxx-simulators/string/main.cpp
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libcxx-simulators/string/main.cpp
@@ -186,7 +186,7 @@ public:
 
   __long &getLongRep() {
 #if COMPRESSED_PAIR_REV == 0
-    return __r_.first().__l
+    return __r_.first().__l;
 #elif COMPRESSED_PAIR_REV <= 2
     return __rep_.__l;
 #endif
@@ -194,7 +194,7 @@ public:
 
   __short &getShortRep() {
 #if COMPRESSED_PAIR_REV == 0
-    return __r_.first().__s
+    return __r_.first().__s;
 #elif COMPRESSED_PAIR_REV <= 2
     return __rep_.__s;
 #endif

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libcxx-simulators/string/main.cpp
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libcxx-simulators/string/main.cpp
@@ -184,31 +184,40 @@ public:
     };
   };
 
+#if COMPRESSED_PAIR_REV == 0
   std::__lldb::__compressed_pair<__rep, allocator_type> __r_;
+#define __R_ __r_
+#define __R_L __r_.first().__l
+#define __R_S __r_.first().__s
+#elif COMPRESSED_PAIR_REV <= 2
+  _LLDB_COMPRESSED_PAIR(__rep, __rep_, allocator_type, __alloc_);
+#define __R_ __rep_
+#define __R_L __rep_.__l
+#define __R_S __rep_.__s
+#endif
 
 public:
   template <size_t __N>
-  basic_string(unsigned char __size, const value_type (&__data)[__N])
-      : __r_({}, {}) {
+  basic_string(unsigned char __size, const value_type (&__data)[__N]) {
     static_assert(__N < __min_cap, "");
 #ifdef BITMASKS
-    __r_.first().__s.__size_ = __size << __short_shift;
+    __R_S.__size_ = __size << __short_shift;
 #else
-    __r_.first().__s.__size_ = __size;
-    __r_.first().__s.__is_long_ = false;
+    __R_S.__size_ = __size;
+    __R_S.__is_long_ = false;
 #endif
     for (size_t __i = 0; __i < __N; ++__i)
-      __r_.first().__s.__data_[__i] = __data[__i];
+      __R_S.__data_[__i] = __data[__i];
   }
-  basic_string(size_t __cap, size_type __size, pointer __data) : __r_({}, {}) {
+  basic_string(size_t __cap, size_type __size, pointer __data) {
 #ifdef BITMASKS
-    __r_.first().__l.__cap_ = __cap | __long_mask;
+    __R_L.__cap_ = __cap | __long_mask;
 #else
-    __r_.first().__l.__cap_ = __cap / __endian_factor;
-    __r_.first().__l.__is_long_ = true;
+    __R_L.__cap_ = __cap / __endian_factor;
+    __R_L.__is_long_ = true;
 #endif
-    __r_.first().__l.__size_ = __size;
-    __r_.first().__l.__data_ = __data;
+    __R_L.__size_ = __size;
+    __R_L.__data_ = __data;
   }
 };
 

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libcxx-simulators/unique_ptr/TestDataFormatterLibcxxUniquePtrSimulator.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libcxx-simulators/unique_ptr/TestDataFormatterLibcxxUniquePtrSimulator.py
@@ -7,13 +7,15 @@ import lldb
 from lldbsuite.test.decorators import *
 from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
+import functools
 
 
 class LibcxxUniquePtrDataFormatterSimulatorTestCase(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
 
-    def test(self):
-        self.build()
+    def _run_test(self, defines):
+        cxxflags_extras = " ".join(["-D%s" % d for d in defines])
+        self.build(dictionary=dict(CXXFLAGS_EXTRAS=cxxflags_extras))
         lldbutil.run_to_source_breakpoint(
             self, "Break here", lldb.SBFileSpec("main.cpp")
         )
@@ -22,3 +24,11 @@ class LibcxxUniquePtrDataFormatterSimulatorTestCase(TestBase):
         self.expect(
             "frame variable var_with_deleter_up", substrs=["pointer =", "deleter ="]
         )
+
+for r in range(3):
+    name = "test_r%d" % r
+    defines = ["COMPRESSED_PAIR_REV=%d" % r]
+    f = functools.partialmethod(
+        LibcxxUniquePtrDataFormatterSimulatorTestCase._run_test, defines
+    )
+    setattr(LibcxxUniquePtrDataFormatterSimulatorTestCase, name, f)

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libcxx-simulators/unique_ptr/TestDataFormatterLibcxxUniquePtrSimulator.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libcxx-simulators/unique_ptr/TestDataFormatterLibcxxUniquePtrSimulator.py
@@ -25,6 +25,7 @@ class LibcxxUniquePtrDataFormatterSimulatorTestCase(TestBase):
             "frame variable var_with_deleter_up", substrs=["pointer =", "deleter ="]
         )
 
+
 for r in range(3):
     name = "test_r%d" % r
     defines = ["COMPRESSED_PAIR_REV=%d" % r]

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libcxx-simulators/unique_ptr/main.cpp
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libcxx-simulators/unique_ptr/main.cpp
@@ -16,9 +16,14 @@ public:
   typedef _Dp deleter_type;
   typedef _Tp *pointer;
 
+#if COMPRESSED_PAIR_REV == 0
   std::__lldb::__compressed_pair<pointer, deleter_type> __ptr_;
   explicit unique_ptr(pointer __p) noexcept
       : __ptr_(__p, std::__lldb::__value_init_tag()) {}
+#elif COMPRESSED_PAIR_REV == 1 || COMPRESSED_PAIR_REV == 2
+  _LLDB_COMPRESSED_PAIR(pointer, __ptr_, deleter_type, __deleter_);
+  explicit unique_ptr(pointer __p) noexcept : __ptr_(__p), __deleter_() {}
+#endif
 };
 } // namespace __lldb
 } // namespace std


### PR DESCRIPTION
This is a follow-up to https://github.com/llvm/llvm-project/pull/98330 for the upcoming `__compressed_pair` refactor in https://github.com/llvm/llvm-project/issues/93069

This patch just adds the 2 new copies of `_LIBCPP_COMPRESSED_PAIR` layouts to the simulator tests.