### PR TITLE
[RISCV][compiler-rt] Small fixes for __riscv_feature_bits

### DIFF
--- a/compiler-rt/lib/builtins/CMakeLists.txt
+++ b/compiler-rt/lib/builtins/CMakeLists.txt
@@ -739,7 +739,7 @@ endif()
 set(powerpc64le_SOURCES ${powerpc64_SOURCES})
 
 set(riscv_SOURCES
-  riscv/feature_bits.c
+  cpu_model/riscv.c
   riscv/fp_mode.c
   riscv/save.S
   riscv/restore.S

--- a/compiler-rt/lib/builtins/cpu_model/riscv.c
+++ b/compiler-rt/lib/builtins/cpu_model/riscv.c
@@ -1,4 +1,4 @@
-//=== feature_bits.c - Update RISC-V Feature Bits Structure -*- C -*-=========//
+//=== cpu_model/riscv.c - Update RISC-V Feature Bits Structure -*- C -*-======//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.

--- a/compiler-rt/lib/builtins/riscv/feature_bits.c
+++ b/compiler-rt/lib/builtins/riscv/feature_bits.c
@@ -277,7 +277,7 @@ static int FeaturesBitCached = 0;
 
 void __init_riscv_feature_bits() CONSTRUCTOR_ATTRIBUTE;
 
-// A constructor function that is sets __riscv_feature_bits, and
+// A constructor function that sets __riscv_feature_bits, and
 // __riscv_vendor_feature_bits to the right values.  This needs to run
 // only once.  This constructor is given the highest priority and it should
 // run before constructors without the priority set.  However, it still runs

--- a/compiler-rt/lib/builtins/riscv/feature_bits.c
+++ b/compiler-rt/lib/builtins/riscv/feature_bits.c
@@ -204,12 +204,10 @@ static void initRISCVFeature(struct riscv_hwprobe Hwprobes[]) {
   // This unsets all extension bitmask bits.
 
   // Init vendor extension
-  __riscv_vendor_feature_bits.length = 0;
   __riscv_vendor_feature_bits.vendorID = Hwprobes[2].value;
 
   // Init standard extension
   // TODO: Maybe Extension implied generate from tablegen?
-  __riscv_feature_bits.length = RISCV_FEATURE_BITS_LENGTH;
 
   unsigned long long features[RISCV_FEATURE_BITS_LENGTH];
   int i;
@@ -277,10 +275,20 @@ static void initRISCVFeature(struct riscv_hwprobe Hwprobes[]) {
 
 static int FeaturesBitCached = 0;
 
-void __init_riscv_feature_bits() {
+void __init_riscv_feature_bits() CONSTRUCTOR_ATTRIBUTE;
+
+// A constructor function that is sets __riscv_feature_bits, and
+// __riscv_vendor_feature_bits to the right values.  This needs to run
+// only once.  This constructor is given the highest priority and it should
+// run before constructors without the priority set.  However, it still runs
+// after ifunc initializers and needs to be called explicitly there.
+void CONSTRUCTOR_ATTRIBUTE __init_riscv_feature_bits() {
 
   if (FeaturesBitCached)
     return;
+
+  __riscv_feature_bits.length = RISCV_FEATURE_BITS_LENGTH;
+  __riscv_vendor_feature_bits.length = RISCV_VENDOR_FEATURE_BITS_LENGTH;
 
 #if defined(__linux__)
   struct riscv_hwprobe Hwprobes[] = {

--- a/compiler-rt/lib/builtins/riscv/feature_bits.c
+++ b/compiler-rt/lib/builtins/riscv/feature_bits.c
@@ -6,6 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "cpu_model.h"
+
 #define RISCV_FEATURE_BITS_LENGTH 1
 struct {
   unsigned length;


### PR DESCRIPTION
Changes included:

- Adding CONSTRUCTOR_ATTRIBUTE so that the static data is setup early on in process lifetime. This is required by gcc docs for __builtin_cpu_supports which we hope to implement in terms of this.
- Move the length initialization outside of the #if defined(linux) block so that the length field always reflects the size of the structures even if non of the feature bits are non-zero.
- Change the __riscv_vendor_feature_bits.length field to match the length of the actual structure.

Note: Copy from https://github.com/llvm/llvm-project/pull/99958