### PR TITLE
[clang-cl] [Sema] Support MSVC non-const lvalue to user-defined temporary reference

### DIFF
--- a/clang/docs/LanguageExtensions.rst
+++ b/clang/docs/LanguageExtensions.rst
@@ -6015,3 +6015,33 @@ qualifications.
 Note, Clang does not allow an ``_Atomic`` function type because
 of explicit constraints against atomically qualified (arrays and) function
 types.
+
+
+MSVC Extensions
+===============
+
+Clang supports a number of extensions inorder to imitate MSVC.
+Some of these extensions are behind ``-fms-compatibility`` and ``-fms-extensions`` which
+are further described in :doc:`MSVCCompatibility`.
+
+MSVC Reference Binding
+----------------------
+
+.. code-block:: c++
+
+  struct A {};
+
+  A& a = A();
+
+Please see the `MSDN doc<https://learn.microsoft.com/en-us/cpp/build/reference/zc-referencebinding-enforce-reference-binding-rules>`_ for more information on this non-conforming C++ extension.
+
+MSVC allows user-defined type temporaries to be bound to non-const lvalue references when `/permissive`
+or `/Zc:referenceBinding-` are given on the command line.
+
+The current default behavior as of MSVC 1940 is `/permissive`.
+As of Visual Studio 2017, `/permissive-` is the default for projects meaning C++ conformance is enforced when
+building with MSVC in Visual Studio.
+
+This MSVC extension can be enabled with ``-fms-reference-binding`` with the clang or cl driver.
+This MSVC extension can be enabled with ``/Zc:referenceBinding-`` with the cl driver.
+>>>>>>> 43d9c2ac844e (PR Feedback on ext warning)

--- a/clang/docs/LanguageExtensions.rst
+++ b/clang/docs/LanguageExtensions.rst
@@ -6033,7 +6033,9 @@ MSVC Reference Binding
 
   A& a = A();
 
-Please see the `MSDN doc<https://learn.microsoft.com/en-us/cpp/build/reference/zc-referencebinding-enforce-reference-binding-rules>`_ for more information on this non-conforming C++ extension.
+Please see the `MSDN doc
+<https://learn.microsoft.com/en-us/cpp/build/reference/zc-referencebinding-enforce-reference-binding-rules>`_
+for more information on this non-conforming C++ extension.
 
 MSVC allows user-defined type temporaries to be bound to non-const lvalue references when ``/permissive``
 or ``/Zc:referenceBinding-`` are given on the command line.

--- a/clang/docs/LanguageExtensions.rst
+++ b/clang/docs/LanguageExtensions.rst
@@ -6044,6 +6044,6 @@ The current default behavior as of MSVC 1942 is ``/permissive``.
 As of Visual Studio 2017, ``/permissive-`` is the default for newly generated projects in Visual Studio meaning C++
 conformance is enforced when building with MSVC in Visual Studio.
 
-This MSVC extension can be enabled with ``-fms-reference-binding`` with the clang or cl driver.
-This MSVC extension can be enabled with ``/Zc:referenceBinding-`` with the cl driver.
+This MSVC extension can be enabled with ``-fms-reference-binding`` with the clang or clang-cl driver.
+This MSVC extension can be enabled with ``/Zc:referenceBinding-`` with the clang-cl driver.
 >>>>>>> 43d9c2ac844e (PR Feedback on ext warning)

--- a/clang/docs/LanguageExtensions.rst
+++ b/clang/docs/LanguageExtensions.rst
@@ -6020,7 +6020,7 @@ types.
 MSVC Extensions
 ===============
 
-Clang supports a number of extensions inorder to imitate MSVC.
+Clang supports a number of extensions in order to imitate MSVC.
 Some of these extensions are behind ``-fms-compatibility`` and ``-fms-extensions`` which
 are further described in :doc:`MSVCCompatibility`.
 
@@ -6040,9 +6040,9 @@ for more information on this non-conforming C++ extension.
 MSVC allows user-defined type temporaries to be bound to non-const lvalue references when ``/permissive``
 or ``/Zc:referenceBinding-`` are given on the command line.
 
-The current default behavior as of MSVC 1940 is ``/permissive``.
-As of Visual Studio 2017, ``/permissive-`` is the default for projects meaning C++ conformance is enforced when
-building with MSVC in Visual Studio.
+The current default behavior as of MSVC 1942 is ``/permissive``.
+As of Visual Studio 2017, ``/permissive-`` is the default for newly generated projects in Visual Studio meaning C++
+conformance is enforced when building with MSVC in Visual Studio.
 
 This MSVC extension can be enabled with ``-fms-reference-binding`` with the clang or cl driver.
 This MSVC extension can be enabled with ``/Zc:referenceBinding-`` with the cl driver.

--- a/clang/docs/LanguageExtensions.rst
+++ b/clang/docs/LanguageExtensions.rst
@@ -6035,11 +6035,11 @@ MSVC Reference Binding
 
 Please see the `MSDN doc<https://learn.microsoft.com/en-us/cpp/build/reference/zc-referencebinding-enforce-reference-binding-rules>`_ for more information on this non-conforming C++ extension.
 
-MSVC allows user-defined type temporaries to be bound to non-const lvalue references when `/permissive`
-or `/Zc:referenceBinding-` are given on the command line.
+MSVC allows user-defined type temporaries to be bound to non-const lvalue references when ``/permissive``
+or ``/Zc:referenceBinding-`` are given on the command line.
 
-The current default behavior as of MSVC 1940 is `/permissive`.
-As of Visual Studio 2017, `/permissive-` is the default for projects meaning C++ conformance is enforced when
+The current default behavior as of MSVC 1940 is ``/permissive``.
+As of Visual Studio 2017, ``/permissive-`` is the default for projects meaning C++ conformance is enforced when
 building with MSVC in Visual Studio.
 
 This MSVC extension can be enabled with ``-fms-reference-binding`` with the clang or cl driver.

--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -419,6 +419,10 @@ New Compiler Flags
   existing ``-fno-c++-static-destructors`` flag) skips all static
   destructors registration.
 
+- ``-fms-reference-binding`` and its clang-cl counterpart ``/Zc:referenceBinding``.
+  Implements the MSVC extension where expressions that bind a user-defined type temporary
+  to a non-const lvalue reference are allowed.
+
 Deprecated Compiler Flags
 -------------------------
 

--- a/clang/include/clang/Basic/DiagnosticGroups.td
+++ b/clang/include/clang/Basic/DiagnosticGroups.td
@@ -1302,6 +1302,7 @@ def MicrosoftStaticAssert : DiagGroup<"microsoft-static-assert">;
 def MicrosoftInitFromPredefined : DiagGroup<"microsoft-init-from-predefined">;
 def MicrosoftStringLiteralFromPredefined : DiagGroup<
     "microsoft-string-literal-from-predefined">;
+def MicrosoftReferenceBinding : DiagGroup<"microsoft-reference-binding">;
 
 // Aliases.
 def : DiagGroup<"msvc-include", [MicrosoftInclude]>;

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -2452,6 +2452,10 @@ def note_explicit_ctor_deduction_guide_here : Note<
   "explicit %select{constructor|deduction guide}0 declared here">;
 def note_implicit_deduction_guide : Note<"implicit deduction guide declared as '%0'">;
 
+def ext_ms_lvalue_reference_binding : ExtWarn<
+  "binding a user-defined type temporary to a non-const lvalue is a "
+  "Microsoft extension">, InGroup<MicrosoftReferenceBinding>;
+
 // C++11 auto
 def warn_cxx98_compat_auto_type_specifier : Warning<
   "'auto' type specifier is incompatible with C++98">,

--- a/clang/include/clang/Basic/LangOptions.def
+++ b/clang/include/clang/Basic/LangOptions.def
@@ -311,7 +311,7 @@ LANGOPT(HIPStdParInterposeAlloc, 1, 0, "Replace allocations / deallocations with
 LANGOPT(OpenACC           , 1, 0, "OpenACC Enabled")
 
 LANGOPT(MSVCEnableStdcMacro , 1, 0, "Define __STDC__ with '-fms-compatibility'")
-LANGOPT(MSVCReferenceBinding , 1, 0, "Accept expressions that bind a non-const lvalue reference to a temporary")
+LANGOPT(MSVCReferenceBinding , 1, 0, "Accept expressions that bind a non-const lvalue reference to a user-defined type temporary")
 LANGOPT(SizedDeallocation , 1, 0, "sized deallocation")
 LANGOPT(AlignedAllocation , 1, 0, "aligned allocation")
 LANGOPT(AlignedAllocationUnavailable, 1, 0, "aligned allocation functions are unavailable")

--- a/clang/include/clang/Basic/LangOptions.def
+++ b/clang/include/clang/Basic/LangOptions.def
@@ -311,6 +311,7 @@ LANGOPT(HIPStdParInterposeAlloc, 1, 0, "Replace allocations / deallocations with
 LANGOPT(OpenACC           , 1, 0, "OpenACC Enabled")
 
 LANGOPT(MSVCEnableStdcMacro , 1, 0, "Define __STDC__ with '-fms-compatibility'")
+LANGOPT(MSVCReferenceBinding , 1, 0, "Accept expressions that bind a non-const lvalue reference to a temporary")
 LANGOPT(SizedDeallocation , 1, 0, "sized deallocation")
 LANGOPT(AlignedAllocation , 1, 0, "aligned allocation")
 LANGOPT(AlignedAllocationUnavailable, 1, 0, "aligned allocation functions are unavailable")

--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -3096,6 +3096,12 @@ def fms_extensions : Flag<["-"], "fms-extensions">, Group<f_Group>,
   Visibility<[ClangOption, CC1Option, CLOption]>,
   HelpText<"Accept some non-standard constructs supported by the Microsoft compiler">,
   MarshallingInfoFlag<LangOpts<"MicrosoftExt">>, ImpliedByAnyOf<[fms_compatibility.KeyPath]>;
+def fms_reference_binding : Flag<["-"], "fms-reference-binding">, Group<f_Group>,
+  Visibility<[ClangOption, CC1Option, CLOption]>,
+  HelpText<"Accept expressions that bind a non-const lvalue reference to a user-defined type temporary as supported by the Microsoft Compiler">,
+  MarshallingInfoFlag<LangOpts<"MSVCReferenceBinding">>;
+def fno_ms_reference_binding : Flag<["-"], "fno-ms-reference-binding">, Group<f_Group>,
+  Visibility<[ClangOption, CLOption]>;
 defm asm_blocks : BoolFOption<"asm-blocks",
   LangOpts<"AsmBlocks">, Default<fms_extensions.KeyPath>,
   PosFlag<SetTrue, [], [ClangOption, CC1Option]>,
@@ -8683,6 +8689,12 @@ def _SLASH_Zc_wchar_t : CLFlag<"Zc:wchar_t">,
   HelpText<"Enable C++ builtin type wchar_t (default)">;
 def _SLASH_Zc_wchar_t_ : CLFlag<"Zc:wchar_t-">,
   HelpText<"Disable C++ builtin type wchar_t">;
+def _SLASH_Zc_referenceBinding : CLFlag<"Zc:referenceBinding">,
+  HelpText<"Do not accept expressions that bind a non-const lvalue reference to a user-defined type temporary">,
+  Alias<fno_ms_reference_binding>;
+def _SLASH_Zc_referenceBinding_ : CLFlag<"Zc:referenceBinding-">,
+  HelpText<"Accept expressions that bind a non-const lvalue reference to a user-defined type temporary">,
+  Alias<fms_reference_binding>;
 def _SLASH_Z7 : CLFlag<"Z7">, Alias<g_Flag>,
   HelpText<"Enable CodeView debug information in object files">;
 def _SLASH_ZH_MD5 : CLFlag<"ZH:MD5">,

--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -3098,7 +3098,8 @@ def fms_extensions : Flag<["-"], "fms-extensions">, Group<f_Group>,
   MarshallingInfoFlag<LangOpts<"MicrosoftExt">>, ImpliedByAnyOf<[fms_compatibility.KeyPath]>;
 def fms_reference_binding : Flag<["-"], "fms-reference-binding">, Group<f_Group>,
   Visibility<[ClangOption, CC1Option, CLOption]>,
-  HelpText<"Accept expressions that bind a non-const lvalue reference to a user-defined type temporary as supported by the Microsoft Compiler">,
+  HelpText<"Accept expressions that bind a non-const lvalue reference to a "
+           "user-defined type temporary as supported by the Microsoft compiler">,
   MarshallingInfoFlag<LangOpts<"MSVCReferenceBinding">>;
 def fno_ms_reference_binding : Flag<["-"], "fno-ms-reference-binding">, Group<f_Group>,
   Visibility<[ClangOption, CLOption]>;
@@ -8690,10 +8691,11 @@ def _SLASH_Zc_wchar_t : CLFlag<"Zc:wchar_t">,
 def _SLASH_Zc_wchar_t_ : CLFlag<"Zc:wchar_t-">,
   HelpText<"Disable C++ builtin type wchar_t">;
 def _SLASH_Zc_referenceBinding : CLFlag<"Zc:referenceBinding">,
-  HelpText<"Do not accept expressions that bind a non-const lvalue reference to a user-defined type temporary">,
+  HelpText<"Do not accept expressions that bind a non-const lvalue reference to a user-defined type temporary (default)">,
   Alias<fno_ms_reference_binding>;
 def _SLASH_Zc_referenceBinding_ : CLFlag<"Zc:referenceBinding-">,
-  HelpText<"Accept expressions that bind a non-const lvalue reference to a user-defined type temporary">,
+  HelpText<"Accept expressions that bind a non-const lvalue reference to a "
+           "user-defined type temporary">,
   Alias<fms_reference_binding>;
 def _SLASH_Z7 : CLFlag<"Z7">, Alias<g_Flag>,
   HelpText<"Enable CodeView debug information in object files">;

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -10144,6 +10144,8 @@ public:
   CompareReferenceRelationship(SourceLocation Loc, QualType T1, QualType T2,
                                ReferenceConversions *Conv = nullptr);
 
+  bool AllowMSLValueReferenceBinding(Qualifiers Quals, QualType QT);
+
   /// AddOverloadCandidate - Adds the given function to the set of
   /// candidate functions, using the given function call arguments.  If
   /// @p SuppressUserConversions, then don't allow user-defined

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -7383,7 +7383,7 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
 
   if (Args.hasFlag(options::OPT_fms_reference_binding,
                    options::OPT_fno_ms_reference_binding,
-                   IsWindowsMSVC && !HaveCxx20))
+                   false))
     CmdArgs.push_back("-fms-reference-binding");
 
   if (Args.hasFlag(options::OPT_fpch_validate_input_files_content,

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -7381,7 +7381,6 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
     CmdArgs.push_back("-fdelayed-template-parsing");
   }
 
-  // -fno-ms-reference-binding is the default.
   if (Args.hasFlag(options::OPT_fms_reference_binding,
                    options::OPT_fno_ms_reference_binding,
                    IsWindowsMSVC && !HaveCxx20))

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -7215,6 +7215,11 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
                    IsWindowsMSVC))
     CmdArgs.push_back("-fms-extensions");
 
+  // -fno-ms-reference-binding is the default.
+  if (Args.hasFlag(options::OPT_fms_reference_binding,
+                   options::OPT_fno_ms_reference_binding, false))
+    CmdArgs.push_back("-fms-reference-binding");
+
   // -fms-compatibility=0 is default.
   bool IsMSVCCompat = Args.hasFlag(
       options::OPT_fms_compatibility, options::OPT_fno_ms_compatibility,

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -7381,10 +7381,8 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
     CmdArgs.push_back("-fdelayed-template-parsing");
   }
 
-  if (Args.hasFlag(options::OPT_fms_reference_binding,
-                   options::OPT_fno_ms_reference_binding,
-                   false))
-    CmdArgs.push_back("-fms-reference-binding");
+  Args.addOptInFlag(CmdArgs, options::OPT_fms_reference_binding,
+                    options::OPT_fno_ms_reference_binding);
 
   if (Args.hasFlag(options::OPT_fpch_validate_input_files_content,
                    options::OPT_fno_pch_validate_input_files_content, false))

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -7215,11 +7215,6 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
                    IsWindowsMSVC))
     CmdArgs.push_back("-fms-extensions");
 
-  // -fno-ms-reference-binding is the default.
-  if (Args.hasFlag(options::OPT_fms_reference_binding,
-                   options::OPT_fno_ms_reference_binding, false))
-    CmdArgs.push_back("-fms-reference-binding");
-
   // -fms-compatibility=0 is default.
   bool IsMSVCCompat = Args.hasFlag(
       options::OPT_fms_compatibility, options::OPT_fno_ms_compatibility,
@@ -7385,6 +7380,12 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
 
     CmdArgs.push_back("-fdelayed-template-parsing");
   }
+
+  // -fno-ms-reference-binding is the default.
+  if (Args.hasFlag(options::OPT_fms_reference_binding,
+                   options::OPT_fno_ms_reference_binding,
+                   IsWindowsMSVC && !HaveCxx20))
+    CmdArgs.push_back("-fms-reference-binding");
 
   if (Args.hasFlag(options::OPT_fpch_validate_input_files_content,
                    options::OPT_fno_pch_validate_input_files_content, false))

--- a/clang/lib/Driver/ToolChains/MSVC.cpp
+++ b/clang/lib/Driver/ToolChains/MSVC.cpp
@@ -947,6 +947,7 @@ static void TranslatePermissive(Arg *A, llvm::opt::DerivedArgList &DAL,
                                 const OptTable &Opts) {
   DAL.AddFlagArg(A, Opts.getOption(options::OPT__SLASH_Zc_twoPhase_));
   DAL.AddFlagArg(A, Opts.getOption(options::OPT_fno_operator_names));
+  DAL.AddFlagArg(A, Opts.getOption(options::OPT_fms_reference_binding));
 }
 
 static void TranslatePermissiveMinus(Arg *A, llvm::opt::DerivedArgList &DAL,

--- a/clang/lib/Driver/ToolChains/MSVC.cpp
+++ b/clang/lib/Driver/ToolChains/MSVC.cpp
@@ -947,7 +947,6 @@ static void TranslatePermissive(Arg *A, llvm::opt::DerivedArgList &DAL,
                                 const OptTable &Opts) {
   DAL.AddFlagArg(A, Opts.getOption(options::OPT__SLASH_Zc_twoPhase_));
   DAL.AddFlagArg(A, Opts.getOption(options::OPT_fno_operator_names));
-  DAL.AddFlagArg(A, Opts.getOption(options::OPT_fms_reference_binding));
 }
 
 static void TranslatePermissiveMinus(Arg *A, llvm::opt::DerivedArgList &DAL,

--- a/clang/lib/Driver/ToolChains/MSVC.cpp
+++ b/clang/lib/Driver/ToolChains/MSVC.cpp
@@ -954,6 +954,7 @@ static void TranslatePermissiveMinus(Arg *A, llvm::opt::DerivedArgList &DAL,
                                      const OptTable &Opts) {
   DAL.AddFlagArg(A, Opts.getOption(options::OPT__SLASH_Zc_twoPhase));
   DAL.AddFlagArg(A, Opts.getOption(options::OPT_foperator_names));
+  DAL.AddFlagArg(A, Opts.getOption(options::OPT_fno_ms_reference_binding));
 }
 
 llvm::opt::DerivedArgList *

--- a/clang/lib/Sema/SemaInit.cpp
+++ b/clang/lib/Sema/SemaInit.cpp
@@ -5331,10 +5331,13 @@ static void TryReferenceInitializationCore(Sema &S,
                                   ConvOvlResult);
     else if (!InitCategory.isLValue()) {
       if (T1Quals.isAddressSpaceSupersetOf(T2Quals, S.getASTContext())) {
-        if (!S.getLangOpts().MSVCReferenceBinding ||
-            !S.AllowMSLValueReferenceBinding(T1Quals, T1))
+        if (S.AllowMSLValueReferenceBinding(T1Quals, T1)) {
+          S.Diag(DeclLoc, diag::ext_ms_lvalue_reference_binding)
+              << Initializer->getSourceRange();
+        } else {
           Sequence.SetFailed(InitializationSequence::
                                  FK_NonConstLValueReferenceBindingToTemporary);
+        }
       } else {
         Sequence.SetFailed(
             InitializationSequence::FK_ReferenceInitDropsQualifiers);

--- a/clang/lib/Sema/SemaInit.cpp
+++ b/clang/lib/Sema/SemaInit.cpp
@@ -5329,13 +5329,17 @@ static void TryReferenceInitializationCore(Sema &S,
       Sequence.SetOverloadFailure(
                         InitializationSequence::FK_ReferenceInitOverloadFailed,
                                   ConvOvlResult);
-    else if (!InitCategory.isLValue())
-      Sequence.SetFailed(
-          T1Quals.isAddressSpaceSupersetOf(T2Quals, S.getASTContext())
-              ? InitializationSequence::
-                    FK_NonConstLValueReferenceBindingToTemporary
-              : InitializationSequence::FK_ReferenceInitDropsQualifiers);
-    else {
+    else if (!InitCategory.isLValue()) {
+      if (T1Quals.isAddressSpaceSupersetOf(T2Quals, S.getASTContext())) {
+        if (!S.getLangOpts().MSVCReferenceBinding ||
+            !S.AllowMSLValueReferenceBinding(T1Quals, T1))
+          Sequence.SetFailed(InitializationSequence::
+                                 FK_NonConstLValueReferenceBindingToTemporary);
+      } else {
+        Sequence.SetFailed(
+            InitializationSequence::FK_ReferenceInitDropsQualifiers);
+      }
+    } else {
       InitializationSequence::FailureKind FK;
       switch (RefRelationship) {
       case Sema::Ref_Compatible:
@@ -5361,7 +5365,9 @@ static void TryReferenceInitializationCore(Sema &S,
       }
       Sequence.SetFailed(FK);
     }
-    return;
+
+    if (Sequence.Failed())
+      return;
   }
 
   //    - If the initializer expression

--- a/clang/lib/Sema/SemaInit.cpp
+++ b/clang/lib/Sema/SemaInit.cpp
@@ -5331,7 +5331,8 @@ static void TryReferenceInitializationCore(Sema &S,
                                   ConvOvlResult);
     else if (!InitCategory.isLValue()) {
       if (T1Quals.isAddressSpaceSupersetOf(T2Quals, S.getASTContext())) {
-        if (S.AllowMSLValueReferenceBinding(T1Quals, T1)) {
+        if (S.AllowMSLValueReferenceBinding(T1Quals, T1) &&
+            RefRelationship != Sema::Ref_Incompatible) {
           S.Diag(DeclLoc, diag::ext_ms_lvalue_reference_binding)
               << Initializer->getSourceRange();
         } else {

--- a/clang/lib/Sema/SemaOverload.cpp
+++ b/clang/lib/Sema/SemaOverload.cpp
@@ -5014,13 +5014,8 @@ Sema::CompareReferenceRelationship(SourceLocation Loc,
 }
 
 bool Sema::AllowMSLValueReferenceBinding(Qualifiers Quals, QualType QT) {
-  if (Quals.hasVolatile())
-    return false;
-  if (Quals.hasConst())
-    return true;
-  if (QT->isBuiltinType() || QT->isArrayType())
-    return false;
-  return true;
+  return getLangOpts().MSVCReferenceBinding &&
+         !(Quals.hasVolatile() || QT->isBuiltinType() || QT->isArrayType());
 }
 
 /// Look for a user-defined conversion to a value reference-compatible
@@ -5255,19 +5250,10 @@ TryReferenceInit(Sema &S, Expr *Init, QualType DeclType,
   //     -- Otherwise, the reference shall be an lvalue reference to a
   //        non-volatile const type (i.e., cv1 shall be const), or the reference
   //        shall be an rvalue reference.
-  if (!isRValRef) {
-    const bool CanBindLValueRef =
-        !S.getLangOpts().MSVCReferenceBinding
-            ? (T1.isConstQualified() && !T1.isVolatileQualified())
-            : S.AllowMSLValueReferenceBinding(T1.getQualifiers(), T1);
-    if (!CanBindLValueRef) {
-      if (InitCategory.isRValue() && RefRelationship != Sema::Ref_Incompatible)
-        ICS.setBad(BadConversionSequence::lvalue_ref_to_rvalue, Init, DeclType);
-      return ICS;
-    }
-  }
-
-  if (!isRValRef && !CanBindLValueRef) {
+  if (!isRValRef && (!T1.isConstQualified() || T1.isVolatileQualified()) &&
+      !S.AllowMSLValueReferenceBinding(T1.getQualifiers(), T1)) {
+    if (InitCategory.isRValue() && RefRelationship != Sema::Ref_Incompatible)
+      ICS.setBad(BadConversionSequence::lvalue_ref_to_rvalue, Init, DeclType);
     return ICS;
   }
 

--- a/clang/lib/Sema/SemaOverload.cpp
+++ b/clang/lib/Sema/SemaOverload.cpp
@@ -4552,6 +4552,24 @@ CompareStandardConversionSequences(Sema &S, SourceLocation Loc,
         T1 = S.Context.getQualifiedType(UnqualT1, T1Quals);
       if (isa<ArrayType>(T2) && T2Quals)
         T2 = S.Context.getQualifiedType(UnqualT2, T2Quals);
+
+      if (S.getLangOpts().MSVCReferenceBinding &&
+          S.Context.hasSameType(SCS1.getFromType(), SCS2.getFromType()) &&
+          !SCS1.getFromType().hasQualifiers() && SCS1.BindsToRvalue &&
+          SCS2.BindsToRvalue) {
+
+        // When binding a user-defined type temporary to an lvalue MSVC will
+        // pick `const T&` over `T&` when binding an unqualified `T&&`.
+        // Therefore we want to pick the more qualified const overload in this
+        // specific case.
+        if (!T2.hasQualifiers() &&
+            (T1.isConstQualified() && !T1.isVolatileQualified()))
+          return ImplicitConversionSequence::Better;
+        if (!T1.hasQualifiers() &&
+            (T2.isConstQualified() && !T2.isVolatileQualified()))
+          return ImplicitConversionSequence::Worse;
+      }
+
       if (T2.isMoreQualifiedThan(T1, S.getASTContext()))
         return ImplicitConversionSequence::Better;
       if (T1.isMoreQualifiedThan(T2, S.getASTContext()))
@@ -5250,11 +5268,15 @@ TryReferenceInit(Sema &S, Expr *Init, QualType DeclType,
   //     -- Otherwise, the reference shall be an lvalue reference to a
   //        non-volatile const type (i.e., cv1 shall be const), or the reference
   //        shall be an rvalue reference.
-  if (!isRValRef && (!T1.isConstQualified() || T1.isVolatileQualified()) &&
-      !S.AllowMSLValueReferenceBinding(T1.getQualifiers(), T1)) {
-    if (InitCategory.isRValue() && RefRelationship != Sema::Ref_Incompatible)
-      ICS.setBad(BadConversionSequence::lvalue_ref_to_rvalue, Init, DeclType);
-    return ICS;
+  if (!isRValRef && (!T1.isConstQualified() || T1.isVolatileQualified())) {
+    if (InitCategory.isRValue() && RefRelationship != Sema::Ref_Incompatible) {
+      if (!S.AllowMSLValueReferenceBinding(T1.getQualifiers(), T1)) {
+        ICS.setBad(BadConversionSequence::lvalue_ref_to_rvalue, Init, DeclType);
+        return ICS;
+      }
+    } else {
+      return ICS;
+    }
   }
 
   //       -- If the initializer expression

--- a/clang/lib/Sema/SemaOverload.cpp
+++ b/clang/lib/Sema/SemaOverload.cpp
@@ -4556,7 +4556,9 @@ CompareStandardConversionSequences(Sema &S, SourceLocation Loc,
       if (S.getLangOpts().MSVCReferenceBinding &&
           S.Context.hasSameType(SCS1.getFromType(), SCS2.getFromType()) &&
           !SCS1.getFromType().hasQualifiers() && SCS1.BindsToRvalue &&
-          SCS2.BindsToRvalue) {
+          SCS2.BindsToRvalue &&
+          !SCS1.BindsImplicitObjectArgumentWithoutRefQualifier &&
+          !SCS2.BindsImplicitObjectArgumentWithoutRefQualifier) {
 
         // When binding a user-defined type temporary to an lvalue MSVC will
         // pick `const T&` over `T&` when binding an unqualified `T&&`.

--- a/clang/lib/Sema/SemaOverload.cpp
+++ b/clang/lib/Sema/SemaOverload.cpp
@@ -5034,9 +5034,8 @@ Sema::CompareReferenceRelationship(SourceLocation Loc,
 }
 
 bool Sema::AllowMSLValueReferenceBinding(Qualifiers Quals, QualType QT) {
-  return getLangOpts().MSVCReferenceBinding &&
-         !(Quals.hasVolatile() || QT->isBuiltinType() || QT->isPointerType() ||
-           QT->isMemberPointerType() || QT->isArrayType());
+  return getLangOpts().MSVCReferenceBinding && !Quals.hasVolatile() &&
+         !QT->isArrayType() && QT->isRecordType();
 }
 
 /// Look for a user-defined conversion to a value reference-compatible

--- a/clang/lib/Sema/SemaOverload.cpp
+++ b/clang/lib/Sema/SemaOverload.cpp
@@ -5035,7 +5035,8 @@ Sema::CompareReferenceRelationship(SourceLocation Loc,
 
 bool Sema::AllowMSLValueReferenceBinding(Qualifiers Quals, QualType QT) {
   return getLangOpts().MSVCReferenceBinding &&
-         !(Quals.hasVolatile() || QT->isBuiltinType() || QT->isArrayType());
+         !(Quals.hasVolatile() || QT->isBuiltinType() || QT->isPointerType() ||
+           QT->isArrayType());
 }
 
 /// Look for a user-defined conversion to a value reference-compatible

--- a/clang/lib/Sema/SemaOverload.cpp
+++ b/clang/lib/Sema/SemaOverload.cpp
@@ -5036,7 +5036,7 @@ Sema::CompareReferenceRelationship(SourceLocation Loc,
 bool Sema::AllowMSLValueReferenceBinding(Qualifiers Quals, QualType QT) {
   return getLangOpts().MSVCReferenceBinding &&
          !(Quals.hasVolatile() || QT->isBuiltinType() || QT->isPointerType() ||
-           QT->isArrayType());
+           QT->isMemberPointerType() || QT->isArrayType());
 }
 
 /// Look for a user-defined conversion to a value reference-compatible

--- a/clang/test/CodeGenCXX/ms-reference-binding.cpp
+++ b/clang/test/CodeGenCXX/ms-reference-binding.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -triple x86_64-windows-msvc %s -emit-llvm -fms-extensions -fms-compatibility -fms-reference-binding -o - | FileCheck %s
+// RUN: %clang_cc1 -triple x86_64-windows-msvc %s -emit-llvm -fms-extensions -fms-compatibility -fms-reference-binding -Wno-microsoft-reference-binding -o - | FileCheck %s
 
 struct A {};
 struct B : A {};
@@ -15,6 +15,31 @@ void fAPickRef(const volatile A&) {}
 void fAPickRef2(A&) {}
 void fAPickRef2(const volatile A&) {}
 
+namespace NS {
+  void fAPickConstRef(A&) {}
+  void fAPickConstRef(const A&) {}
+
+  void fBPickConstRef(A&) {}
+  void fBPickConstRef(const A&) {}
+
+  void fAPickRef(A&) {}
+  void fAPickRef(const volatile A&) {}
+
+  void fAPickRef2(A&) {}
+  void fAPickRef2(const volatile A&) {}
+}
+
+struct S {
+  void memberPickNonConst() {}
+  void memberPickNonConst() const {}
+
+  void memberPickConstRef() const & {}
+  void memberPickConstRef() & {}
+
+  static void fAPickConstRef(A&) {}
+  static void fAPickConstRef(const A&) {}
+};
+
 void test() {
   fAPickConstRef(A());
   // CHECK: call {{.*}} @"?fAPickConstRef@@YAXAEBUA@@@Z"
@@ -27,4 +52,29 @@ void test() {
 
   fAPickRef2(A());
   // CHECK: call {{.*}} @"?fAPickRef2@@YAXAEAUA@@@Z"
+
+  NS::fAPickConstRef(A());
+  // CHECK: call {{.*}} @"?fAPickConstRef@NS@@YAXAEBUA@@@Z"
+
+  NS::fBPickConstRef(B());
+  // CHECK: call {{.*}} @"?fBPickConstRef@NS@@YAXAEBUA@@@Z"
+
+  NS::fAPickRef(A());
+  // CHECK: call {{.*}} @"?fAPickRef@NS@@YAXAEAUA@@@Z"
+
+  NS::fAPickRef2(A());
+  // CHECK: call {{.*}} @"?fAPickRef2@NS@@YAXAEAUA@@@Z"
+
+  S::fAPickConstRef(A());
+  // CHECK: call {{.*}} @"?fAPickConstRef@S@@SAXAEBUA@@@Z"
+}
+
+void test_member_call() {
+  S s;
+
+  static_cast<S&&>(s).memberPickNonConst();
+  // CHECK: call {{.*}} @"?memberPickNonConst@S@@QEAAXXZ"
+
+  static_cast<S&&>(s).memberPickConstRef();
+  // CHECK: call {{.*}} @"?memberPickConstRef@S@@QEGBAXXZ"
 }

--- a/clang/test/CodeGenCXX/ms-reference-binding.cpp
+++ b/clang/test/CodeGenCXX/ms-reference-binding.cpp
@@ -1,0 +1,30 @@
+// RUN: %clang_cc1 -triple x86_64-windows-msvc %s -emit-llvm -fms-extensions -fms-compatibility -fms-reference-binding -o - | FileCheck %s
+
+struct A {};
+struct B : A {};
+
+void fAPickConstRef(A&) {}
+void fAPickConstRef(const A&) {}
+
+void fBPickConstRef(A&) {}
+void fBPickConstRef(const A&) {}
+
+void fAPickRef(A&) {}
+void fAPickRef(const volatile A&) {}
+
+void fAPickRef2(A&) {}
+void fAPickRef2(const volatile A&) {}
+
+void test() {
+  fAPickConstRef(A());
+  // CHECK: call {{.*}} @"?fAPickConstRef@@YAXAEBUA@@@Z"
+
+  fBPickConstRef(B());
+  // CHECK: call {{.*}} @"?fBPickConstRef@@YAXAEBUA@@@Z"
+
+  fAPickRef(A());
+  // CHECK: call {{.*}} @"?fAPickRef@@YAXAEAUA@@@Z"
+
+  fAPickRef2(A());
+  // CHECK: call {{.*}} @"?fAPickRef2@@YAXAEAUA@@@Z"
+}

--- a/clang/test/Driver/cl-permissive.c
+++ b/clang/test/Driver/cl-permissive.c
@@ -3,8 +3,8 @@
 
 // RUN: %clang_cl /permissive -### -- %s 2>&1 | FileCheck -check-prefix=PERMISSIVE %s
 // PERMISSIVE: "-fno-operator-names"
-// PERMISSIVE: "-fms-reference-binding"
 // PERMISSIVE: "-fdelayed-template-parsing"
+// PERMISSIVE: "-fms-reference-binding"
 // RUN: %clang_cl /permissive- -### -- %s 2>&1 | FileCheck -check-prefix=PERMISSIVE-MINUS %s
 // PERMISSIVE-MINUS-NOT: "-fno-operator-names"
 // PERMISSIVE-MINUS-NOT: "-fms-reference-binding"

--- a/clang/test/Driver/cl-permissive.c
+++ b/clang/test/Driver/cl-permissive.c
@@ -3,9 +3,11 @@
 
 // RUN: %clang_cl /permissive -### -- %s 2>&1 | FileCheck -check-prefix=PERMISSIVE %s
 // PERMISSIVE: "-fno-operator-names"
+// PERMISSIVE: "-fms-reference-binding"
 // PERMISSIVE: "-fdelayed-template-parsing"
 // RUN: %clang_cl /permissive- -### -- %s 2>&1 | FileCheck -check-prefix=PERMISSIVE-MINUS %s
 // PERMISSIVE-MINUS-NOT: "-fno-operator-names"
+// PERMISSIVE-MINUS-NOT: "-fms-reference-binding"
 // PERMISSIVE-MINUS-NOT: "-fdelayed-template-parsing"
 
 // The switches set by permissive may then still be manually enabled or disabled
@@ -15,3 +17,8 @@
 // RUN: %clang_cl /permissive- /Zc:twoPhase- -### -- %s 2>&1 | FileCheck -check-prefix=PERMISSIVE-MINUS-OVERWRITE %s
 // PERMISSIVE-MINUS-OVERWRITE-NOT: "-fno-operator-names"
 // PERMISSIVE-MINUS-OVERWRITE: "-fdelayed-template-parsing"
+
+// RUN: %clang_cl /permissive -fno-ms-reference-binding -### -- %s 2>&1 | FileCheck -check-prefix=PERMISSIVE-OVERWRITE-REF-BINDING %s
+// PERMISSIVE-OVERWRITE-REF-BINDING-NOT: "-fms-reference-binding"
+// RUN: %clang_cl /permissive- -fms-reference-binding -### -- %s 2>&1 | FileCheck -check-prefix=PERMISSIVE-MINUS-OVERWRITE-REF-BINDING %s
+// PERMISSIVE-MINUS-OVERWRITE-REF-BINDING: "-fms-reference-binding"

--- a/clang/test/Driver/cl-permissive.c
+++ b/clang/test/Driver/cl-permissive.c
@@ -4,7 +4,6 @@
 // RUN: %clang_cl /permissive -### -- %s 2>&1 | FileCheck -check-prefix=PERMISSIVE %s
 // PERMISSIVE: "-fno-operator-names"
 // PERMISSIVE: "-fdelayed-template-parsing"
-// PERMISSIVE: "-fms-reference-binding"
 // RUN: %clang_cl /permissive- -### -- %s 2>&1 | FileCheck -check-prefix=PERMISSIVE-MINUS %s
 // PERMISSIVE-MINUS-NOT: "-fno-operator-names"
 // PERMISSIVE-MINUS-NOT: "-fms-reference-binding"

--- a/clang/test/Driver/cl-zc.cpp
+++ b/clang/test/Driver/cl-zc.cpp
@@ -127,6 +127,8 @@
 
 // RUN: %clang_cl -c -### /Zc:referenceBinding- -- %s 2>&1 | FileCheck -check-prefix CHECK-REFERENCE_BINDING_ %s
 // CHECK-REFERENCE_BINDING_: "-fms-reference-binding"
+// RUN: %clang_cl -c -### /Zc:referenceBinding -- %s 2>&1 | FileCheck -check-prefix CHECK-REFERENCE_BINDING %s
+// CHECK-REFERENCE_BINDING-NOT: "-fms-reference-binding"
 
 
 // These never warn, but don't have an effect yet.

--- a/clang/test/Driver/cl-zc.cpp
+++ b/clang/test/Driver/cl-zc.cpp
@@ -125,6 +125,8 @@
 // RUN: %clang_cl -c -### /Zc:char8_t- -- %s 2>&1 | FileCheck -check-prefix CHECK-CHAR8_T_ %s
 // CHECK-CHAR8_T_: "-fno-char8_t"
 
+// RUN: %clang_cl -c -### /Zc:referenceBinding- -- %s 2>&1 | FileCheck -check-prefix CHECK-REFERENCE_BINDING_ %s
+// CHECK-REFERENCE_BINDING_: "-fms-reference-binding"
 
 
 // These never warn, but don't have an effect yet.

--- a/clang/test/SemaCXX/ms-reference-binding.cpp
+++ b/clang/test/SemaCXX/ms-reference-binding.cpp
@@ -20,7 +20,7 @@ void fARefDoNotWarn(const A&) {}
 void fARefLoseConstQualifier(A&) {}
 
 void test2() {
-  // This should not warn since `fARef2(const A&)` is a better candidate
+  // This should not warn since `fARefDoNotWarn(const A&)` is a better candidate
   fARefDoNotWarn(A());
 
   const A a;

--- a/clang/test/SemaCXX/ms-reference-binding.cpp
+++ b/clang/test/SemaCXX/ms-reference-binding.cpp
@@ -1,0 +1,102 @@
+// RUN: %clang_cc1 -fsyntax-only -verify -fms-reference-binding %s
+
+struct A {};
+struct B : A {};
+
+B fB();
+A fA();
+
+A&& fARvalueRef();
+A(&&fARvalueRefArray())[1];
+void fARef(A&) {}
+
+void fIntRef(int&) {} // expected-note{{candidate function not viable: expects an lvalue for 1st argument}}
+void fDoubleRef(double&) {} // expected-note{{candidate function not viable: expects an lvalue for 1st argument}}
+
+void fIntConstRef(const int&) {}
+void fDoubleConstRef(const double&) {}
+
+void fIntArray(int (&)[1]); // expected-note{{candidate function not viable: expects an lvalue for 1st argument}}
+void fIntConstArray(const int (&)[1]);
+
+namespace NS {
+  void fARef(A&) {}
+
+  void fIntRef(int&) {} // expected-note{{passing argument to parameter here}}
+  void fDoubleRef(double&) {} // expected-note{{passing argument to parameter here}}
+
+  void fIntConstRef(const int&) {}
+  void fDoubleConstRef(const double&) {}
+
+  A(&&fARvalueRefArray())[1];
+
+  void fIntArray(int (&)[1]); // expected-note{{passing argument to parameter here}}
+
+  void fIntConstArray(const int (&)[1]);
+}
+
+void test1() {
+  double& rd2 = 2.0; // expected-error{{non-const lvalue reference to type 'double' cannot bind to a temporary of type 'double'}}
+  int& i1 = 0; // expected-error{{non-const lvalue reference to type 'int' cannot bind to a temporary of type 'int'}}
+
+  fIntRef(0); // expected-error{{no matching function for call to 'fIntRef'}}
+  fDoubleRef(0.0); // expected-error{{no matching function for call to 'fDoubleRef'}}
+
+  NS::fIntRef(0); // expected-error{{non-const lvalue reference to type 'int' cannot bind to a temporary of type 'int'}}
+  NS::fDoubleRef(0.0); // expected-error{{non-const lvalue reference to type 'double' cannot bind to a temporary of type 'double'}}
+
+  int i2 = 2;
+  double& rd3 = i2; // expected-error{{non-const lvalue reference to type 'double' cannot bind to a value of unrelated type 'int'}}
+}
+
+void test2() {
+  fIntConstRef(0);
+  fDoubleConstRef(0.0);
+
+  NS::fIntConstRef(0);
+  NS::fDoubleConstRef(0.0);
+
+  int i = 0;
+  const int ci = 0;
+  volatile int vi = 0;
+  const volatile int cvi = 0;
+  bool b = true;
+
+  const volatile int &cvir1 = b ? ci : vi; // expected-error{{volatile lvalue reference to type 'const volatile int' cannot bind to a temporary of type 'int'}}
+
+  volatile int& vir1 = 0; // expected-error{{volatile lvalue reference to type 'volatile int' cannot bind to a temporary of type 'int'}}
+  const volatile int& cvir2 = 0; // expected-error{{volatile lvalue reference to type 'const volatile int' cannot bind to a temporary of type 'int'}}
+}
+
+void test3() {
+  A& a1 = A();
+
+  fARef(A());
+  fARef(static_cast<A&&>(a1));
+  fARef(B());
+
+  NS::fARef(A());
+  NS::fARef(static_cast<A&&>(a1));
+  NS::fARef(B());
+
+  A& a2 = fA();
+
+  A& a3 = fARvalueRef();
+
+  const A& rca = fB();
+  A& ra = fB();
+}
+
+void test4() {
+  A (&array1)[1] = fARvalueRefArray(); // expected-error{{non-const lvalue reference to type 'A[1]' cannot bind to a temporary of type 'A[1]'}}
+  const A (&array2)[1] = fARvalueRefArray();
+
+  A (&array3)[1] = NS::fARvalueRefArray(); // expected-error{{non-const lvalue reference to type 'A[1]' cannot bind to a temporary of type 'A[1]'}}
+  const A (&array4)[1] = NS::fARvalueRefArray();
+
+  fIntArray({ 1 }); // expected-error{{no matching function for call to 'fIntArray'}}
+  NS::fIntArray({ 1 }); // expected-error{{non-const lvalue reference to type 'int[1]' cannot bind to an initializer list temporary}}
+
+  fIntConstArray({ 1 });
+  NS::fIntConstArray({ 1 });
+}

--- a/clang/test/SemaCXX/ms-reference-binding.cpp
+++ b/clang/test/SemaCXX/ms-reference-binding.cpp
@@ -33,8 +33,12 @@ void test2() {
 struct A {};
 struct B : A {};
 
+typedef A AAlias;
+
 void fADefaultArgRef(A& = A{});
 void fBDefaultArgRef(A& = B{});
+
+void fAAliasDefaultArgRef(AAlias& = AAlias{});
 
 B fB();
 A fA();
@@ -45,6 +49,7 @@ A(&&fARvalueRefArray())[1];
 void fADefaultArgRef2(A& = fARvalueRef());
 
 void fARef(A&) {}
+void fAAliasRef(AAlias&) {}
 
 // expected-note@+2 {{candidate function not viable: expects an lvalue for 1st argument}}
 // expected-note@+1 {{candidate function not viable: expects an lvalue for 1st argument}}
@@ -61,6 +66,7 @@ void fIntConstArray(const int (&)[1]);
 
 namespace NS {
   void fARef(A&) {}
+  void fAAliasRef(AAlias&) {}
 
   // expected-note@+2 {{passing argument to parameter here}}
   // expected-note@+1 {{passing argument to parameter here}}
@@ -114,29 +120,45 @@ void test2() {
 
 void test3() {
   A& a1 = A();
+  AAlias& aalias1 = A();
 
   fARef(A());
   fARef(static_cast<A&&>(a1));
+
+  fAAliasRef(A());
+  fAAliasRef(static_cast<A&&>(a1));
+  fAAliasRef(AAlias());
+  fAAliasRef(static_cast<AAlias&&>(a1));
 
   fAVolatileRef(A()); // expected-error{{no matching function for call to 'fAVolatileRef'}}
   fAVolatileRef(static_cast<A&&>(a1)); // expected-error{{no matching function for call to 'fAVolatileRef'}}
 
   fARef(B());
+  fAAliasRef(B());
 
   NS::fARef(A());
   NS::fARef(static_cast<A&&>(a1));
+
+  NS::fAAliasRef(A());
+  NS::fAAliasRef(static_cast<A&&>(a1));
+  NS::fAAliasRef(AAlias());
+  NS::fAAliasRef(static_cast<AAlias&&>(a1));
 
   NS::fAVolatileRef(A()); // expected-error{{volatile lvalue reference to type 'volatile A' cannot bind to a temporary of type 'A'}}
   NS::fAVolatileRef(static_cast<A&&>(a1)); // expected-error{{volatile lvalue reference to type 'volatile A' cannot bind to a temporary of type 'A'}}
 
   NS::fARef(B());
+  NS::fAAliasRef(B());
 
   A& a2 = fA();
+  AAlias& aalias2 = fA();
 
   A& a3 = fARvalueRef();
+  AAlias& aalias3 = fARvalueRef();
 
   const A& rca = fB();
   A& ra = fB();
+  AAlias& raalias = fB();
 }
 
 void test4() {
@@ -160,6 +182,10 @@ void test5() {
   fBDefaultArgRef();
   fBDefaultArgRef(B());
   fBDefaultArgRef(A());
+
+  fAAliasDefaultArgRef(A());
+  fAAliasDefaultArgRef(B());
+  fAAliasDefaultArgRef(AAlias());
 }
 
 #endif

--- a/clang/test/SemaCXX/ms-reference-binding.cpp
+++ b/clang/test/SemaCXX/ms-reference-binding.cpp
@@ -42,6 +42,8 @@ A fA();
 A&& fARvalueRef();
 A(&&fARvalueRefArray())[1];
 
+void fADefaultArgRef2(A& = fARvalueRef());
+
 void fARef(A&) {}
 
 // expected-note@+2 {{candidate function not viable: expects an lvalue for 1st argument}}

--- a/clang/test/SemaCXX/ms-reference-binding.cpp
+++ b/clang/test/SemaCXX/ms-reference-binding.cpp
@@ -33,6 +33,9 @@ void test2() {
 struct A {};
 struct B : A {};
 
+void fADefaultArgRef(A& = A{});
+void fBDefaultArgRef(A& = B{});
+
 B fB();
 A fA();
 
@@ -146,6 +149,15 @@ void test4() {
 
   fIntConstArray({ 1 });
   NS::fIntConstArray({ 1 });
+}
+
+void test5() {
+  fADefaultArgRef();
+  fADefaultArgRef(A());
+
+  fBDefaultArgRef();
+  fBDefaultArgRef(B());
+  fBDefaultArgRef(A());
 }
 
 #endif

--- a/clang/test/SemaCXX/ms-reference-binding.cpp
+++ b/clang/test/SemaCXX/ms-reference-binding.cpp
@@ -1,4 +1,18 @@
-// RUN: %clang_cc1 -fsyntax-only -verify -fms-reference-binding %s
+// RUN: %clang_cc1 -fsyntax-only -Wno-microsoft-reference-binding -verify -fms-reference-binding %s
+// RUN: %clang_cc1 -DEXTWARN -fsyntax-only -verify -fms-reference-binding %s
+
+#ifdef EXTWARN
+
+struct A {};
+void fARef(A&) {}
+
+void test() {
+  A& a1 = A(); // expected-warning{{binding a user-defined type temporary to a non-const lvalue is a Microsoft extension}}
+
+  fARef(A()); // expected-warning{{binding a user-defined type temporary to a non-const lvalue is a Microsoft extension}}
+}
+
+#else
 
 struct A {};
 struct B : A {};
@@ -100,3 +114,5 @@ void test4() {
   fIntConstArray({ 1 });
   NS::fIntConstArray({ 1 });
 }
+
+#endif

--- a/clang/test/SemaCXX/ms-reference-binding.cpp
+++ b/clang/test/SemaCXX/ms-reference-binding.cpp
@@ -48,7 +48,8 @@ A(&&fARvalueRefArray())[1];
 
 void fADefaultArgRef2(A& = fARvalueRef());
 
-// expected-note@+2 {{candidate function [with T = int] not viable: expects an lvalue for 1st argument}}
+// expected-note@+3 {{candidate function [with T = int] not viable: expects an lvalue for 1st argument}}
+// expected-note@+2 {{candidate function template not viable: expects an lvalue for 1st argument}}
 template<class T>
 void fTRef(T&) {}
 
@@ -72,7 +73,8 @@ namespace NS {
   void fARef(A&) {}
   void fAAliasRef(AAlias&) {}
 
-  // expected-note@+2 {{candidate function [with T = int] not viable: expects an lvalue for 1st argument}}
+  // expected-note@+3 {{candidate function [with T = int] not viable: expects an lvalue for 1st argument}}
+  // expected-note@+2 {{candidate function template not viable: expects an lvalue for 1st argument}}
   template<class T>
   void fTRef(T&) {}
 
@@ -101,11 +103,13 @@ void test1() {
   fDoubleRef(0.0); // expected-error{{no matching function for call to 'fDoubleRef'}}
 
   fTRef(0); // expected-error{{no matching function for call to 'fTRef'}}
+  fTRef<int>(0); // expected-error{{no matching function for call to 'fTRef'}}
 
   NS::fIntRef(0); // expected-error{{non-const lvalue reference to type 'int' cannot bind to a temporary of type 'int'}}
   NS::fDoubleRef(0.0); // expected-error{{non-const lvalue reference to type 'double' cannot bind to a temporary of type 'double'}}
 
   NS::fTRef(0); // expected-error{{no matching function for call to 'fTRef'}}
+  NS::fTRef<int>(0); // expected-error{{no matching function for call to 'fTRef'}}
 
   int i2 = 2;
   double& rd3 = i2; // expected-error{{non-const lvalue reference to type 'double' cannot bind to a value of unrelated type 'int'}}

--- a/clang/test/SemaCXX/ms-reference-binding.cpp
+++ b/clang/test/SemaCXX/ms-reference-binding.cpp
@@ -260,4 +260,33 @@ void test8() {
   const decltype(nullptr) & nullptrCRef = nullptr;
 }
 
+class G {};
+union H {};
+
+G fG();
+H fH();
+
+enum class I : int {};
+enum J { J_ONE = 1, };
+
+void fGRef(G&);
+void fHRef(H&);
+
+void test9() {
+  G& g1 = fG();
+  const G& g2 = fG();
+
+  H& h1 = fH();
+  const H& h2 = fH();
+
+  fGRef(fG());
+  fHRef(fH());
+
+  I& i1 = I{ 1 }; // expected-error{{non-const lvalue reference to type 'I' cannot bind to a temporary of type 'I'}}
+  const I& i2 = I{ 1 };
+
+  J& j1 = J_ONE; // expected-error{{non-const lvalue reference to type 'J' cannot bind to a temporary of type 'J'}}
+  const J& j2 = J_ONE;
+}
+
 #endif

--- a/clang/test/SemaCXX/ms-reference-binding.cpp
+++ b/clang/test/SemaCXX/ms-reference-binding.cpp
@@ -222,4 +222,27 @@ void test7() {
   A& ARef = E();
 }
 
+void testFunction() {}
+
+void refFuncPtrArg(void (* &)()) {} // expected-note{{}}
+void cRefFuncPtrArg(void (* const &)()) {}
+
+void test8() {
+  refFuncPtrArg(&testFunction); // expected-error{{no matching function for call to 'refFuncPtrArg'}}
+  cRefFuncPtrArg(&testFunction);
+
+  void (* & refFuncPtr1)() = &testFunction; // expected-error{{non-const lvalue reference to type 'void (*)()' cannot bind to a temporary of type 'void (*)()'}}
+  void (* const & cRefFuncPtr1)() = &testFunction;
+
+  void (&refFunc1)() = testFunction;
+
+  int i;
+
+  int * & refIntPtr1 = &i; // expected-error{{non-const lvalue reference to type 'int *' cannot bind to a temporary of type 'int *'}}
+  int * const & cRefIntPtr1 = &i;
+
+  decltype(nullptr) & nullptrRef = nullptr; // expected-error{{non-const lvalue reference to type 'decltype(nullptr)' (aka 'std::nullptr_t') cannot bind to a temporary of type 'std::nullptr_t'}}
+  const decltype(nullptr) & nullptrCRef = nullptr;
+}
+
 #endif

--- a/clang/test/SemaCXX/ms-reference-binding.cpp
+++ b/clang/test/SemaCXX/ms-reference-binding.cpp
@@ -222,7 +222,10 @@ void test7() {
   A& ARef = E();
 }
 
+struct F { void test(); int i; };
+
 void testFunction() {}
+void __vectorcall testVCallFunction() {};
 
 // expected-note@+1 {{candidate function not viable: expects an lvalue for 1st argument}}
 void refFuncPtrArg(void (* &)()) {}
@@ -235,7 +238,18 @@ void test8() {
   void (* & refFuncPtr1)() = &testFunction; // expected-error{{non-const lvalue reference to type 'void (*)()' cannot bind to a temporary of type 'void (*)()'}}
   void (* const & cRefFuncPtr1)() = &testFunction;
 
+  void (__vectorcall * & refFuncPtr2)() = &testVCallFunction; // expected-error{{non-const lvalue reference to type 'void (*)() __attribute__((vectorcall))' cannot bind to a temporary of type 'void (*)() __attribute__((vectorcall))'}}
+  void (__vectorcall * const & cRefFuncPtr2)() = &testVCallFunction;
+
   void (&refFunc1)() = testFunction;
+
+  void (__vectorcall &refFunc2)() = testVCallFunction;
+
+  void (F::* & refFuncPtr3)() = &F::test; // expected-error{{non-const lvalue reference to type 'void (F::*)()' cannot bind to a temporary of type 'void (F::*)()'}}
+  void (F::* const & cRefFuncPtr3)() = &F::test;
+
+  int F::* & refPtr1 = &F::i; // expected-error{{non-const lvalue reference to type 'int F::*' cannot bind to a temporary of type 'int F::*'}}
+  int F::* const & cRefPtr1 = &F::i;
 
   int i;
 

--- a/clang/test/SemaCXX/ms-reference-binding.cpp
+++ b/clang/test/SemaCXX/ms-reference-binding.cpp
@@ -188,4 +188,38 @@ void test5() {
   fAAliasDefaultArgRef(AAlias());
 }
 
+struct C { operator A() { return A(); } };
+struct D { D(int) {} };
+
+// expected-note@+1 {{candidate function not viable: no known conversion from 'C' to 'A &' for 1st argument}}
+void fARefConvOperator(A&);
+
+// expected-note@+1 {{candidate function not viable: no known conversion from 'int' to 'D &' for 1st argument}}
+void fDRefTemp(D&);
+
+void fAConstRefConvOperator(const A&);
+void fDConstRefTemp(const D&);
+
+void test6() {
+  fARefConvOperator(C()); // expected-error{{no matching function for call to 'fARefConvOperator'}}
+  fDRefTemp(1); // expected-error{{no matching function for call to 'fDRefTemp'}}
+
+  fAConstRefConvOperator(C());
+  fDConstRefTemp(1);
+
+  const A& cARef = C();
+  A& ARef = C(); // expected-error{{non-const lvalue reference to type 'A' cannot bind to a temporary of type 'C'}}
+
+  const D& cDRef = 1;
+  D& DRef = 1; // expected-error{{non-const lvalue reference to type 'D' cannot bind to a temporary of type 'int'}}
+}
+
+A& retARef();
+struct E { operator A&() { return retARef(); } };
+
+void test7() {
+  const A& cARef = E();
+  A& ARef = E();
+}
+
 #endif

--- a/clang/test/SemaCXX/ms-reference-binding.cpp
+++ b/clang/test/SemaCXX/ms-reference-binding.cpp
@@ -224,7 +224,8 @@ void test7() {
 
 void testFunction() {}
 
-void refFuncPtrArg(void (* &)()) {} // expected-note{{}}
+// expected-note@+1 {{candidate function not viable: expects an lvalue for 1st argument}}
+void refFuncPtrArg(void (* &)()) {}
 void cRefFuncPtrArg(void (* const &)()) {}
 
 void test8() {


### PR DESCRIPTION
MSDN docs for reference: https://learn.microsoft.com/en-us/cpp/build/reference/zc-referencebinding-enforce-reference-binding-rules?view=msvc-170
The warning referenced in that MSDN article: https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4239?view=msvc-170

MSVC has an extension, that has been enabled by default until very recently when MSVC started their C++ conformance trend, that allows binding a user-defined type temporary to a non-const lvalue.

When trying to port over various large internal windows only tools this became hard as they rely heavily on this extension.
While I am not a fan of this extension changing our code to remove uses of it is quite difficult to do because of how the code is structured.
The end goal is to no longer rely on this extension but at this moment in time it is less bug prone to have clang support this extension and focus on removal sometime in the future after porting to clang.

From the MSDN reference above I did not implement the warning at level 4, C4239, since everyone disables said warning who requires this extension so I felt it wasn't worth the effort. Implementing the MSVC extension is the main requirement.

I also enable this new option with `/permissive` since `/permissive` enables this MSVC extension on MSVC.