### PR TITLE
[lldb][test][win][x86_64] XFAIL already failing Shell/Driver tests

### DIFF
--- a/lldb/test/Shell/Driver/TestConvenienceVariables.test
+++ b/lldb/test/Shell/Driver/TestConvenienceVariables.test
@@ -3,6 +3,7 @@ RUN: mkdir -p %t
 RUN: %build %p/Inputs/hello.cpp -o %t/target.out
 RUN: %lldb %t/target.out -s %p/Inputs/convenience.in -o quit | FileCheck %s
 
+# XFAIL: target=x86_64-{{.*}}-windows{{.*}}
 CHECK: stop reason = breakpoint 1.1
 CHECK: script print(lldb.debugger)
 CHECK-NEXT: Debugger (instance: {{.*}}, id: {{[0-9]+}})

--- a/lldb/test/Shell/Driver/TestSingleQuote.test
+++ b/lldb/test/Shell/Driver/TestSingleQuote.test
@@ -2,5 +2,6 @@
 # RUN: %clang_host %p/Inputs/hello.c -g -o "%t-'pat"
 # RUN: %lldb -s %s "%t-'pat" | FileCheck %s
 
+# XFAIL: target=x86_64-{{.*}}-windows{{.*}}
 br set -p return
 # CHECK: Breakpoint 1: where = TestSingleQuote.test.tmp-'pat`main


### PR DESCRIPTION
I'm currently working on getting the LLDB test suites to pass on Windows x86_64 which is not currently included in LLVM CI. These tests are currently failing in this configuration.

See  https://github.com/llvm/llvm-project/issues/100474