### PR TITLE
[Sema] Default arguments for template parameters affect ContainsUnexpandedPacks

### DIFF
--- a/clang/lib/AST/DeclTemplate.cpp
+++ b/clang/lib/AST/DeclTemplate.cpp
@@ -44,14 +44,13 @@ using namespace clang;
 // TemplateParameterList Implementation
 //===----------------------------------------------------------------------===//
 
-
 namespace {
-template<class TemplateParam>
-bool DefaultArgumentContainsUnexpandedPack(const TemplateParam& P) {
+template <class TemplateParam>
+bool DefaultArgumentContainsUnexpandedPack(const TemplateParam &P) {
   return P.hasDefaultArgument() &&
          P.getDefaultArgument().getArgument().containsUnexpandedParameterPack();
 }
-}
+} // namespace
 
 TemplateParameterList::TemplateParameterList(const ASTContext& C,
                                              SourceLocation TemplateLoc,

--- a/clang/lib/AST/DeclTemplate.cpp
+++ b/clang/lib/AST/DeclTemplate.cpp
@@ -45,6 +45,14 @@ using namespace clang;
 //===----------------------------------------------------------------------===//
 
 
+namespace {
+template<class TemplateParam>
+bool DefaultArgumentContainsUnexpandedPack(const TemplateParam& P) {
+  return P.hasDefaultArgument() &&
+         P.getDefaultArgument().getArgument().containsUnexpandedParameterPack();
+}
+}
+
 TemplateParameterList::TemplateParameterList(const ASTContext& C,
                                              SourceLocation TemplateLoc,
                                              SourceLocation LAngleLoc,
@@ -64,10 +72,7 @@ TemplateParameterList::TemplateParameterList(const ASTContext& C,
       if (!IsPack) {
         if (NTTP->getType()->containsUnexpandedParameterPack())
           ContainsUnexpandedParameterPack = true;
-        else if (NTTP->hasDefaultArgument() &&
-                 NTTP->getDefaultArgument()
-                     .getArgument()
-                     .containsUnexpandedParameterPack())
+        else if (DefaultArgumentContainsUnexpandedPack(*NTTP))
           ContainsUnexpandedParameterPack = true;
       }
       if (NTTP->hasPlaceholderTypeConstraint())
@@ -76,17 +81,11 @@ TemplateParameterList::TemplateParameterList(const ASTContext& C,
       if (!IsPack) {
         if (TTP->getTemplateParameters()->containsUnexpandedParameterPack())
           ContainsUnexpandedParameterPack = true;
-        else if (TTP->hasDefaultArgument() &&
-                 TTP->getDefaultArgument()
-                     .getArgument()
-                     .containsUnexpandedParameterPack())
+        else if (DefaultArgumentContainsUnexpandedPack(*TTP))
           ContainsUnexpandedParameterPack = true;
       }
     } else if (const auto *TTP = dyn_cast<TemplateTypeParmDecl>(P)) {
-      if (!IsPack && TTP->hasDefaultArgument() &&
-          TTP->getDefaultArgument()
-              .getArgument()
-              .containsUnexpandedParameterPack()) {
+      if (!IsPack && DefaultArgumentContainsUnexpandedPack(*TTP)) {
         ContainsUnexpandedParameterPack = true;
       } else if (const TypeConstraint *TC = TTP->getTypeConstraint();
                  TC && TC->getImmediatelyDeclaredConstraint()

--- a/clang/lib/AST/DeclTemplate.cpp
+++ b/clang/lib/AST/DeclTemplate.cpp
@@ -44,13 +44,12 @@ using namespace clang;
 // TemplateParameterList Implementation
 //===----------------------------------------------------------------------===//
 
-namespace {
 template <class TemplateParam>
-bool DefaultArgumentContainsUnexpandedPack(const TemplateParam &P) {
+static bool
+DefaultTemplateArgumentContainsUnexpandedPack(const TemplateParam &P) {
   return P.hasDefaultArgument() &&
          P.getDefaultArgument().getArgument().containsUnexpandedParameterPack();
 }
-} // namespace
 
 TemplateParameterList::TemplateParameterList(const ASTContext& C,
                                              SourceLocation TemplateLoc,
@@ -69,18 +68,18 @@ TemplateParameterList::TemplateParameterList(const ASTContext& C,
     bool IsPack = P->isTemplateParameterPack();
     if (const auto *NTTP = dyn_cast<NonTypeTemplateParmDecl>(P)) {
       if (!IsPack && (NTTP->getType()->containsUnexpandedParameterPack() ||
-                      DefaultArgumentContainsUnexpandedPack(*NTTP)))
+                      DefaultTemplateArgumentContainsUnexpandedPack(*NTTP)))
         ContainsUnexpandedParameterPack = true;
       if (NTTP->hasPlaceholderTypeConstraint())
         HasConstrainedParameters = true;
     } else if (const auto *TTP = dyn_cast<TemplateTemplateParmDecl>(P)) {
       if (!IsPack &&
           (TTP->getTemplateParameters()->containsUnexpandedParameterPack() ||
-           DefaultArgumentContainsUnexpandedPack(*TTP))) {
+           DefaultTemplateArgumentContainsUnexpandedPack(*TTP))) {
         ContainsUnexpandedParameterPack = true;
       }
     } else if (const auto *TTP = dyn_cast<TemplateTypeParmDecl>(P)) {
-      if (!IsPack && DefaultArgumentContainsUnexpandedPack(*TTP)) {
+      if (!IsPack && DefaultTemplateArgumentContainsUnexpandedPack(*TTP)) {
         ContainsUnexpandedParameterPack = true;
       } else if (const TypeConstraint *TC = TTP->getTypeConstraint();
                  TC && TC->getImmediatelyDeclaredConstraint()

--- a/clang/lib/AST/DeclTemplate.cpp
+++ b/clang/lib/AST/DeclTemplate.cpp
@@ -68,20 +68,16 @@ TemplateParameterList::TemplateParameterList(const ASTContext& C,
 
     bool IsPack = P->isTemplateParameterPack();
     if (const auto *NTTP = dyn_cast<NonTypeTemplateParmDecl>(P)) {
-      if (!IsPack) {
-        if (NTTP->getType()->containsUnexpandedParameterPack())
-          ContainsUnexpandedParameterPack = true;
-        else if (DefaultArgumentContainsUnexpandedPack(*NTTP))
-          ContainsUnexpandedParameterPack = true;
-      }
+      if (!IsPack && (NTTP->getType()->containsUnexpandedParameterPack() ||
+                      DefaultArgumentContainsUnexpandedPack(*NTTP)))
+        ContainsUnexpandedParameterPack = true;
       if (NTTP->hasPlaceholderTypeConstraint())
         HasConstrainedParameters = true;
     } else if (const auto *TTP = dyn_cast<TemplateTemplateParmDecl>(P)) {
-      if (!IsPack) {
-        if (TTP->getTemplateParameters()->containsUnexpandedParameterPack())
-          ContainsUnexpandedParameterPack = true;
-        else if (DefaultArgumentContainsUnexpandedPack(*TTP))
-          ContainsUnexpandedParameterPack = true;
+      if (!IsPack &&
+          (TTP->getTemplateParameters()->containsUnexpandedParameterPack() ||
+           DefaultArgumentContainsUnexpandedPack(*TTP))) {
+        ContainsUnexpandedParameterPack = true;
       }
     } else if (const auto *TTP = dyn_cast<TemplateTypeParmDecl>(P)) {
       if (!IsPack && DefaultArgumentContainsUnexpandedPack(*TTP)) {


### PR DESCRIPTION
This addresses the FIXME in the code. There will be tests for the new behavior in an upcoming #86265, which also addresses other bugs that prevent exposing the wrong results of `ContainsUnexpandedPacks` in the outputs of the compiler without crashes.