### PR TITLE
[libc++][vector] Updates LWG3778 status.

### DIFF
--- a/libcxx/docs/Status/Cxx23Issues.csv
+++ b/libcxx/docs/Status/Cxx23Issues.csv
@@ -225,7 +225,7 @@
 "`3773 <https://wg21.link/LWG3773>`__","``views::zip_transform`` still requires ``F`` to be ``copy_constructible`` when empty pack", "November 2022","","","|ranges|"
 "`3774 <https://wg21.link/LWG3774>`__","``<flat_set>`` should include ``<compare>``", "November 2022","","","|flat_containers|"
 "`3775 <https://wg21.link/LWG3775>`__","Broken dependencies in the ``Cpp17Allocator`` requirements", "November 2022","","",""
-"`3778 <https://wg21.link/LWG3778>`__","``vector<bool>`` missing exception specifications", "November 2022","","",""
+"`3778 <https://wg21.link/LWG3778>`__","``vector<bool>`` missing exception specifications", "November 2022","|Complete|","3.7",""
 "`3781 <https://wg21.link/LWG3781>`__","The exposition-only alias templates ``cont-key-type`` and ``cont-mapped-type`` should be removed", "November 2022","|Nothing to do|","",""
 "`3782 <https://wg21.link/LWG3782>`__","Should ``<math.h>`` declare ``::lerp``?", "November 2022","|Complete|","17.0",""
 "`3784 <https://wg21.link/LWG3784>`__","std.compat should not provide ``::byte`` and its friends", "November 2022","","",""

--- a/libcxx/include/vector
+++ b/libcxx/include/vector
@@ -170,7 +170,7 @@ public:
 
     vector()
         noexcept(is_nothrow_default_constructible<allocator_type>::value);
-    explicit vector(const allocator_type&);
+    explicit vector(const allocator_type&) noexcept;
     explicit vector(size_type n, const allocator_type& a = allocator_type()); // C++14
     vector(size_type n, const value_type& value, const allocator_type& = allocator_type());
     template <class InputIterator>
@@ -178,8 +178,7 @@ public:
     template<container-compatible-range<bool> R>
       constexpr vector(from_range_t, R&& rg, const Allocator& = Allocator());
     vector(const vector& x);
-    vector(vector&& x)
-        noexcept(is_nothrow_move_constructible<allocator_type>::value);
+    vector(vector&& x) noexcept;
     vector(initializer_list<value_type> il);
     vector(initializer_list<value_type> il, const allocator_type& a);
     ~vector();
@@ -425,7 +424,7 @@ public:
 #if _LIBCPP_STD_VER <= 14
       _NOEXCEPT_(is_nothrow_copy_constructible<allocator_type>::value)
 #else
-      _NOEXCEPT
+      noexcept
 #endif
       : __end_cap_(nullptr, __a) {
   }


### PR DESCRIPTION
The work was done in a8ae392718313e64e2d7bc092b00f51476c074b2 which implements parts of

  N4258: Cleaning-up noexcept in the Library

However that's paper Summary of Proposed Changes contains
  No change in vector<bool>

This patch updates the status and as a few NFC cleanups. The fixed version is based on the release page and might be off.

Updates
- LWG3778 vector<bool> missing exception specifications