### PR TITLE
[libc++] Revert "Make std::pair trivially copyable if its members are (#89652)"

### DIFF
--- a/libcxx/include/__configuration/abi.h
+++ b/libcxx/include/__configuration/abi.h
@@ -98,10 +98,6 @@
 // and WCHAR_MAX. This ABI setting determines whether we should instead track whether the fill
 // value has been initialized using a separate boolean, which changes the ABI.
 #  define _LIBCPP_ABI_IOS_ALLOW_ARBITRARY_FILL_VALUE
-// Make a std::pair of trivially copyable types trivially copyable.
-// While this technically doesn't change the layout of pair itself, other types may decide to programatically change
-// their representation based on whether something is trivially copyable.
-#  define _LIBCPP_ABI_TRIVIALLY_COPYABLE_PAIR
 #elif _LIBCPP_ABI_VERSION == 1
 #  if !(defined(_LIBCPP_OBJECT_FORMAT_COFF) || defined(_LIBCPP_OBJECT_FORMAT_XCOFF))
 // Enable compiling copies of now inline methods into the dylib to support

--- a/libcxx/include/__type_traits/datasizeof.h
+++ b/libcxx/include/__type_traits/datasizeof.h
@@ -54,7 +54,6 @@ struct _FirstPaddingByte<_Tp, true> {
 // the use as an extension.
 _LIBCPP_DIAGNOSTIC_PUSH
 _LIBCPP_CLANG_DIAGNOSTIC_IGNORED("-Winvalid-offsetof")
-_LIBCPP_GCC_DIAGNOSTIC_IGNORED("-Winvalid-offsetof")
 template <class _Tp>
 inline const size_t __datasizeof_v = offsetof(_FirstPaddingByte<_Tp>, __first_padding_byte_);
 _LIBCPP_DIAGNOSTIC_POP

--- a/libcxx/test/libcxx/utilities/utility/pairs/pairs.pair/abi.trivial_copy_move.pass.cpp
+++ b/libcxx/test/libcxx/utilities/utility/pairs/pairs.pair/abi.trivial_copy_move.pass.cpp
@@ -162,13 +162,8 @@ void test_trivial()
         static_assert(!std::is_trivially_copy_constructible<P>::value, "");
         static_assert(!std::is_trivially_move_constructible<P>::value, "");
 #endif // TEST_STD_VER >= 11
-#ifndef _LIBCPP_ABI_TRIVIALLY_COPYABLE_PAIR
         static_assert(!std::is_trivially_copy_assignable<P>::value, "");
         static_assert(!std::is_trivially_move_assignable<P>::value, "");
-#else
-        static_assert(std::is_trivially_copy_assignable<P>::value, "");
-        static_assert(std::is_trivially_move_assignable<P>::value, "");
-#endif
         static_assert(std::is_trivially_destructible<P>::value, "");
     }
 }

--- a/libcxx/test/libcxx/utilities/utility/pairs/pairs.pair/abi.trivially_copyable.compile.pass.cpp
+++ b/libcxx/test/libcxx/utilities/utility/pairs/pairs.pair/abi.trivially_copyable.compile.pass.cpp
@@ -47,20 +47,11 @@ static_assert(!std::is_trivially_copyable<std::pair<int&, int> >::value, "");
 static_assert(!std::is_trivially_copyable<std::pair<int, int&> >::value, "");
 static_assert(!std::is_trivially_copyable<std::pair<int&, int&> >::value, "");
 
-#ifdef _LIBCPP_ABI_TRIVIALLY_COPYABLE_PAIR
-static_assert(std::is_trivially_copyable<std::pair<int, int> >::value, "");
-static_assert(std::is_trivially_copyable<std::pair<int, char> >::value, "");
-static_assert(std::is_trivially_copyable<std::pair<char, int> >::value, "");
-static_assert(std::is_trivially_copyable<std::pair<std::pair<char, char>, int> >::value, "");
-static_assert(std::is_trivially_copyable<std::pair<trivially_copyable, int> >::value, "");
-#else
 static_assert(!std::is_trivially_copyable<std::pair<int, int> >::value, "");
 static_assert(!std::is_trivially_copyable<std::pair<int, char> >::value, "");
 static_assert(!std::is_trivially_copyable<std::pair<char, int> >::value, "");
 static_assert(!std::is_trivially_copyable<std::pair<std::pair<char, char>, int> >::value, "");
 static_assert(!std::is_trivially_copyable<std::pair<trivially_copyable, int> >::value, "");
-#endif // _LIBCPP_ABI_TRIVIALLY_COPYABLE_PAIR
-
 #if TEST_STD_VER == 03 // Known ABI difference
 static_assert(!std::is_trivially_copyable<std::pair<trivially_copyable_no_copy_assignment, int> >::value, "");
 static_assert(!std::is_trivially_copyable<std::pair<trivially_copyable_no_move_assignment, int> >::value, "");
@@ -68,21 +59,10 @@ static_assert(!std::is_trivially_copyable<std::pair<trivially_copyable_no_move_a
 static_assert(std::is_trivially_copyable<std::pair<trivially_copyable_no_copy_assignment, int> >::value, "");
 static_assert(std::is_trivially_copyable<std::pair<trivially_copyable_no_move_assignment, int> >::value, "");
 #endif
-
-#ifdef _LIBCPP_ABI_TRIVIALLY_COPYABLE_PAIR
-static_assert(std::is_trivially_copyable<std::pair<trivially_copyable_no_construction, int> >::value, "");
-#else
 static_assert(!std::is_trivially_copyable<std::pair<trivially_copyable_no_construction, int> >::value, "");
-#endif
 
 static_assert(std::is_trivially_copy_constructible<std::pair<int, int> >::value, "");
 static_assert(std::is_trivially_move_constructible<std::pair<int, int> >::value, "");
-static_assert(std::is_trivially_destructible<std::pair<int, int> >::value, "");
-
-#ifdef _LIBCPP_ABI_TRIVIALLY_COPYABLE_PAIR
-static_assert(std::is_trivially_copy_assignable<std::pair<int, int> >::value, "");
-static_assert(std::is_trivially_move_assignable<std::pair<int, int> >::value, "");
-#else
 static_assert(!std::is_trivially_copy_assignable<std::pair<int, int> >::value, "");
 static_assert(!std::is_trivially_move_assignable<std::pair<int, int> >::value, "");
-#endif // _LIBCPP_ABI_TRIVIALLY_COPYABLE_PAIR
+static_assert(std::is_trivially_destructible<std::pair<int, int> >::value, "");


### PR DESCRIPTION
This reverts commit f9dd885cb6e6b. We're not certain yet whether the patch has issues, so we are reverting until we've had time to investigate.