### PR TITLE
[BOLT][DWARF][NFC] Remove unused check.

### DIFF
--- a/bolt/lib/Core/DIEBuilder.cpp
+++ b/bolt/lib/Core/DIEBuilder.cpp
@@ -617,14 +617,6 @@ void DIEBuilder::cloneDieReferenceAttribute(
     DIE &Die, const DWARFUnit &U, const DWARFDie &InputDIE,
     const DWARFAbbreviationDeclaration::AttributeSpec AttrSpec,
     const DWARFFormValue &Val) {
-  uint64_t Ref;
-  if (std::optional<uint64_t> Off = Val.getAsRelativeReference())
-    Ref = Val.getUnit()->getOffset() + *Off;
-  else if (Off = Val.getAsDebugInfoReference(); Off)
-    Ref = *Off;
-  else
-    return;
-
   DIE *NewRefDie = nullptr;
   DWARFUnit *RefUnit = nullptr;
 
@@ -641,8 +633,6 @@ void DIEBuilder::cloneDieReferenceAttribute(
   DIEInfo &DieInfo = getDIEInfo(*UnitId, DIEId);
 
   if (!DieInfo.Die) {
-    assert(Ref > InputDIE.getOffset());
-    (void)Ref;
     BC.errs() << "BOLT-WARNING: [internal-dwarf-error]: encounter unexpected "
                  "unallocated DIE. Should be alloc!\n";
     // We haven't cloned this DIE yet. Just create an empty one and


### PR DESCRIPTION
This is a followup for:
https://github.com/llvm/llvm-project/commit/9dab91247d5c40607617f13b8fe5056111dd3045
Looking at this code more I don't think the check is really necessary.
