### PR TITLE
[lldb] Change GetStartSymbol to GetStartAddress in DynamicLoader

### DIFF
--- a/lldb/include/lldb/Target/DynamicLoader.h
+++ b/lldb/include/lldb/Target/DynamicLoader.h
@@ -9,8 +9,8 @@
 #ifndef LLDB_TARGET_DYNAMICLOADER_H
 #define LLDB_TARGET_DYNAMICLOADER_H
 
+#include "lldb/Core/Address.h"
 #include "lldb/Core/PluginInterface.h"
-#include "lldb/Symbol/Symbol.h"
 #include "lldb/Utility/FileSpec.h"
 #include "lldb/Utility/Status.h"
 #include "lldb/Utility/UUID.h"
@@ -25,6 +25,7 @@ namespace lldb_private {
 class ModuleList;
 class Process;
 class SectionList;
+class Symbol;
 class SymbolContext;
 class SymbolContextList;
 class Thread;
@@ -329,10 +330,10 @@ public:
   /// safe to call certain APIs or SPIs.
   virtual bool IsFullyInitialized() { return true; }
 
-  /// Return the `start` function \b symbol in the dynamic loader module.
-  /// This is the symbol the process will begin executing with
+  /// Return the `start` \b address in the dynamic loader module.
+  /// This is the address the process will begin executing with
   /// `process launch --stop-at-entry`.
-  virtual std::optional<lldb_private::Symbol> GetStartSymbol() {
+  virtual std::optional<lldb_private::Address> GetStartAddress() {
     return std::nullopt;
   }
 

--- a/lldb/source/Plugins/DynamicLoader/MacOSX-DYLD/DynamicLoaderDarwin.cpp
+++ b/lldb/source/Plugins/DynamicLoader/MacOSX-DYLD/DynamicLoaderDarwin.cpp
@@ -609,7 +609,7 @@ void DynamicLoaderDarwin::UpdateDYLDImageInfoFromNewImageInfo(
   }
 }
 
-std::optional<lldb_private::Symbol> DynamicLoaderDarwin::GetStartSymbol() {
+std::optional<lldb_private::Address> DynamicLoaderDarwin::GetStartAddress() {
   Log *log = GetLog(LLDBLog::DynamicLoader);
 
   auto log_err = [log](llvm::StringLiteral err_msg) -> std::nullopt_t {
@@ -626,7 +626,7 @@ std::optional<lldb_private::Symbol> DynamicLoaderDarwin::GetStartSymbol() {
   if (!symbol)
     return log_err("Cannot find `start` symbol in DYLD module.");
 
-  return *symbol;
+  return symbol->GetAddress();
 }
 
 void DynamicLoaderDarwin::SetDYLDModule(lldb::ModuleSP &dyld_module_sp) {

--- a/lldb/source/Plugins/DynamicLoader/MacOSX-DYLD/DynamicLoaderDarwin.h
+++ b/lldb/source/Plugins/DynamicLoader/MacOSX-DYLD/DynamicLoaderDarwin.h
@@ -56,6 +56,8 @@ public:
 
   virtual bool NeedToDoInitialImageFetch() = 0;
 
+  std::optional<lldb_private::Address> GetStartAddress() override;
+
 protected:
   void PrivateInitialize(lldb_private::Process *process);
 
@@ -66,8 +68,6 @@ protected:
 
   // Clear method for classes derived from this one
   virtual void DoClear() = 0;
-
-  std::optional<lldb_private::Symbol> GetStartSymbol() override;
 
   void SetDYLDModule(lldb::ModuleSP &dyld_module_sp);
 


### PR DESCRIPTION
On linux, the start address doesn't necessarily have a symbol attached to it.

This is why this patch replaces `DynamicLoader::GetStartSymbol` with `DynamicLoader::GetStartAddress` instead to make it more generic.