### PR TITLE
XFAIL: lld-available lit.cfg tag does not work as intended.

### DIFF
--- a/compiler-rt/test/profile/instrprof-gc-sections.c
+++ b/compiler-rt/test/profile/instrprof-gc-sections.c
@@ -1,7 +1,7 @@
 // REQUIRES: linux, lld-available
 
 // FIXME: Investigate and fix.
-// XFAIL: powerpc64-target-arch,powerpc64le-target-arch
+// XFAIL: powerpc64-target-arch, powerpc64le-target-arch
 
 // RUN: rm -rf %t.profraw
 // RUN: %clang_profgen=%t.profraw -fuse-ld=lld -fcoverage-mapping -mllvm -enable-name-compression=false -DCODE=1 -ffunction-sections -fdata-sections -Wl,--gc-sections -o %t %s

--- a/compiler-rt/test/profile/instrprof-gc-sections.c
+++ b/compiler-rt/test/profile/instrprof-gc-sections.c
@@ -1,7 +1,7 @@
 // REQUIRES: linux, lld-available
 
 // FIXME: Investigate and fix.
-// XFAIL: powerpc64-target-arch
+// XFAIL: powerpc64-target-arch,powerpc64le-target-arch
 
 // RUN: rm -rf %t.profraw
 // RUN: %clang_profgen=%t.profraw -fuse-ld=lld -fcoverage-mapping -mllvm -enable-name-compression=false -DCODE=1 -ffunction-sections -fdata-sections -Wl,--gc-sections -o %t %s


### PR DESCRIPTION
This change XFAILs instrprof-gc-sections.c compiler-rt test case
because it uses the `lld-available` lit.config tag which erroneously
uses the `CMAKE_LINKER` if it is lld instead of checking for the
latest and greatest lld available. A patch is in the works to fix
this.
This change is to bring the clang-ppc64le-linux-test-suite and
clang-ppc64le-linux-multistage back to green as they were broken
as of PR #98382
