### PR TITLE
Globalopt pass produces invalid debug info

### DIFF
--- a/llvm/lib/IR/Metadata.cpp
+++ b/llvm/lib/IR/Metadata.cpp
@@ -348,7 +348,8 @@ void ReplaceableMetadataImpl::SalvageDebugInfo(const Constant &C) {
       continue;
     // Check for MetadataAsValue.
     if (isa<MetadataAsValue *>(Owner)) {
-      cast<MetadataAsValue *>(Owner)->handleChangedMetadata(ValueAsMetadata::get(UndefValue::get(C.getType())));
+      cast<MetadataAsValue *>(Owner)->handleChangedMetadata(
+          ValueAsMetadata::get(UndefValue::get(C.getType())));
       continue;
     }
     if (!isa<Metadata *>(Owner))

--- a/llvm/lib/IR/Metadata.cpp
+++ b/llvm/lib/IR/Metadata.cpp
@@ -346,6 +346,11 @@ void ReplaceableMetadataImpl::SalvageDebugInfo(const Constant &C) {
     MetadataTracking::OwnerTy Owner = Pair.second.first;
     if (!Owner)
       continue;
+    // Check for MetadataAsValue.
+    if (isa<MetadataAsValue *>(Owner)) {
+      cast<MetadataAsValue *>(Owner)->handleChangedMetadata(ValueAsMetadata::get(UndefValue::get(C.getType())));
+      continue;
+    }
     if (!isa<Metadata *>(Owner))
       continue;
     auto *OwnerMD = dyn_cast_if_present<MDNode>(cast<Metadata *>(Owner));

--- a/llvm/lib/Transforms/IPO/GlobalOpt.cpp
+++ b/llvm/lib/Transforms/IPO/GlobalOpt.cpp
@@ -1338,6 +1338,7 @@ deleteIfDead(GlobalValue &GV,
     if (DeleteFnCallback)
       DeleteFnCallback(*F);
   }
+  ReplaceableMetadataImpl::SalvageDebugInfo(GV);
   GV.eraseFromParent();
   ++NumDeleted;
   return true;

--- a/llvm/test/DebugInfo/X86/undef-dbg-val.ll
+++ b/llvm/test/DebugInfo/X86/undef-dbg-val.ll
@@ -1,5 +1,5 @@
-; RUN:  opt -S -passes=globalopt <%s | FileCheck %s
-; CHECK: #dbg_value(ptr poison, 
+; RUN:  opt -S -passes=globalopt --experimental-debuginfo-iterators=false <%s | FileCheck %s
+; CHECK: #dbg_value(ptr undef, 
 ; CHECK-SAME:    [[VAR:![0-9]+]],
 ; CHECK-SAME:    !DIExpression()
 ; CHECK: [[VAR]] = !DILocalVariable(name: "_format"

--- a/llvm/test/DebugInfo/X86/undef-dbg-val.ll
+++ b/llvm/test/DebugInfo/X86/undef-dbg-val.ll
@@ -1,0 +1,35 @@
+; RUN:  opt -S -passes=globalopt <%s | FileCheck %s
+; CHECK: #dbg_value(ptr poison, 
+; CHECK-SAME:    [[VAR:![0-9]+]],
+; CHECK-SAME:    !DIExpression()
+; CHECK: [[VAR]] = !DILocalVariable(name: "_format"
+
+
+; ModuleID = '<stdin>'
+source_filename = "test.cpp"
+
+@_ZZZZ4mainENKUlRN4sycl3_V17handlerEE_clES2_ENKUlvE_clEvE7_format = internal constant [24 x i8] c"Result1: Hello, World!\0A\00", align 16, !dbg !9
+
+; Function Attrs: convergent mustprogress norecurse
+define void  @foo() align 2 !dbg !5 {
+entry:
+  call void @llvm.dbg.value(metadata ptr @_ZZZZ4mainENKUlRN4sycl3_V17handlerEE_clES2_ENKUlvE_clEvE7_format, metadata !11, metadata !DIExpression()), !dbg !12
+  ret void
+}
+
+!llvm.dbg.cu = !{!0}
+!llvm.module.flags = !{!3, !4}
+
+!0 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus_14, file: !1, producer: "clang", isOptimized: true, emissionKind: FullDebug)
+!1 = !DIFile(filename: "test.cpp", directory: "/path/to")
+!2 = !{}
+!3 = !{i32 7, !"Dwarf Version", i32 4}
+!4 = !{i32 2, !"Debug Info Version", i32 3}
+!5 = distinct !DISubprogram(name: "foo", scope: !1, file: !1, line: 27, type: !6, scopeLine: 27, spFlags: DISPFlagDefinition, unit: !0)
+!6 = !DISubroutineType(types: !7)
+!7 = !{null}
+!8 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+!9 = !DIGlobalVariableExpression(var: !10, expr: !DIExpression())
+!10 = distinct !DIGlobalVariable(name: "_format", scope: !5, file: !1, line: 49, type: !8, isLocal: true, isDefinition: true)
+!11 = !DILocalVariable(name: "_format", arg: 1, scope: !5, file: !1, line: 79, type: !8)
+!12 = !DILocation(line: 0, scope: !5)

--- a/llvm/test/DebugInfo/X86/undef-dbg-val.ll
+++ b/llvm/test/DebugInfo/X86/undef-dbg-val.ll
@@ -8,12 +8,11 @@
 ; ModuleID = '<stdin>'
 source_filename = "test.cpp"
 
-@_ZZZZ4mainENKUlRN4sycl3_V17handlerEE_clES2_ENKUlvE_clEvE7_format = internal constant [24 x i8] c"Result1: Hello, World!\0A\00", align 16, !dbg !9
+@_ZZZZ4main_format = internal constant [24 x i8] c"Result1: Hello, World!\0A\00", align 16, !dbg !9
 
-; Function Attrs: convergent mustprogress norecurse
 define void  @foo() align 2 !dbg !5 {
 entry:
-  call void @llvm.dbg.value(metadata ptr @_ZZZZ4mainENKUlRN4sycl3_V17handlerEE_clES2_ENKUlvE_clEvE7_format, metadata !11, metadata !DIExpression()), !dbg !12
+  call void @llvm.dbg.value(metadata ptr @_ZZZZ4main_format, metadata !11, metadata !DIExpression()), !dbg !12
   ret void
 }
 


### PR DESCRIPTION
This patch fixes an issue in the GlobalOpt pass where deleting a global variable fails to update the corresponding dbg.value and it references an empty metadata entry. The SalvageDebugInfo() function has been updated to handle dbg.value intrinsic when globals are deleted.