### PR TITLE
[clang-fuzzer-dictionary] Fix build failure with libfuzzer

### DIFF
--- a/clang/tools/clang-fuzzer/dictionary/CMakeLists.txt
+++ b/clang/tools/clang-fuzzer/dictionary/CMakeLists.txt
@@ -1,3 +1,4 @@
+set(CMAKE_CXX_FLAGS ${CXX_FLAGS_NOFUZZ})
 add_clang_executable(clang-fuzzer-dictionary
   dictionary.c
   )


### PR DESCRIPTION
When building Clang with LLVM_USE_SANITIZE_COVERAGE=ON, libfuzzer is linked against the Clang fuzz targets to inject the main fuzzing loop. The clang-fuzzer-dictionary, which also resides in the same source tree as the fuzz targets, is also linked with -fsanitize=fuzzer because of this.

clang-fuzzer-dictionary is however not an actual fuzz target, but instead just a utilty binary that generates a fuzz dictionary. As it already defines a main function, the main function from libfuzzer causes the build to fail because of the duplicate definitions of main.

This patch just uses the fuzzer-no-link flags already used by the other utility binaries in this directory (i.e., the protobuf utils).