### PR TITLE
[libc] Enable bind test for riscv

### DIFF
--- a/libc/config/linux/riscv/entrypoints.txt
+++ b/libc/config/linux/riscv/entrypoints.txt
@@ -856,6 +856,7 @@ if(LLVM_LIBC_FULL_BUILD)
     libc.src.sys.select.select
 
     # sys/socket.h entrypoints
+    libc.src.sys.socket.bind
     libc.src.sys.socket.socket
   )
 endif()


### PR DESCRIPTION
The bind test was failing in the rv32 build bot because of how the build bot was setup to run the tests: we were using shared directories between the host and qemu and the bind functions was trying to create a file in this directory, thus creating it in the host machine.

The OS was returning "-1 ENXIO (No such device or address)", so we changed the rv32 buildbot to copy the binaries to qemu and dropped the shared directories feature.

A clean run (where all tests need to be copied to qemu) is taking 7 min, up from 3 min. Incremental runs still run in 3 min.