### PR TITLE
Revert "[clang-tidy] fix misc-const-correctness to work with function-try-blocks"

### DIFF
--- a/clang-tools-extra/clang-tidy/misc/ConstCorrectnessCheck.cpp
+++ b/clang-tools-extra/clang-tidy/misc/ConstCorrectnessCheck.cpp
@@ -93,12 +93,13 @@ void ConstCorrectnessCheck::registerMatchers(MatchFinder *Finder) {
   // shall be run.
   const auto FunctionScope =
       functionDecl(
-          hasBody(stmt(forEachDescendant(
-                           declStmt(containsAnyDeclaration(
-                                        LocalValDecl.bind("local-value")),
-                                    unless(has(decompositionDecl())))
-                               .bind("decl-stmt")))
-                      .bind("scope")))
+          hasBody(
+              compoundStmt(forEachDescendant(
+                               declStmt(containsAnyDeclaration(
+                                            LocalValDecl.bind("local-value")),
+                                        unless(has(decompositionDecl())))
+                                   .bind("decl-stmt")))
+                  .bind("scope")))
           .bind("function-decl");
 
   Finder->addMatcher(FunctionScope, this);
@@ -108,7 +109,7 @@ void ConstCorrectnessCheck::registerMatchers(MatchFinder *Finder) {
 enum class VariableCategory { Value, Reference, Pointer };
 
 void ConstCorrectnessCheck::check(const MatchFinder::MatchResult &Result) {
-  const auto *LocalScope = Result.Nodes.getNodeAs<Stmt>("scope");
+  const auto *LocalScope = Result.Nodes.getNodeAs<CompoundStmt>("scope");
   const auto *Variable = Result.Nodes.getNodeAs<VarDecl>("local-value");
   const auto *Function = Result.Nodes.getNodeAs<FunctionDecl>("function-decl");
 
@@ -197,7 +198,7 @@ void ConstCorrectnessCheck::check(const MatchFinder::MatchResult &Result) {
   }
 }
 
-void ConstCorrectnessCheck::registerScope(const Stmt *LocalScope,
+void ConstCorrectnessCheck::registerScope(const CompoundStmt *LocalScope,
                                           ASTContext *Context) {
   auto &Analyzer = ScopesCache[LocalScope];
   if (!Analyzer)

--- a/clang-tools-extra/clang-tidy/misc/ConstCorrectnessCheck.h
+++ b/clang-tools-extra/clang-tidy/misc/ConstCorrectnessCheck.h
@@ -32,10 +32,10 @@ public:
   void check(const ast_matchers::MatchFinder::MatchResult &Result) override;
 
 private:
-  void registerScope(const Stmt *LocalScope, ASTContext *Context);
+  void registerScope(const CompoundStmt *LocalScope, ASTContext *Context);
 
   using MutationAnalyzer = std::unique_ptr<ExprMutationAnalyzer>;
-  llvm::DenseMap<const Stmt *, MutationAnalyzer> ScopesCache;
+  llvm::DenseMap<const CompoundStmt *, MutationAnalyzer> ScopesCache;
   llvm::DenseSet<SourceLocation> TemplateDiagnosticsCache;
 
   const bool AnalyzeValues;

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -381,8 +381,7 @@ Changes in existing checks
 - Improved :doc:`misc-const-correctness
   <clang-tidy/checks/misc/const-correctness>` check by avoiding infinite recursion
   for recursive functions with forwarding reference parameters and reference
-  variables which refer to themselves. Also adapted the check to work with
-  function-try-blocks.
+  variables which refer to themselves.
 
 - Improved :doc:`misc-definitions-in-headers
   <clang-tidy/checks/misc/definitions-in-headers>` check by replacing the local

--- a/clang-tools-extra/test/clang-tidy/checkers/misc/const-correctness-values.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/misc/const-correctness-values.cpp
@@ -56,15 +56,6 @@ void some_function(double np_arg0, wchar_t np_arg1) {
   np_local6--;
 }
 
-int function_try_block() try {
-  int p_local0 = 0;
-  // CHECK-MESSAGES: [[@LINE-1]]:3: warning: variable 'p_local0' of type 'int' can be declared 'const'
-  // CHECK-FIXES: int const p_local0
-  return p_local0;
-} catch (...) {
-  return 0;
-}
-
 void nested_scopes() {
   int p_local0 = 2;
   // CHECK-MESSAGES: [[@LINE-1]]:3: warning: variable 'p_local0' of type 'int' can be declared 'const'


### PR DESCRIPTION
Reverts llvm/llvm-project#99925