### PR TITLE
[APFloat] Add APFloat::format

### DIFF
--- a/llvm/include/llvm/ADT/APFloat.h
+++ b/llvm/include/llvm/ADT/APFloat.h
@@ -15,10 +15,10 @@
 #ifndef LLVM_ADT_APFLOAT_H
 #define LLVM_ADT_APFLOAT_H
 
-#include "llvm/ADT/SmallString.h"
 #include "llvm/ADT/APInt.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/FloatingPointMode.h"
+#include "llvm/ADT/SmallString.h"
 #include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/NativeFormatting.h"
 #include "llvm/Support/float128.h"
@@ -567,6 +567,7 @@ public:
 
   /// decompose to an integer and exponent to radix 2
   bool decomposeToIntegerAndPowerOf2(APInt &, int &) const;
+
 private:
   /// \name Simple Queries
   /// @{
@@ -1398,13 +1399,14 @@ public:
   /// returns true on success, false otherwise (e.g., NaN, Infinity)
   /// similar to the standard modf, but exponent does not
   /// have to have the same sign as the value.
-  bool decomposeToIntegerAndPowerOf2 (APInt &I, int &exp) const {
-    APFLOAT_DISPATCH_ON_SEMANTICS( decomposeToIntegerAndPowerOf2(I, exp));
+  bool decomposeToIntegerAndPowerOf2(APInt &I, int &exp) const {
+    APFLOAT_DISPATCH_ON_SEMANTICS(decomposeToIntegerAndPowerOf2(I, exp));
   }
 
-  SmallVectorImpl<char> &format(SmallVectorImpl<char> &strout,
-              llvm::FloatStyle style = llvm::FloatStyle::Exponent,
-              std::optional<size_t> precision = std::nullopt);
+  SmallVectorImpl<char> &
+  format(SmallVectorImpl<char> &strout,
+         llvm::FloatStyle style = llvm::FloatStyle::Exponent,
+         std::optional<size_t> precision = std::nullopt);
 
   void print(raw_ostream &) const;
   void dump() const;

--- a/llvm/lib/Support/APFloat.cpp
+++ b/llvm/lib/Support/APFloat.cpp
@@ -4596,12 +4596,11 @@ void IEEEFloat::makeZero(bool Negative) {
   APInt::tcSet(significandParts(), 0, partCount());
 }
 
-IEEEFloat::ExponentType IEEEFloat::getExponent() const {
-  return exponent;
-}
+IEEEFloat::ExponentType IEEEFloat::getExponent() const { return exponent; }
 
 APInt IEEEFloat::getSignificand() const {
-  APInt result(semantics->precision, ArrayRef<integerPart>(significandParts(), partCount()));
+  APInt result(semantics->precision,
+               ArrayRef<integerPart>(significandParts(), partCount()));
 
   return result;
 }
@@ -5401,8 +5400,8 @@ APFloat APFloat::getAllOnesValue(const fltSemantics &Semantics) {
 }
 
 SmallVectorImpl<char> &APFloat::format(SmallVectorImpl<char> &strout,
-                                     llvm::FloatStyle style,
-                                     std::optional<size_t> precision_in) {
+                                       llvm::FloatStyle style,
+                                       std::optional<size_t> precision_in) {
   size_t precision = precision_in.value_or(getDefaultPrecision(style));
 
   // everything that follows assumes that precision >= 0
@@ -5426,7 +5425,7 @@ SmallVectorImpl<char> &APFloat::format(SmallVectorImpl<char> &strout,
       strout.push_back('.');
       for (size_t i = 0; i < precision; ++i)
         strout.push_back('0');
-    }  
+    }
     if (style == FloatStyle::Exponent)
       detail::append(strout, "e+00");
     else if (style == FloatStyle::ExponentUpper)
@@ -5539,7 +5538,7 @@ SmallVectorImpl<char> &APFloat::format(SmallVectorImpl<char> &strout,
       // now move decimal point back
       E += (s.size() - 1);
     }
-    if(isNegative())
+    if (isNegative())
       strout.push_back('-');
     strout.push_back(s[0]);
     if (precision > 0) {
@@ -5572,7 +5571,7 @@ SmallVectorImpl<char> &APFloat::format(SmallVectorImpl<char> &strout,
       strout.push_back('0' + E);
     } else {
       s.clear();
-      while(E) {
+      while (E) {
         char c = '0' + E % 10;
         strout.push_back(c);
         E /= 10;
@@ -5585,7 +5584,7 @@ SmallVectorImpl<char> &APFloat::format(SmallVectorImpl<char> &strout,
 
   // output to be formatted along the lines of %f
   if (style == FloatStyle::Percent)
-    decimalPoint += 2;    // multiply by 100
+    decimalPoint += 2; // multiply by 100
 
   int decidingDigit = decimalPoint + precision;
 
@@ -5593,7 +5592,7 @@ SmallVectorImpl<char> &APFloat::format(SmallVectorImpl<char> &strout,
     // theh value is zero.  The deciding digit is to the left
     // of the digits in s.  This is in the area of zeros, and
     // the contents of s can't affect the value.
-  } else if (decidingDigit >= (int) s.size()) {
+  } else if (decidingDigit >= (int)s.size()) {
     // deciding is beyond the end of s
   } else if (decidingDigit == 0) {
     // this is a tricky case, because if the digit at position 0
@@ -5611,13 +5610,14 @@ SmallVectorImpl<char> &APFloat::format(SmallVectorImpl<char> &strout,
     }
   } else if (s[decidingDigit] >= '5') {
     StringRef significantDigits(s.data(), decidingDigit);
-    int distanceBetweenDecimalPointAndDecidingDigit = decidingDigit - decimalPoint;
-    APInt temp (I.getBitWidth(), significantDigits, 10);
+    int distanceBetweenDecimalPointAndDecidingDigit =
+        decidingDigit - decimalPoint;
+    APInt temp(I.getBitWidth(), significantDigits, 10);
     temp += 1;
     s.clear();
     temp.toString(s, 10, false);
     // readjust decimalPoint in case the addition had a carry out
-    decimalPoint = (int) s.size() - distanceBetweenDecimalPointAndDecidingDigit;
+    decimalPoint = (int)s.size() - distanceBetweenDecimalPointAndDecidingDigit;
   }
 
   if (isNegative())
@@ -5631,7 +5631,7 @@ SmallVectorImpl<char> &APFloat::format(SmallVectorImpl<char> &strout,
     strout.push_back('0');
   } else {
     // we need to emit decimalPoint digits
-    int fromS = std::min(decimalPoint, (int) s.size());
+    int fromS = std::min(decimalPoint, (int)s.size());
     int i;
 
     for (i = 0; i < fromS; i++)
@@ -5640,13 +5640,13 @@ SmallVectorImpl<char> &APFloat::format(SmallVectorImpl<char> &strout,
       strout.push_back('0');
   }
 
-  if (precision > 0 ) {
+  if (precision > 0) {
     // need to emit precision digits
     // We need to emit what's to the right of the decimal point.
     int i;
     strout.push_back('.');
     if (decimalPoint < 0) {
-      int numLeadingZeros = std::min((int) precision, -decimalPoint);
+      int numLeadingZeros = std::min((int)precision, -decimalPoint);
       for (i = 0; i < numLeadingZeros; i++)
         strout.push_back('0');
       // update how many digits we have left to emit
@@ -5655,17 +5655,17 @@ SmallVectorImpl<char> &APFloat::format(SmallVectorImpl<char> &strout,
       decimalPoint += numLeadingZeros;
     }
 
-    if ( precision > 0) {
+    if (precision > 0) {
       // decimalPoint must be >= 0.
-      // If it was < 0 befoew we emitted the integer to the left of the decimal ppint,
-      // then it would have been incremented by numLeadingZeros in the previous block.
-      // It would have been incremented by the smaller of |decimalPoint| and precision.
-      // if |decimalPoint| were smaller, then decimalPoint will now be 0.
-      // If precision were smaller, then precision would have been decremented to 0,
-      // so we wouldn't be in this block.
+      // If it was < 0 befoew we emitted the integer to the left of the decimal
+      // ppint, then it would have been incremented by numLeadingZeros in the
+      // previous block. It would have been incremented by the smaller of
+      // |decimalPoint| and precision. If |decimalPoint| were smaller, then
+      // decimalPoint will now be 0. If precision were smaller, then precision
+      // would have been decremented to 0, so we wouldn't be in this block.
       // Hencem if we are in this block, then decimalPoint must be >= 0.
       assert(decimalPoint >= 0);
-      if (decimalPoint < (int) s.size()) {
+      if (decimalPoint < (int)s.size()) {
         // we need to emit digits from s
         int fromS = std::min(precision, s.size() - decimalPoint);
 
@@ -5673,7 +5673,7 @@ SmallVectorImpl<char> &APFloat::format(SmallVectorImpl<char> &strout,
           strout.push_back(s[decimalPoint + i]);
         precision -= fromS;
       }
-      for ( i = 0; i < (int) precision; i++ )
+      for (i = 0; i < (int)precision; i++)
         strout.push_back('0');
     }
   }

--- a/llvm/unittests/ADT/APFloatTest.cpp
+++ b/llvm/unittests/ADT/APFloatTest.cpp
@@ -1379,21 +1379,21 @@ TEST(APFloatTest, toString) {
 }
 
 TEST(APFloatTest, format) {
-  auto doit_precision = [](const fltSemantics &S, const char *value, llvm::FloatStyle style, int precision, const char *expected) {
-
-    SmallString<16>  s;
+  auto doit_precision = [](const fltSemantics &S, const char *value,
+                           llvm::FloatStyle style, int precision,
+                           const char *expected) {
+    SmallString<16> s;
     APFloat apf(S, value);
     apf.format(s, style, precision);
     EXPECT_STREQ(expected, s.c_str());
   };
-  auto doit = [](const fltSemantics &S, const char *value, llvm::FloatStyle style, const char *expected) {
-
-    SmallString<16>  s;
+  auto doit = [](const fltSemantics &S, const char *value,
+                 llvm::FloatStyle style, const char *expected) {
+    SmallString<16> s;
     APFloat apf(S, value);
     apf.format(s, style);
     EXPECT_STREQ(expected, s.c_str());
   };
-
 
   // default precision for Exponent and ExponentUpper is 6
   // and 2 for Fixed and Psercent
@@ -1433,7 +1433,6 @@ TEST(APFloatTest, format) {
     doit(S, "-1.5", llvm::FloatStyle::ExponentUpper, "-1.500000E+00");
     doit(S, "-1.5", llvm::FloatStyle::Fixed, "-1.50");
     doit(S, "-1.5", llvm::FloatStyle::Percent, "-150.00%");
-
 
     // check rounding: 0
     doit_precision(S, "0.0", llvm::FloatStyle::Exponent, 0, "0e+00");
@@ -1476,26 +1475,29 @@ TEST(APFloatTest, format) {
     // check appending fewer than default number of zeros
     if (Precision >= 3) {
       doit_precision(S, "1.75", llvm::FloatStyle::Exponent, 3, "1.750e+00");
-      doit_precision(S, "1.75", llvm::FloatStyle::ExponentUpper, 3, "1.750E+00");
+      doit_precision(S, "1.75", llvm::FloatStyle::ExponentUpper, 3,
+                     "1.750E+00");
       doit_precision(S, "1.75", llvm::FloatStyle::Fixed, 3, "1.750");
       doit_precision(S, "1.75", llvm::FloatStyle::Percent, 3, "175.000%");
     }
 
     // check appending more than default number of zeros
     if (Precision >= 3) {
-      doit_precision(S, "1.75", llvm::FloatStyle::Exponent, 8, "1.75000000e+00");
-      doit_precision(S, "1.75", llvm::FloatStyle::ExponentUpper, 8, "1.75000000E+00");
+      doit_precision(S, "1.75", llvm::FloatStyle::Exponent, 8,
+                     "1.75000000e+00");
+      doit_precision(S, "1.75", llvm::FloatStyle::ExponentUpper, 8,
+                     "1.75000000E+00");
       doit_precision(S, "1.75", llvm::FloatStyle::Fixed, 8, "1.75000000");
       doit_precision(S, "1.75", llvm::FloatStyle::Percent, 8, "175.00000000%");
     }
   }
 
   // test the main types with wider ranges
-  auto sems = { llvm::APFloat::S_IEEEsingle, llvm::APFloat::S_IEEEdouble,
-                llvm::APFloat::S_IEEEquad, llvm::APFloat::S_PPCDoubleDouble,
-                llvm::APFloat::S_x87DoubleExtended};
+  auto sems = {llvm::APFloat::S_IEEEsingle, llvm::APFloat::S_IEEEdouble,
+               llvm::APFloat::S_IEEEquad, llvm::APFloat::S_PPCDoubleDouble,
+               llvm::APFloat::S_x87DoubleExtended};
 
-  for ( auto sem : sems ) {
+  for (auto sem : sems) {
     const auto &S = APFloat::EnumToSemantics(sem);
 
     doit(S, "0.000001", llvm::FloatStyle::Exponent, "1.000000e-06");
@@ -1505,17 +1507,24 @@ TEST(APFloatTest, format) {
 
     // 1/1024 == 0.0009765625
     doit(S, "0.0009765625", llvm::FloatStyle::Exponent, "9.765625e-04");
-    doit_precision(S, "0.0009765625", llvm::FloatStyle::Exponent, 5, "9.76563e-04");
-    doit_precision(S, "0.0009765625", llvm::FloatStyle::Exponent, 4, "9.7656e-04");
-    doit_precision(S, "0.0009765625", llvm::FloatStyle::Exponent, 3, "9.766e-04");
-    doit_precision(S, "0.0009765625", llvm::FloatStyle::Exponent, 2, "9.77e-04");
+    doit_precision(S, "0.0009765625", llvm::FloatStyle::Exponent, 5,
+                   "9.76563e-04");
+    doit_precision(S, "0.0009765625", llvm::FloatStyle::Exponent, 4,
+                   "9.7656e-04");
+    doit_precision(S, "0.0009765625", llvm::FloatStyle::Exponent, 3,
+                   "9.766e-04");
+    doit_precision(S, "0.0009765625", llvm::FloatStyle::Exponent, 2,
+                   "9.77e-04");
     doit_precision(S, "0.0009765625", llvm::FloatStyle::Exponent, 1, "9.8e-04");
     // note change in exponent as the integer 9 goes to 10, and then to 1
     doit_precision(S, "0.0009765625", llvm::FloatStyle::Exponent, 0, "1e-03");
 
-    doit_precision(S, "0.0009765625", llvm::FloatStyle::Fixed, 11, "0.00097656250");
-    doit_precision(S, "0.0009765625", llvm::FloatStyle::Fixed, 10, "0.0009765625");
-    doit_precision(S, "0.0009765625", llvm::FloatStyle::Fixed, 9, "0.000976563");
+    doit_precision(S, "0.0009765625", llvm::FloatStyle::Fixed, 11,
+                   "0.00097656250");
+    doit_precision(S, "0.0009765625", llvm::FloatStyle::Fixed, 10,
+                   "0.0009765625");
+    doit_precision(S, "0.0009765625", llvm::FloatStyle::Fixed, 9,
+                   "0.000976563");
     doit_precision(S, "0.0009765625", llvm::FloatStyle::Fixed, 8, "0.00097656");
     doit_precision(S, "0.0009765625", llvm::FloatStyle::Fixed, 7, "0.0009766");
     doit_precision(S, "0.0009765625", llvm::FloatStyle::Fixed, 6, "0.000977");


### PR DESCRIPTION
This PR adds the format method to the APFloat family. This is intended to ease formatting of an APFloat to a string without having to convert the APFloat to a host-format floating point value.
This is useful when the target type cannot be losslessly converted to a host type.