### PR TITLE
[InstrRef][NFC] Avoid another DenseMap, use a sorted vector

### DIFF
--- a/llvm/lib/CodeGen/LiveDebugValues/InstrRefBasedImpl.cpp
+++ b/llvm/lib/CodeGen/LiveDebugValues/InstrRefBasedImpl.cpp
@@ -316,6 +316,13 @@ public:
     bool isBest() const { return getQuality() == LocationQuality::Best; }
   };
 
+  using ValueLocPair = std::pair<ValueIDNum, LocationAndQuality>;
+
+  static inline bool ValueToLocSort(const ValueLocPair &A,
+                                    const ValueLocPair &B) {
+    return A.first < B.first;
+  };
+
   // Returns the LocationQuality for the location L iff the quality of L is
   // is strictly greater than the provided minimum quality.
   std::optional<LocationQuality>
@@ -344,7 +351,7 @@ public:
   /// \p DbgOpStore is the map containing the DbgOpID->DbgOp mapping needed to
   ///    determine the values used by Value.
   void loadVarInloc(MachineBasicBlock &MBB, DbgOpIDMap &DbgOpStore,
-                    const DenseMap<ValueIDNum, LocationAndQuality> &ValueToLoc,
+                    const SmallVectorImpl<ValueLocPair> &ValueToLoc,
                     DebugVariable Var, DbgValue Value) {
     SmallVector<DbgOp> DbgOps;
     SmallVector<ResolvedDbgOp> ResolvedDbgOps;
@@ -373,9 +380,17 @@ public:
         continue;
       }
 
-      // If the value has no location, we can't make a variable location.
+      // Search for the desired ValueIDNum, to examine the best location found
+      // for it. Use an empty ValueLocPair to search for an entry in ValueToLoc.
       const ValueIDNum &Num = Op.ID;
-      auto ValuesPreferredLoc = ValueToLoc.find(Num);
+      ValueLocPair Probe(Num, LocationAndQuality());
+      auto ValuesPreferredLoc = std::lower_bound(
+          ValueToLoc.begin(), ValueToLoc.end(), Probe, ValueToLocSort);
+
+      // There must be a legitimate entry found for Num.
+      assert(ValuesPreferredLoc != ValueToLoc.end() &&
+             ValuesPreferredLoc->first == Num);
+
       if (ValuesPreferredLoc->second.isIllegal()) {
         // If it's a def that occurs in this block, register it as a
         // use-before-def to be resolved as we step through the block.
@@ -439,8 +454,9 @@ public:
     UseBeforeDefs.clear();
     UseBeforeDefVariables.clear();
 
-    // Map of the preferred location for each value.
-    DenseMap<ValueIDNum, LocationAndQuality> ValueToLoc;
+    // Mapping of the preferred locations for each value. Collected into this
+    // vector then sorted for easy searching.
+    SmallVector<ValueLocPair, 16> ValueToLoc;
 
     // Initialized the preferred-location map with illegal locations, to be
     // filled in later.
@@ -448,8 +464,10 @@ public:
       if (VLoc.second.Kind == DbgValue::Def)
         for (DbgOpID OpID : VLoc.second.getDbgOpIDs())
           if (!OpID.ID.IsConst)
-            ValueToLoc.insert({DbgOpStore.find(OpID).ID, LocationAndQuality()});
+            ValueToLoc.push_back(
+                {DbgOpStore.find(OpID).ID, LocationAndQuality()});
 
+    llvm::sort(ValueToLoc, ValueToLocSort);
     ActiveMLocs.reserve(VLocs.size());
     ActiveVLocs.reserve(VLocs.size());
 
@@ -464,8 +482,10 @@ public:
       VarLocs.push_back(VNum);
 
       // Is there a variable that wants a location for this value? If not, skip.
-      auto VIt = ValueToLoc.find(VNum);
-      if (VIt == ValueToLoc.end())
+      ValueLocPair Probe(VNum, LocationAndQuality());
+      auto VIt = std::lower_bound(ValueToLoc.begin(), ValueToLoc.end(), Probe,
+                                  ValueToLocSort);
+      if (VIt == ValueToLoc.end() || VIt->first != VNum)
         continue;
 
       auto &Previous = VIt->second;


### PR DESCRIPTION
When resolving value-numbers to specific machine locations in the final stages of LiveDebugValues, we've been producing a DenseMap containing all the value-numbers we're interested in. However we never modify the map keys as they're all pre-known. Thus, this is a suitable collection to switch to a sorted vector that gets searched, rather than a DenseMap that gets probed. The overall operation of LiveDebugValues isn't affected at all.

The compile-time-tracker reported a 0.13% speedup from this modification.

http://llvm-compile-time-tracker.com/compare.php?from=5184c90fd87f1bd97968c2b8d8e1c6c0f9de6288&to=96f59e146d1caf0cf02fbdeb2081c416b2251897&stat=instructions:u