### PR TITLE
[compiler-rt] [rtsan] Revert openat interceptor that breaks fortify-source builds

### DIFF
--- a/compiler-rt/lib/rtsan/rtsan_interceptors.cpp
+++ b/compiler-rt/lib/rtsan/rtsan_interceptors.cpp
@@ -69,20 +69,6 @@ INTERCEPTOR(int, open, const char *path, int oflag, ...) {
   return result;
 }
 
-INTERCEPTOR(int, openat, int fd, const char *path, int oflag, ...) {
-  // TODO Establish whether we should intercept here if the flag contains
-  // O_NONBLOCK
-  ExpectNotRealtime("openat");
-
-  va_list args;
-  va_start(args, oflag);
-  mode_t mode = va_arg(args, int);
-  va_end(args);
-
-  const int result = REAL(openat)(fd, path, oflag, mode);
-  return result;
-}
-
 INTERCEPTOR(int, creat, const char *path, mode_t mode) {
   // TODO Establish whether we should intercept here if the flag contains
   // O_NONBLOCK
@@ -385,7 +371,6 @@ void __rtsan::InitializeInterceptors() {
 #endif
 
   INTERCEPT_FUNCTION(open);
-  INTERCEPT_FUNCTION(openat);
   INTERCEPT_FUNCTION(close);
   INTERCEPT_FUNCTION(fopen);
   INTERCEPT_FUNCTION(fread);

--- a/compiler-rt/lib/rtsan/tests/rtsan_test_interceptors.cpp
+++ b/compiler-rt/lib/rtsan/tests/rtsan_test_interceptors.cpp
@@ -178,12 +178,6 @@ TEST_F(RtsanFileTest, OpenDiesWhenRealtime) {
   ExpectNonRealtimeSurvival(func);
 }
 
-TEST_F(RtsanFileTest, OpenatDiesWhenRealtime) {
-  auto func = [this]() { openat(0, GetTemporaryFilePath(), O_RDONLY); };
-  ExpectRealtimeDeath(func, "openat");
-  ExpectNonRealtimeSurvival(func);
-}
-
 TEST_F(RtsanFileTest, OpenCreatesFileWithProperMode) {
   const int mode = S_IRGRP | S_IROTH | S_IRUSR | S_IWUSR;
 


### PR DESCRIPTION
Remove the openat interceptor from the 19.x branch, as it currently breaks builds against fortify-sources glibc, and full rtsan will not be included in this version anyway.

Suggested by Chris Apple in
https://github.com/llvm/llvm-project/issues/100754#issuecomment-2254169856

Bug #100754