### PR TITLE
[BOLT] Update Docker to use Ubuntu 24.04

### DIFF
--- a/bolt/utils/docker/Dockerfile
+++ b/bolt/utils/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04 AS builder
+FROM ubuntu:24.04 AS builder
 
 ARG DEBIAN_FRONTEND=noninteractive
 ENV TZ=UTC
@@ -26,6 +26,6 @@ RUN mkdir build && \
     ninja install-llvm-bolt install-perf2bolt install-merge-fdata \
       install-llvm-boltdiff install-bolt_rt
 
-FROM ubuntu:20.04
+FROM ubuntu:24.04
 
 COPY --from=builder /home/bolt/install /usr/local


### PR DESCRIPTION
Updates the Dockerfile to use Ubuntu 24.04 due to CMake wanting a newer version. Can be tested by trying to build the Docker image currently in main and then try building the Docker image in this PR.