### PR TITLE
Revert "Replace distutils.version with looseversion since the former was deprecated in python 3.10 and removed in 3.12."

### DIFF
--- a/cross-project-tests/lit.cfg.py
+++ b/cross-project-tests/lit.cfg.py
@@ -4,7 +4,8 @@ import re
 import subprocess
 import sys
 
-from looseversion import LooseVersion
+# TODO: LooseVersion is undocumented; use something else.
+from distutils.version import LooseVersion
 
 import lit.formats
 import lit.util


### PR DESCRIPTION
Reverts llvm/llvm-project#99549 because it breaks a bunch of build bots. 