### PR TITLE
Revert "[libc][RISCV] Add naked attribute to setjmp/longjmp"

### DIFF
--- a/libc/src/setjmp/riscv/longjmp.cpp
+++ b/libc/src/setjmp/riscv/longjmp.cpp
@@ -30,7 +30,6 @@
 
 namespace LIBC_NAMESPACE_DECL {
 
-[[gnu::naked]]
 LLVM_LIBC_FUNCTION(void, longjmp, (__jmp_buf * buf, int val)) {
   LOAD(ra, buf->__pc);
   LOAD(s0, buf->__regs[0]);

--- a/libc/src/setjmp/riscv/setjmp.cpp
+++ b/libc/src/setjmp/riscv/setjmp.cpp
@@ -29,7 +29,6 @@
 
 namespace LIBC_NAMESPACE_DECL {
 
-[[gnu::naked]]
 LLVM_LIBC_FUNCTION(int, setjmp, (__jmp_buf * buf)) {
   STORE(ra, buf->__pc);
   STORE(s0, buf->__regs[0]);


### PR DESCRIPTION
Reverts llvm/llvm-project#100036

This caused a failure on bots:    https://lab.llvm.org/buildbot/#/builders/183/builds/1799

We likely need to discuss the particulars here a bit more deeply before either relanding or choosing an alternate solution