### PR TITLE
[Frontend][OpenMP] Allow implicit clauses to fail to apply

### DIFF
--- a/llvm/unittests/Frontend/OpenMPDecompositionTest.cpp
+++ b/llvm/unittests/Frontend/OpenMPDecompositionTest.cpp
@@ -1100,4 +1100,21 @@ TEST_F(OpenMPDecompositionTest, Nowait1) {
   ASSERT_EQ(Dir1, "parallel");      // (23)
   ASSERT_EQ(Dir2, "for");           // (23)
 }
+
+// ---
+
+// Check that "simd linear(x)" does not fail despite the implied "firstprivate"
+// (which "simd" does not allow).
+TEST_F(OpenMPDecompositionTest, Misc1) {
+  omp::Object x{"x"};
+  omp::List<omp::Clause> Clauses{
+      {OMPC_linear,
+       omp::clause::Linear{{std::nullopt, std::nullopt, std::nullopt, {x}}}},
+  };
+
+  omp::ConstructDecomposition Dec(AnyVersion, Helper, OMPD_simd, Clauses);
+  ASSERT_EQ(Dec.output.size(), 1u);
+  std::string Dir0 = stringify(Dec.output[0]);
+  ASSERT_EQ(Dir0, "simd linear(, , , (x)) lastprivate(, (x))");
+}
 } // namespace


### PR DESCRIPTION
The `linear(x)` clause implies `firstprivate(x)` on the compound construct if `x` is not an induction variable. With more construct combinations coming in OpenMP 6.0, the `firstprivate` clause may not be possible to apply, e.g. in "masked simd".
An additional benefit from this change is that it allows treating leaf constructs as combined constructs with a single constituent. Otherwise, a `linear` clause on a lone `simd` construct could imply a `firstprivate` clause that can't be applied.