### PR TITLE
[compiler-rt][ubsan][nfc-ish] Fix a type conversion bug

### DIFF
--- a/compiler-rt/lib/sanitizer_common/sanitizer_ptrauth.h
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_ptrauth.h
@@ -18,7 +18,7 @@
 // the NOP space so will do nothing when it is not enabled or not available.
 #  define ptrauth_strip(__value, __key) \
     ({                                  \
-      unsigned long ret;                \
+      __typeof(__value) ret;            \
       asm volatile(                     \
           "mov x30, %1\n\t"             \
           "hint #7\n\t"                 \
@@ -27,7 +27,7 @@
           : "=r"(ret)                   \
           : "r"(__value)                \
           : "x30");                     \
-      __typeof(__value) ret;            \
+      ret;                              \
     })
 #  define ptrauth_auth_data(__value, __old_key, __old_data) __value
 #  define ptrauth_string_discriminator(__string) ((int)0)

--- a/compiler-rt/lib/sanitizer_common/sanitizer_ptrauth.h
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_ptrauth.h
@@ -27,7 +27,7 @@
           : "=r"(ret)                   \
           : "r"(__value)                \
           : "x30");                     \
-      ret;                              \
+      __typeof(__value) ret;            \
     })
 #  define ptrauth_auth_data(__value, __old_key, __old_data) __value
 #  define ptrauth_string_discriminator(__string) ((int)0)

--- a/compiler-rt/lib/ubsan/ubsan_type_hash_itanium.cpp
+++ b/compiler-rt/lib/ubsan/ubsan_type_hash_itanium.cpp
@@ -207,7 +207,8 @@ struct VtablePrefix {
   std::type_info *TypeInfo;
 };
 VtablePrefix *getVtablePrefix(void *Vtable) {
-  Vtable = ptrauth_strip(Vtable, ptrauth_key_cxx_vtable_pointer);
+  Vtable = reinterpret_cast<void *>(
+      ptrauth_strip(Vtable, ptrauth_key_cxx_vtable_pointer));
   VtablePrefix *Vptr = reinterpret_cast<VtablePrefix*>(Vtable);
   VtablePrefix *Prefix = Vptr - 1;
   if (!IsAccessibleMemoryRange((uptr)Prefix, sizeof(VtablePrefix)))

--- a/compiler-rt/lib/ubsan/ubsan_type_hash_itanium.cpp
+++ b/compiler-rt/lib/ubsan/ubsan_type_hash_itanium.cpp
@@ -207,8 +207,7 @@ struct VtablePrefix {
   std::type_info *TypeInfo;
 };
 VtablePrefix *getVtablePrefix(void *Vtable) {
-  Vtable = reinterpret_cast<void *>(
-      ptrauth_strip(Vtable, ptrauth_key_cxx_vtable_pointer));
+  Vtable = ptrauth_strip(Vtable, ptrauth_key_cxx_vtable_pointer);
   VtablePrefix *Vptr = reinterpret_cast<VtablePrefix*>(Vtable);
   VtablePrefix *Prefix = Vptr - 1;
   if (!IsAccessibleMemoryRange((uptr)Prefix, sizeof(VtablePrefix)))


### PR DESCRIPTION
If the inline asm version of `ptrauth_strip` is used instead of the builtin, the inline asm implementation will return an unsigned long, causing an incompatible pointer conversion issue.