### PR TITLE
[HeaderSearch] Make a test independent of the local environment.

### DIFF
--- a/clang/test/Modules/subdirectory-module-maps-working-dir.m
+++ b/clang/test/Modules/subdirectory-module-maps-working-dir.m
@@ -1,8 +1,8 @@
 // RUN: rm -rf %t
-// RUN: %clang -fsyntax-only -fmodules -fmodules-cache-path=%t \
+// RUN: %clang_cc1 -fsyntax-only -fmodules -fimplicit-module-maps -fmodules-cache-path=%t \
 // RUN:    -working-directory %S/Inputs \
 // RUN:    -I subdirectory-module-maps-working-dir \
-// RUN:    %s -Werror=implicit-function-declaration -Xclang -verify
+// RUN:    %s -Werror=implicit-function-declaration -verify
 
 @import ModuleInSubdir;
 


### PR DESCRIPTION
Don't ask the driver to inspect the local environment but use `cc1` directly.