### PR TITLE
[Support] Add Arm NEON implementation for `llvm::xxh3_64bits`

### DIFF
--- a/llvm/benchmarks/CMakeLists.txt
+++ b/llvm/benchmarks/CMakeLists.txt
@@ -1,4 +1,5 @@
 set(LLVM_LINK_COMPONENTS
   Support)
 
-add_benchmark(DummyYAML DummyYAML.cpp)
+add_benchmark(DummyYAML DummyYAML.cpp PARTIAL_SOURCES_INTENDED)
+add_benchmark(xxhash xxhash.cpp PARTIAL_SOURCES_INTENDED)

--- a/llvm/benchmarks/xxhash.cpp
+++ b/llvm/benchmarks/xxhash.cpp
@@ -1,6 +1,8 @@
 #include "llvm/Support/xxhash.h"
 #include "benchmark/benchmark.h"
 
+#include <memory>
+
 static uint32_t xorshift(uint32_t State) {
   State ^= State << 13;
   State ^= State >> 17;
@@ -9,21 +11,17 @@ static uint32_t xorshift(uint32_t State) {
 }
 
 static void BM_xxh3_64bits(benchmark::State &State) {
-  uint32_t *Data = new uint32_t[State.range(0) / 4];
+  std::unique_ptr<uint32_t[]> Data(new uint32_t[State.range(0) / 4]);
 
   uint32_t Prev = 0xcafebabe;
-  for (int64_t I = 0; I < State.range(0) / 4; I++) {
+  for (int64_t I = 0; I < State.range(0) / 4; I++)
     Data[I] = Prev = xorshift(Prev);
-  }
 
   llvm::ArrayRef DataRef =
-      llvm::ArrayRef(reinterpret_cast<uint8_t *>(Data), State.range(0));
+      llvm::ArrayRef(reinterpret_cast<uint8_t *>(Data.get()), State.range(0));
 
-  for (auto _ : State) {
+  for (auto _ : State)
     llvm::xxh3_64bits(DataRef);
-  }
-
-  delete[] Data;
 }
 
 BENCHMARK(BM_xxh3_64bits)->Arg(32)->Arg(512)->Arg(64 * 1024)->Arg(1024 * 1024);

--- a/llvm/benchmarks/xxhash.cpp
+++ b/llvm/benchmarks/xxhash.cpp
@@ -1,0 +1,36 @@
+#include "llvm/Support/xxhash.h"
+#include "benchmark/benchmark.h"
+
+static uint32_t xorshift(uint32_t State) {
+  State ^= State << 13;
+  State ^= State >> 17;
+  State ^= State << 5;
+  return State;
+}
+
+static void BM_xxh3_64bits(benchmark::State &State) {
+  uint32_t *Data = new uint32_t[State.range(0) / 4];
+
+  uint32_t Prev = 0xcafebabe;
+  for (int64_t I = 0; I < State.range(0) / 4; I++) {
+    Data[I] = Prev = xorshift(Prev);
+  }
+
+  llvm::ArrayRef DataRef =
+      llvm::ArrayRef(reinterpret_cast<uint8_t *>(Data), State.range(0));
+
+  for (auto _ : State) {
+    llvm::xxh3_64bits(DataRef);
+  }
+
+  delete[] Data;
+}
+
+BENCHMARK(BM_xxh3_64bits)
+    ->Arg(32)
+    ->Arg(512)
+    ->Arg(64 * 1024)
+    ->Arg(1024 * 1024);
+
+BENCHMARK_MAIN();
+

--- a/llvm/benchmarks/xxhash.cpp
+++ b/llvm/benchmarks/xxhash.cpp
@@ -26,11 +26,6 @@ static void BM_xxh3_64bits(benchmark::State &State) {
   delete[] Data;
 }
 
-BENCHMARK(BM_xxh3_64bits)
-    ->Arg(32)
-    ->Arg(512)
-    ->Arg(64 * 1024)
-    ->Arg(1024 * 1024);
+BENCHMARK(BM_xxh3_64bits)->Arg(32)->Arg(512)->Arg(64 * 1024)->Arg(1024 * 1024);
 
 BENCHMARK_MAIN();
-


### PR DESCRIPTION
Compared to the generic scalar code, using Arm NEON instructions yields a ~11x speedup: 31 vs 339.5 ms to hash 1 GiB of random data on the Apple M1.

This follows the upstream implementation closely, with some simplifications made:
- Removed workarounds for suboptimal codegen on older GCC
- Removed instruction reordering barriers which seem to have a negligible impact according to my measurements
- We do not support WebAssembly's mostly NEON-compatible API
- There is no configurable mixing of SIMD and scalar code; according to the upstream comments, this is only relevant for smaller Cortex cores which can dispatch relatively few NEON micro-ops per cycle.

This commit intends to use only standard ACLE intrinsics and datatypes, so it should build with all supported versions of GCC, Clang and MSVC.

This feature is enabled by default when targeting AArch64, but the `LLVM_XXH_USE_NEON=0` macro can be set to explicitly disable it.

XXH3 is used for ICF, string deduplication and computing the UUID in ld64.lld; this commit results in a -1.77% +/- 0.59% speed improvement for a `--threads=8` link of Chromium.framework.