### PR TITLE
[MC] Add .loc_label instruction

### DIFF
--- a/llvm/include/llvm/MC/MCDwarf.h
+++ b/llvm/include/llvm/MC/MCDwarf.h
@@ -194,10 +194,16 @@ private:
 
 public:
   // Constructor to create an MCDwarfLineEntry given a symbol and the dwarf loc.
-  MCDwarfLineEntry(MCSymbol *label, const MCDwarfLoc loc)
-      : MCDwarfLoc(loc), Label(label) {}
+  MCDwarfLineEntry(MCSymbol *label, const MCDwarfLoc loc,
+                   MCSymbol *lineStreamLabel = nullptr)
+      : MCDwarfLoc(loc), Label(label), LineStreamLabel(lineStreamLabel) {}
 
   MCSymbol *getLabel() const { return Label; }
+
+  // This is the label that is to be emitted into the line stream. If this is
+  // non-null and we need to emit a label, also make sure to restart the current
+  // line sequence.
+  MCSymbol *LineStreamLabel;
 
   // This indicates the line entry is synthesized for an end entry.
   bool IsEndEntry = false;

--- a/llvm/include/llvm/MC/MCDwarf.h
+++ b/llvm/include/llvm/MC/MCDwarf.h
@@ -195,8 +195,10 @@ private:
 public:
   // Constructor to create an MCDwarfLineEntry given a symbol and the dwarf loc.
   MCDwarfLineEntry(MCSymbol *label, const MCDwarfLoc loc,
-                   MCSymbol *lineStreamLabel = nullptr)
-      : MCDwarfLoc(loc), Label(label), LineStreamLabel(lineStreamLabel) {}
+                   MCSymbol *lineStreamLabel = nullptr,
+                   SMLoc streamLabelDefLoc = {})
+      : MCDwarfLoc(loc), Label(label), LineStreamLabel(lineStreamLabel),
+        StreamLabelDefLoc(streamLabelDefLoc) {}
 
   MCSymbol *getLabel() const { return Label; }
 
@@ -204,6 +206,10 @@ public:
   // non-null and we need to emit a label, also make sure to restart the current
   // line sequence.
   MCSymbol *LineStreamLabel;
+
+  // Location where LineStreamLabel was defined. If there is an error emitting
+  // LineStreamLabel, we can use the SMLoc to report an error.
+  SMLoc StreamLabelDefLoc;
 
   // This indicates the line entry is synthesized for an end entry.
   bool IsEndEntry = false;
@@ -370,6 +376,9 @@ public:
   static void
   emitOne(MCStreamer *MCOS, MCSection *Section,
           const MCLineSection::MCDwarfLineEntryCollection &LineEntries);
+
+  void endCurrentSeqAndEmitLineStreamLabel(MCStreamer *MCOS, SMLoc DefLoc,
+                                           StringRef Name);
 
   Expected<unsigned> tryGetFile(StringRef &Directory, StringRef &FileName,
                                 std::optional<MD5::MD5Result> Checksum,

--- a/llvm/include/llvm/MC/MCObjectStreamer.h
+++ b/llvm/include/llvm/MC/MCObjectStreamer.h
@@ -146,7 +146,8 @@ public:
   void emitDwarfAdvanceLineAddr(int64_t LineDelta, const MCSymbol *LastLabel,
                                 const MCSymbol *Label,
                                 unsigned PointerSize) override;
-  void emitDwarfLineEndEntry(MCSection *Section, MCSymbol *LastLabel) override;
+  void emitDwarfLineEndEntry(MCSection *Section, MCSymbol *LastLabel,
+                             MCSymbol *EndLabel = nullptr) override;
   void emitDwarfAdvanceFrameAddr(const MCSymbol *LastLabel,
                                  const MCSymbol *Label, SMLoc Loc);
   void emitCVLocDirective(unsigned FunctionId, unsigned FileNo, unsigned Line,

--- a/llvm/include/llvm/MC/MCStreamer.h
+++ b/llvm/include/llvm/MC/MCStreamer.h
@@ -912,6 +912,9 @@ public:
                                      unsigned Isa, unsigned Discriminator,
                                      StringRef FileName);
 
+  /// This implements the '.loc_label Name' directive.
+  virtual void emitDwarfLocLabelDirective(SMLoc Loc, StringRef Name);
+
   /// Associate a filename with a specified logical file number, and also
   /// specify that file's checksum information.  This implements the '.cv_file 4
   /// "foo.c"' assembler directive. Returns true on success.

--- a/llvm/include/llvm/MC/MCStreamer.h
+++ b/llvm/include/llvm/MC/MCStreamer.h
@@ -1122,7 +1122,8 @@ public:
   virtual void emitDwarfLineStartLabel(MCSymbol *StartSym);
 
   /// Emit the debug line end entry.
-  virtual void emitDwarfLineEndEntry(MCSection *Section, MCSymbol *LastLabel) {}
+  virtual void emitDwarfLineEndEntry(MCSection *Section, MCSymbol *LastLabel,
+                                     MCSymbol *EndLabel = nullptr) {}
 
   /// If targets does not support representing debug line section by .loc/.file
   /// directives in assembly output, we need to populate debug line section with

--- a/llvm/lib/MC/MCAsmStreamer.cpp
+++ b/llvm/lib/MC/MCAsmStreamer.cpp
@@ -301,6 +301,8 @@ public:
                              unsigned Flags, unsigned Isa,
                              unsigned Discriminator,
                              StringRef FileName) override;
+  virtual void emitDwarfLocLabelDirective(SMLoc Loc, StringRef Name) override;
+
   MCSymbol *getDwarfLineTableSymbol(unsigned CUID) override;
 
   bool emitCVFileDirective(unsigned FileNo, StringRef Filename,
@@ -1765,6 +1767,12 @@ void MCAsmStreamer::emitDwarfLocDirective(unsigned FileNo, unsigned Line,
   EmitEOL();
   this->MCStreamer::emitDwarfLocDirective(FileNo, Line, Column, Flags, Isa,
                                           Discriminator, FileName);
+}
+
+void MCAsmStreamer::emitDwarfLocLabelDirective(SMLoc Loc, StringRef Name) {
+  MCStreamer::emitDwarfLocLabelDirective(Loc, Name);
+  OS << "\t.loc_label " << Name;
+  EmitEOL();
 }
 
 MCSymbol *MCAsmStreamer::getDwarfLineTableSymbol(unsigned CUID) {

--- a/llvm/lib/MC/MCAsmStreamer.cpp
+++ b/llvm/lib/MC/MCAsmStreamer.cpp
@@ -431,7 +431,8 @@ public:
 
   void emitDwarfLineStartLabel(MCSymbol *StartSym) override;
 
-  void emitDwarfLineEndEntry(MCSection *Section, MCSymbol *LastLabel) override;
+  void emitDwarfLineEndEntry(MCSection *Section, MCSymbol *LastLabel,
+                             MCSymbol *EndLabel = nullptr) override;
 
   void emitDwarfAdvanceLineAddr(int64_t LineDelta, const MCSymbol *LastLabel,
                                 const MCSymbol *Label,
@@ -2587,7 +2588,8 @@ void MCAsmStreamer::emitDwarfLineStartLabel(MCSymbol *StartSym) {
 }
 
 void MCAsmStreamer::emitDwarfLineEndEntry(MCSection *Section,
-                                          MCSymbol *LastLabel) {
+                                          MCSymbol *LastLabel,
+                                          MCSymbol *EndLabel) {
   // If the targets write the raw debug line data for assembly output (We can
   // not switch to Section and add the end symbol there for assembly output)
   // we currently use the .text end label as any section end. This will not
@@ -2604,9 +2606,10 @@ void MCAsmStreamer::emitDwarfLineEndEntry(MCSection *Section,
   MCSection *TextSection = Ctx.getObjectFileInfo()->getTextSection();
   assert(TextSection->hasEnded() && ".text section is not end!");
 
-  MCSymbol *SectionEnd = TextSection->getEndSymbol(Ctx);
+  if (!EndLabel)
+    EndLabel = TextSection->getEndSymbol(Ctx);
   const MCAsmInfo *AsmInfo = Ctx.getAsmInfo();
-  emitDwarfAdvanceLineAddr(INT64_MAX, LastLabel, SectionEnd,
+  emitDwarfAdvanceLineAddr(INT64_MAX, LastLabel, EndLabel,
                            AsmInfo->getCodePointerSize());
 }
 

--- a/llvm/lib/MC/MCAsmStreamer.cpp
+++ b/llvm/lib/MC/MCAsmStreamer.cpp
@@ -1772,7 +1772,7 @@ void MCAsmStreamer::emitDwarfLocDirective(unsigned FileNo, unsigned Line,
 
 void MCAsmStreamer::emitDwarfLocLabelDirective(SMLoc Loc, StringRef Name) {
   MCStreamer::emitDwarfLocLabelDirective(Loc, Name);
-  OS << "\t.loc_label " << Name;
+  OS << ".loc_label\t" << Name;
   EmitEOL();
 }
 

--- a/llvm/lib/MC/MCDwarf.cpp
+++ b/llvm/lib/MC/MCDwarf.cpp
@@ -194,7 +194,8 @@ void MCDwarfLineTable::emitOne(
 
     if (LineEntry.LineStreamLabel) {
       if (!IsAtStartSeq) {
-        MCOS->emitDwarfLineEndEntry(Section, LastLabel);
+        MCOS->emitDwarfLineEndEntry(Section, LastLabel,
+                                    /*EndLabel =*/LastLabel);
         init();
       }
       MCOS->emitLabel(LineEntry.LineStreamLabel, LineEntry.StreamLabelDefLoc);
@@ -273,6 +274,7 @@ void MCDwarfLineTable::endCurrentSeqAndEmitLineStreamLabel(MCStreamer *MCOS,
   auto &ctx = MCOS->getContext();
   auto *LineStreamLabel = ctx.getOrCreateSymbol(Name);
   auto *LineSym = ctx.createTempSymbol();
+  MCOS->emitLabel(LineSym);
   const MCDwarfLoc &DwarfLoc = ctx.getCurrentDwarfLoc();
 
   // Create a 'fake' line entry by having LineStreamLabel be non-null. This

--- a/llvm/lib/MC/MCDwarf.cpp
+++ b/llvm/lib/MC/MCDwarf.cpp
@@ -198,8 +198,6 @@ void MCDwarfLineTable::emitOne(
         init();
       }
       MCOS->emitLabel(LineEntry.LineStreamLabel, LineEntry.StreamLabelDefLoc);
-
-      IsAtStartSeq = true;
       continue;
     }
 
@@ -208,7 +206,6 @@ void MCDwarfLineTable::emitOne(
                                      asmInfo->getCodePointerSize());
       init();
       EndEntryEmitted = true;
-      IsAtStartSeq = true;
       continue;
     }
 

--- a/llvm/lib/MC/MCDwarf.cpp
+++ b/llvm/lib/MC/MCDwarf.cpp
@@ -281,8 +281,6 @@ void MCDwarfLineTable::endCurrentSeqAndEmitLineStreamLabel(MCStreamer *MCOS,
   // won't actually emit any line information, it will reset the line table
   // sequence and emit a label at the start of the new line table sequence.
   MCDwarfLineEntry LineEntry(LineSym, DwarfLoc, LineStreamLabel, DefLoc);
-
-  // Add the line entry to this section's entries.
   getMCLineSections().addLineEntry(LineEntry, MCOS->getCurrentSectionOnly());
 }
 

--- a/llvm/lib/MC/MCObjectStreamer.cpp
+++ b/llvm/lib/MC/MCObjectStreamer.cpp
@@ -467,12 +467,14 @@ void MCObjectStreamer::emitDwarfAdvanceLineAddr(int64_t LineDelta,
 }
 
 void MCObjectStreamer::emitDwarfLineEndEntry(MCSection *Section,
-                                             MCSymbol *LastLabel) {
+                                             MCSymbol *LastLabel,
+                                             MCSymbol *EndLabel) {
   // Emit a DW_LNE_end_sequence for the end of the section.
   // Use the section end label to compute the address delta and use INT64_MAX
   // as the line delta which is the signal that this is actually a
   // DW_LNE_end_sequence.
-  MCSymbol *SectionEnd = endSection(Section);
+  if (!EndLabel)
+    EndLabel = endSection(Section);
 
   // Switch back the dwarf line section, in case endSection had to switch the
   // section.
@@ -480,7 +482,7 @@ void MCObjectStreamer::emitDwarfLineEndEntry(MCSection *Section,
   switchSection(Ctx.getObjectFileInfo()->getDwarfLineSection());
 
   const MCAsmInfo *AsmInfo = Ctx.getAsmInfo();
-  emitDwarfAdvanceLineAddr(INT64_MAX, LastLabel, SectionEnd,
+  emitDwarfAdvanceLineAddr(INT64_MAX, LastLabel, EndLabel,
                            AsmInfo->getCodePointerSize());
 }
 

--- a/llvm/lib/MC/MCObjectStreamer.cpp
+++ b/llvm/lib/MC/MCObjectStreamer.cpp
@@ -469,9 +469,11 @@ void MCObjectStreamer::emitDwarfAdvanceLineAddr(int64_t LineDelta,
 void MCObjectStreamer::emitDwarfLineEndEntry(MCSection *Section,
                                              MCSymbol *LastLabel,
                                              MCSymbol *EndLabel) {
-  // Emit a DW_LNE_end_sequence for the end of the section.
-  // Use the section end label to compute the address delta and use INT64_MAX
-  // as the line delta which is the signal that this is actually a
+  // Emit a DW_LNE_end_sequence into the line table. When EndLabel is null, it
+  // means we should emit the entry for the end of the section and therefore we
+  // use the section end label for the reference label. After having the
+  // appropriate reference label, we emit the address delta and use INT64_MAX as
+  // the line delta which is the signal that this is actually a
   // DW_LNE_end_sequence.
   if (!EndLabel)
     EndLabel = endSection(Section);

--- a/llvm/lib/MC/MCStreamer.cpp
+++ b/llvm/lib/MC/MCStreamer.cpp
@@ -267,6 +267,25 @@ void MCStreamer::emitDwarfLocDirective(unsigned FileNo, unsigned Line,
                                   Discriminator);
 }
 
+void MCStreamer::emitDwarfLocLabelDirective(SMLoc Loc, StringRef Name) {
+  auto &ctx = getContext();
+
+  auto *LineStreamLabel = ctx.getOrCreateSymbol(Name);
+
+  auto *LineSym = ctx.createTempSymbol();
+  const MCDwarfLoc &DwarfLoc = ctx.getCurrentDwarfLoc();
+
+  // Create a 'fake' line entry by having LineStreamLabel be non-null. This
+  // won't actually emit any line information, it will reset the line table
+  // sequence and emit a label at the start of the new line table sequence.
+  MCDwarfLineEntry LineEntry(LineSym, DwarfLoc, LineStreamLabel);
+
+  // Add the line entry to this section's entries.
+  ctx.getMCDwarfLineTable(ctx.getDwarfCompileUnitID())
+      .getMCLineSections()
+      .addLineEntry(LineEntry, getCurrentSectionOnly());
+}
+
 MCSymbol *MCStreamer::getDwarfLineTableSymbol(unsigned CUID) {
   MCDwarfLineTable &Table = getContext().getMCDwarfLineTable(CUID);
   if (!Table.getLabel()) {

--- a/llvm/lib/MC/MCStreamer.cpp
+++ b/llvm/lib/MC/MCStreamer.cpp
@@ -268,22 +268,9 @@ void MCStreamer::emitDwarfLocDirective(unsigned FileNo, unsigned Line,
 }
 
 void MCStreamer::emitDwarfLocLabelDirective(SMLoc Loc, StringRef Name) {
-  auto &ctx = getContext();
-
-  auto *LineStreamLabel = ctx.getOrCreateSymbol(Name);
-
-  auto *LineSym = ctx.createTempSymbol();
-  const MCDwarfLoc &DwarfLoc = ctx.getCurrentDwarfLoc();
-
-  // Create a 'fake' line entry by having LineStreamLabel be non-null. This
-  // won't actually emit any line information, it will reset the line table
-  // sequence and emit a label at the start of the new line table sequence.
-  MCDwarfLineEntry LineEntry(LineSym, DwarfLoc, LineStreamLabel);
-
-  // Add the line entry to this section's entries.
-  ctx.getMCDwarfLineTable(ctx.getDwarfCompileUnitID())
-      .getMCLineSections()
-      .addLineEntry(LineEntry, getCurrentSectionOnly());
+  getContext()
+      .getMCDwarfLineTable(getContext().getDwarfCompileUnitID())
+      .endCurrentSeqAndEmitLineStreamLabel(this, Loc, Name);
 }
 
 MCSymbol *MCStreamer::getDwarfLineTableSymbol(unsigned CUID) {

--- a/llvm/test/MC/ELF/debug-loc-label.s
+++ b/llvm/test/MC/ELF/debug-loc-label.s
@@ -13,42 +13,39 @@
 # CHECK-LINE-TABLE-NEXT: 0x0000002a: 00 DW_LNE_set_address (0x0000000000000000)
 # CHECK-LINE-TABLE-NEXT: 0x00000035: 01 DW_LNS_copy
 # CHECK-LINE-TABLE-NEXT:             0x0000000000000000      1      1      1   0             0       0  is_stmt
-# CHECK-LINE-TABLE-NEXT: 0x00000036: 02 DW_LNS_advance_pc (addr += 33, op-index += 0)
-# CHECK-LINE-TABLE-NEXT: 0x00000038: 00 DW_LNE_end_sequence
-# CHECK-LINE-TABLE-NEXT:             0x0000000000000021      1      1      1   0             0       0  is_stmt end_sequence
-# CHECK-LINE-TABLE-NEXT: 0x0000003b: 05 DW_LNS_set_column (2)
-# CHECK-LINE-TABLE-NEXT: 0x0000003d: 00 DW_LNE_set_address (0x0000000000000008)
-# CHECK-LINE-TABLE-NEXT: 0x00000048: 01 DW_LNS_copy
+# CHECK-LINE-TABLE-NEXT: 0x00000036: 00 DW_LNE_end_sequence
+# CHECK-LINE-TABLE-NEXT:             0x0000000000000000      1      1      1   0             0       0  is_stmt end_sequence
+# CHECK-LINE-TABLE-NEXT: 0x00000039: 05 DW_LNS_set_column (2)
+# CHECK-LINE-TABLE-NEXT: 0x0000003b: 00 DW_LNE_set_address (0x0000000000000008)
+# CHECK-LINE-TABLE-NEXT: 0x00000046: 01 DW_LNS_copy
 # CHECK-LINE-TABLE-NEXT:             0x0000000000000008      1      2      1   0             0       0  is_stmt
-# CHECK-LINE-TABLE-NEXT: 0x00000049: 02 DW_LNS_advance_pc (addr += 25, op-index += 0)
-# CHECK-LINE-TABLE-NEXT: 0x0000004b: 00 DW_LNE_end_sequence
-# CHECK-LINE-TABLE-NEXT:             0x0000000000000021      1      2      1   0             0       0  is_stmt end_sequence
-# CHECK-LINE-TABLE-NEXT: 0x0000004e: 05 DW_LNS_set_column (3)
-# CHECK-LINE-TABLE-NEXT: 0x00000050: 00 DW_LNE_set_address (0x0000000000000010)
-# CHECK-LINE-TABLE-NEXT: 0x0000005b: 01 DW_LNS_copy
+# CHECK-LINE-TABLE-NEXT: 0x00000047: 00 DW_LNE_end_sequence
+# CHECK-LINE-TABLE-NEXT:             0x0000000000000008      1      2      1   0             0       0  is_stmt end_sequence
+# CHECK-LINE-TABLE-NEXT: 0x0000004a: 05 DW_LNS_set_column (3)
+# CHECK-LINE-TABLE-NEXT: 0x0000004c: 00 DW_LNE_set_address (0x0000000000000010)
+# CHECK-LINE-TABLE-NEXT: 0x00000057: 01 DW_LNS_copy
 # CHECK-LINE-TABLE-NEXT:             0x0000000000000010      1      3      1   0             0       0  is_stmt
-# CHECK-LINE-TABLE-NEXT: 0x0000005c: 08 DW_LNS_const_add_pc (addr += 0x0000000000000011, op-index += 0)
-# CHECK-LINE-TABLE-NEXT: 0x0000005d: 00 DW_LNE_end_sequence
-# CHECK-LINE-TABLE-NEXT:             0x0000000000000021      1      3      1   0             0       0  is_stmt end_sequence
-# CHECK-LINE-TABLE-NEXT: 0x00000060: 05 DW_LNS_set_column (4)
-# CHECK-LINE-TABLE-NEXT: 0x00000062: 00 DW_LNE_set_address (0x0000000000000018)
-# CHECK-LINE-TABLE-NEXT: 0x0000006d: 01 DW_LNS_copy
+# CHECK-LINE-TABLE-NEXT: 0x00000058: 00 DW_LNE_end_sequence
+# CHECK-LINE-TABLE-NEXT:             0x0000000000000010      1      3      1   0             0       0  is_stmt end_sequence
+# CHECK-LINE-TABLE-NEXT: 0x0000005b: 05 DW_LNS_set_column (4)
+# CHECK-LINE-TABLE-NEXT: 0x0000005d: 00 DW_LNE_set_address (0x0000000000000018)
+# CHECK-LINE-TABLE-NEXT: 0x00000068: 01 DW_LNS_copy
 # CHECK-LINE-TABLE-NEXT:             0x0000000000000018      1      4      1   0             0       0  is_stmt
-# CHECK-LINE-TABLE-NEXT: 0x0000006e: 05 DW_LNS_set_column (5)
-# CHECK-LINE-TABLE-NEXT: 0x00000070: 01 DW_LNS_copy
+# CHECK-LINE-TABLE-NEXT: 0x00000069: 05 DW_LNS_set_column (5)
+# CHECK-LINE-TABLE-NEXT: 0x0000006b: 01 DW_LNS_copy
 # CHECK-LINE-TABLE-NEXT:             0x0000000000000018      1      5      1   0             0       0  is_stmt
-# CHECK-LINE-TABLE-NEXT: 0x00000071: 02 DW_LNS_advance_pc (addr += 9, op-index += 0)
-# CHECK-LINE-TABLE-NEXT: 0x00000073: 00 DW_LNE_end_sequence
+# CHECK-LINE-TABLE-NEXT: 0x0000006c: 02 DW_LNS_advance_pc (addr += 9, op-index += 0)
+# CHECK-LINE-TABLE-NEXT: 0x0000006e: 00 DW_LNE_end_sequence
 # CHECK-LINE-TABLE-NEXT:             0x0000000000000021      1      5      1   0             0       0  is_stmt end_sequence
 
 # CHECK-SECTIONS: Contents of section .offset_02:
-# CHECK-SECTIONS-NEXT: 0000 3b000000
+# CHECK-SECTIONS-NEXT: 0000 39000000
 
 # CHECK-SECTIONS: Contents of section .offset_03:
-# CHECK-SECTIONS-NEXT: 0000 4e000000
+# CHECK-SECTIONS-NEXT: 0000 4a000000
 
 # CHECK-SECTIONS: Contents of section .offset_05:
-# CHECK-SECTIONS-NEXT: 0000 60000000
+# CHECK-SECTIONS-NEXT: 0000 5b000000
 	.text
 	.file	"test.c"
 	.globl	foo

--- a/llvm/test/MC/ELF/debug-loc-label.s
+++ b/llvm/test/MC/ELF/debug-loc-label.s
@@ -1,0 +1,74 @@
+// Verify that the .loc_label instruction resets the line sequence and generates
+// the requested label at the correct position in the line stream
+
+// RUN: llvm-mc -filetype obj -triple x86_64-linux-elf %s -o %t.o
+// RUN: llvm-objdump -d %t.o | FileCheck %s --check-prefix=CHECK-ASM
+// RUN: llvm-dwarfdump -v --debug-line %t.o | FileCheck %s --check-prefix=CHECK-LINE-TABLE
+
+# CHECK-ASM:        <foo>:
+# CHECK-ASM-NEXT:     movq    %rdx, 0x33
+# CHECK-ASM-NEXT:     movq    %rax, 0x3b
+# CHECK-ASM-NEXT:     movq    %rbx, 0x4e
+# CHECK-ASM-NEXT:     movq    %rcx, 0x60
+# CHECK-ASM-NEXT:     retq
+
+# CHECK-LINE-TABLE:                  Address            Line   Column File   ISA Discriminator OpIndex Flags
+# CHECK-LINE-TABLE-NEXT:             ------------------ ------ ------ ------ --- ------------- ------- -------------
+# CHECK-LINE-TABLE-NEXT: 0x00000028: 05 DW_LNS_set_column (1)
+# CHECK-LINE-TABLE-NEXT: 0x0000002a: 00 DW_LNE_set_address (0x0000000000000000)
+# CHECK-LINE-TABLE-NEXT: 0x00000035: 01 DW_LNS_copy
+# CHECK-LINE-TABLE-NEXT:             0x0000000000000000      1      1      1   0             0       0  is_stmt
+# CHECK-LINE-TABLE-NEXT: 0x00000036: 02 DW_LNS_advance_pc (addr += 33, op-index += 0)
+# CHECK-LINE-TABLE-NEXT: 0x00000038: 00 DW_LNE_end_sequence
+# CHECK-LINE-TABLE-NEXT:             0x0000000000000021      1      1      1   0             0       0  is_stmt end_sequence
+# CHECK-LINE-TABLE-NEXT: 0x0000003b: 05 DW_LNS_set_column (2)
+# CHECK-LINE-TABLE-NEXT: 0x0000003d: 00 DW_LNE_set_address (0x0000000000000008)
+# CHECK-LINE-TABLE-NEXT: 0x00000048: 01 DW_LNS_copy
+# CHECK-LINE-TABLE-NEXT:             0x0000000000000008      1      2      1   0             0       0  is_stmt
+# CHECK-LINE-TABLE-NEXT: 0x00000049: 02 DW_LNS_advance_pc (addr += 25, op-index += 0)
+# CHECK-LINE-TABLE-NEXT: 0x0000004b: 00 DW_LNE_end_sequence
+# CHECK-LINE-TABLE-NEXT:             0x0000000000000021      1      2      1   0             0       0  is_stmt end_sequence
+# CHECK-LINE-TABLE-NEXT: 0x0000004e: 05 DW_LNS_set_column (3)
+# CHECK-LINE-TABLE-NEXT: 0x00000050: 00 DW_LNE_set_address (0x0000000000000010)
+# CHECK-LINE-TABLE-NEXT: 0x0000005b: 01 DW_LNS_copy
+# CHECK-LINE-TABLE-NEXT:             0x0000000000000010      1      3      1   0             0       0  is_stmt
+# CHECK-LINE-TABLE-NEXT: 0x0000005c: 08 DW_LNS_const_add_pc (addr += 0x0000000000000011, op-index += 0)
+# CHECK-LINE-TABLE-NEXT: 0x0000005d: 00 DW_LNE_end_sequence
+# CHECK-LINE-TABLE-NEXT:             0x0000000000000021      1      3      1   0             0       0  is_stmt end_sequence
+# CHECK-LINE-TABLE-NEXT: 0x00000060: 05 DW_LNS_set_column (4)
+# CHECK-LINE-TABLE-NEXT: 0x00000062: 00 DW_LNE_set_address (0x0000000000000018)
+# CHECK-LINE-TABLE-NEXT: 0x0000006d: 01 DW_LNS_copy
+# CHECK-LINE-TABLE-NEXT:             0x0000000000000018      1      4      1   0             0       0  is_stmt
+# CHECK-LINE-TABLE-NEXT: 0x0000006e: 05 DW_LNS_set_column (5)
+# CHECK-LINE-TABLE-NEXT: 0x00000070: 01 DW_LNS_copy
+# CHECK-LINE-TABLE-NEXT:             0x0000000000000018      1      5      1   0             0       0  is_stmt
+# CHECK-LINE-TABLE-NEXT: 0x00000071: 02 DW_LNS_advance_pc (addr += 9, op-index += 0)
+# CHECK-LINE-TABLE-NEXT: 0x00000073: 00 DW_LNE_end_sequence
+# CHECK-LINE-TABLE-NEXT:             0x0000000000000021      1      5      1   0             0       0  is_stmt end_sequence
+	.text
+	.file	"test.c"
+	.globl	foo
+	.align	16, 0x90
+	.type	foo,@function
+foo:
+.Lfunc_begin0:
+	.file	1 "test.c"
+	.cfi_startproc
+	.loc	1 1 1
+	mov     %rdx, 0x33
+	.loc_label my_label_02
+	.loc	1 1 2
+  movq    %rax, my_label_02-.Lline_table_start0
+	.loc	1 1 3
+	.loc_label my_label_03
+	.loc_label my_label_03.1
+  movq    %rbx, my_label_03-.Lline_table_start0
+	.loc	1 1 4
+	.loc_label my_label_05
+	.loc	1 1 5
+  movq    %rcx, my_label_05-.Lline_table_start0
+	ret
+	.cfi_endproc
+
+	.section	.debug_line,"",@progbits
+.Lline_table_start0:

--- a/llvm/test/MC/ELF/debug-loc-label.s
+++ b/llvm/test/MC/ELF/debug-loc-label.s
@@ -1,13 +1,13 @@
 // Verify that the .loc_label instruction resets the line sequence and generates
 // the requested label at the correct position in the line stream
 
-// RUN: llvm-mc -filetype obj -triple x86_64-linux-elf %s -o %t.o
+// RUN: llvm-mc -filetype obj -triple x86_64 %s -o %t.o
 // RUN: llvm-dwarfdump -v --debug-line %t.o | FileCheck %s --check-prefix=CHECK-LINE-TABLE
 // RUN: llvm-readelf -s %t.o | FileCheck %s --check-prefix=CHECK-SYM
 // RUN: llvm-objdump -s -j .offsets %t.o | FileCheck %s --check-prefix=CHECK-OFFSETS
 
-// RUN: not llvm-mc -filetype obj -triple x86_64-linux-elf --defsym ERR=1 %s -o /dev/null 2>&1 | FileCheck %s --check-prefix=ERR --implicit-check-not=error:
-// RUN: not llvm-mc -filetype obj -triple x86_64-linux-elf --defsym ERR2=1 %s -o /dev/null 2>&1 | FileCheck %s --check-prefix=ERR2 --implicit-check-not=error:
+// RUN: not llvm-mc -filetype obj -triple x86_64 --defsym ERR=1 %s -o /dev/null 2>&1 | FileCheck %s --check-prefix=ERR --implicit-check-not=error:
+// RUN: not llvm-mc -filetype obj -triple x86_64 --defsym ERR2=1 %s -o /dev/null 2>&1 | FileCheck %s --check-prefix=ERR2 --implicit-check-not=error:
 
 
 


### PR DESCRIPTION
As discussed in [the RFC](https://discourse.llvm.org/t/rfc-extending-llvm-mc-loc-directive-with-labeling-support/79608) we need a way to create labels in the assembler-generated line section in order to support the future addition of the [DW_AT_LLVM_stmt_sequence](https://discourse.llvm.org/t/rfc-new-dwarf-attribute-for-symbolication-of-merged-functions/79434) attribute.

We have a similar precedent for such behavior with the [.cfi_label](https://github.com/llvm/llvm-project/pull/97922) instruction - so we add the `.loc_label THE_LABEL_NAME` instruction which:
- Terminates the current line sequence in the line section
- Creates a new label with the specified label name in the `.debug_line` section