### PR TITLE
[test] Make `xxhash` benchmark target name less generic

### DIFF
--- a/llvm/benchmarks/CMakeLists.txt
+++ b/llvm/benchmarks/CMakeLists.txt
@@ -2,4 +2,4 @@ set(LLVM_LINK_COMPONENTS
   Support)
 
 add_benchmark(DummyYAML DummyYAML.cpp PARTIAL_SOURCES_INTENDED)
-add_benchmark(xxhash xxhash.cpp PARTIAL_SOURCES_INTENDED)
+add_benchmark(bench-xxhash xxhash.cpp PARTIAL_SOURCES_INTENDED)


### PR DESCRIPTION
Downstream users reported that the `xxhash` target name conflicts with some of their existing build targets. Rename it to `bench-xxhash`.

See https://github.com/llvm/llvm-project/pull/99634#discussion_r1687666875