### PR TITLE
[C++20][Modules] Allow using stdarg.h with header units

### DIFF
--- a/clang/lib/Serialization/ASTReader.cpp
+++ b/clang/lib/Serialization/ASTReader.cpp
@@ -4544,7 +4544,7 @@ ASTReader::ASTReadResult ASTReader::ReadAST(StringRef FileName, ModuleKind Type,
 
       // Mark this identifier as being from an AST file so that we can track
       // whether we need to serialize it.
-      markIdentifierFromAST(*this, *II, true);
+      markIdentifierFromAST(*this, *II, /*IsModule=*/true);
 
       // Associate the ID with the identifier so that the writer can reuse it.
       auto ID = Trait.ReadIdentifierID(Data + KeyDataLen.first);

--- a/clang/lib/Serialization/ASTReader.cpp
+++ b/clang/lib/Serialization/ASTReader.cpp
@@ -1079,7 +1079,8 @@ IdentifierInfo *ASTIdentifierLookupTrait::ReadData(const internal_key_type& k,
     II = &Reader.getIdentifierTable().getOwn(k);
     KnownII = II;
   }
-  markIdentifierFromAST(Reader, *II, Reader.getPreprocessor().getCurrentModule() != nullptr);
+  bool IsModule = Reader.getPreprocessor().getCurrentModule() != nullptr;
+  markIdentifierFromAST(Reader, *II, IsModule);
   Reader.markIdentifierUpToDate(II);
 
   IdentifierID ID = Reader.getGlobalIdentifierID(F, RawID);
@@ -8960,7 +8961,8 @@ IdentifierInfo *ASTReader::DecodeIdentifierInfo(IdentifierID ID) {
     auto Key = Trait.ReadKey(Data, KeyDataLen.first);
     auto &II = PP.getIdentifierTable().get(Key);
     IdentifiersLoaded[Index] = &II;
-    markIdentifierFromAST(*this,  II, getPreprocessor().getCurrentModule() != nullptr);
+    bool IsModule = getPreprocessor().getCurrentModule() != nullptr;
+    markIdentifierFromAST(*this,  II, IsModule);
     if (DeserializationListener)
       DeserializationListener->IdentifierRead(ID, &II);
   }

--- a/clang/lib/Serialization/ASTReader.cpp
+++ b/clang/lib/Serialization/ASTReader.cpp
@@ -8962,7 +8962,7 @@ IdentifierInfo *ASTReader::DecodeIdentifierInfo(IdentifierID ID) {
     auto &II = PP.getIdentifierTable().get(Key);
     IdentifiersLoaded[Index] = &II;
     bool IsModule = getPreprocessor().getCurrentModule() != nullptr;
-    markIdentifierFromAST(*this,  II, IsModule);
+    markIdentifierFromAST(*this, II, IsModule);
     if (DeserializationListener)
       DeserializationListener->IdentifierRead(ID, &II);
   }

--- a/clang/lib/Serialization/ASTReader.cpp
+++ b/clang/lib/Serialization/ASTReader.cpp
@@ -1051,7 +1051,8 @@ IdentifierID ASTIdentifierLookupTrait::ReadIdentifierID(const unsigned char *d) 
   return Reader.getGlobalIdentifierID(F, RawID >> 1);
 }
 
-static void markIdentifierFromAST(ASTReader &Reader, IdentifierInfo &II, bool IsModule) {
+static void markIdentifierFromAST(ASTReader &Reader, IdentifierInfo &II,
+                                  bool IsModule) {
   if (!II.isFromAST()) {
     II.setIsFromAST();
     if (isInterestingIdentifier(Reader, II, IsModule))

--- a/clang/test/Headers/stdarg-cxx-modules.cpp
+++ b/clang/test/Headers/stdarg-cxx-modules.cpp
@@ -6,12 +6,10 @@
 // RUN: %clang_cc1 -std=c++20 -fsyntax-only main.cpp -fmodule-file=h1.pcm -fmodule-file=h2.pcm
 
 //--- h1.h
-#pragma once
 #include <stdarg.h>
 // expected-no-diagnostics
 
 //--- h2.h
-#pragma once
 import "h1.h";
 // expected-no-diagnostics
 

--- a/clang/test/Headers/stdarg-cxx-modules.cpp
+++ b/clang/test/Headers/stdarg-cxx-modules.cpp
@@ -1,0 +1,27 @@
+// RUN: rm -fR %t
+// RUN: split-file %s %t
+// RUN: cd %t
+// RUN: %clang_cc1 -std=c++20 -emit-header-unit -xc++-user-header h1.h
+// RUN: %clang_cc1 -std=c++20 -emit-header-unit -xc++-user-header h2.h -fmodule-file=h1.pcm
+// RUN: %clang_cc1 -std=c++20 -fsyntax-only main.cpp -fmodule-file=h1.pcm -fmodule-file=h2.pcm
+
+//--- h1.h
+#pragma once
+#include <stdarg.h>
+// expected-no-diagnostics
+
+//--- h2.h
+#pragma once
+import "h1.h";
+// expected-no-diagnostics
+
+//--- main.cpp
+import "h1.h";
+import "h2.h";
+
+void foo(int x, ...) {
+  va_list v;
+  va_start(v, x);
+  va_end(v);
+}
+// expected-no-diagnostics


### PR DESCRIPTION
Summary:
Macro like `va_start`/`va_end` marked as builtin functions that makes these identifiers special and it results in redefinition of the identifiers as builtins and it hides macro definitions during preloading C++ modules. In case of modules Clang ignores special identifiers but `PP.getCurrentModule()` was not set. This diff fixes IsModule detection logic for this particular case.

Test Plan: check-clang