### PR TITLE
[DAG] Add SDPatternMatch for VScale nodes; Use SDPatternMatch for VScale in some instances

### DIFF
--- a/llvm/include/llvm/CodeGen/SDPatternMatch.h
+++ b/llvm/include/llvm/CodeGen/SDPatternMatch.h
@@ -722,6 +722,10 @@ inline Or<UnaryOpc_match<Opnd>, Opnd> m_TruncOrSelf(const Opnd &Op) {
   return Or<UnaryOpc_match<Opnd>, Opnd>(m_Trunc(Op), Op);
 }
 
+template <typename Opnd> inline UnaryOpc_match<Opnd> m_VScale(const Opnd &Op) {
+  return UnaryOpc_match<Opnd>(ISD::VSCALE, Op);
+}
+
 // === Constants ===
 struct ConstantInt_match {
   APInt *BindVal;

--- a/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp
@@ -1086,10 +1086,9 @@ bool DAGCombiner::reassociationCanBreakAddressingModePattern(unsigned Opc,
   // (load/store (add/sub (add x, y), vscale))
   // (load/store (add/sub (add x, y), (lsl vscale, C)))
   // (load/store (add/sub (add x, y), (mul vscale, C)))
-  if ((N1.getOpcode() == ISD::VSCALE ||
-       ((N1.getOpcode() == ISD::SHL || N1.getOpcode() == ISD::MUL) &&
-        N1.getOperand(0).getOpcode() == ISD::VSCALE &&
-        isa<ConstantSDNode>(N1.getOperand(1)))) &&
+  if (sd_match(N1, m_AnyOf(m_VScale(m_Value()),
+                           m_Shl(m_VScale(m_Value()), m_ConstInt()),
+                           m_Mul(m_VScale(m_Value()), m_ConstInt()))) &&
       N1.getValueType().getFixedSizeInBits() <= 64) {
     int64_t ScalableOffset = N1.getOpcode() == ISD::VSCALE
                                  ? N1.getConstantOperandVal(0)
@@ -2975,8 +2974,7 @@ SDValue DAGCombiner::visitADD(SDNode *N) {
   }
 
   // fold a+vscale(c1)+vscale(c2) -> a+vscale(c1+c2)
-  if (N0.getOpcode() == ISD::ADD &&
-      N0.getOperand(1).getOpcode() == ISD::VSCALE &&
+  if (sd_match(N0, m_Add(m_Value(), m_VScale(m_Value()))) &&
       N1.getOpcode() == ISD::VSCALE) {
     const APInt &VS0 = N0.getOperand(1)->getConstantOperandAPInt(0);
     const APInt &VS1 = N1->getConstantOperandAPInt(0);

--- a/llvm/unittests/CodeGen/SelectionDAGPatternMatchTest.cpp
+++ b/llvm/unittests/CodeGen/SelectionDAGPatternMatchTest.cpp
@@ -228,6 +228,8 @@ TEST_F(SelectionDAGPatternMatchTest, matchUnaryOp) {
   SDValue Neg = DAG->getNegative(Op0, DL, Int32VT);
   SDValue Not = DAG->getNOT(DL, Op0, Int32VT);
 
+  SDValue VScale = DAG->getVScale(DL, Int32VT, APInt::getMaxValue(32));
+
   using namespace SDPatternMatch;
   EXPECT_TRUE(sd_match(ZExt, m_UnaryOp(ISD::ZERO_EXTEND, m_Value())));
   EXPECT_TRUE(sd_match(SExt, m_SExt(m_Value())));
@@ -238,6 +240,7 @@ TEST_F(SelectionDAGPatternMatchTest, matchUnaryOp) {
   EXPECT_FALSE(sd_match(ZExt, m_Neg(m_Value())));
   EXPECT_FALSE(sd_match(Sub, m_Neg(m_Value())));
   EXPECT_FALSE(sd_match(Neg, m_Not(m_Value())));
+  EXPECT_TRUE(sd_match(VScale, m_VScale(m_Value())));
 }
 
 TEST_F(SelectionDAGPatternMatchTest, matchConstants) {


### PR DESCRIPTION
This PR contains two commits:

[DAG] Add SDPatternMatch for VScale nodes

[DAG][NFC] Use SDPatternMatch for VScale in some instances

I will commit them individually.