### PR TITLE
[libc++] Add clang-20 to failing tests on Windows

### DIFF
--- a/libcxx/test/libcxx/fuzzing/random.pass.cpp
+++ b/libcxx/test/libcxx/fuzzing/random.pass.cpp
@@ -8,7 +8,7 @@
 
 // This test fails because Clang no longer enables -fdelayed-template-parsing
 // by default on Windows with C++20 (#69431).
-// XFAIL: msvc && (clang-18 || clang-19)
+// XFAIL: msvc && (clang-18 || clang-19 || clang-20)
 
 // UNSUPPORTED: c++03, c++11
 

--- a/libcxx/test/std/depr/depr.c.headers/math_h.pass.cpp
+++ b/libcxx/test/std/depr/depr.c.headers/math_h.pass.cpp
@@ -8,7 +8,7 @@
 
 // This test fails because Clang no longer enables -fdelayed-template-parsing
 // by default on Windows with C++20 (#69431).
-// XFAIL: msvc && (clang-18 || clang-19)
+// XFAIL: msvc && (clang-18 || clang-19 || clang-20)
 
 // <math.h>
 

--- a/libcxx/test/std/numerics/c.math/cmath.pass.cpp
+++ b/libcxx/test/std/numerics/c.math/cmath.pass.cpp
@@ -8,7 +8,7 @@
 
 // This test fails because Clang no longer enables -fdelayed-template-parsing
 // by default on Windows with C++20 (#69431).
-// XFAIL: msvc && (clang-18 || clang-19)
+// XFAIL: msvc && (clang-18 || clang-19 || clang-20)
 
 // <cmath>
 


### PR DESCRIPTION
After we switched to LLVM version 20, some libc++ tests started failing on Windows. This patch adds the clang-20 condition to XFAIL to fix the issue. The way that these tests are excluded from Windows are fragile and need to be updated every time we bump the LLVM version.