### PR TITLE
[flang][preprocessor] Fix handling of #line before free-form continua…

### DIFF
--- a/flang/lib/Parser/prescan.cpp
+++ b/flang/lib/Parser/prescan.cpp
@@ -111,9 +111,13 @@ void Prescanner::Statement() {
     skipLeadingAmpersand_ |= !inFixedForm_;
     return;
   case LineClassification::Kind::PreprocessorDirective:
+    preprocessor_.Directive(TokenizePreprocessorDirective(), *this);
+    afterPreprocessingDirective_ = true;
+    // Don't set skipLeadingAmpersand_
+    return;
   case LineClassification::Kind::DefinitionDirective:
     preprocessor_.Directive(TokenizePreprocessorDirective(), *this);
-    // Don't set afterPreprocessingDirective_
+    // Don't set afterPreprocessingDirective_ or skipLeadingAmpersand_
     return;
   case LineClassification::Kind::CompilerDirective: {
     directiveSentinel_ = line.sentinel;

--- a/flang/test/Preprocessing/line-in-contin.F90
+++ b/flang/test/Preprocessing/line-in-contin.F90
@@ -1,0 +1,20 @@
+! RUN: %flang_fc1 -E %s 2>&1 | FileCheck %s
+! CHECK: call foo( 0.)
+! CHECK: call foo( 1.)
+! CHECK: call foo( 2.)
+! CHECK: call foo( 3.)
+call foo( &
+# 100 "bar.h"
+         & 0.)
+call foo( &
+# 101 "bar.h"
+         1.)
+call foo( &
+# 102 "bar.h"
+         & 2. &
+    & )
+call foo( &
+# 103 "bar.h"
+         & 3. &
+    )
+end


### PR DESCRIPTION
…tion

See new test.  A #line (or #) directive after a line ending with & and before its continuation shouldn't elicit an error about mismatched parentheses.

Fixes https://github.com/llvm/llvm-project/issues/100073.