### PR TITLE
[compiler-rt][test] Disable lld tests on SPARC

### DIFF
--- a/compiler-rt/CMakeLists.txt
+++ b/compiler-rt/CMakeLists.txt
@@ -801,6 +801,10 @@ if(ANDROID)
   append_list_if(COMPILER_RT_HAS_FUSE_LD_LLD_FLAG -fuse-ld=lld SANITIZER_COMMON_LINK_FLAGS)
   append_list_if(COMPILER_RT_HAS_LLD -fuse-ld=lld COMPILER_RT_UNITTEST_LINK_FLAGS)
 endif()
+if(${COMPILER_RT_DEFAULT_TARGET_ARCH} MATCHES sparc)
+  # lld has several bugs/limitations on SPARC, so disable (Issue #100320).
+  set(COMPILER_RT_HAS_LLD FALSE)
+endif()
 pythonize_bool(COMPILER_RT_HAS_LLD)
 pythonize_bool(COMPILER_RT_TEST_USE_LLD)
 


### PR DESCRIPTION
As detailed in Issue #100320, a considerable number of tests that explicitly use `-fuse-ld=lld` `FAIL` on Linux/sparc64 due to several `lld` limitations (no 32-bit SPARC support, lack of support for various relocations, ...).

To reduce the noise, this patch disables `COMPILER_RT_HAS_LLD` on SPARC wholesale.

Tested on `sparc64-unknown-linux-gnu`.