### PR TITLE
[clang/Lex/DependencyDirectivesScanner] Ignore import/include directives with missing filenames without failing the scan

### DIFF
--- a/clang/lib/Lex/DependencyDirectivesScanner.cpp
+++ b/clang/lib/Lex/DependencyDirectivesScanner.cpp
@@ -914,8 +914,7 @@ bool Scanner::lexPPLine(const char *&First, const char *const End) {
   case pp_import:
     // Ignore missing filenames in include or import directives.
     if (lexIncludeFilename(First, End).is(tok::eod)) {
-      skipDirective(Id, First, End);
-      return true;
+      return false;
     }
     break;
   default:

--- a/clang/unittests/Lex/DependencyDirectivesScannerTest.cpp
+++ b/clang/unittests/Lex/DependencyDirectivesScannerTest.cpp
@@ -653,12 +653,28 @@ TEST(MinimizeSourceToDependencyDirectivesTest, AtImport) {
 TEST(MinimizeSourceToDependencyDirectivesTest, EmptyIncludesAndImports) {
   SmallVector<char, 128> Out;
 
-  ASSERT_TRUE(minimizeSourceToDependencyDirectives("#import\n", Out));
-  ASSERT_TRUE(minimizeSourceToDependencyDirectives("#include\n", Out));
-  ASSERT_TRUE(minimizeSourceToDependencyDirectives("#ifdef A\n"
-                                                   "#import \n"
-                                                   "#endif\n",
-                                                   Out));
+  ASSERT_FALSE(minimizeSourceToDependencyDirectives("#import\n", Out));
+  EXPECT_STREQ("<TokBeforeEOF>\n", Out.data());
+
+  ASSERT_FALSE(minimizeSourceToDependencyDirectives("#include\n", Out));
+  EXPECT_STREQ("<TokBeforeEOF>\n", Out.data());
+
+  ASSERT_FALSE(minimizeSourceToDependencyDirectives("#ifdef A\n"
+                                                    "#import \n"
+                                                    "#endif\n",
+                                                    Out));
+  // The ifdef block is removed because it's "empty".
+  EXPECT_STREQ("<TokBeforeEOF>\n", Out.data());
+
+  ASSERT_FALSE(minimizeSourceToDependencyDirectives("#ifdef A\n"
+                                                    "#import \n"
+                                                    "#define B\n"
+                                                    "#endif\n",
+                                                    Out));
+  EXPECT_STREQ("#ifdef A\n"
+               "#define B\n"
+               "#endif\n",
+               Out.data());
 }
 
 TEST(MinimizeSourceToDependencyDirectivesTest, AtImportFailures) {


### PR DESCRIPTION
Follow-up to `34ab855826b8cb0c3b46c770b83390bd1fe95c64`:

* Don't fail the scan with an include with missing filename, it may be inside a skipped preprocessor block. Let the compilation provide any related error.
* Fix an issue where the lexer was skipping through the next directive, after ignoring the include with missing filename.