### PR TITLE
[tsan] Fix `gettid` declaration on powerpc64 linux buildbots

### DIFF
--- a/compiler-rt/test/tsan/debug_alloc_stack.cpp
+++ b/compiler-rt/test/tsan/debug_alloc_stack.cpp
@@ -6,10 +6,11 @@
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <unistd.h>
 
 #ifndef __APPLE__
+#define _GNU_SOURCE
 #include <sys/types.h>
+#include <unistd.h>
 #endif
 
 extern "C" int __tsan_get_alloc_stack(void *addr, void **trace, size_t size,


### PR DESCRIPTION
The test is failing on PPC buildbots, like https://lab.llvm.org/buildbot/#/builders/76/builds/1285.
Though the man page on Ubuntu 20.04.6 LTS (Focal Fossa) for PowerPC claims
```
NAME
       gettid - get thread identification

SYNOPSIS
       #include <sys/types.h>

       pid_t gettid(void);
```
In practice, this doesn't work. Following code works
```
#define _GNU_SOURCE
#include <unistd.h>
int main() { return gettid(); }
```