### PR TITLE
[libc] Restore DECLS_FILE_PATH property

### DIFF
--- a/libc/cmake/modules/LLVMLibCHeaderRules.cmake
+++ b/libc/cmake/modules/LLVMLibCHeaderRules.cmake
@@ -160,6 +160,7 @@ function(add_gen_header2 target_name)
     ${fq_target_name}
     PROPERTIES
       HEADER_FILE_PATH ${out_file}
+      DECLS_FILE_PATH "${decl_out_file}"
       DEPS "${fq_deps_list}"
   )
 


### PR DESCRIPTION
The DECLS_FILE_PATH property is supposed to be set on the targets for
the generated headers for the GPU build installation. It got missed when
creating the cmake rule for new headergen.
