### PR TITLE
[Clang][CTAD][NFC] Unify transformTemplateParameter()

### DIFF
--- a/clang/lib/Sema/SemaTemplateDeductionGuide.cpp
+++ b/clang/lib/Sema/SemaTemplateDeductionGuide.cpp
@@ -408,7 +408,7 @@ struct ConvertConstructorToDeductionGuideTransform {
               SemaRef, DC, NewParam, OuterInstantiationArgs,
               getTemplateParameterIndex(NewParam),
               getTemplateParameterDepth(NewParam) -
-                  OuterInstantiationArgs.getNumLevels(),
+                  OuterInstantiationArgs.getNumSubstitutedLevels(),
               /*EvaluateConstraint=*/false);
 
         assert(NewParam->getTemplateDepth() == 0 &&


### PR DESCRIPTION
We ended up having two transformTemplateParameter() after CTAD for type aliases was landed. This patch cleans them up and allows them to share one implementation.

As a bonus, this also uses getDepthAndIndex() in preference to getTemplateParameter{Depth,Index}().