### PR TITLE
[llvm-cgdata] Remove `GENERATE_DRIVER` option

### DIFF
--- a/llvm/tools/llvm-cgdata/CMakeLists.txt
+++ b/llvm/tools/llvm-cgdata/CMakeLists.txt
@@ -11,5 +11,4 @@ add_llvm_tool(llvm-cgdata
 
   DEPENDS
   intrinsics_gen
-  GENERATE_DRIVER
   )


### PR DESCRIPTION
This tool shouldn't be used in the driver build until it is converted to use `OptTable` for option parsing, otherwise the `cl::opt` options might conflict with options in other tools resulting in link failures.