### PR TITLE
[libc] Temporarily disable statvfs header

### DIFF
--- a/libc/config/linux/x86_64/headers.txt
+++ b/libc/config/linux/x86_64/headers.txt
@@ -45,7 +45,8 @@ set(TARGET_PUBLIC_HEADERS
     libc.include.sys_select
     libc.include.sys_socket
     libc.include.sys_stat
-    libc.include.sys_statvfs
+    # statvfs is broken, will uncomment once it's fixed.
+    # libc.include.sys_statvfs
     libc.include.sys_syscall
     libc.include.sys_time
     libc.include.sys_types


### PR DESCRIPTION
The statfvs header was not generating for a while. Patch #98983 added it
to the list of headers, but it's apparently broken right now so this
patch comments it out until it can be fixed.
