### PR TITLE
[libc][newheadergen]: PyYaml Version Update

### DIFF
--- a/libc/docs/dev/header_generation.rst
+++ b/libc/docs/dev/header_generation.rst
@@ -23,6 +23,7 @@ Instructions
 
 Required Versions:
   - Python Version: 3.11.8
+  - PyYaml Version: 5.1
 
 1. Keep full-build mode on when building, otherwise headers will not be
    generated.

--- a/libc/docs/dev/header_generation.rst
+++ b/libc/docs/dev/header_generation.rst
@@ -22,8 +22,8 @@ Instructions
 ------------
 
 Required Versions:
-  - Python Version: 3.11.8
-  - PyYaml Version: 5.1
+  - Python Version: 3.6
+  - PyYAML Version: 5.1
 
 1. Keep full-build mode on when building, otherwise headers will not be
    generated.


### PR DESCRIPTION
- a lot of builds had an issue using new headergen because they do not have PyYaml installed.