### PR TITLE
[NFC][libc++][test] Removes a TODO.

### DIFF
--- a/libcxx/test/std/input.output/string.streams/istringstream/istringstream.members/str.allocator_propagation.pass.cpp
+++ b/libcxx/test/std/input.output/string.streams/istringstream/istringstream.members/str.allocator_propagation.pass.cpp
@@ -7,7 +7,6 @@
 //===----------------------------------------------------------------------===//
 
 // UNSUPPORTED: c++03, c++11, c++14, c++17
-// TODO: Change to XFAIL once https://github.com/llvm/llvm-project/issues/40340 is fixed
 // UNSUPPORTED: availability-pmr-missing
 
 // This test ensures that we properly propagate allocators from istringstream's

--- a/libcxx/test/std/input.output/string.streams/ostringstream/ostringstream.members/str.allocator_propagation.pass.cpp
+++ b/libcxx/test/std/input.output/string.streams/ostringstream/ostringstream.members/str.allocator_propagation.pass.cpp
@@ -7,7 +7,6 @@
 //===----------------------------------------------------------------------===//
 
 // UNSUPPORTED: c++03, c++11, c++14, c++17
-// TODO: Change to XFAIL once https://github.com/llvm/llvm-project/issues/40340 is fixed
 // UNSUPPORTED: availability-pmr-missing
 
 // This test ensures that we properly propagate allocators from ostringstream's

--- a/libcxx/test/std/input.output/string.streams/stringstream/stringstream.members/str.allocator_propagation.pass.cpp
+++ b/libcxx/test/std/input.output/string.streams/stringstream/stringstream.members/str.allocator_propagation.pass.cpp
@@ -7,7 +7,6 @@
 //===----------------------------------------------------------------------===//
 
 // UNSUPPORTED: c++03, c++11, c++14, c++17
-// TODO: Change to XFAIL once https://github.com/llvm/llvm-project/issues/40340 is fixed
 // UNSUPPORTED: availability-pmr-missing
 
 // This test ensures that we properly propagate allocators from stringstream's

--- a/libcxx/test/std/utilities/utility/mem.res/mem.poly.allocator.class/mem.poly.allocator.ctor/assign.pass.cpp
+++ b/libcxx/test/std/utilities/utility/mem.res/mem.poly.allocator.class/mem.poly.allocator.ctor/assign.pass.cpp
@@ -7,7 +7,6 @@
 //===----------------------------------------------------------------------===//
 
 // UNSUPPORTED: c++03, c++11, c++14
-// TODO: Change to XFAIL once https://github.com/llvm/llvm-project/issues/40340 is fixed
 // UNSUPPORTED: availability-pmr-missing
 
 // <memory_resource>

--- a/libcxx/test/std/utilities/utility/mem.res/mem.poly.allocator.class/mem.poly.allocator.ctor/copy.pass.cpp
+++ b/libcxx/test/std/utilities/utility/mem.res/mem.poly.allocator.class/mem.poly.allocator.ctor/copy.pass.cpp
@@ -7,7 +7,6 @@
 //===----------------------------------------------------------------------===//
 
 // UNSUPPORTED: c++03, c++11, c++14
-// TODO: Change to XFAIL once https://github.com/llvm/llvm-project/issues/40340 is fixed
 // UNSUPPORTED: availability-pmr-missing
 
 // <memory_resource>

--- a/libcxx/test/std/utilities/utility/mem.res/mem.poly.allocator.class/mem.poly.allocator.ctor/default.pass.cpp
+++ b/libcxx/test/std/utilities/utility/mem.res/mem.poly.allocator.class/mem.poly.allocator.ctor/default.pass.cpp
@@ -7,7 +7,6 @@
 //===----------------------------------------------------------------------===//
 
 // UNSUPPORTED: c++03, c++11, c++14
-// TODO: Change to XFAIL once https://github.com/llvm/llvm-project/issues/40340 is fixed
 // UNSUPPORTED: availability-pmr-missing
 
 // test_memory_resource requires RTTI for dynamic_cast

--- a/libcxx/test/std/utilities/utility/mem.res/mem.poly.allocator.class/mem.poly.allocator.ctor/memory_resource_convert.pass.cpp
+++ b/libcxx/test/std/utilities/utility/mem.res/mem.poly.allocator.class/mem.poly.allocator.ctor/memory_resource_convert.pass.cpp
@@ -7,7 +7,6 @@
 //===----------------------------------------------------------------------===//
 
 // UNSUPPORTED: c++03, c++11, c++14
-// TODO: Change to XFAIL once https://github.com/llvm/llvm-project/issues/40340 is fixed
 // UNSUPPORTED: availability-pmr-missing
 
 // test_memory_resource requires RTTI for dynamic_cast

--- a/libcxx/test/std/utilities/utility/mem.res/mem.poly.allocator.class/mem.poly.allocator.ctor/other_alloc.pass.cpp
+++ b/libcxx/test/std/utilities/utility/mem.res/mem.poly.allocator.class/mem.poly.allocator.ctor/other_alloc.pass.cpp
@@ -7,7 +7,6 @@
 //===----------------------------------------------------------------------===//
 
 // UNSUPPORTED: c++03, c++11, c++14
-// TODO: Change to XFAIL once https://github.com/llvm/llvm-project/issues/40340 is fixed
 // UNSUPPORTED: availability-pmr-missing
 
 // <memory_resource>

--- a/libcxx/test/std/utilities/utility/mem.res/mem.poly.allocator.class/mem.poly.allocator.eq/equal.pass.cpp
+++ b/libcxx/test/std/utilities/utility/mem.res/mem.poly.allocator.class/mem.poly.allocator.eq/equal.pass.cpp
@@ -7,7 +7,6 @@
 //===----------------------------------------------------------------------===//
 
 // UNSUPPORTED: c++03, c++11, c++14
-// TODO: Change to XFAIL once https://github.com/llvm/llvm-project/issues/40340 is fixed
 // UNSUPPORTED: availability-pmr-missing
 
 // test_memory_resource requires RTTI for dynamic_cast

--- a/libcxx/test/std/utilities/utility/mem.res/mem.poly.allocator.class/mem.poly.allocator.eq/not_equal.pass.cpp
+++ b/libcxx/test/std/utilities/utility/mem.res/mem.poly.allocator.class/mem.poly.allocator.eq/not_equal.pass.cpp
@@ -7,7 +7,6 @@
 //===----------------------------------------------------------------------===//
 
 // UNSUPPORTED: c++03, c++11, c++14
-// TODO: Change to XFAIL once https://github.com/llvm/llvm-project/issues/40340 is fixed
 // UNSUPPORTED: availability-pmr-missing
 
 // test_memory_resource requires RTTI for dynamic_cast

--- a/libcxx/test/std/utilities/utility/mem.res/mem.poly.allocator.class/mem.poly.allocator.mem/allocate.pass.cpp
+++ b/libcxx/test/std/utilities/utility/mem.res/mem.poly.allocator.class/mem.poly.allocator.mem/allocate.pass.cpp
@@ -7,7 +7,6 @@
 //===----------------------------------------------------------------------===//
 
 // UNSUPPORTED: c++03, c++11, c++14
-// TODO: Change to XFAIL once https://github.com/llvm/llvm-project/issues/40340 is fixed
 // UNSUPPORTED: availability-pmr-missing
 
 // test_memory_resource requires RTTI for dynamic_cast

--- a/libcxx/test/std/utilities/utility/mem.res/mem.poly.allocator.class/mem.poly.allocator.mem/allocate_deallocate_bytes.pass.cpp
+++ b/libcxx/test/std/utilities/utility/mem.res/mem.poly.allocator.class/mem.poly.allocator.mem/allocate_deallocate_bytes.pass.cpp
@@ -7,7 +7,6 @@
 //===----------------------------------------------------------------------===//
 
 // UNSUPPORTED: c++03, c++11, c++14, c++17
-// TODO: Change to XFAIL once https://github.com/llvm/llvm-project/issues/40340 is fixed
 // UNSUPPORTED: availability-pmr-missing
 
 // test_memory_resource requires RTTI for dynamic_cast

--- a/libcxx/test/std/utilities/utility/mem.res/mem.poly.allocator.class/mem.poly.allocator.mem/allocate_deallocate_object.pass.cpp
+++ b/libcxx/test/std/utilities/utility/mem.res/mem.poly.allocator.class/mem.poly.allocator.mem/allocate_deallocate_object.pass.cpp
@@ -7,7 +7,6 @@
 //===----------------------------------------------------------------------===//
 
 // UNSUPPORTED: c++03, c++11, c++14, c++17
-// TODO: Change to XFAIL once https://github.com/llvm/llvm-project/issues/40340 is fixed
 // UNSUPPORTED: availability-pmr-missing
 
 // test_memory_resource requires RTTI for dynamic_cast

--- a/libcxx/test/std/utilities/utility/mem.res/mem.poly.allocator.class/mem.poly.allocator.mem/construct_pair.pass.cpp
+++ b/libcxx/test/std/utilities/utility/mem.res/mem.poly.allocator.class/mem.poly.allocator.mem/construct_pair.pass.cpp
@@ -7,7 +7,6 @@
 //===----------------------------------------------------------------------===//
 
 // UNSUPPORTED: c++03, c++11, c++14
-// TODO: Change to XFAIL once https://github.com/llvm/llvm-project/issues/40340 is fixed
 // UNSUPPORTED: availability-pmr-missing
 
 // <memory_resource>

--- a/libcxx/test/std/utilities/utility/mem.res/mem.poly.allocator.class/mem.poly.allocator.mem/construct_pair_const_lvalue_pair.pass.cpp
+++ b/libcxx/test/std/utilities/utility/mem.res/mem.poly.allocator.class/mem.poly.allocator.mem/construct_pair_const_lvalue_pair.pass.cpp
@@ -7,7 +7,6 @@
 //===----------------------------------------------------------------------===//
 
 // UNSUPPORTED: c++03, c++11, c++14
-// TODO: Change to XFAIL once https://github.com/llvm/llvm-project/issues/40340 is fixed
 // UNSUPPORTED: availability-pmr-missing
 
 // test_memory_resource requires RTTI for dynamic_cast

--- a/libcxx/test/std/utilities/utility/mem.res/mem.poly.allocator.class/mem.poly.allocator.mem/construct_pair_rvalue.pass.cpp
+++ b/libcxx/test/std/utilities/utility/mem.res/mem.poly.allocator.class/mem.poly.allocator.mem/construct_pair_rvalue.pass.cpp
@@ -7,7 +7,6 @@
 //===----------------------------------------------------------------------===//
 
 // UNSUPPORTED: c++03, c++11, c++14
-// TODO: Change to XFAIL once https://github.com/llvm/llvm-project/issues/40340 is fixed
 // UNSUPPORTED: availability-pmr-missing
 
 // test_memory_resource requires RTTI for dynamic_cast

--- a/libcxx/test/std/utilities/utility/mem.res/mem.poly.allocator.class/mem.poly.allocator.mem/construct_pair_values.pass.cpp
+++ b/libcxx/test/std/utilities/utility/mem.res/mem.poly.allocator.class/mem.poly.allocator.mem/construct_pair_values.pass.cpp
@@ -7,7 +7,6 @@
 //===----------------------------------------------------------------------===//
 
 // UNSUPPORTED: c++03, c++11, c++14
-// TODO: Change to XFAIL once https://github.com/llvm/llvm-project/issues/40340 is fixed
 // UNSUPPORTED: availability-pmr-missing
 
 // test_memory_resource requires RTTI for dynamic_cast

--- a/libcxx/test/std/utilities/utility/mem.res/mem.poly.allocator.class/mem.poly.allocator.mem/construct_piecewise_pair.pass.cpp
+++ b/libcxx/test/std/utilities/utility/mem.res/mem.poly.allocator.class/mem.poly.allocator.mem/construct_piecewise_pair.pass.cpp
@@ -7,7 +7,6 @@
 //===----------------------------------------------------------------------===//
 
 // UNSUPPORTED: c++03, c++11, c++14
-// TODO: Change to XFAIL once https://github.com/llvm/llvm-project/issues/40340 is fixed
 // UNSUPPORTED: availability-pmr-missing
 
 // test_memory_resource requires RTTI for dynamic_cast

--- a/libcxx/test/std/utilities/utility/mem.res/mem.poly.allocator.class/mem.poly.allocator.mem/construct_piecewise_pair_evil.pass.cpp
+++ b/libcxx/test/std/utilities/utility/mem.res/mem.poly.allocator.class/mem.poly.allocator.mem/construct_piecewise_pair_evil.pass.cpp
@@ -7,7 +7,6 @@
 //===----------------------------------------------------------------------===//
 
 // UNSUPPORTED: c++03, c++11, c++14
-// TODO: Change to XFAIL once https://github.com/llvm/llvm-project/issues/40340 is fixed
 // UNSUPPORTED: availability-pmr-missing
 
 // <memory_resource>

--- a/libcxx/test/std/utilities/utility/mem.res/mem.poly.allocator.class/mem.poly.allocator.mem/construct_types.pass.cpp
+++ b/libcxx/test/std/utilities/utility/mem.res/mem.poly.allocator.class/mem.poly.allocator.mem/construct_types.pass.cpp
@@ -7,7 +7,6 @@
 //===----------------------------------------------------------------------===//
 
 // UNSUPPORTED: c++03, c++11, c++14
-// TODO: Change to XFAIL once https://github.com/llvm/llvm-project/issues/40340 is fixed
 // UNSUPPORTED: availability-pmr-missing
 
 // test_memory_resource requires RTTI for dynamic_cast

--- a/libcxx/test/std/utilities/utility/mem.res/mem.poly.allocator.class/mem.poly.allocator.mem/deallocate.pass.cpp
+++ b/libcxx/test/std/utilities/utility/mem.res/mem.poly.allocator.class/mem.poly.allocator.mem/deallocate.pass.cpp
@@ -7,7 +7,6 @@
 //===----------------------------------------------------------------------===//
 
 // UNSUPPORTED: c++03, c++11, c++14
-// TODO: Change to XFAIL once https://github.com/llvm/llvm-project/issues/40340 is fixed
 // UNSUPPORTED: availability-pmr-missing
 
 // test_memory_resource requires RTTI for dynamic_cast

--- a/libcxx/test/std/utilities/utility/mem.res/mem.poly.allocator.class/mem.poly.allocator.mem/destroy.pass.cpp
+++ b/libcxx/test/std/utilities/utility/mem.res/mem.poly.allocator.class/mem.poly.allocator.mem/destroy.pass.cpp
@@ -7,7 +7,6 @@
 //===----------------------------------------------------------------------===//
 
 // UNSUPPORTED: c++03, c++11, c++14
-// TODO: Change to XFAIL once https://github.com/llvm/llvm-project/issues/40340 is fixed
 // UNSUPPORTED: availability-pmr-missing
 
 // <memory_resource>

--- a/libcxx/test/std/utilities/utility/mem.res/mem.poly.allocator.class/mem.poly.allocator.mem/new_delete_object.pass.cpp
+++ b/libcxx/test/std/utilities/utility/mem.res/mem.poly.allocator.class/mem.poly.allocator.mem/new_delete_object.pass.cpp
@@ -7,7 +7,6 @@
 //===----------------------------------------------------------------------===//
 
 // UNSUPPORTED: c++03, c++11, c++14, c++17
-// TODO: Change to XFAIL once https://github.com/llvm/llvm-project/issues/40340 is fixed
 // UNSUPPORTED: availability-pmr-missing
 
 // test_memory_resource requires RTTI for dynamic_cast

--- a/libcxx/test/std/utilities/utility/mem.res/mem.poly.allocator.class/mem.poly.allocator.mem/resource.pass.cpp
+++ b/libcxx/test/std/utilities/utility/mem.res/mem.poly.allocator.class/mem.poly.allocator.mem/resource.pass.cpp
@@ -7,7 +7,6 @@
 //===----------------------------------------------------------------------===//
 
 // UNSUPPORTED: c++03, c++11, c++14
-// TODO: Change to XFAIL once https://github.com/llvm/llvm-project/issues/40340 is fixed
 // UNSUPPORTED: availability-pmr-missing
 
 // <memory_resource>

--- a/libcxx/test/std/utilities/utility/mem.res/mem.poly.allocator.class/mem.poly.allocator.mem/select_on_container_copy_construction.pass.cpp
+++ b/libcxx/test/std/utilities/utility/mem.res/mem.poly.allocator.class/mem.poly.allocator.mem/select_on_container_copy_construction.pass.cpp
@@ -7,7 +7,6 @@
 //===----------------------------------------------------------------------===//
 
 // UNSUPPORTED: c++03, c++11, c++14
-// TODO: Change to XFAIL once https://github.com/llvm/llvm-project/issues/40340 is fixed
 // UNSUPPORTED: availability-pmr-missing
 
 // <memory_resource>

--- a/libcxx/test/std/utilities/utility/mem.res/mem.res.aliases/header_deque_synop.pass.cpp
+++ b/libcxx/test/std/utilities/utility/mem.res/mem.res.aliases/header_deque_synop.pass.cpp
@@ -7,7 +7,6 @@
 //===----------------------------------------------------------------------===//
 
 // UNSUPPORTED: c++03, c++11, c++14
-// TODO: Change to XFAIL once https://github.com/llvm/llvm-project/issues/40340 is fixed
 // UNSUPPORTED: availability-pmr-missing
 
 // <deque>

--- a/libcxx/test/std/utilities/utility/mem.res/mem.res.aliases/header_deque_synop2.pass.cpp
+++ b/libcxx/test/std/utilities/utility/mem.res/mem.res.aliases/header_deque_synop2.pass.cpp
@@ -7,7 +7,6 @@
 //===----------------------------------------------------------------------===//
 
 // UNSUPPORTED: c++03, c++11, c++14
-// TODO: Change to XFAIL once https://github.com/llvm/llvm-project/issues/40340 is fixed
 // UNSUPPORTED: availability-pmr-missing
 
 // <deque>

--- a/libcxx/test/std/utilities/utility/mem.res/mem.res.aliases/header_forward_list_synop.pass.cpp
+++ b/libcxx/test/std/utilities/utility/mem.res/mem.res.aliases/header_forward_list_synop.pass.cpp
@@ -7,7 +7,6 @@
 //===----------------------------------------------------------------------===//
 
 // UNSUPPORTED: c++03, c++11, c++14
-// TODO: Change to XFAIL once https://github.com/llvm/llvm-project/issues/40340 is fixed
 // UNSUPPORTED: availability-pmr-missing
 
 // <forward_list>

--- a/libcxx/test/std/utilities/utility/mem.res/mem.res.aliases/header_list_synop.pass.cpp
+++ b/libcxx/test/std/utilities/utility/mem.res/mem.res.aliases/header_list_synop.pass.cpp
@@ -7,7 +7,6 @@
 //===----------------------------------------------------------------------===//
 
 // UNSUPPORTED: c++03, c++11, c++14
-// TODO: Change to XFAIL once https://github.com/llvm/llvm-project/issues/40340 is fixed
 // UNSUPPORTED: availability-pmr-missing
 
 // <list>

--- a/libcxx/test/std/utilities/utility/mem.res/mem.res.aliases/header_list_synop2.pass.cpp
+++ b/libcxx/test/std/utilities/utility/mem.res/mem.res.aliases/header_list_synop2.pass.cpp
@@ -7,7 +7,6 @@
 //===----------------------------------------------------------------------===//
 
 // UNSUPPORTED: c++03, c++11, c++14
-// TODO: Change to XFAIL once https://github.com/llvm/llvm-project/issues/40340 is fixed
 // UNSUPPORTED: availability-pmr-missing
 
 // <list>

--- a/libcxx/test/std/utilities/utility/mem.res/mem.res.aliases/header_map_synop.pass.cpp
+++ b/libcxx/test/std/utilities/utility/mem.res/mem.res.aliases/header_map_synop.pass.cpp
@@ -7,7 +7,6 @@
 //===----------------------------------------------------------------------===//
 
 // UNSUPPORTED: c++03, c++11, c++14
-// TODO: Change to XFAIL once https://github.com/llvm/llvm-project/issues/40340 is fixed
 // UNSUPPORTED: availability-pmr-missing
 
 // <map>

--- a/libcxx/test/std/utilities/utility/mem.res/mem.res.aliases/header_map_synop2.pass.cpp
+++ b/libcxx/test/std/utilities/utility/mem.res/mem.res.aliases/header_map_synop2.pass.cpp
@@ -7,7 +7,6 @@
 //===----------------------------------------------------------------------===//
 
 // UNSUPPORTED: c++03, c++11, c++14
-// TODO: Change to XFAIL once https://github.com/llvm/llvm-project/issues/40340 is fixed
 // UNSUPPORTED: availability-pmr-missing
 
 // <map>

--- a/libcxx/test/std/utilities/utility/mem.res/mem.res.aliases/header_regex_synop.pass.cpp
+++ b/libcxx/test/std/utilities/utility/mem.res/mem.res.aliases/header_regex_synop.pass.cpp
@@ -8,7 +8,6 @@
 
 // UNSUPPORTED: c++03, c++11, c++14
 // UNSUPPORTED: no-localization
-// TODO: Change to XFAIL once https://github.com/llvm/llvm-project/issues/40340 is fixed
 // UNSUPPORTED: availability-pmr-missing
 
 // <regex>

--- a/libcxx/test/std/utilities/utility/mem.res/mem.res.aliases/header_set_synop.pass.cpp
+++ b/libcxx/test/std/utilities/utility/mem.res/mem.res.aliases/header_set_synop.pass.cpp
@@ -7,7 +7,6 @@
 //===----------------------------------------------------------------------===//
 
 // UNSUPPORTED: c++03, c++11, c++14
-// TODO: Change to XFAIL once https://github.com/llvm/llvm-project/issues/40340 is fixed
 // UNSUPPORTED: availability-pmr-missing
 
 // <set>

--- a/libcxx/test/std/utilities/utility/mem.res/mem.res.aliases/header_set_synop2.pass.cpp
+++ b/libcxx/test/std/utilities/utility/mem.res/mem.res.aliases/header_set_synop2.pass.cpp
@@ -7,7 +7,6 @@
 //===----------------------------------------------------------------------===//
 
 // UNSUPPORTED: c++03, c++11, c++14
-// TODO: Change to XFAIL once https://github.com/llvm/llvm-project/issues/40340 is fixed
 // UNSUPPORTED: availability-pmr-missing
 
 // <set>

--- a/libcxx/test/std/utilities/utility/mem.res/mem.res.aliases/header_string_synop.pass.cpp
+++ b/libcxx/test/std/utilities/utility/mem.res/mem.res.aliases/header_string_synop.pass.cpp
@@ -7,7 +7,6 @@
 //===----------------------------------------------------------------------===//
 
 // UNSUPPORTED: c++03, c++11, c++14
-// TODO: Change to XFAIL once https://github.com/llvm/llvm-project/issues/40340 is fixed
 // UNSUPPORTED: availability-pmr-missing
 
 // <string>

--- a/libcxx/test/std/utilities/utility/mem.res/mem.res.aliases/header_string_synop2.pass.cpp
+++ b/libcxx/test/std/utilities/utility/mem.res/mem.res.aliases/header_string_synop2.pass.cpp
@@ -7,7 +7,6 @@
 //===----------------------------------------------------------------------===//
 
 // UNSUPPORTED: c++03, c++11, c++14
-// TODO: Change to XFAIL once https://github.com/llvm/llvm-project/issues/40340 is fixed
 // UNSUPPORTED: availability-pmr-missing
 
 // <string>

--- a/libcxx/test/std/utilities/utility/mem.res/mem.res.aliases/header_unordered_map_synop.pass.cpp
+++ b/libcxx/test/std/utilities/utility/mem.res/mem.res.aliases/header_unordered_map_synop.pass.cpp
@@ -7,7 +7,6 @@
 //===----------------------------------------------------------------------===//
 
 // UNSUPPORTED: c++03, c++11, c++14
-// TODO: Change to XFAIL once https://github.com/llvm/llvm-project/issues/40340 is fixed
 // UNSUPPORTED: availability-pmr-missing
 
 // <unordered_map>

--- a/libcxx/test/std/utilities/utility/mem.res/mem.res.aliases/header_unordered_map_synop2.pass.cpp
+++ b/libcxx/test/std/utilities/utility/mem.res/mem.res.aliases/header_unordered_map_synop2.pass.cpp
@@ -7,7 +7,6 @@
 //===----------------------------------------------------------------------===//
 
 // UNSUPPORTED: c++03, c++11, c++14
-// TODO: Change to XFAIL once https://github.com/llvm/llvm-project/issues/40340 is fixed
 // UNSUPPORTED: availability-pmr-missing
 
 // <unordered_map>

--- a/libcxx/test/std/utilities/utility/mem.res/mem.res.aliases/header_unordered_set_synop.pass.cpp
+++ b/libcxx/test/std/utilities/utility/mem.res/mem.res.aliases/header_unordered_set_synop.pass.cpp
@@ -7,7 +7,6 @@
 //===----------------------------------------------------------------------===//
 
 // UNSUPPORTED: c++03, c++11, c++14
-// TODO: Change to XFAIL once https://github.com/llvm/llvm-project/issues/40340 is fixed
 // UNSUPPORTED: availability-pmr-missing
 
 // <unordered_set>

--- a/libcxx/test/std/utilities/utility/mem.res/mem.res.aliases/header_unordered_set_synop2.pass.cpp
+++ b/libcxx/test/std/utilities/utility/mem.res/mem.res.aliases/header_unordered_set_synop2.pass.cpp
@@ -7,7 +7,6 @@
 //===----------------------------------------------------------------------===//
 
 // UNSUPPORTED: c++03, c++11, c++14
-// TODO: Change to XFAIL once https://github.com/llvm/llvm-project/issues/40340 is fixed
 // UNSUPPORTED: availability-pmr-missing
 
 // <unordered_set>

--- a/libcxx/test/std/utilities/utility/mem.res/mem.res.aliases/header_vector_synop.pass.cpp
+++ b/libcxx/test/std/utilities/utility/mem.res/mem.res.aliases/header_vector_synop.pass.cpp
@@ -7,7 +7,6 @@
 //===----------------------------------------------------------------------===//
 
 // UNSUPPORTED: c++03, c++11, c++14
-// TODO: Change to XFAIL once https://github.com/llvm/llvm-project/issues/40340 is fixed
 // UNSUPPORTED: availability-pmr-missing
 
 // <vector>

--- a/libcxx/test/std/utilities/utility/mem.res/mem.res.aliases/header_vector_synop2.pass.cpp
+++ b/libcxx/test/std/utilities/utility/mem.res/mem.res.aliases/header_vector_synop2.pass.cpp
@@ -7,7 +7,6 @@
 //===----------------------------------------------------------------------===//
 
 // UNSUPPORTED: c++03, c++11, c++14
-// TODO: Change to XFAIL once https://github.com/llvm/llvm-project/issues/40340 is fixed
 // UNSUPPORTED: availability-pmr-missing
 
 // <vector>

--- a/libcxx/test/std/utilities/utility/mem.res/mem.res.global/default_resource.pass.cpp
+++ b/libcxx/test/std/utilities/utility/mem.res/mem.res.global/default_resource.pass.cpp
@@ -7,7 +7,6 @@
 //===----------------------------------------------------------------------===//
 
 // UNSUPPORTED: c++03, c++11, c++14
-// TODO: Change to XFAIL once https://github.com/llvm/llvm-project/issues/40340 is fixed
 // UNSUPPORTED: availability-pmr-missing
 
 // test_memory_resource requires RTTI for dynamic_cast

--- a/libcxx/test/std/utilities/utility/mem.res/mem.res.global/new_delete_resource.pass.cpp
+++ b/libcxx/test/std/utilities/utility/mem.res/mem.res.global/new_delete_resource.pass.cpp
@@ -7,7 +7,6 @@
 //===----------------------------------------------------------------------===//
 
 // UNSUPPORTED: c++03, c++11, c++14
-// TODO: Change to XFAIL once https://github.com/llvm/llvm-project/issues/40340 is fixed
 // UNSUPPORTED: availability-pmr-missing
 
 // <memory_resource>

--- a/libcxx/test/std/utilities/utility/mem.res/mem.res.global/null_memory_resource.pass.cpp
+++ b/libcxx/test/std/utilities/utility/mem.res/mem.res.global/null_memory_resource.pass.cpp
@@ -7,7 +7,6 @@
 //===----------------------------------------------------------------------===//
 
 // UNSUPPORTED: c++03, c++11, c++14
-// TODO: Change to XFAIL once https://github.com/llvm/llvm-project/issues/40340 is fixed
 // UNSUPPORTED: availability-pmr-missing
 
 // <memory_resource>

--- a/libcxx/test/std/utilities/utility/mem.res/mem.res.monotonic.buffer/mem.res.monotonic.buffer.ctor/copy_move.pass.cpp
+++ b/libcxx/test/std/utilities/utility/mem.res/mem.res.monotonic.buffer/mem.res.monotonic.buffer.ctor/copy_move.pass.cpp
@@ -7,7 +7,6 @@
 //===----------------------------------------------------------------------===//
 
 // UNSUPPORTED: c++03, c++11, c++14
-// TODO: Change to XFAIL once https://github.com/llvm/llvm-project/issues/40340 is fixed
 // UNSUPPORTED: availability-pmr-missing
 
 // <memory_resource>

--- a/libcxx/test/std/utilities/utility/mem.res/mem.res.monotonic.buffer/mem.res.monotonic.buffer.ctor/with_default_resource.pass.cpp
+++ b/libcxx/test/std/utilities/utility/mem.res/mem.res.monotonic.buffer/mem.res.monotonic.buffer.ctor/with_default_resource.pass.cpp
@@ -7,7 +7,6 @@
 //===----------------------------------------------------------------------===//
 
 // UNSUPPORTED: c++03, c++11, c++14
-// TODO: Change to XFAIL once https://github.com/llvm/llvm-project/issues/40340 is fixed
 // UNSUPPORTED: availability-pmr-missing
 
 // <memory_resource>

--- a/libcxx/test/std/utilities/utility/mem.res/mem.res.monotonic.buffer/mem.res.monotonic.buffer.ctor/without_buffer.pass.cpp
+++ b/libcxx/test/std/utilities/utility/mem.res/mem.res.monotonic.buffer/mem.res.monotonic.buffer.ctor/without_buffer.pass.cpp
@@ -7,7 +7,6 @@
 //===----------------------------------------------------------------------===//
 
 // UNSUPPORTED: c++03, c++11, c++14
-// TODO: Change to XFAIL once https://github.com/llvm/llvm-project/issues/40340 is fixed
 // UNSUPPORTED: availability-pmr-missing
 
 // <memory_resource>

--- a/libcxx/test/std/utilities/utility/mem.res/mem.res.monotonic.buffer/mem.res.monotonic.buffer.mem/allocate_deallocate.pass.cpp
+++ b/libcxx/test/std/utilities/utility/mem.res/mem.res.monotonic.buffer/mem.res.monotonic.buffer.mem/allocate_deallocate.pass.cpp
@@ -7,7 +7,6 @@
 //===----------------------------------------------------------------------===//
 
 // UNSUPPORTED: c++03, c++11, c++14
-// TODO: Change to XFAIL once https://github.com/llvm/llvm-project/issues/40340 is fixed
 // UNSUPPORTED: availability-pmr-missing
 
 // <memory_resource>

--- a/libcxx/test/std/utilities/utility/mem.res/mem.res.monotonic.buffer/mem.res.monotonic.buffer.mem/allocate_exception_safety.pass.cpp
+++ b/libcxx/test/std/utilities/utility/mem.res/mem.res.monotonic.buffer/mem.res.monotonic.buffer.mem/allocate_exception_safety.pass.cpp
@@ -8,7 +8,6 @@
 
 // UNSUPPORTED: c++03, c++11, c++14
 // UNSUPPORTED: no-exceptions
-// TODO: Change to XFAIL once https://github.com/llvm/llvm-project/issues/40340 is fixed
 // UNSUPPORTED: availability-pmr-missing
 
 // <memory_resource>

--- a/libcxx/test/std/utilities/utility/mem.res/mem.res.monotonic.buffer/mem.res.monotonic.buffer.mem/allocate_from_initial_buffer.pass.cpp
+++ b/libcxx/test/std/utilities/utility/mem.res/mem.res.monotonic.buffer/mem.res.monotonic.buffer.mem/allocate_from_initial_buffer.pass.cpp
@@ -7,7 +7,6 @@
 //===----------------------------------------------------------------------===//
 
 // UNSUPPORTED: c++03, c++11, c++14
-// TODO: Change to XFAIL once https://github.com/llvm/llvm-project/issues/40340 is fixed
 // UNSUPPORTED: availability-pmr-missing
 
 // <memory_resource>

--- a/libcxx/test/std/utilities/utility/mem.res/mem.res.monotonic.buffer/mem.res.monotonic.buffer.mem/allocate_from_zero_sized_buffer.pass.cpp
+++ b/libcxx/test/std/utilities/utility/mem.res/mem.res.monotonic.buffer/mem.res.monotonic.buffer.mem/allocate_from_zero_sized_buffer.pass.cpp
@@ -7,7 +7,6 @@
 //===----------------------------------------------------------------------===//
 
 // UNSUPPORTED: c++03, c++11, c++14
-// TODO: Change to XFAIL once https://github.com/llvm/llvm-project/issues/40340 is fixed
 // UNSUPPORTED: availability-pmr-missing
 
 // <memory_resource>

--- a/libcxx/test/std/utilities/utility/mem.res/mem.res.monotonic.buffer/mem.res.monotonic.buffer.mem/allocate_in_geometric_progression.pass.cpp
+++ b/libcxx/test/std/utilities/utility/mem.res/mem.res.monotonic.buffer/mem.res.monotonic.buffer.mem/allocate_in_geometric_progression.pass.cpp
@@ -7,7 +7,6 @@
 //===----------------------------------------------------------------------===//
 
 // UNSUPPORTED: c++03, c++11, c++14
-// TODO: Change to XFAIL once https://github.com/llvm/llvm-project/issues/40340 is fixed
 // UNSUPPORTED: availability-pmr-missing
 
 // <memory_resource>

--- a/libcxx/test/std/utilities/utility/mem.res/mem.res.monotonic.buffer/mem.res.monotonic.buffer.mem/allocate_overaligned_request.pass.cpp
+++ b/libcxx/test/std/utilities/utility/mem.res/mem.res.monotonic.buffer/mem.res.monotonic.buffer.mem/allocate_overaligned_request.pass.cpp
@@ -7,7 +7,6 @@
 //===----------------------------------------------------------------------===//
 
 // UNSUPPORTED: c++03, c++11, c++14
-// TODO: Change to XFAIL once https://github.com/llvm/llvm-project/issues/40340 is fixed
 // UNSUPPORTED: availability-pmr-missing
 
 // <memory_resource>

--- a/libcxx/test/std/utilities/utility/mem.res/mem.res.monotonic.buffer/mem.res.monotonic.buffer.mem/allocate_with_initial_size.pass.cpp
+++ b/libcxx/test/std/utilities/utility/mem.res/mem.res.monotonic.buffer/mem.res.monotonic.buffer.mem/allocate_with_initial_size.pass.cpp
@@ -7,7 +7,6 @@
 //===----------------------------------------------------------------------===//
 
 // UNSUPPORTED: c++03, c++11, c++14
-// TODO: Change to XFAIL once https://github.com/llvm/llvm-project/issues/40340 is fixed
 // UNSUPPORTED: availability-pmr-missing
 
 // <memory_resource>

--- a/libcxx/test/std/utilities/utility/mem.res/mem.res.monotonic.buffer/mem.res.monotonic.buffer.mem/equality.pass.cpp
+++ b/libcxx/test/std/utilities/utility/mem.res/mem.res.monotonic.buffer/mem.res.monotonic.buffer.mem/equality.pass.cpp
@@ -7,7 +7,6 @@
 //===----------------------------------------------------------------------===//
 
 // UNSUPPORTED: c++03, c++11, c++14
-// TODO: Change to XFAIL once https://github.com/llvm/llvm-project/issues/40340 is fixed
 // UNSUPPORTED: availability-pmr-missing
 
 // <memory_resource>

--- a/libcxx/test/std/utilities/utility/mem.res/mem.res.pool/mem.res.pool.ctor/ctor_does_not_allocate.pass.cpp
+++ b/libcxx/test/std/utilities/utility/mem.res/mem.res.pool/mem.res.pool.ctor/ctor_does_not_allocate.pass.cpp
@@ -7,7 +7,6 @@
 //===----------------------------------------------------------------------===//
 
 // UNSUPPORTED: c++03, c++11, c++14
-// TODO: Change to XFAIL once https://github.com/llvm/llvm-project/issues/40340 is fixed
 // UNSUPPORTED: availability-pmr-missing
 
 // <memory_resource>

--- a/libcxx/test/std/utilities/utility/mem.res/mem.res.pool/mem.res.pool.ctor/sync_with_default_resource.pass.cpp
+++ b/libcxx/test/std/utilities/utility/mem.res/mem.res.pool/mem.res.pool.ctor/sync_with_default_resource.pass.cpp
@@ -7,7 +7,6 @@
 //===----------------------------------------------------------------------===//
 
 // UNSUPPORTED: c++03, c++11, c++14
-// TODO: Change to XFAIL once https://github.com/llvm/llvm-project/issues/40340 is fixed
 // UNSUPPORTED: availability-pmr-missing
 
 // <memory_resource>

--- a/libcxx/test/std/utilities/utility/mem.res/mem.res.pool/mem.res.pool.ctor/unsync_with_default_resource.pass.cpp
+++ b/libcxx/test/std/utilities/utility/mem.res/mem.res.pool/mem.res.pool.ctor/unsync_with_default_resource.pass.cpp
@@ -7,7 +7,6 @@
 //===----------------------------------------------------------------------===//
 
 // UNSUPPORTED: c++03, c++11, c++14
-// TODO: Change to XFAIL once https://github.com/llvm/llvm-project/issues/40340 is fixed
 // UNSUPPORTED: availability-pmr-missing
 
 // <memory_resource>

--- a/libcxx/test/std/utilities/utility/mem.res/mem.res.pool/mem.res.pool.mem/equality.pass.cpp
+++ b/libcxx/test/std/utilities/utility/mem.res/mem.res.pool/mem.res.pool.mem/equality.pass.cpp
@@ -7,7 +7,6 @@
 //===----------------------------------------------------------------------===//
 
 // UNSUPPORTED: c++03, c++11, c++14
-// TODO: Change to XFAIL once https://github.com/llvm/llvm-project/issues/40340 is fixed
 // UNSUPPORTED: availability-pmr-missing
 
 // <memory_resource>

--- a/libcxx/test/std/utilities/utility/mem.res/mem.res.pool/mem.res.pool.mem/sync_allocate.pass.cpp
+++ b/libcxx/test/std/utilities/utility/mem.res/mem.res.pool/mem.res.pool.mem/sync_allocate.pass.cpp
@@ -7,7 +7,6 @@
 //===----------------------------------------------------------------------===//
 
 // UNSUPPORTED: c++03, c++11, c++14
-// TODO: Change to XFAIL once https://github.com/llvm/llvm-project/issues/40340 is fixed
 // UNSUPPORTED: availability-pmr-missing
 
 // <memory_resource>

--- a/libcxx/test/std/utilities/utility/mem.res/mem.res.pool/mem.res.pool.mem/sync_allocate_overaligned_request.pass.cpp
+++ b/libcxx/test/std/utilities/utility/mem.res/mem.res.pool/mem.res.pool.mem/sync_allocate_overaligned_request.pass.cpp
@@ -7,7 +7,6 @@
 //===----------------------------------------------------------------------===//
 
 // UNSUPPORTED: c++03, c++11, c++14
-// TODO: Change to XFAIL once https://github.com/llvm/llvm-project/issues/40340 is fixed
 // UNSUPPORTED: availability-pmr-missing
 
 // <memory_resource>

--- a/libcxx/test/std/utilities/utility/mem.res/mem.res.pool/mem.res.pool.mem/sync_allocate_reuse_blocks.pass.cpp
+++ b/libcxx/test/std/utilities/utility/mem.res/mem.res.pool/mem.res.pool.mem/sync_allocate_reuse_blocks.pass.cpp
@@ -7,7 +7,6 @@
 //===----------------------------------------------------------------------===//
 
 // UNSUPPORTED: c++03, c++11, c++14
-// TODO: Change to XFAIL once https://github.com/llvm/llvm-project/issues/40340 is fixed
 // UNSUPPORTED: availability-pmr-missing
 
 // <memory_resource>

--- a/libcxx/test/std/utilities/utility/mem.res/mem.res.pool/mem.res.pool.mem/sync_deallocate_matches_allocate.pass.cpp
+++ b/libcxx/test/std/utilities/utility/mem.res/mem.res.pool/mem.res.pool.mem/sync_deallocate_matches_allocate.pass.cpp
@@ -8,7 +8,6 @@
 
 // UNSUPPORTED: no-exceptions
 // UNSUPPORTED: c++03, c++11, c++14
-// TODO: Change to XFAIL once https://github.com/llvm/llvm-project/issues/40340 is fixed
 // UNSUPPORTED: availability-pmr-missing
 
 // <memory_resource>

--- a/libcxx/test/std/utilities/utility/mem.res/mem.res.pool/mem.res.pool.mem/unsync_allocate.pass.cpp
+++ b/libcxx/test/std/utilities/utility/mem.res/mem.res.pool/mem.res.pool.mem/unsync_allocate.pass.cpp
@@ -7,7 +7,6 @@
 //===----------------------------------------------------------------------===//
 
 // UNSUPPORTED: c++03, c++11, c++14
-// TODO: Change to XFAIL once https://github.com/llvm/llvm-project/issues/40340 is fixed
 // UNSUPPORTED: availability-pmr-missing
 
 // <memory_resource>

--- a/libcxx/test/std/utilities/utility/mem.res/mem.res.pool/mem.res.pool.mem/unsync_allocate_overaligned_request.pass.cpp
+++ b/libcxx/test/std/utilities/utility/mem.res/mem.res.pool/mem.res.pool.mem/unsync_allocate_overaligned_request.pass.cpp
@@ -7,7 +7,6 @@
 //===----------------------------------------------------------------------===//
 
 // UNSUPPORTED: c++03, c++11, c++14
-// TODO: Change to XFAIL once https://github.com/llvm/llvm-project/issues/40340 is fixed
 // UNSUPPORTED: availability-pmr-missing
 
 // <memory_resource>

--- a/libcxx/test/std/utilities/utility/mem.res/mem.res.pool/mem.res.pool.mem/unsync_allocate_reuse_blocks.pass.cpp
+++ b/libcxx/test/std/utilities/utility/mem.res/mem.res.pool/mem.res.pool.mem/unsync_allocate_reuse_blocks.pass.cpp
@@ -7,7 +7,6 @@
 //===----------------------------------------------------------------------===//
 
 // UNSUPPORTED: c++03, c++11, c++14
-// TODO: Change to XFAIL once https://github.com/llvm/llvm-project/issues/40340 is fixed
 // UNSUPPORTED: availability-pmr-missing
 
 // <memory_resource>

--- a/libcxx/test/std/utilities/utility/mem.res/mem.res.pool/mem.res.pool.mem/unsync_deallocate_matches_allocate.pass.cpp
+++ b/libcxx/test/std/utilities/utility/mem.res/mem.res.pool/mem.res.pool.mem/unsync_deallocate_matches_allocate.pass.cpp
@@ -8,7 +8,6 @@
 
 // UNSUPPORTED: no-exceptions
 // UNSUPPORTED: c++03, c++11, c++14
-// TODO: Change to XFAIL once https://github.com/llvm/llvm-project/issues/40340 is fixed
 // UNSUPPORTED: availability-pmr-missing
 
 // <memory_resource>

--- a/libcxx/test/std/utilities/utility/mem.res/mem.res/construct.verify.cpp
+++ b/libcxx/test/std/utilities/utility/mem.res/mem.res/construct.verify.cpp
@@ -7,7 +7,6 @@
 //===----------------------------------------------------------------------===//
 
 // UNSUPPORTED: c++03, c++11, c++14
-// TODO: Change to XFAIL once https://github.com/llvm/llvm-project/issues/40340 is fixed
 // UNSUPPORTED: availability-pmr-missing
 
 // <memory_resource>

--- a/libcxx/test/std/utilities/utility/mem.res/mem.res/mem.res.eq/equal.pass.cpp
+++ b/libcxx/test/std/utilities/utility/mem.res/mem.res/mem.res.eq/equal.pass.cpp
@@ -7,7 +7,6 @@
 //===----------------------------------------------------------------------===//
 
 // UNSUPPORTED: c++03, c++11, c++14
-// TODO: Change to XFAIL once https://github.com/llvm/llvm-project/issues/40340 is fixed
 // UNSUPPORTED: availability-pmr-missing
 
 // test_memory_resource requires RTTI for dynamic_cast

--- a/libcxx/test/std/utilities/utility/mem.res/mem.res/mem.res.eq/not_equal.pass.cpp
+++ b/libcxx/test/std/utilities/utility/mem.res/mem.res/mem.res.eq/not_equal.pass.cpp
@@ -7,7 +7,6 @@
 //===----------------------------------------------------------------------===//
 
 // UNSUPPORTED: c++03, c++11, c++14
-// TODO: Change to XFAIL once https://github.com/llvm/llvm-project/issues/40340 is fixed
 // UNSUPPORTED: availability-pmr-missing
 
 // test_memory_resource requires RTTI for dynamic_cast

--- a/libcxx/test/std/utilities/utility/mem.res/mem.res/mem.res.private/private_members.verify.cpp
+++ b/libcxx/test/std/utilities/utility/mem.res/mem.res/mem.res.private/private_members.verify.cpp
@@ -7,7 +7,6 @@
 //===----------------------------------------------------------------------===//
 
 // UNSUPPORTED: c++03, c++11, c++14
-// TODO: Change to XFAIL once https://github.com/llvm/llvm-project/issues/40340 is fixed
 // UNSUPPORTED: availability-pmr-missing
 
 // <memory_resource>

--- a/libcxx/test/std/utilities/utility/mem.res/mem.res/mem.res.private/protected_members.verify.cpp
+++ b/libcxx/test/std/utilities/utility/mem.res/mem.res/mem.res.private/protected_members.verify.cpp
@@ -7,7 +7,6 @@
 //===----------------------------------------------------------------------===//
 
 // UNSUPPORTED: c++03, c++11, c++14
-// TODO: Change to XFAIL once https://github.com/llvm/llvm-project/issues/40340 is fixed
 // UNSUPPORTED: availability-pmr-missing
 
 // <memory_resource>

--- a/libcxx/test/std/utilities/utility/mem.res/mem.res/mem.res.public/allocate.pass.cpp
+++ b/libcxx/test/std/utilities/utility/mem.res/mem.res/mem.res.public/allocate.pass.cpp
@@ -7,7 +7,6 @@
 //===----------------------------------------------------------------------===//
 
 // UNSUPPORTED: c++03, c++11, c++14
-// TODO: Change to XFAIL once https://github.com/llvm/llvm-project/issues/40340 is fixed
 // UNSUPPORTED: availability-pmr-missing
 
 // test_memory_resource requires RTTI for dynamic_cast

--- a/libcxx/test/std/utilities/utility/mem.res/mem.res/mem.res.public/deallocate.pass.cpp
+++ b/libcxx/test/std/utilities/utility/mem.res/mem.res/mem.res.public/deallocate.pass.cpp
@@ -7,7 +7,6 @@
 //===----------------------------------------------------------------------===//
 
 // UNSUPPORTED: c++03, c++11, c++14
-// TODO: Change to XFAIL once https://github.com/llvm/llvm-project/issues/40340 is fixed
 // UNSUPPORTED: availability-pmr-missing
 
 // test_memory_resource requires RTTI for dynamic_cast

--- a/libcxx/test/std/utilities/utility/mem.res/mem.res/mem.res.public/dtor.pass.cpp
+++ b/libcxx/test/std/utilities/utility/mem.res/mem.res/mem.res.public/dtor.pass.cpp
@@ -7,7 +7,6 @@
 //===----------------------------------------------------------------------===//
 
 // UNSUPPORTED: c++03, c++11, c++14
-// TODO: Change to XFAIL once https://github.com/llvm/llvm-project/issues/40340 is fixed
 // UNSUPPORTED: availability-pmr-missing
 
 // test_memory_resource requires RTTI for dynamic_cast

--- a/libcxx/test/std/utilities/utility/mem.res/mem.res/mem.res.public/is_equal.pass.cpp
+++ b/libcxx/test/std/utilities/utility/mem.res/mem.res/mem.res.public/is_equal.pass.cpp
@@ -7,7 +7,6 @@
 //===----------------------------------------------------------------------===//
 
 // UNSUPPORTED: c++03, c++11, c++14
-// TODO: Change to XFAIL once https://github.com/llvm/llvm-project/issues/40340 is fixed
 // UNSUPPORTED: availability-pmr-missing
 
 // test_memory_resource requires RTTI for dynamic_cast

--- a/libcxx/test/std/utilities/utility/mem.res/nodiscard.verify.cpp
+++ b/libcxx/test/std/utilities/utility/mem.res/nodiscard.verify.cpp
@@ -7,7 +7,6 @@
 //===----------------------------------------------------------------------===//
 
 // UNSUPPORTED: c++03, c++11, c++14, c++17
-// TODO: Change to XFAIL once https://github.com/llvm/llvm-project/issues/40340 is fixed
 // UNSUPPORTED: availability-pmr-missing
 
 // check that functions are marked [[nodiscard]]


### PR DESCRIPTION
During the review of #100775 @philnik777 mentioned the referred bug is closed as "Won't fix". Since the bug will never be fixed the TODO will never be addressed; remove them instead.