### PR TITLE
[libcxx] don't `#include <cwchar>` if wide chars aren't enabled

### DIFF
--- a/libcxx/include/format
+++ b/libcxx/include/format
@@ -237,21 +237,21 @@ namespace std {
 #  include <cstdint>
 #  include <cstdlib>
 #  include <cstring>
-#  include <cwchar>
 #  include <initializer_list>
 #  include <limits>
+#  include <locale>
 #  include <new>
 #  include <optional>
+#  include <queue>
+#  include <stack>
 #  include <stdexcept>
 #  include <string>
 #  include <string_view>
 #  include <tuple>
-#endif
 
-#if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
-#  include <locale>
-#  include <queue>
-#  include <stack>
+#  if !defined(_LIBCPP_HAS_NO_WIDE_CHARACTERS)
+#    include <cwchar>
+#  endif
 #endif
 
 #endif // _LIBCPP_FORMAT


### PR DESCRIPTION
Pull request #96032 unconditionall adds the `cwchar` include in the `format` umbrella header. However support for wchar_t can be disabled in the build system (LIBCXX_ENABLE_WIDE_CHARACTERS).

This patch guards against inclusion of `cwchar` in `format` by checking the `_LIBCPP_HAS_NO_WIDE_CHARACTERS` define.

For clarity I've also merged the include header section that `cwchar` was in with the one above as they were both guarded by the same `#if` logic.