### PR TITLE
[libc][CMake] Set library type of libc_diff_test_utils to STATIC

### DIFF
--- a/libc/test/src/math/performance_testing/CMakeLists.txt
+++ b/libc/test/src/math/performance_testing/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_library(
-  libc_diff_test_utils
+  libc_diff_test_utils STATIC
   Timer.cpp
   Timer.h
 )


### PR DESCRIPTION
Fixes linker errors due to hidden symbols when running CMake with
-DBUILD_SHARED_LIBS=ON.
