### PR TITLE
[libc][NFC] clean up some includes

### DIFF
--- a/libc/src/__support/threads/thread.h
+++ b/libc/src/__support/threads/thread.h
@@ -22,6 +22,7 @@
 #include "src/__support/macros/config.h"
 #include "src/__support/macros/properties/architectures.h"
 
+// TODO: fix this unguarded linux dep
 #include <linux/param.h> // for exec_pagesize.
 
 #include <stddef.h> // For size_t

--- a/libc/src/math/generic/expm1.cpp
+++ b/libc/src/math/generic/expm1.cpp
@@ -30,13 +30,6 @@
 #define LIBC_MATH_EXPM1_SKIP_ACCURATE_PASS
 #endif
 
-// #define DEBUGDEBUG
-
-#ifdef DEBUGDEBUG
-#include <iomanip>
-#include <iostream>
-#endif
-
 namespace LIBC_NAMESPACE_DECL {
 
 using fputil::DoubleDouble;


### PR DESCRIPTION
While looking through the list of includes for #99693 I found these
includes that also need to be cleaned up. I removed the extra includes
in expm1.cpp, but the include in thread.h needs more attention so I just
marked it with a todo.
