### PR TITLE
[lldb] IRMemoryMap zero address mapping fix

### DIFF
--- a/lldb/source/Expression/IRMemoryMap.cpp
+++ b/lldb/source/Expression/IRMemoryMap.cpp
@@ -126,6 +126,10 @@ lldb::addr_t IRMemoryMap::FindSpace(size_t size) {
           } else {
             ret = region_info.GetRange().GetRangeEnd();
           }
+        } else if (ret == 0x0) {
+          // Get other region if zero address. Should't map zero address to
+          // get an error in cases when user tries to dereference nullptr
+          ret = region_info.GetRange().GetRangeEnd();
         } else if (ret + size < region_info.GetRange().GetRangeEnd()) {
           return ret;
         } else {


### PR DESCRIPTION
Some tests check error receiving after nullptr dereference during lldb exression. On RISCV targets IRMemoryMap could map zero address during allocations taking into account that host process doesn't dereference nullptr during normal workflow making dereference of zero address valid. This patch adds a check to avoid cases like this.

Fixed tests for RISCV target:

TestEnumTypes.EnumTypesTestCase
TestAnonymous.AnonymousTestCase