### PR TITLE
[Memprof] Changes `HISTOGRAM_GRANULARITY` from 8U to 8ULL.

### DIFF
--- a/compiler-rt/lib/memprof/memprof_mapping.h
+++ b/compiler-rt/lib/memprof/memprof_mapping.h
@@ -55,7 +55,7 @@ extern uptr kHighMemEnd; // Initialized in __memprof_init.
 // computed by summing up all individual 1 byte counters. This can incur an
 // accuracy penalty.
 
-#define HISTOGRAM_GRANULARITY 8U
+#define HISTOGRAM_GRANULARITY 8ULL
 
 #define HISTOGRAM_MAX_COUNTER 255U
 


### PR DESCRIPTION
This changes a bug in memprofiling with histogram where the shadow mask would be `0xFFFFFFF8` instead of `0xFFFFFFFFFFFFFFF8`, essentially discarding the upper 32 bits of the address. This can cause different addresses to be mapped to the same shadow address.