### PR TITLE
[LLDB] Remove decorator from XPASSes x86/Windows

### DIFF
--- a/lldb/test/API/lang/cpp/class-template-non-type-parameter-pack/TestClassTemplateNonTypeParameterPack.py
+++ b/lldb/test/API/lang/cpp/class-template-non-type-parameter-pack/TestClassTemplateNonTypeParameterPack.py
@@ -5,9 +5,6 @@ from lldbsuite.test import lldbutil
 
 
 class TestCaseClassTemplateNonTypeParameterPack(TestBase):
-    @expectedFailureAll(
-        oslist=["windows"], archs=["i[3-6]86", "x86_64"]
-    )  # Fails to read memory from target.
     @no_debug_info_test
     def test(self):
         self.build()

--- a/lldb/test/API/lang/cpp/class-template-type-parameter-pack/TestClassTemplateTypeParameterPack.py
+++ b/lldb/test/API/lang/cpp/class-template-type-parameter-pack/TestClassTemplateTypeParameterPack.py
@@ -5,9 +5,6 @@ from lldbsuite.test import lldbutil
 
 
 class TestCaseClassTemplateTypeParameterPack(TestBase):
-    @expectedFailureAll(
-        oslist=["windows"], archs=["i[3-6]86", "x86_64"]
-    )  # Fails to read memory from target.
     @no_debug_info_test
     def test(self):
         self.build()


### PR DESCRIPTION
This patch removes XFAIL decorators from tests that are passing on x86 Windows.

Corresponding XFAILs for AArch64 were removed here 7daa9a9b40a22.