### PR TITLE
[libc] Use `<assert.h>` in overlay mode for LIBC_ASSERT

### DIFF
--- a/libc/src/__support/libc_assert.h
+++ b/libc/src/__support/libc_assert.h
@@ -10,7 +10,7 @@
 #define LLVM_LIBC_SRC___SUPPORT_LIBC_ASSERT_H
 
 #include "src/__support/macros/config.h"
-#ifdef LIBC_COPT_USE_C_ASSERT
+#if defined(LIBC_COPT_USE_C_ASSERT) || !defined(LIBC_FULL_BUILD)
 
 // The build is configured to just use the public <assert.h> API
 // for libc's internal assertions.

--- a/libc/src/__support/threads/linux/raw_mutex.h
+++ b/libc/src/__support/threads/linux/raw_mutex.h
@@ -13,6 +13,7 @@
 #include "src/__support/libc_assert.h"
 #include "src/__support/macros/attributes.h"
 #include "src/__support/macros/config.h"
+#include "src/__support/macros/optimization.h"
 #include "src/__support/threads/linux/futex_utils.h"
 #include "src/__support/threads/linux/futex_word.h"
 #include "src/__support/threads/sleep.h"


### PR DESCRIPTION
Summary:
This uses `internal::exit` which is not built in overlay mode, leading
to linker errors. Fix this to just use `assert.h`.
