### PR TITLE
[lld-macho][test] Require "shell" feature for usage of `ln -s`

### DIFF
--- a/lld/test/MachO/implicit-and-allowable-clients.test
+++ b/lld/test/MachO/implicit-and-allowable-clients.test
@@ -1,4 +1,4 @@
-# REQUIRES: aarch64
+# REQUIRES: aarch64, shell
 # RUN: rm -rf %t; split-file %s %t
 # RUN: ln -s Versions/A/FrameworkPublic.tbd %t/System/Library/Frameworks/FrameworkPublic.framework/
 # RUN: ln -s Versions/A/FrameworkPrivate.tbd %t/System/Library/Frameworks/FrameworkPrivate.framework/


### PR DESCRIPTION
The use of `ln -s` is not guaranteed to be supported on Windows.