### PR TITLE
[NVPTX] Restore old va_list builtin type

### DIFF
--- a/clang/lib/Basic/Targets/NVPTX.h
+++ b/clang/lib/Basic/Targets/NVPTX.h
@@ -119,7 +119,7 @@ public:
   }
 
   BuiltinVaListKind getBuiltinVaListKind() const override {
-    return TargetInfo::VoidPtrBuiltinVaList;
+    return TargetInfo::CharPtrBuiltinVaList;
   }
 
   bool isValidCPUName(StringRef Name) const override {


### PR DESCRIPTION
Summary:
This was changed to `void *` from `char *` unintentionally, put it back.
