### PR TITLE
[sanitizer] Undef _TIME_BITS along with _FILE_OFFSET_BITS

### DIFF
--- a/compiler-rt/lib/sanitizer_common/sanitizer_procmaps_solaris.cpp
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_procmaps_solaris.cpp
@@ -11,6 +11,10 @@
 
 // Before Solaris 11.4, <procfs.h> doesn't work in a largefile environment.
 #undef _FILE_OFFSET_BITS
+
+// Avoid conflict between `_TIME_BITS` defined vs. `_FILE_OFFSET_BITS`
+// undefined in some Linux configurations.
+#undef _TIME_BITS
 #include "sanitizer_platform.h"
 #if SANITIZER_SOLARIS
 #  include <fcntl.h>


### PR DESCRIPTION
This change is identical to
26800a2c7e7996dc773b4e990dd5cca41c45e1a9 ("[sanitizer] Undef _TIME_BITS along with _FILE_OFFSET_BITS on Linux"), but for sanitizer_procmaps_solaris.cpp.

Indeed, even though sanitizer_procmaps_solaris.cpp is Solaris specific, it also gets built on Linux platforms. It also includes sanitizer_platform.h, which also ends up including features-time64.h, causing a build failure on 32-bit Linux platforms on which 64-bit time_t is enabled by setting _TIME_BITS=64.

To fix this, we do the same change: undefine _TIME_BITS, which anyway will cause no harm as the rest of this file is inside a SANITIZER_SOLARIS compile-time conditional.

Fixes:

In file included from /home/thomas/buildroot/buildroot/output/host/i686-buildroot-linux-gnu/sysroot/usr/include/features.h:394,
                 from ../../../../libsanitizer/sanitizer_common/sanitizer_platform.h:25,
                 from ../../../../libsanitizer/sanitizer_common/sanitizer_procmaps_solaris.cpp:14:
/home/thomas/buildroot/buildroot/output/host/i686-buildroot-linux-gnu/sysroot/usr/include/features-time64.h:26:5: error: #error "_TIME_BITS=64 is al lowed only with _FILE_OFFSET_BITS=64"
   26 | #   error "_TIME_BITS=64 is allowed only with _FILE_OFFSET_BITS=64"
      |     ^~~~~