### PR TITLE
[clangd] fix crash in include cleaner

### DIFF
--- a/clang-tools-extra/clangd/CollectMacros.h
+++ b/clang-tools-extra/clangd/CollectMacros.h
@@ -24,6 +24,7 @@ namespace clangd {
 
 struct MacroOccurrence {
   // Half-open range (end offset is exclusive) inside the main file.
+  FileID FID;
   size_t StartOffset;
   size_t EndOffset;
 

--- a/clang-tools-extra/clangd/IncludeCleaner.cpp
+++ b/clang-tools-extra/clangd/IncludeCleaner.cpp
@@ -302,7 +302,7 @@ collectMacroReferences(ParsedAST &AST) {
   std::vector<include_cleaner::SymbolReference> Macros;
   for (const auto &[_, Refs] : AST.getMacros().MacroRefs) {
     for (const auto &Ref : Refs) {
-      auto Loc = SM.getComposedLoc(SM.getMainFileID(), Ref.StartOffset);
+      auto Loc = SM.getComposedLoc(Ref.FID, Ref.StartOffset);
       const auto *Tok = AST.getTokens().spelledTokenContaining(Loc);
       if (!Tok)
         continue;


### PR DESCRIPTION
Unsure if this is the correct fix. But let me explain what I know so far about this problem:

1. Include cleaner goes over macro refs, and calculates their source locations:
    https://github.com/llvm/llvm-project/blob/676efd0ffb717215c752f200fe14163732290dcc/clang-tools-extra/clangd/IncludeCleaner.cpp#L303-L305
2. It assumes the macro ref is in the main file. I think `ParsedAST::Macros` is meant to only contain macro usages in the main file.
3. `ParsedAST::Macros` is filled in by `CollectMainFileMacros`:
    https://github.com/llvm/llvm-project/blob/676efd0ffb717215c752f200fe14163732290dcc/clang-tools-extra/clangd/CollectMacros.cpp#L27-L43
4. `CollectMainFileMacros` checks if a macro usage is in main file with `if (InMainFile)`, which is updated in `CollectMainFileMacros::FileChange`.
5. I think the intention of `PPCallbacks::FileChange` is that it is called whenever the lexer moves to a new file.

Above is what I am sure about, after that I am not quite sure what's happening. 

I think macro expansions (`HandleIdentifier -> HandleMacroExpansion`) are done out of the normal file change logic? Because I observed `CollectMainFileMacros::add` being called with source locations that are clearly not in the same file as reported by the most recent `FileChange`.

The consequence of that is that `CollectMainFileMacros` will get offsets related to one file, and those offsets will later be combined with another file (the main file) into a source location in the include cleaner. Those source locations will then be used to get a spelling, which at best will be wrong, and at worst will trigger an assertion failure at:

https://github.com/llvm/llvm-project/blob/497ea1d84951626dea5bf644fef2d99e145e21ac/clang/lib/Tooling/Syntax/Tokens.cpp#L382

* * *

What I did here is instead of using `InMainFile`/`PPCallbacks::FileChange` to make sure the macro is in the main file, I check the `FileID` directly