### PR TITLE
[flang] Check assignment conformance for derived types

### DIFF
--- a/flang/lib/Semantics/expression.cpp
+++ b/flang/lib/Semantics/expression.cpp
@@ -4533,6 +4533,8 @@ std::optional<ProcedureRef> ArgumentAnalyzer::TryDefinedAssignment() {
         !OkLogicalIntegerAssignment(lhsType->category(), rhsType->category())) {
       SayNoMatch("ASSIGNMENT(=)", true);
     }
+  } else if (!fatalErrors_) {
+    CheckAssignmentConformance();
   }
   return std::nullopt;
 }

--- a/flang/test/Semantics/array-constr-values.f90
+++ b/flang/test/Semantics/array-constr-values.f90
@@ -35,8 +35,10 @@ subroutine arrayconstructorvalues()
   intarray = [integer:: EMPLOYEE (19, "Jack"), 2, 3, 4, 5]
 
   ! C7112
+  !ERROR: Dimension 1 of left-hand side has extent 3, but right-hand side has extent 2
   !ERROR: Value in array constructor of type 'INTEGER(4)' could not be converted to the type of the array 'employee'
   emparray = (/ EMPLOYEE:: EMPLOYEE(19, "Ganesh"), EMPLOYEE(22, "Omkar"), 19 /)
+  !ERROR: Dimension 1 of left-hand side has extent 3, but right-hand side has extent 2
   !ERROR: Value in array constructor of type 'employeer' could not be converted to the type of the array 'employee'
   emparray = (/ EMPLOYEE:: EMPLOYEE(19, "Ganesh"), EMPLOYEE(22, "Ram"),EMPLOYEER("ShriniwasPvtLtd") /)
 

--- a/flang/test/Semantics/assign10.f90
+++ b/flang/test/Semantics/assign10.f90
@@ -1,7 +1,11 @@
 ! RUN: %python %S/test_errors.py %s %flang_fc1
 ! Shape conformance checks on assignments
 program test
+  type t
+    integer n
+  end type
   real :: a0, a1a(2), a1b(3), a2a(2,3), a2b(3,2)
+  type(t) c(10)
   a0 = 0. ! ok
   !ERROR: No intrinsic or user-defined ASSIGNMENT(=) matches scalar REAL(4) and rank 1 array of REAL(4)
   a0 = [0.]
@@ -20,4 +24,6 @@ program test
   a2a(1,:) = a1a
   !ERROR: Dimension 1 of left-hand side has extent 2, but right-hand side has extent 3
   a2a = a2b
+  !ERROR: Dimension 1 of left-hand side has extent 10, but right-hand side has extent 0
+  c(1:10) = c(10:1)
 end


### PR DESCRIPTION
Derived type assignment checking needs to account for the possibility of derived assignment.  The implementation was checking compile-time conformance errors only on the path for assignments of intrinsic types.  Add a static array conformance check in the derived type flow once it has been established that no defined assignment exists.

Fixes https://github.com/llvm/llvm-project/issues/98981.