### PR TITLE
[compiler-rt] Move `endif` to correct place

### DIFF
--- a/compiler-rt/lib/sanitizer_common/sanitizer_linux.cpp
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_linux.cpp
@@ -2239,6 +2239,7 @@ static const char *RegNumToRegName(int reg) {
 #    endif
     default:
       return NULL;
+#endif
   }
   return NULL;
 }
@@ -2302,7 +2303,6 @@ static void DumpSingleReg(ucontext_t *ctx, int RegNum) {
   (void)RegName;
 #    endif
 }
-#  endif
 
 void SignalContext::DumpAllRegisters(void *context) {
   ucontext_t *ucontext = (ucontext_t *)context;

--- a/compiler-rt/lib/sanitizer_common/sanitizer_linux.cpp
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_linux.cpp
@@ -2237,9 +2237,9 @@ static const char *RegNumToRegName(int reg) {
     case 31:
       return "sp";
 #    endif
+#  endif  // SANITIZER_LINUX
     default:
       return NULL;
-#  endif // SANITIZER_LINUX
   }
   return NULL;
 }

--- a/compiler-rt/lib/sanitizer_common/sanitizer_linux.cpp
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_linux.cpp
@@ -2239,7 +2239,7 @@ static const char *RegNumToRegName(int reg) {
 #    endif
     default:
       return NULL;
-#  endif
+#  endif // SANITIZER_LINUX
   }
   return NULL;
 }

--- a/compiler-rt/lib/sanitizer_common/sanitizer_linux.cpp
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_linux.cpp
@@ -2239,7 +2239,7 @@ static const char *RegNumToRegName(int reg) {
 #    endif
     default:
       return NULL;
-#endif
+#  endif
   }
   return NULL;
 }


### PR DESCRIPTION
A couple of previous commits leaded to wrong endif placement inside the source that caused build problem in
https://lab.llvm.org/buildbot/#/builders/13/builds/1020

See #99613 #99049