### PR TITLE
[mlir][NFC] Add rewrite header to fix standalone header compile

### DIFF
--- a/mlir/include/mlir/CAPI/Rewrite.h
+++ b/mlir/include/mlir/CAPI/Rewrite.h
@@ -15,6 +15,7 @@
 #ifndef MLIR_CAPI_REWRITE_H
 #define MLIR_CAPI_REWRITE_H
 
+#include "mlir-c/Rewrite.h"
 #include "mlir/CAPI/Wrap.h"
 #include "mlir/IR/PatternMatch.h"
 


### PR DESCRIPTION
This uses `MlirRewriterBase` from from `mlir-c/Rewrite.h` without including it.