### PR TITLE
[lldb][debugserver] Retry sleep(0.25s) when interrupted

### DIFF
--- a/lldb/tools/debugserver/source/MacOSX/MachProcess.mm
+++ b/lldb/tools/debugserver/source/MacOSX/MachProcess.mm
@@ -2846,9 +2846,12 @@ pid_t MachProcess::AttachForDebug(
     if (err.Success()) {
       m_flags |= eMachProcessFlagsAttached;
       // Sleep a bit to let the exception get received and set our process
-      // status
-      // to stopped.
-      ::usleep(250000);
+      // status to stopped.
+      int max_retry = 4;
+      do {
+        errno = 0;
+        usleep(250000); // If our 0.25 second sleep is interrupted, redo
+      } while (errno == EINTR && --max_retry > 0);
       DNBLog("[LaunchAttach] (%d) Done napping after ptrace(PT_ATTACHEXC)'ing",
              getpid());
       DNBLogThreadedIf(LOG_PROCESS, "successfully attached to pid %d", pid);


### PR DESCRIPTION
After lldb has ptrace()'ed the process, it sleeps for 0.25 seconds before trying to pause the process.  We see logging that in some rare cases, this sleep is interrupted and the pause fails, the attach fails.  usleep(3) says that the only errno it will return is EINTR if interrupted, so retry on that case.  I capped it at four retries so the process can't hang infinitely if it's being spammed with asynchronous signals.

I don't know what environment setup results in this behavior, it's only rarely seen by end users and we see evidence, after the fact of it, in logging.

rdar://130562344