### PR TITLE
[libcxx] Disable invalid `__start/__stop` reference on NVPTX

### DIFF
--- a/libcxx/src/include/overridable_function.h
+++ b/libcxx/src/include/overridable_function.h
@@ -96,6 +96,7 @@ _LIBCPP_HIDE_FROM_ABI bool __is_function_overridden(_Ret (*__fptr)(_Args...)) no
 }
 _LIBCPP_END_NAMESPACE_STD
 
+// The NVPTX linker cannot create '__start/__stop' sections.
 #elif defined(_LIBCPP_OBJECT_FORMAT_ELF) && !defined(__NVPTX__)
 
 #  define _LIBCPP_CAN_DETECT_OVERRIDDEN_FUNCTION 1

--- a/libcxx/src/include/overridable_function.h
+++ b/libcxx/src/include/overridable_function.h
@@ -96,7 +96,7 @@ _LIBCPP_HIDE_FROM_ABI bool __is_function_overridden(_Ret (*__fptr)(_Args...)) no
 }
 _LIBCPP_END_NAMESPACE_STD
 
-#elif defined(_LIBCPP_OBJECT_FORMAT_ELF)
+#elif defined(_LIBCPP_OBJECT_FORMAT_ELF) && !defined(__NVPTX__)
 
 #  define _LIBCPP_CAN_DETECT_OVERRIDDEN_FUNCTION 1
 #  define _LIBCPP_MAKE_OVERRIDABLE_FUNCTION_DETECTABLE __attribute__((__section__("__lcxx_override")))


### PR DESCRIPTION
Summary:
The logic for this `__is_function_overridden` check requires accessing a
runtime array normally created by the linker. The NVPTX target is an
`__ELF__` target, however it does not support emitting the
`__start/__stop` symbols for C-identifier named sections. This needs to
be disabled explicitly so that the user can compile this with anything.
