### PR TITLE
[clang-tidy][cppcoreguidelines-missing-std-forward] Do not warn when the parameter is used in a `static_cast<T&>`.

### DIFF
--- a/clang-tools-extra/clang-tidy/cppcoreguidelines/MissingStdForwardCheck.cpp
+++ b/clang-tools-extra/clang-tidy/cppcoreguidelines/MissingStdForwardCheck.cpp
@@ -88,6 +88,11 @@ AST_MATCHER(VarDecl, hasIdentifier) {
 
 } // namespace
 
+MissingStdForwardCheck::MissingStdForwardCheck(StringRef Name,
+                                               ClangTidyContext *Context)
+    : ClangTidyCheck(Name, Context),
+      IgnoreStaticCasts(Options.get("IgnoreStaticCasts", false)) {}
+
 void MissingStdForwardCheck::registerMatchers(MatchFinder *Finder) {
   auto RefToParmImplicit = allOf(
       equalsBoundNode("var"), hasInitializer(ignoringParenImpCasts(
@@ -132,7 +137,7 @@ void MissingStdForwardCheck::registerMatchers(MatchFinder *Finder) {
                    hasAncestor(expr(hasUnevaluatedContext())))));
 
   auto StaticCast =
-      Options.get("IgnoreStaticCasts", false)
+      IgnoreStaticCasts
           ? cxxStaticCastExpr(
                 hasDestinationType(lValueReferenceType(
                     pointee(type(equalsBoundNode("qtype"))))),

--- a/clang-tools-extra/clang-tidy/cppcoreguidelines/MissingStdForwardCheck.cpp
+++ b/clang-tools-extra/clang-tidy/cppcoreguidelines/MissingStdForwardCheck.cpp
@@ -129,8 +129,10 @@ void MissingStdForwardCheck::registerMatchers(MatchFinder *Finder) {
       unless(anyOf(hasAncestor(typeLoc()),
                    hasAncestor(expr(hasUnevaluatedContext())))));
 
-  auto StaticCast = cxxStaticCastExpr(
-      hasSourceExpression(declRefExpr(to(equalsBoundNode("param")))));
+  auto StaticCast = Options.get("IgnoreStaticCasts", false)
+                        ? cxxStaticCastExpr(hasSourceExpression(
+                              declRefExpr(to(equalsBoundNode("param")))))
+                        : cxxStaticCastExpr(unless(anything()));
 
   Finder->addMatcher(
       parmVarDecl(

--- a/clang-tools-extra/clang-tidy/cppcoreguidelines/MissingStdForwardCheck.cpp
+++ b/clang-tools-extra/clang-tidy/cppcoreguidelines/MissingStdForwardCheck.cpp
@@ -129,6 +129,9 @@ void MissingStdForwardCheck::registerMatchers(MatchFinder *Finder) {
       unless(anyOf(hasAncestor(typeLoc()),
                    hasAncestor(expr(hasUnevaluatedContext())))));
 
+  auto StaticCast = cxxStaticCastExpr(
+      hasSourceExpression(declRefExpr(to(equalsBoundNode("param")))));
+
   Finder->addMatcher(
       parmVarDecl(
           parmVarDecl().bind("param"), hasIdentifier(),
@@ -136,8 +139,9 @@ void MissingStdForwardCheck::registerMatchers(MatchFinder *Finder) {
           hasAncestor(functionDecl().bind("func")),
           hasAncestor(functionDecl(
               isDefinition(), equalsBoundNode("func"), ToParam,
-              unless(anyOf(isDeleted(),
-                           hasDescendant(std::move(ForwardCallMatcher))))))),
+              unless(anyOf(isDeleted(), hasDescendant(expr(
+                                            anyOf(std::move(ForwardCallMatcher),
+                                                  std::move(StaticCast))))))))),
       this);
 }
 

--- a/clang-tools-extra/clang-tidy/cppcoreguidelines/MissingStdForwardCheck.cpp
+++ b/clang-tools-extra/clang-tidy/cppcoreguidelines/MissingStdForwardCheck.cpp
@@ -26,7 +26,8 @@ AST_MATCHER_P(QualType, possiblyPackExpansionOf,
 }
 
 AST_MATCHER_P(ParmVarDecl, isForwardingReferenceType,
-              ast_matchers::internal::Matcher<RValueReferenceType>, InnerMatcher) {
+              ast_matchers::internal::Matcher<RValueReferenceType>,
+              InnerMatcher) {
   ast_matchers::internal::Matcher<QualType> Inner = possiblyPackExpansionOf(
       qualType(rValueReferenceType(InnerMatcher),
                references(templateTypeParmType(
@@ -130,17 +131,13 @@ void MissingStdForwardCheck::registerMatchers(MatchFinder *Finder) {
       unless(anyOf(hasAncestor(typeLoc()),
                    hasAncestor(expr(hasUnevaluatedContext())))));
 
-  auto StaticCast = Options.get("IgnoreStaticCasts", false)
-                        ? cxxStaticCastExpr(hasDestinationType(
-        lValueReferenceType(
-            pointee(
-                type(equalsBoundNode("qtype"))
-            )
-        )
-    ),
-                                            hasSourceExpression(
-                              declRefExpr(to(equalsBoundNode("param")))))
-                        : cxxStaticCastExpr(unless(anything()));
+  auto StaticCast =
+      Options.get("IgnoreStaticCasts", false)
+          ? cxxStaticCastExpr(
+                hasDestinationType(lValueReferenceType(
+                    pointee(type(equalsBoundNode("qtype"))))),
+                hasSourceExpression(declRefExpr(to(equalsBoundNode("param")))))
+          : cxxStaticCastExpr(unless(anything()));
 
   Finder->addMatcher(
       parmVarDecl(

--- a/clang-tools-extra/clang-tidy/cppcoreguidelines/MissingStdForwardCheck.cpp
+++ b/clang-tools-extra/clang-tidy/cppcoreguidelines/MissingStdForwardCheck.cpp
@@ -93,6 +93,10 @@ MissingStdForwardCheck::MissingStdForwardCheck(StringRef Name,
     : ClangTidyCheck(Name, Context),
       IgnoreStaticCasts(Options.get("IgnoreStaticCasts", false)) {}
 
+void MissingStdForwardCheck::storeOptions(ClangTidyOptions::OptionMap &Opts) {
+  Options.store(Opts, "IgnoreStaticCasts", IgnoreStaticCasts);
+}
+
 void MissingStdForwardCheck::registerMatchers(MatchFinder *Finder) {
   auto RefToParmImplicit = allOf(
       equalsBoundNode("var"), hasInitializer(ignoringParenImpCasts(

--- a/clang-tools-extra/clang-tidy/cppcoreguidelines/MissingStdForwardCheck.h
+++ b/clang-tools-extra/clang-tidy/cppcoreguidelines/MissingStdForwardCheck.h
@@ -21,8 +21,8 @@ namespace clang::tidy::cppcoreguidelines {
 /// http://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines/missing-std-forward.html
 class MissingStdForwardCheck : public ClangTidyCheck {
 public:
-  MissingStdForwardCheck(StringRef Name, ClangTidyContext *Context)
-      : ClangTidyCheck(Name, Context) {}
+  MissingStdForwardCheck(StringRef Name, ClangTidyContext *Context);
+
   void registerMatchers(ast_matchers::MatchFinder *Finder) override;
   void check(const ast_matchers::MatchFinder::MatchResult &Result) override;
   bool isLanguageVersionSupported(const LangOptions &LangOpts) const override {
@@ -31,6 +31,9 @@ public:
   std::optional<TraversalKind> getCheckTraversalKind() const override {
     return TK_IgnoreUnlessSpelledInSource;
   }
+
+private:
+  const bool IgnoreStaticCasts;
 };
 
 } // namespace clang::tidy::cppcoreguidelines

--- a/clang-tools-extra/clang-tidy/cppcoreguidelines/MissingStdForwardCheck.h
+++ b/clang-tools-extra/clang-tidy/cppcoreguidelines/MissingStdForwardCheck.h
@@ -23,6 +23,7 @@ class MissingStdForwardCheck : public ClangTidyCheck {
 public:
   MissingStdForwardCheck(StringRef Name, ClangTidyContext *Context);
 
+  void storeOptions(ClangTidyOptions::OptionMap &Opts) override;
   void registerMatchers(ast_matchers::MatchFinder *Finder) override;
   void check(const ast_matchers::MatchFinder::MatchResult &Result) override;
   bool isLanguageVersionSupported(const LangOptions &LangOpts) const override {

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -104,12 +104,13 @@ New check aliases
 Changes in existing checks
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+- Improved :doc:`cppcoreguidelines-missing-std-forward
+  <clang-tidy/checks/cppcoreguidelines/missing-std-forward>` check to allow
+  using ``static_cast<T&>`` to explicitly convey the intention of using a
+  forwarding reference as an lvalue reference.Removed checks
+
 - Improved :doc:`modernize-use-std-format
   <clang-tidy/checks/modernize/use-std-format>` check to support replacing
-  member function calls too.
-
-- Improved :doc:`modernize-use-std-print
-  <clang-tidy/checks/modernize/use-std-print>` check to support replacing
   member function calls too.
 
 - Improved :doc:`readablility-implicit-bool-conversion
@@ -120,11 +121,6 @@ Changes in existing checks
 - Improved :doc:`readability-redundant-smartptr-get
   <clang-tidy/checks/readability/redundant-smartptr-get>` check to
   remove `->`, when redundant `get()` is removed.
-
-- Improved :doc:`cppcoreguidelines-missing-std-forward
-  <clang-tidy/checks/cppcoreguidelines/missing-std-forward>` check to allow
-  using ``static_cast<T&>`` to explicitly convey the intention of using a
-  forwarding reference as an lvalue reference.
 
 Removed checks
 ^^^^^^^^^^^^^^

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -113,6 +113,10 @@ Changes in existing checks
   <clang-tidy/checks/modernize/use-std-format>` check to support replacing
   member function calls too.
 
+- Improved :doc:`modernize-use-std-print
+  <clang-tidy/checks/modernize/use-std-print>` check to support replacing
+  member function calls too.
+
 - Improved :doc:`readablility-implicit-bool-conversion
   <clang-tidy/checks/readability/implicit-bool-conversion>` check
   by adding the option `UseUpperCaseLiteralSuffix` to select the

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -121,6 +121,11 @@ Changes in existing checks
   <clang-tidy/checks/readability/redundant-smartptr-get>` check to
   remove `->`, when redundant `get()` is removed.
 
+- Improved :doc:`cppcoreguidelines-missing-std-forward
+  <clang-tidy/checks/cppcoreguidelines/missing-std-forward>` check to allow
+  using ``static_cast<T&>`` to explicitly convey the intention of using a
+  forwarding reference as an lvalue reference.
+
 Removed checks
 ^^^^^^^^^^^^^^
 

--- a/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/missing-std-forward.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/missing-std-forward.rst
@@ -38,3 +38,6 @@ Example:
 This check implements `F.19
 <http://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Rf-forward>`_
 from the C++ Core Guidelines.
+
+Users who want to use the forwarding reference as an lvalue reference can convey
+the intention by using ``static_cast<T&>(t)``.

--- a/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/missing-std-forward.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/missing-std-forward.rst
@@ -45,7 +45,7 @@ Options
 
 .. option:: IgnoreStaticCasts
 
-Boolean flag to allow users who want to use the forwarding reference as an
-lvalue reference to convey he intention by using ``static_cast<T&>(t)`` to
-disable warning. Default value is `false`.
+   Boolean flag to allow users who want to use the forwarding reference as an
+   lvalue reference to convey he intention by using ``static_cast<T&>(t)`` to
+   disable warning. Default value is `false`.
 

--- a/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/missing-std-forward.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/missing-std-forward.rst
@@ -39,5 +39,13 @@ This check implements `F.19
 <http://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Rf-forward>`_
 from the C++ Core Guidelines.
 
-Users who want to use the forwarding reference as an lvalue reference can convey
-the intention by using ``static_cast<T&>(t)``.
+
+Options
+-------
+
+.. option:: IgnoreStaticCasts
+
+Boolean flag to allow users who want to use the forwarding reference as an
+lvalue reference to convey he intention by using ``static_cast<T&>(t)`` to
+disable warning. Default value is `false`.
+

--- a/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/missing-std-forward.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/missing-std-forward.rst
@@ -39,7 +39,6 @@ This check implements `F.19
 <http://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Rf-forward>`_
 from the C++ Core Guidelines.
 
-
 Options
 -------
 
@@ -48,4 +47,3 @@ Options
    Boolean flag to allow users who want to use the forwarding reference as an
    lvalue reference to convey he intention by using ``static_cast<T&>(t)`` to
    disable warning. Default value is `false`.
-

--- a/clang-tools-extra/test/clang-tidy/checkers/cppcoreguidelines/missing-std-forward-casts.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/cppcoreguidelines/missing-std-forward-casts.cpp
@@ -15,14 +15,62 @@ template <typename T> using remove_reference_t = typename remove_reference<T>::t
 template <typename T> constexpr T &&forward(remove_reference_t<T> &t) noexcept;
 template <typename T> constexpr T &&forward(remove_reference_t<T> &&t) noexcept;
 
+template<typename T> using add_lvalue_reference_t = __add_lvalue_reference(T);
+
 } // namespace std
 // NOLINTEND
 
 namespace in_static_cast {
 
 template<typename T>
-void static_cast_to_lvalue_ref(T&& t) {
+void to_lvalue_ref(T&& t) {
   static_cast<T&>(t);
+}
+
+template<typename T>
+void to_const_lvalue_ref(T&& t) {
+  static_cast<const T&>(t);
+}
+
+template<typename T>
+void to_rvalue_ref(T&& t) {
+  // CHECK-MESSAGES: :[[@LINE-1]]:24: warning: forwarding reference parameter 't' is never forwarded inside the function body [cppcoreguidelines-missing-std-forward]
+  static_cast<T&&>(t);
+}
+
+template<typename T>
+void to_value(T&& t) {
+  // CHECK-MESSAGES: :[[@LINE-1]]:19: warning: forwarding reference parameter 't' is never forwarded inside the function body [cppcoreguidelines-missing-std-forward]
+  static_cast<T>(t);
+}
+
+template<typename T>
+void to_const_float_lvalue_ref(T&& t) {
+  // CHECK-MESSAGES: :[[@LINE-1]]:36: warning: forwarding reference parameter 't' is never forwarded inside the function body [cppcoreguidelines-missing-std-forward]
+  static_cast<float&>(t);
+}
+
+template<typename T>
+void to_float(T&& t) {
+  // CHECK-MESSAGES: :[[@LINE-1]]:19: warning: forwarding reference parameter 't' is never forwarded inside the function body [cppcoreguidelines-missing-std-forward]
+  static_cast<float>(t);
+}
+
+template<typename T>
+void to_dependent(T&& t) {
+  // CHECK-MESSAGES: :[[@LINE-1]]:23: warning: forwarding reference parameter 't' is never forwarded inside the function body [cppcoreguidelines-missing-std-forward]
+  static_cast<std::add_lvalue_reference_t<T>>(t);
+}
+
+template<typename... T>
+void to_float_expanded(T&&... t) {
+  // CHECK-MESSAGES: :[[@LINE-1]]:31: warning: forwarding reference parameter 't' is never forwarded inside the function body [cppcoreguidelines-missing-std-forward]
+  (static_cast<float>(t), ...);
+}
+
+template<typename... T>
+void to_lvalue_ref_expanded(T&&... t) {
+  (static_cast<T&>(t), ...);
 }
 
 } // namespace in_static_cast

--- a/clang-tools-extra/test/clang-tidy/checkers/cppcoreguidelines/missing-std-forward-casts.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/cppcoreguidelines/missing-std-forward-casts.cpp
@@ -1,0 +1,29 @@
+// RUN: %check_clang_tidy %s cppcoreguidelines-missing-std-forward %t -- \
+// RUN:   -config="{CheckOptions: \
+// RUN:     {cppcoreguidelines-missing-std-forward.IgnoreStaticCasts: true }}" \
+// RUN: -- -fno-delayed-template-parsing
+
+// NOLINTBEGIN
+namespace std {
+
+template <typename T> struct remove_reference      { using type = T; };
+template <typename T> struct remove_reference<T&>  { using type = T; };
+template <typename T> struct remove_reference<T&&> { using type = T; };
+
+template <typename T> using remove_reference_t = typename remove_reference<T>::type;
+
+template <typename T> constexpr T &&forward(remove_reference_t<T> &t) noexcept;
+template <typename T> constexpr T &&forward(remove_reference_t<T> &&t) noexcept;
+
+} // namespace std
+// NOLINTEND
+
+namespace in_static_cast {
+
+template<typename T>
+void static_cast_to_lvalue_ref(T&& t) {
+  static_cast<T&>(t);
+}
+
+} // namespace in_static_cast
+

--- a/clang-tools-extra/test/clang-tidy/checkers/cppcoreguidelines/missing-std-forward-casts.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/cppcoreguidelines/missing-std-forward-casts.cpp
@@ -74,4 +74,3 @@ void to_lvalue_ref_expanded(T&&... t) {
 }
 
 } // namespace in_static_cast
-

--- a/clang-tools-extra/test/clang-tidy/checkers/cppcoreguidelines/missing-std-forward.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/cppcoreguidelines/missing-std-forward.cpp
@@ -211,3 +211,20 @@ template<typename F>
 void unused_argument3(F&& _) {}
 
 } // namespace unused_arguments
+
+namespace escape_hatch {
+
+template<typename T>
+void used_as_lvalue_on_purpose(T&& t) {
+  static_cast<T&>(t);
+  static_cast<const T&>(t);
+}
+
+template<typename T>
+void used_as_rvalue_on_purpose(T&& t) {
+  static_cast<const T&&>(t);
+  // Typically used as another spelling for `std::forward`.
+  static_cast<T&&>(t);
+}
+
+}

--- a/clang-tools-extra/test/clang-tidy/checkers/cppcoreguidelines/missing-std-forward.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/cppcoreguidelines/missing-std-forward.cpp
@@ -212,19 +212,12 @@ void unused_argument3(F&& _) {}
 
 } // namespace unused_arguments
 
-namespace escape_hatch {
+namespace in_static_cast {
 
 template<typename T>
-void used_as_lvalue_on_purpose(T&& t) {
+void static_cast_to_lvalue_ref(T&& t) {
+  // CHECK-MESSAGES: :[[@LINE-1]]:36: warning: forwarding reference parameter 't' is never forwarded inside the function body [cppcoreguidelines-missing-std-forward]
   static_cast<T&>(t);
-  static_cast<const T&>(t);
 }
 
-template<typename T>
-void used_as_rvalue_on_purpose(T&& t) {
-  static_cast<const T&&>(t);
-  // Typically used as another spelling for `std::forward`.
-  static_cast<T&&>(t);
-}
-
-}
+} // namespace in_static_cast

--- a/clang-tools-extra/test/clang-tidy/checkers/cppcoreguidelines/missing-std-forward.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/cppcoreguidelines/missing-std-forward.cpp
@@ -13,6 +13,8 @@ template <typename T> constexpr T &&forward(remove_reference_t<T> &t) noexcept;
 template <typename T> constexpr T &&forward(remove_reference_t<T> &&t) noexcept;
 template <typename T> constexpr remove_reference_t<T> &&move(T &&x);
 
+template<typename T> using add_lvalue_reference_t = __add_lvalue_reference(T);
+
 } // namespace std
 // NOLINTEND
 
@@ -215,9 +217,58 @@ void unused_argument3(F&& _) {}
 namespace in_static_cast {
 
 template<typename T>
-void static_cast_to_lvalue_ref(T&& t) {
-  // CHECK-MESSAGES: :[[@LINE-1]]:36: warning: forwarding reference parameter 't' is never forwarded inside the function body [cppcoreguidelines-missing-std-forward]
+void to_lvalue_ref(T&& t) {
+  // CHECK-MESSAGES: :[[@LINE-1]]:24: warning: forwarding reference parameter 't' is never forwarded inside the function body [cppcoreguidelines-missing-std-forward]
   static_cast<T&>(t);
 }
 
+template<typename T>
+void to_const_lvalue_ref(T&& t) {
+  // CHECK-MESSAGES: :[[@LINE-1]]:30: warning: forwarding reference parameter 't' is never forwarded inside the function body [cppcoreguidelines-missing-std-forward]
+  static_cast<const T&>(t);
+}
+
+template<typename T>
+void to_rvalue_ref(T&& t) {
+  // CHECK-MESSAGES: :[[@LINE-1]]:24: warning: forwarding reference parameter 't' is never forwarded inside the function body [cppcoreguidelines-missing-std-forward]
+  static_cast<T&&>(t);
+}
+
+template<typename T>
+void to_value(T&& t) {
+  // CHECK-MESSAGES: :[[@LINE-1]]:19: warning: forwarding reference parameter 't' is never forwarded inside the function body [cppcoreguidelines-missing-std-forward]
+  static_cast<T>(t);
+}
+
+template<typename T>
+void to_const_float_lvalue_ref(T&& t) {
+  // CHECK-MESSAGES: :[[@LINE-1]]:36: warning: forwarding reference parameter 't' is never forwarded inside the function body [cppcoreguidelines-missing-std-forward]
+  static_cast<float&>(t);
+}
+
+template<typename T>
+void to_float(T&& t) {
+  // CHECK-MESSAGES: :[[@LINE-1]]:19: warning: forwarding reference parameter 't' is never forwarded inside the function body [cppcoreguidelines-missing-std-forward]
+  static_cast<float>(t);
+}
+
+template<typename T>
+void to_dependent(T&& t) {
+  // CHECK-MESSAGES: :[[@LINE-1]]:23: warning: forwarding reference parameter 't' is never forwarded inside the function body [cppcoreguidelines-missing-std-forward]
+  static_cast<std::add_lvalue_reference_t<T>>(t);
+}
+
+template<typename... T>
+void to_float_expanded(T&&... t) {
+  // CHECK-MESSAGES: :[[@LINE-1]]:31: warning: forwarding reference parameter 't' is never forwarded inside the function body [cppcoreguidelines-missing-std-forward]
+  (static_cast<float>(t), ...);
+}
+
+template<typename... T>
+void to_lvalue_ref_expanded(T&&... t) {
+  // CHECK-MESSAGES: :[[@LINE-1]]:36: warning: forwarding reference parameter 't' is never forwarded inside the function body [cppcoreguidelines-missing-std-forward]
+  (static_cast<S&>(t), ...);
+}
+
 } // namespace in_static_cast
+

--- a/clang-tools-extra/test/clang-tidy/checkers/cppcoreguidelines/missing-std-forward.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/cppcoreguidelines/missing-std-forward.cpp
@@ -271,4 +271,3 @@ void to_lvalue_ref_expanded(T&&... t) {
 }
 
 } // namespace in_static_cast
-


### PR DESCRIPTION
This provides a way to inform the check that we're intending to use an the forwarding reference as a specific reference category

Fixes #99474.