### PR TITLE
[analyzer][NFC] Eliminate a dyn_cast

### DIFF
--- a/clang/lib/StaticAnalyzer/Checkers/MallocChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/MallocChecker.cpp
@@ -796,14 +796,13 @@ protected:
   /// done syntactically, because we are trying to argue about alternative
   /// paths of execution, and as a consequence we don't have path-sensitive
   /// information.
-  bool doesFnIntendToHandleOwnership(const Decl *Callee,
+  bool doesFnIntendToHandleOwnership(const FunctionDecl *Callee,
                                      ASTContext &ACtx) final {
     using namespace clang::ast_matchers;
-    const FunctionDecl *FD = dyn_cast<FunctionDecl>(Callee);
 
     auto Matches = match(findAll(stmt(anyOf(cxxDeleteExpr().bind("delete"),
                                             callExpr().bind("call")))),
-                         *FD->getBody(), ACtx);
+                         Callee->getBody(), ACtx);
     for (BoundNodes Match : Matches) {
       if (Match.getNodeAs<CXXDeleteExpr>("delete"))
         return true;

--- a/clang/lib/StaticAnalyzer/Checkers/NoOwnershipChangeVisitor.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/NoOwnershipChangeVisitor.cpp
@@ -72,16 +72,6 @@ bool NoOwnershipChangeVisitor::wasModifiedInFunction(
     const ExplodedNode *CallEnterN, const ExplodedNode *CallExitEndN) {
   const Decl *Callee =
       CallExitEndN->getFirstPred()->getLocationContext()->getDecl();
-  const FunctionDecl *FD = dyn_cast<FunctionDecl>(Callee);
-
-  // Given that the stack frame was entered, the body should always be
-  // theoretically obtainable. In case of body farms, the synthesized body
-  // is not attached to declaration, thus triggering the '!FD->hasBody()'
-  // branch. That said, would a synthesized body ever intend to handle
-  // ownership? As of today they don't. And if they did, how would we
-  // put notes inside it, given that it doesn't match any source locations?
-  if (!FD || !FD->hasBody())
-    return false;
   if (!doesFnIntendToHandleOwnership(
           Callee,
           CallExitEndN->getState()->getAnalysisManager().getASTContext()))

--- a/clang/lib/StaticAnalyzer/Checkers/NoOwnershipChangeVisitor.h
+++ b/clang/lib/StaticAnalyzer/Checkers/NoOwnershipChangeVisitor.h
@@ -26,7 +26,7 @@ protected:
   /// is done syntactically, because we are trying to argue about alternative
   /// paths of execution, and as a consequence we don't have path-sensitive
   /// information.
-  virtual bool doesFnIntendToHandleOwnership(const Decl *Callee,
+  virtual bool doesFnIntendToHandleOwnership(const FunctionDecl *Callee,
                                              ASTContext &ACtx) = 0;
 
   virtual bool hasResourceStateChanged(ProgramStateRef CallEnterState,

--- a/clang/lib/StaticAnalyzer/Checkers/NoOwnershipChangeVisitor.h
+++ b/clang/lib/StaticAnalyzer/Checkers/NoOwnershipChangeVisitor.h
@@ -26,7 +26,7 @@ protected:
   /// is done syntactically, because we are trying to argue about alternative
   /// paths of execution, and as a consequence we don't have path-sensitive
   /// information.
-  virtual bool doesFnIntendToHandleOwnership(const FunctionDecl *Callee,
+  virtual bool doesFnIntendToHandleOwnership(const Decl *Callee,
                                              ASTContext &ACtx) = 0;
 
   virtual bool hasResourceStateChanged(ProgramStateRef CallEnterState,

--- a/clang/lib/StaticAnalyzer/Checkers/StreamChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/StreamChecker.cpp
@@ -746,13 +746,12 @@ protected:
     return StreamChk->FCloseDesc.matchesAsWritten(Call);
   }
 
-  bool doesFnIntendToHandleOwnership(const Decl *Callee,
+  bool doesFnIntendToHandleOwnership(const FunctionDecl *Callee,
                                      ASTContext &ACtx) final {
     using namespace clang::ast_matchers;
-    const FunctionDecl *FD = dyn_cast<FunctionDecl>(Callee);
 
     auto Matches =
-        match(findAll(callExpr().bind("call")), *FD->getBody(), ACtx);
+        match(findAll(callExpr().bind("call")), Callee->getBody(), ACtx);
     for (BoundNodes Match : Matches) {
       if (const auto *Call = Match.getNodeAs<CallExpr>("call"))
         if (isClosingCallAsWritten(*Call))

--- a/clang/lib/StaticAnalyzer/Checkers/StreamChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/StreamChecker.cpp
@@ -746,12 +746,22 @@ protected:
     return StreamChk->FCloseDesc.matchesAsWritten(Call);
   }
 
-  bool doesFnIntendToHandleOwnership(const FunctionDecl *Callee,
+  bool doesFnIntendToHandleOwnership(const Decl *Callee,
                                      ASTContext &ACtx) final {
+    const FunctionDecl *FD = dyn_cast<FunctionDecl>(Callee);
+
+    // Given that the stack frame was entered, the body should always be
+    // theoretically obtainable. In case of body farms, the synthesized body
+    // is not attached to declaration, thus triggering the '!FD->hasBody()'
+    // branch. That said, would a synthesized body ever intend to handle
+    // ownership? As of today they don't. And if they did, how would we
+    // put notes inside it, given that it doesn't match any source locations?
+    if (!FD || !FD->hasBody())
+      return false;
     using namespace clang::ast_matchers;
 
     auto Matches =
-        match(findAll(callExpr().bind("call")), Callee->getBody(), ACtx);
+        match(findAll(callExpr().bind("call")), *FD->getBody(), ACtx);
     for (BoundNodes Match : Matches) {
       if (const auto *Call = Match.getNodeAs<CallExpr>("call"))
         if (isClosingCallAsWritten(*Call))


### PR DESCRIPTION
Response to the catch in this comment: https://github.com/llvm/llvm-project/pull/94357/files/07f6daf2cf0f5d5bd4fc9950f2585a3f52b4ad2f#r1692084074