### PR TITLE
[libc++] fix back slash as root dir breaks lexically_relative, lexically_proximate and hash_value on Windows

### DIFF
--- a/libcxx/src/filesystem/path.cpp
+++ b/libcxx/src/filesystem/path.cpp
@@ -267,7 +267,7 @@ path path::lexically_relative(const path& base) const {
   // Find the first mismatching element
   auto PP     = PathParser::CreateBegin(__pn_);
   auto PPBase = PathParser::CreateBegin(base.__pn_);
-  while (PP && PPBase && PP.State_ == PPBase.State_ && *PP == *PPBase) {
+  while (PP && PPBase && PP.State_ == PPBase.State_ && (*PP == *PPBase || PP.inRootDir())) {
     ++PP;
     ++PPBase;
   }

--- a/libcxx/src/filesystem/path.cpp
+++ b/libcxx/src/filesystem/path.cpp
@@ -368,7 +368,8 @@ size_t hash_value(const path& __p) noexcept {
   size_t hash_value = 0;
   hash<string_view_t> hasher;
   while (PP) {
-    hash_value = __hash_combine(hash_value, hasher(*PP));
+    string_view_t Part = PP.inRootDir() ? PATHSTR("/") : *PP;
+    hash_value         = __hash_combine(hash_value, hasher(Part));
     ++PP;
   }
   return hash_value;

--- a/libcxx/test/std/input.output/filesystems/class.path/path.member/path.gen/lexically_relative_and_proximate.pass.cpp
+++ b/libcxx/test/std/input.output/filesystems/class.path/path.member/path.gen/lexically_relative_and_proximate.pass.cpp
@@ -41,9 +41,11 @@ int main(int, char**) {
 #ifdef _WIN32
       {"//net/", "//net", ""},
       {"//net", "//net/", ""},
+      {"C:\\a\\b", "C:/a", "b"},
 #else
       {"//net/", "//net", "."},
       {"//net", "//net/", "."},
+      {"C:\\a\\b", "C:/a", "../../C:\\a\\b"},
 #endif
       {"//base", "a", ""},
       {"a", "a", "."},


### PR DESCRIPTION
```cpp
#include <filesystem>
#include <iostream>

namespace fs = std::filesystem;
using Path = fs::path;

int main() {
  Path p("C:/a/b");
  Path p2("C:\\a");
  std::cout << p.lexically_proximate(p2) << std::endl;
  std::cout << p.make_preferred().lexically_proximate(p2) << std::endl;
  p = "C:/a";
  p2 = "C:\\a";
  std::cout << (p == p2 ? "true" : "false") << std::endl;
  std::cout << (fs::hash_value(p) == fs::hash_value(p2) ? "true" : "false");
}
```
The above code produces the following result on Windows:
```
"/a\\b"
"b"
true
false
```
lexically_proximate thinks that the root dir is different. However, they are seen as the same thing on windows.
The same issue happens to hash_value(). [The standard](https://timsong-cpp.github.io/cppwp/n4861/fs.class.path#fs.path.nonmember-2) clearly states: If for two paths, p1 == p2 then hash_­value(p1) == hash_­value(p2).

I think we have two solutions:
1. ~~As my PR proposed, make the iterator in the PS_InRootDir state always return "/". If you look at https://en.cppreference.com/w/cpp/filesystem/path/begin, their example has the same behavior. It also prevents other potential issues and saves users time dealing with different root dir slashes.~~
2. Change the implementation of lexically_relative(). Take special care of the PS_InRootDir state. 

Solution 2 is better because it seems it doesn't affect anything else and it is consistent with MSVC behavior (https://godbolt.org/z/GPvx7fc4h)
