### PR TITLE
Fix lifetimebound for field access (#100197)

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -767,6 +767,9 @@ Improvements to Clang's diagnostics
 
 - Clang now diagnoses undefined behavior in constant expressions more consistently. This includes invalid shifts, and signed overflow in arithmetic.
 
+- Clang now diagnoses dangling references to fields of temporary objects. Fixes #GH81589.
+
+
 Improvements to Clang's time-trace
 ----------------------------------
 


### PR DESCRIPTION
Fixes: https://github.com/llvm/llvm-project/issues/81589

There is no way to switch this off without  `-Wno-dangling`.