### PR TITLE
workflows: Fix permissions for release-sources job

### DIFF
--- a/.github/workflows/release-tasks.yml
+++ b/.github/workflows/release-tasks.yml
@@ -89,6 +89,7 @@ jobs:
   release-sources:
     name: Package Release Sources
     permissions:
+      contents: read
       id-token: write
       attestations: write
     needs:


### PR DESCRIPTION
For reusable workflows, the called workflow cannot upgrade it's permissions, and since the default permission is none, we need to explicitly declare 'contents: read' when calling the release-sources workflow.

Fixes the error:
The workflow is requesting 'contents: read', but is only allowed 'contents: none'.