### PR TITLE
[libc][math][c23] Fix totalorder and totalordermag smoke tests

### DIFF
--- a/libc/test/src/math/smoke/TotalOrderMagTest.h
+++ b/libc/test/src/math/smoke/TotalOrderMagTest.h
@@ -104,24 +104,24 @@ public:
   }
 
   void testNaNPayloads(TotalOrderMagFunc func) {
-    T qnan_123 = FPBits::quiet_nan(Sign::POS, 0x123).get_val();
-    T neg_qnan_123 = FPBits::quiet_nan(Sign::NEG, 0x123).get_val();
-    T snan_123 = FPBits::signaling_nan(Sign::POS, 0x123).get_val();
-    T neg_snan_123 = FPBits::signaling_nan(Sign::NEG, 0x123).get_val();
+    T qnan_0x42 = FPBits::quiet_nan(Sign::POS, 0x42).get_val();
+    T neg_qnan_0x42 = FPBits::quiet_nan(Sign::NEG, 0x42).get_val();
+    T snan_0x42 = FPBits::signaling_nan(Sign::POS, 0x42).get_val();
+    T neg_snan_0x42 = FPBits::signaling_nan(Sign::NEG, 0x42).get_val();
 
     EXPECT_TRUE(funcWrapper(func, aNaN, aNaN));
     EXPECT_TRUE(funcWrapper(func, sNaN, sNaN));
-    EXPECT_TRUE(funcWrapper(func, aNaN, qnan_123));
-    EXPECT_TRUE(funcWrapper(func, sNaN, snan_123));
-    EXPECT_FALSE(funcWrapper(func, qnan_123, aNaN));
-    EXPECT_FALSE(funcWrapper(func, snan_123, sNaN));
+    EXPECT_TRUE(funcWrapper(func, aNaN, qnan_0x42));
+    EXPECT_FALSE(funcWrapper(func, sNaN, snan_0x42));
+    EXPECT_FALSE(funcWrapper(func, qnan_0x42, aNaN));
+    EXPECT_TRUE(funcWrapper(func, snan_0x42, sNaN));
 
     EXPECT_TRUE(funcWrapper(func, neg_aNaN, neg_aNaN));
     EXPECT_TRUE(funcWrapper(func, neg_sNaN, neg_sNaN));
-    EXPECT_TRUE(funcWrapper(func, neg_aNaN, neg_qnan_123));
-    EXPECT_TRUE(funcWrapper(func, neg_sNaN, neg_snan_123));
-    EXPECT_FALSE(funcWrapper(func, neg_qnan_123, neg_aNaN));
-    EXPECT_FALSE(funcWrapper(func, neg_snan_123, neg_sNaN));
+    EXPECT_TRUE(funcWrapper(func, neg_aNaN, neg_qnan_0x42));
+    EXPECT_FALSE(funcWrapper(func, neg_sNaN, neg_snan_0x42));
+    EXPECT_FALSE(funcWrapper(func, neg_qnan_0x42, neg_aNaN));
+    EXPECT_TRUE(funcWrapper(func, neg_snan_0x42, neg_sNaN));
   }
 };
 

--- a/libc/test/src/math/smoke/TotalOrderTest.h
+++ b/libc/test/src/math/smoke/TotalOrderTest.h
@@ -102,24 +102,24 @@ public:
   }
 
   void testNaNPayloads(TotalOrderFunc func) {
-    T qnan_123 = FPBits::quiet_nan(Sign::POS, 0x123).get_val();
-    T neg_qnan_123 = FPBits::quiet_nan(Sign::NEG, 0x123).get_val();
-    T snan_123 = FPBits::signaling_nan(Sign::POS, 0x123).get_val();
-    T neg_snan_123 = FPBits::signaling_nan(Sign::NEG, 0x123).get_val();
+    T qnan_0x42 = FPBits::quiet_nan(Sign::POS, 0x42).get_val();
+    T neg_qnan_0x42 = FPBits::quiet_nan(Sign::NEG, 0x42).get_val();
+    T snan_0x42 = FPBits::signaling_nan(Sign::POS, 0x42).get_val();
+    T neg_snan_0x42 = FPBits::signaling_nan(Sign::NEG, 0x42).get_val();
 
     EXPECT_TRUE(funcWrapper(func, aNaN, aNaN));
     EXPECT_TRUE(funcWrapper(func, sNaN, sNaN));
-    EXPECT_TRUE(funcWrapper(func, aNaN, qnan_123));
-    EXPECT_TRUE(funcWrapper(func, sNaN, snan_123));
-    EXPECT_FALSE(funcWrapper(func, qnan_123, aNaN));
-    EXPECT_FALSE(funcWrapper(func, snan_123, sNaN));
+    EXPECT_TRUE(funcWrapper(func, aNaN, qnan_0x42));
+    EXPECT_FALSE(funcWrapper(func, sNaN, snan_0x42));
+    EXPECT_FALSE(funcWrapper(func, qnan_0x42, aNaN));
+    EXPECT_TRUE(funcWrapper(func, snan_0x42, sNaN));
 
     EXPECT_TRUE(funcWrapper(func, neg_aNaN, neg_aNaN));
     EXPECT_TRUE(funcWrapper(func, neg_sNaN, neg_sNaN));
-    EXPECT_FALSE(funcWrapper(func, neg_aNaN, neg_qnan_123));
-    EXPECT_FALSE(funcWrapper(func, neg_sNaN, neg_snan_123));
-    EXPECT_TRUE(funcWrapper(func, neg_qnan_123, neg_aNaN));
-    EXPECT_TRUE(funcWrapper(func, neg_snan_123, neg_sNaN));
+    EXPECT_FALSE(funcWrapper(func, neg_aNaN, neg_qnan_0x42));
+    EXPECT_TRUE(funcWrapper(func, neg_sNaN, neg_snan_0x42));
+    EXPECT_TRUE(funcWrapper(func, neg_qnan_0x42, neg_aNaN));
+    EXPECT_FALSE(funcWrapper(func, neg_snan_0x42, neg_sNaN));
   }
 };
 


### PR DESCRIPTION
FPBits::signaling_nan() defaults to setting the MSB of the payload to 1.
The tests also used signaling NaNs with a payload of 0x123. With
float16, the 1 in 0x123 aligns to the MSB of the payload, therefore
0x123 is greater than the default payload. However, that is not the case
with more precise floating-point types.
