### PR TITLE
[LLVM] Silence compiler-rt warning in runtimes build

### DIFF
--- a/llvm/cmake/modules/LLVMExternalProjectUtils.cmake
+++ b/llvm/cmake/modules/LLVMExternalProjectUtils.cmake
@@ -350,6 +350,7 @@ function(llvm_ExternalProject_Add name source_dir)
                ${sysroot_arg}
                -DLLVM_BINARY_DIR=${PROJECT_BINARY_DIR}
                -DLLVM_CONFIG_PATH=${llvm_config_path}
+               -DLLVM_CMAKE_DIR=${LLVM_CMAKE_DIR}
                -DLLVM_ENABLE_WERROR=${LLVM_ENABLE_WERROR}
                -DLLVM_HOST_TRIPLE=${LLVM_HOST_TRIPLE}
                -DLLVM_HAVE_LINK_VERSION_SCRIPT=${LLVM_HAVE_LINK_VERSION_SCRIPT}


### PR DESCRIPTION
Summary:
The `compiler-rt` project wants `LLVM_CMAKE_DIR` but the
`llvm_ExternalProject_add` interface sets the `LLVM_CONFIG_PATH`. This
patch just makes the utility pass that as well.
