### PR TITLE
[Darwin] Fix availability of exp10 for BridgeOS, DriverKit.

### DIFF
--- a/llvm/lib/IR/RuntimeLibcalls.cpp
+++ b/llvm/lib/IR/RuntimeLibcalls.cpp
@@ -155,6 +155,7 @@ void RuntimeLibcallsInfo::initLibcalls(const Triple &TT) {
         break;
       }
       [[fallthrough]];
+    case Triple::DriverKit:
     case Triple::TvOS:
     case Triple::WatchOS:
     case Triple::XROS:
@@ -164,6 +165,10 @@ void RuntimeLibcallsInfo::initLibcalls(const Triple &TT) {
     default:
       break;
     }
+  } else if (TT.getOS() == Triple::BridgeOS) {
+    // TODO: BridgeOS should be included in isOSDarwin.
+    setLibcallName(RTLIB::EXP10_F32, "__exp10f");
+    setLibcallName(RTLIB::EXP10_F64, "__exp10");
   } else {
     setLibcallName(RTLIB::FPEXT_F16_F32, "__gnu_h2f_ieee");
     setLibcallName(RTLIB::FPROUND_F32_F16, "__gnu_f2h_ieee");

--- a/llvm/test/CodeGen/AArch64/exp10-libcall-names.ll
+++ b/llvm/test/CodeGen/AArch64/exp10-libcall-names.ll
@@ -7,12 +7,12 @@
 ; RUN: llc -mtriple=aarch64-apple-tvos6.0 < %s | FileCheck -check-prefix=APPLE %s
 ; RUN: llc -mtriple=aarch64-apple-xros6.0 < %s | FileCheck -check-prefix=APPLE %s
 ; RUN: llc -mtriple=aarch64-apple-xros1.0 < %s | FileCheck -check-prefix=APPLE %s
-; RUN: llc -mtriple=arm64-apple-driverkit < %s | FileCheck -check-prefix=MISSED %s
-; RUN: llc -mtriple=arm64-apple-driverkit1.0 < %s | FileCheck -check-prefix=MISSED %s
-; RUN: llc -mtriple=arm64-apple-driverkit24.0 < %s | FileCheck -check-prefix=MISSED %s
-; RUN: llc -mtriple=arm64-apple-bridgeos < %s | FileCheck -check-prefix=LINUX %s
-; RUN: llc -mtriple=arm64-apple-bridgeos1.0 < %s | FileCheck -check-prefix=LINUX %s
-; RUN: llc -mtriple=arm64-apple-bridgeos9.0 < %s | FileCheck -check-prefix=LINUX %s
+; RUN: llc -mtriple=arm64-apple-driverkit < %s | FileCheck -check-prefix=APPLE %s
+; RUN: llc -mtriple=arm64-apple-driverkit1.0 < %s | FileCheck -check-prefix=APPLE %s
+; RUN: llc -mtriple=arm64-apple-driverkit24.0 < %s | FileCheck -check-prefix=APPLE %s
+; RUN: llc -mtriple=arm64-apple-bridgeos < %s | FileCheck -check-prefix=BRIDGEOS %s
+; RUN: llc -mtriple=arm64-apple-bridgeos1.0 < %s | FileCheck -check-prefix=BRIDGEOS %s
+; RUN: llc -mtriple=arm64-apple-bridgeos9.0 < %s | FileCheck -check-prefix=BRIDGEOS %s
 
 ; RUN: not llc -mtriple=aarch64-apple-macos10.8 -filetype=null %s 2>&1 | FileCheck -check-prefix=ERR %s
 ; RUN: not llc -mtriple=aarch64-apple-ios6.0 -filetype=null %s 2>&1 | FileCheck -check-prefix=ERR %s
@@ -30,9 +30,9 @@ define float @test_exp10_f32(float %x) {
 ; APPLE:       ; %bb.0:
 ; APPLE-NEXT:    b ___exp10f
 ;
-; MISSED-LABEL: test_exp10_f32:
-; MISSED:       ; %bb.0:
-; MISSED-NEXT:    b _exp10f
+; BRIDGEOS-LABEL: test_exp10_f32:
+; BRIDGEOS:       // %bb.0:
+; BRIDGEOS-NEXT:    b __exp10f
 ;
   %ret = call float @llvm.exp10.f32(float %x)
   ret float %ret
@@ -47,9 +47,9 @@ define double @test_exp10_f64(double %x) {
 ; APPLE:       ; %bb.0:
 ; APPLE-NEXT:    b ___exp10
 ;
-; MISSED-LABEL: test_exp10_f64:
-; MISSED:       ; %bb.0:
-; MISSED-NEXT:    b _exp10
+; BRIDGEOS-LABEL: test_exp10_f64:
+; BRIDGEOS:       // %bb.0:
+; BRIDGEOS-NEXT:    b __exp10
 ;
   %ret = call double @llvm.exp10.f64(double %x)
   ret double %ret

--- a/llvm/test/CodeGen/X86/exp10-libcall-names.ll
+++ b/llvm/test/CodeGen/X86/exp10-libcall-names.ll
@@ -8,8 +8,8 @@
 ; RUN: llc -mtriple=x86_64-apple-ios8.0 < %s | FileCheck -check-prefix=APPLE %s
 ; RUN: llc -mtriple=x86_64-apple-tvos8.0 < %s | FileCheck -check-prefix=APPLE %s
 ; RUN: llc -mtriple=x86_64-apple-xros8.0 < %s | FileCheck -check-prefix=APPLE %s
-; RUN: llc -mtriple=x86_64-apple-driverkit < %s | FileCheck -check-prefix=MISSED %s
-; RUN: llc -mtriple=x86_64-apple-driverkit24.0 < %s | FileCheck -check-prefix=MISSED %s
+; RUN: llc -mtriple=x86_64-apple-driverkit < %s | FileCheck -check-prefix=APPLE %s
+; RUN: llc -mtriple=x86_64-apple-driverkit24.0 < %s | FileCheck -check-prefix=APPLE %s
 
 ; RUN: not llc -mtriple=x86_64-apple-macos10.8 -filetype=null %s 2>&1 | FileCheck -check-prefix=ERR %s
 ; Check exp10/exp10f is emitted as __exp10/__exp10f on assorted systems.


### PR DESCRIPTION
Same as https://github.com/llvm/llvm-project/pull/98542, but also mark exp10 available on BridgeOS and DriverKit.

Note that BridgeOS currently is not included by isOSDarwin, but it probably should.