### PR TITLE
[lldb] Multithreading lldb-server works on Windows now; fixed gdb port mapping

### DIFF
--- a/lldb/include/lldb/Host/FileSystem.h
+++ b/lldb/include/lldb/Host/FileSystem.h
@@ -47,6 +47,12 @@ public:
 
   static FileSystem &Instance();
 
+  static void InitializePerThread() {
+    lldbassert(!InstancePerThread() && "Already initialized.");
+    InstancePerThread().emplace(llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem>(
+        llvm::vfs::createPhysicalFileSystem().release()));
+  }
+
   template <class... T> static void Initialize(T &&...t) {
     lldbassert(!InstanceImpl() && "Already initialized.");
     InstanceImpl().emplace(std::forward<T>(t)...);
@@ -206,6 +212,7 @@ public:
 
 private:
   static std::optional<FileSystem> &InstanceImpl();
+  static std::optional<FileSystem> &InstancePerThread();
   llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> m_fs;
   std::unique_ptr<TildeExpressionResolver> m_tilde_resolver;
   std::string m_home_directory;

--- a/lldb/source/Host/common/FileSystem.cpp
+++ b/lldb/source/Host/common/FileSystem.cpp
@@ -49,7 +49,15 @@ void FileSystem::Terminate() {
   InstanceImpl().reset();
 }
 
+std::optional<FileSystem> &FileSystem::InstancePerThread() {
+  static thread_local std::optional<FileSystem> t_fs;
+  return t_fs;
+}
+
 std::optional<FileSystem> &FileSystem::InstanceImpl() {
+  std::optional<FileSystem> &fs = InstancePerThread();
+  if (fs)
+    return fs;
   static std::optional<FileSystem> g_fs;
   return g_fs;
 }

--- a/lldb/source/Host/posix/ProcessLauncherPosixFork.cpp
+++ b/lldb/source/Host/posix/ProcessLauncherPosixFork.cpp
@@ -201,7 +201,7 @@ struct ForkLaunchInfo {
   execve(info.argv[0], const_cast<char *const *>(info.argv), info.envp);
 
 #if defined(__linux__)
-  if (errno == ETXTBSY) {
+  for (int i = 0; i < 50; ++i) {
     // On android M and earlier we can get this error because the adb daemon
     // can hold a write handle on the executable even after it has finished
     // uploading it. This state lasts only a short time and happens only when
@@ -210,7 +210,13 @@ struct ForkLaunchInfo {
     // shell" command in the fork() child before it has had a chance to exec.)
     // Since this state should clear up quickly, wait a while and then give it
     // one more go.
-    usleep(50000);
+    // If `lldb-server platform` copies the executable in one thread and
+    // launches gdbserver in another thread (fork+execve), the FD may stay
+    // opened in the forked child process until execve() even if the first
+    // thread closed the file. Let's wait a while.
+    if (errno != ETXTBSY)
+      break;
+    usleep(100000);
     execve(info.argv[0], const_cast<char *const *>(info.argv), info.envp);
   }
 #endif


### PR DESCRIPTION
The main purpose of this patch is to fix all issues related to the gdb ports mapping in lldb-server. We need the common gdb ports map which is available in platform connection handlers. Currently `lldb-server platform` forks the child process to handle the incomming connection. This child process cannot request the gdb port from the common map. The optimal solution is to use multithreading lldb-server in the platform mode. lldb-server in the gdbserver mode remains the same.

This solution also gave a new advantage - `lldb-server platform --server` works on Windows now.

Note multithreading connection handlers require an own virtual working directory per thread. The most lldb-server code is using lldb::FileSystem and already resolves pathes. llvm::vfs::createPhysicalFileSystem() can be used as lldb::FileSystem with minimal updates.

Fixes #97537, fixes #90923, fixes #56346, fixes #101475.

lldb-server has been tested on Windows with 50 connections and 100 processes launched simultaneously. Tested also the cross build with Linux x86_64 host and Linux Aarch64 target (8 concurrent threads/connections).