### PR TITLE
[clang][dataflow] Only propagate past CXXDefaultInitExpr if init is

### DIFF
--- a/clang/lib/Analysis/FlowSensitive/DataflowEnvironment.cpp
+++ b/clang/lib/Analysis/FlowSensitive/DataflowEnvironment.cpp
@@ -465,7 +465,12 @@ public:
     }
 
     if (auto *DIE = dyn_cast<CXXDefaultInitExpr>(E)) {
-      PropagateResultObject(DIE->getExpr(), Loc);
+      // If it has a rewritten init, we should propagate to that. If it doesn't,
+      // then the CXXDefaultInitExpr is the only initializer available during
+      // the analysis as the underlying Expr is only traversed as a child of the
+      // Decl being initialized, which is not usually in the CFG.
+      if (DIE->hasRewrittenInit())
+        PropagateResultObject(DIE->getExpr(), Loc);
       return;
     }
 

--- a/clang/unittests/Analysis/FlowSensitive/DataflowEnvironmentTest.cpp
+++ b/clang/unittests/Analysis/FlowSensitive/DataflowEnvironmentTest.cpp
@@ -435,6 +435,8 @@ TEST_F(EnvironmentTest, CXXDefaultInitExprResultObjIsWrappedExprResultObj) {
   const auto *Constructor = selectFirst<CXXConstructorDecl>("ctor", Results);
   const auto *DefaultInit =
       selectFirst<CXXDefaultInitExpr>("default_init_expr", Results);
+  // We only propagate past the `CXXDefaultInitExpr` if it has a rewritten init.
+  ASSERT_TRUE(DefaultInit->hasRewrittenInit());
 
   Environment Env(DAContext, *Constructor);
   Env.initialize();


### PR DESCRIPTION
rewritten.