### PR TITLE
[sanitizer] Fix running sanitizer_set_report_path_test on Android

### DIFF
--- a/compiler-rt/test/sanitizer_common/TestCases/Posix/sanitizer_set_report_path_test.cpp
+++ b/compiler-rt/test/sanitizer_common/TestCases/Posix/sanitizer_set_report_path_test.cpp
@@ -6,7 +6,6 @@
 #include <sanitizer/common_interface_defs.h>
 #include <stdio.h>
 #include <string.h>
-#include <unistd.h>
 
 volatile int *null = 0;
 
@@ -15,16 +14,12 @@ int main(int argc, char **argv) {
   sprintf(buff, "%s.report_path/report", argv[0]);
   __sanitizer_set_report_path(buff);
   assert(strncmp(buff, __sanitizer_get_report_path(), strlen(buff)) == 0);
-  sprintf(buff, "Path %s\n", __sanitizer_get_report_path());
-  write(STDERR_FILENO, buff, strlen(buff));
 
   // Try setting again with an invalid/inaccessible directory.
-  sprintf(buff, "%s/report", argv[0]);
-  __sanitizer_set_report_path(buff);
-  sprintf(buff, "Path %s\n", __sanitizer_get_report_path());
-  write(STDERR_FILENO, buff, strlen(buff));
+  char buff_bad[1000];
+  sprintf(buff_bad, "%s/report", argv[0]);
+  __sanitizer_set_report_path(buff_bad);
+  assert(strncmp(buff, __sanitizer_get_report_path(), strlen(buff)) == 0);
 }
 
-// CHECK: Path {{.*}}Posix/Output/sanitizer_set_report_path_test.cpp.tmp.report_path/report.
 // CHECK: ERROR: Can't create directory: {{.*}}Posix/Output/sanitizer_set_report_path_test.cpp.tmp
-// CHECK-NOT: Path {{.*}}Posix/Output/sanitizer_set_report_path_test.cpp.tmp

--- a/compiler-rt/test/sanitizer_common/TestCases/Posix/sanitizer_set_report_path_test.cpp
+++ b/compiler-rt/test/sanitizer_common/TestCases/Posix/sanitizer_set_report_path_test.cpp
@@ -6,6 +6,7 @@
 #include <sanitizer/common_interface_defs.h>
 #include <stdio.h>
 #include <string.h>
+#include <unistd.h>
 
 volatile int *null = 0;
 
@@ -14,13 +15,14 @@ int main(int argc, char **argv) {
   sprintf(buff, "%s.report_path/report", argv[0]);
   __sanitizer_set_report_path(buff);
   assert(strncmp(buff, __sanitizer_get_report_path(), strlen(buff)) == 0);
-  printf("Path %s\n", __sanitizer_get_report_path());
-  fflush(stdout);
+  sprintf(buff, "Path %s\n", __sanitizer_get_report_path());
+  write(STDERR_FILENO, buff, strlen(buff));
 
   // Try setting again with an invalid/inaccessible directory.
   sprintf(buff, "%s/report", argv[0]);
   __sanitizer_set_report_path(buff);
-  printf("Path %s\n", __sanitizer_get_report_path());
+  sprintf(buff, "Path %s\n", __sanitizer_get_report_path());
+  write(STDERR_FILENO, buff, strlen(buff));
 }
 
 // CHECK: Path {{.*}}Posix/Output/sanitizer_set_report_path_test.cpp.tmp.report_path/report.


### PR DESCRIPTION
sanitizer_set_report_path_test outputs the following on an Android builder [1]:

    ERROR: Can't create directory: /data/local/tmp/Output/var/lib/buildbot/sanitizer-buildbot6/sanitizer-x86_64-linux-android/build/compiler_rt_build_android_arm/test/sanitizer_common/asan-arm-Android/Posix/Output/sanitizer_set_report_path_test.cpp.tmp
    Path /data/local/tmp/Output/var/lib/buildbot/sanitizer-buildbot6/sanitizer-x86_64-linux-android/build/compiler_rt_build_android_arm/test/sanitizer_common/asan-arm-Android/Posix/Output/sanitizer_set_report_path_test.cpp.tmp.report_path/report.24954

The order of messages is reversed. The "Path" message is printed with printf(), and the "ERROR:" message is printed with write(STDERR_FILENO). However, there is an fflush() in between, which is supposed to prevent reordering.

Work around the issue by using write(STDERR_FILENO) to write the "Path" message.

[1] https://lab.llvm.org/buildbot/#/builders/186/builds/703/steps/26/logs/stdio