### PR TITLE
[libc] Make `crt1.o` available to clang for GPU builds

### DIFF
--- a/libc/startup/gpu/CMakeLists.txt
+++ b/libc/startup/gpu/CMakeLists.txt
@@ -26,6 +26,16 @@ function(add_startup_object name)
     PROPERTIES
       OUTPUT_NAME ${name}.o
   )
+
+  # Make an executable target of relocatable bitcode for clang if needed.
+  if(LLVM_ENABLE_PER_TARGET_RUNTIME_DIR)
+    add_executable(${fq_target_name}.exe $<TARGET_OBJECTS:${fq_target_name}>)
+    set_target_properties(${fq_target_name}.exe PROPERTIES
+      RUNTIME_OUTPUT_DIRECTORY ${LIBC_LIBRARY_DIR}
+      RUNTIME_OUTPUT_NAME ${name}.o)
+    target_link_options(${fq_target_name}.exe PRIVATE
+                        "-flto" "-Wl,--lto-emit-llvm" "-march= ")
+  endif()
 endfunction()
 
 if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/${LIBC_TARGET_ARCHITECTURE})


### PR DESCRIPTION
Summary:
We want to provide the `crt1.o` object inside of the current build so
that other projects can use it for tests. Because it's currently an
object library (as is also required for the dependencies for the
hermetic tests) this cannot be renamed and is not emitted by default.
Here we simply add an executable that emits bitcode so that CMake will
give it a name.
