### PR TITLE
[bazel] Fix llvm:Core build

### DIFF
--- a/utils/bazel/llvm-project-overlay/llvm/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/llvm/BUILD.bazel
@@ -947,7 +947,14 @@ cc_library(
     ]) + [
         # To avoid a dependency cycle.
         "include/llvm/Analysis/IVDescriptors.h",
-    ],
+        "include/llvm/CodeGen/GenVT.inc",
+    ] + glob(
+        # To avoid a dependency cycle.
+        [
+            "include/llvm/CodeGen/**/*.h",
+            "include/llvm/CodeGenTypes/**/*.h",
+        ],
+    ),
     hdrs = glob(
         [
             "include/llvm/*.h",


### PR DESCRIPTION
According to @akuegel, this breakage was introduced in c05126bd.