### PR TITLE
[BOLT][YAML] Allow unknown keys in the input

### DIFF
--- a/bolt/lib/Profile/YAMLProfileReader.cpp
+++ b/bolt/lib/Profile/YAMLProfileReader.cpp
@@ -373,6 +373,7 @@ Error YAMLProfileReader::preprocessProfile(BinaryContext &BC) {
     return errorCodeToError(EC);
   }
   yaml::Input YamlInput(MB.get()->getBuffer());
+  YamlInput.setAllowUnknownKeys(true);
 
   // Consume YAML file.
   YamlInput >> YamlBP;

--- a/bolt/test/X86/yaml-unknown-keys.test
+++ b/bolt/test/X86/yaml-unknown-keys.test
@@ -1,0 +1,50 @@
+## Test that BOLT gracefully handles a YAML profile with unknown keys.
+
+# REQUIRES: system-linux
+# RUN: split-file %s %t
+# RUN: llvm-mc -filetype=obj -triple x86_64-unknown-unknown %t/main.s -o %t.o
+# RUN: %clang %cflags %t.o -o %t.exe -Wl,-q -nostdlib
+# RUN: llvm-bolt %t.exe -o %t.null --data %t/profile.yaml \
+# RUN:   --profile-ignore-hash -v=1 2>&1 | FileCheck %s
+# CHECK: warning: unknown key 'unknown-header-key'
+# CHECK: warning: unknown key 'unknown_succ_key'
+# CHECK: warning: unknown key 'unknown_block_key'
+# CHECK: warning: unknown key 'unknown_function_key'
+# CHECK: warning: unknown key 'unknown_toplev_key'
+#--- main.s
+  .globl main
+  .type main, %function
+main:
+  .cfi_startproc
+  cmpl	$0x0, %eax
+  jne .LBB0
+.LBB0:
+  retq
+  .cfi_endproc
+.size main, .-main
+#--- profile.yaml
+---
+header:
+  profile-version: 1
+  binary-name:     'yaml-multiple-profiles.test.tmp.exe'
+  binary-build-id: '<unknown>'
+  profile-flags:   [ lbr ]
+  profile-origin:  branch profile reader
+  profile-events:  ''
+  dfs-order:       false
+  unknown-header-key: true
+functions:
+  - name:            'main'
+    fid:             1
+    hash:            0x50BBA3441D436491
+    exec:            1
+    nblocks:         1
+    blocks:
+      - bid:             0
+        insns:           2
+        hash:            0x4D4D8FAF7D4C0000
+        succ:            [ { bid: 1, cnt: 0, unknown_succ_key: 0x10 } ]
+        unknown_block_key: [ ]
+    unknown_function_key: 1
+unknown_toplev_key: ''
+...

--- a/bolt/tools/merge-fdata/merge-fdata.cpp
+++ b/bolt/tools/merge-fdata/merge-fdata.cpp
@@ -392,6 +392,7 @@ int main(int argc, char **argv) {
     if (std::error_code EC = MB.getError())
       report_error(InputDataFilename, EC);
     yaml::Input YamlInput(MB.get()->getBuffer());
+    YamlInput.setAllowUnknownKeys(true);
 
     errs() << "Merging data from " << InputDataFilename << "...\n";
 


### PR DESCRIPTION
This ensures forward compatibility, where old BOLT versions can consume
the profile created by newer versions with extra keys.

Test Plan: added yaml-unknown-keys.test
