### PR TITLE
[libc] make rand() wait-free

### DIFF
--- a/libc/src/stdlib/rand.cpp
+++ b/libc/src/stdlib/rand.cpp
@@ -31,7 +31,7 @@ LLVM_LIBC_FUNCTION(int, rand, (void)) {
   x = (x >> 32) | (x << 32); 
   uint64_t result = (x * x + z) >> 32;
   // project into range
-  return static_cast<int>(((result) % RAND_MAX + RAND_MAX) % RAND_MAX);
+  return static_cast<int>((result % RAND_MAX + RAND_MAX) % RAND_MAX);
 }
 
 } // namespace LIBC_NAMESPACE_DECL


### PR DESCRIPTION
Use counter based random generator to make `rand()` wait-free. Since we use thread shared random state, counter based approach can perform better.