### PR TITLE
Replace distutils.version with looseversion since the former was deprecated in python 3.10 and removed in 3.12.

### DIFF
--- a/cross-project-tests/lit.cfg.py
+++ b/cross-project-tests/lit.cfg.py
@@ -4,8 +4,7 @@ import re
 import subprocess
 import sys
 
-# TODO: LooseVersion is undocumented; use something else.
-from distutils.version import LooseVersion
+from looseversion import LooseVersion
 
 import lit.formats
 import lit.util


### PR DESCRIPTION
Python deprecated the distutils package in 3.10, and removed it in 3.12 causing problems when trying to run the lit tests with 3.12.

https://docs.python.org/3.10/library/distutils.html

Replace usage with the looseversion package which should be a drop-in replacement for the original usage.