### PR TITLE
[Clang] prevent assertion failure by skipping analysis of invalid field declaration

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -1105,6 +1105,7 @@ Bug Fixes to C++ Support
 - Clang now diagnoses explicit object parameters in member pointers and other contexts where they should not appear.
   Fixes (#GH85992).
 - Fixed a crash-on-invalid bug involving extraneous template parameter with concept substitution. (#GH73885)
+- Fixed assertion failure by skipping the analysis of an invalid field declaration. (#GH99868)
 
 Bug Fixes to AST Handling
 ^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/clang/lib/AST/DeclCXX.cpp
+++ b/clang/lib/AST/DeclCXX.cpp
@@ -675,6 +675,9 @@ bool CXXRecordDecl::hasSubobjectAtOffsetZeroOfEmptyBaseType(
       if (!IsFirstField && !FD->isZeroSize(Ctx))
         continue;
 
+      if (FD->isInvalidDecl())
+        continue;
+
       //   -- If X is n array type, [visit the element type]
       QualType T = Ctx.getBaseElementType(FD->getType());
       if (auto *RD = T->getAsCXXRecordDecl())

--- a/clang/test/CXX/temp/temp.arg/temp.arg.template/p3-0x.cpp
+++ b/clang/test/CXX/temp/temp.arg/temp.arg.template/p3-0x.cpp
@@ -38,3 +38,13 @@ X1<int, X1a> inst_x1a;
 X1<long, X1b> inst_x1b;
 X1<short, X1c> inst_x1c;
 X1<short, X1d> inst_x1d; // expected-error{{template template argument has different template parameters than its corresponding template template paramete}}
+
+template <int> class X2; // expected-note{{template is declared here}} \
+                         // expected-note{{template is declared here}}
+class X3 : X2<1> {}; // expected-error{{implicit instantiation of undefined template 'X2<1>'}}
+
+template <int> class X4 : X3 {
+  struct {
+    X2<1> e; // expected-error{{implicit instantiation of undefined template 'X2<1>'}}
+  } f;
+};


### PR DESCRIPTION
Fixes #99868