### PR TITLE
Increase number of icmps needed for converting to a switch statement

### DIFF
--- a/llvm/lib/Transforms/Utils/SimplifyCFG.cpp
+++ b/llvm/lib/Transforms/Utils/SimplifyCFG.cpp
@@ -180,6 +180,10 @@ static cl::opt<unsigned> MaxSwitchCasesPerResult(
     "max-switch-cases-per-result", cl::Hidden, cl::init(16),
     cl::desc("Limit cases to analyze when converting a switch to select"));
 
+static cl::opt<unsigned> MinICmpsToSwitch(
+    "min-icmps-to-switch", cl::Hidden, cl::init(9),
+    cl::desc("Minimum number of icmp sequences to convert to switch"));
+
 STATISTIC(NumBitMaps, "Number of switch instructions turned into bitmaps");
 STATISTIC(NumLinearMaps,
           "Number of switch instructions turned into linear mapping");
@@ -4893,8 +4897,8 @@ bool SimplifyCFGOpt::SimplifyBranchOnICmpChain(BranchInst *BI,
   if (!CompVal)
     return false;
 
-  // Avoid turning single icmps into a switch.
-  if (UsedICmps <= 1)
+  // Avoid turning few icmps into a switch.
+  if (UsedICmps < MinICmpsToSwitch)
     return false;
 
   bool TrueWhenEqual = match(Cond, m_LogicalOr(m_Value(), m_Value()));


### PR DESCRIPTION
In RISC-V the minimum number of case needed for code-generating a jump table is 5, while on AArch64 it is 13. Ideally we should query the backend for their preferable jump table size before deciding to convert a sequence of compares to a switch statement.

Also make this a parameter for anyone to tune.

Fixes: #48188