### PR TITLE
[Sema] Avoid excessive desuraging in template deduction

### DIFF
--- a/clang/lib/Sema/SemaTemplateDeduction.cpp
+++ b/clang/lib/Sema/SemaTemplateDeduction.cpp
@@ -688,10 +688,7 @@ DeduceTemplateSpecArguments(Sema &S, TemplateParameterList *TemplateParams,
 
   // FIXME: To preserve sugar, the TST needs to carry sugared resolved
   // arguments.
-  ArrayRef<TemplateArgument> PResolved =
-      TP->getCanonicalTypeInternal()
-          ->castAs<TemplateSpecializationType>()
-          ->template_arguments();
+  ArrayRef<TemplateArgument> PResolved = TP->template_arguments();
 
   QualType UA = A;
   std::optional<NestedNameSpecifier *> NNS;
@@ -951,10 +948,12 @@ private:
 
     // Skip over the pack elements that were expanded into separate arguments.
     // If we partially expanded, this is the number of partial arguments.
-    if (IsPartiallyExpanded)
+    if (IsPartiallyExpanded)  {
       PackElements += NumPartialPackArgs;
-    else if (IsExpanded)
+    } else if (IsExpanded) {
+      assert(FixedNumExpansions.has_value());
       PackElements += *FixedNumExpansions;
+    }
 
     for (auto &Pack : Packs) {
       if (Info.PendingDeducedPacks.size() > Pack.Index)

--- a/clang/test/SemaTemplate/variadic-no-mention.cpp
+++ b/clang/test/SemaTemplate/variadic-no-mention.cpp
@@ -1,0 +1,30 @@
+// RUN: %clang_cc1 -fsyntax-only -verify %s
+// expected-no-diagnostics
+
+template <class... T>
+struct Types {};
+template <int& field>
+using Forget = int;
+template <int&... fields>
+using SeqKey = Types<Forget<fields>...>;
+
+template <typename Key, typename Value>
+struct HelperBase {
+  using ResponseParser = Key();
+  HelperBase(ResponseParser response_parser) {}
+};
+template <int&... fields>
+SeqKey<fields...> Parser();
+
+template <int&... fields>
+struct Helper : public HelperBase<SeqKey<fields...>, double> {
+  using Key = SeqKey<fields...>;
+  using Value = double;
+  using ParentClass = HelperBase<Key, Value>;
+  Helper() : ParentClass(Parser<fields...>) {}
+};
+
+void test() {
+  Helper<>();
+}
+


### PR DESCRIPTION
Not for submission yet. Will eventually aim to fix #100095. The current approach should not be correct as it would have *too* much sugar in turn. We should also make sure the final substitution arguments do not contain any sugar.

It does address the crash, though, so probably something along that diretion is needed, e.g. need to check if `decltype()` that's not type-dependent, but instantiation-dependent works correctly and follow the approach taken there.