### PR TITLE
[libcxx][test] Mark sort.pass.cpp as a long test

### DIFF
--- a/libcxx/test/std/algorithms/alg.sorting/alg.sort/sort/sort.pass.cpp
+++ b/libcxx/test/std/algorithms/alg.sorting/alg.sort/sort/sort.pass.cpp
@@ -8,7 +8,7 @@
 
 // This test did pass but is very slow when run using qemu. ~7 minutes on a
 // Neoverse N1 (AArch64) server core.
-// UNSUPPORTED: LIBCXX-PICOLIBC-FIXME
+// REQUIRES: long_tests
 
 // <algorithm>
 


### PR DESCRIPTION
Picolib testing skips any test requiring this feature, I just didn't know the feature existed until now.