### PR TITLE
lldb: android: fix missing Python import of urlparse in lldb test utilities

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/lldbplatformutil.py
+++ b/lldb/packages/Python/lldbsuite/test/lldbplatformutil.py
@@ -9,6 +9,7 @@ import subprocess
 import sys
 import os
 from packaging import version
+from urllib.parse import urlparse
 
 # LLDB modules
 import lldb


### PR DESCRIPTION
## Issue
Attempting to run the lldb API tests against a remote-android target fails with the error `NameError: name 'urlparse' is not defined`.

## Root Cause
It looks the Python import of `urlparse` was removed by mistake in 22ea97d7bfd65abf68a68b13bf96ad69be23df54. This import is only used when running the lldb API tests against a remote-android target so it went unnoticed.

## Fix
This change simply puts back the missing import. It is a one line change.

fixes #99931

## Validation
Tested on Fedora 39 with an attached Android device:

`cd llvm-project`
`cmake -S llvm -B build -G Ninja -DLLVM_ENABLE_PROJECTS='clang;lldb' -DCMAKE_BUILD_TYPE=Release -DLLDB_ENABLE_PYTHON=On`
`ninja -C build`
`./build/bin/lldb-dotest --arch aarch64 --out-of-tree-debugserver --platform-name=remote-android --platform-working-dir=/data/local/tmp/ds2 --platform-url=connect://localhost:5432 --compiler ~/Android/Sdk/ndk/21.4.7075529/toolchains/llvm/prebuilt/linux-x86_64/bin/clang`