### PR TITLE
Revert "[ADT] Make set_subtract more efficient when subtrahend is larger (NFC)"

### DIFF
--- a/llvm/include/llvm/ADT/SetOperations.h
+++ b/llvm/include/llvm/ADT/SetOperations.h
@@ -94,22 +94,7 @@ S1Ty set_difference(const S1Ty &S1, const S2Ty &S2) {
 
 /// set_subtract(A, B) - Compute A := A - B
 ///
-/// Selects the set to iterate based on the relative sizes of A and B for better
-/// efficiency.
-///
 template <class S1Ty, class S2Ty> void set_subtract(S1Ty &S1, const S2Ty &S2) {
-  using ElemTy = decltype(*S1.begin());
-  // A couple callers pass a vector for S2, which doesn't support contains(),
-  // and wouldn't be efficient if it did.
-  if constexpr (detail::HasMemberContains<S2Ty, ElemTy>) {
-    if (S1.size() < S2.size()) {
-      for (typename S1Ty::iterator SI = S1.begin(), SE = S1.end(); SI != SE;
-           ++SI)
-        if (S2.contains(*SI))
-          S1.erase(SI);
-      return;
-    }
-  }
   for (typename S2Ty::const_iterator SI = S2.begin(), SE = S2.end(); SI != SE;
        ++SI)
     S1.erase(*SI);


### PR DESCRIPTION
Reverts llvm/llvm-project#98702

This broke some mlir code and needs investigation.