### PR TITLE
[LLDB][SBSaveCoreOptions] Fix TestProcessSaveCore

### DIFF
--- a/lldb/test/API/functionalities/process_save_core/TestProcessSaveCore.py
+++ b/lldb/test/API/functionalities/process_save_core/TestProcessSaveCore.py
@@ -20,8 +20,8 @@ class ProcessSaveCoreTestCase(TestBase):
         target = self.dbg.CreateTarget(exe)
         process = target.LaunchSimple(None, None, self.get_process_working_directory())
         self.assertNotEqual(process.GetState(), lldb.eStateStopped)
-        options = SBSaveCoreOptions()
-        options.SetOutputFile(SBFileSpec(core))
+        options = lldb.SBSaveCoreOptions()
+        options.SetOutputFile(lldb.SBFileSpec(core))
         error = process.SaveCore(core)
         self.assertTrue(error.Fail())
 


### PR DESCRIPTION
In #98403 some of the tests were transitioned to the new `SBProcess::SaveCore(SBSaveCoreOptions)` API, but were not detected in testing. This patch addresses that.