### PR TITLE
[lldb][test] Mark TestAssertMessages.py as passing remotely on Linux target.

### DIFF
--- a/lldb/test/API/assert_messages_test/TestAssertMessages.py
+++ b/lldb/test/API/assert_messages_test/TestAssertMessages.py
@@ -23,7 +23,7 @@ class AssertMessagesTestCase(TestBase):
         else:
             self.fail("Initial expect should have raised AssertionError!")
 
-    @expectedFailureAll(remote=True)
+    @expectedFailureAll(oslist=no_match(["linux"]), remote=True)
     def test_createTestTarget(self):
         try:
             self.createTestTarget("doesnt_exist")


### PR DESCRIPTION
It has been markad as XFAIL here de2ddc8f3146bd87152ea86b533541039541efe1, but I haven't found the reason for that, and apparently, it passes against the Linux target.