### PR TITLE
[flang] A nested STRUCTURE must declare entities

### DIFF
--- a/flang/test/Semantics/struct03.f90
+++ b/flang/test/Semantics/struct03.f90
@@ -1,0 +1,7 @@
+! RUN: %python %S/test_errors.py %s %flang_fc1
+  structure /s/
+    !ERROR: entity declarations are required on a nested structure
+    structure /nested/
+    end structure
+  end structure
+end


### PR DESCRIPTION
When a DEC legacy STRUCTURE definition appears within another, its STRUCTURE statement must also declare some components of the enclosing structure.

Fixes https://github.com/llvm/llvm-project/issues/99288.