### PR TITLE
Fix fs.op.copy_file/copy_file_large.pass.cpp on z/OS

### DIFF
--- a/libcxx/test/std/input.output/filesystems/fs.op.funcs/fs.op.copy_file/copy_file_large.pass.cpp
+++ b/libcxx/test/std/input.output/filesystems/fs.op.funcs/fs.op.copy_file/copy_file_large.pass.cpp
@@ -72,7 +72,7 @@ static void large_file() {
   // the data at the end of the source file.
   std::string out_data(additional_size, 'z');
   {
-    std::FILE* dest_file = std::fopen(dest.string().c_str(), "rb");
+    std::FILE* dest_file = std::fopen(dest.string().c_str(), "r");
     assert(dest_file != nullptr);
     assert(std::fseek(dest_file, sendfile_size_limit, SEEK_SET) == 0);
     assert(std::fread(&out_data[0], sizeof(out_data[0]), additional_size, dest_file) == additional_size);


### PR DESCRIPTION
This PR is required to fix copy_file_large.pass.cpp which is failing on z/OS in all ASCII variations. The problem is that a destination file is opened in binary mode and auto-conversion does not happen when this lit is compiled with -fzos-le-char-mode=ascii.

In addition opening a destination file will match a text mode of `fopen()` of a source file. 