### PR TITLE
[lldb] Optimized lldb-server memory usage

### DIFF
--- a/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunication.cpp
+++ b/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunication.cpp
@@ -1145,7 +1145,7 @@ Status GDBRemoteCommunication::StartDebugserverProcess(
       if (socket_pipe.CanWrite())
         socket_pipe.CloseWriteFileDescriptor();
       if (socket_pipe.CanRead()) {
-        // The port number may be "1024\0".."65535\0".
+        // The port number may be up to "65535\0".
         char port_cstr[6] = {0};
         size_t num_bytes = sizeof(port_cstr);
         // Read port from pipe with 10 second timeout.

--- a/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunication.cpp
+++ b/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunication.cpp
@@ -1145,7 +1145,8 @@ Status GDBRemoteCommunication::StartDebugserverProcess(
       if (socket_pipe.CanWrite())
         socket_pipe.CloseWriteFileDescriptor();
       if (socket_pipe.CanRead()) {
-        char port_cstr[PATH_MAX] = {0};
+        // The port number may be "1024\0".."65535\0".
+        char port_cstr[6] = {0};
         port_cstr[0] = '\0';
         size_t num_bytes = sizeof(port_cstr);
         // Read port from pipe with 10 second timeout.

--- a/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunication.cpp
+++ b/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunication.cpp
@@ -1147,7 +1147,6 @@ Status GDBRemoteCommunication::StartDebugserverProcess(
       if (socket_pipe.CanRead()) {
         // The port number may be "1024\0".."65535\0".
         char port_cstr[6] = {0};
-        port_cstr[0] = '\0';
         size_t num_bytes = sizeof(port_cstr);
         // Read port from pipe with 10 second timeout.
         error = socket_pipe.ReadWithTimeout(


### PR DESCRIPTION
MAX_PATH is definitely larger than 6 bytes we are expecting for this message, and could be rather large depending on the target OS (4K for some Linux OSs).

Since the buffer gets allocated on the stack we better be conservative and allocate what we actually need.