### PR TITLE
[libc++][regex] add _LIBCPP_FALLTHROUGH to suppress fallthrough warning

### DIFF
--- a/libcxx/include/regex
+++ b/libcxx/include/regex
@@ -3921,7 +3921,7 @@ _ForwardIterator basic_regex<_CharT, _Traits>::__parse_character_escape(
       if (__hd == -1)
         __throw_regex_error<regex_constants::error_escape>();
       __sum = 16 * __sum + static_cast<unsigned>(__hd);
-      // fallthrough
+      _LIBCPP_FALLTHROUGH();
     case 'x':
       ++__first;
       if (__first == __last)


### PR DESCRIPTION
Summary:
The diff https://github.com/llvm/llvm-project/pull/97926 is stacked on top of this patch because this file reports an error when enabling `-Wimplicit-fallthrough` in `-Wextra`.

Test plan:

```sh
$ time (mkdir build_runtimes && cd build_runtimes && set -x && CC=../build/bin/clang CXX=../build/bin/clang++ cmake -G Ninja ../runtimes -DCMAKE_BUILD_TYPE=Release -DLLVM_ENABLE_RUNTIMES='libcxx;libcxxabi;libunwind'  && ninja && bin/llvm-lit -sv ../libcxx/test/std/re )
```

note: whether I put a `break;` or fallthrough, the tests pass anyways which is sus.