### PR TITLE
[MLGO][Infra] Add mlgo-utils to bump-version script

### DIFF
--- a/llvm/utils/release/bump-version.py
+++ b/llvm/utils/release/bump-version.py
@@ -188,6 +188,11 @@ if __name__ == "__main__":
             "llvm/utils/lit/lit/__init__.py",
             LitProcessor(args),
         ),
+        # mlgo-utils configuration
+        (
+            "llvm/utils/mlgo-utils/mlgo/__init__.py",
+            LitProcessor(args),
+        ),
         # GN build system
         (
             "llvm/utils/gn/secondary/llvm/version.gni",


### PR DESCRIPTION
This patch adds support in the bump-version script for bumping the version of the mlgo-utils package. This should hopefully streamline the processor for that with the rest of the project and prevent having to manually update this package individually.