### PR TITLE
Normalize ptrauth handling in sanitizer runtime

### DIFF
--- a/compiler-rt/lib/sanitizer_common/sanitizer_ptrauth.h
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_ptrauth.h
@@ -10,32 +10,32 @@
 #define SANITIZER_PTRAUTH_H
 
 #if __has_feature(ptrauth_intrinsics)
-#include <ptrauth.h>
+#  include <ptrauth.h>
 #elif defined(__ARM_FEATURE_PAC_DEFAULT) && !defined(__APPLE__)
 // On the stack the link register is protected with Pointer
 // Authentication Code when compiled with -mbranch-protection.
 // Let's stripping the PAC unconditionally because xpaclri is in
 // the NOP space so will do nothing when it is not enabled or not available.
-#define ptrauth_strip(__value, __key)     \
-  ({                                      \
-      unsigned long ret;                  \
-      asm volatile(                       \
-        "mov x30, %1\n\t"                 \
-        "hint #7\n\t"                     \
-        "mov %0, x30\n\t"                 \
-        "mov x30, xzr\n\t"                \
-        : "=r"(ret)                       \
-        : "r"(__value)                    \
-        : "x30");                         \
-      ret;                                \
-  })
-#define ptrauth_auth_data(__value, __old_key, __old_data) __value
-#define ptrauth_string_discriminator(__string) ((int)0)
+#  define ptrauth_strip(__value, __key) \
+    ({                                  \
+      unsigned long ret;                \
+      asm volatile(                     \
+          "mov x30, %1\n\t"             \
+          "hint #7\n\t"                 \
+          "mov %0, x30\n\t"             \
+          "mov x30, xzr\n\t"            \
+          : "=r"(ret)                   \
+          : "r"(__value)                \
+          : "x30");                     \
+      ret;                              \
+    })
+#  define ptrauth_auth_data(__value, __old_key, __old_data) __value
+#  define ptrauth_string_discriminator(__string) ((int)0)
 #else
 // Copied from <ptrauth.h>
-#define ptrauth_strip(__value, __key) __value
-#define ptrauth_auth_data(__value, __old_key, __old_data) __value
-#define ptrauth_string_discriminator(__string) ((int)0)
+#  define ptrauth_strip(__value, __key) __value
+#  define ptrauth_auth_data(__value, __old_key, __old_data) __value
+#  define ptrauth_string_discriminator(__string) ((int)0)
 #endif
 
 #define STRIP_PAC_PC(pc) ((uptr)ptrauth_strip(pc, 0))


### PR DESCRIPTION
 1. Include `ptrauth.h` if `ptrauth_intrinsics` language feature is specified (per ptrauth spec, this is what enables `ptrauh.h` usage and functions like `ptrauth_strip`)
 2. For PAC-RET fallback implement two changes:
    1. Switch to macro, so we can ignore key argument
    2. Ensure the unsigned value is erased from LR, so the possibility of gadget reuse is reduced.

Fixes #100467