### PR TITLE
[LLDB][test] Update Makefile.rules to support Windows host+Linux target

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/make/Makefile.rules
+++ b/lldb/packages/Python/lldbsuite/test/make/Makefile.rules
@@ -112,13 +112,25 @@ $(error "C compiler is not specified. Please run tests through lldb-dotest or li
 endif
 
 #----------------------------------------------------------------------
-# Handle SDKROOT on Darwin
+# Handle SDKROOT for the cross platform builds.
 #----------------------------------------------------------------------
 
 ifeq "$(OS)" "Darwin"
     ifeq "$(SDKROOT)" ""
 	# We haven't otherwise set the SDKROOT, so set it now to macosx
 	SDKROOT := $(shell xcrun --sdk macosx --show-sdk-path)
+    endif
+    SYSROOT_FLAGS := -isysroot "$(SDKROOT)"
+    GCC_TOOLCHAIN_FLAGS :=
+else
+    ifneq "$(SDKROOT)" ""
+        SYSROOT_FLAGS := --sysroot "$(SDKROOT)"
+        GCC_TOOLCHAIN_FLAGS := --gcc-toolchain="$(SDKROOT)/usr"
+    else
+        # Do not set up these options if SDKROOT was not specified.
+        # This is a regular build in that case (or Android).
+        SYSROOT_FLAGS :=
+        GCC_TOOLCHAIN_FLAGS :=
     endif
 endif
 
@@ -210,20 +222,15 @@ endif
 DEBUG_INFO_FLAG ?= -g
 
 CFLAGS ?= $(DEBUG_INFO_FLAG) -O0
-
-ifeq "$(OS)" "Darwin"
-	ifneq "$(SDKROOT)" ""
-		CFLAGS += -isysroot "$(SDKROOT)"
-	endif
-endif
+CFLAGS += $(SYSROOT_FLAGS)
 
 ifeq "$(OS)" "Darwin"
 	CFLAGS += $(ARCHFLAG) $(ARCH) $(FRAMEWORK_INCLUDES)
 else
 	CFLAGS += $(ARCHFLAG)$(ARCH)
 endif
-CFLAGS += -I$(LLDB_BASE_DIR)include -I$(LLDB_OBJ_ROOT)/include
 
+CFLAGS += -I$(LLDB_BASE_DIR)/include -I$(LLDB_OBJ_ROOT)/include
 CFLAGS += -I$(SRCDIR) -I$(THIS_FILE_DIR)
 
 ifndef NO_TEST_COMMON_H
@@ -234,9 +241,9 @@ CFLAGS += $(NO_LIMIT_DEBUG_INFO_FLAGS) $(ARCH_CFLAGS)
 
 # Use this one if you want to build one part of the result without debug information:
 ifeq "$(OS)" "Darwin"
-	CFLAGS_NO_DEBUG = -O0 $(ARCHFLAG) $(ARCH) $(FRAMEWORK_INCLUDES) $(ARCH_CFLAGS) $(CFLAGS_EXTRAS) -isysroot "$(SDKROOT)"
+	CFLAGS_NO_DEBUG = -O0 $(ARCHFLAG) $(ARCH) $(FRAMEWORK_INCLUDES) $(ARCH_CFLAGS) $(CFLAGS_EXTRAS) $(SYSROOT_FLAGS)
 else
-	CFLAGS_NO_DEBUG = -O0 $(ARCHFLAG)$(ARCH) $(FRAMEWORK_INCLUDES) $(ARCH_CFLAGS) $(CFLAGS_EXTRAS)
+	CFLAGS_NO_DEBUG = -O0 $(ARCHFLAG)$(ARCH) $(FRAMEWORK_INCLUDES) $(ARCH_CFLAGS) $(CFLAGS_EXTRAS) $(SYSROOT_FLAGS)
 endif
 
 ifeq "$(MAKE_DWO)" "YES"
@@ -267,7 +274,9 @@ endif
 CFLAGS += $(CFLAGS_EXTRAS)
 CXXFLAGS += -std=c++11 $(CFLAGS) $(ARCH_CXXFLAGS)
 LD = $(CC)
-LDFLAGS ?= $(CFLAGS)
+# Copy common options to the linker flags (dwarf, arch. & etc).
+# Note: we get some 'garbage' options for linker here (such as -I, --isystem & etc).
+LDFLAGS += $(CFLAGS)
 LDFLAGS += $(LD_EXTRAS) $(ARCH_LDFLAGS)
 ifeq (,$(filter $(OS), Windows_NT Android Darwin))
 	ifneq (,$(filter YES,$(ENABLE_THREADS)))
@@ -378,11 +387,26 @@ ifeq (1, $(USE_SYSTEM_STDLIB))
 	endif
 endif
 
+ifeq (,$(filter 1, $(USE_LIBSTDCPP) $(USE_LIBCPP) $(USE_SYSTEM_STDLIB)))
+  # If no explicit C++ library request was made, but we have paths to a custom libcxx, use
+  # them.  Otherwise, use the system library by default.
+  ifneq ($(and $(LIBCPP_INCLUDE_DIR), $(LIBCPP_LIBRARY_DIR)),)
+    CXXFLAGS += -nostdlib++ -nostdinc++ -cxx-isystem $(LIBCPP_INCLUDE_DIR)
+    ifneq "$(LIBCPP_INCLUDE_TARGET_DIR)" ""
+      CXXFLAGS += -cxx-isystem $(LIBCPP_INCLUDE_TARGET_DIR)
+    endif
+    LDFLAGS += -L$(LIBCPP_LIBRARY_DIR) -Wl,-rpath,$(LIBCPP_LIBRARY_DIR) -lc++
+  else
+    USE_SYSTEM_STDLIB := 1
+  endif
+endif
+
 ifeq (1,$(USE_LIBSTDCPP))
 	# Clang requires an extra flag: -stdlib=libstdc++
 	ifneq (,$(findstring clang,$(CC)))
-		CXXFLAGS += -stdlib=libstdc++
-		LDFLAGS += -stdlib=libstdc++
+		# Force clang looking for the gcc's headers at specific rootfs folder.
+		CXXFLAGS += -stdlib=libstdc++ $(GCC_TOOLCHAIN_FLAGS)
+		LDFLAGS += -stdlib=libstdc++ $(GCC_TOOLCHAIN_FLAGS)
 	endif
 endif
 
@@ -416,19 +440,13 @@ ifeq (1, $(USE_SYSTEM_STDLIB))
         endif
         CXXFLAGS += -nostdlib++ -nostdinc++ -cxx-isystem $(SDKROOT)/usr/include/c++/v1
         LDFLAGS += -L$(SDKROOT)/usr/lib -Wl,-rpath,$(SDKROOT)/usr/lib -lc++
+    else
+        ifneq (,$(findstring clang,$(CC)))
+            # Force clang looking for the gcc's headers at specific rootfs folder.
+            CXXFLAGS += $(GCC_TOOLCHAIN_FLAGS)
+            LDFLAGS += $(GCC_TOOLCHAIN_FLAGS)
+        endif
     endif
-endif
-
-# If no explicit request was made, but we have paths to a custom libcxx, use
-# them.
-ifeq ($(or $(USE_LIBSTDCPP), $(USE_LIBCPP), $(USE_SYSTEM_STDLIB)),)
-	ifneq ($(and $(LIBCPP_INCLUDE_DIR), $(LIBCPP_LIBRARY_DIR)),)
-		CXXFLAGS += -nostdlib++ -nostdinc++ -cxx-isystem $(LIBCPP_INCLUDE_DIR)
-		ifneq "$(LIBCPP_INCLUDE_TARGET_DIR)" ""
-				CXXFLAGS += -cxx-isystem $(LIBCPP_INCLUDE_TARGET_DIR)
-		endif
-		LDFLAGS += -L$(LIBCPP_LIBRARY_DIR) -Wl,-rpath,$(LIBCPP_LIBRARY_DIR) -lc++
-	endif
 endif
 
 #----------------------------------------------------------------------


### PR DESCRIPTION
These changes aim to support cross-compilation build on Windows host for Linux target for API tests execution. They're not final: changes will follow for refactoring and adjustments to make all tests pass.

Chocolatey make is recommended to be used since it is maintained better than GnuWin32 mentioned here https://lldb.llvm.org/resources/build.html#windows (latest GnuWin32 release is dated by 2010) and helps to avoid problems with building tests (for example, GnuWin32 make doesn't support long paths and there are some other failures with building for Linux with it).