### PR TITLE
[BinaryFormat] Disable MachOTest.UnalignedLC on SPARC

### DIFF
--- a/llvm/unittests/BinaryFormat/MachOTest.cpp
+++ b/llvm/unittests/BinaryFormat/MachOTest.cpp
@@ -13,9 +13,9 @@
 using namespace llvm;
 using namespace llvm::MachO;
 
-#if defined(__sparc__)
+#if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
 // As discussed in Issue #86793, this test cannot work on a strict-alignment
-// targets like SPARC.  The test may even be invalid.
+// targets like SPARC.  Besides, it's undefined behaviour on big-endian hosts.
 #define MAYBE_UnalignedLC DISABLED_UnalignedLC
 #else
 #define MAYBE_UnalignedLC UnalignedLC

--- a/llvm/unittests/BinaryFormat/MachOTest.cpp
+++ b/llvm/unittests/BinaryFormat/MachOTest.cpp
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "llvm/ADT/bit.h"
 #include "llvm/BinaryFormat/MachO.h"
 #include "llvm/TargetParser/Triple.h"
 #include "gtest/gtest.h"
@@ -13,7 +14,7 @@
 using namespace llvm;
 using namespace llvm::MachO;
 
-#if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+#if BYTE_ORDER == BIG_ENDIAN
 // As discussed in Issue #86793, this test cannot work on a strict-alignment
 // targets like SPARC.  Besides, it's undefined behaviour on big-endian hosts.
 #define MAYBE_UnalignedLC DISABLED_UnalignedLC

--- a/llvm/unittests/BinaryFormat/MachOTest.cpp
+++ b/llvm/unittests/BinaryFormat/MachOTest.cpp
@@ -13,7 +13,15 @@
 using namespace llvm;
 using namespace llvm::MachO;
 
-TEST(MachOTest, UnalignedLC) {
+#if defined(__sparc__)
+// As discussed in Issue #86793, this test cannot work on a strict-alignment
+// targets like SPARC.  The test may even be invalid.
+#define MAYBE_UnalignedLC DISABLED_UnalignedLC
+#else
+#define MAYBE_UnalignedLC UnalignedLC
+#endif
+
+TEST(MachOTest, MAYBE_UnalignedLC) {
   unsigned char Valid32BitMachO[] = {
       0xCE, 0xFA, 0xED, 0xFE, 0x07, 0x00, 0x00, 0x00, 0x03, 0x00, 0x00, 0x00,
       0x02, 0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00, 0x70, 0x00, 0x00, 0x00,


### PR DESCRIPTION
As discussed in Issue #86793, the `MachOTest.UnalignedLC` test dies with `SIGBUS` on SPARC, a strict-alignment target.  It simply cannot work there.  Besides, the test invokes undefined behaviour on big-endian targets, so this patch disables it on all of those.

Tested on `sparcv9-sun-solaris2.11` and `amd64-pc-solaris2.11`.