### PR TITLE
[safestack] Various 32-bit Linux fixes

### DIFF
--- a/compiler-rt/lib/safestack/safestack_platform.h
+++ b/compiler-rt/lib/safestack/safestack_platform.h
@@ -7,6 +7,8 @@
 //===----------------------------------------------------------------------===//
 //
 // This file implements platform specific parts of SafeStack runtime.
+// Don't use equivalent functionality from sanitizer_common to avoid dragging
+// a large codebase into security sensitive code.
 //
 //===----------------------------------------------------------------------===//
 
@@ -43,6 +45,19 @@ extern "C" void *__mmap(void *, size_t, int, int, int, int, off_t);
 
 #if SANITIZER_SOLARIS
 #  include <thread.h>
+#endif
+
+// Keep in sync with sanitizer_linux.cpp.
+//
+// Are we using 32-bit or 64-bit Linux syscalls?
+// x32 (which defines __x86_64__) has SANITIZER_WORDSIZE == 32
+// but it still needs to use 64-bit syscalls.
+#if SANITIZER_LINUX &&                                \
+    (defined(__x86_64__) || defined(__powerpc64__) || \
+     SANITIZER_WORDSIZE == 64 || (defined(__mips__) && _MIPS_SIM == _ABIN32))
+#  define SANITIZER_LINUX_USES_64BIT_SYSCALLS 1
+#else
+#  define SANITIZER_LINUX_USES_64BIT_SYSCALLS 0
 #endif
 
 namespace safestack {
@@ -117,7 +132,8 @@ inline int TgKill(pid_t pid, ThreadId tid, int sig) {
 #elif SANITIZER_FREEBSD
   return syscall(SYS_thr_kill2, pid, tid, sig);
 #else
-  return syscall(SYS_tgkill, pid, tid, sig);
+  // tid is pid_t (int), not ThreadId (uint64_t).
+  return syscall(SYS_tgkill, pid, (pid_t)tid, sig);
 #endif
 }
 
@@ -129,8 +145,13 @@ inline void *Mmap(void *addr, size_t length, int prot, int flags, int fd,
   return (void *)__syscall(SYS_mmap, addr, length, prot, flags, fd, offset);
 #elif SANITIZER_SOLARIS
   return _REAL64(mmap)(addr, length, prot, flags, fd, offset);
-#else
+#elif SANITIZER_LINUX_USES_64BIT_SYSCALLS
   return (void *)syscall(SYS_mmap, addr, length, prot, flags, fd, offset);
+#else
+  // mmap2 specifies file offset in 4096-byte units.
+  SFS_CHECK(IsAligned(offset, 4096));
+  return (void *)syscall(SYS_mmap2, addr, length, prot, flags, fd,
+                         offset / 4096);
 #endif
 }
 

--- a/compiler-rt/lib/safestack/safestack_util.h
+++ b/compiler-rt/lib/safestack/safestack_util.h
@@ -33,6 +33,10 @@ inline size_t RoundUpTo(size_t size, size_t boundary) {
   return (size + boundary - 1) & ~(boundary - 1);
 }
 
+inline constexpr bool IsAligned(size_t a, size_t alignment) {
+  return (a & (alignment - 1)) == 0;
+}
+
 class MutexLock {
  public:
   explicit MutexLock(pthread_mutex_t &mutex) : mutex_(&mutex) {


### PR DESCRIPTION
When enabling 32-bit testing on Linux/i386 and Linux/sparc, many tests `FAIL`:

- All Linux/i386 tests `FAIL` with ``` safestack CHECK failed: /vol/llvm/src/llvm-project/local/compiler-rt/lib/safestack/safestack.cpp:95 MAP_FAILED != addr ``` because the safestack `mmap` implementation doesn't work there.  This patch adjusts it to match the `sanitizer_linux.cpp.c` one.
- On 32-bit Linux/sparc, the `pthread*.c` tests `FAIL` because a `tid_t` (`uint64_t`) `tid` arg was passed to `syscall(SYS_tgkill)` while `tid` is actually a `pid_t` (`int`).  Fixed by adding a cast.

Tested on `x86_64-pc-linux-gnu` (32 and 64-bit) and `sparc64-unknown-linux-gnu` (32 and 64-bit).