### PR TITLE
[Sema] Fix computations of "unexpanded packs" in substituted lambdas

### DIFF
--- a/clang/include/clang/AST/ComputeDependence.h
+++ b/clang/include/clang/AST/ComputeDependence.h
@@ -166,7 +166,7 @@ ExprDependence computeDependence(CXXTemporaryObjectExpr *E);
 ExprDependence computeDependence(CXXDefaultInitExpr *E);
 ExprDependence computeDependence(CXXDefaultArgExpr *E);
 ExprDependence computeDependence(LambdaExpr *E,
-                                 bool ContainsUnexpandedParameterPack);
+                                 bool BodyContainsUnexpandedPacks);
 ExprDependence computeDependence(CXXUnresolvedConstructExpr *E);
 ExprDependence computeDependence(CXXDependentScopeMemberExpr *E);
 ExprDependence computeDependence(MaterializeTemporaryExpr *E);

--- a/clang/include/clang/AST/ExprCXX.h
+++ b/clang/include/clang/AST/ExprCXX.h
@@ -1975,7 +1975,8 @@ class LambdaExpr final : public Expr,
              LambdaCaptureDefault CaptureDefault,
              SourceLocation CaptureDefaultLoc, bool ExplicitParams,
              bool ExplicitResultType, ArrayRef<Expr *> CaptureInits,
-             SourceLocation ClosingBrace, bool ContainsUnexpandedParameterPack);
+             SourceLocation ClosingBrace,
+             bool BodyContainsUnexpandedParameterPack);
 
   /// Construct an empty lambda expression.
   LambdaExpr(EmptyShell Empty, unsigned NumCaptures);
@@ -1996,7 +1997,7 @@ public:
          LambdaCaptureDefault CaptureDefault, SourceLocation CaptureDefaultLoc,
          bool ExplicitParams, bool ExplicitResultType,
          ArrayRef<Expr *> CaptureInits, SourceLocation ClosingBrace,
-         bool ContainsUnexpandedParameterPack);
+         bool BodyContainsUnexpandedParameterPack);
 
   /// Construct a new lambda expression that will be deserialized from
   /// an external source.
@@ -4854,15 +4855,7 @@ public:
   CXXFoldExpr(QualType T, UnresolvedLookupExpr *Callee,
               SourceLocation LParenLoc, Expr *LHS, BinaryOperatorKind Opcode,
               SourceLocation EllipsisLoc, Expr *RHS, SourceLocation RParenLoc,
-              std::optional<unsigned> NumExpansions)
-      : Expr(CXXFoldExprClass, T, VK_PRValue, OK_Ordinary),
-        LParenLoc(LParenLoc), EllipsisLoc(EllipsisLoc), RParenLoc(RParenLoc),
-        NumExpansions(NumExpansions ? *NumExpansions + 1 : 0), Opcode(Opcode) {
-    SubExprs[SubExpr::Callee] = Callee;
-    SubExprs[SubExpr::LHS] = LHS;
-    SubExprs[SubExpr::RHS] = RHS;
-    setDependence(computeDependence(this));
-  }
+              std::optional<unsigned> NumExpansions);
 
   CXXFoldExpr(EmptyShell Empty) : Expr(CXXFoldExprClass, Empty) {}
 

--- a/clang/include/clang/Sema/ScopeInfo.h
+++ b/clang/include/clang/Sema/ScopeInfo.h
@@ -895,8 +895,9 @@ public:
   /// Whether any of the capture expressions requires cleanups.
   CleanupInfo Cleanup;
 
-  /// Whether the lambda contains an unexpanded parameter pack.
-  bool ContainsUnexpandedParameterPack = false;
+  /// Whether the lambda body contains an unexpanded parameter pack.
+  /// Note that the captures and template paramters are handled separately.
+  bool BodyContainsUnexpandedParameterPack = false;
 
   /// Packs introduced by this lambda, if any.
   SmallVector<NamedDecl*, 4> LocalPacks;

--- a/clang/lib/Sema/SemaTemplateVariadic.cpp
+++ b/clang/lib/Sema/SemaTemplateVariadic.cpp
@@ -353,7 +353,11 @@ Sema::DiagnoseUnexpandedParameterPacks(SourceLocation Loc,
       }
 
       if (!EnclosingStmtExpr) {
-        LSI->ContainsUnexpandedParameterPack = true;
+        // It is ok to have unexpanded packs in captures, template parameters
+        // and parameters too, but only the body statement does not store this
+        // flag, so we have to propagate it through LamdaScopeInfo.
+        if (LSI->AfterParameterList)
+          LSI->BodyContainsUnexpandedParameterPack = true;
         return false;
       }
     } else {

--- a/clang/test/SemaCXX/fold_lambda_with_variadics.cpp
+++ b/clang/test/SemaCXX/fold_lambda_with_variadics.cpp
@@ -1,0 +1,78 @@
+// RUN: %clang_cc1 -fsyntax-only -std=c++20 -verify %s
+// expected-no-diagnostics
+struct tuple {
+    int x[3];
+};
+
+template <class F>
+int apply(F f, tuple v) {
+    return f(v.x[0], v.x[1], v.x[2]);
+}
+
+int Cartesian1(auto x, auto y) {
+    return apply([&](auto... xs) {
+        return (apply([xs](auto... ys) {
+            return (ys + ...);
+        }, y) + ...);
+    }, x);
+}
+
+int Cartesian2(auto x, auto y) {
+    return apply([&](auto... xs) {
+        return (apply([zs = xs](auto... ys) {
+            return (ys + ...);
+        }, y) + ...);
+    }, x);
+}
+
+template <int ...> struct Ints{};
+template <int> struct Choose {
+  template<class> struct Templ;
+};
+template <int ...x>
+int Cartesian3(auto y) {
+    return [&]<int ...xs>(Ints<xs...>) {
+        // check in default template arguments for
+        // - type template parameters,
+        (void)(apply([]<class = decltype(xs)>(auto... ys) {
+          return (ys + ...);
+        }, y) + ...);
+        // - template template parameters.
+        (void)(apply([]<template<class> class = Choose<xs>::template Templ>(auto... ys) {
+          return (ys + ...);
+        }, y) + ...);
+        // - non-type template parameters,
+        return (apply([]<int = xs>(auto... ys) {
+            return (ys + ...);
+        }, y) + ...);
+
+    }(Ints<x...>());
+}
+
+template <int ...x>
+int Cartesian4(auto y) {
+    return [&]<int ...xs>(Ints<xs...>) {
+        return (apply([]<decltype(xs) xx = 1>(auto... ys) {
+            return (ys + ...);
+        }, y) + ...);
+    }(Ints<x...>());
+}
+
+int Cartesian5(auto x, auto y) {
+    return apply([&](auto... xs) {
+        return (apply([](auto... ys) __attribute__((diagnose_if(!__is_same(decltype(xs), int), "message", "error"))) {
+            return (ys + ...);
+        }, y) + ...);
+    }, x);
+}
+
+
+int main() {
+    auto x = tuple({1, 2, 3});
+    auto y = tuple({4, 5, 6});
+    Cartesian1(x, y);
+    Cartesian2(x, y);
+    Cartesian3<1,2,3>(y);
+    Cartesian4<1,2,3>(y);
+    Cartesian5(x, y);
+}


### PR DESCRIPTION
This addresses a crash in https://github.com/llvm/llvm-project/issues/99877 that happens on nested lambdas that use
template parameter packs, see the added test.

Before this patch, the code computing the 'ContainsUnexpandedPacks' was
relying on a flag from `LambdaScopeInfo`, that was updated differently
in parsing and template substitution.
This led to a discrepancy in how template parameters and captures that
contain unexpanded packs were handled. In particular, the substitution
missed some cases where it was supposed to mark the lambda as containing
unexpanded packs.
In turn, this lead to invalid state when the corresponding lambda was used
to create a substituted `CXXFoldExpr` as `CXXFoldExpr` relies on this
particular flag to distinguish left and right folds, and the code using
it relies on `getPattern` to have unexpanded packs. The latter was
causing assertion failures and subsequent crashes in non-assertion
builds.

This commit addresses those issues by moving the code computing
`ContainsUnexpandedPack` value into `ComputeDependence.cpp` and relying
on structurally checking the dependencies of various components that
substitute a lambda expression instead of relying on the code parity
between parsing and template substitution.
This should help to avoid issues like this in the future, as checking
the correctness of structural code is much easier than ensuring that
global state manipulation is correct across two versions of the code.
It's also all in one file, as opposed to being spread to multiple files.

The only exception to this rule right now is the lambda body, as
statements do not carry around any dependency flags and we have to rely
on the global state for them.

Another tricky case is attributes, one of which was actually checked in
the tests (`diagnose_if`). The new code path handles only `diagnose_if`,
but the long-term solution there would likely be propagating the
`ContainsUnexpandedPack` flag into `Attr`, similar to the
`Attr::IsPackExpansion` flag we already have. Previously, the code
examples like the one in the added test would crash on all attributes.
However, simpler examples used to work and will now report an error if
used inside fold expressions. This is a potential regression, but it
also seems very rare and I think we can address it in a follow up.

Lastly, this commit adds an asssertion that exactly one of the arguments
to `CXXFoldExpr` contains an unexpanded parameter pack. It should help
catch issues like this.