### PR TITLE
[COFF] Do not expose WinCOFFWriter to llvm namespace

### DIFF
--- a/llvm/include/llvm/MC/MCWinCOFFObjectWriter.h
+++ b/llvm/include/llvm/MC/MCWinCOFFObjectWriter.h
@@ -44,12 +44,6 @@ public:
 };
 
 class WinCOFFObjectWriter final : public MCObjectWriter {
-  class WinCOFFWriter;
-
-  std::unique_ptr<MCWinCOFFObjectTargetWriter> TargetObjectWriter;
-  std::unique_ptr<WinCOFFWriter> ObjWriter, DwoWriter;
-  bool IncrementalLinkerCompatible = false;
-
 public:
   WinCOFFObjectWriter(std::unique_ptr<MCWinCOFFObjectTargetWriter> MOTW,
                       raw_pwrite_stream &OS);
@@ -70,6 +64,12 @@ public:
                         const MCFixup &Fixup, MCValue Target,
                         uint64_t &FixedValue) override;
   uint64_t writeObject(MCAssembler &Asm) override;
+
+  std::unique_ptr<MCWinCOFFObjectTargetWriter> TargetObjectWriter;
+  bool IncrementalLinkerCompatible = false;
+
+private:
+  std::unique_ptr<MCObjectWriterBase> ObjWriter, DwoWriter;
 };
 
 /// Construct a new Win COFF writer instance.

--- a/llvm/include/llvm/MC/MCWinCOFFObjectWriter.h
+++ b/llvm/include/llvm/MC/MCWinCOFFObjectWriter.h
@@ -43,10 +43,8 @@ public:
   virtual bool recordRelocation(const MCFixup &) const { return true; }
 };
 
-class WinCOFFWriter;
-
 class WinCOFFObjectWriter final : public MCObjectWriter {
-  friend class WinCOFFWriter;
+  class WinCOFFWriter;
 
   std::unique_ptr<MCWinCOFFObjectTargetWriter> TargetObjectWriter;
   std::unique_ptr<WinCOFFWriter> ObjWriter, DwoWriter;

--- a/llvm/include/llvm/MC/MCWinCOFFObjectWriter.h
+++ b/llvm/include/llvm/MC/MCWinCOFFObjectWriter.h
@@ -71,19 +71,6 @@ public:
 private:
   std::unique_ptr<MCObjectWriterBase> ObjWriter, DwoWriter;
 };
-
-/// Construct a new Win COFF writer instance.
-///
-/// \param MOTW - The target specific WinCOFF writer subclass.
-/// \param OS - The stream to write to.
-/// \returns The constructed object writer.
-std::unique_ptr<MCObjectWriter>
-createWinCOFFObjectWriter(std::unique_ptr<MCWinCOFFObjectTargetWriter> MOTW,
-                          raw_pwrite_stream &OS);
-
-std::unique_ptr<MCObjectWriter>
-createWinCOFFDwoObjectWriter(std::unique_ptr<MCWinCOFFObjectTargetWriter> MOTW,
-                             raw_pwrite_stream &OS, raw_pwrite_stream &DwoOS);
 } // end namespace llvm
 
 #endif // LLVM_MC_MCWINCOFFOBJECTWRITER_H

--- a/llvm/lib/MC/MCAsmBackend.cpp
+++ b/llvm/lib/MC/MCAsmBackend.cpp
@@ -38,7 +38,7 @@ MCAsmBackend::createObjectWriter(raw_pwrite_stream &OS) const {
     return createMachObjectWriter(cast<MCMachObjectTargetWriter>(std::move(TW)),
                                   OS, IsLE);
   case Triple::COFF:
-    return createWinCOFFObjectWriter(
+    return std::make_unique<WinCOFFObjectWriter>(
         cast<MCWinCOFFObjectTargetWriter>(std::move(TW)), OS);
   case Triple::ELF:
     return std::make_unique<ELFObjectWriter>(
@@ -69,7 +69,7 @@ MCAsmBackend::createDwoObjectWriter(raw_pwrite_stream &OS,
   auto TW = createObjectTargetWriter();
   switch (TW->getFormat()) {
   case Triple::COFF:
-    return createWinCOFFDwoObjectWriter(
+    return std::make_unique<WinCOFFObjectWriter>(
         cast<MCWinCOFFObjectTargetWriter>(std::move(TW)), OS, DwoOS);
   case Triple::ELF:
     return std::make_unique<ELFObjectWriter>(

--- a/llvm/lib/MC/MCObjectWriter.cpp
+++ b/llvm/lib/MC/MCObjectWriter.cpp
@@ -17,17 +17,9 @@ class MCSection;
 
 using namespace llvm;
 
-MCObjectWriter::~MCObjectWriter() = default;
+MCObjectWriterBase::~MCObjectWriterBase() = default;
 
-void MCObjectWriter::reset() {
-  FileNames.clear();
-  AddrsigSyms.clear();
-  EmitAddrsigSection = false;
-  SubsectionsViaSymbols = false;
-  CGProfile.clear();
-}
-
-bool MCObjectWriter::isSymbolRefDifferenceFullyResolved(
+bool MCObjectWriterBase::isSymbolRefDifferenceFullyResolved(
     const MCAssembler &Asm, const MCSymbolRefExpr *A, const MCSymbolRefExpr *B,
     bool InSet) const {
   // Modified symbol references cannot be resolved.
@@ -45,13 +37,21 @@ bool MCObjectWriter::isSymbolRefDifferenceFullyResolved(
   return isSymbolRefDifferenceFullyResolvedImpl(Asm, SA, *FB, InSet, /*IsPCRel=*/false);
 }
 
-bool MCObjectWriter::isSymbolRefDifferenceFullyResolvedImpl(
+bool MCObjectWriterBase::isSymbolRefDifferenceFullyResolvedImpl(
     const MCAssembler &Asm, const MCSymbol &SymA, const MCFragment &FB,
     bool InSet, bool IsPCRel) const {
   const MCSection &SecA = SymA.getSection();
   const MCSection &SecB = *FB.getParent();
   // On ELF and COFF  A - B is absolute if A and B are in the same section.
   return &SecA == &SecB;
+}
+
+void MCObjectWriter::reset() {
+  FileNames.clear();
+  AddrsigSyms.clear();
+  EmitAddrsigSection = false;
+  SubsectionsViaSymbols = false;
+  CGProfile.clear();
 }
 
 void MCObjectWriter::addFileName(MCAssembler &Asm, StringRef FileName) {

--- a/llvm/lib/MC/WinCOFFObjectWriter.cpp
+++ b/llvm/lib/MC/WinCOFFObjectWriter.cpp
@@ -1200,17 +1200,3 @@ MCWinCOFFObjectTargetWriter::MCWinCOFFObjectTargetWriter(unsigned Machine_)
 
 // Pin the vtable to this file.
 void MCWinCOFFObjectTargetWriter::anchor() {}
-
-//------------------------------------------------------------------------------
-// WinCOFFObjectWriter factory function
-
-std::unique_ptr<MCObjectWriter> llvm::createWinCOFFObjectWriter(
-    std::unique_ptr<MCWinCOFFObjectTargetWriter> MOTW, raw_pwrite_stream &OS) {
-  return std::make_unique<WinCOFFObjectWriter>(std::move(MOTW), OS);
-}
-
-std::unique_ptr<MCObjectWriter> llvm::createWinCOFFDwoObjectWriter(
-    std::unique_ptr<MCWinCOFFObjectTargetWriter> MOTW, raw_pwrite_stream &OS,
-    raw_pwrite_stream &DwoOS) {
-  return std::make_unique<WinCOFFObjectWriter>(std::move(MOTW), OS, DwoOS);
-}

--- a/llvm/lib/MC/WinCOFFObjectWriter.cpp
+++ b/llvm/lib/MC/WinCOFFObjectWriter.cpp
@@ -121,7 +121,7 @@ public:
 };
 } // namespace
 
-class llvm::WinCOFFWriter {
+class WinCOFFObjectWriter::WinCOFFWriter {
   WinCOFFObjectWriter &OWriter;
   support::endian::Writer W;
 
@@ -227,8 +227,9 @@ void COFFSymbol::set_name_offset(uint32_t Offset) {
 //------------------------------------------------------------------------------
 // WinCOFFWriter class implementation
 
-WinCOFFWriter::WinCOFFWriter(WinCOFFObjectWriter &OWriter,
-                             raw_pwrite_stream &OS, DwoMode Mode)
+WinCOFFObjectWriter::WinCOFFWriter::WinCOFFWriter(WinCOFFObjectWriter &OWriter,
+                                                  raw_pwrite_stream &OS,
+                                                  DwoMode Mode)
     : OWriter(OWriter), W(OS, llvm::endianness::little), Mode(Mode) {
   Header.Machine = OWriter.TargetObjectWriter->getMachine();
   // Some relocations on ARM64 (the 21 bit ADRP relocations) have a slightly
@@ -238,19 +239,20 @@ WinCOFFWriter::WinCOFFWriter(WinCOFFObjectWriter &OWriter,
   UseOffsetLabels = COFF::isAnyArm64(Header.Machine);
 }
 
-COFFSymbol *WinCOFFWriter::createSymbol(StringRef Name) {
+COFFSymbol *WinCOFFObjectWriter::WinCOFFWriter::createSymbol(StringRef Name) {
   Symbols.push_back(std::make_unique<COFFSymbol>(Name));
   return Symbols.back().get();
 }
 
-COFFSymbol *WinCOFFWriter::GetOrCreateCOFFSymbol(const MCSymbol *Symbol) {
+COFFSymbol *WinCOFFObjectWriter::WinCOFFWriter::GetOrCreateCOFFSymbol(
+    const MCSymbol *Symbol) {
   COFFSymbol *&Ret = SymbolMap[Symbol];
   if (!Ret)
     Ret = createSymbol(Symbol->getName());
   return Ret;
 }
 
-COFFSection *WinCOFFWriter::createSection(StringRef Name) {
+COFFSection *WinCOFFObjectWriter::WinCOFFWriter::createSection(StringRef Name) {
   Sections.emplace_back(std::make_unique<COFFSection>(Name));
   return Sections.back().get();
 }
@@ -291,8 +293,8 @@ static uint32_t getAlignment(const MCSectionCOFF &Sec) {
 
 /// This function takes a section data object from the assembler
 /// and creates the associated COFF section staging object.
-void WinCOFFWriter::defineSection(const MCAssembler &Asm,
-                                  const MCSectionCOFF &MCSec) {
+void WinCOFFObjectWriter::WinCOFFWriter::defineSection(
+    const MCAssembler &Asm, const MCSectionCOFF &MCSec) {
   COFFSection *Section = createSection(MCSec.getName());
   COFFSymbol *Symbol = createSymbol(MCSec.getName());
   Section->Symbol = Symbol;
@@ -350,7 +352,8 @@ static uint64_t getSymbolValue(const MCSymbol &Symbol, const MCAssembler &Asm) {
   return Res;
 }
 
-COFFSymbol *WinCOFFWriter::getLinkedSymbol(const MCSymbol &Symbol) {
+COFFSymbol *
+WinCOFFObjectWriter::WinCOFFWriter::getLinkedSymbol(const MCSymbol &Symbol) {
   if (!Symbol.isVariable())
     return nullptr;
 
@@ -368,8 +371,8 @@ COFFSymbol *WinCOFFWriter::getLinkedSymbol(const MCSymbol &Symbol) {
 
 /// This function takes a symbol data object from the assembler
 /// and creates the associated COFF symbol staging object.
-void WinCOFFWriter::defineSymbol(const MCAssembler &Asm,
-                                 const MCSymbol &MCSym) {
+void WinCOFFObjectWriter::WinCOFFWriter::defineSymbol(const MCAssembler &Asm,
+                                                      const MCSymbol &MCSym) {
   const MCSymbol *Base = Asm.getBaseSymbol(MCSym);
   COFFSection *Sec = nullptr;
   MCSectionCOFF *MCSec = nullptr;
@@ -436,7 +439,7 @@ void WinCOFFWriter::defineSymbol(const MCAssembler &Asm,
   Sym->MC = &MCSym;
 }
 
-void WinCOFFWriter::SetSectionName(COFFSection &S) {
+void WinCOFFObjectWriter::WinCOFFWriter::SetSectionName(COFFSection &S) {
   if (S.Name.size() <= COFF::NameSize) {
     std::memcpy(S.Header.Name, S.Name.c_str(), S.Name.size());
     return;
@@ -447,14 +450,14 @@ void WinCOFFWriter::SetSectionName(COFFSection &S) {
     report_fatal_error("COFF string table is greater than 64 GB.");
 }
 
-void WinCOFFWriter::SetSymbolName(COFFSymbol &S) {
+void WinCOFFObjectWriter::WinCOFFWriter::SetSymbolName(COFFSymbol &S) {
   if (S.Name.size() > COFF::NameSize)
     S.set_name_offset(Strings.getOffset(S.Name));
   else
     std::memcpy(S.Data.Name, S.Name.c_str(), S.Name.size());
 }
 
-bool WinCOFFWriter::IsPhysicalSection(COFFSection *S) {
+bool WinCOFFObjectWriter::WinCOFFWriter::IsPhysicalSection(COFFSection *S) {
   return (S->Header.Characteristics & COFF::IMAGE_SCN_CNT_UNINITIALIZED_DATA) ==
          0;
 }
@@ -462,7 +465,8 @@ bool WinCOFFWriter::IsPhysicalSection(COFFSection *S) {
 //------------------------------------------------------------------------------
 // entity writing methods
 
-void WinCOFFWriter::WriteFileHeader(const COFF::header &Header) {
+void WinCOFFObjectWriter::WinCOFFWriter::WriteFileHeader(
+    const COFF::header &Header) {
   if (UseBigObj) {
     W.write<uint16_t>(COFF::IMAGE_FILE_MACHINE_UNKNOWN);
     W.write<uint16_t>(0xFFFF);
@@ -488,7 +492,7 @@ void WinCOFFWriter::WriteFileHeader(const COFF::header &Header) {
   }
 }
 
-void WinCOFFWriter::WriteSymbol(const COFFSymbol &S) {
+void WinCOFFObjectWriter::WinCOFFWriter::WriteSymbol(const COFFSymbol &S) {
   W.OS.write(S.Data.Name, COFF::NameSize);
   W.write<uint32_t>(S.Data.Value);
   if (UseBigObj)
@@ -501,7 +505,7 @@ void WinCOFFWriter::WriteSymbol(const COFFSymbol &S) {
   WriteAuxiliarySymbols(S.Aux);
 }
 
-void WinCOFFWriter::WriteAuxiliarySymbols(
+void WinCOFFObjectWriter::WinCOFFWriter::WriteAuxiliarySymbols(
     const COFFSymbol::AuxiliarySymbols &S) {
   for (const AuxSymbol &i : S) {
     switch (i.AuxType) {
@@ -534,7 +538,7 @@ void WinCOFFWriter::WriteAuxiliarySymbols(
 }
 
 // Write the section header.
-void WinCOFFWriter::writeSectionHeaders() {
+void WinCOFFObjectWriter::WinCOFFWriter::writeSectionHeaders() {
   // Section numbers must be monotonically increasing in the section
   // header, but our Sections array is not sorted by section number,
   // so make a copy of Sections and sort it.
@@ -565,7 +569,8 @@ void WinCOFFWriter::writeSectionHeaders() {
   }
 }
 
-void WinCOFFWriter::WriteRelocation(const COFF::relocation &R) {
+void WinCOFFObjectWriter::WinCOFFWriter::WriteRelocation(
+    const COFF::relocation &R) {
   W.write<uint32_t>(R.VirtualAddress);
   W.write<uint32_t>(R.SymbolTableIndex);
   W.write<uint16_t>(R.Type);
@@ -574,8 +579,8 @@ void WinCOFFWriter::WriteRelocation(const COFF::relocation &R) {
 // Write MCSec's contents. What this function does is essentially
 // "Asm.writeSectionData(&MCSec)", but it's a bit complicated
 // because it needs to compute a CRC.
-uint32_t WinCOFFWriter::writeSectionContents(MCAssembler &Asm,
-                                             const MCSection &MCSec) {
+uint32_t WinCOFFObjectWriter::WinCOFFWriter::writeSectionContents(
+    MCAssembler &Asm, const MCSection &MCSec) {
   // Save the contents of the section to a temporary buffer, we need this
   // to CRC the data before we dump it into the object file.
   SmallVector<char, 128> Buf;
@@ -592,7 +597,8 @@ uint32_t WinCOFFWriter::writeSectionContents(MCAssembler &Asm,
   return JC.getCRC();
 }
 
-void WinCOFFWriter::writeSection(MCAssembler &Asm, const COFFSection &Sec) {
+void WinCOFFObjectWriter::WinCOFFWriter::writeSection(MCAssembler &Asm,
+                                                      const COFFSection &Sec) {
   if (Sec.Number == -1)
     return;
 
@@ -635,7 +641,7 @@ void WinCOFFWriter::writeSection(MCAssembler &Asm, const COFFSection &Sec) {
 }
 
 // Create .file symbols.
-void WinCOFFWriter::createFileSymbols(MCAssembler &Asm) {
+void WinCOFFObjectWriter::WinCOFFWriter::createFileSymbols(MCAssembler &Asm) {
   for (const std::pair<std::string, size_t> &It : OWriter.getFileNames()) {
     // round up to calculate the number of auxiliary symbols required
     const std::string &Name = It.first;
@@ -666,7 +672,7 @@ void WinCOFFWriter::createFileSymbols(MCAssembler &Asm) {
   }
 }
 
-void WinCOFFWriter::setWeakDefaultNames() {
+void WinCOFFObjectWriter::WinCOFFWriter::setWeakDefaultNames() {
   if (WeakDefaults.empty())
     return;
 
@@ -712,7 +718,7 @@ static bool isAssociative(const COFFSection &Section) {
          COFF::IMAGE_COMDAT_SELECT_ASSOCIATIVE;
 }
 
-void WinCOFFWriter::assignSectionNumbers() {
+void WinCOFFObjectWriter::WinCOFFWriter::assignSectionNumbers() {
   size_t I = 1;
   auto Assign = [&](COFFSection &Section) {
     Section.Number = I;
@@ -733,7 +739,7 @@ void WinCOFFWriter::assignSectionNumbers() {
 }
 
 // Assign file offsets to COFF object file structures.
-void WinCOFFWriter::assignFileOffsets(MCAssembler &Asm) {
+void WinCOFFObjectWriter::WinCOFFWriter::assignFileOffsets(MCAssembler &Asm) {
   unsigned Offset = W.OS.tell();
 
   Offset += UseBigObj ? COFF::Header32Size : COFF::Header16Size;
@@ -792,7 +798,7 @@ void WinCOFFWriter::assignFileOffsets(MCAssembler &Asm) {
   Header.PointerToSymbolTable = Offset;
 }
 
-void WinCOFFWriter::reset() {
+void WinCOFFObjectWriter::WinCOFFWriter::reset() {
   memset(&Header, 0, sizeof(Header));
   Header.Machine = OWriter.TargetObjectWriter->getMachine();
   Sections.clear();
@@ -803,7 +809,8 @@ void WinCOFFWriter::reset() {
   WeakDefaults.clear();
 }
 
-void WinCOFFWriter::executePostLayoutBinding(MCAssembler &Asm) {
+void WinCOFFObjectWriter::WinCOFFWriter::executePostLayoutBinding(
+    MCAssembler &Asm) {
   // "Define" each section & symbol. This creates section & symbol
   // entries in the staging area.
   for (const auto &Section : Asm) {
@@ -821,10 +828,9 @@ void WinCOFFWriter::executePostLayoutBinding(MCAssembler &Asm) {
         defineSymbol(Asm, Symbol);
 }
 
-void WinCOFFWriter::recordRelocation(MCAssembler &Asm,
-                                     const MCFragment *Fragment,
-                                     const MCFixup &Fixup, MCValue Target,
-                                     uint64_t &FixedValue) {
+void WinCOFFObjectWriter::WinCOFFWriter::recordRelocation(
+    MCAssembler &Asm, const MCFragment *Fragment, const MCFixup &Fixup,
+    MCValue Target, uint64_t &FixedValue) {
   assert(Target.getSymA() && "Relocation must reference a symbol!");
 
   const MCSymbol &A = Target.getSymA()->getSymbol();
@@ -978,7 +984,7 @@ static std::time_t getTime() {
   return Now;
 }
 
-uint64_t WinCOFFWriter::writeObject(MCAssembler &Asm) {
+uint64_t WinCOFFObjectWriter::WinCOFFWriter::writeObject(MCAssembler &Asm) {
   uint64_t StartOffset = W.OS.tell();
 
   if (Sections.size() > INT32_MAX)


### PR DESCRIPTION
Issue: #100303
WinCOFFWriter is internal implementation to support split-dwarf for
WinCOFFObjectWriter. Expose it would limit use of make_unqiue for
WinCOFFObjectWriter.