### PR TITLE
[libc++] Add missing xlocale.h include on Apple and FreeBSD

### DIFF
--- a/libcxx/include/locale
+++ b/libcxx/include/locale
@@ -232,6 +232,10 @@ template <class charT> class messages_byname;
 #    include <__locale_dir/locale_base_api/bsd_locale_fallbacks.h>
 #  endif
 
+#  if defined(__APPLE__) || defined(__FreeBSD__)
+#    include <xlocale.h>
+#  endif
+
 #  if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
 #    pragma GCC system_header
 #  endif


### PR DESCRIPTION
The `<locale>` header uses `strtoll_l` and friends which are defined in `<xlocale.h>` on these platforms. While this works via transitive includes when modules are disabled, this doesn't work anymore if the platforms are modularized properly.