### PR TITLE
[lldb] add RISCV target specific info in API tests

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/lldbplatformutil.py
+++ b/lldb/packages/Python/lldbsuite/test/lldbplatformutil.py
@@ -34,6 +34,8 @@ def check_first_register_readable(test_case):
         test_case.expect("register read r0", substrs=["r0 = 0x"])
     elif arch in ["powerpc64le"]:
         test_case.expect("register read r0", substrs=["r0 = 0x"])
+    elif re.match("^rv(32|64)", arch):
+        test_case.expect("register read zero", substrs=["zero = 0x"])
     else:
         # TODO: Add check for other architectures
         test_case.fail(


### PR DESCRIPTION
Add information about RISCV first register in python API testsuite, that is used to check register readability in tests.

Fixed tests on RISCV target:

TestBreakpointByFileColonLine.BreakpointByLineAndColumnTestCase TestAddressBreakpoints.AddressBreakpointTestCase
TestBreakpointAutoContinue.BreakpointAutoContinue
TestInterruptBacktrace.TestInterruptingBacktrace
TestBadAddressBreakpoints.BadAddressBreakpointTestCase TestScriptedResolver.TestScriptedResolver
TestStopHookScripted.TestStopHooks
TestBreakpointConditions.BreakpointConditionsTestCase TestLocalVariables.LocalVariablesTestCase
TestFindLineEntry.FindLineEntry
TestScriptedResolver.TestScriptedResolver
TestInlineSourceFiles.InlineSourceFilesTestCase
TestModuleAndSection.ModuleAndSectionAPIsTestCase
TestFrameVar.TestFrameVar
TestInferiorAssert.AssertingInferiorTestCase
TestInferiorCrashing.CrashingInferiorTestCase
TestInferiorCrashingStep.CrashingInferiorStepTestCase TestRegistersIterator.RegistersIteratorTestCase
TestCoroutineHandle.TestCoroutineHandle
TestWithLimitDebugInfo.TestWithLimitDebugInfo
TestLLDBIterator.LLDBIteratorTestCase
TestMemoryWrite.MemoryWriteTestCase
TestNestedTemplate.NestedTemplateTestCase
TestParrayVrsCharArrayChild.TestParrayVrsCharArrayChild TestRecursiveInferior.CrashingRecursiveInferiorTestCase TestRecursiveInferiorStep.CrashingRecursiveInferiorStepTestCase TestRunLocker.TestRunLocker
TestSampleTest.RenameThisSampleTestTestCase
TestUniqueTypes3.UniqueTypesTestCase3
TestPrintStackTraces.ThreadsStackTracesTestCase
TestUnicodeSymbols.TestUnicodeSymbols
TestUnusedInlinedParameters.TestUnusedInlinedParameters TestValueVarUpdate.ValueVarUpdateTestCase
TestPtrRef2Typedef.PtrRef2TypedefTestCase
TestDataFormatterStdIterator.StdIteratorDataFormatterTestCase TestDataFormatterStdString.StdStringDataFormatterTestCase TestDataFormatterStdVBool.StdVBoolDataFormatterTestCase