### PR TITLE
[mlir][BytecodeReader] Fix FusedLoc bytecode builder

### DIFF
--- a/mlir/include/mlir/IR/BuiltinDialectBytecode.td
+++ b/mlir/include/mlir/IR/BuiltinDialectBytecode.td
@@ -101,12 +101,12 @@ def FileLineColLoc : DialectAttribute<(attr
   VarInt:$column
 )>;
 
-let cType = "FusedLoc",
-    cBuilder = "cast<FusedLoc>(get<FusedLoc>(context, $_args))" in {
+let cType = "FusedLoc" in {
 def FusedLoc : DialectAttribute<(attr
   Array<Location>:$locations
 )> {
   let printerPredicate = "!$_val.getMetadata()";
+  let cBuilder = "cast<FusedLoc>(get<FusedLoc>(context, $_args, Attribute()))";
 }
 
 def FusedLocWithMetadata : DialectAttribute<(attr
@@ -114,6 +114,7 @@ def FusedLocWithMetadata : DialectAttribute<(attr
   Attribute:$metadata
 )> {
   let printerPredicate = "$_val.getMetadata()";
+  let cBuilder = "cast<FusedLoc>(get<FusedLoc>(context, $_args))";
 }
 }
 

--- a/mlir/unittests/Bytecode/BytecodeTest.cpp
+++ b/mlir/unittests/Bytecode/BytecodeTest.cpp
@@ -10,6 +10,7 @@
 #include "mlir/Bytecode/BytecodeWriter.h"
 #include "mlir/IR/AsmState.h"
 #include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/OpImplementation.h"
 #include "mlir/IR/OwningOpRef.h"
 #include "mlir/Parser/Parser.h"
@@ -147,4 +148,25 @@ TEST(Bytecode, OpWithoutProperties) {
 
   EXPECT_TRUE(OperationEquivalence::computeHash(op.get()) ==
               OperationEquivalence::computeHash(roundtripped));
+}
+
+TEST(Bytecode, FusedLocCrash) {
+  MLIRContext context;
+  OpBuilder builder(&context);
+  SmallVector<Location> locs;
+  FusedLoc fusedLoc = FusedLoc::get(&context, locs, {});
+
+  auto module = builder.create<mlir::ModuleOp>(fusedLoc, "test");
+
+  // Write the module to bytecode
+  std::string buffer;
+  llvm::raw_string_ostream ostream(buffer);
+  ASSERT_TRUE(succeeded(writeBytecodeToFile(module, ostream)));
+  ostream.flush();
+
+  // Parse it back
+  ParserConfig parseConfig(&context);
+  OwningOpRef<Operation *> roundTripModule =
+      parseSourceString<Operation *>(buffer, parseConfig);
+  ASSERT_TRUE(roundTripModule);
 }


### PR DESCRIPTION
[`FusedLoc::get(MLIRContext*, ArrayRef<Location>)`](https://github.com/llvm/llvm-project/blob/098bd842a7e50853fa231f8b73c24ec5006fe063/mlir/include/mlir/IR/BuiltinLocationAttributes.td#L138) is not guaranteed to return `FusedLoc` but it is used when reading bytecode. This PR changes to use a different getter `FusedLoc::get(MLIRContext*, ArrayRef<Location>, Attribute attribute)` which always returns `FusedLoc`.  

Fix https://github.com/llvm/llvm-project/issues/99626. 