### PR TITLE
Add wasm-opt warning

### DIFF
--- a/clang/include/clang/Basic/DiagnosticDriverKinds.td
+++ b/clang/include/clang/Basic/DiagnosticDriverKinds.td
@@ -826,4 +826,12 @@ def err_drv_triple_version_invalid : Error<
 
 def warn_missing_include_dirs : Warning<
   "no such include directory: '%0'">, InGroup<MissingIncludeDirs>, DefaultIgnore;
+
+def warn_wasm_opt_not_found : Warning<
+  "wasm-opt was not found, some optimizations were not applied">,
+  InGroup<WebAssemblyOptimization>;
+def err_wasm_opt_not_found_with_flag : Error<
+  "wasm-opt was explicitly requested, but was not found">;
+def err_wasm_opt_requested_but_not_supported : Error<
+  "wasm-opt was explicitly requested, but is not supported with '%0'">;
 }

--- a/clang/include/clang/Basic/DiagnosticGroups.td
+++ b/clang/include/clang/Basic/DiagnosticGroups.td
@@ -1520,6 +1520,8 @@ in addition with the pragmas or -fmax-tokens flag to get any warnings.
 
 def WebAssemblyExceptionSpec : DiagGroup<"wasm-exception-spec">;
 
+def WebAssemblyOptimization : DiagGroup<"wasm-opt">;
+
 def RTTI : DiagGroup<"rtti">;
 
 def OpenCLCoreFeaturesDiagGroup : DiagGroup<"pedantic-core-features">;

--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -8923,3 +8923,4 @@ def wasm_opt : Flag<["--"], "wasm-opt">,
   Group<m_Group>,
   HelpText<"Enable the wasm-opt optimizer (default)">,
   MarshallingInfoNegativeFlag<LangOpts<"NoWasmOpt">>;
+def Wwarn_wasm_opt_not_found : Flag<["-"], "Wwarn_wasm_opt_not_found">;

--- a/clang/lib/Driver/ToolChains/WebAssembly.cpp
+++ b/clang/lib/Driver/ToolChains/WebAssembly.cpp
@@ -180,6 +180,9 @@ void wasm::Linker::ConstructJob(Compilation &C, const JobAction &JA,
     if (WasmOptPath == "wasm-opt") {
       WasmOptPath = {};
     }
+    if (WasmOptPath.empty()) {
+      printf("warning: wasm-opt not found but was requested\n");
+    }
   }
 
   if (!WasmOptPath.empty()) {


### PR DESCRIPTION
Add a warning when `wasm-opt` is requested with a flag (#95208) but is not found in the path.

I'm using #77148 as reference on how to add a new warning but please tell me if you can help in implementing this. Also I'm not sure in which warning group include this, at first glance none seem relevant for this specific problem. 

Regarding https://github.com/llvm/llvm-project/pull/98373 another warning might be relevant if people target WASIp2+ and try to use wasm-opt explicitly. This can be grouped in one warning "wasm-opt not available in this context" or separated in 2 for clearer error messages. WDYT?

CC @sunfishcode @sbc100 @alexcrichton 