### PR TITLE
Replace distutils.version with packaging.version since the former was deprecated in python 3.10 and removed in 3.12.

### DIFF
--- a/cross-project-tests/lit.cfg.py
+++ b/cross-project-tests/lit.cfg.py
@@ -4,9 +4,6 @@ import re
 import subprocess
 import sys
 
-# TODO: LooseVersion is undocumented; use something else.
-from distutils.version import LooseVersion
-
 import lit.formats
 import lit.util
 
@@ -279,7 +276,11 @@ dwarf_version_string = get_clang_default_dwarf_version_string(config.host_triple
 gdb_version_string = get_gdb_version_string()
 if dwarf_version_string and gdb_version_string:
     if int(dwarf_version_string) >= 5:
-        if LooseVersion(gdb_version_string) < LooseVersion("10.1"):
+        try:
+            from packaging import version
+        except:
+            lit_config.fatal("Running gdb tests requires the packaging package")
+        if version.parse(gdb_version_string) < version.parse("10.1"):
             # Example for llgdb-tests, which use lldb on darwin but gdb elsewhere:
             # XFAIL: !system-darwin && gdb-clang-incompatibility
             config.available_features.add("gdb-clang-incompatibility")


### PR DESCRIPTION
Attempt to reland #99549, but using packaging.version instead of looseversion, based on the usage used for LLDB in #93712.

@JDevlieghere and @mysterymath I believe this should already be fine for your bots because you already have the packaging package installed for LLDB correct?

@tlively I used this attempt to reland the change to restructure it as was suggested in #99549 to limit the scope of the import until it is needed.

I have tested this manually on both of my cross-project-test bots, and both pass once I installed the packaging package.