### PR TITLE
[ValueTracking] Consistently propagate `DemandedElts` in ValueTracking functions

### DIFF
--- a/llvm/lib/Analysis/ValueTracking.cpp
+++ b/llvm/lib/Analysis/ValueTracking.cpp
@@ -5274,8 +5274,9 @@ void computeKnownFPClass(const Value *V, const APInt &DemandedElts,
     }
       // reverse preserves all characteristics of the input vec's element.
     case Intrinsic::vector_reverse:
-      Known = computeKnownFPClass(II->getArgOperand(0), II->getFastMathFlags(),
-                                  InterestedClasses, Depth + 1, Q);
+      Known = computeKnownFPClass(
+          II->getArgOperand(0), DemandedElts.reverseBits(),
+          II->getFastMathFlags(), InterestedClasses, Depth + 1, Q);
       break;
     case Intrinsic::trunc:
     case Intrinsic::floor:

--- a/llvm/test/Analysis/ValueTracking/known-bits.ll
+++ b/llvm/test/Analysis/ValueTracking/known-bits.ll
@@ -26,11 +26,7 @@ define <4 x i1> @vec_reverse_known_bits_fail(<4 x i8> %xx) {
 
 define i1 @vec_reverse_known_bits_demanded(<4 x i8> %xx) {
 ; CHECK-LABEL: @vec_reverse_known_bits_demanded(
-; CHECK-NEXT:    [[X:%.*]] = or <4 x i8> [[XX:%.*]], <i8 127, i8 55, i8 -128, i8 123>
-; CHECK-NEXT:    [[REV:%.*]] = call <4 x i8> @llvm.vector.reverse.v4i8(<4 x i8> [[X]])
-; CHECK-NEXT:    [[ELE:%.*]] = extractelement <4 x i8> [[REV]], i64 1
-; CHECK-NEXT:    [[R:%.*]] = icmp slt i8 [[ELE]], 0
-; CHECK-NEXT:    ret i1 [[R]]
+; CHECK-NEXT:    ret i1 true
 ;
   %x = or <4 x i8> %xx, <i8 127, i8 55, i8 128, i8 123>
   %rev = call <4 x i8> @llvm.vector.reverse(<4 x i8> %x)

--- a/llvm/test/Analysis/ValueTracking/known-bits.ll
+++ b/llvm/test/Analysis/ValueTracking/known-bits.ll
@@ -23,3 +23,33 @@ define <4 x i1> @vec_reverse_known_bits_fail(<4 x i8> %xx) {
   %r = icmp slt <4 x i8> %rev, zeroinitializer
   ret <4 x i1> %r
 }
+
+define i1 @vec_reverse_known_bits_demanded(<4 x i8> %xx) {
+; CHECK-LABEL: @vec_reverse_known_bits_demanded(
+; CHECK-NEXT:    [[X:%.*]] = or <4 x i8> [[XX:%.*]], <i8 127, i8 55, i8 -128, i8 123>
+; CHECK-NEXT:    [[REV:%.*]] = call <4 x i8> @llvm.vector.reverse.v4i8(<4 x i8> [[X]])
+; CHECK-NEXT:    [[ELE:%.*]] = extractelement <4 x i8> [[REV]], i64 1
+; CHECK-NEXT:    [[R:%.*]] = icmp slt i8 [[ELE]], 0
+; CHECK-NEXT:    ret i1 [[R]]
+;
+  %x = or <4 x i8> %xx, <i8 127, i8 55, i8 128, i8 123>
+  %rev = call <4 x i8> @llvm.vector.reverse(<4 x i8> %x)
+  %ele = extractelement <4 x i8> %rev, i64 1
+  %r = icmp slt i8 %ele, 0
+  ret i1 %r
+}
+
+define i1 @vec_reverse_known_bits_demanded_fail(<4 x i8> %xx) {
+; CHECK-LABEL: @vec_reverse_known_bits_demanded_fail(
+; CHECK-NEXT:    [[X:%.*]] = or <4 x i8> [[XX:%.*]], <i8 127, i8 55, i8 -128, i8 123>
+; CHECK-NEXT:    [[REV:%.*]] = call <4 x i8> @llvm.vector.reverse.v4i8(<4 x i8> [[X]])
+; CHECK-NEXT:    [[ELE:%.*]] = extractelement <4 x i8> [[REV]], i64 2
+; CHECK-NEXT:    [[R:%.*]] = icmp slt i8 [[ELE]], 0
+; CHECK-NEXT:    ret i1 [[R]]
+;
+  %x = or <4 x i8> %xx, <i8 127, i8 55, i8 128, i8 123>
+  %rev = call <4 x i8> @llvm.vector.reverse(<4 x i8> %x)
+  %ele = extractelement <4 x i8> %rev, i64 2
+  %r = icmp slt i8 %ele, 0
+  ret i1 %r
+}

--- a/llvm/test/Analysis/ValueTracking/known-fpclass.ll
+++ b/llvm/test/Analysis/ValueTracking/known-fpclass.ll
@@ -24,3 +24,38 @@ define <4 x i1> @vector_reverse_fpclass2(<4 x double> nofpclass(nzero) %x) {
   ret <4 x i1> %cmp
 }
 
+define i1 @vector_reverse_fpclass_demanded(<4 x double> %vec, double nofpclass(nzero nan) %x) {
+; CHECK-LABEL: @vector_reverse_fpclass_demanded(
+; CHECK-NEXT:    [[X_ABS:%.*]] = call double @llvm.fabs.f64(double [[X:%.*]])
+; CHECK-NEXT:    [[VEC_X:%.*]] = insertelement <4 x double> [[VEC:%.*]], double [[X_ABS]], i64 1
+; CHECK-NEXT:    [[REV:%.*]] = call <4 x double> @llvm.vector.reverse.v4f64(<4 x double> [[VEC_X]])
+; CHECK-NEXT:    [[ELE:%.*]] = extractelement <4 x double> [[REV]], i64 2
+; CHECK-NEXT:    [[CMP:%.*]] = fcmp oge double [[ELE]], 0.000000e+00
+; CHECK-NEXT:    ret i1 [[CMP]]
+;
+
+  %x.abs = call double @llvm.fabs.f64(double %x)
+  %vec.x = insertelement <4 x double> %vec, double %x.abs, i64 1
+  %rev = call <4 x double> @llvm.vector.reverse(<4 x double> %vec.x)
+  %ele = extractelement <4 x double> %rev, i64 2
+  %cmp = fcmp oge double %ele, 0.0
+  ret i1 %cmp
+}
+
+define i1 @vector_reverse_fpclass_demanded_fail(<4 x double> %vec, double nofpclass(nzero nan) %x) {
+; CHECK-LABEL: @vector_reverse_fpclass_demanded_fail(
+; CHECK-NEXT:    [[X_ABS:%.*]] = call double @llvm.fabs.f64(double [[X:%.*]])
+; CHECK-NEXT:    [[VEC_X:%.*]] = insertelement <4 x double> [[VEC:%.*]], double [[X_ABS]], i64 1
+; CHECK-NEXT:    [[REV:%.*]] = call <4 x double> @llvm.vector.reverse.v4f64(<4 x double> [[VEC_X]])
+; CHECK-NEXT:    [[ELE:%.*]] = extractelement <4 x double> [[REV]], i64 1
+; CHECK-NEXT:    [[CMP:%.*]] = fcmp oge double [[ELE]], 0.000000e+00
+; CHECK-NEXT:    ret i1 [[CMP]]
+;
+
+  %x.abs = call double @llvm.fabs.f64(double %x)
+  %vec.x = insertelement <4 x double> %vec, double %x.abs, i64 1
+  %rev = call <4 x double> @llvm.vector.reverse(<4 x double> %vec.x)
+  %ele = extractelement <4 x double> %rev, i64 1
+  %cmp = fcmp oge double %ele, 0.0
+  ret i1 %cmp
+}

--- a/llvm/test/Analysis/ValueTracking/known-fpclass.ll
+++ b/llvm/test/Analysis/ValueTracking/known-fpclass.ll
@@ -26,12 +26,7 @@ define <4 x i1> @vector_reverse_fpclass2(<4 x double> nofpclass(nzero) %x) {
 
 define i1 @vector_reverse_fpclass_demanded(<4 x double> %vec, double nofpclass(nzero nan) %x) {
 ; CHECK-LABEL: @vector_reverse_fpclass_demanded(
-; CHECK-NEXT:    [[X_ABS:%.*]] = call double @llvm.fabs.f64(double [[X:%.*]])
-; CHECK-NEXT:    [[VEC_X:%.*]] = insertelement <4 x double> [[VEC:%.*]], double [[X_ABS]], i64 1
-; CHECK-NEXT:    [[REV:%.*]] = call <4 x double> @llvm.vector.reverse.v4f64(<4 x double> [[VEC_X]])
-; CHECK-NEXT:    [[ELE:%.*]] = extractelement <4 x double> [[REV]], i64 2
-; CHECK-NEXT:    [[CMP:%.*]] = fcmp oge double [[ELE]], 0.000000e+00
-; CHECK-NEXT:    ret i1 [[CMP]]
+; CHECK-NEXT:    ret i1 true
 ;
 
   %x.abs = call double @llvm.fabs.f64(double %x)

--- a/llvm/test/Analysis/ValueTracking/known-non-zero.ll
+++ b/llvm/test/Analysis/ValueTracking/known-non-zero.ll
@@ -1520,4 +1520,34 @@ define <4 x i1> @vec_reverse_non_zero_fail(<4 x i8> %xx) {
   ret <4 x i1> %r
 }
 
+define i1 @vec_reverse_non_zero_demanded(<4 x i8> %xx) {
+; CHECK-LABEL: @vec_reverse_non_zero_demanded(
+; CHECK-NEXT:    [[X:%.*]] = add nuw <4 x i8> [[XX:%.*]], <i8 1, i8 0, i8 0, i8 0>
+; CHECK-NEXT:    [[REV:%.*]] = call <4 x i8> @llvm.vector.reverse.v4i8(<4 x i8> [[X]])
+; CHECK-NEXT:    [[ELE:%.*]] = extractelement <4 x i8> [[REV]], i64 3
+; CHECK-NEXT:    [[R:%.*]] = icmp eq i8 [[ELE]], 0
+; CHECK-NEXT:    ret i1 [[R]]
+;
+  %x = add nuw <4 x i8> %xx, <i8 1, i8 0, i8 0, i8 0>
+  %rev = call <4 x i8> @llvm.vector.reverse(<4 x i8> %x)
+  %ele = extractelement <4 x i8> %rev, i64 3
+  %r = icmp eq i8 %ele, 0
+  ret i1 %r
+}
+
+define i1 @vec_reverse_non_zero_demanded_fail(<4 x i8> %xx) {
+; CHECK-LABEL: @vec_reverse_non_zero_demanded_fail(
+; CHECK-NEXT:    [[X:%.*]] = add nuw <4 x i8> [[XX:%.*]], <i8 1, i8 0, i8 0, i8 0>
+; CHECK-NEXT:    [[REV:%.*]] = call <4 x i8> @llvm.vector.reverse.v4i8(<4 x i8> [[X]])
+; CHECK-NEXT:    [[ELE:%.*]] = extractelement <4 x i8> [[REV]], i64 2
+; CHECK-NEXT:    [[R:%.*]] = icmp eq i8 [[ELE]], 0
+; CHECK-NEXT:    ret i1 [[R]]
+;
+  %x = add nuw <4 x i8> %xx, <i8 1, i8 0, i8 0, i8 0>
+  %rev = call <4 x i8> @llvm.vector.reverse(<4 x i8> %x)
+  %ele = extractelement <4 x i8> %rev, i64 2
+  %r = icmp eq i8 %ele, 0
+  ret i1 %r
+}
+
 declare i32 @llvm.experimental.get.vector.length.i32(i32, i32, i1)

--- a/llvm/test/Analysis/ValueTracking/known-non-zero.ll
+++ b/llvm/test/Analysis/ValueTracking/known-non-zero.ll
@@ -1522,11 +1522,7 @@ define <4 x i1> @vec_reverse_non_zero_fail(<4 x i8> %xx) {
 
 define i1 @vec_reverse_non_zero_demanded(<4 x i8> %xx) {
 ; CHECK-LABEL: @vec_reverse_non_zero_demanded(
-; CHECK-NEXT:    [[X:%.*]] = add nuw <4 x i8> [[XX:%.*]], <i8 1, i8 0, i8 0, i8 0>
-; CHECK-NEXT:    [[REV:%.*]] = call <4 x i8> @llvm.vector.reverse.v4i8(<4 x i8> [[X]])
-; CHECK-NEXT:    [[ELE:%.*]] = extractelement <4 x i8> [[REV]], i64 3
-; CHECK-NEXT:    [[R:%.*]] = icmp eq i8 [[ELE]], 0
-; CHECK-NEXT:    ret i1 [[R]]
+; CHECK-NEXT:    ret i1 false
 ;
   %x = add nuw <4 x i8> %xx, <i8 1, i8 0, i8 0, i8 0>
   %rev = call <4 x i8> @llvm.vector.reverse(<4 x i8> %x)


### PR DESCRIPTION
- **[ValueTracking] Consistently propagate `DemandedElts` is `computeKnownBits`**
- **[ValueTracking] Consistently propagate `DemandedElts` is `isKnownNonZero`**
- **[ValueTracking] Consistently propagate `DemandedElts` is `ComputeNumSignBits`**
- **[ValueTracking] Consistently propagate `DemandedElts` is `computeKnownFPClass`**
