### PR TITLE
CodeGen/NewPM: Initialize MMI in NewPM path

### DIFF
--- a/llvm/include/llvm/Passes/MachinePassRegistry.def
+++ b/llvm/include/llvm/Passes/MachinePassRegistry.def
@@ -17,6 +17,7 @@
 #define MODULE_ANALYSIS(NAME, CREATE_PASS)
 #endif
 MODULE_ANALYSIS("collector-metadata", CollectorMetadataAnalysis())
+MODULE_ANALYSIS("machine-module-info", MachineModuleAnalysis())
 MODULE_ANALYSIS("pass-instrumentation", PassInstrumentationAnalysis(PIC))
 #undef MODULE_ANALYSIS
 

--- a/llvm/lib/CodeGen/SelectionDAG/SelectionDAGISel.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/SelectionDAGISel.cpp
@@ -509,6 +509,8 @@ void SelectionDAGISel::initializeAnalysisResults(
     FnVarLocs = &FAM.getResult<DebugAssignmentTrackingAnalysis>(Fn);
 
   auto *UA = FAM.getCachedResult<UniformityInfoAnalysis>(Fn);
+  MMI = &MFAM.getResult<MachineModuleAnalysis>(*MF).getMMI();
+
   CurDAG->init(*MF, *ORE, MFAM, LibInfo, UA, PSI, BFI, *MMI, FnVarLocs);
 
   // Now get the optional analyzes if we want to.


### PR DESCRIPTION
This should have been in c2019a37bdb1375e9f72b2549361cc50ea7729db,
but it breaks with:

Assertion failed: (AnalysisPasses.count(PassT::ID()) && "This analysis pass was not registered prior to being queried"), function getResult, file PassManager.h, line 407.