### PR TITLE
[clang-tidy][NFC] Fix gsl::not_null template parameter

### DIFF
--- a/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/avoid-const-or-ref-data-members.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/avoid-const-or-ref-data-members.rst
@@ -35,7 +35,7 @@ Examples:
     int* x;
     std::unique_ptr<int> x;
     std::shared_ptr<int> x;
-    gsl::not_null<int> x;
+    gsl::not_null<int*> x;
   };
 
   // Bad, rvalue reference member

--- a/clang-tools-extra/test/clang-tidy/checkers/cppcoreguidelines/avoid-const-or-ref-data-members.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/cppcoreguidelines/avoid-const-or-ref-data-members.cpp
@@ -18,7 +18,7 @@ struct Ok {
   const int *pc;
   std::unique_ptr<int> up;
   std::shared_ptr<int> sp;
-  gsl::not_null<int> n;
+  gsl::not_null<int*> n;
 };
 
 struct ConstMember {
@@ -60,7 +60,7 @@ struct Ok2 {
   const Foo *pc;
   std::unique_ptr<Foo> up;
   std::shared_ptr<Foo> sp;
-  gsl::not_null<Foo> n;
+  gsl::not_null<Foo*> n;
 };
 
 struct ConstMember2 {


### PR DESCRIPTION
`T` is expected to be a pointer type.

https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Rf-nullptr