### PR TITLE
[tsan] Fix alignas specifier in tsan_platform_mac.cpp

### DIFF
--- a/compiler-rt/lib/tsan/rtl/tsan_platform_mac.cpp
+++ b/compiler-rt/lib/tsan/rtl/tsan_platform_mac.cpp
@@ -45,9 +45,9 @@
 
 namespace __tsan {
 
-#if !SANITIZER_GO
-static char main_thread_state[sizeof(ThreadState)] alignas(
-    SANITIZER_CACHE_LINE_SIZE);
+#  if !SANITIZER_GO
+alignas(SANITIZER_CACHE_LINE_SIZE) static char main_thread_state[sizeof(
+    ThreadState)];
 static ThreadState *dead_thread_state;
 static pthread_key_t thread_state_key;
 


### PR DESCRIPTION
Placing the `alignas` specifier after the declaration causes the following:

```
error: 'alignas' attribute cannot be applied to types

```
Breakages can be seen at:
https://ci.chromium.org/ui/p/fuchsia/builders/toolchain.ci/clang-mac-x64/b8742225171944684321/overview
https://logs.chromium.org/logs/fuchsia/buildbucket/cr-buildbucket/8742225171944684321/+/u/clang/install/stdout

This patch corrects the placement, which follows the convention and
style of other `alignas` directives in compiler-rt.
