### PR TITLE
[BOLT][DWARF][NFC] Add mc opt to DWARFRewriter.cpp

### DIFF
--- a/bolt/lib/Rewrite/DWARFRewriter.cpp
+++ b/bolt/lib/Rewrite/DWARFRewriter.cpp
@@ -32,6 +32,7 @@
 #include "llvm/MC/MCAssembler.h"
 #include "llvm/MC/MCObjectWriter.h"
 #include "llvm/MC/MCStreamer.h"
+#include "llvm/MC/MCTargetOptionsCommandFlags.h"
 #include "llvm/Object/ObjectFile.h"
 #include "llvm/Support/Casting.h"
 #include "llvm/Support/CommandLine.h"
@@ -55,6 +56,8 @@
 
 #undef DEBUG_TYPE
 #define DEBUG_TYPE "bolt"
+
+static mc::RegisterMCTargetOptionsFlags MOF;
 
 static void printDie(const DWARFDie &DIE) {
   DIDumpOptions DumpOpts;


### PR DESCRIPTION
Running into an error with removing DWP where the assertion `RelaxAllView &&
"RegisterMCTargetOptionsFlags not created."'` failed. This is a result of DWP bringing the mc::RegisterMCTargetOptionsFlags option in, and the option being removed with DWP. The need for this option didn't originally exist because we didn't use MC in DWARFRewriter, but we switched to using DWARFStreamer which needed the option.

https://reviews.llvm.org/D75579 
https://reviews.llvm.org/D106417