### PR TITLE
[clangd] support the zig c++ compiler wrapper

### DIFF
--- a/clang-tools-extra/clangd/SystemIncludeExtractor.cpp
+++ b/clang-tools-extra/clangd/SystemIncludeExtractor.cpp
@@ -389,7 +389,17 @@ extractSystemIncludesAndTarget(const DriverArgs &InputArgs,
     return std::nullopt;
   }
 
-  llvm::SmallVector<llvm::StringRef> Args = {Driver, "-E", "-v"};
+  llvm::SmallVector<llvm::StringRef> Args = {Driver};
+  // Support the zig compiler wrapper
+  auto DriverExecutable = llvm::sys::path::stem(Driver);
+  if (DriverExecutable == "zig") {
+    if (InputArgs.Lang == "c") {
+      Args.push_back("cc");
+    } else {
+      Args.push_back("c++");
+    }
+  }
+  Args.append({"-E", "-v"});
   Args.append(InputArgs.render());
   // Input needs to go after Lang flags.
   Args.push_back("-");


### PR DESCRIPTION
When using `zig c++` for cross-compiling `clangd` removes the zig command (`c++`/`cc`) from the command line. Because of this the system include extraction fails. This change detects that the driver executable is named `zig` and adds `cc` or `c++` back into the command line.

I don't think there is infrastructure to test this (since it would involve executing the `zig` executable), so I did not add any tests. Screenshot of the feature working on Visual Studio Code on Windows:

![image](https://github.com/user-attachments/assets/8dd59d36-b84f-43ac-afbe-93131f890b7a)

Trivial example project that sets up the cross compilation with CMake and generates `compile_commands.json`: https://github.com/mrexodia/zig-cross. You also need to use `--query-driver=**/zig.exe`.