### PR TITLE
[flang][cuda] Avoid temporary when RHS is a logical constant

### DIFF
--- a/flang/lib/Lower/Bridge.cpp
+++ b/flang/lib/Lower/Bridge.cpp
@@ -4230,9 +4230,13 @@ private:
       auto transferKindAttr = cuf::DataTransferKindAttr::get(
           builder.getContext(), cuf::DataTransferKind::HostDevice);
       if (!rhs.isVariable()) {
+        mlir::Value base = rhs;
+        if (auto convertOp =
+                mlir::dyn_cast<fir::ConvertOp>(rhs.getDefiningOp()))
+          base = convertOp.getValue();
         // Special case if the rhs is a constant.
-        if (matchPattern(rhs.getDefiningOp(), mlir::m_Constant())) {
-          builder.create<cuf::DataTransferOp>(loc, rhs, lhsVal,
+        if (matchPattern(base.getDefiningOp(), mlir::m_Constant())) {
+          builder.create<cuf::DataTransferOp>(loc, base, lhsVal,
                                               transferKindAttr);
         } else {
           auto associate = hlfir::genAssociateExpr(

--- a/flang/test/Lower/CUDA/cuda-data-transfer.cuf
+++ b/flang/test/Lower/CUDA/cuda-data-transfer.cuf
@@ -265,3 +265,12 @@ end subroutine
 ! CHECK: %[[TEMP:.*]] = fir.allocmem !fir.array<?xi32>, %14#1 {bindc_name = ".tmp", uniq_name = ""}
 ! CHECK: cuf.data_transfer
 ! CHECK: fir.freemem %[[TEMP]] : !fir.heap<!fir.array<?xi32>>
+
+subroutine sub14()
+  logical(4), device :: log(10)
+  log = .true.
+end subroutine
+
+! CHECK-LABEL: func.func @_QPsub14()
+! CHECK: %[[TRUE:.*]] = arith.constant true
+! CHECK: cuf.data_transfer %[[TRUE]] to %{{.*}}#0 {transfer_kind = #cuf.cuda_transfer<host_device>} : i1, !fir.ref<!fir.array<10x!fir.logical<4>>>


### PR DESCRIPTION
Enhance the detection of constant on the RHS for logical cases so we don't create a temporary. 