### PR TITLE
[flang] Fix warning in build

### DIFF
--- a/flang/lib/Lower/DirectivesCommon.h
+++ b/flang/lib/Lower/DirectivesCommon.h
@@ -137,7 +137,8 @@ static inline void genOmpAtomicHintAndMemoryOrderClauses(
 }
 
 template <typename AtomicListT>
-static void processOmpAtomicTODO(mlir::Type elementType, mlir::Location loc) {
+static void processOmpAtomicTODO(mlir::Type elementType,
+                                 [[maybe_unused]] mlir::Location loc) {
   if (!elementType)
     return;
   if constexpr (std::is_same<AtomicListT,


### PR DESCRIPTION
After tblah's update #99817, I'm getting a warning about an unusedvariable.  It looks to me like the warning is bogus, possibly due to a bug in the compiler I'm using (GCC 9.3.0).  But adding a "maybe_unused" clause fixes it and makes my builds clean.