### PR TITLE
[lldb][test] Add ABI library to Makefile.rules link flags

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/make/Makefile.rules
+++ b/lldb/packages/Python/lldbsuite/test/make/Makefile.rules
@@ -390,7 +390,7 @@ ifeq (1,$(USE_LIBCPP))
 		ifneq "$(LIBCPP_INCLUDE_TARGET_DIR)" ""
 				CXXFLAGS += -cxx-isystem $(LIBCPP_INCLUDE_TARGET_DIR)
 		endif
-		LDFLAGS += -L$(LIBCPP_LIBRARY_DIR) -Wl,-rpath,$(LIBCPP_LIBRARY_DIR) -lc++
+		LDFLAGS += -L$(LIBCPP_LIBRARY_DIR) -Wl,-rpath,$(LIBCPP_LIBRARY_DIR) -lc++ -lc++abi
 	else
 		ifeq "$(OS)" "Android"
 				# Nothing to do, this is already handled in
@@ -413,7 +413,7 @@ ifeq (1, $(USE_SYSTEM_STDLIB))
              $(error "SDKROOT must be set on Darwin to use the system libcxx")
         endif
         CXXFLAGS += -nostdlib++ -nostdinc++ -cxx-isystem $(SDKROOT)/usr/include/c++/v1
-        LDFLAGS += -L$(SDKROOT)/usr/lib -Wl,-rpath,$(SDKROOT)/usr/lib -lc++
+        LDFLAGS += -L$(SDKROOT)/usr/lib -Wl,-rpath,$(SDKROOT)/usr/lib -lc++ -lc++abi
     endif
 endif
 
@@ -425,7 +425,7 @@ ifeq ($(or $(USE_LIBSTDCPP), $(USE_LIBCPP), $(USE_SYSTEM_STDLIB)),)
 		ifneq "$(LIBCPP_INCLUDE_TARGET_DIR)" ""
 				CXXFLAGS += -cxx-isystem $(LIBCPP_INCLUDE_TARGET_DIR)
 		endif
-		LDFLAGS += -L$(LIBCPP_LIBRARY_DIR) -Wl,-rpath,$(LIBCPP_LIBRARY_DIR) -lc++
+		LDFLAGS += -L$(LIBCPP_LIBRARY_DIR) -Wl,-rpath,$(LIBCPP_LIBRARY_DIR) -lc++ -lc++abi
 	endif
 endif
 


### PR DESCRIPTION
This commit fixes an undefined reference linking problem with cross-compilation and remote testing on Linux host-Linux target configuration, that occurs when libcxx is linked statically.

Many tests fail with errors similar to that:
```
ERROR: test_with_run_command (TestValueObjectRecursion.ValueObjectRecursionTestCase.test_with_run_command)
   Test that deeply nested ValueObjects still work.
----------------------------------------------------------------------
Error when building test subject.

ld.lld: error: undefined symbol: __gxx_personality_v0
>>> referenced by main.cpp
>>>               main.o:(DW.ref.__gxx_personality_v0)

ld.lld: error: undefined symbol: __cxa_allocate_exception
>>> referenced by new_helpers.cpp
>>>               new_helpers.cpp.o:(std::__throw_bad_alloc()) in archive /home/parallels/llvm-build-release/./lib/aarch64-unknown-linux-gnu/libc++.a

ld.lld: error: undefined symbol: std::bad_alloc::bad_alloc()
>>> referenced by new_helpers.cpp
>>>               new_helpers.cpp.o:(std::__throw_bad_alloc()) in archive /home/parallels/llvm-build-release/./lib/aarch64-unknown-linux-gnu/libc++.a

ld.lld: error: undefined symbol: typeinfo for std::bad_alloc
>>> referenced by new_helpers.cpp
>>>               new_helpers.cpp.o:(std::__throw_bad_alloc()) in archive /home/parallels/llvm-build-release/./lib/aarch64-unknown-linux-gnu/libc++.a
>>> referenced by new_helpers.cpp
>>>               new_helpers.cpp.o:(std::__throw_bad_alloc()) in archive /home/parallels/llvm-build-release/./lib/aarch64-unknown-linux-gnu/libc++.a

...
```