### PR TITLE
Revert "[PatternMatch] Fix issue of stale reference in new `m_{I,F,}Cmp` matchers"

### DIFF
--- a/llvm/unittests/IR/PatternMatch.cpp
+++ b/llvm/unittests/IR/PatternMatch.cpp
@@ -2235,7 +2235,7 @@ typedef ::testing::Types<std::tuple<Value*, Instruction*>,
     MutableConstTestTypes;
 TYPED_TEST_SUITE(MutableConstTest, MutableConstTestTypes, );
 
-TYPED_TEST(MutableConstTest, ICmp) {
+TYPED_TEST(MutableConstTest, /* FIXME: UAR bug */ DISABLED_ICmp) {
   auto &IRB = PatternMatchTest::IRB;
 
   typedef std::tuple_element_t<0, TypeParam> ValueType;
@@ -2319,7 +2319,7 @@ TYPED_TEST(MutableConstTest, ICmp) {
                    .match((InstructionType)IRB.CreateICmp(Pred, L, R)));
 }
 
-TYPED_TEST(MutableConstTest, FCmp) {
+TYPED_TEST(MutableConstTest, /* FIXME: UAR bug */ DISABLED_FCmp) {
   auto &IRB = PatternMatchTest::IRB;
 
   typedef std::tuple_element_t<0, TypeParam> ValueType;


### PR DESCRIPTION
Reverts llvm/llvm-project#98866

It's still use-after-scope.