### PR TITLE
[libc] fix pthread build issue for full-build mode

### DIFF
--- a/libc/src/__support/threads/CMakeLists.txt
+++ b/libc/src/__support/threads/CMakeLists.txt
@@ -101,7 +101,7 @@ endif()
 
 set(tid_dep)
 if (LLVM_LIBC_FULL_BUILD)
-  list(APPEND tid_dep libc.src.__support.thread)
+  list(APPEND tid_dep libc.src.__support.threads.thread)
 else()
   list(APPEND tid_dep libc.src.__support.OSUtil.osutil)
   list(APPEND tid_dep libc.include.sys_syscall)


### PR DESCRIPTION
Fix a silly typo that stops pthread from being built