### PR TITLE
[llvm-cgdata] Remove GENERATE_DRIVER option

### DIFF
--- a/llvm/tools/llvm-cgdata/CMakeLists.txt
+++ b/llvm/tools/llvm-cgdata/CMakeLists.txt
@@ -11,5 +11,4 @@ add_llvm_tool(llvm-cgdata
 
   DEPENDS
   intrinsics_gen
-  GENERATE_DRIVER
   )

--- a/llvm/tools/llvm-cgdata/llvm-cgdata.cpp
+++ b/llvm/tools/llvm-cgdata/llvm-cgdata.cpp
@@ -18,7 +18,7 @@
 #include "llvm/IR/LLVMContext.h"
 #include "llvm/Object/Archive.h"
 #include "llvm/Support/CommandLine.h"
-#include "llvm/Support/LLVMDriver.h"
+#include "llvm/Support/InitLLVM.h"
 #include "llvm/Support/Path.h"
 #include "llvm/Support/VirtualFileSystem.h"
 #include "llvm/Support/WithColor.h"
@@ -240,8 +240,8 @@ static int show_main(int argc, const char *argv[]) {
   return 0;
 }
 
-int llvm_cgdata_main(int argc, char **argvNonConst, const llvm::ToolContext &) {
-  const char **argv = const_cast<const char **>(argvNonConst);
+int main(int argc, const char **argv) {
+  llvm::InitLLVM X(argc, argv);
 
   StringRef ProgName(sys::path::filename(argv[0]));
 


### PR DESCRIPTION
This tool shouldn't be used in the driver build until it is converted to
use `OptTable` for option parsing, otherwise the `cl::opt` options might
conflict with options in other tools resulting in link failures.
    
This is a reland of #100066.