### PR TITLE
Fix compilation warning

### DIFF
--- a/flang/lib/Optimizer/Builder/IntrinsicCall.cpp
+++ b/flang/lib/Optimizer/Builder/IntrinsicCall.cpp
@@ -6148,7 +6148,7 @@ IntrinsicLibrary::genScan(mlir::Type resultType,
 fir::ExtendedValue
 IntrinsicLibrary::genSecond(std::optional<mlir::Type> resultType,
                             mlir::ArrayRef<fir::ExtendedValue> args) {
-  assert((args.size() == 1 && !resultType) || args.empty() && resultType);
+  assert((args.size() == 1 && !resultType) || (args.empty() && resultType));
 
   fir::ExtendedValue result;
 

--- a/flang/lib/Optimizer/Builder/IntrinsicCall.cpp
+++ b/flang/lib/Optimizer/Builder/IntrinsicCall.cpp
@@ -6148,7 +6148,7 @@ IntrinsicLibrary::genScan(mlir::Type resultType,
 fir::ExtendedValue
 IntrinsicLibrary::genSecond(std::optional<mlir::Type> resultType,
                             mlir::ArrayRef<fir::ExtendedValue> args) {
-  assert(args.size() == 1 && !resultType || args.empty() && resultType);
+  assert((args.size() == 1 && !resultType) || args.empty() && resultType);
 
   fir::ExtendedValue result;
 


### PR DESCRIPTION
With change #98881, I was getting a warning that an expression needed more parentheses.

Note that I build with GCC 9.3.0.