### PR TITLE
[DAG] ComputeNumSignBits - subo_carry(x,x,c) -> bitwidth 'allsignbits'

### DIFF
--- a/llvm/lib/CodeGen/SelectionDAG/SelectionDAG.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/SelectionDAG.cpp
@@ -4705,14 +4705,18 @@ unsigned SelectionDAG::ComputeNumSignBits(SDValue Op, const APInt &DemandedElts,
       return 1;  // Early out.
     Tmp2 = ComputeNumSignBits(Op.getOperand(1), DemandedElts, Depth + 1);
     return std::min(Tmp, Tmp2);
+  case ISD::SSUBO_CARRY:
+  case ISD::USUBO_CARRY:
+    // sub_carry(x,x,c) -> 0/-1 (sext carry)
+    if (Op.getResNo() == 0 && Op.getOperand(0) == Op.getOperand(1))
+      return VTBits;
+    [[fallthrough]];
   case ISD::SADDO:
   case ISD::UADDO:
   case ISD::SADDO_CARRY:
   case ISD::UADDO_CARRY:
   case ISD::SSUBO:
   case ISD::USUBO:
-  case ISD::SSUBO_CARRY:
-  case ISD::USUBO_CARRY:
   case ISD::SMULO:
   case ISD::UMULO:
     if (Op.getResNo() != 1)

--- a/llvm/test/CodeGen/AArch64/neon-abd.ll
+++ b/llvm/test/CodeGen/AArch64/neon-abd.ll
@@ -332,8 +332,6 @@ define <2 x i64> @uabd_2d(<2 x i64> %a, <2 x i64> %b) #0 {
 ; CHECK-NEXT:    ngc x9, xzr
 ; CHECK-NEXT:    subs x10, x10, x11
 ; CHECK-NEXT:    ngc x11, xzr
-; CHECK-NEXT:    asr x9, x9, #63
-; CHECK-NEXT:    asr x11, x11, #63
 ; CHECK-NEXT:    eor x8, x8, x9
 ; CHECK-NEXT:    eor x10, x10, x11
 ; CHECK-NEXT:    sub x8, x8, x9

--- a/llvm/test/CodeGen/ARM/neon_vabd.ll
+++ b/llvm/test/CodeGen/ARM/neon_vabd.ll
@@ -340,20 +340,20 @@ define <2 x i64> @uabd_2d(<2 x i64> %a, <2 x i64> %b) {
 ; CHECK-NEXT:    sbcs r2, r3, r12
 ; CHECK-NEXT:    sbcs r3, r1, #0
 ; CHECK-NEXT:    sbc r3, r1, #0
-; CHECK-NEXT:    eor r0, r0, r3, asr #31
-; CHECK-NEXT:    eor r2, r2, r3, asr #31
-; CHECK-NEXT:    subs r0, r0, r3, asr #31
-; CHECK-NEXT:    sbc r2, r2, r3, asr #31
+; CHECK-NEXT:    eor r0, r0, r3
+; CHECK-NEXT:    eor r2, r2, r3
+; CHECK-NEXT:    subs r0, r0, r3
+; CHECK-NEXT:    sbc r2, r2, r3
 ; CHECK-NEXT:    subs r3, r4, lr
 ; CHECK-NEXT:    sbcs r6, r5, r6
 ; CHECK-NEXT:    vmov.32 d1[0], r0
 ; CHECK-NEXT:    sbcs r5, r1, #0
 ; CHECK-NEXT:    sbc r1, r1, #0
-; CHECK-NEXT:    eor r3, r3, r1, asr #31
-; CHECK-NEXT:    subs r0, r3, r1, asr #31
+; CHECK-NEXT:    eor r3, r3, r1
+; CHECK-NEXT:    subs r0, r3, r1
 ; CHECK-NEXT:    vmov.32 d0[0], r0
-; CHECK-NEXT:    eor r0, r6, r1, asr #31
-; CHECK-NEXT:    sbc r0, r0, r1, asr #31
+; CHECK-NEXT:    eor r0, r6, r1
+; CHECK-NEXT:    sbc r0, r0, r1
 ; CHECK-NEXT:    vmov.32 d1[1], r2
 ; CHECK-NEXT:    vmov.32 d0[1], r0
 ; CHECK-NEXT:    pop {r4, r5, r6, pc}

--- a/llvm/test/CodeGen/X86/abdu.ll
+++ b/llvm/test/CodeGen/X86/abdu.ll
@@ -289,7 +289,6 @@ define i64 @abd_ext_i64(i64 %a, i64 %b) nounwind {
 ; X86-NEXT:    movl $0, %esi
 ; X86-NEXT:    sbbl %esi, %esi
 ; X86-NEXT:    sbbl %ecx, %ecx
-; X86-NEXT:    sarl $31, %ecx
 ; X86-NEXT:    xorl %ecx, %edx
 ; X86-NEXT:    xorl %ecx, %eax
 ; X86-NEXT:    subl %ecx, %eax
@@ -325,7 +324,6 @@ define i64 @abd_ext_i64_undef(i64 %a, i64 %b) nounwind {
 ; X86-NEXT:    movl $0, %esi
 ; X86-NEXT:    sbbl %esi, %esi
 ; X86-NEXT:    sbbl %ecx, %ecx
-; X86-NEXT:    sarl $31, %ecx
 ; X86-NEXT:    xorl %ecx, %edx
 ; X86-NEXT:    xorl %ecx, %eax
 ; X86-NEXT:    subl %ecx, %eax


### PR DESCRIPTION
Handle cases where the subo_carry is subtracting the same operand (=zero) - so only the subtraction of the 0/1 carry bit is affecting the result, giving a 0/-1 allsignbits value.

Noticed while improving ABDS/ABDU expansion.