### PR TITLE
[clang] Disable runtimes testing in C++03 and Clang modules modes

### DIFF
--- a/.ci/monolithic-linux.sh
+++ b/.ci/monolithic-linux.sh
@@ -77,21 +77,22 @@ if [[ "${runtimes}" != "" ]]; then
   INSTALL_DIR="${BUILD_DIR}/install"
   mkdir -p ${RUNTIMES_BUILD_DIR}
 
-  echo "--- cmake runtimes C++03"
+  # FIXME: This should be re-enabled once we get more CI bandwidth
+  # echo "--- cmake runtimes C++03"
 
-  cmake -S "${MONOREPO_ROOT}/runtimes" -B "${RUNTIMES_BUILD_DIR}" -GNinja \
-      -D CMAKE_C_COMPILER="${INSTALL_DIR}/bin/clang" \
-      -D CMAKE_CXX_COMPILER="${INSTALL_DIR}/bin/clang++" \
-      -D LLVM_ENABLE_RUNTIMES="${runtimes}" \
-      -D LIBCXX_CXX_ABI=libcxxabi \
-      -D CMAKE_BUILD_TYPE=RelWithDebInfo \
-      -D CMAKE_INSTALL_PREFIX="${INSTALL_DIR}" \
-      -D LIBCXX_TEST_PARAMS="std=c++03" \
-      -D LIBCXXABI_TEST_PARAMS="std=c++03"
+  # cmake -S "${MONOREPO_ROOT}/runtimes" -B "${RUNTIMES_BUILD_DIR}" -GNinja \
+  #     -D CMAKE_C_COMPILER="${INSTALL_DIR}/bin/clang" \
+  #     -D CMAKE_CXX_COMPILER="${INSTALL_DIR}/bin/clang++" \
+  #     -D LLVM_ENABLE_RUNTIMES="${runtimes}" \
+  #     -D LIBCXX_CXX_ABI=libcxxabi \
+  #     -D CMAKE_BUILD_TYPE=RelWithDebInfo \
+  #     -D CMAKE_INSTALL_PREFIX="${INSTALL_DIR}" \
+  #     -D LIBCXX_TEST_PARAMS="std=c++03" \
+  #     -D LIBCXXABI_TEST_PARAMS="std=c++03"
 
-  echo "--- ninja runtimes C++03"
+  # echo "--- ninja runtimes C++03"
 
-  ninja -vC "${RUNTIMES_BUILD_DIR}" ${runtime_targets}
+  # ninja -vC "${RUNTIMES_BUILD_DIR}" ${runtime_targets}
 
   echo "--- cmake runtimes C++26"
 
@@ -110,20 +111,21 @@ if [[ "${runtimes}" != "" ]]; then
 
   ninja -vC "${RUNTIMES_BUILD_DIR}" ${runtime_targets}
 
-  echo "--- cmake runtimes clang modules"
+  # FIXME: This should be re-enabled once we get more CI bandwidth
+  # echo "--- cmake runtimes clang modules"
 
-  rm -rf "${RUNTIMES_BUILD_DIR}"
-  cmake -S "${MONOREPO_ROOT}/runtimes" -B "${RUNTIMES_BUILD_DIR}" -GNinja \
-      -D CMAKE_C_COMPILER="${INSTALL_DIR}/bin/clang" \
-      -D CMAKE_CXX_COMPILER="${INSTALL_DIR}/bin/clang++" \
-      -D LLVM_ENABLE_RUNTIMES="${runtimes}" \
-      -D LIBCXX_CXX_ABI=libcxxabi \
-      -D CMAKE_BUILD_TYPE=RelWithDebInfo \
-      -D CMAKE_INSTALL_PREFIX="${INSTALL_DIR}" \
-      -D LIBCXX_TEST_PARAMS="enable_modules=clang" \
-      -D LIBCXXABI_TEST_PARAMS="enable_modules=clang"
+  # rm -rf "${RUNTIMES_BUILD_DIR}"
+  # cmake -S "${MONOREPO_ROOT}/runtimes" -B "${RUNTIMES_BUILD_DIR}" -GNinja \
+  #     -D CMAKE_C_COMPILER="${INSTALL_DIR}/bin/clang" \
+  #     -D CMAKE_CXX_COMPILER="${INSTALL_DIR}/bin/clang++" \
+  #     -D LLVM_ENABLE_RUNTIMES="${runtimes}" \
+  #     -D LIBCXX_CXX_ABI=libcxxabi \
+  #     -D CMAKE_BUILD_TYPE=RelWithDebInfo \
+  #     -D CMAKE_INSTALL_PREFIX="${INSTALL_DIR}" \
+  #     -D LIBCXX_TEST_PARAMS="enable_modules=clang" \
+  #     -D LIBCXXABI_TEST_PARAMS="enable_modules=clang"
 
-  echo "--- ninja runtimes clang modules"
+  # echo "--- ninja runtimes clang modules"
   
-  ninja -vC "${RUNTIMES_BUILD_DIR}" ${runtime_targets}
+  # ninja -vC "${RUNTIMES_BUILD_DIR}" ${runtime_targets}
 fi


### PR DESCRIPTION
This patch (temporarily) disables running libc++, libc++abi, and libunwind test suites in C++03 and Clang modules modes on Clang changes on Linux CI. This should substantially reduce CI load, hopefully bringing queue length and waiting times back to reasonable values. Out of ≈25 minutes per build on Linux CI, runtime tests take (data from [this](https://buildkite.com/llvm-project/github-pull-requests/builds/81304) recent build):
```
--- cmake runtimes C++03
Testing Time: 0.18s
Testing Time: 18.44s
Testing Time: 171.28s
--- cmake runtimes C++26
Testing Time: 0.17s
Testing Time: 23.94s
Testing Time: 337.18s
--- cmake runtimes clang modules
Testing Time: 0.17s
Testing Time: 31.65s
Testing Time: 224.39s
```
Disabling C++03 and Clang modules should reduce total time by 7.5 minutes, which is 30%, then a bit more spent on CMake configuration. This is in line with the fact that we apparently are left with 2 Linux agents out of 3.

I'm not happy with the fact that I even put this patch together, but I think reduced Clang testing is still better than effectively no pre-commit CI for everyone, at 20 hours of waiting times at the moment of writing. See https://discourse.llvm.org/t/reduced-pre-commit-ci-bandwidth/80190 for wider discussion.