### PR TITLE
[clang-tidy] Add modernize-use-cpp-style-comments check

### DIFF
--- a/clang-tools-extra/clang-tidy/modernize/CMakeLists.txt
+++ b/clang-tools-extra/clang-tidy/modernize/CMakeLists.txt
@@ -31,6 +31,7 @@ add_clang_library(clangTidyModernizeModule
   UseAutoCheck.cpp
   UseBoolLiteralsCheck.cpp
   UseConstraintsCheck.cpp
+  UseCppStyleCommentsCheck.cpp
   UseDefaultMemberInitCheck.cpp
   UseDesignatedInitializersCheck.cpp
   UseEmplaceCheck.cpp

--- a/clang-tools-extra/clang-tidy/modernize/ModernizeTidyModule.cpp
+++ b/clang-tools-extra/clang-tidy/modernize/ModernizeTidyModule.cpp
@@ -32,6 +32,7 @@
 #include "UseAutoCheck.h"
 #include "UseBoolLiteralsCheck.h"
 #include "UseConstraintsCheck.h"
+#include "UseCppStyleCommentsCheck.h"
 #include "UseDefaultMemberInitCheck.h"
 #include "UseDesignatedInitializersCheck.h"
 #include "UseEmplaceCheck.h"
@@ -104,6 +105,8 @@ public:
         "modernize-use-bool-literals");
     CheckFactories.registerCheck<UseConstraintsCheck>(
         "modernize-use-constraints");
+    CheckFactories.registerCheck<UseCppStyleCommentsCheck>(
+        "modernize-use-cpp-style-comments");
     CheckFactories.registerCheck<UseDefaultMemberInitCheck>(
         "modernize-use-default-member-init");
     CheckFactories.registerCheck<UseEmplaceCheck>("modernize-use-emplace");

--- a/clang-tools-extra/clang-tidy/modernize/UseCppStyleCommentsCheck.cpp
+++ b/clang-tools-extra/clang-tidy/modernize/UseCppStyleCommentsCheck.cpp
@@ -1,0 +1,64 @@
+//===--- UseCppStyleCommentsCheck.cpp - clang-tidy-------------------------===//
+
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "UseCppStyleCommentsCheck.h"
+#include "clang/ASTMatchers/ASTMatchFinder.h"
+#include "clang/Lex/Lexer.h"
+#include "clang/Lex/Preprocessor.h"
+
+using namespace clang::ast_matchers;
+
+namespace clang::tidy::modernize {
+class UseCppStyleCommentsCheck::CStyleCommentHandler : public CommentHandler {
+public:
+  CStyleCommentHandler(UseCppStyleCommentsCheck &Check)
+      : Check(Check),
+        CStyleCommentMatch(
+            "^[ \t]*/\\*+[ \t\n]*(.*[ \t\n]*)*[ \t\n]*\\*+/[ \t\n]*$") {}
+
+  bool HandleComment(Preprocessor &PP, SourceRange Range) override {
+    if (Range.getBegin().isMacroID() ||
+        PP.getSourceManager().isInSystemHeader(Range.getBegin()))
+      return false;
+
+    const StringRef Text =
+        Lexer::getSourceText(CharSourceRange::getCharRange(Range),
+                             PP.getSourceManager(), PP.getLangOpts());
+
+    SmallVector<StringRef> Matches;
+    if (!CStyleCommentMatch.match(Text, &Matches)) {
+      return false;
+    }
+
+    Check.diag(
+        Range.getBegin(),
+        "use C++ style comments '//' instead of C style comments '/*...*/'");
+
+    return false;
+  }
+
+private:
+  UseCppStyleCommentsCheck &Check;
+  llvm::Regex CStyleCommentMatch;
+};
+
+UseCppStyleCommentsCheck::UseCppStyleCommentsCheck(StringRef Name,
+                                                   ClangTidyContext *Context)
+    : ClangTidyCheck(Name, Context),
+      Handler(std::make_unique<CStyleCommentHandler>(*this)) {}
+
+void UseCppStyleCommentsCheck::registerPPCallbacks(
+    const SourceManager &SM, Preprocessor *PP, Preprocessor *ModuleExpanderPP) {
+  PP->addCommentHandler(Handler.get());
+}
+
+void UseCppStyleCommentsCheck::check(const MatchFinder::MatchResult &Result) {}
+
+UseCppStyleCommentsCheck::~UseCppStyleCommentsCheck() = default;
+} // namespace clang::tidy::modernize

--- a/clang-tools-extra/clang-tidy/modernize/UseCppStyleCommentsCheck.h
+++ b/clang-tools-extra/clang-tidy/modernize/UseCppStyleCommentsCheck.h
@@ -1,0 +1,40 @@
+//===--- UseCppStyleCommentsCheck.h - clang-tidy---------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_MODERNIZE_USE_CPP_STYLE_COMMENTS_CHECK_H
+#define LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_MODERNIZE_USE_CPP_STYLE_COMMENTS_CHECK_H
+
+#include "../ClangTidyCheck.h"
+
+namespace clang::tidy::modernize {
+/// Detects C Style comments and suggests to use C++ style comments instead.
+///
+/// For the user-facing documentation see:
+/// http://clang.llvm.org/extra/clang-tidy/checks/modernize/use-cpp-style-comments.html
+class UseCppStyleCommentsCheck : public ClangTidyCheck {
+public:
+  UseCppStyleCommentsCheck(StringRef Name, ClangTidyContext *Context);
+
+  ~UseCppStyleCommentsCheck() override;
+
+  bool isLanguageVersionSupported(const LangOptions &LangOpts) const override {
+    return LangOpts.CPlusPlus;
+  }
+
+  void registerPPCallbacks(const SourceManager &SM, Preprocessor *PP,
+                           Preprocessor *ModuleExpanderPP) override;
+
+  void check(const ast_matchers::MatchFinder::MatchResult &Result) override;
+
+private:
+  class CStyleCommentHandler;
+  std::unique_ptr<CStyleCommentHandler> Handler;
+};
+} // namespace clang::tidy::modernize
+
+#endif // LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_MODERNIZE_USE_CPP_STYLE_COMMENTS_CHECK_H

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -98,6 +98,95 @@ Improvements to clang-tidy
 New checks
 ^^^^^^^^^^
 
+
+- New :doc:`boost-use-ranges
+  <clang-tidy/checks/boost/use-ranges>` check.
+
+  Detects calls to standard library iterator algorithms that could be replaced
+  with a Boost ranges version instead.
+
+- New :doc:`bugprone-crtp-constructor-accessibility
+  <clang-tidy/checks/bugprone/crtp-constructor-accessibility>` check.
+
+  Detects error-prone Curiously Recurring Template Pattern usage, when the CRTP
+  can be constructed outside itself and the derived class.
+
+- New :doc:`bugprone-pointer-arithmetic-on-polymorphic-object
+  <clang-tidy/checks/bugprone/pointer-arithmetic-on-polymorphic-object>` check.
+
+  Finds pointer arithmetic performed on classes that contain a virtual function.
+
+- New :doc:`bugprone-return-const-ref-from-parameter
+  <clang-tidy/checks/bugprone/return-const-ref-from-parameter>` check.
+
+  Detects return statements that return a constant reference parameter as constant
+  reference. This may cause use-after-free errors if the caller uses xvalues as
+  arguments.
+
+- New :doc:`bugprone-suspicious-stringview-data-usage
+  <clang-tidy/checks/bugprone/suspicious-stringview-data-usage>` check.
+
+  Identifies suspicious usages of ``std::string_view::data()`` that could lead
+  to reading out-of-bounds data due to inadequate or incorrect string null
+  termination.
+
+- New :doc:`misc-use-internal-linkage
+  <clang-tidy/checks/misc/use-internal-linkage>` check.
+
+  Detects variables and functions that can be marked as static or moved into
+  an anonymous namespace to enforce internal linkage.
+
+- New :doc:`modernize-min-max-use-initializer-list
+  <clang-tidy/checks/modernize/min-max-use-initializer-list>` check.
+
+  Replaces nested ``std::min`` and ``std::max`` calls with an initializer list
+  where applicable.
+
+- New :doc:`modernize-use-cpp-style-comments
+  <clang-tidy/checks/modernize/use-cpp-style-comments>` check.
+
+  Detects C Style comments and suggests to use C++ style comments instead.
+
+- New :doc:`modernize-use-designated-initializers
+  <clang-tidy/checks/modernize/use-designated-initializers>` check.
+
+  Finds initializer lists for aggregate types that could be
+  written as designated initializers instead.
+
+- New :doc:`modernize-use-ranges
+  <clang-tidy/checks/modernize/use-ranges>` check.
+
+  Detects calls to standard library iterator algorithms that could be replaced
+  with a ranges version instead.
+
+- New :doc:`modernize-use-std-format
+  <clang-tidy/checks/modernize/use-std-format>` check.
+
+  Converts calls to ``absl::StrFormat``, or other functions via
+  configuration options, to C++20's ``std::format``, or another function
+  via a configuration option, modifying the format string appropriately and
+  removing now-unnecessary calls to ``std::string::c_str()`` and
+  ``std::string::data()``.
+
+- New :doc:`readability-enum-initial-value
+  <clang-tidy/checks/readability/enum-initial-value>` check.
+
+  Enforces consistent style for enumerators' initialization, covering three
+  styles: none, first only, or all initialized explicitly.
+
+- New :doc:`readability-math-missing-parentheses
+  <clang-tidy/checks/readability/math-missing-parentheses>` check.
+
+  Check for missing parentheses in mathematical expressions that involve
+  operators of different priorities.
+
+- New :doc:`readability-use-std-min-max
+  <clang-tidy/checks/readability/use-std-min-max>` check.
+
+  Replaces certain conditional statements with equivalent calls to
+  ``std::min`` or ``std::max``.
+
+
 New check aliases
 ^^^^^^^^^^^^^^^^^
 

--- a/clang-tools-extra/docs/clang-tidy/checks/modernize/use-cpp-style-comments.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/modernize/use-cpp-style-comments.rst
@@ -1,0 +1,6 @@
+.. title:: clang-tidy - modernize-use-cpp-style-comments
+
+modernize-use-cpp-style-comments
+================================
+
+Detects C Style comments and suggests to use C++ style comments instead.

--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/use-cpp-style-comments.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/use-cpp-style-comments.cpp
@@ -1,0 +1,7 @@
+// RUN: %check_clang_tidy -std=c++11 %s modernize-use-cpp-style-comments %t
+
+static auto PI = 3.14159265; /* value of pi upto 8 decimal places */
+// CHECK-MESSAGES: :[[@LINE-1]]:30: warning: use C++ style comments '//' instead of C style comments '/*...*/' [modernize-use-cpp-style-comments]
+
+int a = /*some value */ 5;
+// CHECK-MESSAGES: :[[@LINE-1]]:9: warning: use C++ style comments '//' instead of C style comments '/*...*/' [modernize-use-cpp-style-comments]


### PR DESCRIPTION
  modernize-use-cpp-style-comments check finds C style comments
  and suggests to use C++ style comments

  Fixes #24841



@LegalizeAdulthood @PiotrZSL 


```
~/scratch/llvm_test_ground/test1.cpp:1:1: warning: use C++ style comments '//' instead of C style comments '/*...*/' [modernize-use-cpp-style-comments]
    1 | /* Hello world
      | ^~~~~~~~~~~~~~
    2 |  * this is a line
      |  ~~~~~~~~~~~~~~~~
    3 |  */
      |  ~~
~/scratch/llvm_test_ground/test1.cpp:4:1: warning: use C++ style comments '//' instead of C style comments '/*...*/' [modernize-use-cpp-style-comments]
    4 | /*!
      | ^~~
    5 |  * ... text ...
      |  ~~~~~~~~~~~~~~
    6 | */
      | ~~
~/scratch/llvm_test_ground/test1.cpp:7:1: warning: use C++ style comments '//' instead of C style comments '/*...*/' [modernize-use-cpp-style-comments]
    7 | /*foo bar goo
      | ^~~~~~~~~~~~~
    8 |  *foo bar goo
      |  ~~~~~~~~~~~~
    9 |  */
      |  ~~
~/scratch/llvm_test_ground/test1.cpp:11:1: warning: use C++ style comments '//' instead of C style comments '/*...*/' [modernize-use-cpp-style-comments]
   11 | /*#########################################################
      | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   12 |  * Fancy comment goes here
      |  ~~~~~~~~~~~~~~~~~~~~~~~~~
   13 |  *#########################################################
      |  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   14 |  */
      |  ~~
~/scratch/llvm_test_ground/test1.cpp:22:34: warning: use C++ style comments '//' instead of C style comments '/*...*/' [modernize-use-cpp-style-comments]
   22 |   memcpy(a, b, sizeof(int) * 5); /* Fix me later */
      |                                  ^~~~~~~~~~~~~~~~~~                     
```