### PR TITLE
Revert "[mlir][ArmSME] Suppress potential unused warning (#99573)"

### DIFF
--- a/mlir/lib/Dialect/ArmSME/Transforms/TileAllocation.cpp
+++ b/mlir/lib/Dialect/ArmSME/Transforms/TileAllocation.cpp
@@ -619,7 +619,6 @@ void allocateTilesToLiveRanges(
         // Remove the live range from the active/inactive sets.
         if (!activeRanges.remove(rangeToSpill)) {
           bool removed = inactiveRanges.remove(rangeToSpill);
-          (void)removed;
           assert(removed && "expected a range to be removed!");
           (void)removed;
         }


### PR DESCRIPTION
This reverts commit 05bce3f079b677edd0efd28e3923f4776ffb8b59.

The work was already done in 99faa03.