### PR TITLE
[TableGen] Passing 'Heading' param as const reference

### DIFF
--- a/clang/utils/TableGen/ClangOptionDocEmitter.cpp
+++ b/clang/utils/TableGen/ClangOptionDocEmitter.cpp
@@ -217,7 +217,7 @@ bool canSphinxCopeWithOption(const Record *Option) {
   return false;
 }
 
-void emitHeading(int Depth, std::string Heading, raw_ostream &OS) {
+void emitHeading(int Depth, const std::string &Heading, raw_ostream &OS) {
   assert(Depth < 8 && "groups nested too deeply");
   OS << Heading << '\n'
      << std::string(Heading.size(), "=~-_'+<>"[Depth]) << "\n";


### PR DESCRIPTION
**Issue:** https://github.com/llvm/llvm-project/issues/94373