### PR TITLE
[ADT] Add unit tests for set_subtract

### DIFF
--- a/llvm/unittests/ADT/SetOperationsTest.cpp
+++ b/llvm/unittests/ADT/SetOperationsTest.cpp
@@ -8,6 +8,8 @@
 
 #include "llvm/ADT/SetOperations.h"
 #include "llvm/ADT/SetVector.h"
+#include "llvm/ADT/SmallPtrSet.h"
+#include "llvm/ADT/SmallVector.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
@@ -197,6 +199,42 @@ TEST(SetOperationsTest, SetSubtract) {
   set_subtract(Set1, Set2);
   EXPECT_EQ(ExpectedSet1, Set1);
   EXPECT_EQ(ExpectedSet2, Set2);
+}
+
+TEST(SetOperationsTest, SetSubtractSmallPtrSet) {
+  int A[4];
+
+  // Set1.size() < Set2.size()
+  llvm::SmallPtrSet<int *, 4> Set1 = {&A[0], &A[1]};
+  llvm::SmallPtrSet<int *, 4> Set2 = {&A[1], &A[2], &A[3]};
+  llvm::SmallPtrSet<int *, 4> ExpectedSet1 = {&A[0]};
+  set_subtract(Set1, Set2);
+  EXPECT_EQ(ExpectedSet1, Set1);
+
+  // Set1.size() > Set2.size()
+  Set1 = {&A[0], &A[1], &A[2]};
+  Set2 = {&A[0], &A[2]};
+  ExpectedSet1 = {&A[1]};
+  set_subtract(Set1, Set2);
+  EXPECT_EQ(ExpectedSet1, Set1);
+}
+
+TEST(SetOperationsTest, SetSubtractSmallVector) {
+  int A[4];
+
+  // Set1.size() < Set2.size()
+  llvm::SmallPtrSet<int *, 4> Set1 = {&A[0], &A[1]};
+  llvm::SmallVector<int *> Set2 = {&A[1], &A[2], &A[3]};
+  llvm::SmallPtrSet<int *, 4> ExpectedSet1 = {&A[0]};
+  set_subtract(Set1, Set2);
+  EXPECT_EQ(ExpectedSet1, Set1);
+
+  // Set1.size() > Set2.size()
+  Set1 = {&A[0], &A[1], &A[2]};
+  Set2 = {&A[0], &A[2]};
+  ExpectedSet1 = {&A[1]};
+  set_subtract(Set1, Set2);
+  EXPECT_EQ(ExpectedSet1, Set1);
 }
 
 TEST(SetOperationsTest, SetSubtractRemovedRemaining) {

--- a/llvm/unittests/ADT/SetOperationsTest.cpp
+++ b/llvm/unittests/ADT/SetOperationsTest.cpp
@@ -18,6 +18,7 @@
 using namespace llvm;
 
 using testing::IsEmpty;
+using testing::UnorderedElementsAre;
 
 namespace {
 
@@ -208,13 +209,13 @@ TEST(SetOperationsTest, SetSubtractSmallPtrSet) {
   SmallPtrSet<int *, 4> Set1 = {&A[0], &A[1]};
   SmallPtrSet<int *, 4> Set2 = {&A[1], &A[2], &A[3]};
   set_subtract(Set1, Set2);
-  EXPECT_THAT(Set1, testing::UnorderedElementsAre(&A[0]));
+  EXPECT_THAT(Set1, UnorderedElementsAre(&A[0]));
 
   // Set1.size() > Set2.size()
   Set1 = {&A[0], &A[1], &A[2]};
   Set2 = {&A[0], &A[2]};
   set_subtract(Set1, Set2);
-  EXPECT_THAT(Set1, testing::UnorderedElementsAre(&A[1]));
+  EXPECT_THAT(Set1, UnorderedElementsAre(&A[1]));
 }
 
 TEST(SetOperationsTest, SetSubtractSmallVector) {
@@ -224,13 +225,13 @@ TEST(SetOperationsTest, SetSubtractSmallVector) {
   SmallPtrSet<int *, 4> Set1 = {&A[0], &A[1]};
   SmallVector<int *> Set2 = {&A[1], &A[2], &A[3]};
   set_subtract(Set1, Set2);
-  EXPECT_THAT(Set1, testing::UnorderedElementsAre(&A[0]));
+  EXPECT_THAT(Set1, UnorderedElementsAre(&A[0]));
 
   // Set1.size() > Set2.size()
   Set1 = {&A[0], &A[1], &A[2]};
   Set2 = {&A[0], &A[2]};
   set_subtract(Set1, Set2);
-  EXPECT_THAT(Set1, testing::UnorderedElementsAre(&A[1]));
+  EXPECT_THAT(Set1, UnorderedElementsAre(&A[1]));
 }
 
 TEST(SetOperationsTest, SetSubtractRemovedRemaining) {

--- a/llvm/unittests/ADT/SetOperationsTest.cpp
+++ b/llvm/unittests/ADT/SetOperationsTest.cpp
@@ -205,9 +205,9 @@ TEST(SetOperationsTest, SetSubtractSmallPtrSet) {
   int A[4];
 
   // Set1.size() < Set2.size()
-  llvm::SmallPtrSet<int *, 4> Set1 = {&A[0], &A[1]};
-  llvm::SmallPtrSet<int *, 4> Set2 = {&A[1], &A[2], &A[3]};
-  llvm::SmallPtrSet<int *, 4> ExpectedSet1 = {&A[0]};
+  SmallPtrSet<int *, 4> Set1 = {&A[0], &A[1]};
+  SmallPtrSet<int *, 4> Set2 = {&A[1], &A[2], &A[3]};
+  SmallPtrSet<int *, 4> ExpectedSet1 = {&A[0]};
   set_subtract(Set1, Set2);
   EXPECT_EQ(ExpectedSet1, Set1);
 
@@ -223,9 +223,9 @@ TEST(SetOperationsTest, SetSubtractSmallVector) {
   int A[4];
 
   // Set1.size() < Set2.size()
-  llvm::SmallPtrSet<int *, 4> Set1 = {&A[0], &A[1]};
-  llvm::SmallVector<int *> Set2 = {&A[1], &A[2], &A[3]};
-  llvm::SmallPtrSet<int *, 4> ExpectedSet1 = {&A[0]};
+  SmallPtrSet<int *, 4> Set1 = {&A[0], &A[1]};
+  SmallVector<int *> Set2 = {&A[1], &A[2], &A[3]};
+  SmallPtrSet<int *, 4> ExpectedSet1 = {&A[0]};
   set_subtract(Set1, Set2);
   EXPECT_EQ(ExpectedSet1, Set1);
 

--- a/llvm/unittests/ADT/SetOperationsTest.cpp
+++ b/llvm/unittests/ADT/SetOperationsTest.cpp
@@ -207,16 +207,14 @@ TEST(SetOperationsTest, SetSubtractSmallPtrSet) {
   // Set1.size() < Set2.size()
   SmallPtrSet<int *, 4> Set1 = {&A[0], &A[1]};
   SmallPtrSet<int *, 4> Set2 = {&A[1], &A[2], &A[3]};
-  SmallPtrSet<int *, 4> ExpectedSet1 = {&A[0]};
   set_subtract(Set1, Set2);
-  EXPECT_EQ(ExpectedSet1, Set1);
+  EXPECT_THAT(Set1, testing::UnorderedElementsAre(&A[0]));
 
   // Set1.size() > Set2.size()
   Set1 = {&A[0], &A[1], &A[2]};
   Set2 = {&A[0], &A[2]};
-  ExpectedSet1 = {&A[1]};
   set_subtract(Set1, Set2);
-  EXPECT_EQ(ExpectedSet1, Set1);
+  EXPECT_THAT(Set1, testing::UnorderedElementsAre(&A[1]));
 }
 
 TEST(SetOperationsTest, SetSubtractSmallVector) {
@@ -225,16 +223,14 @@ TEST(SetOperationsTest, SetSubtractSmallVector) {
   // Set1.size() < Set2.size()
   SmallPtrSet<int *, 4> Set1 = {&A[0], &A[1]};
   SmallVector<int *> Set2 = {&A[1], &A[2], &A[3]};
-  SmallPtrSet<int *, 4> ExpectedSet1 = {&A[0]};
   set_subtract(Set1, Set2);
-  EXPECT_EQ(ExpectedSet1, Set1);
+  EXPECT_THAT(Set1, testing::UnorderedElementsAre(&A[0]));
 
   // Set1.size() > Set2.size()
   Set1 = {&A[0], &A[1], &A[2]};
   Set2 = {&A[0], &A[2]};
-  ExpectedSet1 = {&A[1]};
   set_subtract(Set1, Set2);
-  EXPECT_EQ(ExpectedSet1, Set1);
+  EXPECT_THAT(Set1, testing::UnorderedElementsAre(&A[1]));
 }
 
 TEST(SetOperationsTest, SetSubtractRemovedRemaining) {


### PR DESCRIPTION
This patch adds a couple of unit tests:

- SetSubtractSmallPtrSet exercises the code path involving remove_if,
  added in d772cdd6279de1e578dfdfca7432327a1806c659.  Note that
  SmallPtrSet supports remove_if.

- SetSubtractSmallVector exercises the code path involving
  S1.erase(*SI) and ensures that set_subtract continues to accept S2
  being a vector, which does not have contains.
