### PR TITLE
[DebugInfo] SizeInBits and AlignInBits are erroneously swapped

### DIFF
--- a/llvm/lib/IR/DebugInfo.cpp
+++ b/llvm/lib/IR/DebugInfo.cpp
@@ -1511,9 +1511,8 @@ LLVMDIBuilderCreateMemberPointerType(LLVMDIBuilderRef Builder,
                                      uint32_t AlignInBits,
                                      LLVMDIFlags Flags) {
   return wrap(unwrap(Builder)->createMemberPointerType(
-                  unwrapDI<DIType>(PointeeType),
-                  unwrapDI<DIType>(ClassType), AlignInBits, SizeInBits,
-                  map_from_llvmDIFlags(Flags)));
+      unwrapDI<DIType>(PointeeType), unwrapDI<DIType>(ClassType), SizeInBits,
+      AlignInBits, map_from_llvmDIFlags(Flags)));
 }
 
 LLVMMetadataRef


### PR DESCRIPTION
They are being passed in the wrong order.