### PR TITLE
[OpenMP] Do not define '__assert_fail' if we have the GPU libc

### DIFF
--- a/offload/DeviceRTL/src/Debug.cpp
+++ b/offload/DeviceRTL/src/Debug.cpp
@@ -26,10 +26,13 @@ using namespace ompx;
 extern "C" {
 void __assert_assume(bool condition) { __builtin_assume(condition); }
 
+#ifndef OMPTARGET_HAS_LIBC
 [[gnu::weak]] void __assert_fail(const char *expr, const char *file,
                                  unsigned line, const char *function) {
   __assert_fail_internal(expr, nullptr, file, line, function);
 }
+#endif
+
 void __assert_fail_internal(const char *expr, const char *msg, const char *file,
                             unsigned line, const char *function) {
   if (msg) {

--- a/offload/test/libc/assert.c
+++ b/offload/test/libc/assert.c
@@ -2,10 +2,6 @@
 // RUN:   %fcheck-generic --check-prefix=CHECK
 
 // REQUIRES: libc
-
-// AMDGPU and NVPTX without LTO uses the implementation in OpenMP currently.
-// UNSUPPORTED: nvptx64-nvidia-cuda
-// UNSUPPORTED: amdgcn-amd-amdhsa
 // REQUIRES: gpu
 
 #include <assert.h>


### PR DESCRIPTION
Summary:
The C library is intended to provide `__assert_fail`, so in the cases
that we have both we should defer to that. This means that if you build
the C library for GPUs you'll get the RPC based asser, and if not you'll
get the trap based one.
