### PR TITLE
[lldb][test] Fix simulator test for std::unique_ptr

### DIFF
--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libcxx-simulators/unique_ptr/main.cpp
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libcxx-simulators/unique_ptr/main.cpp
@@ -1,5 +1,7 @@
 #include <libcxx-simulators-common/compressed_pair.h>
 
+#include <stdio.h>
+
 namespace std {
 namespace __lldb {
 template <class _Tp> struct default_delete {


### PR DESCRIPTION
libcxx-simulators/unique_ptr/main.cpp uses __builtin_printf, that
maps to printf on Windows. Include stdio.h to avoid linker errors
on Windows.
See https://lab.llvm.org/buildbot/#/builders/141/builds/853
