### PR TITLE
[libc++][Android] Pass -no-metrics to emulator

### DIFF
--- a/libcxx/utils/ci/vendor/android/Dockerfile.emulator
+++ b/libcxx/utils/ci/vendor/android/Dockerfile.emulator
@@ -16,7 +16,7 @@ RUN apt-get update && apt-get install -y \
     unzip \
     && rm -rf /var/lib/apt/lists/*
 
-ENV ANDROID_HOME /opt/android/sdk
+ENV ANDROID_HOME=/opt/android/sdk
 
 RUN curl -sL https://dl.google.com/android/repository/commandlinetools-linux-9477386_latest.zip -o cmdline-tools.zip && \
     mkdir -p ${ANDROID_HOME} && \

--- a/libcxx/utils/ci/vendor/android/emulator-entrypoint.sh
+++ b/libcxx/utils/ci/vendor/android/emulator-entrypoint.sh
@@ -45,5 +45,5 @@ fi
 
 # Use exec so that the emulator is PID 1, so that `docker stop` kills the
 # emulator.
-exec emulator @emulator -no-audio -no-window \
+exec emulator @emulator -no-audio -no-window -no-metrics \
     -partition-size "${EMU_PARTITION_SIZE}"


### PR DESCRIPTION
The Android Emulator has started printing this message, so pass the `-no-metrics` option:

```
##############################################################################
##                        WARNING - ACTION REQUIRED                         ##
##  Consider using the '-metrics-collection' flag to help improve the       ##
##  emulator by sending anonymized usage data. Or use the '-no-metrics'     ##
##  flag to bypass this warning and turn off the metrics collection.        ##
##  In a future release this warning will turn into a one-time blocking     ##
##  prompt to ask for explicit user input regarding metrics collection.     ##
##                                                                          ##
##  Please see '-help-metrics-collection' for more details. You can use     ##
##  '-metrics-to-file' or '-metrics-to-console' flags to see what type of   ##
##  data is being collected by emulator as part of usage statistics.        ##
##############################################################################
```