### PR TITLE
ConstraintElimination: use DynamicAPInt

### DIFF
--- a/llvm/test/Transforms/ConstraintElimination/constraint-overflow.ll
+++ b/llvm/test/Transforms/ConstraintElimination/constraint-overflow.ll
@@ -13,8 +13,7 @@ define i32 @f(i64 %a3, i64 %numElements) {
 ; CHECK-NEXT:    [[CMP:%.*]] = icmp ugt i64 [[A1]], [[A3]]
 ; CHECK-NEXT:    br i1 [[CMP]], label [[IF_END_I:%.*]], label [[ABORT:%.*]]
 ; CHECK:       if.end.i:
-; CHECK-NEXT:    [[CMP2_NOT_I:%.*]] = icmp ult i64 [[A1]], [[A3]]
-; CHECK-NEXT:    br i1 [[CMP2_NOT_I]], label [[ABORT]], label [[EXIT:%.*]]
+; CHECK-NEXT:    br i1 false, label [[ABORT]], label [[EXIT:%.*]]
 ; CHECK:       abort:
 ; CHECK-NEXT:    ret i32 -1
 ; CHECK:       exit:

--- a/llvm/test/Transforms/ConstraintElimination/overflows.ll
+++ b/llvm/test/Transforms/ConstraintElimination/overflows.ll
@@ -23,8 +23,7 @@ define i1 @test_overflow_in_negate_constraint(i8 %x, i64 %y) {
 ; CHECK-NEXT:  bb:
 ; CHECK-NEXT:    [[ZEXT:%.*]] = zext i8 [[X]] to i64
 ; CHECK-NEXT:    [[SHL:%.*]] = shl nuw nsw i64 [[ZEXT]], 63
-; CHECK-NEXT:    [[ICMP:%.*]] = icmp uge i64 [[Y]], [[SHL]]
-; CHECK-NEXT:    ret i1 [[ICMP]]
+; CHECK-NEXT:    ret i1 true
 ;
 bb:
   %zext = zext i8 %x to i64

--- a/llvm/unittests/Analysis/ConstraintSystemTest.cpp
+++ b/llvm/unittests/Analysis/ConstraintSystemTest.cpp
@@ -7,21 +7,31 @@
 //===----------------------------------------------------------------------===//
 
 #include "llvm/Analysis/ConstraintSystem.h"
+#include "llvm/ADT/DynamicAPInt.h"
+#include "llvm/ADT/SmallVector.h"
 #include "gtest/gtest.h"
+#include <initializer_list>
 
 using namespace llvm;
 
 namespace {
+SmallVector<DynamicAPInt> toDynamicAPIntVec(std::initializer_list<int64_t> IL) {
+  SmallVector<DynamicAPInt> Ret;
+  Ret.reserve(IL.size());
+  for (auto El : IL)
+    Ret.emplace_back(El);
+  return Ret;
+}
 
 TEST(ConstraintSolverTest, TestSolutionChecks) {
   {
     ConstraintSystem CS;
     // x + y <= 10, x >= 5, y >= 6, x <= 10, y <= 10
-    CS.addVariableRow({10, 1, 1});
-    CS.addVariableRow({-5, -1, 0});
-    CS.addVariableRow({-6, 0, -1});
-    CS.addVariableRow({10, 1, 0});
-    CS.addVariableRow({10, 0, 1});
+    CS.addVariableRow(toDynamicAPIntVec({10, 1, 1}));
+    CS.addVariableRow(toDynamicAPIntVec({-5, -1, 0}));
+    CS.addVariableRow(toDynamicAPIntVec({-6, 0, -1}));
+    CS.addVariableRow(toDynamicAPIntVec({10, 1, 0}));
+    CS.addVariableRow(toDynamicAPIntVec({10, 0, 1}));
 
     EXPECT_FALSE(CS.mayHaveSolution());
   }
@@ -29,11 +39,11 @@ TEST(ConstraintSolverTest, TestSolutionChecks) {
   {
     ConstraintSystem CS;
     // x + y <= 10, x >= 2, y >= 3, x <= 10, y <= 10
-    CS.addVariableRow({10, 1, 1});
-    CS.addVariableRow({-2, -1, 0});
-    CS.addVariableRow({-3, 0, -1});
-    CS.addVariableRow({10, 1, 0});
-    CS.addVariableRow({10, 0, 1});
+    CS.addVariableRow(toDynamicAPIntVec({10, 1, 1}));
+    CS.addVariableRow(toDynamicAPIntVec({-2, -1, 0}));
+    CS.addVariableRow(toDynamicAPIntVec({-3, 0, -1}));
+    CS.addVariableRow(toDynamicAPIntVec({10, 1, 0}));
+    CS.addVariableRow(toDynamicAPIntVec({10, 0, 1}));
 
     EXPECT_TRUE(CS.mayHaveSolution());
   }
@@ -41,9 +51,9 @@ TEST(ConstraintSolverTest, TestSolutionChecks) {
   {
     ConstraintSystem CS;
     // x + y <= 10, x >= 10, y >= 10; does not have a solution.
-    CS.addVariableRow({10, 1, 1});
-    CS.addVariableRow({-10, -1, 0});
-    CS.addVariableRow({-10, 0, -1});
+    CS.addVariableRow(toDynamicAPIntVec({10, 1, 1}));
+    CS.addVariableRow(toDynamicAPIntVec({-10, -1, 0}));
+    CS.addVariableRow(toDynamicAPIntVec({-10, 0, -1}));
 
     EXPECT_FALSE(CS.mayHaveSolution());
   }
@@ -51,9 +61,9 @@ TEST(ConstraintSolverTest, TestSolutionChecks) {
   {
     ConstraintSystem CS;
     // x + y >= 20, 10 >= x, 10 >= y; does HAVE a solution.
-    CS.addVariableRow({-20, -1, -1});
-    CS.addVariableRow({-10, -1, 0});
-    CS.addVariableRow({-10, 0, -1});
+    CS.addVariableRow(toDynamicAPIntVec({-20, -1, -1}));
+    CS.addVariableRow(toDynamicAPIntVec({-10, -1, 0}));
+    CS.addVariableRow(toDynamicAPIntVec({-10, 0, -1}));
 
     EXPECT_TRUE(CS.mayHaveSolution());
   }
@@ -62,9 +72,9 @@ TEST(ConstraintSolverTest, TestSolutionChecks) {
     ConstraintSystem CS;
 
     // 2x + y + 3z <= 10,  2x + y >= 10, y >= 1
-    CS.addVariableRow({10, 2, 1, 3});
-    CS.addVariableRow({-10, -2, -1, 0});
-    CS.addVariableRow({-1, 0, 0, -1});
+    CS.addVariableRow(toDynamicAPIntVec({10, 2, 1, 3}));
+    CS.addVariableRow(toDynamicAPIntVec({-10, -2, -1, 0}));
+    CS.addVariableRow(toDynamicAPIntVec({-1, 0, 0, -1}));
 
     EXPECT_FALSE(CS.mayHaveSolution());
   }
@@ -73,8 +83,8 @@ TEST(ConstraintSolverTest, TestSolutionChecks) {
     ConstraintSystem CS;
 
     // 2x + y + 3z <= 10,  2x + y >= 10
-    CS.addVariableRow({10, 2, 1, 3});
-    CS.addVariableRow({-10, -2, -1, 0});
+    CS.addVariableRow(toDynamicAPIntVec({10, 2, 1, 3}));
+    CS.addVariableRow(toDynamicAPIntVec({-10, -2, -1, 0}));
 
     EXPECT_TRUE(CS.mayHaveSolution());
   }
@@ -85,47 +95,47 @@ TEST(ConstraintSolverTest, IsConditionImplied) {
     // For the test below, we assume we know
     // x <= 5 && y <= 3
     ConstraintSystem CS;
-    CS.addVariableRow({5, 1, 0});
-    CS.addVariableRow({3, 0, 1});
+    CS.addVariableRow(toDynamicAPIntVec({5, 1, 0}));
+    CS.addVariableRow(toDynamicAPIntVec({3, 0, 1}));
 
     // x + y <= 6 does not hold.
-    EXPECT_FALSE(CS.isConditionImplied({6, 1, 1}));
+    EXPECT_FALSE(CS.isConditionImplied(toDynamicAPIntVec({6, 1, 1})));
     // x + y <= 7 does not hold.
-    EXPECT_FALSE(CS.isConditionImplied({7, 1, 1}));
+    EXPECT_FALSE(CS.isConditionImplied(toDynamicAPIntVec({7, 1, 1})));
     // x + y <= 8 does hold.
-    EXPECT_TRUE(CS.isConditionImplied({8, 1, 1}));
+    EXPECT_TRUE(CS.isConditionImplied(toDynamicAPIntVec({8, 1, 1})));
 
     // 2 * x + y <= 12 does hold.
-    EXPECT_FALSE(CS.isConditionImplied({12, 2, 1}));
+    EXPECT_FALSE(CS.isConditionImplied(toDynamicAPIntVec({12, 2, 1})));
     // 2 * x + y <= 13 does hold.
-    EXPECT_TRUE(CS.isConditionImplied({13, 2, 1}));
+    EXPECT_TRUE(CS.isConditionImplied(toDynamicAPIntVec({13, 2, 1})));
 
     //  x + y <= 12 does hold.
-    EXPECT_FALSE(CS.isConditionImplied({12, 2, 1}));
+    EXPECT_FALSE(CS.isConditionImplied(toDynamicAPIntVec({12, 2, 1})));
     // 2 * x + y <= 13 does hold.
-    EXPECT_TRUE(CS.isConditionImplied({13, 2, 1}));
+    EXPECT_TRUE(CS.isConditionImplied(toDynamicAPIntVec({13, 2, 1})));
 
     // x <= y == x - y <= 0 does not hold.
-    EXPECT_FALSE(CS.isConditionImplied({0, 1, -1}));
+    EXPECT_FALSE(CS.isConditionImplied(toDynamicAPIntVec({0, 1, -1})));
     // y <= x == -x + y <= 0 does not hold.
-    EXPECT_FALSE(CS.isConditionImplied({0, -1, 1}));
+    EXPECT_FALSE(CS.isConditionImplied(toDynamicAPIntVec({0, -1, 1})));
   }
 
   {
     // For the test below, we assume we know
     // x + 1 <= y + 1 == x - y <= 0
     ConstraintSystem CS;
-    CS.addVariableRow({0, 1, -1});
+    CS.addVariableRow(toDynamicAPIntVec({0, 1, -1}));
 
     // x <= y == x - y <= 0 does hold.
-    EXPECT_TRUE(CS.isConditionImplied({0, 1, -1}));
+    EXPECT_TRUE(CS.isConditionImplied(toDynamicAPIntVec({0, 1, -1})));
     // y <= x == -x + y <= 0 does not hold.
-    EXPECT_FALSE(CS.isConditionImplied({0, -1, 1}));
+    EXPECT_FALSE(CS.isConditionImplied(toDynamicAPIntVec({0, -1, 1})));
 
     // x <= y + 10 == x - y <= 10 does hold.
-    EXPECT_TRUE(CS.isConditionImplied({10, 1, -1}));
+    EXPECT_TRUE(CS.isConditionImplied(toDynamicAPIntVec({10, 1, -1})));
     // x + 10 <= y == x - y <= -10 does NOT hold.
-    EXPECT_FALSE(CS.isConditionImplied({-10, 1, -1}));
+    EXPECT_FALSE(CS.isConditionImplied(toDynamicAPIntVec({-10, 1, -1})));
   }
 
   {
@@ -133,21 +143,22 @@ TEST(ConstraintSolverTest, IsConditionImplied) {
     // x <= y == x - y <= 0
     // y <= z == y - x <= 0
     ConstraintSystem CS;
-    CS.addVariableRow({0, 1, -1, 0});
-    CS.addVariableRow({0, 0, 1, -1});
+    CS.addVariableRow(toDynamicAPIntVec({0, 1, -1, 0}));
+    CS.addVariableRow(toDynamicAPIntVec({0, 0, 1, -1}));
 
     // z <= y == -y + z <= 0 does not hold.
-    EXPECT_FALSE(CS.isConditionImplied({0, 0, -1, 1}));
+    EXPECT_FALSE(CS.isConditionImplied(toDynamicAPIntVec({0, 0, -1, 1})));
     // x <= z == x - z <= 0 does hold.
-    EXPECT_TRUE(CS.isConditionImplied({0, 1, 0, -1}));
+    EXPECT_TRUE(CS.isConditionImplied(toDynamicAPIntVec({0, 1, 0, -1})));
   }
 }
 
 TEST(ConstraintSolverTest, IsConditionImpliedOverflow) {
   ConstraintSystem CS;
-  // Make sure isConditionImplied returns false when there is an overflow.
+  // Make sure overflows are automatically handled by DynamicAPInt.
   int64_t Limit = std::numeric_limits<int64_t>::max();
-  CS.addVariableRow({Limit - 1, Limit - 2, Limit - 3});
-  EXPECT_FALSE(CS.isConditionImplied({Limit - 1, Limit - 2, Limit - 3}));
+  CS.addVariableRow(toDynamicAPIntVec({Limit - 1, Limit - 2, Limit - 3}));
+  EXPECT_TRUE(CS.isConditionImplied(
+      toDynamicAPIntVec({Limit - 1, Limit - 2, Limit - 3})));
 }
 } // namespace


### PR DESCRIPTION
To automatically handle overflows correctly and make the transform more powerful, replace uses of int64_t with DynamicAPInt in ConstraintElimination and ConstraintSystem.