### PR TITLE
[libc++] Make libc++ forward-compatible with AppleClang's definition of __builtin_verbose_trap

### DIFF
--- a/libcxx/vendor/llvm/default_assertion_handler.in
+++ b/libcxx/vendor/llvm/default_assertion_handler.in
@@ -24,7 +24,13 @@
 #else
 
 #  if __has_builtin(__builtin_verbose_trap)
-#    define _LIBCPP_ASSERTION_HANDLER(message) __builtin_verbose_trap("libc++", message)
+// AppleClang shipped a slightly different version of __builtin_verbose_trap from the upstream
+// version before upstream Clang actually got the builtin.
+#    if defined(_LIBCPP_APPLE_CLANG_VER) && _LIBCPP_APPLE_CLANG_VER < 17000
+#      define _LIBCPP_ASSERTION_HANDLER(message) __builtin_verbose_trap(message)
+#    else
+#      define _LIBCPP_ASSERTION_HANDLER(message) __builtin_verbose_trap("libc++", message)
+#    endif
 #  else
 #    define _LIBCPP_ASSERTION_HANDLER(message) ((void)message, __builtin_trap())
 #  endif


### PR DESCRIPTION
AppleClang as included in the Xcode 16 beta implements `__builtin_verbose_trap`, but it implements slightly different semantics from the ones implemented upstream. This patch makes libc++ compatible with either definition until we drop support for the version of AppleClang that differs from upstream.