### PR TITLE
[ASTContext] Make the end of the switch case unreachable in `encodeTypeForFunctionPointerAuth`

### DIFF
--- a/clang/lib/AST/ASTContext.cpp
+++ b/clang/lib/AST/ASTContext.cpp
@@ -3363,6 +3363,7 @@ static void encodeTypeForFunctionPointerAuth(const ASTContext &Ctx,
 #include "clang/Basic/RISCVVTypes.def"
       llvm_unreachable("not yet implemented");
     }
+    llvm_unreachable("should never get here");
   }
   case Type::Record: {
     const RecordDecl *RD = T->getAs<RecordType>()->getDecl();


### PR DESCRIPTION
This prevent the warning from compiler.
