### PR TITLE
[NFC] add newline after stack smashing message

### DIFF
--- a/libc/src/compiler/generic/__stack_chk_fail.cpp
+++ b/libc/src/compiler/generic/__stack_chk_fail.cpp
@@ -13,7 +13,7 @@
 extern "C" {
 
 void __stack_chk_fail(void) {
-  LIBC_NAMESPACE::write_to_stderr("stack smashing detected");
+  LIBC_NAMESPACE::write_to_stderr("stack smashing detected\n");
   LIBC_NAMESPACE::abort();
 }
 


### PR DESCRIPTION
<img width="662" alt="smash newline" src="https://github.com/user-attachments/assets/99625bcb-efd6-4733-aa01-2a2167ee686f">
