### PR TITLE
[BOLT][DWARF][NFC] Move initialization of DWOName outside of lambda

### DIFF
--- a/bolt/lib/Rewrite/DWARFRewriter.cpp
+++ b/bolt/lib/Rewrite/DWARFRewriter.cpp
@@ -755,8 +755,8 @@ void DWARFRewriter::updateDebugInfo() {
           opts::DwarfOutputPath.empty()
               ? std::nullopt
               : std::optional<std::string>(opts::DwarfOutputPath.c_str());
-      std::string DWOName = DIEBlder.updateDWONameCompDir(*StrOffstsWriter, *StrWriter, *CU,
-                                              DwarfOutputPath, std::nullopt);
+      std::string DWOName = DIEBlder.updateDWONameCompDir(
+          *StrOffstsWriter, *StrWriter, *CU, DwarfOutputPath, std::nullopt);
       processSplitCU(*CU, **SplitCU, DIEBlder, *TempRangesSectionWriter,
                      AddressWriter, DWOName, DwarfOutputPath);
     }

--- a/bolt/lib/Rewrite/DWARFRewriter.cpp
+++ b/bolt/lib/Rewrite/DWARFRewriter.cpp
@@ -669,8 +669,8 @@ void DWARFRewriter::updateDebugInfo() {
                             DIEBuilder &DIEBlder,
                             DebugRangesSectionWriter &TempRangesSectionWriter,
                             DebugAddrWriter &AddressWriter,
-                            std::string &DWOName,
-                            std::optional<std::string> &DwarfOutputPath) {
+                            const std::string &DWOName,
+                            const std::optional<std::string> &DwarfOutputPath) {
     DIEBuilder DWODIEBuilder(BC, &(SplitCU).getContext(), DebugNamesTable,
                              &Unit);
     DWODIEBuilder.buildDWOUnit(SplitCU);
@@ -751,13 +751,11 @@ void DWARFRewriter::updateDebugInfo() {
       DebugRangesSectionWriter *TempRangesSectionWriter =
           CU->getVersion() >= 5 ? RangeListsWritersByCU[*DWOId].get()
                                 : LegacyRangesWritersByCU[*DWOId].get();
-      std::string DWOName = "";
       std::optional<std::string> DwarfOutputPath =
           opts::DwarfOutputPath.empty()
               ? std::nullopt
               : std::optional<std::string>(opts::DwarfOutputPath.c_str());
-      std::lock_guard<std::mutex> Lock(AccessMutex);
-      DWOName = DIEBlder.updateDWONameCompDir(*StrOffstsWriter, *StrWriter, *CU,
+      std::string DWOName = DIEBlder.updateDWONameCompDir(*StrOffstsWriter, *StrWriter, *CU,
                                               DwarfOutputPath, std::nullopt);
       processSplitCU(*CU, **SplitCU, DIEBlder, *TempRangesSectionWriter,
                      AddressWriter, DWOName, DwarfOutputPath);

--- a/bolt/lib/Rewrite/DWARFRewriter.cpp
+++ b/bolt/lib/Rewrite/DWARFRewriter.cpp
@@ -668,20 +668,12 @@ void DWARFRewriter::updateDebugInfo() {
   auto processSplitCU = [&](DWARFUnit &Unit, DWARFUnit &SplitCU,
                             DIEBuilder &DIEBlder,
                             DebugRangesSectionWriter &TempRangesSectionWriter,
-                            DebugAddrWriter &AddressWriter) {
+                            DebugAddrWriter &AddressWriter,
+                            std::string &DWOName,
+                            std::optional<std::string> &DwarfOutputPath) {
     DIEBuilder DWODIEBuilder(BC, &(SplitCU).getContext(), DebugNamesTable,
                              &Unit);
     DWODIEBuilder.buildDWOUnit(SplitCU);
-    std::string DWOName = "";
-    std::optional<std::string> DwarfOutputPath =
-        opts::DwarfOutputPath.empty()
-            ? std::nullopt
-            : std::optional<std::string>(opts::DwarfOutputPath.c_str());
-    {
-      std::lock_guard<std::mutex> Lock(AccessMutex);
-      DWOName = DIEBlder.updateDWONameCompDir(
-          *StrOffstsWriter, *StrWriter, Unit, DwarfOutputPath, std::nullopt);
-    }
     DebugStrOffsetsWriter DWOStrOffstsWriter(BC);
     DebugStrWriter DWOStrWriter((SplitCU).getContext(), true);
     DWODIEBuilder.updateDWONameCompDirForTypes(
@@ -759,8 +751,16 @@ void DWARFRewriter::updateDebugInfo() {
       DebugRangesSectionWriter *TempRangesSectionWriter =
           CU->getVersion() >= 5 ? RangeListsWritersByCU[*DWOId].get()
                                 : LegacyRangesWritersByCU[*DWOId].get();
+      std::string DWOName = "";
+      std::optional<std::string> DwarfOutputPath =
+          opts::DwarfOutputPath.empty()
+              ? std::nullopt
+              : std::optional<std::string>(opts::DwarfOutputPath.c_str());
+      std::lock_guard<std::mutex> Lock(AccessMutex);
+      DWOName = DIEBlder.updateDWONameCompDir(*StrOffstsWriter, *StrWriter, *CU,
+                                              DwarfOutputPath, std::nullopt);
       processSplitCU(*CU, **SplitCU, DIEBlder, *TempRangesSectionWriter,
-                     AddressWriter);
+                     AddressWriter, DWOName, DwarfOutputPath);
     }
     for (DWARFUnit *CU : DIEBlder.getProcessedCUs())
       processMainBinaryCU(*CU, DIEBlder);


### PR DESCRIPTION
Followup to the splitting of processUnitDIE, moves code that accesses common resource to be outside of the function that will be parallelized.

Followup to #99957