### PR TITLE
[rtsan] Make sure rtsan gets initialized on mac

### DIFF
--- a/compiler-rt/lib/rtsan/rtsan.cpp
+++ b/compiler-rt/lib/rtsan/rtsan.cpp
@@ -25,9 +25,14 @@ static void SetInitialized() {
   atomic_store(&rtsan_initialized, 1, memory_order_release);
 }
 
+static bool IsInitialized() {
+  return atomic_load(&rtsan_initialized, memory_order_acquire) == 1;
+}
+
 extern "C" {
 
 SANITIZER_INTERFACE_ATTRIBUTE void __rtsan_init() {
+  CHECK(!IsInitialized());
   InitializeInterceptors();
   SetInitialized();
 }

--- a/compiler-rt/lib/rtsan/rtsan.cpp
+++ b/compiler-rt/lib/rtsan/rtsan.cpp
@@ -25,14 +25,10 @@ static void SetInitialized() {
   atomic_store(&rtsan_initialized, 1, memory_order_release);
 }
 
-static bool IsInitialized() {
-  return atomic_load(&rtsan_initialized, memory_order_acquire) == 1;
-}
-
 extern "C" {
 
 SANITIZER_INTERFACE_ATTRIBUTE void __rtsan_init() {
-  CHECK(!IsInitialized());
+  CHECK(!__rtsan_is_initialized());
   InitializeInterceptors();
   SetInitialized();
 }

--- a/compiler-rt/lib/rtsan/rtsan.cpp
+++ b/compiler-rt/lib/rtsan/rtsan.cpp
@@ -19,7 +19,7 @@ using namespace __rtsan;
 using namespace __sanitizer;
 
 static StaticSpinMutex rtsan_inited_mutex;
-static atomic_uint8_t rtsan_initialized{0};
+static atomic_uint8_t rtsan_initialized = {0};
 
 static void SetInitialized() {
   atomic_store(&rtsan_initialized, 1, memory_order_release);

--- a/compiler-rt/lib/rtsan/rtsan.h
+++ b/compiler-rt/lib/rtsan/rtsan.h
@@ -18,6 +18,11 @@ extern "C" {
 // A call to this method is added to the preinit array on Linux systems.
 SANITIZER_INTERFACE_ATTRIBUTE void __rtsan_init();
 
+// Initializes rtsan if it has not been initialized yet.
+// Used by the RTSan runtime to ensure that rtsan is initialized before any
+// other rtsan functions are called.
+SANITIZER_INTERFACE_ATTRIBUTE void __rtsan_ensure_initialized();
+
 SANITIZER_INTERFACE_ATTRIBUTE bool __rtsan_is_initialized();
 
 // Enter real-time context.

--- a/compiler-rt/lib/rtsan/rtsan.h
+++ b/compiler-rt/lib/rtsan/rtsan.h
@@ -14,16 +14,11 @@
 
 extern "C" {
 
-namespace __rtsan {
-
-extern bool rtsan_initialized;
-extern bool rtsan_init_is_running;
-
-} // namespace __rtsan
-
 // Initialise rtsan interceptors.
 // A call to this method is added to the preinit array on Linux systems.
 SANITIZER_INTERFACE_ATTRIBUTE void __rtsan_init();
+
+SANITIZER_INTERFACE_ATTRIBUTE bool __rtsan_is_initialized();
 
 // Enter real-time context.
 // When in a real-time context, RTSan interceptors will error if realtime

--- a/compiler-rt/lib/rtsan/rtsan_interceptors.cpp
+++ b/compiler-rt/lib/rtsan/rtsan_interceptors.cpp
@@ -51,7 +51,6 @@ void OSSpinLockLock(volatile OSSpinLock *__lock);
 
 using namespace __sanitizer;
 
-using __rtsan::rtsan_init_is_running;
 using __rtsan::rtsan_initialized;
 
 namespace {
@@ -61,6 +60,9 @@ struct DlsymAlloc : public DlSymAllocator<DlsymAlloc> {
 } // namespace
 
 void ExpectNotRealtime(const char *intercepted_function_name) {
+  if (!rtsan_initialized)
+    __rtsan_init();
+
   __rtsan::GetContextForThisThread().ExpectNotRealtime(
       intercepted_function_name);
 }

--- a/compiler-rt/lib/rtsan/rtsan_interceptors.cpp
+++ b/compiler-rt/lib/rtsan/rtsan_interceptors.cpp
@@ -51,16 +51,14 @@ void OSSpinLockLock(volatile OSSpinLock *__lock);
 
 using namespace __sanitizer;
 
-using __rtsan::rtsan_initialized;
-
 namespace {
 struct DlsymAlloc : public DlSymAllocator<DlsymAlloc> {
-  static bool UseImpl() { return !rtsan_initialized; }
+  static bool UseImpl() { return !__rtsan_is_initialized(); }
 };
 } // namespace
 
 void ExpectNotRealtime(const char *intercepted_function_name) {
-  if (!rtsan_initialized)
+  if (!__rtsan_is_initialized())
     __rtsan_init();
 
   __rtsan::GetContextForThisThread().ExpectNotRealtime(

--- a/compiler-rt/lib/rtsan/rtsan_interceptors.cpp
+++ b/compiler-rt/lib/rtsan/rtsan_interceptors.cpp
@@ -58,8 +58,7 @@ struct DlsymAlloc : public DlSymAllocator<DlsymAlloc> {
 } // namespace
 
 void ExpectNotRealtime(const char *intercepted_function_name) {
-  if (!__rtsan_is_initialized())
-    __rtsan_init();
+  __rtsan_ensure_initialized();
 
   __rtsan::GetContextForThisThread().ExpectNotRealtime(
       intercepted_function_name);


### PR DESCRIPTION
Intermittently on my mac I was getting the same nullptr crash in dlsym.

We need to make sure rtsan gets initialized on mac between when the binary starts running, and the first intercepted function is called. Until that point we should use the DlsymAllocator.