### PR TITLE
[TableGen][SelectionDAG] Make CheckValueTypeMatcher use MVT::SimpleValueType

### DIFF
--- a/llvm/utils/TableGen/Common/DAGISelMatcher.cpp
+++ b/llvm/utils/TableGen/Common/DAGISelMatcher.cpp
@@ -218,7 +218,7 @@ void CheckChild2CondCodeMatcher::printImpl(raw_ostream &OS,
 }
 
 void CheckValueTypeMatcher::printImpl(raw_ostream &OS, unsigned indent) const {
-  OS.indent(indent) << "CheckValueType MVT::" << TypeName << '\n';
+  OS.indent(indent) << "CheckValueType " << getEnumName(VT) << '\n';
 }
 
 void CheckComplexPatMatcher::printImpl(raw_ostream &OS, unsigned indent) const {
@@ -409,7 +409,7 @@ bool CheckChildIntegerMatcher::isContradictoryImpl(const Matcher *M) const {
 
 bool CheckValueTypeMatcher::isContradictoryImpl(const Matcher *M) const {
   if (const CheckValueTypeMatcher *CVT = dyn_cast<CheckValueTypeMatcher>(M))
-    return CVT->getTypeName() != getTypeName();
+    return CVT->getVT() != getVT();
   return false;
 }
 

--- a/llvm/utils/TableGen/Common/DAGISelMatcher.h
+++ b/llvm/utils/TableGen/Common/DAGISelMatcher.h
@@ -684,13 +684,13 @@ private:
 /// CheckValueTypeMatcher - This checks to see if the current node is a
 /// VTSDNode with the specified type, if not it fails to match.
 class CheckValueTypeMatcher : public Matcher {
-  StringRef TypeName;
+  MVT::SimpleValueType VT;
 
 public:
-  CheckValueTypeMatcher(StringRef type_name)
-      : Matcher(CheckValueType), TypeName(type_name) {}
+  CheckValueTypeMatcher(MVT::SimpleValueType SimpleVT)
+      : Matcher(CheckValueType), VT(SimpleVT) {}
 
-  StringRef getTypeName() const { return TypeName; }
+  MVT::SimpleValueType getVT() const { return VT; }
 
   static bool classof(const Matcher *N) {
     return N->getKind() == CheckValueType;
@@ -699,7 +699,7 @@ public:
 private:
   void printImpl(raw_ostream &OS, unsigned indent) const override;
   bool isEqualImpl(const Matcher *M) const override {
-    return cast<CheckValueTypeMatcher>(M)->TypeName == TypeName;
+    return cast<CheckValueTypeMatcher>(M)->VT == VT;
   }
   bool isContradictoryImpl(const Matcher *M) const override;
 };

--- a/llvm/utils/TableGen/DAGISelMatcherEmitter.cpp
+++ b/llvm/utils/TableGen/DAGISelMatcherEmitter.cpp
@@ -697,8 +697,8 @@ unsigned MatcherTableEmitter::EmitMatcher(const Matcher *N,
     return 2;
 
   case Matcher::CheckValueType:
-    OS << "OPC_CheckValueType, MVT::"
-       << cast<CheckValueTypeMatcher>(N)->getTypeName() << ",\n";
+    OS << "OPC_CheckValueType, "
+       << getEnumName(cast<CheckValueTypeMatcher>(N)->getVT()) << ",\n";
     return 2;
 
   case Matcher::CheckComplexPat: {

--- a/llvm/utils/TableGen/DAGISelMatcherGen.cpp
+++ b/llvm/utils/TableGen/DAGISelMatcherGen.cpp
@@ -235,8 +235,7 @@ void MatcherGen::EmitLeafMatchCode(const TreePatternNode &N) {
     if (N.hasName())
       return;
     // An unnamed ValueType as in (sext_inreg GPR:$foo, i8).
-    return AddMatcher(new CheckValueTypeMatcher(
-        static_cast<MVT::SimpleValueType>(LeafRec->getValueAsInt("Value"))));
+    return AddMatcher(new CheckValueTypeMatcher(llvm::getValueType(LeafRec)));
   }
 
   if ( // Handle register references.  Nothing to do here, they always match.

--- a/llvm/utils/TableGen/DAGISelMatcherGen.cpp
+++ b/llvm/utils/TableGen/DAGISelMatcherGen.cpp
@@ -235,7 +235,8 @@ void MatcherGen::EmitLeafMatchCode(const TreePatternNode &N) {
     if (N.hasName())
       return;
     // An unnamed ValueType as in (sext_inreg GPR:$foo, i8).
-    return AddMatcher(new CheckValueTypeMatcher(LeafRec->getName()));
+    return AddMatcher(new CheckValueTypeMatcher(
+        static_cast<MVT::SimpleValueType>(LeafRec->getValueAsInt("Value"))));
   }
 
   if ( // Handle register references.  Nothing to do here, they always match.


### PR DESCRIPTION
The original `CheckValueTypeMatcher` stores StringRef as the member variable type, however it's more efficient to use use MVT::SimpleValueType since it prevents string comparison in isEqualImpl, it also reduce the memory consumption in each object.