### PR TITLE
[flang] Catch ASSOCIATE(x=>assumed_rank)

### DIFF
--- a/flang/lib/Semantics/resolve-names.cpp
+++ b/flang/lib/Semantics/resolve-names.cpp
@@ -7118,8 +7118,12 @@ void ConstructVisitor::Post(const parser::AssociateStmt &x) {
   for (auto nthLastAssoc{assocCount}; nthLastAssoc > 0; --nthLastAssoc) {
     SetCurrentAssociation(nthLastAssoc);
     if (auto *symbol{MakeAssocEntity()}) {
-      if (ExtractCoarrayRef(GetCurrentAssociation().selector.expr)) { // C1103
+      const MaybeExpr &expr{GetCurrentAssociation().selector.expr};
+      if (ExtractCoarrayRef(expr)) { // C1103
         Say("Selector must not be a coindexed object"_err_en_US);
+      }
+      if (evaluate::IsAssumedRank(expr)) {
+        Say("Selector must not be assumed-rank"_err_en_US);
       }
       SetTypeFromAssociation(*symbol);
       SetAttrsFromAssociation(*symbol);

--- a/flang/test/Semantics/associate04.f90
+++ b/flang/test/Semantics/associate04.f90
@@ -1,0 +1,7 @@
+! RUN: %python %S/test_errors.py %s %flang_fc1
+subroutine bad(a)
+  real :: a(..)
+  !ERROR: Selector must not be assumed-rank
+  associate(x => a)
+  end associate
+end subroutine


### PR DESCRIPTION
An assumed-rank dummy argument cannot be the variable or expression in the selector of an ASSOCIATE construct.  (SELECT TYPE/RANK are fine.)