### PR TITLE
Replace |& with 2>&1 in ignore_free_hooks test.

### DIFF
--- a/compiler-rt/test/asan/TestCases/Posix/ignore_free_hook.cpp
+++ b/compiler-rt/test/asan/TestCases/Posix/ignore_free_hook.cpp
@@ -1,15 +1,15 @@
 // RUN: %clangxx_asan -O2 %s -o %t -DTEST=basic_hook_works && not %run %t \
-// RUN:   |& FileCheck %s -check-prefix=CHECK-BASIC
+// RUN:   2>&1 | FileCheck %s -check-prefix=CHECK-BASIC
 // RUN: %clangxx_asan -O2 %s -o %t -DTEST=ignore && %run %t \
-// RUN:   |& FileCheck %s -check-prefix=CHECK-IGNORE
+// RUN:   2>&1 | FileCheck %s -check-prefix=CHECK-IGNORE
 // RUN: %clangxx_asan -O2 %s -o %t -DTEST=ignore_twice && not %run %t \
-// RUN:   |& FileCheck %s -check-prefix=CHECK-IGNORE-2
+// RUN:   2>&1 | FileCheck %s -check-prefix=CHECK-IGNORE-2
 // RUN: %clangxx_asan -O2 %s -o %t -DTEST=mismatch && %env_asan_opts=alloc_dealloc_mismatch=1 not %run %t \
-// RUN:   |& FileCheck %s -check-prefix=CHECK-MISMATCH
+// RUN:   2>&1 | FileCheck %s -check-prefix=CHECK-MISMATCH
 // RUN: %clangxx_asan -O2 %s -o %t -DTEST=ignore_mismatch && %env_asan_opts=alloc_dealloc_mismatch=1 %run %t \
-// RUN:   |& FileCheck %s -check-prefix=CHECK-IGNORE-MISMATCH
+// RUN:   2>&1 | FileCheck %s -check-prefix=CHECK-IGNORE-MISMATCH
 // RUN: %clangxx_asan -O2 %s -o %t -DTEST=double_delete && not %run %t \
-// RUN:   |& FileCheck %s -check-prefix=CHECK-DOUBLE-DELETE
+// RUN:   2>&1 | FileCheck %s -check-prefix=CHECK-DOUBLE-DELETE
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/compiler-rt/test/hwasan/TestCases/Posix/ignore_free_hook.cpp
+++ b/compiler-rt/test/hwasan/TestCases/Posix/ignore_free_hook.cpp
@@ -1,11 +1,11 @@
 // RUN: %clangxx_hwasan -O2 %s -o %t -DTEST=basic_hook_works && not %run %t \
-// RUN:   |& FileCheck %s -check-prefix=CHECK-BASIC
+// RUN:   2>&1 | FileCheck %s -check-prefix=CHECK-BASIC
 // RUN: %clangxx_hwasan -O2 %s -o %t -DTEST=ignore && %run %t \
-// RUN:   |& FileCheck %s -check-prefix=CHECK-IGNORE
+// RUN:   2>&1 | FileCheck %s -check-prefix=CHECK-IGNORE
 // RUN: %clangxx_hwasan -O2 %s -o %t -DTEST=ignore_twice && not %run %t \
-// RUN:   |& FileCheck %s -check-prefix=CHECK-IGNORE-2
+// RUN:   2>&1 | FileCheck %s -check-prefix=CHECK-IGNORE-2
 // RUN: %clangxx_hwasan -O2 %s -o %t -DTEST=double_delete && not %run %t \
-// RUN:   |& FileCheck %s -check-prefix=CHECK-DOUBLE-DELETE
+// RUN:   2>&1 | FileCheck %s -check-prefix=CHECK-DOUBLE-DELETE
 
 #include <sanitizer/hwasan_interface.h>
 #include <stdio.h>


### PR DESCRIPTION
The test file ignore_free_hooks.cpp (added in https://github.com/llvm/llvm-project/pull/96749/files) fails on mac because `|&` doesn't work on mac. Replace with `2>&1`. 