### PR TITLE
[compiler-rt] Add `DumpAllRegisters` impl

### DIFF
--- a/compiler-rt/lib/sanitizer_common/sanitizer_linux.cpp
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_linux.cpp
@@ -2118,6 +2118,7 @@ bool SignalContext::IsTrueFaultingAddress() const {
   return si->si_signo == SIGSEGV && si->si_code != 128;
 }
 
+UNUSED
 static const char *RegNumToRegName(int reg) {
 #  if defined(__x86_64__)
   switch (reg) {
@@ -2199,6 +2200,7 @@ void SignalContext::DumpAllRegisters(void *context) {
   DUMPREG(REG_R15);
   Printf("\n");
 #    endif
+  (void)ucontext;
 #  endif
   // FIXME: Implement this for other OSes and architectures.
 }

--- a/compiler-rt/lib/sanitizer_common/sanitizer_linux.cpp
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_linux.cpp
@@ -2118,8 +2118,89 @@ bool SignalContext::IsTrueFaultingAddress() const {
   return si->si_signo == SIGSEGV && si->si_code != 128;
 }
 
+static const char *RegNumToRegName(int reg) {
+#  if defined(__x86_64__)
+  switch (reg) {
+    case REG_RAX:
+      return "rax";
+    case REG_RBX:
+      return "rbx";
+    case REG_RCX:
+      return "rcx";
+    case REG_RDX:
+      return "rdx";
+    case REG_RDI:
+      return "rdi";
+    case REG_RSI:
+      return "rsi";
+    case REG_RBP:
+      return "rbp";
+    case REG_RSP:
+      return "rsp";
+    case REG_R8:
+      return "r8";
+    case REG_R9:
+      return "r9";
+    case REG_R10:
+      return "r10";
+    case REG_R11:
+      return "r11";
+    case REG_R12:
+      return "r12";
+    case REG_R13:
+      return "r13";
+    case REG_R14:
+      return "r14";
+    case REG_R15:
+      return "r15";
+    default:
+      return NULL;
+  }
+#  endif
+  return NULL;
+}
+
 void SignalContext::DumpAllRegisters(void *context) {
-  // FIXME: Implement this.
+#  if SANITIZER_LINUX
+  ucontext_t *ucontext = (ucontext_t *)context;
+#    define DUMPREG64(r)                             \
+      Printf("%s = 0x%016llx  ", RegNumToRegName(r), \
+             ucontext->uc_mcontext.gregs[r]);
+#    define DUMPREG_(r) \
+      Printf(" ");      \
+      DUMPREG(r);
+#    define DUMPREG__(r) \
+      Printf("  ");      \
+      DUMPREG(r);
+#    define DUMPREG___(r) \
+      Printf("   ");      \
+      DUMPREG(r);
+#    if defined(__x86_64__)
+#      define DUMPREG(r) DUMPREG64(r)
+  Report("Register values:\n");
+  DUMPREG(REG_RAX);
+  DUMPREG(REG_RBX);
+  DUMPREG(REG_RCX);
+  DUMPREG(REG_RDX);
+  Printf("\n");
+  DUMPREG(REG_RDI);
+  DUMPREG(REG_RSI);
+  DUMPREG(REG_RBP);
+  DUMPREG(REG_RSP);
+  Printf("\n");
+  DUMPREG_(REG_R8);
+  DUMPREG_(REG_R9);
+  DUMPREG(REG_R10);
+  DUMPREG(REG_R11);
+  Printf("\n");
+  DUMPREG(REG_R12);
+  DUMPREG(REG_R13);
+  DUMPREG(REG_R14);
+  DUMPREG(REG_R15);
+  Printf("\n");
+#    endif
+#  endif
+  // FIXME: Implement this for other OSes and architectures.
 }
 
 static void GetPcSpBp(void *context, uptr *pc, uptr *sp, uptr *bp) {

--- a/compiler-rt/lib/sanitizer_common/sanitizer_linux.cpp
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_linux.cpp
@@ -2120,84 +2120,115 @@ bool SignalContext::IsTrueFaultingAddress() const {
 
 UNUSED
 static const char *RegNumToRegName(int reg) {
-#  if defined(__x86_64__)
   switch (reg) {
-    case REG_RAX:
-      return "rax";
-    case REG_RBX:
-      return "rbx";
-    case REG_RCX:
-      return "rcx";
-    case REG_RDX:
-      return "rdx";
-    case REG_RDI:
-      return "rdi";
-    case REG_RSI:
-      return "rsi";
-    case REG_RBP:
-      return "rbp";
-    case REG_RSP:
-      return "rsp";
-    case REG_R8:
-      return "r8";
-    case REG_R9:
-      return "r9";
-    case REG_R10:
-      return "r10";
-    case REG_R11:
-      return "r11";
-    case REG_R12:
-      return "r12";
-    case REG_R13:
-      return "r13";
-    case REG_R14:
-      return "r14";
-    case REG_R15:
-      return "r15";
-    default:
-      return NULL;
+#if defined(__x86_64__)
+  case REG_RAX:
+    return "rax";
+  case REG_RBX:
+    return "rbx";
+  case REG_RCX:
+    return "rcx";
+  case REG_RDX:
+    return "rdx";
+  case REG_RDI:
+    return "rdi";
+  case REG_RSI:
+    return "rsi";
+  case REG_RBP:
+    return "rbp";
+  case REG_RSP:
+    return "rsp";
+  case REG_R8:
+    return "r8";
+  case REG_R9:
+    return "r9";
+  case REG_R10:
+    return "r10";
+  case REG_R11:
+    return "r11";
+  case REG_R12:
+    return "r12";
+  case REG_R13:
+    return "r13";
+  case REG_R14:
+    return "r14";
+  case REG_R15:
+    return "r15";
+#elif defined(__i386__)
+  case REG_EAX:
+    return "eax";
+  case REG_EBX:
+    return "ebx";
+  case REG_ECX:
+    return "ecx";
+  case REG_EDX:
+    return "edx";
+  case REG_EDI:
+    return "edi";
+  case REG_ESI:
+    return "esi";
+  case REG_EBP:
+    return "ebp";
+  case REG_ESP:
+    return "esp";
+#endif
+  default:
+    return NULL;
   }
-#  endif
   return NULL;
+}
+
+UNUSED
+static ALWAYS_INLINE void DumpSingleReg(ucontext_t *ctx, int RegNum) {
+  const char *RegName = RegNumToRegName(RegNum);
+#if defined(__x86_64__)
+  Printf("%s%s = 0x%016llx  ", internal_strlen(RegName) == 2 ? " " : "",
+         RegName, ctx->uc_mcontext.gregs[RegNum]);
+#elif defined(__i386__)
+  Printf("%s = 0x%08x  ", RegName, ctx->uc_mcontext.gregs[RegNum]);
+#endif
 }
 
 void SignalContext::DumpAllRegisters(void *context) {
 #  if SANITIZER_LINUX
   ucontext_t *ucontext = (ucontext_t *)context;
-#    define DUMPREG64(r)                             \
-      Printf("%s = 0x%016llx  ", RegNumToRegName(r), \
-             ucontext->uc_mcontext.gregs[r]);
-#    define DUMPREG_(r) \
-      Printf(" ");      \
-      DUMPREG(r);
-#    define DUMPREG__(r) \
-      Printf("  ");      \
-      DUMPREG(r);
-#    define DUMPREG___(r) \
-      Printf("   ");      \
-      DUMPREG(r);
-#    if defined(__x86_64__)
-#      define DUMPREG(r) DUMPREG64(r)
+#if defined(__x86_64__)
   Report("Register values:\n");
-  DUMPREG(REG_RAX);
-  DUMPREG(REG_RBX);
-  DUMPREG(REG_RCX);
-  DUMPREG(REG_RDX);
+  DumpSingleReg(ucontext, REG_RAX);
+  DumpSingleReg(ucontext, REG_RBX);
+  DumpSingleReg(ucontext, REG_RCX);
+  DumpSingleReg(ucontext, REG_RDX);
   Printf("\n");
-  DUMPREG(REG_RDI);
-  DUMPREG(REG_RSI);
-  DUMPREG(REG_RBP);
-  DUMPREG(REG_RSP);
+  DumpSingleReg(ucontext, REG_RDI);
+  DumpSingleReg(ucontext, REG_RSI);
+  DumpSingleReg(ucontext, REG_RBP);
+  DumpSingleReg(ucontext, REG_RSP);
   Printf("\n");
-  DUMPREG_(REG_R8);
-  DUMPREG_(REG_R9);
-  DUMPREG(REG_R10);
-  DUMPREG(REG_R11);
+  DumpSingleReg(ucontext, REG_R8);
+  DumpSingleReg(ucontext, REG_R9);
+  DumpSingleReg(ucontext, REG_R10);
+  DumpSingleReg(ucontext, REG_R11);
   Printf("\n");
-  DUMPREG(REG_R12);
-  DUMPREG(REG_R13);
-  DUMPREG(REG_R14);
-  DUMPREG(REG_R15);
+  DumpSingleReg(ucontext, REG_R12);
+  DumpSingleReg(ucontext, REG_R13);
+  DumpSingleReg(ucontext, REG_R14);
+  DumpSingleReg(ucontext, REG_R15);
+  Printf("\n");
+#elif defined(__i386__)
+  // Duplication of this report print is caused by partial support
+  // of register values dumping. In case of unsupported yet architecture let's
+  // avoid printing 'Register values:' without actual values in the following
+  // output.
+  Report("Register values:\n");
+  DumpSingleReg(ucontext, REG_EAX);
+  DumpSingleReg(ucontext, REG_EBX);
+  DumpSingleReg(ucontext, REG_ECX);
+  DumpSingleReg(ucontext, REG_EDX);
+  Printf("\n");
+  DumpSingleReg(ucontext, REG_EDI);
+  DumpSingleReg(ucontext, REG_ESI);
+  DumpSingleReg(ucontext, REG_EBP);
+  DumpSingleReg(ucontext, REG_ESP);
   Printf("\n");
 #    endif
   (void)ucontext;

--- a/compiler-rt/lib/sanitizer_common/sanitizer_linux.cpp
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_linux.cpp
@@ -2179,7 +2179,7 @@ static const char *RegNumToRegName(int reg) {
 }
 
 UNUSED
-static ALWAYS_INLINE void DumpSingleReg(ucontext_t *ctx, int RegNum) {
+static void DumpSingleReg(ucontext_t *ctx, int RegNum) {
   const char *RegName = RegNumToRegName(RegNum);
 #  if defined(__x86_64__)
   Printf("%s%s = 0x%016llx  ", internal_strlen(RegName) == 2 ? " " : "",

--- a/compiler-rt/lib/sanitizer_common/sanitizer_linux.cpp
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_linux.cpp
@@ -2121,59 +2121,59 @@ bool SignalContext::IsTrueFaultingAddress() const {
 UNUSED
 static const char *RegNumToRegName(int reg) {
   switch (reg) {
-#if defined(__x86_64__)
-  case REG_RAX:
-    return "rax";
-  case REG_RBX:
-    return "rbx";
-  case REG_RCX:
-    return "rcx";
-  case REG_RDX:
-    return "rdx";
-  case REG_RDI:
-    return "rdi";
-  case REG_RSI:
-    return "rsi";
-  case REG_RBP:
-    return "rbp";
-  case REG_RSP:
-    return "rsp";
-  case REG_R8:
-    return "r8";
-  case REG_R9:
-    return "r9";
-  case REG_R10:
-    return "r10";
-  case REG_R11:
-    return "r11";
-  case REG_R12:
-    return "r12";
-  case REG_R13:
-    return "r13";
-  case REG_R14:
-    return "r14";
-  case REG_R15:
-    return "r15";
-#elif defined(__i386__)
-  case REG_EAX:
-    return "eax";
-  case REG_EBX:
-    return "ebx";
-  case REG_ECX:
-    return "ecx";
-  case REG_EDX:
-    return "edx";
-  case REG_EDI:
-    return "edi";
-  case REG_ESI:
-    return "esi";
-  case REG_EBP:
-    return "ebp";
-  case REG_ESP:
-    return "esp";
-#endif
-  default:
-    return NULL;
+#  if defined(__x86_64__)
+    case REG_RAX:
+      return "rax";
+    case REG_RBX:
+      return "rbx";
+    case REG_RCX:
+      return "rcx";
+    case REG_RDX:
+      return "rdx";
+    case REG_RDI:
+      return "rdi";
+    case REG_RSI:
+      return "rsi";
+    case REG_RBP:
+      return "rbp";
+    case REG_RSP:
+      return "rsp";
+    case REG_R8:
+      return "r8";
+    case REG_R9:
+      return "r9";
+    case REG_R10:
+      return "r10";
+    case REG_R11:
+      return "r11";
+    case REG_R12:
+      return "r12";
+    case REG_R13:
+      return "r13";
+    case REG_R14:
+      return "r14";
+    case REG_R15:
+      return "r15";
+#  elif defined(__i386__)
+    case REG_EAX:
+      return "eax";
+    case REG_EBX:
+      return "ebx";
+    case REG_ECX:
+      return "ecx";
+    case REG_EDX:
+      return "edx";
+    case REG_EDI:
+      return "edi";
+    case REG_ESI:
+      return "esi";
+    case REG_EBP:
+      return "ebp";
+    case REG_ESP:
+      return "esp";
+#  endif
+    default:
+      return NULL;
   }
   return NULL;
 }
@@ -2181,18 +2181,18 @@ static const char *RegNumToRegName(int reg) {
 UNUSED
 static ALWAYS_INLINE void DumpSingleReg(ucontext_t *ctx, int RegNum) {
   const char *RegName = RegNumToRegName(RegNum);
-#if defined(__x86_64__)
+#  if defined(__x86_64__)
   Printf("%s%s = 0x%016llx  ", internal_strlen(RegName) == 2 ? " " : "",
          RegName, ctx->uc_mcontext.gregs[RegNum]);
-#elif defined(__i386__)
+#  elif defined(__i386__)
   Printf("%s = 0x%08x  ", RegName, ctx->uc_mcontext.gregs[RegNum]);
-#endif
+#  endif
 }
 
 void SignalContext::DumpAllRegisters(void *context) {
 #  if SANITIZER_LINUX
   ucontext_t *ucontext = (ucontext_t *)context;
-#if defined(__x86_64__)
+#    if defined(__x86_64__)
   Report("Register values:\n");
   DumpSingleReg(ucontext, REG_RAX);
   DumpSingleReg(ucontext, REG_RBX);
@@ -2214,7 +2214,7 @@ void SignalContext::DumpAllRegisters(void *context) {
   DumpSingleReg(ucontext, REG_R14);
   DumpSingleReg(ucontext, REG_R15);
   Printf("\n");
-#elif defined(__i386__)
+#    elif defined(__i386__)
   // Duplication of this report print is caused by partial support
   // of register values dumping. In case of unsupported yet architecture let's
   // avoid printing 'Register values:' without actual values in the following

--- a/compiler-rt/test/sanitizer_common/TestCases/Linux/dump_registers_i386.cpp
+++ b/compiler-rt/test/sanitizer_common/TestCases/Linux/dump_registers_i386.cpp
@@ -1,0 +1,17 @@
+// Check that sanitizer prints registers dump_registers on dump_registers=1
+// RUN: %clangxx  %s -o %t
+// RUN: %env_tool_opts=dump_registers=0 not %run %t 2>&1 | FileCheck %s --check-prefix=CHECK-NODUMP
+// RUN: not %run %t 2>&1 | FileCheck %s --check-prefix=CHECK-DUMP
+//
+// REQUIRES: i386-target-arch
+
+#include <signal.h>
+
+int main() {
+  raise(SIGSEGV);
+  // CHECK-DUMP: Register values
+  // CHECK-DUMP-NEXT: eax = {{0x[0-9a-f]+}}  ebx = {{0x[0-9a-f]+}}  ecx = {{0x[0-9a-f]+}}  edx = {{0x[0-9a-f]+}}
+  // CHECK-DUMP-NEXT: edi = {{0x[0-9a-f]+}}  esi = {{0x[0-9a-f]+}}  ebp = {{0x[0-9a-f]+}}  esp = {{0x[0-9a-f]+}}
+  // CHECK-NODUMP-NOT: Register values
+  return 0;
+}

--- a/compiler-rt/test/sanitizer_common/TestCases/Linux/dump_registers_x86_64.cpp
+++ b/compiler-rt/test/sanitizer_common/TestCases/Linux/dump_registers_x86_64.cpp
@@ -1,0 +1,19 @@
+// Check that sanitizer prints registers dump_registers on dump_registers=1
+// RUN: %clangxx  %s -o %t
+// RUN: %env_tool_opts=dump_registers=0 not %run %t 2>&1 | FileCheck %s --check-prefix=CHECK-NODUMP
+// RUN: not %run %t 2>&1 | FileCheck %s --check-prefix=CHECK-DUMP
+//
+// REQUIRES: x86_64-target-arch
+
+#include <signal.h>
+
+int main() {
+  raise(SIGSEGV);
+  // CHECK-DUMP: Register values
+  // CHECK-DUMP-NEXT: rax = {{0x[0-9a-f]+}}  rbx = {{0x[0-9a-f]+}}  rcx = {{0x[0-9a-f]+}}  rdx = {{0x[0-9a-f]+}}
+  // CHECK-DUMP-NEXT: rdi = {{0x[0-9a-f]+}}  rsi = {{0x[0-9a-f]+}}  rbp = {{0x[0-9a-f]+}}  rsp = {{0x[0-9a-f]+}}
+  // CHECK-DUMP-NEXT:  r8 = {{0x[0-9a-f]+}}   r9 = {{0x[0-9a-f]+}}  r10 = {{0x[0-9a-f]+}}  r11 = {{0x[0-9a-f]+}}
+  // CHECK-DUMP-NEXT: r12 = {{0x[0-9a-f]+}}   r13 = {{0x[0-9a-f]+}} r14 = {{0x[0-9a-f]+}}  r15 = {{0x[0-9a-f]+}}
+  // CHECK-NODUMP-NOT: Register values
+  return 0;
+}

--- a/compiler-rt/test/sanitizer_common/TestCases/Posix/dump_registers.cpp
+++ b/compiler-rt/test/sanitizer_common/TestCases/Posix/dump_registers.cpp
@@ -1,16 +1,20 @@
 // Check that sanitizer prints registers dump_registers on dump_registers=1
 // RUN: %clangxx  %s -o %t
-// RUN: %env_tool_opts=dump_registers=0 %run %t 2>&1 | FileCheck %s --check-prefix=CHECK-NODUMP
-// RUN: %run %t 2>&1 | FileCheck %s --check-prefix=CHECK-DUMP
+// RUN: %env_tool_opts=dump_registers=0 not %run %t 2>&1 | FileCheck %s --check-prefix=CHECK-NODUMP
+// RUN: not %run %t 2>&1 | FileCheck %s --check-prefix=CHECK-DUMP
 //
-// FIXME: Implement.
-// XFAIL: *
+// FIXME: Implement for other OSes and architectures.
+// REQUIRES: x86_64-target-arch, linux
 
 #include <signal.h>
 
 int main() {
   raise(SIGSEGV);
   // CHECK-DUMP: Register values
+  // CHECK-DUMP-NEXT: rax = {{0x[0-9a-f]+}}  rbx = {{0x[0-9a-f]+}}  rcx = {{0x[0-9a-f]+}}  rdx = {{0x[0-9a-f]+}}
+  // CHECK-DUMP-NEXT: rdi = {{0x[0-9a-f]+}}  rsi = {{0x[0-9a-f]+}}  rbp = {{0x[0-9a-f]+}}  rsp = {{0x[0-9a-f]+}}
+  // CHECK-DUMP-NEXT:  r8 = {{0x[0-9a-f]+}}   r9 = {{0x[0-9a-f]+}}  r10 = {{0x[0-9a-f]+}}  r11 = {{0x[0-9a-f]+}}
+  // CHECK-DUMP-NEXT: r12 = {{0x[0-9a-f]+}}   r13 = {{0x[0-9a-f]+}} r14 = {{0x[0-9a-f]+}}  r15 = {{0x[0-9a-f]+}}
   // CHECK-NODUMP-NOT: Register values
   return 0;
 }

--- a/compiler-rt/test/sanitizer_common/TestCases/Posix/dump_registers.cpp
+++ b/compiler-rt/test/sanitizer_common/TestCases/Posix/dump_registers.cpp
@@ -1,20 +1,16 @@
 // Check that sanitizer prints registers dump_registers on dump_registers=1
 // RUN: %clangxx  %s -o %t
-// RUN: %env_tool_opts=dump_registers=0 not %run %t 2>&1 | FileCheck %s --check-prefix=CHECK-NODUMP
-// RUN: not %run %t 2>&1 | FileCheck %s --check-prefix=CHECK-DUMP
+// RUN: %env_tool_opts=dump_registers=0 %run %t 2>&1 | FileCheck %s --check-prefix=CHECK-NODUMP
+// RUN: %run %t 2>&1 | FileCheck %s --check-prefix=CHECK-DUMP
 //
-// FIXME: Implement for other OSes and architectures.
-// REQUIRES: x86_64-target-arch, linux
+// FIXME: Implement.
+// XFAIL: *
 
 #include <signal.h>
 
 int main() {
   raise(SIGSEGV);
   // CHECK-DUMP: Register values
-  // CHECK-DUMP-NEXT: rax = {{0x[0-9a-f]+}}  rbx = {{0x[0-9a-f]+}}  rcx = {{0x[0-9a-f]+}}  rdx = {{0x[0-9a-f]+}}
-  // CHECK-DUMP-NEXT: rdi = {{0x[0-9a-f]+}}  rsi = {{0x[0-9a-f]+}}  rbp = {{0x[0-9a-f]+}}  rsp = {{0x[0-9a-f]+}}
-  // CHECK-DUMP-NEXT:  r8 = {{0x[0-9a-f]+}}   r9 = {{0x[0-9a-f]+}}  r10 = {{0x[0-9a-f]+}}  r11 = {{0x[0-9a-f]+}}
-  // CHECK-DUMP-NEXT: r12 = {{0x[0-9a-f]+}}   r13 = {{0x[0-9a-f]+}} r14 = {{0x[0-9a-f]+}}  r15 = {{0x[0-9a-f]+}}
   // CHECK-NODUMP-NOT: Register values
   return 0;
 }


### PR DESCRIPTION
- Add implementation for x86_64 and linux
- Add test

The output is like

==XXYYZZ==Register values:
rax = 0x...  rbx = 0x...  rcx = 0x...  rdx = 0x...
rdi = 0x...  rsi = 0x...  rbp = 0x...  rsp = 0x...
 r8 = 0x...   r9 = 0x...  r10 = 0x...  r11 = 0x...
r12 = 0x...  r13 = 0x...  r14 = 0x...  r15 = 0x...
