### PR TITLE
[libc] Add AMDGPU Timing to CMake

### DIFF
--- a/libc/benchmarks/gpu/timing/CMakeLists.txt
+++ b/libc/benchmarks/gpu/timing/CMakeLists.txt
@@ -1,4 +1,4 @@
-foreach(target nvptx)
+foreach(target nvptx amdgpu)
   add_subdirectory(${target})
   list(APPEND target_gpu_timing libc.benchmarks.gpu.timing.${target}.${target}_timing)
 endforeach()


### PR DESCRIPTION
`libc/benchmarks/gpu/timing/CMakeLists.txt` did not correctly build `amdgpu` utils. This PR fixes that issue by adding `amdgpu` to the loop that adds the correct sub directories. 