### PR TITLE
[Flang][runtime] Add dependency to build FortranRuntime after flang-new

### DIFF
--- a/flang/runtime/CMakeLists.txt
+++ b/flang/runtime/CMakeLists.txt
@@ -296,8 +296,14 @@ else()
 endif()
 set_target_properties(FortranRuntime PROPERTIES FOLDER "Flang/Runtime Libraries")
 
-# Add dependency to make sure that Fortran runtime library is being built after
+# If FortranRuntime is part of a Flang build (and not a separate build) then
+# add dependency to make sure that Fortran runtime library is being built after
 # we have the Flang compiler available.  This also includes the MODULE files
 # that compile when the 'flang-new' target is built.
-add_dependencies(FortranRuntime flang-new module_files)
+#
+# TODO: This is a workaround and should be updated when runtime build procedure
+# is changed to a regular runtime build.  See discussion in PR #95388.
+if (TARGET flang-new)
+  add_dependencies(FortranRuntime flang-new module_files)
+endif()
 

--- a/flang/runtime/CMakeLists.txt
+++ b/flang/runtime/CMakeLists.txt
@@ -303,7 +303,7 @@ set_target_properties(FortranRuntime PROPERTIES FOLDER "Flang/Runtime Libraries"
 #
 # TODO: This is a workaround and should be updated when runtime build procedure
 # is changed to a regular runtime build.  See discussion in PR #95388.
-if (TARGET flang-new)
+if (TARGET flang-new AND TARGET module_files)
   add_dependencies(FortranRuntime flang-new module_files)
 endif()
 

--- a/flang/runtime/CMakeLists.txt
+++ b/flang/runtime/CMakeLists.txt
@@ -299,5 +299,5 @@ set_target_properties(FortranRuntime PROPERTIES FOLDER "Flang/Runtime Libraries"
 # Add dependency to make sure that Fortran runtime library is being built after
 # we have the Flang compiler available.  This also includes the MODULE files
 # that compile when the 'flang-new' target is built.
-add_dependencies(FortranRuntime flang-new)
+add_dependencies(FortranRuntime flang-new module_files)
 

--- a/flang/runtime/CMakeLists.txt
+++ b/flang/runtime/CMakeLists.txt
@@ -295,3 +295,9 @@ else()
     FortranRuntime.static_dbg FortranRuntime.dynamic_dbg)
 endif()
 set_target_properties(FortranRuntime PROPERTIES FOLDER "Flang/Runtime Libraries")
+
+# Add dependency to make sure that Fortran runtime library is being built after
+# we have the Flang compiler available.  This also includes the MODULE files
+# that compile when the 'flang-new' target is built.
+add_dependencies(FortranRuntime flang-new)
+


### PR DESCRIPTION
Makefile-based builds did not have proper dependencies to built the FortranRuntime target after Flang new is available.  This PR introduces a dependency to ensure that this is the case.  Relates to PR #95388.