### PR TITLE
[libc] Change fsfilcnt_t and fsblkcnt_t to be 64-bits long

### DIFF
--- a/libc/include/llvm-libc-types/fsblkcnt_t.h
+++ b/libc/include/llvm-libc-types/fsblkcnt_t.h
@@ -9,6 +9,6 @@
 #ifndef LLVM_LIBC_TYPES_FSBLKCNT_T_H
 #define LLVM_LIBC_TYPES_FSBLKCNT_T_H
 
-typedef __SIZE_TYPE__ fsblkcnt_t;
+typedef __UINT64_TYPE__ fsblkcnt_t;
 
 #endif // LLVM_LIBC_TYPES_FSBLKCNT_T_H

--- a/libc/include/llvm-libc-types/fsfilcnt_t.h
+++ b/libc/include/llvm-libc-types/fsfilcnt_t.h
@@ -9,6 +9,6 @@
 #ifndef LLVM_LIBC_TYPES_FSFILCNT_T_H
 #define LLVM_LIBC_TYPES_FSFILCNT_T_H
 
-typedef __SIZE_TYPE__ fsfilcnt_t;
+typedef __UINT64_TYPE__ fsfilcnt_t;
 
 #endif // LLVM_LIBC_TYPES_FSFILCNT_T_H


### PR DESCRIPTION
In 32-bit systems with 64-bit offsets, both fsfilcnt_t and fsblkcnt_t are 64-bit long, just like 64-bit systems. This patch changes both types to be 64-bit long for all platforms and follows the reasoning used to change off_t: the standard only requires it to be an unsigned int, so making it 64-bit long doesn't violate this property.

It should be NFC for 64-bit systems.