### PR TITLE
[llvm-dlltool] Use EXPORTAS name type for renamed imports on ARM64EC.

### DIFF
--- a/llvm/lib/Object/COFFImportFile.cpp
+++ b/llvm/lib/Object/COFFImportFile.cpp
@@ -729,7 +729,10 @@ Error writeImportLibrary(StringRef ImportName, StringRef Path,
         else if (Machine == IMAGE_FILE_MACHINE_I386 &&
                  applyNameType(IMPORT_NAME_NOPREFIX, Name) == E.ImportName)
           NameType = IMPORT_NAME_NOPREFIX;
-        else if (Name == E.ImportName)
+        else if (isArm64EC(M)) {
+          NameType = IMPORT_NAME_EXPORTAS;
+          ExportName = E.ImportName;
+        } else if (Name == E.ImportName)
           NameType = IMPORT_NAME;
         else {
           Deferred D;

--- a/llvm/test/tools/llvm-dlltool/arm64ec.test
+++ b/llvm/test/tools/llvm-dlltool/arm64ec.test
@@ -44,6 +44,29 @@ RUN: llvm-nm --print-armap test3.lib | FileCheck --check-prefix=ARMAP2 %s
 RUN: not llvm-dlltool -m arm64 -d test.def -N test2.def -l test4.lib 2>&1 | FileCheck --check-prefix=ERR %s
 ERR: native .def file is supported only on arm64ec target
 
+RUN: llvm-dlltool -m arm64ec -d test3.def -l test3.lib
+RUN: llvm-readobj test3.lib | FileCheck --check-prefix=ALIAS %s
+
+ALIAS:      File: test.dll
+ALIAS-NEXT: Format: COFF-import-file-ARM64EC
+ALIAS-NEXT: Type: code
+ALIAS-NEXT: Name type: export as
+ALIAS-NEXT: Export name: efunc
+ALIAS-NEXT: Symbol: __imp_func
+ALIAS-NEXT: Symbol: func
+ALIAS-NEXT: Symbol: __imp_aux_func
+ALIAS-NEXT: Symbol: #func
+ALIAS-EMPTY:
+ALIAS-NEXT: File: test.dll
+ALIAS-NEXT: Format: COFF-import-file-ARM64EC
+ALIAS-NEXT: Type: code
+ALIAS-NEXT: Name type: export as
+ALIAS-NEXT: Export name: efunc
+ALIAS-NEXT: Symbol: __imp_efunc
+ALIAS-NEXT: Symbol: efunc
+ALIAS-NEXT: Symbol: __imp_aux_efunc
+ALIAS-NEXT: Symbol: #efunc
+
 #--- test.def
 LIBRARY test.dll
 EXPORTS
@@ -53,3 +76,9 @@ EXPORTS
 LIBRARY test.dll
 EXPORTS
     otherfunc
+
+#--- test3.def
+LIBRARY test.dll
+EXPORTS
+    func == efunc
+    efunc


### PR DESCRIPTION
As discussed in #98229, renamed entries are more tricky on ARM64EC due to additional symbols (we need `__imp_aux_*` in addition to `__imp_*` and both mangled and unmangled symbol thunks). While we could extend weak aliases to add them, it seems cleaner to just always use EXPORTAS name type on ARM64EC targets. Unlike other targets, linkers supporting ARM64EC need to support EXPORTAS, so there is no compatibility problem with that.

Compared to weak aliases, there is a small difference for linked binaries. If both original and aliased names are referenced, this solution will create separate import entries with the same name. I don't think it's a problem in practice. Both MSVC and LLD (from my WIP branch) are fine with it and such binaries run fine on Windows.