### PR TITLE
[libc][RISCV] Add naked attribute to setjmp/longjmp

### DIFF
--- a/libc/src/setjmp/riscv/longjmp.cpp
+++ b/libc/src/setjmp/riscv/longjmp.cpp
@@ -30,6 +30,7 @@
 
 namespace LIBC_NAMESPACE_DECL {
 
+[[gnu::naked]]
 LLVM_LIBC_FUNCTION(void, longjmp, (__jmp_buf * buf, int val)) {
   LOAD(ra, buf->__pc);
   LOAD(s0, buf->__regs[0]);

--- a/libc/src/setjmp/riscv/setjmp.cpp
+++ b/libc/src/setjmp/riscv/setjmp.cpp
@@ -29,6 +29,7 @@
 
 namespace LIBC_NAMESPACE_DECL {
 
+[[gnu::naked]]
 LLVM_LIBC_FUNCTION(int, setjmp, (__jmp_buf * buf)) {
   STORE(ra, buf->__pc);
   STORE(s0, buf->__regs[0]);


### PR DESCRIPTION
We want to avoid any possibility that the compiler will insert a
prologue/epilogue violating the calling contracts for these special
functions, potentially clobbering registers that must be preserved. To
do that they should be marked naked, as is already the case on ARM.
