### PR TITLE
[lldb] Disable verbose_trap.test on Windows

### DIFF
--- a/lldb/test/Shell/Recognizer/verbose_trap.test
+++ b/lldb/test/Shell/Recognizer/verbose_trap.test
@@ -1,3 +1,5 @@
+# UNSUPPORTED: system-windows
+#
 # RUN: %clang_host -g -O0 %S/Inputs/verbose_trap.cpp -o %t.out -DVERBOSE_TRAP_TEST_CATEGORY=\"Foo\" -DVERBOSE_TRAP_TEST_MESSAGE=\"Bar\"
 # RUN: %lldb -b -s %s %t.out | FileCheck %s --check-prefixes=CHECK,CHECK-BOTH
 #


### PR DESCRIPTION
verbose_trap.test, added in #80368, fails on some Windows bots.
See https://lab.llvm.org/buildbot/#/builders/141/builds/808.
