### PR TITLE
[ASTMatchers] Extend hasName matcher when matching templates

### DIFF
--- a/clang/include/clang/ASTMatchers/ASTMatchers.h
+++ b/clang/include/clang/ASTMatchers/ASTMatchers.h
@@ -3076,6 +3076,21 @@ inline internal::BindableMatcher<Stmt> sizeOfExpr(
 /// \code
 ///   namespace a { namespace b { class X; } }
 /// \endcode
+///
+/// Qualified names in templated classes can be matched explicitly or implicity
+/// by specifying the template type or using `<*>` to match any template.
+///
+/// Example matches:
+///   - callExpr(callee(functionDecl(hasName("Foo<int>::Bar"))))
+///   - callExpr(callee(functionDecl(hasName("Foo<>::Bar"))))
+/// \code
+///   template<typename T> class Foo{
+///     static void Bar();
+///   };
+///   void Func() {
+///     Foo<int>::Bar();
+///   }
+/// \endcode
 inline internal::Matcher<NamedDecl> hasName(StringRef Name) {
   return internal::Matcher<NamedDecl>(
       new internal::HasNameMatcher({std::string(Name)}));


### PR DESCRIPTION
Allow users to match all record instantiations by using <> as a wildcard.

With
```cpp
template <typename T>
struct Foo {
  void Bar();
};
```

The following code:
```cpp
Foo<int>{}.Bar();
```
Will match against:
```
callExpr(callee(cxxMethodDecl(hasName("Bar"))))
callExpr(callee(cxxMethodDecl(hasName("Foo<int>::Bar"))))
callExpr(callee(cxxMethodDecl(hasName("Foo<>::Bar"))))
```