### PR TITLE
[clang][dataflow] Handle CXXInheritedCtorInitExpr in ResultObjectVisitor.

### DIFF
--- a/clang/lib/Analysis/FlowSensitive/DataflowEnvironment.cpp
+++ b/clang/lib/Analysis/FlowSensitive/DataflowEnvironment.cpp
@@ -416,7 +416,7 @@ public:
     // below them can initialize the same object (or part of it).
     if (isa<CXXConstructExpr>(E) || isa<CallExpr>(E) || isa<LambdaExpr>(E) ||
         isa<CXXDefaultArgExpr>(E) || isa<CXXStdInitializerListExpr>(E) ||
-        isa<AtomicExpr>(E) ||
+        isa<AtomicExpr>(E) || isa<CXXInheritedCtorInitExpr>(E) ||
         // We treat `BuiltinBitCastExpr` as an "original initializer" too as
         // it may not even be casting from a record type -- and even if it is,
         // the two objects are in general of unrelated type.

--- a/clang/unittests/Analysis/FlowSensitive/DataflowEnvironmentTest.cpp
+++ b/clang/unittests/Analysis/FlowSensitive/DataflowEnvironmentTest.cpp
@@ -488,7 +488,7 @@ TEST_F(EnvironmentTest, ResultObjectLocationForInheritedCtorInitExpr) {
   RecordStorageLocation &Loc = Env.getResultObjectLocation(*InheritedCtorInit);
   EXPECT_NE(&Loc, nullptr);
 
-  ASSERT_EQ(&Loc, Env.getThisPointeeStorageLocation());
+  EXPECT_EQ(&Loc, Env.getThisPointeeStorageLocation());
 }
 
 TEST_F(EnvironmentTest, Stmt) {


### PR DESCRIPTION

`CXXInheritedCtorInitExpr` is another of the node kinds that should be considered an "original initializer". An assertion failure in `assert(Children.size() == 1)` happens without this fix.