### PR TITLE
[libc][CMake] Set library type of libcMPFRWrapper to STATIC

### DIFF
--- a/libc/utils/MPFRWrapper/CMakeLists.txt
+++ b/libc/utils/MPFRWrapper/CMakeLists.txt
@@ -1,5 +1,5 @@
 if(LIBC_TESTS_CAN_USE_MPFR)
-  add_library(libcMPFRWrapper
+  add_library(libcMPFRWrapper STATIC
     MPFRUtils.cpp
     MPFRUtils.h
     mpfr_inc.h


### PR DESCRIPTION
Fixes linker errors due to hidden symbols when running CMake with
-DBUILD_SHARED_LIBS=ON.
