### PR TITLE
[nsan] Fix `Wstring-conversion` error

### DIFF
--- a/llvm/lib/Transforms/Instrumentation/NumericalStabilitySanitizer.cpp
+++ b/llvm/lib/Transforms/Instrumentation/NumericalStabilitySanitizer.cpp
@@ -527,7 +527,7 @@ NsanMemOpFn::NsanMemOpFn(Module &M, ArrayRef<StringRef> Sized,
         M.getOrInsertFunction(Fallback, Attr, VoidTy, PtrTy, IntptrTy));
     SizedFnTy = FunctionType::get(VoidTy, {PtrTy}, false);
   } else {
-    assert(0 && "Unexpected value of sized functions arguments");
+    llvm_unreachable("Unexpected value of sized functions arguments");
   }
 
   for (size_t i = 0; i < NumSizedFuncs; ++i)

--- a/llvm/lib/Transforms/Instrumentation/NumericalStabilitySanitizer.cpp
+++ b/llvm/lib/Transforms/Instrumentation/NumericalStabilitySanitizer.cpp
@@ -527,7 +527,7 @@ NsanMemOpFn::NsanMemOpFn(Module &M, ArrayRef<StringRef> Sized,
         M.getOrInsertFunction(Fallback, Attr, VoidTy, PtrTy, IntptrTy));
     SizedFnTy = FunctionType::get(VoidTy, {PtrTy}, false);
   } else {
-    assert(0 && !"Unexpected value of sized functions arguments");
+    assert(0 && "Unexpected value of sized functions arguments");
   }
 
   for (size_t i = 0; i < NumSizedFuncs; ++i)

--- a/llvm/lib/Transforms/Instrumentation/NumericalStabilitySanitizer.cpp
+++ b/llvm/lib/Transforms/Instrumentation/NumericalStabilitySanitizer.cpp
@@ -527,7 +527,7 @@ NsanMemOpFn::NsanMemOpFn(Module &M, ArrayRef<StringRef> Sized,
         M.getOrInsertFunction(Fallback, Attr, VoidTy, PtrTy, IntptrTy));
     SizedFnTy = FunctionType::get(VoidTy, {PtrTy}, false);
   } else {
-    assert(!"Unexpected value of sized functions arguments");
+    assert(0 && !"Unexpected value of sized functions arguments");
   }
 
   for (size_t i = 0; i < NumSizedFuncs; ++i)


### PR DESCRIPTION
Fix error: implicit conversion turns string literal into bool: 'const char[46]' to 'bool' [-Werror,-Wstring-conversion]