### PR TITLE
[mlir][ArmSME] Suppress potential unused warning

### DIFF
--- a/mlir/lib/Dialect/ArmSME/Transforms/TileAllocation.cpp
+++ b/mlir/lib/Dialect/ArmSME/Transforms/TileAllocation.cpp
@@ -619,6 +619,7 @@ void allocateTilesToLiveRanges(
         // Remove the live range from the active/inactive sets.
         if (!activeRanges.remove(rangeToSpill)) {
           bool removed = inactiveRanges.remove(rangeToSpill);
+          (void)removed;
           assert(removed && "expected a range to be removed!");
         }
       }


### PR DESCRIPTION
When building in release mode, the assert will be dropped, making `remove` unused.