### PR TITLE
[libcxx][test] Remove picolib UNSUPPORTED for now.pass.cpp

### DIFF
--- a/libcxx/test/std/time/time.clock/time.clock.file/now.pass.cpp
+++ b/libcxx/test/std/time/time.clock/time.clock.file/now.pass.cpp
@@ -10,9 +10,6 @@
 
 // UNSUPPORTED: availability-filesystem-missing
 
-// qemu: Unsupported SemiHosting SWI 0x30
-// UNSUPPORTED: LIBCXX-PICOLIBC-FIXME
-
 // <chrono>
 
 // file_clock


### PR DESCRIPTION
This ARM semihosting call was implemented in QEMU by https://gitlab.com/qemu-project/qemu/-/commit/4d834039c2107cb86931cb3f22ca3de6e4e42b06 and is present in the qemu-system-arm v8.1.3 used by the builders.