### PR TITLE
[Clang] Remove `IDNS_Ordinary` flag in `IndirectFieldDecl::IdentifierNamespace`

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -137,6 +137,9 @@ Miscellaneous Bug Fixes
 Miscellaneous Clang Crashes Fixed
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+- Fixed a crash in C due to incorrect lookup that members in nested anonymous struct/union
+  can be found as ordinary identifiers in struct/union definition. (#GH31295)
+
 OpenACC Specific Changes
 ------------------------
 

--- a/clang/lib/AST/DeclBase.cpp
+++ b/clang/lib/AST/DeclBase.cpp
@@ -879,8 +879,6 @@ unsigned Decl::getIdentifierNamespaceForKind(Kind DeclKind) {
       return IDNS_Ordinary;
     case Label:
       return IDNS_Label;
-    case IndirectField:
-      return IDNS_Ordinary | IDNS_Member;
 
     case Binding:
     case NonTypeTemplateParm:
@@ -918,6 +916,7 @@ unsigned Decl::getIdentifierNamespaceForKind(Kind DeclKind) {
       return IDNS_ObjCProtocol;
 
     case Field:
+    case IndirectField:
     case ObjCAtDefsField:
     case ObjCIvar:
       return IDNS_Member;

--- a/clang/test/Parser/namelookup-anonymous-struct.c
+++ b/clang/test/Parser/namelookup-anonymous-struct.c
@@ -1,0 +1,6 @@
+// RUN: %clang_cc1 -std=c11 -verify %s
+
+struct GH31295 {
+  struct { int x; };
+  int arr[sizeof(x)]; // expected-error{{use of undeclared identifier 'x'}}
+};


### PR DESCRIPTION
There is a `IDNS_Ordinary` flag in `IndirectFieldDecl::IdentifierNamespace` so that members in nested anonymous struct/union can be found as ordinary identifiers.

```c
struct S {
  struct { int x; };
  // Previous behaviour: `x` in previous line is found
  // Expected: nothing is found
  int arr[sizeof(x)];
};
```

This PR fixes this issue.

Fixes #31295.