### PR TITLE
[LLDB][test] Drop OS/HOST_OS detection code from Makefile.rules

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/make/Makefile.rules
+++ b/lldb/packages/Python/lldbsuite/test/make/Makefile.rules
@@ -47,31 +47,6 @@ LLDB_BASE_DIR := $(THIS_FILE_DIR)/../../../../../
 .DEFAULT_GOAL := all
 
 #----------------------------------------------------------------------
-# If OS is not defined, use 'uname -s' to determine the OS name.
-#
-# GNUWin32 uname gives "windows32" or "server version windows32" while
-# some versions of MSYS uname return "MSYS_NT*", but most environments
-# standardize on "Windows_NT", so we'll make it consistent here. 
-# When running tests from Visual Studio, the environment variable isn't
-# inherited all the way down to the process spawned for make.
-#----------------------------------------------------------------------
-ifeq "$(HOST_OS)" ""
-  HOST_OS := $(shell uname -s)
-endif
-
-ifneq (,$(findstring windows32,$(HOST_OS)))
-	HOST_OS := Windows_NT
-endif
-
-ifneq (,$(findstring MSYS_NT,$(HOST_OS)))
-	HOST_OS := Windows_NT
-endif
-
-ifeq "$(OS)" ""
-	OS := $(HOST_OS)
-endif
-
-#----------------------------------------------------------------------
 # If OS is Windows, force SHELL to be cmd
 #
 # Some versions of make on Windows will search for other shells such as


### PR DESCRIPTION
Remove commands for OS/HOST_OS detection from Makefile.rules to simplify it, since logic for these variables has been implemented in `lldb/packages/Python/lldbsuite/test/lldbplatformutil.py` (https://github.com/llvm/llvm-project/commit/7021e44b2f0e11717c0d82456bad0fed4a0b48f9).