### PR TITLE
[LLDB] Improve ObjectFileELF files ability to load from memory.

### DIFF
--- a/lldb/include/lldb/Target/Process.h
+++ b/lldb/include/lldb/Target/Process.h
@@ -1952,7 +1952,7 @@ public:
 
   lldb::ModuleSP ReadModuleFromMemory(const FileSpec &file_spec,
                                       lldb::addr_t header_addr,
-                                      size_t size_to_read = 512);
+                                      size_t size_to_read = 0);
 
   /// Attempt to get the attributes for a region of memory in the process.
   ///

--- a/lldb/source/Target/Process.cpp
+++ b/lldb/source/Target/Process.cpp
@@ -2543,13 +2543,25 @@ ModuleSP Process::ReadModuleFromMemory(const FileSpec &file_spec,
                                        lldb::addr_t header_addr,
                                        size_t size_to_read) {
   Log *log = GetLog(LLDBLog::Host);
-  if (log) {
-    LLDB_LOGF(log,
-              "Process::ReadModuleFromMemory reading %s binary from memory",
-              file_spec.GetPath().c_str());
-  }
+  LLDB_LOGF(log, "Process::ReadModuleFromMemory reading %s binary from memory",
+            file_spec.GetPath().c_str());
   ModuleSP module_sp(new Module(file_spec, ArchSpec()));
   if (module_sp) {
+    if (size_to_read == 0) {
+      // Default to 8192 in case we can't find a memory region.
+      size_to_read = 0x2000;
+      MemoryRegionInfo range_info;
+      Status error(GetMemoryRegionInfo(header_addr, range_info));
+      if (error.Success()) {
+        // We found a memory region, set the range of bytes ro read to read to
+        // the end of the memory region. This should be enough to contain the
+        // file header and important bits.
+        const auto &range = range_info.GetRange();
+        addr_t end = range.GetRangeBase() + range.GetByteSize();
+        if (end > header_addr)
+          size_to_read = end - header_addr;
+      }
+    }
     Status error;
     std::unique_ptr<Progress> progress_up;
     // Reading an ObjectFile from a local corefile is very fast,

--- a/lldb/test/Shell/ObjectFile/ELF/Inputs/memory-elf.cpp
+++ b/lldb/test/Shell/ObjectFile/ELF/Inputs/memory-elf.cpp
@@ -1,0 +1,5 @@
+#include <stdio.h>
+int main() {
+  printf("Hello World\n"); // Use something from libc.so
+  return 0;
+}

--- a/lldb/test/Shell/ObjectFile/ELF/elf-memory.test
+++ b/lldb/test/Shell/ObjectFile/ELF/elf-memory.test
@@ -1,0 +1,57 @@
+// REQUIRES: system-linux, native
+
+// This test verifies that loading and ELF file from memory works and the new
+// features that were added when loading from memory work like:
+// - Loading the .dynamic section from the PT_DYNAMIC since ELF files loaded 
+//   from memory don't have the section headers available.
+// - Loading the symbol table from the DT_SYMTAB dynamic entries.
+// This test will make a simple executable that:
+//   - links against libc
+//   - runs and stops at a breakpoint
+//   - 
+
+// RUN: %clang_host %p/Inputs/memory-elf.cpp -g -O0 -o %t
+
+// RUN: %lldb %t -b \
+// RUN:   -o "b main" \
+// RUN:   -o "run" \
+// RUN:   -o "script real_module = lldb.target.module[0]" \
+// RUN:   -o "script base_addr = real_module.GetObjectFileHeaderAddress().GetLoadAddress(lldb.target)" \
+// RUN:   -o "script mem_module = lldb.SBModule(lldb.process, base_addr)" \
+// RUN:   -o "script target2 = lldb.debugger.CreateTarget('')" \
+// RUN:   -o "script target2.AddModule(mem_module)" \
+// RUN:   -o "target select 1" \
+// RUN:   -o "image dump objfile" \
+// RUN:   | FileCheck %s --check-prefix=MAIN --dump-input=always
+// MAIN: (lldb) image dump objfile
+// MAIN: Dumping headers for 1 module(s).
+// MAIN: ObjectFileELF, file = '', arch = {{.*, addr = 0x[0-9a-f]+}}
+// MAIN: ELF Header
+
+// Make sure we find the program headers and see a PT_DYNAMIC entry.
+// MAIN: Program Headers
+// MAIN: ] PT_DYNAMIC
+
+// Make sure we see some sections created from the program headers
+// MAIN: SectID
+// MAIN: PT_LOAD[0]
+
+// Test we find some symbols in the symbol table
+// MAIN: Symtab, num_symbols =
+
+// Ensure we find some dependent modules as won't find these if we aren't able
+// to load the .dynamic section from the PT_DYNAMIC program header.
+// MAIN: Dependent Modules:
+
+// Check for the .dynamic dump and ensure we find all dynamic entries that are
+// required to be there and needed to get the .dynstr section and the symbol 
+// table, and the DT_DEBUG entry to find the list of shared libraries.
+// MAIN: .dynamic:
+// Make sure we found the .dynstr section by checking for valid strings after NEEDED
+// MAIN-DAG: NEEDED {{0x[0-9a-f]+ ".*libc.*"}}
+// MAIN-DAG: STRTAB {{0x[0-9a-f]+}}
+// MAIN-DAG: SYMTAB {{0x[0-9a-f]+}}
+// MAIN-DAG: STRSZ {{0x[0-9a-f]+}}
+// MAIN-DAG: SYMENT {{0x[0-9a-f]+}}
+// MAIN-DAG: DEBUG {{0x[0-9a-f]+}}
+// MAIN:     NULL {{0x[0-9a-f]+}}


### PR DESCRIPTION
This is the first part in improving ELF core files in LLDB. This first patch teaches LLDB to get as much data as possible from an in memory ELF image where we don't have section headers mapped into the process' memory. Core files contain the main executable mapped into memory so this patch will allow us to read it in, get the UUID and also find the DT_DEBUG entry so the dynamic loader can get a full list of shared libraries from the linked list in memory.

This patch modified ObjectFileELF to be able to more successfully load ELF files from memory. Highlights include:
- Load the .dynamic section using the PT_DYNAMIC program header if there are no sections headers.
- Load ELF notes from the PT_NOTE program header if there are no section headers.
- Modify the ObjectFileELF::GetArchitecture() to use the PT_NOTE segment if no section headers are available.
- Modify the ObjectFileELF::GetUUID() to use the PT_NOTE segment if no section headers are available. This allows us to find the UUID of a binary in core files without having the executable in disk.
- Modify ObjectFileELF::GetSegmentData() to read data from memory if the program header's data doesn't exist in the first memory region for the object file in memory.
- Modify ObjectFileELF::GetImageInfoAddress() to not rely on section headers. This will allow us in a follow up patch to not require the executable when loading an ELF core file as we can load the executable image from memory and find the DT_DEBUG entry.
- Fix an issue where we would not check if we got any data when we tried to parse the section headers from memory and we would create many SHT_NULL sections. We now check if we have data before we resize our section_headers array.
- Modify cwObjectFileELF::ParseDynamicSymbols() to parse and cache all dynamic entries and their names and change all code that read dynamic entries over to using the cached values. Previously different areas of code would manually parse the dynamic entries and some would get the names, and some wouldn't.
- Add dumping the the .dynamic section when running the "target modules dump objfile" command. This is used to test that this features works in the unit test and verifies we can get the needed DT_* entries needed for this to work.
- Fix dumping of the program headers to work for 64 bit and have the table aligned to the ASCII column headers.
- Load .dynstr string table from the DT_STRTAB dynamic entry.
- Load the dynamic symbol table from the DT_SYMTAB dynamic entry.
- Modify the lldb_private::Process to use the memory region information to get the size the the memory region that contains the object file header to make sure we read as much as we can and don't run into loading the program headers, .dynstr or .dynsym from program headers