### PR TITLE
[llvm][llvm-c] LLVMModuleFlagEntry should be of struct pointer type

### DIFF
--- a/llvm/include/llvm-c/Types.h
+++ b/llvm/include/llvm-c/Types.h
@@ -157,7 +157,7 @@ typedef struct LLVMComdat *LLVMComdatRef;
 /**
  * @see llvm::Module::ModuleFlagEntry
  */
-typedef struct LLVMOpaqueModuleFlagEntry LLVMModuleFlagEntry;
+typedef struct LLVMOpaqueModuleFlagEntry *LLVMModuleFlagEntry;
 
 /**
  * @see llvm::JITEventListener


### PR DESCRIPTION
like other type definitions