### PR TITLE
[libc++] In `<format>`, use availability macro if including `<locale>`

### DIFF
--- a/libcxx/include/format
+++ b/libcxx/include/format
@@ -224,7 +224,9 @@ namespace std {
 #endif
 
 #if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
+#  if !defined(_LIBCPP_HAS_NO_LOCALIZATION)
 #  include <locale>
+#  endif
 #  include <queue>
 #  include <stack>
 #endif

--- a/libcxx/include/format
+++ b/libcxx/include/format
@@ -225,7 +225,7 @@ namespace std {
 
 #if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
 #  if !defined(_LIBCPP_HAS_NO_LOCALIZATION)
-#  include <locale>
+#    include <locale>
 #  endif
 #  include <queue>
 #  include <stack>


### PR DESCRIPTION
This is a follow-up to https://github.com/llvm/llvm-project/pull/85478,
similar to https://github.com/llvm/llvm-project/pull/95686.
