### PR TITLE
[PPC] Disable vsx and altivec when -msoft-float is used

### DIFF
--- a/clang/lib/Basic/Targets/PPC.cpp
+++ b/clang/lib/Basic/Targets/PPC.cpp
@@ -489,6 +489,7 @@ static bool ppcUserFeaturesCheck(DiagnosticsEngine &Diags,
     Found |= FindVSXSubfeature("+paired-vector-memops",
                                "-mpaired-vector-memops", "-msoft-float");
     Found |= FindVSXSubfeature("+mma", "-mmma", "-msoft-float");
+    Found |= FindVSXSubfeature("+crypto", "-mcrypto", "-msoft-float");
     Found |= FindVSXSubfeature("+power10-vector", "-mpower10-vector",
                                "-msoft-float");
   }
@@ -707,6 +708,7 @@ bool PPCTargetInfo::initFeatureMap(
     Features["power10-vector"] = false;
     Features["float128"] = false;
     Features["mma"] = false;
+    Features["crypto"] = false;
   }
 
   return TargetInfo::initFeatureMap(Features, Diags, CPU, FeaturesVec);

--- a/clang/lib/Basic/Targets/PPC.cpp
+++ b/clang/lib/Basic/Targets/PPC.cpp
@@ -690,6 +690,11 @@ bool PPCTargetInfo::initFeatureMap(
     return false;
   }
 
+  if (llvm::is_contained(FeaturesVec, "-hard-float")) {
+    Features["altivec"] = false;
+    Features["vsx"] = false;
+  }
+
   return TargetInfo::initFeatureMap(Features, Diags, CPU, FeaturesVec);
 }
 

--- a/clang/lib/Basic/Targets/PPC.cpp
+++ b/clang/lib/Basic/Targets/PPC.cpp
@@ -786,8 +786,8 @@ void PPCTargetInfo::setFeatureEnabled(llvm::StringMap<bool> &Features,
   } else {
     if (Name == "spe")
       Features["efpu2"] = false;
-    // If we're disabling altivec or vsx go ahead and disable all of the vsx
-    // features.
+    // If we're disabling altivec, hard-float, or vsx go ahead and disable all
+    // of the vsx features.
     if ((Name == "altivec") || (Name == "vsx") || (Name == "hard-float")) {
       if (Name != "vsx")
         Features["altivec"] = Features["crypto"] = false;

--- a/clang/lib/Basic/Targets/PPC.cpp
+++ b/clang/lib/Basic/Targets/PPC.cpp
@@ -697,20 +697,6 @@ bool PPCTargetInfo::initFeatureMap(
     Diags.Report(diag::err_opt_not_valid_with_opt) << "-mprivileged" << CPU;
     return false;
   }
-
-  if (llvm::is_contained(FeaturesVec, "-hard-float")) {
-    Features["altivec"] = false;
-    Features["vsx"] = false;
-    Features["direct-move"] = false;
-    Features["power8-vector"] = false;
-    Features["power9-vector"] = false;
-    Features["paired-vector-memops"] = false;
-    Features["power10-vector"] = false;
-    Features["float128"] = false;
-    Features["mma"] = false;
-    Features["crypto"] = false;
-  }
-
   return TargetInfo::initFeatureMap(Features, Diags, CPU, FeaturesVec);
 }
 
@@ -802,11 +788,14 @@ void PPCTargetInfo::setFeatureEnabled(llvm::StringMap<bool> &Features,
       Features["efpu2"] = false;
     // If we're disabling altivec or vsx go ahead and disable all of the vsx
     // features.
-    if ((Name == "altivec") || (Name == "vsx"))
+    if ((Name == "altivec") || (Name == "vsx") || (Name == "hard-float")) {
+      if (Name != "vsx")
+        Features["altivec"] = Features["crypto"] = false;
       Features["vsx"] = Features["direct-move"] = Features["power8-vector"] =
           Features["float128"] = Features["power9-vector"] =
               Features["paired-vector-memops"] = Features["mma"] =
                   Features["power10-vector"] = false;
+    }
     if (Name == "power8-vector")
       Features["power9-vector"] = Features["paired-vector-memops"] =
           Features["mma"] = Features["power10-vector"] = false;

--- a/clang/test/Driver/ppc-dependent-options.cpp
+++ b/clang/test/Driver/ppc-dependent-options.cpp
@@ -113,6 +113,10 @@
 // RUN: -std=c++11 -msoft-float -mpaired-vector-memops %s 2>&1 | \
 // RUN: FileCheck %s -check-prefix=CHECK-SOFTFLT-PAIREDVECMEMOP
 
+// RUN: not %clang -target powerpc64le-unknown-unknown -fsyntax-only \
+// RUN: -std=c++11 -msoft-float -mcrypto %s 2>&1 | \
+// RUN: FileCheck %s -check-prefix=CHECK-SOFTFLT-CRYPTO
+
 #ifdef __VSX__
 static_assert(false, "VSX enabled");
 #endif
@@ -159,3 +163,4 @@ static_assert(false, "Neither enabled");
 // CHECK-SOFTFLT-DIRECTMOVE: error: option '-mdirect-move' cannot be specified with '-msoft-float'
 // CHECK-SOFTFLT-MMA: error: option '-mmma' cannot be specified with '-msoft-float'
 // CHECK-SOFTFLT-PAIREDVECMEMOP: error: option '-mpaired-vector-memops' cannot be specified with '-msoft-float'
+// CHECK-SOFTFLT-CRYPTO: error: option '-mcrypto' cannot be specified with '-msoft-float'

--- a/clang/test/Driver/ppc-dependent-options.cpp
+++ b/clang/test/Driver/ppc-dependent-options.cpp
@@ -89,6 +89,30 @@
 // RUN: -std=c++11 -msoft-float -mvsx %s 2>&1 | \
 // RUN: FileCheck %s -check-prefix=CHECK-SOFTFLT-VSX
 
+// RUN: not %clang -target powerpc64le-unknown-unknown -fsyntax-only \
+// RUN: -std=c++11 -msoft-float -mpower8-vector %s 2>&1 | \
+// RUN: FileCheck %s -check-prefix=CHECK-SOFTFLT-P8VEC
+
+// RUN: not %clang -target powerpc64le-unknown-unknown -fsyntax-only \
+// RUN: -std=c++11 -msoft-float -mpower9-vector %s 2>&1 | \
+// RUN: FileCheck %s -check-prefix=CHECK-SOFTFLT-P9VEC
+
+// RUN: not %clang -target powerpc64le-unknown-unknown -fsyntax-only \
+// RUN: -std=c++11 -msoft-float -mpower10-vector %s 2>&1 | \
+// RUN: FileCheck %s -check-prefix=CHECK-SOFTFLT-P10VEC
+
+// RUN: not %clang -target powerpc64le-unknown-unknown -fsyntax-only \
+// RUN: -std=c++11 -msoft-float -mdirect-move %s 2>&1 | \
+// RUN: FileCheck %s -check-prefix=CHECK-SOFTFLT-DIRECTMOVE
+
+// RUN: not %clang -target powerpc64le-unknown-unknown -fsyntax-only \
+// RUN: -std=c++11 -msoft-float -mmma %s 2>&1 | \
+// RUN: FileCheck %s -check-prefix=CHECK-SOFTFLT-MMA
+
+// RUN: not %clang -target powerpc64le-unknown-unknown -fsyntax-only \
+// RUN: -std=c++11 -msoft-float -mpaired-vector-memops %s 2>&1 | \
+// RUN: FileCheck %s -check-prefix=CHECK-SOFTFLT-PAIREDVECMEMOP
+
 #ifdef __VSX__
 static_assert(false, "VSX enabled");
 #endif
@@ -126,5 +150,12 @@ static_assert(false, "Neither enabled");
 // CHECK-NVSX: Neither enabled
 // CHECK-VSX: VSX enabled
 // CHECK-NALTI-VSX: error: option '-mvsx' cannot be specified with '-mno-altivec'
-// CHECK-SOFTFLT-ALTI: error: option '-msoft-float' cannot be specified with '-maltivec'
-// CHECK-SOFTFLT-VSX: error: option '-msoft-float' cannot be specified with '-mvsx'
+// CHECK-SOFTFLT-ALTI: error: option '-maltivec' cannot be specified with '-msoft-float'
+// CHECK-SOFTFLT-VSX: error: option '-mvsx' cannot be specified with '-msoft-float'
+// CHECK-SOFTFLT-FLOAT128: error: option '-mfloat128' cannot be specified with '-msoft-float'
+// CHECK-SOFTFLT-P8VEC: error: option '-mpower8-vector' cannot be specified with '-msoft-float'
+// CHECK-SOFTFLT-P9VEC: error: option '-mpower9-vector' cannot be specified with '-msoft-float'
+// CHECK-SOFTFLT-P10VEC: error: option '-mpower10-vector' cannot be specified with '-msoft-float'
+// CHECK-SOFTFLT-DIRECTMOVE: error: option '-mdirect-move' cannot be specified with '-msoft-float'
+// CHECK-SOFTFLT-MMA: error: option '-mmma' cannot be specified with '-msoft-float'
+// CHECK-SOFTFLT-PAIREDVECMEMOP: error: option '-mpaired-vector-memops' cannot be specified with '-msoft-float'

--- a/clang/test/Driver/ppc-soft-float.c
+++ b/clang/test/Driver/ppc-soft-float.c
@@ -8,19 +8,21 @@ int main () {
 // CHECKSOFT-DAG: -hard-float
 // CHECKSOFT-DAG: -vsx
 // CHECKSOFT-DAG: -altivec
-// CHECKSOFT-DAG: -direct-move,
+// CHECKSOFT-DAG: -direct-move
 // CHECKSOFT-DAG: -float128
 // CHECKSOFT-DAG: -mma
 // CHECKSOFT-DAG: -paired-vector-memops
 // CHECKSOFT-DAG: -power10-vector
 // CHECKSOFT-DAG: -power9-vector
 // CHECKSOFT-DAG: -power8-vector
+// CHECKSOFT-DAG: -crypto
 
 // CHECKNOSOFT-DAG: +vsx
 // CHECKNOSOFT-DAG: +altivec
-// CHECKNOSOFT-DAG: +direct-move,
+// CHECKNOSOFT-DAG: +direct-move
 // CHECKNOSOFT-DAG: +mma
 // CHECKNOSOFT-DAG: +paired-vector-memops
 // CHECKNOSOFT-DAG: +power10-vector
 // CHECKNOSOFT-DAG: +power9-vector
 // CHECKNOSOFT-DAG: +power8-vector
+// CHECKNOSOFT-DAG: +crypto

--- a/clang/test/Driver/ppc-soft-float.c
+++ b/clang/test/Driver/ppc-soft-float.c
@@ -8,6 +8,19 @@ int main () {
 // CHECKSOFT-DAG: -hard-float
 // CHECKSOFT-DAG: -vsx
 // CHECKSOFT-DAG: -altivec
+// CHECKSOFT-DAG: -direct-move,
+// CHECKSOFT-DAG: -float128
+// CHECKSOFT-DAG: -mma
+// CHECKSOFT-DAG: -paired-vector-memops
+// CHECKSOFT-DAG: -power10-vector
+// CHECKSOFT-DAG: -power9-vector
+// CHECKSOFT-DAG: -power8-vector
 
 // CHECKNOSOFT-DAG: +vsx
 // CHECKNOSOFT-DAG: +altivec
+// CHECKNOSOFT-DAG: +direct-move,
+// CHECKNOSOFT-DAG: +mma
+// CHECKNOSOFT-DAG: +paired-vector-memops
+// CHECKNOSOFT-DAG: +power10-vector
+// CHECKNOSOFT-DAG: +power9-vector
+// CHECKNOSOFT-DAG: +power8-vector

--- a/clang/test/Driver/ppc-soft-float.c
+++ b/clang/test/Driver/ppc-soft-float.c
@@ -1,0 +1,13 @@
+// RUN: %clang -target powerpc64-unknown-unknown -mcpu=pwr10 -msoft-float -S -emit-llvm %s -o - | FileCheck %s -check-prefix=CHECKSOFT
+// RUN: %clang -target powerpc64-unknown-unknown -mcpu=pwr10 -S -emit-llvm %s -o - | FileCheck %s -check-prefix=CHECKNOSOFT
+
+int main () {
+  return 0;
+}
+
+// CHECKSOFT-DAG: -hard-float
+// CHECKSOFT-DAG: -vsx
+// CHECKSOFT-DAG: -altivec
+
+// CHECKNOSOFT-DAG: +vsx
+// CHECKNOSOFT-DAG: +altivec


### PR DESCRIPTION
We emit an error when -msoft-float and -maltivec/-mvsx is used together, but when -msoft-float is used on its own, there is still +altivec and +vsx in the IR attributes. This patch disables altivec and vsx and all related sub features when -msoft-float is used.