### PR TITLE
[NFC][libc++][exceptions] Adds tests for LWG3112.

### DIFF
--- a/libcxx/docs/Status/Cxx20Issues.csv
+++ b/libcxx/docs/Status/Cxx20Issues.csv
@@ -134,7 +134,7 @@
 "`LWG3077 <https://wg21.link/LWG3077>`__","``(push|emplace)_back``\  should invalidate the ``end``\  iterator","Kona","|Nothing To Do|","",""
 "`LWG3087 <https://wg21.link/LWG3087>`__","One final ``&x``\  in |sect|\ [list.ops]","Kona","|Nothing To Do|","",""
 "`LWG3101 <https://wg21.link/LWG3101>`__","``span``\ 's ``Container``\  constructors need another constraint","Kona","|Complete|","",""
-"`LWG3112 <https://wg21.link/LWG3112>`__","``system_error``\  and ``filesystem_error``\  constructors taking a ``string``\  may not be able to meet their postconditions","Kona","","",""
+"`LWG3112 <https://wg21.link/LWG3112>`__","``system_error``\  and ``filesystem_error``\  constructors taking a ``string``\  may not be able to meet their postconditions","Kona","|Nothing To Do|","",""
 "`LWG3119 <https://wg21.link/LWG3119>`__","Program-definedness of closure types","Kona","|Nothing To Do|","",""
 "`LWG3133 <https://wg21.link/LWG3133>`__","Modernizing numeric type requirements","Kona","","",""
 "`LWG3144 <https://wg21.link/LWG3144>`__","``span``\  does not have a ``const_pointer``\  typedef","Kona","|Complete|","",""

--- a/libcxx/test/std/diagnostics/syserr/syserr.syserr/syserr.syserr.members/ctor_error_code_string.pass.cpp
+++ b/libcxx/test/std/diagnostics/syserr/syserr.syserr/syserr.syserr.members/ctor_error_code_string.pass.cpp
@@ -21,12 +21,25 @@
 #include "test_macros.h"
 
 int main(int, char**) {
+  {
     std::string what_arg("test message");
     std::system_error se(make_error_code(std::errc::not_a_directory), what_arg);
     assert(se.code() == std::make_error_code(std::errc::not_a_directory));
     std::string what_message(se.what());
     assert(what_message.find(what_arg) != std::string::npos);
+    assert(what_message.find(what_arg.c_str()) != std::string::npos);
     assert(what_message.find("Not a directory") != std::string::npos);
+  }
 
-    return 0;
+  {
+    std::string what_arg("test LWG3112 with and With embedded \0 character");
+    std::system_error se(make_error_code(std::errc::not_a_directory), what_arg);
+    assert(se.code() == std::make_error_code(std::errc::not_a_directory));
+    std::string what_message(se.what());
+    assert(what_message.find(what_arg) != std::string::npos);
+    assert(what_message.find(what_arg.c_str()) != std::string::npos);
+    assert(what_message.find("Not a directory") != std::string::npos);
+  }
+
+  return 0;
 }

--- a/libcxx/test/std/diagnostics/syserr/syserr.syserr/syserr.syserr.members/ctor_int_error_category_string.pass.cpp
+++ b/libcxx/test/std/diagnostics/syserr/syserr.syserr/syserr.syserr.members/ctor_int_error_category_string.pass.cpp
@@ -21,13 +21,23 @@
 #include "test_macros.h"
 
 int main(int, char**) {
+  {
     std::string what_arg("test message");
-    std::system_error se(static_cast<int>(std::errc::not_a_directory),
-                         std::generic_category(), what_arg);
+    std::system_error se(static_cast<int>(std::errc::not_a_directory), std::generic_category(), what_arg);
     assert(se.code() == std::make_error_code(std::errc::not_a_directory));
     std::string what_message(se.what());
     assert(what_message.find(what_arg) != std::string::npos);
+    assert(what_message.find(what_arg.c_str()) != std::string::npos);
     assert(what_message.find("Not a directory") != std::string::npos);
-
-    return 0;
+  }
+  {
+    std::string what_arg("test LWG3112 with and With embedded \0 character");
+    std::system_error se(static_cast<int>(std::errc::not_a_directory), std::generic_category(), what_arg);
+    assert(se.code() == std::make_error_code(std::errc::not_a_directory));
+    std::string what_message(se.what());
+    assert(what_message.find(what_arg) != std::string::npos);
+    assert(what_message.find(what_arg.c_str()) != std::string::npos);
+    assert(what_message.find("Not a directory") != std::string::npos);
+  }
+  return 0;
 }

--- a/libcxx/test/std/input.output/filesystems/class.filesystem_error/filesystem_error.members.pass.cpp
+++ b/libcxx/test/std/input.output/filesystems/class.filesystem_error/filesystem_error.members.pass.cpp
@@ -33,49 +33,91 @@ namespace fs = std::filesystem;
 void test_constructors() {
   using namespace fs;
 
-  // The string returned by "filesystem_error::what() must contain runtime_error::what()
-  const std::string what_arg = "Hello World";
-  const std::string what_contains = std::runtime_error(what_arg).what();
-  assert(what_contains.find(what_arg) != std::string::npos);
-  auto CheckWhat = [what_contains](filesystem_error const& e) {
-    std::string s = e.what();
-    assert(s.find(what_contains) != std::string::npos);
-  };
+  {
+    // The string returned by "filesystem_error::what() must contain runtime_error::what().c_str()
+    const std::string what_arg      = "Hello World";
+    const std::string what_contains = std::runtime_error(what_arg).what();
+    assert(what_contains.find(what_arg) != std::string::npos);
+    auto CheckWhat = [what_contains](filesystem_error const& e) {
+      std::string s = e.what();
+      assert(s.find(what_contains.c_str()) != std::string::npos);
+    };
 
-  std::error_code ec = std::make_error_code(std::errc::file_exists);
-  const path p1("foo");
-  const path p2("bar");
+    std::error_code ec = std::make_error_code(std::errc::file_exists);
+    const path p1("foo");
+    const path p2("bar");
 
-  // filesystem_error(const string& what_arg, error_code ec);
-  {
-    ASSERT_NOT_NOEXCEPT(filesystem_error(what_arg, ec));
-    filesystem_error e(what_arg, ec);
-    CheckWhat(e);
-    assert(e.code() == ec);
-    assert(e.path1().empty() && e.path2().empty());
+    // filesystem_error(const string& what_arg, error_code ec);
+    {
+      ASSERT_NOT_NOEXCEPT(filesystem_error(what_arg, ec));
+      filesystem_error e(what_arg, ec);
+      CheckWhat(e);
+      assert(e.code() == ec);
+      assert(e.path1().empty() && e.path2().empty());
+    }
+    // filesystem_error(const string& what_arg, const path&, error_code ec);
+    {
+      ASSERT_NOT_NOEXCEPT(filesystem_error(what_arg, p1, ec));
+      filesystem_error e(what_arg, p1, ec);
+      CheckWhat(e);
+      assert(e.code() == ec);
+      assert(e.path1() == p1);
+      assert(e.path2().empty());
+    }
+    // filesystem_error(const string& what_arg, const path&, const path&, error_code ec);
+    {
+      ASSERT_NOT_NOEXCEPT(filesystem_error(what_arg, p1, p2, ec));
+      filesystem_error e(what_arg, p1, p2, ec);
+      CheckWhat(e);
+      assert(e.code() == ec);
+      assert(e.path1() == p1);
+      assert(e.path2() == p2);
+    }
   }
-  // filesystem_error(const string& what_arg, const path&, error_code ec);
   {
-    ASSERT_NOT_NOEXCEPT(filesystem_error(what_arg, p1, ec));
-    filesystem_error e(what_arg, p1, ec);
-    CheckWhat(e);
-    assert(e.code() == ec);
-    assert(e.path1() == p1);
-    assert(e.path2().empty());
-  }
-  // filesystem_error(const string& what_arg, const path&, const path&, error_code ec);
-  {
-    ASSERT_NOT_NOEXCEPT(filesystem_error(what_arg, p1, p2, ec));
-    filesystem_error e(what_arg, p1, p2, ec);
-    CheckWhat(e);
-    assert(e.code() == ec);
-    assert(e.path1() == p1);
-    assert(e.path2() == p2);
+    // The string returned by "filesystem_error::what() must contain runtime_error::what().c_str()
+    const std::string what_arg("test LWG3112 with and With embedded \0 character");
+    const std::string what_contains = std::runtime_error(what_arg).what();
+    assert(what_contains.find(what_arg) != std::string::npos);
+    auto CheckWhat = [what_contains](filesystem_error const& e) {
+      std::string s = e.what();
+      assert(s.find(what_contains.c_str()) != std::string::npos);
+    };
+
+    std::error_code ec = std::make_error_code(std::errc::file_exists);
+    const path p1("foo");
+    const path p2("bar");
+
+    // filesystem_error(const string& what_arg, error_code ec);
+    {
+      ASSERT_NOT_NOEXCEPT(filesystem_error(what_arg, ec));
+      filesystem_error e(what_arg, ec);
+      CheckWhat(e);
+      assert(e.code() == ec);
+      assert(e.path1().empty() && e.path2().empty());
+    }
+    // filesystem_error(const string& what_arg, const path&, error_code ec);
+    {
+      ASSERT_NOT_NOEXCEPT(filesystem_error(what_arg, p1, ec));
+      filesystem_error e(what_arg, p1, ec);
+      CheckWhat(e);
+      assert(e.code() == ec);
+      assert(e.path1() == p1);
+      assert(e.path2().empty());
+    }
+    // filesystem_error(const string& what_arg, const path&, const path&, error_code ec);
+    {
+      ASSERT_NOT_NOEXCEPT(filesystem_error(what_arg, p1, p2, ec));
+      filesystem_error e(what_arg, p1, p2, ec);
+      CheckWhat(e);
+      assert(e.code() == ec);
+      assert(e.path1() == p1);
+      assert(e.path2() == p2);
+    }
   }
 }
 
-void test_signatures()
-{
+void test_signatures() {
   using namespace fs;
   const path p;
   std::error_code ec;


### PR DESCRIPTION
The tests kept being based on std::string instead of std::string_view to allow testing with older C++ dialects.

Adds tests for:
- LWG3112 system_error and filesystem_error constructors taking a string may not be able to meet their postconditions