### PR TITLE
Record mainfile name in the Frontend time trace

### DIFF
--- a/clang/lib/Parse/ParseAST.cpp
+++ b/clang/lib/Parse/ParseAST.cpp
@@ -152,7 +152,13 @@ void clang::ParseAST(Sema &S, bool PrintStats, bool SkipFunctionBodies) {
   bool HaveLexer = S.getPreprocessor().getCurrentLexer();
 
   if (HaveLexer) {
-    llvm::TimeTraceScope TimeScope("Frontend");
+    llvm::TimeTraceScope TimeScope("Frontend", [&]() {
+      llvm::TimeTraceMetadata M;
+      const SourceManager &SM = S.getSourceManager();
+      if (const auto *FE = SM.getFileEntryForID(SM.getMainFileID()))
+        M.File = FE->tryGetRealPathName();
+      return M;
+    });
     P.Initialize();
     Parser::DeclGroupPtrTy ADecl;
     Sema::ModuleImportState ImportState;

--- a/clang/lib/Parse/ParseAST.cpp
+++ b/clang/lib/Parse/ParseAST.cpp
@@ -154,9 +154,11 @@ void clang::ParseAST(Sema &S, bool PrintStats, bool SkipFunctionBodies) {
   if (HaveLexer) {
     llvm::TimeTraceScope TimeScope("Frontend", [&]() {
       llvm::TimeTraceMetadata M;
-      const SourceManager &SM = S.getSourceManager();
-      if (const auto *FE = SM.getFileEntryForID(SM.getMainFileID()))
-        M.File = FE->tryGetRealPathName();
+      if (llvm::isTimeTraceVerbose()) {
+        const SourceManager &SM = S.getSourceManager();
+        if (const auto *FE = SM.getFileEntryForID(SM.getMainFileID()))
+          M.File = FE->tryGetRealPathName();
+      }
       return M;
     });
     P.Initialize();

--- a/clang/unittests/Support/TimeProfilerTest.cpp
+++ b/clang/unittests/Support/TimeProfilerTest.cpp
@@ -81,7 +81,6 @@ std::string GetMetadata(json::Object *Event) {
   if (json::Object *Args = Event->getObject("args")) {
     if (auto Detail = Args->getString("detail"))
       OS << Detail;
-    // Use only filename to not include os-specific path separators.
     if (auto File = Args->getString("file"))
       OS << ", " << llvm::sys::path::filename(*File);
     if (auto Line = Args->getInteger("line"))
@@ -209,7 +208,7 @@ constexpr int slow_init_list[] = {1, 1, 2, 3, 5, 8, 13, 21}; // 25th line
   ASSERT_TRUE(compileFromString(Code, "-std=c++20", "test.cc"));
   std::string Json = teardownProfiler();
   ASSERT_EQ(R"(
-Frontend
+Frontend (, test.cc)
 | ParseDeclarationOrFunctionDefinition (test.cc:2:1)
 | ParseDeclarationOrFunctionDefinition (test.cc:6:1)
 | | ParseFunctionDefinition (slow_func)
@@ -266,7 +265,7 @@ TEST(TimeProfilerTest, TemplateInstantiations) {
                                 /*Headers=*/{{"a.h", A_H}, {"b.h", B_H}}));
   std::string Json = teardownProfiler();
   ASSERT_EQ(R"(
-Frontend
+Frontend (, test.cc)
 | ParseFunctionDefinition (fooB)
 | ParseFunctionDefinition (fooMTA)
 | ParseFunctionDefinition (fooA)
@@ -291,7 +290,7 @@ struct {
   ASSERT_TRUE(compileFromString(Code, "-std=c99", "test.c"));
   std::string Json = teardownProfiler();
   ASSERT_EQ(R"(
-Frontend
+Frontend (, test.c)
 | ParseDeclarationOrFunctionDefinition (test.c:2:1)
 | | isIntegerConstantExpr (<test.c:3:18>)
 | | EvaluateKnownConstIntCheckOverflow (<test.c:3:18>)

--- a/clang/unittests/Support/TimeProfilerTest.cpp
+++ b/clang/unittests/Support/TimeProfilerTest.cpp
@@ -76,17 +76,18 @@ bool compileFromString(StringRef Code, StringRef Standard, StringRef File,
 }
 
 std::string GetMetadata(json::Object *Event) {
-  std::string Metadata;
-  llvm::raw_string_ostream OS(Metadata);
+  std::string M;
+  llvm::raw_string_ostream OS(M);
   if (json::Object *Args = Event->getObject("args")) {
     if (auto Detail = Args->getString("detail"))
       OS << Detail;
+    // Use only filename to not include os-specific path separators.
     if (auto File = Args->getString("file"))
-      OS << ", " << llvm::sys::path::filename(*File);
+      OS << (M.empty() ? "" : ", ") << llvm::sys::path::filename(*File);
     if (auto Line = Args->getInteger("line"))
       OS << ":" << *Line;
   }
-  return Metadata;
+  return M;
 }
 
 // Returns pretty-printed trace graph.
@@ -208,7 +209,7 @@ constexpr int slow_init_list[] = {1, 1, 2, 3, 5, 8, 13, 21}; // 25th line
   ASSERT_TRUE(compileFromString(Code, "-std=c++20", "test.cc"));
   std::string Json = teardownProfiler();
   ASSERT_EQ(R"(
-Frontend (, test.cc)
+Frontend (test.cc)
 | ParseDeclarationOrFunctionDefinition (test.cc:2:1)
 | ParseDeclarationOrFunctionDefinition (test.cc:6:1)
 | | ParseFunctionDefinition (slow_func)
@@ -265,7 +266,7 @@ TEST(TimeProfilerTest, TemplateInstantiations) {
                                 /*Headers=*/{{"a.h", A_H}, {"b.h", B_H}}));
   std::string Json = teardownProfiler();
   ASSERT_EQ(R"(
-Frontend (, test.cc)
+Frontend (test.cc)
 | ParseFunctionDefinition (fooB)
 | ParseFunctionDefinition (fooMTA)
 | ParseFunctionDefinition (fooA)
@@ -290,7 +291,7 @@ struct {
   ASSERT_TRUE(compileFromString(Code, "-std=c99", "test.c"));
   std::string Json = teardownProfiler();
   ASSERT_EQ(R"(
-Frontend (, test.c)
+Frontend (test.c)
 | ParseDeclarationOrFunctionDefinition (test.c:2:1)
 | | isIntegerConstantExpr (<test.c:3:18>)
 | | EvaluateKnownConstIntCheckOverflow (<test.c:3:18>)


### PR DESCRIPTION
This is done exactly once (only one Frontend event) and is therefore not expensive and does not require a flag.