### PR TITLE
[lldb][test][x86_64][win] Split assertion in TestBreakpointConditions

### DIFF
--- a/lldb/test/API/functionalities/breakpoint/breakpoint_conditions/TestBreakpointConditions.py
+++ b/lldb/test/API/functionalities/breakpoint/breakpoint_conditions/TestBreakpointConditions.py
@@ -176,11 +176,15 @@ class BreakpointConditionsTestCase(TestBase):
             thread.IsValid(),
             "There should be a thread stopped due to breakpoint condition",
         )
+
         frame0 = thread.GetFrameAtIndex(0)
         var = frame0.FindValue("val", lldb.eValueTypeVariableArgument)
-        self.assertTrue(
-            frame0.GetLineEntry().GetLine() == self.line1 and var.GetValue() == "3"
+        self.assertEqual(
+            frame0.GetLineEntry().GetLine(),
+            self.line1,
+            "The debugger stopped on the correct line",
         )
+        self.assertEqual(var.GetValue(), "3")
 
         # The hit count for the breakpoint should be 1.
         self.assertEqual(breakpoint.GetHitCount(), 1)


### PR DESCRIPTION
This PR splits the test assertion that verifies we're on the correct line and have the correct value of `val` to make the error message more clear. At present it just shows `Assertion error: True != False`