### PR TITLE
[lldb][test][win][x86_64] Fix XFAIL and XPASS on LLDB API tests

### DIFF
--- a/lldb/test/API/functionalities/multiple-slides/TestMultipleSlides.py
+++ b/lldb/test/API/functionalities/multiple-slides/TestMultipleSlides.py
@@ -12,6 +12,7 @@ from lldbsuite.test import lldbutil
 class MultipleSlidesTestCase(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
 
+    @expectedFailureAll(oslist=["windows"], archs=["x86_64"])
     def test_mulitple_slides(self):
         """Test that a binary can be slid multiple times correctly."""
         self.build()

--- a/lldb/test/API/lang/cpp/class-template-non-type-parameter-pack/TestClassTemplateNonTypeParameterPack.py
+++ b/lldb/test/API/lang/cpp/class-template-non-type-parameter-pack/TestClassTemplateNonTypeParameterPack.py
@@ -6,7 +6,7 @@ from lldbsuite.test import lldbutil
 
 class TestCaseClassTemplateNonTypeParameterPack(TestBase):
     @expectedFailureAll(
-        oslist=["windows"], archs=["i[3-6]86", "x86_64"]
+        oslist=["windows"], archs=["i[3-6]86"]
     )  # Fails to read memory from target.
     @no_debug_info_test
     def test(self):

--- a/lldb/test/API/lang/cpp/class-template-type-parameter-pack/TestClassTemplateTypeParameterPack.py
+++ b/lldb/test/API/lang/cpp/class-template-type-parameter-pack/TestClassTemplateTypeParameterPack.py
@@ -6,7 +6,7 @@ from lldbsuite.test import lldbutil
 
 class TestCaseClassTemplateTypeParameterPack(TestBase):
     @expectedFailureAll(
-        oslist=["windows"], archs=["i[3-6]86", "x86_64"]
+        oslist=["windows"], archs=["i[3-6]86"]
     )  # Fails to read memory from target.
     @no_debug_info_test
     def test(self):

--- a/lldb/test/API/python_api/thread/TestThreadAPI.py
+++ b/lldb/test/API/python_api/thread/TestThreadAPI.py
@@ -52,6 +52,7 @@ class ThreadAPITestCase(TestBase):
         self.build()
         self.validate_negative_indexing()
  
+    @expectedFailureAll(oslist=["windows"], archs=["x86_64"])
     def test_StepInstruction(self):
         """Test that StepInstruction preserves the plan stack."""
         self.build()


### PR DESCRIPTION
I'm currently working on getting the LLDB test suites to pass on Windows x86_64 which is not currently included in LLVM CI. These tests are currently failing in this configuration.

See https://github.com/llvm/llvm-project/issues/100474

See also https://github.com/llvm/llvm-project/issues/75936