### PR TITLE
[sanitizer_common] Adjust signal_send.cpp for Linux/sparc64

### DIFF
--- a/compiler-rt/test/sanitizer_common/TestCases/Linux/signal_send.cpp
+++ b/compiler-rt/test/sanitizer_common/TestCases/Linux/signal_send.cpp
@@ -62,14 +62,14 @@ void test_sigwait() {
   int res;
   res = fork_and_signal(s);
   fprintf(stderr, "fork_and_signal with SIGUSR1,2: %d\n", res);
-  // CHECK: died with sig 10
+  // CHECK: died with sig {{10|30}}
   // CHECK: fork_and_signal with SIGUSR1,2: 0
 
   // test sigandset... s should only have SIGUSR2 now
   s = sigset_and(s, mkset(1, SIGUSR2));
   res = fork_and_signal(s);
   fprintf(stderr, "fork_and_signal with SIGUSR2: %d\n", res);
-  // CHECK: died with sig 12
+  // CHECK: died with sig {{12|31}}
   // CHECK: fork_and_signal with SIGUSR2: 0
 }
 


### PR DESCRIPTION
```
  SanitizerCommon-ubsan-sparc-Linux :: Linux/signal_send.cpp
```
currently `FAIL`s on Linux/sparc64 (32 and 64-bit).  Instead of the expected values for `SIGUSR1` (`10`) and `SIGUSR1` (`12`), that target uses `30` and `31`.

On Linux/x86_64, the signals get their values from `x86_64-linux-gnu/bits/signum-generic.h`, to be overridden in `x86_64-linux-gnu/bits/signum.h`.  On Linux/sparc64 OTOH, the definitions are from `sparc64-linux-gnu/bits/signum-arch.h` and remain that way. There's no `signum.h` at all.

The patch allows for both values.

Tested on `sparc64-unknown-linux-gnu` and `x86_64-pc-linux-gnu`.