### PR TITLE
libclc: fix convert with half

### DIFF
--- a/libclc/generic/include/clc/convert.h
+++ b/libclc/generic/include/clc/convert.h
@@ -62,6 +62,7 @@
 #define _CLC_VECTOR_CONVERT_TO(SUFFIX)                                         \
   _CLC_VECTOR_CONVERT_TO1(SUFFIX)                                              \
   _CLC_VECTOR_CONVERT_FROM(half, SUFFIX)
+#else
 #define _CLC_VECTOR_CONVERT_TO(SUFFIX) \
   _CLC_VECTOR_CONVERT_TO1(SUFFIX)
 #endif

--- a/libclc/generic/lib/gen_convert.py
+++ b/libclc/generic/lib/gen_convert.py
@@ -142,7 +142,10 @@ def conditional_guard(src, dst):
         float64_count = float64_count + 1
     elif dst in float16_types:
         float16_count = float16_count + 1
-    if float64_count > 0:
+    if float64_count > 0 and float16_count > 0:
+        print("#if defined(cl_khr_fp16) && defined(cl_khr_fp64)")
+        return True
+    elif float64_count > 0:
         # In embedded profile, if cl_khr_fp64 is supported cles_khr_int64 has to be
         print("#ifdef cl_khr_fp64")
         return True


### PR DESCRIPTION
Fix following update of libclc introducing more fp16 support: https://github.com/llvm/llvm-project/commit/7e6a73959ae97b1f9476a90290a492ba90cb950d