### PR TITLE
[libcxx][test] Update picolib xfails

### DIFF
--- a/libcxx/test/libcxx/clang_modules_include.gen.py
+++ b/libcxx/test/libcxx/clang_modules_include.gen.py
@@ -37,9 +37,6 @@ for header in public_headers:
 // TODO: Investigate this failure
 // UNSUPPORTED: LIBCXX-FREEBSD-FIXME
 
-// TODO: Investigate this failure
-// UNSUPPORTED: LIBCXX-PICOLIBC-FIXME
-
 {lit_header_restrictions.get(header, '')}
 
 #include <{header}>

--- a/libcxx/test/std/localization/locale.categories/category.ctype/facet.ctype.special/facet.ctype.char.statics/classic_table.pass.cpp
+++ b/libcxx/test/std/localization/locale.categories/category.ctype/facet.ctype.special/facet.ctype.char.statics/classic_table.pass.cpp
@@ -6,6 +6,10 @@
 //
 //===----------------------------------------------------------------------===//
 
+// Picolibc/newlib checks for the blank flag in isprint, which needs to be false
+// for tab. So they removed the _B flag from the ctype data, which causes this
+// test to fail.
+// See https://github.com/picolibc/picolibc/issues/778.
 // XFAIL: LIBCXX-PICOLIBC-FIXME
 
 // <locale>


### PR DESCRIPTION
clang_modules_include.gen.py works now, and I added some background to classic_table.pass.cpp.

Opened https://github.com/picolibc/picolibc/issues/778 to see if that one is possible to fix.