### PR TITLE
[libc] Updated GettingStarted.rst with PyYAML version

### DIFF
--- a/libc/docs/dev/header_generation.rst
+++ b/libc/docs/dev/header_generation.rst
@@ -22,7 +22,7 @@ Instructions
 ------------
 
 Required Versions:
-  - Python Version: 3.6
+  - Python Version: 3.8
   - PyYAML Version: 5.1
 
 1. Keep full-build mode on when building, otherwise headers will not be

--- a/llvm/docs/GettingStarted.rst
+++ b/llvm/docs/GettingStarted.rst
@@ -295,6 +295,7 @@ Package                                                     Version      Notes
 `python <http://www.python.org/>`_                          >=3.8        Automated test suite\ :sup:`1`
 `zlib <http://zlib.net>`_                                   >=1.2.3.4    Compression library\ :sup:`2`
 `GNU Make <http://savannah.gnu.org/projects/make>`_         3.79, 3.79.1 Makefile/build processor\ :sup:`3`
+`PyYAML <https://pypi.org/project/PyYAML/>`                 >=5.1        Header generator\ :sup:`4`
 =========================================================== ============ ==========================================
 
 .. note::
@@ -305,6 +306,7 @@ Package                                                     Version      Notes
    #. Optional, adds compression / uncompression capabilities to selected LLVM
       tools.
    #. Optional, you can use any other build tool supported by CMake.
+   #. Only needed when building libc with New Headergen. Mainly used by libc.
 
 Additionally, your compilation host is expected to have the usual plethora of
 Unix utilities. Specifically:

--- a/llvm/docs/GettingStarted.rst
+++ b/llvm/docs/GettingStarted.rst
@@ -291,11 +291,11 @@ uses the package and provides other details.
 =========================================================== ============ ==========================================
 Package                                                     Version      Notes
 =========================================================== ============ ==========================================
-`CMake <http://cmake.org/>`__                               >=3.20.0     Makefile/workspace generator
+`CMake <http://cmake.org/>`_                                >=3.20.0     Makefile/workspace generator
 `python <http://www.python.org/>`_                          >=3.8        Automated test suite\ :sup:`1`
 `zlib <http://zlib.net>`_                                   >=1.2.3.4    Compression library\ :sup:`2`
 `GNU Make <http://savannah.gnu.org/projects/make>`_         3.79, 3.79.1 Makefile/build processor\ :sup:`3`
-`PyYAML <https://pypi.org/project/PyYAML/>`                 >=5.1        Header generator\ :sup:`4`
+`PyYAML <https://pypi.org/project/PyYAML/>`_                >=5.1        Header generator\ :sup:`4`
 =========================================================== ============ ==========================================
 
 .. note::


### PR DESCRIPTION
New Headergen requires PyYAML version 5.1 or newer in order to generate
header files .
