### PR TITLE
[Clang][Interp] Visit `DecompositionDecl` and create a local variable

### DIFF
--- a/clang/lib/AST/Interp/Compiler.cpp
+++ b/clang/lib/AST/Interp/Compiler.cpp
@@ -3593,8 +3593,14 @@ VarCreationState Compiler<Emitter>::visitDecl(const VarDecl *VD) {
   if (R.notCreated())
     return R;
 
-  if (R)
-    return true;
+  if (R) {
+    bool Ok = true;
+    if (const auto *DD = dyn_cast<DecompositionDecl>(VD))
+      for (const auto *BD : DD->bindings())
+        if (const auto *HoldingVar = BD->getHoldingVar())
+          Ok &= this->visitDecl(HoldingVar);
+    return Ok;
+  }
 
   if (!R && Context::shouldBeGloballyIndexed(VD)) {
     if (auto GlobalIndex = P.getGlobal(VD)) {
@@ -5233,6 +5239,9 @@ bool Compiler<Emitter>::visitDeclRef(const ValueDecl *D, const Expr *E) {
             return RT->getPointeeType().isConstQualified();
           return false;
         };
+
+        if (isa<DecompositionDecl>(VD))
+          return revisit(VD);
 
         // Visit local const variables like normal.
         if ((VD->hasGlobalStorage() || VD->isLocalVarDecl() ||

--- a/clang/lib/AST/Interp/Compiler.cpp
+++ b/clang/lib/AST/Interp/Compiler.cpp
@@ -3593,14 +3593,8 @@ VarCreationState Compiler<Emitter>::visitDecl(const VarDecl *VD) {
   if (R.notCreated())
     return R;
 
-  if (R) {
-    bool Ok = true;
-    if (const auto *DD = dyn_cast<DecompositionDecl>(VD))
-      for (const auto *BD : DD->bindings())
-        if (const auto *HoldingVar = BD->getHoldingVar())
-          Ok &= this->visitDecl(HoldingVar);
-    return Ok;
-  }
+  if (R)
+    return true;
 
   if (!R && Context::shouldBeGloballyIndexed(VD)) {
     if (auto GlobalIndex = P.getGlobal(VD)) {
@@ -5240,6 +5234,7 @@ bool Compiler<Emitter>::visitDeclRef(const ValueDecl *D, const Expr *E) {
           return false;
         };
 
+        // DecompositionDecls are just proxies for us.
         if (isa<DecompositionDecl>(VD))
           return revisit(VD);
 

--- a/clang/test/SemaCXX/cxx1z-decomposition.cpp
+++ b/clang/test/SemaCXX/cxx1z-decomposition.cpp
@@ -1,5 +1,6 @@
 // RUN: %clang_cc1 -std=c++17 -Wc++20-extensions -verify=expected %s
 // RUN: %clang_cc1 -std=c++20 -Wpre-c++20-compat -verify=expected %s
+// RUN: %clang_cc1 -std=c++20 -Wpre-c++20-compat -fexperimental-new-constant-interpreter -verify=expected %s
 
 void use_from_own_init() {
   auto [a] = a; // expected-error {{binding 'a' cannot appear in the initializer of its own decomposition declaration}}


### PR DESCRIPTION
The following code should be well-formed:
```C++
float decompose_complex(_Complex float cf) {
  static _Complex float scf;
  auto &[sre, sim] = scf;
  // ok, this is references initialized by constant expressions all the way down
  static_assert(&sre == &__real scf);
  static_assert(&sim == &__imag scf);

  auto [re, im] = cf;
  return re*re + im*im;
}

```
We should visit `DecompositionDecl` and create a local variable but not a create a dummy value directly.