### PR TITLE
[CVP] Infer range return attribute

### DIFF
--- a/clang/test/CodeGenHLSL/BasicFeatures/OutputArguments.hlsl
+++ b/clang/test/CodeGenHLSL/BasicFeatures/OutputArguments.hlsl
@@ -83,7 +83,7 @@ void funky(inout int3 X) {
   X.z += 3;
 }
 
-// ALL-LABEL: define noundef <3 x i32> {{.*}}case4
+// ALL-LABEL: define noundef {{.*}}<3 x i32> {{.*}}case4
 
 // This block initializes V = 0.xxx.
 // CHECK:  [[V:%.*]] = alloca <3 x i32>

--- a/llvm/lib/Transforms/Scalar/CorrelatedValuePropagation.cpp
+++ b/llvm/lib/Transforms/Scalar/CorrelatedValuePropagation.cpp
@@ -1304,8 +1304,12 @@ static bool runImpl(Function &F, LazyValueInfo *LVI, DominatorTree *DT,
     Attribute RangeAttr = F.getRetAttribute(Attribute::Range);
     if (RangeAttr.isValid())
       RetRange = RetRange->intersectWith(RangeAttr.getRange());
-    if (!RetRange->isEmptySet() && !RetRange->isSingleElement())
+    // Don't add attribute for constant integer returns to reduce noise. These
+    // are propagated across functions by IPSCCP.
+    if (!RetRange->isEmptySet() && !RetRange->isSingleElement()) {
       F.addRangeRetAttr(*RetRange);
+      FnChanged = true;
+    }
   }
   return FnChanged;
 }

--- a/llvm/lib/Transforms/Scalar/CorrelatedValuePropagation.cpp
+++ b/llvm/lib/Transforms/Scalar/CorrelatedValuePropagation.cpp
@@ -1207,6 +1207,11 @@ static bool processAnd(BinaryOperator *BinOp, LazyValueInfo *LVI) {
 static bool runImpl(Function &F, LazyValueInfo *LVI, DominatorTree *DT,
                     const SimplifyQuery &SQ) {
   bool FnChanged = false;
+  std::optional<ConstantRange> RetRange;
+  if (F.hasExactDefinition() && F.getReturnType()->isIntOrIntVectorTy())
+    RetRange =
+        ConstantRange::getEmpty(F.getReturnType()->getScalarSizeInBits());
+
   // Visiting in a pre-order depth-first traversal causes us to simplify early
   // blocks before querying later blocks (which require us to analyze early
   // blocks).  Eagerly simplifying shallow blocks means there is strictly less
@@ -1277,6 +1282,11 @@ static bool runImpl(Function &F, LazyValueInfo *LVI, DominatorTree *DT,
       // constant folding the return values of callees.
       auto *RetVal = RI->getReturnValue();
       if (!RetVal) break; // handle "ret void"
+      if (RetRange && !RetRange->isFullSet())
+        RetRange =
+            RetRange->unionWith(LVI->getConstantRange(RetVal, RI,
+                                                      /*UndefAllowed=*/false));
+
       if (isa<Constant>(RetVal)) break; // nothing to do
       if (auto *C = getConstantAt(RetVal, RI, LVI)) {
         ++NumReturns;
@@ -1289,6 +1299,14 @@ static bool runImpl(Function &F, LazyValueInfo *LVI, DominatorTree *DT,
     FnChanged |= BBChanged;
   }
 
+  // Infer range attribute on return value.
+  if (RetRange && !RetRange->isFullSet()) {
+    Attribute RangeAttr = F.getRetAttribute(Attribute::Range);
+    if (RangeAttr.isValid())
+      RetRange = RetRange->intersectWith(RangeAttr.getRange());
+    if (!RetRange->isEmptySet() && !RetRange->isSingleElement())
+      F.addRangeRetAttr(*RetRange);
+  }
   return FnChanged;
 }
 

--- a/llvm/test/Transforms/CorrelatedValuePropagation/add.ll
+++ b/llvm/test/Transforms/CorrelatedValuePropagation/add.ll
@@ -311,7 +311,7 @@ exit:
 
 @limit = external global i32
 define i32 @test11(ptr %p, i32 %i) {
-; CHECK-LABEL: define i32 @test11(
+; CHECK-LABEL: define range(i32 0, 2147483645) i32 @test11(
 ; CHECK-SAME: ptr [[P:%.*]], i32 [[I:%.*]]) {
 ; CHECK-NEXT:    [[LIMIT:%.*]] = load i32, ptr [[P]], align 4, !range [[RNG0:![0-9]+]]
 ; CHECK-NEXT:    [[WITHIN_1:%.*]] = icmp ugt i32 [[LIMIT]], [[I]]

--- a/llvm/test/Transforms/CorrelatedValuePropagation/ashr.ll
+++ b/llvm/test/Transforms/CorrelatedValuePropagation/ashr.ll
@@ -159,7 +159,7 @@ exit:
 
 ; check that ashr of -1 or 0 is optimized away
 define i32 @test6(i32 %f, i32 %g) {
-; CHECK-LABEL: define i32 @test6(
+; CHECK-LABEL: define range(i32 -1, 1) i32 @test6(
 ; CHECK-SAME: i32 [[F:%.*]], i32 [[G:%.*]]) {
 ; CHECK-NEXT:  [[ENTRY:.*:]]
 ; CHECK-NEXT:    [[TMP0:%.*]] = add i32 [[F]], 1
@@ -177,7 +177,7 @@ entry:
 
 ; same test as above with different numbers
 define i32 @test7(i32 %f, i32 %g) {
-; CHECK-LABEL: define i32 @test7(
+; CHECK-LABEL: define range(i32 -1, 1) i32 @test7(
 ; CHECK-SAME: i32 [[F:%.*]], i32 [[G:%.*]]) {
 ; CHECK-NEXT:  [[ENTRY:.*:]]
 ; CHECK-NEXT:    [[TMP0:%.*]] = and i32 [[F]], -2
@@ -197,7 +197,7 @@ entry:
 
 ; check that ashr of -2 or 1 is not optimized away
 define i32 @test8(i32 %f, i32 %g, i1 %s) {
-; CHECK-LABEL: define i32 @test8(
+; CHECK-LABEL: define range(i32 -2, 2) i32 @test8(
 ; CHECK-SAME: i32 [[F:%.*]], i32 [[G:%.*]], i1 [[S:%.*]]) {
 ; CHECK-NEXT:  [[ENTRY:.*:]]
 ; CHECK-NEXT:    [[TMP0:%.*]] = ashr i32 -2, [[F]]
@@ -213,7 +213,7 @@ entry:
 }
 
 define i32 @may_including_undef(i1 %c.1, i1 %c.2) {
-; CHECK-LABEL: define i32 @may_including_undef(
+; CHECK-LABEL: define range(i32 -1073741824, 1073741824) i32 @may_including_undef(
 ; CHECK-SAME: i1 [[C_1:%.*]], i1 [[C_2:%.*]]) {
 ; CHECK-NEXT:    br i1 [[C_1]], label %[[TRUE_1:.*]], label %[[FALSE:.*]]
 ; CHECK:       [[TRUE_1]]:

--- a/llvm/test/Transforms/CorrelatedValuePropagation/basic.ll
+++ b/llvm/test/Transforms/CorrelatedValuePropagation/basic.ll
@@ -3,7 +3,7 @@
 ; PR2581
 
 define i32 @test1(i1 %C) {
-; CHECK-LABEL: define i32 @test1
+; CHECK-LABEL: define range(i32 10, 12) i32 @test1
 ; CHECK-SAME: (i1 [[C:%.*]]) {
 ; CHECK-NEXT:    br i1 [[C]], label [[EXIT:%.*]], label [[BODY:%.*]]
 ; CHECK:       body:
@@ -82,7 +82,7 @@ bb2:
 
 ; PR1757
 define i32 @test4(i32) {
-; CHECK-LABEL: define i32 @test4
+; CHECK-LABEL: define range(i32 0, 3) i32 @test4
 ; CHECK-SAME: (i32 [[TMP0:%.*]]) {
 ; CHECK-NEXT:  EntryBlock:
 ; CHECK-NEXT:    [[DOTDEMORGAN:%.*]] = icmp sgt i32 [[TMP0]], 2
@@ -210,7 +210,7 @@ return:
 }
 
 define i32 @switch1(i32 %s) {
-; CHECK-LABEL: define i32 @switch1
+; CHECK-LABEL: define range(i32 -1, 2) i32 @switch1
 ; CHECK-SAME: (i32 [[S:%.*]]) {
 ; CHECK-NEXT:  entry:
 ; CHECK-NEXT:    [[CMP:%.*]] = icmp slt i32 [[S]], 0
@@ -250,7 +250,7 @@ next:
 }
 
 define i32 @switch2(i32 %s) {
-; CHECK-LABEL: define i32 @switch2
+; CHECK-LABEL: define range(i32 -1, 2) i32 @switch2
 ; CHECK-SAME: (i32 [[S:%.*]]) {
 ; CHECK-NEXT:  entry:
 ; CHECK-NEXT:    [[CMP:%.*]] = icmp sgt i32 [[S]], 0
@@ -284,7 +284,7 @@ next:
 }
 
 define i32 @switch3(i32 %s) {
-; CHECK-LABEL: define i32 @switch3
+; CHECK-LABEL: define range(i32 -1, 2) i32 @switch3
 ; CHECK-SAME: (i32 [[S:%.*]]) {
 ; CHECK-NEXT:  entry:
 ; CHECK-NEXT:    [[CMP:%.*]] = icmp sgt i32 [[S]], 0
@@ -451,7 +451,7 @@ unreachable:
 }
 
 define i32 @switch_range(i32 %cond) {
-; CHECK-LABEL: define i32 @switch_range
+; CHECK-LABEL: define range(i32 1, 3) i32 @switch_range
 ; CHECK-SAME: (i32 [[COND:%.*]]) {
 ; CHECK-NEXT:  entry:
 ; CHECK-NEXT:    [[S:%.*]] = urem i32 [[COND]], 3
@@ -491,7 +491,7 @@ unreachable:
 ; switch condition, we should not change the default.
 
 define i32 @switch_range_not_full(i32 %cond) {
-; CHECK-LABEL: define i32 @switch_range_not_full
+; CHECK-LABEL: define range(i32 0, 3) i32 @switch_range_not_full
 ; CHECK-SAME: (i32 [[COND:%.*]]) {
 ; CHECK-NEXT:  entry:
 ; CHECK-NEXT:    [[S:%.*]] = urem i32 [[COND]], 3
@@ -2052,7 +2052,7 @@ define i1 @binop_eval_order(i32 %x) {
 }
 
 define range(i32 0, 1024) i32 @range_larger(i8 %x) {
-; CHECK-LABEL: define range(i32 0, 1024) i32 @range_larger
+; CHECK-LABEL: define range(i32 0, 256) i32 @range_larger
 ; CHECK-SAME: (i8 [[X:%.*]]) {
 ; CHECK-NEXT:    [[ZEXT:%.*]] = zext i8 [[X]] to i32
 ; CHECK-NEXT:    ret i32 [[ZEXT]]
@@ -2072,7 +2072,7 @@ define range(i32 0, 128) i32 @range_smaller(i8 %x) {
 }
 
 define range(i32 128, 512) i32 @range_intersect(i8 %x) {
-; CHECK-LABEL: define range(i32 128, 512) i32 @range_intersect
+; CHECK-LABEL: define range(i32 128, 256) i32 @range_intersect
 ; CHECK-SAME: (i8 [[X:%.*]]) {
 ; CHECK-NEXT:    [[ZEXT:%.*]] = zext i8 [[X]] to i32
 ; CHECK-NEXT:    ret i32 [[ZEXT]]

--- a/llvm/test/Transforms/CorrelatedValuePropagation/cond-using-block-value.ll
+++ b/llvm/test/Transforms/CorrelatedValuePropagation/cond-using-block-value.ll
@@ -38,7 +38,7 @@ end:
 }
 
 define i64 @test_sext_from_implied_cond(i32 %a, i32 %b) {
-; CHECK-LABEL: define i64 @test_sext_from_implied_cond(
+; CHECK-LABEL: define range(i64 0, 2147483647) i64 @test_sext_from_implied_cond(
 ; CHECK-SAME: i32 [[A:%.*]], i32 [[B:%.*]]) {
 ; CHECK-NEXT:    [[A_CMP:%.*]] = icmp slt i32 [[A]], 0
 ; CHECK-NEXT:    br i1 [[A_CMP]], label [[END:%.*]], label [[L1:%.*]]

--- a/llvm/test/Transforms/CorrelatedValuePropagation/select.ll
+++ b/llvm/test/Transforms/CorrelatedValuePropagation/select.ll
@@ -141,7 +141,7 @@ else:
 }
 
 define i8 @not_correlated(i1, i1) {
-; CHECK-LABEL: define i8 @not_correlated
+; CHECK-LABEL: define range(i8 0, 2) i8 @not_correlated
 ; CHECK-SAME: (i1 [[TMP0:%.*]], i1 [[TMP1:%.*]]) {
 ; CHECK-NEXT:  entry:
 ; CHECK-NEXT:    [[S:%.*]] = select i1 [[TMP0]], i8 0, i8 1
@@ -361,7 +361,7 @@ exit:
 }
 
 define i64 @select_cond_may_undef(i32 %a) {
-; CHECK-LABEL: define i64 @select_cond_may_undef
+; CHECK-LABEL: define range(i64 -2147483648, 2147483648) i64 @select_cond_may_undef
 ; CHECK-SAME: (i32 [[A:%.*]]) {
 ; CHECK-NEXT:    [[IS_A_NONNEGATIVE:%.*]] = icmp sgt i32 [[A]], 1
 ; CHECK-NEXT:    [[NARROW:%.*]] = select i1 [[IS_A_NONNEGATIVE]], i32 [[A]], i32 0

--- a/llvm/test/Transforms/CorrelatedValuePropagation/vectors.ll
+++ b/llvm/test/Transforms/CorrelatedValuePropagation/vectors.ll
@@ -60,7 +60,7 @@ define <2 x i1> @cmp_signedness(<2 x i8> %a) {
 }
 
 define <2 x i16> @infer_nowrap(<2 x i8> %a) {
-; CHECK-LABEL: define <2 x i16> @infer_nowrap(
+; CHECK-LABEL: define range(i16 1, 257) <2 x i16> @infer_nowrap(
 ; CHECK-SAME: <2 x i8> [[A:%.*]]) {
 ; CHECK-NEXT:    [[ZEXT:%.*]] = zext <2 x i8> [[A]] to <2 x i16>
 ; CHECK-NEXT:    [[RES:%.*]] = add nuw nsw <2 x i16> [[ZEXT]], <i16 1, i16 1>
@@ -72,7 +72,7 @@ define <2 x i16> @infer_nowrap(<2 x i8> %a) {
 }
 
 define <2 x i16> @infer_nowrap_nonsplat(<2 x i8> %a) {
-; CHECK-LABEL: define <2 x i16> @infer_nowrap_nonsplat(
+; CHECK-LABEL: define range(i16 1, 258) <2 x i16> @infer_nowrap_nonsplat(
 ; CHECK-SAME: <2 x i8> [[A:%.*]]) {
 ; CHECK-NEXT:    [[ZEXT:%.*]] = zext <2 x i8> [[A]] to <2 x i16>
 ; CHECK-NEXT:    [[RES:%.*]] = add nuw nsw <2 x i16> [[ZEXT]], <i16 1, i16 2>
@@ -84,7 +84,7 @@ define <2 x i16> @infer_nowrap_nonsplat(<2 x i8> %a) {
 }
 
 define <vscale x 2 x i16> @infer_nowrap_scalable(<vscale x 2 x i8> %a) {
-; CHECK-LABEL: define <vscale x 2 x i16> @infer_nowrap_scalable(
+; CHECK-LABEL: define range(i16 1, 257) <vscale x 2 x i16> @infer_nowrap_scalable(
 ; CHECK-SAME: <vscale x 2 x i8> [[A:%.*]]) {
 ; CHECK-NEXT:    [[ZEXT:%.*]] = zext <vscale x 2 x i8> [[A]] to <vscale x 2 x i16>
 ; CHECK-NEXT:    [[RES:%.*]] = add nuw nsw <vscale x 2 x i16> [[ZEXT]], shufflevector (<vscale x 2 x i16> insertelement (<vscale x 2 x i16> poison, i16 1, i64 0), <vscale x 2 x i16> poison, <vscale x 2 x i32> zeroinitializer)
@@ -96,7 +96,7 @@ define <vscale x 2 x i16> @infer_nowrap_scalable(<vscale x 2 x i8> %a) {
 }
 
 define <2 x i16> @infer_nowrap_poison(<2 x i8> %a) {
-; CHECK-LABEL: define <2 x i16> @infer_nowrap_poison(
+; CHECK-LABEL: define range(i16 1, 257) <2 x i16> @infer_nowrap_poison(
 ; CHECK-SAME: <2 x i8> [[A:%.*]]) {
 ; CHECK-NEXT:    [[ZEXT:%.*]] = zext <2 x i8> [[A]] to <2 x i16>
 ; CHECK-NEXT:    [[RES:%.*]] = add nuw nsw <2 x i16> [[ZEXT]], <i16 1, i16 poison>
@@ -108,7 +108,7 @@ define <2 x i16> @infer_nowrap_poison(<2 x i8> %a) {
 }
 
 define <2 x i16> @infer_nowrap_nonsplat_nsw_only(<2 x i8> %a) {
-; CHECK-LABEL: define <2 x i16> @infer_nowrap_nonsplat_nsw_only(
+; CHECK-LABEL: define range(i16 -1, 257) <2 x i16> @infer_nowrap_nonsplat_nsw_only(
 ; CHECK-SAME: <2 x i8> [[A:%.*]]) {
 ; CHECK-NEXT:    [[ZEXT:%.*]] = zext <2 x i8> [[A]] to <2 x i16>
 ; CHECK-NEXT:    [[RES:%.*]] = add nsw <2 x i16> [[ZEXT]], <i16 1, i16 -1>
@@ -120,7 +120,7 @@ define <2 x i16> @infer_nowrap_nonsplat_nsw_only(<2 x i8> %a) {
 }
 
 define <2 x i16> @abs(<2 x i8> %a) {
-; CHECK-LABEL: define <2 x i16> @abs(
+; CHECK-LABEL: define range(i16 0, 256) <2 x i16> @abs(
 ; CHECK-SAME: <2 x i8> [[A:%.*]]) {
 ; CHECK-NEXT:    [[ZEXT:%.*]] = zext <2 x i8> [[A]] to <2 x i16>
 ; CHECK-NEXT:    ret <2 x i16> [[ZEXT]]
@@ -131,7 +131,7 @@ define <2 x i16> @abs(<2 x i8> %a) {
 }
 
 define <2 x i16> @saturating(<2 x i8> %a) {
-; CHECK-LABEL: define <2 x i16> @saturating(
+; CHECK-LABEL: define range(i16 1, 257) <2 x i16> @saturating(
 ; CHECK-SAME: <2 x i8> [[A:%.*]]) {
 ; CHECK-NEXT:    [[ZEXT:%.*]] = zext <2 x i8> [[A]] to <2 x i16>
 ; CHECK-NEXT:    [[RES:%.*]] = add nuw nsw <2 x i16> [[ZEXT]], <i16 1, i16 1>
@@ -156,7 +156,7 @@ define {<2 x i16>, <2 x i1>} @with_overflow(<2 x i8> %a) {
 }
 
 define <2 x i16> @srem1(<2 x i8> %a) {
-; CHECK-LABEL: define <2 x i16> @srem1(
+; CHECK-LABEL: define range(i16 0, 42) <2 x i16> @srem1(
 ; CHECK-SAME: <2 x i8> [[A:%.*]]) {
 ; CHECK-NEXT:    [[ZEXT:%.*]] = zext <2 x i8> [[A]] to <2 x i16>
 ; CHECK-NEXT:    [[RES1_LHS_TRUNC:%.*]] = trunc <2 x i16> [[ZEXT]] to <2 x i8>
@@ -170,7 +170,7 @@ define <2 x i16> @srem1(<2 x i8> %a) {
 }
 
 define <2 x i16> @srem2(<2 x i8> %a) {
-; CHECK-LABEL: define <2 x i16> @srem2(
+; CHECK-LABEL: define range(i16 -41, 42) <2 x i16> @srem2(
 ; CHECK-SAME: <2 x i8> [[A:%.*]]) {
 ; CHECK-NEXT:    [[ZEXT:%.*]] = sext <2 x i8> [[A]] to <2 x i16>
 ; CHECK-NEXT:    [[RES_LHS_TRUNC:%.*]] = trunc <2 x i16> [[ZEXT]] to <2 x i8>
@@ -184,7 +184,7 @@ define <2 x i16> @srem2(<2 x i8> %a) {
 }
 
 define <2 x i16> @ashr(<2 x i8> %a) {
-; CHECK-LABEL: define <2 x i16> @ashr(
+; CHECK-LABEL: define range(i16 0, 128) <2 x i16> @ashr(
 ; CHECK-SAME: <2 x i8> [[A:%.*]]) {
 ; CHECK-NEXT:    [[ZEXT:%.*]] = zext <2 x i8> [[A]] to <2 x i16>
 ; CHECK-NEXT:    [[RES:%.*]] = lshr <2 x i16> [[ZEXT]], <i16 1, i16 1>
@@ -196,7 +196,7 @@ define <2 x i16> @ashr(<2 x i8> %a) {
 }
 
 define <2 x i32> @sext(<2 x i8> %a) {
-; CHECK-LABEL: define <2 x i32> @sext(
+; CHECK-LABEL: define range(i32 0, 256) <2 x i32> @sext(
 ; CHECK-SAME: <2 x i8> [[A:%.*]]) {
 ; CHECK-NEXT:    [[ZEXT:%.*]] = zext <2 x i8> [[A]] to <2 x i16>
 ; CHECK-NEXT:    [[RES:%.*]] = zext nneg <2 x i16> [[ZEXT]] to <2 x i32>
@@ -220,7 +220,7 @@ define <2 x float> @sitofp(<2 x i8> %a) {
 }
 
 define <2 x i16> @and(<2 x i8> %a) {
-; CHECK-LABEL: define <2 x i16> @and(
+; CHECK-LABEL: define range(i16 0, 256) <2 x i16> @and(
 ; CHECK-SAME: <2 x i8> [[A:%.*]]) {
 ; CHECK-NEXT:    [[ZEXT:%.*]] = zext <2 x i8> [[A]] to <2 x i16>
 ; CHECK-NEXT:    ret <2 x i16> [[ZEXT]]
@@ -231,7 +231,7 @@ define <2 x i16> @and(<2 x i8> %a) {
 }
 
 define <2 x i16> @and_with_poison(<2 x i8> %a) {
-; CHECK-LABEL: define <2 x i16> @and_with_poison(
+; CHECK-LABEL: define range(i16 0, 256) <2 x i16> @and_with_poison(
 ; CHECK-SAME: <2 x i8> [[A:%.*]]) {
 ; CHECK-NEXT:    [[ZEXT:%.*]] = zext <2 x i8> [[A]] to <2 x i16>
 ; CHECK-NEXT:    ret <2 x i16> [[ZEXT]]
@@ -242,7 +242,7 @@ define <2 x i16> @and_with_poison(<2 x i8> %a) {
 }
 
 define <4 x i64> @issue_97674_getConstantOnEdge(i1 %cond) {
-; CHECK-LABEL: define <4 x i64> @issue_97674_getConstantOnEdge(
+; CHECK-LABEL: define range(i64 0, 2) <4 x i64> @issue_97674_getConstantOnEdge(
 ; CHECK-SAME: i1 [[COND:%.*]]) {
 ; CHECK-NEXT:  [[ENTRY:.*]]:
 ; CHECK-NEXT:    br i1 [[COND]], label %[[IF_THEN:.*]], label %[[IF_END:.*]]
@@ -277,7 +277,7 @@ entry:
 }
 
 define <2 x i16> @phi_merge1(i1 %c, <2 x i8> %a) {
-; CHECK-LABEL: define <2 x i16> @phi_merge1(
+; CHECK-LABEL: define range(i16 2, 259) <2 x i16> @phi_merge1(
 ; CHECK-SAME: i1 [[C:%.*]], <2 x i8> [[A:%.*]]) {
 ; CHECK-NEXT:  [[ENTRY:.*]]:
 ; CHECK-NEXT:    [[ZEXT:%.*]] = zext <2 x i8> [[A]] to <2 x i16>
@@ -303,7 +303,7 @@ join:
 }
 
 define <2 x i16> @phi_merge2(i1 %c, <2 x i8> %a) {
-; CHECK-LABEL: define <2 x i16> @phi_merge2(
+; CHECK-LABEL: define range(i16 2, 259) <2 x i16> @phi_merge2(
 ; CHECK-SAME: i1 [[C:%.*]], <2 x i8> [[A:%.*]]) {
 ; CHECK-NEXT:  [[ENTRY:.*]]:
 ; CHECK-NEXT:    [[ZEXT:%.*]] = zext <2 x i8> [[A]] to <2 x i16>


### PR DESCRIPTION
We already infer this in IPSCCP (which runs very early, so cannot benefit from inlining and simplifications) and SCCP (which runs without PredicateInfo, so does not use assumes). Do it in CVP as well, so it can handle cases that IPSCCP/SCCP can't. 

Fixes https://github.com/llvm/llvm-project/issues/98946 (everything apart from f2, where the assume is dropped by the frontend).

(No compile-time impact: https://llvm-compile-time-tracker.com/compare.php?from=f1ff3a279f3320d8e0d4abbc1a8357bb51de25a2&to=46ab5f809414b3f06ab9956e0fc6910284417b6d&stat=instructions:u)