### PR TITLE
workflows/release-binaries: Fetch composite actions outside of default workspace

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -162,7 +162,7 @@ jobs:
 
     - name: Setup Stage
       id: setup-stage
-      uses: ../workflows/.github/workflows/release-binaries-setup-stage
+      uses: ${{ github.workspace }}/../workflows/.github/workflows/release-binaries-setup-stage
 
     - name: Checkout LLVM
       uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
@@ -196,7 +196,7 @@ jobs:
         ls -ltr ${{ steps.setup-stage.outputs.build-prefix }}/build
     
     - name: Save Stage
-      uses: ../workflows/.github/workflows/release-binaries-save-stage
+      uses: ${{ github.workspace }}/../workflows/.github/workflows/release-binaries-save-stage
       with:
         build-prefix: ${{ steps.setup-stage.outputs.build-prefix }}
 

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -158,7 +158,12 @@ jobs:
         sparse-checkout-cone-mode: false
         # Check out outside of working directory so the source checkout doesn't
         # remove it.
-        path: ../workflows
+        path: workflows
+
+    # Move workflows so they don't get overwritten by checkout.  The checkout job
+    # requires checking out to github.workspace.
+    - shell: bash
+      run: mv workflows  ../workflows-main
 
     - name: Checkout LLVM
       uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
@@ -168,7 +173,7 @@ jobs:
     - name: Copy main workflows
       shell: bash
       run: |
-        mv ../workflows workflows-main
+        mv ../workflows-main .
 
     - name: Setup Stage
       id: setup-stage

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -156,11 +156,13 @@ jobs:
         sparse-checkout: |
           .github/workflows/
         sparse-checkout-cone-mode: false
-        path: workflows
+        # Check out outside of working directory so the source checkout doesn't
+        # remove it.
+        path: ../workflows
 
     - name: Setup Stage
       id: setup-stage
-      uses: ./workflows/.github/workflows/release-binaries-setup-stage
+      uses: ../workflows/.github/workflows/release-binaries-setup-stage
 
     - name: Checkout LLVM
       uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
@@ -194,7 +196,7 @@ jobs:
         ls -ltr ${{ steps.setup-stage.outputs.build-prefix }}/build
     
     - name: Save Stage
-      uses: ./workflows/.github/workflows/release-binaries-save-stage
+      uses: ../workflows/.github/workflows/release-binaries-save-stage
       with:
         build-prefix: ${{ steps.setup-stage.outputs.build-prefix }}
 

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -162,7 +162,7 @@ jobs:
 
     - name: Setup Stage
       id: setup-stage
-      uses: ${{ github.workspace }}/../workflows/.github/workflows/release-binaries-setup-stage
+      uses: "${{ github.workspace }}/../workflows/.github/workflows/release-binaries-setup-stage"
 
     - name: Checkout LLVM
       uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
@@ -196,7 +196,7 @@ jobs:
         ls -ltr ${{ steps.setup-stage.outputs.build-prefix }}/build
     
     - name: Save Stage
-      uses: ${{ github.workspace }}/../workflows/.github/workflows/release-binaries-save-stage
+      uses: "${{ github.workspace }}/../workflows/.github/workflows/release-binaries-save-stage"
       with:
         build-prefix: ${{ steps.setup-stage.outputs.build-prefix }}
 

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -160,14 +160,19 @@ jobs:
         # remove it.
         path: ../workflows
 
-    - name: Setup Stage
-      id: setup-stage
-      uses: "${{ github.workspace }}/../workflows/.github/workflows/release-binaries-setup-stage"
-
     - name: Checkout LLVM
       uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       with:
         ref: ${{ needs.prepare.outputs.ref }}
+
+    - name: Copy main workflows
+      shell: bash
+      run: |
+        mv ../workflows workflows-main
+
+    - name: Setup Stage
+      id: setup-stage
+      uses: ./workflows-main/.github/workflows/release-binaries-setup-stage
 
     - name: Setup sccache
       uses: hendrikmuhs/ccache-action@ca3acd2731eef11f1572ccb126356c2f9298d35e # v1.2.9
@@ -196,7 +201,7 @@ jobs:
         ls -ltr ${{ steps.setup-stage.outputs.build-prefix }}/build
     
     - name: Save Stage
-      uses: "${{ github.workspace }}/../workflows/.github/workflows/release-binaries-save-stage"
+      uses: ./workflows-main/.github/workflows/release-binaries-save-stage
       with:
         build-prefix: ${{ steps.setup-stage.outputs.build-prefix }}
 

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -160,8 +160,13 @@ jobs:
         # remove it.
         path: workflows
 
-    # Move workflows so they don't get overwritten by checkout.  The checkout job
-    # requires checking out to github.workspace.
+    # actions/checkout does not support paths outside of the GITHUB_WORKSPACE.
+    # Also, anything that we put inside of GITHUB_WORKSPACE will be overwritten
+    # by future actions/checkout steps.  Therefore, in order to checkout the
+    # latest actions from main, we need to first checkout out the actions inside of
+    # GITHUB_WORKSPACE (see previous step), then use actions/checkout to checkout
+    # the code being built and the move the actions from main back into GITHUB_WORKSPACE,
+    # becasue the uses on composite actions only reads workflows from inside GITHUB_WORKSPACE.
     - shell: bash
       run: mv workflows  ../workflows-main
 


### PR DESCRIPTION
Otherwise, the checkout step will override them.