### PR TITLE
Use Module level target-abi to assign target features for codegenerated functions.

### DIFF
--- a/llvm/include/llvm/IR/Function.h
+++ b/llvm/include/llvm/IR/Function.h
@@ -190,6 +190,8 @@ public:
   static Function *Create(FunctionType *Ty, LinkageTypes Linkage,
                           const Twine &N, Module &M);
 
+  StringRef getDefaultTargetFeatures(const StringRef TargetABI);
+
   /// Creates a function with some attributes recorded in llvm.module.flags
   /// and the LLVMContext applied.
   ///

--- a/llvm/include/llvm/IR/Module.h
+++ b/llvm/include/llvm/IR/Module.h
@@ -1065,6 +1065,9 @@ public:
 
   /// Set the target variant version build SDK version metadata.
   void setDarwinTargetVariantSDKVersion(VersionTuple Version);
+
+  /// Returns target-abi from MDString, null if target-abi is absent.
+  StringRef getTargetABIFromMD();
 };
 
 /// Given "llvm.used" or "llvm.compiler.used" as a global name, collect the

--- a/llvm/lib/IR/Function.cpp
+++ b/llvm/lib/IR/Function.cpp
@@ -390,21 +390,22 @@ Function *Function::Create(FunctionType *Ty, LinkageTypes Linkage,
 
 StringRef Function::getDefaultTargetFeatures(const StringRef TargetABI) {
   Triple T(getParent()->getTargetTriple());
-  StringRef attr = "";
+  StringRef Attr = "";
   if (T.isRISCV64()) {
     if (TargetABI.equals_insensitive("lp64d"))
-      attr = "+d";
+      Attr = "+d";
     else if (TargetABI.equals_insensitive("lp64f"))
-      attr = "+f";
-    else if (TargetABI.equals_insensitive("lp64q"))
-      attr = "+q";
-  } else if (T.isRISCV32() && TargetABI.contains("ilp32f")) {
-    attr = "+f";
+      Attr = "+f";
+  } else if (T.isRISCV32()) {
+    if (TargetABI.equals_insensitive("ilp32d"))
+      Attr = "+d";
+    else if (TargetABI.equals_insensitive("ilp32f"))
+      Attr = "+f";
   } else if (T.isARM() || T.isThumb()) {
-    attr = "+thumb-mode";
+    Attr = "+thumb-mode";
   }
 
-  return attr;
+  return Attr;
 }
 
 Function *Function::createWithDefaultAttr(FunctionType *Ty,

--- a/llvm/lib/IR/Module.cpp
+++ b/llvm/lib/IR/Module.cpp
@@ -915,3 +915,11 @@ VersionTuple Module::getDarwinTargetVariantSDKVersion() const {
 void Module::setDarwinTargetVariantSDKVersion(VersionTuple Version) {
   addSDKVersionMD(Version, *this, "darwin.target_variant.SDK Version");
 }
+
+StringRef Module::getTargetABIFromMD() {
+  StringRef TargetABI = "";
+  if (auto *TargetABIMD =
+          dyn_cast_or_null<MDString>(getModuleFlag("target-abi")))
+    TargetABI = TargetABIMD->getString();
+  return TargetABI;
+}

--- a/llvm/test/Transforms/CrossDSOCFI/riscv.ll
+++ b/llvm/test/Transforms/CrossDSOCFI/riscv.ll
@@ -1,0 +1,19 @@
+; RUN: opt -S -passes=cross-dso-cfi < %s | FileCheck --check-prefix=RISCV64 %s
+
+target datalayout = "e-m:e-p:64:64-i64:64-i128:128-n32:64-S128"
+target triple = "riscv64-unknown-linux-gnu"
+
+define signext i8 @f() !type !0 !type !1 {
+entry:
+  ret i8 1
+}
+
+!llvm.module.flags = !{!2, !3}
+
+!0 = !{i64 0, !"_ZTSFcvE"}
+!1 = !{i64 0, i64 111}
+!2 = !{i32 4, !"Cross-DSO CFI", i32 1}
+!3 = !{i32 1, !"target-abi", !"lp64d"}
+
+; RISCV64: define void @__cfi_check({{.*}} #[[A:.*]] align 4096
+; RISCV64: attributes #[[A]] = { {{.*}}"target-features"="+d"


### PR DESCRIPTION
It is currently not possible to provide any reasonable target-features for compiler generated functions (See: #69780). Having a target-abi will provide a way to add minimal requirements for target-features like `+d` for RISC-V.