### PR TITLE
[GVN] Look through select/phi when determining underlying object

### DIFF
--- a/llvm/include/llvm/Analysis/ValueTracking.h
+++ b/llvm/include/llvm/Analysis/ValueTracking.h
@@ -738,8 +738,7 @@ inline Value *getUnderlyingObject(Value *V, unsigned MaxLookup = 6) {
 
 /// Like getUnderlyingObject(), but will try harder to find a single underlying
 /// object. In particular, this function also looks through selects and phis.
-const Value *getUnderlyingObjectAggressive(const Value *V,
-                                           unsigned MaxLookup = 6);
+const Value *getUnderlyingObjectAggressive(const Value *V);
 
 /// This method is similar to getUnderlyingObject except that it can
 /// look through phi and select instructions and return multiple objects.

--- a/llvm/include/llvm/Analysis/ValueTracking.h
+++ b/llvm/include/llvm/Analysis/ValueTracking.h
@@ -736,6 +736,11 @@ inline Value *getUnderlyingObject(Value *V, unsigned MaxLookup = 6) {
   return const_cast<Value *>(getUnderlyingObject(VConst, MaxLookup));
 }
 
+/// Like getUnderlyingObject(), but will also look through phi/select nodes
+/// to establish a single underlying object.
+const Value *getUnderlyingObjectThroughPhisAndSelects(const Value *V,
+                                                      unsigned MaxLookup = 6);
+
 /// This method is similar to getUnderlyingObject except that it can
 /// look through phi and select instructions and return multiple objects.
 ///

--- a/llvm/include/llvm/Analysis/ValueTracking.h
+++ b/llvm/include/llvm/Analysis/ValueTracking.h
@@ -736,10 +736,10 @@ inline Value *getUnderlyingObject(Value *V, unsigned MaxLookup = 6) {
   return const_cast<Value *>(getUnderlyingObject(VConst, MaxLookup));
 }
 
-/// Like getUnderlyingObject(), but will also look through phi/select nodes
-/// to establish a single underlying object.
-const Value *getUnderlyingObjectThroughPhisAndSelects(const Value *V,
-                                                      unsigned MaxLookup = 6);
+/// Like getUnderlyingObject(), but will try harder to find a single underlying
+/// object. In particular, this function also looks through selects and phis.
+const Value *getUnderlyingObjectAggressive(const Value *V,
+                                           unsigned MaxLookup = 6);
 
 /// This method is similar to getUnderlyingObject except that it can
 /// look through phi and select instructions and return multiple objects.

--- a/llvm/lib/Analysis/Loads.cpp
+++ b/llvm/lib/Analysis/Loads.cpp
@@ -743,9 +743,8 @@ static bool isPointerAlwaysReplaceable(const Value *From, const Value *To,
   if (isa<Constant>(To) &&
       isDereferenceablePointer(To, Type::getInt8Ty(To->getContext()), DL))
     return true;
-  if (getUnderlyingObject(From) == getUnderlyingObject(To))
-    return true;
-  return false;
+  return getUnderlyingObjectThroughPhisAndSelects(From) ==
+         getUnderlyingObjectThroughPhisAndSelects(To);
 }
 
 bool llvm::canReplacePointersInUseIfEqual(const Use &U, const Value *To,

--- a/llvm/lib/Analysis/Loads.cpp
+++ b/llvm/lib/Analysis/Loads.cpp
@@ -743,8 +743,8 @@ static bool isPointerAlwaysReplaceable(const Value *From, const Value *To,
   if (isa<Constant>(To) &&
       isDereferenceablePointer(To, Type::getInt8Ty(To->getContext()), DL))
     return true;
-  return getUnderlyingObjectThroughPhisAndSelects(From) ==
-         getUnderlyingObjectThroughPhisAndSelects(To);
+  return getUnderlyingObjectAggressive(From) ==
+         getUnderlyingObjectAggressive(To);
 }
 
 bool llvm::canReplacePointersInUseIfEqual(const Use &U, const Value *To,

--- a/llvm/lib/Analysis/ValueTracking.cpp
+++ b/llvm/lib/Analysis/ValueTracking.cpp
@@ -6625,9 +6625,6 @@ const Value *llvm::getUnderlyingObjectAggressive(const Value *V) {
     P = First ? FirstObject : getUnderlyingObject(P);
     First = false;
 
-    if (!FirstObject)
-      FirstObject = P;
-
     if (!Visited.insert(P).second)
       continue;
 

--- a/llvm/lib/Analysis/ValueTracking.cpp
+++ b/llvm/lib/Analysis/ValueTracking.cpp
@@ -6615,10 +6615,15 @@ const Value *llvm::getUnderlyingObjectAggressive(const Value *V) {
   SmallPtrSet<const Value *, 8> Visited;
   SmallVector<const Value *, 8> Worklist;
   Worklist.push_back(V);
-  const Value *Object = nullptr, *FirstObject = nullptr;
+  const Value *Object = nullptr;
+  // Used as fallback if we can't find a common underlying object through
+  // recursion.
+  bool First = true;
+  const Value *FirstObject = getUnderlyingObject(V);
   do {
     const Value *P = Worklist.pop_back_val();
-    P = getUnderlyingObject(P);
+    P = First ? FirstObject : getUnderlyingObject(P);
+    First = false;
 
     if (!FirstObject)
       FirstObject = P;

--- a/llvm/lib/Analysis/ValueTracking.cpp
+++ b/llvm/lib/Analysis/ValueTracking.cpp
@@ -6609,9 +6609,8 @@ void llvm::getUnderlyingObjects(const Value *V,
   } while (!Worklist.empty());
 }
 
-const Value *
-llvm::getUnderlyingObjectThroughPhisAndSelects(const Value *V,
-                                               unsigned MaxLookup) {
+const Value *llvm::getUnderlyingObjectAggressive(const Value *V,
+                                                 unsigned MaxLookup) {
   const unsigned MaxVisited = 8;
 
   SmallPtrSet<const Value *, 8> Visited;

--- a/llvm/lib/Analysis/ValueTracking.cpp
+++ b/llvm/lib/Analysis/ValueTracking.cpp
@@ -6615,19 +6615,18 @@ const Value *llvm::getUnderlyingObjectAggressive(const Value *V) {
   SmallPtrSet<const Value *, 8> Visited;
   SmallVector<const Value *, 8> Worklist;
   Worklist.push_back(V);
-  const Value *Object = nullptr, *FirstObject = nullptr;
+  const Value *Object = nullptr;
   do {
     const Value *P = Worklist.pop_back_val();
     P = getUnderlyingObject(P);
 
-    if (!FirstObject)
-      FirstObject = P;
-
     if (!Visited.insert(P).second)
       continue;
 
-    if (Visited.size() == MaxVisited)
-      return FirstObject;
+    if (Visited.size() == MaxVisited) {
+      Object = nullptr;
+      break;
+    }
 
     if (auto *SI = dyn_cast<SelectInst>(P)) {
       Worklist.push_back(SI->getTrueValue());
@@ -6642,10 +6641,16 @@ const Value *llvm::getUnderlyingObjectAggressive(const Value *V) {
 
     if (!Object)
       Object = P;
-    else if (Object != P)
-      return FirstObject;
+    else if (Object != P) {
+      Object = nullptr;
+      break;
+    }
   } while (!Worklist.empty());
 
+  // If we tried looking through phi/select but did not end up with a single
+  // underlying object, fall back to the non-recursive underlying object of V.
+  if (!Object)
+    return getUnderlyingObject(V);
   return Object;
 }
 

--- a/llvm/lib/Analysis/ValueTracking.cpp
+++ b/llvm/lib/Analysis/ValueTracking.cpp
@@ -6609,8 +6609,7 @@ void llvm::getUnderlyingObjects(const Value *V,
   } while (!Worklist.empty());
 }
 
-const Value *llvm::getUnderlyingObjectAggressive(const Value *V,
-                                                 unsigned MaxLookup) {
+const Value *llvm::getUnderlyingObjectAggressive(const Value *V) {
   const unsigned MaxVisited = 8;
 
   SmallPtrSet<const Value *, 8> Visited;
@@ -6619,7 +6618,7 @@ const Value *llvm::getUnderlyingObjectAggressive(const Value *V,
   const Value *Object = nullptr, *FirstObject = nullptr;
   do {
     const Value *P = Worklist.pop_back_val();
-    P = getUnderlyingObject(P, MaxLookup);
+    P = getUnderlyingObject(P);
 
     if (!FirstObject)
       FirstObject = P;

--- a/llvm/test/Transforms/GVN/condprop.ll
+++ b/llvm/test/Transforms/GVN/condprop.ll
@@ -813,7 +813,7 @@ define void @select_same_obj(i1 %c, ptr %p, i64 %x) {
 ; CHECK-NEXT:    br i1 [[CMP]], label [[IF:%.*]], label [[EXIT:%.*]]
 ; CHECK:       if:
 ; CHECK-NEXT:    call void @use_ptr(ptr [[P]])
-; CHECK-NEXT:    call void @use_ptr(ptr [[P3]])
+; CHECK-NEXT:    call void @use_ptr(ptr [[P]])
 ; CHECK-NEXT:    ret void
 ; CHECK:       exit:
 ; CHECK-NEXT:    ret void
@@ -902,7 +902,7 @@ define void @phi_same_obj(i1 %c, ptr %p, i64 %x) {
 ; CHECK-NEXT:    br i1 [[CMP]], label [[IF2:%.*]], label [[EXIT:%.*]]
 ; CHECK:       if2:
 ; CHECK-NEXT:    call void @use_ptr(ptr [[P]])
-; CHECK-NEXT:    call void @use_ptr(ptr [[P3]])
+; CHECK-NEXT:    call void @use_ptr(ptr [[P]])
 ; CHECK-NEXT:    ret void
 ; CHECK:       exit:
 ; CHECK-NEXT:    ret void
@@ -975,7 +975,7 @@ define void @phi_same_obj_cycle(i1 %c, ptr %p, i64 %x) {
 ; CHECK-NEXT:    [[CMP:%.*]] = icmp eq ptr [[P_IV]], [[P]]
 ; CHECK-NEXT:    br i1 [[CMP]], label [[IF:%.*]], label [[LOOP_LATCH]]
 ; CHECK:       if:
-; CHECK-NEXT:    call void @use_ptr(ptr [[P_IV]])
+; CHECK-NEXT:    call void @use_ptr(ptr [[P]])
 ; CHECK-NEXT:    call void @use_ptr(ptr [[P]])
 ; CHECK-NEXT:    br label [[LOOP_LATCH]]
 ; CHECK:       loop.latch:


### PR DESCRIPTION
This addresses an optimization regression in Rust we have observed after https://github.com/llvm/llvm-project/pull/82458. We now only perform pointer replacement if they have the same underlying object. However, getUnderlyingObject() by default only looks through linear chains, not selects/phis. In particular, this means that we miss cases involving involving pointer induction variables.

This patch fixes this by introducing a new helper getUnderlyingObjectAggressive() which basically does what getUnderlyingObjects() does, just specialized to the case where we must arrive at a single underlying object in the end, and with a limit on the number of inspected values.

Doing this more expensive underlying object check has no measurable compile-time impact on CTMark.