### PR TITLE
[libcxx][test] Require long_tests for eval.PR44847.pass.cp

### DIFF
--- a/libcxx/test/std/numerics/rand/rand.dist/rand.dist.bern/rand.dist.bern.bin/eval.PR44847.pass.cpp
+++ b/libcxx/test/std/numerics/rand/rand.dist/rand.dist.bern/rand.dist.bern.bin/eval.PR44847.pass.cpp
@@ -18,8 +18,8 @@
 // Serializing/deserializing the state of the RNG requires iostreams
 // UNSUPPORTED: no-localization
 
-// This test appears to hang with picolibc & qemu.
-// UNSUPPORTED: LIBCXX-PICOLIBC-FIXME
+// Very slow when run in qemu.
+// REQUIRES: long_tests
 
 #include <random>
 #include <numeric>


### PR DESCRIPTION
This takes 1m40s to run when testing picolib on qemu. This isn't the end of the world but that's on an AArch64 server. So if someone felt the need to mark this unsupported in the first place, it's likely much slower on average hardware.