### PR TITLE
[Flang][OpenMP] Add frontend support for -fopenmp-targets

### DIFF
--- a/flang/include/flang/Frontend/LangOptions.h
+++ b/flang/include/flang/Frontend/LangOptions.h
@@ -16,6 +16,9 @@
 #define FORTRAN_FRONTEND_LANGOPTIONS_H
 
 #include <string>
+#include <vector>
+
+#include "llvm/TargetParser/Triple.h"
 
 namespace Fortran::frontend {
 
@@ -57,6 +60,9 @@ public:
   /// Name of the IR file that contains the result of the OpenMP target
   /// host code generation.
   std::string OMPHostIRFile;
+
+  /// List of triples passed in using -fopenmp-targets.
+  std::vector<llvm::Triple> OMPTargetTriples;
 
   LangOptions();
 };

--- a/flang/include/flang/Tools/CrossToolHelpers.h
+++ b/flang/include/flang/Tools/CrossToolHelpers.h
@@ -131,7 +131,9 @@ struct OffloadModuleOpts {
       bool OpenMPThreadSubscription, bool OpenMPNoThreadState,
       bool OpenMPNoNestedParallelism, bool OpenMPIsTargetDevice,
       bool OpenMPIsGPU, bool OpenMPForceUSM, uint32_t OpenMPVersion,
-      std::string OMPHostIRFile = {}, bool NoGPULib = false)
+      std::string OMPHostIRFile = {},
+      const std::vector<llvm::Triple> &OMPTargetTriples = {},
+      bool NoGPULib = false)
       : OpenMPTargetDebug(OpenMPTargetDebug),
         OpenMPTeamSubscription(OpenMPTeamSubscription),
         OpenMPThreadSubscription(OpenMPThreadSubscription),
@@ -139,7 +141,9 @@ struct OffloadModuleOpts {
         OpenMPNoNestedParallelism(OpenMPNoNestedParallelism),
         OpenMPIsTargetDevice(OpenMPIsTargetDevice), OpenMPIsGPU(OpenMPIsGPU),
         OpenMPForceUSM(OpenMPForceUSM), OpenMPVersion(OpenMPVersion),
-        OMPHostIRFile(OMPHostIRFile), NoGPULib(NoGPULib) {}
+        OMPHostIRFile(OMPHostIRFile),
+        OMPTargetTriples(OMPTargetTriples.begin(), OMPTargetTriples.end()),
+        NoGPULib(NoGPULib) {}
 
   OffloadModuleOpts(Fortran::frontend::LangOptions &Opts)
       : OpenMPTargetDebug(Opts.OpenMPTargetDebug),
@@ -150,7 +154,7 @@ struct OffloadModuleOpts {
         OpenMPIsTargetDevice(Opts.OpenMPIsTargetDevice),
         OpenMPIsGPU(Opts.OpenMPIsGPU), OpenMPForceUSM(Opts.OpenMPForceUSM),
         OpenMPVersion(Opts.OpenMPVersion), OMPHostIRFile(Opts.OMPHostIRFile),
-        NoGPULib(Opts.NoGPULib) {}
+        OMPTargetTriples(Opts.OMPTargetTriples), NoGPULib(Opts.NoGPULib) {}
 
   uint32_t OpenMPTargetDebug = 0;
   bool OpenMPTeamSubscription = false;
@@ -162,6 +166,7 @@ struct OffloadModuleOpts {
   bool OpenMPForceUSM = false;
   uint32_t OpenMPVersion = 11;
   std::string OMPHostIRFile = {};
+  std::vector<llvm::Triple> OMPTargetTriples = {};
   bool NoGPULib = false;
 };
 
@@ -185,6 +190,9 @@ struct OffloadModuleOpts {
       if (!Opts.OMPHostIRFile.empty())
         offloadMod.setHostIRFilePath(Opts.OMPHostIRFile);
     }
+    auto strTriples = llvm::to_vector(llvm::map_range(Opts.OMPTargetTriples,
+        [](llvm::Triple triple) { return triple.normalize(); }));
+    offloadMod.setTargetTriples(strTriples);
   }
 }
 

--- a/flang/test/Lower/OpenMP/offload-targets.f90
+++ b/flang/test/Lower/OpenMP/offload-targets.f90
@@ -1,0 +1,10 @@
+! RUN: %flang_fc1 -emit-hlfir -fopenmp -fopenmp-targets=amdgcn-amd-amdhsa,nvptx64-nvidia-cuda %s -o - | FileCheck %s
+! RUN: bbc -emit-hlfir -fopenmp -fopenmp-targets=amdgcn-amd-amdhsa,nvptx64-nvidia-cuda %s -o - | FileCheck %s
+
+! This test checks the addition of the omp.target_triples attribute when the
+! -fopenmp-targets option is set
+
+!CHECK:      module attributes {
+!CHECK-SAME: omp.target_triples = ["amdgcn-amd-amdhsa", "nvptx64-nvidia-cuda"]
+program targets
+end program targets

--- a/flang/tools/bbc/bbc.cpp
+++ b/flang/tools/bbc/bbc.cpp
@@ -149,6 +149,11 @@ static llvm::cl::opt<bool> enableOpenMPForceUSM(
     llvm::cl::desc("force openmp unified shared memory mode"),
     llvm::cl::init(false));
 
+static llvm::cl::list<std::string> targetTriplesOpenMP(
+    "fopenmp-targets",
+    llvm::cl::desc("comma-separated list of OpenMP offloading triples"),
+    llvm::cl::CommaSeparated);
+
 // A simplified subset of the OpenMP RTL Flags from Flang, only the primary
 // positive options are available, no negative options e.g. fopen_assume* vs
 // fno_open_assume*
@@ -380,11 +385,17 @@ static llvm::LogicalResult convertFortranSourceToMLIR(
                       "-fopenmp-is-target-device is also set";
       return mlir::failure();
     }
+    // Construct offloading target triples vector.
+    std::vector<llvm::Triple> targetTriples;
+    targetTriples.reserve(targetTriplesOpenMP.size());
+    for (llvm::StringRef s : targetTriplesOpenMP)
+      targetTriples.emplace_back(s);
+
     auto offloadModuleOpts = OffloadModuleOpts(
         setOpenMPTargetDebug, setOpenMPTeamSubscription,
         setOpenMPThreadSubscription, setOpenMPNoThreadState,
         setOpenMPNoNestedParallelism, enableOpenMPDevice, enableOpenMPGPU,
-        enableOpenMPForceUSM, setOpenMPVersion, "", setNoGPULib);
+        enableOpenMPForceUSM, setOpenMPVersion, "", targetTriples, setNoGPULib);
     setOffloadModuleInterfaceAttributes(mlirModule, offloadModuleOpts);
     setOpenMPVersionAttribute(mlirModule, setOpenMPVersion);
   }


### PR DESCRIPTION
This patch adds support for the `-fopenmp-targets` option to the `bbc` and `flang -fc1` tools. It adds an `OMPTargetTriples` property to the `LangOptions` structure, which is filled with the triples represented by the compiler option.

This is used to initialize the `omp.target_triples` module attribute for later use by lowering stages.