### PR TITLE
Revert "[llvm/DWARF] Recursively resolve DW_AT_signature references"

### DIFF
--- a/llvm/include/llvm/DebugInfo/DWARF/DWARFDie.h
+++ b/llvm/include/llvm/DebugInfo/DWARF/DWARFDie.h
@@ -181,6 +181,8 @@ public:
   DWARFDie getAttributeValueAsReferencedDie(dwarf::Attribute Attr) const;
   DWARFDie getAttributeValueAsReferencedDie(const DWARFFormValue &V) const;
 
+  DWARFDie resolveTypeUnitReference() const;
+
   /// Extract the range base attribute from this DIE as absolute section offset.
   ///
   /// This is a utility function that checks for either the DW_AT_rnglists_base

--- a/llvm/lib/DebugInfo/DWARF/DWARFDie.cpp
+++ b/llvm/lib/DebugInfo/DWARF/DWARFDie.cpp
@@ -103,6 +103,10 @@ static void dumpLocationExpr(raw_ostream &OS, const DWARFFormValue &FormValue,
       .print(OS, DumpOpts, U);
 }
 
+static DWARFDie resolveReferencedType(DWARFDie D, DWARFFormValue F) {
+  return D.getAttributeValueAsReferencedDie(F).resolveTypeUnitReference();
+}
+
 static void dumpAttribute(raw_ostream &OS, const DWARFDie &Die,
                           const DWARFAttribute &AttrValue, unsigned Indent,
                           DIDumpOptions DumpOpts) {
@@ -194,8 +198,8 @@ static void dumpAttribute(raw_ostream &OS, const DWARFDie &Die,
                 DINameKind::LinkageName))
       OS << Space << "\"" << Name << '\"';
   } else if (Attr == DW_AT_type || Attr == DW_AT_containing_type) {
-    if (DWARFDie D = Die.getAttributeValueAsReferencedDie(FormValue);
-        D && !D.isNULL()) {
+    DWARFDie D = resolveReferencedType(Die, FormValue);
+    if (D && !D.isNULL()) {
       OS << Space << "\"";
       dumpTypeQualifiedName(D, OS);
       OS << '"';
@@ -287,12 +291,13 @@ DWARFDie::findRecursively(ArrayRef<dwarf::Attribute> Attrs) const {
     if (auto Value = Die.find(Attrs))
       return Value;
 
-    for (dwarf::Attribute Attr :
-         {DW_AT_abstract_origin, DW_AT_specification, DW_AT_signature}) {
-      if (auto D = Die.getAttributeValueAsReferencedDie(Attr))
-        if (Seen.insert(D).second)
-          Worklist.push_back(D);
-    }
+    if (auto D = Die.getAttributeValueAsReferencedDie(DW_AT_abstract_origin))
+      if (Seen.insert(D).second)
+        Worklist.push_back(D);
+
+    if (auto D = Die.getAttributeValueAsReferencedDie(DW_AT_specification))
+      if (Seen.insert(D).second)
+        Worklist.push_back(D);
   }
 
   return std::nullopt;
@@ -314,12 +319,19 @@ DWARFDie::getAttributeValueAsReferencedDie(const DWARFFormValue &V) const {
   } else if (Offset = V.getAsDebugInfoReference(); Offset) {
     if (DWARFUnit *SpecUnit = U->getUnitVector().getUnitForOffset(*Offset))
       Result = SpecUnit->getDIEForOffset(*Offset);
-  } else if (std::optional<uint64_t> Sig = V.getAsSignatureReference()) {
-    if (DWARFTypeUnit *TU = U->getContext().getTypeUnitForHash(
-            U->getVersion(), *Sig, U->isDWOUnit()))
-      Result = TU->getDIEForOffset(TU->getTypeOffset() + TU->getOffset());
   }
   return Result;
+}
+
+DWARFDie DWARFDie::resolveTypeUnitReference() const {
+  if (auto Attr = find(DW_AT_signature)) {
+    if (std::optional<uint64_t> Sig = Attr->getAsReferenceUVal()) {
+      if (DWARFTypeUnit *TU = U->getContext().getTypeUnitForHash(
+              U->getVersion(), *Sig, U->isDWOUnit()))
+        return TU->getDIEForOffset(TU->getTypeOffset() + TU->getOffset());
+    }
+  }
+  return *this;
 }
 
 std::optional<uint64_t> DWARFDie::getRangesBaseAttribute() const {

--- a/llvm/test/tools/llvm-dwarfdump/X86/prettyprint_type_units.s
+++ b/llvm/test/tools/llvm-dwarfdump/X86/prettyprint_type_units.s
@@ -18,15 +18,12 @@
 # doesn't really need templates - two local variables would've sufficed
 # (anything that references the type units) but I was working on something else
 # and this seemed minimal enough.
-# A gcc-style type signature reference was also inserted.
 
 
 # CHECK: DW_TAG_template_type_parameter
 # CHECK:   DW_AT_type ({{.*}} "t1")
 # CHECK: DW_TAG_template_type_parameter
 # CHECK:   DW_AT_type ({{.*}} "t2")
-# CHECK: DW_TAG_template_type_parameter
-# CHECK:   DW_AT_type (0xc6694e51369161f2 "t1")
 
 	.text
 	.file	"test.cpp"
@@ -273,13 +270,6 @@ _Z2f1IJ2t12t2EEvv:                      # @_Z2f1IJ2t12t2EEvv
 	.byte	11                              # DW_FORM_data1
 	.byte	0                               # EOM(1)
 	.byte	0                               # EOM(2)
-	.byte	12                              # Abbreviation Code
-	.byte	47                              # DW_TAG_template_type_parameter
-	.byte	0                               # DW_CHILDREN_no
-	.byte	73                              # DW_AT_type
-	.byte	32                              # DW_FORM_ref_sig8
-	.byte	0                               # EOM(1)
-	.byte	0                               # EOM(2)
 	.byte	0                               # EOM(3)
 	.section	.debug_info,"",@progbits
 .Lcu_begin0:
@@ -323,23 +313,18 @@ _Z2f1IJ2t12t2EEvv:                      # @_Z2f1IJ2t12t2EEvv
 	.byte	6                               # Abbrev [6] 0x46:0xd DW_TAG_GNU_template_parameter_pack
 	.byte	5                               # DW_AT_name
 	.byte	7                               # Abbrev [7] 0x48:0x5 DW_TAG_template_type_parameter
-	.long	.Lt1_decl-.Lcu_begin0           # DW_AT_type
+	.long	88                              # DW_AT_type
 	.byte	7                               # Abbrev [7] 0x4d:0x5 DW_TAG_template_type_parameter
-	# Simulate DWARF emitted by GCC where the signature is directly in the type attribute.
-	.long	.Lt2_decl-.Lcu_begin0           # DW_AT_type
-	.byte	12                              # Abbrev [12] DW_TAG_template_type_parameter
-	.quad	-4149699470930386446            # DW_AT_type
+	.long	97                              # DW_AT_type
 	.byte	0                               # End Of Children Mark
 	.byte	0                               # End Of Children Mark
 	.byte	8                               # Abbrev [8] 0x54:0x4 DW_TAG_base_type
 	.byte	4                               # DW_AT_name
 	.byte	5                               # DW_AT_encoding
 	.byte	4                               # DW_AT_byte_size
-  .Lt1_decl:
 	.byte	9                               # Abbrev [9] 0x58:0x9 DW_TAG_structure_type
                                         # DW_AT_declaration
 	.quad	-4149699470930386446            # DW_AT_signature
-  .Lt2_decl:
 	.byte	9                               # Abbrev [9] 0x61:0x9 DW_TAG_structure_type
                                         # DW_AT_declaration
 	.quad	5649318945901130368             # DW_AT_signature


### PR DESCRIPTION
Reverts llvm/llvm-project#97423 due to a failure in the cross-project-tests.