### PR TITLE
[SandboxIR][NFC] Move sandboxir::Use into a separate file

### DIFF
--- a/llvm/include/llvm/SandboxIR/SandboxIR.h
+++ b/llvm/include/llvm/SandboxIR/SandboxIR.h
@@ -55,12 +55,13 @@
 // } // namespace sandboxir
 //
 
-#ifndef LLVM_TRANSFORMS_SANDBOXIR_SANDBOXIR_H
-#define LLVM_TRANSFORMS_SANDBOXIR_SANDBOXIR_H
+#ifndef LLVM_SANDBOXIR_SANDBOXIR_H
+#define LLVM_SANDBOXIR_SANDBOXIR_H
 
 #include "llvm/IR/Function.h"
 #include "llvm/IR/User.h"
 #include "llvm/IR/Value.h"
+#include "llvm/SandboxIR/Use.h"
 #include "llvm/Support/raw_ostream.h"
 #include <iterator>
 
@@ -74,42 +75,6 @@ class Function;
 class Instruction;
 class User;
 class Value;
-
-/// Represents a Def-use/Use-def edge in SandboxIR.
-/// NOTE: Unlike llvm::Use, this is not an integral part of the use-def chains.
-/// It is also not uniqued and is currently passed by value, so you can have
-/// more than one sandboxir::Use objects for the same use-def edge.
-class Use {
-  llvm::Use *LLVMUse;
-  User *Usr;
-  Context *Ctx;
-
-  /// Don't allow the user to create a sandboxir::Use directly.
-  Use(llvm::Use *LLVMUse, User *Usr, Context &Ctx)
-      : LLVMUse(LLVMUse), Usr(Usr), Ctx(&Ctx) {}
-  Use() : LLVMUse(nullptr), Ctx(nullptr) {}
-
-  friend class Value;              // For constructor
-  friend class User;               // For constructor
-  friend class OperandUseIterator; // For constructor
-  friend class UserUseIterator;    // For accessing members
-
-public:
-  operator Value *() const { return get(); }
-  Value *get() const;
-  class User *getUser() const { return Usr; }
-  unsigned getOperandNo() const;
-  Context *getContext() const { return Ctx; }
-  bool operator==(const Use &Other) const {
-    assert(Ctx == Other.Ctx && "Contexts differ!");
-    return LLVMUse == Other.LLVMUse && Usr == Other.Usr;
-  }
-  bool operator!=(const Use &Other) const { return !(*this == Other); }
-#ifndef NDEBUG
-  void dump(raw_ostream &OS) const;
-  void dump() const;
-#endif // NDEBUG
-};
 
 /// Returns the operand edge when dereferenced.
 class OperandUseIterator {
@@ -764,4 +729,4 @@ public:
 } // namespace sandboxir
 } // namespace llvm
 
-#endif // LLVM_TRANSFORMS_SANDBOXIR_SANDBOXIR_H
+#endif // LLVM_SANDBOXIR_SANDBOXIR_H

--- a/llvm/include/llvm/SandboxIR/Use.h
+++ b/llvm/include/llvm/SandboxIR/Use.h
@@ -1,0 +1,63 @@
+//===- Use.h ----------------------------------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Sandbox IR Use.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_SANDBOXIR_USE_H
+#define LLVM_SANDBOXIR_USE_H
+
+#include "llvm/IR/Use.h"
+#include "llvm/Support/raw_ostream.h"
+
+namespace llvm::sandboxir {
+
+class Context;
+class Value;
+class User;
+
+/// Represents a Def-use/Use-def edge in SandboxIR.
+/// NOTE: Unlike llvm::Use, this is not an integral part of the use-def chains.
+/// It is also not uniqued and is currently passed by value, so you can have
+/// more than one sandboxir::Use objects for the same use-def edge.
+class Use {
+  llvm::Use *LLVMUse;
+  User *Usr;
+  Context *Ctx;
+
+  /// Don't allow the user to create a sandboxir::Use directly.
+  Use(llvm::Use *LLVMUse, User *Usr, Context &Ctx)
+      : LLVMUse(LLVMUse), Usr(Usr), Ctx(&Ctx) {}
+  Use() : LLVMUse(nullptr), Ctx(nullptr) {}
+
+  friend class Value;              // For constructor
+  friend class User;               // For constructor
+  friend class OperandUseIterator; // For constructor
+  friend class UserUseIterator;    // For accessing members
+
+public:
+  operator Value *() const { return get(); }
+  Value *get() const;
+  class User *getUser() const { return Usr; }
+  unsigned getOperandNo() const;
+  Context *getContext() const { return Ctx; }
+  bool operator==(const Use &Other) const {
+    assert(Ctx == Other.Ctx && "Contexts differ!");
+    return LLVMUse == Other.LLVMUse && Usr == Other.Usr;
+  }
+  bool operator!=(const Use &Other) const { return !(*this == Other); }
+#ifndef NDEBUG
+  void dump(raw_ostream &OS) const;
+  void dump() const;
+#endif // NDEBUG
+};
+
+} // namespace llvm::sandboxir
+
+#endif // LLVM_SANDBOXIR_USE_H


### PR DESCRIPTION
This helps avoid circular dependencies in a follow-up patch.