### PR TITLE
Revert "[Clang][Driver] Warn about `-c/-S` with `-fsyntax-only`"

### DIFF
--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -794,6 +794,10 @@ static void addPGOAndCoverageFlags(const ToolChain &TC, Compilation &C,
       Args.hasArg(options::OPT_coverage))
     FProfileDir = Args.getLastArg(options::OPT_fprofile_dir);
 
+  // TODO: Don't claim -c/-S to warn about -fsyntax-only -c/-S, -E -c/-S,
+  // like we warn about -fsyntax-only -E.
+  (void)(Args.hasArg(options::OPT_c) || Args.hasArg(options::OPT_S));
+
   // Put the .gcno and .gcda files (if needed) next to the primary output file,
   // or fall back to a file in the current directory for `clang -c --coverage
   // d/a.c` in the absence of -o.

--- a/clang/test/Driver/warn-fsyntax-only.c
+++ b/clang/test/Driver/warn-fsyntax-only.c
@@ -1,7 +1,0 @@
-// RUN: %clang -fsyntax-only -E %s 2>&1 | FileCheck %s --check-prefix=CHECK-PP
-// RUN: %clang -fsyntax-only -S %s 2>&1 | FileCheck %s --check-prefix=CHECK-ASM
-// RUN: %clang -fsyntax-only -c %s 2>&1 | FileCheck %s --check-prefix=CHECK-OBJ
-
-// CHECK-PP:  warning: argument unused during compilation: '-fsyntax-only' [-Wunused-command-line-argument]
-// CHECK-ASM: warning: argument unused during compilation: '-S' [-Wunused-command-line-argument]
-// CHECK-OBJ: warning: argument unused during compilation: '-c' [-Wunused-command-line-argument]


### PR DESCRIPTION
Reverts llvm/llvm-project#98607

The test added was failing on some build bots:
- https://lab.llvm.org/buildbot/#/builders/144/builds/2918
- https://lab.llvm.org/buildbot/#/builders/46/builds/2069