### PR TITLE
[InstCombine] Use more inline elements in a SmallVector

### DIFF
--- a/llvm/lib/Transforms/InstCombine/InstCombineCalls.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineCalls.cpp
@@ -1500,7 +1500,7 @@ Instruction *InstCombinerImpl::visitCallInst(CallInst &CI) {
   // Don't try to simplify calls without uses. It will not do anything useful,
   // but will result in the following folds being skipped.
   if (!CI.use_empty()) {
-    SmallVector<Value *, 4> Args;
+    SmallVector<Value *, 8> Args;
     Args.reserve(CI.arg_size());
     for (Value *Op : CI.args())
       Args.push_back(Op);


### PR DESCRIPTION
The 4 inline elements only cover 58% of cases encountered here during
the compilation of X86ISelLowering.cpp.ll, a .ll version of
X86ISelLowering.cpp.

The 8 inline elements cover 96% and save 0.27% of heap allocations.
