### PR TITLE
[libc++][test] Raise a useful error when no -std=c++NN flag is found to work

### DIFF
--- a/libcxx/utils/libcxx/test/params.py
+++ b/libcxx/utils/libcxx/test/params.py
@@ -87,6 +87,7 @@ def getStdFlag(cfg, std):
         return "-std=" + fallbacks[std]
     return None
 
+
 def getDefaultStdValue(cfg):
     viable = [s for s in reversed(_allStandards) if getStdFlag(cfg, s)]
 
@@ -96,6 +97,7 @@ def getDefaultStdValue(cfg):
         )
 
     return viable[0]
+
 
 def getSpeedOptimizationFlag(cfg):
     if _isClang(cfg) or _isAppleClang(cfg) or _isGCC(cfg):

--- a/libcxx/utils/libcxx/test/params.py
+++ b/libcxx/utils/libcxx/test/params.py
@@ -87,6 +87,15 @@ def getStdFlag(cfg, std):
         return "-std=" + fallbacks[std]
     return None
 
+def getDefaultStdValue(cfg):
+    viable = [s for s in reversed(_allStandards) if getStdFlag(cfg, s)]
+
+    if not viable:
+        raise RuntimeError(
+            "Unable to successfully detect the presence of any -std=c++NN flag. This likely indicates an issue with your compiler."
+        )
+
+    return viable[0]
 
 def getSpeedOptimizationFlag(cfg):
     if _isClang(cfg) or _isAppleClang(cfg) or _isGCC(cfg):
@@ -170,9 +179,7 @@ DEFAULT_PARAMETERS = [
         choices=_allStandards,
         type=str,
         help="The version of the standard to compile the test suite with.",
-        default=lambda cfg: next(
-            s for s in reversed(_allStandards) if getStdFlag(cfg, s)
-        ),
+        default=lambda cfg: getDefaultStdValue(cfg),
         actions=lambda std: [
             AddFeature(std),
             AddSubstitution("%{cxx_std}", re.sub(r"\+", "x", std)),


### PR DESCRIPTION
Recently ran into an issue with symptoms very similar to https://github.com/llvm/llvm-project/issues/56816 while attempting to build and test libc++ on NixOS. The error message is cryptic (just `StopIteration`), which was very annoying to track down. The error at least saying "hey your compiler's bad" would have saved me quite a bit of time figuring out the issue.