### PR TITLE
[Frontend][OpenMP] Apply ompx_attribute to all allowing leaf constructs

### DIFF
--- a/llvm/include/llvm/Frontend/OpenMP/ConstructDecompositionT.h
+++ b/llvm/include/llvm/Frontend/OpenMP/ConstructDecompositionT.h
@@ -236,6 +236,9 @@ private:
                    const ClauseTy *);
   bool applyClause(const tomp::clause::NowaitT<TypeTy, IdTy, ExprTy> &clause,
                    const ClauseTy *);
+  bool
+  applyClause(const tomp::clause::OmpxAttributeT<TypeTy, IdTy, ExprTy> &clause,
+              const ClauseTy *);
 
   uint32_t version;
   llvm::omp::Directive construct;
@@ -1099,6 +1102,13 @@ bool ConstructDecompositionT<C, H>::applyClause(
     const tomp::clause::NowaitT<TypeTy, IdTy, ExprTy> &clause,
     const ClauseTy *node) {
   return applyToOutermost(node);
+}
+
+template <typename C, typename H>
+bool ConstructDecompositionT<C, H>::applyClause(
+    const tomp::clause::OmpxAttributeT<TypeTy, IdTy, ExprTy> &clause,
+    const ClauseTy *node) {
+  return applyToAll(node);
 }
 
 template <typename C, typename H> bool ConstructDecompositionT<C, H>::split() {


### PR DESCRIPTION
By default, in a compound directive, a clause will apply to the unique leaf construct that allows it. Clauses that could apply to multiple leaf constructs follow different rules.

For ompx_attribute, apply it to all leaf constructs that allow it.