### PR TITLE
[clang][CodeGen] Don't crash on output whose size is zero.

### DIFF
--- a/clang/lib/CodeGen/CGStmt.cpp
+++ b/clang/lib/CodeGen/CGStmt.cpp
@@ -2751,7 +2751,10 @@ void CodeGenFunction::EmitAsmStmt(const AsmStmt &S) {
 
       if (RequiresCast) {
         unsigned Size = getContext().getTypeSize(QTy);
-        Ty = llvm::IntegerType::get(getLLVMContext(), Size);
+        if (Size)
+          Ty = llvm::IntegerType::get(getLLVMContext(), Size);
+        else
+          CGM.Error(OutExpr->getExprLoc(), "output size should not be zero");
       }
       ResultRegTypes.push_back(Ty);
       // If this output is tied to an input, and if the input is larger, then

--- a/clang/test/CodeGen/inline-asm-size-zero.c
+++ b/clang/test/CodeGen/inline-asm-size-zero.c
@@ -1,0 +1,6 @@
+// RUN: not %clang_cc1 -S %s -verify -o -
+
+void foo(void) {
+    extern long bar[];
+    asm ("" : "=r"(bar)); // expected-error{{output size should not be zero}}
+}


### PR DESCRIPTION
This fixes issue #63878 caused by creating an integer with zero bitwidth.